### PR TITLE
fix: correct Anthropic provider inputOther token counting

### DIFF
--- a/packages/kosong/src/providers/anthropic.ts
+++ b/packages/kosong/src/providers/anthropic.ts
@@ -595,8 +595,12 @@ class AnthropicStreamedMessage implements StreamedMessage {
     cache_read_input_tokens?: number;
     cache_creation_input_tokens?: number;
   }): void {
+    const totalInput = usage.input_tokens ?? 0;
     this._usage = {
-      inputOther: usage.input_tokens ?? 0,
+      inputOther:
+        totalInput
+        - (usage.cache_read_input_tokens ?? 0)
+        - (usage.cache_creation_input_tokens ?? 0),
       output: usage.output_tokens ?? 0,
       inputCacheRead: usage.cache_read_input_tokens ?? 0,
       inputCacheCreation: usage.cache_creation_input_tokens ?? 0,


### PR DESCRIPTION
## Summary
- `inputOther` was set to raw `input_tokens` which already includes cache tokens, causing double-counting of non-cache input tokens
- Subtract `cache_read_input_tokens` and `cache_creation_input_tokens` from the total, matching the OpenAI provider's calculation pattern (`promptTokens - cached`)

## Root Cause
In `packages/kosong/src/providers/anthropic.ts`, `_extractUsage` assigned `usage.input_tokens` directly to `inputOther`. Per the Anthropic API, `input_tokens` is the total billed input tokens which already includes cache-read and cache-creation tokens. This inflated the reported non-cache input count.

## Test plan
- [ ] Verify existing Anthropic provider tests still pass
- [ ] Confirm `inputOther + inputCacheRead + inputCacheCreation` now sums correctly to `input_tokens`

🤖 Generated with [Claude Code](https://claude.com/claude-code)