### PR TITLE
fix: remove double path resolution in SSH readLines

### DIFF
--- a/packages/kaos/src/ssh.ts
+++ b/packages/kaos/src/ssh.ts
@@ -696,7 +696,7 @@ export class SSHKaos implements Kaos {
     // Match Python's splitlines() semantics: returned lines do NOT include
     // the line terminator, and a trailing newline does not create an extra
     // empty line.
-    const text = await this.readText(this._resolvePath(path), options);
+    const text = await this.readText(path, options);
     if (text === '') {
       return;
     }


### PR DESCRIPTION
## Summary
- readLines was calling this._resolvePath(path) before passing to this.readText(), which internally calls _resolvePath() again
- This made readLines the only method in SSHKaos that double-resolves paths, inconsistent with readBytes, writeBytes, writeText, mkdir, stat, iterdir, and glob

## Test plan
- [ ] Verify existing SSH Kaos tests pass
- [ ] Confirm readLines with both relative and absolute paths resolves correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)