### PR TITLE
fix: remove abort listener leak in abortableSleep

### DIFF
--- a/packages/telemetry/src/transport.ts
+++ b/packages/telemetry/src/transport.ts
@@ -327,7 +327,10 @@ async function fetchWithTimeout(
 function abortableSleep(ms: number, signal?: AbortSignal): Promise<void> {
   if (signal?.aborted === true) return Promise.reject(abortError());
   return new Promise((resolve, reject) => {
-    const timer = setTimeout(resolve, ms);
+    const timer = setTimeout(() => {
+      signal?.removeEventListener('abort', onAbort);
+      resolve();
+    }, ms);
     timer.unref?.();
     const onAbort = (): void => {
       clearTimeout(timer);


### PR DESCRIPTION
## Summary
- The onAbort listener in abortableSleep was never removed when the sleep timer resolved normally
- Over repeated retry attempts, leaked listeners accumulated on the AbortSignal, causing a slow memory leak
- Fixed by removing the listener in the timer callback, matching the cleanup pattern already used by fetchWithTimeout in the same file

## Test plan
- [ ] Verify telemetry transport tests pass
- [ ] Confirm no listener leak after multiple normal sleep completions

🤖 Generated with [Claude Code](https://claude.com/claude-code)