### PR TITLE
fix: clear reverseRpcDisposers array after disposing handlers

### DIFF
--- a/apps/kimi-code/src/tui/kimi-tui.ts
+++ b/apps/kimi-code/src/tui/kimi-tui.ts
@@ -1851,6 +1851,7 @@ export class KimiTUI {
     for (const dispose of this.reverseRpcDisposers) {
       dispose();
     }
+    this.reverseRpcDisposers.length = 0;
   }
 
   // Connects session approval and question requests to local controllers.


### PR DESCRIPTION
## Summary
- `clearReverseRpcPanels` disposed all handlers but did not clear the array
- On session switches via `unloadCurrentSession`, the old already-disposed entries remained, causing double-dispose on the next call
- Added `this.reverseRpcDisposers.length = 0` after the loop, matching the cleanup pattern already used in the `stop()` method

## Test plan
- [ ] Verify TUI session switching works correctly
- [ ] Confirm no double-dispose errors after multiple session switches

🤖 Generated with [Claude Code](https://claude.com/claude-code)