### PR TITLE
fix: use atomic write for tui.toml config to prevent corruption

### DIFF
--- a/apps/kimi-code/src/tui/config.ts
+++ b/apps/kimi-code/src/tui/config.ts
@@ -6,8 +6,8 @@
  */
 
 import { existsSync } from 'node:fs';
-import { mkdir, readFile, writeFile } from 'node:fs/promises';
-import { dirname, join } from 'node:path';
+import { mkdir, readFile, rename, unlink, writeFile } from 'node:fs/promises';
+import { basename, dirname, join } from 'node:path';
 
 import { parse as parseToml } from 'smol-toml';
 import { z } from 'zod';
@@ -108,8 +108,17 @@ export async function saveTuiConfig(
   config: TuiConfig,
   filePath: string = getTuiConfigPath(),
 ): Promise<void> {
-  await mkdir(dirname(filePath), { recursive: true });
-  await writeFile(filePath, renderTuiConfig(config), 'utf-8');
+  const dir = dirname(filePath);
+  await mkdir(dir, { recursive: true });
+  const nonce = `${process.pid}.${Date.now()}.${Math.random().toString(16).slice(2)}`;
+  const tmpPath = join(dir, `.${basename(filePath)}.${nonce}.tmp`);
+  try {
+    await writeFile(tmpPath, renderTuiConfig(config), 'utf-8');
+    await rename(tmpPath, filePath);
+  } catch (error) {
+    await unlink(tmpPath).catch(() => {});
+    throw error;
+  }
 }
 
 export function normalizeTuiConfig(config: TuiConfigFileShape): TuiConfig {


### PR DESCRIPTION
## Summary
- `saveTuiConfig` was writing directly to the target file, risking corruption on crash/power loss
- Now uses the same write-to-temp-then-rename pattern as `writeJsonFile` in `persistence.ts`
- On crash, the temp file is left behind (harmless) rather than a truncated config file

## Test plan
- [ ] Verify config saves and loads correctly
- [ ] Confirm temp file is cleaned up on error

🤖 Generated with [Claude Code](https://claude.com/claude-code)