### PR TITLE
fix: escape all control characters in TOML basic strings

### DIFF
--- a/apps/kimi-code/src/tui/config.ts
+++ b/apps/kimi-code/src/tui/config.ts
@@ -149,5 +149,8 @@ function escapeTomlBasicString(value: string): string {
     .replaceAll('\t', '\\t')
     .replaceAll('\n', '\\n')
     .replaceAll('\f', '\\f')
-    .replaceAll('\r', '\\r');
+    .replaceAll('\r', '\\r')
+    .replaceAll(/[\x00-\x08\x0b\x0e-\x1f\x7f]/g, (ch) =>
+      `\\u${ch.charCodeAt(0).toString(16).padStart(4, '0')}`,
+    );
 }


### PR DESCRIPTION
## Summary
- `escapeTomlBasicString` only handled `\b`, `\t`, `\n`, `\f`, `\r` but not other control characters in U+0000-U+001F and U+007F
- Per the TOML spec, basic strings may only contain certain escape sequences; unescaped control chars produce invalid TOML that `smol-toml` cannot parse
- Now escapes all remaining control characters as `\uXXXX` sequences

## Test plan
- [ ] Verify config saves and loads correctly with normal values
- [ ] Test that strings containing control characters produce valid TOML

🤖 Generated with [Claude Code](https://claude.com/claude-code)