### PR TITLE
feat: add Ctrl-J newline shortcut in TUI prompt

### DIFF
--- a/.changeset/add-ctrl-j-newline.md
+++ b/.changeset/add-ctrl-j-newline.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Add `Ctrl-J` as an additional shortcut for inserting new lines in the TUI prompt.

--- a/apps/kimi-code/src/tui/components/dialogs/help-panel.ts
+++ b/apps/kimi-code/src/tui/components/dialogs/help-panel.ts
@@ -37,7 +37,7 @@ export const DEFAULT_KEYBOARD_SHORTCUTS: readonly KeyboardShortcut[] = [
   // { keys: 'Ctrl-G', description: 'Edit in external editor ($VISUAL / $EDITOR)' },
   { keys: 'Ctrl-O', description: 'Toggle tool output expansion' },
   { keys: 'Ctrl-S', description: 'Steer — inject a follow-up during streaming' },
-  { keys: 'Shift-Enter', description: 'Insert newline' },
+  { keys: 'Shift-Enter / Ctrl-J', description: 'Insert newline' },
   { keys: 'Ctrl-C', description: 'Interrupt stream / clear input' },
   { keys: 'Ctrl-D', description: 'Exit (on empty input)' },
   { keys: 'Esc', description: 'Close dialogs / interrupt streaming' },

--- a/apps/kimi-code/src/tui/components/editor/custom-editor.ts
+++ b/apps/kimi-code/src/tui/components/editor/custom-editor.ts
@@ -81,8 +81,10 @@ function stripSgr(s: string): string {
   return s.replace(ANSI_SGR, '');
 }
 
-function isNewlineShortcut(data: string): boolean {
-  return data === '\n' || data === '\u001B\r' || data === '\u001B[13;2~';
+function getNewlineInput(data: string): string | undefined {
+  if (data === '\n' || data === '\u001B\r' || data === '\u001B[13;2~') return data;
+  if (matchesKey(data, Key.ctrl('j'))) return '\n';
+  return undefined;
 }
 
 export class CustomEditor extends Editor {
@@ -249,8 +251,11 @@ export class CustomEditor extends Editor {
       this.onUndo?.();
     }
 
-    if (isNewlineShortcut(normalized)) {
+    const newlineInput = getNewlineInput(normalized);
+    if (newlineInput !== undefined) {
       this.onInsertNewline?.();
+      super.handleInput(newlineInput);
+      return;
     }
 
     if (matchesKey(normalized, Key.up)) {

--- a/apps/kimi-code/test/tui/components/editor/custom-editor.test.ts
+++ b/apps/kimi-code/test/tui/components/editor/custom-editor.test.ts
@@ -85,18 +85,27 @@ describe('CustomEditor Kitty key release handling', () => {
 });
 
 describe('CustomEditor shortcut telemetry hooks', () => {
-  it('reports newline and undo shortcuts before delegating to the base editor', () => {
+  it('reports newline shortcuts, including Ctrl-J, before delegating to the base editor', () => {
     const editor = makeEditor();
     const onInsertNewline = vi.fn();
-    const onUndo = vi.fn();
     editor.onInsertNewline = onInsertNewline;
-    editor.onUndo = onUndo;
 
     editor.handleInput('a');
     editor.handleInput('\n');
+    editor.handleInput('\u001B[106;5u');
+
+    expect(onInsertNewline).toHaveBeenCalledTimes(2);
+    expect(editor.getText()).toBe('a\n\n');
+  });
+
+  it('reports undo shortcuts before delegating to the base editor', () => {
+    const editor = makeEditor();
+    const onUndo = vi.fn();
+    editor.onUndo = onUndo;
+
+    editor.handleInput('a');
     editor.handleInput('\u001F');
 
-    expect(onInsertNewline).toHaveBeenCalledOnce();
     expect(onUndo).toHaveBeenCalledOnce();
   });
 });

--- a/apps/kimi-code/test/tui/components/panels/help-panel.test.ts
+++ b/apps/kimi-code/test/tui/components/panels/help-panel.test.ts
@@ -28,6 +28,7 @@ describe('HelpPanelComponent', () => {
     expect(out).toMatch(/Keyboard shortcuts/);
     expect(out).toMatch(/Shift-Tab/);
     expect(out).toMatch(/Ctrl-O/);
+    expect(out).toMatch(/Shift-Enter \/ Ctrl-J/);
     expect(out).toMatch(/Slash commands/);
     expect(out).toMatch(/\/exit \(\/quit, \/q\)/);
     expect(out).toMatch(/Exit/);

--- a/apps/kimi-code/test/tui/kimi-tui-message-flow.test.ts
+++ b/apps/kimi-code/test/tui/kimi-tui-message-flow.test.ts
@@ -197,7 +197,7 @@ describe('KimiTUI message flow', () => {
     const { driver, harness } = await makeDriver();
     harness.track.mockClear();
 
-    driver.state.editor.handleInput('\n');
+    driver.state.editor.handleInput('\u001B[106;5u');
     driver.state.editor.handleInput('\u001F');
     delete process.env['VISUAL'];
     delete process.env['EDITOR'];


### PR DESCRIPTION
<!--
Thank you for your contribution to Kimi Code!
Please make sure you already discussed the feature or bugfix you are proposing in an issue with the maintainers.
Please understand that if you have not gotten confirmation from the maintainers, your pull request may be closed or ignored without further review due to limited bandwidth.

See https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md for more.
-->

## Related Issue

<!-- Please link to the issue here. -->

Resolve #(issue_number)

## Description
add Ctrl-J newline shortcut in TUI prompt
<!-- Please describe your changes in detail. -->

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [ ] I have linked the related issue, if any.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.
