### PR TITLE
fix(shell): resolve bash timeout hang when daemon inherits stdio pipes

### DIFF
--- a/packages/agent-core/src/tools/builtin/shell/bash.ts
+++ b/packages/agent-core/src/tools/builtin/shell/bash.ts
@@ -275,6 +275,17 @@ export class BashTool implements BuiltinTool<BashInput> {
           /* ignore */
         }
       }
+
+      try {
+        proc.stdout.destroy();
+      } catch {
+        /* ignore */
+      }
+      try {
+        proc.stderr.destroy();
+      } catch {
+        /* ignore */
+      }
     };
 
     const onAbort = (): void => {

--- a/packages/kaos/src/local.ts
+++ b/packages/kaos/src/local.ts
@@ -58,7 +58,7 @@ class LocalProcess implements KaosProcess {
     this.pid = child.pid ?? -1;
 
     this._exitPromise = new Promise<number>((resolve, reject) => {
-      child.on('close', (code: number | null) => {
+      child.on('exit', (code: number | null) => {
         this._exitCode = code ?? -1;
         resolve(this._exitCode);
       });


### PR DESCRIPTION
## Summary

Fixes a bug where the Bash tool'\''s timeout would not take effect when a command spawned a detached daemon process that inherited stdio pipes. The agent would hang indefinitely because the process exit promise waited for stdio streams to close, which never happened while the daemon held the pipe file descriptors open.

---

### 1. Destroy stdio streams on abort in BashTool

**Problem:** When a Bash command spawned a detached daemon that inherited stdout/stderr pipes, aborting the shell command did not release those pipes. The daemon kept the file descriptors open, preventing the `close` event from firing and causing the agent to hang indefinitely.

**What was done:**
- Explicitly destroy `proc.stdout` and `proc.stderr` in the abort handler inside `BashTool` to forcibly close the stdio pipes.

### 2. Use `exit` instead of `close` in LocalProcess

**Problem:** `child.on('\''close'\'')` waits for all stdio streams to close before resolving the exit promise. If a detached daemon inherits stdio pipes, the `close` event never fires.

**What was done:**
- Changed the event listener from `close` to `exit` in `LocalProcess` so the exit promise resolves as soon as the child process itself terminates, regardless of stdio stream state.

---

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [ ] I have linked the related issue, if any.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [ ] Ran `gen-docs` skill, or this PR needs no doc update.