### PR TITLE
fix: hide empty current session from sessions list

### DIFF
--- a/.changeset/hide-empty-current-session.md
+++ b/.changeset/hide-empty-current-session.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Hide the empty current session from the sessions picker while keeping other empty sessions visible.

--- a/apps/kimi-code/src/tui/kimi-tui.ts
+++ b/apps/kimi-code/src/tui/kimi-tui.ts
@@ -227,6 +227,7 @@ import {
 } from './utils/mcp-server-status';
 import { openUrl } from './utils/open-url';
 import { setProcessTitle } from './utils/proctitle';
+import { sessionRowsForPicker } from './utils/session-picker-rows';
 import { installTerminalFocusTracking } from './utils/terminal-focus';
 import { notifyTerminalOnce } from './utils/terminal-notification';
 import { createTerminalState, type TerminalState } from './utils/terminal-state';
@@ -1866,14 +1867,7 @@ export class KimiTUI {
     this.state.loadingSessions = true;
     try {
       const sessions = await this.harness.listSessions({ workDir: this.state.appState.workDir });
-      this.state.sessions = sessions.map((session) => ({
-        id: session.id,
-        title: session.title ?? null,
-        last_prompt: session.lastPrompt ?? null,
-        work_dir: session.workDir,
-        updated_at: session.updatedAt ?? session.createdAt ?? 0,
-        metadata: session.metadata,
-      }));
+      this.state.sessions = sessionRowsForPicker(sessions, this.state.appState.sessionId);
     } catch {
       /* silently ignore */
     } finally {

--- a/apps/kimi-code/src/tui/kimi-tui.ts
+++ b/apps/kimi-code/src/tui/kimi-tui.ts
@@ -1867,7 +1867,11 @@ export class KimiTUI {
     this.state.loadingSessions = true;
     try {
       const sessions = await this.harness.listSessions({ workDir: this.state.appState.workDir });
-      this.state.sessions = sessionRowsForPicker(sessions, this.state.appState.sessionId);
+      this.state.sessions = sessionRowsForPicker(
+        sessions,
+        this.state.appState.sessionId,
+        this.hasSessionContent(),
+      );
     } catch {
       /* silently ignore */
     } finally {

--- a/apps/kimi-code/src/tui/utils/session-picker-rows.ts
+++ b/apps/kimi-code/src/tui/utils/session-picker-rows.ts
@@ -2,14 +2,13 @@ import type { SessionSummary } from '@moonshot-ai/kimi-code-sdk';
 
 import type { SessionRow } from '#/tui/components/dialogs/session-picker';
 
-const DEFAULT_SESSION_TITLE = 'New Session';
-
 export function sessionRowsForPicker(
   sessions: readonly SessionSummary[],
   currentSessionId: string,
+  currentSessionHasContent: boolean,
 ): SessionRow[] {
   return sessions
-    .filter((session) => !isEmptyCurrentSessionSummary(session, currentSessionId))
+    .filter((session) => currentSessionHasContent || session.id !== currentSessionId)
     .map((session) => ({
       id: session.id,
       title: session.title ?? null,
@@ -18,15 +17,4 @@ export function sessionRowsForPicker(
       updated_at: session.updatedAt ?? session.createdAt ?? 0,
       metadata: session.metadata,
     }));
-}
-
-function isEmptyCurrentSessionSummary(
-  session: Pick<SessionSummary, 'id' | 'lastPrompt' | 'title'>,
-  currentSessionId: string,
-): boolean {
-  if (currentSessionId.length === 0 || session.id !== currentSessionId) return false;
-  const lastPrompt = session.lastPrompt?.trim();
-  if (lastPrompt !== undefined && lastPrompt.length > 0) return false;
-  const title = session.title?.trim();
-  return title === undefined || title.length === 0 || title === DEFAULT_SESSION_TITLE;
 }

--- a/apps/kimi-code/src/tui/utils/session-picker-rows.ts
+++ b/apps/kimi-code/src/tui/utils/session-picker-rows.ts
@@ -1,0 +1,32 @@
+import type { SessionSummary } from '@moonshot-ai/kimi-code-sdk';
+
+import type { SessionRow } from '#/tui/components/dialogs/session-picker';
+
+const DEFAULT_SESSION_TITLE = 'New Session';
+
+export function sessionRowsForPicker(
+  sessions: readonly SessionSummary[],
+  currentSessionId: string,
+): SessionRow[] {
+  return sessions
+    .filter((session) => !isEmptyCurrentSessionSummary(session, currentSessionId))
+    .map((session) => ({
+      id: session.id,
+      title: session.title ?? null,
+      last_prompt: session.lastPrompt ?? null,
+      work_dir: session.workDir,
+      updated_at: session.updatedAt ?? session.createdAt ?? 0,
+      metadata: session.metadata,
+    }));
+}
+
+function isEmptyCurrentSessionSummary(
+  session: Pick<SessionSummary, 'id' | 'lastPrompt' | 'title'>,
+  currentSessionId: string,
+): boolean {
+  if (currentSessionId.length === 0 || session.id !== currentSessionId) return false;
+  const lastPrompt = session.lastPrompt?.trim();
+  if (lastPrompt !== undefined && lastPrompt.length > 0) return false;
+  const title = session.title?.trim();
+  return title === undefined || title.length === 0 || title === DEFAULT_SESSION_TITLE;
+}

--- a/apps/kimi-code/test/tui/utils/session-picker-rows.test.ts
+++ b/apps/kimi-code/test/tui/utils/session-picker-rows.test.ts
@@ -20,19 +20,20 @@ function summary(input: {
 }
 
 describe('sessionRowsForPicker', () => {
-  it('omits the empty current session from the picker rows', () => {
+  it('omits the current session when the TUI session has no content', () => {
     const rows = sessionRowsForPicker(
       [
         summary({ id: 'ses_current', title: 'New Session' }),
         summary({ id: 'ses_previous', title: 'New Session' }),
       ],
       'ses_current',
+      false,
     );
 
     expect(rows.map((row) => row.id)).toEqual(['ses_previous']);
   });
 
-  it('keeps the current session after prompt metadata exists', () => {
+  it('keeps the current session when the TUI session has content', () => {
     const rows = sessionRowsForPicker(
       [
         summary({
@@ -42,17 +43,22 @@ describe('sessionRowsForPicker', () => {
         }),
       ],
       'ses_current',
+      true,
     );
 
     expect(rows.map((row) => row.id)).toEqual(['ses_current']);
   });
 
-  it('keeps a current session with a non-default title', () => {
+  it('does not filter empty historical sessions', () => {
     const rows = sessionRowsForPicker(
-      [summary({ id: 'ses_current', title: 'Pinned workspace' })],
+      [
+        summary({ id: 'ses_current', title: 'New Session' }),
+        summary({ id: 'ses_previous_empty', title: 'New Session' }),
+      ],
       'ses_current',
+      false,
     );
 
-    expect(rows.map((row) => row.id)).toEqual(['ses_current']);
+    expect(rows.map((row) => row.id)).toEqual(['ses_previous_empty']);
   });
 });

--- a/apps/kimi-code/test/tui/utils/session-picker-rows.test.ts
+++ b/apps/kimi-code/test/tui/utils/session-picker-rows.test.ts
@@ -1,0 +1,58 @@
+import type { SessionSummary } from '@moonshot-ai/kimi-code-sdk';
+import { describe, expect, it } from 'vitest';
+
+import { sessionRowsForPicker } from '#/tui/utils/session-picker-rows';
+
+function summary(input: {
+  readonly id: string;
+  readonly title?: string;
+  readonly lastPrompt?: string;
+}): SessionSummary {
+  return {
+    id: input.id,
+    title: input.title,
+    lastPrompt: input.lastPrompt,
+    workDir: '/tmp/project',
+    sessionDir: `/tmp/home/sessions/${input.id}`,
+    createdAt: 1,
+    updatedAt: 2,
+  };
+}
+
+describe('sessionRowsForPicker', () => {
+  it('omits the empty current session from the picker rows', () => {
+    const rows = sessionRowsForPicker(
+      [
+        summary({ id: 'ses_current', title: 'New Session' }),
+        summary({ id: 'ses_previous', title: 'New Session' }),
+      ],
+      'ses_current',
+    );
+
+    expect(rows.map((row) => row.id)).toEqual(['ses_previous']);
+  });
+
+  it('keeps the current session after prompt metadata exists', () => {
+    const rows = sessionRowsForPicker(
+      [
+        summary({
+          id: 'ses_current',
+          title: 'Implement feature',
+          lastPrompt: 'Implement feature',
+        }),
+      ],
+      'ses_current',
+    );
+
+    expect(rows.map((row) => row.id)).toEqual(['ses_current']);
+  });
+
+  it('keeps a current session with a non-default title', () => {
+    const rows = sessionRowsForPicker(
+      [summary({ id: 'ses_current', title: 'Pinned workspace' })],
+      'ses_current',
+    );
+
+    expect(rows.map((row) => row.id)).toEqual(['ses_current']);
+  });
+});


### PR DESCRIPTION
<!--
Thank you for your contribution to Kimi Code!
Please make sure you already discussed the feature or bugfix you are proposing in an issue with the maintainers.
Please understand that if you have not gotten confirmation from the maintainers, your pull request may be closed or ignored without further review due to limited bandwidth.

See https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md for more.
-->

## Related Issue

<!-- Please link to the issue here. -->

Resolve #(issue_number)

## Description
fix: hide empty current session from sessions list
<!-- Please describe your changes in detail. -->

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [ ] I have linked the related issue, if any.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [ ] Ran `gen-docs` skill, or this PR needs no doc update.
