### PR TITLE
fix(oauth): report macOS product version in device model

### DIFF
--- a/.changeset/fix-macos-device-version.md
+++ b/.changeset/fix-macos-device-version.md
@@ -1,0 +1,6 @@
+---
+"@moonshot-ai/kimi-code": patch
+"@moonshot-ai/kimi-code-sdk": patch
+---
+
+Report the macOS product version in OAuth device information instead of the Darwin kernel version.

--- a/packages/oauth/src/identity.ts
+++ b/packages/oauth/src/identity.ts
@@ -7,6 +7,7 @@
  * production state.
  */
 
+import { execFileSync } from 'node:child_process';
 import { randomUUID } from 'node:crypto';
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { arch, hostname, release, type } from 'node:os';
@@ -111,9 +112,21 @@ function deviceModel(): string {
   const os = type();
   const version = release();
   const osArch = arch();
-  if (os === 'Darwin') return `macOS ${version} ${osArch}`;
+  if (os === 'Darwin') return `macOS ${macOsProductVersion() ?? version} ${osArch}`;
   if (os === 'Windows_NT') return `Windows ${version} ${osArch}`;
   return `${os} ${version} ${osArch}`.trim();
+}
+
+function macOsProductVersion(): string | undefined {
+  try {
+    const version = execFileSync('/usr/bin/sw_vers', ['-productVersion'], {
+      encoding: 'utf-8',
+      timeout: 1000,
+    }).trim();
+    return version.length > 0 ? version : undefined;
+  } catch {
+    return undefined;
+  }
 }
 
 function asciiHeader(value: string, fallback = 'unknown'): string {

--- a/packages/oauth/test/identity.test.ts
+++ b/packages/oauth/test/identity.test.ts
@@ -147,4 +147,33 @@ describe('ascii header value sanitization', () => {
       vi.resetModules();
     }
   });
+
+  it('falls back to Darwin kernel version when sw_vers is unavailable', async () => {
+    vi.resetModules();
+    vi.doMock('node:os', async () => ({
+      ...(await vi.importActual<typeof import('node:os')>('node:os')),
+      hostname: () => 'my-mac',
+      release: () => '25.5.0',
+      type: () => 'Darwin',
+      arch: () => 'arm64',
+    }));
+    // Force the sw_vers lookup to fail so the test is deterministic on macOS too,
+    // where the real binary would otherwise return the host's product version.
+    vi.doMock('node:child_process', async () => ({
+      ...(await vi.importActual<typeof import('node:child_process')>('node:child_process')),
+      execFileSync: () => {
+        throw new Error('ENOENT');
+      },
+    }));
+
+    try {
+      const { createKimiDeviceHeaders } = await import('../src/identity');
+      const headers = createKimiDeviceHeaders({ homeDir: tempHome(), version: '1.0.0' });
+      expect(headers['X-Msh-Device-Model']).toBe('macOS 25.5.0 arm64');
+    } finally {
+      vi.doUnmock('node:os');
+      vi.doUnmock('node:child_process');
+      vi.resetModules();
+    }
+  });
 });


### PR DESCRIPTION
<!--
Thank you for your contribution to Kimi Code!
Please open an issue before sending a feature PR — PRs without prior discussion may be closed without review.

See https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md for more.
-->

## Related Issue


<!-- Link the issue this feature came from. If there is no issue, explain the problem in the next section instead. -->

Resolve #32

## Problem

See linked issue
<!-- What user need or limitation does this address? If the linked issue already covers this, write "See linked issue". -->

## What changed

darwin(macOS)下使用product version而不是kernel version

测试结果中官网记录了正确的 macos 版本 26.5 ，而不是kernel版本25.5.0
<img width="1232" height="349" alt="image" src="https://github.com/user-attachments/assets/3aa5c1d2-242a-4efb-a12d-ad7b97ba092a" />


## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.
