### PR TITLE
fix(cli): clarify prompt mode login guidance

### DIFF
--- a/.changeset/friendly-prompt-login.md
+++ b/.changeset/friendly-prompt-login.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Clarify the prompt-mode error when no model is configured by pointing users to the login flow.

--- a/apps/kimi-code/src/cli/run-prompt.ts
+++ b/apps/kimi-code/src/cli/run-prompt.ts
@@ -233,7 +233,9 @@ async function forcePromptPermission(
 function requireConfiguredModel(...models: readonly (string | undefined)[]): string {
   const model = configuredModel(...models);
   if (model === undefined) {
-    throw new Error('No model configured. Set default_model in config.toml.');
+    throw new Error(
+      'No model configured. Run `kimi` and use /login to sign in, then retry; or set default_model in config.toml.',
+    );
   }
   return model;
 }

--- a/apps/kimi-code/test/cli/run-prompt.test.ts
+++ b/apps/kimi-code/test/cli/run-prompt.test.ts
@@ -634,7 +634,9 @@ describe('runPrompt', () => {
         stdout: { write: vi.fn(() => true) },
         stderr: { write: vi.fn(() => true) },
       }),
-    ).rejects.toThrow('No model configured. Set default_model in config.toml.');
+    ).rejects.toThrow(
+      'No model configured. Run `kimi` and use /login to sign in, then retry; or set default_model in config.toml.',
+    );
 
     expect(mocks.harnessClose).toHaveBeenCalled();
   });


### PR DESCRIPTION
## Related Issue

No related issue. This came from trying `kimi -p hello` in a fresh configuration and seeing a prompt-mode error that only mentioned editing `config.toml`.

## Problem

When prompt mode runs without a configured model, the current error tells users to set `default_model` in `config.toml`. That is technically correct, but it misses the normal first-run path for Kimi Code users: start the interactive CLI and run `/login` to provision a model before retrying prompt mode.

## What changed

Updated the prompt-mode missing-model error to point users to `kimi` + `/login` first, while still mentioning `default_model` for manual configuration. The existing prompt-mode test now asserts the friendlier guidance, and a patch changeset records the CLI-visible wording change.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.

Validation:

- `pnpm --filter @moonshot-ai/kimi-code exec vitest run test/cli/run-prompt.test.ts`
- `pnpm -C apps/kimi-code run build`
- `KIMI_CODE_HOME=/private/tmp/kimi-code-prompt-message-check node apps/kimi-code/dist/main.mjs -p hello`