### PR TITLE
fix(cli): correct first launch telemetry timing and extract telemetry init

### DIFF
--- a/packages/agent-core/src/tools/builtin/shell/bash.ts
+++ b/packages/agent-core/src/tools/builtin/shell/bash.ts
@@ -275,6 +275,17 @@ export class BashTool implements BuiltinTool<BashInput> {
           /* ignore */
         }
       }
+
+      try {
+        proc.stdout.destroy();
+      } catch {
+        /* ignore */
+      }
+      try {
+        proc.stderr.destroy();
+      } catch {
+        /* ignore */
+      }
     };
 
     const onAbort = (): void => {

--- a/packages/kaos/src/local.ts
+++ b/packages/kaos/src/local.ts
@@ -58,7 +58,7 @@ class LocalProcess implements KaosProcess {
     this.pid = child.pid ?? -1;
 
     this._exitPromise = new Promise<number>((resolve, reject) => {
-      child.on('close', (code: number | null) => {
+      child.on('exit', (code: number | null) => {
         this._exitCode = code ?? -1;
         resolve(this._exitCode);
       });


### PR DESCRIPTION
## Summary

This PR fixes a bug where first-launch telemetry was not tracked correctly because the deviceId was created after harness construction. It also extracts telemetry initialization into a dedicated module and emits the session resume hint as a meta message in the stream-json output format.

---

### 1. Fix first launch telemetry timing

**Problem:** The deviceId was not guaranteed to exist before harness construction, leading to incorrect first_launch tracking in telemetry events.

**What was done:**
- Extracted telemetry initialization logic into apps/kimi-code/src/cli/telemetry.ts.
- Ensured deviceId is created before harness construction so first_launch is tracked accurately.

### 2. Emit session resume hint in stream-json output

**Problem:** The stream-json output format did not include the session resume hint as a meta message.

**What was done:**
- Added emission of the session resume hint as a meta message in the stream-json output format.

---

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [ ] I have linked a related issue, if any.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] Ran gen-changesets skill, or this PR needs no changeset.
- [ ] Ran gen-docs skill, or this PR needs no doc update.