### PR TITLE
refactor: centralize main agent id constant

### DIFF
--- a/.changeset/centralize-main-agent-id.md
+++ b/.changeset/centralize-main-agent-id.md
@@ -1,0 +1,7 @@
+---
+"@moonshot-ai/agent-core": patch
+"@moonshot-ai/kimi-code-sdk": patch
+"@moonshot-ai/kimi-code": patch
+---
+
+Centralize the main agent identifier used between the core engine, SDK, and CLI.

--- a/apps/kimi-code/src/tui/constant/kimi-tui.ts
+++ b/apps/kimi-code/src/tui/constant/kimi-tui.ts
@@ -1,12 +1,12 @@
 import { DEFAULT_OAUTH_PROVIDER_NAME } from '#/constant/app';
 
 export { DEFAULT_OAUTH_PROVIDER_NAME, OAUTH_LOGIN_REQUIRED_CODE } from '#/constant/app';
+export { MAIN_AGENT_ID } from '@moonshot-ai/kimi-code-sdk';
 
 export const LLM_NOT_SET_MESSAGE = 'LLM not set, send "/login" to login';
 export const NO_ACTIVE_SESSION_MESSAGE = 'No active session. Send /login to login.';
 export const CTRL_D_HINT = 'Press Ctrl+D again to exit';
 export const CTRL_C_HINT = 'Press Ctrl+C again to exit';
-export const MAIN_AGENT_ID = 'main';
 export const OAUTH_LOGIN_REQUIRED_STARTUP_NOTICE = 'OAuth login expired. Send /login to login.';
 export const EXIT_CONFIRM_WINDOW_MS = 1500;
 

--- a/packages/agent-core/src/agent/index.ts
+++ b/packages/agent-core/src/agent/index.ts
@@ -6,17 +6,17 @@ import { log } from '#/logging/logger';
 import type { Logger } from '#/logging/types';
 import type { AgentAPI, AgentEvent, SDKAgentRPC, UsageStatus } from '#/rpc';
 import {
-  generate,
-  type ChatProvider,
-  type Message,
-  type Tool,
+    generate,
+    type ChatProvider,
+    type Message,
+    type Tool,
 } from '@moonshot-ai/kosong';
 
 import type { McpConnectionManager } from '../mcp';
 import {
-  resolveSystemPromptCwd,
-  type PreparedSystemPromptContext,
-  type ResolvedAgentProfile,
+    resolveSystemPromptCwd,
+    type PreparedSystemPromptContext,
+    type ResolvedAgentProfile,
 } from '../profile';
 import type { ProviderManager } from '../providers/provider-manager';
 import { withProviderRequestAuth } from '../providers/request-auth';
@@ -25,9 +25,9 @@ import type { SessionSubagentHost } from '../session/subagent-host';
 import type { SkillRegistry } from '../skill';
 import { noopTelemetryClient, type TelemetryClient } from '../telemetry';
 import {
-  estimateTokens,
-  estimateTokensForMessages,
-  estimateTokensForTools,
+    estimateTokens,
+    estimateTokensForMessages,
+    estimateTokensForTools,
 } from '../utils/tokens';
 import type { PromisableMethods } from '../utils/types';
 import { BackgroundManager } from './background';
@@ -39,19 +39,19 @@ import { InjectionManager } from './injection/manager';
 import { PermissionManager, type PermissionManagerOptions } from './permission';
 import { PlanMode } from './plan';
 import {
-  AgentRecords,
-  FileSystemAgentRecordPersistence,
-  restoreAgentRecord,
-  type AgentRecord,
-  type AgentRecordPersistence,
+    AgentRecords,
+    FileSystemAgentRecordPersistence,
+    restoreAgentRecord,
+    type AgentRecord,
+    type AgentRecordPersistence,
 } from './records';
 import { ReplayBuilder } from './replay';
 import { SkillManager } from './skill';
 import { ToolManager } from './tool/index';
 import { TurnFlow } from './turn';
 import {
-  GENERATE_REQUEST_LOG_CONTEXT,
-  type GenerateOptionsWithRequestLog,
+    GENERATE_REQUEST_LOG_CONTEXT,
+    type GenerateOptionsWithRequestLog,
 } from './turn/kosong-llm';
 import { UsageRecorder } from './usage';
 
@@ -129,7 +129,7 @@ export class Agent {
     this.mcp = config.mcp;
     this.hooks = config.hookEngine;
 
-    this.type = config.type ?? MAIN_AGENT_ID;
+    this.type = config.type ?? 'main';
 
     this.rpc = config.rpc;
     this.telemetry = config.telemetry ?? noopTelemetryClient;

--- a/packages/agent-core/src/agent/index.ts
+++ b/packages/agent-core/src/agent/index.ts
@@ -58,6 +58,7 @@ import { UsageRecorder } from './usage';
 export type { AgentRecord, AgentRecordPersistence } from './records';
 export type { BuiltinTool, ToolInfo, ToolSource, UserToolRegistration } from './tool';
 
+export const MAIN_AGENT_ID = 'main';
 export type AgentType = 'main' | 'sub' | 'independent';
 
 export interface AgentConfig {
@@ -128,7 +129,7 @@ export class Agent {
     this.mcp = config.mcp;
     this.hooks = config.hookEngine;
 
-    this.type = config.type ?? 'main';
+    this.type = config.type ?? MAIN_AGENT_ID;
 
     this.rpc = config.rpc;
     this.telemetry = config.telemetry ?? noopTelemetryClient;

--- a/packages/agent-core/src/rpc/core-impl.ts
+++ b/packages/agent-core/src/rpc/core-impl.ts
@@ -1,79 +1,80 @@
 import { randomUUID } from 'node:crypto';
 import { homedir } from 'node:os';
 
-import { localKaos } from '@moonshot-ai/kaos';
 import { ErrorCodes, KimiError } from '#/errors';
 import { getRootLogger, log } from '#/logging/logger';
 import { LocalFetchURLProvider } from '#/tools/providers/local-fetch-url';
 import { MoonshotFetchURLProvider } from '#/tools/providers/moonshot-fetch-url';
 import { MoonshotWebSearchProvider } from '#/tools/providers/moonshot-web-search';
 import { detectEnvironmentFromNode } from '#/utils/environment';
+import type { PromisableMethods } from '#/utils/types';
 import { getCoreVersion } from '#/version';
-import type {
-  ActivateSkillPayload,
-  BeginCompactionPayload,
-  CancelPayload,
-  CancelPlanPayload,
-  CloseSessionPayload,
-  CoreAPI,
-  CoreInfo,
-  CreateSessionPayload,
-  EmptyPayload,
-  ExportSessionPayload,
-  ExportSessionResult,
-  ForkSessionPayload,
-  GetBackgroundOutputPathPayload,
-  GetBackgroundOutputPayload,
-  GetBackgroundPayload,
-  ListSessionsPayload,
-  McpServerInfo,
-  McpStartupMetrics,
-  PromptPayload,
-  ReconnectMcpServerPayload,
-  RemoveKimiProviderPayload,
-  RenameSessionPayload,
-  ResumeSessionPayload,
-  RegisterToolPayload,
-  SetKimiConfigPayload,
-  SetActiveToolsPayload,
-  SetModelPayload,
-  SetModelResult,
-  SetPermissionPayload,
-  SetThinkingPayload,
-  SkillSummary,
-  SteerPayload,
-  StopBackgroundPayload,
-  SessionSummary,
-  UnregisterToolPayload,
-  UpdateSessionMetadataPayload,
-} from './core-api';
+import { localKaos } from '@moonshot-ai/kaos';
 import type { CoreRPCClient } from './client';
+import type {
+    ActivateSkillPayload,
+    BeginCompactionPayload,
+    CancelPayload,
+    CancelPlanPayload,
+    CloseSessionPayload,
+    CoreAPI,
+    CoreInfo,
+    CreateSessionPayload,
+    EmptyPayload,
+    ExportSessionPayload,
+    ExportSessionResult,
+    ForkSessionPayload,
+    GetBackgroundOutputPathPayload,
+    GetBackgroundOutputPayload,
+    GetBackgroundPayload,
+    ListSessionsPayload,
+    McpServerInfo,
+    McpStartupMetrics,
+    PromptPayload,
+    ReconnectMcpServerPayload,
+    RegisterToolPayload,
+    RemoveKimiProviderPayload,
+    RenameSessionPayload,
+    ResumeSessionPayload,
+    SessionSummary,
+    SetActiveToolsPayload,
+    SetKimiConfigPayload,
+    SetModelPayload,
+    SetModelResult,
+    SetPermissionPayload,
+    SetThinkingPayload,
+    SkillSummary,
+    SteerPayload,
+    StopBackgroundPayload,
+    UnregisterToolPayload,
+    UpdateSessionMetadataPayload,
+} from './core-api';
 import type { ResumedAgentState, ResumeSessionResult } from './resumed';
 import type { SDKRPC } from './sdk-api';
 import { proxyWithExtraPayload } from './types';
-import type { PromisableMethods } from '#/utils/types';
 
-import { resolveSessionMcpConfig } from '../mcp';
-import { Session, type SessionMeta, type SessionSkillConfig } from '../session';
-import { SessionAPIImpl } from '../session/rpc';
+import { MAIN_AGENT_ID } from '../agent';
 import {
-  ensureKimiHome,
-  mergeConfigPatch,
-  readConfigFile,
-  resolveConfigPath,
-  resolveKimiHome,
-  writeConfigFile,
-  type KimiConfig,
-  type MoonshotServiceConfig,
+    ensureKimiHome,
+    mergeConfigPatch,
+    readConfigFile,
+    resolveConfigPath,
+    resolveKimiHome,
+    writeConfigFile,
+    type KimiConfig,
+    type MoonshotServiceConfig,
 } from '../config';
-import { exportSessionDirectory } from '../session/export';
+import type { Logger } from '../logging/types';
+import { resolveSessionMcpConfig } from '../mcp';
 import { ProviderManager } from '../providers/provider-manager';
 import {
-  type BearerTokenProvider,
-  type OAuthTokenProviderResolver,
+    type BearerTokenProvider,
+    type OAuthTokenProviderResolver,
 } from '../providers/runtime-provider';
-import type { Logger } from '../logging/types';
 import type { RuntimeConfig } from '../runtime-types';
+import { Session, type SessionMeta, type SessionSkillConfig } from '../session';
+import { exportSessionDirectory } from '../session/export';
+import { SessionAPIImpl } from '../session/rpc';
 import { normalizeWorkDir, SessionStore } from '../session/store';
 import { noopTelemetryClient, withTelemetryContext, type TelemetryClient } from '../telemetry';
 
@@ -581,12 +582,12 @@ export class KimiCore implements PromisableMethods<CoreAPI> {
     // session may reference a model alias that no longer exists in config.toml.
     // Try the session's own model first, then fall back to the configured
     // default, so resume degrades gracefully instead of hard-failing.
-    const requested = (await api.getModel({ agentId: 'main' })).trim();
+    const requested = (await api.getModel({ agentId: MAIN_AGENT_ID })).trim();
     const fallback = config.defaultModel?.trim() ?? '';
     const candidates = [...new Set([requested, fallback].filter((model) => model.length > 0))];
     for (const model of candidates) {
       try {
-        await api.setModel({ agentId: 'main', model });
+        await api.setModel({ agentId: MAIN_AGENT_ID, model });
         await session.flushMetadata();
         return;
       } catch (error) {
@@ -612,7 +613,7 @@ export class KimiCore implements PromisableMethods<CoreAPI> {
     // selection whose next prompt fails with a config error. Not persisted:
     // `refreshSessionRuntimeConfig` re-derives this on every resume.
     if (requested.length > 0) {
-      session.agents.get('main')?.config.update({ modelAlias: undefined });
+      session.agents.get(MAIN_AGENT_ID)?.config.update({ modelAlias: undefined });
     }
   }
 }

--- a/packages/agent-core/src/session/index.ts
+++ b/packages/agent-core/src/session/index.ts
@@ -144,7 +144,7 @@ export class Session {
 
   async createMain() {
     const { agent } = await this.createAgent(
-      { type: MAIN_AGENT_ID },
+      { type: 'main' },
       DEFAULT_AGENT_PROFILES['agent'],
     );
     await this.triggerSessionStart('startup');
@@ -209,8 +209,8 @@ export class Session {
     parentAgentId?: string | undefined,
   ): Promise<{ readonly id: string; readonly agent: Agent }> {
     await this.skillsReady;
-    const type = config.type ?? MAIN_AGENT_ID;
-    const id = type === MAIN_AGENT_ID ? MAIN_AGENT_ID : this.nextGeneratedAgentId();
+    const type = config.type ?? 'main';
+    const id = type === 'main' ? MAIN_AGENT_ID : this.nextGeneratedAgentId();
     const homedir = config.homedir ?? join(this.config.homedir, 'agents', id);
     const agent = this.instantiateAgent(id, homedir, type, config, parentAgentId ?? null);
     if (profile) {

--- a/packages/agent-core/src/session/index.ts
+++ b/packages/agent-core/src/session/index.ts
@@ -7,7 +7,7 @@ import type { Logger, SessionLogHandle } from '#/logging/types';
 import type { SDKSessionRPC } from '#/rpc';
 import { proxyWithExtraPayload } from '#/rpc/types';
 
-import { Agent, type AgentConfig, type AgentType } from '../agent';
+import { Agent, MAIN_AGENT_ID, type AgentConfig, type AgentType } from '../agent';
 import { HookEngine, type HookDef } from '../agent/hooks';
 import type { PermissionManagerOptions, PermissionRule } from '../agent/permission';
 import { parseBooleanEnv, resolveConfigValue, type BackgroundConfig } from '../config';
@@ -143,7 +143,10 @@ export class Session {
   }
 
   async createMain() {
-    const { agent } = await this.createAgent({ type: 'main' }, DEFAULT_AGENT_PROFILES['agent']);
+    const { agent } = await this.createAgent(
+      { type: MAIN_AGENT_ID },
+      DEFAULT_AGENT_PROFILES['agent'],
+    );
     await this.triggerSessionStart('startup');
     return agent;
   }
@@ -162,7 +165,7 @@ export class Session {
     // main agent comes back with an empty system prompt and no tools. Apply the
     // default profile so the resumed session is usable. Native sessions always
     // replay a non-empty system prompt and never enter this branch.
-    const main = this.agents.get('main');
+    const main = this.agents.get(MAIN_AGENT_ID);
     const profile = DEFAULT_AGENT_PROFILES['agent'];
     if (main !== undefined && profile !== undefined && main.config.systemPrompt === '') {
       await this.bootstrapAgentProfile(main, profile);
@@ -206,8 +209,8 @@ export class Session {
     parentAgentId?: string | undefined,
   ): Promise<{ readonly id: string; readonly agent: Agent }> {
     await this.skillsReady;
-    const type = config.type ?? 'main';
-    const id = type === 'main' ? 'main' : this.nextGeneratedAgentId();
+    const type = config.type ?? MAIN_AGENT_ID;
+    const id = type === MAIN_AGENT_ID ? MAIN_AGENT_ID : this.nextGeneratedAgentId();
     const homedir = config.homedir ?? join(this.config.homedir, 'agents', id);
     const agent = this.instantiateAgent(id, homedir, type, config, parentAgentId ?? null);
     if (profile) {
@@ -356,7 +359,7 @@ export class Session {
     this.log.error('mcp initial load failed', error);
     void this.rpc.emitEvent({
       type: 'error',
-      agentId: 'main',
+      agentId: MAIN_AGENT_ID,
       ...makeErrorPayload(ErrorCodes.MCP_STARTUP_FAILED, message),
     });
   }
@@ -366,7 +369,7 @@ export class Session {
     // can keep its dashboard in sync, even before the main agent exists.
     void this.rpc.emitEvent({
       type: 'mcp.server.status',
-      agentId: 'main',
+      agentId: MAIN_AGENT_ID,
       server: {
         name: entry.name,
         transport: entry.transport,
@@ -472,7 +475,7 @@ export class Session {
   }
 
   private requireMainAgent(): Agent {
-    const agent = this.agents.get('main');
+    const agent = this.agents.get(MAIN_AGENT_ID);
     if (agent === undefined) {
       throw new KimiError(ErrorCodes.AGENT_NOT_FOUND, 'Main agent was not found');
     }

--- a/packages/agent-core/src/session/rpc.ts
+++ b/packages/agent-core/src/session/rpc.ts
@@ -1,38 +1,39 @@
 import { ErrorCodes, KimiError } from '#/errors';
 import type {
-  ActivateSkillPayload,
-  AgentAPI,
-  BeginCompactionPayload,
-  CancelPayload,
-  CancelPlanPayload,
-  EmptyPayload,
-  GetBackgroundOutputPathPayload,
-  GetBackgroundOutputPayload,
-  GetBackgroundPayload,
-  McpServerInfo,
-  McpStartupMetrics,
-  PromptPayload,
-  ReconnectMcpServerPayload,
-  RenameSessionPayload,
-  RegisterToolPayload,
-  SessionAPI,
-  SetActiveToolsPayload,
-  SetModelPayload,
-  SetPermissionPayload,
-  SetThinkingPayload,
-  SkillSummary,
-  SteerPayload,
-  StopBackgroundPayload,
-  UnregisterToolPayload,
-  UpdateSessionMetadataPayload,
+    ActivateSkillPayload,
+    AgentAPI,
+    BeginCompactionPayload,
+    CancelPayload,
+    CancelPlanPayload,
+    EmptyPayload,
+    GetBackgroundOutputPathPayload,
+    GetBackgroundOutputPayload,
+    GetBackgroundPayload,
+    McpServerInfo,
+    McpStartupMetrics,
+    PromptPayload,
+    ReconnectMcpServerPayload,
+    RegisterToolPayload,
+    RenameSessionPayload,
+    SessionAPI,
+    SetActiveToolsPayload,
+    SetModelPayload,
+    SetPermissionPayload,
+    SetThinkingPayload,
+    SkillSummary,
+    SteerPayload,
+    StopBackgroundPayload,
+    UnregisterToolPayload,
+    UpdateSessionMetadataPayload,
 } from '#/rpc';
 import type { PromisableMethods } from '#/utils/types';
 
 import type { Session, SessionMeta } from '.';
+import { MAIN_AGENT_ID } from '../agent';
 import {
-  promptMetadataTextFromPayload,
-  promptMetadataTextFromSkill,
-  titleFromPromptMetadataText,
+    promptMetadataTextFromPayload,
+    promptMetadataTextFromSkill,
+    titleFromPromptMetadataText,
 } from './prompt-metadata';
 
 type AgentScopedPayload<T> = T & { agentId: string };
@@ -89,7 +90,7 @@ export class SessionAPIImpl implements PromisableMethods<SessionAPI> {
   }
 
   async prompt({ agentId, ...payload }: AgentScopedPayload<PromptPayload>) {
-    if (agentId === 'main') {
+    if (agentId === MAIN_AGENT_ID) {
       await this.updatePromptMetadata(promptMetadataTextFromPayload(payload));
     }
     return this.getAgent(agentId).prompt(payload);
@@ -161,7 +162,7 @@ export class SessionAPIImpl implements PromisableMethods<SessionAPI> {
 
   async activateSkill({ agentId, ...payload }: AgentScopedPayload<ActivateSkillPayload>) {
     await this.getAgent(agentId).activateSkill(payload);
-    if (agentId === 'main') {
+    if (agentId === MAIN_AGENT_ID) {
       await this.updatePromptMetadata(promptMetadataTextFromSkill(payload));
     }
   }
@@ -240,7 +241,7 @@ export class SessionAPIImpl implements PromisableMethods<SessionAPI> {
     await this.session.writeMetadata();
     await this.session.rpc.emitEvent({
       type: 'session.meta.updated',
-      agentId: 'main',
+      agentId: MAIN_AGENT_ID,
       title,
       patch: {
         title,

--- a/packages/migration-legacy/src/steps/skills.ts
+++ b/packages/migration-legacy/src/steps/skills.ts
@@ -67,9 +67,9 @@ export async function migrateSkillsStep(input: SkillsStepInput): Promise<SkillsS
     try {
       await cp(srcPath, tmpPath, { recursive: true, errorOnExist: false, force: true });
       await rename(tmpPath, tgtPath);
-    } catch (err) {
+    } catch (error) {
       await rm(tmpPath, { recursive: true, force: true }).catch(() => {});
-      throw err;
+      throw error;
     }
     copied++;
   }

--- a/packages/node-sdk/src/index.ts
+++ b/packages/node-sdk/src/index.ts
@@ -20,6 +20,7 @@ export {
 export {
   flushDiagnosticLogs,
   log,
+  MAIN_AGENT_ID,
   redact,
   resolveGlobalLogPath,
   resolveKimiHome,

--- a/packages/node-sdk/src/rpc.ts
+++ b/packages/node-sdk/src/rpc.ts
@@ -3,6 +3,7 @@ import {
   ErrorCodes,
   KimiCore,
   makeErrorPayload,
+  MAIN_AGENT_ID,
   resolveKimiHome,
   type ApprovalRequest,
   type ApprovalResponse,
@@ -46,8 +47,6 @@ import type {
   Unsubscribe,
   KimiHostIdentity,
 } from '#/types';
-
-const MAIN_AGENT_ID = 'main';
 
 export interface SDKRpcClientOptions {
   readonly homeDir?: string | undefined;

--- a/packages/node-sdk/src/session.ts
+++ b/packages/node-sdk/src/session.ts
@@ -1,23 +1,26 @@
-import { ErrorCodes, KimiError, type KimiErrorCode } from '@moonshot-ai/agent-core';
 import { type ApprovalHandler, type Event, type QuestionHandler } from '#/events';
 import type { SDKRpcClient } from '#/rpc';
 import type {
-  BackgroundTaskInfo,
-  CompactOptions,
-  McpServerInfo,
-  McpStartupMetrics,
-  PermissionMode,
-  PromptInput,
-  ResumedSessionState,
-  SessionPlan,
-  SessionStatus,
-  SessionSummary,
-  SessionUsage,
-  SkillSummary,
-  Unsubscribe,
+    BackgroundTaskInfo,
+    CompactOptions,
+    McpServerInfo,
+    McpStartupMetrics,
+    PermissionMode,
+    PromptInput,
+    ResumedSessionState,
+    SessionPlan,
+    SessionStatus,
+    SessionSummary,
+    SessionUsage,
+    SkillSummary,
+    Unsubscribe,
 } from '#/types';
-
-const MAIN_AGENT_ID = 'main';
+import {
+    ErrorCodes,
+    KimiError,
+    MAIN_AGENT_ID,
+    type KimiErrorCode,
+} from '@moonshot-ai/agent-core';
 
 export interface SessionOptions {
   readonly id: string;

--- a/packages/oauth/test/open-platform.test.ts
+++ b/packages/oauth/test/open-platform.test.ts
@@ -107,7 +107,7 @@ describe('fetchOpenPlatformModels', () => {
       platform,
       'sk-bad',
       fetchMock as unknown as typeof fetch,
-    ).catch((caught: unknown) => caught);
+    ).catch((error: unknown) => error);
 
     expect(error).toBeInstanceOf(OpenPlatformApiError);
     expect((error as OpenPlatformApiError).status).toBe(401);


### PR DESCRIPTION
<!--
Thank you for your contribution to Kimi Code!
Please open an issue before sending a feature PR — PRs without prior discussion may be closed without review.

See https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md for more.
-->

## Related Issue

<!-- Link the issue this feature came from. If there is no issue, explain the problem in the next section instead. -->

Resolve #45

## Problem

<!-- What user need or limitation does this address? If the linked issue already covers this, write "See linked issue". -->
See linked issue.
## What changed

Centralized the main agent id constant so runtime code no longer duplicates the `'main'` agent id across `agent-core`, `node-sdk`, and `apps/kimi-code`.

- Exported `MAIN_AGENT_ID` from `packages/agent-core/src/agent/index.ts`
- Reused `MAIN_AGENT_ID` for actual agent id references in `agent-core`, including `agentId` checks, emitted event payloads, and main-agent map lookups
- Replaced duplicate node SDK `MAIN_AGENT_ID` definitions with the shared `agent-core` export
- Re-exported `MAIN_AGENT_ID` from `@moonshot-ai/kimi-code-sdk`
- Updated `apps/kimi-code` to consume `MAIN_AGENT_ID` through the SDK boundary

<!-- What did you implement, and why does this approach fit Kimi Code? -->

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [ ] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [ ] Ran `gen-docs` skill, or this PR needs no doc update.
