### PR TITLE
fix: correct X-Msh-Platform header value to kimi_code_cli

### DIFF
--- a/.changeset/fix-x-msh-platform-header.md
+++ b/.changeset/fix-x-msh-platform-header.md
@@ -1,0 +1,6 @@
+---
+"@moonshot-ai/kimi-code-oauth": patch
+"@moonshot-ai/kimi-code": patch
+---
+
+Correct the `X-Msh-Platform` header value to `kimi_code_cli`.

--- a/packages/agent-core/test/harness/runtime-provider.test.ts
+++ b/packages/agent-core/test/harness/runtime-provider.test.ts
@@ -26,7 +26,7 @@ const BASE_CONFIG: KimiConfig = {
 
 const TEST_KIMI_HEADERS = {
   'User-Agent': 'kimi-code-cli/0.0.0-test',
-  'X-Msh-Platform': 'kimi-code-cli',
+  'X-Msh-Platform': 'kimi_code_cli',
   'X-Msh-Version': '0.0.0-test',
 };
 
@@ -379,7 +379,7 @@ describe('resolveRuntimeProvider Kimi request headers', () => {
       type: 'kimi',
       defaultHeaders: {
         'User-Agent': 'Custom/1',
-        'X-Msh-Platform': 'kimi-code-cli',
+        'X-Msh-Platform': 'kimi_code_cli',
         'X-Msh-Version': 'override-version',
       },
     });

--- a/packages/node-sdk/test/runtime-provider-identity.test.ts
+++ b/packages/node-sdk/test/runtime-provider-identity.test.ts
@@ -5,7 +5,7 @@ import { join } from 'node:path';
 import { afterEach, describe, expect, it } from 'vitest';
 
 import type { KimiConfig } from '@moonshot-ai/agent-core';
-import { createKimiDefaultHeaders } from '@moonshot-ai/kimi-code-oauth';
+import { createKimiDefaultHeaders, KIMI_CODE_PLATFORM } from '@moonshot-ai/kimi-code-oauth';
 
 import { resolveRuntimeProvider } from '../../agent-core/src/providers/runtime-provider';
 import { TEST_IDENTITY } from './test-identity';
@@ -52,7 +52,7 @@ describe('runtime provider identity headers', () => {
       type: 'kimi',
       defaultHeaders: expect.objectContaining({
         'User-Agent': 'kimi-code-cli/0.0.0-test',
-        'X-Msh-Platform': 'kimi-code-cli',
+        'X-Msh-Platform': KIMI_CODE_PLATFORM,
         'X-Msh-Version': '0.0.0-test',
         'X-Msh-Device-Name': expect.any(String),
         'X-Msh-Device-Model': expect.any(String),
@@ -97,7 +97,7 @@ describe('runtime provider identity headers', () => {
       defaultHeaders: expect.objectContaining({
         'User-Agent': 'Custom/1',
         'X-Msh-Version': 'override-version',
-        'X-Msh-Platform': 'kimi-code-cli',
+        'X-Msh-Platform': KIMI_CODE_PLATFORM,
       }),
     });
   });

--- a/packages/node-sdk/test/session-prompt-events.test.ts
+++ b/packages/node-sdk/test/session-prompt-events.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { setTimeout as delay } from 'node:timers/promises';
 
+import { KIMI_CODE_PLATFORM } from '@moonshot-ai/kimi-code-oauth';
 import type * as KosongModule from '@moonshot-ai/kosong';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -214,7 +215,7 @@ describe('Session.prompt events', () => {
       expect(fakeProviderState.providerConfigs[0]).toMatchObject({
         type: 'kimi',
         defaultHeaders: expect.objectContaining({
-          'X-Msh-Platform': 'kimi-code-cli',
+          'X-Msh-Platform': KIMI_CODE_PLATFORM,
           'User-Agent': 'kimi-code-cli/0.0.0-test',
         }),
       });

--- a/packages/oauth/src/identity.ts
+++ b/packages/oauth/src/identity.ts
@@ -15,6 +15,8 @@ import { join } from 'node:path';
 
 import type { DeviceHeaders } from './types';
 
+export const KIMI_CODE_PLATFORM = 'kimi_code_cli';
+
 export interface KimiHostIdentity {
   readonly userAgentProduct: string;
   readonly version: string;
@@ -66,7 +68,7 @@ export function createKimiDeviceHeaders(options: {
   readonly version: string;
 }): DeviceHeaders {
   return {
-    'X-Msh-Platform': 'kimi-code-cli',
+    'X-Msh-Platform': KIMI_CODE_PLATFORM,
     'X-Msh-Version': requiredAsciiHeader(options.version, 'Kimi identity version'),
     'X-Msh-Device-Name': asciiHeader(hostname()),
     'X-Msh-Device-Model': asciiHeader(deviceModel()),

--- a/packages/oauth/src/index.ts
+++ b/packages/oauth/src/index.ts
@@ -31,6 +31,7 @@ export {
   createKimiDeviceHeaders,
   createKimiDeviceId,
   createKimiUserAgent,
+  KIMI_CODE_PLATFORM,
 } from './identity';
 export type { KimiHostIdentity, KimiIdentityOptions } from './identity';
 

--- a/packages/oauth/test/identity.test.ts
+++ b/packages/oauth/test/identity.test.ts
@@ -9,6 +9,7 @@ import {
   createKimiDeviceHeaders,
   createKimiDeviceId,
   createKimiUserAgent,
+  KIMI_CODE_PLATFORM,
 } from '../src/identity';
 
 const tmpRoots: string[] = [];
@@ -48,7 +49,7 @@ describe('Kimi identity factories', () => {
       version: '1.2.3-test',
     });
 
-    expect(headers['X-Msh-Platform']).toBe('kimi-code-cli');
+    expect(headers['X-Msh-Platform']).toBe(KIMI_CODE_PLATFORM);
     expect(headers['X-Msh-Version']).toBe('1.2.3-test');
     expect(headers['X-Msh-Device-Name']).toBeTruthy();
     expect(headers['X-Msh-Device-Model']).toBeTruthy();

--- a/packages/oauth/test/oauth.test.ts
+++ b/packages/oauth/test/oauth.test.ts
@@ -17,6 +17,7 @@ import {
   requestDeviceAuthorization,
   type RefreshOptions,
 } from '../src/oauth';
+import { KIMI_CODE_PLATFORM } from '../src/identity';
 import type { DeviceHeaders, OAuthFlowConfig } from '../src/types';
 
 interface FakeResponse {
@@ -112,7 +113,7 @@ class FakeOAuthServer {
 let server: FakeOAuthServer;
 
 const TEST_DEVICE_HEADERS: DeviceHeaders = {
-  'X-Msh-Platform': 'kimi-code-cli',
+  'X-Msh-Platform': KIMI_CODE_PLATFORM,
   'X-Msh-Version': '0.0.0-test',
   'X-Msh-Device-Name': 'test-device',
   'X-Msh-Device-Model': 'test-model',
@@ -222,7 +223,7 @@ describe('requestDeviceAuthorization', () => {
     });
     await requestAuth();
     const recorded = server.recorded[0]!;
-    expect(recorded.headers['x-msh-platform']).toBe('kimi-code-cli');
+    expect(recorded.headers['x-msh-platform']).toBe(KIMI_CODE_PLATFORM);
     expect(recorded.headers['x-msh-device-id']).toBe('test-device-id');
     expect(recorded.headers['x-msh-version']).toBe('0.0.0-test');
     expect(recorded.headers['user-agent'] ?? '').not.toContain('kimi-code-cli');


### PR DESCRIPTION
## Related Issue

N/A

## Problem

The `X-Msh-Platform` request header was using the value `kimi-code-cli` (with hyphens), which does not match the expected platform identifier format.

## What changed

- Replaced all hardcoded `X-Msh-Platform` header values with the new constant `KIMI_CODE_PLATFORM = 'kimi_code_cli'` in `packages/oauth/src/identity.ts`.
- Exported the constant from `packages/oauth/src/index.ts` so it can be reused across tests.
- Updated all affected unit tests to reference the constant or the corrected value directly.
- Generated a changeset for `@moonshot-ai/kimi-code-oauth` and `@moonshot-ai/kimi-code`.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran gen-changesets skill, or this PR needs no changeset.
- [ ] Ran gen-docs skill, or this PR needs no doc update.
