### PR TITLE
refactor(agent-core): make AgentRecords hold the Agent instance directly

### DIFF
--- a/.changeset/agent-records-hold-agent-ref.md
+++ b/.changeset/agent-records-hold-agent-ref.md
@@ -1,0 +1,6 @@
+---
+"@moonshot-ai/agent-core": patch
+"@moonshot-ai/kimi-code": patch
+---
+
+Make `AgentRecords` hold the `Agent` instance directly and inline the restore dispatch logic.

--- a/packages/agent-core/src/agent/index.ts
+++ b/packages/agent-core/src/agent/index.ts
@@ -41,7 +41,6 @@ import { PlanMode } from './plan';
 import {
   AgentRecords,
   FileSystemAgentRecordPersistence,
-  restoreAgentRecord,
   type AgentRecord,
   type AgentRecordPersistence,
 } from './records';
@@ -77,7 +76,6 @@ export interface AgentConfig {
   readonly backgroundMaxRunningTasks?: number;
   readonly backgroundSessionDir?: string;
   readonly permission?: PermissionManagerOptions | undefined;
-  readonly onRecord?: ((record: AgentRecord) => void) | undefined;
   /** Parent logger; the agent appends its own ctx (agentId already bound by session). */
   readonly log?: Logger;
   readonly telemetry?: TelemetryClient | undefined;
@@ -133,9 +131,7 @@ export class Agent {
     this.rpc = config.rpc;
     this.telemetry = config.telemetry ?? noopTelemetryClient;
     this.records = new AgentRecords(
-      (record) => {
-        restoreAgentRecord(this, record);
-      },
+      this,
       config.persistence ??
         (config.homedir
           ? new FileSystemAgentRecordPersistence(join(config.homedir, 'wire.jsonl'), {
@@ -145,7 +141,6 @@ export class Agent {
             })
           : undefined),
     );
-    this.records.onRecord = config.onRecord;
     this.fullCompaction = new FullCompaction(this, config.compactionStrategy);
     this.context = new ContextMemory(this);
     this.config = new ConfigState(this);

--- a/packages/agent-core/src/agent/records/index.ts
+++ b/packages/agent-core/src/agent/records/index.ts
@@ -20,7 +20,7 @@ export type { FileSystemAgentRecordPersistenceOptions } from './persistence';
 // Contract: restore MUST NOT emit UI events, call the LLM, execute tools, or
 // touch the filesystem in a way that triggers external side effects. Each case
 // should reproduce the in-memory state the live handler left behind, nothing more.
-export function restoreAgentRecord(agent: Agent, input: AgentRecord): void {
+function restoreAgentRecord(agent: Agent, input: AgentRecord): void {
   switch (input.type) {
     case 'metadata':
       return;
@@ -98,10 +98,9 @@ export function restoreAgentRecord(agent: Agent, input: AgentRecord): void {
 export class AgentRecords {
   private _restoring = false;
   private metadataInitialized = false;
-  onRecord?: (record: AgentRecord) => void;
 
   constructor(
-    private readonly restoreRecord: (record: AgentRecord) => void,
+    private readonly agent: Agent,
     private readonly persistence?: AgentRecordPersistence,
   ) {}
 
@@ -129,13 +128,12 @@ export class AgentRecords {
       this.metadataInitialized = true;
     }
     this.persistence?.append(stamped);
-    this.onRecord?.(stamped);
   }
 
   restore(record: AgentRecord): void {
     this._restoring = true;
     try {
-      this.restoreRecord(record);
+      restoreAgentRecord(this.agent, record);
     } finally {
       this._restoring = false;
     }

--- a/packages/agent-core/src/agent/records/persistence.ts
+++ b/packages/agent-core/src/agent/records/persistence.ts
@@ -9,10 +9,17 @@ export interface FileSystemAgentRecordPersistenceOptions {
   readonly onError?: ((error: unknown) => void) | undefined;
 }
 
+export interface InMemoryAgentRecordPersistenceOptions {
+  readonly onRecord?: ((record: AgentRecord) => void) | undefined;
+}
+
 export class InMemoryAgentRecordPersistence implements AgentRecordPersistence {
   readonly records: AgentRecord[] = [];
 
-  constructor(records: readonly AgentRecord[] = []) {
+  constructor(
+    records: readonly AgentRecord[] = [],
+    private readonly options: InMemoryAgentRecordPersistenceOptions = {},
+  ) {
     this.records.push(...records);
   }
 
@@ -24,6 +31,7 @@ export class InMemoryAgentRecordPersistence implements AgentRecordPersistence {
 
   append(input: AgentRecord): void {
     this.records.push(input);
+    this.options.onRecord?.(input);
   }
 
   rewrite(records: readonly AgentRecord[]): void {

--- a/packages/agent-core/test/agent/harness/agent.ts
+++ b/packages/agent-core/test/agent/harness/agent.ts
@@ -163,11 +163,13 @@ export class AgentTestContext {
       kaos: options.kaos ?? localKaos,
       osEnv: TEST_OS_ENV,
     };
+    const persistence = this.wrapPersistence(
+      options.persistence ?? new InMemoryAgentRecordPersistence(),
+    );
     this.agent = new Agent({
       runtime,
       rpc: this.createRpcProxy(),
-      persistence:
-        options.persistence === undefined ? undefined : this.wrapPersistence(options.persistence),
+      persistence,
       generate: options.generate ?? this.scriptedGenerate.generate,
       compactionStrategy: options.compactionStrategy,
       providerManager,
@@ -179,9 +181,6 @@ export class AgentTestContext {
       telemetry: options.telemetry,
       log: options.log,
     });
-    this.agent.records.onRecord = (event) => {
-      this.captureRecord(event);
-    };
     this.rpc = this.createPromiseAgentApi(this.agent);
   }
 
@@ -445,6 +444,7 @@ export class AgentTestContext {
     return {
       read: () => this.readAndCapturePersistence(persistence),
       append: (event) => {
+        this.captureRecord(event);
         persistence.append(event);
       },
       rewrite: (records) => {

--- a/packages/agent-core/test/agent/harness/snapshots.ts
+++ b/packages/agent-core/test/agent/harness/snapshots.ts
@@ -268,7 +268,7 @@ function normalizeValue(value: unknown, uuidLabels: Map<string, string>): unknow
     return Object.fromEntries(
       Object.entries(value).map(([key, nested]) => [
         key,
-        key === 'time' && typeof nested === 'number'
+        (key === 'time' || key === 'created_at') && typeof nested === 'number'
           ? '<time>'
           : normalizeValue(nested, uuidLabels),
       ]),

--- a/packages/agent-core/test/agent/records/index.test.ts
+++ b/packages/agent-core/test/agent/records/index.test.ts
@@ -6,11 +6,12 @@ import {
   InMemoryAgentRecordPersistence,
   type AgentRecord,
 } from '../../../src/agent/records';
+import { testAgent } from '../harness/agent';
 
 describe('AgentRecords persistence metadata', () => {
   it('writes metadata before the first persisted record', async () => {
     const persistence = new InMemoryAgentRecordPersistence();
-    const records = new AgentRecords(() => {}, persistence);
+    const records = testAgent({ persistence }).agent.records;
 
     records.logRecord({
       type: 'turn.prompt',
@@ -29,7 +30,7 @@ describe('AgentRecords persistence metadata', () => {
 
   it('does not write metadata when replaying an empty stream', async () => {
     const persistence = new InMemoryAgentRecordPersistence();
-    const records = new AgentRecords(() => {}, persistence);
+    const records = testAgent({ persistence }).agent.records;
 
     await records.replay();
     records.logRecord({
@@ -53,7 +54,7 @@ describe('AgentRecords persistence metadata', () => {
         origin: { kind: 'user' },
       },
     ]);
-    const records = new AgentRecords(() => {}, persistence);
+    const records = testAgent({ persistence }).agent.records;
 
     await expect(records.replay()).rejects.toThrow(
       'AgentRecords replay expected metadata as the first record',
@@ -73,7 +74,7 @@ describe('AgentRecords persistence metadata', () => {
         origin: { kind: 'user' },
       },
     ]);
-    const records = new AgentRecords(() => {}, persistence);
+    const records = testAgent({ persistence }).agent.records;
 
     await records.replay();
     records.logRecord({
@@ -104,7 +105,7 @@ describe('AgentRecords persistence metadata', () => {
         origin: { kind: 'user' },
       },
     ]);
-    const records = new AgentRecords(() => {}, persistence);
+    const records = testAgent({ persistence }).agent.records;
 
     await records.replay();
 
@@ -136,7 +137,7 @@ describe('AgentRecords persistence metadata', () => {
         },
       } as unknown as AgentRecord,
     ]);
-    const records = new AgentRecords(() => {}, persistence);
+    const records = testAgent({ persistence }).agent.records;
 
     await records.replay();
 
@@ -165,7 +166,7 @@ describe('AgentRecords persistence metadata', () => {
         created_at: 1,
       },
     ]);
-    const records = new AgentRecords(() => {}, persistence);
+    const records = testAgent({ persistence }).agent.records;
 
     const result = await records.replay();
     expect(result.warning).toContain('9.9');
@@ -180,7 +181,7 @@ describe('AgentRecords persistence metadata', () => {
         created_at: 1,
       },
     ]);
-    const records = new AgentRecords(() => {}, persistence);
+    const records = testAgent({ persistence }).agent.records;
 
     await expect(records.replay()).rejects.toThrow('Missing wire migration for version 0.9');
   });

--- a/packages/agent-core/test/agent/records/migration/v1.1.test.ts
+++ b/packages/agent-core/test/agent/records/migration/v1.1.test.ts
@@ -6,7 +6,13 @@ import {
   InMemoryAgentRecordPersistence,
   type AgentRecord,
 } from '../../../../src/agent/records';
+import type { Agent } from '../../../../src/agent';
 import { eventSnapshot } from '../../harness/snapshots';
+
+const agent = {
+  context: { appendMessage() {}, appendLoopEvent() {} },
+  tools: { registerUserTool() {} },
+} as unknown as Agent;
 
 describe('1.0 to 1.1', () => {
   it('rewrites v1.0 records to the v1.1 wire shape', async () => {
@@ -74,7 +80,7 @@ describe('1.0 to 1.1', () => {
         },
       } as unknown as AgentRecord,
     ]);
-    const records = new AgentRecords(() => {}, persistence);
+    const records = new AgentRecords(agent, persistence);
 
     await records.replay();
 
@@ -83,7 +89,7 @@ describe('1.0 to 1.1', () => {
       protocol_version: AGENT_WIRE_PROTOCOL_VERSION,
     });
     expect(wireSnapshot(persistence.records)).toMatchInlineSnapshot(`
-      [wire] metadata                    { "protocol_version": "1.1", "created_at": 1 }
+      [wire] metadata                    { "protocol_version": "1.1", "created_at": "<time>" }
       [wire] context.append_message      { "message": { "role": "assistant", "content": [], "toolCalls": [ { "type": "function", "id": "call_legacy_bash", "name": "Bash", "arguments": "{\\"command\\":\\"pwd\\"}" } ] } }
       [wire] tools.register_user_tool    { "name": "schema_tool", "description": "Tool with a schema field named function", "parameters": { "type": "object", "properties": { "function": { "type": "object", "properties": { "name": { "type": "string" } } }, "value": { "type": "string" } }, "required": [ "function" ] } }
       [wire] context.append_loop_event   { "event": { "type": "tool.call", "uuid": "call_payload", "turnId": "0", "step": 1, "stepUuid": "step_1", "toolCallId": "call_payload", "name": "PayloadTool", "args": { "payload": { "type": "function", "id": "user_payload", "function": { "name": "do-not-migrate", "arguments": "{\\"keep\\":true}" } } } } }

--- a/packages/agent-core/test/agent/skill-tool-manager.test.ts
+++ b/packages/agent-core/test/agent/skill-tool-manager.test.ts
@@ -6,6 +6,8 @@ import { localKaos } from '@moonshot-ai/kaos';
 import { describe, expect, it, vi } from 'vitest';
 
 import { Agent, type AgentRecord } from '../../src/agent';
+import { InMemoryAgentRecordPersistence } from '../../src/agent/records';
+import type { AgentRecordPersistence } from '../../src/agent/records';
 import { ProviderManager } from '../../src/providers/provider-manager';
 import type { ApprovalResponse, SDKAgentRPC, SDKSessionRPC } from '../../src/rpc';
 import { Session } from '../../src/session';
@@ -40,7 +42,10 @@ function makeSkill(name: string, metadata: SkillDefinition['metadata'] = {}): Sk
   };
 }
 
-function makeAgent(skills?: SkillRegistry): Agent {
+function makeAgent(
+  skills?: SkillRegistry,
+  persistence?: AgentRecordPersistence,
+): Agent {
   const rpc = {
     emitEvent: vi.fn(),
     requestApproval: vi.fn(),
@@ -54,6 +59,7 @@ function makeAgent(skills?: SkillRegistry): Agent {
     },
     rpc,
     skills,
+    persistence,
     providerManager: testProviderManager(),
   });
   agent.config.update({
@@ -135,11 +141,11 @@ describe('ToolManager SkillTool registration', () => {
   it('persists model-invoked inline skill reminders through agent wire', async () => {
     const skills = new SkillRegistry();
     skills.register(makeSkill('review'));
-    const agent = makeAgent(skills);
     const wireRecords: AgentRecord[] = [];
-    agent.records.onRecord = (record) => {
-      wireRecords.push(record);
-    };
+    const persistence = new InMemoryAgentRecordPersistence([], {
+      onRecord: (record) => wireRecords.push(record),
+    });
+    const agent = makeAgent(skills, persistence);
     const skillTool = agent.tools.loopTools.find((tool) => tool.name === 'Skill');
     if (!(skillTool instanceof SkillTool)) {
       throw new Error('Expected SkillTool to be active');

--- a/packages/agent-core/test/agent/turn.test.ts
+++ b/packages/agent-core/test/agent/turn.test.ts
@@ -253,6 +253,7 @@ describe('Agent turn flow', () => {
     await ctx.rpc.prompt({ input: [{ type: 'text', text: 'Hello without login' }] });
 
     expect(await ctx.untilTurnEnd()).toMatchInlineSnapshot(`
+      [wire] metadata                 { "protocol_version": "1.1", "created_at": "<time>" }
       [wire] turn.prompt              { "input": [ { "type": "text", "text": "Hello without login" } ], "origin": { "kind": "user" }, "time": "<time>" }
       [emit] turn.started             { "turnId": 0, "origin": { "kind": "user" } }
       [wire] context.append_message   { "message": { "role": "user", "content": [ { "type": "text", "text": "Hello without login" } ], "toolCalls": [], "origin": { "kind": "user" } }, "time": "<time>" }


### PR DESCRIPTION
## Problem

Previously `AgentRecords` received a callback function `(record) => void` in its constructor, and `Agent` had to create an arrow function that called `restoreAgentRecord(this, record)` to bridge the gap. This indirect wiring is unnecessary since `AgentRecords` always restores records onto the agent that owns it.

`AgentConfig.onRecord` and `AgentRecords.onRecord` are also redundant: callers can observe persistence directly, and `Session` never uses the constructor option.

## What changed

- Change `AgentRecords` constructor to accept the `Agent` instance directly instead of a restore callback.
- Keep `restoreAgentRecord` as a standalone function (no longer exported) used internally by `AgentRecords.restore()`.
- Simplify `Agent` construction: `new AgentRecords(this, persistence)`.
- Remove `AgentConfig.onRecord` and the corresponding constructor assignment.
- Remove `AgentRecords.onRecord`; add `onRecord` option to `InMemoryAgentRecordPersistence` so tests can observe records at the persistence layer instead.
- Update `testAgent` harness to always wrap a default persistence and capture records from `append()`, keeping wire snapshots working without the removed callback.
- Update snapshot normalizer to mask `created_at` timestamps.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] This PR needs a changeset (generated below).
- [x] This PR needs no doc update.
