### PR TITLE
fix(kimi-code): skip masking empty API key input to avoid ghost dot

### DIFF
--- a/.changeset/fix-api-key-empty-dot.md
+++ b/.changeset/fix-api-key-empty-dot.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Fix API key input dialog showing a masked dot in empty state.

--- a/apps/kimi-code/src/tui/components/dialogs/api-key-input-dialog.ts
+++ b/apps/kimi-code/src/tui/components/dialogs/api-key-input-dialog.ts
@@ -106,7 +106,7 @@ export class ApiKeyInputDialogComponent extends Container implements Focusable {
     const subtitleLine = truncateToWidth(subtitleStyled, innerWidth, '…');
     const footerLine = truncateToWidth(footerStyled, innerWidth, '…');
     const rawInputLine = this.input.render(innerWidth)[0] ?? '> ';
-    const inputLine = maskInputLine(rawInputLine);
+    const inputLine = this.input.getValue() === '' ? rawInputLine : maskInputLine(rawInputLine);
 
     const contentLines: string[] = [titleLine, '', subtitleLine, '', inputLine, '', footerLine];
 


### PR DESCRIPTION
## Related Issue

N/A — bug discovered during usage.

## Problem

When the `/connect` command prompts the user to enter an API key, the input box shows a masked dot (`•`) even though the user has typed nothing. This happens because the underlying `Input` component renders the cursor as a space wrapped in an ANSI reverse-video escape sequence, and `maskInputLine` replaces every visible character with `•`, including that empty cursor placeholder.

[Image: /Users/hanrui/.claude/image-cache/1eb1f9f2-52d4-4525-a981-928dcfe53771/1.png]

## What changed

In `ApiKeyInputDialogComponent.render`, check whether `input.getValue()` is empty before applying `maskInputLine`. If the input is still empty, render the raw line (which just shows `> ` plus the cursor) instead of masking it. This preserves the masking behavior once the user starts typing, while eliminating the ghost dot in the empty state.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have explained the problem above.
- [ ] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [ ] Ran `gen-docs` skill, or this PR needs no doc update.