### PR TITLE
fix(catalog): preserve reasoning fields in custom model

### DIFF
--- a/.changeset/catalog-interleaved-reasoning.md
+++ b/.changeset/catalog-interleaved-reasoning.md
@@ -1,0 +1,8 @@
+---
+"@moonshot-ai/agent-core": patch
+"@moonshot-ai/kosong": patch
+"@moonshot-ai/kimi-code-sdk": patch
+"@moonshot-ai/kimi-code": patch
+---
+
+Preserve catalog-declared interleaved reasoning fields for OpenAI-compatible models configured through `/connect`.

--- a/apps/kimi-code/scripts/update-catalog.mjs
+++ b/apps/kimi-code/scripts/update-catalog.mjs
@@ -15,7 +15,16 @@ const outFile = resolveOutputFile(process.argv.slice(2));
 const modelsUrl = process.env.MODELS_DEV_URL || "https://models.dev/api.json";
 
 const KEEP_PROVIDER = new Set(["id", "name", "api", "env", "npm", "type", "models"]);
-const KEEP_MODEL = new Set(["id", "name", "family", "limit", "tool_call", "reasoning", "modalities"]);
+const KEEP_MODEL = new Set([
+  "id",
+  "name",
+  "family",
+  "limit",
+  "tool_call",
+  "reasoning",
+  "interleaved",
+  "modalities",
+]);
 
 function resolveOutputFile(args) {
   const index = args.indexOf("--out");

--- a/packages/agent-core/src/config/schema.ts
+++ b/packages/agent-core/src/config/schema.ts
@@ -42,6 +42,7 @@ export const ModelAliasSchema = z.object({
   maxOutputSize: z.number().int().min(1).optional(),
   capabilities: z.array(z.string()).optional(),
   displayName: z.string().optional(),
+  reasoningKey: z.string().optional(),
 });
 
 export type ModelAlias = z.infer<typeof ModelAliasSchema>;

--- a/packages/agent-core/src/providers/runtime-provider.ts
+++ b/packages/agent-core/src/providers/runtime-provider.ts
@@ -113,6 +113,7 @@ export function resolveRuntimeProvider(
     resolvedModel,
     input.kimiRequestHeaders,
     alias.maxOutputSize,
+    alias.reasoningKey,
     input.promptCacheKey,
   );
   const modelCapabilities = resolveModelCapabilities(alias, provider);
@@ -229,6 +230,7 @@ function toKosongProviderConfig(
   model: string,
   kimiRequestHeaders?: Record<string, string> | undefined,
   maxOutputSize?: number | undefined,
+  reasoningKey?: string | undefined,
   promptCacheKey?: string,
 ): KosongProviderConfig {
   switch (provider.type) {
@@ -247,6 +249,7 @@ function toKosongProviderConfig(
         model,
         baseUrl: providerValue(provider.baseUrl, provider.env, 'OPENAI_BASE_URL'),
         apiKey: providerApiKey(provider),
+        reasoningKey,
         ...defaultHeadersField(provider.customHeaders),
       };
     case 'kimi': {

--- a/packages/kosong/src/catalog.ts
+++ b/packages/kosong/src/catalog.ts
@@ -13,6 +13,7 @@ export interface CatalogModelEntry {
   readonly limit?: { readonly context?: number; readonly output?: number };
   readonly tool_call?: boolean;
   readonly reasoning?: boolean;
+  readonly interleaved?: boolean | { readonly field?: string };
   readonly modalities?: {
     readonly input?: readonly string[];
     readonly output?: readonly string[];
@@ -41,6 +42,7 @@ export interface CatalogModel {
   readonly id: string;
   readonly name?: string;
   readonly maxOutputSize?: number;
+  readonly reasoningKey?: string;
   readonly capability: ModelCapability;
 }
 
@@ -126,6 +128,7 @@ export function catalogModelToCapability(model: CatalogModelEntry): CatalogModel
     id: model.id,
     name: typeof model.name === 'string' && model.name.length > 0 ? model.name : undefined,
     maxOutputSize: typeof output === 'number' && output > 0 ? output : undefined,
+    reasoningKey: catalogReasoningKey(model.interleaved),
     capability: {
       image_in: inputs.includes('image'),
       video_in: inputs.includes('video'),
@@ -135,6 +138,12 @@ export function catalogModelToCapability(model: CatalogModelEntry): CatalogModel
       max_context_tokens: context,
     },
   };
+}
+
+function catalogReasoningKey(interleaved: CatalogModelEntry['interleaved']): string | undefined {
+  if (typeof interleaved !== 'object' || interleaved === null) return undefined;
+  const field = interleaved.field?.trim();
+  return field !== undefined && field.length > 0 ? field : undefined;
 }
 
 /** Extracts the valid, normalized models from a catalog provider entry. */

--- a/packages/kosong/src/catalog.ts
+++ b/packages/kosong/src/catalog.ts
@@ -141,6 +141,10 @@ export function catalogModelToCapability(model: CatalogModelEntry): CatalogModel
 }
 
 function catalogReasoningKey(interleaved: CatalogModelEntry['interleaved']): string | undefined {
+  // models.dev allows `interleaved: true` as "general support" — read it as
+  // the default `reasoning_content` field so providers without an explicit
+  // field name (e.g. some openai-compatible gateways) still round-trip.
+  if (interleaved === true) return 'reasoning_content';
   if (typeof interleaved !== 'object' || interleaved === null) return undefined;
   const field = interleaved.field?.trim();
   return field !== undefined && field.length > 0 ? field : undefined;

--- a/packages/kosong/test/catalog.test.ts
+++ b/packages/kosong/test/catalog.test.ts
@@ -5,6 +5,7 @@ import {
   catalogModelToCapability,
   catalogProviderModels,
   inferWireType,
+  type CatalogModelEntry,
 } from '../src/catalog';
 
 describe('inferWireType', () => {
@@ -121,6 +122,20 @@ describe('catalogModelToCapability', () => {
         modalities: { input: ['text'], output: ['audio'] },
       }),
     ).toBeUndefined();
+  });
+
+  it.each<[CatalogModelEntry['interleaved'], string | undefined]>([
+    [undefined, undefined],
+    [true, 'reasoning_content'],
+    [false, undefined],
+    [{}, undefined],
+    [{ field: '' }, undefined],
+    [{ field: 'reasoning_content' }, 'reasoning_content'],
+    [{ field: 'reasoning_details' }, 'reasoning_details'],
+    [{ field: '  reasoning_content  ' }, 'reasoning_content'],
+  ])('derives reasoningKey from interleaved=%j → %j', (interleaved, expected) => {
+    const model = catalogModelToCapability({ id: 'm', limit: { context: 1000 }, interleaved });
+    expect(model?.reasoningKey).toBe(expected);
   });
 });
 

--- a/packages/node-sdk/src/catalog.ts
+++ b/packages/node-sdk/src/catalog.ts
@@ -59,6 +59,7 @@ export function catalogModelToAlias(providerId: string, model: CatalogModel): Mo
     maxOutputSize: model.maxOutputSize,
     capabilities: capabilityToStrings(model.capability),
     displayName: model.name,
+    reasoningKey: model.reasoningKey,
   };
 }
 

--- a/packages/node-sdk/test/catalog.test.ts
+++ b/packages/node-sdk/test/catalog.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, it, vi } from 'vitest';
 import {
   applyCatalogProvider,
   catalogModelToAlias,
+  catalogProviderModels,
   CatalogFetchError,
   fetchCatalog,
   type CatalogModel,
@@ -88,6 +89,40 @@ describe('applyCatalogProvider', () => {
     });
     expect(config.defaultModel).toBe('anthropic/m1');
     expect(config.defaultThinking).toBe(true);
+  });
+
+  it('writes interleaved reasoning key from a catalog-selected model alias', () => {
+    const models = catalogProviderModels({
+      id: 'deepseek',
+      models: {
+        'deepseek-v4-pro': {
+          id: 'deepseek-v4-pro',
+          name: 'DeepSeek V4 Pro',
+          family: 'deepseek-thinking',
+          limit: { context: 1000000, output: 384000 },
+          reasoning: true,
+          tool_call: true,
+          interleaved: { field: 'reasoning_content' },
+        },
+      },
+    });
+    const config = { providers: {} } as KimiConfig;
+
+    applyCatalogProvider(config, {
+      providerId: 'deepseek',
+      wire: 'openai',
+      baseUrl: 'https://api.deepseek.com',
+      apiKey: 'sk',
+      models,
+      selectedModelId: 'deepseek-v4-pro',
+      thinking: true,
+    });
+
+    expect(config.models?.['deepseek/deepseek-v4-pro']).toMatchObject({
+      provider: 'deepseek',
+      model: 'deepseek-v4-pro',
+      reasoningKey: 'reasoning_content',
+    });
   });
 
   it('clears stale aliases for the same provider but keeps others', () => {


### PR DESCRIPTION
<!--
Thank you for your contribution to Kimi Code!
Please open an issue before sending a feature PR — PRs without prior discussion may be closed without review.

See https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md for more.
-->

## Related Issue

<!-- Link the issue this feature came from. If there is no issue, explain the problem in the next section instead. -->

Resolve Status:  #69

## Problem

<!-- What user need or limitation does this address? If the linked issue already covers this, write "See linked issue". -->

## What changed

<!-- What did you implement, and why does this approach fit Kimi Code? -->
适配model.dev的参数，修复三方模型thinking输出的key字段参数
<img width="337" height="244" alt="Clipboard_Screenshot_1779783428" src="https://github.com/user-attachments/assets/99fd0c81-e8a5-46d2-86a3-565750ba6b49" />

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.
