### PR TITLE
fix(tui): block /model and /sessions while busy

### DIFF
--- a/.changeset/block-model-sessions-busy.md
+++ b/.changeset/block-model-sessions-busy.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Prevent running the `/model` and `/sessions` slash commands while streaming or compacting context.

--- a/apps/kimi-code/src/tui/commands/registry.ts
+++ b/apps/kimi-code/src/tui/commands/registry.ts
@@ -34,7 +34,6 @@ export const BUILTIN_SLASH_COMMANDS = [
     aliases: [],
     description: 'Switch LLM model',
     priority: 100,
-    availability: 'always',
   },
   {
     name: 'help',
@@ -54,7 +53,6 @@ export const BUILTIN_SLASH_COMMANDS = [
     aliases: ['resume'],
     description: 'Browse and resume sessions',
     priority: 80,
-    availability: 'always',
   },
   {
     name: 'tasks',

--- a/apps/kimi-code/test/tui/commands/resolve.test.ts
+++ b/apps/kimi-code/test/tui/commands/resolve.test.ts
@@ -48,6 +48,39 @@ describe('resolveSlashCommandInput', () => {
       commandName: 'init',
       reason: 'streaming',
     });
+    expect(resolve('/model', { isStreaming: true })).toEqual({
+      kind: 'blocked',
+      commandName: 'model',
+      reason: 'streaming',
+    });
+    expect(resolve('/sessions', { isStreaming: true })).toEqual({
+      kind: 'blocked',
+      commandName: 'sessions',
+      reason: 'streaming',
+    });
+    expect(resolve('/resume', { isStreaming: true })).toEqual({
+      kind: 'blocked',
+      commandName: 'resume',
+      reason: 'streaming',
+    });
+  });
+
+  it('blocks model and session pickers while compacting', () => {
+    expect(resolve('/model', { isCompacting: true })).toEqual({
+      kind: 'blocked',
+      commandName: 'model',
+      reason: 'compacting',
+    });
+    expect(resolve('/sessions', { isCompacting: true })).toEqual({
+      kind: 'blocked',
+      commandName: 'sessions',
+      reason: 'compacting',
+    });
+    expect(resolve('/resume', { isCompacting: true })).toEqual({
+      kind: 'blocked',
+      commandName: 'resume',
+      reason: 'compacting',
+    });
   });
 
   it('allows always-available built-ins while streaming', () => {

--- a/apps/kimi-code/test/tui/kimi-tui-message-flow.test.ts
+++ b/apps/kimi-code/test/tui/kimi-tui-message-flow.test.ts
@@ -355,16 +355,21 @@ describe('KimiTUI message flow', () => {
   it('tracks blocked slash commands as invalid without counting them as executed commands', async () => {
     const { driver, harness } = await makeDriver();
     driver.state.appState.isStreaming = true;
-    harness.track.mockClear();
 
-    driver.handleUserInput('/new');
-    await Promise.resolve();
+    for (const command of ['/new', '/model', '/sessions']) {
+      harness.track.mockClear();
 
-    expect(harness.track).toHaveBeenCalledWith('input_command_invalid', {
-      reason: 'blocked',
-      command: 'new',
-    });
-    expect(harness.track).not.toHaveBeenCalledWith('input_command', { command: 'new' });
+      driver.handleUserInput(command);
+      await Promise.resolve();
+
+      expect(harness.track).toHaveBeenCalledWith('input_command_invalid', {
+        reason: 'blocked',
+        command: command.slice(1),
+      });
+      expect(harness.track).not.toHaveBeenCalledWith('input_command', {
+        command: command.slice(1),
+      });
+    }
   });
 
   it('tracks Shift-Tab mode switches through the editor handler', async () => {

--- a/docs/en/guides/sessions.md
+++ b/docs/en/guides/sessions.md
@@ -63,7 +63,7 @@ kimi --session
 - `/fork`: fork the current session (see below).
 - `/title <text>` (`/rename`): set a session title for easier recognition. Without an argument, shows the current title.
 
-`/sessions` works even while streaming, but switching requires interrupting the turn first with `Esc` or `Ctrl-C`. `/new`, `/fork`, and `/compact` are only available while idle.
+`/sessions`, `/new`, `/fork`, and `/compact` are only available while idle. During streaming output or context compaction, interrupt the current operation first with `Esc` or `Ctrl-C`.
 
 ## Context compaction
 

--- a/docs/en/reference/slash-commands.md
+++ b/docs/en/reference/slash-commands.md
@@ -15,7 +15,7 @@ Some commands are only available in the idle state. Running them while the sessi
 | `/login` | — | Pick an account or platform and sign in: Kimi Code uses the OAuth device code flow, while the Moonshot AI Open Platform signs in with an API key. | No |
 | `/logout` | — | Clear the credentials of the currently selected account (Kimi Code OAuth credentials, or the corresponding open platform provider config). | No |
 | `/connect [--refresh] [--url=<catalog-url>]` | — | Configure a provider and model from a model catalog. The default catalog is bundled with the CLI; pass `--refresh` to fetch the latest catalog from models.dev, or `--url` to read it from a custom URL. See [Providers and models — `/connect` and the model catalog](../configuration/providers.md#connect-and-the-model-catalog). | No |
-| `/model` | — | Switch the LLM model used by the current session. | Yes |
+| `/model` | — | Switch the LLM model used by the current session. | No |
 | `/settings` | `/config` | Open the settings panel inside the TUI. | Yes |
 | `/permission` | — | Choose a permission mode. | Yes |
 | `/editor` | — | Configure the external editor launched by `Ctrl-G`. | Yes |
@@ -26,7 +26,7 @@ Some commands are only available in the idle state. Running them while the sessi
 | Command | Alias | Description | Always available |
 | --- | --- | --- | --- |
 | `/new` | `/clear` | Start a brand-new session, discarding the current context. | No |
-| `/sessions` | `/resume` | Browse historical sessions and switch to or resume one. | Yes |
+| `/sessions` | `/resume` | Browse historical sessions and switch to or resume one. | No |
 | `/tasks` | `/task` | Browse the background task list. | Yes |
 | `/fork` | — | Fork a new session from the current one, preserving the full conversation history. | No |
 | `/title [<text>]` | `/rename` | Without arguments, show the current session title; with an argument, set it as the new title (up to 200 characters). | Yes |

--- a/docs/zh/guides/sessions.md
+++ b/docs/zh/guides/sessions.md
@@ -63,7 +63,7 @@ kimi --session
 - `/fork`：派生当前会话（详见下文）。
 - `/title <text>`（`/rename`）：设置会话标题，方便识别。不带参数时显示当前标题。
 
-`/sessions` 在流式输出期间也能浏览，但切换前需先按 `Esc` 或 `Ctrl-C` 中断。`/new`、`/fork`、`/compact` 仅在空闲时可用。
+`/sessions`、`/new`、`/fork`、`/compact` 仅在空闲时可用。流式输出或上下文压缩期间，需先按 `Esc` 或 `Ctrl-C` 中断当前操作。
 
 ## 上下文压缩
 

--- a/docs/zh/reference/slash-commands.md
+++ b/docs/zh/reference/slash-commands.md
@@ -15,7 +15,7 @@
 | `/login` | — | 选择账号或平台并登录：Kimi Code 走 OAuth device code 流程，Moonshot AI 开放平台通过 API 密钥登录。 | 否 |
 | `/logout` | — | 清除当前所选账号的凭据（Kimi Code OAuth 凭据，或对应开放平台的供应商配置）。 | 否 |
 | `/connect [--refresh] [--url=<catalog-url>]` | — | 从模型目录中选择并配置供应商与模型。CLI 已内置默认目录；传入 `--refresh` 可从 models.dev 拉取最新目录，传入 `--url` 可指向自定义目录地址。详见 [平台与模型 — `/connect` 与模型目录](../configuration/providers.md#connect-与模型目录)。 | 否 |
-| `/model` | — | 切换当前会话使用的 LLM 模型。 | 是 |
+| `/model` | — | 切换当前会话使用的 LLM 模型。 | 否 |
 | `/settings` | `/config` | 打开 TUI 内的设置面板。 | 是 |
 | `/permission` | — | 选择权限模式（permission mode）。 | 是 |
 | `/editor` | — | 配置 `Ctrl-G` 调起的外部编辑器。 | 是 |
@@ -26,7 +26,7 @@
 | 命令 | 别名 | 说明 | 随时可用 |
 | --- | --- | --- | --- |
 | `/new` | `/clear` | 开启一个全新会话，丢弃当前上下文。 | 否 |
-| `/sessions` | `/resume` | 浏览历史会话并切换/恢复。 | 是 |
+| `/sessions` | `/resume` | 浏览历史会话并切换/恢复。 | 否 |
 | `/tasks` | `/task` | 浏览后台任务列表。 | 是 |
 | `/fork` | — | 基于当前会话 fork 一份新会话，保留完整对话历史。 | 否 |
 | `/title [<text>]` | `/rename` | 不带参数时显示当前会话标题；带参数时将其设置为新标题（最长 200 个字符）。 | 是 |


### PR DESCRIPTION
## Related Issue

No linked issue. This PR blocks `/model` and `/sessions` during response streaming and context compaction.

## Problem

During response streaming and context compaction, Kimi Code should not allow `/model` or `/sessions` to run. These commands open model and session pickers that can lead to model or session changes while the current operation is still active.

## What changed

- Block `/model` and `/sessions` (including `/resume`) during streaming and compaction at slash command resolution.
- Keep the existing runtime guards for non-slash paths that may still attempt model or session switches while busy.
- Add resolver and TUI telemetry tests to verify blocked commands are not tracked as executed commands.
- Update English and Chinese user docs, and refresh the patch changeset wording.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.