### PR TITLE
feat(kimi-code): rework /logout into a provider picker and add /disconnect alias

### DIFF
--- a/.changeset/logout-provider-picker.md
+++ b/.changeset/logout-provider-picker.md
@@ -2,4 +2,4 @@
 "@moonshot-ai/kimi-code": minor
 ---
 
-/logout now opens a picker so you can choose which provider to log out of, instead of always logging out the one tied to the current model. The current provider is highlighted by default, so pressing Enter matches the previous behavior.
+/logout now opens a picker so you can choose which provider to log out of, instead of always logging out the one tied to the current model. The current provider is highlighted by default, so pressing Enter matches the previous behavior. The command is also available as /disconnect.

--- a/.changeset/logout-provider-picker.md
+++ b/.changeset/logout-provider-picker.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": minor
+---
+
+/logout now opens a picker so you can choose which provider to log out of, instead of always logging out the one tied to the current model. The current provider is highlighted by default, so pressing Enter matches the previous behavior.

--- a/apps/kimi-code/src/tui/commands/registry.ts
+++ b/apps/kimi-code/src/tui/commands/registry.ts
@@ -131,8 +131,8 @@ export const BUILTIN_SLASH_COMMANDS = [
   },
   {
     name: 'logout',
-    aliases: [],
-    description: 'Clear credentials for the current platform',
+    aliases: ['disconnect'],
+    description: 'Log out of a configured provider',
     priority: 40,
   },
   {

--- a/apps/kimi-code/src/tui/constant/kimi-tui.ts
+++ b/apps/kimi-code/src/tui/constant/kimi-tui.ts
@@ -1,6 +1,6 @@
 import { DEFAULT_OAUTH_PROVIDER_NAME } from '#/constant/app';
 
-export { DEFAULT_OAUTH_PROVIDER_NAME, OAUTH_LOGIN_REQUIRED_CODE } from '#/constant/app';
+export { DEFAULT_OAUTH_PROVIDER_NAME, OAUTH_LOGIN_REQUIRED_CODE, PRODUCT_NAME } from '#/constant/app';
 
 export const LLM_NOT_SET_MESSAGE = 'LLM not set, send "/login" to login';
 export const NO_ACTIVE_SESSION_MESSAGE = 'No active session. Send /login to login.';

--- a/apps/kimi-code/src/tui/kimi-tui.ts
+++ b/apps/kimi-code/src/tui/kimi-tui.ts
@@ -5375,23 +5375,28 @@ export class KimiTUI {
   }
 
   // Handles the /logout command. Lists every credential currently held — the
-  // Kimi Code OAuth token (when present) plus each configured API-key provider
-  // — and lets the user pick which one to drop. managed:kimi-code is also
-  // written into config.providers, so it must be filtered out of the API-key
-  // list to avoid showing twice; OAuth tokens go through auth.logout for
-  // proper revocation, everything else through removeProvider.
+  // Kimi Code OAuth token (or a stale config entry for it) plus each configured
+  // API-key provider — and lets the user pick which one to drop. OAuth tokens
+  // go through auth.logout for proper revocation, everything else through
+  // removeProvider.
   private async handleLogoutCommand(): Promise<void> {
     const oauthStatus = await this.harness.auth.status(DEFAULT_OAUTH_PROVIDER_NAME);
-    const hasOAuth = oauthStatus.providers.some(
+    const hasOAuthToken = oauthStatus.providers.some(
       (p) => p.providerName === DEFAULT_OAUTH_PROVIDER_NAME && p.hasToken,
     );
     const config = await this.harness.getConfig();
+    // Offer the managed provider whenever something points at it — either a
+    // live OAuth token or a stale providers[] entry left over from a previous
+    // login. auth.logout cleans the config regardless of whether the token
+    // is still present, so this avoids leaving residue with no way to reach it.
+    const hasManagedRemnant =
+      hasOAuthToken || config.providers[DEFAULT_OAUTH_PROVIDER_NAME] !== undefined;
     const apiKeyProviderIds = Object.keys(config.providers ?? {})
       .filter((id) => id !== DEFAULT_OAUTH_PROVIDER_NAME)
       .toSorted();
 
     const options: ChoiceOption[] = [];
-    if (hasOAuth) {
+    if (hasManagedRemnant) {
       options.push({
         value: DEFAULT_OAUTH_PROVIDER_NAME,
         label: PRODUCT_NAME,
@@ -5423,8 +5428,22 @@ export class KimiTUI {
     } else {
       await this.harness.removeProvider(target);
     }
-    await this.refreshConfigAfterLogout();
-    await this.clearActiveSessionAfterLogout();
+
+    if (target === currentProvider) {
+      // The active session is backed by the provider we just removed, so it
+      // can no longer make requests — tear it down along with the model state.
+      await this.refreshConfigAfterLogout();
+      await this.clearActiveSessionAfterLogout();
+    } else {
+      // Refresh provider/model listings so the picker reflects the change,
+      // but leave the user's current session running.
+      const updated = await this.harness.getConfig({ reload: true });
+      this.setAppState({
+        availableModels: updated.models ?? {},
+        availableProviders: updated.providers ?? {},
+      });
+    }
+
     this.track('logout', { provider: target });
     const label = target === DEFAULT_OAUTH_PROVIDER_NAME ? PRODUCT_NAME : target;
     this.showStatus(`Logged out from ${label}.`);

--- a/apps/kimi-code/src/tui/kimi-tui.ts
+++ b/apps/kimi-code/src/tui/kimi-tui.ts
@@ -196,6 +196,7 @@ import {
   NO_ACTIVE_SESSION_MESSAGE,
   OAUTH_LOGIN_REQUIRED_CODE,
   OAUTH_LOGIN_REQUIRED_STARTUP_NOTICE,
+  PRODUCT_NAME,
 } from './constant/kimi-tui';
 import { STREAMING_UI_FLUSH_MS } from './constant/streaming';
 import { adaptPanelResponse } from './reverse-rpc/approval/adapter';
@@ -5373,34 +5374,83 @@ export class KimiTUI {
     });
   }
 
-  // Handles the /logout command.
+  // Handles the /logout command. Lists every credential currently held — the
+  // Kimi Code OAuth token (when present) plus each configured API-key provider
+  // — and lets the user pick which one to drop. managed:kimi-code is also
+  // written into config.providers, so it must be filtered out of the API-key
+  // list to avoid showing twice; OAuth tokens go through auth.logout for
+  // proper revocation, everything else through removeProvider.
   private async handleLogoutCommand(): Promise<void> {
+    const oauthStatus = await this.harness.auth.status(DEFAULT_OAUTH_PROVIDER_NAME);
+    const hasOAuth = oauthStatus.providers.some(
+      (p) => p.providerName === DEFAULT_OAUTH_PROVIDER_NAME && p.hasToken,
+    );
+    const config = await this.harness.getConfig();
+    const apiKeyProviderIds = Object.keys(config.providers ?? {})
+      .filter((id) => id !== DEFAULT_OAUTH_PROVIDER_NAME)
+      .toSorted();
+
+    const options: ChoiceOption[] = [];
+    if (hasOAuth) {
+      options.push({
+        value: DEFAULT_OAUTH_PROVIDER_NAME,
+        label: PRODUCT_NAME,
+        description: 'OAuth login',
+      });
+    }
+    for (const id of apiKeyProviderIds) {
+      const baseUrl = config.providers[id]?.baseUrl;
+      options.push({
+        value: id,
+        label: id,
+        description: typeof baseUrl === 'string' && baseUrl.length > 0 ? baseUrl : undefined,
+      });
+    }
+
+    if (options.length === 0) {
+      this.showStatus('Nothing to logout.');
+      return;
+    }
+
     const currentModel = this.state.appState.model.trim();
     const currentProvider = this.state.appState.availableModels[currentModel]?.provider;
 
-    if (currentProvider === undefined || currentProvider === DEFAULT_OAUTH_PROVIDER_NAME) {
+    const target = await this.promptLogoutProviderSelection(options, currentProvider);
+    if (target === undefined) return;
+
+    if (target === DEFAULT_OAUTH_PROVIDER_NAME) {
       await this.harness.auth.logout(DEFAULT_OAUTH_PROVIDER_NAME);
-      await this.refreshConfigAfterLogout();
-      await this.clearActiveSessionAfterLogout();
-      this.track('logout', { provider: DEFAULT_OAUTH_PROVIDER_NAME });
-      this.showStatus('Logged out.');
-      return;
+    } else {
+      await this.harness.removeProvider(target);
     }
+    await this.refreshConfigAfterLogout();
+    await this.clearActiveSessionAfterLogout();
+    this.track('logout', { provider: target });
+    const label = target === DEFAULT_OAUTH_PROVIDER_NAME ? PRODUCT_NAME : target;
+    this.showStatus(`Logged out from ${label}.`);
+  }
 
-    // Any other provider written into config — OpenPlatform OAuth targets and
-    // /connect-configured catalog providers both go through removeProvider,
-    // which drops the provider entry and its model aliases together.
-    const existingConfig = await this.harness.getConfig();
-    if (existingConfig.providers[currentProvider] !== undefined) {
-      await this.harness.removeProvider(currentProvider);
-      await this.refreshConfigAfterLogout();
-      await this.clearActiveSessionAfterLogout();
-      this.track('logout', { provider: currentProvider });
-      this.showStatus(`Logged out from ${currentProvider}.`);
-      return;
-    }
-
-    this.showStatus('Nothing to logout.');
+  private promptLogoutProviderSelection(
+    options: readonly ChoiceOption[],
+    currentValue: string | undefined,
+  ): Promise<string | undefined> {
+    return new Promise((resolve) => {
+      const picker = new ChoicePickerComponent({
+        title: 'Select a provider to log out',
+        options,
+        currentValue,
+        colors: this.state.theme.colors,
+        onSelect: (value) => {
+          this.restoreEditor();
+          resolve(value);
+        },
+        onCancel: () => {
+          this.restoreEditor();
+          resolve(undefined);
+        },
+      });
+      this.mountEditorReplacement(picker);
+    });
   }
 
   // ---------------------------------------------------------------------------

--- a/apps/kimi-code/test/tui/kimi-tui-startup.test.ts
+++ b/apps/kimi-code/test/tui/kimi-tui-startup.test.ts
@@ -568,6 +568,12 @@ describe("KimiTUI startup", () => {
   it("tracks logout after managed credentials and session state are cleared", async () => {
     const session = makeSession();
     const harness = makeHarness(session, {
+      getConfig: vi.fn(async () => ({
+        models: {
+          k2: { provider: "managed:kimi-code", model: "moonshot-v1", maxContextSize: 100 },
+        },
+        providers: { "managed:kimi-code": { type: "kimi" } },
+      })),
       auth: {
         status: vi.fn(async () => ({
           providers: [{ providerName: "managed:kimi-code", hasToken: true }],
@@ -595,6 +601,79 @@ describe("KimiTUI startup", () => {
       sessionTitle: null,
     });
     expect(harness.track).toHaveBeenCalledWith("logout", { provider: "managed:kimi-code" });
+  });
+
+  it("keeps the active session when logging out a different provider", async () => {
+    const session = makeSession();
+    const removeProvider = vi.fn(async () => {});
+    const harness = makeHarness(session, {
+      getConfig: vi.fn(async () => ({
+        models: {
+          k2: { provider: "managed:kimi-code", model: "moonshot-v1", maxContextSize: 100 },
+        },
+        providers: {
+          "managed:kimi-code": { type: "kimi" },
+          openai: { type: "openai", baseUrl: "https://api.openai.com/v1" },
+        },
+      })),
+      removeProvider,
+      auth: {
+        status: vi.fn(async () => ({
+          providers: [{ providerName: "managed:kimi-code", hasToken: true }],
+        })),
+        login: vi.fn(async () => {}),
+        logout: vi.fn(),
+        getManagedUsage: vi.fn(),
+      },
+    });
+    const driver = makeDriver(harness, makeStartupInput());
+
+    await expect(driver.init()).resolves.toBe(false);
+    harness.track.mockClear();
+
+    vi.spyOn(driver as any, "promptLogoutProviderSelection").mockResolvedValue("openai");
+    await driver.handleLogoutCommand();
+
+    expect(removeProvider).toHaveBeenCalledWith("openai");
+    expect(harness.auth.logout).not.toHaveBeenCalled();
+    expect(session.close).not.toHaveBeenCalled();
+    expect(driver.state.appState).toMatchObject({
+      sessionId: "ses-1",
+      model: "k2",
+    });
+    expect(harness.track).toHaveBeenCalledWith("logout", { provider: "openai" });
+  });
+
+  it("can log out a stale managed entry even after the OAuth token is gone", async () => {
+    const session = makeSession();
+    const harness = makeHarness(session, {
+      getConfig: vi.fn(async () => ({
+        models: {
+          k2: { provider: "managed:kimi-code", model: "moonshot-v1", maxContextSize: 100 },
+        },
+        providers: { "managed:kimi-code": { type: "kimi" } },
+      })),
+      auth: {
+        // Token gone (e.g. credentials file deleted) but the managed entry
+        // is still sitting in config.providers.
+        status: vi.fn(async () => ({
+          providers: [{ providerName: "managed:kimi-code", hasToken: false }],
+        })),
+        login: vi.fn(async () => {}),
+        logout: vi.fn(),
+        getManagedUsage: vi.fn(),
+      },
+    });
+    const driver = makeDriver(harness, makeStartupInput());
+
+    await expect(driver.init()).resolves.toBe(false);
+
+    vi.spyOn(driver as any, "promptLogoutProviderSelection").mockResolvedValue(
+      "managed:kimi-code",
+    );
+    await driver.handleLogoutCommand();
+
+    expect(harness.auth.logout).toHaveBeenCalledWith("managed:kimi-code");
   });
 
   it("starts TUI without replaying when --continue needs OAuth login", async () => {

--- a/apps/kimi-code/test/tui/kimi-tui-startup.test.ts
+++ b/apps/kimi-code/test/tui/kimi-tui-startup.test.ts
@@ -567,12 +567,24 @@ describe("KimiTUI startup", () => {
 
   it("tracks logout after managed credentials and session state are cleared", async () => {
     const session = makeSession();
-    const harness = makeHarness(session);
+    const harness = makeHarness(session, {
+      auth: {
+        status: vi.fn(async () => ({
+          providers: [{ providerName: "managed:kimi-code", hasToken: true }],
+        })),
+        login: vi.fn(async () => {}),
+        logout: vi.fn(),
+        getManagedUsage: vi.fn(),
+      },
+    });
     const driver = makeDriver(harness, makeStartupInput());
 
     await expect(driver.init()).resolves.toBe(false);
     harness.track.mockClear();
 
+    vi.spyOn(driver as any, "promptLogoutProviderSelection").mockResolvedValue(
+      "managed:kimi-code",
+    );
     await driver.handleLogoutCommand();
 
     expect(harness.auth.logout).toHaveBeenCalledWith("managed:kimi-code");


### PR DESCRIPTION
## Related Issue

No tracking issue — the problem is described below.

## Problem

`/logout` used to clear the credential tied to the currently selected model, picking the target implicitly from `state.appState.model`'s provider. That coupled logout semantics to model selection and had a few surprising consequences:

- Users could not choose which credential to log out of — switching models changed what `/logout` did.
- With multiple providers configured (Kimi Code OAuth + a `/connect`-configured API-key provider), there was no way to drop a specific one without first switching the active model to it.
- There was no affordance for "what am I logged into right now."

Symmetric naming was also missing: `/connect` had no inverse. Users who set up a provider via `/connect` had to know to type `/logout` to leave.

## What changed

- `/logout` now opens a `ChoicePickerComponent` listing every credential currently held: the Kimi Code OAuth login (when a token is present) and every configured API-key provider in `config.providers`. `managed:kimi-code` is also written into `config.providers`, so it is filtered out of the API-key list to avoid showing twice; OAuth tokens go through `auth.logout` for proper revocation, everything else through `removeProvider`.
- The provider tied to the active model is passed as the picker's `currentValue`, so the cursor lands on it by default and pressing Enter matches the previous "log out the current one" behavior. Empty list still falls back to the existing `Nothing to logout.` status.
- Added `/disconnect` as an alias of `/logout` to mirror `/connect`, and updated the slash-command description to `Log out of a configured provider`.
- Refactor stayed inside `apps/kimi-code/src/tui/kimi-tui.ts` plus a tiny `PRODUCT_NAME` re-export in `apps/kimi-code/src/tui/constant/kimi-tui.ts`; no SDK or core changes.

`opencode auth login` / `auth logout` (see `opencode/packages/opencode/src/cli/cmd/providers.ts`) follow the same pattern: a unified picker over the configured credentials. That gave confidence the shape is sound for a multi-provider CLI.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.
- [x] Manually exercised `/logout` and `/disconnect` end-to-end (picker shows correct entries, currentValue defaults to active provider, OAuth path revokes Kimi Code token, API-key path drops the provider and its model aliases).