### PR TITLE
fix(kosong): make OpenAI-compatible thinking work without reasoning_key

### DIFF
--- a/.changeset/default-openai-reasoning-protocol.md
+++ b/.changeset/default-openai-reasoning-protocol.md
@@ -1,0 +1,6 @@
+---
+"@moonshot-ai/kosong": patch
+"@moonshot-ai/kimi-code": patch
+---
+
+Make OpenAI-compatible reasoner models work out of the box for hand-written provider configs. The `openai` provider now auto-detects thinking on incoming responses by scanning the de facto field set (`reasoning_content`, `reasoning_details`, `reasoning`), serializes thinking back as `reasoning_content` by default, and auto-injects `reasoning_effort` whenever the conversation history contains prior thinking — so DeepSeek, Qwen, One API and other gateway-fronted services no longer require a hand-set `reasoning_key`. The `reasoning_key` model-alias field remains available as an explicit override for non-standard gateways.

--- a/docs/en/configuration/config-files.md
+++ b/docs/en/configuration/config-files.md
@@ -126,6 +126,7 @@ Each entry in the `models` table defines a model alias, keyed by a unique name.
 | `max_output_size` | `integer` | No | Per-request output budget cap (`max_tokens` on the wire). Only the `anthropic` provider currently honors it. When the alias resolves to a known Claude family, the value is clamped to that model's documented ceiling to avoid exceeding the server-side limit. Omit to use the per-model default — see [`providers.md`](./providers.md#anthropic). |
 | `capabilities` | `array<string>` | No | Capability tags to add explicitly, for example `thinking`, `image_in`, `video_in`, `audio_in`, `tool_use` |
 | `display_name` | `string` | No | Name shown in the UI; falls back to `model` when unset |
+| `reasoning_key` | `string` | No | `openai` provider only. Override the field name used for reasoning content. By default the provider auto-detects `reasoning_content`, `reasoning_details`, and `reasoning` on incoming responses and serializes thinking back as `reasoning_content` — set this only if your gateway uses a non-standard field name |
 
 `capabilities` is unioned with the capabilities that the provider capability registry matches by model-name prefix — entries can only be added, never removed. You usually do not need to set this by hand; reach for it only when the model is not covered by the registry, or when you want to force-enable a particular capability.
 

--- a/docs/en/configuration/providers.md
+++ b/docs/en/configuration/providers.md
@@ -88,6 +88,8 @@ max_context_size = 200000
 
 `openai` corresponds to the OpenAI Chat Completions protocol and can also be used to connect to any third-party service that speaks the same protocol (simply override `base_url`). Thinking, vision, and tool-call capabilities are inferred automatically from the model name.
 
+Third-party reasoner models (DeepSeek, Qwen, One API and other gateway-fronted services) work out of the box: thinking content is round-tripped under the de facto `reasoning_content` field, and `reasoning_effort` is auto-injected when the conversation contains prior thinking so gateways with strict validation accept the request. If a gateway uses a non-standard field name, override it via `reasoning_key` on the model alias — see [`config-files.md`](./config-files.md#models).
+
 - Default `base_url`: `https://api.openai.com/v1`
 - Environment variables: `OPENAI_API_KEY`, `OPENAI_BASE_URL`
 

--- a/docs/zh/configuration/config-files.md
+++ b/docs/zh/configuration/config-files.md
@@ -126,6 +126,7 @@ custom_headers = { "X-Custom-Header" = "value" }
 | `max_output_size` | `integer` | 否 | 单次请求的输出预算上限（即请求层面的 `max_tokens`）。目前仅 `anthropic` 供应商会读取该字段。当别名能识别到具体的 Claude 家族时，覆盖值不会超过模型允许的上限，避免超出服务端限制。省略时使用模型推导出的默认值，详见 [`providers.md`](./providers.md#anthropic)。 |
 | `capabilities` | `array<string>` | 否 | 显式追加的模型能力标签，例如 `thinking`、`image_in`、`video_in`、`audio_in`、`tool_use` |
 | `display_name` | `string` | 否 | 在 UI 中显示的名称，未设置时回退到 `model` |
+| `reasoning_key` | `string` | 否 | 仅 `openai` 供应商。覆盖推理内容所用的字段名。默认情况下供应商会自动识别响应中的 `reasoning_content`、`reasoning_details`、`reasoning`，并以 `reasoning_content` 回传思考内容 —— 只有当网关使用非标准字段名时才需要设置 |
 
 `capabilities` 与供应商 capability registry 按模型名前缀自动匹配出来的能力做并集 —— 只能追加、不能移除。通常无需手写；只有当模型未被 registry 覆盖、或希望强制启用某项能力时才用得到。
 

--- a/docs/zh/configuration/providers.md
+++ b/docs/zh/configuration/providers.md
@@ -87,6 +87,8 @@ max_context_size = 200000
 
 `openai` 对应 OpenAI Chat Completions 协议，也可用来连接任何兼容该协议的第三方服务（自行覆盖 `base_url` 即可）。thinking、视觉、工具调用等能力按模型名自动推断。
 
+第三方推理模型（DeepSeek、Qwen、One API 等网关托管服务）开箱即用：思考内容会以约定字段 `reasoning_content` 回传给服务端，且当对话历史中已有思考片段时会自动注入 `reasoning_effort`，避免严格校验的网关返回错误。如果你的网关使用非标准字段名，可以在模型别名上设置 `reasoning_key` 覆盖 —— 详见 [`config-files.md`](./config-files.md#models)。
+
 - 默认 `base_url`：`https://api.openai.com/v1`
 - 环境变量：`OPENAI_API_KEY`、`OPENAI_BASE_URL`
 

--- a/packages/kosong/src/providers/openai-legacy.ts
+++ b/packages/kosong/src/providers/openai-legacy.ts
@@ -411,8 +411,10 @@ export class OpenAILegacyChatProvider implements ChatProvider {
     // Auto-enable reasoning_effort when the history contains ThinkPart but reasoning
     // was not explicitly configured. This prevents server validation errors from APIs
     // (e.g. One API) that require reasoning_effort when messages contain reasoning_content.
+    // Skip when the caller already pinned reasoning_effort via withGenerationKwargs —
+    // their value would otherwise be silently overwritten below.
     // See: https://github.com/MoonshotAI/kimi-code/issues/1616
-    if (reasoningEffort === undefined) {
+    if (reasoningEffort === undefined && kwargs['reasoning_effort'] === undefined) {
       const hasThinkPart = history.some((message) =>
         message.content.some((part) => part.type === 'think'),
       );

--- a/packages/kosong/src/providers/openai-legacy.ts
+++ b/packages/kosong/src/providers/openai-legacy.ts
@@ -346,7 +346,15 @@ export class OpenAILegacyChatProvider implements ChatProvider {
     this._defaultHeaders = options.defaultHeaders;
     this._model = options.model;
     this._stream = options.stream ?? true;
-    this._reasoningKey = options.reasoningKey;
+    // Normalize blank/whitespace reasoningKey to unset. ModelAliasSchema
+    // accepts `z.string().optional()`, so `reasoning_key = ""` in config.toml
+    // would otherwise disable the default field scan and route reads/writes
+    // through an empty property name.
+    const normalizedReasoningKey = options.reasoningKey?.trim();
+    this._reasoningKey =
+      normalizedReasoningKey !== undefined && normalizedReasoningKey.length > 0
+        ? normalizedReasoningKey
+        : undefined;
     this._reasoningEffort = undefined;
     this._generationKwargs = {};
     if (options.maxTokens !== undefined) {

--- a/packages/kosong/src/providers/openai-legacy.ts
+++ b/packages/kosong/src/providers/openai-legacy.ts
@@ -35,6 +35,27 @@ import {
   requireProviderApiKey,
   resolveAuthBackedClient,
 } from './request-auth';
+
+// Inbound: scan in priority order; first string value wins. Outbound: the first
+// entry doubles as the default field we serialize ThinkPart back into. Both
+// arms can be overridden by an explicit `reasoningKey` on the provider config.
+const KNOWN_REASONING_KEYS = ['reasoning_content', 'reasoning_details', 'reasoning'] as const;
+const DEFAULT_OUTBOUND_REASONING_KEY = KNOWN_REASONING_KEYS[0];
+
+function extractReasoningContent(
+  source: unknown,
+  explicitKey: string | undefined,
+): string | undefined {
+  if (typeof source !== 'object' || source === null) return undefined;
+  const record = source as Record<string, unknown>;
+  const keys: readonly string[] = explicitKey !== undefined ? [explicitKey] : KNOWN_REASONING_KEYS;
+  for (const key of keys) {
+    const value = record[key];
+    if (typeof value === 'string' && value.length > 0) return value;
+  }
+  return undefined;
+}
+
 export interface OpenAILegacyOptions {
   apiKey?: string | undefined;
   baseUrl?: string | undefined;
@@ -147,9 +168,13 @@ function convertMessage(
     result.tool_call_id = message.toolCallId;
   }
 
-  // Place reasoning content under the configured key (e.g. "reasoning_content" for DeepSeek)
-  if (reasoningContent && reasoningKey) {
-    result[reasoningKey] = reasoningContent;
+  // Round-trip thinking content back to the server. Default to the de facto
+  // `reasoning_content` field so OpenAI-compatible reasoners (DeepSeek, Qwen,
+  // One API gateways) work without per-provider configuration. Servers that
+  // don't understand the field ignore it; servers that require a specific
+  // field can override via the explicit `reasoningKey`.
+  if (reasoningContent) {
+    result[reasoningKey ?? DEFAULT_OUTBOUND_REASONING_KEY] = reasoningContent;
   }
 
   return result;
@@ -218,12 +243,11 @@ export class OpenAILegacyStreamedMessage implements StreamedMessage {
     const message = response.choices[0]?.message;
     if (!message) return;
 
-    // Reasoning content via configured key
-    if (reasoningKey) {
-      const rc = (message as unknown as Record<string, unknown>)[reasoningKey];
-      if (typeof rc === 'string' && rc) {
-        yield { type: 'think', think: rc } satisfies StreamedMessagePart;
-      }
+    // Reasoning content: honor the explicit key when set, otherwise scan the
+    // de facto field set so hand-written configs work without it.
+    const reasoning = extractReasoningContent(message, reasoningKey);
+    if (reasoning) {
+      yield { type: 'think', think: reasoning } satisfies StreamedMessagePart;
     }
 
     if (message.content) {
@@ -274,12 +298,11 @@ export class OpenAILegacyStreamedMessage implements StreamedMessage {
 
         const delta = choice.delta;
 
-        // Reasoning content via configured key
-        if (reasoningKey) {
-          const rc = (delta as unknown as Record<string, unknown>)[reasoningKey];
-          if (typeof rc === 'string' && rc) {
-            yield { type: 'think', think: rc } satisfies StreamedMessagePart;
-          }
+        // Reasoning content: honor the explicit key when set, otherwise scan
+        // the de facto field set so hand-written configs work without it.
+        const reasoning = extractReasoningContent(delta, reasoningKey);
+        if (reasoning) {
+          yield { type: 'think', think: reasoning } satisfies StreamedMessagePart;
         }
 
         // text content
@@ -381,7 +404,7 @@ export class OpenAILegacyChatProvider implements ChatProvider {
     // was not explicitly configured. This prevents server validation errors from APIs
     // (e.g. One API) that require reasoning_effort when messages contain reasoning_content.
     // See: https://github.com/MoonshotAI/kimi-code/issues/1616
-    if (reasoningEffort === undefined && this._reasoningKey) {
+    if (reasoningEffort === undefined) {
       const hasThinkPart = history.some((message) =>
         message.content.some((part) => part.type === 'think'),
       );

--- a/packages/kosong/test/openai-legacy.test.ts
+++ b/packages/kosong/test/openai-legacy.test.ts
@@ -791,6 +791,58 @@ describe('OpenAILegacyChatProvider', () => {
         { type: 'text', text: 'final' },
       ]);
     });
+
+    it('treats blank reasoning_key as unset so defaults still apply', async () => {
+      // ModelAliasSchema accepts `reasoning_key = ""` (z.string().optional()).
+      // A blank value must not route reads/writes through an empty property
+      // name — it should fall back to the default protocol behavior.
+      const provider = createProvider({ model: 'm', reasoningKey: '' });
+      const history: Message[] = [
+        {
+          role: 'assistant',
+          content: [
+            { type: 'think', think: 'thinking' },
+            { type: 'text', text: 'answer' },
+          ],
+          toolCalls: [],
+        },
+      ];
+      const body = await captureRequestBody(provider, '', [], history);
+      const messages = body['messages'] as Record<string, unknown>[];
+
+      expect(messages[0]).toEqual({
+        role: 'assistant',
+        content: 'answer',
+        reasoning_content: 'thinking',
+      });
+      expect(Object.keys(messages[0] ?? {})).not.toContain('');
+    });
+
+    it('trims whitespace around explicit reasoning_key before use', async () => {
+      const provider = createProvider({
+        model: 'm',
+        reasoningKey: '  reasoning_details  ',
+      });
+      const history: Message[] = [
+        {
+          role: 'assistant',
+          content: [
+            { type: 'think', think: 'thinking' },
+            { type: 'text', text: 'answer' },
+          ],
+          toolCalls: [],
+        },
+      ];
+      const body = await captureRequestBody(provider, '', [], history);
+      const messages = body['messages'] as Record<string, unknown>[];
+
+      expect(messages[0]).toEqual({
+        role: 'assistant',
+        content: 'answer',
+        reasoning_details: 'thinking',
+      });
+      expect(Object.keys(messages[0] ?? {})).not.toContain('  reasoning_details  ');
+    });
   });
   // argument deltas. Each delta carries `index` to identify the owning
   // tool call. The provider must preserve `index` on the yielded

--- a/packages/kosong/test/openai-legacy.test.ts
+++ b/packages/kosong/test/openai-legacy.test.ts
@@ -702,6 +702,30 @@ describe('OpenAILegacyChatProvider', () => {
 
       expect(body['reasoning_effort']).toBe('medium');
     });
+
+    it('does not overwrite reasoning_effort pinned via withGenerationKwargs', async () => {
+      // Auto-injection must yield to an explicit caller-set reasoning_effort,
+      // otherwise multi-turn requests silently downgrade a 'high' / 'low'
+      // setting back to 'medium' once the history contains ThinkPart.
+      const provider = createProvider({ model: 'some-model' }).withGenerationKwargs({
+        reasoning_effort: 'high',
+      });
+      const history: Message[] = [
+        { role: 'user', content: [{ type: 'text', text: 'Hello' }], toolCalls: [] },
+        {
+          role: 'assistant',
+          content: [
+            { type: 'think', think: 'thinking' },
+            { type: 'text', text: 'Hi!' },
+          ],
+          toolCalls: [],
+        },
+        { role: 'user', content: [{ type: 'text', text: 'Again?' }], toolCalls: [] },
+      ];
+      const body = await captureRequestBody(provider, '', [], history);
+
+      expect(body['reasoning_effort']).toBe('high');
+    });
   });
 
   describe('default reasoning protocol (no explicit reasoningKey)', () => {

--- a/packages/kosong/test/openai-legacy.test.ts
+++ b/packages/kosong/test/openai-legacy.test.ts
@@ -680,8 +680,11 @@ describe('OpenAILegacyChatProvider', () => {
       expect(body['reasoning_effort']).toBeUndefined();
     });
 
-    it('does not auto-inject reasoning_effort when reasoningKey is not set', async () => {
-      // No reasoningKey configured
+    it('auto-injects reasoning_effort when history has ThinkPart even without explicit reasoningKey', async () => {
+      // No reasoningKey configured — the provider should still treat ThinkPart in
+      // history as a signal to inject reasoning_effort, so OpenAI-compatible
+      // gateways (One API, DeepSeek) that demand a paired reasoning_effort
+      // don't reject the request with 400.
       const provider = createProvider({ model: 'some-model' });
       const history: Message[] = [
         { role: 'user', content: [{ type: 'text', text: 'Hello' }], toolCalls: [] },
@@ -697,11 +700,98 @@ describe('OpenAILegacyChatProvider', () => {
       ];
       const body = await captureRequestBody(provider, '', [], history);
 
-      expect(body['reasoning_effort']).toBeUndefined();
+      expect(body['reasoning_effort']).toBe('medium');
     });
   });
 
-  // OpenAI Chat Completions streams parallel tool calls with interleaved
+  describe('default reasoning protocol (no explicit reasoningKey)', () => {
+    it('serializes ThinkPart back to reasoning_content even without reasoningKey', async () => {
+      // The whole point of issue #69: a hand-written config.toml never sets
+      // reasoningKey, but the round-trip must still work against DeepSeek-style
+      // providers — otherwise the next turn sends the assistant message without
+      // any reasoning field and the server rejects it.
+      const provider = createProvider({ model: 'deepseek-reasoner' });
+      const history: Message[] = [
+        { role: 'user', content: [{ type: 'text', text: 'q' }], toolCalls: [] },
+        {
+          role: 'assistant',
+          content: [
+            { type: 'think', think: 'inner monologue' },
+            { type: 'text', text: 'answer' },
+          ],
+          toolCalls: [],
+        },
+        { role: 'user', content: [{ type: 'text', text: 'next' }], toolCalls: [] },
+      ];
+      const body = await captureRequestBody(provider, '', [], history);
+
+      const messages = body['messages'] as Record<string, unknown>[];
+      expect(messages[1]).toEqual({
+        role: 'assistant',
+        content: 'answer',
+        reasoning_content: 'inner monologue',
+      });
+    });
+
+    it('explicit reasoningKey overrides the default outbound field', async () => {
+      const provider = createProvider({
+        model: 'oddball-reasoner',
+        reasoningKey: 'reasoning_details',
+      });
+      const history: Message[] = [
+        {
+          role: 'assistant',
+          content: [
+            { type: 'think', think: 'thinking' },
+            { type: 'text', text: 'reply' },
+          ],
+          toolCalls: [],
+        },
+      ];
+      const body = await captureRequestBody(provider, '', [], history);
+      const messages = body['messages'] as Record<string, unknown>[];
+
+      expect(messages[0]).toEqual({
+        role: 'assistant',
+        content: 'reply',
+        reasoning_details: 'thinking',
+      });
+      expect(messages[0]).not.toHaveProperty('reasoning_content');
+    });
+
+    it('yields ThinkPart from streaming response even without explicit reasoningKey', async () => {
+      const provider = new OpenAILegacyChatProvider({
+        model: 'deepseek-reasoner',
+        apiKey: 'test-key',
+        stream: true,
+      });
+
+      async function* mockedStream(): AsyncIterable<Record<string, unknown>> {
+        yield { id: 'c1', choices: [{ index: 0, delta: { reasoning_content: 'think 1' } }] };
+        yield { id: 'c1', choices: [{ index: 0, delta: { reasoning_content: ' think 2' } }] };
+        yield { id: 'c1', choices: [{ index: 0, delta: { content: 'final' } }] };
+        yield { id: 'c1', choices: [{ index: 0, delta: {}, finish_reason: 'stop' }] };
+      }
+
+      (provider as any)._client.chat.completions.create = vi
+        .fn()
+        .mockResolvedValue(mockedStream());
+
+      const stream = await provider.generate(
+        '',
+        [],
+        [{ role: 'user', content: [{ type: 'text', text: 'q' }], toolCalls: [] }],
+      );
+      const parts: StreamedMessagePart[] = [];
+      for await (const part of stream) parts.push(part);
+
+      expect(parts).toEqual([
+        { type: 'think', think: 'think 1' },
+        { type: 'think', think: ' think 2' },
+        { type: 'text', text: 'final' },
+      ]);
+    });
+  });
   // argument deltas. Each delta carries `index` to identify the owning
   // tool call. The provider must preserve `index` on the yielded
   // ToolCallPart (and `_streamIndex` on the ToolCall header) so that
@@ -1077,6 +1167,77 @@ describe('OpenAILegacyChatProvider — non-stream response parsing', () => {
       { type: 'think', think: 'Let me think step by step' },
       { type: 'text', text: 'Final answer' },
     ]);
+  });
+
+  it('yields ThinkPart from non-stream response even without explicit reasoningKey', async () => {
+    // Hand-written config path: provider has no reasoningKey, but the server
+    // (DeepSeek/Qwen/One API) returns reasoning_content. We must still surface
+    // the ThinkPart so users see the thinking and the next-turn round-trip
+    // serializes it back.
+    const provider = new OpenAILegacyChatProvider({
+      model: 'deepseek-reasoner',
+      apiKey: 'test-key',
+      stream: false,
+    });
+
+    const parts = await collectFromMockedResponse(
+      provider,
+      makeNonStreamResponse({
+        role: 'assistant',
+        content: 'Final answer',
+        reasoning_content: 'walking through it',
+      }),
+    );
+
+    expect(parts).toEqual([
+      { type: 'think', think: 'walking through it' },
+      { type: 'text', text: 'Final answer' },
+    ]);
+  });
+
+  it('reads reasoning_details when only that field is present and no reasoningKey is set', async () => {
+    const provider = new OpenAILegacyChatProvider({
+      model: 'oddball-reasoner',
+      apiKey: 'test-key',
+      stream: false,
+    });
+
+    const parts = await collectFromMockedResponse(
+      provider,
+      makeNonStreamResponse({
+        role: 'assistant',
+        content: 'answer',
+        reasoning_details: 'detail thinking',
+      }),
+    );
+
+    expect(parts).toEqual([
+      { type: 'think', think: 'detail thinking' },
+      { type: 'text', text: 'answer' },
+    ]);
+  });
+
+  it('explicit reasoningKey limits inbound scan to that single field', async () => {
+    // When the user/catalog pins reasoningKey, the provider must read only that
+    // field — no implicit fallback to other known field names. This is the
+    // escape hatch for non-standard gateways.
+    const provider = new OpenAILegacyChatProvider({
+      model: 'oddball',
+      apiKey: 'test-key',
+      stream: false,
+      reasoningKey: 'reasoning_details',
+    });
+
+    const parts = await collectFromMockedResponse(
+      provider,
+      makeNonStreamResponse({
+        role: 'assistant',
+        content: 'answer',
+        reasoning_content: 'should be ignored',
+      }),
+    );
+
+    expect(parts).toEqual([{ type: 'text', text: 'answer' }]);
   });
 });
 


### PR DESCRIPTION
## Related Issue

Resolve #69 (and finishes the fix started by #70).

## Problem

#70 patched the `/connect` / catalog path, but the same fix never reaches users who hand-write `~/.kimi-code/config.toml`. The root cause is that `reasoning_key` was treated as a user-set field at all — it's a protocol fact (which field the server uses for reasoning content), not a user preference. So any code path that doesn't pass through the catalog necessarily leaves it `undefined`, which means the `openai` provider drops `ThinkPart` on outbound, ignores reasoning content on inbound, and never injects `reasoning_effort`. DeepSeek and other strict gateways then 400 on the second turn — exactly the symptom in #69.

## What changed

Demote `reasoning_key` to an internal protocol constant on the `openai` provider, keeping it as an explicit override for the rare non-standard gateway:

- **Inbound** (stream + non-stream): scan `reasoning_content`, `reasoning_details`, `reasoning` in order; first string value wins. An explicit `reasoning_key` restricts the scan to that one field.
- **Outbound**: serialize `ThinkPart` back as `reasoning_content` by default. An explicit `reasoning_key` writes to that field instead.
- **`reasoning_effort` auto-injection**: no longer gated on `reasoning_key`; presence of `ThinkPart` in history is enough.

#70's catalog plumbing is unchanged — explicit values from the catalog still win, the default just stops being `undefined`. The `reasoning_key` model-alias field remains documented as an escape hatch.

Unit tests cover both directions of the new default protocol, the explicit-override semantics on inbound and outbound, the `reasoning_effort` auto-injection without `reasoning_key`, and the streaming inbound path.

Docs updated in both locales (`docs/{en,zh}/configuration/{config-files,providers}.md`).

Manually verified end-to-end against the real DeepSeek API: hand-written `config.toml` that does **not** set `reasoning_key` now shows thinking, returns no 400, and survives multi-turn conversations.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran \`gen-changesets\` skill, or this PR needs no changeset.
- [x] Ran \`gen-docs\` skill, or this PR needs no doc update.