### PR TITLE
fix(agent-core): ensure tool.call always has paired tool.result

### DIFF
--- a/.changeset/fix-tool-result-pairing.md
+++ b/.changeset/fix-tool-result-pairing.md
@@ -1,0 +1,6 @@
+---
+"@moonshot-ai/agent-core": patch
+"@moonshot-ai/kimi-code": patch
+---
+
+Always emit a paired tool result when a tool returns a malformed or missing result, preventing the next request from failing with a missing tool_call_id error.

--- a/packages/agent-core/src/loop/tool-call.ts
+++ b/packages/agent-core/src/loop/tool-call.ts
@@ -25,7 +25,12 @@ import {
 import { PathSecurityError } from '../tools/policies/path-access';
 
 import { errorMessage, isAbortError } from './errors';
-import type { LoopEventDispatcher, LoopToolCallEvent } from './events';
+import type {
+  LoopEventDispatcher,
+  LoopLiveOnlyEvent,
+  LoopRecordedEvent,
+  LoopToolCallEvent,
+} from './events';
 import type { LLM, LLMChatResponse } from './llm';
 import { ToolAccesses } from './tool-access';
 import { ToolScheduler, type ToolCallTask } from './tool-scheduler';
@@ -110,16 +115,38 @@ export async function runToolCallBatch(
   const pendingResults: Array<Promise<PendingToolResult>> = [];
   let stopTurn = false;
 
+  // Pairing invariant: every `tool.call` event must get a paired `tool.result`.
+  // The wrapper tracks ids so a throw between dispatching the call and
+  // dispatching its result still produces a compensating result in `finally`.
+  // An orphan `tool.call` would otherwise make the next provider request fail
+  // with "tool_call_id did not have response messages".
+  const unpairedCallIds = new Set<string>();
+  function dispatchAndTrack(event: LoopRecordedEvent): Promise<void>;
+  function dispatchAndTrack(event: LoopLiveOnlyEvent): void;
+  function dispatchAndTrack(
+    event: LoopRecordedEvent | LoopLiveOnlyEvent,
+  ): Promise<void> | void {
+    if (event.type === 'tool.call') unpairedCallIds.add(event.toolCallId);
+    else if (event.type === 'tool.result') unpairedCallIds.delete(event.toolCallId);
+    return (
+      step.dispatchEvent as (e: LoopRecordedEvent | LoopLiveOnlyEvent) => Promise<void> | void
+    )(event);
+  }
+  const trackingStep: ToolCallStepContext = {
+    ...step,
+    dispatchEvent: dispatchAndTrack as LoopEventDispatcher,
+  };
+
   try {
     for (let index = 0; index < calls.length; index += 1) {
       const call = calls[index]!;
-      const prepared = await prepareToolCall(step, call);
+      const prepared = await prepareToolCall(trackingStep, call);
       pendingResults.push(scheduler.add(prepared.task));
 
       if (prepared.stopBatchAfterThis === true) {
         stopTurn = true;
         for (const skippedCall of calls.slice(index + 1)) {
-          const skippedTask = await prepareSkippedToolCall(step, skippedCall);
+          const skippedTask = await prepareSkippedToolCall(trackingStep, skippedCall);
           pendingResults.push(scheduler.add(skippedTask));
         }
         break;
@@ -130,9 +157,9 @@ export async function runToolCallBatch(
     // provider order. Await all tasks so each recorded `tool.call` gets a
     // paired `tool.result`; the caller checks abort before writing `step.end`.
     for (const pendingResult of pendingResults) {
-      const result = await finalizePendingToolResult(step, await pendingResult);
+      const result = await finalizePendingToolResult(trackingStep, await pendingResult);
       if (result.stopTurn === true) stopTurn = true;
-      await step.dispatchEvent({
+      await trackingStep.dispatchEvent({
         type: 'tool.result',
         parentUuid: result.toolCall.id,
         toolCallId: result.toolCall.id,
@@ -144,6 +171,27 @@ export async function runToolCallBatch(
     // Always settle spawned tasks before the caller continues so rejected
     // execute promises cannot surface as detached unhandled rejections.
     await Promise.allSettled(pendingResults);
+    if (unpairedCallIds.size > 0) {
+      for (const toolCallId of unpairedCallIds) {
+        try {
+          await step.dispatchEvent({
+            type: 'tool.result',
+            parentUuid: toolCallId,
+            toolCallId,
+            result: {
+              output: `Tool call "${toolCallId}" was interrupted before producing a result.`,
+              isError: true,
+            },
+          });
+        } catch (compensateError) {
+          step.log?.warn('failed to compensate orphan tool.call', {
+            toolCallId,
+            error: compensateError,
+          });
+        }
+      }
+      unpairedCallIds.clear();
+    }
   }
   return { stopTurn };
 }
@@ -411,7 +459,8 @@ async function runRunnableToolCall(
 
   let toolResult: ExecutableToolResult;
   try {
-    toolResult = await executeTool(step, execution, toolCall, toolName, metadata);
+    const raw = await executeTool(step, execution, toolCall, toolName, metadata);
+    toolResult = coerceToolResult(raw, toolName);
   } catch (error) {
     const aborted = isAbortError(error) || signal.aborted;
     if (!aborted) {
@@ -550,28 +599,56 @@ function isMediaContentPart(part: ContentPart): boolean {
   return part.type === 'image_url' || part.type === 'audio_url' || part.type === 'video_url';
 }
 
+/**
+ * Validate a tool's raw return against the {@link ExecutableToolResult} contract.
+ * A tool that returns `undefined`, a primitive, or an object without a valid
+ * `output` field is coerced into an `isError: true` result so the loop can still
+ * emit a paired `tool.result` event. This is the trust boundary between
+ * arbitrary tool implementations and the rest of the loop.
+ */
+function coerceToolResult(value: unknown, toolName: string): ExecutableToolResult {
+  if (value === null || value === undefined) {
+    return { output: `Tool "${toolName}" returned no result.`, isError: true };
+  }
+  if (typeof value !== 'object') {
+    return {
+      output: `Tool "${toolName}" returned a ${typeof value} instead of a tool result.`,
+      isError: true,
+    };
+  }
+  const candidate = value as { output?: unknown };
+  if (typeof candidate.output !== 'string' && !Array.isArray(candidate.output)) {
+    return {
+      output: `Tool "${toolName}" returned a result with a missing or malformed "output" field.`,
+      isError: true,
+    };
+  }
+  return value as ExecutableToolResult;
+}
+
 function normalizeToolResult(r: ExecutableToolResult): ExecutableToolResult {
+  const safe = coerceToolResult(r, '<unknown>');
   let output: ExecutableToolResult['output'];
-  if (typeof r.output === 'string') {
-    output = r.output.length > 0 ? r.output : TOOL_OUTPUT_EMPTY;
-  } else if (r.output.length === 0) {
+  if (typeof safe.output === 'string') {
+    output = safe.output.length > 0 ? safe.output : TOOL_OUTPUT_EMPTY;
+  } else if (safe.output.length === 0) {
     output = TOOL_OUTPUT_EMPTY;
   } else {
-    const hasMediaBlock = r.output.some(isMediaContentPart);
+    const hasMediaBlock = safe.output.some(isMediaContentPart);
     if (hasMediaBlock) {
-      const hasNonEmptyText = r.output.some((c) => c.type === 'text' && c.text.length > 0);
+      const hasNonEmptyText = safe.output.some((c) => c.type === 'text' && c.text.length > 0);
       output = hasNonEmptyText
-        ? r.output
-        : [{ type: 'text', text: TOOL_OUTPUT_NON_TEXT }, ...r.output];
+        ? safe.output
+        : [{ type: 'text', text: TOOL_OUTPUT_NON_TEXT }, ...safe.output];
     } else {
-      const textJoined = r.output
+      const textJoined = safe.output
         .filter((c): c is Extract<typeof c, { type: 'text' }> => c.type === 'text')
         .map((c) => c.text)
         .join('');
       output = textJoined.length > 0 ? textJoined : TOOL_OUTPUT_EMPTY;
     }
   }
-  return r.isError === true ? { output, isError: true } : { output };
+  return safe.isError === true ? { output, isError: true } : { output };
 }
 
 function makeToolResult(
@@ -589,6 +666,7 @@ function makeToolResult(
 }
 
 function toolResultStopsTurn(result: ExecutableToolResult): boolean {
+  if (result === null || typeof result !== 'object') return false;
   return result.isError === true && result.stopTurn === true;
 }
 

--- a/packages/agent-core/src/loop/tool-call.ts
+++ b/packages/agent-core/src/loop/tool-call.ts
@@ -25,12 +25,7 @@ import {
 import { PathSecurityError } from '../tools/policies/path-access';
 
 import { errorMessage, isAbortError } from './errors';
-import type {
-  LoopEventDispatcher,
-  LoopLiveOnlyEvent,
-  LoopRecordedEvent,
-  LoopToolCallEvent,
-} from './events';
+import type { LoopEventDispatcher, LoopToolCallEvent } from './events';
 import type { LLM, LLMChatResponse } from './llm';
 import { ToolAccesses } from './tool-access';
 import { ToolScheduler, type ToolCallTask } from './tool-scheduler';
@@ -115,38 +110,16 @@ export async function runToolCallBatch(
   const pendingResults: Array<Promise<PendingToolResult>> = [];
   let stopTurn = false;
 
-  // Pairing invariant: every `tool.call` event must get a paired `tool.result`.
-  // The wrapper tracks ids so a throw between dispatching the call and
-  // dispatching its result still produces a compensating result in `finally`.
-  // An orphan `tool.call` would otherwise make the next provider request fail
-  // with "tool_call_id did not have response messages".
-  const unpairedCallIds = new Set<string>();
-  function dispatchAndTrack(event: LoopRecordedEvent): Promise<void>;
-  function dispatchAndTrack(event: LoopLiveOnlyEvent): void;
-  function dispatchAndTrack(
-    event: LoopRecordedEvent | LoopLiveOnlyEvent,
-  ): Promise<void> | void {
-    if (event.type === 'tool.call') unpairedCallIds.add(event.toolCallId);
-    else if (event.type === 'tool.result') unpairedCallIds.delete(event.toolCallId);
-    return (
-      step.dispatchEvent as (e: LoopRecordedEvent | LoopLiveOnlyEvent) => Promise<void> | void
-    )(event);
-  }
-  const trackingStep: ToolCallStepContext = {
-    ...step,
-    dispatchEvent: dispatchAndTrack as LoopEventDispatcher,
-  };
-
   try {
     for (let index = 0; index < calls.length; index += 1) {
       const call = calls[index]!;
-      const prepared = await prepareToolCall(trackingStep, call);
+      const prepared = await prepareToolCall(step, call);
       pendingResults.push(scheduler.add(prepared.task));
 
       if (prepared.stopBatchAfterThis === true) {
         stopTurn = true;
         for (const skippedCall of calls.slice(index + 1)) {
-          const skippedTask = await prepareSkippedToolCall(trackingStep, skippedCall);
+          const skippedTask = await prepareSkippedToolCall(step, skippedCall);
           pendingResults.push(scheduler.add(skippedTask));
         }
         break;
@@ -157,9 +130,9 @@ export async function runToolCallBatch(
     // provider order. Await all tasks so each recorded `tool.call` gets a
     // paired `tool.result`; the caller checks abort before writing `step.end`.
     for (const pendingResult of pendingResults) {
-      const result = await finalizePendingToolResult(trackingStep, await pendingResult);
+      const result = await finalizePendingToolResult(step, await pendingResult);
       if (result.stopTurn === true) stopTurn = true;
-      await trackingStep.dispatchEvent({
+      await step.dispatchEvent({
         type: 'tool.result',
         parentUuid: result.toolCall.id,
         toolCallId: result.toolCall.id,
@@ -171,27 +144,6 @@ export async function runToolCallBatch(
     // Always settle spawned tasks before the caller continues so rejected
     // execute promises cannot surface as detached unhandled rejections.
     await Promise.allSettled(pendingResults);
-    if (unpairedCallIds.size > 0) {
-      for (const toolCallId of unpairedCallIds) {
-        try {
-          await step.dispatchEvent({
-            type: 'tool.result',
-            parentUuid: toolCallId,
-            toolCallId,
-            result: {
-              output: `Tool call "${toolCallId}" was interrupted before producing a result.`,
-              isError: true,
-            },
-          });
-        } catch (compensateError) {
-          step.log?.warn('failed to compensate orphan tool.call', {
-            toolCallId,
-            error: compensateError,
-          });
-        }
-      }
-      unpairedCallIds.clear();
-    }
   }
   return { stopTurn };
 }
@@ -293,9 +245,10 @@ async function prepareToolCall(
 
   if (decision.kind === 'synthetic') {
     await dispatchToolCall(step, call, decision.args);
+    const coerced = coerceToolResult(decision.result, call.toolName);
     return {
-      task: makeResolvedToolCallTask(makeToolResult(call, decision.args, decision.result)),
-      stopBatchAfterThis: toolResultStopsTurn(decision.result),
+      task: makeResolvedToolCallTask(makeToolResult(call, decision.args, coerced)),
+      stopBatchAfterThis: toolResultStopsTurn(coerced),
     };
   }
 
@@ -498,7 +451,10 @@ async function finalizePendingToolResult(
       signal,
       llm,
     });
-    const effectiveResult = finalizedResult ?? pendingResult.result;
+    const effectiveResult = coerceToolResult(
+      finalizedResult ?? pendingResult.result,
+      pendingResult.toolName,
+    );
     return {
       ...pendingResult,
       stopTurn: pendingResult.stopTurn === true || toolResultStopsTurn(effectiveResult),
@@ -627,28 +583,27 @@ function coerceToolResult(value: unknown, toolName: string): ExecutableToolResul
 }
 
 function normalizeToolResult(r: ExecutableToolResult): ExecutableToolResult {
-  const safe = coerceToolResult(r, '<unknown>');
   let output: ExecutableToolResult['output'];
-  if (typeof safe.output === 'string') {
-    output = safe.output.length > 0 ? safe.output : TOOL_OUTPUT_EMPTY;
-  } else if (safe.output.length === 0) {
+  if (typeof r.output === 'string') {
+    output = r.output.length > 0 ? r.output : TOOL_OUTPUT_EMPTY;
+  } else if (r.output.length === 0) {
     output = TOOL_OUTPUT_EMPTY;
   } else {
-    const hasMediaBlock = safe.output.some(isMediaContentPart);
+    const hasMediaBlock = r.output.some(isMediaContentPart);
     if (hasMediaBlock) {
-      const hasNonEmptyText = safe.output.some((c) => c.type === 'text' && c.text.length > 0);
+      const hasNonEmptyText = r.output.some((c) => c.type === 'text' && c.text.length > 0);
       output = hasNonEmptyText
-        ? safe.output
-        : [{ type: 'text', text: TOOL_OUTPUT_NON_TEXT }, ...safe.output];
+        ? r.output
+        : [{ type: 'text', text: TOOL_OUTPUT_NON_TEXT }, ...r.output];
     } else {
-      const textJoined = safe.output
+      const textJoined = r.output
         .filter((c): c is Extract<typeof c, { type: 'text' }> => c.type === 'text')
         .map((c) => c.text)
         .join('');
       output = textJoined.length > 0 ? textJoined : TOOL_OUTPUT_EMPTY;
     }
   }
-  return safe.isError === true ? { output, isError: true } : { output };
+  return r.isError === true ? { output, isError: true } : { output };
 }
 
 function makeToolResult(
@@ -666,7 +621,6 @@ function makeToolResult(
 }
 
 function toolResultStopsTurn(result: ExecutableToolResult): boolean {
-  if (result === null || typeof result !== 'object') return false;
   return result.isError === true && result.stopTurn === true;
 }
 

--- a/packages/agent-core/test/loop/tool-call.e2e.test.ts
+++ b/packages/agent-core/test/loop/tool-call.e2e.test.ts
@@ -219,6 +219,89 @@ describe('runTurn — tool-call behaviour', () => {
     );
   });
 
+  it('coerces an undefined tool return into an error tool.result without breaking pairing', async () => {
+    const undef: ExecutableTool = {
+      name: 'undef',
+      description: 'returns undefined',
+      parameters: { type: 'object', additionalProperties: true },
+      resolveExecution: () => ({
+        execute: async () => undefined as unknown as ExecutableToolResult,
+      }),
+    };
+    const { sink, context } = await runTurn({
+      tools: [undef],
+      responses: [
+        makeToolUseResponse([makeToolCall('undef', {}, 'tc-U')]),
+        makeEndTurnResponse('done'),
+      ],
+    });
+    const callIds = sink.byType('tool.call').map((e) => e.toolCallId);
+    const resultIds = sink.byType('tool.result').map((e) => e.toolCallId);
+    expect(resultIds).toEqual(callIds);
+    const result = context.toolResults()[0]?.result;
+    expect(result?.isError).toBe(true);
+    expect(expectTextOutput(result?.output)).toContain('Tool "undef" returned no result');
+  });
+
+  it('coerces a tool returning an object without "output" into an error tool.result', async () => {
+    const noout: ExecutableTool = {
+      name: 'noout',
+      description: 'returns {}',
+      parameters: { type: 'object', additionalProperties: true },
+      resolveExecution: () => ({
+        execute: async () => ({}) as ExecutableToolResult,
+      }),
+    };
+    const { sink, context } = await runTurn({
+      tools: [noout],
+      responses: [
+        makeToolUseResponse([makeToolCall('noout', {}, 'tc-N')]),
+        makeEndTurnResponse('done'),
+      ],
+    });
+    expect(sink.byType('tool.result').length).toBe(1);
+    const result = context.toolResults()[0]?.result;
+    expect(result?.isError).toBe(true);
+    expect(expectTextOutput(result?.output)).toContain('missing or malformed "output" field');
+  });
+
+  it('keeps every tool.call paired when one parallel tool returns a corrupt result', async () => {
+    const undef: ExecutableTool = {
+      name: 'undef',
+      description: 'returns undefined',
+      parameters: { type: 'object', additionalProperties: true },
+      resolveExecution: () => ({
+        execute: async () => undefined as unknown as ExecutableToolResult,
+      }),
+    };
+    const echo = new EchoTool();
+    const { sink, context } = await runTurn({
+      tools: [undef, echo],
+      responses: [
+        makeToolUseResponse([
+          makeToolCall('undef', {}, 'tc-U'),
+          makeToolCall('echo', { text: 'a' }, 'tc-E1'),
+          makeToolCall('echo', { text: 'b' }, 'tc-E2'),
+        ]),
+        makeEndTurnResponse('done'),
+      ],
+    });
+    const callIds = sink
+      .byType('tool.call')
+      .map((e) => e.toolCallId)
+      .toSorted();
+    const resultIds = sink
+      .byType('tool.result')
+      .map((e) => e.toolCallId)
+      .toSorted();
+    expect(callIds).toEqual(['tc-E1', 'tc-E2', 'tc-U']);
+    expect(resultIds).toEqual(callIds);
+    expect(context.toolResults().find((r) => r.toolCallId === 'tc-U')?.result.isError).toBe(true);
+    expect(context.toolResults().find((r) => r.toolCallId === 'tc-E1')?.result.isError).not.toBe(
+      true,
+    );
+  });
+
   it('does not duplicate prepare hook failures in the diagnostic log', async () => {
     const echo = new EchoTool();
     const { log, entries } = makeTestLogger();

--- a/packages/agent-core/test/loop/tool-call.e2e.test.ts
+++ b/packages/agent-core/test/loop/tool-call.e2e.test.ts
@@ -302,6 +302,25 @@ describe('runTurn — tool-call behaviour', () => {
     );
   });
 
+  it('coerces a corrupt finalizeToolResult hook return into an error result', async () => {
+    const echo = new EchoTool();
+    const hooks: LoopHooks = {
+      finalizeToolResult: async () => ({}) as ExecutableToolResult,
+    };
+    const { sink, context } = await runTurn({
+      tools: [echo],
+      hooks,
+      responses: [
+        makeToolUseResponse([makeToolCall('echo', { text: 'hi' }, 'tc-E')]),
+        makeEndTurnResponse('done'),
+      ],
+    });
+    expect(sink.byType('tool.result').length).toBe(1);
+    const result = context.toolResults()[0]?.result;
+    expect(result?.isError).toBe(true);
+    expect(expectTextOutput(result?.output)).toContain('missing or malformed "output" field');
+  });
+
   it('does not duplicate prepare hook failures in the diagnostic log', async () => {
     const echo = new EchoTool();
     const { log, entries } = makeTestLogger();


### PR DESCRIPTION
## Related Issue

No linked issue.

## Problem

When a tool returned `undefined`, a primitive, or an object without a valid `output` field, the loop's normalization helpers crashed with `TypeError`. The throw escaped the per-tool try/catch and exited `runToolCallBatch` without dispatching the matching `tool.result` event. The next provider request then failed with "an assistant message with 'tool_calls' must be followed by tool messages responding to each 'tool_call_id'".

## What changed

- Validate the tool return at the boundary in `runRunnableToolCall` via a new `coerceToolResult` helper. Malformed returns become an `isError` result so the loop can still emit a paired `tool.result` event.
- Harden `normalizeToolResult` and `toolResultStopsTurn` against non-conformant input from synthetic results or finalize hooks.
- Track unpaired `tool.call` ids in `runToolCallBatch` and emit compensating error results in `finally` for any that did not receive a result. The wrapper preserves the original `LoopEventDispatcher` overload signature.
- New tests cover undefined returns, missing-`output` returns, and mixed-batch pairing.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.