### PR TITLE
refactor: share LLM retry classification

### DIFF
--- a/.changeset/share-llm-retry-classification.md
+++ b/.changeset/share-llm-retry-classification.md
@@ -1,0 +1,7 @@
+---
+"@moonshot-ai/agent-core": patch
+"@moonshot-ai/kosong": patch
+"@moonshot-ai/kimi-code": patch
+---
+
+Use one retry classification for transient LLM failures across regular turns and compaction.

--- a/packages/agent-core/src/agent/compaction/full.ts
+++ b/packages/agent-core/src/agent/compaction/full.ts
@@ -6,10 +6,8 @@ import {
   toKimiErrorPayload,
 } from '#/errors';
 import {
-  APIConnectionError,
   APIEmptyResponseError,
-  APIStatusError,
-  APITimeoutError,
+  isRetryableGenerateError,
   inputTotal,
   type GenerateResult,
   type Message,
@@ -478,7 +476,7 @@ export class FullCompaction {
         const summary = extractCompactionSummary(response);
         return { response, summary, retryCount };
       } catch (error) {
-        if (attempt >= maxAttempts || !isRetryableCompactionError(error)) {
+        if (attempt >= maxAttempts || !isRetryableGenerateError(error)) {
           throw error;
         }
         retryCount += 1;
@@ -554,16 +552,4 @@ function compactionTelemetryTrigger(
     return 'manual-with-prompt';
   }
   return trigger;
-}
-
-function isRetryableCompactionError(error: unknown): boolean {
-  if (error instanceof APIConnectionError || error instanceof APITimeoutError) {
-    return true;
-  }
-  if (error instanceof APIEmptyResponseError) {
-    return true;
-  }
-  if (!(error instanceof APIStatusError)) return false;
-  const statusCode = (error as { readonly statusCode?: unknown }).statusCode;
-  return typeof statusCode === 'number' && [429, 500, 502, 503, 504].includes(statusCode);
 }

--- a/packages/agent-core/src/agent/index.ts
+++ b/packages/agent-core/src/agent/index.ts
@@ -50,9 +50,11 @@ import { ToolManager } from './tool/index';
 import { TurnFlow } from './turn';
 import {
   GENERATE_REQUEST_LOG_CONTEXT,
+  KosongLLM,
   type GenerateOptionsWithRequestLog,
 } from './turn/kosong-llm';
 import { UsageRecorder } from './usage';
+import { resolveCompletionBudget } from '../utils/completion-budget';
 
 export type { AgentRecord, AgentRecordPersistence } from './records';
 export type { BuiltinTool, ToolInfo, ToolSource, UserToolRegistration } from './tool';
@@ -176,6 +178,23 @@ export class Agent {
         return this.rawGenerate(provider, systemPrompt, tools, history, callbacks, requestOptions);
       });
     };
+  }
+
+  get llm(): KosongLLM {
+    const model = this.config.model;
+    const provider = this.config.provider.withThinking(this.config.thinkingLevel);
+    const loopControl = this.providerManager?.config.loopControl;
+    const completionBudgetConfig = resolveCompletionBudget({
+      reservedContextSize: loopControl?.reservedContextSize,
+    });
+    return new KosongLLM({
+      provider,
+      modelName: model,
+      systemPrompt: this.config.systemPrompt,
+      capability: this.config.modelCapabilities,
+      generate: this.generate,
+      completionBudgetConfig,
+    });
   }
 
   private logLlmRequest(

--- a/packages/agent-core/src/agent/turn/index.ts
+++ b/packages/agent-core/src/agent/turn/index.ts
@@ -32,11 +32,9 @@ import {
 import type { AgentEvent, TurnEndedEvent } from '../../rpc';
 import type { TelemetryPropertyValue } from '../../telemetry';
 import { abortable } from '../../utils/abort';
-import { resolveCompletionBudget } from '../../utils/completion-budget';
 import { USER_PROMPT_ORIGIN, type PromptOrigin } from '../context';
 import { renderUserPromptHookBlockResult, renderUserPromptHookResult } from '../hooks';
 import { canonicalTelemetryArgs, isPlainRecord } from './canonical-args';
-import { KosongLLM } from './kosong-llm';
 import { ToolCallDeduplicator } from './tool-dedup';
 
 interface ActiveTurn {
@@ -364,24 +362,12 @@ export class TurnFlow {
     while (true) {
       signal.throwIfAborted();
       const model = this.agent.config.model;
-      const provider = this.agent.config.provider.withThinking(this.agent.config.thinkingLevel);
       const loopControl = this.agent.providerManager?.config.loopControl;
-      const completionBudgetConfig = resolveCompletionBudget({
-        reservedContextSize: loopControl?.reservedContextSize,
-      });
-
       try {
         const result = await runTurn({
           turnId: String(turnId),
           signal,
-          llm: new KosongLLM({
-            provider,
-            modelName: model,
-            systemPrompt: this.agent.config.systemPrompt,
-            capability: this.agent.config.modelCapabilities,
-            generate: this.agent.generate,
-            completionBudgetConfig,
-          }),
+          llm: this.agent.llm,
           buildMessages: () => this.agent.context.messages,
           dispatchEvent: this.buildDispatchEvent(turnId),
           tools: this.agent.tools.loopTools,

--- a/packages/agent-core/src/agent/turn/kosong-llm.ts
+++ b/packages/agent-core/src/agent/turn/kosong-llm.ts
@@ -16,12 +16,9 @@
  */
 
 import {
-  APIConnectionError,
-  APIEmptyResponseError,
-  APIStatusError,
-  APITimeoutError,
   emptyUsage,
   generate as kosongGenerate,
+  isRetryableGenerateError,
   type ChatProvider,
   type GenerateCallbacks,
   type Message,
@@ -81,10 +78,6 @@ export class KosongLLM implements LLM {
   }
 
   async chat(params: LLMChatParams): Promise<LLMChatResponse> {
-    return this.chatOnce(params);
-  }
-
-  private async chatOnce(params: LLMChatParams): Promise<LLMChatResponse> {
     const callbacks = buildKosongCallbacks(params);
 
     // Compute and apply the per-request completion budget against a
@@ -127,8 +120,8 @@ export class KosongLLM implements LLM {
 
     const response: LLMChatResponse = {
       toolCalls: [...result.message.toolCalls],
-      ...(result.finishReason !== null ? { providerFinishReason: result.finishReason } : {}),
-      ...(result.rawFinishReason !== null ? { rawFinishReason: result.rawFinishReason } : {}),
+      providerFinishReason: result.finishReason ?? undefined,
+      rawFinishReason: result.rawFinishReason ?? undefined,
       usage: result.usage ?? emptyUsage(),
     };
 
@@ -136,13 +129,7 @@ export class KosongLLM implements LLM {
   }
 
   isRetryableError(error: unknown): boolean {
-    if (error instanceof APIConnectionError || error instanceof APITimeoutError) {
-      return true;
-    }
-    if (error instanceof APIEmptyResponseError) {
-      return true;
-    }
-    return error instanceof APIStatusError && [429, 500, 502, 503, 504].includes(error.statusCode);
+    return isRetryableGenerateError(error);
   }
 }
 

--- a/packages/agent-core/src/loop/llm.ts
+++ b/packages/agent-core/src/loop/llm.ts
@@ -57,8 +57,8 @@ export interface LLMChatParams {
 
 export interface LLMChatResponse {
   toolCalls: ToolCall[];
-  providerFinishReason?: FinishReason | undefined;
-  rawFinishReason?: string | undefined;
+  providerFinishReason?: FinishReason;
+  rawFinishReason?: string;
   usage: TokenUsage;
 }
 

--- a/packages/kosong/src/errors.ts
+++ b/packages/kosong/src/errors.ts
@@ -64,6 +64,16 @@ export class APIEmptyResponseError extends ChatProviderError {
   }
 }
 
+export function isRetryableGenerateError(error: unknown): boolean {
+  if (error instanceof APIConnectionError || error instanceof APITimeoutError) {
+    return true;
+  }
+  if (error instanceof APIEmptyResponseError) {
+    return true;
+  }
+  return error instanceof APIStatusError && [429, 500, 502, 503, 504].includes(error.statusCode);
+}
+
 const CONTEXT_OVERFLOW_MESSAGE_PATTERNS = [
   /context[ _-]?length/,
   /(?:context[ _-]?window.*exceed|exceed.*context[ _-]?window)/,

--- a/packages/kosong/src/index.ts
+++ b/packages/kosong/src/index.ts
@@ -60,6 +60,7 @@ export {
   APIStatusError,
   APITimeoutError,
   ChatProviderError,
+  isRetryableGenerateError,
 } from './errors';
 
 /**

--- a/packages/kosong/test/errors.test.ts
+++ b/packages/kosong/test/errors.test.ts
@@ -5,6 +5,7 @@ import {
   APIStatusError,
   APITimeoutError,
   ChatProviderError,
+  isRetryableGenerateError,
   normalizeAPIStatusError,
 } from '#/errors';
 import { describe, expect, it } from 'vitest';
@@ -81,6 +82,30 @@ describe('APIContextOverflowError', () => {
     expect(err.name).toBe('APIContextOverflowError');
     expect(err.statusCode).toBe(400);
     expect(err.requestId).toBe('req-context');
+  });
+});
+
+describe('isRetryableGenerateError', () => {
+  it('matches transient provider errors and empty generate responses', () => {
+    expect(isRetryableGenerateError(new APIConnectionError('conn'))).toBe(true);
+    expect(isRetryableGenerateError(new APITimeoutError('timeout'))).toBe(true);
+    expect(isRetryableGenerateError(new APIEmptyResponseError('empty'))).toBe(true);
+  });
+
+  it.each([429, 500, 502, 503, 504])('treats HTTP %i as retryable', (statusCode) => {
+    expect(isRetryableGenerateError(new APIStatusError(statusCode, 'retryable'))).toBe(true);
+  });
+
+  it.each([400, 401, 403, 404, 422])('treats HTTP %i as non-retryable', (statusCode) => {
+    expect(isRetryableGenerateError(new APIStatusError(statusCode, 'non-retryable'))).toBe(false);
+  });
+
+  it('does not retry context overflow or unknown errors', () => {
+    expect(
+      isRetryableGenerateError(new APIContextOverflowError(400, 'Context length exceeded')),
+    ).toBe(false);
+    expect(isRetryableGenerateError(new Error('boom'))).toBe(false);
+    expect(isRetryableGenerateError('boom')).toBe(false);
   });
 });
 


### PR DESCRIPTION
## Related Issue

No linked issue. This PR follows up on consolidating duplicate retry classification used by regular turns and compaction.

## Problem

Regular turn generation and compaction used equivalent but separate checks for retryable LLM failures. Keeping those checks in separate places makes it easier for retry behavior to drift as provider error handling evolves.

## What changed

- Added a shared retry classification helper in the LLM abstraction layer for transient generation failures.
- Updated compaction retry handling and the Kosong-backed loop adapter to use the shared helper.
- Moved Kosong LLM construction behind the agent so turn flow no longer duplicates provider and completion budget wiring.
- Preserved the loop-facing finish reason contract by translating missing provider diagnostics to omitted optional fields.
- Added focused coverage for retryable and non-retryable provider errors.
- Added a patch changeset for the affected packages and CLI bundle.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.

## Verification

- `pnpm --filter @moonshot-ai/agent-core typecheck`
- `pnpm --filter @moonshot-ai/kosong typecheck`
- `pnpm exec vitest run packages/kosong/test/errors.test.ts packages/agent-core/test/agent/turn.test.ts packages/agent-core/test/agent/compaction.test.ts packages/agent-core/test/agent/kosong-llm.test.ts`
