### PR TITLE
ci: add pkg.pr.new previews

### DIFF
--- a/.github/workflows/pkg-pr-new.yml
+++ b/.github/workflows/pkg-pr-new.yml
@@ -1,0 +1,50 @@
+name: pkg.pr.new
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  publish:
+    name: Publish Kimi Code preview
+    runs-on: ubuntu-latest
+    if: github.repository_owner == 'MoonshotAI' && github.event.pull_request.draft == false
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version-file: .nvmrc
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build package dependencies
+        run: pnpm run build:packages
+
+      - name: Generate Kimi Code built-in catalog
+        shell: bash
+        run: |
+          CATALOG_FILE="$RUNNER_TEMP/kimi-code-built-in-catalog.json"
+          node apps/kimi-code/scripts/update-catalog.mjs --out "$CATALOG_FILE"
+          echo "KIMI_CODE_BUILT_IN_CATALOG_FILE=$CATALOG_FILE" >> "$GITHUB_ENV"
+
+      - name: Build Kimi Code package
+        run: pnpm --filter @moonshot-ai/kimi-code run build
+
+      - name: Publish pkg.pr.new preview
+        run: pnpm exec pkg-pr-new publish --bin --commentWithSha --packageManager=pnpm,npm --no-template './apps/kimi-code'

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "lint-staged": "16.4.0",
     "oxlint": "1.59.0",
     "oxlint-tsgolint": "0.20.0",
+    "pkg-pr-new": "0.0.75",
     "publint": "0.3.18",
     "sherif": "1.11.1",
     "simple-git-hooks": "2.13.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -45,6 +45,9 @@ importers:
       oxlint-tsgolint:
         specifier: 0.20.0
         version: 0.20.0
+      pkg-pr-new:
+        specifier: 0.0.75
+        version: 0.0.75
       publint:
         specifier: 0.3.18
         version: 0.3.18
@@ -3392,6 +3395,10 @@ packages:
   pkce-challenge@5.0.1:
     resolution: {integrity: sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==}
     engines: {node: '>=16.20.0'}
+
+  pkg-pr-new@0.0.75:
+    resolution: {integrity: sha512-u9mdErTewKSMsr+ceCt8VcNuNP0ro5AXiPXhUVApuEyqr2Zlvt+DdCFBcm+yGWN8mhOdZJ27meIDbnoZgfzpOw==}
+    hasBin: true
 
   possible-typed-array-names@1.1.0:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
@@ -7062,6 +7069,8 @@ snapshots:
   pify@4.0.1: {}
 
   pkce-challenge@5.0.1: {}
+
+  pkg-pr-new@0.0.75: {}
 
   possible-typed-array-names@1.1.0: {}
 


### PR DESCRIPTION
## Related Issue

No linked issue. This PR addresses the need for pull-request preview packages for the Kimi Code CLI without touching the existing npm release workflow.

## Problem

Reviewers and downstream testers currently need to wait for the normal release flow before trying a built `@moonshot-ai/kimi-code` package from an unmerged PR. We want a preview package path that is isolated from npm publishing and scoped only to the CLI package.

## What changed

- Added a dedicated `pkg.pr.new` GitHub Actions workflow for non-draft pull requests.
- Scoped preview publishing to `apps/kimi-code` only.
- Reused the release-style built-in catalog generation before building the CLI so preview artifacts match the expected package shape more closely.
- Added `pkg-pr-new` as a locked root dev dependency so CI executes it from the lockfile, as recommended by pkg.pr.new.
- Kept the existing `release.yml` and npm Trusted Publishing path unchanged.

Local validation performed:

- `pnpm install --frozen-lockfile`
- workflow YAML parse check
- `git diff --check`
- `pnpm run build:packages`
- `node apps/kimi-code/scripts/update-catalog.mjs --out /tmp/kimi-code-pkg-pr-new-catalog.json`
- `KIMI_CODE_BUILT_IN_CATALOG_FILE=/tmp/kimi-code-pkg-pr-new-catalog.json pnpm --filter @moonshot-ai/kimi-code run build`
- `npm pack --json --pack-destination ... ./apps/kimi-code`
- local mocked `pkg-pr-new publish` run that verified `/check`, package URL probing, `/publish`, and GitHub Actions outputs without sending anything to the real pkg.pr.new service

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] This is a CI-only change; package behavior tests are not applicable, and local workflow/package validation is listed above.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.

## 如何配置

1. 在 GitHub 仓库安装 pkg.pr.new GitHub App：打开 https://github.com/apps/pkg-pr-new，选择 `MoonshotAI/kimi-code` 仓库并授权。
2. 不需要配置 npm token，也不需要改 npm Trusted Publishing；这个 workflow 只上传到 pkg.pr.new，不发布到 npm。
3. PR 变为非 draft 后，`.github/workflows/pkg-pr-new.yml` 会自动构建并发布 `apps/kimi-code` 的预览包。
4. pkg.pr.new 会在 PR 中更新评论，提供基于 commit SHA 的预览链接；因为使用了 `--bin`，评论里会展示适合 CLI 包的执行方式。
5. 如需临时禁用预览发布，可以把 PR 标记为 draft，或暂停/移除 `pkg.pr.new` workflow。
