### PR TITLE
fix(read): report both MAX_LINES and MAX_BYTES caps when both are hit

### DIFF
--- a/packages/agent-core/src/tools/builtin/file/read.ts
+++ b/packages/agent-core/src/tools/builtin/file/read.ts
@@ -426,9 +426,11 @@ export class ReadTool implements BuiltinTool<ReadInput> {
     parts.push(`Total lines in file: ${String(input.totalLines)}.`);
     if (input.maxLinesReached) {
       parts.push(`Max ${String(MAX_LINES)} lines reached.`);
-    } else if (input.maxBytesReached) {
+    }
+    if (input.maxBytesReached) {
       parts.push(`Max ${String(MAX_BYTES)} bytes reached.`);
-    } else if (lineCount < input.requestedLines) {
+    }
+    if (!input.maxLinesReached && !input.maxBytesReached && lineCount < input.requestedLines) {
       parts.push('End of file reached.');
     }
     if (input.truncatedLineNumbers.length > 0) {


### PR DESCRIPTION
## Summary

- Replace `else if` chain with independent `if` statements in `finishMessage` so both `maxLinesReached` and `maxBytesReached` are reported independently when both limits are triggered
- Tighten the EOF condition so "End of file reached." only appears when *neither* limit was hit

## Changes

`packages/agent-core/src/tools/builtin/file/read.ts` — `finishMessage` method (lines 427–433):
- `else if (maxBytesReached)` → `if (maxBytesReached)`
- `else if (lineCount < requestedLines)` → `if (!maxLinesReached && !maxBytesReached && lineCount < requestedLines)`

## Related Issue

Fixes #94

## Test Plan

- Read a file that exceeds both `MAX_LINES` (1000) and `MAX_BYTES` (100 KB) — status should now contain both `Max 1000 lines reached.` and `Max 102400 bytes reached.`
- Read a file that only exceeds `MAX_LINES` — only the lines message appears
- Read a file that only exceeds `MAX_BYTES` — only the bytes message appears
- Read a file that fits within both limits — "End of file reached." appears as before