### PR TITLE
fix(read): report both MAX_LINES and MAX_BYTES caps when both are hit

### DIFF
--- a/.changeset/fix-read-both-limit-caps.md
+++ b/.changeset/fix-read-both-limit-caps.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Report both the line and byte caps in the Read tool status when a file trips both limits, instead of silently dropping the byte cap.

--- a/.changeset/fix-read-both-limit-caps.md
+++ b/.changeset/fix-read-both-limit-caps.md
@@ -1,4 +1,5 @@
 ---
+"@moonshot-ai/agent-core": patch
 "@moonshot-ai/kimi-code": patch
 ---
 

--- a/packages/agent-core/src/tools/builtin/file/read.ts
+++ b/packages/agent-core/src/tools/builtin/file/read.ts
@@ -426,9 +426,11 @@ export class ReadTool implements BuiltinTool<ReadInput> {
     parts.push(`Total lines in file: ${String(input.totalLines)}.`);
     if (input.maxLinesReached) {
       parts.push(`Max ${String(MAX_LINES)} lines reached.`);
-    } else if (input.maxBytesReached) {
+    }
+    if (input.maxBytesReached) {
       parts.push(`Max ${String(MAX_BYTES)} bytes reached.`);
-    } else if (lineCount < input.requestedLines) {
+    }
+    if (!input.maxLinesReached && !input.maxBytesReached && lineCount < input.requestedLines) {
       parts.push('End of file reached.');
     }
     if (input.truncatedLineNumbers.length > 0) {

--- a/packages/agent-core/test/tools/read.test.ts
+++ b/packages/agent-core/test/tools/read.test.ts
@@ -588,6 +588,18 @@ describe('ReadTool', () => {
     expect(result.output).not.toContain(`${String(MAX_LINES + 1)}\tline ${String(MAX_LINES + 1)}`);
   });
 
+  it('reports both line and byte caps when a file trips both limits', async () => {
+    const content = Array.from({ length: MAX_LINES + 1 }, () => 'x'.repeat(120)).join('\n');
+    const tool = toolWithContent(content);
+
+    const result = await executeTool(tool, context({ path: '/tmp/both-caps.txt' }));
+    const output = toolContentString(result);
+
+    expect(output).toContain(`Max ${String(MAX_LINES)} lines reached.`);
+    expect(output).toContain(`Max ${String(MAX_BYTES)} bytes reached.`);
+    expect(output).not.toContain('End of file reached.');
+  });
+
   it('tail byte truncation keeps the newest lines closest to EOF', async () => {
     const numLines = Math.floor(MAX_BYTES / 1001) + 20;
     const content = Array.from({ length: numLines }, (_, i) => {


### PR DESCRIPTION
## Related Issue

Resolve #94

## Problem

See linked issue. When a file exceeds both the `MAX_LINES` (1000) and `MAX_BYTES` (100 KB) limits, the Read tool's `<system>` status only reported the line cap. The byte cap was silently dropped, which can mislead the model into thinking paging forward by line will recover the rest of the content when the byte cap would still truncate it.

## What changed

- `packages/agent-core/src/tools/builtin/file/read.ts`: changed the `else if` chain to independent `if` statements so both caps are reported when both trip, and tightened the EOF condition to fire only when neither limit was hit. Single-limit and no-limit outputs are unchanged.
- `packages/agent-core/test/tools/read.test.ts`: added a regression test for the both-caps case (the only previously-uncovered scenario), asserting both messages appear and `End of file reached.` does not.
- Added a `patch` changeset for `@moonshot-ai/kimi-code` (internal `agent-core` fix that changes CLI-visible behavior).

## Checklist

- [x] I have read the CONTRIBUTING document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.