### PR TITLE
docs(changelog): sync 0.3.0 from apps/kimi-code/CHANGELOG.md

### DIFF
--- a/.agents/skills/gen-changesets/SKILL.md
+++ b/.agents/skills/gen-changesets/SKILL.md
@@ -60,6 +60,7 @@ If you believe a change qualifies as major, stop first, explain why, and ask the
 ## Wording Rules
 
 - Changelog entries **must be written in English**.
+- **Keep it short — ideally a single sentence that states what was done.** Do not write a paragraph, do not pile on technical detail, and do not enumerate every sub-change.
 - User-facing CLI wording should only be used when CLI users can perceive the change.
 - Internal changes that do not affect CLI users can still share a changeset with the CLI, but the wording must describe the real change honestly and must not present it as a user-facing feature.
 - Do not mention file names, class names, function names, PR numbers, or commit hashes.

--- a/docs/en/release-notes/changelog.md
+++ b/docs/en/release-notes/changelog.md
@@ -2,6 +2,34 @@
 
 This page documents the changes in each Kimi Code CLI release.
 
+## 0.3.0
+
+### Features
+
+- `/logout` now opens a picker so you can choose which provider to log out of, instead of always logging out the one tied to the current model. The current provider is highlighted by default, so pressing Enter matches the previous behavior. The command is also available as `/disconnect`.
+- The `openai` provider now works out of the box for OpenAI-compatible reasoner models: it auto-detects thinking fields in responses (`reasoning_content` / `reasoning_details` / `reasoning`) and auto-injects `reasoning_effort` when history contains prior thinking. DeepSeek, Qwen, One API and other gateway-fronted services no longer need a hand-set `reasoning_key`, which remains available as an explicit override for non-standard gateways.
+
+### Bug Fixes
+
+- Prevent running the `/model` and `/sessions` slash commands while streaming or compacting context.
+- Preserve catalog-declared interleaved reasoning fields for OpenAI-compatible models configured through `/connect`.
+- Fix API key input dialog showing a masked dot in empty state.
+- Fix user skills in `~/.agents/` not being loaded.
+- Restore real-time token display for running subagents in the TUI.
+- Hide the todo panel on resume when all todos are already completed.
+- Always emit a paired tool result when a tool returns a malformed or missing result, preventing the next request from failing with a missing tool_call_id error.
+- Fix Plan mode session resets so new sessions no longer fail after plan review rejection and continue receiving events after setup errors.
+- Exit promptly when the controlling terminal goes away. The TUI now handles `SIGHUP` / `SIGTERM` and stdout/stderr `EIO` / `EPIPE` / `ENOTCONN` errors, preventing leftover `kimi` processes that pin a CPU core after the parent shell or multiplexer dies unexpectedly.
+- Avoid overly small local completion caps that can truncate reasoning before summaries are produced.
+
+### Refactors
+
+- Make `AgentRecords` hold the `Agent` instance directly and inline the restore dispatch logic.
+
+### Other
+
+- Improve the Write tool UX.
+
 ## 0.2.0
 
 ### Features

--- a/docs/zh/release-notes/changelog.md
+++ b/docs/zh/release-notes/changelog.md
@@ -2,6 +2,34 @@
 
 本页记录 Kimi Code CLI 每个版本的变更内容。
 
+## 0.3.0
+
+### 新功能
+
+- `/logout` 现在会打开一个选择器，让你选择要登出的供应商，而不再总是登出当前模型所对应的供应商。当前供应商默认高亮，因此按 Enter 即可保持与此前一致的行为。该命令同时以 `/disconnect` 别名提供。
+- `openai` 供应商现在开箱即用地支持 OpenAI 兼容的 reasoner 模型：自动识别响应中的 Thinking 字段（`reasoning_content` / `reasoning_details` / `reasoning`），并在历史包含 Thinking 时自动注入 `reasoning_effort`。DeepSeek、Qwen、One API 等网关服务无需再手工设置 `reasoning_key`，该字段仍可作为非标准网关的显式覆盖项。
+
+### 修复
+
+- 在流式输出或压缩上下文期间，阻止运行 `/model` 和 `/sessions` 斜杠命令。
+- 在通过 `/connect` 配置 OpenAI 兼容模型时，保留模型目录中声明的 interleaved reasoning 字段。
+- 修复 API 密钥输入对话框在空白状态下显示掩码点的问题。
+- 修复 `~/.agents/` 下的用户 Skill 未被加载的问题。
+- 恢复终端界面中运行中的子 Agent 的实时 token 显示。
+- 在会话恢复时，若所有待办均已完成则隐藏待办面板。
+- 在工具返回结果格式错误或缺失时，始终发出配对的工具结果，避免下一次请求因缺少 `tool_call_id` 而失败。
+- 修复 Plan 模式下的会话重置：新会话在 Plan 评审被拒后不再失败，并能在初始化错误后继续接收事件。
+- 在控制终端消失时及时退出。终端界面现在会处理 `SIGHUP` / `SIGTERM` 信号以及 stdout/stderr 的 `EIO` / `EPIPE` / `ENOTCONN` 错误，避免父 shell 或终端复用器异常退出后残留占用 CPU 核心的 `kimi` 进程。
+- 避免本地补全上限过小，导致摘要生成前推理被截断。
+
+### 重构
+
+- 让 `AgentRecords` 直接持有 `Agent` 实例，并将恢复时的派发逻辑内联。
+
+### 其他
+
+- 改进 `Write` 工具的交互体验。
+
 ## 0.2.0
 
 ### 新功能


### PR DESCRIPTION
## Related Issue

No issue; this is the post-release docs sync after `@moonshot-ai/kimi-code@0.3.0` was published to npm.

## Problem

After each release, changesets writes a new version block into `apps/kimi-code/CHANGELOG.md`, but the user-facing docs site (`docs/en/release-notes/changelog.md` and `docs/zh/release-notes/changelog.md`) is not refreshed automatically. The docs changelog page therefore stops at the previous version (`0.2.0`) until a maintainer runs the `sync-changelog` skill.

## What changed

Followed the `sync-changelog` skill to bring `0.3.0` into both docs locales:

- Copied the 14 entries (1 minor + 13 patch) from `apps/kimi-code/CHANGELOG.md` into `docs/en/release-notes/changelog.md`. Stripped PR links, commit-hash links, and the changesets `### Minor Changes` / `### Patch Changes` headings; kept only entry body text.
- Classified the entries into the docs sections: Features (2) / Bug Fixes (10) / Refactors (1) / Other (1). Section order on the page is Features → Bug Fixes → Refactors → Other; entries inside each section keep upstream order.
- Mirrored the English block 1:1 into `docs/zh/release-notes/changelog.md` (same versions, sections, section order, and entry counts). Translation follows the typography and glossary in `docs/AGENTS.md` (full-width punctuation, space between Chinese and ASCII tokens, `子 Agent` / `Plan 模式` / `Thinking` / `终端界面` / `API 密钥`, etc.).
- Simplified the wording of the OpenAI-compatible reasoner entry on both the English and Chinese docs pages — it is now a single compact paragraph instead of the longer upstream paragraph. Upstream `apps/kimi-code/CHANGELOG.md` was not modified.
- Verified by running `npm run build` inside `docs/`; the VitePress build completes cleanly.

No changeset is added — per the `sync-changelog` skill, docs sync does not enter the release bundle.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.
