### PR TITLE
fix(agent-core): route session logs exclusively to session sink

### DIFF
--- a/.changeset/session-log-routing.md
+++ b/.changeset/session-log-routing.md
@@ -1,0 +1,6 @@
+---
+"@moonshot-ai/agent-core": patch
+"@moonshot-ai/kimi-code": patch
+---
+
+Route session-tagged log entries exclusively to the session sink instead of duplicating them to the global sink. Consistently omit stable main-agent context keys from all session log lines that carry `agentId=main`.

--- a/packages/agent-core/src/logging/logger.ts
+++ b/packages/agent-core/src/logging/logger.ts
@@ -122,21 +122,19 @@ class RootLoggerImpl implements RootLogger {
     if (config === undefined || config.level === 'off') return;
     if (!levelEnabled(config.level, entry.level)) return;
 
-    const formatted = formatEntry(entry);
-    if (formatted.dropped) return;
-
-    this.globalSink?.enqueue(formatted.text + '\n');
-
     const session = this.resolveSessionEntry(entry);
     if (session !== undefined) {
-      const omitContextKeys =
-        entry.msg === 'llm request' ? llmRequestSessionLogOmittedKeys(entry) : undefined;
+      const omitContextKeys = llmRequestSessionLogOmittedKeys(entry);
       const sessionFormatted = formatEntry(entry, {
         omitContextKeys,
       });
       if (!sessionFormatted.dropped) {
         session.sink.enqueue(sessionFormatted.text + '\n');
       }
+    } else {
+      const formatted = formatEntry(entry);
+      if (formatted.dropped) return;
+      this.globalSink?.enqueue(formatted.text + '\n');
     }
   }
 

--- a/packages/agent-core/test/logging/logger.test.ts
+++ b/packages/agent-core/test/logging/logger.test.ts
@@ -237,7 +237,7 @@ describe('createChild', () => {
 });
 
 describe('session routing', () => {
-  it('writes sessionId-tagged entries to both global and session sink', async () => {
+  it('writes sessionId-tagged entries to session sink only', async () => {
     const sessionDir = await mkdtemp(join(tmpdir(), 'logger-session-'));
     try {
       await getRootLogger().configure(defaultConfig());
@@ -248,7 +248,7 @@ describe('session routing', () => {
       await getRootLogger().flush();
       const global = await readGlobal();
       const session = await readFile(join(sessionDir, 'logs', 'kimi-code.log'), 'utf-8');
-      expect(global).toContain('hello');
+      expect(global).not.toContain('hello');
       expect(session).toContain('hello');
       await handle.close();
     } finally {
@@ -256,7 +256,7 @@ describe('session routing', () => {
     }
   });
 
-  it('prints sessionId once on llm config but omits stable main-agent fields from session llm request lines', async () => {
+  it('omits stable main-agent fields from all session lines with agentId=main', async () => {
     const sessionDir = await mkdtemp(join(tmpdir(), 'logger-session-'));
     try {
       await getRootLogger().configure(defaultConfig());
@@ -268,11 +268,12 @@ describe('session routing', () => {
       await getRootLogger().flush();
 
       const global = await readGlobal();
-      expect(global).toMatch(/llm config.*sessionId=ses_abc/);
-      expect(global).toMatch(/llm request.*sessionId=ses_abc/);
+      expect(global).not.toMatch(/llm config/);
+      expect(global).not.toMatch(/llm request/);
 
       const session = await readFile(join(sessionDir, 'logs', 'kimi-code.log'), 'utf-8');
-      expect(session).toMatch(/llm config.*sessionId=ses_abc/);
+      expect(session).toMatch(/llm config(?!.*sessionId=ses_abc)/);
+      expect(session).toMatch(/llm config(?!.*agentId=main)/);
       expect(session).toMatch(/llm request(?!.*sessionId=ses_abc)/);
       expect(session).toMatch(/llm request(?!.*agentId=main)/);
       await handle.close();
@@ -347,8 +348,8 @@ describe('session routing', () => {
       expect(secondText).not.toContain('ambiguous session id');
 
       const global = await readGlobal();
-      expect(global).toContain('first only');
-      expect(global).toContain('second only');
+      expect(global).not.toContain('first only');
+      expect(global).not.toContain('second only');
       expect(global).toContain('ambiguous session id');
 
       await first.close();

--- a/packages/node-sdk/test/local-logging.test.ts
+++ b/packages/node-sdk/test/local-logging.test.ts
@@ -98,7 +98,7 @@ function readZipEntries(buf: Buffer): Map<string, Buffer> {
 }
 
 describe('Local logging — harness integration', () => {
-  it('writes session-tagged entries to both global and session log files', async () => {
+  it('writes session-tagged entries to session log only and untagged entries to global', async () => {
     const homeDir = await makeTempDir('kimi-log-home-');
     const workDir = await makeTempDir('kimi-log-work-');
 
@@ -131,7 +131,7 @@ describe('Local logging — harness integration', () => {
 
     const global = await readFile(globalPath, 'utf-8');
     const sessionLog = await readFile(sessionLogPath, 'utf-8');
-    expect(global).toContain('session diagnostic');
+    expect(global).not.toContain('session diagnostic');
     expect(sessionLog).toContain('session diagnostic');
     expect(global).toContain('untagged event');
     expect(sessionLog).not.toContain('untagged event');
@@ -284,6 +284,7 @@ describe('Local logging — harness integration', () => {
     const harness = new KimiHarness({ identity: TEST_IDENTITY, homeDir });
     const session = await harness.createSession({ id: 'ses_flush_warning', workDir });
     log.warn('flush warning setup', { sessionId: session.id });
+    log.warn('global untagged marker');
 
     const root = getRootLogger();
     const flushSessionSpy = vi
@@ -305,7 +306,8 @@ describe('Local logging — harness integration', () => {
       const globalLog = entries.get('logs/global/kimi-code.log')!.toString('utf-8');
       expect(sessionLog).toContain('export session log flush failed');
       expect(sessionLog).toContain('export global log flush failed');
-      expect(globalLog).toContain('export global log flush failed');
+      expect(globalLog).toContain('global untagged marker');
+      expect(globalLog).not.toContain('export global log flush failed');
     } finally {
       flushSessionSpy.mockRestore();
       flushGlobalSpy.mockRestore();


### PR DESCRIPTION
## Related Issue

No related issue.

## Problem

Session-tagged log entries were previously written to both the global log sink and the session-specific sink, causing duplication in global logs. Additionally, context key omission for stable main-agent fields (`sessionId`, `agentId`) was only applied to `llm request` messages, leaving other main-agent session lines with redundant context fields.

## What changed

- `RootLoggerImpl.emit` now routes session-tagged entries exclusively to the resolved session sink. Non-session entries continue to go to the global sink, eliminating duplication.
- `llmRequestSessionLogOmittedKeys` is now invoked for every session entry, consistently omitting stable main-agent context keys from all session lines rather than only `llm request` lines.
- Updated test expectations in `logger.test.ts` to match the new routing and omission behavior.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.
