### PR TITLE
fix: show original session command after fork

### DIFF
--- a/.changeset/fork-return-command.md
+++ b/.changeset/fork-return-command.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Show the original session resume command after forking a session.

--- a/apps/kimi-code/src/tui/kimi-tui.ts
+++ b/apps/kimi-code/src/tui/kimi-tui.ts
@@ -5504,7 +5504,10 @@ export class KimiTUI {
     }
 
     try {
-      await this.switchToSession(forked, `Session forked (${forked.id}).`);
+      await this.switchToSession(
+        forked,
+        `Session forked (${forked.id}). To return to the original session: kimi -r ${session.id}`,
+      );
     } catch (error) {
       const msg = formatErrorMessage(error);
       this.showError(`Failed to switch to forked session: ${msg}`);

--- a/apps/kimi-code/test/tui/kimi-tui-message-flow.test.ts
+++ b/apps/kimi-code/test/tui/kimi-tui-message-flow.test.ts
@@ -1476,7 +1476,7 @@ describe('KimiTUI message flow', () => {
       expect(forked.onEvent).toHaveBeenCalledOnce();
       expect(harness.resumeSession).not.toHaveBeenCalled();
       expect(driver.state.transcriptContainer.render(120).join('\n')).toContain(
-        'Session forked (ses-fork).',
+        'Session forked (ses-fork). To return to the original session: kimi -r ses-source',
       );
     } finally {
       process.title = originalTitle;


### PR DESCRIPTION
## Related Issue

No linked issue; this addresses a small TUI clarity gap in the fork flow.

## Problem

After running `/fork`, the TUI switches into the forked session and only shows the new session id. Users who want to return to the pre-fork session need the exact resume command for the original session.

## What changed

- Include `kimi -r <original-session-id>` in the successful fork status message after switching to the forked session.
- Update the existing fork flow test to assert the return command.
- Add a patch changeset for the CLI package.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.