### PR TITLE
feat(tui): add /export-debug-zip slash command

### DIFF
--- a/.changeset/tui-export-debug-zip.md
+++ b/.changeset/tui-export-debug-zip.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": minor
+---
+
+Add `/export-debug-zip` slash command to export the current session as a debug ZIP archive directly from the TUI.

--- a/apps/kimi-code/src/cli/sub/export.ts
+++ b/apps/kimi-code/src/cli/sub/export.ts
@@ -27,6 +27,7 @@ import { CLI_SHUTDOWN_TIMEOUT_MS, CLI_UI_MODE } from '#/constant/app';
 import { createCliTelemetryBootstrap, initializeCliTelemetry } from '#/cli/telemetry';
 import { detectInstallSource } from '#/cli/update/source';
 import { createKimiCodeHostIdentity } from '#/cli/version';
+import { detectShellEnvironment } from '#/utils/process/shell-env';
 
 interface WritableLike {
   write(chunk: string): boolean;
@@ -229,23 +230,6 @@ async function confirmPreviousSession(summary: PreviousSessionSummary): Promise<
   } finally {
     rl.close();
   }
-}
-
-function detectMultiplexer(): string | undefined {
-  if (process.env['TMUX']) return 'tmux';
-  if (process.env['STY']) return 'screen';
-  if (process.env['ZELLIJ']) return 'zellij';
-  return undefined;
-}
-
-function detectShellEnvironment(): ShellEnvironment {
-  return {
-    term: process.env['TERM'] || undefined,
-    termProgram: process.env['TERM_PROGRAM'] || undefined,
-    termProgramVersion: process.env['TERM_PROGRAM_VERSION'] || undefined,
-    multiplexer: detectMultiplexer(),
-    shell: process.env['SHELL'] || undefined,
-  };
 }
 
 function errorMessage(error: unknown): string {

--- a/apps/kimi-code/src/tui/commands/registry.ts
+++ b/apps/kimi-code/src/tui/commands/registry.ts
@@ -146,6 +146,12 @@ export const BUILTIN_SLASH_COMMANDS = [
     priority: 40,
   },
   {
+    name: 'export-debug-zip',
+    aliases: [],
+    description: 'Export current session as a debug ZIP archive',
+    priority: 40,
+  },
+  {
     name: 'exit',
     aliases: ['quit', 'q'],
     description: 'Exit the application',

--- a/apps/kimi-code/src/tui/components/messages/plan-box.ts
+++ b/apps/kimi-code/src/tui/components/messages/plan-box.ts
@@ -11,6 +11,8 @@ import type { Component, MarkdownTheme } from '@earendil-works/pi-tui';
 import { Markdown, visibleWidth } from '@earendil-works/pi-tui';
 import chalk from 'chalk';
 
+import { toTerminalHyperlink } from '#/utils/terminal-hyperlink';
+
 const LEFT_MARGIN = 2; // two-space indent matching other tool call children
 const SIDE_PADDING = 1; // space between the │ and the content on each side
 const TITLE_PREFIX = ' plan: ';
@@ -132,8 +134,4 @@ export class PlanBoxComponent implements Component {
     if (status === undefined || status.label.length === 0) return '';
     return ` · ${chalk.hex(status.colorHex)(status.label)}`;
   }
-}
-
-function toTerminalHyperlink(text: string, url: string): string {
-  return `\u001B]8;;${url}\u0007${text}\u001B]8;;\u0007`;
 }

--- a/apps/kimi-code/src/tui/kimi-tui.ts
+++ b/apps/kimi-code/src/tui/kimi-tui.ts
@@ -98,6 +98,8 @@ import type {
 import chalk from 'chalk';
 
 import type { CLIOptions } from '#/cli/options';
+import { detectInstallSource } from '#/cli/update/source';
+import { detectShellEnvironment } from '#/utils/process/shell-env';
 import { MigrationScreenComponent, type MigrationScreenResult } from '#/migration/index';
 import { ClipboardMediaError, readClipboardMedia } from '#/utils/clipboard/clipboard-image';
 import type { GitLsFilesCache } from '#/utils/git/git-ls-files';
@@ -1585,6 +1587,9 @@ export class KimiTUI {
         return;
       case 'fork':
         await this.handleForkCommand(args);
+        return;
+      case 'export-debug-zip':
+        await this.handleExportDebugZipCommand();
         return;
       case 'login':
         await this.handleLoginCommand();
@@ -5521,6 +5526,31 @@ export class KimiTUI {
     } catch (error) {
       const msg = formatErrorMessage(error);
       this.showError(`Failed to switch to forked session: ${msg}`);
+    }
+  }
+
+  private async handleExportDebugZipCommand(): Promise<void> {
+    const session = this.session;
+    if (session === undefined) {
+      this.showError(NO_ACTIVE_SESSION_MESSAGE);
+      return;
+    }
+
+    this.showStatus('Exporting session…');
+    try {
+      const installSource = await detectInstallSource();
+      const shellEnv = detectShellEnvironment();
+      const result = await this.harness.exportSession({
+        id: session.id,
+        version: this.state.appState.version,
+        installSource,
+        shellEnv,
+        includeGlobalLog: true,
+      });
+      this.showNotice('Export complete', result.zipPath);
+    } catch (error) {
+      const msg = formatErrorMessage(error);
+      this.showError(`Failed to export session: ${msg}`);
     }
   }
 

--- a/apps/kimi-code/src/tui/kimi-tui.ts
+++ b/apps/kimi-code/src/tui/kimi-tui.ts
@@ -10,6 +10,7 @@
 import { writeFileSync } from 'node:fs';
 import { release as osRelease, type as osType } from 'node:os';
 import { join } from 'node:path';
+import { pathToFileURL } from 'node:url';
 
 import {
   Container,
@@ -100,6 +101,7 @@ import chalk from 'chalk';
 import type { CLIOptions } from '#/cli/options';
 import { detectInstallSource } from '#/cli/update/source';
 import { detectShellEnvironment } from '#/utils/process/shell-env';
+import { toTerminalHyperlink } from '#/utils/terminal-hyperlink';
 import { MigrationScreenComponent, type MigrationScreenResult } from '#/migration/index';
 import { ClipboardMediaError, readClipboardMedia } from '#/utils/clipboard/clipboard-image';
 import type { GitLsFilesCache } from '#/utils/git/git-ls-files';
@@ -5547,7 +5549,8 @@ export class KimiTUI {
         shellEnv,
         includeGlobalLog: true,
       });
-      this.showNotice('Export complete', result.zipPath);
+      const linked = toTerminalHyperlink(result.zipPath, pathToFileURL(result.zipPath).href);
+      this.showNotice('Export complete', linked);
     } catch (error) {
       const msg = formatErrorMessage(error);
       this.showError(`Failed to export session: ${msg}`);

--- a/apps/kimi-code/src/utils/process/shell-env.ts
+++ b/apps/kimi-code/src/utils/process/shell-env.ts
@@ -1,0 +1,18 @@
+import type { ShellEnvironment } from '@moonshot-ai/kimi-code-sdk';
+
+function detectMultiplexer(): string | undefined {
+  if (process.env['TMUX']) return 'tmux';
+  if (process.env['STY']) return 'screen';
+  if (process.env['ZELLIJ']) return 'zellij';
+  return undefined;
+}
+
+export function detectShellEnvironment(): ShellEnvironment {
+  return {
+    term: process.env['TERM'] || undefined,
+    termProgram: process.env['TERM_PROGRAM'] || undefined,
+    termProgramVersion: process.env['TERM_PROGRAM_VERSION'] || undefined,
+    multiplexer: detectMultiplexer(),
+    shell: process.env['SHELL'] || undefined,
+  };
+}

--- a/apps/kimi-code/src/utils/terminal-hyperlink.ts
+++ b/apps/kimi-code/src/utils/terminal-hyperlink.ts
@@ -1,0 +1,3 @@
+export function toTerminalHyperlink(text: string, url: string): string {
+  return `\u001B]8;;${url}\u0007${text}\u001B]8;;\u0007`;
+}

--- a/apps/kimi-code/test/tui/commands/registry.test.ts
+++ b/apps/kimi-code/test/tui/commands/registry.test.ts
@@ -81,6 +81,7 @@ describe('built-in slash command registry', () => {
         'compact',
         'editor',
         'exit',
+        'export-debug-zip',
         'fork',
         'help',
         'init',


### PR DESCRIPTION
## Related Issue

N/A — this is a quality-of-life improvement for in-session debugging.

## Problem

Users currently have to exit the TUI and run `kimi export` from the CLI to export a session as a debug ZIP archive. There is no way to do this from within an active TUI session.

## What changed

- **New `/export-debug-zip` slash command** — registered as a built-in command in the TUI that exports the current session (including the global log) as a debug ZIP archive, using the same `KimiHarness.exportSession()` API as the CLI `kimi export` command.
- **Extracted `detectShellEnvironment` into a shared utility** (`apps/kimi-code/src/utils/process/shell-env.ts`) — eliminates duplication between the CLI export handler and the new TUI command.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [ ] Ran `gen-docs` skill, or this PR needs no doc update.