### PR TITLE
docs: document /export-md and /export-debug-zip slash commands

### DIFF
--- a/docs/en/guides/sessions.md
+++ b/docs/en/guides/sessions.md
@@ -105,6 +105,8 @@ kimi export <sessionId> -o ~/Desktop/my-session.zip
 
 The ZIP is written to the current working directory by default. The session's own diagnostic log is always bundled along with the session directory. The global diagnostic log at `$KIMI_CODE_HOME/logs/kimi-code.log` — which captures events that do not belong to a session, such as TUI startup and login — is also bundled by default; pass `--no-include-global-log` to skip it.
 
+You can also export the current session without leaving the TUI. `/export-debug-zip` produces the same kind of debug ZIP as `kimi export`, while `/export-md` (alias `/export`) writes a human-readable Markdown transcript — useful for sharing or archiving a readable conversation history. `/export-md` accepts an optional path; with no argument, it writes to `kimi-export-<short-id>-<timestamp>.md` in the working directory.
+
 ::: tip Tip
 Exported files may contain sensitive information. Review the contents before sharing.
 :::

--- a/docs/en/reference/slash-commands.md
+++ b/docs/en/reference/slash-commands.md
@@ -32,6 +32,8 @@ Some commands are only available in the idle state. Running them while the sessi
 | `/title [<text>]` | `/rename` | Without arguments, show the current session title; with an argument, set it as the new title (up to 200 characters). | Yes |
 | `/compact [<instruction>]` | — | Compact the current conversation context to free up token usage; optionally pass a custom instruction telling the model what to preserve during compaction. | No |
 | `/init` | — | Analyze the current codebase and generate `AGENTS.md`. | No |
+| `/export-md [<path>]` | `/export` | Export the current session as a Markdown file. With no argument, writes to `kimi-export-<short-id>-<timestamp>.md` in the working directory; pass a path to choose the output location. | No |
+| `/export-debug-zip` | — | Export the current session as a debug ZIP archive (mirrors [`kimi export`](./kimi-command.md#kimi-export)). The archive always includes the active global diagnostic log. | No |
 
 ## Mode and runtime control
 

--- a/docs/zh/guides/sessions.md
+++ b/docs/zh/guides/sessions.md
@@ -105,6 +105,8 @@ kimi export <sessionId> -o ~/Desktop/my-session.zip
 
 未指定 `-o` 时，ZIP 写入当前工作目录。会话目录里的诊断日志会一并打包；此外，全局诊断日志 `$KIMI_CODE_HOME/logs/kimi-code.log`（记录 TUI 启动、登录等不属于任何会话的事件）默认也会包含进来，不需要时加 `--no-include-global-log` 跳过。
 
+也可以在不离开 TUI 的情况下导出当前会话。`/export-debug-zip` 产生与 `kimi export` 相同的调试 ZIP，而 `/export-md`（别名 `/export`）会写出一份人类可读的 Markdown 对话记录，适合分享或归档可读的会话内容。`/export-md` 可选接收一个路径参数；不带参数时，写入工作目录下的 `kimi-export-<short-id>-<timestamp>.md`。
+
 ::: tip 提示
 导出文件可能包含敏感信息，分享前请确认内容。
 :::

--- a/docs/zh/reference/slash-commands.md
+++ b/docs/zh/reference/slash-commands.md
@@ -32,6 +32,8 @@
 | `/title [<text>]` | `/rename` | 不带参数时显示当前会话标题；带参数时将其设置为新标题（最长 200 个字符）。 | 是 |
 | `/compact [<instruction>]` | — | 压缩当前对话上下文，释放 token 占用；可选附带一段自定义指令，提示模型在压缩时保留哪些信息。 | 否 |
 | `/init` | — | 分析当前代码库并生成 `AGENTS.md`。 | 否 |
+| `/export-md [<path>]` | `/export` | 将当前会话导出为 Markdown 文件。不带参数时写入工作目录下的 `kimi-export-<short-id>-<timestamp>.md`，传入路径可指定输出位置。 | 否 |
+| `/export-debug-zip` | — | 将当前会话导出为调试用的 ZIP 压缩包（与 [`kimi export`](./kimi-command.md#kimi-export) 行为一致）。压缩包始终包含当前活动的全局诊断日志。 | 否 |
 
 ## 模式与运行控制
 


### PR DESCRIPTION
## Related Issue

There is no linked issue. The repository recently merged two TUI slash commands — `/export-md` (#113, alias `/export`) and `/export-debug-zip` (#112) — and their changesets are pending under `.changeset/`, but the user-facing docs have not been updated yet.

## Problem

Users discovering Kimi Code through the docs site cannot find the new in-TUI export commands. The slash-commands reference lists every other session command (`/fork`, `/title`, `/compact`, `/init`, …) but is missing the two new exports, and the Sessions guide only covers the `kimi export` CLI subcommand.

## What changed

- `docs/en/reference/slash-commands.md` + `docs/zh/reference/slash-commands.md`: added `/export-md [<path>]` (alias `/export`) and `/export-debug-zip` to the "Session management" table, noting the default Markdown filename and that the debug ZIP mirrors `kimi export` and always bundles the active global diagnostic log.
- `docs/en/guides/sessions.md` + `docs/zh/guides/sessions.md`: added a paragraph at the end of "Exporting sessions" describing the in-TUI variants so the Markdown export sits next to the existing CLI flow.

No source code, manifest, or behavior changes — docs-only, so no changeset per `gen-changesets`. Locale pair line counts stay matched (89/89 reference, 112/112 guide) and the new cross-link to `./kimi-command.md#kimi-export` resolves to the existing `### \`kimi export\`` heading in both locales.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [ ] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.
