### PR TITLE
fix(kosong): correct type inference when enum/const contradicts expli…

### DIFF
--- a/.changeset/fix-schema-enum-type-inference.md
+++ b/.changeset/fix-schema-enum-type-inference.md
@@ -1,0 +1,6 @@
+---
+"@moonshot-ai/kosong": patch
+"@moonshot-ai/kimi-code": patch
+---
+
+Fix type inference when enum or const values contradict the declared type in tool schemas.

--- a/packages/kosong/src/providers/kimi-schema.ts
+++ b/packages/kosong/src/providers/kimi-schema.ts
@@ -300,15 +300,29 @@ function normalizeProperty(node: unknown): void {
     return;
   }
 
-  if (!hasOwn(node, 'type') && !hasAnyKey(node, TYPE_COMPLETION_SKIP_KEYS)) {
-    const enumValues = node['enum'];
-    if (Array.isArray(enumValues) && enumValues.length > 0) {
-      node['type'] = inferTypeFromValues(enumValues);
-    } else if (hasOwn(node, 'const')) {
-      node['type'] = inferTypeFromValues([node['const']]);
-    } else {
-      node['type'] = inferTypeFromStructure(node);
+  const enumValues = node['enum'];
+  const hasEnum = Array.isArray(enumValues) && enumValues.length > 0;
+  const hasConst = hasOwn(node, 'const');
+
+  if (hasEnum || hasConst) {
+    if (!hasOwn(node, 'type') && !hasAnyKey(node, TYPE_COMPLETION_SKIP_KEYS)) {
+      node['type'] = hasEnum
+        ? inferTypeFromValues(enumValues)
+        : inferTypeFromValues([node['const']]);
+    } else if (hasOwn(node, 'type') && !hasAnyKey(node, TYPE_COMPLETION_SKIP_KEYS)) {
+      const inferredType = hasEnum
+        ? inferTypeFromValues(enumValues)
+        : inferTypeFromValues([node['const']]);
+      if (node['type'] !== inferredType) {
+        node['type'] = inferredType;
+      }
     }
+    recurseSchema(node);
+    return;
+  }
+
+  if (!hasOwn(node, 'type') && !hasAnyKey(node, TYPE_COMPLETION_SKIP_KEYS)) {
+    node['type'] = inferTypeFromStructure(node);
   }
 
   recurseSchema(node);

--- a/packages/kosong/test/providers/kimi-schema.test.ts
+++ b/packages/kosong/test/providers/kimi-schema.test.ts
@@ -372,6 +372,26 @@ describe('normalizeKimiToolSchema', () => {
     });
   });
 
+  it('fixes a mismatched type when enum/const values contradict it', () => {
+    const schema = {
+      type: 'object',
+      properties: {
+        operation: { type: 'object', enum: ['move', 'copy'] },
+        mode: { type: 'array', const: 'fast' },
+      },
+    };
+
+    const result = normalizeKimiToolSchema(schema);
+
+    expect(result).toEqual({
+      type: 'object',
+      properties: {
+        operation: { type: 'string', enum: ['move', 'copy'] },
+        mode: { type: 'string', const: 'fast' },
+      },
+    });
+  });
+
   it('infers object and array property types from container enum/const values', () => {
     const schema = {
       type: 'object',


### PR DESCRIPTION
     ## Related Issue

     N/A — no prior issue opened for this bug.

     ## Problem

     When a tool JSON schema explicitly declares a `type` that contradicts the actual values in `enum` or `const` (e.g. `type: 'object'` with `enum: ['move', 'copy']`), `normalizeKimiToolSchema` previously only  inferred the type when it was missing. It did **not** correct a mismatched explicit type, leaving an invalid schema that could propagate downstream.

     ## What changed

     Updated `normalizeProperty` in `packages/kosong/src/providers/kimi-schema.ts` so that when `enum` or `const` is present, the function now:

     1. Infers the type from the enum/const values if `type` is absent (existing behavior preserved).
     2. Corrects the `type` if it is already present but contradicts the inferred type from enum/const values.

     Added a test case in `kimi-schema.test.ts` covering both `enum` and `const` mismatch scenarios.

     ## Checklist

     - [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
     - [x] I have explained the problem above (no linked issue).
     - [x] I have added tests that prove my feature works.
     - [x] Ran `gen-changesets` skill — `.changeset/fix-schema-enum-type-inference.md` added.
     - [x] Ran `gen-docs` skill, or this PR needs no doc update. <!-- needs no doc update -->