### PR TITLE
fix(tui): cache Text instance in ThinkingComponent to stop per-frame re-wrap

### DIFF
--- a/apps/kimi-code/src/tui/components/messages/thinking.ts
+++ b/apps/kimi-code/src/tui/components/messages/thinking.ts
@@ -29,6 +29,11 @@ export class ThinkingComponent implements Component {
   private readonly ui: TUI | undefined;
   private spinnerFrame = 0;
   private spinnerInterval: ReturnType<typeof setInterval> | undefined;
+  // Hold a single Text instance so pi-tui's (text, width) → lines cache
+  // actually survives across renders. Re-constructing per render destroys
+  // the cache and forces full re-wrap on every frame, which dominates CPU
+  // once the transcript accumulates many finalized thinking blocks.
+  private readonly textComponent: Text;
 
   constructor(
     text: string,
@@ -42,6 +47,7 @@ export class ThinkingComponent implements Component {
     this.showMarker = showMarker;
     this.mode = mode;
     this.ui = ui;
+    this.textComponent = new Text(this.styled(text), 0, 0);
     if (mode === 'live') {
       this.startSpinner();
     }
@@ -50,7 +56,13 @@ export class ThinkingComponent implements Component {
   invalidate(): void {}
 
   setText(text: string): void {
+    if (this.text === text) return;
     this.text = text;
+    this.textComponent.setText(this.styled(text));
+  }
+
+  private styled(text: string): string {
+    return chalk.hex(this.color).italic(text);
   }
 
   finalize(): void {
@@ -69,8 +81,7 @@ export class ThinkingComponent implements Component {
 
   render(width: number): string[] {
     const contentWidth = Math.max(1, width - MESSAGE_INDENT.length);
-    const textComponent = new Text(chalk.hex(this.color).italic(this.text), 0, 0);
-    const contentLines = this.text.length > 0 ? textComponent.render(contentWidth) : [''];
+    const contentLines = this.text.length > 0 ? this.textComponent.render(contentWidth) : [''];
 
     if (this.mode === 'live') {
       const visibleLines =


### PR DESCRIPTION
## Summary

- `ThinkingComponent.render()` was constructing `new Text(chalk.hex(...).italic(...))` on every call, which throws away pi-tui's `(text, width) → lines` cache on the inner `Text` instance.
- finalized thinking blocks are never removed from `transcriptContainer`, and pi-tui's `Container.render` walks every child unconditionally per frame, so per-frame work grew linearly with the number of thinking blocks accumulated in the session.
- Fix: hold a single `Text` instance per component, update it via `setText` when the underlying text changes, so pi-tui's existing cache short-circuits subsequent renders.

## Impact

Measured on a 21h session with **507 finalized thinking blocks (524 KB total)**, width=100 cols, 30-frame steady state:

| | ms / frame | fps cap | vs 16 ms budget |
|---|---|---|---|
| before | **156** | 6 | 9.8× over |
| after | **0.9** | 1070 | 0.06× |

≈ **168× speedup**. In the wild, this turned a 90%+ pinned main thread (the issue first surfaced as kimi at 92.9% CPU for hours on a long agentic session) into a quiet idle process.

## Test plan

- [x] `pnpm --filter @kimi-code/app test test/tui/components/messages/thinking.test.ts` — 5/5 pass
- [x] `pnpm --filter @kimi-code/app test test/tui/kimi-tui-message-flow.test.ts` — 57/57 pass
- [x] `tsc --noEmit` clean
- [x] Microbenchmark on real session wire.jsonl shows the speedup above