### PR TITLE
chore: reduce default thinking preview lines to 2

### DIFF
--- a/apps/kimi-code/src/tui/components/messages/thinking.ts
+++ b/apps/kimi-code/src/tui/components/messages/thinking.ts
@@ -13,7 +13,7 @@ import {
   BRAILLE_SPINNER_FRAMES,
   BRAILLE_SPINNER_INTERVAL_MS,
   MESSAGE_INDENT,
-  RESULT_PREVIEW_LINES,
+  THINKING_PREVIEW_LINES,
 } from '#/tui/constant/rendering';
 import { STATUS_BULLET } from '#/tui/constant/symbols';
 import type { ColorPalette } from '#/tui/theme/colors';
@@ -85,8 +85,8 @@ export class ThinkingComponent implements Component {
 
     if (this.mode === 'live') {
       const visibleLines =
-        contentLines.length > RESULT_PREVIEW_LINES
-          ? contentLines.slice(contentLines.length - RESULT_PREVIEW_LINES)
+        contentLines.length > THINKING_PREVIEW_LINES
+          ? contentLines.slice(contentLines.length - THINKING_PREVIEW_LINES)
           : contentLines;
       const spinner = chalk.hex(this.color)(
         `${BRAILLE_SPINNER_FRAMES[this.spinnerFrame] ?? BRAILLE_SPINNER_FRAMES[0]} `,
@@ -104,13 +104,13 @@ export class ThinkingComponent implements Component {
       rendered.push(p + contentLines[i]);
     }
 
-    if (this.expanded || contentLines.length <= RESULT_PREVIEW_LINES) {
+    if (this.expanded || contentLines.length <= THINKING_PREVIEW_LINES) {
       return rendered;
     }
 
     // Leading blank + first PREVIEW_LINES content lines + hint line.
-    const truncated = rendered.slice(0, 1 + RESULT_PREVIEW_LINES);
-    const remaining = contentLines.length - RESULT_PREVIEW_LINES;
+    const truncated = rendered.slice(0, 1 + THINKING_PREVIEW_LINES);
+    const remaining = contentLines.length - THINKING_PREVIEW_LINES;
     truncated.push(
       MESSAGE_INDENT + chalk.dim(`... (${String(remaining)} more lines, ctrl+o to expand)`),
     );

--- a/apps/kimi-code/src/tui/constant/rendering.ts
+++ b/apps/kimi-code/src/tui/constant/rendering.ts
@@ -9,6 +9,7 @@ export const CHROME_GUTTER = 1;
 
 // Shared preview caps used by thinking, tool results, and shell snippets.
 export const RESULT_PREVIEW_LINES = 3;
+export const THINKING_PREVIEW_LINES = 2;
 export const COMMAND_PREVIEW_LINES = 10;
 
 // Animation frames are shared by the login/update loaders and live thinking.

--- a/apps/kimi-code/test/tui/components/messages/thinking.test.ts
+++ b/apps/kimi-code/test/tui/components/messages/thinking.test.ts
@@ -28,7 +28,8 @@ describe('ThinkingComponent', () => {
 
     expect(out).not.toContain('line1');
     expect(out).not.toContain('line4');
-    expect(out).toContain('line5');
+    expect(out).not.toContain('line5');
+    expect(out).toContain('line6');
     expect(out).toContain('line7');
     expect(out).not.toContain('ctrl+o to expand');
   });
@@ -60,9 +61,10 @@ describe('ThinkingComponent', () => {
 
     const out = strip(component.render(80).join('\n'));
     expect(out).toContain('line1');
-    expect(out).toContain('line3');
+    expect(out).toContain('line2');
+    expect(out).not.toContain('line3');
     expect(out).not.toContain('line4');
-    expect(out).toContain('... (4 more lines, ctrl+o to expand)');
+    expect(out).toContain('... (5 more lines, ctrl+o to expand)');
   });
 
   it('expands and collapses after finalization', () => {


### PR DESCRIPTION
## Problem

The thinking component in the TUI currently defaults to showing 3 lines of preview content. To make better use of limited terminal screen space and keep the transcript more compact, this should be reduced to 2 lines.

## What changed

- Introduced a dedicated \"THINKING_PREVIEW_LINES\" constant set to 2 in \"src/tui/constant/rendering.ts\".
- Updated \"ThinkingComponent\" to use the new constant instead of the shared \"RESULT_PREVIEW_LINES\" (which remains at 3 for tool results and shell execution previews).
- Adjusted unit test expectations in \"thinking.test.ts\" to match the new 2-line behavior.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [ ] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [ ] Ran \"gen-changesets\" skill, or this PR needs no changeset.
- [ ] Ran \"gen-docs\" skill, or this PR needs no doc update.
