### PR TITLE
fix(tui): merge multi-part steer into single message in idle phase

### DIFF
--- a/apps/kimi-code/src/tui/kimi-tui.ts
+++ b/apps/kimi-code/src/tui/kimi-tui.ts
@@ -792,9 +792,7 @@ export class KimiTUI {
       return;
     }
     if (this.state.appState.streamingPhase === 'idle') {
-      for (const part of input) {
-        this.sendMessageInternal(session, part);
-      }
+      this.sendMessageInternal(session, input.join('\n\n'));
       return;
     }
 


### PR DESCRIPTION
## Summary
  - `steerMessage` idle path looped over input parts calling `sendMessageInternal` for each, causing conflicting
  concurrent `session.prompt()` calls
  - Now joins all parts into one message, matching the streaming-phase steer behavior

  ## Test plan
  - [x] All existing tests pass (985 passed)
  - [ ] Manual test: call steerMessage with multiple parts while idle, verify single request is sent