### PR TITLE
fix(tui): clear reverseRpcDisposers array after disposing

### DIFF
--- a/apps/kimi-code/src/tui/kimi-tui.ts
+++ b/apps/kimi-code/src/tui/kimi-tui.ts
@@ -975,6 +975,7 @@ export class KimiTUI {
     for (const dispose of this.reverseRpcDisposers) {
       dispose();
     }
+    this.reverseRpcDisposers.length = 0;
   }
 
   private registerSessionHandlers(session: Session): void {


### PR DESCRIPTION
## Summary
  - clearReverseRpcPanels() called disposers without clearing the array, causing double-dispose on session switches
  - Added this.reverseRpcDisposers.length = 0 to match the cleanup pattern in stop()

  ## Test plan
  - [x] All existing tests pass (985 passed)
  - [ ] Switch sessions multiple times, verify no double-dispose errors in console