### PR TITLE
fix(tui): cap session-title length at 32 chars

### DIFF
--- a/.changeset/cap-session-title-length.md
+++ b/.changeset/cap-session-title-length.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Shorten the session title written to the terminal window/tab from 80 to 32 characters so long first messages and pasted content no longer stretch the tab bar past readable width.

--- a/apps/kimi-code/src/tui/constant/terminal.ts
+++ b/apps/kimi-code/src/tui/constant/terminal.ts
@@ -33,7 +33,7 @@ export const OSC11_RESPONSE_PREFIX_NO_ESC = "]11;rgb:";
 // Keep notification/title payloads bounded so terminal tabs and desktop
 // notifications stay readable.
 export const MAX_TERMINAL_NOTIFICATION_MESSAGE_LENGTH = 240;
-export const MAX_PROCESS_TITLE_LENGTH = 80;
+export const MAX_PROCESS_TITLE_LENGTH = 32;
 
 // OSC 11 probing must be short because unsupported terminals do not reply.
 export const TERMINAL_THEME_DETECT_TIMEOUT_MS = 250;


### PR DESCRIPTION
## Related Issue

Resolve #128

## Problem

See linked issue. On Windows Terminal the session title written by Kimi Code can stretch the tab bar past readable width — at the current 80-character cap, CJK content reaches ~160 terminal columns and ASCII content shows the entire first user message inline.

This PR addresses the tab-width side of the report. The second concern in the issue — pasted code is unreadable as a title regardless of length — is not addressed here; both suggested directions in the issue (skip the OSC title override entirely, or summarize the first message via the model) are larger behavior changes that benefit from maintainer input first.

## What changed

`MAX_PROCESS_TITLE_LENGTH` is lowered from 80 to 32 in `apps/kimi-code/src/tui/constant/terminal.ts`. The slicing in `setProcessTitle` (`apps/kimi-code/src/tui/utils/proctitle.ts`) already honors the constant, so no other code change is required. The new cap fits typical tab widths (~20–25 visible characters in Windows Terminal / iTerm tab bars) while keeping enough context to identify the session.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [ ] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.