### PR TITLE
feat(cli): add clickable changelog link to update prompt

### DIFF
--- a/.changeset/add-changelog-link-to-update-prompt.md
+++ b/.changeset/add-changelog-link-to-update-prompt.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Add a clickable changelog link to the update prompt.

--- a/apps/kimi-code/src/cli/update/prompt.ts
+++ b/apps/kimi-code/src/cli/update/prompt.ts
@@ -14,6 +14,8 @@ import {
 
 import { type InstallSource, type UpdateTarget } from './types';
 
+const CHANGELOG_URL = 'https://moonshotai.github.io/kimi-code/en/release-notes/changelog.html';
+
 export type InstallPromptChoiceValue = 'install' | 'skip';
 
 export interface InstallPromptChoice {
@@ -66,9 +68,11 @@ function renderInstallPrompt(
   const targetVersion = chalk.hex(UPDATE_PROMPT_SUCCESS).bold(options.target.version);
   const sourceLabel = chalk.hex(UPDATE_PROMPT_PRIMARY).bold(options.installSource);
   const command = chalk.hex(UPDATE_PROMPT_PRIMARY)(options.installCommand);
+  const changelogText = chalk.hex(UPDATE_PROMPT_PRIMARY).underline(`View changelog: ${CHANGELOG_URL}`);
   const lines = [
     chalk.hex(UPDATE_PROMPT_PRIMARY).bold('Kimi Code Update Available'),
     chalk.hex(UPDATE_PROMPT_MUTED)(`${PRODUCT_NAME} has a newer release ready.`),
+    `]8;;${CHANGELOG_URL}\\${changelogText}]8;;\\`,
     '',
     `${label('Current')}  ${currentVersion}`,
     `${label('Target ')}  ${targetVersion}`,

--- a/apps/kimi-code/test/cli/update/prompt.test.ts
+++ b/apps/kimi-code/test/cli/update/prompt.test.ts
@@ -1,9 +1,12 @@
+import { EventEmitter } from 'node:events';
+
 import { describe, expect, it } from 'vitest';
 
 import {
   createInstallPromptChoices,
   getDefaultInstallPromptSelection,
   moveInstallPromptSelection,
+  promptForInstallConfirmation,
 } from '#/cli/update/prompt';
 
 describe('install prompt helpers', () => {
@@ -26,5 +29,44 @@ describe('install prompt helpers', () => {
     expect(moveInstallPromptSelection(0, 'up', 2)).toBe(0);
     expect(moveInstallPromptSelection(0, 'down', 2)).toBe(1);
     expect(moveInstallPromptSelection(1, 'down', 2)).toBe(1);
+  });
+});
+
+describe('promptForInstallConfirmation', () => {
+  it('renders changelog hyperlink in the prompt output', async () => {
+    const CHANGELOG_URL = 'https://moonshotai.github.io/kimi-code/en/release-notes/changelog.html';
+
+    const input = Object.assign(new EventEmitter(), {
+      isRaw: false,
+      setRawMode: () => {},
+      resume: () => {},
+      off: () => {},
+    }) as unknown as NodeJS.ReadStream;
+
+    const outputChunks: string[] = [];
+    const output = {
+      write: (chunk: string) => {
+        outputChunks.push(chunk);
+        return true;
+      },
+    } as NodeJS.WriteStream;
+
+    const promptPromise = promptForInstallConfirmation({
+      currentVersion: '0.4.0',
+      target: { version: '0.5.0' },
+      installCommand: 'npm install -g @moonshot-ai/kimi-code@0.5.0',
+      installSource: 'npm-global',
+      input,
+      output,
+    });
+
+    // Emit keypress to trigger initial render then exit
+    input.emit('keypress', '', { name: 'escape' });
+
+    await promptPromise;
+
+    const rendered = outputChunks.join('');
+    expect(rendered).toContain(CHANGELOG_URL);
+    expect(rendered).toContain('View changelog');
   });
 });


### PR DESCRIPTION
## Related Issue

N/A — this is a small UX improvement that does not require prior discussion.

## Problem

When Kimi Code detects a newer version, the update prompt shows version numbers and an install command, but gives users no way to see what changed in the new release before deciding whether to upgrade.

## What changed

- Added a `CHANGELOG_URL` constant pointing to the release notes page.
- In `renderInstallPrompt`, rendered the URL as an OSC 8 terminal hyperlink with the visible text `View changelog: <URL>`, styled with the primary theme color and underline.
- Added a unit test to verify the prompt output contains both the changelog URL and the "View changelog" label.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [ ] Ran `gen-docs` skill, or this PR needs no doc update.