### PR TITLE
feat(agent-core): `ModelProvider` interface and `SingleModelProvider`

### DIFF
--- a/.changeset/constructable-agent-model-provider.md
+++ b/.changeset/constructable-agent-model-provider.md
@@ -1,0 +1,6 @@
+---
+"@moonshot-ai/agent-core": patch
+"@moonshot-ai/kimi-code": patch
+---
+
+Introduce `ModelProvider` interface and `SingleModelProvider` to decouple `Agent` from `ProviderManager`.

--- a/packages/agent-core/src/agent/compaction/full.ts
+++ b/packages/agent-core/src/agent/compaction/full.ts
@@ -61,7 +61,7 @@ export class FullCompaction {
         {
           ...DEFAULT_COMPACTION_CONFIG,
           reservedContextSize:
-            agent.providerManager?.config.loopControl?.reservedContextSize ??
+            agent.kimiConfig?.loopControl?.reservedContextSize ??
             DEFAULT_COMPACTION_CONFIG.reservedContextSize,
         }
       );

--- a/packages/agent-core/src/agent/config/index.ts
+++ b/packages/agent-core/src/agent/config/index.ts
@@ -128,7 +128,7 @@ export class ConfigState {
 
   private get resolvedProviderConfig(): ResolvedRuntimeProvider | undefined {
     if (this._modelAlias === undefined) return undefined;
-    return this.agent.providerManager?.resolveProviderConfig(this._modelAlias);
+    return this.agent.modelProvider?.resolveProviderConfig(this._modelAlias);
   }
 
   private tryResolvedProviderConfig(): ResolvedRuntimeProvider | undefined {

--- a/packages/agent-core/src/agent/config/index.ts
+++ b/packages/agent-core/src/agent/config/index.ts
@@ -50,7 +50,7 @@ export class ConfigState {
     if (changed.thinkingLevel !== undefined) {
       this._thinkingLevel = resolveThinkingEffort(
         changed.thinkingLevel,
-        this.agent.providerManager?.config.thinking,
+        this.agent.kimiConfig?.thinking,
       );
     }
     if (changed.systemPrompt !== undefined) {

--- a/packages/agent-core/src/agent/config/index.ts
+++ b/packages/agent-core/src/agent/config/index.ts
@@ -24,6 +24,7 @@ export class ConfigState {
 
   constructor(protected readonly agent: Agent) {
     this._cwd = agent.runtime.kaos.getcwd();
+    this._modelAlias = agent.modelProvider?.defaultModel;
   }
 
   update(changed: AgentConfigUpdateData): void {

--- a/packages/agent-core/src/agent/index.ts
+++ b/packages/agent-core/src/agent/index.ts
@@ -82,20 +82,20 @@ export interface AgentOptions {
 }
 
 export class Agent {
+  readonly type: AgentType;
   readonly runtime: RuntimeConfig;
   readonly kimiConfig?: KimiConfig;
   readonly homedir?: string;
-  readonly skills?: SkillManager;
+  readonly rpc?: SDKAgentRPC;
   readonly pluginSessionStarts: readonly EnabledPluginSessionStart[];
   readonly rawGenerate: typeof generate;
-  readonly rpc?: SDKAgentRPC;
+  readonly providerManager?: ProviderManager;
+  readonly subagentHost?: SessionSubagentHost;
+  readonly mcp?: McpConnectionManager;
+  readonly hooks?: HookEngine;
+  readonly log: Logger;
   readonly telemetry: TelemetryClient;
-  readonly providerManager: ProviderManager | undefined;
-  readonly subagentHost: SessionSubagentHost | undefined;
-  readonly mcp: McpConnectionManager | undefined;
-  readonly hooks: HookEngine | undefined;
 
-  readonly type: AgentType;
   readonly blobStore: BlobStore | undefined;
   readonly records: AgentRecords;
   readonly fullCompaction: FullCompaction;
@@ -107,30 +107,28 @@ export class Agent {
   readonly planMode: PlanMode;
   readonly usage: UsageRecorder;
   readonly tools: ToolManager;
+  readonly skills: SkillManager | null;
   readonly background: BackgroundManager;
   readonly cron: CronManager | null;
   readonly replayBuilder: ReplayBuilder;
-  readonly log: Logger;
 
   private lastLlmConfigLogSignature?: string;
 
   constructor(options: AgentOptions) {
-    this.log = options.log ?? log;
-    this.kimiConfig = options.config;
+    this.type = options.type ?? 'main';
     this.runtime = options.runtime;
+    this.kimiConfig = options.config;
     this.homedir = options.homedir;
-    if (options.skills !== undefined) {
-      this.skills = new SkillManager(this, options.skills);
-    }
+    this.rpc = options.rpc;
     this.pluginSessionStarts = options.pluginSessionStarts ?? [];
     this.rawGenerate = options.generate ?? generate;
     this.providerManager = options.providerManager;
     this.subagentHost = options.subagentHost;
     this.mcp = options.mcp;
     this.hooks = options.hookEngine;
-    this.type = options.type ?? 'main';
-    this.rpc = options.rpc;
+    this.log = options.log ?? log;
     this.telemetry = options.telemetry ?? noopTelemetryClient;
+
     this.blobStore = options.homedir
       ? new BlobStore({ blobsDir: join(options.homedir, 'blobs') })
       : undefined;
@@ -155,6 +153,7 @@ export class Agent {
     this.planMode = new PlanMode(this);
     this.usage = new UsageRecorder(this);
     this.tools = new ToolManager(this);
+    this.skills = options.skills === undefined ? null : new SkillManager(this, options.skills);
     this.background = new BackgroundManager(this);
     this.cron = this.type === 'sub' ? null : new CronManager(this);
     this.replayBuilder = new ReplayBuilder(this);
@@ -344,7 +343,7 @@ export class Agent {
         this.context.clear();
       },
       activateSkill: (payload) => {
-        if (this.skills === undefined) {
+        if (this.skills === null) {
           throw new KimiError(ErrorCodes.SKILL_NOT_FOUND, `Skill "${payload.name}" was not found`);
         }
         this.skills.activate(payload);

--- a/packages/agent-core/src/agent/index.ts
+++ b/packages/agent-core/src/agent/index.ts
@@ -64,7 +64,7 @@ export interface AgentOptions {
   readonly runtime: RuntimeConfig;
   readonly config?: KimiConfig;
   readonly homedir?: string;
-  readonly rpc?: SDKAgentRPC;
+  readonly rpc?: Partial<SDKAgentRPC>;
   readonly persistence?: AgentRecordPersistence;
   readonly type?: AgentType;
   readonly generate?: typeof generate;
@@ -85,7 +85,7 @@ export class Agent {
   readonly runtime: RuntimeConfig;
   readonly kimiConfig?: KimiConfig;
   readonly homedir?: string;
-  readonly rpc?: SDKAgentRPC;
+  readonly rpc?: Partial<SDKAgentRPC>;
   readonly pluginSessionStarts: readonly EnabledPluginSessionStart[];
   readonly rawGenerate: typeof generate;
   readonly modelProvider?: ModelProvider;
@@ -105,8 +105,8 @@ export class Agent {
   readonly permission: PermissionManager;
   readonly planMode: PlanMode;
   readonly usage: UsageRecorder;
-  readonly tools: ToolManager;
   readonly skills: SkillManager | null;
+  readonly tools: ToolManager;
   readonly background: BackgroundManager;
   readonly cron: CronManager | null;
   readonly replayBuilder: ReplayBuilder;
@@ -151,8 +151,8 @@ export class Agent {
     this.permission = new PermissionManager(this, options.permission);
     this.planMode = new PlanMode(this);
     this.usage = new UsageRecorder(this);
+    this.skills = options.skills ? new SkillManager(this, options.skills) : null;
     this.tools = new ToolManager(this);
-    this.skills = options.skills === undefined ? null : new SkillManager(this, options.skills);
     this.background = new BackgroundManager(this);
     this.cron = this.type === 'sub' ? null : new CronManager(this);
     this.replayBuilder = new ReplayBuilder(this);
@@ -361,7 +361,7 @@ export class Agent {
 
   emitEvent(event: AgentEvent): void {
     if (this.records.restoring) return;
-    void this.rpc?.emitEvent(event);
+    void this.rpc?.emitEvent?.(event);
   }
 
   emitStatusUpdated(): void {

--- a/packages/agent-core/src/agent/index.ts
+++ b/packages/agent-core/src/agent/index.ts
@@ -169,7 +169,7 @@ export class Agent {
       const withAuth =
         modelAlias === undefined
           ? undefined
-          : this.providerManager?.createAuthResolverForModel(modelAlias, { log: this.log });
+          : this.providerManager?.resolveAuth(modelAlias, { log: this.log });
       if (withAuth === undefined) {
         this.logLlmRequest(provider, systemPrompt, tools, history, options);
         return this.rawGenerate(provider, systemPrompt, tools, history, callbacks, options);
@@ -185,7 +185,7 @@ export class Agent {
   get llm(): KosongLLM {
     const model = this.config.model;
     const provider = this.config.provider.withThinking(this.config.thinkingLevel);
-    const loopControl = this.providerManager?.config.loopControl;
+    const loopControl = this.kimiConfig?.loopControl;
     const completionBudgetConfig = resolveCompletionBudget({
       reservedContextSize: loopControl?.reservedContextSize,
     });

--- a/packages/agent-core/src/agent/index.ts
+++ b/packages/agent-core/src/agent/index.ts
@@ -74,7 +74,6 @@ export interface AgentOptions {
   readonly skills?: SkillRegistry;
   readonly mcp?: McpConnectionManager;
   readonly hookEngine?: HookEngine;
-  readonly cronSessionDir?: string;
   readonly permission?: PermissionManagerOptions | undefined;
   readonly log?: Logger;
   readonly telemetry?: TelemetryClient | undefined;

--- a/packages/agent-core/src/agent/index.ts
+++ b/packages/agent-core/src/agent/index.ts
@@ -16,7 +16,7 @@ import type { EnabledPluginSessionStart } from '#/plugin';
 
 import type { McpConnectionManager } from '../mcp';
 import type { PreparedSystemPromptContext, ResolvedAgentProfile } from '../profile';
-import type { ProviderManager } from '../session/provider-manager';
+import type { ModelProvider } from '../session/provider-manager';
 import type { RuntimeConfig } from '../runtime-types';
 import type { SessionSubagentHost } from '../session/subagent-host';
 import type { SkillRegistry } from '../skill';
@@ -69,7 +69,7 @@ export interface AgentOptions {
   readonly type?: AgentType;
   readonly generate?: typeof generate;
   readonly compactionStrategy?: CompactionStrategy;
-  readonly providerManager?: ProviderManager | undefined;
+  readonly modelProvider?: ModelProvider | undefined;
   readonly subagentHost?: SessionSubagentHost | undefined;
   readonly skills?: SkillRegistry;
   readonly mcp?: McpConnectionManager;
@@ -89,7 +89,7 @@ export class Agent {
   readonly rpc?: SDKAgentRPC;
   readonly pluginSessionStarts: readonly EnabledPluginSessionStart[];
   readonly rawGenerate: typeof generate;
-  readonly providerManager?: ProviderManager;
+  readonly modelProvider?: ModelProvider;
   readonly subagentHost?: SessionSubagentHost;
   readonly mcp?: McpConnectionManager;
   readonly hooks?: HookEngine;
@@ -122,7 +122,7 @@ export class Agent {
     this.rpc = options.rpc;
     this.pluginSessionStarts = options.pluginSessionStarts ?? [];
     this.rawGenerate = options.generate ?? generate;
-    this.providerManager = options.providerManager;
+    this.modelProvider = options.modelProvider;
     this.subagentHost = options.subagentHost;
     this.mcp = options.mcp;
     this.hooks = options.hookEngine;
@@ -169,7 +169,7 @@ export class Agent {
       const withAuth =
         modelAlias === undefined
           ? undefined
-          : this.providerManager?.resolveAuth(modelAlias, { log: this.log });
+          : this.modelProvider?.resolveAuth?.(modelAlias, { log: this.log });
       if (withAuth === undefined) {
         this.logLlmRequest(provider, systemPrompt, tools, history, options);
         return this.rawGenerate(provider, systemPrompt, tools, history, callbacks, options);
@@ -298,7 +298,7 @@ export class Agent {
         // Validate the alias resolves before recording it so resume / runtime
         // callers fail fast on missing aliases instead of deferring to the
         // next prompt.
-        const resolved = this.providerManager?.resolveProviderConfig(payload.model);
+        const resolved = this.modelProvider?.resolveProviderConfig(payload.model);
         if (this.config.modelAlias !== payload.model) {
           this.config.update({ modelAlias: payload.model });
           this.telemetry.track('model_switch', { model: payload.model });

--- a/packages/agent-core/src/agent/permission/index.ts
+++ b/packages/agent-core/src/agent/permission/index.ts
@@ -131,11 +131,7 @@ export class PermissionManager {
     const startedAt = Date.now();
 
     let response: ApprovalResponse;
-    if (this.agent.rpc === undefined) {
-      response = {
-        decision: 'approved',
-      };
-    } else {
+    if (this.agent.rpc?.requestApproval) {
       try {
         response = await this.agent.rpc.requestApproval(
           {
@@ -163,6 +159,10 @@ export class PermissionManager {
           ? Promise.reject(error)
           : this.permissionPolicyResolutionToPrepare(resolved, context, policyName);
       }
+    } else {
+      response = {
+        decision: 'approved',
+      };
     }
 
     const sessionApprovalRule =

--- a/packages/agent-core/src/agent/tool/index.ts
+++ b/packages/agent-core/src/agent/tool/index.ts
@@ -403,7 +403,7 @@ export class ToolManager {
     if (uploadVideo === undefined) return undefined;
 
     const modelAlias = this.agent.config.modelAlias!;
-    const withAuth = this.agent.providerManager?.createAuthResolverForModel(modelAlias, {
+    const withAuth = this.agent.providerManager?.resolveAuth(modelAlias, {
       log: this.agent.log,
     });
     if (withAuth === undefined) return (input) => uploadVideo(input);

--- a/packages/agent-core/src/agent/tool/index.ts
+++ b/packages/agent-core/src/agent/tool/index.ts
@@ -43,6 +43,9 @@ export class ToolManager {
 
   constructor(protected readonly agent: Agent) {
     this.attachMcpTools();
+    if (agent.config.hasProvider) {
+      this.initializeBuiltinTools();
+    }
   }
 
   protected get toolStore(): ToolStore {

--- a/packages/agent-core/src/agent/tool/index.ts
+++ b/packages/agent-core/src/agent/tool/index.ts
@@ -403,7 +403,7 @@ export class ToolManager {
     if (uploadVideo === undefined) return undefined;
 
     const modelAlias = this.agent.config.modelAlias!;
-    const withAuth = this.agent.providerManager?.resolveAuth(modelAlias, {
+    const withAuth = this.agent.modelProvider?.resolveAuth?.(modelAlias, {
       log: this.agent.log,
     });
     if (withAuth === undefined) return (input) => uploadVideo(input);

--- a/packages/agent-core/src/agent/tool/index.ts
+++ b/packages/agent-core/src/agent/tool/index.ts
@@ -377,7 +377,7 @@ export class ToolManager {
         this.agent.cron && new b.CronCreateTool(this.agent.cron),
         this.agent.cron && new b.CronListTool(this.agent.cron),
         this.agent.cron && new b.CronDeleteTool(this.agent.cron),
-        this.agent.skills !== undefined &&
+        this.agent.skills !== null &&
           this.agent.skills.registry.listInvocableSkills().length > 0 &&
           new b.SkillTool(this.agent),
         this.agent.subagentHost &&

--- a/packages/agent-core/src/agent/tool/index.ts
+++ b/packages/agent-core/src/agent/tool/index.ts
@@ -96,7 +96,7 @@ export class ToolManager {
         return {
           approvalRule: name,
           execute: async (context) => {
-            return this.agent.rpc!.toolCall(
+            return this.agent.rpc!.toolCall!(
               {
                 turnId: Number(context.turnId),
                 toolCallId: context.toolCallId,
@@ -372,7 +372,7 @@ export class ToolManager {
           new b.ReadMediaFileTool(kaos, workspace, modelCapabilities, videoUploader),
         new b.EnterPlanModeTool(this.agent),
         new b.ExitPlanModeTool(this.agent),
-        this.agent.rpc && new b.AskUserQuestionTool(this.agent),
+        this.agent.rpc?.requestQuestion && new b.AskUserQuestionTool(this.agent),
         new b.TodoListTool(this.toolStore),
         new b.TaskListTool(background),
         new b.TaskOutputTool(background),
@@ -380,8 +380,7 @@ export class ToolManager {
         this.agent.cron && new b.CronCreateTool(this.agent.cron),
         this.agent.cron && new b.CronListTool(this.agent.cron),
         this.agent.cron && new b.CronDeleteTool(this.agent.cron),
-        this.agent.skills !== null &&
-          this.agent.skills.registry.listInvocableSkills().length > 0 &&
+        this.agent.skills?.registry.listInvocableSkills().length &&
           new b.SkillTool(this.agent),
         this.agent.subagentHost &&
           new b.AgentTool(

--- a/packages/agent-core/src/agent/turn/index.ts
+++ b/packages/agent-core/src/agent/turn/index.ts
@@ -362,7 +362,7 @@ export class TurnFlow {
     while (true) {
       signal.throwIfAborted();
       const model = this.agent.config.model;
-      const loopControl = this.agent.providerManager?.config.loopControl;
+      const loopControl = this.agent.kimiConfig?.loopControl;
       try {
         const result = await runTurn({
           turnId: String(turnId),

--- a/packages/agent-core/src/index.ts
+++ b/packages/agent-core/src/index.ts
@@ -40,8 +40,10 @@ export type {
   BackgroundTaskStatus,
 } from './tools/background/manager';
 export type { RuntimeConfig } from './runtime-types';
+export { SingleModelProvider } from './session/provider-manager';
 export type {
   BearerTokenProvider,
+  ModelProvider,
   OAuthTokenProviderResolver,
 } from './session/provider-manager';
 

--- a/packages/agent-core/src/session/index.ts
+++ b/packages/agent-core/src/session/index.ts
@@ -413,7 +413,7 @@ export class Session {
       homedir,
       skills: this.skills,
       rpc: proxyWithExtraPayload(this.rpc, { agentId: id }),
-      providerManager: this.options.providerManager,
+      modelProvider: this.options.providerManager,
       hookEngine: config.hookEngine ?? this.hookEngine,
       subagentHost:
         config.subagentHost ?? new SessionSubagentHost(this, id, this.backgroundTaskTimeoutMs()),

--- a/packages/agent-core/src/session/provider-manager.ts
+++ b/packages/agent-core/src/session/provider-manager.ts
@@ -34,7 +34,7 @@ type AuthorizedRequest = <T>(
 export class ProviderManager {
   constructor(private readonly options: ProviderManagerOptions) {}
 
-  get config(): KimiConfig {
+  private get config(): KimiConfig {
     const { config } = this.options;
     return typeof config === 'function' ? config() : config;
   }
@@ -88,7 +88,7 @@ export class ProviderManager {
     };
   }
 
-  createAuthResolverForModel(
+  resolveAuth(
     model: string,
     options?: { readonly log?: Logger },
   ): AuthorizedRequest | undefined {

--- a/packages/agent-core/src/session/provider-manager.ts
+++ b/packages/agent-core/src/session/provider-manager.ts
@@ -31,6 +31,7 @@ type AuthorizedRequest = <T>(
 ) => Promise<T>;
 
 export interface ModelProvider {
+  readonly defaultModel?: string;
   resolveProviderConfig(model: string): ResolvedRuntimeProvider;
   resolveAuth?(model: string, options?: { readonly log?: Logger }): AuthorizedRequest | undefined;
 }
@@ -40,6 +41,10 @@ export class SingleModelProvider implements ModelProvider {
     private readonly providerConfig: KosongProviderConfig,
     private readonly modelCapabilities: ModelCapability = UNKNOWN_CAPABILITY,
   ) {}
+
+  get defaultModel(): string {
+    return this.providerConfig.model;
+  }
 
   resolveProviderConfig(model: string): ResolvedRuntimeProvider {
     if (model !== this.providerConfig.model) {

--- a/packages/agent-core/src/session/provider-manager.ts
+++ b/packages/agent-core/src/session/provider-manager.ts
@@ -48,7 +48,10 @@ export class SingleModelProvider implements ModelProvider {
 
   resolveProviderConfig(model: string): ResolvedRuntimeProvider {
     if (model !== this.providerConfig.model) {
-      throw new Error(`Model "${model}" is not supported by SingleModelProvider.`);
+      throw new KimiError(
+        ErrorCodes.CONFIG_INVALID,
+        `Model "${model}" is not supported by SingleModelProvider.`,
+      );
     }
     return {
       modelCapabilities: this.modelCapabilities,

--- a/packages/agent-core/src/session/provider-manager.ts
+++ b/packages/agent-core/src/session/provider-manager.ts
@@ -14,7 +14,6 @@ export type OAuthTokenProviderResolver = (
 ) => BearerTokenProvider | undefined;
 
 export interface ResolvedRuntimeProvider {
-  readonly modelName: string;
   readonly providerName: string;
   readonly provider: KosongProviderConfig;
   readonly modelCapabilities: ModelCapability;
@@ -31,7 +30,30 @@ type AuthorizedRequest = <T>(
   request: (auth: ProviderRequestAuth) => Promise<T>,
 ) => Promise<T>;
 
-export class ProviderManager {
+export interface ModelProvider {
+  resolveProviderConfig(model: string): ResolvedRuntimeProvider;
+  resolveAuth?(model: string, options?: { readonly log?: Logger }): AuthorizedRequest | undefined;
+}
+
+export class SingleModelProvider implements ModelProvider {
+  constructor(
+    private readonly providerConfig: KosongProviderConfig,
+    private readonly modelCapabilities: ModelCapability = UNKNOWN_CAPABILITY,
+  ) {}
+
+  resolveProviderConfig(model: string): ResolvedRuntimeProvider {
+    if (model !== this.providerConfig.model) {
+      throw new Error(`Model "${model}" is not supported by SingleModelProvider.`);
+    }
+    return {
+      modelCapabilities: this.modelCapabilities,
+      providerName: 'single-model-provider',
+      provider: this.providerConfig,
+    }
+  }
+}
+
+export class ProviderManager implements ModelProvider {
   constructor(private readonly options: ProviderManagerOptions) {}
 
   private get config(): KimiConfig {
@@ -81,7 +103,6 @@ export class ProviderManager {
     );
 
     return {
-      modelName: model,
       providerName,
       provider,
       modelCapabilities: resolveModelCapabilities(alias, provider),

--- a/packages/agent-core/src/tools/builtin/collaboration/ask-user.ts
+++ b/packages/agent-core/src/tools/builtin/collaboration/ask-user.ts
@@ -104,7 +104,7 @@ export class AskUserQuestionTool implements BuiltinTool<AskUserQuestionInput> {
     }: ExecutableToolContext,
   ): Promise<ExecutableToolResult> {
     try {
-      const result = await this.agent.rpc!.requestQuestion(
+      const result = await this.agent.rpc!.requestQuestion!(
         {
           turnId: numericTurnId(turnId),
           toolCallId,

--- a/packages/agent-core/src/tools/builtin/collaboration/skill-tool.ts
+++ b/packages/agent-core/src/tools/builtin/collaboration/skill-tool.ts
@@ -105,7 +105,7 @@ export class SkillTool implements BuiltinTool<SkillToolInput> {
     }
 
     const skills = this.agent.skills;
-    if (skills === undefined) {
+    if (skills === null) {
       return errorResult(`Skill "${args.skill}" not found in the current skill listing.`);
     }
     const skill = skills.registry.getSkill(args.skill);

--- a/packages/agent-core/test/agent/compaction.test.ts
+++ b/packages/agent-core/test/agent/compaction.test.ts
@@ -1309,7 +1309,7 @@ describe('Agent compaction', () => {
       provider: CATALOGUED_PROVIDER,
       modelCapabilities: CATALOGUED_MODEL_CAPABILITIES,
     });
-    const providerManager = ctx.agent.providerManager;
+    const providerManager = ctx.agent.modelProvider;
     if (providerManager === undefined) throw new Error('Expected provider manager');
     const resolveProviderConfig = providerManager.resolveProviderConfig.bind(providerManager);
     providerManager.resolveProviderConfig = (model) => ({

--- a/packages/agent-core/test/agent/harness/agent.ts
+++ b/packages/agent-core/test/agent/harness/agent.ts
@@ -181,7 +181,7 @@ export class AgentTestContext {
       persistence,
       generate: options.generate ?? this.scriptedGenerate.generate,
       compactionStrategy: options.compactionStrategy,
-      providerManager,
+      modelProvider: providerManager,
       subagentHost: options.subagentHost,
       type: options.type,
       permission: options.permission,

--- a/packages/agent-core/test/agent/harness/agent.ts
+++ b/packages/agent-core/test/agent/harness/agent.ts
@@ -177,6 +177,7 @@ export class AgentTestContext {
     );
     this.agent = new Agent({
       runtime,
+      config: this.kimiConfig,
       rpc: this.createRpcProxy(),
       persistence,
       generate: options.generate ?? this.scriptedGenerate.generate,

--- a/packages/agent-core/test/agent/question.test.ts
+++ b/packages/agent-core/test/agent/question.test.ts
@@ -6,7 +6,7 @@ describe('Agent question', () => {
   it('roundtrips a question request through wire rpc', async () => {
     const ctx = testAgent();
 
-    const resultPromise = ctx.agent.rpc!.requestQuestion(
+    const resultPromise = ctx.agent.rpc!.requestQuestion!(
       {
         questions: [
           {
@@ -29,7 +29,7 @@ describe('Agent question', () => {
   it('sends multiple questions in one request', async () => {
     const ctx = testAgent();
 
-    const resultPromise = ctx.agent.rpc!.requestQuestion(
+    const resultPromise = ctx.agent.rpc!.requestQuestion!(
       {
         questions: [
           {

--- a/packages/agent-core/test/agent/skill-tool-manager.test.ts
+++ b/packages/agent-core/test/agent/skill-tool-manager.test.ts
@@ -51,7 +51,7 @@ function makeAgent(
     rpc,
     skills,
     persistence,
-    providerManager: testProviderManager(),
+    modelProvider: testProviderManager(),
   });
   agent.config.update({
     cwd: process.cwd(),

--- a/packages/agent-core/test/harness/runtime-provider.test.ts
+++ b/packages/agent-core/test/harness/runtime-provider.test.ts
@@ -67,7 +67,6 @@ describe('resolveRuntimeProvider model metadata', () => {
       tool_use: true,
       max_context_tokens: 1_000_000,
     });
-    expect(resolved.modelName).toBe('kimi-code/kimi-for-coding');
     expect(resolved.provider.model).toBe('kimi-for-coding');
   });
 
@@ -97,7 +96,6 @@ describe('resolveRuntimeProvider model metadata', () => {
     });
 
     expect(resolved.providerName).toBe('openai');
-    expect(resolved.modelName).toBe('gpt-alias');
     expect(resolved.provider).toMatchObject({
       type: 'openai',
       model: 'gpt-runtime',


### PR DESCRIPTION
## Summary

Decouple `Agent` from `ProviderManager` by introducing a `ModelProvider` interface, so that `Agent` can be constructed independently of a full `Session` / `ProviderManager` lifecycle.

## What changed

- **New `ModelProvider` interface** – abstracts model resolution and optional auth away from `ProviderManager`.
- **New `SingleModelProvider`** – a lightweight implementation for single-model scenarios (e.g. headless tests or standalone agents).
- **`ProviderManager` now implements `ModelProvider`** – existing session-based behavior is preserved.
- **`Agent` constructor updates:**
  - `providerManager` → `modelProvider` (type changed to `ModelProvider`).
  - `skills` is now `SkillManager | null` instead of `SkillManager | undefined`.
  - Removed unused `cronSessionDir` option.
  - Reordered fields for clarity.
- **Removed `modelName` from `ResolvedRuntimeProvider`** – callers already have the alias, so the field was redundant.
- **Auth resolver renamed** – `createAuthResolverForModel` → `resolveAuth` on `ModelProvider`.
- Tests and harnesses updated to use the new `modelProvider` field.

## Why

Previously `Agent` required a `ProviderManager` instance, which in turn needs a full `Session` setup. This made it impossible to construct a usable `Agent` outside of a session. With `ModelProvider`, `Agent` becomes independently constructable – useful for testing, sub-agents, and future headless modes.