### PR TITLE
feat(tui): support j/k navigation in non-search pickers

### DIFF
--- a/.changeset/tidy-platform-navigation.md
+++ b/.changeset/tidy-platform-navigation.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": minor
+---
+
+Add Vim-style j/k navigation to non-search TUI pickers.

--- a/apps/kimi-code/src/tui/utils/searchable-list.ts
+++ b/apps/kimi-code/src/tui/utils/searchable-list.ts
@@ -5,7 +5,8 @@
  * The component owns presentation and the keys that carry component-specific
  * meaning — Enter (submit), Esc (cancel), and ←/→ (paging in one picker, a
  * thinking toggle in another). This unit owns the keys that behave identically
- * everywhere: ↑/↓, PgUp/PgDn, and search editing.
+ * everywhere: ↑/↓, PgUp/PgDn, Vim-style j/k navigation for non-search
+ * pickers, and search editing.
  */
 
 import { fuzzyFilter, Key, matchesKey } from '@earendil-works/pi-tui';
@@ -105,6 +106,7 @@ export class SearchableList<T> {
    * Enter, Esc, and ←/→ are intentionally left to the component.
    */
   handleKey(data: string): boolean {
+    const ch = printableChar(data);
     if (matchesKey(data, Key.up)) {
       this.moveUp();
       return true;
@@ -121,6 +123,14 @@ export class SearchableList<T> {
       this.pageDown();
       return true;
     }
+    if (!this.searchable && ch === 'k') {
+      this.moveUp();
+      return true;
+    }
+    if (!this.searchable && ch === 'j') {
+      this.moveDown();
+      return true;
+    }
     if (!this.searchable) return false;
     if (matchesKey(data, Key.backspace)) {
       if (this.query.length > 0) {
@@ -129,7 +139,6 @@ export class SearchableList<T> {
       }
       return true;
     }
-    const ch = printableChar(data);
     if (isPrintableChar(ch)) {
       this.query += ch;
       this.cursor = 0;

--- a/apps/kimi-code/test/tui/utils/searchable-list.test.ts
+++ b/apps/kimi-code/test/tui/utils/searchable-list.test.ts
@@ -97,4 +97,17 @@ describe('SearchableList', () => {
     expect(search.handleKey(BACKSPACE)).toBe(true);
     expect(search.view().query).toBe('');
   });
+
+  it('supports j/k navigation for non-search pickers without stealing searchable input', () => {
+    const nav = make({ searchable: false, initialIndex: 1 });
+    expect(nav.handleKey('j')).toBe(true);
+    expect(nav.selected()).toBe('item02');
+    expect(nav.handleKey('k')).toBe(true);
+    expect(nav.selected()).toBe('item01');
+
+    const search = make({ searchable: true });
+    expect(search.handleKey('j')).toBe(true);
+    expect(search.view().query).toBe('j');
+    expect(search.selected()).toBe(search.view().items[0]);
+  });
 });


### PR DESCRIPTION
<!--
Thank you for your contribution to Kimi Code!
Please open an issue before sending a feature PR — PRs without prior discussion may be closed without review.

See https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md for more.
-->

## Related Issue

No linked issue; this fixes an inconsistency in TUI picker navigation.

## Problem

Some TUI selection popups, including the `/login` platform selector, only accepted `↑` / `↓` for navigation even though other TUI views already support Vim-style `j` / `k` movement. This made keyboard behavior inconsistent across popups.

## What changed

Added `j` / `k` navigation to the shared non-search picker list handling, using the existing printable-key decoding path so Kitty keyboard protocol input works correctly.

Searchable pickers keep `j` / `k` as search input rather than treating them as navigation, so model/provider search behavior is unchanged. The change includes focused unit coverage, a changeset for `@moonshot-ai/kimi-code`.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.
