### PR TITLE
fix(agent-core): handle cross-device ripgrep install

### DIFF
--- a/.changeset/fix-ripgrep-cross-device-install.md
+++ b/.changeset/fix-ripgrep-cross-device-install.md
@@ -1,0 +1,6 @@
+---
+"@moonshot-ai/agent-core": patch
+"@moonshot-ai/kimi-code": patch
+---
+
+Fix automatic ripgrep installation when the temporary directory is on a different filesystem.

--- a/packages/agent-core/src/tools/support/rg-locator.ts
+++ b/packages/agent-core/src/tools/support/rg-locator.ts
@@ -14,9 +14,9 @@
 
 import { createHash } from 'node:crypto';
 import { createWriteStream, existsSync } from 'node:fs';
-import { chmod, mkdir, mkdtemp, readFile, rename, rm, stat } from 'node:fs/promises';
+import { chmod, copyFile, mkdir, mkdtemp, readFile, rename, rm, stat } from 'node:fs/promises';
 import { homedir, tmpdir } from 'node:os';
-import { basename, join } from 'pathe';
+import { basename, dirname, join } from 'pathe';
 import { Readable } from 'node:stream';
 import { pipeline } from 'node:stream/promises';
 
@@ -243,13 +243,42 @@ async function downloadAndInstallRg(shareDir: string): Promise<string> {
             'CDN content may have changed.',
         );
       }
-      await rename(extracted, destination);
-      await chmod(destination, 0o755);
+      await installExtractedRg(extracted, destination);
     }
     return destination;
   } finally {
     await rm(tmp, { recursive: true, force: true });
   }
+}
+
+/** @internal for tests — install an extracted rg binary into the persistent bin dir. */
+export async function installExtractedRg(extracted: string, destination: string): Promise<void> {
+  try {
+    await rename(extracted, destination);
+    await chmod(destination, 0o755);
+    return;
+  } catch (error) {
+    if (!isCrossDeviceRenameError(error)) throw error;
+  }
+
+  const stagingDir = await mkdtemp(join(dirname(destination), '.rg-install-'));
+  const staged = join(stagingDir, basename(destination));
+  try {
+    await copyFile(extracted, staged);
+    await chmod(staged, 0o755);
+    await rename(staged, destination);
+  } finally {
+    await rm(stagingDir, { recursive: true, force: true });
+  }
+}
+
+function isCrossDeviceRenameError(error: unknown): boolean {
+  return (
+    typeof error === 'object' &&
+    error !== null &&
+    'code' in error &&
+    (error as { readonly code?: unknown }).code === 'EXDEV'
+  );
 }
 
 /** @internal for tests — fail closed before extracting downloaded bytes. */

--- a/packages/agent-core/test/tools/rg-locator.test.ts
+++ b/packages/agent-core/test/tools/rg-locator.test.ts
@@ -9,7 +9,15 @@
  */
 
 import { createHash } from 'node:crypto';
-import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync, chmodSync } from 'node:fs';
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from 'node:fs';
 import type * as FsPromises from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'pathe';
@@ -166,6 +174,91 @@ describe('verifyArchiveChecksum', () => {
     await expect(
       verifyArchiveChecksum(archivePath, 'archive.tar.gz', '0'.repeat(64)),
     ).rejects.toThrow(/checksum mismatch/);
+  });
+});
+
+describe('installExtractedRg', () => {
+  let fakeDir: string;
+  beforeEach(() => {
+    fakeDir = join(
+      tmpdir(),
+      `kimi-rg-install-${String(Date.now())}-${String(Math.random()).slice(2)}`,
+    );
+    mkdirSync(fakeDir, { recursive: true });
+  });
+  afterEach(() => {
+    rmSync(fakeDir, { recursive: true, force: true });
+    vi.doUnmock('node:fs/promises');
+    vi.resetModules();
+    vi.restoreAllMocks();
+  });
+
+  it('falls back to a target-side staged copy when rename crosses devices', async () => {
+    const extractDir = join(fakeDir, 'extract');
+    const binDir = join(fakeDir, 'bin');
+    const extracted = join(extractDir, 'rg');
+    const destination = join(binDir, 'rg');
+    const payload = '#!/bin/sh\necho ripgrep\n';
+    mkdirSync(extractDir, { recursive: true });
+    mkdirSync(binDir, { recursive: true });
+    writeFileSync(extracted, payload);
+    const renameCalls: Array<[string, string]> = [];
+
+    vi.resetModules();
+    vi.doMock('node:fs/promises', async () => {
+      const actual = await vi.importActual<typeof FsPromises>('node:fs/promises');
+      return {
+        ...actual,
+        rename: async (from: string, to: string) => {
+          renameCalls.push([from, to]);
+          if (from === extracted && to === destination) {
+            throw Object.assign(new Error('cross-device rename'), { code: 'EXDEV' });
+          }
+          return actual.rename(from, to);
+        },
+      };
+    });
+
+    const { installExtractedRg } = await import('../../src/tools/support/rg-locator');
+
+    await installExtractedRg(extracted, destination);
+
+    expect(readFileSync(destination, 'utf8')).toBe(payload);
+    expect(renameCalls).toHaveLength(2);
+    expect(renameCalls[0]).toEqual([extracted, destination]);
+    expect(renameCalls[1]?.[0]).toContain(join(binDir, '.rg-install-'));
+    expect(renameCalls[1]?.[1]).toBe(destination);
+    if (process.platform !== 'win32') {
+      expect(statSync(destination).mode & 0o777).toBe(0o755);
+    }
+  });
+
+  it('does not mask non-EXDEV rename failures', async () => {
+    const extractDir = join(fakeDir, 'extract');
+    const binDir = join(fakeDir, 'bin');
+    const extracted = join(extractDir, 'rg');
+    const destination = join(binDir, 'rg');
+    mkdirSync(extractDir, { recursive: true });
+    mkdirSync(binDir, { recursive: true });
+    writeFileSync(extracted, 'rg bytes');
+
+    vi.resetModules();
+    vi.doMock('node:fs/promises', async () => {
+      const actual = await vi.importActual<typeof FsPromises>('node:fs/promises');
+      return {
+        ...actual,
+        rename: async () => {
+          throw Object.assign(new Error('permission denied'), { code: 'EACCES' });
+        },
+      };
+    });
+
+    const { installExtractedRg } = await import('../../src/tools/support/rg-locator');
+
+    await expect(installExtractedRg(extracted, destination)).rejects.toMatchObject({
+      code: 'EACCES',
+    });
+    expect(existsSync(destination)).toBe(false);
   });
 });
 


### PR DESCRIPTION
## Related Issue

Resolve #111

## Problem

When ripgrep is not available on `PATH`, Kimi Code downloads and extracts a managed `rg` binary before installing it into the user cache directory. On systems where the temporary directory and the Kimi Code cache directory are on different filesystems, the final `rename()` from the extracted file under `/tmp` to `<KIMI_CODE_HOME>/bin/rg` fails with `EXDEV`.

This makes the automatic ripgrep bootstrap fail even though the download, checksum verification, and extraction have already succeeded.

## What changed

The install step now keeps the existing fast path and still tries to `rename()` the extracted binary directly first.

If that direct rename fails specifically with `EXDEV`, it falls back to copying the extracted binary into a staging directory next to the final destination, applies executable permissions there, and then renames the staged file into place on the same filesystem.

Other rename failures are still surfaced unchanged, so permission errors, missing files, and other unexpected install problems are not hidden by the fallback.

Tests were added for both the `EXDEV` fallback path and the non-`EXDEV` error path.

## Validation

- Reproduced the original `EXDEV` failure locally on Arch Linux by clearing `PATH`, forcing the real CDN bootstrap path, and installing into a temporary `shareDir` on a different device from `/tmp`. The pre-fix flow downloaded, verified, and extracted ripgrep successfully, then failed on the final cross-device `rename()`.
- Re-ran the same real CDN bootstrap scenario after the fix with `/tmp` and the target `shareDir` still on different devices; `ensureRgPath()` returned `share-bin-downloaded` and installed `rg` successfully.
- `pnpm exec vitest run test/tools/rg-locator.test.ts`
- `pnpm run typecheck` in `packages/agent-core`
- `pnpm exec oxlint --type-aware packages/agent-core/src/tools/support/rg-locator.ts packages/agent-core/test/tools/rg-locator.test.ts`
- Manual CDN end-to-end verification with `PATH` cleared and `/tmp` on a different device from the target `shareDir`

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.
