### PR TITLE
test(agent-core): use deterministic jitter id in cron pending-jitter test

### DIFF
--- a/packages/agent-core/test/tools/cron/cron-list.test.ts
+++ b/packages/agent-core/test/tools/cron/cron-list.test.ts
@@ -308,10 +308,15 @@ describe('CronListTool', () => {
     anchor.setMinutes(Math.floor(anchor.getMinutes() / 5) * 5);
     harness.setNow(anchor.getTime());
 
-    manager.store.add(
-      { cron: '*/5 * * * *', prompt: 'pending-jitter', recurring: true },
-      harness.now(),
-    );
+    manager.store.adopt({
+      // Use a high deterministic jitter id so advancing 1 s past the
+      // ideal fire remains inside the pending jitter window.
+      id: 'ffffffff',
+      cron: '*/5 * * * *',
+      prompt: 'pending-jitter',
+      recurring: true,
+      createdAt: harness.now(),
+    });
 
     // Advance 5 min + 1 s — past the next ideal but inside the 30 s
     // jitter cap.


### PR DESCRIPTION
## Summary

Fixes a flaky cron test by using a deterministic high jitter id, ensuring the test remains inside the pending jitter window when time is advanced past the ideal fire time.

---

### 1. Fix flaky pending-jitter test

**Problem:** The `CronListTool` pending-jitter test relied on `store.add()` which generates a random jitter id. Depending on the random id, advancing 5 min + 1 s could fall outside the jitter window, causing flaky failures.

**What was done:**
- Replaced `store.add()` with `store.adopt()` and explicitly set `id: 'ffffffff'`.
- This guarantees a high deterministic jitter id so that advancing 1 s past the ideal fire time always remains inside the 30 s jitter cap.
- Preserved the `createdAt` and other task fields.

---

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [ ] I have linked the related issue, if any.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] Ran `gen-changesets` skill, or this PR needs no changeset.
- [ ] Ran `gen-docs` skill, or this PR needs no doc update.
