### PR TITLE
ci(release): fix Node.js version shadowed by Nix PATH

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,6 +28,11 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@v6
 
+      # Nix must be installed before setup-node so that setup-node's PATH
+      # entry (Node >= 24) is prepended after Nix's, keeping Node 24 first.
+      - name: Install Nix
+        uses: DeterminateSystems/nix-installer-action@main
+
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
@@ -50,9 +55,6 @@ jobs:
 
       - name: Build packages
         run: pnpm build
-
-      - name: Install Nix
-        uses: DeterminateSystems/nix-installer-action@main
 
       - name: Create Release Pull Request or Publish to npm
         id: changesets


### PR DESCRIPTION
## Related Issue

N/A — This is a hotfix for a failing release workflow.

## Problem

The `release` workflow installs Nix after `actions/setup-node`. Nix's installation prepends `/nix/var/nix/profiles/default/bin` to `PATH`, which shadows the Node.js v24.15.0 installed by setup-node with Nix's own Node v22.22.3.

When `changesets/action@v1` later runs `pnpm run version:release`, `pnpm` detects Node v22.22.3 and fails with `ERR_PNPM_UNSUPPORTED_ENGINE` because the monorepo requires `node >=24.15.0` (via `engines.node` + `engine-strict=true` in `.npmrc`).

Example failed run: https://github.com/MoonshotAI/kimi-code/actions/runs/26617979564/job/78437636496

## What changed

Reordered the workflow steps so that `Install Nix` runs **before** `Setup Node.js`. Since `core.addPath()` prepends to `PATH`, this ensures the Node.js v24.15.0 path comes **after** Nix's path, keeping Node 24 first in `PATH` and resolving the version conflict.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [ ] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.
