### PR TITLE
refactor(agent-core): slim llm request log line

### DIFF
--- a/.changeset/slim-llm-request-log.md
+++ b/.changeset/slim-llm-request-log.md
@@ -1,0 +1,6 @@
+---
+"@moonshot-ai/agent-core": patch
+"@moonshot-ai/kimi-code": patch
+---
+
+Slim the LLM diagnostic logs with fewer, more compact fields.

--- a/packages/agent-core/src/agent/index.ts
+++ b/packages/agent-core/src/agent/index.ts
@@ -221,9 +221,23 @@ export class Agent {
       configMetadata,
       buildLlmConfigSignature(configMetadata, systemPrompt, tools),
     );
+
+    let partialMessageCount = 0;
+    for (const message of history) {
+      if (message.partial === true) partialMessageCount += 1;
+    }
+    const requestMetadata: LlmRequestMetadata = {
+      estimatedInputTokens:
+        estimateTokens(systemPrompt) +
+        estimateTokensForMessages(history) +
+        estimateTokensForTools(tools),
+    };
+    if (partialMessageCount > 0) {
+      requestMetadata.partialMessageCount = partialMessageCount;
+    }
     this.log.info('llm request', {
       ...context,
-      ...buildLlmRequestMetadata(systemPrompt, tools, history),
+      ...requestMetadata,
     });
   }
 
@@ -414,16 +428,12 @@ export class Agent {
 }
 
 interface LlmRequestContextFields {
-  turnId?: string;
-  step?: number;
-  attempt?: number;
-  maxAttempts?: number;
+  turnStep?: string;
+  attempt?: string;
 }
 
 interface LlmRequestMetadata {
   estimatedInputTokens: number;
-  messageCount: number;
-  toolCallCount: number;
   partialMessageCount?: number;
 }
 
@@ -447,47 +457,19 @@ function buildLlmRequestContext(options: Parameters<typeof generate>[5]): LlmReq
   if (context === undefined) return {};
 
   const fields: LlmRequestContextFields = {
-    turnId: context.turnId,
-    step: context.step,
+    turnStep:
+      context.turnId === undefined || context.step === undefined
+        ? undefined
+        : `${context.turnId}.${String(context.step)}`,
   };
   if (
     context.attempt !== undefined &&
     context.maxAttempts !== undefined &&
     context.attempt > 1
   ) {
-    fields.attempt = context.attempt;
-    fields.maxAttempts = context.maxAttempts;
+    fields.attempt = `${String(context.attempt)}/${String(context.maxAttempts)}`;
   }
   return fields;
-}
-
-function buildLlmRequestMetadata(
-  systemPrompt: string,
-  tools: readonly Tool[],
-  history: readonly Message[],
-): LlmRequestMetadata {
-  let toolCallCount = 0;
-  let partialMessageCount = 0;
-
-  for (const message of history) {
-    if (message.partial === true) partialMessageCount += 1;
-    toolCallCount += message.toolCalls.length;
-  }
-
-  const estimatedInputTokens =
-    estimateTokens(systemPrompt) +
-    estimateTokensForMessages(history) +
-    estimateTokensForTools(tools);
-
-  const metadata: LlmRequestMetadata = {
-    estimatedInputTokens,
-    messageCount: history.length,
-    toolCallCount,
-  };
-  if (partialMessageCount > 0) {
-    metadata.partialMessageCount = partialMessageCount;
-  }
-  return metadata;
 }
 
 function buildLlmConfigMetadata(

--- a/packages/agent-core/src/loop/retry.ts
+++ b/packages/agent-core/src/loop/retry.ts
@@ -75,10 +75,8 @@ function logRequestFailure(
 ): void {
   if (isAbortError(error) || input.params.signal.aborted) return;
   input.log?.warn('llm request failed', {
-    turnId: input.turnId,
-    step: input.currentStep,
-    attempt,
-    maxAttempts,
+    turnStep: `${input.turnId}.${String(input.currentStep)}`,
+    attempt: `${String(attempt)}/${String(maxAttempts)}`,
     model: input.llm.modelName,
     ...retryErrorFields(error),
   });

--- a/packages/agent-core/test/agent/turn.test.ts
+++ b/packages/agent-core/test/agent/turn.test.ts
@@ -718,8 +718,7 @@ describe('Agent turn flow', () => {
     expect(configLogs).toHaveLength(1);
     const configPayload = configLogs[0]?.payload as Record<string, unknown>;
     expect(configPayload).toMatchObject({
-      turnId: '0',
-      step: 1,
+      turnStep: '0.1',
       provider: 'kimi',
       model: 'mock-model',
       modelAlias: 'mock-model',
@@ -731,12 +730,11 @@ describe('Agent turn flow', () => {
     expect(requestLogs).toHaveLength(1);
     const payload = requestLogs[0]?.payload as Record<string, unknown>;
     expect(payload).toMatchObject({
-      turnId: '0',
-      step: 1,
-      messageCount: 1,
-      toolCallCount: 0,
+      turnStep: '0.1',
     });
     expect(payload['estimatedInputTokens']).toEqual(expect.any(Number));
+    expect(payload).not.toHaveProperty('turnId');
+    expect(payload).not.toHaveProperty('step');
     expect(payload).not.toHaveProperty('attempt');
     expect(payload).not.toHaveProperty('maxAttempts');
     expect(payload).not.toHaveProperty('stepUuid');
@@ -746,6 +744,8 @@ describe('Agent turn flow', () => {
     expect(payload).not.toHaveProperty('thinkingEffort');
     expect(payload).not.toHaveProperty('systemPromptChars');
     expect(payload).not.toHaveProperty('partialMessageCount');
+    expect(payload).not.toHaveProperty('messageCount');
+    expect(payload).not.toHaveProperty('toolCallCount');
     expect(payload).not.toHaveProperty('toolCount');
     expect(payload).not.toHaveProperty('systemPromptHash');
     expect(payload).not.toHaveProperty('toolsHash');
@@ -1152,10 +1152,10 @@ describe('Agent turn flow', () => {
       }),
     );
     const requestLogs = entries.filter((entry) => entry.message === 'llm request');
-    expect(requestLogs.map((entry) => entry.payload)).toEqual([
-      expect.not.objectContaining({ attempt: expect.any(Number), maxAttempts: expect.any(Number) }),
-      expect.objectContaining({ attempt: 2, maxAttempts: 3 }),
-    ]);
+    const payloads = requestLogs.map((entry) => entry.payload as Record<string, unknown>);
+    expect(payloads[0]).toMatchObject({ turnStep: '0.1' });
+    expect(payloads[0]).not.toHaveProperty('attempt');
+    expect(payloads[1]).toMatchObject({ turnStep: '0.1', attempt: '2/3' });
   });
 
   it('force-refreshes OAuth credentials on video upload 401 and falls back to login_required when replay 401', async () => {

--- a/packages/agent-core/test/loop/error-paths.e2e.test.ts
+++ b/packages/agent-core/test/loop/error-paths.e2e.test.ts
@@ -57,10 +57,8 @@ describe('runTurn — error paths', () => {
         level: 'warn',
         message: 'llm request failed',
         payload: {
-          turnId: 'turn-1',
-          step: 1,
-          attempt: 1,
-          maxAttempts: 3,
+          turnStep: 'turn-1.1',
+          attempt: '1/3',
           model: 'fake-model',
           errorName: 'Error',
           errorMessage: 'upstream blew up',


### PR DESCRIPTION
## Related Issue

No prior issue. Opening directly per CONTRIBUTING's "can open a PR directly" path — this is a small, focused refactor (~94 lines, under the ~100-line threshold) that touches diagnostic log output only, not product-user-visible behavior. Problem described below.

## Problem

The high-frequency `llm request` diagnostic log line carried up to 8 fields per request (`turnId`, `step`, `attempt`, `maxAttempts`, `estimatedInputTokens`, `messageCount`, `toolCallCount`, `partialMessageCount`), making it wide and noisy.

## What changed

Slim the per-request `llm request` line down to ~3 fields:

- Merge `turnId` + `step` → `turnStep` (e.g. `"0.1"`)
- Merge `attempt` + `maxAttempts` → `attempt` (e.g. `"2/3"`, only emitted on retries)
- Drop `messageCount` and `toolCallCount`

The deduplicated `llm config` line is unchanged (still includes `thinkingEffort` for all providers). The same `turnStep`/`attempt` formatting is applied to the `llm request failed` line in the retry path for consistency.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above. _(Explained above; no issue.)_
- [x] I have added tests that prove my feature works. _(Updated `turn.test.ts` and `error-paths.e2e.test.ts` to assert the slimmed field shape.)_
- [x] Ran `gen-changesets` skill, or this PR needs no changeset. _(Added `.changeset/slim-llm-request-log.md` — patch bump for `@moonshot-ai/agent-core` + `@moonshot-ai/kimi-code`.)_
- [x] Ran `gen-docs` skill, or this PR needs no doc update. _(Internal log format; no user-facing docs affected.)_