### PR TITLE
fix(agent-core): handle ripgrep cross-device install

### DIFF
--- a/.changeset/fix-ripgrep-cross-device-copy.md
+++ b/.changeset/fix-ripgrep-cross-device-copy.md
@@ -1,0 +1,6 @@
+---
+"@moonshot-ai/agent-core": patch
+"@moonshot-ai/kimi-code": patch
+---
+
+Fix automatic ripgrep installation when temporary files are on another filesystem.

--- a/packages/agent-core/src/tools/support/rg-locator.ts
+++ b/packages/agent-core/src/tools/support/rg-locator.ts
@@ -14,7 +14,7 @@
 
 import { createHash } from 'node:crypto';
 import { createWriteStream, existsSync } from 'node:fs';
-import { chmod, mkdir, mkdtemp, readFile, rename, rm, stat } from 'node:fs/promises';
+import { chmod, copyFile, mkdir, mkdtemp, readFile, rename, rm, stat } from 'node:fs/promises';
 import { homedir, tmpdir } from 'node:os';
 import { basename, join } from 'pathe';
 import { Readable } from 'node:stream';
@@ -243,8 +243,15 @@ async function downloadAndInstallRg(shareDir: string): Promise<string> {
             'CDN content may have changed.',
         );
       }
-      await rename(extracted, destination);
-      await chmod(destination, 0o755);
+      const installDir = await mkdtemp(join(binDir, '.rg-install-'));
+      const staged = join(installDir, rgBinaryName());
+      try {
+        await copyFile(extracted, staged);
+        await chmod(staged, 0o755);
+        await rename(staged, destination);
+      } finally {
+        await rm(installDir, { recursive: true, force: true });
+      }
     }
     return destination;
   } finally {


### PR DESCRIPTION
## Related Issue

Resolves #111

## Problem

When ripgrep is not available on PATH, the automatic bootstrap extracts `rg` under the system temporary directory and then installs it under the Kimi Code home directory. A direct `rename` fails with `EXDEV` when those directories are on different filesystems.

## What changed

Copy the extracted Unix ripgrep binary into a temporary install directory under the target bin directory, apply executable permissions there, then rename it into the final cache path on the same filesystem. This avoids cross-device rename failures while keeping the final cache path from exposing a partial binary.

Added a patch changeset for the agent-core change that enters the CLI bundle.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [ ] I have added tests that prove my feature works. Existing rg-locator tests were run; no new test was added for this small filesystem install-path change.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.