### PR TITLE
chore(agent-core): move tool services type

### DIFF
--- a/.changeset/tool-support-services.md
+++ b/.changeset/tool-support-services.md
@@ -1,0 +1,6 @@
+---
+"@moonshot-ai/agent-core": patch
+"@moonshot-ai/kimi-code": patch
+---
+
+Relocate shared tool service typing to the tool support layer.

--- a/packages/agent-core/src/agent/index.ts
+++ b/packages/agent-core/src/agent/index.ts
@@ -17,7 +17,6 @@ import type { EnabledPluginSessionStart } from '#/plugin';
 import type { McpConnectionManager } from '../mcp';
 import type { PreparedSystemPromptContext, ResolvedAgentProfile } from '../profile';
 import type { ModelProvider } from '../session/provider-manager';
-import type { ToolServices } from '../runtime-types';
 import type { SessionSubagentHost } from '../session/subagent-host';
 import type { SkillRegistry } from '../skill';
 import { noopTelemetryClient, type TelemetryClient } from '../telemetry';
@@ -55,6 +54,7 @@ import {
 import { UsageRecorder } from './usage';
 import { resolveCompletionBudget } from '../utils/completion-budget';
 import type { Kaos } from '@moonshot-ai/kaos';
+import type { ToolServices } from '../tools/support/services';
 
 export type { AgentRecord, AgentRecordPersistence } from './records';
 export type { BuiltinTool, ToolInfo, ToolSource, UserToolRegistration } from './tool';

--- a/packages/agent-core/src/index.ts
+++ b/packages/agent-core/src/index.ts
@@ -39,7 +39,7 @@ export type {
   BackgroundTaskKind,
   BackgroundTaskStatus,
 } from './tools/background/manager';
-export type { ToolServices } from './runtime-types';
+export type { ToolServices } from './tools/support/services';
 export { SingleModelProvider } from './session/provider-manager';
 export type {
   BearerTokenProvider,

--- a/packages/agent-core/src/rpc/core-impl.ts
+++ b/packages/agent-core/src/rpc/core-impl.ts
@@ -22,7 +22,6 @@ import {
 } from '../config';
 import type { Logger } from '../logging/types';
 import { resolveSessionMcpConfig, type SessionMcpConfig } from '../mcp';
-import type { ToolServices } from '../runtime-types';
 import { Session, type SessionMeta, type SessionSkillConfig } from '../session';
 import { exportSessionDirectory } from '../session/export';
 import {
@@ -84,6 +83,7 @@ import type { ResumedAgentState, ResumeSessionResult } from './resumed';
 import type { SDKRPC } from './sdk-api';
 import { proxyWithExtraPayload } from './types';
 import { KaosShellNotFoundError, LocalKaos, type Kaos } from '@moonshot-ai/kaos';
+import type { ToolServices } from '../tools/support/services';
 
 const KIMI_CODE_PROVIDER_NAME = 'managed:kimi-code';
 

--- a/packages/agent-core/src/runtime-types.ts
+++ b/packages/agent-core/src/runtime-types.ts
@@ -1,6 +1,0 @@
-import type { UrlFetcher, WebSearchProvider } from './tools/builtin';
-
-export interface ToolServices {
-  readonly urlFetcher?: UrlFetcher | undefined;
-  readonly webSearcher?: WebSearchProvider | undefined;
-}

--- a/packages/agent-core/src/session/index.ts
+++ b/packages/agent-core/src/session/index.ts
@@ -28,7 +28,6 @@ import {
   type ResolvedAgentProfile,
 } from '../profile';
 import type { ProviderManager } from './provider-manager';
-import type { ToolServices } from '../runtime-types';
 import {
   registerBuiltinSkills,
   resolveSkillRoots,
@@ -39,6 +38,7 @@ import {
 } from '../skill';
 import { noopTelemetryClient, type TelemetryClient } from '../telemetry';
 import { SessionSubagentHost } from './subagent-host';
+import type { ToolServices } from '../tools/support/services';
 
 export interface SessionOptions {
   readonly kaos: Kaos;

--- a/packages/agent-core/src/tools/support/services.ts
+++ b/packages/agent-core/src/tools/support/services.ts
@@ -1,0 +1,6 @@
+import type { UrlFetcher, WebSearchProvider } from '../builtin';
+
+export interface ToolServices {
+  readonly urlFetcher?: UrlFetcher;
+  readonly webSearcher?: WebSearchProvider;
+}

--- a/packages/agent-core/test/agent/harness/agent.ts
+++ b/packages/agent-core/test/agent/harness/agent.ts
@@ -24,7 +24,7 @@ import type { Logger } from '../../../src/logging';
 import { ProviderManager } from '../../../src/session/provider-manager';
 import type { QuestionResult, RPCCallOptions, SDKAgentRPC } from '../../../src/rpc';
 import type { AgentAPI } from '../../../src/rpc/core-api';
-import type { ToolServices } from '../../../src/runtime-types';
+import type { ToolServices } from '../../../src/tools/support/services';
 import type { TelemetryClient } from '../../../src/telemetry';
 import type { PromisifyMethods } from '../../../src/utils/types';
 import { createFakeKaos } from '../../tools/fixtures/fake-kaos';


### PR DESCRIPTION
## Related Issue

No linked issue.

## Problem

The shared tool service typing lived in a root-level runtime types module even though it is only used to wire built-in tool support through agent, session, and RPC paths. Moving it under tool support keeps the type near the code that owns those services while preserving the root public export.

## What changed

Updated agent-core imports and the root type export to read shared tool service typing from the tool support layer, removed the old runtime types module, and updated the agent test harness import. Added a patch changeset for agent-core and the CLI bundle.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] Existing agent-core tests cover this internal type relocation; no new behavior test is needed.
- [x] Ran `gen-changesets` skill and added `.changeset/tool-support-services.md`.
- [x] This PR needs no doc update because it does not affect CLI behavior or user documentation.