### PR TITLE
fix: recover from model token limit errors

### DIFF
--- a/.changeset/retry-model-token-limit.md
+++ b/.changeset/retry-model-token-limit.md
@@ -1,0 +1,7 @@
+---
+"@moonshot-ai/agent-core": patch
+"@moonshot-ai/kosong": patch
+"@moonshot-ai/kimi-code": patch
+---
+
+Recover from provider model token limit errors during long conversations.

--- a/packages/agent-core/src/agent/compaction/full.ts
+++ b/packages/agent-core/src/agent/compaction/full.ts
@@ -46,6 +46,7 @@ export class FullCompaction {
     startedAt: number;
     telemetryTrigger: CompactionTelemetryTrigger;
     promise: Promise<void>;
+    blockedByTurn: boolean;
   } | null = null;
   protected _compactedHistory: CompactedHistory[] = [];
   protected readonly strategy: CompactionStrategy;
@@ -112,6 +113,7 @@ export class FullCompaction {
       startedAt: Date.now(),
       telemetryTrigger: compactionTelemetryTrigger(data.source, data.instruction),
       promise: Promise.resolve(),
+      blockedByTurn: false,
     };
     this.compacting = active;
     active.promise = this.compactionWorker(abortController.signal, data, compactedCount);
@@ -195,6 +197,7 @@ export class FullCompaction {
   private async block(signal: AbortSignal): Promise<void> {
     const active = this.compacting;
     if (active) {
+      active.blockedByTurn = true;
       signal.addEventListener('abort', () => {
         if (this.compacting === active) {
           this.cancel();
@@ -312,19 +315,23 @@ export class FullCompaction {
       this.triggerPostCompactHook(data, result);
     } catch (error) {
       if (!isAbortError(error)) {
+        const active = this.compacting;
+        const blockedByTurn = active?.blockedByTurn === true;
         this.agent.log.error('compaction failed', {
           code: isKimiError(error) ? error.code : undefined,
           error,
         });
         this.markCanceled();
-        const payload =
-          isKimiError(error) && error.code === ErrorCodes.AUTH_LOGIN_REQUIRED
-            ? toKimiErrorPayload(error)
-            : makeErrorPayload(ErrorCodes.COMPACTION_FAILED, String(error));
-        this.agent.emitEvent({
-          type: 'error',
-          ...payload,
-        });
+        if (!blockedByTurn) {
+          const payload =
+            isKimiError(error) && error.code === ErrorCodes.AUTH_LOGIN_REQUIRED
+              ? toKimiErrorPayload(error)
+              : makeErrorPayload(ErrorCodes.COMPACTION_FAILED, String(error));
+          this.agent.emitEvent({
+            type: 'error',
+            ...payload,
+          });
+        }
         this.agent.telemetry.track('compaction_failed', {
           trigger_type: compactionTelemetryTrigger(data.source, data.instruction),
           before_tokens: tokensBefore,
@@ -332,6 +339,10 @@ export class FullCompaction {
           retry_count: retryCount,
           error_type: error instanceof Error ? error.name : 'Unknown',
         });
+        if (blockedByTurn) {
+          if (isKimiError(error) && error.code === ErrorCodes.AUTH_LOGIN_REQUIRED) throw error;
+          throw new KimiError(ErrorCodes.COMPACTION_FAILED, String(error), { cause: error });
+        }
       }
     }
   }

--- a/packages/agent-core/test/agent/compaction.test.ts
+++ b/packages/agent-core/test/agent/compaction.test.ts
@@ -636,6 +636,45 @@ describe('Agent compaction', () => {
     await ctx.expectResumeMatches();
   });
 
+  it('fails a blocked turn when auto compaction generation fails', async () => {
+    let attempts = 0;
+    const generate: GenerateFn = async () => {
+      attempts += 1;
+      throw new APIStatusError(400, 'Bad request');
+    };
+    const ctx = testAgent({ generate, compactionStrategy: alwaysCompactOnce });
+    ctx.configure();
+
+    await ctx.rpc.prompt({ input: [{ type: 'text', text: 'Trigger failed auto compaction' }] });
+    const events = await ctx.untilTurnEnd();
+
+    expect(attempts).toBe(1);
+    expect(events).not.toContainEqual(expect.objectContaining({ event: 'error' }));
+    expect(events).toContainEqual(
+      expect.objectContaining({
+        event: 'turn.ended',
+        args: {
+          turnId: 0,
+          reason: 'failed',
+          error: expect.objectContaining({
+            code: 'compaction.failed',
+            message: 'APIStatusError: Bad request',
+          }),
+        },
+      }),
+    );
+    const errorEvents = ctx.newEvents();
+    expect(errorEvents).toHaveLength(1);
+    expect(errorEvents[0]).toMatchObject({
+      event: 'error',
+      args: expect.objectContaining({
+        code: 'compaction.failed',
+        message: 'APIStatusError: Bad request',
+      }),
+    });
+    await ctx.expectResumeMatches();
+  });
+
   it('reports compaction retry_count when retryable generation failures are exhausted', async () => {
     vi.useFakeTimers();
     const records: TelemetryRecord[] = [];

--- a/packages/kosong/src/errors.ts
+++ b/packages/kosong/src/errors.ts
@@ -82,6 +82,7 @@ const CONTEXT_OVERFLOW_MESSAGE_PATTERNS = [
   /(?:too many tokens.*(?:prompt|input|context)|(?:prompt|input|context).*too many tokens)/,
   /prompt is too long.*maximum/,
   /input token count.*exceeds?.*maximum number of tokens/,
+  /request.*exceed(?:ed|s|ing)?.*model token limit/,
 ] as const;
 
 export function normalizeAPIStatusError(

--- a/packages/kosong/test/errors.test.ts
+++ b/packages/kosong/test/errors.test.ts
@@ -154,6 +154,7 @@ describe('normalizeAPIStatusError', () => {
     [422, 'Too many tokens in prompt'],
     [400, 'prompt is too long: 210000 tokens exceeds the maximum'],
     [400, 'input token count 131072 exceeds the maximum number of tokens allowed'],
+    [400, 'Invalid request: Your request exceeded model token limit: 262144 (requested: 274613)'],
   ])('normalizes %i "%s" to APIContextOverflowError', (statusCode, message) => {
     const error = normalizeAPIStatusError(statusCode, message, 'req-context');
     expect(error).toBeInstanceOf(APIContextOverflowError);


### PR DESCRIPTION
## Related Issue

No linked issue. This fixes a reproducible long-conversation failure where a provider reports context overflow as a generic 400 model token limit error.

## Problem

Some providers return context overflow as `Your request exceeded model token limit` instead of the context overflow phrases Kimi already recognized. Kimi treated that response as a non-retryable provider API error, so compaction did not shrink and retry the request. When a turn was blocked waiting for auto compaction and compaction ultimately failed, the turn could then continue with the original oversized context and surface a second provider error.

## What changed

- Classify provider `model token limit` 400 responses as context overflow so the existing compaction recovery path can handle them.
- Propagate blocked auto-compaction failures back to the waiting turn instead of continuing with the uncompressed context.
- Add regression coverage for both the provider error normalization and blocked auto-compaction failure path.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.

## Validation

- `pnpm vitest run packages/kosong/test/errors.test.ts`
- `pnpm vitest run packages/agent-core/test/agent/compaction.test.ts`
- `pnpm --filter @moonshot-ai/kosong run typecheck`
- `pnpm --filter @moonshot-ai/agent-core run typecheck`
- `pnpm exec oxlint --type-aware packages/kosong/src/errors.ts packages/kosong/test/errors.test.ts packages/agent-core/src/agent/compaction/full.ts packages/agent-core/test/agent/compaction.test.ts`
- `pnpm --filter @moonshot-ai/agent-core run test`
- `pnpm vitest run packages/kosong/test`
- `git diff --check`
