### PR TITLE
fix: back off compaction overflow retries by token budget

### DIFF
--- a/.changeset/compact-overflow-retry-budget.md
+++ b/.changeset/compact-overflow-retry-budget.md
@@ -1,0 +1,6 @@
+---
+"@moonshot-ai/agent-core": patch
+"@moonshot-ai/kimi-code": patch
+---
+
+Back off failed compaction retries by a fixed slice of the model context window.

--- a/packages/agent-core/src/agent/compaction/strategy.ts
+++ b/packages/agent-core/src/agent/compaction/strategy.ts
@@ -10,6 +10,7 @@ export interface CompactionConfig {
   maxRecentMessages: number;
   maxRecentUserMessages: number;
   maxRecentSizeRatio: number;
+  minOverflowReductionRatio: number;
 }
 
 export const DEFAULT_COMPACTION_CONFIG: CompactionConfig = {
@@ -20,6 +21,7 @@ export const DEFAULT_COMPACTION_CONFIG: CompactionConfig = {
   maxRecentMessages: 4,
   maxRecentUserMessages: Infinity,
   maxRecentSizeRatio: 0.2,
+  minOverflowReductionRatio: 0.05,
 };
 
 export interface CompactionStrategy {
@@ -117,12 +119,23 @@ export class DefaultCompactionStrategy implements CompactionStrategy {
   }
 
   reduceCompactOnOverflow(messages: readonly Message[]): number {
+    const minReducedSize = Math.max(
+      1,
+      Math.ceil(this.maxSize * this.config.minOverflowReductionRatio),
+    );
+    let reducedSize = 0;
+    let bestN: number | undefined;
+
     for (let i = messages.length - 2; i > 0; i--) {
+      reducedSize += estimateTokensForMessage(messages[i + 1]!);
       if (canSplitAfter(messages, i)) {
-        return i + 1;
+        bestN = i + 1;
+        if (reducedSize >= minReducedSize) {
+          return i + 1;
+        }
       }
     }
-    return messages.length;
+    return bestN ?? messages.length;
   }
 
   get checkAfterStep(): boolean {

--- a/packages/agent-core/test/agent/compaction.test.ts
+++ b/packages/agent-core/test/agent/compaction.test.ts
@@ -15,6 +15,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import type { AgentOptions } from '../../src/agent';
 import { DefaultCompactionStrategy, type CompactionStrategy } from '../../src/agent/compaction';
 import { HookEngine, type HookEngineTriggerArgs } from '../../src/session/hooks';
+import { estimateTokensForMessages } from '../../src/utils/tokens';
 import { recordingTelemetry, type TelemetryRecord } from '../fixtures/telemetry';
 import type { TestAgentContext, TestAgentOptions } from './harness/agent';
 import { testAgent } from './harness/agent';
@@ -132,6 +133,24 @@ describe('Agent compaction', () => {
     expect(strategy.shouldBlock(210_000)).toBe(true);
   });
 
+  it('backs off overflow compaction by at least five percent of the context window', () => {
+    const strategy = testCompactionStrategy(1_000);
+    const messages = [
+      textMessage('user', 'old user'),
+      textMessage('assistant', 'old assistant'),
+      ...Array.from({ length: 20 }, () => [
+        textMessage('user', 'continue'),
+        textMessage('assistant', ''),
+      ]).flat(),
+    ];
+
+    const reduced = strategy.reduceCompactOnOverflow(messages);
+    const removed = messages.slice(reduced);
+
+    expect(reduced).toBeGreaterThan(0);
+    expect(estimateTokensForMessages(removed)).toBeGreaterThanOrEqual(50);
+  });
+
   it('ignores reserved context when the reserve is not smaller than the model window', () => {
     const strategy = new DefaultCompactionStrategy(() => 32_000, {
       triggerRatio: 0.85,
@@ -141,6 +160,7 @@ describe('Agent compaction', () => {
       maxRecentMessages: 3,
       maxRecentUserMessages: Infinity,
       maxRecentSizeRatio: 0.2,
+      minOverflowReductionRatio: 0.05,
     });
 
     expect(strategy.shouldCompact(1)).toBe(false);
@@ -1601,6 +1621,7 @@ function testCompactionStrategy(maxSize: number = 1_000): DefaultCompactionStrat
     maxRecentMessages: 10,
     maxRecentUserMessages: Infinity,
     maxRecentSizeRatio: 0.2,
+    minOverflowReductionRatio: 0.05,
   });
 }
 
@@ -1613,6 +1634,7 @@ function overflowOnlyCompactionStrategy(maxSize: number = 14): DefaultCompaction
     maxRecentMessages: 3,
     maxRecentUserMessages: Infinity,
     maxRecentSizeRatio: 0.2,
+    minOverflowReductionRatio: 0.05,
   });
 }
 


### PR DESCRIPTION
## Related Issue

No linked issue. This follows up on #207 after checking the exported session and finding that overflow compaction retries can spend the retry budget on tiny trailing messages.

## Problem

When a compaction summary request exceeds the model context window, the retry path used to move the compacted prefix back to the previous safe split only. In the reported session, the tail contained repeated tiny `continue` turns and empty assistant placeholders, so each retry reduced the provider input by only a few tokens and never reached the large tool-result messages before the retry budget was exhausted.

## What changed

- Add `minOverflowReductionRatio` to `CompactionConfig`, defaulting to `0.05`.
- Change overflow compaction backoff so each retry removes at least that fraction of the model context window in estimated tokens, while still choosing only safe split points.
- Add a regression test that covers repeated tiny trailing messages.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.

## Validation

- Replayed the exported session wire in memory up to line 1549. Old first retry would remove 6 estimated tokens; the new first retry removes 15,183 estimated tokens for a 262,144-token context window, above the 13,108-token 5% floor.
- `pnpm vitest run packages/agent-core/test/agent/compaction.test.ts --testNamePattern "backs off overflow compaction"`
- `pnpm vitest run packages/agent-core/test/agent/compaction.test.ts`
- `pnpm --filter @moonshot-ai/agent-core run typecheck`
- `pnpm exec oxlint --type-aware packages/agent-core/src/agent/compaction/strategy.ts packages/agent-core/test/agent/compaction.test.ts`
- `git diff --check`
