### PR TITLE
fix: handle structured context overflow errors

### DIFF
--- a/.changeset/context-overflow-responses.md
+++ b/.changeset/context-overflow-responses.md
@@ -1,0 +1,7 @@
+---
+"@moonshot-ai/agent-core": patch
+"@moonshot-ai/kimi-code": patch
+"@moonshot-ai/kosong": patch
+---
+
+Handle context overflow errors consistently across provider responses.

--- a/packages/agent-core/src/agent/turn/index.ts
+++ b/packages/agent-core/src/agent/turn/index.ts
@@ -7,6 +7,7 @@ import {
   APIStatusError,
   APITimeoutError,
   inputTotal,
+  isContextOverflowStatusError,
   type ContentPart,
   type TokenUsage,
 } from '@moonshot-ai/kosong';
@@ -738,7 +739,7 @@ function classifyApiError(error: unknown, summary: KimiErrorPayload): ApiErrorCl
     if (statusCode === 429) return { errorType: 'rate_limit', statusCode };
     if (statusCode === 401 || statusCode === 403) return { errorType: 'auth', statusCode };
     if (statusCode >= 500) return { errorType: '5xx_server', statusCode };
-    if (isContextOverflowMessage(summary.message)) {
+    if (isContextOverflowStatusError(statusCode, summary.message)) {
       return { errorType: 'context_overflow', statusCode };
     }
     if (statusCode >= 400) return { errorType: '4xx_client', statusCode };
@@ -785,17 +786,6 @@ function isApiTimeoutError(error: unknown, summary: KimiErrorPayload): boolean {
 
 function isApiEmptyResponseError(error: unknown, summary: KimiErrorPayload): boolean {
   return error instanceof APIEmptyResponseError || summary.name === 'APIEmptyResponseError';
-}
-
-function isContextOverflowMessage(message: string): boolean {
-  const lower = message.toLowerCase();
-  return (
-    lower.includes('context length') ||
-    lower.includes('context_length') ||
-    lower.includes('max tokens') ||
-    lower.includes('maximum context') ||
-    lower.includes('too many tokens')
-  );
 }
 
 function currentTurnInputTokens(usage: TokenUsage | undefined): number | undefined {

--- a/packages/agent-core/test/agent/turn.test.ts
+++ b/packages/agent-core/test/agent/turn.test.ts
@@ -1057,6 +1057,17 @@ describe('Agent turn flow', () => {
       statusCode: 422,
     },
     {
+      name: 'context overflow token count status',
+      createError: () =>
+        new APIStatusError(
+          400,
+          'input token count 131072 exceeds the maximum number of tokens allowed',
+          'req-token-count',
+        ),
+      errorType: 'context_overflow',
+      statusCode: 400,
+    },
+    {
       name: 'connection error',
       createError: () => new APIConnectionError('socket hang up'),
       errorType: 'network',

--- a/packages/kosong/src/errors.ts
+++ b/packages/kosong/src/errors.ts
@@ -85,6 +85,10 @@ const CONTEXT_OVERFLOW_MESSAGE_PATTERNS = [
   /request.*exceed(?:ed|s|ing)?.*model token limit/,
 ] as const;
 
+export function isContextOverflowErrorCode(code: string | null | undefined): boolean {
+  return code === 'context_length_exceeded';
+}
+
 export function normalizeAPIStatusError(
   statusCode: number,
   message: string,
@@ -96,7 +100,7 @@ export function normalizeAPIStatusError(
   return new APIStatusError(statusCode, message, requestId);
 }
 
-function isContextOverflowStatusError(statusCode: number, message: string): boolean {
+export function isContextOverflowStatusError(statusCode: number, message: string): boolean {
   if (statusCode !== 400 && statusCode !== 413 && statusCode !== 422) return false;
   const lowerMessage = message.toLowerCase();
   return CONTEXT_OVERFLOW_MESSAGE_PATTERNS.some((pattern) => pattern.test(lowerMessage));

--- a/packages/kosong/src/index.ts
+++ b/packages/kosong/src/index.ts
@@ -60,6 +60,7 @@ export {
   APIStatusError,
   APITimeoutError,
   ChatProviderError,
+  isContextOverflowStatusError,
   isRetryableGenerateError,
 } from './errors';
 

--- a/packages/kosong/src/providers/openai-responses.ts
+++ b/packages/kosong/src/providers/openai-responses.ts
@@ -1,5 +1,5 @@
 import type { ModelCapability } from '#/capability';
-import { ChatProviderError } from '#/errors';
+import { APIContextOverflowError, ChatProviderError, isContextOverflowErrorCode } from '#/errors';
 import type { ContentPart, Message, StreamedMessagePart, ToolCall } from '#/message';
 import { extractText } from '#/message';
 import type {
@@ -217,12 +217,39 @@ function formatResponsesErrorEvent(
   return `${codeText}: ${message}${paramText}`;
 }
 
-function formatResponsesFailedResponse(response: RawObject): string {
+function errorFromOpenAIResponsesEvent(
+  prefix: string,
+  code: string | null,
+  message: string,
+  param: string | null,
+): ChatProviderError {
+  const formatted = formatResponsesErrorEvent(code, message, param);
+  const fullMessage = `${prefix}: ${formatted}`;
+  if (isContextOverflowErrorCode(code)) {
+    return new APIContextOverflowError(400, fullMessage);
+  }
+  return new ChatProviderError(fullMessage);
+}
+
+function readResponsesFailedResponseError(response: RawObject):
+  | {
+      code: string | null;
+      message: string;
+    }
+  | undefined {
   const error = readObjectField(response, 'error');
   if (error !== undefined) {
     const code = readNullableStringField(error, 'code') ?? 'unknown';
     const message = readStringField(error, 'message') ?? 'no message';
-    return `${code}: ${message}`;
+    return { code, message };
+  }
+  return undefined;
+}
+
+function formatResponsesFailedResponse(response: RawObject): string {
+  const error = readResponsesFailedResponseError(response);
+  if (error !== undefined) {
+    return formatResponsesErrorEvent(error.code, error.message, null);
   }
 
   const incompleteDetails = readObjectField(response, 'incomplete_details');
@@ -777,16 +804,24 @@ export class OpenAIResponsesStreamedMessage implements StreamedMessage {
           }
           case 'error': {
             const message = requireStringField(chunk, 'message', type);
-            throw new ChatProviderError(
-              `OpenAI Responses stream error: ${formatResponsesErrorEvent(
-                readNullableStringField(chunk, 'code') ?? null,
-                message,
-                readNullableStringField(chunk, 'param') ?? null,
-              )}`,
+            throw errorFromOpenAIResponsesEvent(
+              'OpenAI Responses stream error',
+              readNullableStringField(chunk, 'code') ?? null,
+              message,
+              readNullableStringField(chunk, 'param') ?? null,
             );
           }
           case 'response.failed': {
             const responseObject = requireObjectField(chunk, 'response', type);
+            const error = readResponsesFailedResponseError(responseObject);
+            if (error !== undefined) {
+              throw errorFromOpenAIResponsesEvent(
+                'OpenAI Responses response.failed',
+                error.code,
+                error.message,
+                null,
+              );
+            }
             throw new ChatProviderError(
               `OpenAI Responses response.failed: ${formatResponsesFailedResponse(responseObject)}`,
             );

--- a/packages/kosong/test/openai-responses.test.ts
+++ b/packages/kosong/test/openai-responses.test.ts
@@ -1,4 +1,4 @@
-import { ChatProviderError } from '#/errors';
+import { APIContextOverflowError, ChatProviderError } from '#/errors';
 import { generate } from '#/generate';
 import type { ContentPart, Message, StreamedMessagePart, ToolCall } from '#/message';
 import {
@@ -1633,6 +1633,35 @@ describe('OpenAIResponsesChatProvider', () => {
       await expect(collectStreamParts(stream)).rejects.toThrow(
         /rate_limit_exceeded.*too many/,
       );
+    });
+
+    it('normalizes response.failed context overflow events', async () => {
+      const events = [
+        {
+          type: 'response.failed',
+          response: {
+            id: 'resp_context_overflow',
+            status: 'failed',
+            error: {
+              code: 'context_length_exceeded',
+              message:
+                'Your input exceeds the context window of this model. Please adjust your input and try again.',
+            },
+          },
+        },
+      ];
+      const stream = new OpenAIResponsesStreamedMessage(makeAsyncIterable(events), true);
+
+      let caughtError: unknown;
+      try {
+        await collectStreamParts(stream);
+      } catch (error) {
+        caughtError = error;
+      }
+
+      expect(caughtError).toBeInstanceOf(APIContextOverflowError);
+      expect((caughtError as APIContextOverflowError).statusCode).toBe(400);
+      expect((caughtError as Error).message).toMatch(/context_length_exceeded/);
     });
 
     it('throws when a known stream event is missing a required field', async () => {


### PR DESCRIPTION
## Related Issue

No linked issue; this addresses inconsistent context overflow handling for provider responses.

## Problem

Context overflow detection used two different text matchers, so telemetry could classify the same provider error differently from the provider layer. OpenAI Responses stream failures also exposed structured `context_length_exceeded` errors as generic provider errors, which prevented the overflow recovery path from seeing the dedicated context overflow type.

## What changed

- Reused the shared kosong context overflow status matcher from agent-core telemetry classification.
- Normalized OpenAI Responses `error` and `response.failed` events with `context_length_exceeded` into the dedicated context overflow provider error.
- Added regression coverage for the shared matcher and structured Responses failure path.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.

## Verification

- `pnpm -C packages/kosong exec vitest run test/errors.test.ts test/openai-responses.test.ts`
- `pnpm -C packages/agent-core exec vitest run test/agent/turn.test.ts`
- `pnpm -C packages/kosong run typecheck`
- `pnpm -C packages/agent-core run typecheck`
- `pnpm exec oxlint --type-aware packages/kosong/src/errors.ts packages/kosong/src/index.ts packages/kosong/src/providers/openai-responses.ts packages/kosong/test/openai-responses.test.ts packages/agent-core/src/agent/turn/index.ts packages/agent-core/test/agent/turn.test.ts`
