### PR TITLE
fix(read): report MAX_BYTES cap independently when both MAX_LINES and MAX_BYTES are hit

### DIFF
--- a/.changeset/read-tool-dual-cap-message.md
+++ b/.changeset/read-tool-dual-cap-message.md
@@ -1,0 +1,6 @@
+---
+"@moonshot-ai/agent-core": patch
+"@moonshot-ai/kimi-code": patch
+---
+
+Report both MAX_LINES and MAX_BYTES limits in Read tool status when both are reached.

--- a/packages/agent-core/src/tools/builtin/file/read.ts
+++ b/packages/agent-core/src/tools/builtin/file/read.ts
@@ -435,9 +435,11 @@ export class ReadTool implements BuiltinTool<ReadInput> {
     parts.push(`Total lines in file: ${String(input.totalLines)}.`);
     if (input.maxLinesReached) {
       parts.push(`Max ${String(MAX_LINES)} lines reached.`);
-    } else if (input.maxBytesReached) {
+    }
+    if (input.maxBytesReached) {
       parts.push(`Max ${String(MAX_BYTES)} bytes reached.`);
-    } else if (lineCount < input.requestedLines) {
+    }
+    if (!input.maxLinesReached && !input.maxBytesReached && lineCount < input.requestedLines) {
       parts.push('End of file reached.');
     }
     if (input.truncatedLineNumbers.length > 0) {

--- a/packages/agent-core/test/tools/read.test.ts
+++ b/packages/agent-core/test/tools/read.test.ts
@@ -597,6 +597,23 @@ describe('ReadTool', () => {
     expect(result.output).not.toContain(`${String(MAX_LINES + 1)}\tline ${String(MAX_LINES + 1)}`);
   });
 
+  it('reports both MAX_LINES and MAX_BYTES when both caps are hit', async () => {
+    const lineCount = MAX_LINES + 5;
+    const lineContent = 'x'.repeat(105);
+    const content = Array.from({ length: lineCount }, (_, i) => `${lineContent} ${String(i + 1)}`).join(
+      '\n',
+    );
+    const tool = toolWithContent(content);
+
+    const result = await executeTool(tool, context({ path: '/tmp/both-caps.txt' }));
+    const output = toolContentString(result);
+
+    expect(result.isError).toBeFalsy();
+    expect(output).toContain(`Max ${String(MAX_LINES)} lines reached.`);
+    expect(output).toContain(`Max ${String(MAX_BYTES)} bytes reached.`);
+    expect(output).not.toContain('End of file reached.');
+  });
+
   it('tail byte truncation keeps the newest lines closest to EOF', async () => {
     const numLines = Math.floor(MAX_BYTES / 1001) + 20;
     const content = Array.from({ length: numLines }, (_, i) => {


### PR DESCRIPTION
### What does this PR do?

1. **Read tool status now reports both caps when both are hit.** The `finishMessage()` method used `else if` for the `maxLinesReached`, `maxBytesReached`, and end-of-file conditions. When a file exceeded both `MAX_LINES` (1000) and `MAX_BYTES` (100 KiB) simultaneously — e.g. a file with many long lines — only the line cap was reported, silently hiding the byte cap from the model. Changed to independent `if` statements so both limits are reported when both are triggered. The EOF message only appears when neither limit was reached.

### Related Issue

Fixes #94

### Changes Made

- `packages/agent-core/src/tools/builtin/file/read.ts` — Changed `else if (input.maxBytesReached)` to independent `if (input.maxBytesReached)`. Changed EOF condition to guard on `!input.maxLinesReached && !input.maxBytesReached`.
- `packages/agent-core/test/tools/read.test.ts` — Added test `reports both MAX_LINES and MAX_BYTES when both caps are hit` that creates a file exceeding both limits and asserts both cap messages appear.

### How to Test

1. Run the full read tool test suite: `pnpm --filter @moonshot-ai/agent-core exec vitest run test/tools/read.test.ts`