### PR TITLE
docs: order changelog entries by reader value

### DIFF
--- a/.agents/skills/sync-changelog/SKILL.md
+++ b/.agents/skills/sync-changelog/SKILL.md
@@ -126,7 +126,13 @@ Within each version, section order is:
 Features → Bug Fixes → Polish → Refactors → Other
 ```
 
-Omit empty sections. Preserve upstream entry order within each section.
+Omit empty sections. Within each section, order entries by reader value, not upstream order:
+
+1. Put the most valuable, obvious, and larger changes first.
+2. Prefer broad user-visible features, workflow-changing fixes, high-frequency bugs, and large cross-cutting improvements over small polish, narrow edge cases, and internal cleanup.
+3. If entries have similar value, preserve upstream order.
+
+Do not reword or exaggerate entries just to make them look more important; only reorder existing entries.
 
 ### 4. Write The English Page
 
@@ -178,8 +184,8 @@ Chinese page requirements:
   - `### Polish` → `### 优化`
   - `### Refactors` → `### 重构`
   - `### Other` → `### 其他`
-- The Chinese page must mirror the English page 1:1 for versions, sections, section order, and entry counts.
-- Keep the classification from the English page. Do not reclassify while translating.
+- The Chinese page must mirror the English page 1:1 for versions, sections, section order, entry order, and entry counts.
+- Keep the classification and entry order from the English page. Do not reclassify or reorder while translating.
 - Translate only entry body text. Do not add entries that are not present in English.
 - Follow `docs/AGENTS.md` for Chinese typography: full-width punctuation, spaces between Chinese and English, and the glossary.
 
@@ -196,6 +202,7 @@ Check:
 - Versions and version counts match between English and Chinese.
 - Each version has the same section set and order on both pages.
 - Each section has the same number of entries on both pages.
+- Within each section, the most valuable, obvious, and larger entries appear before smaller or narrower entries.
 - PR links and commit hashes were stripped.
 - There are no empty sections.
 - Markdown indentation and blank lines are intact.
@@ -237,6 +244,7 @@ Do **not** create a changeset for changelog docs sync. Docs sync does not enter 
 | Guessing unclear entries as Features | Inspect commit/PR; if still unclear, use Other |
 | Treating any `Add ...` line as Features | If the entry only adds a small element to an existing UI/surface, use Polish |
 | Filing UX or performance tweaks under Other | Use Polish for user-visible improvements to existing functionality |
+| Preserving upstream order when a small entry hides a larger change | Reorder within the section so the highest-value, most obvious items appear first |
 | Reclassifying entries while translating | Chinese classification must mirror English |
 | Leaving empty sections | Delete sections with no entries |
 | Putting everything under Other for convenience | Classify what can be classified first |


### PR DESCRIPTION
## Related Issue

No linked issue. This PR makes the changelog sync workflow surface the highest-value release notes first within each section.

## Problem

The `sync-changelog` skill previously preserved upstream entry order inside each section, so small entries could appear before larger or more obvious release highlights.

## What changed

- Update the changelog sync guidance to sort entries within each section by reader value.
- Require the Chinese changelog to mirror the English entry order.
- Add verification and common-mistake checks for value-based ordering.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works. No automated test applies; verified with `git diff --check`.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.
