### PR TITLE
chore(agent-core): remove unused flag resolver exports

### DIFF
--- a/packages/agent-core/src/flags/resolver.ts
+++ b/packages/agent-core/src/flags/resolver.ts
@@ -6,18 +6,6 @@ import type { FlagDefinitionInput } from './types';
 /** Master switch: when truthy, forces every flag on (highest priority). */
 export const MASTER_ENV = 'KIMI_CODE_EXPERIMENTAL_FLAG';
 
-/** Shared prefix for per-feature variables. */
-export const EXPERIMENTAL_PREFIX = 'KIMI_CODE_EXPERIMENTAL_';
-
-/**
- * Conventional env-name generator: flag id → recommended env variable name. Only used when
- * authoring a new flag (to fill `env`) and for an optional consistency test; NOT used during
- * resolution.
- */
-export function flagEnvKey(id: string): string {
-  return `${EXPERIMENTAL_PREFIX}${id.toUpperCase().replaceAll('-', '_')}`;
-}
-
 /**
  * Pure, synchronous flag resolver. State comes entirely from (env, registry) and nothing is
  * cached: env is read live on every call, so a single shared instance always reflects the current
@@ -48,13 +36,6 @@ export class FlagResolver {
     if (override !== undefined) return override;
     return def.default; // L3 default
   }
-}
-
-export function createFlagResolver(
-  env?: Readonly<Record<string, string | undefined>>,
-  definitions?: readonly FlagDefinitionInput[],
-): FlagResolver {
-  return new FlagResolver(env, definitions);
 }
 
 /**

--- a/packages/agent-core/test/flags/resolver.test.ts
+++ b/packages/agent-core/test/flags/resolver.test.ts
@@ -1,11 +1,9 @@
 import { describe, expect, it } from 'vitest';
 
 import {
-  EXPERIMENTAL_PREFIX,
   FLAG_DEFINITIONS,
   MASTER_ENV,
-  createFlagResolver,
-  flagEnvKey,
+  FlagResolver,
   type FlagDefinitionInput,
   type FlagId,
 } from '../../src/flags';
@@ -30,7 +28,7 @@ const DEFS = [
 type Env = Record<string, string | undefined>;
 
 function make(env: Env) {
-  const resolver = createFlagResolver(env, DEFS);
+  const resolver = new FlagResolver(env, DEFS);
   // The fake ids are not part of the real FlagId union, so cast to FlagId when calling.
   return (id: string) => resolver.enabled(id as FlagId);
 }
@@ -84,10 +82,6 @@ describe('FlagResolver', () => {
   it('unknown id resolves to false (defensive)', () => {
     expect(make({})('not-a-real-flag')).toBe(false);
   });
-
-  it('flagEnvKey convention: kebab -> prefix + upper snake', () => {
-    expect(flagEnvKey('my-feature')).toBe('KIMI_CODE_EXPERIMENTAL_MY_FEATURE');
-  });
 });
 
 describe('FLAG_DEFINITIONS invariants', () => {
@@ -96,7 +90,7 @@ describe('FLAG_DEFINITIONS invariants', () => {
     const seenId = new Set<string>();
     const defs: readonly FlagDefinitionInput[] = FLAG_DEFINITIONS;
     for (const def of defs) {
-      expect(def.env.startsWith(EXPERIMENTAL_PREFIX)).toBe(true);
+      expect(def.env.startsWith('KIMI_CODE_EXPERIMENTAL_')).toBe(true);
       expect(def.env).not.toBe(MASTER_ENV);
       expect(def.id).not.toBe('flag'); // reserved: would collide with the master switch
       expect(seenEnv.has(def.env)).toBe(false);


### PR DESCRIPTION
## Problem

The  module exports three unused symbols that are no longer referenced anywhere in the codebase:
- `flagEnvKey` — only used by a self-referencing test
- `EXPERIMENTAL_PREFIX` — only referenced by the same test
- `createFlagResolver` — a thin wrapper around `new FlagResolver()` only used in tests

## What changed

- Removed `flagEnvKey`, `EXPERIMENTAL_PREFIX`, and `createFlagResolver` from `resolver.ts`.
- Updated `resolver.test.ts` to directly construct `FlagResolver` and use an inline string for the prefix assertion.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
