### PR TITLE
fix(kosong): preserve unsigned thinking in anthropic history serialization

### DIFF
--- a/.changeset/preserve-unsigned-thinking.md
+++ b/.changeset/preserve-unsigned-thinking.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kosong": patch
+---
+
+Preserve unsigned assistant thinking when serializing history for the Anthropic provider, instead of dropping it. Anthropic-compatible backends (e.g. Kimi) stream thinking without a signature yet reject a tool-call turn whose thinking is missing ("thinking is enabled but reasoning_content is missing"). api.anthropic.com always supplies a signature, so its behavior is unchanged.

--- a/packages/kosong/src/providers/anthropic.ts
+++ b/packages/kosong/src/providers/anthropic.ts
@@ -461,15 +461,27 @@ function convertMessage(message: Message): MessageParam {
     } else if (part.type === 'image_url') {
       blocks.push(imageUrlPartToAnthropic(part.imageUrl.url) as unknown as ContentBlockParam);
     } else if (part.type === 'think') {
-      // ThinkPart with encrypted -> ThinkingBlockParam; no encrypted -> skip
-      if (part.encrypted === undefined) {
-        continue;
+      // ThinkPart -> ThinkingBlockParam.
+      //
+      // Signed: emit the block with its signature. api.anthropic.com requires a
+      // valid signature and always supplies one, so Anthropic-sourced history
+      // always takes this branch.
+      //
+      // Unsigned: still PRESERVE the thinking, emitted *without* a `signature`
+      // field. Anthropic-compatible backends (e.g. Kimi) stream thinking with
+      // no signature_delta, yet reject a tool-call turn whose thinking is gone
+      // ("thinking is enabled but reasoning_content is missing"). Dropping it
+      // here is what broke multi-step tool use on those backends. An unsigned
+      // part with no text carries nothing, so it is skipped.
+      if (part.encrypted !== undefined) {
+        blocks.push({
+          type: 'thinking',
+          thinking: part.think,
+          signature: part.encrypted,
+        } satisfies ThinkingBlockParam);
+      } else if (part.think !== '') {
+        blocks.push({ type: 'thinking', thinking: part.think } as unknown as ThinkingBlockParam);
       }
-      blocks.push({
-        type: 'thinking',
-        thinking: part.think,
-        signature: part.encrypted,
-      } satisfies ThinkingBlockParam);
     }
     // audio_url, video_url: not supported by Anthropic, skip
   }

--- a/packages/kosong/test/anthropic.test.ts
+++ b/packages/kosong/test/anthropic.test.ts
@@ -689,7 +689,7 @@ describe('AnthropicChatProvider', () => {
       ]);
     });
 
-    it('thinking without signature is stripped', async () => {
+    it('thinking without signature is preserved (no signature field)', async () => {
       const provider = createProvider();
       const history: Message[] = [
         { role: 'user', content: [{ type: 'text', text: 'Hi' }], toolCalls: [] },
@@ -706,10 +706,17 @@ describe('AnthropicChatProvider', () => {
       const body = await captureRequestBody(provider, '', [], history);
       const messages = body['messages'] as unknown[];
 
-      // Assistant message should have thinking stripped (no encrypted)
+      // Unsigned thinking must be PRESERVED, emitted without a `signature`
+      // field — not stripped. Anthropic-compatible backends (e.g. Kimi) reject
+      // a tool-call turn whose thinking is missing ("reasoning_content is
+      // missing"); api.anthropic.com never emits unsigned thinking, so the
+      // signed branch always handles its history and this path is backend-neutral.
       expect(messages[1]).toEqual({
         role: 'assistant',
-        content: [{ type: 'text', text: 'Hello!' }],
+        content: [
+          { type: 'thinking', thinking: 'Thinking...' },
+          { type: 'text', text: 'Hello!' },
+        ],
       });
     });
 
@@ -769,6 +776,38 @@ describe('AnthropicChatProvider', () => {
           { type: 'text', text: '4.' },
         ],
       });
+    });
+
+    it('unsigned thinking is preserved before a tool_use block', async () => {
+      // Reproduces the real failure: a streamed assistant turn whose thinking
+      // arrived without a signature_delta, followed by a tool_use. Dropping the
+      // thinking made Kimi reject the *next* request with
+      // "thinking is enabled but reasoning_content is missing".
+      const provider = createProvider();
+      const history: Message[] = [
+        { role: 'user', content: [{ type: 'text', text: 'Search for 429' }], toolCalls: [] },
+        {
+          role: 'assistant',
+          content: [{ type: 'think', think: 'Let me grep for 429.' }],
+          toolCalls: [
+            { type: 'function', id: 'toolu_1', name: 'Grep', arguments: '{"pattern":"429"}' },
+          ],
+        },
+        {
+          role: 'tool',
+          content: [{ type: 'text', text: 'found in chat.go' }],
+          toolCallId: 'toolu_1',
+          toolCalls: [],
+        },
+      ];
+      const body = await captureRequestBody(provider, '', [], history);
+      const messages = body['messages'] as Array<{ role: string; content: unknown[] }>;
+
+      expect(messages[1]!.role).toBe('assistant');
+      expect(messages[1]!.content).toEqual([
+        { type: 'thinking', thinking: 'Let me grep for 429.' },
+        { type: 'tool_use', id: 'toolu_1', name: 'Grep', input: { pattern: '429' } },
+      ]);
     });
   });
 


### PR DESCRIPTION
## Problem

Multi-step tool use was broken against Anthropic-compatible backends (e.g. Kimi's
Anthropic-protocol endpoint). After the first tool call, the follow-up request failed with:

> 400 thinking is enabled but reasoning_content is missing in assistant tool call message

The Anthropic provider's `convertMessage()` dropped any assistant thinking block that had
no signature. That guard was meant for api.anthropic.com (which rejects thinking blocks with
an invalid/empty signature), but it also discarded the thinking streamed by backends that
don't emit a `signature_delta`. Those backends require the thinking to remain present on a
tool-call turn, so dropping it made every multi-step turn fail.

## What changed

`convertMessage()` now preserves unsigned thinking instead of dropping it, emitting it
without a `signature` field. The two backends are cleanly partitioned by signature presence,
so no backend switch is needed:

- **api.anthropic.com** always supplies a signature -> its history takes the signed branch, unchanged.
- **Anthropic-compatible backends (Kimi)** never supply one -> their thinking is now kept,
  fixing the "reasoning_content is missing" failure.

Empty-and-unsigned parts carry no information and are still skipped. The streaming merge
logic (`mergeInPlace`) was checked and is correct, so it is left untouched -- this is purely
a history-serialization fix.

Verified against both real endpoints: the Kimi Anthropic endpoint now accepts the multi-step
request, while api.anthropic.com behaves exactly as before (it requires a valid signature,
which it always provides). Added regression tests covering unsigned thinking both standalone
and immediately before a `tool_use` block.
