### PR TITLE
chore: normalize line endings to LF via .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,20 @@
+# Normalize line endings to LF in the repository for all text files.
+# Without this, Windows checkouts (core.autocrlf=true) introduce CRLF into
+# source and raw-text prompt/skill `.md` files that are loaded as model
+# input, which inflates token/byte counts and breaks snapshot tests.
+* text=auto eol=lf
+
+# Explicit binary types (never normalize)
+*.png binary
+*.jpg binary
+*.jpeg binary
+*.gif binary
+*.ico binary
+*.webp binary
+*.woff binary
+*.woff2 binary
+*.ttf binary
+*.otf binary
+*.mp4 binary
+*.mov binary
+*.pdf binary


### PR DESCRIPTION
## Related Issue

No linked issue. Per CONTRIBUTING this is a small build/repo-hygiene fix that can be opened directly; the problem is explained below.

## Problem

The repository has no `.gitattributes`. With Git for Windows' default `core.autocrlf=true`, text files are checked out as CRLF on Windows. This includes the raw-text prompt/skill `.md` files that are imported as model input — e.g. `packages/agent-core/src/tools/builtin/file/read.ts`:

```ts
import readDescriptionTemplate from './read.md';
```

Two concrete consequences on Windows checkouts:

1. A contributor who edits and commits one of these `.md` files can silently introduce CRLF, changing the shipped prompt's byte/token footprint.
2. Byte/line-ending–sensitive tests are not reproducible locally (e.g. token-count snapshots differ because the loaded `.md` content carries `\r`).

## What changed

Add a `.gitattributes` that pins line endings to LF for all text files (with explicit `binary` types), so the repository stores and checks out LF on every platform regardless of a contributor's local `core.autocrlf` setting:

```
* text=auto eol=lf
# explicit binary types (never normalized): *.png, *.jpg, *.woff2, *.pdf, …
```

The repository's existing blobs are already LF, so this change is **declarative** — it adds one file with no content churn to existing files. Verified after the change on Node 24.16.0 + pnpm 10.33.0:

- `pnpm lint` → 0 errors
- `pnpm typecheck` → passes

This approach is standard repo hygiene and fits Kimi Code because the prompt/skill `.md` files are part of the shipped artifact; guaranteeing LF in the repo prevents accidental CRLF from a Windows contributor altering them.

## Checklist

- [x] I have read the CONTRIBUTING document.
- [x] I have linked a related issue, or explained the problem above.
- [ ] I have added tests that prove my feature works. — N/A (line-ending policy; no runtime code changed)
- [x] Ran `gen-changesets` skill, or this PR needs no changeset. — No changeset: no publishable package code/behavior changes.
- [x] Ran `gen-docs` skill, or this PR needs no doc update. — No user-facing behavior change.
