### PR TITLE
fix(kimi-code): run external editor through platform shell to fix Windows spawn ENOENT

### DIFF
--- a/.changeset/fix-windows-external-editor.md
+++ b/.changeset/fix-windows-external-editor.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Fix the external editor (Ctrl+G) failing with `spawn /bin/sh ENOENT` on Windows. The editor command is now run through the platform shell (`cmd.exe` on Windows, `/bin/sh` on POSIX) instead of hardcoding `/bin/sh`, and the temp file path is quoted per-platform.

--- a/apps/kimi-code/src/utils/process/external-editor.ts
+++ b/apps/kimi-code/src/utils/process/external-editor.ts
@@ -28,8 +28,9 @@ export function resolveEditorCommand(configured?: string | null): string | undef
  * with `initialText`. Returns the edited contents on success, or
  * `undefined` if the editor exited non-zero / the file disappeared.
  *
- * The command is passed to `/bin/sh -c "<cmd> <tmpfile>"` so users can
- * supply argv-style strings like `"code --wait"` or `"nvim +set ft=markdown"`.
+ * The command is run through the platform shell (`/bin/sh -c` on POSIX,
+ * `cmd.exe /d /s /c` on Windows) so users can supply argv-style strings
+ * like `"code --wait"` or `"nvim +set ft=markdown"`.
  */
 export async function editInExternalEditor(
   initialText: string,
@@ -41,7 +42,9 @@ export async function editInExternalEditor(
   try {
     const code = await new Promise<number>((resolve, reject) => {
       const shellCmd = `${command} ${shellQuote(file)}`;
-      const child = spawn('/bin/sh', ['-c', shellCmd], { stdio: 'inherit' });
+      // `shell: true` lets Node pick the right shell per platform — POSIX
+      // hardcoding `/bin/sh` here breaks on Windows with spawn ENOENT.
+      const child = spawn(shellCmd, { stdio: 'inherit', shell: true });
       child.on('exit', (c) =>{  resolve(c ?? 0); });
       child.on('error', reject);
     });
@@ -55,6 +58,11 @@ export async function editInExternalEditor(
 }
 
 function shellQuote(path: string): string {
+  if (process.platform === 'win32') {
+    // cmd.exe treats single quotes literally; wrap in double quotes so
+    // temp paths under a profile dir with spaces still resolve.
+    return `"${path}"`;
+  }
   // Single-quote and escape any embedded single quotes.
   return `'${path.replaceAll('\'', "'\\''")}'`;
 }

--- a/apps/kimi-code/test/utils/process/external-editor.test.ts
+++ b/apps/kimi-code/test/utils/process/external-editor.test.ts
@@ -28,7 +28,8 @@ vi.mock('node:fs/promises', async () => {
 import { editInExternalEditor, resolveEditorCommand } from '#/utils/process/external-editor';
 
 function shellPath(cmd: string): string {
-  const match = cmd.match(/'([^']+)'$/);
+  // Accept both POSIX single-quoted and Windows double-quoted temp paths.
+  const match = cmd.match(/['"]([^'"]+)['"]$/);
   if (!match) throw new Error(`Could not parse temp path from: ${cmd}`);
   return match[1]!;
 }
@@ -49,20 +50,21 @@ describe('external-editor helpers', () => {
     expect(resolveEditorCommand()).toBe('vim');
   });
 
-  it('returns the edited contents on success and cleans up the temp directory', async () => {
-    mocks.spawn.mockImplementation((_cmd: string, args: string[]) => {
+  it('runs the command through the platform shell and cleans up the temp directory', async () => {
+    mocks.spawn.mockImplementation((cmd: string) => {
       const child = new EventEmitter();
-      void writeFile(shellPath(args[1]!), 'edited text', 'utf8').then(() => {
+      void writeFile(shellPath(cmd), 'edited text', 'utf8').then(() => {
         child.emit('exit', 0);
       });
       return child as never;
     });
 
     await expect(editInExternalEditor('seed', 'code --wait')).resolves.toBe('edited text');
+    // `shell: true` lets Node pick the platform shell — hardcoding `/bin/sh`
+    // here was the cause of `spawn ENOENT` on Windows.
     expect(mocks.spawn).toHaveBeenCalledWith(
-      '/bin/sh',
-      ['-c', expect.stringMatching(/^code --wait /)],
-      { stdio: 'inherit' },
+      expect.stringMatching(/^code --wait /),
+      { stdio: 'inherit', shell: true },
     );
     expect(mocks.rmCalls).toHaveBeenCalled();
   });


### PR DESCRIPTION
## Related Issue

Resolve #238

## Problem

On Windows, pressing **Ctrl+G** to open the external editor fails immediately with:

```
Error: External editor failed: spawn /bin/sh ENOENT
```

`editInExternalEditor()` hardcoded `spawn('/bin/sh', ['-c', shellCmd], ...)`. Windows has no `/bin/sh`, so the spawn fails before the editor ever launches.

## What changed

- Run the editor command through the platform shell via `spawn(shellCmd, { stdio: 'inherit', shell: true })`. Node then uses `cmd.exe /d /s /c` on Windows and `/bin/sh -c` on POSIX, preserving the existing behavior on macOS/Linux while fixing Windows.
- Make `shellQuote()` platform-aware: `cmd.exe` treats single quotes literally, so on Windows the temp file path is wrapped in double quotes (POSIX keeps single-quote escaping). This keeps paths under a profile dir containing spaces working.
- Updated the unit test to assert the new platform-shell invocation (`{ shell: true }`) instead of the hardcoded `/bin/sh`, and accept both quote styles when parsing the temp path.

## Test Plan

- `vitest run test/utils/process/external-editor.test.ts` → 3 passed
- `pnpm lint` → 0 errors
- `pnpm typecheck` → passes
- Manual: on Windows, Ctrl+G now opens the configured `$VISUAL` / `$EDITOR` (e.g. `notepad`, `code --wait`) instead of throwing `spawn /bin/sh ENOENT`; macOS/Linux behavior unchanged.

## Checklist

- [x] I have read the CONTRIBUTING document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my fix works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset. (Added a `patch` changeset for `@moonshot-ai/kimi-code`.)
- [x] Ran `gen-docs` skill, or this PR needs no doc update. (No user-facing docs change — internal spawn fix.)