### PR TITLE
feat(agent-core): load CLAUDE.md as an AGENTS.md fallback

### DIFF
--- a/.changeset/load-claude-md.md
+++ b/.changeset/load-claude-md.md
@@ -1,0 +1,6 @@
+---
+"@moonshot-ai/agent-core": minor
+"@moonshot-ai/kimi-code": minor
+---
+
+Load `CLAUDE.md` as a fallback when discovering project/user memory. `AGENTS.md`/`agents.md` still take priority in each directory; `CLAUDE.md` is only read when neither exists, so repositories that already use Claude Code's `CLAUDE.md` work without maintaining a duplicate `AGENTS.md`.

--- a/packages/agent-core/src/profile/context.ts
+++ b/packages/agent-core/src/profile/context.ts
@@ -6,6 +6,10 @@ import { listDirectory } from '../tools/support/list-directory';
 import type { SystemPromptContext } from './types';
 
 const AGENTS_MD_MAX_BYTES = 32 * 1024;
+
+// Per-directory filename candidates, in priority order. AGENTS.md wins; CLAUDE.md
+// is a Claude Code compatibility fallback read only when no AGENTS.md is present.
+const AGENT_FILE_NAMES = ['AGENTS.md', 'agents.md', 'CLAUDE.md'] as const;
 const S_IFMT = 0o170000;
 const S_IFREG = 0o100000;
 
@@ -42,10 +46,11 @@ export async function loadAgentsMd(kaos: Kaos): Promise<string> {
   const home = kaos.gethome();
   await collect(join(home, '.kimi-code', 'AGENTS.md'));
 
-  // Generic user-level dir (.agents) matches skill discovery.
+  // Generic user-level dir (.agents) matches skill discovery. CLAUDE.md is a
+  // fallback for Claude Code compatibility — only read when no AGENTS.md exists.
   const genericDirs = [join(home, '.agents')];
   const genericFiles = genericDirs.flatMap((dir) =>
-    ['AGENTS.md', 'agents.md'].map((name) => join(dir, name)),
+    AGENT_FILE_NAMES.map((name) => join(dir, name)),
   );
   for (const file of genericFiles) {
     if (await collect(file)) break;
@@ -53,7 +58,7 @@ export async function loadAgentsMd(kaos: Kaos): Promise<string> {
 
   for (const dir of dirs) {
     await collect(join(dir, '.kimi-code', 'AGENTS.md'));
-    for (const fileName of ['AGENTS.md', 'agents.md']) {
+    for (const fileName of AGENT_FILE_NAMES) {
       if (await collect(join(dir, fileName))) break;
     }
   }

--- a/packages/agent-core/src/profile/context.ts
+++ b/packages/agent-core/src/profile/context.ts
@@ -40,16 +40,17 @@ export async function loadAgentsMd(kaos: Kaos): Promise<string> {
 
   // User-level files come first so any project-level AGENTS.md overrides them.
   const home = kaos.gethome();
-  await collect(join(home, '.kimi-code', 'AGENTS.md'));
+  const foundBrandedUser = await collect(join(home, '.kimi-code', 'AGENTS.md'));
 
   // Generic user-level dir (.agents) matches skill discovery. Load the first
   // AGENTS-style file found; fall back to ~/.claude/CLAUDE.md (Claude Code's
-  // documented global memory path) only when no AGENTS file exists there.
+  // documented global memory path) only when no user-level AGENTS file exists
+  // at all — including the branded ~/.kimi-code/AGENTS.md checked above.
   let foundGenericUser = false;
   for (const name of ['AGENTS.md', 'agents.md']) {
     if (await collect(join(home, '.agents', name))) { foundGenericUser = true; break; }
   }
-  if (!foundGenericUser) {
+  if (!foundBrandedUser && !foundGenericUser) {
     await collect(join(home, '.claude', 'CLAUDE.md'));
   }
 

--- a/packages/agent-core/src/profile/context.ts
+++ b/packages/agent-core/src/profile/context.ts
@@ -6,10 +6,6 @@ import { listDirectory } from '../tools/support/list-directory';
 import type { SystemPromptContext } from './types';
 
 const AGENTS_MD_MAX_BYTES = 32 * 1024;
-
-// Per-directory filename candidates, in priority order. AGENTS.md wins; CLAUDE.md
-// is a Claude Code compatibility fallback read only when no AGENTS.md is present.
-const AGENT_FILE_NAMES = ['AGENTS.md', 'agents.md', 'CLAUDE.md'] as const;
 const S_IFMT = 0o170000;
 const S_IFREG = 0o100000;
 
@@ -46,20 +42,32 @@ export async function loadAgentsMd(kaos: Kaos): Promise<string> {
   const home = kaos.gethome();
   await collect(join(home, '.kimi-code', 'AGENTS.md'));
 
-  // Generic user-level dir (.agents) matches skill discovery. CLAUDE.md is a
-  // fallback for Claude Code compatibility — only read when no AGENTS.md exists.
-  const genericDirs = [join(home, '.agents')];
-  const genericFiles = genericDirs.flatMap((dir) =>
-    AGENT_FILE_NAMES.map((name) => join(dir, name)),
-  );
-  for (const file of genericFiles) {
-    if (await collect(file)) break;
+  // Generic user-level dir (.agents) matches skill discovery. Load the first
+  // AGENTS-style file found; fall back to ~/.claude/CLAUDE.md (Claude Code's
+  // documented global memory path) only when no AGENTS file exists there.
+  let foundGenericUser = false;
+  for (const name of ['AGENTS.md', 'agents.md']) {
+    if (await collect(join(home, '.agents', name))) { foundGenericUser = true; break; }
+  }
+  if (!foundGenericUser) {
+    await collect(join(home, '.claude', 'CLAUDE.md'));
   }
 
   for (const dir of dirs) {
-    await collect(join(dir, '.kimi-code', 'AGENTS.md'));
-    for (const fileName of AGENT_FILE_NAMES) {
-      if (await collect(join(dir, fileName))) break;
+    // Kimi-branded override takes highest priority within this scope.
+    const foundKimiCode = await collect(join(dir, '.kimi-code', 'AGENTS.md'));
+    // Standard AGENTS.md / agents.md (second priority).
+    let foundRegular = false;
+    for (const name of ['AGENTS.md', 'agents.md']) {
+      if (await collect(join(dir, name))) { foundRegular = true; break; }
+    }
+    // CLAUDE.md paths are Claude Code compatibility fallbacks. Only check them
+    // when no AGENTS-style file exists anywhere in this directory scope, so that
+    // .kimi-code/AGENTS.md (or a top-level AGENTS.md) fully supersedes them.
+    if (!foundKimiCode && !foundRegular) {
+      if (!(await collect(join(dir, 'CLAUDE.md')))) {
+        await collect(join(dir, '.claude', 'CLAUDE.md'));
+      }
     }
   }
 

--- a/packages/agent-core/test/profile/context.test.ts
+++ b/packages/agent-core/test/profile/context.test.ts
@@ -58,6 +58,33 @@ describe('loadAgentsMd user-level discovery', () => {
     expect(result).not.toContain(homeDir);
   });
 
+  it('loads CLAUDE.md when no AGENTS.md is present', async () => {
+    await writeFile(join(workDir, 'CLAUDE.md'), 'claude instructions', 'utf-8');
+
+    const result = await loadAgentsMd(testKaos);
+
+    expect(result).toContain('claude instructions');
+  });
+
+  it('prefers AGENTS.md over CLAUDE.md in the same directory', async () => {
+    await writeFile(join(workDir, 'AGENTS.md'), 'agents instructions', 'utf-8');
+    await writeFile(join(workDir, 'CLAUDE.md'), 'claude instructions', 'utf-8');
+
+    const result = await loadAgentsMd(testKaos);
+
+    expect(result).toContain('agents instructions');
+    expect(result).not.toContain('claude instructions');
+  });
+
+  it('loads generic user-level .agents/CLAUDE.md', async () => {
+    await mkdir(join(homeDir, '.agents'), { recursive: true });
+    await writeFile(join(homeDir, '.agents', 'CLAUDE.md'), 'dot-agents claude', 'utf-8');
+
+    const result = await loadAgentsMd(testKaos);
+
+    expect(result).toContain('dot-agents claude');
+  });
+
   it('does not load the same file twice when the work dir is the home dir', async () => {
     vi.spyOn(testKaos, 'getcwd').mockReturnValue(homeDir);
     await mkdir(join(homeDir, '.kimi-code'), { recursive: true });

--- a/packages/agent-core/test/profile/context.test.ts
+++ b/packages/agent-core/test/profile/context.test.ts
@@ -76,13 +76,56 @@ describe('loadAgentsMd user-level discovery', () => {
     expect(result).not.toContain('claude instructions');
   });
 
-  it('loads generic user-level .agents/CLAUDE.md', async () => {
-    await mkdir(join(homeDir, '.agents'), { recursive: true });
-    await writeFile(join(homeDir, '.agents', 'CLAUDE.md'), 'dot-agents claude', 'utf-8');
+  it('loads ~/.claude/CLAUDE.md when no .agents file exists', async () => {
+    await mkdir(join(homeDir, '.claude'), { recursive: true });
+    await writeFile(join(homeDir, '.claude', 'CLAUDE.md'), 'global claude memory', 'utf-8');
 
     const result = await loadAgentsMd(testKaos);
 
-    expect(result).toContain('dot-agents claude');
+    expect(result).toContain('global claude memory');
+  });
+
+  it('prefers .agents/AGENTS.md over ~/.claude/CLAUDE.md', async () => {
+    await mkdir(join(homeDir, '.agents'), { recursive: true });
+    await writeFile(join(homeDir, '.agents', 'AGENTS.md'), 'dot-agents', 'utf-8');
+    await mkdir(join(homeDir, '.claude'), { recursive: true });
+    await writeFile(join(homeDir, '.claude', 'CLAUDE.md'), 'global claude memory', 'utf-8');
+
+    const result = await loadAgentsMd(testKaos);
+
+    expect(result).toContain('dot-agents');
+    expect(result).not.toContain('global claude memory');
+  });
+
+  it('loads .claude/CLAUDE.md in the project directory', async () => {
+    await mkdir(join(workDir, '.claude'), { recursive: true });
+    await writeFile(join(workDir, '.claude', 'CLAUDE.md'), 'dot-claude instructions', 'utf-8');
+
+    const result = await loadAgentsMd(testKaos);
+
+    expect(result).toContain('dot-claude instructions');
+  });
+
+  it('prefers bare CLAUDE.md over .claude/CLAUDE.md in the same directory', async () => {
+    await writeFile(join(workDir, 'CLAUDE.md'), 'bare claude', 'utf-8');
+    await mkdir(join(workDir, '.claude'), { recursive: true });
+    await writeFile(join(workDir, '.claude', 'CLAUDE.md'), 'dot-claude', 'utf-8');
+
+    const result = await loadAgentsMd(testKaos);
+
+    expect(result).toContain('bare claude');
+    expect(result).not.toContain('dot-claude');
+  });
+
+  it('does not load CLAUDE.md when .kimi-code/AGENTS.md exists in the same scope', async () => {
+    await mkdir(join(workDir, '.kimi-code'), { recursive: true });
+    await writeFile(join(workDir, '.kimi-code', 'AGENTS.md'), 'kimi override', 'utf-8');
+    await writeFile(join(workDir, 'CLAUDE.md'), 'claude instructions', 'utf-8');
+
+    const result = await loadAgentsMd(testKaos);
+
+    expect(result).toContain('kimi override');
+    expect(result).not.toContain('claude instructions');
   });
 
   it('does not load the same file twice when the work dir is the home dir', async () => {

--- a/packages/agent-core/test/profile/context.test.ts
+++ b/packages/agent-core/test/profile/context.test.ts
@@ -85,6 +85,18 @@ describe('loadAgentsMd user-level discovery', () => {
     expect(result).toContain('global claude memory');
   });
 
+  it('does not load ~/.claude/CLAUDE.md when ~/.kimi-code/AGENTS.md exists', async () => {
+    await mkdir(join(homeDir, '.kimi-code'), { recursive: true });
+    await writeFile(join(homeDir, '.kimi-code', 'AGENTS.md'), 'kimi user memory', 'utf-8');
+    await mkdir(join(homeDir, '.claude'), { recursive: true });
+    await writeFile(join(homeDir, '.claude', 'CLAUDE.md'), 'global claude memory', 'utf-8');
+
+    const result = await loadAgentsMd(testKaos);
+
+    expect(result).toContain('kimi user memory');
+    expect(result).not.toContain('global claude memory');
+  });
+
   it('prefers .agents/AGENTS.md over ~/.claude/CLAUDE.md', async () => {
     await mkdir(join(homeDir, '.agents'), { recursive: true });
     await writeFile(join(homeDir, '.agents', 'AGENTS.md'), 'dot-agents', 'utf-8');


### PR DESCRIPTION
## Related Issue

Resolve #243

## Problem

Many repositories already maintain a `CLAUDE.md` for Claude Code. Kimi Code only reads `AGENTS.md`, forcing users to duplicate their instructions into a second file. See linked issue.

## What changed

- `loadAgentsMd` now appends `CLAUDE.md` to the per-directory filename candidates, after `AGENTS.md`/`agents.md`.
- The existing first-match-wins (`break`) logic makes `CLAUDE.md` a pure fallback: when a directory has an `AGENTS.md`, behavior is unchanged; `CLAUDE.md` is read only when no `AGENTS.md` exists.
- Applies to both the per-directory scan and the user-level `~/.agents` directory. Existing path de-duplication prevents loading the same file twice.

This is additive and opt-out by nature — existing `AGENTS.md` users are unaffected.

## Open questions for maintainer

- Priority is "AGENTS.md first, CLAUDE.md fallback" (no merge of both). Confirm this is the desired semantics.
- The user-level `~/.kimi-code/AGENTS.md` entry is still a hardcoded single file — I did **not** add a `~/.kimi-code/CLAUDE.md` fallback there. Want it added?
- Loading both `AGENTS.md` and `CLAUDE.md` in the same directory (merge instead of either/or) would change existing single-file semantics; left out of this PR by design.

## Checklist

- [x] I have read the CONTRIBUTING document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.