### PR TITLE
perf: cache tool lookups in batches

### DIFF
--- a/.changeset/cache-tool-batch-lookups.md
+++ b/.changeset/cache-tool-batch-lookups.md
@@ -1,0 +1,6 @@
+---
+"@moonshot-ai/agent-core": patch
+"@moonshot-ai/kimi-code": patch
+---
+
+Cache tool lookups during each tool-call batch.

--- a/packages/agent-core/src/loop/tool-call.ts
+++ b/packages/agent-core/src/loop/tool-call.ts
@@ -120,7 +120,8 @@ export async function runToolCallBatch(
   response: LLMChatResponse,
 ): Promise<ToolCallBatchResult> {
   if (response.toolCalls.length === 0) return { stopTurn: false };
-  const calls = response.toolCalls.map((toolCall) => preflightToolCall(step.tools, toolCall));
+  const toolsByName = buildToolsByName(step.tools);
+  const calls = response.toolCalls.map((toolCall) => preflightToolCall(toolsByName, toolCall));
   const scheduler = new ToolScheduler<PendingToolResult>();
   const pendingResults: Array<Promise<PendingToolResult>> = [];
   let stopTurn = false;
@@ -163,18 +164,29 @@ export async function runToolCallBatch(
   return { stopTurn };
 }
 
+function buildToolsByName(
+  tools: readonly ExecutableTool[] | undefined,
+): ReadonlyMap<string, ExecutableTool> | undefined {
+  if (tools === undefined || tools.length === 0) return undefined;
+  const byName = new Map<string, ExecutableTool>();
+  for (const tool of tools) {
+    if (!byName.has(tool.name)) byName.set(tool.name, tool);
+  }
+  return byName;
+}
+
 /**
  * Provider-order validation pass. It does not run hooks, spawn tools, or write
  * events. Validator compilation may populate the local cache.
  */
 function preflightToolCall(
-  tools: readonly ExecutableTool[] | undefined,
+  toolsByName: ReadonlyMap<string, ExecutableTool> | undefined,
   toolCall: ToolCall,
 ): PreflightedToolCall {
   const toolName = toolCall.name;
   const parsedArgs = parseToolCallArguments(toolCall.arguments);
   const args = parsedArgs.success ? parsedArgs.data : {};
-  const tool = tools?.find((candidate) => candidate.name === toolName);
+  const tool = toolsByName?.get(toolName);
   if (tool === undefined) {
     return {
       kind: 'rejected',

--- a/packages/agent-core/test/loop/tool-call.e2e.test.ts
+++ b/packages/agent-core/test/loop/tool-call.e2e.test.ts
@@ -114,6 +114,47 @@ describe('runTurn — tool-call behaviour', () => {
     });
   });
 
+  it('uses the first registered tool when duplicate names are present', async () => {
+    const firstCalls: string[] = [];
+    const secondCalls: string[] = [];
+    const first: ExecutableTool = {
+      name: 'dupe',
+      description: 'first duplicate tool',
+      parameters: { type: 'object', additionalProperties: true },
+      resolveExecution: () => ({
+        approvalRule: 'dupe',
+        execute: async (ctx) => {
+          firstCalls.push(ctx.toolCallId);
+          return { output: 'first' };
+        },
+      }),
+    };
+    const second: ExecutableTool = {
+      name: 'dupe',
+      description: 'second duplicate tool',
+      parameters: { type: 'object', additionalProperties: true },
+      resolveExecution: () => ({
+        approvalRule: 'dupe',
+        execute: async (ctx) => {
+          secondCalls.push(ctx.toolCallId);
+          return { output: 'second' };
+        },
+      }),
+    };
+
+    const { context } = await runTurn({
+      tools: [first, second],
+      responses: [
+        makeToolUseResponse([makeToolCall('dupe', {}, 'tc-1')]),
+        makeEndTurnResponse('done'),
+      ],
+    });
+
+    expect(firstCalls).toEqual(['tc-1']);
+    expect(secondCalls).toEqual([]);
+    expect(context.toolResults()[0]?.result.output).toBe('first');
+  });
+
   it('records an error tool.result when the tool name is unknown', async () => {
     const { sink, context } = await runTurn({
       tools: [], // no tools at all


### PR DESCRIPTION
## Related Issue

No linked issue. This is a focused performance fix for tool-call preflight.

## Problem

Tool-call preflight resolved each call by scanning the full tool list. In batches with multiple tool calls, that repeated linear lookup for every call even though the available tool set is fixed for the batch.

## What changed

- Build a per-batch name-to-tool map before preflight validation.
- Preserve the existing first-registered-tool behavior when duplicate tool names exist.
- Add an e2e regression test covering duplicate tool names.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.

Validation:

- `mise exec node@24.15.0 -- corepack pnpm vitest run packages/agent-core/test/loop/tool-call.e2e.test.ts`
- `mise exec node@24.15.0 -- corepack pnpm --filter @moonshot-ai/agent-core typecheck`