### PR TITLE
fix(tui): recognize CSI-u Shift+Enter as newline

### DIFF
--- a/.changeset/shift-enter-csi-u.md
+++ b/.changeset/shift-enter-csi-u.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+fix(tui): treat CSI-u Shift+Enter as an editor newline

--- a/apps/kimi-code/src/tui/components/editor/custom-editor.ts
+++ b/apps/kimi-code/src/tui/components/editor/custom-editor.ts
@@ -87,6 +87,7 @@ function stripSgr(s: string): string {
 
 function getNewlineInput(data: string): string | undefined {
   if (data === '\n' || data === '\u001B\r' || data === '\u001B[13;2~') return data;
+  if (data === '\u001B[13;2u') return '\n';
   if (matchesKey(data, Key.ctrl('j'))) return '\n';
   return undefined;
 }

--- a/apps/kimi-code/test/tui/components/editor/custom-editor.test.ts
+++ b/apps/kimi-code/test/tui/components/editor/custom-editor.test.ts
@@ -208,7 +208,7 @@ describe('CustomEditor paste marker expansion', () => {
 });
 
 describe('CustomEditor shortcut telemetry hooks', () => {
-  it('reports newline shortcuts, including Ctrl-J, before delegating to the base editor', () => {
+  it('reports newline shortcuts, including Ctrl-J and CSI-u Shift+Enter, before delegating to the base editor', () => {
     const editor = makeEditor();
     const onInsertNewline = vi.fn();
     editor.onInsertNewline = onInsertNewline;
@@ -216,9 +216,10 @@ describe('CustomEditor shortcut telemetry hooks', () => {
     editor.handleInput('a');
     editor.handleInput('\n');
     editor.handleInput('\u001B[106;5u');
+    editor.handleInput('\u001B[13;2u');
 
-    expect(onInsertNewline).toHaveBeenCalledTimes(2);
-    expect(editor.getText()).toBe('a\n\n');
+    expect(onInsertNewline).toHaveBeenCalledTimes(3);
+    expect(editor.getText()).toBe('a\n\n\n');
   });
 
   it('reports undo shortcuts before delegating to the base editor', () => {


### PR DESCRIPTION
## Related Issue

Resolve #256

## Problem

Windows Terminal and some other terminals can encode Shift+Enter as the CSI-u sequence `ESC [ 13 ; 2 u`. `CustomEditor` already handled LF, `ESC + CR`, `ESC [ 13 ; 2 ~`, and Ctrl-J as newline shortcuts, but did not recognize this CSI-u variant, so the sequence fell through to the base editor instead of inserting a newline.

## What changed

- Treat the CSI-u Shift+Enter sequence as a newline input in `CustomEditor`.
- Keep the existing newline sequences unchanged.
- Extend the existing custom editor shortcut test to assert that CSI-u Shift+Enter fires the newline telemetry hook and inserts a newline.
- Add a patch changeset for `@moonshot-ai/kimi-code`.

## Verification

- `pnpm --filter @moonshot-ai/kimi-code run test` — 111 files / 1015 tests passed / 2 skipped.
- `pnpm --filter @moonshot-ai/kimi-code exec vitest run test/tui/components/editor/custom-editor.test.ts`
- `pnpm --filter @moonshot-ai/kimi-code run typecheck`
- `pnpm changeset status --since=origin/main`
- `pnpm exec oxlint apps/kimi-code/src/tui/components/editor/custom-editor.ts apps/kimi-code/test/tui/components/editor/custom-editor.test.ts` — 0 errors; existing escape-sequence warnings remain in unchanged paste-marker test lines.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.
