### PR TITLE
test(migration): make workdir bucket hash expectation platform-aware

### DIFF
--- a/.changeset/workdir-bucket-test-portability.md
+++ b/.changeset/workdir-bucket-test-portability.md
@@ -1,0 +1,4 @@
+---
+---
+
+Test-only Windows portability fix for migration workdir bucket hashing.

--- a/packages/migration-legacy/test/sessions/workdir-bucket.test.ts
+++ b/packages/migration-legacy/test/sessions/workdir-bucket.test.ts
@@ -27,9 +27,10 @@ function referenceEncodeWorkDirKey(workDir: string): string {
 
 describe('computeWorkdirBucket', () => {
   it('produces wd_<slug>_<sha256-12> for a normal path', () => {
-    const bucket = computeWorkdirBucket('/Users/me/Developer/proj');
+    const input = '/Users/me/Developer/proj';
+    const bucket = computeWorkdirBucket(input);
     expect(bucket).toMatch(/^wd_proj_[0-9a-f]{12}$/);
-    const expected = createHash('sha256').update('/Users/me/Developer/proj').digest('hex').slice(0, 12);
+    const expected = createHash('sha256').update(resolve(input)).digest('hex').slice(0, 12);
     expect(bucket).toBe(`wd_proj_${expected}`);
   });
 


### PR DESCRIPTION
## Related Issue

Part of #225

## Problem

`computeWorkdirBucket()` intentionally hashes `resolve(workdirPath)`, matching the running app's workdir key behavior. One test hardcoded the expected hash from the raw POSIX-looking string `'/Users/me/Developer/proj'`. That is stable on POSIX, but on Windows `resolve()` re-anchors the input to the current drive, so the product function and the test expected value diverge even though the function is behaving as documented.

## What changed

- Updated the test expected hash to derive from `resolve(input)`, the same normalization contract used by `computeWorkdirBucket()`.
- Kept the existing slug and hash-shape assertions intact.
- Added an empty changeset because this is a test-only portability fix with no published package bump.

## Verification

- `pnpm --filter @moonshot-ai/migration-legacy exec vitest run test/sessions/workdir-bucket.test.ts`
- `pnpm --filter @moonshot-ai/migration-legacy run typecheck`
- `pnpm exec oxlint packages/migration-legacy/test/sessions/workdir-bucket.test.ts`
- `pnpm --filter @moonshot-ai/migration-legacy run test`
- `pnpm changeset status --since=origin/main`

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.
