### PR TITLE
test(native): make path helper expectations platform-aware

### DIFF
--- a/.changeset/native-path-helper-test-portability.md
+++ b/.changeset/native-path-helper-test-portability.md
@@ -1,0 +1,4 @@
+---
+---
+
+Test-only Windows portability fix for native path helper expectations.

--- a/apps/kimi-code/test/scripts/native/paths.test.ts
+++ b/apps/kimi-code/test/scripts/native/paths.test.ts
@@ -1,3 +1,5 @@
+import { resolve } from 'node:path';
+
 import { describe, expect, it } from 'vitest';
 
 import {
@@ -17,6 +19,10 @@ import {
   nativeSmokeHome,
   SEA_SENTINEL_FUSE,
 } from '../../../scripts/native/paths.mjs';
+
+function underAppRoot(...parts: string[]): string {
+  return resolve(appRoot, ...parts);
+}
 
 describe('targetTriple', () => {
   it('returns platform-arch when env unset', () => {
@@ -49,27 +55,29 @@ describe('executableName', () => {
 
 describe('path helpers', () => {
   it('returns absolute intermediates dir under app root', () => {
-    expect(nativeIntermediatesDir()).toBe(`${appRoot}/dist-native/intermediates`);
+    expect(nativeIntermediatesDir()).toBe(underAppRoot('dist-native', 'intermediates'));
   });
 
   it('returns absolute bin dir per target', () => {
-    expect(nativeBinDir('darwin-arm64')).toBe(`${appRoot}/dist-native/bin/darwin-arm64`);
+    expect(nativeBinDir('darwin-arm64')).toBe(underAppRoot('dist-native', 'bin', 'darwin-arm64'));
   });
 
   it('returns absolute bin path with executable name', () => {
     expect(nativeBinPath('darwin-arm64', 'darwin')).toBe(
-      `${appRoot}/dist-native/bin/darwin-arm64/kimi`,
+      underAppRoot('dist-native', 'bin', 'darwin-arm64', 'kimi'),
     );
     expect(nativeBinPath('win32-x64', 'win32')).toBe(
-      `${appRoot}/dist-native/bin/win32-x64/kimi.exe`,
+      underAppRoot('dist-native', 'bin', 'win32-x64', 'kimi.exe'),
     );
   });
 
   it('returns intermediate artifact paths', () => {
-    expect(nativeJsBundlePath()).toBe(`${appRoot}/dist-native/intermediates/main.cjs`);
-    expect(nativeBlobPath()).toBe(`${appRoot}/dist-native/intermediates/kimi.blob`);
+    expect(nativeJsBundlePath()).toBe(
+      underAppRoot('dist-native', 'intermediates', 'main.cjs'),
+    );
+    expect(nativeBlobPath()).toBe(underAppRoot('dist-native', 'intermediates', 'kimi.blob'));
     expect(nativeSeaConfigPath()).toBe(
-      `${appRoot}/dist-native/intermediates/sea-config.json`,
+      underAppRoot('dist-native', 'intermediates', 'sea-config.json'),
     );
   });
 
@@ -78,21 +86,21 @@ describe('path helpers', () => {
   });
 
   it('returns native dist root', () => {
-    expect(nativeDistRoot()).toBe(`${appRoot}/dist-native`);
+    expect(nativeDistRoot()).toBe(underAppRoot('dist-native'));
   });
 
   it('returns manifest dir for target', () => {
     expect(nativeManifestDir('darwin-arm64')).toBe(
-      `${appRoot}/dist-native/intermediates/native-assets/darwin-arm64`,
+      underAppRoot('dist-native', 'intermediates', 'native-assets', 'darwin-arm64'),
     );
   });
 
   it('returns artifacts dir', () => {
-    expect(nativeArtifactsDir()).toBe(`${appRoot}/dist-native/artifacts`);
+    expect(nativeArtifactsDir()).toBe(underAppRoot('dist-native', 'artifacts'));
   });
 
   it('returns smoke home', () => {
-    expect(nativeSmokeHome()).toBe(`${appRoot}/dist-native/smoke-home`);
+    expect(nativeSmokeHome()).toBe(underAppRoot('dist-native', 'smoke-home'));
   });
 
   it('has correct SEA sentinel fuse value', () => {


### PR DESCRIPTION
## Related Issue

Part of #225

## Problem

The native path helper tests expected absolute paths by interpolating `${appRoot}/...` with POSIX separators. The helpers themselves correctly use `node:path.resolve()`, so they return native `\` separators on Windows. That makes the test fail on Windows even though the implementation is behaving as intended.

## What changed

- Added a small `underAppRoot()` test helper that builds expected absolute paths with `node:path.resolve()`.
- Updated filesystem path expectations to use the helper.
- Left `nativeManifestKey()` expectations unchanged because manifest keys are artifact keys, not native filesystem paths.
- Added an empty changeset because this is a test-only portability fix with no published package bump.

## Verification

- `pnpm --filter @moonshot-ai/kimi-code exec vitest run test/scripts/native/paths.test.ts`
- `pnpm --filter @moonshot-ai/kimi-code run typecheck`
- `pnpm exec oxlint apps/kimi-code/test/scripts/native/paths.test.ts`
- `pnpm --filter @moonshot-ai/kimi-code run test`
- `pnpm changeset status --since=origin/main`

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.
