### PR TITLE
refactor: move Kimi for Coding provider to SDK

### DIFF
--- a/packages/agent-core/src/index.ts
+++ b/packages/agent-core/src/index.ts
@@ -46,6 +46,7 @@ export type {
   BearerTokenProvider,
   ModelProvider,
   OAuthTokenProviderResolver,
+  ResolvedRuntimeProvider,
 } from './session/provider-manager';
 
 // ─── Wire records (for in-monorepo consumers like apps/vis) ────────────────

--- a/packages/node-sdk/src/index.ts
+++ b/packages/node-sdk/src/index.ts
@@ -1,6 +1,8 @@
 export { KimiHarness } from '#/kimi-harness';
 export { Session } from '#/session';
 export { KimiAuthFacade } from '#/auth';
+export { KimiForCodingProvider } from '#/kimi-code-model-provider';
+export type { KimiForCodingProviderOptions } from '#/kimi-code-model-provider';
 
 export {
   applyCatalogProvider,

--- a/packages/node-sdk/src/kimi-code-model-provider.ts
+++ b/packages/node-sdk/src/kimi-code-model-provider.ts
@@ -1,0 +1,117 @@
+import {
+  ErrorCodes,
+  KimiError,
+  resolveKimiHome,
+  type Logger,
+  type ModelProvider,
+  type ResolvedRuntimeProvider,
+} from '@moonshot-ai/agent-core';
+import {
+  createKimiDefaultHeaders,
+  KIMI_CODE_PROVIDER_NAME,
+  KimiOAuthToolkit,
+  kimiCodeBaseUrl,
+  type KimiHostIdentity,
+} from '@moonshot-ai/kimi-code-oauth';
+import type {
+  ProviderConfig as KosongProviderConfig,
+  ProviderRequestAuth,
+} from '@moonshot-ai/kosong';
+import { APIStatusError, UNKNOWN_CAPABILITY } from '@moonshot-ai/kosong';
+
+export interface KimiForCodingProviderOptions extends KimiHostIdentity {
+  readonly homeDir?: string;
+  readonly model?: string;
+  readonly baseUrl?: string;
+  readonly promptCacheKey?: string;
+  readonly defaultHeaders?: Record<string, string>;
+}
+
+export class KimiForCodingProvider implements ModelProvider {
+  private readonly model: string;
+  private readonly baseUrl: string;
+  private readonly promptCacheKey: string | undefined;
+  private readonly defaultHeaders: Record<string, string> | undefined;
+  private readonly toolkit: KimiOAuthToolkit;
+  private readonly homeDir: string;
+  private readonly identity: KimiHostIdentity;
+
+  constructor(options: KimiForCodingProviderOptions) {
+    this.model = options.model ?? 'kimi-for-coding';
+    this.baseUrl = options.baseUrl ?? kimiCodeBaseUrl();
+    this.promptCacheKey = options.promptCacheKey;
+    this.defaultHeaders = options.defaultHeaders;
+    this.homeDir = resolveKimiHome(options.homeDir);
+    this.identity = {
+      userAgentProduct: options.userAgentProduct,
+      version: options.version,
+      userAgentSuffix: options.userAgentSuffix,
+    };
+    this.toolkit = new KimiOAuthToolkit({
+      homeDir: this.homeDir,
+      identity: this.identity,
+    });
+  }
+
+  get defaultModel(): string {
+    return this.model;
+  }
+
+  resolveProviderConfig(model: string): ResolvedRuntimeProvider {
+    if (model !== this.model) {
+      throw new KimiError(
+        ErrorCodes.CONFIG_INVALID,
+        `Model "${model}" is not supported by KimiForCodingProvider.`,
+      );
+    }
+
+    const provider: KosongProviderConfig = {
+      type: 'kimi',
+      model: this.model,
+      baseUrl: this.baseUrl,
+      generationKwargs: this.promptCacheKey
+        ? { prompt_cache_key: this.promptCacheKey }
+        : undefined,
+      defaultHeaders: {
+        ...createKimiDefaultHeaders({
+          homeDir: this.homeDir,
+          ...this.identity,
+        }),
+        ...this.defaultHeaders,
+      },
+    };
+
+    return {
+      providerName: 'kimi-for-coding',
+      provider,
+      modelCapabilities: UNKNOWN_CAPABILITY,
+    };
+  }
+
+  resolveAuth(_model: string, _options?: { readonly log?: Logger }) {
+    return async <T>(request: (auth: ProviderRequestAuth) => Promise<T>): Promise<T> => {
+      let auth = await this.buildAuth(false);
+      for (let refreshed = false; ; refreshed = true) {
+        try {
+          return await request(auth);
+        } catch (error) {
+          const is401 = error instanceof APIStatusError && error.statusCode === 401;
+          if (!is401) throw error;
+          if (refreshed) {
+            throw new KimiError(
+              ErrorCodes.AUTH_LOGIN_REQUIRED,
+              'OAuth token was rejected after refresh. Run /login to re-authenticate.',
+              { cause: error },
+            );
+          }
+          auth = await this.buildAuth(true);
+        }
+      }
+    };
+  }
+
+  private async buildAuth(force: boolean): Promise<ProviderRequestAuth> {
+    const apiKey = await this.toolkit.ensureFresh(KIMI_CODE_PROVIDER_NAME, { force });
+    return { apiKey };
+  }
+}


### PR DESCRIPTION
## Related Issue

No linked issue. The problem is described below.

## Problem

`KimiForCodingProvider` is SDK-specific because it wires Kimi Code OAuth credentials, Kimi Code request headers, and the managed Kimi Code base URL into a `ModelProvider`. Keeping that implementation under `agent-core` crosses the package boundary and makes core carry SDK/OAuth-specific provider construction.

## What changed

- Added `KimiForCodingProvider` in `packages/node-sdk/src/kimi-code-model-provider.ts`.
- Exported `KimiForCodingProvider` and `KimiForCodingProviderOptions` from the SDK entry point.
- Exported `ResolvedRuntimeProvider` from the `agent-core` public entry point so the SDK provider can implement the public `ModelProvider` contract without importing from an internal source path.

## Validation

- `pnpm --filter @moonshot-ai/kimi-code-sdk run typecheck`
- `pnpm --filter @moonshot-ai/agent-core run typecheck`
- `pnpm --filter @moonshot-ai/kimi-code-sdk run build`

## Checklist

- [ ] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [ ] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.