### PR TITLE
fix: warn when fd is missing outside git repos

### DIFF
--- a/.changeset/fd-missing-non-git-warning.md
+++ b/.changeset/fd-missing-non-git-warning.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Warn when @ file completion may be unavailable because fd is missing outside a git repository.

--- a/apps/kimi-code/src/tui/kimi-tui.ts
+++ b/apps/kimi-code/src/tui/kimi-tui.ts
@@ -393,11 +393,20 @@ export class KimiTUI {
     this.renderWelcome();
     setExperimentalFlags(await this.harness.getExperimentalFlags());
     this.setupAutocomplete();
+    this.showFileCompletionWarningIfNeeded();
     void this.loadPersistedInputHistory();
     this.state.editorContainer.clear();
     this.state.editorContainer.addChild(this.state.editor);
     this.state.ui.setFocus(this.state.editor);
     return shouldReplayHistory;
+  }
+
+  private showFileCompletionWarningIfNeeded(): void {
+    if (this.fdPath !== null || this.gitLsFilesCache.isGitRepo()) return;
+    this.showStatus(
+      'Warning: fd not found and this directory is not a git repository. @ file completion may be unavailable. Install fd for full file search.',
+      this.state.theme.colors.warning,
+    );
   }
 
   private startEventLoop(): void {

--- a/apps/kimi-code/test/tui/kimi-tui-startup.test.ts
+++ b/apps/kimi-code/test/tui/kimi-tui-startup.test.ts
@@ -1,8 +1,7 @@
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { MigrationPlan } from "@moonshot-ai/migration-legacy";
 import { log } from "@moonshot-ai/kimi-code-sdk";
-
 import { KimiTUI, type KimiTUIStartupInput, type TUIState } from "#/tui/kimi-tui";
 import {
   handleLoginCommand,
@@ -12,11 +11,6 @@ import {
   promptPlatformSelection,
   promptLogoutProviderSelection,
 } from "#/tui/commands/prompts";
-
-vi.mock("#/tui/commands/prompts", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("#/tui/commands/prompts")>();
-  return { ...actual, promptPlatformSelection: vi.fn(), promptLogoutProviderSelection: vi.fn() };
-});
 import {
   DISABLE_TERMINAL_THEME_REPORTING,
   ENABLE_TERMINAL_THEME_REPORTING,
@@ -24,6 +18,32 @@ import {
   QUERY_TERMINAL_THEME,
   TERMINAL_THEME_LIGHT,
 } from "#/tui/utils/terminal-theme";
+
+vi.mock("#/tui/commands/prompts", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("#/tui/commands/prompts")>();
+  return { ...actual, promptPlatformSelection: vi.fn(), promptLogoutProviderSelection: vi.fn() };
+});
+
+const moduleMocks = vi.hoisted(() => ({
+  detectFdPath: vi.fn(() => "fd" as string | null),
+  createGitLsFilesCache: vi.fn(),
+}));
+
+function makeGitCache(isGitRepo: boolean) {
+  return {
+    isGitRepo: () => isGitRepo,
+    getSnapshot: () => null,
+    list: () => null,
+  };
+}
+
+vi.mock("#/utils/process/fd-detect", () => ({
+  detectFdPath: moduleMocks.detectFdPath,
+}));
+
+vi.mock("#/utils/git/git-ls-files", () => ({
+  createGitLsFilesCache: moduleMocks.createGitLsFilesCache,
+}));
 
 interface StartupDriver {
   state: TUIState;
@@ -169,6 +189,11 @@ function captureInputListeners(driver: StartupDriver) {
 }
 
 describe("KimiTUI startup", () => {
+  beforeEach(() => {
+    moduleMocks.detectFdPath.mockReturnValue("fd");
+    moduleMocks.createGitLsFilesCache.mockReturnValue(makeGitCache(true));
+  });
+
   it("creates a fresh session from startup flags and syncs runtime state", async () => {
     const session = makeSession({
       getStatus: vi.fn(async () => ({
@@ -813,6 +838,49 @@ describe("KimiTUI startup", () => {
     await driver.initMainTui();
 
     expect(uiContainsFooter(driver)).toBe(true);
+  });
+
+  it("warns when fd is missing outside a git repository", async () => {
+    moduleMocks.detectFdPath.mockReturnValue(null);
+    moduleMocks.createGitLsFilesCache.mockReturnValue(makeGitCache(false));
+    const harness = makeHarness();
+    const driver = makeDriver(harness, makeStartupInput()) as unknown as MigrateExitDriver;
+    const showStatus = vi.spyOn(driver as unknown as KimiTUI, "showStatus").mockImplementation(() => {});
+
+    await driver.initMainTui();
+
+    expect(showStatus).toHaveBeenCalledWith(
+      expect.stringContaining("fd not found and this directory is not a git repository"),
+      driver.state.theme.colors.warning,
+    );
+  });
+
+  it("does not warn when fd is missing inside a git repository", async () => {
+    moduleMocks.detectFdPath.mockReturnValue(null);
+    moduleMocks.createGitLsFilesCache.mockReturnValue(makeGitCache(true));
+    const harness = makeHarness();
+    const driver = makeDriver(harness, makeStartupInput()) as unknown as MigrateExitDriver;
+    const showStatus = vi.spyOn(driver as unknown as KimiTUI, "showStatus").mockImplementation(() => {});
+
+    await driver.initMainTui();
+
+    expect(showStatus.mock.calls.filter(([message]) => message.includes("fd not found"))).toEqual(
+      [],
+    );
+  });
+
+  it("does not warn when fd is available outside a git repository", async () => {
+    moduleMocks.detectFdPath.mockReturnValue("fd");
+    moduleMocks.createGitLsFilesCache.mockReturnValue(makeGitCache(false));
+    const harness = makeHarness();
+    const driver = makeDriver(harness, makeStartupInput()) as unknown as MigrateExitDriver;
+    const showStatus = vi.spyOn(driver as unknown as KimiTUI, "showStatus").mockImplementation(() => {});
+
+    await driver.initMainTui();
+
+    expect(showStatus.mock.calls.filter(([message]) => message.includes("fd not found"))).toEqual(
+      [],
+    );
   });
 });
 


### PR DESCRIPTION
## Related Issue

Related to #266

## Problem

When `fd` is not installed, `@` file completion still works inside git repositories through the existing git fallback, but outside git repositories it may not return candidates. That failure mode was not visible to users.

该项目并没有明确`fd`应该是一个系统依赖。

## What changed

这是一个最小警告，我在系统中没有`fd`且不在git项目中启动kimi code是进行了最小化警报。

The TUI now shows a startup warning only when `fd` is missing and the current directory is not a git repository. Git repositories stay quiet because the existing `git ls-files` fallback remains available.

Added startup tests covering missing `fd` in git and non-git directories, plus the `fd`-available path.

Validation:

- `corepack pnpm exec vitest run apps/kimi-code/test/tui/kimi-tui-startup.test.ts apps/kimi-code/test/tui/components/editor/file-mention-provider.test.ts apps/kimi-code/test/utils/git/git-ls-files.test.ts`
- `corepack pnpm --filter @moonshot-ai/kimi-code run typecheck`
- `corepack pnpm exec oxlint --type-aware apps/kimi-code/src/tui/kimi-tui.ts apps/kimi-code/test/tui/kimi-tui-startup.test.ts`
- `git diff --check`

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.