### PR TITLE
fix(test): add missing kind to background task fixture (#285)

### DIFF
--- a/apps/kimi-code/test/tui/kimi-tui-message-flow.test.ts
+++ b/apps/kimi-code/test/tui/kimi-tui-message-flow.test.ts
@@ -774,6 +774,7 @@ describe('KimiTUI message flow', () => {
         sessionId: 'ses-1',
         turnId: 1,
         info: {
+          kind: 'process',
           taskId: 'bash-bg123456',
           command: 'npm test',
           description: 'Run tests in background',


### PR DESCRIPTION
## Related Issue

Related to #285.

## Problem

#285 added a required `kind` discriminant to `BackgroundTaskInfo` (`ProcessBackgroundTaskInfo.kind: 'process'`, `AgentBackgroundTaskInfo.kind: 'agent'`) and updated most fixtures, but the process-task fixture in `apps/kimi-code/test/tui/kimi-tui-message-flow.test.ts` was missed. As a result `pnpm typecheck` fails on `main`:

```
test/tui/kimi-tui-message-flow.test.ts(771,7): error TS2352: ...
  Property 'kind' is missing in type '{ taskId: ...; }' but required in type 'ProcessBackgroundTaskInfo'.
```

(The cast is type-only, so `vitest` still passes — only `tsc` catches it.)

## What changed

Add `kind: 'process'` to the `background.task.started` fixture so it matches the new `ProcessBackgroundTaskInfo` shape. One-line, test-only.

## Checklist

- [x] I have read the CONTRIBUTING document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works. (test-only fix; existing test now typechecks)
- [x] Ran `gen-changesets` skill, or this PR needs no changeset. (test-only, no changeset needed)
- [x] Ran `gen-docs` skill, or this PR needs no doc update.

## Validation

- `corepack pnpm run typecheck` — now passes (was failing on `main`).
- `corepack pnpm exec vitest run apps/kimi-code/test/tui/kimi-tui-message-flow.test.ts` — 68 passed.
