### PR TITLE
fix: show full model name in footer without truncating provider prefix

### DIFF
--- a/.changeset/footer-model-name-full.md
+++ b/.changeset/footer-model-name-full.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Show the full model name in the footer status bar instead of truncating the provider prefix.

--- a/apps/kimi-code/src/tui/components/chrome/footer.ts
+++ b/apps/kimi-code/src/tui/components/chrome/footer.ts
@@ -120,12 +120,6 @@ function tipsForIndex(index: number): { primary: string; pair: string | null } {
   return { primary: current.text, pair: current.text + TIP_SEPARATOR + next.text };
 }
 
-function shortenModel(model: string): string {
-  if (!model) return model;
-  const slash = model.lastIndexOf('/');
-  return slash >= 0 ? model.slice(slash + 1) : model;
-}
-
 function modelDisplayName(state: AppState): string {
   const model = state.availableModels[state.model];
   return model?.displayName ?? model?.model ?? state.model;
@@ -245,7 +239,7 @@ export class FooterComponent implements Component {
     if (state.permissionMode === 'yolo') left.push(chalk.hex(colors.warning).bold('yolo'));
     if (state.planMode) left.push(chalk.hex(colors.primary).bold('plan'));
 
-    const model = shortenModel(modelDisplayName(state));
+    const model = modelDisplayName(state);
     if (model) {
       const thinkingLabel = state.thinking ? ' thinking' : '';
       const modelLabel = `${model}${thinkingLabel}`;


### PR DESCRIPTION
<!--
Thank you for your contribution to Kimi Code!
Please open an issue before sending a feature PR — PRs without prior discussion may be closed without review.

See https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md for more.
-->

## Related Issue

No related issue. This is a small UI fix that addresses an inconsistency in how model names are displayed.

## Problem

The footer status bar truncated the provider prefix from model names by only keeping the portion after the last slash. Users could not see which provider provider was active when looking at the footer, which reduced the usefulness of the model name display.

## What changed

Removed the \shortenModel\ truncation logic in the footer renderer so the full model name (including the provider prefix when it exists) is displayed. Model name resolution still follows the existing priority: displayName > model > state.model.

Full provider-prefixed names make it easier to distinguish models with the same base ID from different providers at a glance.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran \gen-changesets\ skill, or this PR needs no changeset.
- [x] Ran \gen-docs\ skill, or this PR needs no doc update.