### PR TITLE
feat(tui): hint the /dance easter egg and highlight its sub-commands

### DIFF
--- a/apps/kimi-code/src/tui/components/chrome/footer.ts
+++ b/apps/kimi-code/src/tui/components/chrome/footer.ts
@@ -64,6 +64,7 @@ const TOOLBAR_TIPS: readonly ToolbarTip[] = [
   { text: '/auto: auto permission mode' },
   { text: '/yolo: toggle yolo' },
   { text: '/help: show commands' },
+  { text: '/dance: rainbow mode, because why not' },
   { text: '/plugins: manage plugins — try the "superpowers" plugin', solo: true, priority: 3 },
   { text: 'ask Kimi to schedule tasks, e.g. "remind me at 5pm"', solo: true, priority: 3 },
 ];

--- a/apps/kimi-code/src/tui/easter-eggs/dance.ts
+++ b/apps/kimi-code/src/tui/easter-eggs/dance.ts
@@ -230,15 +230,20 @@ export function tryHandleDanceCommand(host: SlashCommandHost, parsed: ParsedSlas
   if (parsed.name !== 'dance') return false;
   if (currentDanceController === undefined) return false;
 
+  // The status line dims the whole message, which buried the command in the
+  // hint. Paint just the command in the brand color (bold) so it reads as a
+  // command; chalk nesting resumes the dim run right after it.
+  const cmd = (text: string): string => chalk.hex(host.state.theme.colors.primary).bold(text);
+
   const sub = parsed.args.trim().toLowerCase();
   if (sub === 'off') {
     currentDanceController.stop();
   } else if (sub === 'on') {
     currentDanceController.start({ hold: true });
-    host.showStatus('Dancing — use /dance off to turn it off.');
+    host.showStatus(`Dancing — use ${cmd('/dance off')} to turn it off.`);
   } else {
     currentDanceController.start({ hold: false });
-    host.showStatus('Use /dance on to keep the rainbow on.');
+    host.showStatus(`Use ${cmd('/dance on')} to keep the rainbow on.`);
   }
   return true;
 }

--- a/apps/kimi-code/test/tui/easter-eggs/dance.test.ts
+++ b/apps/kimi-code/test/tui/easter-eggs/dance.test.ts
@@ -12,6 +12,7 @@ import {
   tryHandleDanceCommand,
 } from '#/tui/easter-eggs/dance';
 import type { SlashCommandHost } from '#/tui/commands/dispatch';
+import { darkColors } from '#/tui/theme/colors';
 
 const TRUECOLOR_PATTERN = /\[38;2;(\d+);(\d+);(\d+)m/g;
 
@@ -167,6 +168,7 @@ describe('installRainbowDance', () => {
     const dispose = installRainbowDance(requestRender);
     const host = {
       showStatus: vi.fn(),
+      state: { theme: { colors: darkColors } },
     } as unknown as SlashCommandHost;
 
     tryHandleDanceCommand(host, { name: 'dance', args: 'on' });
@@ -200,6 +202,7 @@ function makeHost(): { host: SlashCommandHost; calls: DanceCall[]; status: strin
   setRainbowDance(rainbowDance);
   const host = {
     showStatus: (msg: string) => status.push(msg),
+    state: { theme: { colors: darkColors } },
   } as unknown as SlashCommandHost;
   return { host, calls, status };
 }


### PR DESCRIPTION
## Related Issue

No prior issue — this is a tiny, self-contained UX tweak to an existing hidden easter egg, so the problem is described below rather than tracked separately.

## Problem

The `/dance` easter egg has two rough edges:

1. There is no signal it exists, so nobody discovers it.
2. When run, its status hint buries the sub-command — `Use /dance on to keep the rainbow on.` renders entirely in dim text, so `/dance on` does not read as a command.

## What changed

- **Footer tip**: add a rotating tip `/dance: rainbow mode, because why not`, so the hidden command is occasionally discoverable. It uses the default rotation weight to stay low-key, and the wording signals it is just for fun rather than a productivity feature — so nobody mistakes it for something useful.
- **Highlighted hint**: paint the sub-command (`/dance on` / `/dance off`) in the brand color within the status hint so it stands out from the surrounding dim text. The status line dims the whole message, so this relies on chalk nesting to resume the dim run right after the colored segment.

## Checklist

- [x] I have read the CONTRIBUTING document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works. — Existing `dance.test.ts` asserts the hint still surfaces `/dance on` / `/dance off` (updated here to supply theme colors for the new highlight path); the footer tip is covered by existing footer tests.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset. — **No changeset**: a cosmetic tweak to a hidden easter egg, intentionally kept out of the public changelog.
- [x] Ran `gen-docs` skill, or this PR needs no doc update. — **No doc update**: `/dance` is intentionally undocumented (hidden easter egg), and footer tips are not part of the docs.
