### PR TITLE
fix(tui): drain terminal input before exit

### DIFF
--- a/.changeset/drain-terminal-input-exit.md
+++ b/.changeset/drain-terminal-input-exit.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Prevent modified keyboard release sequences from appearing after exiting the CLI.

--- a/apps/kimi-code/src/tui/kimi-tui.ts
+++ b/apps/kimi-code/src/tui/kimi-tui.ts
@@ -558,6 +558,7 @@ export class KimiTUI {
     await this.harness.close();
     this.sessionEventHandler.stopAllMcpServerStatusSpinners();
     this.uninstallRainbowDance();
+    await this.state.terminal.drainInput();
     this.state.ui.stop();
     if (this.onExit) {
       await this.onExit(exitCode);

--- a/apps/kimi-code/test/tui/signal-handlers.test.ts
+++ b/apps/kimi-code/test/tui/signal-handlers.test.ts
@@ -1,8 +1,9 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { KimiTUI, type KimiTUIStartupInput } from '#/tui/kimi-tui';
+import { KimiTUI, type KimiTUIStartupInput, type TUIState } from '#/tui/kimi-tui';
 
 interface SignalDriver {
+  state: TUIState;
   registerSignalHandlers(): void;
   unregisterSignalHandlers(): void;
   emergencyTerminalExit(): never;
@@ -296,6 +297,27 @@ describe('KimiTUI signal handlers', () => {
 
     await tui.stop();
     expect(process.listenerCount('SIGTERM')).toBe(beforeSigterm);
+  });
+
+  it('stop() drains terminal input before stopping the UI and exiting', async () => {
+    const { driver, tui } = makeDriver();
+    const events: string[] = [];
+    const drainInput = vi.spyOn(driver.state.terminal, 'drainInput').mockImplementation(async () => {
+      events.push('drain');
+    });
+    const uiStop = vi.spyOn(driver.state.ui, 'stop').mockImplementation(() => {
+      events.push('ui.stop');
+    });
+    tui.onExit = vi.fn(async () => {
+      events.push('exit');
+    });
+
+    await tui.stop();
+
+    expect(drainInput).toHaveBeenCalledOnce();
+    expect(uiStop).toHaveBeenCalledOnce();
+    expect(tui.onExit).toHaveBeenCalledOnce();
+    expect(events).toEqual(['drain', 'ui.stop', 'exit']);
   });
 
   it('start() unregisters signal handlers when initialization throws', async () => {


### PR DESCRIPTION
## Related Issue

No linked issue; this fixes a terminal cleanup bug reported during `/exit`.

## Problem

When Kitty keyboard protocol reports Enter key release events, exiting immediately after `/exit` can let a late release sequence reach the parent shell, leaving raw CSI-u text in the VS Code terminal.

## What changed

The TUI now drains terminal input before stopping the UI and exiting, preserving existing shutdown cleanup while preventing late keyboard release events from leaking. A regression test covers the shutdown order, and a changeset records the CLI patch.

## Validation

- `pnpm exec vitest run apps/kimi-code/test/tui/signal-handlers.test.ts apps/kimi-code/test/tui/kimi-tui-message-flow.test.ts apps/kimi-code/test/tui/components/editor/custom-editor.test.ts`
- `pnpm exec oxlint --type-aware apps/kimi-code/src/tui/kimi-tui.ts apps/kimi-code/test/tui/signal-handlers.test.ts`
- `git diff --check origin/main...HEAD`
- `pnpm run typecheck`

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update. No doc update is needed for this terminal cleanup fix.