### PR TITLE
fix: use max output size for completion budget

### DIFF
--- a/.changeset/max-output-size-completion-budget.md
+++ b/.changeset/max-output-size-completion-budget.md
@@ -1,0 +1,6 @@
+---
+"@moonshot-ai/agent-core": patch
+"@moonshot-ai/kimi-code": patch
+---
+
+Use configured model output limits as completion token caps.

--- a/packages/agent-core/src/agent/compaction/full.ts
+++ b/packages/agent-core/src/agent/compaction/full.ts
@@ -243,6 +243,7 @@ export class FullCompaction {
       const provider = applyCompletionBudget({
         provider: this.agent.config.provider,
         budget: resolveCompletionBudget({
+          maxOutputSize: this.agent.config.maxOutputSize,
           reservedContextSize: this.agent.kimiConfig?.loopControl?.reservedContextSize,
         }),
         capability: this.agent.config.modelCapabilities,

--- a/packages/agent-core/src/agent/config/index.ts
+++ b/packages/agent-core/src/agent/config/index.ts
@@ -127,6 +127,10 @@ export class ConfigState {
     return this.tryResolvedProviderConfig()?.modelCapabilities ?? UNKNOWN_CAPABILITY;
   }
 
+  get maxOutputSize(): number | undefined {
+    return this.tryResolvedProviderConfig()?.maxOutputSize;
+  }
+
   private get resolvedProviderConfig(): ResolvedRuntimeProvider | undefined {
     if (this._modelAlias === undefined) return undefined;
     return this.agent.modelProvider?.resolveProviderConfig(this._modelAlias);

--- a/packages/agent-core/src/agent/index.ts
+++ b/packages/agent-core/src/agent/index.ts
@@ -201,6 +201,7 @@ export class Agent {
     const provider = this.config.provider.withThinking(this.config.thinkingLevel);
     const loopControl = this.kimiConfig?.loopControl;
     const completionBudgetConfig = resolveCompletionBudget({
+      maxOutputSize: this.config.maxOutputSize,
       reservedContextSize: loopControl?.reservedContextSize,
     });
     return new KosongLLM({

--- a/packages/agent-core/src/session/provider-manager.ts
+++ b/packages/agent-core/src/session/provider-manager.ts
@@ -17,6 +17,7 @@ export interface ResolvedRuntimeProvider {
   readonly providerName: string;
   readonly provider: KosongProviderConfig;
   readonly modelCapabilities: ModelCapability;
+  readonly maxOutputSize?: number | undefined;
 }
 
 interface ProviderManagerOptions {
@@ -115,6 +116,7 @@ export class ProviderManager implements ModelProvider {
       providerName,
       provider,
       modelCapabilities: resolveModelCapabilities(alias, provider),
+      maxOutputSize: alias.maxOutputSize,
     };
   }
 

--- a/packages/agent-core/src/utils/completion-budget.ts
+++ b/packages/agent-core/src/utils/completion-budget.ts
@@ -16,6 +16,7 @@ const DEFAULT_UNKNOWN_CONTEXT_FALLBACK = 32000;
  * non-positive env values disable clamping.
  */
 export function resolveCompletionBudget(args: {
+  readonly maxOutputSize?: number | undefined;
   readonly reservedContextSize?: number;
   readonly env?: NodeJS.ProcessEnv;
 }): CompletionBudgetConfig | undefined {
@@ -27,6 +28,9 @@ export function resolveCompletionBudget(args: {
   const fromLegacy = parseEnvBudget(env['KIMI_MODEL_MAX_TOKENS']);
   if (fromLegacy !== 'absent') {
     return fromLegacy === 'disabled' ? undefined : { hardCap: fromLegacy };
+  }
+  if (args.maxOutputSize !== undefined) {
+    return { hardCap: args.maxOutputSize };
   }
   if (args.reservedContextSize !== undefined && args.reservedContextSize > 0) {
     return { fallback: args.reservedContextSize };

--- a/packages/agent-core/test/harness/runtime-provider.test.ts
+++ b/packages/agent-core/test/harness/runtime-provider.test.ts
@@ -88,6 +88,7 @@ describe('resolveRuntimeProvider model metadata', () => {
             provider: 'openai',
             model: 'gpt-runtime',
             maxContextSize: 200000,
+            maxOutputSize: 24000,
             capabilities: ['tool_use'],
           },
         },
@@ -106,6 +107,7 @@ describe('resolveRuntimeProvider model metadata', () => {
       tool_use: true,
       max_context_tokens: 200000,
     });
+    expect(resolved.maxOutputSize).toBe(24000);
   });
 
   it('uses config Kimi capabilities without requiring an api key during OAuth setup', () => {

--- a/packages/agent-core/test/utils/completion-budget.test.ts
+++ b/packages/agent-core/test/utils/completion-budget.test.ts
@@ -172,6 +172,24 @@ describe('resolveCompletionBudget', () => {
     expect(budget?.hardCap).toBe(2048);
   });
 
+  it('uses maxOutputSize as the hard cap when env vars are unset', () => {
+    const budget = resolveCompletionBudget({
+      maxOutputSize: 2048,
+      reservedContextSize: 1000,
+      env: {},
+    });
+    expect(budget?.hardCap).toBe(2048);
+    expect(budget?.fallback).toBeUndefined();
+  });
+
+  it('lets env vars override maxOutputSize', () => {
+    const budget = resolveCompletionBudget({
+      maxOutputSize: 2048,
+      env: { KIMI_MODEL_MAX_COMPLETION_TOKENS: '4096' },
+    });
+    expect(budget?.hardCap).toBe(4096);
+  });
+
   it('uses reservedContextSize as the unknown-context fallback when no env var is set', () => {
     const budget = resolveCompletionBudget({
       reservedContextSize: 12345,


### PR DESCRIPTION
## Related Issue

Resolve #306

## Problem

According to the OpenAI Chat Completions API reference, `max_tokens` is “the maximum number of tokens that can be generated in the chat completion” ([source](https://platform.openai.com/docs/api-reference/chat/create-chat-completion)). Kimi Code currently derives this provider request field from `max_context_size` instead of the configured `max_output_size`, which can cause OpenAI-compatible providers to reject requests with 400 errors when the context window exceeds the provider's output token limit.

## What changed

This change preserves each model alias's configured output limit and uses it as the completion token cap for runtime requests. The model context size still describes the context window, while `max_output_size` now controls the output budget that is ultimately sent through provider-specific `max_tokens` handling.

This prevents OpenAI-compatible providers from using `max_context_size` as the request output limit when `max_output_size` is available.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.