### PR TITLE
feat: append TODO list as markdown to compaction summary

### DIFF
--- a/.changeset/append-todo-to-compaction-summary.md
+++ b/.changeset/append-todo-to-compaction-summary.md
@@ -1,0 +1,6 @@
+---
+"@moonshot-ai/agent-core": minor
+"@moonshot-ai/kimi-code": minor
+---
+
+Append the current todo list as markdown to compaction summaries before writing them to history.

--- a/packages/agent-core/src/agent/compaction/full.ts
+++ b/packages/agent-core/src/agent/compaction/full.ts
@@ -31,6 +31,7 @@ import {
 } from '../../utils/completion-budget';
 import compactionInstructionTemplate from './compaction-instruction.md';
 import { renderMessagesToText } from './render-messages';
+import { renderTodoList, type TodoItem } from '../../tools/builtin/state/todo-list';
 import type { CompactionBeginData, CompactionResult } from './types';
 import {
   DEFAULT_COMPACTION_CONFIG,
@@ -309,6 +310,8 @@ export class FullCompaction {
         }
       }
 
+      summary = this.postProcessSummary(summary);
+
       const recent = originalHistory.slice(compactedCount);
       const tokensAfter = estimateTokens(summary) + estimateTokensForMessages(recent);
 
@@ -395,6 +398,16 @@ export class FullCompaction {
         estimatedTokenCount: result.tokensAfter,
       },
     });
+  }
+
+  private postProcessSummary(summary: string): string {
+    const storeData = this.agent.tools.storeData();
+    const todos = (storeData['todo'] as readonly TodoItem[] | undefined) ?? [];
+    if (todos.length === 0) {
+      return summary;
+    }
+    const todoMarkdown = renderTodoList(todos, '## TODO List');
+    return `${summary.trim()}\n\n${todoMarkdown}`;
   }
 }
 

--- a/packages/agent-core/src/tools/builtin/state/todo-list.ts
+++ b/packages/agent-core/src/tools/builtin/state/todo-list.ts
@@ -60,7 +60,7 @@ const TODO_STORE_KEY = 'todo';
 
 // ── Implementation ───────────────────────────────────────────────────
 
-function renderTodoList(todos: readonly TodoItem[]): string {
+export function renderTodoList(todos: readonly TodoItem[], title = 'Current todo list:'): string {
   if (todos.length === 0) {
     return 'Todo list is empty.';
   }
@@ -68,7 +68,7 @@ function renderTodoList(todos: readonly TodoItem[]): string {
     const marker = statusMarker(t.status);
     return `  ${marker} ${t.title}`;
   });
-  return ['Current todo list:', ...lines].join('\n');
+  return [title, ...lines].join('\n');
 }
 
 function statusMarker(status: TodoStatus): string {

--- a/packages/agent-core/test/agent/compaction/full.test.ts
+++ b/packages/agent-core/test/agent/compaction/full.test.ts
@@ -1668,6 +1668,39 @@ describe('FullCompaction', () => {
     `);
     await ctx.expectResumeMatches();
   });
+
+  it('appends the todo list to the compaction summary', async () => {
+    const ctx = testAgent();
+    ctx.configure({
+      provider: CATALOGUED_PROVIDER,
+      modelCapabilities: CATALOGUED_MODEL_CAPABILITIES,
+    });
+    ctx.appendExchange(1, 'old user one', 'old assistant one', 20);
+    ctx.appendExchange(2, 'recent user two', 'recent assistant two', 80);
+
+    ctx.agent.tools.updateStore('todo', [
+      { title: 'Fix the auth bug', status: 'in_progress' },
+      { title: 'Add tests', status: 'pending' },
+    ]);
+
+    const compacted = new Promise<void>((resolve) => {
+      ctx.emitter.once('context.apply_compaction', () => {
+        resolve();
+      });
+    });
+
+    ctx.mockNextResponse({ type: 'text', text: 'Compacted summary.' });
+    await ctx.rpc.beginCompaction({});
+    await compacted;
+
+    const history = ctx.compactHistory();
+    expect(history).toHaveLength(1);
+    expect(history[0]).toMatchObject({
+      role: 'assistant',
+      text: 'Compacted summary.\n\n## TODO List\n  [in_progress] Fix the auth bug\n  [pending] Add tests',
+    });
+    await ctx.expectResumeMatches();
+  });
 });
 
 afterEach(() => {


### PR DESCRIPTION
## Related Issue

N/A — this is a standalone feature request.

## Problem

Compaction replaces the conversation prefix with a summary, but the TODO list (maintained via the `TodoList` tool) is stored separately in the tool store. After compaction, the LLM no longer sees outstanding TODOs in context, which can cause tasks to be forgotten during long sessions.

## What changed

- Added a post-process step in `FullCompaction.compactionWorker` that appends the current TODO list to the generated summary before it is written to history.
- Reused the existing `renderTodoList` helper from `todo-list.ts`, adding an optional `title` parameter so the output can start with a `## TODO List` heading for compaction while keeping the original `Current todo list:` heading for the tool response.
- If the TODO list is empty, nothing is appended.
- Added a test case in `full.test.ts` verifying the appended format.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.
