### PR TITLE
fix: inherit custom tools in subagents

### DIFF
--- a/.changeset/subagent-user-tools.md
+++ b/.changeset/subagent-user-tools.md
@@ -1,0 +1,6 @@
+---
+"@moonshot-ai/agent-core": patch
+"@moonshot-ai/kimi-code": patch
+---
+
+Allow subagents to use custom tools registered on their parent agent.

--- a/packages/agent-core/src/agent/tool/index.ts
+++ b/packages/agent-core/src/agent/tool/index.ts
@@ -121,6 +121,17 @@ export class ToolManager {
     this.enabledTools.delete(name);
   }
 
+  inheritUserTools(parent: ToolManager): void {
+    for (const tool of parent.userTools.values()) {
+      if (!parent.enabledTools.has(tool.name)) continue;
+      this.registerUserTool({
+        name: tool.name,
+        description: tool.description,
+        parameters: tool.parameters,
+      });
+    }
+  }
+
   registerMcpServer(
     serverName: string,
     client: MCPClient,

--- a/packages/agent-core/src/session/subagent-host.ts
+++ b/packages/agent-core/src/session/subagent-host.ts
@@ -287,6 +287,7 @@ export class SessionSubagentHost {
 
     const context = await prepareSystemPromptContext(child.kaos);
     child.useProfile(profile, context);
+    child.tools.inheritUserTools(parent.tools);
   }
 
   private async triggerSubagentStart(

--- a/packages/agent-core/test/session/subagent-host.test.ts
+++ b/packages/agent-core/test/session/subagent-host.test.ts
@@ -16,6 +16,7 @@ import { SessionSubagentHost } from '../../src/session/subagent-host';
 import { abortError, userCancellationReason } from '../../src/utils/abort';
 import { testAgent, type AgentTestContext } from '../agent/harness/agent';
 import { createFakeKaos } from '../tools/fixtures/fake-kaos';
+import { executeTool } from '../tools/fixtures/execute-tool';
 
 // Git context collection is exercised in git-context.test.ts; here it is
 // mocked so subagent-host tests stay deterministic and assert only the
@@ -221,6 +222,62 @@ describe('SessionSubagentHost', () => {
         content: [{ type: 'text', text: 'Find the cause' }],
       },
     ]);
+  });
+
+  it('inherits active parent user tools when spawning a subagent', async () => {
+    const parent = testAgent();
+    parent.configure();
+    await parent.rpc.registerTool(lookupToolRegistration());
+    parent.newEvents();
+
+    const summary =
+      'Investigated the delegated task thoroughly, used the inherited custom lookup surface where appropriate, and returned a detailed summary that lets the parent agent continue without repeating the work. '.repeat(
+        2,
+      );
+    const child = testAgent();
+    child.mockNextResponse({
+      type: 'text',
+      text: summary,
+    });
+    const session = fakeSession(parent.agent, child.agent);
+    const host = new SessionSubagentHost(session, 'main');
+
+    const handle = await host.spawn('coder', {
+      parentToolCallId: 'call_agent',
+      prompt: 'Use the available lookup tool',
+      description: 'Use lookup',
+      runInBackground: false,
+      signal,
+    });
+
+    await expect(handle.completion).resolves.toMatchObject({
+      result: summary.trim(),
+    });
+    expect(child.llmCalls[0]?.tools.map((tool) => tool.name)).toContain('Lookup');
+    expect(child.agent.tools.data()).toContainEqual({
+      name: 'Lookup',
+      description: 'Look up a short test value.',
+      active: true,
+      source: 'user',
+    });
+
+    const lookupTool = child.agent.tools.loopTools.find((tool) => tool.name === 'Lookup');
+    expect(lookupTool).toBeDefined();
+
+    const execution = executeTool(lookupTool!, {
+      turnId: '0',
+      toolCallId: 'call_lookup',
+      args: { query: 'moon' },
+      signal,
+    });
+    const routedTo = await Promise.race([
+      child.untilToolCall({ output: 'moon-result' }).then(() => 'child'),
+      parent.untilToolCall({ output: 'moon-result' }).then(() => 'parent'),
+      new Promise<'timeout'>((resolve) => setTimeout(() => resolve('timeout'), 50)),
+    ]);
+
+    expect(routedTo).toBe('child');
+    await expect(execution).resolves.toMatchObject({ output: 'moon-result' });
   });
 
   it('falls back to bundled subagent profiles when the parent profile is missing', async () => {
@@ -1081,6 +1138,21 @@ function contextProfile(): ResolvedAgentProfile {
         `agents=${context.agentsMd ?? ''}`,
       ].join('\n'),
     tools: [],
+  };
+}
+
+function lookupToolRegistration() {
+  return {
+    name: 'Lookup',
+    description: 'Look up a short test value.',
+    parameters: {
+      type: 'object',
+      properties: {
+        query: { type: 'string' },
+      },
+      required: ['query'],
+      additionalProperties: false,
+    },
   };
 }
 


### PR DESCRIPTION
## Related Issue

No linked issue; this fixes a subagent tool inheritance gap found while wiring desktop-provided custom tools through agent-core.

## Problem

Desktop-side tools can be registered as user tools on the main agent, but newly spawned subagents did not inherit those tools. That meant a subagent could have the built-in and MCP tools from its profile while still being unable to use custom tools the parent agent already had available.

## What changed

Subagent setup now inherits the active user tools from the parent after applying the subagent profile. The inheritance recreates the user tool registration on the child agent instead of reusing the parent's executable tool object, so tool calls are routed through the subagent's own RPC context. A regression test covers both tool visibility and child-scoped execution routing.

## Validation

- `pnpm --filter @moonshot-ai/agent-core exec vitest run test/session/subagent-host.test.ts test/agent/tool.test.ts`
- `pnpm --filter @moonshot-ai/agent-core exec tsc -p tsconfig.json --noEmit`
- `git diff --check`

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update. No doc update is needed for this internal subagent tool inheritance fix.