### PR TITLE
fix: drop unsigned Claude thinking history

### DIFF
--- a/.changeset/tool-call-id-normalization.md
+++ b/.changeset/tool-call-id-normalization.md
@@ -3,4 +3,4 @@
 "@moonshot-ai/kimi-code": patch
 ---
 
-Fix cross-provider tool call ID normalization when replaying tool history.
+Fix cross-provider replay failures from incompatible tool call IDs and unsigned Claude thinking history.

--- a/packages/kosong/src/providers/anthropic.ts
+++ b/packages/kosong/src/providers/anthropic.ts
@@ -111,7 +111,6 @@ interface AnthropicGenerationKwargs {
 }
 
 const INTERLEAVED_THINKING_BETA = 'interleaved-thinking-2025-05-14';
-const FAMILY_VERSION_RE = /(?:opus|sonnet|haiku)[.-](\d+)[.-](\d{1,2})(?!\d)/;
 const OPUS_VERSION_RE = /opus[.-](\d+)[.-](\d{1,2})(?!\d)/;
 const ADAPTIVE_MIN_VERSION = { major: 4, minor: 6 } as const;
 const ANTHROPIC_TOOL_CALL_ID_POLICY: ToolCallIdPolicy = {
@@ -197,13 +196,21 @@ const BARE_FAMILY_RE = /(\d{1,2})[-._](opus|sonnet|haiku)/;
  * back to the override or {@link FALLBACK_MAX_TOKENS}.
  */
 function parseClaudeVersion(model: string): ClaudeVersion | null {
+  return parseClaudeFamilyVersion(model, true);
+}
+
+function parseClaudeAliasVersion(model: string): ClaudeVersion | null {
+  return parseClaudeFamilyVersion(model, false);
+}
+
+function parseClaudeFamilyVersion(model: string, requireClaudeMarker: boolean): ClaudeVersion | null {
   const normalized = model.toLowerCase();
   // Guard against false positives on non-Claude models that happen to
   // contain an `opus-4-7`-like substring (e.g. fine-tunes named after a
   // checkpoint). The Anthropic provider might still be configured for
   // non-Claude endpoints, so without this guard we'd quietly apply
   // Claude ceilings to unrelated models.
-  if (!normalized.includes('claude')) return null;
+  if (requireClaudeMarker && !normalized.includes('claude')) return null;
 
   const familyFirst = FAMILY_FIRST_RE.exec(normalized);
   if (familyFirst !== null) {
@@ -284,12 +291,14 @@ function versionAtLeast(
 }
 
 function supportsAdaptiveThinking(model: string): boolean {
-  const normalized = model.toLowerCase();
-  const match = FAMILY_VERSION_RE.exec(normalized);
-  if (match === null) {
+  const version = parseClaudeAliasVersion(model);
+  if (version === null || version.minor === null) {
     return false;
   }
-  return versionAtLeast(parseVersion(match), ADAPTIVE_MIN_VERSION);
+  return versionAtLeast(
+    { major: version.major, minor: version.minor },
+    ADAPTIVE_MIN_VERSION,
+  );
 }
 
 function isOpus47(model: string): boolean {
@@ -340,6 +349,10 @@ function budgetTokensForEffort(effort: ThinkingEffort): number {
 const CACHE_CONTROL = { type: 'ephemeral' as const };
 
 type CacheableBlock = ContentBlockParam & { cache_control?: { type: 'ephemeral' } };
+
+function shouldPreserveUnsignedThinking(model: string): boolean {
+  return parseClaudeAliasVersion(model) === null;
+}
 
 /**
  * Content block types that support cache_control injection.
@@ -445,7 +458,7 @@ function toolResultToBlock(toolCallId: string, content: ContentPart[]): ToolResu
     content: blocks,
   } as ToolResultBlockParam;
 }
-function convertMessage(message: Message): MessageParam {
+function convertMessage(message: Message, model: string): MessageParam {
   const role = message.role;
 
   // system role -> <system>...</system> wrapped user message
@@ -487,15 +500,17 @@ function convertMessage(message: Message): MessageParam {
       // field. Anthropic-compatible backends (e.g. Kimi) stream thinking with
       // no signature_delta, yet reject a tool-call turn whose thinking is gone
       // ("thinking is enabled but reasoning_content is missing"). Dropping it
-      // here is what broke multi-step tool use on those backends. An unsigned
-      // part with no text carries nothing, so it is skipped.
+      // here is what broke multi-step tool use on those backends. Claude
+      // models reject unsigned thinking blocks, so those are only preserved
+      // for non-Claude Anthropic-compatible models. An unsigned part with no
+      // text carries nothing, so it is skipped.
       if (part.encrypted !== undefined) {
         blocks.push({
           type: 'thinking',
           thinking: part.think,
           signature: part.encrypted,
         } satisfies ThinkingBlockParam);
-      } else if (part.think !== '') {
+      } else if (part.think !== '' && shouldPreserveUnsignedThinking(model)) {
         blocks.push({ type: 'thinking', thinking: part.think } as unknown as ThinkingBlockParam);
       }
     }
@@ -917,7 +932,7 @@ export class AnthropicChatProvider implements ChatProvider {
       ANTHROPIC_TOOL_CALL_ID_POLICY,
     );
     for (const msg of normalizedHistory) {
-      const converted = convertMessage(msg);
+      const converted = convertMessage(msg, this._model);
       const last = messages.at(-1);
       if (last !== undefined && isToolResultOnly(last) && isToolResultOnly(converted)) {
         last.content = [

--- a/packages/kosong/test/anthropic.test.ts
+++ b/packages/kosong/test/anthropic.test.ts
@@ -785,11 +785,10 @@ describe('AnthropicChatProvider', () => {
       const body = await captureRequestBody(provider, '', [], history);
       const messages = body['messages'] as unknown[];
 
-      // Unsigned thinking must be PRESERVED, emitted without a `signature`
-      // field — not stripped. Anthropic-compatible backends (e.g. Kimi) reject
-      // a tool-call turn whose thinking is missing ("reasoning_content is
-      // missing"); api.anthropic.com never emits unsigned thinking, so the
-      // signed branch always handles its history and this path is backend-neutral.
+      // Unsigned thinking must still be PRESERVED for non-Claude models,
+      // emitted without a `signature` field. Anthropic-compatible backends
+      // (e.g. Kimi) reject a tool-call turn whose thinking is missing
+      // ("reasoning_content is missing").
       expect(messages[1]).toEqual({
         role: 'assistant',
         content: [
@@ -798,6 +797,36 @@ describe('AnthropicChatProvider', () => {
         ],
       });
     });
+
+    it.each(['claude-opus-4-6', 'opus-4-6'])(
+      'drops unsigned thinking for Claude model %s before tool_use blocks',
+      async (model) => {
+        const provider = createProvider(model);
+        const history: Message[] = [
+          { role: 'user', content: [{ type: 'text', text: 'Search for 429' }], toolCalls: [] },
+          {
+            role: 'assistant',
+            content: [{ type: 'think', think: 'Let me grep for 429.' }],
+            toolCalls: [
+              { type: 'function', id: 'toolu_1', name: 'Grep', arguments: '{"pattern":"429"}' },
+            ],
+          },
+          {
+            role: 'tool',
+            content: [{ type: 'text', text: 'found in chat.go' }],
+            toolCallId: 'toolu_1',
+            toolCalls: [],
+          },
+        ];
+        const body = await captureRequestBody(provider, '', [], history);
+        const messages = body['messages'] as Array<{ role: string; content: unknown[] }>;
+
+        expect(messages[1]!.role).toBe('assistant');
+        expect(messages[1]!.content).toEqual([
+          { type: 'tool_use', id: 'toolu_1', name: 'Grep', input: { pattern: '429' } },
+        ]);
+      },
+    );
 
     it('base64 image', async () => {
       const provider = createProvider();


### PR DESCRIPTION
## Related Issue

No linked issue. Follow-up to #327 for restored sessions that switch from a provider with unsigned reasoning history back to Claude with thinking enabled.

## Problem

Some providers persist `ThinkPart` history without an Anthropic signature. When that history is replayed to a Claude model, the Anthropic adapter was emitting it as an unsigned `thinking` block, and Claude rejects the request with `Invalid signature in thinking block`.

## What changed

For Claude model names, the Anthropic adapter now replays only signed thinking blocks. It continues preserving unsigned thinking for non-Claude Anthropic-compatible models so Kimi-compatible multi-step tool use still has the reasoning content those backends require. A regression test covers unsigned thinking immediately before a `tool_use` block.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.

Verification:

- `pnpm exec vitest run --config vitest.config.ts` in `packages/kosong`
- `pnpm --filter @moonshot-ai/kosong run typecheck`