### PR TITLE
docs(changelog): sync 0.8.0 from apps/kimi-code/CHANGELOG.md

### DIFF
--- a/docs/en/release-notes/changelog.md
+++ b/docs/en/release-notes/changelog.md
@@ -2,6 +2,52 @@
 
 This page documents the changes in each Kimi Code CLI release.
 
+## 0.8.0
+
+### Features
+
+- Add experimental goal mode for longer tasks that need more than one turn. Turn it on with `KIMI_CODE_EXPERIMENTAL_GOAL_COMMAND=1` before you start Kimi.
+
+  Use `/goal <objective>` in the TUI when you want Kimi to keep working on one task across turns. For example:
+
+  ```text
+  /goal Fix the failing checkout test
+  ```
+
+  Kimi shows the goal in the TUI and keeps progress visible while it works. Use `/goal status`, `/goal pause`, `/goal resume`, `/goal cancel`, and `/goal replace <objective>` to manage the goal. This feature is still experimental. Try it and tell us what would make it more useful.
+- Add `kimi provider` CLI subcommand with `add`, `remove`, `list`, and `catalog list` / `catalog add` actions, so providers from a custom registry (api.json) or the public models.dev catalog can be imported and managed without launching the TUI.
+- Add background structured questions so agents can continue while waiting for user answers.
+- Add background automatic upgrades, which can be disabled in tui.toml.
+- Add `/undo` slash command to withdraw the last prompt from conversation history, and keep replay records in sync when a prompt is undone.
+- Add a `kimi upgrade` command for manually checking and upgrade Kimi Code CLI.
+- Add approval lifecycle hook events for observing pending and completed permission prompts.
+- Allow subagents to use custom tools registered on their parent agent.
+- Allow glob searches to target explicit absolute paths outside the workspace.
+
+### Bug Fixes
+
+- Fix cross-provider replay failures from incompatible tool call IDs and unsigned Claude thinking history.
+- Fix custom registry provider handling during re-import. Prevent loss of multi-provider entries and remove stale providers along with their model aliases and default model references.
+- Fix tool output preview rendering: trim trailing empty lines, append ellipsis to multi-line Bash command headers, and truncate long single-line output by visual wrapped lines instead of raw newline count.
+- Fix slash-activated skills not being recognized by the model due to missing system reminder wrapper.
+- Fix a crash in the `/sessions` picker on very narrow terminals by clamping every rendered line to the terminal width.
+- Normalize glob patterns before brace expansion to prevent incorrect path matching.
+- Prevent modified keyboard release sequences from appearing after exiting the CLI.
+- Fix Git Bash path detection on Windows by also searching `usr\bin\bash.exe` locations, which is where bash lives in many Git for Windows installations where `bin\bash.exe` does not exist.
+
+### Polish
+
+- Show MCP server summary in the welcome panel and add configuration hints in the /mcp command output.
+- Point users to `/provider` instead of the removed `/connect` command in the welcome screen and the no-models-configured hint.
+- Append the current todo list as markdown to compaction summaries before writing them to history.
+- Show the full model name in the footer status bar instead of truncating the provider prefix.
+- Remind the model to refresh TodoList during long-running tasks and strengthen TodoList progress-tracking guidance.
+- Replace chalk named color with theme-aware hex in session-directory warning.
+
+### Refactors
+
+- Consolidate background task management under the agent background runtime.
+
 ## 0.7.0
 
 ### Features

--- a/docs/zh/release-notes/changelog.md
+++ b/docs/zh/release-notes/changelog.md
@@ -2,6 +2,52 @@
 
 本页记录 Kimi Code CLI 每个版本的变更内容。
 
+## 0.8.0
+
+### 新功能
+
+- 新增实验性 goal 模式，用于需要多轮处理的较长任务。在启动 Kimi 前设置 `KIMI_CODE_EXPERIMENTAL_GOAL_COMMAND=1` 即可开启。
+
+  在终端界面中使用 `/goal <objective>` 让 Kimi 跨轮次持续专注于同一任务。例如：
+
+  ```text
+  /goal Fix the failing checkout test
+  ```
+
+  Kimi 会在终端界面中显示目标，并在工作过程中保持进度可见。使用 `/goal status`、`/goal pause`、`/goal resume`、`/goal cancel` 和 `/goal replace <objective>` 来管理该目标。该功能仍处于实验阶段，欢迎试用并反馈改进建议。
+- 新增 `kimi provider` CLI 子命令，支持 `add`、`remove`、`list` 以及 `catalog list` / `catalog add` 操作，可在不启动终端界面的情况下导入和管理来自自定义 registry（api.json）或公开 models.dev 目录的供应商。
+- 新增后台结构化提问，让 Agent 在等待用户回答时也能继续工作。
+- 新增后台自动更新，可在 tui.toml 中关闭。
+- 新增 `/undo` 斜杠命令，用于从对话历史中撤回上一条提示词，并在撤回时保持回放记录同步。
+- 新增 `kimi upgrade` 命令，用于手动检查并升级 Kimi Code CLI。
+- 新增审批生命周期 hook 事件，用于观察待处理和已完成的权限提示。
+- 允许子 Agent 使用在其父 Agent 上注册的自定义工具。
+- 支持用 glob 搜索显式的绝对路径（工作空间之外）。
+
+### 修复
+
+- 修复跨供应商回放时因不兼容的工具调用 ID 和未签名的 Claude thinking 历史导致失败的问题。
+- 修复自定义 registry 供应商在重新导入时的处理问题，防止多供应商条目丢失，并移除过时的供应商及其模型别名和默认模型引用。
+- 修复工具输出预览的渲染效果：去除尾部空行、为多行 Bash 命令标题附加省略号，并按视觉换行而非原始换行数裁切过长的单行输出。
+- 修复斜杠激活的 skill 因缺少系统提示词包装器而未被模型识别的问题。
+- 修复在过窄终端上 `/sessions` 选择器崩溃的问题，通过将每行渲染宽度限制在终端宽度内。
+- 在括号展开前规范化 glob 模式，防止不正确的路径匹配。
+- 防止退出 CLI 后仍出现修改过的键盘释放序列。
+- 修复 Windows 上的 Git Bash 路径检测，额外搜索 `usr\bin\bash.exe` 路径，这是许多 Git for Windows 安装中 bash 所在的位置（这些安装中 `bin\bash.exe` 不存在）。
+
+### 优化
+
+- 在欢迎面板中展示 MCP server 摘要，并在 /mcp 命令输出中增加配置提示。
+- 在欢迎界面及未配置模型时的提示中，将用户引导至 `/provider` 而非已移除的 `/connect` 命令。
+- 将当前 todo 列表以 markdown 形式附加到压缩摘要中，再写入历史记录。
+- 在页脚状态栏中显示完整模型名称，不再截断供应商前缀。
+- 在长任务中提醒模型刷新 TodoList，并加强 TodoList 进度追踪引导。
+- 将会话目录警告中的 chalk 具名颜色替换为主题感知的十六进制色值。
+
+### 重构
+
+- 将后台任务管理统一到 Agent 后台运行时中。
+
 ## 0.7.0
 
 ### 新功能


### PR DESCRIPTION
## Related Issue

N/A — routine post-release docs sync.

## Problem

Version 0.8.0 was published to npm but had not yet been synced into the docs-site changelog.

## What changed

- Synced the 0.8.0 entries from apps/kimi-code/CHANGELOG.md into docs/en/release-notes/changelog.md (source of truth).
- Classified 24 entries into Features, Bug Fixes, Polish, and Refactors.
- Translated the new content into docs/zh/release-notes/changelog.md, keeping the same structure, section order, and entry order.
- Stripped PR links and commit hashes per sync-changelog rules.
- Verified docs site builds.