### PR TITLE
fix(agent-core): expose goal budget schema as object

### DIFF
--- a/.changeset/fix-goal-budget-schema.md
+++ b/.changeset/fix-goal-budget-schema.md
@@ -1,0 +1,6 @@
+---
+"@moonshot-ai/agent-core": patch
+"@moonshot-ai/kimi-code": patch
+---
+
+Fix goal budget tool schema compatibility with stricter provider validation.

--- a/packages/agent-core/src/tools/builtin/goal/set-goal-budget.ts
+++ b/packages/agent-core/src/tools/builtin/goal/set-goal-budget.ts
@@ -17,21 +17,24 @@ import DESCRIPTION from './set-goal-budget.md';
 const MIN_REASONABLE_TIME_BUDGET_MS = 1_000;
 const MAX_REASONABLE_TIME_BUDGET_MS = 24 * 60 * 60 * 1000;
 
-const WholeNumberBudgetValueSchema = z
-  .number()
-  .int()
-  .positive()
-  .describe('The positive whole-number budget value.');
 const TimeBudgetValueSchema = z.number().positive().describe('The positive numeric time budget value.');
+const BudgetUnitSchema = z.enum(['turns', 'tokens', 'milliseconds', 'seconds', 'minutes', 'hours']);
 
-export const SetGoalBudgetToolInputSchema = z.discriminatedUnion('unit', [
-  z.object({ value: WholeNumberBudgetValueSchema, unit: z.literal('turns') }).strict(),
-  z.object({ value: WholeNumberBudgetValueSchema, unit: z.literal('tokens') }).strict(),
-  z.object({ value: TimeBudgetValueSchema, unit: z.literal('milliseconds') }).strict(),
-  z.object({ value: TimeBudgetValueSchema, unit: z.literal('seconds') }).strict(),
-  z.object({ value: TimeBudgetValueSchema, unit: z.literal('minutes') }).strict(),
-  z.object({ value: TimeBudgetValueSchema, unit: z.literal('hours') }).strict(),
-]);
+export const SetGoalBudgetToolInputSchema = z
+  .object({
+    value: TimeBudgetValueSchema,
+    unit: BudgetUnitSchema,
+  })
+  .strict()
+  .superRefine((input, ctx) => {
+    if ((input.unit === 'turns' || input.unit === 'tokens') && !Number.isInteger(input.value)) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['value'],
+        message: `${input.unit} budget value must be a positive whole number.`,
+      });
+    }
+  });
 
 export type SetGoalBudgetToolInput = z.infer<typeof SetGoalBudgetToolInputSchema>;
 

--- a/packages/agent-core/test/tools/goal.test.ts
+++ b/packages/agent-core/test/tools/goal.test.ts
@@ -129,6 +129,21 @@ describe('GetGoalTool', () => {
 });
 
 describe('SetGoalBudgetTool', () => {
+  it('exposes an object parameter schema for provider tool registration', () => {
+    const tool = new SetGoalBudgetTool(fakeAgent());
+
+    expect(tool.parameters).toMatchObject({
+      type: 'object',
+      properties: {
+        value: { type: 'number' },
+        unit: {
+          enum: ['turns', 'tokens', 'milliseconds', 'seconds', 'minutes', 'hours'],
+        },
+      },
+      required: ['value', 'unit'],
+    });
+  });
+
   it('accepts a value with a supported budget unit', () => {
     for (const unit of ['turns', 'tokens', 'milliseconds', 'seconds', 'minutes', 'hours']) {
       expect(SetGoalBudgetToolInputSchema.safeParse({ value: 20, unit }).success).toBe(true);


### PR DESCRIPTION
## Related Issue

Resolve #353

## Problem

See linked issue.

## What changed

Changed the goal budget tool input schema to expose provider-facing parameters as a top-level object schema while keeping the existing runtime validation for whole-number turn and token budgets. Added a focused test to prevent the tool schema from regressing to a non-object top-level shape.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.