### PR TITLE
chore: remove goal wire audit records

### DIFF
--- a/.changeset/remove-goal-records.md
+++ b/.changeset/remove-goal-records.md
@@ -1,0 +1,6 @@
+---
+"@moonshot-ai/agent-core": patch
+"@moonshot-ai/kimi-code": patch
+---
+
+Stop writing goal lifecycle audit entries to agent wire records.

--- a/packages/agent-core/src/agent/records/index.ts
+++ b/packages/agent-core/src/agent/records/index.ts
@@ -95,14 +95,6 @@ function restoreAgentRecord(agent: Agent, input: AgentRecord): void {
     case 'tools.update_store':
       agent.tools.updateStore(input.key, input.value);
       return;
-    // Goal records are an audit trail only. Goal state is restored from
-    // `state.json` (metadata.custom.goal), never rebuilt from these records.
-    case 'goal.create':
-    case 'goal.update':
-    case 'goal.account_usage':
-    case 'goal.continuation':
-    case 'goal.clear':
-      return;
   }
 }
 

--- a/packages/agent-core/src/agent/records/types.ts
+++ b/packages/agent-core/src/agent/records/types.ts
@@ -1,7 +1,6 @@
 import type { ContentPart, TokenUsage } from '@moonshot-ai/kosong';
 
 import type { LoopRecordedEvent } from '../../loop';
-import type { GoalActor, GoalBudgetLimits, GoalStatus } from '../../session/goal';
 import type { ToolStoreUpdate } from '../../tools/store';
 import type { CompactionBeginData, CompactionResult } from '../compaction';
 import type { AgentConfigUpdateData } from '../config';
@@ -72,47 +71,6 @@ export interface AgentRecordEvents {
   'context.undo': { count: number };
 
   'tools.update_store': ToolStoreUpdate;
-
-  // Goal-mode audit records. These are an audit trail only: replay MUST NOT
-  // rebuild goal state from them — `state.json` (metadata.custom.goal) is the
-  // source of truth.
-  'goal.create': {
-    goalId: string;
-    objective: string;
-    status: GoalStatus;
-    actor: GoalActor;
-    budgetLimits: GoalBudgetLimits;
-  };
-  'goal.update': {
-    goalId: string;
-    status: GoalStatus;
-    actor: GoalActor;
-    reason?: string;
-    /** Usage counters at the transition, so resume can rebuild the completion card. */
-    turnsUsed?: number;
-    tokensUsed?: number;
-    wallClockMs?: number;
-  };
-  'goal.account_usage': {
-    goalId: string;
-    /** Whether the delta came from token accounting or wall-clock accounting. */
-    usageKind: 'token' | 'wall_clock';
-    delta: number;
-    agentId?: string;
-    agentType?: string;
-    source?: string;
-    tokensUsed: number;
-    wallClockMs: number;
-  };
-  'goal.continuation': {
-    goalId: string;
-    turnsUsed: number;
-  };
-  'goal.clear': {
-    goalId: string;
-    actor: GoalActor;
-    reason?: string;
-  };
 }
 
 export type AgentRecord = {

--- a/packages/agent-core/src/session/goal.ts
+++ b/packages/agent-core/src/session/goal.ts
@@ -1,17 +1,11 @@
 import { randomUUID } from 'node:crypto';
 
 import { ErrorCodes, KimiError } from '#/errors';
-import type { AgentRecord } from '../agent/records/types';
 import {
   noopTelemetryClient,
   type TelemetryClient,
   type TelemetryProperties,
 } from '../telemetry';
-
-/** Minimal audit sink the goal store writes `goal.*` records into. */
-export interface GoalAuditSink {
-  logRecord(record: AgentRecord): void;
-}
 
 /**
  * Durable goal-mode state owned by {@link SessionGoalStore}.
@@ -89,7 +83,7 @@ export type GoalStatus =
    */
   | 'complete';
 
-/** Who performed a goal action. `cleared` is an audit action, not a status. */
+/** Who performed a goal action. */
 export type GoalActor = 'user' | 'model' | 'runtime' | 'system';
 
 export interface GoalBudgetLimits {
@@ -220,11 +214,6 @@ export interface SessionGoalStoreOptions {
   /** Writes (or clears, when `undefined`) the goal state and persists metadata. */
   readonly writeState: (state: SessionGoalState | undefined) => Promise<void>;
   /**
-   * Lazily resolves the main-agent audit sink. Goal audit records are written
-   * here once the sink exists, and queued in order until then.
-   */
-  readonly auditSink?: () => GoalAuditSink | undefined;
-  /**
    * Notified with the current goal snapshot (or `null` when cleared) after each
    * durable state change, so live UI (e.g. the footer badge) can update. A
    * `change` accompanies lifecycle / verdict / terminal transitions so the UI can
@@ -235,8 +224,6 @@ export interface SessionGoalStoreOptions {
   readonly onGoalUpdated?: (snapshot: GoalSnapshot | null, change?: GoalChange) => void;
   /** Remote usage telemetry. Goal content and reasons are never reported. */
   readonly telemetry?: TelemetryClient | undefined;
-  /** Injectable clock (epoch ms) for the live wall-clock timer; tests override it. */
-  readonly now?: () => number;
 }
 
 /**
@@ -258,42 +245,10 @@ export interface SessionGoalStoreOptions {
  *   to `paused` on session resume.
  */
 export class SessionGoalStore {
-  /** Audit records queued until the main-agent sink becomes available. */
-  private readonly pending: AgentRecord[] = [];
   private readonly telemetry: TelemetryClient;
 
   constructor(private readonly options: SessionGoalStoreOptions) {
     this.telemetry = options.telemetry ?? noopTelemetryClient;
-  }
-
-  /** Current epoch ms from the injectable clock (defaults to `Date.now`). */
-  private nowMs(): number {
-    return this.options.now?.() ?? Date.now();
-  }
-
-  // --- Audit -------------------------------------------------------------
-
-  /**
-   * Writes an audit record to the main-agent sink, or queues it in order when
-   * the sink is not yet available (e.g. before the main agent exists).
-   */
-  private appendAudit(record: AgentRecord): void {
-    const sink = this.options.auditSink?.();
-    if (sink !== undefined) {
-      sink.logRecord(record);
-    } else {
-      this.pending.push(record);
-    }
-  }
-
-  /** Flushes queued audit records in original order once a sink is available. */
-  flushPendingRecords(): void {
-    const sink = this.options.auditSink?.();
-    if (sink === undefined) return;
-    const queued = this.pending.splice(0);
-    for (const record of queued) {
-      sink.logRecord(record);
-    }
   }
 
   /**
@@ -329,7 +284,7 @@ export class SessionGoalStore {
     if (state.status === 'active') {
       this.applyStatus(state, 'paused', 'runtime', 'Paused after session resume');
       await this.persistState(state);
-      this.appendStatusUpdate(state, 'runtime', 'Paused after session resume');
+      this.trackStatusChanged(state, 'runtime');
       return;
     }
 
@@ -375,8 +330,8 @@ export class SessionGoalStore {
           'A goal already exists; use replace to start a new one',
         );
       }
-      // Clear the previous goal through the same internal clear path so audit
-      // and metadata stay consistent before storing the replacement.
+      // Clear the previous goal through the same internal clear path before
+      // storing the replacement.
       await this.clearInternal('system', 'Replaced by a new goal');
     }
 
@@ -393,7 +348,7 @@ export class SessionGoalStore {
       turnsUsed: 0,
       tokensUsed: 0,
       wallClockMs: 0,
-      wallClockResumedAt: this.nowMs(),
+      wallClockResumedAt: Date.now(),
       budgetLimits: input.budgetLimits ?? {},
     };
     if (input.completionCriterion !== undefined && input.completionCriterion.trim().length > 0) {
@@ -401,14 +356,6 @@ export class SessionGoalStore {
     }
 
     await this.persistState(state);
-    this.appendAudit({
-      type: 'goal.create',
-      goalId: state.goalId,
-      objective: state.objective,
-      status: state.status,
-      actor,
-      budgetLimits: state.budgetLimits,
-    });
     this.trackGoalCreated(state, actor, input.replace === true);
     return this.toSnapshot(state);
   }
@@ -430,7 +377,7 @@ export class SessionGoalStore {
     await this.persistState(state, {
       change: { kind: 'lifecycle', status: 'paused', reason: input.reason },
     });
-    this.appendStatusUpdate(state, actor, input.reason);
+    this.trackStatusChanged(state, actor);
     return this.toSnapshot(state);
   }
 
@@ -450,7 +397,7 @@ export class SessionGoalStore {
     await this.persistState(state, {
       change: { kind: 'lifecycle', status: 'paused', reason: input.reason },
     });
-    this.appendStatusUpdate(state, actor, input.reason);
+    this.trackStatusChanged(state, actor);
     return this.toSnapshot(state);
   }
 
@@ -471,7 +418,7 @@ export class SessionGoalStore {
     await this.persistState(state, {
       change: { kind: 'lifecycle', status: 'active', reason: input.reason },
     });
-    this.appendStatusUpdate(state, actor, input.reason);
+    this.trackStatusChanged(state, actor);
     return this.toSnapshot(state);
   }
 
@@ -528,7 +475,7 @@ export class SessionGoalStore {
     await this.persistState(state, {
       change: { kind: 'lifecycle', status: 'blocked', reason: input.reason },
     });
-    this.appendStatusUpdate(state, actor, input.reason);
+    this.trackStatusChanged(state, actor);
     return this.toSnapshot(state);
   }
 
@@ -550,9 +497,9 @@ export class SessionGoalStore {
     this.applyStatus(state, 'complete', actor, input.reason);
     state.terminalReason = input.reason;
     const snapshot = this.toSnapshot(state);
-    // Audit + notify the UI of completion (with final stats) directly, without
+    // Notify the UI of completion (with final stats) directly, without
     // persisting `complete` to disk...
-    this.appendStatusUpdate(state, actor, input.reason);
+    this.trackStatusChanged(state, actor);
     this.options.onGoalUpdated?.(snapshot, {
       kind: 'completion',
       status: 'complete',
@@ -592,17 +539,6 @@ export class SessionGoalStore {
     state.tokensUsed += delta;
     state.updatedAt = new Date().toISOString();
     await this.persistState(state, { silent: true }); // per-step: no UI update
-    this.appendAudit({
-      type: 'goal.account_usage',
-      goalId: state.goalId,
-      usageKind: 'token',
-      delta,
-      agentId: input.agentId,
-      agentType: input.agentType,
-      source: input.source,
-      tokensUsed: state.tokensUsed,
-      wallClockMs: state.wallClockMs,
-    });
     return this.toSnapshot(state);
   }
 
@@ -613,11 +549,6 @@ export class SessionGoalStore {
     state.turnsUsed += 1;
     state.updatedAt = new Date().toISOString();
     await this.persistState(state);
-    this.appendAudit({
-      type: 'goal.continuation',
-      goalId: state.goalId,
-      turnsUsed: state.turnsUsed,
-    });
     this.track('goal_continued', {
       turns_used: state.turnsUsed,
     });
@@ -626,32 +557,20 @@ export class SessionGoalStore {
 
   // --- Internals ---------------------------------------------------------
 
-  private async clearInternal(actor: GoalActor, reason?: string): Promise<void> {
+  private async clearInternal(actor: GoalActor, _reason?: string): Promise<void> {
     const state = this.options.readState();
     if (state === undefined) return; // idempotent
-    const goalId = state.goalId;
     await this.persistState(undefined);
-    this.appendAudit({ type: 'goal.clear', goalId, actor, reason });
     this.track('goal_cleared', { actor });
   }
 
-  private appendStatusUpdate(state: SessionGoalState, actor: GoalActor, reason?: string): void {
-    this.appendAudit({
-      type: 'goal.update',
-      goalId: state.goalId,
-      status: state.status,
-      actor,
-      reason,
-      turnsUsed: state.turnsUsed,
-      tokensUsed: state.tokensUsed,
-      wallClockMs: state.wallClockMs,
-    });
+  private trackStatusChanged(state: SessionGoalState, actor: GoalActor): void {
     this.track('goal_status_changed', {
       actor,
       status: state.status,
       turns_used: state.turnsUsed,
       tokens_used: state.tokensUsed,
-      wall_clock_ms: liveWallClockMs(state, this.nowMs()),
+      wall_clock_ms: liveWallClockMs(state, Date.now()),
       ...budgetTelemetryProperties(state.budgetLimits),
     });
   }
@@ -682,7 +601,7 @@ export class SessionGoalStore {
     // Fold the live wall-clock interval into the running total when leaving
     // `active`, and anchor a fresh interval when entering it, so `wallClockMs`
     // stays a correct, persistable total across pause/resume/complete.
-    const now = this.nowMs();
+    const now = Date.now();
     if (state.status === 'active' && state.wallClockResumedAt !== undefined) {
       state.wallClockMs += Math.max(0, now - state.wallClockResumedAt);
       state.wallClockResumedAt = undefined;
@@ -727,7 +646,7 @@ export class SessionGoalStore {
     return {
       turnsUsed: state.turnsUsed,
       tokensUsed: state.tokensUsed,
-      wallClockMs: liveWallClockMs(state, this.nowMs()),
+      wallClockMs: liveWallClockMs(state, Date.now()),
     };
   }
 
@@ -743,8 +662,8 @@ export class SessionGoalStore {
       updatedBy: state.updatedBy,
       turnsUsed: state.turnsUsed,
       tokensUsed: state.tokensUsed,
-      wallClockMs: liveWallClockMs(state, this.nowMs()),
-      budget: computeBudgetReport(state, this.nowMs()),
+      wallClockMs: liveWallClockMs(state, Date.now()),
+      budget: computeBudgetReport(state, Date.now()),
       terminalReason: state.terminalReason,
     };
   }

--- a/packages/agent-core/src/session/index.ts
+++ b/packages/agent-core/src/session/index.ts
@@ -143,7 +143,6 @@ export class Session {
         }
         return this.writeMetadata();
       },
-      auditSink: () => this.agents.get('main')?.records,
       onGoalUpdated: (snapshot, change) => {
         void this.rpc.emitEvent({ type: 'goal.updated', agentId: 'main', snapshot, change });
       },
@@ -171,8 +170,6 @@ export class Session {
 
   async createMain() {
     const { agent } = await this.createAgent({ type: 'main' }, DEFAULT_AGENT_PROFILES['agent']);
-    // The main-agent audit sink now exists; flush any goal records queued before it.
-    this.goals.flushPendingRecords();
     await this.triggerSessionStart('startup');
     return agent;
   }
@@ -180,8 +177,8 @@ export class Session {
   async resume(): Promise<{ warning?: string }> {
     await this.skillsReady;
     const { agents } = await this.readMetadata();
-    // Reconcile the persisted goal (active -> paused, drop malformed/stale) before
-    // agents are rebuilt. The audit record (if any) is queued and flushed below.
+    // Reconcile the persisted goal (active -> paused, drop malformed/stale)
+    // before agents are rebuilt.
     await this.goals.normalizeMetadata();
     this.agents.clear();
     let warning: string | undefined;
@@ -193,9 +190,6 @@ export class Session {
       }
     });
     await Promise.all(resumeTasks);
-    // The main-agent audit sink now exists; flush any goal records queued during
-    // normalizeMetadata (e.g. the active -> paused resume transition).
-    this.goals.flushPendingRecords();
     const resumeWarning = warning;
     // A session migrated from an external tool ships a wire without the
     // `config.update` bootstrap events a natively-created agent writes, so the

--- a/packages/agent-core/test/agent/records/index.test.ts
+++ b/packages/agent-core/test/agent/records/index.test.ts
@@ -184,28 +184,6 @@ describe('AgentRecords persistence metadata', () => {
 
     await expect(records.replay()).rejects.toThrow('Missing wire migration for version 0.9');
   });
-
-  it('ignores goal.* records during replay, leaving agent state unchanged', async () => {
-    const persistence = new InMemoryAgentRecordPersistence([
-      { type: 'metadata', protocol_version: AGENT_WIRE_PROTOCOL_VERSION, created_at: 1 },
-      {
-        type: 'goal.create',
-        goalId: 'g1',
-        objective: 'do work',
-        status: 'active',
-        actor: 'user',
-        budgetLimits: { turnBudget: 20 },
-      },
-      { type: 'goal.account_usage', goalId: 'g1', usageKind: 'token', delta: 5, tokensUsed: 5, wallClockMs: 0 },
-      { type: 'goal.continuation', goalId: 'g1', turnsUsed: 1 },
-      { type: 'goal.update', goalId: 'g1', status: 'complete', actor: 'model' },
-      { type: 'goal.clear', goalId: 'g1', actor: 'user' },
-    ]);
-    const { agent } = testAgent({ persistence });
-
-    await expect(agent.records.replay()).resolves.toEqual({ warning: undefined });
-    expect(agent.context.history).toHaveLength(0);
-  });
 });
 
 class RecordingInMemoryAgentRecordPersistence extends InMemoryAgentRecordPersistence {

--- a/packages/agent-core/test/harness/goal-session.test.ts
+++ b/packages/agent-core/test/harness/goal-session.test.ts
@@ -158,21 +158,10 @@ describe('goal session end-to-end', () => {
     expect(parsed.custom.goal).toBeUndefined();
     expect(api.getGoal({}).goal).toBeNull();
 
-    // Audit trail records the whole run incl. completion — and no evaluator record.
+    // Goal state is stored in session metadata only; wire records must not contain
+    // goal.* audit entries.
     const records = await readWireRecords(sessionDir);
-    const types = new Set(records.map((record) => record['type']));
-    for (const t of ['goal.create', 'goal.account_usage', 'goal.continuation', 'goal.update', 'goal.clear']) {
-      expect(types.has(t)).toBe(true);
-    }
-    expect(types.has('goal.evaluate')).toBe(false);
-    const usageRecords = records.filter((record) => record['type'] === 'goal.account_usage');
-    expect(usageRecords).toHaveLength(2);
-    const finalUsage = usageRecords.at(-1)?.['tokensUsed'];
-    expect(typeof finalUsage).toBe('number');
-    const completion = records.find(
-      (record) => record['type'] === 'goal.update' && record['status'] === 'complete',
-    );
-    expect(completion?.['tokensUsed']).toBe(finalUsage);
+    expect(records.filter((record) => String(record['type']).startsWith('goal.'))).toEqual([]);
   });
 
   it('blocks at a turn budget (no wrap-up segment)', async () => {

--- a/packages/agent-core/test/session/goal.test.ts
+++ b/packages/agent-core/test/session/goal.test.ts
@@ -9,46 +9,16 @@ import { Session } from '../../src/session';
 import { SessionAPIImpl } from '../../src/session/rpc';
 import {
   SessionGoalStore,
-  type GoalAuditSink,
   type GoalChange,
   type GoalSnapshot,
   type SessionGoalState,
 } from '../../src/session/goal';
-import type { AgentRecord } from '../../src/agent/records';
 import type { SDKSessionRPC } from '../../src/rpc';
 import type { TelemetryClient } from '../../src/telemetry';
 import { testKaos } from '../fixtures/test-kaos';
 import { recordingTelemetry, type TelemetryRecord } from '../fixtures/telemetry';
 
 const GOAL_FLAG = 'KIMI_CODE_EXPERIMENTAL_GOAL_COMMAND';
-
-/** An in-memory store backing plus a controllable lazy audit sink. */
-function makeAuditStore(opts: { sinkReady?: boolean } = {}) {
-  let state: SessionGoalState | undefined;
-  const records: AgentRecord[] = [];
-  const sink: GoalAuditSink = { logRecord: (r) => records.push(r) };
-  let ready = opts.sinkReady ?? true;
-  const store = new SessionGoalStore({
-    sessionId: 'test',
-    readState: () => state,
-    writeState: async (next) => {
-      state = next;
-    },
-    auditSink: () => (ready ? sink : undefined),
-  });
-  return {
-    store,
-    records,
-    types: () => records.map((r) => r.type),
-    current: () => state,
-    setState: (next: SessionGoalState | undefined) => {
-      state = next;
-    },
-    enableSink: () => {
-      ready = true;
-    },
-  };
-}
 
 function activeState(overrides: Partial<SessionGoalState> = {}): SessionGoalState {
   return {
@@ -68,7 +38,7 @@ function activeState(overrides: Partial<SessionGoalState> = {}): SessionGoalStat
 }
 
 /** A simple in-memory backing for the goal store. */
-function makeStore(opts: { now?: () => number; telemetry?: TelemetryClient } = {}) {
+function makeStore(opts: { telemetry?: TelemetryClient } = {}) {
   let state: SessionGoalState | undefined;
   let writeCount = 0;
   const updates: (GoalSnapshot | null)[] = [];
@@ -85,11 +55,13 @@ function makeStore(opts: { now?: () => number; telemetry?: TelemetryClient } = {
       changes.push(change);
     },
     telemetry: opts.telemetry,
-    ...(opts.now !== undefined ? { now: opts.now } : {}),
   });
   return {
     store,
     current: () => state,
+    setState: (next: SessionGoalState | undefined) => {
+      state = next;
+    },
     writeCount: () => writeCount,
     updates: () => updates,
     changes: () => changes,
@@ -99,6 +71,8 @@ function makeStore(opts: { now?: () => number; telemetry?: TelemetryClient } = {
 const tempDirs: string[] = [];
 
 afterEach(async () => {
+  vi.useRealTimers();
+  vi.restoreAllMocks();
   for (const dir of tempDirs.splice(0)) {
     await rm(dir, { recursive: true, force: true });
   }
@@ -359,8 +333,9 @@ describe('SessionGoalStore budgets', () => {
   });
 
   it('computes token, turn, and wall-clock budget flags independently', async () => {
-    let clock = 1_000;
-    const { store } = makeStore({ now: () => clock });
+    vi.useFakeTimers();
+    vi.setSystemTime(1_000);
+    const { store } = makeStore();
     await store.createGoal({
       objective: 'work',
       budgetLimits: { tokenBudget: 100, turnBudget: 2, wallClockBudgetMs: 1000 },
@@ -378,7 +353,7 @@ describe('SessionGoalStore budgets', () => {
     expect(snap.budget.turnBudgetReached).toBe(true);
 
     // Live wall-clock: advancing the clock past the budget trips the flag.
-    clock += 1_000;
+    vi.setSystemTime(2_000);
     snap = store.getGoal().goal!;
     expect(snap.budget.wallClockBudgetReached).toBe(true);
   });
@@ -394,15 +369,16 @@ describe('SessionGoalStore accounting', () => {
   });
 
   it('tracks live wall-clock from when the goal became active', async () => {
-    let clock = 10_000;
-    const { store } = makeStore({ now: () => clock });
+    vi.useFakeTimers();
+    vi.setSystemTime(10_000);
+    const { store } = makeStore();
     await store.createGoal({ objective: 'work' });
-    clock += 500;
+    vi.setSystemTime(10_500);
     expect(store.getGoal().goal?.wallClockMs).toBe(500);
     // Folds the interval and stops counting once the goal leaves `active`.
-    clock += 250;
+    vi.setSystemTime(10_750);
     await store.pauseGoal();
-    clock += 9_999; // paused time must not accrue
+    vi.setSystemTime(20_749); // paused time must not accrue
     expect(store.getGoal().goal?.wallClockMs).toBe(750);
   });
 
@@ -524,126 +500,38 @@ describe('SessionGoalStore lifecycle', () => {
   });
 });
 
-describe('SessionGoalStore audit records', () => {
-  it('writes directly when the sink is already available', async () => {
-    const { store, types } = makeAuditStore({ sinkReady: true });
-    await store.createGoal({ objective: 'work' });
-    expect(types()).toEqual(['goal.create']);
-  });
-
-  it('queues records and flushes them in order when the sink becomes available', async () => {
-    const { store, types, enableSink } = makeAuditStore({ sinkReady: false });
-    await store.createGoal({ objective: 'work' });
-    await store.incrementTurn();
-    expect(types()).toEqual([]); // queued, not yet flushed
-    enableSink();
-    store.flushPendingRecords();
-    expect(types()).toEqual(['goal.create', 'goal.continuation']);
-  });
-
-  it('flushPendingRecords is idempotent', async () => {
-    const { store, types, enableSink } = makeAuditStore({ sinkReady: false });
-    await store.createGoal({ objective: 'work' });
-    enableSink();
-    store.flushPendingRecords();
-    store.flushPendingRecords();
-    expect(types()).toEqual(['goal.create']);
-  });
-
-  it('replacing a goal appends one goal.clear before the new goal.create', async () => {
-    const { store, types } = makeAuditStore();
-    await store.createGoal({ objective: 'first' });
-    await store.createGoal({ objective: 'second', replace: true });
-    expect(types()).toEqual(['goal.create', 'goal.clear', 'goal.create']);
-  });
-
-  it('pauseGoal and resumeGoal append goal.update', async () => {
-    const { store, types } = makeAuditStore();
-    await store.createGoal({ objective: 'work' });
-    await store.pauseGoal();
-    await store.resumeGoal();
-    expect(types()).toEqual(['goal.create', 'goal.update', 'goal.update']);
-  });
-
-  it('markBlocked appends a goal.update with the blocked status', async () => {
-    const { store, records } = makeAuditStore();
-    await store.createGoal({ objective: 'work' });
-    await store.markBlocked({ reason: 'stuck' });
-    const last = records.at(-1);
-    expect(last).toMatchObject({ type: 'goal.update', status: 'blocked' });
-  });
-
-  it('markComplete appends a goal.update (complete) then a goal.clear', async () => {
-    const { store, types } = makeAuditStore();
-    await store.createGoal({ objective: 'work' });
-    await store.markComplete({ reason: 'done' });
-    expect(types()).toEqual(['goal.create', 'goal.update', 'goal.clear']);
-  });
-
-  it('accounting appends goal.account_usage for token usage', async () => {
-    const { store, records } = makeAuditStore();
-    await store.createGoal({ objective: 'work' });
-    await store.recordTokenUsage({ tokenDelta: 5, agentId: 'main', agentType: 'main', source: 'agent_step' });
-    const usage = records.filter((r) => r.type === 'goal.account_usage');
-    expect(usage.map((r) => (r as { usageKind: string }).usageKind)).toEqual(['token']);
-  });
-
-  it('incrementTurn appends goal.continuation', async () => {
-    const { store, types } = makeAuditStore();
-    await store.createGoal({ objective: 'work' });
-    await store.incrementTurn();
-    expect(types().at(-1)).toBe('goal.continuation');
-  });
-
-  it('cancelGoal appends only goal.clear (cancel = discard)', async () => {
-    const { store, types } = makeAuditStore();
-    await store.createGoal({ objective: 'work' });
-    await store.cancelGoal({ reason: 'stop' });
-    expect(types()).toEqual(['goal.create', 'goal.clear']);
-  });
-});
-
 describe('SessionGoalStore normalizeMetadata', () => {
   it('converts an active goal to paused on resume', async () => {
-    const { store, current, setState } = makeAuditStore();
+    const { store, current, setState } = makeStore();
     setState(activeState());
     await store.normalizeMetadata();
     expect(current()?.status).toBe('paused');
     expect(store.getGoal().goal?.status).toBe('paused');
   });
 
-  it('queues a goal.update for the active-to-paused resume transition', async () => {
-    const { store, types, setState } = makeAuditStore();
-    setState(activeState());
-    await store.normalizeMetadata();
-    expect(types()).toEqual(['goal.update']);
-  });
-
   it('keeps paused goals on resume', async () => {
-    const { store, types, current, setState } = makeAuditStore();
+    const { store, current, setState } = makeStore();
     setState(activeState({ status: 'paused' }));
     await store.normalizeMetadata();
     expect(current()?.status).toBe('paused');
-    expect(types()).toEqual([]);
   });
 
   it('keeps blocked goals on resume (resumable)', async () => {
-    const { store, types, current, setState } = makeAuditStore();
+    const { store, current, setState } = makeStore();
     setState(activeState({ status: 'blocked', terminalReason: 'stuck' }));
     await store.normalizeMetadata();
     expect(current()?.status).toBe('blocked');
-    expect(types()).toEqual([]);
   });
 
   it('removes malformed goal data on resume', async () => {
-    const { store, current, setState } = makeAuditStore();
+    const { store, current, setState } = makeStore();
     setState({ bogus: true } as unknown as SessionGoalState);
     await store.normalizeMetadata();
     expect(current()).toBeUndefined();
   });
 
   it('removes a stray complete goal on resume (complete is transient)', async () => {
-    const { store, current, setState } = makeAuditStore();
+    const { store, current, setState } = makeStore();
     setState(activeState({ status: 'complete', terminalReason: 'done' }));
     await store.normalizeMetadata();
     expect(current()).toBeUndefined();


### PR DESCRIPTION
## Related Issue

No linked issue; this PR removes goal lifecycle audit records from agent wire persistence.

## Problem

Goal mode state is already persisted in session metadata. Writing separate `goal.*` audit records to agent wire adds an extra persistence path that is no longer needed.

## What changed

Removed the `goal.*` agent record types and stopped the goal store from writing goal lifecycle, usage, continuation, and clear records. Goal updates still emit live RPC events and persist current state through session metadata, and tests now assert that goal sessions no longer write `goal.*` wire entries.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.