### PR TITLE
test: disable harness log writes by default

### DIFF
--- a/apps/kimi-code/test/e2e/local-logging-export.e2e.test.ts
+++ b/apps/kimi-code/test/e2e/local-logging-export.e2e.test.ts
@@ -19,13 +19,16 @@ const ENABLED = process.env['KIMI_E2E'] === '1';
 let homeDir: string;
 let workDir: string;
 let oldHome: string | undefined;
+let oldLogLevel: string | undefined;
 
 beforeEach(async () => {
   await __resetRootLoggerForTest();
   homeDir = await mkdtemp(join(tmpdir(), 'kimi-cli-log-home-'));
   workDir = await mkdtemp(join(tmpdir(), 'kimi-cli-log-work-'));
   oldHome = process.env['KIMI_CODE_HOME'];
+  oldLogLevel = process.env['KIMI_LOG_LEVEL'];
   process.env['KIMI_CODE_HOME'] = homeDir;
+  process.env['KIMI_LOG_LEVEL'] = 'info';
 });
 
 afterEach(async () => {
@@ -34,6 +37,11 @@ afterEach(async () => {
     delete process.env['KIMI_CODE_HOME'];
   } else {
     process.env['KIMI_CODE_HOME'] = oldHome;
+  }
+  if (oldLogLevel === undefined) {
+    delete process.env['KIMI_LOG_LEVEL'];
+  } else {
+    process.env['KIMI_LOG_LEVEL'] = oldLogLevel;
   }
   await rm(homeDir, { recursive: true, force: true });
   await rm(workDir, { recursive: true, force: true });

--- a/apps/kimi-code/vitest.config.ts
+++ b/apps/kimi-code/vitest.config.ts
@@ -15,6 +15,9 @@ export default defineConfig({
   },
   test: {
     name: 'cli',
+    env: {
+      KIMI_LOG_LEVEL: 'off',
+    },
     include: ['test/**/*.test.ts', 'test/**/*.test.tsx'],
   },
 });

--- a/packages/node-sdk/test/auth-facade.test.ts
+++ b/packages/node-sdk/test/auth-facade.test.ts
@@ -1,5 +1,4 @@
-import { mkdirSync, rmSync } from 'node:fs';
-import { readFile, writeFile } from 'node:fs/promises';
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
@@ -29,14 +28,13 @@ function freshToken(): TokenInfo {
   };
 }
 
-beforeEach(() => {
-  homeDir = join(tmpdir(), `kimi-sdk-auth-${Date.now()}-${Math.random().toString(36).slice(2)}`);
-  mkdirSync(homeDir, { recursive: true });
+beforeEach(async () => {
+  homeDir = await mkdtemp(join(tmpdir(), 'kimi-sdk-auth-'));
 });
 
-afterEach(() => {
+afterEach(async () => {
   vi.unstubAllGlobals();
-  rmSync(homeDir, { recursive: true, force: true });
+  await rm(homeDir, { recursive: true, force: true });
 });
 
 describe('KimiHarness.auth', () => {

--- a/packages/node-sdk/test/local-logging.test.ts
+++ b/packages/node-sdk/test/local-logging.test.ts
@@ -20,11 +20,13 @@ const LOG_ENV_KEYS = [
 ] as const;
 
 beforeEach(async () => {
+  process.env['KIMI_LOG_LEVEL'] = 'info';
   await __resetRootLoggerForTest();
 });
 
 afterEach(async () => {
   await __resetRootLoggerForTest();
+  process.env['KIMI_LOG_LEVEL'] = 'off';
   for (const dir of tempDirs.splice(0)) {
     await rm(dir, { recursive: true, force: true });
   }

--- a/packages/node-sdk/vitest.config.ts
+++ b/packages/node-sdk/vitest.config.ts
@@ -16,6 +16,9 @@ export default defineConfig({
   },
   test: {
     name: 'kimi-sdk',
+    env: {
+      KIMI_LOG_LEVEL: 'off',
+    },
     include: ['test/**/*.test.ts'],
   },
 });


### PR DESCRIPTION
## Related Issue

No linked issue. This addresses flaky test cleanup caused by harness logging writing to temporary home directories during non-logging tests.

## Problem

Tests that construct `KimiHarness` configure the process-wide root logger even when the test is not asserting logging behavior. With logging enabled by default, unrelated tests can create log files under temporary home directories and make cleanup timing-sensitive.

## What changed

- Set the SDK and CLI Vitest projects to run with `KIMI_LOG_LEVEL=off` by default.
- Re-enabled logging explicitly in the tests that verify local log files and log export behavior.
- Switched the auth facade test to async `mkdtemp`/`rm` temp directory cleanup without logger-specific reset hooks.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.

## Verification

- `pnpm vitest run packages/node-sdk/test/auth-facade.test.ts packages/node-sdk/test/local-logging.test.ts`
- `pnpm vitest run --project kimi-sdk`
- `pnpm vitest run --project cli`
- `KIMI_E2E=1 pnpm vitest run apps/kimi-code/test/e2e/local-logging-export.e2e.test.ts`
- `pnpm --filter @moonshot-ai/kimi-code-sdk run typecheck`
- `pnpm --filter @moonshot-ai/kimi-code run typecheck`
- auth facade test repeated 25 times