### PR TITLE
feat(agent-core): detect and escalate repeated tool calls to prevent infinite loops

### DIFF
--- a/packages/agent-core/src/agent/turn/index.ts
+++ b/packages/agent-core/src/agent/turn/index.ts
@@ -541,7 +541,7 @@ export class TurnFlow {
 
   private async runStepLoop(turnId: number, signal: AbortSignal): Promise<LoopTurnStopReason> {
     let stopHookContinuationUsed = false;
-    const deduper = new ToolCallDeduplicator();
+    const deduper = new ToolCallDeduplicator({ telemetry: this.agent.telemetry });
     await this.agent.mcp?.waitForInitialLoad(signal);
     // Surface the active goal at the start of the turn (append-only; no-op when
     // goal mode is off). Each goal continuation is its own turn, so this re-injects

--- a/packages/agent-core/src/agent/turn/tool-dedup.ts
+++ b/packages/agent-core/src/agent/turn/tool-dedup.ts
@@ -1,5 +1,6 @@
 import type { ContentPart } from '@moonshot-ai/kosong';
 
+import type { TelemetryClient } from '../../telemetry';
 import type { ExecutableToolResult } from '../../loop/types';
 
 import { canonicalTelemetryArgs } from './canonical-args';
@@ -25,6 +26,17 @@ function makeReminderText2(toolName: string, repeatCount: number, args: unknown)
     '\n</system-reminder>'
   );
 }
+
+const REMINDER_TEXT_3 =
+  '\n\n<system-reminder>\n' +
+  'You are stuck in a dead end and have repeatedly made the same function call without progress.\n' +
+  'Stop all function calls immediately. Do not call any tool in your next response.\n' +
+  'In analysis, review the current execution state and identify why progress is blocked.\n' +
+  'Then return a text-only summary to the user that reports the current problem, what has already been tried, and what information or decision is needed next.' +
+  '\n</system-reminder>';
+
+const REPEAT_REMINDER_MIN_STREAK = 10;
+const REPEAT_FORCE_STOP_STREAK = 15;
 
 interface Deferred<T> {
   readonly promise: Promise<T>;
@@ -63,6 +75,14 @@ function appendReminder(result: ExecutableToolResult, reminderText: string): Exe
     : { ...result, output: newOutput };
 }
 
+function forceStopResult(
+  result: ExecutableToolResult,
+  reminderText: string,
+): ExecutableToolResult {
+  const withReminder = appendReminder(result, reminderText);
+  return { ...withReminder, isError: true, stopTurn: true };
+}
+
 /**
  * Placeholder result returned from `checkSameStep` for a duplicate call. Never
  * reaches the model — it is replaced in `finalizeResult` by awaiting the
@@ -82,8 +102,16 @@ const DEDUP_PLACEHOLDER_RESULT: ExecutableToolResult = { output: '' };
  *   reuses the original call's result instead of executing the tool twice.
  * - Cross-step dedup: when the exact same call is repeated consecutively
  *   across steps, the result returned to the model is suffixed with a system
- *   reminder at specific streak thresholds (3, 5, and 8) to nudge the model
- *   to try a different approach.
+ *   reminder at escalating streak thresholds (3, 5, 8) to nudge the model to
+ *   try a different approach. From streak 10 through 14 a stronger
+ *   dead-end reminder is appended that instructs the model to stop calling
+ *   tools entirely. At streak 15 the turn is force-stopped via
+ *   `{ isError: true, stopTurn: true }` so the loop cannot keep spinning on
+ *   the same call.
+ *
+ * Telemetry: every finalized original call with streak >= 2 emits a
+ * `tool_call_repeat` event carrying the current streak count as `repeat_count`
+ * along with the tool name and which action was taken (none/reminder/stop).
  */
 export class ToolCallDeduplicator {
   private stepDeferreds = new Map<string, Deferred<ExecutableToolResult>>();
@@ -101,6 +129,11 @@ export class ToolCallDeduplicator {
   private callKeyByCallId = new Map<string, string>();
   private consecutiveKey: string | null = null;
   private consecutiveCount = 0;
+  private readonly telemetry: TelemetryClient | undefined;
+
+  constructor(options?: { readonly telemetry?: TelemetryClient | undefined }) {
+    this.telemetry = options?.telemetry;
+  }
 
   beginStep(): void {
     for (const deferred of this.stepDeferreds.values()) {
@@ -195,10 +228,27 @@ export class ToolCallDeduplicator {
     }
 
     let finalResult = result;
-    if (streak === 3) {
+    let action: 'none' | 'reminder' | 'stop' = 'none';
+    if (streak >= REPEAT_FORCE_STOP_STREAK) {
+      finalResult = forceStopResult(result, REMINDER_TEXT_3);
+      action = 'stop';
+    } else if (streak >= REPEAT_REMINDER_MIN_STREAK) {
+      finalResult = appendReminder(result, REMINDER_TEXT_3);
+      action = 'reminder';
+    } else if (streak === 3) {
       finalResult = appendReminder(result, REMINDER_TEXT_1);
+      action = 'reminder';
     } else if (streak === 5 || streak === 8) {
       finalResult = appendReminder(result, makeReminderText2(toolName, streak, args));
+      action = 'reminder';
+    }
+
+    if (streak >= 2) {
+      this.telemetry?.track('tool_call_repeat', {
+        tool_name: toolName,
+        repeat_count: streak,
+        action,
+      });
     }
 
     this.stepDeferreds.get(key)?.resolve(finalResult);
@@ -208,5 +258,8 @@ export class ToolCallDeduplicator {
 
 export const __testing = {
   REMINDER_TEXT_1,
+  REMINDER_TEXT_3,
   makeReminderText2,
+  REPEAT_REMINDER_MIN_STREAK,
+  REPEAT_FORCE_STOP_STREAK,
 };

--- a/packages/agent-core/src/agent/turn/tool-dedup.ts
+++ b/packages/agent-core/src/agent/turn/tool-dedup.ts
@@ -35,8 +35,10 @@ const REMINDER_TEXT_3 =
   'Then return a text-only summary to the user that reports the current problem, what has already been tried, and what information or decision is needed next.' +
   '\n</system-reminder>';
 
-const REPEAT_REMINDER_MIN_STREAK = 10;
-const REPEAT_FORCE_STOP_STREAK = 15;
+const REPEAT_REMINDER_1_START = 3;
+const REPEAT_REMINDER_2_START = 5;
+const REPEAT_REMINDER_3_START = 8;
+const REPEAT_FORCE_STOP_STREAK = 12;
 
 interface Deferred<T> {
   readonly promise: Promise<T>;
@@ -80,7 +82,7 @@ function forceStopResult(
   reminderText: string,
 ): ExecutableToolResult {
   const withReminder = appendReminder(result, reminderText);
-  return { ...withReminder, isError: true, stopTurn: true };
+  return { ...withReminder, stopTurn: true };
 }
 
 /**
@@ -102,16 +104,17 @@ const DEDUP_PLACEHOLDER_RESULT: ExecutableToolResult = { output: '' };
  *   reuses the original call's result instead of executing the tool twice.
  * - Cross-step dedup: when the exact same call is repeated consecutively
  *   across steps, the result returned to the model is suffixed with a system
- *   reminder at escalating streak thresholds (3, 5, 8) to nudge the model to
- *   try a different approach. From streak 10 through 14 a stronger
- *   dead-end reminder is appended that instructs the model to stop calling
- *   tools entirely. At streak 15 the turn is force-stopped via
- *   `{ isError: true, stopTurn: true }` so the loop cannot keep spinning on
- *   the same call.
+ *   reminder once the streak hits 3. The reminder escalates as the streak
+ *   grows: r1 (gentle nudge) from streak 3, r2 (concrete repeat report) from
+ *   streak 5, r3 (dead-end stop instruction) from streak 8. From streak 12
+ *   onward the turn is force-stopped via `{ stopTurn: true }` so the loop
+ *   cannot keep spinning on the same call. Force-stop does not flip a
+ *   successful tool result into an error — the underlying tool's `isError`
+ *   is preserved.
  *
  * Telemetry: every finalized original call with streak >= 2 emits a
  * `tool_call_repeat` event carrying the current streak count as `repeat_count`
- * along with the tool name and which action was taken (none/reminder/stop).
+ * along with the tool name and which action was taken (none/r1/r2/r3/stop).
  */
 export class ToolCallDeduplicator {
   private stepDeferreds = new Map<string, Deferred<ExecutableToolResult>>();
@@ -228,19 +231,19 @@ export class ToolCallDeduplicator {
     }
 
     let finalResult = result;
-    let action: 'none' | 'reminder' | 'stop' = 'none';
+    let action: 'none' | 'r1' | 'r2' | 'r3' | 'stop' = 'none';
     if (streak >= REPEAT_FORCE_STOP_STREAK) {
       finalResult = forceStopResult(result, REMINDER_TEXT_3);
       action = 'stop';
-    } else if (streak >= REPEAT_REMINDER_MIN_STREAK) {
+    } else if (streak >= REPEAT_REMINDER_3_START) {
       finalResult = appendReminder(result, REMINDER_TEXT_3);
-      action = 'reminder';
-    } else if (streak === 3) {
-      finalResult = appendReminder(result, REMINDER_TEXT_1);
-      action = 'reminder';
-    } else if (streak === 5 || streak === 8) {
+      action = 'r3';
+    } else if (streak >= REPEAT_REMINDER_2_START) {
       finalResult = appendReminder(result, makeReminderText2(toolName, streak, args));
-      action = 'reminder';
+      action = 'r2';
+    } else if (streak >= REPEAT_REMINDER_1_START) {
+      finalResult = appendReminder(result, REMINDER_TEXT_1);
+      action = 'r1';
     }
 
     if (streak >= 2) {
@@ -260,6 +263,8 @@ export const __testing = {
   REMINDER_TEXT_1,
   REMINDER_TEXT_3,
   makeReminderText2,
-  REPEAT_REMINDER_MIN_STREAK,
+  REPEAT_REMINDER_1_START,
+  REPEAT_REMINDER_2_START,
+  REPEAT_REMINDER_3_START,
   REPEAT_FORCE_STOP_STREAK,
 };

--- a/packages/agent-core/src/loop/types.ts
+++ b/packages/agent-core/src/loop/types.ts
@@ -85,11 +85,7 @@ export interface ExecutableToolErrorResult {
   readonly isError: true;
   /** See {@link ExecutableToolSuccessResult.message}. */
   readonly message?: string | undefined;
-  /**
-   * Internal loop-control hint. Tool result events strip this field before
-   * persistence; it only tells the current turn whether another model step is
-   * allowed after this tool batch.
-   */
+  /** See {@link ExecutableToolSuccessResult.stopTurn}. */
   readonly stopTurn?: boolean | undefined;
 }
 

--- a/packages/agent-core/test/agent/turn/tool-dedup.test.ts
+++ b/packages/agent-core/test/agent/turn/tool-dedup.test.ts
@@ -120,7 +120,7 @@ describe('ToolCallDeduplicator', () => {
       expect(last!.output as string).not.toContain('repeated_times');
     });
 
-    it('does not inject reminder at 4 consecutive', async () => {
+    it('keeps injecting reminder1 at 4 consecutive', async () => {
       const dedup = new ToolCallDeduplicator();
       let last: ExecutableToolResult | undefined;
       for (let i = 0; i < 4; i += 1) {
@@ -128,7 +128,8 @@ describe('ToolCallDeduplicator', () => {
         last = await runOriginal(dedup, `c${String(i)}`, 'Read', { p: 1 }, okResult('R'));
         dedup.endStep();
       }
-      expect(last!.output as string).not.toContain('<system-reminder>');
+      expect(last!.output as string).toContain('<system-reminder>');
+      expect(last!.output as string).toContain('repeating the exact same tool call');
     });
 
     it('injects reminder2 at exactly 5 consecutive', async () => {
@@ -145,18 +146,20 @@ describe('ToolCallDeduplicator', () => {
       expect(last!.output as string).toContain('arguments:');
     });
 
-    it('does not inject reminder at 6 or 7 consecutive', async () => {
+    it.each([6, 7])('keeps injecting reminder2 at %i consecutive', async (streak) => {
       const dedup = new ToolCallDeduplicator();
       let last: ExecutableToolResult | undefined;
-      for (let i = 0; i < 7; i += 1) {
+      for (let i = 0; i < streak; i += 1) {
         dedup.beginStep();
         last = await runOriginal(dedup, `c${String(i)}`, 'Read', { p: 1 }, okResult('R'));
         dedup.endStep();
       }
-      expect(last!.output as string).not.toContain('<system-reminder>');
+      expect(last!.output as string).toContain('<system-reminder>');
+      expect(last!.output as string).toContain(`repeated_times: ${String(streak)}`);
+      expect(last!.output as string).toContain('tool: Read');
     });
 
-    it('injects reminder2 at exactly 8 consecutive', async () => {
+    it('injects the dead-end reminder at exactly 8 consecutive', async () => {
       const dedup = new ToolCallDeduplicator();
       let last: ExecutableToolResult | undefined;
       for (let i = 0; i < 8; i += 1) {
@@ -165,8 +168,7 @@ describe('ToolCallDeduplicator', () => {
         dedup.endStep();
       }
       expect(last!.output as string).toContain('<system-reminder>');
-      expect(last!.output as string).toContain('repeated_times: 8');
-      expect(last!.output as string).toContain('tool: Read');
+      expect(last!.output as string).toContain('stuck in a dead end');
     });
 
     it('resets streak when a different call is interleaved', async () => {
@@ -384,9 +386,9 @@ describe('ToolCallDeduplicator', () => {
     });
   });
 
-  describe('dead-end stop reminder (streak >= 10)', () => {
+  describe('dead-end stop reminder (streak >= 8)', () => {
     function stopTurnOf(result: ExecutableToolResult): boolean | undefined {
-      return result.isError === true ? result.stopTurn : undefined;
+      return result.stopTurn;
     }
 
     async function runStreak(
@@ -402,18 +404,18 @@ describe('ToolCallDeduplicator', () => {
       return last!;
     }
 
-    it('injects the dead-end reminder at exactly 10 consecutive without force-stopping', async () => {
+    it('injects the dead-end reminder at exactly 8 consecutive without force-stopping', async () => {
       const dedup = new ToolCallDeduplicator();
-      const last = await runStreak(dedup, 10);
+      const last = await runStreak(dedup, 8);
       expect(last.output as string).toContain('<system-reminder>');
       expect(last.output as string).toContain('stuck in a dead end');
       expect(last.output as string).toContain('Stop all function calls immediately');
-      // 10 is the reminder threshold, not yet force-stop.
+      // 8 is the reminder threshold, not yet force-stop.
       expect(last.isError).toBeUndefined();
       expect(stopTurnOf(last)).toBeUndefined();
     });
 
-    it.each([10, 11, 12, 13, 14])(
+    it.each([8, 9, 10, 11])(
       'keeps injecting the dead-end reminder without stopping the turn at streak %i',
       async (streak) => {
         const dedup = new ToolCallDeduplicator();
@@ -424,35 +426,37 @@ describe('ToolCallDeduplicator', () => {
       },
     );
 
-    it('force-stops the turn at exactly 15 consecutive', async () => {
+    it('force-stops the turn at exactly 12 consecutive without marking the tool failed', async () => {
       const dedup = new ToolCallDeduplicator();
-      const last = await runStreak(dedup, 15);
+      const last = await runStreak(dedup, 12);
       expect(last.output as string).toContain('stuck in a dead end');
-      expect(last.isError).toBe(true);
+      // The underlying tool succeeded — force-stop must not flip it to error.
+      expect(last.isError).toBeUndefined();
       expect(stopTurnOf(last)).toBe(true);
     });
 
-    it('continues force-stopping past 15 consecutive', async () => {
+    it('continues force-stopping past 12 consecutive', async () => {
       const dedup = new ToolCallDeduplicator();
-      const last = await runStreak(dedup, 17);
-      expect(last.isError).toBe(true);
+      const last = await runStreak(dedup, 14);
+      expect(last.isError).toBeUndefined();
       expect(stopTurnOf(last)).toBe(true);
     });
 
     it('preserves the dead-end reminder text exactly', async () => {
       const dedup = new ToolCallDeduplicator();
-      const last = await runStreak(dedup, 10);
+      const last = await runStreak(dedup, 8);
       expect(last.output as string).toContain(REMINDER_TEXT_3.trim());
     });
 
     it('keeps an error result error when force-stopping', async () => {
       const dedup = new ToolCallDeduplicator();
       let last: ExecutableToolResult | undefined;
-      for (let i = 0; i < 15; i += 1) {
+      for (let i = 0; i < 12; i += 1) {
         dedup.beginStep();
         last = await runOriginal(dedup, `c${String(i)}`, 'Read', { p: 1 }, errResult('boom'));
         dedup.endStep();
       }
+      // The underlying tool was an error — that must survive force-stop.
       expect(last!.isError).toBe(true);
       expect(stopTurnOf(last!)).toBe(true);
       expect(last!.output as string).toContain('stuck in a dead end');
@@ -482,10 +486,10 @@ describe('ToolCallDeduplicator', () => {
       expect(events.filter((e) => e.event === 'tool_call_repeat')).toHaveLength(0);
     });
 
-    it('labels the action as "reminder" at streak 3, 5, 8 and 10-14', async () => {
+    it('labels the action as r1/r2/r3 according to the reminder tier from streak 3 through 11', async () => {
       const { client, events } = makeRecordingTelemetry();
       const dedup = new ToolCallDeduplicator({ telemetry: client });
-      for (let i = 0; i < 14; i += 1) {
+      for (let i = 0; i < 11; i += 1) {
         dedup.beginStep();
         await runOriginal(dedup, `c${String(i)}`, 'Read', { p: 1 }, okResult('R'));
         dedup.endStep();
@@ -496,31 +500,33 @@ describe('ToolCallDeduplicator', () => {
         byCount.set(e.properties?.['repeat_count'] as number, e.properties?.['action'] as string);
       }
       expect(byCount.get(2)).toBe('none');
-      expect(byCount.get(3)).toBe('reminder');
-      expect(byCount.get(4)).toBe('none');
-      expect(byCount.get(5)).toBe('reminder');
-      expect(byCount.get(8)).toBe('reminder');
-      expect(byCount.get(9)).toBe('none');
-      expect(byCount.get(10)).toBe('reminder');
-      expect(byCount.get(14)).toBe('reminder');
+      expect(byCount.get(3)).toBe('r1');
+      expect(byCount.get(4)).toBe('r1');
+      expect(byCount.get(5)).toBe('r2');
+      expect(byCount.get(6)).toBe('r2');
+      expect(byCount.get(7)).toBe('r2');
+      expect(byCount.get(8)).toBe('r3');
+      expect(byCount.get(9)).toBe('r3');
+      expect(byCount.get(10)).toBe('r3');
+      expect(byCount.get(11)).toBe('r3');
     });
 
-    it('labels the action as "stop" at streak 15+', async () => {
+    it('labels the action as "stop" at streak 12+', async () => {
       const { client, events } = makeRecordingTelemetry();
       const dedup = new ToolCallDeduplicator({ telemetry: client });
-      for (let i = 0; i < 16; i += 1) {
+      for (let i = 0; i < 13; i += 1) {
         dedup.beginStep();
         await runOriginal(dedup, `c${String(i)}`, 'Read', { p: 1 }, okResult('R'));
         dedup.endStep();
       }
-      const at15 = events.find(
-        (e) => e.event === 'tool_call_repeat' && e.properties?.['repeat_count'] === 15,
+      const at12 = events.find(
+        (e) => e.event === 'tool_call_repeat' && e.properties?.['repeat_count'] === 12,
       );
-      const at16 = events.find(
-        (e) => e.event === 'tool_call_repeat' && e.properties?.['repeat_count'] === 16,
+      const at13 = events.find(
+        (e) => e.event === 'tool_call_repeat' && e.properties?.['repeat_count'] === 13,
       );
-      expect(at15?.properties?.['action']).toBe('stop');
-      expect(at16?.properties?.['action']).toBe('stop');
+      expect(at12?.properties?.['action']).toBe('stop');
+      expect(at13?.properties?.['action']).toBe('stop');
     });
 
     it('resets the count when a different call interleaves', async () => {
@@ -545,13 +551,14 @@ describe('ToolCallDeduplicator', () => {
     });
 
     it('does not emit telemetry when no client is provided', async () => {
-      // No throw, no observable effect — just exercises the optional path.
       const dedup = new ToolCallDeduplicator();
       for (let i = 0; i < 3; i += 1) {
         dedup.beginStep();
         await runOriginal(dedup, `c${String(i)}`, 'Read', { p: 1 }, okResult('R'));
         dedup.endStep();
       }
+      // Exercises the optional telemetry path; should complete silently.
+      expect(true).toBe(true);
     });
   });
 });

--- a/packages/agent-core/test/agent/turn/tool-dedup.test.ts
+++ b/packages/agent-core/test/agent/turn/tool-dedup.test.ts
@@ -1,9 +1,31 @@
 import { describe, expect, it } from 'vitest';
 
 import type { ExecutableToolResult } from '../../../src/loop/types';
+import type {
+  TelemetryClient,
+  TelemetryProperties,
+} from '../../../src/telemetry';
 import { ToolCallDeduplicator, __testing } from '../../../src/agent/turn/tool-dedup';
 
-const { REMINDER_TEXT_1, makeReminderText2 } = __testing;
+const { REMINDER_TEXT_1, REMINDER_TEXT_3, makeReminderText2 } = __testing;
+
+interface RecordedTelemetryEvent {
+  readonly event: string;
+  readonly properties: TelemetryProperties | undefined;
+}
+
+function makeRecordingTelemetry(): {
+  readonly client: TelemetryClient;
+  readonly events: RecordedTelemetryEvent[];
+} {
+  const events: RecordedTelemetryEvent[] = [];
+  const client: TelemetryClient = {
+    track: (event, properties) => {
+      events.push({ event, properties });
+    },
+  };
+  return { client, events };
+}
 
 function okResult(text: string): ExecutableToolResult {
   return { output: text };
@@ -359,6 +381,177 @@ describe('ToolCallDeduplicator', () => {
       // resolved with an error result but nothing is awaiting it now.
       const finalDup = await dedup.finalizeResult('dup', 'Read', { p: 1 }, dupCached!);
       expect(finalDup).toEqual(dupCached);
+    });
+  });
+
+  describe('dead-end stop reminder (streak >= 10)', () => {
+    function stopTurnOf(result: ExecutableToolResult): boolean | undefined {
+      return result.isError === true ? result.stopTurn : undefined;
+    }
+
+    async function runStreak(
+      dedup: ToolCallDeduplicator,
+      count: number,
+    ): Promise<ExecutableToolResult> {
+      let last: ExecutableToolResult | undefined;
+      for (let i = 0; i < count; i += 1) {
+        dedup.beginStep();
+        last = await runOriginal(dedup, `c${String(i)}`, 'Read', { p: 1 }, okResult('R'));
+        dedup.endStep();
+      }
+      return last!;
+    }
+
+    it('injects the dead-end reminder at exactly 10 consecutive without force-stopping', async () => {
+      const dedup = new ToolCallDeduplicator();
+      const last = await runStreak(dedup, 10);
+      expect(last.output as string).toContain('<system-reminder>');
+      expect(last.output as string).toContain('stuck in a dead end');
+      expect(last.output as string).toContain('Stop all function calls immediately');
+      // 10 is the reminder threshold, not yet force-stop.
+      expect(last.isError).toBeUndefined();
+      expect(stopTurnOf(last)).toBeUndefined();
+    });
+
+    it.each([10, 11, 12, 13, 14])(
+      'keeps injecting the dead-end reminder without stopping the turn at streak %i',
+      async (streak) => {
+        const dedup = new ToolCallDeduplicator();
+        const last = await runStreak(dedup, streak);
+        expect(last.output as string).toContain('stuck in a dead end');
+        expect(last.isError).toBeUndefined();
+        expect(stopTurnOf(last)).toBeUndefined();
+      },
+    );
+
+    it('force-stops the turn at exactly 15 consecutive', async () => {
+      const dedup = new ToolCallDeduplicator();
+      const last = await runStreak(dedup, 15);
+      expect(last.output as string).toContain('stuck in a dead end');
+      expect(last.isError).toBe(true);
+      expect(stopTurnOf(last)).toBe(true);
+    });
+
+    it('continues force-stopping past 15 consecutive', async () => {
+      const dedup = new ToolCallDeduplicator();
+      const last = await runStreak(dedup, 17);
+      expect(last.isError).toBe(true);
+      expect(stopTurnOf(last)).toBe(true);
+    });
+
+    it('preserves the dead-end reminder text exactly', async () => {
+      const dedup = new ToolCallDeduplicator();
+      const last = await runStreak(dedup, 10);
+      expect(last.output as string).toContain(REMINDER_TEXT_3.trim());
+    });
+
+    it('keeps an error result error when force-stopping', async () => {
+      const dedup = new ToolCallDeduplicator();
+      let last: ExecutableToolResult | undefined;
+      for (let i = 0; i < 15; i += 1) {
+        dedup.beginStep();
+        last = await runOriginal(dedup, `c${String(i)}`, 'Read', { p: 1 }, errResult('boom'));
+        dedup.endStep();
+      }
+      expect(last!.isError).toBe(true);
+      expect(stopTurnOf(last!)).toBe(true);
+      expect(last!.output as string).toContain('stuck in a dead end');
+    });
+  });
+
+  describe('repeat telemetry', () => {
+    it('emits tool_call_repeat with the streak count starting at the second occurrence', async () => {
+      const { client, events } = makeRecordingTelemetry();
+      const dedup = new ToolCallDeduplicator({ telemetry: client });
+      for (let i = 0; i < 3; i += 1) {
+        dedup.beginStep();
+        await runOriginal(dedup, `c${String(i)}`, 'Read', { p: 1 }, okResult('R'));
+        dedup.endStep();
+      }
+      const repeats = events.filter((e) => e.event === 'tool_call_repeat');
+      expect(repeats.map((e) => e.properties?.['repeat_count'])).toEqual([2, 3]);
+      expect(repeats.every((e) => e.properties?.['tool_name'] === 'Read')).toBe(true);
+    });
+
+    it('does not emit telemetry on the first call', async () => {
+      const { client, events } = makeRecordingTelemetry();
+      const dedup = new ToolCallDeduplicator({ telemetry: client });
+      dedup.beginStep();
+      await runOriginal(dedup, 'c0', 'Read', { p: 1 }, okResult('R'));
+      dedup.endStep();
+      expect(events.filter((e) => e.event === 'tool_call_repeat')).toHaveLength(0);
+    });
+
+    it('labels the action as "reminder" at streak 3, 5, 8 and 10-14', async () => {
+      const { client, events } = makeRecordingTelemetry();
+      const dedup = new ToolCallDeduplicator({ telemetry: client });
+      for (let i = 0; i < 14; i += 1) {
+        dedup.beginStep();
+        await runOriginal(dedup, `c${String(i)}`, 'Read', { p: 1 }, okResult('R'));
+        dedup.endStep();
+      }
+      const byCount = new Map<number, string>();
+      for (const e of events) {
+        if (e.event !== 'tool_call_repeat') continue;
+        byCount.set(e.properties?.['repeat_count'] as number, e.properties?.['action'] as string);
+      }
+      expect(byCount.get(2)).toBe('none');
+      expect(byCount.get(3)).toBe('reminder');
+      expect(byCount.get(4)).toBe('none');
+      expect(byCount.get(5)).toBe('reminder');
+      expect(byCount.get(8)).toBe('reminder');
+      expect(byCount.get(9)).toBe('none');
+      expect(byCount.get(10)).toBe('reminder');
+      expect(byCount.get(14)).toBe('reminder');
+    });
+
+    it('labels the action as "stop" at streak 15+', async () => {
+      const { client, events } = makeRecordingTelemetry();
+      const dedup = new ToolCallDeduplicator({ telemetry: client });
+      for (let i = 0; i < 16; i += 1) {
+        dedup.beginStep();
+        await runOriginal(dedup, `c${String(i)}`, 'Read', { p: 1 }, okResult('R'));
+        dedup.endStep();
+      }
+      const at15 = events.find(
+        (e) => e.event === 'tool_call_repeat' && e.properties?.['repeat_count'] === 15,
+      );
+      const at16 = events.find(
+        (e) => e.event === 'tool_call_repeat' && e.properties?.['repeat_count'] === 16,
+      );
+      expect(at15?.properties?.['action']).toBe('stop');
+      expect(at16?.properties?.['action']).toBe('stop');
+    });
+
+    it('resets the count when a different call interleaves', async () => {
+      const { client, events } = makeRecordingTelemetry();
+      const dedup = new ToolCallDeduplicator({ telemetry: client });
+      for (let i = 0; i < 2; i += 1) {
+        dedup.beginStep();
+        await runOriginal(dedup, `a${String(i)}`, 'Read', { p: 1 }, okResult('R'));
+        dedup.endStep();
+      }
+      dedup.beginStep();
+      await runOriginal(dedup, 'b1', 'Read', { p: 2 }, okResult('R'));
+      dedup.endStep();
+      dedup.beginStep();
+      await runOriginal(dedup, 'c1', 'Read', { p: 1 }, okResult('R'));
+      dedup.endStep();
+      const counts = events
+        .filter((e) => e.event === 'tool_call_repeat')
+        .map((e) => e.properties?.['repeat_count']);
+      // Only the second Read({p:1}) is a repeat; the streak then breaks.
+      expect(counts).toEqual([2]);
+    });
+
+    it('does not emit telemetry when no client is provided', async () => {
+      // No throw, no observable effect — just exercises the optional path.
+      const dedup = new ToolCallDeduplicator();
+      for (let i = 0; i < 3; i += 1) {
+        dedup.beginStep();
+        await runOriginal(dedup, `c${String(i)}`, 'Read', { p: 1 }, okResult('R'));
+        dedup.endStep();
+      }
     });
   });
 });


### PR DESCRIPTION
## Summary

This PR adds dead-end detection for consecutively repeated tool calls in the agent loop. When the model keeps calling the exact same tool with identical arguments across steps, the deduplicator now injects escalating system reminders and eventually force-stops the turn to prevent infinite spinning. It also emits `tool_call_repeat` telemetry events and preserves the underlying tool result's `isError` state during force-stop.

---

### 1. Dead-end detection and escalation reminders

**Problem:** When a model gets stuck in a repetitive pattern (e.g., calling `Read` with the same path repeatedly), the turn can loop indefinitely without making progress, wasting tokens and time.

**What was done:**
- Added a streak counter in `ToolCallDeduplicator` that tracks how many consecutive steps contain the exact same tool call.
- At streak ≥ 3, injects a gentle reminder that the call is repeating.
- At streak ≥ 5, injects a concrete report showing the tool name, arguments, and repeat count.
- At streak ≥ 8, injects a stronger dead-end reminder instructing the model to stop all function calls and return a summary.
- At streak ≥ 12, force-stops the turn via `{ stopTurn: true }` so the loop cannot continue spinning.

### 2. Telemetry and cross-step dedup

**Problem:** There was no visibility into how often the model gets stuck in repetitive tool-call patterns.

**What was done:**
- Emits `tool_call_repeat` telemetry events for every streak ≥ 2, carrying the current `repeat_count` and `action` (`none`, `reminder`, or `stop`).
- Wired the telemetry client from `TurnFlow` into `ToolCallDeduplicator` so events are actually recorded.
- Reuses the original tool result for identical calls within the same step (same-step dedup) and only returns a placeholder for duplicates.

### 3. Preserve `isError` during force-stop

**Problem:** The initial implementation force-stopped by setting `{ isError: true, stopTurn: true }`, which incorrectly marked a successful tool result as an error.

**What was done:**
- Moved `stopTurn` into `ExecutableToolSuccessResult` so it can be set independently of `isError`.
- Updated `toolResultStopsTurn` to only check `stopTurn === true` rather than requiring `isError === true`.
- Force-stop now preserves the underlying call's success/error state.

---

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [ ] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [ ] Ran `gen-changesets` skill, or this PR needs no changeset.
- [ ] Ran `gen-docs` skill, or this PR needs no doc update.
