### PR TITLE
fix: provide ripgrep for packaged runtimes

### DIFF
--- a/.changeset/fix-ripgrep-runtime-path.md
+++ b/.changeset/fix-ripgrep-runtime-path.md
@@ -1,0 +1,6 @@
+---
+"@moonshot-ai/agent-core": patch
+"@moonshot-ai/kimi-code": patch
+---
+
+Make packaged runtimes provide a deterministic ripgrep binary for search tools.

--- a/flake.nix
+++ b/flake.nix
@@ -144,6 +144,7 @@
             nativeBuildInputs = [
               nodejs
               pnpm
+              pkgs.makeWrapper
               (pkgs.pnpmConfigHook.override { inherit pnpm; })
             ]
             # The SEA inject step (postject) invalidates the macOS code
@@ -183,7 +184,10 @@
 
               install -Dm755 \
                 "apps/kimi-code/dist-native/bin/${nativeTarget}/kimi" \
-                "$out/bin/kimi"
+                "$out/libexec/kimi-code/kimi"
+
+              makeWrapper "$out/libexec/kimi-code/kimi" "$out/bin/kimi" \
+                --set-default KIMI_CODE_RG_PATH "${pkgs.ripgrep}/bin/rg"
 
               runHook postInstall
             '';
@@ -221,6 +225,7 @@
             packages = [
               nodejs
               pnpm
+              pkgs.ripgrep
             ];
           };
       });

--- a/packages/agent-core/src/tools/support/rg-locator.ts
+++ b/packages/agent-core/src/tools/support/rg-locator.ts
@@ -2,19 +2,30 @@
  * rg-locator — hybrid ripgrep binary resolution.
  *
  * Lookup order (first hit wins):
- *   1. System PATH (`which rg`) — fastest, respects developer setup
- *   2. Bundled vendor binary (hook; not wired yet — `getVendorRgPath` is a stub)
- *   3. `<KIMI_CODE_HOME>/bin/rg` — persistent cache for this app.
- *   4. CDN download to <KIMI_CODE_HOME>/bin/ — one-off bootstrap
+ *   1. `KIMI_CODE_RG_PATH` — deterministic runtime/vendor override
+ *   2. System PATH (`which rg`) — fastest, respects developer setup
+ *   3. Bundled vendor binary (hook; not wired yet — `getVendorRgPath` is a stub)
+ *   4. `<KIMI_CODE_HOME>/bin/rg` — persistent cache for this app.
+ *   5. CDN download to <KIMI_CODE_HOME>/bin/ — one-off bootstrap
  *
- * If steps 1-4 all fail, callers receive a structured error they can
+ * If steps 1-5 all fail, callers receive a structured error they can
  * turn into a user-facing "install ripgrep" hint instead of the naked
  * `spawn rg ENOENT`.
  */
 
 import { createHash } from 'node:crypto';
-import { createWriteStream, existsSync } from 'node:fs';
-import { chmod, copyFile, mkdir, mkdtemp, readFile, rename, rm, stat } from 'node:fs/promises';
+import { constants as fsConstants, createWriteStream, existsSync } from 'node:fs';
+import {
+  access,
+  chmod,
+  copyFile,
+  mkdir,
+  mkdtemp,
+  readFile,
+  rename,
+  rm,
+  stat,
+} from 'node:fs/promises';
 import { homedir, tmpdir } from 'node:os';
 import { basename, join } from 'pathe';
 import { Readable } from 'node:stream';
@@ -28,6 +39,7 @@ import { abortable } from '../../utils/abort';
 const RG_VERSION = '15.0.0';
 const RG_BASE_URL = 'https://code.kimi.com/kimi-code/rg';
 const DOWNLOAD_TIMEOUT_MS = 600_000;
+const RG_PATH_ENV = 'KIMI_CODE_RG_PATH';
 const RG_ARCHIVE_SHA256: Record<string, string> = {
   'ripgrep-15.0.0-aarch64-apple-darwin.tar.gz':
     '98bb2e61e7277ba0ea72d2ae2592497fd8d2940934a16b122448d302a6637e3b',
@@ -44,6 +56,7 @@ const RG_ARCHIVE_SHA256: Record<string, string> = {
 };
 
 export type RgResolutionSource =
+  | 'env-path'
   | 'system-path'
   | 'vendor'
   | 'share-bin-cached'
@@ -91,6 +104,11 @@ async function resolveRgPath(
  */
 export async function findExistingRg(shareDir: string): Promise<RgResolution | undefined> {
   const binName = rgBinaryName();
+  const envRg = getEnvRgPath();
+  if (envRg !== undefined) {
+    if (await isExecutableFile(envRg)) return { path: envRg, source: 'env-path' };
+    throw new Error(`${RG_PATH_ENV} points to ${envRg}, but it is not an executable file`);
+  }
   const systemRg = await whichRg();
   if (systemRg !== undefined) return { path: systemRg, source: 'system-path' };
   const vendorPath = getVendorRgPath(binName);
@@ -134,6 +152,12 @@ function getVendorRgPath(_binName: string): string | undefined {
   return undefined;
 }
 
+function getEnvRgPath(): string | undefined {
+  const override = process.env[RG_PATH_ENV];
+  if (override === undefined || override === '') return undefined;
+  return override;
+}
+
 async function whichRg(): Promise<string | undefined> {
   const pathEnv = process.env['PATH'] ?? '';
   const sep = process.platform === 'win32' ? ';' : ':';
@@ -141,12 +165,7 @@ async function whichRg(): Promise<string | undefined> {
   for (const dir of pathEnv.split(sep)) {
     if (dir === '') continue;
     const candidate = join(dir, binName);
-    try {
-      const st = await stat(candidate);
-      if (st.isFile()) return candidate;
-    } catch {
-      /* not here, try next */
-    }
+    if (await isExecutableFile(candidate)) return candidate;
   }
   return undefined;
 }
@@ -154,7 +173,10 @@ async function whichRg(): Promise<string | undefined> {
 async function isExecutableFile(p: string): Promise<boolean> {
   try {
     const st = await stat(p);
-    return st.isFile();
+    if (!st.isFile()) return false;
+    if (process.platform === 'win32') return true;
+    await access(p, fsConstants.X_OK);
+    return true;
   } catch {
     return false;
   }
@@ -364,6 +386,8 @@ export function rgUnavailableMessage(cause: unknown): string {
     `  macOS:   brew install ripgrep\n` +
     `  Ubuntu:  sudo apt-get install ripgrep\n` +
     `  Other:   https://github.com/BurntSushi/ripgrep#installation\n` +
+    `\n` +
+    `For packaged runtimes, set ${RG_PATH_ENV}=/absolute/path/to/rg.\n` +
     `\n` +
     `Alternatively, drop a static rg binary at ${shareBin}`
   );

--- a/packages/agent-core/test/tools/rg-locator.test.ts
+++ b/packages/agent-core/test/tools/rg-locator.test.ts
@@ -3,6 +3,7 @@
  *
  * Pure-lookup pins (no real CDN download):
  *   - `findExistingRg` returns undefined when PATH + share-bin are both empty
+ *   - `KIMI_CODE_RG_PATH` wins over PATH/cache and fails fast when invalid
  *   - Resolves from `<shareDir>/bin/rg` when that binary exists
  *   - Prefers system PATH over share-dir cache when both are available
  *   - `rgUnavailableMessage` surfaces the underlying cause + install hints
@@ -35,22 +36,59 @@ vi.mock('tar', () => ({ extract: vi.fn() }));
 describe('findExistingRg', () => {
   let fakeShare: string;
   let savedPath: string | undefined;
+  let savedRgPath: string | undefined;
   beforeEach(() => {
     fakeShare = join(tmpdir(), `kimi-rg-${String(Date.now())}-${String(Math.random()).slice(2)}`);
     mkdirSync(join(fakeShare, 'bin'), { recursive: true });
     savedPath = process.env['PATH'];
+    savedRgPath = process.env['KIMI_CODE_RG_PATH'];
     // Empty PATH → rules out step 1 (system-path) for the default case.
     process.env['PATH'] = '';
+    delete process.env['KIMI_CODE_RG_PATH'];
   });
   afterEach(() => {
     rmSync(fakeShare, { recursive: true, force: true });
     if (savedPath === undefined) delete process.env['PATH'];
     else process.env['PATH'] = savedPath;
+    if (savedRgPath === undefined) delete process.env['KIMI_CODE_RG_PATH'];
+    else process.env['KIMI_CODE_RG_PATH'] = savedRgPath;
   });
 
   it('returns undefined when no rg anywhere', async () => {
     const result = await findExistingRg(fakeShare);
     expect(result).toBeUndefined();
+  });
+
+  it('prefers KIMI_CODE_RG_PATH over system PATH and share-dir cache', async () => {
+    const binName = process.platform === 'win32' ? 'rg.exe' : 'rg';
+    const envDir = join(fakeShare, 'env');
+    const pathDir = join(fakeShare, 'path');
+    mkdirSync(envDir, { recursive: true });
+    mkdirSync(pathDir, { recursive: true });
+    const fromEnv = join(envDir, binName);
+    const onPath = join(pathDir, binName);
+    const cached = join(fakeShare, 'bin', binName);
+    writeFileSync(fromEnv, '#!/bin/sh\n');
+    writeFileSync(onPath, '#!/bin/sh\n');
+    writeFileSync(cached, '#!/bin/sh\n');
+    chmodSync(fromEnv, 0o755);
+    chmodSync(onPath, 0o755);
+    chmodSync(cached, 0o755);
+    process.env['KIMI_CODE_RG_PATH'] = fromEnv;
+    process.env['PATH'] = pathDir;
+
+    const result = await findExistingRg(fakeShare);
+
+    expect(result).toEqual({ path: fromEnv, source: 'env-path' });
+  });
+
+  it('throws when KIMI_CODE_RG_PATH points at a missing binary', async () => {
+    const missing = join(fakeShare, 'missing-rg');
+    process.env['KIMI_CODE_RG_PATH'] = missing;
+
+    await expect(findExistingRg(fakeShare)).rejects.toThrow(
+      /KIMI_CODE_RG_PATH points to .*missing-rg.*not an executable file/,
+    );
   });
 
   it('resolves from share-dir when cached', async () => {


### PR DESCRIPTION
## Related Issue

No linked issue; this fixes a packaging/runtime failure where search tools cannot find `rg` in offline or minimal environments.

## Problem

`Grep` depends on ripgrep. When a packaged runtime has no `rg` on `PATH` and cannot download the bootstrap archive, the search tool fails before it can inspect files.

## What changed

- Added `KIMI_CODE_RG_PATH` as a deterministic ripgrep override and validate it before falling back to `PATH`, cache, or download.
- Wrapped the Nix CLI binary so packaged runtimes point `KIMI_CODE_RG_PATH` at Nix's ripgrep binary, and added ripgrep to the dev shell.
- Added locator tests for env precedence and invalid env configuration.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.
