### PR TITLE
fix: load root .mcp.json config

### DIFF
--- a/packages/agent-core/src/mcp/config-loader.ts
+++ b/packages/agent-core/src/mcp/config-loader.ts
@@ -1,5 +1,5 @@
-import { readFile } from 'node:fs/promises';
-import { join } from 'pathe';
+import { readFile, stat } from 'node:fs/promises';
+import { dirname, isAbsolute, join, normalize, resolve } from 'pathe';
 
 import { resolveKimiHome } from '#/config/path';
 import { McpServerConfigSchema, type McpServerConfig } from '#/config/schema';
@@ -12,6 +12,7 @@ const McpJsonFileSchema = z.object({
 
 export interface McpJsonPaths {
   readonly user: string;
+  readonly projectRoot: string;
   readonly project: string;
 }
 
@@ -20,9 +21,12 @@ export interface ResolveMcpJsonPathsInput {
   readonly homeDir?: string;
 }
 
-export function resolveMcpJsonPaths(input: ResolveMcpJsonPathsInput): McpJsonPaths {
+export async function resolveMcpJsonPaths(input: ResolveMcpJsonPathsInput): Promise<McpJsonPaths> {
+  const projectRoot = await findProjectRoot(input.cwd);
+
   return {
     user: join(resolveKimiHome(input.homeDir), 'mcp.json'),
+    projectRoot: join(projectRoot, '.mcp.json'),
     project: join(input.cwd, '.kimi-code', 'mcp.json'),
   };
 }
@@ -33,10 +37,11 @@ export interface LoadMcpServersInput {
 }
 
 /**
- * Load MCP server declarations from the user-global `~/.kimi-code/mcp.json`
- * and the project-local `<cwd>/.kimi-code/mcp.json`. Entries in the project
- * file override user-global entries with the same key, so a repo can specialise
- * or replace a shared definition.
+ * Load MCP server declarations from the user-global `~/.kimi-code/mcp.json`,
+ * the project-root `<project root>/.mcp.json`, and the project-local
+ * `<cwd>/.kimi-code/mcp.json`. Entries in later files override earlier files
+ * with the same key, so a repo can specialise or replace a shared definition,
+ * and Kimi-specific project config wins over the Claude-compatible root file.
  *
  * Note: project-local entries may spawn stdio commands at session start, so
  * opening a session inside an untrusted checkout will execute whatever its
@@ -45,12 +50,45 @@ export interface LoadMcpServersInput {
 export async function loadMcpServers(
   input: LoadMcpServersInput,
 ): Promise<Record<string, McpServerConfig>> {
-  const paths = resolveMcpJsonPaths({ cwd: input.cwd, homeDir: input.homeDir });
-  const [user, project] = await Promise.all([readMcpJson(paths.user), readMcpJson(paths.project)]);
-  return { ...user, ...project };
+  const paths = await resolveMcpJsonPaths({ cwd: input.cwd, homeDir: input.homeDir });
+  const [user, projectRoot, project] = await Promise.all([
+    readMcpJson(paths.user),
+    readMcpJson(paths.projectRoot, { stdioCwdBase: dirname(paths.projectRoot) }),
+    readMcpJson(paths.project),
+  ]);
+  return { ...user, ...projectRoot, ...project };
 }
 
-async function readMcpJson(filePath: string): Promise<Record<string, McpServerConfig>> {
+async function findProjectRoot(cwd: string): Promise<string> {
+  const start = normalize(cwd);
+  let current = start;
+
+  while (true) {
+    if (await pathExists(join(current, '.git'))) return current;
+    const parent = dirname(current);
+    if (parent === current) return start;
+    current = parent;
+  }
+}
+
+async function pathExists(filePath: string): Promise<boolean> {
+  try {
+    await stat(filePath);
+    return true;
+  } catch (error: unknown) {
+    if (isPathMissing(error)) return false;
+    throw error;
+  }
+}
+
+interface ReadMcpJsonOptions {
+  readonly stdioCwdBase?: string;
+}
+
+async function readMcpJson(
+  filePath: string,
+  options: ReadMcpJsonOptions = {},
+): Promise<Record<string, McpServerConfig>> {
   let text: string;
   try {
     text = await readFile(filePath, 'utf-8');
@@ -73,7 +111,7 @@ async function readMcpJson(filePath: string): Promise<Record<string, McpServerCo
   }
 
   try {
-    return McpJsonFileSchema.parse(data).mcpServers;
+    return normalizeMcpServers(McpJsonFileSchema.parse(data).mcpServers, options);
   } catch (error: unknown) {
     throw new KimiError(ErrorCodes.CONFIG_INVALID, `Invalid MCP server config in ${filePath}: ${describeError(error)}`, {
       cause: error,
@@ -81,13 +119,40 @@ async function readMcpJson(filePath: string): Promise<Record<string, McpServerCo
   }
 }
 
-function isFileNotFound(error: unknown): boolean {
-  return (
-    typeof error === 'object' &&
-    error !== null &&
-    'code' in error &&
-    (error as { code: unknown }).code === 'ENOENT'
+function normalizeMcpServers(
+  servers: Record<string, McpServerConfig>,
+  options: ReadMcpJsonOptions,
+): Record<string, McpServerConfig> {
+  const stdioCwdBase = options.stdioCwdBase;
+  if (stdioCwdBase === undefined) return servers;
+
+  return Object.fromEntries(
+    Object.entries(servers).map(([name, config]) => [name, normalizeStdioCwd(config, stdioCwdBase)]),
   );
+}
+
+function normalizeStdioCwd(config: McpServerConfig, cwdBase: string): McpServerConfig {
+  if (config.transport !== 'stdio') return config;
+  const cwd = config.cwd === undefined ? cwdBase : resolvePath(cwdBase, config.cwd);
+  return { ...config, cwd };
+}
+
+function resolvePath(base: string, value: string): string {
+  return isAbsolute(value) ? normalize(value) : resolve(base, value);
+}
+
+function isFileNotFound(error: unknown): boolean {
+  return getErrorCode(error) === 'ENOENT';
+}
+
+function isPathMissing(error: unknown): boolean {
+  const code = getErrorCode(error);
+  return code === 'ENOENT' || code === 'ENOTDIR';
+}
+
+function getErrorCode(error: unknown): unknown {
+  if (typeof error !== 'object' || error === null || !('code' in error)) return undefined;
+  return (error as { code: unknown }).code;
 }
 
 function describeError(error: unknown): string {

--- a/packages/agent-core/src/skill/builtin/mcp-config.md
+++ b/packages/agent-core/src/skill/builtin/mcp-config.md
@@ -37,22 +37,30 @@ tools exist and the user didn't name one, ask which.
 
 ## Config edit
 
-Config lives in two files; on key collision the project file overrides
-the user-global one:
+Config lives in three files; on key collision, later entries in this
+precedence order override earlier ones:
 
 - User-global: `~/.kimi-code/mcp.json` (or `$KIMI_CODE_HOME/mcp.json` if
   set). Use for servers you want everywhere.
-- Project-local: `<cwd>/.kimi-code/mcp.json`. Mention once that stdio
-  entries spawn commands at session start, so this should only live in
-  trusted repos.
+- Project-root: `<project root>/.mcp.json`, where project root is found
+  by walking up from `<cwd>` to the nearest `.git`. Use for
+  Claude-compatible, repo-shared, or cross-agent servers.
+- Project-local: `<cwd>/.kimi-code/mcp.json`. Use for Kimi-specific
+  overrides in the current working directory.
 
-Both files wrap their entries the same way:
+Mention once that project-root and project-local stdio entries spawn
+commands at session start, so they should only live in trusted repos.
+
+All three files wrap their entries the same way:
 
 ```json
 { "mcpServers": { "<name>": { /* entry */ } } }
 ```
 
 A minimal stdio entry needs `command` (+ optional `args`, `env`, `cwd`).
+For project-root `.mcp.json`, stdio entries run from the project root by
+default; relative `cwd` values are resolved against the directory that
+contains `.mcp.json`.
 A minimal http entry needs `url`; add `bearerTokenEnvVar: "ENV_NAME"` for
 servers that authenticate with a static bearer token from the
 environment. Servers that use OAuth take no token field — the login flow
@@ -62,16 +70,20 @@ omit it. For less common fields (`enabled`, `startupTimeoutMs`,
 truth is `McpServerStdioConfigSchema` / `McpServerHttpConfigSchema` in
 `packages/agent-core/src/config/schema.ts`.
 
-If the user only wants to **see** what's configured, read both files,
-show a merged view, and stop — no scope prompt, no write.
+If the user only wants to **see** what's configured, read all three files,
+show a merged view with enough source-path context to inspect or remove a
+server from the file that actually declared it, and stop — no scope
+prompt, no write.
 
 For changes, the flow is:
 
 1. **Pick a scope.** Infer it from the user's words when you can
-   (project / repo / this checkout / cwd → project; global / everywhere /
-   all projects → user-global). When the request is genuinely scope-less,
-   use one `AskUserQuestion` to ask user-global vs project-local, defaulting
-   to user-global. Use plain text for every other question — `AskUserQuestion`
+   (global / everywhere / all projects → user-global; root / repo /
+   shared / cross-agent / Claude / `.mcp.json` → project-root; cwd /
+   current directory / Kimi-specific / `.kimi-code` → project-local). When
+   the request is genuinely scope-less, use one `AskUserQuestion` to ask
+   user-global vs project-root vs project-local, defaulting to
+   user-global. Use plain text for every other question — `AskUserQuestion`
    is a poor fit for free-form input. If the user dismisses the scope
    question, stop; you can't safely guess where they wanted the change.
 2. **Read and announce.** Read the target file (a missing or empty file

--- a/packages/agent-core/test/mcp/config-loader.test.ts
+++ b/packages/agent-core/test/mcp/config-loader.test.ts
@@ -28,10 +28,17 @@ async function writeJson(path: string, value: unknown): Promise<void> {
 }
 
 describe('resolveMcpJsonPaths', () => {
-  it('returns the canonical user and project paths', () => {
-    const paths = resolveMcpJsonPaths({ cwd: '/work/proj', homeDir: '/home/user/.kimi-code' });
+  it('returns the canonical user, project-root, and project-local paths', async () => {
+    const repoRoot = makeTempDir();
+    const cwd = join(repoRoot, 'packages', 'agent-core');
+    await mkdir(join(repoRoot, '.git'), { recursive: true });
+    await mkdir(cwd, { recursive: true });
+
+    const paths = await resolveMcpJsonPaths({ cwd, homeDir: '/home/user/.kimi-code' });
+
     expect(paths.user).toBe('/home/user/.kimi-code/mcp.json');
-    expect(paths.project).toBe('/work/proj/.kimi-code/mcp.json');
+    expect(paths.projectRoot).toBe(join(repoRoot, '.mcp.json'));
+    expect(paths.project).toBe(join(cwd, '.kimi-code', 'mcp.json'));
   });
 });
 
@@ -82,6 +89,94 @@ describe('loadMcpServers', () => {
     expect(servers['local']).toEqual({
       transport: 'http',
       url: 'http://localhost:8080/mcp',
+    });
+  });
+
+  it('loads root .mcp.json from the repo root and lets project-local .kimi-code/mcp.json override it', async () => {
+    const home = makeTempDir();
+    const repoRoot = makeTempDir();
+    const cwd = join(repoRoot, 'packages', 'agent-core');
+    await mkdir(join(repoRoot, '.git'), { recursive: true });
+    await mkdir(cwd, { recursive: true });
+
+    await writeJson(join(home, 'mcp.json'), {
+      mcpServers: {
+        shared: { transport: 'stdio', command: 'shared-user' },
+        userOnly: { transport: 'stdio', command: 'user-only' },
+      },
+    });
+    await writeJson(join(repoRoot, '.mcp.json'), {
+      mcpServers: {
+        shared: { transport: 'stdio', command: 'shared-root' },
+        rootOnly: { command: 'root-only' },
+      },
+    });
+    await writeJson(join(cwd, '.kimi-code', 'mcp.json'), {
+      mcpServers: {
+        shared: { transport: 'stdio', command: 'shared-project' },
+        projectOnly: { transport: 'http', url: 'https://mcp.example.com' },
+      },
+    });
+
+    const servers = await loadMcpServers({ cwd, homeDir: home });
+
+    expect(Object.keys(servers).toSorted()).toEqual([
+      'projectOnly',
+      'rootOnly',
+      'shared',
+      'userOnly',
+    ]);
+    expect(servers['shared']).toEqual({
+      transport: 'stdio',
+      command: 'shared-project',
+    });
+    expect(servers['rootOnly']).toEqual({ transport: 'stdio', command: 'root-only', cwd: repoRoot });
+    expect(servers['userOnly']).toEqual({ transport: 'stdio', command: 'user-only' });
+    expect(servers['projectOnly']).toEqual({ transport: 'http', url: 'https://mcp.example.com' });
+  });
+
+  it('resolves project-root stdio cwd relative to the root .mcp.json directory', async () => {
+    const home = makeTempDir();
+    const repoRoot = makeTempDir();
+    const cwd = join(repoRoot, 'packages', 'agent-core');
+    await mkdir(join(repoRoot, '.git'), { recursive: true });
+    await mkdir(cwd, { recursive: true });
+
+    await writeJson(join(repoRoot, '.mcp.json'), {
+      mcpServers: {
+        implicitRoot: { command: './bin/mcp-server' },
+        explicitDot: { command: './bin/mcp-server', cwd: '.' },
+        nested: { command: 'node', cwd: 'tools/mcp' },
+        absolute: { command: 'node', cwd: '/tmp/mcp-workdir' },
+        remote: { url: 'https://mcp.example.com' },
+      },
+    });
+
+    const servers = await loadMcpServers({ cwd, homeDir: home });
+
+    expect(servers['implicitRoot']).toEqual({
+      transport: 'stdio',
+      command: './bin/mcp-server',
+      cwd: repoRoot,
+    });
+    expect(servers['explicitDot']).toEqual({
+      transport: 'stdio',
+      command: './bin/mcp-server',
+      cwd: repoRoot,
+    });
+    expect(servers['nested']).toEqual({
+      transport: 'stdio',
+      command: 'node',
+      cwd: join(repoRoot, 'tools', 'mcp'),
+    });
+    expect(servers['absolute']).toEqual({
+      transport: 'stdio',
+      command: 'node',
+      cwd: '/tmp/mcp-workdir',
+    });
+    expect(servers['remote']).toEqual({
+      transport: 'http',
+      url: 'https://mcp.example.com',
     });
   });
 


### PR DESCRIPTION
## Summary
- load MCP server declarations from project-root .mcp.json in addition to ~/.kimi-code/mcp.json and .kimi-code/mcp.json
- keep .kimi-code/mcp.json as the highest-priority project override
- add coverage for path resolution and merge precedence

## Test
- pnpm --filter @moonshot-ai/agent-core test -- test/mcp/config-loader.test.ts

Note: the same targeted test passed in the main checkout. A separate /private/tmp worktree without a full pnpm install failed dependency resolution before running the target test.