### PR TITLE
docs: sync changelog 0.9.0

### DIFF
--- a/docs/en/release-notes/changelog.md
+++ b/docs/en/release-notes/changelog.md
@@ -2,6 +2,31 @@
 
 This page documents the changes in each Kimi Code CLI release.
 
+## 0.9.0
+
+### Features
+
+- Add `@moonshot-ai/acp-adapter` and the `kimi acp` subcommand: kimi-code now speaks [Agent Client Protocol 0.23](https://agentclientprotocol.com/) over stdio so IDEs (Zed, JetBrains AI Chat, custom clients) can drive sessions directly — coverage matrix, Zed configuration and breaking pre-release notes are in [kimi acp Subcommand Page](https://moonshotai.github.io/kimi-code/en/reference/kimi-acp.html).
+- Add `/btw` for side-channel conversations without steering the active main turn.
+- Allow `/btw` to open the side-channel panel before entering a question.
+
+### Bug Fixes
+
+- Fix external editor (Ctrl+G) on Windows by removing `/bin/sh` dependency and using platform-aware shell quoting for temp file paths.
+- Use the OpenAI completion token field required by newer Chat Completions models.
+- Use configured model output limits for completion token caps.
+- Fix goal budget tool schemas for OpenAI-compatible providers.
+- Resume saved subagents lazily when they are accessed.
+
+### Polish
+
+- Unify the interaction and visuals across TUI dialogs and selectors.
+- Log enabled experimental flags at startup.
+
+### Refactors
+
+- Allow SDK runtime creation to use a separate RPC client while preserving local CLI startup.
+
 ## 0.8.0
 
 ### Features

--- a/docs/en/release-notes/changelog.md
+++ b/docs/en/release-notes/changelog.md
@@ -6,9 +6,8 @@ This page documents the changes in each Kimi Code CLI release.
 
 ### Features
 
-- Add `@moonshot-ai/acp-adapter` and the `kimi acp` subcommand: kimi-code now speaks [Agent Client Protocol 0.23](https://agentclientprotocol.com/) over stdio so IDEs (Zed, JetBrains AI Chat, custom clients) can drive sessions directly — coverage matrix, Zed configuration and breaking pre-release notes are in [kimi acp Subcommand Page](https://moonshotai.github.io/kimi-code/en/reference/kimi-acp.html).
-- Add `/btw` for side-channel conversations without steering the active main turn.
-- Allow `/btw` to open the side-channel panel before entering a question.
+- Add the `kimi acp` subcommand: kimi-code now speaks [Agent Client Protocol 0.23](https://agentclientprotocol.com/) over stdio so IDEs (Zed, JetBrains AI Chat, custom clients) can drive sessions directly — coverage matrix, Zed configuration and breaking pre-release notes are in [kimi acp Subcommand Page](https://moonshotai.github.io/kimi-code/en/reference/kimi-acp.html).
+- Add `/btw` for side-channel conversations without steering the active main turn, and allow `/btw` to open the side-channel panel before entering a question.
 
 ### Bug Fixes
 

--- a/docs/zh/release-notes/changelog.md
+++ b/docs/zh/release-notes/changelog.md
@@ -2,6 +2,31 @@
 
 本页记录 Kimi Code CLI 每个版本的变更内容。
 
+## 0.9.0
+
+### 新功能
+
+- 新增 `@moonshot-ai/acp-adapter` 和 `kimi acp` 子命令：kimi-code 现在可通过 stdio 使用 [Agent Client Protocol 0.23](https://agentclientprotocol.com/)，因此 IDE（Zed、JetBrains AI Chat、自定义客户端）可以直接驱动会话；覆盖矩阵、Zed 配置和破坏性预发布说明见 [kimi acp 子命令页面](https://moonshotai.github.io/kimi-code/en/reference/kimi-acp.html)。
+- 新增 `/btw`，用于进行不会引导当前主轮次的侧通道对话。
+- 允许 `/btw` 在输入问题前打开侧通道面板。
+
+### 修复
+
+- 修复 Windows 上外部编辑器（Ctrl+G），移除对 `/bin/sh` 的依赖，并为临时文件路径使用平台感知的 shell 引号处理。
+- 使用新版 Chat Completions 模型所需的 OpenAI completion token 字段。
+- 使用已配置的模型输出上限作为 completion token 上限。
+- 修复适用于 OpenAI 兼容供应商的 goal budget 工具 schema。
+- 在访问已保存的子 Agent 时再惰性恢复它们。
+
+### 优化
+
+- 统一 TUI 对话框和选择器的交互与视觉效果。
+- 启动时记录已启用的实验性 flag。
+
+### 重构
+
+- 允许 SDK 运行时创建使用单独的 RPC client，同时保留本地 CLI 启动流程。
+
 ## 0.8.0
 
 ### 新功能

--- a/docs/zh/release-notes/changelog.md
+++ b/docs/zh/release-notes/changelog.md
@@ -6,9 +6,8 @@
 
 ### 新功能
 
-- 新增 `@moonshot-ai/acp-adapter` 和 `kimi acp` 子命令：kimi-code 现在可通过 stdio 使用 [Agent Client Protocol 0.23](https://agentclientprotocol.com/)，因此 IDE（Zed、JetBrains AI Chat、自定义客户端）可以直接驱动会话；覆盖矩阵、Zed 配置和破坏性预发布说明见 [kimi acp 子命令页面](https://moonshotai.github.io/kimi-code/en/reference/kimi-acp.html)。
-- 新增 `/btw`，用于进行不会引导当前主轮次的侧通道对话。
-- 允许 `/btw` 在输入问题前打开侧通道面板。
+- 支持 `kimi acp` 子命令：kimi-code 现在可通过 stdio 使用 [Agent Client Protocol 0.23](https://agentclientprotocol.com/)，因此 IDE（Zed、JetBrains AI Chat、自定义客户端）可以直接驱动会话；覆盖矩阵、Zed 配置和破坏性预发布说明见 [kimi acp 子命令页面](https://moonshotai.github.io/kimi-code/en/reference/kimi-acp.html)。
+- 新增 `/btw`，用于进行不会引导当前主轮次的侧通道对话，并允许 `/btw` 在输入问题前打开侧通道面板。
 
 ### 修复
 


### PR DESCRIPTION
## Problem

The documentation changelogs were missing the 0.9.0 release entries from `apps/kimi-code/CHANGELOG.md`.

## What changed

- Sync version `0.9.0` into `docs/en/release-notes/changelog.md` and `docs/zh/release-notes/changelog.md`
- Classify entries under Features, Bug Fixes, Polish, and Refactors
- Translate into Chinese following the glossary conventions
- Minor wording refinement: merge two `/btw` entries into one, simplify the ACP entry

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset. (docs sync does not need changeset)
- [x] Ran `gen-docs` skill, or this PR needs no doc update. (this is the doc update)