### PR TITLE
fix(update): start automatic installs after fresh version checks

### DIFF
--- a/.changeset/fresh-update-background-install.md
+++ b/.changeset/fresh-update-background-install.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Start automatic background updates as soon as startup's fresh update check finds a newer version.

--- a/apps/kimi-code/src/cli/update/preflight.ts
+++ b/apps/kimi-code/src/cli/update/preflight.ts
@@ -165,6 +165,32 @@ function refreshInBackground(): void {
   void refreshUpdateCache().catch(() => {});
 }
 
+function refreshAndMaybeInstallInBackground(
+  currentVersion: string,
+  isInteractive: boolean,
+  installState: UpdateInstallState,
+  platform: NodeJS.Platform,
+  track: RunUpdatePreflightOptions['track'],
+  logger: UpdateLogger,
+): void {
+  void (async () => {
+    const refreshed = await refreshUpdateCache();
+    if (!isInteractive) return;
+    const target = selectUpdateTarget(currentVersion, refreshed.latest);
+    if (target === null) return;
+    const source = await detectInstallSource().catch(() => 'unsupported' as const);
+    await tryStartAutomaticBackgroundInstall(
+      installState,
+      currentVersion,
+      target,
+      source,
+      platform,
+      track,
+      logger,
+    );
+  })().catch(() => {});
+}
+
 function nowIso(): string {
   return new Date().toISOString();
 }
@@ -433,6 +459,35 @@ async function startBackgroundInstall(
   }
 }
 
+async function tryStartAutomaticBackgroundInstall(
+  installState: UpdateInstallState,
+  currentVersion: string,
+  target: UpdateTarget,
+  source: InstallSource,
+  platform: NodeJS.Platform,
+  track: RunUpdatePreflightOptions['track'],
+  logger: UpdateLogger,
+): Promise<boolean> {
+  const sourceCanAutoInstall = canAutoInstall(source, platform);
+  const autoInstallUpdates = sourceCanAutoInstall ? await shouldAutoInstallUpdates() : false;
+  if (!autoInstallUpdates || !sourceCanAutoInstall) return false;
+  if (failureAttemptsFor(installState, target) >= AUTO_INSTALL_FAILURE_PROMPT_THRESHOLD) {
+    return false;
+  }
+  if (!hasFreshActiveInstall(installState, target)) {
+    await startBackgroundInstall(
+      installState,
+      currentVersion,
+      target,
+      source,
+      platform,
+      track,
+      logger,
+    ).catch(() => {});
+  }
+  return true;
+}
+
 export function decideUpdateAction(
   target: UpdateTarget | null,
   isInteractive: boolean,
@@ -469,33 +524,40 @@ export async function runUpdatePreflight(
     const cache = await readUpdateCache().catch(() => null);
     const latest = cache?.latest ?? null;
     const target = selectUpdateTarget(currentVersion, latest);
+    if (target === null) {
+      refreshAndMaybeInstallInBackground(
+        currentVersion,
+        isInteractive,
+        installState,
+        platform,
+        options.track,
+        logger,
+      );
+      return 'continue';
+    }
+
     refreshInBackground();
     const source: InstallSource =
-      target === null || !isInteractive
+      !isInteractive
         ? 'unsupported'
         : await detectInstallSource().catch(() => 'unsupported' as const);
 
     const decision = decideUpdateAction(target, isInteractive, source, platform);
-    if (decision === 'none' || target === null) return 'continue';
+    if (decision === 'none') return 'continue';
 
     const installCommand = installCommandFor(source, target.version, platform);
-    const sourceCanAutoInstall = canAutoInstall(source, platform);
-    const autoInstallUpdates = sourceCanAutoInstall ? await shouldAutoInstallUpdates() : false;
-    if (autoInstallUpdates && sourceCanAutoInstall) {
-      if (failureAttemptsFor(installState, target) < AUTO_INSTALL_FAILURE_PROMPT_THRESHOLD) {
-        if (!hasFreshActiveInstall(installState, target)) {
-          await startBackgroundInstall(
-            installState,
-            currentVersion,
-            target,
-            source,
-            platform,
-            options.track,
-            logger,
-          ).catch(() => {});
-        }
-        return 'continue';
-      }
+    if (
+      await tryStartAutomaticBackgroundInstall(
+        installState,
+        currentVersion,
+        target,
+        source,
+        platform,
+        options.track,
+        logger,
+      )
+    ) {
+      return 'continue';
     }
 
     trackUpdatePrompted(options.track, currentVersion, target, source, decision);

--- a/apps/kimi-code/test/cli/update/preflight.test.ts
+++ b/apps/kimi-code/test/cli/update/preflight.test.ts
@@ -185,15 +185,42 @@ describe('runUpdatePreflight', () => {
 
   afterEach(() => { vi.clearAllMocks(); });
 
-  it('continues on first launch with empty cache, still refreshes in background', async () => {
+  it('starts an automatic update from the first fresh check when the cache is empty', async () => {
     mocks.readUpdateCache.mockResolvedValue(emptyUpdateCache());
-    mocks.refreshUpdateCache.mockResolvedValue(emptyUpdateCache());
+    mocks.readUpdateInstallState.mockResolvedValue(installState());
+    mocks.refreshUpdateCache.mockResolvedValue(cacheWith('0.5.0'));
+    mocks.detectInstallSource.mockResolvedValue('npm-global');
+    mockSpawnExit(0);
     const { options } = captureOutput();
 
     await expect(runUpdatePreflight('0.4.0', options)).resolves.toBe('continue');
+    await flushBackgroundInstall();
+
     expect(readUpdateCache).toHaveBeenCalledTimes(1);
     expect(refreshUpdateCache).toHaveBeenCalledTimes(1);
-    expect(detectInstallSource).not.toHaveBeenCalled();
+    expect(promptForInstallChoice).not.toHaveBeenCalled();
+    expect(detectInstallSource).toHaveBeenCalledTimes(1);
+    expect(mocks.spawn).toHaveBeenCalledWith(
+      expect.stringMatching(/^npm(\.cmd)?$/),
+      ['install', '-g', '@moonshot-ai/kimi-code@0.5.0'],
+      { detached: true, stdio: 'ignore' },
+    );
+  });
+
+  it('does not start a fresh-check background install when automatic updates are disabled', async () => {
+    disableAutoInstall();
+    mocks.readUpdateCache.mockResolvedValue(emptyUpdateCache());
+    mocks.refreshUpdateCache.mockResolvedValue(cacheWith('0.5.0'));
+    mocks.detectInstallSource.mockResolvedValue('npm-global');
+    const { options } = captureOutput();
+
+    await expect(runUpdatePreflight('0.4.0', options)).resolves.toBe('continue');
+    await flushBackgroundInstall();
+
+    expect(refreshUpdateCache).toHaveBeenCalledTimes(1);
+    expect(detectInstallSource).toHaveBeenCalledTimes(1);
+    expect(promptForInstallChoice).not.toHaveBeenCalled();
+    expect(mocks.spawn).not.toHaveBeenCalled();
   });
 
   it('skips when non-interactive', async () => {
@@ -204,6 +231,22 @@ describe('runUpdatePreflight', () => {
       runUpdatePreflight('0.4.0', { ...options, isTTY: false }),
     ).resolves.toBe('continue');
     expect(detectInstallSource).not.toHaveBeenCalled();
+  });
+
+  it('does not start a fresh-check background install when non-interactive', async () => {
+    mocks.readUpdateCache.mockResolvedValue(emptyUpdateCache());
+    mocks.refreshUpdateCache.mockResolvedValue(cacheWith('0.5.0'));
+    const { options } = captureOutput();
+
+    await expect(
+      runUpdatePreflight('0.4.0', { ...options, isTTY: false }),
+    ).resolves.toBe('continue');
+    await flushBackgroundInstall();
+
+    expect(refreshUpdateCache).toHaveBeenCalledTimes(1);
+    expect(detectInstallSource).not.toHaveBeenCalled();
+    expect(promptForInstallChoice).not.toHaveBeenCalled();
+    expect(mocks.spawn).not.toHaveBeenCalled();
   });
 
   it('npm-global: prompts and spawns npm install -g when automatic updates are disabled', async () => {


### PR DESCRIPTION
## Related Issue

No linked issue; this fixes startup automatic updates delaying installation until the next launch.

## Problem

Automatic updates reused the notification-oriented cache flow: when the cache was empty, startup refreshed the latest-version cache in the background, but the freshly discovered version was not considered for installation until the next CLI launch.

## What changed

- Start the detached automatic installer from the fresh startup update check when it discovers a newer version.
- Reuse the existing active-install, failure-threshold, preference, lock, telemetry, and logging paths for both cached and fresh update checks.
- Add regression coverage for first-check installation, disabled automatic updates, and non-interactive startup.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.

## Validation

- `pnpm exec vitest run apps/kimi-code/test/cli/update/preflight.test.ts`
- `pnpm --filter @moonshot-ai/kimi-code run typecheck`
- `pnpm exec oxlint --type-aware apps/kimi-code/src/cli/update/preflight.ts apps/kimi-code/test/cli/update/preflight.test.ts`
- `git diff --check`