### PR TITLE
docs: fix docs dev and datasource navigation

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -9,7 +9,15 @@ const base = rawBase
     : `/${rawBase}/`
   : '/'
 
-export default withMermaid(defineConfig({
+const mermaidOptimizeDeps = [
+  '@braintree/sanitize-url',
+  'dayjs',
+  'debug',
+  'cytoscape-cose-bilkent',
+  'cytoscape',
+]
+
+const config = withMermaid(defineConfig({
   base,
   title: 'Kimi Code CLI Docs',
   description: 'Kimi Code CLI Documentation',
@@ -57,6 +65,7 @@ export default withMermaid(defineConfig({
                 { text: 'Model Context Protocol', link: '/zh/customization/mcp' },
                 { text: 'Agent Skills', link: '/zh/customization/skills' },
                 { text: 'Plugins', link: '/zh/customization/plugins' },
+                { text: 'Kimi Datasource', link: '/zh/customization/datasource' },
                 { text: 'Agent 与子 Agent', link: '/zh/customization/agents' },
                 { text: 'Hooks', link: '/zh/customization/hooks' },
               ],
@@ -132,6 +141,7 @@ export default withMermaid(defineConfig({
                 { text: 'Model Context Protocol', link: '/en/customization/mcp' },
                 { text: 'Agent Skills', link: '/en/customization/skills' },
                 { text: 'Plugins', link: '/en/customization/plugins' },
+                { text: 'Kimi Datasource', link: '/en/customization/datasource' },
                 { text: 'Agents and Subagents', link: '/en/customization/agents' },
                 { text: 'Hooks', link: '/en/customization/hooks' },
               ],
@@ -183,6 +193,17 @@ export default withMermaid(defineConfig({
   },
 
   vite: {
+    optimizeDeps: {
+      include: mermaidOptimizeDeps.map((dep) => `mermaid > ${dep}`),
+    },
     plugins: [llmstxt()],
   },
 }))
+
+if (config.vite?.optimizeDeps?.include) {
+  config.vite.optimizeDeps.include = config.vite.optimizeDeps.include.filter(
+    (dep) => !mermaidOptimizeDeps.includes(dep),
+  )
+}
+
+export default config

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -7,7 +7,7 @@ This repository uses VitePress for the documentation site. Most user-facing page
 - Locales live under `docs/en/` and `docs/zh/` with mirrored paths and filenames.
 - Main sections (nav + sidebar) are:
   - Guides: getting-started, migration, use-cases, interaction, sessions
-  - Customization: mcp, skills, plugins, agents, hooks
+  - Customization: mcp, skills, plugins, datasource, agents, hooks
   - Configuration: config-files, providers, overrides, env-vars, data-locations
   - Reference: kimi-command, tools, slash-commands, keyboard
   - Release notes: changelog

--- a/docs/en/customization/datasource.md
+++ b/docs/en/customization/datasource.md
@@ -1,4 +1,4 @@
-# Official Plugins
+# Kimi Datasource
 
 Kimi Datasource is the official Kimi Code data plugin. It lets you query financial market data, macroeconomic indicators, corporate registration records, and academic literature in natural language — no manual API calls or data account registration required.
 

--- a/docs/zh/customization/datasource.md
+++ b/docs/zh/customization/datasource.md
@@ -1,4 +1,4 @@
-# 官方插件
+# Kimi Datasource 官方插件
 
 Kimi Datasource 是 Kimi Code 官方数据插件，通过自然语言直接查询金融行情、宏观经济、企业工商和学术文献，无需手动调用接口或申请数据账号。
 


### PR DESCRIPTION
## Related Issue

No linked issue.

## Problem

The docs dev server could render a blank page when Mermaid loaded nested CommonJS dependencies through pnpm's strict layout. Separately, the Kimi Datasource page existed but was not listed in the Customization sidebar.

## What changed

- Added nested Mermaid dependency pre-bundling for the VitePress dev server so the docs page can load under pnpm's strict dependency layout.
- Added Kimi Datasource to both English and Chinese Customization sidebars.
- Updated the docs agent guide's section map to include datasource.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [ ] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.

Verification:

- `pnpm -C docs exec node -e "..."`
- `pnpm -C docs run build`
- `git diff --check --cached`
