### PR TITLE
test: mock browser opener in login tests

### DIFF
--- a/apps/kimi-code/test/cli/login.test.ts
+++ b/apps/kimi-code/test/cli/login.test.ts
@@ -25,9 +25,12 @@ vi.mock('@moonshot-ai/kimi-code-sdk', async () => {
   };
 });
 
+vi.mock('#/utils/open-url', () => ({ openUrl: vi.fn() }));
+
 import { createKimiHarness } from '@moonshot-ai/kimi-code-sdk';
 
 import { registerLoginCommand } from '#/cli/sub/login';
+import { openUrl } from '#/utils/open-url';
 
 class ExitCalled extends Error {
   constructor(public code: number | string | null | undefined) {
@@ -41,6 +44,7 @@ describe('kimi login', () => {
 
   beforeEach(() => {
     mockLogin.mockReset();
+    vi.mocked(openUrl).mockReset();
     vi.mocked(createKimiHarness).mockClear();
     exitSpy = vi.spyOn(process, 'exit').mockImplementation(((code?: number | string | null) => {
       throw new ExitCalled(code);
@@ -96,8 +100,8 @@ describe('kimi login', () => {
       ) => {
         await options.onDeviceCode?.({
           userCode: 'ABCD-EFGH',
-          verificationUri: 'https://kimi.com/v',
-          verificationUriComplete: 'https://kimi.com/v?code=ABCD-EFGH',
+          verificationUri: 'https://example.com/v',
+          verificationUriComplete: 'https://example.com/v?code=ABCD-EFGH',
           expiresIn: 600,
         });
         return { providerName: 'kimi-code', ok: true };
@@ -111,7 +115,10 @@ describe('kimi login', () => {
 
     const writtenChunks = stderrSpy.mock.calls.map((call: unknown[]) => String(call[0]));
     expect(writtenChunks.some((chunk: string) => chunk.includes('ABCD-EFGH'))).toBe(true);
-    expect(writtenChunks.some((chunk: string) => chunk.includes('https://kimi.com/v'))).toBe(true);
+    expect(writtenChunks.some((chunk: string) => chunk.includes('https://example.com/v'))).toBe(
+      true,
+    );
+    expect(openUrl).toHaveBeenCalledWith('https://example.com/v?code=ABCD-EFGH');
     expect(exitSpy).toHaveBeenCalledWith(0);
   });
 

--- a/apps/kimi-code/test/tui/kimi-tui-message-flow.test.ts
+++ b/apps/kimi-code/test/tui/kimi-tui-message-flow.test.ts
@@ -37,7 +37,7 @@ vi.mock('#/tui/commands/prompts', async (importOriginal) => {
   return { ...actual, promptFeedbackInput: vi.fn() };
 });
 
-vi.mock('#/tui/utils/open-url', () => ({ openUrl: vi.fn() }));
+vi.mock('#/utils/open-url', () => ({ openUrl: vi.fn() }));
 
 const ESC = String.fromCodePoint(0x1b);
 const BEL = String.fromCodePoint(0x07);

--- a/apps/kimi-code/test/tui/message-replay.test.ts
+++ b/apps/kimi-code/test/tui/message-replay.test.ts
@@ -16,7 +16,7 @@ import type { StreamingUIController } from '#/tui/controllers/streaming-ui';
 import { AgentGroupComponent } from '#/tui/components/messages/agent-group';
 import { ReadGroupComponent } from '#/tui/components/messages/read-group';
 
-vi.mock('#/tui/utils/open-url', () => ({ openUrl: vi.fn() }));
+vi.mock('#/utils/open-url', () => ({ openUrl: vi.fn() }));
 
 interface ReplayDriver {
   readonly state: TUIState;


### PR DESCRIPTION
## Related Issue

No linked issue; this fixes tests that could invoke the system browser when the device-code callback runs.

## Problem

The `kimi login` test executed the real browser opener through `openUrl`, and two TUI tests mocked an old module path that no longer intercepts the actual opener import.

## What changed

- Mocked `#/utils/open-url` in the login test and asserted the complete verification URL is passed to it.
- Updated TUI tests to mock the current opener module path.
- Replaced login test URL fixtures with neutral `example.com` data.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.

Verification:

- `pnpm --filter @moonshot-ai/kimi-code exec vitest run test/cli/login.test.ts test/tui/message-replay.test.ts test/tui/kimi-tui-message-flow.test.ts`
- `git diff --check`

Changeset: not needed; this is test-only and does not affect release artifacts.
Docs: not needed; product behavior is unchanged.
