### PR TITLE
docs: mention Windows Git Bash requirement

### DIFF
--- a/.changeset/windows-git-bash-docs.md
+++ b/.changeset/windows-git-bash-docs.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Document the Git Bash prerequisite for Windows installs.

--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ curl -fsSL https://code.kimi.com/kimi-code/install.sh | bash
 irm https://code.kimi.com/kimi-code/install.ps1 | iex
 ```
 
+> On Windows, install [Git for Windows](https://gitforwindows.org/) before first launch because Kimi Code CLI uses the bundled Git Bash as its shell environment. If Git Bash is installed in a custom location, set `KIMI_SHELL_PATH` to the absolute path of `bash.exe`.
+
 Then, run it with a new shell session:
 
 ```sh

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -28,6 +28,8 @@ curl -fsSL https://code.kimi.com/kimi-code/install.sh | bash
 irm https://code.kimi.com/kimi-code/install.ps1 | iex
 ```
 
+> Windows 用户首次启动前还需要安装 [Git for Windows](https://gitforwindows.org/)，Kimi Code CLI 会使用其中的 Git Bash 作为 Shell 环境。如果 Git Bash 安装在非标准路径，请把 `KIMI_SHELL_PATH` 设为 `bash.exe` 的绝对路径。
+
 随后在新的终端会话中运行：
 
 ```sh

--- a/apps/kimi-code/README.md
+++ b/apps/kimi-code/README.md
@@ -24,6 +24,8 @@ curl -fsSL https://code.kimi.com/kimi-code/install.sh | bash
 irm https://code.kimi.com/kimi-code/install.ps1 | iex
 ```
 
+> On Windows, install [Git for Windows](https://gitforwindows.org/) before first launch because Kimi Code CLI uses the bundled Git Bash as its shell environment. If Git Bash is installed in a custom location, set `KIMI_SHELL_PATH` to the absolute path of `bash.exe`.
+
 Then run it with a new Terminal session:
 
 ```sh

--- a/docs/en/guides/getting-started.md
+++ b/docs/en/guides/getting-started.md
@@ -30,6 +30,8 @@ curl -fsSL https://code.kimi.com/kimi-code/install.sh | bash
 irm https://code.kimi.com/kimi-code/install.ps1 | iex
 ```
 
+> On Windows, install [Git for Windows](https://gitforwindows.org/) before first launch. Kimi Code CLI uses the bundled Git Bash as its shell environment; if Git Bash is installed in a custom location, set `KIMI_SHELL_PATH` to the absolute path of `bash.exe`.
+
 The script automatically downloads the latest release, verifies the checksum, and places the `kimi` executable on your `PATH`.
 
 ### npm installation

--- a/docs/zh/guides/getting-started.md
+++ b/docs/zh/guides/getting-started.md
@@ -30,6 +30,8 @@ curl -fsSL https://code.kimi.com/kimi-code/install.sh | bash
 irm https://code.kimi.com/kimi-code/install.ps1 | iex
 ```
 
+> Windows 用户首次启动前还需要安装 [Git for Windows](https://gitforwindows.org/)，Kimi Code CLI 会使用其中的 Git Bash 作为 Shell 环境。如果 Git Bash 安装在非标准路径，请把 `KIMI_SHELL_PATH` 设为 `bash.exe` 的绝对路径。
+
 脚本会自动下载最新版本、校验 checksum，并把 `kimi` 可执行文件放到你的 `PATH` 中。
 
 ### npm 安装


### PR DESCRIPTION
## Related Issue

Resolve #259

## Problem

See linked issue. The Windows install command can succeed on a fresh machine, but the install docs did not tell users that Kimi Code CLI expects Git Bash as its Windows shell environment before first launch.

## What changed

Added Git for Windows / Git Bash prerequisite notes to the English and Chinese Getting Started pages, plus the root and package README install sections. The note also points custom Git Bash installations to `KIMI_SHELL_PATH`.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works. (Docs-only; verified with docs build.)
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.