### PR TITLE
fix(nix): expose ripgrep and fd to wrapped kimi

### DIFF
--- a/.changeset/nix-cli-tool-path.md
+++ b/.changeset/nix-cli-tool-path.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Ensure Nix-packaged CLI builds can find ripgrep and fd.

--- a/flake.nix
+++ b/flake.nix
@@ -147,6 +147,7 @@
               nodejs
               pnpm
               (pkgs.pnpmConfigHook.override { inherit pnpm; })
+              pkgs.makeWrapper
             ]
             # The SEA inject step (postject) invalidates the macOS code
             # signature on the copied Node executable; build.mjs then re-applies
@@ -190,6 +191,10 @@
               runHook postInstall
             '';
 
+            postInstall = ''
+              wrapProgram $out/bin/kimi --prefix PATH : ${lib.makeBinPath [ pkgs.ripgrep pkgs.fd ]}
+            '';
+
             meta = {
               description = "Kimi Code CLI";
               homepage = "https://github.com/MoonshotAI/kimi-code";
@@ -223,6 +228,8 @@
             packages = [
               nodejs
               pnpm
+              pkgs.ripgrep
+              pkgs.fd
             ];
           };
       });


### PR DESCRIPTION
## Summary

Fix the Nix-packaged CLI wrapper so `ripgrep` and `fd` are available on `PATH`, and include both tools in the Nix dev shell for local development.

---

### 1. Expose search tools in Nix builds

**Problem:** Nix-built `kimi` binaries could not find `rg`/`fd` at runtime, and the Nix dev shell did not provide these CLI search dependencies either.

**What was done:**
- Added `makeWrapper` to the Nix build inputs.
- Wrapped `$out/bin/kimi` with `ripgrep` and `fd` on `PATH`.
- Added `ripgrep` and `fd` to the dev shell packages.
- Added a patch changeset for the CLI package.

---

## Related Issue

No related issue; the problem is described above.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [ ] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.
