### PR TITLE
feat: add kimi-code web UI

### DIFF
--- a/apps/kimi-code-web/index.html
+++ b/apps/kimi-code-web/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Kimi Code</title>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="/src/main.ts"></script>
+  </body>
+</html>

--- a/apps/kimi-code-web/package.json
+++ b/apps/kimi-code-web/package.json
@@ -1,0 +1,54 @@
+{
+  "name": "@moonshot-ai/kimi-code-web",
+  "version": "0.1.1",
+  "private": true,
+  "description": "Minimal web UI for Kimi Code",
+  "license": "MIT",
+  "author": "Moonshot AI",
+  "homepage": "https://github.com/MoonshotAI/kimi-code/tree/main/apps/kimi-code-web#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/MoonshotAI/kimi-code.git",
+    "directory": "apps/kimi-code-web"
+  },
+  "bugs": {
+    "url": "https://github.com/MoonshotAI/kimi-code/issues"
+  },
+  "keywords": [
+    "kimi",
+    "kimi-code",
+    "web",
+    "agent",
+    "coding-agent",
+    "ai"
+  ],
+  "type": "module",
+  "imports": {
+    "#/*": [
+      "./src/*.ts",
+      "./src/*/index.ts"
+    ]
+  },
+  "scripts": {
+    "predev": "pnpm -C ../../packages/node-sdk run build",
+    "dev": "vite",
+    "prebuild": "pnpm -C ../../packages/node-sdk run build",
+    "build": "vite build",
+    "pretypecheck": "pnpm -C ../../packages/node-sdk run build",
+    "typecheck": "vue-tsc -p tsconfig.json --noEmit",
+    "clean": "rm -rf dist"
+  },
+  "dependencies": {
+    "@moonshot-ai/kimi-code-sdk": "workspace:^",
+    "vue": "^3.5.35"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-vue": "^6.0.7",
+    "typescript": "6.0.2",
+    "vite": "^6.3.3",
+    "vue-tsc": "^3.3.3"
+  },
+  "engines": {
+    "node": ">=24.15.0"
+  }
+}

--- a/apps/kimi-code-web/src/App.vue
+++ b/apps/kimi-code-web/src/App.vue
@@ -1,0 +1,249 @@
+<script setup lang="ts">
+import { onBeforeUnmount, onMounted, ref } from 'vue';
+import type { Event, Session } from '@moonshot-ai/kimi-code-sdk/browser';
+
+import { createKimiWebHarness } from '#/harness';
+
+type WebMessageRole = 'user' | 'assistant' | 'system';
+
+type MutableWebMessage = {
+  id: string;
+  role: WebMessageRole;
+  text: string;
+};
+
+const workDir = __KIMI_CODE_WEB_WORK_DIR__;
+const PRODUCT_NAME = 'Kimi Code';
+const WEB_UI_MODE = 'web';
+const sessionId = ref<string>();
+const model = ref<string>();
+const busy = ref(false);
+const error = ref<string>();
+const messages = ref<MutableWebMessage[]>([]);
+const input = ref('');
+
+let sequence = 0;
+let activeTurnId: number | undefined;
+let activeAssistantMessageId: string | undefined;
+let session: Session | undefined;
+let sessionUnsubscribe: (() => void) | undefined;
+
+const harness = createKimiWebHarness();
+
+onMounted(async () => {
+  await loadConfig();
+});
+
+onBeforeUnmount(() => {
+  sessionUnsubscribe?.();
+  void harness.close();
+});
+
+async function loadConfig(): Promise<void> {
+  try {
+    const config = await harness.getConfig();
+    model.value = config.defaultModel;
+  } catch (loadError) {
+    fail(errorMessage(loadError));
+  }
+}
+
+async function submit(): Promise<void> {
+  const text = input.value.trim();
+  if (text.length === 0 || busy.value) return;
+
+  input.value = '';
+  error.value = undefined;
+  appendMessage('user', text);
+  busy.value = true;
+  activeTurnId = undefined;
+  activeAssistantMessageId = undefined;
+
+  try {
+    const activeSession = await ensureSession();
+    await activeSession.prompt(text);
+  } catch (submitError) {
+    fail(errorMessage(submitError));
+  }
+}
+
+async function cancel(): Promise<void> {
+  if (session === undefined) return;
+
+  try {
+    await session.cancel();
+  } catch (cancelError) {
+    fail(errorMessage(cancelError));
+  }
+}
+
+async function ensureSession(): Promise<Session> {
+  if (session !== undefined) return session;
+
+  session = await harness.createSession({
+    workDir,
+    model: model.value,
+    metadata: {
+      uiMode: WEB_UI_MODE,
+    },
+  });
+  sessionId.value = session.id;
+  session.setApprovalHandler(async (request) => {
+    appendMessage('system', `Approval request cancelled: ${request.toolName}`);
+    return {
+      decision: 'cancelled',
+      feedback: 'Kimi Code Web does not implement approval UI yet.',
+    };
+  });
+  session.setQuestionHandler(async (request) => {
+    appendMessage('system', `Question request ignored: ${String(request.questions.length)}`);
+    return null;
+  });
+  sessionUnsubscribe = session.onEvent(handleEvent);
+
+  const status = await session.getStatus();
+  model.value = status.model ?? model.value;
+  return session;
+}
+
+function handleEvent(event: Event): void {
+  if (sessionId.value !== undefined && event.sessionId !== sessionId.value) return;
+
+  switch (event.type) {
+    case 'turn.started':
+      busy.value = true;
+      activeTurnId = event.turnId;
+      break;
+    case 'assistant.delta':
+      if (isActiveTurn(event.turnId)) {
+        appendAssistantDelta(event.delta);
+      }
+      break;
+    case 'tool.call.started':
+      if (isActiveTurn(event.turnId)) {
+        appendMessage('system', `Tool: ${event.name}`);
+      }
+      break;
+    case 'tool.result':
+      if (isActiveTurn(event.turnId)) {
+        appendMessage('system', `Tool result: ${plainToolResult(event.output)}`);
+      }
+      break;
+    case 'turn.ended':
+      if (isActiveTurn(event.turnId)) {
+        busy.value = false;
+        activeTurnId = undefined;
+        activeAssistantMessageId = undefined;
+      }
+      break;
+    case 'agent.status.updated':
+      model.value = event.model ?? model.value;
+      break;
+    case 'error':
+      fail(`${event.code}: ${event.message}`);
+      break;
+    case 'warning':
+      appendMessage('system', `Warning: ${event.message}`);
+      break;
+    case 'session.meta.updated':
+    case 'thinking.delta':
+    case 'hook.result':
+    case 'skill.activated':
+    case 'turn.step.started':
+    case 'turn.step.completed':
+    case 'turn.step.retrying':
+    case 'turn.step.interrupted':
+    case 'tool.call.delta':
+    case 'tool.progress':
+    case 'tool.list.updated':
+    case 'mcp.server.status':
+    case 'subagent.spawned':
+    case 'subagent.completed':
+    case 'subagent.failed':
+    case 'compaction.started':
+    case 'compaction.blocked':
+    case 'compaction.cancelled':
+    case 'compaction.completed':
+    case 'background.task.started':
+    case 'background.task.terminated':
+    case 'cron.fired':
+      break;
+  }
+}
+
+function isActiveTurn(turnId: number): boolean {
+  return activeTurnId === undefined || activeTurnId === turnId;
+}
+
+function appendAssistantDelta(delta: string): void {
+  if (activeAssistantMessageId === undefined) {
+    const message = appendMessage('assistant', '');
+    activeAssistantMessageId = message.id;
+  }
+  const message = messages.value.find((item) => item.id === activeAssistantMessageId);
+  if (message === undefined) return;
+  message.text += delta;
+}
+
+function appendMessage(role: WebMessageRole, text: string): MutableWebMessage {
+  const message: MutableWebMessage = {
+    id: `msg-${String(++sequence)}`,
+    role,
+    text,
+  };
+  messages.value.push(message);
+  return message;
+}
+
+function fail(message: string): void {
+  error.value = message;
+  busy.value = false;
+  activeTurnId = undefined;
+  activeAssistantMessageId = undefined;
+  appendMessage('system', `Error: ${message}`);
+}
+
+function plainToolResult(result: unknown): string {
+  if (typeof result === 'string') return truncate(result);
+  if (result === null || result === undefined) return '';
+  try {
+    return truncate(JSON.stringify(result));
+  } catch {
+    return truncate(String(result));
+  }
+}
+
+function truncate(value: string): string {
+  const trimmed = value.trim();
+  if (trimmed.length <= 500) return trimmed;
+  return `${trimmed.slice(0, 500)}...`;
+}
+
+function errorMessage(value: unknown): string {
+  return value instanceof Error ? value.message : String(value);
+}
+</script>
+
+<template>
+  <main>
+    <h1>{{ PRODUCT_NAME }}</h1>
+    <p>Workdir: {{ workDir }}</p>
+    <p v-if="sessionId">Session: {{ sessionId }}</p>
+    <p v-if="model">Model: {{ model }}</p>
+    <p v-if="error">Error: {{ error }}</p>
+
+    <form @submit.prevent="submit">
+      <textarea v-model="input" rows="6" cols="80" :disabled="busy"></textarea>
+      <br />
+      <button type="submit" :disabled="busy || input.trim().length === 0">Send</button>
+      <button type="button" :disabled="!busy" @click="cancel">Cancel</button>
+    </form>
+
+    <section>
+      <article v-for="message in messages" :key="message.id">
+        <strong>{{ message.role }}</strong>
+        <pre>{{ message.text }}</pre>
+      </article>
+    </section>
+  </main>
+</template>

--- a/apps/kimi-code-web/src/harness.ts
+++ b/apps/kimi-code-web/src/harness.ts
@@ -1,0 +1,32 @@
+import { createBirpcKimiHarness, type KimiHarness } from '@moonshot-ai/kimi-code-sdk/browser';
+
+const WEB_USER_AGENT_PRODUCT = 'kimi-code-web';
+const WEB_UI_MODE = 'web';
+const CLIENT_TO_SERVER_EVENT = 'kimi-code-web:client';
+const SERVER_TO_CLIENT_EVENT = 'kimi-code-web:server';
+
+export function createKimiWebHarness(): KimiHarness {
+  const hot = import.meta.hot;
+  if (hot === undefined) {
+    throw new Error('Kimi Code Web requires the Vite dev server.');
+  }
+
+  return createBirpcKimiHarness({
+    channel: {
+      post: (data) => {
+        hot.send(CLIENT_TO_SERVER_EVENT, data);
+      },
+      on: (fn) => {
+        hot.on(SERVER_TO_CLIENT_EVENT, fn);
+      },
+      off: (fn) => {
+        hot.off(SERVER_TO_CLIENT_EVENT, fn);
+      },
+    },
+    identity: {
+      userAgentProduct: WEB_USER_AGENT_PRODUCT,
+      version: __KIMI_CODE_WEB_VERSION__,
+    },
+    uiMode: WEB_UI_MODE,
+  });
+}

--- a/apps/kimi-code-web/src/main.ts
+++ b/apps/kimi-code-web/src/main.ts
@@ -1,0 +1,5 @@
+import { createApp } from 'vue';
+
+import App from './App.vue';
+
+createApp(App).mount('#app');

--- a/apps/kimi-code-web/src/vite-plugin.ts
+++ b/apps/kimi-code-web/src/vite-plugin.ts
@@ -1,0 +1,57 @@
+import { resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+import type { Plugin } from 'vite';
+
+import packageJson from '../package.json' with { type: 'json' };
+
+const WEB_USER_AGENT_PRODUCT = 'kimi-code-web';
+const CLIENT_TO_SERVER_EVENT = 'kimi-code-web:client';
+const SERVER_TO_CLIENT_EVENT = 'kimi-code-web:server';
+const SDK_DIST_URL = pathToFileURL(
+  resolve(process.cwd(), '../../packages/node-sdk/dist/index.mjs'),
+).href;
+
+interface KimiCoreBirpcServerRuntime {
+  ensureConfigFile(): Promise<void>;
+  close(): Promise<void>;
+}
+
+interface KimiCoreBirpcServerModule {
+  readonly KimiCoreBirpcServer: new (options: {
+    readonly channel: {
+      post(data: unknown): void;
+      on(fn: (data: unknown) => void): void;
+    };
+    readonly identity: {
+      readonly userAgentProduct: string;
+      readonly version: string;
+    };
+  }) => KimiCoreBirpcServerRuntime;
+}
+
+export function kimiCodeWebPlugin(): Plugin {
+  return {
+    name: 'kimi-code-web',
+    async configureServer(server) {
+      const { KimiCoreBirpcServer: KimiCoreBirpcServerCtor } = (await import(
+        /* @vite-ignore */ SDK_DIST_URL
+      )) as KimiCoreBirpcServerModule;
+      const runtime = new KimiCoreBirpcServerCtor({
+        channel: {
+          post: (data) => server.ws.send(SERVER_TO_CLIENT_EVENT, data),
+          on: (fn) => server.ws.on(CLIENT_TO_SERVER_EVENT, fn),
+        },
+        identity: {
+          userAgentProduct: WEB_USER_AGENT_PRODUCT,
+          version: packageJson.version,
+        },
+      });
+      await runtime.ensureConfigFile();
+
+      server.httpServer?.once('close', () => {
+        void runtime.close();
+      });
+    },
+  };
+}

--- a/apps/kimi-code-web/tsconfig.json
+++ b/apps/kimi-code-web/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "lib": ["ES2023", "DOM", "DOM.Iterable"],
+    "types": ["vite/client", "node"],
+    "resolveJsonModule": true,
+    "paths": {
+      "@moonshot-ai/kimi-code-sdk/browser": [
+        "../../packages/node-sdk/dist/browser.d.mts"
+      ],
+      "#/*": ["./src/*", "./src/*/index.ts"]
+    }
+  },
+  "include": ["src/**/*.ts", "src/**/*.vue", "vite.config.ts", "vite-env.d.ts"]
+}

--- a/apps/kimi-code-web/vite-env.d.ts
+++ b/apps/kimi-code-web/vite-env.d.ts
@@ -1,0 +1,18 @@
+/// <reference types="vite/client" />
+
+declare const __KIMI_CODE_WEB_WORK_DIR__: string;
+declare const __KIMI_CODE_WEB_VERSION__: string;
+
+declare module '*.vue' {
+  import type { DefineComponent } from 'vue';
+
+  const component: DefineComponent<object, object, unknown>;
+  export default component;
+}
+
+declare module 'vite/types/customEvent' {
+  interface CustomEventMap {
+    'kimi-code-web:client': unknown;
+    'kimi-code-web:server': unknown;
+  }
+}

--- a/apps/kimi-code-web/vite.config.ts
+++ b/apps/kimi-code-web/vite.config.ts
@@ -1,0 +1,31 @@
+import { fileURLToPath } from 'node:url';
+
+import vue from '@vitejs/plugin-vue';
+import { defineConfig } from 'vite';
+
+import { kimiCodeWebPlugin } from './src/vite-plugin';
+
+export default defineConfig({
+  plugins: [vue(), kimiCodeWebPlugin()],
+  define: {
+    __KIMI_CODE_WEB_WORK_DIR__: JSON.stringify(process.cwd()),
+    __KIMI_CODE_WEB_VERSION__: JSON.stringify(process.env['npm_package_version'] ?? '0.0.0'),
+  },
+  resolve: {
+    alias: {
+      '#': fileURLToPath(new URL('./src', import.meta.url)),
+      '@moonshot-ai/kimi-code-sdk/browser': fileURLToPath(
+        new URL('../../packages/node-sdk/dist/browser.mjs', import.meta.url),
+      ),
+    },
+  },
+  server: {
+    port: Number(process.env['WEB_PORT']) || 5173,
+    strictPort: false,
+  },
+  build: {
+    outDir: 'dist',
+    emptyOutDir: true,
+    target: 'es2022',
+  },
+});

--- a/flake.nix
+++ b/flake.nix
@@ -71,6 +71,7 @@
         ./packages/oauth
         ./packages/telemetry
         ./apps/kimi-code
+        ./apps/kimi-code-web
         ./apps/vis
         ./apps/vis/server
         ./apps/vis/web
@@ -87,6 +88,7 @@
         "@moonshot-ai/kimi-code-oauth"
         "@moonshot-ai/kimi-telemetry"
         "@moonshot-ai/kimi-code"
+        "@moonshot-ai/kimi-code-web"
         "@moonshot-ai/vis"
         "@moonshot-ai/vis-server"
         "@moonshot-ai/vis-web"

--- a/packages/agent-core/package.json
+++ b/packages/agent-core/package.json
@@ -37,6 +37,18 @@
       "types": "./src/index.ts",
       "default": "./src/index.ts"
     },
+    "./errors/codes": {
+      "types": "./src/errors/codes.ts",
+      "default": "./src/errors/codes.ts"
+    },
+    "./errors/classes": {
+      "types": "./src/errors/classes.ts",
+      "default": "./src/errors/classes.ts"
+    },
+    "./telemetry": {
+      "types": "./src/telemetry.ts",
+      "default": "./src/telemetry.ts"
+    },
     "./agent/records/migration": {
       "types": "./src/agent/records/migration/index.ts",
       "default": "./src/agent/records/migration/index.ts"

--- a/packages/node-sdk/api-extractor.browser.json
+++ b/packages/node-sdk/api-extractor.browser.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json",
+  "extends": "./api-extractor.json",
+  "mainEntryPointFilePath": "<projectFolder>/.tmp-api-extractor/dts/node-sdk/src/browser.d.ts",
+  "dtsRollup": {
+    "untrimmedFilePath": "<projectFolder>/dist/browser.d.mts"
+  }
+}

--- a/packages/node-sdk/package.json
+++ b/packages/node-sdk/package.json
@@ -36,6 +36,10 @@
     ".": {
       "types": "./src/index.ts",
       "default": "./src/index.ts"
+    },
+    "./browser": {
+      "types": "./src/browser.ts",
+      "default": "./src/browser.ts"
     }
   },
   "publishConfig": {
@@ -45,6 +49,11 @@
         "types": "./dist/index.d.mts",
         "import": "./dist/index.mjs",
         "default": "./dist/index.mjs"
+      },
+      "./browser": {
+        "types": "./dist/browser.d.mts",
+        "import": "./dist/browser.mjs",
+        "default": "./dist/browser.mjs"
       }
     },
     "provenance": true
@@ -57,6 +66,7 @@
   },
   "dependencies": {
     "@antfu/utils": "^9.3.0",
+    "birpc": "^4.0.0",
     "smol-toml": "^1.6.1",
     "yazl": "^3.3.1",
     "zod": "catalog:"

--- a/packages/node-sdk/scripts/build-dts.mjs
+++ b/packages/node-sdk/scripts/build-dts.mjs
@@ -22,6 +22,12 @@ try {
   await writeProviderClientShim();
   await rewriteWorkspaceSpecifiers();
   await run('api-extractor', ['run', '--local']);
+  await run('api-extractor', [
+    'run',
+    '--local',
+    '--config',
+    path.join(packageRoot, 'api-extractor.browser.json'),
+  ]);
 } finally {
   await rm(tempDir, { recursive: true, force: true });
 }

--- a/packages/node-sdk/src/birpc-client.ts
+++ b/packages/node-sdk/src/birpc-client.ts
@@ -1,0 +1,90 @@
+import { createBirpc, type BirpcOptions, type BirpcReturn } from 'birpc';
+import { noopTelemetryClient } from '@moonshot-ai/agent-core/telemetry';
+import type { CoreAPI, RPCMethods, SDKAPI } from '@moonshot-ai/agent-core';
+
+import type { KimiAuthFacade } from '#/auth';
+import { KimiHarness } from '#/kimi-harness';
+import { ClientAPI, SDKRpcClientBase } from '#/rpc';
+import type { KimiHostIdentity } from '#/types';
+
+export type BirpcSDKRpcClientChannelOptions = Omit<
+  BirpcOptions<CoreAPI, SDKAPI>,
+  'bind' | 'eventNames'
+> & {
+  readonly eventNames?: (keyof CoreAPI)[];
+};
+
+export interface BirpcSDKRpcClientOptions {
+  readonly channel: BirpcSDKRpcClientChannelOptions;
+}
+
+export interface BirpcKimiHarnessOptions extends BirpcSDKRpcClientOptions {
+  readonly identity?: KimiHostIdentity;
+  readonly uiMode?: string;
+}
+
+export class BirpcSDKRpcClient extends SDKRpcClientBase {
+  private readonly rpc: BirpcReturn<CoreAPI, SDKAPI>;
+
+  constructor(options: BirpcSDKRpcClientOptions) {
+    super();
+    this.rpc = createBirpc<CoreAPI, SDKAPI>(bindRpcMethods(new ClientAPI(this)), {
+      ...options.channel,
+      bind: 'functions',
+      eventNames: options.channel.eventNames ?? [],
+    });
+  }
+
+  close(): void {
+    this.rpc.$close();
+  }
+
+  protected async getRpc(): Promise<RPCMethods<CoreAPI>> {
+    return this.rpc as unknown as RPCMethods<CoreAPI>;
+  }
+}
+
+export function createBirpcKimiHarness(options: BirpcKimiHarnessOptions): KimiHarness {
+  const rpc = new BirpcSDKRpcClient(options);
+  return new KimiHarness(rpc, {
+    identity: options.identity,
+    uiMode: options.uiMode,
+    homeDir: '',
+    configPath: '',
+    auth: unavailableBrowserAuth,
+    telemetry: noopTelemetryClient,
+    ensureConfigFile: async () => {},
+    onClose: () => rpc.close(),
+  });
+}
+
+const unavailableBrowserAuth = new Proxy(
+  {},
+  {
+    get(_target, property) {
+      throw new Error(`Kimi browser harness does not expose auth.${String(property)}.`);
+    },
+  },
+) as KimiAuthFacade;
+
+function bindRpcMethods<T extends object>(obj: T): T {
+  const bound: Record<string, unknown> = {};
+  let current: object | null = obj;
+
+  while (current !== null && current !== Object.prototype) {
+    for (const key of Object.getOwnPropertyNames(current)) {
+      if (key === 'constructor' || Object.hasOwn(bound, key)) {
+        continue;
+      }
+
+      const descriptor = Object.getOwnPropertyDescriptor(current, key);
+      if (typeof descriptor?.value === 'function') {
+        bound[key] = descriptor.value.bind(obj);
+      }
+    }
+
+    current = Object.getPrototypeOf(current);
+  }
+
+  return bound as T;
+}

--- a/packages/node-sdk/src/birpc-server.ts
+++ b/packages/node-sdk/src/birpc-server.ts
@@ -1,0 +1,132 @@
+import {
+  ensureConfigFile,
+  getRootLogger,
+  KimiCore,
+  resolveConfigPath,
+  resolveKimiHome,
+  resolveLoggingConfig,
+  type CoreAPI,
+  type CoreRPCClient,
+  type RPCMethods,
+  type SDKAPI,
+  type TelemetryClient,
+} from '@moonshot-ai/agent-core';
+import { assertKimiHostIdentity, createKimiDefaultHeaders } from '@moonshot-ai/kimi-code-oauth';
+import { createBirpc, type BirpcOptions, type BirpcReturn } from 'birpc';
+
+import { KimiAuthFacade } from '#/auth';
+import type { KimiHostIdentity, OAuthRefreshOutcome } from '#/types';
+
+export type KimiCoreBirpcServerChannelOptions = Omit<
+  BirpcOptions<SDKAPI, CoreAPI>,
+  'bind' | 'eventNames'
+> & {
+  readonly eventNames?: (keyof SDKAPI)[];
+};
+
+export interface KimiCoreBirpcServerOptions {
+  readonly channel: KimiCoreBirpcServerChannelOptions;
+  readonly identity?: KimiHostIdentity;
+  readonly homeDir?: string;
+  readonly configPath?: string;
+  readonly skillDirs?: readonly string[];
+  readonly telemetry?: TelemetryClient;
+  readonly onOAuthRefresh?: (outcome: OAuthRefreshOutcome) => void;
+}
+
+export class KimiCoreBirpcServer {
+  readonly homeDir: string;
+  readonly configPath: string;
+  readonly auth: KimiAuthFacade;
+  readonly core: KimiCore;
+  readonly rpc: BirpcReturn<SDKAPI, CoreAPI>;
+
+  private readonly identity: KimiHostIdentity | undefined;
+
+  constructor(options: KimiCoreBirpcServerOptions) {
+    this.identity =
+      options.identity === undefined ? undefined : assertKimiHostIdentity(options.identity);
+    this.homeDir = resolveKimiHome(options.homeDir);
+    this.configPath = resolveConfigPath({
+      homeDir: this.homeDir,
+      configPath: options.configPath,
+    });
+    void getRootLogger().configure(resolveLoggingConfig({ homeDir: this.homeDir }));
+
+    this.auth = new KimiAuthFacade({
+      homeDir: this.homeDir,
+      configPath: this.configPath,
+      identity: this.identity,
+      onRefresh: options.onOAuthRefresh,
+    });
+
+    let rpc: BirpcReturn<SDKAPI, CoreAPI> | undefined;
+    const rpcClient: CoreRPCClient = async (coreApi) => {
+      rpc = createBirpc<SDKAPI, CoreAPI>(bindRpcMethods(coreApi as unknown as CoreAPI), {
+        ...options.channel,
+        bind: 'functions',
+        eventNames: options.channel.eventNames ?? ['emitEvent'],
+      });
+      return rpc as unknown as RPCMethods<SDKAPI>;
+    };
+
+    this.core = new KimiCore(rpcClient, {
+      homeDir: this.homeDir,
+      configPath: this.configPath,
+      kimiRequestHeaders: this.createKimiRequestHeaders(),
+      resolveOAuthTokenProvider: this.auth.resolveOAuthTokenProvider,
+      skillDirs: options.skillDirs,
+      telemetry: options.telemetry,
+    });
+
+    if (rpc === undefined) {
+      throw new Error('Kimi Core birpc server was not initialized.');
+    }
+    this.rpc = rpc;
+  }
+
+  async ensureConfigFile(): Promise<void> {
+    await ensureConfigFile(this.configPath);
+  }
+
+  async close(): Promise<void> {
+    await Promise.all(Array.from(this.core.sessions.values(), (session) => session.close()));
+    this.rpc.$close();
+    try {
+      await getRootLogger().flush();
+    } catch {
+      // Keep shutdown best-effort, matching local harness.
+    }
+  }
+
+  private createKimiRequestHeaders(): Record<string, string> | undefined {
+    if (this.identity === undefined) return undefined;
+    return createKimiDefaultHeaders({
+      homeDir: this.homeDir,
+      userAgentProduct: this.identity.userAgentProduct,
+      version: this.identity.version,
+    });
+  }
+}
+
+function bindRpcMethods<T extends object>(obj: T): T {
+  const bound: Record<string, unknown> = {};
+  let current: object | null = obj;
+
+  while (current !== null && current !== Object.prototype) {
+    for (const key of Object.getOwnPropertyNames(current)) {
+      if (key === 'constructor' || Object.hasOwn(bound, key)) {
+        continue;
+      }
+
+      const descriptor = Object.getOwnPropertyDescriptor(current, key);
+      if (typeof descriptor?.value === 'function') {
+        bound[key] = descriptor.value.bind(obj);
+      }
+    }
+
+    current = Object.getPrototypeOf(current);
+  }
+
+  return bound as T;
+}

--- a/packages/node-sdk/src/browser.ts
+++ b/packages/node-sdk/src/browser.ts
@@ -1,0 +1,39 @@
+export { KimiHarness } from '#/kimi-harness';
+export { Session } from '#/session';
+export {
+  BirpcSDKRpcClient,
+  createBirpcKimiHarness,
+  type BirpcKimiHarnessOptions,
+  type BirpcSDKRpcClientChannelOptions,
+  type BirpcSDKRpcClientOptions,
+} from '#/birpc-client';
+export {
+  ErrorCodes,
+  KIMI_ERROR_INFO,
+  type KimiErrorCode,
+  type KimiErrorInfo,
+} from '@moonshot-ai/agent-core/errors/codes';
+export {
+  KimiError,
+  type KimiErrorOptions,
+} from '@moonshot-ai/agent-core/errors/classes';
+
+export type {
+  ApprovalHandler,
+  ApprovalRequest,
+  ApprovalResponse,
+  Event,
+  QuestionHandler,
+  QuestionRequest,
+  QuestionResult,
+} from '#/events';
+export type {
+  CoreAPI,
+  SDKAPI,
+  SDKRPCClient,
+} from '@moonshot-ai/agent-core';
+export type {
+  KimiConfig,
+  KimiHostIdentity,
+  SessionStatus,
+} from '#/types';

--- a/packages/node-sdk/src/index.ts
+++ b/packages/node-sdk/src/index.ts
@@ -8,6 +8,11 @@ export {
   type SDKRpcClientOptions,
 } from '#/sdk-rpc-client';
 export { SDKRpcClientBase } from '#/rpc';
+export {
+  KimiCoreBirpcServer,
+  type KimiCoreBirpcServerChannelOptions,
+  type KimiCoreBirpcServerOptions,
+} from '#/birpc-server';
 export { KimiForCodingProvider } from '#/kimi-code-model-provider';
 export type { KimiForCodingProviderOptions } from '#/kimi-code-model-provider';
 

--- a/packages/node-sdk/src/kimi-harness.ts
+++ b/packages/node-sdk/src/kimi-harness.ts
@@ -1,9 +1,7 @@
-import {
-  ErrorCodes,
-  KimiError,
-  withTelemetryContext,
-  type ExperimentalFeatureState,
-} from '@moonshot-ai/agent-core';
+import { KimiError } from '@moonshot-ai/agent-core/errors/classes';
+import { ErrorCodes } from '@moonshot-ai/agent-core/errors/codes';
+import { withTelemetryContext } from '@moonshot-ai/agent-core/telemetry';
+import type { ExperimentalFeatureState } from '@moonshot-ai/agent-core';
 
 import { Session } from '#/session';
 import type { KimiAuthFacade } from '#/auth';

--- a/packages/node-sdk/src/rpc.ts
+++ b/packages/node-sdk/src/rpc.ts
@@ -1,18 +1,22 @@
 import {
   ErrorCodes,
-  makeErrorPayload,
-  type AgentContextData,
-  type ApprovalRequest,
-  type ApprovalResponse,
-  type CoreAPI,
-  type Event,
-  type ExperimentalFeatureState,
-  type QuestionRequest,
-  type QuestionResult,
-  type RPCMethods,
-  type SDKAPI,
-  type ToolCallRequest,
-  type ToolCallResponse,
+  KIMI_ERROR_INFO,
+  type KimiErrorCode,
+} from '@moonshot-ai/agent-core/errors/codes';
+import type {
+  AgentContextData,
+  ApprovalRequest,
+  ApprovalResponse,
+  CoreAPI,
+  Event,
+  ExperimentalFeatureState,
+  KimiErrorPayload,
+  QuestionRequest,
+  QuestionResult,
+  RPCMethods,
+  SDKAPI,
+  ToolCallRequest,
+  ToolCallResponse,
 } from '@moonshot-ai/agent-core';
 
 import type { ApprovalHandler, QuestionHandler } from '#/events';
@@ -609,4 +613,12 @@ export class ClientAPI implements SDKAPI {
 
 function errorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
+}
+
+function makeErrorPayload(code: KimiErrorCode, message: string): KimiErrorPayload {
+  return {
+    code,
+    message,
+    retryable: KIMI_ERROR_INFO[code].retryable,
+  };
 }

--- a/packages/node-sdk/src/session.ts
+++ b/packages/node-sdk/src/session.ts
@@ -1,9 +1,6 @@
-import {
-  ErrorCodes,
-  KimiError,
-  type AgentContextData,
-  type KimiErrorCode,
-} from '@moonshot-ai/agent-core';
+import { KimiError } from '@moonshot-ai/agent-core/errors/classes';
+import { ErrorCodes, type KimiErrorCode } from '@moonshot-ai/agent-core/errors/codes';
+import type { AgentContextData } from '@moonshot-ai/agent-core';
 
 import { type ApprovalHandler, type Event, type QuestionHandler } from '#/events';
 import type { SDKRpcClientBase } from '#/rpc';

--- a/packages/node-sdk/tsdown.config.ts
+++ b/packages/node-sdk/tsdown.config.ts
@@ -1,32 +1,41 @@
-import { fileURLToPath } from 'node:url';
-
 import { defineConfig } from 'tsdown';
 
 import { rawTextPlugin } from '../../build/raw-text-plugin.mjs';
 
-export default defineConfig({
-  entry: ['./src/index.ts'],
-  format: ['esm'],
-  dts: false,
-  outDir: 'dist',
-  clean: true,
-  plugins: [rawTextPlugin()],
-  banner: {
-    js: [
-      "import { fileURLToPath as __cjsShimFileURLToPath } from 'node:url';",
-      "import { dirname as __cjsShimDirname } from 'node:path';",
-      'const __filename = __cjsShimFileURLToPath(import.meta.url);',
-      'const __dirname = __cjsShimDirname(__filename);',
-    ].join('\n'),
+export default defineConfig([
+  {
+    entry: ['./src/index.ts'],
+    format: ['esm'],
+    dts: false,
+    outDir: 'dist',
+    clean: true,
+    plugins: [rawTextPlugin()],
+    banner: {
+      js: [
+        "import { fileURLToPath as __cjsShimFileURLToPath } from 'node:url';",
+        "import { dirname as __cjsShimDirname } from 'node:path';",
+        'const __filename = __cjsShimFileURLToPath(import.meta.url);',
+        'const __dirname = __cjsShimDirname(__filename);',
+      ].join('\n'),
+    },
+    deps: {
+      alwaysBundle: [/^@moonshot-ai\//],
+      neverBundle: [],
+    },
   },
-  alias: {
-    '@moonshot-ai/agent-core': fileURLToPath(new URL('../agent-core/src/index.ts', import.meta.url)),
-    '@moonshot-ai/kaos': fileURLToPath(new URL('../kaos/src/index.ts', import.meta.url)),
-    '@moonshot-ai/kimi-code-oauth': fileURLToPath(new URL('../oauth/src/index.ts', import.meta.url)),
-    '@moonshot-ai/kosong': fileURLToPath(new URL('../kosong/src/index.ts', import.meta.url)),
+  {
+    entry: ['./src/browser.ts'],
+    format: ['esm'],
+    dts: false,
+    outDir: 'dist',
+    clean: false,
+    plugins: [rawTextPlugin()],
+    treeshake: {
+      moduleSideEffects: 'no-external',
+    },
+    deps: {
+      alwaysBundle: [/^@moonshot-ai\/agent-core\/(?:errors\/(?:codes|classes)|telemetry)$/],
+      neverBundle: [/^@moonshot-ai\/(?!agent-core\/(?:errors\/(?:codes|classes)|telemetry)$)/],
+    },
   },
-  deps: {
-    alwaysBundle: [/^@moonshot-ai\//],
-    neverBundle: [],
-  },
-});
+]);

--- a/packages/node-sdk/vitest.config.ts
+++ b/packages/node-sdk/vitest.config.ts
@@ -7,12 +7,20 @@ import { rawTextPlugin } from '../../build/raw-text-plugin.mjs';
 export default defineConfig({
   plugins: [rawTextPlugin()],
   resolve: {
-    alias: {
-      '@moonshot-ai/agent-core': fileURLToPath(new URL('../agent-core/src/index.ts', import.meta.url)),
-      '@moonshot-ai/kimi-code-oauth': fileURLToPath(
-        new URL('../oauth/src/index.ts', import.meta.url),
-      ),
-    },
+    alias: [
+      {
+        find: /^@moonshot-ai\/agent-core\/(.+)$/,
+        replacement: fileURLToPath(new URL('../agent-core/src/$1', import.meta.url)),
+      },
+      {
+        find: '@moonshot-ai/agent-core',
+        replacement: fileURLToPath(new URL('../agent-core/src/index.ts', import.meta.url)),
+      },
+      {
+        find: '@moonshot-ai/kimi-code-oauth',
+        replacement: fileURLToPath(new URL('../oauth/src/index.ts', import.meta.url)),
+      },
+    ],
   },
   test: {
     name: 'kimi-sdk',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -128,6 +128,28 @@ importers:
         specifier: ^3.3.1
         version: 3.3.1
 
+  apps/kimi-code-web:
+    dependencies:
+      '@moonshot-ai/kimi-code-sdk':
+        specifier: workspace:^
+        version: link:../../packages/node-sdk
+      vue:
+        specifier: ^3.5.35
+        version: 3.5.35(typescript@6.0.2)
+    devDependencies:
+      '@vitejs/plugin-vue':
+        specifier: ^6.0.7
+        version: 6.0.7(vite@6.4.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3))(vue@3.5.35(typescript@6.0.2))
+      typescript:
+        specifier: 6.0.2
+        version: 6.0.2
+      vite:
+        specifier: ^6.3.3
+        version: 6.4.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3)
+      vue-tsc:
+        specifier: ^3.3.3
+        version: 3.3.3(typescript@6.0.2)
+
   apps/vis:
     devDependencies:
       concurrently:
@@ -377,6 +399,9 @@ importers:
       '@antfu/utils':
         specifier: ^9.3.0
         version: 9.3.0
+      birpc:
+        specifier: ^4.0.0
+        version: 4.0.0
       smol-toml:
         specifier: ^1.6.1
         version: 1.6.1
@@ -2446,6 +2471,13 @@ packages:
       vite: ^5.0.0 || ^6.0.0
       vue: ^3.2.25
 
+  '@vitejs/plugin-vue@6.0.7':
+    resolution: {integrity: sha512-km+p+XdSz9Sxm5rqUbqcSfZYaAniKxWBj1KURl+Jr7UaPvvX7BmaWMdP69I5rrFDeQGyxAG7NXdc57vz+snhWg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    peerDependencies:
+      vite: ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
+      vue: ^3.2.25
+
   '@vitest/coverage-v8@4.1.4':
     resolution: {integrity: sha512-x7FptB5oDruxNPDNY2+S8tCh0pcq7ymCe1gTHcsp733jYjrJl8V1gMUlVysuCD9Kz46Xz9t1akkv08dPcYDs1w==}
     peerDependencies:
@@ -2484,6 +2516,15 @@ packages:
   '@vitest/utils@4.1.4':
     resolution: {integrity: sha512-13QMT+eysM5uVGa1rG4kegGYNp6cnQcsTc67ELFbhNLQO+vgsygtYJx2khvdt4gVQqSSpC/KT5FZZxUpP3Oatw==}
 
+  '@volar/language-core@2.4.28':
+    resolution: {integrity: sha512-w4qhIJ8ZSitgLAkVay6AbcnC7gP3glYM3fYwKV3srj8m494E3xtrCv6E+bWviiK/8hs6e6t1ij1s2Endql7vzQ==}
+
+  '@volar/source-map@2.4.28':
+    resolution: {integrity: sha512-yX2BDBqJkRXfKw8my8VarTyjv48QwxdJtvRgUpNE5erCsgEUdI2DsLbpa+rOQVAJYshY99szEcRDmyHbF10ggQ==}
+
+  '@volar/typescript@2.4.28':
+    resolution: {integrity: sha512-Ja6yvWrbis2QtN4ClAKreeUZPVYMARDYZl9LMEv1iQ1QdepB6wn0jTRxA9MftYmYa4DQ4k/DaSZpFPUfxl8giw==}
+
   '@vue/compiler-core@3.5.35':
     resolution: {integrity: sha512-BUmHaR1J+O+CKZ9uJucdVTEr1LHsdyvv7vG3eNRhK3CczEHeMd/LtsHAuD7PbrxvI2envCY2v7HI1vC1aBRzKw==}
 
@@ -2504,6 +2545,9 @@ packages:
 
   '@vue/devtools-shared@7.7.9':
     resolution: {integrity: sha512-iWAb0v2WYf0QWmxCGy0seZNDPdO3Sp5+u78ORnyeonS6MT4PC7VPrryX2BpMJrwlDeaZ6BD4vP4XKjK0SZqaeA==}
+
+  '@vue/language-core@3.3.3':
+    resolution: {integrity: sha512-X6p+7nfY7vVT6dQwUJ+v0Jfq/lwIfhL2jMi91dQ3ln4hnlGXlxsDu/FNkeyHYgvYtyQy18ZX76IZy7X4diDbiQ==}
 
   '@vue/reactivity@3.5.35':
     resolution: {integrity: sha512-tVc+SsHConvh/Lz64qq1pP3rYArBmK42xonovEcxY74SQtvctZodG/zhq54P5dr38cVuw25d27cPNRdlMidpGQ==}
@@ -2605,6 +2649,9 @@ packages:
   algoliasearch@5.52.1:
     resolution: {integrity: sha512-fHA8+kXTbjagw3jkLiaS7KKrH8qe2DyOsiUhGlN4cdT77PEsfqXZl7ewDk1hsg+pJnPlnE50XtLxjR91iJOpmg==}
     engines: {node: '>= 14.0.0'}
+
+  alien-signals@3.2.1:
+    resolution: {integrity: sha512-I8FjmltrfnDFoZedi5CG8DghVYNhzb/Ijluz7tCSJH0xpd0484Kowhbb1XDYOxfJpU1p5wnM2X54dA+IfGyD1g==}
 
   ansi-colors@4.1.3:
     resolution: {integrity: sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==}
@@ -4211,6 +4258,9 @@ packages:
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
+  muggle-string@0.4.1:
+    resolution: {integrity: sha512-VNTrAak/KhO2i8dqqnqnAHOa3cYBwXEZe9h+D5h/1ZqFSTEFHdM65lR7RoIqq3tBBYavsOXV84NoHXZ0AkPyqQ==}
+
   mz@2.7.0:
     resolution: {integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==}
 
@@ -4381,6 +4431,9 @@ packages:
   parseurl@1.3.3:
     resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
     engines: {node: '>= 0.8'}
+
+  path-browserify@1.0.1:
+    resolution: {integrity: sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==}
 
   path-data-parser@0.1.0:
     resolution: {integrity: sha512-NOnmBpt5Y2RWbuv0LMzsayp3lVylAHLPUTut412ZA3l+C4uw4ZVkQbjShYCQ8TCpUMdPapr4YjUqLYD6v68j+w==}
@@ -5395,6 +5448,15 @@ packages:
       jsdom:
         optional: true
 
+  vscode-uri@3.1.0:
+    resolution: {integrity: sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ==}
+
+  vue-tsc@3.3.3:
+    resolution: {integrity: sha512-SWUEG7YRUeDJHT7Xsuhf02elYX2gxPzzAII7OxDAh4KNOr4QHQ0Lls0YfnaO5GNd560CwVa2HTfdqmA5MqvRqQ==}
+    hasBin: true
+    peerDependencies:
+      typescript: '>=5.0.0'
+
   vue@3.5.35:
     resolution: {integrity: sha512-cx89fnr+0kVGHiNFG6y6s0bdjypJRFNZn6x3WPstNdQR1bi1mbB7h4v5IBGTsPJU3nK1+0Iqj3Zf+hZWMieR4Q==}
     peerDependencies:
@@ -5701,8 +5763,8 @@ snapshots:
 
   '@babel/generator@7.29.1':
     dependencies:
-      '@babel/parser': 7.29.2
-      '@babel/types': 7.29.0
+      '@babel/parser': 7.29.7
+      '@babel/types': 7.29.7
       '@jridgewell/gen-mapping': 0.3.13
       '@jridgewell/trace-mapping': 0.3.31
       jsesc: 3.1.0
@@ -5729,7 +5791,7 @@ snapshots:
   '@babel/helper-module-imports@7.28.6':
     dependencies:
       '@babel/traverse': 7.29.0
-      '@babel/types': 7.29.0
+      '@babel/types': 7.29.7
     transitivePeerDependencies:
       - supports-color
 
@@ -5761,11 +5823,11 @@ snapshots:
   '@babel/helpers@7.29.2':
     dependencies:
       '@babel/template': 7.28.6
-      '@babel/types': 7.29.0
+      '@babel/types': 7.29.7
 
   '@babel/parser@7.29.2':
     dependencies:
-      '@babel/types': 7.29.0
+      '@babel/types': 7.29.7
 
   '@babel/parser@7.29.7':
     dependencies:
@@ -5794,17 +5856,17 @@ snapshots:
   '@babel/template@7.28.6':
     dependencies:
       '@babel/code-frame': 7.29.0
-      '@babel/parser': 7.29.2
-      '@babel/types': 7.29.0
+      '@babel/parser': 7.29.7
+      '@babel/types': 7.29.7
 
   '@babel/traverse@7.29.0':
     dependencies:
       '@babel/code-frame': 7.29.0
       '@babel/generator': 7.29.1
       '@babel/helper-globals': 7.28.0
-      '@babel/parser': 7.29.2
+      '@babel/parser': 7.29.7
       '@babel/template': 7.28.6
-      '@babel/types': 7.29.0
+      '@babel/types': 7.29.7
       debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
@@ -7032,16 +7094,16 @@ snapshots:
 
   '@types/babel__generator@7.27.0':
     dependencies:
-      '@babel/types': 7.29.0
+      '@babel/types': 7.29.7
 
   '@types/babel__template@7.4.4':
     dependencies:
-      '@babel/parser': 7.29.2
-      '@babel/types': 7.29.0
+      '@babel/parser': 7.29.7
+      '@babel/types': 7.29.7
 
   '@types/babel__traverse@7.28.0':
     dependencies:
-      '@babel/types': 7.29.0
+      '@babel/types': 7.29.7
 
   '@types/chai@5.2.3':
     dependencies:
@@ -7279,6 +7341,12 @@ snapshots:
       vite: 5.4.21(@types/node@22.19.17)(lightningcss@1.32.0)
       vue: 3.5.35(typescript@6.0.2)
 
+  '@vitejs/plugin-vue@6.0.7(vite@6.4.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3))(vue@3.5.35(typescript@6.0.2))':
+    dependencies:
+      '@rolldown/pluginutils': 1.0.1
+      vite: 6.4.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3)
+      vue: 3.5.35(typescript@6.0.2)
+
   '@vitest/coverage-v8@4.1.4(vitest@4.1.4)':
     dependencies:
       '@bcoe/v8-coverage': 1.0.2
@@ -7334,6 +7402,18 @@ snapshots:
       convert-source-map: 2.0.0
       tinyrainbow: 3.1.0
 
+  '@volar/language-core@2.4.28':
+    dependencies:
+      '@volar/source-map': 2.4.28
+
+  '@volar/source-map@2.4.28': {}
+
+  '@volar/typescript@2.4.28':
+    dependencies:
+      '@volar/language-core': 2.4.28
+      path-browserify: 1.0.1
+      vscode-uri: 3.1.0
+
   '@vue/compiler-core@3.5.35':
     dependencies:
       '@babel/parser': 7.29.7
@@ -7381,6 +7461,16 @@ snapshots:
   '@vue/devtools-shared@7.7.9':
     dependencies:
       rfdc: 1.4.1
+
+  '@vue/language-core@3.3.3':
+    dependencies:
+      '@volar/language-core': 2.4.28
+      '@vue/compiler-dom': 3.5.35
+      '@vue/shared': 3.5.35
+      alien-signals: 3.2.1
+      muggle-string: 0.4.1
+      path-browserify: 1.0.1
+      picomatch: 4.0.4
 
   '@vue/reactivity@3.5.35':
     dependencies:
@@ -7474,6 +7564,8 @@ snapshots:
       '@algolia/requester-fetch': 5.52.1
       '@algolia/requester-node-http': 5.52.1
 
+  alien-signals@3.2.1: {}
+
   ansi-colors@4.1.3: {}
 
   ansi-escapes@7.3.0:
@@ -7527,7 +7619,7 @@ snapshots:
 
   ast-kit@3.0.0-beta.1:
     dependencies:
-      '@babel/parser': 8.0.0-rc.4
+      '@babel/parser': 8.0.0-rc.5
       estree-walker: 3.0.3
       pathe: 2.0.3
 
@@ -8993,7 +9085,7 @@ snapshots:
 
   magicast@0.5.2:
     dependencies:
-      '@babel/parser': 7.29.2
+      '@babel/parser': 7.29.7
       '@babel/types': 7.29.0
       source-map-js: 1.2.1
 
@@ -9305,6 +9397,8 @@ snapshots:
 
   ms@2.1.3: {}
 
+  muggle-string@0.4.1: {}
+
   mz@2.7.0:
     dependencies:
       any-promise: 1.3.0
@@ -9474,6 +9568,8 @@ snapshots:
   parse5@6.0.1: {}
 
   parseurl@1.3.3: {}
+
+  path-browserify@1.0.1: {}
 
   path-data-parser@0.1.0: {}
 
@@ -10566,6 +10662,14 @@ snapshots:
       '@vitest/coverage-v8': 4.1.4(vitest@4.1.4)
     transitivePeerDependencies:
       - msw
+
+  vscode-uri@3.1.0: {}
+
+  vue-tsc@3.3.3(typescript@6.0.2):
+    dependencies:
+      '@volar/typescript': 2.4.28
+      '@vue/language-core': 3.3.3
+      typescript: 6.0.2
 
   vue@3.5.35(typescript@6.0.2):
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,6 +1,7 @@
 packages:
   - packages/*
   - apps/*
+  - apps/kimi-code-web
   - apps/vis/server
   - apps/vis/web
   - docs

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -32,7 +32,7 @@
     "apps/*/src/**/*.tsx",
     "apps/*/test/**/*.ts",
     "apps/*/test/**/*.tsx"
-  ],
+, "apps/kimi-code-web/vite-env.d.ts"  ],
   "exclude": [
     "node_modules",
     "dist",


### PR DESCRIPTION
## Related Issue

No linked issue. This draft addresses the problem described below.

## Problem

Kimi Code needs a browser-based development surface that can run against the existing SDK/core runtime without bundling Node-only agent-core code into the browser app. The SDK also needs a browser entry that exposes a client-side RPC harness while keeping the core runtime on the Vite server side.

## What changed

- Added `@moonshot-ai/kimi-code-web`, a private Vue/Vite workspace with a minimal Kimi Code web UI.
- Added a browser SDK entry with a birpc client and a server-side `KimiCoreBirpcServer` bridge for the Vite dev server.
- Split SDK build/declaration generation so `@moonshot-ai/kimi-code-sdk/browser` resolves to browser-safe runtime and types.
- Exposed browser-safe `agent-core` error and telemetry subpaths used by the SDK browser runtime.
- Added workspace and Nix workspace metadata for the new web app.

## Checklist

- [ ] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [ ] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.

Draft PR note: changeset, docs, and validation are intentionally deferred for this draft.
