### PR TITLE
fix: avoid runtime check rpc

### DIFF
--- a/apps/kimi-code/src/cli/run-prompt.ts
+++ b/apps/kimi-code/src/cli/run-prompt.ts
@@ -110,7 +110,6 @@ export async function runPrompt(
   removeTerminationCleanup = installPromptTerminationCleanup(promptProcess, cleanupPromptRun);
 
   try {
-    await harness.checkRuntimeEnvironment();
     await harness.ensureConfigFile();
     const config = await harness.getConfig();
     const { session, resumed, restorePermission, telemetryModel, goalModel } =

--- a/apps/kimi-code/src/cli/run-shell.ts
+++ b/apps/kimi-code/src/cli/run-shell.ts
@@ -34,6 +34,21 @@ export async function runShell(
   runOptions: { readonly migrateOnly?: boolean } = {},
 ): Promise<void> {
   const startedAt = Date.now();
+  const configStartedAt = startedAt;
+  let tuiConfig: TuiConfig;
+  let configWarning: string | undefined;
+  try {
+    tuiConfig = await loadTuiConfig();
+  } catch (error) {
+    if (!(error instanceof TuiConfigParseError)) throw error;
+    tuiConfig = error.fallback;
+    configWarning = error.message;
+  }
+
+  // Resolve `theme = "auto"` against the live terminal once, before pi-tui
+  // grabs stdin. Explicit `dark` / `light` skip detection.
+  const resolvedTheme = tuiConfig.theme === 'auto' ? await detectTerminalTheme() : tuiConfig.theme;
+
   const workDir = process.cwd();
   const telemetryBootstrap = createCliTelemetryBootstrap();
   const telemetryClient: TelemetryClient = {
@@ -63,22 +78,6 @@ export async function runShell(
     platform: `${process.platform}/${process.arch}`,
     workDir,
   });
-  await harness.checkRuntimeEnvironment();
-
-  const configStartedAt = Date.now();
-  let tuiConfig: TuiConfig;
-  let configWarning: string | undefined;
-  try {
-    tuiConfig = await loadTuiConfig();
-  } catch (error) {
-    if (!(error instanceof TuiConfigParseError)) throw error;
-    tuiConfig = error.fallback;
-    configWarning = error.message;
-  }
-
-  // Resolve `theme = "auto"` against the live terminal once, before pi-tui
-  // grabs stdin. Explicit `dark` / `light` skip detection.
-  const resolvedTheme = tuiConfig.theme === 'auto' ? await detectTerminalTheme() : tuiConfig.theme;
 
   await harness.ensureConfigFile();
   const migrationPlan = await detectPendingMigration({

--- a/apps/kimi-code/test/cli/goal-prompt.test.ts
+++ b/apps/kimi-code/test/cli/goal-prompt.test.ts
@@ -112,7 +112,6 @@ const mocks = vi.hoisted(() => {
     mainEvent,
     experimentalFeatures: [{ id: 'goal_command', enabled: true }],
     sessions: [] as Array<{ readonly id: string; readonly workDir: string }>,
-    harnessCheckRuntimeEnvironment: vi.fn(async () => undefined),
   };
 });
 
@@ -123,7 +122,6 @@ vi.mock('@moonshot-ai/kimi-code-sdk', async (importOriginal) => {
     createKimiHarness: () => ({
       homeDir: '/tmp/kimi-goal-home',
       auth: { getCachedAccessToken: vi.fn() },
-      checkRuntimeEnvironment: mocks.harnessCheckRuntimeEnvironment,
       ensureConfigFile: vi.fn(),
       getConfig: vi.fn(async () => ({ providers: {}, defaultModel: 'k2', telemetry: true })),
       getExperimentalFeatures: vi.fn(async () => mocks.experimentalFeatures),

--- a/apps/kimi-code/test/cli/run-prompt.test.ts
+++ b/apps/kimi-code/test/cli/run-prompt.test.ts
@@ -46,7 +46,6 @@ const mocks = vi.hoisted(() => {
     agentEvent,
     mainEvent,
     kimiHarnessConstructor: vi.fn(),
-    harnessCheckRuntimeEnvironment: vi.fn(async () => undefined),
     harnessEnsureConfigFile: vi.fn(),
     harnessGetConfig: vi.fn(
       async (): Promise<{ providers: {}; defaultModel?: string; telemetry: boolean }> => ({
@@ -90,7 +89,6 @@ vi.mock('@moonshot-ai/kimi-code-sdk', async (importOriginal) => {
       return {
         homeDir,
         auth: { getCachedAccessToken: mocks.harnessGetCachedAccessToken },
-        checkRuntimeEnvironment: mocks.harnessCheckRuntimeEnvironment,
         ensureConfigFile: mocks.harnessEnsureConfigFile,
         getConfig: mocks.harnessGetConfig,
         getExperimentalFeatures: mocks.harnessGetExperimentalFeatures,
@@ -189,7 +187,6 @@ describe('runPrompt', () => {
     mocks.resolveKimiHome.mockImplementation(
       (homeDir?: string) => homeDir ?? '/tmp/kimi-code-test-home',
     );
-    mocks.harnessCheckRuntimeEnvironment.mockResolvedValue(undefined);
     mocks.harnessCreatesDeviceIdOnConstruction = false;
   });
 
@@ -201,10 +198,6 @@ describe('runPrompt', () => {
 
     expect(mocks.kimiHarnessConstructor).toHaveBeenCalledWith(
       expect.objectContaining({ skillDirs: ['/skills'], uiMode: 'print' }),
-    );
-    expect(mocks.harnessCheckRuntimeEnvironment).toHaveBeenCalledOnce();
-    expect(mocks.harnessCheckRuntimeEnvironment.mock.invocationCallOrder[0]).toBeLessThan(
-      mocks.harnessEnsureConfigFile.mock.invocationCallOrder[0]!,
     );
     expect(mocks.harnessCreateSession).toHaveBeenCalledWith({
       workDir: process.cwd(),
@@ -221,19 +214,18 @@ describe('runPrompt', () => {
     expect(mocks.harnessClose).toHaveBeenCalled();
   });
 
-  it('stops prompt startup when runtime environment check fails', async () => {
+  it('stops prompt startup when session creation fails', async () => {
     const stdout = writer();
     const stderr = writer();
-    mocks.harnessCheckRuntimeEnvironment.mockRejectedValueOnce(new Error('Git Bash missing'));
+    mocks.harnessCreateSession.mockRejectedValueOnce(new Error('Git Bash missing'));
 
     await expect(runPrompt(opts(), '1.2.3-test', { stdout, stderr })).rejects.toThrow(
       'Git Bash missing',
     );
 
-    expect(mocks.harnessCheckRuntimeEnvironment).toHaveBeenCalledOnce();
-    expect(mocks.harnessEnsureConfigFile).not.toHaveBeenCalled();
-    expect(mocks.harnessGetConfig).not.toHaveBeenCalled();
-    expect(mocks.harnessCreateSession).not.toHaveBeenCalled();
+    expect(mocks.harnessEnsureConfigFile).toHaveBeenCalledOnce();
+    expect(mocks.harnessGetConfig).toHaveBeenCalledOnce();
+    expect(mocks.harnessCreateSession).toHaveBeenCalledOnce();
     expect(mocks.session.prompt).not.toHaveBeenCalled();
     expect(mocks.harnessClose).toHaveBeenCalledOnce();
   });

--- a/apps/kimi-code/test/cli/run-shell.test.ts
+++ b/apps/kimi-code/test/cli/run-shell.test.ts
@@ -31,7 +31,6 @@ const mocks = vi.hoisted(() => {
     loadTuiConfig: vi.fn(),
     detectTerminalTheme: vi.fn(),
     kimiHarnessConstructor: vi.fn(),
-    harnessCheckRuntimeEnvironment: vi.fn(async () => undefined),
     harnessEnsureConfigFile: vi.fn(),
     harnessGetConfig: vi.fn(async () => ({
       providers: {},
@@ -82,7 +81,6 @@ vi.mock('@moonshot-ai/kimi-code-sdk', async (importOriginal) => {
           getCachedAccessToken: mocks.harnessGetCachedAccessToken,
         },
         ensureConfigFile: mocks.harnessEnsureConfigFile,
-        checkRuntimeEnvironment: mocks.harnessCheckRuntimeEnvironment,
         getConfig: mocks.harnessGetConfig,
         close: mocks.harnessClose,
         track: mocks.harnessTrack,
@@ -151,7 +149,6 @@ describe('runShell', () => {
       defaultModel: 'k2',
       telemetry: true,
     });
-    mocks.harnessCheckRuntimeEnvironment.mockResolvedValue(undefined);
     mocks.tuiGetStartupMcpMs.mockResolvedValue(0);
     mocks.tuiGetCurrentSessionId.mockReturnValue('');
     mocks.tuiHasSessionContent.mockReturnValue(false);
@@ -193,10 +190,6 @@ describe('runShell', () => {
           version: '1.2.3-test',
         }),
       }),
-    );
-    expect(mocks.harnessCheckRuntimeEnvironment).toHaveBeenCalledOnce();
-    expect(mocks.harnessCheckRuntimeEnvironment.mock.invocationCallOrder[0]).toBeLessThan(
-      mocks.harnessEnsureConfigFile.mock.invocationCallOrder[0]!,
     );
     expect(mocks.harnessEnsureConfigFile).toHaveBeenCalledOnce();
     expect(mocks.harnessEnsureConfigFile.mock.invocationCallOrder[0]).toBeLessThan(
@@ -249,38 +242,6 @@ describe('runShell', () => {
       init_ms: expect.any(Number),
       mcp_ms: 47,
     });
-  });
-
-  it('stops startup when runtime environment check fails', async () => {
-    mocks.loadTuiConfig.mockResolvedValue({
-      theme: 'dark',
-      editorCommand: null,
-      notifications: { enabled: true, condition: 'unfocused' },
-    });
-    mocks.harnessCheckRuntimeEnvironment.mockRejectedValueOnce(new Error('Git Bash missing'));
-
-    await expect(
-      runShell(
-        {
-          session: undefined,
-          continue: false,
-          yolo: false,
-          auto: false,
-          plan: false,
-          model: undefined,
-          outputFormat: undefined,
-          prompt: undefined,
-          skillsDirs: [],
-        },
-        '1.2.3-test',
-      ),
-    ).rejects.toThrow('Git Bash missing');
-
-    expect(mocks.harnessCheckRuntimeEnvironment).toHaveBeenCalledOnce();
-    expect(mocks.harnessEnsureConfigFile).not.toHaveBeenCalled();
-    expect(mocks.harnessGetConfig).not.toHaveBeenCalled();
-    expect(mocks.kimiTuiConstructor).not.toHaveBeenCalled();
-    expect(mocks.tuiStart).not.toHaveBeenCalled();
   });
 
   it('tracks first launch when device id creation reports first launch', async () => {

--- a/packages/agent-core/src/rpc/core-api.ts
+++ b/packages/agent-core/src/rpc/core-api.ts
@@ -357,7 +357,6 @@ type SessionAPIWithId = WithSessionId<SessionAPI>;
 
 export interface CoreAPI extends SessionAPIWithId {
   getCoreInfo: (payload: EmptyPayload) => CoreInfo;
-  checkRuntimeEnvironment: (payload: EmptyPayload) => void;
   getExperimentalFeatures: (payload: EmptyPayload) => readonly ExperimentalFeatureState[];
   getKimiConfig: (payload: GetKimiConfigPayload) => KimiConfig;
   setKimiConfig: (payload: SetKimiConfigPayload) => KimiConfig;

--- a/packages/agent-core/src/rpc/core-impl.ts
+++ b/packages/agent-core/src/rpc/core-impl.ts
@@ -176,10 +176,6 @@ export class KimiCore implements PromisableMethods<CoreAPI> {
     this.sdk = rpcClient(this);
   }
 
-  async checkRuntimeEnvironment(_: EmptyPayload): Promise<void> {
-    await this.getKaos();
-  }
-
   async createSession(input: CreateSessionPayload): Promise<SessionSummary> {
     const options = input;
     const workDir = requiredWorkDir('createSession', options.workDir);

--- a/packages/agent-core/test/harness/runtime.test.ts
+++ b/packages/agent-core/test/harness/runtime.test.ts
@@ -2,6 +2,7 @@ import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'pathe';
 
+import type { Kaos } from '@moonshot-ai/kaos';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import {
@@ -10,6 +11,7 @@ import {
   createRPC,
   ErrorCodes,
   KimiCore,
+  KimiError,
   type ApprovalResponse,
   type CoreAPI,
   type SDKAPI,
@@ -21,6 +23,7 @@ import {
 } from '../../src/logging/logger';
 import { resolveLoggingConfig } from '../../src/logging/resolve-config';
 import type { OAuthTokenProviderResolver } from '../../src/session/provider-manager';
+import { testKaos } from '../fixtures/test-kaos';
 
 function requiredFlagEnv(id: string): string {
   const def = FLAG_DEFINITIONS.find((item) => item.id === id);
@@ -37,6 +40,16 @@ function clearExperimentalEnv(): void {
 
 function experimentalFeatureEnabled(core: KimiCore, id: string): boolean | undefined {
   return core.getExperimentalFeatures().find((feature) => feature.id === id)?.enabled;
+}
+
+function setCoreKaos(core: KimiCore, kaos: Promise<Kaos>): void {
+  (core as unknown as { kaos?: Promise<Kaos> }).kaos = kaos;
+}
+
+function rejectedKaos(error: Error): Promise<Kaos> {
+  const promise = Promise.reject(error) as Promise<Kaos>;
+  promise.catch(() => undefined);
+  return promise;
 }
 
 describe('KimiCore runtime config', () => {
@@ -282,6 +295,75 @@ max_context_size = 100000
     const mainAgent = session?.getReadyAgent('main');
 
     expect(mainAgent?.config.modelAlias).toBe('default-mock');
+  });
+
+  it('rejects createSession when shell runtime initialization fails', async () => {
+    tmp = await mkdtemp(join(tmpdir(), 'kimi-core-runtime-'));
+    const homeDir = join(tmp, 'home');
+    const workDir = join(tmp, 'work');
+    await mkdir(homeDir, { recursive: true });
+    await mkdir(workDir, { recursive: true });
+    await writeFile(join(homeDir, 'config.toml'), baseModelConfig());
+
+    const [coreRpc, sdkRpc] = createRPC<CoreAPI, SDKAPI>();
+    const core = new KimiCore(coreRpc, { homeDir });
+    const rpc = await sdkRpc({
+      emitEvent: vi.fn(),
+      requestApproval: vi.fn(async (): Promise<ApprovalResponse> => ({ decision: 'rejected' })),
+      requestQuestion: vi.fn(async () => null),
+      toolCall: vi.fn(async () => ({ output: '' })),
+    });
+    setCoreKaos(
+      core,
+      rejectedKaos(
+        new KimiError(ErrorCodes.SHELL_GIT_BASH_NOT_FOUND, 'Git Bash missing'),
+      ),
+    );
+
+    await expect(
+      rpc.createSession({
+        id: 'ses_runtime_shell_missing_create',
+        workDir,
+        model: 'default-mock',
+      }),
+    ).rejects.toMatchObject({ code: ErrorCodes.SHELL_GIT_BASH_NOT_FOUND });
+    expect(core.sessions.has('ses_runtime_shell_missing_create')).toBe(false);
+  });
+
+  it('rejects resumeSession when shell runtime initialization fails', async () => {
+    tmp = await mkdtemp(join(tmpdir(), 'kimi-core-runtime-'));
+    const homeDir = join(tmp, 'home');
+    const workDir = join(tmp, 'work');
+    await mkdir(homeDir, { recursive: true });
+    await mkdir(workDir, { recursive: true });
+    await writeFile(join(homeDir, 'config.toml'), baseModelConfig());
+
+    const [coreRpc, sdkRpc] = createRPC<CoreAPI, SDKAPI>();
+    const core = new KimiCore(coreRpc, { homeDir });
+    const rpc = await sdkRpc({
+      emitEvent: vi.fn(),
+      requestApproval: vi.fn(async (): Promise<ApprovalResponse> => ({ decision: 'rejected' })),
+      requestQuestion: vi.fn(async () => null),
+      toolCall: vi.fn(async () => ({ output: '' })),
+    });
+    setCoreKaos(core, Promise.resolve(testKaos));
+    const created = await rpc.createSession({
+      id: 'ses_runtime_shell_missing_resume',
+      workDir,
+      model: 'default-mock',
+    });
+    await rpc.closeSession({ sessionId: created.id });
+    setCoreKaos(
+      core,
+      rejectedKaos(
+        new KimiError(ErrorCodes.SHELL_GIT_BASH_NOT_FOUND, 'Git Bash missing'),
+      ),
+    );
+
+    await expect(rpc.resumeSession({ sessionId: created.id })).rejects.toMatchObject({
+      code: ErrorCodes.SHELL_GIT_BASH_NOT_FOUND,
+    });
+    expect(core.sessions.has(created.id)).toBe(false);
   });
 
   it('reloads an active session with fresh runtime services from config.toml', async () => {

--- a/packages/node-sdk/src/kimi-harness.ts
+++ b/packages/node-sdk/src/kimi-harness.ts
@@ -210,10 +210,6 @@ export class KimiHarness {
     await this.ensureConfigFileImpl();
   }
 
-  async checkRuntimeEnvironment(): Promise<void> {
-    await this.rpc.checkRuntimeEnvironment();
-  }
-
   async setConfig(patch: KimiConfigPatch): Promise<KimiConfig> {
     return this.rpc.setConfig(patch);
   }

--- a/packages/node-sdk/src/rpc.ts
+++ b/packages/node-sdk/src/rpc.ts
@@ -99,11 +99,6 @@ export abstract class SDKRpcClientBase {
 
   protected abstract getRpc(): Promise<ResolvedCoreAPI>;
 
-  async checkRuntimeEnvironment(): Promise<void> {
-    const rpc = await this.getRpc();
-    return rpc.checkRuntimeEnvironment({});
-  }
-
   async createSession(input: CreateSessionOptions): Promise<SessionSummary> {
     const rpc = await this.getRpc();
     const { planMode, ...coreInput } = input;


### PR DESCRIPTION
## Related Issue

No linked issue; follow-up to #430.

## Problem

The Windows Git Bash preflight merged in #430 added a dedicated `checkRuntimeEnvironment` method through CoreAPI, the SDK RPC client, and `KimiHarness`. That made the fix wider than necessary because the shell runtime is already a core session dependency.

## What changed

Removed the dedicated runtime-check RPC and harness method, and stopped calling it from CLI startup. The Git Bash failure still surfaces from core when creating or resuming a session through the lazy Kaos initialization path. Added core regression coverage for create and resume failures, and adjusted CLI tests so they no longer mock the removed API.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.