### PR TITLE
fix: forward maxOutputSize to OpenAI-compatible providers

### DIFF
--- a/.changeset/openai-max-output-size.md
+++ b/.changeset/openai-max-output-size.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Fix 400 "Invalid max_tokens value" error when using DeepSeek and other OpenAI-compatible providers with `max_output_size` configured

--- a/.changeset/openai-max-output-size.md
+++ b/.changeset/openai-max-output-size.md
@@ -1,4 +1,5 @@
 ---
+"@moonshot-ai/agent-core": patch
 "@moonshot-ai/kimi-code": patch
 ---
 

--- a/packages/agent-core/src/session/provider-manager.ts
+++ b/packages/agent-core/src/session/provider-manager.ts
@@ -236,6 +236,7 @@ function toKosongProviderConfig(
         baseUrl: providerValue(provider.baseUrl, provider.env, 'OPENAI_BASE_URL'),
         apiKey: providerApiKey(provider),
         reasoningKey,
+        ...(maxOutputSize !== undefined ? { maxTokens: maxOutputSize } : {}),
         ...defaultHeadersField(provider.customHeaders),
       };
     case 'kimi':
@@ -259,6 +260,7 @@ function toKosongProviderConfig(
         model,
         baseUrl: providerValue(provider.baseUrl, provider.env, 'OPENAI_BASE_URL'),
         apiKey: providerApiKey(provider),
+        ...(maxOutputSize !== undefined ? { maxOutputTokens: maxOutputSize } : {}),
         ...defaultHeadersField(provider.customHeaders),
       };
     case 'vertexai': {

--- a/packages/agent-core/test/harness/runtime-provider.test.ts
+++ b/packages/agent-core/test/harness/runtime-provider.test.ts
@@ -338,6 +338,101 @@ describe('resolveRuntimeProvider maxOutputSize forwarding', () => {
     });
   });
 
+  it('forwards alias.maxOutputSize to the openai provider config as maxTokens', () => {
+    const resolved = resolveRuntimeProvider({
+      config: {
+        ...BASE_CONFIG,
+        providers: {
+          ...BASE_CONFIG.providers,
+          openai: {
+            type: 'openai',
+            apiKey: 'sk-openai',
+            baseUrl: 'https://openai.example/v1',
+          },
+        },
+        models: {
+          ...BASE_CONFIG.models!,
+          'deepseek-alias': {
+            provider: 'openai',
+            model: 'deepseek-chat',
+            maxContextSize: 1_000_000,
+            maxOutputSize: 393216,
+          },
+        },
+      },
+      model: 'deepseek-alias',
+    });
+
+    expect(resolved.provider).toMatchObject({
+      type: 'openai',
+      model: 'deepseek-chat',
+      maxTokens: 393216,
+    });
+  });
+
+  it('omits maxTokens from the openai provider config when alias.maxOutputSize is unset', () => {
+    const resolved = resolveRuntimeProvider({
+      config: {
+        ...BASE_CONFIG,
+        providers: {
+          ...BASE_CONFIG.providers,
+          openai: {
+            type: 'openai',
+            apiKey: 'sk-openai',
+            baseUrl: 'https://openai.example/v1',
+          },
+        },
+        models: {
+          ...BASE_CONFIG.models!,
+          'gpt-alias': {
+            provider: 'openai',
+            model: 'gpt-4o',
+            maxContextSize: 128000,
+          },
+        },
+      },
+      model: 'gpt-alias',
+    });
+
+    expect(resolved.provider).toMatchObject({
+      type: 'openai',
+      model: 'gpt-4o',
+    });
+    expect('maxTokens' in resolved.provider).toBe(false);
+  });
+
+  it('forwards alias.maxOutputSize to the openai_responses provider config as maxOutputTokens', () => {
+    const resolved = resolveRuntimeProvider({
+      config: {
+        ...BASE_CONFIG,
+        providers: {
+          ...BASE_CONFIG.providers,
+          openai_resp: {
+            type: 'openai_responses',
+            apiKey: 'sk-openai',
+            baseUrl: 'https://openai.example/v1',
+          },
+        },
+        models: {
+          ...BASE_CONFIG.models!,
+          'o3-alias': {
+            provider: 'openai_resp',
+            model: 'o3',
+            maxContextSize: 200000,
+            maxOutputSize: 100000,
+          },
+        },
+      },
+      model: 'o3-alias',
+    });
+
+    expect(resolved.provider).toMatchObject({
+      type: 'openai_responses',
+      model: 'o3',
+      maxOutputTokens: 100000,
+    });
+  });
+
   it('omits adaptiveThinking when alias.adaptiveThinking is unset', () => {
     const resolved = resolveRuntimeProvider({
       config: {


### PR DESCRIPTION
# Related Issue

Resolve #306

# Problem

`toKosongProviderConfig` forwards `maxOutputSize` as `defaultMaxTokens` for the Anthropic provider but omits it for `openai` and `openai_responses`. As a result, OpenAI-compatible providers like DeepSeek receive the full `max_context_size` (1,000,000) as `max_tokens` via the completion-budget fallback, exceeding the model's actual cap and triggering `400 Invalid max_tokens value`.

# What changed

Forward `maxOutputSize` as `maxTokens` to the `openai` provider config and as `maxOutputTokens` to `openai_responses`, matching the constructor signatures of the respective `ChatProvider` classes. Added three tests in `runtime-provider.test.ts` covering both providers (set / unset).

# Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.

# Verification

- `pnpm -C packages/agent-core exec vitest run test/harness/runtime-provider.test.ts`

Note: PR #318 by @qkunio addresses #306 at the budget-resolution layer; this PR addresses the provider-construction layer. The two fixes are complementary.