### PR TITLE
fix: show 'unknown command' for invalid subcommands

### DIFF
--- a/.changeset/cli-unknown-subcommand.md
+++ b/.changeset/cli-unknown-subcommand.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Show "unknown command" instead of misleading "too many arguments" when an invalid subcommand is passed to the CLI

--- a/apps/kimi-code/src/cli/commands.ts
+++ b/apps/kimi-code/src/cli/commands.ts
@@ -27,7 +27,6 @@ export function createProgram(
     .description('The Starting Point for Next-Gen Agents')
     .version(version, '-V, --version')
     .allowUnknownOption(false)
-    .allowExcessArguments(true)
     .showSuggestionAfterError()
     .configureHelp({ helpWidth: 100 })
     .helpOption('-h, --help', 'Show help.')
@@ -103,10 +102,11 @@ export function createProgram(
       onPluginNodeRunner(entry, args);
     });
 
-  program.action((...actionArgs: unknown[]) => {
-    const excess = program.args;
-    if (excess.length > 0) {
-      const unknown = excess[0]!;
+  program
+    .argument('[unknown...]')
+    .action((unknownArgs: string[]) => {
+    if (unknownArgs.length > 0) {
+      const unknown = unknownArgs[0]!;
       const available = program.commands
         .filter((cmd) => !cmd.name().startsWith('__'))
         .map((cmd) => cmd.name());

--- a/apps/kimi-code/src/cli/commands.ts
+++ b/apps/kimi-code/src/cli/commands.ts
@@ -27,6 +27,8 @@ export function createProgram(
     .description('The Starting Point for Next-Gen Agents')
     .version(version, '-V, --version')
     .allowUnknownOption(false)
+    .allowExcessArguments(true)
+    .showSuggestionAfterError()
     .configureHelp({ helpWidth: 100 })
     .helpOption('-h, --help', 'Show help.')
     .addHelpText(
@@ -101,7 +103,18 @@ export function createProgram(
       onPluginNodeRunner(entry, args);
     });
 
-  program.action(() => {
+  program.action((...actionArgs: unknown[]) => {
+    const excess = program.args;
+    if (excess.length > 0) {
+      const unknown = excess[0]!;
+      const available = program.commands
+        .filter((cmd) => !cmd.name().startsWith('__'))
+        .map((cmd) => cmd.name());
+      program.error(
+        `unknown command '${unknown}'. Available commands: ${available.join(', ')}.\nSee '${CLI_COMMAND_NAME} --help'.`,
+      );
+    }
+
     const raw = program.opts<Record<string, unknown>>();
 
     const rawSession = raw['session'] ?? raw['resume'];

--- a/apps/kimi-code/test/cli/options.test.ts
+++ b/apps/kimi-code/test/cli/options.test.ts
@@ -322,4 +322,22 @@ describe('CLI options parsing', () => {
       }
     });
   });
+
+  describe('unknown subcommand', () => {
+    it('reports "unknown command" instead of "too many arguments"', () => {
+      let errorOutput = '';
+      const program = createProgram('0.0.0', () => {}, () => {});
+      program.exitOverride();
+      program.configureOutput({
+        writeOut: () => {},
+        writeErr: (s) => {
+          errorOutput += s;
+        },
+      });
+
+      expect(() => program.parse(['node', 'kimi', 'nonexistent'])).toThrow();
+      expect(errorOutput).toContain("unknown command 'nonexistent'");
+      expect(errorOutput).not.toContain('too many arguments');
+    });
+  });
 });


### PR DESCRIPTION
# Related Issue

Resolve #440

# Problem

`kimi nonexistent` reports `error: too many arguments. Expected 0 arguments but got 1.` instead of saying the command is unknown. Commander treats the unrecognized word as an excess positional on the root command, which has no `argument()` defined.

# What changed

Add `argument('[unknown...]')` on the root command only and check the captured value in the action handler. Subcommands keep Commander's default excess-argument validation (catching the codex review feedback — `allowExcessArguments(true)` at the root would inherit to subcommands and silently accept `kimi upgrade extra`). Also enable `showSuggestionAfterError()` for better hints on misspelled options.

Error becomes:

```
$ kimi nonexistent
error: unknown command 'nonexistent'. Available commands: export, provider, acp, login, doctor, migrate, upgrade.
See 'kimi --help'.
```

# Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.

# Verification

- `pnpm -C apps/kimi-code exec vitest run test/cli/options.test.ts`

Note: PR #442 by @Eric-Song-Nop (the issue reporter) addresses the same issue with a similar approach. Happy to defer to that PR if preferred.