### PR TITLE
fix: preserve TUI context when starting goals

### DIFF
--- a/.changeset/fix-goal-input-receiver.md
+++ b/.changeset/fix-goal-input-receiver.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Fix a crash when starting a goal in the TUI.

--- a/apps/kimi-code/src/tui/commands/goal.ts
+++ b/apps/kimi-code/src/tui/commands/goal.ts
@@ -388,8 +388,11 @@ async function startGoal(
   host.track('goal_create', { replace: parsed.replace });
   host.state.transcriptContainer.addChild(new GoalSetMessageComponent(host.state.theme.colors));
   host.state.ui.requestRender();
-  const sendInput = options.sendInput ?? host.sendNormalUserInput;
-  sendInput(parsed.objective);
+  if (options.sendInput !== undefined) {
+    options.sendInput(parsed.objective);
+  } else {
+    host.sendNormalUserInput(parsed.objective);
+  }
   return true;
 }
 

--- a/apps/kimi-code/test/tui/commands/goal.test.ts
+++ b/apps/kimi-code/test/tui/commands/goal.test.ts
@@ -257,6 +257,17 @@ describe('handleGoalCommand', () => {
     expect(host.sendNormalUserInput).not.toHaveBeenCalledWith('/goal Ship feature X');
   });
 
+  it('/goal <objective> keeps the sendNormalUserInput host receiver', async () => {
+    const calls: Array<{ receiver: unknown; text: string }> = [];
+    host.sendNormalUserInput = function (this: unknown, text: string): void {
+      calls.push({ receiver: this, text });
+    };
+
+    await handleGoalCommand(host, 'Ship feature X');
+
+    expect(calls).toEqual([{ receiver: host, text: 'Ship feature X' }]);
+  });
+
   it('asks before starting a goal in Manual mode', async () => {
     const { host: manualHost, session: s } = makeHost({ permissionMode: 'manual' });
 


### PR DESCRIPTION
<!--
Thank you for your contribution to Kimi Code!
Please open an issue before sending a feature PR — PRs without prior discussion may be closed without review.

See https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md for more.
-->

## Related Issue

<!-- Link the issue this feature came from. If there is no issue, explain the problem in the next section instead. -->

## Problem

<!-- What user need or limitation does this address? If the linked issue already covers this, write "See linked issue". -->

## What changed

<!-- What did you implement, and why does this approach fit Kimi Code? -->

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [ ] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [ ] Ran `gen-docs` skill, or this PR needs no doc update.
