### PR TITLE
feat(cli): add --json output to kimi doctor

### DIFF
--- a/.changeset/doctor-json-output.md
+++ b/.changeset/doctor-json-output.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": minor
+---
+
+Add `--json` flag to `kimi doctor` for machine-readable diagnostic output

--- a/apps/kimi-code/src/cli/sub/doctor.ts
+++ b/apps/kimi-code/src/cli/sub/doctor.ts
@@ -25,6 +25,15 @@ export interface DoctorDeps {
   readonly stdout: WritableLike;
   readonly stderr: WritableLike;
   readonly exit: (code: number) => never;
+  /**
+   * Deferred-exit hook used by JSON mode: set the process exit code and let
+   * the event loop drain stdout naturally before termination. Calling the
+   * synchronous {@link exit} (default `process.exit`) right after writing a
+   * machine-readable report can truncate the pending pipe write on Linux/CI
+   * — exactly when the report describes a failure. Defaults to
+   * `(code) => { process.exitCode = code; }`.
+   */
+  readonly setExitCode?: (code: number) => void;
   readonly configRpc?: KimiConfigRpc;
   readonly fileExists?: (path: string) => boolean;
   readonly readTextFile?: (path: string) => Promise<string>;
@@ -70,6 +79,7 @@ interface ResolvedDoctorDeps {
   readonly stdout: WritableLike;
   readonly stderr: WritableLike;
   readonly exit: (code: number) => never;
+  readonly setExitCode: (code: number) => void;
   readonly fileExists: (path: string) => boolean;
   readonly readTextFile: (path: string) => Promise<string>;
   readonly validateConfigToml: (text: string, path: string) => MaybePromise<void>;
@@ -140,7 +150,15 @@ async function runDoctorCommand(
 ): Promise<void> {
   const resolved = resolveDeps(deps);
   const code = await handleDoctor(resolved, options);
-  if (code !== 0) resolved.exit(code);
+  if (code === 0) return;
+  if (options.json === true) {
+    // Avoid synchronous process.exit while a JSON write may still be queued
+    // on a pipe (e.g. `kimi doctor --json | jq`). Setting the exit code lets
+    // the event loop drain stdout naturally before the process terminates.
+    resolved.setExitCode(code);
+    return;
+  }
+  resolved.exit(code);
 }
 
 function resolveDeps(deps: Partial<DoctorDeps> | DoctorDeps | undefined): ResolvedDoctorDeps {
@@ -157,6 +175,11 @@ function resolveDeps(deps: Partial<DoctorDeps> | DoctorDeps | undefined): Resolv
     stdout: deps?.stdout ?? process.stdout,
     stderr: deps?.stderr ?? process.stderr,
     exit: deps?.exit ?? ((code) => process.exit(code)),
+    setExitCode:
+      deps?.setExitCode ??
+      ((code) => {
+        process.exitCode = code;
+      }),
     fileExists: deps?.fileExists ?? existsSync,
     readTextFile: deps?.readTextFile ?? ((path) => readFile(path, 'utf-8')),
     validateConfigToml:

--- a/apps/kimi-code/src/cli/sub/doctor.ts
+++ b/apps/kimi-code/src/cli/sub/doctor.ts
@@ -34,6 +34,19 @@ export interface DoctorDeps {
 export interface DoctorOptions {
   readonly target?: 'config' | 'tui';
   readonly path?: string;
+  readonly json?: boolean;
+}
+
+/**
+ * Stable JSON shape emitted when `--json` is set. Versioned via `report_version`
+ * so downstream tooling can pin against a schema. Bump when fields change
+ * shape (additive changes don't need a bump).
+ */
+interface DoctorJsonReport {
+  readonly report_version: 1;
+  readonly ok: boolean;
+  readonly issue_count: number;
+  readonly results: readonly CheckResult[];
 }
 
 interface CheckSpec {
@@ -69,6 +82,13 @@ export async function handleDoctor(deps: DoctorDeps, options: DoctorOptions): Pr
   const results = await Promise.all(specs.map((spec) => checkTomlFile(resolved, spec)));
 
   const issueCount = results.filter((result) => result.status === 'ERROR').length;
+  if (options.json === true) {
+    // JSON mode always writes to stdout regardless of exit code so callers can
+    // pipe through `jq` without juggling stderr — the exit code conveys failure.
+    resolved.stdout.write(formatJson(results, issueCount));
+    return issueCount === 0 ? 0 : 1;
+  }
+
   const text = issueCount === 0 ? formatSuccess(results) : formatFailure(results, issueCount);
   if (issueCount === 0) {
     resolved.stdout.write(text);
@@ -79,28 +99,39 @@ export async function handleDoctor(deps: DoctorDeps, options: DoctorOptions): Pr
 }
 
 export function registerDoctorCommand(parent: Command, deps?: Partial<DoctorDeps>): void {
+  // `--json` is declared once on the parent `doctor` command and consumed via
+  // `cmd.optsWithGlobals()` in every action so users can pass it after the root
+  // (`doctor --json`) or after a subcommand (`doctor config --json`). Declaring
+  // the same option on each subcommand would split the flag namespace and let
+  // the parent silently swallow the value when the user typed it on a child.
   const doctor = parent
     .command('doctor')
     .description('Validate Kimi Code configuration files.')
-    .action(async () => {
-      await runDoctorCommand(deps, {});
+    .option('--json', 'Output results as a machine-readable JSON report.', false)
+    .action(async (_opts: unknown, cmd: Command) => {
+      await runDoctorCommand(deps, { json: jsonOptionFrom(cmd) });
     });
 
   doctor
     .command('config')
     .description('Validate config.toml.')
     .argument('[path]', 'Validate this file as config.toml instead of the default path.')
-    .action(async (path: string | undefined) => {
-      await runDoctorCommand(deps, { target: 'config', path });
+    .action(async (path: string | undefined, _opts: unknown, cmd: Command) => {
+      await runDoctorCommand(deps, { target: 'config', path, json: jsonOptionFrom(cmd) });
     });
 
   doctor
     .command('tui')
     .description('Validate tui.toml.')
     .argument('[path]', 'Validate this file as tui.toml instead of the default path.')
-    .action(async (path: string | undefined) => {
-      await runDoctorCommand(deps, { target: 'tui', path });
+    .action(async (path: string | undefined, _opts: unknown, cmd: Command) => {
+      await runDoctorCommand(deps, { target: 'tui', path, json: jsonOptionFrom(cmd) });
     });
+}
+
+function jsonOptionFrom(cmd: Command): boolean {
+  const opts = cmd.optsWithGlobals() as { json?: unknown };
+  return opts.json === true;
 }
 
 async function runDoctorCommand(
@@ -234,6 +265,16 @@ function resolveTuiTargetPath(
 
 function resolveInputPath(input: string, cwd: string): string {
   return isAbsolute(input) ? input : resolve(cwd, input);
+}
+
+function formatJson(results: readonly CheckResult[], issueCount: number): string {
+  const report: DoctorJsonReport = {
+    report_version: 1,
+    ok: issueCount === 0,
+    issue_count: issueCount,
+    results,
+  };
+  return JSON.stringify(report, null, 2) + '\n';
 }
 
 function formatSuccess(results: readonly CheckResult[]): string {

--- a/apps/kimi-code/test/cli/doctor.test.ts
+++ b/apps/kimi-code/test/cli/doctor.test.ts
@@ -27,10 +27,12 @@ function makeDeps(): {
   stdout: string[];
   stderr: string[];
   exitCodes: number[];
+  deferredExitCodes: number[];
 } {
   const stdout: string[] = [];
   const stderr: string[] = [];
   const exitCodes: number[] = [];
+  const deferredExitCodes: number[] = [];
   return {
     deps: {
       cwd: () => dir,
@@ -42,10 +44,14 @@ function makeDeps(): {
         exitCodes.push(code);
         throw new Error(`exit ${String(code)}`);
       },
+      setExitCode: (code) => {
+        deferredExitCodes.push(code);
+      },
     },
     stdout,
     stderr,
     exitCodes,
+    deferredExitCodes,
   };
 }
 
@@ -307,6 +313,39 @@ max_context_size = 0
     const results = report['results'] as ReadonlyArray<Record<string, unknown>>;
     expect(results).toHaveLength(1);
     expect(results[0]).toMatchObject({ label: 'config.toml', status: 'OK' });
+  });
+
+  it('defers exit via setExitCode (not synchronous exit) when --json fails', async () => {
+    // Regression: process.exit() after stdout.write() to a pipe can truncate
+    // the JSON report on Linux/CI, so the command must use process.exitCode
+    // and let the event loop drain stdout before terminating.
+    await writeFile(
+      join(dir, 'config.toml'),
+      `
+[providers.kimi]
+type = "kimi"
+
+[models.kimi]
+provider = "kimi"
+model = "kimi"
+max_context_size = 0
+`,
+      'utf-8',
+    );
+    const { deps, stdout, stderr, exitCodes, deferredExitCodes } = makeDeps();
+    const program = new Command('kimi');
+    registerDoctorCommand(program, deps);
+
+    await program.parseAsync(['node', 'kimi', 'doctor', '--json']);
+
+    // The synchronous exit() must NOT have been called — otherwise stdout
+    // could be truncated mid-write when piped to jq.
+    expect(exitCodes).toEqual([]);
+    expect(deferredExitCodes).toEqual([1]);
+    expect(stderr.join('')).toBe('');
+    const report = JSON.parse(stdout.join('')) as Record<string, unknown>;
+    expect(report['ok']).toBe(false);
+    expect(report['issue_count']).toBe(1);
   });
 
   it('accepts --json on the root doctor command (no subcommand)', async () => {

--- a/apps/kimi-code/test/cli/doctor.test.ts
+++ b/apps/kimi-code/test/cli/doctor.test.ts
@@ -244,6 +244,88 @@ enabled = "yes"
     expect(err).toContain('notifications.enabled:');
   });
 
+  it('emits a JSON report with ok=true when --json is set and config is valid', async () => {
+    await writeValidConfig();
+    await writeValidTuiConfig();
+    const { deps, stdout, stderr } = makeDeps();
+
+    const code = await handleDoctor(deps, { json: true });
+
+    expect(code).toBe(0);
+    expect(stderr.join('')).toBe('');
+    const report = JSON.parse(stdout.join('')) as Record<string, unknown>;
+    expect(report['report_version']).toBe(1);
+    expect(report['ok']).toBe(true);
+    expect(report['issue_count']).toBe(0);
+    const results = report['results'] as ReadonlyArray<Record<string, unknown>>;
+    expect(results).toHaveLength(2);
+    expect(results[0]).toMatchObject({ label: 'config.toml', status: 'OK' });
+    expect(results[1]).toMatchObject({ label: 'tui.toml', status: 'OK' });
+  });
+
+  it('emits a JSON report with ok=false when --json is set and a config is invalid', async () => {
+    await writeFile(
+      join(dir, 'config.toml'),
+      `
+[providers.kimi]
+type = "kimi"
+
+[models.kimi]
+provider = "kimi"
+model = "kimi"
+max_context_size = 0
+`,
+      'utf-8',
+    );
+    const { deps, stdout, stderr } = makeDeps();
+
+    const code = await handleDoctor(deps, { json: true });
+
+    expect(code).toBe(1);
+    expect(stderr.join('')).toBe('');
+    const report = JSON.parse(stdout.join('')) as Record<string, unknown>;
+    expect(report['ok']).toBe(false);
+    expect(report['issue_count']).toBe(1);
+    const results = report['results'] as ReadonlyArray<Record<string, unknown>>;
+    const configResult = results.find((r) => r['label'] === 'config.toml');
+    expect(configResult).toMatchObject({ status: 'ERROR' });
+    expect(typeof configResult?.['message']).toBe('string');
+  });
+
+  it('routes --json through the commander parser', async () => {
+    await writeValidConfig();
+    const { deps, stdout, stderr, exitCodes } = makeDeps();
+    const program = new Command('kimi');
+    registerDoctorCommand(program, deps);
+
+    await program.parseAsync(['node', 'kimi', 'doctor', 'config', '--json']);
+
+    expect(exitCodes).toEqual([]);
+    expect(stderr.join('')).toBe('');
+    const report = JSON.parse(stdout.join('')) as Record<string, unknown>;
+    expect(report['ok']).toBe(true);
+    const results = report['results'] as ReadonlyArray<Record<string, unknown>>;
+    expect(results).toHaveLength(1);
+    expect(results[0]).toMatchObject({ label: 'config.toml', status: 'OK' });
+  });
+
+  it('accepts --json on the root doctor command (no subcommand)', async () => {
+    await writeValidConfig();
+    await writeValidTuiConfig();
+    const { deps, stdout, stderr, exitCodes } = makeDeps();
+    const program = new Command('kimi');
+    registerDoctorCommand(program, deps);
+
+    await program.parseAsync(['node', 'kimi', 'doctor', '--json']);
+
+    expect(exitCodes).toEqual([]);
+    expect(stderr.join('')).toBe('');
+    const report = JSON.parse(stdout.join('')) as Record<string, unknown>;
+    expect(report['ok']).toBe(true);
+    const results = report['results'] as ReadonlyArray<Record<string, unknown>>;
+    expect(results).toHaveLength(2);
+  });
+
   it('formats wrapped Zod validation issues with TOML-style field paths for config.toml', async () => {
     await writeFile(
       join(dir, 'config.toml'),


### PR DESCRIPTION
# Related Issue

Resolve #53

# Problem

`kimi doctor` currently prints a human-formatted block. Bug-report templates and CI pipelines want a stable machine-readable shape, and `codex doctor --json` (referenced in the issue) is the prior art.

# What changed

Add `--json` to `kimi doctor`, `kimi doctor config`, and `kimi doctor tui`. The flag is declared once on the parent `doctor` command and read via `cmd.optsWithGlobals()` from every subcommand action so users can pass it after the root or after a subcommand. Output shape:

```json
{
  "report_version": 1,
  "ok": true,
  "issue_count": 0,
  "results": [{ "label": "config.toml", "path": "...", "status": "OK" }]
}
```

JSON-mode failures defer exit via `process.exitCode` (not synchronous `process.exit`) so the event loop drains stdout before termination — addresses a codex review concern that pipe writes could truncate the report. Scope note: this implements the foundation (config validation as JSON); the broader diagnostic surface area listed in the issue (env, MCP, terminal, network) can land incrementally on top of `report_version: 1`.

# Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.

# Verification

- `pnpm -C apps/kimi-code exec vitest run test/cli/doctor.test.ts`