### PR TITLE
fix(migration-legacy): import slugifyWorkDirName from agent-core

### DIFF
--- a/.changeset/fix-migration-legacy-shared-slugify.md
+++ b/.changeset/fix-migration-legacy-shared-slugify.md
@@ -1,6 +1,7 @@
 ---
 "@moonshot-ai/agent-core": patch
 "@moonshot-ai/kimi-code": patch
+"@moonshot-ai/migration-legacy": patch
 ---
 
 fix(migration-legacy): use shared slugifyWorkDirName from agent-core

--- a/.changeset/fix-migration-legacy-shared-slugify.md
+++ b/.changeset/fix-migration-legacy-shared-slugify.md
@@ -1,0 +1,13 @@
+---
+"@moonshot-ai/agent-core": patch
+"@moonshot-ai/kimi-code": patch
+---
+
+fix(migration-legacy): use shared slugifyWorkDirName from agent-core
+
+Exports `slugifyWorkDirName` from `@moonshot-ai/agent-core` and removes the
+duplicate local implementation in `packages/migration-legacy/src/sessions/workdir-bucket.ts`.
+
+No user-visible behavior change. The migrator now imports the canonical
+slugifier, so migrated bucket names stay byte-identical to agent-core
+without manual sync.

--- a/packages/agent-core/src/index.ts
+++ b/packages/agent-core/src/index.ts
@@ -15,6 +15,7 @@ export {
   resolveGlobalLogPath,
 } from './logging/logger';
 export { resolveLoggingConfig } from './logging/resolve-config';
+export { slugifyWorkDirName } from './utils/workdir-slug';
 export type { ResolveLoggingInput } from './logging/resolve-config';
 export type {
   LogContext,

--- a/packages/migration-legacy/src/sessions/workdir-bucket.ts
+++ b/packages/migration-legacy/src/sessions/workdir-bucket.ts
@@ -1,26 +1,22 @@
 import { basename, resolve } from 'node:path';
 import { createHash } from 'node:crypto';
 
+import { slugifyWorkDirName } from '@moonshot-ai/agent-core';
+
 const WORKDIR_KEY_PREFIX = 'wd_';
 const HASH_LENGTH = 12;
 
 /**
  * Compute the v2 bucket directory name `wd_<slug>_<hash12>` for a workdir
- * path. Hash function and slug rules mirror
- * `packages/kimi-core/src/utils/workdir-slug.ts` and
- * `packages/kimi-core/src/harness/session-manager/workdir-key.ts:13–18`.
+ * path. Slug rules use `slugifyWorkDirName` from `@moonshot-ai/agent-core`
+ * (file: `packages/agent-core/src/utils/workdir-slug.ts`); hash and resolve
+ * logic mirror `packages/agent-core/src/harness/session-manager/workdir-key.ts`.
  *
  * IMPORTANT: agent-core's `encodeWorkDirKey` runs `resolve()` on the workdir
  * before hashing/slugifying, and the session picker locates sessions purely
  * by `readdir(encodeWorkDirKey(...))` — it never consults `session_index.jsonl`.
  * We MUST apply the same `resolve()` here or migrated sessions become
  * invisible in the picker.
- *
- * TODO: The canonical slugifier is `slugifyWorkDirName` in
- * `@moonshot-ai/agent-core` (file: `src/utils/workdir-slug.ts`). It is not part
- * of that package's public export surface today. When/if it becomes public,
- * delete the local duplicate below and import it from agent-core directly so
- * buckets stay byte-identical between the running app and this migrator.
  */
 export function computeWorkdirBucket(workdirPath: string): string {
   const normalized = resolve(workdirPath);
@@ -34,18 +30,4 @@ export function oldMd5BucketName(workdirPath: string): string {
   return createHash('md5').update(workdirPath).digest('hex');
 }
 
-const MAX_WORKDIR_SLUG_LENGTH = 40;
 
-/**
- * Local copy of kimi-core's `slugifyWorkDirName`. Keep byte-identical to the
- * canonical implementation in `packages/kimi-core/src/utils/workdir-slug.ts`.
- */
-function slugifyWorkDirName(name: string): string {
-  const slug = name
-    .toLowerCase()
-    .replaceAll(/[^a-z0-9._-]+/g, '-')
-    .replaceAll(/^-+|-+$/g, '')
-    .slice(0, MAX_WORKDIR_SLUG_LENGTH)
-    .replaceAll(/^-+|-+$/g, '');
-  return slug === '' || slug === '.' || slug === '..' ? 'workspace' : slug;
-}


### PR DESCRIPTION
## Related Issue
The TODO at the top of `packages/migration-legacy/src/sessions/workdir-bucket.ts` is resolved by this PR. No upstream issue needed — the duplicate was flagged in-source.

## Problem

`packages/migration-legacy/src/sessions/workdir-bucket.ts` carried a local copy of `slugifyWorkDirName` identical to the canonical implementation in `packages/agent-core/src/utils/workdir-slug.ts`. The local copy was marked with a TODO to delete it once the function became public on `@moonshot-ai/agent-core`.

This is a small class of bug: if the canonical implementation ever changes (length cap, replacement regex, edge-case handling), the migrator would silently produce a different bucket name than the running app, making migrated sessions invisible in the session picker.

## What changed

- Export `slugifyWorkDirName` from `packages/agent-core/src/index.ts` so in-monorepo consumers can import it directly.
- Replace the local duplicate in `packages/migration-legacy/src/sessions/workdir-bucket.ts` with `import { slugifyWorkDirName } from '@moonshot-ai/agent-core'`.
- Remove the TODO comment block.
- Add a `.changeset/` entry noting the internal dependency update.

No user-visible behavior change. The migrator's `computeWorkdirBucket` produces the same output as before for the same inputs — both call sites now share the canonical implementation, so they cannot drift.

## Why this fits the repo

This is exactly the case the project's monorepo layout was set up for: a canonical utility in `agent-core` consumed by a sibling package. The TODO explicitly asked for this refactor once the export became available; this PR makes the export available and follows through.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above. (In-source TODO, not an issue.)
- [x] I have added tests that prove my feature works. (No new tests needed — the existing test at `packages/migration-legacy/test/sessions/workdir-bucket.test.ts` continues to validate `computeWorkdirBucket` output and the function is unchanged at the call site.)
- [x] Ran `gen-changesets` skill, or this PR needs no changeset. (Changeset added under `.changeset/fix-migration-legacy-shared-slugify.md`.)
- [x] Ran `gen-docs` skill, or this PR needs no doc update. (Internal refactor, no user-facing docs change.)

### Environment note

I was unable to run `pnpm install` / `pnpm test` locally because the repository requires Node `>=24.15.0` and the available toolchain in this environment is Node 22.22.2 (engine-strict is on, so install fails fast). The diff is small and self-contained:

- One new export line in `packages/agent-core/src/index.ts`.
- Net `-17` lines in `workdir-bucket.ts` (duplicate function removed, one import added, comment refreshed).
- The exported function's body is byte-identical to the local copy that was removed, so behavior is preserved.

I would appreciate a CI run from a maintainer to confirm the test suite still passes.
