### PR TITLE
fix(agent): keep KIMI_NOW fresh across turns and session resume

### DIFF
--- a/.changeset/kimi-now-stale-on-resume.md
+++ b/.changeset/kimi-now-stale-on-resume.md
@@ -1,0 +1,6 @@
+---
+"@moonshot-ai/agent-core": patch
+"@moonshot-ai/kimi-code": patch
+---
+
+Fix `KIMI_NOW` system-prompt timestamp going stale across turns and session resume — the agent now sees the live wall-clock ISO time on every LLM call instead of a value frozen at session creation

--- a/packages/agent-core/src/agent/config/index.ts
+++ b/packages/agent-core/src/agent/config/index.ts
@@ -8,6 +8,7 @@ import {
 
 import type { Agent } from '..';
 import { ErrorCodes, KimiError } from '../../errors';
+import { KIMI_NOW_PLACEHOLDER } from '../../profile';
 import type { AgentConfigData, AgentConfigUpdateData } from './types';
 import { resolveThinkingEffort, type ThinkingEffort } from './thinking';
 import type { ResolvedRuntimeProvider } from '../../session/provider-manager';
@@ -120,7 +121,14 @@ export class ConfigState {
   }
 
   get systemPrompt(): string {
-    return this._systemPrompt;
+    // Lazily substitute the KIMI_NOW placeholder so the timestamp stays
+    // fresh across turns and resume. New sessions (post-fix) render the
+    // placeholder into the stored string; old sessions that have a baked
+    // timestamp simply pass through unchanged.
+    if (!this._systemPrompt.includes(KIMI_NOW_PLACEHOLDER)) {
+      return this._systemPrompt;
+    }
+    return this._systemPrompt.replaceAll(KIMI_NOW_PLACEHOLDER, new Date().toISOString());
   }
 
   get modelCapabilities(): ModelCapability {

--- a/packages/agent-core/src/agent/index.ts
+++ b/packages/agent-core/src/agent/index.ts
@@ -16,7 +16,7 @@ import type { EnabledPluginSessionStart } from '#/plugin';
 
 import type { McpConnectionManager } from '../mcp';
 import { FlagResolver, type ExperimentalFlagResolver } from '../flags';
-import type { PreparedSystemPromptContext, ResolvedAgentProfile } from '../profile';
+import { KIMI_NOW_PLACEHOLDER, type PreparedSystemPromptContext, type ResolvedAgentProfile } from '../profile';
 import type { ModelProvider } from '../session/provider-manager';
 import type { SessionGoalStore } from '../session/goal';
 import type { SessionSubagentHost } from '../session/subagent-host';
@@ -282,6 +282,13 @@ export class Agent {
     const systemPrompt = profile.systemPrompt({
       osEnv: this.kaos.osEnv,
       cwd: this.config.cwd,
+      // Embed a sentinel placeholder rather than a concrete timestamp here:
+      // `useProfile` is called once at session bootstrap, but the rendered
+      // string is reused for every turn (and survives session resume via the
+      // wire log). A baked-in timestamp goes stale immediately after the
+      // session is suspended and restored later. `ConfigState.systemPrompt`
+      // substitutes the placeholder with the current ISO time on every read.
+      now: KIMI_NOW_PLACEHOLDER,
       skills: this.skills?.registry,
       cwdListing: context?.cwdListing,
       agentsMd: context?.agentsMd,

--- a/packages/agent-core/src/profile/types.ts
+++ b/packages/agent-core/src/profile/types.ts
@@ -46,6 +46,19 @@ export interface SystemPromptContext {
 
 export type SystemPromptRenderer = (context: SystemPromptContext) => string;
 
+/**
+ * Sentinel embedded into the rendered system prompt in place of a concrete
+ * `KIMI_NOW` timestamp. Substituted with the current wall-clock ISO time at
+ * read time (`ConfigState.systemPrompt` getter) so the value stays fresh
+ * across turns and — most importantly — across session resume, instead of
+ * being frozen at session-creation time.
+ *
+ * Chosen as a long opaque string that no agent template or user content
+ * is expected to contain literally. Persisted verbatim in the wire log so
+ * restored sessions inherit live substitution automatically.
+ */
+export const KIMI_NOW_PLACEHOLDER = '__KIMI_NOW_PLACEHOLDER_v1__';
+
 export interface ResolvedAgentProfile {
   name: string;
   description?: string;

--- a/packages/agent-core/test/agent/config-state.test.ts
+++ b/packages/agent-core/test/agent/config-state.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import { emptyUsage } from '@moonshot-ai/kosong';
 
+import { KIMI_NOW_PLACEHOLDER } from '../../src/profile';
 import { ProviderManager } from '../../src/session/provider-manager';
 import { testAgent } from './harness';
 
@@ -156,5 +157,80 @@ describe('ConfigState model capabilities', () => {
       },
     });
     expect('sessionId' in ctx.agent).toBe(false);
+  });
+});
+
+describe('ConfigState systemPrompt KIMI_NOW placeholder', () => {
+  function makeAgent(): ReturnType<typeof testAgent> {
+    return testAgent({
+      providerManager: new ProviderManager({
+        config: {
+          providers: { kimi: { type: 'kimi', apiKey: 'test-key' } },
+          models: {
+            'kimi-code': { provider: 'kimi', model: 'kimi-code', maxContextSize: 128_000 },
+          },
+        },
+      }),
+    });
+  }
+
+  it('substitutes the KIMI_NOW placeholder with the current ISO timestamp on read', () => {
+    const ctx = makeAgent();
+    ctx.agent.config.update({
+      systemPrompt: `Hello at ${KIMI_NOW_PLACEHOLDER} world`,
+    });
+
+    const before = Date.now();
+    const out = ctx.agent.config.systemPrompt;
+    const after = Date.now();
+
+    expect(out).not.toContain(KIMI_NOW_PLACEHOLDER);
+    const match = /Hello at (.+) world/.exec(out);
+    expect(match).not.toBeNull();
+    const substitutedIso = match![1]!;
+    const substitutedMs = Date.parse(substitutedIso);
+    expect(Number.isFinite(substitutedMs)).toBe(true);
+    // Allow a 1s window for the wall clock to drift between sampling.
+    expect(substitutedMs).toBeGreaterThanOrEqual(before - 1000);
+    expect(substitutedMs).toBeLessThanOrEqual(after + 1000);
+  });
+
+  it('returns a fresh timestamp on each read (lazy, not cached)', async () => {
+    const ctx = makeAgent();
+    ctx.agent.config.update({
+      systemPrompt: `now=${KIMI_NOW_PLACEHOLDER}`,
+    });
+    const first = ctx.agent.config.systemPrompt;
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    const second = ctx.agent.config.systemPrompt;
+
+    // Both reads should produce a valid ISO timestamp, and the second
+    // must be strictly after the first (proves the getter is live).
+    const firstIso = /now=(.+)/.exec(first)![1]!;
+    const secondIso = /now=(.+)/.exec(second)![1]!;
+    expect(Date.parse(secondIso)).toBeGreaterThan(Date.parse(firstIso));
+  });
+
+  it('passes through systemPrompts that do not contain the placeholder unchanged', () => {
+    const ctx = makeAgent();
+    ctx.agent.config.update({
+      systemPrompt: 'Static prompt at 2026-05-08T00:00:00Z',
+    });
+
+    expect(ctx.agent.config.systemPrompt).toBe('Static prompt at 2026-05-08T00:00:00Z');
+  });
+
+  it('substitutes every occurrence (multiple placeholders within one prompt)', () => {
+    const ctx = makeAgent();
+    ctx.agent.config.update({
+      systemPrompt: `a=${KIMI_NOW_PLACEHOLDER} b=${KIMI_NOW_PLACEHOLDER}`,
+    });
+
+    const out = ctx.agent.config.systemPrompt;
+    expect(out).not.toContain(KIMI_NOW_PLACEHOLDER);
+    const match = /a=(.+) b=(.+)/.exec(out);
+    expect(match).not.toBeNull();
+    // Both substitutions share the same Date instance, so they match exactly.
+    expect(match![1]).toBe(match![2]);
   });
 });


### PR DESCRIPTION
# Related Issue

Resolve #446

# Problem

`Agent.useProfile` renders the system prompt once at session bootstrap and the concrete `KIMI_NOW` ISO timestamp is frozen into `ConfigState._systemPrompt`. Every subsequent turn — and every session resume, possibly days or weeks later — feeds that same baked-in `now` to the model. The reporter saw a 4-week-stale timestamp after resuming an old session, which leads the agent to reason incorrectly about file recency, deadlines, and other time-sensitive context.

# What changed

Embed a sentinel placeholder (`__KIMI_NOW_PLACEHOLDER_v1__`) at render time instead of a concrete timestamp, and substitute it with `new Date().toISOString()` on every read of `ConfigState.systemPrompt`. Each turn (and `FullCompaction`, which also reads the prompt through the same getter) picks up the live wall-clock time. The placeholder is persisted verbatim in the wire log so resumed sessions inherit live substitution automatically; static custom prompts that omit the placeholder pass through unchanged.

# Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.

# Verification

- `pnpm -C packages/agent-core exec vitest run test/agent/config-state.test.ts`