### PR TITLE
fix(kosong): clamp OpenAI chat xhigh effort by model

### DIFF
--- a/.changeset/openai-chat-xhigh-effort.md
+++ b/.changeset/openai-chat-xhigh-effort.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Clamp OpenAI Chat Completions `xhigh` and `max` thinking effort to `high` unless the model supports `xhigh` on `v1/chat/completions`.

--- a/packages/kosong/src/provider.ts
+++ b/packages/kosong/src/provider.ts
@@ -8,9 +8,9 @@ import type { TokenUsage } from './usage';
  *
  * Values above `high` are provider/model-specific and may be clamped by the
  * adapter when the native API has no matching level. OpenAI maps `max` to its
- * `xhigh` ceiling; Kimi and Gemini cap `xhigh`/`max` at `high`; Anthropic
- * supports `xhigh`/`max` only on selected models and otherwise clamps to
- * `high`.
+ * `xhigh` ceiling on Responses and selected Chat Completions models; Kimi and
+ * Gemini cap `xhigh`/`max` at `high`; Anthropic supports `xhigh`/`max` only
+ * on selected models and otherwise clamps to `high`.
  */
 export type ThinkingEffort = 'off' | 'low' | 'medium' | 'high' | 'xhigh' | 'max';
 

--- a/packages/kosong/src/providers/capability-registry.ts
+++ b/packages/kosong/src/providers/capability-registry.ts
@@ -21,6 +21,15 @@ const OPENAI_RESPONSES_DEVELOPER_ROLE_MODELS = new Set([
   'o4-mini',
 ]);
 
+// OpenAI models that document `xhigh` and keep `v1/chat/completions` enabled.
+// Pro/Codex xhigh models are Responses-only, so the Chat Completions adapter
+// must clamp them at `high`.
+const OPENAI_CHAT_COMPLETIONS_XHIGH_REASONING_MODELS = new Set([
+  'gpt-5.2',
+  'gpt-5.4',
+  'gpt-5.5',
+]);
+
 const OPENAI_VISION_TOOL_PREFIXES = [
   'gpt-4o',
   'gpt-4-turbo',
@@ -149,6 +158,10 @@ function normalizeModelName(modelName: string): string {
   return modelName.toLowerCase();
 }
 
+function modelIdLeaf(modelName: string): string {
+  return normalizeModelName(modelName).trim().split('/').at(-1) ?? '';
+}
+
 function hasPrefix(modelName: string, prefixes: readonly string[]): boolean {
   return prefixes.some((prefix) => modelName.startsWith(prefix));
 }
@@ -191,6 +204,10 @@ export function getGoogleGenAIModelCapability(modelName: string): ModelCapabilit
     return GEMINI_THINKING_MULTIMODAL_TOOL_CAPABILITY;
   }
   return GEMINI_MULTIMODAL_TOOL_CAPABILITY;
+}
+
+export function supportsOpenAIChatCompletionsXHighReasoning(modelName: string): boolean {
+  return OPENAI_CHAT_COMPLETIONS_XHIGH_REASONING_MODELS.has(modelIdLeaf(modelName));
 }
 
 export function usesOpenAIResponsesDeveloperRole(modelName: string): boolean {

--- a/packages/kosong/src/providers/openai-legacy.ts
+++ b/packages/kosong/src/providers/openai-legacy.ts
@@ -12,7 +12,10 @@ import type { Tool } from '#/tool';
 import type { TokenUsage } from '#/usage';
 import OpenAI from 'openai';
 
-import { getOpenAILegacyModelCapability } from './capability-registry';
+import {
+  getOpenAILegacyModelCapability,
+  supportsOpenAIChatCompletionsXHighReasoning,
+} from './capability-registry';
 import {
   convertContentPart,
   convertOpenAIError,
@@ -130,6 +133,16 @@ function normalizeGenerationKwargs(
     delete kwargs.max_tokens;
   }
   return kwargs;
+}
+
+function clampChatCompletionsReasoningEffort(
+  reasoningEffort: string | undefined,
+  model: string,
+): string | undefined {
+  if (reasoningEffort !== 'xhigh') {
+    return reasoningEffort;
+  }
+  return supportsOpenAIChatCompletionsXHighReasoning(model) ? 'xhigh' : 'high';
 }
 
 function convertMessage(
@@ -505,7 +518,10 @@ export class OpenAILegacyChatProvider implements ChatProvider {
   }
 
   withThinking(effort: ThinkingEffort): OpenAILegacyChatProvider {
-    const reasoningEffort = thinkingEffortToReasoningEffort(effort);
+    const reasoningEffort = clampChatCompletionsReasoningEffort(
+      thinkingEffortToReasoningEffort(effort),
+      this._model,
+    );
     const clone = this._clone();
     clone._reasoningEffort = reasoningEffort;
     return clone;

--- a/packages/kosong/test/openai-legacy.test.ts
+++ b/packages/kosong/test/openai-legacy.test.ts
@@ -717,6 +717,56 @@ describe('OpenAILegacyChatProvider', () => {
 
       expect(body['reasoning_effort']).toBe('high');
     });
+
+    it.each(['gpt-5.2', 'gpt-5.4', 'gpt-5.5', 'openai/gpt-5.5'])(
+      '.withThinking("xhigh") passes through for Chat Completions xhigh model %s',
+      async (model) => {
+        const provider = createProvider({ model }).withThinking('xhigh');
+        const history: Message[] = [
+          { role: 'user', content: [{ type: 'text', text: 'Think' }], toolCalls: [] },
+        ];
+        const body = await captureRequestBody(provider, '', [], history);
+
+        expect(body['reasoning_effort']).toBe('xhigh');
+        expect(provider.thinkingEffort).toBe('xhigh');
+      },
+    );
+
+    it.each(['gpt-5.1', 'gpt-5.4-mini', 'gpt-5.4-pro', 'kimi-k2.6', 'some-model'])(
+      '.withThinking("xhigh") clamps to high for Chat Completions model %s',
+      async (model) => {
+        const provider = createProvider({ model }).withThinking('xhigh');
+        const history: Message[] = [
+          { role: 'user', content: [{ type: 'text', text: 'Think' }], toolCalls: [] },
+        ];
+        const body = await captureRequestBody(provider, '', [], history);
+
+        expect(body['reasoning_effort']).toBe('high');
+        expect(provider.thinkingEffort).toBe('high');
+      },
+    );
+
+    it('.withThinking("max") uses xhigh only for Chat Completions xhigh models', async () => {
+      const history: Message[] = [
+        { role: 'user', content: [{ type: 'text', text: 'Think' }], toolCalls: [] },
+      ];
+
+      const supported = await captureRequestBody(
+        createProvider({ model: 'gpt-5.5' }).withThinking('max'),
+        '',
+        [],
+        history,
+      );
+      const unsupported = await captureRequestBody(
+        createProvider({ model: 'gpt-5.5-pro' }).withThinking('max'),
+        '',
+        [],
+        history,
+      );
+
+      expect(supported['reasoning_effort']).toBe('xhigh');
+      expect(unsupported['reasoning_effort']).toBe('high');
+    });
   });
 
   describe('auto reasoning_effort', () => {


### PR DESCRIPTION
## Related Issue

No linked issue; problem explained below.

## Problem

OpenAI's `xhigh` reasoning effort is not uniformly available on Chat Completions. Some models support `xhigh` only through the Responses API, while the Chat Completions endpoint rejects or does not advertise that level. The provider currently maps `xhigh` / `max` directly to `xhigh` for OpenAI-compatible requests, which can make Chat Completions requests fail for models that only support up to `high`.

## What changed

- Added a Chat Completions-specific capability check for the OpenAI models that document `xhigh` while keeping `v1/chat/completions` enabled: `gpt-5.2`, `gpt-5.4`, and `gpt-5.5`.
- Clamped OpenAI Chat Completions `xhigh` / `max` thinking effort to `high` for other models.
- Left the Responses API mapping unchanged so Responses-only `xhigh` models can still use `xhigh`.
- Added OpenAI legacy provider tests for pass-through and clamped cases.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.

Verification:

```sh
pnpm -C packages/kosong exec vitest run
pnpm --filter @moonshot-ai/kosong run typecheck
git diff --check
```
