### PR TITLE
feat(env): migrate kimi-cli model request params and auto-update toggle

### DIFF
--- a/.changeset/migrate-kimi-cli-env-vars.md
+++ b/.changeset/migrate-kimi-cli-env-vars.md
@@ -1,0 +1,11 @@
+---
+"@moonshot-ai/agent-core": minor
+"@moonshot-ai/kimi-code": minor
+"@moonshot-ai/kosong": patch
+---
+
+Migrate still-relevant environment variables from kimi-cli:
+
+- `KIMI_MODEL_TEMPERATURE`, `KIMI_MODEL_TOP_P` — sampling parameters applied globally to any `kimi` provider (not tied to `KIMI_MODEL_NAME`).
+- `KIMI_MODEL_THINKING_KEEP` — Moonshot preserved-thinking passthrough (`thinking.keep`), injected only while Thinking is on.
+- `KIMI_CODE_NO_AUTO_UPDATE` (legacy alias `KIMI_CLI_NO_AUTO_UPDATE`) — fully disables the update preflight (no check, background install, or prompt).

--- a/apps/kimi-code/src/cli/update/preflight.ts
+++ b/apps/kimi-code/src/cli/update/preflight.ts
@@ -293,6 +293,18 @@ async function showPendingBackgroundInstallNotice(
   return nextState;
 }
 
+/**
+ * `KIMI_CODE_NO_AUTO_UPDATE` (or the legacy `KIMI_CLI_NO_AUTO_UPDATE` alias)
+ * fully disables the update preflight — no check, no background install, no
+ * prompt. Migrated from kimi-cli, where the variable gated all auto-update
+ * behavior. Accepts the usual truthy values (`1`/`true`/`yes`/`on`).
+ */
+function isAutoUpdateDisabledByEnv(env: NodeJS.ProcessEnv = process.env): boolean {
+  const truthy = (value?: string): boolean =>
+    ['1', 'true', 'yes', 'on'].includes((value ?? '').trim().toLowerCase());
+  return truthy(env['KIMI_CODE_NO_AUTO_UPDATE']) || truthy(env['KIMI_CLI_NO_AUTO_UPDATE']);
+}
+
 async function shouldAutoInstallUpdates(): Promise<boolean> {
   try {
     const config = await loadTuiConfig();
@@ -531,6 +543,10 @@ export async function runUpdatePreflight(
   const stderr = options.stderr ?? process.stderr;
   const logger = options.logger ?? log;
   const platform = process.platform;
+
+  if (isAutoUpdateDisabledByEnv()) {
+    return 'continue';
+  }
 
   try {
     const isInteractive =

--- a/apps/kimi-code/test/cli/update/preflight.test.ts
+++ b/apps/kimi-code/test/cli/update/preflight.test.ts
@@ -183,7 +183,32 @@ describe('runUpdatePreflight', () => {
     });
   });
 
-  afterEach(() => { vi.clearAllMocks(); });
+  afterEach(() => { vi.clearAllMocks(); vi.unstubAllEnvs(); });
+
+  it('skips all update work when KIMI_CODE_NO_AUTO_UPDATE is set', async () => {
+    vi.stubEnv('KIMI_CODE_NO_AUTO_UPDATE', '1');
+    mocks.readUpdateCache.mockResolvedValue(cacheWith('0.5.0'));
+    mocks.refreshUpdateCache.mockResolvedValue(cacheWith('0.5.0'));
+    const { options } = captureOutput();
+
+    await expect(runUpdatePreflight('0.4.0', options)).resolves.toBe('continue');
+
+    expect(readUpdateCache).not.toHaveBeenCalled();
+    expect(refreshUpdateCache).not.toHaveBeenCalled();
+    expect(detectInstallSource).not.toHaveBeenCalled();
+    expect(mocks.spawn).not.toHaveBeenCalled();
+  });
+
+  it('also honors the legacy KIMI_CLI_NO_AUTO_UPDATE alias', async () => {
+    vi.stubEnv('KIMI_CLI_NO_AUTO_UPDATE', 'true');
+    mocks.readUpdateCache.mockResolvedValue(cacheWith('0.5.0'));
+    const { options } = captureOutput();
+
+    await expect(runUpdatePreflight('0.4.0', options)).resolves.toBe('continue');
+
+    expect(readUpdateCache).not.toHaveBeenCalled();
+    expect(detectInstallSource).not.toHaveBeenCalled();
+  });
 
   it('starts an automatic update from the first fresh check when the cache is empty', async () => {
     mocks.readUpdateCache.mockResolvedValue(emptyUpdateCache());

--- a/docs/en/configuration/env-vars.md
+++ b/docs/en/configuration/env-vars.md
@@ -131,6 +131,10 @@ Switches that control the behavior of subsystems such as telemetry, background t
 | `KIMI_CODE_EXPERIMENTAL_BACKGROUND_ASK` | Override `[experimental].background_ask` for this process | Truthy or falsy |
 | `KIMI_SHELL_PATH` | Override the Git Bash path on Windows (used when auto-detection fails) | Absolute path |
 | `KIMI_MODEL_MAX_COMPLETION_TOKENS` | Hard cap on `max_completion_tokens` per LLM step; applies to the `kimi` provider only | Positive integer; `0` or negative disables clamping |
+| `KIMI_MODEL_TEMPERATURE` | Sampling temperature for every request; applies to the `kimi` provider only (global — independent of `KIMI_MODEL_NAME`) | Number, e.g. `0.3` |
+| `KIMI_MODEL_TOP_P` | Nucleus-sampling `top_p` for every request; applies to the `kimi` provider only (global) | Number, e.g. `0.95` |
+| `KIMI_MODEL_THINKING_KEEP` | Moonshot preserved-thinking passthrough (`thinking.keep`); applies to the `kimi` provider only, and only while Thinking is on | A value the API accepts, e.g. `all` |
+| `KIMI_CODE_NO_AUTO_UPDATE` | Fully disable the update preflight — no check, background install, or prompt. Legacy alias `KIMI_CLI_NO_AUTO_UPDATE` is also honored | Truthy: `1`/`true`/`yes`/`on` |
 | `KIMI_DISABLE_CRON` | Disable the scheduled-task tool (`CronCreate` rejects new schedules; existing tasks do not fire) | `1` to disable |
 
 ## Diagnostic logs

--- a/docs/zh/configuration/env-vars.md
+++ b/docs/zh/configuration/env-vars.md
@@ -131,6 +131,10 @@ kimi
 | `KIMI_CODE_EXPERIMENTAL_BACKGROUND_ASK` | 覆盖当前进程的 `[experimental].background_ask` | 真值或假值 |
 | `KIMI_SHELL_PATH` | Windows 上覆盖 Git Bash 路径（自动探测失败时使用） | 绝对路径 |
 | `KIMI_MODEL_MAX_COMPLETION_TOKENS` | 单步 LLM 请求的 `max_completion_tokens` 硬上限，仅对 `kimi` 供应商生效 | 正整数；`0` 或负数禁用 clamp |
+| `KIMI_MODEL_TEMPERATURE` | 每次请求的采样温度，仅对 `kimi` 供应商生效（全局生效，不依赖 `KIMI_MODEL_NAME`） | 数字，如 `0.3` |
+| `KIMI_MODEL_TOP_P` | 每次请求的核采样 `top_p`，仅对 `kimi` 供应商生效（全局生效） | 数字，如 `0.95` |
+| `KIMI_MODEL_THINKING_KEEP` | Moonshot 保留思考透传（`thinking.keep`），仅对 `kimi` 供应商生效，且仅在 Thinking 开启时注入 | API 接受的值，如 `all` |
+| `KIMI_CODE_NO_AUTO_UPDATE` | 完全禁用更新预检——不检查、不后台安装、不提示。同时兼容旧名 `KIMI_CLI_NO_AUTO_UPDATE` | 真值：`1`/`true`/`yes`/`on` |
 | `KIMI_DISABLE_CRON` | 禁用定时任务工具（`CronCreate` 拒绝新计划，已有任务不触发） | `1` 表示禁用 |
 
 ## 诊断日志

--- a/packages/agent-core/src/agent/config/index.ts
+++ b/packages/agent-core/src/agent/config/index.ts
@@ -6,6 +6,8 @@ import {
   type ProviderConfig,
 } from '@moonshot-ai/kosong';
 
+import { applyKimiEnvSamplingParams } from '../kimi-env-params';
+
 import type { Agent } from '..';
 import { ErrorCodes, KimiError } from '../../errors';
 import type { AgentConfigData, AgentConfigUpdateData } from './types';
@@ -97,7 +99,11 @@ export class ConfigState {
   }
 
   get provider(): ChatProvider {
-    return createProvider(this.providerConfig);
+    // Sampling params (KIMI_MODEL_TEMPERATURE / TOP_P) are applied here so every
+    // request built from config.provider — main loop and full-history compaction
+    // alike — carries them. thinking.keep is applied later in Agent.llm because
+    // it depends on the runtime thinking state.
+    return applyKimiEnvSamplingParams(createProvider(this.providerConfig));
   }
 
   get model(): string {

--- a/packages/agent-core/src/agent/index.ts
+++ b/packages/agent-core/src/agent/index.ts
@@ -37,6 +37,7 @@ import {
 } from './compaction';
 import { CronManager } from './cron';
 import { ConfigState } from './config';
+import { applyKimiEnvGenerationParams } from './kimi-env-params';
 import { ContextMemory } from './context';
 import { HookEngine } from '../session/hooks';
 import { InjectionManager } from './injection/manager';
@@ -210,7 +211,10 @@ export class Agent {
 
   get llm(): KosongLLM {
     const model = this.config.model;
-    const provider = this.config.provider.withThinking(this.config.thinkingLevel);
+    const provider = applyKimiEnvGenerationParams(
+      this.config.provider.withThinking(this.config.thinkingLevel),
+      this.config.thinkingLevel,
+    );
     const loopControl = this.kimiConfig?.loopControl;
     const completionBudgetConfig = resolveCompletionBudget({
       maxOutputSize: this.config.maxOutputSize,

--- a/packages/agent-core/src/agent/index.ts
+++ b/packages/agent-core/src/agent/index.ts
@@ -37,7 +37,7 @@ import {
 } from './compaction';
 import { CronManager } from './cron';
 import { ConfigState } from './config';
-import { applyKimiEnvGenerationParams } from './kimi-env-params';
+import { applyKimiEnvThinkingKeep } from './kimi-env-params';
 import { ContextMemory } from './context';
 import { HookEngine } from '../session/hooks';
 import { InjectionManager } from './injection/manager';
@@ -211,7 +211,7 @@ export class Agent {
 
   get llm(): KosongLLM {
     const model = this.config.model;
-    const provider = applyKimiEnvGenerationParams(
+    const provider = applyKimiEnvThinkingKeep(
       this.config.provider.withThinking(this.config.thinkingLevel),
       this.config.thinkingLevel,
     );

--- a/packages/agent-core/src/agent/kimi-env-params.ts
+++ b/packages/agent-core/src/agent/kimi-env-params.ts
@@ -1,0 +1,49 @@
+import {
+  type ChatProvider,
+  type GenerationKwargs,
+  KimiChatProvider,
+  type ThinkingEffort,
+} from '@moonshot-ai/kosong';
+
+import { parseFloatEnv } from '#/config/resolve';
+
+type Env = Readonly<Record<string, string | undefined>>;
+
+/**
+ * Apply Kimi-specific request parameters from `KIMI_MODEL_*` environment
+ * variables to a chat provider. Mirrors kimi-cli's `create_llm`: the params
+ * apply to any Kimi provider (global — not tied to `KIMI_MODEL_NAME`), and
+ * `thinking.keep` is attached only when thinking is on, otherwise the API would
+ * receive a `thinking.keep` with no accompanying `thinking.type` it honors.
+ *
+ * Scope note: `max_tokens` is intentionally NOT handled here — `KIMI_MODEL_MAX_TOKENS`
+ * (and `KIMI_MODEL_MAX_COMPLETION_TOKENS`) already flow through the completion-budget
+ * path (`resolveCompletionBudget` -> `applyCompletionBudget`). Handling it here too
+ * would be a redundant, conflicting second source.
+ *
+ * Non-Kimi providers — and Kimi providers with none of these env vars set — are
+ * returned unchanged.
+ */
+export function applyKimiEnvGenerationParams(
+  provider: ChatProvider,
+  thinkingLevel: ThinkingEffort,
+  env: Env = process.env,
+): ChatProvider {
+  if (!(provider instanceof KimiChatProvider)) return provider;
+
+  const kwargs: GenerationKwargs = {};
+  const temperature = parseFloatEnv(env['KIMI_MODEL_TEMPERATURE'], 'KIMI_MODEL_TEMPERATURE');
+  if (temperature !== undefined) kwargs.temperature = temperature;
+  const topP = parseFloatEnv(env['KIMI_MODEL_TOP_P'], 'KIMI_MODEL_TOP_P');
+  if (topP !== undefined) kwargs.top_p = topP;
+
+  let next: KimiChatProvider =
+    Object.keys(kwargs).length > 0 ? provider.withGenerationKwargs(kwargs) : provider;
+
+  const keep = env['KIMI_MODEL_THINKING_KEEP']?.trim();
+  if (keep !== undefined && keep.length > 0 && thinkingLevel !== 'off') {
+    next = next.withExtraBody({ thinking: { keep } });
+  }
+
+  return next;
+}

--- a/packages/agent-core/src/agent/kimi-env-params.ts
+++ b/packages/agent-core/src/agent/kimi-env-params.ts
@@ -10,23 +10,19 @@ import { parseFloatEnv } from '#/config/resolve';
 type Env = Readonly<Record<string, string | undefined>>;
 
 /**
- * Apply Kimi-specific request parameters from `KIMI_MODEL_*` environment
- * variables to a chat provider. Mirrors kimi-cli's `create_llm`: the params
- * apply to any Kimi provider (global — not tied to `KIMI_MODEL_NAME`), and
- * `thinking.keep` is attached only when thinking is on, otherwise the API would
- * receive a `thinking.keep` with no accompanying `thinking.type` it honors.
+ * Apply Kimi sampling params (`KIMI_MODEL_TEMPERATURE`, `KIMI_MODEL_TOP_P`) from
+ * the environment to a chat provider. Applied at provider construction
+ * (`ConfigState.provider`) so every request built from `config.provider` — the
+ * main loop AND full-history compaction — carries them, matching kimi-cli where
+ * these live on the shared `create_llm` provider. Applies globally to any Kimi
+ * provider (not tied to `KIMI_MODEL_NAME`).
  *
- * Scope note: `max_tokens` is intentionally NOT handled here — `KIMI_MODEL_MAX_TOKENS`
- * (and `KIMI_MODEL_MAX_COMPLETION_TOKENS`) already flow through the completion-budget
- * path (`resolveCompletionBudget` -> `applyCompletionBudget`). Handling it here too
- * would be a redundant, conflicting second source.
- *
- * Non-Kimi providers — and Kimi providers with none of these env vars set — are
- * returned unchanged.
+ * Non-Kimi providers — and Kimi providers with neither var set — are returned
+ * unchanged. `max_tokens` is intentionally NOT handled here: `KIMI_MODEL_MAX_TOKENS`
+ * already flows through the completion-budget path (`resolveCompletionBudget`).
  */
-export function applyKimiEnvGenerationParams(
+export function applyKimiEnvSamplingParams(
   provider: ChatProvider,
-  thinkingLevel: ThinkingEffort,
   env: Env = process.env,
 ): ChatProvider {
   if (!(provider instanceof KimiChatProvider)) return provider;
@@ -37,13 +33,25 @@ export function applyKimiEnvGenerationParams(
   const topP = parseFloatEnv(env['KIMI_MODEL_TOP_P'], 'KIMI_MODEL_TOP_P');
   if (topP !== undefined) kwargs.top_p = topP;
 
-  let next: KimiChatProvider =
-    Object.keys(kwargs).length > 0 ? provider.withGenerationKwargs(kwargs) : provider;
+  return Object.keys(kwargs).length > 0 ? provider.withGenerationKwargs(kwargs) : provider;
+}
 
+/**
+ * Apply the Moonshot preserved-thinking passthrough (`KIMI_MODEL_THINKING_KEEP`
+ * -> `thinking.keep`) to a chat provider. Applied in `Agent.llm` after
+ * `withThinking`, and only while thinking is on — otherwise the API would
+ * receive a `thinking.keep` with no accompanying `thinking.type` it honors.
+ * (Compaction uses a raw provider with thinking off, so it correctly skips this.)
+ *
+ * Non-Kimi providers — and an unset/blank value — are returned unchanged.
+ */
+export function applyKimiEnvThinkingKeep(
+  provider: ChatProvider,
+  thinkingLevel: ThinkingEffort,
+  env: Env = process.env,
+): ChatProvider {
+  if (!(provider instanceof KimiChatProvider)) return provider;
   const keep = env['KIMI_MODEL_THINKING_KEEP']?.trim();
-  if (keep !== undefined && keep.length > 0 && thinkingLevel !== 'off') {
-    next = next.withExtraBody({ thinking: { keep } });
-  }
-
-  return next;
+  if (keep === undefined || keep.length === 0 || thinkingLevel === 'off') return provider;
+  return provider.withExtraBody({ thinking: { keep } });
 }

--- a/packages/agent-core/src/config/resolve.ts
+++ b/packages/agent-core/src/config/resolve.ts
@@ -1,3 +1,5 @@
+import { ErrorCodes, KimiError } from '#/errors';
+
 const TRUE_BOOLEAN_ENV_VALUES = new Set(['1', 'true', 'yes', 'on']);
 const FALSE_BOOLEAN_ENV_VALUES = new Set(['0', 'false', 'no', 'off']);
 
@@ -23,4 +25,20 @@ export function parseBooleanEnv(value: string | undefined): boolean | undefined 
   if (TRUE_BOOLEAN_ENV_VALUES.has(normalized)) return true;
   if (FALSE_BOOLEAN_ENV_VALUES.has(normalized)) return false;
   return undefined;
+}
+
+/**
+ * Parse a floating-point environment value (e.g. `KIMI_MODEL_TEMPERATURE`).
+ * Returns `undefined` when unset/blank; throws `KimiError(CONFIG_INVALID)` on a
+ * non-numeric value so a typo fails fast like the other `KIMI_MODEL_*` vars.
+ * No range validation — callers pass values the upstream API accepts.
+ */
+export function parseFloatEnv(value: string | undefined, varName: string): number | undefined {
+  const trimmed = value?.trim();
+  if (trimmed === undefined || trimmed.length === 0) return undefined;
+  const parsed = Number(trimmed);
+  if (!Number.isFinite(parsed)) {
+    throw new KimiError(ErrorCodes.CONFIG_INVALID, `${varName} must be a number, got "${value}".`);
+  }
+  return parsed;
 }

--- a/packages/agent-core/test/agent/config-state.test.ts
+++ b/packages/agent-core/test/agent/config-state.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { emptyUsage } from '@moonshot-ai/kosong';
 
 import { ProviderManager } from '../../src/session/provider-manager';
@@ -156,5 +156,31 @@ describe('ConfigState model capabilities', () => {
       },
     });
     expect('sessionId' in ctx.agent).toBe(false);
+  });
+});
+
+describe('ConfigState.provider applies global KIMI_MODEL_* sampling params', () => {
+  it('injects KIMI_MODEL_TEMPERATURE into config.provider (the provider compaction also uses)', () => {
+    vi.stubEnv('KIMI_MODEL_TEMPERATURE', '0.3');
+    try {
+      const ctx = testAgent({
+        providerManager: new ProviderManager({
+          config: {
+            providers: { kimi: { type: 'kimi', apiKey: 'test-key' } },
+            models: {
+              'kimi-code': { provider: 'kimi', model: 'kimi-code', maxContextSize: 128_000 },
+            },
+          },
+        }),
+      });
+      ctx.agent.config.update({ modelAlias: 'kimi-code' });
+
+      const provider = ctx.agent.config.provider;
+      expect(Reflect.get(provider as object, '_generationKwargs')).toMatchObject({
+        temperature: 0.3,
+      });
+    } finally {
+      vi.unstubAllEnvs();
+    }
   });
 });

--- a/packages/agent-core/test/agent/kimi-env-params.test.ts
+++ b/packages/agent-core/test/agent/kimi-env-params.test.ts
@@ -1,0 +1,70 @@
+import { type ChatProvider, KimiChatProvider } from '@moonshot-ai/kosong';
+import { describe, expect, it } from 'vitest';
+
+import { applyKimiEnvGenerationParams } from '../../src/agent/kimi-env-params';
+import { KimiError } from '../../src/errors';
+
+function kimi(): KimiChatProvider {
+  return new KimiChatProvider({ model: 'kimi-k2', apiKey: 'k' });
+}
+
+interface KimiGenerationState {
+  temperature?: number;
+  top_p?: number;
+  extra_body?: { thinking?: { keep?: unknown } };
+}
+
+function genState(provider: ChatProvider): KimiGenerationState {
+  return Reflect.get(provider as object, '_generationKwargs') as KimiGenerationState;
+}
+
+function expectConfigInvalid(fn: () => unknown): void {
+  try {
+    fn();
+  } catch (error) {
+    expect(error).toBeInstanceOf(KimiError);
+    expect((error as KimiError).code).toBe('config.invalid');
+    return;
+  }
+  throw new Error('expected function to throw');
+}
+
+describe('applyKimiEnvGenerationParams', () => {
+  it('returns the same provider when no env vars are set', () => {
+    const provider = kimi();
+    expect(applyKimiEnvGenerationParams(provider, 'high', {})).toBe(provider);
+  });
+
+  it('injects temperature and top_p for a kimi provider', () => {
+    const out = applyKimiEnvGenerationParams(kimi(), 'high', {
+      KIMI_MODEL_TEMPERATURE: '0.3',
+      KIMI_MODEL_TOP_P: '0.95',
+    });
+    const state = genState(out);
+    expect(state.temperature).toBe(0.3);
+    expect(state.top_p).toBe(0.95);
+  });
+
+  it('injects thinking.keep when thinking is on', () => {
+    const out = applyKimiEnvGenerationParams(kimi(), 'high', { KIMI_MODEL_THINKING_KEEP: 'all' });
+    expect(genState(out).extra_body?.thinking?.keep).toBe('all');
+  });
+
+  it('does NOT inject thinking.keep when thinking is off', () => {
+    const out = applyKimiEnvGenerationParams(kimi(), 'off', { KIMI_MODEL_THINKING_KEEP: 'all' });
+    expect(genState(out).extra_body).toBeUndefined();
+  });
+
+  it('leaves non-kimi providers untouched', () => {
+    const stub = { name: 'stub' } as unknown as ChatProvider;
+    expect(
+      applyKimiEnvGenerationParams(stub, 'high', { KIMI_MODEL_TEMPERATURE: '0.3' }),
+    ).toBe(stub);
+  });
+
+  it('throws config.invalid for an invalid temperature', () => {
+    expectConfigInvalid(() =>
+      applyKimiEnvGenerationParams(kimi(), 'high', { KIMI_MODEL_TEMPERATURE: 'abc' }),
+    );
+  });
+});

--- a/packages/agent-core/test/agent/kimi-env-params.test.ts
+++ b/packages/agent-core/test/agent/kimi-env-params.test.ts
@@ -1,7 +1,7 @@
 import { type ChatProvider, KimiChatProvider } from '@moonshot-ai/kosong';
 import { describe, expect, it } from 'vitest';
 
-import { applyKimiEnvGenerationParams } from '../../src/agent/kimi-env-params';
+import { applyKimiEnvSamplingParams, applyKimiEnvThinkingKeep } from '../../src/agent/kimi-env-params';
 import { KimiError } from '../../src/errors';
 
 function kimi(): KimiChatProvider {
@@ -29,14 +29,14 @@ function expectConfigInvalid(fn: () => unknown): void {
   throw new Error('expected function to throw');
 }
 
-describe('applyKimiEnvGenerationParams', () => {
+describe('applyKimiEnvSamplingParams', () => {
   it('returns the same provider when no env vars are set', () => {
     const provider = kimi();
-    expect(applyKimiEnvGenerationParams(provider, 'high', {})).toBe(provider);
+    expect(applyKimiEnvSamplingParams(provider, {})).toBe(provider);
   });
 
   it('injects temperature and top_p for a kimi provider', () => {
-    const out = applyKimiEnvGenerationParams(kimi(), 'high', {
+    const out = applyKimiEnvSamplingParams(kimi(), {
       KIMI_MODEL_TEMPERATURE: '0.3',
       KIMI_MODEL_TOP_P: '0.95',
     });
@@ -45,26 +45,36 @@ describe('applyKimiEnvGenerationParams', () => {
     expect(state.top_p).toBe(0.95);
   });
 
-  it('injects thinking.keep when thinking is on', () => {
-    const out = applyKimiEnvGenerationParams(kimi(), 'high', { KIMI_MODEL_THINKING_KEEP: 'all' });
-    expect(genState(out).extra_body?.thinking?.keep).toBe('all');
-  });
-
-  it('does NOT inject thinking.keep when thinking is off', () => {
-    const out = applyKimiEnvGenerationParams(kimi(), 'off', { KIMI_MODEL_THINKING_KEEP: 'all' });
-    expect(genState(out).extra_body).toBeUndefined();
-  });
-
   it('leaves non-kimi providers untouched', () => {
     const stub = { name: 'stub' } as unknown as ChatProvider;
-    expect(
-      applyKimiEnvGenerationParams(stub, 'high', { KIMI_MODEL_TEMPERATURE: '0.3' }),
-    ).toBe(stub);
+    expect(applyKimiEnvSamplingParams(stub, { KIMI_MODEL_TEMPERATURE: '0.3' })).toBe(stub);
   });
 
   it('throws config.invalid for an invalid temperature', () => {
     expectConfigInvalid(() =>
-      applyKimiEnvGenerationParams(kimi(), 'high', { KIMI_MODEL_TEMPERATURE: 'abc' }),
+      applyKimiEnvSamplingParams(kimi(), { KIMI_MODEL_TEMPERATURE: 'abc' }),
     );
+  });
+});
+
+describe('applyKimiEnvThinkingKeep', () => {
+  it('injects thinking.keep when thinking is on', () => {
+    const out = applyKimiEnvThinkingKeep(kimi(), 'high', { KIMI_MODEL_THINKING_KEEP: 'all' });
+    expect(genState(out).extra_body?.thinking?.keep).toBe('all');
+  });
+
+  it('does NOT inject thinking.keep when thinking is off', () => {
+    const out = applyKimiEnvThinkingKeep(kimi(), 'off', { KIMI_MODEL_THINKING_KEEP: 'all' });
+    expect(genState(out).extra_body).toBeUndefined();
+  });
+
+  it('returns the same provider when keep is unset', () => {
+    const provider = kimi();
+    expect(applyKimiEnvThinkingKeep(provider, 'high', {})).toBe(provider);
+  });
+
+  it('leaves non-kimi providers untouched', () => {
+    const stub = { name: 'stub' } as unknown as ChatProvider;
+    expect(applyKimiEnvThinkingKeep(stub, 'high', { KIMI_MODEL_THINKING_KEEP: 'all' })).toBe(stub);
   });
 });

--- a/packages/agent-core/test/config/resolve.test.ts
+++ b/packages/agent-core/test/config/resolve.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+
+import { parseFloatEnv } from '../../src/config/resolve';
+import { KimiError } from '../../src/errors';
+
+function expectConfigInvalid(fn: () => unknown): void {
+  try {
+    fn();
+  } catch (error) {
+    expect(error).toBeInstanceOf(KimiError);
+    expect((error as KimiError).code).toBe('config.invalid');
+    return;
+  }
+  throw new Error('expected function to throw');
+}
+
+describe('parseFloatEnv', () => {
+  it('returns undefined when unset, empty, or blank', () => {
+    expect(parseFloatEnv(undefined, 'KIMI_MODEL_TEMPERATURE')).toBeUndefined();
+    expect(parseFloatEnv('', 'KIMI_MODEL_TEMPERATURE')).toBeUndefined();
+    expect(parseFloatEnv('   ', 'KIMI_MODEL_TEMPERATURE')).toBeUndefined();
+  });
+
+  it('parses valid floats and integers', () => {
+    expect(parseFloatEnv('0.3', 'KIMI_MODEL_TEMPERATURE')).toBe(0.3);
+    expect(parseFloatEnv('1', 'KIMI_MODEL_TEMPERATURE')).toBe(1);
+    expect(parseFloatEnv(' 0.95 ', 'KIMI_MODEL_TOP_P')).toBe(0.95);
+    expect(parseFloatEnv('0', 'KIMI_MODEL_TEMPERATURE')).toBe(0);
+  });
+
+  it.each(['abc', '1.2.3', 'NaN', '1,5'])(
+    'throws config.invalid for non-numeric value %s',
+    (value) => {
+      expectConfigInvalid(() => parseFloatEnv(value, 'KIMI_MODEL_TEMPERATURE'));
+    },
+  );
+});

--- a/packages/kosong/src/index.ts
+++ b/packages/kosong/src/index.ts
@@ -27,6 +27,11 @@ export type {
 export * from './provider';
 export { createProvider } from './providers';
 export type { ProviderConfig, ProviderType } from './providers';
+// Kimi provider: exported so callers can narrow a `ChatProvider` to the Kimi
+// backend (instanceof) and apply Kimi-specific request params (generation
+// kwargs, `thinking.keep` extra body).
+export { KimiChatProvider } from './providers/kimi';
+export type { ExtraBody, GenerationKwargs, KimiOptions, ThinkingConfig } from './providers/kimi';
 
 // Model capability matrix
 export { UNKNOWN_CAPABILITY, isUnknownCapability } from './capability';


### PR DESCRIPTION
## 背景

kcode-open 是 kimi-cli 的 TS 重制版。对比两边环境变量后，把 kimi-cli 中仍有价值、但 kcode-open 缺失的变量迁移过来。

## 迁移的变量（全局生效，仅对 \`kimi\` provider）

| 变量 | 作用 |
| --- | --- |
| \`KIMI_MODEL_THINKING_KEEP\` | Moonshot 保留思考 \`thinking.keep\` 透传，仅在 Thinking 开启时注入 |
| \`KIMI_MODEL_TEMPERATURE\` | 采样温度 |
| \`KIMI_MODEL_TOP_P\` | 核采样 top_p |
| \`KIMI_CODE_NO_AUTO_UPDATE\`（+ 兼容旧名 \`KIMI_CLI_NO_AUTO_UPDATE\`） | 完全禁用自动更新预检 |

语义对齐 kimi-cli 的 \`create_llm\`：对任何 kimi provider 全局生效，不依赖 \`KIMI_MODEL_NAME\`。

## 实现

- \`kosong\`：导出 \`KimiChatProvider\` + 相关类型，供上层 \`instanceof\` 判断（对应 kimi-cli 的 \`isinstance(chat_provider, Kimi)\`）。
- \`agent-core\`：新增 \`applyKimiEnvGenerationParams\`，在 \`Agent.get llm()\`（全局唯一 LLM 构造点）接线，复用 kosong 已有的 \`GenerationKwargs\` / \`thinking.keep\` 透传能力。
- \`kimi-code\`：\`runUpdatePreflight\` 入口早退禁用更新。

## 关于 \`KIMI_MODEL_MAX_TOKENS\`（有意未改动）

它在 kcode-open 早已存在并生效——\`completion-budget.ts\` 已把它作为 \`KIMI_MODEL_MAX_COMPLETION_TOKENS\` 的 legacy alias 全链路处理。再迁移会产生重复且冲突的两套来源，故复用现有实现，不重复迁移。

## 不迁移（无承接点 / 已被等价承接）

\`KIMI_WEB_*\`、\`KIMI_VIS_RESTRICT_OPEN_IN\`、\`KIMI_CLI_PASTE_*\`、\`KIMI_FILE_UPLOAD_WITHOUT_MESSAGE\`、\`KIMI_ANSI_THEME*\`（功能不存在）；\`KIMI_CLI_GIT_BASH_PATH\`→已有 \`KIMI_SHELL_PATH\`、\`KIMI_SHARE_DIR\`→已有 \`KIMI_CODE_HOME\`。

## 测试

- 全程 TDD（先写失败测试 → 实现 → 通过）。
- 新增 \`resolve.test.ts\`、\`kimi-env-params.test.ts\`，扩展 \`preflight.test.ts\`。
- agent-core + kosong：2478 passed；kimi-code update 区：72 passed；lint 0/0。
- 文档（en/zh env-vars）与 changeset 已同步。