### PR TITLE
fix: refresh provider model capabilities

### DIFF
--- a/.changeset/refresh-provider-capabilities.md
+++ b/.changeset/refresh-provider-capabilities.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Refresh provider model metadata when capabilities change without model ID changes.

--- a/apps/kimi-code/src/tui/utils/refresh-providers.ts
+++ b/apps/kimi-code/src/tui/utils/refresh-providers.ts
@@ -1,4 +1,5 @@
 import {
+  KIMI_CODE_PLATFORM_ID,
   KIMI_CODE_PROVIDER_NAME,
   applyManagedKimiCodeConfig,
   applyOpenPlatformConfig,
@@ -16,7 +17,7 @@ import {
   type CustomRegistrySource,
   type ManagedKimiConfigShape,
 } from '@moonshot-ai/kimi-code-oauth';
-import type { KimiConfig, KimiConfigPatch, OAuthRef, ProviderConfig } from '@moonshot-ai/kimi-code-sdk';
+import type { KimiConfig, KimiConfigPatch, ModelAlias, OAuthRef, ProviderConfig } from '@moonshot-ai/kimi-code-sdk';
 
 export interface RefreshProviderHost {
   getConfig(): Promise<KimiConfig>;
@@ -57,22 +58,45 @@ function asManaged(config: KimiConfig): ManagedKimiConfigShape {
   return config as unknown as ManagedKimiConfigShape;
 }
 
-function collectModelIdsForProvider(config: KimiConfig, providerId: string): Set<string> {
+function collectModelIdsForAliases(config: KimiConfig, aliasKeys: ReadonlySet<string>): Set<string> {
   const ids = new Set<string>();
-  for (const alias of Object.values(config.models ?? {})) {
-    if (alias.provider === providerId && alias.model.length > 0) {
+  for (const aliasKey of aliasKeys) {
+    const alias = config.models?.[aliasKey];
+    if (alias !== undefined && alias.model.length > 0) {
       ids.add(alias.model);
     }
   }
   return ids;
 }
 
-function setsEqual<T>(a: Set<T>, b: Set<T>): boolean {
-  if (a.size !== b.size) return false;
-  for (const item of a) {
-    if (!b.has(item)) return false;
+function providerAliasKeys(config: KimiConfig, providerId: string): Set<string> {
+  const keys = new Set<string>();
+  for (const [alias, model] of Object.entries(config.models ?? {})) {
+    if (model.provider === providerId) keys.add(alias);
   }
-  return true;
+  return keys;
+}
+
+function generatedProviderAliasKeys(
+  config: KimiConfig,
+  providerId: string,
+  aliasPrefix: string,
+): Set<string> {
+  const keys = new Set<string>();
+  for (const [alias, model] of Object.entries(config.models ?? {})) {
+    if (model.provider === providerId && alias.startsWith(aliasPrefix)) {
+      keys.add(alias);
+    }
+  }
+  return keys;
+}
+
+function unionSets<T>(...sets: ReadonlyArray<ReadonlySet<T>>): Set<T> {
+  const out = new Set<T>();
+  for (const set of sets) {
+    for (const value of set) out.add(value);
+  }
+  return out;
 }
 
 function computeChanges(oldIds: Set<string>, newIds: Set<string>): { added: number; removed: number } {
@@ -85,6 +109,97 @@ function computeChanges(oldIds: Set<string>, newIds: Set<string>): { added: numb
     if (!newIds.has(id)) removed++;
   }
   return { added, removed };
+}
+
+interface ProviderModelSnapshot {
+  readonly alias: string;
+  readonly provider: string;
+  readonly model: string;
+  readonly maxContextSize: number;
+  readonly maxOutputSize?: number;
+  readonly capabilities?: readonly string[];
+  readonly displayName?: string;
+  readonly reasoningKey?: string;
+  readonly adaptiveThinking?: boolean;
+}
+
+function providerModelSnapshots(
+  config: KimiConfig,
+  providerId: string,
+  aliasKeys: ReadonlySet<string>,
+): ProviderModelSnapshot[] {
+  const snapshots: ProviderModelSnapshot[] = [];
+  for (const alias of aliasKeys) {
+    const model = config.models?.[alias];
+    if (model === undefined || model.provider !== providerId) continue;
+    snapshots.push({
+      alias,
+      provider: model.provider,
+      model: model.model,
+      maxContextSize: model.maxContextSize,
+      maxOutputSize: model.maxOutputSize,
+      capabilities: model.capabilities === undefined ? undefined : [...model.capabilities].sort(),
+      displayName: model.displayName,
+      reasoningKey: model.reasoningKey,
+      adaptiveThinking: model.adaptiveThinking,
+    });
+  }
+  return snapshots.sort((a, b) => a.alias.localeCompare(b.alias));
+}
+
+function providerModelsEqual(
+  config: KimiConfig,
+  nextConfig: KimiConfig,
+  providerId: string,
+  aliasKeys: ReadonlySet<string>,
+): boolean {
+  return (
+    JSON.stringify(providerModelSnapshots(config, providerId, aliasKeys)) ===
+    JSON.stringify(providerModelSnapshots(nextConfig, providerId, aliasKeys))
+  );
+}
+
+function providerRefreshAliasKeys(
+  config: KimiConfig,
+  nextConfig: KimiConfig,
+  providerId: string,
+  aliasPrefix: string,
+): Set<string> {
+  return unionSets(
+    generatedProviderAliasKeys(config, providerId, aliasPrefix),
+    providerAliasKeys(nextConfig, providerId),
+  );
+}
+
+function preserveUserProviderAliases(
+  config: KimiConfig,
+  providerId: string,
+  refreshedAliasKeys: ReadonlySet<string>,
+): Record<string, ModelAlias> {
+  const preserved: Record<string, ModelAlias> = {};
+  for (const [alias, model] of Object.entries(config.models ?? {})) {
+    if (model.provider !== providerId || refreshedAliasKeys.has(alias)) continue;
+    preserved[alias] = structuredClone(model);
+  }
+  return preserved;
+}
+
+function restoreProviderAliases(config: KimiConfig, aliases: Record<string, ModelAlias>): void {
+  if (Object.keys(aliases).length === 0) return;
+  config.models = {
+    ...config.models,
+    ...aliases,
+  };
+}
+
+function restoreDefaultSelection(
+  config: KimiConfig,
+  defaultModel: string | undefined,
+  defaultThinking: boolean | undefined,
+): void {
+  if (defaultModel === undefined || config.models?.[defaultModel] === undefined) return;
+  config.defaultModel = defaultModel;
+  config.defaultThinking = defaultThinking;
 }
 
 function pickDefaultModel(config: KimiConfig, providerId: string, models: Array<{ id: string }>): string {
@@ -131,13 +246,34 @@ export async function refreshAllProviderModels(host: RefreshProviderHost): Promi
         baseUrl: auth.baseUrl,
       });
       if (models.length > 0) {
-        const beforeIds = collectModelIdsForProvider(config, KIMI_CODE_PROVIDER_NAME);
-        const newIds = new Set(models.map((m) => m.id));
+        const nextConfig = structuredClone(config);
+        applyManagedKimiCodeConfig(asManaged(nextConfig), {
+          models,
+          baseUrl: auth.baseUrl,
+          oauthKey: auth.oauthRef.key,
+          oauthHost: auth.oauthRef.oauthHost,
+          preserveDefaultModel: true,
+        });
+        const refreshedAliasKeys = providerRefreshAliasKeys(
+          config,
+          nextConfig,
+          KIMI_CODE_PROVIDER_NAME,
+          `${KIMI_CODE_PLATFORM_ID}/`,
+        );
+        const beforeIds = collectModelIdsForAliases(config, refreshedAliasKeys);
+        const newIds = collectModelIdsForAliases(nextConfig, refreshedAliasKeys);
 
-        if (setsEqual(beforeIds, newIds)) {
+        if (providerModelsEqual(config, nextConfig, KIMI_CODE_PROVIDER_NAME, refreshedAliasKeys)) {
           unchanged.push(KIMI_CODE_PROVIDER_NAME);
         } else {
           const { added, removed } = computeChanges(beforeIds, newIds);
+          const previousDefaultModel = config.defaultModel;
+          const previousDefaultThinking = config.defaultThinking;
+          const userAliases = preserveUserProviderAliases(
+            config,
+            KIMI_CODE_PROVIDER_NAME,
+            refreshedAliasKeys,
+          );
           config = await host.removeProvider(KIMI_CODE_PROVIDER_NAME);
           clearManagedKimiCodeConfig(asManaged(config));
           applyManagedKimiCodeConfig(asManaged(config), {
@@ -147,6 +283,8 @@ export async function refreshAllProviderModels(host: RefreshProviderHost): Promi
             oauthHost: auth.oauthRef.oauthHost,
             preserveDefaultModel: true,
           });
+          restoreProviderAliases(config, userAliases);
+          restoreDefaultSelection(config, previousDefaultModel, previousDefaultThinking);
           await host.setConfig({
             providers: config.providers,
             models: config.models,
@@ -187,16 +325,33 @@ export async function refreshAllProviderModels(host: RefreshProviderHost): Promi
       models = filterModelsByPrefix(models, platform);
       if (models.length === 0) continue;
 
-      const beforeIds = collectModelIdsForProvider(config, providerId);
-      const newIds = new Set(models.map((m) => m.id));
+      const selectedModelId = pickDefaultModel(config, providerId, models);
+      const selectedModel = models.find((m) => m.id === selectedModelId);
+      if (selectedModel === undefined) continue;
+      const nextConfig = structuredClone(config);
+      applyOpenPlatformConfig(asManaged(nextConfig), {
+        platform,
+        models,
+        selectedModel,
+        thinking: false,
+        apiKey,
+      });
+      const refreshedAliasKeys = providerRefreshAliasKeys(
+        config,
+        nextConfig,
+        providerId,
+        `${providerId}/`,
+      );
+      const beforeIds = collectModelIdsForAliases(config, refreshedAliasKeys);
+      const newIds = collectModelIdsForAliases(nextConfig, refreshedAliasKeys);
 
-      if (setsEqual(beforeIds, newIds)) {
+      if (providerModelsEqual(config, nextConfig, providerId, refreshedAliasKeys)) {
         unchanged.push(providerId);
       } else {
         const { added, removed } = computeChanges(beforeIds, newIds);
-        const selectedModelId = pickDefaultModel(config, providerId, models);
-        const selectedModel = models.find((m) => m.id === selectedModelId);
-        if (selectedModel === undefined) continue;
+        const previousDefaultModel = config.defaultModel;
+        const previousDefaultThinking = config.defaultThinking;
+        const userAliases = preserveUserProviderAliases(config, providerId, refreshedAliasKeys);
 
         config = await host.removeProvider(providerId);
         removeOpenPlatformConfig(asManaged(config), providerId);
@@ -207,6 +362,8 @@ export async function refreshAllProviderModels(host: RefreshProviderHost): Promi
           thinking: false,
           apiKey,
         });
+        restoreProviderAliases(config, userAliases);
+        restoreDefaultSelection(config, previousDefaultModel, previousDefaultThinking);
         await host.setConfig({
           providers: config.providers,
           models: config.models,
@@ -249,23 +406,64 @@ export async function refreshAllProviderModels(host: RefreshProviderHost): Promi
   for (const { source, providerIds } of customSources.values()) {
     try {
       const entries = await fetchCustomRegistry(source);
-      let changedAny = false;
+      const changedProviders: Array<{
+        readonly providerId: string;
+        readonly entry: NonNullable<(typeof entries)[string]>;
+        readonly userAliases: Record<string, ModelAlias>;
+        readonly added: number;
+        readonly removed: number;
+      }> = [];
 
       for (const providerId of providerIds) {
         const entry = entries[providerId];
         if (entry === undefined) continue;
 
-        const beforeIds = collectModelIdsForProvider(config, providerId);
-        const newIds = new Set(Object.values(entry.models).map((m) => m.id));
+        const nextConfig = structuredClone(config);
+        applyCustomRegistryProvider(asManaged(nextConfig), entry, source);
+        const refreshedAliasKeys = providerRefreshAliasKeys(
+          config,
+          nextConfig,
+          providerId,
+          `${providerId}/`,
+        );
+        const beforeIds = collectModelIdsForAliases(config, refreshedAliasKeys);
+        const newIds = collectModelIdsForAliases(nextConfig, refreshedAliasKeys);
 
-        if (setsEqual(beforeIds, newIds)) {
+        if (providerModelsEqual(config, nextConfig, providerId, refreshedAliasKeys)) {
           unchanged.push(providerId);
         } else {
           const { added, removed } = computeChanges(beforeIds, newIds);
+          changedProviders.push({
+            providerId,
+            entry,
+            userAliases: preserveUserProviderAliases(config, providerId, refreshedAliasKeys),
+            added,
+            removed,
+          });
+        }
+      }
+
+      if (changedProviders.length > 0) {
+        const previousDefaultModel = config.defaultModel;
+        const previousDefaultThinking = config.defaultThinking;
+        for (const { providerId } of changedProviders) {
           config = await host.removeProvider(providerId);
           removeCustomRegistryProvider(asManaged(config), providerId);
+        }
+        for (const { entry } of changedProviders) {
           applyCustomRegistryProvider(asManaged(config), entry, source);
-          changedAny = true;
+        }
+        for (const { userAliases } of changedProviders) {
+          restoreProviderAliases(config, userAliases);
+        }
+        restoreDefaultSelection(config, previousDefaultModel, previousDefaultThinking);
+        await host.setConfig({
+          providers: config.providers,
+          models: config.models,
+          defaultModel: config.defaultModel,
+          defaultThinking: config.defaultThinking,
+        });
+        for (const { providerId, entry, added, removed } of changedProviders) {
           changed.push({
             providerId,
             providerName: entry.name || providerId,
@@ -273,13 +471,6 @@ export async function refreshAllProviderModels(host: RefreshProviderHost): Promi
             removed,
           });
         }
-      }
-
-      if (changedAny) {
-        await host.setConfig({
-          providers: config.providers,
-          models: config.models,
-        });
       }
     } catch (error) {
       for (const providerId of providerIds) {

--- a/apps/kimi-code/src/tui/utils/refresh-providers.ts
+++ b/apps/kimi-code/src/tui/utils/refresh-providers.ts
@@ -4,15 +4,12 @@ import {
   applyManagedKimiCodeConfig,
   applyOpenPlatformConfig,
   applyCustomRegistryProvider,
-  clearManagedKimiCodeConfig,
   fetchCustomRegistry,
   fetchManagedKimiCodeModels,
   fetchOpenPlatformModels,
   filterModelsByPrefix,
   getOpenPlatformById,
   isOpenPlatformId,
-  removeCustomRegistryProvider,
-  removeOpenPlatformConfig,
   resolveKimiCodeRuntimeAuth,
   type CustomRegistrySource,
   type ManagedKimiConfigShape,
@@ -91,14 +88,6 @@ function generatedProviderAliasKeys(
   return keys;
 }
 
-function unionSets<T>(...sets: ReadonlyArray<ReadonlySet<T>>): Set<T> {
-  const out = new Set<T>();
-  for (const set of sets) {
-    for (const value of set) out.add(value);
-  }
-  return out;
-}
-
 function computeChanges(oldIds: Set<string>, newIds: Set<string>): { added: number; removed: number } {
   let added = 0;
   for (const id of newIds) {
@@ -113,38 +102,33 @@ function computeChanges(oldIds: Set<string>, newIds: Set<string>): { added: numb
 
 interface ProviderModelSnapshot {
   readonly alias: string;
-  readonly provider: string;
-  readonly model: string;
-  readonly maxContextSize: number;
-  readonly maxOutputSize?: number;
-  readonly capabilities?: readonly string[];
-  readonly displayName?: string;
-  readonly reasoningKey?: string;
-  readonly adaptiveThinking?: boolean;
+  readonly model: ModelAlias;
 }
 
-function providerModelSnapshots(
+// Compare the full model metadata for the relevant aliases, not just model IDs:
+// a registry can change capabilities (e.g. enabling reasoning) without changing
+// any model ID. Spreading the whole `ModelAlias` keeps this in sync with the
+// schema automatically; only `capabilities` needs normalizing because its order
+// is not meaningful.
+function providerModelSnapshot(
   config: KimiConfig,
   providerId: string,
   aliasKeys: ReadonlySet<string>,
-): ProviderModelSnapshot[] {
+): string {
   const snapshots: ProviderModelSnapshot[] = [];
   for (const alias of aliasKeys) {
     const model = config.models?.[alias];
     if (model === undefined || model.provider !== providerId) continue;
     snapshots.push({
       alias,
-      provider: model.provider,
-      model: model.model,
-      maxContextSize: model.maxContextSize,
-      maxOutputSize: model.maxOutputSize,
-      capabilities: model.capabilities === undefined ? undefined : [...model.capabilities].sort(),
-      displayName: model.displayName,
-      reasoningKey: model.reasoningKey,
-      adaptiveThinking: model.adaptiveThinking,
+      model: {
+        ...model,
+        capabilities: model.capabilities === undefined ? undefined : model.capabilities.toSorted(),
+      },
     });
   }
-  return snapshots.sort((a, b) => a.alias.localeCompare(b.alias));
+  snapshots.sort((a, b) => a.alias.localeCompare(b.alias));
+  return JSON.stringify(snapshots);
 }
 
 function providerModelsEqual(
@@ -154,8 +138,8 @@ function providerModelsEqual(
   aliasKeys: ReadonlySet<string>,
 ): boolean {
   return (
-    JSON.stringify(providerModelSnapshots(config, providerId, aliasKeys)) ===
-    JSON.stringify(providerModelSnapshots(nextConfig, providerId, aliasKeys))
+    providerModelSnapshot(config, providerId, aliasKeys) ===
+    providerModelSnapshot(nextConfig, providerId, aliasKeys)
   );
 }
 
@@ -165,10 +149,9 @@ function providerRefreshAliasKeys(
   providerId: string,
   aliasPrefix: string,
 ): Set<string> {
-  return unionSets(
-    generatedProviderAliasKeys(config, providerId, aliasPrefix),
-    providerAliasKeys(nextConfig, providerId),
-  );
+  const keys = generatedProviderAliasKeys(config, providerId, aliasPrefix);
+  for (const key of providerAliasKeys(nextConfig, providerId)) keys.add(key);
+  return keys;
 }
 
 function preserveUserProviderAliases(
@@ -200,6 +183,17 @@ function restoreDefaultSelection(
   if (defaultModel === undefined || config.models?.[defaultModel] === undefined) return;
   config.defaultModel = defaultModel;
   config.defaultThinking = defaultThinking;
+}
+
+// `apply*` may leave `defaultModel` pointing at an alias that no longer exists
+// (e.g. the previously-selected model was dropped from the registry). The host's
+// `setConfig` deep-merge cannot clear a key, so the matching `removeProvider`
+// call handles disk cleanup while this drops the dangling reference in memory.
+function clampDanglingDefault(config: KimiConfig): void {
+  if (config.defaultModel !== undefined && config.models?.[config.defaultModel] === undefined) {
+    config.defaultModel = undefined;
+    config.defaultThinking = undefined;
+  }
 }
 
 function pickDefaultModel(config: KimiConfig, providerId: string, models: Array<{ id: string }>): string {
@@ -246,8 +240,8 @@ export async function refreshAllProviderModels(host: RefreshProviderHost): Promi
         baseUrl: auth.baseUrl,
       });
       if (models.length > 0) {
-        const nextConfig = structuredClone(config);
-        applyManagedKimiCodeConfig(asManaged(nextConfig), {
+        const next = structuredClone(config);
+        applyManagedKimiCodeConfig(asManaged(next), {
           models,
           baseUrl: auth.baseUrl,
           oauthKey: auth.oauthRef.key,
@@ -256,40 +250,30 @@ export async function refreshAllProviderModels(host: RefreshProviderHost): Promi
         });
         const refreshedAliasKeys = providerRefreshAliasKeys(
           config,
-          nextConfig,
+          next,
           KIMI_CODE_PROVIDER_NAME,
           `${KIMI_CODE_PLATFORM_ID}/`,
         );
-        const beforeIds = collectModelIdsForAliases(config, refreshedAliasKeys);
-        const newIds = collectModelIdsForAliases(nextConfig, refreshedAliasKeys);
+        restoreProviderAliases(
+          next,
+          preserveUserProviderAliases(config, KIMI_CODE_PROVIDER_NAME, refreshedAliasKeys),
+        );
+        restoreDefaultSelection(next, config.defaultModel, config.defaultThinking);
+        clampDanglingDefault(next);
 
-        if (providerModelsEqual(config, nextConfig, KIMI_CODE_PROVIDER_NAME, refreshedAliasKeys)) {
+        if (providerModelsEqual(config, next, KIMI_CODE_PROVIDER_NAME, refreshedAliasKeys)) {
           unchanged.push(KIMI_CODE_PROVIDER_NAME);
         } else {
-          const { added, removed } = computeChanges(beforeIds, newIds);
-          const previousDefaultModel = config.defaultModel;
-          const previousDefaultThinking = config.defaultThinking;
-          const userAliases = preserveUserProviderAliases(
-            config,
-            KIMI_CODE_PROVIDER_NAME,
-            refreshedAliasKeys,
+          const { added, removed } = computeChanges(
+            collectModelIdsForAliases(config, refreshedAliasKeys),
+            collectModelIdsForAliases(next, refreshedAliasKeys),
           );
-          config = await host.removeProvider(KIMI_CODE_PROVIDER_NAME);
-          clearManagedKimiCodeConfig(asManaged(config));
-          applyManagedKimiCodeConfig(asManaged(config), {
-            models,
-            baseUrl: auth.baseUrl,
-            oauthKey: auth.oauthRef.key,
-            oauthHost: auth.oauthRef.oauthHost,
-            preserveDefaultModel: true,
-          });
-          restoreProviderAliases(config, userAliases);
-          restoreDefaultSelection(config, previousDefaultModel, previousDefaultThinking);
-          await host.setConfig({
-            providers: config.providers,
-            models: config.models,
-            defaultModel: config.defaultModel,
-            defaultThinking: config.defaultThinking,
+          await host.removeProvider(KIMI_CODE_PROVIDER_NAME);
+          config = await host.setConfig({
+            providers: next.providers,
+            models: next.models,
+            defaultModel: next.defaultModel,
+            defaultThinking: next.defaultThinking,
           });
           changed.push({
             providerId: KIMI_CODE_PROVIDER_NAME,
@@ -328,8 +312,8 @@ export async function refreshAllProviderModels(host: RefreshProviderHost): Promi
       const selectedModelId = pickDefaultModel(config, providerId, models);
       const selectedModel = models.find((m) => m.id === selectedModelId);
       if (selectedModel === undefined) continue;
-      const nextConfig = structuredClone(config);
-      applyOpenPlatformConfig(asManaged(nextConfig), {
+      const next = structuredClone(config);
+      applyOpenPlatformConfig(asManaged(next), {
         platform,
         models,
         selectedModel,
@@ -338,37 +322,27 @@ export async function refreshAllProviderModels(host: RefreshProviderHost): Promi
       });
       const refreshedAliasKeys = providerRefreshAliasKeys(
         config,
-        nextConfig,
+        next,
         providerId,
         `${providerId}/`,
       );
-      const beforeIds = collectModelIdsForAliases(config, refreshedAliasKeys);
-      const newIds = collectModelIdsForAliases(nextConfig, refreshedAliasKeys);
+      restoreProviderAliases(next, preserveUserProviderAliases(config, providerId, refreshedAliasKeys));
+      restoreDefaultSelection(next, config.defaultModel, config.defaultThinking);
+      clampDanglingDefault(next);
 
-      if (providerModelsEqual(config, nextConfig, providerId, refreshedAliasKeys)) {
+      if (providerModelsEqual(config, next, providerId, refreshedAliasKeys)) {
         unchanged.push(providerId);
       } else {
-        const { added, removed } = computeChanges(beforeIds, newIds);
-        const previousDefaultModel = config.defaultModel;
-        const previousDefaultThinking = config.defaultThinking;
-        const userAliases = preserveUserProviderAliases(config, providerId, refreshedAliasKeys);
-
-        config = await host.removeProvider(providerId);
-        removeOpenPlatformConfig(asManaged(config), providerId);
-        applyOpenPlatformConfig(asManaged(config), {
-          platform,
-          models,
-          selectedModel,
-          thinking: false,
-          apiKey,
-        });
-        restoreProviderAliases(config, userAliases);
-        restoreDefaultSelection(config, previousDefaultModel, previousDefaultThinking);
-        await host.setConfig({
-          providers: config.providers,
-          models: config.models,
-          defaultModel: config.defaultModel,
-          defaultThinking: config.defaultThinking,
+        const { added, removed } = computeChanges(
+          collectModelIdsForAliases(config, refreshedAliasKeys),
+          collectModelIdsForAliases(next, refreshedAliasKeys),
+        );
+        await host.removeProvider(providerId);
+        config = await host.setConfig({
+          providers: next.providers,
+          models: next.models,
+          defaultModel: next.defaultModel,
+          defaultThinking: next.defaultThinking,
         });
         changed.push({
           providerId,
@@ -406,10 +380,13 @@ export async function refreshAllProviderModels(host: RefreshProviderHost): Promi
   for (const { source, providerIds } of customSources.values()) {
     try {
       const entries = await fetchCustomRegistry(source);
+      // Build the whole batch on one clone so that several changed providers
+      // from the same source do not overwrite each other's aliases, and so the
+      // config we compare is exactly the config we persist.
+      const next = structuredClone(config);
       const changedProviders: Array<{
         readonly providerId: string;
-        readonly entry: NonNullable<(typeof entries)[string]>;
-        readonly userAliases: Record<string, ModelAlias>;
+        readonly providerName: string;
         readonly added: number;
         readonly removed: number;
       }> = [];
@@ -418,25 +395,20 @@ export async function refreshAllProviderModels(host: RefreshProviderHost): Promi
         const entry = entries[providerId];
         if (entry === undefined) continue;
 
-        const nextConfig = structuredClone(config);
-        applyCustomRegistryProvider(asManaged(nextConfig), entry, source);
-        const refreshedAliasKeys = providerRefreshAliasKeys(
-          config,
-          nextConfig,
-          providerId,
-          `${providerId}/`,
-        );
-        const beforeIds = collectModelIdsForAliases(config, refreshedAliasKeys);
-        const newIds = collectModelIdsForAliases(nextConfig, refreshedAliasKeys);
+        applyCustomRegistryProvider(asManaged(next), entry, source);
+        const refreshedAliasKeys = providerRefreshAliasKeys(config, next, providerId, `${providerId}/`);
+        restoreProviderAliases(next, preserveUserProviderAliases(config, providerId, refreshedAliasKeys));
 
-        if (providerModelsEqual(config, nextConfig, providerId, refreshedAliasKeys)) {
+        if (providerModelsEqual(config, next, providerId, refreshedAliasKeys)) {
           unchanged.push(providerId);
         } else {
-          const { added, removed } = computeChanges(beforeIds, newIds);
+          const { added, removed } = computeChanges(
+            collectModelIdsForAliases(config, refreshedAliasKeys),
+            collectModelIdsForAliases(next, refreshedAliasKeys),
+          );
           changedProviders.push({
             providerId,
-            entry,
-            userAliases: preserveUserProviderAliases(config, providerId, refreshedAliasKeys),
+            providerName: entry.name || providerId,
             added,
             removed,
           });
@@ -444,32 +416,19 @@ export async function refreshAllProviderModels(host: RefreshProviderHost): Promi
       }
 
       if (changedProviders.length > 0) {
-        const previousDefaultModel = config.defaultModel;
-        const previousDefaultThinking = config.defaultThinking;
+        restoreDefaultSelection(next, config.defaultModel, config.defaultThinking);
+        clampDanglingDefault(next);
         for (const { providerId } of changedProviders) {
-          config = await host.removeProvider(providerId);
-          removeCustomRegistryProvider(asManaged(config), providerId);
+          await host.removeProvider(providerId);
         }
-        for (const { entry } of changedProviders) {
-          applyCustomRegistryProvider(asManaged(config), entry, source);
-        }
-        for (const { userAliases } of changedProviders) {
-          restoreProviderAliases(config, userAliases);
-        }
-        restoreDefaultSelection(config, previousDefaultModel, previousDefaultThinking);
-        await host.setConfig({
-          providers: config.providers,
-          models: config.models,
-          defaultModel: config.defaultModel,
-          defaultThinking: config.defaultThinking,
+        config = await host.setConfig({
+          providers: next.providers,
+          models: next.models,
+          defaultModel: next.defaultModel,
+          defaultThinking: next.defaultThinking,
         });
-        for (const { providerId, entry, added, removed } of changedProviders) {
-          changed.push({
-            providerId,
-            providerName: entry.name || providerId,
-            added,
-            removed,
-          });
+        for (const change of changedProviders) {
+          changed.push(change);
         }
       }
     } catch (error) {

--- a/apps/kimi-code/test/tui/utils/refresh-providers.test.ts
+++ b/apps/kimi-code/test/tui/utils/refresh-providers.test.ts
@@ -19,6 +19,37 @@ function fetchInputUrl(input: Parameters<typeof fetch>[0]): string {
   return input.url;
 }
 
+function makeRefreshHost(initial: KimiConfig): {
+  current: () => KimiConfig;
+  removeProvider: ReturnType<typeof vi.fn<(providerId: string) => Promise<KimiConfig>>>;
+  setConfig: ReturnType<typeof vi.fn<(patch: Partial<KimiConfig>) => Promise<KimiConfig>>>;
+} {
+  let persisted = structuredClone(initial);
+  const removeProvider = vi.fn(async (providerId: string) => {
+    const providers = { ...persisted.providers };
+    delete providers[providerId];
+    const models = { ...persisted.models };
+    let defaultRemoved = false;
+    for (const [alias, model] of Object.entries(models)) {
+      if (model.provider !== providerId) continue;
+      delete models[alias];
+      if (persisted.defaultModel === alias) defaultRemoved = true;
+    }
+    persisted = { ...persisted, providers, models };
+    if (defaultRemoved) persisted = { ...persisted, defaultModel: undefined };
+    return structuredClone(persisted);
+  });
+  const setConfig = vi.fn(async (patch: Partial<KimiConfig>) => {
+    persisted = { ...persisted, ...patch };
+    return structuredClone(persisted);
+  });
+  return {
+    current: () => structuredClone(persisted),
+    removeProvider,
+    setConfig,
+  };
+}
+
 describe('refreshAllProviderModels', () => {
   afterEach(() => {
     vi.unstubAllEnvs();
@@ -52,6 +83,7 @@ describe('refreshAllProviderModels', () => {
           provider: KIMI_CODE_PROVIDER_NAME,
           model: 'kimi-for-coding',
           maxContextSize: 262144,
+          capabilities: ['thinking', 'tool_use'],
         },
       },
       defaultModel: 'kimi-code/kimi-for-coding',
@@ -92,5 +124,222 @@ describe('refreshAllProviderModels', () => {
     expect(result.unchanged).toEqual([KIMI_CODE_PROVIDER_NAME]);
     expect(fetchMock).toHaveBeenCalledTimes(1);
     expect(resolveOAuthToken).toHaveBeenCalledWith(KIMI_CODE_PROVIDER_NAME, envOauthRef);
+  });
+
+  it('refreshes custom-registry model capabilities even when model ids are unchanged', async () => {
+    const registryUrl = 'https://registry.example.test/v1/models/api.json';
+    const providerId = 'example_chat-completions';
+    const siblingProviderId = 'example_messages';
+    const modelId = 'reasoner-pro';
+    const modelAlias = `${providerId}/${modelId}`;
+    const siblingModelAlias = `${siblingProviderId}/${modelId}`;
+    const userAlias = 'my-reasoner';
+    const userAliasModel = {
+      provider: providerId,
+      model: modelId,
+      maxContextSize: 262144,
+      capabilities: ['tool_use'],
+      displayName: 'My Reasoner',
+    };
+    const host = makeRefreshHost({
+      providers: {
+        [providerId]: {
+          type: 'openai',
+          baseUrl: 'https://api.example.test/v1',
+          apiKey: 'sk-test-token',
+          source: { kind: 'apiJson', url: registryUrl, apiKey: 'sk-test-token' },
+        },
+        [siblingProviderId]: {
+          type: 'anthropic',
+          baseUrl: 'https://messages.example.test',
+          apiKey: 'sk-test-token',
+          source: { kind: 'apiJson', url: registryUrl, apiKey: 'sk-test-token' },
+        },
+      },
+      models: {
+        [modelAlias]: {
+          provider: providerId,
+          model: modelId,
+          maxContextSize: 262144,
+          capabilities: ['tool_use'],
+          displayName: 'Reasoner Pro',
+        },
+        [siblingModelAlias]: {
+          provider: siblingProviderId,
+          model: modelId,
+          maxContextSize: 262144,
+          capabilities: ['tool_use'],
+          displayName: 'Reasoner Pro',
+        },
+        [userAlias]: userAliasModel,
+      },
+      defaultModel: modelAlias,
+      telemetry: true,
+    } as unknown as KimiConfig);
+
+    const fetchMock = vi.fn<FetchMock>(async (input, init) => {
+      expect(fetchInputUrl(input)).toBe(registryUrl);
+      expect(new Headers(init?.headers).get('authorization')).toBe('Bearer sk-test-token');
+      return new Response(
+        JSON.stringify({
+          [providerId]: {
+            id: providerId,
+            name: 'Example Chat Completions',
+            api: 'https://api.example.test/v1',
+            type: 'openai',
+            models: {
+              [modelId]: {
+                id: modelId,
+                name: 'Reasoner Pro',
+                limit: { context: 262144, output: 262144 },
+                tool_call: true,
+                reasoning: true,
+                modalities: { input: ['text', 'image', 'video'], output: ['text'] },
+              },
+            },
+          },
+          [siblingProviderId]: {
+            id: siblingProviderId,
+            name: 'Example Messages',
+            api: 'https://messages.example.test',
+            type: 'anthropic',
+            models: {
+              [modelId]: {
+                id: modelId,
+                name: 'Reasoner Pro',
+                limit: { context: 262144, output: 262144 },
+                tool_call: true,
+                reasoning: true,
+                modalities: { input: ['text', 'image', 'video'], output: ['text'] },
+              },
+            },
+          },
+        }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } },
+      );
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await refreshAllProviderModels({
+      getConfig: async () => host.current(),
+      removeProvider: host.removeProvider,
+      setConfig: host.setConfig,
+      resolveOAuthToken: vi.fn(),
+    });
+
+    expect(result.failed).toEqual([]);
+    expect(result.unchanged).toEqual([]);
+    expect(result.changed).toEqual([
+      {
+        providerId,
+        providerName: 'Example Chat Completions',
+        added: 0,
+        removed: 0,
+      },
+      {
+        providerId: siblingProviderId,
+        providerName: 'Example Messages',
+        added: 0,
+        removed: 0,
+      },
+    ]);
+    expect(host.removeProvider).toHaveBeenCalledWith(providerId);
+    expect(host.removeProvider).toHaveBeenCalledWith(siblingProviderId);
+    expect(host.setConfig).toHaveBeenCalledTimes(1);
+    expect(host.current().models?.[modelAlias]?.capabilities).toEqual([
+      'tool_use',
+      'thinking',
+      'image_in',
+      'video_in',
+    ]);
+    expect(host.current().models?.[siblingModelAlias]?.capabilities).toEqual([
+      'tool_use',
+      'thinking',
+      'image_in',
+      'video_in',
+    ]);
+    expect(host.current().models?.[userAlias]).toEqual(userAliasModel);
+  });
+
+  it('ignores user-defined aliases when custom-registry metadata is unchanged', async () => {
+    const registryUrl = 'https://registry.example.test/v1/models/api.json';
+    const providerId = 'example_chat-completions';
+    const modelId = 'reasoner-pro';
+    const modelAlias = `${providerId}/${modelId}`;
+    const userAlias = 'my-reasoner';
+    const richCapabilities = ['tool_use', 'thinking', 'image_in'];
+    const userAliasModel = {
+      provider: providerId,
+      model: modelId,
+      maxContextSize: 262144,
+      capabilities: ['tool_use'],
+      displayName: 'My Reasoner',
+    };
+    const host = makeRefreshHost({
+      providers: {
+        [providerId]: {
+          type: 'openai',
+          baseUrl: 'https://api.example.test/v1',
+          apiKey: 'sk-test-token',
+          source: { kind: 'apiJson', url: registryUrl, apiKey: 'sk-test-token' },
+        },
+      },
+      models: {
+        [modelAlias]: {
+          provider: providerId,
+          model: modelId,
+          maxContextSize: 262144,
+          capabilities: richCapabilities,
+          displayName: 'Reasoner Pro',
+        },
+        [userAlias]: userAliasModel,
+      },
+      defaultModel: userAlias,
+      defaultThinking: false,
+      telemetry: true,
+    } as unknown as KimiConfig);
+
+    const fetchMock = vi.fn<FetchMock>(async (input, init) => {
+      expect(fetchInputUrl(input)).toBe(registryUrl);
+      expect(new Headers(init?.headers).get('authorization')).toBe('Bearer sk-test-token');
+      return new Response(
+        JSON.stringify({
+          [providerId]: {
+            id: providerId,
+            name: 'Example Chat Completions',
+            api: 'https://api.example.test/v1',
+            type: 'openai',
+            models: {
+              [modelId]: {
+                id: modelId,
+                name: 'Reasoner Pro',
+                limit: { context: 262144, output: 262144 },
+                tool_call: true,
+                reasoning: true,
+                modalities: { input: ['text', 'image'], output: ['text'] },
+              },
+            },
+          },
+        }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } },
+      );
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await refreshAllProviderModels({
+      getConfig: async () => host.current(),
+      removeProvider: host.removeProvider,
+      setConfig: host.setConfig,
+      resolveOAuthToken: vi.fn(),
+    });
+
+    expect(result.failed).toEqual([]);
+    expect(result.changed).toEqual([]);
+    expect(result.unchanged).toEqual([providerId]);
+    expect(host.removeProvider).not.toHaveBeenCalled();
+    expect(host.setConfig).not.toHaveBeenCalled();
+    expect(host.current().models?.[userAlias]).toEqual(userAliasModel);
+    expect(host.current().defaultModel).toBe(userAlias);
+    expect(host.current().defaultThinking).toBe(false);
   });
 });


### PR DESCRIPTION
## Related Issue

No linked issue. This fixes a reported custom-registry provider metadata refresh bug.

## Problem

Custom-registry providers were treated as unchanged when the remote model IDs stayed the same. If the registry later changed model metadata, such as enabling reasoning support, the local model alias capabilities were not refreshed, so the model selector could still show thinking as unsupported.

## What changed

Provider refresh now compares the full local model metadata snapshot against the refreshed metadata instead of checking only model IDs. Custom-registry refreshes also apply multiple changed providers from the same source in one batch so their aliases do not overwrite each other.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.

## Verification

- `pnpm -C apps/kimi-code exec vitest run test/tui/utils/refresh-providers.test.ts test/tui/components/dialogs/model-selector.test.ts test/tui/components/dialogs/tabbed-model-selector.test.ts test/cli/provider.test.ts`
- `pnpm -C apps/kimi-code run typecheck`
- `git diff --check`