### PR TITLE
fix: preserve thinking during compaction

### DIFF
--- a/.changeset/preserve-compaction-thinking.md
+++ b/.changeset/preserve-compaction-thinking.md
@@ -1,0 +1,6 @@
+---
+"@moonshot-ai/agent-core": patch
+"@moonshot-ai/kimi-code": patch
+---
+
+Preserve thinking effort when compacting long conversations.

--- a/packages/agent-core/src/agent/config/index.ts
+++ b/packages/agent-core/src/agent/config/index.ts
@@ -97,7 +97,7 @@ export class ConfigState {
   }
 
   get provider(): ChatProvider {
-    return createProvider(this.providerConfig);
+    return createProvider(this.providerConfig).withThinking(this.thinkingLevel);
   }
 
   get model(): string {

--- a/packages/agent-core/src/agent/index.ts
+++ b/packages/agent-core/src/agent/index.ts
@@ -210,7 +210,7 @@ export class Agent {
 
   get llm(): KosongLLM {
     const model = this.config.model;
-    const provider = this.config.provider.withThinking(this.config.thinkingLevel);
+    const provider = this.config.provider;
     const loopControl = this.kimiConfig?.loopControl;
     const completionBudgetConfig = resolveCompletionBudget({
       maxOutputSize: this.config.maxOutputSize,

--- a/packages/agent-core/test/agent/compaction/full.test.ts
+++ b/packages/agent-core/test/agent/compaction/full.test.ts
@@ -1416,6 +1416,47 @@ describe('FullCompaction', () => {
     await ctx.expectResumeMatches();
   });
 
+  it('preserves thinking effort when compacting after provider context overflow', async () => {
+    let callCount = 0;
+    const providerThinkingEfforts: Array<Parameters<GenerateFn>[0]['thinkingEffort']> = [];
+    const generate: GenerateFn = async (provider, _system, _tools, _history, callbacks) => {
+      callCount += 1;
+      providerThinkingEfforts.push(provider.thinkingEffort);
+      if (callCount === 1) {
+        throw new APIContextOverflowError(
+          400,
+          'Context length exceeded',
+          'req-thinking-context-overflow',
+        );
+      }
+      if (callCount === 2) {
+        return textResult('Thinking compacted summary.');
+      }
+      if (callCount === 3) {
+        await callbacks?.onMessagePart?.({
+          type: 'text',
+          text: 'Recovered after thinking compaction.',
+        });
+        return textResult('Recovered after thinking compaction.');
+      }
+      throw new Error(`Unexpected generate call ${String(callCount)}`);
+    };
+    const ctx = testAgent({ generate });
+    ctx.configure({
+      provider: CATALOGUED_PROVIDER,
+      modelCapabilities: CATALOGUED_MODEL_CAPABILITIES,
+    });
+    ctx.agent.config.update({ thinkingLevel: 'high' });
+    ctx.appendExchange(1, 'old user one', 'old assistant one', 20);
+    ctx.newEvents();
+
+    await ctx.rpc.prompt({ input: [{ type: 'text', text: 'Retry with thinking preserved' }] });
+    await ctx.untilTurnEnd();
+
+    expect(callCount).toBe(3);
+    expect(providerThinkingEfforts).toEqual(['high', 'high', 'high']);
+  });
+
   it('compacts provider overflow when model context size is unknown', async () => {
     let callCount = 0;
     const compactionMaxCompletionTokens: unknown[] = [];


### PR DESCRIPTION
## Related Issue

No linked issue. This fixes a focused compaction regression found during development.

## Problem

Full-context compaction could rebuild a provider without the active thinking effort, so the summarization request for long conversations did not preserve the session's thinking setting.

## What changed

The agent config provider getter now applies the resolved thinking effort at the point where providers are created. The main LLM path now consumes that normalized provider directly, and full compaction inherits the same provider state when retrying after context overflow. A regression test covers context-overflow compaction with thinking enabled and asserts every generate call keeps `high` thinking.

## Verification

- `pnpm --filter @moonshot-ai/agent-core test -- test/agent/compaction/full.test.ts`
- `pnpm --filter @moonshot-ai/agent-core typecheck`
- Read-only diff audit for context-specific internal identifiers: no issues found.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.
