### PR TITLE
docs: clarify agent record resume contract

### DIFF
--- a/packages/agent-core/src/agent/records/index.ts
+++ b/packages/agent-core/src/agent/records/index.ts
@@ -19,9 +19,16 @@ export type { FileSystemAgentRecordPersistenceOptions } from './persistence';
 export { BlobStore, isBlobRef } from './blobref';
 export type { BlobStoreOptions } from './blobref';
 
-// Contract: restore MUST NOT emit UI events, call the LLM, execute tools, or
-// touch the filesystem in a way that triggers external side effects. Each case
-// should reproduce the in-memory state the live handler left behind, nothing more.
+// Contract: restore MUST only rebuild in-memory state. It must not emit UI
+// events, call the LLM, execute tools, start background work, make network
+// requests, or touch the filesystem in a way that triggers external side effects.
+//
+// Prefer restoring by calling the same method that wrote the record, so live
+// execution and resume share one state mutation path. For example,
+// permission.set_mode replays through agent.permission.setMode(input.mode),
+// not by assigning modeOverride here. records.logRecord, emitEvent, and
+// emitStatusUpdated already gate on records.restoring, so those calls are safe
+// during resume.
 function restoreAgentRecord(agent: Agent, input: AgentRecord): void {
   switch (input.type) {
     case 'metadata':
@@ -95,8 +102,9 @@ function restoreAgentRecord(agent: Agent, input: AgentRecord): void {
     case 'tools.update_store':
       agent.tools.updateStore(input.key, input.value);
       return;
-    // Goal records are an audit trail only. Goal state is restored from
-    // `state.json` (metadata.custom.goal), never rebuilt from these records.
+    // TODO: Move goal state transitions to real resume semantics. These records
+    // are currently audit-only, while goal state is restored from `state.json`
+    // (metadata.custom.goal) instead of being rebuilt from ordered records.
     case 'goal.create':
     case 'goal.update':
     case 'goal.account_usage':

--- a/packages/agent-core/src/agent/records/types.ts
+++ b/packages/agent-core/src/agent/records/types.ts
@@ -10,6 +10,10 @@ import type { PermissionApprovalResultRecord, PermissionMode } from '../permissi
 import type { UserToolRegistration } from '../tool';
 import type { UsageRecordScope } from '../usage';
 
+// Agent records are the ordered event log used to rebuild agent state on resume.
+// Use records, not state.json, when correctness depends on the order in which
+// state transitions happened. Each persisted record type must have explicit
+// resume semantics in restoreAgentRecord; a write-only record is not persistence.
 export interface AgentRecordEvents {
   metadata: {
     protocol_version: string;


### PR DESCRIPTION
## Related Issue

No linked issue. This PR clarifies the persistence contract around agent records and resume behavior.

## Problem

Agent records are used as ordered persistence for resume, but the code comments did not clearly state the rules for when to use records, how each record should restore state, and why restore paths may call the same functions used by live execution.

## What changed

Clarified the `AgentRecordEvents` contract to use records for ordered state transitions and require resume semantics for persisted record types.

Expanded the `restoreAgentRecord` contract to state that resume must only rebuild in-memory state, should prefer reusing the same state mutation methods as live execution, and can safely pass through guarded `records.logRecord`, `emitEvent`, and `emitStatusUpdated` calls.

Added a TODO on the current `goal.*` audit-only records to move them toward real ordered-record resume semantics.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works. Comment-only change; no tests added.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset. Comment-only change; no changeset needed.
- [x] Ran `gen-docs` skill, or this PR needs no doc update. Internal code comment change; no user docs needed.
