### PR TITLE
docs: fix Bash timeout unit and document background cap

### DIFF
--- a/docs/en/reference/tools.md
+++ b/docs/en/reference/tools.md
@@ -39,8 +39,8 @@ File tools handle reading, writing, and searching the local filesystem — the f
 
 - `command` (required): the shell command to execute
 - `cwd`: working directory
-- `timeout`: timeout in milliseconds; foreground default is 60 seconds, maximum is 5 minutes
-- `run_in_background`: whether to run as a background task; background tasks default to a 10-minute timeout
+- `timeout`: timeout in seconds; foreground default is 60 seconds, maximum is 5 minutes
+- `run_in_background`: whether to run as a background task; background tasks default to a 10-minute timeout, maximum is 24 hours
 - `description`: background task description; required when `run_in_background=true`
 - `disable_timeout`: whether to remove the timeout limit for background tasks
 

--- a/docs/zh/reference/tools.md
+++ b/docs/zh/reference/tools.md
@@ -39,8 +39,8 @@
 
 - `command`（必填）：要执行的 Shell 命令
 - `cwd`：工作目录
-- `timeout`：超时时间（毫秒）；前台默认 60 秒、最长 5 分钟
-- `run_in_background`：是否以后台任务运行；后台默认 10 分钟超时
+- `timeout`：超时时间（秒）；前台默认 60 秒、最长 5 分钟
+- `run_in_background`：是否以后台任务运行；后台默认 10 分钟超时、最长 24 小时
 - `description`：后台任务描述，`run_in_background=true` 时必填
 - `disable_timeout`：后台任务是否取消超时限制
 


### PR DESCRIPTION
## Related Issue

No issue — this is a documentation-only fix, which CONTRIBUTING.md allows to be opened directly.

## Problem

The Built-in Tools reference describes the `Bash` `timeout` parameter as **milliseconds**, but the implementation uses **seconds** (`bash.ts`: `DEFAULT_TIMEOUT_S = 60`, `MAX_TIMEOUT_S = 5 * 60`; the param description and `bash.md` both say "in seconds"). The docs also omit the background timeout maximum of 24h (`MAX_BACKGROUND_TIMEOUT_S = 24 * 60 * 60` = 86400s).

This affects both `docs/en/reference/tools.md` and `docs/zh/reference/tools.md`.

## What changed

- Fixed the `timeout` unit from "milliseconds" → "seconds" (en) / "毫秒" → "秒" (zh).
- Documented the background timeout maximum of 24 hours (matches `MAX_BACKGROUND_TIMEOUT_S`).

No code/behavior change.

Local verification:

```text
$ pnpm --filter kimi-code-docs build
(!) Some chunks are larger than 500 kB after minification. Consider:
- Using dynamic import() to code-split the application
- Use build.rollupOptions.output.manualChunks to improve chunking: https://rollupjs.org/configuration-options/#output-manualchunks
- Adjust chunk size limit for this warning via build.chunkSizeWarningLimit.
✓ building client + server bundles...
- rendering pages...
✓ rendering pages...
build complete in 7.42s.
```

## Checklist

- [x] I have read the CONTRIBUTING document.
- [x] No related issue — documentation-only change (allowed to open directly).
- [ ] Tests — N/A, documentation-only change.
- [x] No changeset needed (docs-only).
- [x] Docs updated directly in this PR.
