### PR TITLE
feat(skills): add experimental sub-skill discovery

### DIFF
--- a/.changeset/add-sub-skill.md
+++ b/.changeset/add-sub-skill.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/agent-core": minor
+"@moonshot-ai/kimi-code": minor
+---
+Add experimental sub-skill discovery gated by the `KIMI_CODE_EXPERIMENTAL_SUB_SKILL` environment variable. Ships the `sub-skill` builtin bundle (`sub-skill.review`, `sub-skill.consolidate`) for inventorying and consolidating skills into hierarchical groups.

--- a/apps/kimi-code/test/tui/commands/skills.test.ts
+++ b/apps/kimi-code/test/tui/commands/skills.test.ts
@@ -30,18 +30,32 @@ describe('skill slash commands', () => {
   it('builds slash commands and command map entries with skill prefixes', () => {
     const built = buildSkillSlashCommands([
       skill('review', 'prompt'),
+      skill('nested-review', 'prompt', {
+        description: 'Nested review skill',
+        path: '/skills/parent/nested-review/SKILL.md',
+      }),
       skill('agent-only', 'agent'),
       skill('commit', 'flow'),
     ]);
 
-    expect(built.commands.map((command) => command.name)).toEqual(['skill:review', 'skill:commit']);
+    expect(built.commands.map((command) => command.name)).toEqual([
+      'skill:review',
+      'skill:nested-review',
+      'skill:commit',
+    ]);
     expect(built.commands[0]).toMatchObject({
       name: 'skill:review',
       aliases: [],
       description: 'review skill',
     });
+    expect(built.commands[1]).toMatchObject({
+      name: 'skill:nested-review',
+      aliases: [],
+      description: 'Nested review skill',
+    });
     expect([...built.commandMap.entries()]).toEqual([
       ['skill:review', 'review'],
+      ['skill:nested-review', 'nested-review'],
       ['skill:commit', 'commit'],
     ]);
   });

--- a/packages/agent-core/src/flags/registry.ts
+++ b/packages/agent-core/src/flags/registry.ts
@@ -36,6 +36,14 @@ export const FLAG_DEFINITIONS = [
     default: false,
     surface: 'core',
   },
+  {
+    id: 'sub-skill',
+    title: 'Sub-skill',
+    description: 'Enable discovery of nested skills inside skill bundles that declare has-sub-skill.',
+    env: 'KIMI_CODE_EXPERIMENTAL_SUB_SKILL',
+    default: false,
+    surface: 'core',
+  },
 ] as const satisfies readonly FlagDefinitionInput[];
 
 /** Literal union of registered flag ids. */

--- a/packages/agent-core/src/session/index.ts
+++ b/packages/agent-core/src/session/index.ts
@@ -166,7 +166,10 @@ export class Session {
       },
       telemetry: this.telemetry,
     });
-    this.skills = new SkillRegistry({ sessionId: options.id });
+    this.skills = new SkillRegistry({
+      sessionId: options.id,
+      experimentalFlags: this.experimentalFlags,
+    });
     this.mcp = new McpConnectionManager({
       oauthService: new McpOAuthService({ kimiHomeDir: options.kimiHomeDir }),
       log: this.log,
@@ -402,7 +405,7 @@ export class Session {
       builtinDir: this.options.skills?.builtinDir,
     });
     await this.skills.loadRoots(roots);
-    registerBuiltinSkills(this.skills);
+    registerBuiltinSkills(this.skills, { experimentalFlags: this.experimentalFlags });
   }
 
   private async loadMcpServers(): Promise<void> {

--- a/packages/agent-core/src/skill/builtin/index.ts
+++ b/packages/agent-core/src/skill/builtin/index.ts
@@ -1,10 +1,35 @@
+import { flags } from '../../flags/resolver';
 import type { SkillRegistry } from '../registry';
 import { MCP_CONFIG_SKILL } from './mcp-config';
+import {
+  SUB_SKILL_CONSOLIDATE,
+  SUB_SKILL_PARENT,
+  SUB_SKILL_REVIEW,
+} from './sub-skill';
 import { UPDATE_CONFIG_SKILL } from './update-config';
 
-export function registerBuiltinSkills(registry: SkillRegistry): void {
+type SubSkillFlagResolver = {
+  enabled(id: 'sub-skill'): boolean;
+};
+
+export function registerBuiltinSkills(
+  registry: SkillRegistry,
+  options: { readonly experimentalFlags?: SubSkillFlagResolver } = {},
+): void {
+  const experimentalFlags = options.experimentalFlags ?? flags;
   registry.registerBuiltinSkill(MCP_CONFIG_SKILL);
   registry.registerBuiltinSkill(UPDATE_CONFIG_SKILL);
+  if (experimentalFlags.enabled('sub-skill')) {
+    registry.registerBuiltinSkill(SUB_SKILL_PARENT);
+    registry.registerBuiltinSkill(SUB_SKILL_REVIEW);
+    registry.registerBuiltinSkill(SUB_SKILL_CONSOLIDATE);
+  }
 }
 
-export { MCP_CONFIG_SKILL, UPDATE_CONFIG_SKILL };
+export {
+  MCP_CONFIG_SKILL,
+  SUB_SKILL_CONSOLIDATE,
+  SUB_SKILL_PARENT,
+  SUB_SKILL_REVIEW,
+  UPDATE_CONFIG_SKILL,
+};

--- a/packages/agent-core/src/skill/builtin/sub-skill.ts
+++ b/packages/agent-core/src/skill/builtin/sub-skill.ts
@@ -1,0 +1,50 @@
+import { parseSkillText } from '../parser';
+import type { SkillDefinition } from '../types';
+import CONSOLIDATE_BODY from './sub-skill/consolidate/SKILL.md';
+import REVIEW_BODY from './sub-skill/review/SKILL.md';
+import PARENT_BODY from './sub-skill/SKILL.md';
+
+function makeBuiltin(
+  body: string,
+  dirName: string,
+  pseudoPath: string,
+  extraMetadata: Record<string, unknown> = {},
+): SkillDefinition {
+  const parsed = parseSkillText({
+    skillMdPath: `/builtin/skills/${dirName}/SKILL.md`,
+    skillDirName: dirName,
+    source: 'builtin',
+    text: body,
+  });
+  return {
+    ...parsed,
+    path: pseudoPath,
+    dir: pseudoPath,
+    metadata: {
+      ...parsed.metadata,
+      type: parsed.metadata.type ?? 'inline',
+      ...extraMetadata,
+    },
+  };
+}
+
+export const SUB_SKILL_PARENT = makeBuiltin(
+  PARENT_BODY,
+  'sub-skill',
+  'builtin://sub-skill',
+  { disableModelInvocation: true, 'has-sub-skill': true },
+);
+
+export const SUB_SKILL_REVIEW = makeBuiltin(
+  REVIEW_BODY,
+  'sub-skill.review',
+  'builtin://sub-skill/review',
+  { disableModelInvocation: true },
+);
+
+export const SUB_SKILL_CONSOLIDATE = makeBuiltin(
+  CONSOLIDATE_BODY,
+  'sub-skill.consolidate',
+  'builtin://sub-skill/consolidate',
+  { disableModelInvocation: true },
+);

--- a/packages/agent-core/src/skill/builtin/sub-skill/SKILL.md
+++ b/packages/agent-core/src/skill/builtin/sub-skill/SKILL.md
@@ -1,0 +1,23 @@
+---
+name: sub-skill
+description: Discover and reorganize the skill inventory into hierarchical sub-skill bundles. Use when the user asks to review, group, or consolidate skills into a parent bundle.
+disable-model-invocation: true
+has-sub-skill: true
+---
+
+# Sub-skill
+
+Container skill for analyzing the local skill inventory and reorganizing it into hierarchical sub-skill bundles (`has-sub-skill: true` parents with children inside).
+
+## When to use
+
+- The user asks to review, reorganize, or consolidate skills.
+- There are many loosely-related skills that might benefit from hierarchical grouping.
+- The user wants to evaluate whether a new skill should be a sub-skill of an existing one.
+
+## Sub-skills
+
+- **`sub-skill.review`** — Analyze the current inventory and propose candidate sub-skill groupings.
+- **`sub-skill.consolidate`** — Apply an approved grouping by moving skills into a parent bundle, with timestamped backups.
+
+The usual flow is `sub-skill.review` first (read-only proposal), then `sub-skill.consolidate` after the user approves a plan. Never run consolidate without an explicit go-ahead from the user.

--- a/packages/agent-core/src/skill/builtin/sub-skill/consolidate/SKILL.md
+++ b/packages/agent-core/src/skill/builtin/sub-skill/consolidate/SKILL.md
@@ -1,0 +1,38 @@
+---
+name: sub-skill.consolidate
+description: Apply an approved sub-skill grouping by moving user-specified skills into a parent bundle, with timestamped backups of every modified directory.
+disable-model-invocation: true
+---
+
+# Consolidate sub-skills (`sub-skill.consolidate`)
+
+Execute the reorganization by moving user-specified skills into a parent bundle, forming a sub-skill hierarchy.
+
+## When to use
+
+- The user has approved a grouping proposal (typically from `sub-skill.review`) and wants to apply it.
+- Migrating standalone skills into a new or existing parent bundle.
+
+## Process
+
+1. **Confirm the plan.** Restate which skills will move and where, and ask the user to confirm **before** making any file changes.
+2. **Back up every original skill directory.** Before moving anything, create a timestamped backup of each skill directory that will be modified.
+   - For a skill at `<root>/<skill-name>/SKILL.md`, back up the entire `<skill-name>` directory:
+     ```bash
+     cp -r <skill-name> "<skill-name>.$(date +%Y%m%d-%H%M%S).bak"
+     ```
+   - Keep all backups; never overwrite an existing backup file.
+3. **Create or update the parent bundle.**
+   - If the parent does not exist, create `<parent-name>/SKILL.md` with `has-sub-skill: true` in the frontmatter.
+   - If the parent already exists, ensure its frontmatter includes `has-sub-skill: true`.
+4. **Move child skills into the parent.** Move each child skill's entire directory under the parent bundle.
+   - Example: `web-search/` → `web-research/web-search/`
+5. **Verify the result.** List the new directory structure and confirm each moved skill still has a valid `SKILL.md` with required frontmatter (`name` and `description`).
+6. **Report the change.** Summarize what was moved, the new structure, and where backups are located.
+
+## Don'ts
+
+- **Never move skills without backing up first.**
+- **Never overwrite an existing backup** — always use a fresh timestamped suffix.
+- **Don't drop frontmatter or payload files** during the move; the entire directory must be preserved.
+- **Don't create deeply nested hierarchies** (3+ levels) unless the user explicitly requests it.

--- a/packages/agent-core/src/skill/builtin/sub-skill/review/SKILL.md
+++ b/packages/agent-core/src/skill/builtin/sub-skill/review/SKILL.md
@@ -1,0 +1,45 @@
+---
+name: sub-skill.review
+description: Analyze the available skill set and recommend candidate groups that could be consolidated into sub-skill bundles. Read-only — proposes a plan, does not move files.
+disable-model-invocation: true
+---
+
+# Review sub-skills (`sub-skill.review`)
+
+Analyze the current skill inventory and identify candidate groups that could be consolidated into sub-skill bundles. This sub-skill is **read-only**: it produces a proposal for the user to review before any file changes are made by `sub-skill.consolidate`.
+
+## When to use
+
+- The user asks to review, reorganize, or audit the skill inventory.
+- There are many loosely-related skills that might benefit from hierarchical grouping.
+- The user wants to evaluate whether a new skill should be a sub-skill of an existing parent.
+
+## Process
+
+1. **List the current inventory.** Use the skill registry (or scan the configured skill roots) to get a full list of skill names, descriptions, and source scopes.
+2. **Categorize by domain.** Group skills by functional domain — e.g. file operations, web tools, collaboration, observability.
+3. **Detect coupling.** Identify skills that are frequently used together or share similar `whenToUse` conditions.
+4. **Flag granularity issues.** Call out skills that are too fine-grained (e.g. one skill per CLI flag) or too broad to land in any single domain.
+5. **Propose sub-skill structures.** For each candidate group, list:
+   - The parent skill name and a one-line description.
+   - The children that should move under it.
+   - Whether the parent needs `has-sub-skill: true` (it does, if children should be discovered).
+6. **Output a summary report.** Present findings as a concise grouped list with rationale, and stop. Do **not** edit any file — that's `sub-skill.consolidate`'s job.
+
+## Criteria for a good sub-skill grouping
+
+- **Shared context.** Children operate within the same domain or workflow.
+- **Composable entry point.** The parent gives a natural top-level handle; children handle specifics.
+- **Shallow nesting.** Prefer 2 levels (parent → child). Avoid 3+ unless strictly necessary.
+- **Backward compatibility.** Existing skill names should ideally remain discoverable.
+
+## Example output format
+
+```
+Proposed sub-skill: web-research
+  - Parent: web-research (has-sub-skill: true)
+  - Children:
+    - web-search    → move under web-research/search
+    - fetch-url     → move under web-research/fetch
+  - Rationale: Both deal with online information retrieval and are often chained together.
+```

--- a/packages/agent-core/src/skill/registry.ts
+++ b/packages/agent-core/src/skill/registry.ts
@@ -1,3 +1,4 @@
+import { flags } from '../flags/resolver';
 import { expandSkillParameters, skillArgumentNames } from './parser';
 import { discoverSkills, type DiscoverSkillsOptions } from './scanner';
 import type { SkillDefinition, SkillRoot, SkillSource, SkippedSkill } from './types';
@@ -5,6 +6,10 @@ import { isInlineSkillType, normalizeSkillName } from './types';
 import { escapeXmlAttr } from '../utils/xml-escape';
 
 const LISTING_DESC_MAX = 250;
+
+type SubSkillFlagResolver = {
+  enabled(id: 'sub-skill'): boolean;
+};
 
 export class SkillNotFoundError extends Error {
   readonly skillName: string;
@@ -18,6 +23,7 @@ export class SkillNotFoundError extends Error {
 
 export interface SkillRegistryOptions {
   readonly discover?: typeof discoverSkills;
+  readonly experimentalFlags?: SubSkillFlagResolver;
   readonly onWarning?: (message: string, cause?: unknown) => void;
   readonly sessionId?: string;
 }
@@ -28,11 +34,13 @@ export class SkillRegistry {
   private readonly roots: string[] = [];
   private readonly skipped: SkippedSkill[] = [];
   private readonly discoverImpl: typeof discoverSkills;
+  private readonly experimentalFlags: SubSkillFlagResolver;
   private readonly onWarning: (message: string, cause?: unknown) => void;
   readonly sessionId?: string;
 
   constructor(options: SkillRegistryOptions = {}) {
     this.discoverImpl = options.discover ?? discoverSkills;
+    this.experimentalFlags = options.experimentalFlags ?? flags;
     this.onWarning = options.onWarning ?? (() => {});
     this.sessionId = options.sessionId;
   }
@@ -44,6 +52,7 @@ export class SkillRegistry {
 
     const skills = await this.discoverImpl({
       roots,
+      experimentalFlags: this.experimentalFlags,
       onWarning: this.onWarning,
       onSkippedByPolicy: (skill) => this.skipped.push(skill),
       onDiscoveredSkill: (skill) => {

--- a/packages/agent-core/src/skill/scanner.ts
+++ b/packages/agent-core/src/skill/scanner.ts
@@ -1,6 +1,7 @@
 import { promises as fs } from 'node:fs';
 import path from 'pathe';
 
+import { flags } from '../flags/resolver';
 import { SkillParseError, UnsupportedSkillTypeError, parseSkillFromFile } from './parser';
 import type { SkillDefinition, SkillRoot, SkillSource, SkippedSkill } from './types';
 import { normalizeSkillName } from './types';
@@ -9,6 +10,10 @@ const USER_BRAND_DIRS = ['.kimi-code/skills'] as const;
 const USER_GENERIC_DIRS = ['.agents/skills'] as const;
 const PROJECT_BRAND_DIRS = ['.kimi-code/skills'] as const;
 const PROJECT_GENERIC_DIRS = ['.agents/skills'] as const;
+
+type SubSkillFlagResolver = {
+  enabled(id: 'sub-skill'): boolean;
+};
 
 // Bounds recursion so a directory symlink cycle inside a skill root cannot
 // loop forever. Real skill trees are 1-3 levels deep.
@@ -32,6 +37,7 @@ export interface ResolveSkillRootsOptions {
 
 export interface DiscoverSkillsOptions {
   readonly roots: readonly SkillRoot[];
+  readonly experimentalFlags?: SubSkillFlagResolver;
   readonly onWarning?: (message: string, cause?: unknown) => void;
   readonly onSkippedByPolicy?: (skill: SkippedSkill) => void;
   readonly onDiscoveredSkill?: (skill: SkillDefinition) => void;
@@ -127,6 +133,7 @@ export async function discoverSkills(
   const isFile = options.isFile ?? defaultIsFile;
   const isDir = options.isDir ?? defaultIsDir;
   const parse = options.parse ?? parseSkillFromFile;
+  const subSkillFlags = options.experimentalFlags ?? flags;
   const warn = options.onWarning ?? (() => {});
   const skip = options.onSkippedByPolicy ?? (() => {});
   const byName = new Map<string, SkillDefinition>();
@@ -152,18 +159,19 @@ export async function discoverSkills(
     const directorySkills = new Set<string>();
     const subdirs: string[] = [];
     for (const entry of entries) {
-      // A directory holding SKILL.md is a skill bundle: register it and do not
-      // descend, so its bundled references/scripts are never scanned.
-      if (await isFile(path.join(dirPath, entry, 'SKILL.md'))) {
+      const entryPath = path.join(dirPath, entry);
+      // A directory holding SKILL.md is a skill bundle: register it, then keep
+      // descending so nested SKILL.md bundles remain discoverable as sub-skills.
+      if (await isFile(path.join(entryPath, 'SKILL.md'))) {
         directorySkills.add(entry);
-        continue;
       }
       if (entry === 'node_modules' || entry.startsWith('.')) continue;
-      if (await isDir(path.join(dirPath, entry))) subdirs.push(entry);
+      if (await isDir(entryPath)) subdirs.push(entry);
     }
 
+    const allowedSubSkillBundles = new Set<string>();
     for (const entry of directorySkills) {
-      await parseAndRegister({
+      const skill = await parseAndRegister({
         parse,
         byName,
         skillMdPath: path.join(dirPath, entry, 'SKILL.md'),
@@ -173,6 +181,9 @@ export async function discoverSkills(
         warn,
         skip,
       });
+      if (skill !== undefined && hasSubSkillEnabled(skill, subSkillFlags)) {
+        allowedSubSkillBundles.add(entry);
+      }
     }
 
     // Flat .md skills count only at a root's top level; deeper .md files are
@@ -223,6 +234,7 @@ export async function discoverSkills(
     }
 
     for (const entry of subdirs) {
+      if (directorySkills.has(entry) && !allowedSubSkillBundles.has(entry)) continue;
       await walkSkillDir(path.join(dirPath, entry), root, false, depth + 1);
     }
   }
@@ -345,7 +357,7 @@ async function parseAndRegister(input: {
   readonly onDiscoveredSkill?: (skill: SkillDefinition) => void;
   readonly warn: (message: string, cause?: unknown) => void;
   readonly skip: (skill: SkippedSkill) => void;
-}): Promise<void> {
+}): Promise<SkillDefinition | undefined> {
   try {
     const skill = await input.parse({
       skillMdPath: input.skillMdPath,
@@ -361,6 +373,7 @@ async function parseAndRegister(input: {
     if (!input.byName.has(key)) {
       input.byName.set(key, discovered);
     }
+    return skill;
   } catch (error) {
     if (error instanceof UnsupportedSkillTypeError) {
       input.skip({
@@ -373,7 +386,26 @@ async function parseAndRegister(input: {
     } else {
       input.warn(`Skipping skill at ${input.skillMdPath} due to unexpected error`, error);
     }
+    return undefined;
   }
+}
+
+function hasSubSkillEnabled(
+  skill: SkillDefinition,
+  experimentalFlags: SubSkillFlagResolver,
+): boolean {
+  if (!experimentalFlags.enabled('sub-skill')) return false;
+  const nested = skill.metadata['metadata'];
+  const nestedFlag =
+    typeof nested === 'object' && nested !== null
+      ? (nested as Record<string, unknown>)['has-sub-skill'] === true ||
+        (nested as Record<string, unknown>)['hasSubSkill'] === true
+      : false;
+  return (
+    skill.metadata['has-sub-skill'] === true ||
+    skill.metadata['hasSubSkill'] === true ||
+    nestedFlag
+  );
 }
 
 async function defaultIsDir(p: string): Promise<boolean> {

--- a/packages/agent-core/test/profile/agent-profile-loader.test.ts
+++ b/packages/agent-core/test/profile/agent-profile-loader.test.ts
@@ -188,6 +188,12 @@ describe('default agent profiles', () => {
   it('renders the model-invocable skill listing for bundled prompts', () => {
     const skills = new SkillRegistry();
     skills.register(skill('review', { whenToUse: 'When code review is requested.' }));
+    skills.register({
+      ...skill('nested-review', { whenToUse: 'When nested review is requested.' }),
+      path: '/skills/parent/nested-review/SKILL.md',
+      dir: '/skills/parent/nested-review',
+      content: 'Nested review body must not enter system prompt.',
+    });
     skills.register(skill('private', { disableModelInvocation: true }));
     skills.register(skill('flow-only', { type: 'flow' }));
 
@@ -198,10 +204,14 @@ describe('default agent profiles', () => {
 
     expect(prompt).toContain('Current available skills:');
     expect(prompt).toContain('- review:');
+    expect(prompt).toContain('- nested-review:');
+    expect(prompt).toContain('Path: /skills/parent/nested-review/SKILL.md');
     expect(prompt).toContain('When to use: When code review is requested.');
+    expect(prompt).toContain('When to use: When nested review is requested.');
     expect(prompt).not.toContain('private');
     expect(prompt).not.toContain('flow-only');
     expect(prompt).not.toContain('body of review');
+    expect(prompt).not.toContain('Nested review body must not enter system prompt.');
   });
 
   it('renders the bundled default prompt from the current runtime context', () => {

--- a/packages/agent-core/test/session/init.test.ts
+++ b/packages/agent-core/test/session/init.test.ts
@@ -8,6 +8,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import type { Agent, AgentOptions } from '../../src/agent';
 import { trimTrailingOpenToolExchange } from '../../src/agent/context/projector';
+import { FLAG_DEFINITIONS, FlagResolver } from '../../src/flags';
 import { ProviderManager } from '../../src/session/provider-manager';
 import type { ResolvedAgentProfile } from '../../src/profile';
 import type { SDKSessionRPC } from '../../src/rpc';
@@ -454,6 +455,65 @@ describe('AgentAPI.startBtw', () => {
       expect(events.filter((event) => String(event['type']).startsWith('subagent.'))).toEqual([]);
     } finally {
       await session.close();
+    }
+  });
+
+  it('uses session-scoped experimental flags for sub-skill discovery and builtins', async () => {
+    const workDir = await makeTempDir();
+    const sessionDir = await makeTempDir();
+    const skillsRoot = join(workDir, 'skills');
+    await mkdir(join(skillsRoot, 'outer', 'inner'), { recursive: true });
+    await writeFile(
+      join(skillsRoot, 'outer', 'SKILL.md'),
+      [
+        '---',
+        'name: outer',
+        'description: Parent skill',
+        'has-sub-skill: true',
+        '---',
+        '',
+        'Outer body.',
+      ].join('\n'),
+    );
+    await writeFile(
+      join(skillsRoot, 'outer', 'inner', 'SKILL.md'),
+      ['---', 'name: inner', 'description: Nested skill', '---', '', 'Inner body.'].join('\n'),
+    );
+
+    const disabledSession = new Session({
+      id: 'test-disabled-sub-skills',
+      kaos: testKaos.withCwd(workDir),
+      homedir: sessionDir,
+      rpc: createSessionRpc([]),
+      skills: { explicitDirs: [skillsRoot] },
+      experimentalFlags: new FlagResolver({}, FLAG_DEFINITIONS, { 'sub-skill': false }),
+    });
+
+    try {
+      const disabledSkills = await disabledSession.listSkills();
+      expect(disabledSkills.map((skill) => skill.name)).toContain('outer');
+      expect(disabledSkills.map((skill) => skill.name)).not.toContain('inner');
+      expect(disabledSkills.map((skill) => skill.name)).not.toContain('sub-skill.consolidate');
+    } finally {
+      await disabledSession.close();
+    }
+
+    const enabledSession = new Session({
+      id: 'test-enabled-sub-skills',
+      kaos: testKaos.withCwd(workDir),
+      homedir: sessionDir,
+      rpc: createSessionRpc([]),
+      skills: { explicitDirs: [skillsRoot] },
+      experimentalFlags: new FlagResolver({}, FLAG_DEFINITIONS, { 'sub-skill': true }),
+    });
+
+    try {
+      const enabledSkills = await enabledSession.listSkills();
+      expect(enabledSkills.map((skill) => skill.name)).toContain('outer');
+      expect(enabledSkills.map((skill) => skill.name)).toContain('inner');
+      expect(enabledSkills.map((skill) => skill.name)).toContain('sub-skill.consolidate');
+    } finally {
+      await enabledSession.close();
     }
   });
 });

--- a/packages/agent-core/test/skill/builtin-sub-skill.test.ts
+++ b/packages/agent-core/test/skill/builtin-sub-skill.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it } from 'vitest';
+
+import { FLAG_DEFINITIONS, FlagResolver } from '../../src/flags';
+import {
+  SkillRegistry,
+  SUB_SKILL_CONSOLIDATE,
+  SUB_SKILL_PARENT,
+  SUB_SKILL_REVIEW,
+  registerBuiltinSkills,
+} from '../../src/skill';
+
+describe('builtin skill: sub-skill', () => {
+  it('has the expected identity and inline metadata', () => {
+    expect(SUB_SKILL_PARENT.name).toBe('sub-skill');
+    expect(SUB_SKILL_PARENT.source).toBe('builtin');
+    expect(SUB_SKILL_PARENT.description.length).toBeGreaterThan(0);
+    expect(SUB_SKILL_PARENT.metadata.type).toBe('inline');
+  });
+
+  it('is hidden from model invocation and marked as a sub-skill', () => {
+    expect(SUB_SKILL_PARENT.metadata.disableModelInvocation).toBe(true);
+    expect(SUB_SKILL_PARENT.metadata['has-sub-skill']).toBe(true);
+  });
+
+  it('registers through registerBuiltinSkills but stays out of the model skill listing', () => {
+    const registry = new SkillRegistry();
+    registerBuiltinSkills(registry, {
+      experimentalFlags: new FlagResolver({}, FLAG_DEFINITIONS, { 'sub-skill': true }),
+    });
+
+    expect(registry.getSkill('sub-skill')).toBeDefined();
+    expect(
+      registry.listInvocableSkills().some((skill) => skill.name === 'sub-skill'),
+    ).toBe(false);
+  });
+
+  it('remains visible in the full skill list for CLI display when enabled', () => {
+    const registry = new SkillRegistry();
+    registerBuiltinSkills(registry, {
+      experimentalFlags: new FlagResolver({}, FLAG_DEFINITIONS, { 'sub-skill': true }),
+    });
+
+    expect(registry.listSkills().some((skill) => skill.name === 'sub-skill')).toBe(true);
+  });
+
+  it('does not register sub-skill builtins when the scoped flag is disabled', () => {
+    const registry = new SkillRegistry();
+    registerBuiltinSkills(registry, {
+      experimentalFlags: new FlagResolver({}, FLAG_DEFINITIONS, { 'sub-skill': false }),
+    });
+
+    expect(registry.getSkill('sub-skill')).toBeUndefined();
+    expect(registry.getSkill('sub-skill.review')).toBeUndefined();
+    expect(registry.getSkill('sub-skill.consolidate')).toBeUndefined();
+  });
+});
+
+describe('builtin skill: sub-skill.review', () => {
+  it('has the expected identity and inline metadata', () => {
+    expect(SUB_SKILL_REVIEW.name).toBe('sub-skill.review');
+    expect(SUB_SKILL_REVIEW.source).toBe('builtin');
+    expect(SUB_SKILL_REVIEW.description.length).toBeGreaterThan(0);
+    expect(SUB_SKILL_REVIEW.metadata.type).toBe('inline');
+  });
+
+  it('is hidden from model invocation', () => {
+    expect(SUB_SKILL_REVIEW.metadata.disableModelInvocation).toBe(true);
+  });
+
+  it('registers through registerBuiltinSkills', () => {
+    const registry = new SkillRegistry();
+    registerBuiltinSkills(registry, {
+      experimentalFlags: new FlagResolver({}, FLAG_DEFINITIONS, { 'sub-skill': true }),
+    });
+
+    expect(registry.getSkill('sub-skill.review')).toBeDefined();
+    expect(
+      registry.listInvocableSkills().some((skill) => skill.name === 'sub-skill.review'),
+    ).toBe(false);
+  });
+});
+
+describe('builtin skill: sub-skill.consolidate', () => {
+  it('has the expected identity and inline metadata', () => {
+    expect(SUB_SKILL_CONSOLIDATE.name).toBe('sub-skill.consolidate');
+    expect(SUB_SKILL_CONSOLIDATE.source).toBe('builtin');
+    expect(SUB_SKILL_CONSOLIDATE.description.length).toBeGreaterThan(0);
+    expect(SUB_SKILL_CONSOLIDATE.metadata.type).toBe('inline');
+  });
+
+  it('is hidden from model invocation', () => {
+    expect(SUB_SKILL_CONSOLIDATE.metadata.disableModelInvocation).toBe(true);
+  });
+
+  it('mentions backup requirements in its content', () => {
+    expect(SUB_SKILL_CONSOLIDATE.content).toContain('back up');
+    expect(SUB_SKILL_CONSOLIDATE.content).toContain('timestamped');
+  });
+
+  it('registers through registerBuiltinSkills', () => {
+    const registry = new SkillRegistry();
+    registerBuiltinSkills(registry, {
+      experimentalFlags: new FlagResolver({}, FLAG_DEFINITIONS, { 'sub-skill': true }),
+    });
+
+    expect(registry.getSkill('sub-skill.consolidate')).toBeDefined();
+    expect(
+      registry.listInvocableSkills().some((skill) => skill.name === 'sub-skill.consolidate'),
+    ).toBe(false);
+  });
+});

--- a/packages/agent-core/test/skill/scanner.test.ts
+++ b/packages/agent-core/test/skill/scanner.test.ts
@@ -2,13 +2,15 @@ import { mkdtemp, mkdir, realpath, rm, symlink, writeFile } from 'node:fs/promis
 import { tmpdir } from 'node:os';
 import path from 'pathe';
 
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
+import { FLAG_DEFINITIONS, FlagResolver } from '../../src/flags';
 import { discoverSkills, resolveSkillRoots, SkillRegistry, type SkillRoot } from '../../src/skill';
 
 const tempDirs: string[] = [];
 
 afterEach(async () => {
+  vi.unstubAllEnvs();
   for (const dir of tempDirs.splice(0)) {
     await rm(dir, { recursive: true, force: true });
   }
@@ -335,20 +337,139 @@ describe('discoverSkills shape and ordering', () => {
     expect(skills.map((s) => s.name)).toEqual(['alpha', 'beta', 'top']);
   });
 
-  it('does not descend into a skill bundle subdirectory', async () => {
+  it('discovers nested SKILL.md files inside a skill bundle when has-sub-skill is enabled', async () => {
+    vi.stubEnv('KIMI_CODE_EXPERIMENTAL_SUB_SKILL', '1');
     const { repoDir } = await makeWorkspace();
     const root = path.join(repoDir, '.kimi-code', 'skills');
     await writeSkill(root, path.join('outer', 'SKILL.md'), [
       '---',
       'name: outer',
-      'description: The real skill',
+      'description: Parent skill',
+      'has-sub-skill: true',
       '---',
+      '',
+      'Outer body.',
     ]);
     await writeSkill(root, path.join('outer', 'references', 'inner', 'SKILL.md'), [
       '---',
       'name: inner',
-      'description: Should be ignored',
+      'description: Nested skill',
       '---',
+      '',
+      'Inner body should stay private until activation.',
+    ]);
+    await writeFile(
+      path.join(root, 'outer', 'references', 'notes.md'),
+      'Nested payload should not be listed.',
+    );
+
+    const skills = await discoverSkills({ roots: [{ path: root, source: 'user' }] });
+
+    expect(skills.map((s) => s.name)).toEqual(['inner', 'outer']);
+  });
+
+  it('discovers nested SKILL.md files when sub-skill is enabled by scoped config', async () => {
+    const { repoDir } = await makeWorkspace();
+    const root = path.join(repoDir, '.kimi-code', 'skills');
+    await writeSkill(root, path.join('outer', 'SKILL.md'), [
+      '---',
+      'name: outer',
+      'description: Parent skill',
+      'has-sub-skill: true',
+      '---',
+      '',
+      'Outer body.',
+    ]);
+    await writeSkill(root, path.join('outer', 'references', 'inner', 'SKILL.md'), [
+      '---',
+      'name: inner',
+      'description: Nested skill',
+      '---',
+      '',
+      'Inner body.',
+    ]);
+
+    const skills = await discoverSkills({
+      roots: [{ path: root, source: 'user' }],
+      experimentalFlags: new FlagResolver({}, FLAG_DEFINITIONS, { 'sub-skill': true }),
+    });
+
+    expect(skills.map((s) => s.name)).toEqual(['inner', 'outer']);
+  });
+
+  it('does not discover nested SKILL.md files when the parent bundle disables sub-skills', async () => {
+    const { repoDir } = await makeWorkspace();
+    const root = path.join(repoDir, '.kimi-code', 'skills');
+    await writeSkill(root, path.join('outer', 'SKILL.md'), [
+      '---',
+      'name: outer',
+      'description: Parent skill',
+      '---',
+      '',
+      'Outer body.',
+    ]);
+    await writeSkill(root, path.join('outer', 'references', 'inner', 'SKILL.md'), [
+      '---',
+      'name: inner',
+      'description: Nested skill',
+      '---',
+      '',
+      'Inner body should stay private until activation.',
+    ]);
+
+    const skills = await discoverSkills({ roots: [{ path: root, source: 'user' }] });
+
+    expect(skills.map((s) => s.name)).toEqual(['outer']);
+  });
+
+  it('discovers nested SKILL.md files when has-sub-skill is nested under metadata', async () => {
+    vi.stubEnv('KIMI_CODE_EXPERIMENTAL_SUB_SKILL', '1');
+    const { repoDir } = await makeWorkspace();
+    const root = path.join(repoDir, '.kimi-code', 'skills');
+    await writeSkill(root, path.join('outer', 'SKILL.md'), [
+      '---',
+      'name: outer',
+      'description: Parent skill',
+      'metadata:',
+      '  has-sub-skill: true',
+      '---',
+      '',
+      'Outer body.',
+    ]);
+    await writeSkill(root, path.join('outer', 'inner', 'SKILL.md'), [
+      '---',
+      'name: outer.inner',
+      'description: Nested skill',
+      '---',
+      '',
+      'Inner body.',
+    ]);
+
+    const skills = await discoverSkills({ roots: [{ path: root, source: 'user' }] });
+
+    expect(skills.map((s) => s.name)).toEqual(['outer', 'outer.inner']);
+  });
+
+  it('treats sub-skill discovery as opt-in via the KIMI_CODE_EXPERIMENTAL_SUB_SKILL flag', async () => {
+    vi.stubEnv('KIMI_CODE_EXPERIMENTAL_SUB_SKILL', '0');
+    const { repoDir } = await makeWorkspace();
+    const root = path.join(repoDir, '.kimi-code', 'skills');
+    await writeSkill(root, path.join('outer', 'SKILL.md'), [
+      '---',
+      'name: outer',
+      'description: Parent skill',
+      'has-sub-skill: true',
+      '---',
+      '',
+      'Outer body.',
+    ]);
+    await writeSkill(root, path.join('outer', 'inner', 'SKILL.md'), [
+      '---',
+      'name: outer.inner',
+      'description: Nested skill',
+      '---',
+      '',
+      'Inner body.',
     ]);
 
     const skills = await discoverSkills({ roots: [{ path: root, source: 'user' }] });


### PR DESCRIPTION
## Related Issue

No linked issue. This PR adds an experimental, opt-in skill-management capability behind the existing feature-flag system.

## Summary

Adds experimental sub-skill discovery so skill bundles can expose nested `SKILL.md` files when they opt in with `has-sub-skill: true` and the `KIMI_CODE_EXPERIMENTAL_SUB_SKILL` flag is enabled. It also ships a built-in `sub-skill` parent with read-only `sub-skill.review` and backup-aware `sub-skill.consolidate` helpers for reorganizing skill inventories.

---

### 1. Nested skill discovery

**Problem:** Skill discovery treated any directory containing `SKILL.md` as a leaf, so bundled references or nested payloads could never be surfaced as first-class skills.

**What was done:**
- Added the `sub-skill` experimental flag to `packages/agent-core/src/flags/registry.ts`.
- Updated skill scanning to descend into a skill bundle only when the parent explicitly enables sub-skill discovery.
- Supported both top-level `has-sub-skill: true` and nested `metadata.has-sub-skill: true` frontmatter.
- Kept legacy behavior intact when the flag is disabled or the parent does not opt in.

### 2. Built-in sub-skill workflow

**Problem:** There was no guided workflow for reviewing and consolidating large skill inventories into hierarchical bundles.

**What was done:**
- Added built-in `sub-skill`, `sub-skill.review`, and `sub-skill.consolidate` definitions.
- Registered the new built-ins while keeping them disabled for model invocation.
- Documented a safe flow: review first, get explicit approval, then consolidate with timestamped backups.

### 3. Test coverage

**Problem:** New discovery behavior and built-ins need regression coverage without changing existing invocation semantics.

**What was done:**
- Added scanner tests for flag-gated discovery, opt-in parent metadata, and disabled-by-default behavior.
- Added built-in skill tests for identities, registration, hidden invocation, and backup guidance.
- Updated TUI/command and profile tests to cover nested skill paths while keeping skill bodies out of prompt listings.

---

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [ ] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.
