### PR TITLE
chore: remove llm request token estimate

### DIFF
--- a/.changeset/remove-llm-request-token-estimate.md
+++ b/.changeset/remove-llm-request-token-estimate.md
@@ -1,0 +1,6 @@
+---
+"@moonshot-ai/agent-core": patch
+"@moonshot-ai/kimi-code": patch
+---
+
+Stop logging estimated token counts for LLM requests.

--- a/.changeset/remove-llm-request-token-estimate.md
+++ b/.changeset/remove-llm-request-token-estimate.md
@@ -1,6 +1,0 @@
----
-"@moonshot-ai/agent-core": patch
-"@moonshot-ai/kimi-code": patch
----
-
-Stop logging estimated token counts for LLM requests.

--- a/packages/agent-core/src/agent/index.ts
+++ b/packages/agent-core/src/agent/index.ts
@@ -22,11 +22,6 @@ import type { SessionGoalStore } from '../session/goal';
 import type { SessionSubagentHost } from '../session/subagent-host';
 import type { SkillRegistry } from '../skill';
 import { noopTelemetryClient, type TelemetryClient } from '../telemetry';
-import {
-  estimateTokens,
-  estimateTokensForMessages,
-  estimateTokensForTools,
-} from '../utils/tokens';
 import type { PromisableMethods } from '../utils/types';
 import { BackgroundManager, BackgroundTaskPersistence } from './background';
 import {
@@ -252,12 +247,7 @@ export class Agent {
     for (const message of history) {
       if (message.partial === true) partialMessageCount += 1;
     }
-    const requestMetadata: LlmRequestMetadata = {
-      estimatedInputTokens:
-        estimateTokens(systemPrompt) +
-        estimateTokensForMessages(history) +
-        estimateTokensForTools(tools),
-    };
+    const requestMetadata: LlmRequestMetadata = {};
     if (partialMessageCount > 0) {
       requestMetadata.partialMessageCount = partialMessageCount;
     }
@@ -462,7 +452,6 @@ interface LlmRequestContextFields {
 }
 
 interface LlmRequestMetadata {
-  estimatedInputTokens: number;
   partialMessageCount?: number;
 }
 

--- a/packages/agent-core/test/agent/turn.test.ts
+++ b/packages/agent-core/test/agent/turn.test.ts
@@ -18,11 +18,6 @@ import { describe, expect, it, vi } from 'vitest';
 import { HookEngine } from '../../src/session/hooks';
 import type { AgentOptions } from '../../src/agent';
 import type { Logger, LogPayload } from '../../src/logging';
-import {
-  estimateTokens,
-  estimateTokensForMessages,
-  estimateTokensForTools,
-} from '../../src/utils/tokens';
 import { recordingTelemetry, type TelemetryRecord } from '../fixtures/telemetry';
 import { createFakeKaos } from '../tools/fixtures/fake-kaos';
 import { SessionGoalStore, type SessionGoalState } from '../../src/session/goal';
@@ -792,7 +787,7 @@ describe('Agent turn flow', () => {
     expect(payload).toMatchObject({
       turnStep: '0.1',
     });
-    expect(payload['estimatedInputTokens']).toEqual(expect.any(Number));
+    expect(payload).not.toHaveProperty('estimatedInputTokens');
     expect(payload).not.toHaveProperty('turnId');
     expect(payload).not.toHaveProperty('step');
     expect(payload).not.toHaveProperty('attempt');
@@ -860,7 +855,7 @@ describe('Agent turn flow', () => {
     }
   });
 
-  it('includes tool schemas in estimated LLM request tokens', async () => {
+  it('does not log estimated LLM request tokens when tools are present', async () => {
     const { logger, entries } = captureLogs();
     const ctx = testAgent({ log: logger });
     ctx.configure();
@@ -872,14 +867,10 @@ describe('Agent turn flow', () => {
 
     const input = ctx.llmCalls[0];
     expect(input?.tools.length).toBeGreaterThan(0);
-    const expectedTokens =
-      estimateTokens(input!.systemPrompt) +
-      estimateTokensForMessages(input!.history) +
-      estimateTokensForTools(input!.tools);
     const requestPayload = entries.find((entry) => entry.message === 'llm request')?.payload as
       | Record<string, unknown>
       | undefined;
-    expect(requestPayload?.['estimatedInputTokens']).toBe(expectedTokens);
+    expect(requestPayload).not.toHaveProperty('estimatedInputTokens');
   });
 
   it('classifies OAuth resolver failures as auth errors', async () => {


### PR DESCRIPTION
## Related Issue

No linked issue; this addresses a requested diagnostic log metadata change.

## Problem

`llm request` diagnostic logs currently include an `estimatedInputTokens` field. That estimate is no longer needed in request log entries.

## What changed

Removed the estimated token count from `llm request` log metadata while keeping the existing turn/attempt context and partial-message count behavior. Updated agent turn tests to assert the field is absent, including requests with tool schemas, and added a changeset for the affected release artifacts.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.
