### PR TITLE
fix(compaction): pass maxOutputSize to resolveCompletionBudget

### DIFF
--- a/.changeset/fix-compaction-max-output-size.md
+++ b/.changeset/fix-compaction-max-output-size.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/agent-core": patch
+---
+
+Pass `maxOutputSize` to `resolveCompletionBudget` in the compaction worker to prevent falling back to `max_context_size` as the completion token cap.

--- a/packages/agent-core/src/agent/compaction/full.ts
+++ b/packages/agent-core/src/agent/compaction/full.ts
@@ -244,6 +244,7 @@ export class FullCompaction {
       const provider = applyCompletionBudget({
         provider: this.agent.config.provider,
         budget: resolveCompletionBudget({
+          maxOutputSize: this.agent.config.maxOutputSize,
           reservedContextSize: this.agent.kimiConfig?.loopControl?.reservedContextSize,
         }),
         capability: this.agent.config.modelCapabilities,


### PR DESCRIPTION
The compaction worker was not passing \maxOutputSize\ to \resolveCompletionBudget\, causing it to fall back to \max_context_size\ as the completion token cap.

For models configured via the openai_legacy provider (e.g. glm-5.1), this resulted in \max_tokens\ being set to the full context window size, which upstream APIs may reject with a 400 error.

Normal chat requests already pass \maxOutputSize\ correctly via \Agent.llm\. This change aligns the compaction path with the normal request path.