### PR TITLE
feat: prefer ReadMediaFile over manual frame extraction for video analysis

### DIFF
--- a/packages/agent-core/src/profile/default/system.md
+++ b/packages/agent-core/src/profile/default/system.md
@@ -61,7 +61,7 @@ The user may ask you to research on certain topics, process or generate certain 
 - Understand the user's requirements thoroughly, ask for clarification before you start if needed.
 - Make plans before doing deep or wide research, to ensure you are always on track.
 - Search on the Internet if possible, with carefully-designed search queries to improve efficiency and accuracy.
-- Use proper tools or shell commands or Python packages to process or generate images, videos, PDFs, docs, spreadsheets, presentations, or other multimedia files. Detect if there are already such tools in the environment. If you have to install third-party tools/packages, you MUST ensure that they are installed in a virtual/isolated environment.
+- Use proper tools or shell commands or Python packages to process or generate images, PDFs, docs, spreadsheets, presentations, or other multimedia files. **For video files, prefer using the `ReadMediaFile` tool to read them directly rather than writing Python scripts or ffmpeg commands to extract frames manually.** Detect if there are already such tools in the environment. If you have to install third-party tools/packages, you MUST ensure that they are installed in a virtual/isolated environment.
 - Once you generate or edit any images, videos or other media files, try to read it again before proceed, to ensure that the content is as expected.
 - Avoid installing or deleting anything to/from outside of the current working directory. If you have to do so, ask the user for confirmation.
 


### PR DESCRIPTION
## Summary

Adds explicit guidance in the system prompt to prefer the `ReadMediaFile` tool over writing Python/ffmpeg scripts when analyzing video content.

## Problem

When users share video files with Kimi Code CLI, the AI may default to writing Python scripts or ffmpeg commands to extract frames manually. This is inefficient and fails to leverage the built-in multimodal `video_in` capability.

## Solution

Modified `system.md` in the General Guidelines for Research and Data Processing section to explicitly state:

> **For video files, prefer using the `ReadMediaFile` tool to read them directly rather than writing Python scripts or ffmpeg commands to extract frames manually.**

## Changes

- `packages/agent-core/src/profile/default/system.md`: updated one line in the multimedia processing guideline.

## Testing

- `prompt-placeholders.test.ts`: 4 tests pass
- `agent-profile-loader.test.ts`: 6 tests pass

## Related Task

Kimi CLI 视频分析希望默认调用 ReadMediaFile 而不是写 Python 切帧 (P0)
