### PR TITLE
docs(changelog): sync 0.11.0 and 0.10.1 from apps/kimi-code/CHANGELOG.md

### DIFF
--- a/docs/en/release-notes/changelog.md
+++ b/docs/en/release-notes/changelog.md
@@ -2,6 +2,44 @@
 
 This page documents the changes in each Kimi Code CLI release.
 
+## 0.11.0 (2026-06-05)
+
+### Features
+
+- Add experimental sub-skill discovery gated by the `KIMI_CODE_EXPERIMENTAL_SUB_SKILL` environment variable. Ships the `sub-skill` builtin bundle (`sub-skill.review`, `sub-skill.consolidate`) for inventorying and consolidating skills into hierarchical groups.
+- Add the following environment variables:
+
+  - `KIMI_MODEL_TEMPERATURE`, `KIMI_MODEL_TOP_P` — sampling parameters applied globally to any `kimi` provider (not tied to `KIMI_MODEL_NAME`).
+  - `KIMI_MODEL_THINKING_KEEP` — Moonshot preserved-thinking passthrough (`thinking.keep`), injected only while Thinking is on.
+  - `KIMI_CODE_NO_AUTO_UPDATE` (legacy alias `KIMI_CLI_NO_AUTO_UPDATE`) — fully disables the update preflight (no check, background install, or prompt).
+- Show built-in skills as direct slash commands and group them ahead of external skill commands.
+
+### Bug Fixes
+
+- Fix slash command autocomplete so goal text can be submitted when the cursor is before existing text.
+- Fix queued goals so failed promotion attempts do not lose or duplicate queued work.
+- Fix upcoming-goal queue handling while editing or pasting queued goals.
+- Ask before starting goals in YOLO mode so users can switch to Auto for unattended work.
+- Show concise provider filtering errors when responses are blocked before visible output.
+- Show "unknown command" instead of "too many arguments" when an invalid subcommand is entered.
+- Clamp OpenAI Chat Completions `xhigh` and `max` thinking effort to `high` unless the model supports `xhigh` on `v1/chat/completions`.
+- Preserve thinking effort when compacting long conversations.
+- Refresh provider model metadata when capabilities change without model ID changes.
+
+### Polish
+
+- Show the upcoming-goal confirmation with the same accent treatment as goal lifecycle messages.
+- Start upcoming goals immediately when there is no active goal to wait for.
+  Support multiline edits when managing upcoming goals.
+- Use a fixed 30-minute timeout for subagents and show concise resume instructions when they time out.
+- Highlight goal queue subcommands while typing slash commands.
+
+## 0.10.1 (2026-06-05)
+
+### Bug Fixes
+
+- Fix a crash when starting a goal in the TUI.
+
 ## 0.10.0 (2026-06-04)
 
 ### Features

--- a/docs/zh/release-notes/changelog.md
+++ b/docs/zh/release-notes/changelog.md
@@ -2,6 +2,44 @@
 
 本页记录 Kimi Code CLI 每个版本的变更内容。
 
+## 0.11.0（2026-06-05）
+
+### 新功能
+
+- 新增由环境变量 `KIMI_CODE_EXPERIMENTAL_SUB_SKILL` 控制的实验性子 Skill 发现能力。随附 `sub-skill` 内置包（`sub-skill.review`、`sub-skill.consolidate`），用于盘点 Skill 并将其整理为分层分组。
+- 新增以下环境变量：
+
+  - `KIMI_MODEL_TEMPERATURE`、`KIMI_MODEL_TOP_P` —— 全局应用于任意 `kimi` 供应商的采样参数（不绑定到 `KIMI_MODEL_NAME`）。
+  - `KIMI_MODEL_THINKING_KEEP` —— Moonshot 的 preserved-thinking 透传（`thinking.keep`），仅在开启 Thinking 时注入。
+  - `KIMI_CODE_NO_AUTO_UPDATE`（旧别名 `KIMI_CLI_NO_AUTO_UPDATE`）—— 完全禁用更新预检（不检查、不后台安装、不提示）。
+- 将内置 Skill 显示为直接斜杠命令，并将其分组排在外部 Skill 命令之前。
+
+### 修复
+
+- 修复斜杠命令自动补全，让光标位于已有文本之前时也能提交目标文本。
+- 修复已排队目标在晋升尝试失败时会丢失或重复的问题。
+- 修复编辑或粘贴已排队目标时的待处理目标队列处理。
+- 在 YOLO 模式下启动目标前进行询问，方便用户切换到 Auto 来处理无人值守工作。
+- 当响应在产生可见输出前被拦截时，显示简洁的供应商过滤错误。
+- 输入无效子命令时显示 “unknown command” 而不是 “too many arguments”。
+- 将 OpenAI Chat Completions 的 `xhigh` 和 `max` thinking effort 限制为 `high`，除非模型在 `v1/chat/completions` 上支持 `xhigh`。
+- 在压缩长对话时保留 thinking effort。
+- 当能力变化而模型 ID 未变化时刷新供应商模型元数据。
+
+### 优化
+
+- 让待处理目标的确认样式与目标生命周期消息使用相同的强调处理。
+- 当没有活跃目标需要等待时立即启动待处理目标。
+  支持在管理待处理目标时进行多行编辑。
+- 为子 Agent 使用固定的 30 分钟超时，并在超时后显示简洁的恢复说明。
+- 输入斜杠命令时高亮目标队列子命令。
+
+## 0.10.1（2026-06-05）
+
+### 修复
+
+- 修复在 TUI 中启动目标时的崩溃问题。
+
 ## 0.10.0（2026-06-04）
 
 ### 新功能


### PR DESCRIPTION
## Related Issue

Resolve N/A — no prior issue; this is a docs-only sync from the published CLI changelog.

## Problem

The docs release notes had not yet captured the published `0.11.0` and `0.10.1` CLI releases from `apps/kimi-code/CHANGELOG.md`.

## What changed

- Added the `0.11.0` and `0.10.1` release sections to `docs/en/release-notes/changelog.md`.
- Mirrored the same structure and translated the new content in `docs/zh/release-notes/changelog.md`.
- Stripped upstream PR links/commit hashes and kept only entry body text.
- Confirmed the docs changelog sync needs no changeset.

## Validation

- `git diff --check`
- `pnpm -C docs run build`

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] Docs-only change; validation completed with `pnpm -C docs run build`.
- [x] No changeset needed for docs-only changelog sync.
- [x] Docs sync completed; no separate `gen-docs` run required.
