### PR TITLE
fix(tui): stop logging plan toggle notices

### DIFF
--- a/.changeset/quiet-plan-toggle-notices.md
+++ b/.changeset/quiet-plan-toggle-notices.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Stop adding transcript notices when plan mode is toggled.

--- a/apps/kimi-code/src/tui/commands/config.ts
+++ b/apps/kimi-code/src/tui/commands/config.ts
@@ -58,15 +58,6 @@ async function applyPlanMode(host: SlashCommandHost, session: Session, enabled: 
   try {
     await session.setPlanMode(enabled);
     host.setAppState({ planMode: enabled });
-    if (enabled) {
-      const plan = await session.getPlan().catch(() => null);
-      host.showNotice(
-        'Plan mode: ON',
-        plan?.path !== undefined ? `Plan will be created here: ${plan.path}` : undefined,
-      );
-      return;
-    }
-    host.showNotice('Plan mode: OFF');
   } catch (error) {
     const msg = formatErrorMessage(error);
     host.showError(`Failed to set plan mode: ${msg}`);

--- a/apps/kimi-code/src/tui/controllers/session-replay.ts
+++ b/apps/kimi-code/src/tui/controllers/session-replay.ts
@@ -173,14 +173,6 @@ export class SessionReplayRenderer {
         return;
       case 'plan_updated':
         this.flushAssistant(context);
-        if (!record.enabled && context.suppressNextPlanModeOffNotice) {
-          context.suppressNextPlanModeOffNotice = false;
-          return;
-        }
-        context.suppressNextPlanModeOffNotice = false;
-        this.host.appendTranscriptEntry(
-          replayEntry(context, 'status', `Plan mode: ${record.enabled ? 'ON' : 'OFF'}`, 'notice'),
-        );
         return;
       case 'permission_updated':
         this.flushAssistant(context);
@@ -460,7 +452,6 @@ export class SessionReplayRenderer {
   ): void {
     const { result } = record;
     if (result.decision === 'approved') {
-      context.suppressNextPlanModeOffNotice = true;
       return;
     }
     this.removeToolCall(record.toolCallId);

--- a/apps/kimi-code/src/tui/utils/message-replay.ts
+++ b/apps/kimi-code/src/tui/utils/message-replay.ts
@@ -32,7 +32,6 @@ export interface ReplayRenderContext {
   toolCalls: Map<string, ToolCallBlockData>;
   completedToolCallIds: Set<string>;
   skillActivationIds: Set<string>;
-  suppressNextPlanModeOffNotice: boolean;
 }
 
 export interface SkillActivationProjection {
@@ -113,7 +112,6 @@ export function createReplayRenderContext(): ReplayRenderContext {
     toolCalls: new Map(),
     completedToolCallIds: new Set(),
     skillActivationIds: new Set(),
-    suppressNextPlanModeOffNotice: false,
   };
 }
 

--- a/apps/kimi-code/test/tui/commands/config.test.ts
+++ b/apps/kimi-code/test/tui/commands/config.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { handlePlanCommand } from '#/tui/commands/config';
+import type { SlashCommandHost } from '#/tui/commands/dispatch';
+
+function makeHost() {
+  const session = {
+    clearPlan: vi.fn(async () => {}),
+    getPlan: vi.fn(async () => ({ path: '/tmp/current-plan.md' })),
+    setPlanMode: vi.fn(async () => {}),
+  };
+  const host = {
+    state: {
+      appState: {
+        planMode: false,
+      },
+    },
+    session,
+    setAppState: vi.fn((patch: Record<string, unknown>) => {
+      Object.assign(host.state.appState, patch);
+    }),
+    showError: vi.fn(),
+    showNotice: vi.fn(),
+  } as unknown as SlashCommandHost;
+  return { host, session };
+}
+
+describe('handlePlanCommand', () => {
+  it('toggles plan mode without appending a transcript notice', async () => {
+    const { host, session } = makeHost();
+
+    await handlePlanCommand(host, 'on');
+
+    expect(session.setPlanMode).toHaveBeenCalledWith(true);
+    expect(host.setAppState).toHaveBeenCalledWith({ planMode: true });
+    expect(host.showNotice).not.toHaveBeenCalled();
+  });
+
+  it('turns plan mode off without appending a transcript notice', async () => {
+    const { host, session } = makeHost();
+    host.state.appState.planMode = true;
+
+    await handlePlanCommand(host, 'off');
+
+    expect(session.setPlanMode).toHaveBeenCalledWith(false);
+    expect(host.setAppState).toHaveBeenCalledWith({ planMode: false });
+    expect(host.showNotice).not.toHaveBeenCalled();
+  });
+
+  it('keeps the explicit clear command feedback', async () => {
+    const { host, session } = makeHost();
+
+    await handlePlanCommand(host, 'clear');
+
+    expect(session.clearPlan).toHaveBeenCalled();
+    expect(host.showNotice).toHaveBeenCalledWith('Plan cleared');
+  });
+});

--- a/apps/kimi-code/test/tui/message-replay.test.ts
+++ b/apps/kimi-code/test/tui/message-replay.test.ts
@@ -604,7 +604,7 @@ describe('KimiTUI resume message replay', () => {
     expect(transcript).toContain('hook response 2');
   });
 
-  it('renders plan permission and approval replay notices', async () => {
+  it('renders permission and approval replay notices without plan toggle notices', async () => {
     const driver = await replayIntoDriver([
       { type: 'plan_updated', enabled: true },
       { type: 'permission_updated', mode: 'auto' },
@@ -629,12 +629,12 @@ describe('KimiTUI resume message replay', () => {
 
     const transcript = driver.state.transcriptContainer.render(120).join('\n');
 
-    expect(transcript).toContain('Plan mode: ON');
     expect(transcript).toContain('Permission mode: auto');
     expect(transcript).toContain('YOLO mode: ON');
     expect(transcript).toContain('YOLO mode: OFF');
     expect(transcript).toContain('Approved for session: run command');
-    expect(transcript).toContain('Plan mode: OFF');
+    expect(transcript).not.toContain('Plan mode: ON');
+    expect(transcript).not.toContain('Plan mode: OFF');
   });
 
   it('keeps only the final approved plan card after rejected plan reviews', async () => {


### PR DESCRIPTION
## Related Issue

Resolve #392

## Problem

Toggling Plan mode through `/plan` or Shift-Tab added `Plan mode: ON/OFF` notices to the transcript. Repeated toggles filled the chat history even though the input/footer already shows the current Plan mode state.

## What changed

- Stop appending transcript notices when Plan mode is toggled.
- Stop rendering replayed `plan_updated` records as transcript notices when resuming older sessions.
- Keep `/plan clear` feedback and permission/approval replay notices unchanged.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.

## Verification

- `pnpm --filter @moonshot-ai/kimi-code exec vitest run test/tui/commands/config.test.ts test/tui/message-replay.test.ts`
- `pnpm --filter @moonshot-ai/kimi-code run typecheck`
- `pnpm exec oxlint apps/kimi-code/src/tui/commands/config.ts apps/kimi-code/src/tui/controllers/session-replay.ts apps/kimi-code/test/tui/commands/config.test.ts apps/kimi-code/test/tui/message-replay.test.ts`
- `pnpm run typecheck`
- `pnpm run lint` (0 errors; existing repo-wide warnings remain)
