### PR TITLE
fix(agent-core): refresh KIMI_NOW on resume

### DIFF
--- a/.changeset/fresh-kimi-now-resume.md
+++ b/.changeset/fresh-kimi-now-resume.md
@@ -1,0 +1,6 @@
+---
+"@moonshot-ai/agent-core": patch
+"@moonshot-ai/kimi-code": patch
+---
+
+Refresh the system prompt timestamp after resuming sessions.

--- a/packages/agent-core/src/agent/config/index.ts
+++ b/packages/agent-core/src/agent/config/index.ts
@@ -17,6 +17,8 @@ import type { ResolvedRuntimeProvider } from '../../session/provider-manager';
 export * from './types';
 export { resolveThinkingEffort, type ThinkingEffort } from './thinking';
 
+const KIMI_NOW_LINE_RE = /The current date and time in ISO format is `[^`]*`\./;
+
 export class ConfigState {
   private _cwd: string;
   private _modelAlias: string | undefined;
@@ -131,6 +133,10 @@ export class ConfigState {
     return this._systemPrompt;
   }
 
+  refreshRuntimeValues(): void {
+    this._systemPrompt = refreshKimiNow(this._systemPrompt);
+  }
+
   get modelCapabilities(): ModelCapability {
     return this.tryResolvedProviderConfig()?.modelCapabilities ?? UNKNOWN_CAPABILITY;
   }
@@ -151,4 +157,11 @@ export class ConfigState {
       return undefined;
     }
   }
+}
+
+function refreshKimiNow(systemPrompt: string): string {
+  return systemPrompt.replace(
+    KIMI_NOW_LINE_RE,
+    `The current date and time in ISO format is \`${new Date().toISOString()}\`.`,
+  );
 }

--- a/packages/agent-core/src/agent/index.ts
+++ b/packages/agent-core/src/agent/index.ts
@@ -284,6 +284,7 @@ export class Agent {
 
   async resume(): Promise<{ warning?: string }> {
     const result = await this.records.replay();
+    this.config.refreshRuntimeValues();
     await this.background.loadFromDisk();
     await this.background.reconcile();
     await this.cron?.loadFromDisk();

--- a/packages/agent-core/test/session/init.test.ts
+++ b/packages/agent-core/test/session/init.test.ts
@@ -37,6 +37,47 @@ afterEach(async () => {
 });
 
 describe('Session.init', () => {
+  it('refreshes KIMI_NOW in the system prompt when resuming a session', async () => {
+    vi.useFakeTimers();
+    try {
+      const workDir = await makeTempDir();
+      const sessionDir = await makeTempDir();
+      const oldNow = '2026-05-08T00:00:18.000Z';
+      const resumedNow = '2026-06-05T02:42:13.000Z';
+
+      vi.setSystemTime(new Date(oldNow));
+      const session = new Session({
+        id: 'test-kimi-now',
+        kaos: testKaos.withCwd(workDir),
+        homedir: sessionDir,
+        rpc: createSessionRpc([]),
+        skills: { explicitDirs: [join(workDir, 'missing-skills')] },
+        providerManager: testProviderManager(),
+      });
+      await session.createMain();
+      expect(session.getReadyAgent('main')?.config.systemPrompt).toContain(oldNow);
+      await session.closeForReload();
+
+      vi.setSystemTime(new Date(resumedNow));
+      const resumed = new Session({
+        id: 'test-kimi-now',
+        kaos: testKaos.withCwd(workDir),
+        homedir: sessionDir,
+        rpc: createSessionRpc([]),
+        skills: { explicitDirs: [join(workDir, 'missing-skills')] },
+        providerManager: testProviderManager(),
+      });
+      await resumed.resume();
+
+      const prompt = resumed.getReadyAgent('main')?.config.systemPrompt;
+      expect(prompt).toContain(resumedNow);
+      expect(prompt).not.toContain(oldNow);
+      await resumed.closeForReload();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('runs an isolated system-trigger turn and records the latest AGENTS as a system reminder', async () => {
     const workDir = await makeTempDir();
     const sessionDir = await makeTempDir();


### PR DESCRIPTION
## Related Issue

Resolve #446

## Problem

See linked issue.

Native sessions persist the rendered system prompt in wire history. On resume, the persisted `KIMI_NOW` value was replayed as-is, so the next model request could still receive the session creation timestamp instead of the resume-time timestamp.

## What changed

- Refresh the default system prompt timestamp once after agent records are replayed during resume.
- Keep the refreshed prompt stable for the resumed runtime, so consecutive requests in the same running session do not drift by milliseconds.
- Add a session resume regression test that creates a session at one timestamp, resumes it at another, and verifies the stale timestamp is not retained.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.

## Verification

- `pnpm --filter @moonshot-ai/agent-core exec vitest run test/session/init.test.ts`
- `pnpm --filter @moonshot-ai/agent-core exec vitest run test/agent/config.test.ts test/agent/resume.test.ts test/profile/default-agent-profiles.test.ts`
- `pnpm --filter @moonshot-ai/kimi-code-sdk exec vitest run test/session-prompt-events.test.ts`
- `pnpm --filter @moonshot-ai/agent-core test`
- `pnpm run typecheck`
- `pnpm test`
- `pnpm run lint` (0 errors; existing repo-wide warnings remain)
- Read-only diff audit found no context-specific internal identifiers, private endpoints, account names, secrets, local-only paths, or unrelated scope.
