### PR TITLE
feat: add /update and /check-update slash commands

### DIFF
--- a/.changeset/update-slash-commands.md
+++ b/.changeset/update-slash-commands.md
@@ -1,0 +1,7 @@
+---
+"@moonshot-ai/kimi-cli": patch
+---
+
+feat: add /update and /check-update slash commands
+
+Add slash commands for checking and applying updates.

--- a/apps/kimi-code/src/tui/commands/dispatch.ts
+++ b/apps/kimi-code/src/tui/commands/dispatch.ts
@@ -49,6 +49,7 @@ import {
   handleInitCommand,
   handleTitleCommand,
 } from './session';
+import { handleCheckUpdateCommand, handleUpdateCommand } from './update';
 import { handleUndoCommand } from './undo';
 
 // ---------------------------------------------------------------------------
@@ -89,6 +90,7 @@ export {
   handleInitCommand,
   handleTitleCommand,
 } from './session';
+export { handleCheckUpdateCommand, handleUpdateCommand } from './update';
 export { handleUndoCommand } from './undo';
 
 // ---------------------------------------------------------------------------
@@ -323,6 +325,12 @@ async function handleBuiltInSlashCommand(
       return;
     case 'logout':
       await handleLogoutCommand(host);
+      return;
+    case 'check-update':
+      await handleCheckUpdateCommand(host);
+      return;
+    case 'update':
+      await handleUpdateCommand(host);
       return;
     case 'undo':
       await handleUndoCommand(host, args);

--- a/apps/kimi-code/src/tui/commands/registry.ts
+++ b/apps/kimi-code/src/tui/commands/registry.ts
@@ -122,6 +122,20 @@ export const BUILTIN_SLASH_COMMANDS = [
     availability: 'always',
   },
   {
+    name: 'update',
+    aliases: ['upgrade'],
+    description: 'Check and install updates',
+    priority: 60,
+    availability: 'always',
+  },
+  {
+    name: 'check-update',
+    aliases: [],
+    description: 'Check for available updates without installing',
+    priority: 60,
+    availability: 'always',
+  },
+  {
     name: 'plugins',
     aliases: [],
     description: 'Manage plugins',

--- a/apps/kimi-code/src/tui/commands/update.ts
+++ b/apps/kimi-code/src/tui/commands/update.ts
@@ -1,0 +1,94 @@
+import { track as trackTelemetry } from '@moonshot-ai/kimi-telemetry';
+
+import { detectInstallSource } from '#/cli/update/source';
+import {
+  canAutoInstall,
+  installCommandFor,
+  renderManualUpdateMessage,
+} from '#/cli/update/preflight';
+import { refreshUpdateCache } from '#/cli/update/refresh';
+import { selectUpdateTarget } from '#/cli/update/select';
+import { type UpdateCache } from '#/cli/update/types';
+import type { SlashCommandHost } from './dispatch';
+
+export async function handleCheckUpdateCommand(host: SlashCommandHost): Promise<void> {
+  const currentVersion = host.state.appState.version;
+
+  let cache: UpdateCache;
+  try {
+    cache = await refreshUpdateCache();
+  } catch (error) {
+    const reason = error instanceof Error ? error.message : String(error);
+    host.showError(`Failed to check for updates: ${reason}`);
+    trackTelemetry('slash_check_update_failed', { current_version: currentVersion, reason });
+    return;
+  }
+
+  const target = selectUpdateTarget(currentVersion, cache.latest);
+  if (target === null) {
+    host.showStatus(`Kimi Code is already up to date (${formatDisplayVersion(currentVersion)}).`);
+    trackTelemetry('slash_check_update_no_update', { current_version: currentVersion });
+    return;
+  }
+
+  host.showNotice(
+    'Update Available',
+    `Kimi Code ${formatDisplayVersion(currentVersion)} → ${formatDisplayVersion(target.version)}\nRun /update to install.`,
+  );
+  trackTelemetry('slash_check_update_available', {
+    current_version: currentVersion,
+    target_version: target.version,
+  });
+}
+
+export async function handleUpdateCommand(host: SlashCommandHost): Promise<void> {
+  const currentVersion = host.state.appState.version;
+
+  let cache: UpdateCache;
+  try {
+    cache = await refreshUpdateCache();
+  } catch (error) {
+    const reason = error instanceof Error ? error.message : String(error);
+    host.showError(`Failed to check for updates: ${reason}`);
+    trackTelemetry('slash_update_failed', { current_version: currentVersion, reason });
+    return;
+  }
+
+  const target = selectUpdateTarget(currentVersion, cache.latest);
+  if (target === null) {
+    host.showStatus(`Kimi Code is already up to date (${formatDisplayVersion(currentVersion)}).`);
+    trackTelemetry('slash_update_no_update', { current_version: currentVersion });
+    return;
+  }
+
+  const source = await detectInstallSource().catch(() => 'unsupported' as const);
+  const installCommand = installCommandFor(source, target.version, process.platform);
+
+  if (!canAutoInstall(source, process.platform)) {
+    host.showNotice(
+      'Manual Update Required',
+      renderManualUpdateMessage(currentVersion, target, source, installCommand),
+    );
+    trackTelemetry('slash_update_manual', {
+      current_version: currentVersion,
+      target_version: target.version,
+      source,
+    });
+    return;
+  }
+
+  // For auto-installable sources, show a prompt-like notice
+  host.showNotice(
+    'Update Ready',
+    `Install Kimi Code ${formatDisplayVersion(target.version)} now?\n\n${installCommand}\n\n(Auto-install via TUI is not yet supported — please run the command above in your terminal)`,
+  );
+  trackTelemetry('slash_update_prompted', {
+    current_version: currentVersion,
+    target_version: target.version,
+    source,
+  });
+}
+
+function formatDisplayVersion(version: string): string {
+  return version.startsWith('v') ? version : `v${version}`;
+}

--- a/apps/kimi-code/test/tui/commands/registry.test.ts
+++ b/apps/kimi-code/test/tui/commands/registry.test.ts
@@ -100,6 +100,7 @@ describe('built-in slash command registry', () => {
     expect(new Set(names).size).toBe(names.length);
     expect(names).toEqual(
       expect.arrayContaining([
+        'check-update',
         'compact',
         'btw',
         'editor',
@@ -123,6 +124,7 @@ describe('built-in slash command registry', () => {
         'theme',
         'title',
         'undo',
+        'update',
         'usage',
         'version',
         'yolo',

--- a/apps/kimi-code/test/tui/commands/update-slash.test.ts
+++ b/apps/kimi-code/test/tui/commands/update-slash.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { handleCheckUpdateCommand, handleUpdateCommand } from '#/tui/commands/update';
+
+const mocks = vi.hoisted(() => ({
+  refreshUpdateCache: vi.fn(),
+  selectUpdateTarget: vi.fn(),
+  detectInstallSource: vi.fn(),
+  installCommandFor: vi.fn(),
+  canAutoInstall: vi.fn(),
+  renderManualUpdateMessage: vi.fn(),
+}));
+
+vi.mock('../../../src/cli/update/refresh', async () => ({
+  refreshUpdateCache: mocks.refreshUpdateCache,
+}));
+
+vi.mock('../../../src/cli/update/select', async () => ({
+  selectUpdateTarget: mocks.selectUpdateTarget,
+}));
+
+vi.mock('../../../src/cli/update/source', async () => ({
+  detectInstallSource: mocks.detectInstallSource,
+}));
+
+vi.mock('../../../src/cli/update/preflight', async () => ({
+  installCommandFor: mocks.installCommandFor,
+  canAutoInstall: mocks.canAutoInstall,
+  renderManualUpdateMessage: mocks.renderManualUpdateMessage,
+}));
+
+function createMockHost(overrides: Record<string, unknown> = {}): Parameters<typeof handleCheckUpdateCommand>[0] {
+  return {
+    state: { appState: { version: '1.0.0' } },
+    showStatus: vi.fn(),
+    showError: vi.fn(),
+    showNotice: vi.fn(),
+    track: vi.fn(),
+    ...overrides,
+  } as unknown as Parameters<typeof handleCheckUpdateCommand>[0];
+}
+
+describe('handleCheckUpdateCommand', () => {
+  it('shows status when already up to date', async () => {
+    mocks.refreshUpdateCache.mockResolvedValue({ latest: '1.0.0', checkedAt: '', source: 'cdn' });
+    mocks.selectUpdateTarget.mockReturnValue(null);
+
+    const host = createMockHost();
+    await handleCheckUpdateCommand(host);
+
+    expect(host.showStatus).toHaveBeenCalledWith('Kimi Code is already up to date (v1.0.0).');
+  });
+
+  it('shows notice when update is available', async () => {
+    mocks.refreshUpdateCache.mockResolvedValue({ latest: '1.1.0', checkedAt: '', source: 'cdn' });
+    mocks.selectUpdateTarget.mockReturnValue({ version: '1.1.0', changelogUrl: '' });
+
+    const host = createMockHost();
+    await handleCheckUpdateCommand(host);
+
+    expect(host.showNotice).toHaveBeenCalledWith(
+      'Update Available',
+      expect.stringContaining('1.1.0'),
+    );
+  });
+
+  it('shows error when refresh fails', async () => {
+    mocks.refreshUpdateCache.mockRejectedValue(new Error('network error'));
+
+    const host = createMockHost();
+    await handleCheckUpdateCommand(host);
+
+    expect(host.showError).toHaveBeenCalledWith('Failed to check for updates: network error');
+  });
+});
+
+describe('handleUpdateCommand', () => {
+  it('shows status when already up to date', async () => {
+    mocks.refreshUpdateCache.mockResolvedValue({ latest: '1.0.0', checkedAt: '', source: 'cdn' });
+    mocks.selectUpdateTarget.mockReturnValue(null);
+
+    const host = createMockHost();
+    await handleUpdateCommand(host);
+
+    expect(host.showStatus).toHaveBeenCalledWith('Kimi Code is already up to date (v1.0.0).');
+  });
+
+  it('shows manual update notice for unsupported sources', async () => {
+    mocks.refreshUpdateCache.mockResolvedValue({ latest: '1.1.0', checkedAt: '', source: 'cdn' });
+    mocks.selectUpdateTarget.mockReturnValue({ version: '1.1.0', changelogUrl: '' });
+    mocks.detectInstallSource.mockResolvedValue('unsupported');
+    mocks.canAutoInstall.mockReturnValue(false);
+    mocks.renderManualUpdateMessage.mockReturnValue('manual update message');
+
+    const host = createMockHost();
+    await handleUpdateCommand(host);
+
+    expect(host.showNotice).toHaveBeenCalledWith('Manual Update Required', 'manual update message');
+  });
+
+  it('shows update prompt for auto-installable sources', async () => {
+    mocks.refreshUpdateCache.mockResolvedValue({ latest: '1.1.0', checkedAt: '', source: 'cdn' });
+    mocks.selectUpdateTarget.mockReturnValue({ version: '1.1.0', changelogUrl: '' });
+    mocks.detectInstallSource.mockResolvedValue('npm');
+    mocks.canAutoInstall.mockReturnValue(true);
+    mocks.installCommandFor.mockReturnValue('npm install -g @moonshot-ai/kimi-code@1.1.0');
+
+    const host = createMockHost();
+    await handleUpdateCommand(host);
+
+    expect(host.showNotice).toHaveBeenCalledWith(
+      'Update Ready',
+      expect.stringContaining('npm install -g @moonshot-ai/kimi-code@1.1.0'),
+    );
+  });
+});

--- a/docs/en/reference/slash-commands.md
+++ b/docs/en/reference/slash-commands.md
@@ -114,6 +114,8 @@ Prompt mode exits with code `0` when the goal completes, `3` when it blocks, and
 | `/mcp` | — | List MCP servers and their connection status in the current session | Yes |
 | `/plugins` | — | Open the interactive plugin manager | Yes |
 | `/version` | — | Display the Kimi Code CLI version number | Yes |
+| `/check-update` | — | Check for available updates without installing | Yes |
+| `/update` | `/upgrade` | Check and install the latest version if available | Yes |
 | `/feedback` | — | Submit feedback to help improve Kimi Code CLI | Yes |
 
 ## Exit

--- a/docs/zh/reference/slash-commands.md
+++ b/docs/zh/reference/slash-commands.md
@@ -112,6 +112,8 @@ Prompt 模式在目标完成时以退出码 `0` 退出，在目标阻塞时以 `
 | `/mcp` | — | 列出当前会话中的 MCP server 及连接状态 | 是 |
 | `/plugins` | — | 打开交互式 plugin 管理器 | 是 |
 | `/version` | — | 显示 Kimi Code CLI 版本号 | 是 |
+| `/check-update` | — | 检查是否有可用更新（不安装） | 是 |
+| `/update` | `/upgrade` | 检查并安装最新版本（如可用） | 是 |
 | `/feedback` | — | 提交反馈以改进 Kimi Code CLI | 是 |
 
 ## 退出


### PR DESCRIPTION
Adds two new slash commands to the TUI for version management:

- `/check-update` — refreshes the update cache and shows whether a new version is available
- `/update` — checks for updates and shows install instructions or the install command

Both commands reuse the existing CLI update infrastructure (`refreshUpdateCache`, `selectUpdateTarget`, `detectInstallSource`, etc.) and surface results through the TUI's `showStatus`/`showNotice` APIs.

Also updates the English and Chinese slash command docs to list the new commands.

Relates to task: 支持版本自动检测和升级