### PR TITLE
fix(node-sdk): pass shell:true on Windows when spawning .cmd shims in build-dts

### DIFF
--- a/packages/node-sdk/scripts/build-dts.mjs
+++ b/packages/node-sdk/scripts/build-dts.mjs
@@ -33,6 +33,7 @@ function run(command, args) {
     const child = spawn(executable, args, {
       cwd: packageRoot,
       stdio: 'inherit',
+      shell: process.platform === 'win32',
     });
 
     child.once('error', reject);


### PR DESCRIPTION
## Related Issue

No linked issue. This fixes a focused Windows portability regression found while building `@moonshot-ai/kimi-code-sdk` locally. Related context: #225 (broader Windows test-suite portability).

## Problem

On Windows, running the SDK's d.ts build script throws `spawn EINVAL` and the build fails before it starts:

```
> @moonshot-ai/kimi-code-sdk@0.8.0 build:dts
> node scripts/build-dts.mjs

Error: spawn EINVAL
    at ChildProcess.spawn (node:internal/child_process:440:11)
    at spawn (node:child_process:796:9)
    at .../packages/node-sdk/scripts/build-dts.mjs:33:19
  errno: -4071, code: 'EINVAL', syscall: 'spawn'
```

This blocks both `pnpm --filter @moonshot-ai/kimi-code-sdk run build:dts` and the aggregate `pnpm --filter @moonshot-ai/kimi-code-sdk run build`. CI runs on `ubuntu-latest`, so the regression is invisible upstream but every Windows contributor hits it.

The script already appends the `.cmd` suffix for `tsc` and `api-extractor` on `win32`, but does not opt in to `shell: true`. Starting with Node 18.20.4 / 20.12.2 / 21.7.2 (the CVE-2024-27980 hardening), `child_process.spawn` of any `.cmd` / `.bat` file refuses to launch unless the caller sets `{ shell: true }`. The repo's `package.json` requires Node `>=24.15.0`, so every supported runtime has this hardening active.

## What changed

One added property in the existing `spawn()` options object:

```diff
     const child = spawn(executable, args, {
       cwd: packageRoot,
       stdio: 'inherit',
+      shell: process.platform === 'win32',
     });
```

The condition keeps the POSIX path byte-for-byte identical to before: on non-Windows platforms, `shell: false` is the documented `spawn` default, so passing it explicitly is observationally a no-op. Only Windows changes behavior, and there it gates the `cmd.exe`-mediated launch that Node now requires for `.cmd` shims.

The two callsites pass strict ASCII arg tokens (`['-p', 'tsconfig.dts.json']` and `['run', '--local']`) — no shell metacharacters — so the Node deprecation warning about shell-args concatenation is informational only for these invocations. The `${command}.cmd` suffix logic is kept; even with `shell: true`, the explicit extension avoids ambiguity when PATHEXT could resolve to a non-Windows entry of the same stem.

No dependencies added; no other files touched; the script is not shipped (`packages/node-sdk/package.json` `"files"` is `["dist", "README.md"]`), so no changeset is needed.

## Verification

On Windows (Node v25.9.0, pnpm 10.33.0):

- Before: `pnpm --filter @moonshot-ai/kimi-code-sdk run build:dts` → `spawn EINVAL`, exit 1
- After: same command → `API Extractor completed successfully`, exit 0
- `pnpm --filter @moonshot-ai/kimi-code-sdk run build` → exit 0
- `pnpm --filter @moonshot-ai/kimi-code-sdk run typecheck` → exit 0
- `pnpm exec oxlint packages/node-sdk/scripts/build-dts.mjs` → 0 warnings, 0 errors

Existing `ubuntu-latest` CI exercises the unchanged POSIX path.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [ ] I have added tests that prove my feature works. *(Fix is a one-line Windows-only build-script change; a regression test would require either expanding the CI matrix to a Windows runner or mocking `child_process.spawn`, neither proportional to the change. Pre/post repro of the exact failure is documented above.)*
- [x] Ran `gen-changesets` skill, or this PR needs no changeset. *(The script lives outside `"files"` in `packages/node-sdk/package.json`, so the change has no user-visible surface; per `.changeset/README.md`, internal/private-tooling fixes do not need a changeset.)*
- [x] Ran `gen-docs` skill, or this PR needs no doc update.
