### PR TITLE
fix(upgrade): pass install-prefix env vars to native install script

### DIFF
--- a/.changeset/wise-berries-return.md
+++ b/.changeset/wise-berries-return.md
@@ -2,4 +2,4 @@
 "@moonshot-ai/kimi-code": patch
 ---
 
-Point `KIMI_INSTALL_DIR` at the current binary's directory so native upgrade overwrites it in place
+Fix native upgrade: set `KIMI_INSTALL_DIR` only when binary is under `bin/`; place env vars after pipe in prompt command so they reach the install script

--- a/.changeset/wise-berries-return.md
+++ b/.changeset/wise-berries-return.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Point `KIMI_INSTALL_DIR` at the current binary's directory so native upgrade overwrites it in place

--- a/apps/kimi-code/src/cli/update/preflight.ts
+++ b/apps/kimi-code/src/cli/update/preflight.ts
@@ -1,4 +1,5 @@
 import { spawn } from 'node:child_process';
+import { basename, dirname } from 'node:path';
 
 import { log, type Logger } from '@moonshot-ai/kimi-code-sdk';
 import type { TelemetryProperties } from '@moonshot-ai/kimi-telemetry';
@@ -92,6 +93,7 @@ export function canAutoInstall(source: InstallSource, platform: NodeJS.Platform)
 interface SpawnCommand {
   readonly cmd: string;
   readonly args: readonly string[];
+  readonly env?: Record<string, string>;
 }
 
 export function spawnForSource(
@@ -108,13 +110,31 @@ export function spawnForSource(
       return { cmd: withCmdSuffix('yarn', platform), args: ['global', 'add', `${NPM_PACKAGE_NAME}@${version}`] };
     case 'bun-global':
       return { cmd: bunCommand(platform), args: ['add', '-g', `${NPM_PACKAGE_NAME}@${version}`] };
-    case 'native':
+    case 'native': {
       // `curl … | bash` reports only the trailing bash's exit status, so a
       // failed download (curl can't connect → empty stdin → bash exits 0)
       // would look like a successful update. `pipefail` makes the pipeline
       // surface curl's non-zero status so installUpdate() rejects and we warn
       // instead of printing "Updated …".
-      return { cmd: 'bash', args: ['-c', `set -o pipefail; ${NATIVE_INSTALL_COMMAND_UNIX}`] };
+      //
+      // Point KIMI_INSTALL_DIR at the directory containing the current native
+      // binary so the install script overwrites it in place.  The install
+      // script always writes to ${KIMI_INSTALL_DIR}/bin/kimi, so when the
+      // binary lives under a `bin/` subdirectory we pass the parent of that
+      // `bin/` dir (e.g. ~/.local/bin/kimi → ~/.local).
+      // Set KIMI_NO_MODIFY_PATH to skip shell-rc modification — during an
+      // upgrade the binary is already on the user's PATH.
+      const execDir = dirname(process.execPath);
+      const installDir = basename(execDir) === 'bin' ? dirname(execDir) : execDir;
+      return {
+        cmd: 'bash',
+        args: ['-c', `set -o pipefail; ${NATIVE_INSTALL_COMMAND_UNIX}`],
+        env: {
+          KIMI_INSTALL_DIR: installDir,
+          KIMI_NO_MODIFY_PATH: '1',
+        },
+      };
+    }
     case 'unsupported':
       throw new Error('unsupported install source cannot be auto-installed');
   }
@@ -379,9 +399,12 @@ export async function installUpdate(
   version: string,
   platform: NodeJS.Platform,
 ): Promise<void> {
-  const { cmd, args } = spawnForSource(source, version, platform);
+  const { cmd, args, env } = spawnForSource(source, version, platform);
   await new Promise<void>((resolve, reject) => {
-    const child = spawn(cmd, [...args], { stdio: 'inherit' });
+    const child = spawn(cmd, [...args], {
+      stdio: 'inherit',
+      ...(env ? { env: { ...process.env, ...env } } : {}),
+    });
     child.once('error', reject);
     child.once('exit', (code, signal) => {
       if (code === 0) {
@@ -435,7 +458,7 @@ async function startBackgroundInstall(
       source,
     });
 
-    const { cmd, args } = spawnForSource(source, target.version, platform);
+    const { cmd, args, env } = spawnForSource(source, target.version, platform);
     let settled = false;
 
     const finish = (succeeded: boolean): void => {
@@ -487,7 +510,11 @@ async function startBackgroundInstall(
       });
     };
 
-    const child = spawn(cmd, [...args], { detached: true, stdio: 'ignore' });
+    const child = spawn(cmd, [...args], {
+      detached: true,
+      stdio: 'ignore',
+      ...(env ? { env: { ...process.env, ...env } } : {}),
+    });
     child.once('error', () => { finish(false); });
     child.once('exit', (code) => { finish(code === 0); });
     child.unref();

--- a/apps/kimi-code/src/cli/update/preflight.ts
+++ b/apps/kimi-code/src/cli/update/preflight.ts
@@ -56,26 +56,33 @@ function bunCommand(platform: NodeJS.Platform): string {
 }
 
 /**
- * Compute the install prefix for a native (SEA) install.
+ * Compute the install prefix for a native (SEA) install, or undefined when
+ * the running binary is not inside a `bin/` directory (e.g. unpacked archive).
  *
  * The native install script writes to `$KIMI_INSTALL_DIR/bin/kimi`.  To
  * overwrite the currently running binary we point the env var at the
  * parent of the `bin/` directory that contains it, if any (e.g.
- * `~/.local/bin/kimi` → `~/.local`).
+ * `~/.local/bin/kimi` → `~/.local`).  When the binary is not under a `bin/`
+ * directory we cannot safely determine a prefix that would cause the installer
+ * to overwrite it, so we skip the override and let the installer use its
+ * default location.
  */
-function nativeInstallDir(): string {
+function nativeInstallDir(): string | undefined {
   const execDir = dirname(process.execPath);
-  return basename(execDir) === 'bin' ? dirname(execDir) : execDir;
+  return basename(execDir) === 'bin' ? dirname(execDir) : undefined;
 }
 
 /**
- * Render the env-var prefix for a native install command so the user-visible
- * command matches what the spawned process actually runs.
+ * Render the env-var suffix (`| KIMI_…=… bash`) for a native install command.
+ * The spawned path passes these variables through `SpawnCommand.env`; the
+ * user-visible command places them between the pipe and `bash` so that they
+ * are visible to the install script when the user copy-pastes.
  */
 function nativeEnvPrefix(): string {
   const dir = nativeInstallDir();
-  // Shell-quote: single-quote wraps the value so spaces are safe.
-  return `KIMI_INSTALL_DIR='${dir}' KIMI_NO_MODIFY_PATH=1`;
+  const vars = ['KIMI_NO_MODIFY_PATH=1'];
+  if (dir !== undefined) vars.unshift(`KIMI_INSTALL_DIR='${dir}'`);
+  return vars.join(' ');
 }
 
 export function installCommandFor(
@@ -95,7 +102,7 @@ export function installCommandFor(
     case 'native':
       return platform === 'win32'
         ? NATIVE_INSTALL_COMMAND_WIN
-        : `${nativeEnvPrefix()} ${NATIVE_INSTALL_COMMAND_UNIX}`;
+        : NATIVE_INSTALL_COMMAND_UNIX.replace('| bash', `| ${nativeEnvPrefix()} bash`);
     case 'unsupported':
       return `npm install -g ${NPM_PACKAGE_NAME}@${version}`;
   }
@@ -150,13 +157,12 @@ export function spawnForSource(
       // Set KIMI_NO_MODIFY_PATH to skip shell-rc modification — during an
       // upgrade the binary is already on the user's PATH.
       const installDir = nativeInstallDir();
+      const env: Record<string, string> = { KIMI_NO_MODIFY_PATH: '1' };
+      if (installDir !== undefined) env.KIMI_INSTALL_DIR = installDir;
       return {
         cmd: 'bash',
         args: ['-c', `set -o pipefail; ${NATIVE_INSTALL_COMMAND_UNIX}`],
-        env: {
-          KIMI_INSTALL_DIR: installDir,
-          KIMI_NO_MODIFY_PATH: '1',
-        },
+        env,
       };
     }
     case 'unsupported':

--- a/apps/kimi-code/src/cli/update/preflight.ts
+++ b/apps/kimi-code/src/cli/update/preflight.ts
@@ -55,6 +55,29 @@ function bunCommand(platform: NodeJS.Platform): string {
   return platform === 'win32' ? 'bun.exe' : 'bun';
 }
 
+/**
+ * Compute the install prefix for a native (SEA) install.
+ *
+ * The native install script writes to `$KIMI_INSTALL_DIR/bin/kimi`.  To
+ * overwrite the currently running binary we point the env var at the
+ * parent of the `bin/` directory that contains it, if any (e.g.
+ * `~/.local/bin/kimi` → `~/.local`).
+ */
+function nativeInstallDir(): string {
+  const execDir = dirname(process.execPath);
+  return basename(execDir) === 'bin' ? dirname(execDir) : execDir;
+}
+
+/**
+ * Render the env-var prefix for a native install command so the user-visible
+ * command matches what the spawned process actually runs.
+ */
+function nativeEnvPrefix(): string {
+  const dir = nativeInstallDir();
+  // Shell-quote: single-quote wraps the value so spaces are safe.
+  return `KIMI_INSTALL_DIR='${dir}' KIMI_NO_MODIFY_PATH=1`;
+}
+
 export function installCommandFor(
   source: InstallSource,
   version: string,
@@ -70,7 +93,9 @@ export function installCommandFor(
     case 'bun-global':
       return `bun add -g ${NPM_PACKAGE_NAME}@${version}`;
     case 'native':
-      return platform === 'win32' ? NATIVE_INSTALL_COMMAND_WIN : NATIVE_INSTALL_COMMAND_UNIX;
+      return platform === 'win32'
+        ? NATIVE_INSTALL_COMMAND_WIN
+        : `${nativeEnvPrefix()} ${NATIVE_INSTALL_COMMAND_UNIX}`;
     case 'unsupported':
       return `npm install -g ${NPM_PACKAGE_NAME}@${version}`;
   }
@@ -124,8 +149,7 @@ export function spawnForSource(
       // `bin/` dir (e.g. ~/.local/bin/kimi → ~/.local).
       // Set KIMI_NO_MODIFY_PATH to skip shell-rc modification — during an
       // upgrade the binary is already on the user's PATH.
-      const execDir = dirname(process.execPath);
-      const installDir = basename(execDir) === 'bin' ? dirname(execDir) : execDir;
+      const installDir = nativeInstallDir();
       return {
         cmd: 'bash',
         args: ['-c', `set -o pipefail; ${NATIVE_INSTALL_COMMAND_UNIX}`],

--- a/apps/kimi-code/src/cli/update/preflight.ts
+++ b/apps/kimi-code/src/cli/update/preflight.ts
@@ -72,6 +72,11 @@ function nativeInstallDir(): string | undefined {
   return basename(execDir) === 'bin' ? dirname(execDir) : undefined;
 }
 
+/** Shell-quote a value for single-quote context: safe for paths containing `'`. */
+function shellQuote(val: string): string {
+  return `'${val.replace(/'/g, "'\\''")}'`;
+}
+
 /**
  * Render the env-var suffix (`| KIMI_…=… bash`) for a native install command.
  * The spawned path passes these variables through `SpawnCommand.env`; the
@@ -80,9 +85,11 @@ function nativeInstallDir(): string | undefined {
  */
 function nativeEnvPrefix(): string {
   const dir = nativeInstallDir();
-  const vars = ['KIMI_NO_MODIFY_PATH=1'];
-  if (dir !== undefined) vars.unshift(`KIMI_INSTALL_DIR='${dir}'`);
-  return vars.join(' ');
+  // Only override the install prefix and suppress PATH edits when we know
+  // where the running binary lives; otherwise let the installer use its
+  // defaults (including PATH modification) so the update ends up reachable.
+  if (dir === undefined) return '';
+  return `KIMI_INSTALL_DIR=${shellQuote(dir)} KIMI_NO_MODIFY_PATH=1`;
 }
 
 export function installCommandFor(
@@ -99,10 +106,13 @@ export function installCommandFor(
       return `yarn global add ${NPM_PACKAGE_NAME}@${version}`;
     case 'bun-global':
       return `bun add -g ${NPM_PACKAGE_NAME}@${version}`;
-    case 'native':
-      return platform === 'win32'
-        ? NATIVE_INSTALL_COMMAND_WIN
-        : NATIVE_INSTALL_COMMAND_UNIX.replace('| bash', `| ${nativeEnvPrefix()} bash`);
+    case 'native': {
+      if (platform === 'win32') return NATIVE_INSTALL_COMMAND_WIN;
+      const suffix = nativeEnvPrefix();
+      return suffix
+        ? NATIVE_INSTALL_COMMAND_UNIX.replace('| bash', `| ${suffix} bash`)
+        : NATIVE_INSTALL_COMMAND_UNIX;
+    }
     case 'unsupported':
       return `npm install -g ${NPM_PACKAGE_NAME}@${version}`;
   }
@@ -155,14 +165,21 @@ export function spawnForSource(
       // binary lives under a `bin/` subdirectory we pass the parent of that
       // `bin/` dir (e.g. ~/.local/bin/kimi → ~/.local).
       // Set KIMI_NO_MODIFY_PATH to skip shell-rc modification — during an
-      // upgrade the binary is already on the user's PATH.
+      // upgrade the binary is already on the user's PATH.  Only pass these
+      // vars when we know the running binary's prefix; otherwise let the
+      // installer use its full defaults (including PATH modification) so
+      // the update ends up reachable.
       const installDir = nativeInstallDir();
-      const env: Record<string, string> = { KIMI_NO_MODIFY_PATH: '1' };
-      if (installDir !== undefined) env.KIMI_INSTALL_DIR = installDir;
+      if (installDir !== undefined) {
+        return {
+          cmd: 'bash',
+          args: ['-c', `set -o pipefail; ${NATIVE_INSTALL_COMMAND_UNIX}`],
+          env: { KIMI_INSTALL_DIR: installDir, KIMI_NO_MODIFY_PATH: '1' },
+        };
+      }
       return {
         cmd: 'bash',
         args: ['-c', `set -o pipefail; ${NATIVE_INSTALL_COMMAND_UNIX}`],
-        env,
       };
     }
     case 'unsupported':

--- a/apps/kimi-code/test/cli/update/preflight.test.ts
+++ b/apps/kimi-code/test/cli/update/preflight.test.ts
@@ -413,13 +413,11 @@ describe('runUpdatePreflight', () => {
       const call = mocks.spawn.mock.calls[0];
       expect(call?.[0]).toBe('bash');
       const execDir = dirname(process.execPath);
-      const expectedInstallDir = basename(execDir) === 'bin' ? dirname(execDir) : execDir;
+      const envExpect: Record<string, unknown> = { KIMI_NO_MODIFY_PATH: '1' };
+      if (basename(execDir) === 'bin') envExpect.KIMI_INSTALL_DIR = dirname(execDir);
       expect(call?.[2]).toMatchObject({
         stdio: 'inherit',
-        env: expect.objectContaining({
-          KIMI_INSTALL_DIR: expectedInstallDir,
-          KIMI_NO_MODIFY_PATH: '1',
-        }),
+        env: expect.objectContaining(envExpect),
       });
       const [flag, script] = call?.[1] as string[];
       expect(flag).toBe('-c');

--- a/apps/kimi-code/test/cli/update/preflight.test.ts
+++ b/apps/kimi-code/test/cli/update/preflight.test.ts
@@ -413,12 +413,17 @@ describe('runUpdatePreflight', () => {
       const call = mocks.spawn.mock.calls[0];
       expect(call?.[0]).toBe('bash');
       const execDir = dirname(process.execPath);
-      const envExpect: Record<string, unknown> = { KIMI_NO_MODIFY_PATH: '1' };
-      if (basename(execDir) === 'bin') envExpect.KIMI_INSTALL_DIR = dirname(execDir);
-      expect(call?.[2]).toMatchObject({
-        stdio: 'inherit',
-        env: expect.objectContaining(envExpect),
-      });
+      if (basename(execDir) === 'bin') {
+        expect(call?.[2]).toMatchObject({
+          stdio: 'inherit',
+          env: expect.objectContaining({
+            KIMI_INSTALL_DIR: dirname(execDir),
+            KIMI_NO_MODIFY_PATH: '1',
+          }),
+        });
+      } else {
+        expect(call?.[2]).toEqual({ stdio: 'inherit' });
+      }
       const [flag, script] = call?.[1] as string[];
       expect(flag).toBe('-c');
       // pipefail must come before the pipeline so a failed `curl` is not masked

--- a/apps/kimi-code/test/cli/update/preflight.test.ts
+++ b/apps/kimi-code/test/cli/update/preflight.test.ts
@@ -1,6 +1,7 @@
 import type * as ChildProcess from 'node:child_process';
 import { spawnSync } from 'node:child_process';
 import { EventEmitter } from 'node:events';
+import { basename, dirname } from 'node:path';
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -411,7 +412,15 @@ describe('runUpdatePreflight', () => {
       await runUpdatePreflight('0.4.0', options);
       const call = mocks.spawn.mock.calls[0];
       expect(call?.[0]).toBe('bash');
-      expect(call?.[2]).toEqual({ stdio: 'inherit' });
+      const execDir = dirname(process.execPath);
+      const expectedInstallDir = basename(execDir) === 'bin' ? dirname(execDir) : execDir;
+      expect(call?.[2]).toMatchObject({
+        stdio: 'inherit',
+        env: expect.objectContaining({
+          KIMI_INSTALL_DIR: expectedInstallDir,
+          KIMI_NO_MODIFY_PATH: '1',
+        }),
+      });
       const [flag, script] = call?.[1] as string[];
       expect(flag).toBe('-c');
       // pipefail must come before the pipeline so a failed `curl` is not masked


### PR DESCRIPTION
## Related Issue
Fixes #500

this is an updated version of this pr it takes in consideration all the code reviews given 

## Problem

During `kimi upgrade` on native (SEA) installs, the spawned install script wrote to the default location instead of overwriting the current binary, and modified `.bashrc`/shell rc files unnecessarily. The user-visible command shown at the prompt also had three issues:

1. **Wrong overwrite for non-bin layouts** — When the binary lived outside a `bin/` directory (e.g. unpacked archive), the code passed that directory as `KIMI_INSTALL_DIR`, but the installer writes to `$KIMI_INSTALL_DIR/bin/kimi`, missing the running binary entirely.
2. **Broken env-var placement in prompt command** — `KIMI_INSTALL_DIR=... KIMI_NO_MODIFY_PATH=1 curl ... | bash` placed vars before `curl`, so they only affected `curl`, not the `bash` install script.
3. **Unsafe shell quoting** — `KIMI_INSTALL_DIR='/Users/O'Neil/.local'` broke on paths containing `'`, producing invalid shell syntax.
4. **PATH edits suppressed without a known prefix** — When falling back to the installer's default prefix, `KIMI_NO_MODIFY_PATH=1` was still set, preventing the newly installed binary from becoming reachable on PATH.

## What changed

- **`nativeInstallDir()`** — returns the install prefix (parent of `bin/`) only when `process.execPath` is under a `bin/` directory; returns `undefined` for flat layouts so the installer uses its defaults.
- **`shellQuote()`** — escapes embedded `'` characters using the `'\''` pattern for safe single-quote shell interpolation.
- **`nativeEnvPrefix()`** — renders `KIMI_INSTALL_DIR=<shell-quoted> KIMI_NO_MODIFY_PATH=1` when `nativeInstallDir()` returns a value; empty string otherwise (no vars at all).
- **`spawnForSource()`** — passes both env vars through `SpawnCommand.env` (safe for all paths) only when `nativeInstallDir()` returns a value; no custom env otherwise.
- **`installCommandFor()`** — places the env prefix between `|` and `bash` so the vars reach the install script: `curl ... | KIMI_INSTALL_DIR='...' KIMI_NO_MODIFY_PATH=1 bash`. Shows bare `curl ... | bash` when vars are empty.
- **`installUpdate()` / `startBackgroundInstall()`** — forward `env` from `SpawnCommand` to `spawn()` options (no change needed).
- **Tests updated** — assert both vars in spawn env when under `bin/`; assert no custom env (`{ stdio: 'inherit' }`) when not.

## Checklist

- [x] I have read the CONTRIBUTING document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill (changeset: `wise-berries-return.md`, patch bump).
- [x] Ran `gen-docs` skill, or this PR needs no doc update.

## Summary

Ensures the native upgrade flow overwrites the running binary in place, skips shell-rc modification, displays a correct and copy-paste-safe command, and safely falls back to the installer's defaults for flat-archive executions.