### PR TITLE
fix: remove auto-compaction turn limit

### DIFF
--- a/.changeset/remove-compaction-turn-limit.md
+++ b/.changeset/remove-compaction-turn-limit.md
@@ -1,0 +1,6 @@
+---
+"@moonshot-ai/agent-core": patch
+"@moonshot-ai/kimi-code": patch
+---
+
+Remove the per-turn auto-compaction limit so long conversations can keep compacting instead of failing early.

--- a/packages/agent-core/src/agent/compaction/strategy.ts
+++ b/packages/agent-core/src/agent/compaction/strategy.ts
@@ -17,7 +17,7 @@ export const DEFAULT_COMPACTION_CONFIG: CompactionConfig = {
   triggerRatio: 0.85,
   blockRatio: 0.85, // Same as triggerRatio to disable async compaction
   reservedContextSize: 50_000,
-  maxCompactionPerTurn: 3,
+  maxCompactionPerTurn: Infinity,
   maxRecentMessages: 4,
   maxRecentUserMessages: Infinity,
   maxRecentSizeRatio: 0.2,


### PR DESCRIPTION
## Related Issue

No related issue. This addresses a reproduced long-conversation failure where automatic context compaction can hit the per-turn cap and end the turn with `context.overflow`.

## Problem

Automatic compaction currently has a default per-turn limit of three attempts. In a long session, a turn can still be above the compaction threshold after those attempts, so the agent fails with `Compaction limit exceeded (3)` even when another compaction pass may still make progress.

## What changed

- Removed the default per-turn auto-compaction cap by setting the default limit to `Infinity`.
- Kept explicit custom compaction strategy limits intact, so tests or callers that inject a capped strategy still behave the same.
- Added a changeset for the agent core package and the CLI bundle that consumes it.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [ ] I have added tests that prove my feature works. Existing compaction tests were run; no new test was added for this one-line default configuration change.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update. No docs mention this internal per-turn cap.
