### PR TITLE
feat: guide AI to prefer ReadMediaFile for user-provided videos

### DIFF
--- a/packages/agent-core/src/profile/default/system.md
+++ b/packages/agent-core/src/profile/default/system.md
@@ -61,7 +61,7 @@ The user may ask you to research on certain topics, process or generate certain 
 - Understand the user's requirements thoroughly, ask for clarification before you start if needed.
 - Make plans before doing deep or wide research, to ensure you are always on track.
 - Search on the Internet if possible, with carefully-designed search queries to improve efficiency and accuracy.
-- Use proper tools or shell commands or Python packages to process or generate images, videos, PDFs, docs, spreadsheets, presentations, or other multimedia files. Detect if there are already such tools in the environment. If you have to install third-party tools/packages, you MUST ensure that they are installed in a virtual/isolated environment.
+- Use proper tools or shell commands or Python packages to process or generate images, videos, PDFs, docs, spreadsheets, presentations, or other multimedia files. **When the user provides video files directly (e.g., via a path in the conversation), prefer the ReadMediaFile tool to read them natively instead of writing Python scripts or shell commands to extract frames or process the video.** Detect if there are already such tools in the environment. If you have to install third-party tools/packages, you MUST ensure that they are installed in a virtual/isolated environment.
 - Once you generate or edit any images, videos or other media files, try to read it again before proceed, to ensure that the content is as expected.
 - Avoid installing or deleting anything to/from outside of the current working directory. If you have to do so, ask the user for confirmation.
 

--- a/packages/agent-core/src/tools/builtin/file/read-media.md
+++ b/packages/agent-core/src/tools/builtin/file/read-media.md
@@ -9,5 +9,6 @@ Read media content from a file.
 - If the file doesn't exist or path is invalid, an error will be returned.
 - The maximum size that can be read is {{ MAX_MEDIA_MEGABYTES }}MB. An error will be returned if the file is larger than this limit.
 - The media content will be returned in a form that you can directly view and understand.
+- **For video files provided by the user, always prefer this tool over writing Python scripts or shell commands to extract frames or process the video. ReadMediaFile handles video input natively when the model supports it.**
 
 **Capabilities**


### PR DESCRIPTION
## Problem

When users provide video files directly (e.g., via a path in the conversation), the AI was defaulting to writing Python scripts or shell commands (e.g., ffmpeg) to extract frames or process the video, instead of using the native `ReadMediaFile` tool which handles video input natively when the model supports it.

This was reported in feedback Q-0266.

## Solution

Add explicit prompt-level guidance in two places to steer the AI toward the correct tool:

### 1. system.md — General Guidelines

In the "General Guidelines for Research and Data Processing" section, added a bold instruction:

> **When the user provides video files directly (e.g., via a path in the conversation), prefer the ReadMediaFile tool to read them natively instead of writing Python scripts or shell commands to extract frames or process the video.**

### 2. read-media.md — Tool Tips

Added a new tip at the end of the Tips section:

> **For video files provided by the user, always prefer this tool over writing Python scripts or shell commands to extract frames or process the video. ReadMediaFile handles video input natively when the model supports it.**

## Why this approach

- **Minimal change**: Only 2 lines added across 2 files. No code logic changes.
- **Dual coverage**: System prompt + tool description both reinforce the guidance, maximizing the chance the AI picks up the instruction regardless of which context it is reasoning from.
- **Zero regression risk**: All existing tests pass (2243 passed; 16 failures are pre-existing environment issues unrelated to this change).
- **Follows existing patterns**: The bold formatting and direct instruction style match how other strong recommendations are phrased in the system prompt.

## Test Results

- `prompt-placeholders.test.ts`: ✅ 4 passed
- `read-media-desc.test.ts`: ✅ 5 passed
- `read-media.test.ts`: ✅ 21 passed
- Full agent-core suite: ✅ 2243 passed (16 failures are pre-existing `undici` missing env issues)

---

Fixes: feedback Q-0266 (Kimi CLI 视频分析希望默认调用 ReadMediaFile 而不是写 Python 切帧)
