### PR TITLE
docs: fix broken fragment anchors in EN reference pages

### DIFF
--- a/docs/en/reference/keyboard.md
+++ b/docs/en/reference/keyboard.md
@@ -69,7 +69,7 @@ When collapsed tool call results exist in the history, press `Ctrl-O` to toggle 
 
 ## Approval Panel
 
-When the Agent initiates a tool call that requires confirmation, the TUI displays an approval panel. For the full approval workflow, see [Interaction & Input](../guides/interaction.md#审批流程). The available keys inside the panel are:
+When the Agent initiates a tool call that requires confirmation, the TUI displays an approval panel. For the full approval workflow, see [Interaction & Input](../guides/interaction.md#approval-flow). The available keys inside the panel are:
 
 | Shortcut | Function |
 | --- | --- |

--- a/docs/en/reference/slash-commands.md
+++ b/docs/en/reference/slash-commands.md
@@ -14,7 +14,7 @@ Some commands are only available in the idle state. Executing these commands whi
 | --- | --- | --- | --- |
 | `/login` | — | Select an account or platform and log in: Kimi Code uses OAuth device-code flow; Kimi Platform uses API key login | No |
 | `/logout` | — | Clear credentials for the currently selected account | No |
-| `/provider` | — | Open the interactive provider manager to view, add, and remove configured providers. See [Platforms & Models — `/provider` and provider management](../configuration/providers.md#provider-与供应商管理) | Yes |
+| `/provider` | — | Open the interactive provider manager to view, add, and remove configured providers. See [Platforms & Models — `/provider` and provider management](../configuration/providers.md#provider-—-interactive-provider-management) | Yes |
 | `/model` | — | Switch the LLM model used in the current session | Yes |
 | `/settings` | `/config` | Open the settings panel inside the TUI | Yes |
 | `/experiments` | `/experimental` | Open the experimental feature panel. Confirm changes to persist them to `config.toml` and reload the current session | Yes |

--- a/docs/en/reference/tools.md
+++ b/docs/en/reference/tools.md
@@ -112,7 +112,7 @@ Background task tools manage tasks started via `Bash`, `Agent`, or `AskUserQuest
 
 ## Scheduled Tasks
 
-Scheduled task tools allow the Agent to re-inject a prompt into the current session at a future time — either as a one-time reminder or as a recurring cron-triggered task (periodic checks, daily reports, deployment monitoring, etc.). Schedules are bound to the session and remain active after `kimi resume`, but are not carried into a brand-new session. A single session can hold at most 50 active scheduled tasks. Set `KIMI_DISABLE_CRON=1` to disable them entirely; see [Environment Variables](../configuration/env-vars.md#运行时开关).
+Scheduled task tools allow the Agent to re-inject a prompt into the current session at a future time — either as a one-time reminder or as a recurring cron-triggered task (periodic checks, daily reports, deployment monitoring, etc.). Schedules are bound to the session and remain active after `kimi resume`, but are not carried into a brand-new session. A single session can hold at most 50 active scheduled tasks. Set `KIMI_DISABLE_CRON=1` to disable them entirely; see [Environment Variables](../configuration/env-vars.md#runtime-switches).
 
 | Tool | Default Approval | Description |
 | --- | --- | --- |


### PR DESCRIPTION
## Problem

Three English reference pages link to Chinese-language fragment anchors that do not exist on the corresponding EN pages (VitePress generates anchors from the heading text, so the EN pages have English anchors). Clicking these links opens the correct page but fails to scroll to the target section.

| File | Broken anchor | Correct anchor |
|------|--------------|----------------|
| `en/reference/slash-commands.md` | `#provider-与供应商管理` | `#provider-—-interactive-provider-management` |
| `en/reference/tools.md` | `#运行时开关` | `#runtime-switches` |
| `en/reference/keyboard.md` | `#审批流程` | `#approval-flow` |

The Chinese anchors were likely carried over from the ZH docs during the EN translation (#386 / #391) and were not updated to match the English headings.

The corresponding ZH docs are correct — they use the same Chinese anchors and the ZH pages have Chinese headings, so the anchors match.

## What changed

Replaced the three Chinese fragment anchors with the correct English anchors generated by VitePress from the EN heading text. 3 files, 3 lines changed.

## Verification

- `pnpm -C docs run build` — passes with no broken-link warnings
- Confirmed all three corrected anchors exist in the built HTML (`id="provider-—-interactive-provider-management"`, `id="runtime-switches"`, `id="approval-flow"`)
- Verified on the live site (`moonshotai.github.io/kimi-code`) that the Chinese anchors return `getElementById → null` while the English anchors resolve correctly

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works. (N/A: docs-only fix; verified with docs build and live-site check.)
- [x] Ran `gen-changesets` skill, or this PR needs no changeset. (Docs-only, no changeset needed.)
- [x] Ran `gen-docs` skill, or this PR needs no doc update. (This *is* the doc fix.)