### PR TITLE
fix(tui): keep the /mcp panel border intact on multi-line server errors

### DIFF
--- a/.changeset/fix-mcp-status-multiline-error.md
+++ b/.changeset/fix-mcp-status-multiline-error.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Fix the `/mcp` status panel border being broken by multi-line MCP server errors, which are now folded onto a single row.

--- a/apps/kimi-code/src/tui/components/messages/mcp-status-panel.ts
+++ b/apps/kimi-code/src/tui/components/messages/mcp-status-panel.ts
@@ -58,6 +58,19 @@ function formatToolsAvailable(count: number): string {
   return `${count} tool${count === 1 ? '' : 's'} available`;
 }
 
+/**
+ * Collapse a (possibly multi-line) MCP error into a single line. The status
+ * panel renders each returned string as exactly one boxed row (see
+ * `UsagePanelComponent.render`), so an embedded newline — e.g. the
+ * `\nstderr: ...` a failed stdio server appends — would drop the trailing
+ * text to column 0 and punch through the rounded border. Folding every run
+ * of whitespace to a single space keeps the error on one row, which the
+ * panel then truncates to the available width.
+ */
+function formatErrorLine(error: string): string {
+  return error.trim().replaceAll(/\s+/g, ' ');
+}
+
 function sortedServers(servers: readonly McpServerInfo[]): McpServerInfo[] {
   return servers.toSorted(
     (a, b) =>
@@ -129,7 +142,7 @@ export function buildMcpStatusReportLines(options: McpStatusReportOptions): stri
       server.error !== undefined &&
       server.error.trim().length > 0
     ) {
-      lines.push(`    ${muted('error:')} ${error(server.error.trim())}`);
+      lines.push(`    ${muted('error:')} ${error(formatErrorLine(server.error))}`);
     }
     if (server.status === 'needs-auth') {
       lines.push(`    ${muted('action:')} ${value(`run /mcp-config login ${server.name}`)}`);

--- a/apps/kimi-code/test/tui/components/messages/mcp-status-panel.test.ts
+++ b/apps/kimi-code/test/tui/components/messages/mcp-status-panel.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest';
+
+import { buildMcpStatusReportLines } from '#/tui/components/messages/mcp-status-panel';
+import { darkColors } from '#/tui/theme/colors';
+
+function strip(text: string): string {
+  return text.replaceAll(/\[[0-9;]*m/g, '');
+}
+
+describe('buildMcpStatusReportLines', () => {
+  it('folds a multi-line server error onto one row so the panel box stays intact', () => {
+    const lines = buildMcpStatusReportLines({
+      colors: darkColors,
+      servers: [
+        {
+          name: 'ghidra',
+          transport: 'stdio',
+          status: 'failed',
+          toolCount: 0,
+          error:
+            'MCP error -32000: Connection closed\nstderr: usage: bridge_mcp_ghidra.py [-h] [--mcp-host MCP_HOST]',
+        },
+      ],
+    }).map(strip);
+
+    // The box renderer (UsagePanelComponent.render) treats each returned string
+    // as exactly one row, so an embedded newline would punch through the border.
+    for (const line of lines) {
+      expect(line).not.toContain('\n');
+    }
+
+    const errorLine = lines.find((line) => line.includes('error:'));
+    expect(errorLine).toContain(
+      'MCP error -32000: Connection closed stderr: usage: bridge_mcp_ghidra.py [-h] [--mcp-host MCP_HOST]',
+    );
+  });
+
+  it('trims and keeps a single-line error intact', () => {
+    const lines = buildMcpStatusReportLines({
+      colors: darkColors,
+      servers: [
+        {
+          name: 'ida',
+          transport: 'http',
+          status: 'failed',
+          toolCount: 0,
+          error: '  fetch failed  ',
+        },
+      ],
+    }).map(strip);
+
+    const errorLine = lines.find((line) => line.includes('error:'));
+    expect(errorLine).toContain('error: fetch failed');
+  });
+});


### PR DESCRIPTION
## Related Issue

Resolve #510

## Problem

When a failed MCP server reports a multi-line error, the `/mcp` status panel's
border breaks. The panel (`UsagePanelComponent.render`) treats each line it is
given as exactly one boxed row, so an embedded newline — e.g. the
`\nstderr: ...` a failed stdio server appends — drops the trailing text to
column 0 and punches through the rounded border.

Repro (from #510): a stdio MCP server that fails to start returns something like
`MCP error -32000: Connection closed\nstderr: usage: ...`; running `/mcp` makes
that error row overflow the rounded box.

## What changed

- Added `formatErrorLine` in `mcp-status-panel.ts`, which trims the error and
  folds every run of whitespace (including newlines) to a single space, keeping
  it on one row that the panel then truncates to the available width.
- Applied it to the rendered `error:` row.
- Added unit tests covering the multi-line fold and the single-line trim cases.

> Note: the same newline-breaks-the-box hazard exists structurally in the shared
> `UsagePanelComponent` renderer (it also affects the `/goal` reason row). This PR
> intentionally scopes the fix to the reported `/mcp` symptom; happy to harden the
> renderer for all panels in a follow-up if preferred.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset. (patch -> `@moonshot-ai/kimi-code`)
- [x] Ran `gen-docs` skill, or this PR needs no doc update. (bug fix, no user-facing doc change)

## Verification

```sh
pnpm run lint && pnpm run sherif
pnpm run test
pnpm run build && pnpm -C apps/kimi-code run smoke
pnpm --filter @moonshot-ai/kimi-code exec tsc --noEmit
```
