### PR TITLE
docs: fix broken fragment anchors (underscore vs hyphen slugify)

### DIFF
--- a/docs/en/configuration/config-files.md
+++ b/docs/en/configuration/config-files.md
@@ -87,7 +87,7 @@ Fields in the config file fall into two categories: **top-level scalars** that d
 | `providers` | `table` | `{}` | API provider table → [`providers`](#providers) |
 | `models` | `table` | — | Model alias table → [`models`](#models) |
 | `thinking` | `table` | — | Default parameters for Thinking mode → [`thinking`](#thinking) |
-| `loop_control` | `table` | — | Agent loop control parameters → [`loop_control`](#loop_control) |
+| `loop_control` | `table` | — | Agent loop control parameters → [`loop_control`](#loop-control) |
 | `background` | `table` | — | Background task runtime parameters → [`background`](#background) |
 | `experimental` | `table` | — | Persistent experimental feature toggles → [`experimental`](#experimental) |
 | `services` | `table` | — | Built-in external service configuration → [`services`](#services) |
@@ -143,7 +143,7 @@ model = "gpt-4.1"
 max_context_size = 1047576
 ```
 
-You can also switch models temporarily without touching the config file — by setting `KIMI_MODEL_*` environment variables, the CLI synthesizes a temporary provider in memory that does not persist after restart. See [Define a model from environment variables](./env-vars.md#define-a-model-from-environment-variables-kimi_model).
+You can also switch models temporarily without touching the config file — by setting `KIMI_MODEL_*` environment variables, the CLI synthesizes a temporary provider in memory that does not persist after restart. See [Define a model from environment variables](./env-vars.md#define-a-model-from-environment-variables-kimi-model).
 
 ## `thinking`
 

--- a/docs/en/configuration/env-vars.md
+++ b/docs/en/configuration/env-vars.md
@@ -34,7 +34,7 @@ export KIMI_DISABLE_TELEMETRY=1
 
 ### `KIMI_MODEL_*` family
 
-Switch models temporarily without modifying `config.toml` — when `KIMI_MODEL_NAME` is set, the CLI synthesizes a temporary provider in memory; the change does not persist after restart. See [Define a model from environment variables](#define-a-model-from-environment-variables-kimi_model).
+Switch models temporarily without modifying `config.toml` — when `KIMI_MODEL_NAME` is set, the CLI synthesizes a temporary provider in memory; the change does not persist after restart. See [Define a model from environment variables](#define-a-model-from-environment-variables-kimi-model).
 
 ## Provider credential key names (written in config.toml)
 

--- a/docs/zh/configuration/config-files.md
+++ b/docs/zh/configuration/config-files.md
@@ -87,7 +87,7 @@ timeout = 5
 | `providers` | `table` | `{}` | API 供应商表 → [`providers`](#providers) |
 | `models` | `table` | — | 模型别名表 → [`models`](#models) |
 | `thinking` | `table` | — | Thinking 模式默认参数 → [`thinking`](#thinking) |
-| `loop_control` | `table` | — | Agent 循环控制参数 → [`loop_control`](#loop_control) |
+| `loop_control` | `table` | — | Agent 循环控制参数 → [`loop_control`](#loop-control) |
 | `background` | `table` | — | 后台任务运行参数 → [`background`](#background) |
 | `experimental` | `table` | — | 持久化实验功能开关 → [`experimental`](#experimental) |
 | `services` | `table` | — | 内置外部服务配置 → [`services`](#services) |

--- a/docs/zh/configuration/env-vars.md
+++ b/docs/zh/configuration/env-vars.md
@@ -34,7 +34,7 @@ export KIMI_DISABLE_TELEMETRY=1
 
 ### `KIMI_MODEL_*` 系列
 
-不修改 `config.toml` 临时切换模型——设置 `KIMI_MODEL_NAME` 后，CLI 在内存里合成一个临时供应商，重启后失效。详见[用环境变量定义模型](#用环境变量定义模型kimi_model)。
+不修改 `config.toml` 临时切换模型——设置 `KIMI_MODEL_NAME` 后，CLI 在内存里合成一个临时供应商，重启后失效。详见[用环境变量定义模型](#用环境变量定义模型-kimi-model)。
 
 ## 供应商凭证键（写在 config.toml 里）
 


### PR DESCRIPTION
## Related Issue

No linked issue; this fixes broken fragment anchors caused by VitePress slugify behavior.

## Problem

Several docs pages use underscores in fragment anchors (e.g. `#loop_control`, `#…-kimi_model`), but VitePress converts underscores to hyphens when generating heading `id` attributes. These links open the correct page but fail to scroll to the target section.

| File | Broken anchor | Correct anchor |
|------|--------------|----------------|
| `en/configuration/config-files.md` | `#loop_control` | `#loop-control` |
| `zh/configuration/config-files.md` | `#loop_control` | `#loop-control` |
| `en/configuration/env-vars.md` | `#…-kimi_model` | `#…-kimi-model` |
| `en/configuration/config-files.md` | `#…-kimi_model` | `#…-kimi-model` |
| `zh/configuration/env-vars.md` | `#…kimi_model` | `#…-kimi-model` |

## What changed

Replaced 5 underscore-based fragment anchors with the correct hyphen-based anchors generated by VitePress. 4 files, 5 lines changed.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works. (N/A: docs-only fix; verified with docs build.)
- [x] Ran `gen-changesets` skill, or this PR needs no changeset. (Docs-only, no changeset needed.)
- [x] Ran `gen-docs` skill, or this PR needs no doc update. (This is the doc fix.)