### PR TITLE
feat: add --agents-dir CLI option for custom agent profiles

### DIFF
--- a/.changeset/custom-agents-dir.md
+++ b/.changeset/custom-agents-dir.md
@@ -1,0 +1,7 @@
+---
+"@moonshot-ai/agent-core": minor
+"@moonshot-ai/kimi-code-sdk": minor
+"@moonshot-ai/kimi-code": minor
+---
+
+Add `--agents-dir` CLI option to load custom agent profiles from a user-specified directory instead of the bundled defaults.

--- a/apps/kimi-code/src/cli/commands.ts
+++ b/apps/kimi-code/src/cli/commands.ts
@@ -71,6 +71,12 @@ export function createProgram(
         .argParser((value: string, previous: string[] | undefined) => [...(previous ?? []), value])
         .default([]),
     )
+    .addOption(
+      new Option(
+        '--agents-dir <dir>',
+        'Load agent profiles from this directory instead of the bundled defaults.',
+      ),
+    )
     .addOption(new Option('--yes').hideHelp().default(false))
     .addOption(new Option('--auto-approve').hideHelp().default(false))
     .option('--plan', 'Start in plan mode.', false);
@@ -119,6 +125,7 @@ export function createProgram(
       outputFormat: raw['outputFormat'] as CLIOptions['outputFormat'],
       prompt: raw['prompt'] as string | undefined,
       skillsDirs: raw['skillsDir'] as string[],
+      agentsDir: raw['agentsDir'] as string | undefined,
     };
 
     onMain(opts);

--- a/apps/kimi-code/src/cli/options.ts
+++ b/apps/kimi-code/src/cli/options.ts
@@ -11,6 +11,7 @@ export interface CLIOptions {
   outputFormat: PromptOutputFormat | undefined;
   prompt: string | undefined;
   skillsDirs: string[];
+  agentsDir?: string | undefined;
 }
 
 export interface ValidatedOptions {

--- a/apps/kimi-code/src/cli/run-prompt.ts
+++ b/apps/kimi-code/src/cli/run-prompt.ts
@@ -75,6 +75,7 @@ export async function runPrompt(
     identity: createKimiCodeHostIdentity(version),
     uiMode: PROMPT_UI_MODE,
     skillDirs: opts.skillsDirs,
+    agentsDir: opts.agentsDir,
     telemetry: telemetryClient,
     onOAuthRefresh: (outcome) => {
       if (outcome.success) {

--- a/apps/kimi-code/src/cli/run-shell.ts
+++ b/apps/kimi-code/src/cli/run-shell.ts
@@ -60,6 +60,7 @@ export async function runShell(
     homeDir: telemetryBootstrap.homeDir,
     identity: createKimiCodeHostIdentity(version),
     telemetry: telemetryClient,
+    agentsDir: opts.agentsDir,
     onOAuthRefresh: (outcome) => {
       if (outcome.success) {
         track('oauth_refresh', { success: true });

--- a/apps/kimi-code/src/main.ts
+++ b/apps/kimi-code/src/main.ts
@@ -113,6 +113,7 @@ const MIGRATE_CLI_OPTIONS: CLIOptions = {
   outputFormat: undefined,
   prompt: undefined,
   skillsDirs: [],
+  agentsDir: undefined,
 };
 
 export function main(): void {

--- a/apps/kimi-code/test/cli/options.test.ts
+++ b/apps/kimi-code/test/cli/options.test.ts
@@ -41,6 +41,7 @@ describe('CLI options parsing', () => {
       expect(opts.outputFormat).toBeUndefined();
       expect(opts.prompt).toBeUndefined();
       expect(opts.skillsDirs).toEqual([]);
+      expect(opts.agentsDir).toBeUndefined();
     });
   });
 
@@ -252,6 +253,12 @@ describe('CLI options parsing', () => {
         '/one',
         '/two',
       ]);
+    });
+  });
+
+  describe('--agents-dir', () => {
+    it('parses a custom agents directory', () => {
+      expect(parse(['--agents-dir', '/custom/agents']).agentsDir).toBe('/custom/agents');
     });
   });
 

--- a/packages/agent-core/src/profile/custom-loader.ts
+++ b/packages/agent-core/src/profile/custom-loader.ts
@@ -1,0 +1,40 @@
+import { readdir, readFile } from 'node:fs/promises';
+import { join } from 'pathe';
+
+import { DEFAULT_INIT_PROMPT, DEFAULT_PROFILE_PATHS, PROFILE_SOURCES } from './default';
+import { loadAgentProfilesFromSources } from './load';
+import type { ResolvedAgentProfile } from './types';
+
+export async function loadCustomAgentProfiles(
+  dir: string,
+): Promise<{ profiles: Record<string, ResolvedAgentProfile>; initPrompt: string }> {
+  const entries = await readdir(dir);
+  const customSources: Record<string, string> = {};
+  const customPaths: string[] = [];
+
+  for (const file of ['agent.yaml']) {
+    if (!entries.includes(file)) continue;
+    const content = await readFile(join(dir, file), 'utf-8');
+    const sourcePath = `profile/default/${file}`;
+    customSources[sourcePath] = content;
+    customPaths.push(sourcePath);
+  }
+
+  for (const file of ['system.md']) {
+    if (entries.includes(file)) {
+      customSources[`profile/default/${file}`] = await readFile(join(dir, file), 'utf-8');
+    }
+  }
+
+  const mergedSources = { ...PROFILE_SOURCES, ...customSources };
+  const allPaths = [...new Set([...DEFAULT_PROFILE_PATHS, ...customPaths])];
+
+  const profiles = loadAgentProfilesFromSources(allPaths, mergedSources);
+
+  let initPrompt = DEFAULT_INIT_PROMPT;
+  if (entries.includes('init.md')) {
+    initPrompt = await readFile(join(dir, 'init.md'), 'utf-8');
+  }
+
+  return { profiles, initPrompt };
+}

--- a/packages/agent-core/src/profile/default.ts
+++ b/packages/agent-core/src/profile/default.ts
@@ -8,7 +8,7 @@ import { loadAgentProfilesFromSources } from './load';
 
 // Keyed by the source path the profile loader expects: profile YAML files
 // plus any file referenced through `systemPromptPath`.
-const PROFILE_SOURCES: Record<string, string> = {
+export const PROFILE_SOURCES: Record<string, string> = {
   'profile/default/agent.yaml': agentYaml,
   'profile/default/coder.yaml': coderYaml,
   'profile/default/explore.yaml': exploreYaml,
@@ -18,9 +18,11 @@ const PROFILE_SOURCES: Record<string, string> = {
 
 export const DEFAULT_INIT_PROMPT = initMd;
 
+export const DEFAULT_PROFILE_PATHS = ['agent.yaml', 'coder.yaml', 'explore.yaml', 'plan.yaml'].map(
+  (file) => `profile/default/${file}`,
+);
+
 export const DEFAULT_AGENT_PROFILES = loadAgentProfilesFromSources(
-  ['agent.yaml', 'coder.yaml', 'explore.yaml', 'plan.yaml'].map(
-    (file) => `profile/default/${file}`,
-  ),
+  DEFAULT_PROFILE_PATHS,
   PROFILE_SOURCES,
 );

--- a/packages/agent-core/src/profile/index.ts
+++ b/packages/agent-core/src/profile/index.ts
@@ -3,3 +3,4 @@ export * from './context';
 export * from './load';
 export * from './resolve';
 export * from './default';
+export * from './custom-loader';

--- a/packages/agent-core/src/rpc/core-impl.ts
+++ b/packages/agent-core/src/rpc/core-impl.ts
@@ -29,6 +29,12 @@ import {
 } from '../flags';
 import type { Logger } from '../logging/types';
 import { resolveSessionMcpConfig, mergeCallerMcpServers, type SessionMcpConfig } from '../mcp';
+import {
+  DEFAULT_AGENT_PROFILES,
+  DEFAULT_INIT_PROMPT,
+  loadCustomAgentProfiles,
+  type ResolvedAgentProfile,
+} from '../profile';
 import { Session, type SessionMeta, type SessionSkillConfig } from '../session';
 import { exportSessionDirectory } from '../session/export';
 import {
@@ -120,6 +126,7 @@ export interface KimiCoreOptions {
   readonly skillDirs?: readonly string[];
   readonly telemetry?: TelemetryClient | undefined;
   readonly appVersion?: string;
+  readonly agentsDir?: string | undefined;
 }
 
 export class KimiCore implements PromisableMethods<CoreAPI> {
@@ -143,6 +150,10 @@ export class KimiCore implements PromisableMethods<CoreAPI> {
   private pluginsLoadError: Error | undefined;
   private readonly appVersion: string | undefined;
   private readonly experimentalFlags: FlagResolver;
+  private readonly agentsDir: string | undefined;
+  private agentProfilesPromise:
+    | Promise<{ profiles: Record<string, ResolvedAgentProfile>; initPrompt: string }>
+    | undefined;
 
   constructor(
     protected readonly rpcClient: CoreRPCClient,
@@ -161,6 +172,7 @@ export class KimiCore implements PromisableMethods<CoreAPI> {
     this.skillDirs = options.skillDirs ?? [];
     this.telemetry = options.telemetry ?? noopTelemetryClient;
     this.appVersion = options.appVersion;
+    this.agentsDir = options.agentsDir;
     ensureKimiHome(this.homeDir);
     this.config = loadRuntimeConfig(this.configPath);
     this.experimentalFlags = new FlagResolver(
@@ -206,6 +218,7 @@ export class KimiCore implements PromisableMethods<CoreAPI> {
     await this.pluginsReady;
     const pluginSessionStarts = this.plugins.enabledSessionStarts();
     const mcpConfig = this.mergePluginMcpConfig(withCallerMcp);
+    const { profiles, initPrompt } = await this.resolveAgentProfiles();
 
     // Session ctor attaches its own log sink. If anything in the setup-after-
     // ctor block throws, `session.close()` releases the sink (and mcp).
@@ -228,6 +241,8 @@ export class KimiCore implements PromisableMethods<CoreAPI> {
       telemetry: withTelemetryContext(this.telemetry, { sessionId: summary.id }),
       pluginSessionStarts,
       appVersion: this.appVersion,
+      profiles,
+      initPrompt,
     });
     try {
       session.metadata = {
@@ -297,6 +312,7 @@ export class KimiCore implements PromisableMethods<CoreAPI> {
     await this.pluginsReady;
     const pluginSessionStarts = this.plugins.enabledSessionStarts();
     const mcpConfig = this.mergePluginMcpConfig(withCallerMcp);
+    const { profiles, initPrompt } = await this.resolveAgentProfiles();
     const runtime = await this.resolveRuntime(config);
     const session = new Session({
       kaos: (await this.getKaos()).withCwd(summary.workDir),
@@ -317,6 +333,8 @@ export class KimiCore implements PromisableMethods<CoreAPI> {
       initializeMainAgent: false,
       pluginSessionStarts,
       appVersion: this.appVersion,
+      profiles,
+      initPrompt,
     });
     let warning: string | undefined;
     try {
@@ -800,6 +818,26 @@ export class KimiCore implements PromisableMethods<CoreAPI> {
       });
     }
     return new SessionAPIImpl(session);
+  }
+
+  private async resolveAgentProfiles(): Promise<{
+    profiles: Record<string, ResolvedAgentProfile>;
+    initPrompt: string;
+  }> {
+    if (this.agentProfilesPromise === undefined) {
+      this.agentProfilesPromise = this.loadAgentProfiles();
+    }
+    return this.agentProfilesPromise;
+  }
+
+  private async loadAgentProfiles(): Promise<{
+    profiles: Record<string, ResolvedAgentProfile>;
+    initPrompt: string;
+  }> {
+    if (this.agentsDir === undefined) {
+      return { profiles: DEFAULT_AGENT_PROFILES, initPrompt: DEFAULT_INIT_PROMPT };
+    }
+    return loadCustomAgentProfiles(this.agentsDir);
   }
 
   private reloadProviderManager(): KimiConfig {

--- a/packages/agent-core/src/session/index.ts
+++ b/packages/agent-core/src/session/index.ts
@@ -61,6 +61,8 @@ export interface SessionOptions {
   readonly pluginSessionStarts?: readonly EnabledPluginSessionStart[];
   readonly appVersion?: string;
   readonly experimentalFlags?: ExperimentalFlagResolver;
+  readonly profiles?: Record<string, ResolvedAgentProfile>;
+  readonly initPrompt?: string;
 }
 
 export interface SessionSkillConfig {
@@ -190,8 +192,9 @@ export class Session {
   }
 
   async createMain() {
+    const profiles = this.options.profiles ?? DEFAULT_AGENT_PROFILES;
     const { agent } = await this.createAgent({ type: 'main' }, {
-      profile: DEFAULT_AGENT_PROFILES['agent'],
+      profile: profiles['agent'],
     });
     // The main-agent audit sink now exists; flush any goal records queued before it.
     this.goals.flushPendingRecords();
@@ -219,7 +222,8 @@ export class Session {
     // default profile so the resumed session is usable. Native sessions always
     // replay a non-empty system prompt and never enter this branch.
     const main = this.getReadyAgent('main');
-    const profile = DEFAULT_AGENT_PROFILES['agent'];
+    const profiles = this.options.profiles ?? DEFAULT_AGENT_PROFILES;
+    const profile = profiles['agent'];
     if (main !== undefined && profile !== undefined && main.config.systemPrompt === '') {
       await this.bootstrapAgentProfile(main, profile);
     }
@@ -331,7 +335,7 @@ export class Session {
     try {
       const handle = await mainAgent.subagentHost!.spawn('coder', {
         parentToolCallId: 'generate-agents-md',
-        prompt: DEFAULT_INIT_PROMPT,
+        prompt: this.options.initPrompt ?? DEFAULT_INIT_PROMPT,
         description: 'Initialize AGENTS.md',
         runInBackground: false,
         origin: { kind: 'system_trigger', name: 'init' },

--- a/packages/agent-core/src/session/subagent-host.ts
+++ b/packages/agent-core/src/session/subagent-host.ts
@@ -220,9 +220,10 @@ export class SessionSubagentHost {
   }
 
   private resolveProfile(parent: Agent, profileName: string): ResolvedAgentProfile {
+    const profiles = this.session.options.profiles ?? DEFAULT_AGENT_PROFILES;
     const profile =
-      DEFAULT_AGENT_PROFILES[parent.config.profileName ?? 'agent']?.subagents?.[profileName] ??
-      DEFAULT_AGENT_PROFILES['agent']?.subagents?.[profileName];
+      profiles[parent.config.profileName ?? 'agent']?.subagents?.[profileName] ??
+      profiles['agent']?.subagents?.[profileName];
     if (profile === undefined) {
       throw new Error(`Subagent profile "${profileName}" was not found`);
     }

--- a/packages/agent-core/test/session/subagent-host.test.ts
+++ b/packages/agent-core/test/session/subagent-host.test.ts
@@ -324,6 +324,7 @@ describe('SessionSubagentHost', () => {
     const createAgent = vi.fn();
     const host = new SessionSubagentHost(
       {
+        options: {},
         agents: new Map([['main', parent.agent]]),
         ensureAgentResumed: vi.fn(async () => parent.agent),
         createAgent,
@@ -349,6 +350,7 @@ describe('SessionSubagentHost', () => {
     const createAgent = vi.fn();
     const host = new SessionSubagentHost(
       {
+        options: {},
         agents: new Map([['main', parent.agent]]),
         ensureAgentResumed: vi.fn(async () => parent.agent),
         createAgent,
@@ -1125,6 +1127,7 @@ function fakeSession(
     agents.set('agent-0', child);
   }
   return {
+    options: {},
     agents,
     metadata: {
       createdAt: '2026-01-01T00:00:00.000Z',

--- a/packages/node-sdk/src/sdk-rpc-client.ts
+++ b/packages/node-sdk/src/sdk-rpc-client.ts
@@ -28,6 +28,7 @@ export interface SDKRpcClientOptions {
   readonly skillDirs?: readonly string[];
   readonly telemetry?: TelemetryClient;
   readonly onOAuthRefresh?: (outcome: OAuthRefreshOutcome) => void;
+  readonly agentsDir?: string;
 }
 
 export class SDKRpcClient extends SDKRpcClientBase {
@@ -69,6 +70,7 @@ export class SDKRpcClient extends SDKRpcClientBase {
       skillDirs: options.skillDirs,
       telemetry: this.telemetry,
       appVersion: this.identity?.version,
+      agentsDir: options.agentsDir,
     });
     this.ready = sdkRpc(new ClientAPI(this));
   }

--- a/packages/node-sdk/src/types.ts
+++ b/packages/node-sdk/src/types.ts
@@ -82,6 +82,7 @@ export interface KimiHarnessOptions {
   readonly skillDirs?: readonly string[];
   readonly telemetry?: TelemetryClient | undefined;
   readonly onOAuthRefresh?: ((outcome: OAuthRefreshOutcome) => void) | undefined;
+  readonly agentsDir?: string | undefined;
 }
 
 export interface CreateSessionOptions {


### PR DESCRIPTION
## Related Issue

Resolve #517

## Problem

Users want the ability to provide their own custom system prompts, agent configurations, and init messages instead of being locked into the bundled defaults from agent-core. Issue #517 specifically requests customising the system.md prompt to match previous preferred setups that performed better for individual workflows.

## What changed

Added a new --agents-dir <dir> CLI flag that loads agent profiles from a user-specified directory instead of the bundled defaults.

The custom directory can contain any combination of:

- agent.yaml - overrides the default agent profile configuration
- system.md - overrides the default system prompt
- init.md - overrides the default init prompt

Only files that exist are loaded; missing files fall back to the bundled defaults, so users can override selectively (e.g. only system.md) without having to provide the full profile set.

### Files changed

- apps/kimi-code/src/cli/commands.ts - registers the --agents-dir option and passes it through to CLIOptions
- apps/kimi-code/src/cli/options.ts - adds agentsDir?: string to the CLIOptions interface
- apps/kimi-code/src/main.ts - passes agentsDir through the harness options
- apps/kimi-code/src/cli/run-shell.ts - passes agentsDir to createKimiHarness
- apps/kimi-code/src/cli/run-prompt.ts - passes agentsDir to createKimiHarness
- packages/node-sdk/src/types.ts - adds agentsDir?: string to KimiHarnessOptions
- packages/node-sdk/src/sdk-rpc-client.ts - forwards agentsDir to KimiCore
- packages/agent-core/src/rpc/core-impl.ts - receives agentsDir, uses it to load custom profiles via loadCustomAgentProfiles
- packages/agent-core/src/profile/custom-loader.ts - new loader that reads agent.yaml, system.md, and init.md from the provided directory and merges them with defaults
- apps/kimi-code/test/cli/options.test.ts - adds parsing test for --agents-dir
- .changeset/custom-agents-dir.md - changeset for minor bumps on agent-core, kimi-code-sdk, and kimi-code

### Design decisions

- The flag is modelled after the existing --skills-dir option for consistency.
- Custom sources are merged with defaults rather than replacing them entirely, so partial overrides work without requiring users to duplicate bundled content.
- The feature is exposed as a CLI flag rather than a config.toml setting because it is inherently per-invocation (different projects may want different agent profiles).

## Checklist

- [x] I have read the CONTRIBUTING document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran gen-changesets skill, or this PR needs no changeset.
