### PR TITLE
docs: fix broken Next steps link in hooks.md

### DIFF
--- a/docs/en/customization/hooks.md
+++ b/docs/en/customization/hooks.md
@@ -152,5 +152,5 @@ This example only demonstrates the blocking mechanism — it is not a production
 
 ## Next steps
 
-- [Configuration files](../configuration/config-files.md#hooks) — Full field reference for `[[hooks]]` in `config.toml`
+- [Configuration files](../configuration/config-files.md) — full reference for `config.toml` fields
 - [Agents and sub-agents](./agents.md) — Use the `SubagentStop` event to trigger notifications after a sub-agent completes

--- a/docs/zh/customization/hooks.md
+++ b/docs/zh/customization/hooks.md
@@ -152,5 +152,5 @@ process.stdin.on('end', () => {
 
 ## 下一步
 
-- [配置文件](../configuration/config-files.md#hooks) — `[[hooks]]` 在 `config.toml` 中的完整字段声明
+- [配置文件](../configuration/config-files.md) — `config.toml` 各字段的完整说明
 - [Agent 与子 Agent](./agents.md) — 利用 `SubagentStop` 事件在子 Agent 完成后触发通知


### PR DESCRIPTION
## Problem

hooks.md "Next steps" links to `config-files.md#hooks`, but config-files.md has no `## hooks` section. The `#hooks` anchor does not exist, so the link does not scroll to any section.

## What changed

Removed the broken `#hooks` fragment and updated the description to match the style used by other pages linking to config-files.md (e.g. data-locations.md). 2 files, 2 lines changed (EN + ZH).

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works. (N/A: docs-only fix; verified with docs build.)
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.