### PR TITLE
feat(agent-core): add experimental PDF text extraction to Read

### DIFF
--- a/.changeset/pdf-read-pdftotext.md
+++ b/.changeset/pdf-read-pdftotext.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": minor
+---
+
+Add experimental PDF text extraction for Read through pdftotext.

--- a/packages/agent-core/src/agent/tool/index.ts
+++ b/packages/agent-core/src/agent/tool/index.ts
@@ -379,7 +379,7 @@ export class ToolManager {
       this.agent.experimentalFlags.enabled('goal_command') && this.agent.type === 'main';
     this.builtinTools = new Map(
       [
-        new b.ReadTool(kaos, workspace),
+        new b.ReadTool(kaos, workspace, this.agent.experimentalFlags),
         new b.WriteTool(kaos, workspace),
         new b.EditTool(kaos, workspace),
         new b.GrepTool(kaos, workspace),

--- a/packages/agent-core/src/flags/registry.ts
+++ b/packages/agent-core/src/flags/registry.ts
@@ -44,6 +44,14 @@ export const FLAG_DEFINITIONS = [
     default: false,
     surface: 'core',
   },
+  {
+    id: 'pdf_read',
+    title: 'PDF Read',
+    description: 'Allow the Read tool to extract text from PDF files through pdftotext.',
+    env: 'KIMI_CODE_EXPERIMENTAL_PDF_READ',
+    default: false,
+    surface: 'core',
+  },
 ] as const satisfies readonly FlagDefinitionInput[];
 
 /** Literal union of registered flag ids. */

--- a/packages/agent-core/src/tools/builtin/file/read.md
+++ b/packages/agent-core/src/tools/builtin/file/read.md
@@ -1,6 +1,6 @@
 Read a text file from the local filesystem.
 
-If the user provides a concrete file path to a text file, call Read directly. Do not `Glob`, `ls`, or otherwise pre-check known text file paths; missing or invalid file paths return errors you can handle. Do not use Read for directories; use `ls` via Bash for a known directory, or Glob when you need files/directories matching a pattern. Use `Grep` only when the task is to search for unknown content or locations.
+If the user provides a concrete file path to a text file, call Read directly. PDF files are treated as a text-workflow subtype: call Read for known `.pdf` paths too; when experimental PDF reading is enabled, Read extracts text with `pdftotext` and returns the same line-numbered text view. Do not use `pdftotext` via Bash just to read or preview a known PDF path. Do not `Glob`, `ls`, or otherwise pre-check known text/PDF file paths; missing or invalid file paths return errors you can handle. Do not use Read for directories; use `ls` via Bash for a known directory, or Glob when you need files/directories matching a pattern. Use `Grep` only when the task is to search for unknown content or locations.
 
 When you need several files, prefer to read them in parallel: emit multiple `Read` calls in a single response instead of reading one file per turn.
 
@@ -8,7 +8,7 @@ When you need several files, prefer to read them in parallel: emit multiple `Rea
 - Returns up to {{ MAX_LINES }} lines or {{ MAX_BYTES_KB }} KB per call, whichever comes first; lines longer than {{ MAX_LINE_LENGTH }} chars are truncated mid-line.
 - Page larger files with `line_offset` (1-based start line) and `n_lines`. Omit `n_lines` to read up to the {{ MAX_LINES }}-line cap.
 - Sensitive files (`.env` files, credential stores, SSH keys, and similar secrets) are refused to protect secrets; do not attempt to read them.
-- Only UTF-8 text files can be read. Non-UTF-8 encodings, binary files, and files containing NUL bytes are refused; use `ReadMediaFile` for images or video, and Bash or an MCP tool for other binary formats.
+- Only UTF-8 text files can be read. PDF is supported as an experimental text extraction subtype when enabled; output is extracted text, not visual page rendering. Non-UTF-8 encodings, binary files, and files containing NUL bytes are refused; use `ReadMediaFile` for images or video, and Bash or an MCP tool for other binary formats.
 - Negative line_offset reads from the end of the file (for example, -100 reads the last 100 lines); the absolute value cannot exceed {{ MAX_LINES }}.
 - Output format: `<line-number>\t<content>` per line.
 - A `<system>...</system>` status block is appended after the file content; it summarizes how much was read (line and byte counts, truncation, line-ending notes) and is not part of the file itself.

--- a/packages/agent-core/src/tools/builtin/file/read.ts
+++ b/packages/agent-core/src/tools/builtin/file/read.ts
@@ -309,11 +309,15 @@ export class ReadTool implements BuiltinTool<ReadInput> {
           pathClass: this.kaos.pathClass(),
           homeDir: this.kaos.gethome(),
         }),
-      execute: () => this.execution(args, path),
+      execute: ({ signal }) => this.execution(args, path, signal),
     };
   }
 
-  private async execution(args: ReadInput, safePath: string): Promise<ExecutableToolResult> {
+  private async execution(
+    args: ReadInput,
+    safePath: string,
+    signal: AbortSignal,
+  ): Promise<ExecutableToolResult> {
     try {
       let stat: StatResult;
       try {
@@ -356,6 +360,7 @@ export class ReadTool implements BuiltinTool<ReadInput> {
             lineOffset,
             effectiveLimit,
             requestedLines,
+            signal,
           );
         }
         return await this.readPdfForward(
@@ -364,6 +369,7 @@ export class ReadTool implements BuiltinTool<ReadInput> {
           lineOffset,
           effectiveLimit,
           requestedLines,
+          signal,
         );
       }
       if (fileType.kind === 'unknown') {
@@ -497,11 +503,12 @@ export class ReadTool implements BuiltinTool<ReadInput> {
     lineOffset: number,
     effectiveLimit: number,
     requestedLines: number,
+    signal: AbortSignal,
   ): Promise<ExecutableToolResult> {
     const selectedEntries: ReadLineEntry[] = [];
     let maxLinesReached = false;
     let collectionClosed = false;
-    const extraction = await this.extractPdfText(safePath, displayPath, {
+    const extraction = await this.extractPdfText(safePath, displayPath, signal, {
       onEntry: (entry) => {
         if (collectionClosed) {
           if (effectiveLimit >= MAX_LINES && entry.lineNo >= lineOffset) {
@@ -542,10 +549,11 @@ export class ReadTool implements BuiltinTool<ReadInput> {
     lineOffset: number,
     effectiveLimit: number,
     requestedLines: number,
+    signal: AbortSignal,
   ): Promise<ExecutableToolResult> {
     const tailCount = Math.abs(lineOffset);
     const entries: ReadLineEntry[] = [];
-    const extraction = await this.extractPdfText(safePath, displayPath, {
+    const extraction = await this.extractPdfText(safePath, displayPath, signal, {
       onEntry: (entry) => {
         entries.push(entry);
         if (entries.length > tailCount) {
@@ -571,8 +579,17 @@ export class ReadTool implements BuiltinTool<ReadInput> {
   private async extractPdfText(
     safePath: string,
     displayPath: string,
+    signal: AbortSignal,
     options: StreamTextOptions,
   ): Promise<CollectTextResult> {
+    if (signal.aborted) {
+      return {
+        result: { isError: true, output: pdfNotReadableOutput(displayPath, 'aborted') },
+        flags: { hasCrLf: false, hasLf: false, hasLoneCr: false },
+        totalLines: 0,
+      };
+    }
+
     let proc: KaosProcess;
     try {
       proc = await this.kaos.exec('pdftotext', '-layout', '-enc', 'UTF-8', safePath, '-');
@@ -604,6 +621,7 @@ export class ReadTool implements BuiltinTool<ReadInput> {
     }
 
     let timedOut = false;
+    let aborted = false;
     let killed = false;
     const killProc = async (): Promise<void> => {
       if (killed) return;
@@ -613,7 +631,24 @@ export class ReadTool implements BuiltinTool<ReadInput> {
       } catch {
         /* process already gone */
       }
+      try {
+        proc.stdout.destroy();
+      } catch {
+        /* ignore */
+      }
+      try {
+        proc.stderr.destroy();
+      } catch {
+        /* ignore */
+      }
     };
+    const onAbort = (): void => {
+      aborted = true;
+      void killProc();
+    };
+    signal.addEventListener('abort', onAbort);
+    if (signal.aborted) onAbort();
+
     const timeoutHandle = setTimeout(() => {
       timedOut = true;
       void killProc();
@@ -634,6 +669,13 @@ export class ReadTool implements BuiltinTool<ReadInput> {
               `pdftotext timed out after ${String(PDF_TEXT_EXTRACTION_TIMEOUT_MS / 1000)}s`,
             ),
           },
+          flags: { hasCrLf: false, hasLf: false, hasLoneCr: false },
+          totalLines: 0,
+        };
+      }
+      if (aborted) {
+        return {
+          result: { isError: true, output: pdfNotReadableOutput(displayPath, 'aborted') },
           flags: { hasCrLf: false, hasLf: false, hasLoneCr: false },
           totalLines: 0,
         };
@@ -668,6 +710,7 @@ export class ReadTool implements BuiltinTool<ReadInput> {
       };
     } finally {
       clearTimeout(timeoutHandle);
+      signal.removeEventListener('abort', onAbort);
     }
   }
 

--- a/packages/agent-core/src/tools/builtin/file/read.ts
+++ b/packages/agent-core/src/tools/builtin/file/read.ts
@@ -1,6 +1,9 @@
-import type { Kaos, StatResult } from '@moonshot-ai/kaos';
+import type { Kaos, KaosProcess, StatResult } from '@moonshot-ai/kaos';
+import type { Readable } from 'node:stream';
+import { StringDecoder } from 'node:string_decoder';
 import { z } from 'zod';
 
+import type { ExperimentalFlagResolver } from '../../../flags';
 import type { BuiltinTool } from '../../../agent/tool';
 import { ToolAccesses } from '../../../loop/tool-access';
 import type { ExecutableToolResult, ToolExecution } from '../../../loop/types';
@@ -18,6 +21,8 @@ export const MAX_LINE_LENGTH: number = 2000;
 export const MAX_BYTES: number = 100 * 1024;
 const S_IFMT = 0o170000;
 const S_IFREG = 0o100000;
+const PDF_TEXT_EXTRACTION_TIMEOUT_MS = 120_000;
+const PDF_TEXT_EXTRACTION_MAX_STDERR_BYTES = 16 * 1024;
 
 const PositiveLineOffsetSchema = z.number().int().min(1);
 const TailLineOffsetSchema = z.number().int().min(-MAX_LINES).max(-1);
@@ -26,7 +31,7 @@ export const ReadInputSchema = z.object({
   path: z
     .string()
     .describe(
-      'Path to a text file. Relative paths resolve against the working directory; a path outside the working directory must be absolute. Directories are not supported; use `ls` via Bash for a known directory, or Glob for pattern search.',
+      'Path to a text file, including PDF files when experimental PDF text extraction is enabled. Relative paths resolve against the working directory; a path outside the working directory must be absolute. Directories are not supported; use `ls` via Bash for a known directory, or Glob for pattern search.',
     ),
   line_offset: z
     .union([PositiveLineOffsetSchema, TailLineOffsetSchema])
@@ -77,6 +82,33 @@ interface FinishReadResultInput {
   readonly startLine: number;
   readonly totalLines: number;
   readonly requestedLines: number;
+  readonly sourceKind?: string;
+}
+
+interface FinishEntriesReadResultInput {
+  readonly entries: readonly ReadLineEntry[];
+  readonly flags: LineEndingFlags;
+  readonly maxLinesReached: boolean;
+  readonly requestedLines: number;
+  readonly startLine: number;
+  readonly totalLines: number;
+  readonly sourceKind?: string;
+  readonly byteTruncationMode?: 'head' | 'tail';
+}
+
+interface CollectTextResult {
+  readonly result?: ExecutableToolResult;
+  readonly flags: LineEndingFlags;
+  readonly totalLines: number;
+}
+
+interface StreamTextOptions {
+  readonly onEntry: (entry: ReadLineEntry) => void;
+}
+
+interface CappedStreamResult {
+  readonly text: string;
+  readonly truncated: boolean;
 }
 
 function truncateLine(line: string, maxLength: number): string {
@@ -152,6 +184,90 @@ function containsNulByte(text: string): boolean {
   return text.includes('\u0000');
 }
 
+function isAbortError(error: unknown): boolean {
+  return (
+    error instanceof Error &&
+    (error.name === 'AbortError' || /aborted|abort/i.test(error.message))
+  );
+}
+
+function isEnoentError(error: unknown): boolean {
+  return (
+    typeof error === 'object' &&
+    error !== null &&
+    (error as NodeJS.ErrnoException).code === 'ENOENT'
+  );
+}
+
+function pdftotextUnavailableOutput(): string {
+  return (
+    'PDF text extraction requires `pdftotext` from Poppler, but it was not found. ' +
+    'Install Poppler (macOS: `brew install poppler`; Ubuntu/Debian: `sudo apt-get install poppler-utils`) and retry.'
+  );
+}
+
+async function readStreamWithCap(stream: Readable, maxBytes: number): Promise<CappedStreamResult> {
+  const chunks: Buffer[] = [];
+  let total = 0;
+  let truncated = false;
+  for await (const chunk of stream) {
+    const buf: Buffer = typeof chunk === 'string' ? Buffer.from(chunk, 'utf8') : (chunk as Buffer);
+    if (truncated) continue;
+    if (total + buf.length > maxBytes) {
+      const remaining = maxBytes - total;
+      if (remaining > 0) chunks.push(buf.subarray(0, remaining));
+      total = maxBytes;
+      truncated = true;
+      continue;
+    }
+    chunks.push(buf);
+    total += buf.length;
+  }
+  return { text: Buffer.concat(chunks).toString('utf8'), truncated };
+}
+
+async function collectTextLines(
+  stream: Readable,
+  options: StreamTextOptions,
+): Promise<CollectTextResult> {
+  const decoder = new StringDecoder('utf8');
+  const flags: LineEndingFlags = { hasCrLf: false, hasLf: false, hasLoneCr: false };
+  let totalLines = 0;
+  let pending = '';
+
+  const flushLine = (line: string): void => {
+    totalLines += 1;
+    updateLineEndingFlags(flags, line);
+    const entry = {
+      lineNo: totalLines,
+      rawContent: stripTrailingLf(line),
+    };
+    options.onEntry(entry);
+  };
+
+  for await (const chunk of stream) {
+    const buf: Buffer = typeof chunk === 'string' ? Buffer.from(chunk, 'utf8') : (chunk as Buffer);
+    pending += decoder.write(buf);
+    let start = 0;
+    for (let i = 0; i < pending.length; i += 1) {
+      if (pending.codePointAt(i) !== 10) continue;
+      flushLine(pending.slice(start, i + 1));
+      start = i + 1;
+    }
+    pending = pending.slice(start);
+  }
+  pending += decoder.end();
+  if (pending.length > 0) {
+    flushLine(pending);
+  }
+
+  return { flags, totalLines };
+}
+
+function pdfNotReadableOutput(path: string, reason: string): string {
+  return `Failed to extract text from PDF "${path}" with pdftotext: ${reason}`;
+}
+
 function notReadableFileOutput(path: string): string {
   return (
     `"${path}" is not readable as UTF-8 text. ` +
@@ -173,6 +289,7 @@ export class ReadTool implements BuiltinTool<ReadInput> {
   constructor(
     private readonly kaos: Kaos,
     private readonly workspace: WorkspaceConfig,
+    private readonly experimentalFlags?: ExperimentalFlagResolver,
   ) {}
 
   resolveExecution(args: ReadInput): ToolExecution {
@@ -219,16 +336,42 @@ export class ReadTool implements BuiltinTool<ReadInput> {
           output: `"${args.path}" is a ${fileType.kind} file. Use ReadMediaFile to read image or video files.`,
         };
       }
+      const lineOffset = args.line_offset ?? 1;
+      const requestedLines = args.n_lines ?? MAX_LINES;
+      const effectiveLimit = Math.min(requestedLines, MAX_LINES);
+
+      if (fileType.kind === 'text' && fileType.mimeType === 'application/pdf') {
+        if (this.experimentalFlags?.enabled('pdf_read') !== true) {
+          return {
+            isError: true,
+            output:
+              `"${args.path}" is a PDF file. PDF text extraction is experimental; ` +
+              'enable KIMI_CODE_EXPERIMENTAL_PDF_READ to read it with pdftotext.',
+          };
+        }
+        if (lineOffset < 0) {
+          return await this.readPdfTail(
+            safePath,
+            args.path,
+            lineOffset,
+            effectiveLimit,
+            requestedLines,
+          );
+        }
+        return await this.readPdfForward(
+          safePath,
+          args.path,
+          lineOffset,
+          effectiveLimit,
+          requestedLines,
+        );
+      }
       if (fileType.kind === 'unknown') {
         return {
           isError: true,
           output: notReadableFileOutput(args.path),
         };
       }
-
-      const lineOffset = args.line_offset ?? 1;
-      const requestedLines = args.n_lines ?? MAX_LINES;
-      const effectiveLimit = Math.min(requestedLines, MAX_LINES);
 
       if (lineOffset < 0) {
         return await this.readTail(
@@ -299,38 +442,11 @@ export class ReadTool implements BuiltinTool<ReadInput> {
       }
     }
 
-    const lineEndingStyle = lineEndingStyleFromFlags(flags);
-    const renderedLines: string[] = [];
-    const truncatedLineNumbers: number[] = [];
-    let bytes = 0;
-    let maxBytesReached = false;
-
-    for (const entry of selectedEntries) {
-      const rendered = renderLine(entry, lineEndingStyle);
-      const lineBytes = renderedLineBytes(rendered.line, renderedLines.length === 0);
-      if (renderedLines.length > 0 && bytes + lineBytes > MAX_BYTES) {
-        maxBytesReached = true;
-        break;
-      }
-
-      if (rendered.wasTruncated) {
-        truncatedLineNumbers.push(entry.lineNo);
-      }
-      renderedLines.push(rendered.line);
-      bytes += lineBytes;
-      if (bytes >= MAX_BYTES) {
-        maxBytesReached = true;
-        break;
-      }
-    }
-
-    return this.finishReadResult({
-      renderedLines,
-      truncatedLineNumbers,
+    return this.finishEntriesReadResult({
+      entries: selectedEntries,
+      flags,
       maxLinesReached,
-      maxBytesReached,
-      lineEndingStyle,
-      startLine: renderedLines.length > 0 ? lineOffset : 0,
+      startLine: selectedEntries.length > 0 ? lineOffset : 0,
       totalLines: currentLineNo,
       requestedLines,
     });
@@ -363,8 +479,201 @@ export class ReadTool implements BuiltinTool<ReadInput> {
       }
     }
 
-    const lineEndingStyle = lineEndingStyleFromFlags(flags);
-    let renderedCandidates = entries.slice(0, effectiveLimit).map((entry) => {
+    const selected = entries.slice(0, effectiveLimit);
+    return this.finishEntriesReadResult({
+      entries: selected,
+      flags,
+      maxLinesReached: false,
+      startLine: selected[0]?.lineNo ?? 0,
+      totalLines: currentLineNo,
+      requestedLines,
+      byteTruncationMode: 'tail',
+    });
+  }
+
+  private async readPdfForward(
+    safePath: string,
+    displayPath: string,
+    lineOffset: number,
+    effectiveLimit: number,
+    requestedLines: number,
+  ): Promise<ExecutableToolResult> {
+    const selectedEntries: ReadLineEntry[] = [];
+    let maxLinesReached = false;
+    let collectionClosed = false;
+    const extraction = await this.extractPdfText(safePath, displayPath, {
+      onEntry: (entry) => {
+        if (collectionClosed) {
+          if (effectiveLimit >= MAX_LINES && entry.lineNo >= lineOffset) {
+            maxLinesReached = true;
+          }
+          return;
+        }
+        if (entry.lineNo < lineOffset) return;
+        if (selectedEntries.length >= effectiveLimit) {
+          if (effectiveLimit >= MAX_LINES) {
+            maxLinesReached = true;
+          }
+          collectionClosed = true;
+          return;
+        }
+        selectedEntries.push(entry);
+        if (selectedEntries.length >= effectiveLimit) {
+          collectionClosed = true;
+        }
+      },
+    });
+    if (extraction.result !== undefined) return extraction.result;
+
+    return this.finishEntriesReadResult({
+      entries: selectedEntries,
+      flags: extraction.flags,
+      maxLinesReached,
+      requestedLines,
+      startLine: selectedEntries.length > 0 ? lineOffset : 0,
+      totalLines: extraction.totalLines,
+      sourceKind: 'PDF',
+    });
+  }
+
+  private async readPdfTail(
+    safePath: string,
+    displayPath: string,
+    lineOffset: number,
+    effectiveLimit: number,
+    requestedLines: number,
+  ): Promise<ExecutableToolResult> {
+    const tailCount = Math.abs(lineOffset);
+    const entries: ReadLineEntry[] = [];
+    const extraction = await this.extractPdfText(safePath, displayPath, {
+      onEntry: (entry) => {
+        entries.push(entry);
+        if (entries.length > tailCount) {
+          entries.shift();
+        }
+      },
+    });
+    if (extraction.result !== undefined) return extraction.result;
+
+    const selected = entries.slice(0, effectiveLimit);
+    return this.finishEntriesReadResult({
+      entries: selected,
+      flags: extraction.flags,
+      maxLinesReached: false,
+      requestedLines,
+      startLine: selected[0]?.lineNo ?? 0,
+      totalLines: extraction.totalLines,
+      sourceKind: 'PDF',
+      byteTruncationMode: 'tail',
+    });
+  }
+
+  private async extractPdfText(
+    safePath: string,
+    displayPath: string,
+    options: StreamTextOptions,
+  ): Promise<CollectTextResult> {
+    let proc: KaosProcess;
+    try {
+      proc = await this.kaos.exec('pdftotext', '-layout', '-enc', 'UTF-8', safePath, '-');
+    } catch (error) {
+      if (isEnoentError(error)) {
+        return {
+          result: { isError: true, output: pdftotextUnavailableOutput() },
+          flags: { hasCrLf: false, hasLf: false, hasLoneCr: false },
+          totalLines: 0,
+        };
+      }
+      return {
+        result: {
+          isError: true,
+          output: pdfNotReadableOutput(
+            displayPath,
+            error instanceof Error ? error.message : String(error),
+          ),
+        },
+        flags: { hasCrLf: false, hasLf: false, hasLoneCr: false },
+        totalLines: 0,
+      };
+    }
+
+    try {
+      proc.stdin.end();
+    } catch {
+      /* process already gone */
+    }
+
+    let timedOut = false;
+    let killed = false;
+    const killProc = async (): Promise<void> => {
+      if (killed) return;
+      killed = true;
+      try {
+        await proc.kill('SIGTERM');
+      } catch {
+        /* process already gone */
+      }
+    };
+    const timeoutHandle = setTimeout(() => {
+      timedOut = true;
+      void killProc();
+    }, PDF_TEXT_EXTRACTION_TIMEOUT_MS);
+
+    try {
+      const [textResult, stderrResult, exitCode] = await Promise.all([
+        collectTextLines(proc.stdout, options),
+        readStreamWithCap(proc.stderr, PDF_TEXT_EXTRACTION_MAX_STDERR_BYTES),
+        proc.wait(),
+      ]);
+      if (timedOut) {
+        return {
+          result: {
+            isError: true,
+            output: pdfNotReadableOutput(
+              displayPath,
+              `pdftotext timed out after ${String(PDF_TEXT_EXTRACTION_TIMEOUT_MS / 1000)}s`,
+            ),
+          },
+          flags: { hasCrLf: false, hasLf: false, hasLoneCr: false },
+          totalLines: 0,
+        };
+      }
+      if (exitCode !== 0) {
+        const detail = stderrResult.text.trim() || `pdftotext exited with code ${String(exitCode)}`;
+        return {
+          result: { isError: true, output: pdfNotReadableOutput(displayPath, detail) },
+          flags: textResult.flags,
+          totalLines: textResult.totalLines,
+        };
+      }
+      return textResult;
+    } catch (error) {
+      if (isAbortError(error)) {
+        return {
+          result: { isError: true, output: pdfNotReadableOutput(displayPath, 'aborted') },
+          flags: { hasCrLf: false, hasLf: false, hasLoneCr: false },
+          totalLines: 0,
+        };
+      }
+      return {
+        result: {
+          isError: true,
+          output: pdfNotReadableOutput(
+            displayPath,
+            error instanceof Error ? error.message : String(error),
+          ),
+        },
+        flags: { hasCrLf: false, hasLf: false, hasLoneCr: false },
+        totalLines: 0,
+      };
+    } finally {
+      clearTimeout(timeoutHandle);
+    }
+  }
+
+  private finishEntriesReadResult(input: FinishEntriesReadResultInput): ExecutableToolResult {
+    const lineEndingStyle = lineEndingStyleFromFlags(input.flags);
+    let renderedCandidates = input.entries.map((entry) => {
       return { entry, rendered: renderLine(entry, lineEndingStyle) };
     });
 
@@ -378,12 +687,20 @@ export class ReadTool implements BuiltinTool<ReadInput> {
       maxBytesReached = true;
       const kept: typeof renderedCandidates = [];
       let bytes = 0;
-      for (let i = renderedCandidates.length - 1; i >= 0; i -= 1) {
+      const iterateFromTail = input.byteTruncationMode === 'tail';
+      const start = iterateFromTail ? renderedCandidates.length - 1 : 0;
+      const end = iterateFromTail ? -1 : renderedCandidates.length;
+      const step = iterateFromTail ? -1 : 1;
+      for (let i = start; i !== end; i += step) {
         const candidate = renderedCandidates[i];
         if (candidate === undefined) continue;
         const lineBytes = renderedLineBytes(candidate.rendered.line, kept.length === 0);
-        if (bytes + lineBytes > MAX_BYTES) break;
-        kept.unshift(candidate);
+        if (bytes + lineBytes > MAX_BYTES && (iterateFromTail || kept.length > 0)) break;
+        if (iterateFromTail) {
+          kept.unshift(candidate);
+        } else {
+          kept.push(candidate);
+        }
         bytes += lineBytes;
       }
       renderedCandidates = kept;
@@ -401,12 +718,13 @@ export class ReadTool implements BuiltinTool<ReadInput> {
     return this.finishReadResult({
       renderedLines,
       truncatedLineNumbers,
-      maxLinesReached: false,
+      maxLinesReached: input.maxLinesReached,
       maxBytesReached,
       lineEndingStyle,
-      startLine: renderedCandidates[0]?.entry.lineNo ?? 0,
-      totalLines: currentLineNo,
-      requestedLines,
+      startLine: renderedCandidates[0]?.entry.lineNo ?? input.startLine,
+      totalLines: input.totalLines,
+      requestedLines: input.requestedLines,
+      sourceKind: input.sourceKind,
     });
   }
 
@@ -428,9 +746,9 @@ export class ReadTool implements BuiltinTool<ReadInput> {
     const parts =
       lineCount > 0
         ? [
-            `${String(lineCount)} ${lineWord} read from file starting from line ${String(input.startLine)}.`,
+            `${String(lineCount)} ${lineWord} read from ${input.sourceKind ?? 'file'} starting from line ${String(input.startLine)}.`,
           ]
-        : ['No lines read from file.'];
+        : [`No lines read from ${input.sourceKind ?? 'file'}.`];
 
     parts.push(`Total lines in file: ${String(input.totalLines)}.`);
     if (input.maxLinesReached) {

--- a/packages/agent-core/src/tools/builtin/shell/bash.md
+++ b/packages/agent-core/src/tools/builtin/shell/bash.md
@@ -2,6 +2,7 @@ Execute a `{{ SHELL_NAME }}` command. Use this for shell semantics — pipes, en
 
 **Translate these to a dedicated tool instead:**
 - `cat` / `head` / `tail` (known path) → `Read`
+- `pdftotext` / PDF preview or extraction for a known `.pdf` path → `Read`
 - `sed` / `awk` (in-place edit) → `Edit`
 - `echo > file` / `cat <<EOF` → `Write`
 - `find` / recursive `ls` to locate files by name pattern → `Glob` (plain `ls <known-directory>` is fine for listing a directory)

--- a/packages/agent-core/src/tools/support/file-type.ts
+++ b/packages/agent-core/src/tools/support/file-type.ts
@@ -50,7 +50,6 @@ export const NON_TEXT_SUFFIXES: ReadonlySet<string> = new Set<string>([
   '.psd',
   '.ai',
   '.eps',
-  '.pdf',
   '.doc',
   '.docx',
   '.dot',
@@ -155,6 +154,8 @@ const FTYP_VIDEO_BRANDS: Readonly<Record<string, string>> = Object.freeze({
   '3g2': 'video/3gpp2',
 });
 
+const PDF_MIME_TYPE = 'application/pdf';
+
 function toBuffer(data: Buffer | Uint8Array): Buffer {
   return Buffer.isBuffer(data) ? data : Buffer.from(data.buffer, data.byteOffset, data.byteLength);
 }
@@ -219,6 +220,9 @@ export function sniffMediaFromMagic(data: Buffer | Uint8Array): FileType | null 
     const lowered = header.toString('latin1').toLowerCase();
     if (lowered.includes('webm')) return { kind: 'video', mimeType: 'video/webm' };
     if (lowered.includes('matroska')) return { kind: 'video', mimeType: 'video/x-matroska' };
+  }
+  if (startsWith(header, Buffer.from('%PDF-'))) {
+    return { kind: 'text', mimeType: PDF_MIME_TYPE };
   }
   const brand = sniffFtypBrand(header);
   if (brand !== null && brand !== '') {
@@ -345,6 +349,8 @@ export function detectFileType(path: string, header?: Buffer | Uint8Array): File
   let mediaHint: FileType | null = null;
   if (suffix in TEXT_MIME_BY_SUFFIX) {
     mediaHint = { kind: 'text', mimeType: TEXT_MIME_BY_SUFFIX[suffix]! };
+  } else if (suffix === '.pdf') {
+    mediaHint = { kind: 'text', mimeType: PDF_MIME_TYPE };
   } else if (suffix in IMAGE_MIME_BY_SUFFIX) {
     mediaHint = { kind: 'image', mimeType: IMAGE_MIME_BY_SUFFIX[suffix]! };
   } else if (suffix in VIDEO_MIME_BY_SUFFIX) {

--- a/packages/agent-core/test/config/configs.test.ts
+++ b/packages/agent-core/test/config/configs.test.ts
@@ -266,6 +266,7 @@ oauth = { storage = "file", key = "oauth/kimi-code-env-1234", oauth_host = "http
 goal_command = true
 micro_compaction = false
 background_ask = true
+pdf_read = true
 `;
     const config = parseConfigString(toml, configPath);
 
@@ -273,6 +274,7 @@ background_ask = true
       'goal_command': true,
       'micro_compaction': false,
       'background_ask': true,
+      'pdf_read': true,
     });
 
     await writeConfigFile(configPath, config);
@@ -282,6 +284,7 @@ background_ask = true
     expect(text).toContain('goal_command = true');
     expect(text).toContain('micro_compaction = false');
     expect(text).toContain('background_ask = true');
+    expect(text).toContain('pdf_read = true');
     expect(parseConfigString(text, configPath).experimental).toEqual(config.experimental);
   });
 

--- a/packages/agent-core/test/tools/bash.test.ts
+++ b/packages/agent-core/test/tools/bash.test.ts
@@ -198,6 +198,13 @@ describe('BashTool', () => {
     }
   });
 
+  it('routes known PDF text extraction commands back to Read in the prompt', () => {
+    const tool = new BashTool(createFakeKaos({ osEnv: posixEnv }), '/workspace');
+
+    expect(tool.description).toContain('pdftotext');
+    expect(tool.description).toMatch(/known `\.pdf` path → `Read`/);
+  });
+
   it('exposes a default timeout in the JSON Schema', () => {
     const tool = new BashTool(createFakeKaos({ osEnv: posixEnv }), '/workspace');
     const properties = (tool.parameters as { properties: Record<string, { default?: number }> })

--- a/packages/agent-core/test/tools/file-type.test.ts
+++ b/packages/agent-core/test/tools/file-type.test.ts
@@ -123,6 +123,13 @@ describe('sniffMediaFromMagic', () => {
     expect(sniffMediaFromMagic(Buffer.from('plain text content'))).toBeNull();
   });
 
+  it('recognises PDF magic bytes', () => {
+    expect(sniffMediaFromMagic(Buffer.from('%PDF-1.7\n', 'utf8'))).toEqual<FileType>({
+      kind: 'text',
+      mimeType: 'application/pdf',
+    });
+  });
+
   it('uses MEDIA_SNIFF_BYTES as the header slice size ceiling', () => {
     // Typed constant guard.
     expect(MEDIA_SNIFF_BYTES).toBe(512);
@@ -200,6 +207,17 @@ describe('detectFileType', () => {
     expect(result.kind).toBe('unknown');
   });
 
+  it('resolves PDF as a text-workflow subtype by extension and magic bytes', () => {
+    expect(detectFileType('paper.pdf')).toEqual<FileType>({
+      kind: 'text',
+      mimeType: 'application/pdf',
+    });
+    expect(detectFileType('paper', Buffer.from('%PDF-1.7\n', 'utf8'))).toEqual<FileType>({
+      kind: 'text',
+      mimeType: 'application/pdf',
+    });
+  });
+
   it('falls back to plain text for unknown suffix with no magic bytes', () => {
     const result = detectFileType('README');
     expect(result.kind).toBe('text');
@@ -209,7 +227,10 @@ describe('detectFileType', () => {
   it('exposes the suffix maps as readonly records', () => {
     expect(IMAGE_MIME_BY_SUFFIX['.png']).toBe('image/png');
     expect(VIDEO_MIME_BY_SUFFIX['.mkv']).toBe('video/x-matroska');
-    expect(NON_TEXT_SUFFIXES.has('.pdf')).toBe(true);
+    expect(detectFileType('paper.pdf')).toEqual({
+      kind: 'text',
+      mimeType: 'application/pdf',
+    });
     expect(NON_TEXT_SUFFIXES.has('.zip')).toBe(true);
     expect(NON_TEXT_SUFFIXES.has('.dll')).toBe(true);
   });
@@ -224,7 +245,10 @@ describe('detectFileType', () => {
     expect(detectFileType('.env').kind).toBe('text');
     expect(detectFileType('icon.svg').kind).toBe('text');
     expect(detectFileType('archive.tar.gz').kind).toBe('unknown');
-    expect(detectFileType('my file.pdf').kind).toBe('unknown');
+    expect(detectFileType('my file.pdf')).toEqual({
+      kind: 'text',
+      mimeType: 'application/pdf',
+    });
   });
 
   it('keeps TypeScript suffixes as text rather than MPEG-TS video', () => {

--- a/packages/agent-core/test/tools/read-media.test.ts
+++ b/packages/agent-core/test/tools/read-media.test.ts
@@ -376,6 +376,26 @@ describe('ReadMediaFileTool', () => {
     expect(result.output).not.toContain('ReadFile');
   });
 
+  it('rejects PDF files as text-workflow files with a Read hint', async () => {
+    const pdf = Buffer.from('%PDF-1.7\n', 'utf8');
+    const tool = makeReadMediaTool({
+      stat: vi.fn<Kaos['stat']>().mockResolvedValue({ ...DEFAULT_STAT, stSize: pdf.length }),
+      readBytes: vi.fn<Kaos['readBytes']>().mockResolvedValue(pdf),
+    });
+
+    const result = await executeTool(tool, {
+      turnId: 't1',
+      toolCallId: 'c_pdf',
+      args: { path: '/workspace/paper.pdf' },
+      signal,
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.output).toBe(
+      '"/workspace/paper.pdf" is a text file. Use Read to read text files.',
+    );
+  });
+
   it('rejects unknown binary files without legacy Python-tool wording', async () => {
     const blob = Buffer.from([0x00, 0x01, 0x02, 0x03]);
     const tool = makeReadMediaTool({

--- a/packages/agent-core/test/tools/read.test.ts
+++ b/packages/agent-core/test/tools/read.test.ts
@@ -1,6 +1,8 @@
 import type { Kaos } from '@moonshot-ai/kaos';
+import { Readable, Writable } from 'node:stream';
 import { describe, expect, it, vi } from 'vitest';
 
+import type { ExperimentalFlagResolver } from '../../src/flags';
 import {
   MAX_BYTES,
   MAX_LINE_LENGTH,
@@ -77,6 +79,72 @@ function toolWithContent(content: string, workspace: WorkspaceConfig = PERMISSIV
     }),
     workspace,
   );
+}
+
+function flagsEnabled(enabled: boolean): ExperimentalFlagResolver {
+  return {
+    enabled: (id) => id === 'pdf_read' && enabled,
+    snapshot: () => ({ pdf_read: enabled }),
+    enabledIds: () => (enabled ? ['pdf_read'] : []),
+    explain: () => undefined,
+    explainAll: () => [],
+    setConfigOverrides: () => {},
+  };
+}
+
+function processFromOutput(
+  stdout: string,
+  options: {
+    readonly stderr?: string;
+    readonly exitCode?: number;
+  } = {},
+): Awaited<ReturnType<Kaos['exec']>> {
+  return {
+    stdin: new Writable({
+      write(_chunk, _encoding, callback) {
+        callback();
+      },
+    }),
+    stdout: Readable.from(stdout === '' ? [] : [stdout]),
+    stderr: Readable.from(options.stderr === undefined ? [] : [options.stderr]),
+    pid: 1234,
+    exitCode: options.exitCode ?? 0,
+    wait: async () => options.exitCode ?? 0,
+    kill: async () => {},
+  };
+}
+
+function pdfTool(
+  options: {
+    readonly stdout?: string;
+    readonly stderr?: string;
+    readonly exitCode?: number;
+    readonly execError?: Error;
+    readonly enabled?: boolean;
+  } = {},
+) {
+  const header = Buffer.from('%PDF-1.7\n', 'utf8');
+  const exec = vi.fn<Kaos['exec']>();
+  if (options.execError !== undefined) {
+    exec.mockRejectedValue(options.execError);
+  } else {
+    exec.mockResolvedValue(
+      processFromOutput(options.stdout ?? 'alpha\nbeta\n', {
+        stderr: options.stderr,
+        exitCode: options.exitCode,
+      }),
+    );
+  }
+  const tool = new ReadTool(
+    createFakeKaos({
+      stat: vi.fn<Kaos['stat']>().mockResolvedValue(REGULAR_FILE_STAT),
+      readBytes: vi.fn<Kaos['readBytes']>().mockResolvedValue(header),
+      exec,
+    }),
+    PERMISSIVE_WORKSPACE,
+    flagsEnabled(options.enabled ?? true),
+  );
+  return { tool, exec };
 }
 
 describe('ReadTool', () => {
@@ -435,6 +503,91 @@ describe('ReadTool', () => {
     expect(readText).not.toHaveBeenCalled();
   });
 
+  it('rejects PDF files when experimental PDF reading is disabled', async () => {
+    const { tool, exec } = pdfTool({ enabled: false });
+
+    const result = await executeTool(tool, context({ path: '/tmp/paper.pdf' }));
+
+    expect(result).toEqual({
+      isError: true,
+      output:
+        '"/tmp/paper.pdf" is a PDF file. PDF text extraction is experimental; enable KIMI_CODE_EXPERIMENTAL_PDF_READ to read it with pdftotext.',
+    });
+    expect(exec).not.toHaveBeenCalled();
+  });
+
+  it('extracts PDF text with pdftotext when experimental PDF reading is enabled', async () => {
+    const { tool, exec } = pdfTool({
+      stdout: 'Title line\nbody line\n',
+    });
+
+    const result = await executeTool(tool, context({ path: '/tmp/paper.pdf' }));
+
+    expect(result.output).toBe(
+      withReadStatus(
+        '1\tTitle line\n2\tbody line',
+        '2 lines read from PDF starting from line 1. Total lines in file: 2. End of file reached.',
+      ),
+    );
+    expect(exec).toHaveBeenCalledWith('pdftotext', '-layout', '-enc', 'UTF-8', '/tmp/paper.pdf', '-');
+  });
+
+  it('applies line_offset and n_lines to extracted PDF text', async () => {
+    const { tool } = pdfTool({
+      stdout: 'a\nb\nc\nd\n',
+    });
+
+    const result = await executeTool(tool, context({ path: '/tmp/paper.pdf', line_offset: 2, n_lines: 2 }));
+
+    expect(result.output).toBe(
+      withReadStatus(
+        '2\tb\n3\tc',
+        '2 lines read from PDF starting from line 2. Total lines in file: 4.',
+      ),
+    );
+  });
+
+  it('supports tail reads from extracted PDF text', async () => {
+    const { tool } = pdfTool({
+      stdout: 'a\nb\nc\nd\n',
+    });
+
+    const result = await executeTool(tool, context({ path: '/tmp/paper.pdf', line_offset: -2 }));
+
+    expect(result.output).toBe(
+      withReadStatus(
+        '3\tc\n4\td',
+        '2 lines read from PDF starting from line 3. Total lines in file: 4. End of file reached.',
+      ),
+    );
+  });
+
+  it('returns an install hint when pdftotext is missing', async () => {
+    const enoent = Object.assign(new Error('spawn pdftotext ENOENT'), { code: 'ENOENT' });
+    const { tool } = pdfTool({ execError: enoent });
+
+    const result = await executeTool(tool, context({ path: '/tmp/paper.pdf' }));
+
+    expect(result.isError).toBe(true);
+    expect(result.output).toContain('PDF text extraction requires `pdftotext` from Poppler');
+    expect(result.output).toContain('sudo apt-get install poppler-utils');
+  });
+
+  it('returns pdftotext stderr when PDF extraction fails', async () => {
+    const { tool } = pdfTool({
+      exitCode: 1,
+      stderr: 'Syntax Error: could not read xref',
+    });
+
+    const result = await executeTool(tool, context({ path: '/tmp/bad.pdf' }));
+
+    expect(result).toEqual({
+      isError: true,
+      output:
+        'Failed to extract text from PDF "/tmp/bad.pdf" with pdftotext: Syntax Error: could not read xref',
+    });
+  });
+
   it('rejects NUL-containing binary files before text decoding', async () => {
     const header = Buffer.concat([Buffer.from('plain prefix'), Buffer.from([0x00, 0x01])]);
     const readText = vi
@@ -631,13 +784,17 @@ describe('ReadTool', () => {
     expect(output).not.toContain('Max');
   });
 
-  it('description pins line/byte caps, tail mode, and the Grep-over-Read preference', () => {
+  it('description pins line/byte caps, tail mode, PDF support, and tool preferences', () => {
     const tool = toolWithContent('');
     // Numeric caps are part of the stable contract.
     expect(tool.description).toContain(String(MAX_LINES));
     expect(tool.description).toContain(String(MAX_LINE_LENGTH));
     // Tail mode (negative line_offset) is documented.
     expect(tool.description).toMatch(/negative line_offset|reads from the end/i);
+    // PDF is part of the text workflow and should not be routed through Bash
+    // just to invoke pdftotext.
+    expect(tool.description).toMatch(/PDF files are treated as a text-workflow subtype/i);
+    expect(tool.description).toMatch(/Do not use `pdftotext` via Bash/i);
     // Recommend Grep when searching for unknown content.
     expect(tool.description).toContain('Grep');
   });
@@ -805,6 +962,7 @@ describe('ReadTool description and schema parity', () => {
     ).properties.path;
 
     expect(pathProperty.description).toContain('working directory');
+    expect(pathProperty.description).toContain('PDF files');
     expect(pathProperty.description).not.toMatch(/^Absolute path/);
   });
 

--- a/packages/agent-core/test/tools/read.test.ts
+++ b/packages/agent-core/test/tools/read.test.ts
@@ -1,5 +1,5 @@
 import type { Kaos } from '@moonshot-ai/kaos';
-import { Readable, Writable } from 'node:stream';
+import { PassThrough, Readable, Writable } from 'node:stream';
 import { describe, expect, it, vi } from 'vitest';
 
 import type { ExperimentalFlagResolver } from '../../src/flags';
@@ -35,12 +35,12 @@ const DIRECTORY_STAT = {
   stMode: 0o040_755,
 } satisfies Awaited<ReturnType<Kaos['stat']>>;
 
-function context(args: ReadInput) {
+function context(args: ReadInput, abortSignal: AbortSignal = signal) {
   return {
     turnId: '0',
     toolCallId: 'call_read',
     args,
-    signal,
+    signal: abortSignal,
   };
 }
 
@@ -111,6 +111,40 @@ function processFromOutput(
     exitCode: options.exitCode ?? 0,
     wait: async () => options.exitCode ?? 0,
     kill: async () => {},
+  };
+}
+
+function pendingProcess() {
+  const stdout = new PassThrough();
+  const stderr = new PassThrough();
+  let currentExitCode: number | null = null;
+  let resolveWait: (code: number) => void = () => {};
+  const waitPromise = new Promise<number>((resolve) => {
+    resolveWait = resolve;
+  });
+  const kill = vi.fn(async () => {
+    currentExitCode = 143;
+    stdout.end();
+    stderr.end();
+    resolveWait(143);
+  });
+  return {
+    proc: {
+      stdin: new Writable({
+        write(_chunk, _encoding, callback) {
+          callback();
+        },
+      }),
+      stdout,
+      stderr,
+      pid: 1235,
+      get exitCode() {
+        return currentExitCode;
+      },
+      wait: vi.fn(async () => waitPromise),
+      kill,
+    } satisfies Awaited<ReturnType<Kaos['exec']>>,
+    kill,
   };
 }
 
@@ -530,6 +564,49 @@ describe('ReadTool', () => {
       ),
     );
     expect(exec).toHaveBeenCalledWith('pdftotext', '-layout', '-enc', 'UTF-8', '/tmp/paper.pdf', '-');
+  });
+
+  it('does not start pdftotext when PDF reading is already aborted', async () => {
+    const { tool, exec } = pdfTool();
+    const controller = new AbortController();
+    controller.abort();
+
+    const result = await executeTool(tool, context({ path: '/tmp/paper.pdf' }, controller.signal));
+
+    expect(result).toEqual({
+      isError: true,
+      output: 'Failed to extract text from PDF "/tmp/paper.pdf" with pdftotext: aborted',
+    });
+    expect(exec).not.toHaveBeenCalled();
+  });
+
+  it('kills pdftotext when PDF reading is aborted after the process starts', async () => {
+    const header = Buffer.from('%PDF-1.7\n', 'utf8');
+    const { proc, kill } = pendingProcess();
+    const exec = vi.fn<Kaos['exec']>().mockResolvedValue(proc);
+    const tool = new ReadTool(
+      createFakeKaos({
+        stat: vi.fn<Kaos['stat']>().mockResolvedValue(REGULAR_FILE_STAT),
+        readBytes: vi.fn<Kaos['readBytes']>().mockResolvedValue(header),
+        exec,
+      }),
+      PERMISSIVE_WORKSPACE,
+      flagsEnabled(true),
+    );
+    const controller = new AbortController();
+
+    const pending = executeTool(tool, context({ path: '/tmp/slow.pdf' }, controller.signal));
+    await vi.waitFor(() => {
+      expect(exec).toHaveBeenCalledOnce();
+    });
+    controller.abort();
+    const result = await pending;
+
+    expect(kill).toHaveBeenCalledWith('SIGTERM');
+    expect(result).toEqual({
+      isError: true,
+      output: 'Failed to extract text from PDF "/tmp/slow.pdf" with pdftotext: aborted',
+    });
   });
 
   it('applies line_offset and n_lines to extracted PDF text', async () => {


### PR DESCRIPTION


## Related Issue

<!-- Link the issue this feature came from. If there is no issue, explain the problem in the next section instead. -->

Resolve #533 

## Problem

<!-- What user need or limitation does this address? If the linked issue already covers this, write "See linked issue". -->
Kimi Code 目前可以通过 `Read` 读取文本文件，通过 `ReadMediaFile` 读取图片和视频，但 PDF 文件还没有进入内置文件阅读工作流。

PDF 在 coding agent 工作流中很常见，例如论文、规格说明、报告、手册、API 文档等。如果没有一条内置的 `Read` 路径，Agent 往往会退回到通过 `Bash` 手动调用 `pdftotext`。这样有几个问题：

- 会绕过 `Read` 已有的行号、分页和 `<system>` 状态输出契约。
- PDF 阅读行为无法自然复用大文本文件的 `line_offset`、`n_lines`、tail read 等机制。
- 当用户系统没有安装 `pdftotext` 时，错误信息和安装指引不够统一。
## What changed
这个 PR 将 PDF 作为 `Read` 的实验性文本子类型处理，而不是新增独立的 PDF 工具或顶层文件类型。

- 将 `.pdf` 扩展名和 `%PDF-` magic bytes 识别为 `kind: 'text'`，`mimeType: 'application/pdf'`。
- 新增 `pdf_read` 实验开关，可通过 `KIMI_CODE_EXPERIMENTAL_PDF_READ` 或 `[experimental] pdf_read = true` 启用。
- 将 scoped experimental flag resolver 传入 `ReadTool`。
- 实验开关启用后，`Read` 使用 Poppler 的 `pdftotext` 抽取 PDF 文本：

<!-- What did you implement, and why does this approach fit Kimi Code? -->
## Dependency strategy

这个 PR 有意不在 Kimi Code 安装流程中自动安装或内置 Poppler。

- npm lifecycle script 不适合自动执行 `brew install poppler` 或 `apt-get install poppler-utils` 这类系统包安装操作。
- native single-binary 当前主要打包 JavaScript 和选定的 npm-native assets，并不是通用系统二进制分发器。
- Poppler 是 GPL 许可。把 `pdftotext` 二进制直接打进 Kimi Code 的 MIT 发行包，会带来平台、体积、动态库、更新和许可证合规复杂度。

因此当前设计是：PDF 阅读保持实验性，`pdftotext` 作为可选运行时依赖；缺失时 `Read` 返回可操作的安装提示。
## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.
