### PR TITLE
feat(tui): add Ctrl+X shell mode toggle

### DIFF
--- a/.changeset/ctrl-x-shell-mode.md
+++ b/.changeset/ctrl-x-shell-mode.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": minor
+---
+
+Add Ctrl+X keyboard shortcut to toggle between Agent mode and Shell mode. In Shell mode, input is executed directly as local shell commands with inherited stdio, supporting interactive programs. Agent-only slash commands are blocked with a hint to switch back to Agent mode.

--- a/apps/kimi-code/src/tui/components/chrome/footer.ts
+++ b/apps/kimi-code/src/tui/components/chrome/footer.ts
@@ -52,6 +52,7 @@ export interface ToolbarTip {
 
 const TOOLBAR_TIPS: readonly ToolbarTip[] = [
   { text: 'shift+tab: plan mode' },
+  { text: 'ctrl+x: toggle mode' },
   { text: '/model: switch model' },
   { text: 'ctrl+s: steer mid-turn', priority: 2 },
   { text: '/compact: compact context', priority: 2 },
@@ -292,6 +293,7 @@ export class FooterComponent implements Component {
     if (state.permissionMode === 'yolo') modes.push(chalk.hex(colors.warning).bold('yolo'));
     if (state.planMode) modes.push(chalk.hex(colors.primary).bold('plan'));
     if (state.swarmMode) modes.push(chalk.hex(colors.accent).bold('swarm'));
+    if (state.inputMode === 'shell') modes.push(chalk.hex(colors.primary).bold('shell'));
     if (modes.length > 0) left.push(modes.join(' '));
 
     const goalBadge = formatGoalBadge(state.goal, colors, this.goalWallClockMs(state.goal));

--- a/apps/kimi-code/src/tui/components/editor/custom-editor.ts
+++ b/apps/kimi-code/src/tui/components/editor/custom-editor.ts
@@ -95,6 +95,7 @@ export class CustomEditor extends Editor {
   public onEscape?: () => void;
   public onCtrlD?: () => void;
   public onCtrlC?: () => void;
+  public onCtrlX?: () => void;
   public onToggleToolExpand?: () => void;
   // Returns true when a plan card actually handled the toggle. When it
   // returns false (no plan in the transcript) the keystroke falls through
@@ -124,6 +125,7 @@ export class CustomEditor extends Editor {
    * the next keystroke.
    */
   public onPasteImage?: () => Promise<boolean>;
+  public promptSymbol = '>';
 
   private consumingPaste = false;
   private consumeBuffer = '';
@@ -207,7 +209,7 @@ export class CustomEditor extends Editor {
     }
     const firstContent = lines[firstContentIdx];
     if (firstContent !== undefined) {
-      const withPrompt = injectPromptSymbol(firstContent);
+      const withPrompt = injectPromptSymbol(firstContent, this.promptSymbol);
       if (withPrompt !== undefined) {
         lines[firstContentIdx] = withPrompt;
       }
@@ -279,6 +281,11 @@ export class CustomEditor extends Editor {
 
     if (matchesKey(normalized, Key.ctrl('c'))) {
       this.onCtrlC?.();
+      return;
+    }
+
+    if (matchesKey(normalized, Key.ctrl('x'))) {
+      this.onCtrlX?.();
       return;
     }
 
@@ -435,12 +442,14 @@ function highlightVisibleRanges(
  * default foreground colour renders the symbol. Returns `undefined` if the
  * line is too short or doesn't begin with the expected padding.
  */
-export function injectPromptSymbol(line: string): string | undefined {
+export function injectPromptSymbol(line: string, symbol = '>'): string | undefined {
   if (line.length < 4) return undefined;
   for (let i = 0; i < 4; i++) {
     if (line[i] !== ' ') return undefined;
   }
-  return '  > ' + line.slice(4);
+  const symbolWithSpace = `${symbol} `;
+  const padding = ' '.repeat(Math.max(0, 4 - symbolWithSpace.length));
+  return padding + symbolWithSpace + line.slice(4);
 }
 
 /**

--- a/apps/kimi-code/src/tui/controllers/editor-keyboard.ts
+++ b/apps/kimi-code/src/tui/controllers/editor-keyboard.ts
@@ -35,6 +35,7 @@ export interface EditorKeyboardHost {
   hideSessionPicker(): void;
   stop(exitCode?: number): Promise<void>;
   handlePlanToggle(next: boolean): void;
+  handleInputModeToggle(): void;
   clearQueuedMessages(): void;
   setExternalEditorRunning(running: boolean): void;
 }
@@ -100,6 +101,12 @@ export class EditorKeyboardController {
         editor.setText('');
       }
       this.armPendingExit('ctrl-c', CTRL_C_HINT);
+    };
+
+    editor.onCtrlX = () => {
+      const next = host.state.appState.inputMode === 'agent' ? 'shell' : 'agent';
+      host.track('shortcut_mode_switch', { to_mode: next });
+      host.handleInputModeToggle();
     };
 
     editor.onCtrlD = () => {

--- a/apps/kimi-code/src/tui/kimi-tui.ts
+++ b/apps/kimi-code/src/tui/kimi-tui.ts
@@ -127,6 +127,9 @@ import { installTerminalThemeTracking } from './utils/terminal-theme';
 import { detectTmuxKeyboardWarning } from './utils/tmux-keyboard';
 import { markTranscriptComponent } from './utils/transcript-component-metadata';
 import { nextTranscriptId } from './utils/transcript-id';
+import { parseSlashInput } from './commands/parse';
+import { findBuiltInSlashCommand } from './commands/registry';
+import { runShellCommand } from './utils/shell-executor';
 
 export type { TUIState } from './tui-state';
 export { createTUIState } from './tui-state';
@@ -182,6 +185,7 @@ function createInitialAppState(input: KimiTUIStartupInput): AppState {
     sessionTitle: null,
     goal: null,
     mcpServersSummary: null,
+    inputMode: 'agent',
   };
 }
 
@@ -190,6 +194,11 @@ interface SendMessageOptions {
   readonly imageAttachmentIds?: readonly number[];
   readonly hasMedia?: boolean;
 }
+
+const AGENT_ONLY_COMMANDS = new Set([
+  'new', 'plan', 'compact', 'goal', 'undo', 'fork',
+  'init', 'export-md', 'export-debug-zip',
+]);
 
 export class KimiTUI {
   readonly harness: KimiHarness;
@@ -683,14 +692,49 @@ export class KimiTUI {
     void slashCommands.handlePlanCommand(this, next ? 'on' : 'off');
   }
 
+  handleInputModeToggle(): void {
+    const next = this.state.appState.inputMode === 'agent' ? 'shell' : 'agent';
+    this.setAppState({ inputMode: next });
+    this.state.editor.promptSymbol = next === 'shell' ? '$' : '>';
+    this.updateEditorBorderHighlight();
+    this.state.ui.requestRender();
+  }
+
   handleUserInput(text: string): void {
     if (text.trim().length === 0) return;
     if (this.state.appState.isReplaying) {
       this.showError('Cannot send input while session history is replaying.');
       return;
     }
+
+    if (this.state.appState.inputMode === 'shell') {
+      const parsed = parseSlashInput(text);
+      if (parsed !== null) {
+        const resolved = findBuiltInSlashCommand(parsed.name);
+        const commandName = resolved?.name ?? parsed.name;
+        if (AGENT_ONLY_COMMANDS.has(commandName)) {
+          this.showError(`/${parsed.name} is not available in shell mode. Press Ctrl+X to switch to agent mode.`);
+          return;
+        }
+        void this.persistInputHistory(text);
+        slashCommands.dispatchInput(this, text);
+        return;
+      }
+      void this.executeShellCommand(text);
+      return;
+    }
+
     void this.persistInputHistory(text);
     slashCommands.dispatchInput(this, text);
+  }
+
+  private async executeShellCommand(text: string): Promise<void> {
+    try {
+      await runShellCommand(text, this.state.ui);
+    } catch (error) {
+      const msg = formatErrorMessage(error);
+      this.showError(`Shell command failed: ${msg}`);
+    }
   }
 
   sendNormalUserInput(text: string): void {

--- a/apps/kimi-code/src/tui/types.ts
+++ b/apps/kimi-code/src/tui/types.ts
@@ -38,6 +38,7 @@ export interface AppState {
   /** Current goal snapshot for the footer badge; null/undefined when no active goal. */
   goal?: GoalSnapshot | null;
   mcpServersSummary: string | null;
+  inputMode: 'agent' | 'shell';
 }
 
 export interface ToolCallBlockData {

--- a/apps/kimi-code/src/tui/utils/shell-executor.ts
+++ b/apps/kimi-code/src/tui/utils/shell-executor.ts
@@ -1,0 +1,48 @@
+import { spawn } from 'node:child_process';
+import { createInterface } from 'node:readline';
+import { constants } from 'node:os';
+import type { TUI } from '@earendil-works/pi-tui';
+
+async function promptToContinue(): Promise<void> {
+  process.stdout.write('\n\n[Press Enter to return to Kimi Code]\n');
+  const rl = createInterface({ input: process.stdin, output: process.stdout });
+  await new Promise<void>((resolve) => {
+    rl.question('', () => {
+      rl.close();
+      resolve();
+    });
+  });
+}
+
+export async function runShellCommand(command: string, ui: TUI): Promise<number> {
+  ui.stop();
+  await new Promise<void>((resolve) => { setImmediate(resolve); });
+  try {
+    const code = await new Promise<number>((resolve, reject) => {
+      const child = spawn(command, { shell: true, stdio: 'inherit' });
+      child.on('exit', (code, signal) => {
+        if (code !== null) {
+          resolve(code);
+        } else if (signal !== null) {
+          const signum = constants.signals[signal] ?? 1;
+          resolve(128 + signum);
+        } else {
+          resolve(0);
+        }
+      });
+      child.on('error', reject);
+    });
+    return code;
+  } finally {
+    await promptToContinue();
+    try {
+      if (typeof process.stdin.pause === 'function') {
+        process.stdin.pause();
+      }
+    } catch {
+      // ignore
+    }
+    ui.start();
+    ui.requestRender(true);
+  }
+}

--- a/apps/kimi-code/test/tui/components/chrome/footer.test.ts
+++ b/apps/kimi-code/test/tui/components/chrome/footer.test.ts
@@ -55,6 +55,7 @@ const appState: AppState = {
   availableModels: {},
   availableProviders: {},
   mcpServersSummary: null,
+  inputMode: 'agent',
 };
 
 describe('FooterComponent', () => {
@@ -88,5 +89,19 @@ describe('FooterComponent', () => {
 
     expect(codes.has(RAINBOW_CYAN)).toBe(false);
     expect(codes.has(RAINBOW_GREEN)).toBe(false);
+  });
+
+  it('renders the [shell] badge when inputMode is shell', () => {
+    const shellState = { ...appState, inputMode: 'shell' as const };
+    const footer = new FooterComponent(shellState, darkColors);
+    const lines = footer.render(120);
+    expect(lines[0]).toContain('shell');
+  });
+
+  it('does not render the [shell] badge when inputMode is agent', () => {
+    const agentState = { ...appState, inputMode: 'agent' as const };
+    const footer = new FooterComponent(agentState, darkColors);
+    const lines = footer.render(120);
+    expect(lines[0]).not.toContain('shell');
   });
 });

--- a/apps/kimi-code/test/tui/components/chrome/welcome.test.ts
+++ b/apps/kimi-code/test/tui/components/chrome/welcome.test.ts
@@ -32,6 +32,7 @@ const appState: AppState = {
   availableModels: {},
   availableProviders: {},
   mcpServersSummary: null,
+  inputMode: 'agent',
 };
 
 function truecolorCodes(text: string): Set<string> {

--- a/apps/kimi-code/test/tui/components/editor/custom-editor.test.ts
+++ b/apps/kimi-code/test/tui/components/editor/custom-editor.test.ts
@@ -85,8 +85,8 @@ describe('CustomEditor Kitty key release handling', () => {
 });
 
 describe('CustomEditor paste marker expansion', () => {
-  const PASTE_START = '\x1b[200~';
-  const PASTE_END = '\x1b[201~';
+  const PASTE_START = '\x1B[200~';
+  const PASTE_END = '\x1B[201~';
 
   function simulateLargePaste(editor: CustomEditor, content: string): void {
     editor.handleInput(`${PASTE_START}${content}${PASTE_END}`);
@@ -151,7 +151,7 @@ describe('CustomEditor paste marker expansion', () => {
 
     expect(editor.getText()).toMatch(/\[paste #1/);
 
-    editor.handleInput('\x16');
+    editor.handleInput('\u0016');
 
     expect(editor.getText()).not.toContain('[paste #');
     expect(editor.getText()).toContain(longText);
@@ -195,7 +195,7 @@ describe('CustomEditor paste marker expansion', () => {
 
     // Split: PASTE_START in chunk 1, paste-end split across chunk 2 and 3
     editor.handleInput(`${PASTE_START}data`);
-    editor.handleInput('\x1b[20');
+    editor.handleInput('\x1B[20');
     editor.handleInput('1~');
 
     expect(editor.getText()).toContain(longText);
@@ -204,6 +204,18 @@ describe('CustomEditor paste marker expansion', () => {
     // Verify editor is not stuck — next keystrokes should work normally
     editor.handleInput('x');
     expect(editor.getText()).toContain('x');
+  });
+});
+
+describe('CustomEditor Ctrl+X handling', () => {
+  it('dispatches onCtrlX when Ctrl+X is pressed', () => {
+    const editor = makeEditor();
+    const onCtrlX = vi.fn();
+    editor.onCtrlX = onCtrlX;
+
+    editor.handleInput('\u001B[120;5u'); // kitty CSI-u for ctrl+x
+
+    expect(onCtrlX).toHaveBeenCalledOnce();
   });
 });
 

--- a/apps/kimi-code/test/tui/components/editor/prompt-symbol.test.ts
+++ b/apps/kimi-code/test/tui/components/editor/prompt-symbol.test.ts
@@ -2,6 +2,21 @@ import { describe, it, expect } from 'vitest';
 
 import { injectPromptSymbol } from '#/tui/components/editor/custom-editor';
 
+describe('injectPromptSymbol with custom symbol', () => {
+  it('places a "$ " prompt when symbol is "$"', () => {
+    expect(injectPromptSymbol('    hello world', '$')).toBe('  $ hello world');
+  });
+
+  it('preserves overall visible width with custom symbol', () => {
+    const original = '    hello       ';
+    expect(injectPromptSymbol(original, '$')).toHaveLength(original.length);
+  });
+
+  it('returns undefined when the line is too short regardless of symbol', () => {
+    expect(injectPromptSymbol('   ', '$')).toBeUndefined();
+  });
+});
+
 describe('injectPromptSymbol', () => {
   it('places a "> " prompt at columns 2-3 (col 0 = border, col 1 = single-space gap)', () => {
     expect(injectPromptSymbol('    hello world')).toBe('  > hello world');

--- a/apps/kimi-code/test/tui/components/panels/footer-bg-agents.test.ts
+++ b/apps/kimi-code/test/tui/components/panels/footer-bg-agents.test.ts
@@ -29,6 +29,7 @@ function baseState(overrides: Partial<AppState> = {}): AppState {
     editorCommand: null,
     notifications: { enabled: true, condition: 'unfocused' },
     availableModels: {},
+    inputMode: 'agent',
     ...overrides,
   } as AppState;
 }

--- a/apps/kimi-code/test/tui/components/panels/footer-context.test.ts
+++ b/apps/kimi-code/test/tui/components/panels/footer-context.test.ts
@@ -38,6 +38,7 @@ function baseState(overrides: Partial<AppState> = {}): AppState {
     editorCommand: null,
     notifications: { enabled: true, condition: 'unfocused' },
     availableModels: {},
+    inputMode: 'agent',
     ...overrides,
   } as AppState;
 }

--- a/apps/kimi-code/test/tui/components/panels/footer-goal-badge.test.ts
+++ b/apps/kimi-code/test/tui/components/panels/footer-goal-badge.test.ts
@@ -30,6 +30,7 @@ function baseState(overrides: Partial<AppState> = {}): AppState {
     editorCommand: null,
     notifications: { enabled: true, condition: 'unfocused' },
     availableModels: {},
+    inputMode: 'agent',
     ...overrides,
   } as AppState;
 }

--- a/apps/kimi-code/test/tui/create-tui-state.test.ts
+++ b/apps/kimi-code/test/tui/create-tui-state.test.ts
@@ -29,6 +29,7 @@ function fakeInitialAppState(): AppState {
     availableProviders: {},
     sessionTitle: null,
     mcpServersSummary: null,
+    inputMode: 'agent',
   };
 }
 

--- a/apps/kimi-code/test/tui/utils/shell-executor.test.ts
+++ b/apps/kimi-code/test/tui/utils/shell-executor.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it, vi } from 'vitest';
+import { spawn } from 'node:child_process';
+import type { TUI } from '@earendil-works/pi-tui';
+import { runShellCommand } from '#/tui/utils/shell-executor';
+
+vi.mock('node:child_process', () => ({
+  spawn: vi.fn(),
+}));
+
+vi.mock('node:readline', () => ({
+  createInterface: vi.fn(() => ({
+    question: vi.fn((_prompt: string, cb: () => void) => {
+      cb();
+    }),
+    close: vi.fn(),
+  })),
+}));
+
+function makeMockTUI(): TUI {
+  return {
+    stop: vi.fn(),
+    start: vi.fn(),
+    requestRender: vi.fn(),
+  } as unknown as TUI;
+}
+
+describe('runShellCommand', () => {
+  it('stops TUI, spawns command with inherited stdio, then restarts TUI', async () => {
+    const ui = makeMockTUI();
+    const mockChild = {
+      on: vi.fn((event: string, cb: (arg?: number) => void) => {
+        if (event === 'exit') cb(0);
+      }),
+    };
+    vi.mocked(spawn).mockReturnValue(mockChild as unknown as ReturnType<typeof spawn>);
+
+    const code = await runShellCommand('echo hello', ui);
+
+    expect(ui.stop).toHaveBeenCalledOnce();
+    expect(spawn).toHaveBeenCalledWith('echo hello', { shell: true, stdio: 'inherit' });
+    expect(code).toBe(0);
+    expect(ui.start).toHaveBeenCalledOnce();
+    expect(ui.requestRender).toHaveBeenCalledWith(true);
+  });
+
+  it('restarts TUI even when spawn throws', async () => {
+    const ui = makeMockTUI();
+    vi.mocked(spawn).mockImplementation(() => {
+      throw new Error('spawn failed');
+    });
+
+    await expect(runShellCommand('bad-cmd', ui)).rejects.toThrow('spawn failed');
+
+    expect(ui.stop).toHaveBeenCalledOnce();
+    expect(ui.start).toHaveBeenCalledOnce();
+    expect(ui.requestRender).toHaveBeenCalledWith(true);
+  });
+
+  it('returns 128 + signum when process is killed by signal', async () => {
+    const ui = makeMockTUI();
+    const mockChild = {
+      on: vi.fn((event: string, cb: (code: number | null, signal: string | null) => void) => {
+        if (event === 'exit') cb(null, 'SIGTERM');
+      }),
+    };
+    vi.mocked(spawn).mockReturnValue(mockChild as unknown as ReturnType<typeof spawn>);
+
+    const code = await runShellCommand('sleep 10', ui);
+
+    expect(code).toBe(143); // 128 + 15 (SIGTERM)
+  });
+});


### PR DESCRIPTION
## Summary

Closes #241
Closes #141

Add `Ctrl+X` keyboard shortcut to toggle between **Agent mode** and **Shell mode** in the TUI, matching the behavior of `kimi-cli`.

In **Shell mode**, user input is executed directly as local shell commands instead of being sent to the AI agent. This avoids context-switching to an external terminal for quick shell operations.

## User Experience

| Mode | Prompt Symbol | Footer Badge | Behavior on `Enter` |
|------|---------------|--------------|---------------------|
| Agent | `> ` | — | Send to AI agent |
| Shell | `$ ` | `[shell]` | Execute as local shell command |

- Press `Ctrl+X` to toggle between modes
- Interactive programs (`vim`, `less`, `htop`) work because the TUI temporarily releases the terminal
- After command execution, press **Enter** to return to the TUI (ensures output is visible)
- Agent-only slash commands (`/new`, `/plan`, `/compact`, `/goal`, `/undo`, `/fork`, `/init`, `/export-md`, `/export-debug-zip`) are blocked with a hint to switch back to Agent mode

## Architecture

- `inputMode: 'agent' | 'shell'` added to `AppState`
- `CustomEditor` captures `Ctrl+X` via pi-tui's `Key.ctrl('x')` and supports configurable `promptSymbol`
- `EditorKeyboardController` wires `onCtrlX` → telemetry (`shortcut_mode_switch`) → `KimiTUI.handleInputModeToggle()`
- `KimiTUI.handleUserInput()` routes shell-mode text to `runShellCommand()` or filtered slash dispatch
- `runShellCommand()` uses the existing TUI suspend/resume pattern (same as external editor):
  1. `ui.stop()` — exit alternate screen
  2. `spawn(command, { shell: true, stdio: 'inherit' })`
  3. On exit: resolve with `code` or `128 + signum` for signal termination
  4. Prompt user to press Enter
  5. `ui.start()` + `ui.requestRender(true)`

## Test Plan

- [x] 944 TUI tests pass
- [x] `Ctrl+X` dispatches `onCtrlX` (unit test)
- [x] Prompt symbol switches to `$` in shell mode (unit test)
- [x] Footer renders `[shell]` badge (unit test)
- [x] Shell executor lifecycle: stop → spawn → start → render (unit test)
- [x] Signal exit code mapping (`SIGTERM` → `143`) (unit test)
- [x] TUI resumes even when `spawn` throws (unit test)
- [x] Manual verification: `Ctrl+X` → shell mode → `echo hello` → Enter to resume

## Files Changed

| File | Change |
|------|--------|
| `src/tui/types.ts` | Add `inputMode: 'agent' \| 'shell'` to `AppState` |
| `src/tui/kimi-tui.ts` | `handleInputModeToggle()`, `executeShellCommand()`, shell-mode routing in `handleUserInput()` |
| `src/tui/components/editor/custom-editor.ts` | `onCtrlX`, `promptSymbol`, `Key.ctrl('x')` handling |
| `src/tui/controllers/editor-keyboard.ts` | Wire `editor.onCtrlX` to telemetry + mode toggle |
| `src/tui/components/chrome/footer.ts` | `[shell]` badge, `ctrl+x: toggle mode` toolbar tip |
| `src/tui/utils/shell-executor.ts` | **New** — `runShellCommand()` with TUI suspend/resume |
| Test files | Coverage for new behavior + `AppState` fixture updates |
