### PR TITLE
docs(guides): add Paseo ACP integration section

### DIFF
--- a/docs/en/guides/ides.md
+++ b/docs/en/guides/ides.md
@@ -62,6 +62,28 @@ In the AI chat panel menu, click **Configure ACP agents** and add the following 
 
 JetBrains is strict about the `command` field — always use an **absolute path**, which you can get by running `which kimi` in a terminal. After saving, `Kimi Code CLI` will appear in the AI chat's agent selector.
 
+## Using Kimi Code CLI in Paseo
+
+[Paseo](https://paseo.sh/) is a self-hosted orchestrator that runs and supervises agent CLIs from your desktop, web, and mobile. It connects to Kimi Code CLI over ACP, the same way an IDE does.
+
+Pick **Kimi Code CLI** from Paseo's built-in ACP provider catalog, or add a custom provider in `~/.paseo/config.json`:
+
+```json
+{
+  "agents": {
+    "providers": {
+      "kimi": {
+        "extends": "acp",
+        "label": "Kimi Code CLI",
+        "command": ["kimi", "acp"]
+      }
+    }
+  }
+}
+```
+
+Paseo's generic ACP adapter does not drive the login flow, so complete the terminal login first (see [Prerequisites](#prerequisites)) — otherwise session creation fails with `Authentication required`.
+
 ## Troubleshooting
 
 - **Session disconnects immediately / IDE shows "agent exited"**: usually a wrong `command` path or a missing login. Run `kimi acp` in a terminal first to verify — if it blocks waiting for stdin, the CLI itself is fine and the problem is in the IDE configuration; if it exits immediately with an error, follow the error message (most commonly you need to run `/login`).

--- a/docs/zh/guides/ides.md
+++ b/docs/zh/guides/ides.md
@@ -62,6 +62,28 @@ JetBrains 系列 IDE（IntelliJ IDEA、PyCharm、WebStorm 等）通过 AI 聊天
 
 JetBrains 这一侧对 `command` 字段处理较严格——务必填写**绝对路径**，可以在终端执行 `which kimi` 拿到。保存后，AI 聊天的 Agent 选择器里就会出现 `Kimi Code CLI`。
 
+## 在 Paseo 中使用
+
+[Paseo](https://paseo.sh/) 是一个自托管的编排器，能在桌面、网页和手机上统一启动并接管各类 agent 的 CLI。它和 IDE 一样，通过 ACP 接入 Kimi Code CLI。
+
+在 Paseo 内置的 ACP provider 目录里选择 **Kimi Code CLI**，或在 `~/.paseo/config.json` 里添加一个自定义 provider：
+
+```json
+{
+  "agents": {
+    "providers": {
+      "kimi": {
+        "extends": "acp",
+        "label": "Kimi Code CLI",
+        "command": ["kimi", "acp"]
+      }
+    }
+  }
+}
+```
+
+Paseo 的通用 ACP 适配层不会帮你走登录流程，所以请先完成终端登录（见[前置准备](#前置准备)）——否则创建会话会以 `Authentication required` 失败。
+
 ## 故障排查
 
 - **会话立刻被中断 / IDE 提示 "agent exited"**：通常是 `command` 路径不对或 kimi 没登录。先在终端跑一次 `kimi acp` 验证：如果阻塞等待标准输入则说明 CLI 本身没问题，问题在 IDE 配置；如果立刻报错则按报错提示处理（多数是没 `/login`）。


### PR DESCRIPTION
> [!NOTE]
> Draft on purpose — should land **after** the Paseo catalog PR ([getpaseo/paseo#1403](https://github.com/getpaseo/paseo/pull/1403)) so the docs match what users see in Paseo's catalog ("Kimi Code CLI").

## Related Issue

No separate issue — the problem is explained below.

## Problem

[Paseo](https://paseo.sh/) is an ACP-based orchestrator that runs coding-agent CLIs across desktop / web / mobile, and it already lists Kimi Code CLI. Our ACP guide only covered Zed and JetBrains, and didn't warn that Paseo's generic ACP adapter cannot drive the login flow — so users hit `Authentication required` with no doc to turn to.

## What changed

Added a "Using Kimi Code CLI in Paseo" section to the existing ACP integration guide (en + zh):

- built-in ACP catalog (one-click) and custom-provider (`~/.paseo/config.json`) setup
- a note to complete `kimi login` in a terminal first (Paseo can't drive login)

Existing sections (Zed, JetBrains, prerequisites, troubleshooting) are unchanged — this is additive only.

## Checklist

- [x] I have read the CONTRIBUTING document.
- [x] I have linked a related issue, or explained the problem above.
- [ ] I have added tests that prove my feature works. — N/A, docs-only change.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset. — No changeset: docs-only, not part of package output (per gen-changesets rule 5).
- [x] Ran `gen-docs` skill, or this PR needs no doc update. — Hand-authored guide section following the existing page structure; `gen-docs` syncs code-derived reference docs and isn't applicable here.
