### PR TITLE
chore: add changeset for PR #486

### DIFF
--- a/.changeset/fix-windows-session-workdir-separators.md
+++ b/.changeset/fix-windows-session-workdir-separators.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Fix session workdir mismatch on Windows caused by inconsistent path separators.


### PR DESCRIPTION
## Related Issue

N/A — this PR only adds a missing changeset for #486.

## Problem

PR #486 (fix: handle windows session workdir separators) was merged without a changeset.

## What changed

Added a patch-level changeset for "@moonshot-ai/kimi-code" to record the Windows session workdir path-separator fix.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.