### PR TITLE
fix(openai-legacy): don't clamp xhigh/max for non-OpenAI models (fixes #525)

### DIFF
--- a/packages/kosong/src/providers/capability-registry.ts
+++ b/packages/kosong/src/providers/capability-registry.ts
@@ -158,7 +158,7 @@ function normalizeModelName(modelName: string): string {
   return modelName.toLowerCase();
 }
 
-function modelIdLeaf(modelName: string): string {
+export function modelIdLeaf(modelName: string): string {
   return normalizeModelName(modelName).trim().split('/').at(-1) ?? '';
 }
 

--- a/packages/kosong/src/providers/openai-legacy.ts
+++ b/packages/kosong/src/providers/openai-legacy.ts
@@ -14,6 +14,7 @@ import OpenAI from 'openai';
 
 import {
   getOpenAILegacyModelCapability,
+  modelIdLeaf,
   supportsOpenAIChatCompletionsXHighReasoning,
 } from './capability-registry';
 import {
@@ -140,6 +141,17 @@ function clampChatCompletionsReasoningEffort(
   model: string,
 ): string | undefined {
   if (reasoningEffort !== 'xhigh') {
+    return reasoningEffort;
+  }
+  // Only clamp for known OpenAI models. Other providers (DeepSeek, Qwen,
+  // One API gateways, etc.) using the openai-legacy adapter may support
+  // xhigh/max reasoning_effort natively, so we should not downgrade them.
+  const modelLeaf = modelIdLeaf(model);
+  const isOpenAIModel =
+    modelLeaf.startsWith('gpt-') ||
+    modelLeaf.startsWith('o1') ||
+    modelLeaf.startsWith('o3');
+  if (!isOpenAIModel) {
     return reasoningEffort;
   }
   return supportsOpenAIChatCompletionsXHighReasoning(model) ? 'xhigh' : 'high';

--- a/packages/kosong/test/openai-legacy.test.ts
+++ b/packages/kosong/test/openai-legacy.test.ts
@@ -718,7 +718,7 @@ describe('OpenAILegacyChatProvider', () => {
       expect(body['reasoning_effort']).toBe('high');
     });
 
-    it.each(['gpt-5.2', 'gpt-5.4', 'gpt-5.5', 'openai/gpt-5.5'])(
+    it.each(['gpt-5.2', 'gpt-5.4', 'gpt-5.5', 'openai/gpt-5.5', 'deepseek-v4-flash', 'deepseek-v4-pro'])(
       '.withThinking("xhigh") passes through for Chat Completions xhigh model %s',
       async (model) => {
         const provider = createProvider({ model }).withThinking('xhigh');
@@ -732,7 +732,7 @@ describe('OpenAILegacyChatProvider', () => {
       },
     );
 
-    it.each(['gpt-5.1', 'gpt-5.4-mini', 'gpt-5.4-pro', 'kimi-k2.6', 'some-model'])(
+    it.each(['gpt-5.1', 'gpt-5.4-mini', 'gpt-5.4-pro'])(
       '.withThinking("xhigh") clamps to high for Chat Completions model %s',
       async (model) => {
         const provider = createProvider({ model }).withThinking('xhigh');


### PR DESCRIPTION
## Problem

PR #457 (v0.11.0) introduced a clamping layer in the shared `openai-legacy` provider that downgrades `xhigh` / `max` thinking effort to `high` for any model not on the OpenAI xhigh whitelist. This incorrectly affected DeepSeek, Qwen, and other OpenAI-compatible providers that natively support `xhigh` / `max` reasoning effort.

**Issue:** #525  
**Regression introduced:** v0.11.0

## Root cause

`clampChatCompletionsReasoningEffort` in `openai-legacy.ts` called `supportsOpenAIChatCompletionsXHighReasoning`, which only checks against a hard-coded OpenAI model whitelist (`gpt-5.2`, `gpt-5.4`, `gpt-5.5`). Any non-OpenAI model (e.g. `deepseek-v4-flash`) was silently downgraded to `high`.

## Fix

Restrict the clamping logic to **known OpenAI models only** (those whose leaf model ID starts with `gpt-`, `o1`, or `o3`). For all other models using the `openai-legacy` adapter, the original `reasoning_effort` value is passed through unchanged, letting the provider handle it natively.

## Changes

- `packages/kosong/src/providers/openai-legacy.ts` — updated `clampChatCompletionsReasoningEffort`
- `packages/kosong/src/providers/capability-registry.ts` — exported `modelIdLeaf` so it can be reused in the clamping check
- `packages/kosong/test/openai-legacy.test.ts` — updated tests: DeepSeek models now pass through `xhigh`; only non-xhigh OpenAI models are clamped

## Verification

All 1080 tests in the `kosong` package pass (47 test files).
