### PR TITLE
fix: correct Anthropic cached token usage

### DIFF
--- a/.changeset/fix-anthropic-cache-usage.md
+++ b/.changeset/fix-anthropic-cache-usage.md
@@ -1,0 +1,6 @@
+---
+"@moonshot-ai/kosong": patch
+"@moonshot-ai/kimi-code": patch
+---
+
+Fix Anthropic cached input token accounting so cached tokens are not counted twice.

--- a/packages/kosong/src/providers/anthropic.ts
+++ b/packages/kosong/src/providers/anthropic.ts
@@ -15,7 +15,7 @@ import type {
   ThinkingEffort,
 } from '#/provider';
 import type { Tool } from '#/tool';
-import type { TokenUsage } from '#/usage';
+import { inputTotal, type TokenUsage } from '#/usage';
 import Anthropic, {
   APIError as AnthropicAPIError,
   APIConnectionError as AnthropicConnectionError,
@@ -639,11 +639,31 @@ class AnthropicStreamedMessage implements StreamedMessage {
     cache_read_input_tokens?: number;
     cache_creation_input_tokens?: number;
   }): void {
+    const inputCacheRead = usage.cache_read_input_tokens ?? 0;
+    const inputCacheCreation = usage.cache_creation_input_tokens ?? 0;
     this._usage = {
-      inputOther: usage.input_tokens ?? 0,
+      inputOther: Math.max((usage.input_tokens ?? 0) - inputCacheRead - inputCacheCreation, 0),
       output: usage.output_tokens ?? 0,
-      inputCacheRead: usage.cache_read_input_tokens ?? 0,
-      inputCacheCreation: usage.cache_creation_input_tokens ?? 0,
+      inputCacheRead,
+      inputCacheCreation,
+    };
+  }
+
+  private _mergeUsage(usage: {
+    input_tokens?: number;
+    output_tokens?: number;
+    cache_read_input_tokens?: number;
+    cache_creation_input_tokens?: number;
+  }): void {
+    const inputCacheRead = usage.cache_read_input_tokens ?? this._usage.inputCacheRead;
+    const inputCacheCreation =
+      usage.cache_creation_input_tokens ?? this._usage.inputCacheCreation;
+    const totalInput = usage.input_tokens ?? inputTotal(this._usage);
+    this._usage = {
+      inputOther: Math.max(totalInput - inputCacheRead - inputCacheCreation, 0),
+      output: usage.output_tokens ?? this._usage.output,
+      inputCacheRead,
+      inputCacheCreation,
     };
   }
 
@@ -792,18 +812,24 @@ class AnthropicStreamedMessage implements StreamedMessage {
           // Update usage from delta
           const deltaUsage = (evt as { usage?: Record<string, unknown> }).usage;
           if (deltaUsage !== undefined) {
-            if (typeof deltaUsage['output_tokens'] === 'number') {
-              this._usage.output = deltaUsage['output_tokens'];
-            }
-            if (typeof deltaUsage['cache_read_input_tokens'] === 'number') {
-              this._usage.inputCacheRead = deltaUsage['cache_read_input_tokens'];
-            }
-            if (typeof deltaUsage['cache_creation_input_tokens'] === 'number') {
-              this._usage.inputCacheCreation = deltaUsage['cache_creation_input_tokens'];
-            }
-            if (typeof deltaUsage['input_tokens'] === 'number') {
-              this._usage.inputOther = deltaUsage['input_tokens'];
-            }
+            this._mergeUsage({
+              input_tokens:
+                typeof deltaUsage['input_tokens'] === 'number'
+                  ? deltaUsage['input_tokens']
+                  : undefined,
+              output_tokens:
+                typeof deltaUsage['output_tokens'] === 'number'
+                  ? deltaUsage['output_tokens']
+                  : undefined,
+              cache_read_input_tokens:
+                typeof deltaUsage['cache_read_input_tokens'] === 'number'
+                  ? deltaUsage['cache_read_input_tokens']
+                  : undefined,
+              cache_creation_input_tokens:
+                typeof deltaUsage['cache_creation_input_tokens'] === 'number'
+                  ? deltaUsage['cache_creation_input_tokens']
+                  : undefined,
+            });
           }
           // The terminal `stop_reason` lives on `delta.stop_reason` of the
           // last `message_delta` event for this response. Capture it here.

--- a/packages/kosong/test/anthropic.test.ts
+++ b/packages/kosong/test/anthropic.test.ts
@@ -1592,7 +1592,7 @@ describe('AnthropicChatProvider', () => {
         },
       ]);
       expect(stream.usage).toEqual({
-        inputOther: 15,
+        inputOther: 10,
         output: 10,
         inputCacheRead: 5,
         inputCacheCreation: 0,
@@ -1635,7 +1635,7 @@ describe('AnthropicChatProvider', () => {
       ]);
       expect(result.id).toBe('msg_stream_001');
       expect(result.usage).toEqual({
-        inputOther: 10,
+        inputOther: 5,
         output: 5,
         inputCacheRead: 3,
         inputCacheCreation: 2,
@@ -1984,7 +1984,7 @@ describe('AnthropicChatProvider', () => {
       await collectParts(result);
 
       expect(result.usage).toEqual({
-        inputOther: 105,
+        inputOther: 25,
         output: 42,
         inputCacheRead: 55,
         inputCacheCreation: 25,

--- a/packages/kosong/test/e2e/anthropic-adapter.test.ts
+++ b/packages/kosong/test/e2e/anthropic-adapter.test.ts
@@ -202,7 +202,7 @@ describe('e2e: Anthropic adapter bridge', () => {
 
       expect(stream.id).toBe('msg_1');
       expect(stream.usage).toEqual({
-        inputOther: 19,
+        inputOther: 16,
         output: 7,
         inputCacheRead: 2,
         inputCacheCreation: 1,


### PR DESCRIPTION
## Related Issue

No linked issue. This PR addresses a reviewed finding that Anthropic cached input tokens were counted twice in usage accounting.

## Problem

Anthropic reports `input_tokens` as a total that already includes `cache_read_input_tokens` and `cache_creation_input_tokens`. The adapter stored that total as uncached input while also storing the cached token fields separately. Because aggregate usage sums uncached input, cache reads, and cache creation, cached tokens were double-counted. That inflated context and cost tracking for Anthropic responses whenever prompt caching was used.

## What changed

The Anthropic adapter now normalizes usage by subtracting cache read and cache creation tokens from the total input token count before assigning `inputOther`. Streaming usage updates now go through the same normalization logic while preserving prior values when a `message_delta` only reports partial usage fields, such as output tokens. Existing Anthropic unit and e2e tests now assert the corrected token breakdown, and a patch changeset was added for the affected package and CLI bundle.

## Validation

- `pnpm test -- packages/kosong/test/anthropic.test.ts packages/kosong/test/e2e/anthropic-adapter.test.ts` passed; the repo test script ran the full Vitest suite with 6,189 passed, 25 skipped, and 2 todo.
- `pnpm --filter @moonshot-ai/kosong run typecheck` passed.
- `pnpm exec oxlint --type-aware packages/kosong/src/providers/anthropic.ts packages/kosong/test/anthropic.test.ts packages/kosong/test/e2e/anthropic-adapter.test.ts` passed.
- `git diff --check` passed.
- Read-only diff audit found no sensitive or context-specific identifiers in the patch.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.
