### PR TITLE
docs: restore Kimi Datasource legacy pages

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -184,11 +184,6 @@ const config = withMermaid(defineConfig({
     },
   },
 
-  redirects: {
-    '/zh/customization/datasource': '/zh/customization/plugins',
-    '/en/customization/datasource': '/en/customization/plugins',
-  },
-
   themeConfig: {
     outline: [2, 3],
     search: { provider: 'local' },
@@ -201,28 +196,7 @@ const config = withMermaid(defineConfig({
     optimizeDeps: {
       include: mermaidOptimizeDeps.map((dep) => `mermaid > ${dep}`),
     },
-    plugins: [
-      llmstxt(),
-      {
-        name: 'dev-redirects',
-        configureServer(server) {
-          const map: Record<string, string> = {
-            '/zh/customization/datasource': '/zh/customization/plugins',
-            '/en/customization/datasource': '/en/customization/plugins',
-          }
-          server.middlewares.use((req, res, next) => {
-            const url = (req.url ?? '').split('?')[0].replace(/\.html$/, '')
-            const target = map[url]
-            if (target) {
-              res.writeHead(302, { Location: target })
-              res.end()
-              return
-            }
-            next()
-          })
-        },
-      },
-    ],
+    plugins: [llmstxt()],
   },
 }))
 

--- a/docs/en/customization/datasource.md
+++ b/docs/en/customization/datasource.md
@@ -1,0 +1,10 @@
+---
+head:
+  - - meta
+    - http-equiv: refresh
+      content: 0; url=./plugins.html#kimi-datasource
+---
+
+# Kimi Datasource
+
+This page has moved to [Plugins: Kimi Datasource](./plugins.md#kimi-datasource).

--- a/docs/zh/customization/datasource.md
+++ b/docs/zh/customization/datasource.md
@@ -1,0 +1,10 @@
+---
+head:
+  - - meta
+    - http-equiv: refresh
+      content: 0; url=./plugins.html#kimi-datasource
+---
+
+# Kimi Datasource
+
+本页已迁移到 [Plugins：Kimi Datasource](./plugins.md#kimi-datasource)。


### PR DESCRIPTION
## Related Issue

No linked issue. The deployed documentation URL `/zh/customization/datasource.html` returns 404 after Kimi Datasource was merged into the Plugins page.

## Problem

PR #551 removed the standalone datasource pages and added redirect-style config that VitePress/GitHub Pages does not use for static deployment. As a result, GitHub Pages has no `datasource.html` file to serve for existing bookmarks and search results.

## What changed

- Restore lightweight English and Chinese `customization/datasource.md` pages so VitePress generates the legacy `.html` URLs again.
- Add a meta refresh and visible link from each legacy page to the Kimi Datasource section on the Plugins page.
- Remove the unsupported `redirects` config and the dev-only redirect middleware so local behavior does not hide deployment behavior.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works. (N/A: docs-only; verified with docs build.)
- [x] Ran `gen-changesets` skill, or this PR needs no changeset. (No changeset needed: docs-only.)
- [x] Ran `gen-docs` skill, or this PR needs no doc update. (N/A: this PR directly updates docs.)

## Verification

- `git diff --check`
- `pnpm -C docs run build`
- `env VITEPRESS_BASE=/kimi-code/ pnpm -C docs run build`
