### PR TITLE
fix(config): ignore retired experimental flags

### DIFF
--- a/.changeset/smooth-experimental-upgrades.md
+++ b/.changeset/smooth-experimental-upgrades.md
@@ -1,0 +1,4 @@
+"@moonshot-ai/kimi-code": patch
+---
+
+Allow startup to ignore retired experimental feature flags left in config.toml after upgrading.

--- a/packages/agent-core/src/config/schema.ts
+++ b/packages/agent-core/src/config/schema.ts
@@ -106,19 +106,30 @@ export const BackgroundConfigSchema = z.object({
 export type BackgroundConfig = z.infer<typeof BackgroundConfigSchema>;
 
 const ExperimentalFlagIdSet = new Set<string>(FLAG_DEFINITIONS.map((def) => def.id));
+const RetiredExperimentalFlagIdSet = new Set<string>([
+  'goal_command',
+  'background_ask',
+  'agent_swarm',
+  'sub_skill',
+]);
 
 export const ExperimentalConfigSchema = z
   .record(z.string(), z.boolean())
   .superRefine((config, ctx) => {
     for (const key of Object.keys(config)) {
-      if (ExperimentalFlagIdSet.has(key)) continue;
+      if (ExperimentalFlagIdSet.has(key) || RetiredExperimentalFlagIdSet.has(key)) continue;
       ctx.addIssue({
         code: 'custom',
         path: [key],
         message: `Unknown experimental feature "${key}".`,
       });
     }
-  }) as z.ZodType<Partial<Record<FlagId, boolean>>>;
+  })
+  .transform((config) =>
+    Object.fromEntries(
+      Object.entries(config).filter(([key]) => !RetiredExperimentalFlagIdSet.has(key)),
+    ),
+  ) as z.ZodType<Partial<Record<FlagId, boolean>>>;
 
 export type ExperimentalConfig = z.infer<typeof ExperimentalConfigSchema>;
 

--- a/packages/agent-core/test/config/configs.test.ts
+++ b/packages/agent-core/test/config/configs.test.ts
@@ -279,6 +279,18 @@ micro_compaction = false
     expect(parseConfigString(text, configPath).experimental).toEqual(config.experimental);
   });
 
+  it('ignores retired experimental feature flags from older configs', () => {
+    const config = parseConfigString(`
+[experimental]
+goal_command = true
+background_ask = true
+agent_swarm = true
+sub_skill = true
+`);
+
+    expect(config.experimental).toEqual({});
+  });
+
   it('rejects unknown experimental feature keys', () => {
     expectKimiErrorCode(
       () =>


### PR DESCRIPTION
## Summary

- tolerate retired `[experimental]` keys left in `config.toml` after upgrading
- drop graduated feature flags such as `goal_command`, `background_ask`, `agent_swarm`, and `sub_skill` from runtime config
- keep unknown experimental keys rejected so invalid config still fails loudly

Fixes #572.

## Tests

- `pnpm exec vitest run packages/agent-core/test/config/configs.test.ts`
- `pnpm --filter @moonshot-ai/agent-core run typecheck`
- `pnpm exec oxlint packages/agent-core/src/config/schema.ts packages/agent-core/test/config/configs.test.ts`
