### PR TITLE
docs: add missing slash commands to reference

### DIFF
--- a/docs/en/reference/slash-commands.md
+++ b/docs/en/reference/slash-commands.md
@@ -32,6 +32,7 @@ Some commands are only available in the idle state. Executing these commands whi
 | `/fork` | — | Fork a new session from the current one, preserving the full conversation history | No |
 | `/title [<text>]` | `/rename` | Without arguments, display the current session title; with an argument, set a new title (max 200 characters) | Yes |
 | `/compact [<instruction>]` | — | Compact the current conversation context to free up token usage; an optional custom instruction can hint to the model what to preserve | No |
+| `/undo [<count>]` | — | Withdraw the last prompt from the conversation history, along with the responses that followed it; pass a positive integer to undo that many prompts | No |
 | `/reload` | — | Reload the current session and apply the latest `config.toml` settings (providers, models, etc.) and `tui.toml` UI preferences, without restarting the CLI | No |
 | `/reload-tui` | — | Reload only the `tui.toml` UI preferences (theme, editor, notifications, etc.) without rebuilding the session | Yes |
 | `/init` | — | Analyze the current codebase and generate `AGENTS.md` | No |

--- a/docs/zh/reference/slash-commands.md
+++ b/docs/zh/reference/slash-commands.md
@@ -32,6 +32,9 @@
 | `/fork` | — | 基于当前会话 fork 一份新会话，保留完整对话历史 | 否 |
 | `/title [<text>]` | `/rename` | 不带参数时显示当前会话标题；带参数时设置为新标题（最长 200 字符） | 是 |
 | `/compact [<instruction>]` | — | 压缩当前对话上下文，释放 token 占用；可附带自定义指令，提示模型压缩时保留哪些信息 | 否 |
+| `/undo [<count>]` | — | 从对话历史中撤回上一条提示词，连同其后的回复一并撤回；可传入正整数一次撤回多条 | 否 |
+| `/reload` | — | 重载当前会话并应用最新的 `config.toml` 配置（供应商、模型等）以及 `tui.toml` UI 偏好，无需重启 CLI | 否 |
+| `/reload-tui` | — | 仅重载 `tui.toml` UI 偏好（主题、编辑器、通知等），不重建会话 | 是 |
 | `/init` | — | 分析当前代码库并生成 `AGENTS.md` | 否 |
 | `/export-md [<path>]` | `/export` | 将当前会话导出为 Markdown 文件 | 否 |
 | `/export-debug-zip` | — | 将当前会话导出为调试用 ZIP 压缩包（与 [`kimi export`](./kimi-command.md#kimi-export) 行为一致） | 否 |


### PR DESCRIPTION
## Related Issue

No related issue. This is a documentation-only change; per [CONTRIBUTING.md](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md), documentation-only changes can be opened directly. The problem is described below.

## Problem

Several slash commands that exist in the TUI command registry are missing from the reference tables, so users browsing the docs cannot discover them:

- `/undo` is absent from **both** the English and Chinese tables.
- `/reload` and `/reload-tui` are absent from the **Chinese** table (they are already present in the English one).

## What changed

Added the missing rows to the reference tables in `docs/en/reference/slash-commands.md` and `docs/zh/reference/slash-commands.md`:

- **EN**: `/undo`
- **ZH**: `/undo`, `/reload`, `/reload-tui`

All three commands are registered in `apps/kimi-code/src/tui/commands/registry.ts` (`undo`, `reload`, `reload-tui`). The `/undo [<count>]` argument is accurate: `handleUndoCommand` parses an optional positive integer (`parseUndoCount` → `session.undoHistory(count)`). Descriptions follow the wording/format of the surrounding rows. These tables are hand-maintained (not generated), so the rows are added directly.

This consolidates and supersedes #516.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] ~~I have added tests that prove my feature works.~~ N/A — documentation-only change; no tests applicable.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset. — docs-only PR; per CONTRIBUTING, no changeset needed.
- [x] Ran `gen-docs` skill, or this PR needs no doc update. — this PR *is* the doc update; the tables are hand-maintained, not generated.