### PR TITLE
docs: fix broken fragment anchors and cross-reference links

### DIFF
--- a/docs/en/configuration/config-files.md
+++ b/docs/en/configuration/config-files.md
@@ -85,7 +85,7 @@ Fields in the config file fall into two categories: **top-level scalars** that d
 | `providers` | `table` | `{}` | API provider table → [`providers`](#providers) |
 | `models` | `table` | — | Model alias table → [`models`](#models) |
 | `thinking` | `table` | — | Default parameters for Thinking mode → [`thinking`](#thinking) |
-| `loop_control` | `table` | — | Agent loop control parameters → [`loop_control`](#loop_control) |
+| `loop_control` | `table` | — | Agent loop control parameters → [`loop_control`](#loop-control) |
 | `background` | `table` | — | Background task runtime parameters → [`background`](#background) |
 | `experimental` | `table` | — | Experimental feature overrides → [`experimental`](#experimental) |
 | `services` | `table` | — | Built-in external service configuration → [`services`](#services) |
@@ -141,7 +141,7 @@ model = "gpt-4.1"
 max_context_size = 1047576
 ```
 
-You can also switch models temporarily without touching the config file — by setting `KIMI_MODEL_*` environment variables, the CLI synthesizes a temporary provider in memory that does not persist after restart. See [Define a model from environment variables](./env-vars.md#define-a-model-from-environment-variables-kimi_model).
+You can also switch models temporarily without touching the config file — by setting `KIMI_MODEL_*` environment variables, the CLI synthesizes a temporary provider in memory that does not persist after restart. See [Define a model from environment variables](./env-vars.md#define-a-model-from-environment-variables-kimi-model).
 
 ## `thinking`
 

--- a/docs/en/configuration/env-vars.md
+++ b/docs/en/configuration/env-vars.md
@@ -34,7 +34,7 @@ export KIMI_DISABLE_TELEMETRY=1
 
 ### `KIMI_MODEL_*` family
 
-Switch models temporarily without modifying `config.toml` — when `KIMI_MODEL_NAME` is set, the CLI synthesizes a temporary provider in memory; the change does not persist after restart. See [Define a model from environment variables](#define-a-model-from-environment-variables-kimi_model).
+Switch models temporarily without modifying `config.toml` — when `KIMI_MODEL_NAME` is set, the CLI synthesizes a temporary provider in memory; the change does not persist after restart. See [Define a model from environment variables](#define-a-model-from-environment-variables-kimi-model).
 
 ## Provider credential key names (written in config.toml)
 

--- a/docs/en/customization/hooks.md
+++ b/docs/en/customization/hooks.md
@@ -152,5 +152,5 @@ This example only demonstrates the blocking mechanism — it is not a production
 
 ## Next steps
 
-- [Configuration files](../configuration/config-files.md#hooks) — Full field reference for `[[hooks]]` in `config.toml`
+- [Configuration files](../configuration/config-files.md) — full reference for `config.toml` fields
 - [Agents and sub-agents](./agents.md) — Use the `SubagentStop` event to trigger notifications after a sub-agent completes

--- a/docs/en/reference/keyboard.md
+++ b/docs/en/reference/keyboard.md
@@ -68,7 +68,7 @@ When collapsed tool call results exist in the history, press `Ctrl-O` to toggle 
 
 ## Approval Panel
 
-When the Agent initiates a tool call that requires confirmation, the TUI displays an approval panel. For the full approval workflow, see [Interaction & Input](../guides/interaction.md#审批流程). The available keys inside the panel are:
+When the Agent initiates a tool call that requires confirmation, the TUI displays an approval panel. For the full approval workflow, see [Interaction & Input](../guides/interaction.md#approval-flow). The available keys inside the panel are:
 
 | Shortcut | Function |
 | --- | --- |

--- a/docs/en/reference/slash-commands.md
+++ b/docs/en/reference/slash-commands.md
@@ -14,7 +14,7 @@ Some commands are only available in the idle state. Executing these commands whi
 | --- | --- | --- | --- |
 | `/login` | — | Select an account or platform and log in: Kimi Code uses OAuth device-code flow; Kimi Platform uses API key login | No |
 | `/logout` | — | Clear credentials for the currently selected account | No |
-| `/provider` | — | Open the interactive provider manager to view, add, and remove configured providers. See [Platforms & Models — `/provider` and provider management](../configuration/providers.md#provider-与供应商管理) | Yes |
+| `/provider` | — | Open the interactive provider manager to view, add, and remove configured providers. See [Platforms & Models — `/provider` and provider management](../configuration/providers.md#provider-—-interactive-provider-management) | Yes |
 | `/model` | — | Switch the LLM model used in the current session | Yes |
 | `/settings` | `/config` | Open the settings panel inside the TUI | Yes |
 | `/experiments` | `/experimental` | Open the experimental feature panel | Yes |

--- a/docs/en/reference/tools.md
+++ b/docs/en/reference/tools.md
@@ -115,7 +115,7 @@ Background task tools manage tasks started via `Bash`, `Agent`, or `AskUserQuest
 
 ## Scheduled Tasks
 
-Scheduled task tools allow the Agent to re-inject a prompt into the current session at a future time — either as a one-time reminder or as a recurring cron-triggered task (periodic checks, daily reports, deployment monitoring, etc.). Schedules are bound to the session and remain active after `kimi resume`, but are not carried into a brand-new session. A single session can hold at most 50 active scheduled tasks. Set `KIMI_DISABLE_CRON=1` to disable them entirely; see [Environment Variables](../configuration/env-vars.md#运行时开关).
+Scheduled task tools allow the Agent to re-inject a prompt into the current session at a future time — either as a one-time reminder or as a recurring cron-triggered task (periodic checks, daily reports, deployment monitoring, etc.). Schedules are bound to the session and remain active after `kimi resume`, but are not carried into a brand-new session. A single session can hold at most 50 active scheduled tasks. Set `KIMI_DISABLE_CRON=1` to disable them entirely; see [Environment Variables](../configuration/env-vars.md#runtime-switches).
 
 | Tool | Default Approval | Description |
 | --- | --- | --- |

--- a/docs/zh/configuration/config-files.md
+++ b/docs/zh/configuration/config-files.md
@@ -85,7 +85,7 @@ timeout = 5
 | `providers` | `table` | `{}` | API 供应商表 → [`providers`](#providers) |
 | `models` | `table` | — | 模型别名表 → [`models`](#models) |
 | `thinking` | `table` | — | Thinking 模式默认参数 → [`thinking`](#thinking) |
-| `loop_control` | `table` | — | Agent 循环控制参数 → [`loop_control`](#loop_control) |
+| `loop_control` | `table` | — | Agent 循环控制参数 → [`loop_control`](#loop-control) |
 | `background` | `table` | — | 后台任务运行参数 → [`background`](#background) |
 | `experimental` | `table` | — | 实验功能覆盖 → [`experimental`](#experimental) |
 | `services` | `table` | — | 内置外部服务配置 → [`services`](#services) |

--- a/docs/zh/configuration/env-vars.md
+++ b/docs/zh/configuration/env-vars.md
@@ -34,7 +34,7 @@ export KIMI_DISABLE_TELEMETRY=1
 
 ### `KIMI_MODEL_*` 系列
 
-不修改 `config.toml` 临时切换模型——设置 `KIMI_MODEL_NAME` 后，CLI 在内存里合成一个临时供应商，重启后失效。详见[用环境变量定义模型](#用环境变量定义模型kimi_model)。
+不修改 `config.toml` 临时切换模型——设置 `KIMI_MODEL_NAME` 后，CLI 在内存里合成一个临时供应商，重启后失效。详见[用环境变量定义模型](#用环境变量定义模型-kimi-model)。
 
 ## 供应商凭证键（写在 config.toml 里）
 

--- a/docs/zh/customization/hooks.md
+++ b/docs/zh/customization/hooks.md
@@ -152,5 +152,5 @@ process.stdin.on('end', () => {
 
 ## 下一步
 
-- [配置文件](../configuration/config-files.md#hooks) — `[[hooks]]` 在 `config.toml` 中的完整字段声明
+- [配置文件](../configuration/config-files.md) — `config.toml` 各字段的完整说明
 - [Agent 与子 Agent](./agents.md) — 利用 `SubagentStop` 事件在子 Agent 完成后触发通知

--- a/docs/zh/reference/slash-commands.md
+++ b/docs/zh/reference/slash-commands.md
@@ -14,7 +14,7 @@
 | --- | --- | --- | --- |
 | `/login` | — | 选择账号或平台并登录：Kimi Code 走 OAuth 验证码流程，Kimi Platform 通过 API 密钥登录 | 否 |
 | `/logout` | — | 清除当前所选账号的凭据 | 否 |
-| `/provider` | — | 打开交互式供应商管理器，查看、添加和删除已配置的供应商。详见[平台与模型 — `/provider` 与供应商管理](../configuration/providers.md#provider-与供应商管理) | 是 |
+| `/provider` | — | 打开交互式供应商管理器，查看、添加和删除已配置的供应商。详见[平台与模型 — `/provider` 与供应商管理](../configuration/providers.md#provider-—-交互式供应商管理) | 是 |
 | `/model` | — | 切换当前会话使用的 LLM 模型 | 是 |
 | `/settings` | `/config` | 打开 TUI 内的设置面板 | 是 |
 | `/experiments` | `/experimental` | 打开实验功能面板 | 是 |


### PR DESCRIPTION
## Related Issue

No related issue. These are documentation-only link fixes; per [CONTRIBUTING.md](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md), documentation-only changes can be opened directly. The problem is described below.

## Problem

Several in-docs cross-references resolve to nothing because their `#fragment` anchors do not match the target heading's slug:

- Some EN pages still link to leftover Chinese-text anchors: `#审批流程`, `#运行时开关`, `#provider-与供应商管理`.
- Some links use underscores where VitePress (the `@mdit-vue/shared` slugify) produces hyphens: `#loop_control`, `...-kimi_model`.
- `hooks.md` links to `config-files.md#hooks`, but no such heading exists on that page.

## What changed

Fixed each cross-reference to match the actual heading slug (EN + ZH where applicable):

| File | Before | After |
| --- | --- | --- |
| `reference/keyboard.md` (en) | `interaction.md#审批流程` | `#approval-flow` |
| `reference/tools.md` (en) | `env-vars.md#运行时开关` | `#runtime-switches` |
| `reference/slash-commands.md` (en/zh) | `providers.md#provider-与供应商管理` | `#provider-—-interactive-provider-management` / `#provider-—-交互式供应商管理` |
| `configuration/config-files.md` (en/zh) | `#loop_control` | `#loop-control` |
| `configuration/config-files.md` & `env-vars.md` (en/zh) | `...-kimi_model` | `...-kimi-model` |
| `customization/hooks.md` (en/zh) | `config-files.md#hooks` (no such anchor) | `config-files.md` |

The slugs follow VitePress's slugify (`@mdit-vue/shared`): underscore → `-`; em-dash (`—`) and CJK characters are kept literally; `NFKD` normalizes full-width parentheses to ASCII (so they also become `-`).

Verified by running `vitepress build` and confirming every updated link resolves to a generated heading `id` in `.vitepress/dist` — including the em-dash anchor `#provider-—-interactive-provider-management` and the CJK anchor `#provider-—-交互式供应商管理`.

This consolidates and supersedes #518, #522, #528, #530.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] ~~I have added tests that prove my feature works.~~ N/A — documentation-only change; no tests applicable.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset. — docs-only PR; per CONTRIBUTING, no changeset needed.
- [x] Ran `gen-docs` skill, or this PR needs no doc update. — this PR *is* the doc update; the edited pages are hand-maintained.