### PR TITLE
fix: truncate queued messages to a single line

### DIFF
--- a/.changeset/truncate-queue-line.md
+++ b/.changeset/truncate-queue-line.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Truncate queued message display to a single line with ellipsis when it exceeds terminal width.

--- a/apps/kimi-code/src/tui/components/panes/queue-pane.ts
+++ b/apps/kimi-code/src/tui/components/panes/queue-pane.ts
@@ -1,4 +1,4 @@
-import { Container, Text } from '@earendil-works/pi-tui';
+import { Container, truncateToWidth, visibleWidth } from '@earendil-works/pi-tui';
 import chalk from 'chalk';
 
 import { SELECT_POINTER } from '../../constant/symbols';
@@ -13,25 +13,45 @@ export interface QueuePaneOptions {
   readonly canSteerImmediately: boolean;
 }
 
+const ELLIPSIS = '…';
+
 export class QueuePaneComponent extends Container {
+  private readonly messages: readonly QueuedMessage[];
+  private readonly colors: ColorPalette;
+  private readonly hint: string | undefined;
+
   constructor(options: QueuePaneOptions) {
     super();
-
-    const accent = chalk.hex(options.colors.accent);
-    const dim = chalk.hex(options.colors.textDim);
-
-    for (const item of options.messages) {
-      this.addChild(new Text(accent(`  ${SELECT_POINTER} ${item.text}`), 0, 0));
-    }
+    this.messages = options.messages;
+    this.colors = options.colors;
 
     if (options.messages.length > 0) {
-      const hint =
+      this.hint =
         options.isCompacting && !options.isStreaming
           ? '  ↑ to edit · will send after compaction'
           : !options.canSteerImmediately
             ? '  ↑ to edit · will send after current task'
-          : '  ↑ to edit · ctrl-s to steer immediately';
-      this.addChild(new Text(dim(hint), 0, 0));
+            : '  ↑ to edit · ctrl-s to steer immediately';
     }
+  }
+
+  override render(width: number): string[] {
+    const accent = chalk.hex(this.colors.accent);
+    const dim = chalk.hex(this.colors.textDim);
+    const lines: string[] = [];
+
+    for (const item of this.messages) {
+      const singleLine = item.text.replaceAll(/\s+/g, ' ').trim();
+      const prefix = `  ${SELECT_POINTER} `;
+      const availableWidth = Math.max(1, width - visibleWidth(prefix));
+      const truncated = truncateToWidth(singleLine, availableWidth, ELLIPSIS);
+      lines.push(accent(prefix + truncated));
+    }
+
+    if (this.hint !== undefined) {
+      lines.push(dim(truncateToWidth(this.hint, width, ELLIPSIS)));
+    }
+
+    return lines;
   }
 }

--- a/apps/kimi-code/test/tui/components/panes/queue-pane.test.ts
+++ b/apps/kimi-code/test/tui/components/panes/queue-pane.test.ts
@@ -55,4 +55,37 @@ describe('QueuePaneComponent', () => {
     expect(output).toContain('will send after current task');
     expect(output).not.toContain('ctrl-s to steer immediately');
   });
+
+  it('truncates long messages to a single line', () => {
+    const longText = 'a'.repeat(200);
+    const component = new QueuePaneComponent({
+      colors: darkColors,
+      isCompacting: false,
+      isStreaming: true,
+      canSteerImmediately: true,
+      messages: [{ text: longText }],
+    });
+
+    const lines = component.render(30);
+    expect(lines).toHaveLength(2); // message + hint
+    const messageLine = stripAnsi(lines[0] as string);
+    expect(messageLine).not.toContain('a'.repeat(30));
+    expect(messageLine.endsWith('…')).toBe(true);
+  });
+
+  it('collapses multiline text into a single line', () => {
+    const component = new QueuePaneComponent({
+      colors: darkColors,
+      isCompacting: false,
+      isStreaming: true,
+      canSteerImmediately: true,
+      messages: [{ text: 'line one\nline two\nline three' }],
+    });
+
+    const lines = component.render(120);
+    expect(lines).toHaveLength(2); // message + hint
+    const messageLine = stripAnsi(lines[0] as string);
+    expect(messageLine).toContain('line one line two line three');
+    expect(messageLine).not.toContain('\n');
+  });
 });


### PR DESCRIPTION
## Related Issue

N/A — this is a small UI fix for an unreported issue.

## Problem

When a user sends a message while the agent is busy, the text is queued and shown in the terminal UI. Previously, these queued items were rendered as-is: long messages could wrap across multiple lines, and multiline text (e.g., pasted input with newlines) would also expand vertically, cluttering the queue pane and breaking the compact layout.

## What changed

- Replaced the naive \"Text child per item\" rendering in \"QueuePaneComponent\" with a proper \"override render(width)\" method.
- Each queued message is now collapsed to a single line (whitespace normalized to a single space).
- Messages that exceed the available terminal width are truncated with an ellipsis (\"…\").
- The bottom hint line is also width-truncated for safety.
- Added tests covering long-message truncation and multiline-to-single-line compression.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran \"gen-changesets\" skill, or this PR needs no changeset.
- [x] Ran \"gen-docs\" skill, or this PR needs no doc update.