### PR TITLE
fix: avoid Windows command shim launches

### DIFF
--- a/.changeset/steady-windows-bins.md
+++ b/.changeset/steady-windows-bins.md
@@ -1,0 +1,6 @@
+---
+"@moonshot-ai/kimi-code": patch
+"@moonshot-ai/kimi-code-sdk": patch
+---
+
+Fix Windows builds and development launches that could fail when package binaries resolve to command shims.

--- a/apps/kimi-code/scripts/dev.mjs
+++ b/apps/kimi-code/scripts/dev.mjs
@@ -1,10 +1,12 @@
 #!/usr/bin/env node
 import { spawn } from 'node:child_process';
+import { createRequire } from 'node:module';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 import { startPluginMarketplaceServer } from './dev-plugin-marketplace-server.mjs';
 
+const require = createRequire(import.meta.url);
 const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url));
 const APP_ROOT = resolve(SCRIPT_DIR, '..');
 const MARKETPLACE_ENV = 'KIMI_CODE_PLUGIN_MARKETPLACE_URL';
@@ -18,12 +20,12 @@ if (env[MARKETPLACE_ENV] === undefined || env[MARKETPLACE_ENV]?.trim().length ==
   console.error(`Plugin marketplace dev server: ${marketplaceServer.marketplaceUrl}`);
 }
 
-const tsxBin = process.platform === 'win32' ? 'tsx.cmd' : 'tsx';
+const tsxCli = require.resolve('tsx/cli');
 const cliArgs = process.argv.slice(2);
 if (cliArgs[0] === '--') cliArgs.shift();
 const child = spawn(
-  tsxBin,
-  ['--import', '../../build/register-raw-text-loader.mjs', './src/main.ts', ...cliArgs],
+  process.execPath,
+  [tsxCli, '--import', '../../build/register-raw-text-loader.mjs', './src/main.ts', ...cliArgs],
   {
     cwd: APP_ROOT,
     env,

--- a/packages/node-sdk/scripts/build-dts.mjs
+++ b/packages/node-sdk/scripts/build-dts.mjs
@@ -1,12 +1,16 @@
 import { spawn } from 'node:child_process';
 import { existsSync } from 'node:fs';
 import { mkdir, readdir, readFile, rm, writeFile } from 'node:fs/promises';
+import { createRequire } from 'node:module';
 import path from 'node:path';
 
+const require = createRequire(import.meta.url);
 const packageRoot = path.resolve(import.meta.dirname, '..');
 const tempDir = path.join(packageRoot, '.tmp-api-extractor');
 const dtsRoot = path.join(tempDir, 'dts');
 const providerClientShimPath = path.join(dtsRoot, 'provider-clients.d.ts');
+const tscBinPath = packageBinPath('typescript', 'bin/tsc');
+const apiExtractorBinPath = packageBinPath('@microsoft/api-extractor', 'bin/api-extractor');
 
 const packageDirs = new Set(['agent-core', 'kaos', 'kosong', 'node-sdk', 'oauth']);
 const workspacePackages = new Map([
@@ -18,19 +22,21 @@ const workspacePackages = new Map([
 
 try {
   await rm(tempDir, { recursive: true, force: true });
-  await run('tsc', ['-p', 'tsconfig.dts.json']);
+  await run('tsc', tscBinPath, ['-p', 'tsconfig.dts.json']);
   await writeProviderClientShim();
   await rewriteWorkspaceSpecifiers();
-  await run('api-extractor', ['run', '--local']);
+  await run('api-extractor', apiExtractorBinPath, ['run', '--local']);
 } finally {
   await rm(tempDir, { recursive: true, force: true });
 }
 
-function run(command, args) {
-  const executable = process.platform === 'win32' ? `${command}.cmd` : command;
+function packageBinPath(packageName, binPath) {
+  return path.join(path.dirname(require.resolve(`${packageName}/package.json`)), binPath);
+}
 
+function run(command, binPath, args) {
   return new Promise((resolve, reject) => {
-    const child = spawn(executable, args, {
+    const child = spawn(process.execPath, [binPath, ...args], {
       cwd: packageRoot,
       stdio: 'inherit',
     });


### PR DESCRIPTION
## Related Issue

Resolve #549

## Problem

Windows builds fail when Node.js v24 tries to spawn package command shims such as `tsc.cmd` directly. Adding `shell: true` avoids that immediate error, but it also puts argument handling back through a shell.

## What changed

Launch the package binary entrypoints with the current Node executable instead of spawning platform-specific command shims. This fixes the node-sdk declaration build path and applies the same safer pattern to the Kimi Code dev launcher for `tsx`.

## Verification

- `pnpm -C packages/node-sdk run build:dts`
- `pnpm --filter @moonshot-ai/kimi-code-sdk run build`
- `pnpm -C apps/kimi-code run dev -- --help`
- `pnpm run lint`
- `pnpm run typecheck`
- `pnpm --filter @moonshot-ai/kimi-code test`

`pnpm test` does not start in this local checkout because ignored legacy package directories under `packages/kimi-*` create duplicate Vitest project names; clean CI should not have those directories.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [ ] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.
