### PR TITLE
fix: keep login fallback prompt visible

### DIFF
--- a/.changeset/login-browser-fallback.md
+++ b/.changeset/login-browser-fallback.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Fix device login to keep the URL and code visible when the browser cannot be opened.

--- a/apps/kimi-code/src/cli/sub/login-flow.ts
+++ b/apps/kimi-code/src/cli/sub/login-flow.ts
@@ -17,18 +17,17 @@ export async function runLoginFlow(): Promise<never> {
     uiMode: 'cli',
   });
   const controller = new AbortController();
-  process.once('SIGINT', () => controller.abort());
+  process.once('SIGINT', () => {
+    controller.abort();
+  });
   try {
     const result = await harness.auth.login(undefined, {
       signal: controller.signal,
       onDeviceCode: (data) => {
         const url = data.verificationUriComplete || data.verificationUri;
-        // Best-effort: try to open the user's default browser at the
-        // pre-baked URL (which already embeds the user code). Print the
-        // URL + code as a fallback for headless boxes / when openUrl
-        // silently fails (it `execFile`s `open`/`xdg-open`/`cmd start`
-        // with no error handling — see `utils/open-url.ts`).
-        openUrl(url);
+        // Print the manual fallback before attempting to open the user's
+        // browser so headless/browser-opener failures never hide the URL
+        // and code needed to complete login.
         process.stderr.write(
           [
             '',
@@ -43,15 +42,20 @@ export async function runLoginFlow(): Promise<never> {
             .filter((line): line is string => line !== undefined)
             .join('\n'),
         );
+        try {
+          openUrl(url);
+        } catch {
+          // Best effort only: the manual fallback has already been printed.
+        }
       },
     });
     process.stderr.write(`Logged in to ${result.providerName}.\n`);
     process.exit(0);
-  } catch (err) {
+  } catch (error) {
     if (controller.signal.aborted) {
       process.stderr.write('Login cancelled.\n');
     } else {
-      const message = err instanceof Error ? err.message : String(err);
+      const message = error instanceof Error ? error.message : String(error);
       process.stderr.write(`Login failed: ${message}\n`);
     }
     process.exit(1);

--- a/apps/kimi-code/test/cli/login.test.ts
+++ b/apps/kimi-code/test/cli/login.test.ts
@@ -122,6 +122,46 @@ describe('kimi login', () => {
     expect(exitSpy).toHaveBeenCalledWith(0);
   });
 
+  it('still prints device code prompt when opening the browser fails', async () => {
+    vi.mocked(openUrl).mockImplementation(() => {
+      throw new Error('no browser');
+    });
+    mockLogin.mockImplementation(
+      async (
+        _providerName: string | undefined,
+        options: {
+          onDeviceCode?: (data: {
+            userCode: string;
+            verificationUri: string;
+            verificationUriComplete: string;
+            expiresIn: number | null;
+          }) => void | Promise<void>;
+        },
+      ) => {
+        await options.onDeviceCode?.({
+          userCode: 'ABCD-EFGH',
+          verificationUri: 'https://example.com/v',
+          verificationUriComplete: 'https://example.com/v?code=ABCD-EFGH',
+          expiresIn: 600,
+        });
+        return { providerName: 'kimi-code', ok: true };
+      },
+    );
+
+    const program = new Command('kimi').exitOverride();
+    registerLoginCommand(program);
+
+    await expect(program.parseAsync(['node', 'kimi', 'login'])).rejects.toThrow(ExitCalled);
+
+    const writtenChunks = stderrSpy.mock.calls.map((call: unknown[]) => String(call[0]));
+    expect(writtenChunks.some((chunk: string) => chunk.includes('ABCD-EFGH'))).toBe(true);
+    expect(writtenChunks.some((chunk: string) => chunk.includes('https://example.com/v'))).toBe(
+      true,
+    );
+    expect(openUrl).toHaveBeenCalledWith('https://example.com/v?code=ABCD-EFGH');
+    expect(exitSpy).toHaveBeenCalledWith(0);
+  });
+
   it('exits 1 when auth.login throws', async () => {
     mockLogin.mockRejectedValue(new Error('boom'));
 


### PR DESCRIPTION
## Related Issue

No linked issue.

## Problem

`kimi login` could fail to print the manual device-login URL and user code when opening the browser throws in a headless or no-GUI environment.

## What changed

- Print the device-login URL and user code before attempting to open the browser.
- Treat browser-opening errors as best-effort failures so the login flow can continue polling.
- Add a regression test for browser-open failures and a patch changeset for the CLI.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.

## Test Plan

- [x] `pnpm --filter @moonshot-ai/kimi-code exec vitest run test/cli/login.test.ts`
- [x] `pnpm --filter @moonshot-ai/kimi-code run typecheck`
- [x] `pnpm exec oxlint --type-aware --quiet apps/kimi-code/src/cli/sub/login-flow.ts apps/kimi-code/test/cli/login.test.ts`
- [x] `git diff --check -- apps/kimi-code/src/cli/sub/login-flow.ts apps/kimi-code/test/cli/login.test.ts .changeset/login-browser-fallback.md`
- [x] `pnpm test`