### PR TITLE
feat(tui): add experimental ultra swarm mode

### DIFF
--- a/.changeset/ultra-swarm-mode.md
+++ b/.changeset/ultra-swarm-mode.md
@@ -1,0 +1,7 @@
+---
+"@moonshot-ai/agent-core": minor
+"@moonshot-ai/kimi-code-sdk": minor
+"@moonshot-ai/kimi-code": minor
+---
+
+Add experimental Ultra swarm commands with advisor-guided routing, bounded multi-agent coordination, and a live swarm map.

--- a/apps/kimi-code/src/tui/commands/dispatch.ts
+++ b/apps/kimi-code/src/tui/commands/dispatch.ts
@@ -42,7 +42,7 @@ import { handleProviderCommand } from './provider';
 import { handleFeedbackCommand, showMcpServers, showStatusReport, showUsage } from './info';
 import { handlePluginsCommand } from './plugins';
 import { handleReloadCommand, handleReloadTuiCommand } from './reload';
-import { handleSwarmCommand } from './swarm';
+import { handleSwarmCommand, handleUltraModeCommand } from './swarm';
 import {
   handleExportDebugZipCommand,
   handleExportMdCommand,
@@ -74,7 +74,7 @@ export {
   showPermissionPicker,
   showSettingsSelector,
 } from './config';
-export { handleSwarmCommand } from './swarm';
+export { handleSwarmCommand, handleUltraModeCommand } from './swarm';
 export {
   handleFeedbackCommand,
   showMcpServers,
@@ -304,6 +304,9 @@ async function handleBuiltInSlashCommand(
       return;
     case 'swarm':
       await handleSwarmCommand(host, args);
+      return;
+    case 'ultramode':
+      await handleUltraModeCommand(host, args);
       return;
     case 'compact':
       await handleCompactCommand(host, args);

--- a/apps/kimi-code/src/tui/commands/index.ts
+++ b/apps/kimi-code/src/tui/commands/index.ts
@@ -23,7 +23,7 @@ export {
   showPermissionPicker,
   showSettingsSelector,
 } from './config';
-export { handleSwarmCommand } from './swarm';
+export { handleSwarmCommand, handleUltraModeCommand } from './swarm';
 export {
   handleFeedbackCommand,
   showMcpServers,
@@ -33,7 +33,7 @@ export {
 export { handlePluginsCommand } from './plugins';
 export { handleReloadCommand, handleReloadTuiCommand } from './reload';
 export { handleGoalCommand, parseGoalCommand } from './goal';
-export { goalArgumentCompletions } from './registry';
+export { goalArgumentCompletions, ultraModeArgumentCompletions } from './registry';
 export {
   handleForkCommand,
   handleInitCommand,

--- a/apps/kimi-code/src/tui/commands/registry.ts
+++ b/apps/kimi-code/src/tui/commands/registry.ts
@@ -1,6 +1,7 @@
 import type { AutocompleteItem } from '@earendil-works/pi-tui';
 
 import { completeLeadingArg, type ArgCompletionSpec } from './complete-args';
+import { isExperimentalFlagEnabled } from './experimental-flags';
 import type { KimiSlashCommand, SlashCommandAvailability } from './types';
 
 /** Subcommands offered when autocompleting `/goal <…>`. */
@@ -20,6 +21,12 @@ const GOAL_NEXT_ARG_COMPLETIONS: readonly ArgCompletionSpec[] = [
 const SWARM_ARG_COMPLETIONS: readonly ArgCompletionSpec[] = [
   { value: 'on', description: 'Turn swarm mode on' },
   { value: 'off', description: 'Turn swarm mode off' },
+  { value: 'ultra', description: 'Run or toggle Ultra swarm mode' },
+];
+
+const ULTRA_MODE_ARG_COMPLETIONS: readonly ArgCompletionSpec[] = [
+  { value: 'on', description: 'Turn Ultra swarm mode on' },
+  { value: 'off', description: 'Turn swarm mode off' },
 ];
 
 /** Argument autocompletion for the `/goal` command (subcommands). */
@@ -38,7 +45,15 @@ export function goalArgumentCompletions(argumentPrefix: string): AutocompleteIte
 
 /** Argument autocompletion for the `/swarm` command (subcommands). */
 export function swarmArgumentCompletions(argumentPrefix: string): AutocompleteItem[] | null {
-  return completeLeadingArg(SWARM_ARG_COMPLETIONS, argumentPrefix);
+  const completions = isExperimentalFlagEnabled('ultra_swarm')
+    ? SWARM_ARG_COMPLETIONS
+    : SWARM_ARG_COMPLETIONS.filter((item) => item.value !== 'ultra');
+  return completeLeadingArg(completions, argumentPrefix);
+}
+
+/** Argument autocompletion for the `/ultramode` command (subcommands). */
+export function ultraModeArgumentCompletions(argumentPrefix: string): AutocompleteItem[] | null {
+  return completeLeadingArg(ULTRA_MODE_ARG_COMPLETIONS, argumentPrefix);
 }
 
 export const BUILTIN_SLASH_COMMANDS = [
@@ -84,6 +99,15 @@ export const BUILTIN_SLASH_COMMANDS = [
     priority: 100,
     completeArgs: swarmArgumentCompletions,
     availability: 'idle-only',
+  },
+  {
+    name: 'ultramode',
+    aliases: ['ultra'],
+    description: 'Run or toggle Ultra swarm orchestration',
+    priority: 100,
+    completeArgs: ultraModeArgumentCompletions,
+    availability: 'idle-only',
+    experimentalFlag: 'ultra_swarm',
   },
   {
     name: 'model',

--- a/apps/kimi-code/src/tui/commands/swarm.ts
+++ b/apps/kimi-code/src/tui/commands/swarm.ts
@@ -11,22 +11,51 @@ import {
 import { LLM_NOT_SET_MESSAGE, NO_ACTIVE_SESSION_MESSAGE } from '../constant/kimi-tui';
 import { formatErrorMessage } from '../utils/event-payload';
 import type { SlashCommandHost } from './dispatch';
+import { isExperimentalFlagEnabled } from './experimental-flags';
+
+type SwarmModeKind = 'standard' | 'ultra';
+type SwarmModeEntry = 'manual' | 'task' | 'ultra' | 'ultra_task';
+
+const ULTRA_SWARM_FLAG = 'ultra_swarm';
+const ULTRA_SWARM_DISABLED_MESSAGE =
+  'Ultra swarm is experimental. Enable it in /experiments or set KIMI_CODE_EXPERIMENTAL_ULTRA_SWARM=1.';
 
 export async function handleSwarmCommand(host: SlashCommandHost, args: string): Promise<void> {
+  const prompt = args.trim();
+  const ultraArgs = parseSwarmUltraArgs(prompt);
+  if (ultraArgs !== undefined) {
+    if (!isUltraSwarmEnabled(host)) return;
+    await handleSwarmModeRequest(host, ultraArgs, 'ultra', commandText('/swarm', prompt));
+    return;
+  }
+  await handleSwarmModeRequest(host, prompt, 'standard', commandText('/swarm', prompt));
+}
+
+export async function handleUltraModeCommand(host: SlashCommandHost, args: string): Promise<void> {
+  if (!isUltraSwarmEnabled(host)) return;
+  const prompt = args.trim();
+  await handleSwarmModeRequest(host, prompt, 'ultra', commandText('/ultramode', prompt));
+}
+
+async function handleSwarmModeRequest(
+  host: SlashCommandHost,
+  prompt: string,
+  mode: SwarmModeKind,
+  inputText: string,
+): Promise<void> {
   if (host.session === undefined) {
     host.showError(NO_ACTIVE_SESSION_MESSAGE);
     return;
   }
 
-  const prompt = args.trim();
-  const mode = swarmModeSubcommand(prompt);
-  if (mode !== undefined) {
-    await applySwarmMode(host, mode, `/swarm ${prompt}`);
+  const enabled = swarmModeSubcommand(prompt);
+  if (enabled !== undefined) {
+    await applySwarmMode(host, enabled, inputText, mode);
     return;
   }
 
   if (prompt.length === 0) {
-    await applySwarmMode(host, !host.state.appState.swarmMode, '/swarm');
+    await applySwarmMode(host, toggledSwarmEnabled(host, mode), inputText, mode);
     return;
   }
 
@@ -36,13 +65,13 @@ export async function handleSwarmCommand(host: SlashCommandHost, args: string): 
   }
 
   if (host.state.appState.permissionMode === 'manual') {
-    showSwarmStartPermissionPrompt(host, `/swarm ${prompt}`, 'Swarm task not started.', (choice) =>
-      startSwarmWithPermission(host, prompt, choice),
+    showSwarmStartPermissionPrompt(host, inputText, 'Swarm task not started.', (choice) =>
+      startSwarmWithPermission(host, prompt, choice, mode),
     );
     return;
   }
 
-  await startSwarmTask(host, prompt);
+  await startSwarmTask(host, prompt, mode);
 }
 
 function showSwarmStartPermissionPrompt(
@@ -70,11 +99,12 @@ async function startSwarmWithPermission(
   host: SlashCommandHost,
   prompt: string,
   choice: SwarmStartPermissionChoice,
+  mode: SwarmModeKind,
 ): Promise<void> {
   if (choice === 'auto') {
     if (!(await setPermissionForSwarm(host, choice))) return;
   }
-  await startSwarmTask(host, prompt);
+  await startSwarmTask(host, prompt, mode);
 }
 
 async function setPermissionForSwarm(host: SlashCommandHost, mode: PermissionMode): Promise<boolean> {
@@ -88,11 +118,15 @@ async function setPermissionForSwarm(host: SlashCommandHost, mode: PermissionMod
   return true;
 }
 
-async function startSwarmTask(host: SlashCommandHost, prompt: string): Promise<void> {
-  if (!host.state.appState.swarmMode && !(await setSwarmMode(host, true, 'task'))) {
+async function startSwarmTask(
+  host: SlashCommandHost,
+  prompt: string,
+  mode: SwarmModeKind,
+): Promise<void> {
+  if (!(await ensureSwarmMode(host, mode, 'task'))) {
     return;
   }
-  renderSwarmModeMarker(host, 'active');
+  renderSwarmModeMarker(host, markerForMode(mode));
   host.sendNormalUserInput(prompt);
 }
 
@@ -100,8 +134,14 @@ async function applySwarmMode(
   host: SlashCommandHost,
   enabled: boolean,
   commandText: string,
+  mode: SwarmModeKind,
 ): Promise<void> {
   if (enabled && host.state.appState.swarmMode) {
+    if (mode === 'ultra' && !isUltraSwarmEntry(host.state.swarmModeEntry)) {
+      if (!(await ensureSwarmMode(host, mode, 'manual'))) return;
+      renderSwarmModeMarker(host, markerForMode(mode));
+      return;
+    }
     host.showStatus('Swarm mode is already on.');
     return;
   }
@@ -109,22 +149,32 @@ async function applySwarmMode(
     host.showStatus('Swarm mode is already off.');
     return;
   }
+  if (!enabled && mode === 'ultra' && !isUltraSwarmEntry(host.state.swarmModeEntry)) {
+    host.showStatus('Ultra swarm mode is already off.');
+    return;
+  }
   if (enabled && host.state.appState.permissionMode === 'manual') {
     showSwarmStartPermissionPrompt(host, commandText, 'Swarm mode not enabled.', async (choice) => {
       if (choice === 'auto' && !(await setPermissionForSwarm(host, choice))) return;
-      if (!(await setSwarmMode(host, true, 'manual'))) return;
-      renderSwarmModeMarker(host, 'active');
+      if (!(await ensureSwarmMode(host, mode, 'manual'))) return;
+      renderSwarmModeMarker(host, markerForMode(mode));
     });
     return;
   }
-  if (!(await setSwarmMode(host, enabled, 'manual'))) return;
-  renderSwarmModeMarker(host, enabled ? 'active' : 'inactive');
+  if (enabled) {
+    if (!(await ensureSwarmMode(host, mode, 'manual'))) return;
+    renderSwarmModeMarker(host, markerForMode(mode));
+    return;
+  }
+  if (!(await setSwarmMode(host, false, 'manual'))) return;
+  renderSwarmModeMarker(host, 'inactive');
 }
 
 async function setSwarmMode(
   host: SlashCommandHost,
   enabled: boolean,
-  trigger: 'manual' | 'task',
+  trigger: SwarmModeEntry,
+  options: { readonly restoreEntry?: 'manual' | 'ultra' } = {},
 ): Promise<boolean> {
   try {
     await host.requireSession().setSwarmMode(enabled, trigger);
@@ -136,7 +186,28 @@ async function setSwarmMode(
   }
   host.setAppState({ swarmMode: enabled });
   host.state.swarmModeEntry = enabled ? trigger : undefined;
+  host.state.swarmModeRestoreEntry = enabled ? options.restoreEntry : undefined;
   return true;
+}
+
+async function ensureSwarmMode(
+  host: SlashCommandHost,
+  mode: SwarmModeKind,
+  triggerKind: 'manual' | 'task',
+): Promise<boolean> {
+  const trigger = triggerForMode(mode, triggerKind);
+  if (!host.state.appState.swarmMode) {
+    return setSwarmMode(host, true, trigger);
+  }
+  if (mode !== 'ultra' || isUltraSwarmEntry(host.state.swarmModeEntry)) {
+    return true;
+  }
+  const restoreEntry =
+    triggerKind === 'task' && host.state.swarmModeEntry === 'manual'
+      ? host.state.swarmModeEntry
+      : undefined;
+  if (!(await setSwarmMode(host, false, 'manual'))) return false;
+  return setSwarmMode(host, true, trigger, { restoreEntry });
 }
 
 function swarmModeSubcommand(input: string): boolean | undefined {
@@ -144,6 +215,42 @@ function swarmModeSubcommand(input: string): boolean | undefined {
   if (command === 'on') return true;
   if (command === 'off') return false;
   return undefined;
+}
+
+function parseSwarmUltraArgs(input: string): string | undefined {
+  if (input.toLowerCase() === 'ultra') return '';
+  const match = /^ultra\s+([\s\S]*)$/i.exec(input);
+  return match?.[1]?.trim();
+}
+
+function isUltraSwarmEnabled(host: SlashCommandHost): boolean {
+  if (isExperimentalFlagEnabled(ULTRA_SWARM_FLAG)) return true;
+  host.showError(ULTRA_SWARM_DISABLED_MESSAGE);
+  return false;
+}
+
+function toggledSwarmEnabled(host: SlashCommandHost, mode: SwarmModeKind): boolean {
+  if (mode === 'ultra') {
+    return !(host.state.appState.swarmMode && isUltraSwarmEntry(host.state.swarmModeEntry));
+  }
+  return !host.state.appState.swarmMode;
+}
+
+function triggerForMode(mode: SwarmModeKind, triggerKind: 'manual' | 'task'): SwarmModeEntry {
+  if (mode === 'ultra') return triggerKind === 'manual' ? 'ultra' : 'ultra_task';
+  return triggerKind;
+}
+
+function isUltraSwarmEntry(entry: unknown): boolean {
+  return entry === 'ultra' || entry === 'ultra_task';
+}
+
+function markerForMode(mode: SwarmModeKind): SwarmModeMarkerState {
+  return mode === 'ultra' ? 'ultra-active' : 'active';
+}
+
+function commandText(command: '/swarm' | '/ultramode', args: string): string {
+  return args.length === 0 ? command : `${command} ${args}`;
 }
 
 function renderSwarmModeMarker(host: SlashCommandHost, state: SwarmModeMarkerState): void {

--- a/apps/kimi-code/src/tui/components/messages/agent-swarm-progress.ts
+++ b/apps/kimi-code/src/tui/components/messages/agent-swarm-progress.ts
@@ -145,6 +145,22 @@ export interface AgentSwarmResultSummary {
   readonly parsed: boolean;
 }
 
+export type AgentSwarmProgressPhase = AgentSwarmPhase;
+
+export interface AgentSwarmProgressMemberSnapshot {
+  readonly id: string;
+  readonly agentId?: string;
+  readonly phase: AgentSwarmProgressPhase;
+  readonly itemText: string;
+  readonly latestModelText: string;
+}
+
+export interface AgentSwarmProgressMapSnapshot {
+  readonly description: string;
+  readonly toolCallActive: boolean;
+  readonly members: readonly AgentSwarmProgressMemberSnapshot[];
+}
+
 interface AgentSwarmSummary {
   readonly active: number;
   readonly completed: number;
@@ -235,6 +251,20 @@ export class AgentSwarmProgressComponent implements Component {
 
   isRequestStreaming(): boolean {
     return !this.inputComplete;
+  }
+
+  getMapSnapshot(): AgentSwarmProgressMapSnapshot {
+    return {
+      description: this.description,
+      toolCallActive: this.toolCallActive,
+      members: this.members.map((member) => ({
+        id: member.id,
+        agentId: member.agentId,
+        phase: member.phase,
+        itemText: member.itemText,
+        latestModelText: member.latestModelText,
+      })),
+    };
   }
 
   updateArgs(

--- a/apps/kimi-code/src/tui/components/messages/swarm-markers.ts
+++ b/apps/kimi-code/src/tui/components/messages/swarm-markers.ts
@@ -3,7 +3,7 @@ import type { Component } from '@earendil-works/pi-tui';
 import { STATUS_BULLET } from '#/tui/constant/symbols';
 import { currentTheme } from '#/tui/theme';
 
-export type SwarmModeMarkerState = 'active' | 'inactive' | 'ended';
+export type SwarmModeMarkerState = 'active' | 'inactive' | 'ended' | 'ultra-active';
 
 export class SwarmModeMarkerComponent implements Component {
   constructor(private readonly state: SwarmModeMarkerState) {}
@@ -22,6 +22,8 @@ function swarmMarkerLabel(state: SwarmModeMarkerState): string {
   switch (state) {
     case 'active':
       return 'Swarm activated';
+    case 'ultra-active':
+      return 'Ultra swarm activated';
     case 'inactive':
       return 'Swarm deactivated';
     case 'ended':

--- a/apps/kimi-code/src/tui/components/panes/ultra-swarm-map.ts
+++ b/apps/kimi-code/src/tui/components/panes/ultra-swarm-map.ts
@@ -1,0 +1,223 @@
+import { truncateToWidth, visibleWidth, type Component } from '@earendil-works/pi-tui';
+
+import type {
+  AgentSwarmProgressMapSnapshot,
+  AgentSwarmProgressMemberSnapshot,
+  AgentSwarmProgressPhase,
+} from '../messages/agent-swarm-progress';
+import { currentTheme, type ColorToken } from '#/tui/theme';
+
+const ELLIPSIS = '...';
+const TITLE = 'Ultra Swarm Map';
+const PHASE_LABEL_WIDTH = 'cancelled'.length;
+const MAX_DETAILED_MEMBERS = 10;
+const PULSE_INTERVAL_MS = 450;
+const MEMBER_STRIP_GAP_WIDTH = 2;
+
+export interface UltraSwarmMapOptions {
+  readonly getWaves: () => readonly AgentSwarmProgressMapSnapshot[];
+}
+
+export class UltraSwarmMapComponent implements Component {
+  private readonly getWaves: () => readonly AgentSwarmProgressMapSnapshot[];
+
+  constructor(options: UltraSwarmMapOptions) {
+    this.getWaves = options.getWaves;
+  }
+
+  invalidate(): void {}
+
+  render(width: number): string[] {
+    const panelWidth = Math.max(1, width);
+    const waves = this.getWaves().filter((wave) =>
+      wave.toolCallActive || wave.members.length > 0
+    );
+    if (waves.length === 0) return [];
+
+    const totalMembers = waves.reduce((sum, wave) => sum + wave.members.length, 0);
+    const activeMembers = waves.reduce(
+      (sum, wave) => sum + wave.members.filter((member) => member.phase === 'running').length,
+      0,
+    );
+    const pulseOn = Math.floor(Date.now() / PULSE_INTERVAL_MS) % 2 === 0;
+    const lines = [
+      '',
+      this.renderHeader(panelWidth, waves.length, totalMembers, activeMembers),
+      this.renderLegend(panelWidth, pulseOn),
+    ];
+
+    waves.forEach((wave, index) => {
+      lines.push(this.renderWaveHeader(panelWidth, wave, index));
+      lines.push(...this.renderMemberStrip(panelWidth, wave.members, pulseOn));
+      lines.push(...this.renderDetailedMembers(panelWidth, wave.members, pulseOn));
+    });
+
+    return lines.map((line) => truncateToWidth(line, panelWidth, ELLIPSIS));
+  }
+
+  private renderHeader(
+    width: number,
+    waveCount: number,
+    memberCount: number,
+    activeCount: number,
+  ): string {
+    const meta = `${waveCount} group${waveCount === 1 ? '' : 's'} / ${memberCount} agents / ${activeCount} active`;
+    const prefix = `- ${currentTheme.boldFg('primary', TITLE)} ${currentTheme.fg('textDim', meta)} `;
+    return withRule(prefix, width);
+  }
+
+  private renderLegend(width: number, pulseOn: boolean): string {
+    const entries = [
+      `${phaseMarker('running', pulseOn)} ${currentTheme.fg('success', 'active')}`,
+      `${phaseMarker('queued', pulseOn)} ${currentTheme.fg('textDim', 'queued')}`,
+      `${phaseMarker('suspended', pulseOn)} ${currentTheme.fg('warning', 'limited')}`,
+      `${phaseMarker('completed', pulseOn)} ${currentTheme.fg('success', 'done')}`,
+      `${phaseMarker('failed', pulseOn)} ${currentTheme.fg('error', 'failed')}`,
+    ];
+    return truncateToWidth(`  ${entries.join(currentTheme.fg('textMuted', ' | '))}`, width, ELLIPSIS);
+  }
+
+  private renderWaveHeader(
+    width: number,
+    wave: AgentSwarmProgressMapSnapshot,
+    index: number,
+  ): string {
+    const label = cleanText(wave.description) || `Group ${index + 1}`;
+    const active = wave.members.filter((member) => member.phase === 'running').length;
+    const meta = `${active}/${wave.members.length} active`;
+    const prefix = `  ${currentTheme.fg('primary', '-')} ${currentTheme.fg('textStrong', label)} ${currentTheme.fg('textDim', meta)} `;
+    return withRule(prefix, width);
+  }
+
+  private renderMemberStrip(
+    width: number,
+    members: readonly AgentSwarmProgressMemberSnapshot[],
+    pulseOn: boolean,
+  ): string[] {
+    if (members.length === 0) return [];
+
+    const initialPrefix = '    ';
+    const continuationPrefix = '    ';
+    const availableWidth = Math.max(1, width - visibleWidth(initialPrefix));
+    const markersPerLine = Math.max(1, Math.floor((availableWidth + 1) / MEMBER_STRIP_GAP_WIDTH));
+    const lines: string[] = [];
+
+    for (let index = 0; index < members.length; index += markersPerLine) {
+      const chunk = members
+        .slice(index, index + markersPerLine)
+        .map((member) => phaseMarker(member.phase, pulseOn))
+        .join(' ');
+      lines.push(`${index === 0 ? initialPrefix : continuationPrefix}${chunk}`);
+    }
+
+    return lines;
+  }
+
+  private renderDetailedMembers(
+    width: number,
+    members: readonly AgentSwarmProgressMemberSnapshot[],
+    pulseOn: boolean,
+  ): string[] {
+    const visibleMembers =
+      members.length <= MAX_DETAILED_MEMBERS
+        ? members
+        : members
+            .toSorted((a, b) => phasePriority(a.phase) - phasePriority(b.phase) || a.id.localeCompare(b.id))
+            .slice(0, MAX_DETAILED_MEMBERS);
+    const lines = visibleMembers.map((member) => this.renderMemberLine(width, member, pulseOn));
+
+    if (members.length > visibleMembers.length) {
+      const hidden = members.length - visibleMembers.length;
+      lines.push(currentTheme.fg('textDim', truncateToWidth(`    ... ${hidden} more agents`, width, ELLIPSIS)));
+    }
+
+    return lines;
+  }
+
+  private renderMemberLine(
+    width: number,
+    member: AgentSwarmProgressMemberSnapshot,
+    pulseOn: boolean,
+  ): string {
+    const marker = phaseMarker(member.phase, pulseOn);
+    const id = currentTheme.fg('primary', member.id);
+    const phase = currentTheme.fg(phaseColor(member.phase), phaseLabel(member.phase).padEnd(PHASE_LABEL_WIDTH));
+    const itemLabel = cleanText(member.itemText);
+    const modelLabel = cleanText(member.latestModelText);
+    const label =
+      itemLabel.length > 0
+        ? itemLabel
+        : modelLabel.length > 0
+          ? modelLabel
+          : member.agentId ?? 'worker';
+    const prefix = `    ${marker} ${id} ${phase} `;
+    const labelWidth = Math.max(1, width - visibleWidth(prefix));
+    return prefix + currentTheme.fg('text', truncateToWidth(label, labelWidth, ELLIPSIS));
+  }
+}
+
+function withRule(prefix: string, width: number): string {
+  const ruleWidth = Math.max(0, width - visibleWidth(prefix));
+  return truncateToWidth(prefix + currentTheme.fg('border', '-'.repeat(ruleWidth)), width, ELLIPSIS);
+}
+
+function phaseMarker(phase: AgentSwarmProgressPhase, pulseOn: boolean): string {
+  switch (phase) {
+    case 'running':
+      return currentTheme.fg(pulseOn ? 'success' : 'textMuted', '●');
+    case 'completed':
+      return currentTheme.fg('success', '✓');
+    case 'failed':
+      return currentTheme.fg('error', '×');
+    case 'suspended':
+      return currentTheme.fg('warning', '!');
+    case 'cancelled':
+      return currentTheme.fg('warning', '-');
+    case 'pending':
+    case 'queued':
+      return currentTheme.fg('textMuted', '○');
+  }
+}
+
+function phaseLabel(phase: AgentSwarmProgressPhase): string {
+  if (phase === 'pending') return 'queued';
+  return phase;
+}
+
+function phaseColor(phase: AgentSwarmProgressPhase): ColorToken {
+  switch (phase) {
+    case 'running':
+    case 'completed':
+      return 'success';
+    case 'failed':
+      return 'error';
+    case 'suspended':
+    case 'cancelled':
+      return 'warning';
+    case 'pending':
+    case 'queued':
+      return 'textDim';
+  }
+}
+
+function phasePriority(phase: AgentSwarmProgressPhase): number {
+  switch (phase) {
+    case 'running':
+      return 0;
+    case 'suspended':
+      return 1;
+    case 'failed':
+      return 2;
+    case 'pending':
+    case 'queued':
+      return 3;
+    case 'cancelled':
+      return 4;
+    case 'completed':
+      return 5;
+  }
+}
+
+function cleanText(value: string | undefined): string {
+  return (value ?? '').replaceAll(/\s+/g, ' ').trim();
+}

--- a/apps/kimi-code/src/tui/controllers/session-event-handler.ts
+++ b/apps/kimi-code/src/tui/controllers/session-event-handler.ts
@@ -37,6 +37,7 @@ import {
   SwarmModeMarkerComponent,
   type SwarmModeMarkerState,
 } from '../components/messages/swarm-markers';
+import type { AgentSwarmProgressMapSnapshot } from '../components/messages/agent-swarm-progress';
 import {
   OAUTH_LOGIN_REQUIRED_CODE,
   OAUTH_LOGIN_REQUIRED_STARTUP_NOTICE,
@@ -85,6 +86,8 @@ import type {
 } from '../types';
 import type { TUIState } from '../tui-state';
 import { createGoal as startGoalCommand } from '../commands/goal';
+
+type RestorableSwarmModeEntry = 'manual' | 'ultra';
 
 export interface SessionEventHost {
   state: TUIState;
@@ -166,6 +169,10 @@ export class SessionEventHandler {
 
   hasActiveAgentSwarmToolCall(): boolean {
     return this.subAgentEventHandler.hasActiveAgentSwarmToolCall();
+  }
+
+  getAgentSwarmMapSnapshots(): readonly AgentSwarmProgressMapSnapshot[] {
+    return this.subAgentEventHandler.getAgentSwarmMapSnapshots();
   }
 
   syncAgentSwarmActivitySpinner(spinner: MoonLoader | undefined): void {
@@ -553,10 +560,14 @@ export class SessionEventHandler {
   }
 
   private handleStatusUpdate(event: AgentStatusUpdatedEvent): void {
+    const restoreSwarmModeEntry =
+      event.swarmMode === false && isOneShotSwarmEntry(this.host.state.swarmModeEntry)
+        ? this.host.state.swarmModeRestoreEntry
+        : undefined;
     const shouldRenderSwarmEnded =
       event.swarmMode === false &&
       this.host.state.appState.swarmMode &&
-      this.host.state.swarmModeEntry === 'task';
+      isOneShotSwarmEntry(this.host.state.swarmModeEntry);
     const patch: Partial<AppState> = {};
     if (event.contextUsage !== undefined) patch.contextUsage = event.contextUsage;
     if (event.contextTokens !== undefined) patch.contextTokens = event.contextTokens;
@@ -568,12 +579,34 @@ export class SessionEventHandler {
     }
     if (event.model !== undefined) patch.model = event.model;
     if (Object.keys(patch).length > 0) this.host.setAppState(patch);
+    if (event.swarmMode === true) {
+      const entry = swarmModeEntryFromTrigger(event.swarmModeTrigger);
+      if (entry !== undefined) {
+        this.host.state.swarmModeEntry = entry;
+      }
+    }
     if (event.swarmMode === false) {
       this.host.state.swarmModeEntry = undefined;
+      this.host.state.swarmModeRestoreEntry = undefined;
       if (shouldRenderSwarmEnded) {
         this.renderSwarmModeMarker('ended');
       }
+      if (restoreSwarmModeEntry !== undefined) {
+        void this.restoreSwarmMode(restoreSwarmModeEntry);
+      }
     }
+  }
+
+  private async restoreSwarmMode(entry: RestorableSwarmModeEntry): Promise<void> {
+    try {
+      await this.host.requireSession().setSwarmMode(true, entry);
+    } catch (error) {
+      this.host.showError(`Failed to restore swarm mode: ${formatErrorMessage(error)}`);
+      return;
+    }
+    this.host.setAppState({ swarmMode: true });
+    this.host.state.swarmModeEntry = entry;
+    this.renderSwarmModeMarker(entry === 'ultra' ? 'ultra-active' : 'active');
   }
 
   private renderSwarmModeMarker(state: SwarmModeMarkerState): void {
@@ -1057,4 +1090,20 @@ export class SessionEventHandler {
     state.footer.setBackgroundCounts({ bashTasks, agentTasks });
     state.ui.requestRender();
   }
+}
+
+function isOneShotSwarmEntry(entry: unknown): boolean {
+  return entry === 'task' || entry === 'ultra_task';
+}
+
+function swarmModeEntryFromTrigger(trigger: unknown): TUIState['swarmModeEntry'] {
+  if (
+    trigger === 'manual' ||
+    trigger === 'task' ||
+    trigger === 'ultra' ||
+    trigger === 'ultra_task'
+  ) {
+    return trigger;
+  }
+  return undefined;
 }

--- a/apps/kimi-code/src/tui/controllers/subagent-event-handler.ts
+++ b/apps/kimi-code/src/tui/controllers/subagent-event-handler.ts
@@ -6,6 +6,7 @@ import type { Component } from '@earendil-works/pi-tui';
 
 import {
   AgentSwarmProgressComponent,
+  type AgentSwarmProgressMapSnapshot,
   agentSwarmDescriptionFromArgs,
   agentSwarmGridHeightForTerminalRows,
 } from '../components/messages/agent-swarm-progress';
@@ -51,9 +52,14 @@ function renderedRowsAfterChild(
     .reduce((sum, component) => sum + component.render(width).length, 0);
 }
 
+function isUltraSwarmEntry(entry: unknown): boolean {
+  return entry === 'ultra' || entry === 'ultra_task';
+}
+
 export class SubAgentEventHandler {
   readonly subagentInfo: Map<string, SubagentInfo> = new Map();
   private readonly agentSwarmProgress: Map<string, AgentSwarmProgressComponent> = new Map();
+  private readonly ultraMapToolCallIds: Set<string> = new Set();
   backgroundAgentMetadata: Map<string, BackgroundAgentMetadata> = new Map();
 
   constructor(
@@ -149,6 +155,7 @@ export class SubAgentEventHandler {
       progress.dispose();
     }
     this.agentSwarmProgress.clear();
+    this.ultraMapToolCallIds.clear();
     this.host.updateActivityPane();
   }
 
@@ -160,6 +167,14 @@ export class SubAgentEventHandler {
     return Array.from(this.agentSwarmProgress.values()).some((progress) =>
       progress.isToolCallActive()
     );
+  }
+
+  getAgentSwarmMapSnapshots(): readonly AgentSwarmProgressMapSnapshot[] {
+    return Array.from(this.ultraMapToolCallIds)
+      .map((toolCallId) => this.agentSwarmProgress.get(toolCallId))
+      .filter((progress): progress is AgentSwarmProgressComponent => progress !== undefined)
+      .map((progress) => progress.getMapSnapshot())
+      .filter((snapshot) => snapshot.toolCallActive || snapshot.members.length > 0);
   }
 
   syncAgentSwarmActivitySpinner(
@@ -176,6 +191,7 @@ export class SubAgentEventHandler {
     toolCallId: string,
     args: Record<string, unknown>,
   ): void {
+    this.trackUltraMapToolCall(toolCallId);
     const progress = this.ensureAgentSwarmProgress(toolCallId, args);
     progress.markInputComplete();
     this.requestRender();
@@ -186,6 +202,7 @@ export class SubAgentEventHandler {
     args: Record<string, unknown>,
     options: { readonly streamingArguments?: string | undefined },
   ): void {
+    this.trackUltraMapToolCall(toolCallId);
     this.ensureAgentSwarmProgress(toolCallId, args, options);
     this.requestRender();
   }
@@ -214,6 +231,7 @@ export class SubAgentEventHandler {
       progress.markToolCallEnded();
       progress.applyResult(resultData.output);
     }
+    this.ultraMapToolCallIds.delete(toolCallId);
     this.host.updateActivityPane();
     this.requestRender();
   }
@@ -542,6 +560,7 @@ export class SubAgentEventHandler {
     progress: AgentSwarmProgressComponent,
   ): void {
     this.agentSwarmProgress.delete(toolCallId);
+    this.ultraMapToolCallIds.delete(toolCallId);
     progress.dispose();
     const children = this.host.state.transcriptContainer.children;
     const index = children.indexOf(progress);
@@ -567,6 +586,12 @@ export class SubAgentEventHandler {
       width,
     );
     return agentSwarmGridHeightForTerminalRows(terminalRows, rowsAfterSwarm);
+  }
+
+  private trackUltraMapToolCall(toolCallId: string): void {
+    if (isUltraSwarmEntry(this.host.state.swarmModeEntry)) {
+      this.ultraMapToolCallIds.add(toolCallId);
+    }
   }
 
   private markAgentSwarmFailedOrCancelled(

--- a/apps/kimi-code/src/tui/kimi-tui.ts
+++ b/apps/kimi-code/src/tui/kimi-tui.ts
@@ -83,6 +83,7 @@ import { ToolCallComponent } from './components/messages/tool-call';
 import { UserMessageComponent } from './components/messages/user-message';
 import { ActivityPaneComponent, type ActivityPaneMode } from './components/panes/activity-pane';
 import { QueuePaneComponent } from './components/panes/queue-pane';
+import { UltraSwarmMapComponent } from './components/panes/ultra-swarm-map';
 import type { TuiConfig } from './config';
 import {
   LLM_NOT_SET_MESSAGE,
@@ -1056,6 +1057,11 @@ export class KimiTUI {
       sessionTitle: session.summary?.title ?? null,
       goal: goalResult.goal,
     });
+    this.state.swarmModeEntry =
+      status.swarmMode === true
+        ? swarmModeEntryFromTrigger(status.swarmModeTrigger)
+        : undefined;
+    this.state.swarmModeRestoreEntry = undefined;
   }
 
   // Plan mode is set by createSession — do not re-enter it here.
@@ -1081,6 +1087,7 @@ export class KimiTUI {
     this.questionController.cancelAll(reason);
     this.session = undefined;
     this.state.swarmModeEntry = undefined;
+    this.state.swarmModeRestoreEntry = undefined;
     this.harness.setTelemetryContext({ sessionId: null });
     this.setAppState({ goal: null });
     return previous;
@@ -1128,6 +1135,7 @@ export class KimiTUI {
     this.streamingUI.discardPending();
     this.state.queuedMessages = [];
     this.state.swarmModeEntry = undefined;
+    this.state.swarmModeRestoreEntry = undefined;
     this.harness.interactiveAgentId = MAIN_AGENT_ID;
     this.streamingUI.resetToolCallState();
     this.streamingUI.resetToolUi();
@@ -1474,7 +1482,12 @@ export class KimiTUI {
     const effectiveMode = this.resolveActivityPaneMode();
     this.syncTerminalProgress(this.shouldShowTerminalProgress(effectiveMode));
     const placeSpinnerInAgentSwarm = this.shouldPlaceActivitySpinnerInAgentSwarm(effectiveMode);
-    const activityModeKey = `${effectiveMode}:${placeSpinnerInAgentSwarm ? 'swarm' : 'pane'}`;
+    const showUltraSwarmMap = this.shouldShowUltraSwarmMap(effectiveMode);
+    const activityModeKey = [
+      effectiveMode,
+      placeSpinnerInAgentSwarm ? 'swarm' : 'pane',
+      showUltraSwarmMap ? 'ultra-map' : 'plain',
+    ].join(':');
 
     if (
       activityModeKey === this.lastActivityMode &&
@@ -1488,6 +1501,13 @@ export class KimiTUI {
 
     this.lastActivityMode = activityModeKey;
     this.state.activityContainer.clear();
+    if (showUltraSwarmMap) {
+      this.state.activityContainer.addChild(
+        new UltraSwarmMapComponent({
+          getWaves: () => this.sessionEventHandler.getAgentSwarmMapSnapshots(),
+        }),
+      );
+    }
 
     switch (effectiveMode) {
       case 'hidden':
@@ -1651,6 +1671,12 @@ export class KimiTUI {
       this.sessionEventHandler.hasActiveAgentSwarmToolCall() &&
       (effectiveMode === 'waiting' || effectiveMode === 'tool')
     );
+  }
+
+  private shouldShowUltraSwarmMap(effectiveMode: EffectiveActivityPaneMode): boolean {
+    if (!isUltraSwarmEntry(this.state.swarmModeEntry)) return false;
+    if (effectiveMode !== 'waiting' && effectiveMode !== 'tool') return false;
+    return this.sessionEventHandler.getAgentSwarmMapSnapshots().length > 0;
   }
 
   private syncAgentSwarmActivitySpinner(spinner: MoonLoader | undefined): void {
@@ -1913,4 +1939,20 @@ export class KimiTUI {
     this.restoreEditor();
   }
 
+}
+
+function isUltraSwarmEntry(entry: TUIState['swarmModeEntry']): boolean {
+  return entry === 'ultra' || entry === 'ultra_task';
+}
+
+function swarmModeEntryFromTrigger(trigger: unknown): TUIState['swarmModeEntry'] {
+  if (
+    trigger === 'manual' ||
+    trigger === 'task' ||
+    trigger === 'ultra' ||
+    trigger === 'ultra_task'
+  ) {
+    return trigger;
+  }
+  return undefined;
 }

--- a/apps/kimi-code/src/tui/tui-state.ts
+++ b/apps/kimi-code/src/tui/tui-state.ts
@@ -50,7 +50,8 @@ export interface TUIState {
   tasksBrowser: TasksBrowserState | undefined;
   externalEditorRunning: boolean;
   queuedMessages: QueuedMessage[];
-  swarmModeEntry: 'manual' | 'task' | undefined;
+  swarmModeEntry: 'manual' | 'task' | 'ultra' | 'ultra_task' | undefined;
+  swarmModeRestoreEntry: 'manual' | 'ultra' | undefined;
 }
 
 export function createTUIState(options: KimiTUIOptions): TUIState {
@@ -99,5 +100,6 @@ export function createTUIState(options: KimiTUIOptions): TUIState {
     externalEditorRunning: false,
     queuedMessages: [],
     swarmModeEntry: undefined,
+    swarmModeRestoreEntry: undefined,
   };
 }

--- a/apps/kimi-code/test/tui/activity-pane.test.ts
+++ b/apps/kimi-code/test/tui/activity-pane.test.ts
@@ -50,28 +50,50 @@ function makeDriverWithTerminalProgress(): {
   return { driver, state: driver.state, setProgress };
 }
 
-function startSwarmProgress(driver: ActivityDriver, state: TUIState): AgentSwarmProgressComponent {
-  const handler = driver.sessionEventHandler.subAgentEventHandler;
-  handler.handleAgentSwarmToolCallStarted('call_swarm', {
-    description: 'Review changed files',
-  });
-  handler.handleLifecycleEvent({
-    type: 'subagent.spawned',
-    subagentId: 'agent-1',
-    subagentName: 'coder',
-    parentToolCallId: 'call_swarm',
-    description: 'Review changed files #1 (coder)',
-    swarmIndex: 1,
-    runInBackground: false,
-  } as Parameters<typeof handler.handleLifecycleEvent>[0]);
-  handler.handleLifecycleEvent({
-    type: 'subagent.started',
-    subagentId: 'agent-1',
-  } as Parameters<typeof handler.handleLifecycleEvent>[0]);
+interface StartSwarmProgressOptions {
+  readonly toolCallId?: string;
+  readonly description?: string;
+  readonly items?: readonly string[];
+  readonly runningIndexes?: readonly number[];
+}
 
-  const progress = state.transcriptContainer.children.find(
-    (child): child is AgentSwarmProgressComponent => child instanceof AgentSwarmProgressComponent,
-  );
+function startSwarmProgress(
+  driver: ActivityDriver,
+  state: TUIState,
+  options: StartSwarmProgressOptions = {},
+): AgentSwarmProgressComponent {
+  const handler = driver.sessionEventHandler.subAgentEventHandler;
+  const toolCallId = options.toolCallId ?? 'call_swarm';
+  const description = options.description ?? 'Review changed files';
+  const items = options.items ?? ['Review changed files #1 (coder)'];
+  const runningIndexes = new Set(options.runningIndexes ?? [1]);
+
+  handler.handleAgentSwarmToolCallStarted(toolCallId, {
+    description,
+    items,
+  });
+  items.forEach((item, itemIndex) => {
+    const swarmIndex = itemIndex + 1;
+    const subagentId = `agent-${String(swarmIndex)}`;
+    handler.handleLifecycleEvent({
+      type: 'subagent.spawned',
+      subagentId,
+      subagentName: 'coder',
+      parentToolCallId: toolCallId,
+      description: item,
+      swarmIndex,
+      runInBackground: false,
+    } as Parameters<typeof handler.handleLifecycleEvent>[0]);
+    if (!runningIndexes.has(swarmIndex)) return;
+    handler.handleLifecycleEvent({
+      type: 'subagent.started',
+      subagentId,
+    } as Parameters<typeof handler.handleLifecycleEvent>[0]);
+  });
+
+  const progress = state.transcriptContainer.children
+    .toReversed()
+    .find((child): child is AgentSwarmProgressComponent => child instanceof AgentSwarmProgressComponent);
   if (progress === undefined) throw new Error('expected AgentSwarm progress');
   return progress;
 }
@@ -189,6 +211,130 @@ describe('updateActivityPane terminal progress', () => {
       const output = strip(progress.render(80).join('\n'));
       expect(output).toContain('  Working...');
       expect(output).not.toContain('🌑 Working...');
+
+      state.activitySpinner?.instance.stop();
+      driver.sessionEventHandler.clearAgentSwarmProgress();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('shows the live Ultra swarm map for active Ultra AgentSwarm progress', () => {
+    vi.useFakeTimers();
+    try {
+      const { driver, state } = makeDriverWithTerminalProgress();
+      state.swarmModeEntry = 'ultra_task';
+      state.appState.swarmMode = true;
+      startSwarmProgress(driver, state, {
+        description: 'Platoon One: migration planning',
+        items: [
+          'Squad Alpha: dependency analysis',
+          'Squad Bravo: build pipeline review',
+          'Squad Charlie: verification baseline',
+        ],
+        runningIndexes: [1, 3],
+      });
+      state.livePane = { ...state.livePane, mode: 'tool' };
+
+      driver.updateActivityPane();
+
+      const output = strip(state.activityContainer.render(120).join('\n'));
+      expect(output).toContain('Ultra Swarm Map');
+      expect(output).toContain('Platoon One: migration planning');
+      expect(output).toContain('Squad Alpha: dependency analysis');
+      expect(output).toContain('Squad Bravo: build pipeline review');
+      expect(output).toContain('running');
+      expect(output).toContain('queued');
+
+      state.activitySpinner?.instance.stop();
+      driver.sessionEventHandler.clearAgentSwarmProgress();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('does not show the Ultra swarm map for regular swarm progress', () => {
+    vi.useFakeTimers();
+    try {
+      const { driver, state } = makeDriverWithTerminalProgress();
+      state.swarmModeEntry = 'task';
+      state.appState.swarmMode = true;
+      startSwarmProgress(driver, state, {
+        description: 'Regular swarm',
+        items: ['Inspect command handling'],
+      });
+      state.livePane = { ...state.livePane, mode: 'tool' };
+
+      driver.updateActivityPane();
+
+      const output = strip(state.activityContainer.render(120).join('\n'));
+      expect(output).not.toContain('Ultra Swarm Map');
+
+      state.activitySpinner?.instance.stop();
+      driver.sessionEventHandler.clearAgentSwarmProgress();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('scopes the Ultra swarm map to active Ultra AgentSwarm progress', () => {
+    vi.useFakeTimers();
+    try {
+      const { driver, state } = makeDriverWithTerminalProgress();
+      const handler = driver.sessionEventHandler.subAgentEventHandler;
+
+      state.swarmModeEntry = 'task';
+      state.appState.swarmMode = true;
+      startSwarmProgress(driver, state, {
+        toolCallId: 'old_regular_swarm',
+        description: 'Old regular swarm',
+        items: ['Historical regular worker'],
+      });
+      handler.handleAgentSwarmToolResult(
+        'old_regular_swarm',
+        {
+          tool_call_id: 'old_regular_swarm',
+          output: 'Done',
+          is_error: false,
+        },
+        false,
+      );
+
+      state.swarmModeEntry = 'ultra';
+      state.livePane = { ...state.livePane, mode: 'tool' };
+      driver.updateActivityPane();
+
+      let output = strip(state.activityContainer.render(120).join('\n'));
+      expect(output).not.toContain('Ultra Swarm Map');
+      expect(output).not.toContain('Old regular swarm');
+
+      startSwarmProgress(driver, state, {
+        toolCallId: 'current_ultra_swarm',
+        description: 'Current Ultra swarm',
+        items: ['Current Ultra worker'],
+      });
+      driver.updateActivityPane();
+
+      output = strip(state.activityContainer.render(120).join('\n'));
+      expect(output).toContain('Ultra Swarm Map');
+      expect(output).toContain('Current Ultra swarm');
+      expect(output).toContain('Current Ultra worker');
+      expect(output).not.toContain('Old regular swarm');
+
+      handler.handleAgentSwarmToolResult(
+        'current_ultra_swarm',
+        {
+          tool_call_id: 'current_ultra_swarm',
+          output: 'Done',
+          is_error: false,
+        },
+        false,
+      );
+      driver.updateActivityPane();
+
+      output = strip(state.activityContainer.render(120).join('\n'));
+      expect(output).not.toContain('Ultra Swarm Map');
+      expect(output).not.toContain('Current Ultra swarm');
 
       state.activitySpinner?.instance.stop();
       driver.sessionEventHandler.clearAgentSwarmProgress();

--- a/apps/kimi-code/test/tui/commands/registry.test.ts
+++ b/apps/kimi-code/test/tui/commands/registry.test.ts
@@ -5,9 +5,11 @@ import {
   resolveSlashCommandAvailability,
   sortSlashCommands,
   swarmArgumentCompletions,
+  ultraModeArgumentCompletions,
   type KimiSlashCommand,
 } from '#/tui/commands/index';
-import { describe, expect, it } from 'vitest';
+import { setExperimentalFeatures } from '#/tui/commands/experimental-flags';
+import { afterEach, describe, expect, it } from 'vitest';
 
 describe('parseSlashInput', () => {
   it('parses command names and trimmed args', () => {
@@ -28,6 +30,10 @@ describe('parseSlashInput', () => {
 });
 
 describe('built-in slash command registry', () => {
+  afterEach(() => {
+    setExperimentalFeatures([]);
+  });
+
   it('finds built-ins by name or alias', () => {
     expect(findBuiltInSlashCommand('exit')?.name).toBe('exit');
     expect(findBuiltInSlashCommand('quit')?.name).toBe('exit');
@@ -71,6 +77,28 @@ describe('built-in slash command registry', () => {
     expect(values('on')).toBeNull();
     expect(values('off')).toBeNull();
     expect(values('Ship feature X')).toBeNull();
+  });
+
+  it('offers Ultra swarm completions only when the experiment is enabled', () => {
+    expect(swarmArgumentCompletions('u')).toBeNull();
+
+    setExperimentalFeatures([{ id: 'ultra_swarm', enabled: true }]);
+
+    expect(swarmArgumentCompletions('u')).toEqual([
+      { value: 'ultra', label: 'ultra', description: 'Run or toggle Ultra swarm mode' },
+    ]);
+    expect(ultraModeArgumentCompletions('')).toEqual([
+      { value: 'on', label: 'on', description: 'Turn Ultra swarm mode on' },
+      { value: 'off', label: 'off', description: 'Turn swarm mode off' },
+    ]);
+  });
+
+  it('registers ultramode behind the Ultra swarm experiment', () => {
+    const ultramode = findBuiltInSlashCommand('ultramode');
+    expect(ultramode).toBeDefined();
+    expect(findBuiltInSlashCommand('ultra')?.name).toBe('ultramode');
+    expect((ultramode as KimiSlashCommand).experimentalFlag).toBe('ultra_swarm');
+    expect(resolveSlashCommandAvailability(ultramode!, 'Ship feature X')).toBe('idle-only');
   });
 
   it('defaults commands without explicit availability to idle-only', () => {

--- a/apps/kimi-code/test/tui/commands/resolve.test.ts
+++ b/apps/kimi-code/test/tui/commands/resolve.test.ts
@@ -226,6 +226,26 @@ describe('resolveSlashCommandInput', () => {
     });
   });
 
+  it('gates /ultramode behind the Ultra swarm experiment', () => {
+    expect(resolve('/ultramode Ship feature X')).toEqual({
+      kind: 'message',
+      input: '/ultramode Ship feature X',
+    });
+
+    setExperimentalFeatures([{ id: 'ultra_swarm', enabled: true }]);
+
+    expect(resolve('/ultramode Ship feature X')).toMatchObject({
+      kind: 'builtin',
+      name: 'ultramode',
+      args: 'Ship feature X',
+    });
+    expect(resolve('/ultra Ship feature X')).toMatchObject({
+      kind: 'builtin',
+      name: 'ultramode',
+      args: 'Ship feature X',
+    });
+  });
+
 });
 
 describe('goal command resolution', () => {

--- a/apps/kimi-code/test/tui/commands/swarm.test.ts
+++ b/apps/kimi-code/test/tui/commands/swarm.test.ts
@@ -1,6 +1,7 @@
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
-import { handleSwarmCommand } from '#/tui/commands/index';
+import { handleSwarmCommand, handleUltraModeCommand } from '#/tui/commands/index';
+import { setExperimentalFeatures } from '#/tui/commands/experimental-flags';
 import type { SlashCommandHost } from '#/tui/commands/dispatch';
 import { currentTheme } from '#/tui/theme';
 
@@ -22,6 +23,8 @@ function makeHost(
     hasSession?: boolean;
     permissionMode?: 'manual' | 'auto' | 'yolo';
     swarmMode?: boolean;
+    swarmModeEntry?: 'manual' | 'task' | 'ultra' | 'ultra_task';
+    swarmModeRestoreEntry?: 'manual' | 'ultra';
   } = {},
 ) {
   const session = {
@@ -36,6 +39,8 @@ function makeHost(
         permissionMode: overrides.permissionMode ?? 'auto',
         swarmMode: overrides.swarmMode ?? false,
       },
+      swarmModeEntry: overrides.swarmModeEntry,
+      swarmModeRestoreEntry: overrides.swarmModeRestoreEntry,
       theme: currentTheme,
       transcriptContainer: { addChild: vi.fn() },
       ui: { requestRender: vi.fn() },
@@ -74,6 +79,10 @@ function expectSwarmMarker(host: SlashCommandHost, text: string): void {
 }
 
 describe('handleSwarmCommand', () => {
+  afterEach(() => {
+    setExperimentalFeatures([]);
+  });
+
   it('sends the swarm prompt as a normal prompt after enabling swarm mode', async () => {
     const { host, session } = makeHost({ permissionMode: 'auto' });
 
@@ -313,6 +322,94 @@ describe('handleSwarmCommand', () => {
       expect.stringContaining('Failed to enable swarm mode'),
     );
     expect(markerAddChild(host)).not.toHaveBeenCalled();
+    expect(host.sendNormalUserInput).not.toHaveBeenCalled();
+  });
+
+  it('rejects /swarm ultra when the Ultra swarm experiment is disabled', async () => {
+    const { host, session } = makeHost({ permissionMode: 'auto' });
+
+    await handleSwarmCommand(host, 'ultra Ship feature X');
+
+    expect(host.showError).toHaveBeenCalledWith(expect.stringContaining('Ultra swarm is experimental'));
+    expect(session.setSwarmMode).not.toHaveBeenCalled();
+    expect(host.sendNormalUserInput).not.toHaveBeenCalled();
+  });
+
+  it('starts an Ultra swarm task through /swarm ultra', async () => {
+    setExperimentalFeatures([{ id: 'ultra_swarm', enabled: true }]);
+    const { host, session } = makeHost({ permissionMode: 'auto' });
+
+    await handleSwarmCommand(host, 'ultra Ship feature X');
+
+    expect(session.setSwarmMode).toHaveBeenCalledWith(true, 'ultra_task');
+    expect(host.state.swarmModeEntry).toBe('ultra_task');
+    expectSwarmMarker(host, 'Ultra swarm activated');
+    expect(host.sendNormalUserInput).toHaveBeenCalledWith('Ship feature X');
+  });
+
+  it('starts an Ultra swarm task through /ultramode', async () => {
+    setExperimentalFeatures([{ id: 'ultra_swarm', enabled: true }]);
+    const { host, session } = makeHost({ permissionMode: 'auto' });
+
+    await handleUltraModeCommand(host, 'Ship feature X');
+
+    expect(session.setSwarmMode).toHaveBeenCalledWith(true, 'ultra_task');
+    expect(host.state.swarmModeEntry).toBe('ultra_task');
+    expectSwarmMarker(host, 'Ultra swarm activated');
+    expect(host.sendNormalUserInput).toHaveBeenCalledWith('Ship feature X');
+  });
+
+  it('records persistent swarm restoration after a one-shot Ultra task', async () => {
+    setExperimentalFeatures([{ id: 'ultra_swarm', enabled: true }]);
+    const { host, session } = makeHost({
+      permissionMode: 'auto',
+      swarmMode: true,
+      swarmModeEntry: 'manual',
+    });
+
+    await handleUltraModeCommand(host, 'Ship feature X');
+
+    expect(session.setSwarmMode).toHaveBeenNthCalledWith(1, false, 'manual');
+    expect(session.setSwarmMode).toHaveBeenNthCalledWith(2, true, 'ultra_task');
+    expect(host.state.swarmModeEntry).toBe('ultra_task');
+    expect(host.state.swarmModeRestoreEntry).toBe('manual');
+    expectSwarmMarker(host, 'Ultra swarm activated');
+    expect(host.sendNormalUserInput).toHaveBeenCalledWith('Ship feature X');
+  });
+
+  it('switches an active regular swarm session to persistent Ultra swarm mode', async () => {
+    setExperimentalFeatures([{ id: 'ultra_swarm', enabled: true }]);
+    const { host, session } = makeHost({
+      permissionMode: 'auto',
+      swarmMode: true,
+      swarmModeEntry: 'manual',
+    });
+
+    await handleUltraModeCommand(host, 'on');
+
+    expect(session.setSwarmMode).toHaveBeenNthCalledWith(1, false, 'manual');
+    expect(session.setSwarmMode).toHaveBeenNthCalledWith(2, true, 'ultra');
+    expect(host.state.swarmModeEntry).toBe('ultra');
+    expect(host.state.swarmModeRestoreEntry).toBeUndefined();
+    expectSwarmMarker(host, 'Ultra swarm activated');
+    expect(host.sendNormalUserInput).not.toHaveBeenCalled();
+  });
+
+  it('does not disable regular swarm mode when /ultramode off is used while Ultra is already off', async () => {
+    setExperimentalFeatures([{ id: 'ultra_swarm', enabled: true }]);
+    const { host, session } = makeHost({
+      permissionMode: 'auto',
+      swarmMode: true,
+      swarmModeEntry: 'manual',
+    });
+
+    await handleUltraModeCommand(host, 'off');
+
+    expect(session.setSwarmMode).not.toHaveBeenCalled();
+    expect(host.state.appState.swarmMode).toBe(true);
+    expect(host.state.swarmModeEntry).toBe('manual');
+    expect(markerAddChild(host)).not.toHaveBeenCalled();
+    expect(host.showStatus).toHaveBeenCalledWith('Ultra swarm mode is already off.');
     expect(host.sendNormalUserInput).not.toHaveBeenCalled();
   });
 });

--- a/apps/kimi-code/test/tui/kimi-tui-message-flow.test.ts
+++ b/apps/kimi-code/test/tui/kimi-tui-message-flow.test.ts
@@ -29,6 +29,7 @@ import {
 import { KimiTUI, type KimiTUIStartupInput, type TUIState } from '#/tui/kimi-tui';
 import type { StreamingUIController } from '#/tui/controllers/streaming-ui';
 import { handleFeedbackCommand } from '#/tui/commands/info';
+import { setExperimentalFeatures } from '#/tui/commands/experimental-flags';
 import {
   promptFeedbackInput,
   runModelSelector,
@@ -310,6 +311,7 @@ async function makeTempHome(): Promise<string> {
 
 afterEach(async () => {
   resetCapabilitiesCache();
+  setExperimentalFeatures([]);
   for (const dir of tempDirs.splice(0)) {
     await rm(dir, { recursive: true, force: true });
   }
@@ -2088,11 +2090,13 @@ command = "vim"
         agentId: 'main',
         sessionId: 'ses-1',
         swarmMode: true,
+        swarmModeTrigger: 'ultra',
       } as Event,
       vi.fn(),
     );
 
     expect(driver.state.appState.swarmMode).toBe(true);
+    expect(driver.state.swarmModeEntry).toBe('ultra');
     expect(stripSgr(renderTranscript(driver))).not.toContain('Swarm activated');
 
     let transcript = stripSgr(renderTranscript(driver));
@@ -2109,6 +2113,7 @@ command = "vim"
     );
 
     expect(driver.state.appState.swarmMode).toBe(false);
+    expect(driver.state.swarmModeEntry).toBeUndefined();
     transcript = stripSgr(renderTranscript(driver));
     expect(transcript).not.toContain('Swarm deactivated');
     expect(transcript).not.toContain('Swarm ended');
@@ -2116,6 +2121,28 @@ command = "vim"
     expect(countOccurrences(transcript, 'Swarm activated')).toBe(0);
     expect(countOccurrences(transcript, 'Swarm deactivated')).toBe(0);
     expect(countOccurrences(transcript, 'Swarm ended')).toBe(0);
+  });
+
+  it('hydrates Ultra swarm mode entry from session status', async () => {
+    const session = makeSession({
+      getStatus: vi.fn(async () => ({
+        model: 'k2',
+        thinkingLevel: 'off',
+        permission: 'manual',
+        planMode: false,
+        swarmMode: true,
+        swarmModeTrigger: 'ultra',
+        contextTokens: 0,
+        maxContextTokens: 100,
+        contextUsage: 0,
+      })),
+    });
+
+    const { driver } = await makeDriver(session);
+
+    expect(driver.state.appState.swarmMode).toBe(true);
+    expect(driver.state.swarmModeEntry).toBe('ultra');
+    expect(driver.state.swarmModeRestoreEntry).toBeUndefined();
   });
 
   it('renders an ended marker when a one-shot /swarm task exits', async () => {
@@ -2149,6 +2176,78 @@ command = "vim"
     expect(countOccurrences(transcript, 'Swarm activated')).toBe(1);
     expect(countOccurrences(transcript, 'Swarm ended')).toBe(1);
     expect(transcript).not.toContain('Swarm deactivated');
+  });
+
+  it('renders an ended marker when a one-shot /ultramode task exits', async () => {
+    const { driver, session } = await makeDriver(undefined);
+    driver.state.appState.permissionMode = 'auto';
+    setExperimentalFeatures([{ id: 'ultra_swarm', enabled: true }]);
+
+    driver.handleUserInput('/ultramode Ship feature X');
+
+    await vi.waitFor(() => {
+      expect(session.setSwarmMode).toHaveBeenCalledWith(true, 'ultra_task');
+    });
+    await vi.waitFor(() => {
+      expect(countOccurrences(stripSgr(renderTranscript(driver)), 'Ultra swarm activated')).toBe(1);
+    });
+    let transcript = stripSgr(renderTranscript(driver));
+    expect(countOccurrences(transcript, 'Ultra swarm activated')).toBe(1);
+    expect(transcript).not.toContain('Swarm ended');
+
+    driver.sessionEventHandler.handleEvent(
+      {
+        type: 'agent.status.updated',
+        agentId: 'main',
+        sessionId: 'ses-1',
+        swarmMode: false,
+      } as Event,
+      vi.fn(),
+    );
+
+    expect(driver.state.appState.swarmMode).toBe(false);
+    transcript = stripSgr(renderTranscript(driver));
+    expect(countOccurrences(transcript, 'Ultra swarm activated')).toBe(1);
+    expect(countOccurrences(transcript, 'Swarm ended')).toBe(1);
+    expect(transcript).not.toContain('Swarm deactivated');
+  });
+
+  it('restores persistent swarm after a one-shot /ultramode task exits', async () => {
+    const { driver, session } = await makeDriver(undefined);
+    driver.state.appState.permissionMode = 'auto';
+    driver.state.appState.swarmMode = true;
+    driver.state.swarmModeEntry = 'manual';
+    setExperimentalFeatures([{ id: 'ultra_swarm', enabled: true }]);
+
+    driver.handleUserInput('/ultramode Ship feature X');
+
+    await vi.waitFor(() => {
+      expect(session.setSwarmMode).toHaveBeenNthCalledWith(1, false, 'manual');
+      expect(session.setSwarmMode).toHaveBeenNthCalledWith(2, true, 'ultra_task');
+    });
+    expect(driver.state.swarmModeEntry).toBe('ultra_task');
+    expect(driver.state.swarmModeRestoreEntry).toBe('manual');
+
+    driver.sessionEventHandler.handleEvent(
+      {
+        type: 'agent.status.updated',
+        agentId: 'main',
+        sessionId: 'ses-1',
+        swarmMode: false,
+      } as Event,
+      vi.fn(),
+    );
+
+    await vi.waitFor(() => {
+      expect(session.setSwarmMode).toHaveBeenNthCalledWith(3, true, 'manual');
+    });
+    expect(driver.state.appState.swarmMode).toBe(true);
+    expect(driver.state.swarmModeEntry).toBe('manual');
+    expect(driver.state.swarmModeRestoreEntry).toBeUndefined();
+    const transcript = stripSgr(renderTranscript(driver));
+    expect(countOccurrences(transcript, 'Ultra swarm activated')).toBe(1);
+    expect(countOccurrences(transcript, 'Swarm ended')).toBe(1);
+    expect(countOccurrences(transcript, 'Swarm activated')).toBe(1);
   });
 
   it('queues Ctrl-S input instead of steering while /init is running', async () => {

--- a/packages/agent-core/src/agent/index.ts
+++ b/packages/agent-core/src/agent/index.ts
@@ -376,6 +376,9 @@ export class Agent {
       getSwarmMode: () => {
         return this.swarmMode.isActive;
       },
+      getSwarmModeTrigger: () => {
+        return this.swarmMode.trigger;
+      },
       beginCompaction: (payload) => {
         this.fullCompaction.begin({ source: 'manual', instruction: payload.instruction });
       },
@@ -449,6 +452,7 @@ export class Agent {
       contextUsage,
       planMode: this.planMode.isActive,
       swarmMode: this.swarmMode.isActive,
+      swarmModeTrigger: this.swarmMode.trigger,
       permission: this.permission.mode,
       usage,
     });

--- a/packages/agent-core/src/agent/swarm/index.ts
+++ b/packages/agent-core/src/agent/swarm/index.ts
@@ -2,13 +2,16 @@ import type { Agent } from '..';
 
 import SWARM_MODE_ENTER_REMINDER from './enter-reminder.md';
 import SWARM_MODE_EXIT_REMINDER from './exit-reminder.md';
+import ULTRA_SWARM_MODE_ENTER_REMINDER from './ultra-enter-reminder.md';
 
 /**
  * manual = persistent toggle (/swarm on);
  * task = one-shot /swarm prompt;
+ * ultra = persistent Ultra swarm toggle (/ultramode on);
+ * ultra_task = one-shot /ultramode prompt;
  * tool = AgentSwarm entry.
  */
-export type SwarmModeTrigger = 'manual' | 'task' | 'tool';
+export type SwarmModeTrigger = 'manual' | 'task' | 'ultra' | 'ultra_task' | 'tool';
 
 export class SwarmMode {
   protected active: SwarmModeTrigger | null = null;
@@ -20,9 +23,9 @@ export class SwarmMode {
     this.agent.records.logRecord({ type: 'swarm_mode.enter', trigger });
     this.active = trigger;
     if (trigger !== 'tool') {
-      this.agent.context.appendSystemReminder(SWARM_MODE_ENTER_REMINDER, {
+      this.agent.context.appendSystemReminder(enterReminderForTrigger(trigger), {
         kind: 'injection',
-        variant: 'swarm_mode',
+        variant: injectionVariantForTrigger(trigger),
       });
     }
     this.agent.emitStatusUpdated();
@@ -39,7 +42,8 @@ export class SwarmMode {
     this.active = null;
     this.agent.emitStatusUpdated();
     if (trigger === 'tool') return;
-    if (this.agent.context.popMatchedMessage((origin) => origin?.kind === 'injection' && origin.variant === 'swarm_mode')) {
+    const variant = injectionVariantForTrigger(trigger);
+    if (this.agent.context.popMatchedMessage((origin) => origin?.kind === 'injection' && origin.variant === variant)) {
       return;
     }
     if (!this.agent.records.restoring) {
@@ -54,7 +58,23 @@ export class SwarmMode {
     return this.active !== null;
   }
 
-  get shouldAutoExit(): boolean {
-    return this.active === 'task' || this.active === 'tool';
+  get trigger(): SwarmModeTrigger | undefined {
+    return this.active ?? undefined;
   }
+
+  get shouldAutoExit(): boolean {
+    return this.active === 'task' || this.active === 'ultra_task' || this.active === 'tool';
+  }
+}
+
+function enterReminderForTrigger(trigger: SwarmModeTrigger): string {
+  return trigger === 'ultra' || trigger === 'ultra_task'
+    ? ULTRA_SWARM_MODE_ENTER_REMINDER
+    : SWARM_MODE_ENTER_REMINDER;
+}
+
+function injectionVariantForTrigger(
+  trigger: Exclude<SwarmModeTrigger, 'tool'>,
+): 'swarm_mode' | 'ultra_swarm_mode' {
+  return trigger === 'ultra' || trigger === 'ultra_task' ? 'ultra_swarm_mode' : 'swarm_mode';
 }

--- a/packages/agent-core/src/agent/swarm/ultra-enter-reminder.md
+++ b/packages/agent-core/src/agent/swarm/ultra-enter-reminder.md
@@ -1,0 +1,30 @@
+## Ultra Swarm Mode
+
+You are now in Ultra swarm mode. Treat the user's request as an intent that may need an organized, multi-agent control loop rather than a single answer.
+
+## Control Loop
+
+You do not need to use TodoList to record this workflow.
+
+1. Advisor pass: before delegating, briefly assess task difficulty, context pressure, safety risk, verification burden, and the smallest useful organization size.
+2. Choose the organization:
+   - Direct chat: questions or tiny edits.
+   - Single worker: focused implementation with one clear owner.
+   - Squad: up to 6 workers under one coordination window.
+   - Platoon: 3 squads for multi-area work.
+   - Company: 3 platoons for very large migrations or broad audits.
+3. Keep every coordination window bounded to 8 participants: current dual leadership plus at most 3 subordinate units with their two leads. Do not flatten a large organization into one giant meeting.
+4. Leader responsibility: preserve the user's intent, constraints, and final accountability. Do not let raw subagent output flood the main context.
+5. Work responsibility: delegate execution through AgentSwarm whenever parallel workers are useful. Give each worker a distinct scope and a compact reporting format.
+6. Meeting checkpoint: at phase boundaries, reconcile worker summaries, disagreements, risks, and the next plan before continuing.
+7. Snapshot discipline: after meaningful phases, write a compact decision snapshot in your response or working notes: goal, scope, decisions, evidence paths, open risks, verification status, and next action.
+8. Context firewall: summarize worker results before using them. Keep evidence paths and only the necessary excerpts; avoid copying large raw outputs into the leader context.
+9. Verification loop: reserve capacity for tests, lint, typecheck, review, or other task-appropriate proof. Prefer a smaller organization with verification over a larger one without proof.
+
+## AgentSwarm Use
+
+For broad or high-risk work, use AgentSwarm after the Advisor pass. Partition by files, modules, hypotheses, test areas, or review roles. Use `subagent_type="explore"` for read-only discovery, `subagent_type="plan"` for design review, and `subagent_type="coder"` for implementation.
+
+Do not issue several AgentSwarm tool calls in the same model step to represent parallel squads. Kimi serializes conflicting tool calls, so later swarms will appear queued. Prefer one AgentSwarm call containing all parallel workers or squad leads for the current coordination window, then launch the next wave after the meeting checkpoint if more work is needed.
+
+Scale down aggressively when the Advisor pass shows the task is small. Ultra swarm is a governance mode, not permission to spend agents when they do not reduce risk or latency.

--- a/packages/agent-core/src/flags/registry.ts
+++ b/packages/agent-core/src/flags/registry.ts
@@ -20,6 +20,14 @@ export const FLAG_DEFINITIONS = [
     default: true,
     surface: 'core',
   },
+  {
+    id: 'ultra_swarm',
+    title: 'Ultra swarm',
+    description: 'Enable Ultra swarm orchestration with advisor-style routing, hierarchy limits, and snapshot discipline.',
+    env: 'KIMI_CODE_EXPERIMENTAL_ULTRA_SWARM',
+    default: false,
+    surface: 'both',
+  },
 ] as const satisfies readonly FlagDefinitionInput[];
 
 /** Literal union of registered flag ids. */

--- a/packages/agent-core/src/rpc/core-api.ts
+++ b/packages/agent-core/src/rpc/core-api.ts
@@ -314,6 +314,7 @@ export interface AgentAPI {
   enterSwarm: (payload: EnterSwarmPayload) => void;
   exitSwarm: (payload: EmptyPayload) => void;
   getSwarmMode: (payload: EmptyPayload) => boolean;
+  getSwarmModeTrigger: (payload: EmptyPayload) => SwarmModeTrigger | undefined;
   beginCompaction: (payload: BeginCompactionPayload) => void;
   cancelCompaction: (payload: EmptyPayload) => void;
   registerTool: (payload: RegisterToolPayload) => void;

--- a/packages/agent-core/src/rpc/core-impl.ts
+++ b/packages/agent-core/src/rpc/core-impl.ts
@@ -537,6 +537,10 @@ export class KimiCore implements PromisableMethods<CoreAPI> {
     return this.sessionApi(sessionId).getSwarmMode(payload);
   }
 
+  getSwarmModeTrigger({ sessionId, ...payload }: SessionAgentPayload<EmptyPayload>) {
+    return this.sessionApi(sessionId).getSwarmModeTrigger(payload);
+  }
+
   beginCompaction({ sessionId, ...payload }: SessionAgentPayload<BeginCompactionPayload>) {
     return this.sessionApi(sessionId).beginCompaction(payload);
   }
@@ -955,6 +959,7 @@ async function resumeSessionResult(
     const permission = await api.getPermission({ agentId });
     const plan = await api.getPlan({ agentId });
     const swarmMode = await api.getSwarmMode({ agentId });
+    const swarmModeTrigger = await api.getSwarmModeTrigger({ agentId });
     const usage = await api.getUsage({ agentId });
     agents[agentId] = {
       type: agent.type,
@@ -964,6 +969,7 @@ async function resumeSessionResult(
       permission,
       plan,
       swarmMode,
+      swarmModeTrigger,
       usage,
       tools: await api.getTools({ agentId }),
       toolStore: agent.tools.storeData(),

--- a/packages/agent-core/src/rpc/events.ts
+++ b/packages/agent-core/src/rpc/events.ts
@@ -4,6 +4,7 @@ import type { GoalChange, GoalSnapshot } from '../agent/goal';
 import type { CronJobOrigin, PromptOrigin } from '../agent/context';
 import type { KimiErrorPayload } from '../errors';
 import type { PermissionMode } from '../agent/permission';
+import type { SwarmModeTrigger } from '../agent/swarm';
 import type { SkillSource } from '../skill';
 import type { BackgroundTaskInfo } from '../agent/background';
 import type { ToolInputDisplay } from '../tools/display';
@@ -49,6 +50,7 @@ export interface AgentStatusUpdatedEvent {
   readonly contextUsage?: number | undefined;
   readonly planMode?: boolean | undefined;
   readonly swarmMode?: boolean | undefined;
+  readonly swarmModeTrigger?: SwarmModeTrigger;
   readonly permission?: PermissionMode | undefined;
   readonly usage?: UsageStatus | undefined;
 }

--- a/packages/agent-core/src/rpc/resumed.ts
+++ b/packages/agent-core/src/rpc/resumed.ts
@@ -9,6 +9,7 @@ import type {
   PermissionMode,
 } from '#/agent/permission';
 import type { PlanData } from '#/agent/plan';
+import type { SwarmModeTrigger } from '#/agent/swarm';
 import type { ToolInfo } from '#/agent/tool';
 import type { SessionSummary } from '#/rpc/core-api';
 import type { UsageStatus } from '#/rpc/events';
@@ -34,6 +35,7 @@ export interface ResumedAgentState {
   readonly permission: PermissionData;
   readonly plan: PlanData;
   readonly swarmMode?: boolean | undefined;
+  readonly swarmModeTrigger?: SwarmModeTrigger;
   readonly usage: UsageStatus;
   readonly tools: readonly ToolInfo[];
   readonly toolStore?: Readonly<Record<string, unknown>>;

--- a/packages/agent-core/src/session/rpc.ts
+++ b/packages/agent-core/src/session/rpc.ts
@@ -150,6 +150,10 @@ export class SessionAPIImpl implements PromisableMethods<SessionAPI> {
     return (await this.getAgent(agentId)).getSwarmMode(payload);
   }
 
+  async getSwarmModeTrigger({ agentId, ...payload }: AgentScopedPayload<EmptyPayload>) {
+    return (await this.getAgent(agentId)).getSwarmModeTrigger(payload);
+  }
+
   async beginCompaction({ agentId, ...payload }: AgentScopedPayload<BeginCompactionPayload>) {
     return (await this.getAgent(agentId)).beginCompaction(payload);
   }

--- a/packages/agent-core/test/agent/turn.test.ts
+++ b/packages/agent-core/test/agent/turn.test.ts
@@ -291,6 +291,49 @@ describe('Agent turn flow', () => {
     await ctx.expectResumeMatches();
   });
 
+  it('keeps persistent Ultra swarm mode active after a turn completes normally', async () => {
+    const ctx = testAgent();
+    ctx.configure();
+    ctx.mockNextResponse({ type: 'text', text: 'ultra swarm done' });
+
+    await ctx.rpc.enterSwarm({ trigger: 'ultra' });
+    await ctx.rpc.prompt({ input: [{ type: 'text', text: 'Run an Ultra swarm task' }] });
+    await ctx.untilTurnEnd();
+
+    const ultraReminder = ctx.agent.context.history.find(
+      (message) => message.origin?.kind === 'injection' && message.origin.variant === 'ultra_swarm_mode',
+    );
+
+    expect(ctx.agent.swarmMode.isActive).toBe(true);
+    expect(ctx.agent.swarmMode.trigger).toBe('ultra');
+    expect(await ctx.rpc.getSwarmModeTrigger({})).toBe('ultra');
+    expect(ultraReminder?.content[0]?.type).toBe('text');
+    expect(ultraReminder?.content[0]?.type === 'text' ? ultraReminder.content[0].text : '').toContain(
+      'Ultra swarm mode',
+    );
+    expect(eventIndex(ctx, '[wire]', 'swarm_mode.exit')).toBe(-1);
+  });
+
+  it('exits one-shot Ultra swarm mode after a turn completes normally', async () => {
+    const ctx = testAgent();
+    ctx.configure();
+    ctx.mockNextResponse({ type: 'text', text: 'ultra swarm done' });
+
+    await ctx.rpc.enterSwarm({ trigger: 'ultra_task' });
+    await ctx.rpc.prompt({ input: [{ type: 'text', text: 'Run an Ultra swarm task' }] });
+    await ctx.untilTurnEnd();
+
+    const turnEndedIndex = eventIndex(ctx, '[rpc]', 'turn.ended');
+    const swarmExitIndex = eventIndex(ctx, '[wire]', 'swarm_mode.exit');
+
+    expect(ctx.agent.swarmMode.isActive).toBe(false);
+    expect(swarmExitIndex).toBeGreaterThan(turnEndedIndex);
+    expect(ctx.agent.context.history.at(-1)?.origin).toEqual({
+      kind: 'injection',
+      variant: 'swarm_mode_exit',
+    });
+  });
+
   it('exits task swarm mode when the swarm turn fails', async () => {
     const ctx = testAgent();
     ctx.configure();

--- a/packages/node-sdk/src/rpc.ts
+++ b/packages/node-sdk/src/rpc.ts
@@ -396,6 +396,10 @@ export abstract class SDKRpcClientBase {
       sessionId: input.sessionId,
       agentId,
     });
+    const swarmModeTrigger = await rpc.getSwarmModeTrigger({
+      sessionId: input.sessionId,
+      agentId,
+    });
     const usage = await rpc.getUsage({
       sessionId: input.sessionId,
       agentId,
@@ -411,6 +415,7 @@ export abstract class SDKRpcClientBase {
       permission: permission.mode,
       planMode: plan !== null,
       swarmMode,
+      swarmModeTrigger,
       contextTokens,
       maxContextTokens,
       contextUsage,

--- a/packages/node-sdk/src/types.ts
+++ b/packages/node-sdk/src/types.ts
@@ -2,6 +2,7 @@ import type {
   ExportSessionManifest,
   ResumeSessionResult,
   ShellEnvironment,
+  SwarmModeTrigger,
   TelemetryClient,
   TelemetryContextPatch,
   TelemetryProperties,
@@ -58,6 +59,7 @@ export type {
   ServicesConfig,
   ShellEnvironment,
   SkillSummary,
+  SwarmModeTrigger,
   ThinkingConfig,
   ToolInfo,
 } from '@moonshot-ai/agent-core';
@@ -177,6 +179,7 @@ export interface SessionStatus {
   readonly permission: PermissionMode;
   readonly planMode: boolean;
   readonly swarmMode?: boolean | undefined;
+  readonly swarmModeTrigger?: SwarmModeTrigger;
   readonly contextTokens: number;
   readonly maxContextTokens: number;
   readonly contextUsage: number;

--- a/packages/node-sdk/test/config.test.ts
+++ b/packages/node-sdk/test/config.test.ts
@@ -334,6 +334,7 @@ micro_compaction = false
 
     const features = await harness.getExperimentalFeatures();
     const microCompaction = features.find((feature) => feature.id === 'micro_compaction');
+    const ultraSwarm = features.find((feature) => feature.id === 'ultra_swarm');
 
     expect(microCompaction).toMatchObject({
       id: 'micro_compaction',
@@ -343,9 +344,17 @@ micro_compaction = false
       configValue: false,
       env: 'KIMI_CODE_EXPERIMENTAL_MICRO_COMPACTION',
     });
-    expect(features).toEqual([
+    expect(ultraSwarm).toMatchObject({
+      id: 'ultra_swarm',
+      title: 'Ultra swarm',
+      enabled: false,
+      source: 'default',
+      env: 'KIMI_CODE_EXPERIMENTAL_ULTRA_SWARM',
+    });
+    expect(features).toEqual(expect.arrayContaining([
       expect.objectContaining({ id: 'micro_compaction', enabled: false }),
-    ]);
+      expect.objectContaining({ id: 'ultra_swarm', enabled: false }),
+    ]));
   });
 
   it('can create the default config scaffold without selecting a model', async () => {


### PR DESCRIPTION
﻿## Related Issue

No linked issue. This PR adds an experimental Ultra swarm entrypoint and live orchestration view for larger swarm tasks.

## Problem

Kimi Code already has `/swarm`, but larger multi-agent tasks need guarded advisor-style sizing before work starts, bounded coordination windows, explicit context governance, and a clear live view of which swarm workers are active, queued, limited, done, or failed.

## What changed

- Added the experimental `ultra_swarm` flag, surfaced through `/experiments` and `KIMI_CODE_EXPERIMENTAL_ULTRA_SWARM`.
- Added `/ultramode` (`/ultra`) and `/swarm ultra` entrypoints for persistent and one-shot Ultra swarm runs.
- Added an Ultra swarm system reminder for Advisor pass, bounded coordination windows, meeting checkpoints, snapshot discipline, context firewalling, and existing AgentSwarm delegation.
- Added a live Ultra Swarm Map activity pane for Ultra runs, with grouped swarm windows, active/queued/limited/done/failed markers, and green pulsing active workers.
- Preserved a user's existing persistent `/swarm on` mode after a one-shot Ultra task exits.
- Added TUI command, command resolution, completion, marker, activity-pane, core turn, and experimental flag metadata coverage.
- Added a changeset for the CLI package.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.

## Test Plan

- `pnpm --filter @moonshot-ai/kimi-code exec vitest run test/tui/activity-pane.test.ts`
- `pnpm --filter @moonshot-ai/kimi-code exec vitest run test/tui/commands/swarm.test.ts`
- `pnpm --filter @moonshot-ai/kimi-code exec vitest run test/tui/commands/swarm.test.ts test/tui/kimi-tui-message-flow.test.ts -t "one-shot /ultramode task exits|restores persistent swarm|records persistent swarm restoration|switches an active regular swarm"`
- `pnpm --filter @moonshot-ai/kimi-code exec vitest run test/tui/commands/swarm.test.ts test/tui/commands/registry.test.ts test/tui/commands/resolve.test.ts test/tui/kimi-tui-message-flow.test.ts -t "one-shot /swarm task exits|one-shot /ultramode task exits|handleSwarmCommand|built-in slash command registry|resolveSlashCommandInput"`
- `pnpm --filter @moonshot-ai/agent-core exec vitest run test/agent/turn.test.ts -t "Ultra swarm"`
- `pnpm --filter @moonshot-ai/kimi-code-sdk exec vitest run test/config.test.ts -t "experimental feature metadata"`
- `pnpm --filter @moonshot-ai/agent-core run typecheck`
- `pnpm --filter @moonshot-ai/kimi-code-sdk run typecheck`
- `pnpm --filter @moonshot-ai/kimi-code run typecheck`
- `pnpm --filter @moonshot-ai/agent-core run build`
- `pnpm --filter @moonshot-ai/kimi-code-sdk run build`
- `pnpm --filter @moonshot-ai/kimi-code run build`
- `pnpm exec oxlint --type-aware apps/kimi-code/src/tui/components/panes/ultra-swarm-map.ts apps/kimi-code/src/tui/components/messages/agent-swarm-progress.ts apps/kimi-code/src/tui/controllers/subagent-event-handler.ts apps/kimi-code/src/tui/controllers/session-event-handler.ts apps/kimi-code/src/tui/kimi-tui.ts apps/kimi-code/test/tui/activity-pane.test.ts`
- `pnpm exec oxlint --type-aware apps/kimi-code/src/tui/commands/swarm.ts apps/kimi-code/src/tui/controllers/session-event-handler.ts apps/kimi-code/src/tui/tui-state.ts apps/kimi-code/src/tui/kimi-tui.ts apps/kimi-code/test/tui/commands/swarm.test.ts apps/kimi-code/test/tui/kimi-tui-message-flow.test.ts`
