### PR TITLE
fix(agent-core): suppress premature close error when bash process terminates

### DIFF
--- a/.changeset/fix-bash-premature-close.md
+++ b/.changeset/fix-bash-premature-close.md
@@ -1,0 +1,6 @@
+---
+"@moonshot-ai/agent-core": patch
+"@moonshot-ai/kimi-code": patch
+---
+
+Fix premature stream close errors when shell processes time out or are killed.

--- a/packages/agent-core/src/tools/builtin/shell/bash.ts
+++ b/packages/agent-core/src/tools/builtin/shell/bash.ts
@@ -309,10 +309,11 @@ export class BashTool implements BuiltinTool<BashInput> {
 
     try {
       const builder = new ToolResultBuilder();
+      const isTerminating = (): boolean => timedOut || aborted || killed;
       const [, exitCode] = await Promise.all([
         Promise.all([
-          readStreamIntoBuilder(proc.stdout, builder),
-          readStreamIntoBuilder(proc.stderr, builder),
+          readStreamIntoBuilder(proc.stdout, builder, isTerminating),
+          readStreamIntoBuilder(proc.stderr, builder, isTerminating),
         ]),
         proc.wait(),
       ]);
@@ -437,13 +438,28 @@ export class BashTool implements BuiltinTool<BashInput> {
 async function readStreamIntoBuilder(
   stream: Readable,
   builder: ToolResultBuilder,
+  suppressPrematureClose?: () => boolean,
 ): Promise<void> {
   const decoder = new StringDecoder('utf8');
-  for await (const chunk of stream) {
-    const buf: Buffer = typeof chunk === 'string' ? Buffer.from(chunk, 'utf8') : (chunk as Buffer);
-    builder.write(decoder.write(buf));
+  try {
+    for await (const chunk of stream) {
+      const buf: Buffer =
+        typeof chunk === 'string' ? Buffer.from(chunk, 'utf8') : (chunk as Buffer);
+      builder.write(decoder.write(buf));
+    }
+  } catch (error) {
+    if (!isPrematureCloseError(error) || suppressPrematureClose?.() !== true) {
+      throw error;
+    }
   }
   builder.write(decoder.end());
+}
+
+function isPrematureCloseError(error: unknown): boolean {
+  return (
+    error instanceof Error &&
+    (error as NodeJS.ErrnoException).code === 'ERR_STREAM_PREMATURE_CLOSE'
+  );
 }
 
 function shellQuote(s: string): string {

--- a/packages/agent-core/test/tools/bash.test.ts
+++ b/packages/agent-core/test/tools/bash.test.ts
@@ -126,6 +126,29 @@ function processThatNeverExits(): KaosProcess {
   };
 }
 
+function processWithOpenStreamsThatExitOnKill(): KaosProcess {
+  let currentExitCode: number | null = null;
+  let resolveWait: (code: number) => void = () => {};
+  const waitPromise = new Promise<number>((resolve) => {
+    resolveWait = resolve;
+  });
+
+  return {
+    stdin: { end: vi.fn(), write: vi.fn() } as unknown as Writable,
+    stdout: new PassThrough(),
+    stderr: new PassThrough(),
+    pid: 127,
+    get exitCode(): number | null {
+      return currentExitCode;
+    },
+    wait: vi.fn(async () => waitPromise),
+    kill: vi.fn(async () => {
+      currentExitCode = 143;
+      resolveWait(143);
+    }),
+  };
+}
+
 function context(args: BashInput, signal = new AbortController().signal) {
   return { turnId: '0', toolCallId: 'call_bash', args, signal };
 }
@@ -755,6 +778,31 @@ describe('BashTool', () => {
         brief: 'Killed by timeout (1s)',
       });
       expect(result.output).toContain('Command killed by timeout (1s)');
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('reports timeout instead of premature close when cleanup destroys open output streams', async () => {
+    vi.useFakeTimers();
+    try {
+      const proc = processWithOpenStreamsThatExitOnKill();
+      const tool = new BashTool(
+        createFakeKaos({ execWithEnv: vi.fn().mockResolvedValue(proc), osEnv: posixEnv }),
+        '/workspace',
+      );
+
+      const running = executeTool(tool, context({ command: 'sleep 2', timeout: 1 }));
+      await vi.advanceTimersByTimeAsync(1000);
+      const result = await running;
+
+      expect(proc.kill).toHaveBeenCalledWith('SIGTERM');
+      expect(result).toMatchObject({
+        isError: true,
+        brief: 'Killed by timeout (1s)',
+      });
+      expect(result.output).toContain('Command killed by timeout (1s)');
+      expect(result.output).not.toContain('Premature close');
     } finally {
       vi.useRealTimers();
     }


### PR DESCRIPTION
## Related Issue

N/A

## Problem

When a bash process is killed (due to timeout, abort, or explicit kill), the cleanup logic may destroy open `stdout`/`stderr` streams. This triggers an `ERR_STREAM_PREMATURE_CLOSE` error inside `readStreamIntoBuilder`, which masks the real reason for termination (e.g., timeout) and pollutes the result output with an unexpected error message.

## What changed

- Added a `suppressPrematureClose` callback to `readStreamIntoBuilder` so premature close errors are ignored when the process is already terminating (`timedOut`, `aborted`, or `killed`).
- Added a dedicated test to verify that when cleanup destroys open output streams after a timeout, the tool reports `Killed by timeout (1s)` instead of surfacing a premature close error.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
