### PR TITLE
docs(changelog): sync 0.12.1, 0.13.0 from apps/kimi-code/CHANGELOG.md

### DIFF
--- a/docs/en/release-notes/changelog.md
+++ b/docs/en/release-notes/changelog.md
@@ -2,6 +2,31 @@
 
 This page documents the changes in each Kimi Code CLI release.
 
+## 0.13.0 (2026-06-10)
+
+### Features
+
+- Add custom color themes. Define your own palette as a JSON file in `~/.kimi-code/themes/`, or generate one with the built-in `/custom-theme` skill command.
+- Add `/import-from-cc-codex` to import selected Claude Code and Codex instructions, Skills, and MCP settings.
+- Show available plugin updates in the marketplace.
+
+### Bug Fixes
+
+- Fix Windows builds and development launches that could fail when package binaries resolve to command shims.
+- Fix device login to keep the URL and code visible when the browser cannot be opened.
+
+### Polish
+
+- Clarify grouped subagent progress with active status breakdowns and elapsed time.
+- Truncate queued message display to a single line with ellipsis when it exceeds terminal width.
+
+## 0.12.1 (2026-06-09)
+
+### Bug Fixes
+
+- Allow obsolete experimental config entries to remain without blocking startup.
+- Pass through xhigh reasoning effort for OpenAI-compatible chat completions requests.
+
 ## 0.12.0 (2026-06-09)
 
 ### Features

--- a/docs/zh/release-notes/changelog.md
+++ b/docs/zh/release-notes/changelog.md
@@ -2,6 +2,31 @@
 
 本页记录 Kimi Code CLI 每个版本的变更内容。
 
+## 0.13.0（2026-06-10）
+
+### 新功能
+
+- 新增自定义颜色主题。在 `~/.kimi-code/themes/` 中以 JSON 文件定义自己的调色板，或使用内置的 `/custom-theme` Skill 命令生成。
+- 新增 `/import-from-cc-codex` 命令，用于导入选定的 Claude Code 和 Codex 指令、Skills 以及 MCP 设置。
+- 在 marketplace 中显示可用的 plugin 更新。
+
+### 修复
+
+- 修复 Windows 构建和开发启动可能因 package binary 解析到命令 shim 而失败的问题。
+- 修复设备登录，在浏览器无法打开时保持 URL 和验证码可见。
+
+### 优化
+
+- 通过活跃状态细分和已用时间，更清晰地展示分组子 Agent 进度。
+- 当排队消息超过终端宽度时，将其截断为单行并显示省略号。
+
+## 0.12.1（2026-06-09）
+
+### 修复
+
+- 允许过时的实验性配置条目保留而不阻塞启动。
+- 为 OpenAI 兼容的 Chat Completions 请求透传 xhigh reasoning effort。
+
 ## 0.12.0（2026-06-09）
 
 ### 新功能


### PR DESCRIPTION
## Related Issue

N/A — this is a post-release docs maintenance task.

## Problem

The documentation-site changelogs (`docs/en/release-notes/changelog.md` and `docs/zh/release-notes/changelog.md`) were missing the entries for the recently published releases 0.12.1 and 0.13.0.

## What changed

- Synced the 0.12.1 and 0.13.0 version blocks from the upstream CLI changelog (`apps/kimi-code/CHANGELOG.md`) into the English docs changelog.
- Translated the new entries into the Chinese docs changelog, following the existing classification (Features / Bug Fixes / Polish / Refactors / Other) and entry ordering conventions.
- Verified the docs build passes (`pnpm --filter kimi-code-docs run build`).

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [ ] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset. *(Docs sync does not enter the CLI bundle — no changeset required.)*
- [x] Ran `gen-docs` skill, or this PR needs no doc update. *(This PR is the doc update.)*