### PR TITLE
fix: stop asking for yolo external writes

### DIFF
--- a/.changeset/yolo-outside-write-approval.md
+++ b/.changeset/yolo-outside-write-approval.md
@@ -1,0 +1,6 @@
+---
+"@moonshot-ai/agent-core": patch
+"@moonshot-ai/kimi-code": patch
+---
+
+YOLO mode no longer asks before writing or editing files outside the working directory.

--- a/packages/agent-core/src/agent/permission/policies/file-access-ask.ts
+++ b/packages/agent-core/src/agent/permission/policies/file-access-ask.ts
@@ -63,26 +63,6 @@ export class GitControlPathAccessAskPermissionPolicy implements PermissionPolicy
   }
 }
 
-export class CwdOutsideFileWriteAskPermissionPolicy implements PermissionPolicy {
-  readonly name = 'cwd-outside-file-write-ask';
-
-  constructor(private readonly agent: Agent) {}
-
-  evaluate(context: PermissionPolicyContext): PermissionPolicyResult | undefined {
-    const cwd = this.agent.config.cwd;
-    if (cwd.length === 0) return;
-    const pathClass = this.agent.kaos.pathClass();
-    const access = writeFileAccesses(context).find((fileAccess) => {
-      return !isWithinDirectory(fileAccess.path, cwd, pathClass);
-    });
-    if (access === undefined) return;
-    return {
-      kind: 'ask',
-      reason: fileAccessReason(access, { cwd_outside: true }),
-    };
-  }
-}
-
 function fileAccesses(context: PermissionPolicyContext): ToolFileAccess[] {
   return (
     context.execution.accesses?.filter((access): access is ToolFileAccess => access.kind === 'file') ??

--- a/packages/agent-core/src/agent/permission/policies/index.ts
+++ b/packages/agent-core/src/agent/permission/policies/index.ts
@@ -6,7 +6,6 @@ import { DefaultToolApprovePermissionPolicy } from './default-tool-approve';
 import { ExitPlanModeReviewAskPermissionPolicy } from './exit-plan-mode-review-ask';
 import { FallbackAskPermissionPolicy } from './fallback-ask';
 import {
-  CwdOutsideFileWriteAskPermissionPolicy,
   GitControlPathAccessAskPermissionPolicy,
   SensitiveFileAccessAskPermissionPolicy,
 } from './file-access-ask';
@@ -50,8 +49,6 @@ export function createPermissionDecisionPolicies(agent: Agent): PermissionPolicy
     new SensitiveFileAccessAskPermissionPolicy(agent),
     // Access touches .git or a git control-dir path → ask.
     new GitControlPathAccessAskPermissionPolicy(agent),
-    // Write target is outside cwd → ask. Reads and searches outside cwd are allowed without prompting.
-    new CwdOutsideFileWriteAskPermissionPolicy(agent),
     // yolo mode → approve.
     new YoloModeApprovePermissionPolicy(agent),
     // Swarm mode keeps AgentSwarm available without making it a globally default-approved tool.

--- a/packages/agent-core/test/agent/permission.test.ts
+++ b/packages/agent-core/test/agent/permission.test.ts
@@ -404,20 +404,16 @@ describe('Permission auto mode', () => {
     },
   );
 
-  it.each(
-    (['manual', 'yolo'] as const).flatMap((mode) =>
-      [
-        [mode, 'Write', { path: '/tmp/notes.md', content: 'x' }, 'write', 'write file'],
-        [mode, 'Edit', { path: '/tmp/notes.md', old_string: 'a', new_string: 'b' }, 'edit', 'edit file'],
-      ] as const,
-    ),
-  )(
-    'requests approval in %s mode for %s outside the cwd',
-    async (mode, toolName, args, operation, action) => {
-      const { manager, requestApproval } = makePermissionManager(async () => ({
+  it.each([
+    ['Write', { path: '/tmp/notes.md', content: 'x' }, 'write', 'write file'],
+    ['Edit', { path: '/tmp/notes.md', old_string: 'a', new_string: 'b' }, 'edit', 'edit file'],
+  ] as const)(
+    'requests approval in manual mode for %s outside the cwd',
+    async (toolName, args, operation, action) => {
+      const { manager, requestApproval, telemetryTrack } = makePermissionManager(async () => ({
         decision: 'approved',
       }));
-      manager.setMode(mode);
+      manager.setMode('manual');
 
       await expect(
         manager.beforeToolCall(hookContext({ id: `call_${toolName}`, toolName, args })),
@@ -435,8 +431,42 @@ describe('Permission auto mode', () => {
         }),
         expect.any(Object),
       );
+      expect(telemetryTrack).toHaveBeenCalledWith(
+        'permission_policy_decision',
+        expect.objectContaining({
+          policy_name: 'fallback-ask',
+          tool_name: toolName,
+          permission_mode: 'manual',
+          decision: 'ask',
+        }),
+      );
     },
   );
+
+  it.each([
+    ['Write', { path: '/tmp/notes.md', content: 'x' }],
+    ['Edit', { path: '/tmp/notes.md', old_string: 'a', new_string: 'b' }],
+  ] as const)('approves %s outside the cwd in yolo mode', async (toolName, args) => {
+    const { manager, requestApproval, telemetryTrack } = makePermissionManager(async () => ({
+      decision: 'approved',
+    }));
+    manager.setMode('yolo');
+
+    await expect(
+      manager.beforeToolCall(hookContext({ id: `call_${toolName}_yolo_outside`, toolName, args })),
+    ).resolves.toBeUndefined();
+
+    expect(requestApproval).not.toHaveBeenCalled();
+    expect(telemetryTrack).toHaveBeenCalledWith(
+      'permission_policy_decision',
+      expect.objectContaining({
+        policy_name: 'yolo-mode-approve',
+        tool_name: toolName,
+        permission_mode: 'yolo',
+        decision: 'approve',
+      }),
+    );
+  });
 
   it.each(
     (['manual', 'yolo'] as const).flatMap((mode) =>
@@ -638,7 +668,7 @@ describe('Permission auto mode', () => {
     );
   });
 
-  it('reuses approve-for-session for repeated outside-workspace writes in yolo mode', async () => {
+  it('approves repeated outside-workspace writes in yolo mode without session approval', async () => {
     const { manager, requestApproval } = makePermissionManager(async () => ({
       decision: 'approved',
       scope: 'session',
@@ -657,8 +687,8 @@ describe('Permission auto mode', () => {
     await expect(call()).resolves.toBeUndefined();
     await expect(call()).resolves.toBeUndefined();
 
-    expect(requestApproval).toHaveBeenCalledTimes(1);
-    expect(manager.sessionApprovalRulePatterns).toEqual(['Write(/tmp/notes.md)']);
+    expect(requestApproval).not.toHaveBeenCalled();
+    expect(manager.sessionApprovalRulePatterns).toEqual([]);
     expect(manager.data().rules).toEqual([]);
   });
 });
@@ -678,7 +708,6 @@ describe('Permission policy chain', () => {
       'plan-mode-tool-approve',
       'sensitive-file-access-ask',
       'git-control-path-access-ask',
-      'cwd-outside-file-write-ask',
       'yolo-mode-approve',
       'swarm-mode-agent-swarm-approve',
       'default-tool-approve',
@@ -3301,7 +3330,7 @@ describe('Default git CWD Write/Edit permission', () => {
     expect(requestApproval).toHaveBeenCalledTimes(1);
     expect(telemetryTrack).toHaveBeenCalledWith(
       'permission_policy_decision',
-      expect.objectContaining({ policy_name: 'cwd-outside-file-write-ask' }),
+      expect.objectContaining({ policy_name: 'fallback-ask' }),
     );
     expect(telemetryTrack).not.toHaveBeenCalledWith(
       'permission_policy_decision',
@@ -3354,146 +3383,6 @@ describe('Default git CWD Write/Edit permission', () => {
     expect(requestApproval).not.toHaveBeenCalled();
     const markerCalls = stat.mock.calls.filter(([path]) => path === '/workspace/.git');
     expect(markerCalls).toHaveLength(4);
-  });
-});
-
-describe('CWD outside file write permission policy', () => {
-  it('falls through when cwd is empty', async () => {
-    const { manager, requestApproval, telemetryTrack } = makePermissionManager(
-      async () => ({ decision: 'approved' }),
-      { cwd: '' },
-    );
-
-    await expect(
-      manager.beforeToolCall(
-        hookContext({
-          id: 'call_empty_cwd_write',
-          toolName: 'Write',
-          args: { path: '/tmp/outside.ts', content: 'x' },
-        }),
-      ),
-    ).resolves.toBeUndefined();
-
-    expect(requestApproval).toHaveBeenCalledTimes(1);
-    expect(telemetryTrack).toHaveBeenCalledWith(
-      'permission_policy_decision',
-      expect.objectContaining({ policy_name: 'fallback-ask' }),
-    );
-  });
-
-  it('falls through when there are no file write accesses', async () => {
-    const args = { path: '/tmp/outside.ts', content: 'x' };
-    const { manager, requestApproval, telemetryTrack } = makePermissionManager(async () => ({
-      decision: 'approved',
-    }));
-
-    await expect(
-      manager.beforeToolCall(
-        hookContext({
-          id: 'call_no_write_accesses',
-          toolName: 'Write',
-          args,
-          execution: {
-            ...testExecution('Write', args),
-            accesses: ToolAccesses.none(),
-          },
-        }),
-      ),
-    ).resolves.toBeUndefined();
-
-    expect(requestApproval).toHaveBeenCalledTimes(1);
-    expect(telemetryTrack).toHaveBeenCalledWith(
-      'permission_policy_decision',
-      expect.objectContaining({ policy_name: 'fallback-ask' }),
-    );
-  });
-
-  it('asks when any write access is outside the cwd', async () => {
-    const args = { path: '/workspace/src/a.ts', content: 'x' };
-    const { manager, requestApproval, telemetryTrack } = makePermissionManager(async () => ({
-      decision: 'approved',
-    }));
-
-    await expect(
-      manager.beforeToolCall(
-        hookContext({
-          id: 'call_mixed_write_accesses',
-          toolName: 'Write',
-          args,
-          execution: {
-            ...testExecution('Write', args),
-            accesses: [
-              { kind: 'file', operation: 'write', path: '/workspace/src/a.ts' },
-              { kind: 'file', operation: 'readwrite', path: '/tmp/outside.ts' },
-            ],
-          },
-        }),
-      ),
-    ).resolves.toBeUndefined();
-
-    expect(requestApproval).toHaveBeenCalledTimes(1);
-    expect(telemetryTrack).toHaveBeenCalledWith(
-      'permission_policy_decision',
-      expect.objectContaining({
-        policy_name: 'cwd-outside-file-write-ask',
-        decision: 'ask',
-        cwd_outside: true,
-        file_access_operation: 'readwrite',
-      }),
-    );
-  });
-
-  it.each([
-    ['Read', { path: '/tmp/outside.ts' }],
-    ['Grep', { pattern: 'TODO', path: '/tmp' }],
-  ] as const)('does not ask for %s access outside cwd', async (toolName, args) => {
-    const { manager, requestApproval, telemetryTrack } = makePermissionManager(async () => ({
-      decision: 'approved',
-    }));
-
-    await expect(
-      manager.beforeToolCall(
-        hookContext({
-          id: `call_${toolName}_outside_cwd`,
-          toolName,
-          args,
-        }),
-      ),
-    ).resolves.toBeUndefined();
-
-    expect(requestApproval).not.toHaveBeenCalled();
-    expect(telemetryTrack).toHaveBeenCalledWith(
-      'permission_policy_decision',
-      expect.objectContaining({ policy_name: 'default-tool-approve' }),
-    );
-  });
-
-  it('uses Win32 path semantics for cwd containment', async () => {
-    const kaos = createFakeKaos({ pathClass: () => 'win32' });
-    const args = { path: 'c:\\repo\\src\\a.ts', content: 'x' };
-    const { manager, telemetryTrack } = makePermissionManager(
-      async () => ({ decision: 'approved' }),
-      { cwd: 'C:\\Repo', kaos },
-    );
-
-    await expect(
-      manager.beforeToolCall(
-        hookContext({
-          id: 'call_win_inside_cwd',
-          toolName: 'Write',
-          args,
-          execution: {
-            ...testExecution('Write', args),
-            accesses: ToolAccesses.writeFile('c:\\repo\\src\\a.ts'),
-          },
-        }),
-      ),
-    ).resolves.toBeUndefined();
-
-    expect(telemetryTrack).not.toHaveBeenCalledWith(
-      'permission_policy_decision',
-      expect.objectContaining({ policy_name: 'cwd-outside-file-write-ask' }),
-    );
   });
 });
 


### PR DESCRIPTION
## Related Issue

No linked issue; this fixes a permission prompt mismatch in YOLO mode.

## Problem

YOLO mode is documented and presented as skipping regular tool approvals, including file writes. However, writing or editing an absolute file path outside the working directory could still trigger a permission prompt, which made YOLO behavior inconsistent for trusted batch work.

## What changed

Removed the dedicated outside-working-directory write prompt policy so YOLO mode can approve those regular file write and edit calls directly. Manual mode still asks through the fallback permission policy, and sensitive-file plus git-control-path checks continue to run before YOLO approval.

Updated permission tests to cover manual fallback approval, YOLO approval for outside-working-directory writes and edits, and the git-cwd write approval boundary.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.

Verification:

- `pnpm vitest run packages/agent-core/test/agent/permission.test.ts`
- `pnpm --filter @moonshot-ai/agent-core run typecheck`
- `git diff --check`
- Read-only diff audit for internal identifiers: no issues found.
