### PR TITLE
feat(agent-core): add Interrupt hook for user-interrupted turns

### DIFF
--- a/.changeset/add-interrupt-hook.md
+++ b/.changeset/add-interrupt-hook.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": minor
+---
+
+Add an `Interrupt` hook event that fires when the user interrupts a turn (e.g. pressing Esc), letting hooks observe the turn stopping instead of getting stuck on a working state.

--- a/docs/en/customization/hooks.md
+++ b/docs/en/customization/hooks.md
@@ -110,6 +110,7 @@ Only **blockable events** (`PreToolUse`, `Stop`, `UserPromptSubmit`) have return
 | `SubagentStart` | Sub-agent name | — | Triggered before a sub-agent starts running |
 | `SubagentStop` | Sub-agent name | — | Triggered after a sub-agent completes successfully (observation only) |
 | `StopFailure` | Error type | — | Triggered after the current turn fails due to an error (observation only) |
+| `Interrupt` | Empty string | — | Triggered when the user interrupts the current turn (e.g. pressing Esc); not fired for timeouts or other programmatic aborts. `Stop` does not fire on interrupts, so this event fires instead. The payload includes a `reason` field (observation only) |
 | `PreCompact` | `manual` or `auto` | — | Triggered before context compaction begins; return values are completely ignored |
 | `PostCompact` | `manual` or `auto` | — | Triggered after context compaction completes (observation only) |
 | `Notification` | Notification type (e.g. `task.completed`) | — | Triggered when a background task status changes (observation only) |

--- a/docs/zh/customization/hooks.md
+++ b/docs/zh/customization/hooks.md
@@ -110,6 +110,7 @@ Hook 命令的工作目录是当前会话的项目目录。非 Windows 平台上
 | `SubagentStart` | 子 Agent 名称 | — | 子 Agent 开始运行前触发 |
 | `SubagentStop` | 子 Agent 名称 | — | 子 Agent 成功完成后触发（观察用） |
 | `StopFailure` | 错误类型 | — | 本轮因错误失败后触发（观察用） |
+| `Interrupt` | 空字符串 | — | 用户中断本轮时触发（例如按下 Esc）；超时或其他程序性中断不会触发。中断时 `Stop` 不会触发，由本事件替代。payload 含 `reason` 字段（观察用） |
 | `PreCompact` | `manual` 或 `auto` | — | 上下文压缩开始前触发；返回值被完全忽略 |
 | `PostCompact` | `manual` 或 `auto` | — | 上下文压缩完成后触发（观察用） |
 | `Notification` | 通知类型（如 `task.completed`） | — | 后台任务状态变化时触发（观察用） |

--- a/packages/agent-core/src/agent/turn/index.ts
+++ b/packages/agent-core/src/agent/turn/index.ts
@@ -35,7 +35,7 @@ import {
 } from '../../loop/index';
 import type { AgentEvent, TurnEndedEvent } from '../../rpc';
 import type { TelemetryPropertyValue } from '../../telemetry';
-import { abortable, userCancellationReason } from '../../utils/abort';
+import { abortable, isUserCancellation, userCancellationReason } from '../../utils/abort';
 import { USER_PROMPT_ORIGIN, type PromptOrigin } from '../context';
 import { renderUserPromptHookBlockResult, renderUserPromptHookResult } from '../../session/hooks';
 import { canonicalTelemetryArgs, isPlainRecord } from './canonical-args';
@@ -471,6 +471,17 @@ export class TurnFlow {
     // is false for those).
     if (this.currentId === turnId) {
       this.agent.usage.endTurn();
+    }
+    // A user interrupt (e.g. Esc) aborts the turn without the normal Stop hook
+    // firing, so external tooling that tracks status from hooks would otherwise
+    // never see the turn stop. Emit an observation-only Interrupt event for it.
+    // Gate on isUserCancellation: a `cancelled` turn can also come from a
+    // programmatic abort (e.g. a subagent deadline timeout, which shares this
+    // hook engine), and those must not be misreported as a user interrupt.
+    if (ended.reason === 'cancelled' && isUserCancellation(signal.reason)) {
+      void this.agent.hooks?.fireAndForgetTrigger('Interrupt', {
+        inputData: { turnId, reason: 'cancelled' },
+      });
     }
     this.agent.emitEvent(ended);
     if (standalone && this.currentId === turnId) {

--- a/packages/agent-core/src/session/hooks/types.ts
+++ b/packages/agent-core/src/session/hooks/types.ts
@@ -9,6 +9,7 @@ export const HOOK_EVENT_TYPES = [
   'UserPromptSubmit',
   'Stop',
   'StopFailure',
+  'Interrupt',
   'SessionStart',
   'SessionEnd',
   'SubagentStart',

--- a/packages/agent-core/test/agent/turn.test.ts
+++ b/packages/agent-core/test/agent/turn.test.ts
@@ -16,6 +16,7 @@ import {
 import { describe, expect, it, vi } from 'vitest';
 
 import { HookEngine } from '../../src/session/hooks';
+import { abortError } from '../../src/utils/abort';
 import type { AgentOptions } from '../../src/agent';
 import type { Logger, LogPayload } from '../../src/logging';
 import {
@@ -631,6 +632,71 @@ describe('Agent turn flow', () => {
     await ctx.untilTurnEnd();
 
     expect(triggered).toEqual([['StopFailure', 'Error', 1]]);
+  });
+
+  it('fires Interrupt when the user cancels an active turn', async () => {
+    const triggered: Array<[string, string, number]> = [];
+    const hookEngine = new HookEngine(
+      [
+        {
+          event: 'Interrupt',
+          command: 'exit 0',
+        },
+      ],
+      {
+        onTriggered: (event, target, count) => {
+          triggered.push([event, target, count]);
+        },
+      },
+    );
+    const ctx = testAgent({
+      hookEngine,
+      kaos: createCommandKaos('should-not-run'),
+    });
+    ctx.configure({ tools: ['Bash'] });
+
+    ctx.mockNextResponse({ type: 'text', text: 'I will run Bash.' }, bashCall());
+    await ctx.rpc.prompt({ input: [{ type: 'text', text: 'Run a command' }] });
+    await ctx.untilApprovalRequest();
+
+    await ctx.rpc.cancel({ turnId: 0 });
+    await ctx.untilTurnEnd();
+
+    expect(triggered).toEqual([['Interrupt', '', 1]]);
+  });
+
+  it('does not fire Interrupt for a non-user (programmatic) abort', async () => {
+    const triggered: Array<[string, string, number]> = [];
+    const hookEngine = new HookEngine(
+      [
+        {
+          event: 'Interrupt',
+          command: 'exit 0',
+        },
+      ],
+      {
+        onTriggered: (event, target, count) => {
+          triggered.push([event, target, count]);
+        },
+      },
+    );
+    const ctx = testAgent({
+      hookEngine,
+      kaos: createCommandKaos('should-not-run'),
+    });
+    ctx.configure({ tools: ['Bash'] });
+
+    ctx.mockNextResponse({ type: 'text', text: 'I will run Bash.' }, bashCall());
+    await ctx.rpc.prompt({ input: [{ type: 'text', text: 'Run a command' }] });
+    await ctx.untilApprovalRequest();
+
+    // A programmatic abort (e.g. a subagent deadline timeout) carries a plain
+    // AbortError as its reason, not a UserCancellationError, so it must not be
+    // reported as a user interrupt.
+    ctx.agent.turn.cancel(0, abortError());
+    await ctx.untilTurnEnd();
+
+    expect(triggered).toEqual([]);
   });
 
   it('resolves the latest request-scoped OAuth auth before each generation', async () => {


### PR DESCRIPTION
## Related Issue

No prior issue — the problem is explained below.

## Problem

When a user interrupts a turn (e.g. pressing <kbd>Esc</kbd>), no hook fires. `Stop` only fires when the model finishes normally, and `StopFailure` only fires on errors — a user interrupt aborts the turn (`turn.ended` with `reason: "cancelled"`) and emits neither.

This breaks external tooling that tracks agent status (idle / working / blocked) purely from hooks: after an interrupt it never receives a stop signal, so it stays stuck on a "working" state until the next turn. This was raised by a user building exactly such a monitor on top of Kimi Code. The same gap exists in Claude Code and Codex (hooks layer), so closing it here is a concrete differentiator.

## What changed

Adds a new observation-only `Interrupt` hook event that fires when a turn is aborted by the user.

- It is **fire-and-forget / non-blocking**, mirroring how the interrupt path must exit quickly. It deliberately does **not** reuse `Stop`, which is blockable and could otherwise let a hook veto the user's own interrupt.
- It is triggered at the single point where a turn ends with `reason === 'cancelled'`, which corresponds precisely to a user interrupt (errors go to `StopFailure`; a `UserPromptSubmit` block ends as `completed`).
- The payload includes `turn_id` and `reason`.

Files:
- `packages/agent-core/src/session/hooks/types.ts` — register the `Interrupt` event type (it auto-flows into the config schema's `z.enum`, so it is immediately configurable).
- `packages/agent-core/src/agent/turn/index.ts` — fire `Interrupt` on the interrupt path.
- `docs/{en,zh}/customization/hooks.md` — document the event in both locales.
- `packages/agent-core/test/agent/turn.test.ts` — test that cancelling an active turn fires `Interrupt`.

Example usage in `~/.kimi-code/config.toml`:

```toml
[[hooks]]
event = "Interrupt"
command = "your-status-script"   # mark the agent idle again
```

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset. _(changeset added: `@moonshot-ai/kimi-code` minor)_
- [x] Ran `gen-docs` skill, or this PR needs no doc update. _(docs updated manually in both locales)_
