### PR TITLE
feat(kosong): support claude-fable-5 with adaptive thinking

### DIFF
--- a/.changeset/anthropic-fable-5.md
+++ b/.changeset/anthropic-fable-5.md
@@ -1,0 +1,6 @@
+---
+"@moonshot-ai/kosong": minor
+"@moonshot-ai/kimi-code": minor
+---
+
+Add Claude Fable 5 support to the Anthropic provider, using adaptive thinking instead of the budget-based thinking config the model rejects.

--- a/.changeset/anthropic-fable-5.md
+++ b/.changeset/anthropic-fable-5.md
@@ -3,4 +3,4 @@
 "@moonshot-ai/kimi-code": minor
 ---
 
-Add Claude Fable 5 support to the Anthropic provider, using adaptive thinking instead of the budget-based thinking config the model rejects.
+Add Claude Fable 5 support to the Anthropic provider.

--- a/packages/kosong/src/providers/anthropic.ts
+++ b/packages/kosong/src/providers/anthropic.ts
@@ -132,6 +132,8 @@ const ANTHROPIC_TOOL_CALL_ID_POLICY: ToolCallIdPolicy = {
  * family's baseline rather than the generic fallback.
  */
 const CEILING_BY_FAMILY_VERSION: Readonly<Record<string, number>> = {
+  // Claude Fable 5 documents a 128k output ceiling.
+  'fable-5': 128000,
   // Claude Opus per minor version. 4.6 and 4.7 raised the cap to 128k;
   // 4.5 ships at 64k; 4.1 and the dated 4.0 release stay at 32k.
   'opus-4-7': 128000,
@@ -162,7 +164,7 @@ const CEILING_BY_FAMILY_VERSION: Readonly<Record<string, number>> = {
 
 const FALLBACK_MAX_TOKENS = 32000;
 
-type ClaudeFamily = 'opus' | 'sonnet' | 'haiku';
+type ClaudeFamily = 'opus' | 'sonnet' | 'haiku' | 'fable';
 
 interface ClaudeVersion {
   family: ClaudeFamily;
@@ -170,12 +172,13 @@ interface ClaudeVersion {
   minor: number | null;
 }
 
-// Family-first form: "opus-4-7", "sonnet-4.6", "haiku-4-5-20251001".
+// Family-first form: "opus-4-7", "sonnet-4.6", "haiku-4-5-20251001",
+// "fable-5" (single version component — Fable ids carry no minor).
 // Version numbers are capped at 1–2 digits with a non-digit lookahead so
 // 8-digit date suffixes (e.g. `-20251001`) don't get consumed as version
 // components.
 const FAMILY_FIRST_RE =
-  /(opus|sonnet|haiku)[-._](\d{1,2})(?!\d)(?:[-._](\d{1,2})(?!\d))?/;
+  /(opus|sonnet|haiku|fable)[-._](\d{1,2})(?!\d)(?:[-._](\d{1,2})(?!\d))?/;
 // Legacy version-first form: "3-5-sonnet", "3.7.opus" — used by older
 // Anthropic model ids and Bedrock variants of Claude 3.x.
 const VERSION_FIRST_RE = /(\d{1,2})[-._](\d{1,2})[-._](opus|sonnet|haiku)/;
@@ -292,11 +295,13 @@ function versionAtLeast(
 
 function supportsAdaptiveThinking(model: string): boolean {
   const version = parseClaudeAliasVersion(model);
-  if (version === null || version.minor === null) {
+  if (version === null) {
     return false;
   }
+  // A missing minor is a bare family-major id: "claude-fable-5" (5.0 ≥ 4.6,
+  // adaptive-only) or "claude-opus-4" (4.0 < 4.6, budget-based).
   return versionAtLeast(
-    { major: version.major, minor: version.minor },
+    { major: version.major, minor: version.minor ?? 0 },
     ADAPTIVE_MIN_VERSION,
   );
 }
@@ -308,6 +313,10 @@ function isOpus47(model: string): boolean {
   }
   const version = parseVersion(match);
   return version.major === 4 && version.minor === 7;
+}
+
+function isFableModel(model: string): boolean {
+  return parseClaudeAliasVersion(model)?.family === 'fable';
 }
 
 function supportsEffortParam(model: string, adaptive: boolean): boolean {
@@ -322,7 +331,7 @@ function clampEffort(effort: ThinkingEffort, model: string, adaptive: boolean): 
   if (effort === 'off') {
     return effort;
   }
-  if (effort === 'xhigh' && !isOpus47(model)) {
+  if (effort === 'xhigh' && !isOpus47(model) && !isFableModel(model)) {
     return 'high';
   }
   if (effort === 'max' && !adaptive) {
@@ -962,8 +971,13 @@ export class AnthropicChatProvider implements ChatProvider {
     if (this._generationKwargs.top_p !== undefined) {
       kwargs['top_p'] = this._generationKwargs.top_p;
     }
-    if (this._generationKwargs.thinking !== undefined) {
-      kwargs['thinking'] = this._generationKwargs.thinking;
+    // Fable rejects an explicit `disabled` thinking config (HTTP 400, unlike
+    // Opus 4.7/4.8 which accept it), so omit the field instead. Note thinking
+    // cannot actually be turned off on Fable: adaptive thinking is always on,
+    // and an omitted `thinking` field still runs with it.
+    const thinking = this._generationKwargs.thinking;
+    if (thinking !== undefined && !(thinking.type === 'disabled' && isFableModel(this._model))) {
+      kwargs['thinking'] = thinking;
     }
     if (this._generationKwargs.output_config !== undefined) {
       kwargs['output_config'] = this._generationKwargs.output_config;

--- a/packages/kosong/src/providers/capability-registry.ts
+++ b/packages/kosong/src/providers/capability-registry.ts
@@ -28,12 +28,19 @@ const OPENAI_VISION_TOOL_PREFIXES = [
   'gpt-4.5',
 ] as const;
 
-const CLAUDE_3_PREFIXES = ['claude-3-', 'claude-3.5-', 'claude-3.7-'] as const;
+// Claude prefixes are grouped by capability set, not by version family:
+// a new model joins the group whose capability it matches (e.g. Fable sits
+// with Opus/Sonnet/Haiku 4), rather than getting a per-version group.
 
-const CLAUDE_4_PREFIXES = [
+// Vision + tool use, no thinking (-> ANTHROPIC_VISION_TOOL_CAPABILITY).
+const CLAUDE_VISION_TOOL_PREFIXES = ['claude-3-', 'claude-3.5-', 'claude-3.7-'] as const;
+
+// Vision + tool use + thinking (-> ANTHROPIC_THINKING_VISION_TOOL_CAPABILITY).
+const CLAUDE_THINKING_VISION_TOOL_PREFIXES = [
   'claude-opus-4',
   'claude-sonnet-4',
   'claude-haiku-4',
+  'claude-fable',
 ] as const;
 
 const GEMINI_CATALOGUED_PREFIXES = [
@@ -136,11 +143,11 @@ const OPENAI_RESPONSES_CAPABILITY_CATALOG: readonly CapabilityCatalogEntry[] = [
 
 const ANTHROPIC_CAPABILITY_CATALOG: readonly CapabilityCatalogEntry[] = [
   {
-    matches: (name) => hasPrefix(name, CLAUDE_3_PREFIXES),
+    matches: (name) => hasPrefix(name, CLAUDE_VISION_TOOL_PREFIXES),
     capability: ANTHROPIC_VISION_TOOL_CAPABILITY,
   },
   {
-    matches: (name) => hasPrefix(name, CLAUDE_4_PREFIXES),
+    matches: (name) => hasPrefix(name, CLAUDE_THINKING_VISION_TOOL_PREFIXES),
     capability: ANTHROPIC_THINKING_VISION_TOOL_CAPABILITY,
   },
 ];

--- a/packages/kosong/test/anthropic.test.ts
+++ b/packages/kosong/test/anthropic.test.ts
@@ -1005,6 +1005,31 @@ describe('AnthropicChatProvider', () => {
       expect(body['output_config']).toEqual({ effort: 'xhigh' });
     });
 
+    it('claude-fable-5: uses adaptive thinking with xhigh effort', async () => {
+      const provider = createProvider('claude-fable-5').withThinking('xhigh');
+      const body = await captureRequestBody(provider, '', [], thinkHistory);
+
+      expect(body['thinking']).toEqual({ type: 'adaptive', display: 'summarized' });
+      expect(body['output_config']).toEqual({ effort: 'xhigh' });
+      // Adaptive should remove interleaved-thinking beta
+      const headers = body['_extra_headers'] as Record<string, string> | undefined;
+      if (headers !== undefined && headers['anthropic-beta'] !== undefined) {
+        expect(headers['anthropic-beta']).not.toContain('interleaved-thinking-2025-05-14');
+      }
+    });
+
+    it('claude-fable-5 with thinking off omits the thinking field entirely', async () => {
+      // Fable 400s on an explicit `disabled` thinking config (unlike Opus
+      // 4.7/4.8); the provider must drop the field from the request while
+      // still reporting `off` to callers.
+      const provider = createProvider('claude-fable-5').withThinking('off');
+      expect(provider.thinkingEffort).toBe('off');
+
+      const body = await captureRequestBody(provider, '', [], thinkHistory);
+      expect('thinking' in body).toBe(false);
+      expect(body['output_config']).toBeUndefined();
+    });
+
     it.each([
       'claude-sonnet-4-6',
       'anthropic.claude-opus-4-7-v1:0',
@@ -1289,6 +1314,9 @@ describe('AnthropicChatProvider', () => {
         'claude-sonnet-5-0',
         'claude-haiku-4-6',
         'claude-haiku-5-0',
+        // Fable (major-only version, no minor)
+        'claude-fable-5',
+        'anthropic.claude-fable-5-v1:0',
         // Bedrock / Vertex / proxy prefixes
         'anthropic.claude-opus-4-7-v1:0',
         'aws/claude-opus-4-7',
@@ -1352,6 +1380,9 @@ describe('AnthropicChatProvider', () => {
         ['claude-sonnet-4-6', 'xhigh', 'high'],
         // low/medium/high passthrough
         ['claude-opus-4-6', 'medium', 'medium'],
+        // Fable 5: full range including xhigh and max
+        ['claude-fable-5', 'xhigh', 'xhigh'],
+        ['claude-fable-5', 'max', 'max'],
         // Future 4.8+: inherits max but xhigh clamps to high
         ['claude-opus-4-8', 'xhigh', 'high'],
         ['claude-opus-4-8', 'max', 'max'],
@@ -2108,6 +2139,7 @@ describe('AnthropicChatProvider', () => {
 
 describe('resolveDefaultMaxTokens', () => {
   it('returns per-version Messages-API caps for known Claude 4 models', () => {
+    expect(resolveDefaultMaxTokens('claude-fable-5')).toBe(128000);
     expect(resolveDefaultMaxTokens('claude-opus-4-7')).toBe(128000);
     expect(resolveDefaultMaxTokens('claude-opus-4-6')).toBe(128000);
     expect(resolveDefaultMaxTokens('claude-opus-4-5-20251101')).toBe(64000);

--- a/packages/kosong/test/capability-providers.test.ts
+++ b/packages/kosong/test/capability-providers.test.ts
@@ -114,6 +114,13 @@ describe('AnthropicChatProvider.getCapability', () => {
     expect(cap.tool_use).toBe(true);
   });
 
+  it('claude-fable-5 → image_in + thinking + tool_use', () => {
+    const cap = make('claude-fable-5').getCapability();
+    expect(cap.image_in).toBe(true);
+    expect(cap.thinking).toBe(true);
+    expect(cap.tool_use).toBe(true);
+  });
+
   it('no Anthropic model supports audio_in', () => {
     // Sanity: Anthropic has no audio-input models today. If one ships later
     // and this fails, update the table — but make it a conscious decision.


### PR DESCRIPTION
## Related Issue

No linked issue — the problem is explained below.

## Problem

Selecting `claude-fable-5` on the Anthropic provider fails on every request with:

```
Error: [provider.api_error] 400 {"error":{"message":"... \"thinking.type.enabled\" is not supported for this model.
Use \"thinking.type.adaptive\" and \"output_config.effort\" to control thinking behavior.","type":"invalid_request_error"}}
```

Fable 5 (like Opus 4.7/4.8) removed the legacy `thinking: {type: "enabled", budget_tokens: N}` config and only accepts `thinking: {type: "adaptive"}` + `output_config.effort`. The provider's model-version inference only recognizes the `opus|sonnet|haiku` families, so `claude-fable-5` fell back to the budget-based path and every request 400'd.

Fable also has one extra constraint the 4.x family doesn't (per the [official migration guide](https://platform.claude.com/docs/en/about-claude/models/migration-guide)): an explicit `thinking: {type: "disabled"}` is rejected too. Adaptive thinking is always on for this model — a request without a `thinking` field still runs with adaptive thinking, so omitting the field is the only valid form.

## What changed

In the Anthropic provider (`@moonshot-ai/kosong`):

- Parse the `fable` family in Claude model ids; a missing minor version is treated as `.0`, so `fable-5` (5.0 ≥ 4.6) routes to adaptive thinking while bare `opus-4` (4.0) stays budget-based, preserving all existing model behavior.
- Allow `xhigh` effort on Fable (previously only Opus 4.7 escaped the clamp to `high`).
- When thinking is `off` on Fable, omit the `thinking` field from the request instead of sending `{type: "disabled"}` (which Fable rejects with 400, unlike Opus 4.7/4.8). Internal state still reports `off` to callers; note the model itself cannot actually disable thinking — an omitted field runs with adaptive thinking, which is the closest reachable behavior.
- Register the 128k output ceiling for `fable-5` (previously fell back to 32k).
- Register thinking/vision/tool capability for `claude-fable` prefixes; the capability prefix groups are now named by capability set (`CLAUDE_THINKING_VISION_TOOL_PREFIXES`) rather than version family, with a comment stating the grouping rule.

This follows the existing version-inference approach so custom endpoint names keep working, and the `adaptiveThinking` config override remains available as before.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.