### PR TITLE
chore: downgrade Fable 5 changeset to patch

### DIFF
--- a/.changeset/anthropic-fable-5.md
+++ b/.changeset/anthropic-fable-5.md
@@ -1,6 +1,6 @@
 ---
-"@moonshot-ai/kosong": minor
-"@moonshot-ai/kimi-code": minor
+"@moonshot-ai/kosong": patch
+"@moonshot-ai/kimi-code": patch
 ---
 
 Add Claude Fable 5 support to the Anthropic provider.


### PR DESCRIPTION
## Related Issue

No linked issue.

## Problem

PR #610 added Claude Fable 5 support, but its changeset currently marks both affected packages as minor releases. This release metadata should be downgraded to patch.

## What changed

Downgraded the existing Fable 5 changeset entries for `@moonshot-ai/kosong` and `@moonshot-ai/kimi-code` from `minor` to `patch`. The changelog text is unchanged.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] Tests are not applicable for this changeset metadata-only change.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.