### PR TITLE
fix: replay compaction records on resume

### DIFF
--- a/.changeset/replay-compaction-records.md
+++ b/.changeset/replay-compaction-records.md
@@ -1,0 +1,6 @@
+---
+"@moonshot-ai/agent-core": patch
+"@moonshot-ai/kimi-code": patch
+---
+
+Show completed and cancelled compaction records correctly when resuming a session.

--- a/apps/kimi-code/src/tui/controllers/session-replay.ts
+++ b/apps/kimi-code/src/tui/controllers/session-replay.ts
@@ -45,6 +45,7 @@ import type { SessionEventHandler } from './session-event-handler';
 import type { TUIState } from '../tui-state';
 
 type GoalReplayRecord = Extract<AgentReplayRecord, { type: 'goal_updated' }>;
+type CompactionReplayRecord = Extract<AgentReplayRecord, { type: 'compaction' }>;
 type GoalReplayLifecycleChange = GoalChange & { readonly kind: 'lifecycle' };
 
 export interface SessionReplayHost {
@@ -177,6 +178,9 @@ export class SessionReplayRenderer {
     switch (record.type) {
       case 'message':
         this.renderMessage(context, record.message);
+        return;
+      case 'compaction':
+        this.renderCompaction(context, record);
         return;
       case 'goal_updated':
         this.renderGoalReplayRecord(context, record);
@@ -370,6 +374,30 @@ export class SessionReplayRenderer {
       skillName: skill.skillName,
       skillArgs: skill.skillArgs,
       skillTrigger: skill.trigger,
+    });
+  }
+
+  private renderCompaction(context: ReplayRenderContext, record: CompactionReplayRecord): void {
+    this.flushAssistant(context);
+    if (record.result === undefined) return;
+    if (record.result === 'cancelled') {
+      this.host.appendTranscriptEntry({
+        ...replayEntry(context, 'status', 'Compaction cancelled', 'plain'),
+        compactionData: {
+          result: 'cancelled',
+          instruction: record.instruction,
+        },
+      });
+      return;
+    }
+
+    this.host.appendTranscriptEntry({
+      ...replayEntry(context, 'status', 'Compaction complete', 'plain'),
+      compactionData: {
+        tokensBefore: record.result.tokensBefore,
+        tokensAfter: record.result.tokensAfter,
+        instruction: record.instruction,
+      },
     });
   }
 

--- a/apps/kimi-code/src/tui/kimi-tui.ts
+++ b/apps/kimi-code/src/tui/kimi-tui.ts
@@ -1269,7 +1269,11 @@ export class KimiTUI {
     if (entry.compactionData !== undefined) {
       const data = entry.compactionData;
       const block = new CompactionComponent(this.state.ui, data.instruction);
-      block.markDone(data.tokensBefore, data.tokensAfter);
+      if (data.result === 'cancelled') {
+        block.markCanceled();
+      } else {
+        block.markDone(data.tokensBefore, data.tokensAfter);
+      }
       return block;
     }
 

--- a/apps/kimi-code/src/tui/types.ts
+++ b/apps/kimi-code/src/tui/types.ts
@@ -96,6 +96,7 @@ export interface BackgroundAgentStatusData {
 }
 
 export interface CompactionTranscriptData {
+  readonly result?: 'cancelled';
   readonly tokensBefore?: number;
   readonly tokensAfter?: number;
   readonly instruction?: string;

--- a/apps/kimi-code/test/tui/message-replay.test.ts
+++ b/apps/kimi-code/test/tui/message-replay.test.ts
@@ -978,6 +978,61 @@ describe('KimiTUI resume message replay', () => {
     expect(transcript).toContain('hook response 2');
   });
 
+  it('renders replayed compaction records as completed compaction blocks', async () => {
+    const driver = await replayIntoDriver([
+      message('user', [{ type: 'text', text: 'prompt before compaction' }]),
+      {
+        type: 'compaction',
+        result: {
+          summary: 'Compacted transcript summary.',
+          compactedCount: 4,
+          tokensBefore: 120,
+          tokensAfter: 24,
+        },
+        instruction: 'preserve implementation notes',
+      },
+      message('user', [{ type: 'text', text: 'prompt after compaction' }]),
+    ]);
+
+    const compactionEntry = driver.state.transcriptEntries.find(
+      (entry) => entry.compactionData !== undefined,
+    );
+    expect(compactionEntry?.compactionData).toEqual({
+      tokensBefore: 120,
+      tokensAfter: 24,
+      instruction: 'preserve implementation notes',
+    });
+    const transcript = stripAnsi(driver.state.transcriptContainer.render(120).join('\n'));
+    expect(transcript).toContain('Compaction complete');
+    expect(transcript).toContain('120 → 24 tokens');
+    expect(transcript).toContain('preserve implementation notes');
+    expect(transcript).not.toContain('Compacted transcript summary.');
+  });
+
+  it('renders replayed cancelled compaction records as cancelled compaction blocks', async () => {
+    const driver = await replayIntoDriver([
+      message('user', [{ type: 'text', text: 'prompt before cancellation' }]),
+      {
+        type: 'compaction',
+        result: 'cancelled',
+        instruction: 'preserve implementation notes',
+      },
+      message('user', [{ type: 'text', text: 'prompt after cancellation' }]),
+    ]);
+
+    const compactionEntry = driver.state.transcriptEntries.find(
+      (entry) => entry.compactionData !== undefined,
+    );
+    expect(compactionEntry?.compactionData).toEqual({
+      result: 'cancelled',
+      instruction: 'preserve implementation notes',
+    });
+    const transcript = stripAnsi(driver.state.transcriptContainer.render(120).join('\n'));
+    expect(transcript).toContain('Compaction cancelled');
+    expect(transcript).toContain('preserve implementation notes');
+    expect(transcript).not.toContain('Compaction complete');
+  });
+
   it('renders plan permission and approval replay notices', async () => {
     const driver = await replayIntoDriver([
       { type: 'plan_updated', enabled: true },

--- a/packages/agent-core/src/agent/compaction/full.ts
+++ b/packages/agent-core/src/agent/compaction/full.ts
@@ -143,12 +143,9 @@ export class FullCompaction {
   }
 
   private markCanceled(): void {
-    if (this.agent.records.restoring) {
-      this.agent.replayBuilder.patchLast('compaction', {
-        result: 'cancelled',
-      });
-      return;
-    }
+    this.agent.replayBuilder.patchLast('compaction', {
+      result: 'cancelled',
+    });
     if (!this.compacting) return;
     this.agent.records.logRecord({
       type: 'full_compaction.cancel',
@@ -156,9 +153,6 @@ export class FullCompaction {
     this.compacting.abortController.abort();
     this.compacting = null;
     this.agent.emitEvent({ type: 'compaction.cancelled' });
-    this.agent.replayBuilder.patchLast('compaction', {
-      result: 'cancelled',
-    });
   }
 
   markCompleted() {

--- a/packages/agent-core/src/agent/compaction/full.ts
+++ b/packages/agent-core/src/agent/compaction/full.ts
@@ -100,6 +100,10 @@ export class FullCompaction {
     }
     if (this.compactionCountInTurn > this.strategy.maxCompactionPerTurn) return;
     if (this.agent.records.restoring) {
+      this.agent.replayBuilder.push({
+        type: 'compaction',
+        instruction: data.instruction,
+      });
       return;
     }
     const compactedCount = this.strategy.computeCompactCount(this.agent.context.history, data.source);
@@ -139,6 +143,12 @@ export class FullCompaction {
   }
 
   private markCanceled(): void {
+    if (this.agent.records.restoring) {
+      this.agent.replayBuilder.patchLast('compaction', {
+        result: 'cancelled',
+      });
+      return;
+    }
     if (!this.compacting) return;
     this.agent.records.logRecord({
       type: 'full_compaction.cancel',
@@ -146,6 +156,9 @@ export class FullCompaction {
     this.compacting.abortController.abort();
     this.compacting = null;
     this.agent.emitEvent({ type: 'compaction.cancelled' });
+    this.agent.replayBuilder.patchLast('compaction', {
+      result: 'cancelled',
+    });
   }
 
   markCompleted() {

--- a/packages/agent-core/src/agent/context/index.ts
+++ b/packages/agent-core/src/agent/context/index.ts
@@ -144,7 +144,12 @@ export class ContextMemory {
       ...result,
     });
     this.agent.replayBuilder.patchLast('compaction', {
-      result,
+      result: {
+        summary: result.summary,
+        compactedCount: result.compactedCount,
+        tokensBefore: result.tokensBefore,
+        tokensAfter: result.tokensAfter,
+      },
     });
     this._history = [
       {

--- a/packages/agent-core/src/agent/context/index.ts
+++ b/packages/agent-core/src/agent/context/index.ts
@@ -139,34 +139,28 @@ export class ContextMemory {
   }
 
   applyCompaction(result: CompactionResult): void {
-    const compactionResult: CompactionResult = {
-      summary: result.summary,
-      compactedCount: result.compactedCount,
-      tokensBefore: result.tokensBefore,
-      tokensAfter: result.tokensAfter,
-    };
     this.agent.records.logRecord({
       type: 'context.apply_compaction',
-      ...compactionResult,
+      ...result,
     });
     this.agent.replayBuilder.patchLast('compaction', {
-      result: compactionResult,
+      result,
     });
     this._history = [
       {
         role: 'assistant',
-        content: [{ type: 'text', text: compactionResult.summary }],
+        content: [{ type: 'text', text: result.summary }],
         toolCalls: [],
         origin: { kind: 'compaction_summary' },
       },
-      ...this._history.slice(compactionResult.compactedCount),
+      ...this._history.slice(result.compactedCount),
     ];
     this.openSteps.clear();
     this.flushDeferredMessagesIfToolExchangeClosed();
-    this._tokenCount = compactionResult.tokensAfter;
+    this._tokenCount = result.tokensAfter;
     this.tokenCountCoveredMessageCount = this._history.length;
     this.agent.microCompaction.reset();
-    this.agent.injection.onContextCompacted(compactionResult.compactedCount);
+    this.agent.injection.onContextCompacted(result.compactedCount);
     this.agent.emitStatusUpdated();
   }
 

--- a/packages/agent-core/src/agent/context/index.ts
+++ b/packages/agent-core/src/agent/context/index.ts
@@ -138,26 +138,35 @@ export class ContextMemory {
     }
   }
 
-  applyCompaction(summary: CompactionResult): void {
+  applyCompaction(result: CompactionResult): void {
+    const compactionResult: CompactionResult = {
+      summary: result.summary,
+      compactedCount: result.compactedCount,
+      tokensBefore: result.tokensBefore,
+      tokensAfter: result.tokensAfter,
+    };
     this.agent.records.logRecord({
       type: 'context.apply_compaction',
-      ...summary,
+      ...compactionResult,
+    });
+    this.agent.replayBuilder.patchLast('compaction', {
+      result: compactionResult,
     });
     this._history = [
       {
         role: 'assistant',
-        content: [{ type: 'text', text: summary.summary }],
+        content: [{ type: 'text', text: compactionResult.summary }],
         toolCalls: [],
         origin: { kind: 'compaction_summary' },
       },
-      ...this._history.slice(summary.compactedCount),
+      ...this._history.slice(compactionResult.compactedCount),
     ];
     this.openSteps.clear();
     this.flushDeferredMessagesIfToolExchangeClosed();
-    this._tokenCount = summary.tokensAfter;
+    this._tokenCount = compactionResult.tokensAfter;
     this.tokenCountCoveredMessageCount = this._history.length;
     this.agent.microCompaction.reset();
-    this.agent.injection.onContextCompacted(summary.compactedCount);
+    this.agent.injection.onContextCompacted(compactionResult.compactedCount);
     this.agent.emitStatusUpdated();
   }
 

--- a/packages/agent-core/src/agent/replay/index.ts
+++ b/packages/agent-core/src/agent/replay/index.ts
@@ -13,6 +13,18 @@ export class ReplayBuilder {
     }
   }
 
+  patchLast<T extends AgentReplayRecord['type']>(
+    type: T,
+    patch: Partial<Extract<AgentReplayRecord, { type: T }>>,
+  ): void {
+    if (this.agent.records.restoring) {
+      const last = this.records.at(-1);
+      if (last && last.type === type) {
+        Object.assign(last, patch);
+      }
+    }
+  }
+
   removeLastMessages(removedMessages: ReadonlySet<ContextMessage>): void {
     if (removedMessages.size === 0) return;
     for (let i = this.records.length - 1; i >= 0; i--) {

--- a/packages/agent-core/src/rpc/resumed.ts
+++ b/packages/agent-core/src/rpc/resumed.ts
@@ -1,5 +1,6 @@
 import type { AgentType } from '#/agent';
 import type { BackgroundTaskInfo } from '#/agent/background';
+import type { CompactionResult } from '#/agent/compaction';
 import type { AgentConfigData, AgentConfigUpdateData } from '#/agent/config';
 import type { AgentContextData, ContextMessage } from '#/agent/context';
 import type { GoalChange, GoalSnapshot } from '#/agent/goal';
@@ -16,6 +17,7 @@ import type { SessionMeta } from '#/session';
 
 export type AgentReplayRecord =
   | { type: 'message'; message: ContextMessage }
+  | { type: 'compaction'; result?: CompactionResult | 'cancelled'; instruction?: string }
   | {
       type: 'goal_updated';
       snapshot: GoalSnapshot;

--- a/packages/agent-core/test/agent/resume.test.ts
+++ b/packages/agent-core/test/agent/resume.test.ts
@@ -224,6 +224,89 @@ describe('Agent resume', () => {
     }
   });
 
+  it('projects restored compactions into replay records', async () => {
+    const persistence = new RecordingAgentPersistence([
+      {
+        type: 'context.append_message',
+        message: {
+          role: 'user',
+          content: [{ type: 'text', text: 'Historical prompt before compaction' }],
+          toolCalls: [],
+          origin: { kind: 'user' },
+        },
+      },
+      {
+        type: 'full_compaction.begin',
+        source: 'manual',
+        instruction: 'preserve implementation notes',
+      },
+      {
+        type: 'full_compaction.complete',
+      },
+      {
+        type: 'context.apply_compaction',
+        summary: 'Compacted implementation notes.',
+        compactedCount: 1,
+        tokensBefore: 120,
+        tokensAfter: 24,
+      },
+    ]);
+    const ctx = testAgent({ persistence });
+
+    await ctx.agent.resume();
+
+    expect(ctx.agent.context.history).toEqual([
+      expect.objectContaining({
+        role: 'assistant',
+        content: [{ type: 'text', text: 'Compacted implementation notes.' }],
+        origin: { kind: 'compaction_summary' },
+      }),
+    ]);
+    expect(ctx.agent.replayBuilder.buildResult()).toEqual([
+      expect.objectContaining({
+        type: 'message',
+        message: expect.objectContaining({
+          role: 'user',
+          content: [{ type: 'text', text: 'Historical prompt before compaction' }],
+        }),
+      }),
+      {
+        type: 'compaction',
+        result: {
+          summary: 'Compacted implementation notes.',
+          compactedCount: 1,
+          tokensBefore: 120,
+          tokensAfter: 24,
+        },
+        instruction: 'preserve implementation notes',
+      },
+    ]);
+  });
+
+  it('projects restored cancelled compactions into replay records', async () => {
+    const persistence = new RecordingAgentPersistence([
+      {
+        type: 'full_compaction.begin',
+        source: 'manual',
+        instruction: 'preserve implementation notes',
+      },
+      {
+        type: 'full_compaction.cancel',
+      },
+    ]);
+    const ctx = testAgent({ persistence });
+
+    await ctx.agent.resume();
+
+    expect(ctx.agent.replayBuilder.buildResult()).toEqual([
+      {
+        type: 'compaction',
+        result: 'cancelled',
+        instruction: 'preserve implementation notes',
+      },
+    ]);
+  });
+
   it('persists undelivered restored background notifications during resume', async () => {
     const persistence = new RecordingAgentPersistence([
       {


### PR DESCRIPTION
## Related Issue

No linked issue.

## Problem

Resumed TUI sessions did not show historical compaction activity because compaction state was not projected as a replay record. This made completed or cancelled compactions disappear from the transcript after resume.

## What changed

- Added compaction replay records for restored full-compaction lifecycle events.
- Render replayed completed and cancelled compactions with the existing TUI compaction block.
- Added resume replay coverage for completed and cancelled compactions in agent-core and TUI tests.
- Added a patch changeset for the CLI-visible resume display fix.

## Verification

- `pnpm vitest run packages/agent-core/test/agent/resume.test.ts`
- `pnpm vitest run apps/kimi-code/test/tui/message-replay.test.ts`
- `pnpm --filter @moonshot-ai/agent-core run typecheck`
- `pnpm --filter @moonshot-ai/kimi-code run typecheck`
- `pnpm exec oxlint --type-aware packages/agent-core/src/rpc/resumed.ts packages/agent-core/src/agent/compaction/full.ts packages/agent-core/src/agent/context/index.ts packages/agent-core/src/agent/replay/index.ts apps/kimi-code/src/tui/types.ts apps/kimi-code/src/tui/kimi-tui.ts apps/kimi-code/src/tui/controllers/session-replay.ts packages/agent-core/test/agent/resume.test.ts apps/kimi-code/test/tui/message-replay.test.ts`
- Read-only diff audit found no internal identifier issues.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.
