### PR TITLE
fix: truncate goal marker text to terminal width

### DIFF
--- a/.changeset/fix-goal-marker-width-truncation.md
+++ b/.changeset/fix-goal-marker-width-truncation.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Fix goal marker text overflowing terminal width.

--- a/apps/kimi-code/src/tui/components/messages/goal-markers.ts
+++ b/apps/kimi-code/src/tui/components/messages/goal-markers.ts
@@ -7,7 +7,7 @@
  * the richer completion card (the `/goal` box), not this marker.
  */
 
-import type { Component } from '@earendil-works/pi-tui';
+import { truncateToWidth, type Component } from '@earendil-works/pi-tui';
 import type { GoalChange } from '@moonshot-ai/kimi-code-sdk';
 
 import { STATUS_BULLET } from '#/tui/constant/symbols';
@@ -58,22 +58,29 @@ export class GoalMarkerComponent implements Component {
     const dot = currentTheme.fg(this.accentToken, this.marker);
     const head = currentTheme.fg(this.textToken, this.headline);
     const hasDetail = this.detail !== undefined && this.detail.length > 0;
-    if (!hasDetail) return this.withLeadingBlank([`${this.indent}${dot} ${head}`]);
+    if (!hasDetail) return this.clampToWidth([`${this.indent}${dot} ${head}`], width);
 
     if (!this.expandable) {
-      return this.withLeadingBlank([`${this.indent}${dot} ${head}`]);
+      return this.clampToWidth([`${this.indent}${dot} ${head}`], width);
     }
     if (!this.expanded) {
-      return this.withLeadingBlank([
-        `${this.indent}${dot} ${head} ${currentTheme.fg('textMuted', '(ctrl+o)')}`,
-      ]);
+      return this.clampToWidth(
+        [`${this.indent}${dot} ${head} ${currentTheme.fg('textMuted', '(ctrl+o)')}`],
+        width,
+      );
     }
     const out = [`${this.indent}${dot} ${head}`];
     const wrapWidth = Math.max(20, width - DETAIL_INDENT.length);
     for (const line of wrap(this.detail!, wrapWidth)) {
       out.push(DETAIL_INDENT + currentTheme.fg('textDim', line));
     }
-    return this.withLeadingBlank(out);
+    return this.clampToWidth(out, width);
+  }
+
+  private clampToWidth(lines: string[], width: number): string[] {
+    const withBlank = this.withLeadingBlank(lines);
+    if (width <= 0) return withBlank.map(() => '');
+    return withBlank.map((line) => truncateToWidth(line, width));
   }
 
   private withLeadingBlank(lines: string[]): string[] {
@@ -163,7 +170,7 @@ function lowercaseFirst(text: string): string {
 }
 
 function wrap(text: string, width: number): string[] {
-  const words = text.replace(/\s+/g, ' ').trim().split(' ');
+  const words = text.replaceAll(/\s+/g, ' ').trim().split(' ');
   const lines: string[] = [];
   let current = '';
   for (const word of words) {

--- a/apps/kimi-code/test/tui/components/messages/goal-markers.test.ts
+++ b/apps/kimi-code/test/tui/components/messages/goal-markers.test.ts
@@ -1,3 +1,4 @@
+import { visibleWidth } from '@earendil-works/pi-tui';
 import { describe, expect, it } from 'vitest';
 
 import { buildGoalMarker, GoalMarkerComponent } from '#/tui/components/messages/goal-markers';
@@ -45,6 +46,22 @@ describe('buildGoalMarker', () => {
     );
 
     expect(strip(marker!.render(80))).toBe('\n● Goal paused after runtime error: socket hang up');
+  });
+
+  it('keeps long provider pause markers within the terminal width', () => {
+    const reason =
+      'Paused after provider API error: 400 {"error":{"message":"request id: 456043b9-6491-11f1-9425-2221bb1af97c, \\"thinking.enabled\\" is not supported for this model. Use \\"thinking.adaptive\\" and \\"output_config.effort\\" to control thinking behavior.","type":"invalid_request_error"}}';
+    const marker = buildGoalMarker(
+      { kind: 'lifecycle', status: 'paused', reason } as GoalChange,
+      false,
+      'runtime',
+    );
+
+    const width = 80;
+    expect(strip(marker!.render(width))).toContain('Goal paused after provider API error');
+    for (const line of marker!.render(width)) {
+      expect(visibleWidth(line)).toBeLessThanOrEqual(width);
+    }
   });
 
   it('attributes model pause and resume markers to the agent', () => {


### PR DESCRIPTION
## Related Issue

N/A — no prior issue for this bug.

## Problem

Goal marker text in the TUI could overflow the available terminal width, causing layout breakage when the terminal is narrow or the goal headline is long.

## What changed

- Import `truncateToWidth` from `@earendil-works/pi-tui` and use it in a new `clampToWidth` helper.
- Apply width clamping to all rendering paths of `GoalMarkerComponent` (collapsed, expanded, and detail views).
- Update existing tests to cover the new truncation behavior.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.
