### PR TITLE
feat: prompt AI to use ReadMediaFile for video attachments instead of Python frame extraction

### DIFF
--- a/packages/agent-core/src/profile/default/system.md
+++ b/packages/agent-core/src/profile/default/system.md
@@ -62,6 +62,7 @@ The user may ask you to research on certain topics, process or generate certain 
 - Make plans before doing deep or wide research, to ensure you are always on track.
 - Search on the Internet if possible, with carefully-designed search queries to improve efficiency and accuracy.
 - Use proper tools or shell commands or Python packages to process or generate images, videos, PDFs, docs, spreadsheets, presentations, or other multimedia files. Detect if there are already such tools in the environment. If you have to install third-party tools/packages, you MUST ensure that they are installed in a virtual/isolated environment.
+- When the user uploads a video as an attachment (represented as `<video path="...">` in the message), you should use the `ReadMediaFile` tool to read the video content directly instead of writing Python scripts to extract frames or process it manually.
 - Once you generate or edit any images, videos or other media files, try to read it again before proceed, to ensure that the content is as expected.
 - Avoid installing or deleting anything to/from outside of the current working directory. If you have to do so, ask the user for confirmation.
 


### PR DESCRIPTION
## Problem

When users upload videos as attachments, the system renders them as `<video path="...">` tags in the prompt. Previously, the system prompt only provided general guidance about "use proper tools or shell commands or Python packages to process... multimedia files", which often led the AI to write Python scripts to extract frames manually instead of using the built-in `ReadMediaFile` tool.

This was reported as feedback Q-0266: **Kimi CLI 视频分析希望默认调用 ReadMediaFile 而不是写 Python 切帧**.

## Solution

Added an explicit instruction in the default system prompt (`packages/agent-core/src/profile/default/system.md`):

> When the user uploads a video as an attachment (represented as `<video path="...">` in the message), you should use the `ReadMediaFile` tool to read the video content directly instead of writing Python scripts to extract frames or process it manually.

## Why this approach

- **Minimal change**: Single-line addition to existing system prompt, no code changes needed.
- **Leverages existing infrastructure**: `ReadMediaFile` already fully supports video files via the `video_in` capability and `videoUploader`.
- **Aligns with user intent**: The feedback specifically requested that video analysis default to `ReadMediaFile` rather than Python frame extraction.
- **No tests affected**: Existing tests for prompt rendering and profile loading continue to pass.
