### PR TITLE
fix(acp-adapter): convert Unix paths to Windows separators for ACP file RPC

### DIFF
--- a/.changeset/fix-windows-acp-paths.md
+++ b/.changeset/fix-windows-acp-paths.md
@@ -1,0 +1,6 @@
+---
+"@moonshot-ai/acp-adapter": patch
+"@moonshot-ai/kimi-code": patch
+---
+
+Fix ACP file reads and edits for Windows workspaces opened through IDE clients.

--- a/packages/acp-adapter/src/kaos-acp.ts
+++ b/packages/acp-adapter/src/kaos-acp.ts
@@ -122,11 +122,12 @@ export class AcpKaos implements Kaos {
     path: string,
     _options?: { encoding?: BufferEncoding; errors?: 'strict' | 'replace' | 'ignore' },
   ): Promise<string> {
+    const rpcPath = this.toClientPath(path);
     try {
-      const resp = await this.conn.readTextFile({ sessionId: this.sessionId, path });
+      const resp = await this.conn.readTextFile({ sessionId: this.sessionId, path: rpcPath });
       return resp.content;
     } catch (err) {
-      throw wrapKaosError(`acp: readTextFile failed for ${path}`, err);
+      throw wrapKaosError(`acp: readTextFile failed for ${rpcPath}`, err);
     }
   }
 
@@ -221,11 +222,17 @@ export class AcpKaos implements Kaos {
   }
 
   private async acpWrite(path: string, content: string): Promise<void> {
+    const rpcPath = this.toClientPath(path);
     try {
-      await this.conn.writeTextFile({ sessionId: this.sessionId, path, content });
+      await this.conn.writeTextFile({ sessionId: this.sessionId, path: rpcPath, content });
     } catch (err) {
-      throw wrapKaosError(`acp: writeTextFile failed for ${path}`, err);
+      throw wrapKaosError(`acp: writeTextFile failed for ${rpcPath}`, err);
     }
+  }
+
+  private toClientPath(path: string): string {
+    if (this.inner.pathClass() !== 'win32') return path;
+    return path.replaceAll('/', '\\');
   }
 
   // ── process execution: delegate to inner ───────────────────────────

--- a/packages/acp-adapter/test/kaos-acp.test.ts
+++ b/packages/acp-adapter/test/kaos-acp.test.ts
@@ -82,7 +82,8 @@ interface MockInnerKaos extends Kaos {
   };
 }
 
-function makeMockInner(): MockInnerKaos {
+function makeMockInner(opts?: { pathClass?: 'posix' | 'win32' }): MockInnerKaos {
+  const pathClass = opts?.pathClass ?? 'posix';
   const spy = {
     pathClassCalls: 0,
     normpathCalls: [] as string[],
@@ -107,7 +108,7 @@ function makeMockInner(): MockInnerKaos {
     osEnv: { os: 'linux', shell: 'bash' } as unknown as Environment,
     pathClass: () => {
       spy.pathClassCalls += 1;
-      return 'posix';
+      return pathClass;
     },
     normpath: (p: string) => {
       spy.normpathCalls.push(p);
@@ -230,6 +231,31 @@ describe('AcpKaos', () => {
         expect((err as Error).message).toContain('acp: readTextFile failed for /x.ts');
         expect((err as Error).message).toContain('rpc died');
       }
+    });
+
+    it('uses win32-native separators for ACP file RPC paths', async () => {
+      const conn = makeMockConn({
+        readHandler: async () => ({ content: 'HELLO' }),
+      });
+      const inner = makeMockInner({ pathClass: 'win32' });
+      const kaos = new AcpKaos(conn.asConn(), 's1', inner);
+
+      await kaos.readText('G:/python-code/render_with_mult_gpu/README.md');
+      await kaos.writeText('G:/python-code/render_with_mult_gpu/README.md', 'updated');
+
+      expect(conn.readCalls).toEqual([
+        {
+          sessionId: 's1',
+          path: 'G:\\python-code\\render_with_mult_gpu\\README.md',
+        },
+      ]);
+      expect(conn.writeCalls).toEqual([
+        {
+          sessionId: 's1',
+          path: 'G:\\python-code\\render_with_mult_gpu\\README.md',
+          content: 'updated',
+        },
+      ]);
     });
   });
 


### PR DESCRIPTION
## Related Issue

N/A — this fix addresses a Windows path compatibility issue discovered during IDE client integration testing.

## Problem

When a Windows workspace is opened through an IDE client (e.g. Zed), ACP file read/write RPC calls receive paths with Unix forward slashes (`/`). The Windows IDE client expects native backslash separators (`\\`), causing `readTextFile` and `writeTextFile` operations to fail or behave incorrectly on Windows environments.

## What changed

- Added `toClientPath` helper in `AcpKaos` that converts `/` to `\\` when the inner `Kaos` environment reports `win32` path class.
- Applied the conversion in `readTextFile` and `writeTextFile` before sending RPC calls, so Windows clients always receive native path separators.
- Added unit tests covering the Windows path conversion scenario.
- Generated a changeset for `@moonshot-ai/acp-adapter` and `@moonshot-ai/kimi-code`.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [ ] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [ ] Ran `gen-docs` skill, or this PR needs no doc update.
