### PR TITLE
Classify provider 403 responses as auth errors

### DIFF
--- a/packages/agent-core/src/errors/serialize.ts
+++ b/packages/agent-core/src/errors/serialize.ts
@@ -57,7 +57,7 @@ export function makeErrorPayload(
  *
  * Recognized errors:
  * - `KimiError`: passthrough.
- * - `APIStatusError`: 429 -> rate_limit, 401 -> auth_error, otherwise -> api_error.
+ * - `APIStatusError`: 429 -> rate_limit, 401/403 -> auth_error, otherwise -> api_error.
  * - `APIConnectionError` / `APITimeoutError`: connection_error.
  * - `ChatProviderError`: api_error.
  *
@@ -79,7 +79,7 @@ export function toKimiErrorPayload(error: unknown): KimiErrorPayload {
     const code: KimiErrorCode =
       error.statusCode === 429
         ? ErrorCodes.PROVIDER_RATE_LIMIT
-        : error.statusCode === 401
+        : error.statusCode === 401 || error.statusCode === 403
           ? ErrorCodes.PROVIDER_AUTH_ERROR
           : ErrorCodes.PROVIDER_API_ERROR;
     return {

--- a/packages/agent-core/test/errors/serialize.test.ts
+++ b/packages/agent-core/test/errors/serialize.test.ts
@@ -1,0 +1,23 @@
+import { APIStatusError } from '@moonshot-ai/kosong';
+import { describe, expect, it } from 'vitest';
+
+import { ErrorCodes, toKimiErrorPayload } from '../../src/errors';
+
+describe('toKimiErrorPayload', () => {
+  it('classifies provider 403 responses as auth errors', () => {
+    const payload = toKimiErrorPayload(
+      new APIStatusError(403, 'access_terminated: Access was terminated', 'req-403'),
+    );
+
+    expect(payload).toMatchObject({
+      code: ErrorCodes.PROVIDER_AUTH_ERROR,
+      message: 'access_terminated: Access was terminated',
+      name: 'APIStatusError',
+      details: {
+        statusCode: 403,
+        requestId: 'req-403',
+      },
+      retryable: false,
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Classifies provider HTTP 403 responses as provider.auth_error instead of provider.api_error when serializing errors across the agent boundary.

This covers the client-side part of #636: an upstream access_terminated / forbidden response should be surfaced as an auth or access problem, not as a generic provider failure. The server-side platform allowlist issue still needs to be handled separately by Moonshot.

## Validation

- pnpm vitest run packages/agent-core/test/errors/serialize.test.ts
- pnpm vitest run packages/agent-core/test/agent/turn.test.ts -t "403 status"

Refs #636.