### PR TITLE
fix: allow YOLO when starting swarm tasks

### DIFF
--- a/.changeset/swarm-yolo-start-option.md
+++ b/.changeset/swarm-yolo-start-option.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Add a YOLO choice when starting swarm tasks from Manual mode.

--- a/apps/kimi-code/src/tui/commands/swarm.ts
+++ b/apps/kimi-code/src/tui/commands/swarm.ts
@@ -71,7 +71,7 @@ async function startSwarmWithPermission(
   prompt: string,
   choice: SwarmStartPermissionChoice,
 ): Promise<void> {
-  if (choice === 'auto') {
+  if (choice === 'auto' || choice === 'yolo') {
     if (!(await setPermissionForSwarm(host, choice))) return;
   }
   await startSwarmTask(host, prompt);
@@ -111,7 +111,9 @@ async function applySwarmMode(
   }
   if (enabled && host.state.appState.permissionMode === 'manual') {
     showSwarmStartPermissionPrompt(host, commandText, 'Swarm mode not enabled.', async (choice) => {
-      if (choice === 'auto' && !(await setPermissionForSwarm(host, choice))) return;
+      if ((choice === 'auto' || choice === 'yolo') && !(await setPermissionForSwarm(host, choice))) {
+        return;
+      }
       if (!(await setSwarmMode(host, true, 'manual'))) return;
       renderSwarmModeMarker(host, 'active');
     });

--- a/apps/kimi-code/src/tui/components/dialogs/swarm-start-permission-prompt.ts
+++ b/apps/kimi-code/src/tui/components/dialogs/swarm-start-permission-prompt.ts
@@ -3,7 +3,7 @@ import {
   type StartPermissionOption,
 } from './start-permission-prompt';
 
-export type SwarmStartPermissionChoice = 'auto' | 'manual';
+export type SwarmStartPermissionChoice = 'auto' | 'yolo' | 'manual';
 
 export interface SwarmStartPermissionPromptOptions {
   readonly onSelect: (choice: SwarmStartPermissionChoice) => void;
@@ -16,6 +16,12 @@ const OPTIONS: readonly StartPermissionOption<SwarmStartPermissionChoice>[] = [
     label: 'Switch to Auto and start',
     description:
       'Best for swarm tasks. Tools are approved automatically, and questions are skipped.',
+  },
+  {
+    value: 'yolo',
+    label: 'Switch to YOLO and start',
+    description:
+      'Tools and plan changes are approved automatically. Kimi Code may still ask you questions.',
   },
   {
     value: 'manual',

--- a/apps/kimi-code/test/tui/commands/swarm.test.ts
+++ b/apps/kimi-code/test/tui/commands/swarm.test.ts
@@ -214,7 +214,7 @@ describe('handleSwarmCommand', () => {
     expect(host.sendNormalUserInput).not.toHaveBeenCalled();
     const text = stripAnsi(mountedPicker(host).render(80).join('\n'));
     expect(text).toContain('Manual mode can block swarm work');
-    expect(text).not.toContain('Switch to YOLO and start');
+    expect(text).toContain('Switch to YOLO and start');
     expect(text).not.toContain('Do not start');
   });
 
@@ -242,6 +242,7 @@ describe('handleSwarmCommand', () => {
     await handleSwarmCommand(host, 'Ship feature X');
     const picker = mountedPicker(host);
     picker.handleInput(DOWN);
+    picker.handleInput(DOWN);
     picker.handleInput(ENTER);
 
     await vi.waitFor(() => {
@@ -250,6 +251,26 @@ describe('handleSwarmCommand', () => {
     expect(session.setPermission).not.toHaveBeenCalled();
     expect(session.setSwarmMode).toHaveBeenCalledWith(true, 'task');
     expect(session.setSwarmMode).toHaveBeenCalledTimes(1);
+    expect(host.state.swarmModeEntry).toBe('task');
+    expectSwarmMarker(host, 'Swarm activated');
+  });
+
+  it('can start a Manual-mode swarm task after switching to YOLO', async () => {
+    const { host, session } = makeHost({ permissionMode: 'manual' });
+
+    await handleSwarmCommand(host, 'Ship feature X');
+    const picker = mountedPicker(host);
+    picker.handleInput(DOWN);
+    picker.handleInput(ENTER);
+
+    await vi.waitFor(() => {
+      expect(host.sendNormalUserInput).toHaveBeenCalledWith('Ship feature X');
+    });
+    expect(session.setPermission).toHaveBeenCalledWith('yolo');
+    expect(session.setSwarmMode).toHaveBeenCalledWith(true, 'task');
+    expect(session.setSwarmMode).toHaveBeenCalledTimes(1);
+    expect(host.setAppState).toHaveBeenCalledWith({ permissionMode: 'yolo' });
+    expect(host.setAppState).toHaveBeenCalledWith({ swarmMode: true });
     expect(host.state.swarmModeEntry).toBe('task');
     expectSwarmMarker(host, 'Swarm activated');
   });

--- a/docs/en/reference/slash-commands.md
+++ b/docs/en/reference/slash-commands.md
@@ -48,7 +48,7 @@ Some commands are only available in the idle state. Executing these commands whi
 | `/plan [on\|off]` | — | Toggle Plan mode. Without arguments, flips the current state; explicitly passing `on`/`off` forces the setting. Simply toggling does not create an empty plan file | Yes |
 | `/plan clear` | — | Clear the current plan | No |
 | `/swarm on\|off` | — | Turn swarm mode on or off without sending a prompt. | Yes |
-| `/swarm <task>` | — | Turn swarm mode on, then send `<task>` as a normal prompt. If the turn completes normally, swarm mode turns off automatically. In `manual` permission mode, Kimi Code asks whether to switch to `auto` before starting. | No |
+| `/swarm <task>` | — | Turn swarm mode on, then send `<task>` as a normal prompt. If the turn completes normally, swarm mode turns off automatically. In `manual` permission mode, Kimi Code asks whether to switch to `auto` or `yolo` before starting. | No |
 | `/goal [...]` | — | Start or manage an autonomous goal | See below |
 
 ::: warning

--- a/docs/zh/reference/slash-commands.md
+++ b/docs/zh/reference/slash-commands.md
@@ -46,7 +46,7 @@
 | `/plan [on\|off]` | — | 切换 Plan 模式。不带参数时翻转；显式传 `on`/`off` 时强制设置。单纯切换不会创建空计划文件 | 是 |
 | `/plan clear` | — | 清除当前 plan 方案 | 否 |
 | `/swarm on\|off` | — | 开启或关闭 swarm mode，但不发送提示词。 | 是 |
-| `/swarm <task>` | — | 先开启 swarm mode，再把 `<task>` 作为普通提示词发送。如果该轮次正常完成，swarm mode 会自动关闭。若当前是 `manual` 权限模式，启动前会提示是否切换到 `auto`。 | 否 |
+| `/swarm <task>` | — | 先开启 swarm mode，再把 `<task>` 作为普通提示词发送。如果该轮次正常完成，swarm mode 会自动关闭。若当前是 `manual` 权限模式，启动前会提示是否切换到 `auto` 或 `yolo`。 | 否 |
 | `/goal [...]` | — | 开始或管理目标模式 | 见下文 |
 
 ::: warning 注意


### PR DESCRIPTION
## Related Issue

No linked issue. This PR addresses a small TUI permission-choice gap for `/swarm`.

## Problem

When starting a swarm task from `manual` permission mode, the prompt let users switch to `auto` or stay in `manual`, but it did not offer `yolo`. That made swarm startup inconsistent with the available permission modes and forced users to switch modes separately when they wanted tool approvals skipped while still allowing questions.

## What changed

Added a YOLO choice to the swarm start permission prompt, wired that choice to set the session permission mode before enabling swarm mode, and covered the new flow in `/swarm` command tests. The slash-command reference docs were updated in English and Chinese, and a patch changeset was added for the CLI package.

Verification:

- `pnpm --filter @moonshot-ai/kimi-code test -- --run test/tui/commands/swarm.test.ts`
- `pnpm exec oxlint --type-aware apps/kimi-code/src/tui/components/dialogs/swarm-start-permission-prompt.ts apps/kimi-code/src/tui/commands/swarm.ts apps/kimi-code/test/tui/commands/swarm.test.ts`
- `pnpm --filter @moonshot-ai/kimi-code run typecheck`
- `pnpm -C docs run build`
- `git diff --check`

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.