### PR TITLE
fix: scope interactive agent requests

### DIFF
--- a/.changeset/steady-agent-scopes.md
+++ b/.changeset/steady-agent-scopes.md
@@ -1,0 +1,6 @@
+---
+"@moonshot-ai/kimi-code": patch
+"@moonshot-ai/kimi-code-sdk": patch
+---
+
+Prevent overlapping interactive agent requests from using the wrong active agent.

--- a/apps/kimi-code/src/tui/controllers/btw-panel.ts
+++ b/apps/kimi-code/src/tui/controllers/btw-panel.ts
@@ -191,14 +191,7 @@ export class BtwPanelController {
   }
 
   private withInteractiveAgent<T>(agentId: string, fn: () => Promise<T>): Promise<T> {
-    const previousAgentId = this.host.harness.interactiveAgentId;
-    this.host.harness.interactiveAgentId = agentId;
-    try {
-      // SDK RPC methods snapshot interactiveAgentId before their first await.
-      return fn();
-    } finally {
-      this.host.harness.interactiveAgentId = previousAgentId;
-    }
+    return this.host.harness.withInteractiveAgent(agentId, fn);
   }
 }
 

--- a/apps/kimi-code/src/tui/kimi-tui.ts
+++ b/apps/kimi-code/src/tui/kimi-tui.ts
@@ -838,10 +838,11 @@ export class KimiTUI {
   }
 
   sendQueuedMessage(session: Session, item: QueuedMessage): void {
-    this.harness.interactiveAgentId = item.agentId ?? MAIN_AGENT_ID;
-    this.sendMessageInternal(session, item.text, {
-      parts: item.parts,
-      imageAttachmentIds: item.imageAttachmentIds,
+    this.harness.withInteractiveAgent(item.agentId ?? MAIN_AGENT_ID, () => {
+      this.sendMessageInternal(session, item.text, {
+        parts: item.parts,
+        imageAttachmentIds: item.imageAttachmentIds,
+      });
     });
   }
 
@@ -1131,7 +1132,6 @@ export class KimiTUI {
     this.streamingUI.discardPending();
     this.state.queuedMessages = [];
     this.state.swarmModeEntry = undefined;
-    this.harness.interactiveAgentId = MAIN_AGENT_ID;
     this.streamingUI.resetToolCallState();
     this.streamingUI.resetToolUi();
     this.sessionEventHandler.resetRuntimeState();

--- a/apps/kimi-code/test/tui/kimi-tui-message-flow.test.ts
+++ b/apps/kimi-code/test/tui/kimi-tui-message-flow.test.ts
@@ -1,3 +1,4 @@
+import { AsyncLocalStorage } from 'node:async_hooks';
 import { mkdtemp, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -199,6 +200,7 @@ function makeSession(overrides: Record<string, unknown> = {}) {
 }
 
 function makeHarness(session = makeSession(), overrides: Record<string, unknown> = {}) {
+  const interactiveAgentScope = new AsyncLocalStorage<string>();
   return {
     getConfig: vi.fn(async () => ({
       models: {
@@ -213,7 +215,12 @@ function makeHarness(session = makeSession(), overrides: Record<string, unknown>
     close: vi.fn(async () => {}),
     track: vi.fn(),
     setTelemetryContext: vi.fn(),
-    interactiveAgentId: 'main',
+    get interactiveAgentId() {
+      return interactiveAgentScope.getStore() ?? 'main';
+    },
+    withInteractiveAgent: vi.fn((agentId: string, fn: () => unknown) => {
+      return interactiveAgentScope.run(agentId, fn);
+    }),
     getExperimentalFeatures: vi.fn(async () => []),
     auth: {
       status: vi.fn(),

--- a/apps/kimi-code/test/tui/message-replay.test.ts
+++ b/apps/kimi-code/test/tui/message-replay.test.ts
@@ -1,3 +1,5 @@
+import { AsyncLocalStorage } from 'node:async_hooks';
+
 import type {
   AgentReplayRecord,
   BackgroundTaskInfo,
@@ -197,6 +199,7 @@ function makeSession(
 }
 
 function makeHarness(initialSession: Session) {
+  const interactiveAgentScope = new AsyncLocalStorage<string>();
   return {
     getConfig: vi.fn(async () => ({
       models: {
@@ -212,7 +215,12 @@ function makeHarness(initialSession: Session) {
     track: vi.fn(),
     setTelemetryContext: vi.fn(),
     getExperimentalFeatures: vi.fn(async () => []),
-    interactiveAgentId: 'main',
+    get interactiveAgentId() {
+      return interactiveAgentScope.getStore() ?? 'main';
+    },
+    withInteractiveAgent: vi.fn((agentId: string, fn: () => unknown) => {
+      return interactiveAgentScope.run(agentId, fn);
+    }),
     auth: {
       status: vi.fn(),
       login: vi.fn(),

--- a/packages/node-sdk/src/kimi-harness.ts
+++ b/packages/node-sdk/src/kimi-harness.ts
@@ -72,8 +72,8 @@ export class KimiHarness {
     return this.rpc.interactiveAgentId;
   }
 
-  set interactiveAgentId(agentId: string) {
-    this.rpc.interactiveAgentId = agentId;
+  withInteractiveAgent<T>(agentId: string, fn: () => T): T {
+    return this.rpc.withInteractiveAgent(agentId, fn);
   }
 
   track(event: string, properties?: TelemetryProperties): void {

--- a/packages/node-sdk/src/rpc.ts
+++ b/packages/node-sdk/src/rpc.ts
@@ -1,3 +1,5 @@
+import { AsyncLocalStorage } from 'node:async_hooks';
+
 import {
   ErrorCodes,
   makeErrorPayload,
@@ -98,10 +100,18 @@ export interface ReconnectMcpServerRpcInput extends SessionIdRpcInput {
 type ResolvedCoreAPI = RPCMethods<CoreAPI>;
 
 export abstract class SDKRpcClientBase {
-  interactiveAgentId = MAIN_AGENT_ID;
+  private readonly interactiveAgentScope = new AsyncLocalStorage<string>();
   private readonly eventListeners = new Set<(event: Event) => void>();
   private readonly approvalHandlers = new Map<string, ApprovalHandler>();
   private readonly questionHandlers = new Map<string, QuestionHandler>();
+
+  get interactiveAgentId(): string {
+    return this.interactiveAgentScope.getStore() ?? MAIN_AGENT_ID;
+  }
+
+  withInteractiveAgent<T>(agentId: string, fn: () => T): T {
+    return this.interactiveAgentScope.run(agentId, fn);
+  }
 
   protected abstract getRpc(): Promise<ResolvedCoreAPI>;
 

--- a/packages/node-sdk/test/session-prompt-events.test.ts
+++ b/packages/node-sdk/test/session-prompt-events.test.ts
@@ -337,10 +337,12 @@ describe('Session.prompt events', () => {
       );
 
       const agentId = await session.startBtw();
-      harness.interactiveAgentId = agentId;
-      await session.prompt('What are you working on right now?');
+      await harness.withInteractiveAgent(agentId, () =>
+        session.prompt('What are you working on right now?'),
+      );
       await done;
       unsubscribe();
+      expect(harness.interactiveAgentId).toBe('main');
 
       const started = events.find(
         (event) =>

--- a/packages/node-sdk/test/session-prompt-input.test.ts
+++ b/packages/node-sdk/test/session-prompt-input.test.ts
@@ -1,7 +1,64 @@
 import { describe, expect, it, vi } from 'vitest';
+import type { CoreAPI, RPCMethods } from '@moonshot-ai/agent-core';
 
-import type { SDKRpcClientBase } from '../src/rpc';
+import { SDKRpcClientBase } from '../src/rpc';
 import { Session } from '../src/session';
+
+class CapturingRpc extends SDKRpcClientBase {
+  readonly promptCalls: unknown[] = [];
+  readonly enterPlanCalls: unknown[] = [];
+  readonly cancelPlanCalls: unknown[] = [];
+  readonly getPlanCalls: unknown[] = [];
+  readonly clearPlanCalls: unknown[] = [];
+  readonly setModelCalls: unknown[] = [];
+  private getRpcDelay: Promise<void> | undefined;
+  private getRpcCallCount = 0;
+  private readonly getRpcWaiters = new Set<() => void>();
+
+  delayGetRpcUntil(promise: Promise<void>): void {
+    this.getRpcDelay = promise;
+  }
+
+  waitForGetRpcCalls(count: number): Promise<void> {
+    if (this.getRpcCallCount >= count) return Promise.resolve();
+    return new Promise<void>((resolve) => {
+      const check = () => {
+        if (this.getRpcCallCount < count) return;
+        this.getRpcWaiters.delete(check);
+        resolve();
+      };
+      this.getRpcWaiters.add(check);
+    });
+  }
+
+  protected async getRpc(): Promise<RPCMethods<CoreAPI>> {
+    this.getRpcCallCount += 1;
+    for (const waiter of this.getRpcWaiters) waiter();
+    if (this.getRpcDelay !== undefined) await this.getRpcDelay;
+    return {
+      prompt: async (input: unknown) => {
+        this.promptCalls.push(input);
+      },
+      setModel: async (input: unknown) => {
+        this.setModelCalls.push(input);
+        return { model: 'captured-model' };
+      },
+      enterPlan: async (input: unknown) => {
+        this.enterPlanCalls.push(input);
+      },
+      cancelPlan: async (input: unknown) => {
+        this.cancelPlanCalls.push(input);
+      },
+      getPlan: async (input: unknown) => {
+        this.getPlanCalls.push(input);
+        return null;
+      },
+      clearPlan: async (input: unknown) => {
+        this.clearPlanCalls.push(input);
+      },
+    } as unknown as RPCMethods<CoreAPI>;
+  }
+}
 
 describe('Session.prompt input normalization', () => {
   it('passes multimodal prompt parts through to the core RPC client', async () => {
@@ -37,5 +94,68 @@ describe('Session.prompt input normalization', () => {
     expect(startBtw).toHaveBeenCalledWith({
       sessionId: 'ses_btw_start',
     });
+  });
+
+  it('scopes interactive agent id across awaited session operations', async () => {
+    const rpc = new CapturingRpc();
+    const session = new Session({
+      id: 'ses_scoped_agent',
+      workDir: '/tmp/work',
+      rpc,
+    });
+
+    await rpc.withInteractiveAgent('agent-btw', async () => {
+      await Promise.resolve();
+      await session.prompt('side question');
+      await session.setPlanMode(true);
+      await session.getPlan();
+      await session.clearPlan();
+      await session.setPlanMode(false);
+      expect(rpc.interactiveAgentId).toBe('agent-btw');
+    });
+
+    expect(rpc.interactiveAgentId).toBe('main');
+    expect(rpc.promptCalls).toEqual([
+      {
+        sessionId: 'ses_scoped_agent',
+        agentId: 'agent-btw',
+        input: [{ type: 'text', text: 'side question' }],
+      },
+    ]);
+    expect(rpc.enterPlanCalls).toEqual([{ sessionId: 'ses_scoped_agent', agentId: 'agent-btw' }]);
+    expect(rpc.getPlanCalls).toEqual([{ sessionId: 'ses_scoped_agent', agentId: 'agent-btw' }]);
+    expect(rpc.clearPlanCalls).toEqual([{ sessionId: 'ses_scoped_agent', agentId: 'agent-btw' }]);
+    expect(rpc.cancelPlanCalls).toEqual([{ sessionId: 'ses_scoped_agent', agentId: 'agent-btw' }]);
+  });
+
+  it('isolates overlapping interactive agent scopes while RPC resolution is pending', async () => {
+    let releaseRpc!: () => void;
+    const getRpcDelay = new Promise<void>((resolve) => {
+      releaseRpc = resolve;
+    });
+    const rpc = new CapturingRpc();
+    rpc.delayGetRpcUntil(getRpcDelay);
+    const session = new Session({
+      id: 'ses_overlapping_agents',
+      workDir: '/tmp/work',
+      rpc,
+    });
+
+    const first = rpc.withInteractiveAgent('agent-a', () => session.setModel('model-a'));
+    const second = rpc.withInteractiveAgent('agent-b', () => session.setModel('model-b'));
+    await rpc.waitForGetRpcCalls(2);
+
+    expect(rpc.setModelCalls).toEqual([]);
+    releaseRpc();
+    await Promise.all([first, second]);
+
+    expect(rpc.interactiveAgentId).toBe('main');
+    expect(rpc.setModelCalls).toHaveLength(2);
+    expect(rpc.setModelCalls).toEqual(
+      expect.arrayContaining([
+        { sessionId: 'ses_overlapping_agents', agentId: 'agent-a', model: 'model-a' },
+        { sessionId: 'ses_overlapping_agents', agentId: 'agent-b', model: 'model-b' },
+      ]),
+    );
   });
 });


### PR DESCRIPTION
## Related Issue

No linked issue. This fixes a race where interactive agent selection could leak between overlapping async requests.

## Problem

Interactive requests used a mutable active agent id on the shared harness. When `/btw`, queued prompts, cancellation, or other session operations overlapped, one request could restore or overwrite the active agent id while another request was still resolving, sending the later RPC to the wrong agent.

## What changed

- Scoped interactive agent selection with async-local state in the SDK instead of mutating shared harness state.
- Updated `/btw` and queued-message flows to run their session operations inside the requested agent scope.
- Added regression coverage for awaited operations and overlapping scoped requests while RPC resolution is pending.
- Updated TUI test harnesses to model the same scoped behavior as the SDK.
- Added a patch changeset for the CLI and SDK packages.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.

## Verification

- `pnpm vitest run packages/node-sdk/test/session-prompt-input.test.ts packages/node-sdk/test/session-prompt-events.test.ts`
- `pnpm vitest run apps/kimi-code/test/tui/kimi-tui-message-flow.test.ts apps/kimi-code/test/tui/message-replay.test.ts`
- `pnpm --filter @moonshot-ai/kimi-code-sdk typecheck`
- `pnpm --filter @moonshot-ai/kimi-code typecheck`
