### PR TITLE
chore: remove pnpm catalog usage

### DIFF
--- a/packages/agent-core/package.json
+++ b/packages/agent-core/package.json
@@ -76,7 +76,7 @@
     "tar": "^7.5.13",
     "undici": "^7.27.1",
     "yauzl": "^3.3.0",
-    "zod": "catalog:"
+    "zod": "^4.3.6"
   },
   "devDependencies": {
     "@types/js-yaml": "^4.0.9",

--- a/packages/kosong/package.json
+++ b/packages/kosong/package.json
@@ -49,7 +49,7 @@
     "@anthropic-ai/sdk": "^0.95.2",
     "@google/genai": "^1.49.0",
     "openai": "^6.34.0",
-    "zod": "catalog:",
+    "zod": "^4.3.6",
     "zod-to-json-schema": "^3.25.2"
   },
   "devDependencies": {

--- a/packages/migration-legacy/package.json
+++ b/packages/migration-legacy/package.json
@@ -29,7 +29,7 @@
   "dependencies": {
     "@moonshot-ai/agent-core": "workspace:^",
     "smol-toml": "^1.6.1",
-    "zod": "catalog:"
+    "zod": "^4.3.6"
   },
   "devDependencies": {
     "@moonshot-ai/kaos": "workspace:^"

--- a/packages/node-sdk/package.json
+++ b/packages/node-sdk/package.json
@@ -59,7 +59,7 @@
     "@antfu/utils": "^9.3.0",
     "smol-toml": "^1.6.1",
     "yazl": "^3.3.1",
-    "zod": "catalog:"
+    "zod": "^4.3.6"
   },
   "devDependencies": {
     "@moonshot-ai/agent-core": "workspace:^",

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -34,6 +34,6 @@
   },
   "dependencies": {
     "ulid": "^3.0.1",
-    "zod": "catalog:"
+    "zod": "^4.3.6"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,12 +4,6 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
-catalogs:
-  default:
-    zod:
-      specifier: ^4.3.6
-      version: 4.3.6
-
 overrides:
   ssh2@1.17.0>cpu-features: '-'
   ssh2@1.17.0>nan: '-'
@@ -296,7 +290,7 @@ importers:
         specifier: ^3.3.0
         version: 3.3.0
       zod:
-        specifier: 'catalog:'
+        specifier: ^4.3.6
         version: 4.3.6
     devDependencies:
       '@types/js-yaml':
@@ -355,7 +349,7 @@ importers:
         specifier: ^6.34.0
         version: 6.34.0(ws@8.20.0)(zod@4.3.6)
       zod:
-        specifier: 'catalog:'
+        specifier: ^4.3.6
         version: 4.3.6
       zod-to-json-schema:
         specifier: ^3.25.2
@@ -377,7 +371,7 @@ importers:
         specifier: ^1.6.1
         version: 1.6.1
       zod:
-        specifier: 'catalog:'
+        specifier: ^4.3.6
         version: 4.3.6
     devDependencies:
       '@moonshot-ai/kaos':
@@ -396,7 +390,7 @@ importers:
         specifier: ^3.3.1
         version: 3.3.1
       zod:
-        specifier: 'catalog:'
+        specifier: ^4.3.6
         version: 4.3.6
     devDependencies:
       '@moonshot-ai/agent-core':
@@ -431,7 +425,7 @@ importers:
         specifier: ^3.0.1
         version: 3.0.2
       zod:
-        specifier: 'catalog:'
+        specifier: ^4.3.6
         version: 4.3.6
 
   packages/telemetry: {}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -5,9 +5,6 @@ packages:
   - apps/vis/web
   - docs
 
-catalog:
-  zod: ^4.3.6
-
 overrides:
   "ssh2@1.17.0>cpu-features": "-"
   "ssh2@1.17.0>nan": "-"


### PR DESCRIPTION
## Related Issue

No linked issue. This PR addresses the package manager metadata needed for Mira to consume this repository as a Git submodule.

## Problem

Mira imports this repository through a submodule, where keeping dependency manifests simple and explicit avoids relying on pnpm catalog metadata from the embedded workspace. The rest of the workspace packages already use normal dependency specifiers rather than pnpm catalog entries. `zod` was the remaining dependency routed through the catalog, so keeping it there made it inconsistent with the surrounding package manifests and less convenient for the submodule use case.

## What changed

Removed the workspace-level pnpm `catalog` entry for `zod`, replaced the remaining `"catalog:"` zod dependency declarations with the explicit `^4.3.6` range, and regenerated `pnpm-lock.yaml` so importer specifiers match the package manifests. The resolved zod version stays at `4.3.6`; this only removes the catalog indirection.

## Verification

- `pnpm install --lockfile-only`
- `pnpm install --lockfile-only --frozen-lockfile`
- `git diff --check`
- Searched for remaining pnpm `catalog:` / `catalogs:` syntax
- Read-only diff audit found no newly introduced internal identifiers or credentials

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] No tests added; this only changes package manager metadata and lockfile specifiers.
- [x] This PR needs no changeset per maintainer request.
- [x] This PR needs no doc update.