### PR TITLE
feat(vis): expose app_version in wire.jsonl metadata for debug

### DIFF
--- a/.changeset/wire-app-version.md
+++ b/.changeset/wire-app-version.md
@@ -1,0 +1,7 @@
+---
+"@moonshot-ai/agent-core": patch
+---
+
+feat(vis): expose app_version in wire.jsonl metadata for debug
+
+Add app_version to wire.jsonl metadata for easier debugging.

--- a/apps/vis/server/src/lib/agent-record-types.ts
+++ b/apps/vis/server/src/lib/agent-record-types.ts
@@ -101,7 +101,7 @@ export interface WireResponse {
   sessionId: string;
   agentId: string;
   protocolVersion: string;
-  metadata: { protocolVersion: string; createdAt: number };
+  metadata: { protocolVersion: string; createdAt: number; appVersion?: string };
   records: readonly WireEntry[];
   warnings: string[];
 }

--- a/apps/vis/server/src/lib/wire-reader.ts
+++ b/apps/vis/server/src/lib/wire-reader.ts
@@ -10,7 +10,7 @@ import {
 import type { AgentRecord, WireEntry } from './agent-record-types';
 
 export interface WireReadResult {
-  metadata: { protocolVersion: string; createdAt: number };
+  metadata: { protocolVersion: string; createdAt: number; appVersion?: string };
   records: ReadonlyArray<WireEntry>;
   warnings: string[];
 }
@@ -66,6 +66,7 @@ export async function readAgentWire(path: string): Promise<WireReadResult> {
       }
       const pv = parsed['protocol_version'];
       const ca = parsed['created_at'];
+      const av = parsed['app_version'];
       if (typeof pv !== 'string' || typeof ca !== 'number') {
         throw new TypeError(`Wire metadata malformed at line ${lineNo}`);
       }
@@ -77,7 +78,7 @@ export async function readAgentWire(path: string): Promise<WireReadResult> {
         );
         migrations = bestEffortMigrations();
       }
-      metadata = { protocolVersion: pv, createdAt: ca };
+      metadata = { protocolVersion: pv, createdAt: ca, appVersion: typeof av === 'string' ? av : undefined };
       continue;
     }
     const raw = parsed as Record<string, unknown>;

--- a/apps/vis/server/test/fixtures/sessions/sample-main/agents/agent-0/wire.jsonl
+++ b/apps/vis/server/test/fixtures/sessions/sample-main/agents/agent-0/wire.jsonl
@@ -1,2 +1,2 @@
-{"type":"metadata","protocol_version":"1.1","created_at":1779256900000}
+{"type":"metadata","protocol_version":"1.1","created_at":1779256900000,"app_version":"1.2.3"}
 {"type":"config.update","cwd":"/tmp/work","profileName":"sub","systemPrompt":"You are a sub-agent.","time":1779256900001}

--- a/apps/vis/server/test/fixtures/sessions/sample-main/agents/main/wire.jsonl
+++ b/apps/vis/server/test/fixtures/sessions/sample-main/agents/main/wire.jsonl
@@ -1,4 +1,4 @@
-{"type":"metadata","protocol_version":"1.1","created_at":1779256791085}
+{"type":"metadata","protocol_version":"1.1","created_at":1779256791085,"app_version":"1.2.3"}
 {"type":"config.update","cwd":"/tmp/work","profileName":"agent","systemPrompt":"You are Kimi.","time":1779256791100}
 {"type":"tools.set_active_tools","names":["Read","Write"],"time":1779256791101}
 {"type":"permission.set_mode","mode":"manual","time":1779256791102}

--- a/apps/vis/server/test/lib/wire-reader.test.ts
+++ b/apps/vis/server/test/lib/wire-reader.test.ts
@@ -17,6 +17,7 @@ describe('wire-reader', () => {
     cleanup = c;
     const result = await readAgentWire(join(sessionDir, 'agents', 'main', 'wire.jsonl'));
     expect(result.metadata.protocolVersion).toBe('1.1');
+    expect(result.metadata.appVersion).toBe('1.2.3');
     expect(result.records[0]!.lineNo).toBe(2); // metadata is line 1, first record is line 2
     expect(result.records.at(-1)!.lineNo).toBe(10);
     expect(result.records.map((r) => r.data.type)).toEqual([


### PR DESCRIPTION
## Problem

wire.jsonl metadata already contains `app_version` written by agent-core, but the vis server's wire reader ignores it. This makes version debugging impossible from the vis UI — when investigating issues, we can't tell which kimi-code CLI version produced a given wire file.

## Solution

1. **WireReader** reads `app_version` from the metadata record and exposes it in the returned metadata
2. **WireResponse** type updated to include optional `appVersion` field
3. **Test fixtures** updated with `app_version` for validation
4. **Tests** verify `appVersion` is correctly parsed

## Technical Choice

Minimal surface change: only the vis server's read path is modified. The write path in agent-core already emits `app_version` when `appVersion` is available (populated from CLI package.json via `identity.version`). This fix bridges the gap between what's written and what's readable.

## Changes

- `apps/vis/server/src/lib/wire-reader.ts` — read `app_version` from metadata
- `apps/vis/server/src/lib/agent-record-types.ts` — add `appVersion` to WireResponse metadata
- `apps/vis/server/test/fixtures/...` — add `app_version` to fixture metadata
- `apps/vis/server/test/lib/wire-reader.test.ts` — assert `appVersion` is parsed

## Test

- All 46 vis-server tests pass ✓
- 4 wire-reader tests pass including new `appVersion` assertion ✓