### PR TITLE
fix(agent-core): relax directory skill frontmatter requirements to prevent silent skipping

### DIFF
--- a/.changeset/relax-skill-frontmatter-requirements.md
+++ b/.changeset/relax-skill-frontmatter-requirements.md
@@ -1,0 +1,6 @@
+---
+"@moonshot-ai/agent-core": patch
+"@moonshot-ai/kimi-code": patch
+---
+
+Fix silent skipping of user skills with missing frontmatter name or description by falling back to the directory name and body text.

--- a/packages/agent-core/src/profile/default/system.md
+++ b/packages/agent-core/src/profile/default/system.md
@@ -152,6 +152,25 @@ Identify the skills that are likely to be useful for the tasks you are currently
 
 Only read skill details when needed to conserve the context window.
 
+## Skill format
+
+A directory skill (e.g. `my-skill/SKILL.md`) may begin with an optional YAML frontmatter block:
+
+```yaml
+---
+name: my-skill
+description: What this skill does and when to use it.
+type: prompt
+whenToUse: When the user asks for ...
+---
+```
+
+- `name` defaults to the directory name if omitted.
+- `description` defaults to the first non-empty line of the body if omitted.
+- `type` defaults to `prompt`; other valid values are `inline` and `flow`.
+- `whenToUse` helps the model decide when to invoke the skill automatically.
+- `disableModelInvocation: true` prevents the model from auto-invoking the skill.
+
 # Ultimate Reminders
 
 At any time, you should be HELPFUL, CONCISE, and ACCURATE. Be thorough in your actions — test what you build, verify what you change — not in your explanations.

--- a/packages/agent-core/src/skill/parser.ts
+++ b/packages/agent-core/src/skill/parser.ts
@@ -105,11 +105,6 @@ export function parseFrontmatter(text: string): ParsedFrontmatter {
 }
 
 export function parseSkillText(options: ParseSkillTextOptions): SkillDefinition {
-  const isDirectorySkill = path.basename(options.skillMdPath) === 'SKILL.md';
-  if (isDirectorySkill && options.text.split(/\r?\n/, 1)[0]?.trim() !== FENCE) {
-    throw new SkillParseError(`Missing frontmatter in ${options.skillMdPath}`);
-  }
-
   let parsed;
   try {
     parsed = parseFrontmatter(options.text);
@@ -137,12 +132,6 @@ export function parseSkillText(options: ParseSkillTextOptions): SkillDefinition 
 
   const name = nonEmptyString(metadata.name);
   const description = nonEmptyString(metadata.description);
-  if (isDirectorySkill && (name === undefined || description === undefined)) {
-    const field = name === undefined ? '"name"' : '"description"';
-    throw new SkillParseError(
-      `Missing required frontmatter field ${field} in ${options.skillMdPath}`,
-    );
-  }
 
   const skillPath = path.resolve(options.skillMdPath);
   const content = parsed.body.trim();

--- a/packages/agent-core/test/skill/scanner.test.ts
+++ b/packages/agent-core/test/skill/scanner.test.ts
@@ -145,7 +145,7 @@ describe('skill discovery', () => {
     expect(registry.listInvocableSkills()).toEqual([]);
   });
 
-  it('skips directory skills with missing frontmatter metadata', async () => {
+  it('falls back to directory name and body for missing directory skill metadata', async () => {
     const { repoDir } = await makeWorkspace();
     const projectRoot = path.join(repoDir, '.kimi-code', 'skills');
     await writeSkill(projectRoot, path.join('valid', 'SKILL.md'), [
@@ -182,11 +182,20 @@ describe('skill discovery', () => {
       onWarning: (message) => warnings.push(message),
     });
 
-    expect(skills.map((skill) => skill.name)).toEqual(['valid']);
-    expect(warnings).toHaveLength(3);
-    expect(warnings.some((message) => message.includes('Missing frontmatter'))).toBe(true);
-    expect(warnings.some((message) => message.includes('"name"'))).toBe(true);
-    expect(warnings.some((message) => message.includes('"description"'))).toBe(true);
+    const names = skills.map((skill) => skill.name).sort();
+    expect(names).toEqual([
+      'missing-description',
+      'missing-name',
+      'no-frontmatter',
+      'valid',
+    ]);
+    expect(warnings).toHaveLength(0);
+
+    const missingNameSkill = skills.find((s) => s.name === 'missing-name');
+    expect(missingNameSkill?.description).toBe('Missing name');
+
+    const noFrontmatterSkill = skills.find((s) => s.name === 'no-frontmatter');
+    expect(noFrontmatterSkill?.description).toBe('# Heading should not become a description');
   });
 });
 


### PR DESCRIPTION
## Related Issue

Closes #580

## Problem

Kimi Code CLI creates a vicious cycle: the system prompt template does not explain the `SKILL.md` format, so the agent writes invalid skills for users, which are then silently discarded by the parser.

### Root cause

`packages/agent-core/src/skill/parser.ts` enforced two strict checks on directory skills:

1. Directory skills **must** start with a YAML frontmatter block (`---`).
2. The frontmatter **must** contain both `name` and `description`.

If either check fails, a `SkillParseError` is thrown and caught in `scanner.ts`, where it is logged as a warning and the skill is skipped entirely. Users receive no visible feedback that their skills were ignored.

This is especially problematic because the code already contains fallback logic (`name ?? skillDirName`, `description ?? firstBodyLine`) that was unreachable due to the early `throw`.

### Secondary cause

The system prompt template (`system.md`) does not mention frontmatter, required fields, or the directory-vs-flat distinction, so agents helping users write skills have no authoritative source for the correct format.

## What changed

1. **`parser.ts`**: Removed the strict frontmatter `name`/`description` requirements for directory skills. The existing fallback logic now works as intended: missing `name` falls back to the directory name, missing `description` falls back to the first non-empty body line.
2. **`system.md`**: Added a "Skill format" section to the system prompt template that explains the optional YAML frontmatter block and its fields, so agents can author valid skills for users.
3. **`scanner.test.ts`**: Updated the test that previously asserted skills were skipped; it now verifies the fallback behavior.
4. **Changeset**: Generated `.changeset/relax-skill-frontmatter-requirements.md` with `patch` bumps for both `@moonshot-ai/agent-core` and `@moonshot-ai/kimi-code`.

## Checklist

- [x] I have read the CONTRIBUTING document.
- [x] I have explained the problem above.
- [x] I have added tests that prove the fix works.
- [x] Ran `gen-changesets` skill.
