### PR TITLE
fix: cancel active turns during session shutdown

### DIFF
--- a/.changeset/cancel-active-turns-on-close.md
+++ b/.changeset/cancel-active-turns-on-close.md
@@ -1,0 +1,6 @@
+---
+"@moonshot-ai/agent-core": patch
+"@moonshot-ai/kimi-code": patch
+---
+
+Cancel active turns during session shutdown so foreground shell commands do not outlive prompt-mode exits.

--- a/apps/kimi-code/src/cli/run-prompt.ts
+++ b/apps/kimi-code/src/cli/run-prompt.ts
@@ -353,16 +353,21 @@ function installPromptTerminationCleanup(
   };
   const onSigint = () => exitAfterCleanup('SIGINT');
   const onSigterm = () => exitAfterCleanup('SIGTERM');
+  const onSighup = () => exitAfterCleanup('SIGHUP');
   promptProcess.once('SIGINT', onSigint);
   promptProcess.once('SIGTERM', onSigterm);
+  promptProcess.once('SIGHUP', onSighup);
   return () => {
     promptProcess.off('SIGINT', onSigint);
     promptProcess.off('SIGTERM', onSigterm);
+    promptProcess.off('SIGHUP', onSighup);
   };
 }
 
 function signalExitCode(signal: NodeJS.Signals): number {
-  return signal === 'SIGINT' ? 130 : 143;
+  if (signal === 'SIGINT') return 130;
+  if (signal === 'SIGHUP') return 129;
+  return 143;
 }
 
 function runPromptTurn(

--- a/apps/kimi-code/test/cli/run-prompt.test.ts
+++ b/apps/kimi-code/test/cli/run-prompt.test.ts
@@ -656,6 +656,47 @@ describe('runPrompt', () => {
     expect(mocks.harnessClose).toHaveBeenCalledTimes(1);
   });
 
+  it.each([
+    ['SIGTERM' as NodeJS.Signals, 143],
+    ['SIGHUP' as NodeJS.Signals, 129],
+  ])('cleans up prompt mode before exiting on %s', async (signal, exitCode) => {
+    let releasePrompt!: () => void;
+    mocks.session.prompt.mockImplementationOnce(async () => {
+      for (const handler of mocks.eventHandlers) {
+        handler(
+          mocks.mainEvent({ type: 'turn.started', turnId: 7, origin: { kind: 'user' } }),
+        );
+      }
+      await new Promise<void>((resolve) => {
+        releasePrompt = resolve;
+      });
+    });
+    const processMock = fakeProcess();
+    const run = runPrompt(opts(), '1.2.3-test', {
+      stdout: { write: vi.fn(() => true) },
+      stderr: { write: vi.fn(() => true) },
+      process: processMock,
+    } as Parameters<typeof runPrompt>[2] & { process: ReturnType<typeof fakeProcess> });
+
+    await waitForAssertion(() => {
+      expect(processMock.listener(signal)).toBeDefined();
+    });
+
+    await processMock.listener(signal)?.();
+
+    expect(mocks.shutdownTelemetry).toHaveBeenCalled();
+    expect(mocks.harnessClose).toHaveBeenCalled();
+    expect(processMock.exit).toHaveBeenCalledWith(exitCode);
+
+    for (const handler of mocks.eventHandlers) {
+      handler(mocks.mainEvent({ type: 'turn.ended', turnId: 7, reason: 'completed' }));
+    }
+    releasePrompt();
+    await run;
+
+    expect(mocks.harnessClose).toHaveBeenCalledTimes(1);
+  });
+
   it('waits for the pending auto permission write before signal restore', async () => {
     let releaseAutoPermission!: () => void;
     let releasePrompt!: () => void;

--- a/packages/agent-core/src/session/index.ts
+++ b/packages/agent-core/src/session/index.ts
@@ -40,6 +40,7 @@ import { noopTelemetryClient, type TelemetryClient } from '../telemetry';
 import { SessionSubagentHost } from './subagent-host';
 import type { ToolServices } from '../tools/support/services';
 import { FlagResolver, type ExperimentalFlagResolver } from '../flags';
+import { abortError } from '../utils/abort';
 
 export interface SessionOptions {
   readonly kaos: Kaos;
@@ -287,9 +288,25 @@ export class Session {
   }
 
   private async cancelActiveTurnsOnClose(): Promise<void> {
-    await Promise.allSettled(
-      Array.from(this.readyAgents(), (agent) => this.cancelAgentTurnOnClose(agent)),
-    );
+    const backgroundAgentIds = this.activeBackgroundAgentIds();
+    const cancellations: Array<Promise<void>> = [];
+    for (const [agentId, entry] of this.agents) {
+      if (!(entry instanceof Agent) || backgroundAgentIds.has(agentId)) continue;
+      cancellations.push(this.cancelAgentTurnOnClose(entry));
+    }
+    await Promise.allSettled(cancellations);
+  }
+
+  private activeBackgroundAgentIds(): Set<string> {
+    const agentIds = new Set<string>();
+    for (const agent of this.readyAgents()) {
+      for (const task of agent.background.list(true)) {
+        if (task.kind === 'agent' && task.agentId !== undefined) {
+          agentIds.add(task.agentId);
+        }
+      }
+    }
+    return agentIds;
   }
 
   private async cancelAgentTurnOnClose(agent: Agent): Promise<void> {
@@ -307,7 +324,7 @@ export class Session {
       return;
     }
 
-    agent.turn.cancel(undefined, new Error('Session closed'));
+    agent.turn.cancel(undefined, abortError('Session closed'));
     const settled = await waitForSettlementOrTimeout(waitForTurn, ACTIVE_TURN_CLOSE_TIMEOUT_MS);
     if (!settled) {
       this.log.warn('timed out waiting for active turn to cancel during session close', {

--- a/packages/agent-core/src/session/index.ts
+++ b/packages/agent-core/src/session/index.ts
@@ -107,6 +107,32 @@ export interface SessionMeta {
 }
 
 const BACKGROUND_KEEP_ALIVE_ON_EXIT_ENV = 'KIMI_CODE_BACKGROUND_KEEP_ALIVE_ON_EXIT';
+const ACTIVE_TURN_CLOSE_TIMEOUT_MS = 8_000;
+
+async function waitForSettlementOrTimeout(
+  promise: Promise<unknown>,
+  timeoutMs: number,
+): Promise<boolean> {
+  let timeout: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      promise.then(
+        () => true,
+        () => true,
+      ),
+      new Promise<false>((resolve) => {
+        timeout = setTimeout(() => {
+          resolve(false);
+        }, timeoutMs);
+        timeout.unref?.();
+      }),
+    ]);
+  } finally {
+    if (timeout !== undefined) {
+      clearTimeout(timeout);
+    }
+  }
+}
 
 export class Session {
   readonly rpc: SDKSessionRPC;
@@ -232,6 +258,7 @@ export class Session {
       await Promise.allSettled(
         Array.from(this.readyAgents(), async (agent) => agent.cron?.stop()),
       );
+      await this.cancelActiveTurnsOnClose();
       await this.stopBackgroundTasksOnExit();
       await this.flushMetadata();
       await this.triggerSessionEnd('exit');
@@ -256,6 +283,38 @@ export class Session {
       } finally {
         await this.logHandle?.close();
       }
+    }
+  }
+
+  private async cancelActiveTurnsOnClose(): Promise<void> {
+    await Promise.allSettled(
+      Array.from(this.readyAgents(), (agent) => this.cancelAgentTurnOnClose(agent)),
+    );
+  }
+
+  private async cancelAgentTurnOnClose(agent: Agent): Promise<void> {
+    if (!agent.turn.hasActiveTurn) return;
+
+    let waitForTurn: Promise<unknown>;
+    try {
+      waitForTurn = agent.turn.waitForCurrentTurn();
+    } catch (error: unknown) {
+      this.log.debug('active turn wait unavailable during session close', {
+        agentType: agent.type,
+        agentHomedir: agent.homedir,
+        error,
+      });
+      return;
+    }
+
+    agent.turn.cancel(undefined, new Error('Session closed'));
+    const settled = await waitForSettlementOrTimeout(waitForTurn, ACTIVE_TURN_CLOSE_TIMEOUT_MS);
+    if (!settled) {
+      this.log.warn('timed out waiting for active turn to cancel during session close', {
+        agentType: agent.type,
+        agentHomedir: agent.homedir,
+        timeoutMs: ACTIVE_TURN_CLOSE_TIMEOUT_MS,
+      });
     }
   }
 

--- a/packages/agent-core/src/tools/builtin/shell/bash.ts
+++ b/packages/agent-core/src/tools/builtin/shell/bash.ts
@@ -405,7 +405,7 @@ export class BashTool implements BuiltinTool<BashInput> {
     }
 
     if (timeoutMs !== undefined) {
-      setTimeout(() => {
+      const timeoutHandle = setTimeout(() => {
         void (async (): Promise<void> => {
           if (proc.exitCode !== null) return;
           const info = backgroundManager.getTask(taskId);
@@ -414,6 +414,7 @@ export class BashTool implements BuiltinTool<BashInput> {
           }
         })();
       }, timeoutMs);
+      timeoutHandle.unref?.();
     }
 
     // registerTask() synchronously inserts taskId into the manager's Map, so

--- a/packages/agent-core/src/utils/abort.ts
+++ b/packages/agent-core/src/utils/abort.ts
@@ -1,5 +1,5 @@
-export function abortError(): Error {
-  const error = new Error('Aborted');
+export function abortError(message = 'Aborted'): Error {
+  const error = new Error(message);
   error.name = 'AbortError';
   return error;
 }

--- a/packages/agent-core/test/session/lifecycle-hooks.test.ts
+++ b/packages/agent-core/test/session/lifecycle-hooks.test.ts
@@ -11,7 +11,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import type { SDKSessionRPC } from '../../src/rpc';
 import { Session } from '../../src/session';
-import { ProcessBackgroundTask } from '../../src/agent/background';
+import { AgentBackgroundTask, ProcessBackgroundTask } from '../../src/agent/background';
 
 
 const tempDirs: string[] = [];
@@ -153,6 +153,46 @@ describe('Session lifecycle hooks', () => {
     expect(agent.background.getTask(taskId)?.status).toBe('running');
   });
 
+  it('keeps background agent turns alive on close when keepAliveOnExit is true', async () => {
+    const { sessionDir, workDir } = await hookFixture();
+    const session = new Session({
+      kaos: testKaos.withCwd(workDir),
+      id: 'session-bg-agent-keepalive',
+      homedir: sessionDir,
+      rpc: createSessionRpc(),
+      skills: { explicitDirs: [join(workDir, 'missing-skills')] },
+      background: { keepAliveOnExit: true },
+    });
+    const main = await session.createMain();
+    const { id: childId, agent: child } = await session.createAgent(
+      { type: 'sub' },
+      { parentAgentId: 'main' },
+    );
+    const turnSettled = createDeferred<void>();
+    const waitSpy = vi
+      .spyOn(child.turn, 'waitForCurrentTurn')
+      .mockImplementation(() => turnSettled.promise as never);
+    const cancelSpy = vi.spyOn(child.turn, 'cancel').mockImplementation(() => {
+      turnSettled.resolve();
+    });
+    vi.spyOn(child.turn, 'hasActiveTurn', 'get').mockReturnValue(true);
+    const abort = vi.fn();
+    const taskId = main.background.registerTask(
+      new AgentBackgroundTask(new Promise(() => {}), 'keep background agent alive', {
+        abort,
+        agentId: childId,
+        subagentType: 'coder',
+      }),
+    );
+
+    await session.close();
+
+    expect(cancelSpy).not.toHaveBeenCalled();
+    expect(waitSpy).not.toHaveBeenCalled();
+    expect(abort).not.toHaveBeenCalled();
+    expect(main.background.getTask(taskId)?.status).toBe('running');
+  });
+
   it('lets the environment override config when deciding background task cleanup', async () => {
     vi.stubEnv('KIMI_CODE_BACKGROUND_KEEP_ALIVE_ON_EXIT', '0');
     const { sessionDir, workDir } = await hookFixture();
@@ -199,6 +239,56 @@ describe('Session lifecycle hooks', () => {
 
     expect(cancelSpy).toHaveBeenCalledWith(undefined, expect.any(Error));
     expect(waitSpy).toHaveBeenCalledOnce();
+  });
+
+  it('records session-close cancellation during UserPromptSubmit hooks as cancelled', async () => {
+    const { sessionDir, workDir } = await hookFixture();
+    const hookStartedPath = join(workDir, 'hook-started');
+    const hookScriptPath = join(workDir, 'blocking-user-prompt-hook.cjs');
+    await writeFile(
+      hookScriptPath,
+      [
+        "const { writeFileSync } = require('node:fs');",
+        "writeFileSync(process.argv[2], 'started');",
+        'setInterval(() => {}, 1000);',
+        '',
+      ].join('\n'),
+      'utf-8',
+    );
+    const emitEvent = vi.fn<SDKSessionRPC['emitEvent']>(async () => {});
+    const session = new Session({
+      kaos: testKaos.withCwd(workDir),
+      id: 'session-close-during-user-hook',
+      homedir: sessionDir,
+      rpc: createSessionRpc({ emitEvent }),
+      skills: { explicitDirs: [join(workDir, 'missing-skills')] },
+      hooks: [
+        {
+          event: 'UserPromptSubmit',
+          command: `node ${JSON.stringify(hookScriptPath)} ${JSON.stringify(hookStartedPath)}`,
+          timeout: 30,
+        },
+      ],
+    });
+    const agent = await session.createMain();
+
+    agent.turn.prompt([{ type: 'text', text: 'run the hook' }]);
+    await waitForFile(hookStartedPath);
+    await session.close();
+
+    const events = emitEvent.mock.calls.map(([event]) => event);
+    expect(events).toContainEqual(
+      expect.objectContaining({
+        type: 'turn.ended',
+        reason: 'cancelled',
+      }),
+    );
+    expect(events).not.toContainEqual(
+      expect.objectContaining({
+        type: 'turn.ended',
+        reason: 'failed',
+      }),
+    );
   });
 
   it('keeps background tasks alive and skips SessionEnd hooks when closing for reload', async () => {
@@ -285,7 +375,7 @@ async function readHookPayloads(path: string): Promise<readonly Record<string, u
     .map((line) => JSON.parse(line) as Record<string, unknown>);
 }
 
-function createSessionRpc(): SDKSessionRPC {
+function createSessionRpc(overrides: Partial<SDKSessionRPC> = {}): SDKSessionRPC {
   return {
     emitEvent: vi.fn(async () => {}),
     requestApproval: vi.fn(async () => ({ decision: 'cancelled' })),
@@ -294,7 +384,22 @@ function createSessionRpc(): SDKSessionRPC {
       output: 'custom tools are not supported in this test',
       isError: true,
     })),
+    ...overrides,
   } as SDKSessionRPC;
+}
+
+async function waitForFile(path: string): Promise<void> {
+  let lastError: unknown;
+  for (let attempt = 0; attempt < 50; attempt += 1) {
+    try {
+      await readFile(path, 'utf-8');
+      return;
+    } catch (error) {
+      lastError = error;
+      await new Promise((resolve) => setTimeout(resolve, 10));
+    }
+  }
+  throw lastError;
 }
 
 function createDeferred<T>(): {

--- a/packages/agent-core/test/session/lifecycle-hooks.test.ts
+++ b/packages/agent-core/test/session/lifecycle-hooks.test.ts
@@ -176,6 +176,31 @@ describe('Session lifecycle hooks', () => {
     expect(agent.background.getTask(taskId)?.status).toBe('killed');
   });
 
+  it('cancels an active foreground turn before closing', async () => {
+    const { sessionDir, workDir } = await hookFixture();
+    const session = new Session({
+      kaos: testKaos.withCwd(workDir),
+      id: 'session-active-turn-cleanup',
+      homedir: sessionDir,
+      rpc: createSessionRpc(),
+      skills: { explicitDirs: [join(workDir, 'missing-skills')] },
+    });
+    const agent = await session.createMain();
+    const turnSettled = createDeferred<void>();
+    const waitSpy = vi
+      .spyOn(agent.turn, 'waitForCurrentTurn')
+      .mockImplementation(() => turnSettled.promise as never);
+    const cancelSpy = vi.spyOn(agent.turn, 'cancel').mockImplementation(() => {
+      turnSettled.resolve();
+    });
+    vi.spyOn(agent.turn, 'hasActiveTurn', 'get').mockReturnValue(true);
+
+    await session.close();
+
+    expect(cancelSpy).toHaveBeenCalledWith(undefined, expect.any(Error));
+    expect(waitSpy).toHaveBeenCalledOnce();
+  });
+
   it('keeps background tasks alive and skips SessionEnd hooks when closing for reload', async () => {
     const { command, logPath, sessionDir, workDir } = await hookFixture();
     const session = new Session({
@@ -270,6 +295,22 @@ function createSessionRpc(): SDKSessionRPC {
       isError: true,
     })),
   } as SDKSessionRPC;
+}
+
+function createDeferred<T>(): {
+  readonly promise: Promise<T>;
+  resolve(value: T): void;
+} {
+  let resolveValue: (value: T) => void = () => {
+    /* replaced below */
+  };
+  const promise = new Promise<T>((resolve) => {
+    resolveValue = resolve;
+  });
+  return {
+    promise,
+    resolve: resolveValue,
+  };
 }
 
 function pendingProcess(exitOnKill = 143): {

--- a/packages/agent-core/test/utils/abort.test.ts
+++ b/packages/agent-core/test/utils/abort.test.ts
@@ -25,6 +25,13 @@ describe('userCancellationReason', () => {
     expect(isUserCancellation(new Error('boom'))).toBe(false);
     expect(isUserCancellation(undefined)).toBe(false);
   });
+
+  it('keeps custom system abort messages classified as AbortError', () => {
+    expect(abortError('Session closed')).toMatchObject({
+      name: 'AbortError',
+      message: 'Session closed',
+    });
+  });
 });
 
 describe('abortable', () => {


### PR DESCRIPTION
## Related Issue

No linked issue. This fixes a prompt-mode shutdown regression where foreground Bash processes could outlive `kimi -p` when the CLI receives `SIGTERM` or `SIGHUP`.

## Problem

Prompt-mode signal cleanup closed the harness, but session shutdown only stopped managed background tasks. If a foreground Bash tool was still running, the active turn was not canceled during `Session.close()`, so the Bash tool never received the abort signal it uses to terminate the child process. Managed background Bash timeout timers also remained referenced, which could keep `kimi -p` alive after the prompt completed.

## What changed

- Cancel active turns during `Session.close()` before background-task shutdown, with a bounded wait and timeout warning.
- `unref()` managed background Bash timeout timers so they do not keep prompt mode alive.
- Handle `SIGHUP` in prompt-mode termination cleanup, matching standard signal exit code `129`.
- Add unit coverage for active turn cancellation and prompt-mode `SIGTERM`/`SIGHUP` cleanup.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.