### PR TITLE
feat: support always-thinking models via supports_thinking_type

### DIFF
--- a/apps/kimi-code/src/tui/components/dialogs/model-selector.ts
+++ b/apps/kimi-code/src/tui/components/dialogs/model-selector.ts
@@ -259,13 +259,19 @@ export class ModelSelectorComponent extends Container implements Focusable {
       active
         ? currentTheme.boldFg('primary', `[ ${label} ]`)
         : currentTheme.fg('text', `  ${label}  `);
+    // The whole segment is muted, suffix included, so the disabled side reads
+    // as a single greyed-out control rather than a selectable option.
+    const unavailable = (label: string): string =>
+      currentTheme.fg('textMuted', `  ${label} (Unsupported)  `);
 
+    // On stays left and Off right in all three states so the control never
+    // shifts while the cursor moves across models.
     const availability = thinkingAvailability(choice.model);
     if (availability === 'always-on') {
-      return `  ${segment('Always on', true)}`;
+      return `  ${segment('On', true)} ${unavailable('Off')}`;
     }
     if (availability === 'unsupported') {
-      return `  ${segment('Off', true)} ${currentTheme.fg('textMuted', 'unsupported')}`;
+      return `  ${unavailable('On')} ${segment('Off', true)}`;
     }
     const draft = this.draftFor(choice);
     return `  ${segment('On', draft)}  ${segment('Off', !draft)}`;

--- a/apps/kimi-code/src/tui/utils/refresh-providers.ts
+++ b/apps/kimi-code/src/tui/utils/refresh-providers.ts
@@ -182,7 +182,10 @@ function restoreDefaultSelection(
 ): void {
   if (defaultModel === undefined || config.models?.[defaultModel] === undefined) return;
   config.defaultModel = defaultModel;
-  config.defaultThinking = defaultThinking;
+  // A refresh may have just learned that the default model cannot disable
+  // thinking — never restore a stale thinking-off selection onto it.
+  const capabilities = config.models[defaultModel]?.capabilities ?? [];
+  config.defaultThinking = capabilities.includes('always_thinking') ? true : defaultThinking;
 }
 
 // `apply*` may leave `defaultModel` pointing at an alias that no longer exists

--- a/apps/kimi-code/test/tui/components/dialogs/model-selector.test.ts
+++ b/apps/kimi-code/test/tui/components/dialogs/model-selector.test.ts
@@ -3,6 +3,7 @@ import { visibleWidth } from '@earendil-works/pi-tui';
 import { describe, expect, it, vi } from 'vitest';
 
 import { ModelSelectorComponent } from '#/tui/components/dialogs/model-selector';
+import { currentTheme } from '#/tui/theme';
 import { darkColors } from '#/tui/theme/colors';
 
 const ANSI = /\[[0-9;]*m/g;
@@ -94,14 +95,58 @@ describe('ModelSelectorComponent', () => {
       onCancel: vi.fn(),
     });
 
-    expect(text(picker)).toContain('[ Always on ]');
+    // Always-on: On selected, Off greyed out with an explanation.
+    const alwaysOut = text(picker);
+    expect(alwaysOut).toContain('[ On ]');
+    expect(alwaysOut).toContain('Off (Unsupported)');
+    expect(alwaysOut).not.toContain('Always on');
+    picker.handleInput('\r');
+    expect(onSelect).toHaveBeenLastCalledWith({ alias: 'always', thinking: true });
+
+    // Unsupported: Off selected, On greyed out — same style, mirrored.
+    picker.handleInput(DOWN);
+    const plainOut = text(picker);
+    expect(plainOut).toContain('On (Unsupported)');
+    expect(plainOut).toContain('[ Off ]');
+    expect(plainOut).not.toContain('] unsupported');
+    picker.handleInput('\r');
+    expect(onSelect).toHaveBeenLastCalledWith({ alias: 'plain', thinking: false });
+  });
+
+  it('ignores Left/Right on always-on and unsupported models', () => {
+    const onSelect = vi.fn();
+    const picker = new ModelSelectorComponent({
+      models: {
+        always: model('Kimi Thinking', ['always_thinking']),
+        plain: model('Kimi Plain', ['tool_use']),
+      },
+      currentValue: 'always',
+      currentThinking: true,
+      onSelect,
+      onCancel: vi.fn(),
+    });
+
+    picker.handleInput(RIGHT);
     picker.handleInput('\r');
     expect(onSelect).toHaveBeenLastCalledWith({ alias: 'always', thinking: true });
 
     picker.handleInput(DOWN);
-    expect(text(picker)).toContain('[ Off ] unsupported');
+    picker.handleInput(LEFT);
     picker.handleInput('\r');
     expect(onSelect).toHaveBeenLastCalledWith({ alias: 'plain', thinking: false });
+  });
+
+  it('renders the unavailable thinking segment muted', () => {
+    const picker = new ModelSelectorComponent({
+      models: { always: model('Kimi Thinking', ['always_thinking']) },
+      currentValue: 'always',
+      currentThinking: true,
+      onSelect: vi.fn(),
+      onCancel: vi.fn(),
+    });
+
+    const raw = picker.render(120).join('\n');
+    expect(raw).toContain(currentTheme.fg('textMuted', '  Off (Unsupported)  '));
   });
 
   it('keeps the thinking draft when moving across models', () => {

--- a/apps/kimi-code/test/tui/utils/refresh-providers.test.ts
+++ b/apps/kimi-code/test/tui/utils/refresh-providers.test.ts
@@ -342,4 +342,61 @@ describe('refreshAllProviderModels', () => {
     expect(host.current().defaultModel).toBe(userAlias);
     expect(host.current().defaultThinking).toBe(false);
   });
+
+  it('forces default thinking on when the refreshed default model cannot disable thinking', async () => {
+    const host = makeRefreshHost({
+      providers: {
+        [KIMI_CODE_PROVIDER_NAME]: {
+          type: 'kimi',
+          apiKey: '',
+          oauth: { storage: 'file', key: 'oauth/kimi-code' },
+        },
+      },
+      models: {
+        'kimi-code/kimi-deep-coder': {
+          provider: KIMI_CODE_PROVIDER_NAME,
+          model: 'kimi-deep-coder',
+          maxContextSize: 262144,
+          capabilities: ['thinking', 'tool_use'],
+        },
+      },
+      defaultModel: 'kimi-code/kimi-deep-coder',
+      defaultThinking: false,
+      telemetry: true,
+    } as unknown as KimiConfig);
+
+    const fetchMock = vi.fn<FetchMock>(
+      async () =>
+        new Response(
+          JSON.stringify({
+            data: [
+              {
+                id: 'kimi-deep-coder',
+                context_length: 262144,
+                supports_reasoning: true,
+                supports_thinking_type: 'only',
+              },
+            ],
+          }),
+          { status: 200, headers: { 'Content-Type': 'application/json' } },
+        ),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await refreshAllProviderModels({
+      getConfig: async () => host.current(),
+      removeProvider: host.removeProvider,
+      setConfig: host.setConfig,
+      resolveOAuthToken: vi.fn(async () => 'oauth-access-token'),
+    });
+
+    expect(result.failed).toEqual([]);
+    expect(host.current().models?.['kimi-code/kimi-deep-coder']?.capabilities).toEqual([
+      'thinking',
+      'always_thinking',
+      'tool_use',
+    ]);
+    expect(host.current().defaultModel).toBe('kimi-code/kimi-deep-coder');
+    expect(host.current().defaultThinking).toBe(true);
+  });
 });

--- a/packages/acp-adapter/src/config-options.ts
+++ b/packages/acp-adapter/src/config-options.ts
@@ -96,8 +96,28 @@ export function buildModelOption(
  * currently-selected model has `thinkingSupported === false`, the
  * snapshot omits it entirely (dynamic visibility), so the client never
  * shows a toggle that wouldn't do anything.
+ *
+ * `alwaysThinking` models (declared `always_thinking` capability — the
+ * runtime cannot disable thinking) collapse the select to a single
+ * locked `on` entry: the state stays visible to the client, but there
+ * is no off option to pick. ACP has no "disabled entry" concept, so
+ * omitting `off` is the wire-level equivalent of the TUI's greyed-out
+ * `Off (Unsupported)` segment.
  */
-export function buildThinkingOption(enabled: boolean): SessionConfigOption {
+export function buildThinkingOption(
+  enabled: boolean,
+  alwaysThinking = false,
+): SessionConfigOption {
+  if (alwaysThinking) {
+    return {
+      type: 'select',
+      id: 'thinking',
+      name: 'Thinking',
+      category: 'thought_level',
+      currentValue: 'on',
+      options: [{ value: 'on', name: 'Thinking On' }],
+    };
+  }
   return {
     type: 'select',
     id: 'thinking',
@@ -171,9 +191,12 @@ export async function buildSessionConfigOptions(
   const models = await listModelsFromHarness(harness);
   const currentModelEntry = models.find((m) => m.id === currentBaseModelId);
   const showThinking = currentModelEntry?.thinkingSupported === true;
+  const alwaysThinking = currentModelEntry?.alwaysThinking === true;
   const out: SessionConfigOption[] = [buildModelOption(models, currentBaseModelId)];
   if (showThinking) {
-    out.push(buildThinkingOption(currentThinkingEnabled));
+    // Always-thinking models render locked-on regardless of the session's
+    // recorded toggle state — agent-core clamps the runtime the same way.
+    out.push(buildThinkingOption(alwaysThinking || currentThinkingEnabled, alwaysThinking));
   }
   out.push(buildModeOption(currentModeId));
   return out;

--- a/packages/acp-adapter/src/model-catalog.ts
+++ b/packages/acp-adapter/src/model-catalog.ts
@@ -35,6 +35,8 @@ export interface AcpModelEntry {
   readonly name: string;
   readonly description?: string | undefined;
   readonly thinkingSupported: boolean;
+  /** Declared 'always_thinking' capability — thinking cannot be turned off. */
+  readonly alwaysThinking?: boolean;
 }
 
 /**
@@ -47,11 +49,22 @@ const TOGGLEABLE_THINKING_MODELS = new Set(['kimi-for-coding', 'kimi-code']);
 
 export function deriveThinkingSupported(alias: ModelAlias): boolean {
   const declared = alias.capabilities ?? [];
-  if (declared.includes('thinking')) return true;
+  if (declared.includes('thinking') || declared.includes('always_thinking')) return true;
   const lower = alias.model.toLowerCase();
   if (lower.includes('thinking') || lower.includes('reason')) return true;
   if (TOGGLEABLE_THINKING_MODELS.has(alias.model)) return true;
   return false;
+}
+
+/**
+ * Whether the alias declares the 'always_thinking' capability — the model
+ * cannot run with thinking disabled, so the ACP toggle must lock to on.
+ * Deliberately capability-only: the name heuristics above keep feeding
+ * `thinkingSupported`, but only an explicit (server-derived) declaration
+ * may remove the off option from the client.
+ */
+export function deriveAlwaysThinking(alias: ModelAlias): boolean {
+  return (alias.capabilities ?? []).includes('always_thinking');
 }
 
 /**
@@ -80,6 +93,7 @@ export async function listModelsFromHarness(
       id,
       name: alias.displayName ?? alias.model ?? id,
       thinkingSupported: deriveThinkingSupported(alias),
+      alwaysThinking: deriveAlwaysThinking(alias),
     });
   }
   return out;

--- a/packages/acp-adapter/src/session.ts
+++ b/packages/acp-adapter/src/session.ts
@@ -37,6 +37,7 @@ import {
   type AcpBuiltinSlashCommandName,
 } from './builtin-commands';
 import { buildSessionConfigOptions } from './config-options';
+import { listModelsFromHarness } from './model-catalog';
 import { acpBlocksToPromptParts } from './convert';
 import {
   acpToolCallId,
@@ -365,11 +366,31 @@ export class AcpSession {
    * carries a fresh snapshot.
    */
   async setThinking(enabled: boolean): Promise<void> {
+    if (!enabled && (await this.currentModelAlwaysThinking())) {
+      // The current model cannot disable thinking (declared
+      // 'always_thinking'); silently ignore the off request — agent-core
+      // clamps the runtime the same way — but still refresh the snapshot
+      // so a stale client toggle snaps back to on.
+      this.currentThinkingEnabledInternal = true;
+      await this.emitConfigOptionUpdate();
+      return;
+    }
     if (typeof this.session.setThinking === 'function') {
       await this.session.setThinking(enabled ? THINKING_ON_LEVEL : THINKING_OFF_LEVEL);
     }
     this.currentThinkingEnabledInternal = enabled;
     await this.emitConfigOptionUpdate();
+  }
+
+  /**
+   * Whether the currently-selected model declares 'always_thinking'.
+   * Harness-less adapter unit tests resolve to false — the agent-core
+   * runtime clamp still protects the actual request in that case.
+   */
+  private async currentModelAlwaysThinking(): Promise<boolean> {
+    if (!this.harness) return false;
+    const models = await listModelsFromHarness(this.harness);
+    return models.find((m) => m.id === this.currentModelIdInternal)?.alwaysThinking === true;
   }
 
   /**

--- a/packages/acp-adapter/test/_helpers/harness-stubs.ts
+++ b/packages/acp-adapter/test/_helpers/harness-stubs.ts
@@ -29,10 +29,20 @@ export const UNAUTHED_STATUS = {
  * mirrors what a real config file would carry.
  */
 export function makeModelsMap(
-  entries: ReadonlyArray<{ id: string; name?: string; thinkingSupported?: boolean }>,
+  entries: ReadonlyArray<{
+    id: string;
+    name?: string;
+    thinkingSupported?: boolean;
+    alwaysThinking?: boolean;
+  }>,
 ): Record<string, ModelAlias> {
   const out: Record<string, ModelAlias> = {};
   for (const entry of entries) {
+    const capabilities = entry.alwaysThinking === true
+      ? ['thinking', 'always_thinking']
+      : entry.thinkingSupported === true
+        ? ['thinking']
+        : undefined;
     out[entry.id] = {
       // The fields below are the minimum shape the adapter reads off
       // each alias — `provider`/`max_context_size` are required by the
@@ -40,7 +50,7 @@ export function makeModelsMap(
       // here and the partial-record cast keeps the test stub honest.
       model: entry.id,
       ...(entry.name !== undefined ? { displayName: entry.name } : {}),
-      ...(entry.thinkingSupported === true ? { capabilities: ['thinking'] } : {}),
+      ...(capabilities !== undefined ? { capabilities } : {}),
     } as ModelAlias;
   }
   return out;

--- a/packages/acp-adapter/test/config-options.test.ts
+++ b/packages/acp-adapter/test/config-options.test.ts
@@ -94,6 +94,14 @@ describe('buildThinkingOption', () => {
     if (off.type !== 'select') throw new Error('expected SessionConfigSelect');
     expect(off.currentValue).toBe('off');
   });
+
+  it('collapses to a single locked "on" entry for always-thinking models', () => {
+    const locked = buildThinkingOption(true, true);
+    if (locked.type !== 'select') throw new Error('expected SessionConfigSelect');
+    expect(locked.currentValue).toBe('on');
+    expect(locked.options.map((o) => ('value' in o ? o.value : ''))).toEqual(['on']);
+    expect(locked.options.map((o) => ('name' in o ? o.name : ''))).toEqual(['Thinking On']);
+  });
 });
 
 describe('buildModeOption', () => {
@@ -169,6 +177,24 @@ describe('buildSessionConfigOptions', () => {
     const toggle = result.find((o) => o.id === 'thinking');
     if (!toggle || toggle.type !== 'select') throw new Error('expected thinking select toggle');
     expect(toggle.currentValue).toBe('on');
+  });
+
+  it('locks the thinking toggle to on for always-thinking models even when the session state says off', async () => {
+    const { harness } = makeHarnessWithModels([
+      {
+        id: 'kimi-deep',
+        model: 'kimi-deep-coder',
+        displayName: 'Kimi Deep',
+        capabilities: ['thinking', 'always_thinking'],
+      },
+    ]);
+
+    const result = await buildSessionConfigOptions(harness, 'kimi-deep', false, 'default');
+
+    const toggle = result.find((o) => o.id === 'thinking');
+    if (!toggle || toggle.type !== 'select') throw new Error('expected thinking select toggle');
+    expect(toggle.currentValue).toBe('on');
+    expect(toggle.options.map((o) => ('value' in o ? o.value : ''))).toEqual(['on']);
   });
 
   it('omits the thinking toggle when the current base model id is not in the catalog (defensive)', async () => {

--- a/packages/acp-adapter/test/model-catalog.test.ts
+++ b/packages/acp-adapter/test/model-catalog.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+
+import type { ModelAlias } from '@moonshot-ai/kimi-code-sdk';
+
+import { deriveAlwaysThinking, deriveThinkingSupported } from '../src/model-catalog';
+
+function alias(model: string, capabilities?: readonly string[]): ModelAlias {
+  return {
+    model,
+    ...(capabilities !== undefined ? { capabilities } : {}),
+  } as unknown as ModelAlias;
+}
+
+describe('deriveThinkingSupported', () => {
+  it('treats a declared always_thinking capability as thinking-supported', () => {
+    expect(deriveThinkingSupported(alias('custom-model', ['always_thinking']))).toBe(true);
+  });
+
+  it('keeps the existing thinking-capability and name-heuristic triggers', () => {
+    expect(deriveThinkingSupported(alias('custom-model', ['thinking']))).toBe(true);
+    expect(deriveThinkingSupported(alias('some-thinking-model'))).toBe(true);
+    expect(deriveThinkingSupported(alias('plain-model'))).toBe(false);
+  });
+});
+
+describe('deriveAlwaysThinking', () => {
+  it('reads the declared always_thinking capability', () => {
+    expect(deriveAlwaysThinking(alias('custom-model', ['thinking', 'always_thinking']))).toBe(true);
+    expect(deriveAlwaysThinking(alias('custom-model', ['thinking']))).toBe(false);
+  });
+
+  it('does not infer always-thinking from the model name', () => {
+    // Name heuristics keep working for thinkingSupported, but only the
+    // server-declared capability may lock the toggle to on.
+    expect(deriveAlwaysThinking(alias('some-thinking-model'))).toBe(false);
+  });
+});

--- a/packages/acp-adapter/test/set-session-config-option.test.ts
+++ b/packages/acp-adapter/test/set-session-config-option.test.ts
@@ -226,6 +226,43 @@ describe('AcpServer session/set_config_option', () => {
     expect(respToggle.currentValue).toBe('off');
   });
 
+  it('configId="thinking" + "off" on an always-thinking model → no SDK call, toggle stays locked on', async () => {
+    const handle = makeFakeSession('sess-thinking-locked');
+    const harness = {
+      auth: { status: async () => AUTHED_STATUS },
+      createSession: async () => handle.session,
+      getConfig: async () => ({
+        providers: {},
+        defaultModel: 'kimi-deep',
+        models: makeModelsMap([
+          { id: 'kimi-deep', name: 'Kimi Deep', thinkingSupported: true, alwaysThinking: true },
+        ]),
+      }),
+    } as unknown as KimiHarness;
+    const { client, capturing, sessionId } = await openSession(harness);
+    capturing.notifications.length = 0;
+
+    const response = await client.setSessionConfigOption({
+      sessionId,
+      configId: 'thinking',
+      value: 'off',
+    });
+
+    // The off request is silently ignored — the runtime cannot disable
+    // thinking on this model, so no SDK call is forwarded.
+    expect(handle.setThinkingCalls).toEqual([]);
+    const respToggle = response.configOptions.find((o) => o.id === 'thinking');
+    if (!respToggle || respToggle.type !== 'select') throw new Error('expected select toggle');
+    expect(respToggle.currentValue).toBe('on');
+    expect(respToggle.options.map((o) => ('value' in o ? o.value : ''))).toEqual(['on']);
+
+    // A snapshot refresh is still emitted so a stale client toggle snaps back.
+    const updates = capturing.notifications.filter(
+      (n) => n.sessionId === sessionId && n.update.sessionUpdate === 'config_option_update',
+    );
+    expect(updates).toHaveLength(1);
+  });
+
   const MODE_CASES: ReadonlyArray<{
     modeId: 'default' | 'plan' | 'auto' | 'yolo';
     expectedPlan: boolean;

--- a/packages/agent-core/src/agent/config/index.ts
+++ b/packages/agent-core/src/agent/config/index.ts
@@ -120,7 +120,18 @@ export class ConfigState {
   }
 
   get thinkingLevel(): ThinkingEffort {
+    // Always-thinking models cannot run with thinking disabled. Clamping in
+    // the getter (rather than in update()) keeps the request builder, status
+    // events, and subagent inheritance consistent, and re-applies after a
+    // later model switch onto an always-thinking alias.
+    if (this._thinkingLevel === 'off' && this.alwaysThinkingModel) {
+      return resolveThinkingEffort('on', this.agent.kimiConfig?.thinking);
+    }
     return this._thinkingLevel;
+  }
+
+  private get alwaysThinkingModel(): boolean {
+    return this.tryResolvedProviderConfig()?.alwaysThinking === true;
   }
 
   get profileName(): string | undefined {

--- a/packages/agent-core/src/session/provider-manager.ts
+++ b/packages/agent-core/src/session/provider-manager.ts
@@ -17,6 +17,8 @@ export interface ResolvedRuntimeProvider {
   readonly providerName: string;
   readonly provider: KosongProviderConfig;
   readonly modelCapabilities: ModelCapability;
+  /** Declared 'always_thinking' capability — the model cannot disable thinking. */
+  readonly alwaysThinking?: boolean;
   readonly maxOutputSize?: number;
 }
 
@@ -116,6 +118,9 @@ export class ProviderManager implements ModelProvider {
       providerName,
       provider,
       modelCapabilities: resolveModelCapabilities(alias, provider),
+      alwaysThinking: (alias.capabilities ?? []).some(
+        (c) => c.trim().toLowerCase() === 'always_thinking',
+      ),
       maxOutputSize: alias.maxOutputSize,
     };
   }

--- a/packages/agent-core/test/agent/config-state.test.ts
+++ b/packages/agent-core/test/agent/config-state.test.ts
@@ -159,6 +159,66 @@ describe('ConfigState model capabilities', () => {
   });
 });
 
+describe('ConfigState thinking clamp for always-thinking models', () => {
+  function alwaysThinkingAgent() {
+    return testAgent({
+      providerManager: new ProviderManager({
+        config: {
+          providers: { kimi: { type: 'kimi', apiKey: 'test-key' } },
+          models: {
+            'kimi-code/deep': {
+              provider: 'kimi',
+              model: 'kimi-deep-coder',
+              maxContextSize: 128_000,
+              capabilities: ['thinking', 'always_thinking', 'tool_use'],
+            },
+            'kimi-code/toggle': {
+              provider: 'kimi',
+              model: 'kimi-for-coding',
+              maxContextSize: 128_000,
+              capabilities: ['thinking'],
+            },
+          },
+        },
+      }),
+    });
+  }
+
+  it('clamps thinkingLevel off to the configured effort', () => {
+    const ctx = alwaysThinkingAgent();
+    ctx.agent.config.update({ modelAlias: 'kimi-code/deep', thinkingLevel: 'off' });
+
+    expect(ctx.agent.config.thinkingLevel).toBe('high');
+  });
+
+  it('builds the provider with thinking enabled even after thinking was set off', () => {
+    const ctx = alwaysThinkingAgent();
+    ctx.agent.config.update({ modelAlias: 'kimi-code/deep', thinkingLevel: 'off' });
+
+    const provider = ctx.agent.config.provider;
+    const gen = Reflect.get(provider as object, '_generationKwargs') as {
+      extra_body?: { thinking?: { type?: unknown } };
+    };
+    expect(gen.extra_body?.thinking?.type).toBe('enabled');
+  });
+
+  it('keeps thinking off working for toggleable models', () => {
+    const ctx = alwaysThinkingAgent();
+    ctx.agent.config.update({ modelAlias: 'kimi-code/toggle', thinkingLevel: 'off' });
+
+    expect(ctx.agent.config.thinkingLevel).toBe('off');
+  });
+
+  it('re-clamps when switching to an always-on model after thinking was off', () => {
+    const ctx = alwaysThinkingAgent();
+    ctx.agent.config.update({ modelAlias: 'kimi-code/toggle', thinkingLevel: 'off' });
+    expect(ctx.agent.config.thinkingLevel).toBe('off');
+
+    ctx.agent.config.update({ modelAlias: 'kimi-code/deep' });
+    expect(ctx.agent.config.thinkingLevel).toBe('high');
+  });
+});
+
 describe('ConfigState.provider applies global KIMI_MODEL_* request config', () => {
   function kimiAgent() {
     return testAgent({

--- a/packages/oauth/src/managed-kimi-code.ts
+++ b/packages/oauth/src/managed-kimi-code.ts
@@ -11,6 +11,15 @@ export const KIMI_CODE_PROVIDER_NAME = 'managed:kimi-code';
 export const KIMI_CODE_OAUTH_KEY = 'oauth/kimi-code';
 const KIMI_CODE_SCOPED_OAUTH_KEY_PREFIX = 'oauth/kimi-code-env-';
 
+/**
+ * Server-declared thinking toggle support from `/models`:
+ *  - 'only' — thinking cannot be turned off (always-thinking)
+ *  - 'no'   — thinking is not supported at all
+ *  - 'both' — thinking can be toggled on and off
+ * Absent on older servers — callers fall back to `supportsReasoning`.
+ */
+export type SupportsThinkingType = 'only' | 'no' | 'both';
+
 export interface ManagedKimiCodeModelInfo {
   readonly id: string;
   readonly contextLength: number;
@@ -18,6 +27,7 @@ export interface ManagedKimiCodeModelInfo {
   readonly supportsImageIn: boolean;
   readonly supportsVideoIn: boolean;
   readonly supportsToolUse?: boolean;
+  readonly supportsThinkingType?: SupportsThinkingType;
   readonly displayName?: string | undefined;
 }
 
@@ -171,7 +181,22 @@ interface SelectedDefaultModel {
 
 function capabilitiesForModel(model: ManagedKimiCodeModelInfo): string[] | undefined {
   const caps = new Set<string>();
-  if (model.supportsReasoning) caps.add('thinking');
+  // supports_thinking_type is the full three-state declaration and wins over
+  // the legacy supports_reasoning boolean; absent (older servers) falls back.
+  switch (model.supportsThinkingType) {
+    case 'only':
+      caps.add('thinking');
+      caps.add('always_thinking');
+      break;
+    case 'both':
+      caps.add('thinking');
+      break;
+    case 'no':
+      break;
+    case undefined:
+      if (model.supportsReasoning) caps.add('thinking');
+      break;
+  }
   if (model.supportsImageIn) caps.add('image_in');
   if (model.supportsVideoIn) caps.add('video_in');
   if (model.supportsToolUse ?? true) caps.add('tool_use');
@@ -357,8 +382,15 @@ function toModelInfo(item: unknown): ManagedKimiCodeModelInfo | undefined {
     supportsImageIn: Boolean(item['supports_image_in']),
     supportsVideoIn: Boolean(item['supports_video_in']),
     supportsToolUse,
+    supportsThinkingType: parseSupportsThinkingType(item['supports_thinking_type']),
     displayName: normalizedDisplayName,
   };
+}
+
+// Unknown or missing values resolve to undefined so callers fall back to the
+// legacy supports_reasoning boolean instead of guessing.
+export function parseSupportsThinkingType(value: unknown): SupportsThinkingType | undefined {
+  return value === 'only' || value === 'no' || value === 'both' ? value : undefined;
 }
 
 export async function fetchManagedKimiCodeModels(
@@ -496,6 +528,19 @@ export function applyManagedKimiCodeLogoutConfig(config: ManagedKimiConfigShape)
   }
 }
 
+// The server's three-state declaration overrides any stale defaultThinking
+// being preserved from an earlier config: an always-thinking model ('only')
+// must never end up with thinking off, and a non-thinking model ('no') must
+// never end up with thinking on.
+function forcedThinking(
+  model: ManagedKimiCodeModelInfo | undefined,
+  fallback: boolean,
+): boolean {
+  if (model?.supportsThinkingType === 'only') return true;
+  if (model?.supportsThinkingType === 'no') return false;
+  return fallback;
+}
+
 function selectDefaultModel(
   config: ManagedKimiConfigShape,
   models: readonly ManagedKimiCodeModelInfo[],
@@ -521,13 +566,16 @@ function selectDefaultModel(
     const preservedModel = managedModels.get(currentDefault);
     return {
       modelKey: currentDefault,
-      thinking: config.defaultThinking ?? preservedModel?.supportsReasoning ?? false,
+      thinking: forcedThinking(
+        preservedModel,
+        config.defaultThinking ?? preservedModel?.supportsReasoning ?? false,
+      ),
     };
   }
 
   return {
     modelKey: managedModelKey(firstModel.id),
-    thinking: config.defaultThinking ?? firstModel.supportsReasoning,
+    thinking: forcedThinking(firstModel, config.defaultThinking ?? firstModel.supportsReasoning),
   };
 }
 

--- a/packages/oauth/src/open-platform.ts
+++ b/packages/oauth/src/open-platform.ts
@@ -1,5 +1,6 @@
 import { readApiErrorMessage } from './api-error';
 import { isRecord } from './utils';
+import { parseSupportsThinkingType } from './managed-kimi-code';
 import type {
   ManagedKimiCodeModelInfo,
   ManagedKimiConfigShape,
@@ -61,13 +62,29 @@ function toModelInfo(item: unknown): ManagedKimiCodeModelInfo | undefined {
     supportsImageIn: Boolean(item['supports_image_in']),
     supportsVideoIn: Boolean(item['supports_video_in']),
     supportsToolUse,
+    supportsThinkingType: parseSupportsThinkingType(item['supports_thinking_type']),
     displayName: normalizedDisplayName,
   };
 }
 
 export function capabilitiesForModel(model: ManagedKimiCodeModelInfo): string[] | undefined {
   const caps = new Set<string>();
-  if (model.supportsReasoning) caps.add('thinking');
+  // supports_thinking_type is the full three-state declaration and wins over
+  // the legacy supports_reasoning boolean; absent (older servers) falls back.
+  switch (model.supportsThinkingType) {
+    case 'only':
+      caps.add('thinking');
+      caps.add('always_thinking');
+      break;
+    case 'both':
+      caps.add('thinking');
+      break;
+    case 'no':
+      break;
+    case undefined:
+      if (model.supportsReasoning) caps.add('thinking');
+      break;
+  }
   if (model.supportsImageIn) caps.add('image_in');
   if (model.supportsVideoIn) caps.add('video_in');
   if (model.supportsToolUse ?? true) caps.add('tool_use');

--- a/packages/oauth/test/managed-kimi-code.test.ts
+++ b/packages/oauth/test/managed-kimi-code.test.ts
@@ -838,3 +838,233 @@ describe('provisionManagedKimiCodeConfig', () => {
     });
   });
 });
+
+describe('supports_thinking_type', () => {
+  function makeThinkingTypeModelsResponse(): Response {
+    return new Response(
+      JSON.stringify({
+        data: [
+          {
+            id: 'kimi-for-coding',
+            context_length: 262144,
+            supports_reasoning: true,
+            supports_image_in: true,
+            supports_video_in: true,
+            supports_thinking_type: 'only',
+            display_name: 'Kimi For Coding',
+          },
+          {
+            // 'no' is the authoritative declaration and overrides the legacy
+            // supports_reasoning boolean.
+            id: 'kimi-plain',
+            context_length: 128000,
+            supports_reasoning: true,
+            supports_thinking_type: 'no',
+          },
+          {
+            id: 'kimi-toggle',
+            context_length: 128000,
+            supports_reasoning: true,
+            supports_thinking_type: 'both',
+          },
+        ],
+      }),
+      { status: 200, headers: { 'Content-Type': 'application/json' } },
+    );
+  }
+
+  it('parses supports_thinking_type from the models endpoint', async () => {
+    const models = await fetchManagedKimiCodeModels({
+      accessToken: 'oauth-access-token',
+      fetchImpl: vi.fn(async () => makeThinkingTypeModelsResponse()) as unknown as typeof fetch,
+    });
+
+    expect(models[0]?.supportsThinkingType).toBe('only');
+    expect(models[1]?.supportsThinkingType).toBe('no');
+    expect(models[2]?.supportsThinkingType).toBe('both');
+  });
+
+  it('leaves supportsThinkingType undefined when the field is absent or invalid', async () => {
+    const absent = await fetchManagedKimiCodeModels({
+      accessToken: 'oauth-access-token',
+      fetchImpl: vi.fn(async () => makeModelsResponse()) as unknown as typeof fetch,
+    });
+    expect(absent[0]?.supportsThinkingType).toBeUndefined();
+
+    const invalid = await fetchManagedKimiCodeModels({
+      accessToken: 'oauth-access-token',
+      fetchImpl: vi.fn(
+        async () =>
+          new Response(
+            JSON.stringify({
+              data: [
+                {
+                  id: 'kimi-for-coding',
+                  context_length: 262144,
+                  supports_reasoning: true,
+                  supports_thinking_type: 'maybe',
+                },
+              ],
+            }),
+            { status: 200, headers: { 'Content-Type': 'application/json' } },
+          ),
+      ) as unknown as typeof fetch,
+    });
+    expect(invalid[0]?.supportsThinkingType).toBeUndefined();
+  });
+
+  it('maps the three states onto capabilities, overriding supports_reasoning', async () => {
+    const config: ManagedKimiConfigShape = { providers: {} };
+
+    await provisionManagedKimiCodeConfig({
+      accessToken: 'oauth-access-token',
+      fetchImpl: vi.fn(async () => makeThinkingTypeModelsResponse()) as unknown as typeof fetch,
+      adapter: {
+        read: () => config,
+        write: vi.fn(),
+        apply: applyManagedKimiCodeConfig,
+      },
+    });
+
+    // 'only' → thinking locked on.
+    expect(config.models?.['kimi-code/kimi-for-coding']?.capabilities).toEqual([
+      'thinking',
+      'always_thinking',
+      'image_in',
+      'video_in',
+      'tool_use',
+    ]);
+    // 'no' → no thinking capability despite supports_reasoning=true.
+    expect(config.models?.['kimi-code/kimi-plain']?.capabilities).toEqual(['tool_use']);
+    // 'both' → plain toggleable thinking.
+    expect(config.models?.['kimi-code/kimi-toggle']?.capabilities).toEqual([
+      'thinking',
+      'tool_use',
+    ]);
+  });
+
+  it('forces default thinking on when the selected default model is thinking-only', async () => {
+    const config: ManagedKimiConfigShape = { providers: {}, defaultThinking: false };
+
+    const result = await provisionManagedKimiCodeConfig({
+      accessToken: 'oauth-access-token',
+      fetchImpl: vi.fn(async () => makeThinkingTypeModelsResponse()) as unknown as typeof fetch,
+      adapter: {
+        read: () => config,
+        write: vi.fn(),
+        apply: applyManagedKimiCodeConfig,
+      },
+    });
+
+    expect(result.defaultModel).toBe('kimi-code/kimi-for-coding');
+    expect(result.defaultThinking).toBe(true);
+    expect(config.defaultThinking).toBe(true);
+  });
+
+  it('forces default thinking on when preserving a thinking-only managed default', async () => {
+    const config: ManagedKimiConfigShape = {
+      providers: {
+        [KIMI_CODE_PROVIDER_NAME]: {
+          type: 'kimi',
+          apiKey: '',
+        },
+      },
+      defaultModel: 'kimi-code/kimi-for-coding',
+      defaultThinking: false,
+      models: {
+        'kimi-code/kimi-for-coding': {
+          provider: KIMI_CODE_PROVIDER_NAME,
+          model: 'kimi-for-coding',
+          maxContextSize: 262144,
+          capabilities: ['thinking'],
+        },
+      },
+    };
+
+    const result = await provisionManagedKimiCodeConfig({
+      accessToken: 'oauth-access-token',
+      fetchImpl: vi.fn(async () => makeThinkingTypeModelsResponse()) as unknown as typeof fetch,
+      preserveDefaultModel: true,
+      adapter: {
+        read: () => config,
+        write: vi.fn(),
+        apply: applyManagedKimiCodeConfig,
+      },
+    });
+
+    expect(result.defaultModel).toBe('kimi-code/kimi-for-coding');
+    expect(result.defaultThinking).toBe(true);
+    expect(config.defaultThinking).toBe(true);
+  });
+
+  it('forces default thinking off when preserving a no-thinking managed default', async () => {
+    const config: ManagedKimiConfigShape = {
+      providers: {
+        [KIMI_CODE_PROVIDER_NAME]: {
+          type: 'kimi',
+          apiKey: '',
+        },
+      },
+      defaultModel: 'kimi-code/kimi-plain',
+      defaultThinking: true,
+      models: {
+        'kimi-code/kimi-plain': {
+          provider: KIMI_CODE_PROVIDER_NAME,
+          model: 'kimi-plain',
+          maxContextSize: 128000,
+          capabilities: ['thinking'],
+        },
+      },
+    };
+
+    const result = await provisionManagedKimiCodeConfig({
+      accessToken: 'oauth-access-token',
+      fetchImpl: vi.fn(async () => makeThinkingTypeModelsResponse()) as unknown as typeof fetch,
+      preserveDefaultModel: true,
+      adapter: {
+        read: () => config,
+        write: vi.fn(),
+        apply: applyManagedKimiCodeConfig,
+      },
+    });
+
+    expect(result.defaultModel).toBe('kimi-code/kimi-plain');
+    expect(result.defaultThinking).toBe(false);
+    expect(config.defaultThinking).toBe(false);
+  });
+
+  it('keeps a preserved non-managed default thinking selection untouched', async () => {
+    const config: ManagedKimiConfigShape = {
+      providers: {
+        custom: {
+          type: 'kimi',
+          apiKey: 'sk-existing',
+        },
+      },
+      defaultModel: 'custom-default',
+      defaultThinking: false,
+      models: {
+        'custom-default': {
+          provider: 'custom',
+          model: 'custom-model',
+          maxContextSize: 1000,
+        },
+      },
+    };
+
+    const result = await provisionManagedKimiCodeConfig({
+      accessToken: 'oauth-access-token',
+      fetchImpl: vi.fn(async () => makeThinkingTypeModelsResponse()) as unknown as typeof fetch,
+      preserveDefaultModel: true,
+      adapter: {
+        read: () => config,
+        write: vi.fn(),
+        apply: applyManagedKimiCodeConfig,
+      },
+    });
+
+    expect(result.defaultModel).toBe('custom-default');
+    expect(result.defaultThinking).toBe(false);
+    expect(config.defaultThinking).toBe(false);
+  });
+});

--- a/packages/oauth/test/open-platform.test.ts
+++ b/packages/oauth/test/open-platform.test.ts
@@ -155,7 +155,78 @@ describe('filterModelsByPrefix', () => {
   });
 });
 
+describe('fetchOpenPlatformModels supports_thinking_type', () => {
+  it('parses supports_thinking_type from the models endpoint', async () => {
+    const fetchMock = vi.fn(
+      async () =>
+        new Response(
+          JSON.stringify({
+            data: [
+              {
+                id: 'kimi-k2-deep',
+                context_length: 256000,
+                supports_reasoning: true,
+                supports_thinking_type: 'only',
+              },
+              {
+                id: 'kimi-k2-lite',
+                context_length: 128000,
+                supports_reasoning: false,
+              },
+            ],
+          }),
+          { status: 200, headers: { 'Content-Type': 'application/json' } },
+        ),
+    );
+    const platform = getOpenPlatformById('moonshot-cn')!;
+
+    const models = await fetchOpenPlatformModels(platform, 'sk-test', fetchMock as unknown as typeof fetch);
+
+    expect(models[0]?.supportsThinkingType).toBe('only');
+    expect(models[1]?.supportsThinkingType).toBeUndefined();
+  });
+});
+
 describe('capabilitiesForModel', () => {
+  it("locks thinking on for 'only' models", () => {
+    const model = {
+      id: 'deep',
+      contextLength: 1000,
+      supportsReasoning: true,
+      supportsImageIn: false,
+      supportsVideoIn: false,
+      supportsToolUse: false,
+      supportsThinkingType: 'only' as const,
+    };
+    expect(capabilitiesForModel(model)).toEqual(['thinking', 'always_thinking']);
+  });
+
+  it("lets 'no' override the legacy supports_reasoning boolean", () => {
+    const model = {
+      id: 'plain',
+      contextLength: 1000,
+      supportsReasoning: true,
+      supportsImageIn: false,
+      supportsVideoIn: false,
+      supportsToolUse: false,
+      supportsThinkingType: 'no' as const,
+    };
+    expect(capabilitiesForModel(model)).toBeUndefined();
+  });
+
+  it("emits a plain toggleable thinking capability for 'both'", () => {
+    const model = {
+      id: 'toggle',
+      contextLength: 1000,
+      supportsReasoning: false,
+      supportsImageIn: false,
+      supportsVideoIn: false,
+      supportsToolUse: false,
+      supportsThinkingType: 'both' as const,
+    };
+    expect(capabilitiesForModel(model)).toEqual(['thinking']);
+  });
+
   it('returns undefined for a model with no capabilities', () => {
     const model = {
       id: 'plain',


### PR DESCRIPTION
## Related Issue

N/A — server-driven model metadata change, coordinated with the backend rollout of the new `/models` field.

## Problem

The `/models` endpoint now returns a three-state `supports_thinking_type` field (`only` = thinking cannot be turned off, `no` = thinking unsupported, `both` = toggleable). The client previously had no producer for the locked-on state: the `always_thinking` capability was consumed by the model picker and the runtime capability resolver, but nothing ever emitted it, so locked-thinking models rendered as ordinary toggleable models and a stale `default_thinking = false` config could silently send `thinking: disabled` upstream.

## What changed

**oauth** — both `/models` parsers read `supports_thinking_type`, which takes precedence over the legacy `supports_reasoning` boolean (absent or unknown values fall back to it): `only` emits `always_thinking` alongside `thinking`, `no` suppresses the thinking capability even when `supports_reasoning` is set. Default-model selection during login and provider refresh forces thinking on for `only` models and off for `no` models, so a stale `default_thinking` can no longer stick to them.

**TUI** — the `/model` thinking control now keeps a fixed On-left / Off-right layout across all three states:

```
toggleable ('both'): [ On ]    Off
locked on ('only'):  [ On ]   Off (Unsupported)   <- greyed out
no thinking ('no'):  On (Unsupported)   [ Off ]   <- greyed out, same style
```

←/→ remain inert outside the toggleable state, and Enter still returns the effective value (locked models always confirm with thinking on, which also repairs a stale config default).

**agent-core** — `ConfigState.thinkingLevel` clamps `'off'` to the configured effort when the resolved model declares `always_thinking`. Clamping in the getter (instead of `update()`) keeps the request builder, status events, and subagent inheritance consistent, and re-applies when a later model switch lands on a locked model — so no bypass path (`setThinking` RPC, dirty config, ACP) can produce a thinking-disabled request.

**acp-adapter** — `AcpModelEntry` gains `alwaysThinking` (derived from the declared capability only; name heuristics still feed `thinkingSupported` but never lock the toggle). The thinking option collapses to a single locked `on` entry for such models, and an `off` request is ignored while a fresh snapshot is re-emitted so stale client toggles snap back.

Behavior is unchanged for servers that do not send the field, except the intentional restyling of the non-thinking state (`[ Off ] unsupported` → `On (Unsupported)  [ Off ]`).

Verified end-to-end against a staging `/models` deployment returning `"supports_thinking_type": "only"`.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.