### PR TITLE
fix(agent-core): improve Edit tool backslash handling and error diagn…

### DIFF
--- a/.changeset/fix-edit-backslash-handling.md
+++ b/.changeset/fix-edit-backslash-handling.md
@@ -1,0 +1,7 @@
+---
+"@moonshot-ai/agent-core": patch
+"@moonshot-ai/kimi-code": patch
+
+---
+
+Improve Edit tool recovery when old_string contains misencoded backslashes from the LLM.

--- a/packages/agent-core/src/tools/builtin/file/edit.md
+++ b/packages/agent-core/src/tools/builtin/file/edit.md
@@ -11,3 +11,4 @@ Perform exact replacements in existing files.
 - A write lock serializes same-file edits in response order, but serialization does not make stale `old_string` valid.
 - For pure CRLF files, Read shows LF; use LF in `old_string` and `new_string`, and Edit writes CRLF back.
 - For mixed endings or lone carriage returns, Read shows carriage returns as \r; include actual \r escapes in those positions.
+- Backslash encoding: when old_string contains backslashes (e.g. Rust `\n`, JSON `\\`, regex `\d`), copy the exact characters from the Read output. Do NOT add extra escaping — the file contains literal backslash characters, not escape sequences.

--- a/packages/agent-core/src/tools/builtin/file/edit.ts
+++ b/packages/agent-core/src/tools/builtin/file/edit.ts
@@ -56,41 +56,40 @@ function replaceOnceLiteral(content: string, oldString: string, newString: strin
 }
 
 /**
- * Attempt to fix common LLM backslash-encoding mistakes in `old_string`.
- *
- * Models sometimes double-escape backslashes when encoding old_string in
- * JSON (e.g. sending `\\\\n` when the file contains `\\n`).  This helper
- * tries progressively less-escaped variants and returns the first one
- * that matches in `content`, or `undefined` if none match.
+ * Attempt to fix common LLM backslash-encoding mistakes in a string.
+ * Used for both old_string (matched against content) and new_string
+ * (applied as replacement).
  */
+function applyBackslashFix(
+  input: string,
+  variant: 'unescape' | 'escape',
+): string {
+  if (variant === 'unescape') {
+    return input
+      .replaceAll('\\n', '\n')
+      .replaceAll('\\t', '\t')
+      .replaceAll('\\r', '\r')
+      .replaceAll('\\\\', '\\');
+  }
+  return input
+    .replaceAll('\n', '\\n')
+    .replaceAll('\t', '\\t')
+    .replaceAll('\r', '\\r');
+}
 function findBackslashAdjustedMatch(
   content: string,
   oldString: string,
-): { adjusted: string; variant: string } | undefined {
-  const variants: Array<{ adjusted: string; variant: string }> = [];
+): { adjusted: string; variant: 'unescape' | 'escape' } | undefined {
+  const variants: Array<{ adjusted: string; variant: 'unescape' | 'escape' }> = [];
 
-  // Variant 1: the LLM double-escaped — unescape one level.
-  // Collapse doubled backslashes first, then translate escape sequences.
-  // Order matters: "\\\\" must collapse before "\\n" is processed,
-  // otherwise the second backslash pairs with 'n' into a real newline.
-  const unescaped = oldString
-    .replaceAll('\\\\', '\\')
-    .replaceAll('\\n', '\n')
-    .replaceAll('\\t', '\t')
-    .replaceAll('\\r', '\r');
+  const unescaped = applyBackslashFix(oldString, 'unescape');
   if (unescaped !== oldString) {
-    variants.push({ adjusted: unescaped, variant: 'unescape-sequences' });
+    variants.push({ adjusted: unescaped, variant: 'unescape' });
   }
 
-  // Variant 2: the LLM under-escaped — the file has literal double-backslash
-  // but old_string has single.  Re-escape common escape sequences.
-  const overEscaped = oldString
-    .replaceAll('\\n', '\\\\n')
-    .replaceAll('\\t', '\\\\t')
-    .replaceAll('\\r', '\\\\r');
-  // Only try this if it actually changed something and differs from variant 1.
+  const overEscaped = applyBackslashFix(oldString, 'escape');
   if (overEscaped !== oldString && overEscaped !== unescaped) {
-    variants.push({ adjusted: overEscaped, variant: 'escape-sequences' });
+    variants.push({ adjusted: overEscaped, variant: 'escape' });
   }
 
   for (const v of variants) {
@@ -176,11 +175,13 @@ export class EditTool implements BuiltinTool<EditInput> {
       // Try the original old_string first; if not found, attempt backslash
       // encoding fixes that cover common LLM mis-encodings.
       let oldString = args.old_string;
+      let newString = args.new_string;
       let backslashHint: string | undefined;
       if (!content.includes(oldString)) {
         const adjusted = findBackslashAdjustedMatch(content, oldString);
         if (adjusted !== undefined) {
           oldString = adjusted.adjusted;
+          newString = applyBackslashFix(newString, adjusted.variant);
           backslashHint = ` (matched after ${adjusted.variant} adjustment)`;
         }
       }
@@ -209,7 +210,7 @@ export class EditTool implements BuiltinTool<EditInput> {
           };
         }
 
-        const newContent = replaceOnceLiteral(content, oldString, args.new_string);
+        const newContent = replaceOnceLiteral(content, oldString, newString);
         await this.kaos.writeText(
           safePath,
           materializeModelText(newContent, modelView.lineEndingStyle),
@@ -225,7 +226,7 @@ export class EditTool implements BuiltinTool<EditInput> {
 ` };
       }
 
-      const newContent = parts.join(args.new_string);
+      const newContent = parts.join(newString);
       await this.kaos.writeText(
         safePath,
         materializeModelText(newContent, modelView.lineEndingStyle),

--- a/packages/agent-core/src/tools/builtin/file/edit.ts
+++ b/packages/agent-core/src/tools/builtin/file/edit.ts
@@ -135,12 +135,44 @@ export class EditTool implements BuiltinTool<EditInput> {
     private readonly workspace: WorkspaceConfig,
   ) {}
 
-  resolveExecution(args: EditInput): ToolExecution {
+  async resolveExecution(args: EditInput): Promise<ToolExecution> {
     const path = resolvePathAccessPath(args.path, {
       kaos: this.kaos,
       workspace: this.workspace,
       operation: 'write',
     });
+
+    // Reject no-op edits before any file I/O.
+    if (args.old_string === args.new_string) {
+      return {
+        isError: true,
+        output: 'No changes to make: old_string and new_string are exactly the same.',
+      };
+    }
+
+    // Read the file and apply backslash fallback early, so the approval
+    // display shows the exact text that will be written.
+    let adjustedArgs = args;
+    try {
+      const raw = await this.kaos.readText(path);
+      const content = toModelTextView(raw).text;
+      if (!content.includes(args.old_string)) {
+        const adjusted = findBackslashAdjustedMatch(content, args.old_string);
+        if (adjusted !== undefined) {
+          adjustedArgs = {
+            ...args,
+            old_string: adjusted.adjusted,
+            new_string: applyBackslashFix(
+              args.new_string,
+              adjusted.variant as 'escape' | 'collapse-only' | 'unescape-seq-first',
+            ),
+          };
+        }
+      }
+    } catch {
+      // If we can't read the file here, execution() will handle it.
+    }
+
     return {
       accesses: ToolAccesses.readWriteFile(path),
       description: `Editing ${args.path}`,
@@ -148,8 +180,8 @@ export class EditTool implements BuiltinTool<EditInput> {
         kind: 'file_io',
         operation: 'edit',
         path,
-        before: args.old_string,
-        after: args.new_string,
+        before: adjustedArgs.old_string,
+        after: adjustedArgs.new_string,
       },
       approvalRule: literalRulePattern(this.name, path),
       matchesRule: (ruleArgs) =>
@@ -158,50 +190,29 @@ export class EditTool implements BuiltinTool<EditInput> {
           pathClass: this.kaos.pathClass(),
           homeDir: this.kaos.gethome(),
         }),
-      execute: () => this.execution(args, path),
+      execute: () => this.execution(adjustedArgs, path),
     };
   }
 
   private async execution(args: EditInput, safePath: string): Promise<ExecutableToolResult> {
-    if (args.old_string === args.new_string) {
-      return {
-        isError: true,
-        output: 'No changes to make: old_string and new_string are exactly the same.',
-      };
-    }
-
     try {
       const raw = await this.kaos.readText(safePath);
       const modelView = toModelTextView(raw);
       const content = modelView.text;
       const replaceAll = args.replace_all ?? false;
 
-      // Try the original old_string first; if not found, attempt backslash
-      // encoding fixes that cover common LLM mis-encodings.
-      let oldString = args.old_string;
-      let newString = args.new_string;
-      let backslashHint: string | undefined;
-      if (!content.includes(oldString)) {
-        const adjusted = findBackslashAdjustedMatch(content, oldString);
-        if (adjusted !== undefined) {
-          oldString = adjusted.adjusted;
-          newString = applyBackslashFix(newString, adjusted.variant as 'escape' | 'collapse-only' | 'unescape-seq-first');
-          backslashHint = ` (matched after ${adjusted.variant} adjustment)`;
-        }
-      }
-
       if (!replaceAll) {
         let count = 0;
         let pos = 0;
         while (pos < content.length) {
-          const idx = content.indexOf(oldString, pos);
+          const idx = content.indexOf(args.old_string, pos);
           if (idx === -1) break;
           count++;
-          pos = idx + oldString.length;
+          pos = idx + args.old_string.length;
         }
 
         if (count === 0) {
-          const hint = buildNotFoundHint(content, oldString, args.path);
+          const hint = buildNotFoundHint(content, args.old_string, args.path);
           return { isError: true, output: `old_string not found in ${args.path}. ${hint}\nThe file contents may be out of date. Please use the Read Tool to reload the content.
 ` };
         }
@@ -214,28 +225,28 @@ export class EditTool implements BuiltinTool<EditInput> {
           };
         }
 
-        const newContent = replaceOnceLiteral(content, oldString, newString);
+        const newContent = replaceOnceLiteral(content, args.old_string, args.new_string);
         await this.kaos.writeText(
           safePath,
           materializeModelText(newContent, modelView.lineEndingStyle),
         );
-        return { output: `Replaced 1 occurrence in ${args.path}${backslashHint ?? ''}` };
+        return { output: `Replaced 1 occurrence in ${args.path}` };
       }
 
-      const parts = content.split(oldString);
+      const parts = content.split(args.old_string);
       const replacementCount = parts.length - 1;
       if (replacementCount === 0) {
-        const hint = buildNotFoundHint(content, oldString, args.path);
+        const hint = buildNotFoundHint(content, args.old_string, args.path);
         return { isError: true, output: `old_string not found in ${args.path}. ${hint}\nThe file contents may be out of date. Please use the Read Tool to reload the content.
 ` };
       }
 
-      const newContent = parts.join(newString);
+      const newContent = parts.join(args.new_string);
       await this.kaos.writeText(
         safePath,
         materializeModelText(newContent, modelView.lineEndingStyle),
       );
-      return { output: `Replaced ${String(replacementCount)} occurrences in ${args.path}${backslashHint ?? ''}` };
+      return { output: `Replaced ${String(replacementCount)} occurrences in ${args.path}` };
     } catch (error) {
       const code = (error as { code?: unknown } | null)?.code;
       if (code === 'EISDIR') {

--- a/packages/agent-core/src/tools/builtin/file/edit.ts
+++ b/packages/agent-core/src/tools/builtin/file/edit.ts
@@ -55,6 +55,73 @@ function replaceOnceLiteral(content: string, oldString: string, newString: strin
   return content.slice(0, index) + newString + content.slice(index + oldString.length);
 }
 
+/**
+ * Attempt to fix common LLM backslash-encoding mistakes in `old_string`.
+ *
+ * Models sometimes double-escape backslashes when encoding old_string in
+ * JSON (e.g. sending `\\\\n` when the file contains `\\n`).  This helper
+ * tries progressively less-escaped variants and returns the first one
+ * that matches in `content`, or `undefined` if none match.
+ */
+function findBackslashAdjustedMatch(
+  content: string,
+  oldString: string,
+): { adjusted: string; variant: string } | undefined {
+  const variants: Array<{ adjusted: string; variant: string }> = [];
+
+  // Variant 1: the LLM double-escaped — unescape one level.
+  // "\\\\n" in JS string → "\\n" (backslash + n), but the file has "\n" (backslash + n).
+  // If old_string contains sequences like "\\n" that the file doesn't have,
+  // try replacing "\\n" → "\n" etc.
+  const unescaped = oldString
+    .replace(/\\\\n/g, '\n')
+    .replace(/\\\\t/g, '\t')
+    .replace(/\\\\r/g, '\r')
+    .replace(/\\\\\\\\/g, '\\');
+  if (unescaped !== oldString) {
+    variants.push({ adjusted: unescaped, variant: 'unescape-sequences' });
+  }
+
+  // Variant 2: the LLM under-escaped — the file has literal double-backslash
+  // but old_string has single.  Try the reverse.
+  const overEscaped = oldString
+    .replace(/\\n/g, '\\n')
+    .replace(/\\t/g, '\\t')
+    .replace(/\\r/g, '\\r');
+  // Only try this if it actually changed something and differs from variant 1.
+  if (overEscaped !== oldString && overEscaped !== unescaped) {
+    variants.push({ adjusted: overEscaped, variant: 'escape-sequences' });
+  }
+
+  for (const v of variants) {
+    if (content.indexOf(v.adjusted) !== -1) {
+      return v;
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Build a short diagnostic snippet showing the first divergence between
+ * `oldString` and the file content, helpful when old_string is not found.
+ */
+function buildNotFoundHint(content: string, oldString: string, filePath: string): string {
+  const lines = content.split('\n');
+  const firstLine = oldString.split('\n')[0] ?? '';
+  if (firstLine.length === 0) return '';
+
+  // Find the closest matching line in the file content.
+  const candidates = lines.filter((l) => l.includes(firstLine.slice(0, 20)));
+  if (candidates.length === 0) {
+    return `The file does not contain a line matching the start of old_string: "${truncate(firstLine, 60)}"`;
+  }
+  return `Closest match in file: "${truncate(candidates[0]!, 80)}"`;
+}
+
+function truncate(s: string, max: number): string {
+  return s.length <= max ? s : s.slice(0, max - 3) + '...';
+}
+
 export class EditTool implements BuiltinTool<EditInput> {
   readonly name = 'Edit' as const;
   readonly description = EDIT_DESCRIPTION;
@@ -106,18 +173,31 @@ export class EditTool implements BuiltinTool<EditInput> {
       const content = modelView.text;
       const replaceAll = args.replace_all ?? false;
 
+      // Try the original old_string first; if not found, attempt backslash
+      // encoding fixes that cover common LLM mis-encodings.
+      let oldString = args.old_string;
+      let backslashHint: string | undefined;
+      if (content.indexOf(oldString) === -1) {
+        const adjusted = findBackslashAdjustedMatch(content, oldString);
+        if (adjusted !== undefined) {
+          oldString = adjusted.adjusted;
+          backslashHint = ` (matched after ${adjusted.variant} adjustment)`;
+        }
+      }
+
       if (!replaceAll) {
         let count = 0;
         let pos = 0;
         while (pos < content.length) {
-          const idx = content.indexOf(args.old_string, pos);
+          const idx = content.indexOf(oldString, pos);
           if (idx === -1) break;
           count++;
-          pos = idx + args.old_string.length;
+          pos = idx + oldString.length;
         }
 
         if (count === 0) {
-          return { isError: true, output: `old_string not found in ${args.path}, the file contents may be out of date. Please use the Read Tool to reload the content.
+          const hint = buildNotFoundHint(content, oldString, args.path);
+          return { isError: true, output: `old_string not found in ${args.path}. ${hint}\nThe file contents may be out of date. Please use the Read Tool to reload the content.
 ` };
         }
         if (count > 1) {
@@ -129,18 +209,19 @@ export class EditTool implements BuiltinTool<EditInput> {
           };
         }
 
-        const newContent = replaceOnceLiteral(content, args.old_string, args.new_string);
+        const newContent = replaceOnceLiteral(content, oldString, args.new_string);
         await this.kaos.writeText(
           safePath,
           materializeModelText(newContent, modelView.lineEndingStyle),
         );
-        return { output: `Replaced 1 occurrence in ${args.path}` };
+        return { output: `Replaced 1 occurrence in ${args.path}${backslashHint ?? ''}` };
       }
 
-      const parts = content.split(args.old_string);
+      const parts = content.split(oldString);
       const replacementCount = parts.length - 1;
       if (replacementCount === 0) {
-        return { isError: true, output: `old_string not found in ${args.path}, the file contents may be out of date. Please use the Read Tool to reload the content.
+        const hint = buildNotFoundHint(content, oldString, args.path);
+        return { isError: true, output: `old_string not found in ${args.path}. ${hint}\nThe file contents may be out of date. Please use the Read Tool to reload the content.
 ` };
       }
 
@@ -149,7 +230,7 @@ export class EditTool implements BuiltinTool<EditInput> {
         safePath,
         materializeModelText(newContent, modelView.lineEndingStyle),
       );
-      return { output: `Replaced ${String(replacementCount)} occurrences in ${args.path}` };
+      return { output: `Replaced ${String(replacementCount)} occurrences in ${args.path}${backslashHint ?? ''}` };
     } catch (error) {
       const code = (error as { code?: unknown } | null)?.code;
       if (code === 'EISDIR') {

--- a/packages/agent-core/src/tools/builtin/file/edit.ts
+++ b/packages/agent-core/src/tools/builtin/file/edit.ts
@@ -56,9 +56,9 @@ function replaceOnceLiteral(content: string, oldString: string, newString: strin
 }
 
 /**
- * Attempt to fix common LLM backslash-encoding mistakes in a string.
- * Used for both old_string (matched against content) and new_string
- * (applied as replacement).
+ * Apply a backslash encoding transformation to detect whether a
+ * different encoding would match the file content. Used for detection
+ * only — the actual replacement uses the original args.
  */
 function applyBackslashFix(
   input: string,
@@ -181,18 +181,21 @@ export class EditTool implements BuiltinTool<EditInput> {
       const content = modelView.text;
       const replaceAll = args.replace_all ?? false;
 
-      // Apply backslash fallback after auth — adjust both old_string and
-      // new_string with the same transformation so the replacement is correct.
-      let oldString = args.old_string;
-      let newString = args.new_string;
-      if (!content.includes(oldString)) {
-        const adjusted = findBackslashAdjustedMatch(content, oldString);
+      // If old_string is not found, check if a backslash encoding mismatch
+      // is the cause. Instead of silently adjusting (which would mismatch
+      // the approval display), return a diagnostic error so the LLM can
+      // resend with the correct encoding.
+      if (!content.includes(args.old_string)) {
+        const adjusted = findBackslashAdjustedMatch(content, args.old_string);
         if (adjusted !== undefined) {
-          oldString = adjusted.adjusted;
-          newString = applyBackslashFix(
-            newString,
-            adjusted.variant as 'escape' | 'collapse-only' | 'unescape-seq-first',
-          );
+          const hint = buildNotFoundHint(content, args.old_string, args.path);
+          return {
+            isError: true,
+            output:
+              `old_string not found in ${args.path}. ${hint}\n` +
+              `The file content differs in backslash encoding (detected: ${adjusted.variant}). ` +
+              `Use the Read Tool to view the exact file content and resend old_string matching the literal characters shown.`,
+          };
         }
       }
 
@@ -200,14 +203,14 @@ export class EditTool implements BuiltinTool<EditInput> {
         let count = 0;
         let pos = 0;
         while (pos < content.length) {
-          const idx = content.indexOf(oldString, pos);
+          const idx = content.indexOf(args.old_string, pos);
           if (idx === -1) break;
           count++;
-          pos = idx + oldString.length;
+          pos = idx + args.old_string.length;
         }
 
         if (count === 0) {
-          const hint = buildNotFoundHint(content, oldString, args.path);
+          const hint = buildNotFoundHint(content, args.old_string, args.path);
           return { isError: true, output: `old_string not found in ${args.path}. ${hint}\nThe file contents may be out of date. Please use the Read Tool to reload the content.
 ` };
         }
@@ -220,7 +223,7 @@ export class EditTool implements BuiltinTool<EditInput> {
           };
         }
 
-        const newContent = replaceOnceLiteral(content, oldString, newString);
+        const newContent = replaceOnceLiteral(content, args.old_string, args.new_string);
         await this.kaos.writeText(
           safePath,
           materializeModelText(newContent, modelView.lineEndingStyle),
@@ -228,15 +231,15 @@ export class EditTool implements BuiltinTool<EditInput> {
         return { output: `Replaced 1 occurrence in ${args.path}` };
       }
 
-      const parts = content.split(oldString);
+      const parts = content.split(args.old_string);
       const replacementCount = parts.length - 1;
       if (replacementCount === 0) {
-        const hint = buildNotFoundHint(content, oldString, args.path);
+        const hint = buildNotFoundHint(content, args.old_string, args.path);
         return { isError: true, output: `old_string not found in ${args.path}. ${hint}\nThe file contents may be out of date. Please use the Read Tool to reload the content.
 ` };
       }
 
-      const newContent = parts.join(newString);
+      const newContent = parts.join(args.new_string);
       await this.kaos.writeText(
         safePath,
         materializeModelText(newContent, modelView.lineEndingStyle),

--- a/packages/agent-core/src/tools/builtin/file/edit.ts
+++ b/packages/agent-core/src/tools/builtin/file/edit.ts
@@ -70,24 +70,24 @@ function findBackslashAdjustedMatch(
   const variants: Array<{ adjusted: string; variant: string }> = [];
 
   // Variant 1: the LLM double-escaped — unescape one level.
-  // "\\\\n" in JS string → "\\n" (backslash + n), but the file has "\n" (backslash + n).
-  // If old_string contains sequences like "\\n" that the file doesn't have,
-  // try replacing "\\n" → "\n" etc.
+  // Collapse doubled backslashes first, then translate escape sequences.
+  // Order matters: "\\\\" must collapse before "\\n" is processed,
+  // otherwise the second backslash pairs with 'n' into a real newline.
   const unescaped = oldString
+    .replaceAll('\\\\', '\\')
     .replaceAll('\\n', '\n')
     .replaceAll('\\t', '\t')
-    .replaceAll('\\r', '\r')
-    .replaceAll('\\\\', '\\');
+    .replaceAll('\\r', '\r');
   if (unescaped !== oldString) {
     variants.push({ adjusted: unescaped, variant: 'unescape-sequences' });
   }
 
   // Variant 2: the LLM under-escaped — the file has literal double-backslash
-  // but old_string has single.  Try the reverse.
+  // but old_string has single.  Re-escape common escape sequences.
   const overEscaped = oldString
-    .replaceAll(/\\n/g, '\\n')
-    .replaceAll(/\\t/g, '\\t')
-    .replaceAll(/\\r/g, '\\r');
+    .replaceAll('\\n', '\\\\n')
+    .replaceAll('\\t', '\\\\t')
+    .replaceAll('\\r', '\\\\r');
   // Only try this if it actually changed something and differs from variant 1.
   if (overEscaped !== oldString && overEscaped !== unescaped) {
     variants.push({ adjusted: overEscaped, variant: 'escape-sequences' });

--- a/packages/agent-core/src/tools/builtin/file/edit.ts
+++ b/packages/agent-core/src/tools/builtin/file/edit.ts
@@ -135,7 +135,7 @@ export class EditTool implements BuiltinTool<EditInput> {
     private readonly workspace: WorkspaceConfig,
   ) {}
 
-  async resolveExecution(args: EditInput): Promise<ToolExecution> {
+  resolveExecution(args: EditInput): ToolExecution {
     const path = resolvePathAccessPath(args.path, {
       kaos: this.kaos,
       workspace: this.workspace,
@@ -150,29 +150,9 @@ export class EditTool implements BuiltinTool<EditInput> {
       };
     }
 
-    // Read the file and apply backslash fallback early, so the approval
-    // display shows the exact text that will be written.
-    let adjustedArgs = args;
-    try {
-      const raw = await this.kaos.readText(path);
-      const content = toModelTextView(raw).text;
-      if (!content.includes(args.old_string)) {
-        const adjusted = findBackslashAdjustedMatch(content, args.old_string);
-        if (adjusted !== undefined) {
-          adjustedArgs = {
-            ...args,
-            old_string: adjusted.adjusted,
-            new_string: applyBackslashFix(
-              args.new_string,
-              adjusted.variant as 'escape' | 'collapse-only' | 'unescape-seq-first',
-            ),
-          };
-        }
-      }
-    } catch {
-      // If we can't read the file here, execution() will handle it.
-    }
-
+    // No file read here — resolveExecution runs BEFORE the authorization
+    // hook in tool-call.ts. Reading the file here would bypass permission
+    // checks. The backslash fallback is applied in execution() after auth.
     return {
       accesses: ToolAccesses.readWriteFile(path),
       description: `Editing ${args.path}`,
@@ -180,8 +160,8 @@ export class EditTool implements BuiltinTool<EditInput> {
         kind: 'file_io',
         operation: 'edit',
         path,
-        before: adjustedArgs.old_string,
-        after: adjustedArgs.new_string,
+        before: args.old_string,
+        after: args.new_string,
       },
       approvalRule: literalRulePattern(this.name, path),
       matchesRule: (ruleArgs) =>
@@ -190,7 +170,7 @@ export class EditTool implements BuiltinTool<EditInput> {
           pathClass: this.kaos.pathClass(),
           homeDir: this.kaos.gethome(),
         }),
-      execute: () => this.execution(adjustedArgs, path),
+      execute: () => this.execution(args, path),
     };
   }
 
@@ -201,18 +181,33 @@ export class EditTool implements BuiltinTool<EditInput> {
       const content = modelView.text;
       const replaceAll = args.replace_all ?? false;
 
+      // Apply backslash fallback after auth — adjust both old_string and
+      // new_string with the same transformation so the replacement is correct.
+      let oldString = args.old_string;
+      let newString = args.new_string;
+      if (!content.includes(oldString)) {
+        const adjusted = findBackslashAdjustedMatch(content, oldString);
+        if (adjusted !== undefined) {
+          oldString = adjusted.adjusted;
+          newString = applyBackslashFix(
+            newString,
+            adjusted.variant as 'escape' | 'collapse-only' | 'unescape-seq-first',
+          );
+        }
+      }
+
       if (!replaceAll) {
         let count = 0;
         let pos = 0;
         while (pos < content.length) {
-          const idx = content.indexOf(args.old_string, pos);
+          const idx = content.indexOf(oldString, pos);
           if (idx === -1) break;
           count++;
-          pos = idx + args.old_string.length;
+          pos = idx + oldString.length;
         }
 
         if (count === 0) {
-          const hint = buildNotFoundHint(content, args.old_string, args.path);
+          const hint = buildNotFoundHint(content, oldString, args.path);
           return { isError: true, output: `old_string not found in ${args.path}. ${hint}\nThe file contents may be out of date. Please use the Read Tool to reload the content.
 ` };
         }
@@ -225,7 +220,7 @@ export class EditTool implements BuiltinTool<EditInput> {
           };
         }
 
-        const newContent = replaceOnceLiteral(content, args.old_string, args.new_string);
+        const newContent = replaceOnceLiteral(content, oldString, newString);
         await this.kaos.writeText(
           safePath,
           materializeModelText(newContent, modelView.lineEndingStyle),
@@ -233,15 +228,15 @@ export class EditTool implements BuiltinTool<EditInput> {
         return { output: `Replaced 1 occurrence in ${args.path}` };
       }
 
-      const parts = content.split(args.old_string);
+      const parts = content.split(oldString);
       const replacementCount = parts.length - 1;
       if (replacementCount === 0) {
-        const hint = buildNotFoundHint(content, args.old_string, args.path);
+        const hint = buildNotFoundHint(content, oldString, args.path);
         return { isError: true, output: `old_string not found in ${args.path}. ${hint}\nThe file contents may be out of date. Please use the Read Tool to reload the content.
 ` };
       }
 
-      const newContent = parts.join(args.new_string);
+      const newContent = parts.join(newString);
       await this.kaos.writeText(
         safePath,
         materializeModelText(newContent, modelView.lineEndingStyle),

--- a/packages/agent-core/src/tools/builtin/file/edit.ts
+++ b/packages/agent-core/src/tools/builtin/file/edit.ts
@@ -74,10 +74,10 @@ function findBackslashAdjustedMatch(
   // If old_string contains sequences like "\\n" that the file doesn't have,
   // try replacing "\\n" → "\n" etc.
   const unescaped = oldString
-    .replace(/\\\\n/g, '\n')
-    .replace(/\\\\t/g, '\t')
-    .replace(/\\\\r/g, '\r')
-    .replace(/\\\\\\\\/g, '\\');
+    .replaceAll('\\n', '\n')
+    .replaceAll('\\t', '\t')
+    .replaceAll('\\r', '\r')
+    .replaceAll('\\\\', '\\');
   if (unescaped !== oldString) {
     variants.push({ adjusted: unescaped, variant: 'unescape-sequences' });
   }
@@ -85,16 +85,16 @@ function findBackslashAdjustedMatch(
   // Variant 2: the LLM under-escaped — the file has literal double-backslash
   // but old_string has single.  Try the reverse.
   const overEscaped = oldString
-    .replace(/\\n/g, '\\n')
-    .replace(/\\t/g, '\\t')
-    .replace(/\\r/g, '\\r');
+    .replaceAll(/\\n/g, '\\n')
+    .replaceAll(/\\t/g, '\\t')
+    .replaceAll(/\\r/g, '\\r');
   // Only try this if it actually changed something and differs from variant 1.
   if (overEscaped !== oldString && overEscaped !== unescaped) {
     variants.push({ adjusted: overEscaped, variant: 'escape-sequences' });
   }
 
   for (const v of variants) {
-    if (content.indexOf(v.adjusted) !== -1) {
+    if (content.includes(v.adjusted)) {
       return v;
     }
   }
@@ -105,7 +105,7 @@ function findBackslashAdjustedMatch(
  * Build a short diagnostic snippet showing the first divergence between
  * `oldString` and the file content, helpful when old_string is not found.
  */
-function buildNotFoundHint(content: string, oldString: string, filePath: string): string {
+function buildNotFoundHint(content: string, oldString: string, _filePath: string): string {
   const lines = content.split('\n');
   const firstLine = oldString.split('\n')[0] ?? '';
   if (firstLine.length === 0) return '';
@@ -177,7 +177,7 @@ export class EditTool implements BuiltinTool<EditInput> {
       // encoding fixes that cover common LLM mis-encodings.
       let oldString = args.old_string;
       let backslashHint: string | undefined;
-      if (content.indexOf(oldString) === -1) {
+      if (!content.includes(oldString)) {
         const adjusted = findBackslashAdjustedMatch(content, oldString);
         if (adjusted !== undefined) {
           oldString = adjusted.adjusted;

--- a/packages/agent-core/src/tools/builtin/file/edit.ts
+++ b/packages/agent-core/src/tools/builtin/file/edit.ts
@@ -62,37 +62,53 @@ function replaceOnceLiteral(content: string, oldString: string, newString: strin
  */
 function applyBackslashFix(
   input: string,
-  variant: 'unescape' | 'escape',
+  variant: 'unescape-collapse-first' | 'unescape-seq-first' | 'escape',
 ): string {
-  if (variant === 'unescape') {
+  if (variant === 'unescape-collapse-first') {
+    // Collapse doubled backslashes first, then translate escape sequences.
+    // Handles: LLM sent \\n (two backslashes + n) but file has \n (one backslash + n).
+    return input
+      .replaceAll('\\\\', '\\')
+      .replaceAll('\\n', '\n')
+      .replaceAll('\\t', '\t')
+      .replaceAll('\\r', '\r');
+  }
+  if (variant === 'unescape-seq-first') {
+    // Translate escape sequences first, then collapse doubled backslashes.
+    // Handles: LLM sent \n (real newline) but file has \n (backslash + n).
     return input
       .replaceAll('\\n', '\n')
       .replaceAll('\\t', '\t')
       .replaceAll('\\r', '\r')
       .replaceAll('\\\\', '\\');
   }
+  // escape: replace real newlines with backslash-n.
+  // Handles: LLM sent \n (real newline) but file has \\n (two backslashes + n).
   return input
     .replaceAll('\n', '\\n')
     .replaceAll('\t', '\\t')
     .replaceAll('\r', '\\r');
 }
+
 function findBackslashAdjustedMatch(
   content: string,
   oldString: string,
-): { adjusted: string; variant: 'unescape' | 'escape' } | undefined {
-  // Check escape first (handles real newlines → backslash-n), then unescape
-  // (handles doubled backslashes → single). Order matters: escape must come
-  // first because unescape would incorrectly match real newlines.
-  const overEscaped = applyBackslashFix(oldString, 'escape');
-  if (overEscaped !== oldString && content.includes(overEscaped)) {
-    return { adjusted: overEscaped, variant: 'escape' };
+): { adjusted: string; variant: string } | undefined {
+  // Try all three variants and return the first that matches the file content.
+  // Each handles a different LLM encoding mistake:
+  //   collapse-first: \\n → \n (double backslash collapsed before escape seq)
+  //   seq-first:      \n → \n (real newline converted before collapse)
+  //   escape:         \n → \\n (real newline re-escaped to backslash-n)
+  const candidates: Array<{ adjusted: string; variant: string }> = [
+    { adjusted: applyBackslashFix(oldString, 'escape'), variant: 'escape' },
+    { adjusted: applyBackslashFix(oldString, 'unescape-collapse-first'), variant: 'unescape-collapse-first' },
+    { adjusted: applyBackslashFix(oldString, 'unescape-seq-first'), variant: 'unescape-seq-first' },
+  ];
+  for (const c of candidates) {
+    if (c.adjusted !== oldString && content.includes(c.adjusted)) {
+      return c;
+    }
   }
-
-  const unescaped = applyBackslashFix(oldString, 'unescape');
-  if (unescaped !== oldString && content.includes(unescaped)) {
-    return { adjusted: unescaped, variant: 'unescape' };
-  }
-
   return undefined;
 }
 
@@ -177,7 +193,7 @@ export class EditTool implements BuiltinTool<EditInput> {
         const adjusted = findBackslashAdjustedMatch(content, oldString);
         if (adjusted !== undefined) {
           oldString = adjusted.adjusted;
-          newString = applyBackslashFix(newString, adjusted.variant);
+          newString = applyBackslashFix(newString, adjusted.variant as 'escape' | 'unescape-collapse-first' | 'unescape-seq-first');
           backslashHint = ` (matched after ${adjusted.variant} adjustment)`;
         }
       }

--- a/packages/agent-core/src/tools/builtin/file/edit.ts
+++ b/packages/agent-core/src/tools/builtin/file/edit.ts
@@ -80,23 +80,19 @@ function findBackslashAdjustedMatch(
   content: string,
   oldString: string,
 ): { adjusted: string; variant: 'unescape' | 'escape' } | undefined {
-  const variants: Array<{ adjusted: string; variant: 'unescape' | 'escape' }> = [];
+  // Check escape first (handles real newlines → backslash-n), then unescape
+  // (handles doubled backslashes → single). Order matters: escape must come
+  // first because unescape would incorrectly match real newlines.
+  const overEscaped = applyBackslashFix(oldString, 'escape');
+  if (overEscaped !== oldString && content.includes(overEscaped)) {
+    return { adjusted: overEscaped, variant: 'escape' };
+  }
 
   const unescaped = applyBackslashFix(oldString, 'unescape');
-  if (unescaped !== oldString) {
-    variants.push({ adjusted: unescaped, variant: 'unescape' });
+  if (unescaped !== oldString && content.includes(unescaped)) {
+    return { adjusted: unescaped, variant: 'unescape' };
   }
 
-  const overEscaped = applyBackslashFix(oldString, 'escape');
-  if (overEscaped !== oldString && overEscaped !== unescaped) {
-    variants.push({ adjusted: overEscaped, variant: 'escape' });
-  }
-
-  for (const v of variants) {
-    if (content.includes(v.adjusted)) {
-      return v;
-    }
-  }
   return undefined;
 }
 

--- a/packages/agent-core/src/tools/builtin/file/edit.ts
+++ b/packages/agent-core/src/tools/builtin/file/edit.ts
@@ -62,46 +62,38 @@ function replaceOnceLiteral(content: string, oldString: string, newString: strin
  */
 function applyBackslashFix(
   input: string,
-  variant: 'unescape-collapse-first' | 'unescape-seq-first' | 'escape',
+  variant: 'collapse-only' | 'escape' | 'unescape-seq-first',
 ): string {
-  if (variant === 'unescape-collapse-first') {
-    // Collapse doubled backslashes first, then translate escape sequences.
-    // Handles: LLM sent \\n (two backslashes + n) but file has \n (one backslash + n).
-    return input
-      .replaceAll('\\\\', '\\')
-      .replaceAll('\\n', '\n')
-      .replaceAll('\\t', '\t')
-      .replaceAll('\\r', '\r');
+  if (variant === 'collapse-only') {
+    // Only collapse doubled backslashes — no escape sequence processing.
+    // Handles: LLM sent \\\\n (two backslashes + n) but file has \n (one backslash + n).
+    return input.replaceAll('\\\\', '\\');
   }
-  if (variant === 'unescape-seq-first') {
-    // Translate escape sequences first, then collapse doubled backslashes.
-    // Handles: LLM sent \n (real newline) but file has \n (backslash + n).
+  if (variant === 'escape') {
+    // Replace real newlines with backslash-n.
+    // Handles: LLM sent \n (real newline) but file has \\n (two backslashes + n).
     return input
-      .replaceAll('\\n', '\n')
-      .replaceAll('\\t', '\t')
-      .replaceAll('\\r', '\r')
-      .replaceAll('\\\\', '\\');
+      .replaceAll('\n', '\\n')
+      .replaceAll('\t', '\\t')
+      .replaceAll('\r', '\\r');
   }
-  // escape: replace real newlines with backslash-n.
-  // Handles: LLM sent \n (real newline) but file has \\n (two backslashes + n).
+  // unescape-seq-first: translate escape sequences first, then collapse.
+  // Handles: LLM sent \n (real newline) but file has \n (backslash + n).
   return input
-    .replaceAll('\n', '\\n')
-    .replaceAll('\t', '\\t')
-    .replaceAll('\r', '\\r');
+    .replaceAll('\\n', '\n')
+    .replaceAll('\\t', '\t')
+    .replaceAll('\\r', '\r')
+    .replaceAll('\\\\', '\\');
 }
 
 function findBackslashAdjustedMatch(
   content: string,
   oldString: string,
 ): { adjusted: string; variant: string } | undefined {
-  // Try all three variants and return the first that matches the file content.
-  // Each handles a different LLM encoding mistake:
-  //   collapse-first: \\n → \n (double backslash collapsed before escape seq)
-  //   seq-first:      \n → \n (real newline converted before collapse)
-  //   escape:         \n → \\n (real newline re-escaped to backslash-n)
+  // Try all variants and return the first that matches the file content.
   const candidates: Array<{ adjusted: string; variant: string }> = [
+    { adjusted: applyBackslashFix(oldString, 'collapse-only'), variant: 'collapse-only' },
     { adjusted: applyBackslashFix(oldString, 'escape'), variant: 'escape' },
-    { adjusted: applyBackslashFix(oldString, 'unescape-collapse-first'), variant: 'unescape-collapse-first' },
     { adjusted: applyBackslashFix(oldString, 'unescape-seq-first'), variant: 'unescape-seq-first' },
   ];
   for (const c of candidates) {
@@ -193,7 +185,7 @@ export class EditTool implements BuiltinTool<EditInput> {
         const adjusted = findBackslashAdjustedMatch(content, oldString);
         if (adjusted !== undefined) {
           oldString = adjusted.adjusted;
-          newString = applyBackslashFix(newString, adjusted.variant as 'escape' | 'unescape-collapse-first' | 'unescape-seq-first');
+          newString = applyBackslashFix(newString, adjusted.variant as 'escape' | 'collapse-only' | 'unescape-seq-first');
           backslashHint = ` (matched after ${adjusted.variant} adjustment)`;
         }
       }

--- a/packages/agent-core/test/tools/edit.test.ts
+++ b/packages/agent-core/test/tools/edit.test.ts
@@ -460,7 +460,7 @@ describe('EditTool', () => {
     );
   });
 
-  it('recovers when old_string has real newlines but file has literal backslash-n', async () => {
+  it('returns encoding mismatch diagnostic when old_string has real newlines but file has literal backslash-n', async () => {
     const writeText = vi.fn().mockResolvedValue(0);
     // File has backslash + n (two chars): the literal string \n
     const fileContent = 'path = "C:\\nUsers\\nadmin";';
@@ -473,7 +473,7 @@ describe('EditTool', () => {
     );
 
     // LLM sent real newlines (\n as one char) instead of backslash + n (two chars).
-    // The unescape fallback should convert \n → backslash + n to match the file.
+    // The tool should return a diagnostic error instead of silently adjusting.
     const result = await executeTool(tool,
       context({
         path: '/tmp/config.txt',
@@ -482,11 +482,10 @@ describe('EditTool', () => {
       }),
     );
 
-    expect(result.output).toContain('Replaced 1 occurrence');
-    expect(writeText).toHaveBeenCalledWith(
-      '/tmp/config.txt',
-      'path = "D:\\nUsers\\nadmin";',
-    );
+    expect(result).toMatchObject({ isError: true });
+    expect(result.output).toContain('backslash encoding');
+    expect(result.output).toContain('Read Tool');
+    expect(writeText).not.toHaveBeenCalled();
   });
 
   it('provides a diagnostic hint when old_string with backslashes is not found', async () => {

--- a/packages/agent-core/test/tools/edit.test.ts
+++ b/packages/agent-core/test/tools/edit.test.ts
@@ -433,4 +433,83 @@ describe('EditTool', () => {
     expect(result.isError).toBeFalsy();
     expect(writeText).toHaveBeenCalledWith('/workspace-sneaky/test.txt', 'new');
   });
+
+  it('matches files with multiple literal backslashes (Rust string escapes)', async () => {
+    const writeText = vi.fn().mockResolvedValue(0);
+    const fileContent = 'let s = "hello\\nworld";\nlet t = "foo\\tbar";';
+    const tool = new EditTool(
+      createFakeKaos({
+        readText: vi.fn().mockResolvedValue(fileContent),
+        writeText,
+      }),
+      PERMISSIVE_WORKSPACE,
+    );
+
+    const result = await executeTool(tool,
+      context({
+        path: '/tmp/rust.rs',
+        old_string: 'let s = "hello\\nworld";',
+        new_string: 'let s = "hello\\nuniverse";',
+      }),
+    );
+
+    expect(result.output).toContain('Replaced 1 occurrence');
+    expect(writeText).toHaveBeenCalledWith(
+      '/tmp/rust.rs',
+      'let s = "hello\\nuniverse";\nlet t = "foo\\tbar";',
+    );
+  });
+
+  it('recovers when old_string has double-escaped backslashes from LLM JSON encoding', async () => {
+    const writeText = vi.fn().mockResolvedValue(0);
+    // File has a literal backslash followed by 'n' (two chars).
+    const fileContent = 'path = "C:\\nUsers\\nadmin";';
+    const tool = new EditTool(
+      createFakeKaos({
+        readText: vi.fn().mockResolvedValue(fileContent),
+        writeText,
+      }),
+      PERMISSIVE_WORKSPACE,
+    );
+
+    // LLM sent double-escaped: in JS string this is "\\n" (backslash + n)
+    // but it was meant to match the literal "\n" in the file.
+    const result = await executeTool(tool,
+      context({
+        path: '/tmp/config.txt',
+        old_string: 'path = "C:\\nUsers\\nadmin";',
+        new_string: 'path = "D:\\nUsers\\nadmin";',
+      }),
+    );
+
+    expect(result.output).toContain('Replaced 1 occurrence');
+    expect(writeText).toHaveBeenCalledWith(
+      '/tmp/config.txt',
+      'path = "D:\\nUsers\\nadmin";',
+    );
+  });
+
+  it('provides a diagnostic hint when old_string with backslashes is not found', async () => {
+    const writeText = vi.fn().mockResolvedValue(0);
+    const tool = new EditTool(
+      createFakeKaos({
+        readText: vi.fn().mockResolvedValue('alpha beta gamma'),
+        writeText,
+      }),
+      PERMISSIVE_WORKSPACE,
+    );
+
+    const result = await executeTool(tool,
+      context({
+        path: '/tmp/a.txt',
+        old_string: 'delta\\nepsilon',
+        new_string: 'new',
+      }),
+    );
+
+    expect(result).toMatchObject({ isError: true });
+    expect(result.output).toContain('old_string not found');
+    expect(result.output).toContain('The file does not contain a line matching');
+    expect(writeText).not.toHaveBeenCalled();
+  });
 });

--- a/packages/agent-core/test/tools/edit.test.ts
+++ b/packages/agent-core/test/tools/edit.test.ts
@@ -11,9 +11,9 @@ function context(args: EditInput) {
 }
 
 describe('EditTool', () => {
-  it('exposes before/after on the file_io display so the approval panel can render a diff', () => {
+  it('exposes before/after on the file_io display so the approval panel can render a diff', async () => {
     const tool = new EditTool(createFakeKaos(), PERMISSIVE_WORKSPACE);
-    const execution = tool.resolveExecution({
+    const execution = await tool.resolveExecution({
       path: '/tmp/foo.ts',
       old_string: 'a\nb\nc',
       new_string: 'a\nB\nc',
@@ -483,7 +483,6 @@ describe('EditTool', () => {
     );
 
     expect(result.output).toContain('Replaced 1 occurrence');
-    expect(result.output).toContain('escape adjustment');
     expect(writeText).toHaveBeenCalledWith(
       '/tmp/config.txt',
       'path = "D:\\nUsers\\nadmin";',

--- a/packages/agent-core/test/tools/edit.test.ts
+++ b/packages/agent-core/test/tools/edit.test.ts
@@ -460,9 +460,9 @@ describe('EditTool', () => {
     );
   });
 
-  it('recovers when old_string has double-escaped backslashes from LLM JSON encoding', async () => {
+  it('recovers when old_string has real newlines but file has literal backslash-n', async () => {
     const writeText = vi.fn().mockResolvedValue(0);
-    // File has a literal backslash followed by 'n' (two chars).
+    // File has backslash + n (two chars): the literal string \n
     const fileContent = 'path = "C:\\nUsers\\nadmin";';
     const tool = new EditTool(
       createFakeKaos({
@@ -472,17 +472,18 @@ describe('EditTool', () => {
       PERMISSIVE_WORKSPACE,
     );
 
-    // LLM sent double-escaped: in JS string this is "\\n" (backslash + n)
-    // but it was meant to match the literal "\n" in the file.
+    // LLM sent real newlines (\n as one char) instead of backslash + n (two chars).
+    // The unescape fallback should convert \n → backslash + n to match the file.
     const result = await executeTool(tool,
       context({
         path: '/tmp/config.txt',
-        old_string: 'path = "C:\\nUsers\\nadmin";',
-        new_string: 'path = "D:\\nUsers\\nadmin";',
+        old_string: 'path = "C:\nUsers\nadmin";',
+        new_string: 'path = "D:\nUsers\nadmin";',
       }),
     );
 
     expect(result.output).toContain('Replaced 1 occurrence');
+    expect(result.output).toContain('escape adjustment');
     expect(writeText).toHaveBeenCalledWith(
       '/tmp/config.txt',
       'path = "D:\\nUsers\\nadmin";',

--- a/packages/agent-core/test/tools/edit.test.ts
+++ b/packages/agent-core/test/tools/edit.test.ts
@@ -11,9 +11,9 @@ function context(args: EditInput) {
 }
 
 describe('EditTool', () => {
-  it('exposes before/after on the file_io display so the approval panel can render a diff', async () => {
+  it('exposes before/after on the file_io display so the approval panel can render a diff', () => {
     const tool = new EditTool(createFakeKaos(), PERMISSIVE_WORKSPACE);
-    const execution = await tool.resolveExecution({
+    const execution = tool.resolveExecution({
       path: '/tmp/foo.ts',
       old_string: 'a\nb\nc',
       new_string: 'a\nB\nc',


### PR DESCRIPTION
…ostics

When old_string is not found, the Edit tool now attempts a backslash unescape fallback to recover from common LLM JSON encoding mistakes (e.g. double-escaped backslashes). Fixes #601.

Changes:
- Added findBackslashAdjustedMatch() that tries common backslash encoding fixes when old_string doesn't match
- Added buildNotFoundHint() that shows the closest matching line in the file when old_string is not found
- Updated edit.md with guidance on backslash encoding

Tests:
- Matches files with multiple literal backslashes (Rust string escapes)
- Recovers when old_string has double-escaped backslashes from LLM
- Provides diagnostic hint when old_string with backslashes not found

Related Issue
Resolve #601

Problem
The Edit tool fails with "old_string not found" when the file contains multiple backslashes (e.g., Rust string literals with \n, \t). The root cause is that the LLM misencodes backslashes when sending old_string in JSON — double-escaping or under-escaping them.

What changed
- Added findBackslashAdjustedMatch() that tries common backslash encoding fixes (unescape-sequences, escape-sequences) when old_string doesn't match
- Added buildNotFoundHint() that shows the closest matching line in the file when old_string is not found
- Updated edit.md with guidance on backslash encoding for the LLM

Checklist
- [x] I have read the CONTRIBUTING document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran gen-changesets skill.
- [ ] Ran gen-docs skill, or this PR needs no doc update.
