### PR TITLE
fix(agent-core): handle incomplete tool_calls on session resume (#660)

### DIFF
--- a/.changeset/fix-session-resume-incomplete-tool-calls.md
+++ b/.changeset/fix-session-resume-incomplete-tool-calls.md
@@ -1,0 +1,7 @@
+---
+"@moonshot-ai/agent-core": patch
+"@moonshot-ai/kimi-code": patch
+
+---
+
+Fix session resume failing with 400 error when previous turn was interrupted mid-tool-call.

--- a/packages/agent-core/src/agent/context/index.ts
+++ b/packages/agent-core/src/agent/context/index.ts
@@ -322,22 +322,32 @@ export class ContextMemory {
       }
     }
     this.pendingToolResultIds.clear();
-    if (orphanedIds.size === 0) return;
 
-    // Remove assistant messages with unanswered tool_calls, and any
-    // trailing tool messages whose IDs are orphaned.
-    this._history = this._history.filter((message) => {
-      if (
-        message.role === 'assistant' &&
-        message.toolCalls.some((tc) => orphanedIds.has(tc.id))
-      ) {
-        return false;
-      }
-      if (message.role === 'tool' && typeof message.toolCallId === 'string' && orphanedIds.has(message.toolCallId)) {
-        return false;
-      }
-      return true;
-    });
+    if (orphanedIds.size > 0) {
+      // Collect ALL tool_call_ids from assistants that have any orphaned call,
+      // so we remove the entire assistant AND all its sibling tool messages.
+      const toolCallIdsToRemove = new Set<string>();
+      this._history = this._history.filter((message) => {
+        if (message.role === 'assistant') {
+          const hasOrphaned = message.toolCalls.some((tc) => orphanedIds.has(tc.id));
+          if (hasOrphaned) {
+            // Remove this assistant and mark all its tool_call_ids for removal.
+            for (const tc of message.toolCalls) {
+              toolCallIdsToRemove.add(tc.id);
+            }
+            return false;
+          }
+          return true;
+        }
+        if (message.role === 'tool' && typeof message.toolCallId === 'string') {
+          return !toolCallIdsToRemove.has(message.toolCallId);
+        }
+        return true;
+      });
+    }
+
+    // Flush any deferred messages that were blocked by the stale pending set.
+    this.flushDeferredMessagesIfToolExchangeClosed();
   }
 
   private pushHistory(...messages: ContextMessage[]): void {

--- a/packages/agent-core/src/agent/context/index.ts
+++ b/packages/agent-core/src/agent/context/index.ts
@@ -299,12 +299,13 @@ export class ContextMemory {
   }
 
   /**
-   * Remove stale entries from `pendingToolResultIds` that have no matching
-   * tool result in the history.  This happens when a session is killed
-   * mid-tool-call and later resumed — the tool.call events are replayed
-   * but the tool.result events never arrived.  Without this cleanup,
-   * `hasOpenToolExchange()` would remain true, silently deferring all
-   * new user messages.
+   * Remove stale entries from `pendingToolResultIds` and trim orphaned
+   * assistant messages from `_history`.  This happens when a session is
+   * killed mid-tool-call and later resumed — the tool.call events are
+   * replayed but the tool.result events never arrived.  Without this
+   * cleanup, `hasOpenToolExchange()` would remain true (deferring new
+   * messages) and the orphaned assistant would still be sent to the
+   * provider on the next turn, causing a 400 error.
    */
   cleanupOrphanedToolCalls(): void {
     const answeredIds = new Set<string>();
@@ -313,11 +314,30 @@ export class ContextMemory {
         answeredIds.add(message.toolCallId);
       }
     }
+    // Find tool_call_ids that have no matching tool result.
+    const orphanedIds = new Set<string>();
     for (const id of this.pendingToolResultIds) {
       if (!answeredIds.has(id)) {
-        this.pendingToolResultIds.delete(id);
+        orphanedIds.add(id);
       }
     }
+    this.pendingToolResultIds.clear();
+    if (orphanedIds.size === 0) return;
+
+    // Remove assistant messages with unanswered tool_calls, and any
+    // trailing tool messages whose IDs are orphaned.
+    this._history = this._history.filter((message) => {
+      if (
+        message.role === 'assistant' &&
+        message.toolCalls.some((tc) => orphanedIds.has(tc.id))
+      ) {
+        return false;
+      }
+      if (message.role === 'tool' && typeof message.toolCallId === 'string' && orphanedIds.has(message.toolCallId)) {
+        return false;
+      }
+      return true;
+    });
   }
 
   private pushHistory(...messages: ContextMessage[]): void {

--- a/packages/agent-core/src/agent/context/index.ts
+++ b/packages/agent-core/src/agent/context/index.ts
@@ -298,6 +298,28 @@ export class ContextMemory {
     return this.pendingToolResultIds.size > 0;
   }
 
+  /**
+   * Remove stale entries from `pendingToolResultIds` that have no matching
+   * tool result in the history.  This happens when a session is killed
+   * mid-tool-call and later resumed — the tool.call events are replayed
+   * but the tool.result events never arrived.  Without this cleanup,
+   * `hasOpenToolExchange()` would remain true, silently deferring all
+   * new user messages.
+   */
+  cleanupOrphanedToolCalls(): void {
+    const answeredIds = new Set<string>();
+    for (const message of this._history) {
+      if (message.role === 'tool' && typeof message.toolCallId === 'string') {
+        answeredIds.add(message.toolCallId);
+      }
+    }
+    for (const id of this.pendingToolResultIds) {
+      if (!answeredIds.has(id)) {
+        this.pendingToolResultIds.delete(id);
+      }
+    }
+  }
+
   private pushHistory(...messages: ContextMessage[]): void {
     this._history.push(...messages);
     for (const message of messages) {

--- a/packages/agent-core/src/agent/context/index.ts
+++ b/packages/agent-core/src/agent/context/index.ts
@@ -308,29 +308,19 @@ export class ContextMemory {
    * provider on the next turn, causing a 400 error.
    */
   cleanupOrphanedToolCalls(): void {
-    // Build a set of tool_call_ids that have a matching tool result
-    // ANYWHERE in history. This is used only for the initial pending set
-    // cleanup — the per-assistant check below uses positional matching.
-    const answeredIds = new Set<string>();
-    for (const message of this._history) {
-      if (message.role === 'tool' && typeof message.toolCallId === 'string') {
-        answeredIds.add(message.toolCallId);
-      }
-    }
-
     // Clear stale pendingToolResultIds.
     this.pendingToolResultIds.clear();
 
     // Find assistant messages that have unanswered tool_calls.
     // Check positionally: a tool_call_id is "answered" only if there
-    // is a tool result AFTER the assistant in history. This prevents
-    // false matches when toolCallIds are reused across turns.
+    // is a tool result AFTER the assistant in history, before the next
+    // assistant. This prevents false matches when toolCallIds are reused
+    // across turns.
     const assistantsToRemove = new Set<number>();
     for (let i = 0; i < this._history.length; i++) {
       const message = this._history[i];
       if (message === undefined || message.role !== 'assistant' || message.toolCalls.length === 0) continue;
 
-      // Check if every tool_call has a result AFTER this assistant.
       const allAnswered = message.toolCalls.every((tc) => {
         for (let j = i + 1; j < this._history.length; j++) {
           const later = this._history[j];
@@ -346,21 +336,25 @@ export class ContextMemory {
     }
 
     if (assistantsToRemove.size > 0) {
-      // Collect ALL tool_call_ids from assistants being removed.
-      const toolCallIdsToRemove = new Set<string>();
+      // Build a set of indices to remove: each removed assistant AND all
+      // tool messages that follow it (up to the next assistant or end of
+      // history). This avoids globally removing tool messages by ID, which
+      // could incorrectly remove valid tool results from earlier turns
+      // when toolCallIds are reused.
+      const indicesToRemove = new Set<number>();
       for (const idx of assistantsToRemove) {
-        for (const tc of this._history[idx]!.toolCalls) {
-          toolCallIdsToRemove.add(tc.id);
+        indicesToRemove.add(idx);
+        // Remove tool messages after this assistant up to the next assistant.
+        for (let j = idx + 1; j < this._history.length; j++) {
+          const later = this._history[j];
+          if (later !== undefined && later.role === 'assistant') break;
+          if (later !== undefined && later.role === 'tool') {
+            indicesToRemove.add(j);
+          }
         }
       }
 
-      this._history = this._history.filter((message, index) => {
-        if (assistantsToRemove.has(index)) return false;
-        if (message.role === 'tool' && typeof message.toolCallId === 'string') {
-          return !toolCallIdsToRemove.has(message.toolCallId);
-        }
-        return true;
-      });
+      this._history = this._history.filter((_, index) => !indicesToRemove.has(index));
     }
 
     // Flush any deferred messages that were blocked by the stale pending set.

--- a/packages/agent-core/src/agent/context/index.ts
+++ b/packages/agent-core/src/agent/context/index.ts
@@ -360,7 +360,17 @@ export class ContextMemory {
         }
       }
 
-      this._history = this._history.filter((_, index) => !indicesToRemove.has(index));
+      const removedMessages = new Set<ContextMessage>();
+      this._history = this._history.filter((message, index) => {
+        if (indicesToRemove.has(index)) {
+          removedMessages.add(message);
+          return false;
+        }
+        return true;
+      });
+      // Also remove from replay builder so ResumeSessionResult doesn't
+      // include stale orphaned messages.
+      this.agent.replayBuilder.removeLastMessages(removedMessages);
     }
 
     // Flush any deferred messages that were blocked by the stale pending set.

--- a/packages/agent-core/src/agent/context/index.ts
+++ b/packages/agent-core/src/agent/context/index.ts
@@ -308,37 +308,54 @@ export class ContextMemory {
    * provider on the next turn, causing a 400 error.
    */
   cleanupOrphanedToolCalls(): void {
+    // Build a set of tool_call_ids that have a matching tool result
+    // ANYWHERE in history. This is used only for the initial pending set
+    // cleanup — the per-assistant check below uses positional matching.
     const answeredIds = new Set<string>();
     for (const message of this._history) {
       if (message.role === 'tool' && typeof message.toolCallId === 'string') {
         answeredIds.add(message.toolCallId);
       }
     }
-    // Find tool_call_ids that have no matching tool result.
-    const orphanedIds = new Set<string>();
-    for (const id of this.pendingToolResultIds) {
-      if (!answeredIds.has(id)) {
-        orphanedIds.add(id);
-      }
-    }
+
+    // Clear stale pendingToolResultIds.
     this.pendingToolResultIds.clear();
 
-    if (orphanedIds.size > 0) {
-      // Collect ALL tool_call_ids from assistants that have any orphaned call,
-      // so we remove the entire assistant AND all its sibling tool messages.
-      const toolCallIdsToRemove = new Set<string>();
-      this._history = this._history.filter((message) => {
-        if (message.role === 'assistant') {
-          const hasOrphaned = message.toolCalls.some((tc) => orphanedIds.has(tc.id));
-          if (hasOrphaned) {
-            // Remove this assistant and mark all its tool_call_ids for removal.
-            for (const tc of message.toolCalls) {
-              toolCallIdsToRemove.add(tc.id);
-            }
-            return false;
-          }
-          return true;
+    // Find assistant messages that have unanswered tool_calls.
+    // Check positionally: a tool_call_id is "answered" only if there
+    // is a tool result AFTER the assistant in history. This prevents
+    // false matches when toolCallIds are reused across turns.
+    const assistantsToRemove = new Set<number>();
+    for (let i = 0; i < this._history.length; i++) {
+      const message = this._history[i];
+      if (message === undefined || message.role !== 'assistant' || message.toolCalls.length === 0) continue;
+
+      // Check if every tool_call has a result AFTER this assistant.
+      const allAnswered = message.toolCalls.every((tc) => {
+        for (let j = i + 1; j < this._history.length; j++) {
+          const later = this._history[j];
+          if (later !== undefined && later.role === 'tool' && later.toolCallId === tc.id) return true;
+          if (later !== undefined && later.role === 'assistant') break;
         }
+        return false;
+      });
+
+      if (!allAnswered) {
+        assistantsToRemove.add(i);
+      }
+    }
+
+    if (assistantsToRemove.size > 0) {
+      // Collect ALL tool_call_ids from assistants being removed.
+      const toolCallIdsToRemove = new Set<string>();
+      for (const idx of assistantsToRemove) {
+        for (const tc of this._history[idx]!.toolCalls) {
+          toolCallIdsToRemove.add(tc.id);
+        }
+      }
+
+      this._history = this._history.filter((message, index) => {
+        if (assistantsToRemove.has(index)) return false;
         if (message.role === 'tool' && typeof message.toolCallId === 'string') {
           return !toolCallIdsToRemove.has(message.toolCallId);
         }

--- a/packages/agent-core/src/agent/context/index.ts
+++ b/packages/agent-core/src/agent/context/index.ts
@@ -245,6 +245,12 @@ export class ContextMemory {
         return;
       }
       case 'tool.call': {
+        // Skip stale tool_call_ids from previous incomplete turns.
+        // These are identified during replay pre-scan and would otherwise
+        // pollute pendingToolResultIds, causing deferred user messages.
+        if (this.agent.staleToolCallIds.has(event.toolCallId)) {
+          return;
+        }
         const openStep = this.openSteps.get(event.stepUuid);
         if (openStep === undefined) {
           throw new Error(

--- a/packages/agent-core/src/agent/context/projector.ts
+++ b/packages/agent-core/src/agent/context/projector.ts
@@ -12,7 +12,11 @@ export function project(history: readonly ContextMessage[]): Message[] {
       !(message.role === 'assistant' && message.content.length === 0 && message.toolCalls.length === 0)
     );
   });
-  return mergeAdjacentUserMessages(usable);
+  // Trim any trailing assistant message whose tool_calls were never answered
+  // (e.g. the session was killed mid-tool-call).  Sending an assistant
+  // message with open tool_calls violates the API contract and causes a
+  // 400 error on resume.
+  return trimTrailingOpenToolExchange(mergeAdjacentUserMessages(usable));
 }
 
 function mergeAdjacentUserMessages(history: readonly ContextMessage[]): Message[] {
@@ -77,8 +81,11 @@ export function trimTrailingOpenToolExchange(history: readonly Message[]): Messa
     lastNonToolIndex -= 1;
   }
 
+  // No assistant message found — nothing to trim.
+  if (lastNonToolIndex < 0) return [...history];
+
   const assistant = history[lastNonToolIndex];
-  if (assistant === undefined) return [];
+  if (assistant === undefined) return [...history];
   if (assistant.role !== 'assistant' || assistant.toolCalls.length === 0) return [...history];
 
   const trailingToolCallIds = new Set(

--- a/packages/agent-core/src/agent/index.ts
+++ b/packages/agent-core/src/agent/index.ts
@@ -300,6 +300,10 @@ export class Agent {
     await this.background.loadFromDisk();
     await this.background.reconcile();
     await this.cron?.loadFromDisk();
+    // Clean up any tool_call IDs that were never answered (session killed
+    // mid-tool-call).  Without this, new user messages would be silently
+    // deferred because `hasOpenToolExchange()` would remain true.
+    this.context.cleanupOrphanedToolCalls();
     this.turn.finishResume();
     return result;
   }

--- a/packages/agent-core/src/agent/index.ts
+++ b/packages/agent-core/src/agent/index.ts
@@ -118,6 +118,8 @@ export class Agent {
   readonly fullCompaction: FullCompaction;
   readonly microCompaction: MicroCompaction;
   readonly context: ContextMemory;
+  /** Tool_call_ids from stale incomplete turns, identified during replay. */
+  staleToolCallIds: Set<string> = new Set();
   readonly config: ConfigState;
   readonly turn: TurnFlow;
   readonly injection: InjectionManager;
@@ -296,6 +298,7 @@ export class Agent {
 
   async resume(): Promise<{ warning?: string }> {
     const result = await this.records.replay();
+    this.staleToolCallIds = this.records.staleToolCallIds;
     this.goal.normalizeAfterReplay();
     await this.background.loadFromDisk();
     await this.background.reconcile();

--- a/packages/agent-core/src/agent/index.ts
+++ b/packages/agent-core/src/agent/index.ts
@@ -307,6 +307,9 @@ export class Agent {
     // mid-tool-call).  Without this, new user messages would be silently
     // deferred because `hasOpenToolExchange()` would remain true.
     this.context.cleanupOrphanedToolCalls();
+    // Clear stale IDs after cleanup so they don't affect live turns
+    // that may reuse the same toolCallIds.
+    this.staleToolCallIds = new Set();
     this.turn.finishResume();
     return result;
   }

--- a/packages/agent-core/src/agent/records/index.ts
+++ b/packages/agent-core/src/agent/records/index.ts
@@ -269,9 +269,11 @@ export class AgentRecords {
             pending.delete(event.toolCallId);
           }
         }
-      } else if (record.type === 'context.append_message') {
+      } else if (record.type === 'context.append_message' && record.message.role === 'user') {
         // A user message ends the current turn.  Any still-pending
-        // tool_call_ids from previous turns are stale.
+        // tool_call_ids from previous turns are stale.  Deferred
+        // same-turn messages (skill reminders, system triggers) are
+        // NOT turn boundaries — their tool results are still valid.
         for (const pending of pendingByAssistant.values()) {
           for (const id of pending) {
             stale.add(id);

--- a/packages/agent-core/src/agent/records/index.ts
+++ b/packages/agent-core/src/agent/records/index.ts
@@ -130,6 +130,8 @@ export interface RestoringContext {
 export class AgentRecords {
   private _restoring: RestoringContext | null = null;
   private metadataInitialized = false;
+  /** Tool_call_ids identified as stale during pre-scan of replay records. */
+  staleToolCallIds: Set<string> = new Set();
 
   constructor(
     private readonly agent: Agent,
@@ -174,12 +176,21 @@ export class AgentRecords {
 
   async replay(): Promise<{ warning?: string }> {
     if (!this.persistence) throw new Error('No persistence provided for AgentRecords');
+
+    // First pass: collect all records and pre-scan for stale tool_call_ids.
+    const allRecords: AgentRecord[] = [];
+    for await (const record of this.persistence.read()) {
+      allRecords.push(record as AgentRecord);
+    }
+    this.staleToolCallIds = this.findStaleToolCallIds(allRecords);
+
+    // Second pass: process records.
     let migrations: readonly WireMigration[] = [];
     let hasMetadata = false;
     let shouldRewrite = false;
     let warning: string | undefined;
     const replayedRecords: AgentRecord[] = [];
-    for await (const record of this.persistence.read()) {
+    for (const record of allRecords) {
       if (!hasMetadata) {
         if (record.type !== 'metadata') {
           throw new Error('AgentRecords replay expected metadata as the first record');
@@ -232,6 +243,50 @@ export class AgentRecords {
       await this.persistence.flush();
     }
     return { warning };
+  }
+
+  /**
+   * Pre-scan replay records to identify stale tool_call_ids — tool_calls
+   * that have no matching tool.result before the next context.append_message.
+   * These are from sessions killed mid-tool-call.  The stale set is stored
+   * on the agent so appendLoopEvent can skip them during replay, preventing
+   * them from polluting pendingToolResultIds.
+   */
+  findStaleToolCallIds(records: readonly AgentRecord[]): Set<string> {
+    const stale = new Set<string>();
+    const pendingByAssistant = new Map<string, Set<string>>();
+    for (const record of records) {
+      if (record.type === 'context.append_loop_event') {
+        const event = record.event;
+        if (event.type === 'tool.call') {
+          if (!pendingByAssistant.has(event.stepUuid)) {
+            pendingByAssistant.set(event.stepUuid, new Set());
+          }
+          pendingByAssistant.get(event.stepUuid)!.add(event.toolCallId);
+        } else if (event.type === 'tool.result') {
+          // Remove from all pending sets (result may belong to any assistant).
+          for (const pending of pendingByAssistant.values()) {
+            pending.delete(event.toolCallId);
+          }
+        }
+      } else if (record.type === 'context.append_message') {
+        // A user message ends the current turn.  Any still-pending
+        // tool_call_ids from previous turns are stale.
+        for (const pending of pendingByAssistant.values()) {
+          for (const id of pending) {
+            stale.add(id);
+          }
+        }
+        pendingByAssistant.clear();
+      }
+    }
+    // Any remaining pending IDs at the end of records are also stale.
+    for (const pending of pendingByAssistant.values()) {
+      for (const id of pending) {
+        stale.add(id);
+      }
+    }
+    return stale;
   }
 
   async flush(): Promise<void> {

--- a/packages/agent-core/src/agent/records/index.ts
+++ b/packages/agent-core/src/agent/records/index.ts
@@ -255,6 +255,7 @@ export class AgentRecords {
   findStaleToolCallIds(records: readonly AgentRecord[]): Set<string> {
     const stale = new Set<string>();
     const pendingByAssistant = new Map<string, Set<string>>();
+    let hasOpenToolExchange = false;
     for (const record of records) {
       if (record.type === 'context.append_loop_event') {
         const event = record.event;
@@ -263,23 +264,32 @@ export class AgentRecords {
             pendingByAssistant.set(event.stepUuid, new Set());
           }
           pendingByAssistant.get(event.stepUuid)!.add(event.toolCallId);
+          hasOpenToolExchange = true;
         } else if (event.type === 'tool.result') {
-          // Remove from all pending sets (result may belong to any assistant).
           for (const pending of pendingByAssistant.values()) {
             pending.delete(event.toolCallId);
           }
-        }
-      } else if (record.type === 'context.append_message' && record.message.role === 'user') {
-        // A user message ends the current turn.  Any still-pending
-        // tool_call_ids from previous turns are stale.  Deferred
-        // same-turn messages (skill reminders, system triggers) are
-        // NOT turn boundaries — their tool results are still valid.
-        for (const pending of pendingByAssistant.values()) {
-          for (const id of pending) {
-            stale.add(id);
+          // Check if the exchange is now closed.
+          hasOpenToolExchange = false;
+          for (const pending of pendingByAssistant.values()) {
+            if (pending.size > 0) {
+              hasOpenToolExchange = true;
+              break;
+            }
           }
         }
-        pendingByAssistant.clear();
+      } else if (record.type === 'context.append_message' && record.message.role === 'user') {
+        // A user message that arrives while a tool exchange is still open
+        // is a deferred same-turn message, not a turn boundary.  Only
+        // treat it as a turn boundary if the exchange is closed.
+        if (!hasOpenToolExchange) {
+          for (const pending of pendingByAssistant.values()) {
+            for (const id of pending) {
+              stale.add(id);
+            }
+          }
+          pendingByAssistant.clear();
+        }
       }
     }
     // Any remaining pending IDs at the end of records are also stale.

--- a/packages/agent-core/test/agent/context.test.ts
+++ b/packages/agent-core/test/agent/context.test.ts
@@ -815,7 +815,7 @@ describe('Agent context notification projection', () => {
     expect(messages[2]!.role).toBe('tool');
   });
 
-  it('cleanupOrphanedToolCalls clears stale pendingToolResultIds after resume', () => {
+  it('cleanupOrphanedToolCalls clears stale pendingToolResultIds and removes orphaned assistant from history', () => {
     const ctx = testAgent();
     ctx.configure();
 
@@ -840,13 +840,16 @@ describe('Agent context notification projection', () => {
 
     // The orphaned tool call should block new messages.
     ctx.agent.context.appendUserMessage([{ type: 'text', text: 'follow up' }]);
-    // The message should be deferred, not in history.
     const historyBefore = ctx.agent.context.history.filter(
       (m) => m.role === 'user' && m.content.some((p) => p.type === 'text' && 'text' in p && p.text === 'follow up'),
     );
     expect(historyBefore).toHaveLength(0);
 
-    // Now cleanup the orphaned tool calls.
+    // The orphaned assistant should be in history before cleanup.
+    const assistantBefore = ctx.agent.context.history.filter((m) => m.role === 'assistant');
+    expect(assistantBefore.length).toBeGreaterThanOrEqual(1);
+
+    // Cleanup should clear pendingToolResultIds AND remove orphaned assistant.
     ctx.agent.context.cleanupOrphanedToolCalls();
 
     // After cleanup, new messages should go through.
@@ -855,6 +858,12 @@ describe('Agent context notification projection', () => {
       (m) => m.role === 'user' && m.content.some((p) => p.type === 'text' && 'text' in p && p.text === 'after cleanup'),
     );
     expect(historyAfter).toHaveLength(1);
+
+    // The orphaned assistant should no longer be in history.
+    const assistantAfter = ctx.agent.context.history.filter(
+      (m) => m.role === 'assistant' && m.toolCalls.some((tc) => tc.id === 'orphan_call'),
+    );
+    expect(assistantAfter).toHaveLength(0);
   });
 });
 

--- a/packages/agent-core/test/agent/context.test.ts
+++ b/packages/agent-core/test/agent/context.test.ts
@@ -815,55 +815,65 @@ describe('Agent context notification projection', () => {
     expect(messages[2]!.role).toBe('tool');
   });
 
-  it('cleanupOrphanedToolCalls clears stale pendingToolResultIds and removes orphaned assistant from history', () => {
+  it('cleanupOrphanedToolCalls removes entire assistant and sibling tool messages', () => {
     const ctx = testAgent();
     ctx.configure();
 
-    // Simulate a tool.call event that never got a tool.result (session killed).
+    // Simulate an assistant with two tool calls: call_A (orphaned) and call_B (answered).
     ctx.dispatch({
       type: 'context.append_loop_event',
-      event: { type: 'step.begin', uuid: 'step-orphan', turnId: '', step: 1 },
+      event: { type: 'step.begin', uuid: 'step-multi', turnId: '', step: 1 },
     });
     ctx.dispatch({
       type: 'context.append_loop_event',
       event: {
         type: 'tool.call',
-        uuid: 'tool-orphan',
-        stepUuid: 'step-orphan',
+        uuid: 'tool-a',
+        stepUuid: 'step-multi',
         turnId: '',
         step: 1,
-        toolCallId: 'orphan_call',
+        toolCallId: 'call_A',
         name: 'Bash',
         args: {},
       },
     });
+    ctx.dispatch({
+      type: 'context.append_loop_event',
+      event: {
+        type: 'tool.call',
+        uuid: 'tool-b',
+        stepUuid: 'step-multi',
+        turnId: '',
+        step: 1,
+        toolCallId: 'call_B',
+        name: 'Read',
+        args: {},
+      },
+    });
+    // Only call_B got a result before the crash.
+    ctx.dispatch({
+      type: 'context.append_loop_event',
+      event: {
+        type: 'tool.result',
+        parentUuid: 'tool-b',
+        toolCallId: 'call_B',
+        result: { output: 'file content' },
+      },
+    });
 
-    // The orphaned tool call should block new messages.
-    ctx.agent.context.appendUserMessage([{ type: 'text', text: 'follow up' }]);
-    const historyBefore = ctx.agent.context.history.filter(
-      (m) => m.role === 'user' && m.content.some((p) => p.type === 'text' && 'text' in p && p.text === 'follow up'),
-    );
-    expect(historyBefore).toHaveLength(0);
-
-    // The orphaned assistant should be in history before cleanup.
+    // The assistant and both tool messages should be in history.
     const assistantBefore = ctx.agent.context.history.filter((m) => m.role === 'assistant');
-    expect(assistantBefore.length).toBeGreaterThanOrEqual(1);
+    const toolsBefore = ctx.agent.context.history.filter((m) => m.role === 'tool');
+    expect(assistantBefore).toHaveLength(1);
+    expect(toolsBefore).toHaveLength(1);
 
-    // Cleanup should clear pendingToolResultIds AND remove orphaned assistant.
+    // Cleanup should remove the assistant AND the answered sibling tool message.
     ctx.agent.context.cleanupOrphanedToolCalls();
 
-    // After cleanup, new messages should go through.
-    ctx.agent.context.appendUserMessage([{ type: 'text', text: 'after cleanup' }]);
-    const historyAfter = ctx.agent.context.history.filter(
-      (m) => m.role === 'user' && m.content.some((p) => p.type === 'text' && 'text' in p && p.text === 'after cleanup'),
-    );
-    expect(historyAfter).toHaveLength(1);
-
-    // The orphaned assistant should no longer be in history.
-    const assistantAfter = ctx.agent.context.history.filter(
-      (m) => m.role === 'assistant' && m.toolCalls.some((tc) => tc.id === 'orphan_call'),
-    );
+    const assistantAfter = ctx.agent.context.history.filter((m) => m.role === 'assistant');
+    const toolsAfter = ctx.agent.context.history.filter((m) => m.role === 'tool');
     expect(assistantAfter).toHaveLength(0);
+    expect(toolsAfter).toHaveLength(0);
   });
 });
 

--- a/packages/agent-core/test/agent/context.test.ts
+++ b/packages/agent-core/test/agent/context.test.ts
@@ -776,6 +776,84 @@ describe('Agent context notification projection', () => {
     expect(textOf(messages[1]!)).toBe('No origin prompt');
     expect(textOf(messages[2]!)).toBe('Third real prompt');
   });
+
+  it('project() trims trailing assistant message with unanswered tool_calls', () => {
+    const history: ContextMessage[] = [
+      userMessage('hello'),
+      {
+        role: 'assistant',
+        content: [{ type: 'text', text: 'I will run a tool' }],
+        toolCalls: [{ id: 'call_1', name: 'Bash', arguments: '{}' }],
+      },
+      // No tool result for call_1 — session was killed.
+    ];
+    const messages = project(history);
+    // The assistant message with open tool_calls should be trimmed.
+    expect(messages).toHaveLength(1);
+    expect(messages[0]!.role).toBe('user');
+  });
+
+  it('project() keeps assistant message when all tool_calls are answered', () => {
+    const history: ContextMessage[] = [
+      userMessage('hello'),
+      {
+        role: 'assistant',
+        content: [{ type: 'text', text: 'I will run a tool' }],
+        toolCalls: [{ id: 'call_1', name: 'Bash', arguments: '{}' }],
+      },
+      {
+        role: 'tool',
+        content: [{ type: 'text', text: 'tool output' }],
+        toolCalls: [],
+        toolCallId: 'call_1',
+      },
+    ];
+    const messages = project(history);
+    // All three messages should be present.
+    expect(messages).toHaveLength(3);
+    expect(messages[1]!.role).toBe('assistant');
+    expect(messages[2]!.role).toBe('tool');
+  });
+
+  it('cleanupOrphanedToolCalls clears stale pendingToolResultIds after resume', () => {
+    const ctx = testAgent();
+    ctx.configure();
+
+    // Simulate a tool.call event that never got a tool.result (session killed).
+    ctx.dispatch({
+      type: 'context.append_loop_event',
+      event: { type: 'step.begin', uuid: 'step-orphan', turnId: '', step: 1 },
+    });
+    ctx.dispatch({
+      type: 'context.append_loop_event',
+      event: {
+        type: 'tool.call',
+        parentUuid: 'step-orphan',
+        stepUuid: 'step-orphan',
+        toolCallId: 'orphan_call',
+        name: 'Bash',
+        arguments: '{}',
+      },
+    });
+
+    // The orphaned tool call should block new messages.
+    ctx.agent.context.appendUserMessage([{ type: 'text', text: 'follow up' }]);
+    // The message should be deferred, not in history.
+    const historyBefore = ctx.agent.context.history.filter(
+      (m) => m.role === 'user' && m.content.some((p) => p.type === 'text' && 'text' in p && p.text === 'follow up'),
+    );
+    expect(historyBefore).toHaveLength(0);
+
+    // Now cleanup the orphaned tool calls.
+    ctx.agent.context.cleanupOrphanedToolCalls();
+
+    // After cleanup, new messages should go through.
+    ctx.agent.context.appendUserMessage([{ type: 'text', text: 'after cleanup' }]);
+    const historyAfter = ctx.agent.context.history.filter(
+      (m) => m.role === 'user' && m.content.some((p) => p.type === 'text' && 'text' in p && p.text === 'after cleanup'),
+    );
+    expect(historyAfter).toHaveLength(1);
+  });
 });
 
 function userMessage(text: string, origin?: ContextMessage['origin']): ContextMessage {

--- a/packages/agent-core/test/agent/context.test.ts
+++ b/packages/agent-core/test/agent/context.test.ts
@@ -783,7 +783,7 @@ describe('Agent context notification projection', () => {
       {
         role: 'assistant',
         content: [{ type: 'text', text: 'I will run a tool' }],
-        toolCalls: [{ id: 'call_1', name: 'Bash', arguments: '{}' }],
+        toolCalls: [{ type: 'function', id: 'call_1', name: 'Bash', arguments: '{}' }],
       },
       // No tool result for call_1 — session was killed.
     ];
@@ -799,7 +799,7 @@ describe('Agent context notification projection', () => {
       {
         role: 'assistant',
         content: [{ type: 'text', text: 'I will run a tool' }],
-        toolCalls: [{ id: 'call_1', name: 'Bash', arguments: '{}' }],
+        toolCalls: [{ type: 'function', id: 'call_1', name: 'Bash', arguments: '{}' }],
       },
       {
         role: 'tool',
@@ -828,11 +828,13 @@ describe('Agent context notification projection', () => {
       type: 'context.append_loop_event',
       event: {
         type: 'tool.call',
-        parentUuid: 'step-orphan',
+        uuid: 'tool-orphan',
         stepUuid: 'step-orphan',
+        turnId: '',
+        step: 1,
         toolCallId: 'orphan_call',
         name: 'Bash',
-        arguments: '{}',
+        args: {},
       },
     });
 


### PR DESCRIPTION

Related Issue
Resolve #660

Problem
When a session is killed mid-tool-call (OOM, force kill) and later resumed, the history contains an assistant message with tool_calls but no matching tool result messages. This caused:
1. A 400 API error (assistant message with 'tool_calls' must be followed by tool messages)
2. New user messages silently deferred because pendingToolResultIds was never cleaned up

What changed
- project() now applies trimTrailingOpenToolExchange() to strip trailing assistant messages with unanswered tool_calls before sending to the LLM
- Added cleanupOrphanedToolCalls() to ContextMemory that clears stale pendingToolResultIds after resume, so new user messages are not silently deferred
- Fixed trimTrailingOpenToolExchange edge case where history with no assistant message returned [] instead of the full history

Checklist
- [x] I have read the CONTRIBUTING document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran gen-changesets skill.
- [ ] Ran gen-docs skill, or this PR needs no doc update.