### PR TITLE
feat(tui): enrich /status card with runtime context and colorized fields

### DIFF
--- a/.changeset/rich-status-card.md
+++ b/.changeset/rich-status-card.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": minor
+---
+
+Enrich the `/status` panel with runtime context and colorized fields.

--- a/apps/kimi-code/src/tui/commands/info.ts
+++ b/apps/kimi-code/src/tui/commands/info.ts
@@ -116,14 +116,18 @@ export async function showStatusReport(host: SlashCommandHost): Promise<void> {
     thinking: appState.thinking,
     permissionMode: appState.permissionMode,
     planMode: appState.planMode,
+    swarmMode: appState.swarmMode,
     contextUsage: appState.contextUsage,
     contextTokens: appState.contextTokens,
     maxContextTokens: appState.maxContextTokens,
     availableModels: appState.availableModels,
+    availableProviders: appState.availableProviders,
     status: runtimeStatus.status,
     statusError: runtimeStatus.error,
     managedUsage: managedUsage?.usage,
     managedUsageError: managedUsage?.error,
+    mcpServersSummary: appState.mcpServersSummary,
+    goal: appState.goal,
   };
   const panel = new UsagePanelComponent(() => buildStatusReportLines(reportArgs), 'primary', ' Status ');
   host.state.transcriptContainer.addChild(panel);

--- a/apps/kimi-code/src/tui/components/messages/status-panel.ts
+++ b/apps/kimi-code/src/tui/components/messages/status-panel.ts
@@ -120,6 +120,7 @@ export function buildStatusReportLines(options: StatusReportOptions): string[] {
 
   const permission = options.status?.permission ?? options.permissionMode;
   const planMode = options.status?.planMode ?? options.planMode;
+  const swarmMode = options.status?.swarmMode ?? options.swarmMode;
   const sessionId = options.sessionId.trim().length > 0 ? options.sessionId : 'none';
   const modelCount = Object.keys(options.availableModels).length;
   const providerCount = Object.keys(options.availableProviders).length;
@@ -131,7 +132,7 @@ export function buildStatusReportLines(options: StatusReportOptions): string[] {
     { label: 'Directory', value: options.workDir },
     { label: 'Permissions', value: formatPermissionMode(permission, value, errorStyle) },
     { label: 'Plan mode', value: formatPlanMode(planMode, value, muted) },
-    { label: 'Swarm', value: formatSwarmMode(options.swarmMode, value, muted) },
+    { label: 'Swarm', value: formatSwarmMode(swarmMode, value, muted) },
     { label: 'Session', value: sessionId },
   ];
   const title = options.sessionTitle?.trim();

--- a/apps/kimi-code/src/tui/components/messages/status-panel.ts
+++ b/apps/kimi-code/src/tui/components/messages/status-panel.ts
@@ -80,7 +80,10 @@ function formatSwarmMode(swarmMode: boolean, value: Colorize, muted: Colorize): 
 
 function formatGoalStatus(goal: GoalSnapshot | null | undefined): string | undefined {
   if (goal === null || goal === undefined) return undefined;
-  const objective = goal.objective.length > 40 ? `${goal.objective.slice(0, 40)}…` : goal.objective;
+  // Truncate by Unicode code points so a surrogate pair (e.g. an emoji) is
+  // never split in half at the cut boundary.
+  const chars = Array.from(goal.objective);
+  const objective = chars.length > 40 ? `${chars.slice(0, 40).join('')}…` : goal.objective;
   return `${objective} · ${goal.status}`;
 }
 

--- a/apps/kimi-code/src/tui/components/messages/status-panel.ts
+++ b/apps/kimi-code/src/tui/components/messages/status-panel.ts
@@ -5,7 +5,7 @@
  * separate from the TUI orchestration layer.
  */
 
-import type { ModelAlias, PermissionMode, SessionStatus } from '@moonshot-ai/kimi-code-sdk';
+import type { GoalSnapshot, ModelAlias, PermissionMode, ProviderConfig, SessionStatus } from '@moonshot-ai/kimi-code-sdk';
 
 import { PRODUCT_NAME } from '#/constant/app';
 import { currentTheme } from '#/tui/theme';
@@ -33,14 +33,18 @@ export interface StatusReportOptions {
   readonly thinking: boolean;
   readonly permissionMode: PermissionMode;
   readonly planMode: boolean;
+  readonly swarmMode: boolean;
   readonly contextUsage: number;
   readonly contextTokens: number;
   readonly maxContextTokens: number;
   readonly availableModels: Record<string, ModelAlias>;
+  readonly availableProviders: Record<string, ProviderConfig>;
   readonly status?: SessionStatus;
   readonly statusError?: string;
   readonly managedUsage?: ManagedUsageReport;
   readonly managedUsageError?: string;
+  readonly mcpServersSummary?: string | null;
+  readonly goal?: GoalSnapshot | null;
 }
 
 type Colorize = (text: string) => string;
@@ -58,6 +62,26 @@ function formatModelStatus(options: StatusReportOptions): string {
     ? 'off'
     : 'on';
   return `${displayModelName(model, options.availableModels)} (thinking ${thinking})`;
+}
+
+function formatPermissionMode(permission: PermissionMode, value: Colorize, errorStyle: Colorize): string {
+  if (permission === 'yolo') return errorStyle('yolo');
+  if (permission === 'auto') return value('auto');
+  return value(permission);
+}
+
+function formatPlanMode(planMode: boolean, value: Colorize, muted: Colorize): string {
+  return planMode ? value('on') : muted('off');
+}
+
+function formatSwarmMode(swarmMode: boolean, value: Colorize, muted: Colorize): string {
+  return swarmMode ? value('on') : muted('off');
+}
+
+function formatGoalStatus(goal: GoalSnapshot | null | undefined): string | undefined {
+  if (goal === null || goal === undefined) return undefined;
+  const objective = goal.objective.length > 40 ? `${goal.objective.slice(0, 40)}…` : goal.objective;
+  return `${objective} · ${goal.status}`;
 }
 
 function addFieldRows(
@@ -97,15 +121,31 @@ export function buildStatusReportLines(options: StatusReportOptions): string[] {
   const permission = options.status?.permission ?? options.permissionMode;
   const planMode = options.status?.planMode ?? options.planMode;
   const sessionId = options.sessionId.trim().length > 0 ? options.sessionId : 'none';
+  const modelCount = Object.keys(options.availableModels).length;
+  const providerCount = Object.keys(options.availableProviders).length;
+  const mcpSummary = options.mcpServersSummary?.trim();
+  const goalStatus = formatGoalStatus(options.goal);
+
   const rows: FieldRow[] = [
     { label: 'Model', value: formatModelStatus(options) },
     { label: 'Directory', value: options.workDir },
-    { label: 'Permissions', value: permission },
-    { label: 'Plan mode', value: planMode ? 'on' : 'off' },
+    { label: 'Permissions', value: formatPermissionMode(permission, value, errorStyle) },
+    { label: 'Plan mode', value: formatPlanMode(planMode, value, muted) },
+    { label: 'Swarm', value: formatSwarmMode(options.swarmMode, value, muted) },
     { label: 'Session', value: sessionId },
   ];
   const title = options.sessionTitle?.trim();
   if (title !== undefined && title.length > 0) rows.push({ label: 'Title', value: title });
+  if (goalStatus !== undefined) {
+    rows.push({ label: 'Goal', value: goalStatus });
+  }
+  rows.push(
+    { label: 'Providers', value: `${providerCount}` },
+    { label: 'Models', value: `${modelCount}` },
+  );
+  if (mcpSummary !== undefined && mcpSummary.length > 0) {
+    rows.push({ label: 'MCP servers', value: mcpSummary });
+  }
   if (options.statusError !== undefined) {
     rows.push({ label: 'Warning', value: options.statusError, severity: 'error' });
   }

--- a/apps/kimi-code/test/tui/components/messages/status-panel.test.ts
+++ b/apps/kimi-code/test/tui/components/messages/status-panel.test.ts
@@ -17,6 +17,7 @@ describe('status panel report lines', () => {
       thinking: true,
       permissionMode: 'manual',
       planMode: false,
+      swarmMode: false,
       contextUsage: 0.25,
       contextTokens: 2500,
       maxContextTokens: 10000,
@@ -26,6 +27,33 @@ describe('status panel report lines', () => {
           model: 'kimi-k2',
           maxContextSize: 10000,
           displayName: 'Kimi K2',
+        },
+      },
+      availableProviders: {
+        'managed:kimi-code': {
+          type: 'kimi',
+          apiKey: 'sk-test',
+        },
+      },
+      mcpServersSummary: '2 connected',
+      goal: {
+        goalId: 'goal-1',
+        objective: 'Ship the status card',
+        status: 'active',
+        turnsUsed: 3,
+        tokensUsed: 1200,
+        wallClockMs: 45000,
+        budget: {
+          tokenBudget: null,
+          turnBudget: null,
+          wallClockBudgetMs: null,
+          remainingTokens: null,
+          remainingTurns: null,
+          remainingWallClockMs: null,
+          tokenBudgetReached: false,
+          turnBudgetReached: false,
+          wallClockBudgetReached: false,
+          overBudget: false,
         },
       },
       status: {
@@ -56,8 +84,13 @@ describe('status panel report lines', () => {
     expect(output).toContain('Directory    /tmp/project');
     expect(output).toContain('Permissions  auto');
     expect(output).toContain('Plan mode    on');
+    expect(output).toContain('Swarm        off');
     expect(output).toContain('Session      ses-1');
     expect(output).toContain('Title        Implement status');
+    expect(output).toContain('Goal         Ship the status card · active');
+    expect(output).toContain('Providers    1');
+    expect(output).toContain('Models       1');
+    expect(output).toContain('MCP servers  2 connected');
     expect(output).toContain('Context window');
     expect(output).toContain('25.0%');
     expect(output).toContain('(3.0k / 12.0k)');
@@ -65,7 +98,6 @@ describe('status panel report lines', () => {
     expect(output).toContain('8% used');
     expect(output).not.toContain('Account');
     expect(output).not.toContain('AGENTS.md');
-    expect(output).not.toContain('Runtime');
   });
 
   it('falls back to app state and shows status load errors as warnings', () => {
@@ -78,10 +110,12 @@ describe('status panel report lines', () => {
       thinking: false,
       permissionMode: 'manual',
       planMode: false,
+      swarmMode: false,
       contextUsage: 0,
       contextTokens: 0,
       maxContextTokens: 0,
       availableModels: {},
+      availableProviders: {},
       statusError: 'No active session',
     }).map(strip);
 

--- a/apps/kimi-code/test/tui/components/messages/status-panel.test.ts
+++ b/apps/kimi-code/test/tui/components/messages/status-panel.test.ts
@@ -147,4 +147,49 @@ describe('status panel report lines', () => {
 
     expect(lines.join('\n')).toContain('Swarm        on');
   });
+
+  it('truncates a long goal objective without splitting a surrogate pair', () => {
+    // 50 rocket emojis (each a surrogate pair); the truncation point at 40
+    // code points must fall between pairs, never inside one.
+    const objective = '🚀'.repeat(50);
+    const lines = buildStatusReportLines({
+      version: '1.2.3',
+      model: 'k2',
+      workDir: '/tmp/project',
+      sessionId: 'ses-1',
+      sessionTitle: null,
+      thinking: false,
+      permissionMode: 'manual',
+      planMode: false,
+      swarmMode: false,
+      contextUsage: 0,
+      contextTokens: 0,
+      maxContextTokens: 0,
+      availableModels: {},
+      availableProviders: {},
+      goal: {
+        goalId: 'g1',
+        objective,
+        status: 'active',
+        turnsUsed: 0,
+        tokensUsed: 0,
+        wallClockMs: 0,
+        budget: {
+          tokenBudget: null,
+          turnBudget: null,
+          wallClockBudgetMs: null,
+          remainingTokens: null,
+          remainingTurns: null,
+          remainingWallClockMs: null,
+          tokenBudgetReached: false,
+          turnBudgetReached: false,
+          wallClockBudgetReached: false,
+          overBudget: false,
+        },
+      },
+    }).map(strip);
+
+    // 40 emojis + ellipsis, and every emoji intact (no lone surrogate halves).
+    expect(lines.join('\n')).toContain('🚀'.repeat(40) + '…');
+  });
 });

--- a/apps/kimi-code/test/tui/components/messages/status-panel.test.ts
+++ b/apps/kimi-code/test/tui/components/messages/status-panel.test.ts
@@ -125,4 +125,26 @@ describe('status panel report lines', () => {
     expect(output).toContain('Warning      No active session');
     expect(output).toContain('No context window data available.');
   });
+
+  it('reads swarm mode from runtime status over stale app state', () => {
+    const lines = buildStatusReportLines({
+      version: '1.2.3',
+      model: 'k2',
+      workDir: '/tmp/project',
+      sessionId: 'ses-1',
+      sessionTitle: null,
+      thinking: false,
+      permissionMode: 'manual',
+      planMode: false,
+      swarmMode: false,
+      contextUsage: 0,
+      contextTokens: 0,
+      maxContextTokens: 0,
+      availableModels: {},
+      availableProviders: {},
+      status: { swarmMode: true },
+    }).map(strip);
+
+    expect(lines.join('\n')).toContain('Swarm        on');
+  });
 });


### PR DESCRIPTION
Extends the `/status` report with additional runtime context and visual polish while keeping the existing panel layout.

### Changes
- Add swarm mode, provider/model counts, MCP server summary, and active goal to the status report.
- Colorize permission and plan-mode values for quicker scanning.
- Surface session title and goal status when available.
- Update unit tests to cover the new rows.

### Testing
- `pnpm vitest run apps/kimi-code/test/tui/components/messages/status-panel.test.ts`
- `pnpm run typecheck` in `apps/kimi-code`