### PR TITLE
test: fix resume test assertions for compaction replay records

### DIFF
--- a/apps/kimi-code/test/tui/message-replay.test.ts
+++ b/apps/kimi-code/test/tui/message-replay.test.ts
@@ -994,6 +994,7 @@ describe('KimiTUI resume message replay', () => {
     const driver = await replayIntoDriver([
       message('user', [{ type: 'text', text: 'prompt before compaction' }]),
       {
+        time: REPLAY_TIME,
         type: 'compaction',
         result: {
           summary: 'Compacted transcript summary.',
@@ -1025,6 +1026,7 @@ describe('KimiTUI resume message replay', () => {
     const driver = await replayIntoDriver([
       message('user', [{ type: 'text', text: 'prompt before cancellation' }]),
       {
+        time: REPLAY_TIME,
         type: 'compaction',
         result: 'cancelled',
         instruction: 'preserve implementation notes',

--- a/packages/agent-core/test/agent/resume.test.ts
+++ b/packages/agent-core/test/agent/resume.test.ts
@@ -270,7 +270,7 @@ describe('Agent resume', () => {
           content: [{ type: 'text', text: 'Historical prompt before compaction' }],
         }),
       }),
-      {
+      expect.objectContaining({
         type: 'compaction',
         result: {
           summary: 'Compacted implementation notes.',
@@ -279,7 +279,7 @@ describe('Agent resume', () => {
           tokensAfter: 24,
         },
         instruction: 'preserve implementation notes',
-      },
+      }),
     ]);
   });
 
@@ -299,11 +299,11 @@ describe('Agent resume', () => {
     await ctx.agent.resume();
 
     expect(ctx.agent.replayBuilder.buildResult()).toEqual([
-      {
+      expect.objectContaining({
         type: 'compaction',
         result: 'cancelled',
         instruction: 'preserve implementation notes',
-      },
+      }),
     ]);
   });
 


### PR DESCRIPTION
## Problem

`test/agent/resume.test.ts` 中两个与 compaction 相关的断言（`projects restored compactions into replay records` 和 `projects restored cancelled compactions into replay records`）使用了 `toEqual` 严格匹配字面量对象，但 `ReplayBuilder.push` 会给所有 replay record 自动注入 `time` 字段（由 `AgentReplayRecord` 类型定义），导致断言失败。

## What changed

将这两个 compaction 的期望对象改用 `expect.objectContaining` 包裹，与同一文件中 message 类型的断言方式保持一致，忽略由 `ReplayBuilder` 自动注入的 `time` 字段。