### PR TITLE
chore: use raw query imports for prompt sources

### DIFF
--- a/.changeset/raw-prompt-imports.md
+++ b/.changeset/raw-prompt-imports.md
@@ -1,6 +1,0 @@
----
-"@moonshot-ai/agent-core": patch
-"@moonshot-ai/kimi-code": patch
----
-
-Use raw query imports for bundled prompt sources.

--- a/.changeset/raw-prompt-imports.md
+++ b/.changeset/raw-prompt-imports.md
@@ -1,0 +1,6 @@
+---
+"@moonshot-ai/agent-core": patch
+"@moonshot-ai/kimi-code": patch
+---
+
+Use raw query imports for bundled prompt sources.

--- a/apps/kimi-code/vitest.config.ts
+++ b/apps/kimi-code/vitest.config.ts
@@ -2,12 +2,9 @@ import { resolve } from 'node:path';
 
 import { defineConfig } from 'vitest/config';
 
-import { rawTextPlugin } from '../../build/raw-text-plugin.mjs';
-
 const appRoot = import.meta.dirname;
 
 export default defineConfig({
-  plugins: [rawTextPlugin()],
   resolve: {
     alias: {
       '@': resolve(appRoot, 'src'),

--- a/build/raw-text-loader.mjs
+++ b/build/raw-text-loader.mjs
@@ -2,17 +2,17 @@ import { readFile } from 'node:fs/promises';
 import { fileURLToPath } from 'node:url';
 
 /**
- * Node ESM `load` hook: import `.md` / `.yaml` files as raw-string modules.
+ * Node ESM `load` hook: import `?raw` files as raw-string modules.
  *
  * This is the runtime counterpart of `build/raw-text-plugin.mjs` (the bundler
- * plugin). The plugin covers build (tsdown) and test (vitest); this loader
- * covers source execution — e.g. `tsx`-run dev flows that import `kimi-core`
- * straight from `src`, where no bundler is involved.
+ * plugin). The plugin covers build (tsdown); this loader covers source
+ * execution — e.g. `tsx`-run dev flows that import `kimi-core` straight from
+ * `src`, where no bundler is involved.
  */
 export async function load(url, context, nextLoad) {
-  const filePath = url.split('?', 1)[0] ?? url;
-  if (filePath.endsWith('.md') || filePath.endsWith('.yaml')) {
-    const text = await readFile(fileURLToPath(filePath), 'utf-8');
+  const [fileUrl, query = ''] = url.split('?', 2);
+  if (query.split('&').includes('raw')) {
+    const text = await readFile(fileURLToPath(fileUrl), 'utf-8');
     return {
       format: 'module',
       shortCircuit: true,

--- a/build/raw-text-plugin.mjs
+++ b/build/raw-text-plugin.mjs
@@ -1,21 +1,21 @@
 import { readFileSync } from 'node:fs';
 
 /**
- * Bundler plugin that lets `.md` / `.yaml` files be imported as raw strings:
+ * Bundler plugin that lets files be imported as raw strings:
  *
- *   import description from './grep.md';
+ *   import description from './grep.md?raw';
  *
  * The file content is inlined into the bundle at build time, so prompt
- * source files never ship separately in `dist`. Shared by tsdown (build)
- * and vitest (test) so both resolve these imports identically.
+ * source files never ship separately in `dist`. Vitest handles the same
+ * `?raw` imports through Vite's built-in asset loader.
  */
 export function rawTextPlugin() {
   return {
     name: 'raw-text',
     enforce: 'pre',
     load(id) {
-      const path = id.split('?', 1)[0] ?? id;
-      if (!path.endsWith('.md') && !path.endsWith('.yaml')) return null;
+      const [path, query = ''] = id.split('?', 2);
+      if (!query.split('&').includes('raw')) return null;
       const text = readFileSync(path, 'utf-8');
       return { code: `export default ${JSON.stringify(text)};`, map: null };
     },

--- a/build/register-raw-text-loader.mjs
+++ b/build/register-raw-text-loader.mjs
@@ -1,7 +1,7 @@
 import { register } from 'node:module';
 
 /**
- * Registers the `.md` / `.yaml` raw-text loader. Pass to Node via `--import`
- * (alongside tsx) so source-executed code can import these prompt files.
+ * Registers the `?raw` text loader. Pass to Node via `--import` (alongside
+ * tsx) so source-executed code can import text files.
  */
 register('./raw-text-loader.mjs', import.meta.url);

--- a/packages/acp-adapter/vitest.config.ts
+++ b/packages/acp-adapter/vitest.config.ts
@@ -1,9 +1,6 @@
 import { defineConfig } from 'vitest/config';
 
-import { rawTextPlugin } from '../../build/raw-text-plugin.mjs';
-
 export default defineConfig({
-  plugins: [rawTextPlugin()],
   test: {
     name: 'acp-adapter',
     include: ['test/**/*.test.ts'],

--- a/packages/agent-core/src/agent/compaction/full.ts
+++ b/packages/agent-core/src/agent/compaction/full.ts
@@ -29,7 +29,7 @@ import {
   applyCompletionBudget,
   resolveCompletionBudget,
 } from '../../utils/completion-budget';
-import compactionInstructionTemplate from './compaction-instruction.md';
+import compactionInstructionTemplate from './compaction-instruction.md?raw';
 import { renderMessagesToText } from './render-messages';
 import { renderTodoList, type TodoItem } from '../../tools/builtin/state/todo-list';
 import type { CompactionBeginData, CompactionResult } from './types';

--- a/packages/agent-core/src/agent/swarm/index.ts
+++ b/packages/agent-core/src/agent/swarm/index.ts
@@ -1,7 +1,7 @@
 import type { Agent } from '..';
 
-import SWARM_MODE_ENTER_REMINDER from './enter-reminder.md';
-import SWARM_MODE_EXIT_REMINDER from './exit-reminder.md';
+import SWARM_MODE_ENTER_REMINDER from './enter-reminder.md?raw';
+import SWARM_MODE_EXIT_REMINDER from './exit-reminder.md?raw';
 
 /**
  * manual = persistent toggle (/swarm on);

--- a/packages/agent-core/src/profile/default.ts
+++ b/packages/agent-core/src/profile/default.ts
@@ -1,9 +1,9 @@
-import agentYaml from './default/agent.yaml';
-import coderYaml from './default/coder.yaml';
-import exploreYaml from './default/explore.yaml';
-import initMd from './default/init.md';
-import planYaml from './default/plan.yaml';
-import systemMd from './default/system.md';
+import agentYaml from './default/agent.yaml?raw';
+import coderYaml from './default/coder.yaml?raw';
+import exploreYaml from './default/explore.yaml?raw';
+import initMd from './default/init.md?raw';
+import planYaml from './default/plan.yaml?raw';
+import systemMd from './default/system.md?raw';
 import { loadAgentProfilesFromSources } from './load';
 
 // Keyed by the source path the profile loader expects: profile YAML files

--- a/packages/agent-core/src/prompt-modules.d.ts
+++ b/packages/agent-core/src/prompt-modules.d.ts
@@ -1,12 +1,7 @@
-// Raw-string imports for prompt sources. The `raw-text-plugin` (used by both
-// tsdown and vitest) loads `.md` / `.yaml` files as their string content.
+// Raw-string imports for prompt sources. Vite/Vitest handles `?raw` natively;
+// tsdown uses the shared `raw-text-plugin` for the same import shape.
 
-declare module '*.md' {
-  const content: string;
-  export default content;
-}
-
-declare module '*.yaml' {
+declare module '*?raw' {
   const content: string;
   export default content;
 }

--- a/packages/agent-core/src/session/subagent-host.ts
+++ b/packages/agent-core/src/session/subagent-host.ts
@@ -27,7 +27,7 @@ import {
   type SubagentSuspendedEvent,
   type QueuedSubagentTask,
 } from './subagent-batch';
-import SUMMARY_CONTINUATION_PROMPT from './summary-continuation.md';
+import SUMMARY_CONTINUATION_PROMPT from './summary-continuation.md?raw';
 
 export const DEFAULT_SUBAGENT_TIMEOUT_MS = 30 * 60 * 1000;
 export const DEFAULT_SUBAGENT_TIMEOUT_DESCRIPTION = '30 minutes';

--- a/packages/agent-core/src/skill/builtin/custom-theme.ts
+++ b/packages/agent-core/src/skill/builtin/custom-theme.ts
@@ -1,6 +1,6 @@
 import { parseSkillText } from '../parser';
 import type { SkillDefinition } from '../types';
-import CUSTOM_THEME_BODY from './custom-theme.md';
+import CUSTOM_THEME_BODY from './custom-theme.md?raw';
 
 const PSEUDO_PATH = 'builtin://custom-theme';
 

--- a/packages/agent-core/src/skill/builtin/import-from-cc-codex.ts
+++ b/packages/agent-core/src/skill/builtin/import-from-cc-codex.ts
@@ -1,6 +1,6 @@
 import { parseSkillText } from '../parser';
 import type { SkillDefinition } from '../types';
-import IMPORT_FROM_CC_CODEX_BODY from './import-from-cc-codex.md';
+import IMPORT_FROM_CC_CODEX_BODY from './import-from-cc-codex.md?raw';
 
 const PSEUDO_PATH = 'builtin://import-from-cc-codex';
 

--- a/packages/agent-core/src/skill/builtin/mcp-config.ts
+++ b/packages/agent-core/src/skill/builtin/mcp-config.ts
@@ -1,6 +1,6 @@
 import { parseSkillText } from '../parser';
 import type { SkillDefinition } from '../types';
-import MCP_CONFIG_BODY from './mcp-config.md';
+import MCP_CONFIG_BODY from './mcp-config.md?raw';
 
 const PSEUDO_PATH = 'builtin://mcp-config';
 

--- a/packages/agent-core/src/skill/builtin/sub-skill.ts
+++ b/packages/agent-core/src/skill/builtin/sub-skill.ts
@@ -1,8 +1,8 @@
 import { parseSkillText } from '../parser';
 import type { SkillDefinition } from '../types';
-import CONSOLIDATE_BODY from './sub-skill/consolidate/SKILL.md';
-import REVIEW_BODY from './sub-skill/review/SKILL.md';
-import PARENT_BODY from './sub-skill/SKILL.md';
+import CONSOLIDATE_BODY from './sub-skill/consolidate/SKILL.md?raw';
+import REVIEW_BODY from './sub-skill/review/SKILL.md?raw';
+import PARENT_BODY from './sub-skill/SKILL.md?raw';
 
 function makeBuiltin(
   body: string,

--- a/packages/agent-core/src/skill/builtin/update-config.ts
+++ b/packages/agent-core/src/skill/builtin/update-config.ts
@@ -1,6 +1,6 @@
 import { parseSkillText } from '../parser';
 import type { SkillDefinition } from '../types';
-import UPDATE_CONFIG_BODY from './update-config.md';
+import UPDATE_CONFIG_BODY from './update-config.md?raw';
 
 const PSEUDO_PATH = 'builtin://update-config';
 

--- a/packages/agent-core/src/tools/background/task-list.ts
+++ b/packages/agent-core/src/tools/background/task-list.ts
@@ -10,7 +10,7 @@ import type { ToolExecution } from '../../loop/types';
 import { toInputJsonSchema } from '../support/input-schema';
 import { matchesGlobRuleSubject } from '../support/rule-match';
 import { formatPlainObject } from './format';
-import TASK_LIST_DESCRIPTION from './task-list.md';
+import TASK_LIST_DESCRIPTION from './task-list.md?raw';
 
 // ── Input schema ─────────────────────────────────────────────────────
 

--- a/packages/agent-core/src/tools/background/task-output.ts
+++ b/packages/agent-core/src/tools/background/task-output.ts
@@ -26,7 +26,7 @@ import type { ExecutableToolResult, ToolExecution } from '../../loop/types';
 import { toInputJsonSchema } from '../support/input-schema';
 import { matchesGlobRuleSubject } from '../support/rule-match';
 import { formatPlainObject } from './format';
-import TASK_OUTPUT_DESCRIPTION from './task-output.md';
+import TASK_OUTPUT_DESCRIPTION from './task-output.md?raw';
 
 /**
  * Maximum bytes of output included inline as a preview. Output larger

--- a/packages/agent-core/src/tools/background/task-stop.ts
+++ b/packages/agent-core/src/tools/background/task-stop.ts
@@ -12,7 +12,7 @@ import {
 import type { ToolExecution } from '../../loop/types';
 import { toInputJsonSchema } from '../support/input-schema';
 import { matchesGlobRuleSubject } from '../support/rule-match';
-import TASK_STOP_DESCRIPTION from './task-stop.md';
+import TASK_STOP_DESCRIPTION from './task-stop.md?raw';
 
 // ── Input schema ─────────────────────────────────────────────────────
 

--- a/packages/agent-core/src/tools/builtin/collaboration/agent-swarm.ts
+++ b/packages/agent-core/src/tools/builtin/collaboration/agent-swarm.ts
@@ -10,7 +10,7 @@ import {
 import { ToolAccesses } from '../../../loop/tool-access';
 import type { ExecutableToolContext, ExecutableToolResult, ToolExecution } from '../../../loop/types';
 import { toInputJsonSchema } from '../../support/input-schema';
-import AGENT_SWARM_DESCRIPTION from './agent-swarm.md';
+import AGENT_SWARM_DESCRIPTION from './agent-swarm.md?raw';
 
 const DEFAULT_SUBAGENT_TYPE = 'coder';
 const PROMPT_TEMPLATE_PLACEHOLDER = '{{item}}';

--- a/packages/agent-core/src/tools/builtin/collaboration/agent.ts
+++ b/packages/agent-core/src/tools/builtin/collaboration/agent.ts
@@ -38,9 +38,9 @@ import {
 import { AgentBackgroundTask, type BackgroundManager } from '../../../agent/background';
 import { toInputJsonSchema } from '../../support/input-schema';
 import { matchesGlobRuleSubject } from '../../support/rule-match';
-import AGENT_BACKGROUND_DISABLED_DESCRIPTION from './agent-background-disabled.md';
-import AGENT_BACKGROUND_DESCRIPTION from './agent-background-enabled.md';
-import AGENT_DESCRIPTION_BASE from './agent.md';
+import AGENT_BACKGROUND_DISABLED_DESCRIPTION from './agent-background-disabled.md?raw';
+import AGENT_BACKGROUND_DESCRIPTION from './agent-background-enabled.md?raw';
+import AGENT_DESCRIPTION_BASE from './agent.md?raw';
 
 // ── AgentTool input ──────────────────────────────────────────────────
 

--- a/packages/agent-core/src/tools/builtin/collaboration/ask-user.ts
+++ b/packages/agent-core/src/tools/builtin/collaboration/ask-user.ts
@@ -27,7 +27,7 @@ import type {
 } from '../../../rpc';
 import type { TelemetryPropertyValue } from '../../../telemetry';
 import { toInputJsonSchema } from '../../support/input-schema';
-import DESCRIPTION from './ask-user.md';
+import DESCRIPTION from './ask-user.md?raw';
 
 // ── Input schema ─────────────────────────────────────────────────────
 

--- a/packages/agent-core/src/tools/builtin/collaboration/skill-tool.ts
+++ b/packages/agent-core/src/tools/builtin/collaboration/skill-tool.ts
@@ -24,7 +24,7 @@ import { isInlineSkillType, type SkillDefinition } from '../../../skill';
 import { renderPrompt } from '../../../utils/render-prompt';
 import { toInputJsonSchema } from '../../support/input-schema';
 import { matchesGlobRuleSubject } from '../../support/rule-match';
-import skillDescriptionTemplate from './skill-tool.md';
+import skillDescriptionTemplate from './skill-tool.md?raw';
 
 export const MAX_SKILL_QUERY_DEPTH = 3;
 

--- a/packages/agent-core/src/tools/builtin/file/edit.ts
+++ b/packages/agent-core/src/tools/builtin/file/edit.ts
@@ -19,7 +19,7 @@ import { toInputJsonSchema } from '../../support/input-schema';
 import { literalRulePattern, matchesPathRuleSubject } from '../../support/rule-match';
 import type { WorkspaceConfig } from '../../support/workspace';
 import { materializeModelText, toModelTextView } from './line-endings';
-import EDIT_DESCRIPTION from './edit.md';
+import EDIT_DESCRIPTION from './edit.md?raw';
 
 // `old_string` must be non-empty: the non-replace_all branch walks
 // occurrences with `content.indexOf("", pos)`, which would loop forever

--- a/packages/agent-core/src/tools/builtin/file/glob.ts
+++ b/packages/agent-core/src/tools/builtin/file/glob.ts
@@ -43,7 +43,7 @@ import type { PathClass } from '../../policies/path-access';
 import { toInputJsonSchema } from '../../support/input-schema';
 import { literalRulePattern, matchesGlobRuleSubject } from '../../support/rule-match';
 import type { WorkspaceConfig } from '../../support/workspace';
-import GLOB_DESCRIPTION from './glob.md';
+import GLOB_DESCRIPTION from './glob.md?raw';
 
 export const GlobInputSchema = z.object({
   pattern: z.string().describe('Glob pattern to match files/directories.'),

--- a/packages/agent-core/src/tools/builtin/file/grep.ts
+++ b/packages/agent-core/src/tools/builtin/file/grep.ts
@@ -35,7 +35,7 @@ import { ensureRgPath, rgUnavailableMessage } from '../../support/rg-locator';
 import { literalRulePattern, matchesGlobRuleSubject } from '../../support/rule-match';
 import { ToolResultBuilder } from '../../support/result-builder';
 import type { WorkspaceConfig } from '../../support/workspace';
-import GREP_DESCRIPTION from './grep.md';
+import GREP_DESCRIPTION from './grep.md?raw';
 
 export const GrepInputSchema = z.object({
   pattern: z.string().describe('Regular expression to search for.'),

--- a/packages/agent-core/src/tools/builtin/file/read-media.ts
+++ b/packages/agent-core/src/tools/builtin/file/read-media.ts
@@ -33,7 +33,7 @@ import { MEDIA_SNIFF_BYTES, detectFileType, sniffImageDimensions } from '../../s
 import { toInputJsonSchema } from '../../support/input-schema';
 import { literalRulePattern, matchesPathRuleSubject } from '../../support/rule-match';
 import type { WorkspaceConfig } from '../../support/workspace';
-import readMediaDescriptionHead from './read-media.md';
+import readMediaDescriptionHead from './read-media.md?raw';
 
 // ── Constants ────────────────────────────────────────────────────────
 

--- a/packages/agent-core/src/tools/builtin/file/read.ts
+++ b/packages/agent-core/src/tools/builtin/file/read.ts
@@ -11,7 +11,7 @@ import { toInputJsonSchema } from '../../support/input-schema';
 import { literalRulePattern, matchesPathRuleSubject } from '../../support/rule-match';
 import type { WorkspaceConfig } from '../../support/workspace';
 import { makeCarriageReturnsVisible, type LineEndingStyle } from './line-endings';
-import readDescriptionTemplate from './read.md';
+import readDescriptionTemplate from './read.md?raw';
 
 export const MAX_LINES: number = 1000;
 export const MAX_LINE_LENGTH: number = 2000;

--- a/packages/agent-core/src/tools/builtin/file/write.ts
+++ b/packages/agent-core/src/tools/builtin/file/write.ts
@@ -16,7 +16,7 @@ import { resolvePathAccessPath } from '../../policies/path-access';
 import { toInputJsonSchema } from '../../support/input-schema';
 import { literalRulePattern, matchesPathRuleSubject } from '../../support/rule-match';
 import type { WorkspaceConfig } from '../../support/workspace';
-import WRITE_DESCRIPTION from './write.md';
+import WRITE_DESCRIPTION from './write.md?raw';
 
 /** Mask isolating the file-type bits of a stat mode. */
 const S_IFMT = 0o170000;

--- a/packages/agent-core/src/tools/builtin/goal/create-goal.ts
+++ b/packages/agent-core/src/tools/builtin/goal/create-goal.ts
@@ -10,7 +10,7 @@ import { z } from 'zod';
 import type { BuiltinTool } from '../../../agent/tool';
 import type { ToolExecution } from '../../../loop/types';
 import { toInputJsonSchema } from '../../support/input-schema';
-import DESCRIPTION from './create-goal.md';
+import DESCRIPTION from './create-goal.md?raw';
 
 export const CreateGoalToolInputSchema = z
   .object({

--- a/packages/agent-core/src/tools/builtin/goal/get-goal.ts
+++ b/packages/agent-core/src/tools/builtin/goal/get-goal.ts
@@ -10,7 +10,7 @@ import { z } from 'zod';
 import type { BuiltinTool } from '../../../agent/tool';
 import type { ToolExecution } from '../../../loop/types';
 import { toInputJsonSchema } from '../../support/input-schema';
-import DESCRIPTION from './get-goal.md';
+import DESCRIPTION from './get-goal.md?raw';
 
 export const GetGoalToolInputSchema = z.object({}).strict();
 export type GetGoalToolInput = z.infer<typeof GetGoalToolInputSchema>;

--- a/packages/agent-core/src/tools/builtin/goal/set-goal-budget.ts
+++ b/packages/agent-core/src/tools/builtin/goal/set-goal-budget.ts
@@ -11,7 +11,7 @@ import type { BuiltinTool } from '../../../agent/tool';
 import type { GoalBudgetLimits } from '../../../agent/goal';
 import type { ToolExecution } from '../../../loop/types';
 import { toInputJsonSchema } from '../../support/input-schema';
-import DESCRIPTION from './set-goal-budget.md';
+import DESCRIPTION from './set-goal-budget.md?raw';
 
 const MIN_REASONABLE_TIME_BUDGET_MS = 1_000;
 const MAX_REASONABLE_TIME_BUDGET_MS = 24 * 60 * 60 * 1000;

--- a/packages/agent-core/src/tools/builtin/goal/update-goal.ts
+++ b/packages/agent-core/src/tools/builtin/goal/update-goal.ts
@@ -24,7 +24,7 @@ import {
 import type { BuiltinTool } from '../../../agent/tool';
 import type { ToolExecution } from '../../../loop/types';
 import { toInputJsonSchema } from '../../support/input-schema';
-import DESCRIPTION from './update-goal.md';
+import DESCRIPTION from './update-goal.md?raw';
 
 export const UpdateGoalToolInputSchema = z
   .object({

--- a/packages/agent-core/src/tools/builtin/planning/enter-plan-mode.ts
+++ b/packages/agent-core/src/tools/builtin/planning/enter-plan-mode.ts
@@ -12,7 +12,7 @@ import { z } from 'zod';
 import type { BuiltinTool } from '../../../agent/tool';
 import type { ToolExecution } from '../../../loop/types';
 import { toInputJsonSchema } from '../../support/input-schema';
-import DESCRIPTION from './enter-plan-mode.md';
+import DESCRIPTION from './enter-plan-mode.md?raw';
 
 // ── Input schema ─────────────────────────────────────────────────────
 

--- a/packages/agent-core/src/tools/builtin/planning/exit-plan-mode.ts
+++ b/packages/agent-core/src/tools/builtin/planning/exit-plan-mode.ts
@@ -14,7 +14,7 @@ import type { BuiltinTool } from '../../../agent/tool';
 import type { ExecutableToolResult, ToolExecution } from '../../../loop/types';
 import type { ToolInputDisplay } from '../../display';
 import { toInputJsonSchema } from '../../support/input-schema';
-import DESCRIPTION from './exit-plan-mode.md';
+import DESCRIPTION from './exit-plan-mode.md?raw';
 
 // ── Input schema ─────────────────────────────────────────────────────
 

--- a/packages/agent-core/src/tools/builtin/shell/bash.ts
+++ b/packages/agent-core/src/tools/builtin/shell/bash.ts
@@ -36,7 +36,7 @@ import { renderPrompt } from '../../../utils/render-prompt';
 import { toInputJsonSchema } from '../../support/input-schema';
 import { literalRulePattern, matchesGlobRuleSubject } from '../../support/rule-match';
 import { ToolResultBuilder } from '../../support/result-builder';
-import bashDescriptionTemplate from './bash.md';
+import bashDescriptionTemplate from './bash.md?raw';
 
 const MS_PER_SECOND = 1000;
 const DEFAULT_TIMEOUT_S = 60;

--- a/packages/agent-core/src/tools/builtin/state/todo-list.ts
+++ b/packages/agent-core/src/tools/builtin/state/todo-list.ts
@@ -19,7 +19,7 @@ import type { BuiltinTool } from '../../../agent/tool';
 import type { ToolExecution } from '../../../loop/types';
 import { toInputJsonSchema } from '../../support/input-schema';
 import type { ToolStore } from '../../store';
-import DESCRIPTION from './todo-list.md';
+import DESCRIPTION from './todo-list.md?raw';
 
 // ── TODO state shape ─────────────────────────────────────────────────
 

--- a/packages/agent-core/src/tools/builtin/web/fetch-url.ts
+++ b/packages/agent-core/src/tools/builtin/web/fetch-url.ts
@@ -14,7 +14,7 @@ import type { ExecutableToolContext, ExecutableToolResult, ToolExecution } from 
 import { toInputJsonSchema } from '../../support/input-schema';
 import { literalRulePattern, matchesGlobRuleSubject } from '../../support/rule-match';
 import { ToolResultBuilder } from '../../support/result-builder';
-import DESCRIPTION from './fetch-url.md';
+import DESCRIPTION from './fetch-url.md?raw';
 
 // ── Provider interface (host-injected) ───────────────────────────────
 

--- a/packages/agent-core/src/tools/builtin/web/web-search.ts
+++ b/packages/agent-core/src/tools/builtin/web/web-search.ts
@@ -14,7 +14,7 @@ import type { ExecutableToolContext, ExecutableToolResult, ToolExecution } from 
 import { toInputJsonSchema } from '../../support/input-schema';
 import { literalRulePattern, matchesGlobRuleSubject } from '../../support/rule-match';
 import { ToolResultBuilder } from '../../support/result-builder';
-import DESCRIPTION from './web-search.md';
+import DESCRIPTION from './web-search.md?raw';
 
 // ── Provider interface (host-injected) ───────────────────────────────
 

--- a/packages/agent-core/src/tools/cron/cron-create.ts
+++ b/packages/agent-core/src/tools/cron/cron-create.ts
@@ -42,7 +42,7 @@ import {
   oneShotJitteredNextCronRunMs,
 } from './jitter';
 import { formatLocalIsoWithOffset } from './time-format';
-import CRON_CREATE_DESCRIPTION from './cron-create.md';
+import CRON_CREATE_DESCRIPTION from './cron-create.md?raw';
 
 // ── Constants ────────────────────────────────────────────────────────
 

--- a/packages/agent-core/src/tools/cron/cron-delete.ts
+++ b/packages/agent-core/src/tools/cron/cron-delete.ts
@@ -42,7 +42,7 @@ import type { BuiltinTool } from '../../agent/tool';
 import type { CronManager } from '../../agent/cron';
 import type { ToolExecution } from '../../loop/types';
 import { toInputJsonSchema } from '../support/input-schema';
-import CRON_DELETE_DESCRIPTION from './cron-delete.md';
+import CRON_DELETE_DESCRIPTION from './cron-delete.md?raw';
 
 // ── Constants ────────────────────────────────────────────────────────
 

--- a/packages/agent-core/src/tools/cron/cron-list.ts
+++ b/packages/agent-core/src/tools/cron/cron-list.ts
@@ -52,7 +52,7 @@ import {
 } from './cron-expr';
 import { formatLocalIsoWithOffset } from './time-format';
 import type { CronTask } from './types';
-import CRON_LIST_DESCRIPTION from './cron-list.md';
+import CRON_LIST_DESCRIPTION from './cron-list.md?raw';
 
 // ── Input schema ─────────────────────────────────────────────────────
 

--- a/packages/agent-core/test/tools/exit-plan-mode-options.test.ts
+++ b/packages/agent-core/test/tools/exit-plan-mode-options.test.ts
@@ -6,7 +6,7 @@ import {
   ExitPlanModeTool,
   type ExitPlanModeInput,
 } from '../../src/tools/builtin/planning/exit-plan-mode';
-import DESCRIPTION from '../../src/tools/builtin/planning/exit-plan-mode.md';
+import DESCRIPTION from '../../src/tools/builtin/planning/exit-plan-mode.md?raw';
 import { executeTool } from './fixtures/execute-tool';
 import { toolContentString } from './fixtures/fake-kaos';
 

--- a/packages/agent-core/vitest.config.ts
+++ b/packages/agent-core/vitest.config.ts
@@ -1,9 +1,6 @@
 import { defineConfig } from 'vitest/config';
 
-import { rawTextPlugin } from '../../build/raw-text-plugin.mjs';
-
 export default defineConfig({
-  plugins: [rawTextPlugin()],
   test: {
     name: 'kimi-core',
     include: ['test/**/*.{test,e2e}.ts'],

--- a/packages/migration-legacy/test/prompt-modules.d.ts
+++ b/packages/migration-legacy/test/prompt-modules.d.ts
@@ -1,14 +1,8 @@
 // `resume.integration.test.ts` imports real kimi-core, which transitively
-// imports `.md` / `.yaml` prompt sources as raw strings (resolved by the
-// shared `raw-text-plugin`). This ambient declaration lets `tsc` type-check
-// the migration package without pulling in kimi-core's own `.d.ts`.
+// imports prompt sources with `?raw`. This ambient declaration lets `tsc`
+// type-check the migration package without pulling in kimi-core's own `.d.ts`.
 
-declare module '*.md' {
-  const content: string;
-  export default content;
-}
-
-declare module '*.yaml' {
+declare module '*?raw' {
   const content: string;
   export default content;
 }

--- a/packages/migration-legacy/vitest.config.ts
+++ b/packages/migration-legacy/vitest.config.ts
@@ -1,12 +1,6 @@
 import { defineConfig } from 'vitest/config';
 
-import { rawTextPlugin } from '../../build/raw-text-plugin.mjs';
-
 export default defineConfig({
-  // `resume.integration.test.ts` imports real kimi-core (`Session`), which
-  // transitively imports `.md` / `.yaml` prompt sources as raw strings.
-  // Reuse the same plugin kimi-core uses so those imports resolve identically.
-  plugins: [rawTextPlugin()],
   test: {
     name: 'migration-legacy',
     include: ['test/**/*.test.ts'],

--- a/packages/node-sdk/vitest.config.ts
+++ b/packages/node-sdk/vitest.config.ts
@@ -2,10 +2,7 @@ import { fileURLToPath } from 'node:url';
 
 import { defineConfig } from 'vitest/config';
 
-import { rawTextPlugin } from '../../build/raw-text-plugin.mjs';
-
 export default defineConfig({
-  plugins: [rawTextPlugin()],
   resolve: {
     alias: {
       '@moonshot-ai/agent-core': fileURLToPath(new URL('../agent-core/src/index.ts', import.meta.url)),

--- a/packages/protocol/vitest.config.ts
+++ b/packages/protocol/vitest.config.ts
@@ -1,9 +1,6 @@
 import { defineConfig } from 'vitest/config';
 
-import { rawTextPlugin } from '../../build/raw-text-plugin.mjs';
-
 export default defineConfig({
-  plugins: [rawTextPlugin()],
   test: {
     name: 'protocol',
     include: ['src/__tests__/**/*.test.ts'],


### PR DESCRIPTION
## Related Issue

No linked issue. This follows up on the prompt-source import cleanup discussed in this thread.

## Problem

Prompt sources were imported as bare `.md` and `.yaml` modules, which forced Vitest projects to carry the repository raw-text plugin even though Vite/Vitest can load explicit `?raw` imports natively.

## What changed

- Added `?raw` to bundled prompt source imports and the one test import that reads a prompt file directly.
- Replaced extension-specific raw module declarations with a generic `*?raw` declaration.
- Removed the raw-text plugin from Vitest project configs while keeping the tsdown plugin as the build-time handler for `?raw` imports.
- Updated the raw-text plugin and Node source loader to key off the `raw` query instead of `.md` / `.yaml` extensions.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] Existing tests cover the changed import paths and package build behavior.
- [x] This PR needs no changeset per maintainer request.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.

## Validation

- `pnpm --filter @moonshot-ai/agent-core run typecheck`
- `pnpm --filter @moonshot-ai/migration-legacy run typecheck`
- `pnpm --filter @moonshot-ai/agent-core run build`
- `pnpm --filter @moonshot-ai/kimi-code-sdk run build`
- `pnpm --filter @moonshot-ai/kimi-code run build`
- `pnpm exec vitest run --project kimi-core packages/agent-core/test/tools/exit-plan-mode-options.test.ts`
- `pnpm exec vitest run --project migration-legacy packages/migration-legacy/test/resume.integration.test.ts`
- `git diff --check`
- Read-only diff audit for internal identifiers: no issues found
