### PR TITLE
fix(changeset): downgrade agent-core and kimi-code bumps from minor to patch

### DIFF
--- a/.changeset/qualify-sub-skill-names.md
+++ b/.changeset/qualify-sub-skill-names.md
@@ -1,6 +1,6 @@
 ---
-"@moonshot-ai/agent-core": minor
-"@moonshot-ai/kimi-code": minor
+"@moonshot-ai/agent-core": patch
+"@moonshot-ai/kimi-code": patch
 ---
 
 Qualify sub-skill names with their parent prefix and expose sub-skills as dotted slash commands in the TUI.


### PR DESCRIPTION
## Related Issue

<!-- No related issue — this is a simple correction to an existing changeset. -->

## Problem

The changeset `.changeset/qualify-sub-skill-names.md` incorrectly specified `minor` bumps for both `@moonshot-ai/agent-core` and `@moonshot-ai/kimi-code`. The actual change (qualifying sub-skill names and exposing them as dotted slash commands) is a backward-compatible fix/enhancement that does not warrant a minor bump.

## What changed

- Downgraded the bump level for `@moonshot-ai/agent-core` from `minor` to `patch`
- Downgraded the bump level for `@moonshot-ai/kimi-code` from `minor` to `patch`

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [ ] I have linked a related issue, or explained the problem above.
- [ ] I have added tests that prove my feature works.
- [ ] Ran `gen-changesets` skill, or this PR needs no changeset.
- [ ] Ran `gen-docs` skill, or this PR needs no doc update.
