### PR TITLE
test: redact internal endpoint fixtures

### DIFF
--- a/apps/kimi-code/test/utils/kimi-datasource-plugin.test.ts
+++ b/apps/kimi-code/test/utils/kimi-datasource-plugin.test.ts
@@ -156,7 +156,7 @@ describe('kimi-datasource MCP server', () => {
       }
 
       const baseUrl = `http://127.0.0.1:${address.port}/coding/v1`;
-      const oauthHost = 'https://auth.dev.kimi.team';
+      const oauthHost = 'https://auth.dev.example.test';
       const scopedCredential = kimiCodeEnvCredentialName({ oauthHost, baseUrl });
 
       await mkdir(join(kimiHome, 'credentials'), { recursive: true });

--- a/packages/agent-core/test/config/configs.test.ts
+++ b/packages/agent-core/test/config/configs.test.ts
@@ -232,29 +232,29 @@ source = { kind = "apiJson", url = "https://registry.example/api.json", apiKey =
     const toml = `
 [providers."managed:kimi-code"]
 type = "kimi"
-base_url = "https://coding.deva.msh.team/coding/v1"
+base_url = "https://api.dev.example.test/coding/v1"
 api_key = ""
-oauth = { storage = "file", key = "oauth/kimi-code-env-1234", oauth_host = "https://auth.dev.kimi.team" }
+oauth = { storage = "file", key = "oauth/kimi-code-env-1234", oauth_host = "https://auth.dev.example.test" }
 
 [services.moonshot_search]
-base_url = "https://coding.deva.msh.team/coding/v1/search"
+base_url = "https://api.dev.example.test/coding/v1/search"
 api_key = ""
-oauth = { storage = "file", key = "oauth/kimi-code-env-1234", oauth_host = "https://auth.dev.kimi.team" }
+oauth = { storage = "file", key = "oauth/kimi-code-env-1234", oauth_host = "https://auth.dev.example.test" }
 `;
     const config = parseConfigString(toml, configPath);
     expect(config.providers['managed:kimi-code']?.oauth).toEqual({
       storage: 'file',
       key: 'oauth/kimi-code-env-1234',
-      oauthHost: 'https://auth.dev.kimi.team',
+      oauthHost: 'https://auth.dev.example.test',
     });
-    expect(config.services?.moonshotSearch?.oauth?.oauthHost).toBe('https://auth.dev.kimi.team');
+    expect(config.services?.moonshotSearch?.oauth?.oauthHost).toBe('https://auth.dev.example.test');
 
     await writeConfigFile(configPath, config);
     const text = await readFile(configPath, 'utf-8');
-    expect(text).toContain('oauth_host = "https://auth.dev.kimi.team"');
+    expect(text).toContain('oauth_host = "https://auth.dev.example.test"');
     const roundTripped = parseConfigString(text, configPath);
     expect(roundTripped.providers['managed:kimi-code']?.oauth?.oauthHost).toBe(
-      'https://auth.dev.kimi.team',
+      'https://auth.dev.example.test',
     );
   });
 

--- a/packages/agent-core/test/rpc/plugins-rpc.test.ts
+++ b/packages/agent-core/test/rpc/plugins-rpc.test.ts
@@ -99,9 +99,9 @@ describe('KimiCore plugin RPCs', () => {
         `
 [providers."managed:kimi-code"]
 type = "kimi"
-base_url = "https://coding.deva.msh.team/coding/v1"
+base_url = "https://api.dev.example.test/coding/v1"
 api_key = ""
-oauth = { storage = "file", key = "oauth/kimi-code-env-1234", oauth_host = "https://auth.dev.kimi.team" }
+oauth = { storage = "file", key = "oauth/kimi-code-env-1234", oauth_host = "https://auth.dev.example.test" }
 `,
         'utf8',
       );
@@ -130,8 +130,8 @@ oauth = { storage = "file", key = "oauth/kimi-code-env-1234", oauth_host = "http
 
       expect(mcpConfig.servers['plugin-kimi-datasource:data']?.env).toEqual(
         expect.objectContaining({
-          KIMI_CODE_BASE_URL: 'https://coding.deva.msh.team/coding/v1',
-          KIMI_CODE_OAUTH_HOST: 'https://auth.dev.kimi.team',
+          KIMI_CODE_BASE_URL: 'https://api.dev.example.test/coding/v1',
+          KIMI_CODE_OAUTH_HOST: 'https://auth.dev.example.test',
         }),
       );
     } finally {

--- a/packages/node-sdk/test/auth-facade.test.ts
+++ b/packages/node-sdk/test/auth-facade.test.ts
@@ -64,8 +64,8 @@ describe('KimiHarness.auth', () => {
 
   it('resolves cached access tokens from the configured scoped OAuth ref', async () => {
     const oauthKey = resolveKimiCodeOAuthKey({
-      oauthHost: 'https://auth.dev.kimi.team',
-      baseUrl: 'https://coding.deva.msh.team/coding/v1',
+      oauthHost: 'https://auth.dev.example.test',
+      baseUrl: 'https://api.dev.example.test/coding/v1',
     });
     const storageName = resolveKimiTokenStorageName({ oauthKey });
     const storage = new FileTokenStorage(join(homeDir, 'credentials'));
@@ -76,9 +76,9 @@ describe('KimiHarness.auth', () => {
       `
 [providers."managed:kimi-code"]
 type = "kimi"
-base_url = "https://coding.deva.msh.team/coding/v1"
+base_url = "https://api.dev.example.test/coding/v1"
 api_key = ""
-oauth = { storage = "file", key = "${oauthKey}", oauth_host = "https://auth.dev.kimi.team" }
+oauth = { storage = "file", key = "${oauthKey}", oauth_host = "https://auth.dev.example.test" }
 `,
     );
     const harness = createKimiHarness({ homeDir, identity: TEST_IDENTITY });
@@ -88,8 +88,8 @@ oauth = { storage = "file", key = "${oauthKey}", oauth_host = "https://auth.dev.
 
   it('reports auth status from the configured scoped OAuth ref', async () => {
     const oauthKey = resolveKimiCodeOAuthKey({
-      oauthHost: 'https://auth.dev.kimi.team',
-      baseUrl: 'https://coding.deva.msh.team/coding/v1',
+      oauthHost: 'https://auth.dev.example.test',
+      baseUrl: 'https://api.dev.example.test/coding/v1',
     });
     await new FileTokenStorage(join(homeDir, 'credentials')).save(
       resolveKimiTokenStorageName({ oauthKey }),
@@ -100,9 +100,9 @@ oauth = { storage = "file", key = "${oauthKey}", oauth_host = "https://auth.dev.
       `
 [providers."managed:kimi-code"]
 type = "kimi"
-base_url = "https://coding.deva.msh.team/coding/v1"
+base_url = "https://api.dev.example.test/coding/v1"
 api_key = ""
-oauth = { storage = "file", key = "${oauthKey}", oauth_host = "https://auth.dev.kimi.team" }
+oauth = { storage = "file", key = "${oauthKey}", oauth_host = "https://auth.dev.example.test" }
 `,
     );
     const harness = createKimiHarness({ homeDir, identity: TEST_IDENTITY });
@@ -174,8 +174,8 @@ oauth = { storage = "file", key = "${oauthKey}", oauth_host = "https://auth.dev.
   });
 
   it('logs in against the configured scoped OAuth host and base URL when env is absent', async () => {
-    const baseUrl = 'https://coding.deva.msh.team/coding/v1';
-    const oauthHost = 'https://auth.dev.kimi.team';
+    const baseUrl = 'https://api.dev.example.test/coding/v1';
+    const oauthHost = 'https://auth.dev.example.test';
     const oauthKey = resolveKimiCodeOAuthKey({ oauthHost, baseUrl });
     const storageName = resolveKimiTokenStorageName({ oauthKey });
     const storage = new FileTokenStorage(join(homeDir, 'credentials'));
@@ -474,8 +474,8 @@ oauth = { storage = "file", key = "oauth/kimi-code" }
 
   it('removes the configured scoped OAuth token on logout without touching the production token', async () => {
     const oauthKey = resolveKimiCodeOAuthKey({
-      oauthHost: 'https://auth.dev.kimi.team',
-      baseUrl: 'https://coding.deva.msh.team/coding/v1',
+      oauthHost: 'https://auth.dev.example.test',
+      baseUrl: 'https://api.dev.example.test/coding/v1',
     });
     const storageName = resolveKimiTokenStorageName({ oauthKey });
     const storage = new FileTokenStorage(join(homeDir, 'credentials'));
@@ -488,9 +488,9 @@ default_model = "kimi-code/kimi-for-coding"
 
 [providers."managed:kimi-code"]
 type = "kimi"
-base_url = "https://coding.deva.msh.team/coding/v1"
+base_url = "https://api.dev.example.test/coding/v1"
 api_key = ""
-oauth = { storage = "file", key = "${oauthKey}", oauth_host = "https://auth.dev.kimi.team" }
+oauth = { storage = "file", key = "${oauthKey}", oauth_host = "https://auth.dev.example.test" }
 
 [models."kimi-code/kimi-for-coding"]
 provider = "managed:kimi-code"
@@ -580,9 +580,9 @@ max_context_size = 262144
   });
 
   it('uses configured scoped OAuth refs and base URLs for managed usage and feedback', async () => {
-    const baseUrl = 'https://coding.deva.msh.team/coding/v1';
+    const baseUrl = 'https://api.dev.example.test/coding/v1';
     const oauthKey = resolveKimiCodeOAuthKey({
-      oauthHost: 'https://auth.dev.kimi.team',
+      oauthHost: 'https://auth.dev.example.test',
       baseUrl,
     });
     const storageName = resolveKimiTokenStorageName({ oauthKey });
@@ -597,7 +597,7 @@ max_context_size = 262144
 type = "kimi"
 base_url = "${baseUrl}"
 api_key = ""
-oauth = { storage = "file", key = "${oauthKey}", oauth_host = "https://auth.dev.kimi.team" }
+oauth = { storage = "file", key = "${oauthKey}", oauth_host = "https://auth.dev.example.test" }
 `,
     );
     const fetchMock = vi.fn<FetchMock>(async (input) => {

--- a/packages/oauth/test/managed-kimi-code.test.ts
+++ b/packages/oauth/test/managed-kimi-code.test.ts
@@ -55,16 +55,16 @@ describe('provisionManagedKimiCodeConfig', () => {
 
   it('scopes credential keys for non-default OAuth hosts and API base URLs', () => {
     const devKey = resolveKimiCodeOAuthKey({
-      oauthHost: 'https://auth.dev.kimi.team',
-      baseUrl: 'https://coding.deva.msh.team/coding/v1',
+      oauthHost: 'https://auth.dev.example.test',
+      baseUrl: 'https://api.dev.example.test/coding/v1',
     });
 
     expect(devKey).not.toBe(KIMI_CODE_OAUTH_KEY);
     expect(devKey).toMatch(/^oauth\/kimi-code-env-[a-f0-9]{16}$/);
     expect(
       resolveKimiCodeOAuthKey({
-        oauthHost: 'https://auth.dev.kimi.team/',
-        baseUrl: 'https://coding.deva.msh.team/coding/v1/',
+        oauthHost: 'https://auth.dev.example.test/',
+        baseUrl: 'https://api.dev.example.test/coding/v1/',
       }),
     ).toBe(devKey);
   });
@@ -94,16 +94,16 @@ describe('provisionManagedKimiCodeConfig', () => {
     // A non-default environment yields a scoped key AND the normalized host,
     // both derived from the same input — login and runtime cannot drift apart.
     const devRef = resolveKimiCodeOAuthRef({
-      oauthHost: 'https://auth.dev.kimi.team/',
-      baseUrl: 'https://coding.deva.msh.team/coding/v1',
+      oauthHost: 'https://auth.dev.example.test/',
+      baseUrl: 'https://api.dev.example.test/coding/v1',
     });
     expect(devRef).toEqual({
       storage: 'file',
       key: resolveKimiCodeOAuthKey({
-        oauthHost: 'https://auth.dev.kimi.team',
-        baseUrl: 'https://coding.deva.msh.team/coding/v1',
+        oauthHost: 'https://auth.dev.example.test',
+        baseUrl: 'https://api.dev.example.test/coding/v1',
       }),
-      oauthHost: 'https://auth.dev.kimi.team',
+      oauthHost: 'https://auth.dev.example.test',
     });
   });
 
@@ -136,14 +136,14 @@ describe('provisionManagedKimiCodeConfig', () => {
   });
 
   it('preserves a matching configured runtime OAuth ref when env is not overridden', () => {
-    const baseUrl = 'https://coding.deva.msh.team/coding/v1';
+    const baseUrl = 'https://api.dev.example.test/coding/v1';
     const configuredOAuthRef = {
       storage: 'keyring' as const,
       key: resolveKimiCodeOAuthKey({
-        oauthHost: 'https://auth.dev.kimi.team',
+        oauthHost: 'https://auth.dev.example.test',
         baseUrl,
       }),
-      oauthHost: 'https://auth.dev.kimi.team',
+      oauthHost: 'https://auth.dev.example.test',
     };
 
     expect(
@@ -277,15 +277,15 @@ describe('provisionManagedKimiCodeConfig', () => {
       providers: {},
     };
     const oauthKey = resolveKimiCodeOAuthKey({
-      oauthHost: 'https://auth.dev.kimi.team',
-      baseUrl: 'https://coding.deva.msh.team/coding/v1',
+      oauthHost: 'https://auth.dev.example.test',
+      baseUrl: 'https://api.dev.example.test/coding/v1',
     });
 
     await provisionManagedKimiCodeConfig({
       accessToken: 'oauth-access-token',
-      baseUrl: 'https://coding.deva.msh.team/coding/v1',
+      baseUrl: 'https://api.dev.example.test/coding/v1',
       oauthKey,
-      oauthHost: 'https://auth.dev.kimi.team',
+      oauthHost: 'https://auth.dev.example.test',
       fetchImpl: vi.fn(async () => makeModelsResponse()) as unknown as typeof fetch,
       adapter: {
         read: () => config,
@@ -295,22 +295,22 @@ describe('provisionManagedKimiCodeConfig', () => {
     });
 
     expect(config.providers[KIMI_CODE_PROVIDER_NAME]).toMatchObject({
-      baseUrl: 'https://coding.deva.msh.team/coding/v1',
+      baseUrl: 'https://api.dev.example.test/coding/v1',
       oauth: {
         storage: 'file',
         key: oauthKey,
-        oauthHost: 'https://auth.dev.kimi.team',
+        oauthHost: 'https://auth.dev.example.test',
       },
     });
     expect(config.services?.moonshotSearch?.oauth).toEqual({
       storage: 'file',
       key: oauthKey,
-      oauthHost: 'https://auth.dev.kimi.team',
+      oauthHost: 'https://auth.dev.example.test',
     });
     expect(config.services?.moonshotFetch?.oauth).toEqual({
       storage: 'file',
       key: oauthKey,
-      oauthHost: 'https://auth.dev.kimi.team',
+      oauthHost: 'https://auth.dev.example.test',
     });
   });
 
@@ -745,22 +745,22 @@ describe('provisionManagedKimiCodeConfig', () => {
 
     const promise = fetchManagedKimiCodeModels({
       accessToken: 'oauth-access-token',
-      baseUrl: 'https://coding.deva.msh.team/coding/v1',
+      baseUrl: 'https://api.dev.example.test/coding/v1',
       fetchImpl,
     });
 
     await expect(promise).rejects.toThrow(
-      "Kimi Code models endpoint https://coding.deva.msh.team/coding/v1 rejected OAuth credentials: We're unable to verify your membership benefits at this time. Please ensure your membership is active.",
+      "Kimi Code models endpoint https://api.dev.example.test/coding/v1 rejected OAuth credentials: We're unable to verify your membership benefits at this time. Please ensure your membership is active.",
     );
     await expect(
       fetchManagedKimiCodeModels({
         accessToken: 'oauth-access-token',
-        baseUrl: 'https://coding.deva.msh.team/coding/v1',
+        baseUrl: 'https://api.dev.example.test/coding/v1',
         fetchImpl,
       }),
     ).rejects.toMatchObject({
       status: 402,
-      baseUrl: 'https://coding.deva.msh.team/coding/v1',
+      baseUrl: 'https://api.dev.example.test/coding/v1',
     });
     await expect(
       fetchManagedKimiCodeModels({

--- a/packages/oauth/test/toolkit.test.ts
+++ b/packages/oauth/test/toolkit.test.ts
@@ -146,10 +146,10 @@ describe('KimiOAuthToolkit', () => {
 
   it('refreshes configured bearer token refs against their OAuth host', async () => {
     const storage = new MemoryTokenStorage();
-    const oauthHost = 'https://auth.dev.kimi.team';
+    const oauthHost = 'https://auth.dev.example.test';
     const oauthKey = resolveKimiCodeOAuthKey({
       oauthHost,
-      baseUrl: 'https://coding.deva.msh.team/coding/v1',
+      baseUrl: 'https://api.dev.example.test/coding/v1',
     });
     storage.tokens.set(resolveKimiTokenStorageName({ oauthKey }), {
       ...token('expired-dev-access'),
@@ -419,8 +419,8 @@ describe('KimiOAuthToolkit', () => {
     const storage = new MemoryTokenStorage();
     storage.tokens.set('kimi-code', token('prod-access'));
     const config: ManagedKimiConfigShape = { providers: {} };
-    const devBaseUrl = 'https://coding.deva.msh.team/coding/v1';
-    const devOauthHost = 'https://auth.dev.kimi.team';
+    const devBaseUrl = 'https://api.dev.example.test/coding/v1';
+    const devOauthHost = 'https://auth.dev.example.test';
     const devOauthKey = resolveKimiCodeOAuthKey({
       oauthHost: devOauthHost,
       baseUrl: devBaseUrl,


### PR DESCRIPTION
## Related Issue

No linked issue. This addresses internal environment endpoints being present in test fixtures.

## Problem

Some tests used real internal/dev endpoint hosts as fixture base URLs, which unnecessarily exposes environment details in the repository.

## What changed

Replaced those fixture hosts with `.example.test` placeholders while preserving OAuth scoping, runtime auth, plugin environment propagation, and config round-trip coverage.

Validation run:

- `pnpm vitest run test/utils/kimi-datasource-plugin.test.ts` from `apps/kimi-code`
- `pnpm vitest run test/auth-facade.test.ts` from `packages/node-sdk`
- `pnpm vitest run test/managed-kimi-code.test.ts test/toolkit.test.ts` from `packages/oauth`
- `pnpm vitest run test/rpc/plugins-rpc.test.ts test/config/configs.test.ts` from `packages/agent-core`
- `git diff --check`

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.
