### PR TITLE
fix(tui): gate terminal progress sequences behind OSC 9;4 support

### DIFF
--- a/.changeset/iterm2-progress-notifications.md
+++ b/.changeset/iterm2-progress-notifications.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Fix endless desktop notifications in iTerm2 by only sending terminal progress sequences to terminals that support them.

--- a/apps/kimi-code/src/tui/kimi-tui.ts
+++ b/apps/kimi-code/src/tui/kimi-tui.ts
@@ -1722,6 +1722,7 @@ export class KimiTUI {
   }
 
   private syncTerminalProgress(active: boolean): void {
+    if (!this.state.terminalState.supportsProgress) return;
     if (this.state.terminalState.progressActive === active) return;
     this.state.terminal.setProgress(active);
     this.state.terminalState.progressActive = active;

--- a/apps/kimi-code/src/tui/utils/terminal-notification.ts
+++ b/apps/kimi-code/src/tui/utils/terminal-notification.ts
@@ -110,6 +110,25 @@ export function supportsOsc9Notification(env: NodeJS.ProcessEnv = process.env): 
   return false;
 }
 
+/**
+ * Best-effort detection of ConEmu-style OSC 9;4 progress support, driven
+ * off well-known environment variables like `supportsOsc9Notification`.
+ * The two allow-lists must stay separate: iTerm2 posts a desktop
+ * notification for ANY `OSC 9;<payload>` it receives, so sending the 9;4
+ * progress sequence there pops a "4;3" notification every keepalive tick.
+ * Terminals outside this list simply get no progress reporting, which is
+ * always safe.
+ */
+export function supportsTerminalProgress(env: NodeJS.ProcessEnv = process.env): boolean {
+  if ((env['WT_SESSION'] ?? '').length > 0) return true;
+  if (env['ConEmuANSI'] === 'ON') return true;
+  const termProgram = env['TERM_PROGRAM'] ?? '';
+  if (termProgram === 'ghostty' || termProgram === 'WezTerm') return true;
+  const term = env['TERM'] ?? '';
+  if (term === 'xterm-ghostty') return true;
+  return false;
+}
+
 export function isInsideTmux(env: NodeJS.ProcessEnv = process.env): boolean {
   const tmux = env['TMUX'] ?? '';
   return tmux.length > 0;

--- a/apps/kimi-code/src/tui/utils/terminal-state.ts
+++ b/apps/kimi-code/src/tui/utils/terminal-state.ts
@@ -1,9 +1,14 @@
-import { isInsideTmux, supportsOsc9Notification } from './terminal-notification';
+import {
+  isInsideTmux,
+  supportsOsc9Notification,
+  supportsTerminalProgress,
+} from './terminal-notification';
 
 export interface TerminalState {
   notificationKeys: Set<string>;
   focused: boolean;
   supportsOsc9: boolean;
+  supportsProgress: boolean;
   insideTmux: boolean;
   progressActive: boolean;
 }
@@ -13,6 +18,7 @@ export function createTerminalState(): TerminalState {
     notificationKeys: new Set<string>(),
     focused: true,
     supportsOsc9: supportsOsc9Notification(),
+    supportsProgress: supportsTerminalProgress(),
     insideTmux: isInsideTmux(),
     progressActive: false,
   };

--- a/apps/kimi-code/test/tui/activity-pane.test.ts
+++ b/apps/kimi-code/test/tui/activity-pane.test.ts
@@ -47,6 +47,7 @@ function makeDriverWithTerminalProgress(): {
   const driver = new KimiTUI({} as never, makeStartupInput()) as unknown as ActivityDriver;
   vi.spyOn(driver.state.ui, 'requestRender').mockImplementation(() => {});
   driver.state.terminal = { columns: 80, setProgress } as unknown as TUIState['terminal'];
+  driver.state.terminalState.supportsProgress = true;
   return { driver, state: driver.state, setProgress };
 }
 
@@ -94,6 +95,24 @@ describe('updateActivityPane terminal progress', () => {
 
       expect(setProgress).toHaveBeenCalledTimes(2);
       expect(setProgress).toHaveBeenLastCalledWith(false);
+      expect(state.terminalState.progressActive).toBe(false);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('never emits terminal progress when the terminal does not support OSC 9;4', () => {
+    vi.useFakeTimers();
+    try {
+      const { driver, state, setProgress } = makeDriverWithTerminalProgress();
+      state.terminalState.supportsProgress = false;
+
+      state.livePane = { ...state.livePane, mode: 'waiting' };
+      driver.updateActivityPane();
+      state.livePane = { ...state.livePane, mode: 'idle' };
+      driver.updateActivityPane();
+
+      expect(setProgress).not.toHaveBeenCalled();
       expect(state.terminalState.progressActive).toBe(false);
     } finally {
       vi.useRealTimers();

--- a/apps/kimi-code/test/tui/terminal-notification.test.ts
+++ b/apps/kimi-code/test/tui/terminal-notification.test.ts
@@ -8,6 +8,7 @@ import {
   isInsideTmux,
   notifyTerminalOnce,
   supportsOsc9Notification,
+  supportsTerminalProgress,
 } from '#/tui/utils/terminal-notification';
 
 function makeNotificationState(args: {
@@ -212,6 +213,32 @@ describe('supportsOsc9Notification', () => {
     expect(supportsOsc9Notification({ ConEmuANSI: 'ON' })).toBe(false);
     expect(supportsOsc9Notification({ TERM: 'xterm-256color' })).toBe(false);
     expect(supportsOsc9Notification({})).toBe(false);
+  });
+});
+
+describe('supportsTerminalProgress', () => {
+  it('detects Windows Terminal / ConEmu via env flags', () => {
+    expect(supportsTerminalProgress({ WT_SESSION: 'abc-123' })).toBe(true);
+    expect(supportsTerminalProgress({ ConEmuANSI: 'ON' })).toBe(true);
+  });
+
+  it('detects Ghostty / WezTerm via TERM_PROGRAM and TERM', () => {
+    expect(supportsTerminalProgress({ TERM_PROGRAM: 'ghostty' })).toBe(true);
+    expect(supportsTerminalProgress({ TERM: 'xterm-ghostty' })).toBe(true);
+    expect(supportsTerminalProgress({ TERM_PROGRAM: 'WezTerm' })).toBe(true);
+  });
+
+  it('rejects terminals that show every OSC 9 payload as a notification', () => {
+    // iTerm2 treats any OSC 9 payload as a desktop notification, so the
+    // ConEmu-style 9;4 progress sequence must never be sent there.
+    expect(supportsTerminalProgress({ TERM_PROGRAM: 'iTerm.app' })).toBe(false);
+    expect(supportsTerminalProgress({ TERM_PROGRAM: 'Apple_Terminal' })).toBe(false);
+    expect(supportsTerminalProgress({ TERM_PROGRAM: 'WarpTerminal' })).toBe(false);
+    expect(supportsTerminalProgress({ TERM: 'xterm-kitty' })).toBe(false);
+    expect(supportsTerminalProgress({ TERM: 'xterm-256color' })).toBe(false);
+    expect(supportsTerminalProgress({ ConEmuANSI: 'OFF' })).toBe(false);
+    expect(supportsTerminalProgress({ WT_SESSION: '' })).toBe(false);
+    expect(supportsTerminalProgress({})).toBe(false);
   });
 });
 


### PR DESCRIPTION
## Related Issue

fix https://github.com/MoonshotAI/kimi-code/issues/603

## Problem

On macOS iTerm2, Kimi Code floods the user with desktop notifications while the model is working — roughly one per second, each showing the literal text `4;3`.

The TUI reports work-in-progress to the terminal via the ConEmu-style `OSC 9;4` progress sequence, and the underlying terminal layer re-sends it every second as a keepalive. iTerm2 does not implement the `9;4` progress extension — it treats *any* `OSC 9;<payload>` as its own "post a desktop notification" protocol, even on current releases (the same conflict hit pytest's terminalprogress plugin: pytest-dev/pytest#13896). So every keepalive tick becomes a notification, and the clear sequence (`9;4;0;`) pops one more.

## What changed

- Added `supportsTerminalProgress()`, a conservative env-based allow-list (Windows Terminal, ConEmu, Ghostty, WezTerm), mirroring the existing `supportsOsc9Notification()` pattern. The two lists must stay separate: iTerm2 belongs in the notification list but must never receive the progress sequence.
- `TerminalState` now carries a `supportsProgress` flag detected once at startup, and `syncTerminalProgress` returns early when the terminal is not in the allow-list. Since `setProgress(true)` is then never called, the keepalive timer never starts and no clear sequence is emitted on exit either.
- Terminals outside the list simply get no progress reporting, which is always safe. Regular notifications (task complete / approval needed) are unaffected — they go through the separate, already-gated OSC 9 notification path.

Tests: unit coverage for the allow/deny list, plus a behavior-level regression test asserting `setProgress` is never called when the terminal lacks `OSC 9;4` support.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.