### PR TITLE
feat: allow configuring a separate model for subagents (#568)

### DIFF
--- a/packages/agent-core/src/config/schema.ts
+++ b/packages/agent-core/src/config/schema.ts
@@ -104,6 +104,12 @@ export const BackgroundConfigSchema = z.object({
 
 export type BackgroundConfig = z.infer<typeof BackgroundConfigSchema>;
 
+export const SubagentConfigSchema = z.object({
+  model: z.string().optional(),
+});
+
+export type SubagentConfig = z.infer<typeof SubagentConfigSchema>;
+
 export const ExperimentalConfigSchema = z.record(z.string(), z.boolean());
 
 export type ExperimentalConfig = z.infer<typeof ExperimentalConfigSchema>;
@@ -204,6 +210,7 @@ export const KimiConfigSchema = z.object({
   loopControl: LoopControlSchema.optional(),
   background: BackgroundConfigSchema.optional(),
   experimental: ExperimentalConfigSchema.optional(),
+  subagents: SubagentConfigSchema.optional(),
   telemetry: z.boolean().optional(),
   raw: z.record(z.string(), z.unknown()).optional(),
 });
@@ -243,6 +250,7 @@ export const KimiConfigPatchSchema = z
     loopControl: LoopControlPatchSchema.optional(),
     background: BackgroundConfigPatchSchema.optional(),
     experimental: ExperimentalConfigPatchSchema.optional(),
+    subagents: SubagentConfigSchema.optional(),
     telemetry: z.boolean().optional(),
   })
   .strict();

--- a/packages/agent-core/src/session/subagent-host.ts
+++ b/packages/agent-core/src/session/subagent-host.ts
@@ -143,7 +143,7 @@ export class SessionSubagentHost {
     const completion = this.runWithActiveChild(agentId, options, async (runOptions) => {
       this.emitSubagentSpawned(parent, agentId, profileName, runOptions);
       try {
-        child.config.update({ modelAlias: parent.config.modelAlias });
+        child.config.update({ modelAlias: this.resolveSubagentModel(parent) });
         return await this.runPromptTurn(parent, agentId, child, profileName, runOptions);
       } catch (error) {
         this.emitSubagentFailed(parent, agentId, runOptions, error);
@@ -159,7 +159,7 @@ export class SessionSubagentHost {
     const completion = this.runWithActiveChild(agentId, options, async (runOptions) => {
       try {
         runOptions.signal.throwIfAborted();
-        child.config.update({ modelAlias: parent.config.modelAlias });
+        child.config.update({ modelAlias: this.resolveSubagentModel(parent) });
         this.emitSubagentStarted(parent, agentId);
         const turnId = child.turn.retry('agent-host');
         if (turnId === null) {
@@ -220,7 +220,7 @@ export class SessionSubagentHost {
     );
 
     child.config.update({
-      modelAlias: parent.config.modelAlias,
+      modelAlias: this.resolveSubagentModel(parent),
       thinkingLevel: parent.config.thinkingLevel,
       systemPrompt: parent.config.systemPrompt,
     });
@@ -350,15 +350,27 @@ export class SessionSubagentHost {
     return { result, usage };
   }
 
+  private resolveSubagentModel(parent: Agent): string {
+    // Env var override has highest priority
+    const envModel = process.env.KIMI_SUBAGENT_MODEL;
+    if (envModel) return envModel;
+
+    // Config override from [subagents] section
+    const subagentModel = this.session.options.config?.subagents?.model;
+    if (subagentModel) return subagentModel;
+
+    // Default: inherit parent model
+    return parent.config.modelAlias;
+  }
+
   private async configureChild(
     parent: Agent,
     child: Agent,
     profile: ResolvedAgentProfile,
   ): Promise<void> {
-    // A subagent always inherits the parent agent's model.
     child.config.update({
       cwd: parent.config.cwd,
-      modelAlias: parent.config.modelAlias,
+      modelAlias: this.resolveSubagentModel(parent),
       thinkingLevel: parent.config.thinkingLevel,
     });
 


### PR DESCRIPTION
## Summary

Adds support for configuring a separate model for subagents via `config.toml`, resolving #568.

### Changes

**`packages/agent-core/src/config/schema.ts`**
- Added `SubagentConfigSchema` with optional `model` field
- Added `subagents` field to both `KimiConfigSchema` and `KimiConfigPatchSchema`

**`packages/agent-core/src/session/subagent-host.ts`**
- Added `resolveSubagentModel()` method with 3-level priority resolution
- Replaced all 4 hardcoded `parent.config.modelAlias` assignments in:
  - `configureChild()`
  - `resume()`
  - `retry()`
  - `startBtw()`

### Priority Order

| Priority | Source | Example |
|----------|--------|---------|
| 1 (highest) | `KIMI_SUBAGENT_MODEL` env var | `KIMI_SUBAGENT_MODEL=mimo-v2.5` |
| 2 | `[subagents].model` in config.toml | `[subagents]\nmodel = "mimo-v2.5"` |
| 3 (default) | Parent agent model | Inherited from parent |

### Usage

```toml
# ~/.kimi-code/config.toml
[subagents]
model = "mimo-v2.5"
```

### Design Decisions

- **Minimal change**: Only 2 files modified, 25 lines added, 5 removed
- **Backward compatible**: Without `[subagents]` section, behavior is identical to current (inherits parent model)
- **Env var override**: `KIMI_SUBAGENT_MODEL` allows per-session override without config file changes
- **No breaking changes**: `SubagentConfigSchema` is optional in both config and patch schemas
- **`startBtw()` also respects the override**: Side-channel conversations use the configured subagent model

Closes #568