### PR TITLE
fix(read): report both MAX_LINES and MAX_BYTES caps when both are hit

### DIFF
--- a/.changeset/fix-read-dual-limit-status.md
+++ b/.changeset/fix-read-dual-limit-status.md
@@ -1,0 +1,8 @@
+---
+"@moonshot-ai/agent-core": patch
+"@moonshot-ai/kimi-code": patch
+---
+
+fix(read): report both MAX_LINES and MAX_BYTES caps when both are hit
+
+Fixes #94

--- a/packages/agent-core/src/tools/builtin/file/read.ts
+++ b/packages/agent-core/src/tools/builtin/file/read.ts
@@ -446,9 +446,11 @@ export class ReadTool implements BuiltinTool<ReadInput> {
     parts.push(`Total lines in file: ${String(input.totalLines)}.`);
     if (input.maxLinesReached) {
       parts.push(`Max ${String(MAX_LINES)} lines reached.`);
-    } else if (input.maxBytesReached) {
+    }
+    if (input.maxBytesReached) {
       parts.push(`Max ${String(MAX_BYTES)} bytes reached.`);
-    } else if (lineCount < input.requestedLines) {
+    }
+    if (!input.maxLinesReached && !input.maxBytesReached && lineCount < input.requestedLines) {
       parts.push('End of file reached.');
     }
     if (input.truncatedLineNumbers.length > 0) {

--- a/packages/agent-core/test/tools/read.test.ts
+++ b/packages/agent-core/test/tools/read.test.ts
@@ -622,6 +622,19 @@ describe('ReadTool', () => {
     expect(result.output).not.toContain(`${String(MAX_LINES + 1)}\tline ${String(MAX_LINES + 1)}`);
   });
 
+  it('reports both line and byte caps when both limits are hit', async () => {
+    const longLine = 'x'.repeat(200);
+    const content = Array.from({ length: MAX_LINES + 1 }, () => longLine).join('\n');
+    const tool = toolWithContent(content);
+
+    const result = await executeTool(tool, context({ path: '/tmp/dual-limit.txt' }));
+    const output = toolContentString(result);
+
+    expect(output).toContain(`Max ${String(MAX_LINES)} lines reached.`);
+    expect(output).toContain(`Max ${String(MAX_BYTES)} bytes reached.`);
+    expect(output).not.toContain('End of file reached.');
+  });
+
   it('tail byte truncation keeps the newest lines closest to EOF', async () => {
     const numLines = Math.floor(MAX_BYTES / 1001) + 20;
     const content = Array.from({ length: numLines }, (_, i) => {


### PR DESCRIPTION
## Related Issue

Fixes #94

## Problem

When a file is large enough to trigger both the `MAX_LINES` (1000) and `MAX_BYTES` (100 KiB) limits, the Read tool\'s `<system>` status block only reports the line cap and silently omits the byte cap. This happens because `finishMessage` uses an `else if` chain that treats the two limits as mutually exclusive.

## What changed

- Changed `finishMessage` in `packages/agent-core/src/tools/builtin/file/read.ts` to use independent `if` checks for `maxLinesReached` and `maxBytesReached`, so both messages appear together when both limits are hit.
- Added an explicit guard for `End of file reached.` (`!maxLinesReached && !maxBytesReached && lineCount < requestedLines`) to prevent it from being suppressed or incorrectly shown alongside the caps.
- Added a regression test `reports both line and byte caps when both limits are hit` that constructs a file with `MAX_LINES + 1` lines of 200 characters each, asserting that the output contains both cap messages and does not contain `End of file reached.`.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [ ] Ran `gen-docs` skill, or this PR needs no doc update.}