### PR TITLE
fix(tui): indent, italicize, and dim AskUserQuestion answer arrow

### DIFF
--- a/.changeset/indent-askuserquestion-answer.md
+++ b/.changeset/indent-askuserquestion-answer.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Indent, italicize, and dim the answer arrow in AskUserQuestion result cards so answers sit visually nested under their questions.

--- a/apps/kimi-code/src/tui/components/messages/tool-call.ts
+++ b/apps/kimi-code/src/tui/components/messages/tool-call.ts
@@ -1994,7 +1994,7 @@ export class ToolCallComponent extends Container {
     }
     if (typeof parsed !== 'object' || parsed === null) return false;
 
-    const accent = (text: string) => currentTheme.fg('primary', text);
+    const answerArrow = (text: string) => currentTheme.italicFg('textDim', text);
 
     const answers = (parsed as { answers?: unknown }).answers;
     const note = (parsed as { note?: unknown }).note;
@@ -2012,7 +2012,7 @@ export class ToolCallComponent extends Container {
     for (const [question, answer] of Object.entries(answers as Record<string, unknown>)) {
       const answerText = typeof answer === 'string' ? answer : JSON.stringify(answer);
       this.addChild(new Text(`  ${currentTheme.dim('Q')}  ${question}`, 0, 0));
-      this.addChild(new Text(`  ${accent('→')}  ${answerText}`, 0, 0));
+      this.addChild(new Text(`    ${answerArrow('→')}  ${answerText}`, 0, 0));
     }
     return true;
   }


### PR DESCRIPTION
## Related Issue

No prior issue — this is a small TUI polish fix.

## Problem

In the transcript, `AskUserQuestion` result cards render the question and answer arrows at the same indentation with the same bright primary color:

```text
  Q  Favorite editor?
  →  Vim
```

The answer does not visually read as nested under the question, and the arrow competes for attention with the actual answer text.

## What changed

- Indented the answer arrow by two extra spaces so answers appear nested beneath their questions.
- Styled the arrow with `italicFg('textDim')` instead of the bright primary color, making it a subtle visual cue rather than the focus.
- Renamed the local helper from `accent` to `answerArrow` to match its new purpose.

```text
  Q  Favorite editor?
    →  Vim
```

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works. (Existing `tool-call.test.ts` covers AskUserQuestion rendering; this is a purely visual styling tweak.)
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.
