### PR TITLE
feat(kimi-code): refresh OAuth provider models before opening model picker

### DIFF
--- a/.changeset/refresh-model-picker-oauth.md
+++ b/.changeset/refresh-model-picker-oauth.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Refresh provider model metadata before opening the model picker.

--- a/apps/kimi-code/src/tui/commands/config.ts
+++ b/apps/kimi-code/src/tui/commands/config.ts
@@ -28,6 +28,8 @@ import type { SlashCommandHost } from './dispatch';
 // Plan / Config commands
 // ---------------------------------------------------------------------------
 
+const MODEL_PICKER_REFRESH_TIMEOUT_MS = 2_000;
+
 export async function handlePlanCommand(host: SlashCommandHost, args: string): Promise<void> {
   const session = host.session;
   if (session === undefined) {
@@ -196,8 +198,9 @@ export async function handleThemeCommand(host: SlashCommandHost, args: string): 
   await applyThemeChoice(host, theme);
 }
 
-export function handleModelCommand(host: SlashCommandHost, args: string): void {
+export async function handleModelCommand(host: SlashCommandHost, args: string): Promise<void> {
   const alias = args.trim();
+  await refreshModelsForPicker(host);
   if (alias.length === 0) {
     showModelPicker(host);
     return;
@@ -227,6 +230,37 @@ function showEditorPicker(host: SlashCommandHost): void {
       },
     }),
   );
+}
+
+async function refreshModelsForPicker(host: SlashCommandHost): Promise<void> {
+  try {
+    const result = await withTimeout(
+      host.authFlow.refreshOAuthProviderModels(),
+      MODEL_PICKER_REFRESH_TIMEOUT_MS,
+    );
+    if (result === undefined) return;
+    for (const f of result.failed) {
+      host.showStatus(`Skipped refreshing ${f.provider}: ${f.reason}`, 'warning');
+    }
+  } catch (error) {
+    host.showStatus(`Skipped refreshing models: ${formatErrorMessage(error)}`, 'warning');
+  }
+}
+
+async function withTimeout<T>(promise: Promise<T>, timeoutMs: number): Promise<T | undefined> {
+  let timeout: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<undefined>((resolve) => {
+        timeout = setTimeout(() => {
+          resolve(undefined);
+        }, timeoutMs);
+      }),
+    ]);
+  } finally {
+    if (timeout !== undefined) clearTimeout(timeout);
+  }
 }
 
 async function applyEditorChoice(host: SlashCommandHost, value: string): Promise<void> {

--- a/apps/kimi-code/src/tui/commands/dispatch.ts
+++ b/apps/kimi-code/src/tui/commands/dispatch.ts
@@ -273,7 +273,7 @@ async function handleBuiltInSlashCommand(
       await handleThemeCommand(host, args);
       return;
     case 'model':
-      handleModelCommand(host, args);
+      await handleModelCommand(host, args);
       return;
     case 'provider':
       await handleProviderCommand(host);

--- a/apps/kimi-code/src/tui/controllers/auth-flow.ts
+++ b/apps/kimi-code/src/tui/controllers/auth-flow.ts
@@ -2,7 +2,11 @@ import type { KimiHarness, Session } from '@moonshot-ai/kimi-code-sdk';
 import type { SkillListSession } from '../commands';
 
 import { OAUTH_LOGIN_REQUIRED_STARTUP_NOTICE } from '../constant/kimi-tui';
-import { refreshAllProviderModels } from '../utils/refresh-providers';
+import {
+  refreshAllProviderModels,
+  type RefreshProviderScope,
+  type RefreshResult,
+} from '../utils/refresh-providers';
 import type { SessionEventHandler } from './session-event-handler';
 import type { AppState, KimiTUIOptions } from '../types';
 import type { TUIState } from '../tui-state';
@@ -142,26 +146,28 @@ export class AuthFlowController {
    * config.  Runs best-effort: individual provider failures are collected
    * and returned instead of thrown.
    */
-  async refreshProviderModels(): Promise<{
-    readonly changed: ReadonlyArray<{
-      readonly providerId: string;
-      readonly providerName: string;
-      readonly added: number;
-      readonly removed: number;
-    }>;
-    readonly unchanged: readonly string[];
-    readonly failed: ReadonlyArray<{ readonly provider: string; readonly reason: string }>;
-  }> {
+  async refreshProviderModels(): Promise<RefreshResult> {
+    return this.refreshProviderModelsWithScope('all');
+  }
+
+  async refreshOAuthProviderModels(): Promise<RefreshResult> {
+    return this.refreshProviderModelsWithScope('oauth');
+  }
+
+  private async refreshProviderModelsWithScope(scope: RefreshProviderScope): Promise<RefreshResult> {
     const { host } = this;
-    const result = await refreshAllProviderModels({
-      getConfig: () => host.harness.getConfig({ reload: true }),
-      removeProvider: (id) => host.harness.removeProvider(id),
-      setConfig: (patch) => host.harness.setConfig(patch),
-      resolveOAuthToken: async (providerName, oauthRef) => {
-        const tokenProvider = host.harness.auth.resolveOAuthTokenProvider(providerName, oauthRef);
-        return tokenProvider.getAccessToken();
+    const result = await refreshAllProviderModels(
+      {
+        getConfig: () => host.harness.getConfig({ reload: true }),
+        removeProvider: (id) => host.harness.removeProvider(id),
+        setConfig: (patch) => host.harness.setConfig(patch),
+        resolveOAuthToken: async (providerName, oauthRef) => {
+          const tokenProvider = host.harness.auth.resolveOAuthTokenProvider(providerName, oauthRef);
+          return tokenProvider.getAccessToken();
+        },
       },
-    });
+      { scope },
+    );
     if (result.changed.length > 0) {
       await this.refreshAvailableModels();
     }

--- a/apps/kimi-code/src/tui/utils/refresh-providers.ts
+++ b/apps/kimi-code/src/tui/utils/refresh-providers.ts
@@ -40,6 +40,12 @@ export interface RefreshResult {
   readonly failed: ReadonlyArray<{ readonly provider: string; readonly reason: string }>;
 }
 
+export type RefreshProviderScope = 'all' | 'oauth';
+
+export interface RefreshProviderOptions {
+  readonly scope?: RefreshProviderScope;
+}
+
 function readCustomRegistrySource(provider: ProviderConfig): CustomRegistrySource | undefined {
   const source = provider.source;
   if (typeof source !== 'object' || source === null) return undefined;
@@ -264,10 +270,14 @@ function pickDefaultModel(config: KimiConfig, providerId: string, models: Array<
   return firstModel.id;
 }
 
-export async function refreshAllProviderModels(host: RefreshProviderHost): Promise<RefreshResult> {
+export async function refreshAllProviderModels(
+  host: RefreshProviderHost,
+  options: RefreshProviderOptions = {},
+): Promise<RefreshResult> {
   const changed: ProviderChange[] = [];
   const unchanged: string[] = [];
   const failed: Array<{ provider: string; reason: string }> = [];
+  const scope = options.scope ?? 'all';
 
   let config = await host.getConfig();
 
@@ -341,6 +351,10 @@ export async function refreshAllProviderModels(host: RefreshProviderHost): Promi
         reason: error instanceof Error ? error.message : String(error),
       });
     }
+  }
+
+  if (scope === 'oauth') {
+    return { changed, unchanged, failed };
   }
 
   // -------------------------------------------------------------------------

--- a/apps/kimi-code/test/tui/kimi-tui-message-flow.test.ts
+++ b/apps/kimi-code/test/tui/kimi-tui-message-flow.test.ts
@@ -3362,8 +3362,10 @@ command = "vim"
 
     driver.handleUserInput('/model turbo');
 
+    await vi.waitFor(() => {
+      expect(driver.state.editorContainer.children[0]).toBeInstanceOf(TabbedModelSelectorComponent);
+    });
     const picker = driver.state.editorContainer.children[0];
-    expect(picker).toBeInstanceOf(TabbedModelSelectorComponent);
     const pickerOutput = stripSgr((picker as TabbedModelSelectorComponent).render(120).join('\n'));
     expect(pickerOutput).toMatch(/Kimi K2\s+Kimi Code ← current/);
     expect(pickerOutput).toMatch(/❯ Kimi Turbo\s+Kimi Code/);
@@ -3411,8 +3413,10 @@ command = "vim"
 
     driver.handleUserInput('/model k2');
 
+    await vi.waitFor(() => {
+      expect(driver.state.editorContainer.children[0]).toBeInstanceOf(TabbedModelSelectorComponent);
+    });
     const picker = driver.state.editorContainer.children[0];
-    expect(picker).toBeInstanceOf(TabbedModelSelectorComponent);
     (picker as TabbedModelSelectorComponent).handleInput('\r');
 
     await vi.waitFor(() => {
@@ -3423,6 +3427,101 @@ command = "vim"
     });
     expect(session.setModel).not.toHaveBeenCalled();
     expect(session.setThinking).not.toHaveBeenCalled();
+  });
+
+  it('refreshes only OAuth provider models before opening /model picker', async () => {
+    const { driver } = await makeDriver(makeSession(), {
+      getConfig: vi.fn(async () => ({
+        models: {
+          k2: {
+            provider: 'managed:kimi-code',
+            model: 'kimi-k2',
+            maxContextSize: 100,
+            displayName: 'Old Kimi K2',
+            capabilities: ['thinking'],
+          },
+        },
+      })),
+    });
+    const tui = driver as unknown as KimiTUI;
+    const refreshProviderModels = vi
+      .spyOn(tui.authFlow, 'refreshProviderModels')
+      .mockRejectedValue(new Error('full provider refresh should not run'));
+    const refreshOAuthProviderModels = vi.fn(async () => {
+      await Promise.resolve();
+      tui.setAppState({
+        availableModels: {
+          k2: {
+            provider: 'managed:kimi-code',
+            model: 'kimi-k2',
+            maxContextSize: 100,
+            displayName: 'Fresh Kimi K2',
+            capabilities: ['thinking'],
+          },
+        },
+      });
+      return { changed: [], unchanged: ['managed:kimi-code'], failed: [] };
+    });
+    (
+      tui.authFlow as unknown as {
+        refreshOAuthProviderModels: typeof refreshOAuthProviderModels;
+      }
+    ).refreshOAuthProviderModels = refreshOAuthProviderModels;
+
+    driver.handleUserInput('/model');
+
+    await vi.waitFor(() => {
+      const picker = driver.state.editorContainer.children[0];
+      expect(picker).toBeInstanceOf(TabbedModelSelectorComponent);
+      const output = stripSgr((picker as TabbedModelSelectorComponent).render(120).join('\n'));
+      expect(output).toContain('Fresh Kimi K2');
+      expect(output).not.toContain('Old Kimi K2');
+    });
+    expect(refreshOAuthProviderModels).toHaveBeenCalledOnce();
+    expect(refreshProviderModels).not.toHaveBeenCalled();
+  });
+
+  it('opens /model picker after 2s when OAuth refresh is still pending', async () => {
+    const { driver } = await makeDriver(makeSession(), {
+      getConfig: vi.fn(async () => ({
+        models: {
+          k2: {
+            provider: 'managed:kimi-code',
+            model: 'kimi-k2',
+            maxContextSize: 100,
+            displayName: 'Kimi K2',
+            capabilities: ['thinking'],
+          },
+        },
+      })),
+    });
+    const tui = driver as unknown as KimiTUI;
+    const refreshOAuthProviderModels = vi.fn(() => new Promise<never>(() => {}));
+    (
+      tui.authFlow as unknown as {
+        refreshOAuthProviderModels: typeof refreshOAuthProviderModels;
+      }
+    ).refreshOAuthProviderModels = refreshOAuthProviderModels;
+
+    vi.useFakeTimers();
+    try {
+      driver.handleUserInput('/model');
+      await Promise.resolve();
+
+      expect(refreshOAuthProviderModels).toHaveBeenCalledOnce();
+      expect(driver.state.editorContainer.children[0]).not.toBeInstanceOf(TabbedModelSelectorComponent);
+
+      await vi.advanceTimersByTimeAsync(1_999);
+      expect(driver.state.editorContainer.children[0]).not.toBeInstanceOf(TabbedModelSelectorComponent);
+
+      await vi.advanceTimersByTimeAsync(1);
+      const picker = driver.state.editorContainer.children[0];
+      expect(picker).toBeInstanceOf(TabbedModelSelectorComponent);
+      const output = stripSgr((picker as TabbedModelSelectorComponent).render(120).join('\n'));
+      expect(output).toContain('Kimi K2');
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it('enables search in the shared model selector helper', async () => {

--- a/apps/kimi-code/test/tui/utils/refresh-providers.test.ts
+++ b/apps/kimi-code/test/tui/utils/refresh-providers.test.ts
@@ -126,6 +126,92 @@ describe('refreshAllProviderModels', () => {
     expect(resolveOAuthToken).toHaveBeenCalledWith(KIMI_CODE_PROVIDER_NAME, envOauthRef);
   });
 
+  it('can refresh only the managed OAuth provider without fetching third-party registries', async () => {
+    const baseUrl = 'https://api.example.test/coding/v1';
+    const registryUrl = 'https://registry.example.test/v1/models/api.json';
+    const config: KimiConfig = {
+      providers: {
+        [KIMI_CODE_PROVIDER_NAME]: {
+          type: 'kimi',
+          baseUrl,
+          apiKey: '',
+          oauth: {
+            storage: 'file',
+            key: resolveKimiCodeOAuthKey({ baseUrl }),
+          },
+        },
+        custom: {
+          type: 'openai',
+          baseUrl: 'https://custom.example.test/v1',
+          apiKey: 'sk-test-token',
+          source: { kind: 'apiJson', url: registryUrl, apiKey: 'sk-test-token' },
+        },
+      },
+      models: {
+        'kimi-code/kimi-for-coding': {
+          provider: KIMI_CODE_PROVIDER_NAME,
+          model: 'kimi-for-coding',
+          maxContextSize: 262144,
+          capabilities: ['thinking', 'tool_use'],
+          displayName: 'Old Kimi',
+        },
+        'custom/m1': {
+          provider: 'custom',
+          model: 'm1',
+          maxContextSize: 131072,
+          capabilities: ['tool_use'],
+          displayName: 'Custom M1',
+        },
+      },
+      defaultModel: 'kimi-code/kimi-for-coding',
+      telemetry: true,
+    };
+    const host = makeRefreshHost(config);
+    const resolveOAuthToken = vi.fn(async () => 'oauth-access-token');
+    const fetchMock = vi.fn<FetchMock>(async (input, init) => {
+      expect(fetchInputUrl(input)).toBe(`${baseUrl}/models`);
+      expect(new Headers(init?.headers).get('authorization')).toBe('Bearer oauth-access-token');
+      return new Response(
+        JSON.stringify({
+          data: [
+            {
+              id: 'kimi-for-coding',
+              context_length: 262144,
+              supports_reasoning: true,
+              display_name: 'Fresh Kimi',
+            },
+          ],
+        }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } },
+      );
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await refreshAllProviderModels(
+      {
+        getConfig: async () => host.current(),
+        removeProvider: host.removeProvider,
+        setConfig: host.setConfig,
+        resolveOAuthToken,
+      },
+      { scope: 'oauth' },
+    );
+
+    expect(result.failed).toEqual([]);
+    expect(result.changed).toEqual([
+      {
+        providerId: KIMI_CODE_PROVIDER_NAME,
+        providerName: 'Kimi Code',
+        added: 0,
+        removed: 0,
+      },
+    ]);
+    expect(result.unchanged).toEqual([]);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(host.current().models?.['kimi-code/kimi-for-coding']?.displayName).toBe('Fresh Kimi');
+    expect(host.current().models?.['custom/m1']?.displayName).toBe('Custom M1');
+  });
+
   it('refreshes custom-registry model capabilities even when model ids are unchanged', async () => {
     const registryUrl = 'https://registry.example.test/v1/models/api.json';
     const providerId = 'example_chat-completions';


### PR DESCRIPTION
## Summary

This PR makes the `/model` slash command refresh OAuth-backed provider models right before opening the model picker, so newly-available or changed OAuth models show up without forcing a full provider refresh. It introduces a scoped refresh mode so the picker can refresh only OAuth providers, and adds a short timeout so the UI stays responsive even if the refresh hangs.

---

### 1. Refresh OAuth models before opening the model picker

**Problem:** The `/model` picker could display stale model lists for OAuth providers because it did not refresh provider models before rendering.

**What was done:**
- Changed `handleModelCommand` to `async` and call `refreshOAuthProviderModels()` before showing the picker.
- Added a `MODEL_PICKER_REFRESH_TIMEOUT_MS` (2 s) helper so the picker still opens promptly even if the refresh is slow or fails.
- Surfaced non-fatal refresh failures as warning status messages instead of throwing.

### 2. Scoped provider model refresh

**Problem:** `refreshAllProviderModels` always refreshed every provider, which is unnecessary when the picker only needs OAuth provider data.

**What was done:**
- Added `RefreshProviderScope = 'all' | 'oauth'` and `RefreshProviderOptions` to `refresh-providers.ts`.
- Updated `AuthFlowController` with `refreshOAuthProviderModels()` (scope `'oauth'`) and kept `refreshProviderModels()` as `'all'`.
- Preserved existing behavior for non-OAuth providers by defaulting the scope to `'all'`.

### 3. Tests

**What was done:**
- Added tests in `test/tui/utils/refresh-providers.test.ts` for OAuth-only refresh behavior.
- Updated `test/tui/kimi-tui-message-flow.test.ts` to cover async model picker rendering after the refresh call.

---

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [ ] I have linked the related issue, if any.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [ ] Ran `gen-docs` skill, or this PR needs a doc update.
- [ ] I have run `make gen-changelog` to update the changelog.
