### PR TITLE
fix(tui): correct IME cursor placement

### DIFF
--- a/.changeset/fix-ime-cursor-placement.md
+++ b/.changeset/fix-ime-cursor-placement.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Fix IME candidate placement and cursor rendering in the terminal editor.

--- a/apps/kimi-code/src/tui/components/editor/custom-editor.ts
+++ b/apps/kimi-code/src/tui/components/editor/custom-editor.ts
@@ -4,6 +4,7 @@
 
 import {
   Editor,
+  CURSOR_MARKER,
   isKeyRelease,
   matchesKey,
   Key,
@@ -23,6 +24,8 @@ const ANSI_SGR = /\u001B\[[0-9;]*m/g;
 const PASTE_MARKER_RE = /\[paste #(\d+)(?: (?:\+\d+ lines|\d+ chars))?\]/g;
 const BRACKET_PASTE_START = '\u001B[200~';
 const BRACKET_PASTE_END = '\u001B[201~';
+const FAKE_CURSOR_START = '\u001B[7m';
+const FAKE_CURSOR_END = '\u001B[0m';
 
 // Kitty keyboard protocol CSI-u sequence: ESC [ keycode ; modifier[:eventType] u.
 // We intentionally match only the simple two-field form — enough to rewrite
@@ -239,9 +242,10 @@ export class CustomEditor extends Editor {
     // overwrite it (e.g. plan-mode / slash-context highlight via
     // `editor.borderColor = chalk.hex(primary)`), so we route corners and
     // side bars through the same hook to stay in sync.
-    return wrapWithSideBorders(lines, (s) => this.borderColor(s), {
+    const wrapped = wrapWithSideBorders(lines, (s) => this.borderColor(s), {
       connectedAbove: this.connectedAbove && !this.borderHighlighted,
     });
+    return wrapped.map(removeFakeCursorAtHardwareMarker);
   }
 
   override handleInput(data: string): void {
@@ -360,6 +364,25 @@ export class CustomEditor extends Editor {
 
     super.handleInput(normalized);
   }
+}
+
+export function removeFakeCursorAtHardwareMarker(line: string): string {
+  const markerStart = line.indexOf(CURSOR_MARKER);
+  if (markerStart < 0) return line;
+
+  const fakeCursorStart = markerStart + CURSOR_MARKER.length;
+  if (!line.startsWith(FAKE_CURSOR_START, fakeCursorStart)) return line;
+
+  const fakeCursorEnd = line.indexOf(
+    FAKE_CURSOR_END,
+    fakeCursorStart + FAKE_CURSOR_START.length,
+  );
+  if (fakeCursorEnd < 0) return line;
+
+  const cursorTextStart = fakeCursorStart + FAKE_CURSOR_START.length;
+  const cursorText = line.slice(cursorTextStart, fakeCursorEnd);
+  const afterFakeCursor = fakeCursorEnd + FAKE_CURSOR_END.length;
+  return line.slice(0, fakeCursorStart) + cursorText + line.slice(afterFakeCursor);
 }
 
 /**

--- a/apps/kimi-code/src/tui/tui-state.ts
+++ b/apps/kimi-code/src/tui/tui-state.ts
@@ -58,7 +58,7 @@ export function createTUIState(options: KimiTUIOptions): TUIState {
   const theme = currentTheme;
 
   const terminal = new ProcessTerminal();
-  const ui = new TUI(terminal);
+  const ui = new TUI(terminal, true);
 
   const transcriptContainer = new GutterContainer(CHROME_GUTTER, CHROME_GUTTER);
   const activityContainer = new GutterContainer(CHROME_GUTTER, CHROME_GUTTER);

--- a/apps/kimi-code/test/tui/components/editor/custom-editor.test.ts
+++ b/apps/kimi-code/test/tui/components/editor/custom-editor.test.ts
@@ -4,9 +4,13 @@ import type {
   AutocompleteSuggestions,
   TUI,
 } from '@earendil-works/pi-tui';
+import { CURSOR_MARKER } from '@earendil-works/pi-tui';
 import { describe, expect, it, vi } from 'vitest';
 
-import { CustomEditor } from '#/tui/components/editor/custom-editor';
+import {
+  CustomEditor,
+  removeFakeCursorAtHardwareMarker,
+} from '#/tui/components/editor/custom-editor';
 
 function makeEditor(): CustomEditor {
   const tui = {
@@ -132,6 +136,31 @@ describe('CustomEditor Kitty key release handling', () => {
   });
 });
 
+describe('removeFakeCursorAtHardwareMarker', () => {
+  it('removes the rendered fake cursor and keeps the hardware cursor marker in place', () => {
+    const line = `before${CURSOR_MARKER}\u001B[7m \u001B[0mafter`;
+
+    expect(removeFakeCursorAtHardwareMarker(line)).toBe(`before${CURSOR_MARKER} after`);
+  });
+
+  it('renders a focused editor with hardware cursor positioning but no fake cursor block', () => {
+    const editor = makeEditor();
+    editor.focused = true;
+    editor.setText('test');
+
+    const output = editor.render(40).join('\n');
+
+    expect(output).toContain(CURSOR_MARKER);
+    expect(output).not.toContain('\u001B[7m');
+  });
+
+  it('leaves unrelated marker-like lines untouched', () => {
+    const line = `before${CURSOR_MARKER}after`;
+
+    expect(removeFakeCursorAtHardwareMarker(line)).toBe(line);
+  });
+});
+
 describe('CustomEditor paste marker expansion', () => {
   const PASTE_START = '\x1b[200~';
   const PASTE_END = '\x1b[201~';
@@ -199,7 +228,7 @@ describe('CustomEditor paste marker expansion', () => {
 
     expect(editor.getText()).toMatch(/\[paste #1/);
 
-    editor.handleInput('\x16');
+    editor.handleInput(process.platform === 'win32' ? '\x1b[118;3u' : '\x16');
 
     expect(editor.getText()).not.toContain('[paste #');
     expect(editor.getText()).toContain(longText);

--- a/apps/kimi-code/test/tui/create-tui-state.test.ts
+++ b/apps/kimi-code/test/tui/create-tui-state.test.ts
@@ -47,6 +47,7 @@ describe('createTUIState', () => {
 
     // UI objects are created.
     expect(state.ui).toBeDefined();
+    expect(state.ui.getShowHardwareCursor()).toBe(true);
     expect(state.terminal).toBeDefined();
     expect(state.transcriptContainer).toBeDefined();
     expect(state.activityContainer).toBeDefined();


### PR DESCRIPTION
## Related Issue

Resolve #712

## Problem

See linked issue. In WezTerm and Alacritty, Chinese IME candidate windows were not anchored to the editor cursor. Enabling the hardware cursor fixed candidate placement, but also exposed a double cursor in the main terminal editor.

## What changed

Enabled the TUI hardware cursor so terminal IME candidate windows can follow the editor cursor. The main editor now removes the rendered fake cursor when the hardware cursor marker is present, avoiding the double-width cursor while preserving IME positioning.

Added regression coverage for hardware cursor initialization and editor cursor rendering.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.