### PR TITLE
test: resolve tsx CLI via createRequire for vitest module runner

### DIFF
--- a/packages/oauth/test/helpers.ts
+++ b/packages/oauth/test/helpers.ts
@@ -1,12 +1,12 @@
 import { spawn, type ChildProcessByStdio } from 'node:child_process';
 import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises';
+import { createRequire } from 'node:module';
 import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
 import type { Readable } from 'node:stream';
-import { fileURLToPath } from 'node:url';
 
 const tsxCli = join(
-  dirname(fileURLToPath(import.meta.resolve('tsx/package.json'))),
+  dirname(createRequire(import.meta.url).resolve('tsx/package.json')),
   'dist',
   'cli.mjs',
 );

--- a/packages/telemetry/test/telemetry.test.ts
+++ b/packages/telemetry/test/telemetry.test.ts
@@ -1,9 +1,10 @@
 import { spawn } from 'node:child_process';
 import { mkdirSync, readdirSync, readFileSync, rmSync, statSync, writeFileSync } from 'node:fs';
 import { mkdtemp } from 'node:fs/promises';
+import { createRequire } from 'node:module';
 import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
-import { fileURLToPath, pathToFileURL } from 'node:url';
+import { pathToFileURL } from 'node:url';
 
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
@@ -852,7 +853,7 @@ async function runTelemetryCrashScript(body: string): Promise<number> {
   const scriptPath = join(dir, 'crash-worker.ts');
   const testDir = import.meta.dirname;
   const tsxCli = join(
-    dirname(fileURLToPath(import.meta.resolve('tsx/package.json'))),
+    dirname(createRequire(import.meta.url).resolve('tsx/package.json')),
     'dist/cli.mjs',
   );
   const crashModuleUrl = pathToFileURL(join(testDir, '../src/crash.ts')).href;


### PR DESCRIPTION
## Related Issue
No existing issue — test-infra fix, problem explained below.

## Problem
Two tests fail to run under the current Vitest because they resolve the `tsx` CLI path with `import.meta.resolve(...)`, which is not supported inside Vitest's module runner: `packages/oauth/test/oauth-manager-multi-process.test.ts` fails to load, and the unhandled-rejection crash test in `packages/telemetry/test/telemetry.test.ts` throws before spawning its worker.

## What changed
Resolve the `tsx` CLI with `createRequire(import.meta.url).resolve('tsx/package.json')`, which uses Node's native resolver and works in both Node and the Vitest module runner. No production code changes.

## Checklist
- [x] I have read the CONTRIBUTING document.
- [x] I have explained the problem above.
- [x] I have added tests that prove the fix works (these two suites now run).
- [x] This PR needs no changeset (test-only).
- [x] This PR needs no doc update.
