### PR TITLE
fix(migration-legacy): correct blank-title and corrupt-classification on kimi-cli import

### DIFF
--- a/.changeset/migration-import-title-and-corrupt-fixes.md
+++ b/.changeset/migration-import-title-and-corrupt-fixes.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Fix two kimi-cli session import edge cases: a blank/whitespace-only custom title is no longer imported as an all-spaces, falsely-custom session title (it falls back to the prompt prefix), and an imported `context.jsonl` whose lines are all valid JSON but not objects is now classified as empty rather than reported as a corrupt migration failure.

--- a/packages/migration-legacy/src/sessions/state-writer.ts
+++ b/packages/migration-legacy/src/sessions/state-writer.ts
@@ -14,9 +14,14 @@ export interface StateWriteInput {
 export async function writeSessionState(sessionDir: string, input: StateWriteInput): Promise<void> {
   await mkdir(sessionDir, { recursive: true, mode: 0o700 });
 
-  const customTitle = input.oldState.custom_title ?? null;
-  const isCustomTitle =
-    customTitle !== null && customTitle.length > 0 && !input.oldState.title_generated;
+  const customTitleRaw = input.oldState.custom_title ?? null;
+  // Trim and treat a blank/whitespace-only custom_title as absent, mirroring
+  // how `fallbackTitle` is trimmed below. Otherwise an all-spaces title slips
+  // past the length checks, producing a blank session title falsely flagged as
+  // user-custom.
+  const customTitle =
+    customTitleRaw !== null && customTitleRaw.trim().length > 0 ? customTitleRaw.trim() : null;
+  const isCustomTitle = customTitle !== null && !input.oldState.title_generated;
   const fallbackTitle = input.lastUserPrompt.slice(0, 50).trim();
   const candidateTitle = customTitle ?? fallbackTitle;
   const finalTitle = candidateTitle.length > 0 ? candidateTitle : 'Imported session';

--- a/packages/migration-legacy/src/sessions/translator.ts
+++ b/packages/migration-legacy/src/sessions/translator.ts
@@ -49,8 +49,12 @@ export function analyzeContextContent(lines: readonly string[]): ContextContent 
     } catch {
       continue;
     }
-    if (typeof parsed !== 'object' || parsed === null) continue;
+    // A line that JSON.parse accepts has "parsed" per the corrupt contract
+    // above, even when it is a scalar/array rather than an object. Mark it
+    // before the shape check so an all-valid-JSON-but-no-object context is
+    // classified 'empty' (cleared session), not 'corrupt' (disk damage).
     hadParseableLine = true;
+    if (typeof parsed !== 'object' || parsed === null) continue;
     const role = (parsed as Record<string, unknown>)['role'];
     if (typeof role === 'string' && USABLE_ROLES.has(role)) return 'real';
   }

--- a/packages/migration-legacy/test/sessions/state-writer.test.ts
+++ b/packages/migration-legacy/test/sessions/state-writer.test.ts
@@ -47,6 +47,34 @@ describe('writeSessionState', () => {
     expect(meta.isCustomTitle).toBe(false);
   });
 
+  it('treats a blank/whitespace-only custom_title as absent and falls back', async () => {
+    await writeSessionState(dir, {
+      oldState: { custom_title: '   ', title_generated: false, wire_mtime: 1 },
+      lastUserPrompt: 'a real prompt here',
+      sourcePath: '/a',
+      oldSessionUuid: 'u',
+      wireProtocolFromOld: null,
+      createdAtMs: 1,
+    });
+    const meta = JSON.parse(await readFile(join(dir, 'state.json'), 'utf-8'));
+    expect(meta.title).toBe('a real prompt here');
+    expect(meta.isCustomTitle).toBe(false);
+  });
+
+  it('trims surrounding whitespace from a custom_title', async () => {
+    await writeSessionState(dir, {
+      oldState: { custom_title: '  My chat  ', title_generated: false, wire_mtime: 1 },
+      lastUserPrompt: 'irrelevant',
+      sourcePath: '/a',
+      oldSessionUuid: 'u',
+      wireProtocolFromOld: null,
+      createdAtMs: 1,
+    });
+    const meta = JSON.parse(await readFile(join(dir, 'state.json'), 'utf-8'));
+    expect(meta.title).toBe('My chat');
+    expect(meta.isCustomTitle).toBe(true);
+  });
+
   it('uses Imported session as fallback when no title source', async () => {
     await writeSessionState(dir, {
       oldState: { wire_mtime: 1 },

--- a/packages/migration-legacy/test/sessions/translator.test.ts
+++ b/packages/migration-legacy/test/sessions/translator.test.ts
@@ -170,4 +170,12 @@ describe('analyzeContextContent', () => {
       ]),
     ).toBe('empty');
   });
+
+  it("'empty' (not 'corrupt') when lines are valid JSON scalars/arrays, not objects", () => {
+    // These lines parse successfully, so they are not "disk damage". Per the
+    // corrupt contract (every non-blank line *failed to parse*), they must be
+    // classified 'empty', not 'corrupt'.
+    expect(analyzeContextContent(['42', '"hi"', 'true'])).toBe('empty');
+    expect(analyzeContextContent(['[]'])).toBe('empty');
+  });
 });


### PR DESCRIPTION
## Related Issue
No existing issue — two kimi-cli import edge cases explained below.

## Problem
When importing legacy kimi-cli sessions: (1) a whitespace-only `custom_title` (e.g. `"   "`) was written verbatim as the session title and flagged `isCustomTitle: true`, surfacing an all-spaces, falsely-custom entry in the picker; (2) `analyzeContextContent` classified a `context.jsonl` whose lines are valid JSON but not objects (`42`, `"hi"`, `[]`) as `corrupt` — even though its own doc comment defines corrupt as "every non-blank line failed to parse" — so such a session was reported as a migration failure instead of empty/skipped.

## What changed
(1) Trim `custom_title` and treat a blank result as absent (mirroring `fallbackTitle`), so it falls back to the prompt prefix and `isCustomTitle` is false. (2) Mark a line as parseable as soon as `JSON.parse` succeeds, before the object-shape check, so an all-valid-JSON-non-object context is `empty`, not `corrupt`. Genuinely truncated lines still fail to parse and remain `corrupt`. Tests added for both.

## Checklist
- [x] I have read the CONTRIBUTING document.
- [x] I have explained the problem above.
- [x] I have added tests (fail-before/pass-after).
- [x] Changeset included (patch, @moonshot-ai/kimi-code).
- [x] This PR needs no doc update.
