### PR TITLE
fix: clear stale custom registry providers

### DIFF
--- a/.changeset/remove-stale-custom-registry-providers.md
+++ b/.changeset/remove-stale-custom-registry-providers.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Fix custom registry re-imports so removed providers are cleared from the provider command.

--- a/apps/kimi-code/src/cli/sub/provider.ts
+++ b/apps/kimi-code/src/cli/sub/provider.ts
@@ -13,10 +13,11 @@
  */
 
 import {
-  applyCustomRegistryProvider,
+  applyCustomRegistryEntries,
   CustomRegistryApiError,
   fetchCustomRegistry,
   type CustomRegistrySource,
+  type CustomRegistryProviderEntry,
   type ManagedKimiConfigShape,
 } from '@moonshot-ai/kimi-code-oauth';
 import {
@@ -112,26 +113,20 @@ export async function handleProviderAdd(
     deps.exit(1);
   }
 
-  // `harness.removeProvider` reloads the config from disk on each call (see
-  // `core-impl.ts removeKimiProvider`), so calling it inside the apply loop
-  // would discard providers we already applied in memory but have not yet
-  // persisted. Drop every stale id up front in a single batch instead, then
-  // apply against the resulting fresh config.
   let config = await harness.getConfig();
-  const staleIds = entryList
-    .filter((entry) => config.providers[entry.id] !== undefined)
-    .map((entry) => entry.id);
-  for (const id of staleIds) {
+  // `setConfig` patches cannot clear defaultModel with undefined, so keep
+  // provider removals on the existing RPC path before applying the fresh batch.
+  for (const id of customRegistryProvidersToRemove(config, entries, source)) {
     config = await harness.removeProvider(id);
   }
 
   const addedProviderIds: string[] = [];
   let modelCount = 0;
   for (const entry of entryList) {
-    applyCustomRegistryProvider(asManaged(config), entry, source);
     addedProviderIds.push(entry.id);
     modelCount += Object.keys(entry.models).length;
   }
+  applyCustomRegistryEntries(asManaged(config), entries, source);
 
   await harness.setConfig({
     providers: config.providers,
@@ -527,15 +522,38 @@ function asManaged(config: KimiConfig): ManagedKimiConfigShape {
   return config as unknown as ManagedKimiConfigShape;
 }
 
-function providerSourceLabel(provider: KimiConfig['providers'][string]): string {
-  const source = provider.source;
-  if (source !== undefined) {
-    if (source['kind'] === 'apiJson' && typeof source['url'] === 'string') {
-      return `apiJson(${source['url']})`;
-    }
+function customRegistryProvidersToRemove(
+  config: KimiConfig,
+  entries: Record<string, CustomRegistryProviderEntry>,
+  source: CustomRegistrySource,
+): string[] {
+  const incoming = new Set(Object.values(entries).map((entry) => entry.id));
+  const removeIds = new Set<string>();
+
+  for (const id of incoming) {
+    if (config.providers[id] !== undefined) removeIds.add(id);
   }
+
+  for (const [id, provider] of Object.entries(config.providers)) {
+    if (incoming.has(id)) continue;
+    if (providerSourceUrl(provider) === source.url) removeIds.add(id);
+  }
+
+  return [...removeIds];
+}
+
+function providerSourceLabel(provider: KimiConfig['providers'][string]): string {
+  const url = providerSourceUrl(provider);
+  if (url !== undefined) return `apiJson(${url})`;
   if (provider.oauth !== undefined) return 'oauth';
   return 'inline';
+}
+
+function providerSourceUrl(provider: KimiConfig['providers'][string]): string | undefined {
+  const source = provider.source;
+  if (source === undefined) return undefined;
+  if (source['kind'] !== 'apiJson' || typeof source['url'] !== 'string') return undefined;
+  return source['url'];
 }
 
 function errorMessage(error: unknown): string {

--- a/apps/kimi-code/test/cli/provider.test.ts
+++ b/apps/kimi-code/test/cli/provider.test.ts
@@ -356,6 +356,80 @@ describe('kimi provider add', () => {
     expect(final.models?.['kohub-responses/legacy-model']).toBeUndefined();
   });
 
+  it('removes providers from the same custom registry when they disappear upstream', async () => {
+    const updatedRegistryBody = {
+      primary: {
+        id: 'registry-primary',
+        name: 'Primary Registry Provider',
+        api: 'https://registry.example.test',
+        type: 'openai',
+        models: {
+          'model-current': { id: 'model-current', name: 'Current Model' },
+        },
+      },
+    };
+    mockRegistryFetch(updatedRegistryBody);
+    const initial: KimiConfig = {
+      providers: {
+        'registry-primary': {
+          type: 'openai',
+          baseUrl: 'https://registry.example.test',
+          apiKey: 'test-key-old',
+          source: { kind: 'apiJson', url: REGISTRY_URL, apiKey: 'test-key-old' },
+        },
+        'registry-removed': {
+          type: 'openai',
+          baseUrl: 'https://registry.example.test/v1',
+          apiKey: 'test-key-old',
+          source: { kind: 'apiJson', url: REGISTRY_URL, apiKey: 'test-key-old' },
+        },
+        manual: {
+          type: 'openai',
+          baseUrl: 'https://manual.example.test/v1',
+          apiKey: 'test-key-manual',
+        },
+      },
+      models: {
+        'registry-primary/model-current': {
+          provider: 'registry-primary',
+          model: 'model-current',
+          maxContextSize: 1024,
+          capabilities: [],
+        },
+        'registry-removed/model-removed': {
+          provider: 'registry-removed',
+          model: 'model-removed',
+          maxContextSize: 1024,
+          capabilities: [],
+        },
+        'manual/model-manual': {
+          provider: 'manual',
+          model: 'model-manual',
+          maxContextSize: 1024,
+          capabilities: [],
+        },
+      },
+      defaultModel: 'registry-removed/model-removed',
+    } as unknown as KimiConfig;
+    const { harness, removeCalls, current } = makeHarness(initial);
+    const { deps, exitCodes } = makeDeps(harness);
+
+    await tryRun(() =>
+      handleProviderAdd(deps, REGISTRY_URL, { apiKey: 'test-key-fresh' }),
+    );
+
+    expect(exitCodes).toEqual([]);
+    expect(removeCalls).toEqual(['registry-primary', 'registry-removed']);
+    const final = current();
+    expect(Object.keys(final.providers).toSorted()).toEqual(['manual', 'registry-primary']);
+    expect(final.providers['registry-primary']?.apiKey).toBe('test-key-fresh');
+    expect(final.models?.['registry-primary/model-current']).toBeDefined();
+    expect(final.providers['registry-removed']).toBeUndefined();
+    expect(final.models?.['registry-removed/model-removed']).toBeUndefined();
+    expect(final.models?.['manual/model-manual']).toBeDefined();
+    expect(final.defaultModel).toBeUndefined();
+  });
+
   it('reads the api key from KIMI_REGISTRY_API_KEY when --api-key is omitted', async () => {
     const fetchMock = mockRegistryFetch();
     const { harness } = makeHarness({ providers: {} } as KimiConfig);


### PR DESCRIPTION
## Related Issue

No related issue. This fixes a focused bug in the non-interactive provider import path.

## Problem

`kimi provider add` refreshed providers that still existed in a custom registry, but it did not remove providers from the same registry URL when they disappeared upstream. That could leave stale provider entries, model aliases, and a dangling default model in the local config.

## What changed

The provider command now removes providers already tied to the same custom registry URL before applying the fresh registry batch. This keeps CLI behavior aligned with the custom-registry batch helper and lets the existing remove-provider path clear provider-linked defaults correctly.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.

## Validation

- `pnpm --filter @moonshot-ai/kimi-code test -- test/cli/provider.test.ts`
- `pnpm --filter @moonshot-ai/kimi-code typecheck`
- `pnpm exec oxlint --type-aware apps/kimi-code/src/cli/sub/provider.ts apps/kimi-code/test/cli/provider.test.ts`
- Read-only diff audit for internal identifiers: no issues found
