### PR TITLE
fix: disable WSL Windows Terminal progress

### DIFF
--- a/.changeset/disable-wsl-terminal-progress.md
+++ b/.changeset/disable-wsl-terminal-progress.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Disable terminal progress reporting under WSL in Windows Terminal.

--- a/apps/kimi-code/src/tui/utils/terminal-notification.ts
+++ b/apps/kimi-code/src/tui/utils/terminal-notification.ts
@@ -120,7 +120,7 @@ export function supportsOsc9Notification(env: NodeJS.ProcessEnv = process.env): 
  * always safe.
  */
 export function supportsTerminalProgress(env: NodeJS.ProcessEnv = process.env): boolean {
-  if ((env['WT_SESSION'] ?? '').length > 0) return true;
+  if ((env['WT_SESSION'] ?? '').length > 0) return !isInsideWsl(env);
   if (env['ConEmuANSI'] === 'ON') return true;
   const termProgram = env['TERM_PROGRAM'] ?? '';
   if (termProgram === 'ghostty' || termProgram === 'WezTerm') return true;
@@ -132,6 +132,14 @@ export function supportsTerminalProgress(env: NodeJS.ProcessEnv = process.env): 
 export function isInsideTmux(env: NodeJS.ProcessEnv = process.env): boolean {
   const tmux = env['TMUX'] ?? '';
   return tmux.length > 0;
+}
+
+function isInsideWsl(env: NodeJS.ProcessEnv): boolean {
+  return (
+    (env['WSL_DISTRO_NAME'] ?? '').length > 0 ||
+    (env['WSLENV'] ?? '').length > 0 ||
+    (env['WSL_INTEROP'] ?? '').length > 0
+  );
 }
 
 function sanitizeNotificationText(value: string): string {

--- a/apps/kimi-code/test/tui/terminal-notification.test.ts
+++ b/apps/kimi-code/test/tui/terminal-notification.test.ts
@@ -222,6 +222,18 @@ describe('supportsTerminalProgress', () => {
     expect(supportsTerminalProgress({ ConEmuANSI: 'ON' })).toBe(true);
   });
 
+  it('rejects Windows Terminal under WSL', () => {
+    expect(supportsTerminalProgress({ WT_SESSION: 'abc-123', WSL_DISTRO_NAME: 'example' })).toBe(
+      false,
+    );
+    expect(supportsTerminalProgress({ WT_SESSION: 'abc-123', WSLENV: 'WT_SESSION/u' })).toBe(
+      false,
+    );
+    expect(
+      supportsTerminalProgress({ WT_SESSION: 'abc-123', WSL_INTEROP: '/run/WSL/example.sock' }),
+    ).toBe(false);
+  });
+
   it('detects Ghostty / WezTerm via TERM_PROGRAM and TERM', () => {
     expect(supportsTerminalProgress({ TERM_PROGRAM: 'ghostty' })).toBe(true);
     expect(supportsTerminalProgress({ TERM: 'xterm-ghostty' })).toBe(true);


### PR DESCRIPTION
## Related Issue

Fixes #727

## Problem

Windows Terminal under WSL receives OSC 9;4 progress updates as Windows taskbar progress. While Kimi Code is responding, that progress state can prevent an auto-hidden Windows taskbar from revealing normally.

## What changed

- Treat Windows Terminal sessions under WSL as unsupported for terminal progress reporting, while keeping native Windows Terminal and the existing allow-listed terminals enabled.
- Added regression coverage for common WSL environment signals with `WT_SESSION`.
- Added a patch changeset for the CLI fix.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.

Validation:

- `pnpm --filter @moonshot-ai/kimi-code test -- test/tui/terminal-notification.test.ts`
- `pnpm --filter @moonshot-ai/kimi-code typecheck`
- `pnpm exec oxlint --type-aware apps/kimi-code/src/tui/utils/terminal-notification.ts apps/kimi-code/test/tui/terminal-notification.test.ts`
