### PR TITLE
feat: include raw input in ACP permission requests

### DIFF
--- a/.changeset/acp-permission-raw-input.md
+++ b/.changeset/acp-permission-raw-input.md
@@ -1,0 +1,7 @@
+---
+"@moonshot-ai/agent-core": minor
+"@moonshot-ai/acp-adapter": minor
+"@moonshot-ai/kimi-code": minor
+---
+
+Expose raw tool inputs on approval requests so ACP clients can inspect exact permission payloads.

--- a/packages/acp-adapter/src/approval.ts
+++ b/packages/acp-adapter/src/approval.ts
@@ -157,16 +157,16 @@ export function permissionResponseToApprovalResponse(
   }
   switch (optionId) {
     case APPROVE_ONCE_OPTION_ID:
-    // Legacy Python kimi-cli (< v0.9.0) used 'approve' as the
-    // allow-once optionId. Keep accepting it so custom ACP clients
-    // built against the old SDK are not silently rejected.
     case 'approve':
+      // Legacy Python kimi-cli (< v0.9.0) used 'approve' as the
+      // allow-once optionId. Keep accepting it so custom ACP clients
+      // built against the old SDK are not silently rejected.
       return { decision: 'approved' };
     case APPROVE_ALWAYS_OPTION_ID:
-    // Legacy Python kimi-cli (< v0.9.0) used 'approve_for_session' as
-    // the allow-always optionId. Same backward-compatibility rationale
-    // as the 'approve' branch above.
     case 'approve_for_session':
+      // Legacy Python kimi-cli (< v0.9.0) used 'approve_for_session' as
+      // the allow-always optionId. Same backward-compatibility rationale
+      // as the 'approve' branch above.
       return { decision: 'approved', scope: 'session' };
     case REJECT_OPTION_ID:
       return { decision: 'rejected' };
@@ -276,6 +276,7 @@ export function buildPermissionToolCallUpdate(
   return {
     toolCallId,
     title: req.toolName,
+    rawInput: req.rawInput,
     content,
   };
 }

--- a/packages/acp-adapter/test/approval.test.ts
+++ b/packages/acp-adapter/test/approval.test.ts
@@ -211,6 +211,7 @@ describe('buildPermissionToolCallUpdate (Phase 5.1 minimal shape)', () => {
     toolCallId: 'abc',
     toolName: 'Bash',
     action: 'run command',
+    rawInput: { command: 'ls -la', timeout: 60 },
     display: fakeDisplay,
   };
 
@@ -218,6 +219,7 @@ describe('buildPermissionToolCallUpdate (Phase 5.1 minimal shape)', () => {
     const update = buildPermissionToolCallUpdate(42, baseReq);
     expect(update.toolCallId).toBe('42:abc');
     expect(update.title).toBe('Bash');
+    expect(update.rawInput).toEqual({ command: 'ls -la', timeout: 60 });
   });
 
   it('falls back to the raw SDK toolCallId when no turnId is tracked yet', () => {
@@ -238,7 +240,8 @@ describe('AcpSession ↔ requestPermission bridge (end-to-end via wire)', () => 
     } as unknown as KimiHarness;
 
     const { agentStream, clientStream } = makeInMemoryStreamPair();
-    new AgentSideConnection((c) => new AcpServer(harness, c), agentStream);
+    const agentConn = new AgentSideConnection((c) => new AcpServer(harness, c), agentStream);
+    void agentConn;
     const client = new ApprovalClient();
     client.reply = {
       outcome: { outcome: 'selected', optionId: APPROVE_ONCE_OPTION_ID },
@@ -278,6 +281,7 @@ describe('AcpSession ↔ requestPermission bridge (end-to-end via wire)', () => 
       toolCallId: 'tc-1',
       toolName: 'Bash',
       action: 'run command',
+      rawInput: { command: 'echo hi', timeout: 60 },
       display: { kind: 'command', command: 'echo hi' },
     };
     const decision = await handle.invokeHandler(approvalReq);
@@ -297,6 +301,7 @@ describe('AcpSession ↔ requestPermission bridge (end-to-end via wire)', () => 
     ]);
     expect(req.toolCall.toolCallId).toBe(`${turnId}:tc-1`);
     expect(req.toolCall.title).toBe('Bash');
+    expect(req.toolCall.rawInput).toEqual({ command: 'echo hi', timeout: 60 });
 
     // Settle the parked prompt with a turn.ended so the test exits
     // cleanly.
@@ -320,7 +325,8 @@ describe('AcpSession ↔ requestPermission bridge (end-to-end via wire)', () => 
     } as unknown as KimiHarness;
 
     const { agentStream, clientStream } = makeInMemoryStreamPair();
-    new AgentSideConnection((c) => new AcpServer(harness, c), agentStream);
+    const agentConn = new AgentSideConnection((c) => new AcpServer(harness, c), agentStream);
+    void agentConn;
     const client = new ApprovalClient();
     // Override to throw so the bridge falls into the catch branch.
     client.requestPermission = async (_p: RequestPermissionRequest) => {

--- a/packages/agent-core/src/agent/permission/index.ts
+++ b/packages/agent-core/src/agent/permission/index.ts
@@ -152,6 +152,7 @@ export class PermissionManager {
             toolCallId: id,
             toolName: name,
             action,
+            rawInput: context.args,
             display,
           },
           { signal },

--- a/packages/agent-core/src/agent/permission/types.ts
+++ b/packages/agent-core/src/agent/permission/types.ts
@@ -37,6 +37,7 @@ export interface ApprovalRequest {
   toolCallId: string;
   toolName: string;
   action: string;
+  rawInput?: unknown;
   display: ToolInputDisplay;
 }
 

--- a/packages/agent-core/src/rpc/sdk-api.ts
+++ b/packages/agent-core/src/rpc/sdk-api.ts
@@ -19,6 +19,7 @@ export interface ApprovalRequest {
   readonly toolCallId: string;
   readonly toolName: string;
   readonly action: string;
+  readonly rawInput?: unknown;
   readonly display: ToolInputDisplay;
 }
 

--- a/packages/agent-core/test/agent/basic.test.ts
+++ b/packages/agent-core/test/agent/basic.test.ts
@@ -105,7 +105,7 @@ it('runs an agent turn through builtin tool approval and execution', async () =>
     [emit] assistant.delta             { "turnId": 0, "delta": "I will run that." }
     [emit] tool.call.delta             { "turnId": 0, "toolCallId": "call_bash", "name": "Bash", "argumentsPart": "{\\"command\\":\\"printf lookup-result\\",\\"timeout\\":60}" }
     [wire] context.append_loop_event   { "event": { "type": "content.part", "uuid": "<uuid-2>", "turnId": "0", "step": 1, "stepUuid": "<uuid-1>", "part": { "type": "text", "text": "I will run that." } }, "time": "<time>" }
-    [emit] requestApproval             { "turnId": 0, "toolCallId": "call_bash", "toolName": "Bash", "action": "Running: printf lookup-result", "display": { "kind": "command", "command": "printf lookup-result", "cwd": "<cwd>", "language": "bash" } }
+    [emit] requestApproval             { "turnId": 0, "toolCallId": "call_bash", "toolName": "Bash", "action": "Running: printf lookup-result", "rawInput": { "command": "printf lookup-result", "timeout": 60 }, "display": { "kind": "command", "command": "printf lookup-result", "cwd": "<cwd>", "language": "bash" } }
   `);
   expect(ctx.lastLlmInput()).toMatchInlineSnapshot(`
     system: <system-prompt>

--- a/packages/agent-core/test/agent/config.test.ts
+++ b/packages/agent-core/test/agent/config.test.ts
@@ -117,7 +117,7 @@ describe('Agent config', () => {
       [emit] assistant.delta             { "turnId": 0, "delta": "I will run Bash." }
       [emit] tool.call.delta             { "turnId": 0, "toolCallId": "call_bash", "name": "Bash", "argumentsPart": "{\\"command\\":\\"printf original-result\\",\\"timeout\\":60}" }
       [wire] context.append_loop_event   { "event": { "type": "content.part", "uuid": "<uuid-2>", "turnId": "0", "step": 1, "stepUuid": "<uuid-1>", "part": { "type": "text", "text": "I will run Bash." } }, "time": "<time>" }
-      [emit] requestApproval             { "turnId": 0, "toolCallId": "call_bash", "toolName": "Bash", "action": "Running: printf original-result", "display": { "kind": "command", "command": "printf original-result", "cwd": "<cwd>", "language": "bash" } }
+      [emit] requestApproval             { "turnId": 0, "toolCallId": "call_bash", "toolName": "Bash", "action": "Running: printf original-result", "rawInput": { "command": "printf original-result", "timeout": 60 }, "display": { "kind": "command", "command": "printf original-result", "cwd": "<cwd>", "language": "bash" } }
     `);
     expect(ctx.lastLlmInput()).toMatchInlineSnapshot(`
       system: <system-prompt>

--- a/packages/agent-core/test/agent/permission.test.ts
+++ b/packages/agent-core/test/agent/permission.test.ts
@@ -218,7 +218,7 @@ describe('Agent permission', () => {
       [emit] assistant.delta             { "turnId": 0, "delta": "I will try Bash." }
       [emit] tool.call.delta             { "turnId": 0, "toolCallId": "call_bash", "name": "Bash", "argumentsPart": "{\\"command\\":\\"printf should-not-run\\",\\"timeout\\":60}" }
       [wire] context.append_loop_event   { "event": { "type": "content.part", "uuid": "<uuid-2>", "turnId": "0", "step": 1, "stepUuid": "<uuid-1>", "part": { "type": "text", "text": "I will try Bash." } }, "time": "<time>" }
-      [emit] requestApproval             { "turnId": 0, "toolCallId": "call_bash", "toolName": "Bash", "action": "Running: printf should-not-run", "display": { "kind": "command", "command": "printf should-not-run", "cwd": "<cwd>", "language": "bash" } }
+      [emit] requestApproval             { "turnId": 0, "toolCallId": "call_bash", "toolName": "Bash", "action": "Running: printf should-not-run", "rawInput": { "command": "printf should-not-run", "timeout": 60 }, "display": { "kind": "command", "command": "printf should-not-run", "cwd": "<cwd>", "language": "bash" } }
     `);
     expect(ctx.lastLlmInput()).toMatchInlineSnapshot(`
       system: <system-prompt>
@@ -426,6 +426,7 @@ describe('Permission auto mode', () => {
         expect.objectContaining({
           toolName,
           action,
+          rawInput: args,
           display: {
             kind: 'file_io',
             operation,
@@ -1771,6 +1772,7 @@ describe('Plan mode Bash permission policy', () => {
         toolCallId: 'call_plan_bash',
         toolName: 'Bash',
         action: 'run command',
+        rawInput: { command: 'ls -la', timeout: 60 },
         display: {
           kind: 'command',
           command: 'ls -la',
@@ -1882,6 +1884,7 @@ describe('ExitPlanMode permission policy', () => {
         toolCallId: 'call_exit',
         toolName: 'ExitPlanMode',
         action: 'Presenting plan and exiting plan mode',
+        rawInput: { options: planOptions },
         display: {
           kind: 'plan_review',
           plan: '# Plan\n\n- Step',

--- a/packages/agent-core/test/agent/turn.test.ts
+++ b/packages/agent-core/test/agent/turn.test.ts
@@ -1480,7 +1480,7 @@ describe('Agent turn flow', () => {
       [emit] assistant.delta             { "turnId": 0, "delta": "I will run Bash." }
       [emit] tool.call.delta             { "turnId": 0, "toolCallId": "call_bash", "name": "Bash", "argumentsPart": "{\\"command\\":\\"printf should-not-run\\",\\"timeout\\":60}" }
       [wire] context.append_loop_event   { "event": { "type": "content.part", "uuid": "<uuid-2>", "turnId": "0", "step": 1, "stepUuid": "<uuid-1>", "part": { "type": "text", "text": "I will run Bash." } }, "time": "<time>" }
-      [emit] requestApproval             { "turnId": 0, "toolCallId": "call_bash", "toolName": "Bash", "action": "Running: printf should-not-run", "display": { "kind": "command", "command": "printf should-not-run", "cwd": "<cwd>", "language": "bash" } }
+      [emit] requestApproval             { "turnId": 0, "toolCallId": "call_bash", "toolName": "Bash", "action": "Running: printf should-not-run", "rawInput": { "command": "printf should-not-run", "timeout": 60 }, "display": { "kind": "command", "command": "printf should-not-run", "cwd": "<cwd>", "language": "bash" } }
     `);
     expect(ctx.lastLlmInput()).toMatchInlineSnapshot(`
       system: <system-prompt>
@@ -1541,7 +1541,7 @@ describe('Agent turn flow', () => {
       [emit] assistant.delta             { "turnId": 0, "delta": "I will ask first." }
       [emit] tool.call.delta             { "turnId": 0, "toolCallId": "call_bash", "name": "Bash", "argumentsPart": "{\\"command\\":\\"printf approved\\",\\"timeout\\":60}" }
       [wire] context.append_loop_event   { "event": { "type": "content.part", "uuid": "<uuid-2>", "turnId": "0", "step": 1, "stepUuid": "<uuid-1>", "part": { "type": "text", "text": "I will ask first." } }, "time": "<time>" }
-      [emit] requestApproval             { "turnId": 0, "toolCallId": "call_bash", "toolName": "Bash", "action": "Running: printf approved", "display": { "kind": "command", "command": "printf approved", "cwd": "<cwd>", "language": "bash" } }
+      [emit] requestApproval             { "turnId": 0, "toolCallId": "call_bash", "toolName": "Bash", "action": "Running: printf approved", "rawInput": { "command": "printf approved", "timeout": 60 }, "display": { "kind": "command", "command": "printf approved", "cwd": "<cwd>", "language": "bash" } }
     `);
     expect(ctx.lastLlmInput()).toMatchInlineSnapshot(`
       system: <system-prompt>
@@ -1610,7 +1610,7 @@ describe('Agent turn flow', () => {
       [emit] assistant.delta             { "turnId": 0, "delta": "I will wait for approval." }
       [emit] tool.call.delta             { "turnId": 0, "toolCallId": "call_bash", "name": "Bash", "argumentsPart": "{\\"command\\":\\"printf should-not-run\\",\\"timeout\\":60}" }
       [wire] context.append_loop_event   { "event": { "type": "content.part", "uuid": "<uuid-2>", "turnId": "0", "step": 1, "stepUuid": "<uuid-1>", "part": { "type": "text", "text": "I will wait for approval." } }, "time": "<time>" }
-      [emit] requestApproval             { "turnId": 0, "toolCallId": "call_bash", "toolName": "Bash", "action": "Running: printf should-not-run", "display": { "kind": "command", "command": "printf should-not-run", "cwd": "<cwd>", "language": "bash" } }
+      [emit] requestApproval             { "turnId": 0, "toolCallId": "call_bash", "toolName": "Bash", "action": "Running: printf should-not-run", "rawInput": { "command": "printf should-not-run", "timeout": 60 }, "display": { "kind": "command", "command": "printf should-not-run", "cwd": "<cwd>", "language": "bash" } }
     `);
     expect(ctx.lastLlmInput()).toMatchInlineSnapshot(`
       system: <system-prompt>

--- a/packages/node-sdk/test/session-event-types.test.ts
+++ b/packages/node-sdk/test/session-event-types.test.ts
@@ -44,6 +44,7 @@ describe('Event public types', () => {
   it('exposes approval and question reverse-RPC requests', () => {
     expectTypeOf<ApprovalRequest['turnId']>().toEqualTypeOf<number | undefined>();
     expectTypeOf<ApprovalRequest['toolName']>().toEqualTypeOf<string>();
+    expectTypeOf<ApprovalRequest['rawInput']>().toEqualTypeOf<unknown>();
     expectTypeOf<QuestionRequest['questions'][number]['question']>().toEqualTypeOf<string>();
   });
 


### PR DESCRIPTION
## Related Issue

Fixes #734

## Problem

ACP permission requests include the tool call summary and options, but the request did not carry the exact tool input. ACP clients that want to inspect the full command or payload had to parse display text or correlate an earlier tool-call update.

## What changed

- Added `rawInput` to approval requests and populated it from the original tool-call args.
- Forwarded `rawInput` onto the ACP `requestPermission.toolCall` update.
- Added core, ACP, and SDK type coverage for the new field.
- Added a minor changeset for the affected packages.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.

Validation:

- `pnpm --filter @moonshot-ai/acp-adapter exec vitest run test/approval.test.ts`
- `pnpm --filter @moonshot-ai/agent-core exec vitest run test/agent/permission.test.ts test/agent/turn.test.ts test/agent/basic.test.ts test/agent/config.test.ts`
- `pnpm --filter @moonshot-ai/kimi-code-sdk exec vitest run test/session-event-types.test.ts`
- `pnpm --filter @moonshot-ai/agent-core typecheck`
- `pnpm --filter @moonshot-ai/acp-adapter typecheck`
- `pnpm --filter @moonshot-ai/kimi-code-sdk typecheck`
- `pnpm --filter @moonshot-ai/kimi-code typecheck`
- `pnpm exec oxlint --type-aware packages/acp-adapter/src/approval.ts packages/acp-adapter/test/approval.test.ts packages/agent-core/src/agent/permission/index.ts packages/agent-core/src/agent/permission/types.ts packages/agent-core/src/rpc/sdk-api.ts packages/agent-core/test/agent/basic.test.ts packages/agent-core/test/agent/config.test.ts packages/agent-core/test/agent/permission.test.ts packages/agent-core/test/agent/turn.test.ts packages/node-sdk/test/session-event-types.test.ts`
