### PR TITLE
fix: set Kimi temperature when thinking is disabled

### DIFF
--- a/.changeset/kimi-thinking-off-temperature.md
+++ b/.changeset/kimi-thinking-off-temperature.md
@@ -1,0 +1,6 @@
+---
+"@moonshot-ai/kosong": patch
+"@moonshot-ai/kimi-code": patch
+---
+
+Set Kimi requests to temperature 0.6 when thinking is disabled.

--- a/packages/kosong/src/providers/kimi.ts
+++ b/packages/kosong/src/providers/kimi.ts
@@ -82,6 +82,19 @@ export interface ExtraBody {
   thinking?: ThinkingConfig;
   [key: string]: unknown;
 }
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function applyDisabledThinkingTemperatureDefault(params: Record<string, unknown>): void {
+  if (params['temperature'] !== undefined) return;
+  const thinking = params['thinking'];
+  if (isRecord(thinking) && thinking['type'] === 'disabled') {
+    params['temperature'] = 0.6;
+  }
+}
+
 const KIMI_TOOL_CALL_ID_POLICY: ToolCallIdPolicy = {
   normalize: (id) => sanitizeToolCallId(id, 64),
   maxLength: 64,
@@ -475,6 +488,7 @@ export class KimiChatProvider implements ChatProvider {
       ...requestKwargs,
       ...(extraBody as Record<string, unknown> | undefined),
     };
+    applyDisabledThinkingTemperatureDefault(createParams);
 
     if (tools.length > 0) {
       createParams['tools'] = tools.map((t) => convertTool(t));

--- a/packages/kosong/test/kimi.test.ts
+++ b/packages/kosong/test/kimi.test.ts
@@ -722,7 +722,22 @@ describe('KimiChatProvider', () => {
 
       expect(body['reasoning_effort']).toBeUndefined();
       expect(body['thinking']).toEqual({ type: 'disabled' });
+      expect(body['temperature']).toBe(0.6);
       expect(body['extra_body']).toBeUndefined();
+    });
+
+    it('does not overwrite an explicit temperature when thinking is off', async () => {
+      const provider = createProvider()
+        .withGenerationKwargs({ temperature: 0.7 })
+        .withThinking('off');
+      const history: Message[] = [
+        { role: 'user', content: [{ type: 'text', text: 'Think' }], toolCalls: [] },
+      ];
+      const body = await captureRequestBody(provider, '', [], history);
+
+      expect(body['reasoning_effort']).toBeUndefined();
+      expect(body['thinking']).toEqual({ type: 'disabled' });
+      expect(body['temperature']).toBe(0.7);
     });
 
     it('thinkingEffort property reflects current state', () => {


### PR DESCRIPTION
## Related Issue

Fixes #686

## Problem

When Kimi thinking is disabled, the provider sends `thinking: { type: "disabled" }` but does not set a temperature unless one was provided through generation kwargs. The managed Kimi coding model rejects thinking-disabled requests unless the request uses `temperature: 0.6`.

## What changed

- Set `temperature: 0.6` on Kimi requests when `thinking.type` is `disabled` and no explicit temperature is already present.
- Preserve explicit temperature values from caller configuration.
- Added coverage for the default and explicit-temperature paths in the existing Kimi provider test file.
- Added a changeset for `@moonshot-ai/kosong` and the CLI bundle.

## Validation

- `pnpm --filter @moonshot-ai/kosong exec vitest run test/kimi.test.ts`
- `pnpm --filter @moonshot-ai/kosong typecheck`
- `pnpm --filter @moonshot-ai/kimi-code typecheck`
- `pnpm exec oxlint --type-aware packages/kosong/src/providers/kimi.ts packages/kosong/test/kimi.test.ts`
- Read-only staged diff audit for internal identifiers and secrets: clean

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.
