### PR TITLE
fix: remove stale default prompt timestamp

### DIFF
--- a/.changeset/remove-stale-kimi-now.md
+++ b/.changeset/remove-stale-kimi-now.md
@@ -1,0 +1,6 @@
+---
+"@moonshot-ai/agent-core": patch
+"@moonshot-ai/kimi-code": patch
+---
+
+Stop injecting a cached timestamp into the default system prompt.

--- a/packages/agent-core/src/profile/default/system.md
+++ b/packages/agent-core/src/profile/default/system.md
@@ -79,7 +79,7 @@ The operating environment is not in a sandbox. Any actions you do will immediate
 
 ## Date and Time
 
-The current date and time in ISO format is `{{ KIMI_NOW }}`. This is only a reference for you when searching the web, or checking file modification time, etc. If you need the exact time, use Bash tool with proper command.
+If a task depends on the current date or time, use the Bash tool with an appropriate command. Do not rely on session creation time or previously cached timestamps.
 
 ## Working Directory
 

--- a/packages/agent-core/test/profile/default-agent-profiles.test.ts
+++ b/packages/agent-core/test/profile/default-agent-profiles.test.ts
@@ -21,6 +21,8 @@ describe('default agent profiles', () => {
     expect(prompt).toContain('You are Kimi Code CLI');
     expect(prompt).toContain('Available skills');
     expect(prompt).toContain('/workspace');
+    expect(prompt).toContain('If a task depends on the current date or time');
+    expect(prompt).not.toContain(promptContext.now);
   });
 
   it('lists the goal tools on the agent profile but not on subagent profiles', () => {


### PR DESCRIPTION
## Related Issue

Fixes #446

## Problem

The default system prompt rendered `KIMI_NOW` into a concrete timestamp when the profile was applied. That rendered prompt is persisted in session records and replayed on resume, so resumed sessions could present an old session-creation timestamp as current context.

## What changed

- Removed the rendered timestamp from the bundled default system prompt.
- Kept a direct instruction to use Bash when a task depends on the current date or time.
- Added a default-profile test assertion that the rendered prompt no longer includes the supplied `now` value.
- Added a changeset for `@moonshot-ai/agent-core` and the CLI bundle.

## Validation

- `pnpm --filter @moonshot-ai/agent-core exec vitest run test/profile/default-agent-profiles.test.ts test/prompt-placeholders.test.ts`
- `pnpm --filter @moonshot-ai/agent-core typecheck`
- `pnpm --filter @moonshot-ai/kimi-code typecheck`
- `pnpm exec oxlint --type-aware packages/agent-core/test/profile/default-agent-profiles.test.ts`
- Read-only staged diff audit for internal identifiers and secrets: clean

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.
