### PR TITLE
fix: apply output cap during compaction

### DIFF
--- a/.changeset/compaction-max-output-size.md
+++ b/.changeset/compaction-max-output-size.md
@@ -1,0 +1,6 @@
+---
+"@moonshot-ai/agent-core": patch
+"@moonshot-ai/kimi-code": patch
+---
+
+Apply configured model output caps to full compaction requests.

--- a/packages/agent-core/src/agent/compaction/full.ts
+++ b/packages/agent-core/src/agent/compaction/full.ts
@@ -251,6 +251,7 @@ export class FullCompaction {
       const provider = applyCompletionBudget({
         provider: this.agent.config.provider,
         budget: resolveCompletionBudget({
+          maxOutputSize: this.agent.config.maxOutputSize,
           reservedContextSize: this.agent.kimiConfig?.loopControl?.reservedContextSize,
         }),
         capability: this.agent.config.modelCapabilities,

--- a/packages/agent-core/test/agent/compaction/full.test.ts
+++ b/packages/agent-core/test/agent/compaction/full.test.ts
@@ -1522,6 +1522,47 @@ describe('FullCompaction', () => {
     );
   });
 
+  it('honors model max output size during compaction', async () => {
+    let callCount = 0;
+    const compactionMaxCompletionTokens: unknown[] = [];
+    const generate: GenerateFn = async (provider, _system, _tools, _history, callbacks) => {
+      callCount += 1;
+      if (callCount === 1) {
+        throw new APIContextOverflowError(400, 'Context length exceeded', 'req-output-cap');
+      }
+      if (callCount === 2) {
+        compactionMaxCompletionTokens.push(providerMaxCompletionTokens(provider));
+        return textResult('Output cap compacted summary.');
+      }
+      await callbacks?.onMessagePart?.({
+        type: 'text',
+        text: 'Recovered with output cap.',
+      });
+      return textResult('Recovered with output cap.');
+    };
+    const ctx = testAgent({ generate });
+    ctx.configure({
+      provider: CATALOGUED_PROVIDER,
+      modelCapabilities: CATALOGUED_MODEL_CAPABILITIES,
+    });
+    const providerManager = ctx.agent.modelProvider;
+    if (providerManager === undefined) throw new Error('Expected provider manager');
+    const resolveProviderConfig = providerManager.resolveProviderConfig.bind(providerManager);
+    providerManager.resolveProviderConfig = (model) => ({
+      ...resolveProviderConfig(model),
+      maxOutputSize: 16_384,
+    });
+    expect(ctx.agent.config.maxOutputSize).toBe(16_384);
+    ctx.appendExchange(1, 'old user one', 'old assistant one', 20);
+    ctx.newEvents();
+
+    await ctx.rpc.prompt({ input: [{ type: 'text', text: 'Retry with output cap' }] });
+    await ctx.untilTurnEnd();
+
+    expect(callCount).toBe(3);
+    expect(compactionMaxCompletionTokens).toEqual([16_384]);
+  });
+
   it('honors completion budget env hard caps during compaction', async () => {
     vi.stubEnv('KIMI_MODEL_MAX_COMPLETION_TOKENS', '8192');
     let callCount = 0;


### PR DESCRIPTION
## Related Issue

Fixes #476

## Problem

Normal model requests pass the configured model `maxOutputSize` into completion budget resolution, but full compaction requests only passed the reserved-context fallback. For models with a very large context window and a smaller output cap, compaction could therefore send a completion cap based on context size rather than the model output limit.

## What changed

- Pass `this.agent.config.maxOutputSize` into full compaction's completion budget resolution.
- Added a regression test that patches the resolved runtime provider with a model output cap and verifies compaction sends that cap.
- Added a changeset for `@moonshot-ai/agent-core` and the CLI bundle.

## Validation

- `pnpm --filter @moonshot-ai/agent-core exec vitest run test/agent/compaction/full.test.ts`
- `pnpm --filter @moonshot-ai/agent-core typecheck`
- `pnpm --filter @moonshot-ai/kimi-code typecheck`
- `pnpm exec oxlint --type-aware packages/agent-core/src/agent/compaction/full.ts packages/agent-core/test/agent/compaction/full.test.ts`
- Read-only staged diff audit for internal identifiers and secrets: clean

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.
