### PR TITLE
fix: set Kimi temperature to 0.6 when thinking is disabled

### DIFF
--- a/.changeset/kimi-thinking-off-temperature.md
+++ b/.changeset/kimi-thinking-off-temperature.md
@@ -1,0 +1,14 @@
+---
+"@moonshot-ai/kosong": patch
+"@moonshot-ai/kimi-code": patch
+---
+
+fix: set Kimi temperature to 0.6 when thinking is disabled
+
+The Kimi API requires temperature=0.6 when thinking is disabled; without
+it, toggling thinking off causes a 400 error with "invalid temperature: only
+0.6 is allowed". This fix applies the default only when no explicit
+temperature has been configured, preserving user overrides (e.g., via
+ProviderConfig or env var).
+
+Fixes #686.

--- a/packages/kosong/src/providers/kimi.ts
+++ b/packages/kosong/src/providers/kimi.ts
@@ -82,6 +82,24 @@ export interface ExtraBody {
   thinking?: ThinkingConfig;
   [key: string]: unknown;
 }
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+/**
+ * Apply the default temperature=0.6 when thinking is disabled and no explicit
+ * temperature has been configured. This prevents 400 errors from the Kimi API
+ * while preserving user overrides (e.g., via ProviderConfig or env var).
+ */
+function applyDisabledThinkingTemperatureDefault(params: Record<string, unknown>): void {
+  if (params['temperature'] !== undefined) return;
+  const thinking = params['thinking'];
+  if (isRecord(thinking) && thinking['type'] === 'disabled') {
+    params['temperature'] = 0.6;
+  }
+}
+
 const KIMI_TOOL_CALL_ID_POLICY: ToolCallIdPolicy = {
   normalize: (id) => sanitizeToolCallId(id, 64),
   maxLength: 64,
@@ -475,6 +493,7 @@ export class KimiChatProvider implements ChatProvider {
       ...requestKwargs,
       ...(extraBody as Record<string, unknown> | undefined),
     };
+    applyDisabledThinkingTemperatureDefault(createParams);
 
     if (tools.length > 0) {
       createParams['tools'] = tools.map((t) => convertTool(t));

--- a/packages/kosong/test/kimi.test.ts
+++ b/packages/kosong/test/kimi.test.ts
@@ -722,7 +722,22 @@ describe('KimiChatProvider', () => {
 
       expect(body['reasoning_effort']).toBeUndefined();
       expect(body['thinking']).toEqual({ type: 'disabled' });
+      expect(body['temperature']).toBe(0.6);
       expect(body['extra_body']).toBeUndefined();
+    });
+
+    it('does not overwrite an explicit temperature when thinking is off', async () => {
+      const provider = createProvider()
+        .withGenerationKwargs({ temperature: 0.7 })
+        .withThinking('off');
+      const history: Message[] = [
+        { role: 'user', content: [{ type: 'text', text: 'Think' }], toolCalls: [] },
+      ];
+      const body = await captureRequestBody(provider, '', [], history);
+
+      expect(body['reasoning_effort']).toBeUndefined();
+      expect(body['thinking']).toEqual({ type: 'disabled' });
+      expect(body['temperature']).toBe(0.7);
     });
 
     it('thinkingEffort property reflects current state', () => {


### PR DESCRIPTION
## Problem

When thinking is toggled off in the Kimi provider, the API returns a 400 error:

```
invalid temperature: only 0.6 is allowed
```

The Kimi API requires `temperature=0.6` when thinking is disabled, and `temperature=1.0` when thinking is enabled. Currently, no default temperature is set, so toggling thinking off causes a hard error.

## Solution

Apply a default temperature at the wire level (in the `generate` method) only when:
- No explicit `temperature` has been configured by the user
- The request has `thinking.type === 'disabled'`

This approach is chosen because it preserves user overrides from `ProviderConfig`, environment variables, or explicit `withGenerationKwargs` calls, and it only applies the default at the last moment (when building the actual request parameters).

## Implementation

- Added `applyDisabledThinkingTemperatureDefault()` helper in `packages/kosong/src/providers/kimi.ts`
- Called after `createParams` is assembled but before the request is sent
- Added tests to verify:
  - Wire-level temperature is set to 0.6 when thinking is off
  - Explicit temperature is preserved and not overwritten

## Tests

All 64 tests in `packages/kosong/test/kimi.test.ts` pass.

## References

- Fixes #686
- Alternative to PR #693 (preserves explicit temperature)
- Alternative to PR #740 (similar approach, but this PR is ready for review)
