### PR TITLE
fix: remove plan mode toggle notices

### DIFF
--- a/.changeset/remove-plan-toggle-notices.md
+++ b/.changeset/remove-plan-toggle-notices.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Stop plan mode toggles from adding status notices to the chat transcript.

--- a/apps/kimi-code/src/tui/commands/config.ts
+++ b/apps/kimi-code/src/tui/commands/config.ts
@@ -60,15 +60,6 @@ async function applyPlanMode(host: SlashCommandHost, session: Session, enabled: 
   try {
     await session.setPlanMode(enabled);
     host.setAppState({ planMode: enabled });
-    if (enabled) {
-      const plan = await session.getPlan().catch(() => null);
-      host.showNotice(
-        'Plan mode: ON',
-        plan?.path !== undefined ? `Plan will be created here: ${plan.path}` : undefined,
-      );
-      return;
-    }
-    host.showNotice('Plan mode: OFF');
   } catch (error) {
     const msg = formatErrorMessage(error);
     host.showError(`Failed to set plan mode: ${msg}`);

--- a/apps/kimi-code/src/tui/controllers/session-replay.ts
+++ b/apps/kimi-code/src/tui/controllers/session-replay.ts
@@ -187,14 +187,6 @@ export class SessionReplayRenderer {
         return;
       case 'plan_updated':
         this.flushAssistant(context);
-        if (!record.enabled && context.suppressNextPlanModeOffNotice) {
-          context.suppressNextPlanModeOffNotice = false;
-          return;
-        }
-        context.suppressNextPlanModeOffNotice = false;
-        this.host.appendTranscriptEntry(
-          replayEntry(context, 'status', `Plan mode: ${record.enabled ? 'ON' : 'OFF'}`, 'notice'),
-        );
         return;
       case 'permission_updated':
         this.flushAssistant(context);
@@ -540,7 +532,6 @@ export class SessionReplayRenderer {
   ): void {
     const { result } = record;
     if (result.decision === 'approved') {
-      context.suppressNextPlanModeOffNotice = true;
       return;
     }
     this.removeToolCall(record.toolCallId);

--- a/apps/kimi-code/src/tui/utils/message-replay.ts
+++ b/apps/kimi-code/src/tui/utils/message-replay.ts
@@ -32,7 +32,6 @@ export interface ReplayRenderContext {
   toolCalls: Map<string, ToolCallBlockData>;
   completedToolCallIds: Set<string>;
   skillActivationIds: Set<string>;
-  suppressNextPlanModeOffNotice: boolean;
 }
 
 export interface SkillActivationProjection {
@@ -114,7 +113,6 @@ export function createReplayRenderContext(): ReplayRenderContext {
     toolCalls: new Map(),
     completedToolCallIds: new Set(),
     skillActivationIds: new Set(),
-    suppressNextPlanModeOffNotice: false,
   };
 }
 

--- a/apps/kimi-code/test/tui/kimi-tui-message-flow.test.ts
+++ b/apps/kimi-code/test/tui/kimi-tui-message-flow.test.ts
@@ -630,6 +630,7 @@ command = "vim"
     });
     expect(harness.track).toHaveBeenCalledWith('shortcut_plan_toggle', { enabled: true });
     expect(harness.track).toHaveBeenCalledWith('shortcut_mode_switch', { to_mode: 'plan' });
+    expect(stripSgr(renderTranscript(driver))).not.toContain('Plan mode: ON');
   });
 
   it('routes /yolo through session permission state without app-layer telemetry duplication', async () => {

--- a/apps/kimi-code/test/tui/message-replay.test.ts
+++ b/apps/kimi-code/test/tui/message-replay.test.ts
@@ -1047,7 +1047,7 @@ describe('KimiTUI resume message replay', () => {
     expect(transcript).not.toContain('Compaction complete');
   });
 
-  it('renders plan permission and approval replay notices', async () => {
+  it('renders permission and approval replay notices without plan toggle notices', async () => {
     const driver = await replayIntoDriver([
       { time: REPLAY_TIME, type: 'plan_updated', enabled: true },
       { time: REPLAY_TIME, type: 'permission_updated', mode: 'auto' },
@@ -1073,12 +1073,12 @@ describe('KimiTUI resume message replay', () => {
 
     const transcript = driver.state.transcriptContainer.render(120).join('\n');
 
-    expect(transcript).toContain('Plan mode: ON');
+    expect(transcript).not.toContain('Plan mode: ON');
     expect(transcript).toContain('Permission mode: auto');
     expect(transcript).toContain('YOLO mode: ON');
     expect(transcript).toContain('YOLO mode: OFF');
     expect(transcript).toContain('Approved for session: run command');
-    expect(transcript).toContain('Plan mode: OFF');
+    expect(transcript).not.toContain('Plan mode: OFF');
   });
 
   it('keeps only the final approved plan card after rejected plan reviews', async () => {


### PR DESCRIPTION
## Related Issue

Resolve #392

## Problem

Plan mode toggles append `Plan mode: ON/OFF` status notices, including the plan file path on entry, directly into the chat transcript. The footer already shows the active plan mode state, so these notices add noise to the conversation history.

## What changed

Removed plan-mode toggle notices from live `/plan` and Shift-Tab toggles, and stopped session replay from reconstructing those notices from older plan-mode records. Plan-mode state changes, error reporting, `/plan clear`, and plan review cards are unchanged.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.
