### PR TITLE
fix: preserve config symlink writes

### DIFF
--- a/.changeset/preserve-config-symlinks.md
+++ b/.changeset/preserve-config-symlinks.md
@@ -1,0 +1,6 @@
+---
+"@moonshot-ai/agent-core": patch
+"@moonshot-ai/kimi-code": patch
+---
+
+Preserve symlinked config files when saving configuration updates.

--- a/packages/agent-core/src/config/toml.ts
+++ b/packages/agent-core/src/config/toml.ts
@@ -1,6 +1,6 @@
 import { existsSync, readFileSync } from 'node:fs';
-import { mkdir, open } from 'node:fs/promises';
-import { dirname } from 'pathe';
+import { lstat, mkdir, open, readlink } from 'node:fs/promises';
+import { dirname, resolve } from 'pathe';
 
 import { ErrorCodes, KimiError } from '#/errors';
 import { applyEnvModelConfig, stripEnvModelConfig } from './env-model';
@@ -450,7 +450,26 @@ export async function writeConfigFile(filePath: string, config: KimiConfig): Pro
   // stripEnvModelConfig / the getConfig -> setConfig round-trip).
   const validated = validateConfig(stripEnvModelConfig(config));
   await mkdir(dirname(filePath), { recursive: true, mode: 0o700 });
-  await atomicWrite(filePath, `${stringifyToml(configToTomlData(validated))}\n`);
+  await atomicWrite(
+    await configWriteTarget(filePath),
+    `${stringifyToml(configToTomlData(validated))}\n`,
+  );
+}
+
+async function configWriteTarget(filePath: string): Promise<string> {
+  let stat: Awaited<ReturnType<typeof lstat>>;
+  try {
+    stat = await lstat(filePath);
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException).code;
+    if (code === 'ENOENT') return filePath;
+    throw error;
+  }
+  if (!stat.isSymbolicLink()) return filePath;
+  // Preserve user-created config sync links while still atomically replacing
+  // the real target file.
+  const target = await readlink(filePath);
+  return resolve(dirname(filePath), target);
 }
 
 export function configToTomlData(config: KimiConfig): Record<string, unknown> {

--- a/packages/agent-core/test/config/configs.test.ts
+++ b/packages/agent-core/test/config/configs.test.ts
@@ -1,5 +1,5 @@
 import { mkdtempSync } from 'node:fs';
-import { readFile, rm, writeFile } from 'node:fs/promises';
+import { lstat, readFile, rm, symlink, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'pathe';
 
@@ -387,6 +387,21 @@ removed_flag = true
     const text = await readFile(configPath, 'utf-8');
     expect(text).not.toContain('default_yolo');
     expect(text).not.toContain('default_permission_mode');
+  });
+
+  it('preserves config.toml symlinks when rewriting config files', async () => {
+    const dir = makeTempDir();
+    const syncDir = makeTempDir();
+    const configPath = join(dir, 'config.toml');
+    const targetPath = join(syncDir, 'config.toml');
+    await writeFile(targetPath, 'default_thinking = false\n', 'utf-8');
+    await symlink(targetPath, configPath);
+
+    const config = parseConfigString('default_thinking = true\n', configPath);
+    await writeConfigFile(configPath, config);
+
+    expect((await lstat(configPath)).isSymbolicLink()).toBe(true);
+    await expect(readFile(targetPath, 'utf-8')).resolves.toContain('default_thinking = true');
   });
 
   it('rejects invalid TOML and invalid schema with KimiError(config.invalid)', () => {


### PR DESCRIPTION
## Related Issue

Resolve #751

## Problem

When `~/.kimi-code/config.toml` is a symlink, saving config updates replaces the symlink itself with a regular file. That breaks user workflows that sync the real config file through another location.

## What changed

Config writes now detect a symlinked config path and atomically write to the resolved target file instead of replacing the symlink entry. The generic atomic write helper keeps its existing replacement semantics for other stores, and the new test covers preserving the symlink while updating the target file content.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.
