### PR TITLE
feat: add vim navigation to non-search pickers

### DIFF
--- a/.changeset/jk-picker-navigation.md
+++ b/.changeset/jk-picker-navigation.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": minor
+---
+
+Add j/k navigation to non-searchable picker lists.

--- a/apps/kimi-code/src/tui/utils/searchable-list.ts
+++ b/apps/kimi-code/src/tui/utils/searchable-list.ts
@@ -5,7 +5,7 @@
  * The component owns presentation and the keys that carry component-specific
  * meaning — Enter (submit), Esc (cancel), and ←/→ (paging in one picker, a
  * thinking toggle in another). This unit owns the keys that behave identically
- * everywhere: ↑/↓, PgUp/PgDn, and search editing.
+ * everywhere: ↑/↓, j/k for non-searchable lists, PgUp/PgDn, and search editing.
  */
 
 import { fuzzyFilter, Key, matchesKey } from '@earendil-works/pi-tui';
@@ -100,16 +100,18 @@ export class SearchableList<T> {
   }
 
   /**
-   * Handles the keys every picker shares: ↑/↓, PgUp/PgDn, and — when searchable —
-   * Backspace and printable characters. Returns true when the key was consumed.
-   * Enter, Esc, and ←/→ are intentionally left to the component.
+   * Handles the keys every picker shares: ↑/↓, j/k for non-searchable lists,
+   * PgUp/PgDn, and — when searchable — Backspace and printable characters.
+   * Returns true when the key was consumed. Enter, Esc, and ←/→ are
+   * intentionally left to the component.
    */
   handleKey(data: string): boolean {
-    if (matchesKey(data, Key.up)) {
+    const ch = printableChar(data);
+    if (matchesKey(data, Key.up) || (!this.searchable && ch === 'k')) {
       this.moveUp();
       return true;
     }
-    if (matchesKey(data, Key.down)) {
+    if (matchesKey(data, Key.down) || (!this.searchable && ch === 'j')) {
       this.moveDown();
       return true;
     }
@@ -129,7 +131,6 @@ export class SearchableList<T> {
       }
       return true;
     }
-    const ch = printableChar(data);
     if (isPrintableChar(ch)) {
       this.query += ch;
       this.cursor = 0;

--- a/apps/kimi-code/test/tui/utils/searchable-list.test.ts
+++ b/apps/kimi-code/test/tui/utils/searchable-list.test.ts
@@ -8,6 +8,8 @@ const DOWN = `${ESC}[B`;
 const PAGE_UP = `${ESC}[5~`;
 const PAGE_DOWN = `${ESC}[6~`;
 const BACKSPACE = String.fromCodePoint(127);
+const KITTY_J = `${ESC}[106u`;
+const KITTY_K = `${ESC}[107u`;
 
 const ITEMS = Array.from({ length: 10 }, (_, i) => `item${String(i).padStart(2, '0')}`);
 
@@ -96,5 +98,21 @@ describe('SearchableList', () => {
     expect(search.handleKey('a')).toBe(true);
     expect(search.handleKey(BACKSPACE)).toBe(true);
     expect(search.view().query).toBe('');
+  });
+
+  it('uses j/k as navigation only for non-searchable lists', () => {
+    const nav = make({ searchable: false });
+    expect(nav.handleKey('j')).toBe(true);
+    expect(nav.view().selectedIndex).toBe(1);
+    expect(nav.handleKey(KITTY_J)).toBe(true);
+    expect(nav.view().selectedIndex).toBe(2);
+    expect(nav.handleKey('k')).toBe(true);
+    expect(nav.view().selectedIndex).toBe(1);
+    expect(nav.handleKey(KITTY_K)).toBe(true);
+    expect(nav.view().selectedIndex).toBe(0);
+
+    const search = make({ searchable: true });
+    expect(search.handleKey('j')).toBe(true);
+    expect(search.view().query).toBe('j');
   });
 });


### PR DESCRIPTION
## Related Issue

Resolve #320

## Problem

Some non-search picker lists only respond to arrow keys, which makes keyboard navigation inconsistent with other TUI surfaces that support Vim-style `j` / `k` movement.

## What changed

The shared list state machine now treats `j` and `k` as down/up navigation only when the list is not searchable. Searchable lists still accept those characters as query text, and the test coverage includes both plain keys and Kitty CSI-u encoded input.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.
