### PR TITLE
fix: show detached head in git status

### DIFF
--- a/.changeset/detached-head-git-status.md
+++ b/.changeset/detached-head-git-status.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Show the current commit in git status when the repository is in detached HEAD.

--- a/apps/kimi-code/src/utils/git/git-status.ts
+++ b/apps/kimi-code/src/utils/git/git-status.ts
@@ -163,7 +163,21 @@ function readBranch(workDir: string): string | null {
     });
     if (result.status !== 0) return null;
     const name = result.stdout.trim();
-    return name.length > 0 ? name : null;
+    return name.length > 0 ? name : readDetachedHead(workDir);
+  } catch {
+    return null;
+  }
+}
+
+function readDetachedHead(workDir: string): string | null {
+  try {
+    const result = spawnSync('git', ['-C', workDir, 'rev-parse', '--short', 'HEAD'], {
+      encoding: 'utf8',
+      timeout: SPAWN_TIMEOUT_MS,
+    });
+    if (result.status !== 0) return null;
+    const hash = result.stdout.trim();
+    return hash.length > 0 ? `detached@${hash}` : null;
   } catch {
     return null;
   }

--- a/apps/kimi-code/test/utils/git/git-status.test.ts
+++ b/apps/kimi-code/test/utils/git/git-status.test.ts
@@ -200,6 +200,44 @@ describe('git status cache', () => {
     });
   });
 
+  it('shows the current commit when the repository is in detached HEAD', async () => {
+    mocks.execFile.mockImplementation(
+      (
+        _cmd: string,
+        _args: string[],
+        _options: unknown,
+        callback: (error: Error | null, stdout: string, stderr: string) => void,
+      ) => {
+        callback(new Error('no pull request'), '', '');
+      },
+    );
+    mocks.spawnSync.mockImplementation((_cmd: string, args: string[]) => {
+      if (args.includes('rev-parse') && args.includes('--is-inside-work-tree')) {
+        return { status: 0, stdout: 'true\n' };
+      }
+      if (args.includes('branch')) {
+        return { status: 0, stdout: '\n' };
+      }
+      if (args.includes('rev-parse') && args.includes('--short')) {
+        return { status: 0, stdout: 'abc1234\n' };
+      }
+      if (args.includes('status')) {
+        return { status: 0, stdout: '## HEAD (no branch)\n' };
+      }
+      return { status: 1, stdout: '' };
+    });
+
+    expect(createGitStatusCache('/tmp/repo').getStatus()).toEqual({
+      branch: 'detached@abc1234',
+      dirty: false,
+      ahead: 0,
+      behind: 0,
+      diffAdded: 0,
+      diffDeleted: 0,
+      pullRequest: null,
+    });
+  });
+
   it('returns null when the working directory is not a git repo and formats badges', () => {
     mocks.spawnSync.mockReturnValue({ status: 1, stdout: '' });
     expect(createGitStatusCache('/tmp/not-a-repo').getStatus()).toBeNull();


### PR DESCRIPTION
## Related Issue

Resolve #566

## Problem

The footer git status helper returns no status when `git branch --show-current` is empty. That hides repository context in detached HEAD checkouts, even though the directory is still a valid git worktree.

## What changed

When the branch name is empty, git status now falls back to `git rev-parse --short HEAD` and displays `detached@<commit>`. Existing branch/status caching and dirty/ahead/behind calculations are unchanged, and the new test covers the detached HEAD path.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.
