### PR TITLE
fix: preserve custom registry output caps

### DIFF
--- a/.changeset/preserve-custom-registry-output-limit.md
+++ b/.changeset/preserve-custom-registry-output-limit.md
@@ -1,0 +1,6 @@
+---
+"@moonshot-ai/kimi-code-oauth": patch
+"@moonshot-ai/kimi-code": patch
+---
+
+Preserve custom registry output limits so imported models use the correct completion cap.

--- a/apps/kimi-code/test/tui/utils/refresh-providers.test.ts
+++ b/apps/kimi-code/test/tui/utils/refresh-providers.test.ts
@@ -338,12 +338,14 @@ describe('refreshAllProviderModels', () => {
       'image_in',
       'video_in',
     ]);
+    expect(host.current().models?.[modelAlias]?.maxOutputSize).toBe(262144);
     expect(host.current().models?.[siblingModelAlias]?.capabilities).toEqual([
       'tool_use',
       'thinking',
       'image_in',
       'video_in',
     ]);
+    expect(host.current().models?.[siblingModelAlias]?.maxOutputSize).toBe(262144);
     expect(host.current().models?.[userAlias]).toEqual(userAliasModel);
   });
 
@@ -658,6 +660,7 @@ describe('refreshAllProviderModels', () => {
           provider: providerId,
           model: modelId,
           maxContextSize: 262144,
+          maxOutputSize: 262144,
           capabilities: richCapabilities,
           displayName: 'Reasoner Pro',
         },

--- a/packages/oauth/src/custom-registry.ts
+++ b/packages/oauth/src/custom-registry.ts
@@ -265,6 +265,11 @@ function resolveMaxContextSize(model: CustomRegistryModelEntry): number {
   return CUSTOM_REGISTRY_DEFAULT_MAX_CONTEXT;
 }
 
+function resolveMaxOutputSize(model: CustomRegistryModelEntry): number | undefined {
+  const output = model.limit?.output;
+  return typeof output === 'number' && Number.isInteger(output) && output > 0 ? output : undefined;
+}
+
 function resolveCapabilities(model: CustomRegistryModelEntry): string[] {
   if (hasRichCapabilityHints(model)) {
     return capabilitiesFromCustomEntry(model);
@@ -314,6 +319,7 @@ export function applyCustomRegistryProvider(
       provider: providerKey,
       model: model.id,
       maxContextSize,
+      maxOutputSize: resolveMaxOutputSize(model),
       capabilities,
       displayName,
     };

--- a/packages/oauth/src/managed-kimi-code.ts
+++ b/packages/oauth/src/managed-kimi-code.ts
@@ -117,6 +117,7 @@ export interface ManagedKimiModelAlias {
   provider: string;
   model: string;
   maxContextSize: number;
+  maxOutputSize?: number;
   capabilities?: string[] | undefined;
   displayName?: string | undefined;
   readonly [key: string]: unknown;

--- a/packages/oauth/test/custom-registry.test.ts
+++ b/packages/oauth/test/custom-registry.test.ts
@@ -271,9 +271,11 @@ describe('applyCustomRegistryProvider', () => {
 
     const alias = config.models?.['rich/rich-vision'] as {
       maxContextSize: number;
+      maxOutputSize: number;
       capabilities: string[];
     };
     expect(alias.maxContextSize).toBe(200000);
+    expect(alias.maxOutputSize).toBe(8192);
     expect(alias.capabilities).toEqual(expect.arrayContaining(['tool_use', 'thinking', 'image_in']));
     expect(alias.capabilities).not.toContain('image_out');
   });


### PR DESCRIPTION
## Related Issue

Resolve #509

## Problem

Custom registry imports preserve model context limits but dropped provider-declared output limits. For OpenAI-compatible models with very large context windows, the completion budget could then use the context window as the request output cap, which can make providers reject the request with an invalid `max_tokens` error.

## What changed

Custom registry model aliases now preserve valid `limit.output` values as `maxOutputSize`. Refresh coverage verifies output-limit metadata is carried forward while user-defined aliases remain untouched, and the OAuth unit test covers alias generation from rich registry metadata.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.

Validation:

- `pnpm vitest run packages/oauth/test/custom-registry.test.ts apps/kimi-code/test/tui/utils/refresh-providers.test.ts apps/kimi-code/test/cli/provider.test.ts`
- `pnpm --filter @moonshot-ai/kimi-code-oauth typecheck`
- `pnpm --filter @moonshot-ai/kimi-code typecheck`
- `pnpm run lint`
