### PR TITLE
fix: scope env model default capabilities

### DIFF
--- a/.changeset/fix-env-model-provider-capabilities.md
+++ b/.changeset/fix-env-model-provider-capabilities.md
@@ -1,0 +1,6 @@
+---
+"@moonshot-ai/agent-core": patch
+"@moonshot-ai/kimi-code": patch
+---
+
+Avoid defaulting non-Kimi environment-configured models to Kimi-specific capabilities.

--- a/packages/agent-core/src/config/env-model.ts
+++ b/packages/agent-core/src/config/env-model.ts
@@ -24,8 +24,10 @@ const DEFAULT_BASE_URL: Partial<Record<ProviderType, string>> = {
 /** Default context window (256K) used when KIMI_MODEL_MAX_CONTEXT_SIZE is unset. */
 const DEFAULT_MAX_CONTEXT_SIZE = 262144;
 
-/** Default capabilities when KIMI_MODEL_CAPABILITIES is unset (kimi models support both). */
-const DEFAULT_CAPABILITIES = ['image_in', 'thinking'];
+/** Default capabilities when KIMI_MODEL_CAPABILITIES is unset. */
+const DEFAULT_CAPABILITIES_BY_TYPE: Partial<Record<ProviderType, string[]>> = {
+  kimi: ['image_in', 'thinking'],
+};
 
 type Env = Readonly<Record<string, string | undefined>>;
 
@@ -119,7 +121,8 @@ export function applyEnvModelConfig(config: KimiConfig, env: Env = process.env):
     maxOutputRaw !== undefined
       ? parsePositiveInt(maxOutputRaw, 'KIMI_MODEL_MAX_OUTPUT_SIZE')
       : undefined;
-  const capabilities = parseCapabilities(env['KIMI_MODEL_CAPABILITIES']) ?? DEFAULT_CAPABILITIES;
+  const capabilities =
+    parseCapabilities(env['KIMI_MODEL_CAPABILITIES']) ?? DEFAULT_CAPABILITIES_BY_TYPE[type];
   const displayName = trimmed(env['KIMI_MODEL_DISPLAY_NAME']);
   const reasoningKey = trimmed(env['KIMI_MODEL_REASONING_KEY']);
   const adaptiveThinking = parseBooleanVar(

--- a/packages/agent-core/test/config/env-model.test.ts
+++ b/packages/agent-core/test/config/env-model.test.ts
@@ -76,16 +76,19 @@ describe('applyEnvModelConfig', () => {
   });
 
   it('applies provider type and its default base url', () => {
-    expect(apply({ ...MIN, KIMI_MODEL_PROVIDER_TYPE: 'openai' })
-      .providers[ENV_MODEL_PROVIDER_KEY]).toMatchObject({
+    const openai = apply({ ...MIN, KIMI_MODEL_PROVIDER_TYPE: 'openai' });
+    expect(openai.providers[ENV_MODEL_PROVIDER_KEY]).toMatchObject({
       type: 'openai',
       baseUrl: 'https://api.openai.com/v1',
     });
-    const anthropic = apply({ ...MIN, KIMI_MODEL_PROVIDER_TYPE: 'anthropic' })
-      .providers[ENV_MODEL_PROVIDER_KEY];
+    expect(openai.models?.[ENV_MODEL_ALIAS_KEY]?.capabilities).toBeUndefined();
+
+    const anthropicConfig = apply({ ...MIN, KIMI_MODEL_PROVIDER_TYPE: 'anthropic' });
+    const anthropic = anthropicConfig.providers[ENV_MODEL_PROVIDER_KEY];
     expect(anthropic).toBeDefined();
     expect(anthropic?.type).toBe('anthropic');
     expect(anthropic?.baseUrl).toBeUndefined();
+    expect(anthropicConfig.models?.[ENV_MODEL_ALIAS_KEY]?.capabilities).toBeUndefined();
   });
 
   it('rejects unsupported provider types', () => {
@@ -103,7 +106,11 @@ describe('applyEnvModelConfig', () => {
 
   it('parses comma-separated capabilities (trimmed, lowercased)', () => {
     expect(
-      apply({ ...MIN, KIMI_MODEL_CAPABILITIES: 'Image_In, thinking ,' })
+      apply({
+        ...MIN,
+        KIMI_MODEL_PROVIDER_TYPE: 'openai',
+        KIMI_MODEL_CAPABILITIES: 'Image_In, thinking ,',
+      })
         .models?.[ENV_MODEL_ALIAS_KEY]?.capabilities,
     ).toEqual(['image_in', 'thinking']);
   });


### PR DESCRIPTION
## Related Issue

Resolve #250

## Problem

`KIMI_MODEL_*` env configuration allowed OpenAI and Anthropic providers, but when `KIMI_MODEL_CAPABILITIES` was unset every synthesized env model alias inherited Kimi-specific default capabilities. That could mark non-Kimi models as supporting image input or thinking even when the provider/model did not declare those capabilities.

## What changed

The env-model path now applies default capabilities by provider type: Kimi models keep the existing image/thinking defaults, while OpenAI and Anthropic env models leave capabilities unset unless the user explicitly provides `KIMI_MODEL_CAPABILITIES`. Tests cover both default behavior and explicit capability overrides for non-Kimi providers.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.

Validation:

- `pnpm vitest run packages/agent-core/test/config/env-model.test.ts packages/agent-core/test/agent/config-state.test.ts`
- `pnpm --filter @moonshot-ai/agent-core typecheck`
- `pnpm --filter @moonshot-ai/kimi-code typecheck`
- `pnpm exec oxlint packages/agent-core/src/config/env-model.ts packages/agent-core/test/config/env-model.test.ts`
- `pnpm run lint`
