### PR TITLE
feat: load Claude instruction files

### DIFF
--- a/.changeset/load-claude-instructions.md
+++ b/.changeset/load-claude-instructions.md
@@ -1,0 +1,6 @@
+---
+"@moonshot-ai/agent-core": minor
+"@moonshot-ai/kimi-code": minor
+---
+
+Load Claude-style project instruction files alongside Kimi-native instruction files.

--- a/docs/en/customization/agents.md
+++ b/docs/en/customization/agents.md
@@ -39,7 +39,9 @@ If you need a particular type of tool to be permanently unavailable inside sub-a
 
 ## Instruction Files
 
-Global Kimi-specific instructions can live at `$KIMI_CODE_HOME/AGENTS.md` (default: `~/.kimi-code/AGENTS.md`). When you relocate the data root with `KIMI_CODE_HOME`, this global instruction file moves with it. Generic cross-tool instructions can still live under `~/.agents/AGENTS.md` in the real OS home, and project-level instructions remain under the project tree, for example `.kimi-code/AGENTS.md` or `AGENTS.md`.
+Global Kimi-specific instructions can live at `$KIMI_CODE_HOME/AGENTS.md` (default: `~/.kimi-code/AGENTS.md`). When you relocate the data root with `KIMI_CODE_HOME`, this global instruction file moves with it. Generic cross-tool instructions can still live under `~/.agents/AGENTS.md` in the real OS home.
+
+Project-level instructions are loaded from the repository root toward the current working directory. In each directory, Kimi Code reads Claude Code-compatible files first: `.claude/CLAUDE.md`, then the first existing file from `CLAUDE.md` and `claude.md`; when both `CLAUDE.md` and `claude.md` exist, `CLAUDE.md` wins. It then appends Kimi-native files: `.kimi-code/AGENTS.md`, then the first existing file from `AGENTS.md` and `agents.md`, so Kimi-specific instructions in the same directory can override reused Claude instructions.
 
 ## Storage Location in the Session Directory
 

--- a/docs/zh/customization/agents.md
+++ b/docs/zh/customization/agents.md
@@ -39,7 +39,9 @@ Kimi Code CLI 内置三种子 Agent，开箱即用，分别面向不同任务形
 
 ## 指令文件
 
-全局 Kimi 专属指令可放在 `$KIMI_CODE_HOME/AGENTS.md`（默认：`~/.kimi-code/AGENTS.md`）。当你用 `KIMI_CODE_HOME` 移动数据根时，这份全局指令文件也会一起移动。跨工具通用指令仍可放在真实 OS home 下的 `~/.agents/AGENTS.md`，项目级指令仍放在项目目录中，例如 `.kimi-code/AGENTS.md` 或 `AGENTS.md`。
+全局 Kimi 专属指令可放在 `$KIMI_CODE_HOME/AGENTS.md`（默认：`~/.kimi-code/AGENTS.md`）。当你用 `KIMI_CODE_HOME` 移动数据根时，这份全局指令文件也会一起移动。跨工具通用指令仍可放在真实 OS home 下的 `~/.agents/AGENTS.md`。
+
+项目级指令会从仓库根目录一路加载到当前工作目录。每个目录中，Kimi Code 会先读取兼容 Claude Code 的指令文件：`.claude/CLAUDE.md`，然后读取 `CLAUDE.md` 和 `claude.md` 中第一个存在的文件；`CLAUDE.md` 和 `claude.md` 同时存在时，使用 `CLAUDE.md`。随后再追加 Kimi 原生文件：`.kimi-code/AGENTS.md`，然后是 `AGENTS.md` 和 `agents.md` 中第一个存在的文件，因此同一目录下的 Kimi 专属指令可以覆盖复用的 Claude 指令。
 
 ## 会话目录中的存储位置
 

--- a/packages/agent-core/src/profile/context.ts
+++ b/packages/agent-core/src/profile/context.ts
@@ -5,7 +5,9 @@ import type { Kaos } from '@moonshot-ai/kaos';
 import { listDirectory } from '../tools/support/list-directory';
 import type { SystemPromptContext } from './types';
 
-const AGENTS_MD_MAX_BYTES = 32 * 1024;
+const INSTRUCTION_FILES_MAX_BYTES = 32 * 1024;
+const KIMI_AGENT_FILE_NAMES = ['AGENTS.md', 'agents.md'] as const;
+const CLAUDE_AGENT_FILE_NAMES = ['CLAUDE.md', 'claude.md'] as const;
 const S_IFMT = 0o170000;
 const S_IFREG = 0o100000;
 
@@ -30,7 +32,7 @@ export async function loadAgentsMd(kaos: Kaos, brandHome?: string): Promise<stri
   const seen = new Set<string>();
 
   const collect = async (path: string): Promise<boolean> => {
-    const file = await readAgentFile(kaos, path);
+    const file = await readInstructionFile(kaos, path);
     if (file === undefined) return false;
     const key = kaos.normpath(file.path);
     if (seen.has(key)) return false;
@@ -39,7 +41,14 @@ export async function loadAgentsMd(kaos: Kaos, brandHome?: string): Promise<stri
     return true;
   };
 
-  // User-level files come first so any project-level AGENTS.md overrides them.
+  const collectFirst = async (paths: readonly string[]): Promise<boolean> => {
+    for (const path of paths) {
+      if (await collect(path)) return true;
+    }
+    return false;
+  };
+
+  // User-level files come first so any project-level instructions override them.
   // The brand dir follows KIMI_CODE_HOME (default ~/.kimi-code); the generic
   // .agents dir stays under the real OS home so it can be shared across tools.
   const realHome = kaos.gethome();
@@ -49,17 +58,15 @@ export async function loadAgentsMd(kaos: Kaos, brandHome?: string): Promise<stri
   // Generic user-level dir (.agents) matches skill discovery.
   const genericDirs = [join(realHome, '.agents')];
   const genericFiles = genericDirs.flatMap((dir) =>
-    ['AGENTS.md', 'agents.md'].map((name) => join(dir, name)),
+    KIMI_AGENT_FILE_NAMES.map((name) => join(dir, name)),
   );
-  for (const file of genericFiles) {
-    if (await collect(file)) break;
-  }
+  await collectFirst(genericFiles);
 
   for (const dir of dirs) {
+    await collect(join(dir, '.claude', 'CLAUDE.md'));
+    await collectFirst(CLAUDE_AGENT_FILE_NAMES.map((name) => join(dir, name)));
     await collect(join(dir, '.kimi-code', 'AGENTS.md'));
-    for (const fileName of ['AGENTS.md', 'agents.md']) {
-      if (await collect(join(dir, fileName))) break;
-    }
+    await collectFirst(KIMI_AGENT_FILE_NAMES.map((name) => join(dir, name)));
   }
 
   return renderAgentFiles(discovered);
@@ -97,7 +104,7 @@ interface AgentFile {
   readonly content: string;
 }
 
-async function readAgentFile(kaos: Kaos, path: string): Promise<AgentFile | undefined> {
+async function readInstructionFile(kaos: Kaos, path: string): Promise<AgentFile | undefined> {
   if (!(await isFile(kaos, path))) return undefined;
   const content = (await kaos.readText(path, { errors: 'ignore' })).trim();
   if (content.length === 0) return undefined;
@@ -125,7 +132,7 @@ async function isFile(kaos: Kaos, path: string): Promise<boolean> {
 function renderAgentFiles(files: readonly AgentFile[]): string {
   if (files.length === 0) return '';
 
-  let remaining = AGENTS_MD_MAX_BYTES;
+  let remaining = INSTRUCTION_FILES_MAX_BYTES;
   const budgeted: Array<AgentFile | undefined> = Array.from({ length: files.length });
 
   for (let i = files.length - 1; i >= 0; i--) {
@@ -170,5 +177,4 @@ function byteLength(text: string): number {
 function annotationFor(path: string): string {
   return `<!-- From: ${path} -->\n`;
 }
-
 

--- a/packages/agent-core/test/profile/context.test.ts
+++ b/packages/agent-core/test/profile/context.test.ts
@@ -6,6 +6,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { loadAgentsMd } from '../../src/profile/context';
 import { testKaos } from '../fixtures/test-kaos';
+import { createFakeKaos } from '../tools/fixtures/fake-kaos';
 
 let homeDir: string;
 let workDir: string;
@@ -111,3 +112,79 @@ describe('loadAgentsMd brand home (KIMI_CODE_HOME)', () => {
     expect(result).toContain('fallback branded');
   });
 });
+
+describe('loadAgentsMd Claude compatibility', () => {
+  it('loads Claude instruction files alongside Kimi-native instructions', async () => {
+    const projectRoot = join(workDir, 'repo');
+    const leafDir = join(projectRoot, 'packages', 'app');
+    vi.spyOn(testKaos, 'getcwd').mockReturnValue(leafDir);
+
+    await mkdir(join(projectRoot, '.git'), { recursive: true });
+    await mkdir(join(projectRoot, '.claude'), { recursive: true });
+    await mkdir(join(projectRoot, '.kimi-code'), { recursive: true });
+    await mkdir(leafDir, { recursive: true });
+
+    await writeFile(join(projectRoot, '.claude', 'CLAUDE.md'), 'root claude dir', 'utf-8');
+    await writeFile(join(projectRoot, 'CLAUDE.md'), 'root claude upper', 'utf-8');
+    await writeFile(join(projectRoot, '.kimi-code', 'AGENTS.md'), 'root branded agents', 'utf-8');
+    await writeFile(join(projectRoot, 'AGENTS.md'), 'root agents', 'utf-8');
+    await writeFile(join(leafDir, 'claude.md'), 'leaf claude lower', 'utf-8');
+    await writeFile(join(leafDir, 'AGENTS.md'), 'leaf agents', 'utf-8');
+
+    const result = await loadAgentsMd(testKaos);
+
+    expect(result).toContain('root claude dir');
+    expect(result).toContain('root claude upper');
+    expect(result).toContain('root branded agents');
+    expect(result).toContain('root agents');
+    expect(result).toContain('leaf claude lower');
+    expect(result).toContain('leaf agents');
+    expect(result.indexOf('root claude dir')).toBeLessThan(result.indexOf('root claude upper'));
+    expect(result.indexOf('root claude upper')).toBeLessThan(
+      result.indexOf('root branded agents'),
+    );
+    expect(result.indexOf('root branded agents')).toBeLessThan(result.indexOf('root agents'));
+    expect(result.indexOf('leaf claude lower')).toBeLessThan(result.indexOf('leaf agents'));
+  });
+
+  it('prefers CLAUDE.md over claude.md in the same directory', async () => {
+    const files = new Map([
+      ['/repo/CLAUDE.md', 'upper claude'],
+      ['/repo/claude.md', 'lower claude'],
+    ]);
+    const dirs = new Set(['/repo', '/repo/.git']);
+    const kaos = createFakeKaos({
+      getcwd: () => '/repo',
+      stat: vi.fn(async (path: string) => {
+        if (dirs.has(path)) return stat('dir');
+        if (files.has(path)) return stat('file');
+        throw new Error(`ENOENT ${path}`);
+      }),
+      readText: vi.fn(async (path: string) => {
+        const content = files.get(path);
+        if (content === undefined) throw new Error(`ENOENT ${path}`);
+        return content;
+      }),
+    });
+
+    const result = await loadAgentsMd(kaos);
+
+    expect(result).toContain('upper claude');
+    expect(result).not.toContain('lower claude');
+  });
+});
+
+function stat(kind: 'dir' | 'file') {
+  return {
+    stMode: kind === 'dir' ? 0o040000 : 0o100000,
+    stIno: 0,
+    stDev: 0,
+    stNlink: 1,
+    stUid: 0,
+    stGid: 0,
+    stSize: 0,
+    stAtime: 0,
+    stMtime: 0,
+    stCtime: 0,
+  };
+}


### PR DESCRIPTION
## Related Issue

Resolve #243

## Problem

Projects that already use Claude Code often keep repository instructions in `CLAUDE.md` or `.claude/CLAUDE.md`. Kimi Code only loaded `AGENTS.md`, so users had to duplicate or manually import those instructions to reuse them.

## What changed

Kimi Code now discovers Claude Code-compatible project instruction files while preserving Kimi-native precedence. For each project directory from the repository root to the current working directory, it loads `.claude/CLAUDE.md`, then the first existing file from `CLAUDE.md` and `claude.md`, then `.kimi-code/AGENTS.md`, then the first existing file from `AGENTS.md` and `agents.md`.

The tests cover coexistence with Kimi instruction files, uppercase `CLAUDE.md` precedence over `claude.md`, and merge order. The bilingual Agents documentation now describes the discovery order. I attempted the docs workflow, but `docs/scripts/sync-changelog.mjs` is not present in this checkout; the docs page updates were made directly and verified with the docs build.

Validation:
- `pnpm vitest run packages/agent-core/test/profile/context.test.ts packages/agent-core/test/session/subagent-host.test.ts`
- `pnpm --filter @moonshot-ai/agent-core typecheck`
- `pnpm --filter @moonshot-ai/kimi-code typecheck`
- `pnpm exec oxlint packages/agent-core/src/profile/context.ts packages/agent-core/test/profile/context.test.ts`
- `pnpm run lint` (515 existing warnings, 0 errors)
- `pnpm --filter kimi-code-docs run build`

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.
