### PR TITLE
fix: require plan approval in auto mode

### DIFF
--- a/.changeset/require-auto-plan-approval.md
+++ b/.changeset/require-auto-plan-approval.md
@@ -1,0 +1,6 @@
+---
+"@moonshot-ai/agent-core": patch
+"@moonshot-ai/kimi-code": patch
+---
+
+Keep plan review approval prompts active when auto permission mode is enabled.

--- a/packages/agent-core/src/agent/permission/policies/exit-plan-mode-review-ask.ts
+++ b/packages/agent-core/src/agent/permission/policies/exit-plan-mode-review-ask.ts
@@ -19,7 +19,6 @@ export class ExitPlanModeReviewAskPermissionPolicy implements PermissionPolicy {
 
   evaluate(context: PermissionPolicyContext): PermissionPolicyResult | undefined {
     if (context.toolCall.name !== 'ExitPlanMode') return;
-    if (this.agent.permission.mode === 'auto') return;
     if (!this.agent.planMode.isActive) return;
     const display = context.execution.display;
     if (display?.kind !== 'plan_review') return;

--- a/packages/agent-core/src/agent/permission/policies/index.ts
+++ b/packages/agent-core/src/agent/permission/policies/index.ts
@@ -36,6 +36,9 @@ export function createPermissionDecisionPolicies(agent: Agent): PermissionPolicy
     new PlanModeGuardDenyPermissionPolicy(agent),
     // User-configured deny rule matches → deny.
     new UserConfiguredDenyPermissionPolicy(agent),
+    // ExitPlanMode with active plan_review + non-empty plan → ask. Runs before
+    // auto/session-history/allow rules so a new plan body always gets reviewed.
+    new ExitPlanModeReviewAskPermissionPolicy(agent),
     // auto mode → approve (any auto-mode block must be a deny rule above this).
     new AutoModeApprovePermissionPolicy(agent),
     // Approve-for-session memorized rule matches → approve. Runs before user-configured ask rules so an in-session grant beats a still-matching ask rule on later calls.
@@ -44,8 +47,6 @@ export function createPermissionDecisionPolicies(agent: Agent): PermissionPolicy
     new UserConfiguredAskPermissionPolicy(agent),
     // User-configured allow rule matches → approve.
     new UserConfiguredAllowPermissionPolicy(agent),
-    // ExitPlanMode with active plan_review + non-empty plan + non-auto → ask (tracks plan_submitted/plan_resolved itself). Runs before session history so a stale session approval can't bypass review of a new plan body.
-    new ExitPlanModeReviewAskPermissionPolicy(agent),
     // EnterPlanMode, Write/Edit on the plan file, or ExitPlanMode with no actionable plan_review → approve.
     new PlanModeToolApprovePermissionPolicy(agent),
     // Access touches a sensitive file (.env, SSH key, credentials) → ask.

--- a/packages/agent-core/test/agent/permission.test.ts
+++ b/packages/agent-core/test/agent/permission.test.ts
@@ -704,11 +704,11 @@ describe('Permission policy chain', () => {
       'auto-mode-ask-user-question-deny',
       'plan-mode-guard-deny',
       'user-configured-deny',
+      'exit-plan-mode-review-ask',
       'auto-mode-approve',
       'session-approval-history',
       'user-configured-ask',
       'user-configured-allow',
-      'exit-plan-mode-review-ask',
       'plan-mode-tool-approve',
       'sensitive-file-access-ask',
       'git-control-path-access-ask',
@@ -1841,18 +1841,47 @@ describe('ExitPlanMode permission policy', () => {
     { label: 'Approach B', description: 'Use the complete refactor.' },
   ];
 
-  it('allows ExitPlanMode directly in auto mode without requesting approval', async () => {
-    const { manager, requestApproval } = makePlanPermissionManager({
+  it('requests plan-review approval in auto mode and returns formatted output', async () => {
+    const { manager, requestApproval, exit } = makePlanPermissionManager({
       mode: 'auto',
-      plan: '# Auto Plan',
+      plan: '# Auto Plan\n\n- Step',
+      path: '/tmp/auto-plan.md',
     });
 
     const result = await manager.beforeToolCall(
-      hookContext({ id: 'call_exit', toolName: 'ExitPlanMode', args: {} }),
+      hookContext({
+        id: 'call_exit',
+        toolName: 'ExitPlanMode',
+        args: {},
+        execution: planReviewExecution({
+          plan: '# Auto Plan\n\n- Step',
+          path: '/tmp/auto-plan.md',
+        }),
+      }),
     );
 
-    expect(result).toBeUndefined();
-    expect(requestApproval).not.toHaveBeenCalled();
+    expect(requestApproval).toHaveBeenCalledWith(
+      {
+        turnId: 0,
+        toolCallId: 'call_exit',
+        toolName: 'ExitPlanMode',
+        action: 'Presenting plan and exiting plan mode',
+        display: {
+          kind: 'plan_review',
+          plan: '# Auto Plan\n\n- Step',
+          path: '/tmp/auto-plan.md',
+          options: undefined,
+        },
+      },
+      { signal: expect.any(AbortSignal) },
+    );
+    expect(exit).toHaveBeenCalled();
+    expect(result).toMatchObject({
+      syntheticResult: {
+        isError: false,
+        output: expect.stringContaining('## Approved Plan:\n# Auto Plan'),
+      },
+    });
   });
 
   it('requests plan-review approval in yolo mode and returns formatted output', async () => {
@@ -1909,7 +1938,7 @@ describe('ExitPlanMode permission policy', () => {
     });
   });
 
-  it('reuses session approval for ExitPlanMode without re-prompting plan review', async () => {
+  it('does not reuse session approval for a new ExitPlanMode plan review', async () => {
     const { manager, requestApproval, exit } = makePlanPermissionManager({
       mode: 'manual',
       plan: '# Updated Plan',
@@ -1933,9 +1962,23 @@ describe('ExitPlanMode permission policy', () => {
       }),
     );
 
-    expect(requestApproval).not.toHaveBeenCalled();
-    expect(exit).not.toHaveBeenCalled();
-    expect(result).toBeUndefined();
+    expect(requestApproval).toHaveBeenCalledWith(
+      expect.objectContaining({
+        toolName: 'ExitPlanMode',
+        display: expect.objectContaining({
+          kind: 'plan_review',
+          plan: '# Updated Plan',
+        }),
+      }),
+      { signal: expect.any(AbortSignal) },
+    );
+    expect(exit).toHaveBeenCalled();
+    expect(result).toMatchObject({
+      syntheticResult: {
+        isError: false,
+        output: expect.stringContaining('## Approved Plan:\n# Updated Plan'),
+      },
+    });
   });
 
   it('returns a synthetic stop-turn result when the user rejects the plan', async () => {

--- a/packages/agent-core/test/tools/planning/exit-plan-mode-telemetry.test.ts
+++ b/packages/agent-core/test/tools/planning/exit-plan-mode-telemetry.test.ts
@@ -123,7 +123,7 @@ function permissionContext(args: ExitPlanModeInput): PermissionPolicyContext {
 }
 
 describe('ExitPlanMode telemetry', () => {
-  it('tracks submitted without options and auto approval', async () => {
+  it('tracks submitted without options and approved auto-mode plan review', async () => {
     const { agent, telemetryTrack, exitPlanMode } = makeAgent({ mode: 'auto' });
 
     const result = await execute(agent);
@@ -132,7 +132,7 @@ describe('ExitPlanMode telemetry', () => {
     expect(exitPlanMode).toHaveBeenCalledTimes(1);
     expect(telemetryTrack).toHaveBeenCalledWith('plan_submitted', { has_options: false });
     expect(telemetryTrack).toHaveBeenCalledWith('plan_resolved', {
-      outcome: 'auto_approved',
+      outcome: 'approved',
     });
   });
 
@@ -245,7 +245,7 @@ describe('ExitPlanMode telemetry', () => {
     );
   });
 
-  it('does not track auto_approved when exitPlanMode fails', async () => {
+  it('does not track approved in auto mode when exitPlanMode fails', async () => {
     const { agent, telemetryTrack, exitPlanMode } = makeAgent({ mode: 'auto' });
     exitPlanMode.mockImplementation(() => {
       throw new Error('state transition failure');
@@ -258,7 +258,7 @@ describe('ExitPlanMode telemetry', () => {
     expect(exitPlanMode).toHaveBeenCalledTimes(1);
     expect(telemetryTrack).toHaveBeenCalledWith('plan_submitted', { has_options: false });
     expect(telemetryTrack).not.toHaveBeenCalledWith('plan_resolved', {
-      outcome: 'auto_approved',
+      outcome: 'approved',
     });
   });
 


### PR DESCRIPTION
## Related Issue

Resolve #650

## Problem

When Plan mode and auto permission mode are both active, `ExitPlanMode` currently reaches the auto-approval policy before the plan-review approval policy. That exits Plan mode without giving the user the manual plan approval step that Plan mode promises.

## What changed

`ExitPlanMode` plan reviews now run before auto/session-history/allow approval policies, while explicit deny policies still win. This keeps ordinary auto-mode tool approval unchanged, but a non-empty plan review always asks the user before Plan mode exits.

Tests were updated to cover auto-mode plan review approval, stale session approval not bypassing a new plan body, and the telemetry outcome changing from auto-approved to approved when the user accepts the review. No docs update is needed because the existing Plan mode wording already describes `ExitPlanMode` as requesting user approval.

Validation:
- `pnpm vitest run packages/agent-core/test/agent/permission.test.ts packages/agent-core/test/tools/planning/exit-plan-mode-telemetry.test.ts packages/agent-core/test/tools/exit-plan-mode.test.ts`
- `pnpm --filter @moonshot-ai/agent-core typecheck`
- `pnpm --filter @moonshot-ai/kimi-code typecheck`
- `pnpm exec oxlint packages/agent-core/src/agent/permission/policies/index.ts packages/agent-core/src/agent/permission/policies/exit-plan-mode-review-ask.ts packages/agent-core/test/agent/permission.test.ts packages/agent-core/test/tools/planning/exit-plan-mode-telemetry.test.ts`
- `pnpm run lint` (515 existing warnings, 0 errors)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.
