### PR TITLE
feat: add sessions flag alias

### DIFF
--- a/.changeset/session-picker-status-alias.md
+++ b/.changeset/session-picker-status-alias.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": minor
+---
+
+Add a `--sessions` session picker alias and show `not selected` instead of login guidance before a session is selected.

--- a/apps/kimi-code/src/cli/commands.ts
+++ b/apps/kimi-code/src/cli/commands.ts
@@ -38,6 +38,11 @@ export function createProgram(
       ).argParser((val: string | boolean) => (val === true ? '' : (val as string))),
     )
     .addOption(
+      new Option('--sessions [id]')
+        .hideHelp()
+        .argParser((val: string | boolean) => (val === true ? '' : (val as string))),
+    )
+    .addOption(
       new Option('-r, --resume [id]')
         .hideHelp()
         .argParser((val: string | boolean) => (val === true ? '' : (val as string))),
@@ -104,7 +109,7 @@ export function createProgram(
 
     const raw = program.opts<Record<string, unknown>>();
 
-    const rawSession = raw['session'] ?? raw['resume'];
+    const rawSession = raw['session'] ?? raw['sessions'] ?? raw['resume'];
     const sessionValue = rawSession === true ? '' : (rawSession as string | undefined);
     const yoloValue = raw['yolo'] === true || raw['yes'] === true || raw['autoApprove'] === true;
     const autoValue = raw['auto'] === true;

--- a/apps/kimi-code/src/tui/components/chrome/welcome.ts
+++ b/apps/kimi-code/src/tui/components/chrome/welcome.ts
@@ -36,11 +36,19 @@ export class WelcomeComponent implements Component {
       textWidth,
       '…',
     );
-    const isLoggedOut = !this.state.model;
+    const hasModel = this.state.model.length > 0;
+    const hasConfiguredModels = Object.keys(this.state.availableModels).length > 0;
+    const needsProvider = !hasModel && !hasConfiguredModels;
     const dim = chalk.hex(currentTheme.palette.textDim);
     const labelStyle = chalk.bold.hex(currentTheme.palette.textDim);
     const rightRow1 = truncateToWidth(
-      dim(isLoggedOut ? 'Run /login or /provider to get started.' : 'Send /help for help information.'),
+      dim(
+        needsProvider
+          ? 'Run /login or /provider to get started.'
+          : hasModel
+            ? 'Send /help for help information.'
+            : 'Pick a session or send /model to choose one.',
+      ),
       textWidth,
       '…',
     );
@@ -54,8 +62,10 @@ export class WelcomeComponent implements Component {
     }
 
     const activeModel = this.state.availableModels[this.state.model];
-    const modelValue = isLoggedOut
-      ? chalk.hex(currentTheme.palette.warning)('not set, run /login or /provider')
+    const modelValue = !hasModel
+      ? needsProvider
+        ? chalk.hex(currentTheme.palette.warning)('not set, run /login or /provider')
+        : dim('not selected')
       : (activeModel?.displayName ?? activeModel?.model ?? this.state.model);
 
     const infoLines = [

--- a/apps/kimi-code/test/cli/session-flag-picker.test.ts
+++ b/apps/kimi-code/test/cli/session-flag-picker.test.ts
@@ -25,10 +25,15 @@ function parse(argv: string[]): CLIOptions {
   return captured;
 }
 
-describe('--session / -r / -S picker routing', () => {
+describe('--session / --sessions / -r / -S picker routing', () => {
   describe('argParser: no-arg forms coerce to empty string', () => {
     it('--session with no id → session === ""', () => {
       const opts = parse(['--session']);
+      expect(opts.session).toBe('');
+    });
+
+    it('--sessions with no id → session === ""', () => {
+      const opts = parse(['--sessions']);
       expect(opts.session).toBe('');
     });
 
@@ -46,6 +51,11 @@ describe('--session / -r / -S picker routing', () => {
   describe('argParser: id forms keep the id verbatim', () => {
     it('--session foo → session === "foo"', () => {
       const opts = parse(['--session', 'foo']);
+      expect(opts.session).toBe('foo');
+    });
+
+    it('--sessions foo → session === "foo"', () => {
+      const opts = parse(['--sessions', 'foo']);
       expect(opts.session).toBe('foo');
     });
 

--- a/apps/kimi-code/test/tui/components/chrome/welcome.test.ts
+++ b/apps/kimi-code/test/tui/components/chrome/welcome.test.ts
@@ -42,6 +42,10 @@ function truecolorCodes(text: string): Set<string> {
   return codes;
 }
 
+function stripSgr(text: string): string {
+  return text.replaceAll(/\u001B\[[0-9;]*m/g, '');
+}
+
 /** The two header rows (logo + title) of the rendered welcome box. */
 function headerOf(lines: string[]): string {
   return [lines[3], lines[4]].join('\n');
@@ -90,5 +94,44 @@ describe('WelcomeComponent', () => {
     const off = headerOf(new WelcomeComponent(appState).render(80));
 
     expect(off).toBe(base);
+  });
+
+  it('shows setup guidance when no models are configured', () => {
+    const output = stripSgr(
+      new WelcomeComponent({
+        ...appState,
+        model: '',
+        availableModels: {},
+      })
+        .render(120)
+        .join('\n'),
+    );
+
+    expect(output).toContain('Run /login or /provider to get started.');
+    expect(output).toContain('Model:     not set, run /login or /provider');
+  });
+
+  it('shows an unselected model state when models are configured', () => {
+    const output = stripSgr(
+      new WelcomeComponent({
+        ...appState,
+        model: '',
+        sessionId: '',
+        availableModels: {
+          'kimi-code/k2': {
+            provider: 'kimi-code',
+            model: 'kimi-k2',
+            maxContextSize: 128000,
+            displayName: 'Kimi K2',
+          },
+        },
+      })
+        .render(120)
+        .join('\n'),
+    );
+
+    expect(output).toContain('Pick a session or send /model to choose one.');
+    expect(output).toContain('Model:     not selected');
+    expect(output).not.toContain('run /login');
   });
 });

--- a/docs/en/reference/kimi-command.md
+++ b/docs/en/reference/kimi-command.md
@@ -25,7 +25,7 @@ All flags are optional — run `kimi` directly to enter an interactive session:
 | `--plan` | | Start a new session in Plan mode — the AI will prioritize read-only tools for exploration and planning |
 | `--skills-dir <dir>` | | Load Skills from the specified directory, replacing the automatically discovered user and project directories. Can be repeated |
 
-`-r` / `--resume` is a hidden alias for `--session`; `--yes` and `--auto-approve` are hidden aliases for `--yolo` and are not shown in help output.
+`-r` / `--resume` and `--sessions` are hidden aliases for `--session`; `--yes` and `--auto-approve` are hidden aliases for `--yolo` and are not shown in help output.
 
 ::: warning
 `--yolo` skips human approval for regular tool calls, including file writes and shell command execution. Use it only in trusted working directories. Plan mode exit approval is not bypassed by `--yolo`; `Bash` inside Plan mode is handled under the regular allow rules.

--- a/docs/zh/reference/kimi-command.md
+++ b/docs/zh/reference/kimi-command.md
@@ -25,7 +25,7 @@ kimi <subcommand> [options]
 | `--plan` | | 以 Plan 模式启动新会话，AI 会优先使用只读工具进行探索和规划 |
 | `--skills-dir <dir>` | | 从指定目录加载 Skills，替换自动发现的用户和项目目录。可重复传入 |
 
-`-r` / `--resume` 是 `--session` 的隐藏别名；`--yes` 和 `--auto-approve` 是 `--yolo` 的隐藏别名，在帮助信息中不显示。
+`-r` / `--resume` 和 `--sessions` 是 `--session` 的隐藏别名；`--yes` 和 `--auto-approve` 是 `--yolo` 的隐藏别名，在帮助信息中不显示。
 
 ::: warning 注意
 `--yolo` 会跳过普通工具调用的人工确认，包括文件写入和 Shell 命令执行，请只在受信任的工作目录下使用。Plan 模式的退出审批不会被 `--yolo` 跳过；Plan 模式下的 `Bash` 按普通放行规则处理。


### PR DESCRIPTION
## Related Issue

Resolve #512

## Problem

`kimi --session` opens the session picker before an active session is selected. The welcome panel treated the empty active model as a setup state, so OAuth users with configured models could still see `not set, run /login or /provider`. The linked issue also asks for parity with the `/sessions` spelling.

## What changed

- Added hidden `--sessions [id]` support through the existing `--session` option path, including bare picker mode and explicit session IDs.
- Updated the welcome panel to distinguish no configured models from no active model selected yet.
- Documented the hidden alias in the English and Chinese command reference.
- Added focused parser and welcome component tests.

## Validation

- `pnpm vitest run apps/kimi-code/test/tui/components/chrome/welcome.test.ts apps/kimi-code/test/cli/session-flag-picker.test.ts`
- `pnpm exec oxlint apps/kimi-code/src/tui/components/chrome/welcome.ts apps/kimi-code/test/tui/components/chrome/welcome.test.ts apps/kimi-code/src/cli/commands.ts apps/kimi-code/test/cli/session-flag-picker.test.ts`
- `pnpm --filter @moonshot-ai/kimi-code typecheck`
- `pnpm --filter kimi-code-docs run build`
- `pnpm run lint`
- Read-only staged diff audit: clean

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.