### PR TITLE
fix: recover incomplete resumed tool calls

### DIFF
--- a/.changeset/recover-incomplete-tool-results.md
+++ b/.changeset/recover-incomplete-tool-results.md
@@ -1,0 +1,6 @@
+---
+"@moonshot-ai/agent-core": patch
+"@moonshot-ai/kimi-code": patch
+---
+
+Recover resumed sessions whose last tool call was missing its recorded result after a crash.

--- a/packages/agent-core/src/agent/context/index.ts
+++ b/packages/agent-core/src/agent/context/index.ts
@@ -20,6 +20,9 @@ const TOOL_EMPTY_STATUS = '<system>Tool output is empty.</system>';
 const TOOL_EMPTY_ERROR_STATUS =
   '<system>ERROR: Tool execution failed. Tool output is empty.</system>';
 const TOOL_OUTPUT_EMPTY_TEXT = 'Tool output is empty.';
+const TOOL_RESULT_MISSING_AFTER_RESUME =
+  'Tool result missing because the previous process exited before it was recorded. ' +
+  'Treat this tool call as interrupted and continue from the next user instruction.';
 
 export class ContextMemory {
   private _history: ContextMessage[] = [];
@@ -203,6 +206,27 @@ export class ContextMemory {
 
   get messages(): Message[] {
     return this.project(this.history);
+  }
+
+  recoverIncompleteToolResultsAfterRestore(): boolean {
+    const missingToolCallIds = [...this.pendingToolResultIds];
+    this.openSteps.clear();
+    if (missingToolCallIds.length === 0) return false;
+
+    // Hard crashes can persist tool.call records before their matching
+    // tool.result records. Repair the transcript before the next prompt.
+    for (const toolCallId of missingToolCallIds) {
+      this.appendLoopEvent({
+        type: 'tool.result',
+        parentUuid: toolCallId,
+        toolCallId,
+        result: {
+          isError: true,
+          output: TOOL_RESULT_MISSING_AFTER_RESUME,
+        },
+      });
+    }
+    return true;
   }
 
   useProjectedHistoryFrom(source: ContextMemory): void {

--- a/packages/agent-core/src/agent/records/index.ts
+++ b/packages/agent-core/src/agent/records/index.ts
@@ -212,6 +212,9 @@ export class AgentRecords {
       this.persistence.rewrite(replayedRecords);
       await this.persistence.flush();
     }
+    if (this.agent.context.recoverIncompleteToolResultsAfterRestore()) {
+      await this.persistence.flush();
+    }
     if (this.agent.blobStore !== undefined) {
       for (const msg of this.agent.context.history) {
         await this.agent.blobStore.rehydrateParts(msg.content);

--- a/packages/agent-core/test/agent/resume.test.ts
+++ b/packages/agent-core/test/agent/resume.test.ts
@@ -408,6 +408,98 @@ describe('Agent resume', () => {
     );
   });
 
+  it('repairs restored tool calls that were missing results after a crash', async () => {
+    const persistence = new RecordingAgentPersistence([
+      {
+        type: 'config.update',
+        cwd: process.cwd(),
+        modelAlias: MOCK_PROVIDER.model,
+        systemPrompt: DEFAULT_TEST_SYSTEM_PROMPT,
+        thinkingLevel: 'off',
+      },
+      {
+        type: 'context.append_message',
+        message: {
+          role: 'user',
+          content: [{ type: 'text', text: 'Historical prompt before crash' }],
+          toolCalls: [],
+          origin: { kind: 'user' },
+        },
+      },
+      {
+        type: 'context.append_loop_event',
+        event: {
+          type: 'step.begin',
+          uuid: 'crashed-step',
+          turnId: '0',
+          step: 1,
+        },
+      },
+      {
+        type: 'context.append_loop_event',
+        event: {
+          type: 'content.part',
+          uuid: 'crashed-text',
+          turnId: '0',
+          step: 1,
+          stepUuid: 'crashed-step',
+          part: { type: 'text', text: 'I will inspect the workspace.' },
+        },
+      },
+      {
+        type: 'context.append_loop_event',
+        event: {
+          type: 'tool.call',
+          uuid: 'crashed-call',
+          turnId: '0',
+          step: 1,
+          stepUuid: 'crashed-step',
+          toolCallId: 'call_crashed_bash',
+          name: 'Bash',
+          args: { command: 'pwd' },
+        },
+      },
+    ]);
+    const ctx = testAgent({ persistence });
+
+    await ctx.agent.resume();
+
+    expect(persistence.appended).toContainEqual(
+      expect.objectContaining({
+        type: 'context.append_loop_event',
+        event: expect.objectContaining({
+          type: 'tool.result',
+          toolCallId: 'call_crashed_bash',
+          result: expect.objectContaining({
+            isError: true,
+            output: expect.stringContaining('previous process exited before it was recorded'),
+          }),
+        }),
+      }),
+    );
+    expect(ctx.agent.context.messages.map((message) => message.role)).toEqual([
+      'user',
+      'assistant',
+      'tool',
+    ]);
+
+    ctx.mockNextResponse({ type: 'text', text: 'Recovered after crash.' });
+    await ctx.rpc.prompt({ input: [{ type: 'text', text: 'Continue after crash' }] });
+    await ctx.untilTurnEnd();
+
+    expect(ctx.llmInputs()).toMatchInlineSnapshot(`
+      call 1:
+        system: <system-prompt>
+        tools: []
+        messages:
+          user: text "Historical prompt before crash"
+          assistant: text "I will inspect the workspace."  calls call_crashed_bash:Bash { "command": "pwd" }
+          tool[call_crashed_bash]: text "<system>ERROR: Tool execution failed.</system>\\nTool result missing because the previous process exited before it was recorded. Treat this tool call as interrupted and continue from the next user instruction."
+          user: text "Continue after crash"
+    `);
+    await ctx.expectResumeMatches();
+  });
+
   it('rebuilds goal completion replay cards without adding model-visible context', async () => {
     const persistence = new RecordingAgentPersistence([
       {


### PR DESCRIPTION
## Related Issue

Resolve #660

Also addresses the same resume/open-tool-call failure class reported in #269 and #701. Related alternative to #664.

## Problem

If the process is killed after an assistant tool call is recorded but before the matching tool result is written, resume restores a model-visible transcript with an open tool exchange. The next user prompt can be deferred behind that open exchange, and provider APIs can reject the history because assistant `tool_calls` are not followed by matching tool messages.

## What changed

- Added resume-time context recovery for restored tool calls that are missing recorded tool results.
- The recovery appends synthetic error tool results and flushes them, so the session is repaired durably and future resumes are idempotent.
- Cleared stale open-step bookkeeping after replay recovery.
- Added a regression test that resumes an incomplete tool exchange, sends the next prompt, and verifies the repaired provider input.

## Validation

- `pnpm vitest run packages/agent-core/test/agent/resume.test.ts`
- `pnpm exec oxlint packages/agent-core/src/agent/context/index.ts packages/agent-core/src/agent/records/index.ts packages/agent-core/test/agent/resume.test.ts`
- `pnpm --filter @moonshot-ai/agent-core typecheck`
- `pnpm --filter @moonshot-ai/kimi-code typecheck`
- `pnpm run lint`
- Read-only staged diff audit: clean

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.