### PR TITLE
fix: prefer media headers when reading media files

### DIFF
--- a/.changeset/read-media-header-types.md
+++ b/.changeset/read-media-header-types.md
@@ -1,0 +1,6 @@
+---
+"@moonshot-ai/agent-core": patch
+"@moonshot-ai/kimi-code": patch
+---
+
+Read media files using header-detected types before falling back to media extensions.

--- a/packages/agent-core/src/tools/builtin/file/read-media.ts
+++ b/packages/agent-core/src/tools/builtin/file/read-media.ts
@@ -171,10 +171,10 @@ export class ReadMediaFileTool implements BuiltinTool<ReadMediaFileInput> {
     }
 
     try {
-      // Sniff header first — read the first 512 bytes before deciding
-      // anything about MIME.
+      // For media input, the bytes are authoritative; the extension is only
+      // a fallback for formats that cannot be sniffed from the header.
       const header = await this.kaos.readBytes(safePath, MEDIA_SNIFF_BYTES);
-      const fileType = detectFileType(safePath, header);
+      const fileType = detectFileType(safePath, header, 'media');
 
       if (fileType.kind === 'text') {
         return {

--- a/packages/agent-core/src/tools/support/file-type.ts
+++ b/packages/agent-core/src/tools/support/file-type.ts
@@ -9,6 +9,8 @@ export interface FileType {
   readonly mimeType: string;
 }
 
+export type DetectFileTypeMode = 'text' | 'media';
+
 export const IMAGE_MIME_BY_SUFFIX: Readonly<Record<string, string>> = Object.freeze({
   '.png': 'image/png',
   '.jpg': 'image/jpeg',
@@ -340,7 +342,11 @@ function getSuffix(path: string): string {
   return path.slice(idx).toLowerCase();
 }
 
-export function detectFileType(path: string, header?: Buffer | Uint8Array): FileType {
+export function detectFileType(
+  path: string,
+  header?: Buffer | Uint8Array,
+  type: DetectFileTypeMode = 'text',
+): FileType {
   const suffix = getSuffix(path);
   let mediaHint: FileType | null = null;
   if (suffix in TEXT_MIME_BY_SUFFIX) {
@@ -351,16 +357,15 @@ export function detectFileType(path: string, header?: Buffer | Uint8Array): File
     mediaHint = { kind: 'video', mimeType: VIDEO_MIME_BY_SUFFIX[suffix]! };
   }
 
-  // When a header is supplied, cross-validate against the ext hint —
-  // a mismatch reports `unknown` rather than blindly trusting the
-  // extension. When ext hint + sniff agree on kind, prefer the ext's
-  // mimeType so the reported MIME matches what the filename advertised.
-  // A disagreement on `kind` (e.g. `.mp4` with JPEG magic) still
-  // collapses to `unknown`.
+  // When a header is supplied, cross-validate against the ext hint by
+  // default: a kind mismatch reports `unknown` rather than blindly trusting
+  // either signal. Media readers treat bytes as authoritative and only fall
+  // back to media suffixes when the header cannot be sniffed.
   if (header !== undefined) {
     const buf = toBuffer(header);
     const sniffed = sniffMediaFromMagic(buf);
     if (sniffed) {
+      if (type === 'media') return sniffed;
       if (mediaHint) {
         if (sniffed.kind !== mediaHint.kind) {
           return { kind: 'unknown', mimeType: '' };
@@ -368,6 +373,13 @@ export function detectFileType(path: string, header?: Buffer | Uint8Array): File
         return mediaHint;
       }
       return sniffed;
+    }
+    if (
+      type === 'media' &&
+      mediaHint !== null &&
+      mediaHint.kind !== 'text'
+    ) {
+      return mediaHint;
     }
     if (buf.includes(0x00)) {
       return { kind: 'unknown', mimeType: '' };

--- a/packages/agent-core/test/tools/file-type.test.ts
+++ b/packages/agent-core/test/tools/file-type.test.ts
@@ -193,6 +193,25 @@ describe('detectFileType', () => {
     expect(result.kind).toBe('unknown');
   });
 
+  it('can prefer the sniffed media header over the extension in media mode', () => {
+    const pngHeader = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+    expect(detectFileType('mismatch.mp4', pngHeader, 'media')).toEqual<FileType>({
+      kind: 'image',
+      mimeType: 'image/png',
+    });
+  });
+
+  it('falls back to a media extension in media mode when sniffing is inconclusive', () => {
+    const mpegProgramStreamHeader = Buffer.from([0x00, 0x00, 0x01, 0xba, 0x21, 0x00]);
+    expect(detectFileType('clip.mpg', mpegProgramStreamHeader, 'media')).toEqual<
+      FileType
+    >({
+      kind: 'video',
+      mimeType: 'video/mpeg',
+    });
+    expect(detectFileType('clip.mpg', mpegProgramStreamHeader).kind).toBe('unknown');
+  });
+
   it('extension in NON_TEXT_SUFFIXES → unknown', () => {
     // A `.zip` file with no header and no image/video hint must not
     // be treated as text.

--- a/packages/agent-core/test/tools/read-media.test.ts
+++ b/packages/agent-core/test/tools/read-media.test.ts
@@ -318,6 +318,27 @@ describe('ReadMediaFileTool', () => {
     expect(parts[3]).toEqual({ type: 'text', text: '</video>' });
   });
 
+  it('falls back to a media extension when the header cannot be sniffed', async () => {
+    const data = Buffer.from([0x00, 0x00, 0x01, 0xba, 0x21, 0x00, 0x01, 0x00]);
+    const tool = makeReadMediaTool({
+      stat: vi.fn<Kaos['stat']>().mockResolvedValue({ ...DEFAULT_STAT, stSize: data.length }),
+      readBytes: vi.fn<Kaos['readBytes']>().mockResolvedValue(data),
+    });
+
+    const result = await executeTool(tool, {
+      turnId: 't1',
+      toolCallId: 'c_mpg',
+      args: { path: '/workspace/sample.mpg' },
+      signal,
+    });
+
+    const parts = outputParts(result);
+    expect(parts[1]).toEqual({ type: 'text', text: '<video path="/workspace/sample.mpg">' });
+    expect((parts[2] as { videoUrl: { url: string } }).videoUrl.url).toBe(
+      `data:video/mpeg;base64,${data.toString('base64')}`,
+    );
+  });
+
   it('uses injected videoUploader for video files when available', async () => {
     const videoUploader = vi.fn().mockResolvedValue({
       type: 'video_url',


### PR DESCRIPTION
## Related Issue

No related issue. This fixes a media-file classification bug in the built-in media reader.

## Problem

`ReadMediaFile` should trust file headers before filename extensions, but shared file-type detection could still prefer the extension when both signals were media types. It could also reject known media files when the header was inconclusive and contained NUL bytes.

## What changed

- Added explicit `text` and `media` detection modes so text reads stay conservative while media reads prioritize sniffed headers.
- Updated `ReadMediaFile` to use media mode, falling back to known media extensions only when header sniffing is inconclusive.
- Added regression coverage for mismatched media extensions and inconclusive media headers with NUL bytes.

## Validation

- `pnpm -C packages/agent-core exec vitest run test/tools/file-type.test.ts test/tools/read-media.test.ts`
- `pnpm exec oxlint packages/agent-core/src/tools/support/file-type.ts packages/agent-core/src/tools/builtin/file/read-media.ts packages/agent-core/test/tools/file-type.test.ts packages/agent-core/test/tools/read-media.test.ts`
- `git diff --cached --check`
- Read-only staged-diff audit found no context-specific internal identifiers; unrelated demo files were not staged.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.
