### PR TITLE
fix: clarify compaction summary output target

### DIFF
--- a/.changeset/quiet-compaction-final-answer.md
+++ b/.changeset/quiet-compaction-final-answer.md
@@ -1,0 +1,6 @@
+---
+"@moonshot-ai/agent-core": patch
+"@moonshot-ai/kimi-code": patch
+---
+
+Clarify that compaction summaries must be emitted in the final answer.

--- a/packages/agent-core/src/agent/compaction/compaction-instruction.md
+++ b/packages/agent-core/src/agent/compaction/compaction-instruction.md
@@ -65,3 +65,5 @@ The goal of compaction is to keep essential code patterns, technical details, an
 
 - [Detailed non tool use user message]
 - ...
+
+<!-- Must output a summary matching the above template in the **final answer**, not in thinking. -->


### PR DESCRIPTION
## Related Issue

No related issue.

## Problem

The compaction instruction template did not explicitly say that the required summary belongs in the final answer rather than thinking, which made the output target ambiguous.

## What changed

Added a final instruction comment requiring the summary to match the template in the final answer, not in thinking. Added a patch changeset for the agent-core and CLI packages because the internal instruction change is bundled into the CLI.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] No tests were added because this is an instruction-only markdown change; ran `git diff --check`.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.