### PR TITLE
fix: close interrupted tool calls on resume

### DIFF
--- a/.changeset/close-interrupted-tool-results.md
+++ b/.changeset/close-interrupted-tool-results.md
@@ -1,0 +1,6 @@
+---
+"@moonshot-ai/agent-core": patch
+"@moonshot-ai/kimi-code": patch
+---
+
+Recover resumed sessions when an interrupted tool call result was not recorded.

--- a/packages/agent-core/src/agent/compaction/strategy.ts
+++ b/packages/agent-core/src/agent/compaction/strategy.ts
@@ -158,7 +158,9 @@ export class DefaultCompactionStrategy implements CompactionStrategy {
  *     results for one exchange land consecutively before the next non-tool
  *     message. So if the suffix starts with a tool result, its `asst_w_tc`
  *     must be in the compacted prefix, which would orphan that result
- *     (e.g. splitting between tool_a and tool_b of a parallel call).
+ *     (e.g. splitting between tool_a and tool_b of a parallel call), AND
+ *   - the compacted prefix itself does not end with an unresolved tool
+ *     exchange, because pending tool results must remain in the retained tail.
  */
 function canSplitAfter(messages: readonly Message[], index: number): boolean {
   const m = messages[index];
@@ -166,5 +168,22 @@ function canSplitAfter(messages: readonly Message[], index: number): boolean {
   if (m.role === 'user') return false;
   if (m.role === 'assistant' && m.toolCalls.length > 0) return false;
   if (messages[index + 1]?.role === 'tool') return false;
+  if (prefixEndsWithOpenToolExchange(messages, index)) return false;
   return true;
+}
+
+function prefixEndsWithOpenToolExchange(messages: readonly Message[], index: number): boolean {
+  if (messages[index]?.role !== 'tool') return false;
+
+  let toolResultCount = 0;
+  for (let i = index; i >= 0; i--) {
+    const message = messages[i];
+    if (message === undefined) return false;
+    if (message.role === 'tool') {
+      toolResultCount++;
+      continue;
+    }
+    return message.role === 'assistant' && message.toolCalls.length > toolResultCount;
+  }
+  return false;
 }

--- a/packages/agent-core/src/agent/context/index.ts
+++ b/packages/agent-core/src/agent/context/index.ts
@@ -20,7 +20,13 @@ const TOOL_EMPTY_STATUS = '<system>Tool output is empty.</system>';
 const TOOL_EMPTY_ERROR_STATUS =
   '<system>ERROR: Tool execution failed. Tool output is empty.</system>';
 const TOOL_OUTPUT_EMPTY_TEXT = 'Tool output is empty.';
+const TOOL_INTERRUPTED_ON_RESUME_OUTPUT =
+  'Tool execution was interrupted before its result was recorded. Do not assume the tool completed successfully.';
 
+// Invariant: _history must not contain an unresolved tool call exchange except
+// at the tail. When the tail is unresolved, pendingToolResultIds is exactly the
+// set of missing tool result ids for that tail exchange; appendMessage keeps
+// later messages in deferredMessages until those ids are resolved.
 export class ContextMemory {
   private _history: ContextMessage[] = [];
   private _tokenCount = 0;
@@ -208,6 +214,29 @@ export class ContextMemory {
   useProjectedHistoryFrom(source: ContextMemory): void {
     this.clear();
     this.pushHistory(...trimTrailingOpenToolExchange(source.project(source.history)));
+  }
+
+  finishResume(): void {
+    const interruptedToolCallIds = [...this.pendingToolResultIds];
+    this.openSteps.clear();
+    if (interruptedToolCallIds.length === 0) return;
+
+    for (const toolCallId of interruptedToolCallIds) {
+      const message = createToolMessage(
+        toolCallId,
+        toolResultOutputForModel({
+          output: TOOL_INTERRUPTED_ON_RESUME_OUTPUT,
+          isError: true,
+        }),
+      );
+      this.pushHistory({
+        ...message,
+        role: 'tool',
+        isError: true,
+      });
+      this.pendingToolResultIds.delete(toolCallId);
+    }
+    this.flushDeferredMessagesIfToolExchangeClosed();
   }
 
   appendLoopEvent(event: LoopRecordedEvent): void {

--- a/packages/agent-core/src/agent/context/index.ts
+++ b/packages/agent-core/src/agent/context/index.ts
@@ -222,21 +222,16 @@ export class ContextMemory {
     if (interruptedToolCallIds.length === 0) return;
 
     for (const toolCallId of interruptedToolCallIds) {
-      const message = createToolMessage(
+      this.appendLoopEvent({
+        type: 'tool.result',
+        parentUuid: toolCallId,
         toolCallId,
-        toolResultOutputForModel({
+        result: {
           output: TOOL_INTERRUPTED_ON_RESUME_OUTPUT,
           isError: true,
-        }),
-      );
-      this.pushHistory({
-        ...message,
-        role: 'tool',
-        isError: true,
+        },
       });
-      this.pendingToolResultIds.delete(toolCallId);
     }
-    this.flushDeferredMessagesIfToolExchangeClosed();
   }
 
   appendLoopEvent(event: LoopRecordedEvent): void {

--- a/packages/agent-core/src/agent/index.ts
+++ b/packages/agent-core/src/agent/index.ts
@@ -300,6 +300,7 @@ export class Agent {
     await this.background.loadFromDisk();
     await this.background.reconcile();
     await this.cron?.loadFromDisk();
+    this.context.finishResume();
     this.turn.finishResume();
     return result;
   }

--- a/packages/agent-core/src/agent/index.ts
+++ b/packages/agent-core/src/agent/index.ts
@@ -296,12 +296,17 @@ export class Agent {
 
   async resume(): Promise<{ warning?: string }> {
     const result = await this.records.replay();
-    this.goal.normalizeAfterReplay();
-    await this.background.loadFromDisk();
-    await this.background.reconcile();
-    await this.cron?.loadFromDisk();
-    this.context.finishResume();
-    this.turn.finishResume();
+    try {
+      this.replayBuilder.postRestoring = true;
+      this.goal.normalizeAfterReplay();
+      await this.background.loadFromDisk();
+      await this.background.reconcile();
+      await this.cron?.loadFromDisk();
+      this.context.finishResume();
+      this.turn.finishResume();
+    } finally {
+      this.replayBuilder.postRestoring = false;
+    }
     return result;
   }
 

--- a/packages/agent-core/src/agent/replay/index.ts
+++ b/packages/agent-core/src/agent/replay/index.ts
@@ -3,13 +3,14 @@ import type { AgentReplayRecord, AgentReplayRecordPayload } from '../..';
 import type { ContextMessage } from '../context';
 
 export class ReplayBuilder {
+  postRestoring = false;
   captureLiveRecords = false;
   protected readonly records: AgentReplayRecord[] = [];
 
   constructor(public readonly agent: Agent) {}
 
   push(record: AgentReplayRecordPayload): void {
-    if (this.captureLiveRecords || this.agent.records.restoring) {
+    if (this.captureLiveRecords || this.agent.records.restoring || this.postRestoring) {
       this.records.push({
         ...record,
         time: this.agent.records.restoring?.time ?? Date.now(),

--- a/packages/agent-core/test/agent/compaction/full.test.ts
+++ b/packages/agent-core/test/agent/compaction/full.test.ts
@@ -879,13 +879,29 @@ describe('FullCompaction', () => {
       messages:
         user: text "old user one"
         assistant: text "old assistant one"
-        user: text "run both tools"
-        assistant: []  calls call_open_one:LookupOne { "query": "one" }, call_open_two:LookupTwo { "query": "two" }
-        tool[call_open_one]: text "one result"
         user: text <compaction-instruction>
     `);
     expect(ctx.agent.context.history.map((message) => message.role)).toEqual([
       'assistant',
+      'user',
+      'assistant',
+      'tool',
+    ]);
+    ctx.dispatch({
+      type: 'context.append_loop_event',
+      event: {
+        type: 'tool.result',
+        parentUuid: 'call_open_two',
+        toolCallId: 'call_open_two',
+        result: { output: 'two result' },
+      },
+    });
+    expect(ctx.agent.context.history.map((message) => message.role)).toEqual([
+      'assistant',
+      'user',
+      'assistant',
+      'tool',
+      'tool',
     ]);
     await ctx.expectResumeMatches();
   });
@@ -1152,6 +1168,9 @@ describe('FullCompaction', () => {
 
     expect(ctx.agent.context.history.map((m) => m.role)).toEqual([
       'assistant',
+      'user',
+      'assistant',
+      'tool',
     ]);
 
     ctx.dispatch({
@@ -1166,6 +1185,9 @@ describe('FullCompaction', () => {
 
     expect(ctx.agent.context.history.map((m) => m.role)).toEqual([
       'assistant',
+      'user',
+      'assistant',
+      'tool',
       'tool',
       'user',
     ]);

--- a/packages/agent-core/test/agent/resume.test.ts
+++ b/packages/agent-core/test/agent/resume.test.ts
@@ -490,6 +490,23 @@ describe('Agent resume', () => {
     expect(textContent(syntheticResult)).toContain(
       'Tool execution was interrupted before its result was recorded',
     );
+    const replayMessages = ctx.agent.replayBuilder
+      .buildResult()
+      .flatMap((record) => (record.type === 'message' ? [record.message] : []));
+    expect(replayMessages.map((message) => message.role)).toEqual([
+      'user',
+      'assistant',
+      'tool',
+      'tool',
+    ]);
+    expect(replayMessages.at(-1)).toMatchObject({
+      role: 'tool',
+      toolCallId: 'call_interrupted_two',
+      isError: true,
+    });
+    expect(textContent(replayMessages.at(-1))).toContain(
+      'Tool execution was interrupted before its result was recorded',
+    );
     expect(
       persistence.appended.filter(
         (record) =>

--- a/packages/agent-core/test/agent/resume.test.ts
+++ b/packages/agent-core/test/agent/resume.test.ts
@@ -490,10 +490,48 @@ describe('Agent resume', () => {
     expect(textContent(syntheticResult)).toContain(
       'Tool execution was interrupted before its result was recorded',
     );
+    expect(
+      persistence.appended.filter(
+        (record) =>
+          record.type === 'context.append_loop_event' &&
+          record.event.type === 'tool.result' &&
+          record.event.toolCallId === 'call_interrupted_two',
+      ),
+    ).toEqual([
+      expect.objectContaining({
+        type: 'context.append_loop_event',
+        event: expect.objectContaining({
+          type: 'tool.result',
+          parentUuid: 'call_interrupted_two',
+          toolCallId: 'call_interrupted_two',
+          result: {
+            output:
+              'Tool execution was interrupted before its result was recorded. Do not assume the tool completed successfully.',
+            isError: true,
+          },
+        }),
+      }),
+    ]);
 
     ctx.mockNextResponse({ type: 'text', text: 'Recovered after resume.' });
     await ctx.rpc.prompt({ input: [{ type: 'text', text: 'continue after resume' }] });
     await ctx.untilTurnEnd();
+
+    const syntheticRecordIndex = persistence.records.findIndex(
+      (record) =>
+        record.type === 'context.append_loop_event' &&
+        record.event.type === 'tool.result' &&
+        record.event.toolCallId === 'call_interrupted_two',
+    );
+    const freshUserRecordIndex = persistence.records.findIndex(
+      (record) =>
+        record.type === 'context.append_message' &&
+        record.message.role === 'user' &&
+        textContent(record.message) === 'continue after resume',
+    );
+    expect(syntheticRecordIndex).toBeGreaterThan(-1);
+    expect(freshUserRecordIndex).toBeGreaterThan(-1);
+    expect(syntheticRecordIndex).toBeLessThan(freshUserRecordIndex);
 
     const llmHistory = ctx.llmCalls[0]?.history ?? [];
     expect(llmHistory.map((message) => message.role)).toEqual([
@@ -515,6 +553,22 @@ describe('Agent resume', () => {
         (message) => message.role === 'user' && textContent(message) === 'continue after resume',
       ),
     ).toBe(true);
+
+    const resumedAgain = testAgent({ persistence });
+    await resumedAgain.agent.resume();
+
+    expect(resumedAgain.agent.context.history.map((message) => message.role)).toEqual([
+      'user',
+      'assistant',
+      'tool',
+      'tool',
+      'user',
+      'assistant',
+    ]);
+    expect(textContent(resumedAgain.agent.context.history[3])).toContain(
+      'Tool execution was interrupted before its result was recorded',
+    );
+    expect(textContent(resumedAgain.agent.context.history[4])).toBe('continue after resume');
   });
 
   it('rebuilds goal completion replay cards without adding model-visible context', async () => {

--- a/packages/agent-core/test/agent/resume.test.ts
+++ b/packages/agent-core/test/agent/resume.test.ts
@@ -408,6 +408,115 @@ describe('Agent resume', () => {
     );
   });
 
+  it('closes interrupted trailing tool calls with synthetic error results after resume', async () => {
+    const persistence = new RecordingAgentPersistence([
+      {
+        type: 'config.update',
+        cwd: process.cwd(),
+        modelAlias: MOCK_PROVIDER.model,
+        systemPrompt: DEFAULT_TEST_SYSTEM_PROMPT,
+        thinkingLevel: 'off',
+      },
+      {
+        type: 'context.append_message',
+        message: {
+          role: 'user',
+          content: [{ type: 'text', text: 'Run both lookups' }],
+          toolCalls: [],
+          origin: { kind: 'user' },
+        },
+      },
+      {
+        type: 'context.append_loop_event',
+        event: {
+          type: 'step.begin',
+          uuid: 'interrupted-step',
+          turnId: '0',
+          step: 1,
+        },
+      },
+      {
+        type: 'context.append_loop_event',
+        event: {
+          type: 'tool.call',
+          uuid: 'call-one',
+          turnId: '0',
+          step: 1,
+          stepUuid: 'interrupted-step',
+          toolCallId: 'call_interrupted_one',
+          name: 'LookupOne',
+          args: { query: 'one' },
+        },
+      },
+      {
+        type: 'context.append_loop_event',
+        event: {
+          type: 'tool.call',
+          uuid: 'call-two',
+          turnId: '0',
+          step: 1,
+          stepUuid: 'interrupted-step',
+          toolCallId: 'call_interrupted_two',
+          name: 'LookupTwo',
+          args: { query: 'two' },
+        },
+      },
+      {
+        type: 'context.append_loop_event',
+        event: {
+          type: 'tool.result',
+          parentUuid: 'call-one',
+          toolCallId: 'call_interrupted_one',
+          result: { output: 'one result' },
+        },
+      },
+    ]);
+    const ctx = testAgent({ persistence });
+
+    await ctx.agent.resume();
+
+    expect(ctx.agent.context.history.map((message) => message.role)).toEqual([
+      'user',
+      'assistant',
+      'tool',
+      'tool',
+    ]);
+    const syntheticResult = ctx.agent.context.history.at(-1);
+    expect(syntheticResult).toMatchObject({
+      role: 'tool',
+      toolCallId: 'call_interrupted_two',
+      isError: true,
+    });
+    expect(textContent(syntheticResult)).toContain(
+      'Tool execution was interrupted before its result was recorded',
+    );
+
+    ctx.mockNextResponse({ type: 'text', text: 'Recovered after resume.' });
+    await ctx.rpc.prompt({ input: [{ type: 'text', text: 'continue after resume' }] });
+    await ctx.untilTurnEnd();
+
+    const llmHistory = ctx.llmCalls[0]?.history ?? [];
+    expect(llmHistory.map((message) => message.role)).toEqual([
+      'user',
+      'assistant',
+      'tool',
+      'tool',
+      'user',
+    ]);
+    expect(textContent(llmHistory[3])).toContain(
+      '<system>ERROR: Tool execution failed.</system>',
+    );
+    expect(textContent(llmHistory[3])).toContain(
+      'Tool execution was interrupted before its result was recorded',
+    );
+    expect(textContent(llmHistory[4])).toBe('continue after resume');
+    expect(
+      ctx.agent.context.history.some(
+        (message) => message.role === 'user' && textContent(message) === 'continue after resume',
+      ),
+    ).toBe(true);
+  });
+
   it('rebuilds goal completion replay cards without adding model-visible context', async () => {
     const persistence = new RecordingAgentPersistence([
       {
@@ -581,6 +690,18 @@ function withMetadata(events: readonly AgentRecord[]): readonly AgentRecord[] {
     },
     ...events,
   ];
+}
+
+function textContent(
+  message:
+    | { readonly content: readonly { readonly type: string; readonly text?: string }[] }
+    | undefined,
+): string {
+  return (
+    message?.content
+      .map((part) => (part.type === 'text' && typeof part.text === 'string' ? part.text : ''))
+      .join('') ?? ''
+  );
 }
 
 function resumeHistory(): AgentRecord[] {


### PR DESCRIPTION
## Related Issue

No linked issue; this fixes a resume recovery bug observed when a session is interrupted after an assistant tool call is recorded but before the corresponding tool result is persisted.

## Problem

Resuming such a session can leave the active context with pending tool result ids. The next model request may include an assistant tool call without matching tool messages, and later user input can remain deferred because the tool exchange never closes.

Manual compaction also had to preserve this invariant: pending tool result ids must always refer to the unresolved tool exchange at the history tail. A compaction split must not compact a partially resolved trailing tool exchange into the summary while leaving its pending ids behind.

## What changed

Resume finalization now converts pending trailing tool result ids into synthetic error tool messages that state the tool result was interrupted before being recorded. This closes the tool exchange, flushes deferred messages, and keeps the resumed context valid for the next request.

`ContextMemory` documents the invariant that unresolved tool exchanges may only exist at the history tail and are represented by `pendingToolResultIds`. Full compaction now rejects split points where the compacted prefix would end with an unresolved tool exchange, so pending tool calls remain in the retained tail instead of being hidden inside the summary.

## Verification

- `pnpm --dir packages/agent-core exec vitest run test/agent/compaction/full.test.ts`
- `pnpm --dir packages/agent-core exec vitest run test/agent/resume.test.ts test/agent/context.test.ts`
- `pnpm --dir packages/agent-core typecheck`
- `pnpm run test`
- `git diff --check`
- Read-only diff audit found no internal identifiers before the PR was opened; follow-up changes use only synthetic test ids and strings.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.
