### PR TITLE
fix: recover incomplete resumed tool calls

### DIFF
--- a/.changeset/recover-incomplete-tool-results.md
+++ b/.changeset/recover-incomplete-tool-results.md
@@ -1,0 +1,6 @@
+---
+"@moonshot-ai/agent-core": patch
+"@moonshot-ai/kimi-code": patch
+---
+
+Recover resumed sessions whose last tool call was missing its recorded result after a crash.

--- a/packages/agent-core/src/agent/context/index.ts
+++ b/packages/agent-core/src/agent/context/index.ts
@@ -20,6 +20,9 @@ const TOOL_EMPTY_STATUS = '<system>Tool output is empty.</system>';
 const TOOL_EMPTY_ERROR_STATUS =
   '<system>ERROR: Tool execution failed. Tool output is empty.</system>';
 const TOOL_OUTPUT_EMPTY_TEXT = 'Tool output is empty.';
+const TOOL_RESULT_MISSING_AFTER_RESUME =
+  'Tool result missing because the previous process exited before it was recorded. ' +
+  'Treat this tool call as interrupted and continue from the next user instruction.';
 
 export class ContextMemory {
   private _history: ContextMessage[] = [];
@@ -203,6 +206,27 @@ export class ContextMemory {
 
   get messages(): Message[] {
     return this.project(this.history);
+  }
+
+  recoverIncompleteToolResultsAfterRestore(): boolean {
+    const missingToolCallIds = [...this.pendingToolResultIds];
+    this.openSteps.clear();
+    if (missingToolCallIds.length === 0) return false;
+
+    // Hard crashes can persist tool.call records before their matching
+    // tool.result records. Repair the transcript before the next prompt.
+    for (const toolCallId of missingToolCallIds) {
+      this.appendLoopEvent({
+        type: 'tool.result',
+        parentUuid: toolCallId,
+        toolCallId,
+        result: {
+          isError: true,
+          output: TOOL_RESULT_MISSING_AFTER_RESUME,
+        },
+      });
+    }
+    return true;
   }
 
   useProjectedHistoryFrom(source: ContextMemory): void {

--- a/packages/agent-core/src/agent/records/index.ts
+++ b/packages/agent-core/src/agent/records/index.ts
@@ -212,6 +212,9 @@ export class AgentRecords {
       this.persistence.rewrite(replayedRecords);
       await this.persistence.flush();
     }
+    if (this.agent.context.recoverIncompleteToolResultsAfterRestore()) {
+      await this.persistence.flush();
+    }
     if (this.agent.blobStore !== undefined) {
       for (const msg of this.agent.context.history) {
         await this.agent.blobStore.rehydrateParts(msg.content);

--- a/packages/agent-core/test/agent/resume.test.ts
+++ b/packages/agent-core/test/agent/resume.test.ts
@@ -408,6 +408,98 @@ describe('Agent resume', () => {
     );
   });
 
+  it('repairs restored tool calls that were missing results after a crash', async () => {
+    const persistence = new RecordingAgentPersistence([
+      {
+        type: 'config.update',
+        cwd: process.cwd(),
+        modelAlias: MOCK_PROVIDER.model,
+        systemPrompt: DEFAULT_TEST_SYSTEM_PROMPT,
+        thinkingLevel: 'off',
+      },
+      {
+        type: 'context.append_message',
+        message: {
+          role: 'user',
+          content: [{ type: 'text', text: 'Historical prompt before crash' }],
+          toolCalls: [],
+          origin: { kind: 'user' },
+        },
+      },
+      {
+        type: 'context.append_loop_event',
+        event: {
+          type: 'step.begin',
+          uuid: 'crashed-step',
+          turnId: '0',
+          step: 1,
+        },
+      },
+      {
+        type: 'context.append_loop_event',
+        event: {
+          type: 'content.part',
+          uuid: 'crashed-text',
+          turnId: '0',
+          step: 1,
+          stepUuid: 'crashed-step',
+          part: { type: 'text', text: 'I will inspect the workspace.' },
+        },
+      },
+      {
+        type: 'context.append_loop_event',
+        event: {
+          type: 'tool.call',
+          uuid: 'crashed-call',
+          turnId: '0',
+          step: 1,
+          stepUuid: 'crashed-step',
+          toolCallId: 'call_crashed_bash',
+          name: 'Bash',
+          args: { command: 'pwd' },
+        },
+      },
+    ]);
+    const ctx = testAgent({ persistence });
+
+    await ctx.agent.resume();
+
+    expect(persistence.appended).toContainEqual(
+      expect.objectContaining({
+        type: 'context.append_loop_event',
+        event: expect.objectContaining({
+          type: 'tool.result',
+          toolCallId: 'call_crashed_bash',
+          result: expect.objectContaining({
+            isError: true,
+            output: expect.stringContaining('previous process exited before it was recorded'),
+          }),
+        }),
+      }),
+    );
+    expect(ctx.agent.context.messages.map((message) => message.role)).toEqual([
+      'user',
+      'assistant',
+      'tool',
+    ]);
+
+    ctx.mockNextResponse({ type: 'text', text: 'Recovered after crash.' });
+    await ctx.rpc.prompt({ input: [{ type: 'text', text: 'Continue after crash' }] });
+    await ctx.untilTurnEnd();
+
+    expect(ctx.llmInputs()).toMatchInlineSnapshot(`
+      call 1:
+        system: <system-prompt>
+        tools: []
+        messages:
+          user: text "Historical prompt before crash"
+          assistant: text "I will inspect the workspace."  calls call_crashed_bash:Bash { "command": "pwd" }
+          tool[call_crashed_bash]: text "<system>ERROR: Tool execution failed.</system>\\nTool result missing because the previous process exited before it was recorded. Treat this tool call as interrupted and continue from the next user instruction."
+          user: text "Continue after crash"
+    `);
+    await ctx.expectResumeMatches();
+  });
+
   it('rebuilds goal completion replay cards without adding model-visible context', async () => {
     const persistence = new RecordingAgentPersistence([
       {


### PR DESCRIPTION
# fix: recover incomplete resumed tool calls

## Summary

On a hard crash (process killed, power loss, OOM), the persistence layer can write a `tool.call` record *before* its matching `tool.result` record. When the session is later resumed, the transcript ends with a dangling tool call: `pendingToolResultIds` is non-empty and the next prompt is sent to the model with an open, never-answered tool exchange.

This PR repairs that state on resume by synthesizing an error `tool.result` for each orphaned `tool.call`, so the model sees the call was interrupted and continues from the next user instruction. The repair is flushed to disk, so it is durable across further resumes.

This is a single, self-contained fix with a focused regression test. It is **not** part of a bulk/batch submission.

## Reproduction

1. Start a session; let the agent issue a tool call (e.g. `Bash { command: "pwd" }`).
2. Kill the process after the `tool.call` record is persisted but before the `tool.result` is written.
3. Resume the session and send a new prompt.

**Before:** the resumed history contains an assistant turn with a tool call that has no result. The next request is built on top of an open tool exchange.

**After:** resume appends an error tool result:

> `Tool result missing because the previous process exited before it was recorded. Treat this tool call as interrupted and continue from the next user instruction.`

and the conversation continues cleanly.

## Design note (the one thing worth a reviewer's attention)

There is already a recovery path for trailing open tool exchanges: `trimTrailingOpenToolExchange` in `packages/agent-core/src/agent/context/projector.ts`. Its strategy is to **drop** the incomplete exchange from projected history.

This PR deliberately takes the **opposite** strategy for the crash-recovery case — it **keeps** the tool call and synthesizes an error result, rather than dropping it. Rationale:

- **Trim** hides that any work was attempted; the model resumes as if the call never happened.
- **Repair** preserves the record that a tool was invoked and surfaces, in-band, that it was interrupted — which is more faithful to what actually occurred and lets the model reason about the interruption.

I am not attached to repair-over-trim. If the maintainers prefer to route crash recovery through the existing `trimTrailingOpenToolExchange` instead of adding a second path, I'm happy to rework it that way. Flagging it explicitly so the design choice is a decision, not an accident — and so the two mechanisms don't silently diverge.

## Changes

- `packages/agent-core/src/agent/context/index.ts` — `recoverIncompleteToolResultsAfterRestore()`: appends an error `tool.result` for each pending tool-call id, clears open steps, returns whether a repair happened.
- `packages/agent-core/src/agent/records/index.ts` — call the recovery after restore and flush persistence if a repair occurred.
- `packages/agent-core/test/agent/resume.test.ts` — regression test: a restored session whose last record is a `tool.call` with no result is repaired, the projected history is `[user, assistant, tool]`, and a follow-up prompt continues correctly (verified via inline snapshot).
- `.changeset/recover-incomplete-tool-results.md` — patch bump for `@moonshot-ai/agent-core` and `@moonshot-ai/kimi-code`.

## Test evidence

```
$ npx vitest run packages/agent-core/test/agent/resume.test.ts -t "repairs restored tool calls"

 Test Files  1 passed (1)
      Tests  1 passed | 11 skipped (12)
```

+125 / -0. No existing behavior changed; the new path only fires when `pendingToolResultIds` is non-empty after restore.
