### PR TITLE
fix: skip legacy max step limit during migration

### DIFF
--- a/.changeset/skip-legacy-max-steps.md
+++ b/.changeset/skip-legacy-max-steps.md
@@ -1,0 +1,6 @@
+---
+"@moonshot-ai/kimi-code": patch
+"@moonshot-ai/migration-legacy": patch
+---
+
+Do not carry legacy `loop_control.max_steps_per_turn` values into migrated config files.

--- a/.changeset/skip-legacy-max-steps.md
+++ b/.changeset/skip-legacy-max-steps.md
@@ -3,4 +3,4 @@
 "@moonshot-ai/migration-legacy": patch
 ---
 
-Do not carry legacy `loop_control.max_steps_per_turn` values into migrated config files.
+Do not carry obsolete legacy loop, background, plan, yolo, or unknown experimental flags into migrated config files.

--- a/packages/migration-legacy/src/steps/config.ts
+++ b/packages/migration-legacy/src/steps/config.ts
@@ -97,6 +97,15 @@ function emptyResult(): ConfigStepResult {
   };
 }
 
+function stripLegacyLoopControlFields(
+  value: Record<string, unknown>,
+): Record<string, unknown> | undefined {
+  const keptEntries = Object.entries(value).filter(
+    ([field]) => field !== 'max_steps_per_turn',
+  );
+  return keptEntries.length > 0 ? Object.fromEntries(keptEntries) : undefined;
+}
+
 /** True when the kimi-cli provider entry validates against kimi-code's schema. */
 function providerIsSupported(prov: Record<string, unknown>): boolean {
   const transformed = transformTomlData({ providers: { x: prov } });
@@ -328,6 +337,13 @@ export async function migrateConfigStep(input: ConfigStepInput): Promise<ConfigS
       keptModels[v] === undefined &&
       !availableModelNames.has(v)
     ) {
+      continue;
+    }
+    if (k === 'loop_control' && isRecord(v)) {
+      const strippedLoopControl = stripLegacyLoopControlFields(v);
+      if (strippedLoopControl !== undefined) {
+        migratedTop[k] = strippedLoopControl;
+      }
       continue;
     }
     migratedTop[k] = v;

--- a/packages/migration-legacy/src/steps/config.ts
+++ b/packages/migration-legacy/src/steps/config.ts
@@ -7,6 +7,7 @@ import {
   ProviderConfigSchema,
   transformTomlData,
 } from '@moonshot-ai/agent-core';
+import { FLAG_DEFINITIONS } from '@moonshot-ai/agent-core/flags/registry';
 import { atomicWrite } from '../atomic-write.js';
 import { DEFAULT_CONFIG_FILE_TEXT, isTuiStubOrMissing } from '../stub-detect.js';
 import {
@@ -19,6 +20,18 @@ import {
 
 // `theme` / `default_editor` belong in tui.toml, not config.toml.
 const TUI_TOP_LEVEL_KEYS = new Set(['theme', 'default_editor']);
+const TOP_LEVEL_KEYS_TO_DROP = new Set(['plan_mode', 'yolo']);
+const LOOP_CONTROL_FIELDS_TO_KEEP = new Set([
+  'max_retries_per_step',
+  'reserved_context_size',
+]);
+const BACKGROUND_FIELDS_TO_KEEP = new Set([
+  'max_running_tasks',
+  'keep_alive_on_exit',
+]);
+const REGISTERED_EXPERIMENTAL_FLAGS: ReadonlySet<string> = new Set(
+  FLAG_DEFINITIONS.map((definition) => definition.id),
+);
 
 // kimi-code's tui.toml `theme` enum (mirrors apps/kimi-code TuiThemeSchema).
 // A legacy theme outside this set would fail loadTuiConfig()'s whole-file
@@ -97,11 +110,19 @@ function emptyResult(): ConfigStepResult {
   };
 }
 
-function stripLegacyLoopControlFields(
+function filterFields(
+  value: Record<string, unknown>,
+  fieldsToKeep: ReadonlySet<string>,
+): Record<string, unknown> | undefined {
+  const keptEntries = Object.entries(value).filter(([field]) => fieldsToKeep.has(field));
+  return keptEntries.length > 0 ? Object.fromEntries(keptEntries) : undefined;
+}
+
+function filterRegisteredExperimentalFlags(
   value: Record<string, unknown>,
 ): Record<string, unknown> | undefined {
   const keptEntries = Object.entries(value).filter(
-    ([field]) => field !== 'max_steps_per_turn',
+    ([field, flag]) => REGISTERED_EXPERIMENTAL_FLAGS.has(field) && typeof flag === 'boolean',
   );
   return keptEntries.length > 0 ? Object.fromEntries(keptEntries) : undefined;
 }
@@ -318,6 +339,7 @@ export async function migrateConfigStep(input: ConfigStepInput): Promise<ConfigS
   for (const [k, v] of Object.entries(parsed)) {
     if (k === 'providers' || k === 'models' || k === 'hooks') continue;
     if (TUI_TOP_LEVEL_KEYS.has(k)) continue;
+    if (TOP_LEVEL_KEYS_TO_DROP.has(k)) continue;
     if (k === 'default_yolo') {
       // kimi-cli's `default_yolo` maps to kimi-code's `default_permission_mode`.
       if (v === true) migratedTop['default_permission_mode'] = 'yolo';
@@ -340,9 +362,23 @@ export async function migrateConfigStep(input: ConfigStepInput): Promise<ConfigS
       continue;
     }
     if (k === 'loop_control' && isRecord(v)) {
-      const strippedLoopControl = stripLegacyLoopControlFields(v);
-      if (strippedLoopControl !== undefined) {
-        migratedTop[k] = strippedLoopControl;
+      const filteredLoopControl = filterFields(v, LOOP_CONTROL_FIELDS_TO_KEEP);
+      if (filteredLoopControl !== undefined) {
+        migratedTop[k] = filteredLoopControl;
+      }
+      continue;
+    }
+    if (k === 'background' && isRecord(v)) {
+      const filteredBackground = filterFields(v, BACKGROUND_FIELDS_TO_KEEP);
+      if (filteredBackground !== undefined) {
+        migratedTop[k] = filteredBackground;
+      }
+      continue;
+    }
+    if (k === 'experimental' && isRecord(v)) {
+      const filteredExperimental = filterRegisteredExperimentalFlags(v);
+      if (filteredExperimental !== undefined) {
+        migratedTop[k] = filteredExperimental;
       }
       continue;
     }

--- a/packages/migration-legacy/test/steps/config.test.ts
+++ b/packages/migration-legacy/test/steps/config.test.ts
@@ -430,6 +430,24 @@ base_url = "https://target.example/v1"
     expect(r.siblingContents.hooks).toBe(2);
   });
 
+  it('drops legacy loop_control.max_steps_per_turn but keeps other loop control fields', async () => {
+    await writeFile(
+      join(src, 'config.toml'),
+      'default_thinking = true\n' +
+        '[loop_control]\n' +
+        'max_steps_per_turn = 1000\n' +
+        'max_retries_per_step = 2\n',
+    );
+
+    const r = await migrateConfigStep({ sourceHome: src, targetHome: tgt });
+
+    expect(r.migrated).toBe(true);
+    const cfg = await readFile(join(tgt, 'config.toml'), 'utf-8');
+    expect(cfg).toContain('[loop_control]');
+    expect(cfg).toContain('max_retries_per_step = 2');
+    expect(cfg).not.toContain('max_steps_per_turn');
+  });
+
   it('maps default_yolo to default_permission_mode = "yolo"', async () => {
     await writeFile(
       join(src, 'config.toml'),

--- a/packages/migration-legacy/test/steps/config.test.ts
+++ b/packages/migration-legacy/test/steps/config.test.ts
@@ -430,22 +430,52 @@ base_url = "https://target.example/v1"
     expect(r.siblingContents.hooks).toBe(2);
   });
 
-  it('drops legacy loop_control.max_steps_per_turn but keeps other loop control fields', async () => {
+  it('drops legacy migration fields but keeps supported loop and background fields', async () => {
     await writeFile(
       join(src, 'config.toml'),
       'default_thinking = true\n' +
+        'plan_mode = true\n' +
+        'yolo = true\n' +
+        '[experimental]\n' +
+        'micro_compaction = false\n' +
+        'unknown_flag = true\n' +
         '[loop_control]\n' +
         'max_steps_per_turn = 1000\n' +
-        'max_retries_per_step = 2\n',
+        'max_steps_per_run = 42\n' +
+        'max_retries_per_step = 2\n' +
+        'max_ralph_iterations = 3\n' +
+        'reserved_context_size = 60000\n' +
+        'compaction_trigger_ratio = 0.7\n' +
+        '[background]\n' +
+        'max_running_tasks = 8\n' +
+        'keep_alive_on_exit = true\n' +
+        'kill_grace_period_ms = 2000\n' +
+        'print_wait_ceiling_s = 3600\n' +
+        'read_max_bytes = 30000\n',
     );
 
     const r = await migrateConfigStep({ sourceHome: src, targetHome: tgt });
 
     expect(r.migrated).toBe(true);
     const cfg = await readFile(join(tgt, 'config.toml'), 'utf-8');
+    expect(cfg).toContain('[experimental]');
+    expect(cfg).toContain('micro_compaction = false');
+    expect(cfg).not.toContain('unknown_flag');
     expect(cfg).toContain('[loop_control]');
     expect(cfg).toContain('max_retries_per_step = 2');
+    expect(cfg).toContain('reserved_context_size = 60000');
     expect(cfg).not.toContain('max_steps_per_turn');
+    expect(cfg).not.toContain('max_steps_per_run');
+    expect(cfg).not.toContain('max_ralph_iterations');
+    expect(cfg).not.toContain('compaction_trigger_ratio');
+    expect(cfg).toContain('[background]');
+    expect(cfg).toContain('max_running_tasks = 8');
+    expect(cfg).toContain('keep_alive_on_exit = true');
+    expect(cfg).not.toContain('kill_grace_period_ms');
+    expect(cfg).not.toContain('print_wait_ceiling_s');
+    expect(cfg).not.toContain('read_max_bytes');
+    expect(cfg).not.toContain('plan_mode = true');
+    expect(cfg).not.toContain('yolo = true');
   });
 
   it('maps default_yolo to default_permission_mode = "yolo"', async () => {


### PR DESCRIPTION
## Related Issue

No linked issue.

## Problem

Legacy migration copied obsolete config values into the new config, which could preserve prior limits or carry fields that are no longer useful after upgrading.

## What changed

- Filter obsolete legacy `loop_control` fields during config migration.
- Filter obsolete legacy `background` fields and unsupported nested background values during config migration.
- Stop migrating top-level `plan_mode` and `yolo`.
- Stop migrating unregistered experimental flags.
- Preserve supported migrated settings such as `loop_control.max_retries_per_step`, `loop_control.reserved_context_size`, `background.max_running_tasks`, `background.keep_alive_on_exit`, and registered experimental flags.
- Add regression coverage for obsolete migration fields.
- Update the changeset for `@moonshot-ai/kimi-code` and `@moonshot-ai/migration-legacy`.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.

## Verification

- `pnpm --filter @moonshot-ai/migration-legacy test -- config.test.ts`
- `pnpm --filter @moonshot-ai/migration-legacy typecheck`
- `pnpm exec oxlint --type-aware packages/migration-legacy/src/steps/config.ts packages/migration-legacy/test/steps/config.test.ts`
