### PR TITLE
feat: add default_swarm_mode and subagent_model config options

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+# build.sh — kimi-code 빌드 및 배포 자동화
+set -e
+cd "$HOME/.kimi-code/src/kimi-code"
+
+# Node.js 24.x 활성화
+export NVM_DIR="$HOME/.nvm"
+[ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh"
+nvm use 24
+
+# 의존성 설치 및 빌드
+echo "📦 Installing dependencies..."
+pnpm install
+
+echo "🔨 Building..."
+pnpm build
+
+# 빌드 산출물 확인
+echo "🚀 Verifying build output..."
+if [ ! -f apps/kimi-code/dist/main.mjs ]; then
+  echo "❌ Build failed! main.mjs not found."
+  exit 1
+fi
+
+# wrapper가 이미 올바른 경로指向하는지 확인
+if [ ! -x "$HOME/.kimi-code/bin/kimi" ]; then
+  echo "⚠️  Wrapper not found, creating..."
+  cat > "$HOME/.kimi-code/bin/kimi" << 'WRAPPER'
+#!/bin/bash
+cd "$HOME/.kimi-code/src/kimi-code/apps/kimi-code"
+exec node dist/main.mjs "$@"
+WRAPPER
+  chmod +x "$HOME/.kimi-code/bin/kimi"
+fi
+
+# 빌드 검증
+echo "✅ Build complete. Testing..."
+"$HOME/.kimi-code/bin/kimi" --version

--- a/packages/agent-core/src/agent/swarm/index.ts
+++ b/packages/agent-core/src/agent/swarm/index.ts
@@ -13,7 +13,11 @@ export type SwarmModeTrigger = 'manual' | 'task' | 'tool';
 export class SwarmMode {
   protected active: SwarmModeTrigger | null = null;
 
-  constructor(protected readonly agent: Agent) {}
+  constructor(protected readonly agent: Agent) {
+    if (agent.kimiConfig?.defaultSwarmMode === true) {
+      this.active = 'manual';
+    }
+  }
 
   enter(trigger: SwarmModeTrigger): void {
     if (this.active !== null) return;

--- a/packages/agent-core/src/config/schema.ts
+++ b/packages/agent-core/src/config/schema.ts
@@ -219,6 +219,7 @@ export const KimiConfigSchema = z.object({
   loopControl: LoopControlSchema.optional(),
   background: BackgroundConfigSchema.optional(),
   defaultSwarmMode: z.boolean().optional(),
+  subagentModel: z.string().optional(),
   experimental: ExperimentalConfigSchema.optional(),
   telemetry: z.boolean().optional(),
   raw: z.record(z.string(), z.unknown()).optional(),
@@ -259,6 +260,7 @@ export const KimiConfigPatchSchema = z
     loopControl: LoopControlPatchSchema.optional(),
     background: BackgroundConfigPatchSchema.optional(),
     defaultSwarmMode: z.boolean().optional(),
+    subagentModel: z.string().optional(),
     experimental: ExperimentalConfigPatchSchema.optional(),
     telemetry: z.boolean().optional(),
   })

--- a/packages/agent-core/src/config/schema.ts
+++ b/packages/agent-core/src/config/schema.ts
@@ -218,6 +218,7 @@ export const KimiConfigSchema = z.object({
   extraSkillDirs: z.array(z.string()).optional(),
   loopControl: LoopControlSchema.optional(),
   background: BackgroundConfigSchema.optional(),
+  defaultSwarmMode: z.boolean().optional(),
   experimental: ExperimentalConfigSchema.optional(),
   telemetry: z.boolean().optional(),
   raw: z.record(z.string(), z.unknown()).optional(),
@@ -257,6 +258,7 @@ export const KimiConfigPatchSchema = z
     extraSkillDirs: z.array(z.string()).optional(),
     loopControl: LoopControlPatchSchema.optional(),
     background: BackgroundConfigPatchSchema.optional(),
+    defaultSwarmMode: z.boolean().optional(),
     experimental: ExperimentalConfigPatchSchema.optional(),
     telemetry: z.boolean().optional(),
   })

--- a/packages/agent-core/src/config/toml.ts
+++ b/packages/agent-core/src/config/toml.ts
@@ -470,6 +470,7 @@ export function configToTomlData(config: KimiConfig): Record<string, unknown> {
     'defaultThinking',
     'defaultPermissionMode',
     'defaultPlanMode',
+    'defaultSwarmMode',
     'mergeAllAvailableSkills',
     'extraSkillDirs',
     'telemetry',

--- a/packages/agent-core/src/config/toml.ts
+++ b/packages/agent-core/src/config/toml.ts
@@ -471,6 +471,7 @@ export function configToTomlData(config: KimiConfig): Record<string, unknown> {
     'defaultPermissionMode',
     'defaultPlanMode',
     'defaultSwarmMode',
+    'subagentModel',
     'mergeAllAvailableSkills',
     'extraSkillDirs',
     'telemetry',

--- a/packages/agent-core/src/session/subagent-host.ts
+++ b/packages/agent-core/src/session/subagent-host.ts
@@ -110,6 +110,10 @@ export class SessionSubagentHost {
     private readonly ownerAgentId: string,
   ) {}
 
+  private resolveSubagentModel(parent: Agent): string | undefined {
+    return this.session.options.config?.subagentModel ?? parent.config.modelAlias;
+  }
+
   async spawn(options: SpawnSubagentOptions): Promise<SubagentHandle> {
     options.signal.throwIfAborted();
 
@@ -143,7 +147,7 @@ export class SessionSubagentHost {
     const completion = this.runWithActiveChild(agentId, options, async (runOptions) => {
       this.emitSubagentSpawned(parent, agentId, profileName, runOptions);
       try {
-        child.config.update({ modelAlias: parent.config.modelAlias });
+        child.config.update({ modelAlias: this.resolveSubagentModel(parent) });
         return await this.runPromptTurn(parent, agentId, child, profileName, runOptions);
       } catch (error) {
         this.emitSubagentFailed(parent, agentId, runOptions, error);
@@ -159,7 +163,7 @@ export class SessionSubagentHost {
     const completion = this.runWithActiveChild(agentId, options, async (runOptions) => {
       try {
         runOptions.signal.throwIfAborted();
-        child.config.update({ modelAlias: parent.config.modelAlias });
+        child.config.update({ modelAlias: this.resolveSubagentModel(parent) });
         this.emitSubagentStarted(parent, agentId);
         const turnId = child.turn.retry('agent-host');
         if (turnId === null) {
@@ -220,7 +224,7 @@ export class SessionSubagentHost {
     );
 
     child.config.update({
-      modelAlias: parent.config.modelAlias,
+      modelAlias: this.resolveSubagentModel(parent),
       thinkingLevel: parent.config.thinkingLevel,
       systemPrompt: parent.config.systemPrompt,
     });
@@ -355,10 +359,9 @@ export class SessionSubagentHost {
     child: Agent,
     profile: ResolvedAgentProfile,
   ): Promise<void> {
-    // A subagent always inherits the parent agent's model.
     child.config.update({
       cwd: parent.config.cwd,
-      modelAlias: parent.config.modelAlias,
+      modelAlias: this.resolveSubagentModel(parent),
       thinkingLevel: parent.config.thinkingLevel,
     });
 


### PR DESCRIPTION
## Changes

This PR adds two new configuration options to `config.toml`:

### 1. `default_swarm_mode` 
Enables swarm mode by default, allowing automatic parallel subagent delegation.

```toml
default_swarm_mode = true
```

### 2. `subagent_model`
Allows overriding the model used by subagents independently from the parent agent's model.

```toml
default_model = "mimo-v2.5-pro"  # Parent agent uses pro
subagent_model = "mimo-v2.5"     # Subagents use non-pro
```

## Motivation

- **Swarm mode**: Reduces friction for users who primarily use parallel subagent workflows
- **Subagent model**: Enables cost optimization by using a lighter model for subagents while keeping a more capable model for the main agent

## Implementation

- Added `defaultSwarmMode` and `subagentModel` to `KimiConfigSchema`
- Added TOML serialization support in `config/toml.ts`
- Added `resolveSubagentModel()` method to `SessionSubagentHost` that checks `config.subagentModel` first, falling back to parent's model
- Updated all 4 subagent spawn/configure sites to use the new resolution logic