### PR TITLE
refactor: resolve model capabilities via a static table lookup

### DIFF
--- a/.changeset/static-capability-lookup.md
+++ b/.changeset/static-capability-lookup.md
@@ -1,0 +1,7 @@
+---
+"@moonshot-ai/kosong": patch
+"@moonshot-ai/agent-core": patch
+"@moonshot-ai/kimi-code": patch
+---
+
+Resolve model capabilities through a static lookup instead of instantiating a temporary provider.

--- a/packages/agent-core/src/session/provider-manager.ts
+++ b/packages/agent-core/src/session/provider-manager.ts
@@ -1,6 +1,6 @@
 import type { Logger } from '#/logging/types';
 import type { ProviderConfig as KosongProviderConfig, ModelCapability, ProviderRequestAuth } from '@moonshot-ai/kosong';
-import { APIStatusError, createProvider, UNKNOWN_CAPABILITY } from '@moonshot-ai/kosong';
+import { APIStatusError, getModelCapability, UNKNOWN_CAPABILITY } from '@moonshot-ai/kosong';
 import type { KimiConfig, ModelAlias, OAuthRef, ProviderConfig } from '../config';
 import { ErrorCodes, isKimiError, KimiError } from '../errors';
 
@@ -201,8 +201,7 @@ function resolveModelCapabilities(
   provider: KosongProviderConfig,
 ): ModelCapability {
   const declared = new Set((alias.capabilities ?? []).map((c) => c.trim().toLowerCase()));
-  const probe = createProvider(providerForCapabilityProbe(provider));
-  const detected = probe.getCapability?.(provider.model) ?? UNKNOWN_CAPABILITY;
+  const detected = getModelCapability(provider.type, provider.model);
 
   return {
     image_in: declared.has('image_in') || detected.image_in,
@@ -295,14 +294,6 @@ function defaultHeadersField(
 ): { defaultHeaders?: Record<string, string> } {
   if (headers === undefined || Object.keys(headers).length === 0) return {};
   return { defaultHeaders: { ...headers } };
-}
-
-function providerForCapabilityProbe(provider: KosongProviderConfig): KosongProviderConfig {
-  const apiKey = provider.apiKey && provider.apiKey.length > 0 ? provider.apiKey : 'capability-probe';
-  if (provider.type === 'vertexai') {
-    return { ...provider, vertexai: false, project: undefined, location: undefined, apiKey };
-  }
-  return { ...provider, apiKey };
 }
 
 function providerApiKey(provider: ProviderConfig): string | undefined {

--- a/packages/kosong/src/capability.ts
+++ b/packages/kosong/src/capability.ts
@@ -1,9 +1,9 @@
 /**
- * Declared capabilities for a specific model exposed by a {@link ChatProvider}.
+ * Declared capabilities for a specific model.
  *
- * Providers return one of these from {@link ChatProvider.getCapability} so
- * callers can gate requests against modalities the model does not accept
- * without dispatching the request and watching it fail upstream.
+ * `getModelCapability(wire, model)` returns one of these so callers can gate
+ * requests against modalities the model does not accept without dispatching
+ * the request and watching it fail upstream.
  *
  * `max_context_tokens: 0` means "unknown"; callers that do not gate on
  * context length can ignore the field.

--- a/packages/kosong/src/index.ts
+++ b/packages/kosong/src/index.ts
@@ -25,7 +25,7 @@ export type {
 
 // Provider interfaces
 export * from './provider';
-export { createProvider } from './providers';
+export { createProvider, getModelCapability } from './providers';
 export type { ProviderConfig, ProviderType } from './providers';
 // Kimi provider: exported so callers can narrow a `ChatProvider` to the Kimi
 // backend (instanceof) and apply Kimi-specific request params (generation

--- a/packages/kosong/src/provider.ts
+++ b/packages/kosong/src/provider.ts
@@ -1,4 +1,3 @@
-import type { ModelCapability } from './capability';
 import type { Message, StreamedMessagePart, VideoURLPart } from './message';
 import type { Tool } from './tool';
 import type { TokenUsage } from './usage';
@@ -163,18 +162,4 @@ export interface ChatProvider {
   withMaxCompletionTokens?(maxCompletionTokens: number): ChatProvider;
   /** Upload a video and return a content part that can be sent to this provider. */
   uploadVideo?(input: string | VideoUploadInput, options?: GenerateOptions): Promise<VideoURLPart>;
-  /**
-   * Return declared capabilities for `model` (defaults to `modelName`).
-   *
-   * Unknown / uncatalogued models return {@link UNKNOWN_CAPABILITY} rather
-   * than throwing, so capability checks stay non-fatal and operators can
-   * point at private/custom deployments without crashing.
-   *
-   * Optional on the interface so pre-existing test mocks (which predate
-   * the capability matrix) still structurally satisfy `ChatProvider`
-   * without churn. Callers that gate on modalities should fall back to
-   * {@link UNKNOWN_CAPABILITY} when a provider does not expose it.
-   */
-  getCapability?(model?: string): ModelCapability;
-  getContextSizeLimit?(): number | undefined;
 }

--- a/packages/kosong/src/providers/anthropic.ts
+++ b/packages/kosong/src/providers/anthropic.ts
@@ -1,4 +1,3 @@
-import type { ModelCapability } from '#/capability';
 import {
   APIConnectionError,
   APITimeoutError,
@@ -38,7 +37,6 @@ import type {
   ToolUseBlockParam,
 } from '@anthropic-ai/sdk/resources/messages/messages.js';
 
-import { getAnthropicModelCapability } from './capability-registry';
 import {
   mergeRequestHeaders,
   requireProviderApiKey,
@@ -929,10 +927,6 @@ export class AnthropicChatProvider implements ChatProvider {
       model: this._model,
       ...this._generationKwargs,
     };
-  }
-
-  getCapability(model?: string): ModelCapability {
-    return getAnthropicModelCapability(model ?? this._model);
   }
 
   async generate(

--- a/packages/kosong/src/providers/google-genai.ts
+++ b/packages/kosong/src/providers/google-genai.ts
@@ -1,4 +1,3 @@
-import type { ModelCapability } from '#/capability';
 import {
   APIConnectionError,
   APITimeoutError,
@@ -18,7 +17,6 @@ import type { Tool } from '#/tool';
 import type { TokenUsage } from '#/usage';
 import { ApiError as GoogleApiError, GoogleGenAI as GenAIClient } from '@google/genai';
 
-import { getGoogleGenAIModelCapability } from './capability-registry';
 import { requireProviderApiKey, resolveAuthBackedClient } from './request-auth';
 
 /**
@@ -747,10 +745,6 @@ export class GoogleGenAIChatProvider implements ChatProvider {
       model: this._model,
       ...this._generationKwargs,
     };
-  }
-
-  getCapability(model?: string): ModelCapability {
-    return getGoogleGenAIModelCapability(model ?? this._model);
   }
 
   async generate(

--- a/packages/kosong/src/providers/index.ts
+++ b/packages/kosong/src/providers/index.ts
@@ -1,5 +1,12 @@
+import { UNKNOWN_CAPABILITY, type ModelCapability } from '../capability';
 import type { ChatProvider } from '../provider';
 import { AnthropicChatProvider, type AnthropicOptions } from './anthropic';
+import {
+  getAnthropicModelCapability,
+  getGoogleGenAIModelCapability,
+  getOpenAILegacyModelCapability,
+  getOpenAIResponsesModelCapability,
+} from './capability-registry';
 import { GoogleGenAIChatProvider, type GoogleGenAIOptions } from './google-genai';
 import { KimiChatProvider, type KimiOptions } from './kimi';
 import { OpenAILegacyChatProvider, type OpenAILegacyOptions } from './openai-legacy';
@@ -32,6 +39,35 @@ export function createProvider(config: ProviderConfig): ChatProvider {
     default: {
       const exhaustive: never = config;
       throw new Error(`Unknown provider type: ${String(exhaustive)}`);
+    }
+  }
+}
+
+/**
+ * Look up the declared {@link ModelCapability} for a `(wire, model)` pair.
+ *
+ * This is a pure static table lookup — it does not instantiate a provider.
+ * Unknown / uncatalogued models (and the Kimi wire, whose capabilities come
+ * from the host's catalog/config rather than the model name) return
+ * {@link UNKNOWN_CAPABILITY} so capability checks stay non-fatal.
+ */
+export function getModelCapability(wire: ProviderType, modelName: string): ModelCapability {
+  switch (wire) {
+    case 'anthropic':
+      return getAnthropicModelCapability(modelName);
+    case 'openai':
+      return getOpenAILegacyModelCapability(modelName);
+    case 'openai_responses':
+      return getOpenAIResponsesModelCapability(modelName);
+    case 'google-genai':
+    case 'vertexai':
+      return getGoogleGenAIModelCapability(modelName);
+    case 'kimi':
+      return UNKNOWN_CAPABILITY;
+    default: {
+      const exhaustive: never = wire;
+      void exhaustive;
+      return UNKNOWN_CAPABILITY;
     }
   }
 }

--- a/packages/kosong/src/providers/kimi.ts
+++ b/packages/kosong/src/providers/kimi.ts
@@ -1,4 +1,3 @@
-import { UNKNOWN_CAPABILITY, type ModelCapability } from '#/capability';
 import { normalizeKimiToolSchema } from './kimi-schema';
 import type { ContentPart, Message, StreamedMessagePart, ToolCall } from '#/message';
 import type {
@@ -496,10 +495,6 @@ export class KimiChatProvider implements ChatProvider {
     } catch (error: unknown) {
       throw convertOpenAIError(error);
     }
-  }
-
-  getCapability(_model?: string): ModelCapability {
-    return UNKNOWN_CAPABILITY;
   }
 
   withThinking(effort: ThinkingEffort): KimiChatProvider {

--- a/packages/kosong/src/providers/openai-legacy.ts
+++ b/packages/kosong/src/providers/openai-legacy.ts
@@ -1,4 +1,3 @@
-import type { ModelCapability } from '#/capability';
 import type { ContentPart, Message, StreamedMessagePart, ToolCall } from '#/message';
 import type {
   ChatProvider,
@@ -12,7 +11,6 @@ import type { Tool } from '#/tool';
 import type { TokenUsage } from '#/usage';
 import OpenAI from 'openai';
 
-import { getOpenAILegacyModelCapability } from './capability-registry';
 import {
   convertContentPart,
   convertOpenAIError,
@@ -492,10 +490,6 @@ export class OpenAILegacyChatProvider implements ChatProvider {
       baseUrl: this._baseUrl,
       ...normalizeGenerationKwargs(this._model, this._generationKwargs),
     };
-  }
-
-  getCapability(model?: string): ModelCapability {
-    return getOpenAILegacyModelCapability(model ?? this._model);
   }
 
   async generate(

--- a/packages/kosong/src/providers/openai-responses.ts
+++ b/packages/kosong/src/providers/openai-responses.ts
@@ -1,4 +1,3 @@
-import type { ModelCapability } from '#/capability';
 import {
   APIContextOverflowError,
   APIProviderRateLimitError,
@@ -19,10 +18,7 @@ import type { Tool } from '#/tool';
 import type { TokenUsage } from '#/usage';
 import OpenAI from 'openai';
 
-import {
-  getOpenAIResponsesModelCapability,
-  usesOpenAIResponsesDeveloperRole,
-} from './capability-registry';
+import { usesOpenAIResponsesDeveloperRole } from './capability-registry';
 import {
   convertOpenAIError,
   isMediaPart,
@@ -1027,10 +1023,6 @@ export class OpenAIResponsesChatProvider implements ChatProvider {
       baseUrl: this._baseUrl,
       ...this._generationKwargs,
     };
-  }
-
-  getCapability(model?: string): ModelCapability {
-    return getOpenAIResponsesModelCapability(model ?? this._model);
   }
 
   async generate(

--- a/packages/kosong/test/capability-providers.test.ts
+++ b/packages/kosong/test/capability-providers.test.ts
@@ -1,10 +1,10 @@
 /**
- * Per-provider `getCapability(model?)` table tests.
+ * `getModelCapability(wire, model)` table tests.
  *
- * For every provider:
+ * For every wire:
  *   - Known models return the capabilities the table declares for them.
  *   - Unknown models return UNKNOWN_CAPABILITY (no throw) so the capability
- *     gate stays non-fatal when the operator uses a model the provider has
+ *     gate stays non-fatal when the operator uses a model the table has
  *     not catalogued yet.
  *
  * Assertions stick to individual fields (image_in / video_in / …) rather
@@ -13,17 +13,10 @@
  */
 
 import { UNKNOWN_CAPABILITY } from '#/capability';
-import { AnthropicChatProvider } from '#/providers/anthropic';
-import { GoogleGenAIChatProvider } from '#/providers/google-genai';
-import { KimiChatProvider } from '#/providers/kimi';
-import { OpenAILegacyChatProvider } from '#/providers/openai-legacy';
-import { OpenAIResponsesChatProvider } from '#/providers/openai-responses';
+import { getModelCapability } from '#/providers/index';
 import { describe, expect, it } from 'vitest';
-describe('KimiChatProvider.getCapability', () => {
-  function make(model: string): KimiChatProvider {
-    return new KimiChatProvider({ model, apiKey: 'test-key' });
-  }
 
+describe('getModelCapability: kimi', () => {
   it('does not infer capabilities from Kimi model names', () => {
     for (const model of [
       'kimi-for-coding',
@@ -32,27 +25,18 @@ describe('KimiChatProvider.getCapability', () => {
       'kimi-k2.5',
       'kimi-thinking-preview',
     ]) {
-      expect(make(model).getCapability()).toEqual(UNKNOWN_CAPABILITY);
+      expect(getModelCapability('kimi', model)).toEqual(UNKNOWN_CAPABILITY);
     }
   });
 
-  it('explicit model arg overrides this.modelName', () => {
-    const provider = make('kimi-k2-turbo-preview');
-    expect(provider.getCapability('kimi-for-coding')).toEqual(UNKNOWN_CAPABILITY);
-  });
-
   it('unknown Kimi model → UNKNOWN_CAPABILITY (no throw)', () => {
-    const cap = make('some-fake-model').getCapability();
-    expect(cap).toEqual(UNKNOWN_CAPABILITY);
+    expect(getModelCapability('kimi', 'some-fake-model')).toEqual(UNKNOWN_CAPABILITY);
   });
 });
-describe('GoogleGenAIChatProvider.getCapability', () => {
-  function make(model: string): GoogleGenAIChatProvider {
-    return new GoogleGenAIChatProvider({ model, apiKey: 'test-key' });
-  }
 
+describe('getModelCapability: google-genai', () => {
   it('gemini-1.5-pro → image_in + video_in + audio_in + tool_use', () => {
-    const cap = make('gemini-1.5-pro').getCapability();
+    const cap = getModelCapability('google-genai', 'gemini-1.5-pro');
     expect(cap.image_in).toBe(true);
     expect(cap.video_in).toBe(true);
     expect(cap.audio_in).toBe(true);
@@ -60,7 +44,7 @@ describe('GoogleGenAIChatProvider.getCapability', () => {
   });
 
   it('gemini-1.5-flash → image_in + video_in + audio_in + tool_use', () => {
-    const cap = make('gemini-1.5-flash').getCapability();
+    const cap = getModelCapability('google-genai', 'gemini-1.5-flash');
     expect(cap.image_in).toBe(true);
     expect(cap.video_in).toBe(true);
     expect(cap.audio_in).toBe(true);
@@ -68,7 +52,7 @@ describe('GoogleGenAIChatProvider.getCapability', () => {
   });
 
   it('gemini-2.0-flash → image_in + video_in + audio_in + tool_use', () => {
-    const cap = make('gemini-2.0-flash').getCapability();
+    const cap = getModelCapability('google-genai', 'gemini-2.0-flash');
     expect(cap.image_in).toBe(true);
     expect(cap.video_in).toBe(true);
     expect(cap.audio_in).toBe(true);
@@ -76,22 +60,24 @@ describe('GoogleGenAIChatProvider.getCapability', () => {
   });
 
   it('unknown Gemini model → UNKNOWN_CAPABILITY (no throw)', () => {
-    const cap = make('gemini-not-real-xyz').getCapability();
-    expect(cap).toEqual(UNKNOWN_CAPABILITY);
+    expect(getModelCapability('google-genai', 'gemini-not-real-xyz')).toEqual(UNKNOWN_CAPABILITY);
   });
 
   it('non-gemini model name → UNKNOWN_CAPABILITY', () => {
-    const cap = make('claude-3-5-sonnet').getCapability();
-    expect(cap).toEqual(UNKNOWN_CAPABILITY);
+    expect(getModelCapability('google-genai', 'claude-3-5-sonnet')).toEqual(UNKNOWN_CAPABILITY);
+  });
+
+  it('vertexai wire shares the gemini table', () => {
+    const cap = getModelCapability('vertexai', 'gemini-1.5-pro');
+    expect(cap.image_in).toBe(true);
+    expect(cap.video_in).toBe(true);
+    expect(cap.tool_use).toBe(true);
   });
 });
-describe('AnthropicChatProvider.getCapability', () => {
-  function make(model: string): AnthropicChatProvider {
-    return new AnthropicChatProvider({ model, apiKey: 'test-key', stream: false });
-  }
 
+describe('getModelCapability: anthropic', () => {
   it('claude-3-5-sonnet → image_in + tool_use, audio_in=false', () => {
-    const cap = make('claude-3-5-sonnet').getCapability();
+    const cap = getModelCapability('anthropic', 'claude-3-5-sonnet');
     expect(cap.image_in).toBe(true);
     expect(cap.tool_use).toBe(true);
     expect(cap.audio_in).toBe(false);
@@ -100,7 +86,7 @@ describe('AnthropicChatProvider.getCapability', () => {
   it('claude-3-haiku → image_in + tool_use, audio_in=false, thinking=false', () => {
     // Claude 3 Haiku supports vision (all Claude 3.x share vision support);
     // Anthropic has no audio models; thinking is a Claude 4 feature.
-    const cap = make('claude-3-haiku').getCapability();
+    const cap = getModelCapability('anthropic', 'claude-3-haiku');
     expect(cap.image_in).toBe(true);
     expect(cap.tool_use).toBe(true);
     expect(cap.audio_in).toBe(false);
@@ -108,14 +94,14 @@ describe('AnthropicChatProvider.getCapability', () => {
   });
 
   it('claude-opus-4 → image_in + thinking + tool_use', () => {
-    const cap = make('claude-opus-4').getCapability();
+    const cap = getModelCapability('anthropic', 'claude-opus-4');
     expect(cap.image_in).toBe(true);
     expect(cap.thinking).toBe(true);
     expect(cap.tool_use).toBe(true);
   });
 
   it('claude-fable-5 → image_in + thinking + tool_use', () => {
-    const cap = make('claude-fable-5').getCapability();
+    const cap = getModelCapability('anthropic', 'claude-fable-5');
     expect(cap.image_in).toBe(true);
     expect(cap.thinking).toBe(true);
     expect(cap.tool_use).toBe(true);
@@ -125,67 +111,58 @@ describe('AnthropicChatProvider.getCapability', () => {
     // Sanity: Anthropic has no audio-input models today. If one ships later
     // and this fails, update the table — but make it a conscious decision.
     for (const m of ['claude-3-5-sonnet', 'claude-3-haiku', 'claude-opus-4']) {
-      expect(make(m).getCapability().audio_in).toBe(false);
+      expect(getModelCapability('anthropic', m).audio_in).toBe(false);
     }
   });
 
   it('unknown Anthropic model → UNKNOWN_CAPABILITY', () => {
-    const cap = make('claude-not-real').getCapability();
-    expect(cap).toEqual(UNKNOWN_CAPABILITY);
+    expect(getModelCapability('anthropic', 'claude-not-real')).toEqual(UNKNOWN_CAPABILITY);
   });
 });
-describe('OpenAILegacyChatProvider.getCapability', () => {
-  function make(model: string): OpenAILegacyChatProvider {
-    return new OpenAILegacyChatProvider({ model, apiKey: 'test-key' });
-  }
 
+describe('getModelCapability: openai', () => {
   it('gpt-4o → image_in + tool_use', () => {
-    const cap = make('gpt-4o').getCapability();
+    const cap = getModelCapability('openai', 'gpt-4o');
     expect(cap.image_in).toBe(true);
     expect(cap.tool_use).toBe(true);
   });
 
   it('gpt-3.5-turbo → image_in=false, tool_use=true', () => {
-    const cap = make('gpt-3.5-turbo').getCapability();
+    const cap = getModelCapability('openai', 'gpt-3.5-turbo');
     expect(cap.image_in).toBe(false);
     expect(cap.tool_use).toBe(true);
   });
 
   it('o1 → thinking=true, tool_use=true', () => {
-    const cap = make('o1').getCapability();
+    const cap = getModelCapability('openai', 'o1');
     expect(cap.thinking).toBe(true);
     expect(cap.tool_use).toBe(true);
   });
 
   it('unknown OpenAI-legacy model → UNKNOWN_CAPABILITY', () => {
-    const cap = make('gpt-mystery').getCapability();
-    expect(cap).toEqual(UNKNOWN_CAPABILITY);
+    expect(getModelCapability('openai', 'gpt-mystery')).toEqual(UNKNOWN_CAPABILITY);
   });
 });
-describe('OpenAIResponsesChatProvider.getCapability', () => {
-  function make(model: string): OpenAIResponsesChatProvider {
-    return new OpenAIResponsesChatProvider({ model, apiKey: 'test-key' });
-  }
 
+describe('getModelCapability: openai_responses', () => {
   it('gpt-4.1 → image_in + tool_use (Responses flagship)', () => {
-    const cap = make('gpt-4.1').getCapability();
+    const cap = getModelCapability('openai_responses', 'gpt-4.1');
     expect(cap.image_in).toBe(true);
     expect(cap.tool_use).toBe(true);
   });
 
   it('o1 → thinking=true, tool_use=true', () => {
-    const cap = make('o1').getCapability();
+    const cap = getModelCapability('openai_responses', 'o1');
     expect(cap.thinking).toBe(true);
     expect(cap.tool_use).toBe(true);
   });
 
   it('o3-mini → thinking=true', () => {
-    const cap = make('o3-mini').getCapability();
+    const cap = getModelCapability('openai_responses', 'o3-mini');
     expect(cap.thinking).toBe(true);
   });
 
   it('unknown Responses model → UNKNOWN_CAPABILITY', () => {
-    const cap = make('gpt-mystery').getCapability();
-    expect(cap).toEqual(UNKNOWN_CAPABILITY);
+    expect(getModelCapability('openai_responses', 'gpt-mystery')).toEqual(UNKNOWN_CAPABILITY);
   });
 });

--- a/packages/kosong/test/capability.test.ts
+++ b/packages/kosong/test/capability.test.ts
@@ -1,6 +1,6 @@
 /**
  * `ModelCapability` type and `UNKNOWN_CAPABILITY` default — pure
- * type/helper layer. Provider-specific `getCapability` tables live in
+ * type/helper layer. Per-wire `getModelCapability` tables live in
  * `capability-providers.test.ts`.
  */
 

--- a/packages/kosong/test/fixtures/echo-provider.ts
+++ b/packages/kosong/test/fixtures/echo-provider.ts
@@ -1,4 +1,3 @@
-import { UNKNOWN_CAPABILITY, type ModelCapability } from '#/capability';
 import { ChatProviderError } from '#/errors';
 import type {
   AudioURLPart,
@@ -383,10 +382,6 @@ export class EchoChatProvider implements ChatProvider {
   withThinking(_effort: ThinkingEffort): EchoChatProvider {
     return new EchoChatProvider();
   }
-
-  getCapability(_model?: string): ModelCapability {
-    return UNKNOWN_CAPABILITY;
-  }
 }
 
 // ---------------------------------------------------------------------------
@@ -432,9 +427,5 @@ export class ScriptedEchoChatProvider implements ChatProvider {
 
   withThinking(_effort: ThinkingEffort): ScriptedEchoChatProvider {
     return new ScriptedEchoChatProvider(this._scripts.slice(this._cursor));
-  }
-
-  getCapability(_model?: string): ModelCapability {
-    return UNKNOWN_CAPABILITY;
   }
 }

--- a/packages/kosong/test/fixtures/mock-provider.ts
+++ b/packages/kosong/test/fixtures/mock-provider.ts
@@ -1,4 +1,3 @@
-import { UNKNOWN_CAPABILITY, type ModelCapability } from '#/capability';
 import type { Message, StreamedMessagePart } from '#/message';
 import type {
   ChatProvider,
@@ -68,10 +67,6 @@ export class MockChatProvider implements ChatProvider {
       this._finishReason,
       this._rawFinishReason,
     );
-  }
-
-  getCapability(_model?: string): ModelCapability {
-    return UNKNOWN_CAPABILITY;
   }
 
   withThinking(_effort: ThinkingEffort): MockChatProvider {


### PR DESCRIPTION
## Related Issue

No linked issue. This is an internal refactor with no user-facing behavior change; the problem is described below.

## Problem

Model capability lookup was exposed as an optional `ChatProvider.getCapability` instance method, but the lookup is a pure `(wire, model) -> capability table` function that reads no instance state. Binding it to an instance forced model-capability resolution to construct a throwaway provider just to call the method, which in turn required forging an API key (`"capability-probe"`) and stripping Vertex AI auth fields to satisfy the constructor. The interface also declared `getContextSizeLimit`, which had no implementation or caller anywhere.

## What changed

- Add a static `getModelCapability(wire, model)` entry point in kosong that dispatches to the existing capability tables.
- Remove `ChatProvider.getCapability` / `getContextSizeLimit` and the five per-provider implementations; capability resolution now calls the static function directly, dropping the throwaway provider construction and the forged credentials.
- Behavior is unchanged: the detected capability is computed by the same tables, and the `declared || detected` merge plus `max_context_tokens` handling are untouched.

Verified: typecheck passes for kosong / agent-core / node-sdk / CLI; kosong (1088 tests) and agent-core (2570 tests) suites are green.

## Checklist

- [x] I have read the CONTRIBUTING document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.