### PR TITLE
feat(agent-core): refine system prompt context

### DIFF
--- a/.changeset/agents-prompt-context.md
+++ b/.changeset/agents-prompt-context.md
@@ -1,0 +1,6 @@
+---
+"@moonshot-ai/agent-core": patch
+"@moonshot-ai/kimi-code": patch
+---
+
+Clarify AGENTS.md prompt guidance and mark truncated instruction files.

--- a/.changeset/hidden-directory-prompt.md
+++ b/.changeset/hidden-directory-prompt.md
@@ -1,0 +1,6 @@
+---
+"@moonshot-ai/agent-core": patch
+"@moonshot-ai/kimi-code": patch
+---
+
+Collapse hidden directories in the workspace prompt and explain how to inspect them.

--- a/packages/agent-core/src/profile/context.ts
+++ b/packages/agent-core/src/profile/context.ts
@@ -16,7 +16,7 @@ export async function prepareSystemPromptContext(
   brandHome?: string,
 ): Promise<PreparedSystemPromptContext> {
   const [cwdListing, agentsMd] = await Promise.all([
-    listDirectory(kaos),
+    listDirectory(kaos, undefined, { collapseHiddenDirs: true }),
     loadAgentsMd(kaos, brandHome),
   ]);
   return { cwdListing, agentsMd };

--- a/packages/agent-core/src/profile/context.ts
+++ b/packages/agent-core/src/profile/context.ts
@@ -6,6 +6,8 @@ import { listDirectory } from '../tools/support/list-directory';
 import type { SystemPromptContext } from './types';
 
 const AGENTS_MD_MAX_BYTES = 32 * 1024;
+const AGENTS_MD_TRUNCATION_MARKER =
+  '<!-- Some AGENTS.md files were truncated or omitted to fit the 32 KB budget -->';
 const S_IFMT = 0o170000;
 const S_IFREG = 0o100000;
 
@@ -126,6 +128,7 @@ function renderAgentFiles(files: readonly AgentFile[]): string {
   if (files.length === 0) return '';
 
   let remaining = AGENTS_MD_MAX_BYTES;
+  let didTruncate = false;
   const budgeted: Array<AgentFile | undefined> = Array.from({ length: files.length });
 
   for (let i = files.length - 1; i >= 0; i--) {
@@ -138,21 +141,25 @@ function renderAgentFiles(files: readonly AgentFile[]): string {
     if (remaining <= 0) {
       budgeted[i] = { path: file.path, content: '' };
       remaining = 0;
+      didTruncate = true;
       continue;
     }
 
     let content = file.content;
     if (byteLength(content) > remaining) {
       content = truncateUtf8(content, remaining).trim();
+      didTruncate = true;
     }
     remaining -= byteLength(content);
     budgeted[i] = { path: file.path, content };
   }
 
-  return budgeted
+  const rendered = budgeted
     .filter((file): file is AgentFile => file !== undefined && file.content.length > 0)
     .map((file) => `${annotationFor(file.path)}${file.content}`)
     .join('\n\n');
+
+  return didTruncate ? `${AGENTS_MD_TRUNCATION_MARKER}\n${rendered}` : rendered;
 }
 
 function truncateUtf8(text: string, maxBytes: number): string {

--- a/packages/agent-core/src/profile/default/system.md
+++ b/packages/agent-core/src/profile/default/system.md
@@ -91,7 +91,9 @@ The directory listing of current working directory is:
 {{ KIMI_WORK_DIR_LS }}
 ```
 
-Use this as your basic understanding of the project structure. The tree only shows the first two levels; entries marked "... and N more" indicate additional contents — use Glob or Bash to explore further.
+Use this as your basic understanding of the project structure. The tree only shows the first two levels for normal directories; entries marked "... and N more" indicate additional contents. Hidden directories are shown as entries only; their contents are intentionally omitted to reduce noise.
+
+If the task requires inspecting hidden paths, use `Glob` to discover them (for example `.*`, `.github/**`, `.agents/**`, or `.git/**`), use `Read` for known non-sensitive hidden files, and use `Grep` to search hidden file contents. `Grep` searches hidden files by default but excludes VCS metadata and sensitive files such as `.env`, credential stores, and SSH keys. Use `Bash` only for raw listings like `ls -A` when a dedicated tool is not appropriate.
 {% if KIMI_ADDITIONAL_DIRS_INFO %}
 
 ## Additional Directories

--- a/packages/agent-core/src/profile/default/system.md
+++ b/packages/agent-core/src/profile/default/system.md
@@ -85,15 +85,15 @@ The current date and time in ISO format is `{{ KIMI_NOW }}`. This is only a refe
 
 The current working directory is `{{ KIMI_WORK_DIR }}`. This should be considered as the project root if you are instructed to perform tasks on the project. Every file system operation will be relative to the working directory if you do not explicitly specify the absolute path. Tools may require absolute paths for some parameters, IF SO, YOU MUST use absolute paths for these parameters.
 
+Use this as your basic understanding of the project structure. The tree only shows the first two levels for normal directories; entries marked "... and N more" indicate additional contents. Hidden directories are shown as entries only; their contents are intentionally omitted to reduce noise.
+
+If the task requires inspecting hidden paths, use `Glob` to discover them (for example `.*`, `.github/**`, `.agents/**`, or `.git/**`), use `Read` for known non-sensitive hidden files, and use `Grep` to search hidden file contents. `Grep` searches hidden files by default but excludes VCS metadata and sensitive files such as `.env`, credential stores, and SSH keys. Use `Bash` only for raw listings like `ls -A` when a dedicated tool is not appropriate.
+
 The directory listing of current working directory is:
 
 ```
 {{ KIMI_WORK_DIR_LS }}
 ```
-
-Use this as your basic understanding of the project structure. The tree only shows the first two levels for normal directories; entries marked "... and N more" indicate additional contents. Hidden directories are shown as entries only; their contents are intentionally omitted to reduce noise.
-
-If the task requires inspecting hidden paths, use `Glob` to discover them (for example `.*`, `.github/**`, `.agents/**`, or `.git/**`), use `Read` for known non-sensitive hidden files, and use `Grep` to search hidden file contents. `Grep` searches hidden files by default but excludes VCS metadata and sensitive files such as `.env`, credential stores, and SSH keys. Use `Bash` only for raw listings like `ls -A` when a dedicated tool is not appropriate.
 {% if KIMI_ADDITIONAL_DIRS_INFO %}
 
 ## Additional Directories
@@ -105,29 +105,17 @@ The following directories have been added to the workspace. You can read, write,
 
 # Project Information
 
-Markdown files named `AGENTS.md` usually contain the background, structure, coding styles, user preferences and other relevant information about the project. You should use this information to understand the project and the user's preferences. `AGENTS.md` files may exist at different locations in the project, but typically there is one in the project root.
+Markdown files named `AGENTS.md` contain agent-specific instructions such as project structure, build commands, coding style, testing expectations, and user preferences. `README.md` files are still useful for human-facing project context; `AGENTS.md` files are the focused instruction source for coding agents.
 
-> Why `AGENTS.md`?
->
-> `README.md` files are for humans: quick starts, project descriptions, and contribution guidelines. `AGENTS.md` complements this by containing the extra, sometimes detailed context coding agents need: build steps, tests, and conventions that might clutter a README or aren’t relevant to human contributors.
->
-> We intentionally kept it separate to:
->
-> - Give agents a clear, predictable place for instructions.
-> - Keep `README`s concise and focused on human contributors.
-> - Provide precise, agent-focused guidance that complements existing `README` and docs.
+`AGENTS.md` files can appear at any level of the project tree, including inside `.kimi-code/` directories. When multiple `AGENTS.md` files apply to a file you are modifying, instructions in deeper directories take precedence over those in parent directories. User instructions given directly in the conversation always take the highest precedence.
 
-The `AGENTS.md` instructions (merged from all applicable directories):
+When working on files in subdirectories, check whether those directories contain their own `AGENTS.md` with more specific guidance. You may also check `README`/`README.md` files for more information about the project. If you modified any files, styles, structures, configurations, workflows, or other conventions mentioned in `AGENTS.md` files, update the corresponding `AGENTS.md` files to keep them current.
 
-`````````
+The applicable `AGENTS.md` instructions are:
+
+```````
 {{ KIMI_AGENTS_MD }}
-`````````
-
-`AGENTS.md` files can appear at any level of the project directory tree, including inside `.kimi-code/` directories. Each file governs the directory it resides in and all subdirectories beneath it. When multiple `AGENTS.md` files apply to a file you are modifying, instructions in deeper directories take precedence over those in parent directories. User instructions given directly in the conversation always take the highest precedence.
-
-When working on files in subdirectories, always check whether those directories contain their own `AGENTS.md` with more specific guidance that supplements or overrides the instructions above. You may also check `README`/`README.md` files for more information about the project.
-
-If you modified any files/styles/structures/configurations/workflows/... mentioned in `AGENTS.md` files, you MUST update the corresponding `AGENTS.md` files to keep them up-to-date.
+```````
 
 # Skills
 
@@ -142,17 +130,17 @@ Skills are modular extensions that provide:
 - Tool integrations: Pre-configured tool chains for specific operations
 - Reference material: Documentation, templates, and examples
 
-## Available skills
-
-Skills are grouped by scope (`Project`, `User`, `Extra`, `Built-in`) so you can tell where each came from. When the user refers to "the skill in this project" or "the user-scope skill", use the scope heading to disambiguate. When multiple scopes define a skill with the same name, the more specific scope takes precedence: **Project overrides User overrides Extra overrides Built-in**.
-
-{{ KIMI_SKILLS }}
-
 ## How to use skills
 
 Identify the skills that are likely to be useful for the tasks you are currently working on, read the skill file for detailed instructions, guidelines, scripts and more.
 
 Only read skill details when needed to conserve the context window.
+
+## Available skills
+
+Skills are grouped by scope (`Project`, `User`, `Extra`, `Built-in`) so you can tell where each came from. When the user refers to "the skill in this project" or "the user-scope skill", use the scope heading to disambiguate. When multiple scopes define a skill with the same name, the more specific scope takes precedence: **Project overrides User overrides Extra overrides Built-in**.
+
+{{ KIMI_SKILLS }}
 
 # Ultimate Reminders
 

--- a/packages/agent-core/src/tools/support/list-directory.ts
+++ b/packages/agent-core/src/tools/support/list-directory.ts
@@ -18,6 +18,10 @@ import type { Kaos } from '@moonshot-ai/kaos';
 export const LIST_DIR_ROOT_WIDTH = 30;
 export const LIST_DIR_CHILD_WIDTH = 10;
 
+export interface ListDirectoryOptions {
+  readonly collapseHiddenDirs?: boolean;
+}
+
 interface Entry {
   readonly name: string;
   readonly isDir: boolean;
@@ -53,12 +57,20 @@ async function collectEntries(
   return { entries: all.slice(0, maxWidth), total: all.length, readable: true };
 }
 
+function shouldCollapseDirectory(entry: Entry, options: ListDirectoryOptions): boolean {
+  return options.collapseHiddenDirs === true && entry.isDir && entry.name.startsWith('.');
+}
+
 /**
  * Return a 2-level tree listing of `workDir` suitable for inclusion in a
  * tool error message. Returns `"(empty directory)"` if the directory is
  * empty, or an error marker line if the directory itself is unreadable.
  */
-export async function listDirectory(kaos: Kaos, workDir: string = kaos.getcwd()): Promise<string> {
+export async function listDirectory(
+  kaos: Kaos,
+  workDir: string = kaos.getcwd(),
+  options: ListDirectoryOptions = {},
+): Promise<string> {
   const lines: string[] = [];
   const { entries, total, readable } = await collectEntries(
     kaos,
@@ -77,6 +89,7 @@ export async function listDirectory(kaos: Kaos, workDir: string = kaos.getcwd())
 
     if (isDir) {
       lines.push(`${connector}${name}/`);
+      if (shouldCollapseDirectory(entry, options)) continue;
       const childPrefix = isLast ? '    ' : '│   ';
       const childDir = join(workDir, name);
       const child = await collectEntries(kaos, childDir, LIST_DIR_CHILD_WIDTH);

--- a/packages/agent-core/test/profile/context.test.ts
+++ b/packages/agent-core/test/profile/context.test.ts
@@ -111,3 +111,16 @@ describe('loadAgentsMd brand home (KIMI_CODE_HOME)', () => {
     expect(result).toContain('fallback branded');
   });
 });
+
+describe('loadAgentsMd truncation marker', () => {
+  it('adds a marker when AGENTS.md content is truncated', async () => {
+    const largeContent = 'x'.repeat(40 * 1024);
+    await writeFile(join(workDir, 'AGENTS.md'), largeContent, 'utf-8');
+
+    const result = await loadAgentsMd(testKaos);
+
+    expect(result).toContain('Some AGENTS.md files were truncated or omitted');
+    expect(result).toContain(`<!-- From: ${join(workDir, 'AGENTS.md')} -->`);
+    expect(result).not.toContain(largeContent);
+  });
+});

--- a/packages/agent-core/test/profile/default-agent-profiles.test.ts
+++ b/packages/agent-core/test/profile/default-agent-profiles.test.ts
@@ -12,6 +12,9 @@ const promptContext = {
   },
   cwd: '/workspace',
   now: '2026-05-09T00:00:00.000Z',
+  cwdListing: 'LISTING_SNAPSHOT',
+  agentsMd: 'AGENTS_MD_BODY',
+  skills: '- test-skill: does things\n  Path: /skills/test/SKILL.md',
 } as const;
 
 describe('default agent profiles', () => {
@@ -21,6 +24,20 @@ describe('default agent profiles', () => {
     expect(prompt).toContain('You are Kimi Code CLI');
     expect(prompt).toContain('Available skills');
     expect(prompt).toContain('/workspace');
+  });
+
+  it('keeps static instructions before dynamic prompt context', () => {
+    const prompt = DEFAULT_AGENT_PROFILES['agent']?.systemPrompt(promptContext) ?? '';
+
+    expect(prompt.indexOf('Use this as your basic understanding of the project structure.')).toBeLessThan(
+      prompt.indexOf('LISTING_SNAPSHOT'),
+    );
+    expect(prompt.indexOf('User instructions given directly in the conversation')).toBeLessThan(
+      prompt.indexOf('AGENTS_MD_BODY'),
+    );
+    expect(prompt.indexOf('Only read skill details when needed')).toBeLessThan(
+      prompt.indexOf('- test-skill: does things'),
+    );
   });
 
   it('lists the goal tools on the agent profile but not on subagent profiles', () => {

--- a/packages/agent-core/test/session/subagent-host.test.ts
+++ b/packages/agent-core/test/session/subagent-host.test.ts
@@ -1242,6 +1242,9 @@ describe('Session.createAgent', () => {
             '/repo/.git',
             '/repo/packages',
             workDir,
+            `${workDir}/.agents`,
+            `${workDir}/.github`,
+            `${workDir}/.github/workflows`,
             `${workDir}/src`,
             `${workDir}/.kimi-code`,
           ].includes(path)
@@ -1255,6 +1258,8 @@ describe('Session.createAgent', () => {
             `${workDir}/AGENTS.md`,
             `${workDir}/package.json`,
             `${workDir}/src/index.ts`,
+            `${workDir}/.agents/hidden.md`,
+            `${workDir}/.github/workflows/ci.yml`,
           ].includes(path)
         ) {
           return stat('file');
@@ -1263,8 +1268,22 @@ describe('Session.createAgent', () => {
       }),
       iterdir: async function* (path: string) {
         if (path === workDir) {
+          yield `${workDir}/.agents`;
+          yield `${workDir}/.github`;
           yield `${workDir}/src`;
           yield `${workDir}/package.json`;
+          return;
+        }
+        if (path === `${workDir}/.agents`) {
+          yield `${workDir}/.agents/hidden.md`;
+          return;
+        }
+        if (path === `${workDir}/.github`) {
+          yield `${workDir}/.github/workflows`;
+          return;
+        }
+        if (path === `${workDir}/.github/workflows`) {
+          yield `${workDir}/.github/workflows/ci.yml`;
           return;
         }
         if (path === `${workDir}/src`) {
@@ -1291,9 +1310,13 @@ describe('Session.createAgent', () => {
     const created = await session.createAgent({ type: 'main' }, { profile: contextProfile() });
 
     expect(created.agent.config.systemPrompt).toContain('cwd=/repo/packages/app');
-    expect(created.agent.config.systemPrompt).toContain('listing=├── src/');
+    expect(created.agent.config.systemPrompt).toContain('listing=├── .agents/');
+    expect(created.agent.config.systemPrompt).toContain('├── .github/');
+    expect(created.agent.config.systemPrompt).toContain('├── src/');
     expect(created.agent.config.systemPrompt).toContain('│   └── index.ts');
     expect(created.agent.config.systemPrompt).toContain('└── package.json');
+    expect(created.agent.config.systemPrompt).not.toContain('hidden.md');
+    expect(created.agent.config.systemPrompt).not.toContain('ci.yml');
     expect(created.agent.config.systemPrompt).toContain('<!-- From: /repo/AGENTS.md -->');
     expect(created.agent.config.systemPrompt).toContain('root instructions');
     expect(created.agent.config.systemPrompt).toContain(

--- a/packages/agent-core/test/tools/list-directory.test.ts
+++ b/packages/agent-core/test/tools/list-directory.test.ts
@@ -244,4 +244,47 @@ describe('listDirectory', () => {
     const tree = await listDirectory(kaos, '/w');
     expect(tree).toBe('└── only_dir/\n    └── child.txt');
   });
+
+  it('collapses hidden directories without hiding hidden files when requested', async () => {
+    const seenDirs: string[] = [];
+    const kaos = createFakeKaos({
+      iterdir: async function* (p: string) {
+        seenDirs.push(p);
+        if (p === '/w') {
+          yield '/w/.git';
+          yield '/w/.gitignore';
+          yield '/w/src';
+        } else if (p === '/w/.git') {
+          yield '/w/.git/HEAD';
+        } else if (p === '/w/src') {
+          yield '/w/src/index.ts';
+        }
+      } as unknown as Kaos['iterdir'],
+      stat: (async (p: string) => ({
+        stMode: p.endsWith('.git') || p.endsWith('src') ? 0o040_755 : 0o100_644,
+        stIno: 1,
+        stDev: 1,
+        stNlink: 1,
+        stUid: 0,
+        stGid: 0,
+        stSize: 1,
+        stAtime: 0,
+        stMtime: 0,
+        stCtime: 0,
+      })) as unknown as Kaos['stat'],
+    });
+
+    const expanded = await listDirectory(kaos, '/w');
+    expect(expanded).toContain('.git/');
+    expect(expanded).toContain('HEAD');
+
+    seenDirs.length = 0;
+    const collapsed = await listDirectory(kaos, '/w', { collapseHiddenDirs: true });
+    expect(collapsed).toContain('.git/');
+    expect(collapsed).toContain('.gitignore');
+    expect(collapsed).toContain('src/');
+    expect(collapsed).toContain('index.ts');
+    expect(collapsed).not.toContain('HEAD');
+    expect(seenDirs).toEqual(['/w', '/w/src']);
+  });
 });


### PR DESCRIPTION
## Related Issue

No linked issue. This PR polishes the system prompt context based on direct prompt-review feedback.

## Problem

The default system prompt spent tokens on hidden directory contents and a long AGENTS.md explanation, while dynamic prompt context was mixed into the surrounding guidance. It also gave no signal when AGENTS.md files were truncated by the prompt budget.

## What changed

- Collapse hidden directories in the workspace directory snapshot while keeping the top-level entries visible.
- Add prompt guidance for inspecting hidden paths with `Glob`, `Read`, and `Grep`.
- Compress the AGENTS.md prompt guidance and move dynamic AGENTS/skill context after the static rules.
- Add a marker when AGENTS.md content is truncated or omitted because of the prompt budget.
- Cover the new behavior with focused prompt/profile tests.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.

Tests run:

```text
pnpm --filter @moonshot-ai/agent-core exec vitest run test/tools/list-directory.test.ts test/profile/context.test.ts test/profile/default-agent-profiles.test.ts test/prompt-placeholders.test.ts test/session/subagent-host.test.ts
pnpm --filter @moonshot-ai/agent-core typecheck
pnpm exec oxlint packages/agent-core/src/tools/support/list-directory.ts packages/agent-core/src/profile/context.ts packages/agent-core/test/tools/list-directory.test.ts packages/agent-core/test/session/subagent-host.test.ts packages/agent-core/test/profile/context.test.ts packages/agent-core/test/profile/default-agent-profiles.test.ts
```
