### PR TITLE
fix(read): report maxLinesReached in tail mode

### DIFF
--- a/.changeset/read-maxlines-tail.md
+++ b/.changeset/read-maxlines-tail.md
@@ -1,0 +1,7 @@
+---
+"@moonshot-ai/agent-core": patch
+---
+
+fix(read): report maxLinesReached in tail mode
+
+Report when max lines are reached in tail mode for better visibility.

--- a/packages/agent-core/src/tools/builtin/file/read.ts
+++ b/packages/agent-core/src/tools/builtin/file/read.ts
@@ -412,7 +412,7 @@ export class ReadTool implements BuiltinTool<ReadInput> {
     return this.finishReadResult({
       renderedLines,
       truncatedLineNumbers,
-      maxLinesReached: false,
+      maxLinesReached: effectiveLimit >= MAX_LINES && entries.length >= effectiveLimit,
       maxBytesReached,
       lineEndingStyle,
       startLine: renderedCandidates[0]?.entry.lineNo ?? 0,

--- a/packages/agent-core/test/tools/read.test.ts
+++ b/packages/agent-core/test/tools/read.test.ts
@@ -622,6 +622,22 @@ describe('ReadTool', () => {
     expect(result.output).not.toContain(`${String(MAX_LINES + 1)}\tline ${String(MAX_LINES + 1)}`);
   });
 
+  it('caps tail reads at MAX_LINES', async () => {
+    const content = Array.from({ length: MAX_LINES + 5 }, (_, i) => `line ${String(i + 1)}`).join(
+      '\n',
+    );
+    const tool = toolWithContent(content);
+
+    const result = await executeTool(
+      tool,
+      context({ path: '/tmp/tail-big.txt', line_offset: -MAX_LINES }),
+    );
+
+    expect(result.output).toContain(`Max ${String(MAX_LINES)} lines reached.`);
+    expect(result.output).toContain(`${String(MAX_LINES + 5)}\tline ${String(MAX_LINES + 5)}`);
+    expect(result.output).toMatch(/^6\tline 6/);
+  });
+
   it('tail byte truncation keeps the newest lines closest to EOF', async () => {
     const numLines = Math.floor(MAX_BYTES / 1001) + 20;
     const content = Array.from({ length: numLines }, (_, i) => {


### PR DESCRIPTION
## Problem

When reading from the tail with `line_offset=-MAX_LINES`, the Read tool never reported `maxLinesReached` even though it hit the cap. This made tail mode inconsistent with forward mode, where the cap is correctly reported.

## What changed

- Set `maxLinesReached` in `readTail` when `effectiveLimit >= MAX_LINES` and `entries.length >= effectiveLimit`.
- Add regression test ensuring tail mode reports the cap.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have explained the problem above.
- [x] I have added tests that prove my feature works.
