### PR TITLE
feat: add all-sessions picker with name search

### DIFF
--- a/.changeset/session-picker-all-sessions.md
+++ b/.changeset/session-picker-all-sessions.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": minor
+---
+
+Add an all-sessions picker view with name search, paginated browsing, and clipboard-ready resume commands for sessions in other working directories.

--- a/.changeset/session-picker-empty-hint.md
+++ b/.changeset/session-picker-empty-hint.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Show the all-sessions toggle hint when the current working directory has no sessions.

--- a/apps/kimi-code/src/tui/components/dialogs/session-picker.ts
+++ b/apps/kimi-code/src/tui/components/dialogs/session-picker.ts
@@ -137,7 +137,7 @@ export class SessionPickerComponent extends Container implements Focusable {
   private resolveInitialSelectedIndex(initialSelectedSessionId: string | undefined): number {
     if (initialSelectedSessionId === undefined) return 0;
     const index = this.sessions.findIndex((session) => session.id === initialSelectedSessionId);
-    return index >= 0 ? index : 0;
+    return Math.max(index, 0);
   }
 
   private filteredSessions(): readonly SessionRow[] {
@@ -206,9 +206,16 @@ export class SessionPickerComponent extends Container implements Focusable {
   // prevents the "Rendered line exceeds terminal width" crash (issue #240).
   private renderLines(width: number): string[] {
     const lines: string[] = [currentTheme.fg('primary', '─'.repeat(width))];
+    const title = this.scope === 'all' ? 'All sessions' : 'Sessions';
+    const scopeHint =
+      this.onToggleScope === undefined
+        ? undefined
+        : this.scope === 'all'
+          ? 'Ctrl+A current cwd'
+          : 'Ctrl+A all';
 
     if (this.loading) {
-      lines.push(currentTheme.boldFg('primary', truncateToWidth('Sessions', width, ELLIPSIS)));
+      lines.push(currentTheme.boldFg('primary', truncateToWidth(title, width, ELLIPSIS)));
       lines.push(
         currentTheme.fg('textMuted', truncateToWidth('Loading sessions...', width, ELLIPSIS)),
       );
@@ -217,27 +224,24 @@ export class SessionPickerComponent extends Container implements Focusable {
     }
 
     if (this.sessions.length === 0) {
-      lines.push(currentTheme.boldFg('primary', truncateToWidth('Sessions', width, ELLIPSIS)));
+      const hintParts = [scopeHint, 'Esc cancel'].filter(
+        (item): item is string => item !== undefined,
+      );
+      lines.push(currentTheme.boldFg('primary', truncateToWidth(title, width, ELLIPSIS)));
       lines.push(
-        currentTheme.fg(
-          'textMuted',
-          truncateToWidth('No sessions found. Press Escape to close.', width, ELLIPSIS),
-        ),
+        currentTheme.fg('textMuted', truncateToWidth(hintParts.join(' · '), width, ELLIPSIS)),
+      );
+      lines.push('');
+      lines.push(
+        currentTheme.fg('textMuted', truncateToWidth('No sessions found.', width, ELLIPSIS)),
       );
       lines.push(currentTheme.fg('primary', '─'.repeat(width)));
       return lines;
     }
 
     const view = this.list.view();
-    const title = this.scope === 'all' ? 'All sessions' : 'Sessions';
     const titleSuffix =
       view.query.length === 0 ? currentTheme.fg('textMuted', '  (type to search)') : '';
-    const scopeHint =
-      this.onToggleScope === undefined
-        ? undefined
-        : this.scope === 'all'
-          ? 'Ctrl+A current cwd'
-          : 'Ctrl+A all';
     const hintParts = [
       ...(view.query.length > 0 ? ['Backspace clear'] : []),
       '↑↓ navigate',

--- a/apps/kimi-code/src/tui/components/dialogs/session-picker.ts
+++ b/apps/kimi-code/src/tui/components/dialogs/session-picker.ts
@@ -171,8 +171,7 @@ export class SessionPickerComponent extends Container implements Focusable {
       return;
     }
     if (matchesKey(data, Key.ctrl('a'))) {
-      const session = this.list.selected();
-      if (session) this.onToggleScope?.(session.id);
+      this.onToggleScope?.(this.list.selected()?.id ?? this.currentSessionId);
       return;
     }
     if (matchesKey(data, Key.escape)) {

--- a/apps/kimi-code/src/tui/components/dialogs/session-picker.ts
+++ b/apps/kimi-code/src/tui/components/dialogs/session-picker.ts
@@ -13,6 +13,7 @@ import {
 import { formatSessionLabel } from '#/migration/index';
 import { CURRENT_MARK, SELECT_POINTER } from '#/tui/constant/symbols';
 import { currentTheme } from '#/tui/theme';
+import { SearchableList } from '#/tui/utils/searchable-list';
 
 export interface SessionRow {
   readonly id: string;
@@ -73,40 +74,92 @@ function singleLine(text: string): string {
   return text.replaceAll(/\s+/g, ' ').trim();
 }
 
+function sessionSearchText(session: SessionRow): string {
+  return singleLine((session.title ?? session.id).trim() || session.id);
+}
+
 export class SessionPickerComponent extends Container implements Focusable {
   private sessions: SessionRow[];
   private currentSessionId: string;
-  private onSelect: (sessionId: string) => void;
+  private onSelect: (session: SessionRow) => void;
   private onCancel: () => void;
+  private onToggleScope?: (selectedSessionId: string) => void;
   private maxVisibleSessions: number;
+  private pageSize: number;
+  private visibleCount: number;
+  private scope: 'cwd' | 'all';
   private loading: boolean;
+  private list: SearchableList<SessionRow>;
 
   focused = false;
-  private selectedIndex = 0;
 
   constructor(opts: {
     sessions: SessionRow[];
     loading: boolean;
     currentSessionId: string;
-    onSelect: (sessionId: string) => void;
+    scope?: 'cwd' | 'all';
+    initialSelectedSessionId?: string;
+    pageSize?: number;
+    onSelect: (session: SessionRow) => void;
     onCancel: () => void;
     onCtrlC?: () => void;
     onCtrlD?: () => void;
+    onToggleScope?: (selectedSessionId: string) => void;
     maxVisibleSessions?: number;
   }) {
     super();
     this.sessions = opts.sessions;
     this.loading = opts.loading;
     this.currentSessionId = opts.currentSessionId;
+    this.scope = opts.scope ?? 'cwd';
     this.onSelect = opts.onSelect;
     this.onCancel = opts.onCancel;
+    this.onToggleScope = opts.onToggleScope;
     this.maxVisibleSessions = opts.maxVisibleSessions ?? 4;
+    this.pageSize = Math.max(1, opts.pageSize ?? 50);
+    const initialIndex = this.resolveInitialSelectedIndex(opts.initialSelectedSessionId);
+    this.list = new SearchableList({
+      items: this.sessions,
+      toSearchText: sessionSearchText,
+      pageSize: this.pageSize,
+      initialIndex,
+      searchable: true,
+    });
+    const initialLoadedPages = Math.ceil((initialIndex + 1) / this.pageSize);
+    this.visibleCount = Math.min(this.sessions.length, initialLoadedPages * this.pageSize);
     this.onCtrlC = opts.onCtrlC;
     this.onCtrlD = opts.onCtrlD;
   }
 
   private readonly onCtrlC?: () => void;
   private readonly onCtrlD?: () => void;
+
+  private resolveInitialSelectedIndex(initialSelectedSessionId: string | undefined): number {
+    if (initialSelectedSessionId === undefined) return 0;
+    const index = this.sessions.findIndex((session) => session.id === initialSelectedSessionId);
+    return index >= 0 ? index : 0;
+  }
+
+  private filteredSessions(): readonly SessionRow[] {
+    return this.list.view().items;
+  }
+
+  private loadedSessions(sessions: readonly SessionRow[] = this.filteredSessions()): SessionRow[] {
+    return sessions.slice(0, Math.min(sessions.length, this.visibleCount));
+  }
+
+  private syncVisibleCount(previousQuery: string): void {
+    const view = this.list.view();
+    if (view.query !== previousQuery) {
+      this.visibleCount = Math.min(view.items.length, this.pageSize);
+      return;
+    }
+
+    const loadedCount = Math.min(view.items.length, this.visibleCount);
+    if (view.selectedIndex >= loadedCount - 1 && loadedCount < view.items.length) {
+      this.visibleCount = Math.min(view.items.length, this.visibleCount + this.pageSize);
+    }
+  }
 
   handleInput(data: string): void {
     if (matchesKey(data, Key.ctrl('c'))) {
@@ -117,21 +170,28 @@ export class SessionPickerComponent extends Container implements Focusable {
       this.onCtrlD?.();
       return;
     }
+    if (matchesKey(data, Key.ctrl('a'))) {
+      const session = this.list.selected();
+      if (session) this.onToggleScope?.(session.id);
+      return;
+    }
     if (matchesKey(data, Key.escape)) {
+      if (this.list.clearQuery()) {
+        this.visibleCount = Math.min(this.filteredSessions().length, this.pageSize);
+        return;
+      }
       this.onCancel();
       return;
     }
-    if (matchesKey(data, Key.enter) && this.sessions.length > 0) {
-      const session = this.sessions[this.selectedIndex];
-      if (session) this.onSelect(session.id);
+    if (matchesKey(data, Key.enter)) {
+      const session = this.list.selected();
+      if (session) this.onSelect(session);
       return;
     }
-    if (matchesKey(data, Key.up)) {
-      this.selectedIndex = Math.max(0, this.selectedIndex - 1);
-      return;
-    }
-    if (matchesKey(data, Key.down)) {
-      this.selectedIndex = Math.min(this.sessions.length - 1, this.selectedIndex + 1);
+
+    const previousQuery = this.list.view().query;
+    if (this.list.handleKey(data)) {
+      this.syncVisibleCount(previousQuery);
     }
   }
 
@@ -169,40 +229,70 @@ export class SessionPickerComponent extends Container implements Focusable {
       return lines;
     }
 
-    const headerLabel = 'Sessions ';
-    const headerHint = '↑↓ navigate · Enter select · Esc cancel';
-    const labelWidth = visibleWidth(headerLabel);
-    const hintBudget = Math.max(0, width - labelWidth);
-    const shownHint = truncateToWidth(headerHint, hintBudget, ELLIPSIS);
-    lines.push(
-      currentTheme.boldFg('primary', headerLabel) + currentTheme.fg('textMuted', shownHint),
-    );
+    const view = this.list.view();
+    const title = this.scope === 'all' ? 'All sessions' : 'Sessions';
+    const titleSuffix =
+      view.query.length === 0 ? currentTheme.fg('textMuted', '  (type to search)') : '';
+    const scopeHint =
+      this.onToggleScope === undefined
+        ? undefined
+        : this.scope === 'all'
+          ? 'Ctrl+A current cwd'
+          : 'Ctrl+A all';
+    const hintParts = [
+      ...(view.query.length > 0 ? ['Backspace clear'] : []),
+      '↑↓ navigate',
+      scopeHint,
+      'Enter select',
+      'Esc cancel',
+    ].filter((item): item is string => item !== undefined);
+
+    lines.push(currentTheme.boldFg('primary', title) + titleSuffix);
+    lines.push(currentTheme.fg('textMuted', hintParts.join(' · ')));
     lines.push('');
 
+    if (view.query.length > 0) {
+      lines.push(currentTheme.fg('primary', 'Search: ') + currentTheme.fg('text', view.query));
+    }
+
+    const loadedSessions = this.loadedSessions(view.items);
+    if (loadedSessions.length === 0) {
+      lines.push(currentTheme.fg('textMuted', truncateToWidth('No matches', width, ELLIPSIS)));
+      lines.push(currentTheme.fg('primary', '─'.repeat(width)));
+      return lines;
+    }
+    const selectedIndex = view.selectedIndex;
     const visibleStart = Math.max(
       0,
       Math.min(
-        this.selectedIndex - Math.floor(this.maxVisibleSessions / 2),
-        Math.max(0, this.sessions.length - this.maxVisibleSessions),
+        selectedIndex - Math.floor(this.maxVisibleSessions / 2),
+        Math.max(0, loadedSessions.length - this.maxVisibleSessions),
       ),
     );
-    const visibleSessions = this.sessions.slice(
+    const visibleSessions = loadedSessions.slice(
       visibleStart,
       visibleStart + this.maxVisibleSessions,
     );
 
     for (const [vi, session] of visibleSessions.entries()) {
       const index = visibleStart + vi;
-      const isSelected = index === this.selectedIndex;
+      const isSelected = index === selectedIndex;
       const isCurrent = session.id === this.currentSessionId;
       const card = this.renderSessionCard(width, session, isSelected, isCurrent);
       lines.push(...card);
       if (vi < visibleSessions.length - 1) lines.push('');
     }
 
-    if (this.sessions.length > visibleSessions.length) {
+    const filteredCount = view.items.length;
+    if (loadedSessions.length > visibleSessions.length || view.query.length > 0) {
       lines.push('');
-      const footer = `Showing ${String(visibleStart + 1)}-${String(visibleStart + visibleSessions.length)} of ${String(this.sessions.length)} sessions`;
+      const totalSuffix =
+        view.query.length > 0
+          ? `${String(loadedSessions.length)} loaded / ${String(filteredCount)} matches`
+          : loadedSessions.length === this.sessions.length
+            ? `${String(loadedSessions.length)} sessions`
+            : `${String(loadedSessions.length)} loaded / ${String(this.sessions.length)} sessions`;
+      const footer = `Showing ${String(visibleStart + 1)}-${String(visibleStart + visibleSessions.length)} of ${totalSuffix}`;
       lines.push(currentTheme.fg('textMuted', truncateToWidth(footer, width, ELLIPSIS)));
     }
 

--- a/apps/kimi-code/src/tui/kimi-tui.ts
+++ b/apps/kimi-code/src/tui/kimi-tui.ts
@@ -1870,6 +1870,7 @@ export class KimiTUI {
     closeOnCancel: false,
     forwardEditorExit: false,
   };
+  private sessionPickerScopeRequestToken = 0;
 
   async showSessionPicker(): Promise<void> {
     await this.openSessionPicker({
@@ -1914,8 +1915,11 @@ export class KimiTUI {
   }
 
   private async toggleSessionPickerScope(selectedSessionId: string): Promise<void> {
+    const requestToken = ++this.sessionPickerScopeRequestToken;
     const nextScope = this.state.sessionsScope === 'cwd' ? 'all' : 'cwd';
     await this.fetchSessions(nextScope);
+    if (requestToken !== this.sessionPickerScopeRequestToken) return;
+    if (this.state.activeDialog !== 'session-picker') return;
     this.mountSessionPicker({
       initialSelectedSessionId: selectedSessionId,
       applyStartupModes: this.sessionPickerOptions.applyStartupModes,
@@ -1937,6 +1941,7 @@ export class KimiTUI {
   }
 
   hideSessionPicker(): void {
+    this.sessionPickerScopeRequestToken += 1;
     this.editorKeyboard.clearPendingExit();
     this.state.activeDialog = null;
     this.restoreEditor();
@@ -1984,6 +1989,7 @@ export class KimiTUI {
   ): Promise<void> {
     if (resolve(session.work_dir) !== resolve(this.state.appState.workDir)) {
       await this.showResumeOtherWorkDirHint(session);
+      if (applyStartupModes) await this.stop(0);
       return;
     }
 

--- a/apps/kimi-code/src/tui/kimi-tui.ts
+++ b/apps/kimi-code/src/tui/kimi-tui.ts
@@ -29,6 +29,7 @@ import { appendInputHistory, loadInputHistory } from '#/utils/history/input-hist
 import { openUrl } from '#/utils/open-url';
 import { getInputHistoryFile } from '#/utils/paths';
 import { detectFdPath, ensureFdPath } from '#/utils/process/fd-detect';
+import { quoteShellArg } from '#/utils/shell-quote';
 
 import { BannerProvider } from './banner/banner-provider';
 import {
@@ -1218,7 +1219,7 @@ export class KimiTUI {
 
   private async showResumeOtherWorkDirHint(session: SessionRow): Promise<void> {
     this.hideSessionPicker();
-    const command = `cd "${session.work_dir}" && kimi --resume ${session.id}`;
+    const command = `cd ${quoteShellArg(session.work_dir)} && kimi --resume ${quoteShellArg(session.id)}`;
     const message = `Current session is in a different working directory.\n  To resume, run: ${command}`;
     try {
       await copyTextToClipboard(command);

--- a/apps/kimi-code/src/tui/kimi-tui.ts
+++ b/apps/kimi-code/src/tui/kimi-tui.ts
@@ -24,6 +24,7 @@ import { resolve } from 'pathe';
 
 import type { CLIOptions } from '#/cli/options';
 import { MigrationScreenComponent, type MigrationScreenResult } from '#/migration/index';
+import { copyTextToClipboard } from '#/utils/clipboard/clipboard-text';
 import { appendInputHistory, loadInputHistory } from '#/utils/history/input-history';
 import { openUrl } from '#/utils/open-url';
 import { getInputHistoryFile } from '#/utils/paths';
@@ -56,7 +57,10 @@ import {
 import { CompactionComponent } from './components/dialogs/compaction';
 import { HelpPanelComponent } from './components/dialogs/help-panel';
 import { QuestionDialogComponent } from './components/dialogs/question-dialog';
-import { SessionPickerComponent } from './components/dialogs/session-picker';
+import {
+  SessionPickerComponent,
+  type SessionRow,
+} from './components/dialogs/session-picker';
 import {
   FileMentionProvider,
   type SlashAutocompleteCommand,
@@ -1167,10 +1171,14 @@ export class KimiTUI {
     session.setQuestionHandler(createQuestionAskHandler(this.questionController));
   }
 
-  async fetchSessions(): Promise<void> {
+  async fetchSessions(scope: 'cwd' | 'all' = this.state.sessionsScope): Promise<void> {
     this.state.loadingSessions = true;
+    this.state.sessionsScope = scope;
     try {
-      const sessions = await this.harness.listSessions({ workDir: this.state.appState.workDir });
+      const sessions =
+        scope === 'all'
+          ? await this.harness.listSessions({})
+          : await this.harness.listSessions({ workDir: this.state.appState.workDir });
       this.state.sessions = sessionRowsForPicker(
         sessions,
         this.state.appState.sessionId,
@@ -1206,6 +1214,18 @@ export class KimiTUI {
     this.streamingUI.setStep(0);
     this.streamingUI.resetLiveText();
     this.updateQueueDisplay();
+  }
+
+  private async showResumeOtherWorkDirHint(session: SessionRow): Promise<void> {
+    this.hideSessionPicker();
+    const command = `cd "${session.work_dir}" && kimi --resume ${session.id}`;
+    const message = `Current session is in a different working directory.\n  To resume, run: ${command}`;
+    try {
+      await copyTextToClipboard(command);
+      this.showStatus(`${message}\n  Command copied to clipboard`, 'warning');
+    } catch {
+      this.showStatus(`${message}\n  Failed to copy command to clipboard`, 'warning');
+    }
   }
 
   private async resumeSession(targetSessionId: string): Promise<boolean> {
@@ -1840,29 +1860,78 @@ export class KimiTUI {
     this.restoreEditor();
   }
 
+  private sessionPickerOptions: {
+    readonly applyStartupModes: boolean;
+    readonly closeOnCancel: boolean;
+    readonly forwardEditorExit: boolean;
+  } = {
+    applyStartupModes: false,
+    closeOnCancel: false,
+    forwardEditorExit: false,
+  };
+
   async showSessionPicker(): Promise<void> {
-    await this.fetchSessions();
-    this.mountSessionPicker({
-      onCancel: () => {
-        this.hideSessionPicker();
-      },
+    await this.openSessionPicker({
+      applyStartupModes: false,
+      closeOnCancel: false,
+      forwardEditorExit: false,
     });
   }
 
   private async bootstrapFromPicker(): Promise<void> {
-    await this.fetchSessions();
-    this.mountSessionPicker({
+    await this.openSessionPicker({
       applyStartupModes: true,
+      closeOnCancel: true,
+      forwardEditorExit: true,
+    });
+  }
+
+  private async openSessionPicker(options: {
+    readonly applyStartupModes: boolean;
+    readonly closeOnCancel: boolean;
+    readonly forwardEditorExit: boolean;
+  }): Promise<void> {
+    this.sessionPickerOptions = options;
+    await this.fetchSessions('cwd');
+    this.mountSessionPicker({
+      applyStartupModes: options.applyStartupModes,
       onCancel: () => {
         this.hideSessionPicker();
-        void this.stop();
+        if (options.closeOnCancel) void this.stop();
       },
-      onCtrlC: () => {
-        this.state.editor.onCtrlC?.();
+      onCtrlC: options.forwardEditorExit
+        ? () => {
+            this.state.editor.onCtrlC?.();
+          }
+        : undefined,
+      onCtrlD: options.forwardEditorExit
+        ? () => {
+            this.state.editor.onCtrlD?.();
+          }
+        : undefined,
+    });
+  }
+
+  private async toggleSessionPickerScope(selectedSessionId: string): Promise<void> {
+    const nextScope = this.state.sessionsScope === 'cwd' ? 'all' : 'cwd';
+    await this.fetchSessions(nextScope);
+    this.mountSessionPicker({
+      initialSelectedSessionId: selectedSessionId,
+      applyStartupModes: this.sessionPickerOptions.applyStartupModes,
+      onCancel: () => {
+        this.hideSessionPicker();
+        if (this.sessionPickerOptions.closeOnCancel) void this.stop();
       },
-      onCtrlD: () => {
-        this.state.editor.onCtrlD?.();
-      },
+      onCtrlC: this.sessionPickerOptions.forwardEditorExit
+        ? () => {
+            this.state.editor.onCtrlC?.();
+          }
+        : undefined,
+      onCtrlD: this.sessionPickerOptions.forwardEditorExit
+        ? () => {
+            this.state.editor.onCtrlD?.();
+          }
+        : undefined,
     });
   }
 
@@ -1876,6 +1945,7 @@ export class KimiTUI {
     readonly onCancel: () => void;
     readonly onCtrlC?: () => void;
     readonly onCtrlD?: () => void;
+    readonly initialSelectedSessionId?: string;
     // CLI mode flags (--auto/--yolo/--plan) target the session picked at
     // startup (bare --session); later /sessions switches keep the picked
     // session's own persisted modes.
@@ -1887,27 +1957,42 @@ export class KimiTUI {
         sessions: this.state.sessions,
         loading: this.state.loadingSessions,
         currentSessionId: this.state.appState.sessionId,
-        onSelect: (sessionId: string) => {
-          void this.resumeSession(sessionId)
-            .then(async (switched) => {
-              if (!switched) {
-                return;
-              }
-              if (options.applyStartupModes === true) {
-                await this.applyStartupModesToResumedSession(this.requireSession());
-                this.applyStartupPermissionAndPlanToAppState();
-              }
-              this.hideSessionPicker();
-            })
-            .catch((error) => {
+        scope: this.state.sessionsScope,
+        initialSelectedSessionId: options.initialSelectedSessionId,
+        pageSize: 50,
+        onSelect: (session: SessionRow) => {
+          void this.handleSessionPickerSelect(session, options.applyStartupModes === true).catch(
+            (error) => {
               this.showError(`Failed to apply startup flags: ${formatErrorMessage(error)}`);
-            });
+            },
+          );
         },
         onCancel: options.onCancel,
         onCtrlC: options.onCtrlC,
         onCtrlD: options.onCtrlD,
+        onToggleScope: (selectedSessionId: string) => {
+          void this.toggleSessionPickerScope(selectedSessionId);
+        },
       }),
     );
+  }
+
+  private async handleSessionPickerSelect(
+    session: SessionRow,
+    applyStartupModes: boolean,
+  ): Promise<void> {
+    if (resolve(session.work_dir) !== resolve(this.state.appState.workDir)) {
+      await this.showResumeOtherWorkDirHint(session);
+      return;
+    }
+
+    const switched = await this.resumeSession(session.id);
+    if (!switched) return;
+    if (applyStartupModes) {
+      await this.applyStartupModesToResumedSession(this.requireSession());
+      this.applyStartupPermissionAndPlanToAppState();
+    }
+    this.hideSessionPicker();
   }
 
   private showApprovalPanel(payload: ApprovalPanelData): void {

--- a/apps/kimi-code/src/tui/tui-state.ts
+++ b/apps/kimi-code/src/tui/tui-state.ts
@@ -46,6 +46,7 @@ export interface TUIState {
   toolOutputExpanded: boolean;
   sessions: SessionRow[];
   loadingSessions: boolean;
+  sessionsScope: 'cwd' | 'all';
   activeDialog: 'session-picker' | 'help' | null;
   tasksBrowser: TasksBrowserState | undefined;
   externalEditorRunning: boolean;
@@ -94,6 +95,7 @@ export function createTUIState(options: KimiTUIOptions): TUIState {
     toolOutputExpanded: false,
     sessions: [],
     loadingSessions: false,
+    sessionsScope: 'cwd',
     activeDialog: null,
     tasksBrowser: undefined,
     externalEditorRunning: false,

--- a/apps/kimi-code/src/utils/clipboard/clipboard-native.ts
+++ b/apps/kimi-code/src/utils/clipboard/clipboard-native.ts
@@ -18,6 +18,7 @@ export interface ClipboardModule {
   availableFormats?(): string[];
   hasText?(): boolean;
   getText?(): Promise<string>;
+  setText?(text: string): Promise<void>;
   hasImage(): boolean;
   getImageBinary(): Promise<Array<number>>;
 }

--- a/apps/kimi-code/src/utils/clipboard/clipboard-text.ts
+++ b/apps/kimi-code/src/utils/clipboard/clipboard-text.ts
@@ -36,14 +36,15 @@ async function copyWithPlatformCommand(text: string): Promise<void> {
     }
   }
 
-  throw lastError ?? new Error('No clipboard command is available.');
+  if (lastError instanceof Error) throw lastError;
+  throw new Error('No clipboard command is available.');
 }
 
 export async function copyTextToClipboard(text: string): Promise<void> {
-  const setText = clipboard?.setText;
-  if (setText !== undefined) {
+  const clipboardModule = clipboard;
+  if (clipboardModule?.setText !== undefined) {
     try {
-      await setText(text);
+      await clipboardModule.setText(text);
       return;
     } catch {
       // Fall back to platform clipboard commands below.

--- a/apps/kimi-code/src/utils/clipboard/clipboard-text.ts
+++ b/apps/kimi-code/src/utils/clipboard/clipboard-text.ts
@@ -1,0 +1,54 @@
+import { spawnSync } from 'node:child_process';
+
+import { clipboard } from './clipboard-native';
+
+function runClipboardCommand(command: string, args: readonly string[], input: string): void {
+  const result = spawnSync(command, args, { encoding: 'utf8', input });
+  if (result.error) throw result.error;
+  if (result.status === 0) return;
+
+  const detail = result.stderr.trim();
+  throw new Error(
+    detail.length > 0
+      ? `${command} exited with code ${String(result.status)}: ${detail}`
+      : `${command} exited with code ${String(result.status)}`,
+  );
+}
+
+async function copyWithPlatformCommand(text: string): Promise<void> {
+  const commands =
+    process.platform === 'darwin'
+      ? [{ command: 'pbcopy', args: [] as string[] }]
+      : process.platform === 'win32'
+        ? [{ command: 'clip.exe', args: [] as string[] }]
+        : [
+            { command: 'wl-copy', args: [] as string[] },
+            { command: 'xclip', args: ['-selection', 'clipboard'] },
+          ];
+
+  let lastError: unknown;
+  for (const candidate of commands) {
+    try {
+      runClipboardCommand(candidate.command, candidate.args, text);
+      return;
+    } catch (error) {
+      lastError = error;
+    }
+  }
+
+  throw lastError ?? new Error('No clipboard command is available.');
+}
+
+export async function copyTextToClipboard(text: string): Promise<void> {
+  const setText = clipboard?.setText;
+  if (setText !== undefined) {
+    try {
+      await setText(text);
+      return;
+    } catch {
+      // Fall back to platform clipboard commands below.
+    }
+  }
+
+  await copyWithPlatformCommand(text);
+}

--- a/apps/kimi-code/src/utils/process/external-editor.ts
+++ b/apps/kimi-code/src/utils/process/external-editor.ts
@@ -13,6 +13,8 @@ import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
+import { quoteShellArg } from '#/utils/shell-quote';
+
 export function resolveEditorCommand(configured?: string | null): string | undefined {
   const candidates = [configured, process.env['VISUAL'], process.env['EDITOR']];
   for (const c of candidates) {
@@ -57,19 +59,3 @@ export async function editInExternalEditor(
   }
 }
 
-/**
- * Quote the appended temp-file path so spaces survive shell parsing.
- */
-function quotePosixArg(value: string): string {
-  return `'${value.replaceAll("'", "'\\''")}'`;
-}
-
-function quoteCmdArg(value: string): string {
-  return `"${value.replaceAll('"', '\\"')}"`;
-}
-
-function quoteShellArg(value: string): string {
-  return process.platform === 'win32'
-    ? quoteCmdArg(value)
-    : quotePosixArg(value);
-}

--- a/apps/kimi-code/src/utils/shell-quote.ts
+++ b/apps/kimi-code/src/utils/shell-quote.ts
@@ -1,0 +1,11 @@
+export function quoteShellArg(value: string): string {
+  return process.platform === 'win32' ? quoteCmdArg(value) : quotePosixArg(value);
+}
+
+function quotePosixArg(value: string): string {
+  return `'${value.replaceAll("'", "'\\''")}'`;
+}
+
+function quoteCmdArg(value: string): string {
+  return `"${value.replaceAll('"', '\\"')}"`;
+}

--- a/apps/kimi-code/test/tui/components/dialogs/session-picker.test.ts
+++ b/apps/kimi-code/test/tui/components/dialogs/session-picker.test.ts
@@ -337,7 +337,7 @@ describe('SessionPickerComponent', () => {
       onToggleScope,
     });
 
-    component.handleInput('\u001b[B');
+    component.handleInput('\u001B[B');
     component.handleInput('\u0001');
 
     expect(onToggleScope).toHaveBeenCalledOnce();
@@ -360,6 +360,23 @@ describe('SessionPickerComponent', () => {
 
     expect(onToggleScope).toHaveBeenCalledOnce();
     expect(onToggleScope).toHaveBeenCalledWith('ses_current');
+  });
+
+  it('renders the Ctrl+A all-sessions hint when the current cwd has no sessions', () => {
+    const component = new SessionPickerComponent({
+      sessions: [],
+      loading: false,
+      currentSessionId: 'ses_current',
+      scope: 'cwd',
+      onSelect: vi.fn(),
+      onCancel: vi.fn(),
+      onToggleScope: vi.fn(),
+    });
+
+    const output = renderPlain(component);
+
+    expect(output).toContain('No sessions found.');
+    expect(output).toContain('Ctrl+A all');
   });
 
   it('renders all-sessions scope header and Ctrl+A current-cwd hint', () => {
@@ -429,7 +446,7 @@ describe('SessionPickerComponent', () => {
     });
 
     for (let i = 0; i < 50; i++) {
-      component.handleInput('\u001b[B');
+      component.handleInput('\u001B[B');
     }
 
     const output = renderPlain(component);
@@ -649,7 +666,7 @@ describe('SessionPickerComponent', () => {
     component.handleInput('l');
     component.handleInput('e');
     for (let i = 0; i < 50; i++) {
-      component.handleInput('\u001b[B');
+      component.handleInput('\u001B[B');
     }
 
     const output = renderPlain(component);

--- a/apps/kimi-code/test/tui/components/dialogs/session-picker.test.ts
+++ b/apps/kimi-code/test/tui/components/dialogs/session-picker.test.ts
@@ -344,6 +344,24 @@ describe('SessionPickerComponent', () => {
     expect(onToggleScope).toHaveBeenCalledWith('ses_b');
   });
 
+  it('calls onToggleScope with the current session id when Ctrl+A is pressed with no sessions', () => {
+    const onToggleScope = vi.fn();
+    const component = new SessionPickerComponent({
+      sessions: [],
+      loading: false,
+      currentSessionId: 'ses_current',
+      scope: 'cwd',
+      onSelect: vi.fn(),
+      onCancel: vi.fn(),
+      onToggleScope,
+    });
+
+    component.handleInput('\u0001');
+
+    expect(onToggleScope).toHaveBeenCalledOnce();
+    expect(onToggleScope).toHaveBeenCalledWith('ses_current');
+  });
+
   it('renders all-sessions scope header and Ctrl+A current-cwd hint', () => {
     const component = new SessionPickerComponent({
       sessions: [

--- a/apps/kimi-code/test/tui/components/dialogs/session-picker.test.ts
+++ b/apps/kimi-code/test/tui/components/dialogs/session-picker.test.ts
@@ -11,6 +11,9 @@ function renderPlain(component: SessionPickerComponent, width = 120): string {
   return stripAnsi(component.render(width).join('\n'));
 }
 
+const BACKSPACE = String.fromCodePoint(127);
+const ESC = String.fromCodePoint(27);
+
 describe('SessionPickerComponent', () => {
   afterEach(() => {
     vi.restoreAllMocks();
@@ -307,5 +310,368 @@ describe('SessionPickerComponent', () => {
         );
       }
     }
+  });
+
+  it('calls onToggleScope with the selected session id when Ctrl+A is pressed', () => {
+    const onToggleScope = vi.fn();
+    const component = new SessionPickerComponent({
+      sessions: [
+        {
+          id: 'ses_a',
+          title: 'Session A',
+          work_dir: '/tmp/project-a',
+          updated_at: 1,
+        },
+        {
+          id: 'ses_b',
+          title: 'Session B',
+          work_dir: '/tmp/project-b',
+          updated_at: 2,
+        },
+      ],
+      loading: false,
+      currentSessionId: '',
+      scope: 'cwd',
+      onSelect: vi.fn(),
+      onCancel: vi.fn(),
+      onToggleScope,
+    });
+
+    component.handleInput('\u001b[B');
+    component.handleInput('\u0001');
+
+    expect(onToggleScope).toHaveBeenCalledOnce();
+    expect(onToggleScope).toHaveBeenCalledWith('ses_b');
+  });
+
+  it('renders all-sessions scope header and Ctrl+A current-cwd hint', () => {
+    const component = new SessionPickerComponent({
+      sessions: [
+        {
+          id: 'ses_all',
+          title: 'All scope session',
+          work_dir: '/tmp/project',
+          updated_at: 1,
+        },
+      ],
+      loading: false,
+      currentSessionId: '',
+      scope: 'all',
+      onSelect: vi.fn(),
+      onCancel: vi.fn(),
+      onToggleScope: vi.fn(),
+    });
+
+    const output = renderPlain(component);
+
+    expect(output).toContain('All sessions');
+    expect(output).toContain('↑↓ navigate · Ctrl+A current cwd · Enter select · Esc cancel');
+  });
+
+  it('selects the full session row on Enter', () => {
+    const onSelect = vi.fn();
+    const session = {
+      id: 'ses_row',
+      title: 'Row session',
+      work_dir: '/tmp/project-row',
+      updated_at: 1,
+    };
+    const component = new SessionPickerComponent({
+      sessions: [session],
+      loading: false,
+      currentSessionId: '',
+      scope: 'cwd',
+      onSelect,
+      onCancel: vi.fn(),
+    });
+
+    component.handleInput('\r');
+
+    expect(onSelect).toHaveBeenCalledOnce();
+    expect(onSelect).toHaveBeenCalledWith(session);
+  });
+
+  it('loads the next 50 sessions after moving past the loaded page', () => {
+    const now = new Date('2026-05-11T12:00:00.000Z').getTime();
+    vi.spyOn(Date, 'now').mockReturnValue(now);
+    const component = new SessionPickerComponent({
+      sessions: Array.from({ length: 120 }, (_, index) => ({
+        id: `ses_${String(index).padStart(4, '0')}`,
+        title: `Session ${String(index).padStart(4, '0')}`,
+        work_dir: '/tmp/project',
+        updated_at: now - index * 1000,
+      })),
+      loading: false,
+      currentSessionId: '',
+      scope: 'all',
+      pageSize: 50,
+      maxVisibleSessions: 4,
+      onSelect: vi.fn(),
+      onCancel: vi.fn(),
+    });
+
+    for (let i = 0; i < 50; i++) {
+      component.handleInput('\u001b[B');
+    }
+
+    const output = renderPlain(component);
+
+    expect(output).toContain('Session 0050');
+    expect(output).toContain('Showing 49-52 of 100 loaded / 120 sessions');
+  });
+
+  it('keeps initial selected session id and loads enough pages for it', () => {
+    const component = new SessionPickerComponent({
+      sessions: Array.from({ length: 80 }, (_, index) => ({
+        id: `ses_${String(index).padStart(4, '0')}`,
+        title: `Session ${String(index).padStart(4, '0')}`,
+        work_dir: '/tmp/project',
+        updated_at: index,
+      })),
+      loading: false,
+      currentSessionId: '',
+      scope: 'all',
+      initialSelectedSessionId: 'ses_0070',
+      pageSize: 50,
+      maxVisibleSessions: 4,
+      onSelect: vi.fn(),
+      onCancel: vi.fn(),
+    });
+
+    const output = renderPlain(component);
+
+    expect(output).toContain('Session 0070');
+    expect(output).toContain('Showing 69-72 of 80 sessions');
+  });
+
+  it('shows type-to-search copy only when the query is empty', () => {
+    const component = new SessionPickerComponent({
+      sessions: [
+        {
+          id: 'ses_search_copy',
+          title: 'Search copy session',
+          work_dir: '/tmp/project',
+          updated_at: 1,
+        },
+      ],
+      loading: false,
+      currentSessionId: '',
+      onSelect: vi.fn(),
+      onCancel: vi.fn(),
+    });
+
+    const output = renderPlain(component);
+
+    expect(output).toContain('Sessions  (type to search)');
+    expect(output).not.toContain('Search:');
+
+    component.handleInput('x');
+    const searchOutput = renderPlain(component);
+
+    expect(searchOutput).toContain('Search: x');
+    expect(searchOutput).not.toContain('Sessions  (type to search)');
+  });
+
+  it('fuzzy-filters by session name only when typing', () => {
+    const component = new SessionPickerComponent({
+      sessions: [
+        {
+          id: 'ses_alpha',
+          title: 'Alpha session',
+          last_prompt: 'needleprompt do not match',
+          work_dir: '/tmp/needleprompt',
+          updated_at: 1,
+        },
+        {
+          id: 'ses_beta',
+          title: 'Beta session',
+          last_prompt: 'other prompt',
+          work_dir: '/tmp/other',
+          updated_at: 2,
+        },
+        {
+          id: 'ses_fuzzy',
+          title: 'N1e2e3d4l5e session',
+          last_prompt: 'prompt only',
+          work_dir: '/tmp/project',
+          updated_at: 3,
+        },
+      ],
+      loading: false,
+      currentSessionId: '',
+      onSelect: vi.fn(),
+      onCancel: vi.fn(),
+    });
+
+    component.handleInput('n');
+    component.handleInput('e');
+    component.handleInput('e');
+    component.handleInput('d');
+    component.handleInput('l');
+    component.handleInput('e');
+
+    const output = renderPlain(component);
+
+    expect(output).toContain('Search: needle');
+    expect(output).toContain('N1e2e3d4l5e session');
+    expect(output).not.toContain('Alpha session');
+    expect(output).not.toContain('Beta session');
+  });
+
+  it('clears the query on Backspace and cancels on Esc only after the query is empty', () => {
+    const onCancel = vi.fn();
+    const component = new SessionPickerComponent({
+      sessions: [
+        {
+          id: 'ses_alpha',
+          title: 'Alpha session',
+          work_dir: '/tmp/project',
+          updated_at: 1,
+        },
+        {
+          id: 'ses_beta',
+          title: 'Beta session',
+          work_dir: '/tmp/project',
+          updated_at: 2,
+        },
+      ],
+      loading: false,
+      currentSessionId: '',
+      onSelect: vi.fn(),
+      onCancel,
+    });
+
+    component.handleInput('z');
+    expect(renderPlain(component)).toContain('Search: z');
+
+    component.handleInput(BACKSPACE);
+    expect(renderPlain(component)).not.toContain('Search:');
+    expect(onCancel).not.toHaveBeenCalled();
+
+    component.handleInput('z');
+    expect(renderPlain(component)).toContain('Search: z');
+
+    component.handleInput(ESC);
+    expect(renderPlain(component)).not.toContain('Search:');
+    expect(onCancel).not.toHaveBeenCalled();
+
+    component.handleInput(ESC);
+    expect(onCancel).toHaveBeenCalledOnce();
+  });
+
+  it('selects the filtered session row on Enter', () => {
+    const onSelect = vi.fn();
+    const target = {
+      id: 'ses_gamma',
+      title: 'Gamma session',
+      work_dir: '/tmp/project-gamma',
+      updated_at: 3,
+    };
+    const component = new SessionPickerComponent({
+      sessions: [
+        {
+          id: 'ses_alpha',
+          title: 'Alpha session',
+          work_dir: '/tmp/project-alpha',
+          updated_at: 1,
+        },
+        {
+          id: 'ses_beta',
+          title: 'Beta session',
+          work_dir: '/tmp/project-beta',
+          updated_at: 2,
+        },
+        target,
+      ],
+      loading: false,
+      currentSessionId: '',
+      onSelect,
+      onCancel: vi.fn(),
+    });
+
+    component.handleInput('g');
+    component.handleInput('a');
+    component.handleInput('m');
+    component.handleInput('\r');
+
+    expect(onSelect).toHaveBeenCalledOnce();
+    expect(onSelect).toHaveBeenCalledWith(target);
+  });
+
+  it('loads the next 50 matching sessions after moving past the filtered page', () => {
+    const now = new Date('2026-05-11T12:00:00.000Z').getTime();
+    vi.spyOn(Date, 'now').mockReturnValue(now);
+    const component = new SessionPickerComponent({
+      sessions: [
+        ...Array.from({ length: 80 }, (_, index) => ({
+          id: `ses_needle_${String(index).padStart(4, '0')}`,
+          title: `Needle ${String(index).padStart(4, '0')}`,
+          work_dir: '/tmp/project',
+          updated_at: now - index * 1000,
+        })),
+        ...Array.from({ length: 40 }, (_, index) => ({
+          id: `ses_other_${String(index).padStart(4, '0')}`,
+          title: `Other ${String(index).padStart(4, '0')}`,
+          work_dir: '/tmp/project',
+          updated_at: now - (80 + index) * 1000,
+        })),
+      ],
+      loading: false,
+      currentSessionId: '',
+      pageSize: 50,
+      maxVisibleSessions: 4,
+      onSelect: vi.fn(),
+      onCancel: vi.fn(),
+    });
+
+    component.handleInput('n');
+    component.handleInput('e');
+    component.handleInput('e');
+    component.handleInput('d');
+    component.handleInput('l');
+    component.handleInput('e');
+    for (let i = 0; i < 50; i++) {
+      component.handleInput('\u001b[B');
+    }
+
+    const output = renderPlain(component);
+
+    expect(output).toContain('Needle 0050');
+    expect(output).toContain('Showing 49-52 of 80 loaded / 80 matches');
+  });
+
+  it('calls onToggleScope with the selected filtered session id when Ctrl+A is pressed', () => {
+    const onToggleScope = vi.fn();
+    const component = new SessionPickerComponent({
+      sessions: [
+        {
+          id: 'ses_alpha',
+          title: 'Alpha session',
+          work_dir: '/tmp/project-a',
+          updated_at: 1,
+        },
+        {
+          id: 'ses_beta',
+          title: 'Beta session',
+          work_dir: '/tmp/project-b',
+          updated_at: 2,
+        },
+      ],
+      loading: false,
+      currentSessionId: '',
+      scope: 'cwd',
+      onSelect: vi.fn(),
+      onCancel: vi.fn(),
+      onToggleScope,
+    });
+
+    component.handleInput('b');
+    component.handleInput('e');
+    component.handleInput('t');
+    component.handleInput('a');
+    component.handleInput('\u0001');
+
+    expect(onToggleScope).toHaveBeenCalledOnce();
+    expect(onToggleScope).toHaveBeenCalledWith('ses_beta');
   });
 });

--- a/apps/kimi-code/test/tui/create-tui-state.test.ts
+++ b/apps/kimi-code/test/tui/create-tui-state.test.ts
@@ -78,6 +78,7 @@ describe('createTUIState', () => {
     expect(state.activeDialog).toBeNull();
     expect(state.externalEditorRunning).toBe(false);
     expect(state.loadingSessions).toBe(false);
+    expect(state.sessionsScope).toBe('cwd');
     expect(state.activitySpinner).toBeNull();
   });
 });

--- a/apps/kimi-code/test/tui/kimi-tui-startup.test.ts
+++ b/apps/kimi-code/test/tui/kimi-tui-startup.test.ts
@@ -8,6 +8,7 @@ import { promptPlatformSelection, promptLogoutProviderSelection } from '#/tui/co
 import { BannerComponent } from '#/tui/components/chrome/banner';
 import { WelcomeComponent } from '#/tui/components/chrome/welcome';
 import { KimiTUI, type KimiTUIStartupInput, type TUIState } from '#/tui/kimi-tui';
+import { copyTextToClipboard } from '#/utils/clipboard/clipboard-text';
 import {
   DISABLE_TERMINAL_THEME_REPORTING,
   ENABLE_TERMINAL_THEME_REPORTING,
@@ -20,6 +21,11 @@ vi.mock('#/tui/commands/prompts', async (importOriginal) => {
   const actual = await importOriginal<typeof import('#/tui/commands/prompts')>();
   return { ...actual, promptPlatformSelection: vi.fn(), promptLogoutProviderSelection: vi.fn() };
 });
+vi.mock('#/utils/clipboard/clipboard-text', () => ({
+  copyTextToClipboard: vi.fn(async () => {}),
+}));
+
+const copyTextToClipboardMock = vi.mocked(copyTextToClipboard);
 
 interface StartupDriver {
   state: TUIState;
@@ -692,6 +698,165 @@ describe('KimiTUI startup', () => {
 
     expect(session.setPlanMode).not.toHaveBeenCalled();
     expect(driver.state.appState.planMode).toBe(true);
+  });
+
+  it('toggles the sessions picker from current cwd to all sessions with Ctrl+A', async () => {
+    const currentWorkDirSession = {
+      id: 'ses-cwd',
+      title: 'Current cwd session',
+      workDir: '/tmp/proj-a',
+      updatedAt: Date.now(),
+    };
+    const otherWorkDirSession = {
+      id: 'ses-other-cwd',
+      title: 'Other cwd session',
+      workDir: '/tmp/proj-b',
+      updatedAt: Date.now() - 1000,
+    };
+    const listSessions = vi.fn(async (input: { workDir?: string } = {}) => {
+      if (input.workDir === '/tmp/proj-a') return [currentWorkDirSession];
+      return [currentWorkDirSession, otherWorkDirSession];
+    });
+    const harness = makeHarness(makeSession({ id: 'ses-current' }), { listSessions });
+    const driver = makeDriver(harness, makeStartupInput());
+    await expect(driver.init()).resolves.toBe(false);
+
+    await (driver as unknown as { showSessionPicker(): Promise<void> }).showSessionPicker();
+    const picker = driver.state.editorContainer.children[0] as { handleInput(data: string): void };
+    picker.handleInput('\u0001');
+    await new Promise((resolve) => setImmediate(resolve));
+
+    expect(listSessions).toHaveBeenNthCalledWith(1, { workDir: '/tmp/proj-a' });
+    expect(listSessions).toHaveBeenNthCalledWith(2, {});
+    expect(driver.state.sessionsScope).toBe('all');
+    expect(driver.state.sessions.map((session) => session.id)).toEqual([
+      'ses-cwd',
+      'ses-other-cwd',
+    ]);
+  });
+
+  it('toggles the sessions picker from all sessions back to current cwd with Ctrl+A', async () => {
+    const currentWorkDirSession = {
+      id: 'ses-cwd',
+      title: 'Current cwd session',
+      workDir: '/tmp/proj-a',
+      updatedAt: Date.now(),
+    };
+    const otherWorkDirSession = {
+      id: 'ses-other-cwd',
+      title: 'Other cwd session',
+      workDir: '/tmp/proj-b',
+      updatedAt: Date.now() - 1000,
+    };
+    const listSessions = vi.fn(async (input: { workDir?: string } = {}) => {
+      if (input.workDir === '/tmp/proj-a') return [currentWorkDirSession];
+      return [currentWorkDirSession, otherWorkDirSession];
+    });
+    const harness = makeHarness(makeSession({ id: 'ses-current' }), { listSessions });
+    const driver = makeDriver(harness, makeStartupInput());
+    await expect(driver.init()).resolves.toBe(false);
+
+    await (driver as unknown as { showSessionPicker(): Promise<void> }).showSessionPicker();
+    const firstPicker = driver.state.editorContainer.children[0] as { handleInput(data: string): void };
+    firstPicker.handleInput('\u0001');
+    await new Promise((resolve) => setImmediate(resolve));
+    const allPicker = driver.state.editorContainer.children[0] as { handleInput(data: string): void };
+    allPicker.handleInput('\u0001');
+    await new Promise((resolve) => setImmediate(resolve));
+
+    expect(listSessions).toHaveBeenNthCalledWith(3, { workDir: '/tmp/proj-a' });
+    expect(driver.state.sessionsScope).toBe('cwd');
+    expect(driver.state.sessions.map((session) => session.id)).toEqual(['ses-cwd']);
+  });
+
+  it('clears the sessions picker search query when toggling scope with Ctrl+A', async () => {
+    const currentWorkDirSession = {
+      id: 'ses-cwd',
+      title: 'Current cwd session',
+      workDir: '/tmp/proj-a',
+      updatedAt: Date.now(),
+    };
+    const otherWorkDirSession = {
+      id: 'ses-other-cwd',
+      title: 'Other cwd session',
+      workDir: '/tmp/proj-b',
+      updatedAt: Date.now() - 1000,
+    };
+    const listSessions = vi.fn(async (input: { workDir?: string } = {}) => {
+      if (input.workDir === '/tmp/proj-a') return [currentWorkDirSession];
+      return [currentWorkDirSession, otherWorkDirSession];
+    });
+    const harness = makeHarness(makeSession({ id: 'ses-current' }), { listSessions });
+    const driver = makeDriver(harness, makeStartupInput());
+    await expect(driver.init()).resolves.toBe(false);
+
+    await (driver as unknown as { showSessionPicker(): Promise<void> }).showSessionPicker();
+    const firstPicker = driver.state.editorContainer.children[0] as {
+      handleInput(data: string): void;
+      render(width: number): string[];
+    };
+    firstPicker.handleInput('c');
+    firstPicker.handleInput('w');
+    firstPicker.handleInput('d');
+    expect(firstPicker.render(160).join('\n')).toContain('Search: cwd');
+
+    firstPicker.handleInput('\u0001');
+    await new Promise((resolve) => setImmediate(resolve));
+
+    const allPicker = driver.state.editorContainer.children[0] as {
+      handleInput(data: string): void;
+      render(width: number): string[];
+    };
+    const output = allPicker.render(160).join('\n');
+
+    expect(driver.state.sessionsScope).toBe('all');
+    expect(output).toContain('All sessions');
+    expect(output).toContain('(type to search)');
+    expect(output).not.toContain('Search: cwd');
+  });
+
+  it('does not resume a session from a different cwd and shows a cd hint', async () => {
+    const currentWorkDirSession = {
+      id: 'ses-cwd',
+      title: 'Current cwd session',
+      workDir: '/tmp/proj-a',
+      updatedAt: Date.now(),
+    };
+    const otherWorkDirSession = {
+      id: 'ses-other-cwd',
+      title: 'Other cwd session',
+      workDir: '/tmp/proj-b',
+      updatedAt: Date.now() - 1000,
+    };
+    const resumeSession = vi.fn(async () => makeSession({ id: 'ses-other-cwd' }));
+    const harness = makeHarness(makeSession({ id: 'ses-current' }), {
+      resumeSession,
+      listSessions: vi.fn(async () => [currentWorkDirSession, otherWorkDirSession]),
+    });
+    const driver = makeDriver(harness, makeStartupInput());
+    await expect(driver.init()).resolves.toBe(false);
+    copyTextToClipboardMock.mockClear();
+
+    await (driver as unknown as { showSessionPicker(): Promise<void> }).showSessionPicker();
+    const picker = driver.state.editorContainer.children[0] as { handleInput(data: string): void };
+    picker.handleInput('\u001b[B');
+    picker.handleInput('\r');
+    await new Promise((resolve) => setImmediate(resolve));
+
+    expect(resumeSession).not.toHaveBeenCalled();
+    expect(driver.state.activeDialog).toBeNull();
+    expect(copyTextToClipboardMock).toHaveBeenCalledWith(
+      'cd "/tmp/proj-b" && kimi --resume ses-other-cwd',
+    );
+    const transcript = driver.state.transcriptContainer.render(160).join('\n');
+    expect(transcript).toContain('Current session is in a different working directory.');
+    expect(transcript).toContain(
+      'To resume, run: cd "/tmp/proj-b" && kimi --resume ses-other-cwd',
+    );
+    expect(transcript).toContain(
+      'To resume, run: cd "/tmp/proj-b" && kimi --resume ses-other-cwd',
+    );
+    expect(transcript).toContain('Command copied to clipboard');
   });
 
   it('does not apply startup flags when switching sessions via the /sessions picker', async () => {

--- a/apps/kimi-code/test/tui/kimi-tui-startup.test.ts
+++ b/apps/kimi-code/test/tui/kimi-tui-startup.test.ts
@@ -769,6 +769,47 @@ describe('KimiTUI startup', () => {
     expect(driver.state.sessions.map((session) => session.id)).toEqual(['ses-cwd']);
   });
 
+  it('does not remount the session picker after it is closed while a scope toggle is pending', async () => {
+    const currentWorkDirSession = {
+      id: 'ses-cwd',
+      title: 'Current cwd session',
+      workDir: '/tmp/proj-a',
+      updatedAt: Date.now(),
+    };
+    const otherWorkDirSession = {
+      id: 'ses-other-cwd',
+      title: 'Other cwd session',
+      workDir: '/tmp/proj-b',
+      updatedAt: Date.now() - 1000,
+    };
+    let resolveAllSessions: ((value: unknown[]) => void) | undefined;
+    const listSessions = vi.fn((input: { workDir?: string } = {}) => {
+      if (input.workDir === '/tmp/proj-a') return Promise.resolve([currentWorkDirSession]);
+      return new Promise<unknown[]>((resolve) => {
+        resolveAllSessions = resolve;
+      });
+    });
+    const harness = makeHarness(makeSession({ id: 'ses-current' }), { listSessions });
+    const driver = makeDriver(harness, makeStartupInput());
+    const mountSessionPicker = vi.spyOn(
+      driver as unknown as { mountSessionPicker(options: unknown): void },
+      'mountSessionPicker',
+    );
+    await expect(driver.init()).resolves.toBe(false);
+
+    await (driver as unknown as { showSessionPicker(): Promise<void> }).showSessionPicker();
+    expect(mountSessionPicker).toHaveBeenCalledTimes(1);
+
+    const picker = driver.state.editorContainer.children[0] as { handleInput(data: string): void };
+    picker.handleInput('\u0001');
+    (driver as unknown as { hideSessionPicker(): void }).hideSessionPicker();
+    resolveAllSessions?.([currentWorkDirSession, otherWorkDirSession]);
+    await new Promise((resolve) => setImmediate(resolve));
+
+    expect(driver.state.activeDialog).toBeNull();
+    expect(mountSessionPicker).toHaveBeenCalledTimes(1);
+  });
+
   it('clears the sessions picker search query when toggling scope with Ctrl+A', async () => {
     const currentWorkDirSession = {
       id: 'ses-cwd',
@@ -839,7 +880,7 @@ describe('KimiTUI startup', () => {
 
     await (driver as unknown as { showSessionPicker(): Promise<void> }).showSessionPicker();
     const picker = driver.state.editorContainer.children[0] as { handleInput(data: string): void };
-    picker.handleInput('\u001b[B');
+    picker.handleInput('\u001B[B');
     picker.handleInput('\r');
     await new Promise((resolve) => setImmediate(resolve));
 
@@ -883,7 +924,7 @@ describe('KimiTUI startup', () => {
 
     await (driver as unknown as { showSessionPicker(): Promise<void> }).showSessionPicker();
     const picker = driver.state.editorContainer.children[0] as { handleInput(data: string): void };
-    picker.handleInput('\u001b[B');
+    picker.handleInput('\u001B[B');
     picker.handleInput('\r');
     await new Promise((resolve) => setImmediate(resolve));
 
@@ -895,6 +936,44 @@ describe('KimiTUI startup', () => {
     expect(transcript).toContain(
       "To resume, run: cd '/tmp/proj$(touch /tmp/pwned)' && kimi --resume 'ses-other-cwd'",
     );
+  });
+
+  it('exits after picking another cwd from the startup picker', async () => {
+    const currentWorkDirSession = {
+      id: 'ses-cwd',
+      title: 'Current cwd session',
+      workDir: '/tmp/proj-a',
+      updatedAt: Date.now(),
+    };
+    const otherWorkDirSession = {
+      id: 'ses-other-cwd',
+      title: 'Other cwd session',
+      workDir: '/tmp/proj-b',
+      updatedAt: Date.now() - 1000,
+    };
+    const resumeSession = vi.fn(async () => makeSession({ id: 'ses-other-cwd' }));
+    const harness = makeHarness(makeSession({ id: 'ses-current' }), {
+      resumeSession,
+      listSessions: vi.fn(async () => [currentWorkDirSession, otherWorkDirSession]),
+    });
+    const driver = makeDriver(harness, makeStartupInput({ session: '' }));
+    const stop = vi.spyOn(driver, 'stop').mockResolvedValue(undefined);
+    copyTextToClipboardMock.mockClear();
+
+    await expect((driver as unknown as MigrateExitDriver).initMainTui()).resolves.toBe(false);
+    await (driver as unknown as { bootstrapFromPicker(): Promise<void> }).bootstrapFromPicker();
+
+    const picker = driver.state.editorContainer.children[0] as { handleInput(data: string): void };
+    picker.handleInput('\u001B[B');
+    picker.handleInput('\r');
+    await new Promise((resolve) => setImmediate(resolve));
+
+    expect(resumeSession).not.toHaveBeenCalled();
+    expect(copyTextToClipboardMock).toHaveBeenCalledWith(
+      "cd '/tmp/proj-b' && kimi --resume 'ses-other-cwd'",
+    );
+    expect(stop).toHaveBeenCalledOnce();
+    expect(stop).toHaveBeenCalledWith(0);
   });
 
   it('does not apply startup flags when switching sessions via the /sessions picker', async () => {

--- a/apps/kimi-code/test/tui/kimi-tui-startup.test.ts
+++ b/apps/kimi-code/test/tui/kimi-tui-startup.test.ts
@@ -846,17 +846,55 @@ describe('KimiTUI startup', () => {
     expect(resumeSession).not.toHaveBeenCalled();
     expect(driver.state.activeDialog).toBeNull();
     expect(copyTextToClipboardMock).toHaveBeenCalledWith(
-      'cd "/tmp/proj-b" && kimi --resume ses-other-cwd',
+      "cd '/tmp/proj-b' && kimi --resume 'ses-other-cwd'",
     );
     const transcript = driver.state.transcriptContainer.render(160).join('\n');
     expect(transcript).toContain('Current session is in a different working directory.');
     expect(transcript).toContain(
-      'To resume, run: cd "/tmp/proj-b" && kimi --resume ses-other-cwd',
+      "To resume, run: cd '/tmp/proj-b' && kimi --resume 'ses-other-cwd'",
     );
     expect(transcript).toContain(
-      'To resume, run: cd "/tmp/proj-b" && kimi --resume ses-other-cwd',
+      "To resume, run: cd '/tmp/proj-b' && kimi --resume 'ses-other-cwd'",
     );
     expect(transcript).toContain('Command copied to clipboard');
+  });
+
+  it('copies a shell-safe resume command for another cwd with metacharacters', async () => {
+    const currentWorkDirSession = {
+      id: 'ses-cwd',
+      title: 'Current cwd session',
+      workDir: '/tmp/proj-a',
+      updatedAt: Date.now(),
+    };
+    const otherWorkDirSession = {
+      id: 'ses-other-cwd',
+      title: 'Other cwd session',
+      workDir: '/tmp/proj$(touch /tmp/pwned)',
+      updatedAt: Date.now() - 1000,
+    };
+    const resumeSession = vi.fn(async () => makeSession({ id: 'ses-other-cwd' }));
+    const harness = makeHarness(makeSession({ id: 'ses-current' }), {
+      resumeSession,
+      listSessions: vi.fn(async () => [currentWorkDirSession, otherWorkDirSession]),
+    });
+    const driver = makeDriver(harness, makeStartupInput());
+    await expect(driver.init()).resolves.toBe(false);
+    copyTextToClipboardMock.mockClear();
+
+    await (driver as unknown as { showSessionPicker(): Promise<void> }).showSessionPicker();
+    const picker = driver.state.editorContainer.children[0] as { handleInput(data: string): void };
+    picker.handleInput('\u001b[B');
+    picker.handleInput('\r');
+    await new Promise((resolve) => setImmediate(resolve));
+
+    expect(resumeSession).not.toHaveBeenCalled();
+    expect(copyTextToClipboardMock).toHaveBeenCalledWith(
+      "cd '/tmp/proj$(touch /tmp/pwned)' && kimi --resume 'ses-other-cwd'",
+    );
+    const transcript = driver.state.transcriptContainer.render(160).join('\n');
+    expect(transcript).toContain(
+      "To resume, run: cd '/tmp/proj$(touch /tmp/pwned)' && kimi --resume 'ses-other-cwd'",
+    );
   });
 
   it('does not apply startup flags when switching sessions via the /sessions picker', async () => {

--- a/apps/kimi-code/test/utils/clipboard/clipboard-text.test.ts
+++ b/apps/kimi-code/test/utils/clipboard/clipboard-text.test.ts
@@ -1,0 +1,25 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { clipboard } from '#/utils/clipboard/clipboard-native';
+import { copyTextToClipboard } from '#/utils/clipboard/clipboard-text';
+
+vi.mock('#/utils/clipboard/clipboard-native', () => ({
+  clipboard: {
+    setText: vi.fn(),
+  },
+}));
+
+const clipboardMock = clipboard as unknown as { setText: ReturnType<typeof vi.fn> };
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('copyTextToClipboard', () => {
+  it('copies text with the native clipboard when available', async () => {
+    clipboardMock.setText.mockResolvedValue(undefined);
+
+    await expect(copyTextToClipboard('cd "/tmp/proj-b"')).resolves.toBeUndefined();
+    expect(clipboardMock.setText).toHaveBeenCalledWith('cd "/tmp/proj-b"');
+  });
+});

--- a/apps/kimi-code/test/utils/clipboard/clipboard-text.test.ts
+++ b/apps/kimi-code/test/utils/clipboard/clipboard-text.test.ts
@@ -1,7 +1,12 @@
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { spawnSync } from 'node:child_process';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { clipboard } from '#/utils/clipboard/clipboard-native';
 import { copyTextToClipboard } from '#/utils/clipboard/clipboard-text';
+
+vi.mock('node:child_process', () => ({
+  spawnSync: vi.fn(),
+}));
 
 vi.mock('#/utils/clipboard/clipboard-native', () => ({
   clipboard: {
@@ -10,9 +15,16 @@ vi.mock('#/utils/clipboard/clipboard-native', () => ({
 }));
 
 const clipboardMock = clipboard as unknown as { setText: ReturnType<typeof vi.fn> };
+const spawnSyncMock = vi.mocked(spawnSync);
 
 afterEach(() => {
   vi.clearAllMocks();
+});
+
+beforeEach(() => {
+  spawnSyncMock.mockImplementation(() => {
+    throw new Error('platform clipboard fallback should not run');
+  });
 });
 
 describe('copyTextToClipboard', () => {
@@ -21,5 +33,22 @@ describe('copyTextToClipboard', () => {
 
     await expect(copyTextToClipboard('cd "/tmp/proj-b"')).resolves.toBeUndefined();
     expect(clipboardMock.setText).toHaveBeenCalledWith('cd "/tmp/proj-b"');
+  });
+
+  it('keeps native clipboard method context when copying text', async () => {
+    clipboardMock.setText.mockImplementation(function (this: unknown, text: string): void {
+      expect(this).toBe(clipboardMock);
+      expect(text).toBe('cd "/tmp/proj-b"');
+    });
+
+    await expect(copyTextToClipboard('cd "/tmp/proj-b"')).resolves.toBeUndefined();
+  });
+
+  it('throws an Error when all platform clipboard commands fail', async () => {
+    clipboardMock.setText = undefined as unknown as ReturnType<typeof vi.fn>;
+    spawnSyncMock.mockReturnValue({ status: 1, stderr: 'missing' } as ReturnType<typeof spawnSync>);
+
+    await expect(copyTextToClipboard('cd "/tmp/proj-b"')).rejects.toBeInstanceOf(Error);
+    await expect(copyTextToClipboard('cd "/tmp/proj-b"')).rejects.toThrow('pbcopy exited with code 1: missing');
   });
 });

--- a/apps/kimi-code/test/utils/clipboard/clipboard-text.test.ts
+++ b/apps/kimi-code/test/utils/clipboard/clipboard-text.test.ts
@@ -49,6 +49,8 @@ describe('copyTextToClipboard', () => {
     spawnSyncMock.mockReturnValue({ status: 1, stderr: 'missing' } as ReturnType<typeof spawnSync>);
 
     await expect(copyTextToClipboard('cd "/tmp/proj-b"')).rejects.toBeInstanceOf(Error);
-    await expect(copyTextToClipboard('cd "/tmp/proj-b"')).rejects.toThrow('pbcopy exited with code 1: missing');
+    await expect(copyTextToClipboard('cd "/tmp/proj-b"')).rejects.toThrow(
+      /(?:clip\.exe|pbcopy|wl-copy|xclip) exited with code 1: missing/,
+    );
   });
 });


### PR DESCRIPTION
## Related Issue

No linked issue.

## Problem

The sessions picker previously only showed sessions for the current working directory and did not support filtering by session name. This made it hard to find and resume older sessions, especially sessions stored under other working directories.

## What changed

- Added a current/all sessions picker scope with `Ctrl+A`.
- Added type-to-search filtering by session name in the sessions picker.
- Kept frontend paginated browsing over the filtered result set.
- Added a clipboard-ready resume command for sessions in other working directories.
- Added component, startup, and clipboard utility tests for the new behavior.
- Added a changeset for `@moonshot-ai/kimi-code`.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.