### PR TITLE
feat(agent-core): extend same-language rule to model reasoning

### DIFF
--- a/.changeset/think-in-user-language.md
+++ b/.changeset/think-in-user-language.md
@@ -1,0 +1,6 @@
+---
+"@moonshot-ai/agent-core": patch
+"@moonshot-ai/kimi-code": patch
+---
+
+Extend the same-language rule to the model's reasoning, so thinking follows the user's language while keeping code and technical terms in their original form.

--- a/packages/agent-core/src/profile/default/system.md
+++ b/packages/agent-core/src/profile/default/system.md
@@ -24,7 +24,7 @@ If the `Bash`, `TaskList`, `TaskOutput`, and `TaskStop` tools are available and 
 
 If a foreground tool call or a background agent requests approval, the approval is coordinated through the unified approval runtime and surfaced through the root UI channel. Do not assume approvals are local to a single subagent turn.
 
-When responding to the user, you MUST use the SAME language as the user, unless explicitly instructed to do otherwise.
+When responding to the user, you MUST use the SAME language as the user, unless explicitly instructed to do otherwise. This applies to your reasoning and thinking as well, not just your final reply — think in the user's language, while keeping code, commands, identifiers, file paths, and technical terms in their original form.
 
 # General Guidelines for Coding
 


### PR DESCRIPTION
## Problem

The default system prompt told the model to reply in the user's language, but
the rule only covered the final reply. The model's reasoning still ran in
English regardless of the user's language, so non-English users saw English
chains of thought with little same-language narration, making trajectories hard
to review.

## What changed

Extended the same-language rule in the default system prompt to also cover the
model's reasoning and thinking, not just the final reply. Code, commands,
identifiers, file paths, and technical terms are explicitly kept in their
original form to avoid forced translation of code.

Scope is prompt-only (no code paths touched). Effectiveness varies by
model/provider — models that surface only reasoning summaries may not fully
honor this; worth an A/B on reasoning quality before relying on it.
