### PR TITLE
fix(kosong): isolate anthropic auth environment

### DIFF
--- a/.changeset/anthropic-env-auth.md
+++ b/.changeset/anthropic-env-auth.md
@@ -3,4 +3,8 @@
 "@moonshot-ai/kosong": patch
 ---
 
-Prevent Anthropic provider authentication from inheriting unrelated shell credentials.
+Isolate the Anthropic adapter from ambient shell credentials.
+
+The adapter is used as a generic transport to *any* anthropic-compatible endpoint (`baseUrl` may point at a third-party gateway). The underlying Anthropic SDK, however, auto-discovers credentials from the shell environment by default. When the endpoint is not official this leaks: even with an explicit API key configured, the SDK would still read `ANTHROPIC_AUTH_TOKEN` from the environment and attach it as an `Authorization: Bearer` header — sending an out-of-band token (often injected by another tool, unbeknownst to the user) to the third-party `baseUrl`. The adapter now hard-disables every SDK environment auto-discovery channel (`authToken`, `baseURL`, custom headers) and uses only host-provided credentials.
+
+**Behavior change:** the adapter no longer reads `ANTHROPIC_API_KEY` / `ANTHROPIC_AUTH_TOKEN` / `ANTHROPIC_BASE_URL` / `ANTHROPIC_CUSTOM_HEADERS` from the shell. Configure credentials through provider config (`apiKey` or `[provider.env]`) instead.

--- a/.changeset/anthropic-env-auth.md
+++ b/.changeset/anthropic-env-auth.md
@@ -1,0 +1,6 @@
+---
+"@moonshot-ai/kimi-code": patch
+"@moonshot-ai/kosong": patch
+---
+
+Prevent Anthropic provider authentication from inheriting unrelated shell credentials.

--- a/packages/kosong/src/providers/anthropic.ts
+++ b/packages/kosong/src/providers/anthropic.ts
@@ -37,11 +37,7 @@ import type {
   ToolUseBlockParam,
 } from '@anthropic-ai/sdk/resources/messages/messages.js';
 
-import {
-  mergeRequestHeaders,
-  requireProviderApiKey,
-  resolveAuthBackedClient,
-} from './request-auth';
+import { mergeRequestHeaders, resolveAuthBackedClient } from './request-auth';
 import {
   normalizeToolCallIdsForProvider,
   sanitizeToolCallId,
@@ -862,7 +858,7 @@ export class AnthropicChatProvider implements ChatProvider {
   private _metadata: Record<string, string> | undefined;
   private _apiKey: string | undefined;
   private _baseUrl: string | undefined;
-  private _defaultHeaders: Record<string, string> | undefined;
+  private _defaultHeaders: Record<string, string | null> | undefined;
   private _clientFactory: ((auth: ProviderRequestAuth) => Anthropic) | undefined;
   private _adaptiveThinking: boolean | undefined;
   private _explicitMaxTokens: boolean;
@@ -1073,16 +1069,35 @@ export class AnthropicChatProvider implements ChatProvider {
     return resolveAuthBackedClient(
       { cachedClient: this._client, clientFactory: this._clientFactory },
       auth,
-      (a) => this._buildClient(requireProviderApiKey('AnthropicChatProvider', a, this._apiKey)),
+      (a) => this._buildClient(this._requireApiKey(a)),
     );
+  }
+
+  private _requireApiKey(auth: ProviderRequestAuth | undefined): string {
+    const apiKey = auth?.apiKey ?? this._apiKey;
+    if (apiKey === undefined || apiKey.length === 0) {
+      throw new ChatProviderError(
+        'AnthropicChatProvider: apiKey is required. Provide it via constructor options, options.auth.apiKey on each request, or an OAuth login. The Anthropic adapter does not read shell API-key environment variables.',
+      );
+    }
+    return apiKey;
+  }
+
+  private _buildDefaultHeaders(apiKey: string): Record<string, string | null> {
+    const defaultHeaders: Record<string, string | null> = { authorization: null };
+    for (const [name, value] of Object.entries(this._defaultHeaders ?? {})) {
+      defaultHeaders[name.toLowerCase()] = value;
+    }
+    defaultHeaders['x-api-key'] = apiKey;
+    return defaultHeaders;
   }
 
   private _buildClient(apiKey: string): Anthropic {
     return new Anthropic({
       apiKey,
       authToken: null,
-      baseURL: this._baseUrl,
-      defaultHeaders: this._defaultHeaders,
+      baseURL: this._baseUrl ?? null,
+      defaultHeaders: this._buildDefaultHeaders(apiKey),
     });
   }
 

--- a/packages/kosong/src/providers/anthropic.ts
+++ b/packages/kosong/src/providers/anthropic.ts
@@ -1110,6 +1110,15 @@ export class AnthropicChatProvider implements ChatProvider {
     return defaultHeaders;
   }
 
+  // We use the Anthropic SDK purely as a transport to arbitrary
+  // anthropic-compatible endpoints (`baseUrl` may point anywhere). Left to its
+  // defaults the SDK auto-discovers credentials from the shell environment
+  // (ANTHROPIC_AUTH_TOKEN, ANTHROPIC_BASE_URL, ANTHROPIC_CUSTOM_HEADERS), which
+  // would leak an out-of-band bearer/headers to a third-party endpoint even when
+  // an explicit apiKey is set. So we hard-disable every auto-discovery channel.
+  // These `null`s — and the nulled headers in _buildDefaultHeaders — are NOT
+  // redundant: removing them reintroduces credential leakage. Regression cover:
+  // test/e2e/anthropic-adapter.test.ts.
   private _buildClient(apiKey: string): Anthropic {
     return new Anthropic({
       apiKey,

--- a/packages/kosong/src/providers/anthropic.ts
+++ b/packages/kosong/src/providers/anthropic.ts
@@ -1083,8 +1083,26 @@ export class AnthropicChatProvider implements ChatProvider {
     return apiKey;
   }
 
+  private _anthropicCustomHeaderEnvNames(): string[] {
+    const customHeaders = process.env['ANTHROPIC_CUSTOM_HEADERS'];
+    if (customHeaders === undefined || customHeaders.length === 0) return [];
+
+    const names: string[] = [];
+    for (const line of customHeaders.split('\n')) {
+      const colonIndex = line.indexOf(':');
+      if (colonIndex < 0) continue;
+
+      const name = line.slice(0, colonIndex).trim().toLowerCase();
+      if (name.length > 0) names.push(name);
+    }
+    return names;
+  }
+
   private _buildDefaultHeaders(apiKey: string): Record<string, string | null> {
     const defaultHeaders: Record<string, string | null> = { authorization: null };
+    for (const name of this._anthropicCustomHeaderEnvNames()) {
+      defaultHeaders[name] = null;
+    }
     for (const [name, value] of Object.entries(this._defaultHeaders ?? {})) {
       defaultHeaders[name.toLowerCase()] = value;
     }

--- a/packages/kosong/src/providers/anthropic.ts
+++ b/packages/kosong/src/providers/anthropic.ts
@@ -872,8 +872,8 @@ export class AnthropicChatProvider implements ChatProvider {
     this._stream = options.stream ?? true;
     this._metadata = options.metadata;
     this._adaptiveThinking = options.adaptiveThinking;
-    const apiKey = options.apiKey ?? process.env['ANTHROPIC_API_KEY'];
-    this._apiKey = apiKey === undefined || apiKey.length === 0 ? undefined : apiKey;
+    this._apiKey =
+      options.apiKey === undefined || options.apiKey.length === 0 ? undefined : options.apiKey;
     this._baseUrl = options.baseUrl;
     this._defaultHeaders = options.defaultHeaders;
     this._clientFactory = options.clientFactory;
@@ -1080,6 +1080,7 @@ export class AnthropicChatProvider implements ChatProvider {
   private _buildClient(apiKey: string): Anthropic {
     return new Anthropic({
       apiKey,
+      authToken: null,
       baseURL: this._baseUrl,
       defaultHeaders: this._defaultHeaders,
     });

--- a/packages/kosong/test/anthropic.test.ts
+++ b/packages/kosong/test/anthropic.test.ts
@@ -163,6 +163,28 @@ describe('AnthropicChatProvider', () => {
     }
   });
 
+  it('does not read ANTHROPIC_BASE_URL from process.env inside the adapter', () => {
+    const previousBaseUrl = process.env['ANTHROPIC_BASE_URL'];
+    process.env['ANTHROPIC_BASE_URL'] = 'http://127.0.0.1:1';
+
+    try {
+      const provider = new AnthropicChatProvider({
+        model: 'k25',
+        apiKey: 'test-key',
+        stream: false,
+      });
+      const client = Reflect.get(provider, '_client') as { baseURL?: string } | undefined;
+
+      expect(client?.baseURL).toBe('https://api.anthropic.com');
+    } finally {
+      if (previousBaseUrl === undefined) {
+        delete process.env['ANTHROPIC_BASE_URL'];
+      } else {
+        process.env['ANTHROPIC_BASE_URL'] = previousBaseUrl;
+      }
+    }
+  });
+
   describe('message conversion', () => {
     it('simple user message with system prompt', async () => {
       const provider = createProvider();

--- a/packages/kosong/test/anthropic.test.ts
+++ b/packages/kosong/test/anthropic.test.ts
@@ -142,6 +142,27 @@ const B64_PNG =
   'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAA' +
   'DUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==';
 describe('AnthropicChatProvider', () => {
+  it('does not read ANTHROPIC_API_KEY from process.env inside the adapter', () => {
+    const previousApiKey = process.env['ANTHROPIC_API_KEY'];
+    process.env['ANTHROPIC_API_KEY'] = 'env-key';
+
+    try {
+      const provider = new AnthropicChatProvider({
+        model: 'k25',
+        stream: false,
+      });
+
+      expect(Reflect.get(provider, '_apiKey')).toBeUndefined();
+      expect(Reflect.get(provider, '_client')).toBeUndefined();
+    } finally {
+      if (previousApiKey === undefined) {
+        delete process.env['ANTHROPIC_API_KEY'];
+      } else {
+        process.env['ANTHROPIC_API_KEY'] = previousApiKey;
+      }
+    }
+  });
+
   describe('message conversion', () => {
     it('simple user message with system prompt', async () => {
       const provider = createProvider();

--- a/packages/kosong/test/e2e/anthropic-adapter.test.ts
+++ b/packages/kosong/test/e2e/anthropic-adapter.test.ts
@@ -59,10 +59,14 @@ const MUL_TOOL: Tool = {
 describe('e2e: Anthropic adapter bridge', () => {
   it('sends the adapter request body and parses streamed text, tool use, and usage', async () => {
     const previousAuthToken = process.env['ANTHROPIC_AUTH_TOKEN'];
-    process.env['ANTHROPIC_AUTH_TOKEN'] = 'env-auth-token';
-
+    const previousCustomHeaders = process.env['ANTHROPIC_CUSTOM_HEADERS'];
     const harness = await createFakeProviderHarness();
+
     try {
+      process.env['ANTHROPIC_AUTH_TOKEN'] = 'env-auth-token';
+      process.env['ANTHROPIC_CUSTOM_HEADERS'] =
+        'Authorization: Bearer env-token\nX-Api-Key: env-key';
+
       harness.route('POST', '/v1/messages', async (request, reply) => {
         const body = request.bodyJson as Record<string, unknown>;
         expect(request.pathname).toBe('/v1/messages');
@@ -214,6 +218,11 @@ describe('e2e: Anthropic adapter bridge', () => {
         delete process.env['ANTHROPIC_AUTH_TOKEN'];
       } else {
         process.env['ANTHROPIC_AUTH_TOKEN'] = previousAuthToken;
+      }
+      if (previousCustomHeaders === undefined) {
+        delete process.env['ANTHROPIC_CUSTOM_HEADERS'];
+      } else {
+        process.env['ANTHROPIC_CUSTOM_HEADERS'] = previousCustomHeaders;
       }
       await harness.close();
     }

--- a/packages/kosong/test/e2e/anthropic-adapter.test.ts
+++ b/packages/kosong/test/e2e/anthropic-adapter.test.ts
@@ -20,11 +20,15 @@ async function collectParts(
   return parts;
 }
 
-function makeAnthropicProvider(baseUrl?: string): AnthropicChatProvider {
+function makeAnthropicProvider(
+  baseUrl?: string,
+  defaultHeaders?: Record<string, string>,
+): AnthropicChatProvider {
   return new AnthropicChatProvider({
     model: 'k25',
     apiKey: 'test-key',
     baseUrl,
+    defaultHeaders,
     defaultMaxTokens: 1024,
     stream: true,
   });
@@ -65,7 +69,7 @@ describe('e2e: Anthropic adapter bridge', () => {
     try {
       process.env['ANTHROPIC_AUTH_TOKEN'] = 'env-auth-token';
       process.env['ANTHROPIC_CUSTOM_HEADERS'] =
-        'Authorization: Bearer env-token\nX-Api-Key: env-key';
+        'Authorization: Bearer env-token\nX-Api-Key: env-key\nX-Leak: shell';
 
       harness.route('POST', '/v1/messages', async (request, reply) => {
         const body = request.bodyJson as Record<string, unknown>;
@@ -175,7 +179,7 @@ describe('e2e: Anthropic adapter bridge', () => {
         });
       });
 
-      const provider = makeAnthropicProvider(harness.baseUrl);
+      const provider = makeAnthropicProvider(harness.baseUrl, { 'X-Configured': 'yes' });
 
       const history: Message[] = [
         {
@@ -213,6 +217,8 @@ describe('e2e: Anthropic adapter bridge', () => {
 
       expect(harness.requests).toHaveLength(1);
       expect(harness.requests[0]!.headers['authorization']).toBeUndefined();
+      expect(harness.requests[0]!.headers['x-leak']).toBeUndefined();
+      expect(harness.requests[0]!.headers['x-configured']).toBe('yes');
     } finally {
       if (previousAuthToken === undefined) {
         delete process.env['ANTHROPIC_AUTH_TOKEN'];

--- a/packages/kosong/test/e2e/anthropic-adapter.test.ts
+++ b/packages/kosong/test/e2e/anthropic-adapter.test.ts
@@ -2,7 +2,6 @@ import type { Message, StreamedMessagePart, ToolCall } from '#/message';
 import { AnthropicChatProvider } from '#/providers/anthropic';
 import type { Tool } from '#/tool';
 import type { TokenUsage } from '#/usage';
-import Anthropic from '@anthropic-ai/sdk';
 import { describe, expect, it } from 'vitest';
 
 import { createFakeProviderHarness } from './fake-provider-harness';
@@ -21,10 +20,11 @@ async function collectParts(
   return parts;
 }
 
-function makeAnthropicProvider(): AnthropicChatProvider {
+function makeAnthropicProvider(baseUrl?: string): AnthropicChatProvider {
   return new AnthropicChatProvider({
     model: 'k25',
     apiKey: 'test-key',
+    baseUrl,
     defaultMaxTokens: 1024,
     stream: true,
   });
@@ -58,6 +58,9 @@ const MUL_TOOL: Tool = {
 
 describe('e2e: Anthropic adapter bridge', () => {
   it('sends the adapter request body and parses streamed text, tool use, and usage', async () => {
+    const previousAuthToken = process.env['ANTHROPIC_AUTH_TOKEN'];
+    process.env['ANTHROPIC_AUTH_TOKEN'] = 'env-auth-token';
+
     const harness = await createFakeProviderHarness();
     try {
       harness.route('POST', '/v1/messages', async (request, reply) => {
@@ -168,11 +171,7 @@ describe('e2e: Anthropic adapter bridge', () => {
         });
       });
 
-      const provider = makeAnthropicProvider();
-      (provider as any)._client = new Anthropic({
-        apiKey: 'test-key',
-        baseURL: harness.baseUrl,
-      });
+      const provider = makeAnthropicProvider(harness.baseUrl);
 
       const history: Message[] = [
         {
@@ -209,7 +208,13 @@ describe('e2e: Anthropic adapter bridge', () => {
       } satisfies TokenUsage);
 
       expect(harness.requests).toHaveLength(1);
+      expect(harness.requests[0]!.headers['authorization']).toBeUndefined();
     } finally {
+      if (previousAuthToken === undefined) {
+        delete process.env['ANTHROPIC_AUTH_TOKEN'];
+      } else {
+        process.env['ANTHROPIC_AUTH_TOKEN'] = previousAuthToken;
+      }
       await harness.close();
     }
   });


### PR DESCRIPTION
## Related Issue

No linked issue; this fixes an Anthropic provider auth leakage found during implementation review.

## Problem

The Anthropic adapter is used as a generic transport to *any* anthropic-compatible endpoint (`baseUrl` may point at a third-party gateway/proxy). The upstream Anthropic SDK, however, auto-discovers credentials from the shell environment by default. When the configured endpoint is **not** the official API, that auto-discovery leaks:

- **Bearer-token leak (primary risk).** Even when the host had configured an explicit API key, the SDK still read `ANTHROPIC_AUTH_TOKEN` from the environment and attached it as an `Authorization: Bearer` header — sending an out-of-band credential (often injected by *another* tool, unbeknownst to the user) to whatever third-party `baseUrl` was configured. Verified end-to-end: with a configured `x-api-key`, the outgoing request still carried `Authorization: Bearer <shell token>`.
- **API-key / base-url / custom-header fallback.** The adapter also read an `ANTHROPIC_API_KEY` fallback directly, and the SDK could pull `ANTHROPIC_BASE_URL` / `ANTHROPIC_CUSTOM_HEADERS` from the shell.

This contradicts the provider credential model, where credentials come from config, not ambient shell state.

## What changed

Treat the SDK as a transport only — disable *every* environment auto-discovery channel so the adapter uses only host-provided credentials:

- Removed the adapter-level `ANTHROPIC_API_KEY` shell fallback; the adapter uses the resolved provider config or per-request auth from the host.
- Pass `authToken: null` and `baseURL: … ?? null` when constructing the SDK client, so shell `ANTHROPIC_AUTH_TOKEN` / `ANTHROPIC_BASE_URL` defaults cannot leak in.
- Null the `authorization` header and every name declared in `ANTHROPIC_CUSTOM_HEADERS`, so shell-injected headers (including a bearer) are stripped, while host-configured `defaultHeaders` still pass through.
- Marked these `null`s as load-bearing (not redundant) with a code comment, to keep a future "cleanup" from reintroducing the leak.
- Added unit + e2e coverage, including a fake-provider assertion that no `authorization` / leaked header reaches the endpoint.
- Added a patch changeset for `@moonshot-ai/kosong` and the CLI bundle.

**Behavior change:** the adapter no longer honors shell `ANTHROPIC_API_KEY` / `ANTHROPIC_AUTH_TOKEN` / `ANTHROPIC_BASE_URL` / `ANTHROPIC_CUSTOM_HEADERS`. Configure credentials via provider config (`apiKey` or `[provider.env]`).

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.

## Verification

- `pnpm exec vitest run --config vitest.config.ts test/anthropic.test.ts test/e2e/anthropic-adapter.test.ts`
- `pnpm run typecheck` from `packages/kosong`
- `pnpm exec oxlint packages/kosong/src/providers/anthropic.ts packages/kosong/test/anthropic.test.ts packages/kosong/test/e2e/anthropic-adapter.test.ts`
