### PR TITLE
fix: tolerate busy log rotation

### DIFF
--- a/.changeset/steady-log-rotation.md
+++ b/.changeset/steady-log-rotation.md
@@ -1,0 +1,6 @@
+---
+"@moonshot-ai/agent-core": patch
+"@moonshot-ai/kimi-code": patch
+---
+
+Avoid surfacing diagnostic log rotation failures when a shared log file is temporarily busy.

--- a/packages/agent-core/src/logging/sinks.ts
+++ b/packages/agent-core/src/logging/sinks.ts
@@ -6,6 +6,7 @@ import { syncDir } from '#/utils/fs';
 
 export const PENDING_MAX = 1000;
 const STDERR_NOTICE_INTERVAL_MS = 30_000;
+const TRANSIENT_ROTATION_ERROR_CODES = new Set(['EACCES', 'EBUSY', 'EPERM']);
 
 class AsyncSerialQueue {
   private tail: Promise<unknown> = Promise.resolve();
@@ -168,28 +169,35 @@ export class RotatingFileSink implements Sink {
 
   private async rotate(): Promise<void> {
     const { path, files } = this.options;
+    this.directorySynced = false;
     for (let i = files - 2; i >= 1; i--) {
       const from = `${path}.${i}`;
       const to = `${path}.${i + 1}`;
       try {
         await rename(from, to);
       } catch (error) {
-        if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error;
+        if (isNotFoundError(error)) continue;
+        if (isTransientRotationError(error)) return;
+        throw error;
       }
     }
     try {
       await rename(path, `${path}.1`);
     } catch (error) {
-      if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error;
+      if (isNotFoundError(error)) {
+        this.currentBytes = 0;
+        return;
+      }
+      if (isTransientRotationError(error)) return;
+      throw error;
     }
     // last archive may be evicted; ensure we don't keep > files
     try {
       await unlink(`${path}.${files}`);
     } catch (error) {
-      if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error;
+      if (!isNotFoundError(error) && !isTransientRotationError(error)) throw error;
     }
     this.currentBytes = 0;
-    this.directorySynced = false;
   }
 
   private async statSize(p: string): Promise<number> {
@@ -218,4 +226,12 @@ export class RotatingFileSink implements Sink {
       process.stderr.write(`[logger] write failed: ${code}\n`);
     } catch {}
   }
+}
+
+function isNotFoundError(error: unknown): boolean {
+  return (error as NodeJS.ErrnoException).code === 'ENOENT';
+}
+
+function isTransientRotationError(error: unknown): boolean {
+  return TRANSIENT_ROTATION_ERROR_CODES.has((error as NodeJS.ErrnoException).code ?? '');
 }

--- a/packages/agent-core/src/logging/sinks.ts
+++ b/packages/agent-core/src/logging/sinks.ts
@@ -6,7 +6,7 @@ import { syncDir } from '#/utils/fs';
 
 export const PENDING_MAX = 1000;
 const STDERR_NOTICE_INTERVAL_MS = 30_000;
-const TRANSIENT_ROTATION_ERROR_CODES = new Set(['EACCES', 'EBUSY', 'EPERM']);
+const TRANSIENT_ROTATION_ERROR_CODES = new Set(['EBUSY', 'EPERM']);
 
 class AsyncSerialQueue {
   private tail: Promise<unknown> = Promise.resolve();

--- a/packages/agent-core/test/logging/sinks.test.ts
+++ b/packages/agent-core/test/logging/sinks.test.ts
@@ -1,8 +1,32 @@
-import { chmod, mkdir, mkdtemp, readFile, readdir, rm, stat, writeFile } from 'node:fs/promises';
+/* eslint-disable import/first -- vi.mock setup must run before RotatingFileSink imports fs promises. */
+import type * as FsPromises from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'pathe';
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const fsMockState = vi.hoisted(() => ({
+  blockedRename: undefined as { from: string; to: string; code: string } | undefined,
+}));
+
+vi.mock('node:fs/promises', async () => {
+  const actual = await vi.importActual<typeof FsPromises>('node:fs/promises');
+  return {
+    ...actual,
+    rename: async (...args: Parameters<typeof actual.rename>) => {
+      const [from, to] = args;
+      const blockedRename = fsMockState.blockedRename;
+      if (blockedRename && String(from) === blockedRename.from && String(to) === blockedRename.to) {
+        throw Object.assign(new Error(`${blockedRename.code}: busy rename`), {
+          code: blockedRename.code,
+        });
+      }
+      return actual.rename(...args);
+    },
+  };
+});
+
+import { mkdtemp, readFile, readdir, rm, stat, writeFile } from 'node:fs/promises';
 
 import { PENDING_MAX, RotatingFileSink } from '#/logging/sinks';
 
@@ -13,6 +37,7 @@ beforeEach(async () => {
 });
 
 afterEach(async () => {
+  fsMockState.blockedRename = undefined;
   await rm(workDir, { recursive: true, force: true });
 });
 
@@ -78,35 +103,32 @@ describe('RotatingFileSink', () => {
     }
   });
 
-  it.skipIf(process.platform === 'win32')(
-    'keeps writing when rotation is temporarily blocked',
-    async () => {
-      const dir = join(workDir, 'locked');
-      const path = join(dir, 'app.log');
-      await mkdir(dir);
-      await writeFile(path, 'seed\n', 'utf-8');
-      await chmod(dir, 0o555);
+  it('keeps writing when rotation is temporarily blocked', async () => {
+    const path = join(workDir, 'app.log');
+    await writeFile(path, 'seed\n', 'utf-8');
+    fsMockState.blockedRename = {
+      from: path,
+      to: `${path}.1`,
+      code: 'EBUSY',
+    };
 
-      const stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
-      try {
-        const sink = new RotatingFileSink({ path, maxBytes: 8, files: 2 });
-        sink.enqueue('after\n');
+    const stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+    try {
+      const sink = new RotatingFileSink({ path, maxBytes: 8, files: 2 });
+      sink.enqueue('after\n');
 
-        expect(await sink.flush()).toBe(true);
-        await chmod(dir, 0o755);
+      expect(await sink.flush()).toBe(true);
 
-        const text = await readFile(path, 'utf-8');
-        expect(text).toContain('seed\n');
-        expect(text).toContain('after\n');
-        expect(
-          stderrSpy.mock.calls.some((c) => String(c[0]).includes('[logger] write failed')),
-        ).toBe(false);
-      } finally {
-        stderrSpy.mockRestore();
-        await chmod(dir, 0o755).catch(() => {});
-      }
-    },
-  );
+      const text = await readFile(path, 'utf-8');
+      expect(text).toContain('seed\n');
+      expect(text).toContain('after\n');
+      expect(stderrSpy.mock.calls.some((c) => String(c[0]).includes('[logger] write failed'))).toBe(
+        false,
+      );
+    } finally {
+      stderrSpy.mockRestore();
+    }
+  });
 
   it('drops oldest when pending overflows', async () => {
     const path = join(workDir, 'app.log');

--- a/packages/agent-core/test/logging/sinks.test.ts
+++ b/packages/agent-core/test/logging/sinks.test.ts
@@ -7,7 +7,6 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { PENDING_MAX, RotatingFileSink } from '#/logging/sinks';
 
 let workDir: string;
-const itPosix = process.platform === 'win32' ? it.skip : it;
 
 beforeEach(async () => {
   workDir = await mkdtemp(join(tmpdir(), 'logger-sinks-'));
@@ -79,32 +78,35 @@ describe('RotatingFileSink', () => {
     }
   });
 
-  itPosix('keeps writing when rotation is temporarily blocked', async () => {
-    const dir = join(workDir, 'locked');
-    const path = join(dir, 'app.log');
-    await mkdir(dir);
-    await writeFile(path, 'seed\n', 'utf-8');
-    await chmod(dir, 0o555);
+  it.skipIf(process.platform === 'win32')(
+    'keeps writing when rotation is temporarily blocked',
+    async () => {
+      const dir = join(workDir, 'locked');
+      const path = join(dir, 'app.log');
+      await mkdir(dir);
+      await writeFile(path, 'seed\n', 'utf-8');
+      await chmod(dir, 0o555);
 
-    const stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
-    try {
-      const sink = new RotatingFileSink({ path, maxBytes: 8, files: 2 });
-      sink.enqueue('after\n');
+      const stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+      try {
+        const sink = new RotatingFileSink({ path, maxBytes: 8, files: 2 });
+        sink.enqueue('after\n');
 
-      expect(await sink.flush()).toBe(true);
-      await chmod(dir, 0o755);
+        expect(await sink.flush()).toBe(true);
+        await chmod(dir, 0o755);
 
-      const text = await readFile(path, 'utf-8');
-      expect(text).toContain('seed\n');
-      expect(text).toContain('after\n');
-      expect(
-        stderrSpy.mock.calls.some((c) => String(c[0]).includes('[logger] write failed')),
-      ).toBe(false);
-    } finally {
-      stderrSpy.mockRestore();
-      await chmod(dir, 0o755).catch(() => {});
-    }
-  });
+        const text = await readFile(path, 'utf-8');
+        expect(text).toContain('seed\n');
+        expect(text).toContain('after\n');
+        expect(
+          stderrSpy.mock.calls.some((c) => String(c[0]).includes('[logger] write failed')),
+        ).toBe(false);
+      } finally {
+        stderrSpy.mockRestore();
+        await chmod(dir, 0o755).catch(() => {});
+      }
+    },
+  );
 
   it('drops oldest when pending overflows', async () => {
     const path = join(workDir, 'app.log');

--- a/packages/agent-core/test/logging/sinks.test.ts
+++ b/packages/agent-core/test/logging/sinks.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, readFile, readdir, rm, stat } from 'node:fs/promises';
+import { chmod, mkdir, mkdtemp, readFile, readdir, rm, stat, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'pathe';
 
@@ -7,6 +7,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { PENDING_MAX, RotatingFileSink } from '#/logging/sinks';
 
 let workDir: string;
+const itPosix = process.platform === 'win32' ? it.skip : it;
 
 beforeEach(async () => {
   workDir = await mkdtemp(join(tmpdir(), 'logger-sinks-'));
@@ -75,6 +76,33 @@ describe('RotatingFileSink', () => {
     expect(files).toContain('app.log.1');
     for (const file of files) {
       expect((await stat(join(workDir, file))).size).toBeLessThanOrEqual(maxBytes);
+    }
+  });
+
+  itPosix('keeps writing when rotation is temporarily blocked', async () => {
+    const dir = join(workDir, 'locked');
+    const path = join(dir, 'app.log');
+    await mkdir(dir);
+    await writeFile(path, 'seed\n', 'utf-8');
+    await chmod(dir, 0o555);
+
+    const stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+    try {
+      const sink = new RotatingFileSink({ path, maxBytes: 8, files: 2 });
+      sink.enqueue('after\n');
+
+      expect(await sink.flush()).toBe(true);
+      await chmod(dir, 0o755);
+
+      const text = await readFile(path, 'utf-8');
+      expect(text).toContain('seed\n');
+      expect(text).toContain('after\n');
+      expect(
+        stderrSpy.mock.calls.some((c) => String(c[0]).includes('[logger] write failed')),
+      ).toBe(false);
+    } finally {
+      stderrSpy.mockRestore();
+      await chmod(dir, 0o755).catch(() => {});
     }
   });
 

--- a/packages/agent-core/test/logging/sinks.test.ts
+++ b/packages/agent-core/test/logging/sinks.test.ts
@@ -130,6 +130,30 @@ describe('RotatingFileSink', () => {
     }
   });
 
+  it('surfaces permanent EACCES rotation failures', async () => {
+    const path = join(workDir, 'app.log');
+    await writeFile(path, 'seed\n', 'utf-8');
+    fsMockState.blockedRename = {
+      from: path,
+      to: `${path}.1`,
+      code: 'EACCES',
+    };
+
+    const stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+    try {
+      const sink = new RotatingFileSink({ path, maxBytes: 8, files: 2 });
+      sink.enqueue('after\n');
+
+      expect(await sink.flush()).toBe(false);
+      expect(await readFile(path, 'utf-8')).toBe('seed\n');
+      expect(stderrSpy.mock.calls.some((c) => String(c[0]).includes('[logger] write failed'))).toBe(
+        true,
+      );
+    } finally {
+      stderrSpy.mockRestore();
+    }
+  });
+
   it('drops oldest when pending overflows', async () => {
     const path = join(workDir, 'app.log');
     const sink = new RotatingFileSink({ path, maxBytes: 1_000_000, files: 2 });


### PR DESCRIPTION
## Related Issue

No linked issue. This addresses reported cases where multiple Kimi instances can surface a diagnostic log file busy error while sharing the same log file.

## Problem

Multiple Kimi processes can write to the same global or resumed-session diagnostic log. When rotation tries to rename that shared log while another process briefly holds it open, the logger can surface a write failure even though appending can continue.

## What changed

- Treat transient rotation errors as a skipped rotation instead of a diagnostic write failure.
- Keep appending to the current log file when rotation is temporarily blocked.
- Added a regression test for blocked rotation continuing to write.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.
