### PR TITLE
fix(kosong): parse DeepSeek inline tool calls when a backend leaves them unstructured

### DIFF
--- a/.changeset/deepseek-inline-tool-calls.md
+++ b/.changeset/deepseek-inline-tool-calls.md
@@ -1,0 +1,7 @@
+---
+"@moonshot-ai/kosong": patch
+---
+
+Parse DeepSeek-format inline tool calls when an OpenAI-compatible backend leaves them unstructured.
+
+DeepSeek-architecture models (deepseek-v3/r1 and derivatives such as cogito) emit tool calls as special tokens rather than OpenAI `tool_calls`. DeepSeek's own API structures these server-side, but many compatible deployments — self-hosted vLLM/SGLang/llama.cpp, ollama, and some proxies — leak the raw `<|tool▁calls▁begin|>…` tokens into the assistant content, leaving the agent with nothing to dispatch and the turn dead-ending. The OpenAI chat-completions provider now detects that case, parses the tokens into structured tool calls, and strips them from the visible text — but only when the backend returned no structured call, so it stays a no-op for providers that already do the right thing.

--- a/packages/kosong/src/providers/deepseek-inline-tool-calls.ts
+++ b/packages/kosong/src/providers/deepseek-inline-tool-calls.ts
@@ -94,9 +94,15 @@ export class DeepSeekInlineToolCallFilter {
     return '';
   }
 
-  /** Remaining buffered text once the stream ends (empty if a block was suppressed). */
+  /**
+   * Remaining buffered text once the stream ends (empty if a block was
+   * suppressed). Idempotent: the buffer is cleared, so a second call returns ''.
+   */
   flush(): string {
-    return this.suppressing ? '' : this.buffer;
+    if (this.suppressing) return '';
+    const out = this.buffer;
+    this.buffer = '';
+    return out;
   }
 
   /** Whether the begin marker was seen. */

--- a/packages/kosong/src/providers/deepseek-inline-tool-calls.ts
+++ b/packages/kosong/src/providers/deepseek-inline-tool-calls.ts
@@ -1,0 +1,111 @@
+import type { ToolCall } from '#/message';
+
+/**
+ * Defensive fallback for DeepSeek-V3 style **inline** tool calls.
+ *
+ * DeepSeek-architecture models (deepseek-v3/r1 and derivatives such as
+ * cogito-2.1) emit tool calls in a special-token format rather than as OpenAI
+ * `tool_calls`. The official DeepSeek API parses this server-side and returns
+ * structured `tool_calls`, but many OpenAI-compatible deployments — self-hosted
+ * vLLM / SGLang / llama.cpp, ollama, and some proxies — do NOT, and instead leak
+ * the raw tokens into the assistant `content`:
+ *
+ *   <|tool▁calls▁begin|>
+ *     <|tool▁call▁begin|>function<|tool▁sep|>NAME
+ *     ```json
+ *     { ...arguments... }
+ *     ```<|tool▁call▁end|>      (repeated for parallel calls)
+ *   <|tool▁calls▁end|>
+ *
+ * (the bars are ASCII U+007C, the separators are U+2581). When that happens the
+ * agent sees no tool call and the turn dead-ends. This module parses those tokens
+ * client-side so the call can still be dispatched. It is applied ONLY when the
+ * provider returned no structured tool call AND the begin token is present, so it
+ * is a no-op for every well-behaved provider/model.
+ */
+
+const SEP = '▁'; // ▁
+export const DEEPSEEK_TOOL_CALLS_BEGIN = `<|tool${SEP}calls${SEP}begin|>`;
+
+// <|tool▁call▁begin|>[function]<|tool▁sep|>NAME ```[json] {ARGS} ```
+const CALL_RE = new RegExp(
+  `<\\|tool${SEP}call${SEP}begin\\|>\\s*(?:function)?\\s*<\\|tool${SEP}sep\\|>\\s*([A-Za-z0-9_.-]+)\\s*` +
+    '```(?:json)?\\s*([\\s\\S]*?)```',
+  'g',
+);
+
+/**
+ * Parse DeepSeek inline tool-call tokens from assistant content into structured
+ * {@link ToolCall}s. Calls whose argument block is not valid JSON are skipped,
+ * so a partially corrupted emission yields the calls it can rather than throwing.
+ */
+export function parseDeepSeekInlineToolCalls(content: string): ToolCall[] {
+  if (typeof content !== 'string' || !content.includes(DEEPSEEK_TOOL_CALLS_BEGIN)) {
+    return [];
+  }
+  const calls: ToolCall[] = [];
+  CALL_RE.lastIndex = 0;
+  let match: RegExpExecArray | null;
+  while ((match = CALL_RE.exec(content)) !== null) {
+    const name = (match[1] ?? '').trim();
+    const args = (match[2] ?? '').trim();
+    if (name.length === 0) continue;
+    try {
+      JSON.parse(args);
+    } catch {
+      continue;
+    }
+    calls.push({ type: 'function', id: crypto.randomUUID(), name, arguments: args });
+  }
+  return calls;
+}
+
+/**
+ * Streaming-safe filter that lets text deltas through live until the DeepSeek
+ * tool-call block begins, then suppresses the raw tokens (so they never reach the
+ * UI) while still accumulating the full content for {@link parseDeepSeekInlineToolCalls}.
+ *
+ * A small trailing holdback covers a begin-marker that straddles two deltas.
+ */
+export class DeepSeekInlineToolCallFilter {
+  private readonly marker = DEEPSEEK_TOOL_CALLS_BEGIN;
+  private buffer = '';
+  private full = '';
+  private suppressing = false;
+
+  /** Feed a content delta; returns the text safe to yield now (possibly empty). */
+  push(delta: string): string {
+    this.full += delta;
+    if (this.suppressing) return '';
+    this.buffer += delta;
+    const idx = this.buffer.indexOf(this.marker);
+    if (idx >= 0) {
+      const out = this.buffer.slice(0, idx);
+      this.suppressing = true;
+      this.buffer = '';
+      return out;
+    }
+    const holdback = this.marker.length - 1;
+    if (this.buffer.length > holdback) {
+      const out = this.buffer.slice(0, this.buffer.length - holdback);
+      this.buffer = this.buffer.slice(this.buffer.length - holdback);
+      return out;
+    }
+    return '';
+  }
+
+  /** Remaining buffered text once the stream ends (empty if a block was suppressed). */
+  flush(): string {
+    return this.suppressing ? '' : this.buffer;
+  }
+
+  /** Whether the begin marker was seen. */
+  get sawToolBlock(): boolean {
+    return this.suppressing;
+  }
+
+  /** Full accumulated content (for parsing). */
+  get content(): string {
+    return this.full;
+  }
+}

--- a/packages/kosong/src/providers/deepseek-inline-tool-calls.ts
+++ b/packages/kosong/src/providers/deepseek-inline-tool-calls.ts
@@ -17,22 +17,42 @@ import type { ToolCall } from '#/message';
  *     ```<|tool▁call▁end|>      (repeated for parallel calls)
  *   <|tool▁calls▁end|>
  *
- * (the bars are ASCII U+007C, the separators are U+2581). When that happens the
- * agent sees no tool call and the turn dead-ends. This module parses those tokens
- * client-side so the call can still be dispatched. It is applied ONLY when the
- * provider returned no structured tool call AND the begin token is present, so it
- * is a no-op for every well-behaved provider/model.
+ * The bar is either ASCII `|` (U+007C, as ollama-cloud emits) or the tokenizer's
+ * full-width `｜` (U+FF5C, as raw vLLM/SGLang/llama.cpp leaks); separators are
+ * `▁` (U+2581). The outer `…calls▁begin…` wrapper is sometimes omitted and the
+ * block starts straight at a per-call `…call▁begin…` (see vllm-project/vllm#21727),
+ * so detection anchors on either boundary.
+ *
+ * When this happens the agent sees no tool call and the turn dead-ends. This
+ * module parses those tokens client-side so the call can still be dispatched. It
+ * is applied ONLY when the provider returned no structured tool call AND a block
+ * boundary is present, so it is a no-op for every well-behaved provider/model.
  */
 
-const SEP = '▁'; // ▁
-export const DEEPSEEK_TOOL_CALLS_BEGIN = `<|tool${SEP}calls${SEP}begin|>`;
+const SEP = '▁'; // U+2581
+const BAR = '[|｜]'; // ASCII U+007C or full-width U+FF5C
 
-// <|tool▁call▁begin|>[function]<|tool▁sep|>NAME ```[json] {ARGS} ```
+/** First block boundary: a calls-begin OR a call-begin token, either bar. */
+const BLOCK_START = new RegExp(`<${BAR}tool${SEP}calls?${SEP}begin${BAR}>`);
+
+// One call: <…call▁begin…>[function]<…sep…>NAME ```[json] {ARGS} ```
 const CALL_RE = new RegExp(
-  `<\\|tool${SEP}call${SEP}begin\\|>\\s*(?:function)?\\s*<\\|tool${SEP}sep\\|>\\s*([A-Za-z0-9_.-]+)\\s*` +
+  `<${BAR}tool${SEP}call${SEP}begin${BAR}>\\s*(?:function)?\\s*<${BAR}tool${SEP}sep${BAR}>\\s*([A-Za-z0-9_.-]+)\\s*` +
     '```(?:json)?\\s*([\\s\\S]*?)```',
   'g',
 );
+
+/** Canonical ASCII calls-begin sentinel (documentation / convenience). */
+export const DEEPSEEK_TOOL_CALLS_BEGIN = `<|tool${SEP}calls${SEP}begin|>`;
+
+// Longest sentinel we might hold back while detecting a marker split across deltas.
+const MAX_MARKER_LEN = DEEPSEEK_TOOL_CALLS_BEGIN.length;
+
+/** Index of the first DeepSeek tool-call block boundary in `content`, or -1. */
+export function firstBlockStart(content: string): number {
+  const match = BLOCK_START.exec(content);
+  return match ? match.index : -1;
+}
 
 /**
  * Parse DeepSeek inline tool-call tokens from assistant content into structured
@@ -40,7 +60,7 @@ const CALL_RE = new RegExp(
  * so a partially corrupted emission yields the calls it can rather than throwing.
  */
 export function parseDeepSeekInlineToolCalls(content: string): ToolCall[] {
-  if (typeof content !== 'string' || !content.includes(DEEPSEEK_TOOL_CALLS_BEGIN)) {
+  if (typeof content !== 'string' || firstBlockStart(content) < 0) {
     return [];
   }
   const calls: ToolCall[] = [];
@@ -61,37 +81,58 @@ export function parseDeepSeekInlineToolCalls(content: string): ToolCall[] {
 }
 
 /**
- * Streaming-safe filter that lets text deltas through live until the DeepSeek
+ * Streaming-safe filter that lets text deltas through live until a DeepSeek
  * tool-call block begins, then suppresses the raw tokens (so they never reach the
- * UI) while still accumulating the full content for {@link parseDeepSeekInlineToolCalls}.
+ * UI) while accumulating the full content for {@link parseDeepSeekInlineToolCalls}.
  *
- * A small trailing holdback covers a begin-marker that straddles two deltas.
+ * A small trailing holdback covers a block-start marker that straddles two deltas.
+ * Once the provider emits a structured tool call ({@link releaseHoldback}) no
+ * inline leak is possible, so the filter releases any held text and passes the
+ * rest through verbatim — preserving ordering for well-behaved providers.
  */
 export class DeepSeekInlineToolCallFilter {
-  private readonly marker = DEEPSEEK_TOOL_CALLS_BEGIN;
   private buffer = '';
   private full = '';
   private suppressing = false;
+  private passthrough = false;
 
   /** Feed a content delta; returns the text safe to yield now (possibly empty). */
   push(delta: string): string {
     this.full += delta;
+    if (this.passthrough) return delta;
     if (this.suppressing) return '';
     this.buffer += delta;
-    const idx = this.buffer.indexOf(this.marker);
+    const idx = firstBlockStart(this.buffer);
     if (idx >= 0) {
       const out = this.buffer.slice(0, idx);
       this.suppressing = true;
       this.buffer = '';
       return out;
     }
-    const holdback = this.marker.length - 1;
+    const holdback = MAX_MARKER_LEN - 1;
     if (this.buffer.length > holdback) {
       const out = this.buffer.slice(0, this.buffer.length - holdback);
       this.buffer = this.buffer.slice(this.buffer.length - holdback);
       return out;
     }
     return '';
+  }
+
+  /**
+   * The provider emitted a structured tool call, so no inline leak is possible.
+   * Release any held-back text (in order) and stop buffering subsequent deltas —
+   * this keeps a short preamble from being reordered after the tool-call parts.
+   *
+   * No-op once suppression has begun: if an inline block was already detected we
+   * must keep stripping it rather than flip to passthrough (which would leak the
+   * remainder of the block as visible text).
+   */
+  releaseHoldback(): string {
+    if (this.suppressing) return '';
+    this.passthrough = true;
+    const out = this.buffer;
+    this.buffer = '';
+    return out;
   }
 
   /**
@@ -105,7 +146,7 @@ export class DeepSeekInlineToolCallFilter {
     return out;
   }
 
-  /** Whether the begin marker was seen. */
+  /** Whether a block-start marker was seen (and the rest of content suppressed). */
   get sawToolBlock(): boolean {
     return this.suppressing;
   }

--- a/packages/kosong/src/providers/deepseek-inline-tool-calls.ts
+++ b/packages/kosong/src/providers/deepseek-inline-tool-calls.ts
@@ -35,10 +35,14 @@ const BAR = '[|｜]'; // ASCII U+007C or full-width U+FF5C
 /** First block boundary: a calls-begin OR a call-begin token, either bar. */
 const BLOCK_START = new RegExp(`<${BAR}tool${SEP}calls?${SEP}begin${BAR}>`);
 
-// One call: <…call▁begin…>[function]<…sep…>NAME ```[json] {ARGS} ```
+// One call: <…call▁begin…>[function]<…sep…>NAME ```[json] {ARGS} ```<…call▁end…>
+// The closing fence is anchored to the call-end sentinel (not just the next
+// ```) so a JSON string argument that itself contains a triple-backtick fence
+// doesn't truncate the capture early — the lazy match backtracks past any
+// ``` not immediately followed by the end token.
 const CALL_RE = new RegExp(
   `<${BAR}tool${SEP}call${SEP}begin${BAR}>\\s*(?:function)?\\s*<${BAR}tool${SEP}sep${BAR}>\\s*([A-Za-z0-9_.-]+)\\s*` +
-    '```(?:json)?\\s*([\\s\\S]*?)```',
+    `\`\`\`(?:json)?\\s*([\\s\\S]*?)\`\`\`\\s*<${BAR}tool${SEP}call${SEP}end${BAR}>`,
   'g',
 );
 
@@ -98,14 +102,21 @@ export class DeepSeekInlineToolCallFilter {
 
   /** Feed a content delta; returns the text safe to yield now (possibly empty). */
   push(delta: string): string {
-    this.full += delta;
     if (this.passthrough) return delta;
-    if (this.suppressing) return '';
+    // Only accumulate `full` once a block boundary is actually found — before
+    // that, and for the common case where no boundary ever appears, keeping a
+    // second copy of the entire stream is pure waste since `content` is only
+    // read when `sawToolBlock` is true.
+    if (this.suppressing) {
+      this.full += delta;
+      return '';
+    }
     this.buffer += delta;
     const idx = firstBlockStart(this.buffer);
     if (idx >= 0) {
       const out = this.buffer.slice(0, idx);
       this.suppressing = true;
+      this.full = this.buffer.slice(idx);
       this.buffer = '';
       return out;
     }

--- a/packages/kosong/src/providers/openai-legacy.ts
+++ b/packages/kosong/src/providers/openai-legacy.ts
@@ -33,6 +33,11 @@ import {
   type BufferedChatCompletionToolCall,
 } from './chat-completions-stream';
 import {
+  DeepSeekInlineToolCallFilter,
+  parseDeepSeekInlineToolCalls,
+  DEEPSEEK_TOOL_CALLS_BEGIN,
+} from './deepseek-inline-tool-calls';
+import {
   mergeRequestHeaders,
   requireProviderApiKey,
   resolveAuthBackedClient,
@@ -374,20 +379,38 @@ export class OpenAILegacyStreamedMessage implements StreamedMessage {
       yield { type: 'think', think: reasoning } satisfies StreamedMessagePart;
     }
 
-    if (message.content) {
-      yield { type: 'text', text: message.content } satisfies StreamedMessagePart;
+    const structuredToolCalls = (message.tool_calls ?? []).filter(isFunctionToolCall);
+
+    // Fallback: a backend served a DeepSeek-format model but left its inline
+    // tool-call tokens in `content` instead of structuring them as `tool_calls`.
+    // Parse them so the call is still dispatched (no-op when absent or when the
+    // provider already structured the call).
+    const inlineToolCalls =
+      structuredToolCalls.length === 0 && typeof message.content === 'string'
+        ? parseDeepSeekInlineToolCalls(message.content)
+        : [];
+
+    if (typeof message.content === 'string' && message.content.length > 0) {
+      const text =
+        inlineToolCalls.length > 0
+          ? message.content.slice(0, message.content.indexOf(DEEPSEEK_TOOL_CALLS_BEGIN))
+          : message.content;
+      if (text.length > 0) {
+        yield { type: 'text', text } satisfies StreamedMessagePart;
+      }
     }
 
-    if (message.tool_calls) {
-      for (const toolCall of message.tool_calls) {
-        if (!isFunctionToolCall(toolCall)) continue;
-        yield {
-          type: 'function',
-          id: toolCall.id || crypto.randomUUID(),
-          name: toolCall.function.name,
-          arguments: toolCall.function.arguments,
-        } satisfies ToolCall;
-      }
+    for (const toolCall of structuredToolCalls) {
+      yield {
+        type: 'function',
+        id: toolCall.id || crypto.randomUUID(),
+        name: toolCall.function.name,
+        arguments: toolCall.function.arguments,
+      } satisfies ToolCall;
+    }
+
+    for (const toolCall of inlineToolCalls) {
+      yield toolCall;
     }
   }
 
@@ -396,6 +419,8 @@ export class OpenAILegacyStreamedMessage implements StreamedMessage {
     reasoningKey: string | undefined,
   ): AsyncGenerator<StreamedMessagePart> {
     const bufferedToolCalls = new Map<number | string, BufferedChatCompletionToolCall>();
+    const inlineFilter = new DeepSeekInlineToolCallFilter();
+    let sawStructuredToolCall = false;
 
     try {
       for await (const chunk of response) {
@@ -429,17 +454,38 @@ export class OpenAILegacyStreamedMessage implements StreamedMessage {
           yield { type: 'think', think: reasoning } satisfies StreamedMessagePart;
         }
 
-        // text content
+        // text content — funnel through the inline filter so a leaked DeepSeek
+        // tool-call block is stripped from visible text (and captured for parsing
+        // once the stream ends) instead of being shown to the user.
         if (delta.content) {
-          yield { type: 'text', text: delta.content } satisfies StreamedMessagePart;
+          const visible = inlineFilter.push(delta.content);
+          if (visible.length > 0) {
+            yield { type: 'text', text: visible } satisfies StreamedMessagePart;
+          }
         }
 
         // tool calls — preserve `index` on every yielded part so the generate
         // loop can route interleaved argument deltas from parallel tool calls.
+        if (delta.tool_calls && delta.tool_calls.length > 0) {
+          sawStructuredToolCall = true;
+        }
         for (const toolCall of delta.tool_calls ?? []) {
           for (const part of convertChatCompletionStreamToolCall(toolCall, bufferedToolCalls)) {
             yield part;
           }
+        }
+      }
+
+      // Flush any text held back for partial begin-marker detection.
+      const tail = inlineFilter.flush();
+      if (tail.length > 0) {
+        yield { type: 'text', text: tail } satisfies StreamedMessagePart;
+      }
+      // Fallback: the backend served a DeepSeek-format model but left its inline
+      // tool-call tokens in `content` instead of structuring them. Parse them.
+      if (!sawStructuredToolCall && inlineFilter.sawToolBlock) {
+        for (const toolCall of parseDeepSeekInlineToolCalls(inlineFilter.content)) {
+          yield toolCall;
         }
       }
     } catch (error: unknown) {

--- a/packages/kosong/src/providers/openai-legacy.ts
+++ b/packages/kosong/src/providers/openai-legacy.ts
@@ -34,8 +34,8 @@ import {
 } from './chat-completions-stream';
 import {
   DeepSeekInlineToolCallFilter,
+  firstBlockStart,
   parseDeepSeekInlineToolCalls,
-  DEEPSEEK_TOOL_CALLS_BEGIN,
 } from './deepseek-inline-tool-calls';
 import {
   mergeRequestHeaders,
@@ -384,18 +384,15 @@ export class OpenAILegacyStreamedMessage implements StreamedMessage {
 
     // Fallback: a backend served a DeepSeek-format model but left its inline
     // tool-call tokens in `content` instead of structuring them as `tool_calls`.
-    // Strip the block from visible text whenever the begin token is present (and
+    // Strip the block from visible text whenever a block boundary is present (and
     // the provider returned no structured call) — even if some blocks fail to
     // parse — so the raw tokens never render. Parse what we can into dispatchable
     // tool calls. No-op when absent or already structured.
-    const hasInlineBlock =
-      structuredToolCalls.length === 0 && content.includes(DEEPSEEK_TOOL_CALLS_BEGIN);
-    const inlineToolCalls = hasInlineBlock ? parseDeepSeekInlineToolCalls(content) : [];
+    const blockStart = structuredToolCalls.length === 0 ? firstBlockStart(content) : -1;
+    const inlineToolCalls = blockStart >= 0 ? parseDeepSeekInlineToolCalls(content) : [];
 
     if (content.length > 0) {
-      const text = hasInlineBlock
-        ? content.slice(0, content.indexOf(DEEPSEEK_TOOL_CALLS_BEGIN))
-        : content;
+      const text = blockStart >= 0 ? content.slice(0, blockStart) : content;
       if (text.length > 0) {
         yield { type: 'text', text } satisfies StreamedMessagePart;
       }
@@ -467,8 +464,14 @@ export class OpenAILegacyStreamedMessage implements StreamedMessage {
 
         // tool calls — preserve `index` on every yielded part so the generate
         // loop can route interleaved argument deltas from parallel tool calls.
-        if (delta.tool_calls && delta.tool_calls.length > 0) {
+        if (delta.tool_calls && delta.tool_calls.length > 0 && !sawStructuredToolCall) {
           sawStructuredToolCall = true;
+          // A structured tool call means no inline leak is possible: release any
+          // held-back preamble text now so it isn't reordered after the call parts.
+          const released = inlineFilter.releaseHoldback();
+          if (released.length > 0) {
+            yield { type: 'text', text: released } satisfies StreamedMessagePart;
+          }
         }
         for (const toolCall of delta.tool_calls ?? []) {
           for (const part of convertChatCompletionStreamToolCall(toolCall, bufferedToolCalls)) {

--- a/packages/kosong/src/providers/openai-legacy.ts
+++ b/packages/kosong/src/providers/openai-legacy.ts
@@ -380,21 +380,22 @@ export class OpenAILegacyStreamedMessage implements StreamedMessage {
     }
 
     const structuredToolCalls = (message.tool_calls ?? []).filter(isFunctionToolCall);
+    const content = typeof message.content === 'string' ? message.content : '';
 
     // Fallback: a backend served a DeepSeek-format model but left its inline
     // tool-call tokens in `content` instead of structuring them as `tool_calls`.
-    // Parse them so the call is still dispatched (no-op when absent or when the
-    // provider already structured the call).
-    const inlineToolCalls =
-      structuredToolCalls.length === 0 && typeof message.content === 'string'
-        ? parseDeepSeekInlineToolCalls(message.content)
-        : [];
+    // Strip the block from visible text whenever the begin token is present (and
+    // the provider returned no structured call) — even if some blocks fail to
+    // parse — so the raw tokens never render. Parse what we can into dispatchable
+    // tool calls. No-op when absent or already structured.
+    const hasInlineBlock =
+      structuredToolCalls.length === 0 && content.includes(DEEPSEEK_TOOL_CALLS_BEGIN);
+    const inlineToolCalls = hasInlineBlock ? parseDeepSeekInlineToolCalls(content) : [];
 
-    if (typeof message.content === 'string' && message.content.length > 0) {
-      const text =
-        inlineToolCalls.length > 0
-          ? message.content.slice(0, message.content.indexOf(DEEPSEEK_TOOL_CALLS_BEGIN))
-          : message.content;
+    if (content.length > 0) {
+      const text = hasInlineBlock
+        ? content.slice(0, content.indexOf(DEEPSEEK_TOOL_CALLS_BEGIN))
+        : content;
       if (text.length > 0) {
         yield { type: 'text', text } satisfies StreamedMessagePart;
       }

--- a/packages/kosong/test/providers/deepseek-inline-tool-calls.test.ts
+++ b/packages/kosong/test/providers/deepseek-inline-tool-calls.test.ts
@@ -1,8 +1,10 @@
+import type { StreamedMessagePart } from '#/message';
 import {
   DEEPSEEK_TOOL_CALLS_BEGIN,
   DeepSeekInlineToolCallFilter,
   parseDeepSeekInlineToolCalls,
 } from '#/providers/deepseek-inline-tool-calls';
+import { OpenAILegacyStreamedMessage } from '#/providers/openai-legacy';
 import { describe, expect, it } from 'vitest';
 
 const SEP = '▁';
@@ -75,5 +77,59 @@ describe('DeepSeekInlineToolCallFilter', () => {
     out += f.flush();
     expect(out).toBe('ok ');
     expect(f.sawToolBlock).toBe(true);
+  });
+
+  it('flush is idempotent — a second call returns empty', () => {
+    const f = new DeepSeekInlineToolCallFilter();
+    f.push('held');
+    expect(f.flush()).toBe('held');
+    expect(f.flush()).toBe('');
+  });
+
+  it('suppresses a malformed block too (it has the begin token but no parseable call)', () => {
+    const f = new DeepSeekInlineToolCallFilter();
+    const malformed = `${DEEPSEEK_TOOL_CALLS_BEGIN}<|tool${SEP}call${SEP}begin|>function<|tool${SEP}sep|>read_file\n\`\`\`json\n{ broken`;
+    let out = f.push(`note ${malformed}`);
+    out += f.flush();
+    expect(out).toBe('note ');
+    expect(f.sawToolBlock).toBe(true);
+    expect(parseDeepSeekInlineToolCalls(f.content)).toEqual([]);
+  });
+});
+
+describe('OpenAILegacyStreamedMessage inline-tool fallback (non-stream)', () => {
+  const nonStream = (content: string) =>
+    new OpenAILegacyStreamedMessage(
+      { id: 'cmpl_test', choices: [{ index: 0, message: { role: 'assistant', content }, finish_reason: 'stop' }] } as never,
+      false,
+      undefined,
+    );
+  const collect = async (sm: AsyncIterable<StreamedMessagePart>): Promise<StreamedMessagePart[]> => {
+    const parts: StreamedMessagePart[] = [];
+    for await (const part of sm) parts.push(part);
+    return parts;
+  };
+  const textOf = (parts: StreamedMessagePart[]) =>
+    parts
+      .filter((p): p is Extract<StreamedMessagePart, { type: 'text' }> => p.type === 'text')
+      .map((p) => p.text)
+      .join('');
+
+  it('parses a leaked block into a function part and strips the tokens', async () => {
+    const parts = await collect(nonStream(`Reading. ${wrap(callBlock('read_file', '{"path":"a.js"}'))}`));
+    expect(textOf(parts)).toBe('Reading. ');
+    const fns = parts.filter((p): p is Extract<StreamedMessagePart, { type: 'function' }> => p.type === 'function');
+    expect(fns).toHaveLength(1);
+    expect(fns[0]?.name).toBe('read_file');
+  });
+
+  it('strips the tokens of a malformed block even though no call is dispatched', async () => {
+    const parts = await collect(
+      nonStream(`Reading. ${DEEPSEEK_TOOL_CALLS_BEGIN}<|tool${SEP}call${SEP}begin|>function<|tool${SEP}sep|>read_file\n\`\`\`json\n{ broken`),
+    );
+    const text = textOf(parts);
+    expect(text).toBe('Reading. ');
+    expect(text).not.toContain(DEEPSEEK_TOOL_CALLS_BEGIN);
+    expect(parts.some((p) => p.type === 'function')).toBe(false);
   });
 });

--- a/packages/kosong/test/providers/deepseek-inline-tool-calls.test.ts
+++ b/packages/kosong/test/providers/deepseek-inline-tool-calls.test.ts
@@ -2,14 +2,17 @@ import type { StreamedMessagePart } from '#/message';
 import {
   DEEPSEEK_TOOL_CALLS_BEGIN,
   DeepSeekInlineToolCallFilter,
+  firstBlockStart,
   parseDeepSeekInlineToolCalls,
 } from '#/providers/deepseek-inline-tool-calls';
 import { OpenAILegacyStreamedMessage } from '#/providers/openai-legacy';
 import { describe, expect, it } from 'vitest';
 
 const SEP = '▁';
-const callBlock = (name: string, args: string) =>
-  `<|tool${SEP}call${SEP}begin|>function<|tool${SEP}sep|>${name}\n\`\`\`json\n${args}\n\`\`\`<|tool${SEP}call${SEP}end|>`;
+// `bar` lets the same helpers build both the ASCII (U+007C) form ollama emits and
+// the full-width (U+FF5C) form raw vLLM/SGLang leaks.
+const callBlock = (name: string, args: string, bar = '|') =>
+  `<${bar}tool${SEP}call${SEP}begin${bar}>function<${bar}tool${SEP}sep${bar}>${name}\n\`\`\`json\n${args}\n\`\`\`<${bar}tool${SEP}call${SEP}end${bar}>`;
 const wrap = (...blocks: string[]) =>
   `${DEEPSEEK_TOOL_CALLS_BEGIN}${blocks.join('')}<|tool${SEP}calls${SEP}end|>`;
 
@@ -43,6 +46,27 @@ describe('parseDeepSeekInlineToolCalls', () => {
       wrap(callBlock('Read', '{"path": broken'), callBlock('Grep', '{"pattern":"x"}')),
     );
     expect(calls.map((c) => c.name)).toEqual(['Grep']);
+  });
+
+  it('parses the full-width (U+FF5C) sentinel form raw vLLM leaks emit', () => {
+    const fw = `<｜tool${SEP}calls${SEP}begin｜>${callBlock('read_file', '{"path":"a.js"}', '｜')}<｜tool${SEP}calls${SEP}end｜>`;
+    const calls = parseDeepSeekInlineToolCalls(fw);
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.name).toBe('read_file');
+  });
+
+  it('parses when the outer calls-begin wrapper is omitted (starts at call-begin)', () => {
+    const calls = parseDeepSeekInlineToolCalls(callBlock('read_file', '{"path":"a.js"}'));
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.name).toBe('read_file');
+  });
+});
+
+describe('firstBlockStart', () => {
+  it('locates either boundary, both bars, and returns -1 otherwise', () => {
+    expect(firstBlockStart('plain text')).toBe(-1);
+    expect(firstBlockStart(`go ${DEEPSEEK_TOOL_CALLS_BEGIN}…`)).toBe(3);
+    expect(firstBlockStart(`go <｜tool${SEP}call${SEP}begin｜>…`)).toBe(3);
   });
 });
 
@@ -94,6 +118,62 @@ describe('DeepSeekInlineToolCallFilter', () => {
     expect(out).toBe('note ');
     expect(f.sawToolBlock).toBe(true);
     expect(parseDeepSeekInlineToolCalls(f.content)).toEqual([]);
+  });
+
+  it('releaseHoldback returns held text and then passes the rest through', () => {
+    const f = new DeepSeekInlineToolCallFilter();
+    expect(f.push('Hi. ')).toBe(''); // shorter than the holdback — held
+    expect(f.releaseHoldback()).toBe('Hi. ');
+    expect(f.push('more')).toBe('more'); // passthrough now
+  });
+
+  it('does not leak a block when a structured call arrives after suppression began', () => {
+    const f = new DeepSeekInlineToolCallFilter();
+    expect(f.push(`go ${DEEPSEEK_TOOL_CALLS_BEGIN}<|tool${SEP}call${SEP}begin|>`)).toBe('go ');
+    expect(f.sawToolBlock).toBe(true);
+    // A structured tool call arrives mid-block: releaseHoldback must NOT flip to
+    // passthrough, or the rest of the raw tokens would leak as visible text.
+    expect(f.releaseHoldback()).toBe('');
+    expect(f.push(`function<|tool${SEP}sep|>read_file`)).toBe('');
+    expect(f.flush()).toBe('');
+  });
+});
+
+describe('OpenAILegacyStreamedMessage inline-tool fallback (stream)', () => {
+  const streamed = (chunks: unknown[]) =>
+    new OpenAILegacyStreamedMessage(
+      (async function* () {
+        for (const c of chunks) yield c;
+      })() as never,
+      true,
+      undefined,
+    );
+
+  it('keeps a short text preamble before structured tool-call parts (no reorder)', async () => {
+    // "Hi. " (4 chars) is shorter than the holdback, so it is buffered; the
+    // structured tool_calls delta must release it first, not after.
+    const sm = streamed([
+      { id: 'c', choices: [{ index: 0, delta: { content: 'Hi. ' } }] },
+      {
+        id: 'c',
+        choices: [
+          {
+            index: 0,
+            delta: {
+              tool_calls: [
+                { index: 0, id: 'call_1', function: { name: 'read_file', arguments: '{"path":"a.js"}' } },
+              ],
+            },
+          },
+        ],
+      },
+      { id: 'c', choices: [{ index: 0, delta: {}, finish_reason: 'tool_calls' }] },
+    ]);
+    const parts: StreamedMessagePart[] = [];
+    for await (const part of sm) parts.push(part);
+    const types = parts.map((p) => p.type);
+    expect(types.indexOf('text')).toBeLessThan(types.indexOf('function'));
+    expect(parts.find((p) => p.type === 'text')).toMatchObject({ text: 'Hi. ' });
   });
 });
 

--- a/packages/kosong/test/providers/deepseek-inline-tool-calls.test.ts
+++ b/packages/kosong/test/providers/deepseek-inline-tool-calls.test.ts
@@ -1,0 +1,79 @@
+import {
+  DEEPSEEK_TOOL_CALLS_BEGIN,
+  DeepSeekInlineToolCallFilter,
+  parseDeepSeekInlineToolCalls,
+} from '#/providers/deepseek-inline-tool-calls';
+import { describe, expect, it } from 'vitest';
+
+const SEP = '▁';
+const callBlock = (name: string, args: string) =>
+  `<|tool${SEP}call${SEP}begin|>function<|tool${SEP}sep|>${name}\n\`\`\`json\n${args}\n\`\`\`<|tool${SEP}call${SEP}end|>`;
+const wrap = (...blocks: string[]) =>
+  `${DEEPSEEK_TOOL_CALLS_BEGIN}${blocks.join('')}<|tool${SEP}calls${SEP}end|>`;
+
+describe('parseDeepSeekInlineToolCalls', () => {
+  it('returns no calls when the begin token is absent', () => {
+    expect(parseDeepSeekInlineToolCalls('A plain assistant answer.')).toEqual([]);
+    expect(parseDeepSeekInlineToolCalls('')).toEqual([]);
+  });
+
+  it('parses a single inline tool call', () => {
+    const calls = parseDeepSeekInlineToolCalls(wrap(callBlock('read_file', '{"path": "app.js"}')));
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toMatchObject({
+      type: 'function',
+      name: 'read_file',
+      arguments: '{"path": "app.js"}',
+    });
+    expect(typeof calls[0]?.id).toBe('string');
+  });
+
+  it('parses parallel inline tool calls in order', () => {
+    const calls = parseDeepSeekInlineToolCalls(
+      wrap(callBlock('Read', '{"path":"a.js"}'), callBlock('Grep', '{"pattern":"foo"}')),
+    );
+    expect(calls.map((c) => c.name)).toEqual(['Read', 'Grep']);
+    expect(calls.map((c) => c.arguments)).toEqual(['{"path":"a.js"}', '{"pattern":"foo"}']);
+  });
+
+  it('skips a call whose argument block is not valid JSON', () => {
+    const calls = parseDeepSeekInlineToolCalls(
+      wrap(callBlock('Read', '{"path": broken'), callBlock('Grep', '{"pattern":"x"}')),
+    );
+    expect(calls.map((c) => c.name)).toEqual(['Grep']);
+  });
+});
+
+describe('DeepSeekInlineToolCallFilter', () => {
+  it('passes ordinary text through and never suppresses', () => {
+    const f = new DeepSeekInlineToolCallFilter();
+    let out = f.push('Hello, ');
+    out += f.push('world.');
+    out += f.flush();
+    expect(out).toBe('Hello, world.');
+    expect(f.sawToolBlock).toBe(false);
+  });
+
+  it('emits text before the block and suppresses the tokens', () => {
+    const f = new DeepSeekInlineToolCallFilter();
+    const content = `Reading now. ${wrap(callBlock('read_file', '{"path":"a.js"}'))}`;
+    let out = '';
+    out += f.push(content);
+    out += f.flush();
+    expect(out).toBe('Reading now. ');
+    expect(f.sawToolBlock).toBe(true);
+    expect(f.content).toBe(content);
+    expect(parseDeepSeekInlineToolCalls(f.content)).toHaveLength(1);
+  });
+
+  it('detects a begin marker split across deltas', () => {
+    const f = new DeepSeekInlineToolCallFilter();
+    const mid = Math.floor(DEEPSEEK_TOOL_CALLS_BEGIN.length / 2);
+    let out = '';
+    out += f.push(`ok ${DEEPSEEK_TOOL_CALLS_BEGIN.slice(0, mid)}`);
+    out += f.push(`${DEEPSEEK_TOOL_CALLS_BEGIN.slice(mid)}rest`);
+    out += f.flush();
+    expect(out).toBe('ok ');
+    expect(f.sawToolBlock).toBe(true);
+  });
+});

--- a/packages/kosong/test/providers/deepseek-inline-tool-calls.test.ts
+++ b/packages/kosong/test/providers/deepseek-inline-tool-calls.test.ts
@@ -48,6 +48,13 @@ describe('parseDeepSeekInlineToolCalls', () => {
     expect(calls.map((c) => c.name)).toEqual(['Grep']);
   });
 
+  it('parses a call whose JSON string argument contains a triple-backtick fence', () => {
+    const args = '{"content":"```js\\nconsole.log(1)\\n```"}';
+    const calls = parseDeepSeekInlineToolCalls(wrap(callBlock('write_file', args)));
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.arguments).toBe(args);
+  });
+
   it('parses the full-width (U+FF5C) sentinel form raw vLLM leaks emit', () => {
     const fw = `<｜tool${SEP}calls${SEP}begin｜>${callBlock('read_file', '{"path":"a.js"}', '｜')}<｜tool${SEP}calls${SEP}end｜>`;
     const calls = parseDeepSeekInlineToolCalls(fw);
@@ -82,13 +89,17 @@ describe('DeepSeekInlineToolCallFilter', () => {
 
   it('emits text before the block and suppresses the tokens', () => {
     const f = new DeepSeekInlineToolCallFilter();
-    const content = `Reading now. ${wrap(callBlock('read_file', '{"path":"a.js"}'))}`;
+    const block = wrap(callBlock('read_file', '{"path":"a.js"}'));
+    const content = `Reading now. ${block}`;
     let out = '';
     out += f.push(content);
     out += f.flush();
     expect(out).toBe('Reading now. ');
     expect(f.sawToolBlock).toBe(true);
-    expect(f.content).toBe(content);
+    // `content` only accumulates from the block boundary onward (the pre-marker
+    // prefix is dropped) since parsing never needs it — see the memory-retention
+    // note on DeepSeekInlineToolCallFilter.push.
+    expect(f.content).toBe(block);
     expect(parseDeepSeekInlineToolCalls(f.content)).toHaveLength(1);
   });
 


### PR DESCRIPTION
## Problem

DeepSeek-architecture models (deepseek-v3/r1 and derivatives such as cogito) emit tool calls in a special-token format rather than as OpenAI `tool_calls`:

````
<|tool▁calls▁begin|><|tool▁call▁begin|>function<|tool▁sep|>NAME
```json
{ ...args... }
```<|tool▁call▁end|><|tool▁calls▁end|>
````

DeepSeek's own API parses this server-side and returns structured `tool_calls`. A lot of OpenAI-compatible deployments don't — self-hosted vLLM/SGLang/llama.cpp, ollama, and some proxy layers pass the raw tokens straight through into the assistant `content`. kosong then sees an ordinary text turn with no tool call, the agent has nothing to dispatch, and the turn dead-ends: the model effectively narrates the call instead of making it.

## Where I ran into it

ollama-cloud serving `cogito-2.1:671b` (DeepSeek-MoE based). At `temperature: 0` it leaks the tokens on essentially every tool turn — ollama's own parser only catches them some of the time. Any DeepSeek-format model behind a backend that doesn't structure tool calls hits the same wall.

## Change

`OpenAILegacyChatProvider` now detects a leaked DeepSeek tool-call block and parses it into structured `tool_calls` — but only when the response carried no structured tool call and the begin-token is present. For any backend that already does the right thing (DeepSeek's API included) it's a no-op.

- Both streaming and non-streaming paths.
- Streaming is marker-aware: text is forwarded live up to the begin-token, then the block is suppressed so the raw tokens never reach the UI, with a one-token holdback so a begin-token split across two deltas is still caught.
- Argument blocks that aren't valid JSON are skipped rather than emitted as a broken call.

The parser and the stream filter are a small standalone module (`deepseek-inline-tool-calls.ts`) so they're unit-testable on their own.

## Tests

`test/providers/deepseek-inline-tool-calls.test.ts` covers single and parallel calls, the no-token no-op, invalid-JSON skipping, and the streaming filter (passthrough, suppression, split-marker detection). Typecheck and the kosong suite pass locally.

End to end against ollama-cloud/cogito, agentic tool loops that previously never completed now run reliably.
