### PR TITLE
fix(tui): add top border to queue pane to separate it from todo panel

### DIFF
--- a/.changeset/queue-pane-border.md
+++ b/.changeset/queue-pane-border.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Polish queue pane styling

--- a/apps/kimi-code/src/tui/components/panes/queue-pane.ts
+++ b/apps/kimi-code/src/tui/components/panes/queue-pane.ts
@@ -34,7 +34,7 @@ export class QueuePaneComponent extends Container {
   override render(width: number): string[] {
     const accent = (text: string) => currentTheme.fg('accent', text);
     const dim = (text: string) => currentTheme.fg('textDim', text);
-    const lines: string[] = [];
+    const lines: string[] = [currentTheme.fg('border', '─'.repeat(width))];
 
     for (const item of this.messages) {
       const singleLine = item.text.replaceAll(/\s+/g, ' ').trim();

--- a/apps/kimi-code/test/tui/components/panes/queue-pane.test.ts
+++ b/apps/kimi-code/test/tui/components/panes/queue-pane.test.ts
@@ -62,8 +62,8 @@ describe('QueuePaneComponent', () => {
     });
 
     const lines = component.render(30);
-    expect(lines).toHaveLength(2); // message + hint
-    const messageLine = stripAnsi(lines[0] as string);
+    expect(lines).toHaveLength(3); // border + message + hint
+    const messageLine = stripAnsi(lines[1] as string);
     expect(messageLine).not.toContain('a'.repeat(30));
     expect(messageLine.endsWith('…')).toBe(true);
   });
@@ -77,8 +77,8 @@ describe('QueuePaneComponent', () => {
     });
 
     const lines = component.render(120);
-    expect(lines).toHaveLength(2); // message + hint
-    const messageLine = stripAnsi(lines[0] as string);
+    expect(lines).toHaveLength(3); // border + message + hint
+    const messageLine = stripAnsi(lines[1] as string);
     expect(messageLine).toContain('line one line two line three');
     expect(messageLine).not.toContain('\n');
   });


### PR DESCRIPTION
<!--
Thank you for your contribution to Kimi Code!
Please open an issue before sending a feature PR — PRs without prior discussion may be closed without review.

See https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md for more.
-->

## Related Issue

No related issue; this is a small visual fix.

## Problem

The queued-messages pane rendered directly below the TODO panel with no visual separator, so the queue hint and TODO items appeared merged together.

## What changed

Add a top border to `QueuePaneComponent` using the theme's `border` color, matching the separator style used by the TODO panel.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [ ] I have added tests that prove my feature works. (Existing component tests still pass; no new behavior to test.)
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.
