### PR TITLE
fix(kimi-code): reduce /btw panel max height to one-third of terminal

### DIFF
--- a/.changeset/reduce-btw-panel-height.md
+++ b/.changeset/reduce-btw-panel-height.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Reduce the maximum height of the /btw side panel from half to one-third of the terminal.

--- a/apps/kimi-code/src/tui/components/panes/btw-panel.ts
+++ b/apps/kimi-code/src/tui/components/panes/btw-panel.ts
@@ -185,7 +185,7 @@ export class BtwPanelComponent implements Component {
   private collapsedBodyLimit(): number | undefined {
     const terminalRows = this.options.terminalRows();
     if (!Number.isFinite(terminalRows) || terminalRows <= 0) return undefined;
-    const maxPanelLines = Math.max(MIN_COLLAPSED_PANEL_LINES, Math.floor(terminalRows / 2));
+    const maxPanelLines = Math.max(MIN_COLLAPSED_PANEL_LINES, Math.floor(terminalRows / 3));
     return Math.max(1, maxPanelLines - 1);
   }
 

--- a/apps/kimi-code/test/tui/kimi-tui-message-flow.test.ts
+++ b/apps/kimi-code/test/tui/kimi-tui-message-flow.test.ts
@@ -1762,10 +1762,10 @@ command = "vim"
     expect(finalLines.at(-1)).toMatch(/^│\s+│$/);
   });
 
-  it('caps /btw height to half the terminal and supports scrolling', async () => {
+  it('caps /btw height to one-third of the terminal and supports scrolling', async () => {
     const session = makeSession();
     const { driver } = await makeDriver(session);
-    setTerminalRows(driver, 12);
+    setTerminalRows(driver, 15);
     await openBtwPanel(driver, session, 'question 1');
 
     const panel = getMountedBtwPanel(driver);
@@ -1778,7 +1778,7 @@ command = "vim"
     }
 
     const collapsed = panel.render(80).map(stripSgr);
-    expect(collapsed).toHaveLength(6);
+    expect(collapsed).toHaveLength(5);
     expect(collapsed.join('\n')).toContain('BTW ─ Esc close · ↑↓ scroll');
     expect(collapsed.join('\n')).not.toContain('ctrl+o expand');
     expect(collapsed.join('\n')).toContain('question 8');


### PR DESCRIPTION
## Related Issue

N/A

## Problem

The /btw side panel could grow up to half of the terminal height, which left too little vertical space for the main session transcript and input on smaller screens.

## What changed

Reduced the maximum collapsed height of the /btw panel from one-half to one-third of the terminal rows. Updated the corresponding test to keep the scrolling assertions meaningful under the new cap.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.