### PR TITLE
fix(agent-core): suppress close-time background notifications

### DIFF
--- a/.changeset/suppress-background-close-notifications.md
+++ b/.changeset/suppress-background-close-notifications.md
@@ -1,0 +1,6 @@
+---
+"@moonshot-ai/agent-core": patch
+"@moonshot-ai/kimi-code": patch
+---
+
+Prevent session shutdown from resuming the agent when stopping background tasks.

--- a/packages/agent-core/src/session/index.ts
+++ b/packages/agent-core/src/session/index.ts
@@ -346,9 +346,15 @@ export class Session {
     });
     if (keepAliveOnExit) return;
     await Promise.all(
-      Array.from(this.readyAgents(), (agent) =>
-        agent.background.stopAll('Session closed'),
-      ),
+      Array.from(this.readyAgents(), async (agent) => {
+        const activeTasks = agent.background.list(true);
+        await Promise.all(
+          activeTasks.map((task) =>
+            agent.background.suppressTerminalNotification(task.taskId),
+          ),
+        );
+        await agent.background.stopAll('Session closed');
+      }),
     );
   }
 

--- a/packages/agent-core/test/session/lifecycle-hooks.test.ts
+++ b/packages/agent-core/test/session/lifecycle-hooks.test.ts
@@ -131,6 +131,30 @@ describe('Session lifecycle hooks', () => {
     expect(agent.background.getTask(taskId)?.status).toBe('killed');
   });
 
+  it('does not steer background task notifications while closing the session', async () => {
+    const { sessionDir, workDir } = await hookFixture();
+    const session = new Session({
+      kaos: testKaos.withCwd(workDir),
+      id: 'session-bg-cleanup-no-steer',
+      homedir: sessionDir,
+      rpc: createSessionRpc(),
+      skills: { explicitDirs: [join(workDir, 'missing-skills')] },
+    });
+    const agent = await session.createMain();
+    const steerSpy = vi.spyOn(agent.turn, 'steer');
+    const { proc, killSpy } = pendingProcess();
+    const taskId = agent.background.registerTask(
+      new ProcessBackgroundTask(proc, 'sleep 60', 'exit cleanup without steer'),
+    );
+
+    await session.close();
+    await new Promise((resolve) => setImmediate(resolve));
+
+    expect(killSpy).toHaveBeenCalledWith('SIGTERM');
+    expect(agent.background.getTask(taskId)?.status).toBe('killed');
+    expect(steerSpy).not.toHaveBeenCalled();
+  });
+
   it('keeps background tasks alive on close when keepAliveOnExit is true', async () => {
     const { sessionDir, workDir } = await hookFixture();
     const session = new Session({


### PR DESCRIPTION
## Related Issue

No linked issue.

## Problem

Stopping background tasks during headless session shutdown can emit terminal task notifications back into the agent turn, causing the agent to resume after it should be closing.

## What changed

Suppress terminal notifications before shutdown stops active background tasks, while preserving the existing behavior that close still stops them unless background keep-alive is enabled. Added a regression test for the shutdown path.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.

## Verification

- `pnpm --filter @moonshot-ai/agent-core test -- test/session/lifecycle-hooks.test.ts --runInBand`
- `pnpm --filter @moonshot-ai/agent-core typecheck`