### PR TITLE
fix: build replay ranges from replay records

### DIFF
--- a/.changeset/replay-range-projection.md
+++ b/.changeset/replay-range-projection.md
@@ -1,0 +1,6 @@
+---
+"@moonshot-ai/agent-core": patch
+"@moonshot-ai/kimi-code": patch
+---
+
+Project session replay ranges over rendered replay records instead of raw persisted records.

--- a/packages/agent-core/src/agent/index.ts
+++ b/packages/agent-core/src/agent/index.ts
@@ -43,7 +43,7 @@ import {
   type AgentRecord,
   type AgentRecordPersistence,
 } from './records';
-import { ReplayBuilder } from './replay';
+import { ReplayBuilder, type ReplayBuilderOptions } from './replay';
 import { SkillManager } from './skill';
 import type { SkillRegistry } from './skill/types';
 import { SwarmMode } from './swarm';
@@ -87,6 +87,7 @@ export interface AgentOptions {
   readonly telemetry?: TelemetryClient | undefined;
   readonly pluginSessionStarts?: readonly EnabledPluginSessionStart[];
   readonly experimentalFlags?: ExperimentalFlagResolver;
+  readonly replay?: ReplayBuilderOptions;
 }
 
 export class Agent {
@@ -182,7 +183,7 @@ export class Agent {
     );
     this.cron = this.type === 'sub' ? null : new CronManager(this);
     this.goal = new GoalMode(this);
-    this.replayBuilder = new ReplayBuilder(this);
+    this.replayBuilder = new ReplayBuilder(this, options.replay);
   }
 
   setKaos(kaos: Kaos) {

--- a/packages/agent-core/src/agent/index.ts
+++ b/packages/agent-core/src/agent/index.ts
@@ -42,6 +42,7 @@ import {
   FileSystemAgentRecordPersistence,
   type AgentRecord,
   type AgentRecordPersistence,
+  type AgentRecordsReplayOptions,
 } from './records';
 import { ReplayBuilder, type ReplayBuilderOptions } from './replay';
 import { SkillManager } from './skill';
@@ -292,8 +293,8 @@ export class Agent {
     this.tools.setActiveTools(profile.tools);
   }
 
-  async resume(): Promise<{ warning?: string }> {
-    const result = await this.records.replay();
+  async resume(options?: AgentRecordsReplayOptions): Promise<{ warning?: string }> {
+    const result = await this.records.replay(options);
     try {
       this.replayBuilder.postRestoring = true;
       this.goal.normalizeAfterReplay();

--- a/packages/agent-core/src/agent/records/index.ts
+++ b/packages/agent-core/src/agent/records/index.ts
@@ -127,6 +127,10 @@ export interface RestoringContext {
   time?: number;
 }
 
+export interface AgentRecordsReplayOptions {
+  readonly rewriteMigratedRecords?: boolean;
+}
+
 export class AgentRecords {
   private _restoring: RestoringContext | null = null;
   private metadataInitialized = false;
@@ -162,22 +166,25 @@ export class AgentRecords {
     this.persistence?.append(stamped);
   }
 
-  restore(record: AgentRecord): void {
+  restore(record: AgentRecord): boolean {
     this._restoring = { time: record.time ?? Date.now() };
     try {
       restoreAgentRecord(this.agent, record);
+      return this.agent.replayBuilder.finishRestoringRecord(record.type);
     } finally {
       this._restoring = null;
     }
   }
 
-  async replay(): Promise<{ warning?: string }> {
+  async replay(options: AgentRecordsReplayOptions = {}): Promise<{ warning?: string }> {
     if (!this.persistence) throw new Error('No persistence provided for AgentRecords');
+    const rewriteMigratedRecords = options.rewriteMigratedRecords ?? true;
     let migrations: readonly WireMigration[] = [];
     let hasMetadata = false;
     let shouldRewrite = false;
     let warning: string | undefined;
-    const replayedRecords: AgentRecord[] = [];
+    const replayedRecords: AgentRecord[] | undefined = rewriteMigratedRecords ? [] : undefined;
+    let completed = true;
     for await (const record of this.persistence.read()) {
       if (!hasMetadata) {
         if (record.type !== 'metadata') {
@@ -204,14 +211,17 @@ export class AgentRecords {
           protocol_version: AGENT_WIRE_PROTOCOL_VERSION,
         };
       }
-      replayedRecords.push(migratedRecord);
-      this.restore(migratedRecord);
+      replayedRecords?.push(migratedRecord);
+      if (this.restore(migratedRecord)) {
+        completed = false;
+        break;
+      }
     }
-    if (shouldRewrite) {
+    if (completed && shouldRewrite && replayedRecords !== undefined) {
       this.persistence.rewrite(replayedRecords);
       await this.persistence.flush();
     }
-    if (this.agent.blobStore !== undefined) {
+    if (completed && this.agent.blobStore !== undefined) {
       for (const msg of this.agent.context.history) {
         await this.agent.blobStore.rehydrateParts(msg.content);
       }

--- a/packages/agent-core/src/agent/replay/build.ts
+++ b/packages/agent-core/src/agent/replay/build.ts
@@ -1,0 +1,27 @@
+import { LocalKaos } from '@moonshot-ai/kaos';
+
+import type { AgentReplayRecord } from '../../rpc/resumed';
+import { Agent } from '../index';
+import type { AgentRecordPersistence } from '../records';
+
+export async function buildReplay(
+  persistence: AgentRecordPersistence,
+  start?: number,
+  count?: number,
+): Promise<readonly AgentReplayRecord[]> {
+  if (count === 0) return [];
+  const replay = start === undefined && count === undefined
+    ? undefined
+    : { range: { start, count } };
+
+  const agent = new Agent({
+    kaos: await LocalKaos.create(),
+    persistence,
+    type: 'sub',
+    replay,
+  });
+  await agent.records.replay({
+    rewriteMigratedRecords: false,
+  });
+  return agent.replayBuilder.buildResult();
+}

--- a/packages/agent-core/src/agent/replay/build.ts
+++ b/packages/agent-core/src/agent/replay/build.ts
@@ -3,22 +3,17 @@ import { LocalKaos } from '@moonshot-ai/kaos';
 import type { AgentReplayRecord } from '../../rpc/resumed';
 import { Agent } from '../index';
 import type { AgentRecordPersistence } from '../records';
+import type { ReplayRangeOptions } from '.';
 
 export async function buildReplay(
   persistence: AgentRecordPersistence,
-  start?: number,
-  count?: number,
+  range?: ReplayRangeOptions,
 ): Promise<readonly AgentReplayRecord[]> {
-  if (count === 0) return [];
-  const replay = start === undefined && count === undefined
-    ? undefined
-    : { range: { start, count } };
-
   const agent = new Agent({
     kaos: await LocalKaos.create(),
     persistence,
     type: 'sub',
-    replay,
+    replay: { range },
   });
   await agent.records.replay({
     rewriteMigratedRecords: false,

--- a/packages/agent-core/src/agent/replay/build.ts
+++ b/packages/agent-core/src/agent/replay/build.ts
@@ -15,8 +15,6 @@ export async function buildReplay(
     type: 'sub',
     replay: { range },
   });
-  await agent.records.replay({
-    rewriteMigratedRecords: false,
-  });
+  await agent.resume({ rewriteMigratedRecords: false });
   return agent.replayBuilder.buildResult();
 }

--- a/packages/agent-core/src/agent/replay/index.ts
+++ b/packages/agent-core/src/agent/replay/index.ts
@@ -1,20 +1,38 @@
 import type { Agent } from '..';
-import type { AgentReplayRecord, AgentReplayRecordPayload } from '../..';
+import type { AgentReplayRecord, AgentReplayRecordPayload } from '../../rpc/resumed';
 import type { ContextMessage } from '../context';
+
+export interface ReplayRangeOptions {
+  readonly start?: number;
+  readonly count?: number;
+}
+
+export interface ReplayBuilderOptions {
+  readonly range?: ReplayRangeOptions;
+}
+
+const UNDO_BOUNDARY_RECORD_TYPES = new Set(['context.clear', 'context.apply_compaction']);
 
 export class ReplayBuilder {
   postRestoring = false;
   captureLiveRecords = false;
   protected readonly records: AgentReplayRecord[] = [];
+  private frozen = false;
+  private segmentStart = 0;
 
-  constructor(public readonly agent: Agent) {}
+  constructor(
+    public readonly agent: Agent,
+    private readonly options: ReplayBuilderOptions = {},
+  ) {}
 
   push(record: AgentReplayRecordPayload): void {
     if (this.captureLiveRecords || this.agent.records.restoring || this.postRestoring) {
-      this.records.push({
+      if (this.frozen) return;
+      const stamped: AgentReplayRecord = {
         ...record,
         time: this.agent.records.restoring?.time ?? Date.now(),
-      });
+      };
+      this.records.push(stamped);
     }
   }
 
@@ -22,6 +40,7 @@ export class ReplayBuilder {
     type: T,
     patch: Partial<Extract<AgentReplayRecord, { type: T }>>,
   ): void {
+    if (this.frozen) return;
     if (this.agent.records.restoring) {
       const last = this.records.at(-1);
       if (last && last.type === type) {
@@ -31,16 +50,50 @@ export class ReplayBuilder {
   }
 
   removeLastMessages(removedMessages: ReadonlySet<ContextMessage>): void {
+    if (this.frozen) return;
     if (removedMessages.size === 0) return;
-    for (let i = this.records.length - 1; i >= 0; i--) {
-      const record = this.records[i]!;
-      if (record.type === 'message' && removedMessages.has(record.message)) {
-        this.records.splice(i, 1);
-      }
+    this.removeMessagesFrom(this.records, removedMessages);
+  }
+
+  finishRestoringRecord(type: string): boolean {
+    const range = this.options.range;
+    if (range === undefined) return false;
+    if (this.frozen) return true;
+    if (!UNDO_BOUNDARY_RECORD_TYPES.has(type)) return false;
+
+    const start = range.start ?? 0;
+    const nextSegmentStart = this.segmentStart + this.records.length;
+    if (nextSegmentStart > start) {
+      this.frozen = true;
+      return true;
     }
+
+    this.segmentStart = nextSegmentStart;
+    this.records.splice(0);
+    return false;
   }
 
   buildResult(): readonly AgentReplayRecord[] {
+    const range = this.options.range;
+    if (range !== undefined) {
+      const start = range.start ?? 0;
+      const offset = Math.max(0, start - this.segmentStart);
+      const count = range.count;
+      const end = count === undefined ? undefined : offset + count;
+      return this.records.slice(offset, end);
+    }
     return this.records;
+  }
+
+  private removeMessagesFrom(
+    records: AgentReplayRecord[],
+    removedMessages: ReadonlySet<ContextMessage>,
+  ): void {
+    for (let i = records.length - 1; i >= 0; i--) {
+      const record = records[i]!;
+      if (record.type === 'message' && removedMessages.has(record.message)) {
+        records.splice(i, 1);
+      }
+    }
   }
 }

--- a/packages/agent-core/src/agent/replay/index.ts
+++ b/packages/agent-core/src/agent/replay/index.ts
@@ -60,8 +60,9 @@ export class ReplayBuilder {
     if (range === undefined) return false;
     if (this.frozen) return true;
     if (!UNDO_BOUNDARY_RECORD_TYPES.has(type)) return false;
+    if (range.start === undefined) return false;
 
-    const start = range.start ?? 0;
+    const start = range.start;
     const nextSegmentStart = this.segmentStart + this.records.length;
     if (nextSegmentStart > start) {
       this.frozen = true;
@@ -76,6 +77,10 @@ export class ReplayBuilder {
   buildResult(): readonly AgentReplayRecord[] {
     const range = this.options.range;
     if (range !== undefined) {
+      if (range.start === undefined && range.count !== undefined) {
+        const offset = Math.max(0, this.records.length - range.count);
+        return this.records.slice(offset);
+      }
       const start = range.start ?? 0;
       const offset = Math.max(0, start - this.segmentStart);
       const count = range.count;

--- a/packages/agent-core/src/index.ts
+++ b/packages/agent-core/src/index.ts
@@ -7,6 +7,7 @@ export * from './session/export';
 export * from './telemetry';
 export * from './errors';
 export * from './plugin';
+export { buildReplay } from './agent/replay/build';
 export {
   flushDiagnosticLogs,
   getRootLogger,

--- a/packages/agent-core/test/agent/records/index.test.ts
+++ b/packages/agent-core/test/agent/records/index.test.ts
@@ -348,13 +348,61 @@ describe('agent replay range build', () => {
       { type: 'context.append_message', message },
     ]);
 
-    const replay = await buildReplay(persistence, 1, 2);
+    const replay = await buildReplay(persistence, { start: 1, count: 2 });
 
     expect(replay).toEqual([
       expect.objectContaining({ type: 'permission_updated', mode: 'yolo' }),
       expect.objectContaining({ type: 'message', message }),
     ]);
     expect(persistence.rewrites).toEqual([]);
+  });
+
+  it('returns the last count replay records when start is omitted', async () => {
+    const firstMessage = userMessage('first');
+    const secondMessage = userMessage('second');
+    const thirdMessage = userMessage('third');
+    const persistence = new InMemoryAgentRecordPersistence([
+      { type: 'metadata', protocol_version: AGENT_WIRE_PROTOCOL_VERSION, created_at: 1 },
+      { type: 'context.append_message', message: firstMessage },
+      { type: 'permission.set_mode', mode: 'auto' },
+      { type: 'context.append_message', message: secondMessage },
+      { type: 'context.append_message', message: thirdMessage },
+    ]);
+
+    await expect(buildReplay(persistence, { count: 2 })).resolves.toEqual([
+      expect.objectContaining({ type: 'message', message: secondMessage }),
+      expect.objectContaining({ type: 'message', message: thirdMessage }),
+    ]);
+    await expect(buildReplay(persistence, { count: 10 })).resolves.toEqual([
+      expect.objectContaining({ type: 'message', message: firstMessage }),
+      expect.objectContaining({ type: 'permission_updated', mode: 'auto' }),
+      expect.objectContaining({ type: 'message', message: secondMessage }),
+      expect.objectContaining({ type: 'message', message: thirdMessage }),
+    ]);
+  });
+
+  it('continues reading all segments before returning the last count replay records', async () => {
+    const beforeClearMessages = Array.from({ length: 50 }, (_item, index) =>
+      userMessage(`before-clear-${String(index)}`),
+    );
+    const afterClearMessages = Array.from({ length: 50 }, (_item, index) =>
+      userMessage(`after-clear-${String(index)}`),
+    );
+    const persistence = new InMemoryAgentRecordPersistence([
+      { type: 'metadata', protocol_version: AGENT_WIRE_PROTOCOL_VERSION, created_at: 1 },
+      ...beforeClearMessages.map((message) => ({ type: 'context.append_message' as const, message })),
+      { type: 'context.clear' },
+      ...afterClearMessages.map((message) => ({ type: 'context.append_message' as const, message })),
+    ]);
+
+    const replay = await buildReplay(persistence, { count: 10 });
+
+    expect(replay).toHaveLength(10);
+    expect(replay).toEqual(
+      afterClearMessages.slice(-10).map((message) =>
+        expect.objectContaining({ type: 'message', message }),
+      ),
+    );
   });
 
   it('continues reading after count so later wire records can patch captured replay records', async () => {
@@ -371,7 +419,7 @@ describe('agent replay range build', () => {
       { type: 'permission.set_mode', mode: 'auto' },
     ]);
 
-    await expect(buildReplay(persistence, 0, 1)).resolves.toEqual([
+    await expect(buildReplay(persistence, { start: 0, count: 1 })).resolves.toEqual([
       expect.objectContaining({
         type: 'compaction',
         instruction: 'keep facts',
@@ -391,7 +439,7 @@ describe('agent replay range build', () => {
       { type: 'permission.set_mode', mode: 'auto' },
     ]);
 
-    await expect(buildReplay(persistence, 0, 1)).resolves.toEqual([
+    await expect(buildReplay(persistence, { start: 0, count: 1 })).resolves.toEqual([
       expect.objectContaining({ type: 'permission_updated', mode: 'auto' }),
     ]);
     expect(persistence.rewrites).toEqual([]);
@@ -415,7 +463,7 @@ describe('agent replay range build', () => {
       { type: 'context.append_message', message: expectedMessage },
     ]);
 
-    await expect(buildReplay(persistence, 2, 1)).resolves.toEqual([
+    await expect(buildReplay(persistence, { start: 2, count: 1 })).resolves.toEqual([
       expect.objectContaining({ type: 'message', message: expectedMessage }),
     ]);
   });
@@ -432,11 +480,11 @@ describe('agent replay range build', () => {
       { type: 'context.append_message', message: afterClearMessage },
     ]);
 
-    await expect(buildReplay(persistence, 0, 10)).resolves.toEqual([
+    await expect(buildReplay(persistence, { start: 0, count: 10 })).resolves.toEqual([
       expect.objectContaining({ type: 'message', message: firstMessage }),
       expect.objectContaining({ type: 'message', message: secondMessage }),
     ]);
-    await expect(buildReplay(persistence, 2, 10)).resolves.toEqual([
+    await expect(buildReplay(persistence, { start: 2, count: 10 })).resolves.toEqual([
       expect.objectContaining({ type: 'message', message: afterClearMessage }),
     ]);
   });

--- a/packages/agent-core/test/agent/records/index.test.ts
+++ b/packages/agent-core/test/agent/records/index.test.ts
@@ -1,10 +1,12 @@
 import { describe, expect, it } from 'vitest';
 
+import { buildReplay } from '../../../src';
 import {
   AGENT_WIRE_PROTOCOL_VERSION,
   InMemoryAgentRecordPersistence,
   type AgentRecord,
 } from '../../../src/agent/records';
+import type { ContextMessage } from '../../../src/agent/context';
 import { testAgent } from '../harness/agent';
 
 describe('AgentRecords persistence metadata', () => {
@@ -306,6 +308,140 @@ describe('AgentRecords persistence metadata', () => {
   });
 });
 
+describe('agent replay range build', () => {
+  it('returns the complete replay when no range is requested', async () => {
+    const firstMessage = userMessage('first');
+    const afterClearMessage = userMessage('after-clear');
+    const persistence = new InMemoryAgentRecordPersistence([
+      { type: 'metadata', protocol_version: AGENT_WIRE_PROTOCOL_VERSION, created_at: 1 },
+      { type: 'context.append_message', message: firstMessage },
+      { type: 'context.clear' },
+      { type: 'context.append_message', message: afterClearMessage },
+    ]);
+
+    await expect(buildReplay(persistence)).resolves.toEqual([
+      expect.objectContaining({ type: 'message', message: firstMessage }),
+      expect.objectContaining({ type: 'message', message: afterClearMessage }),
+    ]);
+  });
+
+  it('applies start and count to replay records instead of wire records', async () => {
+    const message = userMessage('hello');
+    const persistence = new RecordingInMemoryAgentRecordPersistence([
+      { type: 'metadata', protocol_version: AGENT_WIRE_PROTOCOL_VERSION, created_at: 1 },
+      {
+        type: 'usage.record',
+        model: 'mock-model',
+        usage: { inputOther: 1, inputCacheRead: 0, inputCacheCreation: 0, output: 1 },
+      },
+      {
+        type: 'config.update',
+        cwd: process.cwd(),
+        thinkingLevel: 'off',
+      },
+      {
+        type: 'usage.record',
+        model: 'mock-model',
+        usage: { inputOther: 2, inputCacheRead: 0, inputCacheCreation: 0, output: 1 },
+      },
+      { type: 'permission.set_mode', mode: 'yolo' },
+      { type: 'context.append_message', message },
+    ]);
+
+    const replay = await buildReplay(persistence, 1, 2);
+
+    expect(replay).toEqual([
+      expect.objectContaining({ type: 'permission_updated', mode: 'yolo' }),
+      expect.objectContaining({ type: 'message', message }),
+    ]);
+    expect(persistence.rewrites).toEqual([]);
+  });
+
+  it('continues reading after count so later wire records can patch captured replay records', async () => {
+    const persistence = new InMemoryAgentRecordPersistence([
+      { type: 'metadata', protocol_version: AGENT_WIRE_PROTOCOL_VERSION, created_at: 1 },
+      { type: 'full_compaction.begin', source: 'manual', instruction: 'keep facts' },
+      {
+        type: 'context.apply_compaction',
+        summary: 'Compacted summary.',
+        compactedCount: 0,
+        tokensBefore: 10,
+        tokensAfter: 3,
+      },
+      { type: 'permission.set_mode', mode: 'auto' },
+    ]);
+
+    await expect(buildReplay(persistence, 0, 1)).resolves.toEqual([
+      expect.objectContaining({
+        type: 'compaction',
+        instruction: 'keep facts',
+        result: {
+          summary: 'Compacted summary.',
+          compactedCount: 0,
+          tokensBefore: 10,
+          tokensAfter: 3,
+        },
+      }),
+    ]);
+  });
+
+  it('does not rewrite migrated wire records while projecting', async () => {
+    const persistence = new RecordingInMemoryAgentRecordPersistence([
+      { type: 'metadata', protocol_version: '1.0', created_at: 1 },
+      { type: 'permission.set_mode', mode: 'auto' },
+    ]);
+
+    await expect(buildReplay(persistence, 0, 1)).resolves.toEqual([
+      expect.objectContaining({ type: 'permission_updated', mode: 'auto' }),
+    ]);
+    expect(persistence.rewrites).toEqual([]);
+  });
+
+  it('keeps the start offset correct when undo removes more messages than count', async () => {
+    const firstMessage = userMessage('first');
+    const removedBeforeStart = userMessage('removed-before-start');
+    const removedAtStart = userMessage('removed-at-start');
+    const removedAfterStart = userMessage('removed-after-start');
+    const nextMessage = userMessage('next');
+    const expectedMessage = userMessage('expected');
+    const persistence = new InMemoryAgentRecordPersistence([
+      { type: 'metadata', protocol_version: AGENT_WIRE_PROTOCOL_VERSION, created_at: 1 },
+      { type: 'context.append_message', message: firstMessage },
+      { type: 'context.append_message', message: removedBeforeStart },
+      { type: 'context.append_message', message: removedAtStart },
+      { type: 'context.append_message', message: removedAfterStart },
+      { type: 'context.undo', count: 3 },
+      { type: 'context.append_message', message: nextMessage },
+      { type: 'context.append_message', message: expectedMessage },
+    ]);
+
+    await expect(buildReplay(persistence, 2, 1)).resolves.toEqual([
+      expect.objectContaining({ type: 'message', message: expectedMessage }),
+    ]);
+  });
+
+  it('clamps results at undo boundaries', async () => {
+    const firstMessage = userMessage('first');
+    const secondMessage = userMessage('second');
+    const afterClearMessage = userMessage('after-clear');
+    const persistence = new InMemoryAgentRecordPersistence([
+      { type: 'metadata', protocol_version: AGENT_WIRE_PROTOCOL_VERSION, created_at: 1 },
+      { type: 'context.append_message', message: firstMessage },
+      { type: 'context.append_message', message: secondMessage },
+      { type: 'context.clear' },
+      { type: 'context.append_message', message: afterClearMessage },
+    ]);
+
+    await expect(buildReplay(persistence, 0, 10)).resolves.toEqual([
+      expect.objectContaining({ type: 'message', message: firstMessage }),
+      expect.objectContaining({ type: 'message', message: secondMessage }),
+    ]);
+    await expect(buildReplay(persistence, 2, 10)).resolves.toEqual([
+      expect.objectContaining({ type: 'message', message: afterClearMessage }),
+    ]);
+  });
+});
+
 class RecordingInMemoryAgentRecordPersistence extends InMemoryAgentRecordPersistence {
   readonly rewrites: AgentRecord[][] = [];
 
@@ -313,4 +449,12 @@ class RecordingInMemoryAgentRecordPersistence extends InMemoryAgentRecordPersist
     this.rewrites.push([...records]);
     super.rewrite(records);
   }
+}
+
+function userMessage(text: string): ContextMessage {
+  return {
+    role: 'user',
+    content: [{ type: 'text', text }],
+    toolCalls: [],
+  };
 }


### PR DESCRIPTION
## Related Issue

No linked issue; this fixes replay range projection so callers can request rendered replay records directly.

## Problem

Session replay range building needs to paginate over rendered replay records, not raw persisted wire records. Raw records can include non-rendered records, and some rendered records are patched by later wire records.

## What changed

- Added a replay builder helper that restores records into an isolated agent and projects optional start/count ranges over replay output.
- Preserved full replay behavior when no range is requested, avoided migration rewrites during projection, and stopped early at clear/compaction boundaries only when range projection is active.
- Added coverage for output-based range projection, compaction patching, migration rewrite suppression, undo offset handling, boundary clamping, and default full replay output.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.

Verification:

- `pnpm --filter @moonshot-ai/agent-core test -- test/agent/records/index.test.ts`
- `pnpm --filter @moonshot-ai/agent-core typecheck`
- `pnpm exec oxlint --type-aware --quiet packages/agent-core/src/agent/index.ts packages/agent-core/src/agent/records/index.ts packages/agent-core/src/agent/replay/index.ts packages/agent-core/src/agent/replay/build.ts packages/agent-core/src/index.ts packages/agent-core/test/agent/records/index.test.ts`
- `git diff --check`
- Read-only diff audit for internal identifiers: no issues found.