### PR TITLE
fix(kaos): destroy buffered readable sources

### DIFF
--- a/.changeset/destroy-buffered-readable-source.md
+++ b/.changeset/destroy-buffered-readable-source.md
@@ -1,0 +1,6 @@
+---
+"@moonshot-ai/kaos": patch
+"@moonshot-ai/kimi-code": patch
+---
+
+Close wrapped output streams when buffered readers are destroyed.

--- a/packages/kaos/src/internal.ts
+++ b/packages/kaos/src/internal.ts
@@ -267,6 +267,7 @@ export class BufferedReadable extends Readable {
     this._source.off('end', this._onEnd);
     this._source.off('close', this._onClose);
     this._source.off('error', this._onError);
+    this._source.destroy();
     callback(error);
   }
 

--- a/packages/kaos/test/internal.test.ts
+++ b/packages/kaos/test/internal.test.ts
@@ -95,6 +95,15 @@ describe('BufferedReadable', () => {
     expect(received).toBe(boom);
     expect(buffered.destroyed).toBe(true);
   });
+
+  it('destroys the underlying source when the wrapper is destroyed', () => {
+    const source = new PassThrough();
+    const buffered = new BufferedReadable(source);
+
+    buffered.destroy();
+
+    expect(source.destroyed).toBe(true);
+  });
 });
 
 describe('decodeTextWithErrors', () => {


### PR DESCRIPTION
## Related Issue

No linked issue.

## Problem

A buffered reader could be destroyed while its wrapped output stream stayed open. For process output, that can leave stdout or stderr pipes alive after the reader lifecycle ends, making callers wait for EOF longer than intended.

## What changed

Destroy the wrapped source stream when the buffered reader is destroyed, after detaching its listeners, so the source pipe follows the wrapper lifecycle. Added regression coverage for destroying the wrapper and included a patch changeset for the affected package and CLI bundle.

## Verification

- `pnpm vitest run test/internal.test.ts --testNamePattern "destroys the underlying source"`
- `pnpm vitest run`
- `pnpm run typecheck`

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.
