### PR TITLE
feat(kimi-code): support banner display frequency

### DIFF
--- a/.changeset/banner-display-frequency.md
+++ b/.changeset/banner-display-frequency.md
@@ -1,5 +1,5 @@
 ---
-"@moonshot-ai/kimi-code": minor
+"@moonshot-ai/kimi-code": patch
 ---
 
 Add configurable banner display frequencies with local display state.

--- a/.changeset/banner-display-frequency.md
+++ b/.changeset/banner-display-frequency.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": minor
+---
+
+Add configurable banner display frequencies with local display state.

--- a/apps/kimi-code/src/constant/app.ts
+++ b/apps/kimi-code/src/constant/app.ts
@@ -18,6 +18,7 @@ export const NPM_PACKAGE_NAME = '@moonshot-ai/kimi-code';
 export const KIMI_CODE_HOME_ENV = 'KIMI_CODE_HOME';
 export const KIMI_CODE_DATA_DIR_NAME = '.kimi-code';
 export const KIMI_CODE_LOG_DIR_NAME = 'logs';
+export const KIMI_CODE_CACHE_DIR_NAME = 'cache';
 export const KIMI_CODE_UPDATE_DIR_NAME = 'updates';
 export const KIMI_CODE_BIN_DIR_NAME = 'bin';
 export const KIMI_CODE_UPDATE_STATE_FILE_NAME = 'latest.json';
@@ -25,6 +26,8 @@ export const KIMI_CODE_UPDATE_INSTALL_STATE_FILE_NAME = 'install.json';
 export const KIMI_CODE_UPDATE_INSTALL_LOCK_FILE_NAME = 'install.lock';
 export const KIMI_CODE_UPDATE_ROLLOUT_LOG_FILE_NAME = 'rollout.log';
 export const KIMI_CODE_INPUT_HISTORY_DIR_NAME = 'user-history';
+export const KIMI_CODE_BANNER_DIR_NAME = 'banner';
+export const KIMI_CODE_BANNER_STATE_FILE_NAME = 'state.json';
 
 // Managed Kimi auth provider key shared with OAuth/SDK config.
 export const DEFAULT_OAUTH_PROVIDER_NAME = 'managed:kimi-code';

--- a/apps/kimi-code/src/tui/banner/banner-provider.ts
+++ b/apps/kimi-code/src/tui/banner/banner-provider.ts
@@ -1,17 +1,25 @@
+import { createHash } from 'node:crypto';
+
 import { gte, valid } from 'semver';
 
 import { KIMI_CODE_TIPS_BANNER_URL } from '#/constant/app';
-import type { BannerState } from '#/tui/types';
+import type { BannerDisplay, BannerState } from '#/tui/types';
+
+import type { BannerDisplayState } from './state';
 
 interface TipsBannerFallbackItem {
+  banner_id?: string | null;
   enabled?: boolean;
   banner_title?: string | null;
   banner_maintext?: string;
   banner_subtext?: string | null;
   banner_min_version?: string | null;
+  banner_display?: unknown;
+  banner_display_ttl_hours?: unknown;
 }
 
 interface TipsBannerJson {
+  banner_id?: string | null;
   banner_enabled?: boolean;
   banner_title?: string | null;
   banner_maintext?: string;
@@ -19,9 +27,49 @@ interface TipsBannerJson {
   banner_start_time?: string | null;
   banner_end_time?: string | null;
   banner_min_version?: string | null;
+  banner_display?: unknown;
+  banner_display_ttl_hours?: unknown;
   banner_fallback_enabled?: boolean;
   banner_fallback_list?: unknown[];
 }
+
+interface BannerHashInput {
+  tag: string | null;
+  mainText: string;
+  subText: string | null;
+  startTime: string | null;
+  endTime: string | null;
+  display: BannerDisplay;
+  ttlHours?: number;
+}
+
+interface BannerCandidateInput {
+  id: unknown;
+  tag: unknown;
+  mainText: string;
+  subText: unknown;
+  display: BannerDisplay;
+  ttlHours?: number;
+  startTime?: unknown;
+  endTime?: unknown;
+}
+
+export interface SelectDisplayableBannerArgs {
+  json: unknown;
+  clientVersion: string;
+  now: Date;
+  random: () => number;
+  state: BannerDisplayState;
+}
+
+interface BannerProviderLoadOptions {
+  state?: BannerDisplayState;
+  now?: Date;
+  random?: () => number;
+}
+
+const HOUR_MS = 60 * 60 * 1000;
+export const DEFAULT_COOLDOWN_TTL_HOURS = 24;
 
 function normalizeTag(value: unknown): string | null {
   if (typeof value !== 'string') return null;
@@ -63,6 +111,68 @@ function meetsMinVersion(minVersion: unknown, clientVersion: string): boolean {
   return gte(current, min);
 }
 
+function parseBannerDisplay(value: unknown): BannerDisplay {
+  if (value === 'once') return 'once';
+  if (value === 'cooldown') return 'cooldown';
+  return 'always';
+}
+
+function parseBannerDisplayTtlHours(value: unknown): number {
+  return typeof value === 'number' && Number.isFinite(value) && value > 0
+    ? value
+    : DEFAULT_COOLDOWN_TTL_HOURS;
+}
+
+function normalizeBannerId(value: unknown): string | null {
+  if (typeof value !== 'string') return null;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+function hashBannerIdentity(input: BannerHashInput): string {
+  const raw = JSON.stringify([
+    input.tag ?? '',
+    input.mainText,
+    input.subText ?? '',
+    input.startTime ?? '',
+    input.endTime ?? '',
+    input.display,
+    input.ttlHours ?? '',
+  ]);
+  return createHash('sha256').update(raw).digest('hex').slice(0, 32);
+}
+
+function getBannerKey(rawBannerId: unknown, input: BannerHashInput): string {
+  return normalizeBannerId(rawBannerId) ?? hashBannerIdentity(input);
+}
+
+function toBannerState(input: BannerCandidateInput): BannerState {
+  const tag = normalizeTag(input.tag);
+  const subText = normalizeText(input.subText);
+  const display = input.display;
+  const ttlHours = display === 'cooldown' ? parseBannerDisplayTtlHours(input.ttlHours) : undefined;
+  const startTime = normalizeText(input.startTime);
+  const endTime = normalizeText(input.endTime);
+  const key = getBannerKey(input.id, {
+    tag,
+    mainText: input.mainText,
+    subText,
+    startTime,
+    endTime,
+    display,
+    ttlHours,
+  });
+
+  return {
+    key,
+    tag,
+    mainText: input.mainText,
+    subText,
+    display,
+    ttlHours,
+  };
+}
+
 function pickActiveBanner(
   json: TipsBannerJson,
   clientVersion: string,
@@ -75,20 +185,24 @@ function pickActiveBanner(
   if (!isWithinWindow(start, end, now)) return null;
   const mainText = normalizeText(json.banner_maintext);
   if (mainText === null) return null;
-  return {
-    tag: normalizeTag(json.banner_title),
+  const display = parseBannerDisplay(json.banner_display);
+  return toBannerState({
+    id: json.banner_id,
+    tag: json.banner_title,
     mainText,
-    subText: normalizeText(json.banner_subtext),
-  };
+    subText: json.banner_subtext,
+    display,
+    ttlHours: display === 'cooldown' ? parseBannerDisplayTtlHours(json.banner_display_ttl_hours) : undefined,
+    startTime: json.banner_start_time,
+    endTime: json.banner_end_time,
+  });
 }
 
-function pickFallbackBanner(
+function pickFallbackCandidates(
   json: TipsBannerJson,
   clientVersion: string,
-  now: Date,
-  random: () => number,
-): BannerState | null {
-  if (json.banner_fallback_enabled !== true) return null;
+): BannerState[] {
+  if (json.banner_fallback_enabled !== true) return [];
   const list = Array.isArray(json.banner_fallback_list) ? json.banner_fallback_list : [];
   const candidates: BannerState[] = [];
   for (const raw of list) {
@@ -98,15 +212,57 @@ function pickFallbackBanner(
     if (!meetsMinVersion(item.banner_min_version, clientVersion)) continue;
     const mainText = normalizeText(item.banner_maintext);
     if (mainText === null) continue;
-    candidates.push({
-      tag: normalizeTag(item.banner_title),
-      mainText,
-      subText: normalizeText(item.banner_subtext),
-    });
+    const display = parseBannerDisplay(item.banner_display);
+    candidates.push(
+      toBannerState({
+        id: item.banner_id,
+        tag: item.banner_title,
+        mainText,
+        subText: item.banner_subtext,
+        display,
+        ttlHours: display === 'cooldown' ? parseBannerDisplayTtlHours(item.banner_display_ttl_hours) : undefined,
+      }),
+    );
   }
+  return candidates;
+}
+
+function pickRandomCandidate(candidates: BannerState[], random: () => number): BannerState | null {
   if (candidates.length === 0) return null;
   const index = Math.floor(random() * candidates.length);
   return candidates[index]!;
+}
+
+function pickFallbackBanner(
+  json: TipsBannerJson,
+  clientVersion: string,
+  random: () => number,
+): BannerState | null {
+  return pickRandomCandidate(pickFallbackCandidates(json, clientVersion), random);
+}
+
+function parseShownAt(value: string | undefined): Date | null {
+  if (value === undefined) return null;
+  const date = new Date(value);
+  return Number.isNaN(date.getTime()) ? null : date;
+}
+
+function getCooldownTtlHours(banner: BannerState): number {
+  return typeof banner.ttlHours === 'number' && Number.isFinite(banner.ttlHours) && banner.ttlHours > 0
+    ? banner.ttlHours
+    : DEFAULT_COOLDOWN_TTL_HOURS;
+}
+
+export function shouldDisplayBanner(
+  banner: BannerState,
+  state: BannerDisplayState,
+  now: Date,
+): boolean {
+  if (banner.display === 'always') return true;
+  const lastShownAt = parseShownAt(state.shown[banner.key]?.lastShownAt);
+  if (lastShownAt === null) return true;
+  if (banner.display === 'once') return false;
+  return now.getTime() - lastShownAt.getTime() >= getCooldownTtlHours(banner) * HOUR_MS;
 }
 
 export function selectBannerState(
@@ -118,8 +274,24 @@ export function selectBannerState(
   const typed = typeof json === 'object' && json !== null ? (json as TipsBannerJson) : {};
   return (
     pickActiveBanner(typed, clientVersion, now) ??
-    pickFallbackBanner(typed, clientVersion, now, random)
+    pickFallbackBanner(typed, clientVersion, random)
   );
+}
+
+export function selectDisplayableBanner({
+  json,
+  clientVersion,
+  now,
+  random,
+  state,
+}: SelectDisplayableBannerArgs): BannerState | null {
+  const typed = typeof json === 'object' && json !== null ? (json as TipsBannerJson) : {};
+  const active = pickActiveBanner(typed, clientVersion, now);
+  if (active !== null && shouldDisplayBanner(active, state, now)) return active;
+  const candidates = pickFallbackCandidates(typed, clientVersion).filter((candidate) =>
+    shouldDisplayBanner(candidate, state, now),
+  );
+  return pickRandomCandidate(candidates, random);
 }
 
 export class BannerProvider {
@@ -128,7 +300,10 @@ export class BannerProvider {
     private readonly url: string = KIMI_CODE_TIPS_BANNER_URL,
   ) {}
 
-  async load(fetchImpl: typeof fetch = fetch): Promise<BannerState | null> {
+  async load(
+    fetchImpl: typeof fetch = fetch,
+    options: BannerProviderLoadOptions = {},
+  ): Promise<BannerState | null> {
     try {
       const controller = new AbortController();
       const timeout = setTimeout(() => {
@@ -138,7 +313,17 @@ export class BannerProvider {
       clearTimeout(timeout);
       if (!response.ok) return null;
       const json = await response.json();
-      return selectBannerState(json, this.clientVersion, new Date(), Math.random);
+      const now = options.now ?? new Date();
+      const random = options.random ?? Math.random;
+      return options.state === undefined
+        ? selectBannerState(json, this.clientVersion, now, random)
+        : selectDisplayableBanner({
+            json,
+            clientVersion: this.clientVersion,
+            now,
+            random,
+            state: options.state,
+          });
     } catch {
       return null;
     }

--- a/apps/kimi-code/src/tui/banner/state.ts
+++ b/apps/kimi-code/src/tui/banner/state.ts
@@ -1,0 +1,69 @@
+import { z } from 'zod';
+
+import { getBannerStateFile } from '#/utils/paths';
+import { readJsonFile, writeJsonFile } from '#/utils/persistence';
+
+export type BannerDisplayRecord = {
+  lastShownAt: string;
+};
+
+export type BannerDisplayState = {
+  version: 1;
+  shown: Record<string, BannerDisplayRecord>;
+};
+
+const BannerDisplayRecordSchema = z
+  .object({
+    lastShownAt: z.string().min(1),
+  })
+  .strict();
+
+const BannerDisplayStateSchema = z.preprocess(
+  (value) => {
+    if (typeof value !== 'object' || value === null) return value;
+    const shown = (value as { shown?: unknown }).shown;
+    if (typeof shown !== 'object' || shown === null) {
+      return { ...(value as Record<string, unknown>), shown: {} };
+    }
+
+    const normalizedShown: Record<string, BannerDisplayRecord> = {};
+    for (const [key, record] of Object.entries(shown)) {
+      if (key.length === 0 || typeof record !== 'object' || record === null) continue;
+      const lastShownAt = (record as { lastShownAt?: unknown }).lastShownAt;
+      if (typeof lastShownAt !== 'string' || Number.isNaN(Date.parse(lastShownAt))) continue;
+      normalizedShown[key] = { lastShownAt };
+    }
+
+    return { ...(value as Record<string, unknown>), shown: normalizedShown };
+  },
+  z
+    .object({
+      version: z.literal(1),
+      shown: z.record(z.string().min(1), BannerDisplayRecordSchema),
+    })
+    .strict(),
+);
+
+export function emptyBannerDisplayState(): BannerDisplayState {
+  return {
+    version: 1,
+    shown: {},
+  };
+}
+
+export async function readBannerDisplayState(
+  filePath: string = getBannerStateFile(),
+): Promise<BannerDisplayState> {
+  try {
+    return await readJsonFile(filePath, BannerDisplayStateSchema, emptyBannerDisplayState());
+  } catch {
+    return emptyBannerDisplayState();
+  }
+}
+
+export async function writeBannerDisplayState(
+  value: BannerDisplayState,
+  filePath: string = getBannerStateFile(),
+): Promise<void> {
+  await writeJsonFile(filePath, BannerDisplayStateSchema, value);
+}

--- a/apps/kimi-code/src/tui/kimi-tui.ts
+++ b/apps/kimi-code/src/tui/kimi-tui.ts
@@ -32,6 +32,7 @@ import { detectFdPath, ensureFdPath } from '#/utils/process/fd-detect';
 import { quoteShellArg } from '#/utils/shell-quote';
 
 import { BannerProvider } from './banner/banner-provider';
+import { readBannerDisplayState, writeBannerDisplayState } from './banner/state';
 import {
   BUILTIN_SLASH_COMMANDS,
   buildSkillSlashCommands,
@@ -414,10 +415,29 @@ export class KimiTUI {
 
   private async loadBanner(): Promise<void> {
     const provider = new BannerProvider(this.state.appState.version);
-    this.state.appState.banner = await provider.load();
-    if (this.state.appState.banner !== null) {
-      this.renderBanner();
-      this.state.ui.requestRender();
+    const displayState = await readBannerDisplayState();
+    const now = new Date();
+    const banner = await provider.load(fetch, {
+      state: displayState,
+      now,
+    });
+    this.state.appState.banner = banner;
+    if (banner === null) return;
+
+    this.renderBanner();
+    this.state.ui.requestRender();
+
+    if (banner.display === 'always') return;
+    try {
+      await writeBannerDisplayState({
+        version: 1,
+        shown: {
+          ...displayState.shown,
+          [banner.key]: { lastShownAt: now.toISOString() },
+        },
+      });
+    } catch {
+      // Best-effort: banner display state should never block startup.
     }
   }
 

--- a/apps/kimi-code/src/tui/types.ts
+++ b/apps/kimi-code/src/tui/types.ts
@@ -12,10 +12,15 @@ import type { NotificationsConfig, UpgradePreferences } from './config';
 import type { PendingApproval, PendingQuestion } from './reverse-rpc/types';
 import type { ColorToken, ThemeName } from './theme';
 
+export type BannerDisplay = 'always' | 'once' | 'cooldown';
+
 export interface BannerState {
+  key: string;
   tag: string | null;
   mainText: string;
   subText: string | null;
+  display: BannerDisplay;
+  ttlHours?: number;
 }
 
 export interface AppState {

--- a/apps/kimi-code/src/utils/paths.ts
+++ b/apps/kimi-code/src/utils/paths.ts
@@ -10,7 +10,10 @@ import { homedir } from 'node:os';
 import { join } from 'node:path';
 
 import {
+  KIMI_CODE_BANNER_DIR_NAME,
+  KIMI_CODE_BANNER_STATE_FILE_NAME,
   KIMI_CODE_BIN_DIR_NAME,
+  KIMI_CODE_CACHE_DIR_NAME,
   KIMI_CODE_DATA_DIR_NAME,
   KIMI_CODE_HOME_ENV,
   KIMI_CODE_INPUT_HISTORY_DIR_NAME,
@@ -40,6 +43,13 @@ export function getDataDir(): string {
  */
 export function getLogDir(): string {
   return join(getDataDir(), KIMI_CODE_LOG_DIR_NAME);
+}
+
+/**
+ * Return the CLI cache directory: `<dataDir>/cache/`.
+ */
+export function getCacheDir(): string {
+  return join(getDataDir(), KIMI_CODE_CACHE_DIR_NAME);
 }
 
 /**
@@ -75,6 +85,13 @@ export function getUpdateInstallLockFile(): string {
  */
 export function getUpdateRolloutLogFile(): string {
   return join(getDataDir(), KIMI_CODE_UPDATE_DIR_NAME, KIMI_CODE_UPDATE_ROLLOUT_LOG_FILE_NAME);
+}
+
+/**
+ * Return the banner display state file: `<dataDir>/cache/banner/state.json`.
+ */
+export function getBannerStateFile(): string {
+  return join(getCacheDir(), KIMI_CODE_BANNER_DIR_NAME, KIMI_CODE_BANNER_STATE_FILE_NAME);
 }
 
 /**

--- a/apps/kimi-code/test/tui/banner/banner-provider.test.ts
+++ b/apps/kimi-code/test/tui/banner/banner-provider.test.ts
@@ -1,9 +1,26 @@
 import { describe, expect, it } from 'vitest';
 
-import { selectBannerState } from '#/tui/banner/banner-provider';
+import {
+  selectBannerState,
+  selectDisplayableBanner,
+  shouldDisplayBanner,
+} from '#/tui/banner/banner-provider';
+import type { BannerState } from '#/tui/types';
 
 describe('selectBannerState', () => {
   const now = new Date('2026-06-15T12:00:00+08:00');
+
+  function expectAlwaysBanner(
+    result: BannerState | null,
+    expected: Pick<BannerState, 'tag' | 'mainText' | 'subText'>,
+  ): BannerState {
+    expect(result).not.toBeNull();
+    const banner = result!;
+    expect(banner).toMatchObject({ ...expected, display: 'always' });
+    expect(banner.key).toEqual(expect.any(String));
+    expect(banner.ttlHours).toBeUndefined();
+    return banner;
+  }
 
   it('returns the active banner when enabled and no time window is set', () => {
     const result = selectBannerState(
@@ -17,7 +34,7 @@ describe('selectBannerState', () => {
       now,
       () => 0,
     );
-    expect(result).toEqual({ tag: 'New', mainText: 'Active', subText: 'Details' });
+    expectAlwaysBanner(result, { tag: 'New', mainText: 'Active', subText: 'Details' });
   });
 
   it('returns null when the active banner is outside its time window', () => {
@@ -64,7 +81,7 @@ describe('selectBannerState', () => {
       now,
       () => 0.75,
     );
-    expect(result).toEqual({ tag: 'Tip', mainText: 'Second', subText: null });
+    expectAlwaysBanner(result, { tag: 'Tip', mainText: 'Second', subText: null });
   });
 
   it('filters out fallback entries when the client version is too low', () => {
@@ -81,7 +98,7 @@ describe('selectBannerState', () => {
       now,
       () => 0,
     );
-    expect(result).toEqual({ tag: null, mainText: 'Old tip', subText: null });
+    expectAlwaysBanner(result, { tag: null, mainText: 'Old tip', subText: null });
   });
 
   it('returns null when no enabled fallback entries exist', () => {
@@ -112,7 +129,7 @@ describe('selectBannerState', () => {
       now,
       () => 0,
     );
-    expect(result).toEqual({ tag: null, mainText: 'Fallback', subText: null });
+    expectAlwaysBanner(result, { tag: null, mainText: 'Fallback', subText: null });
   });
 
   it('treats an empty tag as null while still showing the banner', () => {
@@ -126,7 +143,7 @@ describe('selectBannerState', () => {
       now,
       () => 0,
     );
-    expect(result).toEqual({ tag: null, mainText: 'No tag', subText: null });
+    expectAlwaysBanner(result, { tag: null, mainText: 'No tag', subText: null });
   });
 
   it('makes the active banner unavailable when mainText is empty', () => {
@@ -142,7 +159,7 @@ describe('selectBannerState', () => {
       now,
       () => 0,
     );
-    expect(result).toEqual({ tag: null, mainText: 'Fallback', subText: null });
+    expectAlwaysBanner(result, { tag: null, mainText: 'Fallback', subText: null });
   });
 
   it('treats missing subtext as null', () => {
@@ -155,7 +172,7 @@ describe('selectBannerState', () => {
       now,
       () => 0,
     );
-    expect(result).toEqual({ tag: null, mainText: 'Main only', subText: null });
+    expectAlwaysBanner(result, { tag: null, mainText: 'Main only', subText: null });
   });
 
   it('treats empty time fields as always valid', () => {
@@ -170,7 +187,7 @@ describe('selectBannerState', () => {
       now,
       () => 0,
     );
-    expect(result).toEqual({ tag: null, mainText: 'Always on', subText: null });
+    expectAlwaysBanner(result, { tag: null, mainText: 'Always on', subText: null });
   });
 
   it('falls back to UTC when timestamps have no timezone', () => {
@@ -185,7 +202,7 @@ describe('selectBannerState', () => {
       now,
       () => 0,
     );
-    expect(result).toEqual({ tag: null, mainText: 'UTC fallback', subText: null });
+    expectAlwaysBanner(result, { tag: null, mainText: 'UTC fallback', subText: null });
   });
 
   it('returns null when the fallback list is empty', () => {
@@ -213,5 +230,376 @@ describe('selectBannerState', () => {
       () => 0,
     );
     expect(result).toBeNull();
+  });
+
+  it('uses banner_id as the banner key when present', () => {
+    const result = selectBannerState(
+      {
+        banner_enabled: true,
+        banner_id: 'active-1',
+        banner_maintext: 'Active',
+      },
+      '0.14.0',
+      now,
+      () => 0,
+    );
+    expect(result).toMatchObject({ key: 'active-1', display: 'always' });
+  });
+
+  it('generates a stable hash key when banner_id is missing', () => {
+    const json = {
+      banner_enabled: true,
+      banner_title: 'New',
+      banner_maintext: 'Active',
+      banner_subtext: 'Details',
+    };
+
+    const first = selectBannerState(json, '0.14.0', now, () => 0);
+    const second = selectBannerState(json, '0.14.0', now, () => 0);
+    const changedDisplay = selectBannerState(
+      {
+        ...json,
+        banner_display: 'cooldown',
+        banner_display_ttl_hours: 72,
+      },
+      '0.14.0',
+      now,
+      () => 0,
+    );
+
+    expect(first).not.toBeNull();
+    expect(second).not.toBeNull();
+    expect(changedDisplay).not.toBeNull();
+    expect(first!.key).toMatch(/^[0-9a-f]{32}$/);
+    expect(second!.key).toBe(first!.key);
+    expect(changedDisplay!.key).not.toBe(first!.key);
+  });
+
+  it('parses cooldown display and ttl hours', () => {
+    const result = selectBannerState(
+      {
+        banner_enabled: true,
+        banner_id: 'active-1',
+        banner_maintext: 'Active',
+        banner_display: 'cooldown',
+        banner_display_ttl_hours: 72,
+      },
+      '0.14.0',
+      now,
+      () => 0,
+    );
+    expect(result).toMatchObject({
+      key: 'active-1',
+      display: 'cooldown',
+      ttlHours: 72,
+    });
+  });
+
+  it('falls back to 24 hours when cooldown ttl is invalid', () => {
+    const result = selectBannerState(
+      {
+        banner_enabled: true,
+        banner_id: 'active-1',
+        banner_maintext: 'Active',
+        banner_display: 'cooldown',
+        banner_display_ttl_hours: 0,
+      },
+      '0.14.0',
+      now,
+      () => 0,
+    );
+    expect(result).toMatchObject({ display: 'cooldown', ttlHours: 24 });
+  });
+
+  it('falls back to always for unknown display values', () => {
+    const result = selectBannerState(
+      {
+        banner_enabled: true,
+        banner_id: 'active-1',
+        banner_maintext: 'Active',
+        banner_display: '24h',
+      },
+      '0.14.0',
+      now,
+      () => 0,
+    );
+    expect(result).toMatchObject({ display: 'always' });
+    expect(result?.ttlHours).toBeUndefined();
+  });
+
+  it('supports fallback display and ttl fields', () => {
+    const result = selectBannerState(
+      {
+        banner_enabled: false,
+        banner_fallback_enabled: true,
+        banner_fallback_list: [
+          {
+            enabled: true,
+            banner_id: 'fallback-1',
+            banner_maintext: 'Fallback',
+            banner_display: 'cooldown',
+            banner_display_ttl_hours: 168,
+          },
+        ],
+      },
+      '0.14.0',
+      now,
+      () => 0,
+    );
+    expect(result).toMatchObject({
+      key: 'fallback-1',
+      display: 'cooldown',
+      ttlHours: 168,
+    });
+  });
+});
+
+describe('shouldDisplayBanner', () => {
+  const now = new Date('2026-06-16T12:00:00.000Z');
+
+  const banner: BannerState = {
+    key: 'always',
+    tag: null,
+    mainText: 'Always',
+    subText: null,
+    display: 'always',
+  };
+
+  it('returns true for always banners even when they were shown before', () => {
+    expect(
+      shouldDisplayBanner(
+        banner,
+        {
+          version: 1,
+          shown: {
+            always: { lastShownAt: '2026-06-16T11:59:59.000Z' },
+          },
+        },
+        now,
+      ),
+    ).toBe(true);
+  });
+
+  it('returns true for once banners without a shown record', () => {
+    expect(shouldDisplayBanner({ ...banner, key: 'once', display: 'once' }, { version: 1, shown: {} }, now)).toBe(
+      true,
+    );
+  });
+
+  it('returns false for once banners with a shown record', () => {
+    expect(
+      shouldDisplayBanner(
+        { ...banner, key: 'once', display: 'once' },
+        {
+          version: 1,
+          shown: {
+            once: { lastShownAt: '2026-06-16T11:59:59.000Z' },
+          },
+        },
+        now,
+      ),
+    ).toBe(false);
+  });
+
+  it('treats an invalid shown record as not shown', () => {
+    expect(
+      shouldDisplayBanner(
+        { ...banner, key: 'once', display: 'once' },
+        {
+          version: 1,
+          shown: {
+            once: { lastShownAt: 'not-a-date' },
+          },
+        },
+        now,
+      ),
+    ).toBe(true);
+  });
+
+  it('returns false during cooldown ttl', () => {
+    expect(
+      shouldDisplayBanner(
+        { ...banner, key: 'cooldown', display: 'cooldown', ttlHours: 24 },
+        {
+          version: 1,
+          shown: {
+            cooldown: { lastShownAt: '2026-06-16T00:00:00.000Z' },
+          },
+        },
+        now,
+      ),
+    ).toBe(false);
+  });
+
+  it('returns true at the cooldown ttl boundary', () => {
+    expect(
+      shouldDisplayBanner(
+        { ...banner, key: 'cooldown', display: 'cooldown', ttlHours: 24 },
+        {
+          version: 1,
+          shown: {
+            cooldown: { lastShownAt: '2026-06-15T12:00:00.000Z' },
+          },
+        },
+        now,
+      ),
+    ).toBe(true);
+  });
+
+  it('supports custom cooldown ttl values', () => {
+    expect(
+      shouldDisplayBanner(
+        { ...banner, key: 'cooldown', display: 'cooldown', ttlHours: 1 },
+        {
+          version: 1,
+          shown: {
+            cooldown: { lastShownAt: '2026-06-16T11:30:00.000Z' },
+          },
+        },
+        now,
+      ),
+    ).toBe(false);
+    expect(
+      shouldDisplayBanner(
+        { ...banner, key: 'cooldown', display: 'cooldown', ttlHours: 168 },
+        {
+          version: 1,
+          shown: {
+            cooldown: { lastShownAt: '2026-06-09T12:00:01.000Z' },
+          },
+        },
+        now,
+      ),
+    ).toBe(false);
+  });
+});
+
+describe('selectDisplayableBanner', () => {
+  const now = new Date('2026-06-16T12:00:00.000Z');
+
+  it('falls back when the active once banner was already shown', () => {
+    const result = selectDisplayableBanner({
+      json: {
+        banner_enabled: true,
+        banner_id: 'active',
+        banner_maintext: 'Active',
+        banner_display: 'once',
+        banner_fallback_enabled: true,
+        banner_fallback_list: [
+          {
+            enabled: true,
+            banner_id: 'fallback',
+            banner_maintext: 'Fallback',
+            banner_display: 'once',
+          },
+        ],
+      },
+      clientVersion: '0.14.0',
+      now,
+      random: () => 0,
+      state: {
+        version: 1,
+        shown: {
+          active: { lastShownAt: '2026-06-16T00:00:00.000Z' },
+        },
+      },
+    });
+
+    expect(result).toMatchObject({ key: 'fallback', display: 'once' });
+  });
+
+  it('falls back when active cooldown is within ttl', () => {
+    const result = selectDisplayableBanner({
+      json: {
+        banner_enabled: true,
+        banner_id: 'active',
+        banner_maintext: 'Active',
+        banner_display: 'cooldown',
+        banner_display_ttl_hours: 1,
+        banner_fallback_enabled: true,
+        banner_fallback_list: [
+          {
+            enabled: true,
+            banner_id: 'fallback',
+            banner_maintext: 'Fallback',
+          },
+        ],
+      },
+      clientVersion: '0.14.0',
+      now,
+      random: () => 0,
+      state: {
+        version: 1,
+        shown: {
+          active: { lastShownAt: '2026-06-16T11:30:00.000Z' },
+        },
+      },
+    });
+
+    expect(result).toMatchObject({ key: 'fallback', display: 'always' });
+  });
+
+  it('returns active cooldown after ttl instead of fallback', () => {
+    const result = selectDisplayableBanner({
+      json: {
+        banner_enabled: true,
+        banner_id: 'active',
+        banner_maintext: 'Active',
+        banner_display: 'cooldown',
+        banner_display_ttl_hours: 24,
+        banner_fallback_enabled: true,
+        banner_fallback_list: [
+          {
+            enabled: true,
+            banner_id: 'fallback',
+            banner_maintext: 'Fallback',
+          },
+        ],
+      },
+      clientVersion: '0.14.0',
+      now,
+      random: () => 0,
+      state: {
+        version: 1,
+        shown: {
+          active: { lastShownAt: '2026-06-15T12:00:00.000Z' },
+        },
+      },
+    });
+
+    expect(result).toMatchObject({ key: 'active', display: 'cooldown', ttlHours: 24 });
+  });
+
+  it('randomly chooses only displayable fallback candidates', () => {
+    const result = selectDisplayableBanner({
+      json: {
+        banner_enabled: false,
+        banner_fallback_enabled: true,
+        banner_fallback_list: [
+          {
+            enabled: true,
+            banner_id: 'fallback-once',
+            banner_maintext: 'Fallback once',
+            banner_display: 'once',
+          },
+          {
+            enabled: true,
+            banner_id: 'fallback-always',
+            banner_maintext: 'Fallback always',
+          },
+        ],
+      },
+      clientVersion: '0.14.0',
+      now,
+      random: () => 0,
+      state: {
+        version: 1,
+        shown: {
+          'fallback-once': { lastShownAt: '2026-06-16T00:00:00.000Z' },
+        },
+      },
+    });
+
+    expect(result).toMatchObject({ key: 'fallback-always', display: 'always' });
   });
 });

--- a/apps/kimi-code/test/tui/banner/state.test.ts
+++ b/apps/kimi-code/test/tui/banner/state.test.ts
@@ -1,0 +1,88 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import {
+  emptyBannerDisplayState,
+  readBannerDisplayState,
+  writeBannerDisplayState,
+} from '#/tui/banner/state';
+import { getBannerStateFile } from '#/utils/paths';
+
+const originalEnv = { ...process.env };
+
+let dir: string;
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), 'kimi-banner-state-'));
+  process.env['KIMI_CODE_HOME'] = dir;
+});
+
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true });
+  process.env = { ...originalEnv };
+});
+
+describe('banner display state cache', () => {
+  it('returns an empty state when the file is missing', async () => {
+    await expect(readBannerDisplayState()).resolves.toEqual(emptyBannerDisplayState());
+  });
+
+  it('falls back to an empty state when the file is corrupt', async () => {
+    mkdirSync(join(dir, 'cache', 'banner'), { recursive: true });
+    writeFileSync(getBannerStateFile(), '{"broken"', 'utf-8');
+    await expect(readBannerDisplayState()).resolves.toEqual(emptyBannerDisplayState());
+  });
+
+  it('falls back to an empty state for an unknown future version', async () => {
+    mkdirSync(join(dir, 'cache', 'banner'), { recursive: true });
+    writeFileSync(
+      getBannerStateFile(),
+      JSON.stringify({
+        version: 2,
+        shown: {},
+      }),
+      'utf-8',
+    );
+    await expect(readBannerDisplayState()).resolves.toEqual(emptyBannerDisplayState());
+  });
+
+  it('writes and reads back the state from cache/banner/state.json', async () => {
+    const state = {
+      version: 1 as const,
+      shown: {
+        active: { lastShownAt: '2026-06-16T00:00:00.000Z' },
+      },
+    };
+
+    await writeBannerDisplayState(state);
+
+    expect(getBannerStateFile()).toBe(join(dir, 'cache', 'banner', 'state.json'));
+    await expect(readBannerDisplayState()).resolves.toEqual(state);
+  });
+
+  it('drops invalid shown records when reading', async () => {
+    mkdirSync(join(dir, 'cache', 'banner'), { recursive: true });
+    writeFileSync(
+      getBannerStateFile(),
+      JSON.stringify({
+        version: 1,
+        shown: {
+          valid: { lastShownAt: '2026-06-16T00:00:00.000Z' },
+          invalid: { lastShownAt: 'not-a-date' },
+          malformed: { shownAt: '2026-06-16T00:00:00.000Z' },
+        },
+      }),
+      'utf-8',
+    );
+
+    await expect(readBannerDisplayState()).resolves.toEqual({
+      version: 1,
+      shown: {
+        valid: { lastShownAt: '2026-06-16T00:00:00.000Z' },
+      },
+    });
+  });
+});

--- a/apps/kimi-code/test/tui/components/chrome/banner.test.ts
+++ b/apps/kimi-code/test/tui/components/chrome/banner.test.ts
@@ -6,11 +6,22 @@ import { BannerComponent } from '#/tui/components/chrome/banner';
 import { currentTheme } from '#/tui/theme';
 import type { BannerState } from '#/tui/types';
 
-const banner: BannerState = {
+function makeBannerState(overrides: Partial<BannerState> = {}): BannerState {
+  return {
+    key: 'component-banner',
+    tag: null,
+    mainText: '',
+    subText: null,
+    display: 'always',
+    ...overrides,
+  };
+}
+
+const banner: BannerState = makeBannerState({
   tag: "What's new:",
   mainText: 'This is the main banner message for testing purposes.',
   subText: 'This is a short subtext line.',
-};
+});
 
 describe('BannerComponent', () => {
   const previousChalkLevel = chalk.level;
@@ -39,7 +50,7 @@ describe('BannerComponent', () => {
   });
 
   it('renders without a tag when tag is empty', () => {
-    const lines = new BannerComponent({ tag: null, mainText: 'Hello', subText: null }).render(80);
+    const lines = new BannerComponent(makeBannerState({ mainText: 'Hello' })).render(80);
     expect(lines.length).toBe(2);
     expect(lines[0]).not.toContain('✦');
     expect(lines[0]).toContain('Hello');
@@ -61,11 +72,10 @@ describe('BannerComponent', () => {
 
   it('wraps long subtext to fit available width', () => {
     const width = 30;
-    const state: BannerState = {
-      tag: null,
+    const state = makeBannerState({
       mainText: 'Short',
       subText: 'Short subtext line one plus subtext line two for wrapping tests.',
-    };
+    });
     const lines = new BannerComponent(state).render(width);
     expect(lines[0]).toContain('Short');
     const subContentLines = lines.filter((line) =>
@@ -89,11 +99,10 @@ describe('BannerComponent', () => {
 
   it('shows tag only on the first wrapped line', () => {
     const width = 40;
-    const state: BannerState = {
+    const state = makeBannerState({
       tag: 'New:',
       mainText: 'This is a very long main text line that should wrap automatically.',
-      subText: null,
-    };
+    });
     const lines = new BannerComponent(state).render(width);
     const mainRows = lines.slice(0, -1);
     let tagCount = 0;
@@ -135,21 +144,21 @@ describe('BannerComponent', () => {
     const width = 40;
     const lines = new BannerComponent(banner).render(width);
     expect(lines[0]).toContain('✦');
-    expect(lines[0]).toContain("What's new:");
+    expect(lines[0]).toContain("What's new");
     for (const line of lines) {
       expect(visibleWidth(line)).toBeLessThanOrEqual(width);
     }
   });
 
   it('does not render subtext when empty', () => {
-    const lines = new BannerComponent({ tag: 'Tip', mainText: 'Use /help', subText: null }).render(80);
+    const lines = new BannerComponent(makeBannerState({ tag: 'Tip', mainText: 'Use /help' })).render(80);
     expect(lines.length).toBe(2);
     expect(lines[0]).toContain('Use /help');
     expect(lines[1]).toBe('');
   });
 
   it('supports explicit newlines in main text', () => {
-    const lines = new BannerComponent({ tag: null, mainText: 'Line 1\nLine 2', subText: null }).render(80);
+    const lines = new BannerComponent(makeBannerState({ mainText: 'Line 1\nLine 2' })).render(80);
     expect(lines.length).toBe(3);
     expect(lines[0]).toContain('Line 1');
     expect(lines[1]).toContain('Line 2');
@@ -174,11 +183,13 @@ describe('BannerComponent', () => {
 
   it('keeps subsequent main lines indented to the main-text column and subtext aligned with the tag text', () => {
     const width = 20;
-    const lines = new BannerComponent({
-      tag: 'New:',
-      mainText: 'Line 1 with a lot of content',
-      subText: 'Sub text',
-    }).render(width);
+    const lines = new BannerComponent(
+      makeBannerState({
+        tag: 'New:',
+        mainText: 'Line 1 with a lot of content',
+        subText: 'Sub text',
+      }),
+    ).render(width);
     for (const line of lines) {
       expect(visibleWidth(line)).toBeLessThanOrEqual(width);
     }

--- a/apps/kimi-code/test/tui/kimi-tui-startup.test.ts
+++ b/apps/kimi-code/test/tui/kimi-tui-startup.test.ts
@@ -1,8 +1,13 @@
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
 import { log, type GoalSnapshot } from '@moonshot-ai/kimi-code-sdk';
 import type { MigrationPlan } from '@moonshot-ai/migration-legacy';
 import { describe, expect, it, vi } from 'vitest';
 
 import { BannerProvider } from '#/tui/banner/banner-provider';
+import { readBannerDisplayState } from '#/tui/banner/state';
 import { handleLoginCommand, handleLogoutCommand } from '#/tui/commands/auth';
 import { promptPlatformSelection, promptLogoutProviderSelection } from '#/tui/commands/prompts';
 import { BannerComponent } from '#/tui/components/chrome/banner';
@@ -1569,9 +1574,11 @@ describe('KimiTUI startup', () => {
 
   it('renders the banner below the welcome message after it loads', async () => {
     const banner = {
+      key: 'new-banner',
       tag: 'New',
       mainText: 'Banner main',
       subText: null,
+      display: 'always' as const,
     };
     const loadSpy = vi.spyOn(BannerProvider.prototype, 'load').mockResolvedValue(banner);
     const session = makeSession({ id: 'ses-target' });
@@ -1603,6 +1610,96 @@ describe('KimiTUI startup', () => {
     expect(bannerIndex).toBe(welcomeIndex + 1);
 
     loadSpy.mockRestore();
+  });
+
+  it('writes display state after rendering a once banner', async () => {
+    const originalEnv = { ...process.env };
+    const dir = mkdtempSync(join(tmpdir(), 'kimi-startup-banner-'));
+    process.env['KIMI_CODE_HOME'] = dir;
+
+    try {
+      const banner = {
+        key: 'once-banner',
+        tag: null,
+        mainText: 'Banner main',
+        subText: null,
+        display: 'once' as const,
+      };
+      const loadSpy = vi.spyOn(BannerProvider.prototype, 'load').mockResolvedValue(banner);
+      const session = makeSession({ id: 'ses-target' });
+      const harness = makeHarness(session, {
+        listSessions: vi.fn(async () => [{ id: 'ses-target', workDir: '/tmp/proj-a' }]),
+      });
+      const driver = makeDriver(
+        harness,
+        makeStartupInput({ session: 'ses-target' }),
+      ) as unknown as MigrateExitDriver;
+
+      await driver.initMainTui();
+
+      await vi.waitFor(() => {
+        expect(
+          driver.state.transcriptContainer.children.some((child) => child instanceof BannerComponent),
+        ).toBe(true);
+      });
+
+      await expect(readBannerDisplayState()).resolves.toMatchObject({
+        version: 1,
+        shown: {
+          'once-banner': {
+            lastShownAt: expect.any(String),
+          },
+        },
+      });
+
+      loadSpy.mockRestore();
+    } finally {
+      process.env = { ...originalEnv };
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('does not write display state for an always banner', async () => {
+    const originalEnv = { ...process.env };
+    const dir = mkdtempSync(join(tmpdir(), 'kimi-startup-banner-'));
+    process.env['KIMI_CODE_HOME'] = dir;
+
+    try {
+      const banner = {
+        key: 'always-banner',
+        tag: null,
+        mainText: 'Banner main',
+        subText: null,
+        display: 'always' as const,
+      };
+      const loadSpy = vi.spyOn(BannerProvider.prototype, 'load').mockResolvedValue(banner);
+      const session = makeSession({ id: 'ses-target' });
+      const harness = makeHarness(session, {
+        listSessions: vi.fn(async () => [{ id: 'ses-target', workDir: '/tmp/proj-a' }]),
+      });
+      const driver = makeDriver(
+        harness,
+        makeStartupInput({ session: 'ses-target' }),
+      ) as unknown as MigrateExitDriver;
+
+      await driver.initMainTui();
+
+      await vi.waitFor(() => {
+        expect(
+          driver.state.transcriptContainer.children.some((child) => child instanceof BannerComponent),
+        ).toBe(true);
+      });
+
+      await expect(readBannerDisplayState()).resolves.toEqual({
+        version: 1,
+        shown: {},
+      });
+
+      loadSpy.mockRestore();
+    } finally {
+      process.env = { ...originalEnv };
+      rmSync(dir, { recursive: true, force: true });
+    }
   });
 
   it('resumes a startup session when Windows workdir uses backslashes', async () => {


### PR DESCRIPTION
## Related Issue

No related issue.

## Problem

The CDN banner previously supported only always-on display. Product needs per-banner control for always-on, one-time, and cooldown-based display while keeping old and future JSON values safe.

## What changed

- Added banner display strategy support for `always`, `once`, and `cooldown`.
- Added optional `banner_id` support with deterministic content hash fallback.
- Added `banner_display_ttl_hours` for configurable cooldown duration.
- Added fallback banner support for the same display strategy fields.
- Added local banner display state under the CLI cache directory.
- Added tests for parsing, state persistence, display filtering, fallback display behavior, and startup writes.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.

## Verification

- `pnpm --filter @moonshot-ai/kimi-code typecheck`
- `pnpm --filter @moonshot-ai/kimi-code test`
- `pnpm run lint -- ...`
