### PR TITLE
docs: simplify anthropic auth changeset

### DIFF
--- a/.changeset/anthropic-env-auth.md
+++ b/.changeset/anthropic-env-auth.md
@@ -3,8 +3,4 @@
 "@moonshot-ai/kosong": patch
 ---
 
-Isolate the Anthropic adapter from ambient shell credentials.
-
-The adapter is used as a generic transport to *any* anthropic-compatible endpoint (`baseUrl` may point at a third-party gateway). The underlying Anthropic SDK, however, auto-discovers credentials from the shell environment by default. When the endpoint is not official this leaks: even with an explicit API key configured, the SDK would still read `ANTHROPIC_AUTH_TOKEN` from the environment and attach it as an `Authorization: Bearer` header — sending an out-of-band token (often injected by another tool, unbeknownst to the user) to the third-party `baseUrl`. The adapter now hard-disables every SDK environment auto-discovery channel (`authToken`, `baseURL`, custom headers) and uses only host-provided credentials.
-
-**Behavior change:** the adapter no longer reads `ANTHROPIC_API_KEY` / `ANTHROPIC_AUTH_TOKEN` / `ANTHROPIC_BASE_URL` / `ANTHROPIC_CUSTOM_HEADERS` from the shell. Configure credentials through provider config (`apiKey` or `[provider.env]`) instead.
+Stop Anthropic-compatible providers from reading ambient Anthropic shell credentials and custom headers.


### PR DESCRIPTION
## Related Issue

No related issue.

## Problem

The Anthropic environment auth changeset used a multi-paragraph technical explanation, while changeset entries should stay short and focused.

## What changed

Condensed the changelog entry into one sentence while preserving the existing package bump metadata.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] This docs-only change does not need tests.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.
