### PR TITLE
fix: dispose process stdio after managed commands

### DIFF
--- a/.changeset/dispose-kaos-process-stdio.md
+++ b/.changeset/dispose-kaos-process-stdio.md
@@ -1,0 +1,7 @@
+---
+"@moonshot-ai/kaos": patch
+"@moonshot-ai/agent-core": patch
+"@moonshot-ai/kimi-code": patch
+---
+
+Release process stdio resources after managed commands finish or are stopped.

--- a/packages/agent-core/src/agent/background/process-task.ts
+++ b/packages/agent-core/src/agent/background/process-task.ts
@@ -1,3 +1,6 @@
+import type { Readable } from 'node:stream';
+import { finished } from 'node:stream/promises';
+
 import type { KaosProcess } from '@moonshot-ai/kaos';
 
 import { errorMessage } from '../../loop/errors';
@@ -14,6 +17,8 @@ export interface ProcessBackgroundTaskInfo extends BackgroundTaskInfoBase {
   readonly exitCode: number | null;
 }
 
+const STREAM_DRAIN_GRACE_MS = 250;
+
 export class ProcessBackgroundTask implements BackgroundTask {
   readonly kind = 'process' as const;
   readonly idPrefix = 'bash';
@@ -26,11 +31,13 @@ export class ProcessBackgroundTask implements BackgroundTask {
   ) {}
 
   async start(sink: BackgroundTaskSink): Promise<void> {
-    for (const stream of [this.proc.stdout, this.proc.stderr]) {
+    const streams = [this.proc.stdout, this.proc.stderr] as const;
+    const appendOutput = (chunk: string): void => {
+      sink.appendOutput(chunk);
+    };
+    for (const stream of streams) {
       stream.setEncoding('utf8');
-      stream.on('data', (chunk: string) => {
-        sink.appendOutput(chunk);
-      });
+      stream.on('data', appendOutput);
     }
 
     const requestStop = (): void => {
@@ -56,12 +63,22 @@ export class ProcessBackgroundTask implements BackgroundTask {
       });
     } finally {
       sink.signal.removeEventListener('abort', requestStop);
+      await waitForStreamDrain(streams);
+      for (const stream of streams) {
+        stream.off('data', appendOutput);
+      }
+      await this.disposeProcess();
     }
   }
 
   async forceStop(): Promise<void> {
-    if (this.proc.exitCode !== null) return;
-    await this.proc.kill('SIGKILL');
+    try {
+      if (this.proc.exitCode === null) {
+        await this.proc.kill('SIGKILL');
+      }
+    } finally {
+      await this.disposeProcess();
+    }
   }
 
   toInfo(base: BackgroundTaskInfoBase): ProcessBackgroundTaskInfo {
@@ -72,5 +89,28 @@ export class ProcessBackgroundTask implements BackgroundTask {
       pid: this.proc.pid,
       exitCode: this.exitCode,
     };
+  }
+
+  private async disposeProcess(): Promise<void> {
+    try {
+      await this.proc.dispose();
+    } catch {
+      /* best-effort cleanup */
+    }
+  }
+}
+
+async function waitForStreamDrain(streams: readonly Readable[]): Promise<void> {
+  let timeout: ReturnType<typeof setTimeout> | undefined;
+  try {
+    await Promise.race([
+      Promise.all(streams.map((stream) => finished(stream).catch(() => {}))),
+      new Promise<void>((resolve) => {
+        timeout = setTimeout(resolve, STREAM_DRAIN_GRACE_MS);
+        timeout.unref?.();
+      }),
+    ]);
+  } finally {
+    if (timeout !== undefined) clearTimeout(timeout);
   }
 }

--- a/packages/agent-core/src/session/git-context.ts
+++ b/packages/agent-core/src/session/git-context.ts
@@ -10,7 +10,7 @@
 
 import type { Readable } from 'node:stream';
 
-import type { Kaos } from '@moonshot-ai/kaos';
+import type { Kaos, KaosProcess } from '@moonshot-ai/kaos';
 
 const GIT_TIMEOUT_MS = 5_000;
 const MAX_DIRTY_FILES = 20;
@@ -26,6 +26,14 @@ const ALLOWED_HOSTS = [
   'codeberg.org',
   'git.sr.ht',
 ] as const;
+
+async function disposeProcess(proc: KaosProcess): Promise<void> {
+  try {
+    await proc.dispose();
+  } catch {
+    /* best-effort cleanup */
+  }
+}
 
 /**
  * Collect git context for the explore agent.
@@ -145,7 +153,7 @@ function tryUrlPath(remoteUrl: string): string | null {
  * `git -C` form runs in the target directory regardless of the Kaos backend.
  */
 async function runGit(kaos: Kaos, cwd: string, args: readonly string[]): Promise<string | null> {
-  let proc;
+  let proc: KaosProcess | undefined;
   try {
     proc = await kaos.exec('git', '-C', cwd, ...args);
   } catch {
@@ -185,6 +193,7 @@ async function runGit(kaos: Kaos, cwd: string, args: readonly string[]): Promise
     return null;
   } finally {
     if (timer !== undefined) clearTimeout(timer);
+    if (proc !== undefined) await disposeProcess(proc);
   }
 }
 

--- a/packages/agent-core/src/tools/builtin/file/grep.ts
+++ b/packages/agent-core/src/tools/builtin/file/grep.ts
@@ -34,6 +34,7 @@ import { toInputJsonSchema } from '../../support/input-schema';
 import { ensureRgPath, rgUnavailableMessage } from '../../support/rg-locator';
 import { literalRulePattern, matchesGlobRuleSubject } from '../../support/rule-match';
 import { ToolResultBuilder } from '../../support/result-builder';
+import { isPrematureCloseError } from '../../support/stream';
 import type { WorkspaceConfig } from '../../support/workspace';
 import GREP_DESCRIPTION from './grep.md?raw';
 
@@ -987,11 +988,4 @@ async function readStreamWithCap(
     }
   }
   return { text: Buffer.concat(chunks).toString('utf8'), truncated };
-}
-
-function isPrematureCloseError(error: unknown): boolean {
-  return (
-    error instanceof Error &&
-    (error as NodeJS.ErrnoException).code === 'ERR_STREAM_PREMATURE_CLOSE'
-  );
 }

--- a/packages/agent-core/src/tools/builtin/file/grep.ts
+++ b/packages/agent-core/src/tools/builtin/file/grep.ts
@@ -135,6 +135,14 @@ export type GrepOutput = z.Infer<typeof GrepOutputSchema>;
 const DEFAULT_TIMEOUT_MS = 20_000;
 const SIGTERM_GRACE_MS = 5_000;
 const MAX_OUTPUT_BYTES = 10 * 1024 * 1024;
+
+async function disposeProcess(proc: KaosProcess): Promise<void> {
+  try {
+    await proc.dispose();
+  } catch {
+    /* best-effort cleanup */
+  }
+}
 // Column cap applied to non-content output modes only; `content` mode returns
 // matching lines in full so the cap is intentionally skipped there.
 const RG_MAX_COLUMNS = 500;
@@ -459,6 +467,7 @@ async function runRipgrepOnce(
         /* ignore */
       }
     }
+    await disposeProcess(proc);
   };
 
   const onAbort = (): void => {
@@ -482,9 +491,10 @@ async function runRipgrepOnce(
   let stderrTruncated = false;
 
   try {
+    const isTerminating = (): boolean => timedOut || aborted || killed;
     const [stdoutResult, stderrResult, code] = await Promise.all([
-      readStreamWithCap(proc.stdout, MAX_OUTPUT_BYTES),
-      readStreamWithCap(proc.stderr, MAX_OUTPUT_BYTES),
+      readStreamWithCap(proc.stdout, MAX_OUTPUT_BYTES, isTerminating),
+      readStreamWithCap(proc.stderr, MAX_OUTPUT_BYTES, isTerminating),
       proc.wait(),
     ]);
     stdoutText = stdoutResult.text;
@@ -493,20 +503,28 @@ async function runRipgrepOnce(
     stderrTruncated = stderrResult.truncated;
     exitCode = code;
   } catch (error) {
-    return {
-      kind: 'tool-error',
-      result: {
-        isError: true,
-        output: error instanceof Error ? error.message : String(error),
-      },
-    };
+    if (isPrematureCloseError(error) && (timedOut || aborted || killed)) {
+      // The disposer intentionally closes streams after a terminating signal.
+    } else {
+      return {
+        kind: 'tool-error',
+        result: {
+          isError: true,
+          output: error instanceof Error ? error.message : String(error),
+        },
+      };
+    }
   } finally {
     clearTimeout(timeoutHandle);
     signal.removeEventListener('abort', onAbort);
+    await disposeProcess(proc);
   }
 
   if (aborted) {
-    return { kind: 'tool-error', result: { isError: true, output: 'Grep aborted' } };
+    return {
+      kind: 'tool-error',
+      result: { isError: true, output: 'Grep aborted' },
+    };
   }
 
   return {
@@ -940,22 +958,40 @@ interface CappedStreamResult {
   readonly truncated: boolean;
 }
 
-async function readStreamWithCap(stream: Readable, maxBytes: number): Promise<CappedStreamResult> {
+async function readStreamWithCap(
+  stream: Readable,
+  maxBytes: number,
+  suppressPrematureClose?: () => boolean,
+): Promise<CappedStreamResult> {
   const chunks: Buffer[] = [];
   let total = 0;
   let truncated = false;
-  for await (const chunk of stream) {
-    const buf: Buffer = typeof chunk === 'string' ? Buffer.from(chunk, 'utf8') : (chunk as Buffer);
-    if (truncated) continue;
-    if (total + buf.length > maxBytes) {
-      const remaining = maxBytes - total;
-      if (remaining > 0) chunks.push(buf.subarray(0, remaining));
-      total = maxBytes;
-      truncated = true;
-      continue;
+  try {
+    for await (const chunk of stream) {
+      const buf: Buffer =
+        typeof chunk === 'string' ? Buffer.from(chunk, 'utf8') : (chunk as Buffer);
+      if (truncated) continue;
+      if (total + buf.length > maxBytes) {
+        const remaining = maxBytes - total;
+        if (remaining > 0) chunks.push(buf.subarray(0, remaining));
+        total = maxBytes;
+        truncated = true;
+        continue;
+      }
+      chunks.push(buf);
+      total += buf.length;
     }
-    chunks.push(buf);
-    total += buf.length;
+  } catch (error) {
+    if (!isPrematureCloseError(error) || suppressPrematureClose?.() !== true) {
+      throw error;
+    }
   }
   return { text: Buffer.concat(chunks).toString('utf8'), truncated };
+}
+
+function isPrematureCloseError(error: unknown): boolean {
+  return (
+    error instanceof Error &&
+    (error as NodeJS.ErrnoException).code === 'ERR_STREAM_PREMATURE_CLOSE'
+  );
 }

--- a/packages/agent-core/src/tools/builtin/shell/bash.ts
+++ b/packages/agent-core/src/tools/builtin/shell/bash.ts
@@ -123,6 +123,14 @@ function normalizeTimeoutMs(timeout: number | undefined, isBackground: boolean):
   return Math.min(value, timeoutCapS(isBackground)) * MS_PER_SECOND;
 }
 
+async function disposeProcess(proc: KaosProcess): Promise<void> {
+  try {
+    await proc.dispose();
+  } catch {
+    /* best-effort cleanup */
+  }
+}
+
 function renderBashDescription(shellName: string): string {
   return renderPrompt(bashDescriptionTemplate, { ...SHELL_TIMEOUT_VARS, SHELL_NAME: shellName });
 }
@@ -288,16 +296,7 @@ export class BashTool implements BuiltinTool<BashInput> {
         }
       }
 
-      try {
-        proc.stdout.destroy();
-      } catch {
-        /* ignore */
-      }
-      try {
-        proc.stderr.destroy();
-      } catch {
-        /* ignore */
-      }
+      await disposeProcess(proc);
     };
 
     const onAbort = (): void => {
@@ -352,6 +351,7 @@ export class BashTool implements BuiltinTool<BashInput> {
     } finally {
       clearTimeout(timeoutHandle);
       signal.removeEventListener('abort', onAbort);
+      await disposeProcess(proc);
     }
   }
 
@@ -402,6 +402,7 @@ export class BashTool implements BuiltinTool<BashInput> {
       } catch {
         /* process already gone */
       }
+      await disposeProcess(proc);
       return {
         isError: true,
         output: error instanceof Error ? error.message : String(error),

--- a/packages/agent-core/src/tools/builtin/shell/bash.ts
+++ b/packages/agent-core/src/tools/builtin/shell/bash.ts
@@ -36,6 +36,7 @@ import { renderPrompt } from '../../../utils/render-prompt';
 import { toInputJsonSchema } from '../../support/input-schema';
 import { literalRulePattern, matchesGlobRuleSubject } from '../../support/rule-match';
 import { ToolResultBuilder } from '../../support/result-builder';
+import { isPrematureCloseError } from '../../support/stream';
 import bashDescriptionTemplate from './bash.md?raw';
 
 const MS_PER_SECOND = 1000;
@@ -465,13 +466,6 @@ async function readStreamIntoBuilder(
   const trailing = decoder.end();
   if (trailing.length > 0) onUpdate?.({ kind, text: trailing });
   builder.write(trailing);
-}
-
-function isPrematureCloseError(error: unknown): boolean {
-  return (
-    error instanceof Error &&
-    (error as NodeJS.ErrnoException).code === 'ERR_STREAM_PREMATURE_CLOSE'
-  );
 }
 
 function shellQuote(s: string): string {

--- a/packages/agent-core/src/tools/support/stream.ts
+++ b/packages/agent-core/src/tools/support/stream.ts
@@ -1,0 +1,6 @@
+export function isPrematureCloseError(error: unknown): boolean {
+  return (
+    error instanceof Error &&
+    (error as NodeJS.ErrnoException).code === 'ERR_STREAM_PREMATURE_CLOSE'
+  );
+}

--- a/packages/agent-core/test/agent/background/ids.test.ts
+++ b/packages/agent-core/test/agent/background/ids.test.ts
@@ -20,6 +20,7 @@ function pendingProcess(): KaosProcess {
     exitCode: null,
     wait: () => new Promise<number>(() => {}),
     kill: vi.fn().mockResolvedValue(undefined) as KaosProcess['kill'],
+    dispose: vi.fn().mockResolvedValue(undefined) as KaosProcess['dispose'],
   };
 }
 

--- a/packages/agent-core/test/agent/background/manager.test.ts
+++ b/packages/agent-core/test/agent/background/manager.test.ts
@@ -20,6 +20,7 @@ import {
   createBackgroundManager,
   registerProcess,
   waitForOutput,
+  waitForTerminal,
 } from './helpers';
 
 function immediateProcess(exitCode: number, stdoutText = ''): KaosProcess {
@@ -31,6 +32,7 @@ function immediateProcess(exitCode: number, stdoutText = ''): KaosProcess {
     exitCode,
     wait: vi.fn().mockResolvedValue(exitCode) as KaosProcess['wait'],
     kill: vi.fn().mockResolvedValue(undefined) as KaosProcess['kill'],
+    dispose: vi.fn().mockResolvedValue(undefined) as KaosProcess['dispose'],
   };
 }
 
@@ -43,6 +45,7 @@ function rejectedProcess(error: Error): KaosProcess {
     exitCode: null,
     wait: vi.fn().mockRejectedValue(error) as KaosProcess['wait'],
     kill: vi.fn().mockResolvedValue(undefined) as KaosProcess['kill'],
+    dispose: vi.fn().mockResolvedValue(undefined) as KaosProcess['dispose'],
   };
 }
 
@@ -70,6 +73,7 @@ function pendingProcess(exitOnKill = 143): {
     },
     wait: () => waitPromise,
     kill: killSpy as unknown as KaosProcess['kill'],
+    dispose: vi.fn().mockResolvedValue(undefined) as KaosProcess['dispose'],
   };
   return { proc, killSpy };
 }
@@ -95,6 +99,7 @@ function manuallyResolvedProcess(): {
     },
     wait: () => waitPromise,
     kill: killSpy as unknown as KaosProcess['kill'],
+    dispose: vi.fn().mockResolvedValue(undefined) as KaosProcess['dispose'],
   };
   return {
     proc,
@@ -122,6 +127,7 @@ function processWithVisibleExitCodeBeforeWait(exitCode = 143): {
     },
     wait: () => new Promise<number>(() => {}),
     kill: vi.fn().mockResolvedValue(undefined) as KaosProcess['kill'],
+    dispose: vi.fn().mockResolvedValue(undefined) as KaosProcess['dispose'],
   };
   return {
     proc,
@@ -218,6 +224,22 @@ describe('BackgroundManager', () => {
     expect(await manager.readOutput(taskId)).toContain('captured output');
   });
 
+  it('disposes process resources after a process task completes', async () => {
+    const { manager } = createBackgroundManager();
+    const dispose = vi.fn();
+    const proc = {
+      ...immediateProcess(0, 'hello'),
+      dispose,
+    } as unknown as KaosProcess;
+    const taskId = registerProcess(manager, proc, 'echo hello', 'test echo');
+
+    await waitForTerminal(manager, taskId);
+
+    await vi.waitFor(() => {
+      expect(dispose).toHaveBeenCalledTimes(1);
+    });
+  });
+
   it('transitions process status from exit code', async () => {
     const { manager } = createBackgroundManager();
     const successId = registerProcess(manager, immediateProcess(0), 'echo done', 'ok');
@@ -286,6 +308,22 @@ describe('BackgroundManager', () => {
       exitCode: 143,
     });
     expect(killSpy).toHaveBeenCalledWith('SIGTERM');
+  });
+
+  it('disposes process resources after a stopped process task settles', async () => {
+    const { manager } = createBackgroundManager();
+    const { proc, killSpy } = pendingProcess(143);
+    const dispose = vi.fn();
+    const disposableProc = {
+      ...proc,
+      dispose,
+    } as unknown as KaosProcess;
+    const taskId = registerProcess(manager, disposableProc, 'sleep 60', 'kill test');
+
+    await manager.stop(taskId, 'user requested');
+
+    expect(killSpy).toHaveBeenCalledWith('SIGTERM');
+    expect(dispose).toHaveBeenCalledTimes(1);
   });
 
   it('stop normalizes blank reasons', async () => {
@@ -496,10 +534,15 @@ describe('BackgroundManager', () => {
           child.on('exit', (code) => {
             resolve(code ?? 0);
           });
-        }),
+      }),
       kill: vi.fn(async (signal?: NodeJS.Signals) => {
         child.kill(signal ?? 'SIGTERM');
       }) as unknown as KaosProcess['kill'],
+      dispose: vi.fn(async () => {
+        child.stdin?.destroy();
+        child.stdout?.destroy();
+        child.stderr?.destroy();
+      }) as KaosProcess['dispose'],
     };
 
     const taskId = registerProcess(manager, proc, 'node -e <stdout bg-ok>', 'real worker');

--- a/packages/agent-core/test/agent/background/output-access.test.ts
+++ b/packages/agent-core/test/agent/background/output-access.test.ts
@@ -27,6 +27,7 @@ function immediateProcess(exitCode: number, stdoutText = ''): KaosProcess {
     exitCode,
     wait: vi.fn().mockResolvedValue(exitCode) as KaosProcess['wait'],
     kill: vi.fn().mockResolvedValue(undefined) as KaosProcess['kill'],
+    dispose: vi.fn().mockResolvedValue(undefined) as KaosProcess['dispose'],
   };
 }
 

--- a/packages/agent-core/test/agent/background/rpc-events.test.ts
+++ b/packages/agent-core/test/agent/background/rpc-events.test.ts
@@ -30,6 +30,7 @@ function immediateProcess(exitCode: number, stdoutText = ''): KaosProcess {
     exitCode,
     wait: vi.fn().mockResolvedValue(exitCode) as KaosProcess['wait'],
     kill: vi.fn().mockResolvedValue(undefined) as KaosProcess['kill'],
+    dispose: vi.fn().mockResolvedValue(undefined) as KaosProcess['dispose'],
   };
 }
 
@@ -53,6 +54,7 @@ function pendingProcess(): KaosProcess {
       currentExitCode = 143;
       resolveWait(143);
     }) as unknown as KaosProcess['kill'],
+    dispose: vi.fn().mockResolvedValue(undefined) as KaosProcess['dispose'],
   };
 }
 

--- a/packages/agent-core/test/agent/harness/agent.ts
+++ b/packages/agent-core/test/agent/harness/agent.ts
@@ -129,6 +129,7 @@ export function createCommandKaos(stdout: string): Kaos {
       exitCode: 0,
       wait: vi.fn().mockResolvedValue(0),
       kill: vi.fn().mockResolvedValue(undefined),
+      dispose: vi.fn().mockResolvedValue(undefined),
     };
   }
 

--- a/packages/agent-core/test/session/git-context.test.ts
+++ b/packages/agent-core/test/session/git-context.test.ts
@@ -15,6 +15,7 @@ function fakeProcess(stdout: string, exitCode = 0): KaosProcess {
     exitCode,
     wait: async () => exitCode,
     kill: async () => {},
+    dispose: async () => {},
   };
 }
 
@@ -114,6 +115,7 @@ describe('collectGitContext', () => {
             kill: async () => {
               release(137);
             },
+            dispose: async () => {},
           };
         },
       });

--- a/packages/agent-core/test/session/lifecycle-hooks.test.ts
+++ b/packages/agent-core/test/session/lifecycle-hooks.test.ts
@@ -468,6 +468,7 @@ function pendingProcess(exitOnKill = 143): {
     },
     wait: () => waitPromise,
     kill: killSpy as unknown as KaosProcess['kill'],
+    dispose: vi.fn().mockResolvedValue(undefined) as KaosProcess['dispose'],
   };
   return { proc, killSpy };
 }

--- a/packages/agent-core/test/tools/background/task-tools.test.ts
+++ b/packages/agent-core/test/tools/background/task-tools.test.ts
@@ -43,6 +43,7 @@ function immediateProcess(exitCode: number, stdoutText = ''): KaosProcess {
     exitCode,
     wait: vi.fn().mockResolvedValue(exitCode) as KaosProcess['wait'],
     kill: vi.fn().mockResolvedValue(undefined) as KaosProcess['kill'],
+    dispose: vi.fn().mockResolvedValue(undefined) as KaosProcess['dispose'],
   };
 }
 
@@ -67,6 +68,7 @@ function pendingProcess(): KaosProcess {
     },
     wait: () => waitPromise,
     kill: killSpy as unknown as KaosProcess['kill'],
+    dispose: vi.fn().mockResolvedValue(undefined) as KaosProcess['dispose'],
   };
 }
 

--- a/packages/agent-core/test/tools/bash-env.test.ts
+++ b/packages/agent-core/test/tools/bash-env.test.ts
@@ -24,6 +24,7 @@ function fakeProcess(): KaosProcess {
     exitCode: 0,
     wait: vi.fn(async () => 0),
     kill: vi.fn(async () => {}),
+    dispose: vi.fn(async () => {}),
   };
 }
 

--- a/packages/agent-core/test/tools/bash.test.ts
+++ b/packages/agent-core/test/tools/bash.test.ts
@@ -34,14 +34,20 @@ function processWithOutput(
   } = {},
 ): KaosProcess {
   const exitCode = options.exitCode ?? 0;
+  const stdout = Readable.from(options.stdout === undefined ? [] : [options.stdout]);
+  const stderr = Readable.from(options.stderr === undefined ? [] : [options.stderr]);
   return {
     stdin: { end: vi.fn(), write: vi.fn() } as unknown as Writable,
-    stdout: Readable.from(options.stdout === undefined ? [] : [options.stdout]),
-    stderr: Readable.from(options.stderr === undefined ? [] : [options.stderr]),
+    stdout,
+    stderr,
     pid: 123,
     exitCode,
     wait: vi.fn(options.wait ?? (async () => exitCode)),
     kill: vi.fn(options.kill ?? (async () => {})),
+    dispose: vi.fn(async () => {
+      stdout.destroy();
+      stderr.destroy();
+    }),
   };
 }
 
@@ -78,6 +84,10 @@ function processWithInterleavedOutput(
     exitCode,
     wait: vi.fn(async () => waitPromise),
     kill: vi.fn(async () => {}),
+    dispose: vi.fn(async () => {
+      stdout.destroy();
+      stderr.destroy();
+    }),
   };
 }
 
@@ -101,6 +111,7 @@ function processWithVisibleExitBeforeWait(exitCode = 0): {
     },
     wait: vi.fn(async () => waitPromise),
     kill: vi.fn(async () => {}),
+    dispose: vi.fn(async () => {}),
   };
 
   return {
@@ -115,14 +126,20 @@ function processWithVisibleExitBeforeWait(exitCode = 0): {
 }
 
 function processThatNeverExits(): KaosProcess {
+  const stdout = new PassThrough();
+  const stderr = new PassThrough();
   return {
     stdin: { end: vi.fn(), write: vi.fn() } as unknown as Writable,
-    stdout: new PassThrough(),
-    stderr: new PassThrough(),
+    stdout,
+    stderr,
     pid: 126,
     exitCode: null,
     wait: vi.fn(async () => new Promise<number>(() => {})),
     kill: vi.fn(async () => {}),
+    dispose: vi.fn(async () => {
+      stdout.destroy();
+      stderr.destroy();
+    }),
   };
 }
 
@@ -132,11 +149,13 @@ function processWithOpenStreamsThatExitOnKill(): KaosProcess {
   const waitPromise = new Promise<number>((resolve) => {
     resolveWait = resolve;
   });
+  const stdout = new PassThrough();
+  const stderr = new PassThrough();
 
   return {
     stdin: { end: vi.fn(), write: vi.fn() } as unknown as Writable,
-    stdout: new PassThrough(),
-    stderr: new PassThrough(),
+    stdout,
+    stderr,
     pid: 127,
     get exitCode(): number | null {
       return currentExitCode;
@@ -145,6 +164,10 @@ function processWithOpenStreamsThatExitOnKill(): KaosProcess {
     kill: vi.fn(async () => {
       currentExitCode = 143;
       resolveWait(143);
+    }),
+    dispose: vi.fn(async () => {
+      stdout.destroy();
+      stderr.destroy();
     }),
   };
 }

--- a/packages/agent-core/test/tools/builtin-current.test.ts
+++ b/packages/agent-core/test/tools/builtin-current.test.ts
@@ -84,14 +84,20 @@ function mockSwarmMode(): SwarmMode {
 }
 
 function processWithOutput(stdout: string, exitCode = 0): KaosProcess {
+  const stdoutStream = Readable.from([stdout]);
+  const stderrStream = Readable.from([]);
   return {
     stdin: { write: vi.fn(), end: vi.fn() } as unknown as Writable,
-    stdout: Readable.from([stdout]),
-    stderr: Readable.from([]),
+    stdout: stdoutStream,
+    stderr: stderrStream,
     pid: 123,
     exitCode,
     wait: vi.fn().mockResolvedValue(exitCode),
     kill: vi.fn().mockResolvedValue(undefined),
+    dispose: vi.fn(async () => {
+      stdoutStream.destroy();
+      stderrStream.destroy();
+    }),
   };
 }
 

--- a/packages/agent-core/test/tools/grep.test.ts
+++ b/packages/agent-core/test/tools/grep.test.ts
@@ -65,14 +65,20 @@ const SENSITIVE_RG_ARGS = [
 ] as const;
 
 function processWithOutput(stdout: string, stderr = '', exitCode = 0): KaosProcess {
+  const stdoutStream = Readable.from([stdout]);
+  const stderrStream = Readable.from([stderr]);
   return {
     stdin: { end: vi.fn(), write: vi.fn() } as unknown as Writable,
-    stdout: Readable.from([stdout]),
-    stderr: Readable.from([stderr]),
+    stdout: stdoutStream,
+    stderr: stderrStream,
     pid: 123,
     exitCode,
     wait: vi.fn().mockResolvedValue(exitCode),
     kill: vi.fn(async () => {}),
+    dispose: vi.fn(async () => {
+      stdoutStream.destroy();
+      stderrStream.destroy();
+    }),
   };
 }
 
@@ -97,11 +103,13 @@ function processThatExitsOnKill(stdout: string, stderr = '', exitCode = 143): Ka
   const waitPromise = new Promise<number>((resolve) => {
     resolveWait = resolve;
   });
+  const stdoutStream = Readable.from(stdout === '' ? [] : [stdout]);
+  const stderrStream = Readable.from(stderr === '' ? [] : [stderr]);
 
   return {
     stdin: { end: vi.fn(), write: vi.fn() } as unknown as Writable,
-    stdout: Readable.from(stdout === '' ? [] : [stdout]),
-    stderr: Readable.from(stderr === '' ? [] : [stderr]),
+    stdout: stdoutStream,
+    stderr: stderrStream,
     pid: 123,
     get exitCode() {
       return currentExitCode;
@@ -110,6 +118,10 @@ function processThatExitsOnKill(stdout: string, stderr = '', exitCode = 143): Ka
     kill: vi.fn(async () => {
       currentExitCode = exitCode;
       resolveWait(exitCode);
+    }),
+    dispose: vi.fn(async () => {
+      stdoutStream.destroy();
+      stderrStream.destroy();
     }),
   };
 }

--- a/packages/agent-core/test/tools/shell-cancel.test.ts
+++ b/packages/agent-core/test/tools/shell-cancel.test.ts
@@ -32,6 +32,7 @@ describe('BashTool cancellation contract', () => {
       exitCode: null,
       wait: vi.fn(async () => waitPromise),
       kill,
+      dispose: vi.fn(async () => {}),
     };
     const execWithEnv = vi.fn().mockResolvedValue(proc);
     const controller = new AbortController();

--- a/packages/agent-core/test/tools/shell-quoting.test.ts
+++ b/packages/agent-core/test/tools/shell-quoting.test.ts
@@ -32,6 +32,7 @@ function fakeProcess(): KaosProcess {
     exitCode: 0,
     wait: vi.fn(async () => 0),
     kill: vi.fn(async () => {}),
+    dispose: vi.fn(async () => {}),
   };
 }
 
@@ -44,6 +45,7 @@ function fakeProcessWithOutput(stdout: Readable, stderr: Readable): KaosProcess 
     exitCode: 0,
     wait: vi.fn(async () => 0),
     kill: vi.fn(async () => {}),
+    dispose: vi.fn(async () => {}),
   };
 }
 

--- a/packages/kaos/src/local.ts
+++ b/packages/kaos/src/local.ts
@@ -46,6 +46,7 @@ class LocalProcess implements KaosProcess {
   private readonly _child: ChildProcess;
   private _exitCode: number | null = null;
   private readonly _exitPromise: Promise<number>;
+  private _disposed = false;
 
   constructor(child: ChildProcess) {
     if (child.stdin === null || child.stdout === null || child.stderr === null) {
@@ -134,6 +135,14 @@ class LocalProcess implements KaosProcess {
       throw error;
     }
     return Promise.resolve();
+  }
+
+  dispose(): void {
+    if (this._disposed) return;
+    this._disposed = true;
+    this.stdin.destroy();
+    this.stdout.destroy();
+    this.stderr.destroy();
   }
 }
 

--- a/packages/kaos/src/process.ts
+++ b/packages/kaos/src/process.ts
@@ -22,4 +22,6 @@ export interface KaosProcess {
   wait(): Promise<number>;
   /** Send a signal to the process (defaults to `SIGTERM`). */
   kill(signal?: NodeJS.Signals): Promise<void>;
+  /** Release stdin/stdout/stderr resources owned by this process wrapper. */
+  dispose(): Promise<void> | void;
 }

--- a/packages/kaos/src/ssh.ts
+++ b/packages/kaos/src/ssh.ts
@@ -222,6 +222,7 @@ export class SSHProcess implements KaosProcess {
   private _exitCode: number | null = null;
   private readonly _exitPromise: Promise<number>;
   private readonly _channel: ClientChannel;
+  private _disposed = false;
 
   constructor(channel: ClientChannel) {
     this._channel = channel;
@@ -260,6 +261,14 @@ export class SSHProcess implements KaosProcess {
     const sshSignal = rawSignal.startsWith('SIG') ? rawSignal.slice(3) : rawSignal;
     this._channel.signal(sshSignal);
     return Promise.resolve();
+  }
+
+  dispose(): void {
+    if (this._disposed) return;
+    this._disposed = true;
+    this.stdin.destroy();
+    this.stdout.destroy();
+    this.stderr.destroy();
   }
 }
 

--- a/packages/kaos/test/local.test.ts
+++ b/packages/kaos/test/local.test.ts
@@ -615,6 +615,20 @@ describe('LocalKaos', () => {
   });
 
   describe('exec timeout', () => {
+    it('dispose destroys process stdio without killing the process', async () => {
+      const proc = await kaos.exec(...nodeArgs('setTimeout(() => {}, 10000);'));
+
+      await proc.dispose();
+      await proc.dispose();
+
+      expect(proc.exitCode).toBeNull();
+      expect(proc.stdout.destroyed).toBe(true);
+      expect(proc.stderr.destroyed).toBe(true);
+
+      await proc.kill('SIGKILL');
+      await proc.wait();
+    });
+
     it('should allow killing a long-running process', async () => {
       const code = `setTimeout(() => {}, 10000);`;
       const proc = await kaos.exec(...nodeArgs(code));


### PR DESCRIPTION
## Related Issue

No linked issue; this fixes observed headless runs where completed or stopped managed commands could keep stdout/stderr pipes open.

## Problem

Managed process commands could finish or be stopped while their Kaos stdin/stdout/stderr resources remained open. In headless execution, inherited pipes can keep the outer harness waiting even after the CLI session has exited.

## What changed

- Added an explicit Kaos process disposal contract and implemented stdio disposal for local and SSH processes.
- Disposed foreground shell, grep, git probe, and background task process resources after completion or termination.
- Added a short background stream-drain grace period so normal tail output can be captured before resources are released.
- Added regression tests for natural background completion, stopped background tasks, and local process stdio disposal.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.

## Testing

- `pnpm -C packages/agent-core test`
- `pnpm exec vitest run` from `packages/kaos`
- `pnpm -r --filter './packages/*' run typecheck`
- `pnpm run lint`
- `git diff --check`