### PR TITLE
refactor: simplify LLM request logging

### DIFF
--- a/.changeset/tidy-llm-request-logs.md
+++ b/.changeset/tidy-llm-request-logs.md
@@ -1,0 +1,6 @@
+---
+"@moonshot-ai/agent-core": patch
+"@moonshot-ai/kimi-code": patch
+---
+
+Remove redundant LLM request logging context plumbing.

--- a/packages/agent-core/src/agent/config/index.ts
+++ b/packages/agent-core/src/agent/config/index.ts
@@ -6,7 +6,7 @@ import {
   type ProviderConfig,
 } from '@moonshot-ai/kosong';
 
-import { applyKimiEnvSamplingParams, applyKimiEnvThinkingKeep } from '../kimi-env-params';
+import { applyKimiEnvSamplingParams, applyKimiEnvThinkingKeep } from '#/config/kimi-env-params';
 
 import type { Agent } from '..';
 import { ErrorCodes, KimiError } from '../../errors';

--- a/packages/agent-core/src/agent/index.ts
+++ b/packages/agent-core/src/agent/index.ts
@@ -1,16 +1,10 @@
-import { createHash } from 'node:crypto';
 import { join } from 'pathe';
 
 import { ErrorCodes, KimiError, makeErrorPayload } from '#/errors';
 import { log } from '#/logging/logger';
 import type { Logger } from '#/logging/types';
 import type { AgentAPI, AgentEvent, KimiConfig, SDKAgentRPC, UsageStatus } from '#/rpc';
-import {
-  generate,
-  type ChatProvider,
-  type Message,
-  type Tool,
-} from '@moonshot-ai/kosong';
+import { generate } from '@moonshot-ai/kosong';
 
 import type { EnabledPluginSessionStart } from '#/plugin';
 
@@ -50,12 +44,9 @@ import type { SkillRegistry } from './skill/types';
 import { SwarmMode } from './swarm';
 import { ToolManager } from './tool/index';
 import { TurnFlow } from './turn';
-import {
-  GENERATE_REQUEST_LOG_CONTEXT,
-  KosongLLM,
-  type GenerateOptionsWithRequestLog,
-} from './turn/kosong-llm';
+import { KosongLLM } from './turn/kosong-llm';
 import { UsageRecorder } from './usage';
+import { LlmRequestLogger, splitGenerateOptions } from './llm-request-logger';
 import { resolveCompletionBudget } from '../utils/completion-budget';
 import type { Kaos } from '@moonshot-ai/kaos';
 import type { ToolServices } from '../tools/support/services';
@@ -113,6 +104,7 @@ export class Agent {
   readonly telemetry: TelemetryClient;
   readonly experimentalFlags: ExperimentalFlagResolver;
 
+  readonly llmRequestLogger: LlmRequestLogger;
   readonly blobStore: BlobStore | undefined;
   readonly records: AgentRecords;
   readonly fullCompaction: FullCompaction;
@@ -132,8 +124,6 @@ export class Agent {
   readonly goal: GoalMode;
   readonly replayBuilder: ReplayBuilder;
 
-  private lastLlmConfigLogSignature?: string;
-
   constructor(options: AgentOptions) {
     this.type = options.type ?? 'main';
     this._kaos = options.kaos;
@@ -151,6 +141,7 @@ export class Agent {
     this.telemetry = options.telemetry ?? noopTelemetryClient;
     this.experimentalFlags = options.experimentalFlags ?? new FlagResolver();
 
+    this.llmRequestLogger = new LlmRequestLogger(this.log);
     this.blobStore = options.homedir
       ? new BlobStore({ blobsDir: join(options.homedir, 'blobs') })
       : undefined;
@@ -193,29 +184,36 @@ export class Agent {
 
   get generate(): typeof generate {
     return async (provider, systemPrompt, tools, history, callbacks, options) => {
-      if (options?.auth !== undefined) {
-        this.logLlmRequest(provider, systemPrompt, tools, history, options);
-        return this.rawGenerate(provider, systemPrompt, tools, history, callbacks, options);
-      }
+      const { requestLogFields, generateOptions } = splitGenerateOptions(options);
       const modelAlias = this.config.modelAlias;
+      const run = (requestOptions: Parameters<typeof generate>[5]) => {
+        this.llmRequestLogger.logRequest({
+          provider,
+          modelAlias,
+          systemPrompt,
+          tools,
+          messages: history,
+          fields: requestLogFields,
+        });
+        return this.rawGenerate(provider, systemPrompt, tools, history, callbacks, requestOptions);
+      };
+      if (generateOptions?.auth !== undefined) {
+        return run(generateOptions);
+      }
       const withAuth =
         modelAlias === undefined
           ? undefined
           : this.modelProvider?.resolveAuth?.(modelAlias, { log: this.log });
       if (withAuth === undefined) {
-        this.logLlmRequest(provider, systemPrompt, tools, history, options);
-        return this.rawGenerate(provider, systemPrompt, tools, history, callbacks, options);
+        return run(generateOptions);
       }
       return withAuth((auth) => {
-        const requestOptions = { ...options, auth };
-        this.logLlmRequest(provider, systemPrompt, tools, history, requestOptions);
-        return this.rawGenerate(provider, systemPrompt, tools, history, callbacks, requestOptions);
+        return run({ ...generateOptions, auth });
       });
     };
   }
 
   get llm(): KosongLLM {
-    const model = this.config.model;
     // All provider-level request config (thinking, sampling params, thinking.keep)
     // is applied in ConfigState.provider so compaction shares it. See get provider().
     const provider = this.config.provider;
@@ -226,58 +224,10 @@ export class Agent {
     });
     return new KosongLLM({
       provider,
-      modelName: model,
       systemPrompt: this.config.systemPrompt,
       capability: this.config.modelCapabilities,
       generate: this.generate,
       completionBudgetConfig,
-    });
-  }
-
-  private logLlmRequest(
-    provider: ChatProvider,
-    systemPrompt: string,
-    tools: readonly Tool[],
-    history: readonly Message[],
-    options: Parameters<typeof generate>[5],
-  ): void {
-    const context = buildLlmRequestContext(options);
-    const configMetadata = buildLlmConfigMetadata(
-      provider,
-      this.config.modelAlias,
-      systemPrompt,
-      tools,
-    );
-    this.logLlmConfigIfChanged(
-      context,
-      configMetadata,
-      buildLlmConfigSignature(configMetadata, systemPrompt, tools),
-    );
-
-    let partialMessageCount = 0;
-    for (const message of history) {
-      if (message.partial === true) partialMessageCount += 1;
-    }
-    const requestMetadata: LlmRequestMetadata = {};
-    if (partialMessageCount > 0) {
-      requestMetadata.partialMessageCount = partialMessageCount;
-    }
-    this.log.info('llm request', {
-      ...context,
-      ...requestMetadata,
-    });
-  }
-
-  private logLlmConfigIfChanged(
-    context: LlmRequestContextFields,
-    metadata: LlmConfigMetadata,
-    signature: string,
-  ): void {
-    if (signature === this.lastLlmConfigLogSignature) return;
-    this.lastLlmConfigLogSignature = signature;
-    this.log.info('llm config', {
-      ...context,
-      ...metadata,
     });
   }
 
@@ -477,89 +427,4 @@ export class Agent {
       ),
     });
   }
-}
-
-interface LlmRequestContextFields {
-  turnStep?: string;
-  attempt?: string;
-}
-
-interface LlmRequestMetadata {
-  partialMessageCount?: number;
-}
-
-/**
- * Fields that identify an LLM configuration for deduplication.
- * Keep this interface simple and avoid dynamic keys — the shape is
- * serialized with `JSON.stringify` to produce a stable signature in
- * `logLlmConfigIfChanged`.
- */
-interface LlmConfigMetadata {
-  provider: string;
-  model: string;
-  modelAlias?: string;
-  thinkingEffort?: string;
-  systemPromptChars: number;
-  toolCount: number;
-}
-
-function buildLlmRequestContext(options: Parameters<typeof generate>[5]): LlmRequestContextFields {
-  const context = requestLogContext(options);
-  if (context === undefined) return {};
-
-  const fields: LlmRequestContextFields = {
-    turnStep:
-      context.turnId === undefined || context.step === undefined
-        ? undefined
-        : `${context.turnId}.${String(context.step)}`,
-  };
-  if (
-    context.attempt !== undefined &&
-    context.maxAttempts !== undefined &&
-    context.attempt > 1
-  ) {
-    fields.attempt = `${String(context.attempt)}/${String(context.maxAttempts)}`;
-  }
-  return fields;
-}
-
-function buildLlmConfigMetadata(
-  provider: ChatProvider,
-  modelAlias: string | undefined,
-  systemPrompt: string,
-  tools: readonly Tool[],
-): LlmConfigMetadata {
-  return {
-    provider: provider.name,
-    model: provider.modelName,
-    modelAlias,
-    thinkingEffort: provider.thinkingEffort ?? undefined,
-    systemPromptChars: systemPrompt.length,
-    toolCount: tools.length,
-  };
-}
-
-function buildLlmConfigSignature(
-  metadata: LlmConfigMetadata,
-  systemPrompt: string,
-  tools: readonly Tool[],
-): string {
-  const toolsForSignature = tools.map(({ name, description, parameters }) => ({
-    name,
-    description,
-    parameters,
-  }));
-  return JSON.stringify({
-    ...metadata,
-    systemPromptHash: fingerprint(systemPrompt),
-    toolsHash: fingerprint(JSON.stringify(toolsForSignature)),
-  });
-}
-
-function fingerprint(content: string): string {
-  return createHash('sha256').update(content).digest('hex');
-}
-
-function requestLogContext(options: Parameters<typeof generate>[5]) {
-  return (options as GenerateOptionsWithRequestLog | undefined)?.[GENERATE_REQUEST_LOG_CONTEXT];
 }

--- a/packages/agent-core/src/agent/llm-request-logger.ts
+++ b/packages/agent-core/src/agent/llm-request-logger.ts
@@ -1,0 +1,73 @@
+import { createHash } from 'node:crypto';
+
+import type { Logger } from '#/logging/types';
+import type { ChatProvider, GenerateOptions, Message, Tool } from '@moonshot-ai/kosong';
+
+import type { LLMRequestLogFields } from '../loop';
+
+export type GenerateOptionsWithRequestLogFields = GenerateOptions & {
+  readonly requestLogFields?: LLMRequestLogFields;
+};
+
+export class LlmRequestLogger {
+  private lastConfigLogSignature: string | undefined;
+
+  constructor(private readonly log: Logger) {}
+
+  logRequest(input: {
+    readonly provider: ChatProvider;
+    readonly modelAlias?: string;
+    readonly systemPrompt: string;
+    readonly tools: readonly Tool[];
+    readonly messages: readonly Message[];
+    readonly fields: LLMRequestLogFields | undefined;
+  }): void {
+    const { provider, modelAlias, systemPrompt, tools, messages, fields } = input;
+    const requestLogFields = fields ?? {};
+    const config = {
+      provider: provider.name,
+      model: provider.modelName,
+      modelAlias,
+      thinkingEffort: provider.thinkingEffort ?? undefined,
+      systemPromptChars: systemPrompt.length,
+      toolCount: tools.length,
+    };
+    const signature = JSON.stringify({
+      ...config,
+      systemPromptHash: fingerprint(systemPrompt),
+      toolsHash: fingerprint(JSON.stringify(toolSignature(tools))),
+    });
+    if (signature !== this.lastConfigLogSignature) {
+      this.lastConfigLogSignature = signature;
+      this.log.info('llm config', { ...requestLogFields, ...config });
+    }
+
+    const partialMessageCount = messages.filter((message) => message.partial === true).length;
+    const requestFields: {
+      turnStep?: string;
+      attempt?: string;
+      partialMessageCount?: number;
+    } = { ...requestLogFields };
+    if (partialMessageCount > 0) requestFields.partialMessageCount = partialMessageCount;
+    this.log.info('llm request', requestFields);
+  }
+}
+
+export function splitGenerateOptions(options: GenerateOptionsWithRequestLogFields | undefined): {
+  readonly requestLogFields: LLMRequestLogFields | undefined;
+  readonly generateOptions: GenerateOptions | undefined;
+} {
+  if (options === undefined) {
+    return { requestLogFields: undefined, generateOptions: undefined };
+  }
+  const { requestLogFields, ...generateOptions } = options;
+  return { requestLogFields, generateOptions };
+}
+
+function toolSignature(tools: readonly Tool[]) {
+  return tools.map(({ name, description, parameters }) => ({ name, description, parameters }));
+}
+
+function fingerprint(content: string): string {
+  return createHash('sha256').update(content).digest('hex');
+}

--- a/packages/agent-core/src/agent/turn/kosong-llm.ts
+++ b/packages/agent-core/src/agent/turn/kosong-llm.ts
@@ -18,7 +18,6 @@
 import {
   emptyUsage,
   generate as kosongGenerate,
-  type GenerateOptions,
   isRetryableGenerateError,
   type ChatProvider,
   type GenerateCallbacks,
@@ -31,25 +30,18 @@ import type {
   LLM,
   LLMChatParams,
   LLMChatResponse,
-  LLMRequestLogContext,
   LLMStreamTiming,
 } from '../../loop';
 import {
   applyCompletionBudget,
   type CompletionBudgetConfig,
 } from '../../utils/completion-budget';
-
-export const GENERATE_REQUEST_LOG_CONTEXT = '__kimiRequestLogContext';
-
-export type GenerateOptionsWithRequestLog = GenerateOptions & {
-  readonly [GENERATE_REQUEST_LOG_CONTEXT]?: LLMRequestLogContext;
-};
+import type { GenerateOptionsWithRequestLogFields } from '../llm-request-logger';
 
 export type GenerateFn = typeof kosongGenerate;
 
 export interface KosongLLMConfig {
   readonly provider: ChatProvider;
-  readonly modelName: string;
   readonly systemPrompt: string;
   readonly capability?: ModelCapability | undefined;
   /**
@@ -76,7 +68,7 @@ export class KosongLLM implements LLM {
 
   constructor(config: KosongLLMConfig) {
     this.provider = config.provider;
-    this.modelName = config.modelName;
+    this.modelName = config.provider.modelName;
     this.systemPrompt = config.systemPrompt;
     this.capability = config.capability;
     this.generate = config.generate ?? kosongGenerate;
@@ -94,9 +86,7 @@ export class KosongLLM implements LLM {
       streamEndedAt = Date.now();
     };
     const markStreamOutput = (): void => {
-      if (firstChunkAt === undefined) {
-        firstChunkAt = Date.now();
-      }
+      firstChunkAt ??= Date.now();
     };
     const callbacks = buildKosongCallbacks(params, markStreamOutput);
 
@@ -109,6 +99,12 @@ export class KosongLLM implements LLM {
       budget: this.completionBudgetConfig,
       capability: this.capability,
     });
+    const options: GenerateOptionsWithRequestLogFields = {
+      signal: params.signal,
+      onRequestStart: markRequestStart,
+      onStreamEnd: markStreamEnd,
+      requestLogFields: params.requestLogFields,
+    };
 
     const result = await this.generate(
       effectiveProvider,
@@ -116,10 +112,7 @@ export class KosongLLM implements LLM {
       [...params.tools],
       params.messages,
       callbacks,
-      generateOptions(params, {
-        onRequestStart: markRequestStart,
-        onStreamEnd: markStreamEnd,
-      }),
+      options,
     );
 
     // Replay merged content parts onto loop per-block callbacks after the
@@ -163,18 +156,6 @@ function buildStreamTiming(
   return {
     firstTokenLatencyMs: Math.max(0, firstChunkAt - requestStartedAt),
     streamDurationMs: Math.max(0, outputEndedAt - firstChunkAt),
-  };
-}
-
-function generateOptions(
-  params: LLMChatParams,
-  hooks: Pick<GenerateOptions, 'onRequestStart' | 'onStreamEnd'>,
-): GenerateOptionsWithRequestLog {
-  return {
-    signal: params.signal,
-    onRequestStart: hooks.onRequestStart,
-    onStreamEnd: hooks.onStreamEnd,
-    [GENERATE_REQUEST_LOG_CONTEXT]: params.requestLogContext,
   };
 }
 

--- a/packages/agent-core/src/config/kimi-env-params.ts
+++ b/packages/agent-core/src/config/kimi-env-params.ts
@@ -38,7 +38,7 @@ export function applyKimiEnvSamplingParams(
 
 /**
  * Apply the Moonshot preserved-thinking passthrough (`KIMI_MODEL_THINKING_KEEP`
- * -> `thinking.keep`) to a chat provider. Applied in `Agent.llm` after
+ * -> `thinking.keep`) to a chat provider. Applied in `ConfigState.provider` after
  * `withThinking`, and only while thinking is on — otherwise the API would
  * receive a `thinking.keep` with no accompanying `thinking.type` it honors.
  * (Compaction uses a raw provider with thinking off, so it correctly skips this.)

--- a/packages/agent-core/src/loop/index.ts
+++ b/packages/agent-core/src/loop/index.ts
@@ -66,7 +66,7 @@ export type {
   LLM,
   LLMChatParams,
   LLMChatResponse,
-  LLMRequestLogContext,
+  LLMRequestLogFields,
   LLMStreamTiming,
   ToolCallDelta,
 } from './llm';

--- a/packages/agent-core/src/loop/llm.ts
+++ b/packages/agent-core/src/loop/llm.ts
@@ -23,12 +23,9 @@ export interface ToolCallDelta {
   readonly argumentsPart?: string | undefined;
 }
 
-export interface LLMRequestLogContext {
-  readonly turnId?: string;
-  readonly step?: number;
-  readonly stepUuid?: string;
-  readonly attempt?: number;
-  readonly maxAttempts?: number;
+export interface LLMRequestLogFields {
+  readonly turnStep: string;
+  readonly attempt?: string;
 }
 
 export interface LLMStreamTiming {
@@ -40,7 +37,7 @@ export interface LLMChatParams {
   messages: Message[];
   tools: readonly Tool[];
   signal: AbortSignal;
-  requestLogContext?: LLMRequestLogContext;
+  requestLogFields?: LLMRequestLogFields;
   onTextDelta?: ((delta: string) => void) | undefined;
   onThinkDelta?: ((delta: string) => void) | undefined;
   onToolCallDelta?: ((delta: ToolCallDelta) => void) | undefined;

--- a/packages/agent-core/src/loop/retry.ts
+++ b/packages/agent-core/src/loop/retry.ts
@@ -87,15 +87,13 @@ function paramsForAttempt(
   attempt: number,
   maxAttempts: number,
 ): LLMChatParams {
+  const turnStep = `${input.turnId}.${String(input.currentStep)}`;
   return {
     ...input.params,
-    requestLogContext: {
-      turnId: input.turnId,
-      step: input.currentStep,
-      stepUuid: input.stepUuid,
-      attempt,
-      maxAttempts,
-    },
+    requestLogFields:
+      attempt === 1
+        ? { turnStep }
+        : { turnStep, attempt: `${String(attempt)}/${String(maxAttempts)}` },
   };
 }
 

--- a/packages/agent-core/test/agent/harness/scripted-generate.ts
+++ b/packages/agent-core/test/agent/harness/scripted-generate.ts
@@ -46,6 +46,7 @@ export function createScriptedGenerate() {
 
   const generate: GenerateFn = async (_chat, systemPrompt, tools, history, callbacks, options) => {
     options?.signal?.throwIfAborted();
+    options?.onRequestStart?.();
 
     const response = responses.shift();
     if (response === undefined) {
@@ -75,6 +76,7 @@ export function createScriptedGenerate() {
       await callbacks?.onMessagePart?.(structuredClone(part));
       options?.signal?.throwIfAborted();
     }
+    options?.onStreamEnd?.();
 
     const inferredFinishReason: FinishReason = toolCalls.length > 0 ? 'tool_calls' : 'completed';
     const finishReason = response.finishReason ?? inferredFinishReason;

--- a/packages/agent-core/test/agent/kosong-llm.test.ts
+++ b/packages/agent-core/test/agent/kosong-llm.test.ts
@@ -111,7 +111,6 @@ describe('KosongLLM stream timing', () => {
     };
     const llm = new KosongLLM({
       provider,
-      modelName: 'test-model',
       systemPrompt: 'system',
       generate,
     });
@@ -154,7 +153,6 @@ describe('KosongLLM completion budget', () => {
     };
     const llm = new KosongLLM({
       provider: providerWithBudget,
-      modelName: 'test-model',
       systemPrompt: 'system',
       capability: makeCapability(10000),
       completionBudgetConfig: { fallback: 32000 },
@@ -196,7 +194,6 @@ async function collectToolCallDeltas(
   };
   const llm = new KosongLLM({
     provider,
-    modelName: 'test-model',
     systemPrompt: 'system',
     generate,
   });

--- a/packages/agent-core/test/agent/turn.test.ts
+++ b/packages/agent-core/test/agent/turn.test.ts
@@ -1372,11 +1372,13 @@ describe('Agent turn flow', () => {
       callbacks,
       options,
     ) => {
+      options?.onRequestStart?.();
       authKeys.push(options?.auth?.apiKey ?? '<missing>');
       if (authKeys.length === 1) {
         throw new APIConnectionError('socket hang up');
       }
       await callbacks?.onMessagePart?.({ type: 'text', text: 'Recovered after retry' });
+      options?.onStreamEnd?.();
       return textResult('Recovered after retry');
     };
     const ctx = testAgent({ ...oauthOptions, generate, log: logger });

--- a/packages/agent-core/test/config/kimi-env-params.test.ts
+++ b/packages/agent-core/test/config/kimi-env-params.test.ts
@@ -1,7 +1,7 @@
 import { type ChatProvider, KimiChatProvider } from '@moonshot-ai/kosong';
 import { describe, expect, it } from 'vitest';
 
-import { applyKimiEnvSamplingParams, applyKimiEnvThinkingKeep } from '../../src/agent/kimi-env-params';
+import { applyKimiEnvSamplingParams, applyKimiEnvThinkingKeep } from '../../src/config/kimi-env-params';
 import { KimiError } from '../../src/errors';
 
 function kimi(): KimiChatProvider {


### PR DESCRIPTION
## Related Issue

No linked issue. This addresses noisy internal request logging plumbing found while cleaning up the agent request path.

## Problem

LLM request logging context was being carried through multiple layers as raw turn, step, and retry state before being unpacked again at the provider request boundary. That made the ownership of logging state unclear and left too much request-log construction logic in the agent top level.

## What changed

- Moved LLM request/config logging into a small agent-side logger component.
- Kept `Agent.generate` as the single request boundary for auth injection and request logging.
- Replaced raw request-log context propagation with compact log fields generated by retry handling.
- Removed redundant `KosongLLM` config fields and test plumbing.
- Added a patch changeset for the internal package and CLI bundle.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.

Validation:

- `pnpm exec oxlint packages/agent-core/src/agent/index.ts packages/agent-core/src/agent/llm-request-logger.ts packages/agent-core/src/agent/turn/kosong-llm.ts packages/agent-core/src/loop/llm.ts packages/agent-core/src/loop/retry.ts packages/agent-core/src/loop/index.ts packages/agent-core/test/agent/harness/scripted-generate.ts packages/agent-core/test/agent/turn.test.ts packages/agent-core/test/agent/kosong-llm.test.ts --type-aware`
- `pnpm --filter @moonshot-ai/agent-core typecheck`
- `pnpm -C packages/agent-core exec vitest run test/agent/turn.test.ts test/agent/kosong-llm.test.ts test/loop/error-paths.e2e.test.ts test/agent/compaction/full.test.ts`

Internal identifier audit: completed by a read-only agent; no issues found.
