### PR TITLE
docs: document the kimi vis command

### DIFF
--- a/docs/en/reference/kimi-command.md
+++ b/docs/en/reference/kimi-command.md
@@ -214,6 +214,32 @@ kimi upgrade
 
 For global npm, pnpm, yarn, bun, and macOS / Linux native installations, `kimi upgrade` shows update options; selecting `Install update now` runs the corresponding foreground install command. When the current installation method cannot be upgraded automatically (e.g., Windows native installation), the manual update command is printed instead.
 
+### `kimi vis`
+
+Launch the session visualizer in your browser to inspect a session as it unfolds. The command starts an in-process server pointed at your local sessions, prints the URL, opens your browser, and keeps running until you press `Ctrl-C`.
+
+```sh
+kimi vis [sessionId] [options]
+```
+
+| Parameter / Option | Description |
+| --- | --- |
+| `sessionId` | Open the visualizer directly to this session. When omitted, it opens the home view listing your sessions |
+| `--port <number>` | Port to bind. By default an available port is picked automatically |
+| `--host <host>` | Host to bind. Default: `127.0.0.1` |
+| `--no-open` | Do not open the browser automatically; just print the URL |
+
+```sh
+# Start the visualizer and open the browser at the home view
+kimi vis
+
+# Open directly to a specific session
+kimi vis 01HZ...XYZ
+
+# Bind a fixed port and host without opening a browser (e.g. on a remote host)
+kimi vis --host 0.0.0.0 --port 8123 --no-open
+```
+
 ### `kimi provider`
 
 Manage providers in the shell — the non-interactive equivalent of `/provider` in the TUI. Suitable for scripted deployments, CI initialization, and one-line setup on a new machine.

--- a/docs/zh/reference/kimi-command.md
+++ b/docs/zh/reference/kimi-command.md
@@ -214,6 +214,32 @@ kimi upgrade
 
 对全局 npm、pnpm、yarn、bun 以及 macOS / Linux native 安装，`kimi upgrade` 会展示更新选项；选择 `Install update now` 后运行对应的前台安装命令。当前安装方式无法自动升级时（如 Windows native 安装），改为打印手动更新命令。
 
+### `kimi vis`
+
+在浏览器中启动会话可视化工具，直观查看一次会话的全过程。命令会启动一个指向本地会话的进程内服务器，打印访问地址并打开浏览器，持续运行直到你按下 `Ctrl-C`。
+
+```sh
+kimi vis [sessionId] [options]
+```
+
+| 参数 / 选项 | 说明 |
+| --- | --- |
+| `sessionId` | 直接打开指定会话的可视化页面。省略时打开列出所有会话的首页 |
+| `--port <number>` | 绑定的端口。默认自动挑选一个空闲端口 |
+| `--host <host>` | 绑定的主机。默认 `127.0.0.1` |
+| `--no-open` | 不自动打开浏览器，仅打印访问地址 |
+
+```sh
+# 启动可视化工具并在浏览器中打开首页
+kimi vis
+
+# 直接打开指定会话
+kimi vis 01HZ...XYZ
+
+# 绑定固定主机和端口且不打开浏览器（例如在远程主机上）
+kimi vis --host 0.0.0.0 --port 8123 --no-open
+```
+
 ### `kimi provider`
 
 在 shell 中管理供应商，相当于 TUI 中 `/provider` 的非交互版本。适合脚本化部署、CI 初始化，以及在新机器上一行完成配置。


### PR DESCRIPTION
## What

Adds a `### kimi vis` subcommand section to the CLI command reference (`docs/en` and `docs/zh`). The command shipped in v0.16.0 but was missing from the command reference page.

## Details

Documents the command signature, options, and usage, matching the implementation in `apps/kimi-code/src/cli/sub/vis.ts`:

- `kimi vis [sessionId] [options]` — launches the session visualizer in the browser, pointed at local sessions, and runs until `Ctrl-C`.
- `sessionId` (optional) deep-links straight to a session.
- `--port <number>` — defaults to an auto-picked free port.
- `--host <host>` — defaults to `127.0.0.1`.
- `--no-open` — print the URL without opening a browser.

Placed between `kimi upgrade` and `kimi provider`, with parallel en/zh wording.

## Test

Docs-only change; no code affected.