### PR TITLE
fix(agent-core): honor model output cap during compaction

### DIFF
--- a/.changeset/honest-timers-flow.md
+++ b/.changeset/honest-timers-flow.md
@@ -1,5 +1,6 @@
 ---
 "@moonshot-ai/kimi-code": patch
+"@moonshot-ai/agent-core": patch
 ---
 
 Respect model output-token limits during full-history compaction.

--- a/.changeset/honest-timers-flow.md
+++ b/.changeset/honest-timers-flow.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Respect model output-token limits during full-history compaction.

--- a/packages/agent-core/test/agent/compaction/full.test.ts
+++ b/packages/agent-core/test/agent/compaction/full.test.ts
@@ -2014,18 +2014,22 @@ describe('FullCompaction', () => {
     const providerManager = ctx.agent.modelProvider;
     if (providerManager === undefined) throw new Error('Expected provider manager');
     const resolveProviderConfig = providerManager.resolveProviderConfig.bind(providerManager);
-    vi.spyOn(providerManager, 'resolveProviderConfig').mockImplementation((model) => ({
+    const spy = vi.spyOn(providerManager, 'resolveProviderConfig').mockImplementation((model) => ({
       ...resolveProviderConfig(model),
       maxOutputSize: 32768,
     }));
-    ctx.appendExchange(1, 'old user one', 'old assistant one', 20);
-    ctx.newEvents();
+    try {
+      ctx.appendExchange(1, 'old user one', 'old assistant one', 20);
+      ctx.newEvents();
 
-    await ctx.rpc.prompt({ input: [{ type: 'text', text: 'Retry with model output cap' }] });
-    await ctx.untilTurnEnd();
+      await ctx.rpc.prompt({ input: [{ type: 'text', text: 'Retry with model output cap' }] });
+      await ctx.untilTurnEnd();
 
-    expect(callCount).toBe(3);
-    expect(compactionMaxCompletionTokens).toEqual([32768]);
+      expect(callCount).toBe(3);
+      expect(compactionMaxCompletionTokens).toEqual([32768]);
+    } finally {
+      spy.mockRestore();
+    }
   });
 
   it('honors completion budget env opt-out during compaction', async () => {

--- a/packages/agent-core/test/agent/compaction/full.test.ts
+++ b/packages/agent-core/test/agent/compaction/full.test.ts
@@ -1891,7 +1891,7 @@ describe('FullCompaction', () => {
 
   it('compacts provider overflow when model context size is unknown', async () => {
     let callCount = 0;
-    const compactionMaxCompletionTokens: unknown[] = [];
+    const compactionMaxCompletionTokens: Array<number | undefined> = [];
     const generate: GenerateFn = async (provider, _system, _tools, _history, callbacks) => {
       callCount += 1;
       if (callCount === 1) {
@@ -1957,7 +1957,7 @@ describe('FullCompaction', () => {
   it('honors completion budget env hard caps during compaction', async () => {
     vi.stubEnv('KIMI_MODEL_MAX_COMPLETION_TOKENS', '8192');
     let callCount = 0;
-    const compactionMaxCompletionTokens: unknown[] = [];
+    const compactionMaxCompletionTokens: Array<number | undefined> = [];
     const generate: GenerateFn = async (provider, _system, _tools, _history, callbacks) => {
       callCount += 1;
       if (callCount === 1) {
@@ -1990,7 +1990,7 @@ describe('FullCompaction', () => {
 
   it('honors model maxOutputSize during compaction', async () => {
     let callCount = 0;
-    const compactionMaxCompletionTokens: unknown[] = [];
+    const compactionMaxCompletionTokens: Array<number | undefined> = [];
     const generate: GenerateFn = async (provider, _system, _tools, _history, callbacks) => {
       callCount += 1;
       if (callCount === 1) {
@@ -2014,10 +2014,10 @@ describe('FullCompaction', () => {
     const providerManager = ctx.agent.modelProvider;
     if (providerManager === undefined) throw new Error('Expected provider manager');
     const resolveProviderConfig = providerManager.resolveProviderConfig.bind(providerManager);
-    providerManager.resolveProviderConfig = (model) => ({
+    vi.spyOn(providerManager, 'resolveProviderConfig').mockImplementation((model) => ({
       ...resolveProviderConfig(model),
       maxOutputSize: 32768,
-    });
+    }));
     ctx.appendExchange(1, 'old user one', 'old assistant one', 20);
     ctx.newEvents();
 
@@ -2031,7 +2031,7 @@ describe('FullCompaction', () => {
   it('honors completion budget env opt-out during compaction', async () => {
     vi.stubEnv('KIMI_MODEL_MAX_COMPLETION_TOKENS', '0');
     let callCount = 0;
-    const compactionMaxCompletionTokens: unknown[] = [];
+    const compactionMaxCompletionTokens: Array<number | undefined> = [];
     const generate: GenerateFn = async (provider, _system, _tools, _history, callbacks) => {
       callCount += 1;
       if (callCount === 1) {
@@ -2325,12 +2325,13 @@ function oauthTestAgentOptions(
   };
 }
 
-function providerMaxCompletionTokens(provider: Parameters<GenerateFn>[0]): unknown {
-  return (
+function providerMaxCompletionTokens(provider: Parameters<GenerateFn>[0]): number | undefined {
+  const value = (
     provider as {
       readonly modelParameters?: Record<string, unknown>;
     }
   ).modelParameters?.['max_completion_tokens'];
+  return typeof value === 'number' ? value : undefined;
 }
 
 function textResult(text: string): Awaited<ReturnType<GenerateFn>> {

--- a/packages/agent-core/test/agent/compaction/full.test.ts
+++ b/packages/agent-core/test/agent/compaction/full.test.ts
@@ -1988,6 +1988,46 @@ describe('FullCompaction', () => {
     expect(compactionMaxCompletionTokens).toEqual([8192]);
   });
 
+  it('honors model maxOutputSize during compaction', async () => {
+    let callCount = 0;
+    const compactionMaxCompletionTokens: unknown[] = [];
+    const generate: GenerateFn = async (provider, _system, _tools, _history, callbacks) => {
+      callCount += 1;
+      if (callCount === 1) {
+        throw new APIContextOverflowError(400, 'Context length exceeded', 'req-model-output-cap');
+      }
+      if (callCount === 2) {
+        compactionMaxCompletionTokens.push(providerMaxCompletionTokens(provider));
+        return textResult('Model output cap compacted summary.');
+      }
+      await callbacks?.onMessagePart?.({
+        type: 'text',
+        text: 'Recovered with model output cap.',
+      });
+      return textResult('Recovered with model output cap.');
+    };
+    const ctx = testAgent({ generate });
+    ctx.configure({
+      provider: CATALOGUED_PROVIDER,
+      modelCapabilities: CATALOGUED_MODEL_CAPABILITIES,
+    });
+    const providerManager = ctx.agent.modelProvider;
+    if (providerManager === undefined) throw new Error('Expected provider manager');
+    const resolveProviderConfig = providerManager.resolveProviderConfig.bind(providerManager);
+    providerManager.resolveProviderConfig = (model) => ({
+      ...resolveProviderConfig(model),
+      maxOutputSize: 32768,
+    });
+    ctx.appendExchange(1, 'old user one', 'old assistant one', 20);
+    ctx.newEvents();
+
+    await ctx.rpc.prompt({ input: [{ type: 'text', text: 'Retry with model output cap' }] });
+    await ctx.untilTurnEnd();
+
+    expect(callCount).toBe(3);
+    expect(compactionMaxCompletionTokens).toEqual([32768]);
+  });
+
   it('honors completion budget env opt-out during compaction', async () => {
     vi.stubEnv('KIMI_MODEL_MAX_COMPLETION_TOKENS', '0');
     let callCount = 0;


### PR DESCRIPTION
## Related Issue

Related to #794 (compaction `APIContextOverflowError`). This fixes a reproducible full-history compaction failure when a model alias has a larger context window than output-token limit.

## Problem

Full compaction reused the selected model provider but resolved its completion budget without the model output cap. Any model alias with `max_context_size` greater than `max_output_size` could make compaction request a token budget above the provider limit and fail before producing a summary.

## What changed

- Pass the selected model output cap into full-compaction budget resolution.
- Add a regression test that covers compaction after a context-overflow-triggered retry.
- Add a patch changeset for the CLI package because the internal fix affects bundled CLI behavior.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.

Verification:

- `pnpm exec vitest run packages/agent-core/test/agent/compaction/full.test.ts packages/agent-core/test/utils/completion-budget.test.ts --config vitest.config.ts`
