### PR TITLE
fix(agent-core): restore turn counter from loop events on resume

### DIFF
--- a/.changeset/resume-turn-id-counter.md
+++ b/.changeset/resume-turn-id-counter.md
@@ -1,0 +1,6 @@
+---
+"@moonshot-ai/agent-core": patch
+"@moonshot-ai/kimi-code": patch
+---
+
+Restore the turn counter from persisted loop events on resume so post-resume turns no longer reuse turn ids that already appear in history.

--- a/packages/agent-core/src/agent/records/index.ts
+++ b/packages/agent-core/src/agent/records/index.ts
@@ -89,6 +89,15 @@ function restoreAgentRecord(agent: Agent, input: AgentRecord): void {
       return;
     case 'context.append_loop_event':
       agent.context.appendLoopEvent(input.event);
+      // Advance the turn counter past internally-driven turns (goal
+      // continuations, steer-launched turns) that allocate a turnId without a
+      // `turn.prompt` record. Their loop events still carry the real turnId.
+      if ('turnId' in input.event) {
+        const restoredTurnId = Number.parseInt(input.event.turnId, 10);
+        if (!Number.isNaN(restoredTurnId)) {
+          agent.turn.observeRestoredTurnId(restoredTurnId);
+        }
+      }
       return;
     case 'context.clear':
       agent.context.clear();

--- a/packages/agent-core/src/agent/turn/index.ts
+++ b/packages/agent-core/src/agent/turn/index.ts
@@ -193,6 +193,21 @@ export class TurnFlow {
     this.activeTurn = 'resuming';
   }
 
+  /**
+   * Raise the turn counter to cover a turnId observed in a replayed loop event.
+   * This is the authoritative source of the restored counter: every turn that
+   * ran — a prompted turn, a goal continuation, or a steer-launched turn —
+   * emits loop events carrying its real turnId, even though only prompted turns
+   * write a `turn.prompt` record. Resuming then continues from `max + 1`. Only
+   * ever raises the counter, never lowers it, so the live path (where `turnId`
+   * is already allocated before any loop event) is unaffected.
+   */
+  observeRestoredTurnId(turnId: number): void {
+    if (Number.isInteger(turnId) && turnId > this.turnId) {
+      this.turnId = turnId;
+    }
+  }
+
   restoreSteer(input: readonly ContentPart[], origin: PromptOrigin): void {
     if (this.activeTurn) {
       this.steerBuffer.push({ input, origin });

--- a/packages/agent-core/test/agent/resume.test.ts
+++ b/packages/agent-core/test/agent/resume.test.ts
@@ -85,6 +85,82 @@ describe('Agent resume', () => {
     `);
   });
 
+  it('allocates monotonically increasing turnIds across multiple historical turns on resume', async () => {
+    const persistence = new RecordingAgentPersistence(multiTurnResumeHistory());
+    const ctx = testAgent({ persistence });
+
+    await ctx.agent.resume();
+
+    // History ran turnId 0 and 1, so the counter must be restored to 1.
+    expect(ctx.agent.turn.currentId).toBe(1);
+
+    // After 2 historical turns (turnId 0 and 1), the next fresh turn must be 2.
+    ctx.mockNextResponse({ type: 'text', text: 'Fresh response.' });
+    await ctx.rpc.prompt({ input: [{ type: 'text', text: 'Fresh prompt' }] });
+    await ctx.untilTurnEnd();
+
+    expect(findRpcEvent(ctx.allEvents, 'turn.started')?.args).toMatchObject({ turnId: 2 });
+    expect(findRpcEvent(ctx.allEvents, 'turn.ended')?.args).toMatchObject({
+      turnId: 2,
+      reason: 'completed',
+    });
+  });
+
+  it('restores the turn counter past goal-continuation turns that have no turn.prompt record', async () => {
+    // A goal drive allocates a fresh turnId per continuation turn but only the
+    // first turn has a `turn.prompt` record — the continuations are driven
+    // internally. The persisted loop events still carry the real turnId, so the
+    // counter must be restored from them, not from the prompt records alone.
+    const persistence = new RecordingAgentPersistence(goalContinuationResumeHistory());
+    const ctx = testAgent({ persistence });
+
+    await ctx.agent.resume();
+
+    // History ran turnId 0 (prompted) plus continuation turns 1 and 2.
+    expect(ctx.agent.turn.currentId).toBe(2);
+
+    ctx.mockNextResponse({ type: 'text', text: 'Fresh response after goal resume.' });
+    await ctx.rpc.prompt({ input: [{ type: 'text', text: 'Fresh prompt after goal' }] });
+    await ctx.untilTurnEnd();
+
+    expect(findRpcEvent(ctx.allEvents, 'turn.started')?.args).toMatchObject({ turnId: 3 });
+    expect(findRpcEvent(ctx.allEvents, 'turn.ended')?.args).toMatchObject({
+      turnId: 3,
+      reason: 'completed',
+    });
+  });
+
+  it('keeps turnIds monotonic across repeated resume cycles', async () => {
+    // Mirrors a real session that was cold-started several times: each resume
+    // must continue the counter, never restart it and collide with history.
+    const persistence = new RecordingAgentPersistence(multiTurnResumeHistory());
+    const ctx = testAgent({ persistence });
+
+    await ctx.agent.resume();
+    ctx.mockNextResponse({ type: 'text', text: 'Response in cycle 1.' });
+    await ctx.rpc.prompt({ input: [{ type: 'text', text: 'Prompt in cycle 1' }] });
+    await ctx.untilTurnEnd();
+    expect(ctx.agent.turn.currentId).toBe(2);
+
+    // Cold-start again from everything persisted so far (history + the turn just
+    // run). The fresh agent must restore the counter to 2 and allocate 3 next.
+    const persistence2 = new RecordingAgentPersistence(persistence.records);
+    const ctx2 = testAgent({ persistence: persistence2 });
+
+    await ctx2.agent.resume();
+    expect(ctx2.agent.turn.currentId).toBe(2);
+
+    ctx2.mockNextResponse({ type: 'text', text: 'Response in cycle 2.' });
+    await ctx2.rpc.prompt({ input: [{ type: 'text', text: 'Prompt in cycle 2' }] });
+    await ctx2.untilTurnEnd();
+
+    expect(findRpcEvent(ctx2.allEvents, 'turn.started')?.args).toMatchObject({ turnId: 3 });
+    expect(findRpcEvent(ctx2.allEvents, 'turn.ended')?.args).toMatchObject({
+      turnId: 3,
+      reason: 'completed',
+    });
+  });
+
   it('replays inline skill reminders after pending tool results before the next prompt', async () => {
     const persistence = new RecordingAgentPersistence(resumeDeferredSystemReminderHistory());
     const ctx = testAgent({ persistence });
@@ -1025,6 +1101,96 @@ function resumeDeferredSystemReminderHistory(): AgentRecord[] {
     },
   ];
 }
+
+function resumeConfigRecord(): AgentRecord {
+  return {
+    type: 'config.update',
+    cwd: process.cwd(),
+    modelAlias: MOCK_PROVIDER.model,
+    systemPrompt: DEFAULT_TEST_SYSTEM_PROMPT,
+    thinkingLevel: 'off',
+  };
+}
+
+// Loop events for one fully-run turn: a single step that emits text and ends.
+// Used to represent both prompted turns and internal (goal-continuation) turns.
+function loopEventsForTurn(turnId: string, responseText: string): AgentRecord[] {
+  return [
+    {
+      type: 'context.append_loop_event',
+      event: { type: 'step.begin', uuid: `step-${turnId}`, turnId, step: 1 },
+    },
+    {
+      type: 'context.append_loop_event',
+      event: {
+        type: 'content.part',
+        uuid: `content-${turnId}`,
+        turnId,
+        step: 1,
+        stepUuid: `step-${turnId}`,
+        part: { type: 'text', text: responseText },
+      },
+    },
+    {
+      type: 'context.append_loop_event',
+      event: {
+        type: 'step.end',
+        uuid: `step-${turnId}`,
+        turnId,
+        step: 1,
+        usage: { inputOther: 5, output: 2, inputCacheRead: 0, inputCacheCreation: 0 },
+        finishReason: 'end_turn',
+      },
+    },
+    {
+      type: 'usage.record',
+      model: MOCK_PROVIDER.model,
+      usage: { inputOther: 5, output: 2, inputCacheRead: 0, inputCacheCreation: 0 },
+    },
+  ];
+}
+
+// A prompted turn: the `turn.prompt` record + the appended user message + the
+// loop events the turn produced.
+function minimalPromptedTurn(turnId: string, promptText: string, responseText: string): AgentRecord[] {
+  return [
+    {
+      type: 'turn.prompt',
+      input: [{ type: 'text', text: promptText }],
+      origin: { kind: 'user' },
+    },
+    {
+      type: 'context.append_message',
+      message: {
+        role: 'user',
+        content: [{ type: 'text', text: promptText }],
+        toolCalls: [],
+        origin: { kind: 'user' },
+      },
+    },
+    ...loopEventsForTurn(turnId, responseText),
+  ];
+}
+
+function multiTurnResumeHistory(): AgentRecord[] {
+  return [
+    resumeConfigRecord(),
+    ...minimalPromptedTurn('0', 'First historical prompt', 'First historical response.'),
+    ...minimalPromptedTurn('1', 'Second historical prompt', 'Second historical response.'),
+  ];
+}
+
+// One prompted turn (turnId 0) followed by two goal-continuation turns (1, 2)
+// that have NO turn.prompt record — only loop events carry their turnId.
+function goalContinuationResumeHistory(): AgentRecord[] {
+  return [
+    resumeConfigRecord(),
+    ...minimalPromptedTurn('0', 'Goal prompt', 'Starting the goal.'),
+    ...loopEventsForTurn('1', 'Continuation turn one.'),
+    ...loopEventsForTurn('2', 'Continuation turn two.'),
+  ];
+}
+
 
 function findRpcEvent(
   ctxEvents: readonly { type: string; event: string; args: unknown }[],


### PR DESCRIPTION
## Problem

On cold-start resume, the turn counter was rebuilt by counting `turn.prompt` records. But `restorePrompt()` set `activeTurn = 'resuming'` on the first record and then early-returned for every subsequent one, so only **one** historical turn advanced `turnId` no matter how many actually ran. After resume, the next prompt reused ids already present in history — emitting duplicate `turnId`s across the session.

This was verified against real `wire.jsonl` sessions. In one, history ran turns `0,1,2,3,4`; after a resume the next turns came out `1,2,3,4,5`, colliding with `1–4`. The same reset signature appears in several other sessions, including one with multiple resume cycles.

The existing resume test only covered a single historical `turn.prompt`, where the off-by-N happened to land on the expected value — so it passed and the bug went unnoticed.

## Fix

Derive the restored counter from the persisted loop events rather than from counting prompt records. Every turn that ran — prompted, goal continuation, or steer-launched — emits loop events carrying its real `turnId`, even though only prompted turns write a `turn.prompt` record. `observeRestoredTurnId()` raises the counter to the max `turnId` seen during `context.append_loop_event` replay, so resume continues from `max + 1`.

- Only ever **raises** the counter, so the live path (where `turnId` is already allocated before any loop event) is unaffected.
- Runs **only on the resume path**; live loop events take a different path and pay nothing.
- $O(1)$ work per already-iterated record — no extra pass.
- Also covers goal-continuation turns, which allocate a `turnId` without any `turn.prompt` record.
- Self-healing: resuming an already-affected session continues past the highest id ever recorded, so no future collisions.

## Tests

Added resume coverage that fails against the old code and passes with the fix:
- multiple prompted historical turns (counter restored to the true max),
- goal-continuation turns with no `turn.prompt` record,
- repeated resume cycles (counter never restarts).

Full `agent-core` suite passes; typecheck clean.