### PR TITLE
fix: classify OAuth token refresh errors by cause

### DIFF
--- a/.changeset/auth-refresh-retry.md
+++ b/.changeset/auth-refresh-retry.md
@@ -1,0 +1,8 @@
+---
+"@moonshot-ai/agent-core": patch
+"@moonshot-ai/kimi-code-oauth": patch
+"@moonshot-ai/kimi-code-sdk": patch
+"@moonshot-ai/kimi-code": patch
+---
+
+Show the underlying connection error when OAuth token refresh fails after internal retries, instead of prompting for login. Token refresh failures are no longer re-retried at the agent loop level.

--- a/packages/agent-core/src/session/provider-manager.ts
+++ b/packages/agent-core/src/session/provider-manager.ts
@@ -163,10 +163,13 @@ export class ProviderManager implements ModelProvider {
       try {
         apiKey = await tokenProvider.getAccessToken(force ? { force: true } : undefined);
       } catch (error) {
+        // login-required is an expected state (the user must /login); don't
+        // warn. Other failures (connection errors, etc.) are logged once for
+        // diagnosis and then propagated — chatWithRetry does not retry them.
         if (!isKimiError(error) || error.code !== ErrorCodes.AUTH_LOGIN_REQUIRED) {
           log?.warn('oauth token fetch failed', { providerName, error });
         }
-        throw loginRequired(error);
+        throw error;
       }
       if (apiKey.trim().length === 0) throw loginRequired();
       return { apiKey };

--- a/packages/agent-core/test/agent/turn.test.ts
+++ b/packages/agent-core/test/agent/turn.test.ts
@@ -18,6 +18,7 @@ import { describe, expect, it, vi } from 'vitest';
 import { HookEngine } from '../../src/session/hooks';
 import { abortError } from '../../src/utils/abort';
 import type { AgentOptions } from '../../src/agent';
+import { ErrorCodes, KimiError } from '../../src/errors';
 import type { Logger, LogPayload } from '../../src/logging';
 import type {
   QueuedSubagentRunResult,
@@ -1064,11 +1065,14 @@ describe('Agent turn flow', () => {
     expect(requestPayload).not.toHaveProperty('estimatedInputTokens');
   });
 
-  it('classifies OAuth resolver failures as auth errors', async () => {
+  it('classifies OAuth resolver connection failures as provider connection errors without retrying', async () => {
     const tokenCalls: Array<boolean | undefined> = [];
     const oauthOptions = oauthAgentOptions(async (options) => {
       tokenCalls.push(options?.force);
-      throw new Error('refresh token expired');
+      throw new KimiError(
+        ErrorCodes.PROVIDER_CONNECTION_ERROR,
+        'OAuth provider "managed:kimi-code" failed to fetch an access token: fetch failed',
+      );
     });
     const generate = vi.fn<GenerateFn>();
     const ctx = testAgent({ ...oauthOptions, generate });
@@ -1088,7 +1092,41 @@ describe('Agent turn flow', () => {
         args: expect.objectContaining({
           reason: 'failed',
           error: expect.objectContaining({
-            code: 'auth.login_required',
+            code: ErrorCodes.PROVIDER_CONNECTION_ERROR,
+            message: expect.stringContaining('fetch failed'),
+            retryable: true,
+          }),
+        }),
+      }),
+    );
+  });
+
+  it('classifies explicit OAuth login-required resolver failures as auth errors', async () => {
+    const tokenCalls: Array<boolean | undefined> = [];
+    const oauthOptions = oauthAgentOptions(async (options) => {
+      tokenCalls.push(options?.force);
+      throw new KimiError(ErrorCodes.AUTH_LOGIN_REQUIRED, 'not logged in');
+    });
+    const generate = vi.fn<GenerateFn>();
+    const ctx = testAgent({ ...oauthOptions, generate });
+    ctx.configure();
+    await ctx.rpc.setModel({ model: 'kimi-code' });
+    ctx.newEvents();
+
+    await ctx.rpc.prompt({ input: [{ type: 'text', text: 'hello after token expiry' }] });
+    const events = await ctx.untilTurnEnd();
+
+    expect(tokenCalls).toEqual([undefined]);
+    expect(generate).not.toHaveBeenCalled();
+    expect(events).not.toContainEqual(expect.objectContaining({ event: 'assistant.delta' }));
+    expect(events).toContainEqual(
+      expect.objectContaining({
+        event: 'turn.ended',
+        args: expect.objectContaining({
+          reason: 'failed',
+          error: expect.objectContaining({
+            code: ErrorCodes.AUTH_LOGIN_REQUIRED,
+            retryable: false,
           }),
         }),
       }),

--- a/packages/agent-core/test/harness/runtime-provider.test.ts
+++ b/packages/agent-core/test/harness/runtime-provider.test.ts
@@ -653,6 +653,57 @@ describe('ProviderManager prompt cache key', () => {
   });
 });
 
+describe('ProviderManager OAuth auth', () => {
+  function oauthConfig(): KimiConfig {
+    return {
+      ...BASE_CONFIG,
+      providers: {
+        'managed:kimi-code': {
+          type: 'kimi',
+          apiKey: '',
+          baseUrl: 'https://api.example/v1',
+          oauth: { storage: 'file', key: 'oauth/kimi-code' },
+        },
+      },
+    };
+  }
+
+  it('preserves non-Kimi token fetch failures instead of guessing their category', async () => {
+    const tokenError = new Error('token storage permission denied');
+    const manager = new ProviderManager({
+      config: oauthConfig(),
+      resolveOAuthTokenProvider: () => ({
+        async getAccessToken() {
+          throw tokenError;
+        },
+      }),
+    });
+
+    const resolveAuth = manager.resolveAuth('kimi-code/kimi-for-coding');
+    expect(resolveAuth).toBeDefined();
+
+    await expect(resolveAuth!(async () => 'ok')).rejects.toBe(tokenError);
+  });
+
+  it('keeps explicit login-required token failures as login-required errors', async () => {
+    const manager = new ProviderManager({
+      config: oauthConfig(),
+      resolveOAuthTokenProvider: () => ({
+        async getAccessToken() {
+          throw new KimiError(ErrorCodes.AUTH_LOGIN_REQUIRED, 'not logged in');
+        },
+      }),
+    });
+
+    const resolveAuth = manager.resolveAuth('kimi-code/kimi-for-coding');
+    expect(resolveAuth).toBeDefined();
+
+    await expect(resolveAuth!(async () => 'ok')).rejects.toMatchObject({
+      code: ErrorCodes.AUTH_LOGIN_REQUIRED,
+    });
+  });
+});
+
 describe('resolveThinkingLevel', () => {
   it('normalizes requested thinking into a concrete effort', () => {
     expect(

--- a/packages/agent-core/test/loop/retry.test.ts
+++ b/packages/agent-core/test/loop/retry.test.ts
@@ -1,8 +1,11 @@
 import { APIConnectionError, emptyUsage, isRetryableGenerateError } from '@moonshot-ai/kosong';
 import { describe, expect, it } from 'vitest';
 
+import type { KimiConfig } from '#/config';
+import { ErrorCodes, KimiError } from '#/errors';
 import type { LLM, LLMChatParams, LLMChatResponse } from '#/loop/llm';
 import { chatWithRetry } from '#/loop/retry';
+import { ProviderManager } from '#/session/provider-manager';
 
 function okResponse(): LLMChatResponse {
   return { toolCalls: [], usage: emptyUsage() };
@@ -67,4 +70,60 @@ describe('chatWithRetry: terminated stream drops', () => {
     });
     expect(calls).toBe(1);
   });
+
+  it('does not retry OAuth token fetch connection errors (already retried internally)', async () => {
+    let tokenCalls = 0;
+    const manager = new ProviderManager({
+      config: oauthConfig(),
+      resolveOAuthTokenProvider: () => ({
+        async getAccessToken() {
+          tokenCalls += 1;
+          throw new KimiError(
+            ErrorCodes.PROVIDER_CONNECTION_ERROR,
+            'OAuth provider "managed:kimi-code" failed to fetch an access token: fetch failed',
+          );
+        },
+      }),
+    });
+    const resolveAuth = manager.resolveAuth('kimi-code/kimi-for-coding');
+    if (resolveAuth === undefined) throw new Error('expected OAuth auth resolver');
+
+    let chatCalls = 0;
+    const llm: LLM = {
+      systemPrompt: '',
+      modelName: 'mock',
+      isRetryableError: (e) => isRetryableGenerateError(e),
+      async chat(_params: LLMChatParams): Promise<LLMChatResponse> {
+        chatCalls += 1;
+        return resolveAuth(async () => okResponse());
+      },
+    };
+
+    await expect(chatWithRetry(makeInput(llm, new AbortController().signal))).rejects.toMatchObject({
+      code: ErrorCodes.PROVIDER_CONNECTION_ERROR,
+    });
+    expect(chatCalls).toBe(1);
+    expect(tokenCalls).toBe(1);
+  });
 });
+
+function oauthConfig(): KimiConfig {
+  return {
+    defaultModel: 'kimi-code/kimi-for-coding',
+    providers: {
+      'managed:kimi-code': {
+        type: 'kimi',
+        apiKey: '',
+        baseUrl: 'https://api.example/v1',
+        oauth: { storage: 'file', key: 'oauth/kimi-code' },
+      },
+    },
+    models: {
+      'kimi-code/kimi-for-coding': {
+        provider: 'managed:kimi-code',
+        model: 'kimi-for-coding',
+        maxContextSize: 1_000_000,
+      },
+    },
+  };
+}

--- a/packages/node-sdk/src/auth.ts
+++ b/packages/node-sdk/src/auth.ts
@@ -23,6 +23,8 @@ import {
   type OAuthRefreshOutcome,
 } from '@moonshot-ai/kimi-code-oauth';
 
+import { mapOAuthTokenError } from '#/oauth-error';
+
 export interface KimiAuthSubmitFeedbackInput {
   readonly content: string;
   readonly sessionId: string;
@@ -170,7 +172,21 @@ export class KimiAuthFacade {
     providerName: string,
     oauthRef?: OAuthRef | undefined,
   ): BearerTokenProvider => {
-    return this.toolkit.tokenProvider(providerName, this.runtimeOAuthRef(providerName, oauthRef));
+    const provider = this.toolkit.tokenProvider(
+      providerName,
+      this.runtimeOAuthRef(providerName, oauthRef),
+    );
+    return {
+      getAccessToken: async (options) => {
+        try {
+          return await provider.getAccessToken(options);
+        } catch (error) {
+          // Classify OAuth token failures into the public KimiError protocol;
+          // unrecognized errors are rethrown raw (see mapOAuthTokenError).
+          throw mapOAuthTokenError(error, providerName) ?? error;
+        }
+      },
+    };
   };
 
   private resolveManagedAuth(providerName?: string | undefined): {

--- a/packages/node-sdk/src/kimi-code-model-provider.ts
+++ b/packages/node-sdk/src/kimi-code-model-provider.ts
@@ -22,6 +22,8 @@ import type {
 } from '@moonshot-ai/kosong';
 import { APIStatusError, UNKNOWN_CAPABILITY } from '@moonshot-ai/kosong';
 
+import { mapOAuthTokenError } from '#/oauth-error';
+
 export interface KimiForCodingProviderOptions extends KimiHostIdentity {
   readonly homeDir?: string;
   readonly model?: string;
@@ -119,10 +121,18 @@ export class KimiForCodingProvider implements ModelProvider {
   }
 
   private async buildAuth(force: boolean): Promise<ProviderRequestAuth> {
-    const apiKey = await this.toolkit.ensureFresh(KIMI_CODE_PROVIDER_NAME, {
-      force,
-      oauthRef: this.oauthRef,
-    });
-    return { apiKey };
+    try {
+      const apiKey = await this.toolkit.ensureFresh(KIMI_CODE_PROVIDER_NAME, {
+        force,
+        oauthRef: this.oauthRef,
+      });
+      return { apiKey };
+    } catch (error) {
+      // Classify OAuth token failures into the public KimiError protocol so the
+      // turn surfaces `auth.login_required` / `provider.connection_error`
+      // instead of collapsing everything to `internal`. Unrecognized errors are
+      // rethrown raw (see mapOAuthTokenError).
+      throw mapOAuthTokenError(error, KIMI_CODE_PROVIDER_NAME) ?? error;
+    }
   }
 }

--- a/packages/node-sdk/src/oauth-error.ts
+++ b/packages/node-sdk/src/oauth-error.ts
@@ -1,0 +1,41 @@
+import { ErrorCodes, KimiError } from '@moonshot-ai/agent-core';
+import {
+  OAuthConnectionError,
+  OAuthUnauthorizedError,
+  RetryableRefreshError,
+} from '@moonshot-ai/kimi-code-oauth';
+
+/**
+ * Classify an OAuth token-fetch failure into the public {@link KimiError}
+ * protocol so callers (turn serialization, SDK clients, ACP) can react on
+ * `code` rather than on class identity.
+ *
+ * Only errors we can positively identify are mapped:
+ *  - `OAuthUnauthorizedError` → `auth.login_required` (drive the user through
+ *    `/login`).
+ *  - `OAuthConnectionError` / `RetryableRefreshError` →
+ *    `provider.connection_error` (transient; the user can retry).
+ *
+ * Anything else returns `undefined` so the caller rethrows it raw and lets it
+ * surface as `internal` with the original message preserved. We deliberately do
+ * **not** guess a category for unrecognized errors — masking e.g. a storage or
+ * lock failure as `auth.login_required` would send the user down the wrong
+ * remediation path.
+ */
+export function mapOAuthTokenError(error: unknown, providerName: string): KimiError | undefined {
+  if (error instanceof OAuthUnauthorizedError) {
+    return new KimiError(
+      ErrorCodes.AUTH_LOGIN_REQUIRED,
+      `OAuth provider "${providerName}" requires login before it can be used.`,
+      { cause: error },
+    );
+  }
+  if (error instanceof OAuthConnectionError || error instanceof RetryableRefreshError) {
+    return new KimiError(
+      ErrorCodes.PROVIDER_CONNECTION_ERROR,
+      `OAuth provider "${providerName}" failed to fetch an access token: ${error.message}`,
+      { cause: error },
+    );
+  }
+  return undefined;
+}

--- a/packages/node-sdk/test/auth-facade.test.ts
+++ b/packages/node-sdk/test/auth-facade.test.ts
@@ -5,13 +5,17 @@ import { join } from 'node:path';
 import {
   FileTokenStorage,
   KIMI_CODE_PROVIDER_NAME,
+  KimiOAuthToolkit,
+  OAuthConnectionError,
+  OAuthError,
+  RetryableRefreshError,
   resolveKimiCodeOAuthKey,
   resolveKimiTokenStorageName,
   type TokenInfo,
 } from '@moonshot-ai/kimi-code-oauth';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { createKimiHarness } from '#/index';
+import { createKimiHarness, ErrorCodes, KimiError } from '#/index';
 
 import { ProviderManager } from '../../agent-core/src/session/provider-manager';
 import { TEST_IDENTITY } from './test-identity';
@@ -60,6 +64,70 @@ describe('KimiHarness.auth', () => {
     const harness = createKimiHarness({ homeDir, identity: TEST_IDENTITY });
 
     await expect(harness.auth.getCachedAccessToken()).resolves.toBe('oauth-access-token');
+  });
+
+  it('maps missing runtime OAuth tokens to login-required errors', async () => {
+    const harness = createKimiHarness({ homeDir, identity: TEST_IDENTITY });
+
+    await expect(
+      harness.auth.resolveOAuthTokenProvider(KIMI_CODE_PROVIDER_NAME).getAccessToken(),
+    ).rejects.toMatchObject({
+      code: ErrorCodes.AUTH_LOGIN_REQUIRED,
+    });
+  });
+
+  it('maps transient OAuth token failures to provider connection errors', async () => {
+    const tokenErrors = [
+      new OAuthConnectionError('OAuth request failed: fetch failed'),
+      new RetryableRefreshError('Token refresh failed (HTTP 503).'),
+    ];
+
+    for (const tokenError of tokenErrors) {
+      const tokenProviderSpy = vi
+        .spyOn(KimiOAuthToolkit.prototype, 'tokenProvider')
+        .mockReturnValue({
+          async getAccessToken() {
+            throw tokenError;
+          },
+        });
+      try {
+        const harness = createKimiHarness({ homeDir, identity: TEST_IDENTITY });
+
+        const error = await harness.auth
+          .resolveOAuthTokenProvider(KIMI_CODE_PROVIDER_NAME)
+          .getAccessToken()
+          .catch((caught: unknown) => caught);
+
+        expect(error).toBeInstanceOf(KimiError);
+        expect(error).toMatchObject({
+          code: ErrorCodes.PROVIDER_CONNECTION_ERROR,
+          message: expect.stringContaining(tokenError.message),
+          cause: tokenError,
+        });
+      } finally {
+        tokenProviderSpy.mockRestore();
+      }
+    }
+  });
+
+  it('preserves non-retryable OAuth refresh failures', async () => {
+    const oauthError = new OAuthError('bad client id');
+    const tokenProviderSpy = vi
+      .spyOn(KimiOAuthToolkit.prototype, 'tokenProvider')
+      .mockReturnValue({
+        async getAccessToken() {
+          throw oauthError;
+        },
+      });
+    try {
+      const harness = createKimiHarness({ homeDir, identity: TEST_IDENTITY });
+
+      await expect(
+        harness.auth.resolveOAuthTokenProvider(KIMI_CODE_PROVIDER_NAME).getAccessToken(),
+      ).rejects.toBe(oauthError);
+    } finally {
+      tokenProviderSpy.mockRestore();
+    }
   });
 
   it('resolves managed auth from a partially invalid config without throwing', async () => {

--- a/packages/node-sdk/test/kimi-code-model-provider.test.ts
+++ b/packages/node-sdk/test/kimi-code-model-provider.test.ts
@@ -1,0 +1,76 @@
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import {
+  KimiOAuthToolkit,
+  OAuthConnectionError,
+  OAuthError,
+  OAuthUnauthorizedError,
+  RetryableRefreshError,
+} from '@moonshot-ai/kimi-code-oauth';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { ErrorCodes, KimiError, KimiForCodingProvider } from '#/index';
+
+import { TEST_IDENTITY } from './test-identity';
+
+describe('KimiForCodingProvider OAuth error mapping', () => {
+  let homeDir: string;
+
+  beforeEach(async () => {
+    homeDir = await mkdtemp(join(tmpdir(), 'kimi-for-coding-provider-'));
+  });
+
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    await rm(homeDir, { recursive: true, force: true });
+  });
+
+  function resolveAuth() {
+    const provider = new KimiForCodingProvider({ homeDir, ...TEST_IDENTITY });
+    return provider.resolveAuth('kimi-for-coding');
+  }
+
+  it('maps unauthorized token failures to auth.login_required', async () => {
+    vi.spyOn(KimiOAuthToolkit.prototype, 'ensureFresh').mockRejectedValue(
+      new OAuthUnauthorizedError('No token for "kimi-code". Run /login to authenticate.'),
+    );
+
+    const auth = resolveAuth();
+    await expect(auth(async () => 'ok')).rejects.toMatchObject({
+      code: ErrorCodes.AUTH_LOGIN_REQUIRED,
+    });
+  });
+
+  it('maps transient token failures to provider.connection_error', async () => {
+    const tokenErrors = [
+      new OAuthConnectionError('OAuth request to https://example.test failed: fetch failed'),
+      new RetryableRefreshError('Token refresh failed (HTTP 503).'),
+    ];
+
+    for (const tokenError of tokenErrors) {
+      vi.spyOn(KimiOAuthToolkit.prototype, 'ensureFresh').mockRejectedValue(tokenError);
+
+      const auth = resolveAuth();
+      const caught = await auth(async () => 'ok').catch((error: unknown) => error);
+
+      expect(caught).toBeInstanceOf(KimiError);
+      expect(caught).toMatchObject({
+        code: ErrorCodes.PROVIDER_CONNECTION_ERROR,
+        message: expect.stringContaining(tokenError.message),
+        cause: tokenError,
+      });
+
+      vi.restoreAllMocks();
+    }
+  });
+
+  it('rethrows unrecognized OAuth errors raw instead of guessing a category', async () => {
+    const oauthError = new OAuthError('Token refresh failed (HTTP 400).');
+    vi.spyOn(KimiOAuthToolkit.prototype, 'ensureFresh').mockRejectedValue(oauthError);
+
+    const auth = resolveAuth();
+    await expect(auth(async () => 'ok')).rejects.toBe(oauthError);
+  });
+});

--- a/packages/oauth/src/errors.ts
+++ b/packages/oauth/src/errors.ts
@@ -5,6 +5,8 @@
  * callers react appropriately:
  *  - `OAuthUnauthorizedError`: 401/403 from token endpoint → refresh_token
  *    or credentials are bad; drive user through `/login` again.
+ *  - `OAuthConnectionError`: transport-level OAuth request failure; callers
+ *    may retry the operation.
  *  - `DeviceCodeExpiredError`: device_code TTL ran out before user approved;
  *    restart the device flow.
  *  - `DeviceCodeTimeoutError`: local 15 min wall-clock budget exhausted
@@ -24,6 +26,13 @@ export class OAuthUnauthorizedError extends OAuthError {
   constructor(message: string) {
     super(message);
     this.name = 'OAuthUnauthorizedError';
+  }
+}
+
+export class OAuthConnectionError extends OAuthError {
+  constructor(message: string) {
+    super(message);
+    this.name = 'OAuthConnectionError';
   }
 }
 

--- a/packages/oauth/src/index.ts
+++ b/packages/oauth/src/index.ts
@@ -1,6 +1,7 @@
 export {
   DeviceCodeExpiredError,
   DeviceCodeTimeoutError,
+  OAuthConnectionError,
   OAuthError,
   OAuthUnauthorizedError,
   RetryableRefreshError,

--- a/packages/oauth/src/oauth-manager.ts
+++ b/packages/oauth/src/oauth-manager.ts
@@ -285,7 +285,9 @@ export class OAuthManager {
     const initial = await this.loadState();
     switch (initial.kind) {
       case 'missing':
-        throw new OAuthError(`No token for "${this.config.name}". Run /login to authenticate.`);
+        throw new OAuthUnauthorizedError(
+          `No token for "${this.config.name}". Run /login to authenticate.`,
+        );
       case 'revoked':
         // A prior 401 (possibly from another process) tombstoned this token.
         // Surface as unauthorized so callers route into the re-login flow
@@ -353,7 +355,7 @@ export class OAuthManager {
       }
 
       if (activeToken.refreshToken.length === 0) {
-        throw new OAuthError(
+        throw new OAuthUnauthorizedError(
           `Token for "${this.config.name}" has no refresh_token; re-login required.`,
         );
       }

--- a/packages/oauth/src/oauth.ts
+++ b/packages/oauth/src/oauth.ts
@@ -11,7 +11,12 @@
  */
 
 import { extractApiErrorMessage } from './api-error';
-import { OAuthError, OAuthUnauthorizedError, RetryableRefreshError } from './errors';
+import {
+  OAuthConnectionError,
+  OAuthError,
+  OAuthUnauthorizedError,
+  RetryableRefreshError,
+} from './errors';
 import type { DeviceAuthorization, DeviceHeaders, OAuthFlowConfig, TokenInfo } from './types';
 import { isRecord } from './utils';
 
@@ -76,7 +81,7 @@ async function postForm(
       signal,
     });
   } catch (error) {
-    throw new OAuthError(
+    throw new OAuthConnectionError(
       `OAuth request to ${url} failed: ${error instanceof Error ? error.message : String(error)}`,
     );
   }

--- a/packages/oauth/test/oauth-manager.test.ts
+++ b/packages/oauth/test/oauth-manager.test.ts
@@ -319,6 +319,7 @@ describe('OAuthManager.ensureFresh', () => {
   it('throws when no stored token (caller should drive /login)', async () => {
     const storage = new InMemoryStorage();
     const mgr = new OAuthManager({ config, storage, now });
+    await expect(mgr.ensureFresh()).rejects.toBeInstanceOf(OAuthUnauthorizedError);
     await expect(mgr.ensureFresh()).rejects.toThrow(/no token/i);
   });
 

--- a/packages/oauth/test/oauth.test.ts
+++ b/packages/oauth/test/oauth.test.ts
@@ -10,7 +10,12 @@ import { createServer, type IncomingMessage, type Server, type ServerResponse } 
 
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
-import { RetryableRefreshError, OAuthError, OAuthUnauthorizedError } from '../src/errors';
+import {
+  OAuthConnectionError,
+  OAuthError,
+  OAuthUnauthorizedError,
+  RetryableRefreshError,
+} from '../src/errors';
 import {
   pollDeviceToken,
   refreshAccessToken,
@@ -567,7 +572,7 @@ describe('refreshAccessToken', () => {
     // Single attempt against unreachable host should throw (not RetryableRefreshError)
     await expect(
       refreshToken(badConfig, 'rt', { maxRetries: 1, backoffMs: () => 0 }),
-    ).rejects.toThrow(/OAuth request|fetch failed|Token refresh request|ECONNREFUSED|connect/i);
+    ).rejects.toBeInstanceOf(OAuthConnectionError);
   });
 
   it('sends grant_type=refresh_token + refresh_token', async () => {


### PR DESCRIPTION
<!--
Thank you for your contribution to Kimi Code!
Please open an issue before sending a feature PR — PRs without prior discussion may be closed without review.

See https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md for more.
-->

## Related Issue

No related issue — see Problem below.

## Problem

When an OAuth token refresh fails after its internal retries (for example a transient network error), the failure was misclassified and the real cause was hidden:

- the managed provider collapsed every token-fetch failure into `auth.login_required`, prompting the user to `/login` for what was actually a network hiccup;
- the standalone SDK provider collapsed the same failures into `internal`, telling the user to report a bug for a transient error.

Neither is actionable, and both sent users down the wrong path.

## What changed

Distinguish OAuth token-fetch failures by cause and map them to the existing public error codes:

- missing or revoked tokens, and 401/403 from the refresh endpoint -> `auth.login_required`
- transport failures, and 429/5xx that persist after the refresh helper's internal retries -> `provider.connection_error`
- anything else is rethrown as-is rather than guessed (it surfaces as `internal` with the original message preserved)

The refresh helper already retries internally, so the agent loop does not re-retry these at the loop level. Both the managed provider and the standalone SDK provider now share one mapping helper, so the two code paths report the same error code for the same failure. Tests were added for each mapping and for the no-retry guarantee.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.
