### PR TITLE
feat(agent-core): record context length before and after micro compaction

### DIFF
--- a/.changeset/record-micro-compaction-context-length.md
+++ b/.changeset/record-micro-compaction-context-length.md
@@ -1,0 +1,6 @@
+---
+"@moonshot-ai/agent-core": patch
+"@moonshot-ai/kimi-code": patch
+---
+
+Record context token length before and after micro compaction.

--- a/.changeset/record-micro-compaction-context-length.md
+++ b/.changeset/record-micro-compaction-context-length.md
@@ -1,6 +1,0 @@
----
-"@moonshot-ai/agent-core": patch
-"@moonshot-ai/kimi-code": patch
----
-
-Record context token length before and after micro compaction.

--- a/packages/agent-core/src/agent/compaction/micro.ts
+++ b/packages/agent-core/src/agent/compaction/micro.ts
@@ -2,7 +2,10 @@ import type { ContentPart } from '@moonshot-ai/kosong';
 
 import type { Agent } from '..';
 import type { ContextMessage } from '../context';
-import { estimateTokensForContentParts } from '../../utils/tokens';
+import {
+  estimateTokensForContentParts,
+  estimateTokensForMessages,
+} from '../../utils/tokens';
 
 export interface MicroCompactionConfig {
   keepRecentMessages: number;
@@ -65,9 +68,17 @@ export class MicroCompaction {
     this.apply(nextCutoff);
     if (previousCutoff !== nextCutoff) {
       const effect = this.measureEffect(history, nextCutoff);
+      // Whole-context length before/after trimming, mirroring the
+      // `tokensBefore`/`tokensAfter` fields on `compaction_finished` so the
+      // two compaction paths can be compared on the same axis.
+      const contextTokensBefore = estimateTokensForMessages(history);
+      const contextTokensAfter =
+        contextTokensBefore - effect.beforeTokens + effect.afterTokens;
       this.agent.telemetry.track('micro_compaction_applied', {
         ...config,
         ...effect,
+        contextTokensBefore,
+        contextTokensAfter,
         previous_cutoff: previousCutoff,
         cutoff: nextCutoff,
         message_count: history.length,

--- a/packages/agent-core/test/agent/compaction/micro.test.ts
+++ b/packages/agent-core/test/agent/compaction/micro.test.ts
@@ -480,9 +480,14 @@ describe('MicroCompaction', () => {
       truncatedToolResultCount: 2,
       beforeTokens: expect.any(Number),
       afterTokens: expect.any(Number),
+      contextTokensBefore: expect.any(Number),
+      contextTokensAfter: expect.any(Number),
     });
     expect(numberProperty(event, 'beforeTokens')).toBeGreaterThan(
       numberProperty(event, 'afterTokens'),
+    );
+    expect(numberProperty(event, 'contextTokensBefore')).toBeGreaterThan(
+      numberProperty(event, 'contextTokensAfter'),
     );
 
     expect(ctx.agent.context.messages).toHaveLength(9);


### PR DESCRIPTION
## Related Issue

No related issue.

## Problem

Full compaction already reports the estimated context length before and after compaction via the `tokensBefore` / `tokensAfter` fields on the `compaction_finished` telemetry event. Micro compaction only reported the token counts of the individual tool results it trimmed (`beforeTokens` / `afterTokens`), so there was no way to observe how the whole context length changed across a micro compaction, nor to compare the two compaction paths on the same axis.

## What changed

Added two fields to the `micro_compaction_applied` telemetry event, mirroring `tokensBefore` / `tokensAfter` on `compaction_finished`:

- `contextTokensBefore`: estimated token count of the whole context (history) before trimming.
- `contextTokensAfter`: estimated token count of the whole context after trimming.

The existing `beforeTokens` / `afterTokens` fields are kept unchanged for backwards compatibility. Full and micro compaction can now be compared on the same axis. The existing micro compaction telemetry test now asserts the new fields.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.
