### PR TITLE
fix: avoid inflated debug TPS

### DIFF
--- a/.changeset/fix-debug-tps.md
+++ b/.changeset/fix-debug-tps.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Report debug TPS over the full model response window so short tool-call streams do not show inflated rates.

--- a/apps/kimi-code/src/utils/usage/debug-timing.ts
+++ b/apps/kimi-code/src/utils/usage/debug-timing.ts
@@ -11,9 +11,12 @@ export function formatStepDebugTiming(input: StepTimingInput): string | undefine
 
   const parts: string[] = [`TTFT: ${formatDuration(latency)}`];
   const outputTokens = input.usage?.output;
-  if (outputTokens !== undefined && outputTokens > 0 && streamMs > 0) {
-    const tps = (outputTokens / (streamMs / 1000)).toFixed(1);
-    parts.push(`TPS: ${tps} tok/s (${outputTokens} tokens in ${formatDuration(streamMs)})`);
+  const totalMs = latency + streamMs;
+  if (outputTokens !== undefined && outputTokens > 0 && totalMs > 0) {
+    const tps = (outputTokens / (totalMs / 1000)).toFixed(1);
+    parts.push(
+      `TPS: ${tps} tok/s (${outputTokens} tokens over ${formatDuration(totalMs)}, stream ${formatDuration(streamMs)})`,
+    );
   }
   return `[Debug] ${parts.join(' | ')}`;
 }

--- a/apps/kimi-code/test/utils/usage/debug-timing.test.ts
+++ b/apps/kimi-code/test/utils/usage/debug-timing.test.ts
@@ -24,7 +24,20 @@ describe('formatStepDebugTiming', () => {
       llmStreamDurationMs: 5000,
       usage: { output: 200 },
     });
-    expect(result).toBe('[Debug] TTFT: 800ms | TPS: 40.0 tok/s (200 tokens in 5.0s)');
+    expect(result).toBe(
+      '[Debug] TTFT: 800ms | TPS: 34.5 tok/s (200 tokens over 5.8s, stream 5.0s)',
+    );
+  });
+
+  it('does not inflate TPS when the streamed window is tiny', () => {
+    const result = formatStepDebugTiming({
+      llmFirstTokenLatencyMs: 1200,
+      llmStreamDurationMs: 1,
+      usage: { output: 44 },
+    });
+    expect(result).toBe(
+      '[Debug] TTFT: 1.2s | TPS: 36.6 tok/s (44 tokens over 1.2s, stream 1ms)',
+    );
   });
 
   it('formats durations under 1s as milliseconds', () => {


### PR DESCRIPTION
## Related Issue

No linked issue. Fixes a reproducible debug-mode reporting issue where short tool-call streams can display unrealistically high TPS values.

## Problem

Debug timing computed TPS from the stream window after the first chunk. For tool-call steps that stream their output in only a few milliseconds while still reporting total output tokens, debug mode could show rates like tens of thousands of tokens per second.

## What changed

Compute debug TPS over the full model response window (`TTFT + stream duration`) while still showing the raw stream duration in the diagnostic text. Added a regression test for a 1ms stream window and included a patch changeset.

## Validation

- `pnpm --filter @moonshot-ai/kimi-code exec vitest run test/utils/usage/debug-timing.test.ts`
- `git diff --check`
- `pnpm -w run build:packages`
- `pnpm --filter @moonshot-ai/vis-server run build`
- `pnpm --filter @moonshot-ai/kimi-code run typecheck` fails with existing `TS2307: Cannot find module '@moonshot-ai/vis-server/start'` at `src/cli/sub/vis.ts:134:49`

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.
