### PR TITLE
refactor(shell): pass cwd via process options instead of shell command

### DIFF
--- a/packages/agent-core/src/tools/builtin/shell/bash.ts
+++ b/packages/agent-core/src/tools/builtin/shell/bash.ts
@@ -195,13 +195,7 @@ export class BashTool implements BuiltinTool<BashInput> {
   }
 
   private spawn(effectiveCwd: string, command: string): Promise<KaosProcess> {
-    const shellCwd = this.isWindowsBash ? windowsPathToPosixPath(effectiveCwd) : effectiveCwd;
-    const shellArgs = [
-      this.kaos.osEnv.shellPath,
-      '-c',
-      `cd ${shellQuote(shellCwd)} && ${command}`,
-    ];
-
+    const shellArgs = [this.kaos.osEnv.shellPath, '-c', command];
     const noninteractiveEnv: Record<string, string> = {
       NO_COLOR: '1',
       TERM: 'dumb',
@@ -218,7 +212,7 @@ export class BashTool implements BuiltinTool<BashInput> {
       ...(process.env as Record<string, string>),
       ...noninteractiveEnv,
     };
-    return this.kaos.execWithEnv(shellArgs, mergedEnv);
+    return this.kaos.withCwd(effectiveCwd).execWithEnv(shellArgs, mergedEnv);
   }
 
   private async execution(
@@ -466,25 +460,6 @@ async function readStreamIntoBuilder(
   const trailing = decoder.end();
   if (trailing.length > 0) onUpdate?.({ kind, text: trailing });
   builder.write(trailing);
-}
-
-function shellQuote(s: string): string {
-  return `'${s.replaceAll("'", "'\\''")}'`;
-}
-
-function windowsPathToPosixPath(path: string): string {
-  if (path.startsWith('\\\\')) {
-    return path.replaceAll('\\', '/');
-  }
-
-  const driveMatch = /^([A-Za-z]):(?:[\\/]|$)/.exec(path);
-  if (driveMatch !== null) {
-    const drive = driveMatch[1]!.toLowerCase();
-    const rest = path.slice(2).replaceAll('\\', '/');
-    return `/${drive}${rest.startsWith('/') ? rest : `/${rest}`}`;
-  }
-
-  return path.replaceAll('\\', '/');
 }
 
 const WINDOWS_NUL_REDIRECT = /(\d?&?>+\s*)[Nn][Uu][Ll](?=\s|$|[|&;)\n])/g;

--- a/packages/agent-core/src/tools/builtin/shell/bash.ts
+++ b/packages/agent-core/src/tools/builtin/shell/bash.ts
@@ -34,6 +34,7 @@ import { ProcessBackgroundTask, type BackgroundManager } from '../../../agent/ba
 import type { BuiltinTool } from '../../../agent/tool';
 import type { ExecutableToolResult, ToolExecution, ToolUpdate } from '../../../loop/types';
 import { renderPrompt } from '../../../utils/render-prompt';
+import { normalizeUserPath } from '../../policies/path-access';
 import { toInputJsonSchema } from '../../support/input-schema';
 import { literalRulePattern, matchesGlobRuleSubject } from '../../support/rule-match';
 import { ToolResultBuilder } from '../../support/result-builder';
@@ -466,7 +467,11 @@ async function readStreamIntoBuilder(
 
 function resolveProcessCwd(baseCwd: string, cwd: string, pathClass: 'posix' | 'win32'): string {
   const path = pathClass === 'win32' ? pathe.win32 : pathe.posix;
-  return path.isAbsolute(cwd) ? path.normalize(cwd) : path.resolve(baseCwd, cwd);
+  const normalizedBaseCwd = normalizeUserPath(baseCwd, pathClass);
+  const normalizedCwd = normalizeUserPath(cwd, pathClass);
+  return path.isAbsolute(normalizedCwd)
+    ? path.normalize(normalizedCwd)
+    : path.resolve(normalizedBaseCwd, normalizedCwd);
 }
 
 const WINDOWS_NUL_REDIRECT = /(\d?&?>+\s*)[Nn][Uu][Ll](?=\s|$|[|&;)\n])/g;

--- a/packages/agent-core/src/tools/builtin/shell/bash.ts
+++ b/packages/agent-core/src/tools/builtin/shell/bash.ts
@@ -27,6 +27,7 @@ import type { Readable } from 'node:stream';
 import { StringDecoder } from 'node:string_decoder';
 
 import type { Kaos, KaosProcess } from '@moonshot-ai/kaos';
+import * as pathe from 'pathe';
 import { z } from 'zod';
 
 import { ProcessBackgroundTask, type BackgroundManager } from '../../../agent/background';
@@ -196,6 +197,7 @@ export class BashTool implements BuiltinTool<BashInput> {
 
   private spawn(effectiveCwd: string, command: string): Promise<KaosProcess> {
     const shellArgs = [this.kaos.osEnv.shellPath, '-c', command];
+    const processCwd = resolveProcessCwd(this.cwd, effectiveCwd, this.kaos.pathClass());
     const noninteractiveEnv: Record<string, string> = {
       NO_COLOR: '1',
       TERM: 'dumb',
@@ -212,7 +214,7 @@ export class BashTool implements BuiltinTool<BashInput> {
       ...(process.env as Record<string, string>),
       ...noninteractiveEnv,
     };
-    return this.kaos.withCwd(effectiveCwd).execWithEnv(shellArgs, mergedEnv);
+    return this.kaos.withCwd(processCwd).execWithEnv(shellArgs, mergedEnv);
   }
 
   private async execution(
@@ -460,6 +462,11 @@ async function readStreamIntoBuilder(
   const trailing = decoder.end();
   if (trailing.length > 0) onUpdate?.({ kind, text: trailing });
   builder.write(trailing);
+}
+
+function resolveProcessCwd(baseCwd: string, cwd: string, pathClass: 'posix' | 'win32'): string {
+  const path = pathClass === 'win32' ? pathe.win32 : pathe.posix;
+  return path.isAbsolute(cwd) ? path.normalize(cwd) : path.resolve(baseCwd, cwd);
 }
 
 const WINDOWS_NUL_REDIRECT = /(\d?&?>+\s*)[Nn][Uu][Ll](?=\s|$|[|&;)\n])/g;

--- a/packages/agent-core/test/tools/bash.test.ts
+++ b/packages/agent-core/test/tools/bash.test.ts
@@ -345,6 +345,33 @@ describe('BashTool', () => {
     expect(execWithEnv.mock.calls[0]?.[0]).toEqual(['/bin/bash', '-c', 'pwd']);
   });
 
+  it('normalizes Git Bash drive cwd before spawning on Windows', async () => {
+    const execWithEnv = vi.fn().mockResolvedValue(processWithOutput({ stdout: 'sub\n' }));
+    const kaos = createFakeKaos({
+      execWithEnv,
+      osEnv: windowsBashEnv,
+      pathClass: () => 'win32',
+    });
+    const withCwd = vi.fn((cwd: string) =>
+      createFakeKaos({
+        execWithEnv,
+        getcwd: () => cwd,
+        osEnv: windowsBashEnv,
+        pathClass: () => 'win32',
+      }),
+    );
+    const tool = new BashTool({ ...kaos, withCwd }, 'C:/workspace/kimi-code');
+
+    await executeTool(tool, context({ command: 'pwd', cwd: '/c/Users/me/project', timeout: 60 }));
+
+    expect(withCwd).toHaveBeenCalledWith('C:/Users/me/project');
+    expect(execWithEnv.mock.calls[0]?.[0]).toEqual([
+      'C:\\Program Files\\Git\\bin\\bash.exe',
+      '-c',
+      'pwd',
+    ]);
+  });
+
   it('keeps cwd out of the shell command string', async () => {
     const execWithEnv = vi.fn().mockResolvedValue(processWithOutput());
     const cwd = "/tmp/project-$(touch injected); `touch injected-too` & unsafe's";

--- a/packages/agent-core/test/tools/bash.test.ts
+++ b/packages/agent-core/test/tools/bash.test.ts
@@ -331,6 +331,20 @@ describe('BashTool', () => {
     expect(execWithEnv.mock.calls[0]?.[0]).toEqual(['/bin/bash', '-c', 'pwd']);
   });
 
+  it('resolves a relative args.cwd against the tool cwd before spawning', async () => {
+    const execWithEnv = vi.fn().mockResolvedValue(processWithOutput({ stdout: 'sub\n' }));
+    const kaos = createFakeKaos({ execWithEnv, osEnv: posixEnv });
+    const withCwd = vi.fn((cwd: string) =>
+      createFakeKaos({ execWithEnv, getcwd: () => cwd, osEnv: posixEnv }),
+    );
+    const tool = new BashTool({ ...kaos, withCwd }, '/workspace/kimi-code');
+
+    await executeTool(tool, context({ command: 'pwd', cwd: 'packages/agent-core', timeout: 60 }));
+
+    expect(withCwd).toHaveBeenCalledWith('/workspace/kimi-code/packages/agent-core');
+    expect(execWithEnv.mock.calls[0]?.[0]).toEqual(['/bin/bash', '-c', 'pwd']);
+  });
+
   it('keeps cwd out of the shell command string', async () => {
     const execWithEnv = vi.fn().mockResolvedValue(processWithOutput());
     const cwd = "/tmp/project-$(touch injected); `touch injected-too` & unsafe's";

--- a/packages/agent-core/test/tools/bash.test.ts
+++ b/packages/agent-core/test/tools/bash.test.ts
@@ -304,7 +304,7 @@ describe('BashTool', () => {
 
     expect(execWithEnv).toHaveBeenCalledTimes(1);
     const [argv, env] = execWithEnv.mock.calls[0]!;
-    expect(argv).toEqual(['/bin/bash', '-c', "cd '/workspace' && printf ok"]);
+    expect(argv).toEqual(['/bin/bash', '-c', 'printf ok']);
     expect(env).toMatchObject({
       NO_COLOR: '1',
       TERM: 'dumb',
@@ -319,11 +319,31 @@ describe('BashTool', () => {
 
   it('uses args.cwd when provided', async () => {
     const execWithEnv = vi.fn().mockResolvedValue(processWithOutput({ stdout: 'sub\n' }));
-    const tool = new BashTool(createFakeKaos({ execWithEnv, osEnv: posixEnv }), '/workspace');
+    const kaos = createFakeKaos({ execWithEnv, osEnv: posixEnv });
+    const withCwd = vi.fn((cwd: string) =>
+      createFakeKaos({ execWithEnv, getcwd: () => cwd, osEnv: posixEnv }),
+    );
+    const tool = new BashTool({ ...kaos, withCwd }, '/workspace');
 
     await executeTool(tool, context({ command: 'pwd', cwd: '/tmp/project', timeout: 60 }));
 
-    expect(execWithEnv.mock.calls[0]?.[0]).toEqual(['/bin/bash', '-c', "cd '/tmp/project' && pwd"]);
+    expect(withCwd).toHaveBeenCalledWith('/tmp/project');
+    expect(execWithEnv.mock.calls[0]?.[0]).toEqual(['/bin/bash', '-c', 'pwd']);
+  });
+
+  it('keeps cwd out of the shell command string', async () => {
+    const execWithEnv = vi.fn().mockResolvedValue(processWithOutput());
+    const cwd = "/tmp/project-$(touch injected); `touch injected-too` & unsafe's";
+    const kaos = createFakeKaos({ execWithEnv, osEnv: posixEnv });
+    const withCwd = vi.fn((next: string) =>
+      createFakeKaos({ execWithEnv, getcwd: () => next, osEnv: posixEnv }),
+    );
+    const tool = new BashTool({ ...kaos, withCwd }, cwd);
+
+    await executeTool(tool, context({ command: 'pwd', timeout: 60 }));
+
+    expect(withCwd).toHaveBeenCalledWith(cwd);
+    expect(execWithEnv.mock.calls[0]?.[0]).toEqual(['/bin/bash', '-c', 'pwd']);
   });
 
   it('uses Git Bash semantics on Windows', async () => {
@@ -341,7 +361,7 @@ describe('BashTool', () => {
     expect(argv).toEqual([
       'C:\\Program Files\\Git\\bin\\bash.exe',
       '-c',
-      "cd '/c/Users/me/project' && echo ok 2>/dev/null",
+      'echo ok 2>/dev/null',
     ]);
     expect(env).toMatchObject({ SHELL: 'C:\\Program Files\\Git\\bin\\bash.exe' });
     expect(result).toMatchObject({
@@ -619,7 +639,7 @@ describe('BashTool', () => {
     expect(argv).toEqual([
       'C:\\Program Files\\Git\\bin\\bash.exe',
       '-c',
-      "cd '/c/Users/me/project' && echo ok 2>/dev/null",
+      'echo ok 2>/dev/null',
     ]);
     expect(env).toMatchObject({ SHELL: 'C:\\Program Files\\Git\\bin\\bash.exe' });
     expect(secondProc.kill).toHaveBeenCalledWith('SIGTERM');
@@ -896,7 +916,7 @@ describe('BashTool', () => {
     await executeTool(tool, context({ command: 'ls 2>nul', timeout: 60 }));
 
     const argv = execWithEnv.mock.calls[0]?.[0] as readonly string[];
-    expect(argv[2]).toBe("cd '/c/Users/me/project' && ls 2>/dev/null");
+    expect(argv[2]).toBe('ls 2>/dev/null');
   });
 
   it('passes nul-redirect through unchanged on Linux so the argv keeps the literal file target', async () => {
@@ -906,7 +926,7 @@ describe('BashTool', () => {
     await executeTool(tool, context({ command: 'ls 2>nul', timeout: 60 }));
 
     const argv = execWithEnv.mock.calls[0]?.[0] as readonly string[];
-    expect(argv[2]).toBe("cd '/workspace' && ls 2>nul");
+    expect(argv[2]).toBe('ls 2>nul');
   });
 
   it('exposes a shell description that documents /bin/bash, TaskOutput/TaskStop, safety and efficiency sections, and background semantics', () => {

--- a/packages/agent-core/test/tools/shell-quoting.test.ts
+++ b/packages/agent-core/test/tools/shell-quoting.test.ts
@@ -66,10 +66,7 @@ function captureCommandRewrite(
     signal,
   }).then(() => {
       const argv = execWithEnv.mock.calls[0]?.[0] as readonly string[];
-      // The shell wrapper is "cd '<cwd>' && <rewritten>"; isolate the rewrite.
-      const wrapped = argv[2]!;
-      const match = /^cd '[^']+' && (.*)$/.exec(wrapped)!;
-      return { rewritten: match[1]!, argv };
+      return { rewritten: argv[2]!, argv };
     });
 }
 


### PR DESCRIPTION
- use kaos.withCwd() to set the working directory
- stop embedding cwd into the generated `bash -c` command
- remove unused shellQuote and windowsPathToPosixPath helpers
- add tests covering cwd propagation and command construction

<!--
Thank you for your contribution to Kimi Code!
Please open an issue before sending a feature PR — PRs without prior discussion may be closed without review.

See https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md for more.
-->

## Related Issue

<!-- Link the issue this feature came from. If there is no issue, explain the problem in the next section instead. -->

Resolve #850 

## Problem

<!-- What user need or limitation does this address? If the linked issue already covers this, write "See linked issue". -->

## What changed

<!-- What did you implement, and why does this approach fit Kimi Code? -->
This PR refactors Bash tool command execution to avoid embedding the working directory into the generated bash -c command string.

Changes include:

* use kaos.withCwd() to set the working directory at the process execution layer
* stop generating cd '<cwd>' && ${command} inside the shell command string
* remove now-unused shellQuote and windowsPathToPosixPath helpers
* add tests covering cwd propagation and command construction

This keeps the intended Bash command semantics unchanged while reducing unnecessary shell string construction around cwd.
## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.
