### PR TITLE
chore(daemon): remove unused daemon package and stale references

### DIFF
--- a/.changeset/README.md
+++ b/.changeset/README.md
@@ -29,7 +29,6 @@ All other workspace packages are private internal packages, are not published to
 - `@moonshot-ai/vis`
 - `@moonshot-ai/vis-server`
 - `@moonshot-ai/vis-web`
-- `daemon`
 - `kimi-migration-legacy`
 
 Version impact from internal dependencies must be judged manually. The published artifacts for CLI and SDK bundle internal workspace packages into the artifact itself; runtime `dependencies` of published packages must not include any `@moonshot-ai/*` internal workspace packages.

--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -21,7 +21,6 @@
     "@moonshot-ai/vis",
     "@moonshot-ai/vis-server",
     "@moonshot-ai/vis-web",
-    "daemon",
     "kimi-migration-legacy"
   ],
   "snapshot": {

--- a/.gitignore
+++ b/.gitignore
@@ -17,7 +17,6 @@ superpowers
 .worktrees/
 
 Dockerfile
-!packages/daemon-e2e/Dockerfile
 docker-compose.yml
 .dockerignore
 

--- a/apps/kimi-web/src/components/DiffView.vue
+++ b/apps/kimi-web/src/components/DiffView.vue
@@ -77,7 +77,7 @@ function badgeGlyph(s: string): string {
 
 /**
  * Truncate a long path from the left, showing the tail.
- * e.g. "packages/daemon/src/middleware/schema.ts" → "…leware/schema.ts"
+ * e.g. "packages/agent-core/src/services/session/sessionService.ts" → "…sion/sessionService.ts"
  */
 function truncateLeft(path: string, maxLen = 60): string {
   if (path.length <= maxLen) return path;

--- a/flake.nix
+++ b/flake.nix
@@ -64,7 +64,6 @@
       workspacePaths = [
         ./packages/acp-adapter
         ./packages/agent-core
-        ./packages/daemon
         ./packages/server
         ./packages/server-e2e
         ./packages/kaos
@@ -100,7 +99,6 @@
         "@moonshot-ai/vis"
         "@moonshot-ai/vis-server"
         "@moonshot-ai/vis-web"
-        "daemon"
         "kimi-code-docs"
         "kimi-migration-legacy"
       ];

--- a/packages/agent-core/src/services/prompt/prompt.ts
+++ b/packages/agent-core/src/services/prompt/prompt.ts
@@ -350,9 +350,9 @@ export interface AgentStateSnapshot {
  * One dispatch record appended to the per-session ring buffer whenever
  * `PromptService._applyAgentState` actually issues a setter RPC against
  * `core.rpc.*`. Absence of an entry between two prompts proves the
- * shadow suppressed a redundant call — which is the property
- * `daemon-e2e` scenarios need to assert directly, since WS frames
- * alone can't distinguish "state held" from "setter re-dispatched".
+ * shadow suppressed a redundant call — letting tests assert "state held"
+ * versus "setter re-dispatched", since WS frames alone can't distinguish
+ * the two.
  */
 export interface PromptDispatchLogEntry {
   /** ISO-8601 timestamp captured immediately after the setter resolves. */

--- a/packages/daemon/package.json
+++ b/packages/daemon/package.json
@@ -1,5 +1,0 @@
-{
-  "name": "daemon",
-  "version": "0.0.0",
-  "private": true
-}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -439,8 +439,6 @@ importers:
         specifier: ^3.3.1
         version: 3.3.1
 
-  packages/daemon: {}
-
   packages/kaos:
     dependencies:
       pathe:


### PR DESCRIPTION
## Related Issue

No related issue — cleanup of leftover traces after the internal `packages/daemon` package was removed.

## Problem

The `packages/daemon` workspace package (an internal, `private` package named `daemon`) was deleted, but several stale references to it — and to its also-removed companion `daemon-e2e` — remained across the repo. These dead entries clutter workspace configuration and could mislead readers or break tooling that walks workspace members (e.g. the Nix build's hardcoded `workspacePaths`/`workspaceNames` lists and the changesets `ignore` list).

## What changed

- Delete the remaining `packages/daemon/package.json`.
- Drop `./packages/daemon` from `workspacePaths` and `"daemon"` from `workspaceNames` in `flake.nix`.
- Remove the empty `packages/daemon: {}` importer entry from `pnpm-lock.yaml`.
- Remove `"daemon"` from the changesets `ignore` list in `.changeset/config.json` and the matching entry in `.changeset/README.md`.
- Remove the dead `!packages/daemon-e2e/Dockerfile` negation from `.gitignore`.
- Update two comments that referenced `packages/daemon` / `daemon-e2e` (`DiffView.vue`, `prompt.ts`) to point at real, existing code.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [ ] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.
