### PR TITLE
feat(tui): add /web slash command to open session in Web UI

### DIFF
--- a/.changeset/README.md
+++ b/.changeset/README.md
@@ -29,7 +29,6 @@ All other workspace packages are private internal packages, are not published to
 - `@moonshot-ai/vis`
 - `@moonshot-ai/vis-server`
 - `@moonshot-ai/vis-web`
-- `daemon`
 - `kimi-migration-legacy`
 
 Version impact from internal dependencies must be judged manually. The published artifacts for CLI and SDK bundle internal workspace packages into the artifact itself; runtime `dependencies` of published packages must not include any `@moonshot-ai/*` internal workspace packages.

--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -21,7 +21,6 @@
     "@moonshot-ai/vis",
     "@moonshot-ai/vis-server",
     "@moonshot-ai/vis-web",
-    "daemon",
     "kimi-migration-legacy"
   ],
   "snapshot": {

--- a/.gitignore
+++ b/.gitignore
@@ -17,7 +17,6 @@ superpowers
 .worktrees/
 
 Dockerfile
-!packages/daemon-e2e/Dockerfile
 docker-compose.yml
 .dockerignore
 

--- a/apps/kimi-code/src/cli/run-shell.ts
+++ b/apps/kimi-code/src/cli/run-shell.ts
@@ -3,18 +3,18 @@ import { homedir } from 'node:os';
 import { join } from 'node:path';
 
 import {
+  createKimiHarness,
+  log,
+  type KimiHarness,
+  type TelemetryClient,
+} from '@moonshot-ai/kimi-code-sdk';
+import {
   setCrashPhase,
   setTelemetryContext,
   shutdownTelemetry,
   track,
   withTelemetryContext,
 } from '@moonshot-ai/kimi-telemetry';
-import {
-  createKimiHarness,
-  log,
-  type KimiHarness,
-  type TelemetryClient,
-} from '@moonshot-ai/kimi-code-sdk';
 
 import { CLI_SHUTDOWN_TIMEOUT_MS, CLI_UI_MODE } from '#/constant/app';
 import { detectPendingMigration } from '#/migration/index';
@@ -24,6 +24,7 @@ import { CHROME_GUTTER } from '#/tui/constant/rendering';
 import { KimiTUI } from '#/tui/index';
 import { currentTheme, getColorPalette } from '#/tui/theme';
 import { combineStartupNotice } from '#/tui/utils/startup';
+import { toTerminalHyperlink } from '#/utils/terminal-hyperlink';
 
 import type { CLIOptions } from './options';
 import { createCliTelemetryBootstrap, initializeCliTelemetry } from './telemetry';
@@ -139,8 +140,15 @@ export async function runShell(
     await shutdownTelemetry({ timeoutMs: CLI_SHUTDOWN_TIMEOUT_MS });
     const gutter = ' '.repeat(CHROME_GUTTER);
     process.stdout.write(`${gutter}Bye!\n`);
+    const hints: string[] = [];
     if (sessionId !== '' && hasContent) {
-      process.stderr.write(`\n${gutter}To resume this session: kimi -r ${sessionId}\n`);
+      hints.push(`${gutter}To resume this session: kimi -r ${sessionId}`);
+    }
+    if (tui.exitOpenUrl !== undefined) {
+      hints.push(`${gutter}open ${toTerminalHyperlink(tui.exitOpenUrl, tui.exitOpenUrl)}`);
+    }
+    if (hints.length > 0) {
+      process.stderr.write(`\n${hints.join('\n')}\n`);
     }
     process.exit(exitCode);
   };

--- a/apps/kimi-code/src/tui/commands/dispatch.ts
+++ b/apps/kimi-code/src/tui/commands/dispatch.ts
@@ -3,32 +3,24 @@ import type { DeviceAuthorization } from '@moonshot-ai/kimi-code-oauth';
 import type { KimiHarness, Session } from '@moonshot-ai/kimi-code-sdk';
 
 import type { ColorToken, ThemeName } from '#/tui/theme';
-import type { ResolvedTheme } from '../theme/colors';
-import {
-  LLM_NOT_SET_MESSAGE,
-} from '../constant/kimi-tui';
-import { formatErrorMessage } from '../utils/event-payload';
-import { parseSlashInput } from './parse';
-import {
-  resolveSlashCommandInput,
-  slashBusyMessage,
-} from './resolve';
-import type { BuiltinSlashCommandName } from './registry';
+
+import { LLM_NOT_SET_MESSAGE } from '../constant/kimi-tui';
 import type { AuthFlowController } from '../controllers/auth-flow';
 import type { BtwPanelController } from '../controllers/btw-panel';
 import type { StreamingUIController } from '../controllers/streaming-ui';
 import type { TasksBrowserController } from '../controllers/tasks-browser';
+import { tryHandleDanceCommand } from '../easter-eggs/dance';
+import type { ResolvedTheme } from '../theme/colors';
+import type { TUIState } from '../tui-state';
 import type {
   AppState,
   LoginProgressSpinnerHandle,
   QueuedMessage,
   TranscriptEntry,
 } from '../types';
-import type { TUIState } from '../tui-state';
-
+import { formatErrorMessage } from '../utils/event-payload';
 import { handleLoginCommand, handleLogoutCommand } from './auth';
 import { handleBtwCommand } from './btw';
-import { tryHandleDanceCommand } from '../easter-eggs/dance';
 import {
   handleAutoCommand,
   handleCompactCommand,
@@ -43,11 +35,13 @@ import {
   showSettingsSelector,
 } from './config';
 import { handleGoalCommand } from './goal';
-import { handleProviderCommand } from './provider';
 import { handleFeedbackCommand, showMcpServers, showStatusReport, showUsage } from './info';
+import { parseSlashInput } from './parse';
 import { handlePluginsCommand } from './plugins';
+import { handleProviderCommand } from './provider';
+import type { BuiltinSlashCommandName } from './registry';
 import { handleReloadCommand, handleReloadTuiCommand } from './reload';
-import { handleSwarmCommand } from './swarm';
+import { resolveSlashCommandInput, slashBusyMessage } from './resolve';
 import {
   handleExportDebugZipCommand,
   handleExportMdCommand,
@@ -55,16 +49,15 @@ import {
   handleInitCommand,
   handleTitleCommand,
 } from './session';
+import { handleSwarmCommand } from './swarm';
 import { handleUndoCommand } from './undo';
+import { handleWebCommand } from './web';
 
 // ---------------------------------------------------------------------------
 // Re-exports — keep existing consumers working
 // ---------------------------------------------------------------------------
 
-export {
-  handleLoginCommand,
-  handleLogoutCommand,
-} from './auth';
+export { handleLoginCommand, handleLogoutCommand } from './auth';
 export { handleBtwCommand } from './btw';
 export {
   handleAutoCommand,
@@ -80,12 +73,7 @@ export {
   showSettingsSelector,
 } from './config';
 export { handleSwarmCommand } from './swarm';
-export {
-  handleFeedbackCommand,
-  showMcpServers,
-  showStatusReport,
-  showUsage,
-} from './info';
+export { handleFeedbackCommand, showMcpServers, showStatusReport, showUsage } from './info';
 export { handlePluginsCommand } from './plugins';
 export { handleReloadCommand, handleReloadTuiCommand } from './reload';
 export { handleGoalCommand } from './goal';
@@ -97,6 +85,7 @@ export {
   handleTitleCommand,
 } from './session';
 export { handleUndoCommand } from './undo';
+export { handleWebCommand } from './web';
 
 // ---------------------------------------------------------------------------
 // Host interface
@@ -337,6 +326,9 @@ async function handleBuiltInSlashCommand(
       return;
     case 'undo':
       await handleUndoCommand(host, args);
+      return;
+    case 'web':
+      await handleWebCommand(host);
       return;
     default:
       host.showError(`Unknown slash command: /${String(name)}`);

--- a/apps/kimi-code/src/tui/commands/dispatch.ts
+++ b/apps/kimi-code/src/tui/commands/dispatch.ts
@@ -130,6 +130,7 @@ export interface SlashCommandHost {
 
   // Dispatch
   stop(exitCode?: number): Promise<void>;
+  setExitOpenUrl(url: string): void;
   showHelpPanel(): void;
   createNewSession(): Promise<void>;
   showSessionPicker(): Promise<void>;

--- a/apps/kimi-code/src/tui/commands/index.ts
+++ b/apps/kimi-code/src/tui/commands/index.ts
@@ -6,10 +6,7 @@ export * from './skills';
 export * from './types';
 
 export { dispatchInput, type SlashCommandHost } from './dispatch';
-export {
-  handleLoginCommand,
-  handleLogoutCommand,
-} from './auth';
+export { handleLoginCommand, handleLogoutCommand } from './auth';
 export { handleBtwCommand } from './btw';
 export {
   handleCompactCommand,
@@ -24,22 +21,14 @@ export {
   showSettingsSelector,
 } from './config';
 export { handleSwarmCommand } from './swarm';
-export {
-  handleFeedbackCommand,
-  showMcpServers,
-  showStatusReport,
-  showUsage,
-} from './info';
+export { handleFeedbackCommand, showMcpServers, showStatusReport, showUsage } from './info';
 export { handlePluginsCommand } from './plugins';
 export { handleReloadCommand, handleReloadTuiCommand } from './reload';
 export { handleGoalCommand, parseGoalCommand } from './goal';
 export { goalArgumentCompletions } from './registry';
-export {
-  handleForkCommand,
-  handleInitCommand,
-  handleTitleCommand,
-} from './session';
+export { handleForkCommand, handleInitCommand, handleTitleCommand } from './session';
 export { handleUndoCommand } from './undo';
+export { handleWebCommand } from './web';
 export {
   promptApiKey,
   promptCatalogProviderSelection,

--- a/apps/kimi-code/src/tui/commands/registry.ts
+++ b/apps/kimi-code/src/tui/commands/registry.ts
@@ -278,6 +278,13 @@ export const BUILTIN_SLASH_COMMANDS = [
     priority: 40,
   },
   {
+    name: 'web',
+    aliases: [],
+    description: 'Open the current session in the Web UI and exit the terminal',
+    priority: 40,
+    availability: 'always',
+  },
+  {
     name: 'exit',
     aliases: ['quit', 'q'],
     description: 'Exit the application',

--- a/apps/kimi-code/src/tui/commands/web.ts
+++ b/apps/kimi-code/src/tui/commands/web.ts
@@ -63,7 +63,9 @@ export async function handleWebCommand(host: SlashCommandHost): Promise<void> {
     return;
   }
 
-  openUrl(webSessionUrl(origin, sessionId));
+  const url = webSessionUrl(origin, sessionId);
+  openUrl(url);
+  host.setExitOpenUrl(url);
   await host.stop();
 }
 

--- a/apps/kimi-code/src/tui/commands/web.ts
+++ b/apps/kimi-code/src/tui/commands/web.ts
@@ -1,0 +1,73 @@
+import { ensureDaemon } from '#/cli/sub/server/daemon';
+import { openUrl } from '#/utils/open-url';
+
+import { ChoicePickerComponent } from '../components/dialogs/choice-picker';
+import { NO_ACTIVE_SESSION_MESSAGE } from '../constant/kimi-tui';
+import { formatErrorMessage } from '../utils/event-payload';
+import type { SlashCommandHost } from './dispatch';
+
+const WEB_CONFIRM = 'confirm';
+const WEB_CANCEL = 'cancel';
+
+/**
+ * `/web` — hand the current session off to the browser.
+ *
+ * Equivalent to `kimi server run` (ensures the background daemon is up) plus
+ * `kimi web` (opens the browser), but deep-linked to the active session and
+ * followed by shutting down this terminal UI. A confirmation step spells out
+ * the consequences and only proceeds when the user presses Enter on Continue.
+ */
+export async function handleWebCommand(host: SlashCommandHost): Promise<void> {
+  const session = host.session;
+  if (session === undefined) {
+    host.showError(NO_ACTIVE_SESSION_MESSAGE);
+    return;
+  }
+  const sessionId = session.id;
+
+  const confirmed = await new Promise<boolean>((resolve) => {
+    const picker = new ChoicePickerComponent({
+      title: 'Open current session in the Web UI?',
+      hint: '↑↓ navigate · Enter select · Esc cancel',
+      options: [
+        {
+          value: WEB_CONFIRM,
+          label: 'Continue',
+          description:
+            'Start the Kimi server (background daemon if needed), open this session in your default browser, and exit the terminal UI.',
+        },
+        {
+          value: WEB_CANCEL,
+          label: 'Cancel',
+          description: 'Stay in the terminal UI.',
+        },
+      ],
+      onSelect: (value) => {
+        resolve(value === WEB_CONFIRM);
+      },
+      onCancel: () => {
+        resolve(false);
+      },
+    });
+    host.mountEditorReplacement(picker);
+  });
+  host.restoreEditor();
+  if (!confirmed) return;
+
+  host.showStatus('Starting Kimi server and opening web UI…');
+  let origin: string;
+  try {
+    ({ origin } = await ensureDaemon({}));
+  } catch (error) {
+    host.showError(`Failed to start server: ${formatErrorMessage(error)}`);
+    return;
+  }
+
+  openUrl(webSessionUrl(origin, sessionId));
+  await host.stop();
+}
+
+/** Build the deep-link URL the web UI recognises for a session. */
+export function webSessionUrl(origin: string, sessionId: string): string {
+  return `${origin.replace(/\/+$/, '')}/sessions/${encodeURIComponent(sessionId)}`;
+}

--- a/apps/kimi-code/src/tui/kimi-tui.ts
+++ b/apps/kimi-code/src/tui/kimi-tui.ts
@@ -59,10 +59,7 @@ import {
 import { CompactionComponent } from './components/dialogs/compaction';
 import { HelpPanelComponent } from './components/dialogs/help-panel';
 import { QuestionDialogComponent } from './components/dialogs/question-dialog';
-import {
-  SessionPickerComponent,
-  type SessionRow,
-} from './components/dialogs/session-picker';
+import { SessionPickerComponent, type SessionRow } from './components/dialogs/session-picker';
 import {
   FileMentionProvider,
   type SlashAutocompleteCommand,
@@ -251,6 +248,9 @@ export class KimiTUI {
     | undefined;
 
   public onExit?: (exitCode?: number) => Promise<void>;
+
+  /** URL opened in the browser just before exit (e.g. by `/web`); printed by onExit. */
+  public exitOpenUrl: string | undefined;
 
   track(event: string, properties?: Parameters<KimiHarness['track']>[1]): void {
     this.harness.track(event, properties);
@@ -501,9 +501,7 @@ export class KimiTUI {
       const result = await this.authFlow.refreshProviderModels();
       for (const c of result.changed) {
         if (c.added <= 0) continue;
-        this.showStatus(
-          `${c.providerName} · +${String(c.added)} model${c.added > 1 ? 's' : ''}.`,
-        );
+        this.showStatus(`${c.providerName} · +${String(c.added)} model${c.added > 1 ? 's' : ''}.`);
       }
       for (const f of result.failed) {
         this.showStatus(`Skipped refreshing ${f.provider}: ${f.reason}`, 'warning');
@@ -1024,6 +1022,10 @@ export class KimiTUI {
 
   hasSessionContent(): boolean {
     return this.state.transcriptEntries.length > 0;
+  }
+
+  setExitOpenUrl(url: string): void {
+    this.exitOpenUrl = url;
   }
 
   async getStartupMcpMs(): Promise<number> {

--- a/apps/kimi-code/test/cli/run-shell.test.ts
+++ b/apps/kimi-code/test/cli/run-shell.test.ts
@@ -531,7 +531,7 @@ describe('runShell', () => {
           session: undefined,
           continue: false,
           yolo: false,
-        auto: false,
+          auto: false,
           plan: false,
           model: undefined,
           outputFormat: undefined,
@@ -568,7 +568,7 @@ describe('runShell', () => {
           session: undefined,
           continue: false,
           yolo: false,
-        auto: false,
+          auto: false,
           plan: false,
           model: undefined,
           outputFormat: undefined,
@@ -602,6 +602,53 @@ describe('runShell', () => {
     }
   });
 
+  it('prints the opened web URL from the TUI exit handler when set', async () => {
+    mocks.loadTuiConfig.mockResolvedValue({
+      theme: 'dark',
+      editorCommand: null,
+      notifications: { enabled: true, condition: 'unfocused' },
+    });
+    mocks.tuiStart.mockResolvedValue(undefined);
+    mocks.tuiGetCurrentSessionId.mockReturnValue('ses-1');
+    mocks.tuiHasSessionContent.mockReturnValue(true);
+
+    const stdout = captureProcessWrite('stdout');
+    const stderr = captureProcessWrite('stderr');
+    const exitSpy = mockProcessExit();
+
+    try {
+      await runShell(
+        {
+          session: undefined,
+          continue: false,
+          yolo: false,
+          auto: false,
+          plan: false,
+          model: undefined,
+          outputFormat: undefined,
+          prompt: undefined,
+          skillsDirs: [],
+        },
+        '1.2.3-test',
+      );
+      const [tui] = mocks.kimiTuiConstructor.mock.calls[0]!;
+      const openedUrl = 'http://127.0.0.1:58627/sessions/ses-1';
+      (tui as { exitOpenUrl?: string }).exitOpenUrl = openedUrl;
+
+      await expect((tui as { onExit: () => Promise<void> }).onExit()).rejects.toBeInstanceOf(
+        ExitCalled,
+      );
+
+      expect(stderr.text()).toContain(' To resume this session: kimi -r ses-1');
+      expect(stderr.text()).toContain('open ');
+      expect(stderr.text()).toContain(openedUrl);
+    } finally {
+      exitSpy.mockRestore();
+      stdout.restore();
+      stderr.restore();
+    }
+  });
+
   it('surfaces an invalid target config as an error for kimi migrate, not silently', async () => {
     mocks.loadTuiConfig.mockResolvedValue({
       theme: 'dark',
@@ -621,7 +668,7 @@ describe('runShell', () => {
           session: undefined,
           continue: false,
           yolo: false,
-        auto: false,
+          auto: false,
           plan: false,
           model: undefined,
           outputFormat: undefined,

--- a/apps/kimi-code/test/tui/commands/web.test.ts
+++ b/apps/kimi-code/test/tui/commands/web.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+
+import { findBuiltInSlashCommand, resolveSlashCommandAvailability } from '#/tui/commands/index';
+import { webSessionUrl } from '#/tui/commands/web';
+
+describe('web slash command', () => {
+  it('is registered as an always-available built-in', () => {
+    const command = findBuiltInSlashCommand('web');
+    expect(command).toBeDefined();
+    expect(resolveSlashCommandAvailability(command!, '')).toBe('always');
+  });
+});
+
+describe('webSessionUrl', () => {
+  it('deep-links to the session under the origin', () => {
+    expect(webSessionUrl('http://127.0.0.1:58627', 'abc123')).toBe(
+      'http://127.0.0.1:58627/sessions/abc123',
+    );
+  });
+
+  it('strips a trailing slash from the origin', () => {
+    expect(webSessionUrl('http://127.0.0.1:58627/', 'abc123')).toBe(
+      'http://127.0.0.1:58627/sessions/abc123',
+    );
+  });
+
+  it('encodes session ids so the web UI can decode them', () => {
+    expect(webSessionUrl('http://127.0.0.1:58627', 'a/b c')).toBe(
+      'http://127.0.0.1:58627/sessions/a%2Fb%20c',
+    );
+  });
+});

--- a/apps/kimi-web/src/components/DiffView.vue
+++ b/apps/kimi-web/src/components/DiffView.vue
@@ -77,7 +77,7 @@ function badgeGlyph(s: string): string {
 
 /**
  * Truncate a long path from the left, showing the tail.
- * e.g. "packages/daemon/src/middleware/schema.ts" → "…leware/schema.ts"
+ * e.g. "packages/agent-core/src/services/session/sessionService.ts" → "…sion/sessionService.ts"
  */
 function truncateLeft(path: string, maxLen = 60): string {
   if (path.length <= maxLen) return path;

--- a/flake.nix
+++ b/flake.nix
@@ -64,7 +64,6 @@
       workspacePaths = [
         ./packages/acp-adapter
         ./packages/agent-core
-        ./packages/daemon
         ./packages/server
         ./packages/server-e2e
         ./packages/kaos
@@ -100,7 +99,6 @@
         "@moonshot-ai/vis"
         "@moonshot-ai/vis-server"
         "@moonshot-ai/vis-web"
-        "daemon"
         "kimi-code-docs"
         "kimi-migration-legacy"
       ];

--- a/packages/agent-core/src/services/prompt/prompt.ts
+++ b/packages/agent-core/src/services/prompt/prompt.ts
@@ -350,9 +350,9 @@ export interface AgentStateSnapshot {
  * One dispatch record appended to the per-session ring buffer whenever
  * `PromptService._applyAgentState` actually issues a setter RPC against
  * `core.rpc.*`. Absence of an entry between two prompts proves the
- * shadow suppressed a redundant call — which is the property
- * `daemon-e2e` scenarios need to assert directly, since WS frames
- * alone can't distinguish "state held" from "setter re-dispatched".
+ * shadow suppressed a redundant call — letting tests assert "state held"
+ * versus "setter re-dispatched", since WS frames alone can't distinguish
+ * the two.
  */
 export interface PromptDispatchLogEntry {
   /** ISO-8601 timestamp captured immediately after the setter resolves. */

--- a/packages/daemon/package.json
+++ b/packages/daemon/package.json
@@ -1,5 +1,0 @@
-{
-  "name": "daemon",
-  "version": "0.0.0",
-  "private": true
-}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -439,8 +439,6 @@ importers:
         specifier: ^3.3.1
         version: 3.3.1
 
-  packages/daemon: {}
-
   packages/kaos:
     dependencies:
       pathe:


### PR DESCRIPTION
<!--
Thank you for your contribution to Kimi Code!
Please open an issue before sending a feature PR — PRs without prior discussion may be closed without review.

See https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md for more.
-->

## Related Issue

<!-- Link the issue this feature came from. If there is no issue, explain the problem in the next section instead. -->

No linked issue — see Problem below.

## Problem

<!-- What user need or limitation does this address? If the linked issue already covers this, write "See linked issue". -->

There was no way to jump from the terminal UI straight into the current session in the browser. Users who wanted to continue a session in the Web UI had to manually run the server, open `kimi web`, and locate the session themselves. A single slash command that hands the active session off to the browser closes that gap.

## What changed

<!-- What did you implement, and why does this approach fit Kimi Code? -->

### 1. `/web` slash command

**Problem:** No built-in command bridged the TUI and the Web UI for the active session.

**What was done:**
- Added `handleWebCommand` in `apps/kimi-code/src/tui/commands/web.ts`. It ensures the background server daemon is up (`ensureDaemon`), opens a deep-linked URL (`<origin>/sessions/<sessionId>`) in the default browser, and then exits the terminal UI.
- Added a confirmation dialog (Continue / Cancel) before executing, so the consequences (start server, open browser, leave the TUI) are explicit.
- Registered `web` as an always-available built-in command in `registry.ts` and wired it into `dispatch.ts` / `index.ts`.
- Added `webSessionUrl` with tests covering trailing-slash stripping and session-id encoding, plus a registration test in `web.test.ts`.

### 2. Show the opened URL after exit

**Problem:** After `/web` opens the browser and the TUI exits, the terminal only printed the `kimi -r <id>` resume hint, leaving no clickable link back to the session that was just opened.

**What was done:**
- Threaded the opened URL from `/web` through a new `KimiTUI.exitOpenUrl` field (via `setExitOpenUrl`) to the `onExit` handler in `runShell`.
- The exit handler now prints `open <url>` as a clickable terminal hyperlink next to the `kimi -r` resume hint.
- Added a `runShell` test covering the exit handler when an opened URL is set.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [ ] Ran `gen-changesets` skill, or this PR needs no changeset.
- [ ] Ran `gen-docs` skill, or this PR needs no doc update.
