### PR TITLE
fix(changeset): remove ignored packages from mixed changesets

### DIFF
--- a/.changeset/auth-refresh-retry.md
+++ b/.changeset/auth-refresh-retry.md
@@ -1,6 +1,4 @@
 ---
-"@moonshot-ai/agent-core": patch
-"@moonshot-ai/kimi-code-oauth": patch
 "@moonshot-ai/kimi-code-sdk": patch
 "@moonshot-ai/kimi-code": patch
 ---

--- a/.changeset/resume-turn-id-counter.md
+++ b/.changeset/resume-turn-id-counter.md
@@ -1,5 +1,4 @@
 ---
-"@moonshot-ai/agent-core": patch
 "@moonshot-ai/kimi-code": patch
 ---
 


### PR DESCRIPTION
## Related Issue

N/A — this fixes the currently failing Release workflow.

## Problem

PR #625 added several internal packages (including `@moonshot-ai/agent-core` and `@moonshot-ai/kimi-code-oauth`) to the `ignore` list in `.changeset/config.json`. Two existing changesets still referenced those ignored packages alongside publishable packages, making them "mixed changesets". Changesets rejects mixed changesets, so the Release workflow has been failing and the release PR (#826) has not been updated with recent changes, including the server-hosted web UI minor bump.

## What changed

- `.changeset/auth-refresh-retry.md`: removed `@moonshot-ai/agent-core` and `@moonshot-ai/kimi-code-oauth`.
- `.changeset/resume-turn-id-counter.md`: removed `@moonshot-ai/agent-core`.

After this fix, `pnpm changeset status` succeeds and correctly reports a minor bump for `@moonshot-ai/kimi-code` and a patch bump for `@moonshot-ai/kimi-code-sdk`.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [ ] I have linked a related issue, or explained the problem above.
- [ ] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.