### PR TITLE
fix(server): harden launchd/systemd/schtasks service backends

### DIFF
--- a/packages/server/src/svc/install-plan.ts
+++ b/packages/server/src/svc/install-plan.ts
@@ -45,6 +45,7 @@ export function buildInstallPlan(input: BuildInstallPlanInput): InstallPlan {
       input.program,
       'server',
       'run',
+      '--foreground',
       '--port',
       String(input.port),
       '--log-level',

--- a/packages/server/src/svc/schtasks-xml.ts
+++ b/packages/server/src/svc/schtasks-xml.ts
@@ -16,12 +16,27 @@ export interface BuildScheduledTaskXmlInput {
   arguments?: string;
 
   taskUser?: string;
+
+  redirectLogPath?: string;
+}
+
+export function buildCmdRedirectArgs(
+  command: string,
+  args: string | undefined,
+  logPath: string,
+): string {
+  const invocation = args ? `"${command}" ${args}` : `"${command}"`;
+  return `/c "${invocation} >> "${logPath}" 2>&1"`;
 }
 
 export function buildScheduledTaskXml(input: BuildScheduledTaskXmlInput): string {
   const description = escapeXmlText(input.description);
-  const command = escapeXmlText(input.command);
-  const args = input.arguments ? escapeXmlText(input.arguments) : '';
+  const redirect = input.redirectLogPath?.trim();
+  const command = redirect ? escapeXmlText('cmd.exe') : escapeXmlText(input.command);
+  const rawArgs = redirect
+    ? buildCmdRedirectArgs(input.command, input.arguments, redirect)
+    : (input.arguments ?? '');
+  const argumentsXml = rawArgs ? `\n      <Arguments>${escapeXmlText(rawArgs)}</Arguments>` : '';
 
   const principalLogon = input.taskUser
     ? `\n      <UserId>${escapeXmlText(input.taskUser)}</UserId>\n      <LogonType>InteractiveToken</LogonType>`
@@ -29,7 +44,6 @@ export function buildScheduledTaskXml(input: BuildScheduledTaskXmlInput): string
   const triggerUser = input.taskUser
     ? `\n      <UserId>${escapeXmlText(input.taskUser)}</UserId>`
     : '';
-  const argumentsXml = args ? `\n      <Arguments>${args}</Arguments>` : '';
 
   return `<?xml version="1.0" encoding="UTF-16"?>
 <Task version="1.2" xmlns="http://schemas.microsoft.com/windows/2004/02/mit/task">

--- a/packages/server/src/svc/schtasks.ts
+++ b/packages/server/src/svc/schtasks.ts
@@ -39,7 +39,7 @@ export interface SchtasksManagerDeps {
 const DEFAULT_DEPS: SchtasksManagerDeps = {
   execSchtasks: (args, options) =>
     execFileUtf8('schtasks', args, { windowsHide: true, ...options }),
-  resolveProgram: () => resolveSupervisorProgram(process.argv, process.cwd(), 'kimi.exe'),
+  resolveProgram: () => resolveSupervisorProgram(),
   logPath: defaultSupervisorLogPath,
   writeTaskXml: defaultWriteTaskXml,
   taskExists: defaultTaskExists,
@@ -69,6 +69,7 @@ export function createSchtasksManager(
       description: 'Kimi Code local server (managed by `kimi server install`)',
       command: plan.program,
       ...(argString.length > 0 ? { arguments: argString } : {}),
+      redirectLogPath: logPath,
     });
     const xmlPath = deps.writeTaskXml(xml);
 

--- a/packages/server/src/svc/systemd-unit.ts
+++ b/packages/server/src/svc/systemd-unit.ts
@@ -23,6 +23,8 @@ export interface BuildSystemdUnitInput {
   workingDirectory?: string;
 
   environment?: Readonly<Record<string, string>>;
+
+  logPath?: string;
 }
 
 
@@ -43,6 +45,16 @@ export function buildSystemdUnit(input: BuildSystemdUnitInput): string {
       })
     : [];
 
+  const logLines = input.logPath
+    ? (() => {
+        assertNoLineBreaks(input.logPath, 'Systemd log path');
+        return [
+          `StandardOutput=append:${input.logPath}`,
+          `StandardError=append:${input.logPath}`,
+        ];
+      })()
+    : [];
+
   const lines = [
     '[Unit]',
     `Description=${description}`,
@@ -61,6 +73,7 @@ export function buildSystemdUnit(input: BuildSystemdUnitInput): string {
     'KillMode=control-group',
     workingDirLine,
     ...envLines,
+    ...logLines,
     '',
     '[Install]',
     'WantedBy=default.target',

--- a/packages/server/src/svc/systemd.ts
+++ b/packages/server/src/svc/systemd.ts
@@ -1,6 +1,7 @@
 
 
 import { existsSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { userInfo } from 'node:os';
 import { dirname } from 'node:path';
 
 import { execFileUtf8, type ExecOptions, type ExecResult } from './exec';
@@ -34,18 +35,24 @@ export interface SystemdManagerDeps {
 
   execSystemctl(args: readonly string[], options?: ExecOptions): Promise<ExecResult>;
 
+  execLoginctl(args: readonly string[], options?: ExecOptions): Promise<ExecResult>;
+
   resolveProgram(): string;
 
   unitPath(): string;
 
   logPath(): string;
+
+  userName(): string;
 }
 
 const DEFAULT_DEPS: SystemdManagerDeps = {
   execSystemctl: (args, options) => execFileUtf8('systemctl', ['--user', ...args], options),
+  execLoginctl: (args, options) => execFileUtf8('loginctl', args, options),
   resolveProgram: () => resolveSupervisorProgram(),
   unitPath: defaultSystemdUnitPath,
   logPath: defaultSupervisorLogPath,
+  userName: () => userInfo().username,
 };
 
 export function createSystemdManager(
@@ -87,9 +94,12 @@ export function createSystemdManager(
       );
     }
 
+    const lingerNote = await enableLinger(deps);
+    const baseMessage = `Kimi server systemd unit ${alreadyInstalled ? 'replaced' : 'installed'} at ${unitPath} (port ${plan.port}).`;
+
     return {
       status: alreadyInstalled ? 'replaced' : 'installed',
-      message: `Kimi server systemd unit ${alreadyInstalled ? 'replaced' : 'installed'} at ${unitPath} (port ${plan.port}).`,
+      message: lingerNote ? `${baseMessage} ${lingerNote}` : baseMessage,
       unitPath,
     };
   }
@@ -190,11 +200,15 @@ export function createSystemdManager(
     const subState = fields['SubState'];
     const mainPid = Number.parseInt(fields['MainPID'] ?? '', 10);
     const running = activeState === 'active' && subState !== 'failed';
+    const lingerNote = await probeLingerNote(deps);
     return {
       ...base,
       running,
       ...(Number.isFinite(mainPid) && mainPid > 0 ? { pid: mainPid } : {}),
-      notes: [`systemd state: ${activeState ?? 'unknown'}/${subState ?? 'unknown'}`],
+      notes: [
+        `systemd state: ${activeState ?? 'unknown'}/${subState ?? 'unknown'}`,
+        ...(lingerNote ? [lingerNote] : []),
+      ],
     };
   }
 
@@ -215,6 +229,7 @@ function writeUnit(unitPath: string, plan: InstallPlan): void {
   const text = buildSystemdUnit({
     description: 'Kimi Code local server (managed by `kimi server install`)',
     programArguments: plan.programArguments,
+    logPath: plan.logPath,
   });
   mkdirSync(dirname(unitPath), { recursive: true, mode: UNIT_DIR_MODE });
   writeFileSync(unitPath, text, { mode: UNIT_MODE });
@@ -223,4 +238,29 @@ function writeUnit(unitPath: string, plan: InstallPlan): void {
 function detail(res: ExecResult): string | undefined {
   const text = (res.stderr || res.stdout).trim();
   return text.length > 0 ? text : undefined;
+}
+
+async function readLinger(deps: SystemdManagerDeps): Promise<'yes' | 'no' | undefined> {
+  const probe = await deps.execLoginctl(['show-user', deps.userName(), '--property=Linger']);
+  if (probe.code !== 0) return undefined;
+  if (/\bLinger=yes\b/.test(probe.stdout)) return 'yes';
+  if (/\bLinger=no\b/.test(probe.stdout)) return 'no';
+  return undefined;
+}
+
+async function enableLinger(deps: SystemdManagerDeps): Promise<string | undefined> {
+  const user = deps.userName();
+  if ((await readLinger(deps)) === 'yes') return undefined;
+  const enable = await deps.execLoginctl(['enable-linger', user]);
+  if (enable.code === 0) return undefined;
+  return `Note: could not enable linger automatically; run \`sudo loginctl enable-linger ${user}\` to keep the server running after logout.`;
+}
+
+async function probeLingerNote(deps: SystemdManagerDeps): Promise<string | undefined> {
+  const current = await readLinger(deps);
+  if (current === 'yes') return 'linger: enabled (survives logout / starts at boot)';
+  if (current === 'no') {
+    return 'linger: disabled (stops on logout; run `sudo loginctl enable-linger $USER` to persist)';
+  }
+  return undefined;
 }

--- a/packages/server/test/svc/launchd.test.ts
+++ b/packages/server/test/svc/launchd.test.ts
@@ -154,6 +154,7 @@ describe('launchd manager — install', () => {
     const xml = readFileSync(plistPath, 'utf8');
     expect(xml).toContain(`<string>${KIMI_SERVER_LABEL}</string>`);
     expect(xml).toContain('<string>/usr/local/bin/kimi</string>');
+    expect(xml).toContain('<string>--foreground</string>');
     expect(xml).toContain('<string>58627</string>');
 
     expect(calls.length).toBe(1);

--- a/packages/server/test/svc/schtasks.test.ts
+++ b/packages/server/test/svc/schtasks.test.ts
@@ -14,7 +14,11 @@ import {
   createSchtasksManager,
   type SchtasksManagerDeps,
 } from '../../src/svc/schtasks';
-import { buildScheduledTaskXml, parseSchtasksQuery } from '../../src/svc/schtasks-xml';
+import {
+  buildCmdRedirectArgs,
+  buildScheduledTaskXml,
+  parseSchtasksQuery,
+} from '../../src/svc/schtasks-xml';
 import { KIMI_SERVER_TASK_NAME } from '../../src/svc/paths';
 import { readInstallPlan, writeInstallPlan } from '../../src/svc/install-plan';
 import type { ExecOptions, ExecResult } from '../../src/svc/exec';
@@ -120,6 +124,34 @@ describe('buildScheduledTaskXml', () => {
     expect(xml).toContain('<LogonType>InteractiveToken</LogonType>');
     expect(xml).not.toContain('<GroupId>S-1-5-32-545</GroupId>');
   });
+
+  it('wraps in cmd.exe and redirects stdout/stderr when redirectLogPath is set', () => {
+    const xml = buildScheduledTaskXml({
+      description: 'desc',
+      command: 'C:\\Program Files\\Kimi\\kimi.exe',
+      arguments: 'server run --foreground --port 58627',
+      redirectLogPath: 'C:\\Users\\alice\\AppData\\Local\\kimi-code\\server.log',
+    });
+    expect(xml).toContain('<Command>cmd.exe</Command>');
+    expect(xml).toContain('<Arguments>');
+    expect(xml).toContain('&gt;&gt;');
+    expect(xml).toContain('2&gt;&amp;1');
+    expect(xml).toContain('C:\\Program Files\\Kimi\\kimi.exe');
+    expect(xml).toContain('C:\\Users\\alice\\AppData\\Local\\kimi-code\\server.log');
+    expect(xml).toContain('server run --foreground --port 58627');
+  });
+});
+
+describe('buildCmdRedirectArgs', () => {
+  it('builds a cmd /c line that redirects to the log file', () => {
+    const args = buildCmdRedirectArgs('C:\\bin\\kimi.exe', 'server run', 'C:\\logs\\server.log');
+    expect(args).toBe('/c ""C:\\bin\\kimi.exe" server run >> "C:\\logs\\server.log" 2>&1"');
+  });
+
+  it('handles a missing argument list', () => {
+    const args = buildCmdRedirectArgs('C:\\bin\\kimi.exe', undefined, 'C:\\logs\\server.log');
+    expect(args).toBe('/c ""C:\\bin\\kimi.exe" >> "C:\\logs\\server.log" 2>&1"');
+  });
 });
 
 describe('parseSchtasksQuery', () => {
@@ -168,6 +200,7 @@ describe('schtasks manager — install', () => {
     expect(writtenXmls.length).toBe(1);
     expect(writtenXmls[0]).toContain(`<Description>Kimi Code local server`);
     expect(writtenXmls[0]).not.toContain('--host');
+    expect(writtenXmls[0]).toContain('--foreground');
     expect(writtenXmls[0]).toContain('--port 58627');
 
     expect(calls.length).toBe(2);

--- a/packages/server/test/svc/systemd.test.ts
+++ b/packages/server/test/svc/systemd.test.ts
@@ -47,17 +47,27 @@ function makeStubExec(responses: ReadonlyArray<ExecResult>) {
 function makeDeps(
   responses: ReadonlyArray<ExecResult>,
   workDir: string,
-): { deps: SystemdManagerDeps; calls: StubCall[]; unitPath: string; logPath: string } {
+  loginctlResponses: ReadonlyArray<ExecResult> = [],
+): {
+  deps: SystemdManagerDeps;
+  calls: StubCall[];
+  loginctlCalls: StubCall[];
+  unitPath: string;
+  logPath: string;
+} {
   const { execSystemctl, calls } = makeStubExec(responses);
+  const { execSystemctl: execLoginctl, calls: loginctlCalls } = makeStubExec(loginctlResponses);
   const unitPath = join(workDir, 'systemd', 'user', KIMI_SERVER_SYSTEMD_UNIT);
   const logPath = join(workDir, 'server', 'server.log');
   const deps: SystemdManagerDeps = {
     execSystemctl,
+    execLoginctl,
     resolveProgram: () => '/usr/local/bin/kimi',
     unitPath: () => unitPath,
     logPath: () => logPath,
+    userName: () => 'alice',
   };
-  return { deps, calls, unitPath, logPath };
+  return { deps, calls, loginctlCalls, unitPath, logPath };
 }
 
 let workDir: string;
@@ -113,6 +123,21 @@ describe('buildSystemdUnit', () => {
     expect(unit).toContain('Environment=FOO=bar');
     expect(unit).toContain('Environment=BAZ=qux');
   });
+
+  it('renders StandardOutput/StandardError append lines when logPath is set', () => {
+    const unit = buildSystemdUnit({
+      programArguments: ['/usr/bin/kimi'],
+      logPath: '/home/alice/.kimi/server/server.log',
+    });
+    expect(unit).toContain('StandardOutput=append:/home/alice/.kimi/server/server.log');
+    expect(unit).toContain('StandardError=append:/home/alice/.kimi/server/server.log');
+  });
+
+  it('omits StandardOutput/StandardError when logPath is unset', () => {
+    const unit = buildSystemdUnit({ programArguments: ['/usr/bin/kimi'] });
+    expect(unit).not.toContain('StandardOutput');
+    expect(unit).not.toContain('StandardError');
+  });
 });
 
 describe('parseSystemctlShow', () => {
@@ -149,7 +174,7 @@ describe('systemd manager — install', () => {
     expect(result.unitPath).toBe(unitPath);
     expect(existsSync(unitPath)).toBe(true);
     const text = readFileSync(unitPath, 'utf8');
-    expect(text).toContain('ExecStart=/usr/local/bin/kimi server run --port 58627 --log-level info');
+    expect(text).toContain('ExecStart=/usr/local/bin/kimi server run --foreground --port 58627 --log-level info');
     expect(text).not.toContain('--host');
 
     expect(calls.length).toBe(3);
@@ -185,7 +210,7 @@ describe('systemd manager — install', () => {
     const result = await mgr.install({ host: '0.0.0.0', port: 9999, logLevel: 'debug', force: true });
     expect(result.status).toBe('replaced');
     const text = readFileSync(unitPath, 'utf8');
-    expect(text).toContain('ExecStart=/usr/local/bin/kimi server run --port 9999 --log-level debug');
+    expect(text).toContain('ExecStart=/usr/local/bin/kimi server run --foreground --port 9999 --log-level debug');
     expect(text).not.toContain('0.0.0.0');
   });
 
@@ -355,5 +380,90 @@ describe('systemd manager — status', () => {
     expect(status.installed).toBe(true);
     expect(status.running).toBe(false);
     expect(status.notes?.[0]).toMatch(/systemctl --user show failed/);
+  });
+});
+
+describe('systemd manager — lingering', () => {
+  it('enables linger on install when not yet enabled', async () => {
+    const { deps, calls, loginctlCalls } = makeDeps(
+      [
+        { stdout: '', stderr: '', code: 0 },
+        { stdout: '', stderr: '', code: 0 },
+        { stdout: '', stderr: '', code: 0 },
+      ],
+      workDir,
+      [
+        { stdout: 'Linger=no', stderr: '', code: 0 },
+        { stdout: '', stderr: '', code: 0 },
+      ],
+    );
+    const mgr = createSystemdManager(deps);
+    const result = await mgr.install({ host: '127.0.0.1', port: 58627, logLevel: 'info' });
+    expect(result.status).toBe('installed');
+    expect(result.message).not.toMatch(/could not enable linger/);
+    expect(loginctlCalls.map((c) => c.args)).toEqual([
+      ['show-user', 'alice', '--property=Linger'],
+      ['enable-linger', 'alice'],
+    ]);
+    expect(calls.length).toBe(3);
+  });
+
+  it('does not call enable-linger when already lingering', async () => {
+    const { deps, loginctlCalls } = makeDeps(
+      [
+        { stdout: '', stderr: '', code: 0 },
+        { stdout: '', stderr: '', code: 0 },
+        { stdout: '', stderr: '', code: 0 },
+      ],
+      workDir,
+      [{ stdout: 'Linger=yes', stderr: '', code: 0 }],
+    );
+    const mgr = createSystemdManager(deps);
+    await mgr.install({ host: '127.0.0.1', port: 58627, logLevel: 'info' });
+    expect(loginctlCalls.map((c) => c.args)).toEqual([['show-user', 'alice', '--property=Linger']]);
+  });
+
+  it('surfaces a note when enable-linger fails', async () => {
+    const { deps } = makeDeps(
+      [
+        { stdout: '', stderr: '', code: 0 },
+        { stdout: '', stderr: '', code: 0 },
+        { stdout: '', stderr: '', code: 0 },
+      ],
+      workDir,
+      [
+        { stdout: 'Linger=no', stderr: '', code: 0 },
+        { stdout: '', stderr: 'Access denied', code: 1 },
+      ],
+    );
+    const mgr = createSystemdManager(deps);
+    const result = await mgr.install({ host: '127.0.0.1', port: 58627, logLevel: 'info' });
+    expect(result.status).toBe('installed');
+    expect(result.message).toMatch(/could not enable linger/);
+    expect(result.message).toMatch(/sudo loginctl enable-linger alice/);
+  });
+
+  it('reports linger state in status notes', async () => {
+    const showOutput = ['ActiveState=active', 'SubState=running', 'MainPID=42'].join('\n');
+    const { deps, unitPath } = makeDeps(
+      [{ stdout: showOutput, stderr: '', code: 0 }],
+      workDir,
+      [{ stdout: 'Linger=yes', stderr: '', code: 0 }],
+    );
+    mkdirSync(unitPath.replace(/\/[^/]+$/, ''), { recursive: true });
+    writeFileSync(unitPath, '# stub');
+    writeInstallPlan({
+      host: '127.0.0.1',
+      port: 58627,
+      logLevel: 'info',
+      program: '/usr/local/bin/kimi',
+      programArguments: [],
+      logPath: '/tmp/x',
+      installedAt: '2026-06-11T00:00:00.000Z',
+    });
+    const mgr = createSystemdManager(deps);
+    const status = await mgr.status();
+    expect(status.running).toBe(true);
+    expect(status.notes?.some((n) => n.includes('linger: enabled'))).toBe(true);
   });
 });


### PR DESCRIPTION
## Related Issue

No linked issue — this hardens the existing (but currently misconfigured) OS service-ization backends in `packages/server/src/svc`.

## Problem

The `kimi server install` flow registers the local server as an OS-managed service (launchd / systemd / schtasks), but the backends had a few correctness problems:

- **Wrong supervised command.** The supervisor was configured to run `kimi server run`, but `server run` now spawns a detached background daemon by default, so the OS service manager saw the process exit immediately instead of supervising a long-lived foreground process.
- **Windows path + logs.** On Windows the task used a relative `kimi.exe` (relied on `PATH`) and discarded the server's stdout/stderr, making failures hard to diagnose.
- **Linux logs + persistence.** The systemd unit only logged to journald (inconsistent with the other backends), and the user service stopped on logout because lingering was not enabled.

## What changed

Harden the three service backends in `packages/server/src/svc` and extend the unit tests:

- **Foreground supervised process.** The install plan now invokes `kimi server run --foreground`, so the supervisor tracks a long-lived in-process server (`install-plan.ts`).
- **Windows (schtasks).** Use the absolute executable path instead of the relative `kimi.exe`, and wrap the action in `cmd.exe /c "... >> <log> 2>&1"` so stdout/stderr are captured to the log file (`schtasks.ts`, `schtasks-xml.ts`).
- **Linux (systemd).** Route stdout/stderr to the log file via `StandardOutput=append:`/`StandardError=append:`, and best-effort enable `loginctl linger` on install so the per-user service survives logout and starts at boot (with the linger state reported in `status`) (`systemd-unit.ts`, `systemd.ts`).
- **Tests.** Extended `test/svc/{launchd,systemd,schtasks}.test.ts` to cover the foreground flag, the Windows redirection, the systemd log lines, and the lingering flow.

This keeps the per-user service model on all three platforms. On macOS/Windows the service starts at login and stops on logout (a user-level service cannot persist after logout without going system-level); Linux gets full "survives logout" via lingering.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [ ] Ran `gen-changesets` skill, or this PR needs no changeset.
- [ ] Ran `gen-docs` skill, or this PR needs no doc update.
