### PR TITLE
fix(web): keep slash skills in composer and match substrings in slash search

### DIFF
--- a/.changeset/web-slash-skill-ux.md
+++ b/.changeset/web-slash-skill-ux.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Fix web slash skill selection sending immediately and allow slash search to match skill names by substring.

--- a/apps/kimi-web/src/lib/slashCommands.ts
+++ b/apps/kimi-web/src/lib/slashCommands.ts
@@ -79,6 +79,10 @@ export function buildSlashItems(
     name: `/${s.name}`,
     desc: s.description,
     isSkill: true,
+    // Keep the selected skill in the composer so the user can append
+    // arguments (or just press Enter to activate with none), instead of
+    // activating the skill immediately on selection.
+    acceptsInput: true,
   }));
   return [...SLASH_COMMANDS, ...skillItems];
 }
@@ -92,7 +96,11 @@ export function filterCommands(
   query: string,
   items: SlashCommand[] = SLASH_COMMANDS,
 ): SlashCommand[] {
-  const q = query.toLowerCase().trim();
-  if (q === '' || q === '/') return items;
-  return items.filter((c) => c.name.toLowerCase().includes(q));
+  // Drop the leading `/` so the query matches anywhere in the command name,
+  // not only as a prefix (e.g. `/context` matches `/xxx-context`).
+  const q = query.toLowerCase().trim().replace(/^\//, '');
+  if (q === '') return items;
+  return items.filter((c) =>
+    c.name.toLowerCase().replace(/^\//, '').includes(q),
+  );
 }

--- a/apps/kimi-web/test/composer.test.ts
+++ b/apps/kimi-web/test/composer.test.ts
@@ -280,6 +280,19 @@ describe('Composer slash command input', () => {
     expect((textarea.element as HTMLTextAreaElement).value).toBe('/goal ');
     expect(wrapper.emitted('command')).toBeUndefined();
   });
+
+  it('keeps selected session skills in the composer so arguments can be added', async () => {
+    const wrapper = mountComposer({
+      skills: [{ name: 'my-skill', description: 'Do a thing', source: 'project' }],
+    });
+    const textarea = wrapper.get('textarea');
+
+    await textarea.setValue('/my');
+    await textarea.trigger('keydown', { key: 'Enter' });
+
+    expect((textarea.element as HTMLTextAreaElement).value).toBe('/my-skill ');
+    expect(wrapper.emitted('command')).toBeUndefined();
+  });
 });
 
 describe('Composer model dropdown', () => {

--- a/apps/kimi-web/test/slash-skills.test.ts
+++ b/apps/kimi-web/test/slash-skills.test.ts
@@ -4,6 +4,7 @@ import { SLASH_COMMANDS, buildSlashItems, filterCommands } from '../src/lib/slas
 const skills = [
   { name: 'brainstorm', description: 'Turn an idea into a design' },
   { name: 'deep-research', description: 'Fan-out web research' },
+  { name: 'xxx-context', description: 'Manage context' },
 ];
 
 describe('slash menu with session skills', () => {
@@ -39,5 +40,21 @@ describe('slash menu with session skills', () => {
   it('empty/slash query returns everything', () => {
     const items = buildSlashItems(skills);
     expect(filterCommands('/', items).length).toBe(items.length);
+  });
+
+  it('flags session skills as accepting input so they stay in the composer', () => {
+    const items = buildSlashItems(skills);
+    const brainstorm = items.find((i) => i.name === '/brainstorm');
+    expect(brainstorm?.acceptsInput).toBe(true);
+  });
+
+  it('matches substrings anywhere in the command name, not only as a prefix', () => {
+    const items = buildSlashItems(skills);
+    expect(filterCommands('/context', items).map((i) => i.name)).toEqual([
+      '/xxx-context',
+    ]);
+    expect(filterCommands('/research', items).map((i) => i.name)).toEqual([
+      '/deep-research',
+    ]);
   });
 });


### PR DESCRIPTION
## Related Issue

N/A — this addresses direct user feedback about web slash skill UX.

## Problem

Two related issues in the web UI slash menu:

1. Selecting a session skill from the slash menu immediately activated/sent the skill, giving users no chance to append arguments or confirm before running it.
2. Slash skill search only matched prefixes after the leading ``/``. For example, typing ``/context`` would not find a skill named ``xxx-context``.

## What changed

- In ``buildSlashItems()``, session skills now carry ``acceptsInput: true``, so selecting a skill leaves ``/skillname `` in the composer. Users can press Enter to run with no arguments or type arguments first.
- In ``filterCommands()``, the leading ``/`` is stripped from both the query and command names before matching, allowing substring matches anywhere in the skill name.
- Added tests covering skill selection staying in the composer and substring search matching.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran ``gen-changesets`` skill, or this PR needs no changeset.
- [x] Ran ``gen-docs`` skill, or this PR needs no doc update.