### PR TITLE
docs(reference): fix kimi web to document background-daemon behavior

### DIFF
--- a/docs/en/reference/kimi-command.md
+++ b/docs/en/reference/kimi-command.md
@@ -194,15 +194,17 @@ The loopback host, chosen port, and log level are recorded to `~/.kimi-code/serv
 
 #### `kimi web`
 
-Alias for `kimi server run` with `--open` defaulted to `true`: it starts a background daemon (reusing a running one), opens the web UI in the default browser once healthy, and returns, leaving the server resident in the background. Use `--no-open` to skip the browser launch (effectively turning it back into `kimi server run`), or `--foreground` to run attached to the current terminal.
+Opens Kimi's graphical session in the browser as an alternative to the terminal TUI.
+
+Equivalent to `kimi server run --open`: it starts a local Kimi server in the background (reusing one already running), opens the web UI in the default browser, and returns, leaving the server resident in the background. The only difference from `kimi server run` is that `--open` is enabled by default (auto-launches the browser); all other behavior is identical.
 
 ```sh
-kimi web                        # background daemon + open browser
-kimi web --no-open              # equivalent to `kimi server run`
-kimi web --foreground           # run attached to the current terminal
+kimi web                 # start the server in the background and open the browser (reuses a running one)
+kimi web --no-open       # don't open the browser; same as `kimi server run`
+kimi web --foreground    # run attached to the current terminal and open the browser
 ```
 
-The same `--port`, `--log-level`, and `--debug-endpoints` flags work as on `kimi server run`.
+Stop the server with `kimi server kill` and list active connections with `kimi server ps`; `--port`, `--log-level`, and the other flags match `kimi server run`.
 
 ### `kimi doctor`
 

--- a/docs/en/reference/kimi-command.md
+++ b/docs/en/reference/kimi-command.md
@@ -194,11 +194,12 @@ The loopback host, chosen port, and log level are recorded to `~/.kimi-code/serv
 
 #### `kimi web`
 
-Alias for `kimi server run` with `--open` defaulted to `true` — runs the server in the foreground and opens the web UI in the default browser once it is healthy. Use `--no-open` to skip the browser launch (effectively turning it back into `kimi server run`).
+Alias for `kimi server run` with `--open` defaulted to `true`: it starts a background daemon (reusing a running one), opens the web UI in the default browser once healthy, and returns, leaving the server resident in the background. Use `--no-open` to skip the browser launch (effectively turning it back into `kimi server run`), or `--foreground` to run attached to the current terminal.
 
 ```sh
-kimi web                        # foreground + open browser
+kimi web                        # background daemon + open browser
 kimi web --no-open              # equivalent to `kimi server run`
+kimi web --foreground           # run attached to the current terminal
 ```
 
 The same `--port`, `--log-level`, and `--debug-endpoints` flags work as on `kimi server run`.

--- a/docs/zh/reference/kimi-command.md
+++ b/docs/zh/reference/kimi-command.md
@@ -194,15 +194,17 @@ kimi server status             # 查看安装与运行状态
 
 #### `kimi web`
 
-`kimi server run --open` 的别名：后台启动本地服务（已运行则复用），健康后立即用默认浏览器打开 web UI，随后命令返回，服务驻留后台。加 `--no-open` 等价于纯 `kimi server run`；加 `--foreground` 则在当前终端前台运行。
+在浏览器中打开 Kimi 的图形会话界面，作为终端 TUI 的替代入口。
+
+等价于 `kimi server run --open`：在后台启动本地 Kimi 服务（若已运行则复用），用默认浏览器打开 web UI，随后命令返回，服务驻留后台。与 `kimi server run` 的唯一区别是默认启用 `--open`（自动打开浏览器），其余行为一致。
 
 ```sh
-kimi web                        # 后台启动 + 自动打开浏览器
-kimi web --no-open              # 等价于 `kimi server run`
-kimi web --foreground           # 在当前终端前台运行
+kimi web                 # 后台启动服务并打开浏览器（已运行则复用）
+kimi web --no-open       # 不打开浏览器，等同 `kimi server run`
+kimi web --foreground    # 在当前终端前台运行，同时打开浏览器
 ```
 
-`--port`、`--log-level`、`--debug-endpoints` 与 `kimi server run` 完全一致。
+停止服务使用 `kimi server kill`，查看活动连接使用 `kimi server ps`；`--port`、`--log-level` 等选项与 `kimi server run` 一致。
 
 ### `kimi doctor`
 

--- a/docs/zh/reference/kimi-command.md
+++ b/docs/zh/reference/kimi-command.md
@@ -194,11 +194,12 @@ kimi server status             # 查看安装与运行状态
 
 #### `kimi web`
 
-`kimi server run --open` 的别名：前台跑服务，健康后立即用默认浏览器打开 web UI。加 `--no-open` 等价于纯 `kimi server run`。
+`kimi server run --open` 的别名：后台启动本地服务（已运行则复用），健康后立即用默认浏览器打开 web UI，随后命令返回，服务驻留后台。加 `--no-open` 等价于纯 `kimi server run`；加 `--foreground` 则在当前终端前台运行。
 
 ```sh
-kimi web                        # 前台 + 自动打开浏览器
+kimi web                        # 后台启动 + 自动打开浏览器
 kimi web --no-open              # 等价于 `kimi server run`
+kimi web --foreground           # 在当前终端前台运行
 ```
 
 `--port`、`--log-level`、`--debug-endpoints` 与 `kimi server run` 完全一致。


### PR DESCRIPTION
## What

The `kimi web` reference doc (`docs/{zh,en}/reference/kimi-command.md`) describes the command as running the server **in the foreground**. That contradicts the actual implementation.

## Why

`kimi web` is registered via `buildRunCommand` with `defaultOpen: true` (see `apps/kimi-code/src/cli/sub/server/web-alias.ts`) — the exact same code path as `kimi server run`, which is a **background daemon by default** (`--foreground` to attach), per `apps/kimi-code/src/cli/sub/server/index.ts`. Its own description string even reads "starts a background daemon if needed."

## Change

- Correct the prose (zh + en) to: background daemon, command returns, server stays resident.
- Add the `kimi web --foreground` example (a valid flag, since it shares `server run`'s options).
- Tone/format unchanged; only the `kimi web` section is touched.