### PR TITLE
chore: suggest /reload alongside /new in plugin hints

### DIFF
--- a/.changeset/plugin-hint-reload.md
+++ b/.changeset/plugin-hint-reload.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Suggest `/reload` alongside `/new` in plugin-change hints.

--- a/apps/kimi-code/src/tui/commands/plugins.ts
+++ b/apps/kimi-code/src/tui/commands/plugins.ts
@@ -95,7 +95,7 @@ export async function handlePluginsCommand(host: SlashCommandHost, rawArgs: stri
       }
       await session.setPluginMcpServerEnabled(id, server, action === 'enable');
       host.showStatus(
-        `${action === 'enable' ? 'Enabled' : 'Disabled'} MCP server ${server} for ${id}. Run /new to apply.`,
+        `${action === 'enable' ? 'Enabled' : 'Disabled'} MCP server ${server} for ${id}. Run /new or /reload to apply.`,
       );
       return;
     }
@@ -274,7 +274,7 @@ async function applyPluginEnabled(
       ? ` Some MCP servers are disabled; re-enable with /plugins mcp enable ${id} <server>.`
       : '';
   if (showStatus) {
-    host.showStatus(`${enabled ? 'Enabled' : 'Disabled'} ${id}. Run /new to apply.${mcpHint}`);
+    host.showStatus(`${enabled ? 'Enabled' : 'Disabled'} ${id}. Run /new or /reload to apply.${mcpHint}`);
   }
   const inlineMcpHint = mcpHint.length > 0 ? ' · MCP servers disabled' : '';
   return `${pluginInlineChangeHint()}${inlineMcpHint}`;
@@ -425,12 +425,12 @@ function showPluginInstallResult(
       : '';
   const action = describeInstallAction(previous, summary);
   host.showStatus(
-    `${action} (${summary.id}).${mcpHint} Run /new to apply plugin changes.`,
+    `${action} (${summary.id}).${mcpHint} Run /new or /reload to apply plugin changes.`,
   );
   if (options?.successNotice === 'marketplace') {
     host.showNotice(
       `Installed or updated ${summary.displayName}`,
-      `Marketplace install or update succeeded for ${summary.id}. Run /new to apply plugin changes.`,
+      `Marketplace install or update succeeded for ${summary.id}. Run /new or /reload to apply plugin changes.`,
     );
   }
 }
@@ -482,5 +482,5 @@ function resolvePluginInstallSource(source: string, workDir: string): string {
 }
 
 function pluginInlineChangeHint(): string {
-  return 'require run /new to apply';
+  return 'require run /new or /reload to apply';
 }

--- a/apps/kimi-code/test/tui/kimi-tui-message-flow.test.ts
+++ b/apps/kimi-code/test/tui/kimi-tui-message-flow.test.ts
@@ -3184,11 +3184,11 @@ command = "vim"
     // refreshed render rather than for an instance swap.
     await vi.waitFor(() => {
       const refreshed = stripSgr(driver.state.editorContainer.children[0]!.render(120).join('\n'));
-      expect(refreshed).toContain('❯ Demo  disabled  require run /new to apply');
+      expect(refreshed).toContain('❯ Demo  disabled  require run /new or /reload to apply');
     });
     const out = stripSgr(driver.state.editorContainer.children[0]!.render(120).join('\n'));
     expect(out).not.toContain('Space enable');
-    expect(stripSgr(renderTranscript(driver))).not.toContain('Disabled demo. Run /new to apply.');
+    expect(stripSgr(renderTranscript(driver))).not.toContain('Disabled demo. Run /new or /reload to apply.');
   });
 
   it('toggles plugin MCP servers from the overview MCP picker', async () => {
@@ -3279,9 +3279,9 @@ command = "vim"
       expect(driver.state.editorContainer.children[0]).toBeInstanceOf(PluginMcpSelectorComponent);
     });
     const out = stripSgr(driver.state.editorContainer.children[0]!.render(120).join('\n'));
-    expect(out).toContain('❯ data  disabled  require run /new to apply');
+    expect(out).toContain('❯ data  disabled  require run /new or /reload to apply');
     expect(stripSgr(renderTranscript(driver))).not.toContain(
-      'Disabled MCP server data for kimi-datasource. Run /new to apply.',
+      'Disabled MCP server data for kimi-datasource. Run /new or /reload to apply.',
     );
   });
 


### PR DESCRIPTION
## Related Issue

No related issue. This is a small wording improvement.

## Problem

After installing, enabling, disabling, or changing MCP servers for a plugin, the UI only tells users to run `/new` to apply changes. However, `/reload` also reloads the session and applies plugin changes, so users who prefer not to start a new chat have no way to know this from the hint.

## What changed

Updated all plugin-change status messages and the inline picker hint from `Run /new to apply` to `Run /new or /reload to apply`. The corresponding tests were updated to match the new wording. A changeset was added for the CLI package.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.