### PR TITLE
fix(web): improve slash menu and skill editing experience

### DIFF
--- a/.changeset/web-slash-menu-wrap.md
+++ b/.changeset/web-slash-menu-wrap.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Allow long web slash command names and descriptions to wrap without overflowing the slash menu.

--- a/.changeset/web-slash-skill-ux.md
+++ b/.changeset/web-slash-skill-ux.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Fix web slash skill selection sending immediately and allow slash search to match skill names by substring.

--- a/apps/kimi-web/src/components/SlashMenu.vue
+++ b/apps/kimi-web/src/components/SlashMenu.vue
@@ -51,8 +51,9 @@ const emit = defineEmits<{
 }
 
 .slash-item {
-  display: flex;
-  align-items: baseline;
+  display: grid;
+  grid-template-columns: minmax(90px, 32%) minmax(0, 1fr);
+  align-items: start;
   gap: 10px;
   padding: 5px 12px;
   cursor: pointer;
@@ -73,12 +74,23 @@ const emit = defineEmits<{
 .slash-name {
   color: var(--blue);
   font-weight: 600;
-  min-width: 90px;
-  flex-shrink: 0;
+  min-width: 0;
+  line-height: 1.45;
+  overflow-wrap: anywhere;
 }
 
 .slash-desc {
   color: var(--dim);
   font-size: calc(var(--ui-font-size) - 2.5px);
+  min-width: 0;
+  line-height: 1.45;
+  overflow-wrap: anywhere;
+}
+
+@media (max-width: 520px) {
+  .slash-item {
+    grid-template-columns: minmax(0, 1fr);
+    gap: 2px;
+  }
 }
 </style>

--- a/apps/kimi-web/src/lib/slashCommands.ts
+++ b/apps/kimi-web/src/lib/slashCommands.ts
@@ -79,6 +79,8 @@ export function buildSlashItems(
     name: `/${s.name}`,
     desc: s.description,
     isSkill: true,
+    // Keep the selected skill in the composer so arguments can be appended.
+    acceptsInput: true,
   }));
   return [...SLASH_COMMANDS, ...skillItems];
 }
@@ -92,7 +94,9 @@ export function filterCommands(
   query: string,
   items: SlashCommand[] = SLASH_COMMANDS,
 ): SlashCommand[] {
-  const q = query.toLowerCase().trim();
-  if (q === '' || q === '/') return items;
-  return items.filter((c) => c.name.toLowerCase().includes(q));
+  const q = query.toLowerCase().trim().replace(/^\//, '');
+  if (q === '') return items;
+  return items.filter((c) =>
+    c.name.toLowerCase().replace(/^\//, '').includes(q),
+  );
 }

--- a/apps/kimi-web/src/lib/slashCommands.ts
+++ b/apps/kimi-web/src/lib/slashCommands.ts
@@ -86,9 +86,10 @@ export function buildSlashItems(
 }
 
 /**
- * Filter slash items by a query string (case-insensitive substring on the name).
- * If query is empty or just "/", returns all items. Defaults to the built-in
- * commands; pass a merged list (see buildSlashItems) to include skills.
+ * Filter slash items by a query string. Matches are ranked so exact and prefix
+ * matches come before arbitrary substring matches. If query is empty or just
+ * "/", returns all items. Defaults to the built-in commands; pass a merged list
+ * (see buildSlashItems) to include skills.
  */
 export function filterCommands(
   query: string,
@@ -96,7 +97,20 @@ export function filterCommands(
 ): SlashCommand[] {
   const q = query.toLowerCase().trim().replace(/^\//, '');
   if (q === '') return items;
-  return items.filter((c) =>
-    c.name.toLowerCase().replace(/^\//, '').includes(q),
-  );
+
+  return items
+    .map((item, index) => {
+      const name = item.name.toLowerCase().replace(/^\//, '');
+      let score = 0;
+      if (name === q) score = 3;
+      else if (name.startsWith(q)) score = 2;
+      else if (name.includes(q)) score = 1;
+      return { item, index, score };
+    })
+    .filter(({ score }) => score > 0)
+    .sort((a, b) => {
+      if (a.score !== b.score) return b.score - a.score;
+      return a.index - b.index;
+    })
+    .map(({ item }) => item);
 }

--- a/apps/kimi-web/test/composer.test.ts
+++ b/apps/kimi-web/test/composer.test.ts
@@ -280,6 +280,19 @@ describe('Composer slash command input', () => {
     expect((textarea.element as HTMLTextAreaElement).value).toBe('/goal ');
     expect(wrapper.emitted('command')).toBeUndefined();
   });
+
+  it('keeps selected session skills in the composer so arguments can be added', async () => {
+    const wrapper = mountComposer({
+      skills: [{ name: 'my-skill', description: 'Do a thing', source: 'project' }],
+    });
+    const textarea = wrapper.get('textarea');
+
+    await textarea.setValue('/my');
+    await textarea.trigger('keydown', { key: 'Enter' });
+
+    expect((textarea.element as HTMLTextAreaElement).value).toBe('/my-skill ');
+    expect(wrapper.emitted('command')).toBeUndefined();
+  });
 });
 
 describe('Composer model dropdown', () => {

--- a/apps/kimi-web/test/slash-skills.test.ts
+++ b/apps/kimi-web/test/slash-skills.test.ts
@@ -4,6 +4,7 @@ import { SLASH_COMMANDS, buildSlashItems, filterCommands } from '../src/lib/slas
 const skills = [
   { name: 'brainstorm', description: 'Turn an idea into a design' },
   { name: 'deep-research', description: 'Fan-out web research' },
+  { name: 'xxx-context', description: 'Manage context' },
 ];
 
 describe('slash menu with session skills', () => {
@@ -39,5 +40,21 @@ describe('slash menu with session skills', () => {
   it('empty/slash query returns everything', () => {
     const items = buildSlashItems(skills);
     expect(filterCommands('/', items).length).toBe(items.length);
+  });
+
+  it('flags session skills as accepting input so they stay in the composer', () => {
+    const items = buildSlashItems(skills);
+    const brainstorm = items.find((i) => i.name === '/brainstorm');
+    expect(brainstorm?.acceptsInput).toBe(true);
+  });
+
+  it('matches substrings anywhere in the command name, not only as a prefix', () => {
+    const items = buildSlashItems(skills);
+    expect(filterCommands('/context', items).map((i) => i.name)).toEqual([
+      '/xxx-context',
+    ]);
+    expect(filterCommands('/research', items).map((i) => i.name)).toEqual([
+      '/deep-research',
+    ]);
   });
 });

--- a/apps/kimi-web/test/slash-skills.test.ts
+++ b/apps/kimi-web/test/slash-skills.test.ts
@@ -57,4 +57,11 @@ describe('slash menu with session skills', () => {
       '/deep-research',
     ]);
   });
+
+  it('ranks exact and prefix matches ahead of substring matches', () => {
+    const items = buildSlashItems([{ name: 'log', description: 'Write a log' }]);
+    const names = filterCommands('/log', items).map((i) => i.name);
+    expect(names[0]).toBe('/log');
+    expect(names).toContain('/login');
+  });
 });


### PR DESCRIPTION
## Related Issue

N/A - Small UX fixes discovered while working on the web composer.

## Problem

1. Session slash skills (e.g. project skills shown in the slash menu) were treated as "fire immediately" commands. Selecting one inserted the skill name and sent it right away, so users could not append arguments or extra text.
2. Long slash command names and descriptions could overflow the fixed-width slash menu row, breaking the layout.

## What changed

- Mark session skills as `acceptsInput: true` in `apps/kimi-web/src/lib/slashCommands.ts` so they stay in the composer after selection, matching built-in slash commands that accept arguments.
- Relaxed slash command filtering to match substrings anywhere in the name and to ignore the leading `/`, so searching for `context` or `research` finds `xxx-context` and `deep-research`.
- Reworked `SlashMenu.vue` layout from flex to a responsive grid so long names and descriptions wrap cleanly instead of overflowing.
- Added/updated unit tests in `apps/kimi-web/test/composer.test.ts` and `apps/kimi-web/test/slash-skills.test.ts`.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [ ] Ran `gen-docs` skill, or this PR needs no doc update.
