### PR TITLE
feat(server): report host kimi-code CLI version in /meta

### DIFF
--- a/packages/server/src/routes/meta.ts
+++ b/packages/server/src/routes/meta.ts
@@ -13,10 +13,6 @@
  * **Wire shape**: matches `metaResponseSchema` (REST.md §3.1) exactly. The
  * envelope wrap is `okEnvelope(data, req.id)` — `req.id` is the bare 26-char
  * ULID set by Fastify's `genReqId` via `resolveRequestId`.
- *
- * **Anti-corruption**: no SDK package import, no broker / bridge access. The
- * version source is the server's own `package.json` read via
- * `getServerVersion()` — no indirection through services or agent-core.
  */
 
 import { metaResponseSchema } from '@moonshot-ai/protocol';
@@ -45,7 +41,6 @@ interface RouteHost {
 }
 
 export interface MetaRouteOptions {
-  /** Server `package.json` version. Cached at startup. */
   readonly serverVersion: string;
   /** Per-process ULID. Minted once at boot in `start.ts`. */
   readonly serverId: string;

--- a/packages/server/src/start.ts
+++ b/packages/server/src/start.ts
@@ -87,7 +87,7 @@ export async function startServer(opts: ServerStartOptions): Promise<RunningServ
   app.setSerializerCompiler(() => (data) => JSON.stringify(data));
   installErrorHandler(app);
 
-  const serverVersion = getServerVersion();
+  const serverVersion = opts.coreProcessOptions?.identity?.version ?? getServerVersion();
 
   async function registerOpenApi(): Promise<void> {
     const { default: swagger } = await import('@fastify/swagger');

--- a/packages/server/src/version.ts
+++ b/packages/server/src/version.ts
@@ -1,12 +1,3 @@
-/**
- * Read the server's own `package.json` version at boot. Mirrors
- * `packages/agent-core/src/version.ts:4-13` so the server's `/meta` can
- * report a real version without taking an SDK / agent-core export dep.
- *
- * Tries the bundled-at-build `package.json` next to `dist/` first; falls back
- * to `0.0.0` if the file is unreachable (e.g. tree-shaken bundle).
- */
-
 import { readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 

--- a/packages/server/test/meta.e2e.test.ts
+++ b/packages/server/test/meta.e2e.test.ts
@@ -165,6 +165,24 @@ describe('GET /api/v1/meta — envelope + metaResponseSchema', () => {
   });
 });
 
+describe('GET /api/v1/meta — server_version precedence', () => {
+  it('reports the host kimi-code identity version when provided', async () => {
+    server = await startServer({
+      host: '127.0.0.1',
+      port: 0,
+      lockPath,
+      logger: pino({ level: 'silent' }),
+      coreProcessOptions: {
+        homeDir: bridgeHome,
+        identity: { userAgentProduct: 'kimi-code-cli', version: '9.9.9-test' },
+      },
+    });
+    const res = await appOf(server).inject({ method: 'GET', url: '/api/v1/meta' });
+    const data = (res.json() as { data: { server_version: string } }).data;
+    expect(data.server_version).toBe('9.9.9-test');
+  });
+});
+
 describe('GET /api/v1/meta — request_id propagation (W4.3 contract)', () => {
   it('echoes a client-supplied valid ULID verbatim', async () => {
     const r = await bootDaemon();


### PR DESCRIPTION
## Summary

When the Kimi Code server runs hosted inside the `kimi-code` CLI process, the `/api/v1/meta` endpoint (and the generated OpenAPI/AsyncAPI docs) reported the server's own `@moonshot-ai/server` package version. That internal version is meaningless to host consumers, who actually want the version of the host CLI. This PR lets a host process pass its identity version down to `/meta`, while preserving the standalone behavior as a fallback.

## Related Issue

No linked issue — problem explained below.

## Problem

`startServer` derived `serverVersion` exclusively from `getServerVersion()`, which reads the server's own `package.json`. There was no channel for a host process (the `kimi-code` CLI) to surface its own version through `/meta`, so the reported `server_version` did not reflect the product the user actually runs. The stale doc comments in `meta.ts` / `version.ts` also asserted that the server's own `package.json` was the intentional version source, which no longer holds once a host identity is involved.

## What changed

- `packages/server/src/start.ts`: `serverVersion` now prefers `opts.coreProcessOptions?.identity?.version` and falls back to `getServerVersion()` when the server runs standalone without a host identity.
- `packages/server/src/routes/meta.ts` / `packages/server/src/version.ts`: removed the "Anti-corruption" / version-source doc comments that described the server's own `package.json` as the source of truth.
- `packages/server/test/meta.e2e.test.ts`: added an e2e test that boots the server with `coreProcessOptions.identity.version = '9.9.9-test'` and asserts `/api/v1/meta` reports it as `server_version`.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset. (needs no changeset — `@moonshot-ai/server` is in `.changeset/config.json` `ignore`)
- [x] Ran `gen-docs` skill, or this PR needs no doc update. (internal server behavior; no user-facing doc change)
