### PR TITLE
fix(web): keep highlighted slash command visible in long menus

### DIFF
--- a/.changeset/web-slash-menu-scroll.md
+++ b/.changeset/web-slash-menu-scroll.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Keep the highlighted web slash command visible while navigating a long slash menu.

--- a/apps/kimi-web/src/components/SlashMenu.vue
+++ b/apps/kimi-web/src/components/SlashMenu.vue
@@ -31,7 +31,7 @@ watch(
   <div v-if="items.length > 0" class="slash-menu" role="listbox">
     <div
       v-for="(item, i) in items"
-      ref="itemRefs"
+      :ref="(el) => { if (el) itemRefs[i] = el as HTMLElement }"
       :key="`${item.name}-${i}`"
       class="slash-item"
       :class="{ active: i === props.activeIndex }"

--- a/apps/kimi-web/src/components/SlashMenu.vue
+++ b/apps/kimi-web/src/components/SlashMenu.vue
@@ -1,6 +1,7 @@
 <!-- apps/kimi-web/src/components/SlashMenu.vue -->
 <!-- Popup list of slash commands shown above the Composer textarea. -->
 <script setup lang="ts">
+import { ref, watch } from 'vue';
 import { useI18n } from 'vue-i18n';
 import type { SlashCommand } from '../lib/slashCommands';
 
@@ -15,13 +16,23 @@ const emit = defineEmits<{
   select: [item: SlashCommand];
   hover: [index: number];
 }>();
+
+const itemRefs = ref<HTMLElement[]>([]);
+
+watch(
+  () => props.activeIndex,
+  (idx) => {
+    itemRefs.value[idx]?.scrollIntoView({ block: 'nearest' });
+  },
+);
 </script>
 
 <template>
   <div v-if="items.length > 0" class="slash-menu" role="listbox">
     <div
       v-for="(item, i) in items"
-      :key="item.name"
+      ref="itemRefs"
+      :key="`${item.name}-${i}`"
       class="slash-item"
       :class="{ active: i === props.activeIndex }"
       role="option"


### PR DESCRIPTION
## Related Issue

N/A — follow-up polish after #878.

## Problem

When the web slash menu is longer than its max height, pressing Arrow keys moves the active item outside the visible area, so the user loses track of the highlighted command. Also, the menu used `item.name` as the Vue `key`, which can collide when the same skill name is provided by multiple sources.

## What changed

- Watch the active index in `SlashMenu.vue` and call `scrollIntoView({ block: 'nearest' })` on the active item so it stays visible while navigating.
- Switch item refs to a function ref that writes by index, guaranteeing the ref order matches the items array.
- Stabilize the v-for `key` by appending the index so duplicate names do not conflict.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [ ] Ran `gen-docs` skill, or this PR needs no doc update.
