### PR TITLE
fix(web): paginate session list on load

### DIFF
--- a/.changeset/web-sessions-pagination.md
+++ b/.changeset/web-sessions-pagination.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Fix the web app only loading the 20 most recent sessions; it now follows pagination so older sessions are reachable.

--- a/.changeset/web-sessions-per-workspace.md
+++ b/.changeset/web-sessions-per-workspace.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Fix the web app only loading the 20 most recent sessions globally; it now lists sessions per workspace and follows pagination so older sessions are reachable.

--- a/.changeset/web-sessions-per-workspace.md
+++ b/.changeset/web-sessions-per-workspace.md
@@ -1,5 +1,0 @@
----
-"@moonshot-ai/kimi-code": patch
----
-
-Fix the web app only loading the 20 most recent sessions globally; it now lists sessions per workspace and follows pagination so older sessions are reachable.

--- a/apps/kimi-web/src/composables/useKimiWebClient.ts
+++ b/apps/kimi-web/src/composables/useKimiWebClient.ts
@@ -2668,29 +2668,12 @@ async function updateConfig(patch: Partial<AppConfig>): Promise<boolean> {
 const initialized = ref(false);
 
 // Backend max page size for GET /sessions. Bigger pages mean fewer round-trips
-// when draining a workspace.
+// when draining the full session list.
 const SESSION_PAGE_SIZE = 100;
 
-/** Drain every page of sessions for a single workspace, newest first. */
-async function listAllSessionsForWorkspace(workspaceId: string): Promise<AppSession[]> {
-  const api = getKimiWebApi();
-  const items: AppSession[] = [];
-  let beforeId: string | undefined;
-  for (;;) {
-    const page = await api.listSessions({
-      workspaceId,
-      pageSize: SESSION_PAGE_SIZE,
-      beforeId,
-    });
-    items.push(...page.items);
-    if (!page.hasMore || page.items.length === 0) break;
-    beforeId = page.items[page.items.length - 1]!.id;
-  }
-  return items;
-}
-
-/** Drain every page of sessions across all workspaces (fallback when the daemon
- *  exposes no workspaces). */
+/** Drain every page of sessions, newest first. A single global walk (instead of
+ *  per-workspace) so sessions whose cwd is not a registered workspace root are
+ *  still reachable after a refresh. */
 async function listAllSessionsGlobal(): Promise<AppSession[]> {
   const api = getKimiWebApi();
   const items: AppSession[] = [];
@@ -2722,30 +2705,13 @@ async function load(): Promise<void> {
     await checkAuth();
     await loadConfig();
 
-    // Load workspaces first so sessions can be listed per workspace. Each
-    // workspace is drained independently so a session beyond the global top-N
-    // is still reachable from the sidebar.
-    await loadWorkspaces();
-
-    let sessions: AppSession[];
-    if (rawState.workspaces.length > 0) {
-      const perWorkspace = await Promise.all(
-        rawState.workspaces.map((w) =>
-          listAllSessionsForWorkspace(w.id).catch(() => [] as AppSession[]),
-        ),
-      );
-      const seen = new Set<string>();
-      sessions = [];
-      for (const s of perWorkspace.flat()) {
-        if (seen.has(s.id)) continue;
-        seen.add(s.id);
-        sessions.push(s);
-      }
-      sessions.sort((a, b) => b.updatedAt.localeCompare(a.updatedAt));
-    } else {
-      sessions = await listAllSessionsGlobal().catch(() => [] as AppSession[]);
-    }
+    // Drain every session via a single global walk so sessions whose cwd is not
+    // a registered workspace root are still reachable after a refresh.
+    const sessions = await listAllSessionsGlobal().catch(() => [] as AppSession[]);
     rawState.sessions = sessions;
+
+    // Load workspaces (real if available, else derived from session cwds).
+    await loadWorkspaces();
 
     // First load: pick the workspace of the most-recent session, unless the
     // user already has a persisted active workspace that still exists.

--- a/apps/kimi-web/src/composables/useKimiWebClient.ts
+++ b/apps/kimi-web/src/composables/useKimiWebClient.ts
@@ -2667,18 +2667,54 @@ async function updateConfig(patch: Partial<AppConfig>): Promise<boolean> {
 // global connecting-splash so a page refresh doesn't flash a half-empty app.
 const initialized = ref(false);
 
+// Backend max page size for GET /sessions. Bigger pages mean fewer round-trips
+// when draining a workspace.
+const SESSION_PAGE_SIZE = 100;
+
+/** Drain every page of sessions for a single workspace, newest first. */
+async function listAllSessionsForWorkspace(workspaceId: string): Promise<AppSession[]> {
+  const api = getKimiWebApi();
+  const items: AppSession[] = [];
+  let beforeId: string | undefined;
+  for (;;) {
+    const page = await api.listSessions({
+      workspaceId,
+      pageSize: SESSION_PAGE_SIZE,
+      beforeId,
+    });
+    items.push(...page.items);
+    if (!page.hasMore || page.items.length === 0) break;
+    beforeId = page.items[page.items.length - 1]!.id;
+  }
+  return items;
+}
+
+/** Drain every page of sessions across all workspaces (fallback when the daemon
+ *  exposes no workspaces). */
+async function listAllSessionsGlobal(): Promise<AppSession[]> {
+  const api = getKimiWebApi();
+  const items: AppSession[] = [];
+  let beforeId: string | undefined;
+  for (;;) {
+    const page = await api.listSessions({ pageSize: SESSION_PAGE_SIZE, beforeId });
+    items.push(...page.items);
+    if (!page.hasMore || page.items.length === 0) break;
+    beforeId = page.items[page.items.length - 1]!.id;
+  }
+  return items;
+}
+
 async function load(): Promise<void> {
   rawState.loading = true;
   try {
     const api = getKimiWebApi();
-    // Parallel: health + meta + sessions + models
-    const [, , sessionsPage] = await Promise.all([
+    // Parallel: health + meta + models
+    await Promise.all([
       api.getHealth().catch(() => null),
       api.getMeta().then((m) => {
         rawState.serverVersion = m.serverVersion;
         rawState.availableOpenInApps = m.openInApps;
       }).catch(() => null),
-      api.listSessions({ pageSize: 20 }).catch(() => ({ items: [], hasMore: false })),
       loadModels(),
     ]);
 
@@ -2686,14 +2722,34 @@ async function load(): Promise<void> {
     await checkAuth();
     await loadConfig();
 
-    rawState.sessions = sessionsPage.items;
-
-    // Load workspaces (real if available, else derived from session cwds).
+    // Load workspaces first so sessions can be listed per workspace. Each
+    // workspace is drained independently so a session beyond the global top-N
+    // is still reachable from the sidebar.
     await loadWorkspaces();
+
+    let sessions: AppSession[];
+    if (rawState.workspaces.length > 0) {
+      const perWorkspace = await Promise.all(
+        rawState.workspaces.map((w) =>
+          listAllSessionsForWorkspace(w.id).catch(() => [] as AppSession[]),
+        ),
+      );
+      const seen = new Set<string>();
+      sessions = [];
+      for (const s of perWorkspace.flat()) {
+        if (seen.has(s.id)) continue;
+        seen.add(s.id);
+        sessions.push(s);
+      }
+      sessions.sort((a, b) => b.updatedAt.localeCompare(a.updatedAt));
+    } else {
+      sessions = await listAllSessionsGlobal().catch(() => [] as AppSession[]);
+    }
+    rawState.sessions = sessions;
 
     // First load: pick the workspace of the most-recent session, unless the
     // user already has a persisted active workspace that still exists.
-    const mostRecent = sessionsPage.items[0];
+    const mostRecent = sessions[0];
     const persisted = rawState.activeWorkspaceId;
     const persistedStillExists =
       persisted !== null && mergedWorkspaces.value.some((w) => w.id === persisted);
@@ -2702,7 +2758,7 @@ async function load(): Promise<void> {
     }
 
     // URL deep link (/sessions/<id>) takes priority over auto-select. The
-    // session may live beyond the first listSessions page — fetch it then.
+    // session may live outside the loaded pages (e.g. archived) — fetch it then.
     // selectSession syncs the active workspace off the (now present) entry.
     bindSessionRoute();
     const urlSessionId =
@@ -2718,8 +2774,8 @@ async function load(): Promise<void> {
 
     // Auto-select first session if none selected (also the fallback for a dead
     // deep link — 'replace' rewrites the URL to the session actually shown).
-    if (!rawState.activeSessionId && sessionsPage.items.length > 0) {
-      await selectSession(sessionsPage.items[0]!.id, { urlMode: 'replace' });
+    if (!rawState.activeSessionId && sessions.length > 0) {
+      await selectSession(sessions[0]!.id, { urlMode: 'replace' });
     }
   } catch (err) {
     pushOperationFailure('load', err);

--- a/apps/kimi-web/test/useKimiWebClient-session-list.test.ts
+++ b/apps/kimi-web/test/useKimiWebClient-session-list.test.ts
@@ -1,0 +1,267 @@
+// apps/kimi-web/test/useKimiWebClient-session-list.test.ts
+//
+// load() must list sessions per workspace and follow pagination, so a session
+// that falls outside the global top-N is still reachable from the sidebar.
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type {
+  AppSession,
+  AppWorkspace,
+  KimiEventHandlers,
+  KimiWebApi,
+  Page,
+} from '../src/api/types';
+
+const t0 = '2026-06-11T00:00:00.000Z';
+
+function session(id: string, overrides?: Partial<AppSession>): AppSession {
+  return {
+    id,
+    title: id,
+    createdAt: t0,
+    updatedAt: t0,
+    status: 'idle',
+    archived: false,
+    cwd: '/repo',
+    model: 'kimi-test',
+    usage: {
+      inputTokens: 0,
+      outputTokens: 0,
+      cacheReadTokens: 0,
+      cacheCreationTokens: 0,
+      totalCostUsd: 0,
+      contextTokens: 0,
+      contextLimit: 128_000,
+      turnCount: 0,
+    },
+    messageCount: 0,
+    lastSeq: 0,
+    ...overrides,
+  };
+}
+
+function workspace(id: string, root: string): AppWorkspace {
+  return { id, root, name: id, isGitRepo: false, sessionCount: 0 };
+}
+
+interface SetupOpts {
+  workspaces: AppWorkspace[];
+  /** Map of workspaceId -> pages, or undefined -> global fallback pages. */
+  pagesByWorkspace: Record<string, Array<Page<AppSession>>>;
+  /** Pages used by the global fallback when no workspaces are returned. */
+  globalPages?: Array<Page<AppSession>>;
+  /** workspaceIds whose listSessions call should reject. */
+  failingWorkspaces?: Set<string>;
+}
+
+async function setup(opts: SetupOpts) {
+  vi.resetModules();
+  vi.stubGlobal('WebSocket', class WebSocket {});
+  window.history.replaceState(null, '', '/');
+
+  let handlers: KimiEventHandlers | undefined;
+  const eventConn = {
+    subscribe: vi.fn(),
+    unsubscribe: vi.fn(),
+    bindNextPromptId: vi.fn(),
+    seedSnapshot: vi.fn(),
+    abort: vi.fn(),
+    close: vi.fn(),
+  };
+
+  // Per-workspace page cursors (mutable so repeated calls walk pages).
+  const cursors = new Map<string, number>();
+  const globalCursor = { value: 0 };
+
+  const listSessions = vi.fn(
+    async (input?: { workspaceId?: string; beforeId?: string; pageSize?: number }) => {
+      if (input?.workspaceId) {
+        if (opts.failingWorkspaces?.has(input.workspaceId)) {
+          throw new Error('boom');
+        }
+        const pages = opts.pagesByWorkspace[input.workspaceId] ?? [];
+        const idx = cursors.get(input.workspaceId) ?? 0;
+        cursors.set(input.workspaceId, idx + 1);
+        return pages[idx] ?? { items: [], hasMore: false };
+      }
+      const pages = opts.globalPages ?? [];
+      const idx = globalCursor.value;
+      globalCursor.value += 1;
+      return pages[idx] ?? { items: [], hasMore: false };
+    },
+  );
+
+  const api = {
+    getHealth: vi.fn(async () => ({ status: 'ok', uptimeSec: 1 })),
+    getMeta: vi.fn(async () => ({ daemonVersion: 't', serverId: 's', startedAt: t0, capabilities: {} })),
+    getAuth: vi.fn(async () => ({ ready: true, defaultModel: 'kimi-test', managedProvider: null })),
+    listModels: vi.fn(async () => []),
+    listWorkspaces: vi.fn(async () => opts.workspaces),
+    getFsHome: vi.fn(async () => ({ home: '/home', recentRoots: [] })),
+    listSessions,
+    getSession: vi.fn(async (id: string) => session(id)),
+    getSessionSnapshot: vi.fn(async (id: string) => ({
+      asOfSeq: 0,
+      epoch: 'ep_test',
+      session: session(id),
+      messages: [],
+      hasMoreMessages: false,
+      inFlightTurn: null,
+      pendingApprovals: [],
+      pendingQuestions: [],
+    })),
+    listTasks: vi.fn(async () => []),
+    getGitStatus: vi.fn(async () => ({ branch: 'main', ahead: 0, behind: 0, entries: {}, additions: 0, deletions: 0 })),
+    getSessionStatus: vi.fn(async () => ({
+      model: 'kimi-test',
+      thinkingLevel: 'high',
+      permission: 'manual',
+      planMode: false,
+      swarmMode: false,
+      contextTokens: 0,
+      maxContextTokens: 128_000,
+      contextUsage: 0,
+    })),
+    connectEvents: vi.fn((nextHandlers: KimiEventHandlers) => {
+      handlers = nextHandlers;
+      return eventConn;
+    }),
+    getFileUrl: vi.fn((fileId: string) => `/files/${fileId}`),
+  } as unknown as KimiWebApi;
+
+  vi.doMock('../src/api', () => ({ getKimiWebApi: () => api }));
+  const { useKimiWebClient } = await import('../src/composables/useKimiWebClient');
+
+  return {
+    api,
+    client: useKimiWebClient(),
+    getHandlers: () => {
+      if (!handlers) throw new Error('connectEvents was not called');
+      return handlers;
+    },
+  };
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.resetModules();
+  vi.clearAllMocks();
+  localStorage.clear();
+  window.history.replaceState(null, '', '/');
+});
+
+describe('load() per-workspace session listing', () => {
+  it('fans out to each workspace with the correct workspaceId', async () => {
+    const wsA = workspace('ws_a', '/repo/a');
+    const wsB = workspace('ws_b', '/repo/b');
+    const { api, client } = await setup({
+      workspaces: [wsA, wsB],
+      pagesByWorkspace: {
+        ws_a: [{ items: [session('sess_a1')], hasMore: false }],
+        ws_b: [{ items: [session('sess_b1'), session('sess_b2')], hasMore: false }],
+      },
+    });
+
+    await client.load();
+
+    const calls = (api.listSessions as ReturnType<typeof vi.fn>).mock.calls;
+    const workspaceIds = calls.map(([input]) => input?.workspaceId).sort();
+    expect(workspaceIds).toEqual(['ws_a', 'ws_b']);
+
+    const ids = client.sessions.value.map((s) => s.id).sort();
+    expect(ids).toEqual(['sess_a1', 'sess_b1', 'sess_b2']);
+  });
+
+  it('follows pagination within a workspace using beforeId', async () => {
+    const ws = workspace('ws_a', '/repo/a');
+    const { api, client } = await setup({
+      workspaces: [ws],
+      pagesByWorkspace: {
+        ws_a: [
+          { items: [session('sess_1'), session('sess_2')], hasMore: true },
+          { items: [session('sess_3')], hasMore: false },
+        ],
+      },
+    });
+
+    await client.load();
+
+    const calls = (api.listSessions as ReturnType<typeof vi.fn>).mock.calls;
+    expect(calls).toHaveLength(2);
+    expect(calls[0]![0]).toMatchObject({ workspaceId: 'ws_a', beforeId: undefined });
+    expect(calls[1]![0]).toMatchObject({ workspaceId: 'ws_a', beforeId: 'sess_2' });
+
+    const ids = client.sessions.value.map((s) => s.id).sort();
+    expect(ids).toEqual(['sess_1', 'sess_2', 'sess_3']);
+  });
+
+  it('sorts merged sessions by updatedAt descending across workspaces', async () => {
+    const wsA = workspace('ws_a', '/repo/a');
+    const wsB = workspace('ws_b', '/repo/b');
+    const { client } = await setup({
+      workspaces: [wsA, wsB],
+      pagesByWorkspace: {
+        ws_a: [
+          {
+            items: [
+              session('sess_old', { updatedAt: '2026-06-10T00:00:00.000Z' }),
+              session('sess_newest', { updatedAt: '2026-06-12T00:00:00.000Z' }),
+            ],
+            hasMore: false,
+          },
+        ],
+        ws_b: [
+          {
+            items: [session('sess_mid', { updatedAt: '2026-06-11T00:00:00.000Z' })],
+            hasMore: false,
+          },
+        ],
+      },
+    });
+
+    await client.load();
+
+    expect(client.sessions.value.map((s) => s.id)).toEqual([
+      'sess_newest',
+      'sess_mid',
+      'sess_old',
+    ]);
+  });
+
+  it('falls back to a global paginated list when no workspaces are returned', async () => {
+    const { api, client } = await setup({
+      workspaces: [],
+      pagesByWorkspace: {},
+      globalPages: [
+        { items: [session('sess_g1')], hasMore: true },
+        { items: [session('sess_g2')], hasMore: false },
+      ],
+    });
+
+    await client.load();
+
+    const calls = (api.listSessions as ReturnType<typeof vi.fn>).mock.calls;
+    expect(calls).toHaveLength(2);
+    expect(calls[0]![0]).toMatchObject({ beforeId: undefined });
+    expect(calls[0]![0]?.workspaceId).toBeUndefined();
+    expect(calls[1]![0]).toMatchObject({ beforeId: 'sess_g1' });
+
+    const ids = client.sessions.value.map((s) => s.id).sort();
+    expect(ids).toEqual(['sess_g1', 'sess_g2']);
+  });
+
+  it('isolates a failing workspace so other workspaces still load', async () => {
+    const wsA = workspace('ws_a', '/repo/a');
+    const wsB = workspace('ws_b', '/repo/b');
+    const { client } = await setup({
+      workspaces: [wsA, wsB],
+      pagesByWorkspace: {
+        ws_b: [{ items: [session('sess_b1')], hasMore: false }],
+      },
+      failingWorkspaces: new Set(['ws_a']),
+    });
+
+    await expect(client.load()).resolves.toBeUndefined();
+    expect(client.sessions.value.map((s) => s.id)).toEqual(['sess_b1']);
+  });
+});

--- a/apps/kimi-web/test/useKimiWebClient-session-list.test.ts
+++ b/apps/kimi-web/test/useKimiWebClient-session-list.test.ts
@@ -1,12 +1,13 @@
 // apps/kimi-web/test/useKimiWebClient-session-list.test.ts
 //
-// load() must list sessions per workspace and follow pagination, so a session
-// that falls outside the global top-N is still reachable from the sidebar.
+// load() must drain every session page (not just the first), so a session
+// beyond the initial page is still reachable from the sidebar. A single global
+// walk is used so sessions whose cwd is not a registered workspace root are
+// included too.
 
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import type {
   AppSession,
-  AppWorkspace,
   KimiEventHandlers,
   KimiWebApi,
   Page,
@@ -40,18 +41,10 @@ function session(id: string, overrides?: Partial<AppSession>): AppSession {
   };
 }
 
-function workspace(id: string, root: string): AppWorkspace {
-  return { id, root, name: id, isGitRepo: false, sessionCount: 0 };
-}
-
 interface SetupOpts {
-  workspaces: AppWorkspace[];
-  /** Map of workspaceId -> pages, or undefined -> global fallback pages. */
-  pagesByWorkspace: Record<string, Array<Page<AppSession>>>;
-  /** Pages used by the global fallback when no workspaces are returned. */
-  globalPages?: Array<Page<AppSession>>;
-  /** workspaceIds whose listSessions call should reject. */
-  failingWorkspaces?: Set<string>;
+  pages: Array<Page<AppSession>>;
+  listWorkspaces?: () => Promise<unknown[]>;
+  listSessionsError?: Error;
 }
 
 async function setup(opts: SetupOpts) {
@@ -69,25 +62,13 @@ async function setup(opts: SetupOpts) {
     close: vi.fn(),
   };
 
-  // Per-workspace page cursors (mutable so repeated calls walk pages).
-  const cursors = new Map<string, number>();
-  const globalCursor = { value: 0 };
-
+  let cursor = 0;
   const listSessions = vi.fn(
-    async (input?: { workspaceId?: string; beforeId?: string; pageSize?: number }) => {
-      if (input?.workspaceId) {
-        if (opts.failingWorkspaces?.has(input.workspaceId)) {
-          throw new Error('boom');
-        }
-        const pages = opts.pagesByWorkspace[input.workspaceId] ?? [];
-        const idx = cursors.get(input.workspaceId) ?? 0;
-        cursors.set(input.workspaceId, idx + 1);
-        return pages[idx] ?? { items: [], hasMore: false };
-      }
-      const pages = opts.globalPages ?? [];
-      const idx = globalCursor.value;
-      globalCursor.value += 1;
-      return pages[idx] ?? { items: [], hasMore: false };
+    async (_input?: { workspaceId?: string; beforeId?: string; pageSize?: number }) => {
+      if (opts.listSessionsError) throw opts.listSessionsError;
+      const page = opts.pages[cursor] ?? { items: [], hasMore: false };
+      cursor += 1;
+      return page;
     },
   );
 
@@ -96,7 +77,7 @@ async function setup(opts: SetupOpts) {
     getMeta: vi.fn(async () => ({ daemonVersion: 't', serverId: 's', startedAt: t0, capabilities: {} })),
     getAuth: vi.fn(async () => ({ ready: true, defaultModel: 'kimi-test', managedProvider: null })),
     listModels: vi.fn(async () => []),
-    listWorkspaces: vi.fn(async () => opts.workspaces),
+    listWorkspaces: vi.fn(opts.listWorkspaces ?? (async () => [])),
     getFsHome: vi.fn(async () => ({ home: '/home', recentRoots: [] })),
     listSessions,
     getSession: vi.fn(async (id: string) => session(id)),
@@ -150,91 +131,12 @@ afterEach(() => {
   window.history.replaceState(null, '', '/');
 });
 
-describe('load() per-workspace session listing', () => {
-  it('fans out to each workspace with the correct workspaceId', async () => {
-    const wsA = workspace('ws_a', '/repo/a');
-    const wsB = workspace('ws_b', '/repo/b');
+describe('load() session listing', () => {
+  it('drains every page using the beforeId cursor', async () => {
     const { api, client } = await setup({
-      workspaces: [wsA, wsB],
-      pagesByWorkspace: {
-        ws_a: [{ items: [session('sess_a1')], hasMore: false }],
-        ws_b: [{ items: [session('sess_b1'), session('sess_b2')], hasMore: false }],
-      },
-    });
-
-    await client.load();
-
-    const calls = (api.listSessions as ReturnType<typeof vi.fn>).mock.calls;
-    const workspaceIds = calls.map(([input]) => input?.workspaceId).sort();
-    expect(workspaceIds).toEqual(['ws_a', 'ws_b']);
-
-    const ids = client.sessions.value.map((s) => s.id).sort();
-    expect(ids).toEqual(['sess_a1', 'sess_b1', 'sess_b2']);
-  });
-
-  it('follows pagination within a workspace using beforeId', async () => {
-    const ws = workspace('ws_a', '/repo/a');
-    const { api, client } = await setup({
-      workspaces: [ws],
-      pagesByWorkspace: {
-        ws_a: [
-          { items: [session('sess_1'), session('sess_2')], hasMore: true },
-          { items: [session('sess_3')], hasMore: false },
-        ],
-      },
-    });
-
-    await client.load();
-
-    const calls = (api.listSessions as ReturnType<typeof vi.fn>).mock.calls;
-    expect(calls).toHaveLength(2);
-    expect(calls[0]![0]).toMatchObject({ workspaceId: 'ws_a', beforeId: undefined });
-    expect(calls[1]![0]).toMatchObject({ workspaceId: 'ws_a', beforeId: 'sess_2' });
-
-    const ids = client.sessions.value.map((s) => s.id).sort();
-    expect(ids).toEqual(['sess_1', 'sess_2', 'sess_3']);
-  });
-
-  it('sorts merged sessions by updatedAt descending across workspaces', async () => {
-    const wsA = workspace('ws_a', '/repo/a');
-    const wsB = workspace('ws_b', '/repo/b');
-    const { client } = await setup({
-      workspaces: [wsA, wsB],
-      pagesByWorkspace: {
-        ws_a: [
-          {
-            items: [
-              session('sess_old', { updatedAt: '2026-06-10T00:00:00.000Z' }),
-              session('sess_newest', { updatedAt: '2026-06-12T00:00:00.000Z' }),
-            ],
-            hasMore: false,
-          },
-        ],
-        ws_b: [
-          {
-            items: [session('sess_mid', { updatedAt: '2026-06-11T00:00:00.000Z' })],
-            hasMore: false,
-          },
-        ],
-      },
-    });
-
-    await client.load();
-
-    expect(client.sessions.value.map((s) => s.id)).toEqual([
-      'sess_newest',
-      'sess_mid',
-      'sess_old',
-    ]);
-  });
-
-  it('falls back to a global paginated list when no workspaces are returned', async () => {
-    const { api, client } = await setup({
-      workspaces: [],
-      pagesByWorkspace: {},
-      globalPages: [
-        { items: [session('sess_g1')], hasMore: true },
-        { items: [session('sess_g2')], hasMore: false },
+      pages: [
+        { items: [session('sess_1'), session('sess_2')], hasMore: true },
+        { items: [session('sess_3')], hasMore: false },
       ],
     });
 
@@ -243,25 +145,32 @@ describe('load() per-workspace session listing', () => {
     const calls = (api.listSessions as ReturnType<typeof vi.fn>).mock.calls;
     expect(calls).toHaveLength(2);
     expect(calls[0]![0]).toMatchObject({ beforeId: undefined });
-    expect(calls[0]![0]?.workspaceId).toBeUndefined();
-    expect(calls[1]![0]).toMatchObject({ beforeId: 'sess_g1' });
+    expect(calls[1]![0]).toMatchObject({ beforeId: 'sess_2' });
 
     const ids = client.sessions.value.map((s) => s.id).sort();
-    expect(ids).toEqual(['sess_g1', 'sess_g2']);
+    expect(ids).toEqual(['sess_1', 'sess_2', 'sess_3']);
   });
 
-  it('isolates a failing workspace so other workspaces still load', async () => {
-    const wsA = workspace('ws_a', '/repo/a');
-    const wsB = workspace('ws_b', '/repo/b');
+  it('never passes a workspaceId so unregistered-cwd sessions are included', async () => {
+    const { api, client } = await setup({
+      pages: [{ items: [session('sess_orphan', { cwd: '/tmp/scratch' })], hasMore: false }],
+    });
+
+    await client.load();
+
+    const calls = (api.listSessions as ReturnType<typeof vi.fn>).mock.calls;
+    expect(calls).toHaveLength(1);
+    expect(calls[0]![0]?.workspaceId).toBeUndefined();
+    expect(client.sessions.value.map((s) => s.id)).toEqual(['sess_orphan']);
+  });
+
+  it('surfaces an empty list when listSessions rejects', async () => {
     const { client } = await setup({
-      workspaces: [wsA, wsB],
-      pagesByWorkspace: {
-        ws_b: [{ items: [session('sess_b1')], hasMore: false }],
-      },
-      failingWorkspaces: new Set(['ws_a']),
+      pages: [],
+      listSessionsError: new Error('boom'),
     });
 
     await expect(client.load()).resolves.toBeUndefined();
-    expect(client.sessions.value.map((s) => s.id)).toEqual(['sess_b1']);
+    expect(client.sessions.value).toEqual([]);
   });
 });


### PR DESCRIPTION
## Related Issue

N/A — root cause identified by the backend team: the web app loads sessions globally with a hard cap of 20, so any session outside that window appears missing.

## Problem

`load()` in `useKimiWebClient.ts` called `listSessions({ pageSize: 20 })` once, with no pagination. The sidebar, the workspace switcher, and `mergedWorkspaces` all derive from `rawState.sessions`, so any session outside the global top-20 is unreachable after a refresh.

## What changed

- Drain every page of the global session list via `listSessions({ pageSize: 100, beforeId })`, following `hasMore` until exhausted.
- A single global walk (rather than per-workspace) is used so sessions whose cwd is not a registered workspace root are still reachable after a refresh. See Codex review on the previous iteration for context.
- `loadWorkspaces()` still runs after, so `mergedWorkspaces` continues to derive cwd-only workspaces from the loaded sessions.
- Added `useKimiWebClient-session-list.test.ts` covering cursor-based pagination, the no-workspaceId contract, and the empty-on-error fallback.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [ ] Ran `gen-docs` skill, or this PR needs no doc update.
