### PR TITLE
feat(web): show server version in settings

### DIFF
--- a/.changeset/web-show-server-version.md
+++ b/.changeset/web-show-server-version.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Show the connected server version in the web settings General tab.

--- a/apps/kimi-web/src/App.vue
+++ b/apps/kimi-web/src/App.vue
@@ -1181,6 +1181,7 @@ function openPr(url: string): void {
       :config="client.config.value"
       :models="client.models.value"
       :config-saving="configSaving"
+      :server-version="client.serverVersion.value"
       @set-theme="client.setTheme($event)"
       @set-color-scheme="client.setColorScheme($event)"
       @set-ui-font-size="client.setUiFontSize($event)"

--- a/apps/kimi-web/src/App.vue
+++ b/apps/kimi-web/src/App.vue
@@ -1299,6 +1299,7 @@ function openPr(url: string): void {
       :ui-font-size="client.uiFontSize.value"
       :auth-ready="client.authReady.value"
       :beta-toc="client.betaToc.value"
+      :server-version="client.serverVersion.value"
       @pick-model="openModelPicker()"
       @set-thinking="client.setThinking($event)"
       @toggle-plan="client.togglePlanMode()"

--- a/apps/kimi-web/src/components/MobileSettingsSheet.vue
+++ b/apps/kimi-web/src/components/MobileSettingsSheet.vue
@@ -28,8 +28,10 @@ const props = withDefaults(
     uiFontSize?: number;
     authReady?: boolean;
     betaToc?: boolean;
+    /** Server version from GET /api/v1/meta, shown as a read-only row. */
+    serverVersion?: string;
   }>(),
-  { theme: 'terminal', colorScheme: 'system', uiFontSize: 14, authReady: false },
+  { theme: 'terminal', colorScheme: 'system', uiFontSize: 14, authReady: false, serverVersion: '' },
 );
 
 const emit = defineEmits<{
@@ -263,6 +265,14 @@ function onLogout(): void {
         <span class="srow-label">{{ t('sidebar.signIn') }}</span>
       </span>
     </button>
+
+    <!-- Server version -->
+    <div v-if="serverVersion" class="srow read-only">
+      <span class="srow-main">
+        <span class="srow-label">{{ t('settings.serverVersion') }}</span>
+      </span>
+      <span class="srow-val dim">{{ serverVersion }}</span>
+    </div>
   </BottomSheet>
 </template>
 
@@ -307,6 +317,10 @@ function onLogout(): void {
   font-size: var(--ui-font-size);
   font-weight: 600;
   color: var(--blue2);
+}
+.srow-val.dim {
+  font-weight: 400;
+  color: var(--muted);
 }
 
 /* Chevron (prototype ›) — fixed icon glyph size, not part of UI font scale. */

--- a/apps/kimi-web/src/components/SettingsDialog.vue
+++ b/apps/kimi-web/src/components/SettingsDialog.vue
@@ -32,6 +32,8 @@ const props = defineProps<{
   models?: AppModel[];
   /** True while POST /api/v1/config is saving. */
   configSaving?: boolean;
+  /** Server version reported by GET /api/v1/meta. */
+  serverVersion?: string;
 }>();
 
 const emit = defineEmits<{
@@ -276,6 +278,14 @@ function setTab(tab: SettingsTab): void {
                 <button type="button" class="act" @click="emit('openOnboarding'); emit('close')">{{ t('onboarding.reopen') }}</button>
                 <button v-if="authReady" type="button" class="act danger" @click="emit('logout')">{{ t('sidebar.signOut') }}</button>
                 <button v-else type="button" class="act signin" @click="emit('login')">{{ t('sidebar.signIn') }}</button>
+              </div>
+            </section>
+
+            <section class="sec">
+              <h3 class="sec-title">{{ t('settings.build') }}</h3>
+              <div class="row">
+                <span class="rlabel">{{ t('settings.serverVersion') }}</span>
+                <span class="rvalue mono">{{ serverVersion || '-' }}</span>
               </div>
             </section>
           </section>

--- a/apps/kimi-web/src/composables/useKimiWebClient.ts
+++ b/apps/kimi-web/src/composables/useKimiWebClient.ts
@@ -2109,6 +2109,7 @@ const connection = computed<ConnectionState>(() => rawState.connection);
 
 const loading = computed<boolean>(() => rawState.loading);
 const sessionLoading = computed<boolean>(() => rawState.sessionLoading);
+const serverVersion = computed<string>(() => rawState.serverVersion);
 
 const permission = computed<PermissionMode>(() => rawState.permission);
 const thinking = computed<ThinkingLevel>(() => rawState.thinking);
@@ -4271,6 +4272,7 @@ export function useKimiWebClient() {
     connection,
     loading,
     sessionLoading,
+    serverVersion,
     initialized,
     permission,
     thinking,

--- a/apps/kimi-web/src/i18n/locales/en/settings.ts
+++ b/apps/kimi-web/src/i18n/locales/en/settings.ts
@@ -37,6 +37,7 @@ export default {
   configUnavailable: 'The server did not return config yet. These settings are unavailable.',
   advanced: 'Advanced',
   build: 'Build',
+  serverVersion: 'Server version',
   exportLog: 'Troubleshooting log',
   logHint: 'Enable with ?debug=1 to capture',
   exportLogBtn: 'Export log',

--- a/apps/kimi-web/src/i18n/locales/zh/settings.ts
+++ b/apps/kimi-web/src/i18n/locales/zh/settings.ts
@@ -37,6 +37,7 @@ export default {
   configUnavailable: '当前服务端没有返回 config，设置项暂不可用。',
   advanced: '高级',
   build: '构建',
+  serverVersion: '服务端版本',
   exportLog: '故障排查日志',
   logHint: '加 ?debug=1 开启采集',
   exportLogBtn: '导出日志',

--- a/apps/kimi-web/test/settings-dialog.test.ts
+++ b/apps/kimi-web/test/settings-dialog.test.ts
@@ -93,6 +93,7 @@ function mountDialog() {
       config,
       models,
       configSaving: false,
+      serverVersion: '1.2.3',
     },
     global: {
       plugins: [i18n],
@@ -180,6 +181,14 @@ describe('SettingsDialog config controls', () => {
     const openaiOptions = groups[1]!.findAll('option');
     expect(openaiOptions.some((o) => o.attributes('value') === 'openai/gpt-5')).toBe(true);
   });
+
+  it('renders server version on the General tab', () => {
+    const wrapper = mountDialog();
+
+    // General is the default active tab.
+    expect(wrapper.text()).toContain('Server version');
+    expect(wrapper.text()).toContain('1.2.3');
+  });
 });
 
 describe('SettingsDialog dialog focus', () => {
@@ -202,6 +211,7 @@ describe('SettingsDialog dialog focus', () => {
         config,
         models,
         configSaving: false,
+        serverVersion: '1.2.3',
       },
       global: { plugins: [i18n], stubs: { LanguageSwitcher: true } },
       attachTo: document.body,


### PR DESCRIPTION
## Related Issue

No related issue.

## Problem

The server already reports its version via `GET /api/v1/meta`, but the web UI never surfaced it, so users could not tell which server build they were connected to from the browser.

## What changed

Expose the server version already fetched by the web client and render it in the settings General tab under a new Build section, with matching English and Chinese labels. The web client already reads this field on load, so no extra request is added.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.