### PR TITLE
fix(skill): dedupe skills with identical SKILL.md content

### DIFF
--- a/.changeset/dedupe-identical-skills.md
+++ b/.changeset/dedupe-identical-skills.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Fix duplicate skills appearing when a sub-skill is also shipped as a flattened copy with identical content.

--- a/packages/agent-core/src/skill/scanner.ts
+++ b/packages/agent-core/src/skill/scanner.ts
@@ -1,3 +1,4 @@
+import { createHash } from 'node:crypto';
 import { promises as fs } from 'node:fs';
 import path from 'pathe';
 
@@ -139,6 +140,7 @@ export async function discoverSkills(
   const warn = options.onWarning ?? (() => {});
   const skip = options.onSkippedByPolicy ?? (() => {});
   const byName = new Map<string, SkillDefinition>();
+  const byContent = new Map<string, SkillDefinition>();
 
   async function walkSkillDir(
     dirPath: string,
@@ -177,6 +179,7 @@ export async function discoverSkills(
       const skill = await parseAndRegister({
         parse,
         byName,
+        byContent,
         skillMdPath: path.join(dirPath, entry, 'SKILL.md'),
         skillDirName: entry,
         root,
@@ -202,6 +205,7 @@ export async function discoverSkills(
           await parseAndRegister({
             parse,
             byName,
+            byContent,
             skillMdPath: rootSkillMd,
             skillDirName: path.basename(dirPath),
             root,
@@ -227,6 +231,7 @@ export async function discoverSkills(
         await parseAndRegister({
           parse,
           byName,
+          byContent,
           skillMdPath,
           skillDirName: skillName,
           root,
@@ -362,6 +367,7 @@ async function pushProvidedRoot(
 async function parseAndRegister(input: {
   readonly parse: NonNullable<DiscoverSkillsOptions['parse']>;
   readonly byName: Map<string, SkillDefinition>;
+  readonly byContent: Map<string, SkillDefinition>;
   readonly skillMdPath: string;
   readonly skillDirName: string;
   readonly root: SkillRoot;
@@ -371,6 +377,9 @@ async function parseAndRegister(input: {
   readonly subSkillParentName?: string;
 }): Promise<SkillDefinition | undefined> {
   try {
+    const raw = await fs.readFile(input.skillMdPath, 'utf8');
+    const contentHash = hashSkillContent(raw);
+
     const parsed = await input.parse({
       skillMdPath: input.skillMdPath,
       skillDirName: input.skillDirName,
@@ -392,6 +401,14 @@ async function parseAndRegister(input: {
       ...skill,
       plugin: input.root.plugin,
     };
+    const existing = input.byContent.get(contentHash);
+    if (existing !== undefined) {
+      const preferCurrent =
+        discovered.metadata.isSubSkill === true && existing.metadata.isSubSkill !== true;
+      if (!preferCurrent) return undefined;
+      input.byName.delete(normalizeSkillName(existing.name));
+    }
+    input.byContent.set(contentHash, discovered);
     input.onDiscoveredSkill?.(discovered);
     const key = normalizeSkillName(discovered.name);
     if (!input.byName.has(key)) {
@@ -412,6 +429,10 @@ async function parseAndRegister(input: {
     }
     return undefined;
   }
+}
+
+function hashSkillContent(content: string): string {
+  return createHash('sha256').update(content).digest('hex');
 }
 
 function qualifySubSkillName(parentName: string, skillName: string): string {

--- a/packages/agent-core/test/skill/scanner.test.ts
+++ b/packages/agent-core/test/skill/scanner.test.ts
@@ -368,6 +368,34 @@ describe('discoverSkills shape and ordering', () => {
     expect(skills.find((s) => s.name === 'outer.inner')?.metadata.isSubSkill).toBe(true);
   });
 
+  it('dedupes identical SKILL.md files discovered via flattened subskill copies', async () => {
+    const { repoDir } = await makeWorkspace();
+    const root = path.join(repoDir, '.kimi-code', 'skills');
+    const childContent = [
+      '---',
+      'name: legacy-child',
+      'description: Nested skill',
+      '---',
+      '',
+      'Child body.',
+    ];
+    await writeSkill(root, path.join('outer', 'SKILL.md'), [
+      '---',
+      'name: outer',
+      'description: Parent skill',
+      'has-sub-skill: true',
+      '---',
+      '',
+      'Outer body.',
+    ]);
+    await writeSkill(root, path.join('outer', 'child', 'SKILL.md'), childContent);
+    await writeSkill(root, path.join('outer__child', 'SKILL.md'), childContent);
+
+    const skills = await discoverSkills({ roots: [{ path: root, source: 'user' }] });
+
+    expect(skills.map((s) => s.name)).toEqual(['outer', 'outer.legacy-child']);
+  });
+
   it('does not discover nested SKILL.md files when the parent bundle disables sub-skills', async () => {
     const { repoDir } = await makeWorkspace();
     const root = path.join(repoDir, '.kimi-code', 'skills');


### PR DESCRIPTION
## Related Issue

<!-- No linked issue. -->

## Problem

When a parent skill bundle has `has-sub-skill: true`, the scanner walks its nested sub-skill directories (e.g. `outer/child/SKILL.md`) and registers qualified names such as `outer.child`. Some setups also ship the same sub-skill as a flattened copy (e.g. `outer__child/SKILL.md`) with byte-identical `SKILL.md` content. Previously both copies were registered, so the same skill showed up twice — once under the qualified sub-skill name and once under the flattened directory name.

## What changed

- Hash each discovered `SKILL.md` with SHA-256 and track seen content during discovery.
- Skip re-registering a skill whose content was already registered.
- When a duplicate collides, prefer the qualified sub-skill form over a non-sub-skill entry so the canonical name wins.
- Added a test covering the flattened-copy dedupe case.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.
