### PR TITLE
feat(web): add session search

### DIFF
--- a/.changeset/web-session-search.md
+++ b/.changeset/web-session-search.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": minor
+---
+
+Add instant session search to the web sidebar, filtering by title and the last user prompt.

--- a/apps/kimi-web/src/api/daemon/agentEventProjector.ts
+++ b/apps/kimi-web/src/api/daemon/agentEventProjector.ts
@@ -616,12 +616,17 @@ export function createAgentProjector(): AgentProjector {
       // -----------------------------------------------------------------------
       case 'session.meta.updated': {
         // The daemon auto-generates a title from the first prompt (and other
-        // clients can rename a session). It announces both via this event. We
+        // clients can rename a session); it also reports the latest user prompt
+        // via patch.lastPrompt. It announces all of these via this event. We
         // don't have the full AppSession here, so emit a lightweight
-        // sessionMetaUpdated that patches only the title field.
+        // sessionMetaUpdated that patches only the changed meta fields.
         const title: string | undefined = p?.patch?.title ?? p?.title;
-        if (typeof title === 'string' && title.length > 0) {
-          out.push({ type: 'sessionMetaUpdated', sessionId, title });
+        const lastPrompt: string | undefined = p?.patch?.lastPrompt;
+        const patch: { title?: string; lastPrompt?: string } = {};
+        if (typeof title === 'string' && title.length > 0) patch.title = title;
+        if (typeof lastPrompt === 'string') patch.lastPrompt = lastPrompt;
+        if (patch.title !== undefined || patch.lastPrompt !== undefined) {
+          out.push({ type: 'sessionMetaUpdated', sessionId, ...patch });
         }
         break;
       }

--- a/apps/kimi-web/src/api/daemon/eventReducer.ts
+++ b/apps/kimi-web/src/api/daemon/eventReducer.ts
@@ -259,12 +259,19 @@ export function reduceAppEvent(
 
     // -------------------------------------------------------------------------
     case 'sessionMetaUpdated': {
-      // Lightweight title patch — the daemon's auto-generated title (or a title
-      // changed by another client) arrives via session.meta.updated. We patch
-      // only the title field; the full session object stays as-is.
-      next.sessions = next.sessions.map((s) =>
-        s.id === event.sessionId ? { ...s, title: event.title } : s,
-      );
+      // Lightweight meta patch — the daemon's auto-generated title (or a title
+      // changed by another client) and the latest user prompt arrive via
+      // session.meta.updated. We patch only the carried fields; the full session
+      // object stays as-is. Keeping lastPrompt fresh lets sidebar search match
+      // the most recent prompt without a full reload.
+      next.sessions = next.sessions.map((s) => {
+        if (s.id !== event.sessionId) return s;
+        return {
+          ...s,
+          ...(event.title !== undefined ? { title: event.title } : {}),
+          ...(event.lastPrompt !== undefined ? { lastPrompt: event.lastPrompt } : {}),
+        };
+      });
       break;
     }
 

--- a/apps/kimi-web/src/api/daemon/eventReducer.ts
+++ b/apps/kimi-web/src/api/daemon/eventReducer.ts
@@ -261,17 +261,15 @@ export function reduceAppEvent(
     case 'sessionMetaUpdated': {
       // Lightweight meta patch — the daemon's auto-generated title (or a title
       // changed by another client) and the latest user prompt arrive via
-      // session.meta.updated. We patch only the carried fields; the full session
-      // object stays as-is. Keeping lastPrompt fresh lets sidebar search match
-      // the most recent prompt without a full reload.
-      next.sessions = next.sessions.map((s) => {
-        if (s.id !== event.sessionId) return s;
-        return {
-          ...s,
-          ...(event.title !== undefined ? { title: event.title } : {}),
-          ...(event.lastPrompt !== undefined ? { lastPrompt: event.lastPrompt } : {}),
-        };
-      });
+      // session.meta.updated. We keep prior values for any field the event does
+      // not carry; the full session object otherwise stays as-is. Keeping
+      // lastPrompt fresh lets sidebar search match the most recent prompt
+      // without a full reload.
+      next.sessions = next.sessions.map((s) =>
+        s.id === event.sessionId
+          ? { ...s, title: event.title ?? s.title, lastPrompt: event.lastPrompt ?? s.lastPrompt }
+          : s,
+      );
       break;
     }
 

--- a/apps/kimi-web/src/api/daemon/mappers.ts
+++ b/apps/kimi-web/src/api/daemon/mappers.ts
@@ -99,6 +99,7 @@ export function toAppSession(wire: WireSession): AppSession {
     status: toAppSessionStatus(wire.status),
     archived: wire.archived ?? false,
     currentPromptId: wire.current_prompt_id,
+    lastPrompt: wire.last_prompt,
     cwd: wire.metadata.cwd,
     model: wire.agent_config.model,
     usage: toAppSessionUsage(wire.usage),

--- a/apps/kimi-web/src/api/daemon/wire.ts
+++ b/apps/kimi-web/src/api/daemon/wire.ts
@@ -69,6 +69,8 @@ export interface WireSession {
   status: WireSessionStatus;
   archived: boolean;
   current_prompt_id?: string;
+  /** Text of the most recent user prompt, for search/preview. */
+  last_prompt?: string;
   // PRESUMED — daemon adds this once it ships the workspace registry; until then
   // it is absent and the client maps sessions by metadata.cwd === workspace.root.
   workspace_id?: string;

--- a/apps/kimi-web/src/api/types.ts
+++ b/apps/kimi-web/src/api/types.ts
@@ -394,7 +394,7 @@ export type AppEvent =
   | { type: 'sessionUpdated'; session: AppSession; changedFields: string[] }
   | { type: 'sessionDeleted'; sessionId: string }
   | { type: 'sessionStatusChanged'; sessionId: string; status: AppSessionStatus; previousStatus: AppSessionStatus; currentPromptId?: string }
-  | { type: 'sessionMetaUpdated'; sessionId: string; title: string }
+  | { type: 'sessionMetaUpdated'; sessionId: string; title?: string; lastPrompt?: string }
   | { type: 'sessionUsageUpdated'; sessionId: string; usage: AppSessionUsage; model?: string; swarmMode?: boolean; planMode?: boolean }
   | { type: 'historyCompacted'; sessionId: string; beforeSeq: number; reason: string; summaryMessageId?: string }
   | { type: 'compactionStarted'; sessionId: string; trigger: 'manual' | 'auto'; instruction?: string }

--- a/apps/kimi-web/src/api/types.ts
+++ b/apps/kimi-web/src/api/types.ts
@@ -67,6 +67,8 @@ export interface AppSession {
   status: AppSessionStatus;
   archived: boolean;
   currentPromptId?: string;
+  /** Text of the most recent user prompt, for search/preview. */
+  lastPrompt?: string;
   cwd: string;
   model: string;
   usage: AppSessionUsage;

--- a/apps/kimi-web/src/components/Sidebar.vue
+++ b/apps/kimi-web/src/components/Sidebar.vue
@@ -436,6 +436,7 @@ function blinkOnce(): void {
           type="text"
           :placeholder="t('sidebar.searchPlaceholder')"
           :aria-label="t('sidebar.searchPlaceholder')"
+          @keydown.esc.stop="clearSearch"
         />
         <button
           v-if="isSearching"

--- a/apps/kimi-web/src/components/Sidebar.vue
+++ b/apps/kimi-web/src/components/Sidebar.vue
@@ -3,14 +3,14 @@
      The old workspace rail and workspace tabs have been removed;
      workspace switching, folding and renaming all live in the group header. -->
 <script setup lang="ts">
-import { nextTick, onBeforeUnmount, ref } from 'vue';
+import { computed, nextTick, onBeforeUnmount, ref } from 'vue';
 import { useI18n } from 'vue-i18n';
 import type { Session, WorkspaceGroup, WorkspaceView } from '../types';
 import SessionRow from './SessionRow.vue';
 
 const { t } = useI18n();
 
-withDefaults(
+const props = withDefaults(
   defineProps<{
     activeWorkspace: WorkspaceView | null;
     activeWorkspaceId: string | null;
@@ -50,7 +50,32 @@ const emit = defineEmits<{
   collapse: [];
 }>();
 
+// ---------------------------------------------------------------------------
+// Session search (title + last prompt, instant client-side filter)
+// ---------------------------------------------------------------------------
+const searchQuery = ref('');
 
+const trimmedQuery = computed(() => searchQuery.value.trim());
+const isSearching = computed(() => trimmedQuery.value.length > 0);
+
+const searchResults = computed<Session[]>(() => {
+  const q = trimmedQuery.value.toLowerCase();
+  if (!q) return [];
+  return props.sessions.filter((s) => {
+    const title = (s.title ?? '').toLowerCase();
+    const last = (s.lastPrompt ?? '').toLowerCase();
+    return title.includes(q) || last.includes(q);
+  });
+});
+
+function clearSearch(): void {
+  searchQuery.value = '';
+}
+
+function onSelectResult(sessionId: string): void {
+  clearSearch();
+  onSelectSession(sessionId);
+}
 
 // ---------------------------------------------------------------------------
 // Collapse groups
@@ -399,6 +424,33 @@ function blinkOnce(): void {
         </button>
       </div>
 
+      <!-- Session search -->
+      <div class="search">
+        <svg class="search-icon" viewBox="0 0 16 16" width="14" height="14" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+          <circle cx="7" cy="7" r="5" />
+          <path d="M11 11l3 3" />
+        </svg>
+        <input
+          v-model="searchQuery"
+          class="search-input"
+          type="text"
+          :placeholder="t('sidebar.searchPlaceholder')"
+          :aria-label="t('sidebar.searchPlaceholder')"
+        />
+        <button
+          v-if="isSearching"
+          type="button"
+          class="search-clear"
+          :title="t('sidebar.searchClear')"
+          :aria-label="t('sidebar.searchClear')"
+          @click.stop="clearSearch"
+        >
+          <svg viewBox="0 0 10 10" width="10" height="10" fill="none" stroke="currentColor" stroke-width="1.5" aria-hidden="true">
+            <line x1="1" y1="1" x2="9" y2="9"/><line x1="9" y1="1" x2="1" y2="9"/>
+          </svg>
+        </button>
+      </div>
+
       <!-- New chat + new workspace buttons -->
       <div class="btn-wrap">
         <button class="btn-new-chat" @click.stop="emit('create')">
@@ -422,8 +474,30 @@ function blinkOnce(): void {
         </button>
       </div>
 
+      <!-- Search results (flat, across all workspaces) -->
+      <div v-if="isSearching" class="sessions">
+        <template v-if="searchResults.length > 0">
+          <SessionRow
+            v-for="s in searchResults"
+            :key="s.id"
+            :session="s"
+            :active="s.id === activeId"
+            :approval-count="pendingBySession[s.id]?.approvals ?? 0"
+            :question-count="pendingBySession[s.id]?.questions ?? 0"
+            :unread="unreadBySession[s.id] ?? false"
+            @select="onSelectResult($event)"
+            @rename="(id, title) => emit('rename', id, title)"
+            @archive="emit('archive', $event)"
+            @fork="emit('fork', $event)"
+          />
+        </template>
+        <div v-else class="empty">
+          {{ t('sidebar.searchNoResults') }}
+        </div>
+      </div>
+
       <!-- Session list — grouped by workspace -->
-      <div class="sessions">
+      <div v-else class="sessions">
         <!-- Empty state — only when no workspace is registered at all; empty
              workspaces still render their group header (with the + button). -->
         <div v-if="groups.length === 0" class="empty">
@@ -614,7 +688,7 @@ function blinkOnce(): void {
   align-items: center;
   justify-content: space-between;
   gap: 8px;
-  padding: 8px 12px 4px;
+  padding: 8px 12px;
   width: 100%;
   box-sizing: border-box;
 }
@@ -680,7 +754,7 @@ function blinkOnce(): void {
  .btn-wrap {
   display: flex;
   gap: 8px;
-  padding: 10px 12px;
+  padding: 0 12px 8px;
 }
 .btn-wrap button {
   display: inline-flex;
@@ -731,6 +805,58 @@ function blinkOnce(): void {
   border-color: var(--bd);
   color: var(--dim);
 }
+
+/* Session search */
+.search {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin: 0 12px 8px;
+  padding: 6px 8px;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: transparent;
+  color: var(--muted);
+}
+.search:focus-within {
+  border-color: var(--bd);
+  color: var(--ink);
+}
+.search-icon {
+  flex: none;
+}
+.search-input {
+  flex: 1;
+  min-width: 0;
+  border: none;
+  outline: none;
+  background: transparent;
+  color: var(--ink);
+  font-family: var(--mono);
+  font-size: calc(var(--ui-font-size) - 1px);
+}
+.search-input::placeholder {
+  color: var(--faint);
+}
+.search-clear {
+  flex: none;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 18px;
+  height: 18px;
+  padding: 0;
+  border: none;
+  border-radius: 4px;
+  background: none;
+  color: var(--muted);
+  cursor: pointer;
+}
+.search-clear:hover {
+  background: var(--soft);
+  color: var(--ink);
+}
+
 /* Sessions */
 .sessions {
   flex: 1;

--- a/apps/kimi-web/src/composables/useKimiWebClient.ts
+++ b/apps/kimi-web/src/composables/useKimiWebClient.ts
@@ -2404,6 +2404,7 @@ const sessionsForView = computed<Session[]>(() => {
       time: formatTime(s.updatedAt, s.status),
       status: s.status,
       busy: isSessionEffectivelyRunning(s.id),
+      lastPrompt: s.lastPrompt,
     }));
 });
 

--- a/apps/kimi-web/src/composables/useKimiWebClient.ts
+++ b/apps/kimi-web/src/composables/useKimiWebClient.ts
@@ -2394,10 +2394,13 @@ const visibleWorkspace = computed<WorkspaceView | null>(() => {
  */
 const sessionsForView = computed<Session[]>(() => {
   void sessionTimeClock.value;
+  const visibleWorkspaceIds = new Set(workspacesView.value.map((w) => w.id));
   // Child ("side chat") sessions never appear in the main list — they live in
-  // the side-chat panel only.
+  // the side-chat panel only. Sessions under a removed (hidden) workspace are
+  // excluded too, so this flat list matches what the grouped sidebar renders
+  // and sidebar search can't resurrect sessions from a removed workspace.
   return rawState.sessions
-    .filter((s) => !s.parentSessionId)
+    .filter((s) => !s.parentSessionId && visibleWorkspaceIds.has(workspaceIdForSession(s)))
     .map((s) => ({
       id: s.id,
       title: s.title,

--- a/apps/kimi-web/src/i18n/locales/en/sidebar.ts
+++ b/apps/kimi-web/src/i18n/locales/en/sidebar.ts
@@ -26,4 +26,7 @@ export default {
   showMore: 'Show more ({count})',
   collapseSidebar: 'Collapse sidebar',
   expandSidebar: 'Expand sidebar',
+  searchPlaceholder: 'Search sessions',
+  searchClear: 'Clear search',
+  searchNoResults: 'No matching sessions',
 } as const;

--- a/apps/kimi-web/src/i18n/locales/zh/sidebar.ts
+++ b/apps/kimi-web/src/i18n/locales/zh/sidebar.ts
@@ -26,4 +26,7 @@ export default {
   showMore: '展开更多 ({count})',
   collapseSidebar: '收起侧边栏',
   expandSidebar: '展开侧边栏',
+  searchPlaceholder: '搜索会话',
+  searchClear: '清除搜索',
+  searchNoResults: '没有匹配的会话',
 };

--- a/apps/kimi-web/src/types.ts
+++ b/apps/kimi-web/src/types.ts
@@ -17,6 +17,8 @@ export interface Session {
   busy: boolean;
   /** ISO timestamp for recency-based filtering (e.g. default visible sessions). */
   updatedAt?: string;
+  /** Text of the most recent user prompt, used by sidebar search. */
+  lastPrompt?: string;
 }
 
 export interface Workspace {

--- a/apps/kimi-web/test/session-meta-updated.test.ts
+++ b/apps/kimi-web/test/session-meta-updated.test.ts
@@ -1,0 +1,90 @@
+// apps/kimi-web/test/session-meta-updated.test.ts
+//
+// The daemon emits `session.meta.updated` whenever a session's title or last
+// user prompt changes. The projector must forward BOTH fields so the cached
+// session list stays fresh — otherwise sidebar search by the latest prompt
+// text goes stale until a full reload.
+
+import { describe, expect, it } from 'vitest';
+import { createAgentProjector } from '../src/api/daemon/agentEventProjector';
+import { createInitialState, reduceAppEvent, type KimiClientState } from '../src/api/daemon/eventReducer';
+import type { AppEvent, AppSession } from '../src/api/types';
+
+const SESSION = 'sess_1';
+
+function seedSession(): AppSession {
+  return {
+    id: SESSION,
+    title: 'Old title',
+    createdAt: '2026-06-11T00:00:00.000Z',
+    updatedAt: '2026-06-11T00:00:00.000Z',
+    status: 'idle',
+    archived: false,
+    cwd: '/repo',
+    model: 'kimi-test',
+    usage: {
+      inputTokens: 0,
+      outputTokens: 0,
+      cacheReadTokens: 0,
+      cacheCreationTokens: 0,
+      totalCostUsd: 0,
+      contextTokens: 0,
+      contextLimit: 128_000,
+      turnCount: 0,
+    },
+    messageCount: 0,
+    lastSeq: 0,
+    lastPrompt: 'old prompt',
+  };
+}
+
+function play(events: [string, unknown][], initial?: KimiClientState): { state: KimiClientState; appEvents: AppEvent[] } {
+  const projector = createAgentProjector();
+  let state = initial ?? createInitialState();
+  const appEvents: AppEvent[] = [];
+  let seq = 0;
+  for (const [type, payload] of events) {
+    for (const appEvent of projector.project(type, payload, SESSION)) {
+      appEvents.push(appEvent);
+      state = reduceAppEvent(state, appEvent, { sessionId: SESSION, seq: ++seq });
+    }
+  }
+  return { state, appEvents };
+}
+
+describe('session.meta.updated pipeline', () => {
+  it('forwards lastPrompt so the cached session stays searchable', () => {
+    const initial: KimiClientState = { ...createInitialState(), sessions: [seedSession()] };
+
+    const { state, appEvents } = play(
+      [['session.meta.updated', { patch: { lastPrompt: 'fix the sidebar search' } }]],
+      initial,
+    );
+
+    expect(appEvents).toEqual([
+      { type: 'sessionMetaUpdated', sessionId: SESSION, lastPrompt: 'fix the sidebar search' },
+    ]);
+    const session = state.sessions.find((s) => s.id === SESSION);
+    expect(session?.lastPrompt).toBe('fix the sidebar search');
+    // Title untouched when not present in the patch.
+    expect(session?.title).toBe('Old title');
+  });
+
+  it('still forwards title and patches it alongside lastPrompt', () => {
+    const initial: KimiClientState = { ...createInitialState(), sessions: [seedSession()] };
+
+    const { state } = play(
+      [['session.meta.updated', { patch: { title: 'New title', lastPrompt: 'latest prompt' } }]],
+      initial,
+    );
+
+    const session = state.sessions.find((s) => s.id === SESSION);
+    expect(session?.title).toBe('New title');
+    expect(session?.lastPrompt).toBe('latest prompt');
+  });
+
+  it('emits nothing when the patch carries neither title nor lastPrompt', () => {
+    const { appEvents } = play([['session.meta.updated', { patch: {} }]]);
+    expect(appEvents).toEqual([]);
+  });
+});

--- a/apps/kimi-web/test/sidebar-search.test.ts
+++ b/apps/kimi-web/test/sidebar-search.test.ts
@@ -84,4 +84,17 @@ describe('Sidebar session search', () => {
     expect(wrapper.find('.search-clear').exists()).toBe(false);
     expect(wrapper.text()).not.toContain('No matching sessions');
   });
+
+  it('clears the query on Escape so it does not bubble to abort a run', async () => {
+    const wrapper = mountSidebar();
+    const input = wrapper.find('.search-input');
+    await input.setValue('refactor');
+    expect(wrapper.find('.search-clear').exists()).toBe(true);
+
+    await input.trigger('keydown', { key: 'Escape' });
+
+    // Query cleared → back to the grouped list, no results panel.
+    expect((input.element as HTMLInputElement).value).toBe('');
+    expect(wrapper.text()).not.toContain('No matching sessions');
+  });
 });

--- a/apps/kimi-web/test/sidebar-search.test.ts
+++ b/apps/kimi-web/test/sidebar-search.test.ts
@@ -1,0 +1,87 @@
+// apps/kimi-web/test/sidebar-search.test.ts
+//
+// The sidebar search box filters the already-loaded sessions instantly by
+// title + last prompt (case-insensitive substring), across all workspaces.
+
+import { mount } from '@vue/test-utils';
+import { createI18n } from 'vue-i18n';
+import { describe, expect, it } from 'vitest';
+
+import Sidebar from '../src/components/Sidebar.vue';
+import enWorkspace from '../src/i18n/locales/en/workspace';
+import enSidebar from '../src/i18n/locales/en/sidebar';
+import enSettings from '../src/i18n/locales/en/settings';
+import type { Session } from '../src/types';
+
+const i18n = createI18n({
+  legacy: false,
+  locale: 'en',
+  messages: { en: { workspace: enWorkspace, sidebar: enSidebar, settings: enSettings } },
+  missingWarn: false,
+  fallbackWarn: false,
+});
+
+const sessions: Session[] = [
+  { id: 's1', title: 'Refactor auth', time: '1m', status: 'idle', busy: false, lastPrompt: 'extract the token refresh logic' },
+  { id: 's2', title: 'Fix tests', time: '2m', status: 'idle', busy: false, lastPrompt: 'make the sidebar spec pass' },
+  { id: 's3', title: 'Write docs', time: '3m', status: 'idle', busy: false },
+];
+
+function mountSidebar() {
+  return mount(Sidebar, {
+    props: {
+      activeWorkspace: null,
+      activeWorkspaceId: null,
+      sessions,
+      groups: [],
+      activeId: '',
+    },
+    global: {
+      plugins: [i18n],
+      stubs: { LanguageSwitcher: true },
+    },
+  });
+}
+
+describe('Sidebar session search', () => {
+  it('shows the grouped list when the query is empty', () => {
+    const wrapper = mountSidebar();
+    expect(wrapper.find('.search-input').exists()).toBe(true);
+    // No flat results / no "no results" empty state rendered while not searching.
+    expect(wrapper.text()).not.toContain('No matching sessions');
+  });
+
+  it('filters by title (case-insensitive)', async () => {
+    const wrapper = mountSidebar();
+    await wrapper.find('.search-input').setValue('refactor');
+
+    expect(wrapper.text()).toContain('Refactor auth');
+    expect(wrapper.text()).not.toContain('Fix tests');
+    expect(wrapper.text()).not.toContain('Write docs');
+  });
+
+  it('filters by last prompt', async () => {
+    const wrapper = mountSidebar();
+    await wrapper.find('.search-input').setValue('sidebar spec');
+
+    expect(wrapper.text()).toContain('Fix tests');
+    expect(wrapper.text()).not.toContain('Refactor auth');
+  });
+
+  it('shows an empty state when nothing matches', async () => {
+    const wrapper = mountSidebar();
+    await wrapper.find('.search-input').setValue('zzzz-no-match');
+
+    expect(wrapper.text()).toContain('No matching sessions');
+  });
+
+  it('clears the query and restores the grouped list', async () => {
+    const wrapper = mountSidebar();
+    await wrapper.find('.search-input').setValue('refactor');
+    expect(wrapper.find('.search-clear').exists()).toBe(true);
+
+    await wrapper.find('.search-clear').trigger('click');
+    expect(wrapper.find('.search-clear').exists()).toBe(false);
+    expect(wrapper.text()).not.toContain('No matching sessions');
+  });
+});

--- a/apps/kimi-web/test/useKimiWebClient-session-list.test.ts
+++ b/apps/kimi-web/test/useKimiWebClient-session-list.test.ts
@@ -173,4 +173,26 @@ describe('load() session listing', () => {
     await expect(client.load()).resolves.toBeUndefined();
     expect(client.sessions.value).toEqual([]);
   });
+
+  it('excludes hidden-workspace sessions from sessionsForView (sidebar search source)', async () => {
+    const { client } = await setup({
+      pages: [
+        {
+          items: [session('a1', { cwd: '/repo/a' }), session('b1', { cwd: '/repo/b' })],
+          hasMore: false,
+        },
+      ],
+    });
+
+    await client.load();
+    expect(client.sessionsForView.value.map((s) => s.id).sort()).toEqual(['a1', 'b1']);
+
+    // Hide the /repo/b workspace — its sessions must drop out of the flat list
+    // that the sidebar search filters, mirroring the grouped sidebar.
+    const wsB = client.workspacesView.value.find((w) => w.root === '/repo/b');
+    expect(wsB).toBeDefined();
+    await client.deleteWorkspace(wsB!.id);
+
+    expect(client.sessionsForView.value.map((s) => s.id)).toEqual(['a1']);
+  });
 });

--- a/packages/agent-core/src/services/session/session.ts
+++ b/packages/agent-core/src/services/session/session.ts
@@ -117,6 +117,7 @@ export function toProtocolSession(
     updated_at: new Date(summary.updatedAt).toISOString(),
     status: 'idle',
     archived: summary.archived === true,
+    last_prompt: summary.lastPrompt,
     metadata: mergedMetadata,
     agent_config: {
       model: '',

--- a/packages/agent-core/test/services/session-service.test.ts
+++ b/packages/agent-core/test/services/session-service.test.ts
@@ -384,6 +384,27 @@ describe('toProtocolSession adapter', () => {
     expect(proto.created_at.endsWith('Z')).toBe(true);
   });
 
+  it('surfaces last_prompt from the summary when present', () => {
+    const withPrompt: SessionSummary = {
+      id: 'sess_lp_1',
+      workDir: '/tmp/wd',
+      sessionDir: '/tmp/sd',
+      createdAt: 0,
+      updatedAt: 0,
+      lastPrompt: 'what is 2 + 2?',
+    };
+    expect(toProtocolSession(withPrompt).last_prompt).toBe('what is 2 + 2?');
+
+    const withoutPrompt: SessionSummary = {
+      id: 'sess_lp_2',
+      workDir: '/tmp/wd',
+      sessionDir: '/tmp/sd',
+      createdAt: 0,
+      updatedAt: 0,
+    };
+    expect(toProtocolSession(withoutPrompt).last_prompt).toBeUndefined();
+  });
+
   it('fills documented defaults when CoreAPI does not surface a field', () => {
     const summary: SessionSummary = {
       id: 'sess_02',

--- a/packages/protocol/src/__tests__/session.test.ts
+++ b/packages/protocol/src/__tests__/session.test.ts
@@ -118,6 +118,14 @@ describe('sessionSchema', () => {
     const parsed = sessionSchema.parse(withoutArchived);
     expect(parsed.archived).toBeUndefined();
   });
+
+  it('accepts the optional last_prompt field', () => {
+    const withPrompt = { ...fullSession, last_prompt: 'hello world' };
+    expect(sessionSchema.parse(withPrompt).last_prompt).toBe('hello world');
+
+    const parsed = sessionSchema.parse(fullSession);
+    expect(parsed.last_prompt).toBeUndefined();
+  });
 });
 
 describe('sessionCreateSchema', () => {

--- a/packages/protocol/src/session.ts
+++ b/packages/protocol/src/session.ts
@@ -94,6 +94,8 @@ export const sessionSchema = z.object({
   status: sessionStatusSchema,
   archived: z.boolean().optional(),
   current_prompt_id: z.string().min(1).optional(),
+  /** Text of the most recent user prompt, for search/preview. Absent for empty sessions. */
+  last_prompt: z.string().optional(),
   metadata: sessionMetadataSchema,
   agent_config: sessionAgentConfigSchema,
   usage: sessionUsageSchema,


### PR DESCRIPTION
## Related Issue

No related issue.

## Problem

The sidebar lists sessions grouped by workspace, but there is no way to find a specific conversation by its title or content. As the session list grows, locating an older session means manually scanning each workspace.

## What changed

Add a search box above the New Chat button in the sidebar. Typing filters all loaded sessions instantly by title and the last user prompt (case-insensitive), showing a flat result list across all workspaces, with a clear button and an empty state.

To make the last user prompt available for matching, the daemon now exposes it on the session. It was already persisted in session metadata; this threads it through the protocol schema into the REST response, so the web client receives it without any extra request.

Includes English/Chinese labels, a changeset, and tests for the schema, the session adapter, and the sidebar filtering.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.