### PR TITLE
fix(agent-core): force UTF-8 for Python MCP stdio servers on Windows

### DIFF
--- a/.changeset/fix-mcp-windows-utf8-stdio.md
+++ b/.changeset/fix-mcp-windows-utf8-stdio.md
@@ -1,0 +1,10 @@
+---
+"@moonshot-ai/agent-core": patch
+---
+
+fix(agent-core): force UTF-8 for Python MCP stdio servers on Windows
+
+Default the child environment to `PYTHONUTF8=1` and `PYTHONIOENCODING=utf-8`
+so Python MCP servers use UTF-8 for stdout/stderr regardless of the active
+Windows console codepage. Prevents `UnicodeEncodeError` when servers emit
+characters such as U+2713 (✓).

--- a/packages/agent-core/src/mcp/client-stdio.ts
+++ b/packages/agent-core/src/mcp/client-stdio.ts
@@ -225,11 +225,21 @@ class BoundedTail {
 // MERGED env so a proxy declared only in `config.env` is honored too.
 // `reconcileChildNoProxy` then mirrors a single-casing `NO_PROXY` override onto
 // both casings so it isn't shadowed by the injected value.
+//
+// Python MCP servers on Windows default to the console codepage (e.g. cp1252)
+// for stdout/stderr, which crashes with `UnicodeEncodeError` when they emit
+// UTF-8 characters such as U+2713. Setting PYTHONUTF8=1 and
+// PYTHONIOENCODING=utf-8 as defaults forces UTF-8 regardless of the active
+// Windows codepage. They are applied as defaults so a parent env or config.env
+// value can still override them intentionally.
 export function mergeStdioEnv(
   configEnv?: Record<string, string>,
   parentEnv: Readonly<Record<string, string | undefined>> = process.env,
 ): Record<string, string> {
-  const merged: Record<string, string> = {};
+  const merged: Record<string, string> = {
+    PYTHONUTF8: '1',
+    PYTHONIOENCODING: 'utf-8',
+  };
   for (const [key, value] of Object.entries(parentEnv)) {
     if (value !== undefined) merged[key] = value;
   }

--- a/packages/agent-core/test/mcp/client-stdio.test.ts
+++ b/packages/agent-core/test/mcp/client-stdio.test.ts
@@ -10,6 +10,7 @@ const here = import.meta.dirname;
 const fixture = join(here, 'fixtures', 'mock-stdio-server.mjs');
 const stderrThenExitFixture = join(here, 'fixtures', 'stderr-then-exit-stdio-server.mjs');
 const crashAfterConnectFixture = join(here, 'fixtures', 'crash-after-connect-stdio-server.mjs');
+const unicodeFixture = join(here, 'fixtures', 'unicode-stdio-server.mjs');
 
 describe('StdioMcpClient', () => {
   it('rejects unsupported executor at construction time', () => {
@@ -51,6 +52,46 @@ describe('StdioMcpClient', () => {
       const result = await client.callTool('echo', { text: 'hello mcp' });
       expect(result.isError).toBe(false);
       expect(result.content).toEqual([{ type: 'text', text: 'hello mcp' }]);
+    } finally {
+      await client.close();
+    }
+  }, 15000);
+
+  it('round-trips Unicode (UTF-8) in tool metadata and results', async () => {
+    const client = new StdioMcpClient({
+      transport: 'stdio',
+      command: process.execPath,
+      args: [unicodeFixture],
+    });
+    try {
+      await client.connect();
+      const tools = await client.listTools();
+      const unicodeEcho = tools.find((t) => t.name === 'unicode_echo');
+      expect(unicodeEcho).toBeDefined();
+      // The description contains a literal U+2713 checkmark; if the stdio
+      // reader interpreted bytes through cp1252/charmap this would be mangled.
+      expect(unicodeEcho?.description).toContain('✓');
+
+      const result = await client.callTool('unicode_echo', { text: 'hello' });
+      expect(result.isError).toBe(false);
+      expect(result.content).toEqual([{ type: 'text', text: '✓ hello' }]);
+    } finally {
+      await client.close();
+    }
+  }, 15000);
+
+  it('injects PYTHONUTF8=1 and PYTHONIOENCODING=utf-8 into the child env', async () => {
+    const client = new StdioMcpClient({
+      transport: 'stdio',
+      command: process.execPath,
+      args: [unicodeFixture],
+    });
+    try {
+      await client.connect();
+      const pythonUtf8 = await client.callTool('read_env', { name: 'PYTHONUTF8' });
+      expect(pythonUtf8.content).toEqual([{ type: 'text', text: '1' }]);
+      const pythonIoEncoding = await client.callTool('read_env', { name: 'PYTHONIOENCODING' });
+      expect(pythonIoEncoding.content).toEqual([{ type: 'text', text: 'utf-8' }]);
     } finally {
       await client.close();
     }
@@ -248,6 +289,31 @@ describe('StdioMcpClient', () => {
 });
 
 describe('mergeStdioEnv', () => {
+  it('defaults Python stdio to UTF-8 so Windows cp1252/charmap crashes do not occur', () => {
+    const merged = mergeStdioEnv(undefined, { PATH: '/usr/bin' });
+    expect(merged['PYTHONUTF8']).toBe('1');
+    expect(merged['PYTHONIOENCODING']).toBe('utf-8');
+  });
+
+  it('lets parent env override the UTF-8 defaults', () => {
+    const merged = mergeStdioEnv(undefined, {
+      PATH: '/usr/bin',
+      PYTHONUTF8: '0',
+      PYTHONIOENCODING: 'latin-1',
+    });
+    expect(merged['PYTHONUTF8']).toBe('0');
+    expect(merged['PYTHONIOENCODING']).toBe('latin-1');
+  });
+
+  it('lets config.env override the UTF-8 defaults', () => {
+    const merged = mergeStdioEnv(
+      { PYTHONUTF8: '0', PYTHONIOENCODING: 'latin-1' },
+      { PATH: '/usr/bin' },
+    );
+    expect(merged['PYTHONUTF8']).toBe('0');
+    expect(merged['PYTHONIOENCODING']).toBe('latin-1');
+  });
+
   it('enables NODE_USE_ENV_PROXY for a proxy set only in the server config.env', () => {
     const merged = mergeStdioEnv({ HTTP_PROXY: 'http://corp:3128' }, { PATH: '/usr/bin' });
     expect(merged['HTTP_PROXY']).toBe('http://corp:3128');

--- a/packages/agent-core/test/mcp/fixtures/unicode-stdio-server.mjs
+++ b/packages/agent-core/test/mcp/fixtures/unicode-stdio-server.mjs
@@ -1,0 +1,36 @@
+// MCP stdio server fixture that emits non-ASCII UTF-8 in its tool metadata
+// and tool results. Used to regression-test that Kimi's stdio reader decodes
+// protocol bytes as UTF-8 rather than the process locale text codec.
+//
+// The checkmark (U+2713 / "✓") is the exact character reported in
+// https://github.com/MoonshotAI/kimi-code/issues/886.
+
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import { z } from 'zod';
+
+const server = new McpServer({ name: 'unicode-stdio', version: '0.0.1' });
+
+server.registerTool(
+  'unicode_echo',
+  {
+    description: 'Echoes input text with a Unicode checkmark ✓ prepended',
+    inputSchema: { text: z.string() },
+  },
+  ({ text }) => ({
+    content: [{ type: 'text', text: `✓ ${text}` }],
+  }),
+);
+
+server.registerTool(
+  'read_env',
+  {
+    description: 'Returns the value of process.env[name], or empty string',
+    inputSchema: { name: z.string() },
+  },
+  ({ name }) => ({
+    content: [{ type: 'text', text: process.env[name] ?? '' }],
+  }),
+);
+
+await server.connect(new StdioServerTransport());


### PR DESCRIPTION
## Problem

On Windows, Python MCP stdio servers inherit the console codepage (typically cp1252 / "charmap") for `stdout`/`stderr`. When they emit Unicode characters such as U+2713 (✓), Python raises:

```
UnicodeEncodeError: 'charmap' codec can't encode character '\u2713' in position 0: character maps to <undefined>
```

The transport then dies and Kimi Code falls back to generic tools.

## Root cause

`mergeStdioEnv()` in `packages/agent-core/src/mcp/client-stdio.ts` builds the environment for the child process but does not request UTF-8 from Python, so Python falls back to the system codepage.

## Fix

Default the child environment to `PYTHONUTF8=1` and `PYTHONIOENCODING=utf-8`. These are applied before inheriting `parentEnv` / `config.env`, so users can still override them intentionally.

## Regression coverage

- Added `unicode-stdio-server.mjs` fixture that emits U+2713 in `tools/list` and tool results.
- Added integration tests verifying UTF-8 round-trip and that the env vars reach the child.
- Added unit tests for `mergeStdioEnv` defaults and override semantics.

```bash
cd packages/agent-core
pnpm exec vitest run test/mcp/client-stdio.test.ts
# 18/18 passed
```

## Standalone reproduction

A minimal Python MCP server that reproduces the crash and confirms the fix is attached to the issue discussion.

Closes #886
