### PR TITLE
fix(agent-core): session approval for Write/Edit at tool scope

### DIFF
--- a/.changeset/fix-437-session-approval-write-edit.md
+++ b/.changeset/fix-437-session-approval-write-edit.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Fix "Approve for this session" not skipping repeated Write and Edit approval prompts in the same session.

--- a/packages/agent-core/src/agent/permission/index.ts
+++ b/packages/agent-core/src/agent/permission/index.ts
@@ -1,5 +1,6 @@
 import type { Agent } from '..';
 import type { PrepareToolExecutionResult } from '../../loop';
+import { parsePattern } from './matches-rule';
 import { createPermissionDecisionPolicies } from './policies';
 import type {
   ApprovalResponse,
@@ -14,6 +15,26 @@ import type {
 } from './types';
 
 export * from './types';
+
+/** Write/Edit 会话审批按工具名缓存，避免同目录多文件重复弹窗（#437）。 */
+function resolveSessionApprovalRule(
+  toolName: string,
+  approvalRule: string,
+  hasArgumentMatcher: boolean,
+): string {
+  if (!hasArgumentMatcher) {
+    return approvalRule;
+  }
+  try {
+    const parsed = parsePattern(approvalRule);
+    if (parsed.argPattern !== undefined && (toolName === 'Write' || toolName === 'Edit')) {
+      return parsed.toolName;
+    }
+  } catch {
+    // 保留字面规则
+  }
+  return approvalRule;
+}
 
 export interface PermissionManagerOptions {
   readonly initialRules?: readonly PermissionRule[];
@@ -191,7 +212,11 @@ export class PermissionManager {
 
     const sessionApprovalRule =
       response.decision === 'approved' && response.scope === 'session'
-        ? context.execution.approvalRule
+        ? resolveSessionApprovalRule(
+            name,
+            context.execution.approvalRule,
+            context.execution.matchesRule !== undefined,
+          )
         : undefined;
 
     if (requestedApproval) {

--- a/packages/agent-core/test/agent/permission.test.ts
+++ b/packages/agent-core/test/agent/permission.test.ts
@@ -2260,6 +2260,36 @@ describe('Agent-local approve for session', () => {
     expect(manager.sessionApprovalRulePatterns).toContain('Custom');
   });
 
+  it('reuses approve-for-session for Write to different paths in the same session (#437)', async () => {
+    const { manager, requestApproval } = makePermissionManager(async () => ({
+      decision: 'approved',
+      scope: 'session',
+      selectedLabel: 'Approve for this session',
+    }));
+
+    await expect(
+      manager.beforeToolCall(
+        hookContext({
+          id: 'call_write_a',
+          toolName: 'Write',
+          args: { path: '/workspace/pkg/a.ts', content: 'a' },
+        }),
+      ),
+    ).resolves.toBeUndefined();
+    await expect(
+      manager.beforeToolCall(
+        hookContext({
+          id: 'call_write_b',
+          toolName: 'Write',
+          args: { path: '/workspace/pkg/b.ts', content: 'b' },
+        }),
+      ),
+    ).resolves.toBeUndefined();
+
+    expect(requestApproval).toHaveBeenCalledTimes(1);
+    expect(manager.sessionApprovalRulePatterns).toContain('Write');
+  });
+
   it('stores runtime rules with literal glob escaping', async () => {
     const { manager, requestApproval } = makePermissionManager(async () => ({
       decision: 'approved',


### PR DESCRIPTION
## Related Issue

Fixes #437

## Problem

In the TUI, choosing "Approve for this session" on Write or Edit did not behave differently from "Approve once": subsequent writes in the same session still showed approval prompts. Issue comment reproduces this when writing multiple files under the same directory after selecting session approval.

## What changed

- When the user approves Write or Edit **for this session**, `PermissionManager` now stores a **tool-name** session rule (for example `Write`) instead of a path-specific rule (for example `Write(/path/a.ts)`).
- `session-approval-history` can then match later Write/Edit calls to different paths in the same session without re-prompting.
- **Approve once** still does not write session patterns; the next matching call prompts again.
- **Bash** session approval is unchanged: it still caches the full command-level rule so different commands remain separately gated.

Implementation is limited to `packages/agent-core` (`resolveSessionApprovalRule` + tests). TUI adapter already maps `approved_for_session` to `scope: 'session'`; no TUI code changes in this PR.

## Checklist

- [x] I have read the CONTRIBUTING document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.


Made with [Cursor](https://cursor.com)