### PR TITLE
fix(mcp): force UTF-8 encoding for Python stdio servers on Windows

### DIFF
--- a/.changeset/mcp-utf8-windows.md
+++ b/.changeset/mcp-utf8-windows.md
@@ -1,0 +1,8 @@
+---
+"@moonshot-ai/mcp-client": patch
+---
+
+fix(mcp): force UTF-8 encoding for Python stdio servers on Windows
+
+Set PYTHONIOENCODING=utf-8 for Python stdio MCP servers on Windows to prevent
+encoding errors.

--- a/packages/agent-core/src/mcp/client-stdio.ts
+++ b/packages/agent-core/src/mcp/client-stdio.ts
@@ -236,5 +236,18 @@ export function mergeStdioEnv(
   if (configEnv !== undefined) Object.assign(merged, configEnv);
   Object.assign(merged, proxyEnvForChild(merged));
   reconcileChildNoProxy(merged, configEnv);
+  // Ensure Python MCP servers use UTF-8 for stdio encoding.
+  // On Windows the default console code page (e.g. cp1252) cannot encode
+  // non-ASCII characters, causing UnicodeEncodeError when Python servers
+  // print Unicode to stdout/stderr.  JSON-RPC over stdio is always UTF-8,
+  // so forcing the encoding is correct on every platform.
+  // See https://github.com/MoonshotAI/kimi-code/issues/886
+  if (merged['PYTHONIOENCODING'] === undefined) {
+    merged['PYTHONIOENCODING'] = 'utf-8';
+  }
+  if (merged['PYTHONUTF8'] === undefined) {
+    merged['PYTHONUTF8'] = '1';
+  }
+
   return merged;
 }

--- a/packages/agent-core/test/mcp/client-stdio.test.ts
+++ b/packages/agent-core/test/mcp/client-stdio.test.ts
@@ -266,4 +266,25 @@ describe('mergeStdioEnv', () => {
     const merged = mergeStdioEnv({ FOO: 'override' }, { FOO: 'parent', PATH: '/x' });
     expect(merged['FOO']).toBe('override');
   });
+
+  it('injects PYTHONIOENCODING=utf-8 and PYTHONUTF8=1 for Python MCP servers', () => {
+    const merged = mergeStdioEnv(undefined, { PATH: '/usr/bin' });
+    expect(merged['PYTHONIOENCODING']).toBe('utf-8');
+    expect(merged['PYTHONUTF8']).toBe('1');
+    expect(merged['PATH']).toBe('/usr/bin');
+  });
+
+  it('does not override user-provided PYTHONIOENCODING or PYTHONUTF8', () => {
+    const merged = mergeStdioEnv(
+      { PYTHONIOENCODING: 'latin-1', PYTHONUTF8: '0' },
+      { PATH: '/usr/bin' },
+    );
+    expect(merged['PYTHONIOENCODING']).toBe('latin-1');
+    expect(merged['PYTHONUTF8']).toBe('0');
+  });
+
+  it('inherits parent PYTHONIOENCODING when present', () => {
+    const merged = mergeStdioEnv(undefined, { PATH: '/usr/bin', PYTHONIOENCODING: 'cp1252' });
+    expect(merged['PYTHONIOENCODING']).toBe('cp1252');
+  });
 });


### PR DESCRIPTION
Python MCP servers on Windows crash with \+UnicodeEncodeError\+ when printing non-ASCII characters (e.g. ✓ U+2713) because the default console code page (e.g. cp1252) cannot encode them.

The MCP SDK's StdioClientTransport spawns child processes with a filtered environment that strips most parent variables. When stdout/stderr is a pipe rather than a console, Python falls back to the system's ANSI code page, which breaks any Unicode output.

**Fix:** inject `PYTHONIOENCODING=utf-8` and `PYTHONUTF8=1` into the merged env for every stdio MCP client when not already explicitly set by the user. This ensures JSON-RPC over stdio is always UTF-8 regardless of platform.

**Changes:**
- Add UTF-8 env vars in `mergeStdioEnv` when absent
- Add unit tests for injection, inheritance, and override behavior

Closes #886