### PR TITLE
fix: drop empty text blocks during projection

### DIFF
--- a/.changeset/clean-empty-text-blocks.md
+++ b/.changeset/clean-empty-text-blocks.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Fix provider requests failing when restored conversation history contains empty text content blocks.

--- a/packages/agent-core/src/agent/context/projector.ts
+++ b/packages/agent-core/src/agent/context/projector.ts
@@ -1,5 +1,6 @@
 import type { ContentPart, Message, TextPart } from '@moonshot-ai/kosong';
 
+import { ErrorCodes, KimiError } from '../../errors';
 import type { ContextMessage } from './types';
 
 export function project(history: readonly ContextMessage[]): Message[] {
@@ -39,6 +40,17 @@ function prepareMessageForProjection(message: ContextMessage): ContextMessage | 
   }
 
   const next = content === undefined ? message : { ...message, content };
+  if (next.role === 'tool' && next.content.length === 0) {
+    throw new KimiError(
+      ErrorCodes.REQUEST_INVALID,
+      'Tool result message content cannot be empty after removing empty text blocks.',
+      {
+        details: {
+          toolCallId: next.toolCallId,
+        },
+      },
+    );
+  }
   return next.content.length === 0 && next.toolCalls.length === 0 ? null : next;
 }
 

--- a/packages/agent-core/src/agent/context/projector.ts
+++ b/packages/agent-core/src/agent/context/projector.ts
@@ -3,21 +3,15 @@ import type { ContentPart, Message, TextPart } from '@moonshot-ai/kosong';
 import type { ContextMessage } from './types';
 
 export function project(history: readonly ContextMessage[]): Message[] {
-  // Keep partial or empty assistant placeholders away from providers.
-  // They can appear when a turn is aborted or errors before any content
-  // or tool call is appended.
-  const usable = history.filter((message) => {
-    return (
-      message.partial !== true &&
-      !(message.role === 'assistant' && message.content.length === 0 && message.toolCalls.length === 0)
-    );
-  });
-  return mergeAdjacentUserMessages(usable);
+  return mergeAdjacentUserMessages(history);
 }
 
 function mergeAdjacentUserMessages(history: readonly ContextMessage[]): Message[] {
   const out: ContextMessage[] = [];
-  for (const message of history) {
+  for (const source of history) {
+    const message = prepareMessageForProjection(source);
+    if (message === null) continue;
+
     const previous = out.at(-1);
     if (
       canMergeUserMessage(message) &&
@@ -30,6 +24,22 @@ function mergeAdjacentUserMessages(history: readonly ContextMessage[]): Message[
     out.push(message);
   }
   return out.map(stripContextMetadata);
+}
+
+function prepareMessageForProjection(message: ContextMessage): ContextMessage | null {
+  if (message.partial === true) return null;
+
+  let content: ContentPart[] | undefined;
+  for (const [index, part] of message.content.entries()) {
+    if (part.type === 'text' && part.text.length === 0) {
+      content ??= message.content.slice(0, index);
+      continue;
+    }
+    content?.push(part);
+  }
+
+  const next = content === undefined ? message : { ...message, content };
+  return next.content.length === 0 && next.toolCalls.length === 0 ? null : next;
 }
 
 function canMergeUserMessage(message: ContextMessage): boolean {

--- a/packages/agent-core/test/agent/context.test.ts
+++ b/packages/agent-core/test/agent/context.test.ts
@@ -80,6 +80,67 @@ describe('Agent context', () => {
     ]);
   });
 
+  it('drops empty text parts only in LLM projection', () => {
+    const history: ContextMessage[] = [
+      {
+        role: 'user',
+        content: [
+          { type: 'text', text: '' },
+          { type: 'text', text: 'Run the tool' },
+        ],
+        toolCalls: [],
+      },
+      {
+        role: 'assistant',
+        content: [{ type: 'text', text: '' }],
+        toolCalls: [],
+      },
+      {
+        role: 'assistant',
+        content: [{ type: 'text', text: '' }],
+        toolCalls: [{ type: 'function', id: 'call_empty', name: 'empty', arguments: '{}' }],
+      },
+      {
+        role: 'assistant',
+        content: [{ type: 'think', think: '', encrypted: 'enc_empty_thinking' }],
+        toolCalls: [],
+      },
+      {
+        role: 'user',
+        content: [{ type: 'text', text: '   ' }],
+        toolCalls: [],
+      },
+    ];
+
+    expect(project(history)).toEqual([
+      {
+        role: 'user',
+        content: [{ type: 'text', text: 'Run the tool' }],
+        toolCalls: [],
+      },
+      {
+        role: 'assistant',
+        content: [],
+        toolCalls: [{ type: 'function', id: 'call_empty', name: 'empty', arguments: '{}' }],
+      },
+      {
+        role: 'assistant',
+        content: [{ type: 'think', think: '', encrypted: 'enc_empty_thinking' }],
+        toolCalls: [],
+      },
+      {
+        role: 'user',
+        content: [{ type: 'text', text: '   ' }],
+        toolCalls: [],
+      },
+    ]);
+    expect(history[0]?.content).toEqual([
+      { type: 'text', text: '' },
+      { type: 'text', text: 'Run the tool' },
+    ]);
+    expect(history[1]?.content).toEqual([{ type: 'text', text: '' }]);
+  });
+
   it('projects hook result messages into LLM projection', async () => {
     const ctx = testAgent();
     ctx.configure();

--- a/packages/agent-core/test/agent/context.test.ts
+++ b/packages/agent-core/test/agent/context.test.ts
@@ -141,6 +141,26 @@ describe('Agent context', () => {
     expect(history[1]?.content).toEqual([{ type: 'text', text: '' }]);
   });
 
+  it('rejects tool result messages left empty by LLM projection cleanup', () => {
+    const history: ContextMessage[] = [
+      {
+        role: 'assistant',
+        content: [],
+        toolCalls: [{ type: 'function', id: 'call_empty', name: 'empty', arguments: '{}' }],
+      },
+      {
+        role: 'tool',
+        content: [{ type: 'text', text: '' }],
+        toolCallId: 'call_empty',
+        toolCalls: [],
+      },
+    ];
+
+    expect(() => project(history)).toThrow(
+      'Tool result message content cannot be empty after removing empty text blocks.',
+    );
+  });
+
   it('projects hook result messages into LLM projection', async () => {
     const ctx = testAgent();
     ctx.configure();


### PR DESCRIPTION
## Related Issue

No linked issue; the problem is described below.

## Problem

Some providers reject empty text content blocks in request messages. Restored conversation history can replay empty streamed assistant text parts into the next provider request, causing the turn to fail before the model can continue.

## What changed

- Drop empty `text` content parts while projecting context history for LLM requests.
- Keep the cleanup in the existing projector pass that skips partial messages and merges adjacent user messages.
- Preserve assistant tool-call messages when their empty text content is removed, because the tool call itself is still meaningful.
- Reject projected tool result messages if cleanup leaves them with empty content, rather than silently orphaning the preceding assistant tool call or synthesizing model-visible tool output.
- Add projection coverage for empty text parts, assistant tool-call messages, malformed empty tool results, encrypted thinking parts, whitespace text, and non-mutating projection behavior.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.

## Validation

- `pnpm vitest run packages/agent-core/test/agent/context.test.ts`
- `pnpm exec oxlint --type-aware packages/agent-core/src/agent/context/projector.ts packages/agent-core/test/agent/context.test.ts`
- `git diff --check -- packages/agent-core/src/agent/context/projector.ts packages/agent-core/test/agent/context.test.ts`
- Read-only diff audit found no new internal identifiers, credentials, real endpoints, or other public-text leaks.