### PR TITLE
fix(tui): persist permission mode defaults

### DIFF
--- a/.changeset/persist-permission-mode-default.md
+++ b/.changeset/persist-permission-mode-default.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Persist permission mode changes from the TUI as the default for new sessions.

--- a/apps/kimi-code/src/tui/commands/config.ts
+++ b/apps/kimi-code/src/tui/commands/config.ts
@@ -86,35 +86,27 @@ export async function handleYoloCommand(host: SlashCommandHost, args: string): P
   const currentMode = host.state.appState.permissionMode;
 
   if (subcmd === 'on') {
-    if (currentMode === 'yolo') {
-      host.showNotice('YOLO mode is already on');
-      return;
+    if (await applyPermissionMode(host, session, 'yolo')) {
+      host.showNotice('YOLO mode: ON', 'Workspace tools auto-approved.');
     }
-    await session.setPermission('yolo');
-    host.setAppState({ permissionMode: 'yolo' });
-    host.showNotice('YOLO mode: ON', 'Workspace tools auto-approved.');
     return;
   }
 
   if (subcmd === 'off') {
-    if (currentMode !== 'yolo') {
-      host.showNotice('YOLO mode is already off');
-      return;
+    if (await applyPermissionMode(host, session, 'manual')) {
+      host.showNotice('YOLO mode: OFF');
     }
-    await session.setPermission('manual');
-    host.setAppState({ permissionMode: 'manual' });
-    host.showNotice('YOLO mode: OFF');
     return;
   }
 
   // toggle
   if (currentMode === 'yolo') {
-    await session.setPermission('manual');
-    host.setAppState({ permissionMode: 'manual' });
-    host.showNotice('YOLO mode: OFF');
-  } else {
-    await session.setPermission('yolo');
-    host.setAppState({ permissionMode: 'yolo' });
+    if (await applyPermissionMode(host, session, 'manual')) {
+      host.showNotice('YOLO mode: OFF');
+    }
+    return;
+  }
+  if (await applyPermissionMode(host, session, 'yolo')) {
     host.showNotice('YOLO mode: ON', 'Workspace tools auto-approved.');
   }
 }
@@ -130,35 +122,27 @@ export async function handleAutoCommand(host: SlashCommandHost, args: string): P
   const currentMode = host.state.appState.permissionMode;
 
   if (subcmd === 'on') {
-    if (currentMode === 'auto') {
-      host.showNotice('Auto mode is already on');
-      return;
+    if (await applyPermissionMode(host, session, 'auto')) {
+      host.showNotice('Auto mode: ON', 'Tools auto-approved. Agent will not ask questions.');
     }
-    await session.setPermission('auto');
-    host.setAppState({ permissionMode: 'auto' });
-    host.showNotice('Auto mode: ON', 'Tools auto-approved. Agent will not ask questions.');
     return;
   }
 
   if (subcmd === 'off') {
-    if (currentMode !== 'auto') {
-      host.showNotice('Auto mode is already off');
-      return;
+    if (await applyPermissionMode(host, session, 'manual')) {
+      host.showNotice('Auto mode: OFF');
     }
-    await session.setPermission('manual');
-    host.setAppState({ permissionMode: 'manual' });
-    host.showNotice('Auto mode: OFF');
     return;
   }
 
   // toggle
   if (currentMode === 'auto') {
-    await session.setPermission('manual');
-    host.setAppState({ permissionMode: 'manual' });
-    host.showNotice('Auto mode: OFF');
-  } else {
-    await session.setPermission('auto');
-    host.setAppState({ permissionMode: 'auto' });
+    if (await applyPermissionMode(host, session, 'manual')) {
+      host.showNotice('Auto mode: OFF');
+    }
+    return;
+  }
+  if (await applyPermissionMode(host, session, 'auto')) {
     host.showNotice('Auto mode: ON', 'Tools auto-approved. Agent will not ask questions.');
   }
 }
@@ -585,21 +569,45 @@ export async function applyUpdatePreferenceChoice(
 }
 
 async function applyPermissionChoice(host: SlashCommandHost, mode: PermissionMode): Promise<void> {
-  if (mode === host.state.appState.permissionMode) {
-    host.showStatus(`Permission mode unchanged: ${mode}.`);
+  const session = host.session;
+  if (session === undefined) {
+    host.showError(NO_ACTIVE_SESSION_MESSAGE);
     return;
   }
 
+  const unchanged = mode === host.state.appState.permissionMode;
+  const applied = await applyPermissionMode(host, session, mode);
+  if (!applied) return;
+
+  if (unchanged) {
+    host.showStatus(`Permission mode unchanged: ${mode}; saved as default.`);
+    return;
+  }
+  host.showNotice(`Permission mode: ${mode}`);
+}
+
+async function applyPermissionMode(
+  host: SlashCommandHost,
+  session: Session,
+  mode: PermissionMode,
+): Promise<boolean> {
   try {
-    await host.requireSession().setPermission(mode);
+    await session.setPermission(mode);
   } catch (error) {
     const msg = formatErrorMessage(error);
     host.showError(`Failed to set permission mode: ${msg}`);
-    return;
+    return false;
   }
 
   host.setAppState({ permissionMode: mode });
-  host.showNotice(`Permission mode: ${mode}`);
+  try {
+    await host.harness.setConfig({ defaultPermissionMode: mode });
+  } catch (error) {
+    const msg = formatErrorMessage(error);
+    host.showError(`Permission mode set for this session, but failed to save default: ${msg}`);
+    return false;
+  }
+  return true;
 }
 
 export function showSettingsSelector(host: SlashCommandHost): void {

--- a/apps/kimi-code/test/tui/kimi-tui-message-flow.test.ts
+++ b/apps/kimi-code/test/tui/kimi-tui-message-flow.test.ts
@@ -28,6 +28,7 @@ import {
   PluginRemoveConfirmComponent,
   PluginsOverviewSelectorComponent,
 } from '#/tui/components/dialogs/plugins-selector';
+import { PermissionSelectorComponent } from '#/tui/components/dialogs/permission-selector';
 import { KimiTUI, type KimiTUIStartupInput, type TUIState } from '#/tui/kimi-tui';
 import type { StreamingUIController } from '#/tui/controllers/streaming-ui';
 import { handleFeedbackCommand } from '#/tui/commands/info';
@@ -635,17 +636,121 @@ command = "vim"
   it('routes /yolo through session permission state without app-layer telemetry duplication', async () => {
     const { driver, session, harness } = await makeDriver();
     harness.track.mockClear();
+    harness.setConfig.mockClear();
 
     driver.handleUserInput('/yolo on');
 
     await vi.waitFor(() => {
       expect(session.setPermission).toHaveBeenCalledWith('yolo');
+      expect(harness.setConfig).toHaveBeenCalledWith({ defaultPermissionMode: 'yolo' });
     });
     expect(driver.state.appState).toMatchObject({
       permissionMode: 'yolo',
     });
     expect(harness.track).toHaveBeenCalledWith('input_command', { command: 'yolo' });
     expect(harness.track).not.toHaveBeenCalledWith('yolo_toggle', expect.anything());
+  });
+
+  it.each([
+    {
+      input: '/yolo off',
+      initialMode: 'yolo',
+      persistedMode: 'manual',
+      notice: 'YOLO mode: OFF',
+    },
+    {
+      input: '/auto on',
+      initialMode: 'manual',
+      persistedMode: 'auto',
+      notice: 'Auto mode: ON',
+    },
+    {
+      input: '/auto off',
+      initialMode: 'auto',
+      persistedMode: 'manual',
+      notice: 'Auto mode: OFF',
+    },
+  ] as const)('persists permission defaults for $input', async ({
+    input,
+    initialMode,
+    persistedMode,
+    notice,
+  }) => {
+    const { driver, session, harness } = await makeDriver();
+    driver.state.appState.permissionMode = initialMode;
+    session.setPermission.mockClear();
+    harness.setConfig.mockClear();
+
+    driver.handleUserInput(input);
+
+    await vi.waitFor(() => {
+      expect(session.setPermission).toHaveBeenCalledWith(persistedMode);
+      expect(harness.setConfig).toHaveBeenCalledWith({
+        defaultPermissionMode: persistedMode,
+      });
+    });
+    expect(driver.state.appState.permissionMode).toBe(persistedMode);
+    expect(stripSgr(renderTranscript(driver))).toContain(notice);
+  });
+
+  it('persists permission changes selected from /permission', async () => {
+    const { driver, session, harness } = await makeDriver();
+    session.setPermission.mockClear();
+    harness.setConfig.mockClear();
+
+    driver.handleUserInput('/permission');
+
+    await vi.waitFor(() => {
+      expect(driver.state.editorContainer.children[0]).toBeInstanceOf(PermissionSelectorComponent);
+    });
+    const picker = driver.state.editorContainer.children[0] as PermissionSelectorComponent;
+    picker.handleInput('\u001B[B');
+    picker.handleInput('\r');
+
+    await vi.waitFor(() => {
+      expect(session.setPermission).toHaveBeenCalledWith('auto');
+      expect(harness.setConfig).toHaveBeenCalledWith({ defaultPermissionMode: 'auto' });
+    });
+    expect(driver.state.appState.permissionMode).toBe('auto');
+  });
+
+  it('does not persist permission defaults when runtime permission setup fails', async () => {
+    const session = makeSession({
+      setPermission: vi.fn(async () => {
+        throw new Error('permission denied');
+      }),
+    });
+    const { driver, harness } = await makeDriver(session);
+    harness.setConfig.mockClear();
+
+    driver.handleUserInput('/yolo on');
+
+    await vi.waitFor(() => {
+      expect(stripSgr(renderTranscript(driver))).toContain(
+        'Failed to set permission mode: permission denied',
+      );
+    });
+    expect(harness.setConfig).not.toHaveBeenCalled();
+    expect(driver.state.appState.permissionMode).toBe('manual');
+  });
+
+  it('reports default permission persistence failures without losing runtime state', async () => {
+    const setConfig = vi.fn(async () => {
+      throw new Error('disk full');
+    });
+    const { driver, session } = await makeDriver(makeSession(), { setConfig });
+    session.setPermission.mockClear();
+
+    driver.handleUserInput('/auto on');
+
+    await vi.waitFor(() => {
+      expect(stripSgr(renderTranscript(driver))).toContain(
+        'Permission mode set for this session, but failed to save default: disk full',
+      );
+    });
+    expect(session.setPermission).toHaveBeenCalledWith('auto');
+    expect(driver.state.appState.permissionMode).toBe('auto');
+    expect(stripSgr(renderTranscript(driver))).not.toContain('Auto mode: ON');
   });
 
   it('hydrates MCP server status after subscribing to session events', async () => {


### PR DESCRIPTION
## Related Issue

Fixes #914

## Problem

Runtime permission changes made inside the TUI updated only the active session. After enabling `/yolo`, `/auto`, or selecting a mode through `/permission`, a newly opened terminal still started from the previously configured default permission mode.

## What changed

Persist successful runtime permission mode changes to `defaultPermissionMode` through the harness config API, so new sessions inherit the latest mode selected in the TUI.

This covers `/yolo`, `/auto`, and `/permission`, while keeping runtime and config error handling separate:

- runtime permission failures are not persisted;
- config persistence failures are reported without rolling back the already-applied session state;
- unchanged `/permission` selections still save the selected mode as the default.

## Testing

- `PATH=/tmp/node-v24.15.0-darwin-arm64/bin:$PATH pnpm --filter @moonshot-ai/kimi-code exec vitest run test/tui/kimi-tui-message-flow.test.ts`
- `PATH=/tmp/node-v24.15.0-darwin-arm64/bin:$PATH pnpm --filter @moonshot-ai/kimi-code run typecheck`
- `PATH=/tmp/node-v24.15.0-darwin-arm64/bin:$PATH pnpm exec oxlint --type-aware apps/kimi-code/src/tui/commands/config.ts apps/kimi-code/test/tui/kimi-tui-message-flow.test.ts`
- `git diff --check`

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.