### PR TITLE
feat(cli): add custom session id startup flag

### DIFF
--- a/.changeset/session-id-create.md
+++ b/.changeset/session-id-create.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": minor
+---
+
+Add a CLI option to create or resume sessions by a custom session ID.

--- a/apps/kimi-code/src/cli/commands.ts
+++ b/apps/kimi-code/src/cli/commands.ts
@@ -44,6 +44,13 @@ export function createProgram(
         .hideHelp()
         .argParser((val: string | boolean) => (val === true ? '' : (val as string))),
     )
+    .addOption(
+      new Option(
+        '--session-id <id>',
+        'Resume this session ID, or create a new session with it when it does not exist.',
+      ),
+    )
+    .addOption(new Option('--session_id <id>').hideHelp())
     .option('-C, --continue', 'Continue the previous session for the working directory.', false)
     .option('-y, --yolo', 'Automatically approve all actions.', false)
     .option('--auto', 'Start in auto permission mode.', false)
@@ -110,11 +117,13 @@ export function createProgram(
 
     const rawSession = raw['session'] ?? raw['resume'];
     const sessionValue = rawSession === true ? '' : (rawSession as string | undefined);
+    const rawSessionId = raw['sessionId'] ?? raw['session_id'];
     const yoloValue = raw['yolo'] === true || raw['yes'] === true || raw['autoApprove'] === true;
     const autoValue = raw['auto'] === true;
 
     const opts: CLIOptions = {
       session: sessionValue,
+      sessionId: rawSessionId as string | undefined,
       continue: raw['continue'] as boolean,
       yolo: yoloValue,
       auto: autoValue,

--- a/apps/kimi-code/src/cli/options.ts
+++ b/apps/kimi-code/src/cli/options.ts
@@ -3,6 +3,7 @@ export type PromptOutputFormat = 'text' | 'stream-json';
 
 export interface CLIOptions {
   session: string | undefined;
+  sessionId?: string;
   continue: boolean;
   yolo: boolean;
   auto: boolean;
@@ -34,6 +35,9 @@ export function validateOptions(opts: CLIOptions): ValidatedOptions {
   if (opts.model !== undefined && opts.model.trim().length === 0) {
     throw new OptionConflictError('Model cannot be empty.');
   }
+  if (opts.sessionId !== undefined && opts.sessionId.trim().length === 0) {
+    throw new OptionConflictError('Session ID cannot be empty.');
+  }
   if (!promptMode && opts.outputFormat !== undefined) {
     throw new OptionConflictError('Output format is only supported in prompt mode.');
   }
@@ -51,6 +55,12 @@ export function validateOptions(opts: CLIOptions): ValidatedOptions {
   }
   if (opts.continue && opts.session !== undefined) {
     throw new OptionConflictError('Cannot combine --continue, --session.');
+  }
+  if (opts.sessionId !== undefined && opts.session !== undefined) {
+    throw new OptionConflictError('Cannot combine --session-id with --session.');
+  }
+  if (opts.sessionId !== undefined && opts.continue) {
+    throw new OptionConflictError('Cannot combine --continue with --session-id.');
   }
   if (opts.yolo && opts.auto) {
     throw new OptionConflictError('Cannot combine --yolo with --auto.');

--- a/apps/kimi-code/src/cli/run-prompt.ts
+++ b/apps/kimi-code/src/cli/run-prompt.ts
@@ -220,6 +220,58 @@ async function resolvePromptSession(
   stderr: PromptOutput,
   setRestorePermission: (restorePermission: () => Promise<void>) => void,
 ): Promise<ResolvedPromptSession> {
+  if (opts.sessionId !== undefined) {
+    const sessions = await harness.listSessions({ sessionId: opts.sessionId, workDir });
+    const target = sessions[0];
+    if (target !== undefined) {
+      if (resolve(target.workDir) !== resolve(workDir)) {
+        stderr.write(
+          `${chalk.hex('#E8A838')(
+            `Session "${opts.sessionId}" was created under a different directory.\n` +
+              `  cd "${target.workDir}" && kimi --session-id ${opts.sessionId}`,
+          )}\n\n`,
+        );
+        throw new Error(
+          `Session "${opts.sessionId}" was created under a different directory.`,
+        );
+      }
+      const session = await harness.resumeSession({ id: opts.sessionId });
+      const status = await session.getStatus();
+      const restorePermission = await forcePromptPermission(
+        session,
+        status.permission,
+        setRestorePermission,
+      );
+      if (opts.model !== undefined) {
+        await session.setModel(opts.model);
+      }
+      installHeadlessHandlers(session);
+      return {
+        session,
+        resumed: true,
+        restorePermission,
+        telemetryModel: configuredModel(opts.model, status.model, defaultModel),
+        goalModel: configuredModel(opts.model, status.model),
+      };
+    }
+
+    const model = requireConfiguredModel(opts.model, defaultModel);
+    const session = await harness.createSession({
+      id: opts.sessionId,
+      workDir,
+      model,
+      permission: 'auto',
+    });
+    installHeadlessHandlers(session);
+    return {
+      session,
+      resumed: false,
+      restorePermission: async () => {},
+      telemetryModel: model,
+      goalModel: model,
+    };
+  }
+
   if (opts.session !== undefined) {
     const sessions = await harness.listSessions({ sessionId: opts.session, workDir });
     const target = sessions[0];
@@ -469,8 +521,15 @@ function runPromptTurn(
         case 'compaction.completed':
         case 'compaction.started':
         case 'cron.fired':
+        case 'event.config.changed':
+        case 'event.session.created':
+        case 'event.session.status_changed':
+        case 'event.workspace.created':
+        case 'event.workspace.deleted':
+        case 'event.workspace.updated':
         case 'goal.updated':
         case 'mcp.server.status':
+        case 'prompt.submitted':
         case 'session.meta.updated':
         case 'skill.activated':
         case 'subagent.completed':

--- a/apps/kimi-code/src/main.ts
+++ b/apps/kimi-code/src/main.ts
@@ -105,6 +105,7 @@ export async function handleUpgradeCommand(version: string): Promise<void> {
 /** A neutral CLIOptions value — `kimi migrate` never opens a chat session. */
 const MIGRATE_CLI_OPTIONS: CLIOptions = {
   session: undefined,
+  sessionId: undefined,
   continue: false,
   yolo: false,
   auto: false,

--- a/apps/kimi-code/src/tui/kimi-tui.ts
+++ b/apps/kimi-code/src/tui/kimi-tui.ts
@@ -262,6 +262,7 @@ export class KimiTUI {
       initialAppState: createInitialAppState(startupInput),
       startup: {
         sessionFlag: startupInput.cliOptions.session,
+        sessionIdFlag: startupInput.cliOptions.sessionId,
         continueLast: startupInput.cliOptions.continue,
         yolo: startupInput.cliOptions.yolo,
         auto: startupInput.cliOptions.auto,
@@ -554,7 +555,10 @@ export class KimiTUI {
     const { workDir } = this.state.appState;
     let session: Session | undefined;
     let shouldReplayHistory = false;
-    const isResumeStartup = startup.sessionFlag !== undefined || startup.continueLast;
+    const isResumeStartup =
+      startup.sessionFlag !== undefined ||
+      startup.sessionIdFlag !== undefined ||
+      startup.continueLast;
     const createSessionOptions: CreateSessionOptions = {
       workDir,
       model: startup.model,
@@ -564,12 +568,38 @@ export class KimiTUI {
 
     try {
       if (isResumeStartup) {
-        if (startup.sessionFlag === '') {
+        if (startup.sessionIdFlag !== undefined) {
+          const sessions = await this.harness.listSessions({
+            sessionId: startup.sessionIdFlag,
+            workDir,
+          });
+          const target = sessions[0];
+          if (target === undefined) {
+            session = await this.harness.createSession({
+              ...createSessionOptions,
+              id: startup.sessionIdFlag,
+            });
+          } else {
+            if (resolve(target.workDir) !== resolve(workDir)) {
+              this.state.ui.stop();
+              process.stderr.write(
+                `${currentTheme.fg(
+                  'warning',
+                  `Session "${startup.sessionIdFlag}" was created under a different directory.\n` +
+                    `  cd "${target.workDir}" && kimi --session-id ${startup.sessionIdFlag}`,
+                )}\n\n`,
+              );
+              throw new Error(
+                `Session "${startup.sessionIdFlag}" was created under a different directory.`,
+              );
+            }
+            session = await this.harness.resumeSession({ id: startup.sessionIdFlag });
+            shouldReplayHistory = true;
+          }
+        } else if (startup.sessionFlag === '') {
           this.state.startupState = 'picker';
           return false;
-        }
-
-        if (startup.sessionFlag !== undefined) {
+        } else if (startup.sessionFlag !== undefined) {
           const sessions = await this.harness.listSessions({
             sessionId: startup.sessionFlag,
             workDir,

--- a/apps/kimi-code/src/tui/types.ts
+++ b/apps/kimi-code/src/tui/types.ts
@@ -193,6 +193,7 @@ export const INITIAL_LIVE_PANE: LivePaneState = {
 
 export interface TUIStartupOptions {
   readonly sessionFlag?: string;
+  readonly sessionIdFlag?: string;
   readonly continueLast: boolean;
   readonly yolo: boolean;
   readonly auto: boolean;

--- a/apps/kimi-code/test/cli/options.test.ts
+++ b/apps/kimi-code/test/cli/options.test.ts
@@ -37,6 +37,7 @@ describe('CLI options parsing', () => {
       expect(opts.plan).toBe(false);
       expect(opts.continue).toBe(false);
       expect(opts.session).toBeUndefined();
+      expect(opts.sessionId).toBeUndefined();
       expect(opts.model).toBeUndefined();
       expect(opts.outputFormat).toBeUndefined();
       expect(opts.prompt).toBeUndefined();
@@ -146,6 +147,14 @@ describe('CLI options parsing', () => {
       expect(parse(['--resume', 'sess-789']).session).toBe('sess-789');
     });
 
+    it('--session-id sets a custom create-or-resume session id', () => {
+      expect(parse(['--session-id', 'ses_custom']).sessionId).toBe('ses_custom');
+    });
+
+    it('--session_id is accepted as a hidden alias for --session-id', () => {
+      expect(parse(['--session_id', 'ses_custom']).sessionId).toBe('ses_custom');
+    });
+
     it('bare -S (no id) yields empty string — triggers the picker', () => {
       expect(parse(['-S']).session).toBe('');
     });
@@ -158,6 +167,18 @@ describe('CLI options parsing', () => {
       const opts = parse(['--continue', '--session', 'abc123']);
       expect(() => validateOptions(opts)).toThrow(OptionConflictError);
       expect(() => validateOptions(opts)).toThrow('Cannot combine --continue, --session.');
+    });
+
+    it('--session-id and --session combined raises a conflict', () => {
+      const opts = parse(['--session-id', 'ses_custom', '--session', 'ses_existing']);
+      expect(() => validateOptions(opts)).toThrow(OptionConflictError);
+      expect(() => validateOptions(opts)).toThrow('Cannot combine --session-id with --session.');
+    });
+
+    it('--session-id and --continue combined raises a conflict', () => {
+      const opts = parse(['--session-id', 'ses_custom', '--continue']);
+      expect(() => validateOptions(opts)).toThrow(OptionConflictError);
+      expect(() => validateOptions(opts)).toThrow('Cannot combine --continue with --session-id.');
     });
   });
 
@@ -179,6 +200,13 @@ describe('CLI options parsing', () => {
       const opts = parse(['--auto', '--session', 'ses_123']);
       expect(opts.auto).toBe(true);
       expect(opts.session).toBe('ses_123');
+      expect(validateOptions(opts).uiMode).toBe('shell');
+    });
+
+    it('allows --auto with a create-or-resume session id', () => {
+      const opts = parse(['--auto', '--session-id', 'ses_123']);
+      expect(opts.auto).toBe(true);
+      expect(opts.sessionId).toBe('ses_123');
       expect(validateOptions(opts).uiMode).toBe('shell');
     });
 

--- a/apps/kimi-code/test/cli/run-prompt.test.ts
+++ b/apps/kimi-code/test/cli/run-prompt.test.ts
@@ -127,6 +127,7 @@ vi.mock('@moonshot-ai/kimi-telemetry', () => ({
 function opts(overrides: Partial<Parameters<typeof runPrompt>[0]> = {}) {
   return {
     session: undefined,
+    sessionId: undefined,
     continue: false,
     yolo: false,
     auto: false,
@@ -440,6 +441,60 @@ describe('runPrompt', () => {
     expect(mocks.session.getStatus).toHaveBeenCalled();
     expect(mocks.session.setPermission).toHaveBeenNthCalledWith(1, 'auto');
     expect(mocks.session.setPermission).toHaveBeenNthCalledWith(2, 'manual');
+  });
+
+  it('creates a prompt session with --session-id when that id does not exist', async () => {
+    mocks.harnessListSessions.mockResolvedValueOnce([]);
+
+    await runPrompt(opts({ sessionId: 'ses_custom' }), '1.2.3-test', {
+      stdout: { write: vi.fn(() => true) },
+      stderr: { write: vi.fn(() => true) },
+    });
+
+    expect(mocks.harnessListSessions).toHaveBeenCalledWith({
+      sessionId: 'ses_custom',
+      workDir: process.cwd(),
+    });
+    expect(mocks.harnessCreateSession).toHaveBeenCalledWith({
+      id: 'ses_custom',
+      workDir: process.cwd(),
+      model: 'k2',
+      permission: 'auto',
+    });
+    expect(mocks.harnessResumeSession).not.toHaveBeenCalled();
+    expect(mocks.session.setPermission).not.toHaveBeenCalled();
+  });
+
+  it('resumes a prompt session with --session-id when that id already exists', async () => {
+    mocks.harnessListSessions.mockResolvedValueOnce([
+      { id: 'ses_custom', workDir: process.cwd() },
+    ]);
+
+    await runPrompt(opts({ sessionId: 'ses_custom' }), '1.2.3-test', {
+      stdout: { write: vi.fn(() => true) },
+      stderr: { write: vi.fn(() => true) },
+    });
+
+    expect(mocks.harnessCreateSession).not.toHaveBeenCalled();
+    expect(mocks.harnessResumeSession).toHaveBeenCalledWith({ id: 'ses_custom' });
+    expect(mocks.session.setPermission).toHaveBeenNthCalledWith(1, 'auto');
+    expect(mocks.session.setPermission).toHaveBeenNthCalledWith(2, 'manual');
+  });
+
+  it('rejects --session-id when the existing session belongs to another workdir', async () => {
+    const stdout = writer();
+    const stderr = writer();
+    mocks.harnessListSessions.mockResolvedValueOnce([
+      { id: 'ses_custom', workDir: '/tmp/other-project' },
+    ]);
+
+    await expect(
+      runPrompt(opts({ sessionId: 'ses_custom' }), '1.2.3-test', { stdout, stderr }),
+    ).rejects.toThrow('Session "ses_custom" was created under a different directory.');
+
+    expect(mocks.harnessCreateSession).not.toHaveBeenCalled();
+    expect(mocks.harnessResumeSession).not.toHaveBeenCalled();
+    expect(stderr.text()).toContain('cd "/tmp/other-project" && kimi --session-id ses_custom');
   });
 
   it('allows resuming a concrete session when Windows workdir uses backslashes', async () => {

--- a/apps/kimi-code/test/cli/session-flag-picker.test.ts
+++ b/apps/kimi-code/test/cli/session-flag-picker.test.ts
@@ -49,6 +49,16 @@ describe('--session / -r / -S picker routing', () => {
       expect(opts.session).toBe('foo');
     });
 
+    it('--session-id foo → sessionId === "foo"', () => {
+      const opts = parse(['--session-id', 'foo']);
+      expect(opts.sessionId).toBe('foo');
+    });
+
+    it('--session_id foo → sessionId === "foo" (hidden alias)', () => {
+      const opts = parse(['--session_id', 'foo']);
+      expect(opts.sessionId).toBe('foo');
+    });
+
     it('-S foo → session === "foo"', () => {
       const opts = parse(['-S', 'foo']);
       expect(opts.session).toBe('foo');

--- a/apps/kimi-code/test/tui/kimi-tui-startup.test.ts
+++ b/apps/kimi-code/test/tui/kimi-tui-startup.test.ts
@@ -75,6 +75,7 @@ function makeStartupInput(
   return {
     cliOptions: {
       session: undefined,
+      sessionId: undefined,
       continue: false,
       yolo: false,
       auto: false,
@@ -288,6 +289,65 @@ describe('KimiTUI startup', () => {
     expect(harness.createSession).not.toHaveBeenCalled();
     expect(driver.state.startupState).toBe('ready');
     expect(driver.state.appState.sessionId).toBe('ses-latest');
+  });
+
+  it('creates a session with --session-id when that id does not exist', async () => {
+    const session = makeSession({ id: 'ses-custom' });
+    const harness = makeHarness(session, {
+      listSessions: vi.fn(async () => []),
+    });
+    const driver = makeDriver(harness, makeStartupInput({ sessionId: 'ses-custom' }));
+
+    await expect(driver.init()).resolves.toBe(false);
+
+    expect(harness.listSessions).toHaveBeenCalledWith({
+      sessionId: 'ses-custom',
+      workDir: '/tmp/proj-a',
+    });
+    expect(harness.createSession).toHaveBeenCalledWith({
+      id: 'ses-custom',
+      workDir: '/tmp/proj-a',
+    });
+    expect(harness.resumeSession).not.toHaveBeenCalled();
+    expect(driver.state.startupState).toBe('ready');
+    expect(driver.state.appState.sessionId).toBe('ses-custom');
+  });
+
+  it('resumes a session with --session-id when that id already exists', async () => {
+    const session = makeSession({ id: 'ses-custom' });
+    const harness = makeHarness(session, {
+      listSessions: vi.fn(async () => [{ id: 'ses-custom', workDir: '/tmp/proj-a' }]),
+    });
+    const driver = makeDriver(harness, makeStartupInput({ sessionId: 'ses-custom' }));
+
+    await expect(driver.init()).resolves.toBe(true);
+
+    expect(harness.createSession).not.toHaveBeenCalled();
+    expect(harness.resumeSession).toHaveBeenCalledWith({ id: 'ses-custom' });
+    expect(driver.state.appState.sessionId).toBe('ses-custom');
+  });
+
+  it('rejects --session-id when the existing session belongs to another cwd', async () => {
+    const session = makeSession({ id: 'ses-custom' });
+    const harness = makeHarness(session, {
+      listSessions: vi.fn(async () => [{ id: 'ses-custom', workDir: '/tmp/proj-b' }]),
+    });
+    const driver = makeDriver(harness, makeStartupInput({ sessionId: 'ses-custom' }));
+    const stderrWrite = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+
+    try {
+      await expect(driver.init()).rejects.toThrow(
+        'Session "ses-custom" was created under a different directory.',
+      );
+
+      expect(harness.createSession).not.toHaveBeenCalled();
+      expect(harness.resumeSession).not.toHaveBeenCalled();
+      expect(stderrWrite).toHaveBeenCalledWith(
+        expect.stringContaining('cd "/tmp/proj-b" && kimi --session-id ses-custom'),
+      );
+    } finally {
+      stderrWrite.mockRestore();
+    }
   });
 
   it('applies --auto permission when resuming a session via --continue', async () => {

--- a/docs/en/configuration/overrides.md
+++ b/docs/en/configuration/overrides.md
@@ -54,6 +54,7 @@ Options passed at startup have the highest priority and apply only to the curren
 | Option | Effect |
 | --- | --- |
 | `-S, --session [id]` | Resume a specific session; enters interactive selection when no id is given |
+| `--session-id <id>` | Resume the given session id, or create a new session with that id when it does not exist |
 | `-C, --continue` | Resume the last session for the current working directory |
 | `-y, --yolo` | Auto-approve all tool calls |
 | `--plan` | Start in Plan mode |
@@ -65,9 +66,9 @@ Options passed at startup have the highest priority and apply only to the curren
 Mutual exclusion rules (startup fails if violated):
 
 - `--output-format` can only be used with `-p`
-- `--prompt` cannot be combined with `--yolo` or `--plan`
-- `--continue` and `--session` cannot be used together
-- In non-prompt mode, `--yolo` and `--plan` cannot be combined with `--continue` or `--session`
+- `--prompt` cannot be combined with `--yolo`, `--auto`, or `--plan`
+- `--continue`, `--session`, and `--session-id` cannot be combined with each other
+- `--yolo` and `--auto` cannot be combined
 
 ::: tip
 `--skills-dir` is a one-shot replacement that only affects the current startup. To persistently add search directories, write `extra_skill_dirs` in `config.toml` (see [Agent Skills](../customization/skills.md)).

--- a/docs/en/guides/sessions.md
+++ b/docs/en/guides/sessions.md
@@ -44,6 +44,12 @@ kimi --continue
 kimi --session abc123
 ```
 
+**Use a custom session ID, creating it if needed:**
+
+```sh
+kimi --session-id my-task-session
+```
+
 **Interactively browse session history and choose one:**
 
 ```sh
@@ -51,7 +57,7 @@ kimi --session
 ```
 
 ::: warning
-`--continue` and `--session` are mutually exclusive.
+`--continue`, `--session`, and `--session-id` are mutually exclusive. Use `--session` when the ID must already exist; use `--session-id` when a missing ID should start a new session.
 :::
 
 ## Switching sessions inside the TUI

--- a/docs/en/reference/kimi-command.md
+++ b/docs/en/reference/kimi-command.md
@@ -16,6 +16,7 @@ All flags are optional — run `kimi` directly to enter an interactive session:
 | `--version` | `-V` | Print the version number and exit |
 | `--help` | `-h` | Show help information and exit |
 | `--session [id]` | `-S` | Resume a session. With an ID, opens that session directly; without an ID, enters an interactive selector |
+| `--session-id <id>` | | Resume this session ID if it exists, or create a new session with this ID if it does not |
 | `--continue` | `-C` | Continue the most recent session in the current working directory, without specifying an ID manually |
 | `--model <model>` | `-m` | Specify a model alias for this launch. When omitted, new sessions use `default_model` from the config file |
 | `--prompt <prompt>` | `-p` | Run a single prompt non-interactively and stream the Assistant output to stdout. This mode does not open the TUI |
@@ -25,7 +26,7 @@ All flags are optional — run `kimi` directly to enter an interactive session:
 | `--plan` | | Start a new session in Plan mode — the AI will prioritize read-only tools for exploration and planning |
 | `--skills-dir <dir>` | | Load Skills from the specified directory, replacing the automatically discovered user and project directories. Can be repeated |
 
-`-r` / `--resume` is a hidden alias for `--session`; `--yes` and `--auto-approve` are hidden aliases for `--yolo` and are not shown in help output.
+`-r` / `--resume` is a hidden alias for `--session`; `--session_id` is a hidden alias for `--session-id`; `--yes` and `--auto-approve` are hidden aliases for `--yolo` and are not shown in help output.
 
 ::: warning
 `--yolo` skips human approval for regular tool calls, including file writes and shell command execution. Use it only in trusted working directories. Plan mode exit approval is not bypassed by `--yolo`; `Bash` inside Plan mode is handled under the regular allow rules.
@@ -36,6 +37,7 @@ All flags are optional — run `kimi` directly to enter an interactive session:
 The following combinations are rejected at startup:
 
 - `--continue` and `--session` are mutually exclusive — both mean "resume a previous session"
+- `--session-id` cannot be combined with `--continue` or `--session`
 - `--yolo` and `--auto` are mutually exclusive — the two permission modes cannot be combined
 - `--prompt` cannot be used with `--yolo`, `--auto`, or `--plan` — non-interactive mode uses `auto` permission by default
 - `--output-format` can only be used together with `--prompt`
@@ -61,6 +63,12 @@ Choose from the session history list, or specify a known ID directly:
 ```sh
 kimi --session
 kimi --session 01HZ...XYZ
+```
+
+Start with a stable custom session ID. If the session already exists in the current working directory, it is resumed; otherwise Kimi Code creates it:
+
+```sh
+kimi --session-id my-task-session
 ```
 
 Skip approval prompts — suitable for batch tasks that are known to be safe:

--- a/docs/zh/configuration/overrides.md
+++ b/docs/zh/configuration/overrides.md
@@ -54,6 +54,7 @@ Kimi Code CLI 有三个地方可以影响运行参数：配置文件、命令行
 | 选项 | 作用 |
 | --- | --- |
 | `-S, --session [id]` | 恢复指定会话；不带 id 时进入交互式选择 |
+| `--session-id <id>` | 使用指定会话 ID；已存在则恢复，不存在则用该 ID 创建新会话 |
 | `-C, --continue` | 续上当前目录的上一次会话 |
 | `-y, --yolo` | 自动批准所有工具调用 |
 | `--plan` | 以 Plan 模式启动 |
@@ -65,9 +66,9 @@ Kimi Code CLI 有三个地方可以影响运行参数：配置文件、命令行
 互斥规则（违反时启动报错）：
 
 - `--output-format` 只能配合 `-p` 使用
-- `--prompt` 不能同时用 `--yolo` 或 `--plan`
-- `--continue` 和 `--session` 不能同时用
-- 非 prompt 模式下，`--yolo` 和 `--plan` 不能配合 `--continue` 或 `--session`
+- `--prompt` 不能同时用 `--yolo`、`--auto` 或 `--plan`
+- `--continue`、`--session` 与 `--session-id` 不能互相组合
+- `--yolo` 与 `--auto` 不能同时使用
 
 ::: tip
 `--skills-dir` 是一次性替换，只影响本次启动。如需长期追加搜索目录，在 `config.toml` 里写 `extra_skill_dirs`（详见 [Agent Skills](../customization/skills.md)）。

--- a/docs/zh/guides/sessions.md
+++ b/docs/zh/guides/sessions.md
@@ -44,6 +44,12 @@ kimi --continue
 kimi --session abc123
 ```
 
+**使用自定义会话 ID，不存在时自动创建：**
+
+```sh
+kimi --session-id my-task-session
+```
+
 **交互式浏览历史会话并选择：**
 
 ```sh
@@ -51,7 +57,7 @@ kimi --session
 ```
 
 ::: warning 注意
-`--continue` 与 `--session` 互斥。
+`--continue`、`--session` 与 `--session-id` 互斥。确定会话必须已存在时用 `--session`；希望 ID 不存在时创建新会话时用 `--session-id`。
 :::
 
 ## 在 TUI 中切换会话

--- a/docs/zh/reference/kimi-command.md
+++ b/docs/zh/reference/kimi-command.md
@@ -16,6 +16,7 @@ kimi <subcommand> [options]
 | `--version` | `-V` | 打印版本号并退出 |
 | `--help` | `-h` | 显示帮助信息并退出 |
 | `--session [id]` | `-S` | 恢复一个会话。带 ID 时直接打开指定会话；不带 ID 时进入交互式选择器 |
+| `--session-id <id>` | | 使用这个会话 ID：已存在则恢复，不存在则用该 ID 创建新会话 |
 | `--continue` | `-C` | 继续当前工作目录下最近一次的会话，无需手动指定 ID |
 | `--model <model>` | `-m` | 为本次启动指定模型别名。省略时新会话使用配置文件中的 `default_model` |
 | `--prompt <prompt>` | `-p` | 非交互执行单次 prompt，并把 Assistant 输出流式写到 stdout。该模式不会打开 TUI |
@@ -25,7 +26,7 @@ kimi <subcommand> [options]
 | `--plan` | | 以 Plan 模式启动新会话，AI 会优先使用只读工具进行探索和规划 |
 | `--skills-dir <dir>` | | 从指定目录加载 Skills，替换自动发现的用户和项目目录。可重复传入 |
 
-`-r` / `--resume` 是 `--session` 的隐藏别名；`--yes` 和 `--auto-approve` 是 `--yolo` 的隐藏别名，在帮助信息中不显示。
+`-r` / `--resume` 是 `--session` 的隐藏别名；`--session_id` 是 `--session-id` 的隐藏别名；`--yes` 和 `--auto-approve` 是 `--yolo` 的隐藏别名，在帮助信息中不显示。
 
 ::: warning 注意
 `--yolo` 会跳过普通工具调用的人工确认，包括文件写入和 Shell 命令执行，请只在受信任的工作目录下使用。Plan 模式的退出审批不会被 `--yolo` 跳过；Plan 模式下的 `Bash` 按普通放行规则处理。
@@ -36,6 +37,7 @@ kimi <subcommand> [options]
 以下组合会在启动时被拒绝：
 
 - `--continue` 与 `--session` 互斥——两者都表示"恢复历史会话"
+- `--session-id` 不能与 `--continue` 或 `--session` 同时使用
 - `--yolo` 和 `--auto` 互斥——两种权限模式互斥
 - `--prompt` 不能与 `--yolo`、`--auto` 或 `--plan` 同时使用——非交互模式固定使用 `auto` 权限
 - `--output-format` 只能与 `--prompt` 一起使用
@@ -61,6 +63,12 @@ kimi --continue
 ```sh
 kimi --session
 kimi --session 01HZ...XYZ
+```
+
+使用稳定的自定义会话 ID。若当前工作目录下已经存在该会话，则恢复；否则用该 ID 创建新会话：
+
+```sh
+kimi --session-id my-task-session
 ```
 
 跳过审批确认，适合已知安全的批处理任务：


### PR DESCRIPTION
## Summary

Fixes #820.

Adds a new `--session-id <id>` startup flag for callers that want a stable session id:

- resumes the matching session when it already exists in the current workdir
- creates a new session with that id when it does not exist
- keeps `--session` resume-only
- rejects ids that already exist under another workdir and prints a cd hint
- supports the hidden `--session_id` alias for compatibility with the issue request

Also updates EN/ZH docs, CLI validation, tests, and the changeset.

## Validation

- `pnpm --filter @moonshot-ai/kimi-code exec vitest run test/cli/options.test.ts test/cli/session-flag-picker.test.ts test/cli/run-prompt.test.ts test/tui/kimi-tui-startup.test.ts`
- `pnpm --filter @moonshot-ai/kimi-code exec vitest run`
- `pnpm --filter @moonshot-ai/kimi-code run typecheck`
- `pnpm exec oxlint --type-aware apps/kimi-code/src/cli/commands.ts apps/kimi-code/src/cli/options.ts apps/kimi-code/src/cli/run-prompt.ts apps/kimi-code/src/main.ts apps/kimi-code/src/tui/kimi-tui.ts apps/kimi-code/src/tui/types.ts apps/kimi-code/test/cli/options.test.ts apps/kimi-code/test/cli/run-prompt.test.ts apps/kimi-code/test/cli/session-flag-picker.test.ts apps/kimi-code/test/tui/kimi-tui-startup.test.ts --quiet`
- `pnpm --filter @moonshot-ai/kimi-code run build`
- `git diff --check`

## Checklist

- [x] Tests updated
- [x] Docs updated
- [x] Changeset added

## AI Assistance Disclosure

I used Codex to review the changes, sanity-check the implementation against existing patterns, and help spot potential edge cases.
