### PR TITLE
fix(agent-core): explain filtered provider stops

### DIFF
--- a/.changeset/provider-filtered-message.md
+++ b/.changeset/provider-filtered-message.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Show a user-facing message when a provider filters a response.

--- a/packages/agent-core/src/agent/turn/index.ts
+++ b/packages/agent-core/src/agent/turn/index.ts
@@ -45,7 +45,7 @@ interface ActiveTurn {
   readonly turnId: number;
   readonly controller: AbortController;
   readonly promise: Promise<TurnEndResult>;
-  readonly firstRequest: ControlledPromise<void>;
+  readonly firstRequest: ControlledPromise;
 }
 
 interface BufferedSteer {
@@ -65,6 +65,8 @@ interface PromptHookEndResult {
 }
 
 const LLM_NOT_SET_MESSAGE = 'LLM not set, send "/login" to login';
+const PROVIDER_FILTERED_MESSAGE =
+  'The provider stopped this response because it was filtered by its safety policy. Try rephrasing or narrowing the request.';
 
 /** Origin tag for the synthetic "continue" prompt that drives each goal turn. */
 const GOAL_CONTINUATION_ORIGIN: PromptOrigin = { kind: 'system_trigger', name: 'goal_continuation' };
@@ -469,6 +471,9 @@ export class TurnFlow {
       } else {
         const stopReason = await this.runStepLoop(turnId, signal);
         completedStopReason = stopReason;
+        if (stopReason === 'filtered') {
+          this.appendProviderFilteredMessage(turnId);
+        }
         ended = {
           type: 'turn.ended',
           turnId,
@@ -554,6 +559,19 @@ export class TurnFlow {
     this.interruptedTelemetryTurnIds.delete(turnId);
     this.stepFailureByTurn.delete(turnId);
     return { event: ended, stopReason: completedStopReason, blockedByUserPromptHook };
+  }
+
+  private appendProviderFilteredMessage(turnId: number): void {
+    this.agent.context.appendMessage({
+      role: 'assistant',
+      content: [{ type: 'text', text: PROVIDER_FILTERED_MESSAGE }],
+      toolCalls: [],
+    });
+    this.agent.emitEvent({
+      type: 'assistant.delta',
+      turnId,
+      delta: PROVIDER_FILTERED_MESSAGE,
+    });
   }
 
   private async applyUserPromptHook(
@@ -794,6 +812,12 @@ export class TurnFlow {
         active.firstRequest.resolve();
         return;
       }
+      case 'step.begin':
+      case 'step.retrying':
+      case 'tool.progress':
+      case 'tool.result':
+      case 'turn.interrupted':
+        return;
       default:
         return;
     }

--- a/packages/agent-core/test/agent/basic.test.ts
+++ b/packages/agent-core/test/agent/basic.test.ts
@@ -66,6 +66,15 @@ it('forwards provider finish diagnostics on filtered steps', async () => {
   const rpcStepEnd = ctx.allEvents.find(
     (event) => event.type === '[rpc]' && event.event === 'turn.step.completed',
   );
+  const assistantDeltaIndex = ctx.allEvents.findIndex(
+    (event) =>
+      event.type === '[rpc]' &&
+      event.event === 'assistant.delta' &&
+      String((event.args as { delta?: unknown }).delta).includes('filtered by its safety policy'),
+  );
+  const turnEndedIndex = ctx.allEvents.findIndex(
+    (event) => event.type === '[rpc]' && event.event === 'turn.ended',
+  );
 
   expect(wireStepEnd?.args).toMatchObject({
     event: {
@@ -78,6 +87,21 @@ it('forwards provider finish diagnostics on filtered steps', async () => {
     finishReason: 'filtered',
     providerFinishReason: 'filtered',
     rawFinishReason: 'content_filter',
+  });
+  expect(ctx.allEvents).toContainEqual(
+    expect.objectContaining({
+      type: '[rpc]',
+      event: 'assistant.delta',
+      args: expect.objectContaining({
+        delta: expect.stringContaining('filtered by its safety policy'),
+      }),
+    }),
+  );
+  expect(assistantDeltaIndex).toBeGreaterThanOrEqual(0);
+  expect(assistantDeltaIndex).toBeLessThan(turnEndedIndex);
+  expect(ctx.agent.context.history.at(-1)).toMatchObject({
+    role: 'assistant',
+    content: [{ type: 'text', text: expect.stringContaining('filtered by its safety policy') }],
   });
   await ctx.expectResumeMatches();
 });


### PR DESCRIPTION
## Summary

Fixes #883.

- show a short assistant message when the provider returns `stopReason: "filtered"`
- emit the message before `turn.ended` so the UI has something visible instead of a silent stop
- keep the existing stop reason and provider finish diagnostics unchanged
- add a regression test for the event and conversation history behavior

## Validation

- `pnpm --filter @moonshot-ai/agent-core exec vitest run test/agent/basic.test.ts`
- `pnpm --filter @moonshot-ai/agent-core run test`
- `pnpm --filter @moonshot-ai/agent-core run typecheck`
- `pnpm exec oxlint --type-aware packages/agent-core/src/agent/turn/index.ts packages/agent-core/test/agent/basic.test.ts --quiet`
- `pnpm --filter @moonshot-ai/agent-core run build`
- `git diff --check`

## AI Assistance Disclosure

I used Codex to review the changes, sanity-check the implementation against existing patterns, and help spot potential edge cases.
