### PR TITLE
fix(agent-core): run bash with process cwd

### DIFF
--- a/.changeset/bash-process-cwd.md
+++ b/.changeset/bash-process-cwd.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Run Bash commands with the process cwd instead of prefixing the shell source with cd.

--- a/packages/agent-core/src/tools/builtin/shell/bash.ts
+++ b/packages/agent-core/src/tools/builtin/shell/bash.ts
@@ -34,6 +34,7 @@ import type { BuiltinTool } from '../../../agent/tool';
 import type { ExecutableToolResult, ToolExecution, ToolUpdate } from '../../../loop/types';
 import { renderPrompt } from '../../../utils/render-prompt';
 import { toInputJsonSchema } from '../../support/input-schema';
+import { normalizeUserPath } from '../../policies/path-access';
 import { literalRulePattern, matchesGlobRuleSubject } from '../../support/rule-match';
 import { ToolResultBuilder } from '../../support/result-builder';
 import { isPrematureCloseError } from '../../support/stream';
@@ -195,12 +196,8 @@ export class BashTool implements BuiltinTool<BashInput> {
   }
 
   private spawn(effectiveCwd: string, command: string): Promise<KaosProcess> {
-    const shellCwd = this.isWindowsBash ? windowsPathToPosixPath(effectiveCwd) : effectiveCwd;
-    const shellArgs = [
-      this.kaos.osEnv.shellPath,
-      '-c',
-      `cd ${shellQuote(shellCwd)} && ${command}`,
-    ];
+    const shellArgs = [this.kaos.osEnv.shellPath, '-c', command];
+    const processCwd = this.isWindowsBash ? normalizeUserPath(effectiveCwd, 'win32') : effectiveCwd;
 
     const noninteractiveEnv: Record<string, string> = {
       NO_COLOR: '1',
@@ -218,7 +215,7 @@ export class BashTool implements BuiltinTool<BashInput> {
       ...(process.env as Record<string, string>),
       ...noninteractiveEnv,
     };
-    return this.kaos.execWithEnv(shellArgs, mergedEnv);
+    return this.kaos.withCwd(processCwd).execWithEnv(shellArgs, mergedEnv);
   }
 
   private async execution(
@@ -466,25 +463,6 @@ async function readStreamIntoBuilder(
   const trailing = decoder.end();
   if (trailing.length > 0) onUpdate?.({ kind, text: trailing });
   builder.write(trailing);
-}
-
-function shellQuote(s: string): string {
-  return `'${s.replaceAll("'", "'\\''")}'`;
-}
-
-function windowsPathToPosixPath(path: string): string {
-  if (path.startsWith('\\\\')) {
-    return path.replaceAll('\\', '/');
-  }
-
-  const driveMatch = /^([A-Za-z]):(?:[\\/]|$)/.exec(path);
-  if (driveMatch !== null) {
-    const drive = driveMatch[1]!.toLowerCase();
-    const rest = path.slice(2).replaceAll('\\', '/');
-    return `/${drive}${rest.startsWith('/') ? rest : `/${rest}`}`;
-  }
-
-  return path.replaceAll('\\', '/');
 }
 
 const WINDOWS_NUL_REDIRECT = /(\d?&?>+\s*)[Nn][Uu][Ll](?=\s|$|[|&;)\n])/g;

--- a/packages/agent-core/test/tools/bash.test.ts
+++ b/packages/agent-core/test/tools/bash.test.ts
@@ -51,6 +51,24 @@ function processWithOutput(
   };
 }
 
+function createKaosWithRecordedCwd(overrides: Parameters<typeof createFakeKaos>[0]): {
+  readonly kaos: ReturnType<typeof createFakeKaos>;
+  readonly cwdCalls: readonly string[];
+} {
+  const cwdCalls: string[] = [];
+  const base = createFakeKaos(overrides);
+  return {
+    kaos: {
+      ...base,
+      withCwd: (next: string) => {
+        cwdCalls.push(next);
+        return createFakeKaos({ ...overrides, getcwd: () => next });
+      },
+    },
+    cwdCalls,
+  };
+}
+
 function processWithInterleavedOutput(
   events: ReadonlyArray<{
     readonly stream: 'stdout' | 'stderr';
@@ -298,13 +316,15 @@ describe('BashTool', () => {
   it('runs through execWithEnv, injects cwd, noninteractive env, and closes stdin', async () => {
     const proc = processWithOutput({ stdout: 'ok\n' });
     const execWithEnv = vi.fn().mockResolvedValue(proc);
-    const tool = new BashTool(createFakeKaos({ execWithEnv, osEnv: posixEnv }), '/workspace');
+    const { kaos, cwdCalls } = createKaosWithRecordedCwd({ execWithEnv, osEnv: posixEnv });
+    const tool = new BashTool(kaos, '/workspace');
 
     const result = await executeTool(tool, context({ command: 'printf ok', timeout: 60 }));
 
     expect(execWithEnv).toHaveBeenCalledTimes(1);
     const [argv, env] = execWithEnv.mock.calls[0]!;
-    expect(argv).toEqual(['/bin/bash', '-c', "cd '/workspace' && printf ok"]);
+    expect(argv).toEqual(['/bin/bash', '-c', 'printf ok']);
+    expect(cwdCalls).toEqual(['/workspace']);
     expect(env).toMatchObject({
       NO_COLOR: '1',
       TERM: 'dumb',
@@ -319,18 +339,24 @@ describe('BashTool', () => {
 
   it('uses args.cwd when provided', async () => {
     const execWithEnv = vi.fn().mockResolvedValue(processWithOutput({ stdout: 'sub\n' }));
-    const tool = new BashTool(createFakeKaos({ execWithEnv, osEnv: posixEnv }), '/workspace');
+    const { kaos, cwdCalls } = createKaosWithRecordedCwd({ execWithEnv, osEnv: posixEnv });
+    const tool = new BashTool(kaos, '/workspace');
 
     await executeTool(tool, context({ command: 'pwd', cwd: '/tmp/project', timeout: 60 }));
 
-    expect(execWithEnv.mock.calls[0]?.[0]).toEqual(['/bin/bash', '-c', "cd '/tmp/project' && pwd"]);
+    expect(execWithEnv.mock.calls[0]?.[0]).toEqual(['/bin/bash', '-c', 'pwd']);
+    expect(cwdCalls).toEqual(['/tmp/project']);
   });
 
   it('uses Git Bash semantics on Windows', async () => {
     const proc = processWithOutput({ stdout: 'ok\n' });
     const execWithEnv = vi.fn().mockResolvedValue(proc);
+    const { kaos, cwdCalls } = createKaosWithRecordedCwd({
+      execWithEnv,
+      osEnv: windowsBashEnv,
+    });
     const tool = new BashTool(
-      createFakeKaos({ execWithEnv, osEnv: windowsBashEnv }),
+      kaos,
       'C:\\Users\\me\\project',
     );
 
@@ -341,14 +367,33 @@ describe('BashTool', () => {
     expect(argv).toEqual([
       'C:\\Program Files\\Git\\bin\\bash.exe',
       '-c',
-      "cd '/c/Users/me/project' && echo ok 2>/dev/null",
+      'echo ok 2>/dev/null',
     ]);
+    expect(cwdCalls).toEqual(['C:\\Users\\me\\project']);
     expect(env).toMatchObject({ SHELL: 'C:\\Program Files\\Git\\bin\\bash.exe' });
     expect(result).toMatchObject({
       output: 'ok\n',
       isError: false,
       message: 'Command executed successfully.',
     });
+  });
+
+  it('normalizes Git Bash drive cwd before spawning on Windows', async () => {
+    const execWithEnv = vi.fn().mockResolvedValue(processWithOutput({ stdout: 'sub\n' }));
+    const { kaos, cwdCalls } = createKaosWithRecordedCwd({
+      execWithEnv,
+      osEnv: windowsBashEnv,
+    });
+    const tool = new BashTool(kaos, 'C:\\Users\\me\\project');
+
+    await executeTool(tool, context({ command: 'pwd', cwd: '/c/Users/me/project', timeout: 60 }));
+
+    expect(execWithEnv.mock.calls[0]?.[0]).toEqual([
+      'C:\\Program Files\\Git\\bin\\bash.exe',
+      '-c',
+      'pwd',
+    ]);
+    expect(cwdCalls).toEqual(['C:/Users/me/project']);
   });
 
   it('returns stderr and marks non-zero exit codes as tool errors', async () => {
@@ -591,8 +636,12 @@ describe('BashTool', () => {
       .fn()
       .mockResolvedValueOnce(firstProc)
       .mockResolvedValueOnce(secondProc);
+    const { kaos, cwdCalls } = createKaosWithRecordedCwd({
+      execWithEnv,
+      osEnv: windowsBashEnv,
+    });
     const tool = new BashTool(
-      createFakeKaos({ execWithEnv, osEnv: windowsBashEnv }),
+      kaos,
       'C:\\Users\\me\\project',
       manager,
     );
@@ -619,8 +668,9 @@ describe('BashTool', () => {
     expect(argv).toEqual([
       'C:\\Program Files\\Git\\bin\\bash.exe',
       '-c',
-      "cd '/c/Users/me/project' && echo ok 2>/dev/null",
+      'echo ok 2>/dev/null',
     ]);
+    expect(cwdCalls).toEqual(['C:\\Users\\me\\project', 'C:\\Users\\me\\project']);
     expect(env).toMatchObject({ SHELL: 'C:\\Program Files\\Git\\bin\\bash.exe' });
     expect(secondProc.kill).toHaveBeenCalledWith('SIGTERM');
     expect(results).toContainEqual(expect.objectContaining({ isError: false }));
@@ -896,7 +946,7 @@ describe('BashTool', () => {
     await executeTool(tool, context({ command: 'ls 2>nul', timeout: 60 }));
 
     const argv = execWithEnv.mock.calls[0]?.[0] as readonly string[];
-    expect(argv[2]).toBe("cd '/c/Users/me/project' && ls 2>/dev/null");
+    expect(argv[2]).toBe('ls 2>/dev/null');
   });
 
   it('passes nul-redirect through unchanged on Linux so the argv keeps the literal file target', async () => {
@@ -906,7 +956,7 @@ describe('BashTool', () => {
     await executeTool(tool, context({ command: 'ls 2>nul', timeout: 60 }));
 
     const argv = execWithEnv.mock.calls[0]?.[0] as readonly string[];
-    expect(argv[2]).toBe("cd '/workspace' && ls 2>nul");
+    expect(argv[2]).toBe('ls 2>nul');
   });
 
   it('exposes a shell description that documents /bin/bash, TaskOutput/TaskStop, safety and efficiency sections, and background semantics', () => {

--- a/packages/agent-core/test/tools/shell-quoting.test.ts
+++ b/packages/agent-core/test/tools/shell-quoting.test.ts
@@ -66,10 +66,7 @@ function captureCommandRewrite(
     signal,
   }).then(() => {
       const argv = execWithEnv.mock.calls[0]?.[0] as readonly string[];
-      // The shell wrapper is "cd '<cwd>' && <rewritten>"; isolate the rewrite.
-      const wrapped = argv[2]!;
-      const match = /^cd '[^']+' && (.*)$/.exec(wrapped)!;
-      return { rewritten: match[1]!, argv };
+      return { rewritten: argv[2]!, argv };
     });
 }
 


### PR DESCRIPTION
## Summary

Fixes #850.

- run Bash commands with the process cwd instead of prefixing the shell source with `cd '<cwd>' &&`
- keep Windows Git Bash `>nul` rewriting, but leave cwd handling to the process runner
- normalize Git Bash-style `/c/...` cwd values back to Windows drive paths before spawning
- update Bash tests so they assert both the spawned argv and the cwd passed through `withCwd()`

## Validation

- `pnpm --filter @moonshot-ai/agent-core exec vitest run test/tools/bash.test.ts test/tools/shell-quoting.test.ts`
- `pnpm --filter @moonshot-ai/agent-core run test`
- `pnpm --filter @moonshot-ai/agent-core run typecheck`
- `pnpm exec oxlint --type-aware packages/agent-core/src/tools/builtin/shell/bash.ts packages/agent-core/test/tools/bash.test.ts packages/agent-core/test/tools/shell-quoting.test.ts --quiet`
- `pnpm --filter @moonshot-ai/agent-core run build`
- `git diff --check`

## AI Assistance Disclosure

I used Codex to review the changes, sanity-check the implementation against existing patterns, and help spot potential edge cases.
