### PR TITLE
feat(tui): show usage cache stats

### DIFF
--- a/.changeset/usage-cache-stats.md
+++ b/.changeset/usage-cache-stats.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": minor
+---
+
+Show prompt cache read and write token counts in the usage report.

--- a/apps/kimi-code/src/tui/components/messages/usage-panel.ts
+++ b/apps/kimi-code/src/tui/components/messages/usage-panel.ts
@@ -62,6 +62,17 @@ function usageInputTotal(usage: TokenUsage): number {
   );
 }
 
+function formatCacheLine(usage: TokenUsage, value: Colorize, muted: Colorize): string | undefined {
+  const cacheRead = usageNumber(usage.inputCacheRead);
+  const cacheWrite = usageNumber(usage.inputCacheCreation);
+  if (cacheRead === 0 && cacheWrite === 0) return undefined;
+  return (
+    `    ${muted('cache')}  read ${value(formatTokenCount(cacheRead))}  write ${value(
+      formatTokenCount(cacheWrite),
+    )}`
+  );
+}
+
 function buildSessionUsageSection(
   usage: SessionUsage | undefined,
   error: string | undefined,
@@ -78,23 +89,39 @@ function buildSessionUsageSection(
   const lines: string[] = [];
   let totalInput = 0;
   let totalOutput = 0;
+  let totalCacheRead = 0;
+  let totalCacheWrite = 0;
   for (const [model, row] of entries) {
     const input = usageInputTotal(row);
     const output = usageNumber(row.output);
+    const cacheRead = usageNumber(row.inputCacheRead);
+    const cacheWrite = usageNumber(row.inputCacheCreation);
     totalInput += input;
     totalOutput += output;
+    totalCacheRead += cacheRead;
+    totalCacheWrite += cacheWrite;
     lines.push(
       `  ${muted(model)}  input ${value(formatTokenCount(input))}  output ${value(
         formatTokenCount(output),
       )}  total ${value(formatTokenCount(input + output))}`,
     );
+    const cacheLine = formatCacheLine(row, value, muted);
+    if (cacheLine !== undefined) lines.push(cacheLine);
   }
   if (entries.length > 1) {
+    const total: TokenUsage = {
+      inputOther: totalInput - totalCacheRead - totalCacheWrite,
+      output: totalOutput,
+      inputCacheRead: totalCacheRead,
+      inputCacheCreation: totalCacheWrite,
+    };
     lines.push(
       `  ${muted('total')}  input ${value(formatTokenCount(totalInput))}  output ${value(
         formatTokenCount(totalOutput),
       )}  total ${value(formatTokenCount(totalInput + totalOutput))}`,
     );
+    const cacheLine = formatCacheLine(total, value, muted);
+    if (cacheLine !== undefined) lines.push(cacheLine);
   }
   return lines;
 }

--- a/apps/kimi-code/test/tui/components/messages/usage-panel.test.ts
+++ b/apps/kimi-code/test/tui/components/messages/usage-panel.test.ts
@@ -23,6 +23,12 @@ describe('UsagePanelComponent', () => {
             inputCacheCreation: 500,
             output: 250,
           },
+          'kimi-lite': {
+            inputOther: 200,
+            inputCacheRead: 0,
+            inputCacheCreation: 100,
+            output: 50,
+          },
         },
       } as never,
       contextUsage: 0.25,
@@ -41,11 +47,37 @@ describe('UsagePanelComponent', () => {
 
     expect(lines).toContain('Session usage');
     expect(lines).toContain('  kimi  input 2.0k  output 250  total 2.3k');
+    expect(lines).toContain('    cache  read 500  write 500');
+    expect(lines).toContain('  kimi-lite  input 300  output 50  total 350');
+    expect(lines).toContain('    cache  read 0  write 100');
+    expect(lines).toContain('  total  input 2.3k  output 300  total 2.6k');
+    expect(lines).toContain('    cache  read 500  write 600');
     expect(lines).toContain('Context window');
     expect(lines.join('\n')).toContain('25.0%');
     expect(lines).toContain('Plan usage');
     expect(lines.join('\n')).toContain('20% used');
     expect(lines.join('\n')).toContain('resets tomorrow');
+  });
+
+  it('omits cache rows when no cache tokens were recorded', () => {
+    const lines = buildUsageReportLines({
+      sessionUsage: {
+        byModel: {
+          kimi: {
+            inputOther: 1000,
+            inputCacheRead: 0,
+            inputCacheCreation: 0,
+            output: 250,
+          },
+        },
+      } as never,
+      contextUsage: 0,
+      contextTokens: 0,
+      maxContextTokens: 0,
+    }).map(strip);
+
+    expect(lines).toContain('  kimi  input 1.0k  output 250  total 1.3k');
+    expect(lines.join('\n')).not.toContain('cache');
   });
 
   it('wraps preformatted usage lines in a bordered panel', () => {


### PR DESCRIPTION
## Related Issue

Resolve #884

## Problem

`/usage` already counted prompt-cache tokens as part of input, but it did not show cache read/write counts separately.

## What changed

- show per-model prompt cache read/write token counts when they are non-zero
- show aggregate cache read/write counts in the multi-model total section
- keep the existing input/output/total lines unchanged
- add coverage for cache rows, multi-model totals, and no-cache output

## Validation

- `pnpm --filter @moonshot-ai/kimi-code exec vitest run test/tui/components/messages/usage-panel.test.ts`
- `pnpm --filter @moonshot-ai/kimi-code run typecheck`
- `pnpm exec oxlint --type-aware apps/kimi-code/src/tui/components/messages/usage-panel.ts apps/kimi-code/test/tui/components/messages/usage-panel.test.ts --quiet`
- `pnpm --filter @moonshot-ai/kimi-code run test`
- `git diff --check`

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.

`gen-docs` is not needed here because the existing command docs already describe `/usage`; this only adds detail to the rendered usage panel.

## AI Assistance Disclosure

I used Codex to review the changes, sanity-check the implementation against existing patterns, and help spot potential edge cases.
