### PR TITLE
feat(agent-core): add compaction model config

### DIFF
--- a/.changeset/compaction-model-config.md
+++ b/.changeset/compaction-model-config.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": minor
+---
+
+Add a `loop_control.compaction_model` option for using a separate model during context compaction.

--- a/docs/en/configuration/config-files.md
+++ b/docs/en/configuration/config-files.md
@@ -161,6 +161,7 @@ You can also switch models temporarily without touching the config file — by s
 | `max_steps_per_turn` | `integer` | — | Maximum steps per turn; unset or `0` means unlimited |
 | `max_retries_per_step` | `integer` | `3` | Maximum retries after a step failure |
 | `reserved_context_size` | `integer` | — | Number of tokens reserved for model output; automatic compaction is triggered when the remaining context window falls below this value |
+| `compaction_model` | `string` | — | Optional model alias from `[models]` to use only for full-history compaction; unset falls back to the active conversation model |
 
 ## `background`
 

--- a/docs/zh/configuration/config-files.md
+++ b/docs/zh/configuration/config-files.md
@@ -161,6 +161,7 @@ max_context_size = 1047576
 | `max_steps_per_turn` | `integer` | — | 单轮最大步数；不设或设为 `0` 则无上限 |
 | `max_retries_per_step` | `integer` | `3` | 单步失败后的最大重试次数 |
 | `reserved_context_size` | `integer` | — | 预留给模型输出的 token 数；上下文窗口剩余量低于此值时触发自动压缩 |
+| `compaction_model` | `string` | — | 可选的 `[models]` 模型别名，仅用于全量上下文压缩；不设置时回退到当前对话模型 |
 
 ## `background`
 

--- a/packages/agent-core/src/agent/compaction/full.ts
+++ b/packages/agent-core/src/agent/compaction/full.ts
@@ -6,14 +6,21 @@ import {
 } from '#/errors';
 import {
   APIEmptyResponseError,
+  type ChatProvider,
+  createProvider,
   isRetryableGenerateError,
   type GenerateResult,
+  type Message,
+  type ModelCapability,
   type TokenUsage,
   APIContextOverflowError,
   createUserMessage,
 } from '@moonshot-ai/kosong';
 
 import type { Agent } from '..';
+import { applyKimiEnvSamplingParams, applyKimiEnvThinkingKeep } from '#/config/kimi-env-params';
+import { resolveThinkingEffort } from '../config';
+import type { GenerateOptionsWithRequestLogFields } from '../llm-request-logger';
 import { isAbortError } from '../../loop/errors';
 import {
   retryBackoffDelays,
@@ -28,6 +35,7 @@ import {
   applyCompletionBudget,
   resolveCompletionBudget,
 } from '../../utils/completion-budget';
+import type { ResolvedRuntimeProvider } from '../../session/provider-manager';
 import compactionInstructionTemplate from './compaction-instruction.md?raw';
 import { renderTodoList, type TodoItem } from '../../tools/builtin/state/todo-list';
 import type { CompactionBeginData, CompactionResult } from './types';
@@ -38,6 +46,13 @@ import {
 } from './strategy';
 
 export const MAX_COMPACTION_RETRY_ATTEMPTS = 5;
+
+interface CompactionRuntimeConfig {
+  readonly model: string;
+  readonly provider: ChatProvider;
+  readonly capability: ModelCapability;
+  readonly maxOutputSize?: number;
+}
 
 class CompactionTruncatedError extends Error {
   constructor() {
@@ -202,9 +217,24 @@ export class FullCompaction {
   private async compactionWorker(
     signal: AbortSignal,
     data: Readonly<CompactionBeginData>,
-    compactedCount: number,
+    initialCompactedCount: number,
   ): Promise<void> {
     try {
+      const runtime = this.resolveCompactionRuntimeConfig();
+      const requestStrategy = this.createRequestCompactionStrategy(runtime);
+      let compactedCount = this.computeRuntimeCompactCount(
+        requestStrategy,
+        this.agent.context.history,
+        data.source,
+        initialCompactedCount,
+      );
+      if (compactedCount === 0) {
+        throw new KimiError(
+          ErrorCodes.COMPACTION_UNABLE,
+          'No prefix that can be compacted in current history.',
+        );
+      }
+
       const finalResult = {
         summary: '',
         compactedCount: 1,
@@ -213,7 +243,14 @@ export class FullCompaction {
       };
 
       for (let round = 1; ; round++) {
-        const result = await this.compactionRound(round, signal, data, compactedCount);
+        const result = await this.compactionRound(
+          round,
+          signal,
+          data,
+          runtime,
+          requestStrategy,
+          compactedCount,
+        );
         if (!result) return;
 
         finalResult.summary = result.summary;
@@ -223,7 +260,12 @@ export class FullCompaction {
 
         if (result.tokensBefore - result.tokensAfter < 1024) break;
         if (!this.strategy.shouldBlock(result.tokensAfter)) break;
-        compactedCount = this.strategy.computeCompactCount(this.agent.context.history, data.source);
+        compactedCount = this.computeRuntimeCompactCount(
+          requestStrategy,
+          this.agent.context.history,
+          data.source,
+          this.strategy.computeCompactCount(this.agent.context.history, data.source),
+        );
         if (compactedCount === 0) break;
       }
       this.markCompleted();
@@ -249,6 +291,8 @@ export class FullCompaction {
     round: number,
     signal: AbortSignal,
     data: Readonly<CompactionBeginData>,
+    runtime: CompactionRuntimeConfig,
+    requestStrategy: CompactionStrategy,
     initialCompactedCount: number,
   ) {
     const startedAt = Date.now();
@@ -260,13 +304,13 @@ export class FullCompaction {
 
       await this.triggerPreCompactHook(data, tokensBefore, signal);
 
-      const model = this.agent.config.model;
       const provider = applyCompletionBudget({
-        provider: this.agent.config.provider,
+        provider: runtime.provider,
         budget: resolveCompletionBudget({
+          maxOutputSize: runtime.maxOutputSize,
           reservedContextSize: this.agent.kimiConfig?.loopControl?.reservedContextSize,
         }),
-        capability: this.agent.config.modelCapabilities,
+        capability: runtime.capability,
       });
 
       const delays = retryBackoffDelays(MAX_COMPACTION_RETRY_ATTEMPTS);
@@ -276,8 +320,16 @@ export class FullCompaction {
         const messagesToCompact = originalHistory.slice(0, compactedCount);
         const messages = [
           ...this.agent.context.project(messagesToCompact),
-          createUserMessage(renderPrompt(compactionInstructionTemplate, { customInstruction: data.instruction ?? '' })),
+          createUserMessage(
+            renderPrompt(compactionInstructionTemplate, {
+              customInstruction: data.instruction ?? '',
+            }),
+          ),
         ];
+        const options: GenerateOptionsWithRequestLogFields = {
+          signal,
+          requestModelAlias: runtime.model,
+        };
         try {
           const response = await this.agent.generate(
             provider,
@@ -285,7 +337,7 @@ export class FullCompaction {
             [...this.agent.tools.loopTools],
             messages,
             undefined,
-            { signal },
+            options,
           );
           if (response.finishReason === 'truncated') {
             throw new CompactionTruncatedError();
@@ -299,7 +351,7 @@ export class FullCompaction {
             error instanceof CompactionTruncatedError ||
             error instanceof APIEmptyResponseError // e.g. think-only
           ) {
-            compactedCount = this.strategy.reduceCompactOnOverflow(messagesToCompact);
+            compactedCount = requestStrategy.reduceCompactOnOverflow(messagesToCompact);
           }
           else if (!isRetryableGenerateError(error)) {
             throw error;
@@ -313,7 +365,7 @@ export class FullCompaction {
       }
 
       if (usage !== null) {
-        this.agent.usage.record(model, usage);
+        this.agent.usage.record(runtime.model, usage);
       }
 
       const newHistory = this.agent.context.history;
@@ -379,6 +431,66 @@ export class FullCompaction {
       },
     });
     signal.throwIfAborted();
+  }
+
+  private resolveCompactionRuntimeConfig(): CompactionRuntimeConfig {
+    const compactionModel = this.agent.kimiConfig?.loopControl?.compactionModel;
+    if (compactionModel === undefined) {
+      return {
+        model: this.agent.config.model,
+        provider: this.agent.config.provider,
+        capability: this.agent.config.modelCapabilities,
+        maxOutputSize: undefined,
+      };
+    }
+
+    const resolved = this.agent.modelProvider?.resolveProviderConfig(compactionModel);
+    if (resolved === undefined) {
+      throw new KimiError(
+        ErrorCodes.CONFIG_INVALID,
+        'loop_control.compaction_model requires a model provider.',
+      );
+    }
+    return {
+      model: compactionModel,
+      provider: this.createCompactionProvider(resolved),
+      capability: resolved.modelCapabilities,
+      maxOutputSize: resolved.maxOutputSize,
+    };
+  }
+
+  private createRequestCompactionStrategy(runtime: CompactionRuntimeConfig): CompactionStrategy {
+    const compactionModel = this.agent.kimiConfig?.loopControl?.compactionModel;
+    if (compactionModel === undefined) return this.strategy;
+    return new DefaultCompactionStrategy(
+      () => runtime.capability.max_context_tokens,
+      {
+        ...DEFAULT_COMPACTION_CONFIG,
+        reservedContextSize:
+          this.agent.kimiConfig?.loopControl?.reservedContextSize ??
+          DEFAULT_COMPACTION_CONFIG.reservedContextSize,
+      },
+    );
+  }
+
+  private computeRuntimeCompactCount(
+    requestStrategy: CompactionStrategy,
+    history: readonly Message[],
+    source: CompactionBeginData['source'],
+    fallbackCount: number,
+  ): number {
+    const compactionModel = this.agent.kimiConfig?.loopControl?.compactionModel;
+    if (compactionModel === undefined) return fallbackCount;
+    return requestStrategy.computeCompactCount(history, source);
+  }
+
+  private createCompactionProvider(resolved: ResolvedRuntimeProvider): ChatProvider {
+    const thinkingLevel =
+      this.agent.config.thinkingLevel === 'off' && resolved.alwaysThinking === true
+        ? resolveThinkingEffort('on', this.agent.kimiConfig?.thinking)
+        : this.agent.config.thinkingLevel;
+    const provider = createProvider(resolved.provider).withThinking(thinkingLevel);
+    return applyKimiEnvThinkingKeep(applyKimiEnvSamplingParams(provider), thinkingLevel);
   }
 
   private triggerPostCompactHook(

--- a/packages/agent-core/src/agent/index.ts
+++ b/packages/agent-core/src/agent/index.ts
@@ -184,8 +184,8 @@ export class Agent {
 
   get generate(): typeof generate {
     return async (provider, systemPrompt, tools, history, callbacks, options) => {
-      const { requestLogFields, generateOptions } = splitGenerateOptions(options);
-      const modelAlias = this.config.modelAlias;
+      const { requestLogFields, requestModelAlias, generateOptions } = splitGenerateOptions(options);
+      const modelAlias = requestModelAlias ?? this.config.modelAlias;
       const run = (requestOptions: Parameters<typeof generate>[5]) => {
         this.llmRequestLogger.logRequest({
           provider,

--- a/packages/agent-core/src/agent/llm-request-logger.ts
+++ b/packages/agent-core/src/agent/llm-request-logger.ts
@@ -7,6 +7,7 @@ import type { LLMRequestLogFields } from '../loop';
 
 export type GenerateOptionsWithRequestLogFields = GenerateOptions & {
   readonly requestLogFields?: LLMRequestLogFields;
+  readonly requestModelAlias?: string;
 };
 
 export class LlmRequestLogger {
@@ -55,13 +56,14 @@ export class LlmRequestLogger {
 
 export function splitGenerateOptions(options: GenerateOptionsWithRequestLogFields | undefined): {
   readonly requestLogFields: LLMRequestLogFields | undefined;
+  readonly requestModelAlias: string | undefined;
   readonly generateOptions: GenerateOptions | undefined;
 } {
   if (options === undefined) {
-    return { requestLogFields: undefined, generateOptions: undefined };
+    return { requestLogFields: undefined, requestModelAlias: undefined, generateOptions: undefined };
   }
-  const { requestLogFields, ...generateOptions } = options;
-  return { requestLogFields, generateOptions };
+  const { requestLogFields, requestModelAlias, ...generateOptions } = options;
+  return { requestLogFields, requestModelAlias, generateOptions };
 }
 
 function toolSignature(tools: readonly Tool[]) {

--- a/packages/agent-core/src/config/schema.ts
+++ b/packages/agent-core/src/config/schema.ts
@@ -91,6 +91,7 @@ export const LoopControlSchema = z.object({
   maxRalphIterations: z.number().int().min(-1).optional(),
   reservedContextSize: z.number().int().min(0).optional(),
   compactionTriggerRatio: z.number().min(0.5).max(0.99).optional(),
+  compactionModel: z.string().min(1).optional(),
 });
 
 export type LoopControl = z.infer<typeof LoopControlSchema>;

--- a/packages/agent-core/test/agent/compaction/full.test.ts
+++ b/packages/agent-core/test/agent/compaction/full.test.ts
@@ -1628,6 +1628,132 @@ describe('FullCompaction', () => {
     expect(providerThinkingEfforts).toEqual(['high', 'high', 'high']);
   });
 
+  it('uses loop_control.compaction_model for full-history compaction', async () => {
+    const authProviderNames: string[] = [];
+    const compactionProviders: Array<{
+      readonly name: string;
+      readonly modelName: string;
+      readonly maxCompletionTokens: unknown;
+      readonly authApiKey?: string;
+    }> = [];
+    const generate: GenerateFn = async (provider, _system, _tools, _history, _callbacks, options) => {
+      compactionProviders.push({
+        name: provider.name,
+        modelName: provider.modelName,
+        maxCompletionTokens: providerMaxCompletionTokens(provider),
+        authApiKey: options?.auth?.apiKey,
+      });
+      return textResult('Compacted with the configured model.');
+    };
+    const ctx = testAgent({
+      generate,
+      compactionStrategy: alwaysCompactOnce,
+      initialConfig: {
+        providers: {
+          compact: {
+            type: 'kimi',
+            oauth: { storage: 'file', key: 'oauth/compact' },
+          },
+        },
+        models: {
+          'compact-alias': {
+            provider: 'compact',
+            model: 'compact-wire',
+            maxContextSize: 12_345,
+            maxOutputSize: 1_234,
+          },
+        },
+        loopControl: {
+          compactionModel: 'compact-alias',
+        },
+      },
+      providerManagerOverrides: {
+        resolveOAuthTokenProvider: (providerName) => {
+          authProviderNames.push(providerName);
+          return {
+            getAccessToken: async () => `${providerName}-token`,
+          };
+        },
+      },
+    });
+    ctx.configure({
+      provider: CATALOGUED_PROVIDER,
+      modelCapabilities: CATALOGUED_MODEL_CAPABILITIES,
+    });
+    ctx.appendExchange(1, 'old user one', 'old assistant one', 20);
+
+    const compacted = ctx.once('context.apply_compaction');
+    await ctx.rpc.beginCompaction({});
+    await compacted;
+
+    expect(compactionProviders).toEqual([
+      {
+        name: 'kimi',
+        modelName: 'compact-wire',
+        maxCompletionTokens: 1_234,
+        authApiKey: 'compact-token',
+      },
+    ]);
+    expect(authProviderNames).toEqual(['compact']);
+    const usage = ctx.agent.usage.data().byModel;
+    expect(usage?.['compact-alias']).toEqual(
+      expect.objectContaining({
+        output: 1,
+      }),
+    );
+    expect(usage?.['kimi-code']).toBeUndefined();
+  });
+
+  it('fits compaction request history to the compaction model window', async () => {
+    let compactionText = '';
+    const generate: GenerateFn = async (_provider, _system, _tools, history) => {
+      compactionText = history.map(messageText).join('\n');
+      return textResult('Compacted with a smaller model window.');
+    };
+    const ctx = testAgent({
+      generate,
+      initialConfig: {
+        providers: {
+          compact: {
+            type: 'kimi',
+            apiKey: 'compact-key',
+          },
+        },
+        models: {
+          'compact-alias': {
+            provider: 'compact',
+            model: 'compact-wire',
+            maxContextSize: 80,
+          },
+        },
+        loopControl: {
+          compactionModel: 'compact-alias',
+        },
+      },
+    });
+    ctx.configure({
+      provider: CATALOGUED_PROVIDER,
+      modelCapabilities: CATALOGUED_MODEL_CAPABILITIES,
+    });
+    ctx.appendExchange(1, 'small old user', 'small old assistant', 20);
+    ctx.appendExchange(
+      2,
+      `large middle user ${'x'.repeat(4_000)}`,
+      `large middle assistant ${'y'.repeat(4_000)}`,
+      20,
+    );
+    ctx.appendExchange(3, 'small recent user', 'small recent assistant', 20);
+
+    const compacted = ctx.once('context.apply_compaction');
+    await ctx.rpc.beginCompaction({});
+    await compacted;
+
+    expect(compactionText).toContain('small old user');
+    expect(compactionText).toContain('small old assistant');
+    expect(compactionText).not.toContain('large middle user');
+    expect(compactionText).not.toContain('large middle assistant');
+  });
+
   it('compacts provider overflow when model context size is unknown', async () => {
     let callCount = 0;
     const compactionMaxCompletionTokens: unknown[] = [];

--- a/packages/agent-core/test/config/configs.test.ts
+++ b/packages/agent-core/test/config/configs.test.ts
@@ -97,6 +97,7 @@ max_steps_per_run = 42
 max_retries_per_step = 3
 reserved_context_size = 50000
 compaction_trigger_ratio = 0.85
+compaction_model = "kimi-code/compact"
 
 [background]
 max_running_tasks = 4
@@ -174,6 +175,7 @@ describe('harness config TOML loader', () => {
       maxRetriesPerStep: 3,
       reservedContextSize: 50000,
       compactionTriggerRatio: 0.85,
+      compactionModel: 'kimi-code/compact',
     });
     expect(config.background).toMatchObject({
       maxRunningTasks: 4,
@@ -334,6 +336,7 @@ removed_flag = true
     expect(text).toContain('pattern = "Read(src/**)"');
     expect(text).not.toContain('[[permission.allow]]');
     expect(text).toContain('max_steps_per_turn = 7');
+    expect(text).toContain('compaction_model = "kimi-code/compact"');
     expect(text).toContain('GOOGLE_CLOUD_PROJECT = "project-1"');
     expect(text).toContain('theme = "dark"');
     expect(text).toContain('claim_stale_after_ms = 15000');
@@ -343,6 +346,7 @@ removed_flag = true
 
     const reloaded = readConfigFile(configPath);
     expect(reloaded.loopControl?.maxStepsPerTurn).toBe(7);
+    expect(reloaded.loopControl?.compactionModel).toBe('kimi-code/compact');
     expect(reloaded.hooks?.[0]?.event).toBe('PreToolUse');
     expect(reloaded.raw?.['theme']).toBe('dark');
   });

--- a/packages/node-sdk/test/config.test.ts
+++ b/packages/node-sdk/test/config.test.ts
@@ -61,6 +61,7 @@ max_retries_per_step = 3
 max_ralph_iterations = 0
 reserved_context_size = 50000
 compaction_trigger_ratio = 0.85
+compaction_model = "compact-model"
 
 [background]
 max_running_tasks = 4
@@ -148,6 +149,7 @@ max_context_size = "large"
       maxRalphIterations: 0,
       reservedContextSize: 50000,
       compactionTriggerRatio: 0.85,
+      compactionModel: 'compact-model',
     });
     expect(config.background).toEqual({
       maxRunningTasks: 4,
@@ -185,6 +187,7 @@ max_context_size = "large"
     expect(text).toContain('extra_skill_dirs = [ "~/team-skills", ".agents/team-skills" ]');
     expect(text).not.toContain('default_yolo');
     expect(text).toContain('max_steps_per_turn = 42');
+    expect(text).toContain('compaction_model = "compact-model"');
     expect(text).toContain('display_name = "Kimi for Coding"');
     expect(text).toContain('GOOGLE_CLOUD_PROJECT = "project-1"');
     expect(text).toContain('claim_stale_after_ms = 15000');
@@ -192,6 +195,7 @@ max_context_size = "large"
 
     const reloaded = readConfigFile(configPath);
     expect(reloaded.loopControl?.maxStepsPerTurn).toBe(42);
+    expect(reloaded.loopControl?.compactionModel).toBe('compact-model');
     expect(reloaded.raw?.['theme']).toBe('dark');
   });
 


### PR DESCRIPTION
## Related Issue

Resolve #840

## Problem

Full-history compaction always used the active conversation model. That made it impossible to use a cheaper or faster configured model just for context compression.

## What changed

- add `loop_control.compaction_model` as an optional model alias
- resolve the compaction alias through the existing model/provider config path
- use the compaction alias for request auth, request logging, usage accounting, completion budget, and request-prefix sizing
- fall back to the active conversation model when `compaction_model` is unset
- document the new field in the EN/ZH config docs

## Validation

- `pnpm --filter @moonshot-ai/agent-core exec vitest run test/agent/compaction/full.test.ts test/config/configs.test.ts`
- `pnpm --filter @moonshot-ai/kimi-code-sdk exec vitest run test/config.test.ts`
- `pnpm --filter @moonshot-ai/agent-core run test`
- `pnpm --filter @moonshot-ai/agent-core run typecheck`
- `pnpm --filter @moonshot-ai/kimi-code-sdk run typecheck`
- `pnpm exec oxlint --type-aware packages/agent-core/src/agent/compaction/full.ts packages/agent-core/src/agent/llm-request-logger.ts packages/agent-core/src/agent/index.ts packages/agent-core/src/config/schema.ts packages/agent-core/test/config/configs.test.ts packages/agent-core/test/agent/compaction/full.test.ts packages/node-sdk/test/config.test.ts --quiet`
- `npm run build` (inside `docs/`)
- `git diff --check`

## Review

Ran a read-only subagent review. It found issues around request auth/log aliasing, alias output caps, and compaction-model window sizing; those are fixed. Second pass found no blockers.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.

## AI Assistance Disclosure

I used Codex to review the changes, sanity-check the implementation against existing patterns, and help spot potential edge cases.
