### PR TITLE
feat(web): add --host option for LAN access

### DIFF
--- a/.changeset/server-host-option.md
+++ b/.changeset/server-host-option.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Add a `--host` option to `kimi web` and `kimi server run` so the server can bind to a specific IP or `0.0.0.0` for LAN/remote access. The default remains `127.0.0.1` (loopback) for backward compatibility and security.

--- a/apps/kimi-code/src/cli/sub/server/daemon.ts
+++ b/apps/kimi-code/src/cli/sub/server/daemon.ts
@@ -257,6 +257,14 @@ export async function ensureDaemon(options: EnsureDaemonOptions = {}): Promise<E
   // 1. Reuse an already-live daemon if one holds the lock.
   const existing = getLiveLock();
   if (existing) {
+    // Refuse to silently reuse a daemon bound to a different host.
+    const existingHost = existing.host ?? DEFAULT_SERVER_HOST;
+    if (host !== existingHost) {
+      throw new Error(
+        `Existing daemon is bound to ${existingHost}:${existing.port}. ` +
+        `Run 'kimi server kill' first to bind to ${host}:${preferred}.`,
+      );
+    }
     const origin = serverOrigin(lockConnectHost(existing), existing.port);
     if (await waitForServerHealthy(origin, REUSE_HEALTH_TIMEOUT_MS)) {
       return { origin };

--- a/apps/kimi-code/src/cli/sub/server/daemon.ts
+++ b/apps/kimi-code/src/cli/sub/server/daemon.ts
@@ -44,6 +44,8 @@ const POLL_INTERVAL_MS = 200;
 const DEFAULT_DAEMON_LOG_LEVEL = 'info';
 
 export interface EnsureDaemonOptions {
+  /** Bind host; defaults to loopback (`127.0.0.1`). Use `0.0.0.0` for LAN access. */
+  host?: string;
   /** Preferred port; on conflict a free port is chosen automatically. */
   port?: number;
   /** Pino log level for the spawned daemon (defaults to `info`). */
@@ -178,6 +180,7 @@ export function resolveDaemonProgram(
 }
 
 interface SpawnDaemonChildOptions {
+  host?: string;
   port: number;
   logLevel: string;
   debugEndpoints?: boolean;
@@ -198,6 +201,9 @@ export function spawnDaemonChild(options: SpawnDaemonChildOptions): void {
     '--log-level',
     options.logLevel,
   ];
+  if (options.host !== undefined) {
+    args.push('--host', options.host);
+  }
   if (options.debugEndpoints === true) {
     args.push('--debug-endpoints');
   }
@@ -246,6 +252,7 @@ function sleep(ms: number): Promise<void> {
 export async function ensureDaemon(options: EnsureDaemonOptions = {}): Promise<EnsureDaemonResult> {
   const preferred = options.port ?? DEFAULT_SERVER_PORT;
   const logLevel = options.logLevel ?? DEFAULT_DAEMON_LOG_LEVEL;
+  const host = options.host ?? DEFAULT_SERVER_HOST;
 
   // 1. Reuse an already-live daemon if one holds the lock.
   const existing = getLiveLock();
@@ -260,8 +267,9 @@ export async function ensureDaemon(options: EnsureDaemonOptions = {}): Promise<E
   }
 
   // 2. No reusable daemon — pick a free port and spawn one detached.
-  const port = await resolveDaemonPort(DEFAULT_SERVER_HOST, preferred);
+  const port = await resolveDaemonPort(host, preferred);
   spawnDaemonChild({
+    host,
     port,
     logLevel,
     debugEndpoints: options.debugEndpoints,

--- a/apps/kimi-code/src/cli/sub/server/run.ts
+++ b/apps/kimi-code/src/cli/sub/server/run.ts
@@ -29,6 +29,7 @@ import { createKimiCodeHostIdentity, getHostPackageRoot, getVersion } from '../.
 import { ensureDaemon } from './daemon';
 import {
   DEFAULT_FOREGROUND_LOG_LEVEL,
+  DEFAULT_SERVER_HOST,
   DEFAULT_SERVER_PORT,
   parseServerOptions,
   VALID_LOG_LEVELS,
@@ -69,6 +70,11 @@ export function buildRunCommand(cmd: Command, options: { defaultOpen: boolean })
       '--port <port>',
       `Bind port (default ${DEFAULT_SERVER_PORT})`,
       String(DEFAULT_SERVER_PORT),
+    )
+    .option(
+      '--host <host>',
+      `Bind host (default ${DEFAULT_SERVER_HOST}; use 0.0.0.0 for LAN access).`,
+      DEFAULT_SERVER_HOST,
     )
     .option(
       '--log-level <level>',
@@ -127,7 +133,7 @@ export async function handleRunCommand(
         const readyMs = Date.now() - startedAt;
         deps.stdout.write(
           parsed.logLevel === DEFAULT_FOREGROUND_LOG_LEVEL
-            ? formatReadyBanner(origin, readyMs)
+            ? formatReadyBanner(origin, readyMs, parsed.host)
             : `Kimi server: ${origin}\n`,
         );
         if (opts.open === true) {
@@ -141,7 +147,7 @@ export async function handleRunCommand(
   const readyMs = Date.now() - startedAt;
   deps.stdout.write(
     parsed.logLevel === DEFAULT_FOREGROUND_LOG_LEVEL
-      ? formatReadyBanner(origin, readyMs)
+      ? formatReadyBanner(origin, readyMs, parsed.host)
       : `Kimi server: ${origin}\n`,
   );
   if (opts.open === true) {
@@ -159,6 +165,7 @@ export async function startServerBackground(
   options: ParsedServerOptions,
 ): Promise<{ origin: string }> {
   const { origin } = await ensureDaemon({
+    host: options.host,
     port: options.port,
     logLevel: options.logLevel,
     debugEndpoints: options.debugEndpoints,
@@ -323,7 +330,7 @@ export function resolveServerWebAssetsDir(
   return nativeWebAssetsDir ?? join(getHostPackageRoot(), WEB_ASSETS_DIR);
 }
 
-function formatReadyBanner(origin: string, readyMs: number): string {
+function formatReadyBanner(origin: string, readyMs: number, host: string = DEFAULT_SERVER_HOST): string {
   const primary = (text: string): string => chalk.hex(darkColors.primary)(text);
   const title = (text: string): string => chalk.bold.hex(darkColors.primary)(text);
   const dim = (text: string): string => chalk.hex(darkColors.textDim)(text);
@@ -348,7 +355,7 @@ function formatReadyBanner(origin: string, readyMs: number): string {
   ];
   const infoLines = [
     label('URL:      ') + url,
-    label('Network:  ') + muted('local only'),
+    label('Network:  ') + muted(networkDescription(host)),
     label('Logs:     ') + muted('off') + dim('  use --log-level info to enable'),
     label('Stop:     ') + muted('kimi server kill'),
     label('Ready:    ') + muted(`${String(Math.max(0, readyMs))} ms`),
@@ -376,6 +383,24 @@ function formatReadyBanner(origin: string, readyMs: number): string {
 
 function displayOrigin(origin: string): string {
   return origin.endsWith('/') ? origin : `${origin}/`;
+}
+
+/**
+ * Human-readable bind scope for the ready banner. Loopback hosts stay "local
+ * only"; anything else (e.g. `0.0.0.0`) is surfaced as LAN-reachable so users
+ * know the server is exposed beyond this machine.
+ */
+function networkDescription(host: string): string {
+  const normalized = host.trim().toLowerCase().replaceAll('[', '').replaceAll(']', '');
+  if (
+    normalized === 'localhost' ||
+    normalized === '::1' ||
+    normalized === '0:0:0:0:0:0:0:1' ||
+    normalized.startsWith('127.')
+  ) {
+    return 'local only';
+  }
+  return `LAN (${host})`;
 }
 
 const DEFAULT_RUN_COMMAND_DEPS: RunCommandDeps = {

--- a/apps/kimi-code/test/cli/server/server.test.ts
+++ b/apps/kimi-code/test/cli/server/server.test.ts
@@ -56,14 +56,14 @@ describe('kimi server', () => {
     expect(subs).toEqual(['kill', 'ps', 'run']);
   });
 
-  it('`server run` exposes local-only foreground options', () => {
+  it('`server run` exposes the expected foreground options including --host', () => {
     const program = makeProgram();
     const run = program.commands
       .find((c) => c.name() === 'server')
       ?.commands.find((c) => c.name() === 'run');
     expect(run).toBeDefined();
     const longs = run!.options.map((o) => o.long).filter(Boolean);
-    expect(longs).not.toContain('--host');
+    expect(longs).toContain('--host');
     expect(longs).toContain('--port');
     expect(longs).toContain('--log-level');
     expect(longs).toContain('--debug-endpoints');
@@ -95,7 +95,7 @@ describe('kimi server', () => {
     const longs = web!.options.map((o) => o.long).filter(Boolean);
     // web defaults to opening → the option is the negative form --no-open
     expect(longs).toContain('--no-open');
-    expect(longs).not.toContain('--host');
+    expect(longs).toContain('--host');
     expect(longs).toContain('--port');
   });
 });
@@ -418,6 +418,35 @@ describe('`kimi server run` background start', () => {
     expect(stdout).toContain(color.bold.hex(darkColors.textDim)('URL:      '));
     expect(stdout).toContain(color.hex(darkColors.textMuted)('local only'));
   });
+
+  it('advertises LAN reachability in the ready banner when bound to 0.0.0.0', async () => {
+    const { handleRunCommand } = await import('#/cli/sub/server/run');
+    let stdout = '';
+
+    await handleRunCommand(
+      { host: '0.0.0.0', port: '58627' },
+      {
+        startServerBackground: async () => ({ origin: 'http://127.0.0.1:58627' }),
+        openUrl: vi.fn(),
+        stdout: {
+          write(chunk: string | Uint8Array) {
+            stdout += String(chunk);
+            return true;
+          },
+        },
+        stderr: {
+          write() {
+            return true;
+          },
+        },
+      },
+    );
+
+    const plain = stripAnsi(stdout);
+    expect(plain).toContain('Network:');
+    expect(plain).toContain('LAN (0.0.0.0)');
+    expect(plain).not.toContain('local only');
+  });
 });
 
 describe('`kimi server run --foreground`', () => {
@@ -680,6 +709,34 @@ describe('spawnDaemonChild', () => {
     expect(args).toEqual(expect.arrayContaining(['server', 'run', '--daemon']));
     expect(options).toMatchObject({ detached: true, cwd: dirname(daemonLogPath()) });
     expect(options?.cwd).not.toBe(process.cwd());
+  });
+
+  it('forwards --host to the spawned daemon when a host is provided', async () => {
+    const { spawn } = await import('node:child_process');
+    const spawnMock = vi.mocked(spawn);
+    spawnMock.mockClear();
+    spawnMock.mockReturnValue({ unref: vi.fn(), once: vi.fn() } as unknown as ChildProcess);
+
+    const { spawnDaemonChild } = await import('#/cli/sub/server/daemon');
+    spawnDaemonChild({ host: '0.0.0.0', port: 58627, logLevel: 'info' });
+
+    expect(spawnMock).toHaveBeenCalledOnce();
+    const args = spawnMock.mock.calls[0]![1] as readonly string[];
+    expect(args).toEqual(expect.arrayContaining(['--host', '0.0.0.0']));
+  });
+
+  it('omits --host from the spawned daemon when no host is provided', async () => {
+    const { spawn } = await import('node:child_process');
+    const spawnMock = vi.mocked(spawn);
+    spawnMock.mockClear();
+    spawnMock.mockReturnValue({ unref: vi.fn(), once: vi.fn() } as unknown as ChildProcess);
+
+    const { spawnDaemonChild } = await import('#/cli/sub/server/daemon');
+    spawnDaemonChild({ port: 58627, logLevel: 'info' });
+
+    expect(spawnMock).toHaveBeenCalledOnce();
+    const args = spawnMock.mock.calls[0]![1] as readonly string[];
+    expect(args).not.toContain('--host');
   });
 });
 

--- a/docs/en/reference/kimi-command.md
+++ b/docs/en/reference/kimi-command.md
@@ -158,12 +158,13 @@ kimi server status             # snapshot of installed/running state
 | Option | Description |
 | --- | --- |
 | `--port <port>` | Bind port; defaults to `58627` |
+| `--host <host>` | Bind host; defaults to `127.0.0.1` (loopback). Use `0.0.0.0` to expose the server on the LAN |
 | `--log-level <level>` | Enable server logs at the selected level; omitted by default |
 | `--debug-endpoints` | Mount `/api/v1/debug/*` routes (off by default) |
 | `--foreground` | Run in the foreground instead of spawning a background daemon |
 | `--open` | Open the web UI in the default browser once the server is healthy |
 
-`kimi server run` binds to local loopback only. By default it spawns a single background daemon (reused across runs) and exits once the daemon is healthy; the daemon shuts itself down after the last web client disconnects. Pass `--foreground` to run the server in the current process instead — it then stays attached to the terminal and shuts down cleanly on `SIGINT` / `SIGTERM`.
+`kimi server run` binds to local loopback by default. Pass `--host 0.0.0.0` (or a specific interface IP) to make it reachable from other machines on the network, e.g. over Tailscale/VPN or from a browser on another device. By default it spawns a single background daemon (reused across runs) and exits once the daemon is healthy; the daemon shuts itself down after the last web client disconnects. Pass `--foreground` to run the server in the current process instead — it then stays attached to the terminal and shuts down cleanly on `SIGINT` / `SIGTERM`.
 
 #### `kimi server install`
 
@@ -202,9 +203,10 @@ Equivalent to `kimi server run --open`: it starts a local Kimi server in the bac
 kimi web                 # start the server in the background and open the browser (reuses a running one)
 kimi web --no-open       # don't open the browser; same as `kimi server run`
 kimi web --foreground    # run attached to the current terminal and open the browser
+kimi web --host 0.0.0.0  # bind to all interfaces for LAN/remote access
 ```
 
-Stop the server with `kimi server kill` and list active connections with `kimi server ps`; `--port`, `--log-level`, and the other flags match `kimi server run`.
+Stop the server with `kimi server kill` and list active connections with `kimi server ps`; `--host`, `--port`, `--log-level`, and the other flags match `kimi server run`.
 
 ### `kimi doctor`
 

--- a/docs/zh/reference/kimi-command.md
+++ b/docs/zh/reference/kimi-command.md
@@ -158,12 +158,13 @@ kimi server status             # 查看安装与运行状态
 | 选项 | 说明 |
 | --- | --- |
 | `--port <port>` | 绑定端口；默认 `58627` |
+| `--host <host>` | 绑定主机；默认 `127.0.0.1`（回环地址）。使用 `0.0.0.0` 可在局域网内暴露服务 |
 | `--log-level <level>` | 按所选级别开启服务日志；默认不输出 |
 | `--debug-endpoints` | 挂载 `/api/v1/debug/*` 调试路由（默认关闭） |
 | `--foreground` | 前台运行，不 spawn 后台守护进程 |
 | `--open` | 服务健康后用默认浏览器打开 web UI |
 
-`kimi server run` 只绑定本机 loopback 地址。默认会 spawn 一个后台守护进程（多次运行会复用同一个），健康后即退出；守护进程在最后一个 web 客户端断开后自行关闭。加 `--foreground` 则在当前进程中运行——保持挂在终端，在 `SIGINT` / `SIGTERM` 时干净退出。
+`kimi server run` 默认只绑定本机 loopback 地址。传入 `--host 0.0.0.0`（或某个网卡 IP）可让局域网内其他机器访问，例如通过 Tailscale/VPN 或从另一台设备的浏览器访问。默认会 spawn 一个后台守护进程（多次运行会复用同一个），健康后即退出；守护进程在最后一个 web 客户端断开后自行关闭。加 `--foreground` 则在当前进程中运行——保持挂在终端，在 `SIGINT` / `SIGTERM` 时干净退出。
 
 #### `kimi server install`
 
@@ -202,9 +203,10 @@ kimi server status             # 查看安装与运行状态
 kimi web                 # 后台启动服务并打开浏览器（已运行则复用）
 kimi web --no-open       # 不打开浏览器，等同 `kimi server run`
 kimi web --foreground    # 在当前终端前台运行，同时打开浏览器
+kimi web --host 0.0.0.0  # 绑定到所有网卡，供局域网/远程访问
 ```
 
-停止服务使用 `kimi server kill`，查看活动连接使用 `kimi server ps`；`--port`、`--log-level` 等选项与 `kimi server run` 一致。
+停止服务使用 `kimi server kill`，查看活动连接使用 `kimi server ps`；`--host`、`--port`、`--log-level` 等选项与 `kimi server run` 一致。
 
 ### `kimi doctor`
 


### PR DESCRIPTION
## Problem

`kimi web` and `kimi server run` always bind to `127.0.0.1` (loopback), so the web UI cannot be reached from other machines. This blocks remote access over Tailscale/VPN, access from other devices on the same LAN, CI/CD scenarios that need to reach the service remotely, and WSL2 accessing a Windows-hosted service. There was previously no way to override the bind host.

Fixes #908

## What changed

- Add a `--host <host>` option to both `kimi web` and `kimi server run` (they share `buildRunCommand`). The default stays `127.0.0.1` (loopback) for backward compatibility and security; pass `--host 0.0.0.0` (or any interface IP) to expose the server on the LAN.
- Thread the host through the background-daemon path: `startServerBackground` -> `ensureDaemon` -> `spawnDaemonChild` now forward `--host` to the detached daemon child, and `resolveDaemonPort` probes the requested host. The in-process (`--foreground`) and `--daemon` paths already passed `host` to `startServer`, so they pick up the new option automatically.
- The ready banner now reports `Network: local only` for loopback binds and `Network: LAN (<host>)` when bound to a non-loopback address.
- Updated `docs/en` + `docs/zh` command reference and added a changeset (`@moonshot-ai/kimi-code`: patch).
- Updated/added tests: assert `--host` is registered on `server run` and the `web` alias; verify `spawnDaemonChild` forwards `--host` when provided and omits it otherwise; verify the banner advertises LAN reachability for `0.0.0.0`.

## Validation

- `pnpm --filter @moonshot-ai/kimi-code test -- test/cli/server/server.test.ts`
- Manual: `kimi server run --foreground --host 0.0.0.0` then reach the UI from another machine on the LAN; `kimi web --host 0.0.0.0` starts the background daemon bound to all interfaces (use `kimi server kill` first if a loopback daemon is already running).