### PR TITLE
fix(acp): tolerate missing MCP optional fields

### DIFF
--- a/.changeset/acp-mcp-optional-fields.md
+++ b/.changeset/acp-mcp-optional-fields.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Fix ACP MCP server conversion when optional headers or environment variables are omitted.

--- a/packages/acp-adapter/src/mcp.ts
+++ b/packages/acp-adapter/src/mcp.ts
@@ -102,17 +102,17 @@ function acpMcpServerToConfig(
 }
 
 function headersArrayToRecord(
-  headers: ReadonlyArray<{ readonly name: string; readonly value: string }>,
+  headers: ReadonlyArray<{ readonly name: string; readonly value: string }> | undefined,
 ): Record<string, string> {
   const out: Record<string, string> = {};
-  for (const h of headers) out[h.name] = h.value;
+  for (const h of headers ?? []) out[h.name] = h.value;
   return out;
 }
 
 function envArrayToRecord(
-  env: ReadonlyArray<{ readonly name: string; readonly value: string }>,
+  env: ReadonlyArray<{ readonly name: string; readonly value: string }> | undefined,
 ): Record<string, string> {
   const out: Record<string, string> = {};
-  for (const e of env) out[e.name] = e.value;
+  for (const e of env ?? []) out[e.name] = e.value;
   return out;
 }

--- a/packages/acp-adapter/test/mcp-forward.test.ts
+++ b/packages/acp-adapter/test/mcp-forward.test.ts
@@ -169,6 +169,34 @@ describe('acpMcpServersToConfigs', () => {
     expect(warnSpy).not.toHaveBeenCalled();
   });
 
+  it('converts HTTP and SSE servers without headers', () => {
+    const out = acpMcpServersToConfigs([
+      {
+        type: 'http',
+        name: 'docs',
+        url: 'https://mcp.example.com',
+      } as unknown as McpServer,
+      {
+        type: 'sse',
+        name: 'events',
+        url: 'https://stream.example.com',
+      } as unknown as McpServer,
+    ]);
+    expect(out).toEqual({
+      docs: {
+        transport: 'http',
+        url: 'https://mcp.example.com',
+        headers: {},
+      },
+      events: {
+        transport: 'sse',
+        url: 'https://stream.example.com',
+        headers: {},
+      },
+    });
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
   it('converts a stdio server with args + env to a Record keyed by name', () => {
     const out = acpMcpServersToConfigs([
       stdioServer(
@@ -187,6 +215,25 @@ describe('acpMcpServersToConfigs', () => {
         command: '/usr/local/bin/mcp-fs',
         args: ['--root', '/tmp'],
         env: { NODE_ENV: 'production', DEBUG: '1' },
+      },
+    });
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it('converts a stdio server without env', () => {
+    const out = acpMcpServersToConfigs([
+      {
+        name: 'fs',
+        command: '/usr/local/bin/mcp-fs',
+        args: ['--root', '/tmp'],
+      } as unknown as McpServer,
+    ]);
+    expect(out).toEqual({
+      fs: {
+        transport: 'stdio',
+        command: '/usr/local/bin/mcp-fs',
+        args: ['--root', '/tmp'],
+        env: {},
       },
     });
     expect(warnSpy).not.toHaveBeenCalled();


### PR DESCRIPTION
## Summary

- tolerate omitted ACP MCP `headers` on HTTP/SSE servers
- tolerate omitted ACP MCP `env` on stdio servers
- add regression coverage for omitted optional MCP fields

## Related Issue

Addresses #837 finding 2.

## Tests

- `pnpm --filter @moonshot-ai/acp-adapter exec vitest run test/mcp-forward.test.ts`
- `pnpm --filter @moonshot-ai/acp-adapter run test`
- `pnpm --filter @moonshot-ai/acp-adapter run typecheck`
- `pnpm --filter @moonshot-ai/acp-adapter run build`
- `pnpm --filter @moonshot-ai/kimi-code run typecheck`
- `pnpm exec oxlint --type-aware packages/acp-adapter/src/mcp.ts packages/acp-adapter/test/mcp-forward.test.ts --quiet`
- `git diff --check`

## AI Assistance Disclosure

I used Codex to review the changes, sanity-check the implementation against existing patterns, and help spot potential edge cases.
