### PR TITLE
fix(acp): match toggleable models case-insensitively

### DIFF
--- a/.changeset/acp-model-toggle-case.md
+++ b/.changeset/acp-model-toggle-case.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Detect ACP toggleable thinking models case-insensitively.

--- a/packages/acp-adapter/src/model-catalog.ts
+++ b/packages/acp-adapter/src/model-catalog.ts
@@ -52,7 +52,7 @@ export function deriveThinkingSupported(alias: ModelAlias): boolean {
   if (declared.includes('thinking') || declared.includes('always_thinking')) return true;
   const lower = alias.model.toLowerCase();
   if (lower.includes('thinking') || lower.includes('reason')) return true;
-  if (TOGGLEABLE_THINKING_MODELS.has(alias.model)) return true;
+  if (TOGGLEABLE_THINKING_MODELS.has(lower)) return true;
   return false;
 }
 

--- a/packages/acp-adapter/test/model-catalog.test.ts
+++ b/packages/acp-adapter/test/model-catalog.test.ts
@@ -21,6 +21,11 @@ describe('deriveThinkingSupported', () => {
     expect(deriveThinkingSupported(alias('some-thinking-model'))).toBe(true);
     expect(deriveThinkingSupported(alias('plain-model'))).toBe(false);
   });
+
+  it('matches toggleable model names case-insensitively', () => {
+    expect(deriveThinkingSupported(alias('Kimi-Code'))).toBe(true);
+    expect(deriveThinkingSupported(alias('Kimi-For-Coding'))).toBe(true);
+  });
 });
 
 describe('deriveAlwaysThinking', () => {


### PR DESCRIPTION
## Summary

- normalize model names before checking the ACP toggleable-thinking allow-list
- add a regression test for mixed-case `Kimi-Code` / `Kimi-For-Coding`

## Related Issue

Addresses #837 finding 7.

## Tests

- `pnpm --filter @moonshot-ai/acp-adapter exec vitest run test/model-catalog.test.ts`
- `pnpm --filter @moonshot-ai/acp-adapter run test`
- `pnpm --filter @moonshot-ai/acp-adapter run typecheck`
- `pnpm --filter @moonshot-ai/acp-adapter run build`
- `pnpm --filter @moonshot-ai/kimi-code run typecheck`
- `pnpm exec oxlint --type-aware packages/acp-adapter/src/model-catalog.ts packages/acp-adapter/test/model-catalog.test.ts --quiet`
- `git diff --check`

## AI Assistance Disclosure

I used Codex to review the changes, sanity-check the implementation against existing patterns, and help spot potential edge cases.
