### PR TITLE
fix(acp): fallback unknown turn end reasons

### DIFF
--- a/.changeset/acp-stop-reason-fallback.md
+++ b/.changeset/acp-stop-reason-fallback.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Fallback ACP turn-end stop reason mapping to `end_turn` for unknown runtime values.

--- a/packages/acp-adapter/src/events-map.ts
+++ b/packages/acp-adapter/src/events-map.ts
@@ -56,6 +56,8 @@ export function assistantDeltaToSessionUpdate(
  *   belong on the JSON-RPC error channel). Returning `end_turn` keeps the
  *   client unblocked; the caller is expected to log the `error` payload
  *   separately so the failure is observable in the agent logs.
+ * Unknown runtime values also fall back to `end_turn` so a newer SDK
+ * reason cannot leak `undefined` onto the ACP wire.
  */
 export function turnEndReasonToStopReason(reason: TurnEndReason): AcpStopReason {
   switch (reason) {
@@ -64,6 +66,8 @@ export function turnEndReasonToStopReason(reason: TurnEndReason): AcpStopReason 
     case 'cancelled':
       return 'cancelled';
     case 'failed':
+      return 'end_turn';
+    default:
       return 'end_turn';
   }
 }

--- a/packages/acp-adapter/test/events-map.test.ts
+++ b/packages/acp-adapter/test/events-map.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest';
+
+import type { TurnEndReason } from '@moonshot-ai/kimi-code-sdk';
+
+import { turnEndReasonToStopReason } from '../src/events-map';
+
+describe('turnEndReasonToStopReason', () => {
+  it('maps known SDK turn-end reasons to ACP stop reasons', () => {
+    expect(turnEndReasonToStopReason('completed')).toBe('end_turn');
+    expect(turnEndReasonToStopReason('cancelled')).toBe('cancelled');
+    expect(turnEndReasonToStopReason('failed')).toBe('end_turn');
+  });
+
+  it('falls back to end_turn for unknown runtime reasons', () => {
+    expect(turnEndReasonToStopReason('interrupted' as TurnEndReason)).toBe('end_turn');
+  });
+});


### PR DESCRIPTION
## Summary

- return `end_turn` for unexpected runtime turn-end reasons instead of falling through to `undefined`
- add focused coverage for known reasons and the unknown fallback path

## Related Issue

Addresses #837 finding 6.

## Tests

- `pnpm --filter @moonshot-ai/acp-adapter exec vitest run test/events-map.test.ts`
- `pnpm --filter @moonshot-ai/acp-adapter run test`
- `pnpm --filter @moonshot-ai/acp-adapter run typecheck`
- `pnpm --filter @moonshot-ai/acp-adapter run build`
- `pnpm --filter @moonshot-ai/kimi-code run typecheck`
- `pnpm exec oxlint --type-aware packages/acp-adapter/src/events-map.ts packages/acp-adapter/test/events-map.test.ts --quiet`
- `git diff --check`

## AI Assistance Disclosure

I used Codex to review the changes, sanity-check the implementation against existing patterns, and help spot potential edge cases.
