### PR TITLE
test(server): relax flaky startServer port-retry integration assertion

### DIFF
--- a/packages/server/test/start.test.ts
+++ b/packages/server/test/start.test.ts
@@ -161,7 +161,7 @@ describe('startServer — lock + healthz smoke', () => {
     expect(existsSync(lockPath)).toBe(false);
   });
 
-  it('retries on port+1 and updates the lock when the requested port is held by a third party', async () => {
+  it('retries to a higher port and updates the lock when the requested port is held by a third party', async () => {
     // Occupy the requested port with a raw TCP server (a "third-party" process
     // from the server's point of view — it does NOT hold the lock).
     const { port, next } = await allocateAdjacentFreePair();
@@ -179,10 +179,17 @@ describe('startServer — lock + healthz smoke', () => {
       });
       running.push(r);
 
-      // Bound to the next port, and the lock advertises it so status/kill/ps work.
-      expect(r.address).toBe(`http://127.0.0.1:${String(next)}`);
+      // The server must bind to a higher port because `port` is occupied.
+      // The exact port can be `next` or higher: in a concurrent test run another
+      // listener may grab `next` before the server does. The +1 retry strategy is
+      // covered by unit tests for listenWithPortRetry.
+      expect(r.address).toMatch(/^http:\/\/127\.0\.0\.1:\d+$/);
+      const actualPort = Number(new URL(r.address).port);
+      expect(actualPort).toBeGreaterThanOrEqual(next);
+
+      // The lock advertises the real bound port so status/kill/ps work.
       const stored = JSON.parse(readFileSync(thirdPartyLockPath, 'utf8')) as LockContents;
-      expect(stored.port).toBe(next);
+      expect(stored.port).toBe(actualPort);
     } finally {
       await closeNetServer(occupant);
     }


### PR DESCRIPTION
## Related Issue

Resolve #937

## Problem

See #937 for the full report.

`packages/server/test/start.test.ts` had a flaky assertion that assumed `startServer` would always bind to exactly `port + 1` when `port` was occupied. Under vitest's concurrent workers, another test could grab `port + 1` in the window between allocation and binding, causing `startServer` to advance to `port + 2` or higher and the strict equality check to fail.

## What changed

- Relaxed the integration assertion to verify the server bound to a port `>= port + 1` instead of requiring exactly `port + 1`.
- Added a check that the lock file records the actual bound port, preserving the invariant that `status`/`kill`/`ps` will work.
- Renamed the test title from "retries on port+1" to "retries to a higher port" to match the looser assertion.

The exact `+1 / +2 / ...` retry strategy is still pinned by the existing unit tests for `listenWithPortRetry`, which use a fake gateway and do not depend on real port allocation.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] This is a test-only fix and needs no changeset.
- [x] This PR needs no doc update.
