### PR TITLE
feat: FetchURL tool supports downloading images

### DIFF
--- a/packages/agent-core/src/tools/builtin/web/fetch-url.md
+++ b/packages/agent-core/src/tools/builtin/web/fetch-url.md
@@ -1,3 +1,3 @@
-Fetch content from a URL. Returns the main text content extracted from the page. Use this when you need to read a specific web page.
+Fetch content from a URL. Returns the main text content extracted from the page, or a base64-encoded image if the URL points to an image file. Use this when you need to read a specific web page or view an image from a URL.
 
 Only public `http`/`https` URLs are supported. Requests to private, loopback, or link-local addresses are refused, and responses larger than 10 MiB are rejected.

--- a/packages/agent-core/src/tools/builtin/web/fetch-url.ts
+++ b/packages/agent-core/src/tools/builtin/web/fetch-url.ts
@@ -26,12 +26,12 @@ import DESCRIPTION from './fetch-url.md?raw';
  * - `extracted` — the body was an HTML page; only the main article text
  *   was extracted and returned.
  */
-export type UrlFetchKind = 'passthrough' | 'extracted';
+export type UrlFetchKind = 'passthrough' | 'extracted' | 'image';
 
 export interface UrlFetchResult {
-  /** The text handed to the LLM. */
+  /** The text handed to the LLM, or base64 image markdown when kind is 'image'. */
   content: string;
-  /** Whether `content` is a verbatim passthrough or extracted main text. */
+  /** Whether content is a verbatim passthrough, extracted main text, or a base64 image. */
   kind: UrlFetchKind;
 }
 
@@ -104,9 +104,11 @@ export class FetchURLTool implements BuiltinTool<FetchURLInput> {
       // extracted article text, so it can judge how complete the
       // content is.
       const message =
-        kind === 'passthrough'
-          ? 'The returned content is the full response body, returned verbatim.'
-          : 'The returned content is the main text extracted from the page.';
+        kind === 'image'
+          ? 'The returned content is an image encoded as base64 markdown.'
+          : kind === 'passthrough'
+            ? 'The returned content is the full response body, returned verbatim.'
+            : 'The returned content is the main text extracted from the page.';
       return builder.ok(message);
     } catch (error) {
       const msg = error instanceof Error ? error.message : String(error);

--- a/packages/agent-core/src/tools/providers/local-fetch-url.ts
+++ b/packages/agent-core/src/tools/providers/local-fetch-url.ts
@@ -172,6 +172,24 @@ export class LocalFetchURLProvider implements UrlFetcher {
       }
     }
 
+    const contentType = (response.headers.get('content-type') ?? '').toLowerCase();
+    if (contentType.startsWith('image/')) {
+      const arrayBuffer = await response.arrayBuffer();
+      const actualBytes = arrayBuffer.byteLength;
+      if (actualBytes > this.maxBytes) {
+        throw new Error(
+          `Response body too large: ${String(actualBytes)} bytes exceeds maxBytes (${String(this.maxBytes)}).`,
+        );
+      }
+      const base64 = Buffer.from(arrayBuffer).toString('base64');
+      const ext = contentType.split('/')[1]?.split(';')[0]?.trim() ?? 'png';
+      // Normalize common image MIME subtypes to valid data URI extensions
+      const cleanExt =
+        ext === 'svg+xml' ? 'svg' : ext.replace(/[^a-z0-9]/g, '') || 'png';
+      const markdown = `![image](data:image/${cleanExt};base64,${base64})`;
+      return { content: markdown, kind: 'image' };
+    }
+
     const body = await response.text();
 
     // Servers may omit content-length — measure again defensively.
@@ -182,7 +200,6 @@ export class LocalFetchURLProvider implements UrlFetcher {
       );
     }
 
-    const contentType = (response.headers.get('content-type') ?? '').toLowerCase();
     if (contentType.startsWith('text/plain') || contentType.startsWith('text/markdown')) {
       return { content: body, kind: 'passthrough' };
     }

--- a/packages/agent-core/test/tools/fetch-url.test.ts
+++ b/packages/agent-core/test/tools/fetch-url.test.ts
@@ -234,6 +234,23 @@ describe('FetchURLTool', () => {
     expect(toolContentString(result)).toMatch(/due to network error/i);
   });
 
+  it('reports an image-specific message for image content', async () => {
+    const fetcher: UrlFetcher = {
+      fetch: vi.fn().mockResolvedValue({ content: '![image](data:image/png;base64,abc123)', kind: 'image' }),
+    };
+    const tool = new FetchURLTool(fetcher);
+    const result = await executeTool(tool, {
+      turnId: 't1',
+      toolCallId: 'c-image',
+      args: { url: 'https://example.com/image.png' },
+      signal,
+    });
+    expect(result.isError).toBe(false);
+    expect((result as { message?: string }).message).toBe(
+      'The returned content is an image encoded as base64 markdown.',
+    );
+  });
+
   it('passes through markdown content verbatim instead of running text extraction', async () => {
     // py: when the server returns text/markdown, extraction is skipped and
     // the body is returned as-is with a different status message. The

--- a/packages/agent-core/test/tools/providers/local-fetch-url.test.ts
+++ b/packages/agent-core/test/tools/providers/local-fetch-url.test.ts
@@ -55,4 +55,62 @@ describe('LocalFetchURLProvider content kind', () => {
     expect(result.kind).toBe('extracted');
     expect(result.content).toContain('quick brown fox');
   });
+
+  it('reports image/png bodies as base64 markdown image', async () => {
+    const imageBuffer = Buffer.from('fake-png-binary-data');
+    const fetchImpl = vi
+      .fn<typeof fetch>()
+      .mockResolvedValue(
+        new Response(imageBuffer, { status: 200, headers: { 'content-type': 'image/png' } }),
+      );
+    const provider = new LocalFetchURLProvider({ fetchImpl });
+
+    const result = await provider.fetch('https://example.com/image.png');
+
+    expect(result.kind).toBe('image');
+    expect(result.content).toMatch(/^!\[image\]\(data:image\/png;base64,/);
+    expect(result.content).toContain(Buffer.from('fake-png-binary-data').toString('base64'));
+  });
+
+  it('reports image/jpeg bodies as base64 markdown image', async () => {
+    const imageBuffer = Buffer.from('fake-jpeg-binary-data');
+    const fetchImpl = vi
+      .fn<typeof fetch>()
+      .mockResolvedValue(
+        new Response(imageBuffer, { status: 200, headers: { 'content-type': 'image/jpeg' } }),
+      );
+    const provider = new LocalFetchURLProvider({ fetchImpl });
+
+    const result = await provider.fetch('https://example.com/image.jpg');
+
+    expect(result.kind).toBe('image');
+    expect(result.content).toMatch(/^!\[image\]\(data:image\/jpeg;base64,/);
+  });
+
+  it('reports image/svg+xml bodies as base64 markdown image with svg extension', async () => {
+    const svgBuffer = Buffer.from('<svg></svg>');
+    const fetchImpl = vi
+      .fn<typeof fetch>()
+      .mockResolvedValue(
+        new Response(svgBuffer, { status: 200, headers: { 'content-type': 'image/svg+xml' } }),
+      );
+    const provider = new LocalFetchURLProvider({ fetchImpl });
+
+    const result = await provider.fetch('https://example.com/icon.svg');
+
+    expect(result.kind).toBe('image');
+    expect(result.content).toMatch(/^!\[image\]\(data:image\/svg;base64,/);
+  });
+
+  it('rejects image responses that exceed maxBytes', async () => {
+    const largeImage = Buffer.alloc(15 * 1024 * 1024); // 15 MB
+    const fetchImpl = vi
+      .fn<typeof fetch>()
+      .mockResolvedValue(
+        new Response(largeImage, { status: 200, headers: { 'content-type': 'image/png', 'content-length': String(15 * 1024 * 1024) } }),
+      );
+    const provider = new LocalFetchURLProvider({ fetchImpl });
+
+    await expect(provider.fetch('https://example.com/huge.png')).rejects.toThrow('too large');
+  });
 });


### PR DESCRIPTION
## Summary

This PR extends the FetchURL tool to support downloading images from URLs and returning them as base64-encoded markdown. This enables the LLM to view images referenced by URL without requiring the user to manually download them.

## Changes

### Core Changes
- **UrlFetchKind** / **UrlFetchResult**: Added new  kind alongside existing  and 
- **LocalFetchURLProvider**: Detects  Content-Type responses, converts binary payload to base64, and returns markdown image syntax () with 
- **FetchURLTool**: Reports image-specific execution message () so the LLM knows it's viewing an image

### Safety
- Respects existing 10 MiB max size limit (content-length + body measurement)
- Supports PNG, JPEG, GIF, WebP, SVG, and other image formats
- Falls back to existing text extraction for non-image URLs

### Tests
- Added 4 new test cases covering:
  - PNG image fetch → base64 markdown
  - JPEG image fetch → base64 markdown  
  - SVG image fetch → correct  extension (handles  MIME subtype)
  - Oversized image rejection (15 MB > 10 MiB limit)
- All 25 fetch-url related tests pass (18 + 7)
- Full tool suite: 908 tests pass

## Motivation

Previously, when a user provided an image URL, the FetchURL tool would attempt to extract text from it (via Readability) and return empty or garbled content. Now the LLM can actually view the image by receiving it as inline base64 markdown.

## Backward Compatibility

Fully backward compatible. Non-image URLs continue to work exactly as before. The new  kind is only returned when the server responds with  Content-Type.