### PR TITLE
fix(web): close slash and mention menus on click outside

### DIFF
--- a/.changeset/slash-menu-click-outside.md
+++ b/.changeset/slash-menu-click-outside.md
@@ -1,0 +1,5 @@
+---
+'@moonshot-ai/kimi-web': patch
+---
+
+Close slash and mention menus when clicking outside the composer.

--- a/apps/kimi-web/src/components/chat/Composer.vue
+++ b/apps/kimi-web/src/components/chat/Composer.vue
@@ -134,6 +134,38 @@ const {
 });
 
 // ---------------------------------------------------------------------------
+// Close slash/mention menus on click outside
+// ---------------------------------------------------------------------------
+
+const cinWrapRef = ref<HTMLDivElement | null>(null);
+
+function closeMenus(): void {
+  slashOpen.value = false;
+  mentionOpen.value = false;
+  // Cancel any pending mention lookup so the menu does not re-open after an
+  // outside click while the debounced search is still in flight.
+  if (mentionTimer !== null) {
+    clearTimeout(mentionTimer);
+    mentionTimer = null;
+  }
+  mentionLoading.value = false;
+}
+
+function onComposerDocClick(e: MouseEvent): void {
+  const t = e.target as Node;
+  if (cinWrapRef.value?.contains(t)) return;
+  closeMenus();
+}
+
+watch(() => slashOpen.value || mentionOpen.value, (open) => {
+  if (open) {
+    document.addEventListener('click', onComposerDocClick, true);
+  } else {
+    document.removeEventListener('click', onComposerDocClick, true);
+  }
+});
+
+// ---------------------------------------------------------------------------
 // Input event handler — updates both menus
 // ---------------------------------------------------------------------------
 
@@ -452,6 +484,7 @@ function onDocClick(e: MouseEvent): void {
 
 onUnmounted(() => {
   document.removeEventListener('click', onDocClick, true);
+  document.removeEventListener('click', onComposerDocClick, true);
 });
 
 // Context formatting
@@ -637,7 +670,7 @@ function selectModel(modelId: string): void {
     <!-- Main composer card -->
     <div class="composer-card">
       <!-- Input row with popup menus -->
-      <div class="cin-wrap">
+      <div ref="cinWrapRef" class="cin-wrap">
         <!-- Slash menu (above textarea) -->
         <SlashMenu
           v-if="slashOpen"


### PR DESCRIPTION
Closes #947

This PR closes the slash menu and `@` mention menu when the user clicks outside the composer input area.

### What changed

- Added a `cinWrapRef` to the composer input wrapper.
- Added a document click listener while either menu is open.
- Clicking outside `.cin-wrap` now closes both menus, matching the behavior of other dropdowns in the composer (e.g., the permission dropdown).
- Removed the listener when both menus are closed or when the component unmounts.

### How to verify

1. Open Kimi Web and start a session.
2. Type `/` in the composer — the slash menu appears.
3. Click outside the menu (e.g., on the chat history) — the menu should close.
4. Repeat with `@` — the mention menu should also close on outside click.
5. Confirm that `Esc`, selecting an item, and submitting a message still close the menus as before.

### Notes

- This is a small focused UI fix; no public API changes.
- A changeset has been added for `@moonshot-ai/kimi-web`.
