### PR TITLE
fix(tui): hide context usage when it is 0

### DIFF
--- a/.changeset/tui-hide-zero-context.md
+++ b/.changeset/tui-hide-zero-context.md
@@ -1,0 +1,7 @@
+---
+"@moonshot-ai/kimi-tui": patch
+---
+
+fix(tui): hide context usage when it is 0
+
+Hide the context status line in the footer until there is actual usage to report.

--- a/apps/kimi-code/src/tui/components/chrome/footer.ts
+++ b/apps/kimi-code/src/tui/components/chrome/footer.ts
@@ -199,6 +199,7 @@ function safeUsage(usage: number): number {
 }
 
 function formatContextStatus(usage: number, tokens?: number, maxTokens?: number): string {
+  if (usage <= 0) return '';
   const pct = `${(safeUsage(usage) * 100).toFixed(1)}%`;
   if (maxTokens && maxTokens > 0 && tokens !== undefined) {
     return `context: ${pct} (${formatTokenCount(tokens)}/${formatTokenCount(maxTokens)})`;


### PR DESCRIPTION
When a session starts, context usage is 0. Displaying 'context: 0.0%' in the footer is misleading because it implies the context window is empty. Instead, hide the context status line until there is actual usage to report.

**Before:**
- Footer shows  on a fresh session

**After:**
- Footer hides the context line when 
- Context status appears only after tokens have actually been consumed

**Test:**
- Existing footer tests pass (3/3)

Fixes: initial Context usage should not show 0 or should be hidden.