### PR TITLE
feat(agent-core): add thinkingLevel to compaction telemetry

### DIFF
--- a/packages/agent-core/src/agent/compaction/full.ts
+++ b/packages/agent-core/src/agent/compaction/full.ts
@@ -344,6 +344,7 @@ export class FullCompaction {
         compactedCount: result.compactedCount,
         retryCount,
         round,
+        thinkingLevel: this.agent.config.thinkingLevel,
         ...usage,
         ...data,
       });
@@ -357,6 +358,7 @@ export class FullCompaction {
         duration: Date.now() - startedAt,
         round,
         retryCount,
+        thinkingLevel: this.agent.config.thinkingLevel,
         errorType: error instanceof Error ? error.name : 'Unknown',
       });
       if (isKimiError(error) && error.code === ErrorCodes.AUTH_LOGIN_REQUIRED) throw error;

--- a/packages/agent-core/src/agent/compaction/micro.ts
+++ b/packages/agent-core/src/agent/compaction/micro.ts
@@ -90,6 +90,7 @@ export class MicroCompaction {
         cutoff: nextCutoff,
         message_count: history.length,
         cache_age_ms: cacheAgeMs,
+        thinkingLevel: this.agent.config.thinkingLevel,
       });
     }
   }

--- a/packages/agent-core/test/agent/compaction/full.test.ts
+++ b/packages/agent-core/test/agent/compaction/full.test.ts
@@ -240,6 +240,7 @@ describe('FullCompaction', () => {
         duration: expect.any(Number),
         compactedCount: 6,
         retryCount: 0,
+        thinkingLevel: 'off',
         inputOther: 520,
         output: 8,
         inputCacheRead: 0,
@@ -1589,6 +1590,7 @@ describe('FullCompaction', () => {
 
   it('preserves thinking effort when compacting after provider context overflow', async () => {
     let callCount = 0;
+    const records: TelemetryRecord[] = [];
     const providerThinkingEfforts: Array<Parameters<GenerateFn>[0]['thinkingEffort']> = [];
     const generate: GenerateFn = async (provider, _system, _tools, _history, callbacks) => {
       callCount += 1;
@@ -1612,7 +1614,7 @@ describe('FullCompaction', () => {
       }
       throw new Error(`Unexpected generate call ${String(callCount)}`);
     };
-    const ctx = testAgent({ generate });
+    const ctx = testAgent({ generate, telemetry: recordingTelemetry(records) });
     ctx.configure({
       provider: CATALOGUED_PROVIDER,
       modelCapabilities: CATALOGUED_MODEL_CAPABILITIES,
@@ -1626,6 +1628,13 @@ describe('FullCompaction', () => {
 
     expect(callCount).toBe(3);
     expect(providerThinkingEfforts).toEqual(['high', 'high', 'high']);
+    expect(records).toContainEqual({
+      event: 'compaction_finished',
+      properties: expect.objectContaining({
+        source: 'auto',
+        thinkingLevel: 'high',
+      }),
+    });
   });
 
   it('compacts provider overflow when model context size is unknown', async () => {

--- a/packages/agent-core/test/agent/compaction/micro.test.ts
+++ b/packages/agent-core/test/agent/compaction/micro.test.ts
@@ -482,6 +482,7 @@ describe('MicroCompaction', () => {
       truncatedToolResultTokensAfter: expect.any(Number),
       tokensBefore: expect.any(Number),
       tokensAfter: expect.any(Number),
+      thinkingLevel: 'off',
     });
     expect(numberProperty(event, 'truncatedToolResultTokensBefore')).toBeGreaterThan(
       numberProperty(event, 'truncatedToolResultTokensAfter'),


### PR DESCRIPTION
## Related Issue

No linked issue — see Problem below.

## Problem

Compaction telemetry (`compaction_finished`, `compaction_failed`, `micro_compaction_finished`) already reports token counts, duration, retry count, etc., but not whether thinking mode was enabled or which thinking effort was used for the compaction LLM call. Thinking materially affects compaction token usage, latency, and even failure modes (e.g. think-only empty responses), so today we cannot correlate compaction behavior with thinking configuration from telemetry alone.

## What changed

- Added a `thinkingLevel` field to `compaction_finished`, `compaction_failed`, and `micro_compaction_finished` telemetry events, with values `off` / `low` / `medium` / `high` / `xhigh` / `max`.
- The value is read from `this.agent.config.thinkingLevel`, the same source used to build the compaction provider (`config.provider` applies `withThinking(this.thinkingLevel)`), so it reflects the effective effort, including the always-thinking-model clamp.
- Extended the existing full- and micro-compaction test cases to assert the new field (default `off`, and `high` when configured).

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset. (telemetry-only change — no changeset)
- [x] Ran `gen-docs` skill, or this PR needs no doc update. (internal telemetry — no user-facing doc change)