### PR TITLE
fix(web): keep page title static instead of tracking session or workspace

### DIFF
--- a/.changeset/web-static-page-title.md
+++ b/.changeset/web-static-page-title.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Keep the web page title fixed instead of changing with the session or workspace name.

--- a/apps/kimi-web/src/App.vue
+++ b/apps/kimi-web/src/App.vue
@@ -109,7 +109,8 @@ function blinkAuthLogo(): void {
 }
 
 
-// Dynamic page title: session title first, then workspace name, then app name.
+// Static page title (app name only). The session title and workspace name are
+// intentionally excluded so the tab title stays stable.
 // Prefix an animated spinner when the agent is running so users can see activity
 // at a glance.
 const SPINNER_FRAMES = ['◐', '◓', '◑', '◒'];
@@ -140,10 +141,6 @@ watch(running, (isRunning) => {
 const pageTitle = computed<string>(() => {
   const prefix = running.value ? `${SPINNER_FRAMES[spinnerFrame.value]} ` : '';
   if (showAuthGate.value) return `${prefix}${t('app.authPageTitle')} - Kimi Code Web`;
-  const sessionTitle = activeSessionTitle.value;
-  if (sessionTitle) return `${prefix}${sessionTitle} - Kimi Code Web`;
-  const workspaceName = client.visibleWorkspace.value?.name;
-  if (workspaceName) return `${prefix}${workspaceName} - Kimi Code Web`;
   return `${prefix}Kimi Code Web`;
 });
 watchEffect(() => {


### PR DESCRIPTION
## Related Issue

No linked issue; this came from a direct request to keep the web tab title stable.

## Problem

The web tab title used to change whenever the active session title or the workspace name updated, which made the browser tab hard to identify at a glance.

## What changed

The web page title is now fixed to the app name (with the auth-gate variant) instead of reflecting the session or workspace name. The animated running indicator in front of the title is kept so activity is still visible at a glance.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [ ] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.
