### PR TITLE
feat(hooks): include assistant response text in Stop hook payload

### DIFF
--- a/.changeset/stop-hook-response-text.md
+++ b/.changeset/stop-hook-response-text.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Include assistant response text in the Stop hook payload for conversation logging.

--- a/packages/agent-core/src/agent/turn/index.ts
+++ b/packages/agent-core/src/agent/turn/index.ts
@@ -682,9 +682,23 @@ export class TurnFlow {
               // 3. The external Stop hook gets exactly one continuation; the cap
               //    is intentionally separate from (and does not cap) goal mode.
               if (!stopHookContinuationUsed) {
+                // Extract the last assistant response text for the Stop hook payload.
+                const lastAssistant = [...this.agent.context.history]
+                  .reverse()
+                  .find((m) => m.role === 'assistant');
+                const responseText = lastAssistant
+                  ? (lastAssistant.content ?? [])
+                      .filter((c) => c.type === 'text')
+                      .map((c) => ('text' in c ? c.text : ''))
+                      .join('')
+                  : null;
+
                 const stopBlock = await this.agent.hooks?.triggerBlock('Stop', {
                   signal,
-                  inputData: { stopHookActive: stopHookContinuationUsed },
+                  inputData: {
+                    stopHookActive: stopHookContinuationUsed,
+                    responseText: responseText || null,
+                  },
                 });
                 signal.throwIfAborted();
                 if (stopBlock !== undefined) {


### PR DESCRIPTION
Fixes #952

## Problem

The Stop hook payload only contains `stop_hook_active` and basic fields (session_id, cwd). Users building persistent session memory or conversation logging on top of Kimi Code hooks have no way to access the assistant response text.

## What changed

Added an optional `responseText` field to the Stop hook payload. It extracts the last assistant message text from the conversation history before the Stop hook fires.

- `responseText` is `null` when the assistant response is empty
- Fully backward compatible — existing hooks that do not read this field are unaffected
- No changes to hook execution flow or timing

## Validation

- The extraction happens right before `triggerBlock(Stop, ...)` is called
- Only text content parts are joined — tool calls and images are excluded
- `null` is passed when there is no assistant message (edge case)