### PR TITLE
fix(agent-core): detect image format from bytes when reading media

### DIFF
--- a/.changeset/fix-read-media-image-format.md
+++ b/.changeset/fix-read-media-image-format.md
@@ -1,0 +1,6 @@
+---
+"@moonshot-ai/agent-core": patch
+"@moonshot-ai/kimi-code": patch
+---
+
+Detect the real image format from file contents when reading media, so a mismatched filename extension no longer produces a data URL the model API rejects.

--- a/packages/agent-core/src/tools/support/file-type.ts
+++ b/packages/agent-core/src/tools/support/file-type.ts
@@ -374,17 +374,31 @@ export function detectFileType(
       }
       return sniffed;
     }
-    if (
-      type === 'media' &&
-      mediaHint !== null &&
-      mediaHint.kind !== 'text'
-    ) {
-      return mediaHint;
+    // Sniff failed. In media mode, only video falls back to the extension:
+    // some video containers (e.g. MPEG-PS `.mpg`) have no magic we recognise,
+    // so the extension is the only signal. Every image format the model
+    // accepts (PNG/JPEG/GIF/WebP) has a reliable magic signature, so a failed
+    // sniff on an image means it is not a supported image — returning the
+    // extension MIME would only produce a mismatched data URL the model API
+    // rejects. (Runs before the NUL check so a video extension wins even when
+    // the header happens to contain a 0x00 byte.)
+    if (type === 'media') {
+      if (mediaHint?.kind === 'video') {
+        return mediaHint;
+      }
+      if (mediaHint?.kind === 'image') {
+        return { kind: 'unknown', mimeType: '' };
+      }
     }
     if (buf.includes(0x00)) {
       return { kind: 'unknown', mimeType: '' };
     }
-    // No sniff and no NUL: fall through to hint / text / unknown logic.
+    // No sniff and no NUL (text mode): still do not trust an image extension
+    // hint, for the same reason as above. Anything else falls through to the
+    // hint / text / unknown logic.
+    if (mediaHint?.kind === 'image') {
+      return { kind: 'unknown', mimeType: '' };
+    }
   }
 
   if (mediaHint) return mediaHint;

--- a/packages/agent-core/test/tools/file-type.test.ts
+++ b/packages/agent-core/test/tools/file-type.test.ts
@@ -212,6 +212,15 @@ describe('detectFileType', () => {
     expect(detectFileType('clip.mpg', mpegProgramStreamHeader).kind).toBe('unknown');
   });
 
+  it('returns unknown for an image extension whose bytes fail to sniff', () => {
+    // A `.png` file with no recognisable image magic and no NUL byte must not
+    // be reported as `image/png` — otherwise a media reader would ship a
+    // mismatched data URL that the model API rejects as
+    // `application/octet-stream`.
+    const garbage = Buffer.from('plain ascii, definitely not a png');
+    expect(detectFileType('fake.png', garbage).kind).toBe('unknown');
+  });
+
   it('extension in NON_TEXT_SUFFIXES → unknown', () => {
     // A `.zip` file with no header and no image/video hint must not
     // be treated as text.

--- a/packages/agent-core/test/tools/read-media.test.ts
+++ b/packages/agent-core/test/tools/read-media.test.ts
@@ -582,4 +582,73 @@ describe('ReadMediaFileTool', () => {
     expect(relative.isError).toBe(true);
     expect(readBytes).not.toHaveBeenCalled();
   });
+
+  it('uses the sniffed MIME over a mismatched image extension', async () => {
+    // `.png` path but JPEG bytes — the data URL must advertise `image/jpeg`
+    // (the real bytes), not `image/png` (the extension), otherwise the model
+    // API rejects it as `application/octet-stream`.
+    const data = Buffer.concat([Buffer.from([0xff, 0xd8, 0xff, 0xe0]), Buffer.from('jpegdata')]);
+    const tool = makeReadMediaTool({
+      stat: vi.fn<Kaos['stat']>().mockResolvedValue({ ...DEFAULT_STAT, stSize: data.length }),
+      readBytes: vi.fn<Kaos['readBytes']>().mockResolvedValue(data),
+    });
+
+    const result = await executeTool(tool, {
+      turnId: 't1',
+      toolCallId: 'c_mismatch',
+      args: { path: '/workspace/actually-jpeg.png' },
+      signal,
+    });
+
+    const parts = outputParts(result);
+    expect((parts[2] as { imageUrl: { url: string } }).imageUrl.url).toBe(
+      `data:image/jpeg;base64,${data.toString('base64')}`,
+    );
+  });
+
+  it('ships sniffed image formats to the provider without gating', async () => {
+    // A `.png` file that is actually a BMP is reported as `image/bmp`. The
+    // tool does not gate on image format — it ships the real bytes with the
+    // sniffed MIME, and the provider decides which formats it accepts.
+    const data = Buffer.concat([Buffer.from('BM'), Buffer.from('bmpdata')]);
+    const tool = makeReadMediaTool({
+      stat: vi.fn<Kaos['stat']>().mockResolvedValue({ ...DEFAULT_STAT, stSize: data.length }),
+      readBytes: vi.fn<Kaos['readBytes']>().mockResolvedValue(data),
+    });
+
+    const result = await executeTool(tool, {
+      turnId: 't1',
+      toolCallId: 'c_bmp',
+      args: { path: '/workspace/photo.png' },
+      signal,
+    });
+
+    const parts = outputParts(result);
+    expect((parts[2] as { imageUrl: { url: string } }).imageUrl.url).toBe(
+      `data:image/bmp;base64,${data.toString('base64')}`,
+    );
+  });
+
+  it('rejects a media-extension file whose bytes are not a supported image', async () => {
+    // `.png` path with garbage bytes (no NUL) fails to sniff; the tool must
+    // report "not a supported image or video file" instead of building a
+    // mismatched data URL.
+    const data = Buffer.from('this is not an image, just plain ascii text');
+    const tool = makeReadMediaTool({
+      stat: vi.fn<Kaos['stat']>().mockResolvedValue({ ...DEFAULT_STAT, stSize: data.length }),
+      readBytes: vi.fn<Kaos['readBytes']>().mockResolvedValue(data),
+    });
+
+    const result = await executeTool(tool, {
+      turnId: 't1',
+      toolCallId: 'c_garbage',
+      args: { path: '/workspace/fake.png' },
+      signal,
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.output).toBe(
+      '"/workspace/fake.png" is not a supported image or video file. Use Read for text files, or Bash or an MCP tool for other binary formats.',
+    );
+  });
 });


### PR DESCRIPTION
## Related Issue

No related issue.

## Problem

When `ReadMediaFile` reads a file whose extension claims an image but whose bytes are not a recognised image (for example a `.png` that is actually plain text, or a truncated/renamed file), `detectFileType` fell back to the extension's MIME type and built a `data:` URL whose bytes did not match the declared format. The model API then rejects the request with `400 Invalid request: unsupported image format: application/octet-stream`, failing the turn.

## What changed

- Detect the image MIME from the file bytes (magic-byte sniff) instead of trusting the extension, so a mismatched extension no longer yields a mismatched data URL.
- Return `unknown` for an image extension whose bytes fail to sniff, so `ReadMediaFile` reports a clear "not a supported image or video file" error instead of shipping a bad data URL. Every image format the model accepts (PNG/JPEG/GIF/WebP) has a reliable magic signature, so a failed sniff means the bytes are not a supported image.
- Keep the extension fallback for video containers with no magic signature (for example MPEG-PS `.mpg`). Beyond the sniff-failed image case, format acceptance is left to the provider — the tool does not gate on image format.
- Added regression tests for the mismatched-extension, sniffed-but-unsupported-extension, and un-sniffable cases.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.
