### PR TITLE
fix(web): stop showing unread dots for cancelled or failed sessions

### DIFF
--- a/.changeset/fix-web-unread-aborted.md
+++ b/.changeset/fix-web-unread-aborted.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Stop showing unread dots on cancelled or failed sessions in the web sidebar.

--- a/apps/kimi-web/src/composables/useKimiWebClient.ts
+++ b/apps/kimi-web/src/composables/useKimiWebClient.ts
@@ -997,7 +997,7 @@ function connectEventsIfNeeded(): void {
         appEvent.type === 'sessionStatusChanged' &&
         (appEvent.status === 'idle' || appEvent.status === 'aborted')
       ) {
-        onSessionIdle(appEvent.sessionId);
+        onSessionIdle(appEvent.sessionId, appEvent.status);
       }
 
       // Permission auto-approve: CLIENT-SIDE POLICY until the daemon exposes a
@@ -2607,7 +2607,7 @@ const availableOpenInApps = computed<string[]>(() => rawState.availableOpenInApp
 // prompt to it was silently enqueued and never flushed.
 // ---------------------------------------------------------------------------
 
-function onSessionIdle(sid: string): void {
+function onSessionIdle(sid: string, status: 'idle' | 'aborted'): void {
   // The turn finished — this session no longer has a prompt in flight.
   inFlightPromptSessions.delete(sid);
   rawState.sendingBySession = { ...rawState.sendingBySession, [sid]: false };
@@ -2625,9 +2625,11 @@ function onSessionIdle(sid: string): void {
     resetFastMoon();
     void loadGitStatus(sid);
     void refreshSessionStatus(sid);
-  } else {
-    // A background session just finished a turn the user hasn't seen — light up
-    // its unread dot until they open it.
+  } else if (status === 'idle') {
+    // A background session finished a turn the user hasn't seen — light up its
+    // unread dot until they open it. Aborted (cancelled/failed) turns are
+    // excluded on purpose: there is no fresh result to read, and counting them
+    // is what made the sidebar fill with stale unreads after a refresh.
     rawState.unreadBySession = { ...rawState.unreadBySession, [sid]: true };
     saveUnreadToStorage(rawState.unreadBySession);
   }


### PR DESCRIPTION
## Related Issue

N/A — reported directly by a user.

## Problem

The web sidebar lights up an unread blue dot for any background session whose turn ends, including sessions that were cancelled or failed. Those flags are persisted to `localStorage`, so after a page refresh the sidebar fills with stale unread dots even though there is no new reply to read.

## What changed

Only mark a session as unread when its turn finishes normally (`idle`). Cancelled / failed turns (`aborted`) still run their in-flight and queue cleanup, but no longer set the unread flag.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [ ] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.