### PR TITLE
fix(web): clear all per-session state when archiving or removing a session

### DIFF
--- a/.changeset/fix-web-forget-session.md
+++ b/.changeset/fix-web-forget-session.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Clear all per-session state when a session is archived or removed, so archived sessions no longer leave orphaned data behind.

--- a/apps/kimi-web/src/api/daemon/ws.ts
+++ b/apps/kimi-web/src/api/daemon/ws.ts
@@ -160,6 +160,10 @@ export class DaemonEventSocket {
   /** Unsubscribe from a session's events. */
   unsubscribe(sessionId: string): void {
     this.subscriptions.delete(sessionId);
+    // Also cancel a subscribe that was queued before server_hello; otherwise
+    // onServerHello would merge it back into the active subscription set.
+    const pendingIdx = this.pendingSubscriptions.findIndex((p) => p.sessionId === sessionId);
+    if (pendingIdx !== -1) this.pendingSubscriptions.splice(pendingIdx, 1);
     if (this.connected && this.ws) {
       this.send({
         type: 'unsubscribe',

--- a/apps/kimi-web/src/composables/client/useWorkspaceState.ts
+++ b/apps/kimi-web/src/composables/client/useWorkspaceState.ts
@@ -64,7 +64,7 @@ export interface UseWorkspaceStateDeps {
   updateSession: (id: string, update: (session: AppSession) => AppSession) => void;
   upsertSessionFront: (session: AppSession) => void;
   appendSession: (session: AppSession) => void;
-  removeSession: (id: string) => void;
+  forgetSession: (id: string) => void;
   setActiveSessionId: (id: string | undefined) => void;
   /** Update one session's message list via a function of the current list. */
   updateSessionMessages: (
@@ -110,7 +110,7 @@ export function useWorkspaceState(rawState: ExtendedState, deps: UseWorkspaceSta
     updateSession,
     upsertSessionFront,
     appendSession,
-    removeSession,
+    forgetSession,
     setActiveSessionId,
     updateSessionMessages,
     nextOptimisticMsgId,
@@ -1322,7 +1322,7 @@ export function useWorkspaceState(rawState: ExtendedState, deps: UseWorkspaceSta
     try {
       const api = getKimiWebApi();
       await api.archiveSession(id);
-      removeSession(id);
+      forgetSession(id);
       sideChat.clearSideChatForSession(id);
       const { [id]: _removedIds, ...restIds } = rawState.sideChatUserMessageIdsBySession;
       void _removedIds;

--- a/apps/kimi-web/src/composables/useKimiWebClient.ts
+++ b/apps/kimi-web/src/composables/useKimiWebClient.ts
@@ -442,6 +442,28 @@ function removeSessionMessages(sessionId: string): void {
   rawState.messagesBySession = rest;
 }
 
+// ---------------------------------------------------------------------------
+// Session teardown — single place that wipes a session and all its per-session
+// sidecar state. Both removal entry points (not-found + archive) go through
+// this, so adding a new per-session map only ever needs one new line here.
+// ---------------------------------------------------------------------------
+function forgetSession(sessionId: string): void {
+  removeSession(sessionId);
+  removeSessionMessages(sessionId);
+  delete rawState.approvalsBySession[sessionId];
+  delete rawState.questionsBySession[sessionId];
+  delete rawState.tasksBySession[sessionId];
+  delete rawState.goalBySession[sessionId];
+  delete rawState.gitStatusBySession[sessionId];
+  delete rawState.lastSeqBySession[sessionId];
+  delete rawState.compactionBySession[sessionId];
+  delete rawState.messagesLoadingMoreBySession[sessionId];
+  delete rawState.messagesHasMoreBySession[sessionId];
+  delete rawState.messagesLoadMoreErrorBySession[sessionId];
+  delete epochBySession[sessionId];
+  sessionsKnownEmpty.delete(sessionId);
+}
+
 // Models + Providers reactive state and helpers live in
 // ./client/useModelProviderState. It is instantiated below (after the
 // `activity` computed it depends on) as `modelProvider`.
@@ -894,20 +916,7 @@ function goalErrorMessage(err: unknown): string | undefined {
 }
 
 async function handleSessionNotFound(sessionId: string): Promise<void> {
-  removeSession(sessionId);
-  removeSessionMessages(sessionId);
-  delete rawState.approvalsBySession[sessionId];
-  delete rawState.questionsBySession[sessionId];
-  delete rawState.tasksBySession[sessionId];
-  delete rawState.goalBySession[sessionId];
-  delete rawState.gitStatusBySession[sessionId];
-  delete rawState.lastSeqBySession[sessionId];
-  delete rawState.compactionBySession[sessionId];
-  delete rawState.messagesLoadingMoreBySession[sessionId];
-  delete rawState.messagesHasMoreBySession[sessionId];
-  delete rawState.messagesLoadMoreErrorBySession[sessionId];
-  delete epochBySession[sessionId];
-  sessionsKnownEmpty.delete(sessionId);
+  forgetSession(sessionId);
 
   if (rawState.activeSessionId !== sessionId) return;
 
@@ -1835,7 +1844,7 @@ const workspaceState = useWorkspaceState(rawState, {
   updateSession,
   upsertSessionFront,
   appendSession,
-  removeSession,
+  forgetSession,
   setActiveSessionId,
   updateSessionMessages,
   nextOptimisticMsgId,

--- a/apps/kimi-web/src/composables/useKimiWebClient.ts
+++ b/apps/kimi-web/src/composables/useKimiWebClient.ts
@@ -462,6 +462,14 @@ function forgetSession(sessionId: string): void {
   delete rawState.messagesLoadMoreErrorBySession[sessionId];
   delete epochBySession[sessionId];
   sessionsKnownEmpty.delete(sessionId);
+  // In-flight / queued prompt state: drop these too so a queued follow-up
+  // can't be submitted to a session that was just archived when its turn later
+  // goes idle (onSessionIdle drains queuedBySession[sid] without re-checking
+  // that the session still exists).
+  inFlightPromptSessions.delete(sessionId);
+  delete rawState.queuedBySession[sessionId];
+  delete rawState.promptIdBySession[sessionId];
+  delete rawState.sendingBySession[sessionId];
 }
 
 // Models + Providers reactive state and helpers live in

--- a/apps/kimi-web/src/composables/useKimiWebClient.ts
+++ b/apps/kimi-web/src/composables/useKimiWebClient.ts
@@ -448,6 +448,10 @@ function removeSessionMessages(sessionId: string): void {
 // this, so adding a new per-session map only ever needs one new line here.
 // ---------------------------------------------------------------------------
 function forgetSession(sessionId: string): void {
+  // Stop receiving events for this session BEFORE clearing its state: a late or
+  // buffered event for this id would otherwise be reduced and recreate the very
+  // per-session maps we are about to delete.
+  eventConn?.unsubscribe(sessionId);
   removeSession(sessionId);
   removeSessionMessages(sessionId);
   delete rawState.approvalsBySession[sessionId];


### PR DESCRIPTION
## Related Issue

N/A — follow-up to the web client structure refactor in #979.

## Problem

The two entry points that remove a session cleaned up per-session state inconsistently:

- `handleSessionNotFound` cleared ~13 fields (messages, approvals, questions, tasks, goal, git status, cursors, etc.).
- `archiveSession` cleared only the session list, side-chat state, and the active-session pointer — leaving the same ~13 per-session maps behind as orphaned data for the archived session.

This is the kind of "change is not thorough" bug that motivated the setter consolidation in #979: adding a new per-session map required remembering to update both teardown sites, and `archiveSession` had drifted.

## What changed

Add `forgetSession(id)` in the facade (next to the existing state setters) as the single place session teardown lives: it drops the session from the list and wipes every per-session sidecar map. Both entry points now route through it:

- `handleSessionNotFound(id)` → `forgetSession(id)` (replaces its inline teardown).
- `archiveSession(id)` → `forgetSession(id)` plus its existing side-chat-specific cleanup and active-session fallback.

Behavior change: archiving a session now also clears its messages / approvals / questions / tasks / etc. (previously leaked). This is the intended fix.

Verified with `typecheck`, `test` (26), `build`, and `oxlint` (0 errors).

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [ ] I have added tests that prove my feature works. (N/A — no component-test infra in `apps/kimi-web`; covered by `typecheck` + existing pure-logic tests.)
- [x] Ran `gen-changesets` skill, or this PR needs no changeset. (Patch on `@moonshot-ai/kimi-code`; `@moonshot-ai/kimi-web` is ignored and bundled into the CLI.)
- [x] Ran `gen-docs` skill, or this PR needs no doc update. (No user-facing config or command change.)
