### PR TITLE
fix(web): remove broken dev:stub script and references

### DIFF
--- a/.changeset/remove-dev-stub.md
+++ b/.changeset/remove-dev-stub.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-web": patch
+---
+
+Remove the broken `dev:stub` script and its documentation references because `dev/stub-daemon.mjs` no longer exists on `main`.

--- a/apps/kimi-web/AGENTS.md
+++ b/apps/kimi-web/AGENTS.md
@@ -36,7 +36,6 @@ The browser web UI for Kimi Code — a peer to the TUI in `apps/kimi-code`. It t
 All via `pnpm --filter @moonshot-ai/kimi-web …`:
 
 - `dev` — Vite dev server (port `WEB_PORT`, default 5175; proxies `/api/v1` to `KIMI_SERVER_URL`, default `http://127.0.0.1:58627`).
-- `dev:stub` — offline stub daemon (`dev/stub-daemon.mjs`).
 - `build` — production build into `dist/`.
 - `typecheck` — `vue-tsc --noEmit`.
 - `test` — `vitest run` (pure logic tests only; no jsdom / component tests).

--- a/apps/kimi-web/README.md
+++ b/apps/kimi-web/README.md
@@ -8,12 +8,9 @@ to a local **server** over REST + WebSocket. Vue 3 + Vite + TypeScript.
 ## Quick start
 
 ```bash
-# 1) Against a REAL server (the server must be running and reachable)
+# Against a REAL server (the server must be running and reachable)
 WEB_PORT=5197 KIMI_SERVER_URL=http://192.168.97.91:58627 pnpm -C apps/kimi-web run dev
 #   …or from the repo root:  pnpm dev:web   (uses the defaults below)
-
-# 2) Offline / no server — a stub that fakes the server API + event stream
-pnpm -C apps/kimi-web run dev:stub      # then run dev in another shell
 
 # checks
 pnpm -C apps/kimi-web run typecheck     # vue-tsc --noEmit

--- a/apps/kimi-web/package.json
+++ b/apps/kimi-web/package.json
@@ -6,7 +6,6 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "dev:stub": "node dev/stub-daemon.mjs",
     "build": "vite build",
     "typecheck": "vue-tsc --noEmit",
     "test": "vitest run"

--- a/apps/kimi-web/vite.config.ts
+++ b/apps/kimi-web/vite.config.ts
@@ -4,8 +4,8 @@ import tailwindcss from '@tailwindcss/vite';
 import { readFileSync } from 'node:fs';
 
 const webPort = Number(process.env.WEB_PORT) || 5175;
-// Where the dev proxy forwards server traffic. Defaults to the local server
-// (or `pnpm dev:stub`). Override to point dev at another server instance.
+// Where the dev proxy forwards server traffic. Defaults to the local server.
+// Override to point dev at another server instance.
 const serverTarget = process.env.KIMI_SERVER_URL || 'http://127.0.0.1:58627';
 const pkg = JSON.parse(readFileSync(new URL('./package.json', import.meta.url), 'utf-8')) as {
   version: string;


### PR DESCRIPTION
Fixes #949

The `dev:stub` script in `apps/kimi-web/package.json` points to `dev/stub-daemon.mjs`, but that file does not exist on `main`. Running `pnpm -C apps/kimi-web run dev:stub` fails with `MODULE_NOT_FOUND`.

Since the stub daemon is no longer maintained and the real server is the supported development path, remove the broken script and all documentation references rather than leaving a misleading command in place.

Changes:
- Remove `"dev:stub": "node dev/stub-daemon.mjs"` from `apps/kimi-web/package.json`
- Remove the offline stub section from `apps/kimi-web/README.md`
- Remove the `dev:stub` command entry from `apps/kimi-web/AGENTS.md`
- Update the comment in `apps/kimi-web/vite.config.ts` to no longer mention `dev:stub`

No changeset is needed because `@moonshot-ai/kimi-web` is a private internal package and this change only affects the local development workflow.