### PR TITLE
fix(mcp): default stdio server cwd to the session directory

### DIFF
--- a/.changeset/fix-mcp-stdio-cwd-in-web.md
+++ b/.changeset/fix-mcp-stdio-cwd-in-web.md
@@ -1,0 +1,14 @@
+---
+'@moonshot-ai/agent-core': patch
+---
+
+fix(mcp): default stdio server cwd to the session directory for user and project-local configs
+
+When `kimi web` launches the background server daemon, the server process runs from `~/.kimi-code/server`. stdio MCP servers that did not explicitly set `cwd` therefore inherited that directory instead of the user's project directory, breaking workspace-relative storage (e.g. memory MCP servers).
+
+`loadMcpServers` now assigns a sensible default `cwd` to every config source:
+- user-global `~/.kimi-code/mcp.json` → session working directory
+- repo-root `.mcp.json` → repo root (unchanged)
+- project-local `.kimi-code/mcp.json` → session working directory
+
+This makes stdio MCP behavior consistent between `kimi` and `kimi web`.

--- a/packages/agent-core/src/mcp/config-loader.ts
+++ b/packages/agent-core/src/mcp/config-loader.ts
@@ -52,9 +52,9 @@ export async function loadMcpServers(
 ): Promise<Record<string, McpServerConfig>> {
   const paths = await resolveMcpJsonPaths({ cwd: input.cwd, homeDir: input.homeDir });
   const [user, projectRoot, project] = await Promise.all([
-    readMcpJson(paths.user),
+    readMcpJson(paths.user, { stdioCwdBase: input.cwd }),
     readMcpJson(paths.projectRoot, { stdioCwdBase: dirname(paths.projectRoot) }),
-    readMcpJson(paths.project),
+    readMcpJson(paths.project, { stdioCwdBase: input.cwd }),
   ]);
   return { ...user, ...projectRoot, ...project };
 }

--- a/packages/agent-core/test/mcp/config-loader.test.ts
+++ b/packages/agent-core/test/mcp/config-loader.test.ts
@@ -81,10 +81,12 @@ describe('loadMcpServers', () => {
     expect(servers['shared']).toEqual({
       transport: 'stdio',
       command: 'shared-project',
+      cwd,
     });
     expect(servers['userOnly']).toEqual({
       transport: 'stdio',
       command: 'user-only',
+      cwd,
     });
     expect(servers['local']).toEqual({
       transport: 'http',
@@ -129,9 +131,10 @@ describe('loadMcpServers', () => {
     expect(servers['shared']).toEqual({
       transport: 'stdio',
       command: 'shared-project',
+      cwd,
     });
     expect(servers['rootOnly']).toEqual({ transport: 'stdio', command: 'root-only', cwd: repoRoot });
-    expect(servers['userOnly']).toEqual({ transport: 'stdio', command: 'user-only' });
+    expect(servers['userOnly']).toEqual({ transport: 'stdio', command: 'user-only', cwd });
     expect(servers['projectOnly']).toEqual({ transport: 'http', url: 'https://mcp.example.com' });
   });
 
@@ -225,6 +228,7 @@ describe('loadMcpServers', () => {
       transport: 'stdio',
       command: 'npx',
       args: ['-y', '@modelcontextprotocol/server-github'],
+      cwd,
     });
   });
 
@@ -275,7 +279,7 @@ describe('loadMcpServers', () => {
     process.env['KIMI_CODE_HOME'] = home;
     try {
       const servers = await loadMcpServers({ cwd });
-      expect(servers['from_env']).toEqual({ transport: 'stdio', command: 'env-cmd' });
+      expect(servers['from_env']).toEqual({ transport: 'stdio', command: 'env-cmd', cwd });
     } finally {
       if (saved === undefined) delete process.env['KIMI_CODE_HOME'];
       else process.env['KIMI_CODE_HOME'] = saved;


### PR DESCRIPTION
When kimi web launches the background server daemon, the server process runs from ~/.kimi-code/server. stdio MCP servers that omitted cwd therefore inherited that directory instead of the user's project directory, breaking workspace-relative storage.

loadMcpServers now assigns a sensible default cwd to every config source:
- user-global ~/.kimi-code/mcp.json -> session working directory
- repo-root .mcp.json -> repo root (unchanged)
- project-local .kimi-code/mcp.json -> session working directory

Closes #982

## Problem

When launching a session via `kimi web`, Kimi Code starts a long-lived background daemon whose working directory is intentionally set to `~/.kimi-code/server` (to avoid pinning the caller's directory on Windows). As a result, any stdio MCP server that omits `cwd` in its config inherited the daemon's directory instead of the user's project directory.

Session-context tools were unaffected because they resolve the active workspace at request time, but storage-oriented tools (e.g. custom memory/note MCP servers) wrote data into a server-side workspace, making `kimi web` behave differently from local `kimi`.

## Root cause

`packages/agent-core/src/mcp/config-loader.ts` only supplied a default `stdioCwdBase` for repo-root `.mcp.json`:

```ts
const [user, projectRoot, project] = await Promise.all([
  readMcpJson(paths.user),                                   // no default cwd
  readMcpJson(paths.projectRoot, { stdioCwdBase: dirname(paths.projectRoot) }),
  readMcpJson(paths.project),                                // no default cwd
]);
```

With `cwd: undefined`, `StdioClientTransport` falls back to `process.cwd()` of the spawning process — `~/.kimi-code/server` in `kimi web` mode.

## Fix

Assign a sensible default `cwd` to every MCP config source:

| Config source | Default `cwd` | Reason |
|---|---|---|
| `~/.kimi-code/mcp.json` | session working directory | User-global servers should run in the current project/session context unless explicitly configured otherwise. |
| `<projectRoot>/.mcp.json` | project root | Preserves the existing Claude-compatible behavior where relative paths resolve from the repo root. |
| `<cwd>/.kimi-code/mcp.json` | session working directory | Project-local Kimi config should run in the project/session context. |

```ts
const [user, projectRoot, project] = await Promise.all([
  readMcpJson(paths.user, { stdioCwdBase: input.cwd }),
  readMcpJson(paths.projectRoot, { stdioCwdBase: dirname(paths.projectRoot) }),
  readMcpJson(paths.project, { stdioCwdBase: input.cwd }),
]);
```

`input.cwd` is the session `workDir`, so the fix also answers the question of whether `kimi web` should inherit the CLI's project context: yes, and MCP server spawning is the place where that inheritance must happen.

## Why not delay daemon startup?

The `kimi web` daemon is a singleton that can host sessions across multiple workspaces, so it cannot wait for a single project directory before starting. The correct fix is therefore to make each session supply its own project directory when configuring MCP servers, which is what this change does.

## Test updates

Updated `packages/agent-core/test/mcp/config-loader.test.ts` to assert that user-global and project-local stdio entries receive a default `cwd` equal to the session directory.

## Verification

```bash
pnpm exec vitest run packages/agent-core/test/mcp/config-loader.test.ts
pnpm exec vitest run packages/agent-core/test/mcp/connection-manager.test.ts
```

Both test suites pass.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] This PR closes a related issue (#982).
- [x] I have updated existing tests to reflect the behavior change.
- [x] Ran the affected test suites locally.
