### PR TITLE
fix: always expose the free-text Other option in question prompts

### DIFF
--- a/.changeset/fix-web-question-other-option.md
+++ b/.changeset/fix-web-question-other-option.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Fix the web question prompt missing the free-text Other option.

--- a/packages/agent-core/src/services/question/question.ts
+++ b/packages/agent-core/src/services/question/question.ts
@@ -142,14 +142,8 @@ function buildItem(
   if (item.header !== undefined) out.header = item.header;
   if (item.body !== undefined) out.body = item.body;
   if (item.multiSelect !== undefined) out.multi_select = item.multiSelect;
-  // SDK has no `allowOther` field — `otherLabel` / `otherDescription` exist
-  // and we expose them on the wire alongside an inferred `allow_other: true`
-  // when either tag is set. (SDK semantics: presence of `otherLabel` enables
-  // the "Other" affordance; we surface that explicitly on the wire so client
-  // renderers don't have to infer.)
-  const hasOtherAffordance =
-    item.otherLabel !== undefined || item.otherDescription !== undefined;
-  if (hasOtherAffordance) out.allow_other = true;
+  // SDK has no allowOther field; always advertise the free-text Other option on the wire.
+  out.allow_other = true;
   if (item.otherLabel !== undefined) out.other_label = item.otherLabel;
   if (item.otherDescription !== undefined) out.other_description = item.otherDescription;
   return out;

--- a/packages/agent-core/test/services/question-adapter.test.ts
+++ b/packages/agent-core/test/services/question-adapter.test.ts
@@ -63,6 +63,9 @@ describe('question-adapter · toBrokerRequest (in-process → protocol)', () => 
     expect(protoReq.questions[0]?.header).toBe('Pets');
     expect(protoReq.questions[0]?.body).toBe('pick one');
     expect(protoReq.questions[0]?.multi_select).toBe(false);
+    // Other affordance is always on, even when the SDK item has no otherLabel.
+    expect(protoReq.questions[0]?.allow_other).toBe(true);
+    expect(protoReq.questions[0]?.other_label).toBeUndefined();
 
     expect(protoReq.questions[1]?.id).toBe('q_1');
     expect(protoReq.questions[1]?.options.map((o) => o.id)).toEqual([


### PR DESCRIPTION
## Related Issue

No prior issue — see **Problem** below.

## Problem

The web version of the structured question prompt was missing the free-text "Other" option that the TUI always shows. The question adapter only set `allow_other` on the wire when the SDK question item carried an `otherLabel` / `otherDescription`, but the question tool never provides those fields. Web clients honor `allow_other`, so the free-text option silently disappeared in the web UI while the TUI (which renders it unconditionally) kept working.

## What changed

Set `allow_other` unconditionally in the question adapter so the wire always advertises the free-text option, matching the tool's "users always have an Other option" contract and keeping web clients in sync with the TUI. Added a unit test asserting the affordance is on even when the SDK item has no `otherLabel`.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.
