### PR TITLE
fix(web): surface cwd errors in mention search and validate new-session cwd

### DIFF
--- a/.changeset/cwd-mention-error.md
+++ b/.changeset/cwd-mention-error.md
@@ -1,0 +1,10 @@
+---
+"@moonshot-ai/kimi-web": patch
+---
+
+Surface workspace directory errors in @-mention search and validate the working directory before creating any new session.
+
+- `@mention` now shows the backend error (e.g. deleted directory) instead of "no match" when `fs:search` fails.
+- Session creation via the new-session dialog, workspace "+", and the onboarding composer now verifies the cwd with `browseFs` first and surfaces the error instead of creating a session in a missing directory.
+
+Note: `browseFs` in the daemon API client now propagates errors instead of returning an empty result. The workspace-state layer still exposes a defensive wrapper (`workspaceState.browseFs`) used by the folder picker, so existing picker behavior is unchanged.

--- a/apps/kimi-web/src/api/daemon/client.ts
+++ b/apps/kimi-web/src/api/daemon/client.ts
@@ -978,26 +978,24 @@ export class DaemonKimiWebApi implements KimiWebApi {
 
   /**
    * Browse directories under `path` (defaults to $HOME on the daemon).
-   * PRESUMED — GET /api/v1/fs:browse?path=. On error returns an empty path so
-   * the picker can distinguish "browse failed" from "directory has no children".
+   * PRESUMED — GET /api/v1/fs:browse?path=. Propagates errors so callers that
+   * need to know whether the path exists (e.g. new-session validation) can rely
+   * on the thrown error. The workspace-state layer still exposes a defensive
+   * wrapper for the folder picker.
    */
   async browseFs(path?: string): Promise<FsBrowseResult> {
-    try {
-      const data = await this.http.get<WireFsBrowseResult>('/fs:browse', { path });
-      return {
-        path: data.path,
-        parent: data.parent,
-        entries: (data.entries ?? []).map((e) => ({
-          name: e.name,
-          path: e.path,
-          isDir: e.is_dir,
-          isGitRepo: e.is_git_repo,
-          branch: e.branch,
-        })),
-      };
-    } catch {
-      return { path: '', parent: null, entries: [] };
-    }
+    const data = await this.http.get<WireFsBrowseResult>('/fs:browse', { path });
+    return {
+      path: data.path,
+      parent: data.parent,
+      entries: (data.entries ?? []).map((e) => ({
+        name: e.name,
+        path: e.path,
+        isDir: e.is_dir,
+        isGitRepo: e.is_git_repo,
+        branch: e.branch,
+      })),
+    };
   }
 
   /**

--- a/apps/kimi-web/src/components/chat/Composer.vue
+++ b/apps/kimi-web/src/components/chat/Composer.vue
@@ -124,6 +124,7 @@ const {
   items: mentionItems,
   active: mentionActive,
   loading: mentionLoading,
+  error: mentionError,
   update: updateMentionMenu,
   select: selectMentionItem,
 } = useMentionMenu({
@@ -653,6 +654,7 @@ function selectModel(modelId: string): void {
           :items="mentionItems"
           :active-index="mentionActive"
           :loading="mentionLoading"
+          :error="mentionError"
           @select="selectMentionItem"
           @hover="mentionActive = $event"
         />

--- a/apps/kimi-web/src/components/chat/MentionMenu.vue
+++ b/apps/kimi-web/src/components/chat/MentionMenu.vue
@@ -12,6 +12,7 @@ const props = defineProps<{
   items: FileItem[];
   activeIndex: number;
   loading: boolean;
+  error?: string | null;
 }>();
 
 const emit = defineEmits<{
@@ -62,7 +63,10 @@ function fileIcon(item: FileItem): string {
     <!-- Loading state -->
     <div v-if="props.loading" class="mention-state dim">{{ t('mention.searching') }}</div>
 
-    <!-- Empty state (not loading, no items) -->
+    <!-- Error state -->
+    <div v-else-if="props.error" class="mention-state mention-error">{{ props.error }}</div>
+
+    <!-- Empty state (not loading, no items, no error) -->
     <div v-else-if="props.items.length === 0" class="mention-state dim">{{ t('mention.noMatch') }}</div>
 
     <!-- File items -->
@@ -109,6 +113,10 @@ function fileIcon(item: FileItem): string {
 
 .dim {
   color: var(--muted);
+}
+
+.mention-error {
+  color: var(--red, #c62828);
 }
 
 .mention-item {

--- a/apps/kimi-web/src/components/dialogs/NewSessionDialog.vue
+++ b/apps/kimi-web/src/components/dialogs/NewSessionDialog.vue
@@ -4,6 +4,7 @@
 <script setup lang="ts">
 import { computed, onMounted, onUnmounted, ref, watch } from 'vue';
 import { useI18n } from 'vue-i18n';
+import { getKimiWebApi } from '../api';
 
 const { t } = useI18n();
 
@@ -22,6 +23,9 @@ const emit = defineEmits<{
 
 const cwdInput = ref('');
 const titleInput = ref('');
+const cwdError = ref<string | null>(null);
+const cwdValidating = ref(false);
+let cwdValidationTimer: ReturnType<typeof setTimeout> | null = null;
 
 // Pre-fill with the first recentCwd if available
 watch(
@@ -35,7 +39,29 @@ watch(
 );
 
 const cwdTrimmed = computed(() => cwdInput.value.trim());
-const canCreate = computed(() => cwdTrimmed.value.length > 0);
+const canCreate = computed(() => cwdTrimmed.value.length > 0 && !cwdError.value && !cwdValidating.value);
+
+async function validateCwd(cwd: string): Promise<void> {
+  if (!cwd) {
+    cwdError.value = null;
+    return;
+  }
+  if (cwdValidationTimer !== null) clearTimeout(cwdValidationTimer);
+  cwdValidationTimer = setTimeout(async () => {
+    cwdValidating.value = true;
+    cwdError.value = null;
+    try {
+      await getKimiWebApi().browseFs(cwd);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      cwdError.value = msg.includes('ENOENT') ? t('newSession.cwdNotFound') : msg;
+    } finally {
+      cwdValidating.value = false;
+    }
+  }, 300);
+}
+
+watch(cwdTrimmed, (cwd) => void validateCwd(cwd), { immediate: true });
 
 // -------------------------------------------------------------------------
 // Actions
@@ -51,6 +77,7 @@ function handleCreate(): void {
 
 function pickRecent(cwd: string): void {
   cwdInput.value = cwd;
+  void validateCwd(cwd);
 }
 
 // -------------------------------------------------------------------------
@@ -66,7 +93,10 @@ function handleKeydown(e: KeyboardEvent): void {
 }
 
 onMounted(() => document.addEventListener('keydown', handleKeydown));
-onUnmounted(() => document.removeEventListener('keydown', handleKeydown));
+onUnmounted(() => {
+  document.removeEventListener('keydown', handleKeydown);
+  if (cwdValidationTimer !== null) clearTimeout(cwdValidationTimer);
+});
 </script>
 
 <template>
@@ -94,11 +124,14 @@ onUnmounted(() => document.removeEventListener('keydown', handleKeydown));
             id="ns-cwd"
             v-model="cwdInput"
             class="finput"
+            :class="{ 'finput-error': cwdError }"
             type="text"
             :placeholder="t('newSession.cwdPlaceholder')"
             autocomplete="off"
             spellcheck="false"
           />
+          <div v-if="cwdError" class="field-error">{{ cwdError }}</div>
+          <div v-else-if="cwdValidating" class="field-hint">{{ t('newSession.validating') }}</div>
         </div>
 
         <!-- Recent cwds quick-pick -->
@@ -239,6 +272,21 @@ onUnmounted(() => document.removeEventListener('keydown', handleKeydown));
 .finput:focus-visible {
   border-color: var(--blue);
   box-shadow: 0 0 0 2px color-mix(in srgb, var(--blue) 25%, transparent);
+}
+.finput-error {
+  border-color: var(--red, #c62828);
+}
+.field-error {
+  flex: 1;
+  font-size: calc(var(--ui-font-size) - 2px);
+  color: var(--red, #c62828);
+  padding-top: 4px;
+}
+.field-hint {
+  flex: 1;
+  font-size: calc(var(--ui-font-size) - 2px);
+  color: var(--muted);
+  padding-top: 4px;
 }
 
 

--- a/apps/kimi-web/src/composables/client/useWorkspaceState.ts
+++ b/apps/kimi-web/src/composables/client/useWorkspaceState.ts
@@ -479,9 +479,19 @@ export function useWorkspaceState(rawState: ExtendedState, deps: UseWorkspaceSta
   }
 
   /**
+   * Verify that a working directory exists and is reachable before creating a
+   * session. Throws the original error (e.g. ENOENT from browseFs) on failure.
+   */
+  async function validateCwdForCreate(cwd: string): Promise<void> {
+    const api = getKimiWebApi();
+    await api.browseFs(cwd);
+  }
+
+  /**
    * Create a session in a workspace — the one-click path (no cwd typing).
    * Register/touch the workspace first when the daemon supports it; if that
-   * fails, fall back to the legacy cwd-only create path.
+   * fails, fall back to the legacy cwd-only create path. Refuses to create the
+   * session if the workspace directory no longer exists.
    */
   async function createSessionInWorkspace(workspaceId: string): Promise<AppSession | undefined> {
     const ws = mergedWorkspaces.value.find((w) => w.id === workspaceId);
@@ -500,6 +510,7 @@ export function useWorkspaceState(rawState: ExtendedState, deps: UseWorkspaceSta
         // path-like workspace id as workspace_id would fail validation, so use
         // metadata.cwd only.
       }
+      await validateCwdForCreate(cwdForCreate);
       const session = await api.createSession({ workspaceId: workspaceIdForCreate, cwd: cwdForCreate });
       upsertSessionFront(session);
       selectWorkspace(session.workspaceId ?? workspaceIdForCreate ?? workspaceId);
@@ -517,7 +528,8 @@ export function useWorkspaceState(rawState: ExtendedState, deps: UseWorkspaceSta
   /**
    * Create a session and immediately submit the first prompt.
    * This is the unified path when there is no active session (e.g. after
-   * clicking "+" or in an empty workspace).
+   * clicking "+" or in an empty workspace). Refuses to create the session if
+   * the workspace directory no longer exists.
    */
   async function startSessionAndSendPrompt(
     workspaceId: string,
@@ -538,6 +550,7 @@ export function useWorkspaceState(rawState: ExtendedState, deps: UseWorkspaceSta
       } catch {
         // Older daemons may not have /workspaces.
       }
+      await validateCwdForCreate(cwdForCreate);
       const draftPick = modelProvider.draftModel.value ?? undefined;
       const session = await api.createSession({
         workspaceId: workspaceIdForCreate,
@@ -758,6 +771,7 @@ export function useWorkspaceState(rawState: ExtendedState, deps: UseWorkspaceSta
 
   async function createSession(cwd: string, opts?: { title?: string; model?: string }): Promise<void> {
     try {
+      await validateCwdForCreate(cwd);
       const api = getKimiWebApi();
       const session = await api.createSession({ cwd, title: opts?.title, model: opts?.model });
       upsertSessionFront(session);
@@ -1578,18 +1592,16 @@ export function useWorkspaceState(rawState: ExtendedState, deps: UseWorkspaceSta
 
   /**
    * Search files in the active session using the daemon searchFiles endpoint.
-   * Returns {path, name}[] — defensive, returns [] on error or no active session.
+   * Returns {path, name}[] for no active session, empty query, or empty results;
+   * propagates backend errors so the UI can distinguish "no matches" from
+   * "search failed".
    */
   async function searchFiles(query: string): Promise<Array<{ path: string; name: string }>> {
     const sid = rawState.activeSessionId;
-    if (!sid) return [];
-    try {
-      const api = getKimiWebApi();
-      const result = await api.searchFiles(sid, { query, limit: 20 });
-      return result.items.map((item) => ({ path: item.path, name: item.name }));
-    } catch {
-      return [];
-    }
+    if (!sid || query.trim().length === 0) return [];
+    const api = getKimiWebApi();
+    const result = await api.searchFiles(sid, { query, limit: 20 });
+    return result.items.map((item) => ({ path: item.path, name: item.name }));
   }
 
   return {

--- a/apps/kimi-web/src/composables/useMentionMenu.ts
+++ b/apps/kimi-web/src/composables/useMentionMenu.ts
@@ -34,6 +34,7 @@ export function useMentionMenu(deps: MentionMenuDeps) {
   const items = ref<FileItem[]>([]);
   const active = ref(0);
   const loading = ref(false);
+  const error = ref<string | null>(null);
 
   // Debounce timer for the search.
   let timer: ReturnType<typeof setTimeout> | null = null;
@@ -67,10 +68,12 @@ export function useMentionMenu(deps: MentionMenuDeps) {
       loading.value = true;
       open.value = true;
       active.value = 0;
+      error.value = null;
       try {
         items.value = await search(query);
-      } catch {
+      } catch (err) {
         items.value = [];
+        error.value = extractMentionSearchError(err);
       } finally {
         loading.value = false;
       }
@@ -94,5 +97,15 @@ export function useMentionMenu(deps: MentionMenuDeps) {
     });
   }
 
-  return { open, items, active, loading, update, select };
+  return { open, items, active, loading, error, update, select };
+}
+
+/** Extract a user-facing message from a mention-search failure. */
+function extractMentionSearchError(err: unknown): string {
+  // DaemonApiError exposes `msg` for code !== 0 envelope errors.
+  if (err && typeof err === 'object' && 'msg' in err && typeof err.msg === 'string') {
+    return err.msg;
+  }
+  if (err instanceof Error) return err.message;
+  return 'Search failed';
 }

--- a/apps/kimi-web/src/i18n/locales/en/newSession.ts
+++ b/apps/kimi-web/src/i18n/locales/en/newSession.ts
@@ -9,4 +9,6 @@ export default {
   create: 'Create',
   cancel: 'Cancel',
   footerHint: 'Enter to create · Esc to close',
+  cwdNotFound: 'Directory does not exist or is not accessible.',
+  validating: 'Checking directory…',
 } as const;

--- a/apps/kimi-web/src/i18n/locales/zh/newSession.ts
+++ b/apps/kimi-web/src/i18n/locales/zh/newSession.ts
@@ -9,4 +9,6 @@ export default {
   create: '新建',
   cancel: '取消',
   footerHint: 'Enter 新建 · Esc 关闭',
+  cwdNotFound: '目录不存在或无法访问。',
+  validating: '正在检查目录…',
 } as const;


### PR DESCRIPTION
## Related Issue

Closes #1007

## Problem

1. **@-mention shows "no match" when search fails.** When the active session's working directory no longer exists, typing `@<query>` in the composer triggers `fs:search`. The backend returns an `ENOENT` error, but `workspaceState.searchFiles` swallowed the exception and returned an empty array. The UI then rendered the generic "无匹配" (no match) state, hiding the real problem.

2. **New sessions can be created in deleted directories.** The new-session dialog validated the cwd, but the one-click "+" button in the sidebar and the onboarding composer both create sessions via `createSessionInWorkspace` / `startSessionAndSendPrompt`, which never checked whether the directory still exists.

## What changed

- `apps/kimi-web/src/composables/client/useWorkspaceState.ts`
  - `searchFiles` now propagates backend errors instead of returning `[]` on failure, so `Composer.vue` can distinguish "no matches" from "search failed".
  - Added `validateCwdForCreate(cwd)` and called it before `createSession`, `createSessionInWorkspace`, and `startSessionAndSendPrompt`.
  - Empty `@` queries short-circuit to `[]` to avoid exposing the backend's "query too small" validation error.

- `apps/kimi-web/src/api/daemon/client.ts`
  - `browseFs` now propagates errors. The folder picker already consumes `workspaceState.browseFs`, which retains its defensive wrapper, so the picker behavior is unchanged.

- `apps/kimi-web/src/components/Composer.vue` / `MentionMenu.vue` / `NewSessionDialog.vue`
  - Added `mentionError` state and error UI for the mention menu.
  - New-session dialog validates cwd via `browseFs` and disables creation while the directory is invalid.

- `.changeset/cwd-mention-error.md`
  - Added a patch changeset for `@moonshot-ai/kimi-web`.

## Verification

- `pnpm -C apps/kimi-web exec vue-tsc --noEmit` passes.
- Manually verified in the browser:
  - In a session whose cwd was deleted, `@package` now shows the backend `ENOENT` message instead of "no match".
  - In the same deleted workspace, clicking "+" and sending a message no longer creates a new session; an error toast is shown.
  - Normal workspaces still list files and create sessions correctly.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [ ] I have added tests that prove my feature works. *(Verified manually; no new test files added.)*
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [ ] Ran `gen-docs` skill, or this PR needs no doc update.
