### PR TITLE
fix(web): persist input history so recall works after the first message

### DIFF
--- a/.changeset/fix-web-persist-input-history.md
+++ b/.changeset/fix-web-persist-input-history.md
@@ -2,4 +2,4 @@
 "@moonshot-ai/kimi-code": patch
 ---
 
-Fix the composer's ↑/↓ input-history recall doing nothing right after the first message of a new session. The history is now persisted to localStorage and re-read on mount, so the docked composer no longer starts empty when it takes over from the empty-session composer.
+Fix the composer's ↑/↓ input-history recall doing nothing right after the first message of a new session. The history is now persisted to localStorage and re-read on mount, so the docked composer no longer starts empty when it takes over from the empty-session composer. Slash commands (with or without args) are now recorded in history too, so they can be recalled like plain messages.

--- a/.changeset/fix-web-persist-input-history.md
+++ b/.changeset/fix-web-persist-input-history.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Fix the composer's ↑/↓ input-history recall doing nothing right after the first message of a new session. The history is now persisted to localStorage and re-read on mount, so the docked composer no longer starts empty when it takes over from the empty-session composer.

--- a/.changeset/fix-web-persist-input-history.md
+++ b/.changeset/fix-web-persist-input-history.md
@@ -2,4 +2,4 @@
 "@moonshot-ai/kimi-code": patch
 ---
 
-Fix the composer's ↑/↓ input-history recall doing nothing right after the first message of a new session. The history is now persisted to localStorage and re-read on mount, so the docked composer no longer starts empty when it takes over from the empty-session composer. Slash commands (with or without args) are now recorded in history too, so they can be recalled like plain messages.
+Fix the composer's ↑/↓ input-history recall doing nothing right after the first message of a new session. The history is now persisted to localStorage and re-read on mount, so the docked composer no longer starts empty when it takes over from the empty-session composer. Slash commands are now recorded too — both typed-and-submitted and ones picked from the slash menu — so they can be recalled like plain messages.

--- a/apps/kimi-web/src/components/Composer.vue
+++ b/apps/kimi-web/src/components/Composer.vue
@@ -459,6 +459,11 @@ function handleSubmit(): void {
 
   if (!trimmed && readyAttachments.length === 0) return;
 
+  // Record for ↑/↓ recall before the slash branch so commands (with or without
+  // args) are recallable too, not just plain messages. `push` ignores empty /
+  // whitespace, so an image-only send adds nothing.
+  history.push(trimmed);
+
   // If it's a known slash command, keep the optional tail as command input
   // instead of submitting it as normal chat text. This covers `/goal <task>`,
   // `/swarm <task>`, `/btw <question>`, slash skills with args, and bare
@@ -488,7 +493,6 @@ function handleSubmit(): void {
   }
   attachments.value = [];
 
-  history.push(trimmed);
   text.value = '';
   slashOpen.value = false;
   mentionOpen.value = false;

--- a/apps/kimi-web/src/components/Composer.vue
+++ b/apps/kimi-web/src/components/Composer.vue
@@ -185,6 +185,10 @@ function selectSlashCommand(item: SlashCommand): void {
     return;
   }
   text.value = '';
+  // Menu-selected bare commands (e.g. /model, /login) reach here directly and
+  // never go through handleSubmit, so record them for ↑/↓ recall too. acceptsInput
+  // commands are pushed later by handleSubmit with their argument.
+  history.push(item.name);
   emit('command', item.name);
 }
 

--- a/apps/kimi-web/src/composables/useInputHistory.ts
+++ b/apps/kimi-web/src/composables/useInputHistory.ts
@@ -1,5 +1,15 @@
 // apps/kimi-web/src/composables/useInputHistory.ts
 import { nextTick, ref, type Ref } from 'vue';
+import { STORAGE_KEYS, safeGetJson, safeSetJson } from '../lib/storage';
+
+/** Cap the persisted history so storage can't grow without bound. */
+const MAX_HISTORY = 200;
+
+function loadHistory(): string[] {
+  const stored = safeGetJson<unknown>(STORAGE_KEYS.inputHistory);
+  if (!Array.isArray(stored)) return [];
+  return stored.filter((s): s is string => typeof s === 'string' && s.length > 0);
+}
 
 export interface InputHistoryDeps {
   /** The live composer text — recalled entries overwrite it. */
@@ -18,6 +28,14 @@ export interface InputHistoryDeps {
  * they started browsing. Any manual edit drops out of browsing mode (see
  * `resetBrowsing`, called from the composer's input handler).
  *
+ * The history is persisted to localStorage (one global list). The composer has
+ * two mutually-exclusive instances — the empty-session composer and the docked
+ * composer — and the first message of a new session is sent by the empty
+ * composer, which unmounts as soon as the first turn appears. Persisting (and
+ * re-reading on mount) is what lets the docked composer recall that first
+ * message instead of starting from an empty list. A single global list also
+ * sidesteps the fact that a new session has no id until after the first submit.
+ *
  * The composer keeps the keydown orchestration (which also juggles the slash
  * and mention menus); this composable owns only the history list, the browsing
  * cursor, and the textarea caret/selection work needed to apply a recalled
@@ -26,7 +44,7 @@ export interface InputHistoryDeps {
 export function useInputHistory(deps: InputHistoryDeps) {
   const { text, textareaRef, autosize } = deps;
 
-  const inputHistory = ref<string[]>([]);
+  const inputHistory = ref(loadHistory());
   // -1 = browsing nothing (live draft). Otherwise an index into inputHistory.
   let historyIndex = -1;
   let draftBeforeHistory = '';
@@ -37,7 +55,9 @@ export function useInputHistory(deps: InputHistoryDeps) {
     if (!trimmed) return;
     // Skip consecutive duplicates so repeated sends don't pad the history.
     if (inputHistory.value.at(-1) === trimmed) return;
-    inputHistory.value = [...inputHistory.value, trimmed];
+    const next = [...inputHistory.value, trimmed];
+    inputHistory.value = next.length > MAX_HISTORY ? next.slice(-MAX_HISTORY) : next;
+    safeSetJson(STORAGE_KEYS.inputHistory, inputHistory.value);
   }
 
   function caretAtFirstLine(): boolean {

--- a/apps/kimi-web/src/lib/storage.ts
+++ b/apps/kimi-web/src/lib/storage.ts
@@ -24,6 +24,7 @@ export const STORAGE_KEYS = {
   hiddenWorkspaces: 'kimi-web.hidden-workspaces',
   betaToc: 'kimi-web.beta-toc',
   notifyOnComplete: 'kimi-web.notify-on-complete',
+  inputHistory: 'kimi-web.input-history',
   // cross-file
   locale: 'kimi-locale',
   clientId: 'kimi-web.client-id',

--- a/apps/kimi-web/test/input-history.test.ts
+++ b/apps/kimi-web/test/input-history.test.ts
@@ -1,6 +1,7 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { ref, type Ref } from 'vue';
 import { useInputHistory } from '../src/composables/useInputHistory';
+import { STORAGE_KEYS } from '../src/lib/storage';
 
 interface MockTextarea {
   value: string;
@@ -132,5 +133,87 @@ describe('useInputHistory — caretAtFirstLine', () => {
   it('is true for an empty composer', () => {
     const { history } = setup('', 0);
     expect(history.caretAtFirstLine()).toBe(true);
+  });
+});
+
+function memoryStorage(): Storage {
+  const map = new Map<string, string>();
+  return {
+    get length() {
+      return map.size;
+    },
+    clear: () => {
+      map.clear();
+    },
+    getItem: (key: string) => map.get(key) ?? null,
+    key: (index: number) => Array.from(map.keys())[index] ?? null,
+    removeItem: (key: string) => {
+      map.delete(key);
+    },
+    setItem: (key: string, value: string) => {
+      map.set(key, value);
+    },
+  };
+}
+
+describe('useInputHistory — persistence', () => {
+  let original: Storage | undefined;
+
+  beforeEach(() => {
+    original = (globalThis as { localStorage?: Storage }).localStorage;
+    Object.defineProperty(globalThis, 'localStorage', {
+      value: memoryStorage(),
+      configurable: true,
+      writable: true,
+    });
+  });
+
+  afterEach(() => {
+    if (original === undefined) {
+      delete (globalThis as { localStorage?: Storage }).localStorage;
+    } else {
+      Object.defineProperty(globalThis, 'localStorage', {
+        value: original,
+        configurable: true,
+        writable: true,
+      });
+    }
+  });
+
+  it('writes each pushed entry to localStorage', () => {
+    const { history } = setup();
+    history.push('hello');
+    const stored = globalThis.localStorage.getItem(STORAGE_KEYS.inputHistory);
+    expect(stored).toBe(JSON.stringify(['hello']));
+  });
+
+  it('a freshly mounted composable reads back the persisted history', () => {
+    const first = setup();
+    first.history.push('a');
+    first.history.push('b');
+
+    // Simulates the empty composer unmounting and the docked composer mounting.
+    const second = setup();
+    second.history.recallOlder();
+    expect(second.text.value).toBe('b');
+    second.history.recallOlder();
+    expect(second.text.value).toBe('a');
+  });
+
+  it('trims to the newest 200 entries, dropping the oldest', () => {
+    const { text, history } = setup();
+    for (let i = 0; i < 205; i++) history.push(`m${i}`);
+
+    // Walk all the way back; the oldest kept entry must be m5 (m0..m4 dropped).
+    for (let i = 0; i < 200; i++) history.recallOlder();
+    expect(text.value).toBe('m5');
+    history.recallOlder(); // already at the oldest kept entry — must not move
+    expect(text.value).toBe('m5');
+  });
+
+  it('ignores a malformed stored value and starts empty', () => {
+    globalThis.localStorage.setItem(STORAGE_KEYS.inputHistory, 'not-json');
+    const { history } = setup();
+    expect(history.hasHistory()).toBe(false);
   });
 });


### PR DESCRIPTION
> **Stacked on #1011** — this PR is based on `refactor/web-extract-input-history`. Review/merge #1011 first; this PR's diff is only the last commit (`fix(web): persist input history so recall works after the first message`).

## Related Issue

Bug found while reviewing #1011. No standalone issue.

## Problem

Pressing ↑ in the composer often did nothing, most notably right after sending the **first** message of a new session — the very case where you want to recall and edit what you just sent.

Root cause: the composer has two mutually-exclusive instances:

- the **empty-session composer** (`turns.length === 0`), and
- the **docked composer** (inside `ChatDock`, once there are turns).

Each kept its own in-memory `inputHistory` (`ref([])`), never persisted. So:

1. New session → empty composer.
2. Send the first message → it gets pushed into the **empty** composer's history.
3. The first turn appears → the empty composer **unmounts** (discarding that push) and the docked composer **mounts fresh with an empty history**.
4. Press ↑ → empty history → nothing happens.

The history was also wiped on every page reload for the same reason (purely in-memory).

## What changed

- `useInputHistory` now persists the history to `localStorage` (key `kimi-web.input-history`) and re-reads it on mount.
  - **Global, not per-session**: a new session has no id until *after* the first submit (`startSessionAndSendPrompt` runs at submit time), so per-session keys would not line up across the empty → docked handoff (the empty composer would write `history:__new__` while the docked composer reads `history:<realId>`). A single global list sidesteps that and also matches shell-style recall.
  - Capped at 200 entries so storage can't grow without bound.
- Added the key to `STORAGE_KEYS` in `lib/storage.ts`.
- Slash commands are now recorded in history too, covering both paths:
  - typed-and-submitted (`/goal <task>`, `/model`) — the `history.push` call moved ahead of the slash-command branch in `handleSubmit`;
  - picked from the slash menu (`/model`, `/login`, …) — `selectSlashCommand` now pushes before emitting, since those bypass `handleSubmit` entirely.
  Previously only plain messages were recallable.
- Added persistence-focused unit tests: surviving a remount, the 200-entry cap, and a malformed stored value being ignored.

No change to the recall navigation logic itself — only where the list lives.

## Verification

- `pnpm --filter @moonshot-ai/kimi-web typecheck` — pass (`vue-tsc --noEmit`)
- `pnpm --filter @moonshot-ai/kimi-web test` — 55 passed (15 in `input-history.test.ts`)
- `pnpm --filter @moonshot-ai/kimi-web build` — pass
- `oxlint --type-aware` on the changed files — 0 warnings, 0 errors

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works. (`test/input-history.test.ts` — persistence/remount/cap/corruption cases.)
- [x] Ran `gen-changesets` skill, or this PR needs no changeset. (Added `.changeset/fix-web-persist-input-history.md`, `patch` on `@moonshot-ai/kimi-code`.)
- [x] Ran `gen-docs` skill, or this PR needs no doc update. (No user-facing doc change.)
