### PR TITLE
docs: add kimi-skill community project link

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for the full contribution guide.
 
 - [Issues](https://github.com/MoonshotAI/kimi-code/issues)
 - For security vulnerabilities, see [SECURITY.md](SECURITY.md).
+- Community project: [kimi-skill](https://github.com/ghyghoo8/kimi-skill) — Agent Skills for using Kimi Code CLI as a headless sub-agent.
 
 ## Acknowledgements
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -126,6 +126,7 @@ pnpm build      # 构建所有包
 
 - [Issues](https://github.com/MoonshotAI/kimi-code/issues)
 - 安全漏洞反馈，请见 [SECURITY.md](SECURITY.md)。
+- 社区项目：[kimi-skill](https://github.com/ghyghoo8/kimi-skill) —— 把 Kimi Code CLI 当作 headless 子 agent 使用的 Agent Skills。
 
 ## 致谢
 


### PR DESCRIPTION
<!--
  Thank you for your contribution to Kimi Code!
  Please open an issue before sending a feature PR — PRs without prior discussion may be closed without review.
  See https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md for more.
  -->

  Thanks for the recent pace and polish — releases have been shipping fast and the Node rewrite feels noticeably snappier to start and run. It's been a pleasure to build
  on, and I'd love to contribute more going forward. Starting small with this docs-only PR.

  ## Related Issue

  No issue — this is a small, documentation-only change, which CONTRIBUTING allows to be opened directly. Happy to convert to an issue-first discussion if you'd prefer.

  ## Problem

  The README has a **Community** section, but community projects built on top of Kimi Code currently have nowhere to be discovered. This adds one such link.

  ## What changed

  Adds a single bullet under **Community / 社区** in both `README.md` and `README.zh-CN.md`, linking [kimi-skill](https://github.com/ghyghoo8/kimi-skill) — a set of Agent
  Skills that help a host agent (e.g. Claude Code / Kimi) use Kimi Code CLI as a headless sub-agent. Wording and format match the existing section; no code or behavior
  change.

  Entirely at your discretion — happy to reword, relocate, or close if community links aren't something you'd like to maintain in the README.

  ## Checklist

  - [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
  - [x] I have linked a related issue, or explained the problem above.
  - [ ] I have added tests that prove my feature works. — N/A (docs-only)
  - [x] Ran `gen-changesets` skill, or this PR needs no changeset. (docs-only → no changeset)
  - [x] Ran `gen-docs` skill, or this PR needs no doc update. (README-only; no `docs/` site change)