### PR TITLE
fix: reattach video tool results for openai providers

### DIFF
--- a/.changeset/reattach-video-tool-media.md
+++ b/.changeset/reattach-video-tool-media.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Reattach video results from tools when using OpenAI-compatible chat providers.

--- a/packages/kosong/src/providers/openai-legacy.ts
+++ b/packages/kosong/src/providers/openai-legacy.ts
@@ -218,11 +218,10 @@ function convertMessage(
   return result;
 }
 
-// Chat Completions has no url-based audio/video content part (only base64
-// `input_audio`), so unlike images these cannot be reattached as user input.
-// Note the omission inline in the tool message text instead.
+// Chat Completions has no url-based audio content part (only base64
+// `input_audio`), so unlike image/video URLs it cannot be reattached as user
+// input. Note the omission inline in the tool message text instead.
 const OMITTED_AUDIO_PLACEHOLDER = '(audio omitted: not supported by this provider)';
-const OMITTED_VIDEO_PLACEHOLDER = '(video omitted: not supported by this provider)';
 
 function convertToolMessageContentForChat(
   message: Message,
@@ -236,25 +235,26 @@ function convertToolMessageContentForChat(
   if (message.content.some((part) => part.type === 'audio_url')) {
     lines.push(OMITTED_AUDIO_PLACEHOLDER);
   }
-  if (message.content.some((part) => part.type === 'video_url')) {
-    lines.push(OMITTED_VIDEO_PLACEHOLDER);
-  }
-  if (lines.length === 0 && message.content.some((part) => part.type === 'image_url')) {
+  if (lines.length === 0 && message.content.some((part) => isReattachableToolMediaPart(part))) {
     return TOOL_RESULT_MEDIA_PLACEHOLDER;
   }
   return lines.join('\n');
 }
 
-function toolResultImageParts(message: Message): OpenAIContentPart[] {
-  const images: OpenAIContentPart[] = [];
+function isReattachableToolMediaPart(part: ContentPart): boolean {
+  return part.type === 'image_url' || part.type === 'video_url';
+}
+
+function toolResultMediaParts(message: Message): OpenAIContentPart[] {
+  const media: OpenAIContentPart[] = [];
   for (const part of message.content) {
-    if (part.type !== 'image_url') continue;
+    if (!isReattachableToolMediaPart(part)) continue;
     const converted = convertContentPart(part);
     if (converted !== null) {
-      images.push(converted);
+      media.push(converted);
     }
   }
-  return images;
+  return media;
 }
 
 function appendToolResultMediaMessage(
@@ -283,7 +283,7 @@ function convertHistoryMessages(
     }
     messages.push(convertMessage(msg, reasoningKey, toolMessageConversion));
     if (msg.role === 'tool') {
-      pendingToolResultMedia.push(...toolResultImageParts(msg));
+      pendingToolResultMedia.push(...toolResultMediaParts(msg));
     }
   }
 

--- a/packages/kosong/test/openai-legacy.test.ts
+++ b/packages/kosong/test/openai-legacy.test.ts
@@ -339,9 +339,9 @@ describe('OpenAILegacyChatProvider', () => {
     });
 
     it('tool call with audio result notes the omission inline without reattaching', async () => {
-      // Chat Completions has no url-based audio/video content part (only
-      // base64 input_audio), so unlike images these cannot be reattached as
-      // a user message — a standard OpenAI endpoint would reject the request
+      // Chat Completions has no url-based audio content part (only base64
+      // input_audio), so unlike image/video URLs it cannot be reattached as a
+      // user message — a standard OpenAI endpoint would reject the request
       // with a 400. The tool message notes the omission inline instead.
       const provider = createProvider();
       const history: Message[] = [
@@ -373,7 +373,7 @@ describe('OpenAILegacyChatProvider', () => {
       expect(messages).toHaveLength(3);
     });
 
-    it('tool call with text and video result appends the omission note to the text', async () => {
+    it('tool call with text and video result keeps the tool result textual and reattaches video as user input', async () => {
       const provider = createProvider();
       const history: Message[] = [
         { role: 'user', content: [{ type: 'text', text: 'Record it' }], toolCalls: [] },
@@ -397,10 +397,16 @@ describe('OpenAILegacyChatProvider', () => {
       const messages = body['messages'] as Record<string, unknown>[];
       expect(messages[2]).toEqual({
         role: 'tool',
-        content: 'recorded 5s clip\n(video omitted: not supported by this provider)',
+        content: 'recorded 5s clip',
         tool_call_id: 'call_rec',
       });
-      expect(messages).toHaveLength(3);
+      expect(messages[3]).toEqual({
+        role: 'user',
+        content: [
+          { type: 'text', text: 'Attached media from tool result:' },
+          { type: 'video_url', video_url: { url: 'https://example.com/rec.mp4' } },
+        ],
+      });
     });
 
     it('groups consecutive tool result images after all matching tool messages', async () => {


### PR DESCRIPTION
## Related Issue

No related issue. This fixes a provider conversion bug where video media returned by a tool is omitted before the next OpenAI-compatible chat request.

## Problem

OpenAI-compatible chat providers can accept `video_url` content parts, and regular user messages already serialize them. However, when a tool returns video media, the tool message is converted to text and only images are reattached in a follow-up user message. Videos are replaced with an omission note, so video-capable OpenAI-compatible providers never receive the media.

## What changed

- Reattach `video_url` tool result media alongside `image_url` media in the follow-up user message.
- Keep audio results as an inline omission note because Chat Completions still has no URL-based audio content part here.
- Updated OpenAI-compatible provider tests for video tool results.
- Added a changeset for the CLI bundle.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.

## Verification

- `pnpm exec vitest run packages/kosong/test/openai-legacy.test.ts`
- `pnpm --filter @moonshot-ai/kosong run typecheck`
