### PR TITLE
fix(changeset): correct bump level for web panel resize changeset

### DIFF
--- a/.changeset/web-unbounded-panel-width.md
+++ b/.changeset/web-unbounded-panel-width.md
@@ -1,5 +1,5 @@
 ---
-"@moonshot-ai/kimi-code": minor
+"@moonshot-ai/kimi-code": patch
 ---
 
 Allow the web sidebar and detail panel to be resized up to the available viewport width, keeping their resize handles reachable on narrow windows.


### PR DESCRIPTION
## Related Issue

No related issue. This PR corrects the bump level of an existing changeset.

## Problem

The changeset for the web sidebar/detail panel resize tweak was classified as `minor`, but the change is a small, limited UX fix rather than a substantial new feature.

## What changed

- Changed `.changeset/web-unbounded-panel-width.md` from `minor` to `patch`.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [ ] I have linked a related issue, or explained the problem above.
- [ ] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.