### PR TITLE
fix(tui): add hardware cursor setting

### DIFF
--- a/.changeset/hardware-cursor-setting.md
+++ b/.changeset/hardware-cursor-setting.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Add a TUI setting for showing the terminal hardware cursor to help IME candidate windows follow the input cursor.

--- a/apps/kimi-code/src/tui/commands/config.ts
+++ b/apps/kimi-code/src/tui/commands/config.ts
@@ -10,6 +10,7 @@ import {
   ExperimentsSelectorComponent,
   type ExperimentalFeatureDraftChange,
 } from '../components/dialogs/experiments-selector';
+import { HardwareCursorSelectorComponent } from '../components/dialogs/hardware-cursor-selector';
 import { TabbedModelSelectorComponent } from '../components/dialogs/tabbed-model-selector';
 import { PermissionSelectorComponent } from '../components/dialogs/permission-selector';
 import { SettingsSelectorComponent, type SettingsSelection } from '../components/dialogs/settings-selector';
@@ -277,6 +278,7 @@ async function applyEditorChoice(host: SlashCommandHost, value: string): Promise
       editorCommand,
       notifications: host.state.appState.notifications,
       upgrade: host.state.appState.upgrade,
+      terminal: host.state.appState.terminal,
     });
   } catch (error) {
     host.showStatus(
@@ -443,6 +445,7 @@ async function applyThemeChoice(host: SlashCommandHost, theme: ThemeName): Promi
       editorCommand: host.state.appState.editorCommand,
       notifications: host.state.appState.notifications,
       upgrade: host.state.appState.upgrade,
+      terminal: host.state.appState.terminal,
     });
   } catch (error) {
     host.showStatus(
@@ -484,6 +487,21 @@ export function showUpdatePreferencePicker(host: SlashCommandHost): void {
       onSelect: (value) => {
         host.restoreEditor();
         void applyUpdatePreferenceChoice(host, value);
+      },
+      onCancel: () => {
+        host.restoreEditor();
+      },
+    }),
+  );
+}
+
+export function showHardwareCursorPicker(host: SlashCommandHost): void {
+  host.mountEditorReplacement(
+    new HardwareCursorSelectorComponent({
+      currentValue: host.state.appState.terminal.showHardwareCursor,
+      onSelect: (value) => {
+        host.restoreEditor();
+        void applyHardwareCursorChoice(host, value);
       },
       onCancel: () => {
         host.restoreEditor();
@@ -562,7 +580,7 @@ type UpdatePreferenceHost = {
   readonly state: {
     readonly appState: Pick<
       SlashCommandHost['state']['appState'],
-      'theme' | 'editorCommand' | 'notifications' | 'upgrade'
+      'theme' | 'editorCommand' | 'notifications' | 'upgrade' | 'terminal'
     >;
   };
   setAppState(patch: Pick<SlashCommandHost['state']['appState'], 'upgrade'>): void;
@@ -586,6 +604,7 @@ export async function applyUpdatePreferenceChoice(
       editorCommand: host.state.appState.editorCommand,
       notifications: host.state.appState.notifications,
       upgrade,
+      terminal: host.state.appState.terminal,
     });
   } catch (error) {
     host.showStatus(
@@ -598,6 +617,51 @@ export async function applyUpdatePreferenceChoice(
   host.setAppState({ upgrade });
   host.track('upgrade_preference_changed', { auto_install: autoInstall });
   host.showStatus(`Automatic updates ${autoInstall ? 'enabled' : 'disabled'}.`);
+}
+
+type HardwareCursorHost = {
+  readonly state: {
+    readonly appState: Pick<
+      SlashCommandHost['state']['appState'],
+      'theme' | 'editorCommand' | 'notifications' | 'upgrade' | 'terminal'
+    >;
+    readonly ui: Pick<SlashCommandHost['state']['ui'], 'setShowHardwareCursor'>;
+  };
+  setAppState(patch: Pick<SlashCommandHost['state']['appState'], 'terminal'>): void;
+  showStatus(msg: string, color?: string): void;
+  track: SlashCommandHost['track'];
+};
+
+export async function applyHardwareCursorChoice(
+  host: HardwareCursorHost,
+  showHardwareCursor: boolean,
+): Promise<void> {
+  if (showHardwareCursor === host.state.appState.terminal.showHardwareCursor) {
+    host.showStatus(`Hardware cursor already ${showHardwareCursor ? 'enabled' : 'disabled'}.`);
+    return;
+  }
+
+  const terminal = { showHardwareCursor };
+  try {
+    await saveTuiConfig({
+      theme: host.state.appState.theme,
+      editorCommand: host.state.appState.editorCommand,
+      notifications: host.state.appState.notifications,
+      upgrade: host.state.appState.upgrade,
+      terminal,
+    });
+  } catch (error) {
+    host.showStatus(
+      `Failed to save hardware cursor setting: ${formatErrorMessage(error)}`,
+      'error',
+    );
+    return;
+  }
+
+  host.state.ui.setShowHardwareCursor(showHardwareCursor);
+  host.setAppState({ terminal });
+  host.track('hardware_cursor_preference_changed', { show_hardware_cursor: showHardwareCursor });
+  host.showStatus(`Hardware cursor ${showHardwareCursor ? 'enabled' : 'disabled'}.`);
 }
 
 async function applyPermissionChoice(host: SlashCommandHost, mode: PermissionMode): Promise<void> {
@@ -639,6 +703,7 @@ function handleSettingsSelection(host: SlashCommandHost, value: SettingsSelectio
     case 'theme': showThemePicker(host); return;
     case 'editor': showEditorPicker(host); return;
     case 'experiments': void showExperimentsPanel(host); return;
+    case 'hardware-cursor': showHardwareCursorPicker(host); return;
     case 'upgrade': showUpdatePreferencePicker(host); return;
     case 'usage': void showUsage(host); return;
   }

--- a/apps/kimi-code/src/tui/commands/reload.ts
+++ b/apps/kimi-code/src/tui/commands/reload.ts
@@ -43,10 +43,12 @@ export async function applyReloadedTuiConfig(
     : undefined;
   await host.applyTheme(config.theme, resolved);
   host.refreshTerminalThemeTracking();
+  host.state.ui.setShowHardwareCursor(config.terminal.showHardwareCursor);
   host.setAppState({
     editorCommand: config.editorCommand,
     notifications: config.notifications,
     upgrade: config.upgrade,
+    terminal: config.terminal,
   });
 }
 

--- a/apps/kimi-code/src/tui/components/dialogs/hardware-cursor-selector.ts
+++ b/apps/kimi-code/src/tui/components/dialogs/hardware-cursor-selector.ts
@@ -1,0 +1,34 @@
+import { ChoicePickerComponent, type ChoiceOption } from './choice-picker';
+
+const HARDWARE_CURSOR_OPTIONS: readonly ChoiceOption[] = [
+  {
+    value: 'on',
+    label: 'On',
+    description: 'Show the terminal cursor for IME candidate positioning.',
+  },
+  {
+    value: 'off',
+    label: 'Off',
+    description: 'Keep only the styled editor cursor visible.',
+  },
+];
+
+export interface HardwareCursorSelectorOptions {
+  readonly currentValue: boolean;
+  readonly onSelect: (value: boolean) => void;
+  readonly onCancel: () => void;
+}
+
+export class HardwareCursorSelectorComponent extends ChoicePickerComponent {
+  constructor(opts: HardwareCursorSelectorOptions) {
+    super({
+      title: 'Hardware cursor',
+      options: [...HARDWARE_CURSOR_OPTIONS],
+      currentValue: opts.currentValue ? 'on' : 'off',
+      onSelect: (value) => {
+        opts.onSelect(value === 'on');
+      },
+      onCancel: opts.onCancel,
+    });
+  }
+}

--- a/apps/kimi-code/src/tui/components/dialogs/settings-selector.ts
+++ b/apps/kimi-code/src/tui/components/dialogs/settings-selector.ts
@@ -6,6 +6,7 @@ export type SettingsSelection =
   | 'editor'
   | 'permission'
   | 'experiments'
+  | 'hardware-cursor'
   | 'upgrade'
   | 'usage';
 
@@ -36,6 +37,11 @@ const SETTINGS_OPTIONS: readonly ChoiceOption[] = [
     description: 'Turn experimental features on or off.',
   },
   {
+    value: 'hardware-cursor',
+    label: 'Hardware cursor',
+    description: 'Make IME candidate windows follow the input cursor.',
+  },
+  {
     value: 'upgrade',
     label: 'Automatic updates',
     description: 'Turn automatic CLI updates on or off.',
@@ -54,6 +60,7 @@ function isSettingsSelection(value: string): value is SettingsSelection {
     value === 'editor' ||
     value === 'permission' ||
     value === 'experiments' ||
+    value === 'hardware-cursor' ||
     value === 'upgrade' ||
     value === 'usage'
   );

--- a/apps/kimi-code/src/tui/components/index.ts
+++ b/apps/kimi-code/src/tui/components/index.ts
@@ -9,6 +9,7 @@ export * from './dialogs/compaction';
 export * from './dialogs/editor-selector';
 export * from './dialogs/experiments-selector';
 export * from './dialogs/help-panel';
+export * from './dialogs/hardware-cursor-selector';
 export * from './dialogs/model-selector';
 export * from './dialogs/permission-selector';
 export * from './dialogs/question-dialog';

--- a/apps/kimi-code/src/tui/config.ts
+++ b/apps/kimi-code/src/tui/config.ts
@@ -30,6 +30,10 @@ export const UpgradePreferencesSchema = z.object({
   autoInstall: z.boolean(),
 });
 
+export const TerminalPreferencesSchema = z.object({
+  showHardwareCursor: z.boolean(),
+});
+
 export const TuiConfigFileSchema = z.object({
   theme: TuiThemeSchema.optional(),
   editor: z
@@ -48,6 +52,11 @@ export const TuiConfigFileSchema = z.object({
       auto_install: z.boolean().optional(),
     })
     .optional(),
+  terminal: z
+    .object({
+      show_hardware_cursor: z.boolean().optional(),
+    })
+    .optional(),
 });
 
 export const TuiConfigSchema = z.object({
@@ -55,12 +64,14 @@ export const TuiConfigSchema = z.object({
   editorCommand: z.string().nullable(),
   notifications: NotificationsConfigSchema,
   upgrade: UpgradePreferencesSchema,
+  terminal: TerminalPreferencesSchema,
 });
 
 export type TuiConfigFileShape = z.infer<typeof TuiConfigFileSchema>;
 export type TuiConfig = z.infer<typeof TuiConfigSchema>;
 export type NotificationsConfig = z.infer<typeof NotificationsConfigSchema>;
 export type UpgradePreferences = z.infer<typeof UpgradePreferencesSchema>;
+export type TerminalPreferences = z.infer<typeof TerminalPreferencesSchema>;
 
 export const DEFAULT_NOTIFICATIONS_CONFIG: NotificationsConfig = {
   enabled: true,
@@ -71,11 +82,16 @@ export const DEFAULT_UPGRADE_PREFERENCES: UpgradePreferences = {
   autoInstall: true,
 };
 
+export const DEFAULT_TERMINAL_PREFERENCES: TerminalPreferences = {
+  showHardwareCursor: false,
+};
+
 export const DEFAULT_TUI_CONFIG: TuiConfig = TuiConfigSchema.parse({
   theme: 'auto',
   editorCommand: null,
   notifications: DEFAULT_NOTIFICATIONS_CONFIG,
   upgrade: DEFAULT_UPGRADE_PREFERENCES,
+  terminal: DEFAULT_TERMINAL_PREFERENCES,
 });
 
 /**
@@ -141,6 +157,10 @@ export function normalizeTuiConfig(config: TuiConfigFileShape): TuiConfig {
     upgrade: {
       autoInstall: config.upgrade?.auto_install ?? DEFAULT_UPGRADE_PREFERENCES.autoInstall,
     },
+    terminal: {
+      showHardwareCursor:
+        config.terminal?.show_hardware_cursor ?? DEFAULT_TERMINAL_PREFERENCES.showHardwareCursor,
+    },
   });
 }
 
@@ -160,6 +180,9 @@ notification_condition = "${config.notifications.condition}" # "unfocused" | "al
 
 [upgrade]
 auto_install = ${String(config.upgrade.autoInstall)} # true | false
+
+[terminal]
+show_hardware_cursor = ${String(config.terminal.showHardwareCursor)} # true | false
 `;
 }
 

--- a/apps/kimi-code/src/tui/kimi-tui.ts
+++ b/apps/kimi-code/src/tui/kimi-tui.ts
@@ -194,6 +194,7 @@ function createInitialAppState(input: KimiTUIStartupInput): AppState {
     editorCommand: input.tuiConfig.editorCommand,
     notifications: input.tuiConfig.notifications,
     upgrade: input.tuiConfig.upgrade,
+    terminal: input.tuiConfig.terminal,
     availableModels: {},
     availableProviders: {},
     sessionTitle: null,

--- a/apps/kimi-code/src/tui/tui-state.ts
+++ b/apps/kimi-code/src/tui/tui-state.ts
@@ -59,7 +59,7 @@ export function createTUIState(options: KimiTUIOptions): TUIState {
   const theme = currentTheme;
 
   const terminal = new ProcessTerminal();
-  const ui = new TUI(terminal);
+  const ui = new TUI(terminal, initialAppState.terminal.showHardwareCursor);
 
   const transcriptContainer = new GutterContainer(CHROME_GUTTER, CHROME_GUTTER);
   const activityContainer = new GutterContainer(CHROME_GUTTER, CHROME_GUTTER);

--- a/apps/kimi-code/src/tui/types.ts
+++ b/apps/kimi-code/src/tui/types.ts
@@ -8,7 +8,7 @@ import type {
   ToolInputDisplay,
 } from '@moonshot-ai/kimi-code-sdk';
 
-import type { NotificationsConfig, UpgradePreferences } from './config';
+import type { NotificationsConfig, TerminalPreferences, UpgradePreferences } from './config';
 import type { PendingApproval, PendingQuestion } from './reverse-rpc/types';
 import type { ColorToken, ThemeName } from './theme';
 
@@ -44,6 +44,7 @@ export interface AppState {
   editorCommand: string | null;
   notifications: NotificationsConfig;
   upgrade: UpgradePreferences;
+  terminal: TerminalPreferences;
   availableModels: Record<string, ModelAlias>;
   availableProviders: Record<string, ProviderConfig>;
   sessionTitle: string | null;

--- a/apps/kimi-code/test/cli/run-shell.test.ts
+++ b/apps/kimi-code/test/cli/run-shell.test.ts
@@ -14,6 +14,7 @@ const mocks = vi.hoisted(() => {
     theme: 'dark' | 'light' | 'auto';
     editorCommand: string | null;
     notifications: { enabled: boolean; condition: 'unfocused' | 'always' };
+    terminal: { showHardwareCursor: boolean };
   };
 
   class TuiConfigParseError extends Error {
@@ -415,6 +416,7 @@ describe('runShell', () => {
         theme: 'auto',
         editorCommand: 'vim',
         notifications: { enabled: true, condition: 'always' },
+        terminal: { showHardwareCursor: false },
       }),
     );
     mocks.detectTerminalTheme.mockResolvedValue('light');
@@ -622,7 +624,7 @@ describe('runShell', () => {
       new Error('Invalid configuration in ~/.kimi-code/config.toml'),
     );
 
-    // A broken config.toml must fail loudly — `kimi migrate` must not swallow
+    // A broken config.toml must fail loudly 鈥?`kimi migrate` must not swallow
     // it and proceed, or the user never learns their config is broken.
     await expect(
       runShell(

--- a/apps/kimi-code/test/cli/update/preflight.test.ts
+++ b/apps/kimi-code/test/cli/update/preflight.test.ts
@@ -164,6 +164,7 @@ function tuiConfig(overrides: Partial<TuiConfig> = {}): TuiConfig {
     editorCommand: null,
     notifications: { enabled: true, condition: 'unfocused' },
     upgrade: { autoInstall: true },
+    terminal: { showHardwareCursor: false },
     ...overrides,
   };
 }
@@ -537,7 +538,7 @@ describe('runUpdatePreflight', () => {
     const { stdout, stderr, options } = captureOutput();
     await expect(runUpdatePreflight('0.4.0', options)).resolves.toBe('continue');
     expect(stderr.join('')).toContain('warning: failed to install');
-    // A failed install must never print the "Updated …" success line.
+    // A failed install must never print the "Updated 鈥? success line.
     expect(stdout.join('')).not.toContain('Updated @moonshot-ai/kimi-code');
   });
 
@@ -1061,9 +1062,9 @@ describe('runUpdatePreflight', () => {
 });
 
 describe('spawnForSource native', () => {
-  // No spawn mock here — we run real bash to prove the failure contract
-  // end-to-end. `curl … | bash` reports only the trailing bash's exit status,
-  // so a curl that never connects (exit 7, empty stdin → bash exits 0) is
+  // No spawn mock here 鈥?we run real bash to prove the failure contract
+  // end-to-end. `curl 鈥?| bash` reports only the trailing bash's exit status,
+  // so a curl that never connects (exit 7, empty stdin 鈫?bash exits 0) is
   // masked and the update is wrongly reported as successful. `set -o pipefail`
   // makes the pipeline surface curl's failure. Shadowing `curl` with a shell
   // function keeps this offline and deterministic; skipped on Windows (no bash,

--- a/apps/kimi-code/test/tui/activity-pane.test.ts
+++ b/apps/kimi-code/test/tui/activity-pane.test.ts
@@ -32,6 +32,7 @@ function makeStartupInput(): KimiTUIStartupInput {
       editorCommand: null,
       notifications: { enabled: true, condition: 'unfocused' },
       upgrade: { autoInstall: true },
+    terminal: { showHardwareCursor: false },
     },
     version: '0.0.0-test',
     workDir: '/tmp/proj-a',
@@ -176,7 +177,7 @@ describe('updateActivityPane terminal progress', () => {
       expect(setProgress).toHaveBeenLastCalledWith(true);
       expect(state.activitySpinner).not.toBeNull();
       expect(state.activityContainer.children).toHaveLength(0);
-      expect(strip(progress.render(80).join('\n'))).toContain('🌑 Working...');
+      expect(strip(progress.render(80).join('\n'))).toContain('馃寫 Working...');
 
       state.activitySpinner?.instance.stop();
       driver.sessionEventHandler.clearAgentSwarmProgress();
@@ -207,7 +208,7 @@ describe('updateActivityPane terminal progress', () => {
       expect(state.activityContainer.children).toHaveLength(1);
       const output = strip(progress.render(80).join('\n'));
       expect(output).toContain('  Working...');
-      expect(output).not.toContain('🌑 Working...');
+      expect(output).not.toContain('馃寫 Working...');
 
       state.activitySpinner?.instance.stop();
       driver.sessionEventHandler.clearAgentSwarmProgress();

--- a/apps/kimi-code/test/tui/commands/reload.test.ts
+++ b/apps/kimi-code/test/tui/commands/reload.test.ts
@@ -44,6 +44,9 @@ notification_condition = "always"
 
 [upgrade]
 auto_install = false
+
+[terminal]
+show_hardware_cursor = true
 `);
     const session = { reloadSession: vi.fn() };
     const host = makeHost({ session });
@@ -58,7 +61,9 @@ auto_install = false
       editorCommand: 'vim',
       notifications: { enabled: false, condition: 'always' },
       upgrade: { autoInstall: false },
+      terminal: { showHardwareCursor: true },
     });
+    expect(host.state.ui.setShowHardwareCursor).toHaveBeenCalledWith(true);
     expect(host.showStatus).toHaveBeenCalledWith(
       'TUI config reloaded.',
       'success',
@@ -132,8 +137,12 @@ function makeHost({
       editorCommand: null,
       notifications: { enabled: true, condition: 'unfocused' },
       upgrade: { autoInstall: true },
+      terminal: { showHardwareCursor: false },
       availableModels: {},
       availableProviders: {},
+    },
+    ui: {
+      setShowHardwareCursor: vi.fn(),
     },
     theme: {
       palette: {

--- a/apps/kimi-code/test/tui/commands/update-preferences.test.ts
+++ b/apps/kimi-code/test/tui/commands/update-preferences.test.ts
@@ -1,6 +1,9 @@
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { applyUpdatePreferenceChoice } from '#/tui/commands/config';
+import {
+  applyHardwareCursorChoice,
+  applyUpdatePreferenceChoice,
+} from '#/tui/commands/config';
 import { darkColors } from '#/tui/theme/colors';
 
 const mocks = vi.hoisted(() => ({
@@ -18,6 +21,10 @@ vi.mock('../../../src/tui/config', async () => {
 });
 
 describe('update preference commands', () => {
+  beforeEach(() => {
+    mocks.saveTuiConfig.mockClear();
+  });
+
   it('saves automatic update preference changes to tui.toml', async () => {
     const setAppState = vi.fn();
     const showStatus = vi.fn();
@@ -29,7 +36,9 @@ describe('update preference commands', () => {
           editorCommand: null,
           notifications: { enabled: true, condition: 'unfocused' as const },
           upgrade: { autoInstall: true },
+          terminal: { showHardwareCursor: false },
         },
+        ui: { setShowHardwareCursor: vi.fn() },
         theme: { palette: darkColors },
       },
       setAppState,
@@ -44,9 +53,49 @@ describe('update preference commands', () => {
       editorCommand: null,
       notifications: { enabled: true, condition: 'unfocused' },
       upgrade: { autoInstall: false },
+      terminal: { showHardwareCursor: false },
     });
     expect(setAppState).toHaveBeenCalledWith({ upgrade: { autoInstall: false } });
     expect(track).toHaveBeenCalledWith('upgrade_preference_changed', { auto_install: false });
     expect(showStatus).toHaveBeenCalledWith('Automatic updates disabled.');
+  });
+
+  it('saves hardware cursor preference changes and applies them immediately', async () => {
+    const setAppState = vi.fn();
+    const showStatus = vi.fn();
+    const track = vi.fn();
+    const setShowHardwareCursor = vi.fn();
+    const host = {
+      state: {
+        appState: {
+          theme: 'auto' as const,
+          editorCommand: null,
+          notifications: { enabled: true, condition: 'unfocused' as const },
+          upgrade: { autoInstall: true },
+          terminal: { showHardwareCursor: false },
+        },
+        ui: { setShowHardwareCursor },
+        theme: { palette: darkColors },
+      },
+      setAppState,
+      showStatus,
+      track,
+    };
+
+    await applyHardwareCursorChoice(host, true);
+
+    expect(mocks.saveTuiConfig).toHaveBeenCalledWith({
+      theme: 'auto',
+      editorCommand: null,
+      notifications: { enabled: true, condition: 'unfocused' },
+      upgrade: { autoInstall: true },
+      terminal: { showHardwareCursor: true },
+    });
+    expect(setShowHardwareCursor).toHaveBeenCalledWith(true);
+    expect(setAppState).toHaveBeenCalledWith({ terminal: { showHardwareCursor: true } });
+    expect(track).toHaveBeenCalledWith('hardware_cursor_preference_changed', {
+      show_hardware_cursor: true,
+    });
+    expect(showStatus).toHaveBeenCalledWith('Hardware cursor enabled.');
   });
 });

--- a/apps/kimi-code/test/tui/components/chrome/footer.test.ts
+++ b/apps/kimi-code/test/tui/components/chrome/footer.test.ts
@@ -53,6 +53,7 @@ const appState: AppState = {
   editorCommand: null,
   notifications: { enabled: true, condition: 'unfocused' },
   upgrade: { autoInstall: true },
+  terminal: { showHardwareCursor: false },
   availableModels: {},
   availableProviders: {},
   mcpServersSummary: null,

--- a/apps/kimi-code/test/tui/components/chrome/welcome.test.ts
+++ b/apps/kimi-code/test/tui/components/chrome/welcome.test.ts
@@ -31,6 +31,7 @@ const appState: AppState = {
   editorCommand: null,
   notifications: { enabled: true, condition: 'unfocused' },
   upgrade: { autoInstall: true },
+  terminal: { showHardwareCursor: false },
   availableModels: {},
   availableProviders: {},
   mcpServersSummary: null,
@@ -75,7 +76,7 @@ describe('WelcomeComponent', () => {
   it('renders the banner in a single brand color by default', () => {
     const codes = truecolorCodes(headerOf(new WelcomeComponent(appState).render(80)));
 
-    // No rainbow by default — just the brand primary (plus the dim tagline).
+    // No rainbow by default 鈥?just the brand primary (plus the dim tagline).
     expect(codes.size).toBeLessThanOrEqual(2);
   });
 

--- a/apps/kimi-code/test/tui/components/dialogs/choice-picker.test.ts
+++ b/apps/kimi-code/test/tui/components/dialogs/choice-picker.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from 'vitest';
 
 import { ChoicePickerComponent } from '#/tui/components/dialogs/choice-picker';
 import { EditorSelectorComponent } from '#/tui/components/dialogs/editor-selector';
+import { HardwareCursorSelectorComponent } from '#/tui/components/dialogs/hardware-cursor-selector';
 import { PermissionSelectorComponent } from '#/tui/components/dialogs/permission-selector';
 import { SettingsSelectorComponent } from '#/tui/components/dialogs/settings-selector';
 import { ThemeSelectorComponent } from '#/tui/components/dialogs/theme-selector';
@@ -103,6 +104,7 @@ describe('ChoicePickerComponent', () => {
     const settingsOutput = settings.render(120).map(strip);
     expect(settingsOutput).toContain('  ❯ Model');
     expect(settingsOutput).toContain('    Switch the active model and thinking mode.');
+    expect(settingsOutput).toContain('    Make IME candidate windows follow the input cursor.');
     expect(settingsOutput).toContain('    Turn automatic CLI updates on or off.');
 
     const upgradePreference = new UpdatePreferenceSelectorComponent({
@@ -113,6 +115,14 @@ describe('ChoicePickerComponent', () => {
     const upgradePreferenceOutput = upgradePreference.render(120).map(strip);
     expect(upgradePreferenceOutput).toContain('  ❯ On ← current');
     expect(upgradePreferenceOutput).toContain('    Install new versions in the background.');
+
+    const hardwareCursor = new HardwareCursorSelectorComponent({
+      currentValue: false,
+      onSelect,
+      onCancel,
+    });
+    const hardwareCursorOutput = hardwareCursor.render(120).map(strip);
+    expect(hardwareCursorOutput).toContain('    Show the terminal cursor for IME candidate positioning.');
   });
 
   it('routes Space into the query for searchable lists instead of selecting', () => {

--- a/apps/kimi-code/test/tui/components/panels/footer-bg-agents.test.ts
+++ b/apps/kimi-code/test/tui/components/panels/footer-bg-agents.test.ts
@@ -33,7 +33,7 @@ function baseState(overrides: Partial<AppState> = {}): AppState {
   } as AppState;
 }
 
-describe('FooterComponent — background task / agent badges', () => {
+describe('FooterComponent 鈥?background task / agent badges', () => {
   it('omits both badges when counts are 0', () => {
     const footer = new FooterComponent(baseState());
     const [line1] = footer.render(120);

--- a/apps/kimi-code/test/tui/components/panels/footer-context.test.ts
+++ b/apps/kimi-code/test/tui/components/panels/footer-context.test.ts
@@ -43,15 +43,15 @@ function baseState(overrides: Partial<AppState> = {}): AppState {
   } as AppState;
 }
 
-describe('FooterComponent — context NaN resilience', () => {
-  it('NaN usage → renders 0.0% (never literal "NaN%")', () => {
+describe('FooterComponent 鈥?context NaN resilience', () => {
+  it('NaN usage 鈫?renders 0.0% (never literal "NaN%")', () => {
     const fc = new FooterComponent(baseState({ contextUsage: Number.NaN }));
     const out = strip(fc.render(120).join(''));
     expect(out).not.toMatch(/NaN/);
     expect(out).toMatch(/context: 0\.0%/);
   });
 
-  it('undefined-ish (coerced) usage → renders 0.0%', () => {
+  it('undefined-ish (coerced) usage 鈫?renders 0.0%', () => {
     const fc = new FooterComponent(
       baseState({ contextUsage: undefined as unknown as number }),
     );
@@ -60,19 +60,19 @@ describe('FooterComponent — context NaN resilience', () => {
     expect(out).toMatch(/context: 0\.0%/);
   });
 
-  it('clamps ratios above 1.0 → renders 100.0%', () => {
+  it('clamps ratios above 1.0 鈫?renders 100.0%', () => {
     const fc = new FooterComponent(baseState({ contextUsage: 1.5 }));
     const out = strip(fc.render(120).join(''));
     expect(out).toMatch(/context: 100\.0%/);
   });
 
-  it('ratio 0.427 → renders 42.7%', () => {
+  it('ratio 0.427 鈫?renders 42.7%', () => {
     const fc = new FooterComponent(baseState({ contextUsage: 0.427 }));
     const out = strip(fc.render(200).join(''));
     expect(out).toMatch(/context: 42\.7%/);
   });
 
-  it('tokens provided but max=0 → falls back to percent-only, no division-by-zero artefact', () => {
+  it('tokens provided but max=0 鈫?falls back to percent-only, no division-by-zero artefact', () => {
     const fc = new FooterComponent(
       baseState({ contextUsage: 0, contextTokens: 500, maxContextTokens: 0 }),
     );
@@ -146,7 +146,7 @@ describe('FooterComponent — context NaN resilience', () => {
   });
 });
 
-describe('buildWeightedTips — weighted rotation', () => {
+describe('buildWeightedTips 鈥?weighted rotation', () => {
   it('repeats higher-priority tips more often (length = sum of weights)', () => {
     const seq = buildWeightedTips([
       { text: 'a' }, // weight 1 (default)
@@ -162,7 +162,7 @@ describe('buildWeightedTips — weighted rotation', () => {
     expect(count('b')).toBeGreaterThan(count('a'));
   });
 
-  it('keeps duplicates spread out — no tip sits next to itself', () => {
+  it('keeps duplicates spread out 鈥?no tip sits next to itself', () => {
     const seq = buildWeightedTips([
       { text: 'a' },
       { text: 'b', priority: 3 },

--- a/apps/kimi-code/test/tui/components/panels/footer-goal-badge.test.ts
+++ b/apps/kimi-code/test/tui/components/panels/footer-goal-badge.test.ts
@@ -51,7 +51,7 @@ function goal(overrides: Partial<GoalSnapshot> = {}): GoalSnapshot {
   } as GoalSnapshot;
 }
 
-describe('FooterComponent — goal badge', () => {
+describe('FooterComponent 鈥?goal badge', () => {
   afterEach(() => {
     vi.useRealTimers();
   });

--- a/apps/kimi-code/test/tui/config.test.ts
+++ b/apps/kimi-code/test/tui/config.test.ts
@@ -37,6 +37,8 @@ describe('TUI config', () => {
     expect(text).toContain('command = ""');
     expect(text).toContain('[upgrade]');
     expect(text).toContain('auto_install = true');
+    expect(text).toContain('[terminal]');
+    expect(text).toContain('show_hardware_cursor = false');
     expect(text).toContain('[notifications]');
     expect(text).toContain('enabled = true');
     expect(text).toContain('notification_condition = "unfocused"');
@@ -55,6 +57,9 @@ notification_condition = "always"
 
 [upgrade]
 auto_install = false
+
+[terminal]
+show_hardware_cursor = true
 `);
 
     expect(config).toEqual({
@@ -62,6 +67,7 @@ auto_install = false
       editorCommand: 'code --wait',
       notifications: { enabled: false, condition: 'always' },
       upgrade: { autoInstall: false },
+      terminal: { showHardwareCursor: true },
     });
   });
 
@@ -76,6 +82,7 @@ command = "   "
       editorCommand: null,
       notifications: { enabled: true, condition: 'unfocused' },
       upgrade: { autoInstall: true },
+      terminal: { showHardwareCursor: false },
     });
   });
 
@@ -84,6 +91,7 @@ command = "   "
 
     expect(config.notifications).toEqual({ enabled: true, condition: 'unfocused' });
     expect(config.upgrade).toEqual({ autoInstall: true });
+    expect(config.terminal).toEqual({ showHardwareCursor: false });
   });
 
   it('throws TuiConfigParseError with fallback when parsing fails, leaving the file untouched', async () => {
@@ -107,6 +115,7 @@ command = "   "
         editorCommand: 'vim',
         notifications: { enabled: false, condition: 'always' },
         upgrade: { autoInstall: false },
+        terminal: { showHardwareCursor: true },
       },
       filePath,
     );
@@ -116,6 +125,7 @@ command = "   "
       editorCommand: 'vim',
       notifications: { enabled: false, condition: 'always' },
       upgrade: { autoInstall: false },
+      terminal: { showHardwareCursor: true },
     });
   });
 
@@ -127,6 +137,7 @@ command = "   "
         editorCommand: null,
         notifications: DEFAULT_TUI_CONFIG.notifications,
         upgrade: DEFAULT_TUI_CONFIG.upgrade,
+        terminal: DEFAULT_TUI_CONFIG.terminal,
       },
       filePath,
     );

--- a/apps/kimi-code/test/tui/create-tui-state.test.ts
+++ b/apps/kimi-code/test/tui/create-tui-state.test.ts
@@ -26,6 +26,7 @@ function fakeInitialAppState(): AppState {
     editorCommand: null,
     notifications: { enabled: true, condition: 'unfocused' },
     upgrade: { autoInstall: true },
+    terminal: { showHardwareCursor: false },
     availableModels: {},
     availableProviders: {},
     sessionTitle: null,

--- a/apps/kimi-code/test/tui/kimi-tui-message-flow.test.ts
+++ b/apps/kimi-code/test/tui/kimi-tui-message-flow.test.ts
@@ -105,6 +105,7 @@ function makeStartupInput(): KimiTUIStartupInput {
       editorCommand: null,
       notifications: { enabled: true, condition: 'unfocused' },
       upgrade: { autoInstall: true },
+    terminal: { showHardwareCursor: false },
     },
     version: '0.0.0-test',
     workDir: '/tmp/proj-a',
@@ -1759,7 +1760,7 @@ command = "vim"
     const finalLines = mountedPanel.render(80).map(stripSgr);
     expect(finalLines).toHaveLength(thinkingLines.length);
     expect(finalLines.join('\n')).toContain('final answer');
-    expect(finalLines.at(-1)).toMatch(/^│\s+│$/);
+    expect(finalLines.at(-1)).toMatch(/^鈹俓s+鈹?/);
   });
 
   it('caps /btw height to one-third of the terminal and supports scrolling', async () => {
@@ -1779,7 +1780,7 @@ command = "vim"
 
     const collapsed = panel.render(80).map(stripSgr);
     expect(collapsed).toHaveLength(5);
-    expect(collapsed.join('\n')).toContain('BTW ─ Esc close · ↑↓ scroll');
+    expect(collapsed.join('\n')).toContain('BTW 鈹€ Esc close 路 鈫戔啌 scroll');
     expect(collapsed.join('\n')).not.toContain('ctrl+o expand');
     expect(collapsed.join('\n')).toContain('question 8');
     expect(collapsed.join('\n')).toContain('answer 8');
@@ -1787,8 +1788,8 @@ command = "vim"
 
     driver.state.editor.setText('draft main input');
     const collapsedWithInput = panel.render(80).map(stripSgr);
-    expect(collapsedWithInput.join('\n')).toContain('BTW ─ Esc close');
-    expect(collapsedWithInput.join('\n')).not.toContain('↑↓ scroll');
+    expect(collapsedWithInput.join('\n')).toContain('BTW 鈹€ Esc close');
+    expect(collapsedWithInput.join('\n')).not.toContain('鈫戔啌 scroll');
     driver.state.editor.setText('');
 
     const requestRender = vi.mocked(driver.state.ui.requestRender);
@@ -2574,7 +2575,7 @@ command = "vim"
     );
 
     transcript = stripSgr(renderTranscript(driver));
-    expect(transcript).toContain('✓ Imports are stable');
+    expect(transcript).toContain('鉁?Imports are stable');
     expect(transcript).not.toContain('Completed');
   });
 
@@ -2638,8 +2639,8 @@ command = "vim"
     );
 
     const transcript = stripSgr(driver.state.transcriptContainer.render(200).join('\n'));
-    expect(transcript).toContain('⊘ Cancelled.');
-    expect(transcript).toContain('✗ The user manually interrupted this subagent x.');
+    expect(transcript).toContain('鈯?Cancelled.');
+    expect(transcript).toContain('鉁?The user manually interrupted this subagent x.');
   });
 
   it('does not let later transcript entries reduce the AgentSwarm grid height', async () => {
@@ -2757,8 +2758,8 @@ command = "vim"
     const totalStatusLine = transcript.split('\n').find((line) => line.includes('Completed.'));
     expect(totalStatusLine).toBeDefined();
     expect(totalStatusLine).not.toContain('Failed.');
-    expect(transcript).toContain('✓ Imports are stable.');
-    expect(transcript).toContain('✗ Agent timed out after 30s.');
+    expect(transcript).toContain('鉁?Imports are stable.');
+    expect(transcript).toContain('鉁?Agent timed out after 30s.');
   });
 
   it('renders AgentSwarm progress while tool args are still streaming', async () => {
@@ -2912,7 +2913,7 @@ command = "vim"
 
     await vi.waitFor(() => {
       const transcript = stripSgr(renderTranscript(driver));
-      expect(transcript).toContain('plan: reject-plan.md · Rejected');
+      expect(transcript).toContain('plan: reject-plan.md 路 Rejected');
       expect(transcript).toContain('Reject Plan');
       expect(countOccurrences(transcript, 'keep this plan visible after reject')).toBe(1);
       expect(transcript).not.toContain('Rejected: Review plan');
@@ -3006,7 +3007,7 @@ command = "vim"
       expect(output).toContain('/mcp-config login linear');
       expect(output).toContain('disabled-tools');
       expect(output).toContain('disabled');
-      expect(output).toContain('1 connected · 1 needs auth · 1 failed · 1 disabled · 2 tools available');
+      expect(output).toContain('1 connected 路 1 needs auth 路 1 failed 路 1 disabled 路 2 tools available');
     });
   });
 
@@ -3204,7 +3205,7 @@ command = "vim"
     // refreshed render rather than for an instance swap.
     await vi.waitFor(() => {
       const refreshed = stripSgr(driver.state.editorContainer.children[0]!.render(120).join('\n'));
-      expect(refreshed).toContain('❯ Demo  disabled  require run /new or /reload to apply');
+      expect(refreshed).toContain('鉂?Demo  disabled  require run /new or /reload to apply');
     });
     const out = stripSgr(driver.state.editorContainer.children[0]!.render(120).join('\n'));
     expect(out).not.toContain('Space enable');
@@ -3299,7 +3300,7 @@ command = "vim"
       expect(driver.state.editorContainer.children[0]).toBeInstanceOf(PluginMcpSelectorComponent);
     });
     const out = stripSgr(driver.state.editorContainer.children[0]!.render(120).join('\n'));
-    expect(out).toContain('❯ data  disabled  require run /new or /reload to apply');
+    expect(out).toContain('鉂?data  disabled  require run /new or /reload to apply');
     expect(stripSgr(renderTranscript(driver))).not.toContain(
       'Disabled MCP server data for kimi-datasource. Run /new or /reload to apply.',
     );
@@ -3387,8 +3388,8 @@ command = "vim"
     });
     const picker = driver.state.editorContainer.children[0];
     const pickerOutput = stripSgr((picker as TabbedModelSelectorComponent).render(120).join('\n'));
-    expect(pickerOutput).toMatch(/Kimi K2\s+Kimi Code ← current/);
-    expect(pickerOutput).toMatch(/❯ Kimi Turbo\s+Kimi Code/);
+    expect(pickerOutput).toMatch(/Kimi K2\s+Kimi Code 鈫?current/);
+    expect(pickerOutput).toMatch(/鉂?Kimi Turbo\s+Kimi Code/);
     (picker as TabbedModelSelectorComponent).handleInput('t');
     (picker as TabbedModelSelectorComponent).handleInput('u');
     const filteredOutput = stripSgr((picker as TabbedModelSelectorComponent).render(120).join('\n'));
@@ -3396,7 +3397,7 @@ command = "vim"
     expect(filteredOutput).toContain('Kimi Turbo');
     expect(filteredOutput).not.toContain('Kimi K2');
     // Turbo is a thinking-capable model that is not the active one, so it
-    // defaults to thinking on — selecting it applies thinking without a toggle.
+    // defaults to thinking on 鈥?selecting it applies thinking without a toggle.
     (picker as TabbedModelSelectorComponent).handleInput('\r');
 
     await vi.waitFor(() => {

--- a/apps/kimi-code/test/tui/kimi-tui-startup.test.ts
+++ b/apps/kimi-code/test/tui/kimi-tui-startup.test.ts
@@ -90,6 +90,7 @@ function makeStartupInput(
       editorCommand: null,
       notifications: { enabled: true, condition: 'unfocused' },
       upgrade: { autoInstall: true },
+      terminal: { showHardwareCursor: false },
       ...tuiConfig,
     },
     version: '0.0.0-test',
@@ -1119,7 +1120,7 @@ describe('KimiTUI startup', () => {
     await (driver as any).refreshProviderModelsInBackground();
 
     expect(showStatus).toHaveBeenCalledTimes(1);
-    expect(showStatus).toHaveBeenCalledWith("New Models · +2 models.");
+    expect(showStatus).toHaveBeenCalledWith("New Models 路 +2 models.");
   });
 
   it("starts TUI without a session when fresh startup needs OAuth login", async () => {
@@ -1506,7 +1507,7 @@ describe('KimiTUI startup', () => {
       migrationPlan: MIGRATION_PLAN,
       migrateOnly: true,
     }) as unknown as MigrateExitDriver;
-    // pi-tui start/stop and focus tracking touch the real TTY — stub the I/O.
+    // pi-tui start/stop and focus tracking touch the real TTY 鈥?stub the I/O.
     vi.spyOn(driver.state.ui, 'start').mockImplementation(() => {});
     vi.spyOn(driver.state.ui, 'stop').mockImplementation(() => {});
     vi.spyOn(driver.state.terminal, 'write').mockImplementation(() => {});
@@ -1518,7 +1519,7 @@ describe('KimiTUI startup', () => {
     await driver.start();
 
     // `kimi migrate` exits via process.exit; startEventLoop() installed focus
-    // tracking, so the exit path must dispose it — otherwise the terminal
+    // tracking, so the exit path must dispose it 鈥?otherwise the terminal
     // keeps emitting focus/OSC sequences after the command finishes.
     expect(driver.terminalFocusTrackingDispose).toBeUndefined();
     expect(onExit).toHaveBeenCalledWith(0);
@@ -1542,7 +1543,7 @@ describe('KimiTUI startup', () => {
     await expect(driver.start()).rejects.toThrow('resume boom');
 
     // The focus tracking installed by startEventLoop() must be torn down
-    // before the error propagates — not left active after the process exits.
+    // before the error propagates 鈥?not left active after the process exits.
     expect(driver.terminalFocusTrackingDispose).toBeUndefined();
   });
 

--- a/apps/kimi-code/test/tui/message-replay.test.ts
+++ b/apps/kimi-code/test/tui/message-replay.test.ts
@@ -55,6 +55,7 @@ function makeStartupInput(): KimiTUIStartupInput {
       editorCommand: null,
       notifications: { enabled: true, condition: 'unfocused' },
       upgrade: { autoInstall: true },
+    terminal: { showHardwareCursor: false },
     },
     version: '0.0.0-test',
     workDir: '/tmp/proj-a',
@@ -295,7 +296,7 @@ describe('KimiTUI resume message replay', () => {
         [
           {
             type: 'text',
-            text: '<system-reminder>\n✓ Goal complete.\nWorked 1 turn over 7m15s, using 4.3M tokens.\n</system-reminder>',
+            text: '<system-reminder>\n鉁?Goal complete.\nWorked 1 turn over 7m15s, using 4.3M tokens.\n</system-reminder>',
           },
         ],
         { origin: { kind: 'system_trigger', name: 'goal_completion' } },
@@ -393,7 +394,7 @@ describe('KimiTUI resume message replay', () => {
     expect(transcript).toContain('Goal paused');
     expect(transcript).toContain('Goal resumed');
     expect(transcript).toContain('Goal blocked');
-    expect(transcript).toContain('Goal complete — done');
+    expect(transcript).toContain('Goal complete 鈥?done');
     expect(transcript).toContain('Worked 1 turn over 7m15s, using 4.3k tokens.');
   });
 
@@ -440,7 +441,7 @@ describe('KimiTUI resume message replay', () => {
     expect(entry).toMatchObject({
       kind: 'assistant',
       renderMode: 'markdown',
-      content: '✓ Goal complete.\nWorked 1 turn over 7m15s, using 4.3M tokens.',
+      content: '鉁?Goal complete.\nWorked 1 turn over 7m15s, using 4.3M tokens.',
     });
   });
 
@@ -653,7 +654,7 @@ describe('KimiTUI resume message replay', () => {
     const driver = await replayIntoDriver(replay);
     const transcript = stripAnsi(driver.state.transcriptContainer.render(140).join('\n'));
 
-    expect(transcript).toContain('Agent swarm: ✓ 1 completed · ✗ 1 failed');
+    expect(transcript).toContain('Agent swarm: 鉁?1 completed 路 鉁?1 failed');
     expect(transcript).not.toContain('<agent_swarm_result>');
     expect(transcript).not.toContain('Reviewed src/a.ts.');
     expect(transcript).not.toContain('Agent timed out.');
@@ -693,8 +694,8 @@ describe('KimiTUI resume message replay', () => {
     const driver = await replayIntoDriver(replay);
     const transcript = stripAnsi(driver.state.transcriptContainer.render(140).join('\n'));
 
-    expect(transcript).toContain('Agent swarm: ✗ 1 failed · ⊘ 1 aborted');
-    expect(transcript).not.toContain('Agent swarm: ✓ Completed.');
+    expect(transcript).toContain('Agent swarm: 鉁?1 failed 路 鈯?1 aborted');
+    expect(transcript).not.toContain('Agent swarm: 鉁?Completed.');
     expect(transcript).not.toContain('<agent_swarm_result>');
   });
 
@@ -1017,7 +1018,7 @@ describe('KimiTUI resume message replay', () => {
     });
     const transcript = stripAnsi(driver.state.transcriptContainer.render(120).join('\n'));
     expect(transcript).toContain('Compaction complete');
-    expect(transcript).toContain('120 → 24 tokens');
+    expect(transcript).toContain('120 鈫?24 tokens');
     expect(transcript).toContain('preserve implementation notes');
     expect(transcript).not.toContain('Compacted transcript summary.');
   });

--- a/apps/kimi-code/test/tui/signal-handlers.test.ts
+++ b/apps/kimi-code/test/tui/signal-handlers.test.ts
@@ -28,6 +28,7 @@ function makeStartupInput(): KimiTUIStartupInput {
       editorCommand: null,
       notifications: { enabled: true, condition: 'unfocused' },
       upgrade: { autoInstall: true },
+    terminal: { showHardwareCursor: false },
     },
     version: '0.0.0-test',
     workDir: '/tmp/proj-signals',
@@ -287,7 +288,7 @@ describe('KimiTUI signal handlers', () => {
 
   it('stop() unregisters previously-installed signal handlers', async () => {
     const { driver, tui } = makeDriver();
-    // Suppress real stop work for this test — focus on the cleanup contract.
+    // Suppress real stop work for this test 鈥?focus on the cleanup contract.
     vi.spyOn(tui, 'stop').mockImplementation(async () => {
       (tui as unknown as SignalDriver).unregisterSignalHandlers();
     });
@@ -323,7 +324,7 @@ describe('KimiTUI signal handlers', () => {
   it('start() unregisters signal handlers when initialization throws', async () => {
     const { tui } = makeDriver();
     // Force the very first awaited call inside start() to reject. We don't
-    // care which method blows up — only that the failure surfaces and any
+    // care which method blows up 鈥?only that the failure surfaces and any
     // listeners we installed up front get cleaned up before the throw escapes.
     vi.spyOn(tui as unknown as { initMainTui(): Promise<boolean> }, 'initMainTui').mockRejectedValue(
       new Error('init boom'),

--- a/docs/en/configuration/config-files.md
+++ b/docs/en/configuration/config-files.md
@@ -248,6 +248,7 @@ Alongside `config.toml`, the CLI keeps terminal-UI and client preferences in a c
 | `[notifications].enabled` | `boolean` | `true` | Whether desktop notifications are sent |
 | `[notifications].notification_condition` | `string` | `unfocused` | When to notify: `unfocused` (only when the terminal is not focused) or `always` |
 | `[upgrade].auto_install` | `boolean` | `true` | Whether new versions are installed automatically |
+| `[terminal].show_hardware_cursor` | `boolean` | `false` | Whether to show the terminal cursor so some IMEs can place candidate windows at the input cursor |
 
 ```toml
 # ~/.kimi-code/tui.toml
@@ -262,6 +263,9 @@ notification_condition = "unfocused" # "unfocused" | "always"
 
 [upgrade]
 auto_install = true
+
+[terminal]
+show_hardware_cursor = false
 ```
 
 Changes apply on the next start, or immediately with `/reload-tui` (which reloads only `tui.toml`); `/reload` reloads both `config.toml` and `tui.toml`.

--- a/docs/en/configuration/data-locations.md
+++ b/docs/en/configuration/data-locations.md
@@ -28,7 +28,7 @@ Once set, **all** Kimi Code data — config, sessions, logs, OAuth credentials, 
 ```
 $KIMI_CODE_HOME  (default: ~/.kimi-code)
 ├── config.toml             # User configuration
-├── tui.toml                # Terminal UI preferences (including auto-update toggle)
+├── tui.toml                # Terminal UI preferences
 ├── AGENTS.md               # Global Kimi-specific agent instructions (optional)
 ├── mcp.json                # User-level MCP server declarations (optional)
 ├── skills/                 # Kimi-specific user-level Skills (optional)
@@ -61,7 +61,7 @@ $KIMI_CODE_HOME  (default: ~/.kimi-code)
 Each top-level file under the data root serves a specific purpose; most are managed automatically by the CLI:
 
 - **`config.toml`**: the main runtime configuration file, storing user-level settings such as providers, models, and loop control. See [Configuration files](./config-files.md).
-- **`tui.toml`**: terminal UI client preferences, including `[upgrade].auto_install` (auto-update, on by default). You can disable it in `/settings` or by manually setting `auto_install = false`.
+- **`tui.toml`**: terminal UI client preferences, including `[upgrade].auto_install` (auto-update, on by default) and `[terminal].show_hardware_cursor` (for IME candidate window positioning). You can change these in `/settings` or by editing the file.
 - **`AGENTS.md`**: global Kimi-specific agent instructions. This file moves with `KIMI_CODE_HOME`; generic cross-tool instructions can still live under `~/.agents/AGENTS.md`.
 - **`mcp.json`**: user-level MCP server declarations, merged with the project-local `.kimi-code/mcp.json` on startup. See [MCP](../customization/mcp.md).
 - **`skills/`**: Kimi-specific user-level Skills. This directory moves with `KIMI_CODE_HOME`; generic cross-tool Skills can still live under `~/.agents/skills/`. See [Agent Skills](../customization/skills.md).

--- a/docs/zh/configuration/config-files.md
+++ b/docs/zh/configuration/config-files.md
@@ -248,6 +248,7 @@ MCP server 的声明配置写在 `~/.kimi-code/mcp.json` 或项目内 `.kimi-cod
 | `[notifications].enabled` | `boolean` | `true` | 是否发送桌面通知 |
 | `[notifications].notification_condition` | `string` | `unfocused` | 何时通知：`unfocused`（仅终端失去焦点时）或 `always`（总是） |
 | `[upgrade].auto_install` | `boolean` | `true` | 是否自动安装新版本 |
+| `[terminal].show_hardware_cursor` | `boolean` | `false` | 是否显示终端光标，以便部分 IME 将候选窗定位到输入光标处 |
 
 ```toml
 # ~/.kimi-code/tui.toml
@@ -262,6 +263,9 @@ notification_condition = "unfocused" # "unfocused" | "always"
 
 [upgrade]
 auto_install = true
+
+[terminal]
+show_hardware_cursor = false
 ```
 
 修改在下次启动时生效，或用 `/reload-tui` 立即生效（只重载 `tui.toml`）；`/reload` 会同时重载 `config.toml` 和 `tui.toml`。

--- a/docs/zh/configuration/data-locations.md
+++ b/docs/zh/configuration/data-locations.md
@@ -28,7 +28,7 @@ export KIMI_CODE_HOME="$HOME/.config/kimi-code"
 ```
 $KIMI_CODE_HOME  （默认 ~/.kimi-code）
 ├── config.toml             # 用户配置
-├── tui.toml                # 终端界面偏好（含自动更新开关）
+├── tui.toml                # 终端界面偏好
 ├── AGENTS.md               # 全局 Kimi 专属 Agent 指令（可选）
 ├── mcp.json                # 用户级 MCP server 声明（可选）
 ├── skills/                 # Kimi 专属用户级 Skills（可选）
@@ -61,7 +61,7 @@ $KIMI_CODE_HOME  （默认 ~/.kimi-code）
 数据根下的顶层文件各有用途，大部分由 CLI 自动管理：
 
 - **`config.toml`**：主运行时配置，存放供应商、模型、循环控制等用户级设置。详见[配置文件](./config-files.md)。
-- **`tui.toml`**：终端界面客户端偏好，包括 `[upgrade].auto_install`（自动更新，默认开启）。可在 `/settings` 关闭，或手动设为 `auto_install = false`。
+- **`tui.toml`**：终端界面客户端偏好，包括 `[upgrade].auto_install`（自动更新，默认开启）和 `[terminal].show_hardware_cursor`（用于 IME 候选窗定位）。可在 `/settings` 修改，也可以直接编辑该文件。
 - **`AGENTS.md`**：全局 Kimi 专属 Agent 指令。该文件会随 `KIMI_CODE_HOME` 移动；跨工具通用指令仍可放在 `~/.agents/AGENTS.md`。
 - **`mcp.json`**：用户级 MCP server 声明，启动时与项目内的 `.kimi-code/mcp.json` 合并加载。详见 [MCP](../customization/mcp.md)。
 - **`skills/`**：Kimi 专属用户级 Skills。该目录会随 `KIMI_CODE_HOME` 移动；跨工具通用 Skills 仍可放在 `~/.agents/skills/`。详见 [Agent Skills](../customization/skills.md)。

--- a/packages/migration-legacy/src/stub-detect.ts
+++ b/packages/migration-legacy/src/stub-detect.ts
@@ -11,17 +11,23 @@ export const DEFAULT_CONFIG_FILE_TEXT =
 // Verbatim from apps/kimi-code/src/tui/config.ts:renderTuiConfig(DEFAULT_TUI_CONFIG)
 export const DEFAULT_TUI_RENDER =
   '# ~/.kimi-code/tui.toml\n' +
-  '# Terminal UI preferences for kimi-code.\n' +
+  '# Client preferences for kimi-code.\n' +
   '# Agent/runtime settings stay in ~/.kimi-code/config.toml.\n' +
   '\n' +
-  'theme = "auto" # "auto" | "dark" | "light"\n' +
+  'theme = "auto" # "auto" | "dark" | "light" | custom theme name\n' +
   '\n' +
   '[editor]\n' +
   'command = "" # Empty uses $VISUAL / $EDITOR\n' +
   '\n' +
   '[notifications]\n' +
   'enabled = true # true | false\n' +
-  'notification_condition = "unfocused" # "unfocused" | "always"\n';
+  'notification_condition = "unfocused" # "unfocused" | "always"\n' +
+  '\n' +
+  '[upgrade]\n' +
+  'auto_install = true # true | false\n' +
+  '\n' +
+  '[terminal]\n' +
+  'show_hardware_cursor = false # true | false\n';
 
 export async function isConfigStubOrMissing(configPath: string): Promise<boolean> {
   let text: string;
@@ -48,6 +54,8 @@ export async function isTuiStubOrMissing(tuiPath: string): Promise<boolean> {
     const theme = parsed['theme'];
     const editor = parsed['editor'] as Record<string, unknown> | undefined;
     const notifications = parsed['notifications'] as Record<string, unknown> | undefined;
+    const upgrade = parsed['upgrade'] as Record<string, unknown> | undefined;
+    const terminal = parsed['terminal'] as Record<string, unknown> | undefined;
 
     const themeOk = theme === undefined || theme === 'auto';
     const editorOk =
@@ -60,8 +68,16 @@ export async function isTuiStubOrMissing(tuiPath: string): Promise<boolean> {
       notifications === undefined ||
       notifications['notification_condition'] === undefined ||
       notifications['notification_condition'] === 'unfocused';
+    const upgradeOk =
+      upgrade === undefined ||
+      upgrade['auto_install'] === undefined ||
+      upgrade['auto_install'] === true;
+    const terminalOk =
+      terminal === undefined ||
+      terminal['show_hardware_cursor'] === undefined ||
+      terminal['show_hardware_cursor'] === false;
 
-    return themeOk && editorOk && notifEnabledOk && notifCondOk;
+    return themeOk && editorOk && notifEnabledOk && notifCondOk && upgradeOk && terminalOk;
   } catch {
     return false; // unparseable = treat as user-modified, do not overwrite
   }

--- a/packages/migration-legacy/test/stub-detect.test.ts
+++ b/packages/migration-legacy/test/stub-detect.test.ts
@@ -59,17 +59,23 @@ describe('isTuiStubOrMissing', () => {
   it('returns true when content is byte-equal to default render', async () => {
     const defaultRender =
       '# ~/.kimi-code/tui.toml\n' +
-      '# Terminal UI preferences for kimi-code.\n' +
+      '# Client preferences for kimi-code.\n' +
       '# Agent/runtime settings stay in ~/.kimi-code/config.toml.\n' +
       '\n' +
-      'theme = "auto" # "auto" | "dark" | "light"\n' +
+      'theme = "auto" # "auto" | "dark" | "light" | custom theme name\n' +
       '\n' +
       '[editor]\n' +
       'command = "" # Empty uses $VISUAL / $EDITOR\n' +
       '\n' +
       '[notifications]\n' +
       'enabled = true # true | false\n' +
-      'notification_condition = "unfocused" # "unfocused" | "always"\n';
+      'notification_condition = "unfocused" # "unfocused" | "always"\n' +
+      '\n' +
+      '[upgrade]\n' +
+      'auto_install = true # true | false\n' +
+      '\n' +
+      '[terminal]\n' +
+      'show_hardware_cursor = false # true | false\n';
     await writeFile(join(dir, 'tui.toml'), defaultRender, 'utf-8');
     expect(await isTuiStubOrMissing(join(dir, 'tui.toml'))).toBe(true);
   });


### PR DESCRIPTION
## Related Issue

Resolve #1022

## Problem

See linked issue.

## What changed

- Added a `terminal.show_hardware_cursor` TUI preference and `/settings` selector for hardware cursor visibility.
- Applied the setting during startup and `/reload` / `/reload-tui` so IME candidate windows can follow the input cursor on terminals that require a visible hardware cursor.
- Updated the default `tui.toml` render path, migration stub detection, tests, docs, and changeset.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.

Verification:

- `corepack pnpm --config.engine-strict=false vitest run apps/kimi-code/test/tui/config.test.ts apps/kimi-code/test/tui/commands/reload.test.ts apps/kimi-code/test/tui/commands/update-preferences.test.ts apps/kimi-code/test/tui/components/dialogs/choice-picker.test.ts packages/migration-legacy/test/stub-detect.test.ts packages/migration-legacy/test/steps/config.test.ts`
- `corepack pnpm --config.engine-strict=false --filter @moonshot-ai/kimi-code run typecheck`
- `corepack pnpm --config.engine-strict=false --filter @moonshot-ai/migration-legacy run typecheck`
- `corepack pnpm --config.engine-strict=false exec oxlint apps/kimi-code/src/tui/commands/config.ts apps/kimi-code/src/tui/commands/reload.ts apps/kimi-code/src/tui/components/dialogs/hardware-cursor-selector.ts apps/kimi-code/src/tui/components/dialogs/settings-selector.ts apps/kimi-code/src/tui/components/index.ts apps/kimi-code/src/tui/config.ts apps/kimi-code/src/tui/kimi-tui.ts apps/kimi-code/src/tui/tui-state.ts apps/kimi-code/src/tui/types.ts packages/migration-legacy/src/stub-detect.ts`
- `git diff --check`

Note: Local verification used `--config.engine-strict=false` because this Windows environment has Node v22.19.0, below the repo requirement `>=24.15.0`.