### PR TITLE
fix(agent-core): realign mid-history interrupted tool calls on resume

### DIFF
--- a/.changeset/fix-mid-history-interrupted-tool-call.md
+++ b/.changeset/fix-mid-history-interrupted-tool-call.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Fix resume not realigning a tool call that was interrupted mid-history. The synthetic interrupted result is now closed in place at the next step boundary, so later turns and deferred messages keep their recorded order instead of only the trailing exchange being repaired.

--- a/.changeset/fix-mid-history-interrupted-tool-call.md
+++ b/.changeset/fix-mid-history-interrupted-tool-call.md
@@ -2,4 +2,4 @@
 "@moonshot-ai/kimi-code": patch
 ---
 
-Fix resume not realigning a tool call that was interrupted mid-history. The synthetic interrupted result is now closed in place at the next step boundary, so later turns and deferred messages keep their recorded order instead of only the trailing exchange being repaired. The `/messages` wire transcript reducer mirrors the same closure so its folded length stays aligned with live history, preventing the later turn from being duplicated/reordered.
+Fix resume not realigning a tool call that was interrupted mid-history. The synthetic interrupted result is now closed in place at the next step boundary, so later turns and deferred messages keep their recorded order instead of only the trailing exchange being repaired. The `/messages` wire transcript reducer mirrors the same closure so its folded length stays aligned with live history, preventing the later turn from being duplicated/reordered. Replay also drops a tool result whose call is no longer awaiting one, so a stale interrupted result left at the log tail by an older resume of a damaged session is not re-applied as a duplicate.

--- a/.changeset/fix-mid-history-interrupted-tool-call.md
+++ b/.changeset/fix-mid-history-interrupted-tool-call.md
@@ -2,4 +2,4 @@
 "@moonshot-ai/kimi-code": patch
 ---
 
-Fix resume not realigning a tool call that was interrupted mid-history. The synthetic interrupted result is now closed in place at the next step boundary, so later turns and deferred messages keep their recorded order instead of only the trailing exchange being repaired.
+Fix resume not realigning a tool call that was interrupted mid-history. The synthetic interrupted result is now closed in place at the next step boundary, so later turns and deferred messages keep their recorded order instead of only the trailing exchange being repaired. The `/messages` wire transcript reducer mirrors the same closure so its folded length stays aligned with live history, preventing the later turn from being duplicated/reordered.

--- a/packages/agent-core/src/agent/context/index.ts
+++ b/packages/agent-core/src/agent/context/index.ts
@@ -227,10 +227,20 @@ export class ContextMemory {
   }
 
   finishResume(): void {
-    const interruptedToolCallIds = [...this.pendingToolResultIds];
     this.openSteps.clear();
-    if (interruptedToolCallIds.length === 0) return;
+    this.closePendingToolResults();
+  }
 
+  // Synthesize interrupted tool results for any still-open tool calls, closing
+  // the exchange in place. Called at every replayed step boundary (see the
+  // `step.begin` case) so a tool call left unresolved mid-history is closed
+  // exactly where it occurred — otherwise it would keep `hasOpenToolExchange`
+  // true and strand every later message in `deferredMessages`, so only the
+  // trailing exchange ends up aligned. `finishResume` runs the same routine once
+  // more to close a genuine trailing interruption at end of resume.
+  private closePendingToolResults(): void {
+    if (this.pendingToolResultIds.size === 0) return;
+    const interruptedToolCallIds = [...this.pendingToolResultIds];
     for (const toolCallId of interruptedToolCallIds) {
       this.appendLoopEvent({
         type: 'tool.result',
@@ -251,6 +261,11 @@ export class ContextMemory {
     });
     switch (event.type) {
       case 'step.begin': {
+        // A new assistant step means any tool calls still pending from an
+        // earlier step were interrupted (the invariant guarantees this never
+        // happens live, so this is a no-op outside replay). Close them in place
+        // before opening the new step so mid-history gaps stay aligned.
+        this.closePendingToolResults();
         const message: ContextMessage = {
           role: 'assistant',
           content: [],

--- a/packages/agent-core/src/agent/context/index.ts
+++ b/packages/agent-core/src/agent/context/index.ts
@@ -331,6 +331,10 @@ export class ContextMemory {
         return;
       }
       case 'tool.result': {
+        // Drop a result for an id that is not awaiting one: it was already
+        // closed in place at a step boundary (a stale duplicate from an older
+        // tail-only finishResume), or its call is gone.
+        if (!this.pendingToolResultIds.has(event.toolCallId)) return;
         const message = createToolMessage(event.toolCallId, toolResultOutputForModel(event.result));
         this.pushHistory({
           ...message,

--- a/packages/agent-core/src/services/message/transcript.ts
+++ b/packages/agent-core/src/services/message/transcript.ts
@@ -118,11 +118,8 @@ export function reduceWireRecords(records: Iterable<AgentRecord>): {
     push(...deferred);
     deferred = [];
   };
-  // Mirrors ContextMemory.closePendingToolResults: a tool call left open when a
-  // new step begins was interrupted, so synthesize its error result in place.
-  // ContextMemory does this during replay, where the synthetic result is NOT
-  // re-persisted to the wire log, so the reducer must reconstruct it to keep
-  // `foldedLength` aligned with the live folded history.
+  // ContextMemory closes these during replay without persisting the synthetic
+  // result, so the reducer must reconstruct it to keep foldedLength aligned.
   const closePendingToolResults = (time: number | undefined): void => {
     if (pendingToolResultIds.size === 0) return;
     const interruptedToolCallIds = [...pendingToolResultIds];

--- a/packages/agent-core/src/services/message/transcript.ts
+++ b/packages/agent-core/src/services/message/transcript.ts
@@ -58,6 +58,8 @@ const TOOL_EMPTY_STATUS = '<system>Tool output is empty.</system>';
 const TOOL_EMPTY_ERROR_STATUS =
   '<system>ERROR: Tool execution failed. Tool output is empty.</system>';
 const TOOL_OUTPUT_EMPTY_TEXT = 'Tool output is empty.';
+const TOOL_INTERRUPTED_ON_RESUME_OUTPUT =
+  'Tool execution was interrupted before its result was recorded. Do not assume the tool completed successfully.';
 
 export interface TranscriptEntry {
   readonly message: ContextMessage;
@@ -116,6 +118,32 @@ export function reduceWireRecords(records: Iterable<AgentRecord>): {
     push(...deferred);
     deferred = [];
   };
+  // Mirrors ContextMemory.closePendingToolResults: a tool call left open when a
+  // new step begins was interrupted, so synthesize its error result in place.
+  // ContextMemory does this during replay, where the synthetic result is NOT
+  // re-persisted to the wire log, so the reducer must reconstruct it to keep
+  // `foldedLength` aligned with the live folded history.
+  const closePendingToolResults = (time: number | undefined): void => {
+    if (pendingToolResultIds.size === 0) return;
+    const interruptedToolCallIds = [...pendingToolResultIds];
+    for (const toolCallId of interruptedToolCallIds) {
+      push({
+        message: {
+          role: 'tool',
+          content: toolResultContent({
+            output: TOOL_INTERRUPTED_ON_RESUME_OUTPUT,
+            isError: true,
+          }),
+          toolCalls: [],
+          toolCallId,
+          isError: true,
+        },
+        time,
+      });
+      pendingToolResultIds.delete(toolCallId);
+    }
+    flushDeferredIfToolExchangeClosed();
+  };
   const resetOpenState = (): void => {
     openSteps.clear();
     pendingToolResultIds.clear();
@@ -125,6 +153,7 @@ export function reduceWireRecords(records: Iterable<AgentRecord>): {
   const applyLoopEvent = (event: LoopRecordedEvent, time: number | undefined): void => {
     switch (event.type) {
       case 'step.begin': {
+        closePendingToolResults(time);
         const entry: MutableEntry = {
           message: { role: 'assistant', content: [], toolCalls: [] },
           time,

--- a/packages/agent-core/src/services/message/transcript.ts
+++ b/packages/agent-core/src/services/message/transcript.ts
@@ -183,6 +183,9 @@ export function reduceWireRecords(records: Iterable<AgentRecord>): {
         return;
       }
       case 'tool.result': {
+        // Drop a result for an id not awaiting one (already closed in place, or
+        // its call is gone) — mirrors ContextMemory.
+        if (!pendingToolResultIds.has(event.toolCallId)) return;
         push({
           message: {
             role: 'tool',

--- a/packages/agent-core/test/agent/context.test.ts
+++ b/packages/agent-core/test/agent/context.test.ts
@@ -20,6 +20,19 @@ describe('Agent context', () => {
     });
     ctx.dispatch({
       type: 'context.append_loop_event',
+      event: {
+        type: 'tool.call',
+        uuid: 'origin-tool',
+        turnId: '',
+        step: 1,
+        stepUuid: 'origin-step',
+        toolCallId: 'call_origin',
+        name: 'Run',
+        args: {},
+      },
+    });
+    ctx.dispatch({
+      type: 'context.append_loop_event',
       event: { type: 'step.end', uuid: 'origin-step', turnId: '', step: 1 },
     });
     ctx.dispatch({
@@ -47,6 +60,25 @@ describe('Agent context', () => {
 
     ctx.dispatch({
       type: 'context.append_loop_event',
+      event: { type: 'step.begin', uuid: 's1', turnId: 't', step: 1 },
+    });
+    for (const toolCallId of ['call_error', 'call_empty']) {
+      ctx.dispatch({
+        type: 'context.append_loop_event',
+        event: {
+          type: 'tool.call',
+          uuid: toolCallId,
+          turnId: 't',
+          step: 1,
+          stepUuid: 's1',
+          toolCallId,
+          name: 'Run',
+          args: {},
+        },
+      });
+    }
+    ctx.dispatch({
+      type: 'context.append_loop_event',
       event: {
         type: 'tool.result',
         parentUuid: 'call_error',
@@ -65,6 +97,7 @@ describe('Agent context', () => {
     });
 
     expect(ctx.agent.context.messages).toMatchObject([
+      { role: 'assistant', toolCalls: [{ id: 'call_error' }, { id: 'call_empty' }] },
       {
         role: 'tool',
         content: [

--- a/packages/agent-core/test/agent/resume.test.ts
+++ b/packages/agent-core/test/agent/resume.test.ts
@@ -779,6 +779,84 @@ describe('Agent resume', () => {
     await ctx.expectResumeMatches();
   });
 
+  it('drops a stale tail interrupted result already closed in place on resume', async () => {
+    // Legacy log: an older tail-only finishResume appended the synthetic result
+    // for `call_interrupted` at the END of the stream (after the later turn from
+    // the deferral avalanche). The new in-place closure handles it at step.begin,
+    // so the trailing persisted copy must be dropped rather than duplicated.
+    const persistence = new RecordingAgentPersistence([
+      {
+        type: 'context.append_message',
+        message: {
+          role: 'user',
+          content: [{ type: 'text', text: 'Run the lookup' }],
+          toolCalls: [],
+          origin: { kind: 'user' },
+        },
+      },
+      {
+        type: 'context.append_loop_event',
+        event: { type: 'step.begin', uuid: 'interrupted-step', turnId: '0', step: 1 },
+      },
+      {
+        type: 'context.append_loop_event',
+        event: {
+          type: 'tool.call',
+          uuid: 'call-interrupted',
+          turnId: '0',
+          step: 1,
+          stepUuid: 'interrupted-step',
+          toolCallId: 'call_interrupted',
+          name: 'Lookup',
+          args: { query: 'one' },
+        },
+      },
+      {
+        type: 'context.append_message',
+        message: {
+          role: 'user',
+          content: [{ type: 'text', text: 'keep going' }],
+          toolCalls: [],
+          origin: { kind: 'user' },
+        },
+      },
+      ...loopEventsForTurn('1', 'All done.'),
+      // The stale synthetic result an older resume appended at the tail.
+      {
+        type: 'context.append_loop_event',
+        event: {
+          type: 'tool.result',
+          parentUuid: 'call_interrupted',
+          toolCallId: 'call_interrupted',
+          result: {
+            output:
+              'Tool execution was interrupted before its result was recorded. Do not assume the tool completed successfully.',
+            isError: true,
+          },
+        },
+      },
+    ]);
+    const ctx = testAgent({ persistence });
+
+    await ctx.agent.resume();
+
+    // The trailing duplicate is dropped: exactly one synthetic result, in place.
+    expect(ctx.agent.context.history.map((message) => message.role)).toEqual([
+      'user',
+      'assistant',
+      'tool',
+      'user',
+      'assistant',
+    ]);
+    expect(ctx.agent.context.history[2]).toMatchObject({
+      role: 'tool',
+      toolCallId: 'call_interrupted',
+      isError: true,
+    });
+    expect(textContent(ctx.agent.context.history[4])).toBe('All done.');
+    await ctx.expectResumeMatches();
+  });
+
   it('rebuilds goal completion replay cards without adding model-visible context', async () => {
     const persistence = new RecordingAgentPersistence([
       {

--- a/packages/agent-core/test/agent/resume.test.ts
+++ b/packages/agent-core/test/agent/resume.test.ts
@@ -686,6 +686,99 @@ describe('Agent resume', () => {
     expect(textContent(resumedAgain.agent.context.history[4])).toBe('continue after resume');
   });
 
+  it('closes an interrupted tool call mid-history so later turns stay aligned', async () => {
+    // An interrupted tool call (`call_interrupted`) sits in the MIDDLE of the
+    // recorded stream: a later user prompt and a fully-run assistant turn follow
+    // it. Without in-place reconciliation the unresolved exchange keeps
+    // `hasOpenToolExchange` true, stranding the later user prompt in
+    // `deferredMessages` and only aligning the trailing turn.
+    const persistence = new RecordingAgentPersistence([
+      {
+        type: 'context.append_message',
+        message: {
+          role: 'user',
+          content: [{ type: 'text', text: 'Run the lookup' }],
+          toolCalls: [],
+          origin: { kind: 'user' },
+        },
+      },
+      {
+        type: 'context.append_loop_event',
+        event: { type: 'step.begin', uuid: 'interrupted-step', turnId: '0', step: 1 },
+      },
+      {
+        type: 'context.append_loop_event',
+        event: {
+          type: 'tool.call',
+          uuid: 'call-interrupted',
+          turnId: '0',
+          step: 1,
+          stepUuid: 'interrupted-step',
+          toolCallId: 'call_interrupted',
+          name: 'Lookup',
+          args: { query: 'one' },
+        },
+      },
+      // Recorded while the interrupted exchange was still open, so live deferral
+      // captured it after the unresolved tool call.
+      {
+        type: 'context.append_message',
+        message: {
+          role: 'user',
+          content: [{ type: 'text', text: 'keep going' }],
+          toolCalls: [],
+          origin: { kind: 'user' },
+        },
+      },
+      ...loopEventsForTurn('1', 'All done.'),
+    ]);
+    const ctx = testAgent({ persistence });
+
+    await ctx.agent.resume();
+
+    expect(ctx.agent.context.history.map((message) => message.role)).toEqual([
+      'user',
+      'assistant',
+      'tool',
+      'user',
+      'assistant',
+    ]);
+    // The synthetic result is spliced in place (index 2), directly after the
+    // interrupted assistant step — not flushed to the tail.
+    const synthetic = ctx.agent.context.history[2];
+    expect(synthetic).toMatchObject({
+      role: 'tool',
+      toolCallId: 'call_interrupted',
+      isError: true,
+    });
+    expect(textContent(synthetic)).toContain(
+      'Tool execution was interrupted before its result was recorded',
+    );
+    // The deferred user prompt is restored in its recorded position, between the
+    // closed exchange and the following turn.
+    expect(textContent(ctx.agent.context.history[3])).toBe('keep going');
+    expect(textContent(ctx.agent.context.history[4])).toBe('All done.');
+
+    expect(ctx.agent.context.messages.map((message) => message.role)).toEqual([
+      'user',
+      'assistant',
+      'tool',
+      'user',
+      'assistant',
+    ]);
+
+    // Option A: the mid-history result is re-derived on every resume and is not
+    // persisted as a positioned record (replay logging is suppressed).
+    expect(
+      persistence.appended.filter(
+        (record) =>
+          record.type === 'context.append_loop_event' && record.event.type === 'tool.result',
+      ),
+    ).toEqual([]);
+
+    await ctx.expectResumeMatches();
+  });
+
   it('rebuilds goal completion replay cards without adding model-visible context', async () => {
     const persistence = new RecordingAgentPersistence([
       {

--- a/packages/agent-core/test/agent/resume.test.ts
+++ b/packages/agent-core/test/agent/resume.test.ts
@@ -857,6 +857,229 @@ describe('Agent resume', () => {
     await ctx.expectResumeMatches();
   });
 
+  it('closes every open call of a multi-call interrupted step in order', async () => {
+    const persistence = new RecordingAgentPersistence([
+      {
+        type: 'context.append_message',
+        message: {
+          role: 'user',
+          content: [{ type: 'text', text: 'Run both' }],
+          toolCalls: [],
+          origin: { kind: 'user' },
+        },
+      },
+      {
+        type: 'context.append_loop_event',
+        event: { type: 'step.begin', uuid: 'interrupted-step', turnId: '0', step: 1 },
+      },
+      ...['call_a', 'call_b'].map((toolCallId) => ({
+        type: 'context.append_loop_event' as const,
+        event: {
+          type: 'tool.call' as const,
+          uuid: toolCallId,
+          turnId: '0',
+          step: 1,
+          stepUuid: 'interrupted-step',
+          toolCallId,
+          name: 'Lookup',
+          args: {},
+        },
+      })),
+      ...loopEventsForTurn('1', 'All done.'),
+    ]);
+    const ctx = testAgent({ persistence });
+
+    await ctx.agent.resume();
+
+    // Both open calls get a synthetic result, in tool-call order, before the
+    // next turn.
+    expect(ctx.agent.context.history.map((message) => message.role)).toEqual([
+      'user',
+      'assistant',
+      'tool',
+      'tool',
+      'assistant',
+    ]);
+    expect(ctx.agent.context.history[2]).toMatchObject({
+      role: 'tool',
+      toolCallId: 'call_a',
+      isError: true,
+    });
+    expect(ctx.agent.context.history[3]).toMatchObject({
+      role: 'tool',
+      toolCallId: 'call_b',
+      isError: true,
+    });
+    await ctx.expectResumeMatches();
+  });
+
+  it('synthesizes only the unresolved call when a step is partially resolved', async () => {
+    const persistence = new RecordingAgentPersistence([
+      {
+        type: 'context.append_message',
+        message: {
+          role: 'user',
+          content: [{ type: 'text', text: 'Run both' }],
+          toolCalls: [],
+          origin: { kind: 'user' },
+        },
+      },
+      {
+        type: 'context.append_loop_event',
+        event: { type: 'step.begin', uuid: 'interrupted-step', turnId: '0', step: 1 },
+      },
+      ...['call_done', 'call_open'].map((toolCallId) => ({
+        type: 'context.append_loop_event' as const,
+        event: {
+          type: 'tool.call' as const,
+          uuid: toolCallId,
+          turnId: '0',
+          step: 1,
+          stepUuid: 'interrupted-step',
+          toolCallId,
+          name: 'Lookup',
+          args: {},
+        },
+      })),
+      {
+        type: 'context.append_loop_event',
+        event: {
+          type: 'tool.result',
+          parentUuid: 'call_done',
+          toolCallId: 'call_done',
+          result: { output: 'real result' },
+        },
+      },
+      ...loopEventsForTurn('1', 'All done.'),
+    ]);
+    const ctx = testAgent({ persistence });
+
+    await ctx.agent.resume();
+
+    expect(ctx.agent.context.history.map((message) => message.role)).toEqual([
+      'user',
+      'assistant',
+      'tool',
+      'tool',
+      'assistant',
+    ]);
+    // The recorded result is kept verbatim; only the open call is synthesized.
+    expect(ctx.agent.context.history[2]).toMatchObject({ toolCallId: 'call_done' });
+    expect(textContent(ctx.agent.context.history[2])).toBe('real result');
+    expect(ctx.agent.context.history[3]).toMatchObject({
+      toolCallId: 'call_open',
+      isError: true,
+    });
+    expect(textContent(ctx.agent.context.history[3])).toContain(
+      'Tool execution was interrupted before its result was recorded',
+    );
+    await ctx.expectResumeMatches();
+  });
+
+  it('closes consecutive interrupted steps each at their own boundary', async () => {
+    const persistence = new RecordingAgentPersistence([
+      {
+        type: 'context.append_message',
+        message: {
+          role: 'user',
+          content: [{ type: 'text', text: 'Go' }],
+          toolCalls: [],
+          origin: { kind: 'user' },
+        },
+      },
+      // First interrupted step.
+      {
+        type: 'context.append_loop_event',
+        event: { type: 'step.begin', uuid: 'step-1', turnId: '0', step: 1 },
+      },
+      {
+        type: 'context.append_loop_event',
+        event: {
+          type: 'tool.call',
+          uuid: 'call_one',
+          turnId: '0',
+          step: 1,
+          stepUuid: 'step-1',
+          toolCallId: 'call_one',
+          name: 'Lookup',
+          args: {},
+        },
+      },
+      // Second interrupted step (closes the first in place at its step.begin).
+      {
+        type: 'context.append_loop_event',
+        event: { type: 'step.begin', uuid: 'step-2', turnId: '1', step: 1 },
+      },
+      {
+        type: 'context.append_loop_event',
+        event: {
+          type: 'tool.call',
+          uuid: 'call_two',
+          turnId: '1',
+          step: 1,
+          stepUuid: 'step-2',
+          toolCallId: 'call_two',
+          name: 'Lookup',
+          args: {},
+        },
+      },
+      // Final fully-run turn (closes the second in place).
+      ...loopEventsForTurn('2', 'Done.'),
+    ]);
+    const ctx = testAgent({ persistence });
+
+    await ctx.agent.resume();
+
+    expect(ctx.agent.context.history.map((message) => message.role)).toEqual([
+      'user',
+      'assistant',
+      'tool',
+      'assistant',
+      'tool',
+      'assistant',
+    ]);
+    expect(ctx.agent.context.history[2]).toMatchObject({ toolCallId: 'call_one', isError: true });
+    expect(ctx.agent.context.history[4]).toMatchObject({ toolCallId: 'call_two', isError: true });
+    await ctx.expectResumeMatches();
+  });
+
+  it('drops an orphan tool result whose call was never recorded', async () => {
+    const persistence = new RecordingAgentPersistence([
+      {
+        type: 'context.append_message',
+        message: {
+          role: 'user',
+          content: [{ type: 'text', text: 'Hi' }],
+          toolCalls: [],
+          origin: { kind: 'user' },
+        },
+      },
+      ...loopEventsForTurn('0', 'Hello.'),
+      // A result with no matching tool.call (e.g. its call was compacted away).
+      {
+        type: 'context.append_loop_event',
+        event: {
+          type: 'tool.result',
+          parentUuid: 'ghost',
+          toolCallId: 'call_ghost',
+          result: { output: 'orphaned' },
+        },
+      },
+    ]);
+    const ctx = testAgent({ persistence });
+
+    await ctx.agent.resume();
+
+    expect(ctx.agent.context.history.map((message) => message.role)).toEqual([
+      'user',
+      'assistant',
+    ]);
+    expect(
+      ctx.agent.context.history.some((message) => message.role === 'tool'),
+    ).toBe(false);
+    await ctx.expectResumeMatches();
+  });
+
   it('rebuilds goal completion replay cards without adding model-visible context', async () => {
     const persistence = new RecordingAgentPersistence([
       {

--- a/packages/agent-core/test/services/message-transcript.test.ts
+++ b/packages/agent-core/test/services/message-transcript.test.ts
@@ -230,9 +230,60 @@ describe('reduceWireRecords', () => {
     expect(foldedLength).toBe(5);
   });
 
+  it('drops a stale tail interrupted result already closed in place', () => {
+    const { entries, foldedLength } = reduceWireRecords([
+      appendMessage(userMessage('u1')),
+      loopEvent({ type: 'step.begin', uuid: 's1', turnId: 't', step: 0 }),
+      loopEvent({
+        type: 'tool.call',
+        uuid: 'c1',
+        turnId: 't',
+        step: 0,
+        stepUuid: 's1',
+        toolCallId: 'call_interrupted',
+        name: 'Lookup',
+        args: { query: 'one' },
+      }),
+      appendMessage(userMessage('keep going')),
+      ...assistantStep('s2', 'a2'),
+      // The stale synthetic result an older tail-only resume appended.
+      loopEvent({
+        type: 'tool.result',
+        parentUuid: 'call_interrupted',
+        toolCallId: 'call_interrupted',
+        result: {
+          output:
+            'Tool execution was interrupted before its result was recorded. Do not assume the tool completed successfully.',
+          isError: true,
+        },
+      }),
+    ]);
+    expect(entries.map((e) => e.message.role)).toEqual([
+      'user',
+      'assistant',
+      'tool',
+      'user',
+      'assistant',
+    ]);
+    expect(entries[2]!.message.toolCallId).toBe('call_interrupted');
+    expect(foldedLength).toBe(5);
+  });
+
   it('wraps tool errors and empty outputs with <system> statuses like agent-core', () => {
     const { entries } = reduceWireRecords([
       loopEvent({ type: 'step.begin', uuid: 's1', turnId: 't', step: 0 }),
+      ...['call_err', 'call_empty'].map((toolCallId) =>
+        loopEvent({
+          type: 'tool.call',
+          uuid: toolCallId,
+          turnId: 't',
+          step: 0,
+          stepUuid: 's1',
+          toolCallId,
+          name: 'Run',
+          args: {},
+        }),
+      ),
       loopEvent({
         type: 'tool.result',
         parentUuid: 's1',

--- a/packages/agent-core/test/services/message-transcript.test.ts
+++ b/packages/agent-core/test/services/message-transcript.test.ts
@@ -193,11 +193,6 @@ describe('reduceWireRecords', () => {
   });
 
   it('closes a tool call interrupted mid-history at the next step.begin', () => {
-    // Mirrors ContextMemory's replay-time closePendingToolResults: the synthetic
-    // interrupted result is re-derived (not persisted to the wire log), so the
-    // reducer must reconstruct it and flush the deferred message in place — and
-    // foldedLength must match the live folded history length so the downstream
-    // tail merge slices from the right index.
     const { entries, foldedLength } = reduceWireRecords([
       appendMessage(userMessage('u1')),
       loopEvent({ type: 'step.begin', uuid: 's1', turnId: 't', step: 0 }),

--- a/packages/agent-core/test/services/message-transcript.test.ts
+++ b/packages/agent-core/test/services/message-transcript.test.ts
@@ -192,6 +192,49 @@ describe('reduceWireRecords', () => {
     expect(textOf(entries[1]!.message)).toBe('ok');
   });
 
+  it('closes a tool call interrupted mid-history at the next step.begin', () => {
+    // Mirrors ContextMemory's replay-time closePendingToolResults: the synthetic
+    // interrupted result is re-derived (not persisted to the wire log), so the
+    // reducer must reconstruct it and flush the deferred message in place — and
+    // foldedLength must match the live folded history length so the downstream
+    // tail merge slices from the right index.
+    const { entries, foldedLength } = reduceWireRecords([
+      appendMessage(userMessage('u1')),
+      loopEvent({ type: 'step.begin', uuid: 's1', turnId: 't', step: 0 }),
+      loopEvent({
+        type: 'tool.call',
+        uuid: 'c1',
+        turnId: 't',
+        step: 0,
+        stepUuid: 's1',
+        toolCallId: 'call_interrupted',
+        name: 'Lookup',
+        args: { query: 'one' },
+      }),
+      // Recorded while the exchange was open, so it was deferred live.
+      appendMessage(userMessage('keep going')),
+      ...assistantStep('s2', 'a2'),
+    ]);
+    expect(entries.map((e) => e.message.role)).toEqual([
+      'user',
+      'assistant',
+      'tool',
+      'user',
+      'assistant',
+    ]);
+    // Synthetic result spliced in place (index 2), before the deferred prompt.
+    expect(entries[2]!.message.toolCallId).toBe('call_interrupted');
+    expect(entries[2]!.message.isError).toBe(true);
+    expect(textOf(entries[2]!.message)).toBe(
+      '<system>ERROR: Tool execution failed.</system>\n' +
+        'Tool execution was interrupted before its result was recorded. ' +
+        'Do not assume the tool completed successfully.',
+    );
+    expect(textOf(entries[3]!.message)).toBe('keep going');
+    expect(textOf(entries[4]!.message)).toBe('a2');
+    expect(foldedLength).toBe(5);
+  });
+
   it('wraps tool errors and empty outputs with <system> statuses like agent-core', () => {
     const { entries } = reduceWireRecords([
       loopEvent({ type: 'step.begin', uuid: 's1', turnId: 't', step: 0 }),

--- a/packages/agent-core/test/services/message-transcript.test.ts
+++ b/packages/agent-core/test/services/message-transcript.test.ts
@@ -269,6 +269,49 @@ describe('reduceWireRecords', () => {
     expect(foldedLength).toBe(5);
   });
 
+  it('closes every open call of a multi-call interrupted step, keeping foldedLength aligned', () => {
+    const { entries, foldedLength } = reduceWireRecords([
+      loopEvent({ type: 'step.begin', uuid: 's1', turnId: 't', step: 0 }),
+      ...['call_a', 'call_b'].map((toolCallId) =>
+        loopEvent({
+          type: 'tool.call',
+          uuid: toolCallId,
+          turnId: 't',
+          step: 0,
+          stepUuid: 's1',
+          toolCallId,
+          name: 'Run',
+          args: {},
+        }),
+      ),
+      ...assistantStep('s2', 'a2'),
+    ]);
+    expect(entries.map((e) => e.message.role)).toEqual([
+      'assistant',
+      'tool',
+      'tool',
+      'assistant',
+    ]);
+    expect(entries[1]!.message.toolCallId).toBe('call_a');
+    expect(entries[2]!.message.toolCallId).toBe('call_b');
+    expect(foldedLength).toBe(4);
+  });
+
+  it('drops an orphan tool result whose call was never recorded', () => {
+    const { entries, foldedLength } = reduceWireRecords([
+      appendMessage(userMessage('u1')),
+      ...assistantStep('s1', 'a1'),
+      loopEvent({
+        type: 'tool.result',
+        parentUuid: 'ghost',
+        toolCallId: 'call_ghost',
+        result: { output: 'orphaned' },
+      }),
+    ]);
+    expect(entries.map((e) => e.message.role)).toEqual(['user', 'assistant']);
+    expect(foldedLength).toBe(2);
+  });
+
   it('wraps tool errors and empty outputs with <system> statuses like agent-core', () => {
     const { entries } = reduceWireRecords([
       loopEvent({ type: 'step.begin', uuid: 's1', turnId: 't', step: 0 }),


### PR DESCRIPTION
## 问题

`ContextMemory.finishResume` 依赖 `pendingToolResultIds`，而按不变式它**只描述 tail** 的那个打开的工具调用 exchange。所以补救只在历史末尾生效。

当被 replay 的记录流里有一个**位于中间**的未闭合 tool call 时：

1. replay 到该 `tool.call` 后 `pendingToolResultIds` 一直非空（result 永不到来）；
2. 之后每条 `appendMessage`（用户消息 / skill reminder…）因为 `hasOpenToolExchange()` 为真被塞进 `deferredMessages`；
3. 而 `step.begin` 这类 loop event 不走 deferral，直接 push 进 `_history`；
4. replay 结束后：中间挂着一个无 result 的 assistant tool call，后面跟着别的 assistant turn，本应穿插其间的用户消息全卡在 `deferredMessages`；
5. `finishResume` resolve 残留 pending 并 flush deferred —— 但 flush 把它们**一股脑接到 tail**，只有最后一段对齐，中间全错位（即"只在最后一个 turn 有效果"）。

## 改动

把"补救"从 tail-only 改成**在每个 replay step 边界就地闭合**：

- 抽出 `closePendingToolResults()`（原 `finishResume` 循环体）；
- 在 `appendLoopEvent` 的 `step.begin` 分支开头调用它：遇到新 assistant step 而上一个 exchange 还开着，就在**当前位置**补合成 interrupted result 再开新 step；
- `finishResume` 复用同一方法做流末尾收尾。

中间 gap 在下一个 step 开始时即就地闭合 → `pendingToolResultIds` 立刻清空 → deferral 雪崩不再发生 → 后续消息按记录顺序回到正确位置。

对健康历史**零影响**：不变式保证 live 的 step 边界不会有残留 pending，这行是 no-op。

## 测试

新增 `closes an interrupted tool call mid-history so later turns stay aligned`：构造"中间未闭合 tool call + 之后还有用户消息和完整 turn"的记录流，断言 history/messages 角色序列为 `[user, assistant, tool, user, assistant]`、synthetic result 落在正确位置（非 tail）、被 defer 的用户消息归位、且 `expectResumeMatches()` 幂等一致。已验证仅回退 src 时该测试会失败（输出 `[user, assistant, assistant, tool, user]`）。

`tsc` / `oxlint` 干净；resume / context / compaction / session-init 套件全过。

## Known limitation（非本 PR 范围，非回归）

若 legacy/损坏会话里 `apply_compaction` 是在某个 exchange 仍打开时录制的，切片可能把持有 pending call 的 assistant step 删掉，留下孤儿 result。该情形**当前 tail-only 版本也一样会触发**，本 PR 既未修复也未恶化（对健康会话严格 no-op）。正确的修法在 compaction 源头（切片后重新对齐 `pendingToolResultIds`），留作后续跟进。