### PR TITLE
fix(web): upgrade markstream-vue to 1.0.3 to fix blank nested code blocks

### DIFF
--- a/.changeset/fix-web-nested-codeblock-blank.md
+++ b/.changeset/fix-web-nested-codeblock-blank.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Fix code blocks nested inside list items rendering blank in the web chat after a turn finishes generating.

--- a/apps/kimi-web/package.json
+++ b/apps/kimi-web/package.json
@@ -16,9 +16,9 @@
     "@fontsource-variable/jetbrains-mono": "^5.2.8",
     "@xterm/addon-fit": "^0.11.0",
     "@xterm/xterm": "^6.0.0",
-    "markstream-vue": "1.0.1-beta.5",
+    "markstream-vue": "1.0.3",
     "shiki": "^4.2.0",
-    "stream-markdown": "^0.0.15",
+    "stream-markdown": "^0.0.16",
     "vue": "^3.5.35",
     "vue-i18n": "^11.4.5"
   },

--- a/flake.nix
+++ b/flake.nix
@@ -150,7 +150,7 @@
               inherit (finalAttrs) pname version src pnpmWorkspaces;
               inherit pnpm;
               fetcherVersion = 3;
-              hash = "sha256-uE/g32Twhshb5BkROi0UiC8hTnrHxE+DMazPijZnCWo=";
+              hash = "sha256-l8RvHgEGwS1XX0VGWCNtF1EmE1SRQFyCCYGPCoPL3JY=";
             };
 
             nativeBuildInputs = [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -164,14 +164,14 @@ importers:
         specifier: ^6.0.0
         version: 6.0.0
       markstream-vue:
-        specifier: 1.0.1-beta.5
-        version: 1.0.1-beta.5(katex@0.16.47)(mermaid@11.15.0)(stream-markdown@0.0.15(react@19.2.5)(shiki@4.2.0)(vue@3.5.35(typescript@6.0.2)))(vue-i18n@11.4.5(vue@3.5.35(typescript@6.0.2)))(vue@3.5.35(typescript@6.0.2))
+        specifier: 1.0.3
+        version: 1.0.3(katex@0.16.47)(mermaid@11.15.0)(stream-markdown@0.0.16(react@19.2.5)(shiki@4.2.0)(vue@3.5.35(typescript@6.0.2)))(vue-i18n@11.4.5(vue@3.5.35(typescript@6.0.2)))(vue@3.5.35(typescript@6.0.2))
       shiki:
         specifier: ^4.2.0
         version: 4.2.0
       stream-markdown:
-        specifier: ^0.0.15
-        version: 0.0.15(react@19.2.5)(shiki@4.2.0)(vue@3.5.35(typescript@6.0.2))
+        specifier: ^0.0.16
+        version: 0.0.16(react@19.2.5)(shiki@4.2.0)(vue@3.5.35(typescript@6.0.2))
       vue:
         specifier: ^3.5.35
         version: 3.5.35(typescript@6.0.2)
@@ -2355,6 +2355,9 @@ packages:
   '@shikijs/core@2.5.0':
     resolution: {integrity: sha512-uu/8RExTKtavlpH7XqnVYBrfBkUc20ngXiX9NSrBhOVZYv/7XQRKUyhtkeflY5QsxC0GbJThCerruZfsUaSldg==}
 
+  '@shikijs/core@3.23.0':
+    resolution: {integrity: sha512-NSWQz0riNb67xthdm5br6lAkvpDJRTgB36fxlo37ZzM2yq0PQFFzbd8psqC2XMPgCzo1fW6cVi18+ArJ44wqgA==}
+
   '@shikijs/core@4.2.0':
     resolution: {integrity: sha512-Hc87Ab1Ld/vEbZRCbwx344I5v+4RU8CVToUTRkqXL1+TjbuOp9U5Xa0M23V4GEWHxVn+yO5otb+HkQVm3ptWQQ==}
     engines: {node: '>=20'}
@@ -2384,21 +2387,6 @@ packages:
     resolution: {integrity: sha512-NOq+DtUkVBJtZMVXL5A0vI0Xk8nvDYaXetFHSJFlOqjDZIVhIPRYFdGkSoElDqNuegikcc3A76SNUa8dTqtAYA==}
     engines: {node: '>=20'}
 
-  '@shikijs/stream@4.2.0':
-    resolution: {integrity: sha512-OaMUUStdIZ+l1GJad9uVACR3Xvgwo4y+RmEuDMU62cgFMMg1IBCaIFmvzAR2HiCpGtwoc/qPfpNnP+ivgrPXZg==}
-    engines: {node: '>=20'}
-    peerDependencies:
-      react: ^19.0.0
-      solid-js: ^1.9.0
-      vue: ^3.2.0
-    peerDependenciesMeta:
-      react:
-        optional: true
-      solid-js:
-        optional: true
-      vue:
-        optional: true
-
   '@shikijs/themes@2.5.0':
     resolution: {integrity: sha512-wGrk+R8tJnO0VMzmUExHR+QdSaPUl/NKs+a4cQQRWyoc3YFbUzuLEi/KWK1hj+8BfHRKm2jNhhJck1dfstJpiw==}
 
@@ -2411,6 +2399,9 @@ packages:
 
   '@shikijs/types@2.5.0':
     resolution: {integrity: sha512-ygl5yhxki9ZLNuNpPitBWvcy9fsSKKaRuO4BAlMyagszQidxcpLAr0qiW/q43DtSIDxO6hEbtYLiFZNXO/hdGw==}
+
+  '@shikijs/types@3.23.0':
+    resolution: {integrity: sha512-3JZ5HXOZfYjsYSk0yPwBrkupyYSLpAE26Qc0HLghhZNGTZg/SKxXIIgoxOpmmeQP0RRSDJTk1/vPfw9tbw+jSQ==}
 
   '@shikijs/types@4.2.0':
     resolution: {integrity: sha512-VT/MKtlpOhEPZloSH3Pb9WCZEBDoQVMa9jedp5UAwmJOar1DVc9DRODAxmYPW9M93IK4ryuqRejFfmlvlVDemw==}
@@ -4577,18 +4568,18 @@ packages:
     engines: {node: '>= 16'}
     hasBin: true
 
-  markstream-core@1.0.0:
-    resolution: {integrity: sha512-V39W0rPgJ5Yj/XEl11LaKQxX9dYOI34RL729Zoi9oyy/Y6z6H+PJOsBFktu7gU9ZZxCsevWMb/Re2LgSKbWfRg==}
+  markstream-core@1.0.3:
+    resolution: {integrity: sha512-QXn+yERo1q+RD6YlGDW61zc/af65uhkQEH3K8YvEKkprHbgRJ/JIeBeEQjELCTyBnPoxqtKQ7I565rylY+PePg==}
 
-  markstream-vue@1.0.1-beta.5:
-    resolution: {integrity: sha512-a1zI20OSgH4xw7j3l87BINbIze8ScWlhQTCPERpbDfrGMkeXSAcckJb/YUHOCZkhbFzvYBP56W2wZKWZ9p5dIA==}
+  markstream-vue@1.0.3:
+    resolution: {integrity: sha512-Eby3wjzNLmig4OpPcZTJ/GgsIWFSGv9LUZ7gdeNZ/QwHg2d3P4LWLlp0x6iP387PTc2hehTydIcTe4XlCalAUA==}
     peerDependencies:
       '@antv/infographic': ^0.2.3
       '@terrastruct/d2': '>=0.1.33'
       katex: '>=0.16.22'
       mermaid: '>=11'
-      stream-markdown: '>=0.0.15'
-      stream-monaco: '>=0.0.41'
+      stream-markdown: '>=0.0.16'
+      stream-monaco: '>=0.0.45'
       vue: '>=3.0.0'
       vue-i18n: '>=9'
     peerDependenciesMeta:
@@ -5467,9 +5458,8 @@ packages:
     resolution: {integrity: sha512-HBFce8NGaPuWPg5NXb6+aI7hJQFjTilhtbrgo+Y/BvtGlkuJAzLnkmC8nyD+p3v7oIAq4KQeA8qySKGga28xZg==}
     hasBin: true
 
-  shiki-stream@0.1.5:
-    resolution: {integrity: sha512-DzkqVlqf02Tp4zTFNgJp+3rOG2RkuoONBq+Pm2sHslAlJ5M0QbR1devn4dr9SgcBTrtHTf6Rqyj3wVJi0g16Bw==}
-    deprecated: shiki-stream is now @shikijs/stream, please migrate by renaming the package
+  shiki-stream@0.1.4:
+    resolution: {integrity: sha512-4pz6JGSDmVTTkPJ/ueixHkFAXY4ySCc+unvCaDZV7hqq/sdJZirRxgIXSuNSKgiFlGTgRR97sdu2R8K55sPsrw==}
     peerDependencies:
       react: ^19.0.0
       solid-js: ^1.9.0
@@ -5599,13 +5589,13 @@ packages:
     resolution: {integrity: sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==}
     engines: {node: '>= 0.4'}
 
-  stream-markdown-parser@1.0.3:
-    resolution: {integrity: sha512-hSU22+3LIPKZTwa80vgSkQV5wuwrZfeeKIEqXnAOqwVnrtWUTJodIYh2IU/6mYwHQeBrs4eWcEe9/JHWx2pvHA==}
+  stream-markdown-parser@1.0.5:
+    resolution: {integrity: sha512-gh+yUjRcITGf0ILMVOAH2bRxe5M6f1U4XrQGc2k+UAMblDByvi6Xmt85EPluRypb+VGcpnNxBFBP0ZgursGoZw==}
 
-  stream-markdown@0.0.15:
-    resolution: {integrity: sha512-1WlzjZUb9W5BWZYMKCr2/exPVh5P7HIhHzkcYZczkXm0upiuN4zEddwjdckL+WSQWGGlv9bboXCqcTYCEgqexw==}
+  stream-markdown@0.0.16:
+    resolution: {integrity: sha512-2WoOxlpc3N5RLc3zGuW+g/w76z6ketWBY0N1YzDYbXds1qw7zrUBv5PTQ3DOtpqgCjLuF3P2iCfjJTEqWGv0NQ==}
     peerDependencies:
-      shiki: '>=3.13.0'
+      shiki: '>=3.23.0'
 
   string-argv@0.3.2:
     resolution: {integrity: sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q==}
@@ -7814,6 +7804,13 @@ snapshots:
       '@types/hast': 3.0.4
       hast-util-to-html: 9.0.5
 
+  '@shikijs/core@3.23.0':
+    dependencies:
+      '@shikijs/types': 3.23.0
+      '@shikijs/vscode-textmate': 10.0.2
+      '@types/hast': 3.0.4
+      hast-util-to-html: 9.0.5
+
   '@shikijs/core@4.2.0':
     dependencies:
       '@shikijs/primitive': 4.2.0
@@ -7858,13 +7855,6 @@ snapshots:
       '@shikijs/vscode-textmate': 10.0.2
       '@types/hast': 3.0.4
 
-  '@shikijs/stream@4.2.0(react@19.2.5)(vue@3.5.35(typescript@6.0.2))':
-    dependencies:
-      '@shikijs/core': 4.2.0
-    optionalDependencies:
-      react: 19.2.5
-      vue: 3.5.35(typescript@6.0.2)
-
   '@shikijs/themes@2.5.0':
     dependencies:
       '@shikijs/types': 2.5.0
@@ -7879,6 +7869,11 @@ snapshots:
       '@shikijs/types': 2.5.0
 
   '@shikijs/types@2.5.0':
+    dependencies:
+      '@shikijs/vscode-textmate': 10.0.2
+      '@types/hast': 3.0.4
+
+  '@shikijs/types@3.23.0':
     dependencies:
       '@shikijs/vscode-textmate': 10.0.2
       '@types/hast': 3.0.4
@@ -10268,19 +10263,19 @@ snapshots:
 
   marked@9.1.6: {}
 
-  markstream-core@1.0.0: {}
+  markstream-core@1.0.3: {}
 
-  markstream-vue@1.0.1-beta.5(katex@0.16.47)(mermaid@11.15.0)(stream-markdown@0.0.15(react@19.2.5)(shiki@4.2.0)(vue@3.5.35(typescript@6.0.2)))(vue-i18n@11.4.5(vue@3.5.35(typescript@6.0.2)))(vue@3.5.35(typescript@6.0.2)):
+  markstream-vue@1.0.3(katex@0.16.47)(mermaid@11.15.0)(stream-markdown@0.0.16(react@19.2.5)(shiki@4.2.0)(vue@3.5.35(typescript@6.0.2)))(vue-i18n@11.4.5(vue@3.5.35(typescript@6.0.2)))(vue@3.5.35(typescript@6.0.2)):
     dependencies:
       '@chenglou/pretext': 0.0.5
       '@floating-ui/dom': 1.7.6
-      markstream-core: 1.0.0
-      stream-markdown-parser: 1.0.3
+      markstream-core: 1.0.3
+      stream-markdown-parser: 1.0.5
       vue: 3.5.35(typescript@6.0.2)
     optionalDependencies:
       katex: 0.16.47
       mermaid: 11.15.0
-      stream-markdown: 0.0.15(react@19.2.5)(shiki@4.2.0)(vue@3.5.35(typescript@6.0.2))
+      stream-markdown: 0.0.16(react@19.2.5)(shiki@4.2.0)(vue@3.5.35(typescript@6.0.2))
       vue-i18n: 11.4.5(vue@3.5.35(typescript@6.0.2))
 
   math-intrinsics@1.1.0: {}
@@ -11377,9 +11372,9 @@ snapshots:
       sherif-windows-arm64: 1.11.1
       sherif-windows-x64: 1.11.1
 
-  shiki-stream@0.1.5(react@19.2.5)(vue@3.5.35(typescript@6.0.2)):
+  shiki-stream@0.1.4(react@19.2.5)(vue@3.5.35(typescript@6.0.2)):
     dependencies:
-      '@shikijs/stream': 4.2.0(react@19.2.5)(vue@3.5.35(typescript@6.0.2))
+      '@shikijs/core': 3.23.0
     optionalDependencies:
       react: 19.2.5
       vue: 3.5.35(typescript@6.0.2)
@@ -11516,7 +11511,7 @@ snapshots:
       es-errors: 1.3.0
       internal-slot: 1.1.0
 
-  stream-markdown-parser@1.0.3:
+  stream-markdown-parser@1.0.5:
     dependencies:
       markdown-it-container: 4.0.0
       markdown-it-footnote: 4.0.0
@@ -11527,10 +11522,10 @@ snapshots:
       markdown-it-task-checkbox: 1.0.6
       markdown-it-ts: 1.0.0
 
-  stream-markdown@0.0.15(react@19.2.5)(shiki@4.2.0)(vue@3.5.35(typescript@6.0.2)):
+  stream-markdown@0.0.16(react@19.2.5)(shiki@4.2.0)(vue@3.5.35(typescript@6.0.2)):
     dependencies:
       shiki: 4.2.0
-      shiki-stream: 0.1.5(react@19.2.5)(vue@3.5.35(typescript@6.0.2))
+      shiki-stream: 0.1.4(react@19.2.5)(vue@3.5.35(typescript@6.0.2))
     transitivePeerDependencies:
       - react
       - solid-js


### PR DESCRIPTION
## Related Issue

No kimi-code issue was filed — this is a clear, reproducible rendering bug with a focused diff, so the problem is explained below. The underlying cause is upstream and tracked at Simon-He95/markstream-vue#498 (fixed by Simon-He95/markstream-vue#502).

## Problem

In the web chat, a fenced code block nested inside a list item (e.g. a ```js block under a `-` bullet) renders **blank** — only the language header shows, with an empty body. It surfaces right when a turn finishes generating, and a full page reload temporarily "fixes" it.

Root cause is two compounding factors:
1. markstream-vue's nested renderers did not forward the app's `code-renderer="shiki"`, so code blocks inside list items fell through to the Monaco renderer. With the optional `stream-monaco` peer not installed, the production bundle stubs it to an empty module, the block hangs at `data-markstream-pending`, and never paints. (Top-level blocks use Shiki and are unaffected.)
2. When the turn settles, `smooth-streaming` flips `true → false`; finalizing the still-pending nested block drops its fallback body, leaving it blank. A fresh reload mounts in the settled state directly, which is why reloading appears to fix it.

## What changed

Upgrade `markstream-vue` `1.0.1-beta.5 → 1.0.3`, which contains the upstream fix so nested renderers inherit the parent code renderer (Shiki) like top-level blocks. `stream-markdown` is bumped `^0.0.15 → ^0.0.16` to satisfy the new peer requirement. No application code changes.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [ ] I have added tests that prove my feature works. — N/A: the blank only reproduces in the production bundle (the empty `stream-monaco` stub), which the unit-test/jsdom environment can't exercise. Verified instead by building the production bundle and confirming in a real browser that nested list code blocks now render with Shiki highlighting and survive the streaming→settled transition; the existing 55 web tests still pass.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update. — N/A: no user-facing docs affected.
