### PR TITLE
fix(agent-core): terminate MCP stdio process tree on close

### DIFF
--- a/.changeset/fix-mcp-stdio-process-tree-cleanup.md
+++ b/.changeset/fix-mcp-stdio-process-tree-cleanup.md
@@ -1,0 +1,11 @@
+---
+"@moonshot-ai/agent-core": patch
+---
+
+Terminate the full MCP stdio process tree on client close.
+
+On Windows, stdio MCP servers launched via `npx` leave behind a `node.exe`
+server process when only the immediate `npx` child is killed. The close path
+now escalates to a platform-specific process-tree kill (`taskkill /T` on
+Windows, process-group signals on POSIX) so that both the wrapper and the
+actual server are reaped.

--- a/packages/agent-core/src/mcp/client-stdio.ts
+++ b/packages/agent-core/src/mcp/client-stdio.ts
@@ -1,3 +1,5 @@
+import { spawn } from 'node:child_process';
+
 import { ErrorCodes, KimiError } from '#/errors';
 import type { McpServerStdioConfig } from '#/config/schema';
 import { proxyEnvForChild, reconcileChildNoProxy } from '#/utils/proxy';
@@ -155,7 +157,22 @@ export class StdioMcpClient implements MCPClient {
   private async closeStartedClient(): Promise<void> {
     if (!this.started) return;
     this.started = false;
-    await this.client.close();
+    // Capture the transport pid before the SDK clears it. The SDK's
+    // StdioClientTransport only signals the immediate child; on Windows,
+    // npx/uvx wrappers leave grandchild server processes behind.
+    const pid = this.transport.pid;
+    // Start tree cleanup immediately and run it in parallel with the SDK's
+    // graceful close. If we waited for the SDK close to finish first, the
+    // wrapper could already have exited and orphaned the real server before
+    // taskkill /T had a chance to run. Killing the tree up front keeps the
+    // descendant PIDs reachable while they are still children of the root.
+    const treeKill = ensureProcessTreeTerminated(pid);
+    try {
+      await this.client.close();
+    } catch {
+      // The transport may already be gone. Continue to process-tree cleanup.
+    }
+    await treeKill;
   }
 
   private installTransportHooks(): void {
@@ -216,6 +233,99 @@ class BoundedTail {
   snapshot(): string {
     return this.buffer;
   }
+}
+
+const PROCESS_EXIT_POLL_MS = 50;
+const PROCESS_GRACE_TIMEOUT_MS = 2_000;
+const PROCESS_FORCE_TIMEOUT_MS = 2_000;
+
+/**
+ * Returns `true` if a process with the given pid is still alive.
+ * `process.kill(pid, 0)` is the portable Node idiom for this check.
+ */
+function isProcessAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Wait up to `timeoutMs` for the process at `pid` to exit.
+ * Returns `true` once it is gone, or `false` if the deadline expires.
+ */
+async function waitForProcessExit(pid: number, timeoutMs: number): Promise<boolean> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (!isProcessAlive(pid)) return true;
+    await new Promise((resolve) => setTimeout(resolve, PROCESS_EXIT_POLL_MS));
+  }
+  return !isProcessAlive(pid);
+}
+
+/**
+ * Kill the whole process tree rooted at `pid`.
+ *
+ * On Windows the immediate child is often a shell wrapper (npx/uvx/cmd) and
+ * Node's default `ChildProcess.kill()` only signals that wrapper, leaving
+ * grandchild server processes orphaned. We use `taskkill /T` to terminate the
+ * entire tree. On POSIX we signal the process group first, then fall back to
+ * the direct child.
+ */
+async function killProcessTree(pid: number, force: boolean): Promise<void> {
+  if (!isProcessAlive(pid)) return;
+
+  if (process.platform === 'win32') {
+    return new Promise<void>((resolve) => {
+      const args = force ? ['/T', '/F', '/PID', String(pid)] : ['/T', '/PID', String(pid)];
+      const killer = spawn('taskkill', args, { stdio: 'ignore', windowsHide: true });
+      const done = (): void => {
+        resolve();
+      };
+      killer.once('error', done);
+      killer.once('close', done);
+    });
+  }
+
+  try {
+    process.kill(-pid, force ? 'SIGKILL' : 'SIGTERM');
+  } catch (error) {
+    const err = error as NodeJS.ErrnoException;
+    if (err.code === 'ESRCH') return;
+    if (err.code === 'EPERM') {
+      try {
+        process.kill(pid, force ? 'SIGKILL' : 'SIGTERM');
+      } catch {
+        /* best effort */
+      }
+      return;
+    }
+    throw error;
+  }
+}
+
+/**
+ * Ensure the process tree rooted at `pid` is terminated.
+ *
+ * If `pid` is null/undefined the transport never started a child and there is
+ * nothing to do. Otherwise we issue a tree-kill up front (so the root is still
+ * alive and its descendants are still reachable on Windows), wait briefly for
+ * graceful termination, then escalate to a forced tree-kill.
+ */
+async function ensureProcessTreeTerminated(pid: number | null | undefined): Promise<void> {
+  if (pid === null || pid === undefined || pid <= 0) return;
+
+  // Kill the tree before the root has a chance to vanish and orphan the real
+  // server process. On Windows taskkill /T needs the root PID to still exist
+  // so it can enumerate descendants; waiting for the root to exit first would
+  // skip the tree cleanup entirely.
+  await killProcessTree(pid, false);
+  if (await waitForProcessExit(pid, PROCESS_GRACE_TIMEOUT_MS)) return;
+
+  await killProcessTree(pid, true);
+  await waitForProcessExit(pid, PROCESS_FORCE_TIMEOUT_MS);
 }
 
 function resolveStdioCwd(configCwd: string | undefined, defaultCwd: string | undefined): string | undefined {

--- a/packages/agent-core/test/mcp/client-stdio.test.ts
+++ b/packages/agent-core/test/mcp/client-stdio.test.ts
@@ -14,6 +14,7 @@ const fixture = join(here, 'fixtures', 'mock-stdio-server.mjs');
 const cwdFixture = join(here, 'fixtures', 'cwd-stdio-server.mjs');
 const stderrThenExitFixture = join(here, 'fixtures', 'stderr-then-exit-stdio-server.mjs');
 const crashAfterConnectFixture = join(here, 'fixtures', 'crash-after-connect-stdio-server.mjs');
+const grandchildFixture = join(here, 'fixtures', 'grandchild-stdio-server.mjs');
 
 describe('StdioMcpClient', () => {
   it('rejects unsupported executor at construction time', () => {
@@ -293,6 +294,40 @@ describe('StdioMcpClient', () => {
     // suppressed and not merely racing.
     await new Promise((r) => setTimeout(r, 100));
     expect(closes).toEqual([]);
+  }, 15000);
+
+  it('reaps the whole process tree including a long-lived grandchild', async () => {
+    const client = new StdioMcpClient({
+      transport: 'stdio',
+      command: process.execPath,
+      args: [grandchildFixture],
+    });
+    let grandchildPid: number | undefined;
+    try {
+      await client.connect();
+      const result = await client.callTool('get_grandchild_pid', {});
+      const text = (result.content[0] as { type: 'text'; text: string }).text;
+      grandchildPid = Number.parseInt(text, 10);
+      expect(Number.isInteger(grandchildPid)).toBe(true);
+      expect(grandchildPid).toBeGreaterThan(0);
+    } finally {
+      await client.close();
+    }
+
+    // After close, both the immediate child (the fixture server) and the
+    // grandchild it spawned must be gone. The grandchild ignores SIGTERM and
+    // sleeps forever, so surviving would mean the tree-kill failed.
+    const deadline = Date.now() + 5_000;
+    while (Date.now() < deadline) {
+      try {
+        process.kill(grandchildPid!, 0);
+      } catch {
+        return;
+      }
+      await new Promise((r) => setTimeout(r, 50));
+    }
+    // One final check so the assertion message is useful on failure.
+    expect(() => process.kill(grandchildPid!, 0)).toThrow();
   }, 15000);
 });
 

--- a/packages/agent-core/test/mcp/fixtures/grandchild-stdio-server.mjs
+++ b/packages/agent-core/test/mcp/fixtures/grandchild-stdio-server.mjs
@@ -1,0 +1,46 @@
+// MCP stdio server fixture that spawns a long-lived grandchild process.
+// Used to verify that StdioMcpClient.close() reaps the whole process tree,
+// not just the immediate child spawned by the SDK transport.
+
+import { spawn } from 'node:child_process';
+
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import { z } from 'zod';
+
+// Spawn a grandchild that sleeps forever and ignores SIGTERM so the test can
+// distinguish "transport killed immediate child" from "whole tree killed".
+const grandchild = spawn(
+  process.execPath,
+  ['-e', 'setInterval(() => {}, 1 << 30); process.on("SIGTERM", () => {});'],
+  {
+    detached: false,
+    stdio: 'ignore',
+  },
+);
+
+const server = new McpServer({ name: 'grandchild-stdio', version: '0.0.1' });
+
+server.registerTool(
+  'get_grandchild_pid',
+  {
+    description: 'Returns the PID of the long-lived grandchild',
+    inputSchema: {},
+  },
+  () => ({
+    content: [{ type: 'text', text: String(grandchild.pid) }],
+  }),
+);
+
+server.registerTool(
+  'echo',
+  {
+    description: 'Echoes input text',
+    inputSchema: { text: z.string() },
+  },
+  ({ text }) => ({
+    content: [{ type: 'text', text }],
+  }),
+);
+
+await server.connect(new StdioServerTransport());


### PR DESCRIPTION
## Problem

On Windows, stdio MCP servers launched via `npx -y <package>` end up with two processes: the `npx` wrapper and the actual `node` server. The MCP SDK's `StdioClientTransport.close()` only kills the immediate child, so the `node` server is left orphaned. Over session reconnects/shutdowns this accumulates many zombie `node.exe` processes.

## Fix

Capture the transport pid before the SDK clears it, then after the SDK's graceful close escalate to a platform-specific process-tree kill:

- **Windows**: `taskkill /T` (with `/F` for the force phase)
- **POSIX**: signal the process group (`kill(-pid, SIGTERM/SIGKILL)`), with `EPERM`/`ESRCH` fallbacks

## Changes

- `packages/agent-core/src/mcp/client-stdio.ts`: add `ensureProcessTreeTerminated`, `killProcessTree`, `waitForProcessExit`, `isProcessAlive`; call tree cleanup from `closeStartedClient`
- `packages/agent-core/test/mcp/fixtures/grandchild-stdio-server.mjs`: new fixture that spawns a long-lived grandchild
- `packages/agent-core/test/mcp/client-stdio.test.ts`: regression test asserting both server and grandchild are reaped within the close deadline

## Verification

- `pnpm --filter @moonshot-ai/agent-core typecheck` passes
- `pnpm --filter @moonshot-ai/agent-core test -- client-stdio.test.ts` passes (14/14, including the new test)

Fixes the zombie process issue observed when multiple MCP servers are restarted within a single Kimi session.