### PR TITLE
fix(web): merge snapshot with live-appended messages on resync

### DIFF
--- a/.changeset/fix-web-snapshot-merge-live.md
+++ b/.changeset/fix-web-snapshot-merge-live.md
@@ -2,4 +2,4 @@
 "@moonshot-ai/kimi-code": patch
 ---
 
-Merge the session snapshot with live-appended messages when resyncing, so messages that arrive while the snapshot is in flight are not briefly dropped.
+When resyncing a session, preserve only live messages that arrived while the snapshot was in flight, so a resync does not briefly drop them — without re-adding optimistic bubbles or undone turns.

--- a/.changeset/fix-web-snapshot-merge-live.md
+++ b/.changeset/fix-web-snapshot-merge-live.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Merge the session snapshot with live-appended messages when resyncing, so messages that arrive while the snapshot is in flight are not briefly dropped.

--- a/apps/kimi-web/src/composables/useKimiWebClient.ts
+++ b/apps/kimi-web/src/composables/useKimiWebClient.ts
@@ -946,6 +946,13 @@ async function handleSessionNotFound(sessionId: string): Promise<void> {
 async function syncSessionFromSnapshot(sessionId: string): Promise<SyncSessionResult> {
   try {
     const api = getKimiWebApi();
+    // Snapshot the in-memory message ids BEFORE the fetch so the merge below can
+    // tell apart messages that arrived during the fetch (preserve) from ones that
+    // were already local-only for other reasons (drop — e.g. optimistic bubbles
+    // or undone turns).
+    const beforeIds = new Set(
+      (rawState.messagesBySession[sessionId] ?? []).map((m) => m.id),
+    );
     const snap = await api.getSessionSnapshot(sessionId);
 
     updateSession(sessionId, (s) => ({
@@ -959,7 +966,11 @@ async function syncSessionFromSnapshot(sessionId: string): Promise<SyncSessionRe
     // snapshot was in flight, so a resync can't briefly drop them.
     setSessionMessages(
       sessionId,
-      mergeSnapshotMessages(snap.messages, rawState.messagesBySession[sessionId] ?? []),
+      mergeSnapshotMessages(
+        snap.messages,
+        rawState.messagesBySession[sessionId] ?? [],
+        beforeIds,
+      ),
     );
     rawState.messagesHasMoreBySession = {
       ...rawState.messagesHasMoreBySession,

--- a/apps/kimi-web/src/composables/useKimiWebClient.ts
+++ b/apps/kimi-web/src/composables/useKimiWebClient.ts
@@ -7,6 +7,7 @@ import { i18n } from '../i18n';
 import { getKimiWebApi } from '../api';
 import { isDaemonApiError, isDaemonNetworkError } from '../api/errors';
 import { loadUnread, safeGetString, safeRemove, safeSetString, saveUnread, STORAGE_KEYS } from '../lib/storage';
+import { mergeSnapshotMessages } from '../lib/mergeSnapshotMessages';
 import { useAppearance } from './client/useAppearance';
 import { useNotification } from './client/useNotification';
 import { useTaskPoller } from './client/useTaskPoller';
@@ -954,7 +955,12 @@ async function syncSessionFromSnapshot(sessionId: string): Promise<SyncSessionRe
           ? snap.session.model
           : s.model,
     }));
-    setSessionMessages(sessionId, snap.messages);
+    // Merge (don't replace) with whatever live events appended while the
+    // snapshot was in flight, so a resync can't briefly drop them.
+    setSessionMessages(
+      sessionId,
+      mergeSnapshotMessages(snap.messages, rawState.messagesBySession[sessionId] ?? []),
+    );
     rawState.messagesHasMoreBySession = {
       ...rawState.messagesHasMoreBySession,
       [sessionId]: snap.hasMoreMessages,

--- a/apps/kimi-web/src/lib/mergeSnapshotMessages.ts
+++ b/apps/kimi-web/src/lib/mergeSnapshotMessages.ts
@@ -2,23 +2,33 @@
 import type { AppMessage } from '../api/types';
 
 /**
- * Merge a freshly fetched session snapshot with the messages that may have been
- * appended by live events while the snapshot was in flight.
+ * Merge a freshly fetched session snapshot with the messages that arrived from
+ * live events *while the snapshot was in flight*.
  *
  * `snapshot` is the authoritative server view up to `asOfSeq`; everything in it
- * is kept in server order. `live` is the current in-memory list, which can
- * contain messages with `seq > asOfSeq` that arrived during the fetch — those
- * are appended (deduped by id) after the snapshot so they are not lost when the
- * snapshot replaces the in-memory list.
+ * is kept in server order. `live` is the current in-memory list. `beforeIds` is
+ * the set of message ids that were already present *before* the fetch started.
+ *
+ * Only messages that are both **new since the fetch started** (not in
+ * `beforeIds`) and **not already in the snapshot** are appended after the
+ * snapshot. This preserves genuine in-flight live messages (so a resync does not
+ * briefly drop them) without re-adding messages that are locally absent from the
+ * snapshot for other reasons — e.g. optimistic user bubbles (which keep their
+ * `msg_opt_*` id while the snapshot carries the daemon id) or turns removed by
+ * an undo. Both of those are in `beforeIds`, so they are correctly dropped.
  *
  * Ordering relies on the caller: `snapshot` must be seq-ordered and every
- * live-only message must sort after it. This holds on the sync path, where any
- * live-only message has `seq > asOfSeq`.
+ * appended message must sort after it. This holds on the sync path, where any
+ * newly-arrived live message has `seq > asOfSeq`.
  */
-export function mergeSnapshotMessages(snapshot: AppMessage[], live: AppMessage[]): AppMessage[] {
+export function mergeSnapshotMessages(
+  snapshot: AppMessage[],
+  live: AppMessage[],
+  beforeIds: ReadonlySet<string>,
+): AppMessage[] {
   if (live.length === 0) return snapshot;
   const snapshotIds = new Set(snapshot.map((m) => m.id));
-  const tail = live.filter((m) => !snapshotIds.has(m.id));
+  const tail = live.filter((m) => !beforeIds.has(m.id) && !snapshotIds.has(m.id));
   if (tail.length === 0) return snapshot;
   return [...snapshot, ...tail];
 }

--- a/apps/kimi-web/src/lib/mergeSnapshotMessages.ts
+++ b/apps/kimi-web/src/lib/mergeSnapshotMessages.ts
@@ -1,0 +1,24 @@
+// apps/kimi-web/src/lib/mergeSnapshotMessages.ts
+import type { AppMessage } from '../api/types';
+
+/**
+ * Merge a freshly fetched session snapshot with the messages that may have been
+ * appended by live events while the snapshot was in flight.
+ *
+ * `snapshot` is the authoritative server view up to `asOfSeq`; everything in it
+ * is kept in server order. `live` is the current in-memory list, which can
+ * contain messages with `seq > asOfSeq` that arrived during the fetch — those
+ * are appended (deduped by id) after the snapshot so they are not lost when the
+ * snapshot replaces the in-memory list.
+ *
+ * Ordering relies on the caller: `snapshot` must be seq-ordered and every
+ * live-only message must sort after it. This holds on the sync path, where any
+ * live-only message has `seq > asOfSeq`.
+ */
+export function mergeSnapshotMessages(snapshot: AppMessage[], live: AppMessage[]): AppMessage[] {
+  if (live.length === 0) return snapshot;
+  const snapshotIds = new Set(snapshot.map((m) => m.id));
+  const tail = live.filter((m) => !snapshotIds.has(m.id));
+  if (tail.length === 0) return snapshot;
+  return [...snapshot, ...tail];
+}

--- a/apps/kimi-web/test/merge-snapshot-messages.test.ts
+++ b/apps/kimi-web/test/merge-snapshot-messages.test.ts
@@ -12,32 +12,51 @@ function msg(id: string): AppMessage {
   };
 }
 
+const ids = (...xs: string[]): ReadonlySet<string> => new Set(xs);
+
 describe('mergeSnapshotMessages', () => {
   it('returns the snapshot verbatim when there is no live list', () => {
     const snapshot = [msg('a'), msg('b')];
-    expect(mergeSnapshotMessages(snapshot, [])).toBe(snapshot);
+    expect(mergeSnapshotMessages(snapshot, [], ids())).toBe(snapshot);
   });
 
   it('returns the snapshot verbatim when every live message is already in it', () => {
     const snapshot = [msg('a'), msg('b')];
     const live = [msg('a'), msg('b')];
-    expect(mergeSnapshotMessages(snapshot, live)).toBe(snapshot);
+    expect(mergeSnapshotMessages(snapshot, live, ids('a', 'b'))).toBe(snapshot);
   });
 
-  it('appends live messages that are not in the snapshot, in order', () => {
+  it('appends live messages that arrived during the fetch (not in beforeIds, not in snapshot)', () => {
     const snapshot = [msg('a'), msg('b')];
     const live = [msg('a'), msg('b'), msg('c'), msg('d')];
-    expect(mergeSnapshotMessages(snapshot, live).map((m) => m.id)).toEqual(['a', 'b', 'c', 'd']);
+    // a,b were present before the fetch; c,d arrived during it.
+    expect(mergeSnapshotMessages(snapshot, live, ids('a', 'b')).map((m) => m.id)).toEqual([
+      'a', 'b', 'c', 'd',
+    ]);
   });
 
-  it('dedups by id and keeps only the live-only tail', () => {
-    const snapshot = [msg('a'), msg('b')];
-    const live = [msg('b'), msg('c')];
-    expect(mergeSnapshotMessages(snapshot, live).map((m) => m.id)).toEqual(['a', 'b', 'c']);
+  it('does NOT re-append a pre-existing local-only message (optimistic bubble)', () => {
+    // Local optimistic bubble keeps its msg_opt_* id; the snapshot carries the
+    // daemon id. Both were present before the fetch.
+    const snapshot = [msg('a'), msg('user_x')];
+    const live = [msg('a'), msg('msg_opt_x')];
+    expect(mergeSnapshotMessages(snapshot, live, ids('a', 'msg_opt_x')).map((m) => m.id)).toEqual([
+      'a', 'user_x',
+    ]);
   });
 
-  it('appends the whole live list when the snapshot is empty', () => {
+  it('does NOT re-append a message removed by an undo', () => {
+    // The undone turn is still in the local list (and was present before the
+    // fetch) but is no longer in the authoritative snapshot.
+    const snapshot = [msg('a')];
+    const live = [msg('a'), msg('undone')];
+    expect(mergeSnapshotMessages(snapshot, live, ids('a', 'undone')).map((m) => m.id)).toEqual([
+      'a',
+    ]);
+  });
+
+  it('appends the whole live list when the snapshot is empty and all are new', () => {
     const live = [msg('x'), msg('y')];
-    expect(mergeSnapshotMessages([], live).map((m) => m.id)).toEqual(['x', 'y']);
+    expect(mergeSnapshotMessages([], live, ids()).map((m) => m.id)).toEqual(['x', 'y']);
   });
 });

--- a/apps/kimi-web/test/merge-snapshot-messages.test.ts
+++ b/apps/kimi-web/test/merge-snapshot-messages.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest';
+import type { AppMessage } from '../src/api/types';
+import { mergeSnapshotMessages } from '../src/lib/mergeSnapshotMessages';
+
+function msg(id: string): AppMessage {
+  return {
+    id,
+    sessionId: 's1',
+    role: 'user',
+    content: [],
+    createdAt: '2026-01-01T00:00:00.000Z',
+  };
+}
+
+describe('mergeSnapshotMessages', () => {
+  it('returns the snapshot verbatim when there is no live list', () => {
+    const snapshot = [msg('a'), msg('b')];
+    expect(mergeSnapshotMessages(snapshot, [])).toBe(snapshot);
+  });
+
+  it('returns the snapshot verbatim when every live message is already in it', () => {
+    const snapshot = [msg('a'), msg('b')];
+    const live = [msg('a'), msg('b')];
+    expect(mergeSnapshotMessages(snapshot, live)).toBe(snapshot);
+  });
+
+  it('appends live messages that are not in the snapshot, in order', () => {
+    const snapshot = [msg('a'), msg('b')];
+    const live = [msg('a'), msg('b'), msg('c'), msg('d')];
+    expect(mergeSnapshotMessages(snapshot, live).map((m) => m.id)).toEqual(['a', 'b', 'c', 'd']);
+  });
+
+  it('dedups by id and keeps only the live-only tail', () => {
+    const snapshot = [msg('a'), msg('b')];
+    const live = [msg('b'), msg('c')];
+    expect(mergeSnapshotMessages(snapshot, live).map((m) => m.id)).toEqual(['a', 'b', 'c']);
+  });
+
+  it('appends the whole live list when the snapshot is empty', () => {
+    const live = [msg('x'), msg('y')];
+    expect(mergeSnapshotMessages([], live).map((m) => m.id)).toEqual(['x', 'y']);
+  });
+});


### PR DESCRIPTION
## Related Issue

The last deferred item from the `apps/kimi-web` refactor handoff (`web-refactor-plan.md`). No standalone issue.

## Problem

`syncSessionFromSnapshot(sessionId)` did a wholesale replacement of the session's messages with the fetched snapshot:

```ts
const snap = await api.getSessionSnapshot(sessionId);          // in flight
setSessionMessages(sessionId, snap.messages);                  // replace
```

If the session was already subscribed (the `onResync` path, e.g. after a reconnect), live events could be appended to `messagesBySession[sessionId]` while the snapshot was in flight. The wholesale replace would drop them; they would then be re-delivered on the subsequent resubscribe at `asOfSeq`, causing a brief disappearance (a flicker), but no permanent loss.

## What changed

- `mergeSnapshotMessages(snapshot, live, beforeIds)` now takes the set of message ids that were present **before** the fetch started, and only appends live messages that are both **new since the fetch** (not in `beforeIds`) and **not already in the snapshot**.
- `syncSessionFromSnapshot` captures `beforeIds` from `rawState.messagesBySession[sessionId]` before the `await`, and passes it to the helper.
- This preserves genuine in-flight live messages (no flicker) while correctly dropping messages that are locally absent from the snapshot for other reasons:
  - **optimistic user bubbles**, which keep their `msg_opt_*` id while the snapshot carries the daemon id (would otherwise duplicate), and
  - **turns removed by an undo**, which are still in the local list when `syncSessionFromSnapshot` runs after `undoSession` (would otherwise reappear).
- Updated `test/merge-snapshot-messages.test.ts` (6 cases, including the optimistic-bubble and undo cases).

This eliminates the flicker window without changing the steady-state result (the same messages end up in the list, just without the transient drop). No user-visible behavior change beyond removing that flicker.

## Verification

- `pnpm --filter @moonshot-ai/kimi-web typecheck` — pass (`vue-tsc --noEmit`)
- `pnpm --filter @moonshot-ai/kimi-web test` — 89 passed (6 in `merge-snapshot-messages.test.ts`)
- `pnpm --filter @moonshot-ai/kimi-web build` — pass
- `oxlint --type-aware` on the changed files — 0 errors (the 16 warnings on `useKimiWebClient.ts` are all pre-existing and not on the changed lines; the change adds none)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works. (`test/merge-snapshot-messages.test.ts`.)
- [x] Ran `gen-changesets` skill, or this PR needs no changeset. (Added `.changeset/fix-web-snapshot-merge-live.md`, `patch` on `@moonshot-ai/kimi-code`.)
- [x] Ran `gen-docs` skill, or this PR needs no doc update. (No user-facing doc change.)
