### PR TITLE
feat(web): show dev-mode indicator in sidebar

### DIFF
--- a/.changeset/web-dev-mode-indicator.md
+++ b/.changeset/web-dev-mode-indicator.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Add a development-mode indicator to the web sidebar for local development.

--- a/apps/kimi-web/src/components/Sidebar.vue
+++ b/apps/kimi-web/src/components/Sidebar.vue
@@ -5,11 +5,18 @@
 <script setup lang="ts">
 import { computed, nextTick, onBeforeUnmount, ref } from 'vue';
 import { useI18n } from 'vue-i18n';
+import { serverEndpointLabel } from '../api/config';
 import type { Session, WorkspaceGroup as WorkspaceGroupType, WorkspaceView } from '../types';
 import SessionRow from './SessionRow.vue';
 import WorkspaceGroup from './WorkspaceGroup.vue';
 
 const { t } = useI18n();
+
+// Dev-only affordance: when the page is served by the Vite dev server, the
+// logo turns yellow and the backend host:port is appended to the title —
+// handy for telling several dev tabs apart. In production this is all inert.
+const isDev = import.meta.env.DEV;
+const endpoint = isDev ? serverEndpointLabel() : '';
 
 const props = withDefaults(
   defineProps<{
@@ -395,7 +402,7 @@ function blinkOnce(): void {
       <!-- Header: logo + settings (no hard border — flows into workspace list) -->
       <div class="ch">
         <div class="ch-brand">
-          <svg ref="logoRef" class="ch-logo" viewBox="0 0 32 22" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Kimi Code" @click="blinkOnce">
+          <svg ref="logoRef" class="ch-logo" :class="{ 'is-dev': isDev }" viewBox="0 0 32 22" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Kimi Code" @click="blinkOnce">
             <defs>
               <mask id="kimiEyes" maskUnits="userSpaceOnUse">
                 <rect x="0" y="0" width="32" height="22" fill="#fff" />
@@ -407,7 +414,7 @@ function blinkOnce(): void {
             </defs>
             <rect x="1" y="1" width="30" height="20" rx="6" fill="var(--logo)" mask="url(#kimiEyes)" />
           </svg>
-          <span class="ch-name">Kimi Code</span>
+          <span class="ch-name">Kimi Code<span v-if="isDev" class="ch-endpoint"> · {{ endpoint }}</span></span>
         </div>
         <button
           type="button"
@@ -645,6 +652,12 @@ function blinkOnce(): void {
 .ch-logo:hover {
   transform: scale(1.08);
 }
+/* Dev-only: tint the mark yellow so a `pnpm dev:web` tab is obvious at a
+   glance. `--logo` is read by the mark's `fill`; overriding it on the svg
+   recolors just this instance. */
+.ch-logo.is-dev {
+  --logo: #f5b301;
+}
 .ch-brand {
   display: flex;
   align-items: center;
@@ -661,6 +674,14 @@ function blinkOnce(): void {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+/* Dev-only: backend host:port appended to the title. Kept secondary so the
+   product name still leads. */
+.ch-endpoint {
+  color: var(--muted);
+  font-family: var(--mono);
+  font-weight: 400;
+  font-size: calc(var(--ui-font-size) - 1px);
 }
 
 /* In narrow sidebars the product name drops out so the logo keeps its fixed


### PR DESCRIPTION
## Related Issue

No related issue.

## Problem

During local development it is easy to lose track of which browser tab is the actively `pnpm dev:web`'d one and which backend server it talks to, especially when several tabs and servers are open at once.

## What changed

When the page is served by the Vite dev server, the sidebar logo turns yellow and the connected backend `host:port` is appended to the "Kimi Code" title, so dev tabs are distinguishable at a glance. It reuses `import.meta.env.DEV` and the existing `serverEndpointLabel()`, and is fully inert in production builds.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [ ] I have added tests that prove my feature works. (N/A — dev-only visual affordance; the web app has no component test infrastructure. Covered by typecheck and lint.)
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.
