### PR TITLE
fix(web): fall back to session abort for stale prompts

### DIFF
--- a/.changeset/web-abort-session-fallback.md
+++ b/.changeset/web-abort-session-fallback.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Fix web chat stop actions so stale prompt ids fall back to cancelling the active session.

--- a/apps/kimi-web/src/composables/client/useWorkspaceState.ts
+++ b/apps/kimi-web/src/composables/client/useWorkspaceState.ts
@@ -1049,15 +1049,22 @@ export function useWorkspaceState(rawState: ExtendedState, deps: UseWorkspaceSta
 
     const api = getKimiWebApi();
 
-    // 3. If we have a real id, try the per-prompt abort first. On 40402 fall back
-    //    to session-level abort (the daemon may have restarted or the id is stale).
+    // 3. If we have a real id, try the per-prompt abort first. If the daemon
+    //    reports the prompt is missing/already completed, clear the stale id and
+    //    fall back to session-level abort for whatever is currently running.
     if (promptId !== undefined) {
       try {
-        await api.abortPrompt(sid, promptId);
-        return;
+        const result = await api.abortPrompt(sid, promptId);
+        if (result.aborted) return;
+        const nextPromptIds = { ...rawState.promptIdBySession };
+        delete nextPromptIds[sid];
+        rawState.promptIdBySession = nextPromptIds;
       } catch (err) {
         if (isDaemonApiError(err) && err.code === PROMPT_NOT_FOUND_CODE) {
           // Stale id — try the session-level fallback below.
+          const nextPromptIds = { ...rawState.promptIdBySession };
+          delete nextPromptIds[sid];
+          rawState.promptIdBySession = nextPromptIds;
         } else {
           pushOperationFailure('abortCurrentPrompt', err, { sessionId: sid });
           return;

--- a/apps/kimi-web/test/workspace-state.test.ts
+++ b/apps/kimi-web/test/workspace-state.test.ts
@@ -1,0 +1,154 @@
+import { computed, ref } from 'vue';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { AppSession } from '../src/api/types';
+import { createInitialState } from '../src/api/daemon/eventReducer';
+import { useWorkspaceState, type UseWorkspaceStateDeps } from '../src/composables/client/useWorkspaceState';
+import type { ExtendedState } from '../src/composables/useKimiWebClient';
+
+const apiMock = vi.hoisted(() => ({
+  abortPrompt: vi.fn(),
+  abortSession: vi.fn(),
+}));
+
+vi.mock('../src/api', () => ({
+  getKimiWebApi: () => apiMock,
+}));
+
+function createSession(): AppSession {
+  return {
+    id: 'sess_1',
+    title: 'Session',
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+    status: 'running',
+    archived: false,
+    currentPromptId: 'prompt_live',
+    cwd: '/workspace',
+    model: 'kimi-code',
+    usage: {
+      inputTokens: 0,
+      outputTokens: 0,
+      cacheReadTokens: 0,
+      cacheCreationTokens: 0,
+      totalCostUsd: 0,
+      contextTokens: 0,
+      contextLimit: 0,
+      turnCount: 0,
+    },
+    messageCount: 0,
+    lastSeq: 0,
+  };
+}
+
+function createState(): ExtendedState {
+  return {
+    ...createInitialState(),
+    sessions: [createSession()],
+    activeSessionId: 'sess_1',
+    connected: true,
+    serverVersion: '',
+    workspaceName: 'kimi-web',
+    connection: 'connected',
+    permission: 'manual',
+    thinking: 'high',
+    planMode: false,
+    swarmMode: false,
+    goalMode: false,
+    loading: false,
+    sessionLoading: false,
+    queuedBySession: {},
+    gitStatusBySession: {},
+    promptIdBySession: { sess_1: 'prompt_stale' },
+    sendingBySession: {},
+    unreadBySession: {},
+    authReady: true,
+    defaultModel: null,
+    managedProviderStatus: null,
+    workspaces: [],
+    activeWorkspaceId: null,
+    fsHome: null,
+    recentRoots: [],
+    hiddenWorkspaceRoots: [],
+    availableOpenInApps: [],
+    config: null,
+    sideChatMessagesByAgent: {},
+    sideChatSendingByAgent: {},
+    sideChatUserMessageIdsBySession: {},
+    messagesLoadingMoreBySession: {},
+    messagesHasMoreBySession: {},
+    messagesLoadMoreErrorBySession: {},
+  };
+}
+
+function createDeps(): UseWorkspaceStateDeps {
+  return {
+    taskPoller: {},
+    sideChat: {},
+    modelProvider: {},
+    pushOperationFailure: vi.fn(),
+    activity: computed(() => 'running'),
+    inFlightPromptSessions: new Set(),
+    sessionsKnownEmpty: new Set(),
+    setSessions: vi.fn(),
+    updateSession: vi.fn(),
+    upsertSessionFront: vi.fn(),
+    appendSession: vi.fn(),
+    forgetSession: vi.fn(),
+    setActiveSessionId: vi.fn(),
+    updateSessionMessages: vi.fn(),
+    nextOptimisticMsgId: () => 'msg_opt_1',
+    getEventConn: () => null,
+    syncSessionFromSnapshot: vi.fn(),
+    subscribeToSessionEvents: vi.fn(),
+    hasLoadedMessages: vi.fn(),
+    refreshSessionStatus: vi.fn(),
+    persistSessionProfile: vi.fn(),
+    mergedWorkspaces: computed(() => []),
+    status: computed(() => ({})),
+    workspaceIdForSession: vi.fn(),
+    savePermissionToStorage: vi.fn(),
+    savePlanModeToStorage: vi.fn(),
+    saveSwarmModeToStorage: vi.fn(),
+    saveGoalModeToStorage: vi.fn(),
+    saveUnread: vi.fn(),
+    saveActiveWorkspaceToStorage: vi.fn(),
+    saveHiddenWorkspacesToStorage: vi.fn(),
+    goalErrorMessage: vi.fn(),
+    basename: (path: string) => path.split('/').at(-1) ?? path,
+    resetFastMoon: vi.fn(),
+    initialized: ref(true),
+    selectedDiffPath: ref(null),
+    fileDiffLines: ref([]),
+    fileDiffLoading: ref(false),
+  } as unknown as UseWorkspaceStateDeps;
+}
+
+describe('useWorkspaceState — abortCurrentPrompt', () => {
+  beforeEach(() => {
+    apiMock.abortPrompt.mockReset();
+    apiMock.abortSession.mockReset();
+  });
+
+  it('falls back to session abort when the cached prompt id is already completed', async () => {
+    apiMock.abortPrompt.mockResolvedValue({ aborted: false });
+    apiMock.abortSession.mockResolvedValue({ aborted: true });
+    const state = createState();
+    const workspace = useWorkspaceState(state, createDeps());
+
+    await workspace.abortCurrentPrompt();
+
+    expect(apiMock.abortPrompt).toHaveBeenCalledWith('sess_1', 'prompt_stale');
+    expect(apiMock.abortSession).toHaveBeenCalledWith('sess_1');
+    expect(state.promptIdBySession).toEqual({});
+  });
+
+  it('does not fall back when prompt abort succeeds', async () => {
+    apiMock.abortPrompt.mockResolvedValue({ aborted: true });
+    const workspace = useWorkspaceState(createState(), createDeps());
+
+    await workspace.abortCurrentPrompt();
+
+    expect(apiMock.abortPrompt).toHaveBeenCalledWith('sess_1', 'prompt_stale');
+    expect(apiMock.abortSession).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Related Issue

No linked issue. This fixes a web chat stop action race observed during streaming.

## Problem

When the web client held a stale `prompt_id`, prompt-level abort could return `aborted: false`. The client treated that as handled and did not try the session-level abort fallback, so clicking Stop could appear to do nothing while the session was still running.

## What changed

- Fall back to session-level abort when prompt-level abort reports the cached prompt is missing or already completed.
- Clear the stale cached prompt id before falling back.
- Add regression coverage for stale prompt abort and successful prompt abort paths.
- Add a patch changeset for the bundled web fix.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.

Verification:

- `pnpm --filter @moonshot-ai/kimi-web typecheck`
- `pnpm --filter @moonshot-ai/kimi-web exec vitest run --reporter=verbose`
- `pnpm --filter @moonshot-ai/kimi-web build`
- `git diff --check origin/main..HEAD`
- Read-only diff audit: No actionable findings.

Docs: no docs update needed; this restores the existing web Stop behavior without adding a new user-facing command or configuration.
