### PR TITLE
feat(web): persist collapsed workspace groups to localStorage

### DIFF
--- a/.changeset/web-persist-workspace-collapse.md
+++ b/.changeset/web-persist-workspace-collapse.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Persist the collapsed state of workspace groups in the web sidebar across page reloads.

--- a/apps/kimi-web/src/components/Sidebar.vue
+++ b/apps/kimi-web/src/components/Sidebar.vue
@@ -7,6 +7,7 @@ import { computed, nextTick, onBeforeUnmount, ref } from 'vue';
 import { useI18n } from 'vue-i18n';
 import { serverEndpointLabel } from '../api/config';
 import { copyTextToClipboard } from '../lib/clipboard';
+import { loadCollapsedWorkspaces, saveCollapsedWorkspaces } from '../lib/storage';
 import type { Session, WorkspaceGroup as WorkspaceGroupType, WorkspaceView } from '../types';
 import SessionRow from './SessionRow.vue';
 import WorkspaceGroup from './WorkspaceGroup.vue';
@@ -89,7 +90,7 @@ function onSelectResult(sessionId: string): void {
 // ---------------------------------------------------------------------------
 // Collapse groups
 // ---------------------------------------------------------------------------
-const collapsedIds = ref<Set<string>>(new Set());
+const collapsedIds = ref<Set<string>>(new Set(loadCollapsedWorkspaces()));
 
 function isCollapsed(id: string): boolean {
   return collapsedIds.value.has(id);
@@ -107,6 +108,7 @@ function toggleCollapse(id: string): void {
     next.add(id);
   }
   collapsedIds.value = next;
+  saveCollapsedWorkspaces(next);
 }
 
 // ---------------------------------------------------------------------------

--- a/apps/kimi-web/src/lib/storage.ts
+++ b/apps/kimi-web/src/lib/storage.ts
@@ -22,6 +22,7 @@ export const STORAGE_KEYS = {
   accent: 'kimi-web.accent',
   colorScheme: 'kimi-web.color-scheme',
   hiddenWorkspaces: 'kimi-web.hidden-workspaces',
+  collapsedWorkspaces: 'kimi-web.collapsed-workspaces',
   betaToc: 'kimi-web.beta-toc',
   notifyOnComplete: 'kimi-web.notify-on-complete',
   inputHistory: 'kimi-web.input-history',
@@ -121,4 +122,19 @@ export function saveUnread(changes: Record<string, boolean>): void {
     else delete merged[id];
   }
   safeSetString(STORAGE_KEYS.unread, JSON.stringify(merged));
+}
+
+/**
+ * Collapsed workspace ids in the sidebar. Persisted as a JSON array of ids so
+ * the fold state of each workspace group survives a page refresh. There is no
+ * server-side source of truth for this UI-only state.
+ */
+export function loadCollapsedWorkspaces(): string[] {
+  const parsed = safeGetJson<unknown>(STORAGE_KEYS.collapsedWorkspaces);
+  if (!Array.isArray(parsed)) return [];
+  return parsed.filter((id): id is string => typeof id === 'string');
+}
+
+export function saveCollapsedWorkspaces(ids: Iterable<string>): void {
+  safeSetJson(STORAGE_KEYS.collapsedWorkspaces, Array.from(ids));
 }

--- a/apps/kimi-web/test/storage-logic.test.ts
+++ b/apps/kimi-web/test/storage-logic.test.ts
@@ -1,6 +1,8 @@
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import {
+  loadCollapsedWorkspaces,
   loadUnread,
+  saveCollapsedWorkspaces,
   saveUnread,
   STORAGE_KEYS,
   draftStorageKey,
@@ -167,5 +169,29 @@ describe('loadUnread / saveUnread', () => {
 
     // B must NOT come back — it was cleared by the other tab.
     expect(loadUnread()).toEqual({ C: true, D: true });
+  });
+});
+
+describe('loadCollapsedWorkspaces / saveCollapsedWorkspaces', () => {
+  it('returns an empty array when the key is missing', () => {
+    expect(loadCollapsedWorkspaces()).toEqual([]);
+  });
+
+  it('round-trips the collapsed ids', () => {
+    saveCollapsedWorkspaces(['ws-1', 'ws-2']);
+    expect(loadCollapsedWorkspaces()).toEqual(['ws-1', 'ws-2']);
+  });
+
+  it('accepts any iterable of ids', () => {
+    saveCollapsedWorkspaces(new Set(['ws-1', 'ws-3']));
+    expect(loadCollapsedWorkspaces()).toEqual(['ws-1', 'ws-3']);
+  });
+
+  it('drops non-string entries and returns [] for malformed values', () => {
+    safeSetString(STORAGE_KEYS.collapsedWorkspaces, JSON.stringify(['ws-1', 2, null, 'ws-2']));
+    expect(loadCollapsedWorkspaces()).toEqual(['ws-1', 'ws-2']);
+
+    safeSetString(STORAGE_KEYS.collapsedWorkspaces, JSON.stringify({ ws: true }));
+    expect(loadCollapsedWorkspaces()).toEqual([]);
   });
 });


### PR DESCRIPTION
## Related Issue

No related issue — this is a small UX polish for the web sidebar.

## Problem

When the web page is reloaded, every workspace group in the sidebar expands back to its default state. Users who keep several workspaces collapsed have to re-fold them on each visit.

## What changed

The collapsed set of workspace ids is now persisted to `localStorage` (key `kimi-web.collapsed-workspaces`) and restored on mount. The fold/unfold toggle writes the updated set back, so the sidebar looks the same after a refresh. This is UI-only state with no server-side source of truth, so `localStorage` is the right place — consistent with how the sidebar already persists its own width/collapsed state, hidden workspaces, and unread dots.

- `src/lib/storage.ts`: new `loadCollapsedWorkspaces` / `saveCollapsedWorkspaces` helpers with array/shape validation.
- `src/components/Sidebar.vue`: initialize the collapsed set from storage and save on every toggle.
- `test/storage-logic.test.ts`: covers missing key, round-trip, iterable input, and malformed/non-string values.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update. (No user-facing docs to update for this behavior.)