### PR TITLE
fix(tui): throttle spinner renders to reduce CPU usage

### DIFF
--- a/.changeset/tui-spinner-throttle.md
+++ b/.changeset/tui-spinner-throttle.md
@@ -1,0 +1,8 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Throttle TUI spinner renders to reduce CPU usage during thinking/loading states.
+
+- `ThinkingComponent` now advances its braille animation frame every 80ms but coalesces `requestRender()` calls to ~200ms.
+- `MoonLoader` similarly coalesces interval-driven renders to ~200ms while still rendering immediately on label/tip/width/color changes.

--- a/apps/kimi-code/src/tui/components/chrome/moon-loader.ts
+++ b/apps/kimi-code/src/tui/components/chrome/moon-loader.ts
@@ -14,6 +14,7 @@ export type SpinnerStyle = 'moon' | 'braille';
 export class MoonLoader extends Text {
   private currentFrame = 0;
   private intervalId: ReturnType<typeof setInterval> | null = null;
+  private renderThrottleTimer: ReturnType<typeof setTimeout> | null = null;
   private ui: TUI;
   private frames: string[];
   private interval: number;
@@ -42,7 +43,7 @@ export class MoonLoader extends Text {
     this.updateDisplay();
     this.intervalId = setInterval(() => {
       this.currentFrame = (this.currentFrame + 1) % this.frames.length;
-      this.updateDisplay();
+      this.scheduleRender();
     }, this.interval);
   }
 
@@ -51,6 +52,23 @@ export class MoonLoader extends Text {
       clearInterval(this.intervalId);
       this.intervalId = null;
     }
+    if (this.renderThrottleTimer) {
+      clearTimeout(this.renderThrottleTimer);
+      this.renderThrottleTimer = null;
+    }
+  }
+
+  /**
+   * Coalesce interval-driven spinner renders to avoid a full TUI re-render on
+   * every animation frame. State changes (label/tip/width/color) still render
+   * immediately via updateDisplay().
+   */
+  private scheduleRender(): void {
+    if (this.renderThrottleTimer !== null) return;
+    this.renderThrottleTimer = setTimeout(() => {
+      this.renderThrottleTimer = null;
+      this.updateDisplay();
+    }, 200);
   }
 
   setLabel(label: string): void {

--- a/apps/kimi-code/src/tui/components/messages/thinking.ts
+++ b/apps/kimi-code/src/tui/components/messages/thinking.ts
@@ -26,6 +26,7 @@ export class ThinkingComponent implements Component {
   private readonly ui: TUI | undefined;
   private spinnerFrame = 0;
   private spinnerInterval: ReturnType<typeof setInterval> | undefined;
+  private spinnerRenderTimer: ReturnType<typeof setTimeout> | null = null;
   // Hold a single Text instance so pi-tui's (text, width) → lines cache
   // actually survives across renders. Re-constructing per render destroys
   // the cache and forces full re-wrap on every frame, which dominates CPU
@@ -122,13 +123,32 @@ export class ThinkingComponent implements Component {
     if (this.ui === undefined || this.spinnerInterval !== undefined) return;
     this.spinnerInterval = setInterval(() => {
       this.spinnerFrame = (this.spinnerFrame + 1) % BRAILLE_SPINNER_FRAMES.length;
-      this.ui?.requestRender();
+      this.scheduleSpinnerRender();
     }, BRAILLE_SPINNER_INTERVAL_MS);
+  }
+
+  /**
+   * Throttle spinner renders to avoid full transcript re-layout on every
+   * animation frame. The frame index advances at the animation interval, but
+   * the expensive requestRender is coalesced to ~200ms — matching the pattern
+   * used by AgentGroupComponent.
+   */
+  private scheduleSpinnerRender(): void {
+    if (this.spinnerRenderTimer !== null) return;
+    this.spinnerRenderTimer = setTimeout(() => {
+      this.spinnerRenderTimer = null;
+      this.ui?.requestRender();
+    }, 200);
   }
 
   private stopSpinner(): void {
     if (this.spinnerInterval === undefined) return;
     clearInterval(this.spinnerInterval);
     this.spinnerInterval = undefined;
+    if (this.spinnerRenderTimer !== null) {
+      clearTimeout(this.spinnerRenderTimer);
+      this.spinnerRenderTimer = null;
+    }
+    this.ui?.requestRender();
   }
 }


### PR DESCRIPTION
## Related Issue

No linked issue. This PR addresses the high CPU usage reported in user testing where the TUI spinners (braille "thinking" spinner and moon loader) trigger a full screen re-render on every animation frame.

## Problem

`ThinkingComponent` and `MoonLoader` both call `ui.requestRender()` on every spinner frame update (80ms and 120ms intervals). `requestRender()` with no arguments causes a full TUI re-layout, including markdown re-parsing and ICU width calculation. On long transcripts this keeps the node process at ~10% CPU continuously while thinking/loading.

## What changed

- `apps/kimi-code/src/tui/components/messages/thinking.ts`
  - Added a 200ms render throttle. The braille frame index still advances every 80ms, but `requestRender()` is coalesced.

- `apps/kimi-code/src/tui/components/chrome/moon-loader.ts`
  - Added the same 200ms render throttle for interval-driven frame changes. Explicit state changes (label, tip, width, color) still render immediately.

- `.changeset/tui-spinner-throttle.md`
  - Added a patch changeset for `@moonshot-ai/kimi-code`.

This matches the existing throttling pattern used by `AgentGroupComponent` (`THROTTLE_MS = 200`).

## Verification

- `pnpm -C apps/kimi-code exec tsc --noEmit` passes.
- Manual verification requested: run `python3 /Users/FiaShi_1/Desktop/monitor-kimi-code.py` while a long-thinking response is in progress; CPU during the spinner state should be significantly lower than before.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have explained the problem above (no linked issue).
- [ ] I have added tests that prove my feature works. *(Verified via typecheck; manual CPU verification requested.)*
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [ ] Ran `gen-docs` skill, or this PR needs no doc update.
