### PR TITLE
fix(kosong): add idle timeout to streaming response loop

### DIFF
--- a/.changeset/stream-idle-timeout.md
+++ b/.changeset/stream-idle-timeout.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Add 60s idle timeout to streaming response loop to prevent indefinite hangs.

--- a/packages/kosong/src/generate.ts
+++ b/packages/kosong/src/generate.ts
@@ -111,7 +111,21 @@ export async function generate(
   // the stream.
   await throwIfAborted(options?.signal, stream);
 
+  // Idle timeout: if no chunk arrives within this period, abort the stream
+  // to prevent indefinite hangs when the connection stalls without closing.
+  const IDLE_TIMEOUT_MS = 60_000;
+  let idleTimer: ReturnType<typeof setTimeout> | undefined;
+  const resetIdleTimer = () => {
+    if (idleTimer) clearTimeout(idleTimer);
+    idleTimer = setTimeout(() => {
+      stream.return?.(undefined);
+    }, IDLE_TIMEOUT_MS);
+  };
+  resetIdleTimer();
+
+  try {
   for await (const part of stream) {
+    resetIdleTimer();
     await throwIfAborted(options?.signal, stream);
 
     // Notify raw part callback (deep copy to avoid aliasing mutations).

--- a/packages/kosong/src/generate.ts
+++ b/packages/kosong/src/generate.ts
@@ -169,6 +169,9 @@ export async function generate(
       pendingPart = part;
     }
   }
+  } finally {
+    if (idleTimer) clearTimeout(idleTimer);
+  }
 
   await throwIfAborted(options?.signal, stream);
   options?.onStreamEnd?.();


### PR DESCRIPTION
Fixes #1050

## Problem

When a model stream stalls — connection remains ESTABLISHED but no bytes arrive — `packages/kosong/src/generate.ts` waits forever inside its `for await (const part of stream)` loop. There is no chunk-level idle timeout, so the UI stays in "thinking" state indefinitely.

## What changed

Added a 60-second idle timeout around the streaming loop:

- `resetIdleTimer()` is called before the loop starts and on every chunk received
- If no chunk arrives within 60s, the timer fires and calls `stream.return()` to abort the stream
- The timer is cleaned up in a `finally` block to avoid leaks
- Existing `AbortSignal` handling is unchanged — the idle timeout is an additional safety net

## Validation

- Normal streaming: timer resets on every chunk, never fires
- Stalled connection: timer fires after 60s, stream aborts, user gets control back
- Manual abort: existing AbortSignal path still works
- Timer cleanup: `finally` block ensures no timer leak on any exit path
