### PR TITLE
fix(web): stop auto-approving plan reviews and sensitive files in yolo mode

### DIFF
--- a/.changeset/fix-web-yolo-auto-approve.md
+++ b/.changeset/fix-web-yolo-auto-approve.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Fix yolo mode in the web app auto-approving plan reviews and sensitive file access.

--- a/apps/kimi-web/src/composables/client/useWorkspaceState.ts
+++ b/apps/kimi-web/src/composables/client/useWorkspaceState.ts
@@ -1229,25 +1229,13 @@ export function useWorkspaceState(rawState: ExtendedState, deps: UseWorkspaceSta
       });
   }
 
-  /** Persist and apply a new permission mode; auto-approve pending approvals if switching to auto/yolo */
+  /** Persist and apply a new permission mode. Approval decisions are owned by
+   *  the daemon (auto/yolo are resolved server-side), so any pending approvals
+   *  are left for the user to answer explicitly. */
   function setPermission(mode: PermissionMode): void {
     rawState.permission = mode;
     savePermissionToStorage(mode);
     persistSessionProfile({ permissionMode: mode });
-
-    // If switching to auto/yolo, auto-approve any currently-pending approvals for the active session
-    if (mode === 'auto' || mode === 'yolo') {
-      const sid = rawState.activeSessionId;
-      if (sid) {
-        const approvals = [...(rawState.approvalsBySession[sid] ?? [])];
-        for (const a of approvals) {
-          void respondApproval(a.approvalId, {
-            decision: 'approved',
-            scope: mode === 'yolo' ? 'session' : undefined,
-          });
-        }
-      }
-    }
   }
 
   /** Dismiss a warning by index */

--- a/apps/kimi-web/src/composables/useKimiWebClient.ts
+++ b/apps/kimi-web/src/composables/useKimiWebClient.ts
@@ -730,19 +730,6 @@ function connectEventsIfNeeded(): void {
       ) {
         onSessionIdle(appEvent.sessionId, appEvent.status);
       }
-
-      // Permission auto-approve: CLIENT-SIDE POLICY until the daemon exposes a
-      // permission endpoint. When permission is 'auto' or 'yolo' and an approval
-      // request arrives, immediately respond with 'approved'.
-      if (appEvent.type === 'approvalRequested') {
-        const perm = rawState.permission;
-        if (perm === 'auto' || perm === 'yolo') {
-          void workspaceState.respondApproval(appEvent.approval.approvalId, {
-            decision: 'approved',
-            scope: perm === 'yolo' ? 'session' : undefined,
-          });
-        }
-      }
     },
 
     onResync(sessionId: string, currentSeq: number, epoch?: string) {


### PR DESCRIPTION
## Related Issue

No prior issue. Found by tracing a yolo-mode web session where a plan was approved without any user interaction.

## Problem

In the web app, a session running in `yolo` permission mode had every approval request silently auto-approved, including requests the daemon intentionally sends for user confirmation: plan reviews (`ExitPlanMode`), sensitive-file access, `.git` control-path access, and goal starts. A plan could be approved within milliseconds without the user ever seeing it.

The cause was a client-side policy in the web app — a temporary "until the daemon exposes a permission endpoint" shim — that answered `approved` to every incoming approval request whenever the mode was `auto` or `yolo`. The daemon already resolves `auto` and `yolo` server-side: `auto` never emits an approval request, and `yolo` deliberately still asks for the sensitive cases above. The web shim overrode that intent. The TUI has no such shim and behaves correctly.

## What changed

- Removed the client-side auto-approve on incoming approval requests in the web event handler.
- Removed the "auto-approve pending approvals on switching to auto/yolo" behavior in the permission-mode setter.

Any approval request that now reaches the web app is a genuine daemon ask and is shown to the user, matching the TUI and the daemon's permission policy chain. `auto` mode is unaffected because it never produced approval requests. The intended behavior is already covered by the daemon-side permission policy tests, so this PR adds no new web test.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [ ] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.
