### PR TITLE
fix: use session cwd for stdio MCP servers

### DIFF
--- a/.changeset/fix-mcp-web-cwd.md
+++ b/.changeset/fix-mcp-web-cwd.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Fix MCP server working directories when sessions are hosted by the web server.

--- a/packages/agent-core/src/mcp/client-stdio.ts
+++ b/packages/agent-core/src/mcp/client-stdio.ts
@@ -3,6 +3,7 @@ import type { McpServerStdioConfig } from '#/config/schema';
 import { proxyEnvForChild, reconcileChildNoProxy } from '#/utils/proxy';
 import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
+import { isAbsolute, resolve } from 'pathe';
 
 import {
   buildRequestOptions,
@@ -19,6 +20,7 @@ export interface StdioMcpClientOptions {
   readonly clientName?: string;
   readonly clientVersion?: string;
   readonly toolCallTimeoutMs?: number;
+  readonly defaultCwd?: string;
 }
 
 const STDERR_BUFFER_CAPACITY = 4 * 1024;
@@ -61,7 +63,7 @@ export class StdioMcpClient implements MCPClient {
       command: config.command,
       args: config.args,
       env: mergeStdioEnv(config.env),
-      cwd: config.cwd,
+      cwd: resolveStdioCwd(config.cwd, options.defaultCwd),
       stderr: 'pipe',
     });
     // `stderr: 'pipe'` means we MUST drain the stream — otherwise the child
@@ -214,6 +216,12 @@ class BoundedTail {
   snapshot(): string {
     return this.buffer;
   }
+}
+
+function resolveStdioCwd(configCwd: string | undefined, defaultCwd: string | undefined): string | undefined {
+  if (configCwd === undefined) return defaultCwd;
+  if (defaultCwd !== undefined && !isAbsolute(configCwd)) return resolve(defaultCwd, configCwd);
+  return configCwd;
 }
 
 // Inherit the parent's env so PATH/HOME/etc. survive — otherwise `npx`/`uvx`

--- a/packages/agent-core/src/mcp/connection-manager.ts
+++ b/packages/agent-core/src/mcp/connection-manager.ts
@@ -42,6 +42,7 @@ type RuntimeMcpClient = StdioMcpClient | HttpMcpClient | SseMcpClient;
 
 export interface McpConnectionManagerOptions {
   readonly envLookup?: (name: string) => string | undefined;
+  readonly stdioCwd?: string;
   /**
    * Optional OAuth orchestrator. When provided, remote servers without a
    * static bearer token participate in the OAuth-via-synthetic-tool flow:
@@ -331,7 +332,7 @@ export class McpConnectionManager {
   private createClient(config: McpServerConfig, name: string): RuntimeMcpClient {
     const toolCallTimeoutMs = config.toolTimeoutMs;
     if (config.transport === 'stdio') {
-      return new StdioMcpClient(config, { toolCallTimeoutMs });
+      return new StdioMcpClient(config, { toolCallTimeoutMs, defaultCwd: this.options.stdioCwd });
     }
     if (config.transport === 'sse') {
       return new SseMcpClient(config, {

--- a/packages/agent-core/src/session/index.ts
+++ b/packages/agent-core/src/session/index.ts
@@ -200,6 +200,7 @@ export class Session {
     this.mcp = new McpConnectionManager({
       oauthService: new McpOAuthService({ kimiHomeDir: options.kimiHomeDir }),
       log: this.log,
+      stdioCwd: options.kaos.getcwd(),
     });
     this.mcp.onStatusChange((entry) => {
       this.onMcpServerStatusChange(entry);

--- a/packages/agent-core/test/mcp/client-stdio.test.ts
+++ b/packages/agent-core/test/mcp/client-stdio.test.ts
@@ -1,3 +1,6 @@
+import { mkdtempSync, realpathSync } from 'node:fs';
+import { rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
 import { dirname, join } from 'pathe';
 import { fileURLToPath } from 'node:url';
 
@@ -8,6 +11,7 @@ import { mergeStdioEnv, StdioMcpClient } from '../../src/mcp/client-stdio';
 
 const here = import.meta.dirname;
 const fixture = join(here, 'fixtures', 'mock-stdio-server.mjs');
+const cwdFixture = join(here, 'fixtures', 'cwd-stdio-server.mjs');
 const stderrThenExitFixture = join(here, 'fixtures', 'stderr-then-exit-stdio-server.mjs');
 const crashAfterConnectFixture = join(here, 'fixtures', 'crash-after-connect-stdio-server.mjs');
 
@@ -33,6 +37,51 @@ describe('StdioMcpClient', () => {
     }
     expect(thrown).toBeInstanceOf(KimiError);
   });
+
+  it('uses defaultCwd when config.cwd is omitted', async () => {
+    const cwd = mkdtempSync(join(tmpdir(), 'kimi-mcp-default-cwd-'));
+    const client = new StdioMcpClient(
+      {
+        transport: 'stdio',
+        command: process.execPath,
+        args: [cwdFixture],
+      },
+      { defaultCwd: cwd },
+    );
+    try {
+      await client.connect();
+      const result = await client.callTool('get_cwd', {});
+      const text = (result.content[0] as { type: 'text'; text: string }).text;
+      expect(realpathSync(text)).toBe(realpathSync(cwd));
+    } finally {
+      await client.close();
+      await rm(cwd, { recursive: true, force: true });
+    }
+  }, 15000);
+
+  it('prefers explicit config.cwd over defaultCwd', async () => {
+    const defaultCwd = mkdtempSync(join(tmpdir(), 'kimi-mcp-default-cwd-'));
+    const configuredCwd = mkdtempSync(join(tmpdir(), 'kimi-mcp-configured-cwd-'));
+    const client = new StdioMcpClient(
+      {
+        transport: 'stdio',
+        command: process.execPath,
+        args: [cwdFixture],
+        cwd: configuredCwd,
+      },
+      { defaultCwd },
+    );
+    try {
+      await client.connect();
+      const result = await client.callTool('get_cwd', {});
+      const text = (result.content[0] as { type: 'text'; text: string }).text;
+      expect(realpathSync(text)).toBe(realpathSync(configuredCwd));
+    } finally {
+      await client.close();
+      await rm(defaultCwd, { recursive: true, force: true });
+      await rm(configuredCwd, { recursive: true, force: true });
+    }
+  }, 15000);
 
   it('connects, lists tools, and round-trips a text result', async () => {
     const client = new StdioMcpClient({

--- a/packages/agent-core/test/mcp/connection-manager.test.ts
+++ b/packages/agent-core/test/mcp/connection-manager.test.ts
@@ -1,3 +1,4 @@
+import { realpathSync } from 'node:fs';
 import { mkdtemp, readFile, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { dirname, join } from 'pathe';
@@ -32,6 +33,7 @@ import { createScriptedGenerate } from '../agent/harness';
 
 const here = import.meta.dirname;
 const stdioFixture = join(here, 'fixtures', 'mock-stdio-server.mjs');
+const cwdStdioFixture = join(here, 'fixtures', 'cwd-stdio-server.mjs');
 const slowStdioFixture = join(here, 'fixtures', 'slow-stdio-server.mjs');
 const crashAfterConnectFixture = join(here, 'fixtures', 'crash-after-connect-stdio-server.mjs');
 const stderrThenExitFixture = join(here, 'fixtures', 'stderr-then-exit-stdio-server.mjs');
@@ -789,6 +791,40 @@ describe('Session MCP startup', () => {
     } finally {
       await session.close();
       await Promise.race([create.catch(() => {}), sleep(1_000)]);
+      await rm(tmp, { recursive: true, force: true, maxRetries: 3, retryDelay: 10 });
+    }
+  }, 7000);
+
+  it('starts stdio MCP servers in the session cwd when config.cwd is omitted', async () => {
+    const tmp = await mkdtemp(join(tmpdir(), 'kimi-session-mcp-cwd-'));
+    const session = new Session({
+      id: 'test-mcp-cwd',
+      kaos: testKaos.withCwd(tmp),
+      homedir: join(tmp, 'session'),
+      rpc: sessionRpc(),
+      mcpConfig: {
+        servers: {
+          cwd: {
+            transport: 'stdio',
+            command: process.execPath,
+            args: [cwdStdioFixture],
+            startupTimeoutMs: 2_000,
+          },
+        },
+      },
+    });
+
+    try {
+      await session.mcp.waitForInitialLoad();
+      const resolved = session.mcp.resolved('cwd');
+      if (resolved === undefined) {
+        throw new Error('MCP server cwd did not connect');
+      }
+      const result = await resolved.client.callTool('get_cwd', {});
+      const text = (result.content[0] as { type: 'text'; text: string }).text;
+      expect(realpathSync(text)).toBe(realpathSync(tmp));
+    } finally {
+      await session.close();
       await rm(tmp, { recursive: true, force: true, maxRetries: 3, retryDelay: 10 });
     }
   }, 7000);

--- a/packages/agent-core/test/mcp/fixtures/cwd-stdio-server.mjs
+++ b/packages/agent-core/test/mcp/fixtures/cwd-stdio-server.mjs
@@ -1,0 +1,21 @@
+// Minimal MCP stdio server fixture for cwd assertions.
+// Exposes:
+//   - get_cwd() -> the server process cwd
+
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+
+const server = new McpServer({ name: 'cwd-stdio', version: '0.0.1' });
+
+server.registerTool(
+  'get_cwd',
+  {
+    description: 'Returns the server process cwd',
+    inputSchema: {},
+  },
+  () => ({
+    content: [{ type: 'text', text: process.cwd() }],
+  }),
+);
+
+await server.connect(new StdioServerTransport());


### PR DESCRIPTION
## Related Issue

Resolve #982

## Problem

See linked issue.

## What changed

Session-hosted stdio MCP servers now default to the session working directory when their config does not set `cwd`, so servers launched by the web server no longer run under `~/.kimi-code/server`. Explicit `cwd` settings still take precedence.

Added tests covering the default cwd fallback, explicit cwd precedence, and the Session-to-MCP startup path.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.