### PR TITLE
docs(server): fix dead link to service conventions AGENTS.md

### DIFF
--- a/.changeset/fix-server-readme-services-link.md
+++ b/.changeset/fix-server-readme-services-link.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/server": patch
+---
+
+docs(server): fix dead link to service conventions AGENTS.md

--- a/packages/server/README.md
+++ b/packages/server/README.md
@@ -91,4 +91,4 @@ apps/kimi-code (CLI)            apps/kimi-web (browser)
 For conventions, gotchas, and the boot wiring order, see
 [`packages/server/AGENTS.md`](./AGENTS.md). For the service naming and
 registration rules, see
-[`packages/services/AGENTS.md`](../services/AGENTS.md).
+[`packages/agent-core/src/services/AGENTS.md`](../agent-core/src/services/AGENTS.md).


### PR DESCRIPTION
## Problem
`packages/server/README.md` points contributors to `packages/services/AGENTS.md` for the service naming and registration rules, but **no `packages/services` package exists** — the link 404s on GitHub.

## Fix
Those conventions actually live in `packages/agent-core/src/services/AGENTS.md` — as `packages/server/AGENTS.md` itself states ("Service conventions (naming, file layout, registration) live in `packages/agent-core/src/services/AGENTS.md`"). Point the README link there.

```diff
- [`packages/services/AGENTS.md`](../services/AGENTS.md).
+ [`packages/agent-core/src/services/AGENTS.md`](../agent-core/src/services/AGENTS.md).
```

Docs-only, no release impact.
