### PR TITLE
fix(web): stop dismissing questions after a 60 second timeout

### DIFF
--- a/.changeset/fix-web-question-timeout.md
+++ b/.changeset/fix-web-question-timeout.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Stop auto-dismissing questions in the web UI after 60 seconds so they wait for the user's answer.

--- a/apps/kimi-web/src/api/daemon/agentEventProjector.ts
+++ b/apps/kimi-web/src/api/daemon/agentEventProjector.ts
@@ -1280,7 +1280,6 @@ const PROTOCOL_EVENT_NAMES = new Set([
   'question.requested',
   'question.answered',
   'question.dismissed',
-  'question.expired',
   // Background tasks (projected)
   'task.created',
   'task.progress',

--- a/apps/kimi-web/src/api/daemon/eventReducer.ts
+++ b/apps/kimi-web/src/api/daemon/eventReducer.ts
@@ -472,8 +472,7 @@ export function reduceAppEvent(
 
     // -------------------------------------------------------------------------
     case 'questionAnswered':
-    case 'questionDismissed':
-    case 'questionExpired': {
+    case 'questionDismissed': {
       const sid = event.sessionId;
       const qid = event.questionId;
       const list = next.questionsBySession[sid] ?? [];

--- a/apps/kimi-web/src/api/daemon/mappers.ts
+++ b/apps/kimi-web/src/api/daemon/mappers.ts
@@ -329,7 +329,6 @@ export function toAppQuestionRequest(wire: WireQuestionRequest): AppQuestionRequ
     turnId: wire.turn_id,
     toolCallId: wire.tool_call_id,
     questions: wire.questions.map(toAppQuestionItem),
-    expiresAt: wire.expires_at,
     createdAt: wire.created_at,
   };
 }
@@ -643,13 +642,6 @@ export function toAppEvent(wire: WireEvent): AppEvent {
         sessionId: w.session_id,
         questionId: w.payload.question_id,
         dismissedAt: w.payload.dismissed_at,
-      };
-
-    case 'event.question.expired':
-      return {
-        type: 'questionExpired',
-        sessionId: w.session_id,
-        questionId: w.payload.question_id,
       };
 
     // ----- Background tasks -----

--- a/apps/kimi-web/src/api/daemon/wire.ts
+++ b/apps/kimi-web/src/api/daemon/wire.ts
@@ -259,7 +259,6 @@ export interface WireQuestionRequest {
   turn_id?: number;
   tool_call_id?: string;
   questions: WireQuestionItem[];
-  expires_at: string;
   created_at: string;
 }
 
@@ -728,8 +727,6 @@ type WireEventQuestionDismissed = WireEventBase<'event.question.dismissed', {
   dismissed_by: string;
   dismissed_at: string;
 }>;
-type WireEventQuestionExpired = WireEventBase<'event.question.expired', { question_id: string }>;
-
 // Background tasks
 type WireEventTaskCreated = WireEventBase<'event.task.created', { task: WireBackgroundTask }>;
 type WireEventTaskProgress = WireEventBase<'event.task.progress', {
@@ -791,7 +788,6 @@ export type WireEvent =
   | WireEventQuestionRequested
   | WireEventQuestionAnswered
   | WireEventQuestionDismissed
-  | WireEventQuestionExpired
   // Background tasks
   | WireEventTaskCreated
   | WireEventTaskProgress

--- a/apps/kimi-web/src/api/types.ts
+++ b/apps/kimi-web/src/api/types.ts
@@ -272,7 +272,6 @@ export interface AppQuestionRequest {
   turnId?: number;
   toolCallId?: string;
   questions: QuestionItem[];
-  expiresAt: string;
   createdAt: string;
 }
 
@@ -415,7 +414,6 @@ export type AppEvent =
   | { type: 'questionRequested'; sessionId: string; question: AppQuestionRequest }
   | { type: 'questionAnswered'; sessionId: string; questionId: string; resolvedAt: string }
   | { type: 'questionDismissed'; sessionId: string; questionId: string; dismissedAt: string }
-  | { type: 'questionExpired'; sessionId: string; questionId: string }
   | { type: 'taskCreated'; sessionId: string; task: AppTask }
   | { type: 'taskProgress'; sessionId: string; taskId: string; outputChunk: string; stream: 'stdout' | 'stderr' }
   | { type: 'taskCompleted'; sessionId: string; taskId: string; status: AppTaskStatus; outputPreview?: string; outputBytes?: number }

--- a/packages/agent-core/src/rpc/client.ts
+++ b/packages/agent-core/src/rpc/client.ts
@@ -55,7 +55,9 @@ export function createRPC<Left extends Record<string, any>, Right extends Record
       signal?.throwIfAborted();
       let response: RpcResponse;
       try {
-        const value = await abortableRpc(Promise.resolve(fn(rpcPayload)), signal);
+        const handlerResult =
+          signal === undefined ? fn(rpcPayload) : fn(rpcPayload, { signal });
+        const value = await abortableRpc(Promise.resolve(handlerResult), signal);
         response = { ok: true, value };
       } catch (error) {
         signal?.throwIfAborted();

--- a/packages/agent-core/src/services/coreProcess/coreProcessClient.ts
+++ b/packages/agent-core/src/services/coreProcess/coreProcessClient.ts
@@ -53,8 +53,9 @@ export class BridgeClientAPI implements SDKAPI {
 
   async requestQuestion(
     request: QuestionRequest & { sessionId: string; agentId: string },
+    options?: { signal?: AbortSignal },
   ): Promise<QuestionResult> {
-    return this.deps.questionService.request(request);
+    return this.deps.questionService.request(request, options);
   }
 
   async toolCall(

--- a/packages/agent-core/src/services/question/question.ts
+++ b/packages/agent-core/src/services/question/question.ts
@@ -66,7 +66,10 @@ export interface IQuestionService {
    * Resolves with the in-process `QuestionResult` (null = no handler / fully
    * dismissed). Concrete impls own timeout policy.
    */
-  request(req: InProcessQuestionRequest & { sessionId: string; agentId: string }): Promise<QuestionResult>;
+  request(
+    req: InProcessQuestionRequest & { sessionId: string; agentId: string },
+    options?: { signal?: AbortSignal },
+  ): Promise<QuestionResult>;
 
   /**
    * Called by the answer-side (REST handler / TUI / mock) to settle a pending

--- a/packages/agent-core/src/services/question/question.ts
+++ b/packages/agent-core/src/services/question/question.ts
@@ -104,8 +104,6 @@ export interface QuestionToBrokerRequestParams {
   readonly sessionId: string;
   /** `createdAt` ISO string; broker passes `new Date().toISOString()`. */
   readonly createdAt: string;
-  /** `expiresAt` ISO string; broker computes `createdAt + 60s`. */
-  readonly expiresAt: string;
 }
 
 /**
@@ -161,7 +159,6 @@ export function toBrokerRequest(
     session_id: params.sessionId,
     questions: req.questions.map((q, i) => buildItem(q, i)),
     created_at: params.createdAt,
-    expires_at: params.expiresAt,
   };
   if (req.turnId !== undefined) out.turn_id = req.turnId;
   if (req.toolCallId !== undefined) out.tool_call_id = req.toolCallId;

--- a/packages/agent-core/src/services/session/sessionService.ts
+++ b/packages/agent-core/src/services/session/sessionService.ts
@@ -222,8 +222,7 @@ export class SessionService extends Disposable implements ISessionService {
       case 'event.approval.expired':
       case 'event.question.requested':
       case 'event.question.answered':
-      case 'event.question.dismissed':
-      case 'event.question.expired': {
+      case 'event.question.dismissed': {
         this._emitStatusChanged(sessionId);
         break;
       }

--- a/packages/agent-core/test/services/question-adapter.test.ts
+++ b/packages/agent-core/test/services/question-adapter.test.ts
@@ -48,7 +48,6 @@ describe('question-adapter · toBrokerRequest (in-process → protocol)', () => 
       questionId: '01J_QUESTION',
       sessionId: 'sess_x',
       createdAt: '2026-06-04T10:30:00.000Z',
-      expiresAt: '2026-06-04T10:31:00.000Z',
     });
 
     expect(protoReq.question_id).toBe('01J_QUESTION');
@@ -91,7 +90,6 @@ describe('question-adapter · toBrokerRequest (in-process → protocol)', () => 
       questionId: 'q',
       sessionId: 's',
       createdAt: '2026-06-04T10:30:00.000Z',
-      expiresAt: '2026-06-04T10:31:00.000Z',
     });
     expect(protoReq.turn_id).toBeUndefined();
     expect(protoReq.tool_call_id).toBeUndefined();

--- a/packages/protocol/src/__tests__/question.test.ts
+++ b/packages/protocol/src/__tests__/question.test.ts
@@ -96,7 +96,6 @@ describe('questionRequestSchema (SCHEMAS §6.2)', () => {
       },
     ],
     created_at: '2026-06-04T10:30:00Z',
-    expires_at: '2026-06-04T10:31:00Z',
   };
 
   it('accepts a 1-question request', () => {
@@ -262,7 +261,6 @@ describe('listPendingQuestionsResponseSchema (REST pending recovery)', () => {
       },
     ],
     created_at: '2026-06-04T10:30:00Z',
-    expires_at: '2026-06-04T10:31:00Z',
   };
 
   it('accepts status=pending query', () => {

--- a/packages/protocol/src/question.ts
+++ b/packages/protocol/src/question.ts
@@ -29,7 +29,6 @@ export const questionRequestSchema = z.object({
   tool_call_id: z.string().min(1).optional(),
   questions: z.array(questionItemSchema).min(1).max(4),
   created_at: isoDateTimeSchema,
-  expires_at: isoDateTimeSchema,
 });
 export type QuestionRequest = z.infer<typeof questionRequestSchema>;
 

--- a/packages/server-e2e/scenarios/08-pending-recovery.ts
+++ b/packages/server-e2e/scenarios/08-pending-recovery.ts
@@ -37,7 +37,6 @@ interface QuestionRequestedPayload {
     options: Array<{ id: string; label: string }>;
   }>;
   created_at: string;
-  expires_at: string;
 }
 
 async function main() {

--- a/packages/server/src/services/question/index.ts
+++ b/packages/server/src/services/question/index.ts
@@ -1,6 +1,4 @@
 export {
   QuestionService,
-  QuestionExpiredError,
-  QUESTION_DEFAULT_TIMEOUT_MS,
   QUESTION_RECENTLY_RESOLVED_CAP,
 } from './questionService';

--- a/packages/server/src/services/question/questionService.ts
+++ b/packages/server/src/services/question/questionService.ts
@@ -16,6 +16,7 @@ export const QUESTION_RECENTLY_RESOLVED_CAP = 1024;
 
 class PendingQuestion implements IDisposable {
   private _settled = false;
+  private _abortCleanup: (() => void) | undefined;
 
   constructor(
     readonly questionId: string,
@@ -27,9 +28,15 @@ class PendingQuestion implements IDisposable {
     private readonly _rejectFn: (e: Error) => void,
   ) {}
 
+  setAbortCleanup(cleanup: () => void): void {
+    this._abortCleanup = cleanup;
+  }
+
   markSettled(): void {
     if (this._settled) return;
     this._settled = true;
+    this._abortCleanup?.();
+    this._abortCleanup = undefined;
   }
 
   resolve(r: QuestionResult): void {
@@ -43,6 +50,8 @@ class PendingQuestion implements IDisposable {
   dispose(): void {
     if (this._settled) return;
     this._settled = true;
+    this._abortCleanup?.();
+    this._abortCleanup = undefined;
     try {
       this.reject(new Error('server shutting down'));
     } catch {
@@ -69,6 +78,7 @@ export class QuestionService extends Disposable implements IQuestionService {
 
   async request(
     req: QuestionRequest & { sessionId: string; agentId: string },
+    options?: { signal?: AbortSignal },
   ): Promise<QuestionResult> {
     if (this._store.isDisposed) {
       throw new Error('question service disposed');
@@ -103,18 +113,29 @@ export class QuestionService extends Disposable implements IQuestionService {
     );
 
     return new Promise<QuestionResult>((resolve, reject) => {
-      this._pending.set(
+      const pending = new PendingQuestion(
         questionId,
-        new PendingQuestion(
-          questionId,
-          req.sessionId,
-          req.toolCallId,
-          createdAt,
-          protocolRequest,
-          resolve,
-          reject,
-        ),
+        req.sessionId,
+        req.toolCallId,
+        createdAt,
+        protocolRequest,
+        resolve,
+        reject,
       );
+      this._pending.set(questionId, pending);
+
+      // When the agent's turn is aborted, the broker entry must be settled so
+      // listPending()/session status don't stay stuck in awaiting_question.
+      const signal = options?.signal;
+      if (signal !== undefined) {
+        if (signal.aborted) {
+          this.dismiss(questionId);
+        } else {
+          const onAbort = () => this.dismiss(questionId);
+          signal.addEventListener('abort', onAbort, { once: true });
+          pending.setAbortCleanup(() => signal.removeEventListener('abort', onAbort));
+        }
+      }
     });
   }
 

--- a/packages/server/src/services/question/questionService.ts
+++ b/packages/server/src/services/question/questionService.ts
@@ -12,16 +12,7 @@ import type {
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 const _typeAnchor: typeof IQuestionService = IQuestionService;
 
-export const QUESTION_DEFAULT_TIMEOUT_MS = 60_000;
-
 export const QUESTION_RECENTLY_RESOLVED_CAP = 1024;
-
-export class QuestionExpiredError extends Error {
-  constructor(public readonly questionId: string, timeoutMs: number) {
-    super(`question ${questionId} expired after ${timeoutMs}ms`);
-    this.name = 'QuestionExpiredError';
-  }
-}
 
 class PendingQuestion implements IDisposable {
   private _settled = false;
@@ -31,17 +22,14 @@ class PendingQuestion implements IDisposable {
     readonly sessionId: string,
     readonly toolCallId: string | undefined,
     readonly createdAt: string,
-    readonly expiresAt: string,
     readonly protocolRequest: ProtocolQuestionRequest,
     private readonly _resolveFn: (r: QuestionResult) => void,
     private readonly _rejectFn: (e: Error) => void,
-    private readonly _timer: NodeJS.Timeout,
   ) {}
 
   markSettled(): void {
     if (this._settled) return;
     this._settled = true;
-    clearTimeout(this._timer);
   }
 
   resolve(r: QuestionResult): void {
@@ -55,9 +43,8 @@ class PendingQuestion implements IDisposable {
   dispose(): void {
     if (this._settled) return;
     this._settled = true;
-    clearTimeout(this._timer);
     try {
-      this._rejectFn(new Error('server shutting down'));
+      this.reject(new Error('server shutting down'));
     } catch {
 
     }
@@ -70,7 +57,6 @@ export class QuestionService extends Disposable implements IQuestionService {
   private readonly _pending: DisposableMap<string, PendingQuestion>;
 
   private readonly _recentlyResolved = new Set<string>();
-  private _timeoutMs = QUESTION_DEFAULT_TIMEOUT_MS;
   private readonly _recentlyResolvedCap = QUESTION_RECENTLY_RESOLVED_CAP;
 
   constructor(
@@ -90,13 +76,11 @@ export class QuestionService extends Disposable implements IQuestionService {
 
     const questionId = ulid();
     const createdAt = new Date().toISOString();
-    const expiresAt = new Date(Date.now() + this._timeoutMs).toISOString();
 
     const protocolRequest = questionToBrokerRequest(req, {
       questionId,
       sessionId: req.sessionId,
       createdAt,
-      expiresAt,
     });
 
     const event: Event = {
@@ -119,8 +103,6 @@ export class QuestionService extends Disposable implements IQuestionService {
     );
 
     return new Promise<QuestionResult>((resolve, reject) => {
-      const timer = setTimeout(() => this._expire(questionId), this._timeoutMs);
-      timer.unref?.();
       this._pending.set(
         questionId,
         new PendingQuestion(
@@ -128,11 +110,9 @@ export class QuestionService extends Disposable implements IQuestionService {
           req.sessionId,
           req.toolCallId,
           createdAt,
-          expiresAt,
           protocolRequest,
           resolve,
           reject,
-          timer,
         ),
       );
     });
@@ -212,28 +192,6 @@ export class QuestionService extends Disposable implements IQuestionService {
     const p = this._pending.get(questionId);
     if (!p) return undefined;
     return { sessionId: p.sessionId, toolCallId: p.toolCallId };
-  }
-
-  _setTimeoutMsForTests(ms: number): void {
-    this._timeoutMs = ms;
-  }
-
-  private _expire(questionId: string): void {
-    const p = this._pending.get(questionId);
-    if (!p) return;
-    p.markSettled();
-    this._pending.deleteAndLeak(questionId);
-    this.markResolved(p.questionId);
-
-    const expiredEvent: Event = {
-      type: 'event.question.expired',
-      sessionId: p.sessionId,
-      agentId: 'main',
-      question_id: p.questionId,
-    } as unknown as Event;
-    this.eventService.publish(expiredEvent);
-
-    p.reject(new QuestionExpiredError(p.questionId, this._timeoutMs));
   }
 
   override dispose(): void {

--- a/packages/server/test/question.e2e.test.ts
+++ b/packages/server/test/question.e2e.test.ts
@@ -480,6 +480,52 @@ describe('Question reverse-RPC: WS broadcast → REST resolve → Promise settle
     ws.close();
   });
 
+  it('aborts the pending question when the request signal aborts', async () => {
+    const r = await bootDaemon();
+    const sid = await createSession(r);
+    const { ws, received } = await openSubscriber(r, sid);
+
+    const broker = r.services.invokeFunction(
+      (a) => a.get(IQuestionService) as QuestionService,
+    );
+
+    const controller = new AbortController();
+    const pending = broker.request(
+      {
+        sessionId: sid,
+        agentId: 'main',
+        questions: [{ question: '?', options: [{ label: 'A' }, { label: 'B' }] }],
+      },
+      { signal: controller.signal },
+    );
+
+    const requested = await waitFor(
+      received,
+      (f) => f['type'] === 'event.question.requested',
+      2000,
+    );
+    const payload = requested['payload'] as { question_id: string };
+
+    // Simulate the turn being aborted before the user answers.
+    controller.abort();
+
+    const dismissedFrame = await waitFor(
+      received,
+      (f) => f['type'] === 'event.question.dismissed',
+      2000,
+    );
+    const dPayload = dismissedFrame['payload'] as { question_id: string };
+    expect(dPayload.question_id).toBe(payload.question_id);
+
+    // Broker entry is cleaned up so listPending/session status don't stick.
+    expect(broker.isPending(payload.question_id)).toBe(false);
+
+    const result: QuestionResult = await pending;
+    expect(result).toBeNull();
+
+    ws.close();
+  });
+
   it('REST resolve on unknown question_id returns 40405', async () => {
     const r = await bootDaemon();
     const sid = await createSession(r);

--- a/packages/server/test/question.e2e.test.ts
+++ b/packages/server/test/question.e2e.test.ts
@@ -26,10 +26,7 @@ import {
 
 import { IRestGateway, startServer, type RunningServer } from '../src';
 import { rawDataToString } from '../src/ws/rawData';
-import {
-  QuestionService,
-  QuestionExpiredError,
-} from '#/services/question/questionService';
+import { QuestionService } from '#/services/question/questionService';
 
 let tmpDir: string;
 let lockPath: string;
@@ -297,7 +294,6 @@ describe('Question reverse-RPC: WS broadcast → REST resolve → Promise settle
             other_label?: string;
           }>;
           created_at: string;
-          expires_at: string;
         }>;
       }>(res.json());
       expect(env.code).toBe(0);
@@ -320,7 +316,6 @@ describe('Question reverse-RPC: WS broadcast → REST resolve → Promise settle
         { id: 'opt_0_1', label: 'No' },
       ]);
       expect(item?.created_at).toMatch(/^\d{4}-\d{2}-\d{2}T/);
-      expect(item?.expires_at).toMatch(/^\d{4}-\d{2}-\d{2}T/);
 
       const dismissed = await appOf(r).inject({
         method: 'POST',
@@ -510,6 +505,8 @@ describe('Question reverse-RPC: WS broadcast → REST resolve → Promise settle
   });
 
   it('REST re-resolve on already-resolved question returns 40902 with data:{resolved:false}', async () => {
+
+
     const r = await bootDaemon();
     const sid = await createSession(r);
 
@@ -585,42 +582,5 @@ describe('Question reverse-RPC: WS broadcast → REST resolve → Promise settle
 
     // Cleanup so the test doesn't leave a hanging Promise.
     broker.dismiss(questionId!);
-  });
-
-  it('60s timeout broadcasts event.question.expired + rejects with QuestionExpiredError', async () => {
-    const r = await bootDaemon();
-    const sid = await createSession(r);
-    const { ws, received } = await openSubscriber(r, sid);
-
-    const broker = r.services.invokeFunction(
-      (a) => a.get(IQuestionService) as QuestionService,
-    );
-    (broker as unknown as { _timeoutMs: number })._timeoutMs = 40;
-
-    const pending = broker.request({
-      sessionId: sid,
-      agentId: 'main',
-      questions: [
-        { question: '?', options: [{ label: 'A' }, { label: 'B' }] },
-      ],
-    });
-
-    let rejection: unknown;
-    try {
-      await pending;
-    } catch (err) {
-      rejection = err;
-    }
-    expect(rejection).toBeInstanceOf(QuestionExpiredError);
-
-    const expiredFrame = await waitFor(
-      received,
-      (f) => f['type'] === 'event.question.expired',
-      2000,
-    );
-    const payload = expiredFrame['payload'] as { question_id: string };
-    expect(payload.question_id).toMatch(/^[0-9A-HJKMNP-TV-Z]{26}$/);
-
-    ws.close();
   });
 });

--- a/packages/server/test/services.test.ts
+++ b/packages/server/test/services.test.ts
@@ -733,29 +733,6 @@ describe('QuestionService (broadcasts + dismiss)', () => {
     bus.dispose();
   });
 
-  it('60s timeout broadcasts event.question.expired + rejects QuestionExpiredError', async () => {
-    const { broker, bus, broadcast, conn } = makeQuestionBroker();
-    broker._setTimeoutMsForTests(30);
-    const pending = broker.request({
-      sessionId: 's',
-      agentId: 'a',
-      questions: [
-        { question: '?', options: [{ label: 'A' }, { label: 'B' }] },
-      ],
-    } as Parameters<typeof broker.request>[0]);
-
-    await expect(pending).rejects.toMatchObject({ name: 'QuestionExpiredError' });
-    await broadcast._drainForTest('s');
-    const expiredFrame = conn.sent.find(
-      (f) => (f as { type: string }).type === 'event.question.expired',
-    );
-    expect(expiredFrame).toBeDefined();
-
-    broker.dispose();
-    broadcast.dispose();
-    bus.dispose();
-  });
-
   it('dispose rejects pending question Promises', async () => {
     const { broker, bus, broadcast } = makeQuestionBroker();
     const pending = broker.request({


### PR DESCRIPTION
## Related Issue

No prior issue. Follow-up to #1056 — found while reviewing the `AskUserQuestion` path after fixing the web yolo auto-approve.

## Problem

In the web UI, an `AskUserQuestion` request was silently dismissed if the user did not answer within 60 seconds. The server's question broker started a 60s timer per question and, on expiry, rejected it, which surfaced to the agent as "user dismissed the question without answering." This made questions unreliable whenever the user needed more than a minute to respond.

## What changed

- Removed the 60s timeout from the server's question broker; a question now stays pending until the user answers or explicitly dismisses it.
- Removed the now-unused `expires_at` field from the question request (protocol, agent-core adapter, and web client types) and the `event.question.expired` emission/handling.
- **Added an abort cleanup path:** the turn's abort signal is now threaded to the question broker, and the pending question is dismissed (and removed from the web UI) when the turn is aborted. Previously, aborting only cancelled the agent-side RPC call, leaving the broker entry stuck in `_pending` and the session in `awaiting_question` until manual dismiss or shutdown (the removed timer had been the only automatic cleanup).
- Updated the affected tests (removed the obsolete timeout tests; added an abort-cleanup test; the remaining question tests still cover resolve, dismiss, and recovery).

Approvals keep their existing 60s timeout — this change is scoped to questions only. The `QUESTION_EXPIRED` protocol error code is left in place (now unused) to avoid a protocol-level removal in this PR; happy to drop it in a follow-up if preferred.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.
