### PR TITLE
fix(agent-core): mark truncated skill descriptions with an ellipsis

### DIFF
--- a/.changeset/fix-skill-listing-truncation.md
+++ b/.changeset/fix-skill-listing-truncation.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Fix truncated skill descriptions missing an ellipsis in the model's skill listing.

--- a/packages/agent-core/src/skill/registry.ts
+++ b/packages/agent-core/src/skill/registry.ts
@@ -183,6 +183,18 @@ function formatModelSkill(skill: SkillDefinition): readonly string[] {
   return lines;
 }
 
+const graphemeSegmenter = new Intl.Segmenter(undefined, { granularity: 'grapheme' });
+
 function truncate(value: string, max: number): string {
-  return value.length > max ? value.slice(0, max) : value;
+  if (value.length <= max) return value;
+  // Reserve one code unit for the trailing ellipsis and walk whole grapheme
+  // clusters so we never split a surrogate pair or combining sequence.
+  let length = 0;
+  let result = '';
+  for (const { segment } of graphemeSegmenter.segment(value)) {
+    if (length + segment.length > max - 1) break;
+    result += segment;
+    length += segment.length;
+  }
+  return `${result}…`;
 }

--- a/packages/agent-core/test/skill/registry.test.ts
+++ b/packages/agent-core/test/skill/registry.test.ts
@@ -73,7 +73,9 @@ describe('skill registry prompt rendering', () => {
   });
 
   it('end-to-end: a project skill that shadows other scopes renders once under Project', () => {
-    const registry = makeRegistry([makeSkill('foo', 'project', 'project version', '/tmp/proj/foo/SKILL.md')]);
+    const registry = makeRegistry([
+      makeSkill('foo', 'project', 'project version', '/tmp/proj/foo/SKILL.md'),
+    ]);
 
     const rendered = registry.getKimiSkillsDescription();
 
@@ -93,6 +95,39 @@ describe('skill registry prompt rendering', () => {
     expect(rendered).toContain('- alpha');
     expect(rendered).toContain('  - Path: /tmp/user/alpha/SKILL.md');
     expect(rendered).toContain('  - Description: Alpha does things');
+  });
+});
+
+describe('getModelSkillListing description truncation', () => {
+  it('keeps descriptions at or below the 250-char limit unchanged', () => {
+    const description = 'a'.repeat(250);
+    const rendered = makeRegistry([makeSkill('demo', 'user', description)]).getModelSkillListing();
+
+    expect(rendered).toContain(`- demo: ${description}`);
+    expect(rendered).not.toContain('…');
+  });
+
+  it('appends an ellipsis and stays within the limit when a description is truncated', () => {
+    const description = 'a'.repeat(300);
+    const rendered = makeRegistry([makeSkill('demo', 'user', description)]).getModelSkillListing();
+
+    expect(rendered).toContain(`- demo: ${'a'.repeat(249)}…`);
+    expect(rendered).not.toContain('a'.repeat(250));
+  });
+
+  it('does not split a grapheme cluster at the truncation boundary', () => {
+    // The 250-char budget cuts at code-unit 249; the emoji spans 248-249, so a
+    // naive slice would leave a dangling surrogate. Grapheme-safe truncation
+    // must drop the whole emoji instead.
+    const description = `${'a'.repeat(248)}😀${'b'.repeat(100)}`;
+    const rendered = makeRegistry([makeSkill('demo', 'user', description)]).getModelSkillListing();
+
+    expect(rendered).toContain(`- demo: ${'a'.repeat(248)}…`);
+    expect(rendered).not.toContain('😀');
+    // no lone high or low surrogate should remain in the rendered output
+    expect(rendered).not.toMatch(
+      /[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/,
+    );
   });
 });
 


### PR DESCRIPTION
## Related Issue

No linked issue

## Problem

The model-facing skill listing (the "available skills" block injected into the system prompt) truncated long skill descriptions to 250 characters by silently slicing, with no ellipsis or marker. Neither the user nor the model could tell a description had been cut, so the second half of a description — often the "when to use / when not to use" guidance — could be dropped without any signal.

## What changed

- Truncated descriptions now end with an ellipsis (`…`), matching the existing body-fallback truncation convention.
- Truncation walks whole grapheme clusters (via `Intl.Segmenter`) so it never splits a surrogate pair or combining sequence.
- Added tests: descriptions at or below the limit stay unchanged; long descriptions get an ellipsis within the limit; a grapheme cluster at the boundary is dropped whole and leaves no dangling surrogate.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update. (No doc update — the change is internal to the model-facing skill listing.)
