### PR TITLE
fix(tui): clear editor draft on Ctrl-C during compaction

### DIFF
--- a/.changeset/fix-ctrl-c-compaction.md
+++ b/.changeset/fix-ctrl-c-compaction.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Fix Ctrl-C during compaction so it clears a pending editor draft first instead of cancelling immediately.

--- a/apps/kimi-code/src/tui/controllers/editor-keyboard.ts
+++ b/apps/kimi-code/src/tui/controllers/editor-keyboard.ts
@@ -72,6 +72,9 @@ export class EditorKeyboardController {
 
       if (host.state.appState.isCompacting) {
         this.clearPendingExit();
+
+        if (this.clearEditorTextIfPresent()) return;
+
         this.cancelCurrentCompaction();
         return;
       }
@@ -88,10 +91,7 @@ export class EditorKeyboardController {
       if (host.state.appState.streamingPhase !== 'idle') {
         this.clearPendingExit();
 
-        if (editor.getText().length > 0) {
-          editor.setText('');
-          return;
-        }
+        if (this.clearEditorTextIfPresent()) return;
 
         this.cancelCurrentStream();
         return;
@@ -252,6 +252,13 @@ export class EditorKeyboardController {
 
     this.pendingExit = { kind, timer };
     this.host.state.ui.requestRender();
+  }
+
+  private clearEditorTextIfPresent(): boolean {
+    const editor = this.host.state.editor;
+    if (editor.getText().length === 0) return false;
+    editor.setText('');
+    return true;
   }
 
   private cancelCurrentStream(): void {

--- a/apps/kimi-code/test/tui/kimi-tui-message-flow.test.ts
+++ b/apps/kimi-code/test/tui/kimi-tui-message-flow.test.ts
@@ -1423,6 +1423,30 @@ command = "vim"
     expect(session.cancelCompaction).toHaveBeenCalledTimes(1);
   });
 
+  it('clears editor text before cancelling compaction on Ctrl-C', async () => {
+    const { driver, session } = await makeDriver();
+    driver.sessionEventHandler.handleEvent(
+      {
+        type: 'compaction.started',
+        agentId: 'main',
+        sessionId: 'ses-1',
+        trigger: 'manual',
+      } as Event,
+      vi.fn(),
+    );
+    driver.state.editor.setText('draft while compacting');
+
+    driver.state.editor.onCtrlC?.();
+
+    expect(driver.state.editor.getText()).toBe('');
+    expect(session.cancelCompaction).not.toHaveBeenCalled();
+    expect(driver.state.appState.isCompacting).toBe(true);
+
+    driver.state.editor.onCtrlC?.();
+
+    expect(session.cancelCompaction).toHaveBeenCalledTimes(1);
+  });
+
   it('dispatches the next queued message after compaction is cancelled', async () => {
     vi.useFakeTimers();
     try {


### PR DESCRIPTION
## Related Issue

No related issue.

## Problem

Pressing Ctrl-C while compaction is in progress cancelled the compaction immediately, even when the editor contained a draft. This was inconsistent with streaming, where Ctrl-C clears the editor draft first and only cancels the turn when the editor is empty.

## What changed

Ctrl-C now clears a pending editor draft first during compaction, and only cancels the compaction once the editor is empty — matching the existing streaming behavior. The clear-text step is shared between the compaction and streaming branches, so it covers every non-idle turn phase without affecting the BTW panel, in-flight requests, or the idle double-Ctrl-C exit. Added a test covering the compaction case.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.
