### PR TITLE
feat(tui): add Ctrl+U/Ctrl+D paging in the task output viewer

### DIFF
--- a/.changeset/task-output-ctrl-ud-paging.md
+++ b/.changeset/task-output-ctrl-ud-paging.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Add Ctrl+U and Ctrl+D as page up and page down shortcuts in the task output viewer.

--- a/apps/kimi-code/src/tui/components/dialogs/task-output-viewer.ts
+++ b/apps/kimi-code/src/tui/components/dialogs/task-output-viewer.ts
@@ -125,11 +125,20 @@ export class TaskOutputViewer extends Container implements Focusable {
       this.scrollBy(1);
       return;
     }
-    if (matchesKey(data, Key.pageUp) || k === ' ' || data === '\u0002' /* C-b */) {
+    if (
+      matchesKey(data, Key.pageUp) ||
+      matchesKey(data, Key.ctrl('u')) ||
+      k === ' ' ||
+      data === '\u0002' /* C-b */
+    ) {
       this.scrollBy(-Math.max(1, visible - 1));
       return;
     }
-    if (matchesKey(data, Key.pageDown) || data === '\u0006' /* C-f */) {
+    if (
+      matchesKey(data, Key.pageDown) ||
+      matchesKey(data, Key.ctrl('d')) ||
+      data === '\u0006' /* C-f */
+    ) {
       this.scrollBy(Math.max(1, visible - 1));
       return;
     }
@@ -240,7 +249,7 @@ export class TaskOutputViewer extends Container implements Focusable {
     );
     const keys =
       `${key('↑↓')} ${dim('line')}  ` +
-      `${key('PgUp/PgDn')} ${dim('page')}  ` +
+      `${key('PgUp/PgDn/Ctrl+U/D')} ${dim('page')}  ` +
       `${key('g/G')} ${dim('top/bot')}  ` +
       `${key('Q/Esc')} ${dim('cancel')}`;
     const left = ` ${keys}`;

--- a/apps/kimi-code/test/tui/task-output-viewer.test.ts
+++ b/apps/kimi-code/test/tui/task-output-viewer.test.ts
@@ -144,6 +144,24 @@ describe('TaskOutputViewer — scrolling', () => {
     expect(out).not.toContain('line-001');
   });
 
+  it('Ctrl+D scrolls a page down', () => {
+    const viewer = makeViewer({ output: bigOutput(50), rows: 12 });
+    viewer.handleInput('\u0004'); // Ctrl+D
+    const out = strip(viewer.render(120).join('\n'));
+    // Same page size as PageDown: body has 8 viewable rows, page = 7 lines.
+    expect(out).toContain('line-008');
+    expect(out).not.toContain('line-001');
+  });
+
+  it('Ctrl+U scrolls a page up', () => {
+    const viewer = makeViewer({ output: bigOutput(50), rows: 12 });
+    viewer.handleInput('G'); // jump to bottom first
+    viewer.handleInput('\u0015'); // Ctrl+U
+    const out = strip(viewer.render(120).join('\n'));
+    expect(out).toContain('line-036');
+    expect(out).not.toContain('line-050');
+  });
+
   it('G jumps to the bottom', () => {
     const viewer = makeViewer({ output: bigOutput(100), rows: 14 });
     viewer.handleInput('G');


### PR DESCRIPTION
## Related Issue

No linked issue.

## Problem

In the task output viewer (opened from `/tasks`), page navigation relies on `PgUp`/`PgDn`. On macOS running inside tmux, those keys are often captured by the terminal or tmux scrollback and never reach the app, leaving no reliable way to scroll by page. The existing `Ctrl+B` shortcut is also intercepted because it is the default tmux prefix.

## What changed

Add `Ctrl+U` (page up) and `Ctrl+D` (page down) as full-page scrolling alternatives in the task output viewer, matching the existing `PgUp`/`PgDn` behavior, and surface them in the footer hint. Matching through `Key.ctrl(...)` covers the traditional control-character, Kitty keyboard protocol, and tmux modifyOtherKeys input paths, so the new shortcuts work under tmux as well. Tests cover both new bindings.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.
