### PR TITLE
fix(server): broadcast session metadata updates to all clients

### DIFF
--- a/.changeset/sync-session-meta-global.md
+++ b/.changeset/sync-session-meta-global.md
@@ -1,0 +1,6 @@
+---
+"@moonshot-ai/kimi-code": patch
+"@moonshot-ai/server": patch
+---
+
+Sync session title changes across all connected clients in server mode.

--- a/packages/server/src/routes/sessions.ts
+++ b/packages/server/src/routes/sessions.ts
@@ -21,8 +21,9 @@ import {
   undoSessionRequestSchema,
   undoSessionResponseSchema,
   workspaceIdSchema,
+  type Event,
 } from '@moonshot-ai/protocol';
-import { IPromptService, ISessionService, SessionNotFoundError, SessionUndoUnavailableError, ErrorCodes, KimiError, IWorkspaceRegistry, WorkspaceNotFoundError, type IInstantiationService, type SessionClientTelemetry } from '@moonshot-ai/agent-core';
+import { IPromptService, ISessionService, SessionNotFoundError, SessionUndoUnavailableError, ErrorCodes, KimiError, IWorkspaceRegistry, WorkspaceNotFoundError, IEventService, type IInstantiationService, type SessionClientTelemetry } from '@moonshot-ai/agent-core';
 import { z } from 'zod';
 
 
@@ -375,6 +376,20 @@ export function registerSessionsRoutes(
         const session = await ix.invokeFunction((a) =>
           a.get(ISessionService).update(session_id, body),
         );
+        // Broadcast the title change to every connection (including clients not
+        // subscribed to this session, and covering inactive sessions whose rename
+        // does not go through the live Session path), so session lists stay in sync.
+        if (typeof body.title === 'string' && body.title.trim().length > 0) {
+          ix.invokeFunction((a) =>
+            a.get(IEventService).publish({
+              type: 'session.meta.updated',
+              agentId: 'main',
+              sessionId: session_id,
+              title: session.title,
+              patch: { title: session.title, isCustomTitle: true },
+            } as Event),
+          );
+        }
         reply.send(okEnvelope(session, req.id));
       } catch (err) {
         sendMappedError(reply, req.id, err);

--- a/packages/server/src/services/gateway/wsBroadcastService.ts
+++ b/packages/server/src/services/gateway/wsBroadcastService.ts
@@ -240,6 +240,10 @@ function isGlobalSessionEvent(type: string): boolean {
   return (
     type === 'event.session.created' ||
     type === 'event.session.status_changed' ||
+    // Session metadata (e.g. title) must reach every connection, including
+    // clients not yet subscribed to the session, so session lists stay in sync
+    // when another client creates or renames a session.
+    type === 'session.meta.updated' ||
     type === 'event.config.changed' ||
     // Workspace registry is not session-scoped: workspace lifecycle events ride
     // the '__global__' watermark and fan out to every connection.

--- a/packages/server/test/sessions.e2e.test.ts
+++ b/packages/server/test/sessions.e2e.test.ts
@@ -446,6 +446,37 @@ describe('POST /api/v1/sessions/{session_id}/profile — update profile', () => 
     const env = envelopeOf<unknown>(res.json());
     expect(env.code).toBe(40401);
   });
+
+  it('broadcasts session.meta.updated to clients not subscribed to the session on rename', async () => {
+    const r = await bootDaemon();
+    const { ws, received } = await openSessionListListener(r);
+    const cwd = join(tmpDir, 'workspace-profile-rename-broadcast');
+    const created = envelopeOf<{ id: string }>(
+      (
+        await appOf(r).inject({
+          method: 'POST',
+          url: '/api/v1/sessions',
+          payload: { metadata: { cwd } },
+        })
+      ).json(),
+    ).data!;
+
+    const res = await appOf(r).inject({
+      method: 'POST',
+      url: `/api/v1/sessions/${created.id}/profile`,
+      payload: { title: 'Renamed' },
+    });
+    expect(envelopeOf<unknown>(res.json()).code).toBe(0);
+
+    const frame = await waitFor(received, (f) => f['type'] === 'session.meta.updated');
+    expect(frame['session_id']).toBe(created.id);
+    expect(frame['payload']).toMatchObject({
+      title: 'Renamed',
+      patch: { title: 'Renamed', isCustomTitle: true },
+    });
+
+    ws.close();
+  });
 });
 
 describe('POST /api/v1/sessions/{session_id}:fork — fork', () => {

--- a/packages/server/test/ws-broadcast.e2e.test.ts
+++ b/packages/server/test/ws-broadcast.e2e.test.ts
@@ -384,6 +384,37 @@ describe('WS broadcast + per-session seq (W5.2)', () => {
     a.ws.close();
     b.ws.close();
   });
+
+  it('session.meta.updated is broadcast to all connections regardless of subscription', async () => {
+    const r = await spawn();
+    const a = await openConn(wsUrl(r.address));
+    const b = await openConn(wsUrl(r.address));
+    // `a` is subscribed to the session; `b` is not. A title change (e.g. a
+    // rename by another client) must still reach `b` so its session list
+    // stays in sync.
+    await helloAndSubscribe(a, 'A', 'sid_meta');
+    await helloAndSubscribe(b, 'B', 'sid_other');
+
+    r.services.invokeFunction((acc) =>
+      acc.get(IEventService).publish({
+        type: 'session.meta.updated',
+        agentId: 'main',
+        sessionId: 'sid_meta',
+        title: 'Renamed',
+        patch: { title: 'Renamed', isCustomTitle: true },
+      } as unknown as Event),
+    );
+
+    const evA = await receiveType(a, 'session.meta.updated', 1000);
+    const evB = await receiveType(b, 'session.meta.updated', 1000);
+    expect(evA.session_id).toBe('sid_meta');
+    expect(evB.session_id).toBe('sid_meta');
+    expect(evA.seq).toBe(1);
+    expect(evB.seq).toBe(1);
+
+    a.ws.close();
+    b.ws.close();
+  });
 });
 
 /** Spin until `cond()` returns true or 2s elapses. */


### PR DESCRIPTION
<!--
Thank you for your contribution to Kimi Code!
Please open an issue before sending a feature PR — PRs without prior discussion may be closed without review.

See https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md for more.
-->

## Related Issue

No related issue. The problem is described below.

## Problem

In server mode, session metadata updates (such as title changes) were only delivered to WebSocket clients that had explicitly subscribed to that session. A client that had not subscribed to a session never received its metadata updates, so its session list would fall out of sync. For example, if frontend A is subscribed to only a subset of sessions and frontend B creates a new session and changes its title, frontend A never sees the new title.

There was a second gap: explicitly renaming a session through the profile API did not emit any metadata event, so even clients subscribed to that session were not notified of the rename.

## What changed

- Broadcast `session.meta.updated` to every connected client instead of only the session's subscribers, so metadata changes stay in sync across all clients regardless of their subscriptions.
- Emit `session.meta.updated` when a session is explicitly renamed, matching the existing auto-title behavior, so renames are propagated to peers.
- Add an end-to-end test covering cross-client delivery of `session.meta.updated`.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.
