### PR TITLE
fix(web): coalesce snapshot reloads on resync

### DIFF
--- a/.changeset/web-snapshot-sync-guard.md
+++ b/.changeset/web-snapshot-sync-guard.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Fix duplicate session snapshot reloads in the bundled web UI during resync.

--- a/apps/kimi-web/src/composables/useKimiWebClient.ts
+++ b/apps/kimi-web/src/composables/useKimiWebClient.ts
@@ -7,6 +7,7 @@ import { i18n } from '../i18n';
 import { getKimiWebApi } from '../api';
 import { isDaemonApiError, isDaemonNetworkError } from '../api/errors';
 import { reconcileWorkspaceOrder, sortByWorkspaceOrder } from '../lib/workspaceOrder';
+import { createCoalescedAsyncRunner } from '../lib/snapshotSync';
 import {
   loadUnread,
   loadWorkspaceOrder,
@@ -747,7 +748,7 @@ function connectEventsIfNeeded(): void {
       // returns the authoritative {asOfSeq, epoch} and re-subscribes.
       if (epoch !== undefined) epochBySession[sessionId] = epoch;
       void currentSeq;
-      void syncSessionFromSnapshot(sessionId);
+      snapshotSyncRunner.request(sessionId);
     },
 
     onError(_code: number, msg: string, _fatal: boolean) {
@@ -1008,6 +1009,8 @@ async function syncSessionFromSnapshot(sessionId: string): Promise<SyncSessionRe
     return 'failed';
   }
 }
+
+const snapshotSyncRunner = createCoalescedAsyncRunner(syncSessionFromSnapshot);
 
 function hasLoadedMessages(sessionId: string): boolean {
   return Object.prototype.hasOwnProperty.call(rawState.messagesBySession, sessionId);

--- a/apps/kimi-web/src/lib/snapshotSync.ts
+++ b/apps/kimi-web/src/lib/snapshotSync.ts
@@ -1,0 +1,35 @@
+export interface CoalescedAsyncRunner<T> {
+  run(key: string): Promise<T>;
+  request(key: string): void;
+}
+
+export function createCoalescedAsyncRunner<T>(
+  fn: (key: string) => Promise<T>,
+): CoalescedAsyncRunner<T> {
+  const inFlight = new Map<string, Promise<T>>();
+  const queued = new Set<string>();
+
+  function run(key: string): Promise<T> {
+    const existing = inFlight.get(key);
+    if (existing !== undefined) return existing;
+
+    const promise = (async () => fn(key))().finally(() => {
+      inFlight.delete(key);
+      if (queued.delete(key)) {
+        void run(key);
+      }
+    });
+    inFlight.set(key, promise);
+    return promise;
+  }
+
+  function request(key: string): void {
+    if (inFlight.has(key)) {
+      queued.add(key);
+      return;
+    }
+    void run(key);
+  }
+
+  return { run, request };
+}

--- a/apps/kimi-web/test/lib-logic.test.ts
+++ b/apps/kimi-web/test/lib-logic.test.ts
@@ -5,6 +5,7 @@ import {
   parseFilePathLinkCandidate,
 } from '../src/lib/filePathLinks';
 import { parseDiff } from '../src/lib/parseDiff';
+import { createCoalescedAsyncRunner } from '../src/lib/snapshotSync';
 import { normalizeToolName, toolSummary } from '../src/lib/toolMeta';
 
 describe('parseDiff', () => {
@@ -74,5 +75,53 @@ describe('toolMeta', () => {
     expect(
       toolSummary('WebFetch', JSON.stringify({ url: 'https://example.com/path/to' })),
     ).toBe('example.com/path');
+  });
+});
+
+describe('createCoalescedAsyncRunner', () => {
+  it('reuses the in-flight promise for the same key', async () => {
+    let runs = 0;
+    let resolveRun!: () => void;
+    const runner = createCoalescedAsyncRunner(async (_key: string) => {
+      runs += 1;
+      await new Promise<void>((resolve) => {
+        resolveRun = resolve;
+      });
+      return runs;
+    });
+
+    const first = runner.run('session-a');
+    const second = runner.run('session-a');
+
+    expect(runs).toBe(1);
+    resolveRun();
+    await expect(Promise.all([first, second])).resolves.toEqual([1, 1]);
+    expect(runs).toBe(1);
+  });
+
+  it('queues at most one rerun requested while a run is in flight', async () => {
+    let runs = 0;
+    const resolvers: Array<() => void> = [];
+    const runner = createCoalescedAsyncRunner(async (_key: string) => {
+      runs += 1;
+      await new Promise<void>((resolve) => {
+        resolvers.push(resolve);
+      });
+      return runs;
+    });
+
+    const first = runner.run('session-a');
+    runner.request('session-a');
+    runner.request('session-a');
+    expect(runs).toBe(1);
+
+    resolvers[0]!();
+    await first;
+    await Promise.resolve();
+
+    expect(runs).toBe(2);
+    resolvers[1]!();
+    await Promise.resolve();
+    expect(runs).toBe(2);
   });
 });


### PR DESCRIPTION
## Related Issue

No linked issue.

## Problem

The web UI could enter a session snapshot request storm when `resync_required` fired repeatedly. Each snapshot request was fast, but concurrent reloads queued up and made session switching or snapshot loading look slow.

## What changed

- Coalesce session snapshot reloads per session so repeated resync signals share one in-flight reload.
- Queue at most one rerun while a reload is in flight, so the latest state is still refreshed after the current reload settles.
- Add unit coverage for the coalescing runner.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.

Tests run:

- `pnpm --filter @moonshot-ai/kimi-web test`
- `pnpm --filter @moonshot-ai/kimi-web typecheck`
