### PR TITLE
fix(tools): guard against unsupported image formats to prevent session deadlock

### DIFF
--- a/.changeset/image-format-guard.md
+++ b/.changeset/image-format-guard.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Guard against unsupported image formats to prevent crashes when processing WebP/GIF images.

--- a/packages/agent-core/src/tools/builtin/file/read-media.ts
+++ b/packages/agent-core/src/tools/builtin/file/read-media.ts
@@ -199,6 +199,22 @@ export class ReadMediaFileTool implements BuiltinTool<ReadMediaFileInput> {
             'Tell the user to use a model with image input capability.',
         };
       }
+      // Guard against image formats the model endpoint may reject.
+      // Some providers (e.g. kimi-for-coding) accept PNG/JPEG but reject
+      // WebP/GIF, causing a 400 that bricks the session because the failed
+      // image stays in history and is re-sent on every turn.
+      if (fileType.kind === 'image' && (fileType.mimeType === 'image/webp' || fileType.mimeType === 'image/gif')) {
+        const supported = this.capabilities.supportedImageMimes ?? ['image/png', 'image/jpeg'];
+        if (!supported.includes(fileType.mimeType)) {
+          return {
+            isError: true,
+            output:
+              `The current model does not support ${fileType.mimeType} images. ` +
+              'Supported formats: ' + supported.join(', ') + '. ' +
+              'Convert the image to PNG or JPEG before reading it.',
+          };
+        }
+      }
       if (fileType.kind === 'video' && !this.capabilities.video_in) {
         return {
           isError: true,


### PR DESCRIPTION
Fixes #1082

## Problem

When a webp or gif image is read via the Read Media tool, it is sent to the model endpoint as-is. Some providers (e.g. kimi-for-coding) accept PNG/JPEG but reject WebP/GIF with HTTP 400. The failed image stays in conversation history and is re-sent on every subsequent turn, permanently bricking the session — no prompt can recover.

## What changed

Added a MIME type guard after the `image_in` capability check:

- If the image is webp or gif, check if the model's `supportedImageMimes` includes that MIME type
- If not supported, return a helpful error message instead of sending the unsupported image
- The error tells the user to convert to PNG or JPEG

This prevents the session deadlock because the unsupported image never enters the conversation history.

## Validation

- PNG/JPEG images: no behavior change (always in supported list)
- WebP/GIF on models that support them: no behavior change (MIME is in supported list)
- WebP/GIF on models that don't support them: error returned, session not bricked
