### PR TITLE
feat(agent-core): add config hint to max-steps-per-turn error

### DIFF
--- a/.changeset/max-steps-config-hint.md
+++ b/.changeset/max-steps-config-hint.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Add a hint to the per-turn step limit error pointing users to the loop_control.max_steps_per_turn config option.

--- a/packages/agent-core/src/errors/codes.ts
+++ b/packages/agent-core/src/errors/codes.ts
@@ -301,7 +301,7 @@ export const KIMI_ERROR_INFO = {
     title: 'Turn exceeded max steps',
     retryable: false,
     public: true,
-    action: 'Increase loop_control.max_steps_per_turn or split the task.',
+    action: 'Increase loop_control.max_steps_per_turn in config.toml or split the task.',
   },
   'provider.api_error': {
     title: 'Provider API error',

--- a/packages/agent-core/src/loop/errors.ts
+++ b/packages/agent-core/src/loop/errors.ts
@@ -5,9 +5,14 @@
 import { ErrorCodes, KimiError, isKimiError } from '#/errors';
 
 export function createMaxStepsExceededError(maxSteps: number, message?: string): KimiError {
-  return new KimiError(ErrorCodes.LOOP_MAX_STEPS_EXCEEDED, message ?? `Turn exceeded maxSteps=${maxSteps}`, {
-    details: { maxSteps },
-  });
+  return new KimiError(
+    ErrorCodes.LOOP_MAX_STEPS_EXCEEDED,
+    message ??
+      `Turn exceeded maxSteps=${maxSteps}. If max_steps_per_turn is too small, raise it in config.toml (loop_control.max_steps_per_turn).`,
+    {
+      details: { maxSteps },
+    },
+  );
 }
 
 export function isMaxStepsExceededError(error: unknown): boolean {

--- a/packages/agent-core/test/agent/turn.test.ts
+++ b/packages/agent-core/test/agent/turn.test.ts
@@ -1208,6 +1208,7 @@ describe('Agent turn flow', () => {
           reason: 'failed',
           error: expect.objectContaining({
             code: 'loop.max_steps_exceeded',
+            message: expect.stringContaining('config.toml'),
             details: expect.objectContaining({
               maxSteps: 1,
             }),


### PR DESCRIPTION
## Related Issue

No related issue.

## Problem

When a turn exceeds `loop_control.max_steps_per_turn`, the agent only reports `Turn exceeded maxSteps=N`. Users who hit the limit because it is set too low get no hint that they can raise it themselves in `config.toml`, so the error is not actionable.

## What changed

Append a hint to the max-steps-exceeded error message that points users to the `loop_control.max_steps_per_turn` option in `config.toml`, and align the error code's `action` text to match. The existing turn test now asserts the hint appears in the error payload.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.
