### PR TITLE
feat(web): show edit diffs inline in tool call cards

### DIFF
--- a/.changeset/web-tool-edit-diff.md
+++ b/.changeset/web-tool-edit-diff.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": minor
+---
+
+Show a line-by-line diff when the agent edits or writes a file in the web chat.

--- a/apps/kimi-web/src/App.vue
+++ b/apps/kimi-web/src/App.vue
@@ -8,6 +8,7 @@ import ConversationPane from './components/chat/ConversationPane.vue';
 import FilePreview from './components/FilePreview.vue';
 import ThinkingPanel from './components/chat/ThinkingPanel.vue';
 import AgentDetailPanel from './components/chat/AgentDetailPanel.vue';
+import ToolDiffPanel from './components/chat/ToolDiffPanel.vue';
 import SideChatPanel from './components/chat/SideChatPanel.vue';
 import DiffView from './components/chat/DiffView.vue';
 import ModelPicker from './components/settings/ModelPicker.vue';
@@ -195,6 +196,9 @@ const {
   agentPanelMember,
   openAgentPanel,
   closeAgentPanel,
+  toolDiffTarget,
+  openToolDiff,
+  closeToolDiff,
   detailDiffMode,
   detailDiffPath,
   openDiffDetail,
@@ -700,6 +704,7 @@ function openPr(url: string): void {
       @open-thinking="openThinkingPanel($event)"
       @open-compaction="openCompactionPanel($event)"
       @open-agent="openAgentPanel($event)"
+      @open-tool-diff="openToolDiff($event)"
       @edit-message="handleEditMessage"
     />
 
@@ -770,6 +775,11 @@ function openPr(url: string): void {
         @open="selectDiffFile"
         @back="detailDiffMode = 'list'; detailDiffPath = null; client.clearFileDiff()"
         @close="closeDiffDetail"
+      />
+      <ToolDiffPanel
+        v-else-if="detailTarget === 'toolDiff' && toolDiffTarget"
+        :target="toolDiffTarget"
+        @close="closeToolDiff"
       />
       <FilePreview
         v-else-if="detailTarget === 'file'"

--- a/apps/kimi-web/src/components/chat/ChatPane.vue
+++ b/apps/kimi-web/src/components/chat/ChatPane.vue
@@ -101,6 +101,12 @@ const props = withDefaults(
      */
     isFollowing?: boolean;
     /**
+     * When true, clicking an Edit/Write tool card opens the right-side diff
+     * panel. Off in contexts that don't wire the panel (e.g. the side chat), so
+     * cards there expand inline instead.
+     */
+    toolDiffPanel?: boolean;
+    /**
      * @deprecated No longer used — Composer is rendered by ConversationPane.
      */
   }>(),
@@ -116,6 +122,7 @@ const props = withDefaults(
     loadingMore: false,
     loadingMoreError: false,
     isFollowing: false,
+    toolDiffPanel: false,
   },
 );
 
@@ -524,11 +531,11 @@ function isStreamingRenderBlock(turn: ChatTurn, block: { sourceIndex: number }):
           <ThinkingBlock v-if="blk.kind === 'thinking'" :text="blk.thinking" :mobile="childBubble" :streaming="isStreamingRenderBlock(turn, blk)" @open="emit('openThinking', { turnId: turn.id, blockIndex: blk.sourceIndex })" />
           <div v-else-if="blk.kind === 'text' && blk.text" class="msg"><Markdown :text="blk.text" :streaming="isStreamingRenderBlock(turn, blk)" :open-file="(target) => emit('openFile', target)" /></div>
           <div v-else-if="blk.kind === 'tool-stack'" class="tool-stack">
-            <ToolCall v-for="(item, si) in blk.tools" :key="toolStackKey(item)" :tool="item.tool" :mobile="childBubble" :stack-position="toolStackPosition(si, blk.tools.length)" @open-media="emit('openMedia', $event)" @open-file="emit('openFile', $event)" @open-tool-diff="emit('openToolDiff', $event)" />
+            <ToolCall v-for="(item, si) in blk.tools" :key="toolStackKey(item)" :tool="item.tool" :mobile="childBubble" :stack-position="toolStackPosition(si, blk.tools.length)" :tool-diff-panel="toolDiffPanel" @open-media="emit('openMedia', $event)" @open-file="emit('openFile', $event)" @open-tool-diff="emit('openToolDiff', $event)" />
           </div>
           <AgentCard v-else-if="blk.kind === 'agent'" :member="blk.member" @open="emit('openAgent', { turnId: turn.id, blockIndex: blk.sourceIndex, memberId: $event })" />
           <AgentGroup v-else-if="blk.kind === 'agentGroup'" :members="blk.members" @open="emit('openAgent', { turnId: turn.id, blockIndex: blk.sourceIndex, memberId: $event })" />
-          <ToolCall v-else-if="blk.kind === 'tool'" :tool="blk.tool" :mobile="childBubble" @open-media="emit('openMedia', $event)" @open-file="emit('openFile', $event)" @open-tool-diff="emit('openToolDiff', $event)" />
+          <ToolCall v-else-if="blk.kind === 'tool'" :tool="blk.tool" :mobile="childBubble" :tool-diff-panel="toolDiffPanel" @open-media="emit('openMedia', $event)" @open-file="emit('openFile', $event)" @open-tool-diff="emit('openToolDiff', $event)" />
         </template>
         <div v-if="turn.id !== streamingTurnId && isAssistantRunEnd(ti) && (assistantRunFinalText(ti).trim().length > 0 || turn.durationMs !== undefined)" class="a-msg-ft">
           <span v-if="turn.durationMs !== undefined" class="a-duration" :title="`${turn.durationMs} ms`">{{ formatDuration(turn.durationMs) }}</span>
@@ -666,11 +673,11 @@ function isStreamingRenderBlock(turn: ChatTurn, block: { sourceIndex: number }):
               <ThinkingBlock v-if="blk.kind === 'thinking'" :text="blk.thinking" :streaming="isStreamingRenderBlock(turn, blk)" @open="emit('openThinking', { turnId: turn.id, blockIndex: blk.sourceIndex })" />
               <Markdown v-else-if="blk.kind === 'text' && blk.text" :text="blk.text" :streaming="isStreamingRenderBlock(turn, blk)" :open-file="(target) => emit('openFile', target)" />
               <div v-else-if="blk.kind === 'tool-stack'" class="tool-stack">
-                <ToolCall v-for="(item, si) in blk.tools" :key="toolStackKey(item)" :tool="item.tool" :stack-position="toolStackPosition(si, blk.tools.length)" @open-media="emit('openMedia', $event)" @open-file="emit('openFile', $event)" @open-tool-diff="emit('openToolDiff', $event)" />
+                <ToolCall v-for="(item, si) in blk.tools" :key="toolStackKey(item)" :tool="item.tool" :stack-position="toolStackPosition(si, blk.tools.length)" :tool-diff-panel="toolDiffPanel" @open-media="emit('openMedia', $event)" @open-file="emit('openFile', $event)" @open-tool-diff="emit('openToolDiff', $event)" />
               </div>
               <AgentCard v-else-if="blk.kind === 'agent'" :member="blk.member" @open="emit('openAgent', { turnId: turn.id, blockIndex: blk.sourceIndex, memberId: $event })" />
               <AgentGroup v-else-if="blk.kind === 'agentGroup'" :members="blk.members" @open="emit('openAgent', { turnId: turn.id, blockIndex: blk.sourceIndex, memberId: $event })" />
-              <ToolCall v-else-if="blk.kind === 'tool'" :tool="blk.tool" @open-media="emit('openMedia', $event)" @open-file="emit('openFile', $event)" @open-tool-diff="emit('openToolDiff', $event)" />
+              <ToolCall v-else-if="blk.kind === 'tool'" :tool="blk.tool" :tool-diff-panel="toolDiffPanel" @open-media="emit('openMedia', $event)" @open-file="emit('openFile', $event)" @open-tool-diff="emit('openToolDiff', $event)" />
             </template>
           </template>
         </div>

--- a/apps/kimi-web/src/components/chat/ChatPane.vue
+++ b/apps/kimi-web/src/components/chat/ChatPane.vue
@@ -2,7 +2,7 @@
 <script setup lang="ts">
 import { computed, nextTick, onMounted, onUnmounted, ref, watch } from 'vue';
 import { useI18n } from 'vue-i18n';
-import type { ChatTurn, ApprovalBlock, FilePreviewRequest, ToolDiffTarget, ToolMedia } from '../../types';
+import type { ChatTurn, ApprovalBlock, FilePreviewRequest, ToolMedia } from '../../types';
 import ToolCall from './ToolCall.vue';
 import Markdown from './Markdown.vue';
 import ThinkingBlock from './ThinkingBlock.vue';
@@ -197,7 +197,7 @@ const emit = defineEmits<{
   /** Show a subagent's full detail in the right-side panel. */
   openAgent: [target: { turnId: string; blockIndex: number; memberId: string }];
   /** Show an Edit/Write tool call's diff in the right-side panel. */
-  openToolDiff: [target: ToolDiffTarget];
+  openToolDiff: [id: string];
   /** Edit + resend the last user message (parent undoes, then refills composer). */
   editMessage: [text: string];
   /** Fetch the next older page of messages (triggered by top sentinel visibility or click). */

--- a/apps/kimi-web/src/components/chat/ChatPane.vue
+++ b/apps/kimi-web/src/components/chat/ChatPane.vue
@@ -2,7 +2,7 @@
 <script setup lang="ts">
 import { computed, nextTick, onMounted, onUnmounted, ref, watch } from 'vue';
 import { useI18n } from 'vue-i18n';
-import type { ChatTurn, ApprovalBlock, FilePreviewRequest, ToolMedia } from '../../types';
+import type { ChatTurn, ApprovalBlock, FilePreviewRequest, ToolDiffTarget, ToolMedia } from '../../types';
 import ToolCall from './ToolCall.vue';
 import Markdown from './Markdown.vue';
 import ThinkingBlock from './ThinkingBlock.vue';
@@ -196,6 +196,8 @@ const emit = defineEmits<{
   openCompaction: [target: { turnId: string }];
   /** Show a subagent's full detail in the right-side panel. */
   openAgent: [target: { turnId: string; blockIndex: number; memberId: string }];
+  /** Show an Edit/Write tool call's diff in the right-side panel. */
+  openToolDiff: [target: ToolDiffTarget];
   /** Edit + resend the last user message (parent undoes, then refills composer). */
   editMessage: [text: string];
   /** Fetch the next older page of messages (triggered by top sentinel visibility or click). */
@@ -522,11 +524,11 @@ function isStreamingRenderBlock(turn: ChatTurn, block: { sourceIndex: number }):
           <ThinkingBlock v-if="blk.kind === 'thinking'" :text="blk.thinking" :mobile="childBubble" :streaming="isStreamingRenderBlock(turn, blk)" @open="emit('openThinking', { turnId: turn.id, blockIndex: blk.sourceIndex })" />
           <div v-else-if="blk.kind === 'text' && blk.text" class="msg"><Markdown :text="blk.text" :streaming="isStreamingRenderBlock(turn, blk)" :open-file="(target) => emit('openFile', target)" /></div>
           <div v-else-if="blk.kind === 'tool-stack'" class="tool-stack">
-            <ToolCall v-for="(item, si) in blk.tools" :key="toolStackKey(item)" :tool="item.tool" :mobile="childBubble" :stack-position="toolStackPosition(si, blk.tools.length)" @open-media="emit('openMedia', $event)" @open-file="emit('openFile', $event)" />
+            <ToolCall v-for="(item, si) in blk.tools" :key="toolStackKey(item)" :tool="item.tool" :mobile="childBubble" :stack-position="toolStackPosition(si, blk.tools.length)" @open-media="emit('openMedia', $event)" @open-file="emit('openFile', $event)" @open-tool-diff="emit('openToolDiff', $event)" />
           </div>
           <AgentCard v-else-if="blk.kind === 'agent'" :member="blk.member" @open="emit('openAgent', { turnId: turn.id, blockIndex: blk.sourceIndex, memberId: $event })" />
           <AgentGroup v-else-if="blk.kind === 'agentGroup'" :members="blk.members" @open="emit('openAgent', { turnId: turn.id, blockIndex: blk.sourceIndex, memberId: $event })" />
-          <ToolCall v-else-if="blk.kind === 'tool'" :tool="blk.tool" :mobile="childBubble" @open-media="emit('openMedia', $event)" @open-file="emit('openFile', $event)" />
+          <ToolCall v-else-if="blk.kind === 'tool'" :tool="blk.tool" :mobile="childBubble" @open-media="emit('openMedia', $event)" @open-file="emit('openFile', $event)" @open-tool-diff="emit('openToolDiff', $event)" />
         </template>
         <div v-if="turn.id !== streamingTurnId && isAssistantRunEnd(ti) && (assistantRunFinalText(ti).trim().length > 0 || turn.durationMs !== undefined)" class="a-msg-ft">
           <span v-if="turn.durationMs !== undefined" class="a-duration" :title="`${turn.durationMs} ms`">{{ formatDuration(turn.durationMs) }}</span>
@@ -664,11 +666,11 @@ function isStreamingRenderBlock(turn: ChatTurn, block: { sourceIndex: number }):
               <ThinkingBlock v-if="blk.kind === 'thinking'" :text="blk.thinking" :streaming="isStreamingRenderBlock(turn, blk)" @open="emit('openThinking', { turnId: turn.id, blockIndex: blk.sourceIndex })" />
               <Markdown v-else-if="blk.kind === 'text' && blk.text" :text="blk.text" :streaming="isStreamingRenderBlock(turn, blk)" :open-file="(target) => emit('openFile', target)" />
               <div v-else-if="blk.kind === 'tool-stack'" class="tool-stack">
-                <ToolCall v-for="(item, si) in blk.tools" :key="toolStackKey(item)" :tool="item.tool" :stack-position="toolStackPosition(si, blk.tools.length)" @open-media="emit('openMedia', $event)" @open-file="emit('openFile', $event)" />
+                <ToolCall v-for="(item, si) in blk.tools" :key="toolStackKey(item)" :tool="item.tool" :stack-position="toolStackPosition(si, blk.tools.length)" @open-media="emit('openMedia', $event)" @open-file="emit('openFile', $event)" @open-tool-diff="emit('openToolDiff', $event)" />
               </div>
               <AgentCard v-else-if="blk.kind === 'agent'" :member="blk.member" @open="emit('openAgent', { turnId: turn.id, blockIndex: blk.sourceIndex, memberId: $event })" />
               <AgentGroup v-else-if="blk.kind === 'agentGroup'" :members="blk.members" @open="emit('openAgent', { turnId: turn.id, blockIndex: blk.sourceIndex, memberId: $event })" />
-              <ToolCall v-else-if="blk.kind === 'tool'" :tool="blk.tool" @open-media="emit('openMedia', $event)" @open-file="emit('openFile', $event)" />
+              <ToolCall v-else-if="blk.kind === 'tool'" :tool="blk.tool" @open-media="emit('openMedia', $event)" @open-file="emit('openFile', $event)" @open-tool-diff="emit('openToolDiff', $event)" />
             </template>
           </template>
         </div>

--- a/apps/kimi-web/src/components/chat/ConversationPane.vue
+++ b/apps/kimi-web/src/components/chat/ConversationPane.vue
@@ -2,7 +2,7 @@
 <script setup lang="ts">
 import { computed, nextTick, onMounted, onUnmounted, ref, watch, type ComponentPublicInstance } from 'vue';
 import { useI18n } from 'vue-i18n';
-import type { ActivationBadges, ApprovalBlock, ChatTurn, ConversationStatus, FilePreviewRequest, PermissionMode, QueuedPromptView, TaskItem, TodoView, ToolMedia, UIQuestion, WorkspaceView } from '../../types';
+import type { ActivationBadges, ApprovalBlock, ChatTurn, ConversationStatus, FilePreviewRequest, PermissionMode, QueuedPromptView, TaskItem, TodoView, ToolDiffTarget, ToolMedia, UIQuestion, WorkspaceView } from '../../types';
 import type { AppGoal, AppModel, AppSkill, QuestionResponse, ThinkingLevel } from '../../api/types';
 import type { SwarmGroup } from '../../composables/swarmGroups';
 import type { FileItem } from './MentionMenu.vue';
@@ -108,6 +108,7 @@ const emit = defineEmits<{
   openThinking: [target: { turnId: string; blockIndex: number }];
   openCompaction: [target: { turnId: string }];
   openAgent: [target: { turnId: string; blockIndex: number; memberId: string }];
+  openToolDiff: [target: ToolDiffTarget];
   /** Chat header / files pane: focus the diff detail layer and refresh git status. */
   openChanges: [];
   refreshGitStatus: [];
@@ -1025,6 +1026,7 @@ defineExpose({ loadComposerForEdit });
               @open-thinking="emit('openThinking', $event)"
               @open-compaction="emit('openCompaction', $event)"
               @open-agent="emit('openAgent', $event)"
+              @open-tool-diff="emit('openToolDiff', $event)"
               @edit-message="emit('editMessage', $event)"
               @load-older-messages="handleLoadOlderMessages"
             />

--- a/apps/kimi-web/src/components/chat/ConversationPane.vue
+++ b/apps/kimi-web/src/components/chat/ConversationPane.vue
@@ -2,7 +2,7 @@
 <script setup lang="ts">
 import { computed, nextTick, onMounted, onUnmounted, ref, watch, type ComponentPublicInstance } from 'vue';
 import { useI18n } from 'vue-i18n';
-import type { ActivationBadges, ApprovalBlock, ChatTurn, ConversationStatus, FilePreviewRequest, PermissionMode, QueuedPromptView, TaskItem, TodoView, ToolDiffTarget, ToolMedia, UIQuestion, WorkspaceView } from '../../types';
+import type { ActivationBadges, ApprovalBlock, ChatTurn, ConversationStatus, FilePreviewRequest, PermissionMode, QueuedPromptView, TaskItem, TodoView, ToolMedia, UIQuestion, WorkspaceView } from '../../types';
 import type { AppGoal, AppModel, AppSkill, QuestionResponse, ThinkingLevel } from '../../api/types';
 import type { SwarmGroup } from '../../composables/swarmGroups';
 import type { FileItem } from './MentionMenu.vue';
@@ -108,7 +108,7 @@ const emit = defineEmits<{
   openThinking: [target: { turnId: string; blockIndex: number }];
   openCompaction: [target: { turnId: string }];
   openAgent: [target: { turnId: string; blockIndex: number; memberId: string }];
-  openToolDiff: [target: ToolDiffTarget];
+  openToolDiff: [id: string];
   /** Chat header / files pane: focus the diff detail layer and refresh git status. */
   openChanges: [];
   refreshGitStatus: [];

--- a/apps/kimi-web/src/components/chat/ConversationPane.vue
+++ b/apps/kimi-web/src/components/chat/ConversationPane.vue
@@ -1020,6 +1020,7 @@ defineExpose({ loadComposerForEdit });
               :loading-more="loadingMore"
               :loading-more-error="loadingMoreError"
               :is-following="following"
+              :tool-diff-panel="true"
               @open-file="emit('openFile', $event)"
               @open-media="emit('openMedia', $event)"
               @copy-conversation-copied="handleCopyConversationCopied"

--- a/apps/kimi-web/src/components/chat/DiffLines.vue
+++ b/apps/kimi-web/src/components/chat/DiffLines.vue
@@ -49,6 +49,11 @@ function rowClass(line: DiffViewLine): string {
   align-items: flex-start;
   min-height: 18px;
   white-space: pre;
+  /* Size each row to its content so the add/del background paints across the
+     whole line. Without this, the row is only as wide as the viewport and the
+     background stops where the text overflows horizontally. */
+  width: max-content;
+  min-width: 100%;
 }
 
 .dl-gutter {
@@ -74,11 +79,12 @@ function rowClass(line: DiffViewLine): string {
 }
 
 .dl-text {
-  flex: 1;
+  /* Do not shrink: the row is sized to its content (see .dl width: max-content)
+     so the text keeps its full width and the background covers it. */
+  flex: none;
   padding-right: 14px;
   white-space: pre;
   color: var(--text);
-  min-width: 0;
 }
 
 /* Added / removed lines: a faint background plus a left accent bar mark the

--- a/apps/kimi-web/src/components/chat/DiffLines.vue
+++ b/apps/kimi-web/src/components/chat/DiffLines.vue
@@ -1,0 +1,121 @@
+<!-- apps/kimi-web/src/components/chat/DiffLines.vue -->
+<!-- Pure line-by-line diff renderer. Shared by the ~/diff panel (DiffView) and
+     inline tool-call edit previews (ToolCall). Owns only the rows + their
+     styling; the parent controls the surrounding height / scroll. -->
+<script setup lang="ts">
+import type { DiffViewLine } from '../../types';
+
+defineProps<{
+  lines: DiffViewLine[];
+}>();
+
+function oldGutter(line: DiffViewLine): string {
+  return line.oldNo !== undefined ? String(line.oldNo) : '';
+}
+function newGutter(line: DiffViewLine): string {
+  return line.newNo !== undefined ? String(line.newNo) : '';
+}
+function rowClass(line: DiffViewLine): string {
+  return `dl-${line.type}`;
+}
+</script>
+
+<template>
+  <div class="diff-lines">
+    <div v-for="(line, i) in lines" :key="i" class="dl" :class="rowClass(line)">
+      <template v-if="line.type === 'hunk'">
+        <span class="hunk-text">{{ line.text }}</span>
+      </template>
+      <template v-else>
+        <span class="dl-gutter old">{{ oldGutter(line) }}</span>
+        <span class="dl-gutter new">{{ newGutter(line) }}</span>
+        <span class="dl-sign">{{ line.type === 'add' ? '+' : line.type === 'del' ? '-' : ' ' }}</span>
+        <span class="dl-text">{{ line.text }}</span>
+      </template>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.diff-lines {
+  padding: 4px 0 12px;
+  font-size: var(--ui-font-size);
+  line-height: 1.5;
+  -webkit-overflow-scrolling: touch;
+}
+
+.dl {
+  display: flex;
+  align-items: flex-start;
+  min-height: 18px;
+  white-space: pre;
+}
+
+.dl-gutter {
+  flex: none;
+  width: 40px;
+  padding: 0 6px;
+  text-align: right;
+  color: var(--faint, #aeb4bc);
+  background: var(--panel, #fafbfc);
+  user-select: none;
+  border-right: 1px solid var(--line2, #eef1f4);
+  font-variant-numeric: tabular-nums;
+}
+
+.dl-gutter.new { border-right: 1px solid var(--line, #e7eaee); }
+
+.dl-sign {
+  flex: none;
+  width: 16px;
+  text-align: center;
+  color: var(--muted);
+  user-select: none;
+}
+
+.dl-text {
+  flex: 1;
+  padding-right: 14px;
+  white-space: pre;
+  color: var(--text);
+  min-width: 0;
+}
+
+/* Added / removed lines: a faint background plus a left accent bar mark the
+   change, while the code TEXT keeps the normal ink colour. Washing the whole
+   line in green/red competed with reading the code itself; the sign (+/-) and
+   the accent carry the colour so the content stays legible. */
+.dl-add {
+  background: color-mix(in srgb, var(--ok) 7%, var(--bg));
+  box-shadow: inset 2px 0 0 color-mix(in srgb, var(--ok) 55%, transparent);
+}
+.dl-add .dl-sign {
+  color: var(--ok, #0e7a38);
+}
+
+.dl-del {
+  background: color-mix(in srgb, var(--err) 7%, var(--bg));
+  box-shadow: inset 2px 0 0 color-mix(in srgb, var(--err) 55%, transparent);
+}
+.dl-del .dl-sign {
+  color: var(--err, #b91c1c);
+}
+
+/* Hunk header — muted band spanning the whole row. */
+.dl-hunk {
+  background: var(--panel2, #f3f5f8);
+}
+.dl-hunk .hunk-text {
+  flex: 1;
+  padding: 1px 12px;
+  color: var(--muted, #8b929b);
+  font-style: normal;
+}
+
+@media (max-width: 640px) {
+  .diff-lines {
+    overflow-x: auto;
+    font-size: var(--ui-font-size);
+  }
+}
+</style>

--- a/apps/kimi-web/src/components/chat/DiffLines.vue
+++ b/apps/kimi-web/src/components/chat/DiffLines.vue
@@ -42,6 +42,10 @@ function rowClass(line: DiffViewLine): string {
   font-size: var(--ui-font-size);
   line-height: 1.5;
   -webkit-overflow-scrolling: touch;
+  /* Grow to the longest line so every row can fill one uniform width — this
+     keeps add/del backgrounds continuous across the whole horizontal scroll. */
+  width: max-content;
+  min-width: 100%;
 }
 
 .dl {
@@ -49,11 +53,9 @@ function rowClass(line: DiffViewLine): string {
   align-items: flex-start;
   min-height: 18px;
   white-space: pre;
-  /* Size each row to its content so the add/del background paints across the
-     whole line. Without this, the row is only as wide as the viewport and the
-     background stops where the text overflows horizontally. */
-  width: max-content;
-  min-width: 100%;
+  /* Fill the (uniform) width of .diff-lines so the add/del background paints
+     end-to-end, even for a short line sitting next to a long one. */
+  width: 100%;
 }
 
 .dl-gutter {
@@ -79,8 +81,8 @@ function rowClass(line: DiffViewLine): string {
 }
 
 .dl-text {
-  /* Do not shrink: the row is sized to its content (see .dl width: max-content)
-     so the text keeps its full width and the background covers it. */
+  /* Do not shrink: the container is sized to the longest line (see .diff-lines
+     width: max-content), so the text keeps its full width and rows line up. */
   flex: none;
   padding-right: 14px;
   white-space: pre;

--- a/apps/kimi-web/src/components/chat/DiffView.vue
+++ b/apps/kimi-web/src/components/chat/DiffView.vue
@@ -6,6 +6,7 @@
 import { computed, ref } from 'vue';
 import { useI18n } from 'vue-i18n';
 import type { DiffViewLine } from '../../types';
+import DiffLines from './DiffLines.vue';
 
 const { t } = useI18n();
 
@@ -96,18 +97,6 @@ const renderDetail = computed(
 );
 const diffLines = computed<DiffViewLine[]>(() => props.fileDiff ?? []);
 const loading = computed(() => props.fileDiffLoading === true);
-
-/** Gutter cell text for a diff row (old / new line numbers). */
-function oldGutter(line: DiffViewLine): string {
-  return line.oldNo !== undefined ? String(line.oldNo) : '';
-}
-function newGutter(line: DiffViewLine): string {
-  return line.newNo !== undefined ? String(line.newNo) : '';
-}
-
-function rowClass(line: DiffViewLine): string {
-  return `dl-${line.type}`;
-}
 
 function onOpen(path: string): void {
   emit('open', path);
@@ -243,23 +232,8 @@ function treePadding(depth: number): string {
 
       <div v-if="loading" class="empty-state">{{ t('diff.loading') }}</div>
 
-      <div v-else-if="diffLines.length > 0" class="diff-lines">
-        <div
-          v-for="(line, i) in diffLines"
-          :key="i"
-          class="dl"
-          :class="rowClass(line)"
-        >
-          <template v-if="line.type === 'hunk'">
-            <span class="hunk-text">{{ line.text }}</span>
-          </template>
-          <template v-else>
-            <span class="dl-gutter old">{{ oldGutter(line) }}</span>
-            <span class="dl-gutter new">{{ newGutter(line) }}</span>
-            <span class="dl-sign">{{ line.type === 'add' ? '+' : line.type === 'del' ? '-' : ' ' }}</span>
-            <span class="dl-text">{{ line.text }}</span>
-          </template>
-        </div>
+      <div v-else-if="diffLines.length > 0" class="dv-lines-wrap">
+        <DiffLines :lines="diffLines" />
       </div>
 
       <div v-else class="empty-state">{{ t('diff.noDiff') }}</div>
@@ -682,81 +656,12 @@ function treePadding(depth: number): string {
   outline-offset: 1px;
 }
 
-.diff-lines {
+/* Wrapper that lets <DiffLines> fill the panel height and scroll internally.
+   The line-row styles themselves live in DiffLines.vue. */
+.dv-lines-wrap {
   flex: 1;
+  min-height: 0;
   overflow: auto;
-  padding: 4px 0 12px;
-  font-size: var(--ui-font-size);
-  line-height: 1.5;
-  -webkit-overflow-scrolling: touch;
-}
-
-.dl {
-  display: flex;
-  align-items: flex-start;
-  min-height: 18px;
-  white-space: pre;
-}
-
-.dl-gutter {
-  flex: none;
-  width: 40px;
-  padding: 0 6px;
-  text-align: right;
-  color: var(--faint, #aeb4bc);
-  background: var(--panel, #fafbfc);
-  user-select: none;
-  border-right: 1px solid var(--line2, #eef1f4);
-  font-variant-numeric: tabular-nums;
-}
-
-.dl-gutter.new { border-right: 1px solid var(--line, #e7eaee); }
-
-.dl-sign {
-  flex: none;
-  width: 16px;
-  text-align: center;
-  color: var(--muted);
-  user-select: none;
-}
-
-.dl-text {
-  flex: 1;
-  padding-right: 14px;
-  white-space: pre;
-  color: var(--text);
-  min-width: 0;
-}
-
-/* Added / removed lines: a faint background plus a left accent bar mark the
-   change, while the code TEXT keeps the normal ink colour. Washing the whole
-   line in green/red competed with reading the code itself; the sign (+/-) and
-   the accent carry the colour so the content stays legible. */
-.dl-add {
-  background: color-mix(in srgb, var(--ok) 7%, var(--bg));
-  box-shadow: inset 2px 0 0 color-mix(in srgb, var(--ok) 55%, transparent);
-}
-.dl-add .dl-sign {
-  color: var(--ok, #0e7a38);
-}
-
-.dl-del {
-  background: color-mix(in srgb, var(--err) 7%, var(--bg));
-  box-shadow: inset 2px 0 0 color-mix(in srgb, var(--err) 55%, transparent);
-}
-.dl-del .dl-sign {
-  color: var(--err, #b91c1c);
-}
-
-/* Hunk header — muted band spanning the whole row. */
-.dl-hunk {
-  background: var(--panel2, #f3f5f8);
-}
-.dl-hunk .hunk-text {
-  flex: 1;
-  padding: 1px 12px;
-  color: var(--muted, #8b929b);
-  font-style: normal;
 }
 
 /* Context rows keep plain colors (inherit). */
@@ -794,11 +699,5 @@ function treePadding(depth: number): string {
   }
   .back-btn:active { background: var(--panel2, #f5f6f8); }
   .diff-path { font-size: calc(var(--ui-font-size) - 1.5px); }
-
-  /* Line panel: horizontal scroll for long lines; keep the mono gutter intact. */
-  .diff-lines {
-    overflow-x: auto;
-    font-size: var(--ui-font-size);
-  }
 }
 </style>

--- a/apps/kimi-web/src/components/chat/ToolCall.vue
+++ b/apps/kimi-web/src/components/chat/ToolCall.vue
@@ -220,7 +220,7 @@ function openMediaPreview(): void {
       <!-- When expanded, the command/summary moves here (and is hidden from the
            header) so it shows exactly once. -->
       <div v-if="summaryFull()" class="bb-summary">{{ summaryFull() }}</div>
-      <template v-if="editDiff">
+      <template v-if="editDiff && tool.status !== 'error'">
         <div v-if="editDiff.length > 0" class="bb-diff"><DiffLines :lines="editDiff" /></div>
         <div v-else class="bb-empty">No changes.</div>
       </template>

--- a/apps/kimi-web/src/components/chat/ToolCall.vue
+++ b/apps/kimi-web/src/components/chat/ToolCall.vue
@@ -115,6 +115,7 @@ const diffTarget = computed<ToolDiffTarget | null>(() => {
   const d = parseToolArg(props.tool.arg);
   const path = d && typeof d.path === 'string' ? d.path : undefined;
   return {
+    id: props.tool.id,
     title: toolLabel(props.tool.name),
     path,
     // On error the diff describes what was attempted, not what happened — show

--- a/apps/kimi-web/src/components/chat/ToolCall.vue
+++ b/apps/kimi-web/src/components/chat/ToolCall.vue
@@ -86,11 +86,17 @@ const editDiff = computed<DiffViewLine[] | null>(() => {
   const d = parseToolArg(props.tool.arg);
   if (!d) return null;
   if (kind === 'edit') {
+    // A replace_all edit changes many occurrences; a single-pair diff would
+    // misrepresent the result, so fall back to the tool output.
+    if (d.replace_all === true) return null;
     const before = typeof d.old_string === 'string' ? d.old_string : undefined;
     const after = typeof d.new_string === 'string' ? d.new_string : undefined;
     if (before === undefined || after === undefined) return null;
     return buildDiffLines(before, after);
   }
+  // An append write extends an existing file; a from-empty diff would show the
+  // appended chunk as a new file, so fall back to the tool output.
+  if (d.mode === 'append') return null;
   const content = typeof d.content === 'string' ? d.content : undefined;
   if (content === undefined) return null;
   return buildDiffLines('', content);

--- a/apps/kimi-web/src/components/chat/ToolCall.vue
+++ b/apps/kimi-web/src/components/chat/ToolCall.vue
@@ -1,8 +1,10 @@
 <!-- apps/kimi-web/src/components/chat/ToolCall.vue -->
 <script setup lang="ts">
 import { computed, ref, watch } from 'vue';
-import type { ToolCall, ToolMedia } from '../../types';
-import { toolLabel, toolGlyph, toolChip, toolSummary } from '../../lib/toolMeta';
+import type { DiffViewLine, ToolCall, ToolMedia } from '../../types';
+import { normalizeToolName, toolLabel, toolGlyph, toolChip, toolSummary } from '../../lib/toolMeta';
+import DiffLines from './DiffLines.vue';
+import { buildDiffLines, diffStats } from '../../lib/diffLines';
 
 const props = withDefaults(
   defineProps<{
@@ -19,7 +21,7 @@ const emit = defineEmits<{
 }>();
 const isRunningBash = computed(() => props.tool.status === 'running' && /^bash$/i.test(props.tool.name));
 const hasOutput = computed(() => !!props.tool.output && props.tool.output.length > 0);
-const canExpand = computed(() => hasOutput.value || isRunningBash.value);
+const canExpand = computed(() => hasOutput.value || isRunningBash.value || editDiff.value !== null);
 const open = ref(props.tool.defaultExpanded === true && canExpand.value);
 
 function toggle() {
@@ -42,16 +44,56 @@ const glyph = () => toolGlyph(props.tool.name);
 const summary = () => toolSummary(props.tool.name, props.tool.arg);
 // Expanded body has room to wrap → show the full, un-clipped summary (no `…`).
 const summaryFull = () => toolSummary(props.tool.name, props.tool.arg, true);
-const chip = () => toolChip({
-  name: props.tool.name,
-  arg: props.tool.arg,
-  output: props.tool.output,
-  timing: props.tool.timing,
-  status: props.tool.status,
-});
+const chip = () => {
+  const diff = editDiff.value;
+  if (diff && props.tool.status !== 'error') {
+    const { added, removed } = diffStats(diff);
+    if (added || removed) return `+${added} −${removed}`;
+  }
+  return toolChip({
+    name: props.tool.name,
+    arg: props.tool.arg,
+    output: props.tool.output,
+    timing: props.tool.timing,
+    status: props.tool.status,
+  });
+};
 
 const isError = () => props.tool.status === 'error';
 const media = computed(() => (props.tool.status === 'ok' ? props.tool.media : undefined));
+
+/** Parse the JSON-stringified tool input into a record, or null. */
+function parseToolArg(arg: string): Record<string, unknown> | null {
+  const s = arg.trim();
+  if (!s.startsWith('{')) return null;
+  try {
+    const v = JSON.parse(s);
+    return v && typeof v === 'object' && !Array.isArray(v) ? (v as Record<string, unknown>) : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * For Edit / Write tools, build a line-by-line diff from the tool input so it
+ * can be rendered inline. Returns null for any other tool or when the input
+ * doesn't carry the expected fields.
+ */
+const editDiff = computed<DiffViewLine[] | null>(() => {
+  const kind = normalizeToolName(props.tool.name);
+  if (kind !== 'edit' && kind !== 'write') return null;
+  const d = parseToolArg(props.tool.arg);
+  if (!d) return null;
+  if (kind === 'edit') {
+    const before = typeof d.old_string === 'string' ? d.old_string : undefined;
+    const after = typeof d.new_string === 'string' ? d.new_string : undefined;
+    if (before === undefined || after === undefined) return null;
+    return buildDiffLines(before, after);
+  }
+  const content = typeof d.content === 'string' ? d.content : undefined;
+  if (content === undefined) return null;
+  return buildDiffLines('', content);
+});
 
 function basename(path: string): string {
   return path.split(/[\\/]+/).pop() || path;
@@ -151,8 +193,14 @@ function openMediaPreview(): void {
       <!-- When expanded, the command/summary moves here (and is hidden from the
            header) so it shows exactly once. -->
       <div v-if="summaryFull()" class="bb-summary">{{ summaryFull() }}</div>
-      <div v-if="!hasOutput" class="bb-empty">Waiting for output…</div>
-      <div v-for="(line, i) in tool.output ?? []" :key="i">{{ line }}</div>
+      <template v-if="editDiff">
+        <div v-if="editDiff.length > 0" class="bb-diff"><DiffLines :lines="editDiff" /></div>
+        <div v-else class="bb-empty">No changes.</div>
+      </template>
+      <template v-else>
+        <div v-if="!hasOutput" class="bb-empty">Waiting for output…</div>
+        <div v-for="(line, i) in tool.output ?? []" :key="i">{{ line }}</div>
+      </template>
     </div>
   </div>
 </template>
@@ -315,6 +363,13 @@ function openMediaPreview(): void {
 .bb-empty {
   color: var(--muted);
   font-style: italic;
+}
+/* Inline edit/write diff: scroll horizontally for long lines so the card
+   width stays intact, and bleed to the card edges (counter the .bb padding)
+   so the gutter lines up cleanly. */
+.bb-diff {
+  overflow-x: auto;
+  margin: 0 -11px;
 }
 /* Mobile bubble layout: no left gutter indent, softer corners (prototype .tool). */
 .box.mob {

--- a/apps/kimi-web/src/components/chat/ToolCall.vue
+++ b/apps/kimi-web/src/components/chat/ToolCall.vue
@@ -13,8 +13,14 @@ const props = withDefaults(
     mobile?: boolean;
     /** Position inside a consecutive run of non-media tool cards. */
     stackPosition?: 'single' | 'first' | 'middle' | 'last';
+    /**
+     * When true, clicking an Edit/Write card opens the right-side diff panel.
+     * When false (e.g. inside the side chat, where the panel isn't wired), the
+     * card expands inline instead so its output stays reachable.
+     */
+    toolDiffPanel?: boolean;
   }>(),
-  { mobile: false, stackPosition: 'single' },
+  { mobile: false, stackPosition: 'single', toolDiffPanel: false },
 );
 const emit = defineEmits<{
   openMedia: [media: ToolMedia];
@@ -32,7 +38,7 @@ const isEditWrite = computed(() => {
 });
 
 function toggle() {
-  if (isEditWrite.value) {
+  if (isEditWrite.value && props.toolDiffPanel) {
     emit('openToolDiff', props.tool.id);
     return;
   }

--- a/apps/kimi-web/src/components/chat/ToolCall.vue
+++ b/apps/kimi-web/src/components/chat/ToolCall.vue
@@ -1,9 +1,10 @@
 <!-- apps/kimi-web/src/components/chat/ToolCall.vue -->
 <script setup lang="ts">
 import { computed, ref, watch } from 'vue';
-import type { DiffViewLine, FilePreviewRequest, ToolCall, ToolDiffTarget, ToolMedia } from '../../types';
+import type { DiffViewLine, FilePreviewRequest, ToolCall, ToolMedia } from '../../types';
 import { normalizeToolName, toolLabel, toolGlyph, toolChip, toolSummary } from '../../lib/toolMeta';
-import { buildDiffLines, diffStats } from '../../lib/diffLines';
+import { diffStats } from '../../lib/diffLines';
+import { buildEditDiffLines } from '../../lib/toolDiff';
 
 const props = withDefaults(
   defineProps<{
@@ -18,16 +19,21 @@ const props = withDefaults(
 const emit = defineEmits<{
   openMedia: [media: ToolMedia];
   openFile: [target: FilePreviewRequest];
-  openToolDiff: [target: ToolDiffTarget];
+  openToolDiff: [id: string];
 }>();
 const isRunningBash = computed(() => props.tool.status === 'running' && /^bash$/i.test(props.tool.name));
 const hasOutput = computed(() => !!props.tool.output && props.tool.output.length > 0);
 const canExpand = computed(() => hasOutput.value || isRunningBash.value);
 const open = ref(props.tool.defaultExpanded === true && canExpand.value);
 
+const isEditWrite = computed(() => {
+  const kind = normalizeToolName(props.tool.name);
+  return kind === 'edit' || kind === 'write';
+});
+
 function toggle() {
-  if (diffTarget.value) {
-    emit('openToolDiff', diffTarget.value);
+  if (isEditWrite.value) {
+    emit('openToolDiff', props.tool.id);
     return;
   }
   if (canExpand.value) open.value = !open.value;
@@ -67,63 +73,9 @@ const chip = () => {
 const isError = () => props.tool.status === 'error';
 const media = computed(() => (props.tool.status === 'ok' ? props.tool.media : undefined));
 
-/** Parse the JSON-stringified tool input into a record, or null. */
-function parseToolArg(arg: string): Record<string, unknown> | null {
-  const s = arg.trim();
-  if (!s.startsWith('{')) return null;
-  try {
-    const v = JSON.parse(s);
-    return v && typeof v === 'object' && !Array.isArray(v) ? (v as Record<string, unknown>) : null;
-  } catch {
-    return null;
-  }
-}
-
-/**
- * For Edit / Write tools, build a line-by-line diff from the tool input so it
- * can be previewed in the side panel. Returns null for any other tool or when
- * the input doesn't carry the expected fields.
- */
-const editDiff = computed<DiffViewLine[] | null>(() => {
-  const kind = normalizeToolName(props.tool.name);
-  if (kind !== 'edit' && kind !== 'write') return null;
-  const d = parseToolArg(props.tool.arg);
-  if (!d) return null;
-  if (kind === 'edit') {
-    // A replace_all edit changes many occurrences; a single-pair diff would
-    // misrepresent the result, so fall back to the tool output.
-    if (d.replace_all === true) return null;
-    const before = typeof d.old_string === 'string' ? d.old_string : undefined;
-    const after = typeof d.new_string === 'string' ? d.new_string : undefined;
-    if (before === undefined || after === undefined) return null;
-    return buildDiffLines(before, after);
-  }
-  // An append write extends an existing file; a from-empty diff would show the
-  // appended chunk as a new file, so fall back to the tool output.
-  if (d.mode === 'append') return null;
-  const content = typeof d.content === 'string' ? d.content : undefined;
-  if (content === undefined) return null;
-  return buildDiffLines('', content);
-});
-
-/** Build the side-panel preview payload for Edit/Write tools, or null for any
- *  other tool. The panel shows `lines` when a from-args diff is faithful,
- *  otherwise it falls back to the tool `output`. */
-const diffTarget = computed<ToolDiffTarget | null>(() => {
-  const kind = normalizeToolName(props.tool.name);
-  if (kind !== 'edit' && kind !== 'write') return null;
-  const d = parseToolArg(props.tool.arg);
-  const path = d && typeof d.path === 'string' ? d.path : undefined;
-  return {
-    id: props.tool.id,
-    title: toolLabel(props.tool.name),
-    path,
-    // On error the diff describes what was attempted, not what happened — show
-    // the tool output (the failure reason) instead.
-    lines: props.tool.status === 'error' ? null : editDiff.value,
-    output: props.tool.output,
-  };
-});
+/** Line diff for an Edit/Write tool call (drives the +/- chip); null for any
+ *  other tool or when a from-args diff can't represent the operation. */
+const editDiff = computed<DiffViewLine[] | null>(() => buildEditDiffLines(props.tool));
 
 // ExitPlanMode: expose the plan file as a clickable link (opens file preview).
 const isExitPlan = computed(() => props.tool.name === 'ExitPlanMode');

--- a/apps/kimi-web/src/components/chat/ToolCall.vue
+++ b/apps/kimi-web/src/components/chat/ToolCall.vue
@@ -1,9 +1,8 @@
 <!-- apps/kimi-web/src/components/chat/ToolCall.vue -->
 <script setup lang="ts">
 import { computed, ref, watch } from 'vue';
-import type { DiffViewLine, FilePreviewRequest, ToolCall, ToolMedia } from '../../types';
+import type { DiffViewLine, FilePreviewRequest, ToolCall, ToolDiffTarget, ToolMedia } from '../../types';
 import { normalizeToolName, toolLabel, toolGlyph, toolChip, toolSummary } from '../../lib/toolMeta';
-import DiffLines from './DiffLines.vue';
 import { buildDiffLines, diffStats } from '../../lib/diffLines';
 
 const props = withDefaults(
@@ -19,13 +18,18 @@ const props = withDefaults(
 const emit = defineEmits<{
   openMedia: [media: ToolMedia];
   openFile: [target: FilePreviewRequest];
+  openToolDiff: [target: ToolDiffTarget];
 }>();
 const isRunningBash = computed(() => props.tool.status === 'running' && /^bash$/i.test(props.tool.name));
 const hasOutput = computed(() => !!props.tool.output && props.tool.output.length > 0);
-const canExpand = computed(() => hasOutput.value || isRunningBash.value || editDiff.value !== null);
+const canExpand = computed(() => hasOutput.value || isRunningBash.value);
 const open = ref(props.tool.defaultExpanded === true && canExpand.value);
 
 function toggle() {
+  if (diffTarget.value) {
+    emit('openToolDiff', diffTarget.value);
+    return;
+  }
   if (canExpand.value) open.value = !open.value;
 }
 
@@ -77,8 +81,8 @@ function parseToolArg(arg: string): Record<string, unknown> | null {
 
 /**
  * For Edit / Write tools, build a line-by-line diff from the tool input so it
- * can be rendered inline. Returns null for any other tool or when the input
- * doesn't carry the expected fields.
+ * can be previewed in the side panel. Returns null for any other tool or when
+ * the input doesn't carry the expected fields.
  */
 const editDiff = computed<DiffViewLine[] | null>(() => {
   const kind = normalizeToolName(props.tool.name);
@@ -100,6 +104,24 @@ const editDiff = computed<DiffViewLine[] | null>(() => {
   const content = typeof d.content === 'string' ? d.content : undefined;
   if (content === undefined) return null;
   return buildDiffLines('', content);
+});
+
+/** Build the side-panel preview payload for Edit/Write tools, or null for any
+ *  other tool. The panel shows `lines` when a from-args diff is faithful,
+ *  otherwise it falls back to the tool `output`. */
+const diffTarget = computed<ToolDiffTarget | null>(() => {
+  const kind = normalizeToolName(props.tool.name);
+  if (kind !== 'edit' && kind !== 'write') return null;
+  const d = parseToolArg(props.tool.arg);
+  const path = d && typeof d.path === 'string' ? d.path : undefined;
+  return {
+    title: toolLabel(props.tool.name),
+    path,
+    // On error the diff describes what was attempted, not what happened — show
+    // the tool output (the failure reason) instead.
+    lines: props.tool.status === 'error' ? null : editDiff.value,
+    output: props.tool.output,
+  };
 });
 
 // ExitPlanMode: expose the plan file as a clickable link (opens file preview).
@@ -226,14 +248,8 @@ function openMediaPreview(): void {
       <!-- When expanded, the command/summary moves here (and is hidden from the
            header) so it shows exactly once. -->
       <div v-if="summaryFull()" class="bb-summary">{{ summaryFull() }}</div>
-      <template v-if="editDiff && tool.status !== 'error'">
-        <div v-if="editDiff.length > 0" class="bb-diff"><DiffLines :lines="editDiff" /></div>
-        <div v-else class="bb-empty">No changes.</div>
-      </template>
-      <template v-else>
-        <div v-if="!hasOutput" class="bb-empty">Waiting for output…</div>
-        <div v-for="(line, i) in tool.output ?? []" :key="i">{{ line }}</div>
-      </template>
+      <div v-if="!hasOutput" class="bb-empty">Waiting for output…</div>
+      <div v-for="(line, i) in tool.output ?? []" :key="i">{{ line }}</div>
     </div>
   </div>
 </template>
@@ -412,13 +428,6 @@ function openMediaPreview(): void {
 .bb-empty {
   color: var(--muted);
   font-style: italic;
-}
-/* Inline edit/write diff: scroll horizontally for long lines so the card
-   width stays intact, and bleed to the card edges (counter the .bb padding)
-   so the gutter lines up cleanly. */
-.bb-diff {
-  overflow-x: auto;
-  margin: 0 -11px;
 }
 /* Mobile bubble layout: no left gutter indent, softer corners (prototype .tool). */
 .box.mob {

--- a/apps/kimi-web/src/components/chat/ToolDiffPanel.vue
+++ b/apps/kimi-web/src/components/chat/ToolDiffPanel.vue
@@ -1,0 +1,121 @@
+<!-- apps/kimi-web/src/components/chat/ToolDiffPanel.vue -->
+<!-- Right-side detail panel previewing an Edit/Write tool call's change. Opened
+     by clicking the tool card; shows the synthesized line diff when it
+     accurately represents the operation, otherwise the raw tool output. -->
+<script setup lang="ts">
+import { useI18n } from 'vue-i18n';
+import type { ToolDiffTarget } from '../../types';
+import DiffLines from './DiffLines.vue';
+
+const props = defineProps<{ target: ToolDiffTarget }>();
+
+const emit = defineEmits<{
+  close: [];
+}>();
+
+const { t } = useI18n();
+</script>
+
+<template>
+  <div class="tdp">
+    <div class="tdp-header">
+      <span class="tdp-title">{{ target.title }}</span>
+      <span v-if="target.path" class="tdp-sub" :title="target.path">{{ target.path }}</span>
+      <button
+        type="button"
+        class="tdp-close"
+        :title="t('thinking.close')"
+        :aria-label="t('thinking.close')"
+        @click="emit('close')"
+      >
+        <svg viewBox="0 0 12 12" width="11" height="11" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" aria-hidden="true"><line x1="2" y1="2" x2="10" y2="10"/><line x1="10" y1="2" x2="2" y2="10"/></svg>
+      </button>
+    </div>
+    <div class="tdp-body">
+      <DiffLines v-if="target.lines && target.lines.length > 0" :lines="target.lines" />
+      <div v-else-if="target.output && target.output.length > 0" class="tdp-output">
+        <div v-for="(line, i) in target.output" :key="i">{{ line }}</div>
+      </div>
+      <div v-else class="tdp-empty">{{ t('diff.noDiff') }}</div>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.tdp {
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  background: var(--bg);
+}
+.tdp-header {
+  flex: none;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  height: var(--panel-head-h, 32px);
+  padding: 0 6px 0 12px;
+  box-sizing: border-box;
+  border-bottom: 1px solid var(--line);
+  background: var(--panel);
+}
+.tdp-title {
+  flex: none;
+  font-family: var(--mono);
+  font-size: var(--ui-font-size-xs);
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  color: var(--ink);
+}
+.tdp-sub {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: var(--mono);
+  font-size: var(--ui-font-size-xs);
+  color: var(--muted);
+}
+.tdp-close {
+  margin-left: auto;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  background: none;
+  border: none;
+  border-radius: 5px;
+  color: var(--muted);
+  cursor: pointer;
+}
+.tdp-close:hover {
+  background: var(--hover);
+  color: var(--ink);
+}
+.tdp-close:focus-visible {
+  outline: 2px solid var(--blue);
+  outline-offset: -2px;
+}
+.tdp-body {
+  flex: 1;
+  min-height: 0;
+  overflow: auto;
+  font-family: var(--mono);
+}
+.tdp-output {
+  padding: 8px 12px;
+  color: var(--dim);
+  font-size: calc(var(--ui-font-size) - 2.5px);
+  line-height: 1.7;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+.tdp-empty {
+  padding: 32px 20px;
+  color: var(--muted, #9098a0);
+  font-size: var(--ui-font-size);
+  text-align: center;
+}
+</style>

--- a/apps/kimi-web/src/composables/useDetailPanel.ts
+++ b/apps/kimi-web/src/composables/useDetailPanel.ts
@@ -161,6 +161,10 @@ export function useDetailPanel({
   const toolDiffVisible = computed(() => toolDiffTarget.value !== null);
 
   function openToolDiff(target: ToolDiffTarget): void {
+    if (detailTarget.value === 'toolDiff' && toolDiffTarget.value?.id === target.id) {
+      closeToolDiff();
+      return;
+    }
     detailTarget.value = 'toolDiff';
     toolDiffTarget.value = target;
   }
@@ -177,6 +181,10 @@ export function useDetailPanel({
   const detailDiffPath = ref<string | null>(null);
 
   function openDiffDetail(): void {
+    if (detailTarget.value === 'diff') {
+      closeDiffDetail();
+      return;
+    }
     detailTarget.value = 'diff';
     detailDiffMode.value = 'list';
     detailDiffPath.value = null;

--- a/apps/kimi-web/src/composables/useDetailPanel.ts
+++ b/apps/kimi-web/src/composables/useDetailPanel.ts
@@ -2,7 +2,7 @@
 // Unified right-side detail layer. Only one detail is open at a time.
 
 import { computed, ref, watch, type Ref } from 'vue';
-import type { AgentMember } from '../types';
+import type { AgentMember, ToolDiffTarget } from '../types';
 import type { DetailTarget } from './useFilePreview';
 import type { useKimiWebClient } from './useKimiWebClient';
 import { clampPanelWidth, panelMaxWidth, useViewportWidth } from './useViewportWidth';
@@ -154,6 +154,23 @@ export function useDetailPanel({
   }
 
   // ---------------------------------------------------------------------------
+  // Edit/Write tool-call diff preview
+  // ---------------------------------------------------------------------------
+  const toolDiffTarget = ref<ToolDiffTarget | null>(null);
+
+  const toolDiffVisible = computed(() => toolDiffTarget.value !== null);
+
+  function openToolDiff(target: ToolDiffTarget): void {
+    detailTarget.value = 'toolDiff';
+    toolDiffTarget.value = target;
+  }
+
+  function closeToolDiff(): void {
+    toolDiffTarget.value = null;
+    if (detailTarget.value === 'toolDiff') detailTarget.value = null;
+  }
+
+  // ---------------------------------------------------------------------------
   // Diff detail layer (opened from the chat header git area)
   // ---------------------------------------------------------------------------
   const detailDiffMode = ref<'list' | 'detail'>('list');
@@ -219,6 +236,7 @@ export function useDetailPanel({
     if (detailTarget.value === 'thinking' && thinkingVisible.value) { closeThinkingPanel(); return true; }
     if (detailTarget.value === 'compaction' && compactionPanelVisible.value) { closeCompactionPanel(); return true; }
     if (detailTarget.value === 'agent' && agentPanelVisible.value) { closeAgentPanel(); return true; }
+    if (detailTarget.value === 'toolDiff' && toolDiffVisible.value) { closeToolDiff(); return true; }
     if (detailTarget.value === 'file') { closeFilePreview(); return true; }
     if (detailTarget.value === 'diff') { closeDiffDetail(); return true; }
     if (detailTarget.value === 'btw') { closeSideChat(); return true; }
@@ -230,6 +248,7 @@ export function useDetailPanel({
     closeThinkingPanel();
     closeCompactionPanel();
     closeAgentPanel();
+    closeToolDiff();
     closeDiffDetail();
     hideSideChatPanel();
   });
@@ -253,6 +272,10 @@ export function useDetailPanel({
     agentPanelVisible,
     openAgentPanel,
     closeAgentPanel,
+    toolDiffTarget,
+    toolDiffVisible,
+    openToolDiff,
+    closeToolDiff,
     detailDiffMode,
     detailDiffPath,
     openDiffDetail,

--- a/apps/kimi-web/src/composables/useDetailPanel.ts
+++ b/apps/kimi-web/src/composables/useDetailPanel.ts
@@ -5,6 +5,8 @@ import { computed, ref, watch, type Ref } from 'vue';
 import type { AgentMember, ToolDiffTarget } from '../types';
 import type { DetailTarget } from './useFilePreview';
 import type { useKimiWebClient } from './useKimiWebClient';
+import { buildEditDiffLines, extractEditPath, findToolCallById } from '../lib/toolDiff';
+import { toolLabel } from '../lib/toolMeta';
 import { clampPanelWidth, panelMaxWidth, useViewportWidth } from './useViewportWidth';
 
 type KimiWebClient = ReturnType<typeof useKimiWebClient>;
@@ -156,21 +158,40 @@ export function useDetailPanel({
   // ---------------------------------------------------------------------------
   // Edit/Write tool-call diff preview
   // ---------------------------------------------------------------------------
-  const toolDiffTarget = ref<ToolDiffTarget | null>(null);
+  // Store only the tool id and re-derive the panel payload from the live tool
+  // call in the session turns, so a panel opened while the tool is still
+  // running keeps tracking its status / output / diff as they update.
+  const toolDiffToolId = ref<string | null>(null);
+
+  const toolDiffTarget = computed<ToolDiffTarget | null>(() => {
+    const id = toolDiffToolId.value;
+    if (!id) return null;
+    const tool = findToolCallById(client.turns.value, id);
+    if (!tool) return null;
+    return {
+      id,
+      title: toolLabel(tool.name),
+      path: extractEditPath(tool.arg),
+      // On error the diff describes what was attempted, not what happened —
+      // show the tool output (the failure reason) instead.
+      lines: tool.status === 'error' ? null : buildEditDiffLines(tool),
+      output: tool.output,
+    };
+  });
 
   const toolDiffVisible = computed(() => toolDiffTarget.value !== null);
 
-  function openToolDiff(target: ToolDiffTarget): void {
-    if (detailTarget.value === 'toolDiff' && toolDiffTarget.value?.id === target.id) {
+  function openToolDiff(id: string): void {
+    if (detailTarget.value === 'toolDiff' && toolDiffToolId.value === id) {
       closeToolDiff();
       return;
     }
     detailTarget.value = 'toolDiff';
-    toolDiffTarget.value = target;
+    toolDiffToolId.value = id;
   }
 
   function closeToolDiff(): void {
-    toolDiffTarget.value = null;
+    toolDiffToolId.value = null;
     if (detailTarget.value === 'toolDiff') detailTarget.value = null;
   }
 

--- a/apps/kimi-web/src/composables/useDetailPanel.ts
+++ b/apps/kimi-web/src/composables/useDetailPanel.ts
@@ -253,6 +253,7 @@ export function useDetailPanel({
       (detailTarget.value !== 'thinking' || thinkingVisible.value) &&
       (detailTarget.value !== 'compaction' || compactionPanelVisible.value) &&
       (detailTarget.value !== 'agent' || agentPanelVisible.value) &&
+      (detailTarget.value !== 'toolDiff' || toolDiffVisible.value) &&
       (detailTarget.value !== 'btw' || btwVisible.value),
   );
 

--- a/apps/kimi-web/src/composables/useFilePreview.ts
+++ b/apps/kimi-web/src/composables/useFilePreview.ts
@@ -87,6 +87,17 @@ export function useFilePreview({ client, detailTarget }: UseFilePreviewOptions) 
   }
 
   async function openFilePreview(target: FilePreviewRequest): Promise<void> {
+    // Clicking the link for the already-open file toggles the panel closed.
+    const current = previewTarget.value;
+    if (
+      detailTarget.value === 'file' &&
+      current &&
+      current.path === target.path &&
+      current.line === target.line
+    ) {
+      closeFilePreview();
+      return;
+    }
     const requestSeq = ++previewRequestSeq;
     detailTarget.value = 'file';
     previewFile.value = null;

--- a/apps/kimi-web/src/composables/useFilePreview.ts
+++ b/apps/kimi-web/src/composables/useFilePreview.ts
@@ -10,7 +10,7 @@ import type { useKimiWebClient } from './useKimiWebClient';
 type KimiWebClient = ReturnType<typeof useKimiWebClient>;
 
 /** Which occupant currently owns the shared right-side detail layer. */
-export type DetailTarget = 'file' | 'diff' | 'thinking' | 'compaction' | 'agent' | 'btw';
+export type DetailTarget = 'file' | 'diff' | 'thinking' | 'compaction' | 'agent' | 'toolDiff' | 'btw';
 
 export interface UseFilePreviewOptions {
   client: KimiWebClient;

--- a/apps/kimi-web/src/lib/diffLines.ts
+++ b/apps/kimi-web/src/lib/diffLines.ts
@@ -1,0 +1,91 @@
+// apps/kimi-web/src/lib/diffLines.ts
+// Build line-by-line diff rows for <DiffLines/> from a before/after pair of
+// plain texts (Edit's old_string/new_string, or Write's content vs an empty
+// before). Uses a classic line-level LCS so unchanged lines line up as context.
+
+import type { DiffViewLine } from '../types';
+
+function splitLines(s: string): string[] {
+  if (s === '') return [];
+  const lines = s.split('\n');
+  // A trailing newline produces a trailing empty element that is not a real
+  // content line — drop exactly one of them.
+  if (lines[lines.length - 1] === '') lines.pop();
+  return lines;
+}
+
+export interface DiffStats {
+  added: number;
+  removed: number;
+}
+
+/**
+ * Line-level LCS diff between `before` and `after`, producing rows consumable
+ * by <DiffLines/>. Line numbers are 1-based and advance per side like a
+ * unified diff: context lines advance both, deletions advance old, additions
+ * advance new.
+ */
+export function buildDiffLines(before: string, after: string): DiffViewLine[] {
+  const oldLines = splitLines(before);
+  const newLines = splitLines(after);
+  const n = oldLines.length;
+  const m = newLines.length;
+  if (n === 0 && m === 0) return [];
+
+  const dp: number[][] = Array.from({ length: n + 1 }, () => new Array<number>(m + 1).fill(0));
+  for (let i = 1; i <= n; i++) {
+    for (let j = 1; j <= m; j++) {
+      dp[i]![j] =
+        oldLines[i - 1] === newLines[j - 1]
+          ? dp[i - 1]![j - 1]! + 1
+          : Math.max(dp[i - 1]![j]!, dp[i]![j - 1]!);
+    }
+  }
+
+  type Op = { type: 'context' | 'add' | 'del'; text: string };
+  const ops: Op[] = [];
+  let i = n;
+  let j = m;
+  while (i > 0 || j > 0) {
+    if (i > 0 && j > 0 && oldLines[i - 1] === newLines[j - 1]) {
+      ops.push({ type: 'context', text: oldLines[i - 1]! });
+      i--;
+      j--;
+    } else if (j > 0 && (i === 0 || dp[i]![j - 1]! >= dp[i - 1]![j]!)) {
+      ops.push({ type: 'add', text: newLines[j - 1]! });
+      j--;
+    } else {
+      ops.push({ type: 'del', text: oldLines[i - 1]! });
+      i--;
+    }
+  }
+  ops.reverse();
+
+  const result: DiffViewLine[] = [];
+  let oldNo = 1;
+  let newNo = 1;
+  for (const op of ops) {
+    if (op.type === 'context') {
+      result.push({ type: 'context', text: op.text, oldNo, newNo });
+      oldNo++;
+      newNo++;
+    } else if (op.type === 'add') {
+      result.push({ type: 'add', text: op.text, newNo });
+      newNo++;
+    } else {
+      result.push({ type: 'del', text: op.text, oldNo });
+      oldNo++;
+    }
+  }
+  return result;
+}
+
+export function diffStats(lines: DiffViewLine[]): DiffStats {
+  let added = 0;
+  let removed = 0;
+  for (const l of lines) {
+    if (l.type === 'add') added++;
+    else if (l.type === 'del') removed++;
+  }
+  return { added, removed };
+}

--- a/apps/kimi-web/src/lib/diffLines.ts
+++ b/apps/kimi-web/src/lib/diffLines.ts
@@ -13,6 +13,13 @@ import type { DiffViewLine } from '../types';
  */
 const MAX_DIFF_CELLS = 1_000_000;
 
+/**
+ * Cap on either side's line count. The output has at most n + m rows, so this
+ * bounds the result array for asymmetric edits (e.g. one line replaced by a
+ * hundred thousand) that the matrix-size cap alone would let through.
+ */
+const MAX_DIFF_ROWS = 5000;
+
 function splitLines(s: string): string[] {
   if (s === '') return [];
   const lines = s.split('\n');
@@ -42,6 +49,7 @@ export function buildDiffLines(before: string, after: string): DiffViewLine[] | 
   const n = oldLines.length;
   const m = newLines.length;
   if (n === 0 && m === 0) return [];
+  if (n > MAX_DIFF_ROWS || m > MAX_DIFF_ROWS) return null;
   if ((n + 1) * (m + 1) > MAX_DIFF_CELLS) return null;
 
   const dp: number[][] = Array.from({ length: n + 1 }, () => Array.from({ length: m + 1 }, () => 0));

--- a/apps/kimi-web/src/lib/diffLines.ts
+++ b/apps/kimi-web/src/lib/diffLines.ts
@@ -10,7 +10,7 @@ function splitLines(s: string): string[] {
   const lines = s.split('\n');
   // A trailing newline produces a trailing empty element that is not a real
   // content line — drop exactly one of them.
-  if (lines[lines.length - 1] === '') lines.pop();
+  if (lines.at(-1) === '') lines.pop();
   return lines;
 }
 
@@ -32,7 +32,7 @@ export function buildDiffLines(before: string, after: string): DiffViewLine[] {
   const m = newLines.length;
   if (n === 0 && m === 0) return [];
 
-  const dp: number[][] = Array.from({ length: n + 1 }, () => new Array<number>(m + 1).fill(0));
+  const dp: number[][] = Array.from({ length: n + 1 }, () => Array.from({ length: m + 1 }, () => 0));
   for (let i = 1; i <= n; i++) {
     for (let j = 1; j <= m; j++) {
       dp[i]![j] =

--- a/apps/kimi-web/src/lib/diffLines.ts
+++ b/apps/kimi-web/src/lib/diffLines.ts
@@ -5,6 +5,14 @@
 
 import type { DiffViewLine } from '../types';
 
+/**
+ * Maximum LCS matrix size (`(oldLines + 1) * (newLines + 1)`) we are willing to
+ * allocate. Beyond this the diff would be too expensive to compute client-side
+ * (a 5k × 5k edit is 25M cells, ~200MB) and we fall back to showing the raw
+ * tool output instead.
+ */
+const MAX_DIFF_CELLS = 1_000_000;
+
 function splitLines(s: string): string[] {
   if (s === '') return [];
   const lines = s.split('\n');
@@ -24,13 +32,17 @@ export interface DiffStats {
  * by <DiffLines/>. Line numbers are 1-based and advance per side like a
  * unified diff: context lines advance both, deletions advance old, additions
  * advance new.
+ *
+ * Returns null when the inputs are large enough that the LCS matrix would
+ * exceed `MAX_DIFF_CELLS`; callers should fall back to the raw tool output.
  */
-export function buildDiffLines(before: string, after: string): DiffViewLine[] {
+export function buildDiffLines(before: string, after: string): DiffViewLine[] | null {
   const oldLines = splitLines(before);
   const newLines = splitLines(after);
   const n = oldLines.length;
   const m = newLines.length;
   if (n === 0 && m === 0) return [];
+  if ((n + 1) * (m + 1) > MAX_DIFF_CELLS) return null;
 
   const dp: number[][] = Array.from({ length: n + 1 }, () => Array.from({ length: m + 1 }, () => 0));
   for (let i = 1; i <= n; i++) {

--- a/apps/kimi-web/src/lib/toolDiff.ts
+++ b/apps/kimi-web/src/lib/toolDiff.ts
@@ -34,10 +34,11 @@ export function buildEditDiffLines(tool: { name: string; arg: string }): DiffVie
     if (before === undefined || after === undefined) return null;
     return buildDiffLines(before, after);
   }
-  if (d.mode === 'append') return null;
-  const content = typeof d.content === 'string' ? d.content : undefined;
-  if (content === undefined) return null;
-  return buildDiffLines('', content);
+  // Write only reports the new content (and whether it appended); the client
+  // cannot tell a new file from an overwrite of an existing one. A from-empty
+  // diff would show an overwrite as "all additions, no deletions", which is
+  // misleading — so fall back to the tool output for every Write.
+  return null;
 }
 
 /** Pull the file path out of an Edit/Write tool call's input, if present. */

--- a/apps/kimi-web/src/lib/toolDiff.ts
+++ b/apps/kimi-web/src/lib/toolDiff.ts
@@ -1,0 +1,56 @@
+// apps/kimi-web/src/lib/toolDiff.ts
+// Helpers for previewing Edit/Write tool calls: build the line diff and locate
+// a live tool call in the session turns so the side panel can stay reactive.
+
+import type { ChatTurn, DiffViewLine, ToolCall } from '../types';
+import { buildDiffLines } from './diffLines';
+import { normalizeToolName } from './toolMeta';
+
+function parseArg(arg: string): Record<string, unknown> | null {
+  const s = arg.trim();
+  if (!s.startsWith('{')) return null;
+  try {
+    const v = JSON.parse(s);
+    return v && typeof v === 'object' && !Array.isArray(v) ? (v as Record<string, unknown>) : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Build a line diff for an Edit/Write tool call from its input. Returns null
+ * for any other tool, for operations a from-args diff cannot represent
+ * (replace_all, append), or when the inputs are too large to diff cheaply.
+ */
+export function buildEditDiffLines(tool: { name: string; arg: string }): DiffViewLine[] | null {
+  const kind = normalizeToolName(tool.name);
+  if (kind !== 'edit' && kind !== 'write') return null;
+  const d = parseArg(tool.arg);
+  if (!d) return null;
+  if (kind === 'edit') {
+    if (d.replace_all === true) return null;
+    const before = typeof d.old_string === 'string' ? d.old_string : undefined;
+    const after = typeof d.new_string === 'string' ? d.new_string : undefined;
+    if (before === undefined || after === undefined) return null;
+    return buildDiffLines(before, after);
+  }
+  if (d.mode === 'append') return null;
+  const content = typeof d.content === 'string' ? d.content : undefined;
+  if (content === undefined) return null;
+  return buildDiffLines('', content);
+}
+
+/** Pull the file path out of an Edit/Write tool call's input, if present. */
+export function extractEditPath(arg: string): string | undefined {
+  const d = parseArg(arg);
+  return d && typeof d.path === 'string' ? d.path : undefined;
+}
+
+/** Find a tool call by id across all session turns (for the live panel lookup). */
+export function findToolCallById(turns: ChatTurn[], id: string): ToolCall | undefined {
+  for (const turn of turns) {
+    const found = turn.tools?.find((t) => t.id === id);
+    if (found) return found;
+  }
+  return undefined;
+}

--- a/apps/kimi-web/src/types.ts
+++ b/apps/kimi-web/src/types.ts
@@ -185,6 +185,8 @@ export interface FilePreviewRequest {
  * shown instead.
  */
 export interface ToolDiffTarget {
+  /** Tool-call id; used so clicking the same card again toggles the panel closed. */
+  id: string;
   title: string;
   path?: string;
   lines: DiffViewLine[] | null;

--- a/apps/kimi-web/src/types.ts
+++ b/apps/kimi-web/src/types.ts
@@ -177,6 +177,20 @@ export interface FilePreviewRequest {
   line?: number;
 }
 
+/**
+ * Payload for opening an Edit/Write tool-call diff in the right-side detail
+ * panel. `lines` carries the synthesized diff for single edits / new writes;
+ * it is null for operations a from-args diff can't represent (replace_all,
+ * append, multi-edit, errors), in which case `output` (the tool result) is
+ * shown instead.
+ */
+export interface ToolDiffTarget {
+  title: string;
+  path?: string;
+  lines: DiffViewLine[] | null;
+  output?: string[];
+}
+
 /** One ordered piece of an assistant turn: a thinking segment, a text segment
  * OR a tool card. Built in call order so every piece renders inline where it
  * happened (a turn can think → act → think again — nothing is hoisted). */

--- a/apps/kimi-web/test/lib-logic.test.ts
+++ b/apps/kimi-web/test/lib-logic.test.ts
@@ -67,6 +67,11 @@ describe('buildDiffLines', () => {
     ]);
     expect(buildDiffLines('', '')).toEqual([]);
   });
+
+  it('returns null when the LCS matrix would be too large', () => {
+    const big = Array.from({ length: 2000 }, (_, i) => `line${i}`).join('\n');
+    expect(buildDiffLines(big, `${big}\nextra`)).toBeNull();
+  });
 });
 
 describe('filePathLinks', () => {

--- a/apps/kimi-web/test/lib-logic.test.ts
+++ b/apps/kimi-web/test/lib-logic.test.ts
@@ -6,6 +6,7 @@ import {
 } from '../src/lib/filePathLinks';
 import { parseDiff } from '../src/lib/parseDiff';
 import { buildDiffLines } from '../src/lib/diffLines';
+import { buildEditDiffLines } from '../src/lib/toolDiff';
 import { createCoalescedAsyncRunner } from '../src/lib/snapshotSync';
 import { normalizeToolName, toolSummary } from '../src/lib/toolMeta';
 
@@ -71,6 +72,33 @@ describe('buildDiffLines', () => {
   it('returns null when the LCS matrix would be too large', () => {
     const big = Array.from({ length: 2000 }, (_, i) => `line${i}`).join('\n');
     expect(buildDiffLines(big, `${big}\nextra`)).toBeNull();
+  });
+});
+
+describe('buildEditDiffLines', () => {
+  it('builds a diff for a single Edit', () => {
+    const arg = JSON.stringify({ path: 'a.ts', old_string: 'a\nb', new_string: 'a\nB' });
+    expect(buildEditDiffLines({ name: 'Edit', arg })).toEqual([
+      { type: 'context', text: 'a', oldNo: 1, newNo: 1 },
+      { type: 'del', text: 'b', oldNo: 2 },
+      { type: 'add', text: 'B', newNo: 2 },
+    ]);
+  });
+
+  it('falls back to output for replace_all edits', () => {
+    const arg = JSON.stringify({ path: 'a.ts', old_string: 'a', new_string: 'b', replace_all: true });
+    expect(buildEditDiffLines({ name: 'Edit', arg })).toBeNull();
+  });
+
+  it('falls back to output for every Write (new file or overwrite)', () => {
+    expect(buildEditDiffLines({ name: 'Write', arg: JSON.stringify({ path: 'a.ts', content: 'x' }) })).toBeNull();
+    expect(
+      buildEditDiffLines({ name: 'Write', arg: JSON.stringify({ path: 'a.ts', content: 'x', mode: 'append' }) }),
+    ).toBeNull();
+  });
+
+  it('returns null for non-edit/write tools', () => {
+    expect(buildEditDiffLines({ name: 'Bash', arg: JSON.stringify({ command: 'ls' }) })).toBeNull();
   });
 });
 

--- a/apps/kimi-web/test/lib-logic.test.ts
+++ b/apps/kimi-web/test/lib-logic.test.ts
@@ -73,6 +73,11 @@ describe('buildDiffLines', () => {
     const big = Array.from({ length: 2000 }, (_, i) => `line${i}`).join('\n');
     expect(buildDiffLines(big, `${big}\nextra`)).toBeNull();
   });
+
+  it('returns null when one side is huge even though the matrix is small', () => {
+    const huge = Array.from({ length: 6000 }, (_, i) => `line${i}`).join('\n');
+    expect(buildDiffLines('one line', huge)).toBeNull();
+  });
 });
 
 describe('buildEditDiffLines', () => {

--- a/apps/kimi-web/test/lib-logic.test.ts
+++ b/apps/kimi-web/test/lib-logic.test.ts
@@ -5,6 +5,7 @@ import {
   parseFilePathLinkCandidate,
 } from '../src/lib/filePathLinks';
 import { parseDiff } from '../src/lib/parseDiff';
+import { buildDiffLines } from '../src/lib/diffLines';
 import { createCoalescedAsyncRunner } from '../src/lib/snapshotSync';
 import { normalizeToolName, toolSummary } from '../src/lib/toolMeta';
 
@@ -36,6 +37,35 @@ describe('parseDiff', () => {
       { type: 'del', text: '-- old comment', oldNo: 5 },
       { type: 'add', text: '++ new comment', newNo: 5 },
     ]);
+  });
+});
+
+describe('buildDiffLines', () => {
+  it('lines up context, deletions and additions with old/new line numbers', () => {
+    const before = 'a\nb\nc';
+    const after = 'a\nB\nc\nd';
+    expect(buildDiffLines(before, after)).toEqual([
+      { type: 'context', text: 'a', oldNo: 1, newNo: 1 },
+      { type: 'del', text: 'b', oldNo: 2 },
+      { type: 'add', text: 'B', newNo: 2 },
+      { type: 'context', text: 'c', oldNo: 3, newNo: 3 },
+      { type: 'add', text: 'd', newNo: 4 },
+    ]);
+  });
+
+  it('treats an empty before as an all-addition write', () => {
+    expect(buildDiffLines('', 'x\ny')).toEqual([
+      { type: 'add', text: 'x', newNo: 1 },
+      { type: 'add', text: 'y', newNo: 2 },
+    ]);
+  });
+
+  it('returns all context for identical texts and empty for two empties', () => {
+    expect(buildDiffLines('a\nb', 'a\nb')).toEqual([
+      { type: 'context', text: 'a', oldNo: 1, newNo: 1 },
+      { type: 'context', text: 'b', oldNo: 2, newNo: 2 },
+    ]);
+    expect(buildDiffLines('', '')).toEqual([]);
   });
 });
 


### PR DESCRIPTION
## Related Issue

N/A — no linked issue.

## Problem

When the agent edits or writes a file in the web chat, the tool card only showed a one-line summary (e.g. "Replaced 1 occurrence(s) in path") as plain text. Users could not see what actually changed without opening the file, unlike the CLI/TUI which renders the diff inline.

## What changed

Render a line-by-line diff inside Edit/Write tool cards in the web chat, reusing the existing diff-line visual style from the changes panel.

- Extracted the shared line-by-line diff rendering into a reusable component used by both the changes panel and the tool card.
- Build the diff client-side from the tool input, so no protocol or server changes were needed.
- The header chip now shows the real +/- counts instead of guessing from the summary text.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.
