### PR TITLE
fix(server): import bcryptjs via default export for ESM dev runner

### DIFF
--- a/packages/server/src/services/auth/password.ts
+++ b/packages/server/src/services/auth/password.ts
@@ -1,4 +1,6 @@
-import { compare, hash } from 'bcryptjs';
+import bcrypt from 'bcryptjs';
+
+const { compare, hash } = bcrypt;
 
 const BCRYPT_COST = 12;
 


### PR DESCRIPTION
## Related Issue

No linked issue — this fixes a runtime crash in the dev runner (`make dev` / `pnpm dev:cli`).

## Problem

`make dev` crashes at startup with:

```
SyntaxError: Named export 'compare' not found. The requested module 'bcryptjs'
is a CommonJS module, which may not support all module.exports as named exports.
```

The offending line is in `packages/server/src/services/auth/password.ts`:

```ts
import { compare, hash } from 'bcryptjs';
```

`bcryptjs` is a CommonJS package whose entry `index.js` is just:

```js
module.exports = require("./dist/bcrypt.js");
```

Node's ESM loader detects named exports of a CJS module via `cjs-module-lexer`, which scans the source statically. It cannot see through the `require()` re-export indirection, so it reports zero named exports and the named import throws — but **only under the tsx dev runner**, which delegates `node_modules/*.js` to Node's native ESM loader.

This is why it slipped through CI and the binary build:

- **vitest** (unit/e2e tests) and **esbuild / tsdown** (the bundled CLI binary and SEA) both synthesize or statically resolve CJS named exports, so they were green.
- Only the tsx dev path hits Node's native ESM loader against the raw CJS file, and no CI job runs `make dev` end-to-end.

## What changed

Switch to the default import and destructure, which does not rely on named-export detection and works across tsx, vitest, and the bundled binary:

```ts
import bcrypt from 'bcryptjs';

const { compare, hash } = bcrypt;
```

Verified:

- `pnpm --filter @moonshot-ai/server typecheck` passes.
- `pnpm run dev:cli` boots to the TUI with no `bcrypt` / `SyntaxError`.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above. (explained above; no issue)
- [x] I have added tests that prove my feature works. (import-style fix; covered by existing auth tests plus a manual dev boot)
- [x] Ran `gen-changesets` skill, or this PR needs no changeset. (no user-facing behavior change — the bundled CLI already worked)
- [x] Ran `gen-docs` skill, or this PR needs no doc update. (no user-facing change)
