### PR TITLE
feat(web): add a copy button to user messages

### DIFF
--- a/.changeset/web-copy-user-message.md
+++ b/.changeset/web-copy-user-message.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Add a copy button to user messages in the web chat.

--- a/apps/kimi-web/src/components/chat/ChatPane.vue
+++ b/apps/kimi-web/src/components/chat/ChatPane.vue
@@ -512,6 +512,21 @@ function isStreamingRenderBlock(turn: ChatTurn, block: { sourceIndex: number }):
             </div>
           </div>
           <button
+            v-if="turn.text.trim().length > 0"
+            type="button"
+            class="u-copy"
+            :data-tooltip="t('filePreview.copy')"
+            @click.stop="copyUserMessage(turn)"
+          >
+            <svg v-if="copiedTurn !== turn.id" viewBox="0 0 16 16" width="12" height="12" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+              <rect x="3" y="3" width="9" height="9" rx="1.5"/>
+              <path d="M6 1h7a1 1 0 0 1 1 1v7"/>
+            </svg>
+            <svg v-else viewBox="0 0 16 16" width="12" height="12" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+              <polyline points="3,8 6.5,11.5 13,5"/>
+            </svg>
+          </button>
+          <button
             v-if="turn.createdAt"
             type="button"
             class="u-time"
@@ -657,16 +672,6 @@ function isStreamingRenderBlock(turn: ChatTurn, block: { sourceIndex: number }):
 
             <!-- Per-message copy button (always visible, only when turn is complete) -->
             <button v-if="turn.id !== streamingTurnId && isAssistantRunEnd(ti) && assistantRunFinalText(ti).trim().length > 0" class="cpbtn" @click="copyAssistantRun(ti)" tabindex="-1">
-              <svg v-if="copiedTurn !== turn.id" viewBox="0 0 16 16" width="12" height="12" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-                <rect x="3" y="3" width="9" height="9" rx="1.5"/>
-                <path d="M6 1h7a1 1 0 0 1 1 1v7"/>
-              </svg>
-              <svg v-else viewBox="0 0 16 16" width="12" height="12" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-                <polyline points="3,8 6.5,11.5 13,5"/>
-              </svg>
-              <span class="cpbtn-text">{{ t('filePreview.copy') }}</span>
-            </button>
-            <button v-if="turn.role === 'user' && turn.id !== streamingTurnId && turn.text.trim().length > 0" class="cpbtn" @click="copyUserMessage(turn)" tabindex="-1">
               <svg v-if="copiedTurn !== turn.id" viewBox="0 0 16 16" width="12" height="12" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
                 <rect x="3" y="3" width="9" height="9" rx="1.5"/>
                 <path d="M6 1h7a1 1 0 0 1 1 1v7"/>
@@ -1053,13 +1058,33 @@ function isStreamingRenderBlock(turn: ChatTurn, block: { sourceIndex: number }):
 }
 .u-edit span { line-height: 1; }
 .u-edit:hover { opacity: 1; color: var(--blue); background: var(--hover); }
+/* Copy button — icon-only, shares the undo button's muted→hover style. */
+.u-copy {
+  display: inline-flex;
+  align-items: center;
+  padding: 2px 5px;
+  background: none;
+  border: none;
+  border-radius: 5px;
+  color: var(--muted);
+  font: inherit;
+  font-size: calc(var(--ui-font-size) - 3px);
+  line-height: 1;
+  cursor: pointer;
+  opacity: 0.7;
+  transition: opacity 0.12s, color 0.12s, background-color 0.12s;
+  min-height: 22px;
+  box-sizing: border-box;
+}
+.u-copy svg { display: block; flex: none; }
+.u-copy:hover { opacity: 1; color: var(--blue); background: var(--hover); }
 /* Custom tooltip for the undo button: appears faster than the native title
    tooltip and avoids duplicating the browser's long default delay. */
-.u-edit[data-tooltip] {
+.u-meta [data-tooltip] {
   position: relative;
 }
-.u-edit[data-tooltip]::after,
-.u-edit[data-tooltip]::before {
+.u-meta [data-tooltip]::after,
+.u-meta [data-tooltip]::before {
   position: absolute;
   left: 50%;
   transform: translateX(-50%);
@@ -1070,7 +1095,7 @@ function isStreamingRenderBlock(turn: ChatTurn, block: { sourceIndex: number }):
   transition-delay: 0s;
   z-index: 100;
 }
-.u-edit[data-tooltip]::after {
+.u-meta [data-tooltip]::after {
   content: attr(data-tooltip);
   bottom: calc(100% + 6px);
   padding: 4px 8px;
@@ -1081,17 +1106,17 @@ function isStreamingRenderBlock(turn: ChatTurn, block: { sourceIndex: number }):
   border-radius: 5px;
   white-space: nowrap;
 }
-.u-edit[data-tooltip]::before {
+.u-meta [data-tooltip]::before {
   content: '';
   bottom: calc(100% + 2px);
   border-width: 4px;
   border-style: solid;
   border-color: var(--ink) transparent transparent transparent;
 }
-.u-edit[data-tooltip]:hover::after,
-.u-edit[data-tooltip]:hover::before,
-.u-edit[data-tooltip]:focus-visible::after,
-.u-edit[data-tooltip]:focus-visible::before {
+.u-meta [data-tooltip]:hover::after,
+.u-meta [data-tooltip]:hover::before,
+.u-meta [data-tooltip]:focus-visible::after,
+.u-meta [data-tooltip]:focus-visible::before {
   opacity: 1;
   visibility: visible;
   transition-delay: 0.25s;

--- a/apps/kimi-web/src/components/chat/ChatPane.vue
+++ b/apps/kimi-web/src/components/chat/ChatPane.vue
@@ -385,6 +385,20 @@ function copyAssistantRun(index: number): void {
   }).catch(() => {/* ignore */});
 }
 
+function copyUserMessage(turn: ChatTurn): void {
+  const text = turn.text;
+  if (!text.trim()) return;
+  void copyTextToClipboard(text).then((ok) => {
+    if (!ok) return;
+    copiedTurn.value = turn.id;
+    if (copiedTimer !== null) clearTimeout(copiedTimer);
+    copiedTimer = setTimeout(() => {
+      copiedTimer = null;
+      copiedTurn.value = null;
+    }, 1400);
+  }).catch(() => {/* ignore */});
+}
+
 function isStreamingRenderBlock(turn: ChatTurn, block: { sourceIndex: number }): boolean {
   if (turn.id !== streamingTurnId.value) return false;
   return block.sourceIndex === turnBlocks(turn).length - 1;
@@ -643,6 +657,16 @@ function isStreamingRenderBlock(turn: ChatTurn, block: { sourceIndex: number }):
 
             <!-- Per-message copy button (always visible, only when turn is complete) -->
             <button v-if="turn.id !== streamingTurnId && isAssistantRunEnd(ti) && assistantRunFinalText(ti).trim().length > 0" class="cpbtn" @click="copyAssistantRun(ti)" tabindex="-1">
+              <svg v-if="copiedTurn !== turn.id" viewBox="0 0 16 16" width="12" height="12" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                <rect x="3" y="3" width="9" height="9" rx="1.5"/>
+                <path d="M6 1h7a1 1 0 0 1 1 1v7"/>
+              </svg>
+              <svg v-else viewBox="0 0 16 16" width="12" height="12" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                <polyline points="3,8 6.5,11.5 13,5"/>
+              </svg>
+              <span class="cpbtn-text">{{ t('filePreview.copy') }}</span>
+            </button>
+            <button v-if="turn.role === 'user' && turn.id !== streamingTurnId && turn.text.trim().length > 0" class="cpbtn" @click="copyUserMessage(turn)" tabindex="-1">
               <svg v-if="copiedTurn !== turn.id" viewBox="0 0 16 16" width="12" height="12" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
                 <rect x="3" y="3" width="9" height="9" rx="1.5"/>
                 <path d="M6 1h7a1 1 0 0 1 1 1v7"/>


### PR DESCRIPTION
## Related Issue

N/A — no linked issue.

## Problem

Assistant messages have a per-message copy button, but user messages do not, so there is no quick way to copy the text of a message you sent.

## What changed

Add a copy button to the modern user-message meta row, alongside the undo and time buttons. It copies the user turn's text with the same checkmark confirmation as the assistant copy button.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [ ] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.
