### PR TITLE
perf(web): reuse sessions reference to stop sidebar re-render on streaming deltas

### DIFF
--- a/.changeset/web-sidebar-sessions-ref.md
+++ b/.changeset/web-sidebar-sessions-ref.md
@@ -1,0 +1,8 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Keep the web session sidebar from re-rendering on every streaming token. The
+event reducer now reuses the `sessions` array reference for events that do not
+change sessions, so the sidebar computeds (`sessionsForView` / `workspaceGroups`
+/ `mergedWorkspaces`) are no longer dirtied by unrelated high-frequency events.

--- a/apps/kimi-web/src/api/daemon/eventReducer.ts
+++ b/apps/kimi-web/src/api/daemon/eventReducer.ts
@@ -84,7 +84,13 @@ export function createInitialState(): KimiClientState {
 function cloneState(s: KimiClientState): KimiClientState {
   return {
     ...s,
-    sessions: [...s.sessions],
+    // Reuse the `sessions` array reference when an event does not touch it.
+    // Every session-mutating case below already builds its own array via
+    // `[...]` / `.map` / `.filter`, so sharing the reference is safe — and it
+    // keeps `rawState.sessions` stable for events that don't change sessions,
+    // so the sidebar computeds (sessionsForView / workspaceGroups /
+    // mergedWorkspaces) are not dirtied by unrelated events.
+    sessions: s.sessions,
     messagesBySession: { ...s.messagesBySession },
     approvalsBySession: { ...s.approvalsBySession },
     planReviewByToolCallId: { ...s.planReviewByToolCallId },

--- a/apps/kimi-web/test/event-reducer.test.ts
+++ b/apps/kimi-web/test/event-reducer.test.ts
@@ -149,3 +149,44 @@ describe('reduceAppEvent taskProgress', () => {
     expect(lines?.at(-1)).toBe('line 59');
   });
 });
+
+describe('reduceAppEvent sessions reference stability', () => {
+  // The sidebar computeds (sessionsForView / workspaceGroups / mergedWorkspaces)
+  // depend on `rawState.sessions`. Events that do not change sessions must keep
+  // the SAME array reference so those computeds are not dirtied; events that do
+  // change sessions must produce a NEW array.
+
+  it('reuses the sessions reference for an event that does not touch sessions', () => {
+    const state = {
+      ...createInitialState(),
+      sessions: [makeSession('s1', '2026-01-01T00:00:00.000Z')],
+      messagesBySession: { s1: [makeMessage('s1', '2026-01-01T00:00:00.000Z')] },
+    };
+    const next = reduceAppEvent(
+      state,
+      {
+        type: 'messageUpdated',
+        sessionId: 's1',
+        messageId: 'msg_2026-01-01T00:00:00.000Z',
+        content: [{ type: 'text', text: 'updated' }],
+        status: 'completed',
+      },
+      { sessionId: 's1', seq: 2 },
+    );
+    expect(next.sessions).toBe(state.sessions);
+  });
+
+  it('produces a new sessions array for an event that changes sessions', () => {
+    const state = {
+      ...createInitialState(),
+      sessions: [makeSession('s1', '2026-01-01T00:00:00.000Z')],
+    };
+    const next = reduceAppEvent(
+      state,
+      { type: 'sessionCreated', session: makeSession('s2', '2026-02-01T00:00:00.000Z') },
+      { sessionId: 's2', seq: 3 },
+    );
+    expect(next.sessions).not.toBe(state.sessions);
+    expect(next.sessions.map((s) => s.id)).toEqual(['s2', 's1']);
+  });
+});


### PR DESCRIPTION
## Problem

During long streaming replies the web UI's session sidebar re-renders on every single token, contributing to main-thread jank. Profiling attributed ~2.2s/frame to the sidebar computeds (`sessionsForView` / `workspaceGroups` / `mergedWorkspaces`).

Root cause: the event reducer's `cloneState()` did `sessions: [...s.sessions]` on **every** event, so the `sessions` array reference changed on every high-frequency event (e.g. `assistantDelta`, `toolOutput`, `taskProgress`) even though those events never touch sessions. Since the sidebar computeds depend on `rawState.sessions`, the changed reference dirtied all of them each token.

## What changed

`cloneState()` now reuses the existing `sessions` reference for events that do not change sessions. Every session-mutating case in the reducer already builds its own array via `[...]` / `.map` / `.filter`, so sharing the reference is safe — events that genuinely change sessions still produce a new array.

This is a small, focused subset of the larger streaming-render work, split out so it can be reviewed and merged on its own. It does **not** change any rendering or event-routing behavior; it only avoids invalidating the sidebar on unrelated events.

## Checklist

- [x] I have read the CONTRIBUTING document.
- [x] I have explained the problem above (focused bug/perf fix with a small diff — no separate issue).
- [x] I have added tests that prove the fix works (`reduceAppEvent sessions reference stability`: reuses the array when sessions are untouched, produces a new array when sessions change).
- [x] Added a changeset (`@moonshot-ai/kimi-code: patch`).
- [x] No doc update needed — internal state-management change, no user-visible docs (`gen-docs` N/A).