### PR TITLE
ci: bump windows test timeout to 30s

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,10 @@ jobs:
           cache: pnpm
 
       - run: pnpm install --frozen-lockfile
-      - run: pnpm run test
+      # Windows runners are slower and run the whole suite (including
+      # in-process e2e tests) under more contention, so the default 5s test
+      # timeout causes flaky failures. Give it more headroom.
+      - run: pnpm run test -- --testTimeout=30000
 
   lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Related Issue

N/A — see Problem below.

## Problem

The `test-windows` job is flaky. It runs the entire test suite on a `windows-latest` runner, where the in-process e2e tests (server HTTP/WS round-trips, TUI banner file writes, etc.) regularly exceed the default 5s test timeout under load, and the worker occasionally crashes. The failure point shifts between runs and across packages, and other PRs hit the same flaky failures — so this is a runner/timing issue, not a logic bug in any specific change.

## What changed

Raise the test timeout for the `test-windows` job from the default 5s to 30s by passing `--testTimeout=30000` to vitest. This only affects the Windows job; the Linux/macOS `test` job keeps the default timeout.

This is a targeted mitigation for the flakiness. If the worker still crashes from memory pressure, a follow-up can shard the job by package.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works. (N/A — CI config only.)
- [x] Ran `gen-changesets` skill, or this PR needs no changeset. (No changeset — CI config only.)
- [x] Ran `gen-docs` skill, or this PR needs no doc update. (No doc update needed.)
