### PR TITLE
feat(cli): add update alias for upgrade command

### DIFF
--- a/.changeset/add-update-alias.md
+++ b/.changeset/add-update-alias.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Add an `update` alias for the `kimi upgrade` command. Run `kimi update` to upgrade to the latest version.

--- a/apps/kimi-code/src/cli/commands.ts
+++ b/apps/kimi-code/src/cli/commands.ts
@@ -96,6 +96,7 @@ export function createProgram(
   registerMigrateCommand(program, onMigrate);
   program
     .command('upgrade')
+    .alias('update')
     .description('Upgrade Kimi Code to the latest version.')
     .action(async () => {
       await onUpgrade();

--- a/apps/kimi-code/test/cli/options.test.ts
+++ b/apps/kimi-code/test/cli/options.test.ts
@@ -347,6 +347,30 @@ describe('CLI options parsing', () => {
       expect(upgradeCalls).toBe(1);
     });
 
+    it('routes update alias to the upgrade handler', () => {
+      let upgradeCalls = 0;
+      const program = createProgram(
+        '0.0.0',
+        () => {
+          throw new Error('main action should not run');
+        },
+        () => {},
+        () => {},
+        () => {
+          upgradeCalls += 1;
+        },
+      );
+      program.exitOverride();
+      program.configureOutput({
+        writeOut: () => {},
+        writeErr: () => {},
+      });
+
+      program.parse(['node', 'kimi', 'update']);
+
+      expect(upgradeCalls).toBe(1);
+    });
+
     it('registers the visible sub-commands', () => {
       const program = createProgram(
         '0.0.0',

--- a/docs/en/reference/kimi-command.md
+++ b/docs/en/reference/kimi-command.md
@@ -274,7 +274,7 @@ For full migration instructions, see [Migrating from kimi-cli](../guides/migrati
 
 ### `kimi upgrade`
 
-Immediately check for the latest version and display an update prompt; exits after you make a selection.
+Immediately check for the latest version and display an update prompt; exits after you make a selection. `kimi update` is an alias for this command.
 
 ```sh
 kimi upgrade

--- a/docs/zh/reference/kimi-command.md
+++ b/docs/zh/reference/kimi-command.md
@@ -274,7 +274,7 @@ kimi migrate
 
 ### `kimi upgrade`
 
-立即检查最新版本并展示更新提示，选择操作后退出。
+立即检查最新版本并展示更新提示，选择操作后退出。也可以使用别名 `kimi update`。
 
 ```sh
 kimi upgrade


### PR DESCRIPTION
## Related Issue

No related issue.

## Problem

Users often reach for `kimi update` as a natural synonym for upgrading the CLI, but only `kimi upgrade` was accepted, so `kimi update` fell through to the unknown-command error.

## What changed

- Registered `update` as a commander alias of the existing `upgrade` subcommand, so `kimi update` runs the exact same upgrade flow (telemetry, prompts, and install behavior are unchanged).
- Added a routing test confirming `kimi update` dispatches to the upgrade handler without invoking the main action.
- Documented the alias in the `kimi upgrade` section of the command reference (English and Chinese).
- Added a patch changeset for `@moonshot-ai/kimi-code`.

## Checklist

- [ ] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran \`gen-changesets\` skill, or this PR needs no changeset.
- [ ] Ran \`gen-docs\` skill, or this PR needs no doc update.