### PR TITLE
chore: downgrade feedback changeset to patch

### DIFF
--- a/.changeset/feedback-attachments.md
+++ b/.changeset/feedback-attachments.md
@@ -1,6 +1,6 @@
 ---
-"@moonshot-ai/kimi-code": minor
-"@moonshot-ai/kimi-code-sdk": minor
+"@moonshot-ai/kimi-code": patch
+"@moonshot-ai/kimi-code-sdk": patch
 ---
 
 Add optional feedback attachments for diagnostic logs and codebase context.


### PR DESCRIPTION
## Related Issue

Follow-up to #1120 (feedback attachments). No separate issue.

## Problem

The changeset for the feedback attachments feature (`.changeset/feedback-attachments.md`) currently marks `@moonshot-ai/kimi-code` and `@moonshot-ai/kimi-code-sdk` as `minor`, but this change should ship as a `patch` instead.

## What changed

Bumped the changeset entry for both `@moonshot-ai/kimi-code` and `@moonshot-ai/kimi-code-sdk` from `minor` to `patch` in `.changeset/feedback-attachments.md`.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [ ] I have added tests that prove my feature works.
- [x] Ran \`gen-changesets\` skill, or this PR needs no changeset.
- [x] Ran \`gen-docs\` skill, or this PR needs no doc update.