### PR TITLE
chore: downgrade plugin hooks changeset to patch

### DIFF
--- a/.changeset/plugin-hooks.md
+++ b/.changeset/plugin-hooks.md
@@ -1,5 +1,5 @@
 ---
-"@moonshot-ai/kimi-code": minor
+"@moonshot-ai/kimi-code": patch
 ---
 
 Plugins can now declare hooks in their manifest to run scripts on lifecycle events.


### PR DESCRIPTION
Downgrade the plugin hooks changeset from `minor` to `patch`. While hooks are a new capability for plugin manifests, the user-facing impact is small, so a patch bump is sufficient.
