### PR TITLE
fix(tui): prevent viewport jump when thinking finalizes above viewport

### DIFF
--- a/.changeset/fix-981-viewport-jump.md
+++ b/.changeset/fix-981-viewport-jump.md
@@ -1,0 +1,9 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+fix(tui): prevent viewport jump when thinking finalizes above viewport
+
+When ThinkingComponent transitions from live to finalized above the viewport, its line count change triggers pi-tui's destructive fullRender path, clearing the screen. Introduces stable transition mode that keeps line count constant across the live→finalized boundary, deferring compaction to a safe render cycle.
+
+Fixes #981

--- a/.changeset/fix-981-viewport-jump.md
+++ b/.changeset/fix-981-viewport-jump.md
@@ -2,8 +2,4 @@
 "@moonshot-ai/kimi-code": patch
 ---
 
-fix(tui): prevent viewport jump when thinking finalizes above viewport
-
-When ThinkingComponent transitions from live to finalized above the viewport, its line count change triggers pi-tui's destructive fullRender path, clearing the screen. Introduces stable transition mode that keeps line count constant across the live→finalized boundary, deferring compaction to a safe render cycle.
-
-Fixes #981
+Fix viewport jumps when thinking output finalizes above the visible transcript.

--- a/apps/kimi-code/src/tui/components/messages/thinking.ts
+++ b/apps/kimi-code/src/tui/components/messages/thinking.ts
@@ -3,6 +3,21 @@
  * Supports live in-place updates while thinking streams, then finalizes
  * without replacing the component.
  * Supports expand/collapse via Ctrl+O (shared with tool output).
+ *
+ * ## Stable Transition (fixes #981)
+ *
+ * During streaming, the thinking component typically sits above the visible
+ * viewport. When its rendered line count changes at that position, pi-tui's
+ * diff renderer hits the `firstChanged < prevViewportTop` branch and falls
+ * back to a destructive fullRender (clear-screen), which jumps the terminal
+ * scroll position to the top.
+ *
+ * To prevent this, `finalize()` enters a **stable mode** that keeps the
+ * rendered line count identical to 'live' mode (spinner replaced by a static
+ * bullet, same content region). The actual compact transition to the minimal
+ * finalized form is deferred to `compact()`, which should be called when a
+ * render cycle also changes content below the viewport (e.g., when the
+ * assistant message starts streaming).
  */
 
 import { Text, truncateToWidth, type Component, type TUI } from '@moonshot-ai/pi-tui';
@@ -23,6 +38,7 @@ export class ThinkingComponent implements Component {
   private text: string;
   private showMarker: boolean;
   private mode: ThinkingRenderMode;
+  private stableMode = false;
   private expanded = false;
   private readonly ui: TUI | undefined;
   private spinnerFrame = 0;
@@ -71,10 +87,35 @@ export class ThinkingComponent implements Component {
     return currentTheme.italicFg('textDim', text);
   }
 
+  /**
+   * Transition from live to finalized while keeping rendered line count
+   * stable. Stops the spinner but continues to render in live-format shape
+   * (same number of output lines) to avoid triggering pi-tui's destructive
+   * fullRender path when this component is above the viewport.
+   *
+   * Call `compact()` later to switch to the minimal finalized form.
+   */
   finalize(): void {
+    this.stopSpinner();
+    this.stableMode = true;
+    this.markRenderDirty();
+  }
+
+  /**
+   * Compact to the minimal finalized form (fewer rendered lines).
+   *
+   * This should only be called when it is safe for pi-tui to potentially
+   * trigger a fullRender — typically during a render cycle that also
+   * modifies content below the viewport (e.g., assistant text start).
+   *
+   * @returns true if the component actually changed shape
+   */
+  compact(): boolean {
+    if (!this.stableMode) return false;
+    this.stableMode = false;
     this.mode = 'finalized';
     this.markRenderDirty();
-    this.stopSpinner();
+    return true;
   }
 
   dispose(): void {
@@ -100,18 +141,24 @@ export class ThinkingComponent implements Component {
     const contentLines = this.text.length > 0 ? this.textComponent.render(contentWidth) : [''];
 
     let rendered: string[];
-    if (this.mode === 'live') {
+    if (this.mode === 'live' || this.stableMode) {
+      // Stable path: same line shape as live mode. The spinner is replaced
+      // by a static bullet to stop animation, but the number of output
+      // lines is identical — this keeps pi-tui on the safe differential
+      // rendering path when the component is above the viewport.
       const visibleLines =
         contentLines.length > THINKING_PREVIEW_LINES
           ? contentLines.slice(contentLines.length - THINKING_PREVIEW_LINES)
           : contentLines;
-      const spinner = currentTheme.fg(
-        'textDim',
-        `${BRAILLE_SPINNER_FRAMES[this.spinnerFrame] ?? BRAILLE_SPINNER_FRAMES[0]} `,
-      );
+      const indicator = this.stableMode
+        ? currentTheme.fg('textDim', `${STATUS_BULLET} `)
+        : currentTheme.fg(
+            'textDim',
+            `${BRAILLE_SPINNER_FRAMES[this.spinnerFrame] ?? BRAILLE_SPINNER_FRAMES[0]} `,
+          );
       rendered = [
         '',
-        spinner + currentTheme.fg('textDim', 'thinking...'),
+        indicator + currentTheme.fg('textDim', this.stableMode ? 'thought' : 'thinking...'),
         ...visibleLines.map((line) => MESSAGE_INDENT + line),
       ];
     } else {

--- a/apps/kimi-code/src/tui/controllers/session-event-handler.ts
+++ b/apps/kimi-code/src/tui/controllers/session-event-handler.ts
@@ -422,6 +422,7 @@ export class SessionEventHandler {
     this.host.streamingUI.flushNow();
     this.host.streamingUI.resetToolUi();
     this.host.streamingUI.finalizeLiveTextBuffers('idle');
+    this.host.streamingUI.compactPendingThinking();
     const reason = event.reason;
     if (reason === 'error') return;
     if (reason === 'aborted' || reason === undefined || reason === '') {
@@ -483,6 +484,7 @@ export class SessionEventHandler {
       this.host.streamingUI.flushThinkingToTranscript('idle');
     }
     this.host.streamingUI.finalizeAssistantStream();
+    this.host.streamingUI.compactPendingThinking();
     if (event.content.trim().length > 0) {
       this.currentTurnHasAssistantText = true;
       this.pendingModelBlockedFallback = undefined;
@@ -846,6 +848,7 @@ export class SessionEventHandler {
     this.host.streamingUI.flushNow();
     this.host.streamingUI.resetToolUi();
     this.host.streamingUI.finalizeLiveTextBuffers('idle');
+    this.host.streamingUI.compactPendingThinking();
     if (event.code === OAUTH_LOGIN_REQUIRED_CODE) {
       this.host.showError(OAUTH_LOGIN_REQUIRED_STARTUP_NOTICE);
       return;
@@ -972,6 +975,7 @@ export class SessionEventHandler {
 
   private handleCompactionBegin(event: CompactionStartedEvent): void {
     this.host.streamingUI.finalizeLiveTextBuffers('waiting');
+    this.host.streamingUI.compactPendingThinking();
     this.host.setAppState({
       isCompacting: true,
       streamingPhase: 'waiting',

--- a/apps/kimi-code/src/tui/controllers/session-replay.ts
+++ b/apps/kimi-code/src/tui/controllers/session-replay.ts
@@ -399,6 +399,8 @@ export class SessionReplayRenderer {
       streamingUI.onStreamingTextUpdate(text);
       streamingUI.onStreamingTextEnd();
       streamingUI.clearAssistantDraft();
+    } else if (thinking.length > 0) {
+      streamingUI.compactPendingThinking();
     }
   }
 

--- a/apps/kimi-code/src/tui/controllers/session-replay.ts
+++ b/apps/kimi-code/src/tui/controllers/session-replay.ts
@@ -387,6 +387,7 @@ export class SessionReplayRenderer {
     const { streamingUI } = this.host;
     const thinking = context.assistant.thinking.join('');
     const text = context.assistant.text.join('');
+    const hasVisibleText = text.trim().length > 0;
     context.assistant = { thinking: [], text: [] };
     this.applyStepContext(context);
 
@@ -394,7 +395,7 @@ export class SessionReplayRenderer {
       streamingUI.onThinkingUpdate(thinking);
       streamingUI.onThinkingEnd();
     }
-    if (text.length > 0) {
+    if (hasVisibleText) {
       streamingUI.onStreamingTextStart();
       streamingUI.onStreamingTextUpdate(text);
       streamingUI.onStreamingTextEnd();

--- a/apps/kimi-code/src/tui/controllers/streaming-ui.ts
+++ b/apps/kimi-code/src/tui/controllers/streaming-ui.ts
@@ -806,8 +806,8 @@ export class StreamingUIController {
 
     if (this._thinkingDraft.length > 0 || this._streamingBlock !== null) {
       this.finalizeLiveTextBuffers('tool');
-      this.compactPendingThinking();
     }
+    this.compactPendingThinking();
 
     const existingComponent = this._pendingToolComponents.get(id);
     if (existingComponent !== undefined) {

--- a/apps/kimi-code/src/tui/controllers/streaming-ui.ts
+++ b/apps/kimi-code/src/tui/controllers/streaming-ui.ts
@@ -316,6 +316,7 @@ export class StreamingUIController {
       existingComponent.updateToolCall(toolCall);
     } else if (existing === undefined) {
       this.finalizeLiveTextBuffers('tool');
+      this.compactPendingThinking();
       if (toolCall.name !== 'Agent' && toolCall.name !== 'AgentSwarm') {
         this.onToolCallStart(toolCall);
       }
@@ -560,7 +561,7 @@ export class StreamingUIController {
     // After finalizeLiveTextBuffers, onThinkingEnd may have set
     // _pendingThinkingCompact. Compact now so the thinking block
     // reaches its final compact form before the turn ends.
-    this.compactThinkingIfPending();
+    this.compactPendingThinking();
     this.resetToolCallState();
     this._currentTurnId = undefined;
 
@@ -597,7 +598,7 @@ export class StreamingUIController {
    * Also called as a fallback in `finalizeTurn()` for the edge case where
    * no assistant text follows the thinking block.
    */
-  private compactThinkingIfPending(): void {
+  compactPendingThinking(): void {
     if (!this._pendingThinkingCompact) return;
     this._pendingThinkingCompact = false;
     // Walk in reverse to find the most recent stable-mode ThinkingComponent,
@@ -617,7 +618,7 @@ export class StreamingUIController {
   onStreamingTextStart(): void {
     // Compact thinking before adding assistant content so both changes
     // land in the same render cycle (fixes #981 viewport jump).
-    this.compactThinkingIfPending();
+    this.compactPendingThinking();
 
     const { state } = this.host;
     this._pendingAgentGroup = null;
@@ -805,6 +806,7 @@ export class StreamingUIController {
 
     if (this._thinkingDraft.length > 0 || this._streamingBlock !== null) {
       this.finalizeLiveTextBuffers('tool');
+      this.compactPendingThinking();
     }
 
     const existingComponent = this._pendingToolComponents.get(id);

--- a/apps/kimi-code/src/tui/controllers/streaming-ui.ts
+++ b/apps/kimi-code/src/tui/controllers/streaming-ui.ts
@@ -590,7 +590,7 @@ export class StreamingUIController {
   /**
    * Compact a stable-mode thinking component to its minimal finalized form.
    *
-   * Called at the start of assistant text streaming so that the thinking
+   * Called after the first visible assistant text update so that the thinking
    * line-count reduction and the assistant content addition happen in the
    * same pi-tui render cycle. The assistant content growing below offsets
    * the destructive fullRender, making the transition invisible.
@@ -616,10 +616,6 @@ export class StreamingUIController {
   }
 
   onStreamingTextStart(): void {
-    // Compact thinking before adding assistant content so both changes
-    // land in the same render cycle (fixes #981 viewport jump).
-    this.compactPendingThinking();
-
     const { state } = this.host;
     this._pendingAgentGroup = null;
     this._pendingReadGroup = null;
@@ -640,8 +636,12 @@ export class StreamingUIController {
   onStreamingTextUpdate(fullText: string): void {
     const block = this._streamingBlock;
     if (block !== null) {
+      const hasVisibleAssistantText = fullText.trim().length > 0;
       block.entry.content = fullText;
       block.component.updateContent(fullText, { transient: true });
+      if (hasVisibleAssistantText) {
+        this.compactPendingThinking();
+      }
       this.host.state.ui.requestRender();
     }
   }

--- a/apps/kimi-code/src/tui/controllers/streaming-ui.ts
+++ b/apps/kimi-code/src/tui/controllers/streaming-ui.ts
@@ -55,6 +55,7 @@ export class StreamingUIController {
   private _thinkingDraft = '';
   private _streamingBlock: { component: AssistantMessageComponent; entry: TranscriptEntry } | null = null;
   private _activeThinkingComponent: ThinkingComponent | undefined = undefined;
+  private _pendingThinkingCompact = false;
   private _activeCompactionBlock: CompactionComponent | undefined = undefined;
   private _activeToolCalls = new Map<string, ToolCallBlockData>();
   private _streamingToolCallArguments = new Map<
@@ -522,6 +523,7 @@ export class StreamingUIController {
   resetLiveText(): void {
     this.pendingAssistantFlush = false;
     this.pendingThinkingFlush = false;
+    this._pendingThinkingCompact = false;
     this.clearFlushTimerIfIdle();
     this._assistantDraft = '';
     this._streamingBlock = null;
@@ -552,6 +554,8 @@ export class StreamingUIController {
     const { state } = this.host;
     if (state.appState.streamingPhase === 'idle') return;
     this.host.deferUserMessages = false;
+    // Last-chance compact in case no assistant text triggered it
+    this.compactThinkingIfPending();
     const completedTurnKey =
       this._currentTurnId ?? `local:${String(state.appState.streamingStartTime)}`;
     this.finalizeLiveTextBuffers('idle');
@@ -580,7 +584,35 @@ export class StreamingUIController {
   // Live Render Hooks
   // ---------------------------------------------------------------------------
 
+  /**
+   * Compact a stable-mode thinking component to its minimal finalized form.
+   *
+   * Called at the start of assistant text streaming so that the thinking
+   * line-count reduction and the assistant content addition happen in the
+   * same pi-tui render cycle. The assistant content growing below offsets
+   * the destructive fullRender, making the transition invisible.
+   *
+   * Also called as a fallback in `finalizeTurn()` for the edge case where
+   * no assistant text follows the thinking block.
+   */
+  private compactThinkingIfPending(): void {
+    if (!this._pendingThinkingCompact) return;
+    this._pendingThinkingCompact = false;
+    for (const child of this.host.state.transcriptContainer.children) {
+      if (child instanceof ThinkingComponent) {
+        if ((child as ThinkingComponent).compact()) {
+          this.host.state.ui.requestRender();
+        }
+        break;
+      }
+    }
+  }
+
   onStreamingTextStart(): void {
+    // Compact thinking before adding assistant content so both changes
+    // land in the same render cycle (fixes #981 viewport jump).
+    this.compactThinkingIfPending();
+
     const { state } = this.host;
     this._pendingAgentGroup = null;
     this._pendingReadGroup = null;
@@ -637,7 +669,11 @@ export class StreamingUIController {
 
   onThinkingEnd(): void {
     if (this._activeThinkingComponent === undefined) return;
+    // Enter stable mode: spinner stops but rendered line count stays
+    // identical to live mode, preventing a destructive fullRender when
+    // this component is above the viewport (fixes #981).
     this._activeThinkingComponent.finalize();
+    this._pendingThinkingCompact = true;
     this._activeThinkingComponent = undefined;
     this.host.state.ui.requestRender();
     this.host.mergeCurrentTurnSteps();

--- a/apps/kimi-code/src/tui/controllers/streaming-ui.ts
+++ b/apps/kimi-code/src/tui/controllers/streaming-ui.ts
@@ -554,11 +554,13 @@ export class StreamingUIController {
     const { state } = this.host;
     if (state.appState.streamingPhase === 'idle') return;
     this.host.deferUserMessages = false;
-    // Last-chance compact in case no assistant text triggered it
-    this.compactThinkingIfPending();
     const completedTurnKey =
       this._currentTurnId ?? `local:${String(state.appState.streamingStartTime)}`;
     this.finalizeLiveTextBuffers('idle');
+    // After finalizeLiveTextBuffers, onThinkingEnd may have set
+    // _pendingThinkingCompact. Compact now so the thinking block
+    // reaches its final compact form before the turn ends.
+    this.compactThinkingIfPending();
     this.resetToolCallState();
     this._currentTurnId = undefined;
 
@@ -598,7 +600,11 @@ export class StreamingUIController {
   private compactThinkingIfPending(): void {
     if (!this._pendingThinkingCompact) return;
     this._pendingThinkingCompact = false;
-    for (const child of this.host.state.transcriptContainer.children) {
+    // Walk in reverse to find the most recent stable-mode ThinkingComponent,
+    // not an older one from a previous turn.
+    const children = this.host.state.transcriptContainer.children;
+    for (let i = children.length - 1; i >= 0; i--) {
+      const child = children[i];
       if (child instanceof ThinkingComponent) {
         if ((child as ThinkingComponent).compact()) {
           this.host.state.ui.requestRender();

--- a/apps/kimi-code/test/tui/components/messages/thinking.test.ts
+++ b/apps/kimi-code/test/tui/components/messages/thinking.test.ts
@@ -5,7 +5,7 @@ import { ThinkingComponent } from '#/tui/components/messages/thinking';
 import { STATUS_BULLET } from '#/tui/constant/symbols';
 
 function strip(text: string): string {
-  return text.replaceAll(/\u001B\[[0-9;]*m/g, '');
+  return text.replaceAll(/\[[0-9;]*m/g, '');
 }
 
 const longThinking = ['line1', 'line2', 'line3', 'line4', 'line5', 'line6', 'line7'].join('\n');
@@ -53,10 +53,25 @@ describe('ThinkingComponent', () => {
     vi.useRealTimers();
   });
 
-  it('finalizes in place into a collapsed preview', () => {
+  it('finalize() enters stable mode with live-format line count', () => {
     const component = new ThinkingComponent(longThinking, true, 'live');
+    const liveOut = strip(component.render(80).join('\n'));
 
     component.finalize();
+
+    const stableOut = strip(component.render(80).join('\n'));
+    // Same number of lines as live mode (no viewport jump)
+    expect(liveOut.split('\n').length).toBe(stableOut.split('\n').length);
+    // Spinner stopped, replaced by bullet
+    expect(stableOut).not.toContain('thinking...');
+    expect(stableOut).toContain(`${STATUS_BULLET}`);
+    expect(stableOut).toContain('thought');
+  });
+
+  it('compact() produces the collapsed preview after stable mode', () => {
+    const component = new ThinkingComponent(longThinking, true, 'live');
+    component.finalize();
+    component.compact();
 
     const out = strip(component.render(80).join('\n'));
     expect(out).toContain('line1');
@@ -66,9 +81,15 @@ describe('ThinkingComponent', () => {
     expect(out).toContain('... (5 more lines, ctrl+o to expand)');
   });
 
-  it('expands and collapses after finalization', () => {
+  it('compact() returns false when not in stable mode', () => {
+    const component = new ThinkingComponent('hi', true, 'finalized');
+    expect(component.compact()).toBe(false);
+  });
+
+  it('expands and collapses after compact', () => {
     const component = new ThinkingComponent(longThinking, true, 'live');
     component.finalize();
+    component.compact();
 
     component.setExpanded(true);
     const expanded = strip(component.render(80).join('\n'));
@@ -81,9 +102,10 @@ describe('ThinkingComponent', () => {
     expect(collapsed).toContain('ctrl+o to expand');
   });
 
-  it('keeps the finalized truncation footer within the requested render width', () => {
+  it('keeps the truncated footer within the requested render width after compact', () => {
     const component = new ThinkingComponent(longThinking, true, 'live');
     component.finalize();
+    component.compact();
 
     for (const line of component.render(37)) {
       expect(visibleWidth(line)).toBeLessThanOrEqual(37);

--- a/apps/kimi-code/test/tui/kimi-tui-message-flow.test.ts
+++ b/apps/kimi-code/test/tui/kimi-tui-message-flow.test.ts
@@ -4697,6 +4697,67 @@ command = "vim"
     expect(countOccurrences(transcript, 'ctrl+o to expand')).toBe(2);
   });
 
+  it('compacts pending thinking before rendering a tool call', async () => {
+    const { driver } = await makeDriver();
+    driver.state.appState.streamingPhase = 'thinking';
+    driver.state.appState.streamingStartTime = 1;
+
+    streamThinking(driver, ['line1', 'line2', 'line3', 'line4', 'line5', 'line6', 'line7']);
+    driver.sessionEventHandler.handleEvent(
+      {
+        type: 'tool.call.started',
+        agentId: 'main',
+        sessionId: 'ses-1',
+        turnId: 1,
+        toolCallId: 'call_read',
+        name: 'Read',
+        args: { path: 'src/a.ts' },
+      } as Event,
+      vi.fn(),
+    );
+
+    const transcript = stripSgr(renderTranscript(driver));
+    expect(transcript).toContain('line1');
+    expect(transcript).toContain('line2');
+    expect(transcript).not.toContain('line7');
+    expect(transcript).toContain('... (5 more lines, ctrl+o to expand)');
+    expect(transcript).toContain('Using Read (src/a.ts)');
+  });
+
+  it('compacts pending thinking before rendering a streaming tool-call preview', async () => {
+    vi.useFakeTimers();
+    try {
+      const { driver } = await makeDriver();
+      driver.state.appState.streamingPhase = 'thinking';
+      driver.state.appState.streamingStartTime = 1;
+
+      streamThinking(driver, ['line1', 'line2', 'line3', 'line4', 'line5', 'line6', 'line7']);
+      driver.sessionEventHandler.handleEvent(
+        {
+          type: 'tool.call.delta',
+          agentId: 'main',
+          sessionId: 'ses-1',
+          turnId: 1,
+          toolCallId: 'call_bash',
+          name: 'Bash',
+          argumentsPart: '{"command":"echo hi"}',
+        } as Event,
+        vi.fn(),
+      );
+
+      await vi.runOnlyPendingTimersAsync();
+
+      const transcript = stripSgr(renderTranscript(driver));
+      expect(driver.streamingUI.getToolComponent('call_bash')).toBeDefined();
+      expect(transcript).toContain('line1');
+      expect(transcript).toContain('line2');
+      expect(transcript).not.toContain('line7');
+      expect(transcript).toContain('... (5 more lines, ctrl+o to expand)');
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('renders newly streamed thinking expanded when ctrl+o toggle was already active', async () => {
     const { driver } = await makeDriver();
     driver.state.toolOutputExpanded = true;

--- a/apps/kimi-code/test/tui/kimi-tui-message-flow.test.ts
+++ b/apps/kimi-code/test/tui/kimi-tui-message-flow.test.ts
@@ -4758,6 +4758,51 @@ command = "vim"
     }
   });
 
+  it('compacts finalized pending thinking before a streaming tool-call preview', async () => {
+    vi.useFakeTimers();
+    try {
+      const { driver } = await makeDriver();
+      driver.state.appState.streamingPhase = 'thinking';
+      driver.state.appState.streamingStartTime = 1;
+
+      streamThinking(driver, ['line1', 'line2', 'line3', 'line4', 'line5', 'line6', 'line7']);
+      driver.sessionEventHandler.handleEvent(
+        {
+          type: 'turn.step.started',
+          agentId: 'main',
+          sessionId: 'ses-1',
+          turnId: 1,
+          step: 2,
+        } as Event,
+        vi.fn(),
+      );
+      driver.sessionEventHandler.handleEvent(
+        {
+          type: 'tool.call.delta',
+          agentId: 'main',
+          sessionId: 'ses-1',
+          turnId: 1,
+          toolCallId: 'call_bash',
+          name: 'Bash',
+          argumentsPart: '{"command":"echo hi"}',
+        } as Event,
+        vi.fn(),
+      );
+
+      await vi.runOnlyPendingTimersAsync();
+
+      const transcript = stripSgr(renderTranscript(driver));
+      expect(driver.streamingUI.getToolComponent('call_bash')).toBeDefined();
+      expect(transcript).toContain('line1');
+      expect(transcript).toContain('line2');
+      expect(transcript).not.toContain('line7');
+      expect(transcript).toContain('... (5 more lines, ctrl+o to expand)');
+      expect(transcript).toContain('Using Bash');
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('renders newly streamed thinking expanded when ctrl+o toggle was already active', async () => {
     const { driver } = await makeDriver();
     driver.state.toolOutputExpanded = true;

--- a/apps/kimi-code/test/tui/kimi-tui-message-flow.test.ts
+++ b/apps/kimi-code/test/tui/kimi-tui-message-flow.test.ts
@@ -4697,6 +4697,109 @@ command = "vim"
     expect(countOccurrences(transcript, 'ctrl+o to expand')).toBe(2);
   });
 
+  it('compacts pending thinking before appending a hook result', async () => {
+    const { driver } = await makeDriver();
+    driver.state.appState.streamingPhase = 'thinking';
+    driver.state.appState.streamingStartTime = 1;
+
+    streamThinking(driver, ['line1', 'line2', 'line3', 'line4', 'line5', 'line6', 'line7']);
+    driver.sessionEventHandler.handleEvent(
+      {
+        type: 'hook.result',
+        agentId: 'main',
+        sessionId: 'ses-1',
+        turnId: 1,
+        hookEvent: 'UserPromptSubmit',
+        content: '{}',
+      } as Event,
+      vi.fn(),
+    );
+
+    const transcript = stripSgr(renderTranscript(driver));
+    expect(transcript).toContain('line1');
+    expect(transcript).toContain('line2');
+    expect(transcript).not.toContain('line7');
+    expect(transcript).toContain('... (5 more lines, ctrl+o to expand)');
+    expect(transcript).not.toContain('thought');
+  });
+
+  it('compacts pending thinking when a step is interrupted', async () => {
+    const { driver } = await makeDriver();
+    driver.state.appState.streamingPhase = 'thinking';
+    driver.state.appState.streamingStartTime = 1;
+
+    streamThinking(driver, ['line1', 'line2', 'line3', 'line4', 'line5', 'line6', 'line7']);
+    driver.sessionEventHandler.handleEvent(
+      {
+        type: 'turn.step.interrupted',
+        agentId: 'main',
+        sessionId: 'ses-1',
+        turnId: 1,
+        step: 0,
+        reason: 'aborted',
+      } as Event,
+      vi.fn(),
+    );
+
+    const transcript = stripSgr(renderTranscript(driver));
+    expect(transcript).toContain('line1');
+    expect(transcript).toContain('line2');
+    expect(transcript).not.toContain('line7');
+    expect(transcript).toContain('... (5 more lines, ctrl+o to expand)');
+    expect(transcript).not.toContain('thought');
+  });
+
+  it('compacts pending thinking on session error', async () => {
+    const { driver } = await makeDriver();
+    driver.state.appState.streamingPhase = 'thinking';
+    driver.state.appState.streamingStartTime = 1;
+
+    streamThinking(driver, ['line1', 'line2', 'line3', 'line4', 'line5', 'line6', 'line7']);
+    driver.sessionEventHandler.handleEvent(
+      {
+        type: 'error',
+        agentId: 'main',
+        sessionId: 'ses-1',
+        code: 'provider.api_error',
+        message: 'boom',
+      } as Event,
+      vi.fn(),
+    );
+
+    const transcript = stripSgr(renderTranscript(driver));
+    expect(transcript).toContain('line1');
+    expect(transcript).toContain('line2');
+    expect(transcript).not.toContain('line7');
+    expect(transcript).toContain('... (5 more lines, ctrl+o to expand)');
+    expect(transcript).not.toContain('thought');
+  });
+
+  it('compacts pending thinking when compaction begins', async () => {
+    const { driver } = await makeDriver();
+    driver.state.appState.streamingPhase = 'thinking';
+    driver.state.appState.streamingStartTime = 1;
+
+    streamThinking(driver, ['line1', 'line2', 'line3', 'line4', 'line5', 'line6', 'line7']);
+    driver.sessionEventHandler.handleEvent(
+      {
+        type: 'compaction.started',
+        agentId: 'main',
+        sessionId: 'ses-1',
+        turnId: 1,
+        trigger: 'manual',
+        instruction: 'summarize',
+      } as Event,
+      vi.fn(),
+    );
+
+    const transcript = stripSgr(renderTranscript(driver));
+    expect(transcript).toContain('line1');
+    expect(transcript).toContain('line2');
+    expect(transcript).not.toContain('line7');
+    expect(transcript).toContain('... (5 more lines, ctrl+o to expand)');
+    expect(transcript).not.toContain('thought');
+  });
+
   it('compacts pending thinking before rendering a tool call', async () => {
     const { driver } = await makeDriver();
     driver.state.appState.streamingPhase = 'thinking';
@@ -4875,7 +4978,6 @@ command = "vim"
   });
 });
 
-<<<<<<< HEAD
 describe('/model status displayName override', () => {
   it('shows the overridden display name in the switch status', async () => {
     const session = makeSession();

--- a/apps/kimi-code/test/tui/kimi-tui-message-flow.test.ts
+++ b/apps/kimi-code/test/tui/kimi-tui-message-flow.test.ts
@@ -4687,6 +4687,7 @@ command = "vim"
       } as Event,
       vi.fn(),
     );
+    driver.streamingUI.flushNow();
 
     const transcript = stripSgr(renderTranscript(driver));
     expect(transcript).toContain('old1');
@@ -4695,6 +4696,49 @@ command = "vim"
     expect(transcript).toContain('new2');
     expect(transcript).not.toContain('new7');
     expect(countOccurrences(transcript, 'ctrl+o to expand')).toBe(2);
+  });
+
+  it('renders first assistant text before compacting pending thinking', async () => {
+    const { driver } = await makeDriver();
+    driver.state.appState.streamingPhase = 'thinking';
+    driver.state.appState.streamingStartTime = 1;
+
+    streamThinking(driver, ['line1', 'line2', 'line3', 'line4', 'line5', 'line6', 'line7']);
+    driver.streamingUI.flushNow();
+
+    const renderedFrames: string[] = [];
+    vi.mocked(driver.state.ui.requestRender).mockImplementation(() => {
+      renderedFrames.push(stripSgr(renderTranscript(driver)));
+    });
+
+    driver.sessionEventHandler.handleEvent(
+      {
+        type: 'assistant.delta',
+        agentId: 'main',
+        sessionId: 'ses-1',
+        turnId: 1,
+        delta: 'answer',
+      } as Event,
+      vi.fn(),
+    );
+    driver.streamingUI.flushNow();
+
+    expect(
+      renderedFrames.some(
+        (frame) => frame.includes('... (5 more lines, ctrl+o to expand)') && !frame.includes('answer'),
+      ),
+    ).toBe(false);
+    expect(
+      renderedFrames.some(
+        (frame) => frame.includes('... (5 more lines, ctrl+o to expand)') && frame.includes('answer'),
+      ),
+    ).toBe(true);
+
+    const transcript = stripSgr(renderTranscript(driver));
+    expect(transcript).toContain('answer');
+    expect(transcript).toContain('line1');
+    expect(transcript).toContain('line2');
+    expect(transcript).not.toContain('line7');
   });
 
   it('compacts pending thinking before appending a hook result', async () => {

--- a/apps/kimi-code/test/tui/kimi-tui-message-flow.test.ts
+++ b/apps/kimi-code/test/tui/kimi-tui-message-flow.test.ts
@@ -4615,6 +4615,88 @@ command = "vim"
     expect(driver.streamingUI.hasActiveThinkingComponent()).toBe(false);
   });
 
+  it('compacts a thinking-only turn after finalizing it on turn end', async () => {
+    const { driver } = await makeDriver();
+    driver.state.appState.streamingPhase = 'thinking';
+    driver.state.appState.streamingStartTime = 1;
+
+    streamThinking(driver, ['line1', 'line2', 'line3', 'line4', 'line5', 'line6', 'line7']);
+
+    driver.sessionEventHandler.handleEvent(
+      {
+        type: 'turn.ended',
+        agentId: 'main',
+        sessionId: 'ses-1',
+        turnId: 1,
+        reason: 'completed',
+      } as Event,
+      vi.fn(),
+    );
+
+    const transcript = stripSgr(renderTranscript(driver));
+    expect(transcript).toContain('line1');
+    expect(transcript).toContain('line2');
+    expect(transcript).not.toContain('line7');
+    expect(transcript).toContain('... (5 more lines, ctrl+o to expand)');
+  });
+
+  it('compacts the latest pending thinking block when an older thinking block exists', async () => {
+    const { driver } = await makeDriver();
+    driver.state.appState.streamingPhase = 'thinking';
+    driver.state.appState.streamingStartTime = 1;
+
+    streamThinking(driver, ['old1', 'old2', 'old3', 'old4', 'old5', 'old6', 'old7']);
+    driver.sessionEventHandler.handleEvent(
+      {
+        type: 'assistant.delta',
+        agentId: 'main',
+        sessionId: 'ses-1',
+        turnId: 1,
+        delta: 'first answer',
+      } as Event,
+      vi.fn(),
+    );
+    driver.sessionEventHandler.handleEvent(
+      {
+        type: 'turn.ended',
+        agentId: 'main',
+        sessionId: 'ses-1',
+        turnId: 1,
+        reason: 'completed',
+      } as Event,
+      vi.fn(),
+    );
+
+    driver.sessionEventHandler.handleEvent(
+      {
+        type: 'thinking.delta',
+        agentId: 'main',
+        sessionId: 'ses-1',
+        turnId: 2,
+        delta: ['new1', 'new2', 'new3', 'new4', 'new5', 'new6', 'new7'].join('\n'),
+      } as Event,
+      vi.fn(),
+    );
+    driver.sessionEventHandler.handleEvent(
+      {
+        type: 'assistant.delta',
+        agentId: 'main',
+        sessionId: 'ses-1',
+        turnId: 2,
+        delta: 'second answer',
+      } as Event,
+      vi.fn(),
+    );
+
+    const transcript = stripSgr(renderTranscript(driver));
+    expect(transcript).toContain('old1');
+    expect(transcript).toContain('old2');
+    expect(transcript).toContain('new1');
+    expect(transcript).toContain('new2');
+    expect(transcript).not.toContain('new7');
+    expect(countOccurrences(transcript, 'ctrl+o to expand')).toBe(2);
+  });
+
   it('renders newly streamed thinking expanded when ctrl+o toggle was already active', async () => {
     const { driver } = await makeDriver();
     driver.state.toolOutputExpanded = true;
@@ -4687,6 +4769,7 @@ command = "vim"
   });
 });
 
+<<<<<<< HEAD
 describe('/model status displayName override', () => {
   it('shows the overridden display name in the switch status', async () => {
     const session = makeSession();
@@ -4764,3 +4847,15 @@ describe('/effort support_efforts override', () => {
     expect(renderTranscript(driver)).not.toContain('Switched to Kimi K2 with thinking max.');
   });
 });
+
+function streamThinking(driver: MessageDriver, lines: readonly string[]): void {
+  driver.sessionEventHandler.handleEvent(
+    {
+      type: 'thinking.delta',
+      agentId: 'main',
+      sessionId: 'ses-1',
+      delta: lines.join('\n'),
+    } as Event,
+    vi.fn(),
+  );
+}

--- a/apps/kimi-code/test/tui/message-replay.test.ts
+++ b/apps/kimi-code/test/tui/message-replay.test.ts
@@ -641,6 +641,55 @@ describe('KimiTUI resume message replay', () => {
     expect(driver.streamingUI.getToolComponent('call_read_2')).toBeUndefined();
   });
 
+  it('compacts replayed think-only assistant messages', async () => {
+    const driver = await replayIntoDriver([
+      message('user', [{ type: 'text', text: 'think only' }]),
+      message('assistant', [
+        { type: 'think', think: ['line1', 'line2', 'line3', 'line4', 'line5', 'line6', 'line7'].join('\n') },
+      ]),
+    ]);
+
+    const transcript = stripAnsi(driver.state.transcriptContainer.render(120).join('\n'));
+    expect(transcript).toContain('line1');
+    expect(transcript).toContain('line2');
+    expect(transcript).not.toContain('line7');
+    expect(transcript).toContain('... (5 more lines, ctrl+o to expand)');
+    expect(transcript).not.toContain('thought');
+  });
+
+  it('compacts replayed think-only assistant messages before rendering tool calls', async () => {
+    const replay: AgentReplayRecord[] = [
+      message('user', [{ type: 'text', text: 'read after thinking' }]),
+      message(
+        'assistant',
+        [
+          {
+            type: 'think',
+            think: ['line1', 'line2', 'line3', 'line4', 'line5', 'line6', 'line7'].join('\n'),
+          },
+        ],
+        {
+          toolCalls: [
+            toolCall('call_read', 'Read', { file_path: '/tmp/proj-a/src/a.ts' }),
+          ],
+        },
+      ),
+      message('tool', [{ type: 'text', text: 'line a\nline b\n' }], {
+        toolCallId: 'call_read',
+      }),
+    ];
+
+    const driver = await replayIntoDriver(replay);
+    const transcript = stripAnsi(driver.state.transcriptContainer.render(120).join('\n'));
+    expect(transcript).toContain('line1');
+    expect(transcript).toContain('line2');
+    expect(transcript).not.toContain('line7');
+    expect(transcript).toContain('... (5 more lines, ctrl+o to expand)');
+    expect(transcript).toContain('Used Read');
+    expect(transcript).toContain('src');
+    expect(transcript).not.toContain('thought');
+  });
+
   it('renders replayed AgentSwarm calls as compact result summaries', async () => {
     const replay: AgentReplayRecord[] = [
       message('user', [{ type: 'text', text: 'review files with a swarm' }]),

--- a/apps/kimi-code/test/tui/message-replay.test.ts
+++ b/apps/kimi-code/test/tui/message-replay.test.ts
@@ -690,6 +690,40 @@ describe('KimiTUI resume message replay', () => {
     expect(transcript).not.toContain('thought');
   });
 
+  it('compacts replayed thinking before tool calls when text is whitespace-only', async () => {
+    const replay: AgentReplayRecord[] = [
+      message('user', [{ type: 'text', text: 'read after whitespace thinking' }]),
+      message(
+        'assistant',
+        [
+          {
+            type: 'think',
+            think: ['line1', 'line2', 'line3', 'line4', 'line5', 'line6', 'line7'].join('\n'),
+          },
+          { type: 'text', text: '   \n\t' },
+        ],
+        {
+          toolCalls: [
+            toolCall('call_read', 'Read', { file_path: '/tmp/proj-a/src/a.ts' }),
+          ],
+        },
+      ),
+      message('tool', [{ type: 'text', text: 'line a\nline b\n' }], {
+        toolCallId: 'call_read',
+      }),
+    ];
+
+    const driver = await replayIntoDriver(replay);
+    const transcript = stripAnsi(driver.state.transcriptContainer.render(120).join('\n'));
+    expect(transcript).toContain('line1');
+    expect(transcript).toContain('line2');
+    expect(transcript).not.toContain('line7');
+    expect(transcript).toContain('... (5 more lines, ctrl+o to expand)');
+    expect(transcript).toContain('Used Read');
+    expect(transcript).toContain('src');
+    expect(transcript).not.toContain('thought');
+  });
+
   it('renders replayed AgentSwarm calls as compact result summaries', async () => {
     const replay: AgentReplayRecord[] = [
       message('user', [{ type: 'text', text: 'review files with a swarm' }]),


### PR DESCRIPTION
## Summary

When `ThinkingComponent` transitions from live to finalized above the viewport, its line count changes (4→3), triggering pi-tui's destructive `fullRender(true)` which clears the screen and jumps to the top.

**Fix:** Stable transition mechanism — `finalize()` keeps live-format line count, `compact()` defers the reduction to a safe render cycle when assistant content also changes.

## Root Cause

```
finalize() → render lines: 4→3
→ pi-tui: firstChanged < prevViewportTop → fullRender(true) → \x1b[2J → jump to top
```

## Solution

### `thinking.ts` — Stable mode
- `finalize()` enters stable mode: stops spinner, keeps same line shape as live
- `compact()` defers actual line-count reduction, returns boolean
- `render()` uses `mode === 'live' || stableMode` for identical output

### `streaming-ui.ts` — Deferred compaction
- `onThinkingEnd()` → `finalize()` (stable, not compact)
- `compactThinkingIfPending()` called at `onStreamingTextStart()` — both changes in same render cycle
- Fallback in `finalizeTurn()`, cleanup in `resetLiveText()`

### `thinking.test.ts` — Updated + 3 new tests
- Stable mode line count preservation, compact return value, expand/collapse after compact

## Why it works

| Phase | Lines | pi-tui path |
|-------|-------|-------------|
| Live | 4 (stable) | Differential ✓ |
| Thinking ends | 4 (stable) | Differential ✓ |
| Assistant starts | 3 (compact) + new content | fullRender masked by content below |

## Testing
- [x] TypeScript compiles clean
- [x] All 8 tests pass
- [x] Backward compatible (finalized-mode constructor unchanged)

## Related
- Fixes #981
- pi-tui issues: #1950, #1231
