### PR TITLE
ci: disable windows test job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,8 @@ jobs:
 
   test-windows:
     runs-on: windows-latest
+    # Temporarily disabled while Windows tests are being stabilized.
+    if: false
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Related Issue

N/A — no prior issue.

## Problem

Windows CI tests have been failing consistently and blocking merges while the underlying flakiness is being investigated.

## What changed

Disable the `test-windows` job in `.github/workflows/ci.yml` by setting `if: false`. This keeps the job definition in place so it can be re-enabled easily once the failures are resolved, while preventing it from running or blocking PRs in the meantime.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [ ] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.