### PR TITLE
style(kimi-web): unify composer card and toolbar radius with --r-xl token

### DIFF
--- a/.changeset/kimi-toolbar-radius.md
+++ b/.changeset/kimi-toolbar-radius.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Unify the Kimi theme composer card and toolbar bottom radius using the `--r-xl` radius token.

--- a/apps/kimi-web/src/style.css
+++ b/apps/kimi-web/src/style.css
@@ -35,6 +35,7 @@
   --r-sm: 8px;
   --r-md: 12px;
   --r-lg: 16px;
+  --r-xl: 20px;
   --ui-font-size: 14px;
   --ui-font-size-sm: calc(var(--ui-font-size) - 1px);
   --ui-font-size-xs: calc(var(--ui-font-size) - 2px);
@@ -876,8 +877,12 @@ html[data-color-scheme="dark"][data-theme="kimi"] {
 /* Composer: the one card that keeps a shadow (effect.shadow.inputDefault),
    with the chat-input radius documented in web-best-practices §8. */
 html[data-theme="kimi"] .composer-card {
-  border-radius: 20px;
+  border-radius: var(--r-xl);
   box-shadow: 0 5px 16px -4px rgba(0, 0, 0, 0.07);
+}
+
+html[data-theme="kimi"] .toolbar {
+  border-radius: 0 0 var(--r-xl) var(--r-xl);
 }
 
 /* Cards stay flat: no hover lift, no shadow (Quiet Utility / card.md). */

--- a/apps/kimi-web/src/style.css
+++ b/apps/kimi-web/src/style.css
@@ -882,7 +882,7 @@ html[data-theme="kimi"] .composer-card {
 }
 
 html[data-theme="kimi"] .toolbar {
-  border-radius: 0 0 var(--r-xl) var(--r-xl);
+  border-radius: 0 0 calc(var(--r-xl) - 1px) calc(var(--r-xl) - 1px);
 }
 
 /* Cards stay flat: no hover lift, no shadow (Quiet Utility / card.md). */


### PR DESCRIPTION
## Related Issue

N/A — small visual consistency fix.

## Problem

In the Kimi web theme, the composer card used a hard-coded `20px` radius and the
bottom toolbar kept the default `var(--r-md)` radius, so the two edges did not
align visually.

## What changed

- Add `--r-xl: 20px` to the global radius scale.
- Replace the hard-coded composer-card radius with `var(--r-xl)`.
- Give `.toolbar` the same bottom radius in the Kimi theme so its corners match
  the composer card.

|  Before |   After |  
|---|---| 
|<img width="1090" height="665" alt="image" src="https://github.com/user-attachments/assets/17ea5c41-818c-4992-834e-705f50900de1" />| <img width="1090" height="665" alt="image" src="https://github.com/user-attachments/assets/ddc83808-acd3-4b26-809d-f3709302969d" />|

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [ ] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.