### PR TITLE
fix(kimi-web): set rewriteWsOrigin for dev and preview proxy

### DIFF
--- a/.changeset/fix-ws-origin-dev-proxy.md
+++ b/.changeset/fix-ws-origin-dev-proxy.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Fix WebSocket connection failures in the bundled web UI's local dev mode when the browser opens on `localhost` while the server binds `127.0.0.1`.

--- a/apps/kimi-web/vite.config.ts
+++ b/apps/kimi-web/vite.config.ts
@@ -11,6 +11,18 @@ const pkg = JSON.parse(readFileSync(new URL('./package.json', import.meta.url), 
   version: string;
 };
 
+function apiProxyConfig() {
+  return {
+    target: serverTarget,
+    changeOrigin: true,
+    ws: true,
+    // Rewrite the WebSocket Origin header to the upstream target so the
+    // server's same-origin check passes even when the browser opens the dev UI
+    // on `localhost:5175` while the server binds `127.0.0.1`.
+    rewriteWsOrigin: true,
+  };
+}
+
 export default defineConfig({
   plugins: [vue(), tailwindcss()],
   // Expose the dev proxy's upstream server target to the client so the UI can
@@ -26,7 +38,7 @@ export default defineConfig({
     // Same-origin dev: the browser calls Vite, Vite forwards to the server.
     // No CORS anywhere. The real server serves REST + WS all under /api/v1.
     proxy: {
-      '/api/v1': { target: serverTarget, changeOrigin: true, ws: true },
+      '/api/v1': apiProxyConfig(),
     },
   },
   // `vite preview` (the production build served locally) needs the same proxy —
@@ -35,7 +47,7 @@ export default defineConfig({
   preview: {
     port: Number(process.env.WEB_PREVIEW_PORT) || 4175,
     proxy: {
-      '/api/v1': { target: serverTarget, changeOrigin: true, ws: true },
+      '/api/v1': apiProxyConfig(),
     },
   },
   build: {


### PR DESCRIPTION
## Related Issue

Closes #1157

## Problem

When running `pnpm dev:web` and `pnpm dev:server`, the browser opens the web UI at `http://localhost:5175` while the local server binds `127.0.0.1:58627`. The WebSocket upgrade request carries `Origin: http://localhost:5175`, but Vite's dev proxy rewrites the `Host` header to `127.0.0.1:58627`. The server's Origin check treats `localhost` and `127.0.0.1` as different origins and rejects the handshake with 403, causing the web UI to show a persistent "WebSocket error".

## What changed

Set Vite's `rewriteWsOrigin: true` option on the `/api/v1` proxy for both dev and preview modes. This tells Vite to rewrite the WebSocket `Origin` header to match the upstream target origin during the upgrade handshake, so the server's same-origin check passes.

This uses the built-in Vite option added in vitejs/vite#16558 rather than a custom `configure` + `proxyReqWs` handler.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [ ] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [ ] Ran `gen-docs` skill, or this PR needs no doc update.
