### PR TITLE
chore(web): show five sessions per workspace

### DIFF
--- a/.changeset/web-session-initial-page-size.md
+++ b/.changeset/web-session-initial-page-size.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Show the first five sessions per workspace in the web sidebar instead of ten.

--- a/apps/kimi-web/src/composables/client/useWorkspaceState.ts
+++ b/apps/kimi-web/src/composables/client/useWorkspaceState.ts
@@ -287,7 +287,7 @@ export function useWorkspaceState(rawState: ExtendedState, deps: UseWorkspaceSta
   const SESSION_PAGE_SIZE = 100;
   // Sessions fetched per workspace on first load — keeps the initial request
   // count at (number of workspaces) and each response small.
-  const SESSIONS_INITIAL_PAGE_SIZE = 10;
+  const SESSIONS_INITIAL_PAGE_SIZE = 5;
   // Sessions fetched per "load more" click within a workspace.
   const SESSIONS_LOAD_MORE_SIZE = 30;
 


### PR DESCRIPTION
## Related Issue

No linked issue.

## Problem

The web sidebar fetched and showed ten sessions per workspace on first load, which was more than the desired default.

## What changed

- Lowered the web per-workspace initial session page size from 10 to 5.
- Kept the existing "show more" pagination unchanged at 30 sessions per click.
- Added a changeset for the bundled web change.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [ ] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.