### PR TITLE
fix(web): replace the web composer attach plus icon with an image icon

### DIFF
--- a/.changeset/web-composer-image-icon.md
+++ b/.changeset/web-composer-image-icon.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Replace the web composer attach button's plus icon with an image icon.

--- a/apps/kimi-web/src/components/chat/Composer.vue
+++ b/apps/kimi-web/src/components/chat/Composer.vue
@@ -835,7 +835,11 @@ function selectModel(modelId: string): void {
             type="button"
             @click="openFilePicker"
           >
-            <svg class="attach-icon" viewBox="0 0 16 16" width="16" height="16" fill="none" stroke="currentColor" stroke-width="1.2" stroke-linecap="round" stroke-linejoin="round" xmlns="http://www.w3.org/2000/svg"><path d="M8 3v10M3 8h10"/></svg>
+            <svg class="attach-icon" viewBox="0 0 16 16" width="16" height="16" fill="none" stroke="currentColor" stroke-width="1.2" stroke-linecap="round" stroke-linejoin="round" xmlns="http://www.w3.org/2000/svg">
+              <rect x="2" y="3" width="12" height="10" rx="1.5"/>
+              <circle cx="5" cy="6" r="1.2"/>
+              <path d="M2 10.5l3-2.5L8 11l2.5-2L14 11"/>
+            </svg>
           </button>
 
           <!-- Permission pill — click to open dropdown -->


### PR DESCRIPTION
## Related Issue

No linked issue — this is a small web UI polish fix.

## Problem

The web composer's attachment button (used to attach images/videos) rendered a "+" icon, which reads as a generic "add" rather than "attach an image". Its tooltip is already "Attach image", so the icon did not match the action.

## What changed

Swapped the button's inline SVG from a plus sign to an image icon (a rounded picture frame with a small sun and a mountain line), keeping the same 16px size and stroke style as the rest of the toolbar. No behavior or logic changed.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [ ] I have added tests that prove my feature works. (Pure icon swap — no logic to test.)
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update. (Icon-only change, no user-facing docs affected.)
