### PR TITLE
feat(web): preserve side panel and scope input history per session

### DIFF
--- a/.changeset/web-preserve-scroll-position.md
+++ b/.changeset/web-preserve-scroll-position.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Restore each session's scroll position when switching back to it in the web UI.

--- a/.changeset/web-preserve-side-panel.md
+++ b/.changeset/web-preserve-side-panel.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Keep the open side panel when switching between sessions in the web UI.

--- a/.changeset/web-scope-composer-attachments.md
+++ b/.changeset/web-scope-composer-attachments.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Keep unsent composer attachments scoped to their session in the web UI, so switching sessions no longer leaks them into another session's next message.

--- a/.changeset/web-session-input-history.md
+++ b/.changeset/web-session-input-history.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Scope the web composer's up/down input history to the current session instead of sharing it across all sessions.

--- a/apps/kimi-web/src/App.vue
+++ b/apps/kimi-web/src/App.vue
@@ -1,6 +1,6 @@
 <!-- apps/kimi-web/src/App.vue -->
 <script setup lang="ts">
-import { computed, nextTick, onMounted, onUnmounted, provide, ref } from 'vue';
+import { computed, nextTick, onMounted, onUnmounted, provide, ref, watch } from 'vue';
 import { useI18n } from 'vue-i18n';
 import Sidebar from './components/Sidebar.vue';
 import ResizeHandle from './components/ResizeHandle.vue';
@@ -135,6 +135,15 @@ function onGlobalKeydown(e: KeyboardEvent): void {
 // composables can both claim the single right-side slot.
 // ---------------------------------------------------------------------------
 const detailTarget = ref<DetailTarget | null>(null);
+
+// True for one frame while the active session changes: suppresses the right
+// panel's width transition so a restored panel snaps to its width instead of
+// animating open from zero.
+const panelSwitching = ref(false);
+watch(client.activeSessionId, () => {
+  panelSwitching.value = true;
+  void nextTick(() => { panelSwitching.value = false; });
+});
 
 const {
   previewTarget,
@@ -735,7 +744,7 @@ function openPr(url: string): void {
     <aside
       v-if="!isMobile || sidePanelVisible"
       class="global-preview"
-      :class="{ open: sidePanelVisible, mobile: isMobile, 'no-anim': panelDragging }"
+      :class="{ open: sidePanelVisible, mobile: isMobile, 'no-anim': panelDragging || panelSwitching }"
       role="complementary"
       :aria-label="t('layout.detailPanelAria')"
       :aria-hidden="!sidePanelVisible"

--- a/apps/kimi-web/src/components/chat/Composer.vue
+++ b/apps/kimi-web/src/components/chat/Composer.vue
@@ -232,7 +232,7 @@ const {
   handleDragLeave,
   handleDrop,
   clearAfterSubmit,
-} = useAttachmentUpload({ uploadImage: () => props.uploadImage });
+} = useAttachmentUpload({ uploadImage: () => props.uploadImage, sessionId: () => props.sessionId });
 
 // Silence noUnusedLocals: fileInputRef is used as a template ref (ref="fileInputRef").
 void fileInputRef;

--- a/apps/kimi-web/src/components/chat/Composer.vue
+++ b/apps/kimi-web/src/components/chat/Composer.vue
@@ -160,7 +160,7 @@ watch(() => props.sessionId, () => {
 // implementation; the composer keeps the keydown orchestration (which also
 // juggles the slash and mention menus).
 // ---------------------------------------------------------------------------
-const history = useInputHistory({ text, textareaRef, autosize });
+const history = useInputHistory({ text, textareaRef, autosize, sessionId: () => props.sessionId });
 
 // ---------------------------------------------------------------------------
 // Slash-command menu — see useSlashMenu for the implementation. The composer

--- a/apps/kimi-web/src/components/chat/ConversationPane.vue
+++ b/apps/kimi-web/src/components/chat/ConversationPane.vue
@@ -678,13 +678,10 @@ watch(
     const saved = newKey ? scrollStateBySession.get(String(newKey)) : undefined;
     if (saved && el2) {
       following.value = saved.following;
+      el2.scrollTop = saved.top;
+      lastScrollTop = saved.top;
       if (saved.following) {
-        lastScrollTop = 0;
-        scrollToBottom(false);
         scheduleStableFollow();
-      } else {
-        el2.scrollTop = saved.top;
-        lastScrollTop = saved.top;
       }
     } else {
       following.value = true;

--- a/apps/kimi-web/src/components/chat/ConversationPane.vue
+++ b/apps/kimi-web/src/components/chat/ConversationPane.vue
@@ -659,12 +659,29 @@ watch(
   },
 );
 
+// Per-session scroll position: switching back to a session restores where the
+// user was instead of always jumping to the bottom (which replayed the
+// conversation when the session was already at the bottom).
+const scrollTopBySession = new Map<string, number>();
+
 watch(
   () => props.fileReloadKey,
-  async () => {
+  async (newKey, oldKey) => {
+    const el = panesRef.value;
+    if (oldKey && el) {
+      scrollTopBySession.set(String(oldKey), el.scrollTop);
+    }
     following.value = true;
     lastScrollTop = 0;
     await nextTick();
+    const el2 = panesRef.value;
+    const saved = newKey ? scrollTopBySession.get(String(newKey)) : undefined;
+    if (saved !== undefined && el2) {
+      el2.scrollTop = saved;
+      lastScrollTop = saved;
+    } else {
+      scrollToBottom(false);
+    }
     scheduleStableFollow();
     updateTocViewport();
   },

--- a/apps/kimi-web/src/components/chat/ConversationPane.vue
+++ b/apps/kimi-web/src/components/chat/ConversationPane.vue
@@ -659,30 +659,39 @@ watch(
   },
 );
 
-// Per-session scroll position: switching back to a session restores where the
-// user was instead of always jumping to the bottom (which replayed the
-// conversation when the session was already at the bottom).
-const scrollTopBySession = new Map<string, number>();
+// Per-session scroll state: switching back to a session restores both the scroll
+// position and whether the user was following the bottom, instead of always
+// jumping to the bottom (which replayed the conversation when the session was
+// already there) or getting yanked to the bottom by a new message after
+// restoring a scrolled-up position.
+const scrollStateBySession = new Map<string, { top: number; following: boolean }>();
 
 watch(
   () => props.fileReloadKey,
   async (newKey, oldKey) => {
     const el = panesRef.value;
     if (oldKey && el) {
-      scrollTopBySession.set(String(oldKey), el.scrollTop);
+      scrollStateBySession.set(String(oldKey), { top: el.scrollTop, following: following.value });
     }
-    following.value = true;
-    lastScrollTop = 0;
     await nextTick();
     const el2 = panesRef.value;
-    const saved = newKey ? scrollTopBySession.get(String(newKey)) : undefined;
-    if (saved !== undefined && el2) {
-      el2.scrollTop = saved;
-      lastScrollTop = saved;
+    const saved = newKey ? scrollStateBySession.get(String(newKey)) : undefined;
+    if (saved && el2) {
+      following.value = saved.following;
+      if (saved.following) {
+        lastScrollTop = 0;
+        scrollToBottom(false);
+        scheduleStableFollow();
+      } else {
+        el2.scrollTop = saved.top;
+        lastScrollTop = saved.top;
+      }
     } else {
+      following.value = true;
+      lastScrollTop = 0;
       scrollToBottom(false);
+      scheduleStableFollow();
     }
-    scheduleStableFollow();
     updateTocViewport();
   },
 );

--- a/apps/kimi-web/src/composables/useAttachmentUpload.ts
+++ b/apps/kimi-web/src/composables/useAttachmentUpload.ts
@@ -1,5 +1,15 @@
 // apps/kimi-web/src/composables/useAttachmentUpload.ts
-import { onMounted, onUnmounted, ref } from 'vue';
+// Image/video attachment handling for the composer: file picker, paste, drag &
+// drop, the upload machinery, the chip strip, and the preview lightbox.
+//
+// Pending attachments are scoped per session (keyed by session id) so switching
+// sessions can't leak one session's unsent attachments into another session's
+// next submit. The composer keeps `handleSubmit`/`handleSteer` (which read the
+// attachments to build the payload) and the `hasUpload` toolbar flag; this
+// composable owns the attachment state, all the file-input UI handlers, and the
+// paste listener + object-URL cleanup lifecycle.
+
+import { computed, onMounted, onUnmounted, ref, watch } from 'vue';
 
 export interface Attachment {
   /** Unique local id (used as :key) */
@@ -27,21 +37,15 @@ export interface AttachmentUploadDeps {
   /** Upload a blob; resolves to the daemon file id, or null on failure.
       Getter so a prop change is picked up. Undefined disables attaching. */
   uploadImage: () => UploadImage | undefined;
+  /** Active session id — scopes pending attachments (getter for reactivity). */
+  sessionId: () => string | undefined;
 }
 
-/**
- * Image/video attachment handling for the composer: file picker, paste, drag &
- * drop, the upload machinery, the chip strip, and the preview lightbox.
- *
- * The composer keeps `handleSubmit`/`handleSteer` (which read the attachments to
- * build the payload) and the `hasUpload` toolbar flag; this composable owns the
- * attachment state, all the file-input UI handlers, and the paste listener +
- * object-URL cleanup lifecycle.
- */
 export function useAttachmentUpload(deps: AttachmentUploadDeps) {
-  const { uploadImage } = deps;
+  const { uploadImage, sessionId } = deps;
 
-  const attachments = ref<Attachment[]>([]);
+  const attachmentsBySession = ref<Record<string, Attachment[]>>({});
+  const attachments = computed(() => attachmentsBySession.value[sessionId() ?? ''] ?? []);
   const previewAttachment = ref<Attachment | null>(null);
   const fileInputRef = ref<HTMLInputElement | null>(null);
   const isDragOver = ref(false);
@@ -49,6 +53,10 @@ export function useAttachmentUpload(deps: AttachmentUploadDeps) {
   let localIdCounter = 0;
   function nextLocalId(): string {
     return `att_${++localIdCounter}`;
+  }
+
+  function setForSession(sid: string, next: Attachment[]): void {
+    attachmentsBySession.value = { ...attachmentsBySession.value, [sid]: next };
   }
 
   function revokeAttachment(att: Attachment): void {
@@ -64,6 +72,9 @@ export function useAttachmentUpload(deps: AttachmentUploadDeps) {
   async function addFiles(files: File[]): Promise<void> {
     const upload = uploadImage();
     if (!upload) return;
+    // Capture the session at upload time; async completion must update the same
+    // session even if the user has since switched away.
+    const sid = sessionId() ?? '';
     const media = files
       .map((file) => ({ file, kind: mediaKind(file.type) }))
       .filter((m): m is { file: File; kind: 'image' | 'video' } => m.kind !== null);
@@ -73,28 +84,36 @@ export function useAttachmentUpload(deps: AttachmentUploadDeps) {
       const localId = nextLocalId();
       const previewUrl = URL.createObjectURL(file);
       const att: Attachment = { localId, name: file.name, kind, previewUrl, uploading: true };
-      attachments.value = [...attachments.value, att];
+      setForSession(sid, [...(attachmentsBySession.value[sid] ?? []), att]);
 
       // Upload in background; update the attachment when done.
       upload(file, file.name).then((result) => {
-        attachments.value = attachments.value.map((a) =>
-          a.localId === localId
-            ? { ...a, uploading: false, fileId: result?.fileId, error: result === null }
-            : a,
+        const current = attachmentsBySession.value[sid] ?? [];
+        setForSession(
+          sid,
+          current.map((a) =>
+            a.localId === localId
+              ? { ...a, uploading: false, fileId: result?.fileId, error: result === null }
+              : a,
+          ),
         );
       }).catch(() => {
-        attachments.value = attachments.value.map((a) =>
-          a.localId === localId ? { ...a, uploading: false, error: true } : a,
+        const current = attachmentsBySession.value[sid] ?? [];
+        setForSession(
+          sid,
+          current.map((a) => (a.localId === localId ? { ...a, uploading: false, error: true } : a)),
         );
       });
     }
   }
 
   function removeAttachment(localId: string): void {
-    const att = attachments.value.find((a) => a.localId === localId);
+    const sid = sessionId() ?? '';
+    const current = attachmentsBySession.value[sid] ?? [];
+    const att = current.find((a) => a.localId === localId);
     if (previewAttachment.value?.localId === localId) previewAttachment.value = null;
     if (att) revokeAttachment(att);
-    attachments.value = attachments.value.filter((a) => a.localId !== localId);
+    setForSession(sid, current.filter((a) => a.localId !== localId));
   }
 
   function openAttachmentPreview(att: Attachment): void {
@@ -179,23 +198,31 @@ export function useAttachmentUpload(deps: AttachmentUploadDeps) {
     void addFiles(files);
   }
 
-  /** Revoke every object URL and drop all attachments (called after submit/steer). */
+  /** Revoke every object URL and drop all attachments for the current session
+      (called after submit/steer). */
   function clearAfterSubmit(): void {
-    for (const att of attachments.value) {
+    const sid = sessionId() ?? '';
+    for (const att of attachmentsBySession.value[sid] ?? []) {
       revokeAttachment(att);
     }
-    attachments.value = [];
+    setForSession(sid, []);
   }
+
+  // Close the preview lightbox when switching sessions — it may reference an
+  // attachment that belongs to the previous session.
+  watch(sessionId, () => {
+    previewAttachment.value = null;
+  });
 
   onMounted(() => {
     document.addEventListener('paste', handleDocumentPaste);
   });
 
-  // Revoke all object URLs and remove the global listener on unmount.
+  // Revoke all object URLs (every session) and remove the global listener on unmount.
   onUnmounted(() => {
     document.removeEventListener('paste', handleDocumentPaste);
-    for (const att of attachments.value) {
-      revokeAttachment(att);
+    for (const atts of Object.values(attachmentsBySession.value)) {
+      for (const att of atts) revokeAttachment(att);
     }
     previewAttachment.value = null;
   });

--- a/apps/kimi-web/src/composables/useDetailPanel.ts
+++ b/apps/kimi-web/src/composables/useDetailPanel.ts
@@ -261,6 +261,70 @@ export function useDetailPanel({
       transition is disabled so the panel follows the pointer 1:1. */
   const panelDragging = ref(false);
 
+  // ---------------------------------------------------------------------------
+  // Per-session panel snapshot (in-memory only). Switching sessions still closes
+  // the right-side detail layer, but for the transient panels whose content is
+  // re-derived from the session's turns (thinking / compaction / agent /
+  // toolDiff) or already stored per session (btw), we remember which one was
+  // open and restore it when the user switches back.
+  //
+  // File preview ('file') and git diff ('diff') are intentionally excluded:
+  // their content is tied to the active session's cwd / git state and is
+  // re-fetched on demand, so restoring them across sessions would be ambiguous.
+  // ---------------------------------------------------------------------------
+  type PanelSnapshot =
+    | { kind: 'thinking'; turnId: string; blockIndex: number }
+    | { kind: 'compaction'; turnId: string }
+    | { kind: 'agent'; turnId: string; blockIndex: number; memberId: string }
+    | { kind: 'toolDiff'; toolId: string }
+    | { kind: 'btw' };
+
+  const snapshotBySession = ref<Record<string, PanelSnapshot>>({});
+
+  function captureSnapshot(): PanelSnapshot | null {
+    switch (detailTarget.value) {
+      case 'thinking':
+        return thinkingTarget.value ? { kind: 'thinking', ...thinkingTarget.value } : null;
+      case 'compaction':
+        return compactionTarget.value ? { kind: 'compaction', ...compactionTarget.value } : null;
+      case 'agent':
+        return agentTarget.value ? { kind: 'agent', ...agentTarget.value } : null;
+      case 'toolDiff':
+        return toolDiffToolId.value ? { kind: 'toolDiff', toolId: toolDiffToolId.value } : null;
+      case 'btw':
+        return { kind: 'btw' };
+      default:
+        return null;
+    }
+  }
+
+  function restoreSnapshot(snap: PanelSnapshot | undefined): void {
+    if (!snap) return;
+    switch (snap.kind) {
+      case 'thinking':
+        thinkingTarget.value = { turnId: snap.turnId, blockIndex: snap.blockIndex };
+        detailTarget.value = 'thinking';
+        break;
+      case 'compaction':
+        compactionTarget.value = { turnId: snap.turnId };
+        detailTarget.value = 'compaction';
+        break;
+      case 'agent':
+        agentTarget.value = { turnId: snap.turnId, blockIndex: snap.blockIndex, memberId: snap.memberId };
+        detailTarget.value = 'agent';
+        break;
+      case 'toolDiff':
+        toolDiffToolId.value = snap.toolId;
+        detailTarget.value = 'toolDiff';
+        break;
+      case 'btw':
+        // Only re-open the BTW panel if this session still has a live side chat;
+        // the snapshot can outlive it if the user closed the side chat explicitly.
+        if (client.sideChatVisible.value) detailTarget.value = 'btw';
+        break;
+    }
+  }
+
   // Escape closes whichever transient right-side detail panel is open.
   function closeOpenSidePanel(): boolean {
     if (detailTarget.value === 'thinking' && thinkingVisible.value) { closeThinkingPanel(); return true; }
@@ -273,7 +337,15 @@ export function useDetailPanel({
     return false;
   }
 
-  watch(client.activeSessionId, () => {
+  watch(client.activeSessionId, (newId, oldId) => {
+    // Remember the leaving session's open panel (restorable kinds only) before
+    // the close calls below wipe the target refs.
+    if (oldId) {
+      const snap = captureSnapshot();
+      if (snap) snapshotBySession.value[oldId] = snap;
+      else delete snapshotBySession.value[oldId];
+    }
+    // Close everything for the incoming session (unchanged behavior).
     closeFilePreview();
     closeThinkingPanel();
     closeCompactionPanel();
@@ -281,6 +353,10 @@ export function useDetailPanel({
     closeToolDiff();
     closeDiffDetail();
     hideSideChatPanel();
+    // Restore the entering session's panel, if it had one.
+    if (newId) {
+      restoreSnapshot(snapshotBySession.value[newId]);
+    }
   });
 
   return {

--- a/apps/kimi-web/src/composables/useInputHistory.ts
+++ b/apps/kimi-web/src/composables/useInputHistory.ts
@@ -1,15 +1,27 @@
 // apps/kimi-web/src/composables/useInputHistory.ts
-import { nextTick, ref, type Ref } from 'vue';
+// Shell-style ↑/↓ recall of previously sent messages, scoped per session.
+//
+// `ArrowUp` on the first line steps back through older entries sent in the
+// current session; `ArrowDown` walks forward again and ultimately restores the
+// draft the user had before they started browsing. Any manual edit drops out of
+// browsing mode (see `resetBrowsing`, called from the composer's input handler).
+//
+// The history is persisted to localStorage as a `Record<sessionId, string[]>`.
+// A draft session (no id yet — the empty-session composer before its first
+// message is sent) does NOT record history: that first message is submitted
+// before the session exists, so it is intentionally dropped rather than
+// attributed to the wrong session.
+//
+// The composer keeps the keydown orchestration (which also juggles the slash
+// and mention menus); this composable owns only the history map, the browsing
+// cursor, and the textarea caret/selection work needed to apply a recalled
+// entry.
+
+import { computed, nextTick, ref, watch, type Ref } from 'vue';
 import { STORAGE_KEYS, safeGetJson, safeSetJson } from '../lib/storage';
 
-/** Cap the persisted history so storage can't grow without bound. */
-const MAX_HISTORY = 200;
-
-function loadHistory(): string[] {
-  const stored = safeGetJson<unknown>(STORAGE_KEYS.inputHistory);
-  if (!Array.isArray(stored)) return [];
-  return stored.filter((s): s is string => typeof s === 'string' && s.length > 0);
-}
+/** Cap each session's persisted history so storage can't grow without bound. */
+const MAX_HISTORY = 100;
 
 export interface InputHistoryDeps {
   /** The live composer text — recalled entries overwrite it. */
@@ -18,46 +30,56 @@ export interface InputHistoryDeps {
   textareaRef: Ref<HTMLTextAreaElement | null>;
   /** Re-fit the textarea after its text changes. */
   autosize: () => void;
+  /** Active session id — scopes the recalled history (getter for reactivity). */
+  sessionId: () => string | undefined;
 }
 
 /**
- * Shell-style ↑/↓ recall of previously sent messages.
- *
- * `ArrowUp` on the first line steps back through older entries; `ArrowDown`
- * walks forward again and ultimately restores the draft the user had before
- * they started browsing. Any manual edit drops out of browsing mode (see
- * `resetBrowsing`, called from the composer's input handler).
- *
- * The history is persisted to localStorage (one global list). The composer has
- * two mutually-exclusive instances — the empty-session composer and the docked
- * composer — and the first message of a new session is sent by the empty
- * composer, which unmounts as soon as the first turn appears. Persisting (and
- * re-reading on mount) is what lets the docked composer recall that first
- * message instead of starting from an empty list. A single global list also
- * sidesteps the fact that a new session has no id until after the first submit.
- *
- * The composer keeps the keydown orchestration (which also juggles the slash
- * and mention menus); this composable owns only the history list, the browsing
- * cursor, and the textarea caret/selection work needed to apply a recalled
- * entry.
+ * Read the persisted history map, migrating the legacy global `string[]` format
+ * (pre per-session) into the current session on first sight. Migration is
+ * one-shot: once a sessioned map is written, the array branch never runs again.
  */
-export function useInputHistory(deps: InputHistoryDeps) {
-  const { text, textareaRef, autosize } = deps;
+function loadMap(sessionId: string | undefined): Record<string, string[]> {
+  const raw = safeGetJson<unknown>(STORAGE_KEYS.inputHistory);
+  if (Array.isArray(raw)) {
+    const list = raw.filter((s): s is string => typeof s === 'string' && s.length > 0);
+    // No session yet (empty-session composer): leave the legacy value in place
+    // so a later docked mount — which has a session id — can migrate it.
+    if (!sessionId || list.length === 0) return {};
+    const capped = list.length > MAX_HISTORY ? list.slice(-MAX_HISTORY) : list;
+    const map = { [sessionId]: capped };
+    safeSetJson(STORAGE_KEYS.inputHistory, map);
+    return map;
+  }
+  if (raw && typeof raw === 'object') {
+    return raw as Record<string, string[]>;
+  }
+  return {};
+}
 
-  const inputHistory = ref(loadHistory());
-  // -1 = browsing nothing (live draft). Otherwise an index into inputHistory.
+export function useInputHistory(deps: InputHistoryDeps) {
+  const { text, textareaRef, autosize, sessionId } = deps;
+
+  const historyMap = ref<Record<string, string[]>>(loadMap(sessionId()));
+  const currentList = computed(() => historyMap.value[sessionId() ?? ''] ?? []);
+  // -1 = browsing nothing (live draft). Otherwise an index into currentList.
   let historyIndex = -1;
   let draftBeforeHistory = '';
 
   function push(entry: string): void {
-    const trimmed = entry.trim();
+    const sid = sessionId();
     historyIndex = -1;
+    // Draft sessions have no id yet — drop the entry (see file header).
+    if (!sid) return;
+    const trimmed = entry.trim();
     if (!trimmed) return;
+    const list = historyMap.value[sid] ?? [];
     // Skip consecutive duplicates so repeated sends don't pad the history.
-    if (inputHistory.value.at(-1) === trimmed) return;
-    const next = [...inputHistory.value, trimmed];
-    inputHistory.value = next.length > MAX_HISTORY ? next.slice(-MAX_HISTORY) : next;
-    safeSetJson(STORAGE_KEYS.inputHistory, inputHistory.value);
+    if (list.at(-1) === trimmed) return;
+    const next = [...list, trimmed];
+    const capped = next.length > MAX_HISTORY ? next.slice(-MAX_HISTORY) : next;
+    historyMap.value = { ...historyMap.value, [sid]: capped };
+    safeSetJson(STORAGE_KEYS.inputHistory, historyMap.value);
   }
 
   function caretAtFirstLine(): boolean {
@@ -80,23 +102,25 @@ export function useInputHistory(deps: InputHistoryDeps) {
   }
 
   function recallOlder(): void {
-    if (inputHistory.value.length === 0) return;
+    const list = currentList.value;
+    if (list.length === 0) return;
     if (historyIndex === -1) {
       draftBeforeHistory = text.value;
-      historyIndex = inputHistory.value.length - 1;
+      historyIndex = list.length - 1;
     } else if (historyIndex > 0) {
       historyIndex -= 1;
     } else {
       return; // already at the oldest entry
     }
-    applyHistoryText(inputHistory.value[historyIndex]!);
+    applyHistoryText(list[historyIndex]!);
   }
 
   function recallNewer(): void {
     if (historyIndex === -1) return;
-    if (historyIndex < inputHistory.value.length - 1) {
+    const list = currentList.value;
+    if (historyIndex < list.length - 1) {
       historyIndex += 1;
-      applyHistoryText(inputHistory.value[historyIndex]!);
+      applyHistoryText(list[historyIndex]!);
     } else {
       historyIndex = -1;
       applyHistoryText(draftBeforeHistory);
@@ -112,8 +136,14 @@ export function useInputHistory(deps: InputHistoryDeps) {
   }
 
   function hasHistory(): boolean {
-    return inputHistory.value.length > 0;
+    return currentList.value.length > 0;
   }
+
+  // Switching sessions: drop the browsing cursor so a recall in the new session
+  // starts from its own latest entry, not wherever the previous session left off.
+  watch(sessionId, () => {
+    historyIndex = -1;
+  });
 
   return {
     push,

--- a/apps/kimi-web/test/attachment-upload.test.ts
+++ b/apps/kimi-web/test/attachment-upload.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { ref } from 'vue';
 import { useAttachmentUpload, type Attachment } from '../src/composables/useAttachmentUpload';
 
 // The composable registers its paste listener and cleanup via onMounted /
@@ -15,8 +16,8 @@ type UploadImage = (
   name?: string,
 ) => Promise<{ fileId: string; name: string; mediaType: string } | null>;
 
-function setup(uploadImage?: UploadImage) {
-  return useAttachmentUpload({ uploadImage: () => uploadImage });
+function setup(uploadImage?: UploadImage, sessionId: string | null = 'test-session') {
+  return useAttachmentUpload({ uploadImage: () => uploadImage, sessionId: () => sessionId ?? undefined });
 }
 
 function imageFile(name: string): File {
@@ -106,5 +107,28 @@ describe('useAttachmentUpload', () => {
     att.clearAfterSubmit();
     expect(att.attachments.value).toHaveLength(0);
     expect(revokeObjectURL).toHaveBeenCalledTimes(2);
+  });
+
+  it('isolates attachments between sessions', () => {
+    const uploadImage = vi.fn<UploadImage>().mockResolvedValue(null);
+    const sessionId = ref<string | undefined>('sess-a');
+    const att = useAttachmentUpload({ uploadImage: () => uploadImage, sessionId: () => sessionId.value });
+
+    att.handleFileInputChange(inputEvent([imageFile('a.png')]));
+    expect(att.attachments.value).toHaveLength(1);
+
+    // Switch to session B — A's attachment must not show up here.
+    sessionId.value = 'sess-b';
+    expect(att.attachments.value).toHaveLength(0);
+    att.handleFileInputChange(inputEvent([imageFile('b.png')]));
+    expect(att.attachments.value).toHaveLength(1);
+
+    // Switch back to A — its attachment is still there.
+    sessionId.value = 'sess-a';
+    expect(att.attachments.value).toHaveLength(1);
+    expect(att.attachments.value[0].name).toBe('a.png');
+
+    // B's attachment is gone from A's view.
+    expect(att.attachments.value.map((a) => a.name)).not.toContain('b.png');
   });
 });

--- a/apps/kimi-web/test/input-history.test.ts
+++ b/apps/kimi-web/test/input-history.test.ts
@@ -10,7 +10,7 @@ interface MockTextarea {
   setSelectionRange: (start: number, end: number) => void;
 }
 
-function setup(initialText = '', caret = 0) {
+function setup(initialText = '', caret = 0, sessionId: string | null = 'test-session') {
   const textarea: MockTextarea = {
     value: initialText,
     selectionStart: caret,
@@ -22,7 +22,7 @@ function setup(initialText = '', caret = 0) {
   };
   const text = ref(initialText);
   const textareaRef = ref(textarea as unknown as HTMLTextAreaElement) as Ref<HTMLTextAreaElement | null>;
-  const history = useInputHistory({ text, textareaRef, autosize: () => {} });
+  const history = useInputHistory({ text, textareaRef, autosize: () => {}, sessionId: () => sessionId ?? undefined });
   return { text, textarea, history };
 }
 
@@ -53,6 +53,12 @@ describe('useInputHistory — push', () => {
     expect(text.value).toBe('a');
     history.recallOlder(); // already oldest — must stay, not land on a second 'a'
     expect(text.value).toBe('a');
+  });
+
+  it('drops entries pushed without a session (draft / empty composer)', () => {
+    const { history } = setup('', 0, null);
+    history.push('hello');
+    expect(history.hasHistory()).toBe(false);
   });
 });
 
@@ -180,11 +186,11 @@ describe('useInputHistory — persistence', () => {
     }
   });
 
-  it('writes each pushed entry to localStorage', () => {
+  it('writes each pushed entry to localStorage under its session', () => {
     const { history } = setup();
     history.push('hello');
     const stored = globalThis.localStorage.getItem(STORAGE_KEYS.inputHistory);
-    expect(stored).toBe(JSON.stringify(['hello']));
+    expect(stored).toBe(JSON.stringify({ 'test-session': ['hello'] }));
   });
 
   it('a freshly mounted composable reads back the persisted history', () => {
@@ -200,12 +206,30 @@ describe('useInputHistory — persistence', () => {
     expect(second.text.value).toBe('a');
   });
 
-  it('trims to the newest 200 entries, dropping the oldest', () => {
+  it('keeps histories of different sessions isolated', () => {
+    const a = setup('', 0, 'sess-a');
+    a.history.push('from-a');
+    const b = setup('', 0, 'sess-b');
+    b.history.push('from-b');
+
+    // Re-mount each session and confirm each only recalls its own entry.
+    const a2 = setup('', 0, 'sess-a');
+    a2.history.recallOlder();
+    expect(a2.text.value).toBe('from-a');
+    a2.history.recallOlder(); // no older entry — must stay
+    expect(a2.text.value).toBe('from-a');
+
+    const b2 = setup('', 0, 'sess-b');
+    b2.history.recallOlder();
+    expect(b2.text.value).toBe('from-b');
+  });
+
+  it('trims to the newest 100 entries, dropping the oldest', () => {
     const { text, history } = setup();
-    for (let i = 0; i < 205; i++) history.push(`m${i}`);
+    for (let i = 0; i < 105; i++) history.push(`m${i}`);
 
     // Walk all the way back; the oldest kept entry must be m5 (m0..m4 dropped).
-    for (let i = 0; i < 200; i++) history.recallOlder();
+    for (let i = 0; i < 100; i++) history.recallOlder();
     expect(text.value).toBe('m5');
     history.recallOlder(); // already at the oldest kept entry — must not move
     expect(text.value).toBe('m5');
@@ -215,5 +239,27 @@ describe('useInputHistory — persistence', () => {
     globalThis.localStorage.setItem(STORAGE_KEYS.inputHistory, 'not-json');
     const { history } = setup();
     expect(history.hasHistory()).toBe(false);
+  });
+
+  it('migrates a legacy global array into the current session once', () => {
+    globalThis.localStorage.setItem(STORAGE_KEYS.inputHistory, JSON.stringify(['old1', 'old2']));
+    const { text, history } = setup('', 0, 'sess-x');
+    history.recallOlder(); // -> old2
+    expect(text.value).toBe('old2');
+    history.recallOlder(); // -> old1
+    expect(text.value).toBe('old1');
+    // Persisted in the new map format under the current session.
+    const stored = JSON.parse(globalThis.localStorage.getItem(STORAGE_KEYS.inputHistory)!);
+    expect(stored).toEqual({ 'sess-x': ['old1', 'old2'] });
+  });
+
+  it('leaves the legacy array untouched when mounted without a session', () => {
+    globalThis.localStorage.setItem(STORAGE_KEYS.inputHistory, JSON.stringify(['old1']));
+    const { history } = setup('', 0, null);
+    expect(history.hasHistory()).toBe(false);
+    // A later docked mount (with a session id) can still migrate it.
+    const { text, history: docked } = setup('', 0, 'sess-y');
+    docked.recallOlder();
+    expect(text.value).toBe('old1');
   });
 });


### PR DESCRIPTION
## Related Issue

No related issue — these are small UX improvements to the web UI, explained below.

## Problem

Two related session-scoping issues in the web UI:

1. **Open panels are lost on session switch.** Switching to another session closes whatever side panel was open (thinking, agent, tool diff, side chat, etc.). Coming back to the session means reopening it by hand.
2. **Input history leaks across sessions.** The composer's `↑`/`↓` input history is one global list, so prompts sent in session A show up when browsing history in session B.

## What changed

- **Preserve the open side panel per session.** On session switch, snapshot the leaving session's open panel (thinking / compaction / agent / tool diff / side chat) and restore it when switching back. File preview and git diff are intentionally left out — their content depends on the active session's cwd / git state and is re-fetched on demand.
- **Scope input history to the current session.** Store history as `Record<sessionId, string[]>` (capped at 100 per session) instead of a single global list. Draft sessions (no id yet) do not record; the existing global history is migrated into the current session on first load.

Both changes are web-only and ship via the bundled CLI artifact, so the changesets list `@moonshot-ai/kimi-code`.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.
