### PR TITLE
refactor: standardize telemetry property names

### DIFF
--- a/apps/kimi-code/src/cli/run-prompt.ts
+++ b/apps/kimi-code/src/cli/run-prompt.ts
@@ -78,10 +78,10 @@ export async function runPrompt(
     telemetry: telemetryClient,
     onOAuthRefresh: (outcome) => {
       if (outcome.success) {
-        track('oauth_refresh', { success: true });
+        track('oauth_refresh', { outcome: 'success' });
         return;
       }
-      track('oauth_refresh', { success: false, reason: outcome.reason });
+      track('oauth_refresh', { outcome: 'error', reason: outcome.reason });
     },
     sessionStartedProperties: { yolo: false, plan: false, afk: true },
   });
@@ -153,7 +153,7 @@ export async function runPrompt(
     writeResumeHint(session.id, outputFormat, stdout, stderr);
 
     withTelemetryContext({ sessionId: session.id }).track('exit', {
-      duration_s: (Date.now() - startedAt) / 1000,
+      duration_ms: Date.now() - startedAt,
     });
   } finally {
     await cleanupPromptRun();

--- a/apps/kimi-code/src/cli/run-shell.ts
+++ b/apps/kimi-code/src/cli/run-shell.ts
@@ -64,11 +64,11 @@ export async function runShell(
     telemetry: telemetryClient,
     onOAuthRefresh: (outcome) => {
       if (outcome.success) {
-        track('oauth_refresh', { success: true });
+        track('oauth_refresh', { outcome: 'success' });
         return;
       }
       track('oauth_refresh', {
-        success: false,
+        outcome: 'error',
         reason: outcome.reason,
       });
     },
@@ -137,7 +137,7 @@ export async function runShell(
     const sessionId = tui.getCurrentSessionId();
     const hasContent = tui.hasSessionContent();
     setCrashPhase('shutdown');
-    trackLifecycle('exit', { duration_s: (Date.now() - startedAt) / 1000 });
+    trackLifecycle('exit', { duration_ms: Date.now() - startedAt });
     await shutdownTelemetry({ timeoutMs: CLI_SHUTDOWN_TIMEOUT_MS });
     const gutter = ' '.repeat(CHROME_GUTTER);
     process.stdout.write(`${gutter}Bye!\n`);
@@ -172,7 +172,7 @@ export async function runShell(
     });
   } catch (error) {
     setCrashPhase('shutdown');
-    trackLifecycle('exit', { duration_s: (Date.now() - startedAt) / 1000 });
+    trackLifecycle('exit', { duration_ms: Date.now() - startedAt });
     await shutdownTelemetry({ timeoutMs: CLI_SHUTDOWN_TIMEOUT_MS });
     await harness.close();
     throw error;

--- a/apps/kimi-code/test/cli/run-shell.test.ts
+++ b/apps/kimi-code/test/cli/run-shell.test.ts
@@ -398,13 +398,13 @@ describe('runShell', () => {
     harnessOptions.onOAuthRefresh({ success: false, reason: 'unauthorized' });
     harnessOptions.onOAuthRefresh({ success: false, reason: 'network_or_other' });
 
-    expect(mocks.telemetryTrack).toHaveBeenCalledWith('oauth_refresh', { success: true });
+    expect(mocks.telemetryTrack).toHaveBeenCalledWith('oauth_refresh', { outcome: 'success' });
     expect(mocks.telemetryTrack).toHaveBeenCalledWith('oauth_refresh', {
-      success: false,
+      outcome: 'error',
       reason: 'unauthorized',
     });
     expect(mocks.telemetryTrack).toHaveBeenCalledWith('oauth_refresh', {
-      success: false,
+      outcome: 'error',
       reason: 'network_or_other',
     });
   });
@@ -505,7 +505,7 @@ describe('runShell', () => {
     ).rejects.toThrow('boom');
 
     expect(mocks.setCrashPhase).toHaveBeenCalledWith('shutdown');
-    expect(mocks.harnessTrack).toHaveBeenCalledWith('exit', { duration_s: expect.any(Number) });
+    expect(mocks.harnessTrack).toHaveBeenCalledWith('exit', { duration_ms: expect.any(Number) });
     expect(mocks.shutdownTelemetry).toHaveBeenCalledOnce();
     expect(mocks.harnessClose).toHaveBeenCalledOnce();
   });
@@ -551,7 +551,7 @@ describe('runShell', () => {
       expect(mocks.setCrashPhase).toHaveBeenCalledWith('shutdown');
       expect(mocks.withTelemetryContext).toHaveBeenCalledWith({ sessionId: 'ses-1' });
       expect(mocks.lifecycleTrack).toHaveBeenCalledWith('exit', {
-        duration_s: expect.any(Number),
+        duration_ms: expect.any(Number),
       });
       expect(mocks.harnessTrack).not.toHaveBeenCalledWith('exit', expect.anything());
       expect(mocks.shutdownTelemetry).toHaveBeenCalledOnce();

--- a/packages/agent-core/src/agent/background/index.ts
+++ b/packages/agent-core/src/agent/background/index.ts
@@ -237,7 +237,7 @@ export class BackgroundManager {
     this.agent.emitEvent({ type: 'background.task.terminated', info });
     this.agent.telemetry.track('background_task_completed', {
       kind: info.kind,
-      duration: info.endedAt !== null ? info.endedAt - info.startedAt : null,
+      duration_ms: info.endedAt !== null ? info.endedAt - info.startedAt : null,
       status: info.status,
     });
   }

--- a/packages/agent-core/src/agent/compaction/full.ts
+++ b/packages/agent-core/src/agent/compaction/full.ts
@@ -416,7 +416,7 @@ export class FullCompaction {
       this.agent.telemetry.track('compaction_finished', {
         tokensBefore: result.tokensBefore,
         tokensAfter: result.tokensAfter,
-        duration: Date.now() - startedAt,
+        duration_ms: Date.now() - startedAt,
         compactedCount: result.compactedCount,
         retryCount,
         round,
@@ -431,7 +431,7 @@ export class FullCompaction {
       this.agent.telemetry.track('compaction_failed', {
         ...data,
         tokensBefore,
-        duration: Date.now() - startedAt,
+        duration_ms: Date.now() - startedAt,
         round,
         retryCount,
         thinkingLevel: this.agent.config.thinkingLevel,

--- a/packages/agent-core/src/agent/tool/index.ts
+++ b/packages/agent-core/src/agent/tool/index.ts
@@ -559,13 +559,13 @@ export class ToolManager {
       };
       try {
         const part = await upload(input);
-        track({ ...base, success: true, latency_ms: Date.now() - startedAt });
+        track({ ...base, outcome: 'success', duration_ms: Date.now() - startedAt });
         return part;
       } catch (error) {
         track({
           ...base,
-          success: false,
-          latency_ms: Date.now() - startedAt,
+          outcome: 'error',
+          duration_ms: Date.now() - startedAt,
           error: error instanceof Error ? error.message : String(error),
         });
         throw error;
@@ -574,7 +574,7 @@ export class ToolManager {
   }
 
   private videoUploadTelemetryProps(modelAlias: string): {
-    type?: string;
+    provider_type?: string;
     protocol?: string;
     model: string;
   } {
@@ -583,7 +583,7 @@ export class ToolManager {
       if (resolved === undefined) return { model: modelAlias };
       return {
         model: modelAlias,
-        type: resolved.type,
+        provider_type: resolved.type,
         protocol: resolved.protocol ?? resolved.type,
       };
     } catch {

--- a/packages/agent-core/src/agent/turn/index.ts
+++ b/packages/agent-core/src/agent/turn/index.ts
@@ -936,14 +936,14 @@ export class TurnFlow {
    * turn over an unresolvable provider config (the step loop will surface that
    * error on its own).
    */
-  private requestProtocolProps(): { type?: string; protocol?: string } {
+  private requestProtocolProps(): { provider_type?: string; protocol?: string } {
     const model = this.agent.config.modelAlias;
     if (model === undefined) return {};
     try {
       const resolved = this.agent.modelProvider?.resolveProviderConfig(model);
       if (resolved === undefined) return {};
       return {
-        type: resolved.type,
+        provider_type: resolved.type,
         protocol: resolved.protocol ?? resolved.type,
       };
     } catch {

--- a/packages/agent-core/test/agent/background/rpc-events.test.ts
+++ b/packages/agent-core/test/agent/background/rpc-events.test.ts
@@ -150,10 +150,37 @@ describe('BackgroundManager — event emission', () => {
       'background_task_completed',
       expect.objectContaining({
         kind: 'process',
-        duration: expect.any(Number),
+        duration_ms: expect.any(Number),
         status: 'completed',
       }),
     );
+  });
+
+  it('sends null duration_ms when a terminal task has no endedAt', () => {
+    const { agent, manager } = createBackgroundManager();
+    agent.telemetry.track.mockClear();
+
+    const info: BackgroundTaskInfo = {
+      taskId: 'task-1',
+      description: 'lost task',
+      status: 'lost',
+      kind: 'process',
+      command: 'sleep 60',
+      pid: 123,
+      exitCode: null,
+      startedAt: 100,
+      endedAt: null,
+    };
+
+    (manager as unknown as { emitTaskTerminated: (info: BackgroundTaskInfo) => void }).emitTaskTerminated(
+      info,
+    );
+
+    const trackCall = agent.telemetry.track.mock.calls.find(
+      (call) => call[0] === 'background_task_completed',
+    );
+    expect(trackCall?.[1]).toMatchObject({ kind: 'process', status: 'lost' });
+    expect(trackCall?.[1]?.duration_ms).toBeNull();
   });
 
   it('tracks failed and timed-out terminal statuses', async () => {

--- a/packages/agent-core/test/agent/compaction/full.test.ts
+++ b/packages/agent-core/test/agent/compaction/full.test.ts
@@ -238,7 +238,7 @@ describe('FullCompaction', () => {
         instruction: 'Keep the important test facts.',
         tokensBefore: 39,
         tokensAfter: 5,
-        duration: expect.any(Number),
+        duration_ms: expect.any(Number),
         compactedCount: 6,
         retryCount: 0,
         thinkingLevel: 'off',
@@ -765,7 +765,7 @@ describe('FullCompaction', () => {
       properties: expect.objectContaining({
         source: 'manual',
         tokensBefore: 25,
-        duration: expect.any(Number),
+        duration_ms: expect.any(Number),
         round: 1,
         retryCount: 0,
         errorType: 'Error',
@@ -879,7 +879,7 @@ describe('FullCompaction', () => {
       properties: expect.objectContaining({
         source: 'manual',
         tokensBefore: 25,
-        duration: expect.any(Number),
+        duration_ms: expect.any(Number),
         retryCount: 4,
         errorType: 'APIConnectionError',
       }),


### PR DESCRIPTION
## Related Issue

No related issue — this is an internal telemetry-schema consistency cleanup.

## Problem

Telemetry property names had drifted across events. A handful of events used their own conventions while the rest of the codebase had settled on a different set:

- Durations were split across `duration`, `duration_s` (seconds), and `latency_ms`, even though the dominant convention is `duration_ms` (used by `tool_call`, `api_error`, `permission_approval_result`, `startup_perf`, etc.).
- Success/failure was reported as a `success` boolean on `oauth_refresh` and `video_upload`, while `tool_call` and the plan events report an `outcome` enum (`'success' | 'error' | ...`).
- The provider kind was emitted as a bare `type` on `turn_started` and `video_upload`, instead of the `*_type` suffix used by `error_type`, `dup_type`, etc.

This made the schema harder to reason about and to query consistently across events.

## What changed

Renamed the outlier properties to match the established conventions:

- `duration` / `duration_s` / `latency_ms` → `duration_ms` (`background_task_completed`, `compaction_finished`, `compaction_failed`, `video_upload`, `exit`)
- `success: true/false` → `outcome: 'success' | 'error'` (`oauth_refresh`, `video_upload`)
- `type` → `provider_type` (`turn_started`, `video_upload`)

One semantic change worth calling out: the `exit` event previously reported `duration_s` in **seconds** (`(Date.now() - startedAt) / 1000`) and now reports `duration_ms` in **milliseconds**, so its numeric scale changes by 1000×. Confirmed there are no downstream dashboards/alerts depending on the old field names or the second-scale value, so no migration is needed.

All affected tests were updated, and one new test was added to cover the `duration_ms: null` branch for terminal background tasks that have no `endedAt` (a "lost" task). A full-repo sweep confirms no `latency_ms`, `duration_s`, telemetry `success` booleans, or bare telemetry `type` properties remain.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset. *(No changeset — telemetry-only change per repository convention.)*
- [x] Ran `gen-docs` skill, or this PR needs no doc update. *(No doc update — no user-facing behavior change.)*
