### PR TITLE
fix(tui): stop full-screen redraw on input and slash panel toggle

### DIFF
--- a/.changeset/fix-tui-redraw-flash.md
+++ b/.changeset/fix-tui-redraw-flash.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Fix unnecessary full-screen redraws when typing in the input box or toggling the slash panel.

--- a/apps/kimi-code/src/tui/tui-state.ts
+++ b/apps/kimi-code/src/tui/tui-state.ts
@@ -60,11 +60,6 @@ export function createTUIState(options: KimiTUIOptions): TUIState {
 
   const terminal = new ProcessTerminal();
   const ui = new TUI(terminal);
-  // Content shrinks (e.g. a tall inline image is replaced by a short
-  // placeholder or text) can leave stale rows behind because pi-tui's
-  // differential renderer does not clear them by default. Enable clearing so
-  // artifacts like duplicated input boxes do not accumulate.
-  ui.setClearOnShrink(true);
 
   const transcriptContainer = new GutterContainer(CHROME_GUTTER, CHROME_GUTTER);
   const activityContainer = new GutterContainer(CHROME_GUTTER, CHROME_GUTTER);


### PR DESCRIPTION
## Related Issue

fixed https://github.com/MoonshotAI/kimi-code/issues/1180
fixed https://github.com/MoonshotAI/kimi-code/issues/1117

## Problem

Since 0.19.2, the TUI flashes with a full-screen redraw on trivial input: typing a couple of characters in the input box, or opening then closing the slash panel. The whole screen clears and repaints instead of doing a cheap incremental update.

Root cause: the terminal renderer was running with global clear-on-shrink enabled (introduced in #1028). Its differential renderer then treats any content shrink as a reason to clear the whole screen and repaint. Because the slash autocomplete is rendered inline, opening it raises the high-water line count and filtering or closing it drops below it, so typing `/` plus another character, or swapping a tall panel back for the shorter input box, reliably triggers a full clear.

## What changed

Removed the global clear-on-shrink setting so these actions go back to incremental renders.

Trade-off: this knowingly reverts the part of #1028 that cleared stale rows when tall inline images shrink, so duplicated input boxes / stale rows may occasionally reappear after an inline image collapses. That edge case is rarer and less disruptive than the constant redraw flash; if it resurfaces, it should be handled with a targeted clear at the image-removal point rather than a global setting.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works (N/A — one-line removal of a renderer setting; verified manually and via lint).
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update (N/A — no user-facing doc change).
