### PR TITLE
fix(tui): keep working tips out of the agent swarm progress line

### DIFF
--- a/.changeset/fix-working-tips-swarm.md
+++ b/.changeset/fix-working-tips-swarm.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Fix working tips getting squeezed against the agent swarm progress bar.

--- a/apps/kimi-code/src/tui/components/chrome/moon-loader.ts
+++ b/apps/kimi-code/src/tui/components/chrome/moon-loader.ts
@@ -20,6 +20,12 @@ export class MoonLoader extends Text {
   private colorFn?: (s: string) => string;
   private label: string;
   private displayText = '';
+  // Inline text used when the spinner is embedded into another line (e.g. the
+  // agent-swarm progress status line). It intentionally excludes the tip: the
+  // tip is only rendered when the loader sits on its own row in the activity
+  // pane, otherwise it would get squeezed against whatever follows the inline
+  // spinner (like the swarm progress bar).
+  private inlineText = '';
   private tip: string = '';
   private availableWidth = 0;
 
@@ -75,13 +81,14 @@ export class MoonLoader extends Text {
   }
 
   renderInline(): string {
-    return this.displayText;
+    return this.inlineText;
   }
 
   private updateDisplay(): void {
     const frame = this.frames[this.currentFrame]!;
     const coloredFrame = this.colorFn ? this.colorFn(frame) : frame;
     const baseText = this.label ? `${coloredFrame} ${this.label}` : coloredFrame;
+    this.inlineText = baseText;
     let text = baseText;
     if (this.tip) {
       const withTip = baseText + currentTheme.fg('textDim', this.tip);

--- a/apps/kimi-code/test/tui/components/chrome/moon-loader.test.ts
+++ b/apps/kimi-code/test/tui/components/chrome/moon-loader.test.ts
@@ -1,0 +1,31 @@
+import type { TUI } from '@earendil-works/pi-tui';
+import { describe, expect, it } from 'vitest';
+
+import { MoonLoader } from '#/tui/components/chrome/moon-loader';
+
+function createLoader(): MoonLoader {
+  const ui = { requestRender() {} } as unknown as TUI;
+  return new MoonLoader(ui, 'moon');
+}
+
+describe('MoonLoader', () => {
+  it('keeps the tip out of renderInline so it does not squeeze against the swarm progress bar', () => {
+    const loader = createLoader();
+    loader.setTip(' · Tip: ctrl+s: steer mid-turn');
+    loader.setAvailableWidth(80);
+
+    const inline = loader.renderInline();
+    expect(inline).not.toContain('Tip');
+    expect(inline).not.toContain('steer');
+    expect(inline.trim().length).toBeGreaterThan(0);
+  });
+
+  it('still shows the tip on its own row when width allows', () => {
+    const loader = createLoader();
+    loader.setTip(' · Tip: ctrl+s: steer mid-turn');
+    loader.setAvailableWidth(80);
+
+    const row = loader.render(80).join('\n');
+    expect(row).toContain('Tip: ctrl+s: steer mid-turn');
+  });
+});

--- a/apps/kimi-code/test/tui/components/chrome/moon-loader.test.ts
+++ b/apps/kimi-code/test/tui/components/chrome/moon-loader.test.ts
@@ -1,12 +1,23 @@
 import type { TUI } from '@earendil-works/pi-tui';
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it } from 'vitest';
 
 import { MoonLoader } from '#/tui/components/chrome/moon-loader';
 
+// MoonLoader starts a real setInterval in its constructor, so every loader
+// created in these tests must be stopped to avoid leaving live timers behind.
+const loaders: MoonLoader[] = [];
+
 function createLoader(): MoonLoader {
   const ui = { requestRender() {} } as unknown as TUI;
-  return new MoonLoader(ui, 'moon');
+  const loader = new MoonLoader(ui, 'moon');
+  loaders.push(loader);
+  return loader;
 }
+
+afterEach(() => {
+  for (const loader of loaders) loader.stop();
+  loaders.length = 0;
+});
 
 describe('MoonLoader', () => {
   it('keeps the tip out of renderInline so it does not squeeze against the swarm progress bar', () => {


### PR DESCRIPTION
## Related Issue

N/A — reported directly, no tracking issue.

## Problem

Working tips are shown after the moon loader. In agent swarm mode the moon loader moves up into the swarm progress status line, which is immediately followed by the progress bar. Because the tip was written into the shared loader, it leaked into that status line and got squeezed against the progress bar.

## What changed

Keep the inline spinner text used by the agent swarm progress line free of tips. The loader still renders the tip on its own row in the activity pane, so non-swarm behavior is unchanged. Added a unit test covering both the inline (no tip) and own-row (with tip) cases.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.