### PR TITLE
chore(changeset): mark web completion sound as patch

### DIFF
--- a/.changeset/web-completion-sound.md
+++ b/.changeset/web-completion-sound.md
@@ -1,5 +1,5 @@
 ---
-"@moonshot-ai/kimi-code": minor
+"@moonshot-ai/kimi-code": patch
 ---
 
 Add a completion sound and question notifications to the web UI, with separate Settings toggles for completion notifications, question notifications, and sound. Question notifications default off so question text only reaches your desktop after you opt in.


### PR DESCRIPTION
## Related Issue

N/A — changeset metadata correction.

## Problem

The web completion sound / question notifications feature was tagged as a `minor` bump in its changeset, but it is a small additive UX enhancement (completion sound plus opt-in question notifications) that better fits a `patch`-level release. Keeping it as `minor` would overstate the scope of the change in the next release.

## What changed

- Changed the bump level in `.changeset/web-completion-sound.md` from `minor` to `patch`.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [ ] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.
