### PR TITLE
fix: render provider HTML error messages instead of blank lines

### DIFF
--- a/.changeset/fix-html-error-message-rendering.md
+++ b/.changeset/fix-html-error-message-rendering.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Fix provider error messages rendering as blank lines in the TUI when the server returns an HTML error page.

--- a/apps/kimi-code/src/tui/components/messages/status-message.ts
+++ b/apps/kimi-code/src/tui/components/messages/status-message.ts
@@ -30,12 +30,16 @@ export class StatusMessageComponent extends Container {
 
   // Indent every line, not just the first. The `content` may be multi-line
   // (e.g. `!` shell output); prefixing the whole string once would only indent
-  // the first line and leave the rest at column 0.
+  // the first line and leave the rest at column 0. Strip carriage returns
+  // first: a trailing `\r` (e.g. from CRLF server error pages) is zero-width
+  // for the line wrapper, so the padding spaces appended after it overwrite
+  // the visible content and the line renders blank.
   private renderText(): string {
-    const colored = this.color === undefined
-      ? currentTheme.fg('textDim', this.content)
-      : currentTheme.fg(this.color, this.content);
-    return colored.split('\n').map((line) => `  ${line}`).join('\n');
+    const colored =
+      this.color === undefined
+        ? currentTheme.fg('textDim', this.content)
+        : currentTheme.fg(this.color, this.content);
+    return colored.replaceAll('\r', '').split('\n').map((line) => `  ${line}`).join('\n');
   }
 }
 

--- a/apps/kimi-code/test/tui/components/messages/notice.test.ts
+++ b/apps/kimi-code/test/tui/components/messages/notice.test.ts
@@ -2,7 +2,10 @@ import { visibleWidth } from '@earendil-works/pi-tui';
 import { describe, expect, it } from 'vitest';
 
 import { CronMessageComponent } from '#/tui/components/messages/cron-message';
-import { NoticeMessageComponent } from '#/tui/components/messages/status-message';
+import {
+  NoticeMessageComponent,
+  StatusMessageComponent,
+} from '#/tui/components/messages/status-message';
 
 function strip(text: string): string {
   return text.replaceAll(/\u001B\[[0-9;]*m/g, '');
@@ -37,5 +40,21 @@ describe('CronMessageComponent', () => {
         expect(visibleWidth(line)).toBeLessThanOrEqual(width);
       }
     }
+  });
+});
+
+describe('StatusMessageComponent', () => {
+  it('strips carriage returns so a CRLF line does not render blank', () => {
+    // A trailing `\r` (e.g. from a CRLF server error page) is zero-width for
+    // the line wrapper, so padding spaces appended after it would otherwise
+    // overwrite the visible content. The status component strips `\r`.
+    const component = new StatusMessageComponent('Error: boom\r\nmore\r', 'error');
+    const text = component
+      .render(120)
+      .map((line) => strip(line))
+      .join('\n');
+    expect(text).toContain('Error: boom');
+    expect(text).toContain('more');
+    expect(text).not.toContain('\r');
   });
 });

--- a/packages/agent-core/src/errors/serialize.ts
+++ b/packages/agent-core/src/errors/serialize.ts
@@ -84,7 +84,7 @@ export function toKimiErrorPayload(error: unknown): KimiErrorPayload {
           : ErrorCodes.PROVIDER_API_ERROR;
     return {
       code,
-      message: error.message,
+      message: sanitizeStatusErrorMessage(error.message),
       name: error.name,
       details: {
         statusCode: error.statusCode,
@@ -139,6 +139,22 @@ export function toKimiErrorPayload(error: unknown): KimiErrorPayload {
     message: String(error),
     retryable: KIMI_ERROR_INFO[ErrorCodes.INTERNAL].retryable,
   };
+}
+
+/**
+ * Provider status errors occasionally carry an HTML body instead of a
+ * structured message (for example, nginx returning
+ * "413 <html><head><title>413 Request Entity Too Large</title>...</html>").
+ * Extract the `<title>` when present so the wire message is human readable,
+ * and strip carriage returns so the text renders cleanly in terminals — a
+ * trailing `\r` combined with line-end padding would otherwise overwrite
+ * the whole line. The original HTML remains available in logs and `details`.
+ */
+function sanitizeStatusErrorMessage(message: string): string {
+  const titleMatch = /<title[^>]*>([\s\S]*?)<\/title>/i.exec(message);
+  const extracted = titleMatch?.[1]?.trim();
+  const normalized = extracted !== undefined && extracted.length > 0 ? extracted : message;
+  return normalized.replaceAll('\r', '');
 }
 
 /**

--- a/packages/agent-core/test/errors/serialize.test.ts
+++ b/packages/agent-core/test/errors/serialize.test.ts
@@ -1,0 +1,50 @@
+import { APIStatusError } from '@moonshot-ai/kosong';
+import { describe, expect, it } from 'vitest';
+
+import { toKimiErrorPayload } from '#/errors/serialize';
+
+const NGINX_413_HTML =
+  '413 <html>\r\n<head><title>413 Request Entity Too Large</title></head>\r\n' +
+  '<body>\r\n<center><h1>413 Request Entity Too Large</h1></center>\r\n' +
+  '<hr><center>nginx</center>\r\n</body>\r\n</html>\r\n';
+
+describe('toKimiErrorPayload — APIStatusError message sanitization', () => {
+  it('extracts the <title> from an nginx 413 HTML body and strips CR', () => {
+    const payload = toKimiErrorPayload(new APIStatusError(413, NGINX_413_HTML));
+    expect(payload.code).toBe('provider.api_error');
+    expect(payload.message).toBe('413 Request Entity Too Large');
+    expect(payload.details).toMatchObject({ statusCode: 413 });
+  });
+
+  it('extracts the <title> from other nginx HTML error pages', () => {
+    const html =
+      '<html>\r\n<head><title>502 Bad Gateway</title></head>\r\n' +
+      '<body><center><h1>502 Bad Gateway</h1></center></body></html>';
+    const payload = toKimiErrorPayload(new APIStatusError(502, html));
+    expect(payload.message).toBe('502 Bad Gateway');
+  });
+
+  it('leaves a plain-text message unchanged', () => {
+    const payload = toKimiErrorPayload(new APIStatusError(500, 'Internal Server Error'));
+    expect(payload.message).toBe('Internal Server Error');
+  });
+
+  it('strips carriage returns from a non-HTML message', () => {
+    const payload = toKimiErrorPayload(new APIStatusError(500, 'line1\r\nline2\r'));
+    expect(payload.message).toBe('line1\nline2');
+  });
+
+  it('falls back to the original message when the <title> is empty', () => {
+    const html = '<html><head><title>   </title></head><body>x</body></html>';
+    const payload = toKimiErrorPayload(new APIStatusError(500, html));
+    expect(payload.message).toContain('<html>');
+  });
+
+  it('does not affect 429 / 401 code mapping, only the message', () => {
+    const html = '<html><head><title>429 Too Many Requests</title></head></html>';
+    expect(toKimiErrorPayload(new APIStatusError(429, html)).code).toBe('provider.rate_limit');
+    expect(toKimiErrorPayload(new APIStatusError(401, 'Unauthorized')).code).toBe(
+      'provider.auth_error',
+    );
+  });
+});


### PR DESCRIPTION
## Related Issue

No linked issue. Diagnosed from an exported session where the LLM request failed with an nginx 413 and the TUI rendered no error.

## Problem

When a provider returns an HTML error page (for example, nginx `413 Request Entity Too Large`), the error message carries CRLF line endings and raw HTML. The trailing carriage return is zero-width for the TUI line wrapper, so the padding spaces appended after it overwrote the visible content and the entire error line rendered blank. Users saw no error at all, only the diagnostic hint line.

## What changed

- Extract the `<title>` from HTML error pages and strip carriage returns when serializing provider status errors, so the wire message becomes a single readable line (e.g. `413 Request Entity Too Large`).
- Strip carriage returns in the TUI status message component as a defensive fallback, so any CRLF status text renders correctly.
- Added unit tests for the HTML title extraction and the carriage-return stripping.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.