### PR TITLE
fix(tui): silence noisy provider refresh warnings during startup

### DIFF
--- a/.changeset/silence-startup-refresh-warnings.md
+++ b/.changeset/silence-startup-refresh-warnings.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Silence noisy warnings from background provider refreshes during startup.

--- a/apps/kimi-code/src/tui/kimi-tui.ts
+++ b/apps/kimi-code/src/tui/kimi-tui.ts
@@ -577,9 +577,10 @@ export class KimiTUI {
         if (c.added <= 0) continue;
         this.showStatus(`${c.providerName} · +${String(c.added)} model${c.added > 1 ? 's' : ''}.`);
       }
-      for (const f of result.failed) {
-        this.showStatus(`Skipped refreshing ${f.provider}: ${f.reason}`, 'warning');
-      }
+      // Per-provider failures are best-effort during the startup background
+      // refresh (offline, transient network errors, expired OAuth), so don't
+      // surface them as warnings here. The manual refresh in the model picker
+      // still reports failures when the user asks for it.
     } catch {
       // Best-effort: startup must not crash on background refresh failures.
     }

--- a/apps/kimi-code/test/tui/kimi-tui-startup.test.ts
+++ b/apps/kimi-code/test/tui/kimi-tui-startup.test.ts
@@ -1094,7 +1094,7 @@ describe('KimiTUI startup', () => {
     expect(write).toHaveBeenCalledWith(DISABLE_TERMINAL_THEME_REPORTING);
   });
 
-  it("only shows provider refresh status for added models", async () => {
+  it("only shows provider refresh status for added models and ignores failures", async () => {
     const harness = makeHarness();
     const driver = makeDriver(harness, makeStartupInput());
     const showStatus = vi.spyOn(driver as any, "showStatus").mockImplementation(() => {});
@@ -1105,7 +1105,7 @@ describe('KimiTUI startup', () => {
         { providerId: "metadata-only", providerName: "Metadata Only", added: 0, removed: 0 },
       ],
       unchanged: [],
-      failed: [],
+      failed: [{ provider: "managed:kimi-code", reason: "fetch failed" }],
     });
 
     await (driver as any).refreshProviderModelsInBackground();

--- a/packages/oauth/src/custom-registry.ts
+++ b/packages/oauth/src/custom-registry.ts
@@ -217,9 +217,6 @@ export async function fetchCustomRegistry(
       // fetch, mirroring `toModelEntry`'s skip-on-invalid behavior. This keeps
       // existing providers working when kokub adds a new provider type that
       // this client doesn't yet recognize.
-      console.warn(
-        `[custom-registry] Skipping invalid entry "${key}" at ${source.url}: missing required fields or unsupported type (id, name, api, type, models).`,
-      );
       continue;
     }
     out[key] = entry;

--- a/packages/oauth/test/custom-registry.test.ts
+++ b/packages/oauth/test/custom-registry.test.ts
@@ -158,27 +158,15 @@ describe('fetchCustomRegistry', () => {
           'registry_chat-completions': goodEntry,
         }),
     );
-    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const result = await fetchCustomRegistry(
+      KOKUB_SOURCE,
+      fetchMock as unknown as typeof fetch,
+    );
 
-    try {
-      const result = await fetchCustomRegistry(
-        KOKUB_SOURCE,
-        fetchMock as unknown as typeof fetch,
-      );
-
-      expect(Object.keys(result)).toEqual(['registry_chat-completions']);
-      expect(result['broken-entry']).toBeUndefined();
-      expect(result['unknown-type']).toBeUndefined();
-      expect(result['registry_chat-completions']?.type).toBe('openai');
-
-      expect(warnSpy).toHaveBeenCalledTimes(2);
-      const warnings = warnSpy.mock.calls.map((args) => String(args[0]));
-      expect(warnings.some((m) => m.includes('broken-entry'))).toBe(true);
-      expect(warnings.some((m) => m.includes('unknown-type'))).toBe(true);
-      expect(warnings.every((m) => m.includes(KOKUB_SOURCE.url))).toBe(true);
-    } finally {
-      warnSpy.mockRestore();
-    }
+    expect(Object.keys(result)).toEqual(['registry_chat-completions']);
+    expect(result['broken-entry']).toBeUndefined();
+    expect(result['unknown-type']).toBeUndefined();
+    expect(result['registry_chat-completions']?.type).toBe('openai');
   });
 });
 


### PR DESCRIPTION
<!--
Thank you for your contribution to Kimi Code!
Please open an issue before sending a feature PR — PRs without prior discussion may be closed without review.

See https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md for more.
-->

## Related Issue

No linked issue.

## Problem

Startup runs a best-effort background refresh of every provider's model list. Transient failures — being offline, an expired OAuth token, or a custom-registry entry this client does not yet recognize — surfaced a warning on every launch (`Skipped refreshing ...` in the status area and a `[custom-registry] Skipping invalid entry ...` console warning). These are not actionable and add noise to each startup.

## What changed

- The startup background refresh no longer shows per-provider failure warnings. The manual refresh in the model picker still reports failures when the user asks for it.
- Custom registries now skip unrecognized entries quietly instead of logging a console warning.
- Updated the affected tests to cover the new silent behavior and added a changeset.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.
