### PR TITLE
test(agent-core): align turn telemetry expectations with provider_type

### DIFF
--- a/packages/agent-core/test/agent/turn.test.ts
+++ b/packages/agent-core/test/agent/turn.test.ts
@@ -84,7 +84,7 @@ describe('Agent turn flow', () => {
     const started = records.find((candidate) => candidate.event === 'turn_started');
     expect(started).toEqual({
       event: 'turn_started',
-      properties: expect.objectContaining({ mode: 'agent', type: 'kimi', protocol: 'kimi' }),
+      properties: expect.objectContaining({ mode: 'agent', provider_type: 'kimi', protocol: 'kimi' }),
     });
 
     const ended = records.find((candidate) => candidate.event === 'turn_ended');
@@ -93,7 +93,7 @@ describe('Agent turn flow', () => {
       properties: expect.objectContaining({
         mode: 'agent',
         reason: 'completed',
-        type: 'kimi',
+        provider_type: 'kimi',
         protocol: 'kimi',
         duration_ms: expect.any(Number),
       }),
@@ -1455,7 +1455,7 @@ describe('Agent turn flow', () => {
       error_type: errorType,
       model: 'mock-model',
       alias: 'mock-model',
-      type: 'kimi',
+      provider_type: 'kimi',
       protocol: 'kimi',
       retryable: expect.any(Boolean),
       duration_ms: expect.any(Number),


### PR DESCRIPTION
## Related Issue

No linked issue. This fixes a CI regression introduced by #1184 ("refactor: standardize telemetry property names").

## Problem

#1184 renamed the telemetry property `type` → `provider_type` in the agent-core turn/tool telemetry (alongside `success` → `outcome` and `duration_s`/`latency_ms` → `duration_ms`) and updated most affected tests, but missed `packages/agent-core/test/agent/turn.test.ts`.

As a result, 12 test cases failed on CI:

- `tracks turn_ended telemetry with protocol props`
- `tracks api_error telemetry for '429 status'` … `'generic step error'` (11 cases)

All failed with the same diff:

```
- "type": "kimi"
+ "provider_type": "kimi"
```

The implementation is the intended source of truth; the test expectations were simply stale.

## What changed

Updated the three stale `type: 'kimi'` expectations in `turn.test.ts` to `provider_type: 'kimi'`, covering the `turn_started`/`turn_ended` assertion and the shared `api_error` expected-properties object. No runtime behavior change — test-only fix.

Verified locally: all 53 tests in `packages/agent-core/test/agent/turn.test.ts` pass.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works. (This PR is itself a test fix; the corrected assertions now pass.)
- [x] Ran `gen-changesets` skill, or this PR needs no changeset. (Test-only change; the underlying behavior already shipped in #1184.)
- [x] Ran `gen-docs` skill, or this PR needs no doc update. (No user-facing behavior change.)
