### PR TITLE
fix(web): align composer toolbar corners with card border-radius

### DIFF
--- a/apps/kimi-web/src/components/chat/Composer.vue
+++ b/apps/kimi-web/src/components/chat/Composer.vue
@@ -1386,7 +1386,10 @@ function selectModel(modelId: string): void {
   padding: 6px 10px 4px;
   background: color-mix(in srgb, var(--panel2), black 1.5%);
   position: relative;
-  border-radius: 0 0 var(--r-md) var(--r-md);
+  /* Match the .composer-card's inner bottom corners. The card has a 1px
+     border, so the toolbar's radius must be 1px smaller than the card's
+     outer radius to avoid the toolbar's background bulging past the border. */
+  border-radius: 0 0 15px 15px;
 }
 
 .toolbar-left,

--- a/apps/kimi-web/src/style.css
+++ b/apps/kimi-web/src/style.css
@@ -444,6 +444,10 @@ html[data-color-scheme="dark"][data-theme="modern"] {
 }
 :is(html[data-theme="modern"], html[data-theme="kimi"]) .toolbar {
   background: color-mix(in srgb, var(--panel), black 1.5%);
+  /* Match the .composer-card's inner bottom corners. The card has a 1px
+     border, so the toolbar's radius must be 1px smaller than the card's
+     outer radius to avoid the toolbar's background bulging past the border. */
+  border-radius: 0 0 calc(var(--r-md) - 1px) calc(var(--r-md) - 1px);
 }
 :is(html[data-theme="modern"], html[data-theme="kimi"]) .attach-btn {
   width: 26px;


### PR DESCRIPTION
## Problem

The composer toolbar's bottom corners (where the file picker, mode selector, and model dropdown live) don't match the composer card's border-radius, causing a visible mismatch where the toolbar corners look cut off or overlapping inside the card's rounded shape.

| Area | Card radius | Toolbar radius (before) | Mismatch |
|---|---|---|---|
| Terminal theme | 16px | 12px (var(--r-md)) | **4px** |
| Modern/Kimi theme | var(--r-md) (12px) | var(--r-md) (12px) | **1px** (no border compensation) |

## Fix

Set the toolbar's bottom corners to match the card's **inner** curve (card radius minus the 1px border):

- **Terminal:** toolbar changed from `var(--r-md)` to `15px` (card's `16px` − `1px` border)
- **Modern/Kimi:** added `border-radius: 0 0 calc(var(--r-md) - 1px) calc(var(--r-md) - 1px)` override in `style.css`

## Screenshots

**Before** — toolbar corners don't follow the card's curve:
> The bottom corners of the toolbar section (file picker + model area) appear squared off or cut short relative to the card's rounded corners.

**After** — toolbar corners align cleanly with the card:
> The toolbar's bottom corners now follow the same curve as the composer card, creating a seamless rounded shape.

## Testing
- [x] Type-check passes (`vue-tsc --noEmit`)
- [x] Build passes (`vite build`)
- [ ] Visual verification across terminal, modern, and kimi themes

## Changes
- `apps/kimi-web/src/components/chat/Composer.vue` — toolbar border-radius `var(--r-md)` → `15px`
- `apps/kimi-web/src/style.css` — modern/kimi toolbar override adds matching `calc(var(--r-md) - 1px)` radius