### PR TITLE
fix(web): fix mobile Safari composer toolbar overlap and focus zoom

### DIFF
--- a/.changeset/fix-web-mobile-safari-composer.md
+++ b/.changeset/fix-web-mobile-safari-composer.md
@@ -2,4 +2,4 @@
 "@moonshot-ai/kimi-code": patch
 ---
 
-Fix the web composer being hidden behind the browser toolbar and keyboard on mobile Safari.
+Fix the web composer being hidden behind the browser toolbar on mobile Safari.

--- a/.changeset/fix-web-mobile-safari-composer.md
+++ b/.changeset/fix-web-mobile-safari-composer.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Fix the web composer being hidden behind the browser toolbar and keyboard on mobile Safari.

--- a/.changeset/fix-web-mobile-safari-composer.md
+++ b/.changeset/fix-web-mobile-safari-composer.md
@@ -2,4 +2,4 @@
 "@moonshot-ai/kimi-code": patch
 ---
 
-Fix the web composer being hidden behind the browser toolbar on mobile Safari.
+Fix the web composer being hidden behind the mobile Safari toolbar and the page auto-zooming when the composer is focused.

--- a/apps/kimi-web/index.html
+++ b/apps/kimi-web/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" href="/favicon.ico" sizes="64x64" />
-    <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
+    <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, viewport-fit=cover" />
     <meta name="color-scheme" content="light dark" />
     <meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
     <meta name="theme-color" content="#0d1117" media="(prefers-color-scheme: dark)" />

--- a/apps/kimi-web/index.html
+++ b/apps/kimi-web/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" href="/favicon.ico" sizes="64x64" />
-    <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
+    <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover, interactive-widget=resizes-content" />
     <meta name="color-scheme" content="light dark" />
     <meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
     <meta name="theme-color" content="#0d1117" media="(prefers-color-scheme: dark)" />

--- a/apps/kimi-web/index.html
+++ b/apps/kimi-web/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" href="/favicon.ico" sizes="64x64" />
-    <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover, interactive-widget=resizes-content" />
+    <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
     <meta name="color-scheme" content="light dark" />
     <meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
     <meta name="theme-color" content="#0d1117" media="(prefers-color-scheme: dark)" />

--- a/apps/kimi-web/src/App.vue
+++ b/apps/kimi-web/src/App.vue
@@ -971,6 +971,7 @@ function openPr(url: string): void {
 
 .app-shell {
   height: 100vh;
+  height: 100dvh;
   display: flex;
   flex-direction: column;
   overflow: hidden;


### PR DESCRIPTION
## Related Issue

No linked issue — reported directly by a user.

## Problem

Two related mobile Safari issues with the bottom composer (message input):

1. **Hidden behind the toolbar.** The app shell was sized with `100vh`, which on iOS Safari resolves to the *large* viewport (toolbars collapsed). When Safari's top and bottom toolbars are showing, the shell ends up taller than the visible area, so the composer at its bottom edge sits behind Safari's bottom toolbar.
2. **Page zooms on focus.** iOS Safari auto-zooms the page when a focused input is under 16px. Because the page was zoomable, tapping the composer could zoom the whole page in slightly.

## What changed

- Size the app shell with the dynamic viewport unit `100dvh` (keeping `100vh` as a fallback for older browsers), so the layout tracks Safari's toolbars as they show and hide and the composer stays above the bottom toolbar.
- Add `maximum-scale=1` to the viewport meta so iOS no longer auto-zooms the page when the composer (or any input) is focused. This also disables pinch-to-zoom on the page.

Note: the separate case of the on-screen keyboard covering the composer is **not** addressed here. `interactive-widget=resizes-content` is not implemented by WebKit / iOS Safari, so a proper fix needs a `visualViewport`-driven fallback; that is left to a follow-up.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [ ] I have added tests that prove my feature works. (CSS / viewport-meta changes; behavior is device-specific and needs confirmation on a real iOS Safari device.)
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.
