### PR TITLE
fix(agent-core): repair misplaced tool results in projected context

### DIFF
--- a/.changeset/fix-tool-use-ordering.md
+++ b/.changeset/fix-tool-use-ordering.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Fix long tool-use conversations getting stuck with repeated request errors.

--- a/docs/en/configuration/config-files.md
+++ b/docs/en/configuration/config-files.md
@@ -52,7 +52,7 @@ max_running_tasks = 4
 keep_alive_on_exit = false
 
 [experimental]
-micro_compaction = true
+micro_compaction = false
 
 [[permission.rules]]
 decision = "allow"
@@ -175,11 +175,11 @@ You can also switch models temporarily without touching the config file — by s
 
 ## `experimental`
 
-`experimental` stores persistent overrides for experimental-feature flags. Currently, `micro_compaction` is the only user-facing entry and defaults to `true`; set it to `false` only when you need to disable automatic trimming of older large tool results.
+`experimental` stores persistent overrides for experimental-feature flags. Currently, `micro_compaction` is the only user-facing entry and defaults to `false`; set it to `true` to enable automatic trimming of older large tool results.
 
 | Field | Type | Default | Description |
 | --- | --- | --- | --- |
-| `micro_compaction` | `boolean` | `true` | Trim older large tool results from context while preserving recent conversation |
+| `micro_compaction` | `boolean` | `false` | Trim older large tool results from context while preserving recent conversation |
 
 ## `services`
 

--- a/docs/en/configuration/env-vars.md
+++ b/docs/en/configuration/env-vars.md
@@ -126,7 +126,7 @@ Switches that control the behavior of subsystems such as telemetry, background t
 | `KIMI_CODE_BACKGROUND_KEEP_ALIVE_ON_EXIT` | Whether to keep background tasks when the session closes; takes higher priority than `config.toml`. The default is to stop them on exit | Truthy: `1`/`true`/`yes`/`on`; falsy: `0`/`false`/`no`/`off` |
 | `KIMI_CODE_PLUGIN_MARKETPLACE_URL` | Override the plugin marketplace JSON loaded by `/plugins`; useful for dev loopback servers, staging CDN files, or alternate marketplace directories | `https://code.kimi.com/kimi-code/plugins/marketplace.json`; also accepts `http://`, `file://` URLs, and local paths |
 | `KIMI_CODE_AGENT_SWARM_MAX_CONCURRENCY` | Cap how many AgentSwarm subagents run concurrently during the initial ramp; leave unset for no cap | Positive integer; invalid values fail fast |
-| `KIMI_CODE_EXPERIMENTAL_FLAG` | Enable all registered experimental features for this process; `micro_compaction` is already enabled by default | `1`, `true`, `yes`, `on` |
+| `KIMI_CODE_EXPERIMENTAL_FLAG` | Enable all registered experimental features for this process | `1`, `true`, `yes`, `on` |
 | `KIMI_CODE_EXPERIMENTAL_MICRO_COMPACTION` | Override [`[experimental].micro_compaction`](./config-files.md#experimental) for this process | Truthy or falsy |
 | `KIMI_SHELL_PATH` | Override the Git Bash path on Windows (used when auto-detection fails) | Absolute path |
 | `KIMI_MODEL_MAX_COMPLETION_TOKENS` | Hard cap on `max_completion_tokens` per LLM step; applies to the `kimi` provider only | Positive integer; `0` or negative disables clamping |

--- a/docs/zh/configuration/config-files.md
+++ b/docs/zh/configuration/config-files.md
@@ -52,7 +52,7 @@ max_running_tasks = 4
 keep_alive_on_exit = false
 
 [experimental]
-micro_compaction = true
+micro_compaction = false
 
 [[permission.rules]]
 decision = "allow"
@@ -175,11 +175,11 @@ max_context_size = 1047576
 
 ## `experimental`
 
-`experimental` 存放实验功能 flag 的持久化覆盖。目前 `micro_compaction` 是唯一用户可见的字段，默认值为 `true`；只有在需要关闭自动清理较旧的大型工具结果时，才需要把它设为 `false`。
+`experimental` 存放实验功能 flag 的持久化覆盖。目前 `micro_compaction` 是唯一用户可见的字段，默认值为 `false`；如需自动清理较旧的大型工具结果，把它设为 `true`。
 
 | 字段 | 类型 | 默认值 | 说明 |
 | --- | --- | --- | --- |
-| `micro_compaction` | `boolean` | `true` | 清理较旧的大型工具结果内容，同时保留最近对话 |
+| `micro_compaction` | `boolean` | `false` | 清理较旧的大型工具结果内容，同时保留最近对话 |
 
 ## `services`
 

--- a/docs/zh/configuration/env-vars.md
+++ b/docs/zh/configuration/env-vars.md
@@ -126,7 +126,7 @@ kimi
 | `KIMI_CODE_BACKGROUND_KEEP_ALIVE_ON_EXIT` | 会话关闭时是否保留后台任务，优先级高于 `config.toml`。默认会在退出时停止后台任务 | 真值：`1`/`true`/`yes`/`on`；假值：`0`/`false`/`no`/`off` |
 | `KIMI_CODE_PLUGIN_MARKETPLACE_URL` | 覆盖 `/plugins` 加载的 plugin marketplace JSON，适合 dev loopback server、测试 CDN 文件或替换 marketplace 目录 | `https://code.kimi.com/kimi-code/plugins/marketplace.json`；也接受 `http://`、`file://` URL 和本地路径 |
 | `KIMI_CODE_AGENT_SWARM_MAX_CONCURRENCY` | 限制 AgentSwarm 初始提升并发阶段可同时运行的子 Agent 数量；不设置表示不限制 | 正整数；非法值会立即失败 |
-| `KIMI_CODE_EXPERIMENTAL_FLAG` | 在当前进程启用所有已注册的实验功能；`micro_compaction` 已默认开启 | `1`、`true`、`yes`、`on` |
+| `KIMI_CODE_EXPERIMENTAL_FLAG` | 在当前进程启用所有已注册的实验功能 | `1`、`true`、`yes`、`on` |
 | `KIMI_CODE_EXPERIMENTAL_MICRO_COMPACTION` | 覆盖当前进程的 [`[experimental].micro_compaction`](./config-files.md#experimental) | 真值或假值 |
 | `KIMI_SHELL_PATH` | Windows 上覆盖 Git Bash 路径（自动探测失败时使用） | 绝对路径 |
 | `KIMI_MODEL_MAX_COMPLETION_TOKENS` | 单步 LLM 请求的 `max_completion_tokens` 硬上限，仅对 `kimi` 供应商生效 | 正整数；`0` 或负数禁用 clamp |

--- a/packages/agent-core/src/agent/compaction/full.ts
+++ b/packages/agent-core/src/agent/compaction/full.ts
@@ -344,7 +344,7 @@ export class FullCompaction {
       while (true) {
         const messagesToCompact = originalHistory.slice(0, compactedCount);
         const messages = [
-          ...this.agent.context.project(messagesToCompact),
+          ...this.agent.context.project(messagesToCompact, { synthesizeMissing: true }),
           createUserMessage(renderPrompt(compactionInstructionTemplate, { customInstruction: data.instruction ?? '' })),
         ];
         const estimatedCompactionRequestTokens = this.estimateRequestTokens(messages);

--- a/packages/agent-core/src/agent/context/index.ts
+++ b/packages/agent-core/src/agent/context/index.ts
@@ -6,7 +6,7 @@ import type { ExecutableToolResult, LoopRecordedEvent } from '../../loop';
 import { estimateTokensForMessages } from '../../utils/tokens';
 import { escapeXml } from '../../utils/xml-escape';
 import type { CompactionResult } from '../compaction';
-import { project, trimTrailingOpenToolExchange } from './projector';
+import { project, type ProjectOptions, trimTrailingOpenToolExchange } from './projector';
 import {
   USER_PROMPT_ORIGIN,
   type AgentContextData,
@@ -256,8 +256,8 @@ export class ContextMemory {
     return this._history;
   }
 
-  project(messages: readonly ContextMessage[]): Message[] {
-    return project(this.agent.microCompaction.compact(messages));
+  project(messages: readonly ContextMessage[], options?: ProjectOptions): Message[] {
+    return project(this.agent.microCompaction.compact(messages), options);
   }
 
   get messages(): Message[] {

--- a/packages/agent-core/src/agent/context/projector.ts
+++ b/packages/agent-core/src/agent/context/projector.ts
@@ -4,7 +4,58 @@ import { ErrorCodes, KimiError } from '../../errors';
 import type { ContextMessage } from './types';
 
 export function project(history: readonly ContextMessage[]): Message[] {
-  return mergeAdjacentUserMessages(history);
+  return repairToolExchangeAdjacency(mergeAdjacentUserMessages(history));
+}
+
+// Strict providers (Anthropic) require every assistant `tool_use` to be answered
+// by a matching `tool_result` in the immediately following message(s). A
+// misordered history — where a `tool_result` is not adjacent to its `tool_use`,
+// e.g. because a user message (background-task notification, flushed steer)
+// landed in between, or because an interrupted / nested step delayed the result
+// — is rejected with HTTP 400 ("`tool_use` without `tool_result` immediately
+// after"). Micro compaction only exposed this latent misordering by busting the
+// prompt cache and forcing a full revalidation.
+//
+// Repair the adjacency so every assistant `tool_use` is immediately followed by
+// its matching `tool_result` message(s). Matching results are moved up from
+// wherever they appear later in the history; any intervening messages keep their
+// relative order and simply follow the repaired exchange. A tool call with no
+// recorded result anywhere later in the history is left untouched — it is still
+// in-flight (pending) rather than orphaned, and the trailing-open-exchange trim
+// plus the interrupted-result synthesis during replay own those cases. This is
+// purely a projection-time fix: the underlying history is left untouched, so
+// replay and transcripts keep their original order, while the model always sees
+// a well-formed tool exchange.
+function repairToolExchangeAdjacency(messages: readonly Message[]): Message[] {
+  const out: Message[] = [];
+  const consumed = new Set<number>();
+  for (let i = 0; i < messages.length; i++) {
+    if (consumed.has(i)) continue;
+    const message = messages[i]!;
+    if (message.role !== 'assistant' || message.toolCalls.length === 0) {
+      out.push(message);
+      continue;
+    }
+
+    out.push(message);
+    const pending = new Set(message.toolCalls.map((toolCall) => toolCall.id));
+    for (let j = i + 1; j < messages.length && pending.size > 0; j++) {
+      if (consumed.has(j)) continue;
+      const next = messages[j]!;
+      const toolCallId = next.toolCallId;
+      if (next.role === 'tool' && toolCallId !== undefined && pending.has(toolCallId)) {
+        out.push(next);
+        consumed.add(j);
+        pending.delete(toolCallId);
+      }
+    }
+    // If a tool call has no recorded result anywhere later in the history, it is
+    // still in-flight (pending) rather than orphaned, so leave it untouched — the
+    // trailing-open-exchange trim and the interrupted-result synthesis during
+    // replay own those cases, and synthesizing here would wrongly close a call
+    // that is simply still running.
+  }
+  return out;
 }
 
 function mergeAdjacentUserMessages(history: readonly ContextMessage[]): Message[] {

--- a/packages/agent-core/src/agent/context/projector.ts
+++ b/packages/agent-core/src/agent/context/projector.ts
@@ -3,8 +3,21 @@ import type { ContentPart, Message, TextPart } from '@moonshot-ai/kosong';
 import { ErrorCodes, KimiError } from '../../errors';
 import type { ContextMessage } from './types';
 
-export function project(history: readonly ContextMessage[]): Message[] {
-  return repairToolExchangeAdjacency(mergeAdjacentUserMessages(history));
+export interface ProjectOptions {
+  /**
+   * When `true`, emit a synthetic `tool_result` for any assistant `tool_use`
+   * whose result is not present in the provided messages. Used by full
+   * compaction, where the compacted prefix is a slice that may exclude a
+   * delayed result preserved in the retained tail; the synthetic result keeps
+   * the exchange closed so the summary request is not rejected. Leave `false`
+   * for normal turns, where a missing result means the call is still in-flight
+   * and must not be closed prematurely.
+   */
+  readonly synthesizeMissing?: boolean;
+}
+
+export function project(history: readonly ContextMessage[], options?: ProjectOptions): Message[] {
+  return repairToolExchangeAdjacency(mergeAdjacentUserMessages(history), options);
 }
 
 // Strict providers (Anthropic) require every assistant `tool_use` to be answered
@@ -20,13 +33,22 @@ export function project(history: readonly ContextMessage[]): Message[] {
 // its matching `tool_result` message(s). Matching results are moved up from
 // wherever they appear later in the history; any intervening messages keep their
 // relative order and simply follow the repaired exchange. A tool call with no
-// recorded result anywhere later in the history is left untouched — it is still
-// in-flight (pending) rather than orphaned, and the trailing-open-exchange trim
-// plus the interrupted-result synthesis during replay own those cases. This is
-// purely a projection-time fix: the underlying history is left untouched, so
-// replay and transcripts keep their original order, while the model always sees
-// a well-formed tool exchange.
-function repairToolExchangeAdjacency(messages: readonly Message[]): Message[] {
+// recorded result anywhere later in the history is left untouched by default —
+// it is still in-flight (pending) rather than orphaned, and the
+// trailing-open-exchange trim plus the interrupted-result synthesis during replay
+// own those cases. With `synthesizeMissing`, a synthetic `tool_result` is emitted
+// for such calls instead; full compaction uses this to keep a sliced prefix
+// closed when a delayed result lives in the retained tail. This is purely a
+// projection-time fix: the underlying history is left untouched, so replay and
+// transcripts keep their original order, while the model always sees a
+// well-formed tool exchange.
+const SYNTHETIC_TOOL_RESULT_TEXT =
+  'Tool result is not available in the current context. Do not assume the tool completed successfully.';
+
+function repairToolExchangeAdjacency(
+  messages: readonly Message[],
+  options?: ProjectOptions,
+): Message[] {
   const out: Message[] = [];
   const consumed = new Set<number>();
   for (let i = 0; i < messages.length; i++) {
@@ -49,13 +71,28 @@ function repairToolExchangeAdjacency(messages: readonly Message[]): Message[] {
         pending.delete(toolCallId);
       }
     }
-    // If a tool call has no recorded result anywhere later in the history, it is
-    // still in-flight (pending) rather than orphaned, so leave it untouched — the
-    // trailing-open-exchange trim and the interrupted-result synthesis during
-    // replay own those cases, and synthesizing here would wrongly close a call
-    // that is simply still running.
+    if (options?.synthesizeMissing === true) {
+      // Close any tool call whose result is absent from the provided messages.
+      // Only used by full compaction, where the prefix is a slice that may
+      // exclude a delayed result preserved in the retained tail. For normal
+      // turns a missing result means the call is still in-flight, so it is left
+      // for the trailing-open-exchange trim and replay's interrupted-result
+      // synthesis instead of being closed here.
+      for (const missingId of pending) {
+        out.push(makeSyntheticToolResult(missingId));
+      }
+    }
   }
   return out;
+}
+
+function makeSyntheticToolResult(toolCallId: string): Message {
+  return {
+    role: 'tool',
+    content: [{ type: 'text', text: SYNTHETIC_TOOL_RESULT_TEXT }],
+    toolCalls: [],
+    toolCallId,
+  };
 }
 
 function mergeAdjacentUserMessages(history: readonly ContextMessage[]): Message[] {

--- a/packages/agent-core/src/flags/registry.ts
+++ b/packages/agent-core/src/flags/registry.ts
@@ -17,7 +17,7 @@ export const FLAG_DEFINITIONS = [
     title: 'Micro compaction',
     description: 'Trim older large tool results from context while keeping recent conversation intact.',
     env: 'KIMI_CODE_EXPERIMENTAL_MICRO_COMPACTION',
-    default: true,
+    default: false,
     surface: 'core',
   },
 ] as const satisfies readonly FlagDefinitionInput[];

--- a/packages/agent-core/test/agent/basic.test.ts
+++ b/packages/agent-core/test/agent/basic.test.ts
@@ -9,7 +9,7 @@ it('creates an independent agent with a scoped experimental flag resolver', () =
     experimentalFlags: new FlagResolver({}, FLAG_DEFINITIONS),
   });
 
-  expect(ctx.agent.experimentalFlags.enabled('micro_compaction')).toBe(true);
+  expect(ctx.agent.experimentalFlags.enabled('micro_compaction')).toBe(false);
 });
 
 it('runs a text-only agent turn from prompt to completion', async () => {

--- a/packages/agent-core/test/agent/compaction/full.test.ts
+++ b/packages/agent-core/test/agent/compaction/full.test.ts
@@ -288,6 +288,94 @@ describe('FullCompaction', () => {
     ).toBe(false);
   });
 
+  // Regression: a delayed tool result can fall outside the compacted prefix
+  // (the split is computed on the raw, misordered history). The compaction
+  // request must still close the exchange so the summary request is not
+  // rejected by strict providers.
+  it('closes a tool call whose delayed result falls outside the compacted prefix', async () => {
+    const compactFirstTwo: CompactionStrategy = {
+      ...alwaysCompactOnce,
+      computeCompactCount: () => 2,
+    };
+    const ctx = testAgent({ compactionStrategy: compactFirstTwo });
+    ctx.configure({
+      provider: CATALOGUED_PROVIDER,
+      modelCapabilities: CATALOGUED_MODEL_CAPABILITIES,
+    });
+
+    const stepUuid = 'delayed-result-step';
+    ctx.agent.context.appendUserMessage([{ type: 'text', text: 'first prompt' }]);
+    ctx.dispatch({
+      type: 'context.append_loop_event',
+      event: { type: 'step.begin', uuid: stepUuid, turnId: '0', step: 1 },
+    });
+    // Notification flushed before the tool call lands it between the tool_use
+    // and its (later) tool result.
+    ctx.agent.context.appendUserMessage([{ type: 'text', text: '<notification>bg</notification>' }], {
+      kind: 'background_task',
+      taskId: 'task-1',
+      status: 'completed',
+      notificationId: 'task:task-1:completed',
+    });
+    ctx.dispatch({
+      type: 'context.append_loop_event',
+      event: {
+        type: 'tool.call',
+        uuid: 'call_delayed',
+        turnId: '0',
+        step: 1,
+        stepUuid,
+        toolCallId: 'call_delayed',
+        name: 'Run',
+        args: {},
+      },
+    });
+    ctx.dispatch({
+      type: 'context.append_loop_event',
+      event: { type: 'step.end', uuid: stepUuid, turnId: '0', step: 1, finishReason: 'tool_use' },
+    });
+    ctx.dispatch({
+      type: 'context.append_loop_event',
+      event: {
+        type: 'tool.result',
+        parentUuid: 'call_delayed',
+        toolCallId: 'call_delayed',
+        result: { output: 'real result' },
+      },
+    });
+
+    // Sanity: history is [user, assistant(call_delayed), user, tool(call_delayed)];
+    // the split at 2 excludes the tool result.
+    expect(ctx.agent.context.history.map((m) => m.role)).toEqual([
+      'user',
+      'assistant',
+      'user',
+      'tool',
+    ]);
+
+    const compacted = new Promise<void>((resolve) => {
+      ctx.emitter.once('context.apply_compaction', () => resolve());
+    });
+    ctx.mockNextResponse({ type: 'text', text: 'Compacted summary.' });
+    await ctx.rpc.beginCompaction({});
+    await compacted;
+
+    const [compactionCall] = ctx.llmCalls;
+    expect(compactionCall?.history.map((m) => m.role)).toEqual([
+      'user',
+      'assistant',
+      'tool',
+      'user',
+    ]);
+    // The tool result answering call_delayed is a synthetic placeholder (the real
+    // result lives in the retained tail, outside the compacted prefix).
+    expect(compactionCall?.history[2]).toMatchObject({
+      role: 'tool',
+      toolCallId: 'call_delayed',
+    });
+    expect(textOf(compactionCall?.history[2])).toContain('not available');
+  });
+
   it('micro-compacts old tool results before sending the summary request', async () => {
     vi.useFakeTimers();
     enableMicroCompactionFlag();
@@ -2332,4 +2420,10 @@ function inputHistorySnapshot(history: readonly Message[]): string[] {
 
 function normalizeInputText(text: string): string {
   return text.includes('compact this conversation context') ? '<compaction-instruction>' : text;
+}
+
+function textOf(message: Message | undefined): string {
+  return (
+    message?.content.map((part) => (part.type === 'text' ? part.text : '')).join('') ?? ''
+  );
 }

--- a/packages/agent-core/test/agent/compaction/micro.test.ts
+++ b/packages/agent-core/test/agent/compaction/micro.test.ts
@@ -35,8 +35,8 @@ describe('MicroCompaction', () => {
     vi.stubEnv(MICRO_COMPACTION_FLAG_ENV, '1');
   });
 
-  it('defaults the micro_compaction flag on', () => {
-    expect(new FlagResolver({}, FLAG_DEFINITIONS).enabled('micro_compaction')).toBe(true);
+  it('defaults the micro_compaction flag off', () => {
+    expect(new FlagResolver({}, FLAG_DEFINITIONS).enabled('micro_compaction')).toBe(false);
   });
 
   it('truncates old tool results after cache miss', () => {

--- a/packages/agent-core/test/agent/context.test.ts
+++ b/packages/agent-core/test/agent/context.test.ts
@@ -563,6 +563,94 @@ describe('Agent context', () => {
     await ctx.expectResumeMatches();
   });
 
+  // Regression: a user message injected after `step.begin` but before the first
+  // `tool.call` (e.g. a background-task notification flushed mid-step) lands
+  // between the assistant `tool_use` and its `tool_result` in history, which
+  // strict providers (Anthropic) reject with HTTP 400. The projector must repair
+  // the adjacency so the `tool_result` immediately follows the `tool_use`. Micro
+  // compaction exposed this latent misordering by busting the prompt cache.
+  it('repairs a tool_use/tool_result adjacency broken by an injected user message', async () => {
+    const ctx = testAgent();
+    ctx.configure();
+    const stepUuid = 'mid-step-notify-step';
+
+    ctx.agent.context.appendUserMessage([{ type: 'text', text: 'drive the tank' }]);
+    ctx.dispatch({
+      type: 'context.append_loop_event',
+      event: { type: 'step.begin', uuid: stepUuid, turnId: '0', step: 1 },
+    });
+
+    // Notification arrives in the gap between step.begin and tool.call, when no
+    // tool result is yet pending, so it is pushed directly into history.
+    ctx.agent.context.appendUserMessage([{ type: 'text', text: '<notification>bg done</notification>' }], {
+      kind: 'background_task',
+      taskId: 'task-1',
+      status: 'completed',
+      notificationId: 'task:task-1:completed',
+    });
+
+    ctx.dispatch({
+      type: 'context.append_loop_event',
+      event: {
+        type: 'tool.call',
+        uuid: 'call_drive',
+        turnId: '0',
+        step: 1,
+        stepUuid,
+        toolCallId: 'call_drive',
+        name: 'Drive',
+        args: {},
+      },
+    });
+    ctx.dispatch({
+      type: 'context.append_loop_event',
+      event: {
+        type: 'step.end',
+        uuid: stepUuid,
+        turnId: '0',
+        step: 1,
+        finishReason: 'tool_use',
+      },
+    });
+    ctx.dispatch({
+      type: 'context.append_loop_event',
+      event: {
+        type: 'tool.result',
+        parentUuid: 'call_drive',
+        toolCallId: 'call_drive',
+        result: { output: 'drove forward' },
+      },
+    });
+
+    // History preserves the original (misordered) sequence: the notification sits
+    // between the assistant tool_use and its tool_result.
+    expect(ctx.agent.context.history.map((message) => message.role)).toEqual([
+      'user',
+      'assistant',
+      'user',
+      'tool',
+    ]);
+
+    // Projection repairs the adjacency: the tool_result immediately follows the
+    // assistant tool_use, and the sandwiched notification is moved after it.
+    const projected = ctx.agent.context.messages;
+    expect(projected.map((message) => message.role)).toEqual(['user', 'assistant', 'tool', 'user']);
+    const assistantIndex = projected.findIndex(
+      (message) => message.role === 'assistant' && message.toolCalls.length > 0,
+    );
+    expect(projected[assistantIndex]?.toolCalls.map((toolCall) => toolCall.id)).toEqual([
+      'call_drive',
+    ]);
+    expect(projected[assistantIndex + 1]).toMatchObject({
+      role: 'tool',
+      toolCallId: 'call_drive',
+    });
+    expect(projected[assistantIndex + 2]?.content).toEqual([
+      { type: 'text', text: '<notification>bg done</notification>' },
+    ]);
+    await ctx.expectResumeMatches();
+  });
+
   it('preserves deferred reminders when compaction keeps a pending tool exchange', async () => {
     const ctx = testAgent();
     ctx.configure();

--- a/packages/agent-core/test/agent/context/projector.test.ts
+++ b/packages/agent-core/test/agent/context/projector.test.ts
@@ -1,0 +1,394 @@
+import type { ContentPart, Message, ToolCall } from '@moonshot-ai/kosong';
+import { describe, expect, it } from 'vitest';
+
+import { project } from '../../../src/agent/context/projector';
+import type { ContextMessage } from '../../../src/agent/context/types';
+
+// ---------------------------------------------------------------------------
+// Invariant under test
+// ---------------------------------------------------------------------------
+//
+// Strict providers (Anthropic) reject a request with HTTP 400 when an assistant
+// `tool_use` is not immediately followed by its matching `tool_result`. The
+// projector must therefore guarantee that, for every assistant tool call whose
+// result exists anywhere in the projected history, that result sits in the
+// consecutive tool messages immediately following the assistant message.
+//
+// A tool call with no recorded result anywhere is considered still in-flight
+// (pending) and is intentionally left untouched — it is not an orphan.
+
+interface MisplacedToolUse {
+  readonly assistantIndex: number;
+  readonly toolCallId: string;
+}
+
+/**
+ * Return tool calls whose result exists somewhere in `messages` but is not
+ * adjacent to the assistant `tool_use`. An empty result means the invariant
+ * holds and the history is safe to send to a strict provider.
+ */
+function findMisplacedToolUses(messages: readonly Message[]): MisplacedToolUse[] {
+  // Index every recorded tool result by its toolCallId.
+  const resultIndexById = new Map<string, number>();
+  messages.forEach((message, index) => {
+    if (message.role === 'tool' && message.toolCallId !== undefined) {
+      resultIndexById.set(message.toolCallId, index);
+    }
+  });
+
+  const violations: MisplacedToolUse[] = [];
+  for (let i = 0; i < messages.length; i++) {
+    const message = messages[i]!;
+    if (message.role !== 'assistant' || message.toolCalls.length === 0) continue;
+
+    // Collect the toolCallIds answered in the consecutive tool messages that
+    // immediately follow this assistant message.
+    const adjacentResultIds = new Set<string>();
+    let j = i + 1;
+    while (j < messages.length && messages[j]!.role === 'tool') {
+      const id = messages[j]!.toolCallId;
+      if (id !== undefined) adjacentResultIds.add(id);
+      j++;
+    }
+
+    for (const toolCall of message.toolCalls) {
+      // Only flag tool calls whose result was actually recorded; a missing
+      // result means the call is still in-flight, not misplaced.
+      if (!resultIndexById.has(toolCall.id)) continue;
+      if (!adjacentResultIds.has(toolCall.id)) {
+        violations.push({ assistantIndex: i, toolCallId: toolCall.id });
+      }
+    }
+  }
+  return violations;
+}
+
+// ---------------------------------------------------------------------------
+// Builders
+// ---------------------------------------------------------------------------
+
+function textPart(text: string): ContentPart {
+  return { type: 'text', text };
+}
+
+function user(text: string): ContextMessage {
+  return { role: 'user', content: [textPart(text)], toolCalls: [] };
+}
+
+function notification(text: string): ContextMessage {
+  return {
+    role: 'user',
+    content: [textPart(text)],
+    toolCalls: [],
+    origin: {
+      kind: 'background_task',
+      taskId: 'task',
+      status: 'completed',
+      notificationId: 'task:task:completed',
+    },
+  };
+}
+
+function assistant(toolCallIds: readonly string[], text = ''): ContextMessage {
+  return {
+    role: 'assistant',
+    content: text.length > 0 ? [textPart(text)] : [],
+    toolCalls: toolCallIds.map(
+      (id): ToolCall => ({ type: 'function', id, name: 'Run', arguments: '{}' }),
+    ),
+  };
+}
+
+function emptyAssistant(): ContextMessage {
+  return { role: 'assistant', content: [], toolCalls: [] };
+}
+
+function tool(toolCallId: string, text = 'ok'): ContextMessage {
+  return { role: 'tool', content: [textPart(text)], toolCalls: [], toolCallId };
+}
+
+function compactionSummary(text = 'summary'): ContextMessage {
+  return {
+    role: 'assistant',
+    content: [textPart(text)],
+    toolCalls: [],
+    origin: { kind: 'compaction_summary' },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Targeted regression tests
+// ---------------------------------------------------------------------------
+
+describe('project tool_use/tool_result adjacency', () => {
+  it('leaves an already well-formed history unchanged (idempotent)', () => {
+    const history: ContextMessage[] = [
+      user('u1'),
+      assistant(['a']),
+      tool('a'),
+      user('u2'),
+      assistant(['b', 'c']),
+      tool('b'),
+      tool('c'),
+      user('u3'),
+    ];
+    const projected = project(history);
+    expect(projected.map((m) => [m.role, m.toolCallId])).toEqual([
+      ['user', undefined],
+      ['assistant', undefined],
+      ['tool', 'a'],
+      ['user', undefined],
+      ['assistant', undefined],
+      ['tool', 'b'],
+      ['tool', 'c'],
+      ['user', undefined],
+    ]);
+    expect(findMisplacedToolUses(projected)).toEqual([]);
+  });
+
+  it('moves a user message sandwiched between tool_use and tool_result to after the result', () => {
+    const history: ContextMessage[] = [user('u1'), assistant(['a']), notification('ping'), tool('a')];
+    const projected = project(history);
+    expect(projected.map((m) => m.role)).toEqual(['user', 'assistant', 'tool', 'user']);
+    expect(projected[1]?.toolCalls.map((tc) => tc.id)).toEqual(['a']);
+    expect(projected[2]).toMatchObject({ role: 'tool', toolCallId: 'a' });
+    expect(findMisplacedToolUses(projected)).toEqual([]);
+  });
+
+  it('pulls a distant tool result back up across intervening exchanges', () => {
+    const history: ContextMessage[] = [
+      user('u1'),
+      assistant(['a']),
+      user('middle'),
+      assistant(['b']),
+      tool('b'),
+      user('later'),
+      tool('a'),
+    ];
+    const projected = project(history);
+    expect(projected.map((m) => [m.role, m.toolCallId])).toEqual([
+      ['user', undefined],
+      ['assistant', undefined],
+      ['tool', 'a'],
+      ['user', undefined],
+      ['assistant', undefined],
+      ['tool', 'b'],
+      ['user', undefined],
+    ]);
+    expect(findMisplacedToolUses(projected)).toEqual([]);
+  });
+
+  it('reorders parallel tool results that arrive out of order', () => {
+    const history: ContextMessage[] = [
+      user('u1'),
+      assistant(['a', 'b', 'c']),
+      tool('c'),
+      tool('a'),
+      tool('b'),
+    ];
+    const projected = project(history);
+    // All three results must be adjacent to the assistant, regardless of order.
+    expect(projected.map((m) => m.role)).toEqual(['user', 'assistant', 'tool', 'tool', 'tool']);
+    const resultIds = projected.slice(2).map((m) => m.toolCallId);
+    expect(resultIds).toEqual(expect.arrayContaining(['a', 'b', 'c']));
+    expect(findMisplacedToolUses(projected)).toEqual([]);
+  });
+
+  it('repairs multiple misplaced exchanges in a single history', () => {
+    const history: ContextMessage[] = [
+      user('u1'),
+      assistant(['a']),
+      user('sandwich-a'),
+      assistant(['b']),
+      tool('b'),
+      user('sandwich-b'),
+      tool('a'),
+    ];
+    const projected = project(history);
+    expect(findMisplacedToolUses(projected)).toEqual([]);
+    // a's result must immediately follow a's assistant.
+    const aIndex = projected.findIndex((m) => m.toolCalls.some((tc) => tc.id === 'a'));
+    expect(projected[aIndex + 1]).toMatchObject({ role: 'tool', toolCallId: 'a' });
+    const bIndex = projected.findIndex((m) => m.toolCalls.some((tc) => tc.id === 'b'));
+    expect(projected[bIndex + 1]).toMatchObject({ role: 'tool', toolCallId: 'b' });
+  });
+
+  it('leaves a pending (in-flight) tool call without a recorded result untouched', () => {
+    const history: ContextMessage[] = [user('u1'), assistant(['a', 'b']), tool('a')];
+    // b has no recorded result — it is still pending, not orphaned.
+    const projected = project(history);
+    expect(projected.map((m) => [m.role, m.toolCallId])).toEqual([
+      ['user', undefined],
+      ['assistant', undefined],
+      ['tool', 'a'],
+    ]);
+    // No new (synthetic) tool result for b was introduced.
+    expect(projected.some((m) => m.toolCallId === 'b')).toBe(false);
+  });
+
+  it('does not move a tool result whose toolCallId matches no assistant tool_use', () => {
+    const history: ContextMessage[] = [
+      user('u1'),
+      assistant(['a']),
+      tool('a'),
+      tool('orphan-result'),
+      user('u2'),
+    ];
+    const projected = project(history);
+    // The stray result stays where it was; nothing references it.
+    expect(projected.map((m) => [m.role, m.toolCallId])).toEqual([
+      ['user', undefined],
+      ['assistant', undefined],
+      ['tool', 'a'],
+      ['tool', 'orphan-result'],
+      ['user', undefined],
+    ]);
+  });
+
+  it('does not crash when a tool result appears before its tool_use', () => {
+    const history: ContextMessage[] = [tool('a'), user('u1'), assistant(['a'])];
+    // Forward scan cannot find the result (it is behind the assistant), so the
+    // exchange is left as-is rather than throwing.
+    expect(() => project(history)).not.toThrow();
+  });
+
+  it('preserves compaction summaries and empty assistants while repairing', () => {
+    const history: ContextMessage[] = [
+      compactionSummary(),
+      user('u1'),
+      assistant(['a']),
+      notification('ping'),
+      emptyAssistant(),
+      tool('a'),
+    ];
+    const projected = project(history);
+    expect(findMisplacedToolUses(projected)).toEqual([]);
+    const aIndex = projected.findIndex((m) => m.toolCalls.some((tc) => tc.id === 'a'));
+    expect(projected[aIndex + 1]).toMatchObject({ role: 'tool', toolCallId: 'a' });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Property-based fuzz test
+// ---------------------------------------------------------------------------
+//
+// Generate a large number of histories with randomized, worst-case misordering
+// (sandwiched user messages, distant results, parallel calls, pending calls,
+// empty assistants, compaction summaries) and assert the projector ALWAYS
+// produces a history that satisfies the adjacency invariant. This is the guard
+// that catches regressions which would otherwise strand the user with HTTP 400.
+
+describe('project adjacency invariant (fuzz)', () => {
+  it('holds for thousands of randomized histories', () => {
+    const rng = mulberry32(0x5eed_c0de);
+    const iterations = 4000;
+    for (let n = 0; n < iterations; n++) {
+      const history = generateHistory(rng, n);
+      const projected = project(history);
+      const violations = findMisplacedToolUses(projected);
+      expect(
+        violations,
+        `adjacency invariant violated at iteration ${n}\n` +
+          `history:   ${JSON.stringify(history.map(label))}\n` +
+          `projected: ${JSON.stringify(projected.map(label))}`,
+      ).toEqual([]);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Fuzz generator
+// ---------------------------------------------------------------------------
+
+type Rng = () => number;
+
+function label(message: Message): string {
+  const id = message.toolCallId ?? message.toolCalls.map((toolCall) => toolCall.id).join(',');
+  return `${message.role}:${id}`;
+}
+
+// mulberry32 requires unsigned 32-bit wrapping arithmetic (`>>> 0`), which
+// `Math.trunc` does not provide, so the prefer-math-trunc lint is a false
+// positive here.
+/* eslint-disable unicorn/prefer-math-trunc */
+function mulberry32(seed: number): Rng {
+  let state = seed >>> 0;
+  return () => {
+    state = (state + 0x6d2b79f5) >>> 0;
+    let t = state;
+    t = Math.imul(t ^ (t >>> 15), t | 1);
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+/* eslint-enable unicorn/prefer-math-trunc */
+
+function pick<T>(rng: Rng, items: readonly T[]): T {
+  return items[Math.floor(rng() * items.length)]!;
+}
+
+function generateHistory(rng: Rng, seed: number): ContextMessage[] {
+  const messages: ContextMessage[] = [];
+  let nextId = 1;
+  const blockCount = 2 + Math.floor(rng() * 8);
+
+  for (let b = 0; b < blockCount; b++) {
+    const kind = pick(rng, ['user', 'exchange', 'notification', 'empty', 'compaction'] as const);
+    switch (kind) {
+      case 'user':
+        messages.push(user(`u-${seed}-${b}`));
+        break;
+      case 'notification':
+        messages.push(notification(`n-${seed}-${b}`));
+        break;
+      case 'empty':
+        messages.push(emptyAssistant());
+        break;
+      case 'compaction':
+        messages.push(compactionSummary());
+        break;
+      case 'exchange': {
+        const arity = 1 + Math.floor(rng() * 3);
+        const ids: string[] = [];
+        for (let k = 0; k < arity; k++) {
+          ids.push(`c${nextId++}`);
+        }
+        messages.push(assistant(ids));
+        // Decide which results are recorded (some may be pending).
+        const recorded = ids.filter(() => rng() > 0.25);
+        // Randomize result order to simulate parallel calls completing out of order.
+        shuffle(recorded, rng);
+        // Randomly inject a sandwiched user/notification before the results.
+        if (rng() > 0.5) {
+          messages.push(pick(rng, [user(`sandwich-${seed}-${b}`), notification(`sandwich-n-${seed}-${b}`)]));
+        }
+        // Randomly delay one recorded result past a following exchange.
+        let delayed: ContextMessage | undefined;
+        if (recorded.length > 0 && rng() > 0.6) {
+          delayed = tool(recorded.pop()!);
+        }
+        for (const id of recorded) {
+          messages.push(tool(id));
+        }
+        // Possibly emit a full extra exchange before the delayed result lands.
+        if (delayed !== undefined) {
+          if (rng() > 0.4) {
+            const laterIds = [`c${nextId++}`];
+            messages.push(assistant(laterIds));
+            messages.push(tool(laterIds[0]!));
+          }
+          messages.push(delayed);
+        }
+        break;
+      }
+    }
+  }
+  return messages;
+}
+
+function shuffle<T>(items: T[], rng: Rng): void {
+  for (let i = items.length - 1; i > 0; i--) {
+    const j = Math.floor(rng() * (i + 1));
+    [items[i], items[j]] = [items[j]!, items[i]!];
+  }
+}

--- a/packages/agent-core/test/agent/context/projector.test.ts
+++ b/packages/agent-core/test/agent/context/projector.test.ts
@@ -71,6 +71,14 @@ function textPart(text: string): ContentPart {
   return { type: 'text', text };
 }
 
+function textOf(message: Message | undefined): string {
+  return (
+    message?.content
+      .map((part) => (part.type === 'text' ? part.text : ''))
+      .join('') ?? ''
+  );
+}
+
 function user(text: string): ContextMessage {
   return { role: 'user', content: [textPart(text)], toolCalls: [] };
 }
@@ -224,6 +232,43 @@ describe('project tool_use/tool_result adjacency', () => {
     ]);
     // No new (synthetic) tool result for b was introduced.
     expect(projected.some((m) => m.toolCallId === 'b')).toBe(false);
+  });
+
+  it('synthesizes a tool result for a missing tool call when synthesizeMissing is set', () => {
+    const history: ContextMessage[] = [user('u1'), assistant(['a', 'b']), tool('a')];
+    const projected = project(history, { synthesizeMissing: true });
+    expect(projected.map((m) => [m.role, m.toolCallId])).toEqual([
+      ['user', undefined],
+      ['assistant', undefined],
+      ['tool', 'a'],
+      ['tool', 'b'],
+    ]);
+    expect(projected.at(-1)).toMatchObject({ role: 'tool', toolCallId: 'b' });
+    expect(findMisplacedToolUses(projected)).toEqual([]);
+  });
+
+  // Regression for the full-compaction prefix gap: a delayed tool result may be
+  // sliced out of the compacted prefix (the split is computed on the raw,
+  // misordered history). With synthesizeMissing the sliced projection must still
+  // close the exchange so the summary request is not rejected.
+  it('closes a tool call whose delayed result is sliced out of a compaction prefix', () => {
+    const fullHistory: ContextMessage[] = [
+      user('u1'),
+      assistant(['a']),
+      user('middle'),
+      assistant(['b']),
+      tool('b'),
+      user('later'),
+      tool('a'),
+    ];
+    // The strategy may split after tool('b'), excluding the distant tool('a').
+    const prefix = fullHistory.slice(0, 5);
+    const projected = project(prefix, { synthesizeMissing: true });
+    expect(findMisplacedToolUses(projected)).toEqual([]);
+    const aIndex = projected.findIndex((m) => m.toolCalls.some((tc) => tc.id === 'a'));
+    expect(projected[aIndex + 1]).toMatchObject({ role: 'tool', toolCallId: 'a' });
+    // The synthesized result carries the placeholder text, not the real output.
+    expect(textOf(projected[aIndex + 1])).toContain('not available');
   });
 
   it('does not move a tool result whose toolCallId matches no assistant tool_use', () => {


### PR DESCRIPTION
## Related Issue

No linked issue — see Problem below.

## Problem

Long tool-use sessions could get stuck with repeated `400` errors ("`tool_use` without `tool_result` immediately after"), leaving the user completely unable to continue. Two things combine:

1. A tool result can end up non-adjacent to its tool call in the projected history. For example, a background-task notification flushed after `step.begin` but before the first `tool.call` lands between them (the tool call is folded into the already-pushed assistant message), or an interrupted / nested step delays the result across later exchanges.
2. The experimental micro compaction feature busts the prompt cache, forcing a full revalidation that surfaces this latent misordering as a hard 400.

## What changed

- Repair the `tool_use` / `tool_result` adjacency at projection time, so every tool call is immediately followed by its matching result(s) before messages reach the model. The repair is a no-op for well-formed histories, provider-agnostic, and leaves the underlying history untouched (only the model-facing projection is reordered).
- Default the experimental micro compaction flag off so the cache-bust trigger is no longer active by default; it can still be re-enabled via env or config.
- Add a property-based fuzz test (4,000 randomized histories) plus targeted regression tests asserting the adjacency invariant always holds after projection.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.
