### PR TITLE
fix(tui): open @ file mentions inside slash command arguments

### DIFF
--- a/.changeset/fix-at-mention-slash-arg.md
+++ b/.changeset/fix-at-mention-slash-arg.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Fix @ file mentions not opening when typed inside a slash command argument.

--- a/apps/kimi-code/src/tui/components/editor/file-mention-provider.ts
+++ b/apps/kimi-code/src/tui/components/editor/file-mention-provider.ts
@@ -67,20 +67,11 @@ export class FileMentionProvider implements AutocompleteProvider {
     const currentLine = lines[cursorLine] ?? '';
     const textBeforeCursor = currentLine.slice(0, cursorCol);
 
-    if (shouldSuppressLeadingWhitespaceSlashPath(textBeforeCursor, options.force)) {
-      return null;
-    }
-
-    if (
-      shouldSuppressSlashArgumentCompletion(
-        textBeforeCursor,
-        currentLine.slice(cursorCol),
-        options.force,
-      )
-    ) {
-      return null;
-    }
-
+    // `@` file / folder mentions take priority over the slash-command guards
+    // below. Without this, typing `@` inside a slash command's argument text
+    // (e.g. `/goal Fix the @|checkout docs`) would be swallowed by
+    // `shouldSuppressSlashArgumentCompletion` before the mention branch ever
+    // runs, so the file list never opens.
     const atPrefix = extractAtPrefix(textBeforeCursor);
     if (atPrefix !== null) {
       if (this.fdPath === null || this.additionalDirs.length > 0) {
@@ -102,6 +93,20 @@ export class FileMentionProvider implements AutocompleteProvider {
           options.signal,
         );
       }
+    }
+
+    if (shouldSuppressLeadingWhitespaceSlashPath(textBeforeCursor, options.force)) {
+      return null;
+    }
+
+    if (
+      shouldSuppressSlashArgumentCompletion(
+        textBeforeCursor,
+        currentLine.slice(cursorCol),
+        options.force,
+      )
+    ) {
+      return null;
     }
 
     // Handle slash-command name completion ourselves so that aliases are

--- a/apps/kimi-code/test/tui/components/editor/file-mention-provider.test.ts
+++ b/apps/kimi-code/test/tui/components/editor/file-mention-provider.test.ts
@@ -99,6 +99,21 @@ describe('FileMentionProvider', () => {
     expect(result).toBeNull();
   });
 
+  it('opens @ file mention when typed in the middle of a slash command argument', async () => {
+    writeFileSync(join(workDir, 'README.md'), 'readme');
+    const provider = new FileMentionProvider([GOAL_COMMAND], workDir, NO_FD);
+    // Cursor sits in the middle of the /goal argument text, right after a
+    // freshly typed `@`. The slash-argument guard must not suppress the @
+    // file list here.
+    const line = '/goal Fix the @checkout docs';
+    const result = await provider.getSuggestions([line], 0, '/goal Fix the @'.length, {
+      signal: ctrl(),
+    });
+    expect(result).not.toBeNull();
+    expect(result!.prefix).toBe('@');
+    expect(result!.items.map((item) => item.value)).toContain('@README.md');
+  });
+
   it('still completes slash arguments at the end of an empty argument', async () => {
     const provider = new FileMentionProvider([GOAL_COMMAND], workDir, NO_FD);
     const line = '/goal ';


### PR DESCRIPTION
<!--
Thank you for your contribution to Kimi Code!
Please open an issue before sending a feature PR — PRs without prior discussion may be closed without review.

See https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md for more.
-->

## Related Issue

No related issue.

## Problem

When the editor already holds a slash command with argument text (for example `/goal Fix the checkout docs`) and the cursor is moved back into the middle of that text, typing `@` does not open the file mention list. The slash-argument completion guard returned early because the line starts with `/`, already contains a space, and has non-empty text after the cursor, so the `@` mention branch never ran.

## What changed

Run the `@` file mention branch ahead of the slash-command suppression guards in the autocomplete provider, so file mentions take priority over slash-argument suppression. Plain slash-argument editing without an `@` prefix is still suppressed as before. Added a regression test that types `@` inside a `/goal` argument.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.