### PR TITLE
feat(timing): split TTFT into api-server and client portions

### DIFF
--- a/.changeset/ttft-client-server-split.md
+++ b/.changeset/ttft-client-server-split.md
@@ -2,4 +2,4 @@
 "@moonshot-ai/kimi-code": patch
 ---
 
-Split time-to-first-token in the session log and `KIMI_CODE_DEBUG=1` output into the API-server portion (network + server) and the client portion (in-process request building), so slow turns can be attributed without parsing the wire log.
+Split LLM streaming timing in the session log and `KIMI_CODE_DEBUG=1` output into client vs. API-server portions, so slow turns can be attributed without parsing the wire log. Time-to-first-token splits into the API-server portion (network + server) and the client portion (in-process request building); the decode window splits into time awaiting tokens from the server and time the client spends processing each streamed chunk.

--- a/.changeset/ttft-client-server-split.md
+++ b/.changeset/ttft-client-server-split.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Split time-to-first-token in the session log and `KIMI_CODE_DEBUG=1` output into the API-server portion (network + server) and the client portion (in-process request building), so slow turns can be attributed without parsing the wire log.

--- a/apps/kimi-code/src/utils/usage/debug-timing.ts
+++ b/apps/kimi-code/src/utils/usage/debug-timing.ts
@@ -17,6 +17,13 @@ export interface StepTimingInput {
    */
   readonly llmRequestBuildMs?: number;
   readonly llmServerFirstTokenMs?: number;
+  /**
+   * Split of `llmStreamDurationMs` (the decode window) into server time spent
+   * awaiting parts (`llmServerDecodeMs`) and client time spent processing parts
+   * (`llmClientConsumeMs`). Both present together or not at all.
+   */
+  readonly llmServerDecodeMs?: number;
+  readonly llmClientConsumeMs?: number;
   readonly usage?: DebugTokenUsage;
 }
 
@@ -38,7 +45,9 @@ export function formatStepDebugTiming(input: StepTimingInput): string | undefine
   if (outputTokens !== undefined && outputTokens > 0) {
     if (streamMs >= MIN_STREAM_MS_FOR_TPS) {
       const tps = (outputTokens / (streamMs / 1000)).toFixed(1);
-      parts.push(`TPS: ${tps} tok/s (${outputTokens} tokens in ${formatDuration(streamMs)})`);
+      parts.push(
+        `TPS: ${tps} tok/s (${outputTokens} tokens in ${formatDuration(streamMs)}${formatDecodeSplit(input)})`,
+      );
     } else {
       parts.push(
         `${outputTokens} tokens in ${formatDuration(streamMs)} (stream too short for TPS)`,
@@ -81,6 +90,16 @@ function formatTtft(input: StepTimingInput): string {
   const server = input.llmServerFirstTokenMs;
   if (build === undefined || server === undefined) return total;
   return `${total} (api ${formatDuration(server)} + client ${formatDuration(build)})`;
+}
+
+// Render the decode-window split as a trailing clause, e.g.
+// `; server 4.6s + client 0.4s`. A large client share means the host's per-part
+// processing is throttling decode. Empty when the provider did not report it.
+function formatDecodeSplit(input: StepTimingInput): string {
+  const server = input.llmServerDecodeMs;
+  const client = input.llmClientConsumeMs;
+  if (server === undefined || client === undefined) return '';
+  return `; server ${formatDuration(server)} + client ${formatDuration(client)}`;
 }
 
 function formatDuration(ms: number): string {

--- a/apps/kimi-code/src/utils/usage/debug-timing.ts
+++ b/apps/kimi-code/src/utils/usage/debug-timing.ts
@@ -10,6 +10,13 @@ interface DebugTokenUsage {
 export interface StepTimingInput {
   readonly llmFirstTokenLatencyMs?: number;
   readonly llmStreamDurationMs?: number;
+  /**
+   * Split of `llmFirstTokenLatencyMs` into the client-side request-build
+   * portion (`llmRequestBuildMs`) and the network + API-server portion
+   * (`llmServerFirstTokenMs`). Both present together or not at all.
+   */
+  readonly llmRequestBuildMs?: number;
+  readonly llmServerFirstTokenMs?: number;
   readonly usage?: DebugTokenUsage;
 }
 
@@ -26,7 +33,7 @@ export function formatStepDebugTiming(input: StepTimingInput): string | undefine
   const streamMs = input.llmStreamDurationMs;
   if (latency === undefined || streamMs === undefined) return undefined;
 
-  const parts: string[] = [`TTFT: ${formatDuration(latency)}`];
+  const parts: string[] = [`TTFT: ${formatTtft(input)}`];
   const outputTokens = input.usage?.output;
   if (outputTokens !== undefined && outputTokens > 0) {
     if (streamMs >= MIN_STREAM_MS_FOR_TPS) {
@@ -63,6 +70,17 @@ export function formatStepDebugTiming(input: StepTimingInput): string | undefine
 function usageInputTotal(usage: DebugTokenUsage | undefined): number {
   if (usage === undefined) return 0;
   return (usage.inputOther ?? 0) + (usage.inputCacheRead ?? 0) + (usage.inputCacheCreation ?? 0);
+}
+
+// Render TTFT, splitting the latency into the network + API-server portion and
+// the in-process request-build portion when the provider reported the
+// boundary. Falls back to the bare total otherwise.
+function formatTtft(input: StepTimingInput): string {
+  const total = formatDuration(input.llmFirstTokenLatencyMs ?? 0);
+  const build = input.llmRequestBuildMs;
+  const server = input.llmServerFirstTokenMs;
+  if (build === undefined || server === undefined) return total;
+  return `${total} (api ${formatDuration(server)} + client ${formatDuration(build)})`;
 }
 
 function formatDuration(ms: number): string {

--- a/apps/kimi-code/test/utils/usage/debug-timing.test.ts
+++ b/apps/kimi-code/test/utils/usage/debug-timing.test.ts
@@ -89,6 +89,29 @@ describe('formatStepDebugTiming', () => {
     expect(result).toContain('900ms');
   });
 
+  it('splits TTFT into api-server and client portions when both are present', () => {
+    const result = formatStepDebugTiming({
+      llmFirstTokenLatencyMs: 2500,
+      llmStreamDurationMs: 5000,
+      llmServerFirstTokenMs: 2400,
+      llmRequestBuildMs: 100,
+      usage: { output: 200 },
+    });
+    expect(result).toBe(
+      '[Debug] TTFT: 2.5s (api 2.4s + client 100ms) | TPS: 40.0 tok/s (200 tokens in 5.0s)',
+    );
+  });
+
+  it('falls back to the bare TTFT when only one split component is present', () => {
+    const result = formatStepDebugTiming({
+      llmFirstTokenLatencyMs: 800,
+      llmStreamDurationMs: 5000,
+      llmServerFirstTokenMs: 700,
+      usage: { output: 0 },
+    });
+    expect(result).toBe('[Debug] TTFT: 800ms');
+  });
+
   it('formats durations at or above 1s as seconds', () => {
     const result = formatStepDebugTiming({
       llmFirstTokenLatencyMs: 1500,

--- a/apps/kimi-code/test/utils/usage/debug-timing.test.ts
+++ b/apps/kimi-code/test/utils/usage/debug-timing.test.ts
@@ -112,6 +112,29 @@ describe('formatStepDebugTiming', () => {
     expect(result).toBe('[Debug] TTFT: 800ms');
   });
 
+  it('appends the decode wait/consume split to the TPS clause', () => {
+    const result = formatStepDebugTiming({
+      llmFirstTokenLatencyMs: 800,
+      llmStreamDurationMs: 5000,
+      llmServerDecodeMs: 4600,
+      llmClientConsumeMs: 400,
+      usage: { output: 200 },
+    });
+    expect(result).toBe(
+      '[Debug] TTFT: 800ms | TPS: 40.0 tok/s (200 tokens in 5.0s; server 4.6s + client 400ms)',
+    );
+  });
+
+  it('omits the decode split when only one component is present', () => {
+    const result = formatStepDebugTiming({
+      llmFirstTokenLatencyMs: 800,
+      llmStreamDurationMs: 5000,
+      llmServerDecodeMs: 4600,
+      usage: { output: 200 },
+    });
+    expect(result).toBe('[Debug] TTFT: 800ms | TPS: 40.0 tok/s (200 tokens in 5.0s)');
+  });
+
   it('formats durations at or above 1s as seconds', () => {
     const result = formatStepDebugTiming({
       llmFirstTokenLatencyMs: 1500,

--- a/apps/vis/web/src/components/analysis/TimelineTab.tsx
+++ b/apps/vis/web/src/components/analysis/TimelineTab.tsx
@@ -290,7 +290,19 @@ function StepRow({ step, turnDurationMs }: { step: StepNode; turnDurationMs?: nu
         ) : null}
         <span className="text-fg-3 tabular" title="step wall-clock duration">{formatDuration(step.durationMs)}</span>
         {step.llmFirstTokenLatencyMs !== undefined ? (
-          <span className="text-fg-3 tabular" title="time to first token">ttft {step.llmFirstTokenLatencyMs}ms</span>
+          <span
+            className="text-fg-3 tabular"
+            title={
+              step.llmServerFirstTokenMs !== undefined && step.llmRequestBuildMs !== undefined
+                ? `time to first token (api ${step.llmServerFirstTokenMs}ms + client ${step.llmRequestBuildMs}ms)`
+                : 'time to first token'
+            }
+          >
+            ttft {step.llmFirstTokenLatencyMs}ms
+            {step.llmServerFirstTokenMs !== undefined && step.llmRequestBuildMs !== undefined
+              ? ` (api ${step.llmServerFirstTokenMs} + client ${step.llmRequestBuildMs})`
+              : ''}
+          </span>
         ) : null}
         {step.contextTokens !== undefined ? (
           <span className="text-fg-3 tabular" title="context-window fill after step">ctx {formatTokens(step.contextTokens)}</span>

--- a/apps/vis/web/src/components/analysis/TimelineTab.tsx
+++ b/apps/vis/web/src/components/analysis/TimelineTab.tsx
@@ -304,6 +304,14 @@ function StepRow({ step, turnDurationMs }: { step: StepNode; turnDurationMs?: nu
               : ''}
           </span>
         ) : null}
+        {step.llmServerDecodeMs !== undefined && step.llmClientConsumeMs !== undefined ? (
+          <span
+            className="text-fg-3 tabular"
+            title="decode window split (server awaiting parts + client processing parts)"
+          >
+            decode {step.llmServerDecodeMs}+{step.llmClientConsumeMs}ms
+          </span>
+        ) : null}
         {step.contextTokens !== undefined ? (
           <span className="text-fg-3 tabular" title="context-window fill after step">ctx {formatTokens(step.contextTokens)}</span>
         ) : null}

--- a/apps/vis/web/src/components/wire/parts.tsx
+++ b/apps/vis/web/src/components/wire/parts.tsx
@@ -362,6 +362,16 @@ export function LoopEventDetail({ event }: { event: LoopRecordedEvent }) {
                 <span className="text-fg-1">{event.llmFirstTokenLatencyMs} ms</span>
               </FieldRow>
             ) : null}
+            {event.llmServerFirstTokenMs !== undefined ? (
+              <FieldRow label="firstToken/api">
+                <span className="text-fg-1">{event.llmServerFirstTokenMs} ms</span>
+              </FieldRow>
+            ) : null}
+            {event.llmRequestBuildMs !== undefined ? (
+              <FieldRow label="firstToken/client">
+                <span className="text-fg-1">{event.llmRequestBuildMs} ms</span>
+              </FieldRow>
+            ) : null}
             {event.llmStreamDurationMs !== undefined ? (
               <FieldRow label="streamDuration">
                 <span className="text-fg-1">{event.llmStreamDurationMs} ms</span>

--- a/apps/vis/web/src/components/wire/parts.tsx
+++ b/apps/vis/web/src/components/wire/parts.tsx
@@ -377,6 +377,16 @@ export function LoopEventDetail({ event }: { event: LoopRecordedEvent }) {
                 <span className="text-fg-1">{event.llmStreamDurationMs} ms</span>
               </FieldRow>
             ) : null}
+            {event.llmServerDecodeMs !== undefined ? (
+              <FieldRow label="streamDuration/server">
+                <span className="text-fg-1">{event.llmServerDecodeMs} ms</span>
+              </FieldRow>
+            ) : null}
+            {event.llmClientConsumeMs !== undefined ? (
+              <FieldRow label="streamDuration/client">
+                <span className="text-fg-1">{event.llmClientConsumeMs} ms</span>
+              </FieldRow>
+            ) : null}
           </div>
           {usage !== undefined ? (
             <div>

--- a/apps/vis/web/src/lib/analysis.ts
+++ b/apps/vis/web/src/lib/analysis.ts
@@ -54,6 +54,9 @@ export interface StepNode {
   contextTokens?: number;
   llmFirstTokenLatencyMs?: number;
   llmStreamDurationMs?: number;
+  /** TTFT split: client-side request-build vs. network + API-server time. */
+  llmRequestBuildMs?: number;
+  llmServerFirstTokenMs?: number;
   content: ContentSummary;
   toolCalls: ToolCallNode[];
 }
@@ -317,6 +320,8 @@ export function analyzeWire(entries: readonly WireEntry[]): Analysis {
             step.finishReason = ev.finishReason;
             step.llmFirstTokenLatencyMs = ev.llmFirstTokenLatencyMs;
             step.llmStreamDurationMs = ev.llmStreamDurationMs;
+            step.llmRequestBuildMs = ev.llmRequestBuildMs;
+            step.llmServerFirstTokenMs = ev.llmServerFirstTokenMs;
             if (step.beginTime !== undefined && t !== undefined) step.durationMs = t - step.beginTime;
             // Steps don't carry a generic 'error' finish reason (errors are
             // thrown, not recorded). 'filtered' means the provider blocked the

--- a/apps/vis/web/src/lib/analysis.ts
+++ b/apps/vis/web/src/lib/analysis.ts
@@ -57,6 +57,9 @@ export interface StepNode {
   /** TTFT split: client-side request-build vs. network + API-server time. */
   llmRequestBuildMs?: number;
   llmServerFirstTokenMs?: number;
+  /** Decode split: server time awaiting parts vs. client time processing them. */
+  llmServerDecodeMs?: number;
+  llmClientConsumeMs?: number;
   content: ContentSummary;
   toolCalls: ToolCallNode[];
 }
@@ -322,6 +325,8 @@ export function analyzeWire(entries: readonly WireEntry[]): Analysis {
             step.llmStreamDurationMs = ev.llmStreamDurationMs;
             step.llmRequestBuildMs = ev.llmRequestBuildMs;
             step.llmServerFirstTokenMs = ev.llmServerFirstTokenMs;
+            step.llmServerDecodeMs = ev.llmServerDecodeMs;
+            step.llmClientConsumeMs = ev.llmClientConsumeMs;
             if (step.beginTime !== undefined && t !== undefined) step.durationMs = t - step.beginTime;
             // Steps don't carry a generic 'error' finish reason (errors are
             // thrown, not recorded). 'filtered' means the provider blocked the

--- a/packages/agent-core/src/agent/turn/index.ts
+++ b/packages/agent-core/src/agent/turn/index.ts
@@ -997,6 +997,8 @@ function mapLoopEvent(event: LoopEvent, turnId: number): AgentEvent | undefined 
         finishReason: event.finishReason,
         llmFirstTokenLatencyMs: event.llmFirstTokenLatencyMs,
         llmStreamDurationMs: event.llmStreamDurationMs,
+        llmRequestBuildMs: event.llmRequestBuildMs,
+        llmServerFirstTokenMs: event.llmServerFirstTokenMs,
         providerFinishReason: event.providerFinishReason,
         rawFinishReason: event.rawFinishReason,
       };

--- a/packages/agent-core/src/agent/turn/index.ts
+++ b/packages/agent-core/src/agent/turn/index.ts
@@ -999,6 +999,8 @@ function mapLoopEvent(event: LoopEvent, turnId: number): AgentEvent | undefined 
         llmStreamDurationMs: event.llmStreamDurationMs,
         llmRequestBuildMs: event.llmRequestBuildMs,
         llmServerFirstTokenMs: event.llmServerFirstTokenMs,
+        llmServerDecodeMs: event.llmServerDecodeMs,
+        llmClientConsumeMs: event.llmClientConsumeMs,
         providerFinishReason: event.providerFinishReason,
         rawFinishReason: event.rawFinishReason,
       };

--- a/packages/agent-core/src/agent/turn/kosong-llm.ts
+++ b/packages/agent-core/src/agent/turn/kosong-llm.ts
@@ -25,6 +25,7 @@ import {
   type GenerateCallbacks,
   type Message,
   type ModelCapability,
+  type StreamDecodeStats,
   type StreamedMessagePart,
 } from '@moonshot-ai/kosong';
 
@@ -90,14 +91,16 @@ export class KosongLLM implements LLM {
     let requestSentAt: number | undefined;
     let firstChunkAt: number | undefined;
     let streamEndedAt: number | undefined;
+    let decodeStats: StreamDecodeStats | undefined;
     const markRequestStart = (): void => {
       requestStartedAt = Date.now();
     };
     const markRequestSent = (): void => {
       requestSentAt ??= Date.now();
     };
-    const markStreamEnd = (): void => {
+    const markStreamEnd = (stats?: StreamDecodeStats): void => {
       streamEndedAt = Date.now();
+      decodeStats = stats;
     };
     const markStreamOutput = (): void => {
       firstChunkAt ??= Date.now();
@@ -152,7 +155,7 @@ export class KosongLLM implements LLM {
       streamTiming:
         firstChunkAt === undefined
           ? undefined
-          : buildStreamTiming(requestStartedAt, requestSentAt, firstChunkAt, streamEndedAt),
+          : buildStreamTiming(requestStartedAt, requestSentAt, firstChunkAt, streamEndedAt, decodeStats),
     };
 
     return response;
@@ -168,6 +171,7 @@ function buildStreamTiming(
   requestSentAt: number | undefined,
   firstChunkAt: number,
   streamEndedAt: number | undefined,
+  decodeStats: StreamDecodeStats | undefined,
 ): LLMStreamTiming {
   const outputEndedAt = streamEndedAt ?? Date.now();
   const firstTokenLatencyMs = Math.max(0, firstChunkAt - requestStartedAt);
@@ -184,6 +188,12 @@ function buildStreamTiming(
     const sentAt = Math.min(Math.max(requestSentAt, requestStartedAt), firstChunkAt);
     timing.requestBuildMs = sentAt - requestStartedAt;
     timing.serverFirstTokenMs = firstChunkAt - sentAt;
+  }
+  // Split the decode window into server (awaiting parts) vs. client (processing
+  // parts) time, as accounted by the stream loop.
+  if (decodeStats !== undefined) {
+    timing.serverDecodeMs = Math.max(0, decodeStats.serverDecodeMs);
+    timing.clientConsumeMs = Math.max(0, decodeStats.clientConsumeMs);
   }
   return timing;
 }

--- a/packages/agent-core/src/agent/turn/kosong-llm.ts
+++ b/packages/agent-core/src/agent/turn/kosong-llm.ts
@@ -87,10 +87,14 @@ export class KosongLLM implements LLM {
 
   async chat(params: LLMChatParams): Promise<LLMChatResponse> {
     let requestStartedAt = Date.now();
+    let requestSentAt: number | undefined;
     let firstChunkAt: number | undefined;
     let streamEndedAt: number | undefined;
     const markRequestStart = (): void => {
       requestStartedAt = Date.now();
+    };
+    const markRequestSent = (): void => {
+      requestSentAt ??= Date.now();
     };
     const markStreamEnd = (): void => {
       streamEndedAt = Date.now();
@@ -113,6 +117,7 @@ export class KosongLLM implements LLM {
     const options: GenerateOptionsWithRequestLogFields = {
       signal: params.signal,
       onRequestStart: markRequestStart,
+      onRequestSent: markRequestSent,
       onStreamEnd: markStreamEnd,
       requestLogFields: params.requestLogFields,
     };
@@ -147,7 +152,7 @@ export class KosongLLM implements LLM {
       streamTiming:
         firstChunkAt === undefined
           ? undefined
-          : buildStreamTiming(requestStartedAt, firstChunkAt, streamEndedAt),
+          : buildStreamTiming(requestStartedAt, requestSentAt, firstChunkAt, streamEndedAt),
     };
 
     return response;
@@ -160,14 +165,27 @@ export class KosongLLM implements LLM {
 
 function buildStreamTiming(
   requestStartedAt: number,
+  requestSentAt: number | undefined,
   firstChunkAt: number,
   streamEndedAt: number | undefined,
 ): LLMStreamTiming {
   const outputEndedAt = streamEndedAt ?? Date.now();
-  return {
-    firstTokenLatencyMs: Math.max(0, firstChunkAt - requestStartedAt),
+  const firstTokenLatencyMs = Math.max(0, firstChunkAt - requestStartedAt);
+  const timing: {
+    -readonly [K in keyof LLMStreamTiming]: LLMStreamTiming[K];
+  } = {
+    firstTokenLatencyMs,
     streamDurationMs: Math.max(0, outputEndedAt - firstChunkAt),
   };
+  // Split TTFT across the request-dispatch boundary when the provider reported
+  // it. Clamp `requestSentAt` into [requestStartedAt, firstChunkAt] so a stray
+  // clock reading can never produce a negative or over-long component.
+  if (requestSentAt !== undefined) {
+    const sentAt = Math.min(Math.max(requestSentAt, requestStartedAt), firstChunkAt);
+    timing.requestBuildMs = sentAt - requestStartedAt;
+    timing.serverFirstTokenMs = firstChunkAt - sentAt;
+  }
+  return timing;
 }
 
 function buildKosongCallbacks(

--- a/packages/agent-core/src/loop/events.ts
+++ b/packages/agent-core/src/loop/events.ts
@@ -29,6 +29,13 @@ export interface LoopStepEndEvent {
   readonly llmRequestBuildMs?: number | undefined;
   readonly llmServerFirstTokenMs?: number | undefined;
   /**
+   * Split of `llmStreamDurationMs` (the decode window): time awaiting parts
+   * from the provider vs. time processing parts in-process. Both `undefined`
+   * when the provider stream did not report decode accounting.
+   */
+  readonly llmServerDecodeMs?: number | undefined;
+  readonly llmClientConsumeMs?: number | undefined;
+  /**
    * Provider diagnostics are optional and must not drive loop control.
    * Use `finishReason` for normalized behavior.
    */

--- a/packages/agent-core/src/loop/events.ts
+++ b/packages/agent-core/src/loop/events.ts
@@ -22,6 +22,13 @@ export interface LoopStepEndEvent {
   readonly llmFirstTokenLatencyMs?: number | undefined;
   readonly llmStreamDurationMs?: number | undefined;
   /**
+   * Split of `llmFirstTokenLatencyMs`: in-process request-building time on the
+   * client vs. network + API-server time to the first token. Both `undefined`
+   * when the provider does not report the client/server boundary.
+   */
+  readonly llmRequestBuildMs?: number | undefined;
+  readonly llmServerFirstTokenMs?: number | undefined;
+  /**
    * Provider diagnostics are optional and must not drive loop control.
    * Use `finishReason` for normalized behavior.
    */

--- a/packages/agent-core/src/loop/llm.ts
+++ b/packages/agent-core/src/loop/llm.ts
@@ -31,6 +31,19 @@ export interface LLMRequestLogFields {
 export interface LLMStreamTiming {
   readonly firstTokenLatencyMs: number;
   readonly streamDurationMs: number;
+  /**
+   * Portion of `firstTokenLatencyMs` spent in-process building the request
+   * (message serialization, param assembly) before the provider dispatched the
+   * network call. `undefined` when the provider does not report the
+   * client/server boundary (no `onRequestSent`).
+   */
+  readonly requestBuildMs?: number;
+  /**
+   * Portion of `firstTokenLatencyMs` spent waiting on the network + API server
+   * from request dispatch to the first streamed token. `undefined` when the
+   * provider does not report the client/server boundary.
+   */
+  readonly serverFirstTokenMs?: number;
 }
 
 export interface LLMChatParams {

--- a/packages/agent-core/src/loop/llm.ts
+++ b/packages/agent-core/src/loop/llm.ts
@@ -44,6 +44,14 @@ export interface LLMStreamTiming {
    * provider does not report the client/server boundary.
    */
   readonly serverFirstTokenMs?: number;
+  /**
+   * Split of `streamDurationMs` (the decode window): time spent awaiting parts
+   * from the provider (`serverDecodeMs`, server + network) vs. time spent
+   * processing parts in-process (`clientConsumeMs`, host callbacks / merge).
+   * `undefined` when the provider stream did not report decode accounting.
+   */
+  readonly serverDecodeMs?: number;
+  readonly clientConsumeMs?: number;
 }
 
 export interface LLMChatParams {

--- a/packages/agent-core/src/loop/turn-step.ts
+++ b/packages/agent-core/src/loop/turn-step.ts
@@ -151,6 +151,8 @@ export async function executeLoopStep(deps: ExecuteLoopStepDeps): Promise<{
     llmStreamDurationMs: response.streamTiming?.streamDurationMs,
     llmRequestBuildMs: response.streamTiming?.requestBuildMs,
     llmServerFirstTokenMs: response.streamTiming?.serverFirstTokenMs,
+    llmServerDecodeMs: response.streamTiming?.serverDecodeMs,
+    llmClientConsumeMs: response.streamTiming?.clientConsumeMs,
     ...stepEndProviderDiagnostics(response, effectiveStopReason),
   });
 
@@ -183,7 +185,9 @@ export async function executeLoopStep(deps: ExecuteLoopStepDeps): Promise<{
 /**
  * Emit a per-step completion log with the LLM response timing. TTFT is split
  * into the client-side request-build portion and the network + API-server
- * portion so slow turns can be attributed without parsing the wire log.
+ * portion, and the decode window is split into server (awaiting parts) vs.
+ * client (processing parts) time, so slow turns can be attributed without
+ * parsing the wire log.
  */
 function logStepTiming(
   log: Logger | undefined,
@@ -202,6 +206,8 @@ function logStepTiming(
       ? { serverFirstTokenMs: timing.serverFirstTokenMs }
       : {}),
     streamDurationMs: timing.streamDurationMs,
+    ...(timing.serverDecodeMs !== undefined ? { serverDecodeMs: timing.serverDecodeMs } : {}),
+    ...(timing.clientConsumeMs !== undefined ? { clientConsumeMs: timing.clientConsumeMs } : {}),
     outputTokens: response.usage.output,
   });
 }

--- a/packages/agent-core/src/loop/turn-step.ts
+++ b/packages/agent-core/src/loop/turn-step.ts
@@ -149,8 +149,12 @@ export async function executeLoopStep(deps: ExecuteLoopStepDeps): Promise<{
     finishReason: effectiveStopReason,
     llmFirstTokenLatencyMs: response.streamTiming?.firstTokenLatencyMs,
     llmStreamDurationMs: response.streamTiming?.streamDurationMs,
+    llmRequestBuildMs: response.streamTiming?.requestBuildMs,
+    llmServerFirstTokenMs: response.streamTiming?.serverFirstTokenMs,
     ...stepEndProviderDiagnostics(response, effectiveStopReason),
   });
+
+  logStepTiming(log, turnId, currentStep, response);
 
   let stopTurnAfterStep = stopTurnAfterUsage;
   if (hooks?.afterStep !== undefined) {
@@ -174,6 +178,32 @@ export async function executeLoopStep(deps: ExecuteLoopStepDeps): Promise<{
     stopReason:
       stopTurnAfterStep && effectiveStopReason === 'tool_use' ? 'end_turn' : effectiveStopReason,
   };
+}
+
+/**
+ * Emit a per-step completion log with the LLM response timing. TTFT is split
+ * into the client-side request-build portion and the network + API-server
+ * portion so slow turns can be attributed without parsing the wire log.
+ */
+function logStepTiming(
+  log: Logger | undefined,
+  turnId: string,
+  step: number,
+  response: LLMChatResponse,
+): void {
+  if (log === undefined) return;
+  const timing = response.streamTiming;
+  if (timing === undefined) return;
+  log.info('llm response', {
+    turnStep: `${turnId}/${String(step)}`,
+    ttftMs: timing.firstTokenLatencyMs,
+    ...(timing.requestBuildMs !== undefined ? { requestBuildMs: timing.requestBuildMs } : {}),
+    ...(timing.serverFirstTokenMs !== undefined
+      ? { serverFirstTokenMs: timing.serverFirstTokenMs }
+      : {}),
+    streamDurationMs: timing.streamDurationMs,
+    outputTokens: response.usage.output,
+  });
 }
 
 function deriveStepStopReason(response: LLMChatResponse): LoopStepStopReason {

--- a/packages/agent-core/test/agent/harness/snapshots.ts
+++ b/packages/agent-core/test/agent/harness/snapshots.ts
@@ -319,6 +319,8 @@ function isVolatileDurationKey(key: string): boolean {
     key === 'llmStreamDurationMs' ||
     key === 'llmRequestBuildMs' ||
     key === 'llmServerFirstTokenMs' ||
+    key === 'llmServerDecodeMs' ||
+    key === 'llmClientConsumeMs' ||
     key === 'durationMs'
   );
 }

--- a/packages/agent-core/test/agent/harness/snapshots.ts
+++ b/packages/agent-core/test/agent/harness/snapshots.ts
@@ -314,7 +314,13 @@ function isUuid(value: string): boolean {
 }
 
 function isVolatileDurationKey(key: string): boolean {
-  return key === 'llmFirstTokenLatencyMs' || key === 'llmStreamDurationMs' || key === 'durationMs';
+  return (
+    key === 'llmFirstTokenLatencyMs' ||
+    key === 'llmStreamDurationMs' ||
+    key === 'llmRequestBuildMs' ||
+    key === 'llmServerFirstTokenMs' ||
+    key === 'durationMs'
+  );
 }
 
 function isPlanModeReminder(value: string): boolean {

--- a/packages/agent-core/test/agent/kosong-llm.test.ts
+++ b/packages/agent-core/test/agent/kosong-llm.test.ts
@@ -206,6 +206,71 @@ describe('KosongLLM stream timing', () => {
     expect(response.streamTiming?.requestBuildMs).toBeUndefined();
     expect(response.streamTiming?.serverFirstTokenMs).toBeUndefined();
   });
+
+  it('surfaces the decode wait/consume split reported by the stream', async () => {
+    const generate: GenerateFn = async (
+      _provider,
+      _systemPrompt,
+      _tools,
+      _history,
+      callbacks,
+      options,
+    ) => {
+      options?.onRequestStart?.();
+      options?.onRequestSent?.();
+      await callbacks?.onMessagePart?.({ type: 'text', text: 'timed' });
+      options?.onStreamEnd?.({ serverDecodeMs: 800, clientConsumeMs: 200 });
+      return {
+        id: 'response-1',
+        message: { role: 'assistant', content: [{ type: 'text', text: 'timed' }], toolCalls: [] },
+        usage: emptyUsage(),
+        finishReason: 'completed',
+        rawFinishReason: 'stop',
+      };
+    };
+    const llm = new KosongLLM({ provider, systemPrompt: 'system', generate });
+
+    const response = await llm.chat({
+      messages: [],
+      tools: [],
+      signal: new AbortController().signal,
+    });
+
+    expect(response.streamTiming?.serverDecodeMs).toBe(800);
+    expect(response.streamTiming?.clientConsumeMs).toBe(200);
+  });
+
+  it('leaves the decode split undefined when the stream reports no accounting', async () => {
+    const generate: GenerateFn = async (
+      _provider,
+      _systemPrompt,
+      _tools,
+      _history,
+      callbacks,
+      options,
+    ) => {
+      options?.onRequestStart?.();
+      await callbacks?.onMessagePart?.({ type: 'text', text: 'timed' });
+      options?.onStreamEnd?.(); // no decode stats
+      return {
+        id: 'response-1',
+        message: { role: 'assistant', content: [{ type: 'text', text: 'timed' }], toolCalls: [] },
+        usage: emptyUsage(),
+        finishReason: 'completed',
+        rawFinishReason: 'stop',
+      };
+    };
+    const llm = new KosongLLM({ provider, systemPrompt: 'system', generate });
+
+    const response = await llm.chat({
+      messages: [],
+      tools: [],
+      signal: new AbortController().signal,
+    });
+
+    expect(response.streamTiming?.serverDecodeMs).toBeUndefined();
+    expect(response.streamTiming?.clientConsumeMs).toBeUndefined();
+  });
 });
 
 describe('KosongLLM completion budget', () => {

--- a/packages/agent-core/test/agent/kosong-llm.test.ts
+++ b/packages/agent-core/test/agent/kosong-llm.test.ts
@@ -134,6 +134,78 @@ describe('KosongLLM stream timing', () => {
     expect(response.streamTiming?.firstTokenLatencyMs).toBeGreaterThanOrEqual(0);
     expect(response.streamTiming?.streamDurationMs).toBeGreaterThanOrEqual(0);
   });
+
+  it('splits first-token latency across the request-dispatch boundary', async () => {
+    const generate: GenerateFn = async (
+      _provider,
+      _systemPrompt,
+      _tools,
+      _history,
+      callbacks,
+      options,
+    ) => {
+      options?.onRequestStart?.();
+      options?.onRequestSent?.();
+      await callbacks?.onMessagePart?.({ type: 'text', text: 'timed' });
+      options?.onStreamEnd?.();
+      return {
+        id: 'response-1',
+        message: { role: 'assistant', content: [{ type: 'text', text: 'timed' }], toolCalls: [] },
+        usage: emptyUsage(),
+        finishReason: 'completed',
+        rawFinishReason: 'stop',
+      };
+    };
+    const llm = new KosongLLM({ provider, systemPrompt: 'system', generate });
+
+    const response = await llm.chat({
+      messages: [],
+      tools: [],
+      signal: new AbortController().signal,
+    });
+
+    const timing = response.streamTiming;
+    expect(timing?.requestBuildMs).toBeGreaterThanOrEqual(0);
+    expect(timing?.serverFirstTokenMs).toBeGreaterThanOrEqual(0);
+    // The two components reconstruct the total (allowing for clock granularity).
+    expect((timing?.requestBuildMs ?? 0) + (timing?.serverFirstTokenMs ?? 0)).toBe(
+      timing?.firstTokenLatencyMs,
+    );
+  });
+
+  it('leaves the split undefined when the provider does not report dispatch', async () => {
+    const generate: GenerateFn = async (
+      _provider,
+      _systemPrompt,
+      _tools,
+      _history,
+      callbacks,
+      options,
+    ) => {
+      options?.onRequestStart?.();
+      // No onRequestSent — older providers / stubs that do not mark dispatch.
+      await callbacks?.onMessagePart?.({ type: 'text', text: 'timed' });
+      options?.onStreamEnd?.();
+      return {
+        id: 'response-1',
+        message: { role: 'assistant', content: [{ type: 'text', text: 'timed' }], toolCalls: [] },
+        usage: emptyUsage(),
+        finishReason: 'completed',
+        rawFinishReason: 'stop',
+      };
+    };
+    const llm = new KosongLLM({ provider, systemPrompt: 'system', generate });
+
+    const response = await llm.chat({
+      messages: [],
+      tools: [],
+      signal: new AbortController().signal,
+    });
+
+    expect(response.streamTiming?.firstTokenLatencyMs).toBeGreaterThanOrEqual(0);
+    expect(response.streamTiming?.requestBuildMs).toBeUndefined();
+    expect(response.streamTiming?.serverFirstTokenMs).toBeUndefined();
+  });
 });
 
 describe('KosongLLM completion budget', () => {

--- a/packages/kosong/src/generate.ts
+++ b/packages/kosong/src/generate.ts
@@ -111,53 +111,83 @@ export async function generate(
   // the stream.
   await throwIfAborted(options?.signal, stream);
 
+  // Decode-phase accounting. We split the window from the first streamed part
+  // to stream end into time spent awaiting the next part (server + network) vs.
+  // time spent processing each part in-process (deep copy, host callback, part
+  // merge). `lastResumeAt` marks the end of the previous part's processing, so
+  // the gap until the next part arrives is attributed to the server. The
+  // per-part processing is wrapped in try/finally so the accounting stays
+  // correct across `continue` and thrown aborts.
+  let serverDecodeMs = 0;
+  let clientConsumeMs = 0;
+  let firstPartAt: number | undefined;
+  let lastResumeAt = 0;
+
   for await (const part of stream) {
-    await throwIfAborted(options?.signal, stream);
+    const arrivedAt = Date.now();
+    if (firstPartAt === undefined) {
+      firstPartAt = arrivedAt;
+    } else {
+      serverDecodeMs += arrivedAt - lastResumeAt;
+    }
 
-    // Notify raw part callback (deep copy to avoid aliasing mutations).
-    if (callbacks?.onMessagePart !== undefined) {
-      await callbacks.onMessagePart(deepCopyPart(part));
+    try {
       await throwIfAborted(options?.signal, stream);
-    }
 
-    // Index-based routing for parallel tool call argument deltas.
-    // When a ToolCallPart arrives with an index referring to a tool call
-    // that is NOT the currently-pending one, append it directly to the
-    // correct ToolCall in message.toolCalls instead of relying on sequential
-    // merging. This prevents argument cross-contamination across parallel calls.
-    if (
-      isToolCallPart(part) &&
-      part.index !== undefined &&
-      !isPendingToolCallAtIndex(pendingPart, part.index)
-    ) {
-      const arrayIdx = toolCallIndexMap.get(part.index);
-      if (arrayIdx !== undefined) {
-        const target = message.toolCalls[arrayIdx];
-        if (target !== undefined && part.argumentsPart !== null) {
-          target.arguments =
-            target.arguments === null
-              ? part.argumentsPart
-              : target.arguments + part.argumentsPart;
-        }
-        continue;
+      // Notify raw part callback (deep copy to avoid aliasing mutations).
+      if (callbacks?.onMessagePart !== undefined) {
+        await callbacks.onMessagePart(deepCopyPart(part));
+        await throwIfAborted(options?.signal, stream);
       }
-      // Unknown index — fall through to the sequential logic as a safety net.
-    }
 
-    if (pendingPart === null) {
-      pendingPart = part;
-    } else if (!mergeInPlace(pendingPart, part)) {
-      // Could not merge — flush the pending part and start a new one.
-      // For parallel tool calls this happens when a new ToolCall header arrives
-      // while a previous ToolCall is still pending; the flush finalizes the
-      // previous tool call into `message.toolCalls`.
-      flushPart(message, pendingPart, toolCallIndexMap);
-      pendingPart = part;
+      // Index-based routing for parallel tool call argument deltas.
+      // When a ToolCallPart arrives with an index referring to a tool call
+      // that is NOT the currently-pending one, append it directly to the
+      // correct ToolCall in message.toolCalls instead of relying on sequential
+      // merging. This prevents argument cross-contamination across parallel calls.
+      if (
+        isToolCallPart(part) &&
+        part.index !== undefined &&
+        !isPendingToolCallAtIndex(pendingPart, part.index)
+      ) {
+        const arrayIdx = toolCallIndexMap.get(part.index);
+        if (arrayIdx !== undefined) {
+          const target = message.toolCalls[arrayIdx];
+          if (target !== undefined && part.argumentsPart !== null) {
+            target.arguments =
+              target.arguments === null
+                ? part.argumentsPart
+                : target.arguments + part.argumentsPart;
+          }
+          continue;
+        }
+        // Unknown index — fall through to the sequential logic as a safety net.
+      }
+
+      if (pendingPart === null) {
+        pendingPart = part;
+      } else if (!mergeInPlace(pendingPart, part)) {
+        // Could not merge — flush the pending part and start a new one.
+        // For parallel tool calls this happens when a new ToolCall header arrives
+        // while a previous ToolCall is still pending; the flush finalizes the
+        // previous tool call into `message.toolCalls`.
+        flushPart(message, pendingPart, toolCallIndexMap);
+        pendingPart = part;
+      }
+    } finally {
+      lastResumeAt = Date.now();
+      clientConsumeMs += lastResumeAt - arrivedAt;
     }
   }
 
   await throwIfAborted(options?.signal, stream);
-  options?.onStreamEnd?.();
+  if (firstPartAt !== undefined) {
+    // Tail wait: from the last processed part to the stream's done signal.
+    serverDecodeMs += Date.now() - lastResumeAt;
+  }
+  options?.onStreamEnd?.(
+    firstPartAt === undefined ? undefined : { serverDecodeMs, clientConsumeMs },
+  );
 
   // Flush the last pending part.
   if (pendingPart !== null) {

--- a/packages/kosong/src/provider.ts
+++ b/packages/kosong/src/provider.ts
@@ -130,9 +130,29 @@ export interface GenerateOptions {
   onRequestSent?: () => void;
   /**
    * Host-side instrumentation hook fired after the provider stream is fully
-   * drained, before post-processing the assembled response.
+   * drained, before post-processing the assembled response. Receives the
+   * {@link StreamDecodeStats} accounting accumulated across the stream when at
+   * least one part was streamed, or `undefined` for an empty stream.
    */
-  onStreamEnd?: () => void;
+  onStreamEnd?: (stats?: StreamDecodeStats) => void;
+}
+
+/**
+ * Decode-phase accounting for a single streamed generation. Splits the window
+ * from the first streamed part to stream end into the time spent waiting on the
+ * provider for the next part (server + network) versus the time spent
+ * processing each part in-process (deep copy, host callbacks, part merging).
+ *
+ * Because both buckets are wall-clock measured on the single JS thread, a
+ * stop-the-world GC pause that lands while awaiting the next part is counted in
+ * {@link serverDecodeMs}; a non-trivial {@link clientConsumeMs} share is the
+ * unambiguous signal that the host's per-part processing is throttling decode.
+ */
+export interface StreamDecodeStats {
+  /** Cumulative time spent awaiting the next streamed part (server + network). */
+  readonly serverDecodeMs: number;
+  /** Cumulative time spent processing streamed parts in-process (client). */
+  readonly clientConsumeMs: number;
 }
 
 /**

--- a/packages/kosong/src/provider.ts
+++ b/packages/kosong/src/provider.ts
@@ -119,6 +119,16 @@ export interface GenerateOptions {
    */
   onRequestStart?: () => void;
   /**
+   * Host-side instrumentation hook fired by the provider adapter immediately
+   * before it dispatches the network request to the upstream API. The window
+   * between {@link onRequestStart} and this hook is in-process request-building
+   * time (message serialization, param assembly) spent by the client; the
+   * window between this hook and the first streamed part is network + server
+   * time. Splitting time-to-first-token across this boundary lets hosts
+   * attribute latency to the client vs. the API server.
+   */
+  onRequestSent?: () => void;
+  /**
    * Host-side instrumentation hook fired after the provider stream is fully
    * drained, before post-processing the assembled response.
    */

--- a/packages/kosong/src/providers/anthropic.ts
+++ b/packages/kosong/src/providers/anthropic.ts
@@ -1102,6 +1102,7 @@ export class AnthropicChatProvider implements ChatProvider {
     }
     const finalRequestOptions = Object.keys(requestOptions).length > 0 ? requestOptions : undefined;
     const client = this._createClient(options?.auth);
+    options?.onRequestSent?.();
 
     if (this._stream) {
       // Use the raw Messages stream instead of the SDK MessageStream helper.

--- a/packages/kosong/src/providers/google-genai.ts
+++ b/packages/kosong/src/providers/google-genai.ts
@@ -790,6 +790,7 @@ export class GoogleGenAIChatProvider implements ChatProvider {
       // the initial SDK request against the caller's abort signal ourselves.
       // Once we have a response/stream object, the wrapper below continues to
       // check the signal at each chunk boundary.
+      options?.onRequestSent?.();
       if (this._stream) {
         const stream = await Promise.race([
           models.generateContentStream(params),

--- a/packages/kosong/src/providers/kimi.ts
+++ b/packages/kosong/src/providers/kimi.ts
@@ -488,6 +488,7 @@ export class KimiChatProvider implements ChatProvider {
       const client = this._createClient(options?.auth);
       // Use type assertion via unknown because we pass Moonshot-proprietary fields
       // (reasoning_effort, thinking) that don't exist in the OpenAI type definitions.
+      options?.onRequestSent?.();
       const response = (await client.chat.completions.create(
         createParams as unknown as OpenAI.Chat.ChatCompletionCreateParamsNonStreaming,
         options?.signal ? { signal: options.signal } : undefined,

--- a/packages/kosong/src/providers/openai-legacy.ts
+++ b/packages/kosong/src/providers/openai-legacy.ts
@@ -571,6 +571,7 @@ export class OpenAILegacyChatProvider implements ChatProvider {
 
     try {
       const client = this._createClient(options?.auth);
+      options?.onRequestSent?.();
       const response = (await client.chat.completions.create(
         createParams as unknown as OpenAI.Chat.ChatCompletionCreateParamsNonStreaming,
         options?.signal ? { signal: options.signal } : undefined,

--- a/packages/kosong/src/providers/openai-responses.ts
+++ b/packages/kosong/src/providers/openai-responses.ts
@@ -1084,6 +1084,7 @@ export class OpenAIResponsesChatProvider implements ChatProvider {
         );
       }
 
+      options?.onRequestSent?.();
       const response = await (
         client.responses as {
           create(params: unknown, opts?: unknown): Promise<unknown>;

--- a/packages/kosong/test/generate.test.ts
+++ b/packages/kosong/test/generate.test.ts
@@ -932,4 +932,84 @@ describe('generate()', () => {
       expect(result.rawFinishReason).toBe('content_filter');
     });
   });
+
+  describe('decode accounting', () => {
+    const sleep = (ms: number): Promise<void> => new Promise((r) => setTimeout(r, ms));
+
+    function createDelayedStream(
+      parts: StreamedMessagePart[],
+      perPartWaitMs: number,
+    ): StreamedMessage {
+      return {
+        get id(): string | null {
+          return null;
+        },
+        get usage(): TokenUsage | null {
+          return null;
+        },
+        finishReason: 'completed',
+        rawFinishReason: 'stop',
+        async *[Symbol.asyncIterator](): AsyncIterator<StreamedMessagePart> {
+          let first = true;
+          for (const part of parts) {
+            // Simulate the provider taking time to produce each part after the
+            // first (the first part's wait is time-to-first-token, not decode).
+            if (!first && perPartWaitMs > 0) await sleep(perPartWaitMs);
+            first = false;
+            yield part;
+          }
+        },
+      };
+    }
+
+    it('attributes per-part processing time to the client bucket', async () => {
+      const stream = createDelayedStream(
+        [
+          { type: 'text', text: 'a' },
+          { type: 'text', text: 'b' },
+          { type: 'text', text: 'c' },
+        ],
+        0, // provider yields instantly — all measurable time is client-side
+      );
+      const provider = createMockProvider(stream);
+      let stats: { serverDecodeMs: number; clientConsumeMs: number } | undefined;
+      await generate(provider, '', [], [], {
+        async onMessagePart(): Promise<void> {
+          await sleep(25);
+        },
+      }, {
+        onStreamEnd: (s) => {
+          stats = s;
+        },
+      });
+      expect(stats).toBeDefined();
+      expect(stats!.clientConsumeMs).toBeGreaterThan(stats!.serverDecodeMs);
+      expect(stats!.clientConsumeMs).toBeGreaterThanOrEqual(50);
+    });
+
+    it('attributes time spent awaiting parts to the server bucket', async () => {
+      const stream = createDelayedStream(
+        [
+          { type: 'text', text: 'a' },
+          { type: 'text', text: 'b' },
+          { type: 'text', text: 'c' },
+        ],
+        25, // provider stalls before each part after the first
+      );
+      const provider = createMockProvider(stream);
+      let stats: { serverDecodeMs: number; clientConsumeMs: number } | undefined;
+      await generate(provider, '', [], [], {
+        onMessagePart(): void {
+          // instant client processing
+        },
+      }, {
+        onStreamEnd: (s) => {
+          stats = s;
+        },
+      });
+      expect(stats).toBeDefined();
+      expect(stats!.serverDecodeMs).toBeGreaterThan(stats!.clientConsumeMs);
+      expect(stats!.serverDecodeMs).toBeGreaterThanOrEqual(40);
+    });
+  });
 });

--- a/packages/node-sdk/test/session-event-types.test.ts
+++ b/packages/node-sdk/test/session-event-types.test.ts
@@ -34,6 +34,12 @@ describe('Event public types', () => {
     expectTypeOf<EventByType<'turn.step.completed'>['llmServerFirstTokenMs']>().toEqualTypeOf<
       number | undefined
     >();
+    expectTypeOf<EventByType<'turn.step.completed'>['llmServerDecodeMs']>().toEqualTypeOf<
+      number | undefined
+    >();
+    expectTypeOf<EventByType<'turn.step.completed'>['llmClientConsumeMs']>().toEqualTypeOf<
+      number | undefined
+    >();
   });
 
   it('narrows subagent lifecycle events by type', () => {

--- a/packages/node-sdk/test/session-event-types.test.ts
+++ b/packages/node-sdk/test/session-event-types.test.ts
@@ -28,6 +28,12 @@ describe('Event public types', () => {
     expectTypeOf<EventByType<'turn.step.completed'>['llmStreamDurationMs']>().toEqualTypeOf<
       number | undefined
     >();
+    expectTypeOf<EventByType<'turn.step.completed'>['llmRequestBuildMs']>().toEqualTypeOf<
+      number | undefined
+    >();
+    expectTypeOf<EventByType<'turn.step.completed'>['llmServerFirstTokenMs']>().toEqualTypeOf<
+      number | undefined
+    >();
   });
 
   it('narrows subagent lifecycle events by type', () => {

--- a/packages/protocol/src/events.ts
+++ b/packages/protocol/src/events.ts
@@ -437,6 +437,13 @@ export interface TurnStepCompletedEvent {
    */
   readonly llmRequestBuildMs?: number;
   readonly llmServerFirstTokenMs?: number;
+  /**
+   * Split of `llmStreamDurationMs` (the decode window): time awaiting parts from
+   * the provider vs. time processing parts in-process. Both omitted when the
+   * provider stream did not report decode accounting.
+   */
+  readonly llmServerDecodeMs?: number;
+  readonly llmClientConsumeMs?: number;
   readonly providerFinishReason?: FinishReason;
   readonly rawFinishReason?: string;
 }
@@ -1105,6 +1112,8 @@ export const turnStepCompletedEventSchema = z.object({
   llmStreamDurationMs: z.number().optional(),
   llmRequestBuildMs: z.number().optional(),
   llmServerFirstTokenMs: z.number().optional(),
+  llmServerDecodeMs: z.number().optional(),
+  llmClientConsumeMs: z.number().optional(),
   providerFinishReason: finishReasonSchema.optional(),
   rawFinishReason: z.string().optional(),
 }) satisfies z.ZodType<TurnStepCompletedEvent>;

--- a/packages/protocol/src/events.ts
+++ b/packages/protocol/src/events.ts
@@ -430,6 +430,13 @@ export interface TurnStepCompletedEvent {
   readonly finishReason?: string;
   readonly llmFirstTokenLatencyMs?: number;
   readonly llmStreamDurationMs?: number;
+  /**
+   * Split of `llmFirstTokenLatencyMs`: in-process request-building time on the
+   * client vs. network + API-server time to the first token. Both omitted when
+   * the provider does not report the client/server boundary.
+   */
+  readonly llmRequestBuildMs?: number;
+  readonly llmServerFirstTokenMs?: number;
   readonly providerFinishReason?: FinishReason;
   readonly rawFinishReason?: string;
 }
@@ -1096,6 +1103,8 @@ export const turnStepCompletedEventSchema = z.object({
   finishReason: z.string().optional(),
   llmFirstTokenLatencyMs: z.number().optional(),
   llmStreamDurationMs: z.number().optional(),
+  llmRequestBuildMs: z.number().optional(),
+  llmServerFirstTokenMs: z.number().optional(),
   providerFinishReason: finishReasonSchema.optional(),
   rawFinishReason: z.string().optional(),
 }) satisfies z.ZodType<TurnStepCompletedEvent>;


### PR DESCRIPTION
## Why

Time-to-first-token (TTFT) previously lumped together two very different things: the in-process work kimi-code does to build a request (serializing the message history, assembling params) and the network + API-server latency until the first token. When a turn felt slow, there was no way to tell whether the client or the server was responsible — exactly the question that came up while investigating slow sessions.

## What

Add an `onRequestSent` hook to kosong's `GenerateOptions`, fired by every provider (`kimi`, `openai-legacy`, `openai-responses`, `anthropic`, `google-genai`) immediately before it dispatches the network call. TTFT is then split across that boundary:

- **client** = request start → dispatch (message serialization, param build)
- **api** = dispatch → first streamed token (network + server)

The split flows through `step.end` / `turn.step.completed` (and therefore `wire.jsonl`) and shows up in three places:

- **`KIMI_CODE_DEBUG=1`**: `TTFT: 2.5s (api 2.4s + client 100ms)`
- **session log**: new `llm response` line with `ttftMs` / `requestBuildMs` / `serverFirstTokenMs` / `streamDurationMs` / `outputTokens`
- **vis**: `firstToken/api` + `firstToken/client` detail rows and a timeline label

When a provider does not report the boundary, the split is omitted and only the total TTFT is shown — fully backward compatible.

### Boundary note

The provider SDKs' own JSON serialization happens inside `create()`, so it is counted in the `api` portion (typically tens of ms). This is the known trade-off of placing the marker just before the SDK call rather than wrapping `fetch`.

## Test

- Full `typecheck` passes across all packages
- `lint`: 0 errors
- New/updated unit tests: TTFT split display + fallback (`debug-timing`), split computation + graceful degradation when no boundary is reported (`kosong-llm`), snapshot normalizer, protocol type assertions, vis analysis
- Full suite: the only failures are pre-existing and unrelated to this change (`cli/update/preflight.test.ts` — confirmed failing on the base via stash; `packages/server/test/fileLaunch.test.ts` — a Windows-path assertion in an untouched package)