### PR TITLE
ci(kimi-desktop): strip Developer ID prefix from CSC_NAME

### DIFF
--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -118,6 +118,16 @@ jobs:
           certificate-p12: ${{ secrets.APPLE_CERTIFICATE_P12 }}
           certificate-password: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
 
+      - name: Prepare CSC_NAME for electron-builder (macOS)
+        if: runner.os == 'macOS' && inputs.sign-macos
+        shell: bash
+        run: |
+          # electron-builder rejects the "Developer ID Application: " prefix in
+          # CSC_NAME; strip it so the certificate matches by team name + ID.
+          name="${APPLE_SIGNING_IDENTITY}"
+          name="${name#Developer ID Application: }"
+          echo "CSC_NAME=$name" >> "$GITHUB_ENV"
+
       - name: Prepare notarization API key (macOS)
         if: runner.os == 'macOS' && inputs.sign-macos
         shell: bash
@@ -137,7 +147,6 @@ jobs:
           # API key; otherwise it builds unsigned.
           CSC_IDENTITY_AUTO_DISCOVERY: ${{ (runner.os == 'macOS' && inputs.sign-macos) && 'true' || 'false' }}
           CSC_KEYCHAIN: ${{ env.APPLE_KEYCHAIN_PATH }}
-          CSC_NAME: ${{ env.APPLE_SIGNING_IDENTITY }}
           KIMI_DESKTOP_NOTARIZE: ${{ (runner.os == 'macOS' && inputs.sign-macos) && 'true' || 'false' }}
           APPLE_API_KEY_ID: ${{ secrets.APPLE_NOTARIZATION_KEY_ID }}
           APPLE_API_ISSUER: ${{ secrets.APPLE_NOTARIZATION_ISSUER_ID }}

--- a/apps/kimi-desktop/electron-builder.config.cjs
+++ b/apps/kimi-desktop/electron-builder.config.cjs
@@ -63,5 +63,6 @@ module.exports = {
     category: 'Development',
     target: ['AppImage', 'deb'],
     artifactName: 'KCD-Internal-${version}-${arch}.${ext}',
+    maintainer: 'Moonshot AI',
   },
 };

--- a/apps/kimi-desktop/package.json
+++ b/apps/kimi-desktop/package.json
@@ -5,6 +5,7 @@
   "license": "MIT",
   "description": "Kimi Code desktop client — an Electron shell around the Kimi web UI.",
   "author": "Moonshot AI",
+  "homepage": "https://github.com/MoonshotAI/kimi-code",
   "type": "module",
   "main": "out/main.cjs",
   "scripts": {


### PR DESCRIPTION
Fixes the macOS signing step in the desktop-build workflow.

electron-builder rejects the 'Developer ID Application: ' prefix in CSC_NAME, but the keychain setup exports the full certificate name. Strip the prefix before passing it to electron-builder.

Without this, the macOS desktop build fails with: `Please remove prefix "Developer ID Application:" from the specified name`.