### PR TITLE
fix(web): surface error when adding a workspace by path fails

### DIFF
--- a/.changeset/fix-web-add-workspace-invalid-path.md
+++ b/.changeset/fix-web-add-workspace-invalid-path.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Fix adding a workspace by path in the web UI failing silently when the daemon rejects the path; it now shows an error instead of a broken workspace.

--- a/apps/kimi-web/src/App.vue
+++ b/apps/kimi-web/src/App.vue
@@ -483,11 +483,12 @@ async function handleSubmit(payload: SubmitPayload): Promise<void> {
 }
 
 async function handleAddWorkspace(root: string): Promise<void> {
-  showAddWorkspace.value = false;
   const added = await client.addWorkspaceByPath(root);
-  // Keep the pending submission when the daemon rejects the path so the user
-  // can retry with a valid one instead of losing their prompt.
+  // Keep the picker open (and the pending submission intact) when the daemon
+  // rejects the path so the user can retry with a valid one. Closing via
+  // Escape goes through handleCloseAddWorkspace, which drops the pending prompt.
   if (!added) return;
+  showAddWorkspace.value = false;
   const pending = pendingWorkspaceSubmit.value;
   pendingWorkspaceSubmit.value = null;
   const wsId = client.activeWorkspaceId.value;

--- a/apps/kimi-web/src/App.vue
+++ b/apps/kimi-web/src/App.vue
@@ -484,7 +484,10 @@ async function handleSubmit(payload: SubmitPayload): Promise<void> {
 
 async function handleAddWorkspace(root: string): Promise<void> {
   showAddWorkspace.value = false;
-  await client.addWorkspaceByPath(root);
+  const added = await client.addWorkspaceByPath(root);
+  // Keep the pending submission when the daemon rejects the path so the user
+  // can retry with a valid one instead of losing their prompt.
+  if (!added) return;
   const pending = pendingWorkspaceSubmit.value;
   pendingWorkspaceSubmit.value = null;
   const wsId = client.activeWorkspaceId.value;

--- a/apps/kimi-web/src/App.vue
+++ b/apps/kimi-web/src/App.vue
@@ -244,6 +244,10 @@ type SubmitPayload = {
   attachments: { fileId: string; kind: 'image' | 'video' }[];
 };
 const pendingWorkspaceSubmit = ref<SubmitPayload | null>(null);
+// Inline error shown inside the add-workspace picker after the daemon rejects
+// a path. Kept separate from the global toast so the feedback is visible above
+// the picker's backdrop and persists until the user retries or closes.
+const addWorkspaceError = ref<string | null>(null);
 
 // Any of these modal/overlay layers, when open, owns Escape. The global
 // capture-phase handler must NOT close a background side panel out from under an
@@ -483,11 +487,16 @@ async function handleSubmit(payload: SubmitPayload): Promise<void> {
 }
 
 async function handleAddWorkspace(root: string): Promise<void> {
+  addWorkspaceError.value = null;
   const added = await client.addWorkspaceByPath(root);
   // Keep the picker open (and the pending submission intact) when the daemon
-  // rejects the path so the user can retry with a valid one. Closing via
-  // Escape goes through handleCloseAddWorkspace, which drops the pending prompt.
-  if (!added) return;
+  // rejects the path so the user can retry with a valid one. The error is shown
+  // inline in the picker. Closing via Escape goes through handleCloseAddWorkspace,
+  // which drops the pending prompt.
+  if (!added) {
+    addWorkspaceError.value = t('workspace.addFailed');
+    return;
+  }
   showAddWorkspace.value = false;
   const pending = pendingWorkspaceSubmit.value;
   pendingWorkspaceSubmit.value = null;
@@ -499,6 +508,7 @@ async function handleAddWorkspace(root: string): Promise<void> {
 
 function handleCloseAddWorkspace(): void {
   pendingWorkspaceSubmit.value = null;
+  addWorkspaceError.value = null;
   showAddWorkspace.value = false;
 }
 
@@ -885,6 +895,7 @@ function openPr(url: string): void {
       :browse-fs="client.browseFs"
       :get-fs-home="client.getFsHome"
       :default-path="client.visibleWorkspace.value?.root ?? client.status.value.cwd"
+      :error="addWorkspaceError"
       @add="handleAddWorkspace($event)"
       @close="handleCloseAddWorkspace"
     />

--- a/apps/kimi-web/src/api/daemon/client.ts
+++ b/apps/kimi-web/src/api/daemon/client.ts
@@ -973,8 +973,8 @@ export class DaemonKimiWebApi implements KimiWebApi {
 
   /**
    * Register a workspace by folder path.
-   * PRESUMED — POST /api/v1/workspaces { root, name? }. On error this throws so
-   * the composable can fall back to a locally-derived workspace from the path.
+   * PRESUMED — POST /api/v1/workspaces { root, name? }. Throws on error (e.g.
+   * path not found) so the caller can surface it to the user.
    */
   async addWorkspace(input: { root: string; name?: string }): Promise<AppWorkspace> {
     const body: Record<string, unknown> = { root: input.root };

--- a/apps/kimi-web/src/components/dialogs/AddWorkspaceDialog.vue
+++ b/apps/kimi-web/src/components/dialogs/AddWorkspaceDialog.vue
@@ -16,6 +16,8 @@ const props = defineProps<{
   getFsHome: () => Promise<{ home: string; recentRoots: string[] }>;
   /** Where the browser opens by default — the path kimi-web is working in. */
   defaultPath?: string;
+  /** Inline error from a failed add attempt (e.g. daemon rejected the path). */
+  error?: string | null;
 }>();
 
 const emit = defineEmits<{
@@ -336,6 +338,10 @@ onUnmounted(() => {
         </template>
       </div>
 
+      <!-- Inline error from a failed add attempt. Shown inside the dialog so it
+           is visible above the backdrop and persists until the next attempt. -->
+      <div v-if="error" class="add-error" role="alert">{{ error }}</div>
+
       <!-- Actions -->
       <div class="actions">
         <button
@@ -591,6 +597,16 @@ onUnmounted(() => {
 .paste-add:disabled { opacity: 0.5; cursor: not-allowed; }
 
 /* Actions */
+.add-error {
+  margin: 0 14px 8px;
+  padding: 6px 10px;
+  font-family: var(--mono);
+  font-size: var(--ui-font-size-xs);
+  color: #b3261e;
+  background: rgba(179, 38, 30, 0.08);
+  border: 1px solid rgba(179, 38, 30, 0.25);
+  border-radius: 3px;
+}
 .actions {
   display: flex;
   gap: 8px;

--- a/apps/kimi-web/src/composables/client/useWorkspaceState.ts
+++ b/apps/kimi-web/src/composables/client/useWorkspaceState.ts
@@ -659,17 +659,24 @@ export function useWorkspaceState(rawState: ExtendedState, deps: UseWorkspaceSta
     }
   }
 
-  /** Add a workspace by folder path, registering it with the daemon. */
-  async function addWorkspaceByPath(root: string): Promise<void> {
+  /**
+   * Add a workspace by folder path, registering it with the daemon. Returns true
+   * when the workspace was registered and selected; false when the daemon
+   * rejected the path (the error is surfaced to the user) so callers can keep
+   * any pending submission instead of dropping it.
+   */
+  async function addWorkspaceByPath(root: string): Promise<boolean> {
     const trimmed = root.trim();
-    if (!trimmed) return;
+    if (!trimmed) return false;
     const api = getKimiWebApi();
     try {
       const ws = await api.addWorkspace({ root: trimmed });
       upsertWorkspacePreserveOrder(ws);
       openWorkspaceDraft(ws.id);
+      return true;
     } catch (err) {
       pushOperationFailure('addWorkspace', err);
+      return false;
     }
   }
 

--- a/apps/kimi-web/src/composables/client/useWorkspaceState.ts
+++ b/apps/kimi-web/src/composables/client/useWorkspaceState.ts
@@ -23,7 +23,6 @@ import type {
 } from '../../api/types';
 import { safeRemove, STORAGE_KEYS } from '../../lib/storage';
 import { parseDiff } from '../../lib/parseDiff';
-import { basename } from '../../lib/pathBasename';
 import { readSessionIdFromLocation, sessionUrl } from '../../lib/sessionRoute';
 import type { SessionUrlMode } from '../../lib/sessionRoute';
 import type {
@@ -660,11 +659,7 @@ export function useWorkspaceState(rawState: ExtendedState, deps: UseWorkspaceSta
     }
   }
 
-  /**
-   * Add a workspace by folder path. Tries the daemon registry; on failure (or in
-   * fallback mode) creates a locally-derived workspace from the path and
-   * remembers it, then selects it.
-   */
+  /** Add a workspace by folder path, registering it with the daemon. */
   async function addWorkspaceByPath(root: string): Promise<void> {
     const trimmed = root.trim();
     if (!trimmed) return;
@@ -673,22 +668,8 @@ export function useWorkspaceState(rawState: ExtendedState, deps: UseWorkspaceSta
       const ws = await api.addWorkspace({ root: trimmed });
       upsertWorkspacePreserveOrder(ws);
       openWorkspaceDraft(ws.id);
-    } catch {
-      // Fallback: remember a derived workspace locally (id = root = path).
-      const existing = rawState.workspaces.find((w) => w.root === trimmed);
-      if (!existing) {
-        rawState.workspaces = [
-          {
-            id: trimmed,
-            root: trimmed,
-            name: basename(trimmed),
-            isGitRepo: false,
-            sessionCount: 0,
-          },
-          ...rawState.workspaces,
-        ];
-      }
-      openWorkspaceDraft(trimmed);
+    } catch (err) {
+      pushOperationFailure('addWorkspace', err);
     }
   }
 

--- a/apps/kimi-web/src/composables/client/useWorkspaceState.ts
+++ b/apps/kimi-web/src/composables/client/useWorkspaceState.ts
@@ -662,8 +662,9 @@ export function useWorkspaceState(rawState: ExtendedState, deps: UseWorkspaceSta
   /**
    * Add a workspace by folder path, registering it with the daemon. Returns true
    * when the workspace was registered and selected; false when the daemon
-   * rejected the path (the error is surfaced to the user) so callers can keep
-   * any pending submission instead of dropping it.
+   * rejected the path, so callers can keep the picker open and any pending
+   * submission instead of dropping it. The caller surfaces the failure to the
+   * user (e.g. an inline error in the picker).
    */
   async function addWorkspaceByPath(root: string): Promise<boolean> {
     const trimmed = root.trim();
@@ -674,8 +675,7 @@ export function useWorkspaceState(rawState: ExtendedState, deps: UseWorkspaceSta
       upsertWorkspacePreserveOrder(ws);
       openWorkspaceDraft(ws.id);
       return true;
-    } catch (err) {
-      pushOperationFailure('addWorkspace', err);
+    } catch {
       return false;
     }
   }

--- a/apps/kimi-web/src/i18n/locales/en/workspace.ts
+++ b/apps/kimi-web/src/i18n/locales/en/workspace.ts
@@ -24,6 +24,7 @@ export default {
   add: 'Add',
   cancel: 'Cancel',
   addHint: 'Paste an absolute folder path, or pick a recent one.',
+  addFailed: "Couldn't open this folder. Check the path and try again.",
   // Folder browser
   openThisFolder: 'Open this folder',
   up: 'Up',

--- a/apps/kimi-web/src/i18n/locales/zh/workspace.ts
+++ b/apps/kimi-web/src/i18n/locales/zh/workspace.ts
@@ -24,6 +24,7 @@ export default {
   add: '添加',
   cancel: '取消',
   addHint: '粘贴一个绝对路径，或从最近用过的文件夹中选择。',
+  addFailed: '无法打开此文件夹，请检查路径后重试。',
   // Folder browser
   openThisFolder: '打开此文件夹',
   up: '上一级',

--- a/apps/kimi-web/test/workspace-state.test.ts
+++ b/apps/kimi-web/test/workspace-state.test.ts
@@ -243,7 +243,7 @@ describe('useWorkspaceState — addWorkspaceByPath', () => {
     expect(deps.pushOperationFailure).not.toHaveBeenCalled();
   });
 
-  it('surfaces the error and adds no local workspace on failure', async () => {
+  it('returns false and adds no local workspace on failure', async () => {
     const err = new Error('path not found');
     apiMock.addWorkspace.mockRejectedValue(err);
     const state = createState();
@@ -253,7 +253,8 @@ describe('useWorkspaceState — addWorkspaceByPath', () => {
     const ok = await workspace.addWorkspaceByPath('/abs/missing');
 
     expect(ok).toBe(false);
-    expect(deps.pushOperationFailure).toHaveBeenCalledWith('addWorkspace', err);
+    // The caller (the picker) is responsible for surfacing the failure inline.
+    expect(deps.pushOperationFailure).not.toHaveBeenCalled();
     expect(state.workspaces).toEqual([]);
     expect(state.activeWorkspaceId).toBeNull();
   });

--- a/apps/kimi-web/test/workspace-state.test.ts
+++ b/apps/kimi-web/test/workspace-state.test.ts
@@ -9,6 +9,7 @@ import type { ExtendedState } from '../src/composables/useKimiWebClient';
 const apiMock = vi.hoisted(() => ({
   abortPrompt: vi.fn(),
   abortSession: vi.fn(),
+  addWorkspace: vi.fn(),
 }));
 
 vi.mock('../src/api', () => ({
@@ -212,5 +213,46 @@ describe('mergeWorkspaces', () => {
     });
 
     expect(result.map((w) => w.root)).not.toContain('/agent/A');
+  });
+});
+
+describe('useWorkspaceState — addWorkspaceByPath', () => {
+  beforeEach(() => {
+    apiMock.addWorkspace.mockReset();
+  });
+
+  it('registers the workspace with the daemon and selects it', async () => {
+    const registered = {
+      id: 'wd_abc',
+      root: '/abs/path',
+      name: 'path',
+      isGitRepo: false,
+      sessionCount: 0,
+    };
+    apiMock.addWorkspace.mockResolvedValue(registered);
+    const state = createState();
+    const deps = createDeps();
+    const workspace = useWorkspaceState(state, deps);
+
+    await workspace.addWorkspaceByPath('  /abs/path  ');
+
+    expect(apiMock.addWorkspace).toHaveBeenCalledWith({ root: '/abs/path' });
+    expect(state.workspaces).toContainEqual(registered);
+    expect(state.activeWorkspaceId).toBe('wd_abc');
+    expect(deps.pushOperationFailure).not.toHaveBeenCalled();
+  });
+
+  it('surfaces the error and adds no local workspace on failure', async () => {
+    const err = new Error('path not found');
+    apiMock.addWorkspace.mockRejectedValue(err);
+    const state = createState();
+    const deps = createDeps();
+    const workspace = useWorkspaceState(state, deps);
+
+    await workspace.addWorkspaceByPath('/abs/missing');
+
+    expect(deps.pushOperationFailure).toHaveBeenCalledWith('addWorkspace', err);
+    expect(state.workspaces).toEqual([]);
+    expect(state.activeWorkspaceId).toBeNull();
   });
 });

--- a/apps/kimi-web/test/workspace-state.test.ts
+++ b/apps/kimi-web/test/workspace-state.test.ts
@@ -234,8 +234,9 @@ describe('useWorkspaceState — addWorkspaceByPath', () => {
     const deps = createDeps();
     const workspace = useWorkspaceState(state, deps);
 
-    await workspace.addWorkspaceByPath('  /abs/path  ');
+    const ok = await workspace.addWorkspaceByPath('  /abs/path  ');
 
+    expect(ok).toBe(true);
     expect(apiMock.addWorkspace).toHaveBeenCalledWith({ root: '/abs/path' });
     expect(state.workspaces).toContainEqual(registered);
     expect(state.activeWorkspaceId).toBe('wd_abc');
@@ -249,8 +250,9 @@ describe('useWorkspaceState — addWorkspaceByPath', () => {
     const deps = createDeps();
     const workspace = useWorkspaceState(state, deps);
 
-    await workspace.addWorkspaceByPath('/abs/missing');
+    const ok = await workspace.addWorkspaceByPath('/abs/missing');
 
+    expect(ok).toBe(false);
     expect(deps.pushOperationFailure).toHaveBeenCalledWith('addWorkspace', err);
     expect(state.workspaces).toEqual([]);
     expect(state.activeWorkspaceId).toBeNull();


### PR DESCRIPTION
## Related Issue

None.

## Problem

In the web UI, adding a workspace by typing an absolute path could silently fail. When the daemon rejected the path (for example because it does not exist on the daemon's filesystem), the error was swallowed and a local-only workspace was fabricated instead. That workspace could not host sessions and disappeared after a reload, so the add looked like it succeeded but never took effect, with no feedback to the user.

## What changed

- Adding a workspace by path now reports daemon errors through the same notification path used by other operations, instead of silently creating a fake local workspace.
- Removed the local-fallback fabrication and the misleading comments about falling back to a locally-derived workspace. Legitimate derived workspaces still come from existing sessions.
- Added tests for both the success path (registers and selects the workspace) and the failure path (reports the error and adds nothing).

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.