### PR TITLE
fix(kimi-desktop): revert sidebar header padding to 80px

### DIFF
--- a/apps/kimi-web/src/components/Sidebar.vue
+++ b/apps/kimi-web/src/components/Sidebar.vue
@@ -682,7 +682,7 @@ function blinkOnce(): void {
    and turn the empty header area into the window-drag region; interactive
    controls opt out with no-drag. */
 .side.macos-desktop .ch {
-  padding-left: 100px;
+  padding-left: 80px;
   -webkit-app-region: drag;
 }
 .side.macos-desktop .ch-logo,


### PR DESCRIPTION
The 100px left padding added to clear the traffic lights left too much empty space next to the traffic lights. 80px clears them without the extra gap, so revert to that.

The conversation-header drag region from #1237 is kept unchanged.