### PR TITLE
fix(tui): hide redundant Off option for always-on effort models

### DIFF
--- a/.changeset/hide-off-always-on-effort.md
+++ b/.changeset/hide-off-always-on-effort.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Hide the unsupported Off option in the /model thinking switcher for always-on models that already expose multiple effort levels.

--- a/apps/kimi-code/src/tui/components/dialogs/model-selector.ts
+++ b/apps/kimi-code/src/tui/components/dialogs/model-selector.ts
@@ -374,12 +374,6 @@ export class ModelSelectorComponent extends Container implements Focusable {
     const segments = segmentsFor(choice.model);
     const active = this.effectiveEffort(choice);
     const rendered = segments.map((effort) => segment(effortLabel(effort), effort === active));
-    // Always-on models (including effort-capable ones) additionally surface an
-    // unsupported Off so it's explicit that thinking cannot be disabled — same
-    // shape as the legacy always-on control.
-    if (availability === 'always-on') {
-      rendered.push(unavailable('Off'));
-    }
     return `  ${rendered.join('  ')}`;
   }
 }

--- a/apps/kimi-code/test/tui/components/dialogs/model-selector.test.ts
+++ b/apps/kimi-code/test/tui/components/dialogs/model-selector.test.ts
@@ -363,7 +363,7 @@ describe('ModelSelectorComponent', () => {
     expect(onSelect).toHaveBeenLastCalledWith({ alias: 'kimi', thinking: 'off' });
   });
 
-  it('always-on effort models show an unsupported Off that cannot be selected', () => {
+  it('always-on effort models hide Off and clamp selection at the last effort', () => {
     const onSelect = vi.fn();
     const picker = new ModelSelectorComponent({
       models: {
@@ -376,8 +376,8 @@ describe('ModelSelectorComponent', () => {
     });
 
     const raw = picker.render(120).join('\n');
-    // Off is rendered muted as unavailable, not as a selectable segment.
-    expect(raw).toContain(currentTheme.fg('textMuted', '  Off (Unsupported)  '));
+    // Off is not surfaced at all — the selectable segments are effort-only.
+    expect(raw).not.toContain('Off (Unsupported)');
     // The active effort is still highlighted.
     expect(strip(raw)).toContain('[ High ]');
 


### PR DESCRIPTION
## Related Issue

No related issue — minor TUI refinement.

## Problem

In the `/model` picker, always-on models that expose multiple effort levels (for example `low` / `high` / `max`) already render only the effort segments, so `Off` can never be selected. The control still appended a greyed-out `Off (Unsupported)` label, which was redundant visual clutter for those models.

## What changed

Drop the trailing `Off (Unsupported)` label for always-on, effort-capable models, so the thinking switcher shows only the selectable effort levels. Legacy boolean always-on models (no `support_efforts`) keep the `Off (Unsupported)` hint, and toggle / unsupported models are unchanged.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.
