### PR TITLE
fix(tui): reduce default transcript window to keep long sessions responsive

### DIFF
--- a/.changeset/tune-transcript-window-defaults.md
+++ b/.changeset/tune-transcript-window-defaults.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Reduce the default TUI transcript window to keep long sessions responsive.

--- a/apps/kimi-code/src/tui/utils/transcript-window.ts
+++ b/apps/kimi-code/src/tui/utils/transcript-window.ts
@@ -29,13 +29,13 @@ export function readEnvInt(name: string, fallback: number): number {
 export const TRANSCRIPT_WINDOW_ENABLED = true;
 
 /** Keep the most recent N turns. `0` disables trimming. */
-export const TRANSCRIPT_MAX_TURNS = readEnvInt('KIMI_CODE_TUI_MAX_TURNS', 50);
+export const TRANSCRIPT_MAX_TURNS = readEnvInt('KIMI_CODE_TUI_MAX_TURNS', 15);
 
 /** Only the most recent E turns are allowed to expand (Ctrl+O). `0` disables expanding. */
 export const TRANSCRIPT_EXPAND_TURNS = readEnvInt('KIMI_CODE_TUI_EXPAND_TURNS', 3);
 
 /** Only trim once the window exceeds maxTurns by this much (avoids churn). */
-export const TRANSCRIPT_HYSTERESIS = readEnvInt('KIMI_CODE_TUI_HYSTERESIS', 10);
+export const TRANSCRIPT_HYSTERESIS = readEnvInt('KIMI_CODE_TUI_HYSTERESIS', 5);
 
 /** Keep this many recent steps untouched inside a turn; older steps are merged into a summary. `0` disables merging. */
 export const TRANSCRIPT_KEEP_RECENT_STEPS = readEnvInt('KIMI_CODE_TUI_KEEP_RECENT_STEPS', 30);


### PR DESCRIPTION
## Related Issue

No prior issue — this is a small tuning change to the TUI sliding window.

## Problem

In long sessions the TUI keeps up to 50 transcript turns, and only trims once the count passes 60 with the default hysteresis. That accumulates a large number of rendered components and hurts responsiveness. Trimming only touches the TUI display layer, so the agent's underlying conversation context is unaffected.

## What changed

Lower the sliding-window defaults so fewer transcript turns are retained on screen:

- `KIMI_CODE_TUI_MAX_TURNS`: 50 -> 15
- `KIMI_CODE_TUI_HYSTERESIS`: 10 -> 5

Both can still be overridden via their environment variables. Existing tests already cover the trimming logic, so this default-value change adds no new test.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.
