### PR TITLE
fix(changeset): unblock release by dropping private kimi-code-docs from web-search changeset

### DIFF
--- a/.changeset/web-search-query-only.md
+++ b/.changeset/web-search-query-only.md
@@ -1,6 +1,5 @@
 ---
 "@moonshot-ai/agent-core": minor
-"kimi-code-docs": patch
 ---
 
 WebSearch now sends only the query and returns lightweight result summaries (title, source site, date, URL, snippet) instead of inlined page content; fetch a result's full page content on demand with FetchURL. Both tools now include a citation reminder in their results.


### PR DESCRIPTION
## 背景

main 分支的 Release workflow 在 `changeset version` 步骤失败([run](https://github.com/MoonshotAI/kimi-code/actions/runs/28511947926/job/84514169121)):

```
Found mixed changeset web-search-query-only
Found ignored packages: kimi-code-docs
Found not ignored packages: @moonshot-ai/agent-core
Mixed changesets that contain both ignored and not ignored packages are not allowed
```

## 根因

随 #1260 合入的 `.changeset/web-search-query-only.md` 同时声明了:

- `@moonshot-ai/agent-core`(公开包,参与发布)
- `kimi-code-docs`(`private: true` 且无 `version` 字段 → changesets 隐式视为 ignored)

changesets 不允许同一个 changeset 混合 ignored 与非 ignored 包,导致整个 release 卡住,连带其它待发布的 changeset 一起被阻塞。

## 修复

从该 changeset 中移除 `kimi-code-docs` 一行,仅保留 `@moonshot-ai/agent-core`。私有文档站从不发布、无需 changelog,本就不应出现在 changeset 中。

## 验证

`changeset status` 已能干净解析,不再报 mixed changeset 错误:

```
Packages to be bumped at minor:
- @moonshot-ai/agent-core
```