### PR TITLE
fix(server): prevent live session resource leaks on shutdown

### DIFF
--- a/.changeset/clean-session-shutdown.md
+++ b/.changeset/clean-session-shutdown.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Close live sessions during server shutdown.

--- a/packages/agent-core/src/rpc/core-impl.ts
+++ b/packages/agent-core/src/rpc/core-impl.ts
@@ -352,6 +352,24 @@ export class KimiCore implements PromisableMethods<CoreAPI> {
     }
   }
 
+  async closeAllSessions(): Promise<void> {
+    const results = await Promise.allSettled(
+      Array.from(this.sessions.entries(), async ([sessionId, session]) => {
+        try {
+          await session.close();
+        } finally {
+          this.sessions.delete(sessionId);
+        }
+      }),
+    );
+    const failures = results
+      .filter((result) => result.status === 'rejected')
+      .map((result) => result.reason);
+    if (failures.length > 0) {
+      throw new AggregateError(failures, 'failed to close all sessions');
+    }
+  }
+
   async archiveSession({ sessionId }: ArchiveSessionPayload): Promise<void> {
     await this.closeSession({ sessionId });
     await this.sessionStore.archive(sessionId);

--- a/packages/agent-core/src/services/coreProcess/coreProcess.ts
+++ b/packages/agent-core/src/services/coreProcess/coreProcess.ts
@@ -66,6 +66,9 @@ export interface ICoreProcessService {
    */
   ready(): Promise<void>;
 
+  /** Gracefully close every live in-process session before disposal. */
+  closeAllSessions(): Promise<void>;
+
   /**
    * Tear down the adapter. After dispose, `rpc.<method>(...)` rejects with a
    * "core process disposed" error before reaching `KimiCore`. Idempotent.

--- a/packages/agent-core/src/services/coreProcess/coreProcessService.ts
+++ b/packages/agent-core/src/services/coreProcess/coreProcessService.ts
@@ -139,12 +139,15 @@ export class CoreProcessService extends Disposable implements ICoreProcessServic
     return this._ready;
   }
 
+  async closeAllSessions(): Promise<void> {
+    await this._core.closeAllSessions();
+  }
+
   override dispose(): void {
     if (this._store.isDisposed) return;
-    // KimiCore does not currently expose a dispose() — when it does, we'll
-    // await/call it here BEFORE super.dispose(). For now, disposing the
-    // service flips _disposed, which makes future rpc.* invocations reject
-    // before they reach KimiCore.
+    // Session shutdown is async and is owned by `closeAllSessions()` so callers
+    // can await it before tearing down the DI graph. `dispose()` remains the
+    // synchronous guard that rejects future rpc.* invocations.
     super.dispose();
   }
 

--- a/packages/agent-core/test/rpc/core-close-all.test.ts
+++ b/packages/agent-core/test/rpc/core-close-all.test.ts
@@ -1,0 +1,60 @@
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { KimiCore } from '../../src/rpc/core-impl';
+
+let homeDir: string;
+
+beforeEach(() => {
+  homeDir = mkdtempSync(join(tmpdir(), 'kimi-core-close-all-'));
+});
+
+afterEach(() => {
+  rmSync(homeDir, { recursive: true, force: true });
+});
+
+describe('KimiCore.closeAllSessions', () => {
+  it('closes every live session and clears the active session map', async () => {
+    const core = new KimiCore(async () => ({}) as never, { homeDir });
+    const closed: string[] = [];
+    core.sessions.set('sess_a', {
+      close: async () => {
+        closed.push('sess_a');
+      },
+    } as never);
+    core.sessions.set('sess_b', {
+      close: async () => {
+        closed.push('sess_b');
+      },
+    } as never);
+
+    await core.closeAllSessions();
+
+    expect(closed.toSorted()).toEqual(['sess_a', 'sess_b']);
+    expect(core.sessions.size).toBe(0);
+  });
+
+  it('continues closing later sessions and clears entries when one close fails', async () => {
+    const core = new KimiCore(async () => ({}) as never, { homeDir });
+    const closed: string[] = [];
+    core.sessions.set('sess_bad', {
+      close: async () => {
+        closed.push('sess_bad');
+        throw new Error('close failed');
+      },
+    } as never);
+    core.sessions.set('sess_good', {
+      close: async () => {
+        closed.push('sess_good');
+      },
+    } as never);
+
+    await expect(core.closeAllSessions()).rejects.toThrow(AggregateError);
+
+    expect(closed.toSorted()).toEqual(['sess_bad', 'sess_good']);
+    expect(core.sessions.size).toBe(0);
+  });
+});

--- a/packages/agent-core/test/services/message-service.test.ts
+++ b/packages/agent-core/test/services/message-service.test.ts
@@ -53,6 +53,7 @@ function makeFakeBridge(
   return {
     rpc: rpc as CoreRPC,
     ready: vi.fn().mockResolvedValue(undefined),
+    closeAllSessions: vi.fn().mockResolvedValue(undefined),
     dispose: vi.fn(),
     _serviceBrand: undefined,
   };
@@ -349,6 +350,7 @@ describe('MessageService', () => {
     const failingBridge: ICoreProcessService = {
       rpc: rpc as CoreRPC,
       ready: vi.fn().mockResolvedValue(undefined),
+      closeAllSessions: vi.fn().mockResolvedValue(undefined),
       dispose: vi.fn(),
       _serviceBrand: undefined,
     };

--- a/packages/agent-core/test/services/message-transcript.test.ts
+++ b/packages/agent-core/test/services/message-transcript.test.ts
@@ -590,6 +590,7 @@ describe('MessageService over a compacted wire log', () => {
     bridge = {
       rpc: rpc as CoreRPC,
       ready: vi.fn().mockResolvedValue(undefined),
+      closeAllSessions: vi.fn().mockResolvedValue(undefined),
       dispose: vi.fn(),
       _serviceBrand: undefined,
     };

--- a/packages/agent-core/test/services/model-catalog-service.test.ts
+++ b/packages/agent-core/test/services/model-catalog-service.test.ts
@@ -84,6 +84,7 @@ function makeCore(configRef: { current: KimiConfig }): {
       _serviceBrand: undefined,
       rpc: rpc as CoreRPC,
       ready: async () => undefined,
+      closeAllSessions: async () => undefined,
       dispose: () => undefined,
     },
     getCalls,

--- a/packages/agent-core/test/services/prompt-service.test.ts
+++ b/packages/agent-core/test/services/prompt-service.test.ts
@@ -246,6 +246,7 @@ function makeBridge(
   const bridge: ICoreProcessService = {
     rpc: rpc as CoreRPC,
     ready: vi.fn().mockResolvedValue(undefined),
+    closeAllSessions: vi.fn().mockResolvedValue(undefined),
     dispose: vi.fn(),
     _serviceBrand: undefined,
   };

--- a/packages/agent-core/test/services/session-service.test.ts
+++ b/packages/agent-core/test/services/session-service.test.ts
@@ -201,6 +201,7 @@ function makeFakeBridge(state: FakeBridgeState): ICoreProcessService {
   return {
     rpc: rpc as CoreRPC,
     ready: async () => undefined,
+    closeAllSessions: async () => undefined,
     dispose: () => undefined,
     _serviceBrand: undefined,
   };

--- a/packages/agent-core/test/services/task-service.test.ts
+++ b/packages/agent-core/test/services/task-service.test.ts
@@ -59,6 +59,7 @@ function makeBridge(state: FakeState): ICoreProcessService {
   return {
     rpc: rpc as CoreRPC,
     ready: async () => undefined,
+    closeAllSessions: async () => undefined,
     dispose: () => undefined,
     _serviceBrand: undefined,
   };

--- a/packages/agent-core/test/services/tool-service.test.ts
+++ b/packages/agent-core/test/services/tool-service.test.ts
@@ -51,6 +51,7 @@ function makeFakeBridge(state: FakeBridgeState): ICoreProcessService {
   return {
     rpc: rpc as CoreRPC,
     ready: async () => undefined,
+    closeAllSessions: async () => undefined,
     dispose: () => undefined,
     _serviceBrand: undefined,
   };

--- a/packages/server/src/start.ts
+++ b/packages/server/src/start.ts
@@ -614,6 +614,15 @@ export async function startServer(opts: ServerStartOptions): Promise<RunningServ
     }
 
     try {
+      await coreProcess.closeAllSessions();
+    } catch (error) {
+      pinoLogger.warn(
+        { err: error instanceof Error ? error : new Error(String(error)) },
+        'failed to close live sessions during server shutdown',
+      );
+    }
+
+    try {
       ix.dispose();
     } catch {
 


### PR DESCRIPTION
## Related Issue

Fixes #1273

## Problem

Server shutdown currently disposes the DI graph without first closing live `KimiCore` sessions.

Formal proof of the bug:

1. `KimiCore` owns live sessions in `this.sessions`.
2. `KimiCore.closeSession()` closes exactly one session by calling `session.close()`, then removes that session from the map.
3. Before this change, server shutdown closed WebSocket connections and Fastify, then called `ix.dispose()`.
4. Before this change, `CoreProcessService.dispose()` only marked the core process service as disposed so future RPC calls reject. It did not call `Session.close()` for live sessions.
5. `Session.close()` is the path that cancels active turns, stops background tasks, flushes metadata, emits session-end behavior, shuts down MCP, and closes the session log handle.
6. Therefore, if the server shuts down while sessions are still live and no client explicitly closed them first, those sessions skip normal `Session.close()` cleanup.

Impact:

Live sessions can leave session-owned work and resources running past server shutdown, including active turns, background tasks, MCP transports, unflushed metadata, and log handles.

## What changed

Added a core lifecycle method that closes all live sessions before disposal.

The implementation snapshots the live session map, attempts to close every session, deletes each entry after its close attempt, and reports any close failures with an `AggregateError` after all sessions have been attempted.

Server shutdown now awaits this lifecycle method before disposing the DI graph. If one or more session closes fail, shutdown logs a warning and continues with the existing best-effort cleanup path.

A focused regression test covers both important behaviors:

- every live session is closed and removed;
- later sessions are still closed even when one session close fails.

## Validation

- `pnpm --filter @moonshot-ai/agent-core exec vitest run test/rpc/core-close-all.test.ts` passes: 1 file, 2 tests.
## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.
