### PR TITLE
fix(agent-core): dispose session terminal records on close

### DIFF
--- a/.changeset/session-terminal-records.md
+++ b/.changeset/session-terminal-records.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Release session terminal records when sessions close.

--- a/packages/agent-core/src/services/terminal/terminalService.ts
+++ b/packages/agent-core/src/services/terminal/terminalService.ts
@@ -60,6 +60,11 @@ export class TerminalService extends Disposable implements ITerminalService {
     this.defaultCols = options.defaultCols ?? DEFAULT_COLS;
     this.defaultRows = options.defaultRows ?? DEFAULT_ROWS;
     this.maxBufferedFrames = options.maxBufferedFrames ?? DEFAULT_MAX_BUFFERED_FRAMES;
+    this._register(
+      this.sessionService.onDidClose(({ sessionId }) => {
+        this.closeSessionRecords(sessionId);
+      }),
+    );
   }
 
   async create(sessionId: string, input: CreateTerminalRequest): Promise<Terminal> {
@@ -172,6 +177,27 @@ export class TerminalService extends Disposable implements ITerminalService {
     }
     this.records.clear();
     super.dispose();
+  }
+
+  private closeSessionRecords(sessionId: string): void {
+    const prefix = `${sessionId}\0`;
+    for (const [key, record] of Array.from(this.records.entries())) {
+      if (!key.startsWith(prefix)) continue;
+      if (!record.closed) {
+        record.closed = true;
+        try {
+          record.process.kill();
+        } catch {
+        }
+        this.markExited(record, null);
+      } else {
+        disposeAll(record.disposables);
+        record.disposables = [];
+      }
+      record.sinks.clear();
+      record.buffer = [];
+      this.records.delete(key);
+    }
   }
 
   private async requireRecord(

--- a/packages/agent-core/test/services/terminal-service.test.ts
+++ b/packages/agent-core/test/services/terminal-service.test.ts
@@ -111,7 +111,10 @@ function session(id: string, cwd: string): Session {
   };
 }
 
-function makeSessionService(sessions: Map<string, Session>): ISessionService {
+function makeSessionService(
+  sessions: Map<string, Session>,
+  closeEmitter = new Emitter<{ sessionId: string }>(),
+): ISessionService {
   const emptyEmitter = new Emitter<never>();
   return {
     _serviceBrand: undefined,
@@ -148,7 +151,7 @@ function makeSessionService(sessions: Map<string, Session>): ISessionService {
       throw new Error('not implemented');
     },
     onDidCreate: emptyEmitter.event,
-    onDidClose: emptyEmitter.event,
+    onDidClose: closeEmitter.event,
   };
 }
 
@@ -289,6 +292,27 @@ describe('TerminalService streams', () => {
     const terminal = await svc.create('sess_a', {});
 
     await expect(svc.get('sess_b', terminal.id)).rejects.toBeInstanceOf(
+      TerminalNotFoundError,
+    );
+  });
+
+  it('kills and forgets session terminals when the session closes', async () => {
+    const root = join(tmpDir, 'workspace-h');
+    mkdirSync(root, { recursive: true });
+    const backend = new FakeTerminalBackend();
+    const closeEmitter = new Emitter<{ sessionId: string }>();
+    const svc = new TerminalService({ backend }, makeSessionService(new Map([
+      ['sess_h', session('sess_h', root)],
+    ]), closeEmitter));
+    const terminal = await svc.create('sess_h', {});
+    const process = backend.processes[0]!;
+    process.emitData('buffered output');
+
+    closeEmitter.fire({ sessionId: 'sess_h' });
+
+    expect(process.killed).toBe(true);
+    expect(await svc.list('sess_h')).toEqual([]);
+    await expect(svc.get('sess_h', terminal.id)).rejects.toBeInstanceOf(
       TerminalNotFoundError,
     );
   });


### PR DESCRIPTION
## Related Issue

No linked issue. This is a focused follow-up to #1276 for one session-owned resource type.

## Problem

Terminal records are session-scoped resources: each record holds a backend terminal process, output listeners, attached sinks, and buffered output.

Today, `TerminalService` creates those records for a session but does not subscribe to `ISessionService.onDidClose`. As a result, when a session is closed while the service remains alive, terminal records for that session can remain in memory until the whole service is disposed.

This breaks the expected ownership model and can leak memory: closing a session should release resources owned by that session.

Code-path proof:

1. `TerminalService.create()` stores each terminal in `records`.
2. `records` entries hold the process, output listeners, sinks, and output buffer.
3. `TerminalService` removes records during whole-service disposal, but did not respond to session close events.
4. `ISessionService` exposes `onDidClose`, but `TerminalService` did not subscribe to it.
5. Therefore, closing a session did not release terminal records owned by that session.

This is separate from TUI terminal restoration in #1272. This change concerns agent-core terminal records owned by server sessions.

## What changed

`TerminalService` now subscribes to `ISessionService.onDidClose` and releases terminal records for the closed session.

For each matching terminal record, the cleanup path:

- kills the backend terminal process best-effort;
- marks the terminal as exited;
- clears attached sinks and buffered output;
- removes the record from the service map.

A focused regression test covers the session-close behavior through the public terminal service seam.

## Validation

- `pnpm --filter @moonshot-ai/agent-core exec vitest run test/services/terminal-service.test.ts` passes: 1 file, 8 tests.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.
