### PR TITLE
fix(agent-core): release filesystem watchers on session close

### DIFF
--- a/.changeset/session-fs-watchers.md
+++ b/.changeset/session-fs-watchers.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Release session filesystem watchers when sessions close.

--- a/packages/agent-core/src/services/fs/fsWatcherService.ts
+++ b/packages/agent-core/src/services/fs/fsWatcherService.ts
@@ -109,7 +109,7 @@ export class FsWatcherService extends Disposable implements IFsWatcher {
     private readonly lookup: FsWatcherConnectionLookup,
     options: FsWatcherServiceOptions,
     @ILogService private readonly logger: ILogService,
-    @ISessionService _sessionService: ISessionService,
+    @ISessionService sessionService: ISessionService,
   ) {
     super();
     this.sessions = this._register(new DisposableMap<string, SessionEntry>());
@@ -126,6 +126,11 @@ export class FsWatcherService extends Disposable implements IFsWatcher {
           persistent: false,
           ignored: (p: string) => /(?:^|[/\\])\.git(?:$|[/\\])/.test(p),
         }));
+    this._register(
+      sessionService.onDidClose(({ sessionId }) => {
+        this.disposeSessionEntry(sessionId);
+      }),
+    );
   }
 
   addPaths(
@@ -255,6 +260,19 @@ export class FsWatcherService extends Disposable implements IFsWatcher {
       );
       entry.cwd = cwd;
     }
+  }
+
+  private disposeSessionEntry(sessionId: string): void {
+    const entry = this.sessions.get(sessionId);
+    if (!entry) return;
+    for (const connectionId of entry.connectionPathRefs.keys()) {
+      const connSessions = this.connections.get(connectionId);
+      connSessions?.delete(sessionId);
+      if (connSessions !== undefined && connSessions.size === 0) {
+        this.connections.delete(connectionId);
+      }
+    }
+    this.sessions.deleteAndDispose(sessionId);
   }
 
   private getOrCreateConnection(

--- a/packages/server/test/services.test.ts
+++ b/packages/server/test/services.test.ts
@@ -7,7 +7,7 @@ import { join } from 'node:path';
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { InstantiationService, ServiceCollection, EventService, FsWatcherService, IApprovalService, IEventService, ILogService, IQuestionService, type ApprovalResponse, type QuestionResult, type FsWatcherServiceOptions, type IEnvironmentService, type ILogService as ILoggerT, type ISessionService } from '@moonshot-ai/agent-core';
+import { Emitter, InstantiationService, ServiceCollection, EventService, FsWatcherService, IApprovalService, IEventService, ILogService, IQuestionService, type ApprovalResponse, type QuestionResult, type FsWatcherServiceOptions, type IEnvironmentService, type ILogService as ILoggerT, type ISessionService } from '@moonshot-ai/agent-core';
 import type { Event } from '@moonshot-ai/protocol';
 
 import { ApprovalService } from '#/services/approval/approvalService';
@@ -134,6 +134,29 @@ class FakeWatcher {
 }
 
 type TestFsWatcher = ReturnType<NonNullable<FsWatcherServiceOptions['watcherFactory']>>;
+
+function makeSessionService(
+  closeEmitter = new Emitter<{ sessionId: string }>(),
+): ISessionService {
+  const createEmitter = new Emitter<never>();
+  return {
+    _serviceBrand: undefined,
+    create: async () => { throw new Error('not implemented'); },
+    list: async () => ({ items: [], has_more: false }),
+    get: async () => { throw new Error('not implemented'); },
+    update: async () => { throw new Error('not implemented'); },
+    fork: async () => { throw new Error('not implemented'); },
+    listChildren: async () => ({ items: [], has_more: false }),
+    createChild: async () => { throw new Error('not implemented'); },
+    getStatus: async () => { throw new Error('not implemented'); },
+    getSessionWarnings: async () => [],
+    compact: async () => { throw new Error('not implemented'); },
+    undo: async () => { throw new Error('not implemented'); },
+    archive: async () => { throw new Error('not implemented'); },
+    onDidCreate: createEmitter.event,
+    onDidClose: closeEmitter.event,
+  };
+}
 
 let ix: InstantiationService;
 let testLogger: TestLogger;
@@ -463,7 +486,7 @@ describe('FsWatcherService', () => {
       { resolve: () => undefined },
       { watcherFactory: () => watcher as unknown as TestFsWatcher },
       testLogger,
-      {} as ISessionService,
+      makeSessionService(),
     );
     const path = '/workspace/src';
 
@@ -496,7 +519,7 @@ describe('FsWatcherService', () => {
       { resolve: () => undefined },
       { watcherFactory: () => watcher as unknown as TestFsWatcher },
       testLogger,
-      {} as ISessionService,
+      makeSessionService(),
     );
     const paths = ['/workspace/src', '/workspace/docs', '/workspace/notes'];
     watcher.unwatchErrors.set(paths[0]!, new Error('unwatch-src'));
@@ -515,6 +538,29 @@ describe('FsWatcherService', () => {
     expect(watcher.unwatched).toEqual([[paths[0]!], [paths[1]!]]);
     expect(service.watchedPaths('conn', 'sid')).toEqual([paths[2]!]);
     expect(watcher.closeCalls).toBe(0);
+    service.dispose();
+  });
+
+  it('releases a session watcher when the session closes', () => {
+    const watcher = new FakeWatcher();
+    const closeEmitter = new Emitter<{ sessionId: string }>();
+    const service = new FsWatcherService(
+      { resolve: () => undefined },
+      { watcherFactory: () => watcher as unknown as TestFsWatcher },
+      testLogger,
+      makeSessionService(closeEmitter),
+    );
+    const path = '/workspace/src';
+
+    service.addPaths('sid', 'conn-a', [path]);
+    service.addPaths('sid', 'conn-b', [path]);
+    closeEmitter.fire({ sessionId: 'sid' });
+
+    expect(watcher.closeCalls).toBe(1);
+    expect(service.watchedPaths('conn-a', 'sid')).toEqual([]);
+    expect(service.watchedPaths('conn-b', 'sid')).toEqual([]);
+    expect(service.countForConnection('conn-a')).toBe(0);
+    expect(service.countForConnection('conn-b')).toBe(0);
     service.dispose();
   });
 });


### PR DESCRIPTION
## Related Issue

No linked issue. This is a focused follow-up to #1276 for one session-owned resource type.

## Problem

Filesystem watchers are session-scoped resources. Each session watcher owns path references, connection/session reference maps, pending change buffers, debounce timers, and an underlying chokidar watcher.

Today, `FsWatcherService` can create watcher state for a session, but it does not release that state when `ISessionService.onDidClose` fires. As a result, when a session closes while the service remains alive, watcher state for that session can remain until paths are explicitly removed or the whole service is disposed.

This breaks the expected ownership model: closing a session should release resources owned by that session.

Code-path proof:

1. `FsWatcherService.addPaths()` creates or reuses a `SessionEntry` in `sessions`.
2. Each `SessionEntry` owns path references, connection references, pending change state, timers, and a chokidar watcher.
3. `FsWatcherService.removePaths()` and service disposal clean entries, but session close did not clean entries.
4. `ISessionService` exposes `onDidClose`, but `FsWatcherService` did not subscribe to it.
5. Therefore, closing a session did not release filesystem watcher state owned by that session.

## What changed

`FsWatcherService` now subscribes to `ISessionService.onDidClose` and disposes watcher state for the closed session.

The cleanup removes the session from each connection map, drops empty connection maps, and disposes the session watcher entry.

A focused regression test verifies that closing a session releases the watcher, clears watched paths for each connection, and resets connection path counts.

## Validation

- `pnpm --filter @moonshot-ai/server exec vitest run test/services.test.ts` passes: 1 file, 22 tests.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.
