### PR TITLE
fix(kimi-desktop): make the sidebar header buttons clickable

### DIFF
--- a/apps/kimi-web/src/components/Sidebar.vue
+++ b/apps/kimi-web/src/components/Sidebar.vue
@@ -806,15 +806,18 @@ onBeforeUnmount(() => {
 }
 /* macOS desktop: the window uses a hidden title bar, so the traffic lights float
    over the top-left of the sidebar. Push the header content right to clear them,
-   and turn the empty header area into the window-drag region; interactive
-   controls opt out with no-drag. */
+   and turn the whole header into the window-drag region — matching the chat
+   header. The action buttons and the logo opt out with no-drag so they stay
+   clickable: this is the same no-drag-inside-drag pattern ChatHeader.vue relies
+   on (the previous "drag only the brand area" approach still captured the
+   sibling buttons, because Electron treats a flex-grown drag item's hit area as
+   covering the whole flex line). */
 .side.macos-desktop .ch {
   padding-left: 80px;
   -webkit-app-region: drag;
 }
-.side.macos-desktop .ch-logo,
-.side.macos-desktop .collapse-btn,
-.side.macos-desktop .settings-btn {
+.side.macos-desktop .ch button,
+.side.macos-desktop .ch-logo {
   -webkit-app-region: no-drag;
 }
 .ch-logo {


### PR DESCRIPTION
On macOS the sidebar header was a window-drag region, and the collapse / settings buttons sat inside it. Even though they were marked no-drag, clicks were being captured by the drag region.

Move the drag region to just the brand area (logo + name + tag). The buttons now sit outside the drag region and receive clicks normally. The logo keeps no-drag so its click animation still fires.

No layout change.