### PR TITLE
fix(web): prevent horizontal scrollbar in session search dialog

### DIFF
--- a/.changeset/fix-search-sessions-horizontal-scroll.md
+++ b/.changeset/fix-search-sessions-horizontal-scroll.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Fix the session search dialog showing a horizontal scrollbar for long session titles or snippets.

--- a/apps/kimi-web/src/components/dialogs/SearchSessionsDialog.vue
+++ b/apps/kimi-web/src/components/dialogs/SearchSessionsDialog.vue
@@ -261,6 +261,7 @@ onMounted(() => {
 }
 
 .sd-title {
+  min-width: 0;
   font-size: var(--text-base);
   color: var(--color-text);
   overflow: hidden;
@@ -268,6 +269,7 @@ onMounted(() => {
   white-space: nowrap;
 }
 .sd-snippet {
+  min-width: 0;
   font-size: var(--text-sm);
   color: var(--color-text-muted);
   overflow: hidden;


### PR DESCRIPTION
## Related Issue

No related issue.

## Problem

The session search dialog showed a horizontal scrollbar whenever a session title or a matched snippet was long. Each result row is a column flex container, and its title and snippet used `white-space: nowrap` with `text-overflow: ellipsis` but no `min-width: 0`. Flex items default to `min-width: auto`, so under `nowrap` they refused to shrink below their full text width and overflowed the row, surfacing as a horizontal scrollbar on the dialog body instead of being truncated with an ellipsis.

The workspace-name line in the same dialog did not have this problem because it already set `min-width: 0`.

## What changed

Added `min-width: 0` to the title and snippet so the flex items can shrink to the row width and the existing ellipsis styling takes effect, matching the workspace-name line.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [ ] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.
