### PR TITLE
fix(kosong): recognize OpenAI-compatible tool_call_id 400 as a recoverable tool-exchange error

### DIFF
--- a/.changeset/moonshot-tool-call-id-recovery.md
+++ b/.changeset/moonshot-tool-call-id-recovery.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kosong": patch
+---
+
+Recognize the OpenAI-compatible (Moonshot / Kimi) `tool_call_id ... is not found` 400 as a recoverable tool-exchange structural error, so the post-400 strict-resend fallback fires and un-bricks the session instead of failing every subsequent turn with the same error.

--- a/packages/agent-core/test/loop/tool-exchange-fallback.e2e.test.ts
+++ b/packages/agent-core/test/loop/tool-exchange-fallback.e2e.test.ts
@@ -28,6 +28,10 @@ const ADJACENCY_400 = new APIStatusError(
     '`tool_result` block in the next message.',
 );
 
+// The OpenAI-compatible (Moonshot / Kimi) phrasing of the same tool-exchange
+// structural rejection. Verbatim from the field, doubled space included.
+const MOONSHOT_TOOL_CALL_ID_400 = new APIStatusError(400, '400 tool_call_id  is not found');
+
 function userMessage(text: string): Message {
   return { role: 'user', content: [{ type: 'text', text }], toolCalls: [] };
 }
@@ -77,6 +81,19 @@ describe('executeLoopStep — tool exchange adjacency fallback', () => {
     expect(llm.callCount).toBe(2);
     expect(strictCalls.count).toBe(1);
     // The first attempt used the normal projection; the resend used the strict one.
+    expect(llm.calls[0]?.messages).toEqual([userMessage('normal projection')]);
+    expect(llm.calls[1]?.messages).toBe(strictMessages);
+  });
+
+  it('resends once and recovers after a Moonshot tool_call_id-not-found 400', async () => {
+    const { input, llm, strictCalls, strictMessages } = makeHarness(MOONSHOT_TOOL_CALL_ID_400);
+
+    const result = await runTurn(input);
+
+    expect(result.stopReason).toBe('end_turn');
+    // Exactly two provider calls: the rejected one and the strict resend.
+    expect(llm.callCount).toBe(2);
+    expect(strictCalls.count).toBe(1);
     expect(llm.calls[0]?.messages).toEqual([userMessage('normal projection')]);
     expect(llm.calls[1]?.messages).toBe(strictMessages);
   });

--- a/packages/kosong/src/errors.ts
+++ b/packages/kosong/src/errors.ts
@@ -170,16 +170,25 @@ export function isContextOverflowStatusError(statusCode: number, message: string
   return CONTEXT_OVERFLOW_MESSAGE_PATTERNS.some((pattern) => pattern.test(lowerMessage));
 }
 
-// Strict providers (Anthropic) reject a request whose assistant `tool_use` and
-// `tool_result` blocks are not correctly paired and adjacent — a missing result,
-// a stray result with no matching call, or a result that does not immediately
-// follow its call. The validation runs before any generation, so the error is a
-// non-retryable 4xx. A caller can react by resending a re-projected, strictly
-// wire-compliant request rather than leaving the session permanently stuck.
+// Strict providers reject a request whose assistant `tool_use`/`tool_calls` and
+// `tool_result`/`tool` blocks are not correctly paired and adjacent — a missing
+// result, a stray result with no matching call, or a result that does not
+// immediately follow its call. Anthropic phrases this in terms of
+// `tool_use`/`tool_result`; OpenAI-compatible providers (Moonshot / Kimi) phrase
+// it as a `tool_call_id` that "is not found" in the preceding assistant message.
+// The validation runs before any generation, so the error is a non-retryable
+// 4xx. A caller can react by resending a re-projected, strictly wire-compliant
+// request rather than leaving the session permanently stuck.
 const TOOL_EXCHANGE_ADJACENCY_MESSAGE_PATTERNS = [
   /tool_use[\s\S]*tool_result/,
   /tool_result[\s\S]*tool_use/,
   /unexpected\s+`?tool_result/,
+  // OpenAI-compatible (Moonshot / Kimi): a `tool` message references a
+  // `tool_call_id` with no matching `tool_calls` entry in the preceding
+  // assistant message. Observed verbatim as `tool_call_id  is not found`
+  // (doubled space). Anchored on `tool_call_id` so an unrelated "not found"
+  // (e.g. a 404-style body) cannot trip the recovery.
+  /tool_call_id[\s\S]*not found/,
 ] as const;
 
 export function isToolExchangeAdjacencyError(error: unknown): boolean {

--- a/packages/kosong/test/errors.test.ts
+++ b/packages/kosong/test/errors.test.ts
@@ -246,11 +246,35 @@ describe('isToolExchangeAdjacencyError', () => {
     );
   });
 
+  // The exact OpenAI-compatible (Moonshot / Kimi) message observed in the field
+  // when a `tool` message's `tool_call_id` has no matching `tool_calls` entry in
+  // the preceding assistant message. The doubled space is verbatim from the
+  // provider.
+  const MOONSHOT_TOOL_CALL_ID_NOT_FOUND = '400 tool_call_id  is not found';
+
+  it('matches the OpenAI/Moonshot tool_call_id-not-found 400', () => {
+    expect(
+      isToolExchangeAdjacencyError(new APIStatusError(400, MOONSHOT_TOOL_CALL_ID_NOT_FOUND)),
+    ).toBe(true);
+    expect(
+      isToolExchangeAdjacencyError(new APIStatusError(400, "tool_call_id 'call_abc123' is not found")),
+    ).toBe(true);
+  });
+
+  it('also matches a 422 tool_call_id-not-found', () => {
+    expect(
+      isToolExchangeAdjacencyError(new APIStatusError(422, MOONSHOT_TOOL_CALL_ID_NOT_FOUND)),
+    ).toBe(true);
+  });
+
   it('does not match a context-overflow 400 or unrelated errors', () => {
     expect(
       isToolExchangeAdjacencyError(new APIContextOverflowError(400, 'context length exceeded')),
     ).toBe(false);
     expect(isToolExchangeAdjacencyError(new APIStatusError(400, 'Bad request'))).toBe(false);
+    // A bare "not found" without a tool_call_id anchor must not match, so an
+    // unrelated 404-style body cannot trip the tool-exchange recovery.
+    expect(isToolExchangeAdjacencyError(new APIStatusError(400, 'resource not found'))).toBe(false);
     expect(isToolExchangeAdjacencyError(new APIStatusError(500, ANTHROPIC_MISSING_RESULT))).toBe(
       false,
     );
@@ -265,6 +289,12 @@ describe('isRecoverableRequestStructureError', () => {
       isRecoverableRequestStructureError(
         new APIStatusError(400, '`tool_use` ids were found without `tool_result` blocks'),
       ),
+    ).toBe(true);
+  });
+
+  it('matches the OpenAI/Moonshot tool_call_id-not-found 400', () => {
+    expect(
+      isRecoverableRequestStructureError(new APIStatusError(400, '400 tool_call_id  is not found')),
     ).toBe(true);
   });
 


### PR DESCRIPTION
## Problem

A field session (exported debug zip) was permanently stuck: every turn failed with

```
Error: [provider.api_error] 400 tool_call_id  is not found
```

The history contained a `tool` message whose `tool_call_id` had no matching `tool_calls` entry in the immediately preceding assistant message (a user message had been interleaved into the tool exchange). Moonshot validates this before generation and rejects the request deterministically — and since the same history is re-sent every turn, the session could never recover.

## Root cause

The recovery chain for exactly this situation already exists (#1241): `repairToolExchangeAdjacency` in the normal projection, plus a one-shot **strict resend** (`strictMessages`: adjacency repair + orphan-result drop + synthetic results) in `executeLoopStep` when the provider rejects the request structure.

But the trigger, `isRecoverableRequestStructureError`, only matched **Anthropic's** phrasing (`tool_use`/`tool_result`, roles must alternate, ...). The OpenAI-compatible phrasing used by Moonshot / Kimi — `tool_call_id ... is not found` — matched nothing, so the strict resend never fired for the **default provider** and the session stayed bricked. (In the field log: `turn failed` with no `resending with strict projection` line before it.)

## Fix

Add a `tool_call_id`-anchored pattern to `TOOL_EXCHANGE_ADJACENCY_MESSAGE_PATTERNS`:

```ts
/tool_call_id[\s\S]*not found/
```

Anchored on `tool_call_id` so an unrelated "not found" body (e.g. 404-style) cannot trip the recovery; still gated on status 400/422 and not-context-overflow, and the resend remains one-shot.

## Tests

- `kosong/test/errors.test.ts`: classifier accepts the field-observed message (doubled space verbatim) for 400 and 422, on both `isToolExchangeAdjacencyError` and `isRecoverableRequestStructureError`; negative case: `400 resource not found` does not match.
- `agent-core/test/loop/tool-exchange-fallback.e2e.test.ts`: end-to-end — Moonshot-phrased 400 triggers exactly one strict resend and the turn recovers.
- Written red-first: all three new assertions failed before the one-line pattern change.
- Full suite: kosong 1133 passed; repo-wide green except 6 pre-existing failures in `apps/kimi-code/test/cli/update/preflight.test.ts` (verified pre-existing via stash on a clean tree).