### PR TITLE
fix(web): stop session row from shifting on hover

### DIFF
--- a/.changeset/fix-web-session-row-hover.md
+++ b/.changeset/fix-web-session-row-hover.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Fix the sidebar session row shifting its title and status badges when hovered.

--- a/apps/kimi-web/design/design-system.html
+++ b/apps/kimi-web/design/design-system.html
@@ -2188,19 +2188,34 @@ export function auth(token: string) {
         </div></div>
 
         <h3 class="sub">Session row</h3>
-        <p>A session row is an inset rounded pill, structured as: <code>status slot → title → time → attention Badge → kebab</code>.</p>
+        <p>A session row is an inset rounded pill, structured as: <code>status slot → title → attention Badge → trailing action slot</code>.</p>
         <table class="dt">
           <thead><tr><th>Part</th><th>Rule</th></tr></thead>
           <tbody>
             <tr><td>Container</td><td><code>margin: 1px 6px; padding: 7px 10px; radius-md</code>; hover = <code>surface-sunken</code>; active = <code>accent-soft</code> + <code>inset 0 0 0 1px accent-bd</code></td></tr>
             <tr><td>Status slot (lead)</td><td>fixed <code>--sb-gutter</code> width; running = <code>Spinner</code> sm, otherwise unread = 7px accent dot</td></tr>
             <tr><td>Title</td><td>flex:1 with truncation; double-click enters inline rename (compact input, not Input)</td></tr>
-            <tr><td>Time</td><td>mono xs, <code>fg-faint</code>; yields to the kebab on hover</td></tr>
-            <tr><td>Attention Badge</td><td><code>Badge</code> sm: info (needs answer) / warning (needs approval) / danger (aborted)</td></tr>
-            <tr><td>kebab</td><td><code>IconButton</code> sm, shown on hover; dropdown uses <code>Menu/MenuItem</code></td></tr>
+            <tr><td>Attention Badge</td><td><code>Badge</code> sm: info (needs answer) / warning (needs approval) / danger (aborted); <b>always shown</b>, not toggled on hover</td></tr>
+            <tr><td>Trailing action slot (trail)</td><td>fixed slot shared by the time ↔ kebab (see below)</td></tr>
             <tr><td>Archive confirmation</td><td>replaces the title area, <code>Button</code> sm (danger confirm / secondary cancel)</td></tr>
           </tbody>
         </table>
+
+        <h4 class="mini">Trailing action slot</h4>
+        <p>The session row's rightmost is a <b>fixed-width</b> action slot: at rest it shows the relative time (mono xs, <code>fg-faint</code>); on hover it swaps <b>in place</b> to the kebab (<code>IconButton</code> sm).</p>
+        <ul class="clean">
+          <li>The time and kebab are stacked with <code>display:inline-grid</code> + <code>grid-area:1/1</code> and swapped on hover via <code>visibility</code> — <b>never <code>display:none</code></b>.</li>
+          <li>The slot width is always <code>max(time width, IconButton sm 26px)</code>, so the right region's total width is unchanged across hover — badges don't shift, the title's visible character count doesn't change, <b>no jitter</b>.</li>
+          <li>A session awaiting an answer (info Badge) likewise shows no time on hover: the slot holds only the kebab.</li>
+        </ul>
+        <div class="code"><div class="code-bar"><span class="d"></span><span class="d"></span><span class="d"></span><span class="fn">SessionRow.vue</span></div><pre>.act { display: inline-grid; flex: none; align-items: center; justify-items: center; }
+.act .ts, .act .kebab { grid-area: 1 / 1; }
+.act .kebab { visibility: hidden; }
+.se:hover .act .kebab, .act:has(.kebab.open) .kebab { visibility: visible; }
+.se:hover .act .ts,   .act:has(.kebab.open) .ts   { visibility: hidden; }</pre></div>
+        <div class="callout info"><span class="ico">i</span><div>
+          <b>Why the time and kebab share a slot and use <code>visibility</code> rather than <code>display:none</code>:</b> the time is variable-width (<code>2h</code> / <code>5m</code> / <code>just now</code> …), the kebab a fixed 26px. If hover used <code>display:none</code> to drop the time and append the kebab, the right region would reflow — badges shift and the title's truncation changes, causing visible jitter. Sharing one slot and swapping via <code>visibility</code> keeps the slot width constant; this is a hard rule for sidebar list-row stability.
+        </div></div>
 
         <h3 class="sub">Workspace group</h3>
         <p>The group head and session rows share <code>--sb-*</code>: folder icon (open/closed) → name → path subtitle, with the kebab and "+" revealed on hover.</p>

--- a/apps/kimi-web/public/design-system.html
+++ b/apps/kimi-web/public/design-system.html
@@ -2188,19 +2188,34 @@ export function auth(token: string) {
         </div></div>
 
         <h3 class="sub">Session row</h3>
-        <p>A session row is an inset rounded pill, structured as: <code>status slot → title → time → attention Badge → kebab</code>.</p>
+        <p>A session row is an inset rounded pill, structured as: <code>status slot → title → attention Badge → trailing action slot</code>.</p>
         <table class="dt">
           <thead><tr><th>Part</th><th>Rule</th></tr></thead>
           <tbody>
             <tr><td>Container</td><td><code>margin: 1px 6px; padding: 7px 10px; radius-md</code>; hover = <code>surface-sunken</code>; active = <code>accent-soft</code> + <code>inset 0 0 0 1px accent-bd</code></td></tr>
             <tr><td>Status slot (lead)</td><td>fixed <code>--sb-gutter</code> width; running = <code>Spinner</code> sm, otherwise unread = 7px accent dot</td></tr>
             <tr><td>Title</td><td>flex:1 with truncation; double-click enters inline rename (compact input, not Input)</td></tr>
-            <tr><td>Time</td><td>mono xs, <code>fg-faint</code>; yields to the kebab on hover</td></tr>
-            <tr><td>Attention Badge</td><td><code>Badge</code> sm: info (needs answer) / warning (needs approval) / danger (aborted)</td></tr>
-            <tr><td>kebab</td><td><code>IconButton</code> sm, shown on hover; dropdown uses <code>Menu/MenuItem</code></td></tr>
+            <tr><td>Attention Badge</td><td><code>Badge</code> sm: info (needs answer) / warning (needs approval) / danger (aborted); <b>always shown</b>, not toggled on hover</td></tr>
+            <tr><td>Trailing action slot (trail)</td><td>fixed slot shared by the time ↔ kebab (see below)</td></tr>
             <tr><td>Archive confirmation</td><td>replaces the title area, <code>Button</code> sm (danger confirm / secondary cancel)</td></tr>
           </tbody>
         </table>
+
+        <h4 class="mini">Trailing action slot</h4>
+        <p>The session row's rightmost is a <b>fixed-width</b> action slot: at rest it shows the relative time (mono xs, <code>fg-faint</code>); on hover it swaps <b>in place</b> to the kebab (<code>IconButton</code> sm).</p>
+        <ul class="clean">
+          <li>The time and kebab are stacked with <code>display:inline-grid</code> + <code>grid-area:1/1</code> and swapped on hover via <code>visibility</code> — <b>never <code>display:none</code></b>.</li>
+          <li>The slot width is always <code>max(time width, IconButton sm 26px)</code>, so the right region's total width is unchanged across hover — badges don't shift, the title's visible character count doesn't change, <b>no jitter</b>.</li>
+          <li>A session awaiting an answer (info Badge) likewise shows no time on hover: the slot holds only the kebab.</li>
+        </ul>
+        <div class="code"><div class="code-bar"><span class="d"></span><span class="d"></span><span class="d"></span><span class="fn">SessionRow.vue</span></div><pre>.act { display: inline-grid; flex: none; align-items: center; justify-items: center; }
+.act .ts, .act .kebab { grid-area: 1 / 1; }
+.act .kebab { visibility: hidden; }
+.se:hover .act .kebab, .act:has(.kebab.open) .kebab { visibility: visible; }
+.se:hover .act .ts,   .act:has(.kebab.open) .ts   { visibility: hidden; }</pre></div>
+        <div class="callout info"><span class="ico">i</span><div>
+          <b>Why the time and kebab share a slot and use <code>visibility</code> rather than <code>display:none</code>:</b> the time is variable-width (<code>2h</code> / <code>5m</code> / <code>just now</code> …), the kebab a fixed 26px. If hover used <code>display:none</code> to drop the time and append the kebab, the right region would reflow — badges shift and the title's truncation changes, causing visible jitter. Sharing one slot and swapping via <code>visibility</code> keeps the slot width constant; this is a hard rule for sidebar list-row stability.
+        </div></div>
 
         <h3 class="sub">Workspace group</h3>
         <p>The group head and session rows share <code>--sb-*</code>: folder icon (open/closed) → name → path subtitle, with the kebab and "+" revealed on hover.</p>

--- a/apps/kimi-web/src/components/SessionRow.vue
+++ b/apps/kimi-web/src/components/SessionRow.vue
@@ -205,8 +205,6 @@ defineExpose({ closeMenu });
         <span v-else class="t" @dblclick.stop="startRename">{{ session.title }}</span>
       </div>
 
-      <span class="ts">{{ session.time }}</span>
-
       <!-- Pending tags — coloured per kind, shown even when the row isn't
            active. "Answer" = an askUserQuestion is waiting; "Approve" = a
            permission request is waiting. The session's lifecycle status drives
@@ -241,18 +239,24 @@ defineExpose({ closeMenu });
         </Badge>
       </Tooltip>
 
-      <!-- Kebab button (visible on hover) -->
-      <IconButton
-        ref="kebabRef"
-        v-if="!renaming"
-        class="kebab"
-        :class="{ open: menuOpen }"
-        size="sm"
-        :label="t('sidebar.options')"
-        @click.stop="toggleMenu($event)"
-      >
-        <Icon name="dots-horizontal" size="sm" />
-      </IconButton>
+      <!-- Trailing action slot: the relative time and the kebab share one grid
+           cell and swap via `visibility` (never display:none), so the slot
+           width is identical in hover and rest. The badges and title therefore
+           don't reflow on hover — see design-system §07 "Session row". -->
+      <span class="act">
+        <span class="ts">{{ session.time }}</span>
+        <IconButton
+          ref="kebabRef"
+          v-if="!renaming"
+          class="kebab"
+          :class="{ open: menuOpen }"
+          size="sm"
+          :label="t('sidebar.options')"
+          @click.stop="toggleMenu($event)"
+        >
+          <Icon name="dots-horizontal" size="sm" />
+        </IconButton>
+      </span>
     </div>
 
     <!-- Kebab dropdown — teleported to <body> and position:fixed so it escapes
@@ -350,16 +354,27 @@ defineExpose({ closeMenu });
   color: var(--color-text-faint);
   font-size: var(--text-xs);
   font-family: var(--font-mono);
-  flex: none;
 }
-.se:hover .ts { display: none; }
 
-/* Kebab button — hidden until hover. Sits at the RIGHT of the timestamp
-   and attention badge so it is the right-most element. `.se .kebab` out-
-   specificities IconButton's display so the hidden default actually wins. */
-.se .kebab { display: none; }
-.se:hover .kebab,
-.kebab.open { display: inline-flex; }
+/* Trailing action slot: time and kebab share one grid cell (grid-area:1/1).
+   Both stay in the layout and swap via `visibility` (never display:none), so
+   the slot width = max(time width, IconButton sm 26px) is identical in hover
+   and rest — the badges and title don't reflow, eliminating hover jitter.
+   `.act .kebab` out-specificities IconButton's own display so the hidden
+   default wins. */
+.act {
+  display: inline-grid;
+  flex: none;
+  align-items: center;
+  justify-items: center;
+}
+.act .ts,
+.act .kebab { grid-area: 1 / 1; }
+.act .kebab { visibility: hidden; }
+.se:hover .act .kebab,
+.act:has(.kebab.open) .kebab { visibility: visible; }
+.se:hover .act .ts,
+.act:has(.kebab.open) .ts { visibility: hidden; }
 .kebab.open { color: var(--color-text); background: var(--color-surface-sunken); }
 
 /* Fixed + anchored to the ⋯ button via inline style (see positionMenu); the menu


### PR DESCRIPTION
## Related Issue

No linked issue — small sidebar polish fix.

## Problem

Hovering a session row in the sidebar made the row reflow: the status badges (Answer / Approve / Stopped) shifted sideways and the session title's truncation changed by a few characters, producing visible jitter. It was most noticeable on rows carrying a pending badge.

Root cause: on hover the row used `display:none` to remove the relative time and appended the kebab (`⋯`) at the end. The time is variable-width (`2h` / `5m` / `just now` …) while the kebab is a fixed 26px, so the right-hand region changed width between rest and hover.

## What changed

- Put the relative time and the kebab in a single `inline-grid` cell (`grid-area: 1/1`) and swap them with `visibility` instead of `display:none`. The slot width is now `max(time width, 26px)` in both states, so the right region's total width is constant across hover — badges and the title no longer reflow.
- A session awaiting an answer still hides the time on hover (the slot shows only the kebab).
- Documented the rule in the design system (§07 Session row → "Trailing action slot"), including the `visibility`-over-`display:none` rationale.

Verified with a side-by-side interactive demo (rest vs. hover, with layout boxes showing the badge/title stay put); `check:style` and `typecheck` pass.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [ ] I have added tests that prove my feature works. — N/A: this is a layout-only change and the web package has no component tests; verified interactively with a side-by-side demo.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update. — No user-facing CLI doc change; the in-repo design system is updated in this PR.
