### PR TITLE
fix(web): cap live session subscriptions to reduce lag with many sessions

### DIFF
--- a/.changeset/web-session-subscription-cap.md
+++ b/.changeset/web-session-subscription-cap.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Fix the web UI becoming sluggish after opening many sessions.

--- a/apps/kimi-web/src/composables/client/useWorkspaceState.ts
+++ b/apps/kimi-web/src/composables/client/useWorkspaceState.ts
@@ -118,7 +118,7 @@ export interface UseWorkspaceStateDeps {
   nextOptimisticMsgId: () => string;
   getEventConn: () => KimiEventConnection | null;
   syncSessionFromSnapshot: (sessionId: string) => Promise<SyncSessionResult>;
-  subscribeToSessionEvents: (sessionId: string) => void;
+  reopenSession: (sessionId: string) => Promise<SyncSessionResult>;
   hasLoadedMessages: (sessionId: string) => boolean;
   refreshSessionStatus: (sessionId: string) => Promise<void>;
   persistSessionProfile: (patch: PersistSessionProfilePatch) => void;
@@ -166,7 +166,7 @@ export function useWorkspaceState(rawState: ExtendedState, deps: UseWorkspaceSta
     nextOptimisticMsgId,
     getEventConn,
     syncSessionFromSnapshot,
-    subscribeToSessionEvents,
+    reopenSession,
     hasLoadedMessages,
     refreshSessionStatus,
     persistSessionProfile,
@@ -959,9 +959,12 @@ export function useWorkspaceState(rawState: ExtendedState, deps: UseWorkspaceSta
         const result = await syncSessionFromSnapshot(sessionId);
         if (result === 'not-found') return;
       } else {
-        // Re-open: resume from the tracked cursor; the daemon replays any
-        // missed durable events (or answers resync_required → snapshot).
-        subscribeToSessionEvents(sessionId);
+        // Re-open: if the session was evicted from the subscription cap since
+        // last open, reopenSession rebuilds it from a snapshot (the kept cursor
+        // may have skipped per-session events); otherwise it re-subscribes from
+        // the tracked cursor and the daemon replays any missed durable events.
+        const result = await reopenSession(sessionId);
+        if (result === 'not-found') return;
       }
 
       // Refresh sidecars AFTER the snapshot settles so status/usage updates

--- a/apps/kimi-web/src/composables/useKimiWebClient.ts
+++ b/apps/kimi-web/src/composables/useKimiWebClient.ts
@@ -503,6 +503,7 @@ function forgetSession(sessionId: string): void {
   // buffered event for this id would otherwise be reduced and recreate the very
   // per-session maps we are about to delete.
   eventConn?.unsubscribe(sessionId);
+  dropWsSubscription(sessionId);
   // Drain the streaming-event batcher too. unsubscribe() stops future server
   // frames, but events already queued for the next animation frame would
   // otherwise survive and be reduced AFTER the maps below are cleared —
@@ -1158,6 +1159,7 @@ async function syncSessionFromSnapshot(sessionId: string): Promise<SyncSessionRe
       // before live deltas (aligned by wire offset) start appending to it.
       eventConn.seedSnapshot(sessionId, snap);
       eventConn.subscribe(sessionId, { seq: snap.asOfSeq, epoch: snap.epoch });
+      retainWsSubscription(sessionId);
     }
     void pullSessionWarnings(sessionId);
     return 'ok';
@@ -1181,6 +1183,45 @@ function hasLoadedMessages(sessionId: string): boolean {
   return Object.prototype.hasOwnProperty.call(rawState.messagesBySession, sessionId);
 }
 
+// ---------------------------------------------------------------------------
+// WS subscription cap (LRU eviction)
+// ---------------------------------------------------------------------------
+//
+// Every opened session subscribes to its WS event stream, and the socket keeps
+// subscriptions across reconnects (re-sending them in `client_hello`). Without
+// a cap, a user who has opened hundreds of sessions stays subscribed to all of
+// them: every background session's status/meta/usage event then flows through
+// the reducer and dirties the sidebar computeds — the root cause of "the UI
+// gets sluggish once I have a lot of sessions".
+//
+// Keep only the most-recently-opened sessions subscribed (MRU order, index 0 =
+// newest). The active session is always retained. Evicting an entry only drops
+// the live WS subscription; `lastSeqBySession` / `epochBySession` are kept so
+// re-opening the session resumes from the tracked cursor — the daemon replays
+// missed durable events, or answers `resync_required` → snapshot.
+const MAX_WS_SUBSCRIPTIONS = 4;
+const wsSubscriptionOrder: string[] = [];
+
+function retainWsSubscription(sessionId: string): void {
+  const idx = wsSubscriptionOrder.indexOf(sessionId);
+  if (idx !== -1) wsSubscriptionOrder.splice(idx, 1);
+  wsSubscriptionOrder.unshift(sessionId);
+  // Evict oldest subscriptions past the cap. The active session sits at the
+  // front (selectSession touches it on every open), but guard anyway so it can
+  // never be evicted.
+  while (wsSubscriptionOrder.length > MAX_WS_SUBSCRIPTIONS) {
+    const tail = wsSubscriptionOrder.at(-1);
+    if (tail === undefined || tail === rawState.activeSessionId) break;
+    wsSubscriptionOrder.pop();
+    eventConn?.unsubscribe(tail);
+  }
+}
+
+function dropWsSubscription(sessionId: string): void {
+  const idx = wsSubscriptionOrder.indexOf(sessionId);
+  if (idx !== -1) wsSubscriptionOrder.splice(idx, 1);
+}
+
 function subscribeToSessionEvents(sessionId: string): void {
   connectEventsIfNeeded();
   if (eventConn) {
@@ -1192,6 +1233,7 @@ function subscribeToSessionEvents(sessionId: string): void {
     const seq = rawState.lastSeqBySession[sessionId] ?? 0;
     const epoch = epochBySession[sessionId];
     eventConn.subscribe(sessionId, { seq, epoch });
+    retainWsSubscription(sessionId);
   }
 }
 

--- a/apps/kimi-web/src/composables/useKimiWebClient.ts
+++ b/apps/kimi-web/src/composables/useKimiWebClient.ts
@@ -1195,12 +1195,21 @@ function hasLoadedMessages(sessionId: string): boolean {
 // gets sluggish once I have a lot of sessions".
 //
 // Keep only the most-recently-opened sessions subscribed (MRU order, index 0 =
-// newest). The active session is always retained. Evicting an entry only drops
-// the live WS subscription; `lastSeqBySession` / `epochBySession` are kept so
-// re-opening the session resumes from the tracked cursor — the daemon replays
-// missed durable events, or answers `resync_required` → snapshot.
+// newest). The active session is always retained.
+//
+// Eviction drops the live WS subscription but keeps the session's cursor so a
+// quick re-open can resume cheaply. However, a cursor kept across an eviction
+// can go stale: some session events (`event.session.status_changed`,
+// `session.meta.updated`, ...) are broadcast to EVERY connection (see
+// `isGlobalSessionEvent` on the server) and still advance `lastSeqBySession`
+// for an unsubscribed session. If a session emits per-session durable events
+// while evicted and then a global event, the cursor jumps past the missed
+// events and resuming from it would skip them. Evicted sessions are therefore
+// tracked in `sessionsWithStaleCursor`, and their cursor is reset on the next
+// re-subscribe so the daemon replays (or snapshots) what was missed.
 const MAX_WS_SUBSCRIPTIONS = 4;
 const wsSubscriptionOrder: string[] = [];
+const sessionsWithStaleCursor = new Set<string>();
 
 function retainWsSubscription(sessionId: string): void {
   const idx = wsSubscriptionOrder.indexOf(sessionId);
@@ -1214,12 +1223,14 @@ function retainWsSubscription(sessionId: string): void {
     if (tail === undefined || tail === rawState.activeSessionId) break;
     wsSubscriptionOrder.pop();
     eventConn?.unsubscribe(tail);
+    sessionsWithStaleCursor.add(tail);
   }
 }
 
 function dropWsSubscription(sessionId: string): void {
   const idx = wsSubscriptionOrder.indexOf(sessionId);
   if (idx !== -1) wsSubscriptionOrder.splice(idx, 1);
+  sessionsWithStaleCursor.delete(sessionId);
 }
 
 function subscribeToSessionEvents(sessionId: string): void {
@@ -1230,6 +1241,14 @@ function subscribeToSessionEvents(sessionId: string): void {
     // they don't advance lastSeqBySession — but flushing here is cheap and
     // future-proofs the cursor if the batching set ever changes.)
     enqueueEvent.flush();
+    // If this session was evicted from the cap, its cursor may have been
+    // advanced past missed per-session events by global session events. Reset
+    // it so the daemon replays (or snapshots) what was missed while
+    // unsubscribed, instead of resuming from a cursor that skips them.
+    if (sessionsWithStaleCursor.delete(sessionId)) {
+      delete rawState.lastSeqBySession[sessionId];
+      delete epochBySession[sessionId];
+    }
     const seq = rawState.lastSeqBySession[sessionId] ?? 0;
     const epoch = epochBySession[sessionId];
     eventConn.subscribe(sessionId, { seq, epoch });

--- a/apps/kimi-web/src/composables/useKimiWebClient.ts
+++ b/apps/kimi-web/src/composables/useKimiWebClient.ts
@@ -1161,6 +1161,7 @@ async function syncSessionFromSnapshot(sessionId: string): Promise<SyncSessionRe
       eventConn.subscribe(sessionId, { seq: snap.asOfSeq, epoch: snap.epoch });
       retainWsSubscription(sessionId);
     }
+    sessionsWithStaleCursor.delete(sessionId);
     void pullSessionWarnings(sessionId);
     return 'ok';
   } catch (err) {
@@ -1204,9 +1205,9 @@ function hasLoadedMessages(sessionId: string): boolean {
 // `isGlobalSessionEvent` on the server) and still advance `lastSeqBySession`
 // for an unsubscribed session. If a session emits per-session durable events
 // while evicted and then a global event, the cursor jumps past the missed
-// events and resuming from it would skip them. Evicted sessions are therefore
-// tracked in `sessionsWithStaleCursor`, and their cursor is reset on the next
-// re-subscribe so the daemon replays (or snapshots) what was missed.
+// events. Evicted sessions are therefore tracked in `sessionsWithStaleCursor`;
+// when one is re-opened we rebuild from a snapshot (see `reopenSession`) rather
+// than resume from a cursor that may have skipped events.
 const MAX_WS_SUBSCRIPTIONS = 4;
 const wsSubscriptionOrder: string[] = [];
 const sessionsWithStaleCursor = new Set<string>();
@@ -1215,15 +1216,24 @@ function retainWsSubscription(sessionId: string): void {
   const idx = wsSubscriptionOrder.indexOf(sessionId);
   if (idx !== -1) wsSubscriptionOrder.splice(idx, 1);
   wsSubscriptionOrder.unshift(sessionId);
-  // Evict oldest subscriptions past the cap. The active session sits at the
-  // front (selectSession touches it on every open), but guard anyway so it can
-  // never be evicted.
+  // Evict the oldest entries past the cap, skipping the active session. The
+  // active session is NOT guaranteed to sit at the front: first-time opens only
+  // retain after an awaited snapshot, so rapid clicks can complete out of order
+  // and leave the active session at the tail. Skipping it (rather than breaking
+  // when the tail is active) keeps the cap effective.
   while (wsSubscriptionOrder.length > MAX_WS_SUBSCRIPTIONS) {
-    const tail = wsSubscriptionOrder.at(-1);
-    if (tail === undefined || tail === rawState.activeSessionId) break;
-    wsSubscriptionOrder.pop();
-    eventConn?.unsubscribe(tail);
-    sessionsWithStaleCursor.add(tail);
+    let victimIdx = -1;
+    for (let i = wsSubscriptionOrder.length - 1; i >= 0; i--) {
+      if (wsSubscriptionOrder[i] !== rawState.activeSessionId) {
+        victimIdx = i;
+        break;
+      }
+    }
+    if (victimIdx === -1) break;
+    const [victim] = wsSubscriptionOrder.splice(victimIdx, 1);
+    if (victim === undefined) break;
+    eventConn?.unsubscribe(victim);
+    sessionsWithStaleCursor.add(victim);
   }
 }
 
@@ -1241,19 +1251,25 @@ function subscribeToSessionEvents(sessionId: string): void {
     // they don't advance lastSeqBySession — but flushing here is cheap and
     // future-proofs the cursor if the batching set ever changes.)
     enqueueEvent.flush();
-    // If this session was evicted from the cap, its cursor may have been
-    // advanced past missed per-session events by global session events. Reset
-    // it so the daemon replays (or snapshots) what was missed while
-    // unsubscribed, instead of resuming from a cursor that skips them.
-    if (sessionsWithStaleCursor.delete(sessionId)) {
-      delete rawState.lastSeqBySession[sessionId];
-      delete epochBySession[sessionId];
-    }
     const seq = rawState.lastSeqBySession[sessionId] ?? 0;
     const epoch = epochBySession[sessionId];
     eventConn.subscribe(sessionId, { seq, epoch });
     retainWsSubscription(sessionId);
   }
+}
+
+/** Re-open an already-loaded session. If it was evicted from the subscription
+ *  cap since it was last open, rebuild from a snapshot: resuming from the kept
+ *  cursor would skip the per-session events that arrived while unsubscribed,
+ *  and replaying from seq 0 would make the projector regenerate message ids and
+ *  duplicate the already-loaded transcript. Otherwise just re-subscribe from the
+ *  tracked cursor. */
+async function reopenSession(sessionId: string): Promise<SyncSessionResult> {
+  if (sessionsWithStaleCursor.delete(sessionId)) {
+    return syncSessionFromSnapshot(sessionId);
+  }
+  subscribeToSessionEvents(sessionId);
+  return 'ok';
 }
 
 // ---------------------------------------------------------------------------
@@ -2181,7 +2197,7 @@ const workspaceState = useWorkspaceState(rawState, {
   nextOptimisticMsgId,
   getEventConn: () => eventConn,
   syncSessionFromSnapshot,
-  subscribeToSessionEvents,
+  reopenSession,
   hasLoadedMessages,
   refreshSessionStatus,
   persistSessionProfile,

--- a/apps/kimi-web/src/composables/useKimiWebClient.ts
+++ b/apps/kimi-web/src/composables/useKimiWebClient.ts
@@ -1263,9 +1263,14 @@ function subscribeToSessionEvents(sessionId: string): void {
  *  cursor would skip the per-session events that arrived while unsubscribed,
  *  and replaying from seq 0 would make the projector regenerate message ids and
  *  duplicate the already-loaded transcript. Otherwise just re-subscribe from the
- *  tracked cursor. */
+ *  tracked cursor.
+ *
+ * The stale marker is only read here; `syncSessionFromSnapshot` clears it once
+ * the snapshot succeeds. If the snapshot fails transiently the marker stays, so
+ * the next re-open retries the snapshot instead of falling back to a cursor
+ * that may have skipped events while unsubscribed. */
 async function reopenSession(sessionId: string): Promise<SyncSessionResult> {
-  if (sessionsWithStaleCursor.delete(sessionId)) {
+  if (sessionsWithStaleCursor.has(sessionId)) {
     return syncSessionFromSnapshot(sessionId);
   }
   subscribeToSessionEvents(sessionId);


### PR DESCRIPTION
## Related Issue

No linked issue — this comes from a user report that the web UI gets sluggish once they have a hundred or so sessions.

## Problem

Every session the user opens subscribes to its WebSocket event stream, and the socket keeps all subscriptions across reconnects (re-sending them in `client_hello`). Subscriptions were only dropped on archive / delete, never on session switch. After opening many sessions, every background session's status / meta / usage event flows through the reducer and dirties the sidebar computeds, so the whole UI slows down as the session count grows.

## What changed

Cap the number of live WebSocket session subscriptions with a small MRU list (4). The active session is always retained; when the cap is exceeded, the least-recently-opened subscription is evicted. Eviction only drops the live subscription — the per-session seq / epoch cursor is kept, so re-opening an evicted session resumes from the cursor (the daemon replays missed durable events, or answers `resync_required`). Reconnects also get cheaper because `client_hello` only carries the retained subscriptions.

Trade-off: a background session that has fallen out of the 4-slot window no longer lights up its unread dot / completion notification in real time; it syncs when the user switches back to it.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [ ] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.
