### PR TITLE
fix(oauth): treat API-key providers as authed in ACP session gate

### DIFF
--- a/.changeset/acp-api-key-auth-gate.md
+++ b/.changeset/acp-api-key-auth-gate.md
@@ -1,0 +1,14 @@
+---
+'@moonshot-ai/kimi-code': patch
+---
+
+Fix ACP `session/new` rejecting API-key-only users with `auth_required`.
+
+API-key login (open-platform path) writes `apiKey` into the config file but not the
+OAuth credentials file, so the ACP session auth gate — which only checked for an OAuth
+token — returned `auth_required` (`-32000`) for every `session/new`, `session/load`,
+and `session/resume`, even though the API key was valid. `initialize` still succeeded
+(it carries no credentials), so ACP clients saw init OK followed by an auth failure.
+
+`KimiOAuthToolkit.status()` now also surfaces providers configured with a non-empty
+`apiKey`, so the gate treats API-key users as authed.

--- a/packages/node-sdk/src/auth.ts
+++ b/packages/node-sdk/src/auth.ts
@@ -119,7 +119,11 @@ export class KimiAuthFacade {
   }
 
   async status(providerName?: string | undefined): Promise<AuthStatus> {
-    return this.toolkit.status(providerName, this.resolveRuntimeManagedAuth(providerName).oauthRef);
+    return this.toolkit.status(
+      providerName,
+      this.resolveRuntimeManagedAuth(providerName).oauthRef,
+      { apiKeyProviders: this.resolveApiKeyProviders() },
+    );
   }
 
   async login(
@@ -292,6 +296,24 @@ export class KimiAuthFacade {
       oauthRef: provider?.oauth,
       baseUrl: provider?.baseUrl,
     };
+  }
+
+  /**
+   * Provider names configured with a non-empty `apiKey`. Like
+   * {@link resolveManagedAuth} this reads via the lenient loader so a broken
+   * unrelated config section cannot abort status resolution. The managed OAuth
+   * slot is provisioned with an empty `apiKey`, so it is excluded by the
+   * non-empty check.
+   */
+  private resolveApiKeyProviders(): string[] {
+    const { config } = loadRuntimeConfigSafe(this.options.configPath);
+    const names: string[] = [];
+    for (const [name, provider] of Object.entries(config.providers)) {
+      if (provider.apiKey && provider.apiKey.length > 0) {
+        names.push(name);
+      }
+    }
+    return names;
   }
 
   private resolveRuntimeManagedAuth(providerName?: string | undefined): {

--- a/packages/node-sdk/test/auth-facade.test.ts
+++ b/packages/node-sdk/test/auth-facade.test.ts
@@ -153,6 +153,29 @@ max_steps_per_turn = "abc"
     });
   });
 
+  it('reports an API-key provider as authed even with a broken unrelated config section', async () => {
+    // No OAuth token file — the user authenticated via API key only. A broken
+    // [loop_control] must not abort status resolution (the read path uses the
+    // lenient loader, not the strict write-path reader).
+    await writeFile(
+      join(homeDir, 'config.toml'),
+      `
+[providers."moonshot-cn"]
+type = "kimi"
+base_url = "https://api.moonshot.cn/v1"
+api_key = "sk-test"
+
+[loop_control]
+max_steps_per_turn = "abc"
+`,
+    );
+    const harness = createKimiHarness({ homeDir, identity: TEST_IDENTITY });
+
+    const status = await harness.auth.status();
+    expect(status.providers).toContainEqual({ providerName: 'moonshot-cn', hasToken: true });
+    expect(status.providers.some((entry) => entry.hasToken)).toBe(true);
+  });
+
   it('resolves cached access tokens from the configured scoped OAuth ref', async () => {
     const oauthKey = resolveKimiCodeOAuthKey({
       oauthHost: 'https://auth.dev.example.test',

--- a/packages/oauth/src/toolkit.ts
+++ b/packages/oauth/src/toolkit.ts
@@ -140,10 +140,15 @@ export class KimiOAuthToolkit<TConfig = unknown> {
     const name = providerName ?? KIMI_CODE_PROVIDER_NAME;
     const oauthHost = this.oauthHostFor(oauthRef);
     const oauthKey = oauthRef?.key ?? this.defaultOAuthKey(undefined, oauthHost);
+    const apiKeyProviderNames = new Set(options?.apiKeyProviders ?? []);
+    // The requested provider may itself authenticate via an API key (no OAuth
+    // token file). Merge that case into the primary entry instead of appending
+    // a duplicate, so callers reading providers[0] see the correct status.
     const providers: AuthProviderStatus[] = [
       {
         providerName: name,
-        hasToken: await this.managerFor(name, oauthKey, oauthHost).hasToken(),
+        hasToken:
+          apiKeyProviderNames.has(name) || (await this.managerFor(name, oauthKey, oauthHost).hasToken()),
       },
     ];
     // API-key providers authenticate with a configured `apiKey` instead of an
@@ -153,8 +158,9 @@ export class KimiOAuthToolkit<TConfig = unknown> {
     // `auth_required`, even though their key is valid. The caller resolves the
     // list of API-key provider names from a lenient config read so a broken
     // unrelated config section cannot abort status resolution.
-    for (const providerName of options?.apiKeyProviders ?? []) {
-      providers.push({ providerName, hasToken: true });
+    for (const apiKeyProviderName of options?.apiKeyProviders ?? []) {
+      if (apiKeyProviderName === name) continue;
+      providers.push({ providerName: apiKeyProviderName, hasToken: true });
     }
     return { providers };
   }

--- a/packages/oauth/src/toolkit.ts
+++ b/packages/oauth/src/toolkit.ts
@@ -30,7 +30,6 @@ import {
   resolveKimiCodeOAuthKey,
   type ManagedKimiCodeProvisionResult,
   type ManagedKimiConfigAdapter,
-  type ManagedKimiConfigShape,
 } from './managed-kimi-code';
 import {
   fetchManagedUsage,
@@ -136,6 +135,7 @@ export class KimiOAuthToolkit<TConfig = unknown> {
   async status(
     providerName?: string | undefined,
     oauthRef?: KimiOAuthTokenRef | undefined,
+    options?: { readonly apiKeyProviders?: readonly string[] | undefined },
   ): Promise<AuthStatus> {
     const name = providerName ?? KIMI_CODE_PROVIDER_NAME;
     const oauthHost = this.oauthHostFor(oauthRef);
@@ -150,16 +150,11 @@ export class KimiOAuthToolkit<TConfig = unknown> {
     // OAuth token file, so they have no credentials entry for `hasToken()` to
     // find. Without surfacing them here the ACP session gate (which treats any
     // provider with `hasToken` as authed) rejects API-key-only users with
-    // `auth_required`, even though their key is valid.
-    if (this.configAdapter !== undefined) {
-      const config = (await this.configAdapter.read()) as ManagedKimiConfigShape;
-      for (const [key, entry] of Object.entries(config.providers ?? {})) {
-        if (typeof entry !== 'object' || entry === null) continue;
-        const apiKey = (entry as { apiKey?: unknown }).apiKey;
-        if (typeof apiKey === 'string' && apiKey.length > 0) {
-          providers.push({ providerName: key, hasToken: true });
-        }
-      }
+    // `auth_required`, even though their key is valid. The caller resolves the
+    // list of API-key provider names from a lenient config read so a broken
+    // unrelated config section cannot abort status resolution.
+    for (const providerName of options?.apiKeyProviders ?? []) {
+      providers.push({ providerName, hasToken: true });
     }
     return { providers };
   }

--- a/packages/oauth/src/toolkit.ts
+++ b/packages/oauth/src/toolkit.ts
@@ -30,6 +30,7 @@ import {
   resolveKimiCodeOAuthKey,
   type ManagedKimiCodeProvisionResult,
   type ManagedKimiConfigAdapter,
+  type ManagedKimiConfigShape,
 } from './managed-kimi-code';
 import {
   fetchManagedUsage,
@@ -139,14 +140,28 @@ export class KimiOAuthToolkit<TConfig = unknown> {
     const name = providerName ?? KIMI_CODE_PROVIDER_NAME;
     const oauthHost = this.oauthHostFor(oauthRef);
     const oauthKey = oauthRef?.key ?? this.defaultOAuthKey(undefined, oauthHost);
-    return {
-      providers: [
-        {
-          providerName: name,
-          hasToken: await this.managerFor(name, oauthKey, oauthHost).hasToken(),
-        },
-      ],
-    };
+    const providers: AuthProviderStatus[] = [
+      {
+        providerName: name,
+        hasToken: await this.managerFor(name, oauthKey, oauthHost).hasToken(),
+      },
+    ];
+    // API-key providers authenticate with a configured `apiKey` instead of an
+    // OAuth token file, so they have no credentials entry for `hasToken()` to
+    // find. Without surfacing them here the ACP session gate (which treats any
+    // provider with `hasToken` as authed) rejects API-key-only users with
+    // `auth_required`, even though their key is valid.
+    if (this.configAdapter !== undefined) {
+      const config = (await this.configAdapter.read()) as ManagedKimiConfigShape;
+      for (const [key, entry] of Object.entries(config.providers ?? {})) {
+        if (typeof entry !== 'object' || entry === null) continue;
+        const apiKey = (entry as { apiKey?: unknown }).apiKey;
+        if (typeof apiKey === 'string' && apiKey.length > 0) {
+          providers.push({ providerName: key, hasToken: true });
+        }
+      }
+    }
+    return { providers };
   }
 
   async login(

--- a/packages/oauth/test/toolkit.test.ts
+++ b/packages/oauth/test/toolkit.test.ts
@@ -133,6 +133,60 @@ describe('KimiOAuthToolkit', () => {
     await expect(toolkit.tokenProvider().getAccessToken()).resolves.toBe('access-1');
   });
 
+  it('reports API-key providers as authed even without an OAuth token', async () => {
+    const storage = new MemoryTokenStorage();
+    const config: ManagedKimiConfigShape = {
+      providers: {
+        'moonshot-cn': { type: 'kimi', baseUrl: 'https://api.moonshot.cn/v1', apiKey: 'sk-test' },
+      },
+    };
+    const toolkit = new KimiOAuthToolkit({
+      homeDir: join('/tmp', 'kimi-oauth-toolkit-test'),
+      identity: TEST_IDENTITY,
+      storage,
+      now: () => 100,
+      configAdapter: {
+        read: () => config,
+        write: vi.fn(),
+        apply: () => ({ defaultModel: 'moonshot-cn/kimi-for-coding', defaultThinking: true }),
+      },
+    });
+
+    const status = await toolkit.status();
+    // The managed OAuth slot has no token file, but the API-key provider must
+    // still surface as authed so the ACP session gate does not reject it.
+    expect(status.providers).toContainEqual({ providerName: 'moonshot-cn', hasToken: true });
+    expect(status.providers.some((entry) =>  entry.hasToken)).toBe(true);
+  });
+
+  it('does not report API-key providers when the key is empty', async () => {
+    const storage = new MemoryTokenStorage();
+    const config: ManagedKimiConfigShape = {
+      providers: {
+        // Managed OAuth provisioning writes an empty `apiKey`; it must not
+        // count as an API-key provider.
+        [KIMI_CODE_PROVIDER_NAME]: { type: 'kimi', apiKey: '' },
+      },
+    };
+    const toolkit = new KimiOAuthToolkit({
+      homeDir: join('/tmp', 'kimi-oauth-toolkit-test'),
+      identity: TEST_IDENTITY,
+      storage,
+      now: () => 100,
+      configAdapter: {
+        read: () => config,
+        write: vi.fn(),
+        apply: () => ({ defaultModel: 'kimi-code/kimi-for-coding', defaultThinking: true }),
+      },
+    });
+
+    const status = await toolkit.status();
+    expect(status.providers).toEqual([
+      { providerName: KIMI_CODE_PROVIDER_NAME, hasToken: false },
+    ]);
+    expect(status.providers.some((entry) => entry.hasToken)).toBe(false);
+  });
+
   it('resolves bearer token providers using the configured oauth key', async () => {
     const storage = new MemoryTokenStorage();
     storage.tokens.set('custom-kimi-code', token('custom-access'));
@@ -494,7 +548,7 @@ describe('KimiOAuthToolkit', () => {
       key: devOauthKey,
       oauthHost: devOauthHost,
     });
-    const modelRequest = fetchMock.mock.calls[0]?.[1] as RequestInit | undefined;
+    const modelRequest = fetchMock.mock.calls[0]?.[1];
     expect(new Headers(modelRequest?.headers).get('authorization')).toBe('Bearer dev-access');
     expect(write).toHaveBeenCalledWith(config);
   });

--- a/packages/oauth/test/toolkit.test.ts
+++ b/packages/oauth/test/toolkit.test.ts
@@ -167,6 +167,24 @@ describe('KimiOAuthToolkit', () => {
     expect(status.providers.some((entry) => entry.hasToken)).toBe(false);
   });
 
+  it('merges the API-key status into the primary entry when the requested provider is an API-key provider', async () => {
+    const storage = new MemoryTokenStorage();
+    const toolkit = new KimiOAuthToolkit({
+      homeDir: join('/tmp', 'kimi-oauth-toolkit-test'),
+      identity: TEST_IDENTITY,
+      storage,
+      now: () => 100,
+    });
+
+    // `moonshot-cn` has no OAuth token file, so the OAuth probe alone would
+    // report hasToken:false. Because it is listed as an API-key provider, the
+    // primary entry must reflect hasToken:true with no duplicate appended.
+    const status = await toolkit.status('moonshot-cn', undefined, {
+      apiKeyProviders: ['moonshot-cn'],
+    });
+    expect(status.providers).toEqual([{ providerName: 'moonshot-cn', hasToken: true }]);
+  });
+
   it('resolves bearer token providers using the configured oauth key', async () => {
     const storage = new MemoryTokenStorage();
     storage.tokens.set('custom-kimi-code', token('custom-access'));

--- a/packages/oauth/test/toolkit.test.ts
+++ b/packages/oauth/test/toolkit.test.ts
@@ -133,51 +133,31 @@ describe('KimiOAuthToolkit', () => {
     await expect(toolkit.tokenProvider().getAccessToken()).resolves.toBe('access-1');
   });
 
-  it('reports API-key providers as authed even without an OAuth token', async () => {
+  it('surfaces API-key providers as authed when passed via apiKeyProviders', async () => {
     const storage = new MemoryTokenStorage();
-    const config: ManagedKimiConfigShape = {
-      providers: {
-        'moonshot-cn': { type: 'kimi', baseUrl: 'https://api.moonshot.cn/v1', apiKey: 'sk-test' },
-      },
-    };
     const toolkit = new KimiOAuthToolkit({
       homeDir: join('/tmp', 'kimi-oauth-toolkit-test'),
       identity: TEST_IDENTITY,
       storage,
       now: () => 100,
-      configAdapter: {
-        read: () => config,
-        write: vi.fn(),
-        apply: () => ({ defaultModel: 'moonshot-cn/kimi-for-coding', defaultThinking: true }),
-      },
     });
 
-    const status = await toolkit.status();
     // The managed OAuth slot has no token file, but the API-key provider must
     // still surface as authed so the ACP session gate does not reject it.
+    const status = await toolkit.status(undefined, undefined, {
+      apiKeyProviders: ['moonshot-cn'],
+    });
     expect(status.providers).toContainEqual({ providerName: 'moonshot-cn', hasToken: true });
-    expect(status.providers.some((entry) =>  entry.hasToken)).toBe(true);
+    expect(status.providers.some((entry) => entry.hasToken)).toBe(true);
   });
 
-  it('does not report API-key providers when the key is empty', async () => {
+  it('returns only the OAuth slot when no API-key providers are passed', async () => {
     const storage = new MemoryTokenStorage();
-    const config: ManagedKimiConfigShape = {
-      providers: {
-        // Managed OAuth provisioning writes an empty `apiKey`; it must not
-        // count as an API-key provider.
-        [KIMI_CODE_PROVIDER_NAME]: { type: 'kimi', apiKey: '' },
-      },
-    };
     const toolkit = new KimiOAuthToolkit({
       homeDir: join('/tmp', 'kimi-oauth-toolkit-test'),
       identity: TEST_IDENTITY,
       storage,
       now: () => 100,
-      configAdapter: {
-        read: () => config,
-        write: vi.fn(),
-        apply: () => ({ defaultModel: 'kimi-code/kimi-for-coding', defaultThinking: true }),
-      },
     });
 
     const status = await toolkit.status();


### PR DESCRIPTION
## Related Issue

Resolve #1330

## Problem

API-key-only users cannot use ACP mode. When a user authenticates with an API key (open-platform path), `session/new` (and `session/load` / `session/resume`) always returns `auth_required` (`-32000`), even though the API key is valid and works in the TUI. `initialize` still succeeds (it carries no credentials), so ACP clients see init OK followed by an auth failure. This reproduces against any ACP-compliant client (Zed, JetBrains, Paseo, raw JSON-RPC).

Root cause: API-key login (`applyOpenPlatformConfig`) writes `apiKey` into the config file under a platform-specific provider key (e.g. `moonshot-cn`), but writes **no** OAuth token to the credentials file. The ACP session gate `harnessIsAuthed()` checks `harness.auth.status().providers.some(e => e.hasToken)`, but `status()` / `hasToken()` only inspect the OAuth token file (`~/.kimi-code/credentials/kimi-code.json`). So for API-key users `hasToken` is always `false` and the gate rejects every session.

## What changed

`KimiOAuthToolkit.status()` now also enumerates providers from the config (via the existing `configAdapter`) and surfaces any provider with a non-empty `apiKey` as `hasToken: true`. The gate already treats any provider with `hasToken` as authed, so API-key users now pass.

This is a small, contained fix:
- `packages/oauth/src/toolkit.ts` — `status()` scans `config.providers` for non-empty `apiKey` entries and appends them to the returned `providers[]`. The OAuth slot check is unchanged; API-key entries are additive.
- `packages/oauth/test/toolkit.test.ts` — two cases added to the existing file: (1) an API-key provider is reported as `hasToken: true` with no OAuth token present; (2) an empty `apiKey` (what the managed OAuth path writes) is **not** treated as an API-key provider.

Why this approach fits: the toolkit already holds `configAdapter` and `resolveManagedAuth()` already reads `config.providers`, so no new plumbing is needed — `status()` just reuses the existing config access. A non-empty-string check correctly excludes the managed OAuth slot, which `applyManagedKimiCodeConfig` provisions with `apiKey: ""`.

Note: a stale/invalid API key will pass the gate and the real failure surfaces at LLM call time — but this matches the existing OAuth behavior (an expired token also passes the gate and fails on use), so it is not a new failure mode.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.