### PR TITLE
fix: run package-manager upgrades through a shell on Windows

### DIFF
--- a/.changeset/fix-windows-upgrade-spawn.md
+++ b/.changeset/fix-windows-upgrade-spawn.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Fix `kimi upgrade` failing on Windows with a spawn error when installing the new version.

--- a/apps/kimi-code/src/cli/update/preflight.ts
+++ b/apps/kimi-code/src/cli/update/preflight.ts
@@ -488,7 +488,14 @@ export async function installUpdate(
 ): Promise<void> {
   const { cmd, args } = spawnForSource(source, version, platform);
   await new Promise<void>((resolve, reject) => {
-    const child = spawn(cmd, [...args], { stdio: 'inherit' });
+    // Windows package managers (npm/pnpm/yarn) are .cmd shims. Since the
+    // CVE-2024-27980 fix, Node throws EINVAL when spawning a .cmd/.bat without
+    // a shell, so run through the shell on win32. The version is a validated
+    // semver and the package name is a constant, so args are shell-safe.
+    const child = spawn(cmd, [...args], {
+      stdio: 'inherit',
+      shell: platform === 'win32' ? true : undefined,
+    });
     child.once('error', reject);
     child.once('exit', (code, signal) => {
       if (code === 0) {
@@ -596,7 +603,11 @@ async function startBackgroundInstall(
       });
     };
 
-    const child = spawn(cmd, [...args], { detached: true, stdio: 'ignore' });
+    const child = spawn(cmd, [...args], {
+      detached: true,
+      stdio: 'ignore',
+      shell: platform === 'win32' ? true : undefined,
+    });
     child.once('error', () => { finish(false); });
     child.once('exit', (code) => { finish(code === 0); });
     child.unref();

--- a/apps/kimi-code/test/cli/update/preflight.test.ts
+++ b/apps/kimi-code/test/cli/update/preflight.test.ts
@@ -419,6 +419,28 @@ describe('runUpdatePreflight', () => {
     );
   });
 
+  it('pnpm-global on win32: spawns pnpm.cmd through a shell', async () => {
+    disableAutoInstall();
+    mocks.readUpdateCache.mockResolvedValue(cacheWith('0.5.0'));
+    mocks.refreshUpdateCache.mockResolvedValue(cacheWith('0.5.0'));
+    mocks.detectInstallSource.mockResolvedValue('pnpm-global');
+    mocks.promptForInstallChoice.mockResolvedValue('install');
+    mockSpawnExit(0);
+    const originalPlatform = process.platform;
+    Object.defineProperty(process, 'platform', { value: 'win32' });
+    try {
+      const { options } = captureOutput();
+      await runUpdatePreflight('0.4.0', options);
+      expect(mocks.spawn).toHaveBeenCalledWith(
+        'pnpm.cmd',
+        ['add', '-g', '@moonshot-ai/kimi-code@0.5.0'],
+        { stdio: 'inherit', shell: true },
+      );
+    } finally {
+      Object.defineProperty(process, 'platform', { value: originalPlatform });
+    }
+  });
+
   it('yarn-global: spawns yarn global add', async () => {
     disableAutoInstall();
     mocks.readUpdateCache.mockResolvedValue(cacheWith('0.5.0'));


### PR DESCRIPTION
## Related Issue

No related issue — clear, reproducible bug fix with a focused diff.

## Problem

On Windows, both `kimi upgrade` and the background auto-update fail with:

```text
warning: failed to install @moonshot-ai/kimi-code@<version>: spawn EINVAL
```

npm/pnpm/yarn are installed as `.cmd` shims on Windows. Since Node's CVE-2024-27980 fix, `child_process.spawn` refuses to execute a `.cmd`/`.bat` file unless it is launched through a shell, so the install never starts and users have to copy the printed command and run it manually.

## What changed

Pass `shell: true` when spawning the upgrade command on `win32`, in both the foreground `kimi upgrade` path and the background auto-install path. The version is a validated semver and the package name is a constant, so the arguments are shell-safe. Other platforms are unaffected (`shell` stays `undefined`).

Added a win32 test that drives the `process.platform = 'win32'` path on the existing macOS/Linux CI (the dedicated Windows CI job is currently disabled), plus a changeset.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.
