### PR TITLE
fix: hide the background updater console window on Windows

### DIFF
--- a/.changeset/fix-windows-update-console-flash.md
+++ b/.changeset/fix-windows-update-console-flash.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Keep automatic background updates from flashing a console window on Windows.

--- a/apps/kimi-code/src/cli/update/preflight.ts
+++ b/apps/kimi-code/src/cli/update/preflight.ts
@@ -607,6 +607,10 @@ async function startBackgroundInstall(
       detached: true,
       stdio: 'ignore',
       shell: platform === 'win32' ? true : undefined,
+      // On Windows a detached child gets its own console window; with shell:true
+      // that window would flash during a passive background update. Hide it so
+      // the silent updater stays silent.
+      windowsHide: platform === 'win32' ? true : undefined,
     });
     child.once('error', () => { finish(false); });
     child.once('exit', (code) => { finish(code === 0); });

--- a/apps/kimi-code/test/cli/update/preflight.test.ts
+++ b/apps/kimi-code/test/cli/update/preflight.test.ts
@@ -600,6 +600,27 @@ describe('runUpdatePreflight', () => {
     }));
   });
 
+  it('win32 background auto-update hides the console window', async () => {
+    mocks.readUpdateCache.mockResolvedValue(cacheWith('0.5.0'));
+    mocks.readUpdateInstallState.mockResolvedValue(installState());
+    mocks.refreshUpdateCache.mockResolvedValue(cacheWith('0.5.0'));
+    mocks.detectInstallSource.mockResolvedValue('npm-global');
+    mockSpawnExit(0);
+    const originalPlatform = process.platform;
+    Object.defineProperty(process, 'platform', { value: 'win32' });
+    try {
+      const { options } = captureOutput();
+      await expect(runUpdatePreflight('0.4.0', options)).resolves.toBe('continue');
+      expect(mocks.spawn).toHaveBeenCalledWith(
+        'npm.cmd',
+        ['install', '-g', '@moonshot-ai/kimi-code@0.5.0'],
+        { detached: true, stdio: 'ignore', shell: true, windowsHide: true },
+      );
+    } finally {
+      Object.defineProperty(process, 'platform', { value: originalPlatform });
+    }
+  });
+
   it('tracks and logs successful background update installs', async () => {
     mocks.readUpdateCache.mockResolvedValue(cacheWith('0.5.0'));
     mocks.readUpdateInstallState.mockResolvedValue(installState());


### PR DESCRIPTION
## Related Issue

Follow-up to #1332, addressing a review comment on the Windows upgrade fix.

## Problem

#1332 made the Windows upgrade/auto-update spawn the package-manager `.cmd` shim through a shell (`shell: true`) to avoid `spawn EINVAL`. The background auto-update path runs that shell with `detached: true` and the default `windowsHide: false`. On Windows a detached child gets its own console window, so a passive background update could flash a command window even though `stdio` is ignored — defeating the silent updater.

## What changed

Set `windowsHide: true` on `win32` for the detached background install spawn only, so the silent updater stays silent. The foreground `kimi upgrade` path is interactive (`stdio: inherit`, non-detached) and reuses the parent console, so it does not pop a window and is left unchanged. Added a win32 test covering the background spawn options, plus a changeset.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.
