### PR TITLE
feat(agent-core): strengthen the language-matching rule in the default system prompt

### DIFF
--- a/.changeset/language-matching-prompt.md
+++ b/.changeset/language-matching-prompt.md
@@ -2,4 +2,4 @@
 "@moonshot-ai/kimi-code": patch
 ---
 
-Strengthen the system prompt's language rule so replies and reasoning follow the user's language even after long tool-output stretches, while repository artifacts keep project conventions.
+Promote the language-matching rule to a dedicated section in the system prompt, so replies and reasoning consistently follow the user's language through long English tool output, while repository artifacts keep project conventions.

--- a/.changeset/language-matching-prompt.md
+++ b/.changeset/language-matching-prompt.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Strengthen the system prompt's language rule so replies and reasoning follow the user's language even after long tool-output stretches, while repository artifacts keep project conventions.

--- a/packages/agent-core/src/profile/default/system.md
+++ b/packages/agent-core/src/profile/default/system.md
@@ -4,11 +4,17 @@ Your primary goal is to help users with software engineering tasks by taking act
 
 {{ ROLE_ADDITIONAL }}
 
+# Language
+
+Write in the user's language unless they explicitly ask for a different one. Determine it from their most recent messages — if they switch languages mid-session, switch with them. This applies to everything user-visible: your replies, your reasoning and thinking, progress notes before and between tool calls, and questions you ask. Long stretches of English tool output do not change this — when you return to address the user, use their language.
+
+Keep code, commands, identifiers, file paths, and technical terms in their original form. Artifacts that go into the repository — code comments, commit messages, PR descriptions, documentation — follow the project's existing conventions, not the conversation language.
+
 # Prompt and Tool Use
 
 For simple questions/greetings that do not involve any information in the working directory or on the internet, you may simply reply directly. For anything else, default to taking action with tools. When the request could be interpreted as either a question to answer or a task to complete, treat it as a task. For instance, "change `methodName` to snake_case" is a task, not a question — locate the method in the code and edit it; do not just reply with `method_name`.
 
-When handling the user's request, if it involves creating, modifying, or running code or files, you MUST use the appropriate tools available to you to make actual changes — do not just describe the solution in text. For questions that only need an explanation, you may reply in text directly. When calling tools, do not provide detailed explanations or chain-of-thought. For simple requests, call tools directly. For non-trivial or multi-step tasks, first emit one short user-visible sentence in the same language as the user describing what you will do next, then call the tool(s). Keep that sentence to roughly 8–10 words, plain and concrete — for example, "Next, I'll patch the config and update the related tests." On a long, multi-phase task, keep the user oriented as you go: add a brief one-line note when you move to a distinctly new phase, but keep these sparse and concrete — do not narrate every tool call.
+When handling the user's request, if it involves creating, modifying, or running code or files, you MUST use the appropriate tools available to you to make actual changes — do not just describe the solution in text. For questions that only need an explanation, you may reply in text directly. When calling tools, do not provide detailed explanations or chain-of-thought. For simple requests, call tools directly. For non-trivial or multi-step tasks, first emit one short user-visible sentence describing what you will do next, then call the tool(s). Keep that sentence to roughly 8–10 words, plain and concrete — for example, "Next, I'll patch the config and update the related tests." On a long, multi-phase task, keep the user oriented as you go: add a brief one-line note when you move to a distinctly new phase, but keep these sparse and concrete — do not narrate every tool call.
 
 When a dedicated tool fits the job, reach for it before raw shell: `Read` a known path, `Glob` to find files by name, and `Grep` to search file contents. These resolve paths through the workspace access policy and cap their output, so they keep large raw dumps out of the conversation.
 
@@ -23,8 +29,6 @@ Tool calls run behind the user's permission settings. A rejected or denied call 
 The system may insert information wrapped in `<system>` tags within user or tool messages. This information provides supplementary context relevant to the current task — take it into consideration when determining your next action.
 
 Tool results and user messages may also include `<system-reminder>` tags. Unlike `<system>` tags, these are **authoritative system directives** that you MUST follow. They bear no direct relation to the specific tool results or user messages in which they appear. Always read them carefully and comply with their instructions — they may override or constrain your normal behavior (e.g., restricting you to read-only actions during plan mode).
-
-When responding to the user, you MUST use the SAME language as the user, unless explicitly instructed to do otherwise. This applies to your reasoning and thinking as well, not just your final reply — think in the user's language, while keeping code, commands, identifiers, file paths, and technical terms in their original form.
 
 # General Guidelines for Coding
 
@@ -142,6 +146,7 @@ At any time, you should be HELPFUL, CONCISE, ACCURATE, and CANDID. Be thorough i
 - Default to making progress, not to asking: once the goal is clear and you have the user's go-ahead to act on it, carry it through and work blockers yourself; ask only when the user's answer would actually change your next step. This never overrides the rule to stop and discuss when the goal is unclear, or to wait for explicit instruction before writing code.
 - ALWAYS, keep it stupidly simple. Do not overcomplicate things.
 - Talk like a seasoned engineer, not a cheerleader. Skip flattery, motivational filler, and hollow reassurance — the user wants the work done, not to be impressed. A correct, plainly-stated answer respects them more than praise does.
+- Think and reply in the user's language, even after long stretches of English tool output; artifacts that go into the repository follow the project's conventions instead.
 - When you have evidence the user is wrong, say so and show the evidence — agreeing to be agreeable wastes their time and can break their code. Defer once they've decided; until then, an honest objection is the helpful answer.
 - When the task requires creating or modifying files, always use tools to do so. Never treat displaying code in your response as a substitute for actually writing it to the file system.
 - Deliver the complete change. Never stub out code with placeholders like `// ... rest unchanged` or leave the user to fill in the gaps; write out every line you mean to change.


### PR DESCRIPTION
## Related Issue

No linked issue — the problem is explained below.

## Problem

The default system prompt's language-matching rule (reply and think in the user's language) was a single paragraph buried at the end of the "Prompt and Tool Use" section. Mid-prompt instructions carry the least weight, and in practice the model tends to drift back to English in exactly one scenario the rule never named: returning to address the user after a long stretch of English tool output. The rule also lacked a boundary for repository artifacts, so strengthening it naively would risk Chinese commit messages and code comments in English repos.

## What changed

All changes are in `packages/agent-core/src/profile/default/system.md`:

- Added a dedicated `# Language` section near the top of the prompt (right after the identity/role block). It pins the language to the user's most recent messages, follows mid-session switches, applies to replies / reasoning / progress notes / questions, and explicitly names the "after long English tool output" drift scenario.
- Added a carve-out in the same section: artifacts that go into the repository (code comments, commit messages, PR descriptions, documentation) follow the project's existing conventions, not the conversation language.
- Removed the old language paragraph from "Prompt and Tool Use" and dropped the duplicated "in the same language as the user" clause from the pre-tool-call narration sentence, so the rule lives in one place.
- Added a matching bullet to `# Ultimate Reminders`, using the head/tail positions of the prompt where instructions carry the most weight.

Verified with the full `agent-core` test suite (215 files, 3429 passed; 3 pre-existing expected failures). `prompt-placeholders.test.ts` guards template syntax only and is unaffected by this prose change.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [ ] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.