### PR TITLE
feat(web): enlarge user message images on click

### DIFF
--- a/.changeset/web-user-image-preview.md
+++ b/.changeset/web-user-image-preview.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": minor
+---
+
+Click an image in a user message to open its full-size preview in the web chat.

--- a/apps/kimi-web/src/components/chat/ChatPane.vue
+++ b/apps/kimi-web/src/components/chat/ChatPane.vue
@@ -8,6 +8,7 @@ import ToolGroup from './ToolGroup.vue';
 import Markdown from './Markdown.vue';
 import ThinkingBlock from './ThinkingBlock.vue';
 import ActivityNotice from './ActivityNotice.vue';
+import AuthMedia from './AuthMedia.vue';
 import MoonSpinner from '../ui/MoonSpinner.vue';
 import Spinner from '../ui/Spinner.vue';
 import Icon from '../ui/Icon.vue';
@@ -487,6 +488,12 @@ function copyUserMessage(turn: ChatTurn): void {
   }).catch(() => {/* ignore */});
 }
 
+function userImageMedia(img: { url: string; alt?: string }): ToolMedia {
+  // User-uploaded images carry no path/mime metadata; the preview panel falls
+  // back to a generic label and sniffs the mime from the URL when needed.
+  return { kind: 'image', url: img.url, path: img.alt };
+}
+
 function isStreamingRenderBlock(turn: ChatTurn, block: { sourceIndex: number }): boolean {
   if (turn.id !== streamingTurnId.value) return false;
   return block.sourceIndex === turnBlocks(turn).length - 1;
@@ -537,21 +544,28 @@ function isStreamingRenderBlock(turn: ChatTurn, block: { sourceIndex: number }):
             <!-- Image / video attachments -->
             <div v-if="turn.images && turn.images.length > 0" class="u-imgs">
               <template v-for="(img, ii) in turn.images" :key="ii">
-                <video
+                <AuthMedia
                   v-if="img.kind === 'video'"
-                  class="u-img"
-                  :src="img.url"
-                  controls
-                  playsinline
-                  preload="metadata"
+                  :url="img.url"
+                  kind="video"
+                  :file-id="img.fileId"
+                  media-class="u-img"
                 />
-                <img
+                <button
                   v-else
-                  class="u-img"
-                  :src="img.url"
-                  :alt="img.alt || ''"
-                  loading="lazy"
-                />
+                  type="button"
+                  class="u-img-btn"
+                  :aria-label="t('filePreview.enlargeImage')"
+                  @click="emit('openMedia', userImageMedia(img))"
+                >
+                  <AuthMedia
+                    :url="img.url"
+                    kind="image"
+                    :alt="img.alt"
+                    :file-id="img.fileId"
+                    media-class="u-img"
+                  />
+                </button>
               </template>
             </div>
             <!-- Skill activation card (replaces raw XML) -->
@@ -716,10 +730,16 @@ function isStreamingRenderBlock(turn: ChatTurn, block: { sourceIndex: number }):
             </span>
           </button>
           <div v-if="hasImages(item)" class="q-imgs">
-            <template v-for="(att, ai) in item.attachments" :key="ai">
-              <video v-if="att.kind === 'video'" class="q-img" :src="att.url" muted playsinline preload="metadata" />
-              <img v-else class="q-img" :src="att.url" alt="" loading="lazy" />
-            </template>
+            <AuthMedia
+              v-for="(att, ai) in item.attachments"
+              :key="ai"
+              :url="att.url"
+              :kind="att.kind"
+              :file-id="att.fileId"
+              media-class="q-img"
+              :controls="false"
+              muted
+            />
           </div>
           <span v-if="qi === 0" class="q-tag q-tag-next">{{ t('composer.queueNext') }}</span>
           <span v-else class="q-tag q-tag-idx">#{{ qi + 1 }}</span>
@@ -1077,6 +1097,27 @@ function isStreamingRenderBlock(turn: ChatTurn, block: { sourceIndex: number }):
   max-height: 200px;
   border-radius: 8px;
   object-fit: cover;
+}
+/* Clickable image thumbnail — reset button chrome so it looks like the plain
+   image it replaced, while still opening the preview on click. */
+.u-img-btn {
+  display: block;
+  flex: none;
+  align-self: flex-start;
+  max-width: 100%;
+  padding: 0;
+  border: none;
+  background: transparent;
+  cursor: pointer;
+  border-radius: 8px;
+  overflow: hidden;
+}
+.u-img-btn .u-img {
+  display: block;
+}
+.u-img-btn:focus-visible {
+  outline: none;
+  box-shadow: var(--p-focus-ring);
 }
 
 /* NOTE: Chat/bubble styles live in src/style.css (global). Scoped `.u-bub`

--- a/apps/kimi-web/src/i18n/locales/en/filePreview.ts
+++ b/apps/kimi-web/src/i18n/locales/en/filePreview.ts
@@ -24,6 +24,7 @@ export default {
   binaryNoPreview: 'Binary file · {mime} · {size} bytes · preview unavailable',
   unknownType: 'unknown type',
   copyCode: 'Copy code',
+  enlargeImage: 'Enlarge image',
   errors: {
     emptyPath: 'File path is empty',
     unsupportedPath: 'URLs and remote paths cannot be previewed',

--- a/apps/kimi-web/src/i18n/locales/zh/filePreview.ts
+++ b/apps/kimi-web/src/i18n/locales/zh/filePreview.ts
@@ -24,6 +24,7 @@ export default {
   binaryNoPreview: '二进制文件 · {mime} · {size} 字节 · 暂不预览',
   unknownType: '未知类型',
   copyCode: '复制代码',
+  enlargeImage: '放大图片',
   errors: {
     emptyPath: '文件路径为空',
     unsupportedPath: '不支持预览 URL 或远程路径',


### PR DESCRIPTION
## Related Issue

No linked issue — small UX gap noticed while using the web chat.

## Problem

Images attached to a user message render as small thumbnails in the bubble, but there was no way to view them at full size. Tool-result images (for example from `ReadMediaFile`) already open the preview panel on click; images the user uploaded did not.

## What changed

- Wrapped the user-message image thumbnail in a button that emits the existing `openMedia` flow, reusing the same preview panel as tool-result images instead of adding a new lightbox.
- Reset the button's default chrome so the thumbnail looks identical to before, and added a focus ring plus an `aria-label` (en/zh) for accessibility.
- Video attachments keep their native `<video controls>` (already has fullscreen), so they are left untouched.

This is a UI-only change in `kimi-web`, which has no component-test infra, so it is covered by the existing preview flow and manual visual verification rather than a new unit test.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [ ] I have added tests that prove my feature works. (UI-only change; `kimi-web` has no component tests — verified manually.)
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.
