### PR TITLE
feat(web): support multi-level thinking effort selection

### DIFF
--- a/.changeset/web-thinking-effort-levels.md
+++ b/.changeset/web-thinking-effort-levels.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": minor
+---
+
+Add a segmented thinking-level control in the web model picker for models that support multiple reasoning efforts. Open the composer model menu to choose a level.

--- a/apps/kimi-web/src/App.vue
+++ b/apps/kimi-web/src/App.vue
@@ -37,7 +37,7 @@ import { openDialogCount } from './composables/dialogStack';
 import ServerAuthDialog from './components/ServerAuthDialog.vue';
 import { initServerAuth, onAuthRequired } from './api/daemon/serverAuth';
 import type { AppConfig, ThinkingLevel } from './api/types';
-import { commitLevel, segmentsFor } from './lib/modelThinking';
+import { coerceThinkingForModel, commitLevel, segmentsFor } from './lib/modelThinking';
 import Button from './components/ui/Button.vue';
 import IconButton from './components/ui/IconButton.vue';
 import Icon from './components/ui/Icon.vue';
@@ -97,7 +97,11 @@ function nextThinkingLevel(current: ThinkingLevel): ThinkingLevel {
     (m) => m.id === raw || m.model === raw || m.displayName === client.status.value.model,
   );
   const segs = segmentsFor(model);
-  const idx = segs.indexOf(current);
+  // Coerce the stored level against the active model before indexing, so a
+  // stale value (e.g. 'on' from a boolean model) doesn't resolve to index -1
+  // and jump to 'off' instead of advancing from the model's default effort.
+  const coerced = coerceThinkingForModel(model, current);
+  const idx = segs.indexOf(coerced);
   const next = segs[(idx + 1) % segs.length] ?? segs[0] ?? 'off';
   return commitLevel(model, next);
 }

--- a/apps/kimi-web/src/App.vue
+++ b/apps/kimi-web/src/App.vue
@@ -37,6 +37,7 @@ import { openDialogCount } from './composables/dialogStack';
 import ServerAuthDialog from './components/ServerAuthDialog.vue';
 import { initServerAuth, onAuthRequired } from './api/daemon/serverAuth';
 import type { AppConfig, ThinkingLevel } from './api/types';
+import { commitLevel, segmentsFor } from './lib/modelThinking';
 import Button from './components/ui/Button.vue';
 import IconButton from './components/ui/IconButton.vue';
 import Icon from './components/ui/Icon.vue';
@@ -87,10 +88,18 @@ const { showAuthGate, blinkAuthLogo } = useAuthGate({ client, authLogoRef });
 // spinner while the agent is running so activity is visible at a glance.
 usePageTitle({ running, showAuthGate });
 
-// Thinking is on/off (TUI parity — no effort-level cycling). The /thinking
-// command flips between off and the backend default effort ('high').
+// The /thinking slash command has no popover anchor, so it steps to the next
+// segment for the active model (effort models cycle through their declared
+// levels; boolean models flip on/off; unsupported stays off).
 function nextThinkingLevel(current: ThinkingLevel): ThinkingLevel {
-  return current === 'off' ? 'high' : 'off';
+  const raw = client.status.value.modelId ?? client.status.value.model ?? '';
+  const model = client.models.value.find(
+    (m) => m.id === raw || m.model === raw || m.displayName === client.status.value.model,
+  );
+  const segs = segmentsFor(model);
+  const idx = segs.indexOf(current);
+  const next = segs[(idx + 1) % segs.length] ?? segs[0] ?? 'off';
+  return commitLevel(model, next);
 }
 
 // First-run onboarding (language + welcome greeting). Shown until the user
@@ -939,6 +948,7 @@ function openPr(url: string): void {
       v-model="showMobileSettings"
       :status="client.status.value"
       :thinking="client.thinking.value"
+      :models="client.models.value"
       :plan-mode="client.planMode.value"
       :swarm-mode="client.swarmMode.value"
       :color-scheme="client.colorScheme.value"

--- a/apps/kimi-web/src/api/daemon/mappers.ts
+++ b/apps/kimi-web/src/api/daemon/mappers.ts
@@ -716,6 +716,8 @@ export function toAppModel(wire: WireModel): AppModel {
     displayName: wire.display_name,
     maxContextSize: wire.max_context_size,
     capabilities: wire.capabilities,
+    supportEfforts: wire.support_efforts,
+    defaultEffort: wire.default_effort,
   };
 }
 

--- a/apps/kimi-web/src/api/daemon/wire.ts
+++ b/apps/kimi-web/src/api/daemon/wire.ts
@@ -343,6 +343,8 @@ export interface WireModel {
   display_name?: string;
   max_context_size: number;
   capabilities?: string[];
+  support_efforts?: string[];
+  default_effort?: string;
 }
 
 export interface WireProvider {

--- a/apps/kimi-web/src/api/types.ts
+++ b/apps/kimi-web/src/api/types.ts
@@ -193,7 +193,17 @@ export interface CompactionMarkerMetadata {
 // Prompt
 // ---------------------------------------------------------------------------
 
-export type ThinkingLevel = 'off' | 'low' | 'medium' | 'high' | 'xhigh' | 'max';
+/**
+ * Runtime thinking level. 'off' disables extended thinking; 'on' is the
+ * enable signal for legacy boolean models (those without `support_efforts`);
+ * any other string is a model-declared effort level (e.g. 'low'/'high'/'max').
+ *
+ * `support_efforts` is the single source of truth for which concrete levels a
+ * model accepts; providers silently drop unknown efforts rather than erroring.
+ * Collapses to `string` at runtime — this is a semantic marker, not a closed
+ * enum. Mirrors kosong's `ThinkingEffort`.
+ */
+export type ThinkingLevel = 'off' | 'on' | (string & {});
 
 export interface PromptSubmission {
   content: AppMessageContent[];
@@ -550,6 +560,11 @@ export interface AppModel {
   maxContextSize: number;
   /** Optional capability tags (e.g. ["vision", "thinking"]) */
   capabilities?: string[];
+  /** Effort levels this model supports for extended thinking (e.g. ["low", "high", "max"]).
+      Sourced from the model catalog (managed) or config [models.<id>.overrides]. */
+  supportEfforts?: readonly string[];
+  /** Catalog-declared default effort for extended thinking. */
+  defaultEffort?: string;
 }
 
 export interface AppProvider {

--- a/apps/kimi-web/src/components/chat/Composer.vue
+++ b/apps/kimi-web/src/components/chat/Composer.vue
@@ -9,6 +9,7 @@ import type { FileItem } from './MentionMenu.vue';
 import type { ActivationBadges, ConversationStatus, PermissionMode, QueuedPromptView } from '../../types';
 import type { AppModel, AppSkill, ThinkingLevel } from '../../api/types';
 import {
+  coerceThinkingForModel,
   commitLevel,
   effortLabel,
   isThinkingOn,
@@ -599,19 +600,27 @@ const currentModel = computed(() => {
 });
 const thinkingAvailability = computed(() => modelThinkingAvailability(currentModel.value));
 const thinkingSegments = computed(() => segmentsFor(currentModel.value));
+// The persisted level can be stale relative to the active model (e.g. a
+// boolean 'on'/'off' carried over when selecting another session). Coerce it
+// against the current model before deriving display state so an always-on
+// model never shows "thinking: off" and an effort model shows its concrete
+// level instead of the bare "thinking" tag.
+const coercedThinkingLevel = computed(() =>
+  coerceThinkingForModel(currentModel.value, props.thinking ?? 'off'),
+);
 // Runtime level clamped to the segments this model actually offers, so a
 // carried-over value never highlights a segment that doesn't exist here.
 const activeThinkingSegment = computed(() => {
   const segs = thinkingSegments.value;
-  const raw = props.thinking ?? 'off';
-  if (segs.includes(raw)) return raw;
+  const level = coercedThinkingLevel.value;
+  if (segs.includes(level)) return level;
   if (segs.includes('on')) return 'on';
   return segs[0] ?? 'off';
 });
 const thinkingOn = computed(() => {
   if (thinkingAvailability.value === 'always-on') return true;
   if (thinkingAvailability.value === 'unsupported') return false;
-  return isThinkingOn(props.thinking ?? 'off');
+  return isThinkingOn(coercedThinkingLevel.value);
 });
 // Single-segment (always-on boolean) or unsupported models can't be changed.
 const thinkingReadonly = computed(
@@ -622,7 +631,7 @@ const thinkingReadonly = computed(
 const thinkingSuffix = computed(() => {
   if (!thinkingOn.value) return '';
   const hasEfforts = (currentModel.value?.supportEfforts?.length ?? 0) > 0;
-  const level = props.thinking ?? 'off';
+  const level = coercedThinkingLevel.value;
   if (hasEfforts && level !== 'on') return t('composer.thinkingSuffixEffort', { level });
   return t('composer.thinkingSuffix');
 });

--- a/apps/kimi-web/src/components/chat/Composer.vue
+++ b/apps/kimi-web/src/components/chat/Composer.vue
@@ -8,7 +8,13 @@ import { buildSlashItems, parseSlash } from '../../lib/slashCommands';
 import type { FileItem } from './MentionMenu.vue';
 import type { ActivationBadges, ConversationStatus, PermissionMode, QueuedPromptView } from '../../types';
 import type { AppModel, AppSkill, ThinkingLevel } from '../../api/types';
-import { modelThinkingAvailability } from '../../lib/modelThinking';
+import {
+  commitLevel,
+  effortLabel,
+  isThinkingOn,
+  modelThinkingAvailability,
+  segmentsFor,
+} from '../../lib/modelThinking';
 import { useInputHistory } from '../../composables/useInputHistory';
 import { useSlashMenu } from '../../composables/useSlashMenu';
 import { useMentionMenu } from '../../composables/useMentionMenu';
@@ -592,15 +598,37 @@ const currentModel = computed(() => {
   );
 });
 const thinkingAvailability = computed(() => modelThinkingAvailability(currentModel.value));
-const thinkingToggleable = computed(() => thinkingAvailability.value === 'toggle');
+const thinkingSegments = computed(() => segmentsFor(currentModel.value));
+// Runtime level clamped to the segments this model actually offers, so a
+// carried-over value never highlights a segment that doesn't exist here.
+const activeThinkingSegment = computed(() => {
+  const segs = thinkingSegments.value;
+  const raw = props.thinking ?? 'off';
+  if (segs.includes(raw)) return raw;
+  if (segs.includes('on')) return 'on';
+  return segs[0] ?? 'off';
+});
 const thinkingOn = computed(() => {
   if (thinkingAvailability.value === 'always-on') return true;
   if (thinkingAvailability.value === 'unsupported') return false;
-  return (props.thinking ?? 'off') !== 'off';
+  return isThinkingOn(props.thinking ?? 'off');
 });
-function toggleThinking(): void {
-  if (!thinkingToggleable.value) return;
-  emit('setThinking', thinkingOn.value ? 'off' : 'high');
+// Single-segment (always-on boolean) or unsupported models can't be changed.
+const thinkingReadonly = computed(
+  () => thinkingAvailability.value === 'unsupported' || thinkingSegments.value.length <= 1,
+);
+// Footer-style suffix: effort models show the concrete level; boolean models
+// keep the plain "thinking" tag; off shows nothing.
+const thinkingSuffix = computed(() => {
+  if (!thinkingOn.value) return '';
+  const hasEfforts = (currentModel.value?.supportEfforts?.length ?? 0) > 0;
+  const level = props.thinking ?? 'off';
+  if (hasEfforts && level !== 'on') return t('composer.thinkingSuffixEffort', { level });
+  return t('composer.thinkingSuffix');
+});
+function setThinkingSegment(draft: string): void {
+  if (thinkingReadonly.value) return;
+  emit('setThinking', commitLevel(currentModel.value, draft));
 }
 
 // Plan toggle
@@ -928,7 +956,7 @@ function selectModel(modelId: string): void {
             @keydown.space.prevent="toggleDropdown"
           >
             <b>{{ status.model }}</b>
-            <span v-if="thinkingOn" class="think-suffix">{{ t('composer.thinkingSuffix') }}</span>
+            <span v-if="thinkingSuffix" class="think-suffix">{{ thinkingSuffix }}</span>
             <Icon class="cv" name="chevron-down" size="sm" />
           </span>
           <Tooltip v-if="running" :text="t('composer.interruptTitle')">
@@ -986,19 +1014,31 @@ function selectModel(modelId: string): void {
 
           <div v-if="providerModels.length > 0" class="md-divider" />
 
-          <!-- Thinking toggle -->
-          <button
-            class="md-row md-row-toggle"
-            role="menuitem"
-            :class="{ 'is-on': thinkingOn, 'is-disabled': !thinkingToggleable }"
-            :disabled="!thinkingToggleable"
-            @click="toggleThinking()"
-          >
-            <span class="md-check"><Icon v-if="thinkingOn" name="check" size="sm" /></span>
+          <!-- Thinking level — segmented control. Effort models show every
+               declared level; boolean models show On/Off; unsupported shows a note. -->
+          <div class="md-thinking" :class="{ 'is-readonly': thinkingReadonly }">
             <span class="md-name">{{ t('status.thinkingLabel') }}</span>
-            <span v-if="thinkingAvailability === 'always-on'" class="md-note">{{ t('status.planOn') }}</span>
-            <span v-else-if="thinkingAvailability === 'unsupported'" class="md-note">{{ t('status.modeNotSupported') }}</span>
-          </button>
+            <span
+              v-if="thinkingAvailability === 'unsupported'"
+              class="md-note"
+            >{{ t('status.modeNotSupported') }}</span>
+            <div
+              v-else
+              class="effort-segments"
+              role="group"
+              :aria-label="t('status.thinkingLabel')"
+            >
+              <button
+                v-for="seg in thinkingSegments"
+                :key="seg"
+                type="button"
+                class="effort-seg"
+                :class="{ 'is-active': seg === activeThinkingSegment }"
+                :disabled="thinkingReadonly"
+                @click="setThinkingSegment(seg)"
+              >{{ effortLabel(seg) }}</button>
+            </div>
+          </div>
 
           <div class="md-divider" />
 
@@ -1551,6 +1591,73 @@ function selectModel(modelId: string): void {
   margin: 3px 0;
 }
 
+/* Thinking level segmented control — sits inside the model dropdown. */
+.md-thinking {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 7px;
+  border-radius: var(--radius-sm);
+}
+.md-thinking .md-name {
+  font-family: var(--mono);
+  font-size: var(--ui-font-size);
+  color: var(--color-text);
+  flex: none;
+}
+.md-thinking .md-note {
+  margin-left: auto;
+}
+.effort-segments {
+  margin-left: auto;
+  display: inline-flex;
+  align-items: center;
+  gap: 1px;
+  padding: 2px;
+  background: var(--color-surface-sunken);
+  border: 1px solid var(--color-line);
+  border-radius: var(--radius-md);
+}
+.effort-seg {
+  appearance: none;
+  border: none;
+  background: none;
+  cursor: pointer;
+  font-family: var(--mono);
+  font-size: var(--ui-font-size-xs);
+  line-height: 1;
+  color: var(--color-text-muted);
+  padding: 4px 9px;
+  border-radius: var(--radius-sm);
+  white-space: nowrap;
+  transition: background 0.12s, color 0.12s, box-shadow 0.12s;
+}
+.effort-seg:hover:not(:disabled):not(.is-active) {
+  background: var(--color-surface-raised);
+  color: var(--color-text);
+}
+.effort-seg:focus-visible {
+  outline: 2px solid var(--color-accent);
+  outline-offset: -2px;
+}
+.effort-seg.is-active {
+  background: var(--color-accent);
+  color: var(--color-text-on-accent);
+  box-shadow: var(--shadow-xs);
+  font-weight: 500;
+}
+.effort-seg:disabled {
+  cursor: default;
+}
+.md-thinking.is-readonly .effort-segments {
+  opacity: 0.62;
+}
+.md-thinking.is-readonly .effort-seg.is-active {
+  background: var(--color-surface-raised);
+  color: var(--color-text-muted);
+  box-shadow: none;
+}
+
 /* Permission dropdown — anchored to the toolbar left side */
 .perm-dropdown {
   position: absolute;
@@ -1871,6 +1978,19 @@ function selectModel(modelId: string): void {
   }
   .md-section {
     font-size: var(--ui-font-size);
+  }
+  .md-thinking {
+    flex-wrap: wrap;
+    row-gap: 6px;
+  }
+  .md-thinking .effort-segments {
+    margin-left: 0;
+    width: 100%;
+    justify-content: space-between;
+  }
+  .md-thinking .effort-seg {
+    flex: 1;
+    padding: 5px 6px;
   }
   .pd-name {
     font-size: var(--ui-font-size);

--- a/apps/kimi-web/src/components/mobile/MobileSettingsSheet.vue
+++ b/apps/kimi-web/src/components/mobile/MobileSettingsSheet.vue
@@ -12,6 +12,7 @@ import type { ConversationStatus, PermissionMode } from '../../types';
 import type { AppModel, ThinkingLevel } from '../../api/types';
 import type { ColorScheme } from '../../composables/useKimiWebClient';
 import {
+  coerceThinkingForModel,
   commitLevel,
   effortLabel,
   modelThinkingAvailability,
@@ -76,11 +77,18 @@ const currentModel = computed<AppModel | undefined>(() => {
 });
 const thinkingAvailability = computed(() => modelThinkingAvailability(currentModel.value));
 const thinkingSegments = computed(() => segmentsFor(currentModel.value));
+// The persisted level can be stale relative to the active model (e.g. 'on'
+// from a boolean model, or 'off' while viewing an always-on effort model).
+// Coerce it before computing the active segment so the mobile sheet shows and
+// selects the same model-aware default the composer and prompt submission use.
+const coercedThinkingLevel = computed(() =>
+  coerceThinkingForModel(currentModel.value, props.thinking ?? 'off'),
+);
 // Runtime level clamped to the segments this model actually offers.
 const activeThinkingSegment = computed<string>(() => {
   const segs = thinkingSegments.value;
-  const raw = props.thinking ?? 'off';
-  if (segs.includes(raw)) return raw;
+  const level = coercedThinkingLevel.value;
+  if (segs.includes(level)) return level;
   if (segs.includes('on')) return 'on';
   return segs[0] ?? 'off';
 });

--- a/apps/kimi-web/src/components/mobile/MobileSettingsSheet.vue
+++ b/apps/kimi-web/src/components/mobile/MobileSettingsSheet.vue
@@ -9,8 +9,14 @@
 import { computed } from 'vue';
 import { useI18n } from 'vue-i18n';
 import type { ConversationStatus, PermissionMode } from '../../types';
-import type { ThinkingLevel } from '../../api/types';
+import type { AppModel, ThinkingLevel } from '../../api/types';
 import type { ColorScheme } from '../../composables/useKimiWebClient';
+import {
+  commitLevel,
+  effortLabel,
+  modelThinkingAvailability,
+  segmentsFor,
+} from '../../lib/modelThinking';
 import BottomSheet from '../dialogs/BottomSheet.vue';
 import LanguageSwitcher from '../settings/LanguageSwitcher.vue';
 import SegmentedControl from '../ui/SegmentedControl.vue';
@@ -30,8 +36,16 @@ const props = withDefaults(
     conversationToc?: boolean;
     /** Server version from GET /api/v1/meta, shown as a read-only row. */
     serverVersion?: string;
+    /** Available models — used to derive the current model's thinking segments. */
+    models?: AppModel[];
   }>(),
-  { colorScheme: 'system', uiFontSize: 14, authReady: false, serverVersion: '' },
+  {
+    colorScheme: 'system',
+    uiFontSize: 14,
+    authReady: false,
+    serverVersion: '',
+    models: () => [],
+  },
 );
 
 const emit = defineEmits<{
@@ -54,7 +68,25 @@ function onColorScheme(v: string): void {
 
 const PERM_MODES: PermissionMode[] = ['manual', 'auto', 'yolo'];
 
-const thinkingLevel = computed<ThinkingLevel>(() => props.thinking ?? 'high');
+const currentModel = computed<AppModel | undefined>(() => {
+  const raw = props.status?.modelId ?? props.status?.model ?? '';
+  return props.models?.find(
+    (m) => m.id === raw || m.model === raw || m.displayName === props.status?.model,
+  );
+});
+const thinkingAvailability = computed(() => modelThinkingAvailability(currentModel.value));
+const thinkingSegments = computed(() => segmentsFor(currentModel.value));
+// Runtime level clamped to the segments this model actually offers.
+const activeThinkingSegment = computed<string>(() => {
+  const segs = thinkingSegments.value;
+  const raw = props.thinking ?? 'off';
+  if (segs.includes(raw)) return raw;
+  if (segs.includes('on')) return 'on';
+  return segs[0] ?? 'off';
+});
+const thinkingOptions = computed(() =>
+  thinkingSegments.value.map((seg) => ({ value: seg, label: effortLabel(seg) })),
+);
 const planOn = computed<boolean>(() => props.planMode === true);
 const swarmOn = computed<boolean>(() => props.swarmMode === true);
 
@@ -82,9 +114,8 @@ const ctxValue = computed<string>(() =>
   props.status.ctxMax > 0 ? `${kFmt(props.status.ctxUsed)}/${kFmt(props.status.ctxMax)}` : t('status.statusNone'),
 );
 
-function cycleThinking(): void {
-  // On/off toggle (TUI parity). 'high' = the backend default effort.
-  emit('setThinking', thinkingLevel.value === 'off' ? 'high' : 'off');
+function setThinkingSegment(value: string): void {
+  emit('setThinking', commitLevel(currentModel.value, value));
 }
 
 function cyclePermission(): void {
@@ -126,14 +157,28 @@ function onLogout(): void {
       <span class="chev">›</span>
     </button>
 
-    <!-- Thinking level → inline cycle (value + chevron) -->
-    <button type="button" class="srow" @click="cycleThinking">
+    <!-- Thinking level → segmented control (or read-only value when single/unsupported) -->
+    <div class="srow read-only">
       <span class="srow-main">
         <span class="srow-label">{{ t('status.statusThinking') }}</span>
+        <span
+          v-if="thinkingAvailability === 'unsupported'"
+          class="srow-sub"
+        >{{ t('status.modeNotSupported') }}</span>
       </span>
-      <span class="srow-val">{{ thinkingLevel === 'off' ? t('status.planOff') : t('status.planOn') }}</span>
-      <span class="chev">›</span>
-    </button>
+      <SegmentedControl
+        v-if="thinkingSegments.length > 1"
+        :model-value="activeThinkingSegment"
+        :options="thinkingOptions"
+        size="sm"
+        @update:model-value="setThinkingSegment"
+      />
+      <span
+        v-else
+        class="srow-val"
+        :class="{ dim: activeThinkingSegment === 'off' }"
+      >{{ activeThinkingSegment === 'off' ? t('status.planOff') : effortLabel(activeThinkingSegment) }}</span>
+    </div>
 
     <!-- Plan mode → real toggle switch -->
     <button type="button" class="srow" @click="emit('togglePlan')">

--- a/apps/kimi-web/src/composables/client/useWorkspaceState.ts
+++ b/apps/kimi-web/src/composables/client/useWorkspaceState.ts
@@ -30,6 +30,7 @@ import {
   STORAGE_KEYS,
 } from '../../lib/storage';
 import { parseDiff } from '../../lib/parseDiff';
+import { coerceThinkingForModel } from '../../lib/modelThinking';
 import { readSessionIdFromLocation, sessionUrl } from '../../lib/sessionRoute';
 import type { SessionUrlMode } from '../../lib/sessionRoute';
 import type {
@@ -990,6 +991,22 @@ export function useWorkspaceState(rawState: ExtendedState, deps: UseWorkspaceSta
     }
   }
 
+  // Coerce the persisted thinking level against the prompt's target model before
+  // submitting, so a stale value carried over from another session (e.g. 'max'
+  // from an effort model) isn't sent to a model that doesn't declare it. The
+  // composer already renders the coerced value; this keeps the submitted level
+  // in sync with what's displayed. Falls back to the raw level when the model
+  // catalog hasn't loaded yet (coerceThinkingForModel preserves it).
+  function coercePromptThinking(model: string | undefined) {
+    const promptModel =
+      model === undefined
+        ? undefined
+        : modelProvider.models.value.find(
+            (m) => m.model === model || m.id === model || m.displayName === model,
+          );
+    return coerceThinkingForModel(promptModel, rawState.thinking);
+  }
+
   /** Internal: submit a prompt to a specific session, bypassing the queue check.
       Returns true when the daemon accepted the prompt. */
   async function submitPromptInternal(sid: string, text: string, attachments?: PromptAttachment[]): Promise<boolean> {
@@ -1058,7 +1075,7 @@ export function useWorkspaceState(rawState: ExtendedState, deps: UseWorkspaceSta
       const result = await api.submitPrompt(sid, {
         content,
         model,
-        thinking: rawState.thinking,
+        thinking: coercePromptThinking(model),
         permissionMode: rawState.permission,
         planMode,
         swarmMode,
@@ -1192,7 +1209,7 @@ export function useWorkspaceState(rawState: ExtendedState, deps: UseWorkspaceSta
       const result = await api.submitPrompt(sid, {
         content,
         model,
-        thinking: rawState.thinking,
+        thinking: coercePromptThinking(model),
         permissionMode: rawState.permission,
         planMode: rawState.planModeBySession[sid] ?? false,
         swarmMode: rawState.swarmModeBySession[sid] ?? false,

--- a/apps/kimi-web/src/composables/useKimiWebClient.ts
+++ b/apps/kimi-web/src/composables/useKimiWebClient.ts
@@ -99,7 +99,13 @@ const SWARM_MODE_STORAGE_KEY = STORAGE_KEYS.swarmMode;
 const GOAL_MODE_STORAGE_KEY = STORAGE_KEYS.goalMode;
 const SESSION_NOT_FOUND_CODE = 40401;
 const ONBOARDED_STORAGE_KEY = STORAGE_KEYS.onboarded;
-const THINKING_LEVELS: readonly ThinkingLevel[] = ['off', 'low', 'medium', 'high', 'xhigh', 'max'];
+// A persisted thinking level may be any non-empty effort string: the reserved
+// 'off'/'on', or a model-declared level (e.g. 'low'/'high'/'max'). Since the
+// set of legal levels comes from each model's support_efforts, we can't
+// whitelist values — only guard against corrupted localStorage with a charset
+// + length check. coerceThinkingForModel adapts the loaded value to the active
+// model once the catalog is available.
+const PERSISTED_THINKING_LEVEL_RE = /^[a-zA-Z0-9][a-zA-Z0-9_-]{0,31}$/;
 
 // Appearance types + logic live in ./client/useAppearance; re-exported here so
 // existing `import type { ColorScheme, Accent } from './useKimiWebClient'`
@@ -135,7 +141,7 @@ function savePermissionToStorage(mode: PermissionMode): void {
 function loadThinkingFromStorage(): ThinkingLevel {
   try {
     const v = safeGetString(THINKING_STORAGE_KEY);
-    if (v && (THINKING_LEVELS as readonly string[]).includes(v)) return v as ThinkingLevel;
+    if (v && PERSISTED_THINKING_LEVEL_RE.test(v)) return v as ThinkingLevel;
   } catch {
     // ignore
   }

--- a/apps/kimi-web/src/i18n/locales/en/composer.ts
+++ b/apps/kimi-web/src/i18n/locales/en/composer.ts
@@ -23,5 +23,6 @@ export default {
   emptyConversation: 'No messages yet — type below to start the conversation',
   quickStartPlaceholder: 'Type a message to start a new conversation…',
   thinkingSuffix: ' · thinking',
+  thinkingSuffixEffort: ' · thinking: {level}',
 
 } as const;

--- a/apps/kimi-web/src/i18n/locales/zh/composer.ts
+++ b/apps/kimi-web/src/i18n/locales/zh/composer.ts
@@ -23,5 +23,6 @@ export default {
   emptyConversation: '还没有消息 —— 在下方输入开始对话',
   quickStartPlaceholder: '输入消息开始新对话…',
   thinkingSuffix: ' · thinking',
+  thinkingSuffixEffort: ' · thinking: {level}',
 
 } as const;

--- a/apps/kimi-web/src/lib/modelThinking.ts
+++ b/apps/kimi-web/src/lib/modelThinking.ts
@@ -2,7 +2,10 @@ import type { AppModel, ThinkingLevel } from '../api/types';
 
 export type ThinkingAvailability = 'toggle' | 'always-on' | 'unsupported';
 
-export type ModelThinkingInfo = Pick<AppModel, 'capabilities'> & {
+export type ModelThinkingInfo = Pick<
+  AppModel,
+  'capabilities' | 'supportEfforts' | 'defaultEffort'
+> & {
   readonly adaptiveThinking?: boolean;
 };
 
@@ -16,16 +19,91 @@ export function modelThinkingAvailability(
   return 'unsupported';
 }
 
+function effortsOf(model: ModelThinkingInfo | undefined): readonly string[] {
+  return model?.supportEfforts ?? [];
+}
+
+function middleOf(efforts: readonly string[]): string {
+  return efforts[Math.floor(efforts.length / 2)]!;
+}
+
+/**
+ * Default thinking level for a model:
+ *  - unsupported / no model → 'off'
+ *  - effort model          → defaultEffort, else the middle declared effort
+ *  - boolean model         → 'on'
+ */
+export function defaultThinkingLevelFor(
+  model: ModelThinkingInfo | undefined,
+): ThinkingLevel {
+  if (modelThinkingAvailability(model) === 'unsupported') return 'off';
+  const efforts = effortsOf(model);
+  if (efforts.length > 0) return model?.defaultEffort ?? middleOf(efforts);
+  return 'on';
+}
+
+/**
+ * UI segments (left → right) for a model's thinking control:
+ *  - unsupported       → ['off']
+ *  - boolean toggle    → ['on', 'off']            (On on the left, legacy layout)
+ *  - boolean always-on → ['on']
+ *  - effort toggle     → ['off', ...efforts]      (Off on the left)
+ *  - effort always-on  → [...efforts]             (no Off segment)
+ */
+export function segmentsFor(model: ModelThinkingInfo | undefined): readonly string[] {
+  const efforts = effortsOf(model);
+  const availability = modelThinkingAvailability(model);
+  if (efforts.length > 0) {
+    return availability === 'always-on' ? [...efforts] : ['off', ...efforts];
+  }
+  if (availability === 'always-on') return ['on'];
+  if (availability === 'unsupported') return ['off'];
+  return ['on', 'off'];
+}
+
+/** Display label for a level: capitalize the first letter (off→Off, max→Max). */
+export function effortLabel(effort: string): string {
+  return effort.length === 0 ? effort : effort.charAt(0).toUpperCase() + effort.slice(1);
+}
+
+export function isThinkingOn(level: ThinkingLevel): boolean {
+  return level !== 'off';
+}
+
+/**
+ * Coerce a carried-over level against a new model's capabilities when switching
+ * models, so the level stays valid for the target:
+ *  - unsupported                          → 'off'
+ *  - always-on + 'off'                    → default level (always-on can't be off)
+ *  - effort model + undeclared level      → default level
+ *  - effort model + declared level        → requested
+ *  - boolean model + non-'off'            → 'on'
+ */
 export function coerceThinkingForModel(
   model: ModelThinkingInfo | undefined,
   requested: ThinkingLevel,
 ): ThinkingLevel {
-  switch (modelThinkingAvailability(model)) {
-    case 'always-on':
-      return requested === 'off' ? 'high' : requested;
-    case 'unsupported':
-      return 'off';
-    case 'toggle':
-      return requested;
+  const availability = modelThinkingAvailability(model);
+  if (availability === 'unsupported') return 'off';
+  if (requested === 'off') {
+    return availability === 'always-on' ? defaultThinkingLevelFor(model) : 'off';
   }
+  const efforts = effortsOf(model);
+  if (efforts.length > 0) {
+    return efforts.includes(requested) ? requested : defaultThinkingLevelFor(model);
+  }
+  return 'on';
+}
+
+/**
+ * Normalize a UI draft before it crosses the component boundary. 'on' never
+ * leaks out of the control — it becomes the model's default level.
+ */
+export function commitLevel(
+  model: ModelThinkingInfo | undefined,
+  draft: string,
+): ThinkingLevel {
+  if (draft === 'off') return 'off';
+  if (draft === 'on') return defaultThinkingLevelFor(model);
+  return draft;
 }

--- a/apps/kimi-web/src/lib/modelThinking.ts
+++ b/apps/kimi-web/src/lib/modelThinking.ts
@@ -83,6 +83,11 @@ export function coerceThinkingForModel(
   model: ModelThinkingInfo | undefined,
   requested: ThinkingLevel,
 ): ThinkingLevel {
+  // Model catalog (and thus the active model) is not known yet on early app
+  // load — keep the requested/persisted level as-is. loadModels() re-runs this
+  // coercion once models are available, so an effort like 'high' is not
+  // rewritten to the boolean 'on' and silently lost.
+  if (model === undefined) return requested;
   const availability = modelThinkingAvailability(model);
   if (availability === 'unsupported') return 'off';
   if (requested === 'off') {

--- a/apps/kimi-web/test/lib-logic.test.ts
+++ b/apps/kimi-web/test/lib-logic.test.ts
@@ -9,6 +9,15 @@ import { buildDiffLines } from '../src/lib/diffLines';
 import { buildEditDiffLines } from '../src/lib/toolDiff';
 import { createCoalescedAsyncRunner } from '../src/lib/snapshotSync';
 import { normalizeToolName, toolSummary } from '../src/lib/toolMeta';
+import {
+  coerceThinkingForModel,
+  commitLevel,
+  defaultThinkingLevelFor,
+  effortLabel,
+  modelThinkingAvailability,
+  segmentsFor,
+} from '../src/lib/modelThinking';
+import type { AppModel } from '../src/api/types';
 import { resolveToolRenderer } from '../src/components/chat/tool-calls/toolRegistry';
 import AgentTool from '../src/components/chat/tool-calls/AgentTool.vue';
 import EditTool from '../src/components/chat/tool-calls/EditTool.vue';
@@ -229,5 +238,128 @@ describe('createCoalescedAsyncRunner', () => {
     resolvers[1]!();
     await Promise.resolve();
     expect(runs).toBe(2);
+  });
+});
+
+describe('modelThinking', () => {
+  const effortModel = (over: Partial<AppModel> = {}): AppModel => ({
+    id: 'k',
+    provider: 'p',
+    model: 'k',
+    maxContextSize: 1,
+    capabilities: ['thinking'],
+    supportEfforts: ['low', 'high', 'max'],
+    defaultEffort: 'high',
+    ...over,
+  });
+  const booleanModel = (capabilities: string[] = ['thinking']): AppModel => ({
+    id: 'b',
+    provider: 'p',
+    model: 'b',
+    maxContextSize: 1,
+    capabilities,
+  });
+  const unsupportedModel = (): AppModel => ({
+    id: 'u',
+    provider: 'p',
+    model: 'u',
+    maxContextSize: 1,
+    capabilities: [],
+  });
+
+  describe('modelThinkingAvailability', () => {
+    it('toggle when model has thinking capability', () => {
+      expect(modelThinkingAvailability(booleanModel())).toBe('toggle');
+    });
+    it('always-on when model has always_thinking', () => {
+      expect(modelThinkingAvailability(booleanModel(['always_thinking']))).toBe('always-on');
+    });
+    it('unsupported when model lacks thinking capability', () => {
+      expect(modelThinkingAvailability(unsupportedModel())).toBe('unsupported');
+    });
+    it('toggle when adaptiveThinking is set', () => {
+      expect(modelThinkingAvailability({ ...unsupportedModel(), adaptiveThinking: true })).toBe('toggle');
+    });
+  });
+
+  describe('defaultThinkingLevelFor', () => {
+    it('effort model returns defaultEffort', () => {
+      expect(defaultThinkingLevelFor(effortModel())).toBe('high');
+    });
+    it('effort model without defaultEffort returns middle effort', () => {
+      expect(defaultThinkingLevelFor(effortModel({ defaultEffort: undefined }))).toBe('high');
+    });
+    it('boolean model returns on', () => {
+      expect(defaultThinkingLevelFor(booleanModel())).toBe('on');
+    });
+    it('unsupported model returns off', () => {
+      expect(defaultThinkingLevelFor(unsupportedModel())).toBe('off');
+    });
+  });
+
+  describe('segmentsFor', () => {
+    it('effort toggle → off + efforts (off left)', () => {
+      expect(segmentsFor(effortModel())).toEqual(['off', 'low', 'high', 'max']);
+    });
+    it('effort always-on → efforts only (no off)', () => {
+      expect(segmentsFor(effortModel({ capabilities: ['thinking', 'always_thinking'] }))).toEqual([
+        'low',
+        'high',
+        'max',
+      ]);
+    });
+    it('boolean toggle → on/off (on left)', () => {
+      expect(segmentsFor(booleanModel())).toEqual(['on', 'off']);
+    });
+    it('boolean always-on → on', () => {
+      expect(segmentsFor(booleanModel(['always_thinking']))).toEqual(['on']);
+    });
+    it('unsupported → off', () => {
+      expect(segmentsFor(unsupportedModel())).toEqual(['off']);
+    });
+  });
+
+  describe('commitLevel', () => {
+    it('on normalizes to the model default', () => {
+      expect(commitLevel(effortModel(), 'on')).toBe('high');
+      expect(commitLevel(booleanModel(), 'on')).toBe('on');
+    });
+    it('off stays off', () => {
+      expect(commitLevel(effortModel(), 'off')).toBe('off');
+    });
+    it('concrete effort passes through', () => {
+      expect(commitLevel(effortModel(), 'max')).toBe('max');
+    });
+  });
+
+  describe('coerceThinkingForModel', () => {
+    it('unsupported model → off', () => {
+      expect(coerceThinkingForModel(unsupportedModel(), 'high')).toBe('off');
+    });
+    it('always-on + off → default level', () => {
+      expect(
+        coerceThinkingForModel(effortModel({ capabilities: ['thinking', 'always_thinking'] }), 'off'),
+      ).toBe('high');
+    });
+    it('effort model + undeclared level → default', () => {
+      expect(coerceThinkingForModel(effortModel(), 'xhigh')).toBe('high');
+    });
+    it('effort model + declared level → kept', () => {
+      expect(coerceThinkingForModel(effortModel(), 'max')).toBe('max');
+    });
+    it('boolean model + non-off level → on', () => {
+      expect(coerceThinkingForModel(booleanModel(), 'high')).toBe('on');
+    });
+    it('toggle + off → off', () => {
+      expect(coerceThinkingForModel(booleanModel(), 'off')).toBe('off');
+    });
+  });
+
+  describe('effortLabel', () => {
+    it('capitalizes the first letter', () => {
+      expect(effortLabel('max')).toBe('Max');
+      expect(effortLabel('off')).toBe('Off');
+      expect(effortLabel('xhigh')).toBe('Xhigh');
+    });
   });
 });

--- a/apps/kimi-web/test/lib-logic.test.ts
+++ b/apps/kimi-web/test/lib-logic.test.ts
@@ -333,6 +333,12 @@ describe('modelThinking', () => {
   });
 
   describe('coerceThinkingForModel', () => {
+    it('undefined model preserves the requested level (catalog not loaded yet)', () => {
+      expect(coerceThinkingForModel(undefined, 'high')).toBe('high');
+      expect(coerceThinkingForModel(undefined, 'max')).toBe('max');
+      expect(coerceThinkingForModel(undefined, 'on')).toBe('on');
+      expect(coerceThinkingForModel(undefined, 'off')).toBe('off');
+    });
     it('unsupported model → off', () => {
       expect(coerceThinkingForModel(unsupportedModel(), 'high')).toBe('off');
     });


### PR DESCRIPTION
## Related Issue

No related issue. This is the web-side follow-up to the thinking-effort work that already shipped in the TUI (`plan/thinking-effort-switching.md`, `plan/thinking-model-overhaul.md`).

## Problem

The web composer collapsed thinking into a binary on/off toggle. Models that declare multiple reasoning efforts (`support_efforts` / `default_effort`, e.g. `low` / `high` / `max`) had no way to expose those levels in the web UI — the two fields were even dropped at the wire → app mapping layer, so the front end never saw them.

## What changed

- Carry `support_efforts` / `default_effort` from the model catalog through to the web app (`WireModel` → `AppModel` mapper).
- Widen `ThinkingLevel` to an open string (`'off' | 'on' | (string & {})`) and add `lib/modelThinking.ts` helpers (`segmentsFor`, `defaultThinkingLevelFor`, `commitLevel`, `coerceThinkingForModel`) that mirror the TUI semantics.
- Replace the on/off toggle in the composer model dropdown with a segmented control (e.g. `[Off] [Low] [High] [Max]`), and show the concrete level in the model pill suffix.
- Use the same segmented control in the mobile settings sheet, and make the `/thinking` slash command step through the active model's levels.
- Add unit coverage for the normalization logic and a changeset.

The segmented-control UX was chosen to stay faithful to the TUI, so the two clients behave identically for every model capability (boolean / effort / always-on / unsupported).

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.
