### PR TITLE
fix(agent-core): refresh MCP tools on list changes

### DIFF
--- a/.changeset/refresh-mcp-tools-list.md
+++ b/.changeset/refresh-mcp-tools-list.md
@@ -1,0 +1,6 @@
+---
+"@moonshot-ai/agent-core": patch
+"@moonshot-ai/kimi-code": patch
+---
+
+Refresh MCP tools when servers report tool list changes.

--- a/packages/agent-core/src/mcp/client-http.ts
+++ b/packages/agent-core/src/mcp/client-http.ts
@@ -4,11 +4,13 @@ import type { OAuthClientProvider } from '@modelcontextprotocol/sdk/client/auth.
 import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
 
 import {
+  buildListChangedClientOptions,
   buildRequestOptions,
   KIMI_MCP_CLIENT_NAME,
   KIMI_MCP_CLIENT_VERSION,
   toMcpToolDefinition,
   toMcpToolResult,
+  type ToolsChangedListener,
   type UnexpectedCloseListener,
   type UnexpectedCloseReason,
 } from './client-shared';
@@ -54,6 +56,7 @@ export class HttpMcpClient implements MCPClient {
   private ready = false;
   private hooksInstalled = false;
   private unexpectedCloseListener: UnexpectedCloseListener | undefined;
+  private toolsChangedListener: ToolsChangedListener | undefined;
   private lastTransportError: Error | undefined;
   // See StdioMcpClient — buffered when the listener has not been installed
   // yet so an early close is replayed instead of dropped.
@@ -75,7 +78,7 @@ export class HttpMcpClient implements MCPClient {
     this.client = new Client({
       name: options.clientName ?? KIMI_MCP_CLIENT_NAME,
       version: options.clientVersion ?? KIMI_MCP_CLIENT_VERSION,
-    });
+    }, buildListChangedClientOptions(() => this.toolsChangedListener));
     this.toolCallTimeoutMs = options.toolCallTimeoutMs;
   }
 
@@ -119,6 +122,10 @@ export class HttpMcpClient implements MCPClient {
       this.pendingUnexpectedClose = undefined;
       listener(pending);
     }
+  }
+
+  onToolsChanged(listener: ToolsChangedListener): void {
+    this.toolsChangedListener = listener;
   }
 
   async listTools(): Promise<MCPToolDefinition[]> {

--- a/packages/agent-core/src/mcp/client-shared.ts
+++ b/packages/agent-core/src/mcp/client-shared.ts
@@ -1,4 +1,5 @@
 import { getCoreVersion } from '#/version';
+import type { ClientOptions } from '@modelcontextprotocol/sdk/client/index.js';
 
 import type { MCPToolDefinition, MCPToolResult } from './types';
 
@@ -26,6 +27,11 @@ export interface UnexpectedCloseReason {
 
 export type UnexpectedCloseListener = (reason: UnexpectedCloseReason) => void;
 
+export type ToolsChangedListener = (
+  error: Error | null,
+  tools: MCPToolDefinition[] | null,
+) => void;
+
 export interface McpRequestOptions {
   readonly timeout?: number;
   readonly signal?: AbortSignal;
@@ -43,6 +49,22 @@ export function buildRequestOptions(
 ): McpRequestOptions | undefined {
   if (toolCallTimeoutMs === undefined && signal === undefined) return undefined;
   return { timeout: toolCallTimeoutMs, signal };
+}
+
+export function buildListChangedClientOptions(
+  getToolsChangedListener: () => ToolsChangedListener | undefined,
+): Pick<ClientOptions, 'listChanged'> {
+  return {
+    listChanged: {
+      tools: {
+        onChanged: (error, tools) => {
+          const listener = getToolsChangedListener();
+          if (listener === undefined) return;
+          listener(error, tools?.map(toMcpToolDefinition) ?? null);
+        },
+      },
+    },
+  };
 }
 
 interface SdkListedTool {

--- a/packages/agent-core/src/mcp/client-sse.ts
+++ b/packages/agent-core/src/mcp/client-sse.ts
@@ -4,11 +4,13 @@ import type { OAuthClientProvider } from '@modelcontextprotocol/sdk/client/auth.
 import { SSEClientTransport, SseError } from '@modelcontextprotocol/sdk/client/sse.js';
 
 import {
+  buildListChangedClientOptions,
   buildRequestOptions,
   KIMI_MCP_CLIENT_NAME,
   KIMI_MCP_CLIENT_VERSION,
   toMcpToolDefinition,
   toMcpToolResult,
+  type ToolsChangedListener,
   type UnexpectedCloseListener,
   type UnexpectedCloseReason,
 } from './client-shared';
@@ -52,6 +54,7 @@ export class SseMcpClient implements MCPClient {
   private ready = false;
   private hooksInstalled = false;
   private unexpectedCloseListener: UnexpectedCloseListener | undefined;
+  private toolsChangedListener: ToolsChangedListener | undefined;
   private lastTransportError: Error | undefined;
   private pendingUnexpectedClose: UnexpectedCloseReason | undefined;
   private unexpectedCloseFired = false;
@@ -68,7 +71,7 @@ export class SseMcpClient implements MCPClient {
     this.client = new Client({
       name: options.clientName ?? KIMI_MCP_CLIENT_NAME,
       version: options.clientVersion ?? KIMI_MCP_CLIENT_VERSION,
-    });
+    }, buildListChangedClientOptions(() => this.toolsChangedListener));
     this.toolCallTimeoutMs = options.toolCallTimeoutMs;
   }
 
@@ -110,6 +113,10 @@ export class SseMcpClient implements MCPClient {
       this.pendingUnexpectedClose = undefined;
       listener(pending);
     }
+  }
+
+  onToolsChanged(listener: ToolsChangedListener): void {
+    this.toolsChangedListener = listener;
   }
 
   async listTools(): Promise<MCPToolDefinition[]> {

--- a/packages/agent-core/src/mcp/client-stdio.ts
+++ b/packages/agent-core/src/mcp/client-stdio.ts
@@ -6,11 +6,13 @@ import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js'
 import { isAbsolute, resolve } from 'pathe';
 
 import {
+  buildListChangedClientOptions,
   buildRequestOptions,
   KIMI_MCP_CLIENT_NAME,
   KIMI_MCP_CLIENT_VERSION,
   toMcpToolDefinition,
   toMcpToolResult,
+  type ToolsChangedListener,
   type UnexpectedCloseListener,
   type UnexpectedCloseReason,
 } from './client-shared';
@@ -46,6 +48,7 @@ export class StdioMcpClient implements MCPClient {
   private ready = false;
   private hooksInstalled = false;
   private unexpectedCloseListener: UnexpectedCloseListener | undefined;
+  private toolsChangedListener: ToolsChangedListener | undefined;
   private lastTransportError: Error | undefined;
   // Buffered when the transport closes before a listener is installed (e.g.
   // a server that exits seconds after answering `tools/list`). Replayed when
@@ -76,7 +79,7 @@ export class StdioMcpClient implements MCPClient {
     this.client = new Client({
       name: options.clientName ?? KIMI_MCP_CLIENT_NAME,
       version: options.clientVersion ?? KIMI_MCP_CLIENT_VERSION,
-    });
+    }, buildListChangedClientOptions(() => this.toolsChangedListener));
     this.toolCallTimeoutMs = options.toolCallTimeoutMs;
   }
 
@@ -126,6 +129,10 @@ export class StdioMcpClient implements MCPClient {
       this.pendingUnexpectedClose = undefined;
       listener(pending);
     }
+  }
+
+  onToolsChanged(listener: ToolsChangedListener): void {
+    this.toolsChangedListener = listener;
   }
 
   /**

--- a/packages/agent-core/src/mcp/connection-manager.ts
+++ b/packages/agent-core/src/mcp/connection-manager.ts
@@ -8,10 +8,10 @@ import { abortable } from '../utils/abort';
 import { HttpMcpClient } from './client-http';
 import { isRemoteMcpConfig } from './client-remote';
 import { SseMcpClient } from './client-sse';
-import type { UnexpectedCloseReason } from './client-shared';
+import type { ToolsChangedListener, UnexpectedCloseReason } from './client-shared';
 import { StdioMcpClient } from './client-stdio';
 import type { McpOAuthService } from './oauth';
-import { assertMcpInputSchema, type MCPClient } from './types';
+import { assertMcpInputSchema, type MCPClient, type MCPToolDefinition } from './types';
 
 export type McpServerStatus = 'pending' | 'connected' | 'failed' | 'disabled' | 'needs-auth';
 
@@ -263,6 +263,7 @@ export class McpConnectionManager {
       const startupClient = this.createClient(entry.config, entry.name);
       client = startupClient;
       entry.client = startupClient;
+      this.watchForToolsChanged(entry, startupClient, attemptId);
       const tools = await withTimeout(
         this.connectAndDiscoverTools(startupClient),
         timeoutMs,
@@ -324,6 +325,57 @@ export class McpConnectionManager {
     });
   }
 
+  private watchForToolsChanged(
+    entry: InternalEntry,
+    client: RuntimeMcpClient,
+    attemptId: number,
+  ): void {
+    const listener: ToolsChangedListener = (error, mcpTools) => {
+      this.handleToolsChanged(entry, client, attemptId, error, mcpTools);
+    };
+    client.onToolsChanged(listener);
+  }
+
+  private handleToolsChanged(
+    entry: InternalEntry,
+    client: RuntimeMcpClient,
+    attemptId: number,
+    error: Error | null,
+    mcpTools: MCPToolDefinition[] | null,
+  ): void {
+    if (!this.isCurrent(entry, attemptId)) return;
+    if (entry.client !== client) return;
+    if (entry.status !== 'connected') return;
+    if (error !== null) {
+      this.log.warn('mcp tools refresh failed', {
+        server: entry.name,
+        transport: entry.config.transport,
+        error,
+      });
+      return;
+    }
+    if (mcpTools === null) return;
+
+    let tools: Tool[];
+    try {
+      tools = this.mcpToolsToTools(mcpTools);
+    } catch (refreshError) {
+      this.log.warn('mcp tools refresh failed', {
+        server: entry.name,
+        transport: entry.config.transport,
+        error: refreshError,
+      });
+      return;
+    }
+    if (!this.isCurrent(entry, attemptId)) return;
+    if (entry.client !== client) return;
+    if (entry.status !== 'connected') return;
+    entry.tools = tools;
+    entry.enabledNames = computeEnabledNames(entry.config, tools);
+    entry.error = undefined;
+    this.emit(entry);
+  }
+
   private beginConnectAttempt(entry: InternalEntry): number {
     entry.attemptId += 1;
     return entry.attemptId;
@@ -379,6 +431,10 @@ export class McpConnectionManager {
   private async connectAndDiscoverTools(client: RuntimeMcpClient): Promise<Tool[]> {
     await client.connect();
     const mcpTools = await client.listTools();
+    return this.mcpToolsToTools(mcpTools);
+  }
+
+  private mcpToolsToTools(mcpTools: readonly MCPToolDefinition[]): Tool[] {
     return mcpTools.map((mcpTool) => ({
       name: mcpTool.name,
       description: mcpTool.description,

--- a/packages/agent-core/test/mcp/connection-manager.test.ts
+++ b/packages/agent-core/test/mcp/connection-manager.test.ts
@@ -37,6 +37,7 @@ const cwdStdioFixture = join(here, 'fixtures', 'cwd-stdio-server.mjs');
 const slowStdioFixture = join(here, 'fixtures', 'slow-stdio-server.mjs');
 const crashAfterConnectFixture = join(here, 'fixtures', 'crash-after-connect-stdio-server.mjs');
 const stderrThenExitFixture = join(here, 'fixtures', 'stderr-then-exit-stdio-server.mjs');
+const dynamicToolsFixture = join(here, 'fixtures', 'dynamic-tools-stdio-server.mjs');
 const MOCK_PROVIDER: ProviderConfig = {
   type: 'kimi',
   apiKey: 'test-key',
@@ -163,6 +164,54 @@ describe('McpConnectionManager', () => {
       expect([...(resolved?.enabledNames ?? [])]).toEqual(['echo']);
       const entry = cm.get('filtered');
       expect(entry?.toolCount).toBe(1);
+    } finally {
+      await cm.shutdown();
+    }
+  }, 15000);
+
+  it('refreshes connected tools when the server sends tools/list_changed', async () => {
+    const cm = new McpConnectionManager();
+    const seen: Array<{ name: string; status: McpServerEntry['status']; toolCount: number }> = [];
+    cm.onStatusChange((e) => {
+      seen.push({ name: e.name, status: e.status, toolCount: e.toolCount });
+    });
+    try {
+      await cm.connectAll({ dynamic: stdioConfig([dynamicToolsFixture]) });
+      expect(cm.get('dynamic')).toMatchObject({
+        status: 'connected',
+        toolCount: 1,
+      });
+
+      const firstResolved = cm.resolved('dynamic');
+      expect(firstResolved?.tools.map((tool) => tool.name)).toEqual(['enable_extra_tool']);
+      if (firstResolved === undefined) {
+        throw new Error('Expected dynamic MCP server to be connected');
+      }
+      await firstResolved.client.callTool('enable_extra_tool', {});
+
+      for (let i = 0; i < 50; i++) {
+        if (cm.get('dynamic')?.toolCount === 2) break;
+        await sleep(50);
+      }
+
+      expect(cm.get('dynamic')).toMatchObject({
+        status: 'connected',
+        toolCount: 2,
+      });
+      const refreshed = cm.resolved('dynamic');
+      expect(refreshed?.tools.map((tool) => tool.name).toSorted()).toEqual([
+        'dynamic_echo',
+        'enable_extra_tool',
+      ]);
+      expect([...(refreshed?.enabledNames ?? [])].toSorted()).toEqual([
+        'dynamic_echo',
+        'enable_extra_tool',
+      ]);
+      expect(seen.filter((e) => e.name === 'dynamic')).toEqual([
+        { name: 'dynamic', status: 'pending', toolCount: 0 },
+        { name: 'dynamic', status: 'connected', toolCount: 1 },
+        { name: 'dynamic', status: 'connected', toolCount: 2 },
+      ]);
     } finally {
       await cm.shutdown();
     }
@@ -949,6 +998,75 @@ describe('Session MCP startup', () => {
         (e) => e.type === 'tool.list.updated' && e.reason === 'mcp.connected',
       );
       expect(disconnects.length).toBeGreaterThanOrEqual(1);
+      expect(connects.length).toBeGreaterThanOrEqual(1);
+    } finally {
+      await session.close();
+      await rm(tmp, { recursive: true, force: true, maxRetries: 3, retryDelay: 10 });
+    }
+  }, 10_000);
+
+  it('updates the main agent tool list when an MCP server reports new tools', async () => {
+    const tmp = await mkdtemp(join(tmpdir(), 'kimi-session-mcp-dynamic-tools-'));
+    const events: SessionRpcEvent[] = [];
+    const session = new Session({
+      id: 'test-mcp-dynamic-tools',
+      kaos: testKaos.withCwd(tmp),
+      homedir: join(tmp, 'session'),
+      rpc: sessionRpc({ events }),
+      mcpConfig: {
+        servers: {
+          dynamic: {
+            transport: 'stdio',
+            command: process.execPath,
+            args: [dynamicToolsFixture],
+            startupTimeoutMs: 4_000,
+          },
+        },
+      },
+    });
+
+    try {
+      const agent = await session.createMain();
+      for (let i = 0; i < 50; i++) {
+        if (
+          [...agent.tools.toolInfos()].some(
+            (tool) => tool.name === 'mcp__dynamic__enable_extra_tool',
+          )
+        ) {
+          break;
+        }
+        await sleep(50);
+      }
+      expect([...agent.tools.toolInfos()].map((tool) => tool.name)).toContain(
+        'mcp__dynamic__enable_extra_tool',
+      );
+      expect([...agent.tools.toolInfos()].map((tool) => tool.name)).not.toContain(
+        'mcp__dynamic__dynamic_echo',
+      );
+
+      events.length = 0;
+      const resolved = session.mcp.resolved('dynamic');
+      if (resolved === undefined) {
+        throw new Error('Expected dynamic MCP server to be connected');
+      }
+      await resolved.client.callTool('enable_extra_tool', {});
+      for (let i = 0; i < 50; i++) {
+        if (
+          [...agent.tools.toolInfos()].some(
+            (tool) => tool.name === 'mcp__dynamic__dynamic_echo',
+          )
+        ) {
+          break;
+        }
+        await sleep(50);
+      }
+
+      expect([...agent.tools.toolInfos()].map((tool) => tool.name)).toContain(
+        'mcp__dynamic__dynamic_echo',
+      );
+      const connects = events.filter(
+        (e) => e.type === 'tool.list.updated' && e.reason === 'mcp.connected',
+      );
       expect(connects.length).toBeGreaterThanOrEqual(1);
     } finally {
       await session.close();

--- a/packages/agent-core/test/mcp/fixtures/dynamic-tools-stdio-server.mjs
+++ b/packages/agent-core/test/mcp/fixtures/dynamic-tools-stdio-server.mjs
@@ -1,0 +1,37 @@
+// MCP stdio server fixture that changes its visible tool list at runtime.
+// Initially exposes enable_extra_tool; calling it enables dynamic_echo and
+// emits notifications/tools/list_changed through the SDK.
+
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import { z } from 'zod';
+
+const server = new McpServer({ name: 'dynamic-tools-stdio', version: '0.0.1' });
+
+let dynamicEchoTool;
+
+server.registerTool(
+  'enable_extra_tool',
+  {
+    description: 'Enables the dynamic echo tool',
+    inputSchema: {},
+  },
+  () => {
+    dynamicEchoTool.enable();
+    return { content: [{ type: 'text', text: 'enabled' }] };
+  },
+);
+
+dynamicEchoTool = server.registerTool(
+  'dynamic_echo',
+  {
+    description: 'Echoes input text after being enabled',
+    inputSchema: { text: z.string() },
+  },
+  ({ text }) => ({
+    content: [{ type: 'text', text }],
+  }),
+);
+dynamicEchoTool.disable();
+
+await server.connect(new StdioServerTransport());


### PR DESCRIPTION
## Related Issue

Resolve #1138

## Problem

See linked issue. Connected MCP servers can advertise `tools.listChanged`, but the active session kept the startup tool registry after `notifications/tools/list_changed`.

## What changed

- Wire SDK tool-list change callbacks into the stdio, streamable HTTP, and SSE MCP clients.
- Refresh the current connected server entry in `McpConnectionManager` while ignoring stale reconnect attempts and preserving existing tools on refresh errors.
- Add a dynamic stdio MCP fixture plus manager and session-level tests proving new tools become visible in the active agent.
- Add a patch changeset for the CLI and agent-core packages.

Validation:

- `pnpm -C packages/agent-core exec vitest run test/mcp/connection-manager.test.ts`
- `pnpm --filter @moonshot-ai/agent-core run typecheck`
- `pnpm exec oxlint --type-aware packages/agent-core/src/mcp/client-shared.ts packages/agent-core/src/mcp/client-stdio.ts packages/agent-core/src/mcp/client-http.ts packages/agent-core/src/mcp/client-sse.ts packages/agent-core/src/mcp/connection-manager.ts packages/agent-core/test/mcp/connection-manager.test.ts packages/agent-core/test/mcp/fixtures/dynamic-tools-stdio-server.mjs`
- `pnpm changeset status --since main`

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.