### PR TITLE
feat(web,server): allow file preview for system temp paths

### DIFF
--- a/.changeset/web-temp-path-preview.md
+++ b/.changeset/web-temp-path-preview.md
@@ -1,0 +1,9 @@
+---
+"@moonshot-ai/kimi-server": patch
+"@moonshot-ai/kimi-web": patch
+---
+
+feat(web,server): allow file preview for system temp paths
+
+Enable previewing files in system temp directories (/tmp, /var/tmp, /dev/shm)
+across both server and web UI layers.

--- a/apps/kimi-web/src/composables/client/useWorkspaceState.ts
+++ b/apps/kimi-web/src/composables/client/useWorkspaceState.ts
@@ -1899,12 +1899,17 @@ export function useWorkspaceState(rawState: ExtendedState, deps: UseWorkspaceSta
     // model usually references images by absolute path. Strip the session cwd.
     let path = src;
     if (path.startsWith('/')) {
-      const cwd = rawState.sessions.find((s) => s.id === sid)?.cwd;
-      if (cwd && (path === cwd || path.startsWith(cwd.endsWith('/') ? cwd : `${cwd}/`))) {
-        path = path.slice(cwd.length).replace(/^\//, '');
-        if (!path) return src;
+      // Allow system temp directories (e.g. /tmp/...) to be read directly
+      if (/^\/(tmp|var\/tmp|dev\/shm)\b/.test(path)) {
+        // keep absolute path for temp files
       } else {
-        return src; // absolute path outside the workspace — unreadable
+        const cwd = rawState.sessions.find((s) => s.id === sid)?.cwd;
+        if (cwd && (path === cwd || path.startsWith(cwd.endsWith('/') ? cwd : `${cwd}/`))) {
+          path = path.slice(cwd.length).replace(/^\//, '');
+          if (!path) return src;
+        } else {
+          return src; // absolute path outside the workspace — unreadable
+        }
       }
     }
 

--- a/apps/kimi-web/src/composables/useFilePreview.ts
+++ b/apps/kimi-web/src/composables/useFilePreview.ts
@@ -55,6 +55,10 @@ export function useFilePreview({ client, detailTarget }: UseFilePreviewOptions) 
     return out.join('/');
   }
 
+  function isSystemTempPath(path: string): boolean {
+    return /^\/(tmp|var\/tmp|dev\/shm)\b/.test(path);
+  }
+
   function normalizePreviewPath(inputPath: string): { path: string } | { error: string } {
     const raw = inputPath.trim();
     if (!raw) return { error: t('filePreview.errors.emptyPath') };
@@ -65,8 +69,14 @@ export function useFilePreview({ client, detailTarget }: UseFilePreviewOptions) 
       return { error: t('filePreview.errors.outsideWorkspace') };
     }
 
-    const cwd = trimTrailingSlash(client.status.value.cwd);
+    // Allow absolute paths inside system temp directories (e.g. /tmp/...)
     if (raw.startsWith('/')) {
+      if (isSystemTempPath(raw)) {
+        const normalized = normalizeRelativePath(raw);
+        return normalized ? { path: raw } : { error: t('filePreview.errors.emptyPath') };
+      }
+
+      const cwd = trimTrailingSlash(client.status.value.cwd);
       if (!cwd || (raw !== cwd && !raw.startsWith(`${cwd}/`))) {
         return { error: t('filePreview.errors.outsideWorkspace') };
       }

--- a/packages/agent-core/src/services/fs/fsPathSafety.ts
+++ b/packages/agent-core/src/services/fs/fsPathSafety.ts
@@ -1,5 +1,6 @@
 
 
+import os from 'node:os';
 import { promises as fs } from 'node:fs';
 import path from 'node:path';
 
@@ -70,6 +71,55 @@ export async function resolveSafePath(
   return {
     absolute: resolved,
     relative: toPosixRelative(realCwd, resolved),
+  };
+}
+
+/**
+ * Determine whether a path resides inside a system temporary directory.
+ * Covers cross-platform defaults (/tmp, /var/tmp, /dev/shm, os.tmpdir()).
+ */
+export function isTempPath(inputPath: string): boolean {
+  const normalized = path.normalize(inputPath);
+  const tmpDir = path.normalize(os.tmpdir());
+  const prefixes = [
+    '/tmp',
+    '/var/tmp',
+    '/dev/shm',
+    tmpDir,
+  ];
+  for (const p of prefixes) {
+    if (normalized === p || normalized.startsWith(p + path.sep)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * Resolve a path that is known to be inside a system temp directory.
+ * Mirrors the shape of resolveSafePath but skips cwd containment checks.
+ * Rejects paths with '..' segments for safety.
+ */
+export async function resolveTempPath(
+  inputPath: string,
+): Promise<PathSafetyResult> {
+  if (inputPath === '' || inputPath === '/') {
+    throw new FsPathEscapesError(inputPath, 'empty');
+  }
+
+  const segments = inputPath.split(/[/\\]+/);
+  if (segments.some((s) => s === '..')) {
+    throw new FsPathEscapesError(inputPath, 'dotdot_segment');
+  }
+
+  if (!isTempPath(inputPath)) {
+    throw new FsPathEscapesError(inputPath, 'resolved_outside_cwd', 'not a temp path');
+  }
+
+  const resolved = path.resolve(inputPath);
+  return {
+    absolute: resolved,
+    relative: resolved,
   };
 }
 

--- a/packages/agent-core/src/services/fs/fsService.ts
+++ b/packages/agent-core/src/services/fs/fsService.ts
@@ -32,7 +32,7 @@ import {
   type FsDownloadResolved,
   type FsPathResolved,
 } from './fs';
-import { FsPathEscapesError, resolveSafePath } from './fsPathSafety';
+import { FsPathEscapesError, resolveSafePath, resolveTempPath } from './fsPathSafety';
 
 const FS_READ_MAX_BYTES = 10 * 1024 * 1024;
 
@@ -55,6 +55,26 @@ export class FsService extends Disposable implements IFsService {
   override dispose(): void {
     this.gitignoreCache.clear();
     super.dispose();
+  }
+
+  /**
+   * Try resolveSafePath first; if the path is absolute and inside a system
+   * temp directory, fall back to resolveTempPath. This lets web clients
+   * preview files written to /tmp (or platform equivalents) without escaping
+   * the session workspace for normal relative paths.
+   */
+  private async resolveWithTempFallback(
+    cwd: string,
+    inputPath: string,
+  ): Promise<{ absolute: string; relative: string }> {
+    try {
+      return await resolveSafePath(cwd, inputPath);
+    } catch (err) {
+      if (err instanceof FsPathEscapesError && err.reason === 'absolute') {
+        return await resolveTempPath(inputPath);
+      }
+      throw err;
+    }
   }
 
   async list(sessionId: string, req: FsListRequest): Promise<FsListResponse> {
@@ -163,7 +183,7 @@ export class FsService extends Disposable implements IFsService {
   async read(sessionId: string, req: FsReadRequest): Promise<FsReadResponse> {
     const session = await this.sessions.get(sessionId);
     const cwd = session.metadata.cwd;
-    const safe = await resolveSafePath(cwd, req.path);
+    const safe = await this.resolveWithTempFallback(cwd, req.path);
 
     let st: import('node:fs').Stats;
     try {
@@ -358,7 +378,7 @@ export class FsService extends Disposable implements IFsService {
   ): Promise<FsDownloadResolved> {
     const session = await this.sessions.get(sessionId);
     const cwd = session.metadata.cwd;
-    const safe = await resolveSafePath(cwd, relPath);
+    const safe = await this.resolveWithTempFallback(cwd, relPath);
     let st: import('node:fs').Stats;
     try {
       st = await fs.stat(safe.absolute);
@@ -392,7 +412,7 @@ export class FsService extends Disposable implements IFsService {
   ): Promise<FsPathResolved> {
     const session = await this.sessions.get(sessionId);
     const cwd = session.metadata.cwd;
-    const safe = await resolveSafePath(cwd, relPath);
+    const safe = await this.resolveWithTempFallback(cwd, relPath);
     let st: import('node:fs').Stats;
     try {
       st = await fs.stat(safe.absolute);

--- a/packages/agent-core/src/services/fs/index.ts
+++ b/packages/agent-core/src/services/fs/index.ts
@@ -35,5 +35,7 @@ export { FsWatcherService } from './fsWatcherService';
 export {
   FsPathEscapesError,
   resolveSafePath,
+  isTempPath,
+  resolveTempPath,
   type PathSafetyResult,
 } from './fsPathSafety';

--- a/packages/agent-core/src/services/index.ts
+++ b/packages/agent-core/src/services/index.ts
@@ -77,6 +77,8 @@ export { FsWatcherService } from './fs/fsWatcherService';
 export {
   FsPathEscapesError,
   resolveSafePath,
+  isTempPath,
+  resolveTempPath,
 } from './fs/fsPathSafety';
 export type { PathSafetyResult } from './fs/fsPathSafety';
 

--- a/packages/server/test/fs-path-safety.test.ts
+++ b/packages/server/test/fs-path-safety.test.ts
@@ -9,6 +9,8 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import {
   FsPathEscapesError,
   resolveSafePath,
+  isTempPath,
+  resolveTempPath,
 } from '@moonshot-ai/agent-core';
 
 let tmpDir: string;
@@ -109,5 +111,51 @@ describe('resolveSafePath', () => {
   it('accepts a missing-tail path (e.g. for future write or 40409 surface)', async () => {
     const r = await resolveSafePath(cwd, 'does-not-exist.txt');
     expect(r.relative).toBe('does-not-exist.txt');
+  });
+});
+
+describe('isTempPath', () => {
+  it('recognises /tmp and descendants', () => {
+    expect(isTempPath('/tmp')).toBe(true);
+    expect(isTempPath('/tmp/foo.txt')).toBe(true);
+    expect(isTempPath('/tmp/nested/file')).toBe(true);
+  });
+
+  it('recognises /var/tmp and /dev/shm', () => {
+    expect(isTempPath('/var/tmp')).toBe(true);
+    expect(isTempPath('/var/tmp/bar')).toBe(true);
+    expect(isTempPath('/dev/shm')).toBe(true);
+    expect(isTempPath('/dev/shm/baz')).toBe(true);
+  });
+
+  it('rejects non-temp absolute paths', () => {
+    expect(isTempPath('/etc/passwd')).toBe(false);
+    expect(isTempPath('/home/user/file')).toBe(false);
+    expect(isTempPath('/')).toBe(false);
+  });
+
+  it('rejects relative paths', () => {
+    expect(isTempPath('tmp/foo')).toBe(false);
+    expect(isTempPath('./tmp/foo')).toBe(false);
+  });
+});
+
+describe('resolveTempPath', () => {
+  it('resolves a simple /tmp file', async () => {
+    const r = await resolveTempPath('/tmp/hello.txt');
+    expect(r.absolute).toBe('/tmp/hello.txt');
+    expect(r.relative).toBe('/tmp/hello.txt');
+  });
+
+  it('rejects empty string', async () => {
+    await expect(resolveTempPath('')).rejects.toThrowError(FsPathEscapesError);
+  });
+
+  it('rejects paths with ".." segments', async () => {
+    await expect(resolveTempPath('/tmp/../etc/passwd')).rejects.toThrowError(FsPathEscapesError);
+  });
+
+  it('rejects non-temp absolute paths', async () => {
+    await expect(resolveTempPath('/etc/passwd')).rejects.toThrowError(FsPathEscapesError);
   });
 });


### PR DESCRIPTION
## Problem

When the model references files in  (or platform equivalents like  and ), the web UI previously rejected them with  and the server rejected them with  path errors. This meant users couldn't preview files written to temp by tools (e.g.  outputting to ).

## Changes

**Server side:**
- Add  and  to , with cross-platform temp prefix support and  rejection
- Add  in , used by , , and  so temp files can be read, downloaded, opened, and revealed without weakening normal workspace containment

**Web side:**
-  now passes through  paths directly
-  no longer drops absolute temp paths, letting temp images display inline

**Tests:**
- Add  and  coverage (8 new tests)
- All 19 fs-path-safety tests pass; agent-core (3457) and server (685) suites also pass (1 pre-existing unrelated failure in )

## Backwards Compatibility

- Normal relative paths still go through  unchanged
- , , , etc. still reject absolute paths — only // gain temp support, matching web preview needs

## Closes

- web支持temp路径 (P1 Backlog)