### PR TITLE
fix(web): refill attachments when editing a queued or undone message

### DIFF
--- a/.changeset/refill-composer-attachments.md
+++ b/.changeset/refill-composer-attachments.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Fix queued media messages not loading back into the composer and keep attachments when undoing a message in the web chat.

--- a/.changeset/refill-composer-attachments.md
+++ b/.changeset/refill-composer-attachments.md
@@ -2,4 +2,4 @@
 "@moonshot-ai/kimi-code": patch
 ---
 
-Fix queued media messages not loading back into the composer and keep attachments when undoing a message in the web chat.
+web: Fix queued media messages not loading back into the composer and keep attachments when undoing a message.

--- a/apps/kimi-web/src/App.vue
+++ b/apps/kimi-web/src/App.vue
@@ -369,10 +369,13 @@ async function handleLoginSuccess(): Promise<void> {
 
 // Edit + resend the last user message: undo the latest exchange on the daemon,
 // then drop that message's text back into the composer for editing.
-async function handleEditMessage(text: string): Promise<void> {
+async function handleEditMessage(payload: {
+  text: string;
+  images?: { url: string; alt?: string; kind: 'image' | 'video'; fileId?: string }[];
+}): Promise<void> {
   await client.undo(1);
   await nextTick();
-  conversationPaneRef.value?.loadComposerForEdit(text);
+  conversationPaneRef.value?.loadComposerForEdit(payload.text, payload.images);
 }
 
 // Handler for slash commands emitted by Composer (via ConversationPane)

--- a/apps/kimi-web/src/components/chat/ChatDock.vue
+++ b/apps/kimi-web/src/components/chat/ChatDock.vue
@@ -80,12 +80,20 @@ const emit = defineEmits<{
 }>();
 
 const { t } = useI18n();
-const composerRef = ref<{ loadForEdit: (value: string) => void; focus: () => void } | null>(null);
+const composerRef = ref<{
+  loadForEdit: (value: string) => void;
+  loadAttachmentsForEdit: (atts: { fileId?: string; kind: 'image' | 'video'; url: string; name?: string }[]) => void;
+  focus: () => void;
+} | null>(null);
 const workPanelRef = ref<HTMLElement | null>(null);
 const workbarRef = ref<HTMLElement | null>(null);
 
 function loadForEdit(value: string): void {
   composerRef.value?.loadForEdit(value);
+}
+
+function loadAttachmentsForEdit(atts: { fileId?: string; kind: 'image' | 'video'; url: string; name?: string }[]): void {
+  composerRef.value?.loadAttachmentsForEdit(atts);
 }
 
 function focus(): void {
@@ -117,7 +125,7 @@ onUnmounted(() => {
   }
 });
 
-defineExpose({ loadForEdit, focus });
+defineExpose({ loadForEdit, loadAttachmentsForEdit, focus });
 </script>
 
 <template>

--- a/apps/kimi-web/src/components/chat/ChatDock.vue
+++ b/apps/kimi-web/src/components/chat/ChatDock.vue
@@ -81,15 +81,20 @@ const emit = defineEmits<{
 
 const { t } = useI18n();
 const composerRef = ref<{
-  loadForEdit: (value: string) => void;
+  loadForEdit: (value: string) => boolean;
   loadAttachmentsForEdit: (atts: { fileId?: string; kind: 'image' | 'video'; url: string; name?: string }[]) => void;
   focus: () => void;
 } | null>(null);
 const workPanelRef = ref<HTMLElement | null>(null);
 const workbarRef = ref<HTMLElement | null>(null);
 
-function loadForEdit(value: string): void {
-  composerRef.value?.loadForEdit(value);
+function loadForEdit(value: string): boolean {
+  // The nested Composer is only rendered in ChatDock's v-else — when a pending
+  // question or approval is shown it is unmounted, so report unavailability so
+  // the caller doesn't dequeue a prompt it can't actually load.
+  if (!composerRef.value) return false;
+  composerRef.value.loadForEdit(value);
+  return true;
 }
 
 function loadAttachmentsForEdit(atts: { fileId?: string; kind: 'image' | 'video'; url: string; name?: string }[]): void {

--- a/apps/kimi-web/src/components/chat/ChatPane.vue
+++ b/apps/kimi-web/src/components/chat/ChatPane.vue
@@ -199,7 +199,7 @@ const emit = defineEmits<{
   /** Show an Edit/Write tool call's diff in the right-side panel. */
   openToolDiff: [id: string];
   /** Edit + resend the last user message (parent undoes, then refills composer). */
-  editMessage: [text: string];
+  editMessage: [payload: { text: string; images?: { url: string; alt?: string; kind: 'image' | 'video'; fileId?: string }[] }];
   /** Fetch the next older page of messages (triggered by top sentinel visibility or click). */
   loadOlderMessages: [];
   /** Remove a queued message by index. */
@@ -220,10 +220,10 @@ function hasImages(item: QueuedPromptView): boolean {
   return (item.attachments?.length ?? 0) > 0;
 }
 
-function onQueueEdit(index: number, item: QueuedPromptView): void {
-  // Image-carrying prompts can't be round-tripped through the text composer, so
-  // they are remove-only (matches the previous dock queue behaviour).
-  if (hasImages(item)) return;
+function onQueueEdit(index: number): void {
+  // Image/video attachments round-trip through the composer now (the composer
+  // can hold fileIds), so a queued prompt can be loaded back for edit whether or
+  // not it carries media.
   emit('editQueued', index);
 }
 
@@ -353,7 +353,7 @@ async function onUndo(turn: ChatTurn): Promise<void> {
 function confirmEditMessage(turn: ChatTurn): void {
   if (undoingTurnId.value !== null) return;
   undoingTurnId.value = turn.id;
-  emit('editMessage', turn.text);
+  emit('editMessage', { text: turn.text, images: turn.images });
   // Fallback: if the server rewind never removes the turn (e.g. it failed),
   // release the guard so the user can retry.
   undoFallbackTimer = setTimeout(() => {
@@ -721,9 +721,8 @@ function isStreamingRenderBlock(turn: ChatTurn, block: { sourceIndex: number }):
           <button
             type="button"
             class="q-body"
-            :title="hasImages(item) ? t('composer.queuedHasImage', { n: item.attachments?.length ?? 0 }) : t('composer.editQueued')"
-            :disabled="hasImages(item)"
-            @click="onQueueEdit(qi, item)"
+            :title="t('composer.editQueued')"
+            @click="onQueueEdit(qi)"
           >
             <span v-if="item.text" class="u-text q-text">{{ item.text }}</span>
             <span v-else class="q-text q-text-placeholder">

--- a/apps/kimi-web/src/components/chat/Composer.vue
+++ b/apps/kimi-web/src/components/chat/Composer.vue
@@ -246,6 +246,7 @@ const {
   handleDragLeave,
   handleDrop,
   clearAfterSubmit,
+  loadAttachments,
 } = useAttachmentUpload({ uploadImage: () => props.uploadImage, sessionId: () => props.sessionId });
 
 // Silence noUnusedLocals: fileInputRef is used as a template ref (ref="fileInputRef").
@@ -277,7 +278,10 @@ function focus(): void {
   // or if focus is triggered during an animation/transition.
   textareaRef.value?.focus({ preventScroll: true });
 }
-defineExpose({ loadForEdit, focus });
+function loadAttachmentsForEdit(atts: { fileId?: string; kind: 'image' | 'video'; url: string; name?: string }[]): void {
+  loadAttachments(atts);
+}
+defineExpose({ loadForEdit, loadAttachmentsForEdit, focus });
 
 function handleSubmit(): void {
   const trimmed = text.value.trim();

--- a/apps/kimi-web/src/components/chat/ConversationPane.vue
+++ b/apps/kimi-web/src/components/chat/ConversationPane.vue
@@ -192,16 +192,22 @@ let copyConversationCopiedTimer: ReturnType<typeof setTimeout> | null = null;
 
 /** Load text (and any attachments) into whichever composer is currently mounted
     (docked vs the empty-session composer). Used by App for "edit & resend the
-    last message", and by the queue when a pending prompt is loaded for edit. */
+    last message", and by the queue when a pending prompt is loaded for edit.
+    Returns false when no composer is actually able to receive the content (e.g.
+    the dock is showing a pending question/approval and the composer is hidden),
+    so the caller can avoid dropping the prompt. */
 function loadComposerForEdit(
   value: string,
   attachments?: { fileId?: string; kind: 'image' | 'video'; url: string; name?: string }[],
-): void {
+): boolean {
   const composer = dockedComposerRef.value ?? emptyComposerRef.value;
-  composer?.loadForEdit(value);
-  // Always replace the attachment strip (even when empty) so a text-only edit
-  // clears media left over from a prior edit instead of sending it on resubmit.
-  composer?.loadAttachmentsForEdit(attachments ?? []);
+  if (!composer) return false;
+  // loadForEdit returns false when the dock's nested Composer is hidden; the
+  // empty composer's loadForEdit returns void (treat as success).
+  const ok = composer.loadForEdit(value);
+  if (ok === false) return false;
+  composer.loadAttachmentsForEdit(attachments ?? []);
+  return true;
 }
 
 function handleCopyConversationCopied(): void {
@@ -374,7 +380,7 @@ const chatDockStyle = computed(() => ({
   '--panes-scrollbar-width': `${panesScrollbarWidth.value}px`,
 }));
 type ComposerHandle = {
-  loadForEdit: (value: string) => void;
+  loadForEdit: (value: string) => boolean | void;
   loadAttachmentsForEdit: (atts: { fileId?: string; kind: 'image' | 'video'; url: string; name?: string }[]) => void;
   focus: () => void;
 };
@@ -787,12 +793,14 @@ function handleEditMessage(payload: {
 
 // A queued message was clicked for editing: load its text (and any attachments)
 // back into the active composer, then let the parent dequeue it (mirrors the old
-// dock-queue flow).
+// dock-queue flow). Only dequeue when the load actually succeeds — if the dock is
+// showing a pending question/approval the composer is hidden and the load no-ops,
+// so dequeuing would drop the prompt instead of making it editable.
 function handleEditQueued(index: number): void {
   const item = props.queued?.[index];
   const text = item?.text ?? '';
-  if (text || (item?.attachments?.length ?? 0) > 0) loadComposerForEdit(text, item?.attachments);
-  emit('editQueued', index);
+  const loaded = loadComposerForEdit(text, item?.attachments);
+  if (loaded) emit('editQueued', index);
 }
 
 function handleReorderQueue(payload: { from: number; to: number }): void {

--- a/apps/kimi-web/src/components/chat/ConversationPane.vue
+++ b/apps/kimi-web/src/components/chat/ConversationPane.vue
@@ -199,7 +199,9 @@ function loadComposerForEdit(
 ): void {
   const composer = dockedComposerRef.value ?? emptyComposerRef.value;
   composer?.loadForEdit(value);
-  if (attachments?.length) composer?.loadAttachmentsForEdit(attachments);
+  // Always replace the attachment strip (even when empty) so a text-only edit
+  // clears media left over from a prior edit instead of sending it on resubmit.
+  composer?.loadAttachmentsForEdit(attachments ?? []);
 }
 
 function handleCopyConversationCopied(): void {

--- a/apps/kimi-web/src/components/chat/ConversationPane.vue
+++ b/apps/kimi-web/src/components/chat/ConversationPane.vue
@@ -119,7 +119,7 @@ const emit = defineEmits<{
   openChanges: [];
   refreshGitStatus: [];
   /** Edit + resend the last user message (App undoes, then refills composer). */
-  editMessage: [text: string];
+  editMessage: [payload: { text: string; images?: { url: string; alt?: string; kind: 'image' | 'video'; fileId?: string }[] }];
   /** Empty-composer workspace picker: start a new conversation elsewhere. */
   selectWorkspace: [workspaceId: string];
   /** Empty-composer workspace picker: create a new workspace. */
@@ -190,10 +190,16 @@ const copyConversationCopied = ref(false);
 const goalExpandSignal = ref(0);
 let copyConversationCopiedTimer: ReturnType<typeof setTimeout> | null = null;
 
-/** Load text into whichever composer is currently mounted (docked vs the
-    empty-session composer). Used by App for "edit & resend the last message". */
-function loadComposerForEdit(value: string): void {
-  (dockedComposerRef.value ?? emptyComposerRef.value)?.loadForEdit(value);
+/** Load text (and any attachments) into whichever composer is currently mounted
+    (docked vs the empty-session composer). Used by App for "edit & resend the
+    last message", and by the queue when a pending prompt is loaded for edit. */
+function loadComposerForEdit(
+  value: string,
+  attachments?: { fileId?: string; kind: 'image' | 'video'; url: string; name?: string }[],
+): void {
+  const composer = dockedComposerRef.value ?? emptyComposerRef.value;
+  composer?.loadForEdit(value);
+  if (attachments?.length) composer?.loadAttachmentsForEdit(attachments);
 }
 
 function handleCopyConversationCopied(): void {
@@ -365,7 +371,11 @@ const dockHeight = ref(0);
 const chatDockStyle = computed(() => ({
   '--panes-scrollbar-width': `${panesScrollbarWidth.value}px`,
 }));
-type ComposerHandle = { loadForEdit: (value: string) => void; focus: () => void };
+type ComposerHandle = {
+  loadForEdit: (value: string) => void;
+  loadAttachmentsForEdit: (atts: { fileId?: string; kind: 'image' | 'video'; url: string; name?: string }[]) => void;
+  focus: () => void;
+};
 type RefArg = Element | (ComponentPublicInstance & Partial<ComposerHandle>) | null;
 
 function toHtmlEl(el: RefArg): HTMLElement | null {
@@ -396,6 +406,10 @@ function bindChatDock(el: RefArg): void {
   ) {
     dockedComposerRef.value = {
       loadForEdit: el.loadForEdit.bind(el),
+      loadAttachmentsForEdit:
+        'loadAttachmentsForEdit' in el && typeof el.loadAttachmentsForEdit === 'function'
+          ? el.loadAttachmentsForEdit.bind(el)
+          : () => {},
       focus: el.focus.bind(el),
     };
   } else {
@@ -759,18 +773,23 @@ function handleComposerSubmit(payload: { text: string; attachments: { fileId: st
 // returns. Scrolling here would target the pre-rewind bottom and fight the
 // bubble-exit animation, so we only arm the follow state; the scrollKey watcher
 // smooth-scrolls once the truncated turns actually land.
-function handleEditMessage(text: string): void {
+function handleEditMessage(payload: {
+  text: string;
+  images?: { url: string; alt?: string; kind: 'image' | 'video'; fileId?: string }[];
+}): void {
   following.value = true;
   showPill.value = false;
   userActionFollowUntil = Date.now() + USER_ACTION_FOLLOW_LOCK_MS;
-  emit('editMessage', text);
+  emit('editMessage', payload);
 }
 
-// A queued message was clicked for editing: load its text back into the active
-// composer, then let the parent dequeue it (mirrors the old dock-queue flow).
+// A queued message was clicked for editing: load its text (and any attachments)
+// back into the active composer, then let the parent dequeue it (mirrors the old
+// dock-queue flow).
 function handleEditQueued(index: number): void {
-  const text = props.queued?.[index]?.text ?? '';
-  if (text) loadComposerForEdit(text);
+  const item = props.queued?.[index];
+  const text = item?.text ?? '';
+  if (text || (item?.attachments?.length ?? 0) > 0) loadComposerForEdit(text, item?.attachments);
   emit('editQueued', index);
 }
 

--- a/apps/kimi-web/src/composables/useAttachmentUpload.ts
+++ b/apps/kimi-web/src/composables/useAttachmentUpload.ts
@@ -218,8 +218,11 @@ export function useAttachmentUpload(deps: AttachmentUploadDeps) {
     );
   }
 
-  function dataUrlToBlob(url: string): Promise<Blob> {
-    return fetch(url).then((r) => r.blob());
+  function urlToBlob(url: string): Promise<Blob> {
+    return fetch(url).then((r) => {
+      if (!r.ok) throw new Error(`fetch failed: ${r.status}`);
+      return r.blob();
+    });
   }
 
   /** Refill the attachment strip from already-uploaded files (used when a queued
@@ -262,9 +265,12 @@ export function useAttachmentUpload(deps: AttachmentUploadDeps) {
             // Keep the fallback previewUrl (honest broken state if it 401s).
           });
         }
-      } else if (isData) {
-        // No fileId (e.g. an image the server base64-inlined): re-upload so the
-        // chip is actually resendable — otherwise handleSubmit silently drops it.
+      } else {
+        // No fileId (e.g. a server-base64-inlined image, or a URL-backed source
+        // from the wire/REST prompt path): re-upload the URL so the chip is
+        // actually resendable — otherwise handleSubmit silently drops it. If the
+        // URL can't be fetched (CORS / non-2xx) or upload is unavailable, skip
+        // the chip rather than show a misleading ready attachment.
         const upload = uploadImage();
         if (!upload) continue;
         const entry: Attachment = {
@@ -275,24 +281,24 @@ export function useAttachmentUpload(deps: AttachmentUploadDeps) {
           uploading: true,
         };
         setForSession(sid, [...(attachmentsBySession.value[sid] ?? []), entry]);
-        void dataUrlToBlob(att.url)
+        void urlToBlob(att.url)
           .then((blob) => {
             const fname = name.includes('.') ? name : `${name}.${blob.type.split('/')[1] ?? 'bin'}`;
             return upload(blob, fname);
           })
           .then((result) => {
-            patchAttachment(sid, localId, {
-              uploading: false,
-              fileId: result?.fileId,
-              error: result === null,
-            });
+            if (result === null) {
+              const current = attachmentsBySession.value[sid] ?? [];
+              setForSession(sid, current.filter((a) => a.localId !== localId));
+              return;
+            }
+            patchAttachment(sid, localId, { uploading: false, fileId: result.fileId });
           })
           .catch(() => {
-            patchAttachment(sid, localId, { uploading: false, error: true });
+            const current = attachmentsBySession.value[sid] ?? [];
+            setForSession(sid, current.filter((a) => a.localId !== localId));
           });
       }
-      // No fileId and not a data URL — can't make resendable, skip rather than
-      // show a chip that handleSubmit would silently drop.
     }
   }
 

--- a/apps/kimi-web/src/composables/useAttachmentUpload.ts
+++ b/apps/kimi-web/src/composables/useAttachmentUpload.ts
@@ -209,6 +209,19 @@ export function useAttachmentUpload(deps: AttachmentUploadDeps) {
     setForSession(sid, []);
   }
 
+  function patchAttachment(sid: string, localId: string, patch: Partial<Attachment>): void {
+    const current = attachmentsBySession.value[sid] ?? [];
+    if (!current.some((a) => a.localId === localId)) return;
+    setForSession(
+      sid,
+      current.map((a) => (a.localId === localId ? { ...a, ...patch } : a)),
+    );
+  }
+
+  function dataUrlToBlob(url: string): Promise<Blob> {
+    return fetch(url).then((r) => r.blob());
+  }
+
   /** Refill the attachment strip from already-uploaded files (used when a queued
    *  prompt or an undone message is loaded back into the composer). The fileIds
    *  are reused directly (no re-upload); for a protected getFileUrl preview we
@@ -221,34 +234,65 @@ export function useAttachmentUpload(deps: AttachmentUploadDeps) {
     setForSession(sid, []);
     for (const att of atts) {
       const localId = nextLocalId();
-      const localSrc = /^(data:|blob:)/i.test(att.url);
-      const entry: Attachment = {
-        localId,
-        name: att.name ?? att.kind,
-        kind: att.kind,
-        previewUrl: att.url,
-        uploading: false,
-        fileId: att.fileId,
-      };
-      setForSession(sid, [...(attachmentsBySession.value[sid] ?? []), entry]);
-      if (att.fileId && !localSrc) {
-        void getKimiWebApi().getFileBlob(att.fileId).then((blob) => {
-          const blobUrl = URL.createObjectURL(blob);
-          const current = attachmentsBySession.value[sid] ?? [];
-          if (!current.some((a) => a.localId === localId)) {
-            URL.revokeObjectURL(blobUrl);
-            return;
-          }
-          setForSession(
-            sid,
-            (attachmentsBySession.value[sid] ?? []).map((a) =>
-              a.localId === localId ? { ...a, previewUrl: blobUrl } : a,
-            ),
-          );
-        }).catch(() => {
-          // Keep the fallback previewUrl (honest broken state if it 401s).
-        });
+      const isData = /^data:/i.test(att.url);
+      const isBlob = /^blob:/i.test(att.url);
+      const name = att.name ?? att.kind;
+
+      if (att.fileId) {
+        // Ready as-is; fetch an authenticated thumbnail for protected URLs.
+        const entry: Attachment = {
+          localId,
+          name,
+          kind: att.kind,
+          previewUrl: att.url,
+          uploading: false,
+          fileId: att.fileId,
+        };
+        setForSession(sid, [...(attachmentsBySession.value[sid] ?? []), entry]);
+        if (!isData && !isBlob) {
+          void getKimiWebApi().getFileBlob(att.fileId).then((blob) => {
+            const blobUrl = URL.createObjectURL(blob);
+            const current = attachmentsBySession.value[sid] ?? [];
+            if (!current.some((a) => a.localId === localId)) {
+              URL.revokeObjectURL(blobUrl);
+              return;
+            }
+            patchAttachment(sid, localId, { previewUrl: blobUrl });
+          }).catch(() => {
+            // Keep the fallback previewUrl (honest broken state if it 401s).
+          });
+        }
+      } else if (isData) {
+        // No fileId (e.g. an image the server base64-inlined): re-upload so the
+        // chip is actually resendable — otherwise handleSubmit silently drops it.
+        const upload = uploadImage();
+        if (!upload) continue;
+        const entry: Attachment = {
+          localId,
+          name,
+          kind: att.kind,
+          previewUrl: att.url,
+          uploading: true,
+        };
+        setForSession(sid, [...(attachmentsBySession.value[sid] ?? []), entry]);
+        void dataUrlToBlob(att.url)
+          .then((blob) => {
+            const fname = name.includes('.') ? name : `${name}.${blob.type.split('/')[1] ?? 'bin'}`;
+            return upload(blob, fname);
+          })
+          .then((result) => {
+            patchAttachment(sid, localId, {
+              uploading: false,
+              fileId: result?.fileId,
+              error: result === null,
+            });
+          })
+          .catch(() => {
+            patchAttachment(sid, localId, { uploading: false, error: true });
+          });
       }
+      // No fileId and not a data URL — can't make resendable, skip rather than
+      // show a chip that handleSubmit would silently drop.
     }
   }
 

--- a/apps/kimi-web/src/composables/useAttachmentUpload.ts
+++ b/apps/kimi-web/src/composables/useAttachmentUpload.ts
@@ -212,9 +212,13 @@ export function useAttachmentUpload(deps: AttachmentUploadDeps) {
   /** Refill the attachment strip from already-uploaded files (used when a queued
    *  prompt or an undone message is loaded back into the composer). The fileIds
    *  are reused directly (no re-upload); for a protected getFileUrl preview we
-   *  fetch an authenticated blob URL so the thumbnail doesn't 401. */
+   *  fetch an authenticated blob URL so the thumbnail doesn't 401. Replaces any
+   *  unsent draft attachments (mirroring loadForEdit(text), which overwrites) so
+   *  a later submit sends exactly the edited message's files, not a mix. */
   function loadAttachments(atts: { fileId?: string; kind: 'image' | 'video'; url: string; name?: string }[]): void {
     const sid = sessionId() ?? '';
+    for (const existing of attachmentsBySession.value[sid] ?? []) revokeAttachment(existing);
+    setForSession(sid, []);
     for (const att of atts) {
       const localId = nextLocalId();
       const localSrc = /^(data:|blob:)/i.test(att.url);

--- a/apps/kimi-web/src/composables/useAttachmentUpload.ts
+++ b/apps/kimi-web/src/composables/useAttachmentUpload.ts
@@ -10,6 +10,7 @@
 // paste listener + object-URL cleanup lifecycle.
 
 import { computed, onMounted, onUnmounted, ref, watch } from 'vue';
+import { getKimiWebApi } from '../api';
 
 export interface Attachment {
   /** Unique local id (used as :key) */
@@ -208,6 +209,45 @@ export function useAttachmentUpload(deps: AttachmentUploadDeps) {
     setForSession(sid, []);
   }
 
+  /** Refill the attachment strip from already-uploaded files (used when a queued
+   *  prompt or an undone message is loaded back into the composer). The fileIds
+   *  are reused directly (no re-upload); for a protected getFileUrl preview we
+   *  fetch an authenticated blob URL so the thumbnail doesn't 401. */
+  function loadAttachments(atts: { fileId?: string; kind: 'image' | 'video'; url: string; name?: string }[]): void {
+    const sid = sessionId() ?? '';
+    for (const att of atts) {
+      const localId = nextLocalId();
+      const localSrc = /^(data:|blob:)/i.test(att.url);
+      const entry: Attachment = {
+        localId,
+        name: att.name ?? att.kind,
+        kind: att.kind,
+        previewUrl: att.url,
+        uploading: false,
+        fileId: att.fileId,
+      };
+      setForSession(sid, [...(attachmentsBySession.value[sid] ?? []), entry]);
+      if (att.fileId && !localSrc) {
+        void getKimiWebApi().getFileBlob(att.fileId).then((blob) => {
+          const blobUrl = URL.createObjectURL(blob);
+          const current = attachmentsBySession.value[sid] ?? [];
+          if (!current.some((a) => a.localId === localId)) {
+            URL.revokeObjectURL(blobUrl);
+            return;
+          }
+          setForSession(
+            sid,
+            (attachmentsBySession.value[sid] ?? []).map((a) =>
+              a.localId === localId ? { ...a, previewUrl: blobUrl } : a,
+            ),
+          );
+        }).catch(() => {
+          // Keep the fallback previewUrl (honest broken state if it 401s).
+        });
+      }
+    }
+  }
+
   // Close the preview lightbox when switching sessions — it may reference an
   // attachment that belongs to the previous session.
   watch(sessionId, () => {
@@ -241,5 +281,6 @@ export function useAttachmentUpload(deps: AttachmentUploadDeps) {
     handleDragLeave,
     handleDrop,
     clearAfterSubmit,
+    loadAttachments,
   };
 }

--- a/apps/kimi-web/test/attachment-upload.test.ts
+++ b/apps/kimi-web/test/attachment-upload.test.ts
@@ -151,7 +151,7 @@ describe('useAttachmentUpload', () => {
     const uploadImage = vi.fn<UploadImage>().mockResolvedValue({ fileId: 'f_new', name: 'a.png', mediaType: 'image/png' });
     const att = setup(uploadImage);
     const blob = new Blob(['x'], { type: 'image/png' });
-    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ blob: () => Promise.resolve(blob) }));
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: true, blob: () => Promise.resolve(blob) }));
 
     att.loadAttachments([{ kind: 'image', url: 'data:image/png;base64,AAAA', name: 'a.png' }]);
     expect(att.attachments.value).toHaveLength(1);
@@ -167,6 +167,29 @@ describe('useAttachmentUpload', () => {
   it('loadAttachments skips a fileId-less data URL when re-upload is unavailable', () => {
     const att = setup(undefined);
     att.loadAttachments([{ kind: 'image', url: 'data:image/png;base64,AAAA', name: 'a.png' }]);
+    expect(att.attachments.value).toHaveLength(0);
+  });
+
+  it('loadAttachments re-uploads a fileId-less http URL so it becomes resendable', async () => {
+    const uploadImage = vi.fn<UploadImage>().mockResolvedValue({ fileId: 'f_http', name: 'x.png', mediaType: 'image/png' });
+    const att = setup(uploadImage);
+    const blob = new Blob(['x'], { type: 'image/png' });
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: true, blob: () => Promise.resolve(blob) }));
+
+    att.loadAttachments([{ kind: 'image', url: 'https://example.test/x.png', name: 'x.png' }]);
+    expect(att.attachments.value).toHaveLength(1);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(att.attachments.value[0].fileId).toBe('f_http');
+  });
+
+  it('loadAttachments drops a fileId-less URL whose fetch fails', async () => {
+    const uploadImage = vi.fn<UploadImage>().mockResolvedValue({ fileId: 'f_x', name: 'x.png', mediaType: 'image/png' });
+    const att = setup(uploadImage);
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: false, status: 401 }));
+
+    att.loadAttachments([{ kind: 'image', url: 'https://example.test/protected.png', name: 'protected.png' }]);
+    expect(att.attachments.value).toHaveLength(1);
+    await new Promise((resolve) => setTimeout(resolve, 0));
     expect(att.attachments.value).toHaveLength(0);
   });
 

--- a/apps/kimi-web/test/attachment-upload.test.ts
+++ b/apps/kimi-web/test/attachment-upload.test.ts
@@ -109,6 +109,21 @@ describe('useAttachmentUpload', () => {
     expect(revokeObjectURL).toHaveBeenCalledTimes(2);
   });
 
+  it('loadAttachments refills an already-uploaded attachment without re-uploading', () => {
+    const att = setup(undefined);
+    att.loadAttachments([
+      { fileId: 'f_existing', kind: 'image', url: 'data:image/png;base64,AAAA', name: 'a.png' },
+    ]);
+    expect(att.attachments.value).toHaveLength(1);
+    expect(att.attachments.value[0]).toMatchObject({
+      fileId: 'f_existing',
+      kind: 'image',
+      name: 'a.png',
+      uploading: false,
+      previewUrl: 'data:image/png;base64,AAAA',
+    });
+  });
+
   it('isolates attachments between sessions', () => {
     const uploadImage = vi.fn<UploadImage>().mockResolvedValue(null);
     const sessionId = ref<string | undefined>('sess-a');

--- a/apps/kimi-web/test/attachment-upload.test.ts
+++ b/apps/kimi-web/test/attachment-upload.test.ts
@@ -147,6 +147,29 @@ describe('useAttachmentUpload', () => {
     expect(att.attachments.value).toHaveLength(0);
   });
 
+  it('loadAttachments re-uploads a fileId-less data URL so it becomes resendable', async () => {
+    const uploadImage = vi.fn<UploadImage>().mockResolvedValue({ fileId: 'f_new', name: 'a.png', mediaType: 'image/png' });
+    const att = setup(uploadImage);
+    const blob = new Blob(['x'], { type: 'image/png' });
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ blob: () => Promise.resolve(blob) }));
+
+    att.loadAttachments([{ kind: 'image', url: 'data:image/png;base64,AAAA', name: 'a.png' }]);
+    expect(att.attachments.value).toHaveLength(1);
+    expect(att.attachments.value[0].uploading).toBe(true);
+
+    // Flush the fetch → blob → upload promise chain so the re-upload resolves.
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(att.attachments.value[0].uploading).toBe(false);
+    expect(att.attachments.value[0].fileId).toBe('f_new');
+    expect(uploadImage).toHaveBeenCalledOnce();
+  });
+
+  it('loadAttachments skips a fileId-less data URL when re-upload is unavailable', () => {
+    const att = setup(undefined);
+    att.loadAttachments([{ kind: 'image', url: 'data:image/png;base64,AAAA', name: 'a.png' }]);
+    expect(att.attachments.value).toHaveLength(0);
+  });
+
   it('isolates attachments between sessions', () => {
     const uploadImage = vi.fn<UploadImage>().mockResolvedValue(null);
     const sessionId = ref<string | undefined>('sess-a');

--- a/apps/kimi-web/test/attachment-upload.test.ts
+++ b/apps/kimi-web/test/attachment-upload.test.ts
@@ -137,6 +137,16 @@ describe('useAttachmentUpload', () => {
     expect(att.attachments.value[0].name).toBe('refill.png');
   });
 
+  it('loadAttachments with an empty list clears the attachment strip', () => {
+    const uploadImage = vi.fn<UploadImage>().mockResolvedValue(null);
+    const att = setup(uploadImage);
+    att.handleFileInputChange(inputEvent([imageFile('draft.png')]));
+    expect(att.attachments.value).toHaveLength(1);
+
+    att.loadAttachments([]);
+    expect(att.attachments.value).toHaveLength(0);
+  });
+
   it('isolates attachments between sessions', () => {
     const uploadImage = vi.fn<UploadImage>().mockResolvedValue(null);
     const sessionId = ref<string | undefined>('sess-a');

--- a/apps/kimi-web/test/attachment-upload.test.ts
+++ b/apps/kimi-web/test/attachment-upload.test.ts
@@ -124,6 +124,19 @@ describe('useAttachmentUpload', () => {
     });
   });
 
+  it('loadAttachments replaces any unsent draft attachments instead of appending', () => {
+    const uploadImage = vi.fn<UploadImage>().mockResolvedValue(null);
+    const att = setup(uploadImage);
+    att.handleFileInputChange(inputEvent([imageFile('draft.png')]));
+    expect(att.attachments.value).toHaveLength(1);
+
+    att.loadAttachments([
+      { fileId: 'f_existing', kind: 'image', url: 'data:image/png;base64,AAAA', name: 'refill.png' },
+    ]);
+    expect(att.attachments.value).toHaveLength(1);
+    expect(att.attachments.value[0].name).toBe('refill.png');
+  });
+
   it('isolates attachments between sessions', () => {
     const uploadImage = vi.fn<UploadImage>().mockResolvedValue(null);
     const sessionId = ref<string | undefined>('sess-a');


### PR DESCRIPTION
## Related Issue

No linked issue — from user feedback.

## Problem

In the web chat, two "load back into the composer" paths dropped attachments:

- A queued prompt that carries images/video could not be clicked back into the composer at all (the row was disabled, remove-only).
- Undoing ("edit & resend") the last user message restored only its text; any images/video were lost.

Both came from the same root cause: the composer's refill entry only accepted text, even though the composer already knows how to hold attachments and the data (fileIds) was available on the queued item / the undone turn.

## What changed

- `useAttachmentUpload` gains `loadAttachments`, which refills the attachment strip from already-uploaded files (reuses the existing fileIds, no re-upload). For a protected `getFileUrl` preview it fetches an authenticated blob URL so the thumbnail doesn't 401.
- `loadComposerForEdit` now carries attachments alongside text; the undo path and the queue-edit path both pass them through.
- Queued prompts that carry media are no longer remove-only — clicking one loads text + attachments back into the composer.
- Added a unit test for `loadAttachments`.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.
