### PR TITLE
fix(kosong): make Gemini (google-genai/vertexai) tool-calling work

### DIFF
--- a/.changeset/fix-gemini-tool-calling.md
+++ b/.changeset/fix-gemini-tool-calling.md
@@ -1,0 +1,19 @@
+---
+"@moonshot-ai/kimi-code": patch
+"@moonshot-ai/kimi-code-sdk": patch
+---
+
+fix(kosong): make Gemini (google-genai/vertexai) tool-calling work
+
+The Google GenAI provider built function declarations and content parts with
+snake_case keys (`function_declarations`, `parameters_json_schema`,
+`function_call`, `function_response`, `thought_signature`). The `@google/genai`
+SDK expects camelCase, so it silently dropped those keys and sent empty tool
+specs, causing Gemini to return `MALFORMED_FUNCTION_CALL`. Separately, tool-call
+`thought_signature` extras captured from responses were dropped in the
+agent-core tool-call event pipeline, so multi-turn Gemini 3.x tool use failed
+with `missing thought_signature`.
+
+Emit the camelCase keys the SDK expects and thread tool-call `extras` through the
+event pipeline so thought signatures round-trip. Gemini tool-calling now works
+for both `google-genai` and `vertexai`.

--- a/packages/agent-core/src/agent/context/index.ts
+++ b/packages/agent-core/src/agent/context/index.ts
@@ -620,6 +620,7 @@ export class ContextMemory {
           id: event.toolCallId,
           name: event.name,
           arguments: event.args === undefined ? null : JSON.stringify(event.args),
+          ...(event.extras !== undefined ? { extras: event.extras } : {}),
         });
         this.pendingToolResultIds.add(event.toolCallId);
         return;

--- a/packages/agent-core/src/loop/events.ts
+++ b/packages/agent-core/src/loop/events.ts
@@ -78,6 +78,7 @@ export interface LoopToolCallEvent {
   readonly args: unknown;
   readonly description?: string | undefined;
   readonly display?: ToolInputDisplay | undefined;
+  readonly extras?: Record<string, unknown> | undefined;
 }
 
 export interface LoopToolResultEvent {

--- a/packages/agent-core/src/loop/tool-call.ts
+++ b/packages/agent-core/src/loop/tool-call.ts
@@ -713,5 +713,6 @@ async function dispatchToolCall(
     args,
     description: displayFields?.description,
     display: displayFields?.display,
+    extras: toolCall.extras,
   });
 }

--- a/packages/agent-core/src/services/message/transcript.ts
+++ b/packages/agent-core/src/services/message/transcript.ts
@@ -190,6 +190,7 @@ export function reduceWireRecords(records: Iterable<AgentRecord>): {
           id: event.toolCallId,
           name: event.name,
           arguments: event.args === undefined ? null : JSON.stringify(event.args),
+          ...(event.extras !== undefined ? { extras: event.extras } : {}),
         });
         pendingToolResultIds.add(event.toolCallId);
         return;

--- a/packages/kosong/src/providers/google-genai.ts
+++ b/packages/kosong/src/providers/google-genai.ts
@@ -108,20 +108,20 @@ interface ThinkingConfig {
 interface GoogleFunctionDeclaration {
   name: string;
   description: string;
-  parameters_json_schema: Record<string, unknown>;
+  parametersJsonSchema: Record<string, unknown>;
 }
 
 interface GoogleTool {
-  function_declarations: GoogleFunctionDeclaration[];
+  functionDeclarations: GoogleFunctionDeclaration[];
 }
 
 function toolToGoogleGenAI(tool: Tool): GoogleTool {
   return {
-    function_declarations: [
+    functionDeclarations: [
       {
         name: tool.name,
         description: tool.description,
-        parameters_json_schema: tool.parameters,
+        parametersJsonSchema: tool.parameters,
       },
     ],
   };
@@ -133,13 +133,13 @@ interface GoogleContent {
 
 interface GooglePart {
   text?: string;
-  function_call?: { name: string; args: Record<string, unknown> };
-  function_response?: {
+  functionCall?: { name: string; args: Record<string, unknown> };
+  functionResponse?: {
     name: string;
     response: Record<string, string>;
     parts: unknown[];
   };
-  thought_signature?: string;
+  thoughtSignature?: string;
   [key: string]: unknown;
 }
 
@@ -274,7 +274,7 @@ function messageToGoogleGenAI(message: Message): GoogleContent {
     }
 
     const functionCallPart: GooglePart = {
-      function_call: {
+      functionCall: {
         name: toolCall.name,
         args,
       },
@@ -282,7 +282,7 @@ function messageToGoogleGenAI(message: Message): GoogleContent {
 
     // Restore thought_signature if available
     if (toolCall.extras && 'thought_signature_b64' in toolCall.extras) {
-      functionCallPart['thought_signature'] = toolCall.extras['thought_signature_b64'] as string;
+      functionCallPart['thoughtSignature'] = toolCall.extras['thought_signature_b64'] as string;
     }
 
     parts.push(functionCallPart);
@@ -335,7 +335,7 @@ function toolMessageToFunctionResponseParts(
   }
 
   const functionResponsePart: GooglePart = {
-    function_response: {
+    functionResponse: {
       name: toolCallIdToName(message.toolCallId, toolNameById),
       response: { output: textOutput },
       parts: [],
@@ -463,7 +463,7 @@ export function messagesToGoogleGenAIContents(messages: Message[]): GoogleConten
     isUser: (content) => content.role === 'user',
     isToolResultOnly: (content) =>
       content.parts.length > 0 &&
-      content.parts.every((part) => part.function_response !== undefined),
+      content.parts.every((part) => part.functionResponse !== undefined),
     merge: (last, next) => ({ ...last, parts: [...last.parts, ...next.parts] }),
   });
 }

--- a/packages/kosong/test/google-genai.test.ts
+++ b/packages/kosong/test/google-genai.test.ts
@@ -253,7 +253,7 @@ describe('GoogleGenAIChatProvider', () => {
 
       expect(contents.map((c) => c.role)).toEqual(['user', 'model', 'user']);
       const last = contents.at(-1)!;
-      expect(last.parts.some((p) => p.function_response !== undefined)).toBe(true);
+      expect(last.parts.some((p) => p.functionResponse !== undefined)).toBe(true);
       expect(last.parts.some((p) => p.text === 'Now multiply')).toBe(true);
     });
 
@@ -276,7 +276,7 @@ describe('GoogleGenAIChatProvider', () => {
       expect(config['system_instruction']).toBe('You are a math tutor.');
     });
 
-    it('tool definitions use parameters_json_schema', async () => {
+    it('tool definitions use parametersJsonSchema', async () => {
       const provider = createProvider();
       const history: Message[] = [
         { role: 'user', content: [{ type: 'text', text: 'Add 2 and 3' }], toolCalls: [] },
@@ -286,11 +286,11 @@ describe('GoogleGenAIChatProvider', () => {
       const config = body['config'] as Record<string, unknown>;
       expect(config['tools']).toEqual([
         {
-          function_declarations: [
+          functionDeclarations: [
             {
               name: 'add',
               description: 'Add two integers.',
-              parameters_json_schema: {
+              parametersJsonSchema: {
                 type: 'object',
                 properties: {
                   a: { type: 'integer', description: 'First number' },
@@ -302,11 +302,11 @@ describe('GoogleGenAIChatProvider', () => {
           ],
         },
         {
-          function_declarations: [
+          functionDeclarations: [
             {
               name: 'multiply',
               description: 'Multiply two integers.',
-              parameters_json_schema: {
+              parametersJsonSchema: {
                 type: 'object',
                 properties: {
                   a: { type: 'integer', description: 'First number' },
@@ -348,14 +348,14 @@ describe('GoogleGenAIChatProvider', () => {
         {
           parts: [
             { text: "I'll add those numbers for you." },
-            { function_call: { name: 'add', args: { a: 2, b: 3 } } },
+            { functionCall: { name: 'add', args: { a: 2, b: 3 } } },
           ],
           role: 'model',
         },
         {
           parts: [
             {
-              function_response: {
+              functionResponse: {
                 name: 'add',
                 response: { output: '5' },
                 parts: [],
@@ -367,11 +367,11 @@ describe('GoogleGenAIChatProvider', () => {
       ]);
     });
 
-    it('tool call with thought_signature_b64 emits thoughtSignature on outbound function_call', async () => {
+    it('tool call with thought_signature_b64 emits thoughtSignature on outbound functionCall', async () => {
       // Round-trip: a previous turn returned a tool call with thoughtSignature
       // (decoded into ToolCall.extras.thought_signature_b64). When we send
       // the assistant message back, the converter must put the original
-      // signature back into the function_call part so Gemini can resume the
+      // signature back into the functionCall part so Gemini can resume the
       // reasoning chain.
       const provider = createProvider();
       const history: Message[] = [
@@ -394,15 +394,15 @@ describe('GoogleGenAIChatProvider', () => {
       const contents = body['contents'] as Array<{ parts: unknown[]; role: string }>;
       const assistantParts = contents.find((c) => c.role === 'model')!.parts;
       const fnCallPart = assistantParts.find(
-        (p) => (p as Record<string, unknown>)['function_call'] !== undefined,
-      ) as { function_call: Record<string, unknown>; thought_signature?: unknown } | undefined;
+        (p) => (p as Record<string, unknown>)['functionCall'] !== undefined,
+      ) as { functionCall: Record<string, unknown>; thoughtSignature?: unknown } | undefined;
       expect(fnCallPart).toMatchObject({
-        function_call: { name: 'add', args: { a: 2, b: 3 } },
-        thought_signature: 'dGhvdWdodF9zaWduYXR1cmVfZGF0YQ==',
+        functionCall: { name: 'add', args: { a: 2, b: 3 } },
+        thoughtSignature: 'dGhvdWdodF9zaWduYXR1cmVfZGF0YQ==',
       });
     });
 
-    it('tool message with image_url result yields function_response + inline data part', () => {
+    it('tool message with image_url result yields functionResponse + inline data part', () => {
       const messages: Message[] = [
         {
           role: 'assistant',
@@ -437,11 +437,11 @@ describe('GoogleGenAIChatProvider', () => {
       expect(userContent.role).toBe('user');
       expect(userContent.parts.length).toBeGreaterThanOrEqual(2);
 
-      const fnResp = userContent.parts.find((p) => 'function_response' in p) as
-        | { function_response: { name: string; response: { output: string } } }
+      const fnResp = userContent.parts.find((p) => 'functionResponse' in p) as
+        | { functionResponse: { name: string; response: { output: string } } }
         | undefined;
       expect(fnResp).toMatchObject({
-        function_response: {
+        functionResponse: {
           name: 'fetch_image',
           response: { output: 'Found image:' },
         },
@@ -488,14 +488,14 @@ describe('GoogleGenAIChatProvider', () => {
         parts: Array<Record<string, unknown>>;
       };
       expect(userContent.role).toBe('user');
-      // function_response + audio + video
+      // functionResponse + audio + video
       expect(userContent.parts).toHaveLength(3);
 
-      const fnResp = userContent.parts.find((p) => 'function_response' in p) as
-        | { function_response: { response: { output: string } } }
+      const fnResp = userContent.parts.find((p) => 'functionResponse' in p) as
+        | { functionResponse: { response: { output: string } } }
         | undefined;
       expect(fnResp).toMatchObject({
-        function_response: { response: { output: 'Got audio and video:' } },
+        functionResponse: { response: { output: 'Got audio and video:' } },
       });
 
       const fileDataParts = userContent.parts.filter((p) => 'fileData' in p) as Array<{
@@ -581,7 +581,7 @@ describe('GoogleGenAIChatProvider', () => {
       const body = await captureRequestBody(provider, '', [ADD_TOOL, MUL_TOOL], history);
 
       // Snapshot of the expected wire format:
-      // - exactly 3 contents in order (user, model with 2 function_calls, user with 2 function_responses bundled)
+      // - exactly 3 contents in order (user, model with 2 functionCalls, user with 2 functionResponses bundled)
       // - both tool results are N:1 packed into ONE user Content
       // - text parts are concatenated into `response.output` (system-reminder + result)
       // - functionCall / functionResponse never include an `id` field
@@ -590,15 +590,15 @@ describe('GoogleGenAIChatProvider', () => {
         {
           parts: [
             { text: "I'll calculate both." },
-            { function_call: { name: 'add', args: { a: 2, b: 3 } } },
-            { function_call: { name: 'multiply', args: { a: 4, b: 5 } } },
+            { functionCall: { name: 'add', args: { a: 2, b: 3 } } },
+            { functionCall: { name: 'multiply', args: { a: 4, b: 5 } } },
           ],
           role: 'model',
         },
         {
           parts: [
             {
-              function_response: {
+              functionResponse: {
                 name: 'add',
                 response: {
                   output: '<system-reminder>This is a system reminder</system-reminder>5',
@@ -607,7 +607,7 @@ describe('GoogleGenAIChatProvider', () => {
               },
             },
             {
-              function_response: {
+              functionResponse: {
                 name: 'multiply',
                 response: {
                   output: '<system-reminder>This is a system reminder</system-reminder>20',
@@ -678,7 +678,7 @@ describe('GoogleGenAIChatProvider', () => {
       const contents = messagesToGoogleGenAIContents(history);
       for (const content of contents) {
         for (const part of content.parts) {
-          if (part.function_response) return part.function_response.name;
+          if (part.functionResponse) return part.functionResponse.name;
         }
       }
       return undefined;
@@ -733,8 +733,8 @@ describe('GoogleGenAIChatProvider', () => {
     });
   });
 
-  describe('no id in function_call or function_response', () => {
-    it('does not include id in function_call or function_response parts', () => {
+  describe('no id in functionCall or functionResponse', () => {
+    it('does not include id in functionCall or functionResponse parts', () => {
       const history: Message[] = [
         { role: 'user', content: [{ type: 'text', text: 'Add 2 and 3' }], toolCalls: [] },
         {
@@ -760,11 +760,11 @@ describe('GoogleGenAIChatProvider', () => {
 
       for (const content of contents) {
         for (const part of content.parts) {
-          if (part.function_call) {
-            expect(part.function_call).not.toHaveProperty('id');
+          if (part.functionCall) {
+            expect(part.functionCall).not.toHaveProperty('id');
           }
-          if (part.function_response) {
-            expect(part.function_response).not.toHaveProperty('id');
+          if (part.functionResponse) {
+            expect(part.functionResponse).not.toHaveProperty('id');
           }
         }
       }


### PR DESCRIPTION
## Related Issue

No existing issue — this is a clear, reproducible bug fix with a focused diff (allowed without prior discussion per CONTRIBUTING). Problem described below.

## Problem

Gemini tool-calling is broken for both `google-genai` and `vertexai`:

1. **Empty tool specs → `MALFORMED_FUNCTION_CALL`.** The provider builds function declarations with snake_case keys (`function_declarations`, `parameters_json_schema`) and content parts with `function_call` / `function_response` / `thought_signature`. The `@google/genai` SDK expects camelCase, so it drops these keys and sends empty tool objects (`tools: [{}]`) on the wire. Gemini then responds with `finishReason: MALFORMED_FUNCTION_CALL` and empty content.

2. **Multi-turn fails with `missing thought_signature`.** Once tools are populated, Gemini 3.x requires the `thoughtSignature` to be echoed back on later turns. The provider captures it into `ToolCall.extras.thought_signature_b64`, but `LoopToolCallEvent` has no `extras` field and the `ContextMemory` / transcript reconstructors rebuild tool calls without it, so the signature is lost and continuations are rejected.

The existing `google-genai` tests mock `generateContentStream` and assert the snake_case object passed *into* the SDK, so the real serialization was never exercised and the bug went uncaught.

## What changed

- **`packages/kosong/src/providers/google-genai.ts`** — emit the camelCase keys the SDK expects: `functionDeclarations`, `parametersJsonSchema`, `functionCall`, `functionResponse`, `thoughtSignature`.
- **`packages/agent-core`** — add `extras` to `LoopToolCallEvent`, dispatch `toolCall.extras` in `dispatchToolCall`, and copy `extras` when rebuilding tool calls in `ContextMemory` (`agent/context`) and the transcript service, so `thoughtSignature` round-trips across turns.
- **`packages/kosong/test/google-genai.test.ts`** — updated to assert the camelCase keys the SDK requires.

Verified end-to-end against a real Gemini endpoint (`gemini-3.1-pro-preview`): multi-turn tool-using tasks (create file → shell command → read back) now complete for both `google-genai` and `vertexai`. `pnpm typecheck`, `pnpm lint` (0 errors), and the kosong/agent-core test suites pass.

## Checklist

- [x] I have read the CONTRIBUTING document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset. (changeset added manually)
- [x] Ran `gen-docs` skill, or this PR needs no doc update. (no user-facing doc change)
