### PR TITLE
docs(server): document --dangerous-bypass-auth and --keep-alive flags

### DIFF
--- a/.changeset/server-bypass-auth-keep-alive.md
+++ b/.changeset/server-bypass-auth-keep-alive.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": minor
+---
+
+Add `--dangerous-bypass-auth` and `--keep-alive` flags to `kimi server run`, so the server can run without a token on trusted networks and stay alive past the idle timeout.

--- a/docs/en/reference/kimi-command.md
+++ b/docs/en/reference/kimi-command.md
@@ -161,10 +161,16 @@ kimi server status             # snapshot of installed/running state
 | `--port <port>` | Bind port; defaults to `58627` |
 | `--log-level <level>` | Enable server logs at the selected level; omitted by default |
 | `--debug-endpoints` | Mount `/api/v1/debug/*` routes (off by default) |
+| `--keep-alive` | Keep the server running instead of exiting after 60s with no connected clients; implied by `--host` / `--allowed-host` and always on with `--foreground` |
+| `--dangerous-bypass-auth` | Disable bearer-token auth on all REST and WebSocket routes so the web UI connects without a token; only for trusted networks or behind an authenticating proxy |
 | `--foreground` | Run in the foreground instead of spawning a background daemon |
 | `--open` | Open the web UI in the default browser once the server is healthy |
 
-`kimi server run` binds to local loopback only. By default it spawns a single background daemon (reused across runs) and exits once the daemon is healthy; the daemon shuts itself down after the last web client disconnects. Pass `--foreground` to run the server in the current process instead — it then stays attached to the terminal and shuts down cleanly on `SIGINT` / `SIGTERM`.
+`kimi server run` binds to local loopback only. By default it spawns a single background daemon (reused across runs) and exits once the daemon is healthy; the daemon shuts itself down after the last web client disconnects. Pass `--keep-alive` to keep it running past the idle timeout, or `--foreground` to run the server in the current process instead — it then stays attached to the terminal and shuts down cleanly on `SIGINT` / `SIGTERM`.
+
+::: danger
+`--dangerous-bypass-auth` disables authentication entirely. Anyone who can reach the port gets full access to your sessions, filesystem, and shell. Only use it on a trusted network or behind your own authenticating reverse proxy, and run `kimi server kill` to stop the server when you are done.
+:::
 
 #### `kimi server install`
 

--- a/docs/zh/reference/kimi-command.md
+++ b/docs/zh/reference/kimi-command.md
@@ -161,10 +161,16 @@ kimi server status             # 查看安装与运行状态
 | `--port <port>` | 绑定端口；默认 `58627` |
 | `--log-level <level>` | 按所选级别开启服务日志；默认不输出 |
 | `--debug-endpoints` | 挂载 `/api/v1/debug/*` 调试路由（默认关闭） |
+| `--keep-alive` | 让服务在没有客户端连接 60 秒后继续运行，不会因空闲退出；`--host` / `--allowed-host` 会自动启用，`--foreground` 模式下始终开启 |
+| `--dangerous-bypass-auth` | 关闭所有 REST 与 WebSocket 路由的 bearer token 鉴权，使 web UI 无需 token 即可连接；仅用于可信网络或自有鉴权代理之后 |
 | `--foreground` | 前台运行，不 spawn 后台守护进程 |
 | `--open` | 服务健康后用默认浏览器打开 web UI |
 
-`kimi server run` 只绑定本机 loopback 地址。默认会 spawn 一个后台守护进程（多次运行会复用同一个），健康后即退出；守护进程在最后一个 web 客户端断开后自行关闭。加 `--foreground` 则在当前进程中运行——保持挂在终端，在 `SIGINT` / `SIGTERM` 时干净退出。
+`kimi server run` 只绑定本机 loopback 地址。默认会 spawn 一个后台守护进程（多次运行会复用同一个），健康后即退出；守护进程在最后一个 web 客户端断开后自行关闭。加 `--keep-alive` 可让它在空闲超时后继续运行，或加 `--foreground` 则在当前进程中运行——保持挂在终端，在 `SIGINT` / `SIGTERM` 时干净退出。
+
+::: danger 警告
+`--dangerous-bypass-auth` 会彻底关闭鉴权。任何能访问该端口的人都能完全控制你的会话、文件系统和 shell。请仅在可信网络或自有鉴权反向代理之后使用，用完后运行 `kimi server kill` 停止服务。
+:::
 
 #### `kimi server install`
 


### PR DESCRIPTION
## Related Issue

Follow-up to #1368, which added the `--dangerous-bypass-auth` and `--keep-alive` flags to `kimi server run` but merged with the changeset and docs checklist items still open.

## Problem

The two new `kimi server run` flags shipped in #1368 have no user-facing documentation and no changeset, so the next release would ship the feature without a changelog entry and users would have no reference for how to use them (or the security implications of `--dangerous-bypass-auth`).

## What changed

- Added `.changeset/server-bypass-auth-keep-alive.md` (minor bump for `@moonshot-ai/kimi-code`) so the next release notes the feature.
- Documented both flags in the `kimi server run` reference (`docs/en/reference/kimi-command.md` + `docs/zh/reference/kimi-command.md`), including a `::: danger` callout spelling out the risk of `--dangerous-bypass-auth`.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works. (N/A — docs and changeset only)
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.
