### PR TITLE
chore: downgrade unreleased changesets to patch

### DIFF
--- a/.changeset/cap-background-command-output.md
+++ b/.changeset/cap-background-command-output.md
@@ -1,5 +1,5 @@
 ---
-"@moonshot-ai/agent-core": minor
+"@moonshot-ai/agent-core": patch
 ---
 
 Apply the 16 MiB output cap to background shell commands too, so a runaway background command can no longer fill the disk or crash the process; it is now terminated with the same guidance to redirect large output to a file.

--- a/.changeset/print-drain-subagents.md
+++ b/.changeset/print-drain-subagents.md
@@ -1,5 +1,5 @@
 ---
-"@moonshot-ai/kimi-code": minor
+"@moonshot-ai/kimi-code": patch
 ---
 
 Wait for background subagents to finish and respond to their results before exiting in `kimi -p`, instead of ending the turn early.

--- a/.changeset/server-bypass-auth-keep-alive.md
+++ b/.changeset/server-bypass-auth-keep-alive.md
@@ -1,5 +1,5 @@
 ---
-"@moonshot-ai/kimi-code": minor
+"@moonshot-ai/kimi-code": patch
 ---
 
 Add `--dangerous-bypass-auth` and `--keep-alive` flags to `kimi server run`, so the server can run without a token on trusted networks and stay alive past the idle timeout.


### PR DESCRIPTION
## Related Issue

No related issue. This PR adjusts the bump levels of already-existing, unreleased changesets.

## Problem

Several pending changesets were marked as "minor" even though the changes they describe are bug fixes or small incremental improvements that fit the "patch" level better. Keeping them as "minor" would trigger unnecessary minor version bumps for the next release.

## What changed

Downgraded the bump level of the following changesets from "minor" to "patch":

- `.changeset/cap-background-command-output.md` (`@moonshot-ai/agent-core`)
- `.changeset/print-drain-subagents.md` (`@moonshot-ai/kimi-code`)
- `.changeset/server-bypass-auth-keep-alive.md` (`@moonshot-ai/kimi-code`)

All other unreleased changesets were already at "patch" and remain unchanged.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works. (Not applicable — changeset-only change.)
- [x] Ran `gen-changesets` skill, or this PR needs no changeset. (No new changeset needed.)
- [x] Ran `gen-docs` skill, or this PR needs no doc update. (No doc update needed.)