### PR TITLE
fix(kimi-web): make ask-user question card scrollable on mobile

### DIFF
--- a/apps/kimi-web/src/components/chat/QuestionCard.vue
+++ b/apps/kimi-web/src/components/chat/QuestionCard.vue
@@ -624,5 +624,19 @@ onUnmounted(() => document.removeEventListener('keydown', handleKeydown));
     min-height: 46px;
   }
   .qfoot-main { order: -1; }
+
+  /* Constrain the card height so long questions stay reachable on small screens.
+     The header and footer stay pinned; the scrollable area is Card.vue's body
+     wrapper, which is the flex child under .qcard. */
+  .qcard {
+    display: flex;
+    flex-direction: column;
+    max-height: min(520px, 70vh);
+  }
+  .qcard :deep(.ui-card__body) {
+    min-height: 0;
+    overflow-y: auto;
+    -webkit-overflow-scrolling: touch;
+  }
 }
 </style>


### PR DESCRIPTION
On mobile the app shell disables document scrolling, and the bottom dock (ChatDock) has no max-height or overflow. A question card with many/long options could grow past the viewport, making the Submit button unreachable.

This change constrains QuestionCard on narrow viewports (<=640px) to a flex column with a capped height, and makes .ui-card__body scrollable while the header/footer stay pinned.

Fixes #1400