### PR TITLE
fix: show Windows session search shortcut

### DIFF
--- a/.changeset/fix-session-search-shortcut.md
+++ b/.changeset/fix-session-search-shortcut.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+web: Show the correct session search shortcut on Windows.

--- a/apps/kimi-web/src/components/Sidebar.vue
+++ b/apps/kimi-web/src/components/Sidebar.vue
@@ -83,6 +83,7 @@ const emit = defineEmits<{
 // Session search dialog (Spotlight-style; filters title + last prompt)
 // ---------------------------------------------------------------------------
 const showSearch = ref(false);
+const sessionSearchShortcut = isAppleShortcutPlatform() ? '⌘K' : 'Ctrl K';
 
 function openSearch(): void {
   // Sessions are loaded per-workspace (first page only); lazily drain the rest
@@ -100,6 +101,14 @@ function onSearchKeydown(e: KeyboardEvent): void {
 
 onMounted(() => window.addEventListener('keydown', onSearchKeydown));
 onBeforeUnmount(() => window.removeEventListener('keydown', onSearchKeydown));
+
+function isAppleShortcutPlatform(): boolean {
+  if (typeof navigator === 'undefined') return false;
+  if (/Mac|iPod|iPhone|iPad/.test(navigator.platform)) return true;
+
+  const userAgentData = (navigator as Navigator & { userAgentData?: { platform?: string } }).userAgentData;
+  return userAgentData?.platform === 'macOS' || userAgentData?.platform === 'iOS';
+}
 
 // Scroll-linked header seam: the .btn-wrap bottom border/shadow only appears
 // once the session list has actually scrolled, so an unscrolled list shows no
@@ -590,7 +599,7 @@ onBeforeUnmount(() => {
       <!-- Session search — opens the Spotlight-style search dialog -->
       <button class="search" type="button" @click="openSearch">
         <Icon class="search-icon" name="search" />
-        <span class="search-input">{{ t('sidebar.searchShortcut') }}</span>
+        <span class="search-input">{{ t('sidebar.searchShortcut', { shortcut: sessionSearchShortcut }) }}</span>
       </button>
 
       <!-- New chat + new workspace buttons -->

--- a/apps/kimi-web/src/i18n/locales/en/sidebar.ts
+++ b/apps/kimi-web/src/i18n/locales/en/sidebar.ts
@@ -38,7 +38,7 @@ export default {
   collapseSidebar: 'Collapse sidebar',
   expandSidebar: 'Expand sidebar',
   searchPlaceholder: 'Search sessions',
-  searchShortcut: 'Search sessions (⌘K)',
+  searchShortcut: 'Search sessions ({shortcut})',
   searchHint: '↑↓ navigate · ↵ open · Esc close',
   searchNoResults: 'No matching sessions',
 } as const;

--- a/apps/kimi-web/src/i18n/locales/zh/sidebar.ts
+++ b/apps/kimi-web/src/i18n/locales/zh/sidebar.ts
@@ -38,7 +38,7 @@ export default {
   collapseSidebar: '收起侧边栏',
   expandSidebar: '展开侧边栏',
   searchPlaceholder: '搜索会话',
-  searchShortcut: '搜索会话 (⌘K)',
+  searchShortcut: '搜索会话 ({shortcut})',
   searchHint: '↑↓ 选择 · ↵ 打开 · Esc 关闭',
   searchNoResults: '没有匹配的会话',
 };


### PR DESCRIPTION
## Related Issue

No linked issue. This fixes a platform-specific shortcut label bug in the web sidebar.

## Problem

The session search entry showed `⌘K` on Windows even though the shortcut users press there is `Ctrl K`.

## What changed

- Detect the client shortcut platform in the sidebar and render `⌘K` only on Apple platforms.
- Render `Ctrl K` on Windows and other non-Apple platforms while keeping the existing Cmd/Ctrl+K handler behavior.
- Added a patch changeset for the bundled web UI change.

## Verification

- `git diff --check`
- `node apps/kimi-web/scripts/check-style.mjs` (passes in baseline mode; reports existing baseline findings)
- Typecheck was not runnable in this environment: repo requires Node `>=24.15.0`, while system Node is `v24.1.0` and bundled Node is `v24.14.0`.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [ ] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.