### PR TITLE
fix(kimi-code): reject malformed server CLI numbers

### DIFF
--- a/.changeset/strict-server-cli-numbers.md
+++ b/.changeset/strict-server-cli-numbers.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Reject malformed numeric values for server CLI options instead of accepting partial decimal prefixes.

--- a/apps/kimi-code/src/cli/sub/server/shared.ts
+++ b/apps/kimi-code/src/cli/sub/server/shared.ts
@@ -129,10 +129,16 @@ function parseHost(raw: string | boolean | undefined): string {
   return raw;
 }
 
+function parseDecimalInteger(raw: string): number | undefined {
+  if (!/^\d+$/.test(raw)) return undefined;
+  const n = Number(raw);
+  return Number.isSafeInteger(n) ? n : undefined;
+}
+
 function parseIdleGraceMs(raw: string | undefined): number {
   if (raw === undefined) return DEFAULT_IDLE_GRACE_MS;
-  const n = Number.parseInt(raw, 10);
-  if (!Number.isFinite(n) || n < 0) {
+  const n = parseDecimalInteger(raw);
+  if (n === undefined) {
     throw new Error(`error: invalid --idle-grace-ms value: ${raw}`);
   }
   return n;
@@ -140,8 +146,8 @@ function parseIdleGraceMs(raw: string | undefined): number {
 
 export function parsePort(raw: string | undefined, label: string, fallback: number): number {
   if (raw === undefined) return fallback;
-  const n = Number.parseInt(raw, 10);
-  if (!Number.isFinite(n) || n < 0 || n > 65535) {
+  const n = parseDecimalInteger(raw);
+  if (n === undefined || n > 65535) {
     throw new Error(`error: invalid ${label} value: ${raw}`);
   }
   return n;

--- a/apps/kimi-code/test/cli/server/server.test.ts
+++ b/apps/kimi-code/test/cli/server/server.test.ts
@@ -663,6 +663,27 @@ describe('shared parsers stay strict', () => {
     expect(parsePort('8080', '--port', 58627)).toBe(8080);
   });
 
+  it('rejects --port values that are not complete decimal integers', async () => {
+    const { parsePort } = await import('#/cli/sub/server/shared');
+    expect(() => parsePort('123abc', '--port', 58627)).toThrow(/invalid --port/);
+    expect(() => parsePort('1.5', '--port', 58627)).toThrow(/invalid --port/);
+    expect(() => parsePort('10ms', '--port', 58627)).toThrow(/invalid --port/);
+  });
+
+  it('rejects --idle-grace-ms values that are not complete decimal integers', async () => {
+    const { parseServerOptions } = await import('#/cli/sub/server/shared');
+    expect(() => parseServerOptions({ idleGraceMs: '123abc' })).toThrow(
+      /invalid --idle-grace-ms/,
+    );
+    expect(() => parseServerOptions({ idleGraceMs: '1.5' })).toThrow(
+      /invalid --idle-grace-ms/,
+    );
+    expect(() => parseServerOptions({ idleGraceMs: '10ms' })).toThrow(
+      /invalid --idle-grace-ms/,
+    );
+    expect(parseServerOptions({ idleGraceMs: '1000' }).idleGraceMs).toBe(1000);
+  });
+
   it('rejects unknown --log-level values', async () => {
     const { parseLogLevel } = await import('#/cli/sub/server/shared');
     expect(() => parseLogLevel('shout')).toThrow(/invalid --log-level/);


### PR DESCRIPTION
<!--
Thank you for your contribution to Kimi Code!
Please open an issue before sending a feature PR — PRs without prior discussion may be closed without review.

See https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md for more.
-->

## Related Issue

No linked issue; this is a focused, reproducible CLI parser bug fix.

## Problem

`kimi server run --port <port>` and the shared internal server option parser accepted numeric values through `Number.parseInt(raw, 10)`. That is a poor fit for CLI option validation because `parseInt` is a prefix parser, not a strict decimal-integer validator: once it has read a valid numeric prefix, it stops at the first non-digit character and returns the prefix instead of rejecting the whole input.

As a result, malformed values could be silently accepted:

```text
123abc -> 123
1.5    -> 1
10ms   -> 10
```

For server options, that behavior is surprising and potentially risky. A user who mistypes a port or idle grace value would not get feedback that the input is invalid; the server could instead start with a different value than the one the user intended. This is especially visible for `--port`, where a malformed value can still pass the later port-range check after being truncated, and for `--idle-grace-ms`, where a time-like suffix such as `10ms` looks readable but is reduced to `10`.

The shared parser is also used below the direct CLI entry point, so this is not only a display or help-text issue. The loose conversion happens before the rest of the server option object is built, which means downstream server lifecycle code receives a normalized number and cannot distinguish a genuinely valid integer from a partially parsed malformed string.

The expected behavior for these server numeric options is stricter: either the entire input is a decimal integer, or the option should be rejected. That keeps CLI typos visible, preserves the existing valid cases such as `8080` and `1000`, and avoids treating unit suffixes, decimals, or mixed strings as valid configuration.

## What changed

- Added a shared complete-decimal-integer parser for server CLI numeric options.
- Updated `parsePort` and `parseIdleGraceMs` to reject values unless the entire input is decimal digits and fits a safe integer.
- Preserved existing defaults, valid integer inputs, and the `--port` range check.
- Added focused parser tests for malformed `--port` and `--idle-grace-ms` values.

Validation run locally:

```text
corepack pnpm --filter @moonshot-ai/kimi-code exec vitest run test/cli/server/server.test.ts -t "shared parsers stay strict"
corepack pnpm --filter @moonshot-ai/kimi-code exec vitest run test/cli/server/server.test.ts
git diff --check
```

Note: local install used `ELECTRON_SKIP_BINARY_DOWNLOAD=1` / `ELECTRON_SKIP_DOWNLOAD=1` because the unrelated Electron postinstall binary download hit `ECONNRESET`; this parser test path does not require the Electron binary.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.

