### PR TITLE
fix(kimi-code): format IPv6 server origins correctly

### DIFF
--- a/.changeset/server-ipv6-origin.md
+++ b/.changeset/server-ipv6-origin.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Format IPv6 server host literals with brackets when building server origins.

--- a/apps/kimi-code/src/cli/sub/server/shared.ts
+++ b/apps/kimi-code/src/cli/sub/server/shared.ts
@@ -10,6 +10,8 @@ import { join } from 'node:path';
 
 import type { ServerLogLevel } from '@moonshot-ai/server';
 
+import { formatHostForUrl } from './networks';
+
 export const LOCAL_SERVER_HOST = '127.0.0.1';
 export const DEFAULT_LAN_HOST = '0.0.0.0';
 export const DEFAULT_SERVER_HOST = LOCAL_SERVER_HOST;
@@ -158,7 +160,11 @@ export function parseLogLevel(raw: string | undefined): ServerLogLevel {
 }
 
 export function serverOrigin(host: string, port: number): string {
-  return `http://${host}:${port}`;
+  const formattedHost =
+    host.startsWith('[') && host.endsWith(']')
+      ? host
+      : formatHostForUrl(host, host.includes(':') ? 'IPv6' : 'IPv4');
+  return `http://${formattedHost}:${port}`;
 }
 
 /** Strip `/api/v1` and trailing slashes so user-supplied origins are uniform. */

--- a/apps/kimi-code/test/cli/server/server.test.ts
+++ b/apps/kimi-code/test/cli/server/server.test.ts
@@ -669,6 +669,13 @@ describe('shared parsers stay strict', () => {
     expect(parseLogLevel(undefined)).toBe('info');
     expect(parseLogLevel('debug')).toBe('debug');
   });
+
+  it('wraps IPv6 hosts when formatting server origins', async () => {
+    const { serverOrigin } = await import('#/cli/sub/server/shared');
+    expect(serverOrigin('::1', 58627)).toBe('http://[::1]:58627');
+    expect(serverOrigin('127.0.0.1', 58627)).toBe('http://127.0.0.1:58627');
+    expect(serverOrigin('[::1]', 58627)).toBe('http://[::1]:58627');
+  });
 });
 
 describe('server web asset directory resolution', () => {


### PR DESCRIPTION
<!--
Thank you for your contribution to Kimi Code!
Please open an issue before sending a feature PR — PRs without prior discussion may be closed without review.

See https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md for more.
-->

## Related Issue

No linked issue; this is a focused, reproducible CLI server URL formatting bug fix.

## Problem

`serverOrigin(host, port)` builds the shared server origin used by multiple `kimi server` subcommands. It currently interpolates the host directly into a URL string:

```ts
`http://${host}:${port}`
```

That works for IPv4 addresses and hostnames, but it produces an invalid URL for IPv6 literal hosts. IPv6 addresses contain `:` characters, so a raw value such as `::1` conflicts with the URL's `host:port` separator:

```text
serverOrigin('::1', 58627)
// before: http://::1:58627
// expected: http://[::1]:58627
```

This is not just a display issue. `serverOrigin()` is shared by server lifecycle, daemon, status, kill, and health-check paths, so a malformed origin can be passed into `new URL(...)` / fetch-style call sites that require bracketed IPv6 host literals.

The behavior should match URL syntax and the existing server access URL formatter: IPv6 literal hosts must be wrapped in brackets, while IPv4 addresses and hostnames should remain unchanged.

## What changed

- Updated `serverOrigin()` to format IPv6 hosts with the existing `formatHostForUrl()` helper.
- Preserved already-bracketed IPv6 hosts so they are not double-wrapped.
- Preserved IPv4 and hostname output unchanged.
- Added focused tests for raw IPv6, already-bracketed IPv6, and IPv4 server origins.
- Added a patch changeset for `@moonshot-ai/kimi-code`.

Validation run locally:

```text
node -e "for (const u of ['http://::1:58627','http://[::1]:58627']) { try { console.log(u + ' -> ' + new URL(u).href) } catch (e) { console.log(u + ' -> ' + e.name + ': ' + e.message) } }"
corepack pnpm --filter @moonshot-ai/kimi-code exec vitest run test/cli/server/server.test.ts -t "wraps IPv6 hosts when formatting server origins"
corepack pnpm --filter @moonshot-ai/kimi-code exec vitest run test/cli/server/server.test.ts
git diff --check
```

Observed URL-construction proof:

```text
http://::1:58627 -> TypeError: Invalid URL
http://[::1]:58627 -> http://[::1]:58627/
```

Note: local validation used `ELECTRON_SKIP_BINARY_DOWNLOAD=1` / `ELECTRON_SKIP_DOWNLOAD=1`; this parser/URL formatting test path does not require the Electron binary.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.