### PR TITLE
fix(kimi-code): encode server token fragments

### DIFF
--- a/.changeset/encode-token-fragments.md
+++ b/.changeset/encode-token-fragments.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Encode server Web UI token fragments before adding them to openable URLs.

--- a/apps/kimi-code/src/cli/sub/server/access-urls.ts
+++ b/apps/kimi-code/src/cli/sub/server/access-urls.ts
@@ -16,7 +16,7 @@ import { formatHostForUrl, listNetworkAddresses, type NetworkAddress } from './n
  */
 export function buildOpenableUrl(bareOrigin: string, token: string | undefined): string {
   const base = bareOrigin.endsWith('/') ? bareOrigin.slice(0, -1) : bareOrigin;
-  return token === undefined ? `${base}/` : `${base}/#token=${token}`;
+  return token === undefined ? `${base}/` : `${base}/#token=${encodeURIComponent(token)}`;
 }
 
 /**

--- a/apps/kimi-code/src/tui/commands/web.ts
+++ b/apps/kimi-code/src/tui/commands/web.ts
@@ -88,5 +88,5 @@ export async function handleWebCommand(host: SlashCommandHost): Promise<void> {
  */
 export function webSessionUrl(origin: string, sessionId: string, token?: string): string {
   const base = `${origin.replace(/\/+$/, '')}/sessions/${encodeURIComponent(sessionId)}`;
-  return token === undefined ? base : `${base}#token=${token}`;
+  return token === undefined ? base : `${base}#token=${encodeURIComponent(token)}`;
 }

--- a/apps/kimi-code/test/cli/server/server.test.ts
+++ b/apps/kimi-code/test/cli/server/server.test.ts
@@ -1585,6 +1585,14 @@ describe('buildWebUrl', () => {
     expect(parsed.search).not.toContain('abc123');
   });
 
+  it('encodes token fragment values before Web UI parsing', async () => {
+    const { buildWebUrl } = await import('#/cli/sub/server/run');
+    const token = 'a&b a%20b #token';
+    const url = buildWebUrl('http://127.0.0.1:58627', token);
+    expect(url).toBe(`http://127.0.0.1:58627/#token=${encodeURIComponent(token)}`);
+    expect(new URLSearchParams(new URL(url).hash.slice(1)).get('token')).toBe(token);
+  });
+
   it('normalizes a trailing slash', async () => {
     const { buildWebUrl } = await import('#/cli/sub/server/run');
     expect(buildWebUrl('http://127.0.0.1:58627/', 't')).toBe(
@@ -1610,6 +1618,18 @@ describe('accessUrlLines', () => {
     const lines = accessUrlLines('127.0.0.1', 58627, 'tok');
     expect(lines).toEqual([
       { label: 'Local:    ', url: 'http://127.0.0.1:58627/#token=tok' },
+    ]);
+  });
+
+  it('encodes token fragments in access URL lines', async () => {
+    const { accessUrlLines } = await import('#/cli/sub/server/access-urls');
+    const token = 'a&b%20c';
+    const lines = accessUrlLines('127.0.0.1', 58627, token);
+    expect(lines).toEqual([
+      {
+        label: 'Local:    ',
+        url: `http://127.0.0.1:58627/#token=${encodeURIComponent(token)}`,
+      },
     ]);
   });
 

--- a/apps/kimi-code/test/tui/commands/web.test.ts
+++ b/apps/kimi-code/test/tui/commands/web.test.ts
@@ -146,6 +146,15 @@ describe('webSessionUrl', () => {
     );
   });
 
+  it('encodes bearer token fragments so URLSearchParams can read them back', () => {
+    const token = 'a&b a%20b #token';
+    const url = webSessionUrl('http://127.0.0.1:58627', 'abc123', token);
+    expect(url).toBe(
+      `http://127.0.0.1:58627/sessions/abc123#token=${encodeURIComponent(token)}`,
+    );
+    expect(new URLSearchParams(new URL(url).hash.slice(1)).get('token')).toBe(token);
+  });
+
   it('omits the fragment when no token is available', () => {
     expect(webSessionUrl('http://127.0.0.1:58627', 'abc123', undefined)).toBe(
       'http://127.0.0.1:58627/sessions/abc123',


### PR DESCRIPTION
<!--
Thank you for your contribution to Kimi Code!
Please open an issue before sending a feature PR — PRs without prior discussion may be closed without review.

See https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md for more.
-->

## Related Issue

No linked issue; this is a focused, reproducible Web UI token-fragment URL bug fix.

## Problem

The server Web UI URLs carry the persistent server token in a client-side fragment:

```text
#token=<token>
```

That keeps the token out of HTTP requests and server logs, but the token value still has to be URL-encoded before it is inserted into the fragment. The Web UI reads the fragment with `new URLSearchParams(hash.slice(1))`, which treats `&` as a parameter separator and decodes percent-encoded sequences while parsing.

Today, the CLI and TUI `/web` deep-link helpers append the raw token value:

```ts
`#token=${token}`
```

That means tokens containing URL parameter delimiters or percent-like sequences can be read back incorrectly by the Web UI. For example:

```text
a&b   | raw=a   | encoded=a&b
a%20b | raw=a b | encoded=a%20b
a%26b | raw=a&b | encoded=a%26b
```

The desktop entry point already encodes this same `#token=` fragment, so the CLI and TUI URL builders should follow the same boundary: put an encoded fragment value in the URL, then let the Web UI's existing `URLSearchParams` parser decode it back to the original token.

## What changed

- Encoded token fragment values in server openable URLs built by `buildOpenableUrl()`.
- Encoded token fragment values in `/web` session deep links built by `webSessionUrl()`.
- Preserved existing output for simple ASCII tokens such as `tok-1`.
- Added regression tests proving special-character tokens round-trip through `URLSearchParams`.
- Added a patch changeset for `@moonshot-ai/kimi-code`.

Validation run locally:

```text
node -e "const parse=(url)=>new URLSearchParams(new URL(url).hash.slice(1)).get('token'); for (const token of ['a&b','a%20b','a%26b','abc#def']) { const raw=`http://localhost:58627/#token=${token}`; const encoded=`http://localhost:58627/#token=${encodeURIComponent(token)}`; console.log(`${token} | raw=${parse(raw)} | encoded=${parse(encoded)}`); }"
corepack pnpm --filter @moonshot-ai/kimi-code exec vitest run test/cli/server/server.test.ts -t "token fragment"
corepack pnpm --filter @moonshot-ai/kimi-code exec vitest run test/tui/commands/web.test.ts
corepack pnpm --filter @moonshot-ai/kimi-code exec vitest run test/cli/server/server.test.ts
git diff --check
```

Results:

```text
targeted server token tests: 1 file passed, 4 tests passed, 85 skipped
TUI web tests: 1 file passed, 9 tests passed
full server test: 1 file passed, 89 tests passed
git diff --check: passed
```

Note: local validation used `ELECTRON_SKIP_BINARY_DOWNLOAD=1` / `ELECTRON_SKIP_DOWNLOAD=1`; these CLI/TUI URL tests do not require the Electron binary.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.