### PR TITLE
fix(web): keep Sidebar single-root so collapse hides it

### DIFF
--- a/.changeset/fix-sidebar-collapse-single-root.md
+++ b/.changeset/fix-sidebar-collapse-single-root.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+web: Fix the collapsed sidebar not hiding and squeezing the conversation layout.

--- a/apps/kimi-web/src/components/Sidebar.vue
+++ b/apps/kimi-web/src/components/Sidebar.vue
@@ -752,10 +752,13 @@ onBeforeUnmount(() => {
       @select="onSelectSession"
       @close="showSearch = false"
     />
+    <!-- Keep inside <aside>: a top-level <Teleport> makes Sidebar multi-root,
+         which breaks v-show on the host (Vue can't apply display:none to a
+         Fragment). Teleport still renders to body regardless of placement. -->
+    <Teleport to="body">
+      <DesignSystemView v-if="showDesignSystem" @close="showDesignSystem = false" />
+    </Teleport>
   </aside>
-  <Teleport to="body">
-    <DesignSystemView v-if="showDesignSystem" @close="showDesignSystem = false" />
-  </Teleport>
 </template>
 
 <style scoped>


### PR DESCRIPTION
## Related Issue

No linked issue — reported and fixed directly from the web UI.

## Problem

Collapsing the sidebar in the web UI left it mounted at the rail width instead of hiding it, so the session list got squashed into a narrow column of clipped icons and the conversation pane was pushed aside. Root cause: a top-level `<Teleport>` in the sidebar template made the component multi-root, so `v-show` could not apply `display:none` to a Fragment and silently did nothing.

## What changed

Moved the teleport inside the sidebar `<aside>` so the component is single-root again and `v-show` hides it correctly on collapse. The teleported overlay still renders to `body`, so its behavior is unchanged. Changeset included.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [ ] I have added tests that prove my feature works. (N/A — single-root structural fix; verified by collapsing the sidebar in the UI.)
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.
