### PR TITLE
fix(web): reconcile session from snapshot on reopen

### DIFF
--- a/.changeset/fix-web-reopen-reconcile.md
+++ b/.changeset/fix-web-reopen-reconcile.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+web: Fix the end of a reply staying missing after reopening a session.

--- a/apps/kimi-web/src/composables/client/useWorkspaceState.ts
+++ b/apps/kimi-web/src/composables/client/useWorkspaceState.ts
@@ -972,10 +972,9 @@ export function useWorkspaceState(rawState: ExtendedState, deps: UseWorkspaceSta
         const result = await syncSessionFromSnapshot(sessionId);
         if (result === 'not-found') return;
       } else {
-        // Re-open: if the session was evicted from the subscription cap since
-        // last open, reopenSession rebuilds it from a snapshot (the kept cursor
-        // may have skipped per-session events); otherwise it re-subscribes from
-        // the tracked cursor and the daemon replays any missed durable events.
+        // Re-open: rebuild from a fresh snapshot rather than resuming from the
+        // tracked cursor — the daemon only replays durable events, so volatile
+        // streamed deltas lost to a WS hiccup would otherwise stay missing.
         const result = await reopenSession(sessionId);
         if (result === 'not-found') return;
       }

--- a/apps/kimi-web/src/composables/client/useWorkspaceState.ts
+++ b/apps/kimi-web/src/composables/client/useWorkspaceState.ts
@@ -122,7 +122,7 @@ export interface UseWorkspaceStateDeps {
   ) => void;
   nextOptimisticMsgId: () => string;
   getEventConn: () => KimiEventConnection | null;
-  syncSessionFromSnapshot: (sessionId: string) => Promise<SyncSessionResult>;
+  syncSessionFromSnapshot: (sessionId: string, opts?: { force?: boolean }) => Promise<SyncSessionResult>;
   reopenSession: (sessionId: string) => Promise<SyncSessionResult>;
   hasLoadedMessages: (sessionId: string) => boolean;
   refreshSessionStatus: (sessionId: string) => Promise<void>;
@@ -1762,7 +1762,7 @@ export function useWorkspaceState(rawState: ExtendedState, deps: UseWorkspaceSta
     })();
     try {
       await getKimiWebApi().undoSession(sid, count);
-      await syncSessionFromSnapshot(sid);
+      await syncSessionFromSnapshot(sid, { force: true });
       return lastUserText;
     } catch (err) {
       pushOperationFailure('undo', err, { sessionId: sid });

--- a/apps/kimi-web/src/composables/client/useWorkspaceState.ts
+++ b/apps/kimi-web/src/composables/client/useWorkspaceState.ts
@@ -122,7 +122,7 @@ export interface UseWorkspaceStateDeps {
   ) => void;
   nextOptimisticMsgId: () => string;
   getEventConn: () => KimiEventConnection | null;
-  syncSessionFromSnapshot: (sessionId: string, opts?: { force?: boolean }) => Promise<SyncSessionResult>;
+  syncSessionFromSnapshot: (sessionId: string) => Promise<SyncSessionResult>;
   reopenSession: (sessionId: string) => Promise<SyncSessionResult>;
   hasLoadedMessages: (sessionId: string) => boolean;
   refreshSessionStatus: (sessionId: string) => Promise<void>;
@@ -1762,7 +1762,7 @@ export function useWorkspaceState(rawState: ExtendedState, deps: UseWorkspaceSta
     })();
     try {
       await getKimiWebApi().undoSession(sid, count);
-      await syncSessionFromSnapshot(sid, { force: true });
+      await syncSessionFromSnapshot(sid);
       return lastUserText;
     } catch (err) {
       pushOperationFailure('undo', err, { sessionId: sid });

--- a/apps/kimi-web/src/composables/useKimiWebClient.ts
+++ b/apps/kimi-web/src/composables/useKimiWebClient.ts
@@ -1118,41 +1118,10 @@ async function pullSessionWarnings(sessionId: string): Promise<void> {
   }
 }
 
-async function syncSessionFromSnapshot(
-  sessionId: string,
-  opts?: { force?: boolean },
-): Promise<SyncSessionResult> {
-  // Preconditions captured before the await, used to detect an optimistic send
-  // or prompt change that appears while the snapshot is in flight (see guard
-  // below).
-  const promptBefore = rawState.promptIdBySession[sessionId];
-  const inFlightBefore = inFlightPromptSessions.has(sessionId);
-  const wasLoaded = hasLoadedMessages(sessionId);
+async function syncSessionFromSnapshot(sessionId: string): Promise<SyncSessionResult> {
   try {
     const api = getKimiWebApi();
     const snap = await api.getSessionSnapshot(sessionId);
-
-    // Staleness guard, scoped to the re-open path (session already loaded AND
-    // not evicted from the subscription cap): there the composer stays usable, so
-    // a send can race this GET — replacing messages with a snapshot whose
-    // `asOfSeq` predates newer local state would wipe a live turn (volatile
-    // deltas are not replayable) or the just-sent optimistic user message.
-    //   - seq: discard only when the LOCAL cursor is ahead of `snap.asOfSeq` —
-    //     a durable event that raced the GET but is already included in the
-    //     snapshot must not cancel the install (that would skip the repair this
-    //     path exists for).
-    //   - prompt / optimistic send: a submission that started mid-fetch is not
-    //     in the snapshot yet, so discard.
-    // First opens always install + subscribe, even if events advanced lastSeq
-    // during the await; an evicted session is already unsubscribed, so it must
-    // always rebuild + re-subscribe; and a forced resync (delta-gap recovery) or
-    // post-undo sync must always apply the authoritative snapshot. When
-    // discarded, the live stream / next re-open reconciles.
-    if (!opts?.force && wasLoaded && !sessionsWithStaleCursor.has(sessionId)) {
-      if ((rawState.lastSeqBySession[sessionId] ?? 0) > snap.asOfSeq) return 'ok';
-      if (rawState.promptIdBySession[sessionId] !== promptBefore) return 'ok';
-      if (inFlightPromptSessions.has(sessionId) !== inFlightBefore) return 'ok';
-    }
 
     // Drain any queued streaming deltas before the snapshot replaces
     // messagesBySession[sessionId]. The snapshot is authoritative (it already
@@ -1226,11 +1195,7 @@ async function syncSessionFromSnapshot(
   }
 }
 
-// Resync (delta-gap recovery) must always apply the authoritative snapshot, so
-// it bypasses the staleness guard that only the re-open path needs.
-const snapshotSyncRunner = createCoalescedAsyncRunner((sid) =>
-  syncSessionFromSnapshot(sid, { force: true }),
-);
+const snapshotSyncRunner = createCoalescedAsyncRunner(syncSessionFromSnapshot);
 
 function hasLoadedMessages(sessionId: string): boolean {
   return Object.prototype.hasOwnProperty.call(rawState.messagesBySession, sessionId);
@@ -1295,31 +1260,18 @@ function dropWsSubscription(sessionId: string): void {
   sessionsWithStaleCursor.delete(sessionId);
 }
 
-/** Re-open an already-loaded session: rebuild from a fresh snapshot.
+/** Re-open an already-loaded session: always rebuild from a fresh snapshot.
  *
  *  Volatile `assistant.delta` frames are never journaled or replayed: if a
  *  transport hiccup covered the tail of a turn while the user was away, the
  *  local transcript silently lost the model's final text, and a cursor
- *  resubscribe has nothing to recover it with. Fetching the authoritative
- *  snapshot on every re-open keeps the logic trivially correct (no freshness
- *  heuristics); the snapshot is cheap server-side (LRU on the wire file), and
- *  the staleness guard inside syncSessionFromSnapshot discards the fetched
- *  snapshot if newer local activity (a send / live events) raced the GET.
- *
- *  Exception: a RUNNING session that is still subscribed keeps its live stream.
- *  Rebuilding mid-stream can drop volatile deltas that arrived after the
- *  snapshot was assembled (queued deltas are flushed onto the old transcript and
- *  then overwritten, with no replay path). The live stream is already feeding
- *  this session; any lost tail is repaired on the next idle re-open. Evicted
- *  sessions are NOT exempt — they have no live stream, so the snapshot (with its
- *  seeded in-flight turn) is strictly better than staying unsubscribed. */
+ *  resubscribe has nothing to recover it with. Always fetching the authoritative
+ *  snapshot keeps the logic trivially correct (no freshness heuristics, no
+ *  races to reason about); the snapshot is cheap server-side (LRU on the wire
+ *  file). Trade-off: a snapshot GET in flight during a steep local send can
+ *  momentarily overwrite that optimistic message — the user notices immediately
+ *  and the next re-open (or a refresh) reconciles. */
 async function reopenSession(sessionId: string): Promise<SyncSessionResult> {
-  const running =
-    rawState.sessions.find((s) => s.id === sessionId)?.status === 'running' ||
-    inFlightPromptSessions.has(sessionId);
-  if (running && !sessionsWithStaleCursor.has(sessionId)) {
-    return 'ok';
-  }
   return syncSessionFromSnapshot(sessionId);
 }
 

--- a/apps/kimi-web/src/composables/useKimiWebClient.ts
+++ b/apps/kimi-web/src/composables/useKimiWebClient.ts
@@ -13,6 +13,7 @@ import {
   type WorkspaceSortMode,
 } from '../lib/workspaceOrder';
 import { mergeWorkspaces } from '../lib/mergeWorkspaces';
+import { mergeSnapshotMessages } from '../lib/snapshotMessages';
 import { createCoalescedAsyncRunner } from '../lib/snapshotSync';
 import {
   loadUnread,
@@ -1137,7 +1138,12 @@ async function syncSessionFromSnapshot(sessionId: string): Promise<SyncSessionRe
           ? snap.session.model
           : s.model,
     }));
-    setSessionMessages(sessionId, snap.messages);
+    // The snapshot only carries the most recent page; keep any older pages the
+    // user already loaded so reopening does not reset scrollback.
+    setSessionMessages(
+      sessionId,
+      mergeSnapshotMessages(rawState.messagesBySession[sessionId] ?? [], snap.messages),
+    );
     rawState.messagesHasMoreBySession = {
       ...rawState.messagesHasMoreBySession,
       [sessionId]: snap.hasMoreMessages,

--- a/apps/kimi-web/src/composables/useKimiWebClient.ts
+++ b/apps/kimi-web/src/composables/useKimiWebClient.ts
@@ -1125,7 +1125,10 @@ async function pullSessionWarnings(sessionId: string): Promise<void> {
   }
 }
 
-async function syncSessionFromSnapshot(sessionId: string): Promise<SyncSessionResult> {
+async function syncSessionFromSnapshot(
+  sessionId: string,
+  opts?: { force?: boolean },
+): Promise<SyncSessionResult> {
   // Preconditions captured before the await, used to detect a newer local
   // prompt/seq or optimistic send that appears while the snapshot is in flight
   // (see guard below).
@@ -1143,10 +1146,12 @@ async function syncSessionFromSnapshot(sessionId: string): Promise<SyncSessionRe
     // whose `asOfSeq` predates newer local state — replacing messages would wipe a
     // live turn (volatile deltas are not replayable) or the just-sent optimistic
     // user message. On first open we must always install + subscribe, even if a
-    // global event advanced lastSeq during the await; and an evicted session is
-    // already unsubscribed, so it must always rebuild + re-subscribe here instead
-    // of discarding. When discarded, the live stream / next re-open reconciles.
-    if (wasLoaded && !sessionsWithStaleCursor.has(sessionId)) {
+    // global event advanced lastSeq during the await; an evicted session is
+    // already unsubscribed, so it must always rebuild + re-subscribe; and a forced
+    // resync (delta-gap recovery) must always apply the authoritative snapshot,
+    // even though the triggering cursor advance is exactly what the guard watches.
+    // When discarded, the live stream / next re-open reconciles.
+    if (!opts?.force && wasLoaded && !sessionsWithStaleCursor.has(sessionId)) {
       if ((rawState.lastSeqBySession[sessionId] ?? 0) !== seqBefore) return 'ok';
       if (rawState.promptIdBySession[sessionId] !== promptBefore) return 'ok';
       if (inFlightPromptSessions.has(sessionId) !== inFlightBefore) return 'ok';
@@ -1225,7 +1230,11 @@ async function syncSessionFromSnapshot(sessionId: string): Promise<SyncSessionRe
   }
 }
 
-const snapshotSyncRunner = createCoalescedAsyncRunner(syncSessionFromSnapshot);
+// Resync (delta-gap recovery) must always apply the authoritative snapshot, so
+// it bypasses the staleness guard that only the re-open path needs.
+const snapshotSyncRunner = createCoalescedAsyncRunner((sid) =>
+  syncSessionFromSnapshot(sid, { force: true }),
+);
 
 function hasLoadedMessages(sessionId: string): boolean {
   return Object.prototype.hasOwnProperty.call(rawState.messagesBySession, sessionId);

--- a/apps/kimi-web/src/composables/useKimiWebClient.ts
+++ b/apps/kimi-web/src/composables/useKimiWebClient.ts
@@ -541,7 +541,6 @@ function forgetSession(sessionId: string): void {
   delete rawState.messagesHasMoreBySession[sessionId];
   delete rawState.messagesLoadMoreErrorBySession[sessionId];
   delete epochBySession[sessionId];
-  lastLoadedSeq.delete(sessionId);
   sessionsKnownEmpty.delete(sessionId);
   // In-flight / queued prompt state: drop these too so a queued follow-up
   // can't be submitted to a session that was just archived when its turn later
@@ -905,14 +904,6 @@ function connectEventsIfNeeded(): void {
 // reactive — only consulted when building the subscribe cursor.
 const epochBySession: Record<string, string> = {};
 
-// Durable `seq` (event journal offset) captured the last time we loaded this
-// session's messages from a snapshot. Compared on re-open to skip the snapshot
-// fetch + transcript remount when nothing durable happened since. Not reactive
-// — only read inside reopenSession. Preferred over `updatedAt`: every durable
-// event (including `turn.ended`, which does not bump `updatedAt`) advances seq,
-// so it can never miss a change that matters here.
-const lastLoadedSeq = new Map<string, number>();
-
 // Sessions created locally in this client instance are known to be empty until
 // they receive their first message. This is more reliable than the daemon's
 // messageCount field, which can be stale for old sessions and would otherwise
@@ -1205,7 +1196,6 @@ async function syncSessionFromSnapshot(
       [sessionId]: snap.asOfSeq,
     };
     epochBySession[sessionId] = snap.epoch;
-    lastLoadedSeq.set(sessionId, snap.asOfSeq);
 
     connectEventsIfNeeded();
     if (eventConn) {
@@ -1301,50 +1291,17 @@ function dropWsSubscription(sessionId: string): void {
   sessionsWithStaleCursor.delete(sessionId);
 }
 
-/** Re-subscribe to live events from the tracked cursor (cheap, no remount).
- *  Used on re-open when the session provably has not changed since we last
- *  loaded it, so there is nothing new to rebuild from a snapshot. */
-function resubscribeSessionEvents(sessionId: string): void {
-  connectEventsIfNeeded();
-  if (eventConn) {
-    // Apply any queued streaming deltas before re-subscribing so the transcript
-    // is current. (Volatile — never replayed by the server, but flushing here is
-    // cheap and future-proofs the cursor if the batching set ever changes.)
-    enqueueEvent.flush();
-    const seq = rawState.lastSeqBySession[sessionId] ?? 0;
-    const epoch = epochBySession[sessionId];
-    eventConn.subscribe(sessionId, { seq, epoch });
-    retainWsSubscription(sessionId);
-  }
-}
-
-/** Re-open an already-loaded session.
+/** Re-open an already-loaded session: always rebuild from a fresh snapshot.
  *
  *  Volatile `assistant.delta` frames are never journaled or replayed: if a
  *  transport hiccup covered the tail of a turn while the user was away, the
  *  local transcript silently lost the model's final text, and a cursor
- *  resubscribe has nothing to recover it with. So re-open must be able to
- *  rebuild from the authoritative snapshot.
- *
- *  But rebuilding on EVERY re-open remounts the transcript (scroll reset +
- *  entrance-animation replay) even when nothing changed — a daily annoyance.
- *  Gate on the durable event `seq` captured at the last snapshot load: every
- *  durable event (including `turn.ended`, which does NOT bump `updatedAt`)
- *  advances it, so unlike `updatedAt` it can never miss a content change —
- *  including a mid-turn snapshot followed by a lost tail whose reconnect replay
- *  is only `turn.ended`.
- *    - evicted subscription  → cursor untrustworthy, always rebuild;
- *    - seq unchanged         → cheap cursor resubscribe, no remount;
- *    - seq advanced          → rebuild from snapshot, restoring any lost tail. */
+ *  resubscribe has nothing to recover it with. Fetching the authoritative
+ *  snapshot on every re-open keeps the logic trivially correct (no freshness
+ *  heuristics); the snapshot is cheap server-side (LRU on the wire file), and
+ *  the staleness guard inside syncSessionFromSnapshot discards the fetched
+ *  snapshot if newer local activity (a send / live events) raced the GET. */
 async function reopenSession(sessionId: string): Promise<SyncSessionResult> {
-  if (sessionsWithStaleCursor.has(sessionId)) {
-    return syncSessionFromSnapshot(sessionId);
-  }
-  const currentSeq = rawState.lastSeqBySession[sessionId] ?? 0;
-  if (currentSeq === (lastLoadedSeq.get(sessionId) ?? 0)) {
-    resubscribeSessionEvents(sessionId);
-    return 'ok';
-  }
   return syncSessionFromSnapshot(sessionId);
 }
 

--- a/apps/kimi-web/src/composables/useKimiWebClient.ts
+++ b/apps/kimi-web/src/composables/useKimiWebClient.ts
@@ -1126,9 +1126,22 @@ async function pullSessionWarnings(sessionId: string): Promise<void> {
 }
 
 async function syncSessionFromSnapshot(sessionId: string): Promise<SyncSessionResult> {
+  // Preconditions captured before the await, used to detect a newer local
+  // prompt/seq that appears while the snapshot is in flight (see guard below).
+  const seqBefore = rawState.lastSeqBySession[sessionId] ?? 0;
+  const promptBefore = rawState.promptIdBySession[sessionId];
   try {
     const api = getKimiWebApi();
     const snap = await api.getSessionSnapshot(sessionId);
+
+    // Discard a snapshot that went stale because a newer local prompt/seq
+    // arrived while it was in flight. On the re-open path `sessionLoading` is
+    // false and the composer stays usable, so a send can race this GET: the
+    // snapshot's `asOfSeq` predates the new prompt, and replacing messages here
+    // would wipe a live turn whose volatile deltas are not replayable. The live
+    // stream will populate messages; a later re-open reconciles again if needed.
+    if ((rawState.lastSeqBySession[sessionId] ?? 0) !== seqBefore) return 'ok';
+    if (rawState.promptIdBySession[sessionId] !== promptBefore) return 'ok';
 
     // Drain any queued streaming deltas before the snapshot replaces
     // messagesBySession[sessionId]. The snapshot is authoritative (it already

--- a/apps/kimi-web/src/composables/useKimiWebClient.ts
+++ b/apps/kimi-web/src/composables/useKimiWebClient.ts
@@ -1122,10 +1122,9 @@ async function syncSessionFromSnapshot(
   sessionId: string,
   opts?: { force?: boolean },
 ): Promise<SyncSessionResult> {
-  // Preconditions captured before the await, used to detect a newer local
-  // prompt/seq or optimistic send that appears while the snapshot is in flight
-  // (see guard below).
-  const seqBefore = rawState.lastSeqBySession[sessionId] ?? 0;
+  // Preconditions captured before the await, used to detect an optimistic send
+  // or prompt change that appears while the snapshot is in flight (see guard
+  // below).
   const promptBefore = rawState.promptIdBySession[sessionId];
   const inFlightBefore = inFlightPromptSessions.has(sessionId);
   const wasLoaded = hasLoadedMessages(sessionId);
@@ -1135,17 +1134,22 @@ async function syncSessionFromSnapshot(
 
     // Staleness guard, scoped to the re-open path (session already loaded AND
     // not evicted from the subscription cap): there the composer stays usable, so
-    // a send or a broadcast global event can race this GET and produce a snapshot
-    // whose `asOfSeq` predates newer local state — replacing messages would wipe a
-    // live turn (volatile deltas are not replayable) or the just-sent optimistic
-    // user message. On first open we must always install + subscribe, even if a
-    // global event advanced lastSeq during the await; an evicted session is
-    // already unsubscribed, so it must always rebuild + re-subscribe; and a forced
-    // resync (delta-gap recovery) must always apply the authoritative snapshot,
-    // even though the triggering cursor advance is exactly what the guard watches.
-    // When discarded, the live stream / next re-open reconciles.
+    // a send can race this GET — replacing messages with a snapshot whose
+    // `asOfSeq` predates newer local state would wipe a live turn (volatile
+    // deltas are not replayable) or the just-sent optimistic user message.
+    //   - seq: discard only when the LOCAL cursor is ahead of `snap.asOfSeq` —
+    //     a durable event that raced the GET but is already included in the
+    //     snapshot must not cancel the install (that would skip the repair this
+    //     path exists for).
+    //   - prompt / optimistic send: a submission that started mid-fetch is not
+    //     in the snapshot yet, so discard.
+    // First opens always install + subscribe, even if events advanced lastSeq
+    // during the await; an evicted session is already unsubscribed, so it must
+    // always rebuild + re-subscribe; and a forced resync (delta-gap recovery) or
+    // post-undo sync must always apply the authoritative snapshot. When
+    // discarded, the live stream / next re-open reconciles.
     if (!opts?.force && wasLoaded && !sessionsWithStaleCursor.has(sessionId)) {
-      if ((rawState.lastSeqBySession[sessionId] ?? 0) !== seqBefore) return 'ok';
+      if ((rawState.lastSeqBySession[sessionId] ?? 0) > snap.asOfSeq) return 'ok';
       if (rawState.promptIdBySession[sessionId] !== promptBefore) return 'ok';
       if (inFlightPromptSessions.has(sessionId) !== inFlightBefore) return 'ok';
     }
@@ -1291,7 +1295,7 @@ function dropWsSubscription(sessionId: string): void {
   sessionsWithStaleCursor.delete(sessionId);
 }
 
-/** Re-open an already-loaded session: always rebuild from a fresh snapshot.
+/** Re-open an already-loaded session: rebuild from a fresh snapshot.
  *
  *  Volatile `assistant.delta` frames are never journaled or replayed: if a
  *  transport hiccup covered the tail of a turn while the user was away, the
@@ -1300,8 +1304,22 @@ function dropWsSubscription(sessionId: string): void {
  *  snapshot on every re-open keeps the logic trivially correct (no freshness
  *  heuristics); the snapshot is cheap server-side (LRU on the wire file), and
  *  the staleness guard inside syncSessionFromSnapshot discards the fetched
- *  snapshot if newer local activity (a send / live events) raced the GET. */
+ *  snapshot if newer local activity (a send / live events) raced the GET.
+ *
+ *  Exception: a RUNNING session that is still subscribed keeps its live stream.
+ *  Rebuilding mid-stream can drop volatile deltas that arrived after the
+ *  snapshot was assembled (queued deltas are flushed onto the old transcript and
+ *  then overwritten, with no replay path). The live stream is already feeding
+ *  this session; any lost tail is repaired on the next idle re-open. Evicted
+ *  sessions are NOT exempt — they have no live stream, so the snapshot (with its
+ *  seeded in-flight turn) is strictly better than staying unsubscribed. */
 async function reopenSession(sessionId: string): Promise<SyncSessionResult> {
+  const running =
+    rawState.sessions.find((s) => s.id === sessionId)?.status === 'running' ||
+    inFlightPromptSessions.has(sessionId);
+  if (running && !sessionsWithStaleCursor.has(sessionId)) {
+    return 'ok';
+  }
   return syncSessionFromSnapshot(sessionId);
 }
 

--- a/apps/kimi-web/src/composables/useKimiWebClient.ts
+++ b/apps/kimi-web/src/composables/useKimiWebClient.ts
@@ -541,7 +541,7 @@ function forgetSession(sessionId: string): void {
   delete rawState.messagesHasMoreBySession[sessionId];
   delete rawState.messagesLoadMoreErrorBySession[sessionId];
   delete epochBySession[sessionId];
-  lastLoadedUpdatedAt.delete(sessionId);
+  lastLoadedSeq.delete(sessionId);
   sessionsKnownEmpty.delete(sessionId);
   // In-flight / queued prompt state: drop these too so a queued follow-up
   // can't be submitted to a session that was just archived when its turn later
@@ -905,11 +905,13 @@ function connectEventsIfNeeded(): void {
 // reactive — only consulted when building the subscribe cursor.
 const epochBySession: Record<string, string> = {};
 
-// Session `updatedAt` (ISO string) captured the last time we loaded this
+// Durable `seq` (event journal offset) captured the last time we loaded this
 // session's messages from a snapshot. Compared on re-open to skip the snapshot
-// fetch + transcript remount when the session has not changed since. Not
-// reactive — only read inside reopenSession.
-const lastLoadedUpdatedAt = new Map<string, string>();
+// fetch + transcript remount when nothing durable happened since. Not reactive
+// — only read inside reopenSession. Preferred over `updatedAt`: every durable
+// event (including `turn.ended`, which does not bump `updatedAt`) advances seq,
+// so it can never miss a change that matters here.
+const lastLoadedSeq = new Map<string, number>();
 
 // Sessions created locally in this client instance are known to be empty until
 // they receive their first message. This is more reliable than the daemon's
@@ -1203,7 +1205,7 @@ async function syncSessionFromSnapshot(
       [sessionId]: snap.asOfSeq,
     };
     epochBySession[sessionId] = snap.epoch;
-    lastLoadedUpdatedAt.set(sessionId, snap.session.updatedAt);
+    lastLoadedSeq.set(sessionId, snap.asOfSeq);
 
     connectEventsIfNeeded();
     if (eventConn) {
@@ -1326,18 +1328,20 @@ function resubscribeSessionEvents(sessionId: string): void {
  *
  *  But rebuilding on EVERY re-open remounts the transcript (scroll reset +
  *  entrance-animation replay) even when nothing changed — a daily annoyance.
- *  The session `updatedAt` is a zero-fetch, always-fresh signal: it advances on
- *  the durable `turn.ended` at the latest, so it can never miss a content
- *  change that matters here. Gate on it:
+ *  Gate on the durable event `seq` captured at the last snapshot load: every
+ *  durable event (including `turn.ended`, which does NOT bump `updatedAt`)
+ *  advances it, so unlike `updatedAt` it can never miss a content change —
+ *  including a mid-turn snapshot followed by a lost tail whose reconnect replay
+ *  is only `turn.ended`.
  *    - evicted subscription  → cursor untrustworthy, always rebuild;
- *    - updatedAt unchanged   → cheap cursor resubscribe, no remount;
- *    - updatedAt advanced    → rebuild from snapshot, restoring any lost tail. */
+ *    - seq unchanged         → cheap cursor resubscribe, no remount;
+ *    - seq advanced          → rebuild from snapshot, restoring any lost tail. */
 async function reopenSession(sessionId: string): Promise<SyncSessionResult> {
   if (sessionsWithStaleCursor.has(sessionId)) {
     return syncSessionFromSnapshot(sessionId);
   }
-  const current = rawState.sessions.find((s) => s.id === sessionId)?.updatedAt;
-  if (current !== undefined && current === lastLoadedUpdatedAt.get(sessionId)) {
+  const currentSeq = rawState.lastSeqBySession[sessionId] ?? 0;
+  if (currentSeq === (lastLoadedSeq.get(sessionId) ?? 0)) {
     resubscribeSessionEvents(sessionId);
     return 'ok';
   }

--- a/apps/kimi-web/src/composables/useKimiWebClient.ts
+++ b/apps/kimi-web/src/composables/useKimiWebClient.ts
@@ -541,6 +541,7 @@ function forgetSession(sessionId: string): void {
   delete rawState.messagesHasMoreBySession[sessionId];
   delete rawState.messagesLoadMoreErrorBySession[sessionId];
   delete epochBySession[sessionId];
+  lastLoadedUpdatedAt.delete(sessionId);
   sessionsKnownEmpty.delete(sessionId);
   // In-flight / queued prompt state: drop these too so a queued follow-up
   // can't be submitted to a session that was just archived when its turn later
@@ -904,6 +905,12 @@ function connectEventsIfNeeded(): void {
 // reactive — only consulted when building the subscribe cursor.
 const epochBySession: Record<string, string> = {};
 
+// Session `updatedAt` (ISO string) captured the last time we loaded this
+// session's messages from a snapshot. Compared on re-open to skip the snapshot
+// fetch + transcript remount when the session has not changed since. Not
+// reactive — only read inside reopenSession.
+const lastLoadedUpdatedAt = new Map<string, string>();
+
 // Sessions created locally in this client instance are known to be empty until
 // they receive their first message. This is more reliable than the daemon's
 // messageCount field, which can be stale for old sessions and would otherwise
@@ -1169,6 +1176,7 @@ async function syncSessionFromSnapshot(sessionId: string): Promise<SyncSessionRe
       [sessionId]: snap.asOfSeq,
     };
     epochBySession[sessionId] = snap.epoch;
+    lastLoadedUpdatedAt.set(sessionId, snap.session.updatedAt);
 
     connectEventsIfNeeded();
     if (eventConn) {
@@ -1260,13 +1268,15 @@ function dropWsSubscription(sessionId: string): void {
   sessionsWithStaleCursor.delete(sessionId);
 }
 
-function subscribeToSessionEvents(sessionId: string): void {
+/** Re-subscribe to live events from the tracked cursor (cheap, no remount).
+ *  Used on re-open when the session provably has not changed since we last
+ *  loaded it, so there is nothing new to rebuild from a snapshot. */
+function resubscribeSessionEvents(sessionId: string): void {
   connectEventsIfNeeded();
   if (eventConn) {
     // Apply any queued streaming deltas before re-subscribing so the transcript
-    // is current. (These deltas are volatile — never replayed by the server and
-    // they don't advance lastSeqBySession — but flushing here is cheap and
-    // future-proofs the cursor if the batching set ever changes.)
+    // is current. (Volatile — never replayed by the server, but flushing here is
+    // cheap and future-proofs the cursor if the batching set ever changes.)
     enqueueEvent.flush();
     const seq = rawState.lastSeqBySession[sessionId] ?? 0;
     const epoch = epochBySession[sessionId];
@@ -1275,23 +1285,32 @@ function subscribeToSessionEvents(sessionId: string): void {
   }
 }
 
-/** Re-open an already-loaded session. If it was evicted from the subscription
- *  cap since it was last open, rebuild from a snapshot: resuming from the kept
- *  cursor would skip the per-session events that arrived while unsubscribed,
- *  and replaying from seq 0 would make the projector regenerate message ids and
- *  duplicate the already-loaded transcript. Otherwise just re-subscribe from the
- *  tracked cursor.
+/** Re-open an already-loaded session.
  *
- * The stale marker is only read here; `syncSessionFromSnapshot` clears it once
- * the snapshot succeeds. If the snapshot fails transiently the marker stays, so
- * the next re-open retries the snapshot instead of falling back to a cursor
- * that may have skipped events while unsubscribed. */
+ *  Volatile `assistant.delta` frames are never journaled or replayed: if a
+ *  transport hiccup covered the tail of a turn while the user was away, the
+ *  local transcript silently lost the model's final text, and a cursor
+ *  resubscribe has nothing to recover it with. So re-open must be able to
+ *  rebuild from the authoritative snapshot.
+ *
+ *  But rebuilding on EVERY re-open remounts the transcript (scroll reset +
+ *  entrance-animation replay) even when nothing changed — a daily annoyance.
+ *  The session `updatedAt` is a zero-fetch, always-fresh signal: it advances on
+ *  the durable `turn.ended` at the latest, so it can never miss a content
+ *  change that matters here. Gate on it:
+ *    - evicted subscription  → cursor untrustworthy, always rebuild;
+ *    - updatedAt unchanged   → cheap cursor resubscribe, no remount;
+ *    - updatedAt advanced    → rebuild from snapshot, restoring any lost tail. */
 async function reopenSession(sessionId: string): Promise<SyncSessionResult> {
   if (sessionsWithStaleCursor.has(sessionId)) {
     return syncSessionFromSnapshot(sessionId);
   }
-  subscribeToSessionEvents(sessionId);
-  return 'ok';
+  const current = rawState.sessions.find((s) => s.id === sessionId)?.updatedAt;
+  if (current !== undefined && current === lastLoadedUpdatedAt.get(sessionId)) {
+    resubscribeSessionEvents(sessionId);
+    return 'ok';
+  }
+  return syncSessionFromSnapshot(sessionId);
 }
 
 // ---------------------------------------------------------------------------

--- a/apps/kimi-web/src/composables/useKimiWebClient.ts
+++ b/apps/kimi-web/src/composables/useKimiWebClient.ts
@@ -1137,14 +1137,16 @@ async function syncSessionFromSnapshot(sessionId: string): Promise<SyncSessionRe
     const api = getKimiWebApi();
     const snap = await api.getSessionSnapshot(sessionId);
 
-    // Staleness guard, scoped to the re-open path (session already loaded):
-    // there the composer stays usable, so a send or a broadcast global event can
-    // race this GET and produce a snapshot whose `asOfSeq` predates newer local
-    // state — replacing messages would wipe a live turn (volatile deltas are not
-    // replayable) or the just-sent optimistic user message. On first open we must
-    // always install messages + subscribe, even if a global event advanced lastSeq
-    // during the await. When discarded, the live stream / next re-open reconciles.
-    if (wasLoaded) {
+    // Staleness guard, scoped to the re-open path (session already loaded AND
+    // not evicted from the subscription cap): there the composer stays usable, so
+    // a send or a broadcast global event can race this GET and produce a snapshot
+    // whose `asOfSeq` predates newer local state — replacing messages would wipe a
+    // live turn (volatile deltas are not replayable) or the just-sent optimistic
+    // user message. On first open we must always install + subscribe, even if a
+    // global event advanced lastSeq during the await; and an evicted session is
+    // already unsubscribed, so it must always rebuild + re-subscribe here instead
+    // of discarding. When discarded, the live stream / next re-open reconciles.
+    if (wasLoaded && !sessionsWithStaleCursor.has(sessionId)) {
       if ((rawState.lastSeqBySession[sessionId] ?? 0) !== seqBefore) return 'ok';
       if (rawState.promptIdBySession[sessionId] !== promptBefore) return 'ok';
       if (inFlightPromptSessions.has(sessionId) !== inFlightBefore) return 'ok';

--- a/apps/kimi-web/src/composables/useKimiWebClient.ts
+++ b/apps/kimi-web/src/composables/useKimiWebClient.ts
@@ -1127,21 +1127,28 @@ async function pullSessionWarnings(sessionId: string): Promise<void> {
 
 async function syncSessionFromSnapshot(sessionId: string): Promise<SyncSessionResult> {
   // Preconditions captured before the await, used to detect a newer local
-  // prompt/seq that appears while the snapshot is in flight (see guard below).
+  // prompt/seq or optimistic send that appears while the snapshot is in flight
+  // (see guard below).
   const seqBefore = rawState.lastSeqBySession[sessionId] ?? 0;
   const promptBefore = rawState.promptIdBySession[sessionId];
+  const inFlightBefore = inFlightPromptSessions.has(sessionId);
+  const wasLoaded = hasLoadedMessages(sessionId);
   try {
     const api = getKimiWebApi();
     const snap = await api.getSessionSnapshot(sessionId);
 
-    // Discard a snapshot that went stale because a newer local prompt/seq
-    // arrived while it was in flight. On the re-open path `sessionLoading` is
-    // false and the composer stays usable, so a send can race this GET: the
-    // snapshot's `asOfSeq` predates the new prompt, and replacing messages here
-    // would wipe a live turn whose volatile deltas are not replayable. The live
-    // stream will populate messages; a later re-open reconciles again if needed.
-    if ((rawState.lastSeqBySession[sessionId] ?? 0) !== seqBefore) return 'ok';
-    if (rawState.promptIdBySession[sessionId] !== promptBefore) return 'ok';
+    // Staleness guard, scoped to the re-open path (session already loaded):
+    // there the composer stays usable, so a send or a broadcast global event can
+    // race this GET and produce a snapshot whose `asOfSeq` predates newer local
+    // state — replacing messages would wipe a live turn (volatile deltas are not
+    // replayable) or the just-sent optimistic user message. On first open we must
+    // always install messages + subscribe, even if a global event advanced lastSeq
+    // during the await. When discarded, the live stream / next re-open reconciles.
+    if (wasLoaded) {
+      if ((rawState.lastSeqBySession[sessionId] ?? 0) !== seqBefore) return 'ok';
+      if (rawState.promptIdBySession[sessionId] !== promptBefore) return 'ok';
+      if (inFlightPromptSessions.has(sessionId) !== inFlightBefore) return 'ok';
+    }
 
     // Drain any queued streaming deltas before the snapshot replaces
     // messagesBySession[sessionId]. The snapshot is authoritative (it already

--- a/apps/kimi-web/src/lib/snapshotMessages.ts
+++ b/apps/kimi-web/src/lib/snapshotMessages.ts
@@ -1,0 +1,27 @@
+// apps/kimi-web/src/lib/snapshotMessages.ts
+// Merge an authoritative snapshot tail into already-loaded messages.
+//
+// The session snapshot returns only the most recent bounded page. After a user
+// has loaded older pages, replacing the whole message array with that tail would
+// drop the older prefix they already fetched and reset scrollback. Preserve any
+// loaded messages older than the snapshot window; the snapshot is authoritative
+// for its own window and replaces anything inside it.
+import type { AppMessage } from '../api/types';
+
+export function mergeSnapshotMessages(
+  loaded: AppMessage[],
+  snapshot: AppMessage[],
+): AppMessage[] {
+  if (snapshot.length === 0) return snapshot;
+  if (loaded.length === 0) return snapshot;
+
+  const earliestSnapshotMs = Date.parse(snapshot[0]!.createdAt);
+  if (Number.isNaN(earliestSnapshotMs)) return snapshot;
+
+  const older = loaded.filter((message) => {
+    const createdAtMs = Date.parse(message.createdAt);
+    return !Number.isNaN(createdAtMs) && createdAtMs < earliestSnapshotMs;
+  });
+
+  return older.length > 0 ? [...older, ...snapshot] : snapshot;
+}

--- a/apps/kimi-web/test/lib-logic.test.ts
+++ b/apps/kimi-web/test/lib-logic.test.ts
@@ -8,6 +8,7 @@ import { parseDiff } from '../src/lib/parseDiff';
 import { buildDiffLines } from '../src/lib/diffLines';
 import { buildEditDiffLines } from '../src/lib/toolDiff';
 import { createCoalescedAsyncRunner } from '../src/lib/snapshotSync';
+import { mergeSnapshotMessages } from '../src/lib/snapshotMessages';
 import { normalizeToolName, toolSummary } from '../src/lib/toolMeta';
 import {
   coerceThinkingForModel,
@@ -17,7 +18,7 @@ import {
   modelThinkingAvailability,
   segmentsFor,
 } from '../src/lib/modelThinking';
-import type { AppModel } from '../src/api/types';
+import type { AppMessage, AppModel } from '../src/api/types';
 import { resolveToolRenderer } from '../src/components/chat/tool-calls/toolRegistry';
 import AgentTool from '../src/components/chat/tool-calls/AgentTool.vue';
 import EditTool from '../src/components/chat/tool-calls/EditTool.vue';
@@ -367,5 +368,44 @@ describe('modelThinking', () => {
       expect(effortLabel('off')).toBe('Off');
       expect(effortLabel('xhigh')).toBe('Xhigh');
     });
+  });
+});
+
+describe('mergeSnapshotMessages', () => {
+  function msg(id: string, createdAt: string): AppMessage {
+    return { id, sessionId: 's1', role: 'assistant', content: [], createdAt };
+  }
+
+  it('keeps loaded messages older than the snapshot window', () => {
+    const loaded = [
+      msg('old-1', '2026-01-01T00:00:00.000Z'),
+      msg('old-2', '2026-01-02T00:00:00.000Z'),
+      msg('recent-live', '2026-01-03T00:00:00.000Z'),
+    ];
+    const snapshot = [
+      msg('m0', '2026-01-03T00:00:00.000Z'),
+      msg('m1', '2026-01-04T00:00:00.000Z'),
+    ];
+    expect(mergeSnapshotMessages(loaded, snapshot).map((m) => m.id)).toEqual([
+      'old-1',
+      'old-2',
+      'm0',
+      'm1',
+    ]);
+  });
+
+  it('returns the snapshot when there is no older loaded prefix', () => {
+    const loaded = [msg('recent-live', '2026-01-03T00:00:00.000Z')];
+    const snapshot = [
+      msg('m0', '2026-01-03T00:00:00.000Z'),
+      msg('m1', '2026-01-04T00:00:00.000Z'),
+    ];
+    expect(mergeSnapshotMessages(loaded, snapshot)).toBe(snapshot);
+  });
+
+  it('returns the snapshot when either side is empty', () => {
+    const snapshot = [msg('m0', '2026-01-03T00:00:00.000Z')];
+    expect(mergeSnapshotMessages([], snapshot)).toBe(snapshot);
+    expect(mergeSnapshotMessages(snapshot, [])).toEqual([]);
   });
 });


### PR DESCRIPTION
## Related Issue

No linked issue — the problem was reproduced live and is described below.

## Problem

The web client builds the live transcript from WebSocket events. Assistant text deltas are **volatile** frames: they are never journaled and never replayed after a reconnect (`packages/protocol/src/events.ts`). When a transport hiccup covers the **tail** of a turn — easy to hit during a swarm, where many subagents stream over the same socket — the projector's offset-based gap detection never fires (it needs a *later* delta to notice the hole), so the model's final report text is silently lost. The data is intact on disk and the server snapshot is authoritative, but the local transcript stayed broken forever: reopening the session only re-subscribed from the cursor, which has nothing to replay.

User-facing symptom: the end of a long reply is missing and stays missing even after switching away and back.

## What changed

Deliberately simple: **re-opening an already-loaded session refreshes it from a fresh server snapshot** (`reopenSession` → `syncSessionFromSnapshot`). The snapshot is cheap server-side (LRU keyed on the wire file's size/mtime), so going to the authoritative record is the most reliable way to recover from any lost-tail scenario.

One adjustment keeps this simple without a regression: the snapshot only carries the most recent message page, so applying it now **merges** into already-loaded messages — any older pages the user already fetched are preserved, and the snapshot is authoritative for its own window. This keeps scrollback intact while still repairing the latest turn tail.

Trade-off (accepted): a snapshot GET that returns during a live stream can briefly overwrite in-flight assistant delta text; the user notices immediately and a refresh or the next re-open reconciles.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works. — Added coverage for preserving already-loaded older messages when merging the snapshot tail.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update. — Reliability fix with no new user-facing behavior to document.
