### PR TITLE
fix(web): stop replaying the bubble entrance animation on session open

### DIFF
--- a/.changeset/fix-web-remove-bubble-anim.md
+++ b/.changeset/fix-web-remove-bubble-anim.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+web: Stop the chat history from replaying its entrance animation every time a session is opened.

--- a/apps/kimi-web/src/components/chat/ChatPane.vue
+++ b/apps/kimi-web/src/components/chat/ChatPane.vue
@@ -1258,12 +1258,10 @@ function isStreamingRenderBlock(turn: ChatTurn, block: { sourceIndex: number }):
   border-radius: var(--radius-xl) var(--radius-xl) var(--radius-sm) var(--radius-xl);
   padding: 11px 15px;
   box-shadow: var(--shc);
-  animation: kimi-bubble-in 0.24s ease-out both;
 }
 .a-msg {
   max-width: 100%;
   width: 100%;
-  animation: kimi-bubble-in 0.24s ease-out both;
 }
 
 /* ---- Inline queue: pending user messages at the tail of the transcript ----

--- a/apps/kimi-web/src/style.css
+++ b/apps/kimi-web/src/style.css
@@ -742,10 +742,6 @@ body {
 /* ---- Composer: permission pill, model menu, queue strip ---- */
 /* ---- Floating menus + status line ---- */
 /* ---- Entrance / micro keyframes (shared by component-scoped rules) ---- */
-@keyframes kimi-bubble-in {
-  from { opacity: 0; transform: translateY(6px); }
-  to { opacity: 1; transform: translateY(0); }
-}
 @keyframes kimi-card-in {
   from { opacity: 0; transform: translateY(8px) scale(0.995); }
   to { opacity: 1; transform: translateY(0) scale(1); }


### PR DESCRIPTION
## Related Issue

No linked issue — reported directly by a user; described below.

## Problem

Opening any session — even one with no new content — briefly re-played the chat bubble entrance animation (fade + 6px slide) on every visible message. Because `ChatPane` is keyed on the active session id, it remounts on every session switch, and the `kimi-bubble-in` animation on `.u-bub` / `.a-msg` replayed for the whole viewport. Since the viewport follows the bottom, this read as "the tail of the conversation deliberately re-streaming" on every entry. (Historical turns already disable markstream's typewriter reveal, so this is purely the CSS entrance animation, not a text re-stream.)

## What changed

Removed the `kimi-bubble-in` entrance animation from `.u-bub` and `.a-msg`, and deleted the now-unused `@keyframes`. Conversation history now renders statically when opening or switching sessions.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [ ] I have added tests that prove my feature works. — Pure CSS removal; `typecheck` and the existing suite (276 tests) pass.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update. — Visual-only change with no user-facing behavior to document.
