### PR TITLE
feat(agent-core): enable Preserved Thinking by default for kimi models

### DIFF
--- a/.changeset/default-preserved-thinking.md
+++ b/.changeset/default-preserved-thinking.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": minor
+---
+
+Enable Preserved Thinking by default for Kimi models when Thinking is on, keeping prior reasoning across turns. Set `[thinking] keep = "off"` in config.toml (or `KIMI_MODEL_THINKING_KEEP=off`) to disable it.

--- a/docs/en/configuration/config-files.md
+++ b/docs/en/configuration/config-files.md
@@ -42,6 +42,7 @@ max_context_size = 262144
 [thinking]
 enabled = true
 effort = "high"
+keep = "all"
 
 [loop_control]
 max_retries_per_step = 3
@@ -168,6 +169,7 @@ You can also switch models temporarily without touching the config file — by s
 | --- | --- | --- | --- |
 | `enabled` | `boolean` | `true` | Whether Thinking is enabled by default for new sessions; set to `false` to force Thinking off |
 | `effort` | `string` | — | Thinking effort level (for example `low`, `medium`, `high`, `xhigh`, `max`); the levels actually available depend on the model's declared `support_efforts`, and unrecognized values are ignored by the provider |
+| `keep` | `string` | `"all"` | Moonshot Preserved Thinking passthrough (`thinking.keep`). `"all"` preserves previous turns' `reasoning_content`; set to an off-value (`false`/`0`/`no`/`off`/`none`/`null`) to disable. Overridden by `KIMI_MODEL_THINKING_KEEP`; applies to the `kimi` provider only, and only while Thinking is on |
 
 ### Deprecated fields
 

--- a/docs/en/configuration/env-vars.md
+++ b/docs/en/configuration/env-vars.md
@@ -130,7 +130,7 @@ Switches that control the behavior of subsystems such as telemetry, background t
 | `KIMI_MODEL_TEMPERATURE` | Sampling temperature for every request; applies to the `kimi` provider only (global — independent of `KIMI_MODEL_NAME`) | Number, e.g. `0.3` |
 | `KIMI_MODEL_TOP_P` | Nucleus-sampling `top_p` for every request; applies to the `kimi` provider only (global) | Number, e.g. `0.95` |
 | `KIMI_MODEL_THINKING_EFFORT` | Force a specific thinking effort on the wire (`thinking.effort`), bypassing the model's declared `support_efforts`; applies to the `kimi` provider only, and only while Thinking is on | An effort value, e.g. `max` |
-| `KIMI_MODEL_THINKING_KEEP` | Moonshot preserved-thinking passthrough (`thinking.keep`); applies to the `kimi` provider only, and only while Thinking is on | A value the API accepts, e.g. `all` |
+| `KIMI_MODEL_THINKING_KEEP` | Moonshot preserved-thinking passthrough (`thinking.keep`); overrides `[thinking] keep` (which defaults to `"all"`); applies to the `kimi` provider only, and only while Thinking is on | A value the API accepts, e.g. `all`; an off-value (`false`/`0`/`no`/`off`/`none`/`null`) disables it |
 | `KIMI_CODE_NO_AUTO_UPDATE` | Fully disable the update preflight — no check, background install, or prompt. Legacy alias `KIMI_CLI_NO_AUTO_UPDATE` is also honored | Truthy: `1`/`true`/`yes`/`on` |
 | `KIMI_DISABLE_CRON` | Disable the scheduled-task tool (`CronCreate` rejects new schedules; existing tasks do not fire) | `1` to disable |
 

--- a/docs/zh/configuration/config-files.md
+++ b/docs/zh/configuration/config-files.md
@@ -42,6 +42,7 @@ max_context_size = 262144
 [thinking]
 enabled = true
 effort = "high"
+keep = "all"
 
 [loop_control]
 max_retries_per_step = 3
@@ -168,6 +169,7 @@ display_name = "Kimi for Coding (custom)"
 | --- | --- | --- | --- |
 | `enabled` | `boolean` | `true` | 新会话是否默认开启 Thinking，设为 `false` 可强制关闭 |
 | `effort` | `string` | — | Thinking 强度（例如 `low`、`medium`、`high`、`xhigh`、`max`），实际可用等级取决于模型声明的 `support_efforts`，未识别的值会被供应商忽略 |
+| `keep` | `string` | `"all"` | Moonshot 保留思考透传（`thinking.keep`）。`"all"` 会保留历史轮次的 `reasoning_content`；传入关值（`false`/`0`/`no`/`off`/`none`/`null`）可禁用。可被 `KIMI_MODEL_THINKING_KEEP` 覆盖；仅对 `kimi` 供应商生效，且仅在 Thinking 开启时注入 |
 
 ### 已废弃字段
 

--- a/docs/zh/configuration/env-vars.md
+++ b/docs/zh/configuration/env-vars.md
@@ -130,7 +130,7 @@ kimi
 | `KIMI_MODEL_TEMPERATURE` | 每次请求的采样温度，仅对 `kimi` 供应商生效（全局生效，不依赖 `KIMI_MODEL_NAME`） | 数字，如 `0.3` |
 | `KIMI_MODEL_TOP_P` | 每次请求的核采样 `top_p`，仅对 `kimi` 供应商生效（全局生效） | 数字，如 `0.95` |
 | `KIMI_MODEL_THINKING_EFFORT` | 在线上强制使用指定的思考强度（`thinking.effort`），绕过模型声明的 `support_efforts`；仅对 `kimi` 供应商生效，且仅在 Thinking 开启时注入 | 思考强度值，如 `max` |
-| `KIMI_MODEL_THINKING_KEEP` | Moonshot 保留思考透传（`thinking.keep`），仅对 `kimi` 供应商生效，且仅在 Thinking 开启时注入 | API 接受的值，如 `all` |
+| `KIMI_MODEL_THINKING_KEEP` | Moonshot 保留思考透传（`thinking.keep`）；覆盖 `[thinking] keep`（其默认值为 `"all"`）；仅对 `kimi` 供应商生效，且仅在 Thinking 开启时注入 | API 接受的值，如 `all`；传入关值（`false`/`0`/`no`/`off`/`none`/`null`）可禁用 |
 | `KIMI_CODE_NO_AUTO_UPDATE` | 完全禁用更新预检——不检查、不后台安装、不提示。同时兼容旧名 `KIMI_CLI_NO_AUTO_UPDATE` | 真值：`1`/`true`/`yes`/`on` |
 | `KIMI_DISABLE_CRON` | 禁用定时任务工具（`CronCreate` 拒绝新计划，已有任务不触发） | `1` 表示禁用 |
 

--- a/packages/agent-core/src/agent/config/index.ts
+++ b/packages/agent-core/src/agent/config/index.ts
@@ -122,11 +122,16 @@ export class ConfigState {
     //   - withThinking: preserve thinking during compaction (#464)
     //   - sampling params: KIMI_MODEL_TEMPERATURE / KIMI_MODEL_TOP_P
     //   - thinking.effort: KIMI_MODEL_THINKING_EFFORT (forces an effort, only while thinking is on)
-    //   - thinking.keep: KIMI_MODEL_THINKING_KEEP (only while thinking is on)
+    //   - thinking.keep: env KIMI_MODEL_THINKING_KEEP > config thinking.keep > default "all" (only while thinking is on)
     const provider = createProvider(this.providerConfig).withThinking(this.thinkingEffort);
     const withSampling = applyKimiEnvSamplingParams(provider);
     const withEffort = applyKimiEnvThinkingEffort(withSampling, this.thinkingEffort);
-    return applyKimiEnvThinkingKeep(withEffort, this.thinkingEffort);
+    return applyKimiEnvThinkingKeep(
+      withEffort,
+      this.thinkingEffort,
+      undefined,
+      this.agent.kimiConfig?.thinking?.keep,
+    );
   }
 
   get model(): string {

--- a/packages/agent-core/src/config/kimi-env-params.ts
+++ b/packages/agent-core/src/config/kimi-env-params.ts
@@ -57,22 +57,61 @@ export function applyKimiEnvThinkingEffort(
   return provider.withExtraBody({ thinking: { effort } });
 }
 
+const KEEP_OFF_VALUES = new Set(['0', 'false', 'no', 'off', 'none', 'null']);
+
+type KeepResolution =
+  | { readonly specified: false }
+  | { readonly specified: true; readonly value: string | undefined };
+
 /**
- * Apply the Moonshot preserved-thinking passthrough (`KIMI_MODEL_THINKING_KEEP`
- * -> `thinking.keep`) to a chat provider. Applied in `ConfigState.provider` after
- * `withThinking`, and only while thinking is on — otherwise the API would
- * receive a `thinking.keep` with no accompanying `thinking.type` it honors.
- * (Compaction uses a raw provider with thinking off, so it correctly skips this.)
+ * Parse a single keep source (env var or config field). A blank value is
+ * "unspecified" and falls through to the next source; an off-value explicitly
+ * disables Preserved Thinking (short-circuits, no fallback); anything else is
+ * forwarded verbatim (e.g. "all").
+ */
+function parseKeepValue(raw: string | undefined): KeepResolution {
+  const trimmed = raw?.trim();
+  if (trimmed === undefined || trimmed.length === 0) return { specified: false };
+  if (KEEP_OFF_VALUES.has(trimmed.toLowerCase())) return { specified: true, value: undefined };
+  return { specified: true, value: trimmed };
+}
+
+/**
+ * Resolve the Moonshot Preserved Thinking passthrough (`thinking.keep`) with
+ * precedence env (`KIMI_MODEL_THINKING_KEEP`) > config (`thinking.keep`) >
+ * default `"all"`. Only meaningful while thinking is on — otherwise the API
+ * would receive a `thinking.keep` with no accompanying `thinking.type` it
+ * honors. (Compaction uses a raw provider with thinking off, so it correctly
+ * resolves to `undefined`.)
  *
- * Non-Kimi providers — and an unset/blank value — are returned unchanged.
+ * Returns `undefined` when Preserved Thinking should be disabled.
+ */
+export function resolveThinkingKeep(
+  env: Env,
+  configKeep: string | undefined,
+  thinkingEffort: ThinkingEffort,
+): string | undefined {
+  if (thinkingEffort === 'off') return undefined;
+  const fromEnv = parseKeepValue(env['KIMI_MODEL_THINKING_KEEP']);
+  if (fromEnv.specified) return fromEnv.value;
+  const fromConfig = parseKeepValue(configKeep);
+  if (fromConfig.specified) return fromConfig.value;
+  return 'all';
+}
+
+/**
+ * Apply the Moonshot Preserved Thinking passthrough to a chat provider. See
+ * `resolveThinkingKeep` for precedence. Non-Kimi providers are returned
+ * unchanged.
  */
 export function applyKimiEnvThinkingKeep(
   provider: ChatProvider,
   thinkingEffort: ThinkingEffort,
   env: Env = process.env,
+  configKeep?: string,
 ): ChatProvider {
   if (!(provider instanceof KimiChatProvider)) return provider;
-  const keep = env['KIMI_MODEL_THINKING_KEEP']?.trim();
-  if (keep === undefined || keep.length === 0 || thinkingEffort === 'off') return provider;
+  const keep = resolveThinkingKeep(env, configKeep, thinkingEffort);
+  if (keep === undefined) return provider;
   return provider.withExtraBody({ thinking: { keep } });
 }

--- a/packages/agent-core/src/config/schema.ts
+++ b/packages/agent-core/src/config/schema.ts
@@ -82,6 +82,10 @@ export type ModelAlias = z.infer<typeof ModelAliasSchema>;
 export const ThinkingConfigSchema = z.object({
   enabled: z.boolean().optional(),
   effort: z.string().optional(),
+  // Moonshot Preserved Thinking passthrough (`thinking.keep`). The value is
+  // forwarded verbatim to the wire; "all" enables it, an off-value
+  // (false/0/no/off/none/null) disables it. Defaults to "all" when unset.
+  keep: z.string().optional(),
 });
 
 export type ThinkingConfig = z.infer<typeof ThinkingConfigSchema>;

--- a/packages/agent-core/test/agent/config-state.test.ts
+++ b/packages/agent-core/test/agent/config-state.test.ts
@@ -243,6 +243,22 @@ describe('ConfigState.provider applies global KIMI_MODEL_* request config', () =
     });
   }
 
+  // The same config backs both the ProviderManager (provider resolution) and
+  // the agent's kimiConfig (where ConfigState reads thinking.keep).
+  function kimiAgentWithThinkingKeep(keep: string | undefined) {
+    const config: KimiConfig = {
+      providers: { kimi: { type: 'kimi', apiKey: 'test-key' } },
+      models: {
+        'kimi-code': { provider: 'kimi', model: 'kimi-code', maxContextSize: 128_000 },
+      },
+      ...(keep !== undefined ? { thinking: { keep } } : {}),
+    };
+    return testAgent({
+      initialConfig: config,
+      providerManager: new ProviderManager({ config }),
+    });
+  }
+
   it('injects KIMI_MODEL_TEMPERATURE into config.provider (the provider compaction also uses)', () => {
     vi.stubEnv('KIMI_MODEL_TEMPERATURE', '0.3');
     try {
@@ -290,6 +306,67 @@ describe('ConfigState.provider applies global KIMI_MODEL_* request config', () =
     }
   });
 
+  it('injects thinking.keep="all" into config.provider by default (no env, no config)', () => {
+    vi.stubEnv('KIMI_MODEL_THINKING_KEEP', '');
+    try {
+      const ctx = kimiAgent();
+      ctx.agent.config.update({ modelAlias: 'kimi-code', thinkingEffort: 'high' });
+
+      const provider = ctx.agent.config.provider;
+      const gen = Reflect.get(provider as object, '_generationKwargs') as {
+        extra_body?: { thinking?: { keep?: unknown } };
+      };
+      expect(gen.extra_body?.thinking?.keep).toBe('all');
+    } finally {
+      vi.unstubAllEnvs();
+    }
+  });
+
+  it('config thinking.keep="off" disables keep by default', () => {
+    vi.stubEnv('KIMI_MODEL_THINKING_KEEP', '');
+    try {
+      const ctx = kimiAgentWithThinkingKeep('off');
+      ctx.agent.config.update({ modelAlias: 'kimi-code', thinkingEffort: 'high' });
+
+      const gen = Reflect.get(ctx.agent.config.provider as object, '_generationKwargs') as {
+        extra_body?: { thinking?: { keep?: unknown } };
+      };
+      expect(gen.extra_body?.thinking?.keep).toBeUndefined();
+    } finally {
+      vi.unstubAllEnvs();
+    }
+  });
+
+  it('env off-value overrides config thinking.keep="all"', () => {
+    vi.stubEnv('KIMI_MODEL_THINKING_KEEP', 'off');
+    try {
+      const ctx = kimiAgentWithThinkingKeep('all');
+      ctx.agent.config.update({ modelAlias: 'kimi-code', thinkingEffort: 'high' });
+
+      const gen = Reflect.get(ctx.agent.config.provider as object, '_generationKwargs') as {
+        extra_body?: { thinking?: { keep?: unknown } };
+      };
+      expect(gen.extra_body?.thinking?.keep).toBeUndefined();
+    } finally {
+      vi.unstubAllEnvs();
+    }
+  });
+
+  it('env="all" overrides config thinking.keep="off"', () => {
+    vi.stubEnv('KIMI_MODEL_THINKING_KEEP', 'all');
+    try {
+      const ctx = kimiAgentWithThinkingKeep('off');
+      ctx.agent.config.update({ modelAlias: 'kimi-code', thinkingEffort: 'high' });
+
+      const gen = Reflect.get(ctx.agent.config.provider as object, '_generationKwargs') as {
+        extra_body?: { thinking?: { keep?: unknown } };
+      };
+      expect(gen.extra_body?.thinking?.keep).toBe('all');
+    } finally {
+      vi.unstubAllEnvs();
+    }
+  });
+
   it('injects KIMI_MODEL_THINKING_EFFORT into config.provider when thinking is on', () => {
     vi.stubEnv('KIMI_MODEL_THINKING_EFFORT', 'max');
     try {
@@ -300,7 +377,7 @@ describe('ConfigState.provider applies global KIMI_MODEL_* request config', () =
       const gen = Reflect.get(provider as object, '_generationKwargs') as {
         extra_body?: { thinking?: { type?: string; effort?: string } };
       };
-      expect(gen.extra_body?.thinking).toEqual({ type: 'enabled', effort: 'max' });
+      expect(gen.extra_body?.thinking).toMatchObject({ type: 'enabled', effort: 'max' });
     } finally {
       vi.unstubAllEnvs();
     }

--- a/packages/agent-core/test/config/kimi-env-params.test.ts
+++ b/packages/agent-core/test/config/kimi-env-params.test.ts
@@ -62,19 +62,47 @@ describe('applyKimiEnvSamplingParams', () => {
 });
 
 describe('applyKimiEnvThinkingKeep', () => {
-  it('injects thinking.keep when thinking is on', () => {
+  it('injects thinking.keep="all" by default when thinking is on', () => {
+    const out = applyKimiEnvThinkingKeep(kimi(), 'high', {});
+    expect(genState(out).extra_body?.thinking?.keep).toBe('all');
+  });
+
+  it('injects thinking.keep from env when thinking is on', () => {
     const out = applyKimiEnvThinkingKeep(kimi(), 'high', { KIMI_MODEL_THINKING_KEEP: 'all' });
     expect(genState(out).extra_body?.thinking?.keep).toBe('all');
+  });
+
+  it('injects thinking.keep from config when env is unset', () => {
+    const out = applyKimiEnvThinkingKeep(kimi(), 'high', {}, 'all');
+    expect(genState(out).extra_body?.thinking?.keep).toBe('all');
+  });
+
+  it('env takes precedence over config', () => {
+    const out = applyKimiEnvThinkingKeep(kimi(), 'high', { KIMI_MODEL_THINKING_KEEP: 'all' }, 'off');
+    expect(genState(out).extra_body?.thinking?.keep).toBe('all');
+  });
+
+  it.each(['off', 'false', '0', 'no', 'none', 'null', 'OFF', 'None'])(
+    'env off-value %s disables keep even when config enables it',
+    (off) => {
+      const out = applyKimiEnvThinkingKeep(kimi(), 'high', { KIMI_MODEL_THINKING_KEEP: off }, 'all');
+      expect(genState(out).extra_body).toBeUndefined();
+    },
+  );
+
+  it.each(['off', 'none', 'null'])('config off-value %s disables keep by default', (off) => {
+    const out = applyKimiEnvThinkingKeep(kimi(), 'high', {}, off);
+    expect(genState(out).extra_body).toBeUndefined();
+  });
+
+  it('blank env falls through to config', () => {
+    const out = applyKimiEnvThinkingKeep(kimi(), 'high', { KIMI_MODEL_THINKING_KEEP: '  ' }, 'off');
+    expect(genState(out).extra_body).toBeUndefined();
   });
 
   it('does NOT inject thinking.keep when thinking is off', () => {
     const out = applyKimiEnvThinkingKeep(kimi(), 'off', { KIMI_MODEL_THINKING_KEEP: 'all' });
     expect(genState(out).extra_body).toBeUndefined();
-  });
-
-  it('returns the same provider when keep is unset', () => {
-    const provider = kimi();
-    expect(applyKimiEnvThinkingKeep(provider, 'high', {})).toBe(provider);
   });
 
   it('leaves non-kimi providers untouched', () => {


### PR DESCRIPTION
## Related Issue

No tracking issue — implements a direct maintainer/user request to default Preserved Thinking on.

## Problem

For Kimi thinking models, prior turns' `reasoning_content` was not preserved across turns unless the user manually exported `KIMI_MODEL_THINKING_KEEP=all`. Multi-turn reasoning therefore lost continuity by default.

## What changed

- Default `thinking.keep` to `"all"` while Thinking is on, so previous turns' reasoning is preserved across turns (Preserved Thinking).
- Add a `[thinking] keep` field to `config.toml` (string, default `"all"`); an off-value (`false`/`0`/`no`/`off`/`none`/`null`) disables it.
- Keep `KIMI_MODEL_THINKING_KEEP` as an override with precedence env > config > default. Applies to the `kimi` provider only, and only while Thinking is on.

Tests and bilingual docs (`config-files.md`, `env-vars.md`) are updated, and a changeset is included.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.