### PR TITLE
chore(changelog): enable thanks credit in changelog

### DIFF
--- a/.agents/skills/pre-changelog/SKILL.md
+++ b/.agents/skills/pre-changelog/SKILL.md
@@ -37,7 +37,7 @@ If the CLI changelog is not in the diff (for example an SDK-only release), stop 
 
 Process the version block exactly as `sync-changelog` does for the docs site, but only in memory:
 
-- **Strip** (`sync-changelog` step 3): drop the H1, the `### Patch Changes` / `### Minor Changes` / `### Major Changes` subheadings, PR links, and commit-hash links; keep only each entry's body text.
+- **Strip** (`sync-changelog` step 3): drop the H1, the `### Patch Changes` / `### Minor Changes` / `### Major Changes` subheadings, PR links, commit-hash links, and the `Thanks [@user](...)!` credit (including the multi-author form); keep only each entry's body text.
 - **Classify** (`sync-changelog` step 4): bucket into Features / Bug Fixes / Polish / Refactors / Other; order within each section by reader value.
 - **Translate** (`sync-changelog` step 6): translate entry bodies to Chinese; section headings become 新功能 / 修复 / 优化 / 重构 / 其他.
 

--- a/.agents/skills/sync-changelog/SKILL.md
+++ b/.agents/skills/sync-changelog/SKILL.md
@@ -90,16 +90,16 @@ Use upstream order: newest version first.
 
 ### 3. Strip Decorations And Extract Entry Text
 
-Upstream entries look like this:
+Upstream entries look like this (with the changelog thanks feature enabled, each entry carries a `Thanks ...!` credit):
 
 ```markdown
-- [#317](https://github.com/...) [`2f51db4`](https://github.com/...) - Clean up lint warnings ...
+- [#317](https://github.com/...) [`2f51db4`](https://github.com/...) Thanks [@user](https://github.com/...)! - Clean up lint warnings ...
 ```
 
 Keep:
 
 - Version headings such as `## 0.2.0`.
-- Only the body text of each entry, after the PR/hash decoration.
+- Only the body text of each entry, after the PR/hash/thanks decoration.
 
 Remove:
 
@@ -107,6 +107,7 @@ Remove:
 - Changesets subheadings such as `### Patch Changes`, `### Minor Changes`, and `### Major Changes`.
 - PR links such as `[#317](...)`.
 - Commit hash links such as ``[`2f51db4`](...)``.
+- The `Thanks [@user](...)!` credit, including the multi-author form `Thanks [@a](...), [@b](...)!`. Drop the whole `Thanks ...!` segment so only the body text remains.
 
 After stripping, each entry should be only:
 
@@ -299,7 +300,7 @@ Check:
 - Each version has the same section set and order on both pages.
 - Each section has the same number of entries on both pages.
 - Within each section, the most valuable, obvious, and larger entries appear before smaller or narrower entries.
-- PR links and commit hashes were stripped.
+- PR links, commit hashes, and the `Thanks ...!` credit were stripped.
 - Real internal identifiers were replaced with neutral placeholders.
 - There are no empty sections.
 - Markdown indentation and blank lines are intact.
@@ -415,7 +416,7 @@ Return the PR URL to the user when done.
 | Mistake | Fix |
 |---|---|
 | Adding entries directly to the English docs page without reading upstream | Use `apps/kimi-code/CHANGELOG.md` as the source |
-| Copying PR links or commit hashes into docs | Strip them; keep only body text |
+| Copying PR links, commit hashes, or the `Thanks ...!` credit into docs | Strip them; keep only body text |
 | Rewording upstream English entries | Upstream is frozen; copy the body text unless the user explicitly asks otherwise |
 | Leaving English text untranslated in the Chinese page | The Chinese page must be fully Chinese except preserved technical terms |
 | Editing upstream changelog text | Do not edit upstream |

--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -1,5 +1,5 @@
 {
-  "changelog": ["@changesets/changelog-github", { "repo": "MoonshotAI/kimi-code", "disableThanks": true }],
+  "changelog": ["@changesets/changelog-github", { "repo": "MoonshotAI/kimi-code" }],
   "commit": false,
   "fixed": [],
   "linked": [],


### PR DESCRIPTION
## Related Issue

N/A — changelog tooling maintenance.

## Problem

The CLI changelog generated by changesets suppresses the `Thanks ...!` credit via `disableThanks: true`, so merged contributors are not acknowledged. The changelog skills also do not yet describe how to handle that credit segment when syncing entries into the docs site.

## What changed

- Enabled the thanks credit by removing `disableThanks` from `.changeset/config.json`, so future generated changelogs include `Thanks [@user](...)!`.
- Updated the `sync-changelog` and `pre-changelog` skills to strip the `Thanks [@user](...)!` segment (including the multi-author form) alongside PR links and commit hashes, keeping only the entry body text in the docs-site changelog.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [ ] I have added tests that prove my feature works. (N/A — tooling config and internal skill docs)
- [x] Ran `gen-changesets` skill, or this PR needs no changeset. (No changeset — changesets tooling config and internal skill docs do not enter the CLI bundle)
- [x] Ran `gen-docs` skill, or this PR needs no doc update. (Internal skill instructions, not docs-site content)