### PR TITLE
chore: symlink CLAUDE.md to AGENTS.md for compatibility

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md


### PR DESCRIPTION
## What

Add a `CLAUDE.md` symlink at the repo root pointing to the canonical `AGENTS.md`.

## Why

For compatibility: some agent tooling looks for a `CLAUDE.md` at the repo root, while this repo keeps its instructions in `AGENTS.md`. The symlink makes both filename conventions resolve to the same content — single source of truth, nothing duplicated to keep in sync.

## Notes

- `AGENTS.md` remains the only real file; `CLAUDE.md` is just a link (git stores it as mode `120000`).
- No change to `.gitignore`; the local `.claude` convenience link stays ignored as before.