### PR TITLE
fix(tui): keep Edit preview height stable as results land

### DIFF
--- a/.changeset/fix-edit-preview-height.md
+++ b/.changeset/fix-edit-preview-height.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Fix the Edit tool card jumping in height and flickering while its result streams in.

--- a/apps/kimi-code/src/tui/components/messages/tool-call.ts
+++ b/apps/kimi-code/src/tui/components/messages/tool-call.ts
@@ -1921,7 +1921,14 @@ export class ToolCallComponent extends Container {
       this.buildStreamingPreview(this.toolCall.streamingArguments);
       return;
     }
-    const shouldCap = this.result !== undefined && !this.expanded;
+    // Cap Edit's diff as soon as args finalize, not only when the result
+    // lands — mirroring Write's writeShouldCap below. Otherwise the render
+    // tick between finalized args (streamingArguments cleared by the
+    // `tool.call.started` payload) and the result draws the full diff, then
+    // snaps back to the cap: a height collapse that triggers pi-tui's full
+    // redraw and wipes scrollback. Streaming frames (streamingArguments set)
+    // still take buildStreamingPreview above and never reach here.
+    const shouldCap = !this.expanded;
     if (name === 'Write') {
       const content = str(this.toolCall.args['content']);
       if (content.length === 0) return;


### PR DESCRIPTION
## Related Issue

N/A — no prior issue; see Problem below.

## Problem

The Edit tool card in the TUI collapses in height and flickers when its result arrives. `tool.call.started` already carries the finalized arguments, but the preview only applied its line cap after the result landed. For one render tick the card drew the full diff, then snapped back to the capped height, which triggered a full terminal redraw that wiped scrollback and left empty space below the input box.

## What changed

Apply the Edit preview line cap as soon as the arguments finalize, mirroring the Write tool, instead of waiting for the result. The streaming preview, the finalized-args frame, and the result frame now share the same capped height, so the card no longer grows and collapses.

Verified manually in the TUI with a multi-line edit.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [ ] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.