### PR TITLE
feat(telemetry): add system metrics collection

### DIFF
--- a/apps/kimi-code/src/cli/run-prompt.ts
+++ b/apps/kimi-code/src/cli/run-prompt.ts
@@ -179,6 +179,7 @@ export async function runPrompt(
       version,
       uiMode: PROMPT_UI_MODE,
       model: telemetryModel,
+      sessionId: session.id,
     });
     setCrashPhase('runtime');
 

--- a/apps/kimi-code/src/cli/telemetry.ts
+++ b/apps/kimi-code/src/cli/telemetry.ts
@@ -32,6 +32,7 @@ export interface InitializeCliTelemetryOptions {
   readonly version: string;
   readonly uiMode: string;
   readonly model?: string;
+  readonly sessionId?: string;
 }
 
 export function createCliTelemetryBootstrap(): CliTelemetryBootstrap {
@@ -54,6 +55,7 @@ export function initializeCliTelemetry(options: InitializeCliTelemetryOptions): 
     version: options.version,
     uiMode: options.uiMode,
     model: options.model ?? options.config.defaultModel,
+    sessionId: options.sessionId,
     getAccessToken: async () =>
       (await options.harness.auth.getCachedAccessToken(KIMI_CODE_PROVIDER_NAME)) ?? null,
   });

--- a/apps/kimi-code/test/cli/export.test.ts
+++ b/apps/kimi-code/test/cli/export.test.ts
@@ -412,6 +412,7 @@ describe('kimi export', () => {
       version: expect.any(String),
       uiMode: 'shell',
       model: 'k2',
+      sessionId: undefined,
       getAccessToken: expect.any(Function),
     });
     expect(mocks.initializeTelemetry.mock.invocationCallOrder[0]).toBeLessThan(

--- a/apps/kimi-code/test/cli/run-prompt.test.ts
+++ b/apps/kimi-code/test/cli/run-prompt.test.ts
@@ -217,6 +217,9 @@ describe('runPrompt', () => {
     expect(mocks.session.prompt).toHaveBeenCalledWith('say hello');
     expect(stdout.text()).toBe('• hello world\n\n');
     expect(stderr.text()).toBe('To resume this session: kimi -r ses_prompt\n');
+    expect(mocks.initializeTelemetry).toHaveBeenCalledWith(
+      expect.objectContaining({ sessionId: 'ses_prompt' }),
+    );
     expect(mocks.shutdownTelemetry).toHaveBeenCalled();
     expect(mocks.harnessClose).toHaveBeenCalled();
   });

--- a/apps/kimi-code/test/cli/run-shell.test.ts
+++ b/apps/kimi-code/test/cli/run-shell.test.ts
@@ -213,6 +213,7 @@ describe('runShell', () => {
       version: '1.2.3-test',
       uiMode: 'shell',
       model: 'k2',
+      sessionId: undefined,
       getAccessToken: expect.any(Function),
     });
     expect(mocks.setCrashPhase).toHaveBeenCalledWith('runtime');

--- a/packages/telemetry/src/bootstrap.ts
+++ b/packages/telemetry/src/bootstrap.ts
@@ -1,5 +1,6 @@
 import { getDefaultTelemetryClient } from './client';
 import { EventSink } from './sink';
+import { SystemMetricsCollector } from './systemMetrics';
 import { AsyncTransport } from './transport';
 
 export const TELEMETRY_DISABLE_ENV = 'KIMI_DISABLE_TELEMETRY';
@@ -65,5 +66,10 @@ export function initializeTelemetry(options: TelemetryBootstrapOptions): void {
 
   client.attachSink(sink);
   sink.startPeriodicFlush();
+
+  const systemMetricsCollector = new SystemMetricsCollector({ client });
+  client.setSystemMetricsCollector(systemMetricsCollector);
+  systemMetricsCollector.start();
+
   void sink.retryDiskEvents().catch(() => {});
 }

--- a/packages/telemetry/src/client.ts
+++ b/packages/telemetry/src/client.ts
@@ -13,6 +13,10 @@ export interface TelemetryShutdownOptions {
   readonly timeoutMs?: number;
 }
 
+export interface SystemMetricsCollectorHandle {
+  stop(): void;
+}
+
 const MAX_QUEUE_SIZE = 1000;
 
 interface PendingTelemetryEvent extends TelemetryEvent {
@@ -25,6 +29,7 @@ interface PendingTelemetryEvent extends TelemetryEvent {
 export class TelemetryClient {
   private queue: PendingTelemetryEvent[] = [];
   private sink: EventSink | null = null;
+  private systemMetricsCollector: SystemMetricsCollectorHandle | null = null;
   private deviceId: string | null = null;
   private sessionId: string | null = null;
   private disabled = false;
@@ -36,6 +41,13 @@ export class TelemetryClient {
 
   withContext(input: TelemetryContextIds): TelemetryClient {
     return new ScopedTelemetryClient(this, input);
+  }
+
+  setSystemMetricsCollector(collector: SystemMetricsCollectorHandle): void {
+    if (this.systemMetricsCollector !== null && this.systemMetricsCollector !== collector) {
+      this.systemMetricsCollector.stop();
+    }
+    this.systemMetricsCollector = collector;
   }
 
   attachSink(sink: EventSink): void {
@@ -60,6 +72,8 @@ export class TelemetryClient {
   disable(): void {
     this.disabled = true;
     this.queue = [];
+    this.systemMetricsCollector?.stop();
+    this.systemMetricsCollector = null;
     if (this.sink !== null) {
       this.sink.stopPeriodicFlush();
       this.sink.clearBuffer();
@@ -116,6 +130,8 @@ export class TelemetryClient {
   }
 
   async shutdown(options: TelemetryShutdownOptions = {}): Promise<void> {
+    this.systemMetricsCollector?.stop();
+    this.systemMetricsCollector = null;
     const sink = this.sink;
     if (sink === null) return;
     sink.stopPeriodicFlush();
@@ -139,6 +155,8 @@ export class TelemetryClient {
 
   resetForTests(): void {
     this.sink?.stopPeriodicFlush();
+    this.systemMetricsCollector?.stop();
+    this.systemMetricsCollector = null;
     this.queue = [];
     this.sink = null;
     this.deviceId = null;
@@ -161,6 +179,10 @@ class ScopedTelemetryClient extends TelemetryClient {
 
   override withContext(input: TelemetryContextIds): TelemetryClient {
     return new ScopedTelemetryClient(this.parent, mergeContext(this.context, input));
+  }
+
+  override setSystemMetricsCollector(collector: SystemMetricsCollectorHandle): void {
+    this.parent.setSystemMetricsCollector(collector);
   }
 
   override attachSink(sink: EventSink): void {

--- a/packages/telemetry/src/systemMetrics.ts
+++ b/packages/telemetry/src/systemMetrics.ts
@@ -1,0 +1,107 @@
+import { cpus, freemem, loadavg, totalmem } from 'node:os';
+
+import type { TelemetryProperties } from './types';
+
+const DEFAULT_INTERVAL_MS = 30_000;
+const DEFAULT_WARMUP_SAMPLE_MS = 1_500;
+const SYSTEM_METRICS_EVENT = 'system_metrics';
+
+export interface SystemMetricsTrackClient {
+  track(event: string, properties?: TelemetryProperties): void;
+}
+
+export interface SystemMetricsCollectorOptions {
+  readonly client: SystemMetricsTrackClient;
+  readonly intervalMs?: number;
+  readonly warmupSampleMs?: number | null;
+}
+
+export class SystemMetricsCollector {
+  private readonly client: SystemMetricsTrackClient;
+  private readonly intervalMs: number;
+  private readonly warmupSampleMs: number | null;
+  private intervalTimer: ReturnType<typeof setInterval> | null = null;
+  private warmupTimer: ReturnType<typeof setTimeout> | null = null;
+  private previousCpuUsage = process.cpuUsage();
+  private previousHrtime = process.hrtime.bigint();
+  private readonly processStartedAtSeconds = Math.floor(Date.now() / 1000 - process.uptime());
+
+  constructor(options: SystemMetricsCollectorOptions) {
+    this.client = options.client;
+    this.intervalMs = options.intervalMs ?? DEFAULT_INTERVAL_MS;
+    this.warmupSampleMs =
+      options.warmupSampleMs === undefined ? DEFAULT_WARMUP_SAMPLE_MS : options.warmupSampleMs;
+  }
+
+  start(): void {
+    if (this.intervalTimer !== null) return;
+
+    if (this.warmupSampleMs !== null && this.warmupSampleMs > 0) {
+      this.warmupTimer = setTimeout(() => {
+        this.warmupTimer = null;
+        this.sampleSafely();
+      }, this.warmupSampleMs);
+      this.warmupTimer.unref?.();
+    }
+
+    this.intervalTimer = setInterval(() => {
+      this.sampleSafely();
+    }, this.intervalMs);
+    this.intervalTimer.unref?.();
+  }
+
+  stop(): void {
+    if (this.warmupTimer !== null) {
+      clearTimeout(this.warmupTimer);
+      this.warmupTimer = null;
+    }
+    if (this.intervalTimer !== null) {
+      clearInterval(this.intervalTimer);
+      this.intervalTimer = null;
+    }
+  }
+
+  private sampleSafely(): void {
+    try {
+      this.sample();
+    } catch {
+      this.stop();
+    }
+  }
+
+  private sample(): void {
+    const now = process.hrtime.bigint();
+    const elapsedUs = Number(now - this.previousHrtime) / 1_000;
+
+    const cpu = process.cpuUsage(this.previousCpuUsage);
+    this.previousCpuUsage = process.cpuUsage();
+    this.previousHrtime = now;
+
+    const mem = process.memoryUsage();
+    const constrainedMemory = getConstrainedMemoryBytes();
+
+    this.client.track(SYSTEM_METRICS_EVENT, {
+      process_started_at: this.processStartedAtSeconds,
+      process_uptime_ms: Math.round(process.uptime() * 1000),
+      rss_bytes: mem.rss,
+      heap_used_bytes: mem.heapUsed,
+      heap_total_bytes: mem.heapTotal,
+      external_bytes: mem.external,
+      array_buffers_bytes: mem.arrayBuffers,
+      constrained_memory_bytes: constrainedMemory,
+      cpu_user_us: cpu.user,
+      cpu_system_us: cpu.system,
+      cpu_elapsed_us: Math.round(elapsedUs),
+      load_avg_1m: loadavg()[0],
+      free_mem_bytes: freemem(),
+      total_mem_bytes: totalmem(),
+      cpu_count: cpus().length,
+    });
+  }
+}
+
+function getConstrainedMemoryBytes(): number | undefined {
+  if (typeof process.constrainedMemory !== 'function') return undefined;
+  const value = process.constrainedMemory();
+  return Number.isFinite(value) ? value : undefined;
+}

--- a/packages/telemetry/test/telemetry.test.ts
+++ b/packages/telemetry/test/telemetry.test.ts
@@ -12,6 +12,7 @@ import { isTelemetryDisabledByEnv } from '../src/bootstrap';
 import { TelemetryClient, resetDefaultTelemetryClientForTests } from '../src/client';
 import { installCrashHandlersForClient, setCrashPhase, uninstallCrashHandlers } from '../src/crash';
 import { EventSink } from '../src/sink';
+import { SystemMetricsCollector } from '../src/systemMetrics';
 import {
   AsyncTransport,
   DISK_EVENT_MAX_AGE_MS,
@@ -30,6 +31,7 @@ afterEach(() => {
   uninstallCrashHandlers();
   setCrashPhase('startup');
   resetDefaultTelemetryClientForTests();
+  vi.useRealTimers();
   for (const dir of tempDirs.splice(0)) {
     rmSync(dir, { recursive: true, force: true });
   }
@@ -158,6 +160,19 @@ describe('TelemetryClient', () => {
     expect(transport.sent).toHaveLength(0);
   });
 
+  it('stops the previous system metrics collector when replacing it', () => {
+    const client = new TelemetryClient();
+    const first = { stop: vi.fn() };
+    const second = { stop: vi.fn() };
+
+    client.setSystemMetricsCollector(first);
+    client.setSystemMetricsCollector(second);
+    client.disable();
+
+    expect(first.stop).toHaveBeenCalledTimes(1);
+    expect(second.stop).toHaveBeenCalledTimes(1);
+  });
+
   it('flushes the previous sink synchronously when replacing sinks', () => {
     const client = new TelemetryClient();
     const first = new RecordingTransport();
@@ -201,6 +216,77 @@ describe('TelemetryClient', () => {
     expect(event?.timestamp).toBeGreaterThanOrEqual(before);
     expect(event?.timestamp).toBeLessThanOrEqual(Date.now() / 1000);
     expect(event?.properties).toEqual({});
+  });
+});
+
+describe('SystemMetricsCollector', () => {
+  it('emits a numeric system_metrics sample after the warmup delay', () => {
+    vi.useFakeTimers();
+    const tracked: Array<{
+      event: string;
+      properties: Record<string, number | string | boolean | undefined | null>;
+    }> = [];
+    const client = {
+      track(
+        event: string,
+        properties: Record<string, number | string | boolean | undefined | null> = {},
+      ): void {
+        tracked.push({ event, properties });
+      },
+    };
+    const collector = new SystemMetricsCollector({
+      client,
+      intervalMs: 30_000,
+      warmupSampleMs: 1_500,
+    });
+
+    collector.start();
+    vi.advanceTimersByTime(1_499);
+    expect(tracked).toHaveLength(0);
+
+    vi.advanceTimersByTime(1);
+    collector.stop();
+
+    expect(tracked).toHaveLength(1);
+    const event = tracked[0];
+    if (event === undefined) throw new Error('Expected a system_metrics event');
+    expect(event.event).toBe('system_metrics');
+    expect(numberProperty(event.properties, 'process_started_at')).toBeGreaterThan(0);
+    expect(numberProperty(event.properties, 'process_uptime_ms')).toBeGreaterThanOrEqual(0);
+    expect(numberProperty(event.properties, 'rss_bytes')).toBeGreaterThan(0);
+    expect(numberProperty(event.properties, 'heap_used_bytes')).toBeGreaterThan(0);
+    expect(numberProperty(event.properties, 'heap_total_bytes')).toBeGreaterThan(0);
+    expect(numberProperty(event.properties, 'external_bytes')).toBeGreaterThanOrEqual(0);
+    expect(numberProperty(event.properties, 'array_buffers_bytes')).toBeGreaterThanOrEqual(0);
+    expect(numberProperty(event.properties, 'cpu_user_us')).toBeGreaterThanOrEqual(0);
+    expect(numberProperty(event.properties, 'cpu_system_us')).toBeGreaterThanOrEqual(0);
+    expect(numberProperty(event.properties, 'cpu_elapsed_us')).toBeGreaterThan(0);
+    expect(numberProperty(event.properties, 'load_avg_1m')).toBeGreaterThanOrEqual(0);
+    expect(numberProperty(event.properties, 'free_mem_bytes')).toBeGreaterThanOrEqual(0);
+    expect(numberProperty(event.properties, 'total_mem_bytes')).toBeGreaterThan(0);
+    expect(numberProperty(event.properties, 'cpu_count')).toBeGreaterThanOrEqual(1);
+  });
+
+  it('does not duplicate interval sampling when started twice', () => {
+    vi.useFakeTimers();
+    const tracked: string[] = [];
+    const client = {
+      track(event: string): void {
+        tracked.push(event);
+      },
+    };
+    const collector = new SystemMetricsCollector({
+      client,
+      intervalMs: 30_000,
+      warmupSampleMs: null,
+    });
+
+    collector.start();
+    collector.start();
+    vi.advanceTimersByTime(30_000);
+    collector.stop();
+
+    expect(tracked).toEqual(['system_metrics']);
   });
 });
 
@@ -692,6 +778,44 @@ describe('telemetry bootstrap', () => {
     const file = readFileSync(join(telemetryDir, readdirOne(telemetryDir)), 'utf-8');
     expect(file).toContain('"event":"sync_flush"');
   });
+
+  it('writes system metrics with the singleton session context', async () => {
+    vi.useFakeTimers();
+    const homeDir = await tempHome();
+    initializeTelemetry({
+      homeDir,
+      deviceId: 'dev',
+      sessionId: 'ses',
+      appName: 'kimi-code-cli',
+      version: '1.2.3',
+    });
+
+    vi.advanceTimersByTime(1_500);
+    flushTelemetrySync();
+
+    const telemetryDir = join(homeDir, 'telemetry');
+    const file = readFileSync(join(telemetryDir, readdirOne(telemetryDir)), 'utf-8');
+    const events = file
+      .trim()
+      .split('\n')
+      .map(
+        (line) =>
+          JSON.parse(line) as {
+            event: string;
+            session_id: string | null;
+            properties: Record<string, number>;
+          },
+      );
+    const metrics = events.find((event) => event.event === 'system_metrics');
+    if (metrics === undefined) throw new Error('Expected a system_metrics event');
+
+    expect(metrics.session_id).toBe('ses');
+    expect(Number.isFinite(metrics.properties['process_started_at'])).toBe(true);
+    expect(metrics.properties['process_started_at']).toBeGreaterThan(0);
+    expect(Number.isFinite(metrics.properties['process_uptime_ms'])).toBe(true);
+    expect(metrics.properties['process_uptime_ms']).toBeGreaterThanOrEqual(0);
+    expect(metrics.properties['rss_bytes']).toBeGreaterThan(0);
+  });
 });
 
 describe('crash handler', () => {
@@ -824,6 +948,17 @@ function readdirOne(dir: string): string {
   const entry = readdirSync(dir)[0];
   if (entry === undefined) throw new Error(`No files in ${dir}`);
   return entry;
+}
+
+function numberProperty(
+  properties: Record<string, number | string | boolean | undefined | null>,
+  key: string,
+): number {
+  const value = properties[key];
+  if (typeof value !== 'number' || !Number.isFinite(value)) {
+    throw new Error(`Expected property ${key} to be a finite number, got ${String(value)}`);
+  }
+  return value;
 }
 
 function requestInitFrom(


### PR DESCRIPTION
## Related Issue

No linked issue. This PR adds internal process resource telemetry for Kimi Code hosts.

## Problem

Kimi Code telemetry currently has no visibility into host process resource usage. When investigating memory growth, CPU spikes, or resource exhaustion across CLI/TUI/server sessions, there is no runtime signal to correlate with existing telemetry events.

## What changed

- Added a `SystemMetricsCollector` that emits a `system_metrics` telemetry event with CPU, memory, load, and process uptime fields.
- The collector performs one warmup sample shortly after startup so short-lived CLI runs still capture a baseline, then continues sampling every 30 seconds.
- Wired the collector into telemetry bootstrap so it follows the existing telemetry opt-in/opt-out path and attaches to the same telemetry client.
- Added lifecycle cleanup so replacing, disabling, shutting down, or resetting telemetry stops the collector and avoids duplicate interval timers.
- Added tests for warmup sampling, duplicate-start protection, collector replacement cleanup, and bootstrap-level `system_metrics` emission with session context.

Verification:

- `pnpm --filter @moonshot-ai/kimi-telemetry test`
- `pnpm --filter @moonshot-ai/kimi-telemetry typecheck`

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.
