### PR TITLE
fix(kimi-web): disable text hyphenation and code ligatures

### DIFF
--- a/.changeset/web-text-rendering.md
+++ b/.changeset/web-text-rendering.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+web: Prevent chat text from hyphenating at line breaks and render code without font ligatures.

--- a/apps/kimi-web/src/style.css
+++ b/apps/kimi-web/src/style.css
@@ -223,6 +223,17 @@ summary {
   vertical-align: -0.15em;
 }
 
+/* Render code literally: disable the ligatures coding fonts enable by default
+   (e.g. `!=` collapsing to `≠`, `=>` to `⇒`). */
+code,
+pre,
+kbd,
+samp,
+tt {
+  font-feature-settings: "liga" 0, "calt" 0, "ss01" 0;
+  font-variant-ligatures: none;
+}
+
 /* color-scheme drives UA-rendered parts (scrollbars, form controls, etc.).
    An explicit choice must pin it to a single value — otherwise a dark-mode
    user on a light OS gets light scrollbars floating on the dark UI. */
@@ -635,6 +646,10 @@ body {
   text-rendering: auto;
   font-synthesis: none;
   text-size-adjust: 100%;
+  /* Never insert a hyphen glyph at line breaks (the page is `lang="en"`);
+     word-break/overflow-wrap still decide where lines wrap. */
+  -webkit-hyphens: none;
+  hyphens: none;
 }
 
 /* ---------------------------------------------------------------------------


### PR DESCRIPTION
## Related Issue

No linked issue — small text-rendering polish for the web UI.

## Problem

- The web UI is `lang="en"` and had no explicit guard against automatic text hyphenation, so chat/markdown prose could gain a hyphen glyph at line breaks.
- Code is rendered in JetBrains Mono, which enables ligatures by default, so sequences like `!=`, `=>`, `->` collapse into a single glyph (`≠`, `⇒`, `→`) instead of rendering literally.

## What changed

In `apps/kimi-web/src/style.css`:

- Set `hyphens: none` (with the `-webkit-` prefix) on `body`. Inherited, so it covers chat and markdown everywhere; components still decide where lines wrap via `word-break`/`overflow-wrap`.
- Disable font ligatures on native code elements (`code`, `pre`, `kbd`, `samp`, `tt`) via `font-feature-settings: "liga" 0, "calt" 0, "ss01" 0` plus `font-variant-ligatures: none`, so code renders literally.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [ ] I have added tests that prove my feature works. (CSS-only change; kimi-web has no component/render tests, so ran `pnpm --filter @moonshot-ai/kimi-web check:style` instead.)
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update. (Internal CSS-only change; no user-facing docs to update.)