### PR TITLE
chore(skills): merge similar changelog entries and credit external contributors

### DIFF
--- a/.agents/skills/gen-changesets/SKILL.md
+++ b/.agents/skills/gen-changesets/SKILL.md
@@ -148,7 +148,7 @@ Clarify session status typing for internal SDK callers.
 `@moonshot-ai/kimi-web` is ignored by changesets and must **never** appear in a changeset frontmatter. Because the web app is bundled into the CLI release artifact, any web change that ships must list `@moonshot-ai/kimi-code` instead and describe the actual web-facing change in the text.
 
 - Prefix the changelog entry text with `web: ` (for example `web: Fix the chat not scrolling to the bottom after sending a message.`) so the synced docs changelog can mark web UI entries. Apply this whenever the change is to the web project (`@moonshot-ai/kimi-web`).
-- If a PR contains both web UI changes and server API changes, split them into separate changesets so each entry has a focused description.
+- If a PR ships a web UI feature backed by server API changes that exist solely to power that feature, prefer a single `web:` entry describing what the web user gets. Do not add a separate server-API changeset unless the API has independent user value (a public endpoint that SDK or server consumers call directly). The docs changelog sync also deduplicates this pattern, but catching it here avoids duplicate changesets.
 - Do not enumerate every micro-tweak; keep it to one sentence that captures what the web user gets.
 
 Web-only fix:
@@ -161,7 +161,7 @@ Web-only fix:
 web: Fix the chat not scrolling to the bottom after sending a message.
 ```
 
-Web UI plus server APIs in the same PR (split into two changesets):
+Web UI plus backing server APIs in the same PR (prefer a single `web:` entry; the API is plumbing):
 
 ```markdown
 ---
@@ -171,13 +171,7 @@ Web UI plus server APIs in the same PR (split into two changesets):
 web: Add the server-hosted web UI, including chat layout and session list behaviors.
 ```
 
-```markdown
----
-"@moonshot-ai/kimi-code": minor
----
-
-Add the server REST and WebSocket APIs that power the web UI.
-```
+Split into two changesets only when the API has independent user value on its own (for example, a public endpoint SDK consumers call directly). In that case add the web entry above plus a separate one such as `Add a public REST API to list archived sessions for SDK consumers.`
 
 ## `@moonshot-ai/pi-tui` changes
 
@@ -228,3 +222,4 @@ Fix the transcript jumping to the top when scrolling up through history during s
 - The entry includes real internal identifiers instead of neutral placeholders.
 - A change that only touches `@moonshot-ai/pi-tui` lists `@moonshot-ai/kimi-code` instead of `@moonshot-ai/pi-tui`, or mixes both packages in one frontmatter.
 - A web app change entry is missing the `web: ` prefix.
+- A server/API changeset exists only to back a web feature that a `web:` changeset already describes (use one `web:` entry instead, unless the API has independent user value).

--- a/.agents/skills/pre-changelog/SKILL.md
+++ b/.agents/skills/pre-changelog/SKILL.md
@@ -37,9 +37,10 @@ If the CLI changelog is not in the diff (for example an SDK-only release), stop 
 
 Process the version block exactly as `sync-changelog` does for the docs site, but only in memory:
 
-- **Strip** (`sync-changelog` step 3): drop the H1, the `### Patch Changes` / `### Minor Changes` / `### Major Changes` subheadings, PR links, commit-hash links, and the `Thanks [@user](...)!` credit (including the multi-author form); keep only each entry's body text.
-- **Classify** (`sync-changelog` step 4): bucket into Features / Bug Fixes / Polish / Refactors / Other; order within each section by reader value.
-- **Translate** (`sync-changelog` step 6): translate entry bodies to Chinese; section headings become 新功能 / 修复 / 优化 / 重构 / 其他.
+- **Strip** (`sync-changelog` step 3): drop the H1, the `### Patch Changes` / `### Minor Changes` / `### Major Changes` subheadings, PR links, and commit-hash links. Drop the `Thanks [@user](...)!` credit only for team members; preserve it for external contributors (see `sync-changelog` "Contributor credit"). Within each entry, drop SDK-only and provider-internal sentences (SDK capability mapping / API exposure, provider wire-format mechanics, internal XML markers) and keep only the user-facing effect and required constraints.
+- **Merge and deduplicate** (`sync-changelog` step 4): merge micro-tweaks to the same surface into one higher-level entry; when three or more fixes target the same UI area or the same class of problem, merge them into one higher-level fix entry (do not merge broad or genuinely distinct fixes); and drop a server/API entry that only backs a web feature already listed.
+- **Classify** (`sync-changelog` step 4): bucket into Features / Bug Fixes / Polish / Refactors / Other; order within each section by reader value (in Polish, user-visible improvements before protocol/internal adjustments).
+- **Translate** (`sync-changelog` step 6): translate entry bodies to Chinese; keep one sentence per entry with a parallel rhythm within a section; render a preserved contributor credit as `（感谢 @user）`; section headings become 新功能 / 修复 / 优化 / 重构 / 其他.
 
 If an upstream entry is not in English, flag it and stop (changeset entries must be English).
 

--- a/.agents/skills/sync-changelog/SKILL.md
+++ b/.agents/skills/sync-changelog/SKILL.md
@@ -107,13 +107,17 @@ Remove:
 - Changesets subheadings such as `### Patch Changes`, `### Minor Changes`, and `### Major Changes`.
 - PR links such as `[#317](...)`.
 - Commit hash links such as ``[`2f51db4`](...)``.
-- The `Thanks [@user](...)!` credit, including the multi-author form `Thanks [@a](...), [@b](...)!`. Drop the whole `Thanks ...!` segment so only the body text remains.
+- The `Thanks [@user](...)!` credit is handled by the "Contributor credit" rule below: drop it for team members, but preserve it for external contributors. Do not silently drop an external contributor's credit.
 
-After stripping, each entry should be only:
+After stripping, each entry is `- <body text>`, optionally followed by a preserved contributor credit (see below).
 
-```markdown
-- <body text>
-```
+Drop SDK-only and provider-internal detail. This changelog serves `@moonshot-ai/kimi-code` CLI and web users. Within an entry, keep only what CLI/web users can perceive, and remove sentences that document internals instead of user-visible behavior. Apply this on both the English and Chinese pages:
+
+- Drop sentences about how the SDK maps a capability, builds model aliases, or exposes a flag through an API such as `getExperimentalFeatures()` — that belongs in the SDK changelog, not here.
+- Drop provider / wire-format implementation mechanics (XML markers like `<tools_added>`, protocol field explanations, "the wire protocol is unchanged", cache-hit mechanics) unless they are the behavior a user perceives.
+- Keep the user-facing effect and any constraints users must follow (for example "question texts must be unique").
+
+Do not change facts or drop a real user-facing behavior — only trim the internal-only scaffolding. For over-long, internal-heavy entries, this trim applies on the English page too, not only in translation.
 
 Web UI prefix: if the entry is a web UI change, prefix the body text with `web: ` so readers can tell it affects the web UI:
 
@@ -123,11 +127,38 @@ Web UI prefix: if the entry is a web UI change, prefix the body text with `web: 
 
 An entry counts as a web UI change when its upstream commit touches `apps/kimi-web/`. Check with `git show --name-only <hash>` (the commit hash is the one stripped above). `gen-changesets` writes this prefix for web changes, so it is usually already present in upstream — preserve it when it is there, and add it when a web entry lacks it. When a commit touches both web and non-web code, use `web:` only if the user-facing change described by the entry is in the web UI. Keep the `web:` prefix on the Chinese page too — it is a scope marker, not translated text.
 
+Contributor credit (`Thanks ...!`): the upstream line ends with `Thanks [@user](https://github.com/<user>)!`, naming the author of the PR that introduced the change. Decide whether to keep it by resolving the source PR (the `[#NNNN]` link on the same entry) and reading `author_association`:
+
+```bash
+gh api repos/MoonshotAI/kimi-code/pulls/<NNNN> --jq .author_association
+```
+
+- `OWNER`, `MEMBER`, or `COLLABORATOR` → treat as **team** → **drop** the credit. Rationale: MoonshotAI team members push branches to the main repo, so they show up as `COLLABORATOR` (org membership is usually private); external contributors submit from forks and show up as `CONTRIBUTOR` / `FIRST_TIME_CONTRIBUTOR`.
+- `CONTRIBUTOR`, `FIRST_TIME_CONTRIBUTOR`, `NONE`, `null`, or an unresolvable PR → external contributor, or unknown → **preserve** the credit.
+
+When preserved, append the credit to the entry body:
+
+- English page: ` Thanks @user!`
+- Chinese page: `（感谢 @user）`
+
+Group entries by the thanks handle; one PR lookup per unique handle is enough. Bias toward preserving when the lookup is inconclusive — wrongly dropping an external contributor's credit is worse than thanking someone on the team. If a classification still looks wrong, note it and confirm with the reviewer rather than guessing silently.
+
 Upstream language rule: `gen-changesets` requires changelog entries to be English. If the upstream CLI changelog contains a non-English entry, stop and report it to the user. Do not silently rewrite it while syncing docs.
 
 Public-text rule: do not copy real internal endpoints, key names, account names, or service names into docs changelogs. Replace examples with neutral placeholders such as `example.com`, `example.test`, or `YOUR_API_KEY` while preserving the user-visible meaning.
 
-### 4. Classify Entries
+### 4. Merge, Deduplicate, And Classify Entries
+
+Before classifying, merge related entries and drop redundant ones from the user-facing changelog:
+
+- **Merge micro-tweaks to the same surface.** Collapse several small tweaks to the same UI area or feature into one concise entry at the higher level. For example, "change the composer's default height" and "change the composer's default font" merge into "Polish the composer's default styling." Use the most specific common ancestor (composer, settings page, tool card, and so on). Classify the merged entry by its combined effect, and keep the `web:` prefix if the combined change is still web-facing.
+- **Merge same-surface or same-kind fixes when you have three or more.** The `Bug Fixes` section tends to accumulate many narrow UI/polish fixes that read as noise when listed one by one. When three or more fixes target the same area (for example several tool cards in the TUI, or the web session/conversation surface) or the same class of problem (for example several "jumping/flickering/collapsing during streaming" fixes), merge them into one higher-level entry. Examples:
+  - "Fix the Bash tool card collapsing...", "Fix the Edit tool card jumping in height...", "Fix the Edit tool card flickering while its result streams in" → "Fix several TUI tool cards jumping, flickering, or collapsing in height when results stream in or end with short output."
+  - "Fix the collapsed sidebar not hiding...", "Stop the chat history from replaying its entrance animation...", "Fix tool components jumping the conversation when expanded/collapsed" → "web: Fix several layout and display glitches when switching sessions, including the collapsed sidebar not hiding, the chat history replaying its entrance animation, and tool components jumping the conversation."
+  - Keep `web:` if the merged fixes are all web-facing. Classify as `Bug Fixes`.
+  - **Do not over-merge.** Leave a fix standalone when it is broad, high-value, or genuinely distinct (for example model/provider tool-calling bugs, session-list corruption, file-completion gaps). Merging is for low-reader-value, similar-shape fixes that read as a wall of similar bullets.
+- **Drop server/API plumbing covered by a web entry.** If one entry adds a web UI feature (for example, an Archived sessions page) and another entry only adds the server or REST/WebSocket endpoints that exist solely to power that web feature, keep the `web:` entry and drop the API entry. CLI and web users perceive the web page; the backing API is implementation detail with no independent user value on this changelog. Keep the API entry only when it has independent user value — a new public endpoint that SDK or server consumers call directly, or a capability usable outside the web feature. When unsure, keep both and let the reviewer decide.
+- **Do not lose external credit.** When you drop or merge an entry that carried an external-contributor thanks, attach that thanks to the surviving entry so the contribution is still credited.
 
 The docs changelog uses five section types:
 
@@ -149,6 +180,8 @@ Classification process:
 
 Features vs. Polish: ask whether the entry introduces something the user could not do before. If yes (new command, flag, mode, viewer, or capability), use `Features`. If it only improves an existing surface (a UI panel that already existed, an existing prompt, an existing tool card, an existing payload pipeline), use `Polish`. Verbs like `Add` do not automatically mean `Features` — a small visual addition to an existing UI is still polish.
 
+Default-behavior changes: changing the default value of an existing capability (for example flipping a feature on by default) is usually `Polish`, because the capability already existed. Use `Features` only when the new default materially changes the out-of-box experience for most users in a way they could not get before. When genuinely ambiguous, flag it and confirm with the reviewer rather than guessing.
+
 Keyword hints:
 
 - **Features**: `Add ... command/flag/option/mode/viewer`, `Introduce`, `Support`, `Allow`, `Enable`, `Implement`, `New ... command/flag/option`
@@ -167,7 +200,8 @@ Omit empty sections. Within each section, order entries by reader value, not ups
 
 1. Put the most valuable, obvious, and larger changes first.
 2. Prefer broad user-visible features, workflow-changing fixes, high-frequency bugs, and large cross-cutting improvements over small polish, narrow edge cases, and internal cleanup.
-3. If entries have similar value, preserve upstream order.
+3. Within `Polish`, put directly user-visible UX or performance improvements (something users can see or feel) before protocol or internal-behavior adjustments (something that makes the model or pipeline behave more reliably but is invisible to users).
+4. If entries have similar value, preserve upstream order.
 
 Do not reword or exaggerate entries just to make them look more important; only reorder existing entries.
 
@@ -247,6 +281,7 @@ Structural fidelity does not mean literal translation. The Chinese entries shoul
 Guidelines:
 
 - **One entry, one sentence.** Avoid chaining multiple effects with commas or semicolons. If the English entry is long, split it into shorter sentences or keep only the most important effect.
+- **Drop SDK-only and provider-internal detail.** Apply the trim from step 3 while translating: keep the user-facing effect and required constraints, drop SDK-mapping sentences, provider / wire-format mechanics, and internal XML markers. A long internal entry should collapse to one short Chinese sentence about what the user gets.
 - **Prefer common changelog verbs**: 新增、支持、修复、优化、改进、调整.
 - **Avoid indirect "through... make..." structures**. Do not write "通过 X，使 Y"; prefer direct cause-effect or just state the result.
   - Bad: `通过缓存已渲染消息行，使终端在长篇对话中保持响应。`
@@ -264,6 +299,7 @@ Guidelines:
   - Bad: `传入 --allowed-host 以允许额外的 host。例如 ... （多句展开）`
   - Better: `例如 kimi web --allowed-host example.com。`
 - **Do not translate technical identifiers**: keep command names, flag names, file names, env vars, config keys, and the `web:` scope prefix as-is.
+- **Keep parallel rhythm within a section.** When several entries fix similar web surfaces (layout, animation, sizing), phrase them with a consistent structure (for example 修复 <问题>，现 <行为>) so the section reads as a tidy list rather than a mix of shapes.
 
 Example — translating a feature entry:
 
@@ -300,7 +336,7 @@ Check:
 - Each version has the same section set and order on both pages.
 - Each section has the same number of entries on both pages.
 - Within each section, the most valuable, obvious, and larger entries appear before smaller or narrower entries.
-- PR links, commit hashes, and the `Thanks ...!` credit were stripped.
+- PR links and commit hashes were stripped; the `Thanks ...!` credit was dropped for team members and preserved for external contributors.
 - Real internal identifiers were replaced with neutral placeholders.
 - There are no empty sections.
 - Markdown indentation and blank lines are intact.
@@ -416,7 +452,11 @@ Return the PR URL to the user when done.
 | Mistake | Fix |
 |---|---|
 | Adding entries directly to the English docs page without reading upstream | Use `apps/kimi-code/CHANGELOG.md` as the source |
-| Copying PR links, commit hashes, or the `Thanks ...!` credit into docs | Strip them; keep only body text |
+| Copying PR links or commit hashes into docs | Strip them; keep only body text |
+| Dropping every `Thanks ...!` credit | Drop it only for team members; preserve `Thanks @user!` (EN) / `（感谢 @user）` (ZH) for external contributors |
+| Leaving near-duplicate micro-tweaks as separate bullets | Merge small tweaks to the same surface into one higher-level entry (e.g. composer height + font → composer's default styling) |
+| Listing many narrow fixes to the same surface as separate bullets | When three or more fixes target the same UI area or the same class of problem, merge them into one higher-level fix entry; keep genuinely distinct or high-value fixes standalone |
+| Listing a server/API entry that only backs a web feature already listed | Drop the API entry and keep the `web:` entry, unless the API has independent user value |
 | Rewording upstream English entries | Upstream is frozen; copy the body text unless the user explicitly asks otherwise |
 | Leaving English text untranslated in the Chinese page | The Chinese page must be fully Chinese except preserved technical terms |
 | Editing upstream changelog text | Do not edit upstream |


### PR DESCRIPTION
## Related Issue

N/A — agent-skill maintenance for the changelog workflow

## Problem

The `/pre-changelog` and `/sync-changelog` skills produced release notes that read like a raw changeset dump:
- Many narrow fixes to the same UI surface were listed as separate bullets, making the \`Bug Fixes\` section a wall of similar entries.
- A web feature and the server/API changes that only backed it were both listed, even though users only perceive the web feature.
- SDK-only and provider/wire-format internals (capability mapping, XML markers, \`getExperimentalFeatures()\`) leaked into the CLI changelog.
- The \`Thanks @user\` credit was stripped for everyone, so external contributors were not credited.
- The \`Polish\` section mixed user-visible UX improvements with internal protocol adjustments without consistent ordering.

## What changed

Updated three agent skills under \`.agents/skills/\`. No product code changed.

- \`sync-changelog/SKILL.md\`
  - New "Merge same-surface or same-kind fixes when you have three or more" rule so repetitive narrow fixes collapse into one higher-level entry; broad or genuinely distinct fixes stay standalone.
  - New "Contributor credit" rule: drop \`Thanks ...!\` for team members (\`OWNER\`/\`MEMBER\`/\`COLLABORATOR\`) but preserve it for external contributors (\`CONTRIBUTOR\`/\`FIRST_TIME_CONTRIBUTOR\`/\`NONE\`, or when unresolvable). Renders as \`Thanks @user!\` (EN) / \`（感谢 @user）\` (ZH).
  - Trim SDK-only and provider-internal detail from entries on both English and Chinese pages; keep the user-facing effect and required constraints.
  - Keep user-visible UX/performance improvements before protocol/internal adjustments within \`Polish\`; default-behavior changes usually classify as \`Polish\`.
  - Encourage a parallel sentence rhythm within a section on the Chinese page.
- \`pre-changelog/SKILL.md\`: step 3 now mirrors the merge / deduplicate / thanks / trim / ordering rules above so the preview matches the real sync.
- \`gen-changesets/SKILL.md\`: soften the "always split web + server API" guidance so a web feature whose server API is pure plumbing produces a single \`web:\` changeset, with a separate API changeset only when the API has independent user value.

This is skill-only guidance and does not enter any package output, so no changeset is needed (per Core Rule 5 of \`gen-changesets\`).

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [ ] I have added tests that prove my feature works. (N/A — agent-skill docs only)
- [x] Ran \`gen-changesets\` skill, or this PR needs no changeset. (No changeset — skill-only change, not in any package output)
- [x] Ran \`gen-docs\` skill, or this PR needs no doc update. (No user-facing product behavior change)