### PR TITLE
chore: downgrade #1432 changeset to patch

### DIFF
--- a/.changeset/anthropic-preserved-thinking-by-default.md
+++ b/.changeset/anthropic-preserved-thinking-by-default.md
@@ -1,5 +1,5 @@
 ---
-"@moonshot-ai/kimi-code": minor
+"@moonshot-ai/kimi-code": patch
 ---
 
 Preserve prior turns' thinking by default on the Anthropic provider (Claude and Kimi's Anthropic-compatible mode), matching the Kimi default. Disable with `[thinking] keep = "off"` or `KIMI_MODEL_THINKING_KEEP=off`.


### PR DESCRIPTION
## Related PR

#1432

## Problem

The changeset added in #1432 currently bumps `@moonshot-ai/kimi-code` as `minor`, but this change should be released as a `patch`.

## What changed

- Updated `.changeset/anthropic-preserved-thinking-by-default.md` to use `patch` instead of `minor`.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.
