### PR TITLE
fix(kimi-web): shrink collapsed thinking block on mobile

### DIFF
--- a/apps/kimi-web/src/components/chat/ThinkingBlock.vue
+++ b/apps/kimi-web/src/components/chat/ThinkingBlock.vue
@@ -35,7 +35,7 @@ const isFoldable = computed(() => props.foldable && paragraphs.value.length > 1)
 const open = computed(() => props.streaming || !isFoldable.value);
 
 /** Last non-empty paragraph, shown as the collapsed teaser. */
-const teaser = computed(() => paragraphs.value.pop() ?? '');
+const teaser = computed(() => paragraphs.value.at(-1) ?? '');
 
 const bodyEl = ref<HTMLElement | null>(null);
 
@@ -99,7 +99,13 @@ watch(
 }
 .tc-anim,
 .prev-anim {
+  /* min-height: 0 is required for the 0fr/1fr grid collapse to actually shrink
+     below the tracks' content. Without it, an inner scroll container (`.tc`,
+     overflow-y: auto) contributes its content as the automatic minimum, so the
+     row keeps its streaming height and never collapses to the short teaser —
+     most visible on iOS Safari. */
   overflow: hidden;
+  min-height: 0;
 }
 
 /* Hover hints clickability (opens the full text in the side panel) */


### PR DESCRIPTION
## Related Issue

No tracking issue. Follows up on a mobile kimi-web visual regression report.

## Problem

On mobile the collapsible thinking block could grow tall while streaming and then fail to shrink back when the stream ended and it folded into the one-paragraph teaser. A short last paragraph would leave the block stuck at its previous streaming height, most visible on iOS Safari.

Root causes:

- The `0fr`/`1fr` grid-collapse rows had no explicit `min-height`, so the inner `overflow-y: auto` `.tc` element contributed its streaming content as the track's automatic minimum size, keeping the row tall after collapse.
- The teaser read the last paragraph with `paragraphs.value.pop()`, which mutates the cached computed array and could shift the teaser to the wrong paragraph across renders.

## What changed

- Added `min-height: 0` to the `.tc-anim` and `.prev-anim` grid tracks so the collapse shrinks below nested scroll content.
- Switched the teaser to `paragraphs.value.at(-1)` so the cached paragraph list is not mutated.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] Ran pnpm --filter @moonshot-ai/kimi-web typecheck.
- [x] Ran oxlint on the changed file.
- [x] Ran gen-changesets skill, or this PR needs no changeset.
