### PR TITLE
fix(kosong): fall back to nearest lower catalogued minor for Claude max tokens

### DIFF
--- a/.changeset/opus-4-8-max-tokens.md
+++ b/.changeset/opus-4-8-max-tokens.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Fix newer Claude minor versions (e.g. Opus 4.8) defaulting to the family-baseline max output tokens; an uncatalogued minor now reuses the nearest earlier known version's limit.

--- a/packages/kosong/src/providers/anthropic.ts
+++ b/packages/kosong/src/providers/anthropic.ts
@@ -158,8 +158,9 @@ const ANTHROPIC_TOOL_CALL_ID_POLICY: ToolCallIdPolicy = {
 const CEILING_BY_FAMILY_VERSION: Readonly<Record<string, number>> = {
   // Claude Fable 5 documents a 128k output ceiling.
   'fable-5': 128000,
-  // Claude Opus per minor version. 4.6 and 4.7 raised the cap to 128k;
+  // Claude Opus per minor version. 4.6 through 4.8 document a 128k cap;
   // 4.5 ships at 64k; 4.1 and the dated 4.0 release stay at 32k.
+  'opus-4-8': 128000,
   'opus-4-7': 128000,
   'opus-4-6': 128000,
   'opus-4-5': 64000,

--- a/packages/kosong/src/providers/anthropic.ts
+++ b/packages/kosong/src/providers/anthropic.ts
@@ -151,9 +151,9 @@ const ANTHROPIC_TOOL_CALL_ID_POLICY: ToolCallIdPolicy = {
  * can silently truncate mid-`tool_use`.
  *
  * Keys are `<family>-<major>[-<minor>]`. Lookups try the most specific
- * key first, then fall back to the family/major-only entry, so an
- * unrecognized minor version (e.g. a future `opus-4-10`) gets the
- * family's baseline rather than the generic fallback.
+ * key first, then the nearest lower catalogued minor of the same
+ * family/major (a not-yet-catalogued `opus-4-8` reuses `opus-4-7`'s
+ * ceiling), and finally the family/major-only baseline entry.
  */
 const CEILING_BY_FAMILY_VERSION: Readonly<Record<string, number>> = {
   // Claude Fable 5 documents a 128k output ceiling.
@@ -269,8 +269,16 @@ function parseClaudeFamilyVersion(model: string, requireClaudeMarker: boolean): 
 function lookupClaudeCeiling(version: ClaudeVersion): number | undefined {
   const { family, major, minor } = version;
   if (minor !== null) {
-    const exact = CEILING_BY_FAMILY_VERSION[`${family}-${major}-${minor}`];
-    if (exact !== undefined) return exact;
+    // Exact minor first, then walk down to the nearest catalogued minor:
+    // a newer minor release inherits at least its predecessor's ceiling
+    // (Anthropic has never lowered the cap within a major), so a
+    // not-yet-catalogued 4.8 reuses 4.7's value instead of dropping to
+    // the family baseline. The regex caps minors at two digits, so this
+    // walk is bounded.
+    for (let candidate = minor; candidate >= 0; candidate--) {
+      const ceiling = CEILING_BY_FAMILY_VERSION[`${family}-${major}-${candidate}`];
+      if (ceiling !== undefined) return ceiling;
+    }
   }
   return CEILING_BY_FAMILY_VERSION[`${family}-${major}`];
 }

--- a/packages/kosong/test/anthropic.test.ts
+++ b/packages/kosong/test/anthropic.test.ts
@@ -2619,6 +2619,7 @@ describe('AnthropicChatProvider', () => {
 describe('resolveDefaultMaxTokens', () => {
   it('returns per-version Messages-API caps for known Claude 4 models', () => {
     expect(resolveDefaultMaxTokens('claude-fable-5')).toBe(128000);
+    expect(resolveDefaultMaxTokens('claude-opus-4-8')).toBe(128000);
     expect(resolveDefaultMaxTokens('claude-opus-4-7')).toBe(128000);
     expect(resolveDefaultMaxTokens('claude-opus-4-6')).toBe(128000);
     expect(resolveDefaultMaxTokens('claude-opus-4-5-20251101')).toBe(64000);
@@ -2650,6 +2651,7 @@ describe('resolveDefaultMaxTokens', () => {
   });
 
   it('matches dotted version separators', () => {
+    expect(resolveDefaultMaxTokens('claude-opus-4.8')).toBe(128000);
     expect(resolveDefaultMaxTokens('claude-opus-4.7')).toBe(128000);
     expect(resolveDefaultMaxTokens('claude-opus-4.6')).toBe(128000);
     expect(resolveDefaultMaxTokens('claude-sonnet-4.6')).toBe(64000);
@@ -2673,10 +2675,9 @@ describe('resolveDefaultMaxTokens', () => {
   });
 
   it('falls back to the nearest lower catalogued minor for unknown minors', () => {
-    // opus-4-8 is not in the table; it reuses opus-4-7's 128k ceiling
-    // (a newer minor inherits at least its predecessor's cap).
-    expect(resolveDefaultMaxTokens('claude-opus-4-8')).toBe(128000);
-    expect(resolveDefaultMaxTokens('claude-opus-4.8')).toBe(128000);
+    // opus-4-9/4-10 are not in the table; they reuse opus-4-8's 128k
+    // ceiling (a newer minor inherits at least its predecessor's cap).
+    expect(resolveDefaultMaxTokens('claude-opus-4-9')).toBe(128000);
     expect(resolveDefaultMaxTokens('claude-opus-4-10')).toBe(128000);
     expect(resolveDefaultMaxTokens('claude-sonnet-4-9')).toBe(64000);
     expect(resolveDefaultMaxTokens('claude-haiku-4-9')).toBe(64000);

--- a/packages/kosong/test/anthropic.test.ts
+++ b/packages/kosong/test/anthropic.test.ts
@@ -2672,12 +2672,16 @@ describe('resolveDefaultMaxTokens', () => {
     expect(resolveDefaultMaxTokens('anthropic.claude-3-5-sonnet-20240620-v1:0')).toBe(8192);
   });
 
-  it('falls back to family-only ceiling for unknown minor versions', () => {
-    // Future opus-4-X release: minor not in table, falls back to opus-4 = 32000.
-    // Better to under-quote and fail loudly than over-quote a model we can't verify.
-    expect(resolveDefaultMaxTokens('claude-opus-4-10')).toBe(32000);
+  it('falls back to the nearest lower catalogued minor for unknown minors', () => {
+    // opus-4-8 is not in the table; it reuses opus-4-7's 128k ceiling
+    // (a newer minor inherits at least its predecessor's cap).
+    expect(resolveDefaultMaxTokens('claude-opus-4-8')).toBe(128000);
+    expect(resolveDefaultMaxTokens('claude-opus-4.8')).toBe(128000);
+    expect(resolveDefaultMaxTokens('claude-opus-4-10')).toBe(128000);
     expect(resolveDefaultMaxTokens('claude-sonnet-4-9')).toBe(64000);
     expect(resolveDefaultMaxTokens('claude-haiku-4-9')).toBe(64000);
+    // A gap between catalogued minors also resolves to the nearest lower one.
+    expect(resolveDefaultMaxTokens('claude-opus-4-3')).toBe(32000);
   });
 
   it('matches case-insensitively', () => {


### PR DESCRIPTION
## Related Issue

No linked issue — the problem is explained below.

## Problem

The default `max_tokens` for Anthropic requests is resolved from a per-version ceiling table keyed by `<family>-<major>-<minor>`. A minor version missing from the table fell straight through to the family/major baseline, so `claude-opus-4-8` (not catalogued at the time) resolved to the `opus-4` baseline of 32k instead of the 128k output ceiling Opus 4.8 actually documents. Any request on Opus 4.8 was silently capped at a quarter of its real output budget, which can truncate long responses mid-`tool_use`.

## What changed

Two complementary fixes:

1. **Nearest-lower-minor fallback.** The ceiling lookup now walks the minor version downward to the nearest catalogued entry of the same family/major before using the family baseline. Anthropic has not lowered the output cap within a major version, so a newer uncatalogued minor inheriting its predecessor's ceiling is the safe default: a future `opus-4-9`/`opus-4-10` reuses the latest catalogued Opus 4.x ceiling, and gaps between catalogued minors resolve to the nearest lower one (`opus-4-3` gets `opus-4-1`'s 32k). The walk is bounded because the version regex caps minors at two digits. An explicit caller override is still honored and clamped as before.
2. **Explicit entry for Opus 4.8.** Known models should resolve from documented table entries rather than lean on the fallback, so `opus-4-8` is now catalogued at its documented 128k ceiling (Fable 5 already had an explicit entry). The fallback remains as the safety net for minors released after this table was last updated.

One existing test pinned the old under-quote-by-default behavior (`claude-opus-4-10` → 32k); it now asserts the nearest-lower-minor fallback, with added coverage for dashed/dotted `opus-4.8` ids and the gap case.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.