### PR TITLE
chore: correct wire request trace changeset

### DIFF
--- a/.changeset/wire-request-trace.md
+++ b/.changeset/wire-request-trace.md
@@ -1,7 +1,5 @@
 ---
-"@moonshot-ai/agent-core": minor
-"@moonshot-ai/kimi-code": minor
-"@moonshot-ai/kosong": minor
+"@moonshot-ai/kimi-code": patch
 ---
 
-Record a request trace in each agent's `wire.jsonl`: content-addressed snapshots of the tool schemas sent to the model, one record per model request (including retries, strict resends, and compaction rounds) with the effective request parameters, and the raw MCP tool listing per server, so sessions carry enough data to reconstruct every model request for debugging. Chat providers now expose the effective completion-token cap they send on the wire, so the trace records the provider-clamped value rather than the requested budget.
+Record a per-request trace in the session wire log, so model requests can be reconstructed for debugging. Not a user-facing feature.


### PR DESCRIPTION
## Related Issue

No related issue. This corrects the changeset added in #1448.

## Problem

PR #1448 records a per-request trace in the session wire log for debugging, but its changeset bumped the CLI and private internal packages as `minor`. The change does not introduce user-visible CLI behavior, and `@moonshot-ai/agent-core` / `@moonshot-ai/kosong` are private internal packages that are not published.

## What changed

- Limit the changeset to `@moonshot-ai/kimi-code`.
- Downgrade the bump from `minor` to `patch`.
- Shorten the changelog text to one honest sentence.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [ ] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.