### PR TITLE
fix(agent-core): hide console window when running hooks on Windows

### DIFF
--- a/.changeset/fix-hooks-windows-console-popup.md
+++ b/.changeset/fix-hooks-windows-console-popup.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Fix console windows flashing on Windows each time a hook runs.

--- a/packages/agent-core/src/session/hooks/runner.ts
+++ b/packages/agent-core/src/session/hooks/runner.ts
@@ -1,4 +1,4 @@
-import { spawn, type ChildProcessWithoutNullStreams } from 'node:child_process';
+import { spawn, type ChildProcessWithoutNullStreams, type SpawnOptionsWithoutStdio } from 'node:child_process';
 
 import { z } from 'zod';
 
@@ -9,6 +9,24 @@ export interface RunHookOptions {
   readonly cwd?: string;
   readonly env?: Readonly<Record<string, string>>;
   readonly signal?: AbortSignal;
+}
+
+export function buildHookSpawnOptions(options: {
+  cwd?: string;
+  env?: Readonly<Record<string, string>>;
+}): SpawnOptionsWithoutStdio {
+  return {
+    shell: true,
+    cwd: options.cwd,
+    stdio: 'pipe',
+    detached: process.platform !== 'win32',
+    // Hide the console Windows would otherwise allocate for the shell child.
+    // Without `windowsHide:true`, each hook flashes a visible console window —
+    // the same regression the Bash tool path already guards against in KAOS
+    // (see `buildLocalSpawnOptions`). Unconditional: it is a no-op on POSIX.
+    windowsHide: true,
+    env: options.env ? { ...process.env, ...options.env } : undefined,
+  };
 }
 
 const DEFAULT_TIMEOUT_SECONDS = 30;
@@ -46,13 +64,7 @@ export async function runHook(
 ): Promise<HookResult> {
   let child: ChildProcessWithoutNullStreams;
   try {
-    child = spawn(command, {
-      shell: true,
-      cwd: options.cwd,
-      stdio: 'pipe',
-      detached: process.platform !== 'win32',
-      env: options.env ? { ...process.env, ...options.env } : undefined,
-    });
+    child = spawn(command, buildHookSpawnOptions({ cwd: options.cwd, env: options.env }));
   } catch (error) {
     return allowResult({ stderr: errorMessage(error) });
   }

--- a/packages/agent-core/test/hooks/runner.test.ts
+++ b/packages/agent-core/test/hooks/runner.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
+import { buildHookSpawnOptions } from '../../src/session/hooks/runner';
+
 const RUNNER_MODULE = '../../src/session/hooks/runner' as string;
 
 interface HookResult {
@@ -96,5 +98,29 @@ describe('runHook process runner', () => {
       'node -e "let s=\\"\\";process.stdin.on(\\"data\\",d=>s+=d);process.stdin.on(\\"end\\",()=>{const o=JSON.parse(s);process.stdout.write(o.tool_name);})"';
     const result = await runHook(cmd, { tool_name: 'WriteFile' }, { timeout: 5 });
     expect(result.stdout?.trim()).toBe('WriteFile');
+  });
+});
+
+// Regression coverage for the "every hook flashes an empty console window on
+// Windows" bug. With `shell:true` and no `windowsHide`, Node allocates a
+// visible console for each hook child process on Windows. The fix is to pass
+// `windowsHide:true` (mirrors KAOS' `buildLocalSpawnOptions` and the runner's
+// own taskkill spawn). The flag is only observable on Windows, so we assert
+// the spawn options builder directly.
+describe('buildHookSpawnOptions (Windows console-window regression)', () => {
+  it('sets windowsHide:true so hooks do not flash a console on Windows', () => {
+    expect(buildHookSpawnOptions({}).windowsHide).toBe(true);
+  });
+
+  it('runs through the shell with stdio piped', () => {
+    const options = buildHookSpawnOptions({});
+    expect(options.shell).toBe(true);
+    expect(options.stdio).toBe('pipe');
+  });
+
+  it('merges hook env onto process.env and forwards cwd', () => {
+    const options = buildHookSpawnOptions({ cwd: '/repo', env: { FOO: 'bar' } });
+    expect(options.cwd).toBe('/repo');
+    expect(options.env).toMatchObject({ FOO: 'bar' });
   });
 });


### PR DESCRIPTION
<!-- Thank you for your contribution to Kimi Code! -->

## Related Issue

Relates to #1298.

## Problem

On Windows, every hook command spawned a visible console window (mintty / Git Bash) that briefly stole foreground focus. This is the same root cause reported in #1298, but in the hook runner path, which the earlier fix did not cover. The Bash tool path was already hardened with `windowsHide: true`; the hook runner's process `spawn` was missing the `windowsHide` flag, even though its own `taskkill` helper already passed it.

## What changed

Pass `windowsHide: true` when spawning the hook process, so hooks run silently without flashing a console window on Windows. The spawn options were extracted into a pure builder so the flag can be covered by a regression test, mirroring the existing KAOS spawn-options regression test.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update. (No doc update needed — a bug fix restoring expected behavior.)
