### PR TITLE
chore(telemetry): sample system metrics every 5 minutes

### DIFF
--- a/packages/telemetry/src/systemMetrics.ts
+++ b/packages/telemetry/src/systemMetrics.ts
@@ -2,7 +2,7 @@ import { cpus, freemem, loadavg, totalmem } from 'node:os';
 
 import type { TelemetryProperties } from './types';
 
-const DEFAULT_INTERVAL_MS = 30_000;
+const DEFAULT_INTERVAL_MS = 300_000;
 const DEFAULT_WARMUP_SAMPLE_MS = 1_500;
 const SYSTEM_METRICS_EVENT = 'system_metrics';
 


### PR DESCRIPTION
<!--
Thank you for your contribution to Kimi Code!
Please open an issue before sending a feature PR — PRs without prior discussion may be closed without review.

See https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md for more.
-->

## Related Issue

<!-- Link the issue this feature came from. If there is no issue, explain the problem in the next section instead. -->

No related issue.

## Problem

<!-- What user need or limitation does this address? If the linked issue already covers this, write "See linked issue". -->

The `system_metrics` telemetry event is sampled every 30 seconds by default. For resource-usage monitoring this cadence is higher than necessary and produces more telemetry volume than needed.

## What changed

<!-- What did you implement, and why does this approach fit Kimi Code? -->

Raised the default sampling interval of `SystemMetricsCollector` from 30s to 5min by changing `DEFAULT_INTERVAL_MS` in `packages/telemetry/src/systemMetrics.ts` from `30_000` to `300_000`.

This keeps the collector's behavior and public options unchanged; only the default cadence changes. Callers and tests that pass an explicit `intervalMs` (including the existing `SystemMetricsCollector` tests) are unaffected.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [ ] I have added tests that prove my feature works. (Existing `SystemMetricsCollector` tests already cover the sampling loop and pass with an explicit `intervalMs`; a default-constant change does not need new coverage.)
- [x] Ran `gen-changesets` skill, or this PR needs no changeset. (Telemetry-only change; no changeset per repo convention.)
- [x] Ran `gen-docs` skill, or this PR needs no doc update. (Internal telemetry tuning; no user-facing behavior or doc change.)
