### PR TITLE
fix(web): dismiss stale connection error toast after ws reconnect

### DIFF
--- a/.changeset/fix-web-ws-reconnect-toast.md
+++ b/.changeset/fix-web-ws-reconnect-toast.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+web: Fix the connection error toast lingering after the WebSocket reconnects when returning from the background.

--- a/apps/kimi-web/src/composables/useKimiWebClient.ts
+++ b/apps/kimi-web/src/composables/useKimiWebClient.ts
@@ -929,6 +929,12 @@ function connectEventsIfNeeded(): void {
     onConnectionChange(connected: boolean) {
       rawState.connected = connected;
       rawState.connection = connected ? 'connected' : 'disconnected';
+      // The data channel is healthy again (server_hello received). Clear any
+      // stale "Realtime connection error" toast instead of relying on its
+      // auto-dismiss timer: iOS Safari freezes timers while a tab is
+      // backgrounded, so the toast would otherwise linger until a manual
+      // refresh even though the reconnect already succeeded.
+      if (connected) dismissWsError();
     },
   });
 }
@@ -1093,6 +1099,19 @@ function operationFailureNotice(
 
 function pushWarning(warning: AppWarning): void {
   rawState.warnings = [...rawState.warnings, warning];
+}
+
+// Drop every "Realtime connection error" notice pushed by the WS onError
+// handler. Matched by severity + the localized wsTitle (the same i18n instance
+// used to push it), so other errors are left untouched.
+function dismissWsError(): void {
+  const title = i18n.global.t('warnings.wsTitle');
+  const next = rawState.warnings.filter(
+    (w) => !(typeof w === 'object' && w !== null && w.severity === 'error' && w.title === title),
+  );
+  if (next.length !== rawState.warnings.length) {
+    rawState.warnings = next;
+  }
 }
 
 function pushOperationFailure(


### PR DESCRIPTION
<!--
Thank you for your contribution to Kimi Code!
Please open an issue before sending a feature PR — PRs without prior discussion may be closed without review.

See https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md for more.
-->

## Related Issue

No linked issue. Reported via in-product feedback.

## Problem

On iOS Safari, after the tab is backgrounded for ~30s and brought back to the foreground, the WebSocket reconnects successfully and messages flow again, but the "Realtime connection error" toast stays on screen until the page is manually refreshed.

iOS Safari freezes the page's timers while a tab is in the background. The connection error toast is dismissed only by an auto-dismiss timer, so a timer that started before or during backgrounding is still frozen when the user returns. The foreground recovery path restores the WebSocket data channel but never clears the warning, so the stale toast lingers even though the connection is already healthy.

## What changed

When the connection state machine transitions to connected (after the server handshake completes), the web client now drops any pending realtime-connection-error warning from the warning list instead of relying on its auto-dismiss timer. The existing toast reconcile then removes the toast and clears its (possibly frozen) timer. This keeps the current recovery behavior and ties UI cleanup to the same reconnection signal.

No new test: `useKimiWebClient` is a module-level singleton with no existing test harness, and adding one is disproportionate for this targeted fix. Typecheck and the existing kimi-web test suite (358 tests) pass.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [ ] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.
