### PR TITLE
fix: count goal creation turn

### DIFF
--- a/.changeset/count-created-goal-turn.md
+++ b/.changeset/count-created-goal-turn.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Count the turn that starts an autonomous goal toward its goal turn usage.

--- a/packages/agent-core/src/agent/turn/index.ts
+++ b/packages/agent-core/src/agent/turn/index.ts
@@ -370,6 +370,13 @@ export class TurnFlow {
         end.event.reason !== 'failed' &&
         end.event.reason !== 'filtered'
       ) {
+        // The ordinary turn created or resumed the goal, so it counts as the
+        // first active goal turn before the continuation driver takes over.
+        const countedGoal = await this.agent.goal.incrementTurn();
+        if (countedGoal?.budget.overBudget === true) {
+          await this.agent.goal.markBlocked({ reason: 'A configured budget was reached' });
+          return end;
+        }
         return await this.driveGoal(
           this.allocateTurnId(),
           [{ type: 'text', text: GOAL_CONTINUATION_PROMPT }],

--- a/packages/agent-core/test/harness/goal-session.test.ts
+++ b/packages/agent-core/test/harness/goal-session.test.ts
@@ -291,7 +291,51 @@ describe('goal session end-to-end', () => {
     );
     const turnStarts = events.filter((e) => e['type'] === 'turn.started').length;
     expect(turnStarts).toBeGreaterThanOrEqual(2);
+    const completionEvent = events.find((event) => {
+      const change = event['change'] as Record<string, unknown> | undefined;
+      return event['type'] === 'goal.updated' && change?.['kind'] === 'completion';
+    });
+    expect(completionEvent?.['change']).toMatchObject({
+      kind: 'completion',
+      stats: expect.objectContaining({ turnsUsed: 2 }),
+    });
     expect((await api.getGoal({ agentId: 'main' })).goal).toBeNull();
+  });
+
+  it('does not start a synthetic continuation when creating the goal exhausts its turn budget', async () => {
+    const sessionDir = await makeTempDir();
+    const events: Array<Record<string, unknown>> = [];
+    const { session, agent, scripted } = await setupSession(sessionDir, events, [
+      'CreateGoal',
+      'SetGoalBudget',
+    ]);
+    const api = new SessionAPIImpl(session);
+
+    scripted.mockNextResponse({
+      type: 'function',
+      id: 'create',
+      name: 'CreateGoal',
+      arguments: JSON.stringify({ objective: 'work' }),
+    });
+    scripted.mockNextResponse({
+      type: 'function',
+      id: 'budget',
+      name: 'SetGoalBudget',
+      arguments: JSON.stringify({ value: 1, unit: 'turns' }),
+    });
+    scripted.mockNextResponse({ type: 'text', text: 'Goal created with a one-turn budget.' });
+
+    agent.turn.prompt([{ type: 'text', text: 'Please start a one-turn goal' }]);
+    await agent.turn.waitForCurrentTurn();
+
+    const goal = (await api.getGoal({ agentId: 'main' })).goal;
+    expect(goal?.status).toBe('blocked');
+    expect(goal?.turnsUsed).toBe(1);
+    expect(scripted.calls).toHaveLength(3);
+    expect(events.filter((e) => e['type'] === 'turn.started')).toHaveLength(1);
+    expect(JSON.stringify(agent.context.history)).not.toContain(
+      'Continue working toward the active goal',
+    );
   });
 
   it('keeps the active turn alive (cancelable) while driving a goal created mid-turn', async () => {


### PR DESCRIPTION
## Related Issue

No linked issue. This PR fixes a focused goal-mode accounting bug.

## Problem

When the model created a goal during an ordinary turn, that turn did not count toward the goal's turn usage. The next continuation turn became turn 1, so completion summaries and turn budgets undercounted the work already done to start the goal.

## What changed

- Count the ordinary turn that creates or resumes an active goal before the continuation driver runs.
- Added a goal-session regression test that completes a model-created goal and checks the final turn count.
- Added a patch changeset for the CLI release.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.
