### PR TITLE
fix(kimi-code): exit 1 when a headless (-p) turn fails

### DIFF
--- a/.changeset/fix-headless-exit-code.md
+++ b/.changeset/fix-headless-exit-code.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Fix `kimi -p` runs exiting with code 0 when a turn fails.

--- a/apps/kimi-code/src/cli/run-prompt.ts
+++ b/apps/kimi-code/src/cli/run-prompt.ts
@@ -44,7 +44,11 @@ import { createKimiCodeHostIdentity } from './version';
  *
  * Used to bound shutdown so a wedged cleanup step can't keep a completed
  * headless run alive, without silently swallowing a cleanup that fails fast. The
- * timer is unref'd so it never keeps the loop alive on its own.
+ * timer stays ref'd so a cleanup step that suspends on an unref'd handle (e.g.
+ * telemetry's retry backoff when the network is blocked) can't drain the event
+ * loop and exit 0 before the rejection propagates — the timer keeps the loop
+ * alive until it fires, then gives the rejection a chance to surface. A wedged
+ * cleanup is still bounded by `timeoutMs`, so this can't hang the run forever.
  */
 async function raceWithTimeout(promise: Promise<void>, timeoutMs: number): Promise<void> {
   let timedOut = false;
@@ -61,7 +65,6 @@ async function raceWithTimeout(promise: Promise<void>, timeoutMs: number): Promi
       timedOut = true;
       resolve();
     }, timeoutMs);
-    timer.unref?.();
   });
   try {
     await Promise.race([guarded, timedOutSignal]);

--- a/apps/kimi-code/src/main.ts
+++ b/apps/kimi-code/src/main.ts
@@ -172,6 +172,16 @@ export function main(): void {
           }
         })
         .catch(async (error: unknown) => {
+          // Set the failure exit code synchronously, before any `await`. The
+          // terminal `process.exit(1)` below is our intended exit, but it sits
+          // behind `await logStartupFailure(...)`; by the time we reach that
+          // await, the failed run's `finally` cleanup has already torn down its
+          // ref'd handles (sockets, timers, background tasks). If the event loop
+          // drains during the await, Node exits on its own with the DEFAULT code
+          // 0 and `process.exit(1)` never runs — headless (`kimi -p`) failures
+          // would then exit 0 nondeterministically. Setting `process.exitCode`
+          // up front makes that drain-exit report failure too.
+          process.exitCode = 1;
           const operation = opts.prompt !== undefined ? 'run prompt' : 'start shell';
           await logStartupFailure(operation, error);
           process.stderr.write(

--- a/apps/kimi-code/test/cli/main.test.ts
+++ b/apps/kimi-code/test/cli/main.test.ts
@@ -32,6 +32,7 @@ const mocks = vi.hoisted(() => {
     })),
     initializeCliTelemetry: vi.fn(),
     handleUpgrade: vi.fn(),
+    flushDiagnosticLogs: vi.fn(),
     finalizeHeadlessRun: vi.fn(),
     log: {
       info: vi.fn(),
@@ -80,6 +81,7 @@ vi.mock('@moonshot-ai/kimi-code-sdk', async () => {
       mocks.createKimiHarness(...args);
       return mocks.harness;
     },
+    flushDiagnosticLogs: mocks.flushDiagnosticLogs,
     KimiHarness: MockKimiHarness,
     log: mocks.log,
   };
@@ -215,6 +217,7 @@ describe('main entry command handling', () => {
     mocks.harness.close.mockResolvedValue(undefined);
     mocks.shutdownTelemetry.mockResolvedValue(undefined);
     mocks.handleUpgrade.mockResolvedValue(0);
+    mocks.flushDiagnosticLogs.mockResolvedValue(undefined);
   });
 
   it('runs update preflight before starting the shell', async () => {
@@ -299,6 +302,34 @@ describe('main entry command handling', () => {
     // The exit code is resolved lazily so a goal turn that sets process.exitCode wins.
     const forceExitArgs = mocks.finalizeHeadlessRun.mock.calls[0] as unknown as unknown[];
     expect(typeof forceExitArgs[2]).toBe('function');
+  });
+
+  it('sets the failure exit code before awaiting startup failure logging', async () => {
+    const originalExitCode = process.exitCode;
+    const opts: CLIOptions = { ...defaultOpts(), prompt: 'explain the repo' };
+    mocks.validateOptions.mockReturnValue({ options: opts, uiMode: 'print' });
+    mocks.runUpdatePreflight.mockResolvedValue('continue');
+    mocks.runPrompt.mockRejectedValue(new Error('provider failed'));
+    mocks.flushDiagnosticLogs.mockImplementation(() => new Promise(() => {}));
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation((code?: string | number | null) => {
+      throw new ExitCalled(Number(code ?? 0));
+    });
+
+    try {
+      main();
+      const programArgs = mocks.createProgram.mock.calls[0] as unknown as unknown[];
+      const mainAction = programArgs[1] as (opts: CLIOptions) => void;
+      mainAction(opts);
+
+      await waitForAssertion(() => {
+        expect(mocks.flushDiagnosticLogs).toHaveBeenCalledTimes(1);
+      });
+      expect(process.exitCode).toBe(1);
+      expect(exitSpy).not.toHaveBeenCalled();
+    } finally {
+      exitSpy.mockRestore();
+      process.exitCode = originalExitCode;
+    }
   });
 
   it('keeps shell mode update preflight interactive by default', async () => {


### PR DESCRIPTION
## Related Issue

No linked issue. Found while investigating two failed benchmark runs of `kimi -p` that exited cleanly but scored 0.

## Problem

Headless (`kimi -p`) runs could exit with code **0** when a turn fails, instead of code **1**. To a caller (e.g. the benchmark harness) this looks like a successful run, so the failure goes unnoticed.

**Root cause.** When a turn fails, the error has to traverse an async chain to reach the `process.exit(1)` call:

```
runPromptTurn reject → runPrompt finally { await cleanupPromptRun() }
                     → main .catch() → await logStartupFailure() → process.exit(1)
```

Node only keeps the process alive while the event loop has a ref'd handle; a pending promise does not count. The cleanup's `await`s (notably telemetry's unref'd retry backoff when the network is blocked) can leave the loop with no ref'd handle, so Node drains and exits with the default code **0** before `process.exit(1)` ever runs.

There are two distinct drain points:

- **Scenario B** — `runPrompt`'s `finally { await cleanupPromptRun() }` drains. The error never propagates out of the `finally`, so `main`'s `.catch()` never runs.
- **Scenario C** — cleanup completes and the error reaches `.catch()`, but `.catch()`'s `await logStartupFailure(...)` drains before `process.exit(1)`.

This was nondeterministic: it depended on whether a ref'd handle happened to survive until the chain completed (e.g. whether the telemetry endpoint was reachable).

## What changed

- `src/cli/run-prompt.ts` — make `raceWithTimeout`'s cleanup timeout ref'd. This keeps the event loop alive during cleanup (bounded by `timeoutMs`), so Scenario B can't drain mid-cleanup; the rejection propagates to `main`'s `.catch()` normally.
- `src/main.ts` — set `process.exitCode = 1` synchronously at the start of `.catch()`, before any `await`. Covers Scenario C: even if the loop drains during `await logStartupFailure(...)`, the drain-exit reports failure.
- `test/cli/main.test.ts` — assert the failure exit code is set before awaiting startup-failure logging.

An earlier iteration also set `process.exitCode = 1` in a `catch` inside `runPrompt`, but that mutated global `process.exitCode` for any direct caller (including the existing `run-prompt.test.ts` rejection cases). Since the ref'd cleanup timeout already prevents Scenario B, that belt-and-suspenders write was redundant and was removed.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.
