### PR TITLE
feat(plugins): add Vercel plugin to marketplace

### DIFF
--- a/.changeset/add-vercel-plugin.md
+++ b/.changeset/add-vercel-plugin.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Add the Vercel plugin to the bundled plugin marketplace. Run /plugins and select Vercel Plugin to install it.

--- a/plugins/marketplace.json
+++ b/plugins/marketplace.json
@@ -18,6 +18,15 @@
       "homepage": "https://github.com/obra/superpowers",
       "keywords": ["skills", "planning", "tdd", "debugging", "code-review"],
       "source": "https://github.com/obra/superpowers"
+    },
+    {
+      "id": "vercel-plugin",
+      "tier": "curated",
+      "displayName": "Vercel Plugin",
+      "description": "Comprehensive Vercel ecosystem plugin — skills, agents, and conventions for the Vercel platform.",
+      "homepage": "https://vercel.com/docs/agent-resources/vercel-plugin",
+      "keywords": ["vercel", "deployment", "nextjs", "skills", "agents"],
+      "source": "https://github.com/vercel/vercel-plugin"
     }
   ]
 }


### PR DESCRIPTION
## Related Issue

N/A — marketplace catalog maintenance.

## Problem

The Vercel plugin is installable today via `/plugins install <github-url>`, but it is not discoverable in the bundled plugin marketplace, so users have to know the repository URL to find it.

## What changed

- Added a curated marketplace entry for the Vercel plugin, sourced from `https://github.com/vercel/vercel-plugin`.
- The entry has no explicit version. With no upstream release yet, install falls back to the default branch HEAD (same as a direct install); the version badge and update prompts will appear automatically once the first release is published.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [ ] I have added tests that prove my feature works. (N/A — marketplace catalog data; existing `plugin-marketplace.test.ts` still loads the catalog.)
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update. (N/A — marketplace catalog change, no user-facing docs to update.)