### PR TITLE
feat(web): support Enter key to confirm archive and other dialogs

### DIFF
--- a/.changeset/web-confirm-dialog-enter-key.md
+++ b/.changeset/web-confirm-dialog-enter-key.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+web: Press Enter to confirm in archive and other confirmation dialogs.

--- a/apps/kimi-web/src/components/dialogs/ConfirmDialog.vue
+++ b/apps/kimi-web/src/components/dialogs/ConfirmDialog.vue
@@ -3,11 +3,19 @@
      Dialog (height auto, right-aligned footer). The single confirmation surface
      for user actions — driven app-wide by useConfirmDialog(). -->
 <script setup lang="ts">
+import { onBeforeUnmount, ref } from 'vue';
 import { useI18n } from 'vue-i18n';
 import Dialog from '../ui/Dialog.vue';
 import Button from '../ui/Button.vue';
 
-withDefaults(defineProps<{
+const confirmButtonRef = ref<InstanceType<typeof Button> | null>(null);
+
+function confirmButtonElement(): HTMLElement | null {
+  const el = confirmButtonRef.value?.$el;
+  return el instanceof HTMLElement ? el : null;
+}
+
+const props = withDefaults(defineProps<{
   open: boolean;
   title: string;
   message?: string;
@@ -32,6 +40,33 @@ function onCancel(): void {
   emit('update:open', false);
   emit('cancel');
 }
+
+function onKeydown(event: KeyboardEvent): void {
+  if (event.key !== 'Enter' || !props.open || props.loading) return;
+  // Preserve native Enter semantics for interactive controls (buttons, links,
+  // form fields) so tabbing to Cancel / Close and pressing Enter does not
+  // accidentally confirm the dialog. Only treat Enter as confirm when focus is
+  // on a non-interactive part of the dialog.
+  const target = event.target as HTMLElement | null;
+  if (
+    target instanceof HTMLButtonElement ||
+    target instanceof HTMLAnchorElement ||
+    target instanceof HTMLTextAreaElement ||
+    target instanceof HTMLSelectElement ||
+    target instanceof HTMLInputElement
+  ) {
+    return;
+  }
+  event.preventDefault();
+  emit('confirm');
+}
+
+if (typeof window !== 'undefined') {
+  window.addEventListener('keydown', onKeydown);
+}
+onBeforeUnmount(() => {
+  if (typeof window !== 'undefined') window.removeEventListener('keydown', onKeydown);
+});
 </script>
 
 <template>
@@ -39,6 +74,7 @@ function onCancel(): void {
     :open="open"
     :title="title"
     height="auto"
+    :initial-focus="confirmButtonElement"
     @update:open="emit('update:open', $event)"
     @close="onCancel"
   >
@@ -47,7 +83,12 @@ function onCancel(): void {
       <Button variant="secondary" :disabled="loading" @click="onCancel">
         {{ cancelLabel ?? t('common.cancel') }}
       </Button>
-      <Button :variant="variant" :loading="loading" @click="emit('confirm')">
+      <Button
+        ref="confirmButtonRef"
+        :variant="variant"
+        :loading="loading"
+        @click="emit('confirm')"
+      >
         {{ confirmLabel ?? t('common.confirm') }}
       </Button>
     </template>

--- a/apps/kimi-web/src/components/ui/Dialog.vue
+++ b/apps/kimi-web/src/components/ui/Dialog.vue
@@ -22,6 +22,9 @@ const props = withDefaults(defineProps<{
   /** When false, the body has no padding so the consumer controls layout
    *  (e.g. a full-bleed side-nav). */
   padded?: boolean;
+  /** Element (or selector / resolver) to receive focus when the dialog opens.
+   *  Falls back to the first focusable element, then the dialog panel. */
+  initialFocus?: HTMLElement | string | (() => HTMLElement | null | undefined);
 }>(), {
   closeOnOverlay: true,
   closeOnEsc: true,
@@ -48,6 +51,18 @@ function close() {
 
 function focusables(): HTMLElement[] {
   return panel.value ? Array.from(panel.value.querySelectorAll<HTMLElement>(FOCUSABLE)) : [];
+}
+
+function resolveInitialFocus(): HTMLElement | null {
+  const { initialFocus } = props;
+  if (!initialFocus) return null;
+  if (typeof initialFocus === 'function') {
+    return initialFocus() ?? null;
+  }
+  if (typeof initialFocus === 'string') {
+    return panel.value?.querySelector<HTMLElement>(initialFocus) ?? null;
+  }
+  return panel.value?.contains(initialFocus) ? initialFocus : null;
 }
 
 function onKeydown(event: KeyboardEvent) {
@@ -87,8 +102,9 @@ watch(
       openDialogCount.value += 1;
       previouslyFocused = document.activeElement;
       await nextTick();
+      const initial = resolveInitialFocus();
       const list = focusables();
-      (list[0] ?? panel.value)?.focus();
+      (initial ?? list[0] ?? panel.value)?.focus();
     } else {
       openDialogCount.value = Math.max(0, openDialogCount.value - 1);
       if (previouslyFocused instanceof HTMLElement) {


### PR DESCRIPTION
## Related Issue

N/A — small UX improvement.

## Problem

Archive and other confirmation modals in the Kimi Web UI currently require a mouse click on the Confirm button. Keyboard users expect to press Enter to quickly confirm.

## What changed

- Added a window `keydown` listener to `ConfirmDialog.vue`.
- When the dialog is open and Enter is pressed, it emits `confirm` immediately.
- Loading state blocks the shortcut.
- Text inputs and textareas keep their native Enter behavior for future-proofing.

This affects all confirmation dialogs driven by `useConfirmDialog()`, including the archive-session confirmation.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have explained the problem above (no linked issue for this small UX tweak).
- [ ] I have added tests that prove my feature works. (No existing test file for `ConfirmDialog`; verified with `pnpm typecheck` and manual behavior review.)
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] This PR needs no doc update (minor keyboard shortcut in web UI).