### PR TITLE
fix(web): composer model switch also updates global default model

### DIFF
--- a/.changeset/web-composer-default-model-switch.md
+++ b/.changeset/web-composer-default-model-switch.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+web: The composer model switcher switches the active session's model as before and additionally bumps the global default model, so new sessions inherit the choice.

--- a/apps/kimi-web/src/App.vue
+++ b/apps/kimi-web/src/App.vue
@@ -338,7 +338,10 @@ function openLogin(): void {
 
 async function handleSelectModel(modelId: string): Promise<void> {
   showModelPicker.value = false;
-  await client.setModel(modelId);
+  // Same semantics as the composer dropdown rows: the overlay is just the
+  // "more models" continuation of the same flow, so it must also bump the
+  // global default (see handleComposerSelectModel).
+  await handleComposerSelectModel(modelId);
 }
 
 async function handleComposerSelectModel(modelId: string): Promise<void> {

--- a/apps/kimi-web/src/App.vue
+++ b/apps/kimi-web/src/App.vue
@@ -349,12 +349,14 @@ async function handleComposerSelectModel(modelId: string): Promise<void> {
   // (same as the model picker overlay). Awaited so the model pill reflects the
   // result and failures surface. In the onboarding draft this just stores the
   // pick for the first session.
-  await client.setModel(modelId);
+  const switched = await client.setModel(modelId);
 
   // Side effect: also bump the daemon-wide default model via POST /config so
   // new sessions inherit the choice. Fire-and-forget — it must not block the UI
-  // or mask the session switch. Skip when it already matches the default.
-  if (modelId !== client.defaultModel.value) {
+  // or mask the session switch. Only after a confirmed switch (a stale/invalid
+  // alias must not become the global default), and skip when it already
+  // matches the default.
+  if (switched && modelId !== client.defaultModel.value) {
     void client.updateConfig({ defaultModel: modelId });
   }
 }

--- a/apps/kimi-web/src/App.vue
+++ b/apps/kimi-web/src/App.vue
@@ -341,6 +341,21 @@ async function handleSelectModel(modelId: string): Promise<void> {
   await client.setModel(modelId);
 }
 
+async function handleComposerSelectModel(modelId: string): Promise<void> {
+  // Primary action: switch the active session's model via POST /sessions/{id}/profile
+  // (same as the model picker overlay). Awaited so the model pill reflects the
+  // result and failures surface. In the onboarding draft this just stores the
+  // pick for the first session.
+  await client.setModel(modelId);
+
+  // Side effect: also bump the daemon-wide default model via POST /config so
+  // new sessions inherit the choice. Fire-and-forget — it must not block the UI
+  // or mask the session switch. Skip when it already matches the default.
+  if (modelId !== client.defaultModel.value) {
+    void client.updateConfig({ defaultModel: modelId });
+  }
+}
+
 async function handleAddProvider(input: { type: string; apiKey?: string; baseUrl?: string; defaultModel?: string }): Promise<void> {
   await client.addProvider(input);
 }
@@ -759,7 +774,7 @@ function openPr(url: string): void {
       @archive-session="(id) => client.archiveSession(id)"
       @compact="client.compact()"
       @pick-model="openModelPicker()"
-      @select-model="client.setModel($event)"
+      @select-model="handleComposerSelectModel($event)"
       @open-file="openFilePreview($event)"
       @open-media="openMediaPreview($event)"
       @open-thinking="openThinkingPanel($event)"

--- a/apps/kimi-web/src/composables/client/useModelProviderState.ts
+++ b/apps/kimi-web/src/composables/client/useModelProviderState.ts
@@ -181,8 +181,12 @@ export function useModelProviderState(
    * can return model '', so the authoritative current model comes from
    * GET /sessions/{id}/status, which we re-read right after. Optimistically show
    * the chosen id meanwhile. Never crashes.
+   *
+   * Returns whether the switch was accepted (true for the draft path too), so
+   * callers can gate follow-up persistence (e.g. bumping the global default) on
+   * a confirmed switch — errors are surfaced here, not thrown.
    */
-  async function setModel(modelId: string): Promise<void> {
+  async function setModel(modelId: string): Promise<boolean> {
     const sid = rawState.activeSessionId;
     const nextThinking = coerceThinkingForModel(modelById(modelId), rawState.thinking);
     const prevThinking = rawState.thinking;
@@ -191,7 +195,7 @@ export function useModelProviderState(
       // Remember the pick — startSessionAndSendPrompt applies it at create time.
       draftModel.value = modelId;
       applyThinkingLevel(nextThinking);
-      return;
+      return true;
     }
     // Optimistic: show the chosen model immediately, but remember the previous
     // one so we can roll back if the switch never reaches the daemon.
@@ -217,12 +221,13 @@ export function useModelProviderState(
         saveThinkingToStorage(prevThinking);
       }
       pushOperationFailure('setModel', err, { sessionId: sid });
-      return;
+      return false;
     }
     // refreshSessionStatus folds the authoritative current model from /status
     // back into the session (the profile echo can return ''). Best-effort: a
     // failure here does not mean the switch failed, so it must not roll back.
     await refreshSessionStatus(sid);
+    return true;
   }
 
   /** Toggle whether a model is starred (favorited) in the model picker. */


### PR DESCRIPTION
## Related Issue

No linked issue — this came from direct user feedback that switching the model from the composer did not update the global default model.

## Problem

The composer model switcher under the input box only changed the active session's model. Users expect picking a model there to also become the default for new sessions, matching the Settings dialog behavior. Without that, a session created after the switch would still fall back to the old global default.

## What changed

- The composer model switcher still switches the active session's model via `POST /sessions/{id}/profile` (awaited, so the model pill reflects the result and failures surface; in the onboarding draft it just stores the pick for the first session).
- It additionally fires `POST /api/v1/config` with `{ default_model }` as a fire-and-forget side effect so new sessions inherit the chosen default. The config request is skipped when the model already matches the current default.
- Other existing sessions are untouched; only the active session and the global default change.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [ ] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.