### PR TITLE
feat(tui): support external status line command

### DIFF
--- a/.changeset/status-line-command.md
+++ b/.changeset/status-line-command.md
@@ -2,4 +2,4 @@
 "@moonshot-ai/kimi-code": minor
 ---
 
-Add a TUI status line command for custom footer output. Set `[status_line].command` in `tui.toml` to use it.
+Add a TUI status line command with session, context, and plan quota data for custom footer output. Set `[status_line].command` in `tui.toml` to use it.

--- a/.changeset/status-line-command.md
+++ b/.changeset/status-line-command.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": minor
+---
+
+Add a TUI status line command for custom footer output. Set `[status_line].command` in `tui.toml` to use it.

--- a/apps/kimi-code/src/tui/commands/config.ts
+++ b/apps/kimi-code/src/tui/commands/config.ts
@@ -42,6 +42,7 @@ function currentTuiConfig(host: SlashCommandHost): TuiConfig {
     disablePasteBurst: host.state.appState.disablePasteBurst ?? DEFAULT_TUI_CONFIG.disablePasteBurst,
     notifications: host.state.appState.notifications,
     upgrade: host.state.appState.upgrade,
+    statusLine: host.state.appState.statusLine,
   };
 }
 

--- a/apps/kimi-code/src/tui/commands/reload.ts
+++ b/apps/kimi-code/src/tui/commands/reload.ts
@@ -48,6 +48,7 @@ export async function applyReloadedTuiConfig(
     disablePasteBurst: config.disablePasteBurst,
     notifications: config.notifications,
     upgrade: config.upgrade,
+    statusLine: config.statusLine,
   });
   host.state.editor.setDisablePasteBurst(config.disablePasteBurst);
 }

--- a/apps/kimi-code/src/tui/components/chrome/footer.ts
+++ b/apps/kimi-code/src/tui/components/chrome/footer.ts
@@ -20,6 +20,9 @@ import { DEFAULT_TUI_CONFIG, type StatusLineConfig } from '#/tui/config';
 import {
   runStatusLineCommand,
   type StatusLineCommandPayload,
+  type StatusLineManagedUsage,
+  type StatusLineManagedUsageLoader,
+  type StatusLineRateLimit,
 } from '#/tui/utils/status-line-command';
 import {
   createGitStatusCache,
@@ -33,6 +36,7 @@ import { safeUsageRatio } from '#/utils/usage/usage-format';
 const MAX_CWD_SEGMENTS = 3;
 const GOAL_TIMER_INTERVAL_MS = 1_000;
 const STATUS_LINE_REFRESH_INTERVAL_MS = 1_000;
+const STATUS_LINE_RATE_LIMIT_REFRESH_INTERVAL_MS = 30_000;
 
 // Toolbar tips — rotates every 10s. Most tips are short and pair up (two
 // joined by " | ") when space allows; tips flagged `solo` are long or
@@ -196,9 +200,14 @@ export class FooterComponent implements Component {
   private transientHint: string | null = null;
   private statusLineText: string | null = null;
   private statusLineInFlight = false;
+  private statusLineRefreshPending = false;
   private statusLineTimer: ReturnType<typeof setInterval> | null = null;
   private statusLineCommand: string | null = null;
   private statusLineGeneration = 0;
+  private statusLineRateLimits: readonly StatusLineRateLimit[] = [];
+  private statusLineRateLimitsProvider: string | null = null;
+  private statusLineRateLimitsLoadedAt = 0;
+  private statusLineRateLimitsInFlight = false;
   private disposed = false;
   private goalSnapshotKey: string | null = null;
   private goalObservedAtMs = Date.now();
@@ -213,7 +222,12 @@ export class FooterComponent implements Component {
   private backgroundBashTaskCount = 0;
   private backgroundAgentCount = 0;
 
-  constructor(state: AppState, onRefresh: () => void = () => {}) {
+  constructor(
+    state: AppState,
+    onRefresh: () => void = () => {},
+    private readonly loadStatusLineManagedUsage: StatusLineManagedUsageLoader = async () =>
+      undefined,
+  ) {
     this.state = state;
     this.onRefresh = onRefresh;
     this.gitCacheWorkDir = state.workDir;
@@ -400,21 +414,30 @@ export class FooterComponent implements Component {
 
   private syncStatusLineTimer(command: string | null): void {
     const commandChanged = command !== this.statusLineCommand;
+    const providerKey = statusLineProvider(this.state);
+    const providerChanged = providerKey !== this.statusLineRateLimitsProvider;
     if (command !== this.statusLineCommand) {
       this.statusLineCommand = command;
       this.statusLineGeneration += 1;
       this.statusLineText = null;
+    }
+    if (providerChanged) {
+      this.statusLineRateLimitsProvider = providerKey;
+      this.statusLineRateLimits = [];
+      this.statusLineRateLimitsLoadedAt = 0;
     }
 
     if (command !== null) {
       const timerCreated = this.statusLineTimer === null;
       if (this.statusLineTimer === null) {
         this.statusLineTimer = setInterval(() => {
+          void this.refreshStatusLineRateLimits();
           void this.refreshStatusLine();
         }, STATUS_LINE_REFRESH_INTERVAL_MS);
         this.statusLineTimer.unref?.();
       }
-      if (commandChanged || timerCreated) {
+      void this.refreshStatusLineRateLimits();
+      if (commandChanged || timerCreated || providerChanged) {
         void this.refreshStatusLine();
       }
       return;
@@ -428,7 +451,12 @@ export class FooterComponent implements Component {
 
   private async refreshStatusLine(): Promise<void> {
     const { command, timeoutMs } = statusLineConfig(this.state);
-    if (command === null || this.statusLineInFlight) return;
+    if (command === null) return;
+    if (this.statusLineInFlight) {
+      this.statusLineRefreshPending = true;
+      return;
+    }
+    this.statusLineRefreshPending = false;
     const generation = this.statusLineGeneration;
     this.statusLineInFlight = true;
     let text: string | null = null;
@@ -457,6 +485,38 @@ export class FooterComponent implements Component {
 
     this.statusLineText = text;
     this.onRefresh();
+    if (this.statusLineRefreshPending) {
+      void this.refreshStatusLine();
+    }
+  }
+
+  private async refreshStatusLineRateLimits(): Promise<void> {
+    const providerKey = this.statusLineRateLimitsProvider;
+    if (
+      providerKey === null ||
+      this.statusLineRateLimitsInFlight ||
+      Date.now() - this.statusLineRateLimitsLoadedAt <
+        STATUS_LINE_RATE_LIMIT_REFRESH_INTERVAL_MS
+    ) {
+      return;
+    }
+
+    this.statusLineRateLimitsInFlight = true;
+    let result: StatusLineManagedUsage | undefined;
+    try {
+      result = await this.loadStatusLineManagedUsage(providerKey);
+    } catch {
+      result = undefined;
+    } finally {
+      this.statusLineRateLimitsInFlight = false;
+    }
+
+    if (this.disposed || providerKey !== this.statusLineRateLimitsProvider) return;
+    this.statusLineRateLimitsLoadedAt = Date.now();
+    this.statusLineRateLimits = managedUsageRateLimits(result);
+    if (statusLineConfig(this.state).command !== null) {
+      void this.refreshStatusLine();
+    }
   }
 
   private createStatusLinePayload(): StatusLineCommandPayload {
@@ -476,6 +536,7 @@ export class FooterComponent implements Component {
         tokens: state.contextTokens,
         max_tokens: state.maxContextTokens,
       },
+      rate_limits: this.statusLineRateLimits,
     };
   }
 
@@ -515,4 +576,23 @@ function goalSnapshotKey(goal: AppState['goal']): string | null {
 
 function statusLineConfig(state: AppState): StatusLineConfig {
   return (state as Partial<AppState>).statusLine ?? DEFAULT_TUI_CONFIG.statusLine;
+}
+
+function statusLineProvider(state: AppState): string | null {
+  return state.availableModels[state.model]?.provider ?? null;
+}
+
+function managedUsageRateLimits(
+  result: StatusLineManagedUsage | undefined,
+): readonly StatusLineRateLimit[] {
+  if (result?.kind !== 'ok') return [];
+  const rows = result.summary === null ? result.limits : [result.summary, ...result.limits];
+  return rows
+    .filter((row) => row.limit > 0)
+    .map((row) => ({
+      label: row.label,
+      used: row.used,
+      limit: row.limit,
+      reset_hint: row.resetHint,
+    }));
 }

--- a/apps/kimi-code/src/tui/components/chrome/footer.ts
+++ b/apps/kimi-code/src/tui/components/chrome/footer.ts
@@ -16,6 +16,7 @@ import { isRainbowDancing, renderDanceFooterModel } from '#/tui/easter-eggs/danc
 import { currentTheme } from '#/tui/theme';
 import type { ColorPalette } from '#/tui/theme/colors';
 import type { AppState } from '#/tui/types';
+import { DEFAULT_TUI_CONFIG, type StatusLineConfig } from '#/tui/config';
 import {
   runStatusLineCommand,
   type StatusLineCommandPayload,
@@ -219,7 +220,7 @@ export class FooterComponent implements Component {
     this.gitCache = createGitStatusCache(state.workDir, { onChange: this.onRefresh });
     this.syncGoalClock(state.goal);
     this.syncGoalTimer(state.goal);
-    this.syncStatusLineTimer(state.statusLine.command);
+    this.syncStatusLineTimer(statusLineConfig(state).command);
   }
 
   setState(state: AppState): void {
@@ -230,7 +231,7 @@ export class FooterComponent implements Component {
     this.syncGoalClock(state.goal);
     this.syncGoalTimer(state.goal);
     this.state = state;
-    this.syncStatusLineTimer(state.statusLine.command);
+    this.syncStatusLineTimer(statusLineConfig(state).command);
   }
 
   /**
@@ -398,6 +399,7 @@ export class FooterComponent implements Component {
   }
 
   private syncStatusLineTimer(command: string | null): void {
+    const commandChanged = command !== this.statusLineCommand;
     if (command !== this.statusLineCommand) {
       this.statusLineCommand = command;
       this.statusLineGeneration += 1;
@@ -405,13 +407,16 @@ export class FooterComponent implements Component {
     }
 
     if (command !== null) {
+      const timerCreated = this.statusLineTimer === null;
       if (this.statusLineTimer === null) {
         this.statusLineTimer = setInterval(() => {
           void this.refreshStatusLine();
         }, STATUS_LINE_REFRESH_INTERVAL_MS);
         this.statusLineTimer.unref?.();
       }
-      void this.refreshStatusLine();
+      if (commandChanged || timerCreated) {
+        void this.refreshStatusLine();
+      }
       return;
     }
 
@@ -422,7 +427,7 @@ export class FooterComponent implements Component {
   }
 
   private async refreshStatusLine(): Promise<void> {
-    const { command, timeoutMs } = this.state.statusLine;
+    const { command, timeoutMs } = statusLineConfig(this.state);
     if (command === null || this.statusLineInFlight) return;
     const generation = this.statusLineGeneration;
     this.statusLineInFlight = true;
@@ -442,9 +447,9 @@ export class FooterComponent implements Component {
     if (
       this.disposed ||
       generation !== this.statusLineGeneration ||
-      this.state.statusLine.command !== command
+      statusLineConfig(this.state).command !== command
     ) {
-      if (!this.disposed && this.state.statusLine.command !== null) {
+      if (!this.disposed && statusLineConfig(this.state).command !== null) {
         void this.refreshStatusLine();
       }
       return;
@@ -506,4 +511,8 @@ function goalSnapshotKey(goal: AppState['goal']): string | null {
     String(goal.budget.turnBudget),
     String(goal.budget.wallClockBudgetMs),
   ].join('\u0000');
+}
+
+function statusLineConfig(state: AppState): StatusLineConfig {
+  return (state as Partial<AppState>).statusLine ?? DEFAULT_TUI_CONFIG.statusLine;
 }

--- a/apps/kimi-code/src/tui/components/chrome/footer.ts
+++ b/apps/kimi-code/src/tui/components/chrome/footer.ts
@@ -17,6 +17,10 @@ import { currentTheme } from '#/tui/theme';
 import type { ColorPalette } from '#/tui/theme/colors';
 import type { AppState } from '#/tui/types';
 import {
+  runStatusLineCommand,
+  type StatusLineCommandPayload,
+} from '#/tui/utils/status-line-command';
+import {
   createGitStatusCache,
   formatGitBadgeBase,
   formatPullRequestBadge,
@@ -27,6 +31,7 @@ import { safeUsageRatio } from '#/utils/usage/usage-format';
 
 const MAX_CWD_SEGMENTS = 3;
 const GOAL_TIMER_INTERVAL_MS = 1_000;
+const STATUS_LINE_REFRESH_INTERVAL_MS = 1_000;
 
 // Toolbar tips — rotates every 10s. Most tips are short and pair up (two
 // joined by " | ") when space allows; tips flagged `solo` are long or
@@ -188,6 +193,12 @@ export class FooterComponent implements Component {
   private gitCache: GitStatusCache;
   private gitCacheWorkDir: string;
   private transientHint: string | null = null;
+  private statusLineText: string | null = null;
+  private statusLineInFlight = false;
+  private statusLineTimer: ReturnType<typeof setInterval> | null = null;
+  private statusLineCommand: string | null = null;
+  private statusLineGeneration = 0;
+  private disposed = false;
   private goalSnapshotKey: string | null = null;
   private goalObservedAtMs = Date.now();
   private goalTimer: ReturnType<typeof setInterval> | null = null;
@@ -208,6 +219,7 @@ export class FooterComponent implements Component {
     this.gitCache = createGitStatusCache(state.workDir, { onChange: this.onRefresh });
     this.syncGoalClock(state.goal);
     this.syncGoalTimer(state.goal);
+    this.syncStatusLineTimer(state.statusLine.command);
   }
 
   setState(state: AppState): void {
@@ -218,6 +230,7 @@ export class FooterComponent implements Component {
     this.syncGoalClock(state.goal);
     this.syncGoalTimer(state.goal);
     this.state = state;
+    this.syncStatusLineTimer(state.statusLine.command);
   }
 
   /**
@@ -332,29 +345,30 @@ export class FooterComponent implements Component {
       line1 = truncateToWidth(leftLine, width, '…');
     }
 
-    // ── Line 2: transient hint (bottom-left) + context (right) ──
-    const contextText = formatContextStatus(
-      state.contextUsage,
-      state.contextTokens,
-      state.maxContextTokens,
-    );
-    const contextWidth = visibleWidth(contextText);
+    // ── Line 2: transient hint (bottom-left) + status line (right) ──
+    const statusLineText =
+      this.statusLineText ??
+      formatContextStatus(state.contextUsage, state.contextTokens, state.maxContextTokens);
+    const renderedStatusLine =
+      this.statusLineText === null ? chalk.hex(colors.text)(statusLineText) : statusLineText;
     let line2: string;
     if (this.transientHint) {
-      const maxHintWidth = Math.max(0, width - contextWidth - 1);
+      const statusLineWidth = visibleWidth(statusLineText);
+      const maxHintWidth = Math.max(0, width - statusLineWidth - 1);
       const shownHint =
         visibleWidth(this.transientHint) <= maxHintWidth
           ? this.transientHint
           : truncateToWidth(this.transientHint, maxHintWidth, '…');
       const hintWidth = visibleWidth(shownHint);
-      const pad = Math.max(0, width - hintWidth - contextWidth);
+      const pad = Math.max(0, width - hintWidth - statusLineWidth);
       line2 =
         chalk.hex(colors.warning).bold(shownHint) +
         ' '.repeat(pad) +
-        chalk.hex(colors.text)(contextText);
+        renderedStatusLine;
     } else {
-      const leftPad = Math.max(0, width - contextWidth);
-      line2 = ' '.repeat(leftPad) + chalk.hex(colors.text)(contextText);
+      const statusLineWidth = visibleWidth(statusLineText);
+      const leftPad = Math.max(0, width - statusLineWidth);
+      line2 = ' '.repeat(leftPad) + renderedStatusLine;
     }
 
     return [truncateToWidth(line1, width), truncateToWidth(line2, width)];
@@ -383,10 +397,92 @@ export class FooterComponent implements Component {
     }
   }
 
+  private syncStatusLineTimer(command: string | null): void {
+    if (command !== this.statusLineCommand) {
+      this.statusLineCommand = command;
+      this.statusLineGeneration += 1;
+      this.statusLineText = null;
+    }
+
+    if (command !== null) {
+      if (this.statusLineTimer === null) {
+        this.statusLineTimer = setInterval(() => {
+          void this.refreshStatusLine();
+        }, STATUS_LINE_REFRESH_INTERVAL_MS);
+        this.statusLineTimer.unref?.();
+      }
+      void this.refreshStatusLine();
+      return;
+    }
+
+    if (this.statusLineTimer !== null) {
+      clearInterval(this.statusLineTimer);
+      this.statusLineTimer = null;
+    }
+  }
+
+  private async refreshStatusLine(): Promise<void> {
+    const { command, timeoutMs } = this.state.statusLine;
+    if (command === null || this.statusLineInFlight) return;
+    const generation = this.statusLineGeneration;
+    this.statusLineInFlight = true;
+    let text: string | null = null;
+    try {
+      text = await runStatusLineCommand({
+        command,
+        timeoutMs,
+        payload: this.createStatusLinePayload(),
+      });
+    } catch {
+      text = null;
+    } finally {
+      this.statusLineInFlight = false;
+    }
+
+    if (
+      this.disposed ||
+      generation !== this.statusLineGeneration ||
+      this.state.statusLine.command !== command
+    ) {
+      if (!this.disposed && this.state.statusLine.command !== null) {
+        void this.refreshStatusLine();
+      }
+      return;
+    }
+
+    this.statusLineText = text;
+    this.onRefresh();
+  }
+
+  private createStatusLinePayload(): StatusLineCommandPayload {
+    const state = this.state;
+    return {
+      session_id: state.sessionId,
+      model: state.model,
+      display_model: modelDisplayName(state),
+      cwd: state.workDir,
+      permission_mode: state.permissionMode,
+      plan_mode: state.planMode,
+      input_mode: state.inputMode,
+      swarm_mode: state.swarmMode,
+      thinking_effort: state.thinkingEffort,
+      context: {
+        usage: safeUsage(state.contextUsage),
+        tokens: state.contextTokens,
+        max_tokens: state.maxContextTokens,
+      },
+    };
+  }
+
   dispose(): void {
+    this.disposed = true;
     if (this.goalTimer !== null) {
       clearInterval(this.goalTimer);
       this.goalTimer = null;
+    }
+    if (this.statusLineTimer !== null) {
+      clearInterval(this.statusLineTimer);
+      this.statusLineTimer = null;
     }
   }
 

--- a/apps/kimi-code/src/tui/config.ts
+++ b/apps/kimi-code/src/tui/config.ts
@@ -30,6 +30,11 @@ export const UpgradePreferencesSchema = z.object({
   autoInstall: z.boolean(),
 });
 
+export const StatusLineConfigSchema = z.object({
+  command: z.string().nullable(),
+  timeoutMs: z.number().int().positive(),
+});
+
 export const TuiConfigFileSchema = z.object({
   theme: TuiThemeSchema.optional(),
   disable_paste_burst: z.boolean().optional(),
@@ -49,6 +54,12 @@ export const TuiConfigFileSchema = z.object({
       auto_install: z.boolean().optional(),
     })
     .optional(),
+  status_line: z
+    .object({
+      command: z.string().optional(),
+      timeout_ms: z.number().int().positive().optional(),
+    })
+    .optional(),
 });
 
 export const TuiConfigSchema = z.object({
@@ -57,12 +68,14 @@ export const TuiConfigSchema = z.object({
   editorCommand: z.string().nullable(),
   notifications: NotificationsConfigSchema,
   upgrade: UpgradePreferencesSchema,
+  statusLine: StatusLineConfigSchema,
 });
 
 export type TuiConfigFileShape = z.infer<typeof TuiConfigFileSchema>;
 export type TuiConfig = z.infer<typeof TuiConfigSchema>;
 export type NotificationsConfig = z.infer<typeof NotificationsConfigSchema>;
 export type UpgradePreferences = z.infer<typeof UpgradePreferencesSchema>;
+export type StatusLineConfig = z.infer<typeof StatusLineConfigSchema>;
 
 export const DEFAULT_NOTIFICATIONS_CONFIG: NotificationsConfig = {
   enabled: true,
@@ -73,12 +86,18 @@ export const DEFAULT_UPGRADE_PREFERENCES: UpgradePreferences = {
   autoInstall: true,
 };
 
+export const DEFAULT_STATUS_LINE_CONFIG: StatusLineConfig = {
+  command: null,
+  timeoutMs: 200,
+};
+
 export const DEFAULT_TUI_CONFIG: TuiConfig = TuiConfigSchema.parse({
   theme: 'auto',
   disablePasteBurst: false,
   editorCommand: null,
   notifications: DEFAULT_NOTIFICATIONS_CONFIG,
   upgrade: DEFAULT_UPGRADE_PREFERENCES,
+  statusLine: DEFAULT_STATUS_LINE_CONFIG,
 });
 
 /**
@@ -133,6 +152,7 @@ export async function saveTuiConfig(
 
 export function normalizeTuiConfig(config: TuiConfigFileShape): TuiConfig {
   const command = config.editor?.command?.trim();
+  const statusLineCommand = config.status_line?.command?.trim();
   return TuiConfigSchema.parse({
     theme: config.theme ?? DEFAULT_TUI_CONFIG.theme,
     disablePasteBurst: config.disable_paste_burst ?? DEFAULT_TUI_CONFIG.disablePasteBurst,
@@ -144,6 +164,13 @@ export function normalizeTuiConfig(config: TuiConfigFileShape): TuiConfig {
     },
     upgrade: {
       autoInstall: config.upgrade?.auto_install ?? DEFAULT_UPGRADE_PREFERENCES.autoInstall,
+    },
+    statusLine: {
+      command:
+        statusLineCommand === undefined || statusLineCommand.length === 0
+          ? null
+          : statusLineCommand,
+      timeoutMs: config.status_line?.timeout_ms ?? DEFAULT_STATUS_LINE_CONFIG.timeoutMs,
     },
   });
 }
@@ -165,6 +192,10 @@ notification_condition = "${config.notifications.condition}" # "unfocused" | "al
 
 [upgrade]
 auto_install = ${String(config.upgrade.autoInstall)} # true | false
+
+[status_line]
+command = "${escapeTomlBasicString(config.statusLine.command ?? '')}" # External command; empty disables custom status line
+timeout_ms = ${String(config.statusLine.timeoutMs)} # Command timeout in milliseconds
 `;
 }
 

--- a/apps/kimi-code/src/tui/kimi-tui.ts
+++ b/apps/kimi-code/src/tui/kimi-tui.ts
@@ -223,6 +223,7 @@ function createInitialAppState(input: KimiTUIStartupInput): AppState {
     disablePasteBurst: input.tuiConfig.disablePasteBurst,
     notifications: input.tuiConfig.notifications,
     upgrade: input.tuiConfig.upgrade,
+    statusLine: input.tuiConfig.statusLine,
     availableModels: {},
     availableProviders: {},
     sessionTitle: null,

--- a/apps/kimi-code/src/tui/kimi-tui.ts
+++ b/apps/kimi-code/src/tui/kimi-tui.ts
@@ -94,6 +94,7 @@ import {
   MAIN_AGENT_ID,
   NO_ACTIVE_SESSION_MESSAGE,
   PRODUCT_NAME,
+  isManagedUsageProvider,
 } from './constant/kimi-tui';
 import { CHROME_GUTTER } from './constant/rendering';
 import { MAX_TERMINAL_TITLE_LENGTH } from './constant/terminal';
@@ -320,6 +321,10 @@ export class KimiTUI {
     this.harness = harness;
     const tuiOptions: KimiTUIOptions = {
       initialAppState: createInitialAppState(startupInput),
+      loadStatusLineManagedUsage: async (providerKey) => {
+        if (!isManagedUsageProvider(providerKey)) return undefined;
+        return harness.auth.getManagedUsage(providerKey);
+      },
       startup: {
         sessionFlag: startupInput.cliOptions.session,
         continueLast: startupInput.cliOptions.continue,

--- a/apps/kimi-code/src/tui/tui-state.ts
+++ b/apps/kimi-code/src/tui/tui-state.ts
@@ -79,9 +79,13 @@ export function createTUIState(options: KimiTUIOptions): TUIState {
   const editor = new CustomEditor(ui, {
     disablePasteBurst: initialAppState.disablePasteBurst ?? DEFAULT_TUI_CONFIG.disablePasteBurst,
   });
-  const footer = new FooterComponent({ ...initialAppState }, () => {
-    ui.requestRender();
-  });
+  const footer = new FooterComponent(
+    { ...initialAppState },
+    () => {
+      ui.requestRender();
+    },
+    options.loadStatusLineManagedUsage,
+  );
 
   return {
     ui,

--- a/apps/kimi-code/src/tui/types.ts
+++ b/apps/kimi-code/src/tui/types.ts
@@ -9,7 +9,7 @@ import type {
   ToolInputDisplay,
 } from '@moonshot-ai/kimi-code-sdk';
 
-import type { NotificationsConfig, UpgradePreferences } from './config';
+import type { NotificationsConfig, StatusLineConfig, UpgradePreferences } from './config';
 import type { PendingApproval, PendingQuestion } from './reverse-rpc/types';
 import type { ColorToken, ThemeName } from './theme';
 
@@ -52,6 +52,7 @@ export interface AppState {
   disablePasteBurst?: boolean;
   notifications: NotificationsConfig;
   upgrade: UpgradePreferences;
+  statusLine: StatusLineConfig;
   availableModels: Record<string, ModelAlias>;
   availableProviders: Record<string, ProviderConfig>;
   sessionTitle: string | null;

--- a/apps/kimi-code/src/tui/types.ts
+++ b/apps/kimi-code/src/tui/types.ts
@@ -12,6 +12,7 @@ import type {
 import type { NotificationsConfig, StatusLineConfig, UpgradePreferences } from './config';
 import type { PendingApproval, PendingQuestion } from './reverse-rpc/types';
 import type { ColorToken, ThemeName } from './theme';
+import type { StatusLineManagedUsageLoader } from './utils/status-line-command';
 
 export type BannerDisplay = 'always' | 'once' | 'cooldown';
 
@@ -232,6 +233,7 @@ export type TUIStartupState = 'pending' | 'ready' | 'picker';
 export interface KimiTUIOptions {
   initialAppState: AppState;
   startup: TUIStartupOptions;
+  loadStatusLineManagedUsage?: StatusLineManagedUsageLoader;
 }
 
 export interface PendingExit {

--- a/apps/kimi-code/src/tui/utils/status-line-command.ts
+++ b/apps/kimi-code/src/tui/utils/status-line-command.ts
@@ -1,6 +1,10 @@
 import { spawn } from 'node:child_process';
 import { once } from 'node:events';
 
+import type { KimiHarness } from '@moonshot-ai/kimi-code-sdk';
+
+const PROCESS_KILL_GRACE_MS = 100;
+
 export interface StatusLineCommandPayload {
   readonly session_id: string;
   readonly model: string;
@@ -16,7 +20,23 @@ export interface StatusLineCommandPayload {
     readonly tokens: number;
     readonly max_tokens: number;
   };
+  readonly rate_limits: readonly StatusLineRateLimit[];
 }
+
+export interface StatusLineRateLimit {
+  readonly label: string;
+  readonly used: number;
+  readonly limit: number;
+  readonly reset_hint?: string;
+}
+
+export type StatusLineManagedUsage = Awaited<
+  ReturnType<KimiHarness['auth']['getManagedUsage']>
+>;
+
+export type StatusLineManagedUsageLoader = (
+  providerKey: string,
+) => Promise<StatusLineManagedUsage | undefined>;
 
 export interface RunStatusLineCommandOptions {
   readonly command: string;
@@ -30,8 +50,10 @@ export async function runStatusLineCommand({
   payload,
 }: RunStatusLineCommandOptions): Promise<string | null> {
   const child = spawn(command, {
+    detached: process.platform !== 'win32',
     shell: true,
     stdio: ['pipe', 'pipe', 'ignore'],
+    windowsHide: true,
   });
 
   let stdout = '';
@@ -57,7 +79,7 @@ export async function runStatusLineCommand({
   const result = await Promise.race([closed, errored, timeout]);
 
   if (result === 'timeout') {
-    child.kill();
+    killProcessTree(child);
     return null;
   }
   if (result.kind === 'error' || result.code !== 0) {
@@ -66,4 +88,46 @@ export async function runStatusLineCommand({
 
   const line = stdout.trimEnd().split(/\r?\n/, 1)[0]?.trimEnd() ?? '';
   return line.length > 0 ? line : null;
+}
+
+function killProcessTree(child: ReturnType<typeof spawn>): void {
+  tryKillProcessTree(child, 'SIGTERM');
+  const timer = setTimeout(() => {
+    tryKillProcessTree(child, 'SIGKILL');
+  }, PROCESS_KILL_GRACE_MS);
+  timer.unref?.();
+}
+
+function tryKillProcessTree(
+  child: ReturnType<typeof spawn>,
+  signal: NodeJS.Signals,
+): void {
+  if (process.platform === 'win32') {
+    if (child.pid === undefined) return;
+    const args =
+      signal === 'SIGKILL'
+        ? ['/T', '/F', '/PID', String(child.pid)]
+        : ['/T', '/PID', String(child.pid)];
+    try {
+      const killer = spawn('taskkill', args, { stdio: 'ignore', windowsHide: true });
+      killer.once('error', () => {});
+    } catch {
+      try {
+        child.kill(signal);
+      } catch {}
+    }
+    return;
+  }
+
+  try {
+    if (child.pid !== undefined) {
+      process.kill(-child.pid, signal);
+    } else {
+      child.kill(signal);
+    }
+  } catch {
+    try {
+      child.kill(signal);
+    } catch {}
+  }
 }

--- a/apps/kimi-code/src/tui/utils/status-line-command.ts
+++ b/apps/kimi-code/src/tui/utils/status-line-command.ts
@@ -1,0 +1,69 @@
+import { spawn } from 'node:child_process';
+import { once } from 'node:events';
+
+export interface StatusLineCommandPayload {
+  readonly session_id: string;
+  readonly model: string;
+  readonly display_model: string;
+  readonly cwd: string;
+  readonly permission_mode: string;
+  readonly plan_mode: boolean;
+  readonly input_mode: string;
+  readonly swarm_mode: boolean;
+  readonly thinking_effort: string;
+  readonly context: {
+    readonly usage: number;
+    readonly tokens: number;
+    readonly max_tokens: number;
+  };
+}
+
+export interface RunStatusLineCommandOptions {
+  readonly command: string;
+  readonly timeoutMs: number;
+  readonly payload: StatusLineCommandPayload;
+}
+
+export async function runStatusLineCommand({
+  command,
+  timeoutMs,
+  payload,
+}: RunStatusLineCommandOptions): Promise<string | null> {
+  const child = spawn(command, {
+    shell: true,
+    stdio: ['pipe', 'pipe', 'ignore'],
+  });
+
+  let stdout = '';
+  child.stdout.setEncoding('utf8');
+  child.stdout.on('data', (chunk: string) => {
+    stdout += chunk;
+  });
+
+  child.stdin.on('error', () => {});
+  child.stdin.end(`${JSON.stringify(payload)}\n`);
+
+  const timeout = new Promise<'timeout'>((resolve) => {
+    const timer = setTimeout(() => {
+      resolve('timeout');
+    }, timeoutMs);
+    timer.unref?.();
+  });
+  const closed = once(child, 'close').then(([code]) => ({
+    kind: 'close' as const,
+    code: typeof code === 'number' ? code : null,
+  }));
+  const errored = once(child, 'error').then(() => ({ kind: 'error' as const }));
+  const result = await Promise.race([closed, errored, timeout]);
+
+  if (result === 'timeout') {
+    child.kill();
+    return null;
+  }
+  if (result.kind === 'error' || result.code !== 0) {
+    return null;
+  }
+
+  const line = stdout.trimEnd().split(/\r?\n/, 1)[0]?.trimEnd() ?? '';
+  return line.length > 0 ? line : null;
+}

--- a/apps/kimi-code/test/cli/update/preflight.test.ts
+++ b/apps/kimi-code/test/cli/update/preflight.test.ts
@@ -165,6 +165,7 @@ function tuiConfig(overrides: Partial<TuiConfig> = {}): TuiConfig {
     editorCommand: null,
     notifications: { enabled: true, condition: 'unfocused' },
     upgrade: { autoInstall: true },
+    statusLine: { command: null, timeoutMs: 200 },
     ...overrides,
   };
 }

--- a/apps/kimi-code/test/tui/activity-pane.test.ts
+++ b/apps/kimi-code/test/tui/activity-pane.test.ts
@@ -33,6 +33,7 @@ function makeStartupInput(): KimiTUIStartupInput {
       editorCommand: null,
       notifications: { enabled: true, condition: 'unfocused' },
       upgrade: { autoInstall: true },
+      statusLine: { command: null, timeoutMs: 200 },
     },
     version: '0.0.0-test',
     workDir: '/tmp/proj-a',

--- a/apps/kimi-code/test/tui/components/chrome/footer.test.ts
+++ b/apps/kimi-code/test/tui/components/chrome/footer.test.ts
@@ -2,6 +2,7 @@ import chalk from 'chalk';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { FooterComponent } from '#/tui/components/chrome/footer';
+import { DEFAULT_OAUTH_PROVIDER_NAME } from '#/tui/constant/kimi-tui';
 import { setRainbowDance, type RainbowDanceController } from '#/tui/easter-eggs/dance';
 import { currentTheme, darkColors, lightColors } from '#/tui/theme';
 import type { ModelAlias } from '@moonshot-ai/kimi-code-sdk';
@@ -245,6 +246,94 @@ describe('FooterComponent status line command', () => {
     });
 
     footer.dispose();
+  });
+
+  it('includes managed rate limits in the command payload', async () => {
+    statusLineMocks.runStatusLineCommand.mockResolvedValue('custom status');
+    const loadManagedUsage = vi.fn().mockResolvedValue({
+      kind: 'ok',
+      summary: null,
+      limits: [
+        {
+          label: 'Weekly limit',
+          used: 25,
+          limit: 100,
+          resetHint: 'resets in 2d',
+        },
+      ],
+      extraUsage: null,
+    });
+    const footer = new FooterComponent(
+      {
+        ...appState,
+        availableModels: {
+          'kimi-k2': {
+            model: 'kimi-k2',
+            provider: DEFAULT_OAUTH_PROVIDER_NAME,
+          } as ModelAlias,
+        },
+        statusLine: { command: 'kimi-hud', timeoutMs: 250 },
+      },
+      () => {},
+      loadManagedUsage,
+    );
+
+    await vi.waitFor(() => {
+      expect(statusLineMocks.runStatusLineCommand).toHaveBeenCalledWith(
+        expect.objectContaining({
+          payload: expect.objectContaining({
+            rate_limits: [
+              {
+                label: 'Weekly limit',
+                used: 25,
+                limit: 100,
+                reset_hint: 'resets in 2d',
+              },
+            ],
+          }),
+        }),
+      );
+    });
+
+    expect(loadManagedUsage).toHaveBeenCalledTimes(1);
+    expect(loadManagedUsage).toHaveBeenCalledWith(DEFAULT_OAUTH_PROVIDER_NAME);
+    footer.dispose();
+  });
+
+  it('caches managed rate limits for thirty seconds', async () => {
+    vi.useFakeTimers();
+    statusLineMocks.runStatusLineCommand.mockResolvedValue('custom status');
+    const loadManagedUsage = vi.fn().mockResolvedValue({
+      kind: 'ok',
+      summary: null,
+      limits: [],
+      extraUsage: null,
+    });
+    const footer = new FooterComponent(
+      {
+        ...appState,
+        availableModels: {
+          'kimi-k2': {
+            model: 'kimi-k2',
+            provider: DEFAULT_OAUTH_PROVIDER_NAME,
+          } as ModelAlias,
+        },
+        statusLine: { command: 'kimi-hud', timeoutMs: 250 },
+      },
+      () => {},
+      loadManagedUsage,
+    );
+
+    try {
+      await vi.advanceTimersByTimeAsync(29_000);
+      expect(loadManagedUsage).toHaveBeenCalledTimes(1);
+
+      await vi.advanceTimersByTimeAsync(1_000);
+      expect(loadManagedUsage).toHaveBeenCalledTimes(2);
+    } finally {
+      footer.dispose();
+      vi.useRealTimers();
+    }
   });
 
   it('does not refresh the external command on unrelated state updates', async () => {

--- a/apps/kimi-code/test/tui/components/chrome/footer.test.ts
+++ b/apps/kimi-code/test/tui/components/chrome/footer.test.ts
@@ -205,6 +205,15 @@ describe('FooterComponent displayName override', () => {
 });
 
 describe('FooterComponent status line command', () => {
+  it('falls back when older app state fixtures omit statusLine', () => {
+    const { statusLine: _statusLine, ...legacyState } = appState;
+
+    const footer = new FooterComponent(legacyState as AppState);
+
+    expect(footer.render(120).join('\n')).toContain('context: 0.0%');
+    footer.dispose();
+  });
+
   it('uses the command output on the second line when configured', async () => {
     statusLineMocks.runStatusLineCommand.mockResolvedValue('model: kimi-k2 | dir: project');
     const onRefresh = vi.fn();
@@ -235,6 +244,28 @@ describe('FooterComponent status line command', () => {
       }),
     });
 
+    footer.dispose();
+  });
+
+  it('does not refresh the external command on unrelated state updates', async () => {
+    statusLineMocks.runStatusLineCommand.mockResolvedValue('model: kimi-k2 | dir: project');
+    const footer = new FooterComponent({
+      ...appState,
+      statusLine: { command: 'kimi-hud', timeoutMs: 250 },
+    });
+
+    await vi.waitFor(() => {
+      expect(statusLineMocks.runStatusLineCommand).toHaveBeenCalled();
+    });
+    statusLineMocks.runStatusLineCommand.mockClear();
+
+    footer.setState({
+      ...appState,
+      contextUsage: 0.5,
+      statusLine: { command: 'kimi-hud', timeoutMs: 250 },
+    });
+
+    expect(statusLineMocks.runStatusLineCommand).not.toHaveBeenCalled();
     footer.dispose();
   });
 

--- a/apps/kimi-code/test/tui/components/chrome/footer.test.ts
+++ b/apps/kimi-code/test/tui/components/chrome/footer.test.ts
@@ -1,11 +1,17 @@
 import chalk from 'chalk';
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { FooterComponent } from '#/tui/components/chrome/footer';
 import { setRainbowDance, type RainbowDanceController } from '#/tui/easter-eggs/dance';
 import { currentTheme, darkColors, lightColors } from '#/tui/theme';
 import type { ModelAlias } from '@moonshot-ai/kimi-code-sdk';
 import type { AppState } from '#/tui/types';
+
+const statusLineMocks = vi.hoisted(() => ({
+  runStatusLineCommand: vi.fn(),
+}));
+
+vi.mock('#/tui/utils/status-line-command', () => statusLineMocks);
 
 const TRUECOLOR_PATTERN = /\[38;2;(\d+);(\d+);(\d+)m/g;
 
@@ -15,6 +21,14 @@ function truecolorCodes(text: string): Set<string> {
     codes.add(`${match[1]},${match[2]},${match[3]}`);
   }
   return codes;
+}
+
+function deferred<T>(): { promise: Promise<T>; resolve: (value: T) => void } {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((innerResolve) => {
+    resolve = innerResolve;
+  });
+  return { promise, resolve };
 }
 
 // Dark dance colors the footer never uses outside of /dance.
@@ -55,6 +69,7 @@ const appState: AppState = {
   editorCommand: null,
   notifications: { enabled: true, condition: 'unfocused' },
   upgrade: { autoInstall: true },
+  statusLine: { command: null, timeoutMs: 200 },
   availableModels: {},
   availableProviders: {},
   mcpServersSummary: null,
@@ -65,6 +80,7 @@ describe('FooterComponent', () => {
 
   beforeEach(() => {
     chalk.level = 3;
+    statusLineMocks.runStatusLineCommand.mockReset();
   });
 
   afterEach(() => {
@@ -185,5 +201,113 @@ describe('FooterComponent displayName override', () => {
 
     expect(footer.render(120).join('\n')).toContain('Custom Name');
     expect(footer.render(120).join('\n')).not.toContain('Remote Name');
+  });
+});
+
+describe('FooterComponent status line command', () => {
+  it('uses the command output on the second line when configured', async () => {
+    statusLineMocks.runStatusLineCommand.mockResolvedValue('model: kimi-k2 | dir: project');
+    const onRefresh = vi.fn();
+    const footer = new FooterComponent(
+      {
+        ...appState,
+        statusLine: { command: 'kimi-hud', timeoutMs: 250 },
+      },
+      onRefresh,
+    );
+
+    await vi.waitFor(() => {
+      expect(onRefresh).toHaveBeenCalled();
+    });
+
+    const rendered = footer.render(120).join('\n');
+    expect(rendered).toContain('model: kimi-k2 | dir: project');
+    expect(rendered).not.toContain('context: 0.0%');
+    expect(statusLineMocks.runStatusLineCommand).toHaveBeenCalledWith({
+      command: 'kimi-hud',
+      timeoutMs: 250,
+      payload: expect.objectContaining({
+        session_id: 'ses-1',
+        model: 'kimi-k2',
+        display_model: 'kimi-k2',
+        cwd: '/tmp/project',
+        permission_mode: 'manual',
+      }),
+    });
+
+    footer.dispose();
+  });
+
+  it('falls back to the built-in context line when the command returns no output', async () => {
+    statusLineMocks.runStatusLineCommand.mockResolvedValue(null);
+    const onRefresh = vi.fn();
+    const footer = new FooterComponent(
+      {
+        ...appState,
+        statusLine: { command: 'kimi-hud', timeoutMs: 250 },
+      },
+      onRefresh,
+    );
+
+    await vi.waitFor(() => {
+      expect(onRefresh).toHaveBeenCalled();
+    });
+
+    expect(footer.render(120).join('\n')).toContain('context: 0.0%');
+
+    footer.dispose();
+  });
+
+  it('ignores stale command output after the status line is disabled', async () => {
+    const first = deferred<string | null>();
+    statusLineMocks.runStatusLineCommand.mockReturnValue(first.promise);
+    const footer = new FooterComponent({
+      ...appState,
+      statusLine: { command: 'kimi-hud', timeoutMs: 250 },
+    });
+
+    footer.setState({ ...appState, statusLine: { command: null, timeoutMs: 250 } });
+    first.resolve('stale hud');
+    await first.promise;
+    await Promise.resolve();
+
+    const rendered = footer.render(120).join('\n');
+    expect(rendered).toContain('context: 0.0%');
+    expect(rendered).not.toContain('stale hud');
+
+    footer.dispose();
+  });
+
+  it('ignores stale output after switching to another status line command', async () => {
+    const first = deferred<string | null>();
+    const second = deferred<string | null>();
+    statusLineMocks.runStatusLineCommand.mockImplementation(
+      ({ command }: { command: string }) =>
+        command === 'kimi-hud-a' ? first.promise : second.promise,
+    );
+    const onRefresh = vi.fn();
+    const footer = new FooterComponent(
+      {
+        ...appState,
+        statusLine: { command: 'kimi-hud-a', timeoutMs: 250 },
+      },
+      onRefresh,
+    );
+
+    footer.setState({ ...appState, statusLine: { command: 'kimi-hud-b', timeoutMs: 250 } });
+    first.resolve('old hud');
+    await first.promise;
+    await Promise.resolve();
+    await Promise.resolve();
+    second.resolve('new hud');
+    await second.promise;
+    await Promise.resolve();
+    await Promise.resolve();
+
+    const rendered = footer.render(120).join('\n');
+    expect(rendered).toContain('new hud');
+    expect(rendered).not.toContain('old hud');
+
+    footer.dispose();
   });
 });

--- a/apps/kimi-code/test/tui/components/chrome/welcome.test.ts
+++ b/apps/kimi-code/test/tui/components/chrome/welcome.test.ts
@@ -32,6 +32,7 @@ const appState: AppState = {
   editorCommand: null,
   notifications: { enabled: true, condition: 'unfocused' },
   upgrade: { autoInstall: true },
+  statusLine: { command: null, timeoutMs: 200 },
   availableModels: {},
   availableProviders: {},
   mcpServersSummary: null,

--- a/apps/kimi-code/test/tui/config.test.ts
+++ b/apps/kimi-code/test/tui/config.test.ts
@@ -37,6 +37,8 @@ describe('TUI config', () => {
     expect(text).toContain('command = ""');
     expect(text).toContain('[upgrade]');
     expect(text).toContain('auto_install = true');
+    expect(text).toContain('[status_line]');
+    expect(text).toContain('timeout_ms = 200');
     expect(text).toContain('[notifications]');
     expect(text).toContain('enabled = true');
     expect(text).toContain('notification_condition = "unfocused"');
@@ -55,6 +57,10 @@ notification_condition = "always"
 
 [upgrade]
 auto_install = false
+
+[status_line]
+command = "kimi-hud"
+timeout_ms = 500
 `);
 
     expect(config).toEqual({
@@ -63,6 +69,7 @@ auto_install = false
       editorCommand: 'code --wait',
       notifications: { enabled: false, condition: 'always' },
       upgrade: { autoInstall: false },
+      statusLine: { command: 'kimi-hud', timeoutMs: 500 },
     });
   });
 
@@ -87,6 +94,7 @@ command = "   "
       editorCommand: null,
       notifications: { enabled: true, condition: 'unfocused' },
       upgrade: { autoInstall: true },
+      statusLine: { command: null, timeoutMs: 200 },
     });
   });
 
@@ -95,6 +103,7 @@ command = "   "
 
     expect(config.notifications).toEqual({ enabled: true, condition: 'unfocused' });
     expect(config.upgrade).toEqual({ autoInstall: true });
+    expect(config.statusLine).toEqual({ command: null, timeoutMs: 200 });
   });
 
   it('throws TuiConfigParseError with fallback when parsing fails, leaving the file untouched', async () => {
@@ -119,6 +128,7 @@ command = "   "
         editorCommand: 'vim',
         notifications: { enabled: false, condition: 'always' },
         upgrade: { autoInstall: false },
+        statusLine: { command: 'kimi-hud', timeoutMs: 300 },
       },
       filePath,
     );
@@ -129,6 +139,7 @@ command = "   "
       editorCommand: 'vim',
       notifications: { enabled: false, condition: 'always' },
       upgrade: { autoInstall: false },
+      statusLine: { command: 'kimi-hud', timeoutMs: 300 },
     });
   });
 
@@ -141,10 +152,15 @@ command = "   "
         editorCommand: null,
         notifications: DEFAULT_TUI_CONFIG.notifications,
         upgrade: DEFAULT_TUI_CONFIG.upgrade,
+        statusLine: {
+          command: 'status"line\\cmd',
+          timeoutMs: DEFAULT_TUI_CONFIG.statusLine.timeoutMs,
+        },
       },
       filePath,
     );
 
     expect((await loadTuiConfig(filePath)).theme).toBe(theme);
+    expect((await loadTuiConfig(filePath)).statusLine.command).toBe('status"line\\cmd');
   });
 });

--- a/apps/kimi-code/test/tui/create-tui-state.test.ts
+++ b/apps/kimi-code/test/tui/create-tui-state.test.ts
@@ -27,6 +27,7 @@ function fakeInitialAppState(): AppState {
     editorCommand: null,
     notifications: { enabled: true, condition: 'unfocused' },
     upgrade: { autoInstall: true },
+    statusLine: { command: null, timeoutMs: 200 },
     availableModels: {},
     availableProviders: {},
     sessionTitle: null,

--- a/apps/kimi-code/test/tui/kimi-tui-message-flow.test.ts
+++ b/apps/kimi-code/test/tui/kimi-tui-message-flow.test.ts
@@ -132,6 +132,7 @@ function makeStartupInput(): KimiTUIStartupInput {
       editorCommand: null,
       notifications: { enabled: true, condition: 'unfocused' },
       upgrade: { autoInstall: true },
+      statusLine: { command: null, timeoutMs: 200 },
     },
     version: '0.0.0-test',
     workDir: '/tmp/proj-a',

--- a/apps/kimi-code/test/tui/kimi-tui-startup.test.ts
+++ b/apps/kimi-code/test/tui/kimi-tui-startup.test.ts
@@ -92,6 +92,7 @@ function makeStartupInput(
       editorCommand: null,
       notifications: { enabled: true, condition: 'unfocused' },
       upgrade: { autoInstall: true },
+      statusLine: { command: null, timeoutMs: 200 },
       ...tuiConfig,
     },
     version: '0.0.0-test',

--- a/apps/kimi-code/test/tui/message-replay.test.ts
+++ b/apps/kimi-code/test/tui/message-replay.test.ts
@@ -56,6 +56,7 @@ function makeStartupInput(): KimiTUIStartupInput {
       editorCommand: null,
       notifications: { enabled: true, condition: 'unfocused' },
       upgrade: { autoInstall: true },
+      statusLine: { command: null, timeoutMs: 200 },
     },
     version: '0.0.0-test',
     workDir: '/tmp/proj-a',

--- a/apps/kimi-code/test/tui/signal-handlers.test.ts
+++ b/apps/kimi-code/test/tui/signal-handlers.test.ts
@@ -29,6 +29,7 @@ function makeStartupInput(): KimiTUIStartupInput {
       editorCommand: null,
       notifications: { enabled: true, condition: 'unfocused' },
       upgrade: { autoInstall: true },
+      statusLine: { command: null, timeoutMs: 200 },
     },
     version: '0.0.0-test',
     workDir: '/tmp/proj-signals',

--- a/apps/kimi-code/test/tui/utils/status-line-command.test.ts
+++ b/apps/kimi-code/test/tui/utils/status-line-command.test.ts
@@ -1,3 +1,7 @@
+import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
 import { describe, expect, it } from 'vitest';
 
 import {
@@ -20,10 +24,20 @@ const payload: StatusLineCommandPayload = {
     tokens: 1000,
     max_tokens: 4000,
   },
+  rate_limits: [],
 };
 
 function nodeCommand(script: string): string {
   return `${JSON.stringify(process.execPath)} -e ${JSON.stringify(script)}`;
+}
+
+function isProcessAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 describe('runStatusLineCommand', () => {
@@ -47,5 +61,32 @@ describe('runStatusLineCommand', () => {
     });
 
     expect(result).toBeNull();
+  });
+
+  it('terminates the whole shell process tree on timeout', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'kimi-status-line-'));
+    const pidFile = join(dir, 'child.pid');
+    let childPid: number | undefined;
+    try {
+      const writer = nodeCommand(
+        `require('node:fs').writeFileSync(${JSON.stringify(pidFile)}, String(process.pid)); setInterval(() => {}, 1000);`,
+      );
+      const relay = nodeCommand('process.stdin.resume();');
+
+      const result = await runStatusLineCommand({
+        command: `${writer} | ${relay}`,
+        timeoutMs: 50,
+        payload,
+      });
+
+      expect(result).toBeNull();
+      childPid = Number(await readFile(pidFile, 'utf8'));
+      await expect.poll(() => isProcessAlive(childPid!), { timeout: 500 }).toBe(false);
+    } finally {
+      if (childPid !== undefined && isProcessAlive(childPid)) {
+        process.kill(childPid, 'SIGKILL');
+      }
+      await rm(dir, { recursive: true, force: true });
+    }
   });
 });

--- a/apps/kimi-code/test/tui/utils/status-line-command.test.ts
+++ b/apps/kimi-code/test/tui/utils/status-line-command.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  runStatusLineCommand,
+  type StatusLineCommandPayload,
+} from '#/tui/utils/status-line-command';
+
+const payload: StatusLineCommandPayload = {
+  session_id: 'ses-1',
+  model: 'kimi-k2',
+  display_model: 'Kimi K2',
+  cwd: '/tmp/project',
+  permission_mode: 'manual',
+  plan_mode: false,
+  input_mode: 'prompt',
+  swarm_mode: false,
+  thinking_effort: 'off',
+  context: {
+    usage: 0.25,
+    tokens: 1000,
+    max_tokens: 4000,
+  },
+};
+
+function nodeCommand(script: string): string {
+  return `${JSON.stringify(process.execPath)} -e ${JSON.stringify(script)}`;
+}
+
+describe('runStatusLineCommand', () => {
+  it('passes the payload on stdin and returns the first stdout line', async () => {
+    const result = await runStatusLineCommand({
+      command: nodeCommand(
+        "let input='';process.stdin.on('data',(chunk)=>input+=chunk);process.stdin.on('end',()=>{const payload=JSON.parse(input);console.log(payload.model+' @ '+payload.cwd);console.log('ignored');});",
+      ),
+      timeoutMs: 500,
+      payload,
+    });
+
+    expect(result).toBe('kimi-k2 @ /tmp/project');
+  });
+
+  it('returns null when the command times out', async () => {
+    const result = await runStatusLineCommand({
+      command: nodeCommand('setTimeout(() => {}, 1000);'),
+      timeoutMs: 10,
+      payload,
+    });
+
+    expect(result).toBeNull();
+  });
+});

--- a/docs/en/configuration/config-files.md
+++ b/docs/en/configuration/config-files.md
@@ -334,9 +334,19 @@ Example payload:
     "usage": 0.12,
     "tokens": 31457,
     "max_tokens": 262144
-  }
+  },
+  "rate_limits": [
+    {
+      "label": "Weekly limit",
+      "used": 120,
+      "limit": 1000,
+      "reset_hint": "resets in 2d"
+    }
+  ]
 }
 ```
+
+For managed Kimi providers, `rate_limits` contains the available plan quota rows and is refreshed at most once every 30 seconds. It is an empty array for other providers or when usage data is unavailable.
 
 Changes apply on the next start, or immediately with `/reload-tui` (which reloads only `tui.toml`); `/reload` reloads both `config.toml` and `tui.toml`.
 

--- a/docs/en/configuration/config-files.md
+++ b/docs/en/configuration/config-files.md
@@ -292,6 +292,8 @@ Alongside `config.toml`, the CLI keeps terminal-UI and client preferences in a c
 | `[notifications].enabled` | `boolean` | `true` | Whether desktop notifications are sent |
 | `[notifications].notification_condition` | `string` | `unfocused` | When to notify: `unfocused` (only when the terminal is not focused) or `always` |
 | `[upgrade].auto_install` | `boolean` | `true` | Whether new versions are installed automatically |
+| `[status_line].command` | `string` | `""` | External command used to render the second footer line; empty uses the built-in context indicator |
+| `[status_line].timeout_ms` | `integer` | `200` | Maximum time to wait for the status-line command |
 
 ```toml
 # ~/.kimi-code/tui.toml
@@ -307,6 +309,33 @@ notification_condition = "unfocused" # "unfocused" | "always"
 
 [upgrade]
 auto_install = true
+
+[status_line]
+command = "" # External command; empty uses the built-in context indicator
+timeout_ms = 200
+```
+
+When `[status_line].command` is set, Kimi Code runs the command about once per second, sends a JSON payload on stdin, and uses the first stdout line as the second footer line. If the command exits non-zero, times out, or prints no output, the built-in context indicator is shown instead.
+
+Example payload:
+
+```json
+{
+  "session_id": "ses_123",
+  "model": "kimi-k2",
+  "display_model": "Kimi K2",
+  "cwd": "/path/to/project",
+  "permission_mode": "manual",
+  "plan_mode": false,
+  "input_mode": "prompt",
+  "swarm_mode": false,
+  "thinking_effort": "off",
+  "context": {
+    "usage": 0.12,
+    "tokens": 31457,
+    "max_tokens": 262144
+  }
+}
 ```
 
 Changes apply on the next start, or immediately with `/reload-tui` (which reloads only `tui.toml`); `/reload` reloads both `config.toml` and `tui.toml`.

--- a/docs/zh/configuration/config-files.md
+++ b/docs/zh/configuration/config-files.md
@@ -292,6 +292,8 @@ MCP server 的声明配置写在 `~/.kimi-code/mcp.json` 或项目内 `.kimi-cod
 | `[notifications].enabled` | `boolean` | `true` | 是否发送桌面通知 |
 | `[notifications].notification_condition` | `string` | `unfocused` | 何时通知：`unfocused`（仅终端失去焦点时）或 `always`（总是） |
 | `[upgrade].auto_install` | `boolean` | `true` | 是否自动安装新版本 |
+| `[status_line].command` | `string` | `""` | 用来渲染第二行 footer 的外部命令；留空则使用内置上下文用量指示 |
+| `[status_line].timeout_ms` | `integer` | `200` | 等待 status line 命令的最长时间 |
 
 ```toml
 # ~/.kimi-code/tui.toml
@@ -307,6 +309,33 @@ notification_condition = "unfocused" # "unfocused" | "always"
 
 [upgrade]
 auto_install = true
+
+[status_line]
+command = "" # 外部命令；留空则使用内置上下文用量指示
+timeout_ms = 200
+```
+
+设置 `[status_line].command` 后，Kimi Code 会约每秒运行一次该命令，通过 stdin 传入 JSON，并把 stdout 的第一行作为第二行 footer 显示。命令非零退出、超时或没有输出时，会回退到内置上下文用量指示。
+
+示例 payload：
+
+```json
+{
+  "session_id": "ses_123",
+  "model": "kimi-k2",
+  "display_model": "Kimi K2",
+  "cwd": "/path/to/project",
+  "permission_mode": "manual",
+  "plan_mode": false,
+  "input_mode": "prompt",
+  "swarm_mode": false,
+  "thinking_effort": "off",
+  "context": {
+    "usage": 0.12,
+    "tokens": 31457,
+    "max_tokens": 262144
+  }
+}
 ```
 
 修改在下次启动时生效，或用 `/reload-tui` 立即生效（只重载 `tui.toml`）；`/reload` 会同时重载 `config.toml` 和 `tui.toml`。

--- a/docs/zh/configuration/config-files.md
+++ b/docs/zh/configuration/config-files.md
@@ -334,9 +334,19 @@ timeout_ms = 200
     "usage": 0.12,
     "tokens": 31457,
     "max_tokens": 262144
-  }
+  },
+  "rate_limits": [
+    {
+      "label": "Weekly limit",
+      "used": 120,
+      "limit": 1000,
+      "reset_hint": "resets in 2d"
+    }
+  ]
 }
 ```
+
+对于 Kimi 托管供应商，`rate_limits` 包含可用的套餐额度行，并且最多每 30 秒刷新一次。使用其他供应商或无法获取用量数据时，它是一个空数组。
 
 修改在下次启动时生效，或用 `/reload-tui` 立即生效（只重载 `tui.toml`）；`/reload` 会同时重载 `config.toml` 和 `tui.toml`。
 


### PR DESCRIPTION
## Summary
- add `[status_line]` TUI config for rendering the footer status line with an external command
- pass session, model, cwd, context, and managed plan quota metadata to the command via stdin JSON
- cache managed quota data for 30 seconds and fall back to an empty `rate_limits` array when unavailable
- fall back to the built-in context indicator on empty output, failures, or timeouts
- terminate the full shell process tree on timeout on both POSIX and Windows
- document the config and payload in English and Chinese docs

## Related issue
- Related to #1171, which proposes an external `statusLine` command as an alternative to a built-in quota footer

## Tests
- `pnpm exec vitest run apps/kimi-code/test/tui/config.test.ts apps/kimi-code/test/tui/components/chrome/footer.test.ts apps/kimi-code/test/tui/utils/status-line-command.test.ts apps/kimi-code/test/tui/commands/reload.test.ts apps/kimi-code/test/tui/kimi-tui-startup.test.ts apps/kimi-code/test/tui/create-tui-state.test.ts apps/kimi-code/test/tui/activity-pane.test.ts apps/kimi-code/test/tui/kimi-tui-message-flow.test.ts apps/kimi-code/test/tui/message-replay.test.ts apps/kimi-code/test/tui/signal-handlers.test.ts apps/kimi-code/test/cli/update/preflight.test.ts` (304 tests)
- `pnpm --filter @moonshot-ai/kimi-code run typecheck`
- `pnpm exec oxlint --type-aware` on the changed TypeScript files (0 errors; one pre-existing warning remains in `kimi-tui.ts`)
- `pnpm exec changeset status`
- `pnpm -C docs run build`
- `git diff --check`
