### PR TITLE
fix: surface provider auth error for unavailable models

### DIFF
--- a/.changeset/fix-model-auth-error-message.md
+++ b/.changeset/fix-model-auth-error-message.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Fix a misleading "OAuth login expired" message shown when a model is not available for the current account; the CLI now shows the provider's actual error.

--- a/packages/agent-core/src/agent/compaction/full.ts
+++ b/packages/agent-core/src/agent/compaction/full.ts
@@ -595,7 +595,12 @@ export class FullCompaction {
         thinking_effort: this.agent.config.thinkingEffort,
         error_type: error instanceof Error ? error.name : 'Unknown',
       });
-      if (isKimiError(error) && error.code === ErrorCodes.AUTH_LOGIN_REQUIRED) throw error;
+      if (
+        isKimiError(error) &&
+        (error.code === ErrorCodes.AUTH_LOGIN_REQUIRED ||
+          error.code === ErrorCodes.PROVIDER_AUTH_ERROR)
+      )
+        throw error;
       throw new KimiError(ErrorCodes.COMPACTION_FAILED, String(error), { cause: error });
     }
   }

--- a/packages/agent-core/src/session/provider-manager.ts
+++ b/packages/agent-core/src/session/provider-manager.ts
@@ -203,9 +203,10 @@ export class ProviderManager implements ModelProvider {
         } catch (error) {
           if (!(error instanceof APIStatusError) || error.statusCode !== 401) throw error;
           if (refreshed) {
+            const reason = error.message.replaceAll('\r', '');
             throw new KimiError(
-              ErrorCodes.AUTH_LOGIN_REQUIRED,
-              'OAuth provider credentials were rejected. Send /login to login.',
+              ErrorCodes.PROVIDER_AUTH_ERROR,
+              reason.length > 0 ? reason : 'OAuth provider credentials were rejected.',
               {
                 cause: error,
                 details: { statusCode: error.statusCode, requestId: error.requestId },

--- a/packages/agent-core/test/agent/compaction/full.test.ts
+++ b/packages/agent-core/test/agent/compaction/full.test.ts
@@ -362,7 +362,7 @@ describe('FullCompaction', () => {
     expect(messageText(compactionCall?.history[5])).toBe('lookup result');
   });
 
-  it('force-refreshes OAuth credentials on compaction 401 and falls back to login_required when replay 401', async () => {
+  it('force-refreshes OAuth credentials on compaction 401 and treats replay 401 as provider auth error', async () => {
     const tokenCalls: Array<boolean | undefined> = [];
     const authKeys: string[] = [];
     const oauthOptions = oauthTestAgentOptions(async (options) => {
@@ -398,7 +398,7 @@ describe('FullCompaction', () => {
       expect.objectContaining({
         event: 'error',
         args: expect.objectContaining({
-          code: 'auth.login_required',
+          code: 'provider.auth_error',
           details: expect.objectContaining({
             statusCode: 401,
             requestId: 'req-compact-401',

--- a/packages/agent-core/test/agent/turn.test.ts
+++ b/packages/agent-core/test/agent/turn.test.ts
@@ -1409,7 +1409,7 @@ describe('Agent turn flow', () => {
     );
   });
 
-  it('falls back to login_required when force-refresh and replay both 401', async () => {
+  it('treats 401 after force-refresh as provider auth error', async () => {
     const tokenCalls: Array<boolean | undefined> = [];
     const authKeys: string[] = [];
     const oauthOptions = oauthAgentOptions(
@@ -1447,7 +1447,7 @@ describe('Agent turn flow', () => {
         args: expect.objectContaining({
           reason: 'failed',
           error: expect.objectContaining({
-            code: 'auth.login_required',
+            code: 'provider.auth_error',
             details: expect.objectContaining({
               statusCode: 401,
               requestId: 'req-401',
@@ -1644,7 +1644,7 @@ describe('Agent turn flow', () => {
     expect(payloads[1]).toMatchObject({ turnStep: '0.1', attempt: '2/3' });
   });
 
-  it('force-refreshes OAuth credentials on video upload 401 and falls back to login_required when replay 401', async () => {
+  it('force-refreshes OAuth credentials on video upload 401 and surfaces the provider auth error when replay 401', async () => {
     const tokenCalls: Array<boolean | undefined> = [];
     const authKeys: string[] = [];
     const oauthOptions = oauthAgentOptions(
@@ -1689,8 +1689,9 @@ describe('Agent turn flow', () => {
     expect(result.isError).toBe(true);
     expect(authKeys).toEqual(['fresh-token', 'forced-refresh-token']);
     expect(tokenCalls).toEqual([undefined, true]);
-    expect(result.output).toContain('OAuth provider credentials were rejected');
-    expect(result.output).toContain('Send /login to login');
+    expect(result.output).toContain('Unauthorized');
+    expect(result.output).not.toContain('OAuth provider credentials were rejected');
+    expect(result.output).not.toContain('Send /login to login');
   });
 
   it('cancels an active turn', async () => {


### PR DESCRIPTION
## Related Issue

No related issue — this is a clear, reproducible bug fix with a focused diff (see Problem below).

## Problem

When an OAuth-managed model is not available for the current account (for example a highspeed variant the plan does not include), the CLI shows:

> OAuth login expired. Send /login to login.

That is misleading: the user is already logged in and other models on the same account work fine, so re-running `/login` does nothing — the account simply lacks access to that specific model. The provider actually returns a precise explanation (which model is unavailable and what plan is required), but the CLI was discarding it and showing the generic login-expired text.

## What changed

In the OAuth runtime, a request that returns 401 after a forced token refresh means the token is valid but the provider rejected it for that model. This now emits `provider.auth_error` carrying the provider's own message, instead of `auth.login_required` with the "Send /login" prompt.

This also makes the managed OAuth path consistent with the rest of the codebase, where a provider 401 already maps to `provider.auth_error`. The compaction path now lets both auth codes pass through as well, instead of wrapping a provider auth rejection as a generic `compaction.failed`, so the provider message surfaces during compaction too. Genuine not-logged-in / token-refresh-failed cases are unchanged and still produce `auth.login_required` → "OAuth login expired. Send /login to login."

Tests were updated to cover the corrected code and the surfaced provider message.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.
