### PR TITLE
fix: reduce grouped tool refreshes

### DIFF
--- a/.changeset/reduce-group-refreshes.md
+++ b/.changeset/reduce-group-refreshes.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Reduce redundant transcript refresh work for grouped agent and file-read activity.

--- a/apps/kimi-code/src/tui/components/messages/agent-group.ts
+++ b/apps/kimi-code/src/tui/components/messages/agent-group.ts
@@ -48,7 +48,6 @@ export class AgentGroupComponent extends Container {
   private readonly bodyContainer: Container;
   private throttleTimer: ReturnType<typeof setTimeout> | null = null;
   private lastFlushPhases = new Map<string, ToolCallSubagentSnapshot['phase']>();
-  private _invalidating = false;
 
   constructor(private readonly ui: TUI | undefined) {
     super();
@@ -85,7 +84,6 @@ export class AgentGroupComponent extends Container {
     tc.setSnapshotListener(() => {
       this.scheduleRender();
     });
-    this.flushRender();
   }
 
   /**
@@ -143,7 +141,7 @@ export class AgentGroupComponent extends Container {
       if (snap !== undefined) this.lastFlushPhases.set(entry.toolCallId, snap.phase);
     });
 
-    this.invalidate();
+    super.invalidate();
     this.ui?.requestRender();
   }
 
@@ -225,13 +223,7 @@ export class AgentGroupComponent extends Container {
 
   /** Releases throttle timers so destroyed components cannot refresh later. */
   override invalidate(): void {
-    if (this._invalidating) {
-      super.invalidate();
-      return;
-    }
-    this._invalidating = true;
     this.flushRender();
-    this._invalidating = false;
   }
 
   dispose(): void {

--- a/apps/kimi-code/src/tui/components/messages/read-group.ts
+++ b/apps/kimi-code/src/tui/components/messages/read-group.ts
@@ -41,7 +41,6 @@ export class ReadGroupComponent extends Container {
   private readonly bodyContainer: Container;
   private throttleTimer: ReturnType<typeof setTimeout> | null = null;
   private lastFlushPhases = new Map<string, ToolCallReadSnapshot['phase']>();
-  private _invalidating = false;
 
   constructor(private readonly ui: TUI | undefined) {
     super();
@@ -67,7 +66,6 @@ export class ReadGroupComponent extends Container {
     tc.setSnapshotListener(() => {
       this.scheduleRender();
     });
-    this.flushRender();
   }
 
   /**
@@ -126,7 +124,7 @@ export class ReadGroupComponent extends Container {
       if (snap !== undefined) this.lastFlushPhases.set(entry.toolCallId, snap.phase);
     });
 
-    this.invalidate();
+    super.invalidate();
     this.ui?.requestRender();
   }
 
@@ -171,13 +169,7 @@ export class ReadGroupComponent extends Container {
   }
 
   override invalidate(): void {
-    if (this._invalidating) {
-      super.invalidate();
-      return;
-    }
-    this._invalidating = true;
     this.flushRender();
-    this._invalidating = false;
   }
 
   /** Releases throttle timers so destroyed components cannot refresh later. */

--- a/apps/kimi-code/test/tui/components/messages/agent-group.test.ts
+++ b/apps/kimi-code/test/tui/components/messages/agent-group.test.ts
@@ -60,6 +60,23 @@ describe('AgentGroupComponent', () => {
     vi.useRealTimers();
   });
 
+  it('requests one render when attaching an agent', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(0);
+    const ui = stubTui();
+    const group = new AgentGroupComponent(ui);
+    const agent = createAgent('call_agent_1', 'inspect project', 'reviewer', ui);
+
+    vi.mocked(ui.requestRender).mockClear();
+
+    group.attach('call_agent_1', agent);
+
+    expect(ui.requestRender).toHaveBeenCalledTimes(1);
+
+    group.dispose();
+    agent.dispose();
+  });
+
   it('shows explicit active breakdown, row state, and waiting fallback', () => {
     vi.useFakeTimers();
     vi.setSystemTime(0);

--- a/apps/kimi-code/test/tui/components/messages/read-group.test.ts
+++ b/apps/kimi-code/test/tui/components/messages/read-group.test.ts
@@ -1,0 +1,41 @@
+import type { TUI } from '@moonshot-ai/pi-tui';
+import { describe, expect, it, vi } from 'vitest';
+
+import { ReadGroupComponent } from '#/tui/components/messages/read-group';
+import { ToolCallComponent } from '#/tui/components/messages/tool-call';
+
+function stubTui(): TUI {
+  return {
+    terminal: { rows: 40 },
+    requestRender: vi.fn(),
+  } as unknown as TUI;
+}
+
+function createRead(id: string, filePath: string, ui: TUI): ToolCallComponent {
+  return new ToolCallComponent(
+    {
+      id,
+      name: 'Read',
+      args: { file_path: filePath },
+    },
+    undefined,
+    ui,
+  );
+}
+
+describe('ReadGroupComponent', () => {
+  it('requests one render when attaching a read', () => {
+    const ui = stubTui();
+    const group = new ReadGroupComponent(ui);
+    const read = createRead('call_read_1', 'src/a.ts', ui);
+
+    vi.mocked(ui.requestRender).mockClear();
+
+    group.attach('call_read_1', read);
+
+    expect(ui.requestRender).toHaveBeenCalledTimes(1);
+
+    group.dispose();
+    read.dispose();
+  });
+});


### PR DESCRIPTION
## Related Issue

Fixes #1511

## Problem

Grouped Agent and Read transcript components were doing redundant component-level refresh work when attaching a borrowed tool-call component. Actual terminal rendering is coalesced by the TUI scheduler, but the group components still rebuilt and requested render more often than needed.

## What changed

- Let the initial snapshot listener callback drive the first group refresh instead of flushing again from `attach()`.
- In grouped Agent and Read refresh paths, invalidate child render state through the base container instead of re-entering the component's overridden `invalidate()` path.
- Added focused component tests that prove a single attach requests one render for Agent and Read groups.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.

Verification:

- `pnpm exec vitest run apps/kimi-code/test/tui/components/messages/agent-group.test.ts apps/kimi-code/test/tui/components/messages/read-group.test.ts`
- `pnpm exec vitest run apps/kimi-code/test/tui/message-replay.test.ts`
- `pnpm exec oxlint --type-aware apps/kimi-code/src/tui/components/messages/agent-group.ts apps/kimi-code/src/tui/components/messages/read-group.ts apps/kimi-code/test/tui/components/messages/agent-group.test.ts apps/kimi-code/test/tui/components/messages/read-group.test.ts`
- `pnpm --filter @moonshot-ai/kimi-code run typecheck`
