### PR TITLE
fix: resume sessions with missing workdir

### DIFF
--- a/.changeset/fix-missing-workdir-resume.md
+++ b/.changeset/fix-missing-workdir-resume.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Fix resuming sessions whose original working directory no longer exists.

--- a/packages/agent-core/src/agent/config/index.ts
+++ b/packages/agent-core/src/agent/config/index.ts
@@ -48,7 +48,7 @@ export class ConfigState {
     });
     if (changed.cwd) {
       this._cwd = changed.cwd;
-      void this.agent.kaos.chdir(changed.cwd);
+      this.agent.setKaos(this.agent.kaos.withCwd(changed.cwd));
     }
     if (changed.modelAlias) {
       this._modelAlias = changed.modelAlias;

--- a/packages/agent-core/test/agent/config-state.test.ts
+++ b/packages/agent-core/test/agent/config-state.test.ts
@@ -4,8 +4,27 @@ import { emptyUsage } from '@moonshot-ai/kosong';
 import { ProviderManager } from '../../src/session/provider-manager';
 import type { KimiConfig } from '../../src/config';
 import { testAgent } from './harness';
+import { createFakeKaos } from '../tools/fixtures/fake-kaos';
 
 describe('ConfigState model capabilities', () => {
+  it('updates the agent cwd without requiring the directory to exist', () => {
+    const chdir = vi.fn(async () => {
+      throw Object.assign(new Error('missing workspace'), { code: 'ENOENT' });
+    });
+    const ctx = testAgent({
+      kaos: createFakeKaos({
+        getcwd: () => '/workspace',
+        chdir,
+      }),
+    });
+
+    ctx.agent.config.update({ cwd: '/tmp/missing-workdir' });
+
+    expect(ctx.agent.config.cwd).toBe('/tmp/missing-workdir');
+    expect(ctx.agent.kaos.getcwd()).toBe('/tmp/missing-workdir');
+    expect(chdir).not.toHaveBeenCalled();
+  });
+
   it('computes provider and model capabilities from ProviderManager metadata', () => {
     const ctx = testAgent({
       providerManager: new ProviderManager({

--- a/packages/agent-core/test/tools/fixtures/fake-kaos.ts
+++ b/packages/agent-core/test/tools/fixtures/fake-kaos.ts
@@ -32,9 +32,9 @@ export function createFakeKaos(
   overrides?: Partial<Kaos>,
   envLayers: readonly Record<string, string>[] = [],
 ): Kaos {
-  // Hold cwd in a closure so `chdir` (which `config.update({cwd})` now
-  // routes through) can mutate it and later `getcwd()` calls see the
-  // update — mirroring real-kaos semantics without needing a backing fs.
+  // Hold cwd in a closure so tests that call `chdir` directly can mutate it
+  // and later `getcwd()` calls see the update — mirroring real-kaos semantics
+  // without needing a backing fs.
   let cwd = overrides?.getcwd?.() ?? '/workspace';
   const base: Kaos = {
     name: 'fake',


### PR DESCRIPTION
## Related Issue

No linked issue; this fixes a reported `ENOENT` crash when resuming a session whose original temporary working directory was removed.

## Problem

Session resume replays persisted `config.update` records, including the session cwd. That path may point at a temporary directory that no longer exists, but replay still called `LocalKaos.chdir`, which stats the directory and can throw before the session resumes.

## What changed

- Rebind agent Kaos with `withCwd` when config cwd changes, so replay preserves the recorded cwd without requiring the directory to exist.
- Added a regression test proving cwd updates do not call `chdir` when the recorded workdir is missing.
- Added a patch changeset for the CLI release artifact.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.

Validation:

- `pnpm --filter @moonshot-ai/agent-core test -- test/agent/config-state.test.ts` (ran the agent-core suite: 3,647 passed, existing skips/expected failures)
- `pnpm --filter @moonshot-ai/agent-core typecheck`
- `pnpm exec oxlint --type-aware packages/agent-core/src/agent/config/index.ts packages/agent-core/test/agent/config-state.test.ts packages/agent-core/test/tools/fixtures/fake-kaos.ts`
- `pnpm --filter @moonshot-ai/agent-core exec vitest run test/agent/config-state.test.ts`
- Read-only internal identifier audit passed for HEAD `52c0bd373e20fbeb4fc476ad2c23d7c3a99f5aa7`
