### PR TITLE
feat: add Ctrl+Y keyboard shortcut to toggle YOLO mode

### DIFF
--- a/.changeset/six-foxes-smoke.md
+++ b/.changeset/six-foxes-smoke.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Add Ctrl+Y keyboard shortcut to toggle YOLO permission mode. Press Ctrl+Y to switch YOLO mode on or off.

--- a/apps/kimi-code/src/tui/components/editor/custom-editor.ts
+++ b/apps/kimi-code/src/tui/components/editor/custom-editor.ts
@@ -133,6 +133,7 @@ export class CustomEditor extends Editor {
   /** Return `true` to consume Ctrl+B; return `false`/`undefined` to fall through to the editor default (cursor-left). */
   public onCtrlB?: () => boolean;
   /** Return `true` to consume Ctrl+T (the todo list had overflow to toggle); return `false`/`undefined` to fall through to the editor default. */
+  public onCtrlY?: () => void;
   public onToggleTodoExpand?: () => boolean;
   public onUndo?: () => void;
   public onTextPaste?: () => void;
@@ -439,6 +440,11 @@ export class CustomEditor extends Editor {
       // otherwise fall through so readline's backward-char still works at the
       // idle prompt.
       if (this.onCtrlB?.() === true) return;
+    }
+
+    if (matchesKey(normalized, Key.ctrl('y'))) {
+      this.onCtrlY?.();
+      return;
     }
 
     if (matchesKey(normalized, Key.ctrl('t'))) {

--- a/apps/kimi-code/src/tui/controllers/editor-keyboard.ts
+++ b/apps/kimi-code/src/tui/controllers/editor-keyboard.ts
@@ -46,6 +46,7 @@ export interface EditorKeyboardHost {
   openUndoSelector(): void;
   stop(exitCode?: number): Promise<void>;
   handlePlanToggle(next: boolean): void;
+  handleYoloToggle(): void;
   handleInputModeChange(mode: 'prompt' | 'bash'): void;
   clearQueuedMessages(): void;
   setExternalEditorRunning(running: boolean): void;
@@ -199,6 +200,11 @@ export class EditorKeyboardController {
         return;
       }
       this.armPendingUndoEsc();
+    };
+
+    editor.onCtrlY = () => {
+      host.track('shortcut_yolo_toggle');
+      host.handleYoloToggle();
     };
 
     editor.onShiftTab = () => {

--- a/apps/kimi-code/src/tui/kimi-tui.ts
+++ b/apps/kimi-code/src/tui/kimi-tui.ts
@@ -917,6 +917,10 @@ export class KimiTUI {
     void slashCommands.handlePlanCommand(this, next ? 'on' : 'off');
   }
 
+  handleYoloToggle(): void {
+    void slashCommands.handleYoloCommand(this, '');
+  }
+
   handleInputModeChange(mode: 'prompt' | 'bash'): void {
     this.setAppState({ inputMode: mode });
     this.updateEditorBorderHighlight();


### PR DESCRIPTION
<!--
Thank you for your contribution to Kimi Code!
Please open an issue before sending a feature PR — PRs without prior discussion may be closed without review.

See https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md for more.
-->

## Related Issue

<!-- Link the issue this feature came from. If there is no issue, explain the problem in the next section instead. -->

Resolve #(issue_number)

## Problem

YOLO 模式只能通过 /yolo 斜杠命令切换，缺少键盘快捷键，影响快速操作体验

<!-- What user need or limitation does this address? If the linked issue already covers this, write "See linked issue". -->

## What changed

新增 ctrl+y 全局快捷键，按 ctrl+y 可即时切换 YOLO 模式的开关。遵循现有快捷键模式（ctrl+s、ctrl+b、ctrl+o 等），在 CustomEditor 中注册 onCtrlY 回调，EditorKeyboardController 中绑定 telemetry + 委托给 /yolo 切换逻辑

<!-- What did you implement, and why does this approach fit Kimi Code? -->

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [ ] I have linked a related issue, or explained the problem above.
- [ ] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [ ] Ran `gen-docs` skill, or this PR needs no doc update.
