### PR TITLE
fix(ci): pin npm to 11.x in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,7 @@ jobs:
           registry-url: "https://registry.npmjs.org"
 
       - name: Upgrade npm for Trusted Publishing
-        run: npm install -g npm@latest
+        run: npm install -g npm@11
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile


### PR DESCRIPTION
## Related Issue

N/A — unblocks the 0.23.4 release.

## Problem

The Release workflow failed to publish `@moonshot-ai/kimi-code@0.23.4` to npm ([failed run](https://github.com/MoonshotAI/kimi-code/actions/runs/29030811246)). The `pnpm changeset publish` step invokes `npm publish`, which errored with:

```
MODULE_NOT_FOUND Cannot find module 'sigstore'
Require stack: …/npm/node_modules/libnpmpublish/lib/provenance.js
```

`npm@latest` is now 12.0.0, which ships with a packaging bug that drops `sigstore` (used by npm provenance / OIDC trusted publishing) from the global install — see [npm/cli#9722](https://github.com/npm/cli/issues/9722). The "Upgrade npm for Trusted Publishing" step pulls `@latest`, so it picked up the broken 12.0.0.

## What changed

Pin the npm upgrade to the 11.x line (`npm install -g npm@11`) instead of `@latest`. npm 11.x (>= 11.5.1) already supports trusted publishing and is unaffected by the 12.0.0 sigstore bug.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [ ] I have added tests that prove my feature works. (N/A — CI workflow change)
- [x] Ran `gen-changesets` skill, or this PR needs no changeset. (No changeset — workflow change, not bundled)
- [x] Ran `gen-docs` skill, or this PR needs no doc update. (N/A — workflow change)
