### PR TITLE
chore(agents): place Polish before Bug Fixes in changelog sections

### DIFF
--- a/.agents/skills/sync-changelog/SKILL.md
+++ b/.agents/skills/sync-changelog/SKILL.md
@@ -148,8 +148,8 @@ The docs changelog uses five section types:
 | English section | Chinese section | Meaning |
 |---|---|---|
 | `### Features` | `### 新功能` | New user-facing functionality, such as a new command, flag, mode, or capability that did not exist before |
-| `### Bug Fixes` | `### 修复` | Fixes for behavior that was broken |
 | `### Polish` | `### 优化` | User-visible improvements to existing functionality, including UX adjustments, behavior tweaks, and performance improvements that are not fixes or new capabilities |
+| `### Bug Fixes` | `### 修复` | Fixes for behavior that was broken |
 | `### Refactors` | `### 重构` | Internal changes with no user-visible behavior change, including build, CI, tests, dependency cleanup, and internal renames |
 | `### Other` | `### 其他` | Anything that does not fit above, such as CDN/endpoint swaps and docs-related artifacts |
 
@@ -176,7 +176,7 @@ Keyword hints:
 Within each version, section order is:
 
 ```text
-Features → Bug Fixes → Polish → Refactors → Other
+Features → Polish → Bug Fixes → Refactors → Other
 ```
 
 Omit empty sections. Within each section, order entries by reader value, not upstream order:


### PR DESCRIPTION
## Related Issue

N/A — agent workflow tweak.

## Problem

The `sync-changelog` skill ordered changelog sections as Features → Bug Fixes → Polish → Refactors → Other. We want Polish (优化) to appear before Bug Fixes (修复) so user-visible improvements are listed ahead of fixes in the docs changelog and the pre-release preview.

## What changed

Reorder the section order in `.agents/skills/sync-changelog/SKILL.md` to Features → Polish → Bug Fixes → Refactors → Other, and update the section-definition table to match. `pre-changelog` inherits this order automatically since it delegates ordering to `sync-changelog`.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [ ] I have added tests that prove my feature works. (N/A — skill doc change)
- [x] Ran `gen-changesets` skill, or this PR needs no changeset. (No changeset — skill doc, not bundled)
- [x] Ran `gen-docs` skill, or this PR needs no doc update. (N/A — skill doc change)
