### PR TITLE
feat: harden LLM API fault tolerance against 429 and overload

### DIFF
--- a/.changeset/retry-fault-tolerance.md
+++ b/.changeset/retry-fault-tolerance.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Retry provider 429, overload, and other transient errors more reliably, honoring the server Retry-After delay, and surface retries in `-p --output-format stream-json`.

--- a/apps/kimi-code/src/cli/run-prompt.ts
+++ b/apps/kimi-code/src/cli/run-prompt.ts
@@ -501,6 +501,7 @@ function runPromptTurn(
           return;
         case 'turn.step.retrying':
           outputWriter.discardAssistant();
+          outputWriter.writeRetrying(event);
           return;
         case 'assistant.delta':
           outputWriter.writeAssistantDelta(event.delta);
@@ -612,6 +613,7 @@ interface PromptTurnWriter {
     argumentsPart: string | undefined,
   ): void;
   writeToolResult(toolCallId: string, output: unknown): void;
+  writeRetrying(event: Extract<Event, { type: 'turn.step.retrying' }>): void;
   flushAssistant(): void;
   discardAssistant(): void;
   finish(): void;
@@ -647,6 +649,11 @@ class PromptTranscriptWriter implements PromptTurnWriter {
   writeToolCallDelta(): void {}
 
   writeToolResult(): void {}
+
+  // Text `-p` keeps retries silent: only the failed attempt's partial assistant
+  // text is discarded (handled by the caller). No human-readable retry line is
+  // emitted, matching the prior behavior.
+  writeRetrying(): void {}
 
   flushAssistant(): void {
     this.assistantWriter.finish();
@@ -687,6 +694,18 @@ interface PromptJsonResumeMetaMessage {
   session_id: string;
   command: string;
   content: string;
+}
+
+interface PromptJsonRetryMetaMessage {
+  role: 'meta';
+  type: 'turn.step.retrying';
+  failed_attempt: number;
+  next_attempt: number;
+  max_attempts: number;
+  delay_ms: number;
+  error_name: string;
+  error_message: string;
+  status_code?: number;
 }
 
 function writeResumeHint(
@@ -787,6 +806,24 @@ class PromptJsonWriter implements PromptTurnWriter {
     this.toolCalls.length = 0;
   }
 
+  writeRetrying(event: Extract<Event, { type: 'turn.step.retrying' }>): void {
+    // Emit a machine-readable meta line so stream-json consumers can observe
+    // provider retries. The failed attempt's partial assistant text was already
+    // discarded by the caller, so no half-formed assistant message leaks.
+    const message: PromptJsonRetryMetaMessage = {
+      role: 'meta',
+      type: 'turn.step.retrying',
+      failed_attempt: event.failedAttempt,
+      next_attempt: event.nextAttempt,
+      max_attempts: event.maxAttempts,
+      delay_ms: event.delayMs,
+      error_name: event.errorName,
+      error_message: event.errorMessage,
+      status_code: event.statusCode,
+    };
+    this.writeJsonLine(message);
+  }
+
   finish(): void {
     this.flushAssistant();
   }
@@ -806,7 +843,9 @@ class PromptJsonWriter implements PromptTurnWriter {
     return toolCall;
   }
 
-  private writeJsonLine(message: PromptJsonAssistantMessage | PromptJsonToolMessage): void {
+  private writeJsonLine(
+    message: PromptJsonAssistantMessage | PromptJsonToolMessage | PromptJsonRetryMetaMessage,
+  ): void {
     this.stdout.write(`${JSON.stringify(message)}\n`);
   }
 }

--- a/apps/kimi-code/test/cli/run-prompt.test.ts
+++ b/apps/kimi-code/test/cli/run-prompt.test.ts
@@ -666,6 +666,59 @@ describe('runPrompt', () => {
     );
   });
 
+  it('emits a stream-json meta line on retry and discards the failed attempt output', async () => {
+    mocks.session.prompt.mockImplementationOnce(async () => {
+      for (const handler of mocks.eventHandlers) {
+        handler(mocks.mainEvent({ type: 'turn.started', turnId: 10, origin: { kind: 'user' } }));
+        handler(mocks.mainEvent({ type: 'assistant.delta', turnId: 10, delta: 'partial attempt' }));
+        handler(
+          mocks.mainEvent({
+            type: 'turn.step.retrying',
+            turnId: 10,
+            step: 1,
+            stepId: 'step-uuid',
+            failedAttempt: 1,
+            nextAttempt: 2,
+            maxAttempts: 3,
+            delayMs: 300,
+            errorName: 'APIProviderRateLimitError',
+            errorMessage: 'llmproxy/openai/responses/resp_abc.json status_code=429',
+            statusCode: 429,
+          }),
+        );
+        handler(mocks.mainEvent({ type: 'assistant.delta', turnId: 10, delta: 'final answer' }));
+        handler(mocks.mainEvent({ type: 'turn.ended', turnId: 10, reason: 'completed' }));
+      }
+    });
+    const stdout = writer();
+    const stderr = writer();
+
+    await runPrompt(opts({ outputFormat: 'stream-json' }), '1.2.3-test', { stdout, stderr });
+
+    const retryMeta = JSON.stringify({
+      role: 'meta',
+      type: 'turn.step.retrying',
+      failed_attempt: 1,
+      next_attempt: 2,
+      max_attempts: 3,
+      delay_ms: 300,
+      error_name: 'APIProviderRateLimitError',
+      error_message: 'llmproxy/openai/responses/resp_abc.json status_code=429',
+      status_code: 429,
+    });
+    expect(stdout.text()).toBe(
+      [
+        retryMeta,
+        '{"role":"assistant","content":"final answer"}',
+        '{"role":"meta","type":"session.resume_hint","session_id":"ses_prompt","command":"kimi -r ses_prompt","content":"To resume this session: kimi -r ses_prompt"}',
+        '',
+      ].join('\n'),
+    );
+    // The failed attempt's partial text must not leak as an assistant line.
+    expect(stdout.text()).not.toContain('partial attempt');
+    expect(stderr.text()).toBe('');
+  });
+
   it('flushes stream-json assistant output before waiting for background tasks', async () => {
     let releaseWait: () => void = () => {};
     const waitGate = new Promise<void>((resolve) => {

--- a/packages/agent-core/src/loop/retry.ts
+++ b/packages/agent-core/src/loop/retry.ts
@@ -10,15 +10,14 @@ import type { LLM, LLMChatParams, LLMChatResponse } from './llm';
 export const DEFAULT_MAX_RETRY_ATTEMPTS = 3;
 
 const BASE_DELAY_MS = 500;
-// Per-attempt backoff cap, mirroring claude-code's `getRetryDelay`
-// (maxDelayMs = 32000). With the default 3 attempts the ramp (0.5s, 1s) never
-// reaches the cap, so interactive runs are unaffected; it only matters for
-// high-attempt configs (e.g. eval harnesses with `max_retries_per_step = 10`),
-// where it lets retries ride out multi-minute provider overload instead of
-// giving up after a few seconds of backoff.
+// Per-attempt backoff cap (32s). With the default 3 attempts the ramp
+// (0.5s, 1s) never reaches the cap, so interactive runs are unaffected; it
+// only matters for high-attempt configs (e.g. eval harnesses with
+// `max_retries_per_step = 10`), where it lets retries ride out multi-minute
+// provider overload instead of giving up after a few seconds of backoff.
 const MAX_DELAY_MS = 32_000;
 const RETRY_FACTOR = 2;
-// Claude-code adds up to 25% jitter on top of the exponential base.
+// Up to 25% jitter on top of the exponential base to avoid herd retries.
 const JITTER_FACTOR = 0.25;
 
 export interface ChatWithRetryInput {
@@ -57,8 +56,8 @@ export async function chatWithRetry(input: ChatWithRetryInput): Promise<LLMChatR
       }
 
       // A server `Retry-After` (carried on the error) overrides the computed
-      // backoff, mirroring claude-code. The chosen delay is what gets reported
-      // on the `step.retrying` event via `delayMs` either way.
+      // backoff. The chosen delay is what gets reported on the
+      // `step.retrying` event via `delayMs` either way.
       const delayMs = readRetryAfterMs(error) ?? delays[attempt - 1] ?? 0;
       input.params.signal.throwIfAborted();
       input.dispatchEvent({
@@ -114,9 +113,8 @@ function paramsForAttempt(
 }
 
 export function retryBackoffDelays(maxAttempts: number): number[] {
-  // Mirrors claude-code's getRetryDelay: for attempt (1-based) the base delay
-  // is min(500ms * 2^(attempt-1), 32s), plus up to 25% jitter. Index i here is
-  // 0-based, so attempt = i + 1.
+  // For attempt (1-based) the base delay is min(500ms * 2^(attempt-1), 32s),
+  // plus up to 25% jitter. Index i here is 0-based, so attempt = i + 1.
   const count = Math.max(maxAttempts - 1, 0);
   const delays: number[] = [];
   for (let i = 0; i < count; i += 1) {
@@ -129,8 +127,8 @@ export function retryBackoffDelays(maxAttempts: number): number[] {
 /**
  * Server-requested backoff carried on a kosong `APIStatusError` (parsed from
  * the `retry-after` response header). When present and positive it overrides
- * the computed backoff — matching claude-code, where a server `Retry-After`
- * directive takes precedence over the local exponential delay.
+ * the computed backoff — a server `Retry-After` directive takes precedence
+ * over the local exponential delay.
  */
 function readRetryAfterMs(error: unknown): number | null {
   if (typeof error !== 'object' || error === null) return null;

--- a/packages/agent-core/src/loop/retry.ts
+++ b/packages/agent-core/src/loop/retry.ts
@@ -1,5 +1,4 @@
 import { sleep } from '@antfu/utils';
-import * as retry from 'retry';
 
 import type { Logger } from '#/logging/types';
 
@@ -10,9 +9,17 @@ import type { LLM, LLMChatParams, LLMChatResponse } from './llm';
 
 export const DEFAULT_MAX_RETRY_ATTEMPTS = 3;
 
-const RETRY_MIN_TIMEOUT_MS = 300;
-const RETRY_MAX_TIMEOUT_MS = 5000;
+const BASE_DELAY_MS = 500;
+// Per-attempt backoff cap, mirroring claude-code's `getRetryDelay`
+// (maxDelayMs = 32000). With the default 3 attempts the ramp (0.5s, 1s) never
+// reaches the cap, so interactive runs are unaffected; it only matters for
+// high-attempt configs (e.g. eval harnesses with `max_retries_per_step = 10`),
+// where it lets retries ride out multi-minute provider overload instead of
+// giving up after a few seconds of backoff.
+const MAX_DELAY_MS = 32_000;
 const RETRY_FACTOR = 2;
+// Claude-code adds up to 25% jitter on top of the exponential base.
+const JITTER_FACTOR = 0.25;
 
 export interface ChatWithRetryInput {
   readonly llm: LLM;
@@ -49,7 +56,10 @@ export async function chatWithRetry(input: ChatWithRetryInput): Promise<LLMChatR
         throw error;
       }
 
-      const delayMs = delays[attempt - 1] ?? 0;
+      // A server `Retry-After` (carried on the error) overrides the computed
+      // backoff, mirroring claude-code. The chosen delay is what gets reported
+      // on the `step.retrying` event via `delayMs` either way.
+      const delayMs = readRetryAfterMs(error) ?? delays[attempt - 1] ?? 0;
       input.params.signal.throwIfAborted();
       input.dispatchEvent({
         type: 'step.retrying',
@@ -104,13 +114,28 @@ function paramsForAttempt(
 }
 
 export function retryBackoffDelays(maxAttempts: number): number[] {
-  return retry.timeouts({
-    retries: Math.max(maxAttempts - 1, 0),
-    minTimeout: RETRY_MIN_TIMEOUT_MS,
-    maxTimeout: RETRY_MAX_TIMEOUT_MS,
-    factor: RETRY_FACTOR,
-    randomize: true,
-  });
+  // Mirrors claude-code's getRetryDelay: for attempt (1-based) the base delay
+  // is min(500ms * 2^(attempt-1), 32s), plus up to 25% jitter. Index i here is
+  // 0-based, so attempt = i + 1.
+  const count = Math.max(maxAttempts - 1, 0);
+  const delays: number[] = [];
+  for (let i = 0; i < count; i += 1) {
+    const base = Math.min(BASE_DELAY_MS * Math.pow(RETRY_FACTOR, i), MAX_DELAY_MS);
+    delays.push(base + Math.random() * JITTER_FACTOR * base);
+  }
+  return delays;
+}
+
+/**
+ * Server-requested backoff carried on a kosong `APIStatusError` (parsed from
+ * the `retry-after` response header). When present and positive it overrides
+ * the computed backoff — matching claude-code, where a server `Retry-After`
+ * directive takes precedence over the local exponential delay.
+ */
+function readRetryAfterMs(error: unknown): number | null {
+  if (typeof error !== 'object' || error === null) return null;
+  const value = (error as { retryAfterMs?: unknown }).retryAfterMs;
+  return typeof value === 'number' && value > 0 ? value : null;
 }
 
 export async function sleepForRetry(delayMs: number, signal: AbortSignal): Promise<void> {

--- a/packages/agent-core/test/loop/retry.test.ts
+++ b/packages/agent-core/test/loop/retry.test.ts
@@ -143,7 +143,7 @@ describe('chatWithRetry: terminated stream drops', () => {
 });
 
 describe('retryBackoffDelays', () => {
-  it('matches claude-code: base 500ms, factor 2, cap 32s, up to +25% jitter', () => {
+  it('uses a 500ms base, factor-2 ramp, 32s cap, and up to +25% jitter', () => {
     const delays = retryBackoffDelays(10);
     expect(delays).toHaveLength(9);
     // Max possible delay is the capped base (32s) plus 25% jitter = 40s.

--- a/packages/agent-core/test/loop/retry.test.ts
+++ b/packages/agent-core/test/loop/retry.test.ts
@@ -1,10 +1,15 @@
-import { APIConnectionError, emptyUsage, isRetryableGenerateError } from '@moonshot-ai/kosong';
+import {
+  APIConnectionError,
+  APIProviderRateLimitError,
+  emptyUsage,
+  isRetryableGenerateError,
+} from '@moonshot-ai/kosong';
 import { describe, expect, it } from 'vitest';
 
 import type { KimiConfig } from '#/config';
 import { ErrorCodes, KimiError } from '#/errors';
 import type { LLM, LLMChatParams, LLMChatResponse } from '#/loop/llm';
-import { chatWithRetry } from '#/loop/retry';
+import { chatWithRetry, retryBackoffDelays } from '#/loop/retry';
 import { ProviderManager } from '#/session/provider-manager';
 
 function okResponse(): LLMChatResponse {
@@ -134,6 +139,74 @@ describe('chatWithRetry: terminated stream drops', () => {
     });
     expect(chatCalls).toBe(1);
     expect(tokenCalls).toBe(1);
+  });
+});
+
+describe('retryBackoffDelays', () => {
+  it('matches claude-code: base 500ms, factor 2, cap 32s, up to +25% jitter', () => {
+    const delays = retryBackoffDelays(10);
+    expect(delays).toHaveLength(9);
+    // Max possible delay is the capped base (32s) plus 25% jitter = 40s.
+    for (const d of delays) {
+      expect(d).toBeGreaterThan(0);
+      expect(d).toBeLessThanOrEqual(40_000);
+    }
+    // First attempt base is 500ms (plus up to 25% jitter) -> within [500, 625].
+    expect(delays[0]).toBeGreaterThanOrEqual(500);
+    expect(delays[0]).toBeLessThanOrEqual(625);
+  });
+
+  it('reaches the 32s cap for high-attempt configs (overload ride-out)', () => {
+    // The ramp hits 32s by attempt 7 (500 * 2^6); across many draws the peak
+    // approaches the cap (32s..40s with jitter), well above the old 5s cap.
+    let maxSeen = 0;
+    for (let i = 0; i < 50; i += 1) {
+      for (const d of retryBackoffDelays(12)) {
+        maxSeen = Math.max(maxSeen, d);
+      }
+    }
+    expect(maxSeen).toBeGreaterThan(30_000);
+  });
+
+  it('keeps default-attempt retries quick so interactive runs are not slowed', () => {
+    // 3 attempts -> 2 delays at the bottom of the ramp (~0.5s / ~1s before
+    // jitter); their sum stays small.
+    const delays = retryBackoffDelays(3);
+    expect(delays).toHaveLength(2);
+    expect(delays.reduce((a, b) => a + b, 0)).toBeLessThan(3_000);
+  });
+});
+
+describe('chatWithRetry: honors server retry-after', () => {
+  it('uses the error retryAfterMs as the retry delay instead of the backoff', async () => {
+    let calls = 0;
+    const captured: Array<{ type: string; delayMs?: number }> = [];
+    const llm: LLM = {
+      systemPrompt: '',
+      modelName: 'mock',
+      isRetryableError: (e) => isRetryableGenerateError(e),
+      async chat(): Promise<LLMChatResponse> {
+        calls += 1;
+        if (calls === 1) {
+          // 429 carrying a server `retry-after` of 42ms. Kept tiny so the test
+          // sleeps only briefly, while still being distinguishable from the
+          // attempt-1 backoff (500..625ms) it must override.
+          throw new APIProviderRateLimitError('rate limited', null, 42);
+        }
+        return okResponse();
+      },
+    };
+    const input = makeInput(llm, new AbortController().signal);
+    await chatWithRetry({
+      ...input,
+      dispatchEvent: async (event) => {
+        captured.push(event as { type: string; delayMs?: number });
+      },
+    });
+
+    expect(calls).toBe(2);
+    const retrying = captured.find((e) => e.type === 'step.retrying');
+    expect(retrying?.delayMs).toBe(42);
   });
 });
 

--- a/packages/kosong/src/errors.ts
+++ b/packages/kosong/src/errors.ts
@@ -39,8 +39,8 @@ export class APIStatusError extends ChatProviderError {
   /**
    * Server-requested backoff from the `retry-after` response header, in
    * milliseconds. When present, the retry loop honors it instead of its own
-   * computed backoff — mirroring claude-code, where a server `Retry-After`
-   * directive overrides the local exponential delay.
+   * computed backoff — a server `Retry-After` directive overrides the local
+   * exponential delay.
    */
   readonly retryAfterMs: number | null;
 
@@ -132,7 +132,7 @@ export function isRetryableGenerateError(error: unknown): boolean {
     return true;
   }
   if (error instanceof APIStatusError) {
-    // Mirrors claude-code's retryable statuses: 408 (request timeout), 409
+    // Transient statuses worth retrying: 408 (request timeout), 409
     // (lock/conflict timeout), 429 (rate limit), 5xx (server errors) and 529
     // (provider overloaded — the "engine is currently overloaded" case).
     return [408, 409, 429, 500, 502, 503, 504, 529].includes(error.statusCode);
@@ -245,11 +245,11 @@ export function normalizeAPIStatusError(
 }
 
 /**
- * Parse a `retry-after` response header into milliseconds. Mirrors
- * claude-code: only integer seconds is honored; an HTTP-date (or any
- * non-integer / missing value) returns null and the caller falls back to its
- * computed backoff. Shared by the provider error converters so every backend
- * honors the same server backoff directive.
+ * Parse a `retry-after` response header into milliseconds. Only integer
+ * seconds is honored; an HTTP-date (or any non-integer / missing value)
+ * returns null and the caller falls back to its computed backoff. Shared by
+ * the provider error converters so every backend honors the same server
+ * backoff directive.
  */
 export function parseRetryAfterMs(headers: unknown): number | null {
   const raw =

--- a/packages/kosong/src/errors.ts
+++ b/packages/kosong/src/errors.ts
@@ -36,12 +36,25 @@ export class APITimeoutError extends ChatProviderError {
 export class APIStatusError extends ChatProviderError {
   readonly statusCode: number;
   readonly requestId: string | null;
+  /**
+   * Server-requested backoff from the `retry-after` response header, in
+   * milliseconds. When present, the retry loop honors it instead of its own
+   * computed backoff — mirroring claude-code, where a server `Retry-After`
+   * directive overrides the local exponential delay.
+   */
+  readonly retryAfterMs: number | null;
 
-  constructor(statusCode: number, message: string, requestId?: string | null) {
+  constructor(
+    statusCode: number,
+    message: string,
+    requestId?: string | null,
+    retryAfterMs?: number | null,
+  ) {
     super(message);
     this.name = 'APIStatusError';
     this.statusCode = statusCode;
     this.requestId = requestId ?? null;
+    this.retryAfterMs = retryAfterMs ?? null;
   }
 }
 
@@ -50,8 +63,13 @@ export class APIStatusError extends ChatProviderError {
  * context window.
  */
 export class APIContextOverflowError extends APIStatusError {
-  constructor(statusCode: number, message: string, requestId?: string | null) {
-    super(statusCode, message, requestId);
+  constructor(
+    statusCode: number,
+    message: string,
+    requestId?: string | null,
+    retryAfterMs?: number | null,
+  ) {
+    super(statusCode, message, requestId, retryAfterMs);
     this.name = 'APIContextOverflowError';
   }
 }
@@ -63,8 +81,13 @@ export class APIContextOverflowError extends APIStatusError {
  * size rejection is not — it needs media to be dropped or shrunk.
  */
 export class APIRequestTooLargeError extends APIStatusError {
-  constructor(statusCode: number, message: string, requestId?: string | null) {
-    super(statusCode, message, requestId);
+  constructor(
+    statusCode: number,
+    message: string,
+    requestId?: string | null,
+    retryAfterMs?: number | null,
+  ) {
+    super(statusCode, message, requestId, retryAfterMs);
     this.name = 'APIRequestTooLargeError';
   }
 }
@@ -74,8 +97,8 @@ export class APIRequestTooLargeError extends APIStatusError {
  * request.
  */
 export class APIProviderRateLimitError extends APIStatusError {
-  constructor(message: string, requestId?: string | null) {
-    super(429, message, requestId);
+  constructor(message: string, requestId?: string | null, retryAfterMs?: number | null) {
+    super(429, message, requestId, retryAfterMs);
     this.name = 'APIProviderRateLimitError';
   }
 }
@@ -108,7 +131,22 @@ export function isRetryableGenerateError(error: unknown): boolean {
   if (error instanceof APIEmptyResponseError) {
     return true;
   }
-  return error instanceof APIStatusError && [429, 500, 502, 503, 504].includes(error.statusCode);
+  if (error instanceof APIStatusError) {
+    // Mirrors claude-code's retryable statuses: 408 (request timeout), 409
+    // (lock/conflict timeout), 429 (rate limit), 5xx (server errors) and 529
+    // (provider overloaded — the "engine is currently overloaded" case).
+    return [408, 409, 429, 500, 502, 503, 504, 529].includes(error.statusCode);
+  }
+  // Fallback safety net: an unclassified provider failure — typically an
+  // upstream gateway that forwards the original error only as text, with no
+  // usable HTTP status (e.g. llmproxy embedding `status_code=429` in the
+  // message) — lands here as a base `ChatProviderError`. Retrying beats
+  // failing the run on the first transient blip. Typed `APIStatusError`
+  // instances are deliberately excluded above: deterministic 4xx
+  // (400/401/403/404/422) and the recovery-owned context-overflow /
+  // request-too-large subclasses keep their dedicated handling instead of
+  // burning retries first.
+  return error instanceof ChatProviderError;
 }
 
 // `terminated` is the undici signature for an SSE/HTTP body stream that is
@@ -190,19 +228,40 @@ export function normalizeAPIStatusError(
   statusCode: number,
   message: string,
   requestId?: string | null,
+  retryAfterMs?: number | null,
 ): APIStatusError {
   if (statusCode === 429) {
-    return new APIProviderRateLimitError(message, requestId);
+    return new APIProviderRateLimitError(message, requestId, retryAfterMs);
   }
   // Context overflow first: Vertex returns prompt-too-long as a 413, and a
   // token overflow must keep routing to compaction even on that status.
   if (isContextOverflowStatusError(statusCode, message)) {
-    return new APIContextOverflowError(statusCode, message, requestId);
+    return new APIContextOverflowError(statusCode, message, requestId, retryAfterMs);
   }
   if (isRequestTooLargeStatusError(statusCode, message)) {
-    return new APIRequestTooLargeError(statusCode, message, requestId);
+    return new APIRequestTooLargeError(statusCode, message, requestId, retryAfterMs);
   }
-  return new APIStatusError(statusCode, message, requestId);
+  return new APIStatusError(statusCode, message, requestId, retryAfterMs);
+}
+
+/**
+ * Parse a `retry-after` response header into milliseconds. Mirrors
+ * claude-code: only integer seconds is honored; an HTTP-date (or any
+ * non-integer / missing value) returns null and the caller falls back to its
+ * computed backoff. Shared by the provider error converters so every backend
+ * honors the same server backoff directive.
+ */
+export function parseRetryAfterMs(headers: unknown): number | null {
+  const raw =
+    headers !== null &&
+    typeof headers === 'object' &&
+    typeof (headers as { get?: unknown }).get === 'function'
+      ? (headers as { get(name: string): string | null }).get('retry-after')
+      : null;
+  if (raw === null || raw === undefined) return null;
+  const seconds = Number.parseInt(raw, 10);
+  if (!Number.isFinite(seconds) || seconds < 0) return null;
+  return seconds * 1000;
 }
 
 export function isContextOverflowStatusError(statusCode: number, message: string): boolean {

--- a/packages/kosong/src/providers/anthropic.ts
+++ b/packages/kosong/src/providers/anthropic.ts
@@ -4,6 +4,7 @@ import {
   ChatProviderError,
   classifyBaseApiError,
   normalizeAPIStatusError,
+  parseRetryAfterMs,
 } from '#/errors';
 import type { ContentPart, Message, StreamedMessagePart, ToolCall } from '#/message';
 import { isToolDeclarationOnlyMessage } from '#/message';
@@ -693,7 +694,12 @@ export function convertAnthropicError(error: unknown): ChatProviderError {
   // APIError with a status code => status error
   if (error instanceof AnthropicAPIError && typeof error.status === 'number') {
     const reqId = error.requestID ?? null;
-    return normalizeAPIStatusError(error.status, error.message, reqId);
+    return normalizeAPIStatusError(
+      error.status,
+      error.message,
+      reqId,
+      parseRetryAfterMs(error.headers),
+    );
   }
   if (error instanceof AnthropicError) {
     return new ChatProviderError(`Anthropic error: ${error.message}`);

--- a/packages/kosong/src/providers/openai-common.ts
+++ b/packages/kosong/src/providers/openai-common.ts
@@ -4,6 +4,7 @@ import {
   ChatProviderError,
   classifyBaseApiError,
   normalizeAPIStatusError,
+  parseRetryAfterMs,
 } from '#/errors';
 import { extractText } from '#/message';
 import type { ContentPart, Message } from '#/message';
@@ -103,7 +104,12 @@ export function convertOpenAIError(error: unknown): ChatProviderError {
   // APIError with a status code => status error
   if (error instanceof OpenAIAPIError && typeof error.status === 'number') {
     const reqId = error.requestID ?? null;
-    return normalizeAPIStatusError(error.status, error.message, reqId);
+    return normalizeAPIStatusError(
+      error.status,
+      error.message,
+      reqId,
+      parseRetryAfterMs(error.headers),
+    );
   }
   // Base APIError with no status and no body => transport-layer failure.
   // When the error has a body (e.g. SSE error events from the server),

--- a/packages/kosong/src/providers/openai-responses.ts
+++ b/packages/kosong/src/providers/openai-responses.ts
@@ -235,6 +235,13 @@ function formatResponsesErrorEvent(
   return `${codeText}: ${message}${paramText}`;
 }
 
+const EMBEDDED_STATUS_CODE_RE = /\bstatus_code\s*[:=]\s*(\d{3})\b/;
+
+function readEmbeddedStatusCode(message: string): number | undefined {
+  const match = EMBEDDED_STATUS_CODE_RE.exec(message);
+  return match === null ? undefined : Number(match[1]);
+}
+
 function errorFromOpenAIResponsesEvent(
   prefix: string,
   code: string | null,
@@ -246,7 +253,7 @@ function errorFromOpenAIResponsesEvent(
   if (isContextOverflowErrorCode(code)) {
     return new APIContextOverflowError(400, fullMessage);
   }
-  if (code === 'rate_limit_exceeded') {
+  if (code === 'rate_limit_exceeded' || readEmbeddedStatusCode(message) === 429) {
     return new APIProviderRateLimitError(fullMessage);
   }
   return new ChatProviderError(fullMessage);

--- a/packages/kosong/test/anthropic-errors.test.ts
+++ b/packages/kosong/test/anthropic-errors.test.ts
@@ -86,6 +86,30 @@ describe('convertAnthropicError', () => {
     expect((result as APIProviderRateLimitError).statusCode).toBe(429);
   });
 
+  it('reads an integer retry-after header (seconds) onto the rate-limit error', () => {
+    const err = AnthropicAPIError.generate(
+      429,
+      { type: 'error', error: { type: 'rate_limit_error', message: 'rate limited' } },
+      'rate limited',
+      new Headers({ 'retry-after': '7' }),
+    );
+    const result = convertAnthropicError(err);
+    expect(result).toBeInstanceOf(APIProviderRateLimitError);
+    expect((result as APIProviderRateLimitError).retryAfterMs).toBe(7_000);
+  });
+
+  it('ignores a non-integer (HTTP-date) retry-after header, leaving retryAfterMs null', () => {
+    const err = AnthropicAPIError.generate(
+      429,
+      { type: 'error', error: { type: 'rate_limit_error', message: 'rate limited' } },
+      'rate limited',
+      new Headers({ 'retry-after': 'Wed, 21 Oct 2026 07:28:00 GMT' }),
+    );
+    const result = convertAnthropicError(err);
+    expect(result).toBeInstanceOf(APIProviderRateLimitError);
+    expect((result as APIProviderRateLimitError).retryAfterMs).toBeNull();
+  });
+
   it('generic AnthropicError -> ChatProviderError', () => {
     const err = new AnthropicError('something went wrong');
     const result = convertAnthropicError(err);
@@ -120,11 +144,17 @@ describe('convertAnthropicError', () => {
     expect(isRetryableGenerateError(result)).toBe(true);
   });
 
-  it('still wraps an unrelated raw Error as a non-retryable ChatProviderError', () => {
+  it('still wraps an unrelated raw Error as a base ChatProviderError, now retryable via fallback', () => {
+    // An unrelated raw Error is NOT an Anthropic SDK error and carries no
+    // usable HTTP status, so convertAnthropicError wraps it as a base
+    // ChatProviderError (constructor check guards that typing). The fallback
+    // safety net in isRetryableGenerateError then treats such unclassified
+    // provider failures as transient — retry beats failing the run on the
+    // first blip.
     const result = convertAnthropicError(new Error('something completely unrelated'));
 
     expect(result.constructor).toBe(ChatProviderError);
-    expect(isRetryableGenerateError(result)).toBe(false);
+    expect(isRetryableGenerateError(result)).toBe(true);
   });
 });
 describe('non-stream error propagation', () => {

--- a/packages/kosong/test/errors.test.ts
+++ b/packages/kosong/test/errors.test.ts
@@ -137,12 +137,27 @@ describe('isRetryableGenerateError', () => {
     expect(isRetryableGenerateError(new APIEmptyResponseError('empty'))).toBe(true);
   });
 
-  it.each([429, 500, 502, 503, 504])('treats HTTP %i as retryable', (statusCode) => {
+  it.each([408, 409, 429, 500, 502, 503, 504, 529])('treats HTTP %i as retryable', (statusCode) => {
     expect(isRetryableGenerateError(new APIStatusError(statusCode, 'retryable'))).toBe(true);
   });
 
   it.each([400, 401, 403, 404, 422])('treats HTTP %i as non-retryable', (statusCode) => {
     expect(isRetryableGenerateError(new APIStatusError(statusCode, 'non-retryable'))).toBe(false);
+  });
+
+  it('propagates retryAfterMs through normalizeAPIStatusError onto the typed error', () => {
+    const rateLimited = normalizeAPIStatusError(429, 'rate limited', 'req-1', 12_500);
+    expect(rateLimited).toBeInstanceOf(APIProviderRateLimitError);
+    expect(rateLimited.retryAfterMs).toBe(12_500);
+
+    const generic = normalizeAPIStatusError(503, 'bad gateway', null, 3_000);
+    expect(generic).toBeInstanceOf(APIStatusError);
+    expect(generic.retryAfterMs).toBe(3_000);
+  });
+
+  it('defaults retryAfterMs to null when no retry-after header is present', () => {
+    expect(new APIStatusError(429, 'x').retryAfterMs).toBeNull();
+    expect(normalizeAPIStatusError(429, 'x').retryAfterMs).toBeNull();
   });
 
   it('does not retry context overflow or unknown errors', () => {
@@ -151,6 +166,17 @@ describe('isRetryableGenerateError', () => {
     ).toBe(false);
     expect(isRetryableGenerateError(new Error('boom'))).toBe(false);
     expect(isRetryableGenerateError('boom')).toBe(false);
+  });
+
+  it('retries an unclassified base ChatProviderError as a transient fallback', () => {
+    // An upstream gateway that forwards the original failure only as text (no
+    // usable HTTP status) surfaces as a base ChatProviderError. It must be
+    // retried rather than failing the run on the first blip — while typed
+    // 4xx / context-overflow / request-too-large (all APIStatusError) stay
+    // non-retryable on their dedicated recovery paths.
+    expect(isRetryableGenerateError(new ChatProviderError('unclassified upstream failure'))).toBe(
+      true,
+    );
   });
 });
 

--- a/packages/kosong/test/openai-common-errors.test.ts
+++ b/packages/kosong/test/openai-common-errors.test.ts
@@ -118,6 +118,30 @@ describe('convertOpenAIError: provider rate limit', () => {
     expect(result).toBeInstanceOf(APIProviderRateLimitError);
     expect((result as APIProviderRateLimitError).statusCode).toBe(429);
   });
+
+  it('reads an integer retry-after header (seconds) onto the rate-limit error', () => {
+    const err = new OpenAIAPIError(
+      429,
+      undefined,
+      'Too many requests',
+      new Headers({ 'retry-after': '12' }),
+    );
+    const result = convertOpenAIError(err);
+    expect(result).toBeInstanceOf(APIProviderRateLimitError);
+    expect((result as APIProviderRateLimitError).retryAfterMs).toBe(12_000);
+  });
+
+  it('ignores a non-integer (HTTP-date) retry-after header, leaving retryAfterMs null', () => {
+    const err = new OpenAIAPIError(
+      429,
+      undefined,
+      'Too many requests',
+      new Headers({ 'retry-after': 'Wed, 21 Oct 2026 07:28:00 GMT' }),
+    );
+    const result = convertOpenAIError(err);
+    expect(result).toBeInstanceOf(APIProviderRateLimitError);
+    expect((result as APIProviderRateLimitError).retryAfterMs).toBeNull();
+  });
 });
 describe('convertOpenAIError: subclass errors still match first', () => {
   it('APIConnectionError matches its own case', () => {
@@ -211,11 +235,16 @@ describe('convertOpenAIError: raw transport-layer stream errors', () => {
     expect(isRetryableGenerateError(result)).toBe(true);
   });
 
-  it('still wraps an unrelated raw Error as a non-retryable ChatProviderError', () => {
+  it('still wraps an unrelated raw Error as a base ChatProviderError, now retryable via fallback', () => {
+    // An unrelated raw Error is NOT an OpenAI SDK error and carries no usable
+    // HTTP status, so convertOpenAIError wraps it as a base ChatProviderError
+    // (constructor check guards that typing). The fallback safety net in
+    // isRetryableGenerateError then treats such unclassified provider failures
+    // as transient — retry beats failing the run on the first blip.
     const result = convertOpenAIError(new Error('something completely unrelated'));
 
     expect(result.constructor).toBe(ChatProviderError);
-    expect(isRetryableGenerateError(result)).toBe(false);
+    expect(isRetryableGenerateError(result)).toBe(true);
   });
 });
 describe('OpenAI streaming: undici terminated mid-stream', () => {

--- a/packages/kosong/test/openai-responses.test.ts
+++ b/packages/kosong/test/openai-responses.test.ts
@@ -1911,6 +1911,33 @@ describe('OpenAIResponsesChatProvider', () => {
       expect((caughtError as Error).message).not.toContain('stream event.type must be a string');
     });
 
+    it('promotes an embedded upstream status_code=429 to a retryable rate limit', async () => {
+      // llmproxy forwards the original provider 429 as text inside the message
+      // (`.../responses/<id>.json status_code=429`) while the Responses API
+      // `code` is not `rate_limit_exceeded`. It must still surface as an
+      // APIProviderRateLimitError so chatWithRetry recovers it.
+      const events = [
+        {
+          type: 'error',
+          code: 'upstream_error',
+          message: 'llmproxy/openai/responses/resp_abc.json status_code=429',
+          param: null,
+        },
+      ];
+      const stream = new OpenAIResponsesStreamedMessage(makeAsyncIterable(events), true);
+
+      let caughtError: unknown;
+      try {
+        await collectStreamParts(stream);
+      } catch (error) {
+        caughtError = error;
+      }
+
+      expect(caughtError).toBeInstanceOf(APIProviderRateLimitError);
+      expect((caughtError as APIProviderRateLimitError).statusCode).toBe(429);
+      expect((caughtError as Error).message).toContain('status_code=429');
+    });
+
     it('rejects malformed stream events with a non-string type even when message is present', async () => {
       const events = [
         {


### PR DESCRIPTION
## Related Issue

No linked issue — see Problem.

## Problem

In long-running eval runs, a kimi-code run could die mid-rollout when the provider returned a 429 / overload / stream interruption, surfacing as an unfinished turn ("API error occurred at step N") and triggering far more container-level retries than a peer harness against the same model and backend. The OpenAI path (a) did not retry several transient errors, (b) used a small backoff budget that gave up long before an overloaded engine recovered, and (c) ignored the server `Retry-After`, whereas that peer harness absorbs these in place.

## What changed

- Retry more transient errors: 408/409/429/5xx/529 are now retried; an embedded upstream `status_code=429` in OpenAI Responses stream error text is treated as a rate limit; and any unclassified provider error is retried as a last-resort fallback instead of failing the run on the first error.
- Honor `Retry-After` and align the backoff with the reference CLI: the OpenAI and Anthropic providers parse the response `Retry-After` header into the error and the retry loop prefers it over its own delay; the app backoff is now 500ms base / 32s cap / factor 2 / up to 25% jitter, so high-attempt configs ride out multi-minute overload.
- Surface retries in stream-json: `-p --output-format stream-json` now emits a `turn.step.retrying` meta line so consumers can observe retries.

Request timeout is unchanged (the OpenAI SDK default of 600s already matches the reference CLI's default). Deterministic 4xx (auth, not-found, bad-request) are intentionally still not retried.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [ ] Ran `gen-docs` skill, or this PR needs no doc update.
