### PR TITLE
fix(agent-core-v2): preserve turn result details

### DIFF
--- a/packages/agent-core-v2/src/agent/contextMemory/loopEventFold.ts
+++ b/packages/agent-core-v2/src/agent/contextMemory/loopEventFold.ts
@@ -34,6 +34,7 @@
  * concurrent replays of different agent scopes never share fold state.
  */
 
+import type { FinishReason } from '#/app/llmProtocol/finishReason';
 import { createToolMessage, type ContentPart, type ToolCall } from '#/app/llmProtocol/message';
 import type { TokenUsage } from '#/app/llmProtocol/usage';
 
@@ -63,7 +64,7 @@ export type LoopRecordedEvent =
       readonly llmServerDecodeMs?: number;
       readonly llmClientConsumeMs?: number;
       readonly messageId?: string;
-      readonly providerFinishReason?: string;
+      readonly providerFinishReason?: FinishReason;
       readonly rawFinishReason?: string;
     }
   | {

--- a/packages/agent-core-v2/src/agent/externalHooks/externalHooksService.ts
+++ b/packages/agent-core-v2/src/agent/externalHooks/externalHooksService.ts
@@ -36,7 +36,7 @@ import {
   IAgentPromptService,
   type PromptSubmitContext,
 } from '#/agent/prompt/prompt';
-import type { HookResultEvent, TurnEndReason } from '@moonshot-ai/protocol';
+import type { HookResultEvent, TurnEndedEvent } from '@moonshot-ai/protocol';
 import { IEventBus } from '#/app/event/eventBus';
 import type { ExecutableToolResult } from '#/agent/tool/toolContract';
 import type { ToolDidExecuteContext, ToolWillExecuteContext } from '#/agent/tool/toolHooks';
@@ -308,11 +308,7 @@ export class AgentExternalHooksService extends Disposable implements IAgentExter
     return false;
   }
 
-  private notifyTurnEnded(event: {
-    turnId: number;
-    reason: TurnEndReason;
-    error?: unknown;
-  }): void {
+  private notifyTurnEnded(event: Pick<TurnEndedEvent, 'turnId' | 'reason' | 'error'>): void {
     this.stopHookContinuationUsed = false;
     if (event.reason === 'failed' && event.error !== undefined) {
       this.notifyStopFailure(event.error, new AbortController().signal);

--- a/packages/agent-core-v2/src/agent/goal/goalService.ts
+++ b/packages/agent-core-v2/src/agent/goal/goalService.ts
@@ -21,6 +21,7 @@
 
 import { randomUUID } from 'node:crypto';
 
+import type { TurnEndedEvent } from '@moonshot-ai/protocol';
 import { Disposable } from '#/_base/di/lifecycle';
 import { InstantiationType } from '#/_base/di/extensions';
 import { LifecycleScope, registerScopedService } from '#/_base/di/scope';
@@ -38,7 +39,7 @@ import {
   type BeforeStepContext,
 } from '#/agent/loop/loop';
 import { IAgentSystemReminderService } from '#/agent/systemReminder/systemReminder';
-import { IAgentTurnService, type TurnResult } from '#/agent/turn/turn';
+import { IAgentTurnService } from '#/agent/turn/turn';
 import { IAgentActivityService } from '#/activity/activity';
 import type { ActivityLease } from '#/activity/activity';
 import type { TokenUsage } from '#/app/llmProtocol/usage';
@@ -413,7 +414,7 @@ export class AgentGoalService extends Disposable implements IAgentGoalService {
 
   private async handleTurnEnded(
     turnId: number,
-    result: { reason: TurnResult['reason']; error?: TurnResult['error'] },
+    result: Pick<TurnEndedEvent, 'reason' | 'error'>,
   ): Promise<void> {
     this.goalDrivenTurns.delete(turnId);
     this.countedGoalTurns.delete(turnId);

--- a/packages/agent-core-v2/src/agent/loop/loop.ts
+++ b/packages/agent-core-v2/src/agent/loop/loop.ts
@@ -2,7 +2,6 @@ import { createDecorator } from '#/_base/di/instantiation';
 import type { FinishReason } from '#/app/llmProtocol/finishReason';
 import type { TokenUsage } from '#/app/llmProtocol/usage';
 import type { Hooks } from '#/hooks';
-import type { TurnEndReason } from '@moonshot-ai/protocol';
 
 export interface BeforeStepContext {
   readonly turnId: number;
@@ -36,11 +35,22 @@ export interface LoopRunOptions {
   readonly onStarted?: (step: number) => void;
 }
 
-export interface LoopRunResult {
-  readonly reason: TurnEndReason;
-  readonly error?: unknown;
-  readonly steps?: number;
-}
+export type LoopRunResult =
+  | {
+      readonly type: 'completed';
+      readonly steps: number;
+      readonly truncated: boolean;
+    }
+  | {
+      readonly type: 'failed';
+      readonly steps: number;
+      readonly error: unknown;
+    }
+  | {
+      readonly type: 'cancelled';
+      readonly steps: number;
+      readonly reason: unknown;
+    };
 
 export interface IAgentLoopService {
   readonly _serviceBrand: undefined;

--- a/packages/agent-core-v2/src/agent/loop/loopService.ts
+++ b/packages/agent-core-v2/src/agent/loop/loopService.ts
@@ -111,11 +111,11 @@ export class AgentLoopService implements IAgentLoopService {
           continue;
         }
 
-        return { reason: 'completed', steps };
+        return { type: 'completed', steps, truncated: stepResult.stopReason === 'truncated' };
       } catch (error) {
         if (isAbortError(error) || signal.aborted) {
           this.emitStepInterrupted(turnId, activeStep, 'aborted');
-          return { reason: 'cancelled', steps };
+          return { type: 'cancelled', reason: signal.reason ?? error, steps };
         }
 
         const reason: LoopInterruptReason = isMaxStepsExceededError(error) ? 'max_steps' : 'error';
@@ -125,13 +125,13 @@ export class AgentLoopService implements IAgentLoopService {
         try {
           await this.hooks.onError.run(context);
         } catch (hookError) {
-          return { reason: 'failed', error: hookError, steps };
+          return { type: 'failed', error: hookError, steps };
         }
         if (context.retry) {
           activeStep = undefined;
           continue;
         }
-        return { reason: 'failed', error, steps };
+        return { type: 'failed', error, steps };
       }
     }
   }
@@ -249,17 +249,13 @@ export class AgentLoopService implements IAgentLoopService {
 
     markStepStarted();
     const timing = response.timing;
-    const stepProviderFinishReason =
-      response.providerFinishReason !== undefined &&
-      response.providerFinishReason !== finishReason
-        ? response.providerFinishReason
-        : undefined;
+    const stepFinishReason = normalizeFinishReason(finishReason);
     this.context.appendLoopEvent({
       type: 'step.end',
       uuid: stepUuid,
       turnId: turnIdStr,
       step: currentStep,
-      finishReason: normalizeFinishReason(finishReason),
+      finishReason: stepFinishReason,
       usage,
       llmFirstTokenLatencyMs: timing?.firstTokenLatencyMs,
       llmStreamDurationMs: timing?.streamDurationMs,
@@ -268,14 +264,13 @@ export class AgentLoopService implements IAgentLoopService {
       llmServerDecodeMs: timing?.serverDecodeMs,
       llmClientConsumeMs: timing?.clientConsumeMs,
       messageId: response.providerMessageId,
-      providerFinishReason: stepProviderFinishReason,
-      rawFinishReason:
-        stepProviderFinishReason !== undefined ? response.rawFinishReason : undefined,
+      providerFinishReason,
+      rawFinishReason: response.rawFinishReason,
     });
     if (response.model !== undefined) {
       this.usage.record(response.model, usage, { type: 'turn', turnId, step: currentStep });
     }
-    this.emitStepCompleted(turnId, currentStep, stepUuid, usage, finishReason, response);
+    this.emitStepCompleted(turnId, currentStep, stepUuid, usage, stepFinishReason, response);
 
     const afterStepContext: AfterStepContext = {
       turnId,
@@ -306,11 +301,6 @@ export class AgentLoopService implements IAgentLoopService {
     finishReason: string,
     response: LLMRequestFinish,
   ): void {
-    const providerFinishReason =
-      response.providerFinishReason !== undefined &&
-        response.providerFinishReason !== finishReason
-        ? response.providerFinishReason
-        : undefined;
     this.eventBus.publish({
       type: 'turn.step.completed',
       turnId,
@@ -324,8 +314,8 @@ export class AgentLoopService implements IAgentLoopService {
       llmServerFirstTokenMs: response.timing?.serverFirstTokenMs,
       llmServerDecodeMs: response.timing?.serverDecodeMs,
       llmClientConsumeMs: response.timing?.clientConsumeMs,
-      providerFinishReason,
-      rawFinishReason: providerFinishReason !== undefined ? response.rawFinishReason : undefined,
+      providerFinishReason: response.providerFinishReason,
+      rawFinishReason: response.rawFinishReason,
     });
   }
 
@@ -408,9 +398,10 @@ export class AgentLoopService implements IAgentLoopService {
   }
 }
 
-function normalizeFinishReason(reason: string): string {
+function normalizeFinishReason(reason: FinishReason): string {
   if (reason === 'tool_calls') return 'tool_use';
   if (reason === 'completed') return 'end_turn';
+  if (reason === 'truncated') return 'max_tokens';
   return reason;
 }
 

--- a/packages/agent-core-v2/src/agent/prompt/promptService.ts
+++ b/packages/agent-core-v2/src/agent/prompt/promptService.ts
@@ -174,7 +174,7 @@ export class AgentPromptService implements IAgentPromptService {
       if (this.observedTurn === turn) {
         this.observedTurn = undefined;
       }
-      if (result.reason !== 'completed') {
+      if (result.type !== 'completed') {
         this.discardQueuedSteers();
       }
     });

--- a/packages/agent-core-v2/src/agent/runtime/runtime.ts
+++ b/packages/agent-core-v2/src/agent/runtime/runtime.ts
@@ -11,7 +11,7 @@
  */
 
 import { createDecorator, type ServiceIdentifier } from '#/_base/di/instantiation';
-import type { TurnEndReason } from '@moonshot-ai/protocol';
+import type { TurnEndedEvent } from '@moonshot-ai/protocol';
 
 export type AgentPhase =
   | { readonly kind: 'idle' }
@@ -71,7 +71,7 @@ export type AgentPhase =
   | {
       readonly kind: 'ended';
       readonly turnId: number;
-      readonly reason: TurnEndReason;
+      readonly reason: TurnEndedEvent['reason'];
       readonly durationMs?: number;
       readonly at: number;
     };

--- a/packages/agent-core-v2/src/agent/runtime/runtimeService.ts
+++ b/packages/agent-core-v2/src/agent/runtime/runtimeService.ts
@@ -20,7 +20,7 @@ import { InstantiationType } from '#/_base/di/extensions';
 import { LifecycleScope, registerScopedService } from '#/_base/di/scope';
 import { IEventBus } from '#/app/event/eventBus';
 import type { PermissionApprovalRequestContext } from '#/agent/permissionGate/permissionGateService';
-import type { TurnEndReason } from '@moonshot-ai/protocol';
+import type { TurnEndedEvent } from '@moonshot-ai/protocol';
 import { IAgentWireService } from '#/wire/tokens';
 import type { IWireService } from '#/wire/wireService';
 import type {
@@ -237,7 +237,11 @@ export class AgentRuntimeService extends Disposable implements IAgentRuntimeServ
     this.publishSnapshot();
   }
 
-  private onTurnEnded(turnId: number, reason: TurnEndReason, durationMs: number | undefined): void {
+  private onTurnEnded(
+    turnId: number,
+    reason: TurnEndedEvent['reason'],
+    durationMs: number | undefined,
+  ): void {
     this.setPhase({ kind: 'ended', turnId, reason, durationMs, at: Date.now() });
     this.cursor = { turnId: -1, step: 0, stepId: '' };
     this.priorForApproval = undefined;

--- a/packages/agent-core-v2/src/agent/turn/turn.ts
+++ b/packages/agent-core-v2/src/agent/turn/turn.ts
@@ -1,4 +1,4 @@
-import { createDecorator } from "#/_base/di/instantiation";
+import { createDecorator } from '#/_base/di/instantiation';
 import type { ContentPart } from '#/app/llmProtocol/message';
 import type { PromptOrigin } from '#/agent/contextMemory/types';
 import type { LoopRunResult } from '#/agent/loop/loop';

--- a/packages/agent-core-v2/src/agent/turn/turnService.ts
+++ b/packages/agent-core-v2/src/agent/turn/turnService.ts
@@ -78,7 +78,11 @@ export class AgentTurnService implements IAgentTurnService {
       id: lease.turnId,
       signal: lease.signal,
       ready,
-      result: Promise.resolve({ reason: 'failed' }),
+      result: Promise.resolve({
+        type: 'failed',
+        steps: 0,
+        error: new Error('Turn result was not initialized'),
+      }),
     };
     void ready.catch(() => undefined);
     this.activeTurn = turn;
@@ -121,37 +125,38 @@ export class AgentTurnService implements IAgentTurnService {
       return result;
     } catch (error) {
       if (lease.signal.aborted) {
-        result = { reason: 'cancelled' };
+        result = {
+          type: 'cancelled',
+          steps: 0,
+          reason: lease.signal.reason ?? error,
+        };
         return result;
       }
-      result = { reason: 'failed', error };
+      result = { type: 'failed', error, steps: 0 };
       return result;
     } finally {
-      ready.reject(new Error('Turn ended before first step', { cause: result?.error }));
+      ready.reject(new Error('Turn ended before first step', {
+        cause: result?.type === 'failed' ? result.error : undefined,
+      }));
       if (this.activeTurn === turn) {
         this.activeTurn = undefined;
       }
-      const outcome: 'completed' | 'cancelled' | 'failed' =
-        result?.reason === 'completed'
-          ? 'completed'
-          : result?.reason === 'cancelled'
-            ? 'cancelled'
-            : 'failed';
-      lease.end(outcome, result?.error === undefined ? undefined : { error: result.error });
+      const outcome = result?.type ?? 'failed';
+      lease.end(outcome, result?.type === 'failed' ? { error: result.error } : undefined);
       if (result !== undefined) {
-        const error = result.error !== undefined ? toKimiErrorPayload(result.error) : undefined;
+        const error = result.type === 'failed' ? toKimiErrorPayload(result.error) : undefined;
         this.eventBus.publish({
           type: 'turn.ended',
           turnId: turn.id,
-          reason: result.reason,
+          reason: result.type,
           error,
           durationMs: Date.now() - startedAt,
         });
         if (error !== undefined) {
           this.eventBus.publish({ type: 'error', ...error });
         }
-        if (result.reason !== 'completed') {
-          turnTelemetry.track('turn_interrupted', { at_step: result.steps ?? null });
+        if (result.type !== 'completed') {
+          turnTelemetry.track('turn_interrupted', { at_step: result.steps });
         }
       }
       // `turn.ended` is published to `IEventBus` above; subscribers (swarm /

--- a/packages/agent-core-v2/src/session/agentLifecycle/runAgentTurn.ts
+++ b/packages/agent-core-v2/src/session/agentLifecycle/runAgentTurn.ts
@@ -21,15 +21,13 @@ import { type TokenUsage } from '#/app/llmProtocol/usage';
 
 import { linkAbortSignal, userCancellationReason } from '#/_base/utils/abort';
 import type { IAgentScopeHandle } from '#/_base/di/scope';
-import type { IDisposable } from '#/_base/di/lifecycle';
 import { IAgentContextMemoryService } from '#/agent/contextMemory/contextMemory';
 import type { ContextMessage, PromptOrigin } from '#/agent/contextMemory/types';
 import { ErrorCodes, toKimiErrorPayload, type KimiErrorPayload } from '#/errors';
 import { IAgentPromptService } from '#/agent/prompt/prompt';
-import { IAgentTurnService, type Turn } from '#/agent/turn/turn';
+import { IAgentTurnService, type Turn, type TurnResult } from '#/agent/turn/turn';
 import { IAgentUsageService } from '#/agent/usage/usage';
 import type { AgentProfileSummaryPolicy } from '#/app/agentProfileCatalog/agentProfileCatalog';
-import { IEventBus } from '#/app/event/eventBus';
 
 import type { AgentRunHandle, AgentRunRequest } from './agentLifecycle';
 
@@ -68,37 +66,30 @@ export async function runAgentTurn(
   options: RunAgentTurnOptions,
 ): Promise<AgentRunHandle> {
   options.signal.throwIfAborted();
-  const finishObserver = observeTurnFinishReasons(target);
-  try {
-    const promptService = target.accessor.get(IAgentPromptService);
-    const turn =
-      request.kind === 'prompt'
-        ? await promptService.prompt({
-            role: 'user',
-            content: [{ type: 'text', text: request.prompt }],
-            toolCalls: [],
-            origin: AGENT_RUN_PROMPT_ORIGIN,
-          })
-        : promptService.retry();
-    if (turn === undefined) throw new Error('Agent turn could not be started');
+  const promptService = target.accessor.get(IAgentPromptService);
+  const turn =
+    request.kind === 'prompt'
+      ? await promptService.prompt({
+          role: 'user',
+          content: [{ type: 'text', text: request.prompt }],
+          toolCalls: [],
+          origin: AGENT_RUN_PROMPT_ORIGIN,
+        })
+      : promptService.retry();
+  if (turn === undefined) throw new Error('Agent turn could not be started');
 
-    if (options.onReady !== undefined) {
-      void turn.ready.then(() => options.onReady?.()).catch(() => {});
-    }
-
-    const completion = awaitRun(target, turn, options, finishObserver);
-    return { agentId: target.id, turn, completion };
-  } catch (error) {
-    finishObserver.dispose();
-    throw error;
+  if (options.onReady !== undefined) {
+    void turn.ready.then(() => options.onReady?.()).catch(() => {});
   }
+
+  const completion = awaitRun(target, turn, options);
+  return { agentId: target.id, turn, completion };
 }
 
 async function awaitRun(
   target: IAgentScopeHandle,
   turn: Turn,
   options: RunAgentTurnOptions,
-  finishObserver: TurnFinishObserver,
 ): Promise<{ summary: string; usage?: TokenUsage }> {
   const controller = new AbortController();
   const unlink = linkAbortSignal(options.signal, controller);
@@ -109,7 +100,7 @@ async function awaitRun(
   let turnRef: Turn = turn;
   try {
     const result = await awaitTurn(turnRef, controller, cancelTurn);
-    classifyTurnResult(result, finishObserver.finishReasonFor(turnRef.id));
+    classifyTurnResult(result);
     const summary = await distillSummary(
       target,
       controller,
@@ -117,13 +108,11 @@ async function awaitRun(
       (t) => {
         turnRef = t;
       },
-      finishObserver,
       cancelTurn,
     );
     const usage = target.accessor.get(IAgentUsageService)?.status().total;
     return { summary, usage };
   } finally {
-    finishObserver.dispose();
     unlink();
     if (controller.signal.aborted) {
       cancelTurn(controller.signal.reason);
@@ -135,7 +124,7 @@ async function awaitTurn(
   turn: Turn,
   controller: AbortController,
   cancelTurn: (reason: unknown) => void,
-): Promise<{ reason: string; error?: unknown }> {
+): Promise<TurnResult> {
   const onAbort = (): void => {
     cancelTurn(controller.signal.reason);
   };
@@ -152,7 +141,6 @@ async function distillSummary(
   controller: AbortController,
   policy: AgentProfileSummaryPolicy | undefined,
   setTurn: (turn: Turn) => void,
-  finishObserver: TurnFinishObserver,
   cancelTurn: (reason: unknown) => void,
 ): Promise<string> {
   const memory = target.accessor.get(IAgentContextMemoryService);
@@ -171,8 +159,7 @@ async function distillSummary(
     if (turn === undefined) break;
     setTurn(turn);
     const result = await awaitTurn(turn, controller, cancelTurn);
-    throwIfTruncatedSummary(result, finishObserver.finishReasonFor(turn.id));
-    if (result.reason !== 'completed') break;
+    classifyTurnResult(result);
     const continued = latestAssistantText(memory.get());
     if (continued.trim().length > 0) summary = continued;
     if (summary.trim().length >= policy.minChars) break;
@@ -180,50 +167,25 @@ async function distillSummary(
   return summary;
 }
 
-function classifyTurnResult(
-  result: {
-    reason: string;
-    error?: unknown;
-  },
-  finishReason?: string,
-): void {
-  throwIfTruncatedSummary(result, finishReason);
-  if (result.reason === 'filtered') {
-    throw new Error('Agent turn blocked by provider safety policy');
-  }
-  if (result.reason === 'failed') {
-    const error = result.error;
-    if (isProviderRateLimitError(error)) throw error;
-    const payload = toKimiErrorPayload(error);
-    if (payload.code === ErrorCodes.PROVIDER_RATE_LIMIT) {
-      throw providerRateLimitErrorFromPayload(payload);
+function classifyTurnResult(result: TurnResult): void {
+  switch (result.type) {
+    case 'completed':
+      if (result.truncated) {
+        throw new Error(SUBAGENT_MAX_TOKENS_ERROR);
+      }
+      return;
+    case 'failed': {
+      const error = result.error;
+      if (isProviderRateLimitError(error)) throw error;
+      const payload = toKimiErrorPayload(error);
+      if (payload.code === ErrorCodes.PROVIDER_RATE_LIMIT) {
+        throw providerRateLimitErrorFromPayload(payload);
+      }
+      throw toRunError(error);
     }
-    throw toRunError(error);
+    case 'cancelled':
+      throw toRunError(result.reason ?? userCancellationReason());
   }
-  if (result.reason === 'cancelled') {
-    throw userCancellationReason();
-  }
-}
-
-function throwIfTruncatedSummary(result: { reason: string }, finishReason?: string): void {
-  if (result.reason === 'completed' && finishReason === 'truncated') {
-    throw new Error(SUBAGENT_MAX_TOKENS_ERROR);
-  }
-}
-
-interface TurnFinishObserver extends IDisposable {
-  finishReasonFor(turnId: number): string | undefined;
-}
-
-function observeTurnFinishReasons(target: IAgentScopeHandle): TurnFinishObserver {
-  const byTurnId = new Map<number, string>();
-  const disposable = target.accessor.get(IEventBus).subscribe('turn.step.completed', (event) => {
-    if (event.finishReason !== undefined) byTurnId.set(event.turnId, event.finishReason);
-  });
-  return {
-    dispose: () => disposable.dispose(),
-    finishReasonFor: (turnId) => byTurnId.get(turnId),
-  };
 }
 
 function toRunError(error: unknown): Error {

--- a/packages/agent-core-v2/test/cron/cron.e2e.test.ts
+++ b/packages/agent-core-v2/test/cron/cron.e2e.test.ts
@@ -88,7 +88,7 @@ describe('Cron — session E2E (P1.9)', () => {
           id: 1,
           signal: new AbortController().signal,
           ready: Promise.resolve(),
-          result: Promise.resolve({ reason: 'completed' as const }),
+          result: Promise.resolve({ type: 'completed' as const, steps: 0, truncated: false }),
         }),
       };
     });

--- a/packages/agent-core-v2/test/cron/cron.test.ts
+++ b/packages/agent-core-v2/test/cron/cron.test.ts
@@ -35,7 +35,7 @@ function fakeTurn(): Turn {
     id: 1,
     signal: new AbortController().signal,
     ready: Promise.resolve(),
-    result: Promise.resolve({ reason: 'completed' }),
+    result: Promise.resolve({ type: 'completed', steps: 0, truncated: false }),
   };
 }
 

--- a/packages/agent-core-v2/test/cron/manager.test.ts
+++ b/packages/agent-core-v2/test/cron/manager.test.ts
@@ -56,7 +56,7 @@ function createSteerSpy(
     id: 1,
     signal: new AbortController().signal,
     ready: Promise.resolve(),
-    result: Promise.resolve({ reason: 'completed' as const }),
+    result: Promise.resolve({ type: 'completed' as const, steps: 0, truncated: false }),
   } : args[0];
   const calls: Array<{ content: readonly ContentPart[]; origin: PromptOrigin }> = [];
   vi.spyOn(prompt, 'steer').mockImplementation((message: ContextMessage) => {
@@ -152,7 +152,7 @@ describe('SessionCronService', () => {
         id: 7,
         signal: new AbortController().signal,
         ready: Promise.resolve(),
-        result: Promise.resolve({ reason: 'completed' as const }),
+        result: Promise.resolve({ type: 'completed' as const, steps: 0, truncated: false }),
       });
     });
 
@@ -468,7 +468,7 @@ describe('SessionCronService', () => {
             id: 1,
             signal: new AbortController().signal,
             ready: Promise.resolve(),
-            result: Promise.resolve({ reason: 'completed' as const }),
+            result: Promise.resolve({ type: 'completed' as const, steps: 0, truncated: false }),
           }
           : undefined;
       });

--- a/packages/agent-core-v2/test/cron/manual-tick.test.ts
+++ b/packages/agent-core-v2/test/cron/manual-tick.test.ts
@@ -37,7 +37,7 @@ function spySteer(prompt: IAgentPromptService) {
       id: 1,
       signal: new AbortController().signal,
       ready: Promise.resolve(),
-      result: Promise.resolve({ reason: 'completed' as const }),
+      result: Promise.resolve({ type: 'completed' as const, steps: 0, truncated: false }),
     }),
   }));
 }

--- a/packages/agent-core-v2/test/goal/goal.test.ts
+++ b/packages/agent-core-v2/test/goal/goal.test.ts
@@ -1,11 +1,13 @@
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
+import type { TurnEndedEvent } from '@moonshot-ai/protocol';
+
 import { IAgentContextMemoryService } from '#/agent/contextMemory/contextMemory';
 import { USER_PROMPT_ORIGIN } from '#/agent/contextMemory/types';
 import { IAgentGoalService } from '#/agent/goal/goal';
 import { type AgentGoalService } from '#/agent/goal/goalService';
 import { IAgentLoopService, type AfterStepContext } from '#/agent/loop/loop';
-import { IAgentTurnService, type Turn, type TurnResult } from '#/agent/turn/turn';
+import { IAgentTurnService, type Turn } from '#/agent/turn/turn';
 import type { PersistedWireRecord, WireRecord } from '#/agent/wireRecord/wireRecord';
 import { type DomainEvent, IEventBus } from '#/app/event/eventBus';
 import type { TokenUsage } from '#/app/llmProtocol/usage';
@@ -26,6 +28,10 @@ type GoalServiceTestManager = IAgentGoalService & AgentGoalService;
 type GoalRecord = Extract<PersistedWireRecord, { type: `goal.${string}` }>;
 type AgentEvent = DomainEvent;
 type GoalUpdatedEvent = Extract<AgentEvent, { type: 'goal.updated' }>;
+type TurnEndedInput = {
+  readonly reason: TurnEndedEvent['reason'];
+  readonly error?: unknown;
+};
 
 const zeroUsage: TokenUsage = {
   inputCacheRead: 0,
@@ -52,7 +58,7 @@ function makeTurn(id: number): Turn {
     id,
     signal: new AbortController().signal,
     ready: Promise.resolve(),
-    result: Promise.resolve({ reason: 'completed' }),
+    result: Promise.resolve({ type: 'completed', steps: 0, truncated: false }),
   };
 }
 
@@ -96,7 +102,7 @@ async function runStepUsageHooks(
 function endTurn(
   eventBus: IEventBus,
   turn: Turn,
-  result: TurnResult = { reason: 'completed' },
+  result: TurnEndedInput = { reason: 'completed' },
 ): void {
   const error = result.error !== undefined ? toKimiErrorPayload(result.error) : undefined;
   eventBus.publish({

--- a/packages/agent-core-v2/test/loop/basic.test.ts
+++ b/packages/agent-core-v2/test/loop/basic.test.ts
@@ -6,6 +6,7 @@ import { IAgentProfileService } from '#/index';
 import { IAgentLLMRequesterService, type LLMStreamTiming } from '#/agent/llmRequester/llmRequester';
 import { IAgentContextMemoryService } from '#/agent/contextMemory/contextMemory';
 import { IAgentLoopService } from '#/agent/loop/loop';
+import { IAgentTurnService } from '#/agent/turn/turn';
 import type { ExecutableTool } from '#/agent/tool/toolContract';
 import { IAgentToolRegistryService } from '#/agent/toolRegistry/toolRegistry';
 
@@ -55,10 +56,10 @@ describe('Agent loop', () => {
       [emit] agent.status.updated        { "contextTokens": 11 }
       [wire] context.append_loop_event   { "event": { "type": "content.part", "uuid": "<uuid-2>", "turnId": "0", "step": 1, "stepUuid": "<uuid-1>", "part": { "type": "think", "think": "<think-1>" } }, "time": "<time>" }
       [wire] context.append_loop_event   { "event": { "type": "content.part", "uuid": "<uuid-3>", "turnId": "0", "step": 1, "stepUuid": "<uuid-1>", "part": { "type": "text", "text": "<text-1>" } }, "time": "<time>" }
-      [wire] context.append_loop_event   { "event": { "type": "step.end", "uuid": "<uuid-1>", "turnId": "0", "step": 1, "finishReason": "end_turn", "usage": { "inputOther": 3, "output": 8, "inputCacheRead": 0, "inputCacheCreation": 0 }, "messageId": "mock-1" }, "time": "<time>" }
+      [wire] context.append_loop_event   { "event": { "type": "step.end", "uuid": "<uuid-1>", "turnId": "0", "step": 1, "finishReason": "end_turn", "usage": { "inputOther": 3, "output": 8, "inputCacheRead": 0, "inputCacheCreation": 0 }, "messageId": "mock-1", "providerFinishReason": "completed", "rawFinishReason": "stop" }, "time": "<time>" }
       [wire] usage.record                { "model": "mock-model", "usage": { "inputOther": 3, "output": 8, "inputCacheRead": 0, "inputCacheCreation": 0 }, "usageScope": "turn", "time": "<time>" }
       [emit] agent.status.updated        { "usage": { "byModel": { "mock-model": { "inputOther": 3, "output": 8, "inputCacheRead": 0, "inputCacheCreation": 0 } }, "total": { "inputOther": 3, "output": 8, "inputCacheRead": 0, "inputCacheCreation": 0 }, "currentTurn": { "inputOther": 3, "output": 8, "inputCacheRead": 0, "inputCacheCreation": 0 } } }
-      [emit] turn.step.completed         { "turnId": 0, "step": 1, "stepId": "<uuid-1>", "usage": { "inputOther": 3, "output": 8, "inputCacheRead": 0, "inputCacheCreation": 0 }, "finishReason": "completed" }
+      [emit] turn.step.completed         { "turnId": 0, "step": 1, "stepId": "<uuid-1>", "usage": { "inputOther": 3, "output": 8, "inputCacheRead": 0, "inputCacheCreation": 0 }, "finishReason": "end_turn", "providerFinishReason": "completed", "rawFinishReason": "stop" }
       [emit] turn.ended                  { "turnId": 0, "reason": "completed" }
     `);
     expect(ctx.lastLlmInput()).toMatchInlineSnapshot(`
@@ -88,10 +89,10 @@ describe('Agent loop', () => {
       [emit] assistant.delta             { "turnId": 0, "delta": "blocked" }
       [emit] agent.status.updated        { "contextTokens": 8 }
       [wire] context.append_loop_event   { "event": { "type": "content.part", "uuid": "<uuid-2>", "turnId": "0", "step": 1, "stepUuid": "<uuid-1>", "part": { "type": "text", "text": "blocked" } }, "time": "<time>" }
-      [wire] context.append_loop_event   { "event": { "type": "step.end", "uuid": "<uuid-1>", "turnId": "0", "step": 1, "finishReason": "filtered", "usage": { "inputOther": 3, "output": 5, "inputCacheRead": 0, "inputCacheCreation": 0 }, "messageId": "mock-1" }, "time": "<time>" }
+      [wire] context.append_loop_event   { "event": { "type": "step.end", "uuid": "<uuid-1>", "turnId": "0", "step": 1, "finishReason": "filtered", "usage": { "inputOther": 3, "output": 5, "inputCacheRead": 0, "inputCacheCreation": 0 }, "messageId": "mock-1", "providerFinishReason": "filtered", "rawFinishReason": "filtered" }, "time": "<time>" }
       [wire] usage.record                { "model": "mock-model", "usage": { "inputOther": 3, "output": 5, "inputCacheRead": 0, "inputCacheCreation": 0 }, "usageScope": "turn", "time": "<time>" }
       [emit] agent.status.updated        { "usage": { "byModel": { "mock-model": { "inputOther": 3, "output": 5, "inputCacheRead": 0, "inputCacheCreation": 0 } }, "total": { "inputOther": 3, "output": 5, "inputCacheRead": 0, "inputCacheCreation": 0 }, "currentTurn": { "inputOther": 3, "output": 5, "inputCacheRead": 0, "inputCacheCreation": 0 } } }
-      [emit] turn.step.completed         { "turnId": 0, "step": 1, "stepId": "<uuid-1>", "usage": { "inputOther": 3, "output": 5, "inputCacheRead": 0, "inputCacheCreation": 0 }, "finishReason": "filtered" }
+      [emit] turn.step.completed         { "turnId": 0, "step": 1, "stepId": "<uuid-1>", "usage": { "inputOther": 3, "output": 5, "inputCacheRead": 0, "inputCacheCreation": 0 }, "finishReason": "filtered", "providerFinishReason": "filtered", "rawFinishReason": "filtered" }
       [emit] turn.ended                  { "turnId": 0, "reason": "failed", "error": { "code": "provider.filtered", "message": "Provider safety policy blocked the response.", "name": "ProviderFilteredError", "details": { "finishReason": "filtered" }, "retryable": false } }
     `);
 
@@ -102,6 +103,39 @@ describe('Agent loop', () => {
     expect(stepCompleted?.args).toMatchObject({
       finishReason: 'filtered',
     });
+  });
+
+  it('marks a completed turn as truncated when the provider stops at max tokens', async () => {
+    profile.update({ activeToolNames: [] });
+    ctx.mockNextProviderResponse({
+      parts: [{ type: 'text', text: 'partial answer' }],
+      finishReason: 'truncated',
+      rawFinishReason: 'length',
+    });
+
+    await ctx.rpc.prompt({ input: [{ type: 'text', text: 'Hello' }] });
+    const turn = ctx.get(IAgentTurnService).getActiveTurn();
+    expect(turn).toBeDefined();
+
+    await ctx.untilTurnEnd();
+    await expect(turn!.result).resolves.toEqual({
+      type: 'completed',
+      steps: 1,
+      truncated: true,
+    });
+
+    const stepCompleted = ctx.allEvents.find(
+      (event) => event.type === '[rpc]' && event.event === 'turn.step.completed',
+    );
+    expect(stepCompleted?.args).toMatchObject({
+      finishReason: 'max_tokens',
+      providerFinishReason: 'truncated',
+      rawFinishReason: 'length',
+    });
+    const turnEnded = ctx.allEvents.find(
+      (event) => event.type === '[rpc]' && event.event === 'turn.ended',
+    );
+    expect(turnEnded?.args).toMatchObject({ reason: 'completed' });
   });
 
   it('lets onError recover a non-context loop error by retrying', async () => {
@@ -146,7 +180,7 @@ describe('Agent loop', () => {
 
     const result = await loop.run({ turnId: 0, signal: controller.signal });
 
-    expect(result.reason).toBe('cancelled');
+    expect(result.type).toBe('cancelled');
     expect(called).toBe(false);
   });
 
@@ -158,8 +192,8 @@ describe('Agent loop', () => {
 
     const result = await loop.run({ turnId: 0 });
 
-    expect(result.reason).toBe('failed');
-    if (result.reason === 'failed') {
+    expect(result.type).toBe('failed');
+    if (result.type === 'failed') {
       expect(result.error).toBe(recoveryError);
     }
   });
@@ -227,20 +261,20 @@ describe('Agent loop', () => {
       [wire] context.append_loop_event           { "event": { "type": "tool.call", "uuid": "<uuid-3>", "turnId": "0", "step": 1, "stepUuid": "<uuid-1>", "toolCallId": "call_lookup", "name": "Lookup", "args": { "query": "moon" } }, "time": "<time>" }
       [emit] tool.result                         { "turnId": 0, "toolCallId": "call_lookup", "output": "lookup-result" }
       [wire] context.append_loop_event           { "event": { "type": "tool.result", "parentUuid": "<uuid-3>", "toolCallId": "call_lookup", "result": { "output": "lookup-result" } }, "time": "<time>" }
-      [wire] context.append_loop_event           { "event": { "type": "step.end", "uuid": "<uuid-1>", "turnId": "0", "step": 1, "finishReason": "tool_use", "usage": { "inputOther": 4, "output": 16, "inputCacheRead": 0, "inputCacheCreation": 0 }, "messageId": "mock-1" }, "time": "<time>" }
+      [wire] context.append_loop_event           { "event": { "type": "step.end", "uuid": "<uuid-1>", "turnId": "0", "step": 1, "finishReason": "tool_use", "usage": { "inputOther": 4, "output": 16, "inputCacheRead": 0, "inputCacheCreation": 0 }, "messageId": "mock-1", "providerFinishReason": "tool_calls", "rawFinishReason": "tool_calls" }, "time": "<time>" }
       [wire] usage.record                        { "model": "mock-model", "usage": { "inputOther": 4, "output": 16, "inputCacheRead": 0, "inputCacheCreation": 0 }, "usageScope": "turn", "time": "<time>" }
       [emit] agent.status.updated                { "usage": { "byModel": { "mock-model": { "inputOther": 4, "output": 16, "inputCacheRead": 0, "inputCacheCreation": 0 } }, "total": { "inputOther": 4, "output": 16, "inputCacheRead": 0, "inputCacheCreation": 0 }, "currentTurn": { "inputOther": 4, "output": 16, "inputCacheRead": 0, "inputCacheCreation": 0 } } }
-      [emit] turn.step.completed                 { "turnId": 0, "step": 1, "stepId": "<uuid-1>", "usage": { "inputOther": 4, "output": 16, "inputCacheRead": 0, "inputCacheCreation": 0 }, "finishReason": "tool_calls" }
+      [emit] turn.step.completed                 { "turnId": 0, "step": 1, "stepId": "<uuid-1>", "usage": { "inputOther": 4, "output": 16, "inputCacheRead": 0, "inputCacheCreation": 0 }, "finishReason": "tool_use", "providerFinishReason": "tool_calls", "rawFinishReason": "tool_calls" }
       [emit] turn.step.started                   { "turnId": 0, "step": 2, "stepId": "<uuid-4>" }
       [wire] context.append_loop_event           { "event": { "type": "step.begin", "uuid": "<uuid-4>", "turnId": "0", "step": 2 }, "time": "<time>" }
       [wire] llm.request                         { "kind": "loop", "provider": "kimi", "model": "mock-model", "modelAlias": "mock-model", "thinkingEffort": "off", "maxTokens": 999980, "toolSelect": false, "systemPromptHash": "ec9c34379c88babbc468ef2f3e0e08cd2f422c8c4a910664fb8bb394d703a575", "toolsHash": "3bfeb22e61431247933e79f6ab94e7ca14a127f899bc87e7bbd22594ba9cdb66", "messageCount": 3, "turnStep": "0.2", "time": "<time>" }
       [emit] assistant.delta                     { "turnId": 0, "delta": "The lookup result is lookup-result." }
       [emit] agent.status.updated                { "contextTokens": 37 }
       [wire] context.append_loop_event           { "event": { "type": "content.part", "uuid": "<uuid-5>", "turnId": "0", "step": 2, "stepUuid": "<uuid-4>", "part": { "type": "text", "text": "The lookup result is lookup-result." } }, "time": "<time>" }
-      [wire] context.append_loop_event           { "event": { "type": "step.end", "uuid": "<uuid-4>", "turnId": "0", "step": 2, "finishReason": "end_turn", "usage": { "inputOther": 25, "output": 12, "inputCacheRead": 0, "inputCacheCreation": 0 }, "messageId": "mock-2" }, "time": "<time>" }
+      [wire] context.append_loop_event           { "event": { "type": "step.end", "uuid": "<uuid-4>", "turnId": "0", "step": 2, "finishReason": "end_turn", "usage": { "inputOther": 25, "output": 12, "inputCacheRead": 0, "inputCacheCreation": 0 }, "messageId": "mock-2", "providerFinishReason": "completed", "rawFinishReason": "stop" }, "time": "<time>" }
       [wire] usage.record                        { "model": "mock-model", "usage": { "inputOther": 25, "output": 12, "inputCacheRead": 0, "inputCacheCreation": 0 }, "usageScope": "turn", "time": "<time>" }
       [emit] agent.status.updated                { "usage": { "byModel": { "mock-model": { "inputOther": 29, "output": 28, "inputCacheRead": 0, "inputCacheCreation": 0 } }, "total": { "inputOther": 29, "output": 28, "inputCacheRead": 0, "inputCacheCreation": 0 }, "currentTurn": { "inputOther": 29, "output": 28, "inputCacheRead": 0, "inputCacheCreation": 0 } } }
-      [emit] turn.step.completed                 { "turnId": 0, "step": 2, "stepId": "<uuid-4>", "usage": { "inputOther": 25, "output": 12, "inputCacheRead": 0, "inputCacheCreation": 0 }, "finishReason": "completed" }
+      [emit] turn.step.completed                 { "turnId": 0, "step": 2, "stepId": "<uuid-4>", "usage": { "inputOther": 25, "output": 12, "inputCacheRead": 0, "inputCacheCreation": 0 }, "finishReason": "end_turn", "providerFinishReason": "completed", "rawFinishReason": "stop" }
       [emit] turn.ended                          { "turnId": 0, "reason": "completed" }
     `);
     expect(ctx.lastLlmInput()).toMatchInlineSnapshot(`

--- a/packages/agent-core-v2/test/promptLegacy/promptLegacyService.test.ts
+++ b/packages/agent-core-v2/test/promptLegacy/promptLegacyService.test.ts
@@ -192,7 +192,7 @@ describe('AgentPromptLegacyService', () => {
     const { service, turns, settleActive } = createHarness();
     await service.submit(textBody('first'));
     const second = await service.submit(textBody('second'));
-    settleActive({ reason: 'completed' });
+    settleActive({ type: 'completed', steps: 0, truncated: false });
     await vi.waitFor(() => expect(turns).toHaveLength(2));
     expect(service.list().active?.prompt_id).toBe(second.prompt_id);
   });
@@ -203,7 +203,7 @@ describe('AgentPromptLegacyService', () => {
     const second = await service.submit(textBody('second'));
     const aborted = await service.abort(first.prompt_id);
     expect(aborted.aborted).toBe(true);
-    settleActive({ reason: 'cancelled' });
+    settleActive({ type: 'cancelled', steps: 0, reason: 'Aborted' });
     await vi.waitFor(() => expect(turns).toHaveLength(2));
     expect(service.list().active?.prompt_id).toBe(second.prompt_id);
   });
@@ -246,10 +246,10 @@ describe('AgentPromptLegacyService', () => {
     const { service, settleActive } = createHarness();
     const { submit, completion } = await service.submitAndSettle(textBody('hi'));
     expect(submit.status).toBe('running');
-    settleActive({ reason: 'completed' });
+    settleActive({ type: 'completed', steps: 0, truncated: false });
     await expect(completion).resolves.toMatchObject({
       promptId: submit.prompt_id,
-      result: { reason: 'completed' },
+      result: { type: 'completed' },
     });
   });
 
@@ -260,16 +260,16 @@ describe('AgentPromptLegacyService', () => {
     expect(second.submit.status).toBe('queued');
 
     // Settle the active (first) turn so the queued second prompt launches.
-    settleActive({ reason: 'completed' });
+    settleActive({ type: 'completed', steps: 0, truncated: false });
     await vi.waitFor(() =>
       expect(service.list().active?.prompt_id).toBe(second.submit.prompt_id),
     );
 
     // Settle the now-active second turn; its completion should resolve.
-    settleActive({ reason: 'completed' });
+    settleActive({ type: 'completed', steps: 0, truncated: false });
     await expect(second.completion).resolves.toMatchObject({
       promptId: second.submit.prompt_id,
-      result: { reason: 'completed' },
+      result: { type: 'completed' },
     });
   });
 

--- a/packages/agent-core-v2/test/sessionActivity/sessionActivity.test.ts
+++ b/packages/agent-core-v2/test/sessionActivity/sessionActivity.test.ts
@@ -21,7 +21,7 @@ function makeTurn(id: number): Turn {
     id,
     signal: new AbortController().signal,
     ready: Promise.resolve(),
-    result: Promise.resolve({ reason: 'completed' }),
+    result: Promise.resolve({ type: 'completed', steps: 0, truncated: false }),
   };
 }
 

--- a/packages/agent-core-v2/test/skill/skill.test.ts
+++ b/packages/agent-core-v2/test/skill/skill.test.ts
@@ -50,7 +50,7 @@ function fakeTurn(): Turn {
     id: 1,
     signal: new AbortController().signal,
     ready: Promise.resolve(),
-    result: Promise.resolve({ reason: 'completed' }),
+    result: Promise.resolve({ type: 'completed', steps: 0, truncated: false }),
   };
 }
 

--- a/packages/agent-core-v2/test/turn/stubs.ts
+++ b/packages/agent-core-v2/test/turn/stubs.ts
@@ -47,7 +47,7 @@ function makeTurn(id: number): Turn {
     id,
     signal: controller.signal,
     ready: Promise.resolve(),
-    result: Promise.resolve({ reason: 'completed' }),
+    result: Promise.resolve({ type: 'completed', steps: 0, truncated: false }),
   };
   turnControllers.set(turn, controller);
   return turn;
@@ -130,7 +130,7 @@ export function stubLoopWithHooks(): IAgentLoopService {
     hooks,
     run: async (options) => {
       options.onStarted?.(1);
-      return { reason: 'completed', steps: 0 };
+      return { type: 'completed', steps: 0, truncated: false };
     },
   };
 }

--- a/packages/agent-core-v2/test/turn/turn-ready.test.ts
+++ b/packages/agent-core-v2/test/turn/turn-ready.test.ts
@@ -102,7 +102,7 @@ describe('AgentTurnService ready', () => {
       options.onStarted?.(1);
       await release;
       events.push('done');
-      return { reason: 'completed', steps: 1 };
+      return { type: 'completed', steps: 1, truncated: false };
     };
 
     const turn = ix.get(IAgentTurnService).launch();
@@ -125,13 +125,13 @@ describe('AgentTurnService ready', () => {
     expect(events).toEqual(['loop', 'before', 'after', 'response']);
 
     release.resolve();
-    await expect(turn.result).resolves.toMatchObject({ reason: 'completed', steps: 1 });
+    await expect(turn.result).resolves.toMatchObject({ type: 'completed', steps: 1 });
     expect(events).toEqual(['loop', 'before', 'after', 'response', 'done']);
   });
 
   it('rejects with an Error when the turn ends before the first step starts', async () => {
     const cause = new Error('loop failed before first step');
-    loop.run = async () => ({ reason: 'failed', error: cause, steps: 0 });
+    loop.run = async () => ({ type: 'failed', error: cause, steps: 0 });
 
     const turn = ix.get(IAgentTurnService).launch();
     let readyError: unknown;
@@ -142,14 +142,14 @@ describe('AgentTurnService ready', () => {
     expect(readyError).toBeInstanceOf(Error);
     expect((readyError as Error).message).toBe('Turn ended before first step');
     expect((readyError as Error).cause).toBe(cause);
-    await expect(turn.result).resolves.toMatchObject({ reason: 'failed', error: cause });
+    await expect(turn.result).resolves.toMatchObject({ type: 'failed', error: cause });
   });
 
   it('throws a KimiError when launching while a turn is active', async () => {
     const release = createControlledPromise<void>();
     loop.run = async () => {
       await release;
-      return { reason: 'completed', steps: 1 };
+      return { type: 'completed', steps: 1, truncated: false };
     };
 
     const turnService = ix.get(IAgentTurnService);
@@ -168,7 +168,7 @@ describe('AgentTurnService ready', () => {
       code: ErrorCodes.ACTIVITY_AGENT_BUSY,
       details: { turnId: turn.id },
     });
-    await expect(turn.result).resolves.toMatchObject({ reason: 'completed', steps: 1 });
+    await expect(turn.result).resolves.toMatchObject({ type: 'completed', steps: 1 });
   });
 
   it('records turn.cancel when cancelling the active turn', async () => {
@@ -182,7 +182,7 @@ describe('AgentTurnService ready', () => {
       await new Promise<void>((resolve) => {
         signal?.addEventListener('abort', () => resolve(), { once: true });
       });
-      return { reason: 'cancelled', steps: 0 };
+      return { type: 'cancelled', steps: 0, reason: 'Aborted' };
     };
 
     const turnService = ix.get(IAgentTurnService);
@@ -192,7 +192,11 @@ describe('AgentTurnService ready', () => {
     });
 
     expect(turnService.cancel(turn.id)).toBe(true);
-    await expect(turn.result).resolves.toMatchObject({ reason: 'cancelled', steps: 0 });
+    await expect(turn.result).resolves.toMatchObject({
+      type: 'cancelled',
+      steps: 0,
+      reason: 'Aborted',
+    });
     expect(records.map((record) => record.type)).toEqual(['turn.prompt', 'turn.cancel']);
     expect(records[1]).toEqual({ type: 'turn.cancel', turnId: turn.id, time: expect.any(Number) });
   });
@@ -289,7 +293,7 @@ describe('AgentLoopService onStarted', () => {
     expect(started).toBe(true);
 
     release.resolve();
-    await expect(result).resolves.toMatchObject({ reason: 'completed', steps: 1 });
+    await expect(result).resolves.toMatchObject({ type: 'completed', steps: 1 });
   });
 
   it('fires at step completion when no response event is streamed', async () => {
@@ -331,7 +335,7 @@ describe('AgentLoopService onStarted', () => {
     release.resolve();
     await stepStarted;
     expect(started).toBe(true);
-    await expect(result).resolves.toMatchObject({ reason: 'completed', steps: 1 });
+    await expect(result).resolves.toMatchObject({ type: 'completed', steps: 1 });
   });
 
   it('does not fire when the requester fails before the first response event', async () => {
@@ -352,7 +356,7 @@ describe('AgentLoopService onStarted', () => {
           started = true;
         },
       }),
-    ).resolves.toMatchObject({ reason: 'failed', error: cause, steps: 1 });
+    ).resolves.toMatchObject({ type: 'failed', error: cause, steps: 1 });
     expect(started).toBe(false);
   });
 });

--- a/packages/agent-core-v2/test/turn/turn.test.ts
+++ b/packages/agent-core-v2/test/turn/turn.test.ts
@@ -1940,10 +1940,10 @@ describe('Agent turn flow', () => {
       [emit] tool.progress                       { "turnId": 0, "toolCallId": "call_bash", "update": { "kind": "stdout", "text": "approved" } }
       [emit] tool.result                         { "turnId": 0, "toolCallId": "call_bash", "output": "approved" }
       [wire] context.append_loop_event           { "event": { "type": "tool.result", "parentUuid": "<uuid-3>", "toolCallId": "call_bash", "result": { "output": "approved" } }, "time": "<time>" }
-      [wire] context.append_loop_event           { "event": { "type": "step.end", "uuid": "<uuid-1>", "turnId": "0", "step": 1, "finishReason": "tool_use", "usage": { "inputOther": 7, "output": 22, "inputCacheRead": 0, "inputCacheCreation": 0 }, "messageId": "mock-1" }, "time": "<time>" }
+      [wire] context.append_loop_event           { "event": { "type": "step.end", "uuid": "<uuid-1>", "turnId": "0", "step": 1, "finishReason": "tool_use", "usage": { "inputOther": 7, "output": 22, "inputCacheRead": 0, "inputCacheCreation": 0 }, "messageId": "mock-1", "providerFinishReason": "tool_calls", "rawFinishReason": "tool_calls" }, "time": "<time>" }
       [wire] usage.record                        { "model": "mock-model", "usage": { "inputOther": 7, "output": 22, "inputCacheRead": 0, "inputCacheCreation": 0 }, "usageScope": "turn", "time": "<time>" }
       [emit] agent.status.updated                { "usage": { "byModel": { "mock-model": { "inputOther": 7, "output": 22, "inputCacheRead": 0, "inputCacheCreation": 0 } }, "total": { "inputOther": 7, "output": 22, "inputCacheRead": 0, "inputCacheCreation": 0 }, "currentTurn": { "inputOther": 7, "output": 22, "inputCacheRead": 0, "inputCacheCreation": 0 } } }
-      [emit] turn.step.completed                 { "turnId": 0, "step": 1, "stepId": "<uuid-1>", "usage": { "inputOther": 7, "output": 22, "inputCacheRead": 0, "inputCacheCreation": 0 }, "finishReason": "tool_calls" }
+      [emit] turn.step.completed                 { "turnId": 0, "step": 1, "stepId": "<uuid-1>", "usage": { "inputOther": 7, "output": 22, "inputCacheRead": 0, "inputCacheCreation": 0 }, "finishReason": "tool_use", "providerFinishReason": "tool_calls", "rawFinishReason": "tool_calls" }
       [wire] turn.steer                          { "input": [ { "type": "text", "text": "Also mention the steer." } ], "origin": { "kind": "user" }, "time": "<time>" }
       [wire] context.append_message              { "message": { "role": "user", "content": [ { "type": "text", "text": "Also mention the steer." } ], "toolCalls": [] }, "time": "<time>" }
       [emit] context.spliced                     { "start": 3, "deleteCount": 0, "messages": [ { "role": "user", "content": [ { "type": "text", "text": "Also mention the steer." } ], "toolCalls": [] } ] }
@@ -1953,10 +1953,10 @@ describe('Agent turn flow', () => {
       [emit] assistant.delta                     { "turnId": 0, "delta": "Approved, and I saw the steer." }
       [emit] agent.status.updated                { "contextTokens": 50 }
       [wire] context.append_loop_event           { "event": { "type": "content.part", "uuid": "<uuid-5>", "turnId": "0", "step": 2, "stepUuid": "<uuid-4>", "part": { "type": "text", "text": "Approved, and I saw the steer." } }, "time": "<time>" }
-      [wire] context.append_loop_event           { "event": { "type": "step.end", "uuid": "<uuid-4>", "turnId": "0", "step": 2, "finishReason": "end_turn", "usage": { "inputOther": 39, "output": 11, "inputCacheRead": 0, "inputCacheCreation": 0 }, "messageId": "mock-2" }, "time": "<time>" }
+      [wire] context.append_loop_event           { "event": { "type": "step.end", "uuid": "<uuid-4>", "turnId": "0", "step": 2, "finishReason": "end_turn", "usage": { "inputOther": 39, "output": 11, "inputCacheRead": 0, "inputCacheCreation": 0 }, "messageId": "mock-2", "providerFinishReason": "completed", "rawFinishReason": "stop" }, "time": "<time>" }
       [wire] usage.record                        { "model": "mock-model", "usage": { "inputOther": 39, "output": 11, "inputCacheRead": 0, "inputCacheCreation": 0 }, "usageScope": "turn", "time": "<time>" }
       [emit] agent.status.updated                { "usage": { "byModel": { "mock-model": { "inputOther": 46, "output": 33, "inputCacheRead": 0, "inputCacheCreation": 0 } }, "total": { "inputOther": 46, "output": 33, "inputCacheRead": 0, "inputCacheCreation": 0 }, "currentTurn": { "inputOther": 46, "output": 33, "inputCacheRead": 0, "inputCacheCreation": 0 } } }
-      [emit] turn.step.completed                 { "turnId": 0, "step": 2, "stepId": "<uuid-4>", "usage": { "inputOther": 39, "output": 11, "inputCacheRead": 0, "inputCacheCreation": 0 }, "finishReason": "completed" }
+      [emit] turn.step.completed                 { "turnId": 0, "step": 2, "stepId": "<uuid-4>", "usage": { "inputOther": 39, "output": 11, "inputCacheRead": 0, "inputCacheCreation": 0 }, "finishReason": "end_turn", "providerFinishReason": "completed", "rawFinishReason": "stop" }
       [emit] turn.ended                          { "turnId": 0, "reason": "completed" }
     `);
     expect(ctx.lastLlmInput()).toMatchInlineSnapshot(`


### PR DESCRIPTION
## Related Issue

No linked issue. This addresses an inconsistency in the in-progress `agent-core-v2` turn result contract.

## Problem

Loop execution reused the public turn-ended event shape as its internal result. That made step counts optional, discarded cancellation causes, and required subagent runs to observe step events separately to detect max-token truncation. Step completion records also omitted provider finish metadata when it appeared equivalent to the effective loop reason.

## What changed

- Replace the loose loop result with a discriminated completed/failed/cancelled result that always carries step counts and preserves truncation, errors, and cancellation reasons.
- Propagate the structured result through turn, prompt, goal, runtime, legacy prompt, and subagent lifecycle consumers.
- Normalize the effective step finish reason once while preserving both the normalized provider reason and the raw provider value in records and live events.
- Remove the subagent finish-event observer now that truncation is part of the turn result itself, and normalize thrown cancellation values to `Error` objects.
- Update focused tests, stubs, and inline snapshots for the new contract.

## Validation

- `pnpm --filter @moonshot-ai/agent-core-v2 lint:domain`
- `pnpm --filter @moonshot-ai/agent-core-v2 typecheck`
- `pnpm exec oxlint --type-aware --quiet`
- 23 focused loop/context tests
- 2 focused subagent cancellation/truncation tests
- 1 focused turn steer test

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] This PR needs no changeset, as requested for the `kimi-code-v2` target branch.
- [x] This internal contract change needs no user documentation update.
