### PR TITLE
fix: classify web search http errors

### DIFF
--- a/.changeset/fuzzy-buses-search.md
+++ b/.changeset/fuzzy-buses-search.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Report web search HTTP failures with more specific error categories.

--- a/packages/agent-core/src/tools/builtin/web/web-search.ts
+++ b/packages/agent-core/src/tools/builtin/web/web-search.ts
@@ -117,23 +117,47 @@ function classifySearchError(error: unknown): string {
   const name = error instanceof Error ? error.name : '';
   const message = error instanceof Error ? error.message : String(error);
   const lower = message.toLowerCase();
+  const httpStatus = parseHttpStatus(message);
 
   if (name === 'AbortError' || lower.includes('abort')) {
     return `Search cancelled: ${message}`;
   }
-  if (name === 'TimeoutError' || lower.includes('timed out') || lower.includes('timeout')) {
+  if (
+    httpStatus === 408 ||
+    name === 'TimeoutError' ||
+    lower.includes('timed out') ||
+    lower.includes('timeout')
+  ) {
     return `Search timed out: ${message}`;
   }
-  if (lower.includes('401') || lower.includes('unauthorized') || lower.includes('auth')) {
+  if (httpStatus !== undefined) {
+    if (httpStatus === 401) {
+      return `Search failed (authentication): ${message}`;
+    }
+    if (httpStatus === 403) {
+      return `Search failed (authorization): ${message}`;
+    }
+    if (httpStatus === 429) {
+      return `Search failed (rate limit): ${message}`;
+    }
+    if (httpStatus >= 500) {
+      return `Search failed (server): ${message}`;
+    }
+    if (httpStatus >= 400) {
+      return `Search failed (bad request): ${message}`;
+    }
+  }
+  if (lower.includes('unauthorized') || lower.includes('auth')) {
     return `Search failed (authentication): ${message}`;
   }
-  if (
-    lower.includes('http ') ||
-    lower.includes('network') ||
-    lower.includes('fetch') ||
-    name === 'TypeError'
-  ) {
+  if (lower.includes('network') || lower.includes('fetch') || name === 'TypeError') {
     return `Search failed (network): ${message}`;
   }
   return `Search failed: ${message}`;
+}
+
+function parseHttpStatus(message: string): number | undefined {
+  const match = /\bHTTP\s+(\d{3})\b/i.exec(message);
+  if (match?.[1] === undefined) return undefined;
+  return Number.parseInt(match[1], 10);
 }

--- a/packages/agent-core/test/tools/web-search.test.ts
+++ b/packages/agent-core/test/tools/web-search.test.ts
@@ -228,6 +228,103 @@ describe('WebSearchTool', () => {
     expect(content).toContain('HTTP 401');
   });
 
+  it('classifies authorization failures', async () => {
+    const provider: WebSearchProvider = {
+      search: vi.fn().mockRejectedValue(new Error('Moonshot search request failed: HTTP 403.')),
+    };
+    const tool = new WebSearchTool(provider);
+    const result = await executeTool(tool, {
+      turnId: 't1',
+      toolCallId: 'c-forbidden',
+      args: { query: 'fail' },
+      signal,
+    });
+    expect(result.isError).toBe(true);
+    const content = toolContentString(result);
+    expect(content).toContain('Search failed (authorization):');
+    expect(content).toContain('HTTP 403');
+  });
+
+  it('classifies rate limit failures', async () => {
+    const provider: WebSearchProvider = {
+      search: vi.fn().mockRejectedValue(new Error('Moonshot search request failed: HTTP 429.')),
+    };
+    const tool = new WebSearchTool(provider);
+    const result = await executeTool(tool, {
+      turnId: 't1',
+      toolCallId: 'c-rate-limit',
+      args: { query: 'fail' },
+      signal,
+    });
+    expect(result.isError).toBe(true);
+    const content = toolContentString(result);
+    expect(content).toContain('Search failed (rate limit):');
+    expect(content).toContain('HTTP 429');
+  });
+
+  it('classifies server failures', async () => {
+    const provider: WebSearchProvider = {
+      search: vi
+        .fn()
+        .mockRejectedValue(
+          new Error(
+            'Moonshot search request failed: HTTP 500. {"error":{"type":"server_error"}}',
+          ),
+        ),
+    };
+    const tool = new WebSearchTool(provider);
+    const result = await executeTool(tool, {
+      turnId: 't1',
+      toolCallId: 'c-server',
+      args: { query: 'fail' },
+      signal,
+    });
+    expect(result.isError).toBe(true);
+    const content = toolContentString(result);
+    expect(content).toContain('Search failed (server):');
+    expect(content).toContain('HTTP 500');
+  });
+
+  it('classifies bad request failures', async () => {
+    const provider: WebSearchProvider = {
+      search: vi.fn().mockRejectedValue(new Error('Moonshot search request failed: HTTP 400.')),
+    };
+    const tool = new WebSearchTool(provider);
+    const result = await executeTool(tool, {
+      turnId: 't1',
+      toolCallId: 'c-bad-request',
+      args: { query: 'fail' },
+      signal,
+    });
+    expect(result.isError).toBe(true);
+    const content = toolContentString(result);
+    expect(content).toContain('Search failed (bad request):');
+    expect(content).toContain('HTTP 400');
+  });
+
+  it('prefers HTTP status over body text when classifying failures', async () => {
+    const provider: WebSearchProvider = {
+      search: vi
+        .fn()
+        .mockRejectedValue(
+          new Error(
+            'Moonshot search request failed: HTTP 500. {"error":{"message":"auth upstream failed"}}',
+          ),
+        ),
+    };
+    const tool = new WebSearchTool(provider);
+    const result = await executeTool(tool, {
+      turnId: 't1',
+      toolCallId: 'c-status-priority',
+      args: { query: 'fail' },
+      signal,
+    });
+    expect(result.isError).toBe(true);
+    const content = toolContentString(result);
+    expect(content).toContain('Search failed (server):');
+    expect(content).not.toContain('Search failed (authentication):');
+  });
+
   it('classifies timeout failures', async () => {
     const err = new Error('request timed out');
     err.name = 'TimeoutError';
@@ -245,6 +342,23 @@ describe('WebSearchTool', () => {
     expect(content).toContain('Search timed out:');
     // The original error text is preserved alongside the prefix.
     expect(content).toContain('request timed out');
+  });
+
+  it('classifies HTTP 408 as a timeout failure', async () => {
+    const provider: WebSearchProvider = {
+      search: vi.fn().mockRejectedValue(new Error('Moonshot search request failed: HTTP 408.')),
+    };
+    const tool = new WebSearchTool(provider);
+    const result = await executeTool(tool, {
+      turnId: 't1',
+      toolCallId: 'c-http-timeout',
+      args: { query: 'fail' },
+      signal,
+    });
+    expect(result.isError).toBe(true);
+    const content = toolContentString(result);
+    expect(content).toContain('Search timed out:');
+    expect(content).toContain('HTTP 408');
   });
 
   it('classifies aborted requests', async () => {


### PR DESCRIPTION
## Related Issue

No linked issue.

## Problem

WebSearch grouped Moonshot search HTTP 500 responses under the generic network failure label, making server-side failures look like transport errors.

## What changed

- Classify HTTP search failures by status code: authentication, authorization, timeout, rate limit, server, and bad request.
- Preserve the original upstream error body in the tool output.
- Add tests for the new HTTP status classifications.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.
