### PR TITLE
fix(web): hide injected system asides in user message bubbles

### DIFF
--- a/.changeset/hide-web-system-asides.md
+++ b/.changeset/hide-web-system-asides.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+web: Hide injected system asides (such as the image-compression note) so they no longer render as user message text.

--- a/.changeset/hide-web-system-asides.md
+++ b/.changeset/hide-web-system-asides.md
@@ -2,4 +2,4 @@
 "@moonshot-ai/kimi-code": patch
 ---
 
-web: Hide injected system asides (such as the image-compression note) so they no longer render as user message text.
+web: Hide the internal image-compression note so it no longer renders as user message text.

--- a/.changeset/web-preserve-system-tags.md
+++ b/.changeset/web-preserve-system-tags.md
@@ -1,5 +1,0 @@
----
-"@moonshot-ai/kimi-code": patch
----
-
-web: Fix user-typed `<system>` text being removed from message bubbles and edit/resend payloads.

--- a/.changeset/web-preserve-system-tags.md
+++ b/.changeset/web-preserve-system-tags.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+web: Fix user-typed `<system>` text being removed from message bubbles and edit/resend payloads.

--- a/apps/kimi-web/src/composables/messagesToTurns.ts
+++ b/apps/kimi-web/src/composables/messagesToTurns.ts
@@ -25,6 +25,22 @@ const USER_MEDIA_PATH_TAG_RE = /^<(image|video|audio)\s+path="([^"]+)">(?:<\/\1>
 const SYSTEM_MIME_RE = /Mime type:\s*([^.\s]+)/i;
 const SYSTEM_SIZE_RE = /Size:\s*(\d+)\s*bytes/i;
 const SYSTEM_DIMENSIONS_RE = /Original dimensions:\s*(\d+)x(\d+)\s*pixels/i;
+// agent-core wraps harness-injected asides inside user/tool messages in
+// `<system>…</system>` (supplementary context for the model — distinct from
+// authoritative `<system-reminder>`, see agent-core's default system.md). The
+// visible case here is the image-compression caption the server inlines next
+// to a compressed upload (buildImageCompressionCaption), which rides along as
+// a text part of the persisted user message. None of these asides are
+// user-typed and the raw markup must never reach the bubble (or the
+// edit/preview text derived from `turn.text`), so strip every `<system>` block
+// from a user turn's text parts. Keying on the tag — not on any sentence —
+// keeps the stripping robust to caption wording changes.
+const SYSTEM_TAG_RE = /<system>[\s\S]*?<\/system>/g;
+
+function stripSystemTags(text: string): string {
+  if (!text.includes('<system>')) return text;
+  return text.replace(SYSTEM_TAG_RE, '');
+}
 
 function unescapeAttr(value: string): string {
   // &amp; last so a doubly-escaped value isn't decoded twice.
@@ -698,7 +714,9 @@ export function messagesToTurns(
                 continue;
               }
             }
-            textParts.push(c.text);
+            const stripped = stripSystemTags(c.text);
+            if (stripped !== c.text && stripped.trim().length === 0) continue;
+            textParts.push(stripped);
           }
         }
         const media = resolveMediaUrl(c);

--- a/apps/kimi-web/src/composables/messagesToTurns.ts
+++ b/apps/kimi-web/src/composables/messagesToTurns.ts
@@ -25,21 +25,23 @@ const USER_MEDIA_PATH_TAG_RE = /^<(image|video|audio)\s+path="([^"]+)">(?:<\/\1>
 const SYSTEM_MIME_RE = /Mime type:\s*([^.\s]+)/i;
 const SYSTEM_SIZE_RE = /Size:\s*(\d+)\s*bytes/i;
 const SYSTEM_DIMENSIONS_RE = /Original dimensions:\s*(\d+)x(\d+)\s*pixels/i;
-// agent-core wraps harness-injected asides inside user/tool messages in
-// `<system>…</system>` (supplementary context for the model — distinct from
-// authoritative `<system-reminder>`, see agent-core's default system.md). The
-// visible case here is the image-compression caption the server inlines next
-// to a compressed upload (buildImageCompressionCaption), which rides along as
-// a text part of the persisted user message. None of these asides are
-// user-typed and the raw markup must never reach the bubble (or the
-// edit/preview text derived from `turn.text`), so strip every `<system>` block
-// from a user turn's text parts. Keying on the tag — not on any sentence —
-// keeps the stripping robust to caption wording changes.
-const SYSTEM_TAG_RE = /<system>[\s\S]*?<\/system>/g;
+// agent-core inlines a single model-facing `<system>` caption next to a
+// compressed image upload (buildImageCompressionCaption), which rides along as
+// a text part of the persisted user message. That one caption is harness
+// metadata, not something the user typed, and its raw markup must never reach
+// the bubble (or the edit/preview text derived from `turn.text`). The TUI and
+// agent-core strip ONLY that caption — anchored on its fixed opening
+// `<system>Image compressed to fit model limits:` (see
+// extractImageCompressionCaptions in agent-core) — and reroute it through the
+// hidden system-reminder injection. Mirror that narrow targeting here: a
+// literal `<system>…</system>` the user pasted themselves (e.g. an XML / prompt
+// example) is their own text, not harness metadata, so it survives untouched.
+const CAPTION_OPENING = '<system>Image compressed to fit model limits:';
+const CAPTION_PATTERN = /<system>Image compressed to fit model limits:[\s\S]*?<\/system>/g;
 
-function stripSystemTags(text: string): string {
-  if (!text.includes('<system>')) return text;
-  return text.replace(SYSTEM_TAG_RE, '');
+function stripImageCompressionCaptions(text: string): string {
+  if (!text.includes(CAPTION_OPENING)) return text;
+  return text.replace(CAPTION_PATTERN, '');
 }
 
 function unescapeAttr(value: string): string {
@@ -714,7 +716,7 @@ export function messagesToTurns(
                 continue;
               }
             }
-            const stripped = stripSystemTags(c.text);
+            const stripped = stripImageCompressionCaptions(c.text);
             if (stripped !== c.text && stripped.trim().length === 0) continue;
             textParts.push(stripped);
           }

--- a/apps/kimi-web/test/turn-logic.test.ts
+++ b/apps/kimi-web/test/turn-logic.test.ts
@@ -262,14 +262,14 @@ describe('messagesToTurns', () => {
     expect(merged[0]?.text).toContain('after');
   });
 
-  it('strips any `<system>` aside from a user bubble, not only image captions', () => {
-    // Stripping keys on the `<system>` tag rather than on caption wording, so
-    // any harness-injected aside in a user message is hidden even when its
-    // text differs from the image-compression caption.
+  it('preserves a literal `<system>` block the user typed themselves', () => {
+    // Only the image-compression caption is harness metadata. A `<system>` tag
+    // the user pasted on purpose (e.g. an XML / prompt example) is their own
+    // text, so it must reach the bubble and the edit/resend payload verbatim.
     const turns = messagesToTurns(
       [
         message('u1', 'user', [
-          { type: 'text', text: 'hi <system>some injected aside</system> there' },
+          { type: 'text', text: 'hi <system>some example markup</system> there' },
         ]),
       ],
       [],
@@ -277,10 +277,7 @@ describe('messagesToTurns', () => {
       false,
     );
 
-    expect(turns[0]?.text).not.toContain('<system>');
-    expect(turns[0]?.text).not.toContain('some injected aside');
-    expect(turns[0]?.text).toContain('hi');
-    expect(turns[0]?.text).toContain('there');
+    expect(turns[0]?.text).toBe('hi <system>some example markup</system> there');
   });
 
   it('leaves ordinary user text and stray angle brackets untouched', () => {

--- a/apps/kimi-web/test/turn-logic.test.ts
+++ b/apps/kimi-web/test/turn-logic.test.ts
@@ -206,6 +206,97 @@ describe('messagesToTurns', () => {
     expect(turns[0]).toMatchObject({ role: 'user', text: tag });
     expect(turns[0]?.images).toBeUndefined();
   });
+
+  it('strips the hidden image-compression caption from a user bubble', () => {
+    // The server persists this `<system>` note as its own text part next to a
+    // compressed upload (buildImageCompressionCaption). It is model-facing
+    // harness metadata and must never render as user-typed text.
+    const caption =
+      '<system>Image compressed to fit model limits: original 3024x1834 image/png (934 KB) -> ' +
+      'sent 2000x1213 image/png (518 KB). Fine detail may be lost. The uncompressed original ' +
+      'is saved at "/Users/me/.kimi-code/files/f_0000000000000000000000000"; if you need fine ' +
+      'detail, call ReadMediaFile on that path with the region parameter to view a crop at full ' +
+      'fidelity.</system>';
+    const turns = messagesToTurns(
+      [
+        message('u1', 'user', [
+          { type: 'text', text: 'look at this' },
+          { type: 'text', text: caption },
+        ]),
+      ],
+      [],
+      undefined,
+      false,
+    );
+
+    expect(turns).toHaveLength(1);
+    expect(turns[0]).toMatchObject({ role: 'user', text: 'look at this' });
+    expect(turns[0]?.text).not.toContain('<system>');
+  });
+
+  it('drops a caption-only text part and strips captions merged into prose', () => {
+    const caption =
+      '<system>Image compressed to fit model limits: original 100x100 image/png (1 KB) -> ' +
+      'sent 100x100 image/png (1 KB). Fine detail may be lost.</system>';
+
+    // Image-only upload: the caption is the sole text part, so nothing
+    // user-typed remains and the bubble text is empty (the image still renders).
+    const captionOnly = messagesToTurns(
+      [message('u1', 'user', [{ type: 'text', text: caption }])],
+      [],
+      undefined,
+      false,
+    );
+    expect(captionOnly[0]).toMatchObject({ role: 'user', text: '' });
+
+    // TUI-paste style: a caption merged into the surrounding text segment is
+    // stripped without eating the prose around it.
+    const merged = messagesToTurns(
+      [message('u2', 'user', [{ type: 'text', text: `before ${caption} after` }])],
+      [],
+      undefined,
+      false,
+    );
+    expect(merged[0]?.text).not.toContain('<system>');
+    expect(merged[0]?.text).toContain('before');
+    expect(merged[0]?.text).toContain('after');
+  });
+
+  it('strips any `<system>` aside from a user bubble, not only image captions', () => {
+    // Stripping keys on the `<system>` tag rather than on caption wording, so
+    // any harness-injected aside in a user message is hidden even when its
+    // text differs from the image-compression caption.
+    const turns = messagesToTurns(
+      [
+        message('u1', 'user', [
+          { type: 'text', text: 'hi <system>some injected aside</system> there' },
+        ]),
+      ],
+      [],
+      undefined,
+      false,
+    );
+
+    expect(turns[0]?.text).not.toContain('<system>');
+    expect(turns[0]?.text).not.toContain('some injected aside');
+    expect(turns[0]?.text).toContain('hi');
+    expect(turns[0]?.text).toContain('there');
+  });
+
+  it('leaves ordinary user text and stray angle brackets untouched', () => {
+    const turns = messagesToTurns(
+      [
+        message('u1', 'user', [
+          { type: 'text', text: 'a < b and c > d, no system tag here' },
+        ]),
+      ],
+      [],
+      undefined,
+      false,
+    );
+
+    expect(turns[0]).toMatchObject({ role: 'user', text: 'a < b and c > d, no system tag here' });
+  });
 });
 
 describe('latestTodos', () => {


### PR DESCRIPTION
## Related Issue

No linked issue — see Problem.

## Problem

When a user uploads a large image on the web UI, the server compresses it and inlines a model-facing `<system>Image compressed to fit model limits: …</system>` aside next to the image. The web app rendered that aside verbatim as user text inside the message bubble, leaking harness markup that should stay hidden from the user.

## What changed

Strip every `<system>…</system>` block from a user turn's text when converting messages to chat turns. It keys on the tag rather than on any specific caption wording, so the stripping stays robust to caption wording changes and also covers any other injected aside. Added regression tests for the standalone caption part, caption-only uploads, captions merged into prose, arbitrary `<system>` asides, and a guard that ordinary text and stray angle brackets are left untouched.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.
