### PR TITLE
feat(ci): publish plugin marketplace on release

### DIFF
--- a/.changeset/plugin-marketplace-ci.md
+++ b/.changeset/plugin-marketplace-ci.md
@@ -1,0 +1,9 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+feat(ci): publish plugin marketplace on release
+
+- Add `build:plugin-marketplace` step to the release workflow
+- Upload plugin marketplace artifacts as GitHub Release assets
+- Make `build-plugin-marketplace-cdn` script skip missing sources gracefully

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,6 +52,16 @@ jobs:
       - name: Build packages
         run: pnpm build
 
+      - name: Build plugin marketplace
+        run: pnpm run build:plugin-marketplace
+
+      - name: Upload plugin marketplace artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: plugin-marketplace
+          path: plugins/cdn
+          retention-days: 7
+
       - name: Create Release Pull Request or Publish to npm
         id: changesets
         uses: changesets/action@v1
@@ -144,3 +154,33 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           RELEASE_TAG: ${{ needs.release.outputs.kimi_release_tag }}
         run: gh release upload "$RELEASE_TAG" dist-native-release/* --clobber
+
+  publish-plugin-marketplace:
+    name: Publish plugin marketplace
+    needs: release
+    if: needs.release.outputs.packages_published == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Download plugin marketplace artifact
+        uses: actions/download-artifact@v8
+        with:
+          name: plugin-marketplace
+          path: dist-plugin-marketplace
+          merge-multiple: true
+
+      - name: Upload plugin marketplace to GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ needs.release.outputs.kimi_release_tag }}
+        run: |
+          # The artifact contains files directly under dist-plugin-marketplace/
+          cd dist-plugin-marketplace
+          gh release upload "$RELEASE_TAG" marketplace.json --clobber
+          find . -name "*.zip" -exec gh release upload "$RELEASE_TAG" {} --clobber \;
+          cd ..
+          # Also upload as a zip archive for convenience
+          zip -r plugin-marketplace.zip dist-plugin-marketplace
+          gh release upload "$RELEASE_TAG" plugin-marketplace.zip --clobber

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -158,7 +158,7 @@ jobs:
   publish-plugin-marketplace:
     name: Publish plugin marketplace
     needs: release
-    if: needs.release.outputs.packages_published == 'true'
+    if: needs.release.outputs.kimi_native_release == 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/apps/kimi-code/scripts/build-plugin-marketplace-cdn.mjs
+++ b/apps/kimi-code/scripts/build-plugin-marketplace-cdn.mjs
@@ -94,7 +94,8 @@ async function materializeEntrySource(source, pluginsRoot, outDir) {
   const sourcePath = resolveInsideRoot(pluginsRoot, source);
   const info = await stat(sourcePath).catch(() => undefined);
   if (info === undefined) {
-    throw new Error(`Marketplace source does not exist: ${source}`);
+    console.warn(`Warning: Marketplace source does not exist, skipping: ${source}`);
+    return { source };
   }
 
   if (info.isDirectory()) {


### PR DESCRIPTION
This PR adds plugin marketplace publishing to the release workflow.

## Changes
- Add `build:plugin-marketplace` step to the release workflow
- Upload plugin marketplace artifacts as GitHub Release assets
- Make `build-plugin-marketplace-cdn` script skip missing sources gracefully instead of failing

## Why
Currently the plugin marketplace needs to be built and published manually. This automates the process so every release includes the latest marketplace data.

## Testing
- The build script change has been tested to skip missing sources without crashing
- The workflow additions follow the same pattern as native artifact publishing