### PR TITLE
fix: update the WebBridge install link in the /plugins panel

### DIFF
--- a/.changeset/webbridge-plugins-link.md
+++ b/.changeset/webbridge-plugins-link.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Update the WebBridge install page link opened from the /plugins panel.

--- a/apps/kimi-code/src/tui/components/dialogs/plugins-selector.ts
+++ b/apps/kimi-code/src/tui/components/dialogs/plugins-selector.ts
@@ -32,7 +32,7 @@ const ELLIPSIS = '…';
 // Official tab, even when the marketplace catalog is unavailable. Selecting it
 // opens the install page in the browser rather than installing from a source,
 // because Web Bridge is a browser extension + daemon, not a plugin package.
-const WEB_BRIDGE_URL = 'https://www.kimi.com/zh-cn/features/webbridge#local-agent';
+const WEB_BRIDGE_URL = 'https://www.kimi.com/features/webbridge#local-agent';
 const WEB_BRIDGE_ENTRY: PluginMarketplaceEntry = {
   id: 'kimi-webbridge',
   displayName: 'Kimi WebBridge',

--- a/apps/kimi-code/src/tui/components/dialogs/plugins-selector.ts
+++ b/apps/kimi-code/src/tui/components/dialogs/plugins-selector.ts
@@ -32,7 +32,7 @@ const ELLIPSIS = '…';
 // Official tab, even when the marketplace catalog is unavailable. Selecting it
 // opens the install page in the browser rather than installing from a source,
 // because Web Bridge is a browser extension + daemon, not a plugin package.
-const WEB_BRIDGE_URL = 'https://www.kimi.com/features/webbridge';
+const WEB_BRIDGE_URL = 'https://www.kimi.com/zh-cn/features/webbridge#local-agent';
 const WEB_BRIDGE_ENTRY: PluginMarketplaceEntry = {
   id: 'kimi-webbridge',
   displayName: 'Kimi WebBridge',

--- a/apps/kimi-code/test/tui/components/dialogs/plugins-selector.test.ts
+++ b/apps/kimi-code/test/tui/components/dialogs/plugins-selector.test.ts
@@ -313,7 +313,7 @@ describe('plugins selector dialogs', () => {
     panel.handleInput('\r');
     expect(onSelect).toHaveBeenCalledWith({
       kind: 'open-url',
-      url: 'https://www.kimi.com/zh-cn/features/webbridge#local-agent',
+      url: 'https://www.kimi.com/features/webbridge#local-agent',
       label: 'Kimi WebBridge',
     });
   });

--- a/apps/kimi-code/test/tui/components/dialogs/plugins-selector.test.ts
+++ b/apps/kimi-code/test/tui/components/dialogs/plugins-selector.test.ts
@@ -313,7 +313,7 @@ describe('plugins selector dialogs', () => {
     panel.handleInput('\r');
     expect(onSelect).toHaveBeenCalledWith({
       kind: 'open-url',
-      url: 'https://www.kimi.com/features/webbridge',
+      url: 'https://www.kimi.com/zh-cn/features/webbridge#local-agent',
       label: 'Kimi WebBridge',
     });
   });


### PR DESCRIPTION
## Related Issue

No linked issue — small link update, see Problem below.

## Problem

Selecting the pinned Kimi WebBridge entry in the `/plugins` panel opened the old install page URL (`https://www.kimi.com/features/webbridge`). The install page has moved to `https://www.kimi.com/features/webbridge#local-agent`, so the entry should point users at the current page.

## What changed

- Pointed the pinned WebBridge entry in the `/plugins` panel at `https://www.kimi.com/features/webbridge#local-agent`.
- Updated the plugins selector test to assert the new URL.
- Added a `patch` changeset for `@moonshot-ai/kimi-code`.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.