### PR TITLE
fix(tui): resolve shell carriage-return redraws

### DIFF
--- a/.changeset/fix-shell-carriage-return-redraw.md
+++ b/.changeset/fix-shell-carriage-return-redraw.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Fix shell progress output that redraws the same line with carriage returns.

--- a/apps/kimi-code/src/tui/utils/shell-output.ts
+++ b/apps/kimi-code/src/tui/utils/shell-output.ts
@@ -11,6 +11,8 @@ import { currentTheme } from '#/tui/theme';
 // ESC [ <params> <intermediates> <final> — colours, cursor moves, clear, and
 // private modes such as ESC[?1049h (alt screen) / ESC[?25l (hide cursor).
 const CSI_PATTERN = /\u001B\[[0-9:;<=>?]*[ -/]*[@-~]/g;
+const ERASE_IN_LINE_PATTERN = /\u001B\[[0-9:;<=>?]*[ -/]*K/g;
+const ERASE_IN_LINE_MARKER = '\uE000';
 // ESC ] … <BEL>  or  ESC ] … ESC \ — window titles and OSC 8 hyperlinks.
 const OSC_PATTERN = /\u001B\][\s\S]*?(?:\u0007|\u001B\\)/g;
 // ESC <char> (and ESC <intermediate> <char>) — charset/keypad selection,
@@ -24,20 +26,42 @@ const ESC_SINGLE_PATTERN = /\u001B(?:[ -/][0-~]|[0-~])/g;
 const C0_CONTROL_PATTERN = /[\u0000-\u0008\u000B-\u000C\u000E-\u001B\u001C-\u001F]/g;
 
 function resolveCarriageReturns(text: string): string {
-  if (!text.includes('\r')) return text;
+  if (!text.includes('\r') && !text.includes(ERASE_IN_LINE_MARKER)) return text;
   return text
     .split('\n')
     .map((line) => {
-      if (!line.includes('\r')) return line;
-      const parts = line.split('\r');
-      let out = parts[0] ?? '';
-      for (let i = 1; i < parts.length; i++) {
-        const over = parts[i] ?? '';
-        out = over.length >= out.length ? over : over + out.slice(over.length);
+      if (!line.includes('\r') && !line.includes(ERASE_IN_LINE_MARKER)) return line;
+      let out = '';
+      let cursor = 0;
+      for (let i = 0; i < line.length;) {
+        const char = line[i];
+        if (char === '\r') {
+          cursor = 0;
+          i++;
+          continue;
+        }
+        if (char === ERASE_IN_LINE_MARKER) {
+          out = out.slice(0, cursor);
+          i++;
+          continue;
+        }
+        const nextControl = nextControlIndex(line, i);
+        const chunk = line.slice(i, nextControl);
+        out = out.slice(0, cursor) + chunk + out.slice(cursor + chunk.length);
+        cursor += chunk.length;
+        i = nextControl;
       }
       return out;
     })
     .join('\n');
+}
+
+function nextControlIndex(line: string, start: number): number {
+  let index = start;
+  while (index < line.length && line[index] !== '\r' && line[index] !== ERASE_IN_LINE_MARKER) {
+    index++;
+  }
+  return index;
 }
 
 /**
@@ -53,11 +77,14 @@ export function sanitizeShellOutput(text: string): string {
   try {
     const withoutEscapes = text
       .replace(OSC_PATTERN, '')
+      .replace(ERASE_IN_LINE_PATTERN, ERASE_IN_LINE_MARKER)
       .replace(CSI_PATTERN, '')
       .replace(ESC_SINGLE_PATTERN, '');
-    return resolveCarriageReturns(withoutEscapes).replace(C0_CONTROL_PATTERN, '');
+    return resolveCarriageReturns(withoutEscapes)
+      .replace(C0_CONTROL_PATTERN, '')
+      .replaceAll(ERASE_IN_LINE_MARKER, '');
   } catch {
-    return resolveCarriageReturns(text).replace(C0_CONTROL_PATTERN, '');
+    return resolveCarriageReturns(text).replace(C0_CONTROL_PATTERN, '').replaceAll(ERASE_IN_LINE_MARKER, '');
   }
 }
 

--- a/apps/kimi-code/src/tui/utils/shell-output.ts
+++ b/apps/kimi-code/src/tui/utils/shell-output.ts
@@ -17,9 +17,28 @@ const OSC_PATTERN = /\u001B\][\s\S]*?(?:\u0007|\u001B\\)/g;
 // save/restore cursor (ESC 7 / ESC 8), full reset (ESC c), etc. Runs after the
 // CSI/OSC patterns, so it only catches sequences they didn't already consume.
 const ESC_SINGLE_PATTERN = /\u001B(?:[ -/][0-~]|[0-~])/g;
-// C0 control characters except \n (0x0A) and \t (0x09): NUL, BEL, \b, \r, …
-// plus a lone ESC (0x1B) that wasn't part of a sequence recognised above.
-const C0_CONTROL_PATTERN = /[\u0000-\u0008\u000B-\u001B\u001C-\u001F]/g;
+// C0 control characters except \n (0x0A), \t (0x09), and \r (0x0D): NUL,
+// BEL, \b, … plus a lone ESC (0x1B) that wasn't part of a sequence recognised
+// above. Carriage returns are resolved separately because command progress
+// redraws use them to overwrite the current line.
+const C0_CONTROL_PATTERN = /[\u0000-\u0008\u000B-\u000C\u000E-\u001B\u001C-\u001F]/g;
+
+function resolveCarriageReturns(text: string): string {
+  if (!text.includes('\r')) return text;
+  return text
+    .split('\n')
+    .map((line) => {
+      if (!line.includes('\r')) return line;
+      const parts = line.split('\r');
+      let out = parts[0] ?? '';
+      for (let i = 1; i < parts.length; i++) {
+        const over = parts[i] ?? '';
+        out = over.length >= out.length ? over : over + out.slice(over.length);
+      }
+      return out;
+    })
+    .join('\n');
+}
 
 /**
  * Strip every terminal control sequence from captured command output so it is
@@ -32,13 +51,13 @@ export function sanitizeShellOutput(text: string): string {
   if (typeof text !== 'string') return '';
   if (text.length === 0) return text;
   try {
-    return text
+    const withoutEscapes = text
       .replace(OSC_PATTERN, '')
       .replace(CSI_PATTERN, '')
-      .replace(ESC_SINGLE_PATTERN, '')
-      .replace(C0_CONTROL_PATTERN, '');
+      .replace(ESC_SINGLE_PATTERN, '');
+    return resolveCarriageReturns(withoutEscapes).replace(C0_CONTROL_PATTERN, '');
   } catch {
-    return text.replace(C0_CONTROL_PATTERN, '');
+    return resolveCarriageReturns(text).replace(C0_CONTROL_PATTERN, '');
   }
 }
 

--- a/apps/kimi-code/test/tui/utils/shell-output.test.ts
+++ b/apps/kimi-code/test/tui/utils/shell-output.test.ts
@@ -38,8 +38,9 @@ describe('sanitizeShellOutput', () => {
     expect(sanitizeShellOutput(link)).toBe('click here');
   });
 
-  it('strips carriage returns (spinner redraw)', () => {
-    expect(sanitizeShellOutput('frame1\rframe2\rframe3')).toBe('frame1frame2frame3');
+  it('resolves carriage-return redraws before rendering', () => {
+    expect(sanitizeShellOutput('frame1\rframe2\rframe3')).toBe('frame3');
+    expect(sanitizeShellOutput('Hello World\rHi')).toBe('Hillo World');
     expect(sanitizeShellOutput('line\r\nnext')).toBe('line\nnext');
   });
 

--- a/apps/kimi-code/test/tui/utils/shell-output.test.ts
+++ b/apps/kimi-code/test/tui/utils/shell-output.test.ts
@@ -41,6 +41,8 @@ describe('sanitizeShellOutput', () => {
   it('resolves carriage-return redraws before rendering', () => {
     expect(sanitizeShellOutput('frame1\rframe2\rframe3')).toBe('frame3');
     expect(sanitizeShellOutput('Hello World\rHi')).toBe('Hillo World');
+    expect(sanitizeShellOutput(`Downloading 100%\rDone${ESC}[K`)).toBe('Done');
+    expect(sanitizeShellOutput(`Downloading 100%\r${ESC}[KDone`)).toBe('Done');
     expect(sanitizeShellOutput('line\r\nnext')).toBe('line\nnext');
   });
 


### PR DESCRIPTION
## Related Issue

No linked issue. This is a focused bug fix for shell output that redraws the current terminal line with carriage returns.

## Problem

Captured shell output is sanitized before pi-tui renders it. The sanitizer currently removes carriage returns as ordinary control characters, so redraw sequences such as `frame1\rframe2\rframe3` become `frame1frame2frame3` instead of the terminal-visible final frame, `frame3`.

That makes progress output grow and wrap unnecessarily in the live and final shell output views.

## What changed

Resolve carriage-return redraws after stripping terminal escape sequences and before removing other C0 control characters. This keeps CRLF line endings as newlines while simulating same-line overwrite behavior for progress updates.

Added regression coverage for equal-length redraws, shorter partial overwrites, and CRLF normalization.

## Validation

- `pnpm --filter @moonshot-ai/kimi-code exec vitest run test/tui/utils/shell-output.test.ts`
- `pnpm exec oxlint apps/kimi-code/src/tui/utils/shell-output.ts apps/kimi-code/test/tui/utils/shell-output.test.ts`
- `pnpm --filter @moonshot-ai/kimi-code run typecheck`

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.
