### PR TITLE
fix(agent-core): treat dismissed AskUserQuestion as no answer, not recommended pick

### DIFF
--- a/.changeset/ask-user-dismiss-not-recommended.md
+++ b/.changeset/ask-user-dismiss-not-recommended.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Treat a dismissed question prompt as the user choosing not to answer, instead of implicitly selecting the recommended option.

--- a/packages/agent-core/src/tools/builtin/collaboration/ask-user.md
+++ b/packages/agent-core/src/tools/builtin/collaboration/ask-user.md
@@ -18,4 +18,4 @@ Overusing this tool interrupts the user's flow. Only use it when the user's inpu
 - Question texts must be unique across the call, and option labels must be unique within each question
 - You can ask 1-4 questions at a time; group related questions to minimize interruptions
 - If you recommend a specific option, list it first and append "(Recommended)" to its label
-- The result is JSON with an `answers` object keyed by question text; each value is the chosen option's label (comma-separated labels for multi_select, or the user's own words if they picked "Other"); if `answers` is empty and a `note` says the user dismissed it, they declined to answer — proceed with your best judgment and do not re-ask the same question
+- The result is JSON with an `answers` object keyed by question text; each value is the chosen option's label (comma-separated labels for multi_select, or the user's own words if they picked "Other"); if `answers` is empty and a `note` says the user dismissed it, they chose not to answer — do not treat this as selecting the recommended option; decide based on context and do not re-ask the same question


### PR DESCRIPTION
## Related Issue

No linked issue — the problem is explained below.

## Problem

When a user dismisses an `AskUserQuestion` prompt (ESC / close), the tool description told the model to "proceed with your best judgment". In practice the model read this as "go with the option I marked (Recommended)", so a dismissal silently became an implicit selection of the recommended option instead of the user declining to answer.

## What changed

Updated the model-facing `AskUserQuestion` tool description so a dismissed question (empty `answers` with a `note`) is described as the user choosing not to answer, with an explicit instruction not to treat it as selecting the recommended option and to decide based on context instead. The dismiss result payload and the web pre-selection behavior are unchanged. Added a patch changeset for `@moonshot-ai/kimi-code`.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [ ] I have added tests that prove my feature works. (Prompt-only change; existing ask-user tests pass.)
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update. (No user-facing doc change needed for an internal prompt tweak.)