### PR TITLE
fix(web): keep ReadMediaFile media rendering after session resume

### DIFF
--- a/.changeset/web-resume-media-tool.md
+++ b/.changeset/web-resume-media-tool.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+web: Fix ReadMediaFile results rendering as plain tool cards instead of images after resuming or reloading a session.

--- a/apps/kimi-web/test/turn-logic.test.ts
+++ b/apps/kimi-web/test/turn-logic.test.ts
@@ -47,6 +47,46 @@ describe('messagesToTurns', () => {
     ]);
   });
 
+  it('surfaces a ReadMediaFile snapshot result as media', () => {
+    // After a reload the daemon snapshot delivers a ReadMediaFile result as
+    // raw content parts (the same shape the live tool.result stream carries),
+    // so a resumed session must render the image card, not a generic tool card.
+    const turns = messagesToTurns(
+      [
+        message('a1', 'assistant', [
+          { type: 'toolUse', toolCallId: 'tool-9', toolName: 'ReadMediaFile', input: { path: 'shot.png' } },
+        ]),
+        message('t1', 'tool', [
+          {
+            type: 'toolResult',
+            toolCallId: 'tool-9',
+            output: [
+              { type: 'text', text: '<image path="/tmp/shot.png">' },
+              { type: 'image_url', imageUrl: { url: 'data:image/png;base64,QUJD' } },
+              { type: 'text', text: '</image>' },
+            ],
+          },
+        ]),
+      ],
+      [],
+      undefined,
+      false,
+    );
+
+    expect(turns[0]?.tools).toMatchObject([
+      {
+        id: 'tool-9',
+        status: 'ok',
+        media: {
+          kind: 'image',
+          url: 'data:image/png;base64,QUJD',
+          path: '/tmp/shot.png',
+          mimeType: 'image/png',
+        },
+      },
+    ]);
+  });
+
   it('splits assistant turns when prompt ids differ', () => {
     const turns = messagesToTurns(
       [

--- a/packages/agent-core/src/services/message/message.ts
+++ b/packages/agent-core/src/services/message/message.ts
@@ -184,9 +184,13 @@ function mapContentPart(part: ContextMessage['content'][number]): MessageContent
  * Build the protocol-shaped `Message.content[]` for one ContextMessage.
  *
  * Order:
- *   1. For `tool` role: emit a SINGLE `tool_result` part. The output is the
- *      flattened text of the kosong message's content parts (most tool
- *      messages emit a single text). `is_error` is taken from `ContextMessage.isError`.
+ *   1. For `tool` role: emit a SINGLE `tool_result` part. Plain-text results
+ *      keep the historical flattened-text output (most tool messages emit a
+ *      single text); a result that carries media parts (image/video/audio —
+ *      e.g. ReadMediaFile) passes the raw kosong content-part array through
+ *      instead, the same shape the live `tool.result` event stream carries,
+ *      so REST consumers can still render the media. `is_error` is taken
+ *      from `ContextMessage.isError`.
  *   2. For other roles: emit each content part mapped per `mapContentPart`,
  *      THEN append one `tool_use` part per `ToolCall` (assistant only).
  */
@@ -197,20 +201,23 @@ function buildProtocolContent(msg: ContextMessage): MessageContent[] {
       // fall back to text passthrough so we don't lose user-visible content.
       return msg.content.map((p) => mapContentPart(p));
     }
-    const flattenedOutput = msg.content
-      .map((p) => (p.type === 'text' ? p.text : ''))
-      .join('');
+    const hasMediaPart = msg.content.some(
+      (p) => p.type === 'image_url' || p.type === 'video_url' || p.type === 'audio_url',
+    );
+    const output: unknown = hasMediaPart
+      ? msg.content
+      : msg.content.map((p) => (p.type === 'text' ? p.text : '')).join('');
     const part: MessageContent = msg.isError === true
       ? {
           type: 'tool_result',
           tool_call_id: msg.toolCallId,
-          output: flattenedOutput,
+          output,
           is_error: true,
         }
       : {
           type: 'tool_result',
           tool_call_id: msg.toolCallId,
-          output: flattenedOutput,
+          output,
         };
     return [part];
   }

--- a/packages/agent-core/test/services/message-service.test.ts
+++ b/packages/agent-core/test/services/message-service.test.ts
@@ -362,10 +362,12 @@ describe('MessageService', () => {
 
 
 describe('toProtocolMessage tool-result output passthrough', () => {
-  it('flattens tool result text verbatim — no stripping, tool metadata rides `note`', () => {
-    // Tool metadata no longer travels inside `output` (producers put it on
-    // the result's `note` side channel), so the protocol mapper must not eat
-    // content that merely contains a literal tag.
+  it('passes media tool results through as raw content parts instead of flattening', () => {
+    // A ReadMediaFile-style result carries an image_url part next to the
+    // wrapper text tags; flattening to text would drop the media bytes, so
+    // the mapper passes the raw part array through (same shape the live
+    // tool.result event carries). Literal text — even system/image-looking
+    // markup from a user file — rides along verbatim.
     const toolMessage: ContextMessage = {
       role: 'tool',
       toolCallId: 'call_1',
@@ -379,8 +381,26 @@ describe('toProtocolMessage tool-result output passthrough', () => {
     };
     const [part] = toProtocolMessage(SESSION_ID, 0, toolMessage, SESSION_CREATED_AT).content;
     expect(part?.type).toBe('tool_result');
-    const output = (part as { output: string }).output;
-    expect(output).toContain('<system>literal text from a user file</system>');
-    expect(output).toContain('<image path="/tmp/x.png">');
+    expect((part as { output: unknown }).output).toEqual([
+      { type: 'text', text: '<system>literal text from a user file</system>' },
+      { type: 'text', text: '<image path="/tmp/x.png">' },
+      { type: 'image_url', imageUrl: { url: 'data:image/png;base64,A' } },
+      { type: 'text', text: '</image>' },
+    ]);
+  });
+
+  it('flattens text-only tool results to a single output string', () => {
+    const toolMessage: ContextMessage = {
+      role: 'tool',
+      toolCallId: 'call_1',
+      content: [
+        { type: 'text', text: 'line one\n' },
+        { type: 'text', text: 'line two' },
+      ],
+      toolCalls: [],
+    };
+    const [part] = toProtocolMessage(SESSION_ID, 0, toolMessage, SESSION_CREATED_AT).content;
+    expect(part?.type).toBe('tool_result');
+    expect((part as { output: unknown }).output).toBe('line one\nline two');
   });
 });


### PR DESCRIPTION
## Related Issue

No tracking issue — this is a clear, reproducible rendering bug; the problem is explained below.

## Problem

In the web UI, a `ReadMediaFile` tool call renders as an image card while the session is streaming, but after resuming the session or reloading the page it degrades to a generic `ReadMediaFile` tool card — the image is gone.

The two delivery paths disagree on the tool-result payload shape:

- **Live (WS):** the `tool.result` event carries `output` as the raw kosong content-part array (`[text('<image path="…">'), image_url, text('</image>')]`), which the web client parses into the media card.
- **Resume (REST snapshot / messages):** the protocol projection flattened tool-role message content to text only (non-text parts became `''`), so `output` arrived as `"<image path=\"…\"></image>"` — the media bytes never left the server, and the client fell back to the generic card. (The wire log on disk keeps the full parts; they were dropped only at projection time.)

## What changed

- In the shared protocol message projection (`toProtocolMessage`, used by both the snapshot and messages endpoints), a tool result that carries image/video/audio parts now passes the raw content-part array through as `tool_result.output` — the same shape the live event stream already sends. Text-only results keep the historical flattened string, so the common case is byte-identical. The protocol field is `z.unknown()` and the web client already parses both shapes, so no schema or client changes were needed.
- Tests: agent-core projection now asserts media parts pass through (and text-only results still flatten to a string); kimi-web turn logic asserts a snapshot-shaped `ReadMediaFile` result surfaces as a media card.
- Verified: agent-core suite (3736 tests) and kimi-web suite (390 tests) pass; agent-core / server / kimi-web typechecks clean.

This fits Kimi Code because it removes the divergence at its source — one canonical payload shape for both delivery paths — instead of adding a second, lossy recovery path in the client. Old sessions are fixed retroactively since the media bytes were always preserved in the wire log.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update. (Bug fix only — no user-facing behavior to document.)