### PR TITLE
fix(web): stop mid-turn resync from duplicating prior steps into a text blob

### DIFF
--- a/.changeset/web-fix-midturn-resync-blob.md
+++ b/.changeset/web-fix-midturn-resync-blob.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+web: Fix thinking blocks and tool calls collapsing into one giant duplicated text blob when the page reconnects or resyncs mid-turn.

--- a/apps/kimi-web/src/api/daemon/agentEventProjector.ts
+++ b/apps/kimi-web/src/api/daemon/agentEventProjector.ts
@@ -497,13 +497,15 @@ export interface AgentProjector {
    */
   bindNextPromptId(sessionId: string, promptId: string): void;
   /**
-   * Seed mid-turn state from a session snapshot's `in_flight_turn` (v2 sync):
+   * Seed mid-step state from a session snapshot's `in_flight_turn` (v2 sync):
    * resets per-session state, builds the partially-streamed assistant message
-   * (thinking + text + running tool_use parts), and returns the messageCreated
-   * AppEvent to apply to the reducer. Live deltas continue appending; their
-   * wire `offset` aligns against the seeded text so the overlap window around
-   * snapshot/subscribe is exact. Session status is NOT seeded here — the REST
-   * snapshot's `session.status` is the authoritative value.
+   * (thinking + text + running tool_use parts of the CURRENT step only — the
+   * snapshot transcript already carries every completed step), and returns
+   * the messageCreated AppEvent to apply to the reducer. Live deltas continue
+   * appending; their wire `offset` aligns against the seeded text so the
+   * overlap window around snapshot/subscribe is exact. Session status is NOT
+   * seeded here — the REST snapshot's `session.status` is the authoritative
+   * value.
    */
   seedInFlight(sessionId: string, turn: AppInFlightTurn): AppEvent[];
   /** Reset all per-session state (call on re-subscribe / resync). */
@@ -723,6 +725,13 @@ export function createAgentProjector(): AgentProjector {
           s.currentPromptId = promptId;
           if (turnId !== undefined) s.turnPromptId.set(turnId, promptId);
         }
+
+        // Delta offsets are step-relative: the daemon's InFlightTurnTracker
+        // resets its accumulation at each step boundary (the snapshot
+        // transcript already carries prior steps), so the local counters must
+        // reset in step with it or every delta of the new step mis-aligns.
+        s.turnTextLen = 0;
+        s.turnThinkLen = 0;
 
         // Create a new pending assistant message
         const msg = startAssistantMessage(s, sessionId, promptId);

--- a/apps/kimi-web/test/agent-event-projector.test.ts
+++ b/apps/kimi-web/test/agent-event-projector.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from 'vitest';
 import { classifyFrame, createAgentProjector, subagentProgressText } from '../src/api/daemon/agentEventProjector';
+import { createInitialState, reduceAppEvent, type KimiClientState } from '../src/api/daemon/eventReducer';
+import { messagesToTurns } from '../src/composables/messagesToTurns';
+import type { AppEvent } from '../src/api/types';
 
 describe('subagentProgressText', () => {
   it('drops turn.step.started as noise', () => {
@@ -177,5 +180,102 @@ describe('session status single-sourcing', () => {
         message: expect.objectContaining({ role: 'assistant' }),
       }),
     );
+  });
+});
+
+// Delta offsets are step-relative: the daemon's InFlightTurnTracker resets its
+// text accumulation at every turn.step.started (prior steps already live in the
+// snapshot transcript), so the projector's local counters must reset in step
+// with it.
+describe('step-boundary delta alignment', () => {
+  function applyAll(state: KimiClientState, events: AppEvent[], sid: string): KimiClientState {
+    for (const event of events) state = reduceAppEvent(state, event, { sessionId: sid, seq: 1 });
+    return state;
+  }
+
+  it('resets the offset baseline at turn.step.started', () => {
+    const projector = createAgentProjector();
+    projector.project('turn.started', { turnId: 1 }, 's1');
+    projector.project('turn.step.started', { turnId: 1, step: 1 }, 's1');
+    // Step 1 streams 50 chars.
+    projector.project('assistant.delta', { turnId: 1, delta: 'x'.repeat(50) }, 's1', { offset: 0 });
+    projector.project('turn.step.completed', { turnId: 1, step: 1 }, 's1');
+    projector.project('turn.step.started', { turnId: 1, step: 2 }, 's1');
+    // Step 2's first delta was lost in transit; the first one we see carries
+    // offset 6. Without the step-boundary reset the local baseline is still 50
+    // (step 1), so this delta — and every later delta of the step — would be
+    // silently skipped as a duplicate. With the reset the offset is ahead of
+    // local state: a recoverable gap that triggers a snapshot resync.
+    const events = projector.project('assistant.delta', { turnId: 1, delta: 'tail' }, 's1', { offset: 6 });
+    expect(events).toContainEqual(
+      expect.objectContaining({ type: 'historyCompacted', reason: 'delta_gap' }),
+    );
+  });
+
+  it('a snapshot resync mid-turn does not duplicate prior steps into a trailing blob', () => {
+    const sid = 's1';
+    const projector = createAgentProjector();
+    let state = createInitialState();
+
+    // A resync lands mid-turn (step 2 streaming). The client first replaces the
+    // message log with the snapshot transcript — every COMPLETED step with full
+    // structure (thinking + text + tool_use/tool_result), no prompt ids, exactly
+    // as the REST snapshot serves them...
+    state.messagesBySession[sid] = [
+      {
+        id: 'msg_s1_000000',
+        sessionId: sid,
+        role: 'user',
+        content: [{ type: 'text', text: 'do the thing' }],
+        createdAt: '2026-07-11T00:00:00.000Z',
+      },
+      {
+        id: 'msg_s1_000001',
+        sessionId: sid,
+        role: 'assistant',
+        content: [
+          { type: 'thinking', thinking: 'step one think' },
+          { type: 'text', text: 'step one text' },
+          { type: 'toolUse', toolCallId: 'Grep_0', toolName: 'Grep', input: { pattern: 'x' } },
+        ],
+        createdAt: '2026-07-11T00:00:01.000Z',
+      },
+      {
+        id: 'msg_s1_000002',
+        sessionId: sid,
+        role: 'tool',
+        content: [{ type: 'toolResult', toolCallId: 'Grep_0', output: 'found', isError: false }],
+        createdAt: '2026-07-11T00:00:02.000Z',
+      },
+    ];
+
+    // ...then seeds the in-flight turn, which (server-side) carries only the
+    // CURRENT step's accumulated stream.
+    const seedEvents = projector.seedInFlight(sid, {
+      turnId: 1,
+      assistantText: '',
+      thinkingText: 'step two think so far',
+      runningTools: [],
+    });
+    state = applyAll(state, seedEvents, sid);
+
+    // The seeded message holds only step 2's thinking — prior steps' text must
+    // not reappear inside it (that duplication was the giant trailing blob).
+    const seeded = seedEvents.find((e) => e.type === 'messageCreated');
+    expect(seeded).toBeDefined();
+    const seededText = JSON.stringify((seeded as { message: unknown }).message);
+    expect(seededText).not.toContain('step one text');
+    expect(seededText).not.toContain('step one think');
+
+    // The rendered turn keeps step 1's structured text + tool card and gains
+    // step 2's thinking — no giant text block trailing after them.
+    const turns = messagesToTurns(state.messagesBySession[sid] ?? [], [], undefined, true);
+    const assistantTurns = turns.filter((t) => t.role === 'assistant');
+    expect(assistantTurns).toHaveLength(1);
+    const turn = assistantTurns[0]!;
+    expect(turn.tools?.map((t) => t.name)).toEqual(['Grep']);
+    const textBlocks = (turn.blocks ?? []).filter((b) => b.kind === 'text');
+    expect(textBlocks).toHaveLength(1);
+    expect((textBlocks[0] as { kind: 'text'; text: string }).text).toBe('step one text');
   });
 });

--- a/packages/protocol/src/rest/snapshot.ts
+++ b/packages/protocol/src/rest/snapshot.ts
@@ -11,9 +11,10 @@
  * No gap and no duplication by construction: the watermark ties the REST
  * snapshot to the WS event stream.
  *
- * `in_flight_turn` carries the accumulated state of a currently-running turn
- * (volatile deltas are not replayable; this is how a reconnecting client
- * recovers mid-turn assistant/thinking text and running tool calls).
+ * `in_flight_turn` carries the accumulated state of the currently-streaming
+ * STEP (volatile deltas are not replayable; this is how a reconnecting client
+ * recovers mid-step assistant/thinking text and running tool calls). The
+ * transcript in `messages` already covers every completed step.
  *
  * The server reads the watermark, assembles the snapshot, then re-reads the
  * watermark and retries assembly if a durable event landed in between
@@ -48,9 +49,11 @@ export type InFlightToolCall = z.infer<typeof inFlightToolCallSchema>;
 
 export const inFlightTurnSchema = z.object({
   turn_id: z.number().int().nonnegative(),
-  /** Assistant text accumulated from `assistant.delta` so far. */
+  /** Assistant text accumulated from `assistant.delta` in the CURRENT step
+   *  (reset at each `turn.step.started`; prior steps live in `messages`). */
   assistant_text: z.string(),
-  /** Thinking text accumulated from `thinking.delta` so far. */
+  /** Thinking text accumulated from `thinking.delta` in the CURRENT step
+   *  (reset at each `turn.step.started`; prior steps live in `messages`). */
   thinking_text: z.string(),
   /** Tool calls started but without a `tool.result` yet. */
   running_tools: z.array(inFlightToolCallSchema),

--- a/packages/server/src/services/gateway/inFlightTurnTracker.ts
+++ b/packages/server/src/services/gateway/inFlightTurnTracker.ts
@@ -1,16 +1,22 @@
 /**
- * `InFlightTurnTracker` — accumulates the current turn's volatile stream
+ * `InFlightTurnTracker` — accumulates the current STEP's volatile stream
  * state per session so a reconnecting client can rebuild mid-turn UI from
  * the session snapshot instead of replaying deltas (which are not journaled).
+ *
+ * Accumulation resets at every `turn.step.started`: the snapshot transcript
+ * already carries every completed step's text/thinking, so `in_flight_turn`
+ * must describe only the step still streaming. Keeping the whole turn's
+ * text made seeding clients re-render every prior step's text as one giant
+ * duplicated blob appended after the structured history.
  *
  * Owned by `WSBroadcastService` and updated INSIDE its per-session dispatch
  * queue — this keeps the accumulated text, the journal watermark, and the
  * fan-out order mutually consistent without a second event subscription.
  *
  * `apply()` also returns the pre-append character offset for text-delta
- * frames; the broadcast layer stamps it on the wire envelope so clients can
- * align live deltas against snapshot text exactly (skip duplicates, detect
- * gaps).
+ * frames (step-relative, matching the accumulation); the broadcast layer
+ * stamps it on the wire envelope so clients can align live deltas against
+ * snapshot text exactly (skip duplicates, detect gaps).
  *
  * Only main-agent activity is tracked: subagent deltas share the session id
  * but describe a different stream and would corrupt the accumulation.
@@ -63,6 +69,15 @@ export class InFlightTurnTracker {
       }
       case 'turn.ended': {
         this.bySession.delete(sessionId);
+        return {};
+      }
+      case 'turn.step.started': {
+        // New step → fresh accumulation. Completed steps live in the
+        // transcript; only the streaming step belongs in `in_flight_turn`.
+        const turn = this.bySession.get(sessionId);
+        if (!turn || turn.turnId !== event.turnId) return {};
+        turn.assistantText = '';
+        turn.thinkingText = '';
         return {};
       }
       case 'assistant.delta': {

--- a/packages/server/test/inFlightTurnTracker.test.ts
+++ b/packages/server/test/inFlightTurnTracker.test.ts
@@ -1,0 +1,80 @@
+/**
+ * `InFlightTurnTracker` — the snapshot `in_flight_turn` must describe only the
+ * CURRENTLY streaming step. The snapshot transcript already carries every
+ * completed step's text/thinking; if the tracker kept accumulating across
+ * steps, a reconnecting client would re-render all prior steps' text as one
+ * duplicated blob after the structured history (the kimi-web "giant text
+ * blob" bug).
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import { InFlightTurnTracker } from '#/services/gateway/inFlightTurnTracker';
+import type { Event } from '@moonshot-ai/protocol';
+
+const SID = 'session_1';
+const MAIN = 'main';
+
+function ev(partial: Record<string, unknown>): Event {
+  return { agentId: MAIN, ...partial } as unknown as Event;
+}
+
+describe('InFlightTurnTracker', () => {
+  it('resets assistant/thinking accumulation at each turn.step.started', () => {
+    const tracker = new InFlightTurnTracker();
+    tracker.apply(SID, ev({ type: 'turn.started', turnId: 0 }));
+
+    // Step 1 streams, then completes.
+    tracker.apply(SID, ev({ type: 'turn.step.started', turnId: 0, step: 1 }));
+    tracker.apply(SID, ev({ type: 'assistant.delta', turnId: 0, delta: 'step one text ' }));
+    tracker.apply(SID, ev({ type: 'thinking.delta', turnId: 0, delta: 'step one think ' }));
+    tracker.apply(SID, ev({ type: 'turn.step.completed', turnId: 0, step: 1 }));
+
+    // Step 2 begins — step 1's text/thinking now belong to the transcript.
+    tracker.apply(SID, ev({ type: 'turn.step.started', turnId: 0, step: 2 }));
+    tracker.apply(SID, ev({ type: 'assistant.delta', turnId: 0, delta: 'step two text' }));
+
+    const snap = tracker.get(SID);
+    expect(snap?.assistant_text).toBe('step two text');
+    expect(snap?.thinking_text).toBe('');
+  });
+
+  it('stamps step-relative offsets on delta frames', () => {
+    const tracker = new InFlightTurnTracker();
+    tracker.apply(SID, ev({ type: 'turn.started', turnId: 0 }));
+    tracker.apply(SID, ev({ type: 'turn.step.started', turnId: 0, step: 1 }));
+    expect(tracker.apply(SID, ev({ type: 'assistant.delta', turnId: 0, delta: 'abcde' })).offset).toBe(0);
+    expect(tracker.apply(SID, ev({ type: 'assistant.delta', turnId: 0, delta: 'fg' })).offset).toBe(5);
+
+    // After a step boundary the offset restarts from 0.
+    tracker.apply(SID, ev({ type: 'turn.step.started', turnId: 0, step: 2 }));
+    expect(tracker.apply(SID, ev({ type: 'assistant.delta', turnId: 0, delta: 'x' })).offset).toBe(0);
+    expect(tracker.apply(SID, ev({ type: 'thinking.delta', turnId: 0, delta: 'yy' })).offset).toBe(0);
+  });
+
+  it('keeps running tool calls across the accumulation reset until their result', () => {
+    const tracker = new InFlightTurnTracker();
+    tracker.apply(SID, ev({ type: 'turn.started', turnId: 0 }));
+    tracker.apply(SID, ev({ type: 'turn.step.started', turnId: 0, step: 1 }));
+    tracker.apply(SID, ev({ type: 'assistant.delta', turnId: 0, delta: 'working' }));
+    tracker.apply(SID, ev({ type: 'tool.call.started', turnId: 0, toolCallId: 'Bash_0', name: 'Bash', args: { command: 'ls' } }));
+
+    const snap = tracker.get(SID);
+    expect(snap?.running_tools.map((t) => t.tool_call_id)).toEqual(['Bash_0']);
+
+    tracker.apply(SID, ev({ type: 'tool.result', turnId: 0, toolCallId: 'Bash_0', output: 'ok' }));
+    expect(tracker.get(SID)?.running_tools).toEqual([]);
+  });
+
+  it('ignores subagent frames and clears on turn.ended', () => {
+    const tracker = new InFlightTurnTracker();
+    tracker.apply(SID, { type: 'turn.started', turnId: 0, agentId: 'sub_1' } as unknown as Event);
+    expect(tracker.get(SID)).toBeNull();
+
+    tracker.apply(SID, ev({ type: 'turn.started', turnId: 0 }));
+    tracker.apply(SID, ev({ type: 'assistant.delta', turnId: 0, delta: 'text' }));
+    expect(tracker.get(SID)?.assistant_text).toBe('text');
+    tracker.apply(SID, ev({ type: 'turn.ended', turnId: 0, reason: 'completed' }));
+    expect(tracker.get(SID)).toBeNull();
+  });
+});


### PR DESCRIPTION
## Related Issue

No issue — the problem was reported directly with an exported session (`session_e267cc76`, protocol 1.4) plus screenshots of the web UI.

## Problem

While a multi-step agent turn is running, opening the session in kimi-web (or any WS reconnect / delta-gap resync) rebuilds the view from `GET /sessions/{sid}/snapshot` plus the live event stream. In that state the turn rendered incorrectly: every prior step's text was concatenated into one giant Markdown blob appended after the structured history, and thinking blocks / tool cards stopped rendering for the rest of the turn.

Root cause: the server's `InFlightTurnTracker` accumulates `assistant_text` / `thinking_text` from `turn.started` across **all** steps of the turn. The snapshot returns that whole-turn text as `in_flight_turn`, and the web client (`seedInFlight`) seeds a single assistant message with it — duplicating content the snapshot transcript already carries as structured per-step messages. The seeded message merges into the turn and renders as the trailing blob (with ~90 KB of duplicated thinking folded behind a teaser).

## What changed

- **Server** (`InFlightTurnTracker`): reset the text/thinking accumulation at every `turn.step.started`, so `in_flight_turn` describes only the currently-streaming step; completed steps already live in the snapshot transcript. Delta-frame offsets become step-relative to match.
- **Web** (`agentEventProjector`): reset the local delta-offset counters at `turn.step.started` so alignment stays in step with the daemon. A missed step-initial delta now surfaces as a recoverable gap (triggers resync) instead of a silent permanent skip.
- **Protocol**: document the per-step semantics of `in_flight_turn.assistant_text` / `thinking_text`.
- **Tests**: tracker unit tests (step reset, step-relative offsets, tool-call survival, subagent/turn-end handling) and web projector regression tests (offset reset at step boundary; a mid-turn resync renders prior steps as structured text + tool cards with no trailing blob).

Verified against the real session export: the seeded render now ends with `[thinking, text, tool:Read, thinking, text]` — identical structure to the vis viewer — with no blob. Changeset included (`@moonshot-ai/kimi-code` patch, `web:` entry).

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update. (Internal rendering fix — no user-facing behavior to document.)