### PR TITLE
fix(web): don't interrupt the running prompt when Escape closes a dialog

### DIFF
--- a/.changeset/web-escape-dialog-no-interrupt.md
+++ b/.changeset/web-escape-dialog-no-interrupt.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+web: Don't interrupt the running prompt when Escape closes an open dialog (such as the session search popup).

--- a/apps/kimi-web/src/components/chat/ConversationPane.vue
+++ b/apps/kimi-web/src/components/chat/ConversationPane.vue
@@ -16,6 +16,7 @@ import Spinner from '../ui/Spinner.vue';
 import Tooltip from '../ui/Tooltip.vue';
 import { getVisibleWorkspaces } from '../../lib/workspacePicker';
 import { safeRemove, STORAGE_KEYS } from '../../lib/storage';
+import { openDialogCount } from '../../composables/dialogStack';
 
 const { t, locale } = useI18n();
 
@@ -1026,6 +1027,10 @@ function handleInterrupt(): void {
 }
 
 function onKeyDown(event: KeyboardEvent): void {
+  // A modal dialog open on top of the conversation owns Escape (it closes
+  // itself); don't also interrupt the running prompt underneath. Mirrors the
+  // `anyOverlayOpen` guard in App.vue's global capture-phase Escape handler (#1538).
+  if (openDialogCount.value > 0) return;
   if (event.key === 'Escape' && (props.running || props.sending)) {
     event.preventDefault();
     handleInterrupt();


### PR DESCRIPTION
## Related Issue

Resolve #1538

## Problem

See linked issue. In Kimi Web, pressing <kbd>Esc</kbd> to close the session-search popup (`Ctrl`/`Cmd`+`K`) **while a prompt is running** also interrupts the running task.

## What changed

Root cause: `ConversationPane`'s document-level `onKeyDown` interrupts the running prompt on <kbd>Esc</kbd> (`props.running || props.sending`), but it didn't check whether a modal dialog owns <kbd>Esc</kbd>.

`App.vue`'s capture-phase global handler deliberately *leaves* <kbd>Esc</kbd> for an open dialog so the dialog can close itself (`if (anyOverlayOpen.value) return;`, no `stopPropagation`). `SearchSessionsDialog` uses the design-system `Dialog`, which closes on the `window` bubble phase and also doesn't `stopPropagation`. So one <kbd>Esc</kbd> reaches both: the `Dialog` closes the popup **and** `ConversationPane` interrupts the task.

Fix: guard `onKeyDown` with `openDialogCount` — the same signal `App.vue`'s `anyOverlayOpen` is built on — so `ConversationPane` doesn't interrupt while a modal dialog is open. With no dialog open (`openDialogCount === 0`) the interrupt behaves exactly as before. It's a two-line change mirroring the existing guard.

## Verification

- `pnpm build:packages`, `pnpm --filter @moonshot-ai/kimi-web typecheck` (vue-tsc), `test` (380 passed), `check:style`, and `oxlint` on the changed file are all clean.
- End-to-end against a live local daemon (`kimi server` + this branch's web): with a prompt running, open the search popup and press <kbd>Esc</kbd>.
  - **before:** session `status` → `aborted` (task terminated mid-run).
  - **after:** session `status` stays `running` (dialog closes, task runs to completion).

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [ ] I have added tests that prove my feature works. — kimi-web has no component-mount test harness (`@vue/test-utils` isn't a dependency), so this keyboard interaction isn't unit-testable in the current setup; verified via the full gate plus the live before/after above.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset. — changeset included (`web:` prefix, bumps `@moonshot-ai/kimi-code`).
- [x] Ran `gen-docs` skill, or this PR needs no doc update. — no user-facing docs affected.
