### PR TITLE
feat(agent-core): configurable subagent timeout with 2h default

### DIFF
--- a/.changeset/subagent-timeout-config.md
+++ b/.changeset/subagent-timeout-config.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Add a `subagent.timeout_ms` config option to control how long a single subagent may run before timing out, and raise the default from 30 minutes to 2 hours. Set `[subagent] timeout_ms` in config.toml (or the `KIMI_SUBAGENT_TIMEOUT_MS` env var) to adjust it.

--- a/docs/en/configuration/config-files.md
+++ b/docs/en/configuration/config-files.md
@@ -217,6 +217,14 @@ You can also switch models temporarily without touching the config file — by s
 
 In print mode (`kimi -p "<prompt>"`), Kimi Code by default runs a single non-interactive turn and exits as soon as the main agent finishes (`print_background_mode = "exit"`). If you launch background tasks (for example, concurrent subagents via `Agent(run_in_background=true)`, or a long command via `Bash(run_in_background=true)`) and need them to run to completion, set `print_background_mode` to `"drain"` (wait for them to finish, without feeding results back) or `"steer"` (feed each completion back to the main agent, starting a new turn so it can act on the result). `"steer"` is useful when the main agent should keep working based on the outcome of a long background task (e.g. training or evaluation); its total wall-clock is bounded by `print_wait_ceiling_s` and the number of extra turns by `print_max_turns`.
 
+## `subagent`
+
+| Field | Type | Default | Description |
+| --- | --- | --- | --- |
+| `timeout_ms` | `integer` | `7200000` (2 hours) | Maximum wall-clock time (milliseconds) a single subagent (`Agent` / `AgentSwarm`) is allowed to run before it is settled as `timed_out`. Set a very large value (e.g. `259200000`, i.e. 3 days) to effectively lift the cap. This is the background-task manager's per-task timeout for each subagent task, so it applies to both foreground and background subagents. Note: any value above `2147483647` (about 24.8 days) is clamped to 1ms by the runtime. |
+
+`timeout_ms` can be overridden by the `KIMI_SUBAGENT_TIMEOUT_MS` environment variable, which takes higher priority than `config.toml`.
+
 ## `image`
 
 `image` controls how images are compressed before being sent to the model, across every ingestion point (pasted images, `ReadMediaFile` reads, images in MCP tool results, and so on).

--- a/docs/zh/configuration/config-files.md
+++ b/docs/zh/configuration/config-files.md
@@ -217,6 +217,14 @@ display_name = "Kimi for Coding (custom)"
 
 在 print 模式（`kimi -p "<prompt>"`）下，Kimi Code 默认只跑一个非交互的单轮 turn，主 agent 一结束就退出（`print_background_mode = "exit"`）。如果你启动了后台任务（例如通过 `Agent(run_in_background=true)` 并发子代理，或 `Bash(run_in_background=true)` 的长命令）并希望它们跑完，可将 `print_background_mode` 设为 `"drain"`（等任务结束再退出，结果不回馈）或 `"steer"`（任务结束后把结果 steer 给主 agent，触发新 turn 继续处理）。`"steer"` 适合让主 agent 依据后台长任务（如训练、评测）的结果继续做后续步骤；其总耗时受 `print_wait_ceiling_s` 限制、额外 turn 数受 `print_max_turns` 限制。
 
+## `subagent`
+
+| 字段 | 类型 | 默认值 | 说明 |
+| --- | --- | --- | --- |
+| `timeout_ms` | `integer` | `7200000`（2 小时） | 单个子代理（`Agent` / `AgentSwarm`）允许运行的最长时间（毫秒）。超时后子代理以 `timed_out` 收尾。设为很大的值（例如 `259200000`，即 3 天）可近似取消上限。该值是后台任务管理器对每个子代理任务的 per-task timeout，因此对前台与后台子代理同时生效。注意：超过 `2147483647`（约 24.8 天）会被运行时钳成 1ms |
+
+`timeout_ms` 可被环境变量 `KIMI_SUBAGENT_TIMEOUT_MS` 覆盖，优先级高于配置文件。
+
 ## `image`
 
 `image` 控制图片发送给模型前的压缩行为，对所有图片入口生效（粘贴图片、`ReadMediaFile` 读图、MCP 工具结果里的图片等）。

--- a/packages/agent-core/src/agent/tool/index.ts
+++ b/packages/agent-core/src/agent/tool/index.ts
@@ -14,6 +14,7 @@ import { mcpResultToExecutableOutput } from '../../mcp/output';
 import { isMcpToolName, qualifyMcpToolName } from '../../mcp/tool-naming';
 import type { MCPClient, MCPToolDefinition } from '../../mcp/types';
 import { DEFAULT_AGENT_PROFILES } from '../../profile';
+import { resolveSubagentTimeoutMs } from '../../session/subagent-host';
 import { extendWorkspaceWithSkillRoots } from '../../skill';
 import { fingerprint } from '../llm-request-logger';
 import * as b from '../../tools/builtin';
@@ -742,10 +743,15 @@ export class ToolManager {
             {
               allowBackground,
               log: this.agent.log,
+              subagentTimeoutMs: resolveSubagentTimeoutMs(this.agent.kimiConfig?.subagent?.timeoutMs),
             },
           ),
         this.agent.subagentHost &&
-          new b.AgentSwarmTool(this.agent.subagentHost, this.agent.swarmMode),
+          new b.AgentSwarmTool(
+            this.agent.subagentHost,
+            this.agent.swarmMode,
+            resolveSubagentTimeoutMs(this.agent.kimiConfig?.subagent?.timeoutMs),
+          ),
         toolServices?.webSearcher && new b.WebSearchTool(toolServices.webSearcher),
         toolServices?.urlFetcher && new b.FetchURLTool(toolServices.urlFetcher),
       ]

--- a/packages/agent-core/src/config/schema.ts
+++ b/packages/agent-core/src/config/schema.ts
@@ -136,6 +136,12 @@ export const BackgroundConfigSchema = z.object({
 
 export type BackgroundConfig = z.infer<typeof BackgroundConfigSchema>;
 
+export const SubagentConfigSchema = z.object({
+  timeoutMs: z.number().int().min(1).optional(),
+});
+
+export type SubagentConfig = z.infer<typeof SubagentConfigSchema>;
+
 export const ImageConfigSchema = z.object({
   /**
    * Longest-edge ceiling (px) applied when compressing images for the model.
@@ -277,6 +283,7 @@ export const KimiConfigSchema = z.object({
   extraSkillDirs: z.array(z.string()).optional(),
   loopControl: LoopControlSchema.optional(),
   background: BackgroundConfigSchema.optional(),
+  subagent: SubagentConfigSchema.optional(),
   image: ImageConfigSchema.optional(),
   modelCatalog: ModelCatalogConfigSchema.optional(),
   experimental: ExperimentalConfigSchema.optional(),
@@ -292,6 +299,7 @@ const ThinkingConfigPatchSchema = ThinkingConfigSchema.partial();
 const PermissionConfigPatchSchema = PermissionConfigSchema.partial();
 const LoopControlPatchSchema = LoopControlSchema.partial();
 const BackgroundConfigPatchSchema = BackgroundConfigSchema.partial();
+const SubagentConfigPatchSchema = SubagentConfigSchema.partial();
 const ImageConfigPatchSchema = ImageConfigSchema.partial();
 const ModelCatalogConfigPatchSchema = ModelCatalogConfigSchema.partial();
 const ExperimentalConfigPatchSchema = ExperimentalConfigSchema;
@@ -319,6 +327,7 @@ export const KimiConfigPatchSchema = z
     extraSkillDirs: z.array(z.string()).optional(),
     loopControl: LoopControlPatchSchema.optional(),
     background: BackgroundConfigPatchSchema.optional(),
+    subagent: SubagentConfigPatchSchema.optional(),
     image: ImageConfigPatchSchema.optional(),
     modelCatalog: ModelCatalogConfigPatchSchema.optional(),
     experimental: ExperimentalConfigPatchSchema.optional(),

--- a/packages/agent-core/src/config/toml.ts
+++ b/packages/agent-core/src/config/toml.ts
@@ -20,6 +20,7 @@ import {
   type PermissionConfig,
   type ProviderConfig,
   type ServicesConfig,
+  type SubagentConfig,
   type ThinkingConfig,
   validateConfig,
 } from '#/config/schema';
@@ -317,6 +318,8 @@ export function transformTomlData(data: Record<string, unknown>): Record<string,
       result[targetKey] = transformPlainObject(value);
     } else if (targetKey === 'experimental' && isPlainObject(value)) {
       result[targetKey] = cloneRecord(value);
+    } else if (targetKey === 'subagent' && isPlainObject(value)) {
+      result[targetKey] = transformPlainObject(value);
     } else if (!isPlainObject(value)) {
       result[targetKey] = value;
     }
@@ -492,6 +495,7 @@ export function configToTomlData(config: KimiConfig): Record<string, unknown> {
   setSection(out, 'services', config.services, servicesToToml);
   setSection(out, 'loop_control', config.loopControl, loopControlToToml);
   setSection(out, 'background', config.background, backgroundToToml);
+  setSection(out, 'subagent', config.subagent, subagentToToml);
   setSection(out, 'image', config.image, imageToToml);
   setSection(out, 'experimental', config.experimental, experimentalToToml);
   setSection(out, 'permission', config.permission, permissionToToml);
@@ -669,6 +673,14 @@ function backgroundToToml(
 ): Record<string, unknown> {
   const out = cloneRecord(rawBackground);
   for (const [key, value] of Object.entries(background)) {
+    setDefined(out, camelToSnake(key), value);
+  }
+  return out;
+}
+
+function subagentToToml(subagent: SubagentConfig, rawSubagent: unknown): Record<string, unknown> {
+  const out = cloneRecord(rawSubagent);
+  for (const [key, value] of Object.entries(subagent)) {
     setDefined(out, camelToSnake(key), value);
   }
   return out;

--- a/packages/agent-core/src/session/subagent-host.ts
+++ b/packages/agent-core/src/session/subagent-host.ts
@@ -30,8 +30,46 @@ import {
 } from './subagent-batch';
 import SUMMARY_CONTINUATION_PROMPT from './summary-continuation.md?raw';
 
-export const DEFAULT_SUBAGENT_TIMEOUT_MS = 30 * 60 * 1000;
-export const DEFAULT_SUBAGENT_TIMEOUT_DESCRIPTION = '30 minutes';
+export const DEFAULT_SUBAGENT_TIMEOUT_MS = 2 * 60 * 60 * 1000;
+export const DEFAULT_SUBAGENT_TIMEOUT_DESCRIPTION = '2 hours';
+
+const SUBAGENT_TIMEOUT_ENV = 'KIMI_SUBAGENT_TIMEOUT_MS';
+
+/**
+ * Resolve the effective subagent per-task timeout. Precedence:
+ * `KIMI_SUBAGENT_TIMEOUT_MS` (positive integer ms) → `configMs` →
+ * `DEFAULT_SUBAGENT_TIMEOUT_MS` (30 min). Set a large value to effectively
+ * disable the cap. The value feeds the background-task manager's per-task
+ * timeout, so it governs foreground and background subagents (and AgentSwarm).
+ */
+export function resolveSubagentTimeoutMs(configMs?: number): number {
+  const raw = process.env[SUBAGENT_TIMEOUT_ENV];
+  if (raw !== undefined && raw.trim().length > 0) {
+    const parsed = Number(raw);
+    if (Number.isInteger(parsed) && parsed >= 1) return parsed;
+  }
+  if (configMs !== undefined && Number.isInteger(configMs) && configMs >= 1) {
+    return configMs;
+  }
+  return DEFAULT_SUBAGENT_TIMEOUT_MS;
+}
+
+/** Human-readable duration for the subagent timeout message. */
+export function formatSubagentTimeoutDescription(ms: number): string {
+  if (ms % (60 * 60 * 1000) === 0) {
+    const h = ms / (60 * 60 * 1000);
+    return `${h} hour${h === 1 ? '' : 's'}`;
+  }
+  if (ms % (60 * 1000) === 0) {
+    const m = ms / (60 * 1000);
+    return `${m} minute${m === 1 ? '' : 's'}`;
+  }
+  if (ms % 1000 === 0) {
+    const s = ms / 1000;
+    return `${s} second${s === 1 ? '' : 's'}`;
+  }
+  return `${ms} ms`;
+}
 
 export type {
   SubagentResult as QueuedSubagentRunResult,

--- a/packages/agent-core/src/tools/builtin/collaboration/agent-swarm.ts
+++ b/packages/agent-core/src/tools/builtin/collaboration/agent-swarm.ts
@@ -91,6 +91,7 @@ export class AgentSwarmTool implements BuiltinTool<AgentSwarmToolInput> {
   constructor(
     private readonly subagentHost: SessionSubagentHost,
     private readonly swarmMode: SwarmMode,
+    private readonly subagentTimeoutMs?: number,
   ) {}
 
   resolveExecution(args: AgentSwarmToolInput): ToolExecution {
@@ -145,7 +146,7 @@ export class AgentSwarmTool implements BuiltinTool<AgentSwarmToolInput> {
         runInBackground: false,
         swarmItem: spec.item,
         signal,
-        timeout: DEFAULT_SUBAGENT_TIMEOUT_MS,
+        timeout: this.subagentTimeoutMs ?? DEFAULT_SUBAGENT_TIMEOUT_MS,
       };
       if (spec.kind === 'resume') {
         return {

--- a/packages/agent-core/src/tools/builtin/collaboration/agent.ts
+++ b/packages/agent-core/src/tools/builtin/collaboration/agent.ts
@@ -24,8 +24,8 @@ import { isAbortError } from '../../../loop/errors';
 import type { ExecutableToolContext, ExecutableToolResult, ToolExecution } from '../../../loop/types';
 import type { ResolvedAgentProfile } from '../../../profile';
 import {
-  DEFAULT_SUBAGENT_TIMEOUT_DESCRIPTION,
   DEFAULT_SUBAGENT_TIMEOUT_MS,
+  formatSubagentTimeoutDescription,
   type SessionSubagentHost,
   type SubagentHandle,
 } from '../../../session/subagent-host';
@@ -115,10 +115,12 @@ export class AgentTool implements BuiltinTool<AgentToolInput> {
     options?: {
       log?: Logger;
       allowBackground?: boolean | undefined;
+      subagentTimeoutMs?: number | undefined;
     },
   ) {
     const log = options?.log;
     this.allowBackground = options?.allowBackground ?? true;
+    this.subagentTimeoutMs = options?.subagentTimeoutMs;
     const typeLines = buildSubagentDescriptions(subagents);
     const baseDescription = `${AGENT_DESCRIPTION_BASE}\n\n${
       this.allowBackground ? AGENT_BACKGROUND_DESCRIPTION : AGENT_BACKGROUND_DISABLED_DESCRIPTION
@@ -131,6 +133,7 @@ export class AgentTool implements BuiltinTool<AgentToolInput> {
 
   private readonly log?: Logger;
   private readonly allowBackground: boolean;
+  private readonly subagentTimeoutMs?: number;
 
   async resolveExecution(args: AgentToolInput): Promise<ToolExecution> {
     let profileName = args.subagent_type?.length ? args.subagent_type : 'coder';
@@ -228,7 +231,7 @@ export class AgentTool implements BuiltinTool<AgentToolInput> {
           new AgentBackgroundTask(handle, args.description, this.subagentHost, controller),
           {
             detached: runInBackground,
-            timeoutMs: DEFAULT_SUBAGENT_TIMEOUT_MS,
+            timeoutMs: this.subagentTimeoutMs ?? DEFAULT_SUBAGENT_TIMEOUT_MS,
             signal: runInBackground ? undefined : signal,
           },
         );
@@ -293,7 +296,7 @@ export class AgentTool implements BuiltinTool<AgentToolInput> {
     const timedOut = info?.status === 'timed_out';
     const message =
       timedOut
-        ? `Agent timed out after ${DEFAULT_SUBAGENT_TIMEOUT_DESCRIPTION}.`
+        ? `Agent timed out after ${formatSubagentTimeoutDescription(this.subagentTimeoutMs ?? DEFAULT_SUBAGENT_TIMEOUT_MS)}.`
         : info?.stopReason === 'Interrupted by user'
           ? USER_INTERRUPTED_SUBAGENT_MESSAGE
           : info?.stopReason !== undefined

--- a/packages/agent-core/test/config/configs.test.ts
+++ b/packages/agent-core/test/config/configs.test.ts
@@ -104,6 +104,9 @@ keep_alive_on_exit = false
 kill_grace_period_ms = 2000
 print_wait_ceiling_s = 3600
 
+[subagent]
+timeout_ms = 600000
+
 [image]
 max_edge_px = 1500
 read_byte_budget = 131072
@@ -185,6 +188,7 @@ describe('harness config TOML loader', () => {
       killGracePeriodMs: 2000,
       printWaitCeilingS: 3600,
     });
+    expect(config.subagent).toMatchObject({ timeoutMs: 600000 });
     expect(config.image).toEqual({ maxEdgePx: 1500, readByteBudget: 131072 });
     expect(config.hooks).toEqual([
       {

--- a/packages/agent-core/test/session/subagent-host.test.ts
+++ b/packages/agent-core/test/session/subagent-host.test.ts
@@ -13,7 +13,10 @@ import type { SDKSessionRPC } from '../../src/rpc';
 import { Session } from '../../src/session';
 import { collectGitContext } from '../../src/session/git-context';
 import {
+  DEFAULT_SUBAGENT_TIMEOUT_MS,
   SessionSubagentHost,
+  formatSubagentTimeoutDescription,
+  resolveSubagentTimeoutMs,
   type QueuedSubagentTask,
 } from '../../src/session/subagent-host';
 import { abortError, userCancellationReason } from '../../src/utils/abort';
@@ -36,6 +39,50 @@ afterEach(async () => {
   for (const dir of tempDirs.splice(0)) {
     await rm(dir, { recursive: true, force: true });
   }
+});
+
+const SUBAGENT_TIMEOUT_ENV = 'KIMI_SUBAGENT_TIMEOUT_MS';
+
+describe('resolveSubagentTimeoutMs', () => {
+  const saved: { value: string | undefined } = { value: process.env[SUBAGENT_TIMEOUT_ENV] };
+  afterEach(() => {
+    if (saved.value === undefined) {
+      delete process.env[SUBAGENT_TIMEOUT_ENV];
+    } else {
+      process.env[SUBAGENT_TIMEOUT_ENV] = saved.value;
+    }
+  });
+
+  it('returns the default when nothing is set', () => {
+    delete process.env[SUBAGENT_TIMEOUT_ENV];
+    expect(resolveSubagentTimeoutMs()).toBe(DEFAULT_SUBAGENT_TIMEOUT_MS);
+  });
+
+  it('uses the config value when set', () => {
+    delete process.env[SUBAGENT_TIMEOUT_ENV];
+    expect(resolveSubagentTimeoutMs(600000)).toBe(600000);
+  });
+
+  it('lets the env override the config value', () => {
+    process.env[SUBAGENT_TIMEOUT_ENV] = '120000';
+    expect(resolveSubagentTimeoutMs(600000)).toBe(120000);
+  });
+
+  it('ignores an invalid env and falls back to config/default', () => {
+    process.env[SUBAGENT_TIMEOUT_ENV] = 'not-a-number';
+    expect(resolveSubagentTimeoutMs(600000)).toBe(600000);
+    process.env[SUBAGENT_TIMEOUT_ENV] = '-5';
+    expect(resolveSubagentTimeoutMs()).toBe(DEFAULT_SUBAGENT_TIMEOUT_MS);
+  });
+});
+
+describe('formatSubagentTimeoutDescription', () => {
+  it('formats hours, minutes, seconds and milliseconds', () => {
+    expect(formatSubagentTimeoutDescription(30 * 60 * 1000)).toBe('30 minutes');
+    expect(formatSubagentTimeoutDescription(2 * 60 * 60 * 1000)).toBe('2 hours');
+    expect(formatSubagentTimeoutDescription(45 * 1000)).toBe('45 seconds');
+    expect(formatSubagentTimeoutDescription(1500)).toBe('1500 ms');
+  });
 });
 
 describe('SessionSubagentHost', () => {

--- a/packages/agent-core/test/tools/agent.test.ts
+++ b/packages/agent-core/test/tools/agent.test.ts
@@ -3,7 +3,11 @@ import { describe, expect, it, vi } from 'vitest';
 import { ToolAccesses } from '../../src/loop';
 import type { Logger, LogPayload } from '../../src/logging';
 import type { ResolvedAgentProfile } from '../../src/profile';
-import type { SessionSubagentHost } from '../../src/session/subagent-host';
+import {
+  DEFAULT_SUBAGENT_TIMEOUT_MS,
+  formatSubagentTimeoutDescription,
+  type SessionSubagentHost,
+} from '../../src/session/subagent-host';
 import { AgentTool, AgentToolInputSchema } from '../../src/tools/builtin/collaboration/agent';
 import { userCancellationReason } from '../../src/utils/abort';
 import { agentTask, createBackgroundManager } from '../agent/background/helpers';
@@ -467,7 +471,7 @@ describe('AgentTool', () => {
     expect(background.getTask(taskId!)).toMatchObject({
       status: 'running',
       description: 'Find cause',
-      timeoutMs: 30 * 60 * 1000,
+      timeoutMs: DEFAULT_SUBAGENT_TIMEOUT_MS,
     });
   });
 
@@ -873,14 +877,16 @@ describe('AgentTool', () => {
           description: 'Find cause',
         }),
       );
-      await vi.advanceTimersByTimeAsync(30 * 60 * 1000);
+      await vi.advanceTimersByTimeAsync(DEFAULT_SUBAGENT_TIMEOUT_MS);
       const result = await resultPromise;
 
       expect(result).toMatchObject({ isError: true });
       expect(result.output).toContain('agent_id: agent-child');
       expect(result.output).toContain('actual_subagent_type: coder');
       expect(result.output).toContain('status: failed');
-      expect(result.output).toContain('subagent error: Agent timed out after 30 minutes.');
+      expect(result.output).toContain(
+        `subagent error: Agent timed out after ${formatSubagentTimeoutDescription(DEFAULT_SUBAGENT_TIMEOUT_MS)}.`,
+      );
       expect(result.output).toContain('resume_hint:');
       expect(result.output).toContain('Agent(resume="agent-child", prompt="continue")');
       expect(result.output).toContain('do not set subagent_type');


### PR DESCRIPTION
## Summary

Make the subagent run timeout configurable instead of a hardcoded 30 minutes, and raise the default to 2 hours. This lets long-running subagents (for example training or evaluation tasks launched via `Agent` / `AgentSwarm`) run to completion, and lets users tune the cap to their needs.

## Related Issue

No linked issue — see the problem below.

## Problem

Subagents spawned by the `Agent` and `AgentSwarm` tools were always settled as `timed_out` after a hardcoded 30-minute timeout, with no way to adjust it. Long-running subagents would be killed even while still making progress, which is especially limiting for `kimi -p` sessions that are kept alive to wait on background work.

## What changed

- Added a `[subagent] timeout_ms` config option (overridable by the `KIMI_SUBAGENT_TIMEOUT_MS` env var) that replaces the hardcoded cap for both foreground and background subagents, including `AgentSwarm`.
- Raised the default subagent timeout from 30 minutes to 2 hours when the option is unset.
- Threaded the value through tool construction so the effective value is used, and the timeout message reflects it.
- Documented the option (including the 32-bit timer upper bound) and added tests for config parsing and the env / config / default resolution.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.
