### PR TITLE
fix(web): avoid repeated session list scans in sidebar computeds

### DIFF
--- a/.changeset/web-session-list-jank.md
+++ b/.changeset/web-session-list-jank.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+web: Fix sidebar lag with many sessions by removing repeated session list scans during rendering.

--- a/apps/kimi-web/src/composables/useKimiWebClient.ts
+++ b/apps/kimi-web/src/composables/useKimiWebClient.ts
@@ -1347,10 +1347,10 @@ async function reopenSession(sessionId: string): Promise<SyncSessionResult> {
     running task is its BTW side-channel agent should not look busy. When tasks
     have not been loaded yet — e.g. right after a page refresh — we trust the
     daemon-reported `running` status rather than hiding the spinner. */
-function isSessionEffectivelyRunning(sessionId: string): boolean {
-  const session = rawState.sessions.find((s) => s.id === sessionId);
+function isSessionEffectivelyRunning(session: AppSession | undefined): boolean {
   if (!session) return false;
   if (session.status !== 'running') return false;
+  const sessionId = session.id;
   const hiddenBtwAgentId = sideChat.sideChatTargetBySession.value[sessionId]?.agentId;
   const tasks = rawState.tasksBySession[sessionId] ?? [];
   const runningTasks = tasks.filter((t) => t.status === 'running');
@@ -1664,7 +1664,7 @@ const sessions = computed<Session[]>(() => {
       title: s.title,
       time: formatTime(s.updatedAt, s.status),
       status: s.status,
-      busy: isSessionEffectivelyRunning(s.id),
+      busy: isSessionEffectivelyRunning(s),
     }));
 });
 
@@ -1875,7 +1875,8 @@ const activity = computed<ActivityState>(() => {
   const questionList = rawState.questionsBySession[sid] ?? [];
   if (questionList.length > 0) return 'awaiting-question';
 
-  if (isSessionEffectivelyRunning(sid)) {
+  const activeSession = rawState.sessions.find((s) => s.id === sid);
+  if (isSessionEffectivelyRunning(activeSession)) {
     return 'running';
   }
 
@@ -2148,7 +2149,7 @@ const sessionsForView = computed<Session[]>(() => {
         title: s.title,
         time: formatTime(s.updatedAt, s.status),
         status: s.status,
-        busy: isSessionEffectivelyRunning(s.id),
+        busy: isSessionEffectivelyRunning(s),
         lastPrompt: s.lastPrompt,
         workspaceId,
         workspaceName: nameByWorkspaceId.get(workspaceId),
@@ -2170,7 +2171,7 @@ const workspaceGroups = computed<WorkspaceGroup[]>(() => {
       title: s.title,
       time: formatTime(s.updatedAt, s.status),
       status: s.status,
-      busy: isSessionEffectivelyRunning(s.id),
+      busy: isSessionEffectivelyRunning(s),
       updatedAt: s.updatedAt,
     };
     const list = byId.get(wid) ?? [];


### PR DESCRIPTION
## Related Issue

No linked issue — the problem is explained below.

## Problem

With many sessions, the web sidebar visibly stutters. A Chrome Performance recording shows animation-frame tasks of ~87–89 ms against a 16.7 ms frame budget at 60 Hz. Bottom-up attributes ~60 ms (71.5% of the selected range) to `isSessionEffectivelyRunning()` re-running `rawState.sessions.find()`: the three sidebar list computeds (`sessions`, `sessionsForView`, `workspaceGroups`) each re-scan the whole reactive session array once per row, so the per-frame work grows roughly quadratically with the session count.

## What changed

`isSessionEffectivelyRunning()` now takes the `AppSession` object the caller already holds instead of a session id:

- `sessions`, `sessionsForView`, and `workspaceGroups` pass the row's session directly — no more per-row `find()` over the whole list.
- `activity` (active session only, outside any list loop) keeps a single explicit `find()` and passes the result in.
- Not-found still returns `false`; the BTW side-chat, running-task, and tasks-not-yet-loaded rules are untouched, so all spinner behavior is identical.
- No new caches, maps, exports, or modules; this is the minimal fix. Remaining smaller hotspots (`workspaceIdForSession`, `toSorted`) are intentionally left for a follow-up only if profiling still shows long tasks.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] Behavior is unchanged and covered by the existing test suite (25 files / 380 tests pass); typecheck and production build pass. This is an internal data-passing change, so no new test file was added.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update — internal performance fix with no user-facing behavior change.