### PR TITLE
feat(oauth): parse support_efforts/default_effort in custom registry import

### DIFF
--- a/.changeset/shaggy-pandas-think.md
+++ b/.changeset/shaggy-pandas-think.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Recognize the support_efforts and default_effort fields when importing a custom registry, so thinking effort levels are available for those models.

--- a/packages/oauth/src/custom-registry.ts
+++ b/packages/oauth/src/custom-registry.ts
@@ -249,7 +249,11 @@ export async function fetchCustomRegistry(
 export function capabilitiesFromCustomEntry(model: CustomRegistryModelEntry): string[] {
   const caps = new Set<string>();
   if (model.tool_call === true) caps.add('tool_use');
-  if (model.reasoning === true) caps.add('thinking');
+  // Declaring concrete effort levels implies thinking support even when the
+  // legacy `reasoning` boolean is absent.
+  if (model.reasoning === true || (model.support_efforts?.length ?? 0) > 0) {
+    caps.add('thinking');
+  }
   if (model.modalities?.input?.includes('image') === true) caps.add('image_in');
   if (model.modalities?.input?.includes('video') === true) caps.add('video_in');
   if (model.modalities?.output?.includes('image') === true) caps.add('image_out');
@@ -261,7 +265,8 @@ function hasRichCapabilityHints(model: CustomRegistryModelEntry): boolean {
   return (
     typeof model.tool_call === 'boolean' ||
     typeof model.reasoning === 'boolean' ||
-    model.modalities !== undefined
+    model.modalities !== undefined ||
+    model.support_efforts !== undefined
   );
 }
 

--- a/packages/oauth/src/custom-registry.ts
+++ b/packages/oauth/src/custom-registry.ts
@@ -39,6 +39,8 @@ export interface CustomRegistryModelEntry {
     input?: readonly string[];
     output?: readonly string[];
   };
+  readonly support_efforts?: readonly string[];
+  readonly default_effort?: string;
 }
 
 export interface CustomRegistryProviderEntry {
@@ -102,6 +104,8 @@ function toModelEntry(value: unknown): CustomRegistryModelEntry | undefined {
     tool_call?: boolean;
     reasoning?: boolean;
     modalities?: { input?: readonly string[]; output?: readonly string[] };
+    support_efforts?: readonly string[];
+    default_effort?: string;
   } = { id };
 
   const name = value['name'];
@@ -125,6 +129,13 @@ function toModelEntry(value: unknown): CustomRegistryModelEntry | undefined {
 
   if (typeof value['tool_call'] === 'boolean') entry.tool_call = value['tool_call'];
   if (typeof value['reasoning'] === 'boolean') entry.reasoning = value['reasoning'];
+
+  const supportEfforts = toStringArrayOrUndefined(value['support_efforts']);
+  if (supportEfforts !== undefined) entry.support_efforts = supportEfforts;
+  const defaultEffort = value['default_effort'];
+  if (typeof defaultEffort === 'string' && defaultEffort.length > 0) {
+    entry.default_effort = defaultEffort;
+  }
 
   const modalities = value['modalities'];
   if (isRecord(modalities)) {
@@ -323,6 +334,8 @@ export function applyCustomRegistryProvider(
       maxContextSize,
       capabilities,
       displayName,
+      ...(model.support_efforts !== undefined ? { supportEfforts: model.support_efforts } : {}),
+      ...(model.default_effort !== undefined ? { defaultEffort: model.default_effort } : {}),
     };
     existingModels[aliasKey] = mergeRefreshedModelAlias(
       existing,

--- a/packages/oauth/src/model-alias-merge.ts
+++ b/packages/oauth/src/model-alias-merge.ts
@@ -20,6 +20,8 @@ export const CUSTOM_REGISTRY_MODEL_FIELDS: ReadonlySet<string> = new Set([
   'maxContextSize',
   'capabilities',
   'displayName',
+  'supportEfforts',
+  'defaultEffort',
 ]);
 
 function cloneOverrides(

--- a/packages/oauth/test/custom-registry.test.ts
+++ b/packages/oauth/test/custom-registry.test.ts
@@ -89,6 +89,29 @@ describe('fetchCustomRegistry', () => {
     );
   });
 
+  it('parses support_efforts and default_effort from model entries', async () => {
+    const body = makeKokubResponseBody();
+    body['registry_chat-completions']!.models['gpt-5.5'] = {
+      id: 'gpt-5.5',
+      name: 'GPT 5.5',
+      support_efforts: ['low', 'high', 'max'],
+      default_effort: 'high',
+    };
+    const fetchMock = vi.fn(async () => makeJsonResponse(body));
+
+    const result = await fetchCustomRegistry(
+      KOKUB_SOURCE,
+      fetchMock as unknown as typeof fetch,
+    );
+
+    expect(result['registry_chat-completions']?.models['gpt-5.5']).toEqual({
+      id: 'gpt-5.5',
+      name: 'GPT 5.5',
+      support_efforts: ['low', 'high', 'max'],
+      default_effort: 'high',
+    });
+  });
+
   it('omits the Authorization header when the apiKey is empty', async () => {
     const fetchMock = vi.fn(async () => makeJsonResponse(makeKokubResponseBody()));
 
@@ -328,6 +351,68 @@ describe('applyCustomRegistryProvider', () => {
           provider: 'registry_chat-completions',
           model: 'gpt-5.5',
           maxContextSize: 131072,
+          betaApi: true,
+        } as Record<string, unknown>,
+      },
+    };
+
+    applyCustomRegistryProvider(
+      config,
+      {
+        id: 'registry_chat-completions',
+        name: 'Sample Registry (chat completions)',
+        api: 'https://registry.example.test/v1',
+        type: 'openai',
+        models: {
+          'gpt-5.5': { id: 'gpt-5.5', name: 'GPT 5.5' },
+        },
+      },
+      KOKUB_SOURCE,
+    );
+
+    const alias = config.models?.['registry_chat-completions/gpt-5.5'];
+    expect(alias?.['betaApi']).toBe(true);
+    // Upstream-owned fields are still refreshed.
+    expect(alias?.['displayName']).toBe('GPT 5.5');
+  });
+
+  it('maps support_efforts / default_effort onto the model alias', () => {
+    const config: ManagedKimiConfigShape = { providers: {} };
+    const entry: CustomRegistryProviderEntry = {
+      id: 'rich',
+      name: 'Rich Provider',
+      api: 'https://rich.example/v1',
+      type: 'openai',
+      models: {
+        'rich-thinker': {
+          id: 'rich-thinker',
+          name: 'Rich Thinker',
+          reasoning: true,
+          support_efforts: ['low', 'high', 'max'],
+          default_effort: 'high',
+        },
+      },
+    };
+
+    applyCustomRegistryProvider(config, entry, {
+      kind: 'apiJson',
+      url: 'https://rich.example/api.json',
+      apiKey: 'sk-rich',
+    });
+
+    const alias = config.models?.['rich/rich-thinker'] as Record<string, unknown>;
+    expect(alias['supportEfforts']).toEqual(['low', 'high', 'max']);
+    expect(alias['defaultEffort']).toBe('high');
+  });
+
+  it('drops stale effort fields when a refresh no longer declares them', () => {
+    const config: ManagedKimiConfigShape = {
+      providers: {},
+      models: {
+        'registry_chat-completions/gpt-5.5': {
+          provider: 'registry_chat-completions',
+          model: 'gpt-5.5',
+          maxContextSize: 131072,
           supportEfforts: ['low', 'high', 'max'],
           defaultEffort: 'high',
         } as Record<string, unknown>,
@@ -349,10 +434,8 @@ describe('applyCustomRegistryProvider', () => {
     );
 
     const alias = config.models?.['registry_chat-completions/gpt-5.5'];
-    expect(alias?.['supportEfforts']).toEqual(['low', 'high', 'max']);
-    expect(alias?.['defaultEffort']).toBe('high');
-    // Upstream-owned fields are still refreshed.
-    expect(alias?.['displayName']).toBe('GPT 5.5');
+    expect(alias?.['supportEfforts']).toBeUndefined();
+    expect(alias?.['defaultEffort']).toBeUndefined();
   });
 });
 

--- a/packages/oauth/test/custom-registry.test.ts
+++ b/packages/oauth/test/custom-registry.test.ts
@@ -405,6 +405,34 @@ describe('applyCustomRegistryProvider', () => {
     expect(alias['defaultEffort']).toBe('high');
   });
 
+  it('treats support_efforts as a thinking capability hint without reasoning: true', () => {
+    const config: ManagedKimiConfigShape = { providers: {} };
+    const entry: CustomRegistryProviderEntry = {
+      id: 'rich',
+      name: 'Rich Provider',
+      api: 'https://rich.example/v1',
+      type: 'openai',
+      models: {
+        'rich-effort-only': {
+          id: 'rich-effort-only',
+          name: 'Rich Effort Only',
+          support_efforts: ['low', 'high', 'max'],
+          default_effort: 'high',
+        },
+      },
+    };
+
+    applyCustomRegistryProvider(config, entry, {
+      kind: 'apiJson',
+      url: 'https://rich.example/api.json',
+      apiKey: 'sk-rich',
+    });
+
+    const alias = config.models?.['rich/rich-effort-only'] as Record<string, unknown>;
+    expect(alias['capabilities']).toContain('thinking');
+    expect(alias['supportEfforts']).toEqual(['low', 'high', 'max']);
+  });
+
   it('drops stale effort fields when a refresh no longer declares them', () => {
     const config: ManagedKimiConfigShape = {
       providers: {},

--- a/packages/oauth/test/model-alias-merge.test.ts
+++ b/packages/oauth/test/model-alias-merge.test.ts
@@ -48,7 +48,7 @@ describe('mergeRefreshedModelAlias', () => {
     expect(merged.supportEfforts).toBeUndefined();
   });
 
-  it('keeps custom-registry supportEfforts as user data', () => {
+  it('refreshes custom-registry supportEfforts from upstream', () => {
     const merged = mergeRefreshedModelAlias(
       {
         provider: 'registry',
@@ -60,10 +60,34 @@ describe('mergeRefreshedModelAlias', () => {
         provider: 'registry',
         model: 'gpt-5.5',
         maxContextSize: 131072,
+        supportEfforts: ['low', 'high', 'max'],
+        defaultEffort: 'high',
       },
       CUSTOM_REGISTRY_MODEL_FIELDS,
     );
 
-    expect(merged.supportEfforts).toEqual(['low', 'high']);
+    expect(merged.supportEfforts).toEqual(['low', 'high', 'max']);
+    expect(merged.defaultEffort).toBe('high');
+  });
+
+  it('drops custom-registry effort fields when upstream stops declaring them', () => {
+    const merged = mergeRefreshedModelAlias(
+      {
+        provider: 'registry',
+        model: 'gpt-5.5',
+        maxContextSize: 131072,
+        supportEfforts: ['low', 'high'],
+        defaultEffort: 'high',
+      },
+      {
+        provider: 'registry',
+        model: 'gpt-5.5',
+        maxContextSize: 131072,
+      },
+      CUSTOM_REGISTRY_MODEL_FIELDS,
+    );
+
+    expect(merged.supportEfforts).toBeUndefined();
+    expect(merged.defaultEffort).toBeUndefined();
   });
 });


### PR DESCRIPTION
## Related Issue

No linked issue — the problem is explained below.

## Problem

When adding a platform via a custom registry (api.json), model entries declaring `support_efforts` / `default_effort` had those fields silently dropped: the parser only recognized `tool_call`, `reasoning`, `modalities`, and `limit`. As a result, models imported this way never exposed thinking effort levels, even though the same fields are already honored for managed Kimi Code and open-platform imports.

## What changed

- Parse `support_efforts` (string array) and `default_effort` (non-empty string) from api.json model entries in the custom-registry import path; invalid values are ignored, matching the existing lenient handling of other optional fields.
- Map them onto the generated model aliases as `supportEfforts` / `defaultEffort` — the same camelCase keys the managed and open-platform flows write, so the existing thinking-effort selection works without downstream changes.
- Add both keys to `CUSTOM_REGISTRY_MODEL_FIELDS`, making them upstream-owned: refreshes sync declared values, and stale values are dropped when upstream stops declaring them (same semantics as the managed flow).
- Tests: parsing from api.json, alias mapping, refresh overwrite / drop behavior in `custom-registry.test.ts` and `model-alias-merge.test.ts`.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.
