### PR TITLE
fix(web): match current model by id in model picker dropdown

### DIFF
--- a/.changeset/web-model-picker-id-match.md
+++ b/.changeset/web-model-picker-id-match.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+web: Fix the model dropdown showing checkmarks on same-named models from other providers; the current model is now matched by its unique model id.

--- a/apps/kimi-web/src/App.vue
+++ b/apps/kimi-web/src/App.vue
@@ -110,10 +110,8 @@ usePageTitle({ running, showAuthGate });
 // segment for the active model (effort models cycle through their declared
 // levels; boolean models flip on/off; unsupported stays off).
 function nextThinkingLevel(current: ThinkingLevel): ThinkingLevel {
-  const raw = client.status.value.modelId ?? client.status.value.model ?? '';
-  const model = client.models.value.find(
-    (m) => m.id === raw || m.model === raw || m.displayName === client.status.value.model,
-  );
+  // Identity is the model id — display/model names can collide across providers.
+  const model = client.models.value.find((m) => m.id === client.status.value.modelId);
   const segs = segmentsFor(model);
   // Coerce the stored level against the active model before indexing, so a
   // stale value (e.g. 'on' from a boolean model) doesn't resolve to index -1

--- a/apps/kimi-web/src/components/chat/Composer.vue
+++ b/apps/kimi-web/src/components/chat/Composer.vue
@@ -606,14 +606,10 @@ const ctxTooltip = computed(() => {
 const showCompact = computed(() => pct.value >= 80);
 
 // Thinking toggle
-const currentModel = computed(() => {
-  const raw = props.status?.modelId ?? props.status?.model ?? '';
-  return props.models?.find((m) =>
-    m.id === raw ||
-    m.model === raw ||
-    m.displayName === props.status?.model,
-  );
-});
+// Identity is the model id — display/model names can collide across providers.
+const currentModel = computed(() =>
+  props.models?.find((m) => m.id === props.status?.modelId),
+);
 const thinkingAvailability = computed(() => modelThinkingAvailability(currentModel.value));
 const thinkingSegments = computed(() => segmentsFor(currentModel.value));
 // The persisted level can be stale relative to the active model (e.g. a
@@ -1160,7 +1156,7 @@ function selectModel(modelId: string): void {
             role="menuitem"
             @click="selectModel(m.id)"
           >
-            <span class="md-check"><Icon v-if="m.id === status.model || m.model === status.model || m.displayName === status.model" name="check" size="sm" /></span>
+            <span class="md-check"><Icon v-if="m.id === status.modelId" name="check" size="sm" /></span>
             <span class="md-name">{{ m.displayName ?? m.model }}</span>
             <span class="md-provider">{{ m.provider }}</span>
             <Icon class="md-star" name="star" size="sm" />
@@ -1178,7 +1174,7 @@ function selectModel(modelId: string): void {
             role="menuitem"
             @click="selectModel(m.id)"
           >
-            <span class="md-check"><Icon v-if="m.id === status.model || m.model === status.model || m.displayName === status.model" name="check" size="sm" /></span>
+            <span class="md-check"><Icon v-if="m.id === status.modelId" name="check" size="sm" /></span>
             <span class="md-name">{{ m.displayName ?? m.model }}</span>
             <Icon v-if="isStarred(m.id)" class="md-star" name="star" size="sm" />
           </button>

--- a/apps/kimi-web/src/components/mobile/MobileSettingsSheet.vue
+++ b/apps/kimi-web/src/components/mobile/MobileSettingsSheet.vue
@@ -72,12 +72,10 @@ function onColorScheme(v: string): void {
 
 const PERM_MODES: PermissionMode[] = ['manual', 'auto', 'yolo'];
 
-const currentModel = computed<AppModel | undefined>(() => {
-  const raw = props.status?.modelId ?? props.status?.model ?? '';
-  return props.models?.find(
-    (m) => m.id === raw || m.model === raw || m.displayName === props.status?.model,
-  );
-});
+// Identity is the model id — display/model names can collide across providers.
+const currentModel = computed<AppModel | undefined>(() =>
+  props.models?.find((m) => m.id === props.status?.modelId),
+);
 const thinkingAvailability = computed(() => modelThinkingAvailability(currentModel.value));
 const thinkingSegments = computed(() => segmentsFor(currentModel.value));
 // The persisted level can be stale relative to the active model (e.g. 'on'

--- a/apps/kimi-web/src/composables/client/useModelProviderState.ts
+++ b/apps/kimi-web/src/composables/client/useModelProviderState.ts
@@ -102,7 +102,11 @@ export function useModelProviderState(
 
   function modelById(modelId: string | null | undefined): AppModel | undefined {
     if (modelId === undefined || modelId === null || modelId.length === 0) return undefined;
-    return models.value.find((m) => m.id === modelId || m.model === modelId);
+    // Prefer the exact id — model names can collide across providers.
+    return (
+      models.value.find((m) => m.id === modelId) ??
+      models.value.find((m) => m.model === modelId)
+    );
   }
 
   function activeThinkingModel(): AppModel | undefined {

--- a/apps/kimi-web/src/composables/useKimiWebClient.ts
+++ b/apps/kimi-web/src/composables/useKimiWebClient.ts
@@ -1950,7 +1950,11 @@ const status = computed<ConversationStatus>(() => {
 
   // Use the friendly displayName from the models list; fall back to stripping
   // the provider prefix (e.g. "moonshot/moonshot-v1-128k" → "moonshot-v1-128k").
-  const matched = modelProvider.models.value.find((m) => m.id === rawModel || m.model === rawModel);
+  // Prefer the exact id — model names can collide across providers, so a
+  // name-only match may resolve to the wrong provider's entry.
+  const matched =
+    modelProvider.models.value.find((m) => m.id === rawModel) ??
+    modelProvider.models.value.find((m) => m.model === rawModel);
   const displayModel =
     matched?.displayName ||
     matched?.model ||


### PR DESCRIPTION
## Related Issue

No linked issue — the problem is explained below.

## Problem

In the web UI composer's model quick-switch dropdown, the checkmark for the current model was matched by name (`m.id === status.model || m.model === status.model || m.displayName === status.model`). Different providers can serve models with identical display names, so every same-named entry across providers showed a checkmark at once — misleading about which model is actually active.

## What changed

Match the current model by its unique `AppModel.id` everywhere instead of by name:

- `Composer.vue`: the dropdown checkmark condition is now `m.id === status.modelId`, consistent with the existing `is-current` row highlight; the `currentModel` computed that drives the thinking-level controls also resolves by id.
- `useKimiWebClient.ts`: `status.modelId` resolution now prefers an exact id match and only falls back to a model-name match, so a bare model name in `session.model` still resolves to a single entry.
- `MobileSettingsSheet.vue` and `App.vue` (`nextThinkingLevel`): same id-based resolution for the thinking controls.
- `useModelProviderState.ts`: `modelById` prefers exact id match before the name fallback.

`vue-tsc` typecheck and the full `kimi-web` vitest suite (380 tests) pass.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [ ] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.
