### PR TITLE
fix(web): persist server access token across tabs and browser restarts

### DIFF
--- a/.changeset/web-persist-server-token.md
+++ b/.changeset/web-persist-server-token.md
@@ -2,4 +2,4 @@
 "@moonshot-ai/kimi-code": patch
 ---
 
-web: Keep the server access token across tab close and browser restarts, so it only needs to be entered once per device instead of after every new tab.
+web: Keep the server access token for up to 7 days across tab close and browser restarts, instead of asking for it again with every new tab.

--- a/.changeset/web-persist-server-token.md
+++ b/.changeset/web-persist-server-token.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+web: Keep the server access token across tab close and browser restarts, so it only needs to be entered once per device instead of after every new tab.

--- a/apps/kimi-web/src/App.vue
+++ b/apps/kimi-web/src/App.vue
@@ -46,7 +46,7 @@ import Icon from './components/ui/Icon.vue';
 import InternalBuildBanner from './components/InternalBuildBanner.vue';
 import { isMacosDesktop } from './lib/desktopFlag';
 
-// Hydrate the server-transport credential (fragment token or sessionStorage)
+// Hydrate the server-transport credential (fragment token or localStorage)
 // BEFORE the client connects, so the first REST/WS calls already carry it.
 const hasServerCredential = initServerAuth();
 const authRequired = ref(!hasServerCredential);

--- a/apps/kimi-web/src/api/daemon/serverAuth.ts
+++ b/apps/kimi-web/src/api/daemon/serverAuth.ts
@@ -9,17 +9,24 @@
 //      does not linger in history or screenshots.
 //   2. From a token the user types into the ServerAuthDialog modal.
 //
-// The credential is held in memory and mirrored to localStorage so it survives
-// tab close and browser restarts — entering it once per device is enough. The
-// token is already persisted server-side at <KIMI_CODE_HOME>/server.token and
-// handed to the browser in the launch URL, so keeping it in the browser profile
-// does not materially widen exposure for this local tool. `kimi server
-// rotate-token` invalidates a stale copy, and the next 401 clears it here.
+// The credential is held in memory and mirrored to localStorage for up to 7
+// days so it survives tab close and browser restarts without becoming a
+// permanent browser-profile secret. The token is already persisted server-side
+// at <KIMI_CODE_HOME>/server.token and handed to the browser in the launch URL.
+// `kimi server rotate-token` invalidates a stale copy, and the next 401 clears
+// it here.
 
 const STORAGE_KEY = 'kimi-web.server-credential';
 const FRAGMENT_PARAM = 'token';
+const CREDENTIAL_TTL_MS = 7 * 24 * 60 * 60 * 1000;
 
-let memory: string | undefined;
+interface StoredCredential {
+  version: 1;
+  credential: string;
+  expiresAt: number;
+}
+
+let memory: StoredCredential | undefined;
 
 type AuthRequiredListener = () => void;
 const listeners = new Set<AuthRequiredListener>();
@@ -43,18 +50,115 @@ function readFragmentToken(): string | undefined {
   return token;
 }
 
-function loadStored(): string | undefined {
+function createStoredCredential(credential: string): StoredCredential {
+  return {
+    version: 1,
+    credential,
+    expiresAt: Date.now() + CREDENTIAL_TTL_MS,
+  };
+}
+
+function encodeStoredCredential(stored: StoredCredential): string {
+  return JSON.stringify(stored);
+}
+
+function decodeStoredCredential(raw: string): StoredCredential | undefined {
   try {
-    const stored = globalThis.localStorage?.getItem(STORAGE_KEY);
-    if (stored) return stored;
+    const parsed = JSON.parse(raw) as unknown;
+    if (typeof parsed !== 'object' || parsed === null) return undefined;
+    const record = parsed as Record<string, unknown>;
+    if (
+      record['version'] !== 1 ||
+      typeof record['credential'] !== 'string' ||
+      record['credential'].length === 0 ||
+      typeof record['expiresAt'] !== 'number' ||
+      !Number.isFinite(record['expiresAt'])
+    ) {
+      return undefined;
+    }
+    return {
+      version: 1,
+      credential: record['credential'],
+      expiresAt: record['expiresAt'],
+    };
+  } catch {
+    return undefined;
+  }
+}
+
+function persistCredential(stored: StoredCredential): void {
+  globalThis.localStorage?.setItem(
+    STORAGE_KEY,
+    encodeStoredCredential(stored),
+  );
+}
+
+function loadStored(): StoredCredential | undefined {
+  try {
+    const raw = globalThis.localStorage?.getItem(STORAGE_KEY);
+    if (raw) {
+      const stored = decodeStoredCredential(raw);
+      if (stored === undefined) {
+        // Upgrade values written by the initial localStorage implementation,
+        // before persisted credentials carried an expiry timestamp.
+        const migrated = createStoredCredential(raw);
+        let migrationRecorded = false;
+        try {
+          persistCredential(migrated);
+          migrationRecorded = true;
+        } catch {
+          // If the expiring record cannot be written, remove the undated value
+          // so a reload cannot grant it a fresh 7-day window again.
+        }
+        if (!migrationRecorded) {
+          try {
+            if (globalThis.localStorage?.getItem(STORAGE_KEY) === raw) {
+              globalThis.localStorage?.removeItem(STORAGE_KEY);
+            }
+            migrationRecorded = true;
+          } catch {
+            // Neither persisting nor removing succeeded; do not use a value
+            // whose lifetime cannot be bounded.
+          }
+        }
+        try {
+          globalThis.sessionStorage?.removeItem(STORAGE_KEY);
+        } catch {
+          // The local migration result above still determines whether it is safe.
+        }
+        return migrationRecorded ? migrated : undefined;
+      }
+      if (stored.expiresAt > Date.now()) return stored;
+      // Do not revive an expired local credential from a leftover legacy
+      // sessionStorage copy. Clear that tab-local copy first; if it cannot be
+      // removed, keep the expired local record as a tombstone that prevents
+      // the legacy value from receiving a new 7-day window on reload.
+      globalThis.sessionStorage?.removeItem(STORAGE_KEY);
+      if (globalThis.localStorage?.getItem(STORAGE_KEY) === raw) {
+        globalThis.localStorage?.removeItem(STORAGE_KEY);
+      }
+      return undefined;
+    }
     // One-time upgrade: older builds kept the credential in sessionStorage
     // (tab-scoped). Adopt it into localStorage so the update itself does not
     // force the re-entry this change is meant to eliminate.
     const legacy = globalThis.sessionStorage?.getItem(STORAGE_KEY);
     if (legacy) {
-      globalThis.localStorage?.setItem(STORAGE_KEY, legacy);
-      globalThis.sessionStorage?.removeItem(STORAGE_KEY);
-      return legacy;
+      const migrated = createStoredCredential(legacy);
+      let migrationRecorded = false;
+      try {
+        persistCredential(migrated);
+        migrationRecorded = true;
+      } catch {
+        // Fall through and try to discard the undated session copy instead.
+      }
+      try {
+        globalThis.sessionStorage?.removeItem(STORAGE_KEY);
+        migrationRecorded = true;
+      } catch {
+        // If both operations fail, its lifetime cannot be bounded.
+      }
+      return migrationRecorded ? migrated : undefined;
     }
     return undefined;
   } catch {
@@ -77,16 +181,44 @@ export function initServerAuth(): boolean {
   return memory !== undefined;
 }
 
-/** Current credential, or undefined if none has been provided yet. */
+/** Current unexpired credential, or undefined if none is available. */
 export function getCredential(): string | undefined {
-  return memory;
+  if (memory === undefined) return undefined;
+  if (memory.expiresAt <= Date.now()) {
+    clearExpiredCredential(memory);
+    return undefined;
+  }
+  return memory.credential;
 }
 
-/** Store a credential (memory + localStorage) for subsequent requests. */
-export function setCredential(value: string): void {
-  memory = value;
+function clearExpiredCredential(expired: StoredCredential): void {
+  memory = undefined;
   try {
-    globalThis.localStorage?.setItem(STORAGE_KEY, value);
+    // Keep the expired local record as a tombstone if the legacy session copy
+    // cannot be cleared; otherwise a reload could migrate it into a fresh TTL.
+    globalThis.sessionStorage?.removeItem(STORAGE_KEY);
+    const raw = globalThis.localStorage?.getItem(STORAGE_KEY);
+    const stored = raw === null || raw === undefined
+      ? undefined
+      : decodeStoredCredential(raw);
+    const matchesExpired = stored === undefined
+      ? raw === expired.credential
+      : stored.credential === expired.credential &&
+        stored.expiresAt === expired.expiresAt;
+    if (matchesExpired) {
+      globalThis.localStorage?.removeItem(STORAGE_KEY);
+    }
+  } catch {
+    // ignore
+  }
+}
+
+/** Store a credential in memory and in localStorage for up to 7 days. */
+export function setCredential(value: string): void {
+  const stored = createStoredCredential(value);
+  memory = stored;
+  try {
+    persistCredential(stored);
     // Drop any legacy sessionStorage copy so the two stores cannot diverge.
     globalThis.sessionStorage?.removeItem(STORAGE_KEY);
   } catch {
@@ -103,10 +235,14 @@ export function clearCredential(): void {
     // tab was using. localStorage is shared across tabs, so an unconditional
     // removal would let a stale tab erase a newer token another tab stored
     // (e.g. right after `kimi server rotate-token`).
-    if (
-      rejected !== undefined &&
-      globalThis.localStorage?.getItem(STORAGE_KEY) === rejected
-    ) {
+    const raw = globalThis.localStorage?.getItem(STORAGE_KEY);
+    const stored = raw === null || raw === undefined
+      ? undefined
+      : decodeStoredCredential(raw);
+    const persistedCredential = stored?.credential ?? raw;
+    const matchesRejected = rejected !== undefined &&
+      persistedCredential === rejected.credential;
+    if (matchesRejected) {
       globalThis.localStorage?.removeItem(STORAGE_KEY);
     }
     // sessionStorage is tab-scoped (legacy store) — clearing it cannot

--- a/apps/kimi-web/src/api/daemon/serverAuth.ts
+++ b/apps/kimi-web/src/api/daemon/serverAuth.ts
@@ -219,10 +219,17 @@ export function setCredential(value: string): void {
   memory = stored;
   try {
     persistCredential(stored);
-    // Drop any legacy sessionStorage copy so the two stores cannot diverge.
-    globalThis.sessionStorage?.removeItem(STORAGE_KEY);
   } catch {
     // Storage may be unavailable (private mode) — memory still works.
+  }
+  try {
+    // Drop any legacy sessionStorage copy so the two stores cannot diverge.
+    // Best-effort even when localStorage is blocked — otherwise a stale
+    // session-scoped value left behind gets re-migrated (and 401s) on the
+    // next reload.
+    globalThis.sessionStorage?.removeItem(STORAGE_KEY);
+  } catch {
+    // ignore
   }
 }
 

--- a/apps/kimi-web/src/api/daemon/serverAuth.ts
+++ b/apps/kimi-web/src/api/daemon/serverAuth.ts
@@ -96,9 +96,21 @@ export function setCredential(value: string): void {
 
 /** Drop the credential (memory + localStorage). */
 export function clearCredential(): void {
+  const rejected = memory;
   memory = undefined;
   try {
-    globalThis.localStorage?.removeItem(STORAGE_KEY);
+    // Only clear the persisted copy when it still holds the credential this
+    // tab was using. localStorage is shared across tabs, so an unconditional
+    // removal would let a stale tab erase a newer token another tab stored
+    // (e.g. right after `kimi server rotate-token`).
+    if (
+      rejected !== undefined &&
+      globalThis.localStorage?.getItem(STORAGE_KEY) === rejected
+    ) {
+      globalThis.localStorage?.removeItem(STORAGE_KEY);
+    }
+    // sessionStorage is tab-scoped (legacy store) — clearing it cannot
+    // affect other tabs.
     globalThis.sessionStorage?.removeItem(STORAGE_KEY);
   } catch {
     // ignore

--- a/apps/kimi-web/src/api/daemon/serverAuth.ts
+++ b/apps/kimi-web/src/api/daemon/serverAuth.ts
@@ -9,10 +9,12 @@
 //      does not linger in history or screenshots.
 //   2. From a token the user types into the ServerAuthDialog modal.
 //
-// The credential is held in memory and mirrored to sessionStorage so a page
-// refresh keeps working without re-prompting (sessionStorage is tab-scoped and
-// cleared when the tab closes — we deliberately do NOT use localStorage, since
-// the credential authenticates as the server).
+// The credential is held in memory and mirrored to localStorage so it survives
+// tab close and browser restarts — entering it once per device is enough. The
+// token is already persisted server-side at <KIMI_CODE_HOME>/server.token and
+// handed to the browser in the launch URL, so keeping it in the browser profile
+// does not materially widen exposure for this local tool. `kimi server
+// rotate-token` invalidates a stale copy, and the next 401 clears it here.
 
 const STORAGE_KEY = 'kimi-web.server-credential';
 const FRAGMENT_PARAM = 'token';
@@ -43,7 +45,18 @@ function readFragmentToken(): string | undefined {
 
 function loadStored(): string | undefined {
   try {
-    return globalThis.sessionStorage?.getItem(STORAGE_KEY) ?? undefined;
+    const stored = globalThis.localStorage?.getItem(STORAGE_KEY);
+    if (stored) return stored;
+    // One-time upgrade: older builds kept the credential in sessionStorage
+    // (tab-scoped). Adopt it into localStorage so the update itself does not
+    // force the re-entry this change is meant to eliminate.
+    const legacy = globalThis.sessionStorage?.getItem(STORAGE_KEY);
+    if (legacy) {
+      globalThis.localStorage?.setItem(STORAGE_KEY, legacy);
+      globalThis.sessionStorage?.removeItem(STORAGE_KEY);
+      return legacy;
+    }
+    return undefined;
   } catch {
     return undefined;
   }
@@ -69,20 +82,23 @@ export function getCredential(): string | undefined {
   return memory;
 }
 
-/** Store a credential (memory + sessionStorage) for subsequent requests. */
+/** Store a credential (memory + localStorage) for subsequent requests. */
 export function setCredential(value: string): void {
   memory = value;
   try {
-    globalThis.sessionStorage?.setItem(STORAGE_KEY, value);
+    globalThis.localStorage?.setItem(STORAGE_KEY, value);
+    // Drop any legacy sessionStorage copy so the two stores cannot diverge.
+    globalThis.sessionStorage?.removeItem(STORAGE_KEY);
   } catch {
-    // sessionStorage may be unavailable (private mode) — memory still works.
+    // Storage may be unavailable (private mode) — memory still works.
   }
 }
 
-/** Drop the credential (memory + sessionStorage). */
+/** Drop the credential (memory + localStorage). */
 export function clearCredential(): void {
   memory = undefined;
   try {
+    globalThis.localStorage?.removeItem(STORAGE_KEY);
     globalThis.sessionStorage?.removeItem(STORAGE_KEY);
   } catch {
     // ignore

--- a/apps/kimi-web/test/server-auth.test.ts
+++ b/apps/kimi-web/test/server-auth.test.ts
@@ -1,0 +1,163 @@
+// apps/kimi-web/test/server-auth.test.ts
+// Credential store for the server bearer token: localStorage persistence,
+// one-time sessionStorage migration, fragment-token intake, and the
+// markAuthRequired clearing path.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const STORAGE_KEY = 'kimi-web.server-credential';
+
+function createMemoryStorage(): Storage {
+  const data = new Map<string, string>();
+  return {
+    get length() {
+      return data.size;
+    },
+    clear() {
+      data.clear();
+    },
+    getItem(key: string) {
+      return data.get(key) ?? null;
+    },
+    key(index: number) {
+      return Array.from(data.keys()).at(index) ?? null;
+    },
+    removeItem(key: string) {
+      data.delete(key);
+    },
+    setItem(key: string, value: string) {
+      data.set(key, String(value));
+    },
+  };
+}
+
+let localStore: Storage;
+let sessionStore: Storage;
+
+/** Fresh module instance per test — the store keeps module-level state. */
+async function loadAuth() {
+  vi.resetModules();
+  return await import('../src/api/daemon/serverAuth');
+}
+
+beforeEach(() => {
+  localStore = createMemoryStorage();
+  sessionStore = createMemoryStorage();
+  Object.defineProperty(globalThis, 'localStorage', { configurable: true, value: localStore });
+  Object.defineProperty(globalThis, 'sessionStorage', { configurable: true, value: sessionStore });
+});
+
+afterEach(() => {
+  delete (globalThis as { window?: unknown }).window;
+});
+
+describe('credential persistence', () => {
+  it('round-trips through localStorage across module reloads', async () => {
+    const auth = await loadAuth();
+    auth.setCredential('tok-1');
+    expect(auth.getCredential()).toBe('tok-1');
+    expect(localStore.getItem(STORAGE_KEY)).toBe('tok-1');
+
+    // Simulate a full page reload: fresh module state, same browser storage.
+    const reloaded = await loadAuth();
+    expect(reloaded.initServerAuth()).toBe(true);
+    expect(reloaded.getCredential()).toBe('tok-1');
+  });
+
+  it('clearCredential drops the persisted copy', async () => {
+    const auth = await loadAuth();
+    auth.setCredential('tok-1');
+    auth.clearCredential();
+    expect(auth.getCredential()).toBeUndefined();
+    expect(localStore.getItem(STORAGE_KEY)).toBeNull();
+  });
+
+  it('adopts a legacy sessionStorage credential into localStorage', async () => {
+    sessionStore.setItem(STORAGE_KEY, 'legacy-tok');
+    const auth = await loadAuth();
+    expect(auth.initServerAuth()).toBe(true);
+    expect(auth.getCredential()).toBe('legacy-tok');
+    expect(localStore.getItem(STORAGE_KEY)).toBe('legacy-tok');
+    expect(sessionStore.getItem(STORAGE_KEY)).toBeNull();
+  });
+
+  it('setCredential removes any legacy sessionStorage copy', async () => {
+    sessionStore.setItem(STORAGE_KEY, 'legacy-tok');
+    const auth = await loadAuth();
+    auth.setCredential('tok-2');
+    expect(sessionStore.getItem(STORAGE_KEY)).toBeNull();
+    expect(localStore.getItem(STORAGE_KEY)).toBe('tok-2');
+  });
+
+  it('keeps working in memory when storage throws', async () => {
+    const throwing = createMemoryStorage();
+    throwing.setItem = () => {
+      throw new Error('denied');
+    };
+    throwing.getItem = () => {
+      throw new Error('denied');
+    };
+    Object.defineProperty(globalThis, 'localStorage', { configurable: true, value: throwing });
+    Object.defineProperty(globalThis, 'sessionStorage', { configurable: true, value: throwing });
+
+    const auth = await loadAuth();
+    expect(auth.initServerAuth()).toBe(false);
+    auth.setCredential('tok-mem');
+    expect(auth.getCredential()).toBe('tok-mem');
+    expect(() => auth.clearCredential()).not.toThrow();
+  });
+});
+
+describe('fragment token intake', () => {
+  function installWindow(hash: string) {
+    const replaceState = vi.fn();
+    const win = {
+      location: {
+        hash,
+        href: `http://localhost:58627/some/path?x=1${hash}`,
+      },
+      history: { state: null, replaceState },
+    };
+    Object.defineProperty(globalThis, 'window', { configurable: true, value: win });
+    return { replaceState };
+  }
+
+  it('prefers the fragment token, stores it, and scrubs the URL', async () => {
+    localStore.setItem(STORAGE_KEY, 'stored-tok');
+    const { replaceState } = installWindow('#token=frag-tok');
+    const auth = await loadAuth();
+
+    expect(auth.initServerAuth()).toBe(true);
+    expect(auth.getCredential()).toBe('frag-tok');
+    expect(localStore.getItem(STORAGE_KEY)).toBe('frag-tok');
+    // Fragment scrubbed: path + query kept, token gone.
+    expect(replaceState).toHaveBeenCalledWith(null, '', '/some/path?x=1');
+  });
+
+  it('ignores an empty fragment and falls back to storage', async () => {
+    localStore.setItem(STORAGE_KEY, 'stored-tok');
+    installWindow('');
+    const auth = await loadAuth();
+
+    expect(auth.initServerAuth()).toBe(true);
+    expect(auth.getCredential()).toBe('stored-tok');
+  });
+});
+
+describe('markAuthRequired', () => {
+  it('clears the credential and notifies listeners', async () => {
+    const auth = await loadAuth();
+    auth.setCredential('tok-1');
+    const listener = vi.fn();
+    const off = auth.onAuthRequired(listener);
+
+    auth.markAuthRequired();
+    expect(auth.getCredential()).toBeUndefined();
+    expect(localStore.getItem(STORAGE_KEY)).toBeNull();
+    expect(listener).toHaveBeenCalledTimes(1);
+
+    off();
+    auth.markAuthRequired();
+    expect(listener).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/kimi-web/test/server-auth.test.ts
+++ b/apps/kimi-web/test/server-auth.test.ts
@@ -218,6 +218,23 @@ describe('credential persistence', () => {
     expect(readStoredCredential()?.credential).toBe('tok-2');
   });
 
+  it('removes the legacy sessionStorage copy even when localStorage is blocked', async () => {
+    const blockedLocal = createMemoryStorage();
+    blockedLocal.setItem = () => {
+      throw new Error('denied');
+    };
+    Object.defineProperty(globalThis, 'localStorage', { configurable: true, value: blockedLocal });
+    sessionStore.setItem(STORAGE_KEY, 'legacy-tok');
+
+    const auth = await loadAuth();
+    auth.setCredential('tok-new');
+
+    // The credential lives in memory only, but the stale session copy must
+    // not survive to be re-migrated on the next reload.
+    expect(auth.getCredential()).toBe('tok-new');
+    expect(sessionStore.getItem(STORAGE_KEY)).toBeNull();
+  });
+
   it('keeps working in memory when storage throws', async () => {
     const throwing = createMemoryStorage();
     throwing.setItem = () => {

--- a/apps/kimi-web/test/server-auth.test.ts
+++ b/apps/kimi-web/test/server-auth.test.ts
@@ -161,3 +161,33 @@ describe('markAuthRequired', () => {
     expect(listener).toHaveBeenCalledTimes(1);
   });
 });
+
+describe('cross-tab credential clearing', () => {
+  it('keeps a newer token another tab persisted when this tab is stale', async () => {
+    const auth = await loadAuth();
+    auth.setCredential('stale-tok');
+    // Another tab stores a fresh token (e.g. after rotation + `kimi web`).
+    localStore.setItem(STORAGE_KEY, 'fresh-tok');
+
+    auth.markAuthRequired();
+
+    // This tab forgets its rejected credential and prompts…
+    expect(auth.getCredential()).toBeUndefined();
+    // …but the fresh shared token survives for reloads and other tabs.
+    expect(localStore.getItem(STORAGE_KEY)).toBe('fresh-tok');
+  });
+
+  it('clears the persisted copy when it still matches the rejected credential', async () => {
+    const auth = await loadAuth();
+    auth.setCredential('tok-1');
+    auth.markAuthRequired();
+    expect(localStore.getItem(STORAGE_KEY)).toBeNull();
+  });
+
+  it('does not clear another tab’s token when this tab had no credential', async () => {
+    localStore.setItem(STORAGE_KEY, 'fresh-tok');
+    const auth = await loadAuth();
+    auth.markAuthRequired();
+    expect(localStore.getItem(STORAGE_KEY)).toBe('fresh-tok');
+  });
+});

--- a/apps/kimi-web/test/server-auth.test.ts
+++ b/apps/kimi-web/test/server-auth.test.ts
@@ -1,11 +1,19 @@
 // apps/kimi-web/test/server-auth.test.ts
-// Credential store for the server bearer token: localStorage persistence,
-// one-time sessionStorage migration, fragment-token intake, and the
+// Credential store for the server bearer token: expiring localStorage
+// persistence, one-time storage migration, fragment-token intake, and the
 // markAuthRequired clearing path.
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const STORAGE_KEY = 'kimi-web.server-credential';
+const DAY_MS = 24 * 60 * 60 * 1000;
+const NOW = Date.parse('2026-07-12T00:00:00Z');
+
+interface StoredCredential {
+  version: 1;
+  credential: string;
+  expiresAt: number;
+}
 
 function createMemoryStorage(): Storage {
   const data = new Map<string, string>();
@@ -34,6 +42,22 @@ function createMemoryStorage(): Storage {
 let localStore: Storage;
 let sessionStore: Storage;
 
+function writeStoredCredential(
+  credential: string,
+  expiresAt = Date.now() + 7 * DAY_MS,
+): void {
+  localStore.setItem(STORAGE_KEY, JSON.stringify({
+    version: 1,
+    credential,
+    expiresAt,
+  } satisfies StoredCredential));
+}
+
+function readStoredCredential(): StoredCredential | undefined {
+  const raw = localStore.getItem(STORAGE_KEY);
+  return raw === null ? undefined : JSON.parse(raw) as StoredCredential;
+}
+
 /** Fresh module instance per test — the store keeps module-level state. */
 async function loadAuth() {
   vi.resetModules();
@@ -41,6 +65,8 @@ async function loadAuth() {
 }
 
 beforeEach(() => {
+  vi.useFakeTimers();
+  vi.setSystemTime(NOW);
   localStore = createMemoryStorage();
   sessionStore = createMemoryStorage();
   Object.defineProperty(globalThis, 'localStorage', { configurable: true, value: localStore });
@@ -49,6 +75,7 @@ beforeEach(() => {
 
 afterEach(() => {
   delete (globalThis as { window?: unknown }).window;
+  vi.useRealTimers();
 });
 
 describe('credential persistence', () => {
@@ -56,12 +83,41 @@ describe('credential persistence', () => {
     const auth = await loadAuth();
     auth.setCredential('tok-1');
     expect(auth.getCredential()).toBe('tok-1');
-    expect(localStore.getItem(STORAGE_KEY)).toBe('tok-1');
+    expect(readStoredCredential()).toEqual({
+      version: 1,
+      credential: 'tok-1',
+      expiresAt: NOW + 7 * DAY_MS,
+    });
 
     // Simulate a full page reload: fresh module state, same browser storage.
     const reloaded = await loadAuth();
     expect(reloaded.initServerAuth()).toBe(true);
     expect(reloaded.getCredential()).toBe('tok-1');
+  });
+
+  it('expires 7 days after write without extending on reads', async () => {
+    const auth = await loadAuth();
+    auth.setCredential('tok-1');
+
+    vi.setSystemTime(NOW + 6 * DAY_MS);
+    const beforeExpiry = await loadAuth();
+    expect(beforeExpiry.initServerAuth()).toBe(true);
+    expect(readStoredCredential()?.expiresAt).toBe(NOW + 7 * DAY_MS);
+
+    vi.setSystemTime(NOW + 7 * DAY_MS);
+    const expired = await loadAuth();
+    expect(expired.initServerAuth()).toBe(false);
+    expect(expired.getCredential()).toBeUndefined();
+    expect(localStore.getItem(STORAGE_KEY)).toBeNull();
+  });
+
+  it('stops using an in-memory credential when its 7 days expire', async () => {
+    const auth = await loadAuth();
+    auth.setCredential('tok-1');
+
+    vi.setSystemTime(NOW + 7 * DAY_MS);
+    expect(auth.getCredential()).toBeUndefined();
+    expect(localStore.getItem(STORAGE_KEY)).toBeNull();
   });
 
   it('clearCredential drops the persisted copy', async () => {
@@ -77,8 +133,81 @@ describe('credential persistence', () => {
     const auth = await loadAuth();
     expect(auth.initServerAuth()).toBe(true);
     expect(auth.getCredential()).toBe('legacy-tok');
-    expect(localStore.getItem(STORAGE_KEY)).toBe('legacy-tok');
+    expect(readStoredCredential()).toEqual({
+      version: 1,
+      credential: 'legacy-tok',
+      expiresAt: NOW + 7 * DAY_MS,
+    });
     expect(sessionStore.getItem(STORAGE_KEY)).toBeNull();
+  });
+
+  it('adds an expiry to a credential stored by the earlier localStorage format', async () => {
+    localStore.setItem(STORAGE_KEY, 'legacy-local-tok');
+    const auth = await loadAuth();
+
+    expect(auth.initServerAuth()).toBe(true);
+    expect(auth.getCredential()).toBe('legacy-local-tok');
+    expect(readStoredCredential()).toEqual({
+      version: 1,
+      credential: 'legacy-local-tok',
+      expiresAt: NOW + 7 * DAY_MS,
+    });
+  });
+
+  it('keeps using a legacy session credential when localStorage migration fails', async () => {
+    sessionStore.setItem(STORAGE_KEY, 'legacy-tok');
+    localStore.setItem = () => {
+      throw new Error('quota exceeded');
+    };
+    const auth = await loadAuth();
+
+    expect(auth.initServerAuth()).toBe(true);
+    expect(auth.getCredential()).toBe('legacy-tok');
+    expect(sessionStore.getItem(STORAGE_KEY)).toBeNull();
+
+    const reloaded = await loadAuth();
+    expect(reloaded.initServerAuth()).toBe(false);
+  });
+
+  it('does not grant a fresh window on reload when legacy local migration fails', async () => {
+    localStore.setItem(STORAGE_KEY, 'legacy-local-tok');
+    localStore.setItem = () => {
+      throw new Error('quota exceeded');
+    };
+    const auth = await loadAuth();
+
+    expect(auth.initServerAuth()).toBe(true);
+    expect(auth.getCredential()).toBe('legacy-local-tok');
+    expect(localStore.getItem(STORAGE_KEY)).toBeNull();
+
+    const reloaded = await loadAuth();
+    expect(reloaded.initServerAuth()).toBe(false);
+  });
+
+  it('does not revive an expired credential from legacy sessionStorage', async () => {
+    writeStoredCredential('expired-tok', NOW);
+    sessionStore.setItem(STORAGE_KEY, 'expired-tok');
+    const auth = await loadAuth();
+
+    expect(auth.initServerAuth()).toBe(false);
+    expect(auth.getCredential()).toBeUndefined();
+    expect(localStore.getItem(STORAGE_KEY)).toBeNull();
+    expect(sessionStore.getItem(STORAGE_KEY)).toBeNull();
+  });
+
+  it('keeps an expired record when legacy session cleanup fails', async () => {
+    writeStoredCredential('expired-tok', NOW);
+    sessionStore.setItem(STORAGE_KEY, 'expired-tok');
+    sessionStore.removeItem = () => {
+      throw new Error('denied');
+    };
+    const auth = await loadAuth();
+
+    expect(auth.initServerAuth()).toBe(false);
+    expect(localStore.getItem(STORAGE_KEY)).not.toBeNull();
+
+    const reloaded = await loadAuth();
+    expect(reloaded.initServerAuth()).toBe(false);
   });
 
   it('setCredential removes any legacy sessionStorage copy', async () => {
@@ -86,7 +215,7 @@ describe('credential persistence', () => {
     const auth = await loadAuth();
     auth.setCredential('tok-2');
     expect(sessionStore.getItem(STORAGE_KEY)).toBeNull();
-    expect(localStore.getItem(STORAGE_KEY)).toBe('tok-2');
+    expect(readStoredCredential()?.credential).toBe('tok-2');
   });
 
   it('keeps working in memory when storage throws', async () => {
@@ -125,19 +254,19 @@ describe('fragment token intake', () => {
   }
 
   it('prefers the fragment token, stores it, and scrubs the URL', async () => {
-    localStore.setItem(STORAGE_KEY, 'stored-tok');
+    writeStoredCredential('stored-tok');
     const { replaceState } = installWindow('#token=frag-tok');
     const auth = await loadAuth();
 
     expect(auth.initServerAuth()).toBe(true);
     expect(auth.getCredential()).toBe('frag-tok');
-    expect(localStore.getItem(STORAGE_KEY)).toBe('frag-tok');
+    expect(readStoredCredential()?.credential).toBe('frag-tok');
     // Fragment scrubbed: path + query kept, token gone.
     expect(replaceState).toHaveBeenCalledWith(null, '', '/some/path?x=1');
   });
 
   it('ignores an empty fragment and falls back to storage', async () => {
-    localStore.setItem(STORAGE_KEY, 'stored-tok');
+    writeStoredCredential('stored-tok');
     installWindow('');
     const auth = await loadAuth();
 
@@ -165,18 +294,30 @@ describe('markAuthRequired', () => {
 });
 
 describe('cross-tab credential clearing', () => {
+  it('keeps a newer same-token record when this tab’s in-memory copy expires', async () => {
+    const auth = await loadAuth();
+    auth.setCredential('tok-1');
+    writeStoredCredential('tok-1', NOW + 8 * DAY_MS);
+    const refreshedStored = localStore.getItem(STORAGE_KEY);
+
+    vi.setSystemTime(NOW + 7 * DAY_MS);
+    expect(auth.getCredential()).toBeUndefined();
+    expect(localStore.getItem(STORAGE_KEY)).toBe(refreshedStored);
+  });
+
   it('keeps a newer token another tab persisted when this tab is stale', async () => {
     const auth = await loadAuth();
     auth.setCredential('stale-tok');
     // Another tab stores a fresh token (e.g. after rotation + `kimi web`).
-    localStore.setItem(STORAGE_KEY, 'fresh-tok');
+    writeStoredCredential('fresh-tok');
+    const freshStored = localStore.getItem(STORAGE_KEY);
 
     auth.markAuthRequired();
 
     // This tab forgets its rejected credential and prompts…
     expect(auth.getCredential()).toBeUndefined();
     // …but the fresh shared token survives for reloads and other tabs.
-    expect(localStore.getItem(STORAGE_KEY)).toBe('fresh-tok');
+    expect(localStore.getItem(STORAGE_KEY)).toBe(freshStored);
   });
 
   it('clears the persisted copy when it still matches the rejected credential', async () => {
@@ -186,10 +327,22 @@ describe('cross-tab credential clearing', () => {
     expect(localStore.getItem(STORAGE_KEY)).toBeNull();
   });
 
+  it('clears the same rejected token even if another tab refreshed its expiry', async () => {
+    const auth = await loadAuth();
+    auth.setCredential('tok-1');
+    writeStoredCredential('tok-1', NOW + 8 * DAY_MS);
+
+    auth.markAuthRequired();
+
+    expect(auth.getCredential()).toBeUndefined();
+    expect(localStore.getItem(STORAGE_KEY)).toBeNull();
+  });
+
   it('does not clear another tab’s token when this tab had no credential', async () => {
-    localStore.setItem(STORAGE_KEY, 'fresh-tok');
+    writeStoredCredential('fresh-tok');
+    const freshStored = localStore.getItem(STORAGE_KEY);
     const auth = await loadAuth();
     auth.markAuthRequired();
-    expect(localStore.getItem(STORAGE_KEY)).toBe('fresh-tok');
+    expect(localStore.getItem(STORAGE_KEY)).toBe(freshStored);
   });
 });

--- a/apps/kimi-web/test/server-auth.test.ts
+++ b/apps/kimi-web/test/server-auth.test.ts
@@ -26,7 +26,7 @@ function createMemoryStorage(): Storage {
       data.delete(key);
     },
     setItem(key: string, value: string) {
-      data.set(key, String(value));
+      data.set(key, value);
     },
   };
 }
@@ -37,7 +37,7 @@ let sessionStore: Storage;
 /** Fresh module instance per test — the store keeps module-level state. */
 async function loadAuth() {
   vi.resetModules();
-  return await import('../src/api/daemon/serverAuth');
+  return import('../src/api/daemon/serverAuth');
 }
 
 beforeEach(() => {
@@ -104,7 +104,9 @@ describe('credential persistence', () => {
     expect(auth.initServerAuth()).toBe(false);
     auth.setCredential('tok-mem');
     expect(auth.getCredential()).toBe('tok-mem');
-    expect(() => auth.clearCredential()).not.toThrow();
+    expect(() => {
+      auth.clearCredential();
+    }).not.toThrow();
   });
 });
 


### PR DESCRIPTION
## Related Issue

No linked issue — reported as direct user feedback ("access token 隔一阵就需要重新输入"). This PR is split out from #1554, which bundled four fixes; of those, the workspace-path entry already landed via #1556 and the mid-turn resync fix was dropped in #1558 (to be reworked on the v2 kernel). The legacy session-recovery parts were held back for now.

## Problem

The web UI stored the server bearer credential in sessionStorage, which is tab-scoped and cleared when the tab closes. Users had to re-enter the token for every new tab, after closing the browser, and after mobile browsers evicted background tabs. The server token itself is persistent (`<KIMI_CODE_HOME>/server.token` survives restarts and is only rotated explicitly); only the browser-side storage was short-lived.

## What changed

Persist the credential in localStorage with a fixed seven-day expiry, so it survives tab close and browser restarts without being retained indefinitely. Details:

- The seven-day window starts when the credential is written and is not renewed by reads; a page kept open past the deadline also stops using it.
- Legacy sessionStorage values are migrated into the expiring format once. Failed migrations cannot silently grant a fresh seven-day window on every reload.
- Expiry clears the matching stored value without deleting a newer value written by another tab.
- A 401 (for example after `kimi server rotate-token`) clears the rejected credential and shows the token dialog. A different fresh token written by another tab is preserved.
- The same storage slot may contain the persistent server token or a manually entered `KIMI_CODE_PASSWORD`, so browser-profile retention is capped at seven days for both.
- Tests cover reload persistence, the exact expiry boundary, no renewal on reads, legacy migration, fragment intake and URL scrubbing, 401 and cross-tab clearing, and storage failures.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.
