### PR TITLE
fix(web): finish local prompt state from session snapshot after a reconnect

### DIFF
--- a/.changeset/web-finish-prompt-on-snapshot.md
+++ b/.changeset/web-finish-prompt-on-snapshot.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+web: Fix sessions getting stuck in a sending state after a reconnect, so the working spinner stops and the next message sends normally once a turn finishes while the connection is down.

--- a/apps/kimi-web/src/composables/client/useModelProviderState.ts
+++ b/apps/kimi-web/src/composables/client/useModelProviderState.ts
@@ -10,6 +10,7 @@ import { getKimiWebApi } from '../../api';
 import type { AppMessage, AppModel, AppProvider, AppSession, AppSkill, ThinkingLevel } from '../../api/types';
 import { safeGetString, safeSetString, STORAGE_KEYS } from '../../lib/storage';
 import { coerceThinkingForModel, thinkingLevelForModelSwitch } from '../../lib/modelThinking';
+import { beginLocalTurn, settleLocalTurn } from './useWorkspaceState';
 import type { ActivityState } from '../../types';
 import type { ExtendedState } from '../useKimiWebClient';
 
@@ -273,7 +274,10 @@ export function useModelProviderState(
     const guarded = activity.value === 'idle' && !inFlightPromptSessions.has(sid);
     const tempId = `msg_skill_opt_${Date.now().toString(36)}`;
 
+    const localTurnToken = guarded ? beginLocalTurn(sid) : undefined;
     if (guarded) {
+      // Share the local-turn-start lifecycle with prompt submits: a racing
+      // terminal snapshot must not clear this skill's turn either.
       inFlightPromptSessions.add(sid);
       rawState.sendingBySession = { ...rawState.sendingBySession, [sid]: true };
       const optimisticMsg: AppMessage = {
@@ -304,6 +308,10 @@ export function useModelProviderState(
         updateSessionMessages(sid, (msgs) => msgs.filter((m) => m.id !== tempId));
       }
       pushOperationFailure('activateSkill', err, { sessionId: sid });
+    } finally {
+      // The daemon answered the activation (accepted or rejected) — the
+      // pending window in which a snapshot can't reflect this turn is over.
+      if (localTurnToken !== undefined) settleLocalTurn(sid, localTurnToken);
     }
   }
 

--- a/apps/kimi-web/src/composables/client/useWorkspaceState.ts
+++ b/apps/kimi-web/src/composables/client/useWorkspaceState.ts
@@ -14,8 +14,10 @@ import { useConfirmDialog } from '../useConfirmDialog';
 import { isDaemonApiError } from '../../api/errors';
 import type {
   AppConfig,
+  AppInFlightTurn,
   AppMessage,
   AppSession,
+  AppSessionStatus,
   AppWorkspace,
   ApprovalDecision,
   ApprovalResponse,
@@ -93,6 +95,82 @@ const pendingTaskCancellations = reactive<Record<string, true>>({});
  * `pending*Actions` guards above.
  */
 const startingFirstPromptWorkspaces = reactive(new Set<string>());
+
+/**
+ * Per-session local-turn-start lifecycle, shared by EVERY entry point that
+ * starts a turn locally (prompt submit/steer in this module, skill activation
+ * in useModelProviderState). Two pieces of state:
+ *  - generation: bumped synchronously at every local turn start, so a
+ *    snapshot requested BEFORE the start can tell it predates the turn;
+ *  - pending: set while the start request (POST /prompts or skill
+ *    activation) has not been acknowledged by the daemon — a snapshot
+ *    requested in that window cannot reflect the turn server-side either.
+ * Module-level singleton — matches `inFlightPromptSessions` in the facade.
+ */
+const promptGenerationBySession = new Map<string, number>();
+const pendingLocalTurnStarts = new Map<string, Set<number>>();
+const afterLocalTurnsSettled = new Map<string, () => void>();
+let nextLocalTurnToken = 0;
+
+export interface LocalTurnStartState {
+  generation: number;
+  pending: boolean;
+}
+
+/** Snapshot of the local-turn-start state, captured BEFORE an async snapshot
+ *  fetch so the caller can reject a snapshot that predates a local turn. */
+export function localTurnStartState(sid: string): LocalTurnStartState {
+  return {
+    generation: promptGenerationBySession.get(sid) ?? 0,
+    pending: (pendingLocalTurnStarts.get(sid)?.size ?? 0) > 0,
+  };
+}
+
+/** Shared "a local turn just started" lifecycle: bumps the generation and
+ *  marks the start request pending. Call synchronously before the first
+ *  await of every local turn entry point. */
+export function beginLocalTurn(sid: string): number {
+  const token = ++nextLocalTurnToken;
+  promptGenerationBySession.set(sid, token);
+  const pending = pendingLocalTurnStarts.get(sid) ?? new Set<number>();
+  pending.add(token);
+  pendingLocalTurnStarts.set(sid, pending);
+  return token;
+}
+
+/** The daemon acknowledged (or rejected) the turn-start request. */
+export function settleLocalTurn(sid: string, token: number): void {
+  const pending = pendingLocalTurnStarts.get(sid);
+  if (pending === undefined) return;
+  pending.delete(token);
+  if (pending.size > 0) return;
+  pendingLocalTurnStarts.delete(sid);
+  const callback = afterLocalTurnsSettled.get(sid);
+  afterLocalTurnsSettled.delete(sid);
+  callback?.();
+}
+
+/** Drop lifecycle state with the rest of a forgotten session. */
+export function forgetLocalTurnState(sid: string): void {
+  promptGenerationBySession.delete(sid);
+  pendingLocalTurnStarts.delete(sid);
+  afterLocalTurnsSettled.delete(sid);
+}
+
+/** Whether a snapshot request can still be applied without overwriting a
+ *  local turn that started before or during the request. */
+export function isLocalTurnSnapshotCurrent(sid: string, atRequest: LocalTurnStartState): boolean {
+  return !atRequest.pending && atRequest.generation === (promptGenerationBySession.get(sid) ?? 0);
+}
+
+/** Coalesce a skipped snapshot into one retry after local turn-start requests settle. */
+export function afterLocalTurnStartsSettle(sid: string, callback: () => void): void {
+  if ((pendingLocalTurnStarts.get(sid)?.size ?? 0) === 0) {
+    callback();
+    return;
+  }
+  afterLocalTurnsSettled.set(sid, callback);
+}
 
 type SyncSessionResult = 'ok' | 'not-found' | 'failed';
 
@@ -1133,6 +1211,10 @@ export function useWorkspaceState(rawState: ExtendedState, deps: UseWorkspaceSta
   async function submitPromptInternal(sid: string, text: string, attachments?: PromptAttachment[]): Promise<boolean> {
     // Mark this session as having a prompt in flight BEFORE any await, so a racing
     // sendPrompt sees it and enqueues. Cleared when activity returns to idle.
+    // beginLocalTurn also bumps the snapshot generation and marks the submit
+    // pending, so a racing terminal snapshot can't clear this prompt (see
+    // handleSessionSnapshot).
+    const localTurnToken = beginLocalTurn(sid);
     inFlightPromptSessions.add(sid);
     rawState.sendingBySession = { ...rawState.sendingBySession, [sid]: true };
     const tempId = nextOptimisticMsgId();
@@ -1249,6 +1331,10 @@ export function useWorkspaceState(rawState: ExtendedState, deps: UseWorkspaceSta
       );
       pushOperationFailure('sendPrompt', err, { sessionId: sid });
       return false;
+    } finally {
+      // The daemon answered the submit (accepted or rejected) — the pending
+      // window in which a snapshot can't reflect this turn is over.
+      settleLocalTurn(sid, localTurnToken);
     }
   }
 
@@ -1321,6 +1407,7 @@ export function useWorkspaceState(rawState: ExtendedState, deps: UseWorkspaceSta
     };
     updateSessionMessages(sid, (msgs) => [...msgs, optimisticMsg]);
 
+    const localTurnToken = beginLocalTurn(sid);
     try {
       const api = getKimiWebApi();
       const promptSession = rawState.sessions.find((s) => s.id === sid);
@@ -1368,6 +1455,8 @@ export function useWorkspaceState(rawState: ExtendedState, deps: UseWorkspaceSta
       // a delivered-looking message the daemon never received.
       updateSessionMessages(sid, (msgs) => msgs.filter((m) => m.id !== tempId));
       pushOperationFailure('steer', err, { sessionId: sid });
+    } finally {
+      settleLocalTurn(sid, localTurnToken);
     }
   }
 
@@ -1395,6 +1484,74 @@ export function useWorkspaceState(rawState: ExtendedState, deps: UseWorkspaceSta
       ...rawState.queuedBySession,
       [sid]: [...current, { text, attachments }],
     };
+  }
+
+  /**
+   * Shared prompt-finish cleanup, used by BOTH the WS idle/aborted event path
+   * (facade `onSessionIdle`) and the authoritative-snapshot path
+   * (handleSessionSnapshot below). Returns whether this call actually flipped
+   * an in-flight prompt to finished.
+   *
+   * Clears the local in-flight/sending/prompt-id state and drains exactly ONE
+   * queued message — the resubmitted prompt re-arms the in-flight flag, and
+   * its own finish drains the following one. Repeat calls (e.g. a late
+   * duplicate idle event) therefore cannot drain more than one message per
+   * real turn end. Callers layer their own side effects (notify, sound,
+   * unread) on top; the snapshot path deliberately adds none.
+   */
+  function finishPromptLocal(sid: string): boolean {
+    const wasInFlight = inFlightPromptSessions.delete(sid);
+    rawState.sendingBySession = { ...rawState.sendingBySession, [sid]: false };
+    // Drop any cached prompt_id so a later skill activation (which has no
+    // prompt_id) doesn't accidentally reuse this stale id for :abort.
+    if (rawState.promptIdBySession[sid] !== undefined) {
+      const nextPromptIds = { ...rawState.promptIdBySession };
+      delete nextPromptIds[sid];
+      rawState.promptIdBySession = nextPromptIds;
+    }
+    if (sid === rawState.activeSessionId) {
+      resetFastMoon();
+    }
+
+    const queue = rawState.queuedBySession[sid] ?? [];
+    if (queue.length > 0) {
+      const [next, ...rest] = queue;
+      rawState.queuedBySession = { ...rawState.queuedBySession, [sid]: rest };
+      // Flush the first queued message; on failure put it back at the head so
+      // a transient error doesn't silently drop the prompt.
+      if (next !== undefined) {
+        void submitPromptInternal(sid, next.text, next.attachments).then((ok) => {
+          if (!ok) {
+            const current = rawState.queuedBySession[sid] ?? [];
+            rawState.queuedBySession = {
+              ...rawState.queuedBySession,
+              [sid]: [next, ...current],
+            };
+          }
+        });
+      }
+    }
+
+    return wasInFlight;
+  }
+
+  /**
+   * Snapshot-driven finish. An authoritative snapshot replaces the event
+   * stream on resync (buffer overflow / epoch change / delta gap): no
+   * sessionStatusChanged event arrives in that case, so without this the
+   * local in-flight flag would stick forever — the moon keeps spinning and
+   * the next prompt queues behind a turn that already ended.
+   *
+   * Unlike the WS path this adds NO completion side effects (no notification,
+   * sound, or unread): opening a historical session must not cry wolf.
+   */
+  function handleSessionSnapshot(
+    sid: string,
+    snapshot: { inFlightTurn: AppInFlightTurn | null; status: AppSessionStatus },
+  ): void {
+    if (snapshot.inFlightTurn !== null) return;
+    if (snapshot.status !== 'idle' && snapshot.status !== 'aborted') return;
+    finishPromptLocal(sid);
   }
 
   async function abortCurrentPrompt(): Promise<void> {
@@ -2178,6 +2335,11 @@ export function useWorkspaceState(rawState: ExtendedState, deps: UseWorkspaceSta
     bindSessionRoute,
     selectSession,
     submitPromptInternal,
+    finishPromptLocal,
+    localTurnStartState,
+    isLocalTurnSnapshotCurrent,
+    afterLocalTurnStartsSettle,
+    handleSessionSnapshot,
     sendPrompt,
     steerPrompt,
     uploadImage,

--- a/apps/kimi-web/src/composables/useKimiWebClient.ts
+++ b/apps/kimi-web/src/composables/useKimiWebClient.ts
@@ -35,7 +35,11 @@ import { useSoundNotification } from './client/useSoundNotification';
 import { useTaskPoller } from './client/useTaskPoller';
 import { useModelProviderState } from './client/useModelProviderState';
 import { useSideChat } from './client/useSideChat';
-import { SESSIONS_INITIAL_PAGE_SIZE, useWorkspaceState } from './client/useWorkspaceState';
+import {
+  forgetLocalTurnState,
+  SESSIONS_INITIAL_PAGE_SIZE,
+  useWorkspaceState,
+} from './client/useWorkspaceState';
 
 const appearance = useAppearance();
 const notification = useNotification();
@@ -499,6 +503,10 @@ if (typeof document !== 'undefined') {
     }
   });
 }
+if (typeof window !== 'undefined') {
+  window.addEventListener('focus', recoverStaleConnection);
+  window.addEventListener('online', recoverStaleConnection);
+}
 
 // ---------------------------------------------------------------------------
 // rawState.activeSessionId — single mutation funnel.
@@ -567,12 +575,15 @@ function forgetSession(sessionId: string): void {
   delete rawState.messagesHasMoreBySession[sessionId];
   delete rawState.messagesLoadMoreErrorBySession[sessionId];
   delete epochBySession[sessionId];
+  sessionsRequiringSnapshot.delete(sessionId);
+  sessionsRetryingStaleSnapshot.delete(sessionId);
   sessionsKnownEmpty.delete(sessionId);
   // In-flight / queued prompt state: drop these too so a queued follow-up
   // can't be submitted to a session that was just archived when its turn later
   // goes idle (onSessionIdle drains queuedBySession[sid] without re-checking
   // that the session still exists).
   inFlightPromptSessions.delete(sessionId);
+  forgetLocalTurnState(sessionId);
   delete rawState.queuedBySession[sessionId];
   delete rawState.promptIdBySession[sessionId];
   delete rawState.sendingBySession[sessionId];
@@ -797,6 +808,11 @@ function applyEvent(event: ReturnType<typeof toAppEvent>, sessionId: string, seq
 type PendingEvent = { appEvent: AppEvent; meta: { sessionId: string; seq: number } };
 
 function processEvent(appEvent: AppEvent, meta: { sessionId: string; seq: number }): void {
+  // Capture BEFORE applyEvent advances lastSeqBySession: turn-end side
+  // effects below only run when this event actually moves the durable cursor
+  // forward. A late duplicate idle (e.g. replayed after a snapshot already
+  // advanced past it) must not drain a second queued message.
+  const prevSeq = rawState.lastSeqBySession[meta.sessionId] ?? 0;
   // meta carries wire-level seq/sessionId so the reducer can advance
   // lastSeqBySession[sessionId] = seq. Compaction completion appends a
   // persistent divider marker in the reducer (TUI parity: the scrollback
@@ -846,9 +862,13 @@ function processEvent(appEvent: AppEvent, meta: { sessionId: string; seq: number
   // Turn-end: both 'idle' and 'aborted' mean the prompt is no longer in
   // flight, so both must flush in-flight/queued state. (Awaiting-* is still
   // in flight — it's waiting on the user — and must NOT flush.)
+  // Gated on the durable cursor advancing: a late duplicate of an idle we
+  // already consumed (directly or via a snapshot past it) must not run the
+  // side effects again — above all, it must not drain another queued message.
   if (
     appEvent.type === 'sessionStatusChanged' &&
-    (appEvent.status === 'idle' || appEvent.status === 'aborted')
+    (appEvent.status === 'idle' || appEvent.status === 'aborted') &&
+    meta.seq > prevSeq
   ) {
     onSessionIdle(appEvent.sessionId, appEvent.status);
   }
@@ -913,10 +933,12 @@ function connectEventsIfNeeded(): void {
       // so they are applied to the pre-snapshot array too rather than on top
       // of the fresh snapshot (which would duplicate text / tool output).
       enqueueEvent.flush();
-      // The server-announced cursor is only a hint; the snapshot fetch
-      // returns the authoritative {asOfSeq, epoch} and re-subscribes.
-      if (epoch !== undefined) epochBySession[sessionId] = epoch;
+      // The server-announced cursor is only a hint; keep the previous epoch
+      // until the snapshot arrives so seq values from two epochs are never
+      // compared with each other.
       void currentSeq;
+      void epoch;
+      sessionsRequiringSnapshot.add(sessionId);
       snapshotSyncRunner.request(sessionId);
     },
 
@@ -947,6 +969,12 @@ function connectEventsIfNeeded(): void {
 // Journal epoch per session, learned from snapshots / resync frames. Not
 // reactive — only consulted when building the subscribe cursor.
 const epochBySession: Record<string, string> = {};
+// onResync resets the event projector, so that path must apply a snapshot even
+// if a newer global event advances the local cursor while the GET is in flight.
+const sessionsRequiringSnapshot = new Set<string>();
+// A normal foreground refresh may race one newer event. Retry once with a
+// fresh snapshot so volatile text missed during sleep is still restored.
+const sessionsRetryingStaleSnapshot = new Set<string>();
 
 // Sessions created locally in this client instance are known to be empty until
 // they receive their first message. This is more reliable than the daemon's
@@ -1176,9 +1204,12 @@ async function pullSessionWarnings(sessionId: string): Promise<void> {
 }
 
 async function syncSessionFromSnapshot(sessionId: string): Promise<SyncSessionResult> {
+  // A snapshot that races a local turn start must not overwrite that turn.
+  const turnStartAtRequest = workspaceState.localTurnStartState(sessionId);
   try {
     const api = getKimiWebApi();
     const snap = await api.getSessionSnapshot(sessionId);
+    if (!rawState.sessions.some((session) => session.id === sessionId)) return 'ok';
 
     // Drain any queued streaming deltas before the snapshot replaces
     // messagesBySession[sessionId]. The snapshot is authoritative (it already
@@ -1186,6 +1217,32 @@ async function syncSessionFromSnapshot(sessionId: string): Promise<SyncSessionRe
     // of it would duplicate text / tool output. Flushing here applies them to
     // the pre-snapshot array, which the snapshot then overwrites.
     enqueueEvent.flush();
+
+    // Do not let an old snapshot overwrite state that moved forward while the
+    // request was in flight. Retry once to recover volatile text at a fresh
+    // cursor; resync/LRU rebuilds must always apply because their projector or
+    // subscription was deliberately reset.
+    const currentSeq = rawState.lastSeqBySession[sessionId] ?? 0;
+    const knownEpoch = epochBySession[sessionId];
+    const mustApplySnapshot =
+      sessionsRequiringSnapshot.has(sessionId) || sessionsWithStaleCursor.has(sessionId);
+    if (
+      !mustApplySnapshot &&
+      knownEpoch !== undefined &&
+      knownEpoch === snap.epoch &&
+      currentSeq > snap.asOfSeq
+    ) {
+      if (sessionsRetryingStaleSnapshot.delete(sessionId)) return 'ok';
+      sessionsRetryingStaleSnapshot.add(sessionId);
+      snapshotSyncRunner.request(sessionId);
+      return 'ok';
+    }
+    if (!workspaceState.isLocalTurnSnapshotCurrent(sessionId, turnStartAtRequest)) {
+      workspaceState.afterLocalTurnStartsSettle(sessionId, () => {
+        snapshotSyncRunner.request(sessionId);
+      });
+      return 'ok';
+    }
 
     updateSession(sessionId, (s) => ({
       ...snap.session,
@@ -1231,6 +1288,15 @@ async function syncSessionFromSnapshot(sessionId: string): Promise<SyncSessionRe
       [sessionId]: snap.asOfSeq,
     };
     epochBySession[sessionId] = snap.epoch;
+    sessionsRequiringSnapshot.delete(sessionId);
+    sessionsRetryingStaleSnapshot.delete(sessionId);
+
+    // Resync replaces the missed event stream, so a terminal snapshot must
+    // also clear the local sending flag that normally ends on a WS idle event.
+    workspaceState.handleSessionSnapshot(
+      sessionId,
+      { inFlightTurn: snap.inFlightTurn, status: snap.session.status },
+    );
 
     connectEventsIfNeeded();
     if (eventConn) {
@@ -2345,24 +2411,18 @@ function isUserWatching(sid: string): boolean {
 }
 
 function onSessionIdle(sid: string, status: 'idle' | 'aborted'): void {
-  // The turn finished — this session no longer has a prompt in flight.
-  inFlightPromptSessions.delete(sid);
-  rawState.sendingBySession = { ...rawState.sendingBySession, [sid]: false };
-  // Capture before the cleanup below drops it — it keys the completion
+  // Capture before finishPromptLocal drops it — it keys the completion
   // notification's dedup tag so each finished turn alerts once.
   const finishedPromptId = rawState.promptIdBySession[sid];
-  // Drop any cached prompt_id so a later skill activation (which has no
-  // prompt_id) doesn't accidentally reuse this stale id for :abort.
-  if (rawState.promptIdBySession[sid] !== undefined) {
-    const next = { ...rawState.promptIdBySession };
-    delete next[sid];
-    rawState.promptIdBySession = next;
-  }
+  // Shared finish cleanup: clears in-flight/sending/prompt-id and drains one
+  // queued message. The notification/sound/unread side effects below stay
+  // WS-event-only — the snapshot path (handleSessionSnapshot) must not cry
+  // wolf when opening a historical session.
+  workspaceState.finishPromptLocal(sid);
 
   // For the session on screen, refresh git status (edits the agent just made)
   // and runtime status (model/context usage may have changed this turn).
   if (sid === rawState.activeSessionId) {
-    appearance.resetFastMoon();
     void workspaceState.loadGitStatus(sid);
     void refreshSessionStatus(sid);
   } else if (status === 'idle') {
@@ -2394,25 +2454,6 @@ function onSessionIdle(sid: string, status: 'idle' | 'aborted'): void {
   // silent). Plays regardless of visibility so it also reaches a backgrounded tab.
   if (status === 'idle') {
     sound.maybePlayCompletionSound();
-  }
-
-  const queue = rawState.queuedBySession[sid] ?? [];
-  if (queue.length === 0) return;
-
-  const [next, ...rest] = queue;
-  rawState.queuedBySession = { ...rawState.queuedBySession, [sid]: rest };
-  // Flush the first queued message; on failure put it back at the head so a
-  // transient error doesn't silently drop the prompt.
-  if (next !== undefined) {
-    void workspaceState.submitPromptInternal(sid, next.text, next.attachments).then((ok) => {
-      if (!ok) {
-        const current = rawState.queuedBySession[sid] ?? [];
-        rawState.queuedBySession = {
-          ...rawState.queuedBySession,
-          [sid]: [next, ...current],
-        };
-      }
-    });
   }
 }
 

--- a/apps/kimi-web/test/workspace-state.test.ts
+++ b/apps/kimi-web/test/workspace-state.test.ts
@@ -942,3 +942,94 @@ describe('useWorkspaceState — startSessionAndOpenSideChat', () => {
     expect(deps.pushOperationFailure).not.toHaveBeenCalled();
   });
 });
+
+// Regression coverage for wake/reconnect snapshot recovery.
+describe('useWorkspaceState — snapshot prompt recovery', () => {
+  function promptDeps(overrides: Partial<UseWorkspaceStateDeps> = {}): UseWorkspaceStateDeps {
+    return {
+      ...createDeps(),
+      modelProvider: { models: ref([]) } as unknown as UseWorkspaceStateDeps['modelProvider'],
+      ...overrides,
+    };
+  }
+
+  beforeEach(() => {
+    apiMock.submitPrompt.mockReset();
+    apiMock.submitPrompt.mockResolvedValue({ promptId: 'prompt_new' });
+  });
+
+  it('clears a finished prompt from a terminal snapshot so the next send is immediate', async () => {
+    const state = createState();
+    const inFlight = new Set(['sess_1']);
+    state.sendingBySession = { sess_1: true };
+    const ws = useWorkspaceState(
+      state,
+      promptDeps({ inFlightPromptSessions: inFlight, activity: computed(() => 'idle') }),
+    );
+
+    ws.handleSessionSnapshot('sess_1', { inFlightTurn: null, status: 'idle' });
+
+    expect(inFlight.has('sess_1')).toBe(false);
+    expect(state.sendingBySession.sess_1).toBe(false);
+    expect(state.promptIdBySession.sess_1).toBeUndefined();
+
+    await ws.sendPrompt('next');
+    expect(apiMock.submitPrompt).toHaveBeenCalledOnce();
+    expect(state.queuedBySession.sess_1).toBeUndefined();
+  });
+
+  it('keeps a genuinely running prompt in flight and queues the next send', async () => {
+    const state = createState();
+    const inFlight = new Set(['sess_1']);
+    state.sendingBySession = { sess_1: true };
+    const ws = useWorkspaceState(state, promptDeps({ inFlightPromptSessions: inFlight }));
+
+    ws.handleSessionSnapshot('sess_1', {
+      inFlightTurn: { turnId: 1, assistantText: '', thinkingText: '', runningTools: [] },
+      status: 'running',
+    });
+    await ws.sendPrompt('next');
+
+    expect(inFlight.has('sess_1')).toBe(true);
+    expect(state.sendingBySession.sess_1).toBe(true);
+    expect(apiMock.submitPrompt).not.toHaveBeenCalled();
+    expect(state.queuedBySession.sess_1).toEqual([{ text: 'next', attachments: undefined }]);
+  });
+
+  it('rejects a snapshot when a new local prompt started during the request', async () => {
+    const state = createState();
+    const inFlight = new Set<string>();
+    const ws = useWorkspaceState(state, promptDeps({ inFlightPromptSessions: inFlight }));
+    const atRequest = ws.localTurnStartState('sess_1');
+
+    await ws.submitPromptInternal('sess_1', 'fresh prompt');
+
+    expect(ws.isLocalTurnSnapshotCurrent('sess_1', atRequest)).toBe(false);
+    expect(inFlight.has('sess_1')).toBe(true);
+    expect(state.sendingBySession.sess_1).toBe(true);
+  });
+
+  it('rejects a snapshot requested while the local submit is still pending', async () => {
+    let resolveSubmit!: (value: { promptId: string }) => void;
+    apiMock.submitPrompt.mockImplementation(
+      () =>
+        new Promise<{ promptId: string }>((resolve) => {
+          resolveSubmit = resolve;
+        }),
+    );
+    const ws = useWorkspaceState(createState(), promptDeps());
+    const pendingSubmit = ws.submitPromptInternal('sess_1', 'fresh prompt');
+    const atRequest = ws.localTurnStartState('sess_1');
+    const retrySnapshot = vi.fn();
+
+    expect(atRequest.pending).toBe(true);
+    expect(ws.isLocalTurnSnapshotCurrent('sess_1', atRequest)).toBe(false);
+    ws.afterLocalTurnStartsSettle('sess_1', retrySnapshot);
+    expect(retrySnapshot).not.toHaveBeenCalled();
+
+    resolveSubmit({ promptId: 'prompt_new' });
+    await pendingSubmit;
+    expect(ws.localTurnStartState('sess_1').pending).toBe(false);
+    expect(retrySnapshot).toHaveBeenCalledOnce();
+  });
+});


### PR DESCRIPTION
## Related Issue

No linked issue — the problem is explained below.

## Problem

In the web UI, a turn that finishes while the client is disconnected (laptop
closed, backgrounded tab, network drop) can leave the session stuck: the
working spinner never stops and the next message is queued behind a turn that
already ended.

The missed turn end is normally recovered by durable-event replay on
reconnect, but not when the client rebuilds from a session snapshot instead —
server-initiated resync (buffer overflow / epoch change / delta gap) or an
LRU-evicted subscription rebuild. Local prompt state (in-flight flag, sending
flag, cached prompt id, the message queue) was only ever cleared by the WS
`sessionStatusChanged` idle/aborted event, and snapshots never delivered one.

## What changed

Web-only fix; no server, protocol, or UI style changes.

- A shared local-turn-start lifecycle (generation + submit-pending, in
  `useWorkspaceState`) is now entered by every local turn start: prompt
  submit, steer, and skill activation. A snapshot requested before or during
  a turn start can tell it cannot reflect that turn.
- `syncSessionFromSnapshot` rejects a snapshot that predates a local turn
  (or raced one) and re-syncs once the turn start settles, instead of
  permanently ignoring it. Snapshots that fall behind the live cursor during
  the fetch are dropped (one retry) rather than applied — resync/LRU rebuilds
  still always apply because their projector was deliberately reset.
- When an authoritative snapshot shows the turn ended (`inFlightTurn ===
  null`, status idle/aborted), it finishes the local prompt state through the
  same cleanup the WS idle path uses (`finishPromptLocal`), without firing
  completion notifications/sounds — opening a historical session must not cry
  wolf.
- Turn-end side effects on the WS path are gated on the durable cursor
  actually advancing, so a late duplicate idle can never drain a second
  queued message.
- `window focus` / `online` also trigger the existing stale-socket recovery
  (previously only `visibilitychange`); recovery still only reconnects when
  the socket actually looks stale.

Tests cover the snapshot finish path, the running/awaiting cases, the
new-prompt-during-fetch and submit-pending rejections, and the settle
callback retry.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.
