### PR TITLE
fix(web): keep the connecting splash and retry the first-load auth check

### DIFF
--- a/.changeset/web-first-load-auth-gate.md
+++ b/.changeset/web-first-load-auth-gate.md
@@ -2,4 +2,4 @@
 "@moonshot-ai/kimi-code": patch
 ---
 
-web: Fix the first visit after starting or updating the web UI bouncing to the login page when the initial auth check fails; the connecting screen now stays up and retries until the server answers.
+web: Fix the first visit after starting or updating the web UI bouncing to the login page when the initial auth check fails; the connecting screen now stays up, shows the connection error, and retries until the server answers.

--- a/.changeset/web-first-load-auth-gate.md
+++ b/.changeset/web-first-load-auth-gate.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+web: Fix the first visit after starting or updating the web UI bouncing to the login page when the initial auth check fails; the connecting screen now stays up and retries until the server answers.

--- a/apps/kimi-code/dist-web
+++ b/apps/kimi-code/dist-web
@@ -1,1 +1,0 @@
-../kimi-web/dist

--- a/apps/kimi-code/dist-web
+++ b/apps/kimi-code/dist-web
@@ -1,0 +1,1 @@
+../kimi-web/dist

--- a/apps/kimi-web/src/App.vue
+++ b/apps/kimi-web/src/App.vue
@@ -993,9 +993,11 @@ function openPr(url: string): void {
       <GlobalLoading v-if="!client.initialized.value" :issue="client.connectIssue.value" />
     </Transition>
 
-    <!-- First-run onboarding overlay (language + welcome greeting) -->
+    <!-- First-run onboarding overlay (language + welcome greeting). Held back
+         until the first load settled so it can't cover the connecting splash
+         (it teleports to <body> and would float above the retry error). -->
     <Onboarding
-      v-if="showOnboarding && !showAuthGate"
+      v-if="client.initialized.value && showOnboarding && !showAuthGate"
       @complete="completeOnboarding"
       @skip="completeOnboarding"
     />

--- a/apps/kimi-web/src/App.vue
+++ b/apps/kimi-web/src/App.vue
@@ -48,8 +48,11 @@ import { isMacosDesktop } from './lib/desktopFlag';
 
 // Hydrate the server-transport credential (fragment token or sessionStorage)
 // BEFORE the client connects, so the first REST/WS calls already carry it.
-const hasServerCredential = initServerAuth();
-const authRequired = ref(!hasServerCredential);
+initServerAuth();
+// Stays false until the server actually rejects us with 401/40101. Starting
+// from "no credential ⇒ prompt" flashed the token dialog for a frame in
+// `--dangerous-bypass-auth` mode, before /meta had advertised the bypass.
+const authRequired = ref(false);
 let offAuthRequired: (() => void) | null = null;
 
 const client = useKimiWebClient();
@@ -134,17 +137,19 @@ function openOnboarding(): void {
 }
 
 onMounted(() => {
-  void client.load();
-  loadSidebarCollapsed();
-  // Capture-phase so Escape closes the side detail layer BEFORE the
-  // conversation pane's bubble-phase handler interrupts a running prompt.
-  document.addEventListener('keydown', onGlobalKeydown, true);
+  // Register the 401 listener before the first requests go out, so a token
+  // rejection during the initial load() can never be missed.
   offAuthRequired = onAuthRequired(() => {
     authRequired.value = true;
     // The server now demands a token, so any cached "bypass" state from a
     // previous mode is stale — drop it so the token prompt can show.
     client.clearDangerousBypassAuth();
   });
+  void client.load();
+  loadSidebarCollapsed();
+  // Capture-phase so Escape closes the side detail layer BEFORE the
+  // conversation pane's bubble-phase handler interrupts a running prompt.
+  document.addEventListener('keydown', onGlobalKeydown, true);
 });
 
 onUnmounted(() => {

--- a/apps/kimi-web/src/App.vue
+++ b/apps/kimi-web/src/App.vue
@@ -990,7 +990,7 @@ function openPr(url: string): void {
 
     <!-- Global connecting splash on first load (until the daemon round-trips) -->
     <Transition name="gload-fade">
-      <GlobalLoading v-if="!client.initialized.value" />
+      <GlobalLoading v-if="!client.initialized.value" :issue="client.connectIssue.value" />
     </Transition>
 
     <!-- First-run onboarding overlay (language + welcome greeting) -->

--- a/apps/kimi-web/src/api/daemon/http.ts
+++ b/apps/kimi-web/src/api/daemon/http.ts
@@ -17,7 +17,7 @@ const BODY_PREVIEW_LIMIT = 500;
 
 // Server-transport auth failure envelope code (see packages/server
 // middleware/auth.ts AUTH_ERROR_CODE). Distinct from provider-auth 40110–40113.
-const SERVER_AUTH_UNAUTHORIZED_CODE = 40101;
+export const SERVER_AUTH_UNAUTHORIZED_CODE = 40101;
 
 export interface DaemonHttpClientIdentity {
   readonly clientId: string;

--- a/apps/kimi-web/src/components/GlobalLoading.vue
+++ b/apps/kimi-web/src/components/GlobalLoading.vue
@@ -7,6 +7,9 @@
 <script setup lang="ts">
 import { useI18n } from 'vue-i18n';
 import Spinner from './ui/Spinner.vue';
+/** Last connection error from the first-load auth gate's retry loop, shown so
+ *  a "cannot connect" state is diagnosable instead of a bare spinner. */
+defineProps<{ issue?: string | null }>();
 const { t } = useI18n();
 </script>
 
@@ -21,6 +24,10 @@ const { t } = useI18n();
       </svg>
       <Spinner size="md" :label="t('app.connecting')" />
       <div class="gload-text">{{ t('app.connecting') }}</div>
+      <div v-if="issue" class="gload-issue">
+        <div>{{ t('app.connectRetrying') }}</div>
+        <div class="gload-issue-detail">{{ issue }}</div>
+      </div>
     </div>
   </div>
 </template>
@@ -62,6 +69,24 @@ const { t } = useI18n();
   font-size: var(--text-base);
   color: var(--muted);
   letter-spacing: 0.04em;
+}
+.gload-issue {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--space-2);
+  max-width: min(480px, 80vw);
+  font-family: var(--sans);
+  font-size: var(--text-sm);
+  color: var(--muted);
+  text-align: center;
+}
+.gload-issue-detail {
+  font-family: var(--mono);
+  font-size: var(--text-xs);
+  color: var(--muted);
+  opacity: 0.8;
+  word-break: break-word;
 }
 @keyframes gload-pop {
   from { opacity: 0; transform: translateY(6px) scale(0.96); }

--- a/apps/kimi-web/src/components/ServerAuthDialog.vue
+++ b/apps/kimi-web/src/components/ServerAuthDialog.vue
@@ -74,7 +74,9 @@ function onKeydown(e: KeyboardEvent): void {
 .server-auth-overlay {
   position: fixed;
   inset: 0;
-  z-index: var(--z-modal);
+  /* Above the connecting splash (--z-toast): on a 401 during first load the
+     splash stays up, and this prompt must remain reachable on top of it. */
+  z-index: var(--z-max);
   display: flex;
   align-items: center;
   justify-content: center;

--- a/apps/kimi-web/src/composables/client/useWorkspaceState.ts
+++ b/apps/kimi-web/src/composables/client/useWorkspaceState.ts
@@ -61,7 +61,7 @@ const ALREADY_RESOLVED_CODE = 40902;
 // First load polls /auth until it gives a definitive answer (see load()).
 const FIRST_LOAD_AUTH_RETRY_MS = 2000;
 
-type AuthCheckResult = 'answered' | 'retry' | 'server-auth-required';
+type AuthCheckResult = 'proceed' | 'retry' | 'server-auth-required';
 
 function isAlreadyResolvedError(err: unknown): boolean {
   return isDaemonApiError(err) && err.code === ALREADY_RESOLVED_CODE;
@@ -309,8 +309,12 @@ export function useWorkspaceState(rawState: ExtendedState, deps: UseWorkspaceSta
   }
 
   /** Fetch auth readiness from GET /api/v1/auth. Defensive — never throws.
-   *  Returns whether the daemon gave a definitive answer:
-   *  - 'answered'             — response received; rawState reflects it (ready or not)
+   *  - 'proceed'              — definitive outcome: either a response (rawState
+   *                             reflects it, ready or not) or a deterministic
+   *                             4xx that retrying can never fix (e.g. 404 from
+   *                             an older daemon without this endpoint) — the
+   *                             caller proceeds with the defaults, exactly like
+   *                             the pre-gate fallback did
    *  - 'server-auth-required' — the daemon rejected our server credential
    *                             (401/40101); the ServerAuthDialog owns recovery
    *                             (it reloads once the token is entered)
@@ -324,15 +328,28 @@ export function useWorkspaceState(rawState: ExtendedState, deps: UseWorkspaceSta
       rawState.authReady = result.ready;
       rawState.defaultModel = result.defaultModel;
       rawState.managedProviderStatus = result.managedProvider?.status ?? null;
-      return 'answered';
+      return 'proceed';
     } catch (err) {
-      if (
-        isDaemonApiError(err) &&
-        (err.code === 401 || err.code === SERVER_AUTH_UNAUTHORIZED_CODE)
-      ) {
-        return 'server-auth-required';
+      if (isDaemonApiError(err)) {
+        if (err.code === 401 || err.code === SERVER_AUTH_UNAUTHORIZED_CODE) {
+          return 'server-auth-required';
+        }
+        if (err.code >= 400 && err.code < 500) return 'proceed';
       }
       return 'retry';
+    }
+  }
+
+  /** Poll /auth until the daemon gives a definitive outcome, waiting
+   *  FIRST_LOAD_AUTH_RETRY_MS between transient failures. Never resolves with
+   *  'retry'. Used only by the first load. */
+  async function waitForFirstAuth(): Promise<AuthCheckResult> {
+    for (;;) {
+      const result = await checkAuth();
+      if (result !== 'retry') return result;
+      await new Promise((resolve) => {
+        setTimeout(resolve, FIRST_LOAD_AUTH_RETRY_MS);
+      });
     }
   }
 
@@ -570,24 +587,15 @@ export function useWorkspaceState(rawState: ExtendedState, deps: UseWorkspaceSta
     // The very first load gates on /auth before anything else: a transient
     // failure there (daemon still booting, network blip, 5xx) must NOT be read
     // as "not signed in" — that bounced users to /login until a manual refresh.
-    // Keep the connecting splash up and poll /auth until it gives a definitive
-    // answer. A 401/40101 means the server wants a token: stop and let the
+    // Keep the connecting splash up and poll /auth until a definitive outcome.
+    // A 401/40101 means the server wants a token: stop and let the
     // ServerAuthDialog take over (it reloads once the token is entered).
     const firstLoad = !initialized.value;
-    let authAnswered = true;
+    let authResolved = true;
     try {
-      if (firstLoad) {
-        for (;;) {
-          const result = await checkAuth();
-          if (result === 'answered') break;
-          if (result === 'server-auth-required') {
-            authAnswered = false;
-            return;
-          }
-          await new Promise((resolve) => {
-            setTimeout(resolve, FIRST_LOAD_AUTH_RETRY_MS);
-          });
-        }
+      if (firstLoad && (await waitForFirstAuth()) === 'server-auth-required') {
+        authResolved = false;
+        return;
       }
       const api = getKimiWebApi();
       // Parallel: health + meta + models
@@ -648,9 +656,9 @@ export function useWorkspaceState(rawState: ExtendedState, deps: UseWorkspaceSta
       // Do not re-throw — app stays mounted with empty sessions
     } finally {
       rawState.loading = false;
-      // Without a definitive /auth answer the splash stays up (retry loop or
+      // Without a definitive /auth outcome the splash stays up (retry loop or
       // ServerAuthDialog is handling it) — never expose the half-loaded app.
-      if (authAnswered) initialized.value = true;
+      if (authResolved) initialized.value = true;
     }
   }
 

--- a/apps/kimi-web/src/composables/client/useWorkspaceState.ts
+++ b/apps/kimi-web/src/composables/client/useWorkspaceState.ts
@@ -161,6 +161,9 @@ export interface UseWorkspaceStateDeps {
   goalErrorMessage: (err: unknown) => string | undefined;
   resetFastMoon: () => void;
   initialized: Ref<boolean>;
+  /** Diagnostic for the connecting splash, set by checkAuth on transient
+   *  failures and cleared once a check gets through. */
+  connectIssue: Ref<string | null>;
   selectedDiffPath: Ref<string | null>;
   fileDiffLines: Ref<DiffViewLine[]>;
   fileDiffLoading: Ref<boolean>;
@@ -206,6 +209,7 @@ export function useWorkspaceState(rawState: ExtendedState, deps: UseWorkspaceSta
     goalErrorMessage,
     resetFastMoon,
     initialized,
+    connectIssue,
     selectedDiffPath,
     fileDiffLines,
     fileDiffLoading,
@@ -328,14 +332,23 @@ export function useWorkspaceState(rawState: ExtendedState, deps: UseWorkspaceSta
       rawState.authReady = result.ready;
       rawState.defaultModel = result.defaultModel;
       rawState.managedProviderStatus = result.managedProvider?.status ?? null;
+      connectIssue.value = null;
       return 'proceed';
     } catch (err) {
       if (isDaemonApiError(err)) {
         if (err.code === 401 || err.code === SERVER_AUTH_UNAUTHORIZED_CODE) {
+          // The ServerAuthDialog explains this one — nothing to surface.
+          connectIssue.value = null;
           return 'server-auth-required';
         }
-        if (err.code >= 400 && err.code < 500) return 'proceed';
+        if (err.code >= 400 && err.code < 500) {
+          connectIssue.value = null;
+          return 'proceed';
+        }
       }
+      // Surface the reason on the splash so "cannot connect" is diagnosable
+      // instead of an unexplained spinner.
+      connectIssue.value = (err instanceof Error ? err.message : String(err)).slice(0, 140);
       return 'retry';
     }
   }

--- a/apps/kimi-web/src/composables/client/useWorkspaceState.ts
+++ b/apps/kimi-web/src/composables/client/useWorkspaceState.ts
@@ -12,6 +12,7 @@ import { getKimiWebApi } from '../../api';
 import { i18n } from '../../i18n';
 import { useConfirmDialog } from '../useConfirmDialog';
 import { isDaemonApiError } from '../../api/errors';
+import { SERVER_AUTH_UNAUTHORIZED_CODE } from '../../api/daemon/http';
 import type {
   AppConfig,
   AppMessage,
@@ -57,6 +58,10 @@ const WORKSPACE_NOT_FOUND_CODE = 40410;
 // duplicate submit is reported as a conflict even though the desired end
 // state (resolved) is already reached. We treat it as a benign no-op.
 const ALREADY_RESOLVED_CODE = 40902;
+// First load polls /auth until it gives a definitive answer (see load()).
+const FIRST_LOAD_AUTH_RETRY_MS = 2000;
+
+type AuthCheckResult = 'answered' | 'retry' | 'server-auth-required';
 
 function isAlreadyResolvedError(err: unknown): boolean {
   return isDaemonApiError(err) && err.code === ALREADY_RESOLVED_CODE;
@@ -303,16 +308,31 @@ export function useWorkspaceState(rawState: ExtendedState, deps: UseWorkspaceSta
     }
   }
 
-  /** Fetch auth readiness from GET /api/v1/auth. Defensive — never throws. */
-  async function checkAuth(): Promise<void> {
+  /** Fetch auth readiness from GET /api/v1/auth. Defensive — never throws.
+   *  Returns whether the daemon gave a definitive answer:
+   *  - 'answered'             — response received; rawState reflects it (ready or not)
+   *  - 'server-auth-required' — the daemon rejected our server credential
+   *                             (401/40101); the ServerAuthDialog owns recovery
+   *                             (it reloads once the token is entered)
+   *  - 'retry'                — transient failure (network, timeout, 5xx); the
+   *                             caller should retry instead of treating it as
+   *                             "not signed in" */
+  async function checkAuth(): Promise<AuthCheckResult> {
     try {
       const api = getKimiWebApi();
       const result = await api.getAuth();
       rawState.authReady = result.ready;
       rawState.defaultModel = result.defaultModel;
       rawState.managedProviderStatus = result.managedProvider?.status ?? null;
-    } catch {
-      // Daemon may not have this endpoint yet; leave defaults (authReady: false)
+      return 'answered';
+    } catch (err) {
+      if (
+        isDaemonApiError(err) &&
+        (err.code === 401 || err.code === SERVER_AUTH_UNAUTHORIZED_CODE)
+      ) {
+        return 'server-auth-required';
+      }
+      return 'retry';
     }
   }
 
@@ -547,7 +567,28 @@ export function useWorkspaceState(rawState: ExtendedState, deps: UseWorkspaceSta
 
   async function load(): Promise<void> {
     rawState.loading = true;
+    // The very first load gates on /auth before anything else: a transient
+    // failure there (daemon still booting, network blip, 5xx) must NOT be read
+    // as "not signed in" — that bounced users to /login until a manual refresh.
+    // Keep the connecting splash up and poll /auth until it gives a definitive
+    // answer. A 401/40101 means the server wants a token: stop and let the
+    // ServerAuthDialog take over (it reloads once the token is entered).
+    const firstLoad = !initialized.value;
+    let authAnswered = true;
     try {
+      if (firstLoad) {
+        for (;;) {
+          const result = await checkAuth();
+          if (result === 'answered') break;
+          if (result === 'server-auth-required') {
+            authAnswered = false;
+            return;
+          }
+          await new Promise((resolve) => {
+            setTimeout(resolve, FIRST_LOAD_AUTH_RETRY_MS);
+          });
+        }
+      }
       const api = getKimiWebApi();
       // Parallel: health + meta + models
       await Promise.all([
@@ -561,7 +602,7 @@ export function useWorkspaceState(rawState: ExtendedState, deps: UseWorkspaceSta
       ]);
 
       // Check auth readiness and global config (separate calls — defensive)
-      await checkAuth();
+      if (!firstLoad) await checkAuth();
       await loadConfig();
 
       // Load workspaces first (registered + derived, each with a session_count),
@@ -607,7 +648,9 @@ export function useWorkspaceState(rawState: ExtendedState, deps: UseWorkspaceSta
       // Do not re-throw — app stays mounted with empty sessions
     } finally {
       rawState.loading = false;
-      initialized.value = true;
+      // Without a definitive /auth answer the splash stays up (retry loop or
+      // ServerAuthDialog is handling it) — never expose the half-loaded app.
+      if (authAnswered) initialized.value = true;
     }
   }
 

--- a/apps/kimi-web/src/composables/client/useWorkspaceState.ts
+++ b/apps/kimi-web/src/composables/client/useWorkspaceState.ts
@@ -357,9 +357,17 @@ export function useWorkspaceState(rawState: ExtendedState, deps: UseWorkspaceSta
    *  FIRST_LOAD_AUTH_RETRY_MS between transient failures. Never resolves with
    *  'retry'. Used only by the first load. */
   async function waitForFirstAuth(): Promise<AuthCheckResult> {
+    let firstRetry = true;
     for (;;) {
       const result = await checkAuth();
       if (result !== 'retry') return result;
+      // Keep the first quick failure silent — a single blip right after page
+      // load shouldn't flash an error. Surface it from the 2nd failed attempt
+      // (~2s in) onward, so a genuinely stuck connection stays diagnosable.
+      if (firstRetry) {
+        connectIssue.value = null;
+        firstRetry = false;
+      }
       await new Promise((resolve) => {
         setTimeout(resolve, FIRST_LOAD_AUTH_RETRY_MS);
       });

--- a/apps/kimi-web/src/composables/client/useWorkspaceState.ts
+++ b/apps/kimi-web/src/composables/client/useWorkspaceState.ts
@@ -391,12 +391,11 @@ export function useWorkspaceState(rawState: ExtendedState, deps: UseWorkspaceSta
   }
 
   /** Fetch auth readiness from GET /api/v1/auth. Defensive — never throws.
-   *  - 'proceed'              — definitive outcome: either a response (rawState
-   *                             reflects it, ready or not) or a deterministic
-   *                             4xx that retrying can never fix (e.g. 404 from
-   *                             an older daemon without this endpoint) — the
-   *                             caller proceeds with the defaults, exactly like
-   *                             the pre-gate fallback did
+   *  The web bundle always ships paired with its daemon, so this endpoint is
+   *  guaranteed to exist — every failure is either a credential rejection or
+   *  a transient error worth retrying:
+   *  - 'proceed'              — response received; rawState reflects it (ready
+   *                             or not)
    *  - 'server-auth-required' — the daemon rejected our server credential
    *                             (401/40101); the ServerAuthDialog owns recovery
    *                             (it reloads once the token is entered)
@@ -413,16 +412,13 @@ export function useWorkspaceState(rawState: ExtendedState, deps: UseWorkspaceSta
       connectIssue.value = null;
       return 'proceed';
     } catch (err) {
-      if (isDaemonApiError(err)) {
-        if (err.code === 401 || err.code === SERVER_AUTH_UNAUTHORIZED_CODE) {
-          // The ServerAuthDialog explains this one — nothing to surface.
-          connectIssue.value = null;
-          return 'server-auth-required';
-        }
-        if (err.code >= 400 && err.code < 500) {
-          connectIssue.value = null;
-          return 'proceed';
-        }
+      if (
+        isDaemonApiError(err) &&
+        (err.code === 401 || err.code === SERVER_AUTH_UNAUTHORIZED_CODE)
+      ) {
+        // The ServerAuthDialog explains this one — nothing to surface.
+        connectIssue.value = null;
+        return 'server-auth-required';
       }
       // Surface the reason on the splash so "cannot connect" is diagnosable
       // instead of an unexplained spinner.

--- a/apps/kimi-web/src/composables/useKimiWebClient.ts
+++ b/apps/kimi-web/src/composables/useKimiWebClient.ts
@@ -599,6 +599,10 @@ const fileDiffLoading = ref(false);
 // False until the very first load() settles (success OR failure). Gates the
 // global connecting-splash so a page refresh doesn't flash a half-empty app.
 const initialized = ref(false);
+// Short diagnostic shown on the connecting splash while the first-load /auth
+// gate keeps retrying (e.g. the daemon's error message). Null when no attempt
+// has failed yet or the last attempt got through.
+const connectIssue = ref<string | null>(null);
 
 /**
  * Fetch GET /sessions/{id}/status and fold the live model + context usage back
@@ -2325,6 +2329,7 @@ const workspaceState = useWorkspaceState(rawState, {
   goalErrorMessage,
   resetFastMoon: appearance.resetFastMoon,
   initialized,
+  connectIssue,
   selectedDiffPath,
   fileDiffLines,
   fileDiffLoading,
@@ -2520,6 +2525,7 @@ export function useKimiWebClient() {
     dangerousBypassAuth,
     clearDangerousBypassAuth,
     initialized,
+    connectIssue,
     permission,
     thinking,
     planMode,

--- a/apps/kimi-web/src/i18n/locales/en/app.ts
+++ b/apps/kimi-web/src/i18n/locales/en/app.ts
@@ -5,5 +5,6 @@ export default {
   authPageMessage: 'Connect your Kimi Code account before starting or continuing conversations.',
   authPageLogin: 'Sign in',
   connecting: 'Connecting…',
+  connectRetrying: 'Cannot reach the server — retrying…',
   internalBuildBanner: 'Internal testing only',
 } as const;

--- a/apps/kimi-web/src/i18n/locales/zh/app.ts
+++ b/apps/kimi-web/src/i18n/locales/zh/app.ts
@@ -5,5 +5,6 @@ export default {
   authPageMessage: '先连接 Kimi Code 账号，然后再开始或继续对话。',
   authPageLogin: '登录',
   connecting: '连接中…',
+  connectRetrying: '无法连接服务器，正在重试…',
   internalBuildBanner: '仅供内部测试',
 } as const;

--- a/apps/kimi-web/test/workspace-state.test.ts
+++ b/apps/kimi-web/test/workspace-state.test.ts
@@ -1,4 +1,4 @@
-import { computed, ref } from 'vue';
+import { computed, ref, type Ref } from 'vue';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { AppApprovalRequest, AppQuestionRequest, AppSession, AppTask } from '../src/api/types';
 import { DaemonApiError } from '../src/api/errors';
@@ -20,6 +20,13 @@ const apiMock = vi.hoisted(() => ({
   respondApproval: vi.fn(),
   dismissQuestion: vi.fn(),
   cancelTask: vi.fn(),
+  getAuth: vi.fn(),
+  getConfig: vi.fn(),
+  getFsHome: vi.fn(),
+  getHealth: vi.fn(),
+  getMeta: vi.fn(),
+  listSessions: vi.fn(),
+  listWorkspaces: vi.fn(),
 }));
 
 vi.mock('../src/api', () => ({
@@ -941,4 +948,100 @@ describe('useWorkspaceState — startSessionAndOpenSideChat', () => {
     expect(openSideChatOn).not.toHaveBeenCalled();
     expect(deps.pushOperationFailure).not.toHaveBeenCalled();
   });
+});
+
+describe('useWorkspaceState — first-load auth gate', () => {
+  beforeEach(() => {
+    apiMock.getAuth.mockReset();
+    apiMock.getHealth.mockReset().mockResolvedValue({ ok: true });
+    apiMock.getMeta.mockReset().mockResolvedValue({
+      serverVersion: '0.0.0',
+      openInApps: [],
+      dangerousBypassAuth: false,
+    });
+    apiMock.getConfig.mockReset().mockResolvedValue({});
+    apiMock.listWorkspaces.mockReset().mockResolvedValue([]);
+    apiMock.getFsHome.mockReset().mockResolvedValue({ home: '', recentRoots: [] });
+    apiMock.listSessions.mockReset().mockResolvedValue({ items: [], hasMore: false });
+  });
+
+  function createLoadDeps(initialized: Ref<boolean>): UseWorkspaceStateDeps {
+    return {
+      ...createDeps(),
+      modelProvider: { loadModels: vi.fn().mockResolvedValue(undefined) },
+      initialized,
+    } as unknown as UseWorkspaceStateDeps;
+  }
+
+  it('keeps the splash up and retries /auth when the first check fails transiently', async () => {
+    vi.useFakeTimers();
+    try {
+      const initialized = ref(false);
+      const state = createState();
+      state.authReady = false;
+      apiMock.getAuth
+        .mockRejectedValueOnce(new Error('connection refused'))
+        .mockResolvedValue({ ready: true, defaultModel: 'kimi-code', managedProvider: null });
+      const ws = useWorkspaceState(state, createLoadDeps(initialized));
+
+      const pending = ws.load();
+      await vi.advanceTimersByTimeAsync(0);
+      // First /auth failed: NOT treated as "not signed in" — no initialization.
+      expect(initialized.value).toBe(false);
+      expect(apiMock.getAuth).toHaveBeenCalledTimes(1);
+
+      // The 2s retry re-checks /auth; once it answers, load completes.
+      await vi.advanceTimersByTimeAsync(2000);
+      await pending;
+      expect(apiMock.getAuth).toHaveBeenCalledTimes(2);
+      expect(initialized.value).toBe(true);
+      expect(state.authReady).toBe(true);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('initializes normally (into the login gate) when /auth answers ready:false', async () => {
+    const initialized = ref(false);
+    const state = createState();
+    state.authReady = false;
+    apiMock.getAuth.mockResolvedValue({ ready: false, defaultModel: null, managedProvider: null });
+    const ws = useWorkspaceState(state, createLoadDeps(initialized));
+
+    await ws.load();
+
+    // A definitive "not ready" answer behaves exactly as before: initialize and
+    // let the auth gate show /login.
+    expect(apiMock.getAuth).toHaveBeenCalledTimes(1);
+    expect(initialized.value).toBe(true);
+    expect(state.authReady).toBe(false);
+  });
+
+  it.each([40101, 401])(
+    'stops without retrying when /auth rejects with %i (server token required)',
+    async (code) => {
+      vi.useFakeTimers();
+      try {
+        const initialized = ref(false);
+        const state = createState();
+        state.authReady = false;
+        apiMock.getAuth.mockRejectedValue(
+          new DaemonApiError({ code, msg: 'Unauthorized', requestId: 'req_1' }),
+        );
+        const ws = useWorkspaceState(state, createLoadDeps(initialized));
+
+        await ws.load();
+        expect(apiMock.getAuth).toHaveBeenCalledTimes(1);
+        expect(initialized.value).toBe(false);
+
+        // No retry loop is running — recovery belongs to the ServerAuthDialog,
+        // which reloads the page once the user enters the token.
+        await vi.advanceTimersByTimeAsync(10_000);
+        expect(apiMock.getAuth).toHaveBeenCalledTimes(1);
+        expect(initialized.value).toBe(false);
+      } finally {
+        vi.useRealTimers();
+      }
+    },
+  );
 });

--- a/apps/kimi-web/test/workspace-state.test.ts
+++ b/apps/kimi-web/test/workspace-state.test.ts
@@ -1044,4 +1044,29 @@ describe('useWorkspaceState — first-load auth gate', () => {
       }
     },
   );
+
+  it('proceeds with the defaults when /auth returns a deterministic 4xx (older daemon)', async () => {
+    vi.useFakeTimers();
+    try {
+      const initialized = ref(false);
+      const state = createState();
+      state.authReady = false;
+      // e.g. an older daemon without /api/v1/auth answers 404 — retrying can
+      // never fix that, so the pre-gate fallback (defaults → login gate) runs.
+      apiMock.getAuth.mockRejectedValue(
+        new DaemonApiError({ code: 404, msg: 'Not Found', requestId: 'req_1' }),
+      );
+      const ws = useWorkspaceState(state, createLoadDeps(initialized));
+
+      await ws.load();
+      expect(apiMock.getAuth).toHaveBeenCalledTimes(1);
+      expect(initialized.value).toBe(true);
+      expect(state.authReady).toBe(false);
+
+      await vi.advanceTimersByTimeAsync(10_000);
+      expect(apiMock.getAuth).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
 });

--- a/apps/kimi-web/test/workspace-state.test.ts
+++ b/apps/kimi-web/test/workspace-state.test.ts
@@ -986,21 +986,28 @@ describe('useWorkspaceState — first-load auth gate', () => {
       state.authReady = false;
       apiMock.getAuth
         .mockRejectedValueOnce(new Error('connection refused'))
+        .mockRejectedValueOnce(new Error('connection refused'))
         .mockResolvedValue({ ready: true, defaultModel: 'kimi-code', managedProvider: null });
       const ws = useWorkspaceState(state, createLoadDeps(initialized, connectIssue));
 
       const pending = ws.load();
       await vi.advanceTimersByTimeAsync(0);
       // First /auth failed: NOT treated as "not signed in" — no initialization.
+      // The first failure stays silent so a single blip flashes no error.
       expect(initialized.value).toBe(false);
       expect(apiMock.getAuth).toHaveBeenCalledTimes(1);
-      // The failure reason is surfaced for the connecting splash.
+      expect(connectIssue.value).toBeNull();
+
+      // From the 2nd failed attempt the reason is surfaced for the splash.
+      await vi.advanceTimersByTimeAsync(2000);
+      expect(apiMock.getAuth).toHaveBeenCalledTimes(2);
+      expect(initialized.value).toBe(false);
       expect(connectIssue.value).toBe('connection refused');
 
-      // The 2s retry re-checks /auth; once it answers, load completes.
+      // The retry re-checks /auth; once it answers, load completes.
       await vi.advanceTimersByTimeAsync(2000);
       await pending;
-      expect(apiMock.getAuth).toHaveBeenCalledTimes(2);
+      expect(apiMock.getAuth).toHaveBeenCalledTimes(3);
       expect(initialized.value).toBe(true);
       expect(state.authReady).toBe(true);
       expect(connectIssue.value).toBeNull();

--- a/apps/kimi-web/test/workspace-state.test.ts
+++ b/apps/kimi-web/test/workspace-state.test.ts
@@ -1059,31 +1059,6 @@ describe('useWorkspaceState — first-load auth gate', () => {
       }
     },
   );
-
-  it('proceeds with the defaults when /auth returns a deterministic 4xx (older daemon)', async () => {
-    vi.useFakeTimers();
-    try {
-      const initialized = ref(false);
-      const state = createState();
-      state.authReady = false;
-      // e.g. an older daemon without /api/v1/auth answers 404 — retrying can
-      // never fix that, so the pre-gate fallback (defaults → login gate) runs.
-      apiMock.getAuth.mockRejectedValue(
-        new DaemonApiError({ code: 404, msg: 'Not Found', requestId: 'req_1' }),
-      );
-      const ws = useWorkspaceState(state, createLoadDeps(initialized, ref(null)));
-
-      await ws.load();
-      expect(apiMock.getAuth).toHaveBeenCalledTimes(1);
-      expect(initialized.value).toBe(true);
-      expect(state.authReady).toBe(false);
-
-      await vi.advanceTimersByTimeAsync(10_000);
-      expect(apiMock.getAuth).toHaveBeenCalledTimes(1);
-    } finally {
-      vi.useRealTimers();
-    }
-  });
 });
 
 // Regression coverage for wake/reconnect snapshot recovery.

--- a/apps/kimi-web/test/workspace-state.test.ts
+++ b/apps/kimi-web/test/workspace-state.test.ts
@@ -965,11 +965,15 @@ describe('useWorkspaceState — first-load auth gate', () => {
     apiMock.listSessions.mockReset().mockResolvedValue({ items: [], hasMore: false });
   });
 
-  function createLoadDeps(initialized: Ref<boolean>): UseWorkspaceStateDeps {
+  function createLoadDeps(
+    initialized: Ref<boolean>,
+    connectIssue: Ref<string | null>,
+  ): UseWorkspaceStateDeps {
     return {
       ...createDeps(),
       modelProvider: { loadModels: vi.fn().mockResolvedValue(undefined) },
       initialized,
+      connectIssue,
     } as unknown as UseWorkspaceStateDeps;
   }
 
@@ -977,18 +981,21 @@ describe('useWorkspaceState — first-load auth gate', () => {
     vi.useFakeTimers();
     try {
       const initialized = ref(false);
+      const connectIssue = ref<string | null>(null);
       const state = createState();
       state.authReady = false;
       apiMock.getAuth
         .mockRejectedValueOnce(new Error('connection refused'))
         .mockResolvedValue({ ready: true, defaultModel: 'kimi-code', managedProvider: null });
-      const ws = useWorkspaceState(state, createLoadDeps(initialized));
+      const ws = useWorkspaceState(state, createLoadDeps(initialized, connectIssue));
 
       const pending = ws.load();
       await vi.advanceTimersByTimeAsync(0);
       // First /auth failed: NOT treated as "not signed in" — no initialization.
       expect(initialized.value).toBe(false);
       expect(apiMock.getAuth).toHaveBeenCalledTimes(1);
+      // The failure reason is surfaced for the connecting splash.
+      expect(connectIssue.value).toBe('connection refused');
 
       // The 2s retry re-checks /auth; once it answers, load completes.
       await vi.advanceTimersByTimeAsync(2000);
@@ -996,6 +1003,7 @@ describe('useWorkspaceState — first-load auth gate', () => {
       expect(apiMock.getAuth).toHaveBeenCalledTimes(2);
       expect(initialized.value).toBe(true);
       expect(state.authReady).toBe(true);
+      expect(connectIssue.value).toBeNull();
     } finally {
       vi.useRealTimers();
     }
@@ -1006,7 +1014,7 @@ describe('useWorkspaceState — first-load auth gate', () => {
     const state = createState();
     state.authReady = false;
     apiMock.getAuth.mockResolvedValue({ ready: false, defaultModel: null, managedProvider: null });
-    const ws = useWorkspaceState(state, createLoadDeps(initialized));
+    const ws = useWorkspaceState(state, createLoadDeps(initialized, ref(null)));
 
     await ws.load();
 
@@ -1028,7 +1036,7 @@ describe('useWorkspaceState — first-load auth gate', () => {
         apiMock.getAuth.mockRejectedValue(
           new DaemonApiError({ code, msg: 'Unauthorized', requestId: 'req_1' }),
         );
-        const ws = useWorkspaceState(state, createLoadDeps(initialized));
+        const ws = useWorkspaceState(state, createLoadDeps(initialized, ref(null)));
 
         await ws.load();
         expect(apiMock.getAuth).toHaveBeenCalledTimes(1);
@@ -1056,7 +1064,7 @@ describe('useWorkspaceState — first-load auth gate', () => {
       apiMock.getAuth.mockRejectedValue(
         new DaemonApiError({ code: 404, msg: 'Not Found', requestId: 'req_1' }),
       );
-      const ws = useWorkspaceState(state, createLoadDeps(initialized));
+      const ws = useWorkspaceState(state, createLoadDeps(initialized, ref(null)));
 
       await ws.load();
       expect(apiMock.getAuth).toHaveBeenCalledTimes(1);


### PR DESCRIPTION
## Related Issue

No linked issue — the problem is explained below (reported by users).

## Problem

Right after starting or updating the web UI, the first visit lands on `/login`; a manual refresh then loads the app normally.

Root cause: the first `GET /api/v1/auth` failing transiently (daemon still booting, config being rewritten by an upgrade, network blip, 5xx) was silently swallowed by the auth check, leaving `authReady` at its default `false`. The initial load then unconditionally marked itself initialized, so the auth gate (`initialized && !authReady`) rewrote the URL to `/login` — with no re-check anywhere, the page stayed there until a full reload.

## What changed

- The auth check now distinguishes three outcomes instead of swallowing all errors: `proceed` (a definitive response, ready or not), `retry` (transient failure: network error, timeout, 5xx), and `server-auth-required` (401 or envelope code 40101). The web bundle always ships paired with its daemon, so a daemon lacking this endpoint is out of scope by design.
- The first load gates on `/auth` before health/meta/models: a transient failure keeps the existing connecting splash up and retries `/auth` every 2s until it answers; a definitive answer proceeds exactly as before (`ready:true` → app, `ready:false` → `/login`); a 401/40101 stops and hands over to the server-token dialog, which already reloads the page once the token is entered.
- While the splash is retrying, it now shows a "cannot reach the server — retrying…" line with the last error message underneath, so a stuck "connecting" state is diagnosable from the page itself.
- `App.vue`: the token dialog flag now starts `false` and is only set by a real 401/40101 — previously it started from "no credential ⇒ prompt" and flashed the dialog for a frame in `--dangerous-bypass-auth` mode before `/meta` arrived. The 401 listener is also registered before the initial load starts.
- `ServerAuthDialog`: z-index `--z-modal` → `--z-max`, so the prompt stays reachable above the connecting splash (`--z-toast`) when a 401 happens during first load.
- Onboarding overlay: now gated on `client.initialized` too — it teleports to `<body>` and previously floated above the connecting splash (and its retry error) when the first load was still stuck.
- Tests: three new cases in `workspace-state.test.ts` — transient failure keeps the splash and retries until success (first failure silent, error surfaced from the second); a definitive `ready:false` still initializes into the login gate; 401/40101 stops without retrying or initializing.

Verified: `pnpm --filter @moonshot-ai/kimi-web test|typecheck|check:style|build` all pass; oxlint reports no new warnings on the touched files.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update (bug fix restoring the intended behavior; no documented behavior changes).
