### PR TITLE
fix(web): scroll wide markdown tables inside their own wrapper

### DIFF
--- a/.changeset/web-wide-table-scroll.md
+++ b/.changeset/web-wide-table-scroll.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+web: Let wide Markdown tables scroll horizontally inside the table instead of being squeezed into the reading column.

--- a/apps/kimi-web/src/components/chat/Markdown.vue
+++ b/apps/kimi-web/src/components/chat/Markdown.vue
@@ -723,33 +723,34 @@ function copyDiff(code: string, idx: number) {
   font-weight: var(--weight-medium);
 }
 
-/* Markdown tables. markstream-vue pins these to the message width
-   (`width:100%` + `table-layout:fixed`), squeezing wide content into narrow
-   columns. Instead we size columns to their content (`width:auto` +
-   `table-layout:auto`) and let cells WRAP, so a wide table fills the reading
-   column and wraps its text rather than being crushed or scrolling. (An earlier
-   attempt to break the table out into a *wider* column than the prose — via
-   container units and then fixed @container caps — is parked; see the handover
-   doc.) `!important` beats markstream's scoped `.table-node[data-v-…]` rules
-   regardless of injection order. */
+/* Markdown tables — wide tables scroll horizontally INSIDE the table's own
+   wrapper instead of squeezing into (or overflowing) the reading column.
+   The wrapper is a fixed-width local scroll container: it stays pinned to the
+   message width (`width:100%`, `min-width:0` so it can shrink inside flex
+   tracks) and clips any overflow behind its own `overflow-x:auto` scrollbar —
+   the chat pane and the page never scroll sideways. The table itself grows to
+   its content width (`width:max-content`, `max-width:none`,
+   `table-layout:auto`), so many-column or long-cell tables keep their natural
+   layout and only the excess scrolls within the wrapper. `min-width:100%` keeps
+   narrow tables stretched to fill the wrapper exactly as before. `!important`
+   beats markstream's scoped `.table-node[data-v-…]` rules regardless of
+   injection order. */
+.md :deep(.table-node-wrapper) {
+  width: 100%;
+  max-width: 100% !important;
+  min-width: 0;
+  overflow-x: auto !important;
+}
+
 .md :deep(.table-node) {
   --table-border: var(--color-line);
   --table-header-bg: var(--color-surface);
   font-size: var(--text-lg);
   margin: 0.5em 0;
-  width: auto !important;
-  max-width: 100% !important;
+  width: max-content !important;
+  min-width: 100%;
+  max-width: none !important;
   table-layout: auto !important;
-}
-/* Default: the table stays inside the reading column and its cells wrap to fit
-   — markstream's own cell default is already `white-space:normal`, so a wide
-   table simply wraps into the column instead of forcing a horizontal scroll.
-   `max-content` + `max-width:100%` sizes columns to their content up to the
-   column width; `overflow-x:auto` is a safety net for an unbreakable cell. */
-.md :deep(.table-node-wrapper) {
-  width: max-content;
-  max-width: 100% !important;
-  overflow-x: auto !important;
 }
 .md :deep(.table-node th),
 .md :deep(.table-node td) {


### PR DESCRIPTION
## Related Issue

No linked issue — the problem is explained below.

## Problem

In the web UI, markdown tables were pinned to the message width (`width: 100%` + `table-layout: fixed` from markstream-vue's defaults, with cells wrapping to fit). Tables with many columns or long unbreakable cells (URLs, paths, inline code) were crushed into narrow columns and became hard to read, and an unbreakable cell could still overflow the 760px reading column.

## What changed

Scoped CSS only in `apps/kimi-web/src/components/chat/Markdown.vue`:

- `.table-node-wrapper` is now a fixed-width local scroll container (`width: 100%`, `min-width: 0`, `overflow-x: auto`): wide tables scroll horizontally inside the table itself, never the chat pane or the page.
- `.table-node` grows to its content width (`width: max-content`, `max-width: none`, `table-layout: auto`), so columns keep their natural layout.
- `min-width: 100%` keeps narrow tables stretched to fill the reading column exactly as before.
- Existing table colors, alignment, and hover rules are unchanged; no parser or dependency changes.

Verified: `pnpm --filter @moonshot-ai/kimi-web typecheck`, `check:style`, and `build` all pass.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [ ] I have added tests that prove my feature works. (CSS-only behavior change; no internal tests for CSS behavior — verified via typecheck/check:style/build and manual browser checks.)
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update. (Minor rendering behavior tweak; nothing documented to update.)
