### PR TITLE
fix(web): wide markdown tables scroll internally and break out on desktop

### DIFF
--- a/.changeset/web-wide-table-breakout.md
+++ b/.changeset/web-wide-table-breakout.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+web: Let wide Markdown tables in the desktop chat grow beyond the reading column up to 1040px, temporarily hiding the conversation outline while a table passes under it; anything wider still scrolls inside the table.

--- a/.changeset/web-wide-table-scroll.md
+++ b/.changeset/web-wide-table-scroll.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+web: Let wide Markdown tables scroll horizontally inside the table instead of being squeezed into the reading column.

--- a/apps/kimi-web/src/components/chat/ChatPane.vue
+++ b/apps/kimi-web/src/components/chat/ChatPane.vue
@@ -1032,6 +1032,33 @@ function isStreamingRenderBlock(turn: ChatTurn, block: { sourceIndex: number }):
   color: var(--color-accent-hover);
 }
 
+/* ===================== Wide tables (desktop) ===================== */
+/* 760px corresponds to --p-content-max. Container-query conditions cannot
+   reference CSS custom properties directly. */
+@container (min-width: 760px) {
+  /* markstream's content-visibility:auto implies paint containment, which can
+     clip a table that breaks out of the normal Markdown width. Disable it only
+     for renderers that actually contain a table. Keep contain:layout intact. */
+  .a-msg .msg :deep(.markstream-vue.markdown-renderer:has(.table-node-wrapper)) {
+    content-visibility: visible;
+  }
+
+  /* Let a table grow naturally beyond the reading column, centred within the
+     conversation pane. The first-stage overflow-x:auto continues to handle
+     content wider than this wrapper. */
+  .a-msg .msg :deep(.table-node-wrapper) {
+    position: relative;
+    left: 50%;
+    width: max-content;
+    min-width: 100%;
+    max-width: min(
+      var(--p-table-max),
+      calc(100cqi - var(--space-5) - var(--space-5))
+    ) !important;
+    transform: translateX(-50%);
+  }
+}
+
 .u-imgs {
   display: flex;
   flex-wrap: wrap;

--- a/apps/kimi-web/src/components/chat/ConversationPane.vue
+++ b/apps/kimi-web/src/components/chat/ConversationPane.vue
@@ -405,6 +405,52 @@ function updateActiveTocQuery(): void {
   activeTurnId.value = bestId ?? items[0]!.id;
 }
 
+// --- TOC occlusion by wide tables -------------------------------------------
+// Wide markdown tables (up to --p-table-max) can extend past the TOC rail,
+// which stays anchored to the --p-content-wide edge. While a table actually
+// covers the rail we hide the TOC temporarily so the table stays fully
+// interactive (clicks, text selection, horizontal scroll). The user's TOC
+// setting is untouched and the rail returns as soon as the table scrolls away.
+const tocOccludedByTable = ref(false);
+let tocHitTestRaf = 0;
+
+function scheduleTocTableHitTest(): void {
+  if (tocHitTestRaf) return;
+  tocHitTestRaf = raf(() => {
+    tocHitTestRaf = 0;
+    updateTocTableOcclusion();
+  });
+}
+
+function updateTocTableOcclusion(): void {
+  const pane = panesRef.value;
+  const toc =
+    !props.mobile && props.conversationToc && pane
+      ? pane.closest('.con')?.querySelector<HTMLElement>('.conversation-toc')
+      : null;
+  // The hit point is the centre of the fixed rail bar: `.toc-bar` keeps a
+  // stable x even when hover expands the labels rightward, so hovering the TOC
+  // itself never flips the state (the nav centre would).
+  const bar = toc?.querySelector<HTMLElement>('.toc-bar');
+  let covered = false;
+  if (pane && toc && bar) {
+    const barRect = bar.getBoundingClientRect();
+    const tocRect = toc.getBoundingClientRect();
+    const x = barRect.left + barRect.width / 2;
+    const y = tocRect.top + tocRect.height / 2;
+    // The rail paints above the table, so look THROUGH it at the full element
+    // stack; only a table wrapper inside THIS pane counts (other panes, e.g.
+    // the side chat or a preview, must not occlude this rail).
+    covered = document.elementsFromPoint(x, y).some((element) => {
+      const wrapper = element.closest('.table-node-wrapper');
+      return wrapper instanceof HTMLElement && pane.contains(wrapper);
+    });
+  }
+  if (tocOccludedByTable.value !== covered) {
+    tocOccludedByTable.value = covered;
+  }
+}
+
 // The first pending question (if any)
 const pendingQuestion = computed<UIQuestion | undefined>(() =>
   props.questions && props.questions.length > 0 ? props.questions[0] : undefined,
@@ -527,6 +573,7 @@ function hasUserActionFollowLock(): boolean {
 }
 
 function onPanesScroll(): void {
+  scheduleTocTableHitTest();
   const el = panesRef.value;
   if (!el) return;
   const top = el.scrollTop;
@@ -1155,11 +1202,13 @@ function rebindScrollObservers(): void {
   }
   lastObservedScrollHeight = el?.scrollHeight ?? 0;
   lastObservedClientHeight = el?.clientHeight ?? 0;
+  scheduleTocTableHitTest();
 }
 
 function onContentMutated(): void {
   ensureContentObserved();
   scheduleFollow();
+  scheduleTocTableHitTest();
 }
 
 function onVisibilityChange(): void {
@@ -1203,6 +1252,7 @@ onMounted(() => {
     }
     if (typeof ResizeObserver === 'function') {
       resizeObserver = new ResizeObserver(() => {
+        scheduleTocTableHitTest();
         updatePanesScrollbarWidth();
         const el = panesRef.value;
         if (!el) return;
@@ -1235,6 +1285,7 @@ onUnmounted(() => {
   if (scrollRaf) cancelRaf(scrollRaf);
   if (stableFollowRaf) cancelRaf(stableFollowRaf);
   if (pinRaf) cancelRaf(pinRaf);
+  if (tocHitTestRaf) cancelRaf(tocHitTestRaf);
   if (abortToastTimer !== null) clearTimeout(abortToastTimer);
   if (copyConversationCopiedTimer !== null) {
     clearTimeout(copyConversationCopiedTimer);
@@ -1288,6 +1339,7 @@ defineExpose({ loadComposerForEdit, focusComposer });
       :active-turn-id="activeTurnId"
       :mobile="mobile"
       :session-loading="sessionLoading"
+      :occluded="tocOccludedByTable"
       @select="scrollToTurn"
     />
 

--- a/apps/kimi-web/src/components/chat/ConversationPane.vue
+++ b/apps/kimi-web/src/components/chat/ConversationPane.vue
@@ -407,7 +407,7 @@ function updateActiveTocQuery(): void {
 
 // --- TOC occlusion by wide tables -------------------------------------------
 // Wide markdown tables (up to --p-table-max) can extend past the TOC rail,
-// which stays anchored to the --p-content-wide edge. While a table actually
+// which stays anchored to the reading-column edge. While a table actually
 // covers the rail we hide the TOC temporarily so the table stays fully
 // interactive (clicks, text selection, horizontal scroll). The user's TOC
 // setting is untouched and the rail returns as soon as the table scrolls away.
@@ -428,23 +428,31 @@ function updateTocTableOcclusion(): void {
     !props.mobile && props.conversationToc && pane
       ? pane.closest('.con')?.querySelector<HTMLElement>('.conversation-toc')
       : null;
-  // The hit point is the centre of the fixed rail bar: `.toc-bar` keeps a
-  // stable x even when hover expands the labels rightward, so hovering the TOC
-  // itself never flips the state (the nav centre would).
+  // The hit x is the centre of the fixed rail bar: `.toc-bar` keeps a stable x
+  // even when hover expands the labels rightward, so hovering the TOC itself
+  // never flips the state (the nav centre would).
   const bar = toc?.querySelector<HTMLElement>('.toc-bar');
   let covered = false;
   if (pane && toc && bar) {
     const barRect = bar.getBoundingClientRect();
     const tocRect = toc.getBoundingClientRect();
     const x = barRect.left + barRect.width / 2;
-    const y = tocRect.top + tocRect.height / 2;
-    // The rail paints above the table, so look THROUGH it at the full element
-    // stack; only a table wrapper inside THIS pane counts (other panes, e.g.
-    // the side chat or a preview, must not occlude this rail).
-    covered = document.elementsFromPoint(x, y).some((element) => {
-      const wrapper = element.closest('.table-node-wrapper');
-      return wrapper instanceof HTMLElement && pane.contains(wrapper);
-    });
+    // Sample down the whole rail, not just its midpoint: a short wide table
+    // can pass under the top or bottom rows without ever covering the centre,
+    // and the rows there would still intercept the table's pointer events.
+    // 40px steps are smaller than any real table's height, so none can slip
+    // between samples; stop at the first hit.
+    const step = 40;
+    const startY = tocRect.top + Math.min(step / 2, tocRect.height / 2);
+    for (let y = startY; y < tocRect.bottom && !covered; y += step) {
+      // The rail paints above the table, so look THROUGH it at the full
+      // element stack; only a table wrapper inside THIS pane counts (other
+      // panes, e.g. the side chat or a preview, must not occlude this rail).
+      covered = document.elementsFromPoint(x, y).some((element) => {
+        const wrapper = element.closest('.table-node-wrapper');
+        return wrapper instanceof HTMLElement && pane.contains(wrapper);
+      });
+    }
   }
   if (tocOccludedByTable.value !== covered) {
     tocOccludedByTable.value = covered;

--- a/apps/kimi-web/src/components/chat/ConversationPane.vue
+++ b/apps/kimi-web/src/components/chat/ConversationPane.vue
@@ -436,23 +436,24 @@ function updateTocTableOcclusion(): void {
   if (pane && toc && bar) {
     const barRect = bar.getBoundingClientRect();
     const tocRect = toc.getBoundingClientRect();
-    const x = barRect.left + barRect.width / 2;
-    // Sample down the whole rail, not just its midpoint: a short wide table
-    // can pass under the top or bottom rows without ever covering the centre,
-    // and the rows there would still intercept the table's pointer events.
-    // 40px steps are smaller than any real table's height, so none can slip
-    // between samples; stop at the first hit.
-    const step = 40;
-    const startY = tocRect.top + Math.min(step / 2, tocRect.height / 2);
-    for (let y = startY; y < tocRect.bottom && !covered; y += step) {
-      // The rail paints above the table, so look THROUGH it at the full
-      // element stack; only a table wrapper inside THIS pane counts (other
-      // panes, e.g. the side chat or a preview, must not occlude this rail).
-      covered = document.elementsFromPoint(x, y).some((element) => {
-        const wrapper = element.closest('.table-node-wrapper');
-        return wrapper instanceof HTMLElement && pane.contains(wrapper);
-      });
-    }
+    const railX = barRect.left + barRect.width / 2;
+    // Plain geometric overlap: the rail paints above the content, so any table
+    // wrapper that covers the bar's x AND overlaps the rail vertically would
+    // have its pointer events intercepted by the rail — hide the TOC until the
+    // table scrolls away. Rect overlap is exact (no sampling gap) and ignores
+    // paint-order quirks. Only wrappers inside THIS pane count; other panes
+    // (side chat, preview) are outside `pane`.
+    covered = Array.from(
+      pane.querySelectorAll<HTMLElement>('.table-node-wrapper'),
+    ).some((wrapper) => {
+      const rect = wrapper.getBoundingClientRect();
+      return (
+        rect.left <= railX &&
+        railX <= rect.right &&
+        rect.top < tocRect.bottom &&
+        rect.bottom > tocRect.top
+      );
+    });
   }
   if (tocOccludedByTable.value !== covered) {
     tocOccludedByTable.value = covered;

--- a/apps/kimi-web/src/components/chat/ConversationToc.vue
+++ b/apps/kimi-web/src/components/chat/ConversationToc.vue
@@ -17,6 +17,10 @@ const props = defineProps<{
   activeTurnId: string | null;
   mobile?: boolean;
   sessionLoading?: boolean;
+  /** Temporarily hidden while a wide table actually covers the rail. Kept out
+      of `visible` on purpose: the nav must stay mounted so the occlusion can
+      be measured and lifted again. Never touches the user's TOC setting. */
+  occluded?: boolean;
 }>();
 
 const emit = defineEmits<{
@@ -95,9 +99,9 @@ onBeforeUnmount(() => {
     v-if="visible"
     ref="navRef"
     class="conversation-toc"
-    :class="{ 'toc-clipped': !fits }"
+    :class="{ 'toc-clipped': !fits || occluded }"
     :aria-label="t('conversation.toc')"
-    :aria-hidden="fits ? undefined : true"
+    :aria-hidden="fits && !occluded ? undefined : true"
   >
     <div class="toc-scroll">
       <button
@@ -121,7 +125,15 @@ onBeforeUnmount(() => {
   z-index: var(--z-sticky);
   top: 50%;
   transform: translateY(-50%);
-  left: calc(50% + (var(--read-max) / 2) + 14px);
+  /* Anchor to the reading-column edge, the rail's original position. Tables
+     that grow past it (up to --p-table-max) temporarily hide the rail via the
+     occlusion hit-test in ConversationPane, so proximity is safe again.
+     The cqi cap keeps the rail inside narrow containers. */
+  --toc-content-max: min(
+    var(--p-content-max),
+    calc(100cqi - var(--space-5) - var(--space-5))
+  );
+  left: calc(50% + (var(--toc-content-max) / 2) + 14px);
   display: flex;
   flex-direction: column;
   justify-content: center;
@@ -130,15 +142,18 @@ onBeforeUnmount(() => {
 }
 /* Invisible hover bridge: the collapsed rail is only a few px wide, so this
    extends the hover target on both sides to make the outline easy to open and
-   forgiving to stay within. Kept at z-index 0 so it sits behind the rows
-   (which are raised to z-index 1) — otherwise the bridge, as a positioned
-   pseudo-element, paints above the in-flow rows and swallows their clicks. */
+   forgiving to stay within. The left side covers only the 14px gap to the
+   content edge — a table wide enough to reach past the gap also covers the
+   bar, which hides the rail (pointer-events: none) before the bridge can
+   steal its events. Kept at z-index 0 so it sits behind the rows (which are
+   raised to z-index 1) — otherwise the bridge, as a positioned pseudo-element,
+   paints above the in-flow rows and swallows their clicks. */
 .conversation-toc::before {
   content: "";
   position: absolute;
   top: 0;
   bottom: 0;
-  left: -48px;
+  left: -14px;
   right: -48px;
   z-index: 0;
 }

--- a/apps/kimi-web/src/components/chat/Markdown.vue
+++ b/apps/kimi-web/src/components/chat/Markdown.vue
@@ -723,33 +723,34 @@ function copyDiff(code: string, idx: number) {
   font-weight: var(--weight-medium);
 }
 
-/* Markdown tables. markstream-vue pins these to the message width
-   (`width:100%` + `table-layout:fixed`), squeezing wide content into narrow
-   columns. Instead we size columns to their content (`width:auto` +
-   `table-layout:auto`) and let cells WRAP, so a wide table fills the reading
-   column and wraps its text rather than being crushed or scrolling. (An earlier
-   attempt to break the table out into a *wider* column than the prose — via
-   container units and then fixed @container caps — is parked; see the handover
-   doc.) `!important` beats markstream's scoped `.table-node[data-v-…]` rules
-   regardless of injection order. */
+/* Markdown tables — wide tables scroll horizontally INSIDE the table's own
+   wrapper instead of squeezing into (or overflowing) the reading column.
+   The wrapper is a fixed-width local scroll container: it stays pinned to the
+   message width (`width:100%`, `min-width:0` so it can shrink inside flex
+   tracks) and clips any overflow behind its own `overflow-x:auto` scrollbar —
+   the chat pane and the page never scroll sideways. The table itself grows to
+   its content width (`width:max-content`, `max-width:none`,
+   `table-layout:auto`), so many-column or long-cell tables keep their natural
+   layout and only the excess scrolls within the wrapper. `min-width:100%` keeps
+   narrow tables stretched to fill the wrapper exactly as before. `!important`
+   beats markstream's scoped `.table-node[data-v-…]` rules regardless of
+   injection order. */
+.md :deep(.table-node-wrapper) {
+  width: 100%;
+  max-width: 100% !important;
+  min-width: 0;
+  overflow-x: auto !important;
+}
+
 .md :deep(.table-node) {
   --table-border: var(--color-line);
   --table-header-bg: var(--color-surface);
   font-size: var(--text-lg);
   margin: 0.5em 0;
-  width: auto !important;
-  max-width: 100% !important;
+  width: max-content !important;
+  min-width: 100%;
+  max-width: none !important;
   table-layout: auto !important;
-}
-/* Default: the table stays inside the reading column and its cells wrap to fit
-   — markstream's own cell default is already `white-space:normal`, so a wide
-   table simply wraps into the column instead of forcing a horizontal scroll.
-   `max-content` + `max-width:100%` sizes columns to their content up to the
-   column width; `overflow-x:auto` is a safety net for an unbreakable cell. */
-.md :deep(.table-node-wrapper) {
-  width: max-content;
-  max-width: 100% !important;
-  overflow-x: auto !important;
 }
 .md :deep(.table-node th),
 .md :deep(.table-node td) {

--- a/apps/kimi-web/src/style.css
+++ b/apps/kimi-web/src/style.css
@@ -503,6 +503,7 @@ html[data-color-scheme="dark"][data-accent="mono"] {
   --p-sidebar-w: 264px;
   --p-content-max: 760px;
   --p-content-wide: 920px;
+  --p-table-max: 1040px;
   --p-bp-sm: 640px;
   --p-bp-md: 980px;
 }

--- a/apps/kimi-web/src/views/DesignSystemView.vue
+++ b/apps/kimi-web/src/views/DesignSystemView.vue
@@ -417,8 +417,9 @@ onUnmounted(() => {
               <thead><tr><th>Token</th><th>Value</th><th>Usage</th></tr></thead>
               <tbody>
                 <tr><td class="tk">--p-sidebar-w</td><td class="val">264px</td><td>left session sidebar width</td></tr>
-                <tr><td class="tk">--p-content-max</td><td class="val">760px</td><td>chat reading-column max width</td></tr>
+                <tr><td class="tk">--p-content-max</td><td class="val">760px</td><td>chat reading-column max width (regular chat prose)</td></tr>
                 <tr><td class="tk">--p-content-wide</td><td class="val">920px</td><td>wide content (settings / panel)</td></tr>
+                <tr><td class="tk">--p-table-max</td><td class="val">1040px</td><td>desktop wide-table max width (see §04)</td></tr>
                 <tr><td class="tk">--p-bp-sm</td><td class="val">640px</td><td>mobile / desktop boundary</td></tr>
                 <tr><td class="tk">--p-bp-md</td><td class="val">980px</td><td>narrow / wide screen boundary</td></tr>
               </tbody>
@@ -1118,6 +1119,7 @@ onUnmounted(() => {
                 </div>
               </div>
             </div>
+            <p><b>Wide markdown tables (desktop):</b> regular chat prose stays within the 760px reading column (<code>--p-content-max</code>). On desktop a wide table may grow naturally with its content up to 1040px (<code>--p-table-max</code>), centred within the conversation pane; beyond that the excess scrolls horizontally inside the table's own wrapper — the page and the chat area never scroll sideways. The conversation outline (TOC) keeps its usual position just outside the reading column; when a table grows past it and scrolls under the rail, the TOC is hidden temporarily and returns as soon as the table leaves, without touching the user's TOC setting. On mobile a table never breaks out of the reading column.</p>
 
             <h3 class="sub">Tool calls: compact by default, grouped, expand on demand</h3>
             <p>High-frequency calls like <code>read_file</code> / <code>bash</code> / <code>grep</code> are "operational noise" — if each one took a full card, parallel triggers would quickly drown out the conversation.


### PR DESCRIPTION
## Related Issue

None — the problem is explained below.

## Problem

Wide markdown tables in the web chat were squeezed into the 760px reading column: many-column tables were compressed into unreadably narrow cells, and there was no good way to view them. On desktop the reading column is also narrower than typical data tables need, and simply letting a table break out would collide with the conversation outline (TOC) that sits beside the message stream.

## What changed

Stage 1 (first commit): wide tables scroll horizontally inside their own wrapper — the wrapper stays pinned to the message width with `overflow-x: auto`, while the table keeps its natural content width. The chat pane and the page never scroll sideways.

Stage 2 (second commit), built on top of stage 1:

- On desktop, a wide table grows naturally beyond the 760px reading column up to the new `--p-table-max: 1040px` token, centred within the conversation pane via a container query on the existing `.con` inline-size container; anything wider keeps scrolling inside the table wrapper. Narrow tables still fill exactly the reading column, and the wrapper is capped by `100cqi` so it shrinks automatically when the sidebar or preview resizes. No ResizeObserver / JS sizing is involved.
- markstream's `content-visibility: auto` is disabled only for renderers that actually contain a table, so paint containment cannot clip a table that breaks out.
- The TOC rail keeps its usual position just outside the reading column. A RAF-throttled hit-test in `ConversationPane` (`document.elementsFromPoint` at the fixed `.toc-bar`, accepted only when a `.table-node-wrapper` inside this pane covers it) hides the TOC only while a table actually passes under the rail, and restores it when the table scrolls away. The hit-test is scheduled from the existing scroll handler, MutationObserver, ResizeObserver, and rebind path — no new observers, no table enumeration. The user's TOC setting is never touched and nothing is written to localStorage.
- Mobile, SideChat, code blocks, Mermaid, tool cards, and the composer keep their existing width behavior; the markdown parser and markstream-vue are untouched.
- Design-system view updated: `--p-table-max` token, wide-table rules, and the TOC occlusion behavior.

Verification: `pnpm --filter @moonshot-ai/kimi-web typecheck`, `check:style`, `build`, and `git diff --check` all pass. Runtime acceptance (narrow/medium/20+-column tables, TOC hide/restore, sidebar/preview resize, streaming tables, mobile) is manual in the browser; this package has no component-test harness.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [ ] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.
