### PR TITLE
chore: downgrade print-goal-cron-turns changeset to patch

### DIFF
--- a/.changeset/print-goal-cron-turns.md
+++ b/.changeset/print-goal-cron-turns.md
@@ -1,5 +1,5 @@
 ---
-"@moonshot-ai/kimi-code": minor
+"@moonshot-ai/kimi-code": patch
 ---
 
 Keep `kimi -p` runs alive after a turn ends while a goal is still active or a cron task is pending, so goal continuations and cron fires run their turns instead of being cut off when the main turn finishes.


### PR DESCRIPTION
## Related Issue

N/A — release tooling correction for the open release PR (#1546).

## Problem

The changeset from #1555 (keep `kimi -p` alive while a goal is active or a cron task is pending) is marked `minor`, which makes the pending release 0.24.0. Per the gen-changesets bump rules, `minor` is reserved for substantial new user-facing capabilities; this change introduces no new command, flag, mode, or config — it fixes the existing goal/cron features being cut off in print mode. It should be `patch`, making the release 0.23.6.

## What changed

- Changed `.changeset/print-goal-cron-turns.md` frontmatter from `minor` to `patch`
- After this merges, the changesets release action will regenerate the release PR (#1546) as 0.23.6 with the entry under `### Patch Changes`

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [ ] I have added tests that prove my feature works. (N/A — changeset metadata only)
- [x] Ran `gen-changesets` skill, or this PR needs no changeset. (This PR edits a changeset itself; no new changeset needed)
- [x] Ran `gen-docs` skill, or this PR needs no doc update. (N/A — no product behavior change)