### PR TITLE
fix(kaos): detect bash when git comes from a native MSYS2 toolchain

### DIFF
--- a/.changeset/msys2-bash-detection.md
+++ b/.changeset/msys2-bash-detection.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Fix bash auto-detection on Windows failing when git comes from a native MSYS2 toolchain (ucrt64/clang64/clangarm64).

--- a/packages/kaos/src/environment.ts
+++ b/packages/kaos/src/environment.ts
@@ -6,10 +6,10 @@
  * identically on any host OS. `detectEnvironmentFromNode()` bundles the Node
  * defaults for production callers.
  *
- * On Windows the probe expects Git Bash (the canonical POSIX shell that
- * ships with Git for Windows). If it cannot be located the function
- * throws `KaosShellNotFoundError`; the SDK layer can wrap that into a
- * user-facing install hint. Set `KIMI_SHELL_PATH` to override.
+ * On Windows the probe expects bash from Git for Windows or MSYS2. If it
+ * cannot be located the function throws `KaosShellNotFoundError`; the SDK
+ * layer can wrap that into a user-facing install hint. Set
+ * `KIMI_SHELL_PATH` to override.
  */
 
 import { execFile as nodeExecFile } from 'node:child_process';
@@ -50,6 +50,14 @@ export interface EnvironmentDeps {
 }
 
 const GIT_EXEC_PATH_TIMEOUT_MS = 5_000;
+
+const MINGW_PREFIX_SET: ReadonlySet<string> = new Set([
+  'mingw32',
+  'mingw64',
+  'ucrt64',
+  'clang64',
+  'clangarm64',
+]);
 
 function resolveOsKind(platform: string): OsKind {
   switch (platform) {
@@ -189,7 +197,7 @@ function gitBashCandidatesFromGitExecPath(execPath: string): readonly string[] {
   const parts = normalized.split('\\');
   for (let i = parts.length - 1; i >= 0; i -= 1) {
     const segment = parts[i]?.toLowerCase();
-    if (segment === 'mingw32' || segment === 'mingw64') {
+    if (segment !== undefined && MINGW_PREFIX_SET.has(segment)) {
       const root = parts.slice(0, i).join('\\');
       if (root.length > 0) {
         return gitBashCandidatesFromGitRoot(root);

--- a/packages/kaos/test/environment.test.ts
+++ b/packages/kaos/test/environment.test.ts
@@ -202,6 +202,54 @@ describe('detectEnvironment', () => {
     expect(env.shellPath).toBe('C:\\Users\\me\\scoop\\apps\\git\\current\\usr\\bin\\bash.exe');
   });
 
+  it('resolves MSYS2 ucrt64 native git through git --exec-path', async () => {
+    const gitExe = 'C:\\msys64\\ucrt64\\bin\\git.exe';
+    const env = await detectEnvironment(
+      stubDeps({
+        platform: 'win32',
+        env: { PATH: 'C:\\msys64\\ucrt64\\bin' },
+        execFileResults: {
+          [execFileKey(gitExe, ['--exec-path'])]: 'C:/msys64/ucrt64/libexec/git-core\n',
+        },
+        existingPaths: [gitExe, 'C:\\msys64\\usr\\bin\\bash.exe'],
+      }),
+    );
+    expect(env.shellName).toBe('bash');
+    expect(env.shellPath).toBe('C:\\msys64\\usr\\bin\\bash.exe');
+  });
+
+  it('resolves MSYS2 clang64 native git through git --exec-path', async () => {
+    const gitExe = 'C:\\msys64\\clang64\\bin\\git.exe';
+    const env = await detectEnvironment(
+      stubDeps({
+        platform: 'win32',
+        env: { PATH: 'C:\\msys64\\clang64\\bin' },
+        execFileResults: {
+          [execFileKey(gitExe, ['--exec-path'])]: 'C:/msys64/clang64/libexec/git-core\n',
+        },
+        existingPaths: [gitExe, 'C:\\msys64\\usr\\bin\\bash.exe'],
+      }),
+    );
+    expect(env.shellName).toBe('bash');
+    expect(env.shellPath).toBe('C:\\msys64\\usr\\bin\\bash.exe');
+  });
+
+  it('resolves MSYS2 clangarm64 native git through git --exec-path', async () => {
+    const gitExe = 'C:\\msys64\\clangarm64\\bin\\git.exe';
+    const env = await detectEnvironment(
+      stubDeps({
+        platform: 'win32',
+        env: { PATH: 'C:\\msys64\\clangarm64\\bin' },
+        execFileResults: {
+          [execFileKey(gitExe, ['--exec-path'])]: 'C:/msys64/clangarm64/libexec/git-core\n',
+        },
+        existingPaths: [gitExe, 'C:\\msys64\\usr\\bin\\bash.exe'],
+      }),
+    );
+    expect(env.shellName).toBe('bash');
+    expect(env.shellPath).toBe('C:\\msys64\\usr\\bin\\bash.exe');
+  });
+
   it('does not treat shim-adjacent bash.exe as the Git installation shell', async () => {
     const gitExe = 'C:\\Users\\me\\scoop\\shims\\git.exe';
     const env = await detectEnvironment(


### PR DESCRIPTION
## Related Issue

Fixes #1579

## Problem

On Windows, the shell probe infers the bash location from
`git --exec-path` by scanning the path for known mingw-w64 prefix
segments, then looks for bash at `<root>\bin\bash.exe` /
`<root>\usr\bin\bash.exe`. The scan only covered the legacy
`mingw32`/`mingw64` prefixes. On a host where git comes from a native
MSYS2 environment and Git for Windows is not installed, the exec path
(e.g. `C:/msys64/ucrt64/libexec/git-core`) matches nothing, so
detection throws `KaosShellNotFoundError` even though bash exists at
`C:\msys64\usr\bin\bash.exe`. Setting `KIMI_SHELL_PATH` works around
it; installs passed the override were not affected.

## What changed

- Collected the mingw-w64 prefix names into a `MINGW_PREFIX_SET`
  covering all current MSYS2 toolchain prefixes, adding
  `ucrt64`/`clang64`/`clangarm64` next to the legacy
  `mingw32`/`mingw64`. A native MSYS2 git's exec path now walks back
  to the MSYS2 root and resolves the shared bash at
  `usr\bin\bash.exe`.
- Git for Windows layouts are unaffected — their exec paths still hit
  `mingw32`/`mingw64` first, so resolution results are unchanged and
  the legacy prefixes stay for compatibility.
- No new options, no changed error messages. Added unit tests for the
  three new prefixes; existing suites continue to exercise Scoop shims
  and Git for Windows layouts.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.