### PR TITLE
docs(changelog): sync 0.23.6 from apps/kimi-code/CHANGELOG.md

### DIFF
--- a/docs/en/release-notes/changelog.md
+++ b/docs/en/release-notes/changelog.md
@@ -6,6 +6,34 @@ outline: 2
 
 This page documents the changes in each Kimi Code CLI release.
 
+## 0.23.6 (2026-07-12)
+
+### Polish
+
+- web: Let wide Markdown tables grow beyond the reading column up to 1040px, scrolling horizontally inside the table when wider.
+- web: Keep the server access token for up to 7 days across tab close and browser restarts, instead of asking for it again with every new tab.
+- web: Add workspaces by typing an absolute path directly in the workspace picker's search box, with live validation and completion suggestions.
+- web: Auto-enable the default thinking effort when switching to a model that supports effort levels in the web UI.
+- Recognize the `support_efforts` and `default_effort` fields when importing a custom registry, so thinking effort levels are available for those models.
+- Update the WebBridge install page link opened from the `/plugins` panel.
+- Add a `subagent.timeout_ms` config option (or the `KIMI_SUBAGENT_TIMEOUT_MS` env var) to control how long a single subagent may run before timing out; the default is raised from 30 minutes to 2 hours.
+- Add a print-mode background policy: set `[background].print_background_mode = "steer"` to keep `kimi -p` alive across background-task completions, so the main agent can be steered into follow-up turns.
+
+### Bug Fixes
+
+- web: Fix sessions getting stuck in a sending state after a reconnect; turns that finish while the connection is down now stop the spinner and let the next message send normally.
+- web: Fix the first visit after starting or updating the web UI bouncing to the login page when the initial auth check fails; the connecting screen now stays up, shows the connection error, and retries.
+- Keep `kimi -p` runs alive after a turn ends while a goal is still active or a cron task is pending, so goal continuations and cron fires run their turns instead of being cut off when the main turn finishes.
+- Treat a dismissed question prompt as the user choosing not to answer, instead of implicitly selecting the recommended option.
+- web: Fix ReadMediaFile results rendering as plain tool cards instead of images after resuming or reloading a session.
+- web: Fix the chat view jumping downward while scrolling through conversation history.
+- web: Fix the model dropdown showing checkmarks on same-named models from other providers; the current model is now matched by its unique model id.
+- web: Fix sidebar lag with many sessions by removing repeated session list scans during rendering.
+
+### Refactors
+
+- Rename the dynamic tool loading model capability from `select_tools` to `dynamically_loaded_tools`.
+
 ## 0.23.5 (2026-07-10)
 
 ### Polish
@@ -169,7 +197,6 @@ This page documents the changes in each Kimi Code CLI release.
 - Add a TUI preference to keep rapid multi-line pastes from submitting line by line when bracketed paste is unavailable. Set `disable_paste_burst = true` in `tui.toml` to turn it off.
 - Keep subagent cards at a stable height and show a live status spinner with a compact two-row activity window.
 - In `kimi -p` runs, wait for background subagents to finish before exiting when `background.keep_alive_on_exit` is enabled. Set `keep_alive_on_exit = true` to let concurrent background subagents complete.
-- Add `background.print_background_mode` (`exit`/`drain`/`steer`) for `kimi -p`: in `steer` mode, a completing background task (including `Bash(run_in_background=true)`) behaves like a background subagent — it injects a synthetic user message that steers the main agent into a new turn so it can act on the result. Bounded by `print_wait_ceiling_s` and the new `print_max_turns`.
 
 ### Refactors
 

--- a/docs/zh/release-notes/changelog.md
+++ b/docs/zh/release-notes/changelog.md
@@ -6,6 +6,34 @@ outline: 2
 
 本页记录 Kimi Code CLI 每个版本的变更内容。
 
+## 0.23.6（2026-07-12）
+
+### 优化
+
+- web: 优化宽 Markdown 表格的显示，可超出阅读栏宽至 1040px，更宽时在表格内部横向滚动。
+- web: 服务端访问令牌在关闭标签页或重启浏览器后最多保留 7 天，不再每次开新标签页都要求重新输入。
+- web: 工作区选择器搜索框支持直接输入绝对路径添加工作区，输入时实时校验并给出补全建议。
+- web: 切换到支持思考强度级别的模型时，自动启用默认思考强度。
+- 导入自定义 registry 时识别 `support_efforts` 和 `default_effort` 字段，这些模型可设置思考强度（thinking effort）级别。
+- 更新 `/plugins` 面板中打开的 WebBridge 安装页链接。
+- 新增 `subagent.timeout_ms` 配置项（或 `KIMI_SUBAGENT_TIMEOUT_MS` 环境变量），控制单个子代理的超时时间，默认从 30 分钟提高到 2 小时。
+- 新增 print 模式后台策略：设置 `[background].print_background_mode = "steer"` 后，`kimi -p` 在后台任务完成后保持运行，继续引导主 Agent 进入后续轮次。
+
+### 修复
+
+- web: 修复断线重连后会话卡在发送状态的问题，断线期间完成的轮次现在能正常结束加载状态并发送下一条消息。
+- web: 修复启动或更新 web UI 后首次访问时，初始鉴权检查失败跳转到登录页的问题；现在停留在连接界面，显示连接错误并持续重试。
+- 修复 `kimi -p` 在目标仍活跃或有定时任务待触发时主轮次结束即退出的问题，目标续跑与定时任务触发现在能正常执行对应轮次。
+- 修复关闭问题提示时默认选中推荐选项的问题，现在视为用户选择不回答。
+- web: 修复恢复或重新加载会话后，ReadMediaFile 结果显示为普通工具卡片而非图片的问题。
+- web: 修复滚动浏览对话历史时聊天视图向下跳动的问题。
+- web: 修复模型下拉菜单中其他提供商的同名模型被错误勾选的问题，现在按唯一的模型 id 匹配当前模型。
+- web: 修复会话较多时侧边栏卡顿的问题，移除了渲染期间重复的会话列表扫描。
+
+### 重构
+
+- 将动态工具加载的模型能力名称从 `select_tools` 重命名为 `dynamically_loaded_tools`。
+
 ## 0.23.5（2026-07-10）
 
 ### 优化
@@ -169,7 +197,6 @@ outline: 2
 - TUI 新增一项偏好设置：当 bracketed paste 不可用时，避免快速多行粘贴被逐行提交。可在 `tui.toml` 中设置 `disable_paste_burst = true` 关闭该行为。
 - 优化子 Agent 卡片，使其保持固定高度，并在紧凑的双行活动窗口内显示实时状态 spinner。
 - `kimi -p` 运行时，若启用了 `background.keep_alive_on_exit`，退出前会等待后台子 Agent 完成。设置 `keep_alive_on_exit = true` 可让并发的后台子 Agent 执行完毕。
-- `kimi -p` 新增 `background.print_background_mode`（`exit`/`drain`/`steer`）：`steer` 模式下，后台任务（含 `Bash(run_in_background=true)`）完成时会像后台子 Agent 一样，以合成 user 消息 steer 主 Agent 进入新 turn，使其能依据后台结果继续工作；上限由 `print_wait_ceiling_s` 与新增的 `print_max_turns` 控制。
 
 ### 重构
 


### PR DESCRIPTION
## Related Issue

N/A — post-release docs maintenance

## Problem

The docs-site changelog has not yet been synced for 0.23.6 after the npm release.

## What changed

- Synced 0.23.6 (2026-07-12) from `apps/kimi-code/CHANGELOG.md` into `docs/en/release-notes/changelog.md`
- Translated the new English increment into `docs/zh/release-notes/changelog.md`
- Removed a misplaced `print_background_mode` entry from the 0.22.2 block on both pages — it was committed directly to the docs page in the feature PR but the feature only ships in 0.23.6, where it is now covered
- Classified the 0.23.6 entries as Polish / Bug Fixes / Refactors (no new top-level surfaces in this release), with the two wide-Markdown-table entries merged into one
- Verified with `pnpm --filter kimi-code-docs run build`

## Checklist

- [x] I have read the CONTRIBUTING document.
- [x] I have linked a related issue, or explained the problem above.
- [ ] I have added tests that prove my feature works. (N/A — docs-only sync)
- [x] Ran `gen-changesets` skill, or this PR needs no changeset. (No changeset — docs sync is out of bundle)
- [x] Ran `gen-docs` skill, or this PR needs no doc update. (This PR is the dedicated changelog sync)