### PR TITLE
feat(web): cap markdown table column width at 700px

### DIFF
--- a/.changeset/web-wide-table-breakout.md
+++ b/.changeset/web-wide-table-breakout.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+web: Let wide Markdown tables in the desktop chat grow up to 1040px with each column capped at 700px so long cell content wraps, temporarily hiding the conversation outline while a table passes under it; anything wider still scrolls inside the table.

--- a/apps/kimi-web/src/components/chat/Markdown.vue
+++ b/apps/kimi-web/src/components/chat/Markdown.vue
@@ -756,6 +756,12 @@ function copyDiff(code: string, idx: number) {
 .md :deep(.table-node td) {
   text-align: left;
   vertical-align: top;
+  /* Cap runaway columns: a single cell with long prose no longer stretches
+     its column past --p-table-cell-max — the text wraps inside the cell
+     instead (markstream cells are already white-space:normal +
+     overflow-wrap:break-word, so no wrap override is needed here). Wider
+     tables made of many columns still scroll inside the wrapper. */
+  max-width: var(--p-table-cell-max);
 }
 
 /* Drop markstream-vue's default table-row hover background — the conversation

--- a/apps/kimi-web/src/components/chat/Markdown.vue
+++ b/apps/kimi-web/src/components/chat/Markdown.vue
@@ -756,12 +756,26 @@ function copyDiff(code: string, idx: number) {
 .md :deep(.table-node td) {
   text-align: left;
   vertical-align: top;
-  /* Cap runaway columns: a single cell with long prose no longer stretches
-     its column past --p-table-cell-max — the text wraps inside the cell
-     instead (markstream cells are already white-space:normal +
-     overflow-wrap:break-word, so no wrap override is needed here). Wider
-     tables made of many columns still scroll inside the wrapper. */
+  /* Cap runaway columns: a single cell with long prose should stop stretching
+     its column at --p-table-cell-max and wrap inside the cell instead.
+     max-width on the cell itself only works in Firefox — Chromium ignores it
+     under table-layout:auto — so the clamp is reinforced on the content box
+     below. Wider tables made of many columns still scroll inside the
+     wrapper. */
   max-width: var(--p-table-cell-max);
+}
+/* Chromium honors max-width on this inner box even under table-layout:auto:
+   markstream wraps plain-text cell content in a .text-node span, and as an
+   inline-block its max-content contribution to the column is clamped to
+   --p-table-cell-max, so the column stops there and the text wraps inside
+   (the span is already white-space:pre-wrap + overflow-wrap:break-word).
+   Cells mixing several inline children can still exceed the cap by the sum
+   of those children — acceptable; the runaway single-prose-cell case is the
+   one that matters. */
+.md :deep(.table-node .text-node) {
+  display: inline-block;
+  max-width: var(--p-table-cell-max);
+  vertical-align: top;
 }
 
 /* Drop markstream-vue's default table-row hover background — the conversation

--- a/apps/kimi-web/src/style.css
+++ b/apps/kimi-web/src/style.css
@@ -504,6 +504,7 @@ html[data-color-scheme="dark"][data-accent="mono"] {
   --p-content-max: 760px;
   --p-content-wide: 920px;
   --p-table-max: 1040px;
+  --p-table-cell-max: 700px;
   --p-bp-sm: 640px;
   --p-bp-md: 980px;
 }

--- a/apps/kimi-web/src/views/DesignSystemView.vue
+++ b/apps/kimi-web/src/views/DesignSystemView.vue
@@ -420,6 +420,7 @@ onUnmounted(() => {
                 <tr><td class="tk">--p-content-max</td><td class="val">760px</td><td>chat reading-column max width (regular chat prose)</td></tr>
                 <tr><td class="tk">--p-content-wide</td><td class="val">920px</td><td>wide content (settings / panel)</td></tr>
                 <tr><td class="tk">--p-table-max</td><td class="val">1040px</td><td>desktop wide-table max width (see §04)</td></tr>
+                <tr><td class="tk">--p-table-cell-max</td><td class="val">700px</td><td>max width of a single table column; longer cell content wraps (see §04)</td></tr>
                 <tr><td class="tk">--p-bp-sm</td><td class="val">640px</td><td>mobile / desktop boundary</td></tr>
                 <tr><td class="tk">--p-bp-md</td><td class="val">980px</td><td>narrow / wide screen boundary</td></tr>
               </tbody>
@@ -1119,7 +1120,7 @@ onUnmounted(() => {
                 </div>
               </div>
             </div>
-            <p><b>Wide markdown tables (desktop):</b> regular chat prose stays within the 760px reading column (<code>--p-content-max</code>). On desktop a wide table may grow naturally with its content up to 1040px (<code>--p-table-max</code>), centred within the conversation pane; beyond that the excess scrolls horizontally inside the table's own wrapper — the page and the chat area never scroll sideways. The conversation outline (TOC) keeps its usual position just outside the reading column; when a table grows past it and scrolls under the rail, the TOC is hidden temporarily and returns as soon as the table leaves, without touching the user's TOC setting. On mobile a table never breaks out of the reading column.</p>
+            <p><b>Wide markdown tables (desktop):</b> regular chat prose stays within the 760px reading column (<code>--p-content-max</code>). On desktop a wide table may grow naturally with its content up to 1040px (<code>--p-table-max</code>), centred within the conversation pane; beyond that the excess scrolls horizontally inside the table's own wrapper — the page and the chat area never scroll sideways. A single column is capped at 700px (<code>--p-table-cell-max</code>), so long cell content wraps inside the cell instead of stretching the table. The conversation outline (TOC) keeps its usual position just outside the reading column; when a table grows past it and scrolls under the rail, the TOC is hidden temporarily and returns as soon as the table leaves, without touching the user's TOC setting. On mobile a table never breaks out of the reading column.</p>
 
             <h3 class="sub">Tool calls: compact by default, grouped, expand on demand</h3>
             <p>High-frequency calls like <code>read_file</code> / <code>bash</code> / <code>grep</code> are "operational noise" — if each one took a full card, parallel triggers would quickly drown out the conversation.


### PR DESCRIPTION
## Related Issue

None — the problem is explained below. Follow-up to #1577.

## Problem

After #1577, a wide markdown table grows with its content up to 1040px. But a table does not need many columns to become wide: a single cell holding long prose (a description column, a pasted log line, a long URL list) stretches its column without bound, dragging the whole table past the reading column and forcing horizontal scrolling where simple wrapping would read better.

## What changed

- New layout token `--p-table-cell-max: 700px` in `src/style.css`, next to `--p-table-max`.
- `.table-node th/td` in `Markdown.vue` get `max-width: var(--p-table-cell-max)`: under the stage-1 `table-layout: auto`, the column stops growing at 700px and the cell content wraps. markstream's cells already use `white-space: normal` + `overflow-wrap: break-word`, so wrapping — including long unbroken strings — is native and no wrap override is needed.
- Narrow tables are unaffected (their columns never reach 700px), and many-column tables still grow to `--p-table-max` and scroll inside their wrapper beyond it.
- Design-system view updated: token row for `--p-table-cell-max` and the §04 wide-table paragraph. Changeset included.

Verification: `pnpm --filter @moonshot-ai/kimi-web typecheck`, `check:style`, `build`, and `git diff --check` all pass. Runtime acceptance (long single-cell table wraps at 700px; 20-column table unchanged; mobile unchanged) is manual in the browser; this package has no component-test harness.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [ ] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.
