### PR TITLE
refactor(agent-core-v2): derive wire-record scope from agent scope context

### DIFF
--- a/packages/agent-core-v2/src/agent/wireRecord/wireRecordService.ts
+++ b/packages/agent-core-v2/src/agent/wireRecord/wireRecordService.ts
@@ -3,7 +3,7 @@ import { relative } from 'pathe';
 import { InstantiationType } from '#/_base/di/extensions';
 import { Disposable } from '#/_base/di/lifecycle';
 import { LifecycleScope, registerScopedService } from '#/_base/di/scope';
-import { IBootstrapService } from '#/app/bootstrap/bootstrap';
+import { IAgentScopeContext } from '#/agent/scopeContext/scopeContext';
 import { IAppendLogStore } from '#/persistence/interface/appendLogStore';
 import { IAgentWireService } from '#/wire/tokens';
 import type { IWireService } from '#/wire/wireService';
@@ -29,18 +29,16 @@ export class AgentWireRecordService extends Disposable implements IAgentWireReco
   private readonly wireScope: string;
 
   constructor(
-    options: { readonly homedir?: string } = {},
-    @IBootstrapService bootstrap: IBootstrapService,
+    @IAgentScopeContext scopeContext: IAgentScopeContext,
     @IAppendLogStore private readonly log?: IAppendLogStore,
     @IAgentWireService private readonly wire?: IWireService,
   ) {
     super();
-    // Each agent scope seeds its own `homedir` (`<homeDir>/sessions/<ws>/<sid>/
-    // agents/<aid>`); the wire log is the fixed `wire.jsonl` beneath it. The
-    // `IAppendLogStore` is App-scoped (shared, rooted at `homeDir`), so the
-    // store `scope` is the homedir made relative to `homeDir` — keeping every
-    // agent's records in its own file instead of one shared log.
-    this.wireScope = relative(bootstrap.homeDir, options.homedir ?? bootstrap.homeDir);
+    // The agent scope carries its persistence scope (`sessions/<ws>/<sid>/
+    // agents/<aid>`); the wire log is the fixed `wire.jsonl` beneath it —
+    // the same scope `WireService` appends to, so `restore()` reads back
+    // what live dispatch wrote.
+    this.wireScope = scopeContext.scope();
     if (this.log !== undefined) {
       this._register(this.log.acquire(this.wireScope, WIRE_RECORD_FILENAME));
     }

--- a/packages/agent-core-v2/src/session/agentLifecycle/agentLifecycleService.ts
+++ b/packages/agent-core-v2/src/session/agentLifecycle/agentLifecycleService.ts
@@ -231,10 +231,10 @@ export class AgentLifecycleService extends Disposable implements IAgentLifecycle
     readonly agentScope: string;
     readonly mcpManager: McpConnectionManager;
   }): ScopeSeed {
-    const { agentId, agentHomedir, agentScope, mcpManager } = input;
+    const { agentId, agentScope, mcpManager } = input;
     return [
       [IAgentScopeContext, makeAgentScopeContext({ agentId, agentScope })],
-      [IAgentWireRecordService, new SyncDescriptor(AgentWireRecordService, [{ homedir: agentHomedir }])],
+      [IAgentWireRecordService, new SyncDescriptor(AgentWireRecordService)],
       [
         IAgentWireService,
         new SyncDescriptor(WireService, [

--- a/packages/agent-core-v2/test/harness/agent.ts
+++ b/packages/agent-core-v2/test/harness/agent.ts
@@ -1056,7 +1056,7 @@ export class AgentTestContext {
           (reg) => {
             reg.defineDescriptor(
               IAgentWireRecordService,
-              new SyncDescriptor(AgentWireRecordService, [{}]),
+              new SyncDescriptor(AgentWireRecordService),
             );
             reg.defineDescriptor(
               IAgentWireService,


### PR DESCRIPTION
## Related Issue

No linked issue — internal refactor, problem explained below.

## Problem

`AgentWireRecordService` (agent-core-v2) took an ad-hoc `options: { readonly homedir?: string } = {}` bag as its first constructor parameter, passed per agent scope through `SyncDescriptor` args in `agentLifecycle`. In the DI × Scope architecture, per-scope configuration should flow through scope context tokens, not anonymous constructor option bags.

## What changed

The store scope was derived as `relative(homeDir, agentHomedir)`, and `agentHomedir` is defined as `join(homeDir, agentScope)` — so the value always equals `IAgentScopeContext.scope()`, which every agent scope already seeds.

- `wireRecordService.ts`: inject `@IAgentScopeContext` and use `scopeContext.scope()` as the wire-log scope; drop the options parameter and the now-unused `IBootstrapService` dependency.
- `agentLifecycleService.ts`: seed `IAgentWireRecordService` without constructor args.
- `test/harness/agent.ts`: same seed simplification (the harness already defines `IAgentScopeContext` for the agent scope).

No behavior change: production resolves to the identical `sessions/<ws>/<sid>/agents/<aid>` scope string, and the harness's in-memory `IAppendLogStore` ignores scope/key entirely. Verified with `tsc --noEmit` and `test/agent/wireRecord/resume.test.ts` (14 passed).

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [ ] I have added tests that prove my feature works. (No new behavior — covered by the existing wireRecord/wire suites.)
- [x] Ran `gen-changesets` skill, or this PR needs no changeset. (Internal refactor, no changeset.)
- [x] Ran `gen-docs` skill, or this PR needs no doc update. (No user-facing change.)