### PR TITLE
fix(web): keep context usage live on the v2 engine

### DIFF
--- a/.changeset/fix-v2-status-context-size.md
+++ b/.changeset/fix-v2-status-context-size.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kap-server": patch
+---
+
+Report the live (measured + estimated) context size in the v2 server's v1-compatible status stream instead of the measured-only count, which read 0 until the first model response of a session completed and could dip mid-turn while the context was being rewritten.

--- a/.changeset/fix-web-context-usage-zero.md
+++ b/.changeset/fix-web-context-usage-zero.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+web: Fix the context usage indicator dropping to 0 when a session is reopened or the session list reloads (e.g. after a sidebar search) — the cached live usage is now kept instead of the session record's all-zero placeholder.

--- a/apps/kimi-web/src/api/daemon/mappers.ts
+++ b/apps/kimi-web/src/api/daemon/mappers.ts
@@ -70,6 +70,24 @@ export function toAppSessionUsage(wire: WireSessionUsage): AppSessionUsage {
   };
 }
 
+/**
+ * True when a session usage object is the daemon's all-zero placeholder.
+ * Both engines return placeholders for the heavy session fields on the
+ * list/snapshot read paths; the live values arrive via GET /status and the
+ * WS `agent.status.updated` stream. Callers replacing a cached session with
+ * a wire record must keep the live usage when the incoming one is this
+ * placeholder, or the context ring drops to 0 until the next refresh.
+ */
+export function isPlaceholderSessionUsage(usage: AppSessionUsage): boolean {
+  return (
+    usage.contextTokens === 0 &&
+    usage.contextLimit === 0 &&
+    usage.inputTokens === 0 &&
+    usage.outputTokens === 0 &&
+    usage.turnCount === 0
+  );
+}
+
 export function toAppSessionStatus(wire: WireSessionStatus): AppSessionStatus {
   switch (wire) {
     case 'idle': return 'idle';

--- a/apps/kimi-web/src/composables/client/useWorkspaceState.ts
+++ b/apps/kimi-web/src/composables/client/useWorkspaceState.ts
@@ -13,6 +13,7 @@ import { i18n } from '../../i18n';
 import { useConfirmDialog } from '../useConfirmDialog';
 import { isDaemonApiError } from '../../api/errors';
 import { SERVER_AUTH_UNAUTHORIZED_CODE } from '../../api/daemon/http';
+import { isPlaceholderSessionUsage } from '../../api/daemon/mappers';
 import type {
   AppConfig,
   AppInFlightTurn,
@@ -503,6 +504,26 @@ export function useWorkspaceState(rawState: ExtendedState, deps: UseWorkspaceSta
     return items;
   }
 
+  /**
+   * Replace the sessions list wholesale, preserving the live usage accumulated
+   * from /status and the WS status stream: the list endpoint returns all-zero
+   * placeholder usage for every session, and a blind replace would zero the
+   * context ring until the next refresh.
+   */
+  function setSessionsPreservingLiveUsage(sessions: AppSession[]): void {
+    const liveUsageById = new Map(rawState.sessions.map((s) => [s.id, s.usage] as const));
+    setSessions(
+      sessions.map((s) => {
+        const live = liveUsageById.get(s.id);
+        return live !== undefined &&
+          isPlaceholderSessionUsage(s.usage) &&
+          !isPlaceholderSessionUsage(live)
+          ? { ...s, usage: live }
+          : s;
+      }),
+    );
+  }
+
   /** Load the initial page of sessions for one workspace, then keep fetching
    *  older pages while the oldest loaded session is still within
    *  SESSIONS_RECENT_WINDOW_MS. Every page (including continuations) uses the
@@ -670,7 +691,7 @@ export function useWorkspaceState(rawState: ExtendedState, deps: UseWorkspaceSta
     if (rawState.sessionsFullyLoaded) return;
     const sessions = await listAllSessionsGlobal().catch(() => null);
     if (sessions === null) return;
-    setSessions(sessions);
+    setSessionsPreservingLiveUsage(sessions);
     rawState.sessionsFullyLoaded = true;
     const cleared: Record<string, boolean> = {};
     for (const w of rawState.workspaces) cleared[w.id] = false;
@@ -727,7 +748,7 @@ export function useWorkspaceState(rawState: ExtendedState, deps: UseWorkspaceSta
       // hiding already-fetched rows.
       await loadWorkspaces();
       const sessions = await loadInitialSessionsByWorkspace();
-      setSessions(sessions);
+      setSessionsPreservingLiveUsage(sessions);
 
       // First load: pick the workspace of the most-recent session, unless the
       // user already has a persisted active workspace that still exists.

--- a/apps/kimi-web/src/composables/useKimiWebClient.ts
+++ b/apps/kimi-web/src/composables/useKimiWebClient.ts
@@ -1262,6 +1262,7 @@ async function syncSessionFromSnapshot(sessionId: string): Promise<SyncSessionRe
       return 'ok';
     }
 
+    const snapUsagePlaceholder = isPlaceholderSessionUsage(snap.session.usage);
     updateSession(sessionId, (s) => ({
       ...snap.session,
       model:
@@ -1271,7 +1272,7 @@ async function syncSessionFromSnapshot(sessionId: string): Promise<SyncSessionRe
       // The wire session's usage is a placeholder (both engines return zeros
       // for the heavy fields); keep the live usage folded in from /status and
       // the WS status stream instead of zeroing it on every snapshot sync.
-      usage: isPlaceholderSessionUsage(snap.session.usage) ? s.usage : snap.session.usage,
+      usage: snapUsagePlaceholder ? s.usage : snap.session.usage,
     }));
     // The snapshot only carries the most recent page; keep any older pages the
     // user already loaded so reopening does not reset scrollback.
@@ -1329,6 +1330,12 @@ async function syncSessionFromSnapshot(sessionId: string): Promise<SyncSessionRe
       retainWsSubscription(sessionId);
     }
     sessionsWithStaleCursor.delete(sessionId);
+    // The snapshot carries placeholder usage, so a preserved cached value may
+    // itself be stale — resync / stale-socket recovery reach here without
+    // selectSession's sidecar refresh, and the volatile status frames that
+    // would update it were exactly what the resync replaced. Re-read /status
+    // so the ring converges on the live value.
+    if (snapUsagePlaceholder) void refreshSessionStatus(sessionId);
     void pullSessionWarnings(sessionId);
     return 'ok';
   } catch (err) {

--- a/apps/kimi-web/src/composables/useKimiWebClient.ts
+++ b/apps/kimi-web/src/composables/useKimiWebClient.ts
@@ -66,7 +66,7 @@ import type {
   ThinkingLevel,
 } from '../api/types';
 import { createInitialState, reduceAppEvent, type CompactionStatus, type KimiClientState } from '../api/daemon/eventReducer';
-import { toAppEvent } from '../api/daemon/mappers';
+import { isPlaceholderSessionUsage, toAppEvent } from '../api/daemon/mappers';
 
 import { messagesToTurns } from './messagesToTurns';
 import { latestTodos } from './latestTodos';
@@ -1268,6 +1268,10 @@ async function syncSessionFromSnapshot(sessionId: string): Promise<SyncSessionRe
         snap.session.model && snap.session.model.length > 0
           ? snap.session.model
           : s.model,
+      // The wire session's usage is a placeholder (both engines return zeros
+      // for the heavy fields); keep the live usage folded in from /status and
+      // the WS status stream instead of zeroing it on every snapshot sync.
+      usage: isPlaceholderSessionUsage(snap.session.usage) ? s.usage : snap.session.usage,
     }));
     // The snapshot only carries the most recent page; keep any older pages the
     // user already loaded so reopening does not reset scrollback.

--- a/apps/kimi-web/test/workspace-state.test.ts
+++ b/apps/kimi-web/test/workspace-state.test.ts
@@ -1218,3 +1218,54 @@ describe('useWorkspaceState — snapshot prompt recovery', () => {
     expect(retrySnapshot).toHaveBeenCalledOnce();
   });
 });
+
+// Regression: a search-triggered full session-list reload must not clobber the
+// live usage (context ring) with the list endpoint's all-zero placeholder.
+describe('useWorkspaceState — loadAllSessions usage preservation', () => {
+  beforeEach(() => {
+    apiMock.listSessions.mockReset();
+  });
+
+  function liveUsage() {
+    return {
+      inputTokens: 100,
+      outputTokens: 50,
+      cacheReadTokens: 0,
+      cacheCreationTokens: 0,
+      totalCostUsd: 0,
+      contextTokens: 28772,
+      contextLimit: 1048576,
+      turnCount: 3,
+    };
+  }
+
+  it('keeps the cached live usage when the reloaded row carries the placeholder', async () => {
+    const state = createState();
+    state.sessions = [{ ...createSession(), usage: liveUsage() }];
+    apiMock.listSessions.mockResolvedValue({
+      items: [{ ...createSession(), title: 'Fresh from server' }],
+      hasMore: false,
+    });
+    const setSessions = vi.fn();
+    const ws = useWorkspaceState(state, { ...createDeps(), setSessions });
+
+    await ws.loadAllSessions();
+
+    expect(setSessions).toHaveBeenCalledOnce();
+    const next = setSessions.mock.calls[0][0];
+    expect(next[0].title).toBe('Fresh from server');
+    expect(next[0].usage).toEqual(liveUsage());
+  });
+
+  it('takes the server row as-is when there is no live usage to preserve', async () => {
+    const state = createState();
+    apiMock.listSessions.mockResolvedValue({ items: [createSession()], hasMore: false });
+    const setSessions = vi.fn();
+    const ws = useWorkspaceState(state, { ...createDeps(), setSessions });
+
+    await ws.loadAllSessions();
+
+    const next = setSessions.mock.calls[0][0];
+    expect(next[0].usage.contextTokens).toBe(0);
+  });
+});

--- a/packages/kap-server/src/services/legacyStatus/legacyStatus.ts
+++ b/packages/kap-server/src/services/legacyStatus/legacyStatus.ts
@@ -17,6 +17,7 @@
  */
 
 import {
+  IAgentContextSizeService,
   IAgentProfileService,
   IAgentUsageService,
   IAgentWireService,
@@ -39,6 +40,12 @@ interface LegacyStatusState {
  * Reacts to the Ops that can change the status line. The state itself carries
  * no business data; the handler re-reads the authoritative services on every
  * bump so the emitted snapshot is always consistent with the live Models.
+ *
+ * The context-append Ops are watched alongside the usage / measurement Ops
+ * because the emitted contextTokens is the live (measured + estimated) size:
+ * a freshly appended prompt or step event grows it before any LLM response
+ * lands. The derived model's dedupe (in the broadcaster) suppresses appends
+ * that don't move the size, so the extra watches cost no extra frames.
  */
 export const LegacyStatusModel = defineDerivedModel<LegacyStatusState>(
   'legacyStatus',
@@ -46,6 +53,8 @@ export const LegacyStatusModel = defineDerivedModel<LegacyStatusState>(
   {
     'usage.record': (s) => ({ version: s.version + 1 }),
     'context_size.measured': (s) => ({ version: s.version + 1 }),
+    'context.append_message': (s) => ({ version: s.version + 1 }),
+    'context.append_loop_event': (s) => ({ version: s.version + 1 }),
     'config.update': (s) => ({ version: s.version + 1 }),
   },
 );
@@ -61,7 +70,17 @@ export interface LegacyStatusSnapshot {
 export function readLegacyStatus(agent: IAgentScopeHandle): LegacyStatusSnapshot {
   const profile = agent.accessor.get(IAgentProfileService);
   const usage = agent.accessor.get(IAgentUsageService).status();
-  const contextTokens = agent.accessor.get(IAgentWireService).getModel(ContextSizeModel).tokens;
+  // Live (measured + estimated) context size — mirrors the REST status rollup
+  // (`ISessionLegacyService.status`) and v1's `context.tokenCount`, which
+  // reflect the context even before the first measured exchange completes.
+  // `size` alone can transiently dip below the last measured total while a
+  // post-step fold/rewrite leaves the context shorter than the measured
+  // prefix (the estimate then excludes the system prompt); the measured total
+  // is the better reading there. Every REAL shrink (undo / clear / compaction)
+  // rebases the measured model first, so the max only wins in that window.
+  const contextSize = agent.accessor.get(IAgentContextSizeService);
+  const measured = agent.accessor.get(IAgentWireService).getModel(ContextSizeModel);
+  const contextTokens = Math.max(contextSize.get().size, measured.tokens);
   const maxContextTokens = profile.getModelCapabilities().max_context_tokens;
   const model = profile.getModel();
   return { usage, contextTokens, maxContextTokens, model };


### PR DESCRIPTION
## Related Issue

No linked issue — the problem is explained below.

## Problem

On the web UI connected to the v2 engine (kap-server), the composer's context usage indicator stays at 0:

- During a new session's first turn it never leaves 0: the v2 server's v1-compatible `agent.status.updated` bridge reported the measured-only context token count, which is 0 until the first model response completes (v1 reports the live measured + estimated size, so it grows from the first request).
- After reopening a session or reloading the session list (e.g. via sidebar search), a previously correct reading drops back to 0: the client replaces the cached session with the wire record wholesale, and both engines return an all-zero placeholder for the record's usage field; for an idle session nothing repairs it until the next select.

## What changed

- `packages/kap-server` (legacyStatus bridge): report `max(live measured+estimated size, measured tokens)` — the live size matches the REST `/status` rollup and v1 semantics, while the measured total floors the transient window where a post-step context fold leaves the context shorter than the measured prefix (every real shrink — undo/clear/compaction — rebases the measured model first, so the max only wins in that window). The derived model also watches context-append Ops so the status line moves as soon as a prompt or step event lands.
- `apps/kimi-web`: add `isPlaceholderSessionUsage` and preserve the accumulated live usage whenever an incoming session record carries the placeholder — in snapshot sync (mirroring the existing `model` preservation) and in wholesale session-list replaces (initial load + search-triggered full reload).
- Tests: two regression cases in `apps/kimi-web/test/workspace-state.test.ts` covering list-reload usage preservation. The server-side fix was verified live against a kap-server instance: frames go 0 (empty context) → single-digit estimate on prompt append → measured total after the response, with no zero frames after the first non-zero one and no end-of-turn dip.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.
