### PR TITLE
fix(agent-core-v2): skip deterministic provider validation retries

### DIFF
--- a/.changeset/skip-deterministic-provider-retries.md
+++ b/.changeset/skip-deterministic-provider-retries.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Avoid retry delays for malformed or unsupported base64 image data URLs.

--- a/.changeset/skip-deterministic-provider-retries.md
+++ b/.changeset/skip-deterministic-provider-retries.md
@@ -1,5 +1,0 @@
----
-"@moonshot-ai/kimi-code": patch
----
-
-Avoid retry delays for malformed or unsupported base64 image data URLs.

--- a/packages/agent-core-v2/src/app/llmProtocol/errors.ts
+++ b/packages/agent-core-v2/src/app/llmProtocol/errors.ts
@@ -136,6 +136,18 @@ export class APIEmptyResponseError extends ChatProviderError {
   }
 }
 
+const DETERMINISTIC_PROVIDER_VALIDATION_MESSAGE_PATTERNS = [
+  /unsupported media type for base64 image/,
+  /invalid data url for image/,
+] as const;
+
+function isDeterministicProviderValidationError(error: ChatProviderError): boolean {
+  const lowerMessage = error.message.toLowerCase();
+  return DETERMINISTIC_PROVIDER_VALIDATION_MESSAGE_PATTERNS.some((pattern) =>
+    pattern.test(lowerMessage),
+  );
+}
+
 export function isRetryableGenerateError(error: unknown): boolean {
   if (error instanceof APIConnectionError || error instanceof APITimeoutError) {
     return true;
@@ -149,7 +161,9 @@ export function isRetryableGenerateError(error: unknown): boolean {
   if (error instanceof APIStatusError) {
     return [408, 409, 429, 500, 502, 503, 504, 529].includes(error.statusCode);
   }
-  return error instanceof ChatProviderError;
+  return (
+    error instanceof ChatProviderError && !isDeterministicProviderValidationError(error)
+  );
 }
 
 const NETWORK_RE = /network|connection|connect|disconnect|terminated/i;

--- a/packages/agent-core-v2/test/app/llmProtocol/errors.test.ts
+++ b/packages/agent-core-v2/test/app/llmProtocol/errors.test.ts
@@ -193,6 +193,15 @@ describe('isRetryableGenerateError', () => {
   it('retries an unclassified provider error as a transient fallback', () => {
     expect(isRetryableGenerateError(new ChatProviderError('upstream failure'))).toBe(true);
   });
+
+  it.each([
+    ['Invalid data URL for image: data:image/png;base64'],
+    [
+      'Unsupported media type for base64 image: image/avif, url: data:image/avif;base64,AAAA',
+    ],
+  ])('does not retry deterministic provider validation error: %s', (message) => {
+    expect(isRetryableGenerateError(new ChatProviderError(message))).toBe(false);
+  });
 });
 
 describe('error hierarchy instanceof checks', () => {


### PR DESCRIPTION
## Related Issue

Follow-up to #1598 and its review finding about deterministic provider validation errors.

## Problem

The v2 retry fallback introduced in #1598 treats every base `ChatProviderError` as transient. The Anthropic adapter uses that base error for malformed image data URLs and unsupported base64 image media types before making an HTTP request, so retrying repeats the same deterministic failure, delays the final error, and emits misleading retry events.

## What changed

- Exclude the same two client-side image validation message families that v1 already excludes from its base provider-error retry fallback.
- Keep generic unclassified provider failures retryable, along with the existing transient HTTP status handling.
- Add regression coverage for both deterministic validation messages while retaining coverage for the generic fallback.

## Validation

- `pnpm --filter @moonshot-ai/agent-core-v2 exec vitest run test/app/llmProtocol/errors.test.ts test/agent/stepRetry/stepRetry.test.ts --maxWorkers=2` (105 tests passed)
- `pnpm --filter @moonshot-ai/agent-core-v2 test -- --reporter=dot` (3,159 tests passed)
- `pnpm --filter @moonshot-ai/agent-core-v2 typecheck`
- `pnpm --filter @moonshot-ai/agent-core-v2 lint:domain`
- `pnpm exec oxlint --type-aware packages/agent-core-v2/src/app/llmProtocol/errors.ts packages/agent-core-v2/test/app/llmProtocol/errors.test.ts`
- `pnpm exec changeset status`
- `pnpm --filter @moonshot-ai/agent-core-v2 dep-graph:lint` still reports the 21 pre-existing unresolved `IAgentWireService` binding errors from `main`; none of its findings are in files changed by this PR.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update. (No documentation update is needed for this retry-classification bug fix.)
