### PR TITLE
fix(web): prevent ESC in dialog from interrupting running tasks

### DIFF
--- a/apps/kimi-web/src/components/chat/ConversationPane.vue
+++ b/apps/kimi-web/src/components/chat/ConversationPane.vue
@@ -3,6 +3,7 @@
 import { measureNaturalWidth, prepareWithSegments } from '@chenglou/pretext';
 import { computed, nextTick, onMounted, onUnmounted, provide, ref, watch, type ComponentPublicInstance } from 'vue';
 import { useI18n } from 'vue-i18n';
+import { openDialogCount } from '../../composables/dialogStack';
 import type { ActivationBadges, ApprovalBlock, ChatTurn, ConversationStatus, FilePreviewRequest, PermissionMode, QueuedPromptView, TaskItem, TodoView, ToolMedia, UIQuestion, WorkspaceView } from '../../types';
 import type { AppGoal, AppModel, AppSkill, QuestionResponse, ThinkingLevel } from '../../api/types';
 import type { FileItem } from './MentionMenu.vue';
@@ -1248,7 +1249,11 @@ function handleInterrupt(): void {
 }
 
 function onKeyDown(event: KeyboardEvent): void {
-  if (event.key === 'Escape' && (props.running || props.sending)) {
+  if (event.key !== 'Escape') return;
+  // When a modal dialog is open (e.g. SearchSessionsDialog), Escape is owned
+  // by the dialog layer. Do NOT interrupt the running prompt behind it.
+  if (openDialogCount.value > 0) return;
+  if (props.running || props.sending) {
     event.preventDefault();
     handleInterrupt();
   }


### PR DESCRIPTION
When a modal dialog (e.g. SearchSessionsDialog) is open, pressing Escape closes the dialog but also triggers the global document-level Escape handler in ConversationPane.vue, which interrupts any running prompt.

The fix checks <code>openDialogCount</code> before handling Escape in the conversation pane's onKeyDown, so dialog layers own the Escape key while they are open.

Fixes #1538