### PR TITLE
fix(agent-core-v2): append sessions to shared index so v1 TUI can resume web-created sessions

### DIFF
--- a/.changeset/fix-v2-session-resume-in-tui.md
+++ b/.changeset/fix-v2-session-resume-in-tui.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Fix resuming web-created sessions in the TUI when the experimental v2 engine is enabled.

--- a/.changeset/fix-v2-session-resume-in-tui.md
+++ b/.changeset/fix-v2-session-resume-in-tui.md
@@ -1,5 +1,0 @@
----
-"@moonshot-ai/kimi-code": patch
----
-
-Fix resuming web-created sessions in the TUI when the experimental v2 engine is enabled.

--- a/packages/agent-core-v2/src/app/sessionLifecycle/sessionLifecycleService.ts
+++ b/packages/agent-core-v2/src/app/sessionLifecycle/sessionLifecycleService.ts
@@ -125,7 +125,7 @@ export class SessionLifecycleService extends Disposable implements ISessionLifec
   async create(opts: CreateSessionOptions): Promise<ISessionScopeHandle> {
     const sessionId = opts.sessionId ?? createSessionId();
     const handle = await this.materializeSession({ ...opts, sessionId });
-    this.appendLegacySessionIndexEntry(sessionId, opts.workDir);
+    this.appendSessionIndexEntry(sessionId, opts.workDir);
     if (this.config.get<boolean>(DEFAULT_PLAN_MODE_SECTION) === true) {
       const main = await ensureMainAgent(handle);
       await main.accessor.get(IAgentPlanService).enter();
@@ -195,14 +195,14 @@ export class SessionLifecycleService extends Disposable implements ISessionLifec
   }
 
   /**
-   * Append the session to v1's legacy `session_index.jsonl` so v1 clients (TUI,
+   * Append the session to the shared `session_index.jsonl` so v1 clients (TUI,
    * export, etc.) can discover sessions created by the v2 engine. The index is
    * append-only JSONL; later entries for the same id override earlier ones, so
    * redundant appends on resume/fork are safe. A failure here must not fail
    * session creation — the v2 read model (`ISessionIndex`) remains the
    * authoritative index for v2 itself.
    */
-  private appendLegacySessionIndexEntry(sessionId: string, workDir: string): void {
+  private appendSessionIndexEntry(sessionId: string, workDir: string): void {
     const workspaceId = encodeWorkDirKey(workDir);
     const sessionDir = this.bootstrap.sessionDir(workspaceId, sessionId);
     this.appendLogStore.append('', 'session_index.jsonl', {
@@ -395,7 +395,7 @@ export class SessionLifecycleService extends Disposable implements ISessionLifec
         sessionId: targetId,
         workDir: workspace.root,
       });
-      this.appendLegacySessionIndexEntry(targetId, workspace.root);
+      this.appendSessionIndexEntry(targetId, workspace.root);
       const targetCtx = target.accessor.get(ISessionContext);
       const targetMeta = target.accessor.get(ISessionMetadata);
 

--- a/packages/agent-core-v2/src/app/sessionLifecycle/sessionLifecycleService.ts
+++ b/packages/agent-core-v2/src/app/sessionLifecycle/sessionLifecycleService.ts
@@ -25,6 +25,7 @@ import {
   registerScopedService,
 } from '#/_base/di/scope';
 import { Emitter, type Event } from '#/_base/event';
+import { encodeWorkDirKey } from '#/_base/utils/workdir-slug';
 import { ISessionActivityKernel } from '#/activity/activity';
 import { IAgentContextMemoryService } from '#/agent/contextMemory/contextMemory';
 import { DEFAULT_PLAN_MODE_SECTION } from '#/agent/plan/configSection';
@@ -124,6 +125,7 @@ export class SessionLifecycleService extends Disposable implements ISessionLifec
   async create(opts: CreateSessionOptions): Promise<ISessionScopeHandle> {
     const sessionId = opts.sessionId ?? createSessionId();
     const handle = await this.materializeSession({ ...opts, sessionId });
+    this.appendLegacySessionIndexEntry(sessionId, opts.workDir);
     if (this.config.get<boolean>(DEFAULT_PLAN_MODE_SECTION) === true) {
       const main = await ensureMainAgent(handle);
       await main.accessor.get(IAgentPlanService).enter();
@@ -190,6 +192,24 @@ export class SessionLifecycleService extends Disposable implements ISessionLifec
     await handle.accessor.get(IAgentLifecycleService).ensureMcpReady();
     handle.accessor.get(ISessionExternalHooksService);
     return handle;
+  }
+
+  /**
+   * Append the session to v1's legacy `session_index.jsonl` so v1 clients (TUI,
+   * export, etc.) can discover sessions created by the v2 engine. The index is
+   * append-only JSONL; later entries for the same id override earlier ones, so
+   * redundant appends on resume/fork are safe. A failure here must not fail
+   * session creation — the v2 read model (`ISessionIndex`) remains the
+   * authoritative index for v2 itself.
+   */
+  private appendLegacySessionIndexEntry(sessionId: string, workDir: string): void {
+    const workspaceId = encodeWorkDirKey(workDir);
+    const sessionDir = this.bootstrap.sessionDir(workspaceId, sessionId);
+    this.appendLogStore.append('', 'session_index.jsonl', {
+      sessionId,
+      sessionDir,
+      workDir,
+    });
   }
 
   private async announceCreated(event: SessionCreatedEvent): Promise<void> {
@@ -375,6 +395,7 @@ export class SessionLifecycleService extends Disposable implements ISessionLifec
         sessionId: targetId,
         workDir: workspace.root,
       });
+      this.appendLegacySessionIndexEntry(targetId, workspace.root);
       const targetCtx = target.accessor.get(ISessionContext);
       const targetMeta = target.accessor.get(ISessionMetadata);
 

--- a/packages/agent-core-v2/src/app/sessionLifecycle/sessionLifecycleService.ts
+++ b/packages/agent-core-v2/src/app/sessionLifecycle/sessionLifecycleService.ts
@@ -10,7 +10,9 @@
  * through `telemetry`. Materializes the session's initial metadata on
  * creation by resolving `sessionMetadata`. Bound at App scope. Persisted
  * sessions are discovered through the `sessionIndex` read model, and workspace
- * roots are remembered through `workspaceRegistry`.
+ * roots are remembered through `workspaceRegistry`. On create / fork the
+ * session is also appended to the shared `session_index.jsonl` so v1 clients
+ * (TUI, export) can discover sessions created by the v2 engine.
  */
 
 import { randomUUID } from 'node:crypto';
@@ -125,7 +127,7 @@ export class SessionLifecycleService extends Disposable implements ISessionLifec
   async create(opts: CreateSessionOptions): Promise<ISessionScopeHandle> {
     const sessionId = opts.sessionId ?? createSessionId();
     const handle = await this.materializeSession({ ...opts, sessionId });
-    this.appendSessionIndexEntry(sessionId, opts.workDir);
+    await this.appendSessionIndexEntry(sessionId, opts.workDir);
     if (this.config.get<boolean>(DEFAULT_PLAN_MODE_SECTION) === true) {
       const main = await ensureMainAgent(handle);
       await main.accessor.get(IAgentPlanService).enter();
@@ -194,15 +196,7 @@ export class SessionLifecycleService extends Disposable implements ISessionLifec
     return handle;
   }
 
-  /**
-   * Append the session to the shared `session_index.jsonl` so v1 clients (TUI,
-   * export, etc.) can discover sessions created by the v2 engine. The index is
-   * append-only JSONL; later entries for the same id override earlier ones, so
-   * redundant appends on resume/fork are safe. A failure here must not fail
-   * session creation — the v2 read model (`ISessionIndex`) remains the
-   * authoritative index for v2 itself.
-   */
-  private appendSessionIndexEntry(sessionId: string, workDir: string): void {
+  private async appendSessionIndexEntry(sessionId: string, workDir: string): Promise<void> {
     const workspaceId = encodeWorkDirKey(workDir);
     const sessionDir = this.bootstrap.sessionDir(workspaceId, sessionId);
     this.appendLogStore.append('', 'session_index.jsonl', {
@@ -210,6 +204,7 @@ export class SessionLifecycleService extends Disposable implements ISessionLifec
       sessionDir,
       workDir,
     });
+    await this.appendLogStore.flush();
   }
 
   private async announceCreated(event: SessionCreatedEvent): Promise<void> {
@@ -395,7 +390,6 @@ export class SessionLifecycleService extends Disposable implements ISessionLifec
         sessionId: targetId,
         workDir: workspace.root,
       });
-      this.appendSessionIndexEntry(targetId, workspace.root);
       const targetCtx = target.accessor.get(ISessionContext);
       const targetMeta = target.accessor.get(ISessionMetadata);
 
@@ -441,6 +435,7 @@ export class SessionLifecycleService extends Disposable implements ISessionLifec
         await agentHandle.accessor.get(IAgentWireService).replay(...forkRecords);
       }
 
+      await this.appendSessionIndexEntry(targetId, workspace.root);
       this._onDidForkSession.fire({
         sourceSessionId: sourceId,
         sessionId: targetId,

--- a/packages/agent-core-v2/test/app/sessionLifecycle/sessionLifecycle.test.ts
+++ b/packages/agent-core-v2/test/app/sessionLifecycle/sessionLifecycle.test.ts
@@ -426,6 +426,33 @@ describe('SessionLifecycleService', () => {
     expect(h.kind).toBe(LifecycleScope.Session);
   });
 
+  it('create appends the session to the legacy v1 session_index.jsonl', async () => {
+    const appended: unknown[] = [];
+    const svc = build([
+      stubPair(IAppendLogStore, {
+        ...appendLogStoreStub(),
+        append: (scope: string, key: string, record: unknown) => {
+          appended.push({ scope, key, record });
+        },
+      }),
+    ]);
+
+    await svc.create({ sessionId: 's1', workDir: '/tmp/proj' });
+
+    const workspaceId = encodeWorkDirKey('/tmp/proj');
+    expect(appended).toEqual([
+      {
+        scope: '',
+        key: 'session_index.jsonl',
+        record: {
+          sessionId: 's1',
+          sessionDir: `/tmp/sessions/${workspaceId}/s1`,
+          workDir: '/tmp/proj',
+        },
+      },
+    ]);
+  });
+
   it('registers the workspace during create so a cold resume can resolve the workdir', async () => {
     const workDir = '/tmp/proj';
     const workspaceRegistry = persistentWorkspaceRegistryStub();

--- a/packages/agent-core-v2/test/app/sessionLifecycle/sessionLifecycle.test.ts
+++ b/packages/agent-core-v2/test/app/sessionLifecycle/sessionLifecycle.test.ts
@@ -426,7 +426,7 @@ describe('SessionLifecycleService', () => {
     expect(h.kind).toBe(LifecycleScope.Session);
   });
 
-  it('create appends the session to the legacy v1 session_index.jsonl', async () => {
+  it('create appends the session to the shared session_index.jsonl', async () => {
     const appended: unknown[] = [];
     const svc = build([
       stubPair(IAppendLogStore, {


### PR DESCRIPTION
## Related Issue

Web-created sessions cannot be resumed in the TUI when the experimental v2 engine is enabled.

## Problem

When `KIMI_CODE_EXPERIMENTAL_FLAG=1` is set, the web UI talks to the v2 daemon (`kap-server` / `agent-core-v2`). Sessions created through the v2 `ISessionLifecycleService` are written to the same on-disk layout as v1 (`~/.kimi-code/sessions/<workDirKey>/<sessionId>/`), but v2 never appends them to the shared `session_index.jsonl`.

The TUI always runs the in-process v1 `KimiCore`. Its `SessionStore.get(id)` only reads `session_index.jsonl`; when the entry is missing, resume throws `SESSION_NOT_FOUND`. Notably, `listSessions({ sessionId, workDir })` still finds the session by scanning the bucket directory, so users can see the session in the picker but cannot open it.

## What changed

- `SessionLifecycleService.create()` and `fork()` now call `appendSessionIndexEntry()`, which writes `{ sessionId, sessionDir, workDir }` to the shared `session_index.jsonl` using v2's own `IAppendLogStore` (no dependency on `@moonshot-ai/agent-core`).
- Added a test verifying that `create` emits the shared index entry.

This keeps the v1/v2 index contract consistent: v1 remains index-based, v2 remains directory-scan-based, but both engines now populate the shared index so v1 clients (TUI, export, etc.) can discover v2-created sessions.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.