### PR TITLE
chore(web): drop the /help, /model, /provider, and /permission slash commands

### DIFF
--- a/.changeset/web-drop-unused-slash-commands.md
+++ b/.changeset/web-drop-unused-slash-commands.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": minor
+---
+
+web: Remove the /help, /model, /provider, and /permission slash commands; switch models or approval modes from the buttons in the chat UI instead.

--- a/.changeset/web-drop-unused-slash-commands.md
+++ b/.changeset/web-drop-unused-slash-commands.md
@@ -1,5 +1,0 @@
----
-"@moonshot-ai/kimi-code": minor
----
-
-web: Remove the /help, /model, /provider, and /permission slash commands; switch models or approval modes from the buttons in the chat UI instead.

--- a/apps/kimi-web/src/App.vue
+++ b/apps/kimi-web/src/App.vue
@@ -269,9 +269,6 @@ const conversationPaneRef = ref<InstanceType<typeof ConversationPane> | null>(nu
 const showModelPicker = ref(false);
 const showProviders = ref(false);
 
-// Provider management (add / delete) is not shipped by the daemon yet — hide the
-// manager UI entry points for now. Re-enable once POST/DELETE /providers land.
-const PROVIDER_MANAGER_ENABLED = false;
 const showLogin = ref(false);
 const showAddWorkspace = ref(false);
 const showStatusPanel = ref(false);
@@ -476,13 +473,6 @@ function handleCommand(cmd: string): void {
     case '/undo':
       void client.undo();
       break;
-    case '/permission': {
-      // Cycle manual → auto → yolo → manual
-      const current = client.permission.value;
-      const next = current === 'manual' ? 'auto' : current === 'auto' ? 'yolo' : 'manual';
-      client.setPermission(next);
-      break;
-    }
     case '/plan':
       client.togglePlanMode();
       break;
@@ -496,17 +486,8 @@ function handleCommand(cmd: string): void {
       // No popover anchor from a slash command — step to the next level.
       client.setThinking(nextThinkingLevel(client.thinking.value));
       break;
-    case '/help':
-      client.dismissWarning(-1);
-      break;
     case '/status':
       showStatusPanel.value = true;
-      break;
-    case '/model':
-      void openModelPicker();
-      break;
-    case '/provider':
-      if (PROVIDER_MANAGER_ENABLED) void openProviders();
       break;
     case '/login':
       openLogin();

--- a/apps/kimi-web/src/i18n/locales/en/commands.ts
+++ b/apps/kimi-web/src/i18n/locales/en/commands.ts
@@ -1,11 +1,7 @@
 export default {
-  help: { desc: 'Show the list of available commands' },
   new: { desc: 'Create a new session' },
   clear: { desc: 'Clear and start a new session' },
-  model: { desc: 'Switch model' },
-  provider: { desc: 'Manage providers (add / remove / refresh)' },
   login: { desc: 'Sign in to Kimi in the browser' },
-  permission: { desc: 'Switch approval mode (manual / auto / yolo)' },
   plan: { desc: 'Toggle plan mode on/off' },
   swarm: { desc: 'Toggle swarm mode; /swarm <task> runs a task in swarm' },
   goal: { desc: 'Create/control a goal: /goal <objective>, /goal pause|resume|cancel' },
@@ -15,7 +11,6 @@ export default {
   thinking: { desc: 'Set the thinking level' },
   compact: { desc: 'Compact the conversation history' },
   fork: { desc: 'Fork this session into a new one' },
-  undoNotImplemented: '/undo isn\'t supported by the daemon yet',
   status: { desc: 'View session status' },
   undo: { desc: 'Undo the last message' },
 } as const;

--- a/apps/kimi-web/src/i18n/locales/zh/commands.ts
+++ b/apps/kimi-web/src/i18n/locales/zh/commands.ts
@@ -1,11 +1,7 @@
 export default {
-  help: { desc: '显示可用命令列表' },
   new: { desc: '创建新会话' },
   clear: { desc: '清空并新建会话' },
-  model: { desc: '切换模型' },
-  provider: { desc: '管理提供商 (添加/删除/刷新)' },
   login: { desc: '在浏览器中登录 Kimi' },
-  permission: { desc: '切换审批模式 (manual/auto/yolo)' },
   plan: { desc: '切换计划模式 开/关' },
   swarm: { desc: '切换 swarm 模式；/swarm <任务> 直接在 swarm 下执行' },
   goal: { desc: '创建/控制目标：/goal <目标>、/goal pause|resume|cancel' },
@@ -15,7 +11,6 @@ export default {
   thinking: { desc: '设置思考强度' },
   compact: { desc: '压缩会话历史' },
   fork: { desc: '把当前会话 fork 出一个新会话' },
-  undoNotImplemented: 'daemon 尚未支持 /undo',
   status: { desc: '查看会话状态' },
   undo: { desc: '撤销上一条消息' },
 };

--- a/apps/kimi-web/src/lib/slashCommands.ts
+++ b/apps/kimi-web/src/lib/slashCommands.ts
@@ -22,12 +22,9 @@ export interface SlashCommand {
 }
 
 export const SLASH_COMMANDS: SlashCommand[] = [
-  { name: '/help',       desc: 'commands.help.desc' },
   { name: '/new',        desc: 'commands.new.desc' },
   { name: '/clear',      desc: 'commands.clear.desc' },
-  { name: '/model',      desc: 'commands.model.desc' },
   { name: '/login',      desc: 'commands.login.desc' },
-  { name: '/permission', desc: 'commands.permission.desc' },
   { name: '/plan',       desc: 'commands.plan.desc' },
   { name: '/swarm',      desc: 'commands.swarm.desc', acceptsInput: true },
   { name: '/goal',       desc: 'commands.goal.desc', acceptsInput: true },

--- a/apps/kimi-web/test/slash-menu.test.ts
+++ b/apps/kimi-web/test/slash-menu.test.ts
@@ -50,10 +50,10 @@ describe('useSlashMenu — update', () => {
   });
 
   it('filters to matching commands', () => {
-    const { slash } = setup('/mod');
+    const { slash } = setup('/com');
     slash.update();
     expect(slash.open.value).toBe(true);
-    expect(slash.items.value.map((i) => i.name)).toContain('/model');
+    expect(slash.items.value.map((i) => i.name)).toContain('/compact');
   });
 
   it('closes when nothing matches', () => {
@@ -98,11 +98,11 @@ describe('useSlashMenu — update', () => {
 
 describe('useSlashMenu — select', () => {
   it('non-acceptsInput: clears text, pushes history, emits the command', () => {
-    const { text, emitted, pushed, slash } = setup('/model');
-    slash.select({ name: '/model', desc: '' });
+    const { text, emitted, pushed, slash } = setup('/new');
+    slash.select({ name: '/new', desc: '' });
     expect(text.value).toBe('');
-    expect(pushed).toEqual(['/model']);
-    expect(emitted).toEqual(['/model']);
+    expect(pushed).toEqual(['/new']);
+    expect(emitted).toEqual(['/new']);
     expect(slash.open.value).toBe(false);
   });
 


### PR DESCRIPTION
## Related Issue

No linked issue — the problem is explained below.

## Problem

The web slash menu carried four commands that were dead or redundant:

- `/provider` was unreachable: it was never in the menu list (so hand-typing it failed the composer's exact-match check and went out as chat text), and its handler was gated behind a flag that is hardcoded off because the daemon has no provider-management endpoints yet.
- `/help` did not show help — it just dismissed the latest warning toast (a no-op when no warnings are showing). The web UI has no help panel.
- `/model` and `/permission` worked, but only duplicated the model button and the permission dropdown that are already in the chat UI.

Hand-typed input that is not a known command already falls through as normal chat text, so removing these entries changes nothing for unknown commands — `/help`, `/model`, `/provider`, and `/permission` now simply behave like any other unrecognized slash input.

## What changed

- Removed `/help`, `/model`, `/provider`, and `/permission` from the web slash menu (`SLASH_COMMANDS`) and from `handleCommand` in `App.vue`.
- Removed the now-unused `PROVIDER_MANAGER_ENABLED` flag (its only consumer was the `/provider` case; the settings-dialog provider entry does not use it and is untouched).
- Removed the four dead i18n keys (en + zh), plus the already-dead `undoNotImplemented` key left over from before the daemon supported `/undo`.
- Updated the two slash-menu tests that referenced `/model` to use `/compact` and `/new`.

Model switching and approval-mode switching remain available from the chat UI buttons, and `/auto` / `/yolo` still work as slash commands.

Verified with the kimi-web test suite (465 tests) and `vue-tsc --noEmit`.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.