### PR TITLE
test(server): stabilize approval teardown

### DIFF
--- a/.changeset/stabilize-approval-test-cleanup.md
+++ b/.changeset/stabilize-approval-test-cleanup.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/server": patch
+---
+
+Stabilize server approval end-to-end test cleanup after daemon shutdown.

--- a/packages/server/test/approval.e2e.test.ts
+++ b/packages/server/test/approval.e2e.test.ts
@@ -58,8 +58,8 @@ afterEach(async () => {
     // ignore
   }
   server = undefined;
-  rmSync(tmpDir, { recursive: true, force: true });
-  rmSync(bridgeHome, { recursive: true, force: true });
+  rmSync(tmpDir, { recursive: true, force: true, maxRetries: 3, retryDelay: 100 });
+  rmSync(bridgeHome, { recursive: true, force: true, maxRetries: 3, retryDelay: 100 });
 });
 
 async function bootDaemon(): Promise<RunningServer> {


### PR DESCRIPTION
## Related Issue

No related issue. This fixes a flaky server end-to-end test teardown that failed in CI.

## Problem

The approval end-to-end test stops the server and immediately removes its temporary home directory. The daemon's core process can still be flushing files after `server.close()` resolves, so cleanup can race with those writes and fail with `ENOTEMPTY`.

## What changed

- Retry removal of both temporary directories up to three times with a 100ms delay between attempts.
- Add a patch changeset for `@moonshot-ai/server`.

## Validation

- Approval test: 5 parallel repetitions, 7/7 tests passed in each run.
- `pnpm --filter @moonshot-ai/server test` — 63 files, 699 tests passed.
- `pnpm --filter @moonshot-ai/server typecheck`
- `pnpm exec oxlint packages/server/test/approval.e2e.test.ts`
- `git diff --check`

## Checklist

- [x] I have explained the problem and the fix above.
- [x] I have run the relevant server tests and checks.
- [x] I have added a patch changeset.
- [ ] I have added new behavior tests. This is a teardown reliability fix; the existing approval tests cover the behavior and the repeated runs cover cleanup stability.