### PR TITLE
chore: remove v2 web search changeset

### DIFF
--- a/.changeset/v2-moonshot-search-config.md
+++ b/.changeset/v2-moonshot-search-config.md
@@ -1,5 +1,0 @@
----
-"@moonshot-ai/kimi-code": patch
----
-
-Support the `services.moonshot_search` api-key config for WebSearch in the v2 engine, matching v1: the tool is now available without an OAuth login, and explicit config takes precedence over the OAuth-derived provider.


### PR DESCRIPTION
## Related Issue

Follow-up to #1613.

## Problem

PR #1613 added a CLI changeset for restoring behavior in the experimental agent-core-v2 engine. This fix should not produce a separate user-facing CLI release entry.

## What changed

Removed `.changeset/v2-moonshot-search-config.md`. No runtime or test code changes are included.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] Tests are not needed because this only removes release metadata.
- [x] Ran `gen-changesets` skill; this PR intentionally needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.