### PR TITLE
fix(agent-core-v2): fall back to protocol default base URL when unconfigured

### DIFF
--- a/.changeset/fix-provider-default-base-url.md
+++ b/.changeset/fix-provider-default-base-url.md
@@ -1,0 +1,6 @@
+---
+"@moonshot-ai/agent-core-v2": patch
+"@moonshot-ai/kimi-code": patch
+---
+
+Fix providers without a configured base_url being rejected: anthropic/openai and other protocol providers now fall back to their official default endpoints again, as before.

--- a/packages/agent-core-v2/src/app/model/modelImpl.ts
+++ b/packages/agent-core-v2/src/app/model/modelImpl.ts
@@ -39,7 +39,7 @@ export interface ModelImplInit {
   readonly name: string;
   readonly aliases: readonly string[];
   readonly protocol: Protocol;
-  readonly baseUrl: string;
+  readonly baseUrl?: string;
   readonly headers: Readonly<Record<string, string>>;
   readonly capabilities: ModelCapability;
   readonly maxContextSize: number;
@@ -60,7 +60,7 @@ export class ModelImpl implements Model {
   readonly name: string;
   readonly aliases: readonly string[];
   readonly protocol: Protocol;
-  readonly baseUrl: string;
+  readonly baseUrl: string | undefined;
   readonly headers: Readonly<Record<string, string>>;
   readonly capabilities: ModelCapability;
   readonly maxContextSize: number;

--- a/packages/agent-core-v2/src/app/model/modelInstance.ts
+++ b/packages/agent-core-v2/src/app/model/modelInstance.ts
@@ -87,7 +87,7 @@ export interface Model {
   /** Free-form routing aliases; a name-based lookup matches these. */
   readonly aliases: readonly string[];
   readonly protocol: Protocol;
-  readonly baseUrl: string;
+  readonly baseUrl?: string;
   readonly headers: Readonly<Record<string, string>>;
 
   readonly capabilities: ModelCapability;

--- a/packages/agent-core-v2/src/app/model/modelResolverService.ts
+++ b/packages/agent-core-v2/src/app/model/modelResolverService.ts
@@ -99,7 +99,9 @@ export class ModelResolverService extends Disposable implements IModelResolver {
     // overrides into the Anthropic transport. Native Anthropic providers keep
     // their configured `/v1` because the old provider manager did too.
     const resolvedBaseUrl =
-      model.protocol === 'anthropic' ? stripTrailingV1(rawBaseUrl) : rawBaseUrl;
+      model.protocol === 'anthropic' && rawBaseUrl !== undefined
+        ? stripTrailingV1(rawBaseUrl)
+        : rawBaseUrl;
     const wireName = model.name ?? model.model;
     if (wireName === undefined) {
       throw new Error2(
@@ -201,7 +203,10 @@ export class ModelResolverService extends Disposable implements IModelResolver {
   /**
    * Return the ProviderConfig this Model resolves against, plus the URL to
    * hit at runtime. Structured path reads `[providers.<providerId>]`; flat
-   * path synthesizes a Provider record from the Model's inline baseUrl.
+   * path synthesizes a Provider record from the Model's inline baseUrl. A
+   * structured Model with no baseUrl anywhere (config, provider, env) yields
+   * `undefined` — the wire provider then applies its protocol default
+   * endpoint, matching v1's `provider-manager`.
    */
   private resolveProviderContext(
     id: string,
@@ -209,7 +214,7 @@ export class ModelResolverService extends Disposable implements IModelResolver {
   ): {
     readonly providerConfig: ProviderConfig | undefined;
     readonly providerName: string;
-    readonly resolvedBaseUrl: string;
+    readonly resolvedBaseUrl: string | undefined;
   } {
     // Structured path — Model references a Provider (which may reference a
     // Platform). Legacy configs still use `provider` in place of `providerId`,
@@ -232,12 +237,6 @@ export class ModelResolverService extends Disposable implements IModelResolver {
           model.protocol ?? providerConfig.type,
           providerConfig.env,
         );
-      if (baseUrl === undefined || baseUrl.length === 0) {
-        throw new Error2(
-          ErrorCodes.CONFIG_INVALID,
-          `Model "${id}" (via provider "${providerId}") is missing a base URL.`,
-        );
-      }
       return { providerConfig, providerName: providerId, resolvedBaseUrl: baseUrl };
     }
 
@@ -360,7 +359,7 @@ function buildProtocolProviderOptions(
   model: ModelConfig,
   protocol: Protocol,
   provider: ProviderConfig | undefined,
-  baseUrl: string,
+  baseUrl: string | undefined,
 ): ProtocolProviderOptions | undefined {
   const options: MutableProtocolProviderOptions = {};
 

--- a/packages/agent-core-v2/src/app/protocol/protocol.ts
+++ b/packages/agent-core-v2/src/app/protocol/protocol.ts
@@ -51,7 +51,7 @@ export interface ProtocolProviderOptions {
  */
 export interface ProtocolAdapterConfig {
   readonly protocol: Protocol;
-  readonly baseUrl: string;
+  readonly baseUrl?: string;
   readonly modelName: string;
   readonly apiKey?: string;
   readonly defaultHeaders?: Readonly<Record<string, string>>;

--- a/packages/agent-core-v2/test/app/model/modelResolver.test.ts
+++ b/packages/agent-core-v2/test/app/model/modelResolver.test.ts
@@ -816,7 +816,11 @@ describe('ModelResolverService', () => {
       );
     });
 
-    function resolveBaseUrl(protocol: string, providerType: string, baseUrl: string): string {
+    function resolveBaseUrl(
+      protocol: string,
+      providerType: string,
+      baseUrl: string,
+    ): string | undefined {
       providers['p'] = { type: providerType, baseUrl, apiKey: 'sk' } as ProviderConfig;
       models['m'] = { provider: 'p', model: 'wire-name', maxContextSize: 1000, protocol } as ModelConfig;
       return ix.get(IModelResolver).resolve('m').baseUrl;
@@ -850,6 +854,36 @@ describe('ModelResolverService', () => {
     it('does not strip /v1 for non-anthropic protocols', () => {
       expect(resolveBaseUrl('kimi', 'kimi', 'https://example.test/coding/v1')).toBe(
         'https://example.test/coding/v1',
+      );
+    });
+
+    it.each(['anthropic', 'openai', 'openai_responses', 'kimi', 'google-genai'] as const)(
+      'resolves a %s provider without base_url to an undefined baseUrl (protocol default applies)',
+      (type) => {
+        providers['p'] = { type, apiKey: 'sk' };
+        models['m'] = { provider: 'p', model: 'wire-name', maxContextSize: 1000 };
+
+        expect(ix.get(IModelResolver).resolve('m').baseUrl).toBeUndefined();
+      },
+    );
+
+    it('resolves an anthropic-protocol override without base_url without stripping', () => {
+      providers['p'] = { type: 'kimi', apiKey: 'sk' };
+      models['m'] = {
+        provider: 'p',
+        model: 'wire-name',
+        maxContextSize: 1000,
+        protocol: 'anthropic',
+      };
+
+      expect(ix.get(IModelResolver).resolve('m').baseUrl).toBeUndefined();
+    });
+
+    it('still rejects a flat model with neither providerId nor baseUrl', () => {
+      models['m'] = { model: 'wire-name', maxContextSize: 1000 };
+
+      expect(() => ix.get(IModelResolver).resolve('m')).toThrow(
+        'Model "m" must set either providerId or baseUrl in config.toml.',
       );
     });
   });


### PR DESCRIPTION
## Related Issue

No linked issue — the problem is explained below.

## Problem

In agent-core-v2, a structured model whose provider has no `base_url` configured (neither in config, provider, nor env) was rejected with `CONFIG_INVALID` ("missing a base URL"). This is a regression from v1, where `provider-manager` let providers without a configured `base_url` fall back to their protocol's official default endpoint (e.g. the official Anthropic / OpenAI endpoints). Users migrating such configs to v2 hit a hard config error instead of the previous working behavior.

## What changed

- `ModelResolverService`: removed the `CONFIG_INVALID` throw when a structured provider resolves no base URL; `resolvedBaseUrl` is now `string | undefined` and the wire provider applies its protocol default endpoint, matching v1's `provider-manager`.
- Guarded the Anthropic `/v1` stripping so it only runs when a base URL actually exists.
- Threaded the optional `baseUrl` through the `Model`, `ModelImpl`, `ProtocolAdapterConfig`, and `buildProtocolProviderOptions` types.
- Added tests: every protocol type (`anthropic`, `openai`, `openai_responses`, `kimi`, `google-genai`) without `base_url` resolves to `undefined`; an anthropic-protocol override without `base_url` is left untouched; and flat models with neither `providerId` nor `baseUrl` are still rejected as before.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.
