### PR TITLE
fix(tui): preserve dollar-delimited math source

### DIFF
--- a/.changeset/preserve-cli-latex-source.md
+++ b/.changeset/preserve-cli-latex-source.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Fix terminal transcripts dropping Markdown-like characters from dollar-delimited math.

--- a/.changeset/preserve-pi-tui-latex-source.md
+++ b/.changeset/preserve-pi-tui-latex-source.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/pi-tui": patch
+---
+
+Preserve dollar-delimited math source as literal text during Markdown rendering.

--- a/apps/kimi-code/src/tui/components/messages/assistant-message.ts
+++ b/apps/kimi-code/src/tui/components/messages/assistant-message.ts
@@ -61,7 +61,14 @@ export class AssistantMessageComponent implements Component {
 
     if (this.markdown === undefined || this.markdownTransient !== transient) {
       this.contentContainer.clear();
-      this.markdown = new Markdown(displayText, 0, 0, createMarkdownTheme({ transient }));
+      this.markdown = new Markdown(
+        displayText,
+        0,
+        0,
+        createMarkdownTheme({ transient }),
+        undefined,
+        { preserveIncompleteMath: transient },
+      );
       this.markdownTransient = transient;
       this.contentContainer.addChild(this.markdown);
       return;
@@ -84,6 +91,8 @@ export class AssistantMessageComponent implements Component {
         0,
         0,
         createMarkdownTheme({ transient: this.lastTransient }),
+        undefined,
+        { preserveIncompleteMath: this.lastTransient },
       );
       this.markdownTransient = this.lastTransient;
       this.contentContainer.addChild(this.markdown);

--- a/apps/kimi-code/test/tui/components/messages/assistant-message.test.ts
+++ b/apps/kimi-code/test/tui/components/messages/assistant-message.test.ts
@@ -112,6 +112,52 @@ describe('AssistantMessageComponent', () => {
     expect(finalized).not.toBe(streaming);
   });
 
+  it('preserves incomplete math source while assistant content is streaming', () => {
+    const component = new AssistantMessageComponent();
+    const source = String.raw`[lead $\text{a](b)} tail`;
+
+    component.updateContent(source, { transient: true });
+
+    expect(strip(component.render(120).join('\n'))).toContain(source);
+  });
+
+  it('preserves incomplete math source after a streaming render is invalidated', () => {
+    const component = new AssistantMessageComponent();
+    const source = String.raw`[lead $\text{a](b)} tail`;
+    component.updateContent(source, { transient: true });
+
+    component.invalidate();
+
+    expect(strip(component.render(120).join('\n'))).toContain(source);
+  });
+
+  it('preserves math-like incomplete source when assistant content is finalized', () => {
+    const component = new AssistantMessageComponent();
+    const source = String.raw`$5 \theta^*_A + \phi^*_B`;
+    component.updateContent(source, { transient: true });
+
+    component.updateContent(source, { transient: false });
+
+    expect(strip(component.render(120).join('\n'))).toContain(source);
+  });
+
+  it('reparses an unmatched dollar as ordinary table text when streaming finishes', () => {
+    const component = new AssistantMessageComponent();
+    const source = `| Price | Meaning |
+| --- | --- |
+| $5 | cheap |`;
+
+    component.updateContent(source, { transient: true });
+    expect(strip(component.render(120).join('\n'))).toContain('| --- | --- |');
+
+    component.updateContent(source, { transient: false });
+    const finalized = strip(component.render(120).join('\n'));
+
+    expect(finalized).toContain('┌───────┬─────────┐');
+    expect(finalized).toContain('│ $5    │ cheap   │');
+    expect(finalized).not.toContain('| --- | --- |');
+  });
+
   it('skips synchronous syntax highlighting in transient markdown themes', () => {
     const highlightSpy = vi.mocked(cliHighlight.highlight);
     highlightSpy.mockClear();

--- a/packages/pi-tui/src/components/markdown.ts
+++ b/packages/pi-tui/src/components/markdown.ts
@@ -1,21 +1,276 @@
-import { Marked, type Token, Tokenizer, type Tokens } from "marked";
+import { type Links, Marked, type Token, Tokenizer, type TokenizerExtension, type Tokens } from "marked";
 import { getCapabilities, hyperlink, isImageLine } from "../terminal-image.ts";
 import type { Component } from "../tui.ts";
 import { applyBackgroundToLine, visibleWidth, wrapTextWithAnsi } from "../utils.ts";
 
 const STRICT_STRIKETHROUGH_REGEX = /^(~~)(?=[^\s~])((?:\\.|[^\\])*?(?:\\.|[^\s~\\]))\1(?=[^~]|$)/;
+const DISPLAY_MATH_OPEN_LINE_REGEX = /^ {0,3}\$\$(?!\$)/;
+const DISPLAY_MATH_OPEN_LINE_SEARCH_REGEX = /\n {0,3}\$\$(?!\$)/;
 
-class StrictStrikethroughTokenizer extends Tokenizer {
-	override del(src: string): Tokens.Del | undefined {
-		const match = STRICT_STRIKETHROUGH_REGEX.exec(src);
+// Marked does not recognize TeX dollar delimiters, so Markdown markers inside
+// math must be tokenized as opaque text before the built-in tokenizers see them.
+// Ambiguous dollar-delimited text is also kept literal: source preservation
+// takes priority over applying Markdown styles inside a possible formula.
+interface LiteralMathToken extends Tokens.Generic {
+	type: "math_block" | "math_inline";
+	raw: string;
+	text: string;
+}
+
+function isLiteralMathToken(token: Token): token is LiteralMathToken {
+	return (
+		(token.type === "math_block" || token.type === "math_inline") &&
+		typeof token.raw === "string" &&
+		"text" in token &&
+		typeof token["text"] === "string"
+	);
+}
+
+function isEscapedAt(text: string, index: number): boolean {
+	let backslashCount = 0;
+	for (let i = index - 1; i >= 0 && text[i] === "\\"; i--) {
+		backslashCount++;
+	}
+	return backslashCount % 2 === 1;
+}
+
+function getDollarRunLength(text: string, index: number): number {
+	let end = index;
+	while (text[end] === "$") {
+		end++;
+	}
+	return end - index;
+}
+
+function findInlineMathEnd(src: string, start: number): number | undefined {
+	const delimiterLength = getDollarRunLength(src, start);
+	if (delimiterLength !== 1 && delimiterLength !== 2) {
+		return undefined;
+	}
+
+	for (let i = start + delimiterLength; i < src.length; i++) {
+		if (delimiterLength === 1 && src[i] === "\n") {
+			return i;
+		}
+		if (src[i] !== "$" || isEscapedAt(src, i)) {
+			continue;
+		}
+
+		const closingRunLength = getDollarRunLength(src, i);
+		if (closingRunLength === delimiterLength) {
+			return i + delimiterLength;
+		}
+
+		// An unescaped dollar run of another length starts a new candidate.
+		// Treat the current span as incomplete instead of scanning past it.
+		return i;
+	}
+
+	// Preservation takes priority over Markdown styling while a delimiter is
+	// incomplete (including during streaming), so keep the rest opaque.
+	return src.length;
+}
+
+function readInlineMath(src: string): string | undefined {
+	const end = findInlineMathEnd(src, 0);
+	return end === undefined ? undefined : src.slice(0, end);
+}
+
+function hasIncompleteMathSpan(src: string): boolean {
+	let searchStart = 0;
+	while (searchStart < src.length) {
+		const mathStart = src.indexOf("$", searchStart);
+		if (mathStart === -1) {
+			return false;
+		}
+		if (isEscapedAt(src, mathStart)) {
+			searchStart = mathStart + 1;
+			continue;
+		}
+
+		const delimiterLength = getDollarRunLength(src, mathStart);
+		const mathEnd = findInlineMathEnd(src, mathStart);
+		if (mathEnd === undefined) {
+			searchStart = mathStart + delimiterLength;
+			continue;
+		}
+		const closingStart = mathEnd - delimiterLength;
+		if (
+			mathEnd - mathStart < delimiterLength * 2 ||
+			getDollarRunLength(src, closingStart) !== delimiterLength ||
+			isEscapedAt(src, closingStart)
+		) {
+			return true;
+		}
+		searchStart = mathEnd;
+	}
+	return false;
+}
+
+function findClosingDollarRun(src: string, start: number, delimiterLength: number): number | undefined {
+	for (let i = start; i < src.length; i++) {
+		if (src[i] !== "$" || isEscapedAt(src, i)) {
+			continue;
+		}
+		const runLength = getDollarRunLength(src, i);
+		if (runLength === delimiterLength) {
+			return i;
+		}
+		i += runLength - 1;
+	}
+	return undefined;
+}
+
+function readDisplayMath(src: string): LiteralMathToken | undefined {
+	const opening = DISPLAY_MATH_OPEN_LINE_REGEX.exec(src);
+	if (!opening) {
+		return undefined;
+	}
+
+	const openingDelimiterEnd = opening[0].length;
+	const closingStart = findClosingDollarRun(src, openingDelimiterEnd, 2);
+	const openingLineEnd = src.indexOf("\n", openingDelimiterEnd);
+	if (closingStart !== undefined && (openingLineEnd === -1 || closingStart < openingLineEnd)) {
+		// A same-line $$...$$ span belongs to the inline tokenizer.
+		return undefined;
+	}
+
+	let rawEnd = closingStart === undefined ? src.length : closingStart + 2;
+	if (closingStart !== undefined) {
+		const closingLineEnd = src.indexOf("\n", rawEnd);
+		const restOfClosingLine = src.slice(rawEnd, closingLineEnd === -1 ? src.length : closingLineEnd);
+		if (/^[\t ]*$/.test(restOfClosingLine) && closingLineEnd !== -1) {
+			rawEnd = closingLineEnd + 1;
+		}
+	}
+
+	const raw = src.slice(0, rawEnd);
+	return {
+		type: "math_block",
+		raw,
+		text: raw.endsWith("\n") ? raw.slice(0, -1) : raw,
+	};
+}
+
+function maskInlineMath(src: string): string {
+	const parts: string[] = [];
+	let cursor = 0;
+	let searchStart = 0;
+
+	while (searchStart < src.length) {
+		const mathStart = src.indexOf("$", searchStart);
+		if (mathStart === -1) {
+			break;
+		}
+		if (isEscapedAt(src, mathStart)) {
+			searchStart = mathStart + 1;
+			continue;
+		}
+
+		const mathEnd = findInlineMathEnd(src, mathStart);
+		if (mathEnd === undefined) {
+			searchStart = mathStart + getDollarRunLength(src, mathStart);
+			continue;
+		}
+
+		parts.push(src.slice(cursor, mathStart));
+		parts.push(src.slice(mathStart, mathEnd).replace(/[^\n]/g, "a"));
+		cursor = mathEnd;
+		searchStart = mathEnd;
+	}
+
+	if (parts.length === 0) {
+		return src;
+	}
+	parts.push(src.slice(cursor));
+	return parts.join("");
+}
+
+function mathSpanContainsTableDelimiter(src: string): boolean {
+	let searchStart = 0;
+	while (searchStart < src.length) {
+		const mathStart = src.indexOf("$", searchStart);
+		if (mathStart === -1) {
+			return false;
+		}
+		if (isEscapedAt(src, mathStart)) {
+			searchStart = mathStart + 1;
+			continue;
+		}
+
+		const mathEnd = findInlineMathEnd(src, mathStart);
+		if (mathEnd === undefined) {
+			searchStart = mathStart + getDollarRunLength(src, mathStart);
+			continue;
+		}
+		if (src.slice(mathStart, mathEnd).includes("|")) {
+			return true;
+		}
+		searchStart = mathEnd;
+	}
+	return false;
+}
+
+const literalMathBlockExtension: TokenizerExtension = {
+	name: "math_block",
+	level: "block",
+	start(src): number | undefined {
+		const match = DISPLAY_MATH_OPEN_LINE_SEARCH_REGEX.exec(src);
+		return match === null ? undefined : match.index + 1;
+	},
+	tokenizer(src): LiteralMathToken | undefined {
+		return readDisplayMath(src);
+	},
+};
+
+const literalMathInlineExtension: TokenizerExtension = {
+	name: "math_inline",
+	level: "inline",
+	start(src): number | undefined {
+		const index = src.indexOf("$");
+		return index === -1 ? undefined : index;
+	},
+	tokenizer(src): LiteralMathToken | undefined {
+		const raw = readInlineMath(src);
+		if (raw === undefined) {
+			return undefined;
+		}
+		return {
+			type: "math_inline",
+			raw,
+			text: raw,
+		};
+	},
+};
+
+class LiteralMathTokenizer extends Tokenizer {
+	override link(src: string): Tokens.Link | Tokens.Image | undefined {
+		const token = super.link(src);
+		// Link labels are parsed before inline extensions. Falling back lets the
+		// math tokenizer preserve brackets and parentheses inside the formula.
+		return token && hasIncompleteMathSpan(token.raw) ? undefined : token;
+	}
+
+	override reflink(src: string, links: Links): Tokens.Link | Tokens.Image | Tokens.Text | undefined {
+		const token = super.reflink(src, links);
+		if ((token?.type === "link" || token?.type === "image") && hasIncompleteMathSpan(token.raw)) {
+			return { type: "text", raw: src[0]!, text: src[0]! };
+		}
+		return token;
+	}
+
+	override del(src: string, maskedSrc: string): Tokens.Del | undefined {
+		const match = STRICT_STRIKETHROUGH_REGEX.exec(maskedSrc.slice(-src.length));
 		if (!match) {
 			return undefined;
 		}
 
-		const text = match[2]!;
+		const raw = src.slice(0, match[0].length);
+		const delimiterLength = match[1]!.length;
+		const text = raw.slice(delimiterLength, -delimiterLength);
 		return {
 			type: "del",
-			raw: match[0],
+			raw,
 			text,
 			tokens: this.lexer.inlineTokens(text),
 		};
@@ -49,7 +304,13 @@ function trimPartialClosingFences(tokens: readonly Token[]): void {
 
 const markdownParser = new Marked();
 markdownParser.setOptions({
-	tokenizer: new StrictStrikethroughTokenizer(),
+	tokenizer: new LiteralMathTokenizer(),
+});
+markdownParser.use({
+	extensions: [literalMathBlockExtension, literalMathInlineExtension],
+	hooks: {
+		emStrongMask: maskInlineMath,
+	},
 });
 
 /**
@@ -333,6 +594,14 @@ export class Markdown implements Component {
 		const lines: string[] = [];
 
 		switch (token.type) {
+			case "math_block":
+				if (isLiteralMathToken(token)) {
+					const text = token.raw.endsWith("\n") ? token.raw.slice(0, -1) : token.raw;
+					const applyText = styleContext?.applyText ?? ((line: string) => this.applyDefaultStyle(line));
+					lines.push(...text.split("\n").map(applyText));
+				}
+				break;
+
 			case "heading": {
 				const headingLevel = token.depth;
 				const headingPrefix = `${"#".repeat(headingLevel)} `;
@@ -406,7 +675,19 @@ export class Markdown implements Component {
 			}
 
 			case "table": {
-				const tableLines = this.renderTable(token as Tokens.Table, width, nextTokenType, styleContext);
+				const tableToken = token as Tokens.Table;
+				if (mathSpanContainsTableDelimiter(tableToken.raw)) {
+					// The block table tokenizer splits on pipes before inline math is
+					// tokenized, so fall back to the raw table when a pipe belongs to math.
+					const text = tableToken.raw.endsWith("\n") ? tableToken.raw.slice(0, -1) : tableToken.raw;
+					const applyText = styleContext?.applyText ?? ((line: string) => this.applyDefaultStyle(line));
+					lines.push(...text.split("\n").map(applyText));
+					if (nextTokenType && nextTokenType !== "space") {
+						lines.push("");
+					}
+					break;
+				}
+				const tableLines = this.renderTable(tableToken, width, nextTokenType, styleContext);
 				lines.push(...tableLines);
 				break;
 			}
@@ -500,6 +781,12 @@ export class Markdown implements Component {
 
 		for (const token of tokens) {
 			switch (token.type) {
+				case "math_inline":
+					if (isLiteralMathToken(token)) {
+						result += applyTextWithNewlines(token.raw);
+					}
+					break;
+
 				case "escape":
 					result += applyTextWithNewlines(this.options.preserveBackslashEscapes ? token.raw : token.text);
 					break;

--- a/packages/pi-tui/src/components/markdown.ts
+++ b/packages/pi-tui/src/components/markdown.ts
@@ -9,8 +9,8 @@ const DISPLAY_MATH_OPEN_LINE_SEARCH_REGEX = /\n {0,3}\$\$(?!\$)/;
 
 // Marked does not recognize TeX dollar delimiters, so Markdown markers inside
 // math must be tokenized as opaque text before the built-in tokenizers see them.
-// Ambiguous dollar-delimited text is also kept literal: source preservation
-// takes priority over applying Markdown styles inside a possible formula.
+// Streaming keeps every incomplete span opaque; finalized text keeps only
+// source-sensitive candidates opaque so `$5` and `$HOME` remain normal text.
 interface LiteralMathToken extends Tokens.Generic {
 	type: "math_block" | "math_inline";
 	raw: string;
@@ -42,7 +42,118 @@ function getDollarRunLength(text: string, index: number): number {
 	return end - index;
 }
 
-function findInlineMathEnd(src: string, start: number): number | undefined {
+function getBacktickRunLength(text: string, index: number): number {
+	let end = index;
+	while (text[end] === "`") {
+		end++;
+	}
+	return end - index;
+}
+
+function findInlineCodeSpanEnd(text: string, start: number): number | undefined {
+	const delimiterLength = getBacktickRunLength(text, start);
+	if (delimiterLength === 0 || isEscapedAt(text, start)) {
+		return undefined;
+	}
+
+	for (let i = start + delimiterLength; i < text.length; i++) {
+		if (text[i] !== "`") {
+			continue;
+		}
+		const runLength = getBacktickRunLength(text, i);
+		if (runLength === delimiterLength) {
+			return i + delimiterLength;
+		}
+		i += runLength - 1;
+	}
+	return undefined;
+}
+
+function findNextDollarOutsideInlineCode(text: string, start: number): number {
+	for (let i = start; i < text.length; i++) {
+		if (text[i] === "`") {
+			const runLength = getBacktickRunLength(text, i);
+			const codeSpanEnd = findInlineCodeSpanEnd(text, i);
+			if (codeSpanEnd !== undefined) {
+				i = codeSpanEnd - 1;
+				continue;
+			}
+			// A contiguous backtick run is one delimiter candidate. Once it has
+			// no closer, retrying every suffix of the same run is both incorrect
+			// and quadratic. An escaped first tick is skipped alone so the
+			// unescaped suffix can still begin a valid code span.
+			if (!isEscapedAt(text, i)) {
+				i += runLength - 1;
+			}
+		}
+		if (text[i] === "$") {
+			return i;
+		}
+	}
+	return -1;
+}
+
+function inlineCodeSpanContainsUnescapedPipe(text: string): boolean {
+	for (let i = 0; i < text.length; i++) {
+		if (text[i] !== "`") {
+			continue;
+		}
+		const delimiterLength = getBacktickRunLength(text, i);
+		const codeSpanEnd = findInlineCodeSpanEnd(text, i);
+		if (codeSpanEnd === undefined) {
+			if (!isEscapedAt(text, i)) {
+				i += delimiterLength - 1;
+			}
+			continue;
+		}
+		const closingStart = codeSpanEnd - delimiterLength;
+		for (let j = i + delimiterLength; j < closingStart; j++) {
+			if (text[j] === "|" && !isEscapedAt(text, j)) {
+				return true;
+			}
+		}
+		i = codeSpanEnd - 1;
+	}
+	return false;
+}
+
+function isClearCurrencyDollarStart(text: string, index: number): boolean {
+	if (getDollarRunLength(text, index) !== 1) {
+		return false;
+	}
+
+	const rest = text.slice(index + 1);
+	return /^\d+(?:[.,]\d+)?(?=$|[\s/.,;:!?|)\]])/.test(rest);
+}
+
+function isClearLiteralDollarStart(text: string, index: number): boolean {
+	if (isClearCurrencyDollarStart(text, index)) {
+		return true;
+	}
+	if (getDollarRunLength(text, index) !== 1) {
+		return false;
+	}
+
+	const rest = text.slice(index + 1);
+	return /^(?:[A-Za-z_][A-Za-z0-9_]*|\{[A-Za-z_][A-Za-z0-9_]*\})(?=$|[\s/.,;:!?|)\]])/.test(
+		rest,
+	);
+}
+
+function startsAnotherDollarTerm(text: string, index: number): boolean {
+	const next = text[index + 1];
+	return next !== undefined && /[A-Za-z0-9\\{_^]/.test(next);
+}
+
+interface InlineMathSpan {
+	// `end` is also the opaque rendering boundary for streamed input. `closed`
+	// distinguishes that boundary from a real closing dollar delimiter.
+	closed: boolean;
+	delimiterLength: number;
+	end: number;
+}
+
+function findInlineMathSpan(src: string, start: number): InlineMathSpan | undefined {
 	const delimiterLength = getDollarRunLength(src, start);
 	if (delimiterLength !== 1 && delimiterLength !== 2) {
 		return undefined;
@@ -50,7 +161,7 @@ function findInlineMathEnd(src: string, start: number): number | undefined {
 
 	for (let i = start + delimiterLength; i < src.length; i++) {
 		if (delimiterLength === 1 && src[i] === "\n") {
-			return i;
+			return { closed: false, delimiterLength, end: i };
 		}
 		if (src[i] !== "$" || isEscapedAt(src, i)) {
 			continue;
@@ -58,28 +169,64 @@ function findInlineMathEnd(src: string, start: number): number | undefined {
 
 		const closingRunLength = getDollarRunLength(src, i);
 		if (closingRunLength === delimiterLength) {
-			return i + delimiterLength;
+			// `$5 ... $10` and `$PATH/$HOME` contain two literal dollar
+			// prefixes, not one math span. Do not pair a clear literal opener
+			// with a dollar that itself starts another term.
+			if (
+				delimiterLength === 1 &&
+				isClearLiteralDollarStart(src, start) &&
+				startsAnotherDollarTerm(src, i)
+			) {
+				return { closed: false, delimiterLength, end: i };
+			}
+			return { closed: true, delimiterLength, end: i + delimiterLength };
 		}
 
 		// An unescaped dollar run of another length starts a new candidate.
 		// Treat the current span as incomplete instead of scanning past it.
-		return i;
+		return { closed: false, delimiterLength, end: i };
 	}
 
 	// Preservation takes priority over Markdown styling while a delimiter is
 	// incomplete (including during streaming), so keep the rest opaque.
-	return src.length;
+	return { closed: false, delimiterLength, end: src.length };
 }
 
-function readInlineMath(src: string): string | undefined {
-	const end = findInlineMathEnd(src, 0);
-	return end === undefined ? undefined : src.slice(0, end);
+function incompleteMathNeedsProtection(src: string, start: number, span: InlineMathSpan): boolean {
+	const interruptedByAnotherDollar = src[span.end] === "$";
+	const body = src.slice(start + span.delimiterLength, span.end);
+
+	// Finalized input can still end mid-formula after cancellation, truncation,
+	// or a malformed response. Strong TeX evidence takes precedence even when
+	// the candidate begins like currency or an environment variable.
+	const bracedShellVariable = /^\{[A-Za-z_][A-Za-z0-9_]*\}(?=$|[\s/.,;:!?|)\]])/.test(body);
+	if (!bracedShellVariable && /[\\^{}]/.test(body)) {
+		return true;
+	}
+	if (isClearLiteralDollarStart(src, start) && !interruptedByAnotherDollar) {
+		return false;
+	}
+
+	// Protect remaining candidates only when Markdown could consume or
+	// normalize their source characters. Plain `$word` stays ordinary text.
+	return /[*~<>\[\]`&]/.test(body);
 }
 
-function hasIncompleteMathSpan(src: string): boolean {
+function readInlineMath(src: string, preserveIncompleteMath: boolean): string | undefined {
+	const span = findInlineMathSpan(src, 0);
+	if (
+		span === undefined ||
+		(!span.closed && !preserveIncompleteMath && !incompleteMathNeedsProtection(src, 0, span))
+	) {
+		return undefined;
+	}
+	return src.slice(0, span.end);
+}
+
+function hasProtectedIncompleteMathSpan(src: string, preserveIncompleteMath: boolean): boolean {
 	let searchStart = 0;
 	while (searchStart < src.length) {
-		const mathStart = src.indexOf("$", searchStart);
+		const mathStart = findNextDollarOutsideInlineCode(src, searchStart);
 		if (mathStart === -1) {
 			return false;
 		}
@@ -88,21 +235,148 @@ function hasIncompleteMathSpan(src: string): boolean {
 			continue;
 		}
 
-		const delimiterLength = getDollarRunLength(src, mathStart);
-		const mathEnd = findInlineMathEnd(src, mathStart);
-		if (mathEnd === undefined) {
-			searchStart = mathStart + delimiterLength;
+		const span = findInlineMathSpan(src, mathStart);
+		if (span === undefined) {
+			searchStart = mathStart + getDollarRunLength(src, mathStart);
 			continue;
 		}
-		const closingStart = mathEnd - delimiterLength;
-		if (
-			mathEnd - mathStart < delimiterLength * 2 ||
-			getDollarRunLength(src, closingStart) !== delimiterLength ||
-			isEscapedAt(src, closingStart)
-		) {
+		if (!span.closed && (preserveIncompleteMath || incompleteMathNeedsProtection(src, mathStart, span))) {
 			return true;
 		}
-		searchStart = mathEnd;
+		searchStart = span.closed ? span.end : mathStart + span.delimiterLength;
+	}
+	return false;
+}
+
+function findLinkLabelBacktickSpanEnd(text: string, start: number): number | undefined {
+	const openingRunLength = getBacktickRunLength(text, start);
+	if (openingRunLength === 0 || isEscapedAt(text, start)) {
+		return undefined;
+	}
+
+	const openingEnd = start + openingRunLength;
+	for (let i = openingEnd; i < text.length; i++) {
+		if (text[i] === "`") {
+			return i + getBacktickRunLength(text, i);
+		}
+	}
+
+	// Marked also masks a terminal run of at least two backticks immediately
+	// before the label's closing bracket.
+	return openingRunLength >= 2 && text[openingEnd] === "]" ? openingEnd : undefined;
+}
+
+function findLinkLabelEnd(raw: string): number {
+	const openingBracket = raw.startsWith("![") ? 1 : raw.startsWith("[") ? 0 : -1;
+	if (openingBracket === -1) {
+		return raw.length;
+	}
+
+	let depth = 1;
+	for (let i = openingBracket + 1; i < raw.length; i++) {
+		if (raw[i] === "`") {
+			const runLength = getBacktickRunLength(raw, i);
+			// Link-label parsing masks the next backtick run even when its
+			// length differs from the opener. This deliberately differs from
+			// CommonMark inline-code parsing.
+			const maskedSpanEnd = findLinkLabelBacktickSpanEnd(raw, i);
+			if (maskedSpanEnd !== undefined) {
+				i = maskedSpanEnd - 1;
+				continue;
+			}
+			if (!isEscapedAt(raw, i)) {
+				i += runLength - 1;
+			}
+		}
+		if (raw[i] !== "[" && raw[i] !== "]") {
+			continue;
+		}
+		if (isEscapedAt(raw, i)) {
+			continue;
+		}
+		if (raw[i] === "[") {
+			depth++;
+		} else if (raw[i] === "]") {
+			depth--;
+			if (depth === 0) {
+				return i;
+			}
+		}
+	}
+	return raw.length;
+}
+
+function linkLabelCodeSpanNeedsSourceProtection(raw: string, labelEnd: number): boolean {
+	const openingBracket = raw.startsWith("![") ? 1 : raw.startsWith("[") ? 0 : -1;
+	if (openingBracket === -1) {
+		return false;
+	}
+
+	for (let i = openingBracket + 1; i < labelEnd; i++) {
+		if (raw[i] !== "`") {
+			continue;
+		}
+		const delimiterLength = getBacktickRunLength(raw, i);
+		const codeSpanEnd = findInlineCodeSpanEnd(raw, i);
+		if (codeSpanEnd === undefined || codeSpanEnd > labelEnd) {
+			if (!isEscapedAt(raw, i)) {
+				i += delimiterLength - 1;
+			}
+			continue;
+		}
+
+		const closingStart = codeSpanEnd - delimiterLength;
+		for (let j = i + delimiterLength; j < closingStart; j++) {
+			if ((raw[j] === "[" || raw[j] === "]") && raw[j - 1] === "\\") {
+				return true;
+			}
+		}
+		i = codeSpanEnd - 1;
+	}
+	return false;
+}
+
+function tokenOverlapsClosedMathSpan(src: string, tokenEnd: number, labelEnd: number): boolean {
+	const boundedTokenEnd = Math.min(tokenEnd, src.length);
+	let searchStart = 0;
+	while (searchStart < boundedTokenEnd) {
+		const mathStart = findNextDollarOutsideInlineCode(src, searchStart);
+		// Dollar text in a link destination or reference id belongs to the URL,
+		// not the visible label. Only spans that start in the label can have link
+		// syntax consume part of a displayed formula.
+		if (mathStart === -1 || mathStart >= boundedTokenEnd || mathStart >= labelEnd) {
+			return false;
+		}
+		if (isEscapedAt(src, mathStart)) {
+			searchStart = mathStart + 1;
+			continue;
+		}
+
+		const span = findInlineMathSpan(src, mathStart);
+		if (span === undefined) {
+			searchStart = mathStart + getDollarRunLength(src, mathStart);
+			continue;
+		}
+		if (span.closed) {
+			if (mathStart < boundedTokenEnd && boundedTokenEnd < span.end) {
+				return true;
+			}
+			// Fall back when Marked chose a label boundary from inside the formula.
+			if (mathStart < labelEnd && labelEnd < span.end) {
+				return true;
+			}
+			// Marked normalizes escaped brackets in link labels before the math
+			// extension sees them, so preserve any such source inside the formula.
+			const overlapEnd = Math.min(span.end, boundedTokenEnd);
+			for (let i = mathStart + span.delimiterLength; i < overlapEnd; i++) {
+				if ((src[i] === "[" || src[i] === "]") && src[i - 1] === "\\") {
+					return true;
+				}
+			}
+			searchStart = span.end;
+			continue;
+		}
+		searchStart = mathStart + span.delimiterLength;
 	}
 	return false;
 }
@@ -134,7 +408,6 @@ function readDisplayMath(src: string): LiteralMathToken | undefined {
 		// A same-line $$...$$ span belongs to the inline tokenizer.
 		return undefined;
 	}
-
 	let rawEnd = closingStart === undefined ? src.length : closingStart + 2;
 	if (closingStart !== undefined) {
 		const closingLineEnd = src.indexOf("\n", rawEnd);
@@ -152,13 +425,13 @@ function readDisplayMath(src: string): LiteralMathToken | undefined {
 	};
 }
 
-function maskInlineMath(src: string): string {
+function maskInlineMath(src: string, preserveIncompleteMath: boolean): string {
 	const parts: string[] = [];
 	let cursor = 0;
 	let searchStart = 0;
 
 	while (searchStart < src.length) {
-		const mathStart = src.indexOf("$", searchStart);
+		const mathStart = findNextDollarOutsideInlineCode(src, searchStart);
 		if (mathStart === -1) {
 			break;
 		}
@@ -167,16 +440,24 @@ function maskInlineMath(src: string): string {
 			continue;
 		}
 
-		const mathEnd = findInlineMathEnd(src, mathStart);
-		if (mathEnd === undefined) {
+		const span = findInlineMathSpan(src, mathStart);
+		if (span === undefined) {
 			searchStart = mathStart + getDollarRunLength(src, mathStart);
+			continue;
+		}
+		if (
+			!span.closed &&
+			!preserveIncompleteMath &&
+			!incompleteMathNeedsProtection(src, mathStart, span)
+		) {
+			searchStart = mathStart + span.delimiterLength;
 			continue;
 		}
 
 		parts.push(src.slice(cursor, mathStart));
-		parts.push(src.slice(mathStart, mathEnd).replace(/[^\n]/g, "a"));
-		cursor = mathEnd;
-		searchStart = mathEnd;
+		parts.push(src.slice(mathStart, span.end).replace(/[^\n]/g, "a"));
+		cursor = span.end;
+		searchStart = span.end;
 	}
 
 	if (parts.length === 0) {
@@ -186,10 +467,79 @@ function maskInlineMath(src: string): string {
 	return parts.join("");
 }
 
-function mathSpanContainsTableDelimiter(src: string): boolean {
+function countTableCells(row: string): number {
+	const trimmed = row.trim();
+	if (trimmed.length === 0) {
+		return 0;
+	}
+
+	let cells = 1;
+	for (let i = 0; i < trimmed.length; i++) {
+		if (trimmed[i] === "|" && !isEscapedAt(trimmed, i)) {
+			cells++;
+		}
+	}
+	if (trimmed[0] === "|") {
+		cells--;
+	}
+	const trailingPipe = trimmed.lastIndexOf("|");
+	if (trailingPipe === trimmed.length - 1 && !isEscapedAt(trimmed, trailingPipe)) {
+		cells--;
+	}
+	return cells;
+}
+
+function tableHasOverflowingRow(src: string, columnCount: number): boolean {
+	return src.split("\n").some((row) => countTableCells(row) > columnCount);
+}
+
+function incompleteSpanHasLikelyFormulaPipe(src: string, start: number, span: InlineMathSpan): boolean {
+	if (span.closed) {
+		return false;
+	}
+	const body = src.slice(start + span.delimiterLength, span.end);
+	for (let pipeIndex = 0; pipeIndex < body.length; pipeIndex++) {
+		if (body[pipeIndex] !== "|" || isEscapedAt(body, pipeIndex)) {
+			continue;
+		}
+
+		let rightEnd = pipeIndex + 1;
+		while (rightEnd < body.length && (body[rightEnd] !== "|" || isEscapedAt(body, rightEnd))) {
+			rightEnd++;
+		}
+		const rawLeft = body.slice(0, pipeIndex);
+		const left = rawLeft.trim();
+		const right = body.slice(pipeIndex + 1, rightEnd).trim();
+		if (left.length === 0 || right.length === 0) {
+			continue;
+		}
+
+		// A compact symbolic left-hand side (`$A|...`) is stronger formula
+		// evidence than a shell variable separated from the next table cell.
+		// Keep compact numeric currency (`$5|cheap`) boxed unless the right-hand
+		// side itself carries formula evidence.
+		const compactSymbolicLeft =
+			!/[\t ]$/.test(rawLeft) && !/^\d+(?:[.,]\d+)?$/.test(left);
+		const rightHasFormulaEvidence =
+			/^[A-Z][A-Z0-9_]*$/.test(right) ||
+			/^[A-Za-z0-9]$/.test(right) ||
+			/[+\-*/^_=<>()[\]{}\\]/.test(right);
+		if (compactSymbolicLeft || rightHasFormulaEvidence) {
+			return true;
+		}
+	}
+	return false;
+}
+
+function mathSpanContainsTableDelimiter(
+	src: string,
+	columnCount: number,
+	preserveIncompleteMath: boolean,
+): boolean {
+	const hasOverflowingRow = tableHasOverflowingRow(src, columnCount);
 	let searchStart = 0;
 	while (searchStart < src.length) {
-		const mathStart = src.indexOf("$", searchStart);
+		const mathStart = findNextDollarOutsideInlineCode(src, searchStart);
 		if (mathStart === -1) {
 			return false;
 		}
@@ -198,62 +548,100 @@ function mathSpanContainsTableDelimiter(src: string): boolean {
 			continue;
 		}
 
-		const mathEnd = findInlineMathEnd(src, mathStart);
-		if (mathEnd === undefined) {
+		const span = findInlineMathSpan(src, mathStart);
+		if (span === undefined) {
 			searchStart = mathStart + getDollarRunLength(src, mathStart);
 			continue;
 		}
-		if (src.slice(mathStart, mathEnd).includes("|")) {
+		const spanContainsPipe = src.slice(mathStart, span.end).includes("|");
+		const protectSpan =
+			span.closed ||
+			preserveIncompleteMath ||
+			incompleteMathNeedsProtection(src, mathStart, span) ||
+			incompleteSpanHasLikelyFormulaPipe(src, mathStart, span) ||
+			(spanContainsPipe &&
+				(!isClearLiteralDollarStart(src, mathStart) || hasOverflowingRow));
+		if (protectSpan && spanContainsPipe) {
 			return true;
 		}
-		searchStart = mathEnd;
+		searchStart = protectSpan ? span.end : mathStart + span.delimiterLength;
 	}
 	return false;
 }
 
-const literalMathBlockExtension: TokenizerExtension = {
-	name: "math_block",
-	level: "block",
-	start(src): number | undefined {
-		const match = DISPLAY_MATH_OPEN_LINE_SEARCH_REGEX.exec(src);
-		return match === null ? undefined : match.index + 1;
-	},
-	tokenizer(src): LiteralMathToken | undefined {
-		return readDisplayMath(src);
-	},
-};
+function createLiteralMathBlockExtension(): TokenizerExtension {
+	return {
+		name: "math_block",
+		level: "block",
+		start(src): number | undefined {
+			const match = DISPLAY_MATH_OPEN_LINE_SEARCH_REGEX.exec(src);
+			return match === null ? undefined : match.index + 1;
+		},
+		tokenizer(src): LiteralMathToken | undefined {
+			return readDisplayMath(src);
+		},
+	};
+}
 
-const literalMathInlineExtension: TokenizerExtension = {
-	name: "math_inline",
-	level: "inline",
-	start(src): number | undefined {
-		const index = src.indexOf("$");
-		return index === -1 ? undefined : index;
-	},
-	tokenizer(src): LiteralMathToken | undefined {
-		const raw = readInlineMath(src);
-		if (raw === undefined) {
-			return undefined;
-		}
-		return {
-			type: "math_inline",
-			raw,
-			text: raw,
-		};
-	},
-};
+function createLiteralMathInlineExtension(preserveIncompleteMath: boolean): TokenizerExtension {
+	return {
+		name: "math_inline",
+		level: "inline",
+		start(src): number | undefined {
+			const index = src.indexOf("$");
+			return index === -1 ? undefined : index;
+		},
+		tokenizer(src): LiteralMathToken | undefined {
+			const raw = readInlineMath(src, preserveIncompleteMath);
+			if (raw === undefined) {
+				return undefined;
+			}
+			return {
+				type: "math_inline",
+				raw,
+				text: raw,
+			};
+		},
+	};
+}
 
 class LiteralMathTokenizer extends Tokenizer {
+	private readonly preserveIncompleteMath: boolean;
+
+	constructor(preserveIncompleteMath: boolean) {
+		super();
+		this.preserveIncompleteMath = preserveIncompleteMath;
+	}
+
 	override link(src: string): Tokens.Link | Tokens.Image | undefined {
 		const token = super.link(src);
+		const labelEnd = token === undefined ? 0 : findLinkLabelEnd(token.raw);
 		// Link labels are parsed before inline extensions. Falling back lets the
 		// math tokenizer preserve brackets and parentheses inside the formula.
-		return token && hasIncompleteMathSpan(token.raw) ? undefined : token;
+		return token &&
+			(tokenOverlapsClosedMathSpan(src, token.raw.length, labelEnd) ||
+				linkLabelCodeSpanNeedsSourceProtection(token.raw, labelEnd) ||
+				hasProtectedIncompleteMathSpan(
+					token.raw.slice(0, labelEnd + 1),
+					this.preserveIncompleteMath,
+				))
+			? undefined
+			: token;
 	}
 
 	override reflink(src: string, links: Links): Tokens.Link | Tokens.Image | Tokens.Text | undefined {
 		const token = super.reflink(src, links);
-		if ((token?.type === "link" || token?.type === "image") && hasIncompleteMathSpan(token.raw)) {
+		const labelEnd =
+			token?.type === "link" || token?.type === "image" ? findLinkLabelEnd(token.raw) : 0;
+		if (
+			(token?.type === "link" || token?.type === "image") &&
+			(tokenOverlapsClosedMathSpan(src, token.raw.length, labelEnd) ||
+				linkLabelCodeSpanNeedsSourceProtection(token.raw, labelEnd) ||
+				hasProtectedIncompleteMathSpan(
+					token.raw.slice(0, labelEnd + 1),
+					this.preserveIncompleteMath,
+				))
+		) {
 			return { type: "text", raw: src[0]!, text: src[0]! };
 		}
 		return token;
@@ -302,16 +690,25 @@ function trimPartialClosingFences(tokens: readonly Token[]): void {
 	token.text = token.text.slice(0, -lastLine.length).replace(/\n$/, "");
 }
 
-const markdownParser = new Marked();
-markdownParser.setOptions({
-	tokenizer: new LiteralMathTokenizer(),
-});
-markdownParser.use({
-	extensions: [literalMathBlockExtension, literalMathInlineExtension],
-	hooks: {
-		emStrongMask: maskInlineMath,
-	},
-});
+function createMarkdownParser(preserveIncompleteMath: boolean): Marked {
+	const parser = new Marked();
+	parser.setOptions({
+		tokenizer: new LiteralMathTokenizer(preserveIncompleteMath),
+	});
+	parser.use({
+		extensions: [
+			createLiteralMathBlockExtension(),
+			createLiteralMathInlineExtension(preserveIncompleteMath),
+		],
+		hooks: {
+			emStrongMask: (src) => maskInlineMath(src, preserveIncompleteMath),
+		},
+	});
+	return parser;
+}
+
+const markdownParser = createMarkdownParser(false);
+const streamingMarkdownParser = createMarkdownParser(true);
 
 /**
  * Default text styling for markdown content.
@@ -361,6 +758,8 @@ export interface MarkdownOptions {
 	preserveOrderedListMarkers?: boolean;
 	/** Preserve source backslash escapes instead of normalizing escaped punctuation. */
 	preserveBackslashEscapes?: boolean;
+	/** Keep unclosed dollar spans opaque while their closing delimiter may still arrive. */
+	preserveIncompleteMath?: boolean;
 }
 
 interface InlineStyleContext {
@@ -432,7 +831,8 @@ export class Markdown implements Component {
 		const normalizedText = this.text.replace(/\t/g, "   ");
 
 		// Parse markdown to HTML-like tokens
-		const tokens = markdownParser.lexer(normalizedText);
+		const parser = this.options.preserveIncompleteMath ? streamingMarkdownParser : markdownParser;
+		const tokens = parser.lexer(normalizedText);
 		trimPartialClosingFences(tokens);
 
 		// Convert tokens to styled terminal output
@@ -676,9 +1076,16 @@ export class Markdown implements Component {
 
 			case "table": {
 				const tableToken = token as Tokens.Table;
-				if (mathSpanContainsTableDelimiter(tableToken.raw)) {
-					// The block table tokenizer splits on pipes before inline math is
-					// tokenized, so fall back to the raw table when a pipe belongs to math.
+				if (
+					inlineCodeSpanContainsUnescapedPipe(tableToken.raw) ||
+					mathSpanContainsTableDelimiter(
+						tableToken.raw,
+						tableToken.header.length,
+						this.options.preserveIncompleteMath === true,
+					)
+				) {
+					// The block table tokenizer splits on pipes before inline math or code
+					// is tokenized, so fall back when a pipe belongs to either inline span.
 					const text = tableToken.raw.endsWith("\n") ? tableToken.raw.slice(0, -1) : tableToken.raw;
 					const applyText = styleContext?.applyText ?? ((line: string) => this.applyDefaultStyle(line));
 					lines.push(...text.split("\n").map(applyText));

--- a/packages/pi-tui/test/markdown.test.ts
+++ b/packages/pi-tui/test/markdown.test.ts
@@ -674,6 +674,220 @@ describe("Markdown component", () => {
 		});
 	});
 
+	describe("Math source preservation", () => {
+		it("preserves every character when repeated inline math contains asterisks", () => {
+			const source = String.raw`定义三个参考点：$\theta_{\text{true}}$（生成分布）、$\theta^*_A$（假设类内最优）、$\hat\theta_D$（给无限算力在 $D$ 上学到的）、$\hat\theta_O$（实际 SGD 输出）。对 $-\log p(E\mid\hat\theta_O)$ 在 $\theta^*_A$ 附近做二阶展开，得到可加分解：`;
+			const markdown = new Markdown(source, 0, 0, defaultMarkdownTheme);
+
+			const lines = markdown.render(500).map((line) => stripAnsi(line).trimEnd());
+
+			assert.deepStrictEqual(lines, [source]);
+		});
+
+		it("keeps italic Markdown outside protected inline math", () => {
+			const markdown = new Markdown(
+				String.raw`模型：$\theta^*_A$，*仍然使用 Markdown*。`,
+				0,
+				0,
+				defaultMarkdownTheme,
+			);
+
+			const [rendered] = markdown.render(80);
+
+			assert.ok(rendered);
+			assert.strictEqual(stripAnsi(rendered).trimEnd(), String.raw`模型：$\theta^*_A$，仍然使用 Markdown。`);
+			assert.ok(rendered.includes(chalk.italic("仍然使用 Markdown")));
+		});
+
+		it("preserves ambiguous paired dollar text verbatim", () => {
+			const source = "Cost $5 *discount* $10.";
+			const markdown = new Markdown(source, 0, 0, defaultMarkdownTheme);
+
+			const [rendered] = markdown.render(100);
+
+			assert.ok(rendered);
+			assert.strictEqual(stripAnsi(rendered).trimEnd(), source);
+		});
+
+		it("keeps environment variables in normal Markdown text", () => {
+			const source = "Use $PATH/$HOME and *italic*.";
+			const markdown = new Markdown(source, 0, 0, defaultMarkdownTheme);
+
+			const [rendered] = markdown.render(100);
+
+			assert.ok(rendered);
+			assert.strictEqual(stripAnsi(rendered).trimEnd(), "Use $PATH/$HOME and italic.");
+			assert.ok(rendered.includes(chalk.italic("italic")));
+		});
+
+		it("preserves escaped dollars inside inline math", () => {
+			const source = String.raw`$\text{cost}=\$5^*_A$`;
+			const markdown = new Markdown(source, 0, 0, defaultMarkdownTheme);
+
+			const lines = markdown.render(80).map((line) => stripAnsi(line).trimEnd());
+
+			assert.deepStrictEqual(lines, [source]);
+		});
+
+		it("preserves Markdown-like syntax inside inline math", () => {
+			const source = String.raw`$x^{**}+\text{[a](b)}+y~~z$`;
+			const markdown = new Markdown(source, 0, 0, defaultMarkdownTheme);
+
+			const lines = markdown.render(80).map((line) => stripAnsi(line).trimEnd());
+
+			assert.deepStrictEqual(lines, [source]);
+		});
+
+		it("preserves inline math with delimiter-adjacent whitespace", () => {
+			const source = String.raw`$ x^*_A $ and $ y^*_B $`;
+			const markdown = new Markdown(source, 0, 0, defaultMarkdownTheme);
+
+			const lines = markdown.render(80).map((line) => stripAnsi(line).trimEnd());
+
+			assert.deepStrictEqual(lines, [source]);
+		});
+
+		it("preserves inline math followed immediately by prose", () => {
+			const source = String.raw`$x^*_A$foo and $y^*_B$bar`;
+			const markdown = new Markdown(source, 0, 0, defaultMarkdownTheme);
+
+			const lines = markdown.render(80).map((line) => stripAnsi(line).trimEnd());
+
+			assert.deepStrictEqual(lines, [source]);
+		});
+
+		it("preserves math markers inside surrounding emphasis", () => {
+			const source = String.raw`*lead $x*y$ tail*`;
+			const markdown = new Markdown(source, 0, 0, defaultMarkdownTheme);
+
+			const [rendered] = markdown.render(80);
+
+			assert.ok(rendered);
+			assert.strictEqual(stripAnsi(rendered).trimEnd(), String.raw`lead $x*y$ tail`);
+		});
+
+		it("preserves math markers inside surrounding strikethrough", () => {
+			const source = String.raw`~~lead $x~~y$ tail~~`;
+			const markdown = new Markdown(source, 0, 0, defaultMarkdownTheme);
+
+			const [rendered] = markdown.render(80);
+
+			assert.ok(rendered);
+			assert.strictEqual(stripAnsi(rendered).trimEnd(), String.raw`lead $x~~y$ tail`);
+		});
+
+		it("preserves math syntax that overlaps a Markdown link label", () => {
+			const source = String.raw`[lead $\text{a](b)}$ tail](https://example.com)`;
+			const markdown = new Markdown(source, 0, 0, defaultMarkdownTheme);
+
+			const [rendered] = markdown.render(100);
+
+			assert.ok(rendered);
+			assert.strictEqual(stripAnsi(rendered).trimEnd(), source);
+		});
+
+		it("keeps link formatting when math does not overlap link syntax", () => {
+			const source = String.raw`[value $x^*_A$](https://example.com)`;
+			const markdown = new Markdown(source, 0, 0, defaultMarkdownTheme);
+
+			const [rendered] = markdown.render(100);
+
+			assert.ok(rendered);
+			assert.strictEqual(
+				stripAnsi(rendered).trimEnd(),
+				String.raw`value $x^*_A$ (https://example.com)`,
+			);
+		});
+
+		it("preserves incomplete inline math during streaming", () => {
+			const source = String.raw`open $x^*_A + [y](z) + q~~r`;
+			const markdown = new Markdown(source, 0, 0, defaultMarkdownTheme);
+
+			const lines = markdown.render(80).map((line) => stripAnsi(line).trimEnd());
+
+			assert.deepStrictEqual(lines, [source]);
+		});
+
+		it("preserves display math as literal lines", () => {
+			const source = String.raw`$$
+# \theta^*_A
++ \phi^*_B
+$$`;
+			const markdown = new Markdown(source, 0, 0, defaultMarkdownTheme);
+
+			const lines = markdown.render(80).map((line) => stripAnsi(line).trimEnd());
+
+			assert.deepStrictEqual(lines, ["$$", String.raw`# \theta^*_A`, String.raw`+ \phi^*_B`, "$$"]);
+		});
+
+		it("preserves incomplete display math during streaming", () => {
+			const source = String.raw`$$
+# \theta^*_A
++ \phi^*_B`;
+			const markdown = new Markdown(source, 0, 0, defaultMarkdownTheme);
+
+			const lines = markdown.render(80).map((line) => stripAnsi(line).trimEnd());
+
+			assert.deepStrictEqual(lines, ["$$", String.raw`# \theta^*_A`, String.raw`+ \phi^*_B`]);
+		});
+
+		it("preserves multiline display math whose opener contains content", () => {
+			const source = String.raw`$$ \theta^*_A
+\phi^*_B
+$$`;
+			const markdown = new Markdown(source, 0, 0, defaultMarkdownTheme);
+
+			const lines = markdown.render(80).map((line) => stripAnsi(line).trimEnd());
+
+			assert.deepStrictEqual(lines, [String.raw`$$ \theta^*_A`, String.raw`\phi^*_B`, "$$"]);
+		});
+
+		it("does not treat mid-line double dollars as a display block", () => {
+			const source = "prefix a$$\n# heading";
+			const markdown = new Markdown(source, 0, 0, defaultMarkdownTheme);
+
+			const lines = markdown.render(80).map((line) => stripAnsi(line).trimEnd());
+
+			assert.deepStrictEqual(lines, ["prefix a$$", "", "heading"]);
+		});
+
+		it("preserves tables literally when math contains a table delimiter", () => {
+			const source = String.raw`| Formula | Meaning |
+| --- | --- |
+| $p(A|B)^*$ | conditional |`;
+			const markdown = new Markdown(source, 0, 0, defaultMarkdownTheme);
+
+			const lines = markdown.render(100).map((line) => stripAnsi(line).trimEnd());
+
+			assert.deepStrictEqual(lines, source.split("\n"));
+		});
+
+		it("keeps math-like text inside inline code", () => {
+			const markdown = new Markdown("Use `$\\theta^*_A$` literally.", 0, 0, defaultMarkdownTheme);
+
+			const [rendered] = markdown.render(80);
+
+			assert.ok(rendered);
+			assert.strictEqual(stripAnsi(rendered).trimEnd(), String.raw`Use $\theta^*_A$ literally.`);
+			assert.ok(rendered.includes(defaultMarkdownTheme.code(String.raw`$\theta^*_A$`)));
+		});
+
+		it("keeps delimiter-only display math inside fenced code", () => {
+			const source = ["```tex", "$$", String.raw`# \theta^*_A + \phi^*_B`, "$$", "```"].join("\n");
+			const markdown = new Markdown(source, 0, 0, defaultMarkdownTheme);
+
+			const lines = markdown.render(80).map((line) => stripAnsi(line).trimEnd());
+
+			assert.deepStrictEqual(lines, [
+				"```tex",
+				"  $$",
+				String.raw`  # \theta^*_A + \phi^*_B`,
+				"  $$",
+				"```",
+			]);
+		});
+	});
+
 	describe("Pre-styled text (thinking traces)", () => {
 		it("should preserve gray italic styling after inline code", () => {
 			// This replicates how thinking content is rendered in assistant-message.ts

--- a/packages/pi-tui/test/markdown.test.ts
+++ b/packages/pi-tui/test/markdown.test.ts
@@ -1,3 +1,5 @@
+// Scenarios: Markdown rendering contracts through the public component with the real parser and theme.
+// Run: pnpm --filter @moonshot-ai/pi-tui test
 import assert from "node:assert";
 import { afterEach, describe, it } from "node:test";
 import type { Terminal as XtermTerminalType } from "@xterm/headless";
@@ -720,6 +722,35 @@ describe("Markdown component", () => {
 			assert.ok(rendered.includes(chalk.italic("italic")));
 		});
 
+		it("keeps underscored environment variables in normal Markdown text", () => {
+			const source = "Use $MY_VAR and *italic*.";
+			const markdown = new Markdown(source, 0, 0, defaultMarkdownTheme);
+
+			const [rendered] = markdown.render(100);
+
+			assert.ok(rendered);
+			assert.strictEqual(stripAnsi(rendered).trimEnd(), "Use $MY_VAR and italic.");
+			assert.ok(rendered.includes(chalk.italic("italic")));
+		});
+
+		it("preserves strong TeX syntax after a currency-like prefix", () => {
+			const source = String.raw`$5 x^*_A + y^*_B`;
+			const markdown = new Markdown(source, 0, 0, defaultMarkdownTheme);
+
+			const lines = markdown.render(100).map((line) => stripAnsi(line).trimEnd());
+
+			assert.deepStrictEqual(lines, [source]);
+		});
+
+		it("preserves strong TeX syntax after an environment-like prefix", () => {
+			const source = String.raw`$HOME \theta^*_A + \phi^*_B`;
+			const markdown = new Markdown(source, 0, 0, defaultMarkdownTheme);
+
+			const lines = markdown.render(100).map((line) => stripAnsi(line).trimEnd());
+
+			assert.deepStrictEqual(lines, [source]);
+		});
+
 		it("preserves escaped dollars inside inline math", () => {
 			const source = String.raw`$\text{cost}=\$5^*_A$`;
 			const markdown = new Markdown(source, 0, 0, defaultMarkdownTheme);
@@ -786,6 +817,188 @@ describe("Markdown component", () => {
 			assert.strictEqual(stripAnsi(rendered).trimEnd(), source);
 		});
 
+		it("preserves closed math that crosses a direct-link boundary", () => {
+			const source = String.raw`[lead $a](b$) tail`;
+			const markdown = new Markdown(source, 0, 0, defaultMarkdownTheme);
+
+			const [rendered] = markdown.render(100);
+
+			assert.ok(rendered);
+			assert.strictEqual(stripAnsi(rendered).trimEnd(), source);
+		});
+
+		it("preserves closed math across link boundaries with mismatched backtick runs", () => {
+			const sources = [
+				"[pre $`[``](dest$) tail",
+				"[pre $``[```](dest$) tail",
+			];
+
+			for (const source of sources) {
+				const markdown = new Markdown(source, 0, 0, defaultMarkdownTheme);
+				const [rendered] = markdown.render(100);
+
+				assert.ok(rendered);
+				assert.strictEqual(stripAnsi(rendered).trimEnd(), source);
+			}
+		});
+
+		it("preserves closed math across a mismatched-backtick link while streaming", () => {
+			const source = "[pre $`[``](dest$) tail";
+			const markdown = new Markdown(source, 0, 0, defaultMarkdownTheme, undefined, {
+				preserveIncompleteMath: true,
+			});
+
+			const [rendered] = markdown.render(100);
+
+			assert.ok(rendered);
+			assert.strictEqual(stripAnsi(rendered).trimEnd(), source);
+		});
+
+		it("preserves an escaped link-like boundary inside closed math", () => {
+			const source = String.raw`[lead $a\](b$ tail](https://example.com)`;
+			const markdown = new Markdown(source, 0, 0, defaultMarkdownTheme);
+
+			const [rendered] = markdown.render(100);
+
+			assert.ok(rendered);
+			assert.strictEqual(stripAnsi(rendered).trimEnd(), source);
+		});
+
+		it("preserves an escaped opening bracket inside linked math", () => {
+			const source = String.raw`[lead $a\[b$ tail](https://example.com)`;
+			const markdown = new Markdown(source, 0, 0, defaultMarkdownTheme);
+
+			const [rendered] = markdown.render(100);
+
+			assert.ok(rendered);
+			assert.strictEqual(stripAnsi(rendered).trimEnd(), source);
+		});
+
+		it("preserves an escaped closing bracket inside linked math", () => {
+			const source = String.raw`[lead $a\]b$ tail](https://example.com)`;
+			const markdown = new Markdown(source, 0, 0, defaultMarkdownTheme);
+
+			const [rendered] = markdown.render(100);
+
+			assert.ok(rendered);
+			assert.strictEqual(stripAnsi(rendered).trimEnd(), source);
+		});
+
+		it("preserves consecutive backslashes before brackets inside linked math", () => {
+			const sources = [
+				String.raw`[value $[a\\]$](https://example.com)`,
+				String.raw`[value $\\[a]$](https://example.com)`,
+			];
+
+			for (const source of sources) {
+				const markdown = new Markdown(source, 0, 0, defaultMarkdownTheme);
+				const [rendered] = markdown.render(100);
+
+				assert.ok(rendered);
+				assert.strictEqual(stripAnsi(rendered).trimEnd(), source);
+			}
+		});
+
+		it("preserves closed math that crosses an image boundary", () => {
+			const source = String.raw`![lead $a](b$) tail`;
+			const markdown = new Markdown(source, 0, 0, defaultMarkdownTheme);
+
+			const [rendered] = markdown.render(100);
+
+			assert.ok(rendered);
+			assert.strictEqual(stripAnsi(rendered).trimEnd(), source);
+		});
+
+		it("preserves closed math that crosses a reference-link boundary", () => {
+			const source = String.raw`[lead $a][tier$] tail`;
+			const markdown = new Markdown(
+				`${source}\n\n[tier$]: https://example.com`,
+				0,
+				0,
+				defaultMarkdownTheme,
+			);
+
+			const lines = markdown.render(100).map((line) => stripAnsi(line).trimEnd());
+
+			assert.deepStrictEqual(lines, [source, ""]);
+		});
+
+		it("preserves closed math that crosses a reference-image boundary", () => {
+			const source = String.raw`![lead $a][tier$] tail`;
+			const markdown = new Markdown(
+				`${source}\n\n[tier$]: https://example.com`,
+				0,
+				0,
+				defaultMarkdownTheme,
+			);
+
+			const lines = markdown.render(100).map((line) => stripAnsi(line).trimEnd());
+
+			assert.deepStrictEqual(lines, [source, ""]);
+		});
+
+		it("preserves incomplete math that overlaps direct-link syntax while streaming", () => {
+			const source = String.raw`[lead $\text{a](b)} tail`;
+			const markdown = new Markdown(source, 0, 0, defaultMarkdownTheme, undefined, {
+				preserveIncompleteMath: true,
+			});
+
+			const [rendered] = markdown.render(100);
+
+			assert.ok(rendered);
+			assert.strictEqual(stripAnsi(rendered).trimEnd(), source);
+		});
+
+		it("preserves math-like incomplete text that overlaps link syntax after finalization", () => {
+			const source = String.raw`[lead $\text{a](b)} tail`;
+			const markdown = new Markdown(source, 0, 0, defaultMarkdownTheme);
+
+			const [rendered] = markdown.render(100);
+
+			assert.ok(rendered);
+			assert.strictEqual(stripAnsi(rendered).trimEnd(), source);
+		});
+
+		it("preserves mismatched math that overlaps direct-link syntax while streaming", () => {
+			const source = String.raw`[lead $\text{a](b)}$$ tail`;
+			const markdown = new Markdown(source, 0, 0, defaultMarkdownTheme, undefined, {
+				preserveIncompleteMath: true,
+			});
+
+			const [rendered] = markdown.render(100);
+
+			assert.ok(rendered);
+			assert.strictEqual(stripAnsi(rendered).trimEnd(), source);
+		});
+
+		it("preserves incomplete math that overlaps image syntax while streaming", () => {
+			const source = String.raw`![lead $\text{a](b)} tail`;
+			const markdown = new Markdown(source, 0, 0, defaultMarkdownTheme, undefined, {
+				preserveIncompleteMath: true,
+			});
+
+			const [rendered] = markdown.render(100);
+
+			assert.ok(rendered);
+			assert.strictEqual(stripAnsi(rendered).trimEnd(), source);
+		});
+
+		it("preserves incomplete math that overlaps reference-link syntax while streaming", () => {
+			const source = String.raw`[lead $\text{a][tier] tail`;
+			const markdown = new Markdown(
+				`${source}\n\n[tier]: https://example.com`,
+				0,
+				0,
+				defaultMarkdownTheme,
+				undefined,
+				{ preserveIncompleteMath: true },
+			);
+
+			const lines = markdown.render(100).map((line) => stripAnsi(line).trimEnd());
+
+			assert.deepStrictEqual(lines, [source, ""]);
+		});
+
 		it("keeps link formatting when math does not overlap link syntax", () => {
 			const source = String.raw`[value $x^*_A$](https://example.com)`;
 			const markdown = new Markdown(source, 0, 0, defaultMarkdownTheme);
@@ -801,6 +1014,17 @@ describe("Markdown component", () => {
 
 		it("preserves incomplete inline math during streaming", () => {
 			const source = String.raw`open $x^*_A + [y](z) + q~~r`;
+			const markdown = new Markdown(source, 0, 0, defaultMarkdownTheme, undefined, {
+				preserveIncompleteMath: true,
+			});
+
+			const lines = markdown.render(80).map((line) => stripAnsi(line).trimEnd());
+
+			assert.deepStrictEqual(lines, [source]);
+		});
+
+		it("preserves math-like incomplete inline text after finalization", () => {
+			const source = String.raw`$\theta^*_A + \phi^*_B`;
 			const markdown = new Markdown(source, 0, 0, defaultMarkdownTheme);
 
 			const lines = markdown.render(80).map((line) => stripAnsi(line).trimEnd());
@@ -821,6 +1045,19 @@ $$`;
 		});
 
 		it("preserves incomplete display math during streaming", () => {
+			const source = String.raw`$$
+# \theta^*_A
++ \phi^*_B`;
+			const markdown = new Markdown(source, 0, 0, defaultMarkdownTheme, undefined, {
+				preserveIncompleteMath: true,
+			});
+
+			const lines = markdown.render(80).map((line) => stripAnsi(line).trimEnd());
+
+			assert.deepStrictEqual(lines, ["$$", String.raw`# \theta^*_A`, String.raw`+ \phi^*_B`]);
+		});
+
+		it("preserves incomplete display math after finalization", () => {
 			const source = String.raw`$$
 # \theta^*_A
 + \phi^*_B`;
@@ -862,6 +1099,270 @@ $$`;
 			assert.deepStrictEqual(lines, source.split("\n"));
 		});
 
+		it("renders a table normally when a cell contains a literal unmatched dollar", () => {
+			const source = `| Price | Meaning |
+| --- | --- |
+| $5 | cheap |`;
+			const markdown = new Markdown(source, 0, 0, defaultMarkdownTheme);
+
+			const lines = markdown.render(100).map((line) => stripAnsi(line).trimEnd());
+
+			assert.deepStrictEqual(lines, [
+				"┌───────┬─────────┐",
+				"│ Price │ Meaning │",
+				"├───────┼─────────┤",
+				"│ $5    │ cheap   │",
+				"└───────┴─────────┘",
+			]);
+		});
+
+		it("renders a table normally when a header contains a literal unmatched dollar", () => {
+			const source = `| $5 plan | Feature |
+| --- | --- |
+| Basic | yes |`;
+			const markdown = new Markdown(source, 0, 0, defaultMarkdownTheme);
+
+			const lines = markdown.render(100).map((line) => stripAnsi(line).trimEnd());
+
+			assert.deepStrictEqual(lines, [
+				"┌─────────┬─────────┐",
+				"│ $5 plan │ Feature │",
+				"├─────────┼─────────┤",
+				"│ Basic   │ yes     │",
+				"└─────────┴─────────┘",
+			]);
+		});
+
+		it("renders a table normally when separate cells contain currency amounts", () => {
+			const source = `| Price | Other |
+| --- | --- |
+| $5 | $10 |`;
+			const markdown = new Markdown(source, 0, 0, defaultMarkdownTheme);
+
+			const lines = markdown.render(100).map((line) => stripAnsi(line).trimEnd());
+
+			assert.deepStrictEqual(lines, [
+				"┌───────┬───────┐",
+				"│ Price │ Other │",
+				"├───────┼───────┤",
+				"│ $5    │ $10   │",
+				"└───────┴───────┘",
+			]);
+		});
+
+		it("renders a table normally when cells contain environment variables", () => {
+			const source = `| First | Second |
+| --- | --- |
+| $PATH | $MY_VAR |`;
+			const markdown = new Markdown(source, 0, 0, defaultMarkdownTheme);
+
+			const lines = markdown.render(100).map((line) => stripAnsi(line).trimEnd());
+
+			assert.deepStrictEqual(lines, [
+				"┌───────┬─────────┐",
+				"│ First │ Second  │",
+				"├───────┼─────────┤",
+				"│ $PATH │ $MY_VAR │",
+				"└───────┴─────────┘",
+			]);
+		});
+
+		it("renders common shell-variable forms as ordinary table text", () => {
+			const source = `| Variable |
+| --- |
+| $CI |
+| $X |
+| $foo |
+| \${HOME} |`;
+			const markdown = new Markdown(source, 0, 0, defaultMarkdownTheme);
+
+			const lines = markdown.render(100).map((line) => stripAnsi(line).trimEnd());
+
+			assert.deepStrictEqual(lines, [
+				"┌──────────┐",
+				"│ Variable │",
+				"├──────────┤",
+				"│ $CI      │",
+				"├──────────┤",
+				"│ $X       │",
+				"├──────────┤",
+				"│ $foo     │",
+				"├──────────┤",
+				"│ ${HOME}  │",
+				"└──────────┘",
+			]);
+		});
+
+		it("renders a table normally when inline code contains a literal dollar", () => {
+			const source = `| Value |
+| --- |
+| \`$HOME\` |`;
+			const markdown = new Markdown(source, 0, 0, defaultMarkdownTheme);
+
+			const lines = markdown.render(100).map((line) => stripAnsi(line).trimEnd());
+
+			assert.deepStrictEqual(lines, [
+				"┌───────┐",
+				"│ Value │",
+				"├───────┤",
+				"│ $HOME │",
+				"└───────┘",
+			]);
+		});
+
+		it("preserves a table when inline code contains an unescaped pipe", () => {
+			const source = `| Value |
+| --- |
+| \`$A|B\` |`;
+			const markdown = new Markdown(source, 0, 0, defaultMarkdownTheme);
+
+			const lines = markdown.render(100).map((line) => stripAnsi(line).trimEnd());
+
+			assert.deepStrictEqual(lines, source.split("\n"));
+		});
+
+		it("renders a compact currency table normally", () => {
+			const source = `|Price|Meaning|
+|---|---|
+|$5|cheap|`;
+			const markdown = new Markdown(source, 0, 0, defaultMarkdownTheme);
+
+			const lines = markdown.render(100).map((line) => stripAnsi(line).trimEnd());
+
+			assert.deepStrictEqual(lines, [
+				"┌───────┬─────────┐",
+				"│ Price │ Meaning │",
+				"├───────┼─────────┤",
+				"│ $5    │ cheap   │",
+				"└───────┴─────────┘",
+			]);
+		});
+
+		it("preserves an incomplete table formula before another cell arrives while streaming", () => {
+			const source = `| Formula | Meaning |
+| --- | --- |
+| $p(A|B)`;
+			const markdown = new Markdown(source, 0, 0, defaultMarkdownTheme, undefined, {
+				preserveIncompleteMath: true,
+			});
+
+			const lines = markdown.render(100).map((line) => stripAnsi(line).trimEnd());
+
+			assert.deepStrictEqual(lines, source.split("\n"));
+		});
+
+		it("preserves an incomplete table formula containing an escaped pipe while streaming", () => {
+			const source = String.raw`| Formula | Meaning |
+| --- | --- |
+| $p(A\|B)`;
+			const markdown = new Markdown(source, 0, 0, defaultMarkdownTheme, undefined, {
+				preserveIncompleteMath: true,
+			});
+
+			const lines = markdown.render(100).map((line) => stripAnsi(line).trimEnd());
+
+			assert.deepStrictEqual(lines, source.split("\n"));
+		});
+
+		it("preserves an incomplete table formula after finalization", () => {
+			const source = `| Formula | Meaning |
+| --- | --- |
+| $p(A|B) | conditional |`;
+			const markdown = new Markdown(source, 0, 0, defaultMarkdownTheme);
+
+			const lines = markdown.render(100).map((line) => stripAnsi(line).trimEnd());
+
+			assert.deepStrictEqual(lines, source.split("\n"));
+		});
+
+		it("preserves an incomplete uppercase table formula after finalization", () => {
+			const source = `| Formula | Meaning |
+| --- | --- |
+| $A|B`;
+			const markdown = new Markdown(source, 0, 0, defaultMarkdownTheme);
+
+			const lines = markdown.render(100).map((line) => stripAnsi(line).trimEnd());
+
+			assert.deepStrictEqual(lines, source.split("\n"));
+		});
+
+		it("preserves an overflowing numeric table formula after finalization", () => {
+			const source = `| Formula | Meaning |
+| --- | --- |
+| $5|B | conditional |`;
+			const markdown = new Markdown(source, 0, 0, defaultMarkdownTheme);
+
+			const lines = markdown.render(100).map((line) => stripAnsi(line).trimEnd());
+
+			assert.deepStrictEqual(lines, source.split("\n"));
+		});
+
+		it("preserves a short numeric table formula after finalization", () => {
+			const source = `| Left | Right |
+| --- | --- |
+| $5|B`;
+			const markdown = new Markdown(source, 0, 0, defaultMarkdownTheme);
+
+			const lines = markdown.render(100).map((line) => stripAnsi(line).trimEnd());
+
+			assert.deepStrictEqual(lines, source.split("\n"));
+		});
+
+		it("preserves a short subscript table formula after finalization", () => {
+			const source = `| Left | Right |
+| --- | --- |
+| $A_B|C`;
+			const markdown = new Markdown(source, 0, 0, defaultMarkdownTheme);
+
+			const lines = markdown.render(100).map((line) => stripAnsi(line).trimEnd());
+
+			assert.deepStrictEqual(lines, source.split("\n"));
+		});
+
+		it("preserves a subscript after a short formula pipe", () => {
+			const source = `| Left | Right |
+| --- | --- |
+| $A|B_1`;
+			const markdown = new Markdown(source, 0, 0, defaultMarkdownTheme);
+
+			const lines = markdown.render(100).map((line) => stripAnsi(line).trimEnd());
+
+			assert.deepStrictEqual(lines, source.split("\n"));
+		});
+
+		it("preserves an uppercase term after a short formula pipe", () => {
+			const source = `| Left | Right |
+| --- | --- |
+| $A|BC`;
+			const markdown = new Markdown(source, 0, 0, defaultMarkdownTheme);
+
+			const lines = markdown.render(100).map((line) => stripAnsi(line).trimEnd());
+
+			assert.deepStrictEqual(lines, source.split("\n"));
+		});
+
+		it("preserves an expression after a short formula pipe", () => {
+			const source = `| Left | Right |
+| --- | --- |
+| $A|B+C`;
+			const markdown = new Markdown(source, 0, 0, defaultMarkdownTheme);
+
+			const lines = markdown.render(100).map((line) => stripAnsi(line).trimEnd());
+
+			assert.deepStrictEqual(lines, source.split("\n"));
+		});
+
+		it("preserves an incomplete escaped table formula after finalization", () => {
+			const source = String.raw`| Formula | Meaning |
+| --- | --- |
+| $p(A\|B)`;
+			const markdown = new Markdown(source, 0, 0, defaultMarkdownTheme);
+
+			const lines = markdown.render(100).map((line) => stripAnsi(line).trimEnd());
+
+			assert.deepStrictEqual(lines, source.split("\n"));
+		});
+
 		it("keeps math-like text inside inline code", () => {
 			const markdown = new Markdown("Use `$\\theta^*_A$` literally.", 0, 0, defaultMarkdownTheme);
 
@@ -870,6 +1371,18 @@ $$`;
 			assert.ok(rendered);
 			assert.strictEqual(stripAnsi(rendered).trimEnd(), String.raw`Use $\theta^*_A$ literally.`);
 			assert.ok(rendered.includes(defaultMarkdownTheme.code(String.raw`$\theta^*_A$`)));
+		});
+
+		it("renders a long unmatched backtick run without quadratic slowdown", { timeout: 2_000 }, () => {
+			const source = `prefix ${"`".repeat(64_000)} suffix`;
+			const markdown = new Markdown(source, 0, 0, defaultMarkdownTheme);
+			const startedAt = performance.now();
+
+			const lines = markdown.render(100_000).map((line) => stripAnsi(line).trimEnd());
+
+			const elapsedMs = performance.now() - startedAt;
+			assert.deepStrictEqual(lines, [source]);
+			assert.ok(elapsedMs < 1_000, `Expected linear rendering, took ${elapsedMs.toFixed(1)}ms`);
 		});
 
 		it("keeps delimiter-only display math inside fenced code", () => {
@@ -1542,6 +2055,174 @@ bar`,
 				line.replace(/\x1b\]8;;[^\x1b]*\x1b\\/g, "").replace(/\x1b\[[0-9;]*m/g, ""),
 			);
 			assert.ok(!rawPlain.join("").includes("(https://example.com)"), "URL should not appear inline in parentheses");
+		});
+
+		it("keeps a link label with a literal dollar clickable", () => {
+			setCapabilities({ images: null, trueColor: false, hyperlinks: true });
+			const markdown = new Markdown(
+				"[$5 plan](https://example.com) after text",
+				0,
+				0,
+				defaultMarkdownTheme,
+			);
+
+			const rendered = markdown.render(80).join("");
+			const hyperlink = stripAnsi(rendered).trimEnd();
+
+			assert.ok(hyperlink.includes("\x1b]8;;https://example.com\x1b\\$5 plan\x1b]8;;\x1b\\"));
+		});
+
+		it("keeps an underscored environment-variable label clickable", () => {
+			setCapabilities({ images: null, trueColor: false, hyperlinks: true });
+			const markdown = new Markdown("[$API_KEY](https://example.com)", 0, 0, defaultMarkdownTheme);
+
+			const rendered = markdown.render(80).join("");
+			const hyperlink = stripAnsi(rendered).trimEnd();
+
+			assert.ok(hyperlink.includes("\x1b]8;;https://example.com\x1b\\$API_KEY\x1b]8;;\x1b\\"));
+		});
+
+		it("preserves backslashes before brackets inside a code-span link label", () => {
+			for (const bracket of ["[", "]"]) {
+				for (let slashCount = 1; slashCount <= 4; slashCount++) {
+					const source = "[`$a" + "\\".repeat(slashCount) + bracket + "b$`](https://example.com)";
+					const markdown = new Markdown(source, 0, 0, defaultMarkdownTheme);
+					const [rendered] = markdown.render(100);
+
+					assert.ok(rendered);
+					assert.strictEqual(stripAnsi(rendered).trimEnd(), source.replaceAll("`", ""));
+				}
+			}
+		});
+
+		it("keeps a code-span label containing a dollar clickable", () => {
+			setCapabilities({ images: null, trueColor: false, hyperlinks: true });
+			const markdown = new Markdown("[`$HOME`](https://example.com)", 0, 0, defaultMarkdownTheme);
+
+			const rendered = markdown.render(80).join("");
+			const hyperlink = stripAnsi(rendered).trimEnd();
+
+			assert.ok(hyperlink.includes("\x1b]8;;https://example.com\x1b\\$HOME\x1b]8;;\x1b\\"));
+		});
+
+		it("preserves math after a code span containing a closing bracket", () => {
+			const markdown = new Markdown("[`]` $a](b$) tail", 0, 0, defaultMarkdownTheme);
+
+			const [rendered] = markdown.render(80);
+
+			assert.ok(rendered);
+			assert.strictEqual(stripAnsi(rendered).trimEnd(), "[] $a](b$) tail");
+		});
+
+		it("keeps a link clickable when closed math contains link-like text", () => {
+			setCapabilities({ images: null, trueColor: false, hyperlinks: true });
+			const label = String.raw`lead $\text{[a](b)}$ tail`;
+			const markdown = new Markdown(`[${label}](https://example.com)`, 0, 0, defaultMarkdownTheme);
+
+			const rendered = markdown.render(100).join("");
+			const hyperlink = stripAnsi(rendered).trimEnd();
+
+			assert.ok(
+				hyperlink.includes(`\x1b]8;;https://example.com\x1b\\${label}\x1b]8;;\x1b\\`),
+			);
+		});
+
+		it("keeps a currency link clickable when another amount follows", () => {
+			setCapabilities({ images: null, trueColor: false, hyperlinks: true });
+			const markdown = new Markdown(
+				"[$5 plan](https://example.com), then $10",
+				0,
+				0,
+				defaultMarkdownTheme,
+			);
+
+			const rendered = markdown.render(80).join("");
+			const hyperlink = stripAnsi(rendered).trimEnd();
+
+			assert.ok(hyperlink.includes("\x1b]8;;https://example.com\x1b\\$5 plan\x1b]8;;\x1b\\"));
+		});
+
+		it("keeps a currency link clickable when a formula follows", () => {
+			setCapabilities({ images: null, trueColor: false, hyperlinks: true });
+			const markdown = new Markdown(
+				"[$5 plan](https://example.com), then $x$",
+				0,
+				0,
+				defaultMarkdownTheme,
+			);
+
+			const rendered = markdown.render(80).join("");
+			const hyperlink = stripAnsi(rendered).trimEnd();
+
+			assert.ok(hyperlink.includes("\x1b]8;;https://example.com\x1b\\$5 plan\x1b]8;;\x1b\\"));
+			assert.ok(hyperlink.includes("$x$"));
+		});
+
+		it("uses a destination containing a literal dollar as the OSC 8 target", () => {
+			setCapabilities({ images: null, trueColor: false, hyperlinks: true });
+			const markdown = new Markdown(
+				"[docs](https://example.com/$metadata) after text",
+				0,
+				0,
+				defaultMarkdownTheme,
+			);
+
+			const rendered = markdown.render(80).join("");
+			const hyperlink = stripAnsi(rendered).trimEnd();
+
+			assert.ok(
+				hyperlink.includes("\x1b]8;;https://example.com/$metadata\x1b\\docs\x1b]8;;\x1b\\"),
+			);
+		});
+
+		it("keeps a dollar destination clickable when a formula follows", () => {
+			setCapabilities({ images: null, trueColor: false, hyperlinks: true });
+			const markdown = new Markdown(
+				"[docs](https://example.com/$metadata), then $x$",
+				0,
+				0,
+				defaultMarkdownTheme,
+			);
+
+			const rendered = markdown.render(80).join("");
+			const hyperlink = stripAnsi(rendered).trimEnd();
+
+			assert.ok(
+				hyperlink.includes("\x1b]8;;https://example.com/$metadata\x1b\\docs\x1b]8;;\x1b\\"),
+			);
+			assert.ok(hyperlink.includes("$x$"));
+		});
+
+		it("uses a destination containing an underscored dollar term", () => {
+			setCapabilities({ images: null, trueColor: false, hyperlinks: true });
+			const markdown = new Markdown(
+				"[docs](https://example.com/$meta_data) after text",
+				0,
+				0,
+				defaultMarkdownTheme,
+			);
+
+			const rendered = markdown.render(80).join("");
+			const hyperlink = stripAnsi(rendered).trimEnd();
+
+			assert.ok(
+				hyperlink.includes("\x1b]8;;https://example.com/$meta_data\x1b\\docs\x1b]8;;\x1b\\"),
+			);
+		});
+
+		it("keeps a reference-link label with a literal dollar clickable", () => {
+			setCapabilities({ images: null, trueColor: false, hyperlinks: true });
+			const markdown = new Markdown(
+				"[$5 plan][tier]\n\n[tier]: https://example.com",
+				0,
+				0,
+				defaultMarkdownTheme,
+			);
+
+			const rendered = markdown.render(80).join("");
+			const hyperlink = stripAnsi(rendered).trimEnd();
+
+			assert.ok(hyperlink.includes("\x1b]8;;https://example.com\x1b\\$5 plan\x1b]8;;\x1b\\"));
 		});
 
 		it("should use OSC 8 for mailto links when terminal supports hyperlinks", () => {


### PR DESCRIPTION
## Related Issue

No linked issue. This fixes a problem reported through user feedback.

## Problem

The terminal Markdown renderer does not recognize TeX dollar delimiters. As a result, Markdown-like characters inside separate formulas can be paired across formula boundaries. For example, the asterisks in repeated `$\theta^*_A$` expressions may be interpreted as emphasis markers and disappear from the rendered transcript even though the stored assistant response is correct.

The TUI does not need to render math, but it must not remove or rewrite the original formula source.

## What changed

- Tokenize dollar-delimited inline and display math as opaque literal text before the built-in Markdown tokenizers process it.
- Preserve incomplete math while responses are streaming.
- Keep ordinary Markdown formatting outside math unchanged.
- Preserve source when math overlaps Markdown emphasis, strikethrough, links, or table delimiters.
- Add regression coverage for the reported expression and related boundary cases, including code spans and fenced code blocks.

This intentionally prioritizes source preservation over Markdown styling for ambiguous or incomplete dollar-delimited text. A table containing a formula-level `|` falls back to its literal Markdown source instead of risking content loss.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.

## Validation

- `pnpm --filter @moonshot-ai/pi-tui test` (750 passed)
- `pnpm --filter @moonshot-ai/pi-tui typecheck`
- `oxlint --no-ignore src/components/markdown.ts test/markdown.test.ts` (0 errors)
- `git diff --check`
