### PR TITLE
docs: explain Git Bash path handling on Windows

### DIFF
--- a/docs/en/reference/tools.md
+++ b/docs/en/reference/tools.md
@@ -46,6 +46,22 @@ File tools handle reading, writing, and searching the local filesystem — the f
 
 Foreground mode blocks the current turn until the command completes or times out, and the TUI streams stdout and stderr into the running `Bash` tool card while the command is still active. Background mode returns a task ID immediately and automatically notifies the Agent when the task finishes. stdin is always closed — interactive commands receive EOF immediately. A two-phase termination strategy (SIGTERM → 5-second grace period → SIGKILL) ensures reliable process cleanup after a timeout. On Windows, Git Bash is used by default.
 
+### Windows path handling
+
+On Windows, `Bash` runs through Git Bash, a POSIX-compatible environment (it uses Unix-style commands and paths) rather than PowerShell. Pass POSIX-style paths to POSIX programs such as `tar`; otherwise a Windows drive prefix can be interpreted as a remote path (`host:path`).
+
+```sh
+# In Git Bash, use a POSIX-style path.
+tar -cf /e/work/archive.tar sample.txt
+
+# Do not pass a Windows drive path to a POSIX program such as tar.
+# It can be interpreted as a remote path and fail with
+# "tar: Cannot connect to E: resolve failed".
+tar -cf E:\work\archive.tar sample.txt
+```
+
+For commands that require Windows-native path behavior or PowerShell-specific syntax, invoke PowerShell explicitly instead of assuming that `Bash` runs in PowerShell.
+
 ## Web Tools
 
 | Tool | Default Approval | Description |

--- a/docs/zh/reference/tools.md
+++ b/docs/zh/reference/tools.md
@@ -46,6 +46,22 @@
 
 前台模式会阻塞当前轮次，直到命令结束或超时；命令运行期间，TUI 会把 stdout 和 stderr 流式显示在正在运行的 `Bash` 工具卡片中。后台模式立即返回任务 ID，任务结束时自动通知 Agent。stdin 始终被关闭，交互式命令会立即收到 EOF。两阶段终止策略（SIGTERM → 5 秒宽限期 → SIGKILL）确保超时后进程可靠结束。Windows 平台默认使用 Git Bash。
 
+### Windows 路径处理
+
+在 Windows 上，`Bash` 通过 Git Bash 运行；Git Bash 是 POSIX 兼容环境（使用 Unix 风格的命令和路径），并非 PowerShell。向 `tar` 等 POSIX 程序传递路径时，应使用 POSIX 风格；否则 Windows 盘符前缀可能会被当作远程路径（`host:path`）解析。
+
+```sh
+# 在 Git Bash 中使用 POSIX 风格路径。
+tar -cf /e/work/archive.tar sample.txt
+
+# 不要将 Windows 盘符路径传给 tar 等 POSIX 程序。
+# 它可能被当作远程路径，并报错：
+# "tar: Cannot connect to E: resolve failed"。
+tar -cf E:\work\archive.tar sample.txt
+```
+
+如需 Windows 原生路径行为或 PowerShell 专用语法，请显式调用 PowerShell，而不要假设 `Bash` 在 PowerShell 中运行。
+
 ## 网络类
 
 | 工具 | 默认审批 | 说明 |


### PR DESCRIPTION
## Related Issue

Resolve #1568

## Problem

On Windows, Kimi Code runs the `Bash` tool through Git Bash. Windows drive paths passed to POSIX programs can therefore be interpreted as remote paths.

## What changed

Added matching English and Simplified Chinese guidance to the built-in tools reference. It explains POSIX-style paths, shows the `tar` failure mode, and identifies when to invoke PowerShell explicitly.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue.
- [x] I verified the documentation with `pnpm -C docs run build`.
- [x] This documentation-only PR needs no changeset.
- [x] Updated the matching English and Chinese documentation pages.