### PR TITLE
fix(agent-core-v2): bound terminal resource retention

### DIFF
--- a/.changeset/bound-terminal-retention.md
+++ b/.changeset/bound-terminal-retention.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Limit retained terminal replay output and exited terminal history in long-running sessions.

--- a/packages/agent-core-v2/src/os/backends/node-local/hostTerminalService.ts
+++ b/packages/agent-core-v2/src/os/backends/node-local/hostTerminalService.ts
@@ -2,9 +2,10 @@
  * `terminal` domain (L6) — `IHostTerminalService` implementation.
  *
  * App-scoped OS terminal process factory backed by `node-pty`. It spawns and
- * tracks every `TerminalProcess` so the whole process-wide PTY layer can be
- * torn down on disposal. It has no session, workspace, or buffering concerns;
- * those live in the Session-scoped `ISessionTerminalService`.
+ * tracks live `TerminalProcess` handles so the process-wide PTY layer can be
+ * torn down on disposal, releasing App ownership after each PTY exits. It has
+ * no session, workspace, or buffering concerns; those live in the
+ * Session-scoped `ISessionTerminalService`.
  *
  * `node-pty` is loaded lazily so merely importing this module (for example in
  * tests that override the service with a fake) does not require the native
@@ -14,7 +15,7 @@
 import type { IPty } from 'node-pty';
 
 import { InstantiationType } from '#/_base/di/extensions';
-import { Disposable } from '#/_base/di/lifecycle';
+import { Disposable, type IDisposable } from '#/_base/di/lifecycle';
 import { LifecycleScope, registerScopedService } from '#/_base/di/scope';
 
 import { IHostTerminalService, type TerminalProcess, type TerminalSpawnOptions } from '#/os/interface/terminal';
@@ -22,7 +23,7 @@ import { IHostTerminalService, type TerminalProcess, type TerminalSpawnOptions }
 export class HostTerminalService extends Disposable implements IHostTerminalService {
   declare readonly _serviceBrand: undefined;
 
-  private readonly processes = new Set<TerminalProcess>();
+  private readonly processes = new Map<TerminalProcess, IDisposable>();
 
   async spawn(options: TerminalSpawnOptions): Promise<TerminalProcess> {
     const pty = await import('node-pty');
@@ -40,20 +41,35 @@ export class HostTerminalService extends Disposable implements IHostTerminalServ
       resize: (cols, rows) => proc.resize(cols, rows),
       kill: () => proc.kill(),
     };
-    this.processes.add(terminalProcess);
+    this.processes.set(terminalProcess, Disposable.None);
+    const exitSubscription = terminalProcess.onProcessExit(() => {
+      this.releaseProcess(terminalProcess);
+    });
+    if (this.processes.has(terminalProcess)) {
+      this.processes.set(terminalProcess, exitSubscription);
+    } else {
+      exitSubscription.dispose();
+    }
     return terminalProcess;
   }
 
   override dispose(): void {
-    for (const process of this.processes) {
+    const processes = [...this.processes.entries()];
+    this.processes.clear();
+    for (const [process, exitSubscription] of processes) {
+      exitSubscription.dispose();
       try {
         process.kill();
-      } catch {
-        // best-effort cleanup
-      }
+      } catch {}
     }
-    this.processes.clear();
     super.dispose();
+  }
+
+  private releaseProcess(process: TerminalProcess): void {
+    const exitSubscription = this.processes.get(process);
+    if (exitSubscription === undefined) return;
+    this.processes.delete(process);
+    exitSubscription.dispose();
   }
 }
 

--- a/packages/agent-core-v2/src/os/backends/node-local/hostTerminalService.ts
+++ b/packages/agent-core-v2/src/os/backends/node-local/hostTerminalService.ts
@@ -5,7 +5,8 @@
  * tracks live `TerminalProcess` handles so the process-wide PTY layer can be
  * torn down on disposal, releasing App ownership after each PTY exits. It has
  * no session, workspace, or buffering concerns; those live in the
- * Session-scoped `ISessionTerminalService`.
+ * Session-scoped `ISessionTerminalService`. PTYs that arrive after App
+ * teardown are terminated instead of being published.
  *
  * `node-pty` is loaded lazily so merely importing this module (for example in
  * tests that override the service with a fake) does not require the native
@@ -24,9 +25,12 @@ export class HostTerminalService extends Disposable implements IHostTerminalServ
   declare readonly _serviceBrand: undefined;
 
   private readonly processes = new Map<TerminalProcess, IDisposable>();
+  private _disposed = false;
 
   async spawn(options: TerminalSpawnOptions): Promise<TerminalProcess> {
+    this.assertActive();
     const pty = await import('node-pty');
+    this.assertActive();
     const proc: IPty = pty.spawn(options.shell, [], {
       name: 'xterm-256color',
       cwd: options.cwd,
@@ -34,6 +38,10 @@ export class HostTerminalService extends Disposable implements IHostTerminalServ
       rows: options.rows,
       env: globalThis.process.env,
     });
+    if (this._disposed) {
+      killQuietly(proc);
+      throw disposedError();
+    }
     const terminalProcess: TerminalProcess = {
       onProcessData: (listener) => proc.onData(listener),
       onProcessExit: (listener) => proc.onExit((event) => listener({ exitCode: event.exitCode })),
@@ -50,17 +58,25 @@ export class HostTerminalService extends Disposable implements IHostTerminalServ
     } else {
       exitSubscription.dispose();
     }
+    if (this._disposed) {
+      const ownedSubscription = this.processes.get(terminalProcess);
+      if (ownedSubscription !== undefined) {
+        this.processes.delete(terminalProcess);
+        ownedSubscription.dispose();
+        killQuietly(terminalProcess);
+      }
+      throw disposedError();
+    }
     return terminalProcess;
   }
 
   override dispose(): void {
+    this._disposed = true;
     const processes = [...this.processes.entries()];
     this.processes.clear();
     for (const [process, exitSubscription] of processes) {
       exitSubscription.dispose();
-      try {
-        process.kill();
-      } catch {}
+      killQuietly(process);
     }
     super.dispose();
   }
@@ -71,6 +87,20 @@ export class HostTerminalService extends Disposable implements IHostTerminalServ
     this.processes.delete(process);
     exitSubscription.dispose();
   }
+
+  private assertActive(): void {
+    if (this._disposed) throw disposedError();
+  }
+}
+
+function killQuietly(process: Pick<IPty, 'kill'>): void {
+  try {
+    process.kill();
+  } catch {}
+}
+
+function disposedError(): Error {
+  return new Error('Host terminal service is disposed');
 }
 
 registerScopedService(

--- a/packages/agent-core-v2/src/session/terminal/terminalService.ts
+++ b/packages/agent-core-v2/src/session/terminal/terminalService.ts
@@ -4,7 +4,9 @@
  * Owns this session's terminal set and its per-terminal output buffers and
  * attached sinks; spawns PTYs through the App-scoped `IHostTerminalService`,
  * resolves the working directory through `workspaceContext`, and reads the
- * session id through `sessionContext` to tag frames. Bound at Session scope.
+ * session id through `sessionContext` to tag frames. Keeps replay output and
+ * exited terminal history bounded while live terminals remain owned until
+ * exit or Session disposal. Bound at Session scope.
  */
 
 import { randomUUID } from 'node:crypto';
@@ -31,12 +33,15 @@ import { ISessionWorkspaceContext } from '#/session/workspaceContext/workspaceCo
 const DEFAULT_COLS = 80;
 const DEFAULT_ROWS = 24;
 const DEFAULT_MAX_BUFFERED_FRAMES = 2000;
+const DEFAULT_MAX_BUFFERED_OUTPUT_BYTES = 1_048_576;
+const DEFAULT_MAX_EXITED_TERMINALS = 16;
 
 interface TerminalRecord {
   terminal: Terminal;
   process: TerminalProcess;
   sinks: Map<string, TerminalAttachSink>;
   buffer: TerminalFrame[];
+  bufferedOutputBytes: number;
   nextSeq: number;
   disposables: IDisposable[];
   closed: boolean;
@@ -67,6 +72,7 @@ export class SessionTerminalService extends Disposable implements ISessionTermin
   declare readonly _serviceBrand: undefined;
 
   private readonly records = new Map<string, TerminalRecord>();
+  private readonly exitedRecords: TerminalRecord[] = [];
 
   constructor(
     @IHostTerminalService private readonly terminalService: IHostTerminalService,
@@ -100,6 +106,7 @@ export class SessionTerminalService extends Disposable implements ISessionTermin
       process,
       sinks: new Map(),
       buffer: [],
+      bufferedOutputBytes: 0,
       nextSeq: 0,
       disposables: [],
       closed: false,
@@ -128,7 +135,9 @@ export class SessionTerminalService extends Disposable implements ISessionTermin
     options: TerminalAttachOptions = {},
   ): Promise<{ replayed: number }> {
     const record = this.requireRecord(terminalId);
-    record.sinks.set(sink.id, sink);
+    if (record.terminal.status === 'running') {
+      record.sinks.set(sink.id, sink);
+    }
     const sinceSeq = options.sinceSeq ?? 0;
     const replay = record.buffer.filter((frame) => frameSeq(frame) > sinceSeq);
     for (const frame of replay) {
@@ -171,13 +180,14 @@ export class SessionTerminalService extends Disposable implements ISessionTermin
   override dispose(): void {
     for (const record of this.records.values()) {
       disposeAll(record.disposables);
-      try {
-        record.process.kill();
-      } catch {
-        // best-effort cleanup
+      if (record.terminal.status === 'running') {
+        try {
+          record.process.kill();
+        } catch {}
       }
     }
     this.records.clear();
+    this.exitedRecords.length = 0;
     super.dispose();
   }
 
@@ -224,18 +234,44 @@ export class SessionTerminalService extends Disposable implements ISessionTermin
       timestamp: new Date().toISOString(),
       payload: { exit_code: exitCode },
     };
-    this.pushFrame(record, frame);
-    disposeAll(record.disposables);
-    record.disposables = [];
+    try {
+      this.pushFrame(record, frame);
+    } finally {
+      disposeAll(record.disposables);
+      record.disposables = [];
+      record.sinks.clear();
+      this.exitedRecords.push(record);
+      this.pruneExitedRecords();
+    }
   }
 
   private pushFrame(record: TerminalRecord, frame: TerminalFrame): void {
-    record.buffer.push(frame);
-    if (record.buffer.length > DEFAULT_MAX_BUFFERED_FRAMES) {
-      record.buffer.splice(0, record.buffer.length - DEFAULT_MAX_BUFFERED_FRAMES);
+    const buffered = boundedReplayFrame(frame);
+    record.buffer.push(buffered.frame);
+    record.bufferedOutputBytes += buffered.outputBytes;
+    while (
+      record.buffer.length > DEFAULT_MAX_BUFFERED_FRAMES ||
+      record.bufferedOutputBytes > DEFAULT_MAX_BUFFERED_OUTPUT_BYTES
+    ) {
+      const removed = record.buffer.shift();
+      if (removed !== undefined) {
+        record.bufferedOutputBytes -= outputBytes(removed);
+      }
     }
     for (const sink of record.sinks.values()) {
       sink.send(frame);
+    }
+  }
+
+  private pruneExitedRecords(): void {
+    while (this.exitedRecords.length > DEFAULT_MAX_EXITED_TERMINALS) {
+      const record = this.exitedRecords.shift();
+      if (record === undefined) return;
+      if (this.records.get(record.terminal.id) !== record) continue;
+      this.records.delete(record.terminal.id);
+      record.buffer = [];
+      record.bufferedOutputBytes = 0;
+      record.sinks.clear();
     }
   }
 }
@@ -250,10 +286,54 @@ function frameSeq(frame: TerminalFrame): number {
   return frame.type === 'terminal_output' ? frame.seq : Number.MAX_SAFE_INTEGER;
 }
 
+function outputBytes(frame: TerminalFrame): number {
+  return frame.type === 'terminal_output' ? Buffer.byteLength(frame.payload.data) : 0;
+}
+
+function boundedReplayFrame(
+  frame: TerminalFrame,
+): { frame: TerminalFrame; outputBytes: number } {
+  if (frame.type !== 'terminal_output') return { frame, outputBytes: 0 };
+  const bytes =
+    frame.payload.data.length > DEFAULT_MAX_BUFFERED_OUTPUT_BYTES
+      ? DEFAULT_MAX_BUFFERED_OUTPUT_BYTES + 1
+      : outputBytes(frame);
+  if (bytes <= DEFAULT_MAX_BUFFERED_OUTPUT_BYTES) {
+    return { frame, outputBytes: bytes };
+  }
+  const suffix = utf8Suffix(frame.payload.data, DEFAULT_MAX_BUFFERED_OUTPUT_BYTES);
+  return {
+    frame: { ...frame, payload: { data: suffix.value } },
+    outputBytes: suffix.bytes,
+  };
+}
+
+function utf8Suffix(value: string, maxBytes: number): { value: string; bytes: number } {
+  let bytes = 0;
+  let start = value.length;
+  while (start > 0) {
+    const next = precedingUtf8CodePoint(value, start);
+    if (bytes + next.bytes > maxBytes) break;
+    bytes += next.bytes;
+    start = next.start;
+  }
+  return { value: Buffer.from(value.slice(start)).toString('utf8'), bytes };
+}
+
+function precedingUtf8CodePoint(value: string, end: number): { start: number; bytes: number } {
+  const last = value.codePointAt(end - 1)!;
+  if (last >= 0xdc00 && last <= 0xdfff && end > 1) {
+    const previous = value.codePointAt(end - 2)!;
+    if (previous > 0xffff) {
+      return { start: end - 2, bytes: 4 };
+    }
+  }
+  if (last <= 0x7f) return { start: end - 1, bytes: 1 };
+  if (last <= 0x7ff) return { start: end - 1, bytes: 2 };
+  return { start: end - 1, bytes: 3 };
+}
+
 function defaultShell(): string {
-  // Use `||` (not `??`): an EMPTY $SHELL (set but blank, as some daemon/launchd
-  // envs leave it) must still fall back, or a PTY spawn fails with
-  // "posix_spawnp failed".
   return process.env['SHELL'] || '/bin/sh';
 }
 

--- a/packages/agent-core-v2/src/session/terminal/terminalService.ts
+++ b/packages/agent-core-v2/src/session/terminal/terminalService.ts
@@ -6,7 +6,8 @@
  * resolves the working directory through `workspaceContext`, and reads the
  * session id through `sessionContext` to tag frames. Keeps replay output and
  * exited terminal history bounded while live terminals remain owned until
- * exit or Session disposal. Bound at Session scope.
+ * exit or Session disposal, and rejects PTYs that arrive after Session
+ * teardown. Bound at Session scope.
  */
 
 import { randomUUID } from 'node:crypto';
@@ -73,6 +74,7 @@ export class SessionTerminalService extends Disposable implements ISessionTermin
 
   private readonly records = new Map<string, TerminalRecord>();
   private readonly exitedRecords: TerminalRecord[] = [];
+  private _disposed = false;
 
   constructor(
     @IHostTerminalService private readonly terminalService: IHostTerminalService,
@@ -83,6 +85,7 @@ export class SessionTerminalService extends Disposable implements ISessionTermin
   }
 
   async create(input: CreateTerminalRequest): Promise<Terminal> {
+    this.assertActive();
     const cwd =
       input.cwd === undefined
         ? this.workspace.workDir
@@ -91,6 +94,10 @@ export class SessionTerminalService extends Disposable implements ISessionTermin
     const cols = input.cols ?? DEFAULT_COLS;
     const rows = input.rows ?? DEFAULT_ROWS;
     const process = await this.terminalService.spawn({ cwd, shell, cols, rows });
+    if (this._disposed) {
+      killQuietly(process);
+      throw this.closedError();
+    }
     const terminal: Terminal = {
       id: `term_${randomUUID()}`,
       session_id: this.sessionContext.sessionId,
@@ -115,6 +122,11 @@ export class SessionTerminalService extends Disposable implements ISessionTermin
       process.onProcessData((data) => this.onData(record, data)),
       process.onProcessExit((event) => this.onExit(record, event.exitCode)),
     );
+    if (this._disposed) {
+      disposeAll(record.disposables);
+      killQuietly(process);
+      throw this.closedError();
+    }
     this.records.set(terminal.id, record);
     return { ...terminal };
   }
@@ -178,12 +190,11 @@ export class SessionTerminalService extends Disposable implements ISessionTermin
   }
 
   override dispose(): void {
+    this._disposed = true;
     for (const record of this.records.values()) {
       disposeAll(record.disposables);
       if (record.terminal.status === 'running') {
-        try {
-          record.process.kill();
-        } catch {}
+        killQuietly(record.process);
       }
     }
     this.records.clear();
@@ -200,6 +211,17 @@ export class SessionTerminalService extends Disposable implements ISessionTermin
       );
     }
     return record;
+  }
+
+  private assertActive(): void {
+    if (this._disposed) throw this.closedError();
+  }
+
+  private closedError(): Error2 {
+    return new Error2(
+      ErrorCodes.SESSION_CLOSED,
+      `session ${this.sessionContext.sessionId} is closed`,
+    );
   }
 
   private onData(record: TerminalRecord, data: string): void {
@@ -280,6 +302,12 @@ function disposeAll(items: Iterable<IDisposable>): void {
   for (const item of items) {
     item.dispose();
   }
+}
+
+function killQuietly(process: TerminalProcess): void {
+  try {
+    process.kill();
+  } catch {}
 }
 
 function frameSeq(frame: TerminalFrame): number {

--- a/packages/agent-core-v2/test/session/terminal/terminalService.test.ts
+++ b/packages/agent-core-v2/test/session/terminal/terminalService.test.ts
@@ -1,5 +1,16 @@
+/**
+ * `terminal` lifecycle scenarios — bounded replay and exited-resource ownership.
+ *
+ * Exercises `ISessionTerminalService` and `IHostTerminalService` through DI,
+ * using the real services with only the OS PTY/workspace/session boundaries
+ * replaced. Covers live delivery, replay, exit retention, and App/Session
+ * teardown. Run with `pnpm --filter @moonshot-ai/agent-core-v2 exec vitest run
+ * test/session/terminal/terminalService.test.ts`.
+ */
+
 import { resolve } from 'node:path';
 
+import { spawn } from 'node-pty';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { DisposableStore, toDisposable } from '#/_base/di/lifecycle';
@@ -99,7 +110,36 @@ function collectSink(id = 'sink-1'): { sink: TerminalAttachSink; frames: Termina
   return { sink: { id, send: (frame) => frames.push(frame) }, frames };
 }
 
-describe('SessionTerminalService', () => {
+function createMockPty(): {
+  readonly pty: import('node-pty').IPty;
+  readonly dataListeners: Set<(data: string) => void>;
+  readonly exitListeners: Set<(event: { exitCode: number }) => void>;
+  readonly write: ReturnType<typeof vi.fn>;
+  readonly resize: ReturnType<typeof vi.fn>;
+  readonly kill: ReturnType<typeof vi.fn>;
+} {
+  const dataListeners = new Set<(data: string) => void>();
+  const exitListeners = new Set<(event: { exitCode: number }) => void>();
+  const write = vi.fn();
+  const resize = vi.fn();
+  const kill = vi.fn();
+  const pty = {
+    onData: (listener: (data: string) => void) => {
+      dataListeners.add(listener);
+      return toDisposable(() => dataListeners.delete(listener));
+    },
+    onExit: (listener: (event: { exitCode: number }) => void) => {
+      exitListeners.add(listener);
+      return toDisposable(() => exitListeners.delete(listener));
+    },
+    write,
+    resize,
+    kill,
+  } as unknown as import('node-pty').IPty;
+  return { pty, dataListeners, exitListeners, write, resize, kill };
+}
+
+describe('session terminal lifecycle (live I/O, replay, and retention)', () => {
   let disposables: DisposableStore;
   let ix: TestInstantiationService;
   let host: FakeHostTerminalService;
@@ -194,6 +234,66 @@ describe('SessionTerminalService', () => {
     expect(frames.map((f) => (f as { seq?: number }).seq)).toEqual([2, 3]);
   });
 
+  it('replays only complete output frames within the one MiB retention limit', async () => {
+    const svc = ix.get(ISessionTerminalService);
+    const terminal = await svc.create({});
+    const proc = host.processes[0]!;
+    proc.emitData('a'.repeat(716_800));
+    proc.emitData('b'.repeat(409_600));
+
+    const { sink, frames } = collectSink();
+    const result = await svc.attach(terminal.id, sink);
+
+    expect(result).toEqual({ replayed: 1 });
+    expect(frames).toMatchObject([
+      { type: 'terminal_output', seq: 2, payload: { data: 'b'.repeat(409_600) } },
+    ]);
+    expect(
+      frames.reduce(
+        (bytes, frame) =>
+          bytes +
+          (frame.type === 'terminal_output' ? Buffer.byteLength(frame.payload.data) : 0),
+        0,
+      ),
+    ).toBe(409_600);
+  });
+
+  it('replays the UTF-8 tail of a single oversized output frame', async () => {
+    const svc = ix.get(ISessionTerminalService);
+    const terminal = await svc.create({});
+    const proc = host.processes[0]!;
+    proc.emitData(`prefix${'界'.repeat(349_526)}tails`);
+
+    const { sink, frames } = collectSink();
+    const result = await svc.attach(terminal.id, sink);
+
+    expect(result).toEqual({ replayed: 1 });
+    expect(frames).toHaveLength(1);
+    const replayed = frames[0];
+    expect(replayed).toMatchObject({ type: 'terminal_output', seq: 1 });
+    const data = replayed?.type === 'terminal_output' ? replayed.payload.data : '';
+    expect(data.startsWith('界')).toBe(true);
+    expect(data.endsWith('tails')).toBe(true);
+    expect(
+      replayed?.type === 'terminal_output' ? Buffer.byteLength(replayed.payload.data) : 0,
+    ).toBeLessThanOrEqual(1_048_576);
+  });
+
+  it('streams an oversized output frame without truncating live delivery', async () => {
+    const svc = ix.get(ISessionTerminalService);
+    const terminal = await svc.create({});
+    const proc = host.processes[0]!;
+    const { sink, frames } = collectSink();
+    await svc.attach(terminal.id, sink);
+    const output = `prefix${'界'.repeat(349_526)}tails`;
+
+    proc.emitData(output);
+
+    expect(frames).toMatchObject([
+      { type: 'terminal_output', seq: 1, payload: { data: output } },
+    ]);
+  });
+
   it('emits an exit frame and marks the terminal exited on process exit', async () => {
     const svc = ix.get(ISessionTerminalService);
     const terminal = await svc.create({});
@@ -212,6 +312,65 @@ describe('SessionTerminalService', () => {
     const fetched = await svc.get(terminal.id);
     expect(fetched.status).toBe('exited');
     expect(fetched.exit_code).toBe(7);
+  });
+
+  it('replays retained output and the exit frame after process exit', async () => {
+    const svc = ix.get(ISessionTerminalService);
+    const terminal = await svc.create({});
+    const proc = host.processes[0]!;
+    proc.emitData('tail');
+    proc.emitExit(7);
+
+    const { sink, frames } = collectSink();
+    const result = await svc.attach(terminal.id, sink);
+
+    expect(result).toEqual({ replayed: 2 });
+    expect(frames).toMatchObject([
+      { type: 'terminal_output', seq: 1, payload: { data: 'tail' } },
+      { type: 'terminal_exit', payload: { exit_code: 7 } },
+    ]);
+  });
+
+  it('lists at most 16 exited terminals across three waves', async () => {
+    const svc = ix.get(ISessionTerminalService);
+    const terminalIds: string[] = [];
+    const retainedCounts: number[] = [];
+
+    for (let wave = 0; wave < 3; wave += 1) {
+      for (let index = 0; index < 8; index += 1) {
+        const terminal = await svc.create({});
+        terminalIds.push(terminal.id);
+        const proc = host.processes.at(-1)!;
+        proc.emitData('x'.repeat(65_536));
+        proc.emitExit(0);
+      }
+      retainedCounts.push((await svc.list()).length);
+    }
+
+    expect(retainedCounts).toEqual([8, 16, 16]);
+    expect((await svc.list()).map((terminal) => terminal.id)).toEqual(terminalIds.slice(8));
+  });
+
+  it('evicts exited terminals by exit order rather than creation order', async () => {
+    const svc = ix.get(ISessionTerminalService);
+    const terminals = [];
+    for (let index = 0; index < 17; index += 1) {
+      terminals.push(await svc.create({}));
+    }
+    const exitOrder = [...host.processes.slice(1), host.processes[0]!];
+
+    for (const proc of exitOrder) {
+      proc.emitExit(0);
+    }
+
+    const retained = await svc.list();
+    expect(new Set(retained.map((terminal) => terminal.id))).toEqual(
+      new Set([...terminals.slice(2).map((terminal) => terminal.id), terminals[0]!.id]),
+    );
+    await expect(svc.get(terminals[1]!.id)).rejects.toMatchObject({
+      code: ErrorCodes.TERMINAL_NOT_FOUND,
+    });
+    await expect(svc.get(terminals[0]!.id)).resolves.toMatchObject({ status: 'exited' });
   });
 
   it('delegates write and resize to the process', async () => {
@@ -258,15 +417,26 @@ describe('SessionTerminalService', () => {
     disposables.dispose();
     expect(proc.killed).toBe(true);
   });
+
+  it('does not kill an exited process when the service is disposed', async () => {
+    const svc = ix.get(ISessionTerminalService);
+    await svc.create({});
+    const proc = host.processes[0]!;
+    proc.emitExit(0);
+
+    disposables.dispose();
+
+    expect(proc.killed).toBe(false);
+  });
 });
 
-// Sanity check for the App-scoped OS HostTerminalService.
-describe('HostTerminalService (App scope)', () => {
+describe('host terminal lifecycle (PTY forwarding and App ownership)', () => {
   let disposables: DisposableStore;
   let ix: TestInstantiationService;
 
   beforeEach(() => {
     disposables = new DisposableStore();
+    vi.mocked(spawn).mockReset();
     ix = createServices(disposables, {
       additionalServices: (reg) => {
         reg.define(IHostTerminalService, HostTerminalService);
@@ -276,23 +446,8 @@ describe('HostTerminalService (App scope)', () => {
   afterEach(() => disposables.dispose());
 
   it('spawns a PTY through node-pty and forwards events', async () => {
-    const { spawn } = await import('node-pty');
-    const dataListeners = new Set<(data: string) => void>();
-    const exitListeners = new Set<(event: { exitCode: number }) => void>();
-    const mockPty = {
-      onData: (listener: (data: string) => void) => {
-        dataListeners.add(listener);
-        return toDisposable(() => dataListeners.delete(listener));
-      },
-      onExit: (listener: (event: { exitCode: number }) => void) => {
-        exitListeners.add(listener);
-        return toDisposable(() => exitListeners.delete(listener));
-      },
-      write: vi.fn(),
-      resize: vi.fn(),
-      kill: vi.fn(),
-    };
-    vi.mocked(spawn).mockReturnValue(mockPty as unknown as import('node-pty').IPty);
+    const mockPty = createMockPty();
+    vi.mocked(spawn).mockReturnValue(mockPty.pty);
 
     const svc = ix.get(IHostTerminalService);
     const proc = await svc.spawn({ cwd: '/ws', shell: '/bin/sh', cols: 80, rows: 24 });
@@ -309,14 +464,14 @@ describe('HostTerminalService (App scope)', () => {
     proc.onProcessData((data) => {
       receivedData += data;
     });
-    for (const listener of dataListeners) listener('hello');
+    for (const listener of [...mockPty.dataListeners]) listener('hello');
     expect(receivedData).toBe('hello');
 
     let receivedExit: { exitCode: number | null } | undefined;
     proc.onProcessExit((event) => {
       receivedExit = event;
     });
-    for (const listener of exitListeners) listener({ exitCode: 5 });
+    for (const listener of [...mockPty.exitListeners]) listener({ exitCode: 5 });
     expect(receivedExit).toEqual({ exitCode: 5 });
 
     proc.write('ls\n');
@@ -327,5 +482,26 @@ describe('HostTerminalService (App scope)', () => {
 
     proc.kill();
     expect(mockPty.kill).toHaveBeenCalled();
+  });
+
+  it('releases an exited PTY before App disposal without breaking its listeners', async () => {
+    const mockPty = createMockPty();
+    vi.mocked(spawn).mockReturnValue(mockPty.pty);
+    const svc = ix.get(IHostTerminalService);
+    const proc = await svc.spawn({ cwd: '/ws', shell: '/bin/sh', cols: 80, rows: 24 });
+    const output: string[] = [];
+    let exitCode: number | null | undefined;
+    proc.onProcessData((data) => output.push(data));
+    proc.onProcessExit((event) => {
+      exitCode = event.exitCode;
+    });
+
+    for (const listener of [...mockPty.dataListeners]) listener('complete output');
+    for (const listener of [...mockPty.exitListeners]) listener({ exitCode: 0 });
+    disposables.dispose();
+
+    expect(output).toEqual(['complete output']);
+    expect(exitCode).toBe(0);
+    expect(mockPty.kill).not.toHaveBeenCalled();
   });
 });

--- a/packages/agent-core-v2/test/session/terminal/terminalService.test.ts
+++ b/packages/agent-core-v2/test/session/terminal/terminalService.test.ts
@@ -10,7 +10,6 @@
 
 import { resolve } from 'node:path';
 
-import { spawn } from 'node-pty';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { DisposableStore, toDisposable } from '#/_base/di/lifecycle';
@@ -70,12 +69,14 @@ class FakeHostTerminalService implements IHostTerminalService {
   declare readonly _serviceBrand: undefined;
   readonly processes: FakeTerminalProcess[] = [];
   readonly lastOptions: TerminalSpawnOptions[] = [];
+  spawnGate: Promise<void> | undefined;
 
-  spawn(options: TerminalSpawnOptions): Promise<TerminalProcess> {
+  async spawn(options: TerminalSpawnOptions): Promise<TerminalProcess> {
     this.lastOptions.push(options);
     const proc = new FakeTerminalProcess();
     this.processes.push(proc);
-    return Promise.resolve(proc);
+    await this.spawnGate;
+    return proc;
   }
 }
 
@@ -110,7 +111,15 @@ function collectSink(id = 'sink-1'): { sink: TerminalAttachSink; frames: Termina
   return { sink: { id, send: (frame) => frames.push(frame) }, frames };
 }
 
-function createMockPty(): {
+function deferred<T>(): { readonly promise: Promise<T>; resolve(value: T): void } {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+  return { promise, resolve };
+}
+
+function createMockPty(onExitRegistered?: () => void): {
   readonly pty: import('node-pty').IPty;
   readonly dataListeners: Set<(data: string) => void>;
   readonly exitListeners: Set<(event: { exitCode: number }) => void>;
@@ -130,6 +139,7 @@ function createMockPty(): {
     },
     onExit: (listener: (event: { exitCode: number }) => void) => {
       exitListeners.add(listener);
+      onExitRegistered?.();
       return toDisposable(() => exitListeners.delete(listener));
     },
     write,
@@ -177,6 +187,23 @@ describe('session terminal lifecycle (live I/O, replay, and retention)', () => {
     expect(terminal.cwd).toBe('/ws');
     expect(terminal.cols).toBe(80);
     expect(terminal.rows).toBe(24);
+  });
+
+  it('kills a deferred spawn when it resolves after Session disposal', async () => {
+    const gate = deferred<void>();
+    host.spawnGate = gate.promise;
+    const svc = ix.get(ISessionTerminalService);
+    const pendingCreate = svc.create({});
+    const rejected = expect(pendingCreate).rejects.toMatchObject({
+      code: ErrorCodes.SESSION_CLOSED,
+    });
+
+    disposables.dispose();
+    gate.resolve();
+
+    await rejected;
+    expect(host.processes).toHaveLength(1);
+    expect(host.processes[0]!.killed).toBe(true);
   });
 
   it('lists and gets terminals', async () => {
@@ -433,10 +460,12 @@ describe('session terminal lifecycle (live I/O, replay, and retention)', () => {
 describe('host terminal lifecycle (PTY forwarding and App ownership)', () => {
   let disposables: DisposableStore;
   let ix: TestInstantiationService;
+  let spawnPty: typeof import('node-pty').spawn;
 
-  beforeEach(() => {
+  beforeEach(async () => {
     disposables = new DisposableStore();
-    vi.mocked(spawn).mockReset();
+    ({ spawn: spawnPty } = await import('node-pty'));
+    vi.mocked(spawnPty).mockReset();
     ix = createServices(disposables, {
       additionalServices: (reg) => {
         reg.define(IHostTerminalService, HostTerminalService);
@@ -447,12 +476,12 @@ describe('host terminal lifecycle (PTY forwarding and App ownership)', () => {
 
   it('spawns a PTY through node-pty and forwards events', async () => {
     const mockPty = createMockPty();
-    vi.mocked(spawn).mockReturnValue(mockPty.pty);
+    vi.mocked(spawnPty).mockReturnValue(mockPty.pty);
 
     const svc = ix.get(IHostTerminalService);
     const proc = await svc.spawn({ cwd: '/ws', shell: '/bin/sh', cols: 80, rows: 24 });
 
-    expect(spawn).toHaveBeenCalledWith('/bin/sh', [], {
+    expect(spawnPty).toHaveBeenCalledWith('/bin/sh', [], {
       name: 'xterm-256color',
       cwd: '/ws',
       cols: 80,
@@ -486,7 +515,7 @@ describe('host terminal lifecycle (PTY forwarding and App ownership)', () => {
 
   it('releases an exited PTY before App disposal without breaking its listeners', async () => {
     const mockPty = createMockPty();
-    vi.mocked(spawn).mockReturnValue(mockPty.pty);
+    vi.mocked(spawnPty).mockReturnValue(mockPty.pty);
     const svc = ix.get(IHostTerminalService);
     const proc = await svc.spawn({ cwd: '/ws', shell: '/bin/sh', cols: 80, rows: 24 });
     const output: string[] = [];
@@ -503,5 +532,44 @@ describe('host terminal lifecycle (PTY forwarding and App ownership)', () => {
     expect(output).toEqual(['complete output']);
     expect(exitCode).toBe(0);
     expect(mockPty.kill).not.toHaveBeenCalled();
+  });
+
+  it('rejects a spawn that resumes from import after App disposal', async () => {
+    const svc = ix.get(IHostTerminalService);
+    const pendingSpawn = svc.spawn({ cwd: '/ws', shell: '/bin/sh', cols: 80, rows: 24 });
+    const rejected = expect(pendingSpawn).rejects.toThrow('Host terminal service is disposed');
+
+    disposables.dispose();
+
+    await rejected;
+    expect(spawnPty).not.toHaveBeenCalled();
+  });
+
+  it('kills a PTY created while App disposal interrupts spawn', async () => {
+    const mockPty = createMockPty();
+    vi.mocked(spawnPty).mockImplementation(() => {
+      disposables.dispose();
+      return mockPty.pty;
+    });
+    const svc = ix.get(IHostTerminalService);
+
+    await expect(
+      svc.spawn({ cwd: '/ws', shell: '/bin/sh', cols: 80, rows: 24 }),
+    ).rejects.toThrow('Host terminal service is disposed');
+
+    expect(mockPty.kill).toHaveBeenCalledTimes(1);
+  });
+
+  it('rejects a PTY when App disposal interrupts exit-listener registration', async () => {
+    const mockPty = createMockPty(() => disposables.dispose());
+    vi.mocked(spawnPty).mockReturnValue(mockPty.pty);
+    const svc = ix.get(IHostTerminalService);
+
+    await expect(
+      svc.spawn({ cwd: '/ws', shell: '/bin/sh', cols: 80, rows: 24 }),
+    ).rejects.toThrow('Host terminal service is disposed');
+
+    expect(mockPty.kill).toHaveBeenCalledTimes(1);
+    expect(mockPty.exitListeners.size).toBe(0);
   });
 });


### PR DESCRIPTION
## Related Issue

No linked issue. This is a focused follow-up from the long-running session resource audit.

## Problem

The Session-scoped terminal owner retained output by frame count only, so one PTY data frame could retain an arbitrary amount of memory. It also kept every exited terminal record, its replay buffer, and attached sinks until the whole Session scope was disposed.

Separately, the App-scoped PTY owner kept wrappers for processes that had already emitted their exit event. A public lifecycle reproduction showed that output and exit listeners completed normally, but App disposal still tried to kill the already-exited PTY.

Both owners also had an asynchronous teardown window: Session disposal could happen while host spawn was pending, and App disposal could happen while the lazy PTY import or process/listener registration was pending. The continuation could otherwise publish and return a process after its owner had already been destroyed.

The deterministic baseline reproduced these growth paths without an RSS threshold:

- `700 KiB + 400 KiB` of output replayed both frames (`1.1 MiB`) instead of a bounded tail;
- one oversized UTF-8 frame remained larger than `1 MiB`;
- three waves of eight exited terminals grew the retained owner count as `[8, 16, 24]`;
- an exited PTY was killed again during later App disposal.

## What changed

- Bound each terminal's retained replay payload to `1 MiB` of UTF-8 output. Whole older frames are evicted first; if one frame alone exceeds the limit, replay keeps a code-point-safe suffix while live sinks still receive the original frame unchanged.
- Keep only the latest 16 exited terminal records by actual exit order. Running terminals are never capacity-evicted. Exit remains observable and replayable before attached sinks are released, and late replay does not retain a new sink.
- Kill only running PTYs during Session disposal, so already-exited processes are not killed again.
- Release the App owner's PTY wrapper and its own exit subscription after a real process exit without disposing the returned process handle or its consumer output/exit listeners.
- Reject late Session/App spawns after disposal. A process that has already been created is killed best-effort and its listeners are released before the pending call rejects; it is never inserted into an owner map or returned.

The low-wave resource contract now plateaus at `[8, 16, 16]` exited owners across `3 x 8` cycles. Tests assert owner counts and replay bytes rather than an absolute RSS value.

Validation:

- `pnpm --filter @moonshot-ai/agent-core-v2 exec vitest run test/session/terminal/terminalService.test.ts --pool=forks --maxWorkers=1` — 1 file, 24 tests passed
- `pnpm --filter @moonshot-ai/agent-core-v2 typecheck`
- `pnpm --filter @moonshot-ai/agent-core-v2 lint:domain` — 848 files passed
- targeted `oxlint` — 0 warnings, 0 errors
- `git diff --check`
- `pnpm changeset status --since=origin/main` — `@moonshot-ai/kimi-code` patch
- fixed-diff review and public/internal-identifier audit — no findings

`gen-docs` stopped at its required prerequisite check because the current `main` does not contain `docs/scripts/sync-changelog.mjs`. There is no terminal API page to update, so this PR does not add unrelated documentation or tooling.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.
