### PR TITLE
fix: prevent startup sessions from losing tools

### DIFF
--- a/.changeset/fix-startup-tool-catalog-race.md
+++ b/.changeset/fix-startup-tool-catalog-race.md
@@ -1,0 +1,9 @@
+---
+"@moonshot-ai/kimi-code": patch
+"@moonshot-ai/kimi-code-sdk": patch
+"@moonshot-ai/agent-core": patch
+"@moonshot-ai/agent-core-v2": patch
+"@moonshot-ai/kimi-code-oauth": patch
+---
+
+Fix startup races that could leave sessions without their configured tools by serializing configuration writes and atomically replacing provider and model catalogs.

--- a/apps/kimi-code/src/tui/controllers/auth-flow.ts
+++ b/apps/kimi-code/src/tui/controllers/auth-flow.ts
@@ -172,6 +172,8 @@ export class AuthFlowController {
         getConfig: () => host.harness.getConfig({ reload: true }),
         removeProvider: (id) => host.harness.removeProvider(id),
         setConfig: (patch) => host.harness.setConfig(patch),
+        replaceModelCatalog: (expected, next) =>
+          host.harness.replaceModelCatalog(expected, next),
         resolveOAuthToken: async (providerName, oauthRef) => {
           const tokenProvider = host.harness.auth.resolveOAuthTokenProvider(providerName, oauthRef);
           return tokenProvider.getAccessToken();

--- a/apps/kimi-code/src/tui/kimi-tui.ts
+++ b/apps/kimi-code/src/tui/kimi-tui.ts
@@ -301,6 +301,7 @@ export class KimiTUI {
   private readonly imageStore = new ImageAttachmentStore();
   private fdPath: string | null = detectFdPath();
   private fdDownloadStarted = false;
+  private providerModelsRefreshStarted = false;
   sessionEventUnsubscribe: (() => void) | undefined;
   cancelInFlight: (() => void) | undefined;
   deferUserMessages = false;
@@ -652,6 +653,8 @@ export class KimiTUI {
   }
 
   private async refreshProviderModelsInBackground(): Promise<void> {
+    if (this.providerModelsRefreshStarted) return;
+    this.providerModelsRefreshStarted = true;
     try {
       const result = await this.authFlow.refreshProviderModels();
       for (const c of result.changed) {
@@ -718,7 +721,6 @@ export class KimiTUI {
   private async init(): Promise<boolean> {
     setExperimentalFeatures(await this.harness.getExperimentalFeatures());
     await this.authFlow.refreshAvailableModels();
-    void this.refreshProviderModelsInBackground();
 
     const { startup } = this.options;
     const { workDir } = this.state.appState;
@@ -807,7 +809,7 @@ export class KimiTUI {
     await this.setSession(session);
     await this.syncRuntimeState(session);
     this.applyStartupPermissionAndPlanToAppState();
-    this.state.startupState = 'ready';
+    this.setStartupReady();
     return shouldReplayHistory;
   }
 
@@ -1389,6 +1391,9 @@ export class KimiTUI {
 
   setStartupReady(): void {
     this.state.startupState = 'ready';
+    if (this.session !== undefined) {
+      void this.refreshProviderModelsInBackground();
+    }
   }
 
   clearQueuedMessages(): void {
@@ -1536,6 +1541,9 @@ export class KimiTUI {
       goal: goalResult.goal,
     });
     this.syncAdditionalDirs(session);
+    if (this.state.startupState === 'ready') {
+      void this.refreshProviderModelsInBackground();
+    }
   }
 
   // Apply --auto/--yolo/--plan startup flags to a resumed session. The resumed
@@ -2891,6 +2899,7 @@ export class KimiTUI {
     if (applyStartupModes) {
       await this.applyStartupModesToResumedSession(this.requireSession());
       this.applyStartupPermissionAndPlanToAppState();
+      this.setStartupReady();
     }
     this.hideSessionPicker();
   }

--- a/apps/kimi-code/src/tui/utils/refresh-providers.ts
+++ b/apps/kimi-code/src/tui/utils/refresh-providers.ts
@@ -5,7 +5,12 @@ import {
   type RefreshProviderScope,
   type RefreshResult,
 } from '@moonshot-ai/kimi-code-oauth';
-import type { KimiConfig, KimiConfigPatch, OAuthRef } from '@moonshot-ai/kimi-code-sdk';
+import type {
+  KimiConfig,
+  KimiConfigPatch,
+  KimiModelCatalogSnapshot,
+  OAuthRef,
+} from '@moonshot-ai/kimi-code-sdk';
 
 /**
  * CLI-side host for provider-model refresh. Kept on the SDK's full config types
@@ -16,6 +21,10 @@ export interface RefreshProviderHost {
   getConfig(): Promise<KimiConfig>;
   removeProvider(providerId: string): Promise<KimiConfig>;
   setConfig(patch: KimiConfigPatch): Promise<KimiConfig>;
+  replaceModelCatalog?(
+    expected: KimiModelCatalogSnapshot,
+    next: KimiModelCatalogSnapshot,
+  ): Promise<KimiConfig>;
   resolveOAuthToken(providerName: string, oauthRef?: OAuthRef): Promise<string>;
   /** Product User-Agent sent on custom-registry (api.json) fetches. */
   readonly userAgent?: string;
@@ -37,6 +46,14 @@ export async function refreshAllProviderModels(
       getConfig: () => host.getConfig(),
       removeProvider: (providerId) => host.removeProvider(providerId),
       setConfig: (patch) => host.setConfig(patch as unknown as KimiConfigPatch),
+      replaceModelCatalog:
+        host.replaceModelCatalog === undefined
+          ? undefined
+          : (expected, next) =>
+              host.replaceModelCatalog!(
+                expected as unknown as KimiModelCatalogSnapshot,
+                next as unknown as KimiModelCatalogSnapshot,
+              ),
       resolveOAuthToken: (providerName, oauthRef) =>
         host.resolveOAuthToken(providerName, oauthRef as unknown as OAuthRef),
       userAgent: host.userAgent,

--- a/apps/kimi-code/test/tui/kimi-tui-startup.test.ts
+++ b/apps/kimi-code/test/tui/kimi-tui-startup.test.ts
@@ -1,8 +1,14 @@
+/**
+ * Startup scenarios: session activation, OAuth recovery, and provider refresh ordering.
+ * Wiring: real KimiTUI orchestration with SDK/session and network boundaries stubbed.
+ * Run: pnpm --filter @moonshot-ai/kimi-code exec vitest run test/tui/kimi-tui-startup.test.ts
+ */
+
 import { mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
-import { log, type GoalSnapshot } from '@moonshot-ai/kimi-code-sdk';
+import { log, type GoalSnapshot, type KimiConfig } from '@moonshot-ai/kimi-code-sdk';
 import type { MigrationPlan } from '@moonshot-ai/migration-legacy';
 import { describe, expect, it, vi } from 'vitest';
 
@@ -191,6 +197,7 @@ function loginRequiredError(): Error & { readonly code: string } {
 function makeHarness(session = makeSession(), overrides: Record<string, unknown> = {}) {
   return {
     getConfig: vi.fn(async () => ({
+      providers: {},
       models: {
         k2: { model: 'moonshot-v1', maxContextSize: 100 },
       },
@@ -217,6 +224,64 @@ function makeDriver(harness: ReturnType<typeof makeHarness>, input: KimiTUIStart
   vi.spyOn(driver.state.ui, 'requestRender').mockImplementation(() => {});
   vi.spyOn(driver.state.terminal, 'setProgress').mockImplementation(() => {});
   return driver;
+}
+
+function deferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  const promise = new Promise<T>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+  return { promise, resolve };
+}
+
+type RuntimeStatus = Awaited<ReturnType<ReturnType<typeof makeSession>['getStatus']>>;
+
+const DEFAULT_RUNTIME_STATUS: RuntimeStatus = {
+  model: 'k2',
+  thinkingEffort: 'off',
+  permission: 'manual',
+  planMode: false,
+  contextTokens: 10,
+  maxContextTokens: 100,
+  contextUsage: 0.1,
+};
+
+function gateRuntimeStatus() {
+  const requested = deferred<void>();
+  const result = deferred<RuntimeStatus>();
+  const getStatus = vi.fn(() => {
+    requested.resolve();
+    return result.promise;
+  });
+  return {
+    getStatus,
+    requested: requested.promise,
+    resolve: () => {
+      result.resolve(DEFAULT_RUNTIME_STATUS);
+    },
+  };
+}
+
+function gateConfigRead(
+  readNumber: number,
+  config: KimiConfig = {
+    providers: {},
+    models: {
+      k2: { provider: 'kimi', model: 'moonshot-v1', maxContextSize: 100 },
+    },
+  },
+) {
+  const reached = deferred<void>();
+  let reads = 0;
+  const getConfig = vi.fn(async () => {
+    reads++;
+    if (reads === readNumber) reached.resolve();
+    return config;
+  });
+  return {
+    getConfig,
+    reached: reached.promise,
+  };
 }
 
 type InputListener = Parameters<TUIState['ui']['addInputListener']>[0];
@@ -277,6 +342,26 @@ describe('KimiTUI startup', () => {
     });
   });
 
+  it('starts provider refresh in the background only after a fresh session is runtime-ready', async () => {
+    const runtimeStatus = gateRuntimeStatus();
+    const session = makeSession({ getStatus: runtimeStatus.getStatus });
+    const configRead = gateConfigRead(2);
+    const harness = makeHarness(session, { getConfig: configRead.getConfig });
+    const driver = makeDriver(harness, makeStartupInput());
+
+    const init = driver.init();
+    await runtimeStatus.requested;
+
+    expect(configRead.getConfig).toHaveBeenCalledOnce();
+
+    runtimeStatus.resolve();
+    await expect(init).resolves.toBe(false);
+    await configRead.reached;
+
+    expect(driver.state.startupState).toBe('ready');
+    expect(configRead.getConfig).toHaveBeenCalledTimes(2);
+  });
+
   it('resumes the latest session for --continue and marks history for replay', async () => {
     const session = makeSession({ id: 'ses-latest' });
     const harness = makeHarness(session, {
@@ -290,6 +375,32 @@ describe('KimiTUI startup', () => {
     expect(harness.createSession).not.toHaveBeenCalled();
     expect(driver.state.startupState).toBe('ready');
     expect(driver.state.appState.sessionId).toBe('ses-latest');
+  });
+
+  it('starts provider refresh in the background only after a resumed session is runtime-ready', async () => {
+    const runtimeStatus = gateRuntimeStatus();
+    const session = makeSession({
+      id: 'ses-latest',
+      getStatus: runtimeStatus.getStatus,
+    });
+    const configRead = gateConfigRead(2);
+    const harness = makeHarness(session, {
+      getConfig: configRead.getConfig,
+      listSessions: vi.fn(async () => [{ id: 'ses-latest' }]),
+    });
+    const driver = makeDriver(harness, makeStartupInput({ continue: true }));
+
+    const init = driver.init();
+    await runtimeStatus.requested;
+
+    expect(configRead.getConfig).toHaveBeenCalledOnce();
+
+    runtimeStatus.resolve();
+    await expect(init).resolves.toBe(true);
+    await configRead.reached;
+
+    expect(driver.state.startupState).toBe('ready');
+    expect(configRead.getConfig).toHaveBeenCalledTimes(2);
   });
 
   it('applies --auto permission when resuming a session via --continue', async () => {
@@ -624,6 +735,50 @@ describe('KimiTUI startup', () => {
     expect(harness.createSession).not.toHaveBeenCalled();
     expect(harness.resumeSession).not.toHaveBeenCalled();
     expect(driver.state.startupState).toBe('picker');
+  });
+
+  it('starts provider refresh only after a bare-session picker activates its selection', async () => {
+    const pickedSession = makeSession({ id: 'ses-picked' });
+    const resumeRequested = deferred<void>();
+    const resumedSession = deferred<typeof pickedSession>();
+    const configRead = gateConfigRead(2);
+    const harness = makeHarness(pickedSession, {
+      getConfig: configRead.getConfig,
+      listSessions: vi.fn(async () => [
+        {
+          id: 'ses-picked',
+          title: 'Picked session',
+          workDir: '/tmp/proj-a',
+          updatedAt: Date.now(),
+        },
+      ]),
+      resumeSession: vi.fn(() => {
+        resumeRequested.resolve();
+        return resumedSession.promise;
+      }),
+    });
+    const driver = makeDriver(harness, makeStartupInput({ session: '' }));
+
+    await expect(
+      (driver as unknown as { initMainTui(): Promise<boolean> }).initMainTui(),
+    ).resolves.toBe(false);
+    await (driver as unknown as { bootstrapFromPicker(): Promise<void> }).bootstrapFromPicker();
+
+    expect(driver.state.startupState).toBe('picker');
+    expect(configRead.getConfig).toHaveBeenCalledOnce();
+
+    const picker = driver.state.editorContainer.children[0] as { handleInput(data: string): void };
+    picker.handleInput('\r');
+    await resumeRequested.promise;
+
+    expect(configRead.getConfig).toHaveBeenCalledOnce();
+
+    resumedSession.resolve(pickedSession);
+    await configRead.reached;
+
+    expect(driver.state.startupState).toBe('ready');
+    expect(driver.state.appState.sessionId).toBe('ses-picked');
+    expect(configRead.getConfig).toHaveBeenCalledTimes(2);
   });
 
   it('applies --auto after picking a session from bare --session', async () => {
@@ -1115,6 +1270,17 @@ describe('KimiTUI startup', () => {
     expect(showStatus).toHaveBeenCalledWith("New Models · +2 models.");
   });
 
+  it('does not restart provider refresh during later runtime synchronization', async () => {
+    const session = makeSession();
+    const harness = makeHarness(session);
+    const driver = makeDriver(harness, makeStartupInput());
+
+    await expect(driver.init()).resolves.toBe(false);
+    await (driver as unknown as KimiTUI).syncRuntimeState(session as never);
+
+    expect(harness.getConfig).toHaveBeenCalledTimes(2);
+  });
+
   it("starts TUI without a session when fresh startup needs OAuth login", async () => {
     const harness = makeHarness(makeSession(), {
       createSession: vi.fn(async () => {
@@ -1136,6 +1302,47 @@ describe('KimiTUI startup', () => {
       contextUsage: 0,
       sessionTitle: null,
     });
+  });
+
+  it('starts provider refresh after an OAuth-recovered session is runtime-ready', async () => {
+    const runtimeStatus = gateRuntimeStatus();
+    const session = makeSession({ getStatus: runtimeStatus.getStatus });
+    const createSession = vi
+      .fn()
+      .mockRejectedValueOnce(loginRequiredError())
+      .mockResolvedValueOnce(session);
+    const configRead = gateConfigRead(3, {
+      providers: {},
+      defaultModel: 'k2',
+      thinking: { enabled: false },
+      models: {
+        k2: { provider: 'kimi', model: 'moonshot-v1', maxContextSize: 100 },
+      },
+    });
+    const harness = makeHarness(session, {
+      getConfig: configRead.getConfig,
+      createSession,
+    });
+    const driver = makeDriver(harness, makeStartupInput());
+
+    await expect(driver.init()).resolves.toBe(false);
+    expect(configRead.getConfig).toHaveBeenCalledOnce();
+
+    vi.mocked(promptPlatformSelection).mockResolvedValue('kimi-code');
+    const login = handleLoginCommand(
+      driver as unknown as Parameters<typeof handleLoginCommand>[0],
+    );
+    await runtimeStatus.requested;
+
+    expect(configRead.getConfig).toHaveBeenCalledTimes(2);
+
+    runtimeStatus.resolve();
+    await login;
+    await configRead.reached;
+
+    expect(driver.state.startupState).toBe('ready');
+    expect(driver.state.appState.sessionId).toBe('ses-1');
+    expect(configRead.getConfig).toHaveBeenCalledTimes(3);
   });
 
   it('preserves fresh startup yolo and plan intent after OAuth login', async () => {

--- a/apps/kimi-code/test/tui/utils/refresh-providers.test.ts
+++ b/apps/kimi-code/test/tui/utils/refresh-providers.test.ts
@@ -1,3 +1,11 @@
+/**
+ * Provider-model refresh scenarios: remote catalogs are fetched at the network
+ * boundary and persisted through either the atomic catalog host contract or its
+ * legacy remove/set fallback.
+ * Wiring: real shared refresh orchestration with fetch and persistence boundaries stubbed.
+ * Run: pnpm --filter @moonshot-ai/kimi-code exec vitest run test/tui/utils/refresh-providers.test.ts
+ */
+
 import {
   KIMI_CODE_PROVIDER_NAME,
   resolveKimiCodeOAuthKey,
@@ -6,7 +14,7 @@ import {
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { refreshAllProviderModels } from '../../../src/tui/utils/refresh-providers';
-import type { KimiConfig } from '@moonshot-ai/kimi-code-sdk';
+import type { KimiConfig, KimiModelCatalogSnapshot } from '@moonshot-ai/kimi-code-sdk';
 
 type FetchMock = (
   input: Parameters<typeof fetch>[0],
@@ -23,6 +31,14 @@ function makeRefreshHost(initial: KimiConfig): {
   current: () => KimiConfig;
   removeProvider: ReturnType<typeof vi.fn<(providerId: string) => Promise<KimiConfig>>>;
   setConfig: ReturnType<typeof vi.fn<(patch: Partial<KimiConfig>) => Promise<KimiConfig>>>;
+  replaceModelCatalog: ReturnType<
+    typeof vi.fn<
+      (
+        expected: KimiModelCatalogSnapshot,
+        next: KimiModelCatalogSnapshot,
+      ) => Promise<KimiConfig>
+    >
+  >;
 } {
   let persisted = structuredClone(initial);
   const removeProvider = vi.fn(async (providerId: string) => {
@@ -43,10 +59,17 @@ function makeRefreshHost(initial: KimiConfig): {
     persisted = { ...persisted, ...patch };
     return structuredClone(persisted);
   });
+  const replaceModelCatalog = vi.fn(
+    async (_expected: KimiModelCatalogSnapshot, next: KimiModelCatalogSnapshot) => {
+      persisted = { ...persisted, ...next };
+      return structuredClone(persisted);
+    },
+  );
   return {
     current: () => structuredClone(persisted),
     removeProvider,
     setConfig,
+    replaceModelCatalog,
   };
 }
 
@@ -126,7 +149,7 @@ describe('refreshAllProviderModels', () => {
     expect(resolveOAuthToken).toHaveBeenCalledWith(KIMI_CODE_PROVIDER_NAME, envOauthRef);
   });
 
-  it('can refresh only the managed OAuth provider without fetching third-party registries', async () => {
+  it('persists a scoped OAuth refresh through one atomic catalog replacement', async () => {
     const baseUrl = 'https://api.example.test/coding/v1';
     const registryUrl = 'https://registry.example.test/v1/models/api.json';
     const config: KimiConfig = {
@@ -192,6 +215,7 @@ describe('refreshAllProviderModels', () => {
         getConfig: async () => host.current(),
         removeProvider: host.removeProvider,
         setConfig: host.setConfig,
+        replaceModelCatalog: host.replaceModelCatalog,
         resolveOAuthToken,
       },
       { scope: 'oauth' },
@@ -208,6 +232,9 @@ describe('refreshAllProviderModels', () => {
     ]);
     expect(result.unchanged).toEqual([]);
     expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(host.replaceModelCatalog).toHaveBeenCalledOnce();
+    expect(host.removeProvider).not.toHaveBeenCalled();
+    expect(host.setConfig).not.toHaveBeenCalled();
     expect(host.current().models?.['kimi-code/kimi-for-coding']?.displayName).toBe('Fresh Kimi');
     expect(host.current().models?.['custom/m1']?.displayName).toBe('Custom M1');
   });

--- a/packages/agent-core-v2/src/app/auth/authService.ts
+++ b/packages/agent-core-v2/src/app/auth/authService.ts
@@ -78,6 +78,7 @@ import {
 const TERMINAL_RETENTION_MS = 5 * 60 * 1000;
 const DEFAULT_DEVICE_EXPIRES_IN_SEC = 15 * 60;
 const DEFAULT_MODEL_SECTION = 'defaultModel';
+const DEFAULT_PROVIDER_SECTION = 'defaultProvider';
 const THINKING_SECTION = 'thinking';
 const SERVICES_SECTION = 'services';
 
@@ -94,6 +95,15 @@ interface FlowState {
   gcTimer: ReturnType<typeof setTimeout> | undefined;
   errorMessage: string | undefined;
   resolvedAt: string | undefined;
+}
+
+interface ManagedKimiUserConfigSnapshot {
+  readonly providers: ManagedKimiConfigShape['providers'] | undefined;
+  readonly models: ManagedKimiConfigShape['models'];
+  readonly services: ManagedKimiConfigShape['services'];
+  readonly defaultProvider: string | undefined;
+  readonly defaultModel: string | undefined;
+  readonly thinking: ManagedKimiConfigShape['thinking'];
 }
 
 export class OAuthService extends Disposable implements IOAuthService {
@@ -285,7 +295,8 @@ export class OAuthService extends Disposable implements IOAuthService {
     const failed: RefreshOAuthProviderModelsResponse['failed'] = [];
 
     await this.config.reload();
-    const current = this.readUserConfigShape();
+    const expected = this.readUserConfigSnapshot();
+    const current = this.toManagedKimiConfigShape(expected);
     const provider = current.providers[KIMI_CODE_PROVIDER_NAME];
     if (!isKimiOAuthProvider(provider)) {
       return { changed, unchanged, failed };
@@ -337,10 +348,24 @@ export class OAuthService extends Disposable implements IOAuthService {
           collectModelIdsForAliases(current, refreshedAliasKeys),
           collectModelIdsForAliases(next, refreshedAliasKeys),
         );
-        await this.config.replace(PROVIDERS_SECTION, next.providers);
-        await this.config.replace(MODELS_SECTION, next.models ?? {});
-        await this.config.set(DEFAULT_MODEL_SECTION, next.defaultModel);
-        await this.config.set(THINKING_SECTION, next.thinking);
+        await this.config.replaceMany(
+          {
+            [PROVIDERS_SECTION]: next.providers,
+            [MODELS_SECTION]: next.models,
+            [DEFAULT_PROVIDER_SECTION]: next.defaultProvider,
+            [DEFAULT_MODEL_SECTION]: next.defaultModel,
+            [THINKING_SECTION]: next.thinking,
+          },
+          {
+            expected: {
+              [PROVIDERS_SECTION]: expected.providers,
+              [MODELS_SECTION]: expected.models,
+              [DEFAULT_PROVIDER_SECTION]: expected.defaultProvider,
+              [DEFAULT_MODEL_SECTION]: expected.defaultModel,
+              [THINKING_SECTION]: expected.thinking,
+            },
+          },
+        );
         changed.push({
           provider_id: KIMI_CODE_PROVIDER_NAME,
           provider_name: 'Kimi Code',
@@ -362,21 +387,42 @@ export class OAuthService extends Disposable implements IOAuthService {
     return result;
   }
 
-  private readUserConfigShape(): ManagedKimiConfigShape {
+  private readUserConfigSnapshot(): ManagedKimiUserConfigSnapshot {
     const providers =
-      this.config.inspect<Record<string, ProviderConfig>>(PROVIDERS_SECTION).userValue ?? {};
-    const models = this.config.inspect<Record<string, ModelAlias>>(MODELS_SECTION).userValue ?? {};
+      this.config.inspect<Record<string, ProviderConfig>>(PROVIDERS_SECTION).userValue;
+    const models = this.config.inspect<Record<string, ModelAlias>>(MODELS_SECTION).userValue;
     const services =
       this.config.inspect<ManagedKimiConfigShape['services']>(SERVICES_SECTION).userValue;
+    const defaultProvider = this.config.inspect<string>(DEFAULT_PROVIDER_SECTION).userValue;
     const defaultModel = this.config.inspect<string>(DEFAULT_MODEL_SECTION).userValue;
     const thinking =
       this.config.inspect<ManagedKimiConfigShape['thinking']>(THINKING_SECTION).userValue;
     return {
-      providers: { ...providers } as ManagedKimiConfigShape['providers'],
-      models: { ...models } as ManagedKimiConfigShape['models'],
+      providers:
+        providers === undefined
+          ? undefined
+          : ({ ...providers } as ManagedKimiConfigShape['providers']),
+      models:
+        models === undefined
+          ? undefined
+          : ({ ...models } as ManagedKimiConfigShape['models']),
       services: services === undefined ? undefined : { ...services },
+      defaultProvider,
       defaultModel,
       thinking: thinking === undefined ? undefined : { ...thinking },
+    };
+  }
+
+  private toManagedKimiConfigShape(
+    snapshot: ManagedKimiUserConfigSnapshot,
+  ): ManagedKimiConfigShape {
+    return {
+      providers: snapshot.providers ?? {},
+      models: snapshot.models,
+      services: snapshot.services,
+      defaultProvider: snapshot.defaultProvider,
+      defaultModel: snapshot.defaultModel,
+      thinking: snapshot.thinking,
     };
   }
 
@@ -521,32 +567,46 @@ export class OAuthService extends Disposable implements IOAuthService {
 
   private async deprovisionProvider(provider: string): Promise<void> {
     if (provider !== KIMI_CODE_PROVIDER_NAME) return;
-    const next = structuredClone(this.readUserConfigShape());
+    const expected = this.readUserConfigSnapshot();
+    const current = this.toManagedKimiConfigShape(expected);
+    const next = structuredClone(current);
     const cleanup = clearManagedKimiCodeConfig(next);
+    const defaultProviderCleared = current.defaultProvider === KIMI_CODE_PROVIDER_NAME;
+    if (defaultProviderCleared) {
+      next.defaultProvider = undefined;
+    }
     if (
       !cleanup.removedProvider &&
       cleanup.removedModels.length === 0 &&
       !cleanup.defaultModelCleared &&
-      cleanup.removedServices.length === 0
+      cleanup.removedServices.length === 0 &&
+      !defaultProviderCleared
     ) {
       return;
     }
     if (cleanup.defaultModelCleared) {
       next.thinking = undefined;
     }
-    if (cleanup.removedProvider) {
-      await this.config.replace(PROVIDERS_SECTION, next.providers);
-    }
-    if (cleanup.removedModels.length > 0) {
-      await this.config.replace(MODELS_SECTION, next.models ?? {});
-    }
-    if (cleanup.removedServices.length > 0) {
-      await this.config.replace(SERVICES_SECTION, next.services);
-    }
-    if (cleanup.defaultModelCleared) {
-      await this.config.set(DEFAULT_MODEL_SECTION, undefined);
-      await this.config.set(THINKING_SECTION, undefined);
-    }
+    await this.config.replaceMany(
+      {
+        [PROVIDERS_SECTION]: next.providers,
+        [MODELS_SECTION]: next.models,
+        [SERVICES_SECTION]: next.services,
+        [DEFAULT_PROVIDER_SECTION]: next.defaultProvider,
+        [DEFAULT_MODEL_SECTION]: next.defaultModel,
+        [THINKING_SECTION]: next.thinking,
+      },
+      {
+        expected: {
+          [PROVIDERS_SECTION]: expected.providers,
+          [MODELS_SECTION]: expected.models,
+          [SERVICES_SECTION]: expected.services,
+          [DEFAULT_PROVIDER_SECTION]: expected.defaultProvider,
+          [DEFAULT_MODEL_SECTION]: expected.defaultModel,
+          [THINKING_SECTION]: expected.thinking,
+        },
+      },
+    );
   }
 
   private handleFailure(state: FlowState, err: unknown): void {

--- a/packages/agent-core-v2/src/app/config/config.ts
+++ b/packages/agent-core-v2/src/app/config/config.ts
@@ -4,10 +4,12 @@
  * Defines the config service identifiers and section models: the
  * `IConfigRegistry` for section schemas, and the App-scoped `IConfigService`
  * that resolves a value by precedence across layers (defaults → user config →
- * per-run memory overrides) and writes through a `ConfigTarget`. Owners react
- * to edits through two change events — `onDidChangeConfiguration` (a domain was touched) and
- * `onDidSectionChange` (the delivered value actually changed, deep-diffed) —
- * each carrying the delivered `value` and `previousValue`.
+ * per-run memory overrides), writes through a `ConfigTarget`, and atomically
+ * replaces multiple sections with optional compare-and-swap protection. Owners
+ * react to edits through two change events — `onDidChangeConfiguration` (a
+ * domain was touched) and `onDidSectionChange` (the delivered value actually
+ * changed, deep-diffed) — each carrying the delivered `value` and
+ * `previousValue`.
  */
 
 import type { Event } from '#/_base/event';
@@ -144,6 +146,10 @@ export interface ConfigInspectValue<T = unknown> {
   readonly memoryValue: T | undefined;
 }
 
+export interface ConfigReplaceManyOptions {
+  readonly expected?: Readonly<Record<string, unknown>>;
+}
+
 export interface IConfigService {
   readonly _serviceBrand: undefined;
 
@@ -155,6 +161,10 @@ export interface IConfigService {
   getAll(): ResolvedConfig;
   set(domain: string, patch: unknown, target?: ConfigTarget): Promise<void>;
   replace(domain: string, value: unknown, target?: ConfigTarget): Promise<void>;
+  replaceMany(
+    replacements: Readonly<Record<string, unknown>>,
+    options?: ConfigReplaceManyOptions,
+  ): Promise<void>;
   reload(): Promise<void>;
   diagnostics(): readonly ConfigDiagnostic[];
 }

--- a/packages/agent-core-v2/src/app/config/configService.ts
+++ b/packages/agent-core-v2/src/app/config/configService.ts
@@ -11,8 +11,10 @@
  * `onDidSectionChange`. Reads config paths and the environment overlay through
  * `bootstrap`, persists the TOML document through the `storage` TOML
  * atomic-document store (reloading when the document changes on disk), and logs
- * through `log`. Late section / overlay registration re-validates the
- * already-loaded raw value and re-runs overlays. Bound at App scope.
+ * through `log`. Multi-section replacements validate and persist as one
+ * compare-and-swap state transition. Late section / overlay registration
+ * re-validates the already-loaded raw value and re-runs overlays. Bound at App
+ * scope.
  */
 
 import { InstantiationType } from '#/_base/di/extensions';
@@ -21,6 +23,7 @@ import { LifecycleScope, registerScopedService } from '#/_base/di/scope';
 import { Emitter, type Event } from '#/_base/event';
 import { IBootstrapService } from '#/app/bootstrap/bootstrap';
 import { ILogService } from '#/_base/log/log';
+import { Error2, ErrorCodes } from '#/errors';
 import {
   IAtomicTomlDocumentStore,
   type IAtomicDocumentStore,
@@ -35,6 +38,7 @@ import {
   type ConfigInspectValue,
   type ConfigMerge,
   type ConfigOverlayRegisteredEvent,
+  type ConfigReplaceManyOptions,
   type ConfigSchema,
   type ConfigSection,
   type ConfigSectionRegisteredEvent,
@@ -389,6 +393,46 @@ export class ConfigService extends Disposable implements IConfigService {
       }
       await this.persist(domain);
       this.rebuildEffective('set', [domain]);
+    });
+  }
+
+  async replaceMany(
+    replacements: Readonly<Record<string, unknown>>,
+    options: ConfigReplaceManyOptions = {},
+  ): Promise<void> {
+    await this.ready;
+    const domains = Object.keys(replacements);
+    if (domains.length === 0) return;
+
+    await this.enqueueStateTransition(async () => {
+      const current = this.raw;
+      for (const [domain, expected] of Object.entries(options.expected ?? {})) {
+        if (!deepEqual(current[domain], expected)) {
+          throw new Error2(
+            ErrorCodes.CONFIG_INVALID,
+            'Configuration changed before the batched replacement could be applied.',
+          );
+        }
+      }
+
+      const next: ResolvedConfig = { ...current };
+      for (const [domain, value] of Object.entries(replacements)) {
+        const stripped = this.stripEnv(domain, value);
+        if (stripped === undefined) {
+          delete next[domain];
+        } else {
+          next[domain] = this.registry.validate(domain, stripped);
+        }
+      }
+
+      const nextRawSnake = cloneRecord(this.rawSnake);
+      for (const domain of domains) {
+        applySectionToToml(nextRawSnake, domain, next[domain], this.registry);
+      }
+      await this.documentStore.set(CONFIG_SCOPE, this.configKey, nextRawSnake);
+      this.raw = next;
+      this.rawSnake = nextRawSnake;
+      this.rebuildEffective('set', domains);
     });
   }
 

--- a/packages/agent-core-v2/src/app/modelCatalog/modelCatalogService.ts
+++ b/packages/agent-core-v2/src/app/modelCatalog/modelCatalogService.ts
@@ -14,6 +14,7 @@
 import {
   refreshProviderModels,
   type ManagedKimiConfigShape,
+  type ManagedKimiModelCatalogSnapshot,
   type ManagedKimiOAuthRef,
   type RefreshProviderHost,
   type RefreshResult,
@@ -49,6 +50,7 @@ import {
 } from './modelCatalog';
 
 const DEFAULT_MODEL_SECTION = 'defaultModel';
+const DEFAULT_PROVIDER_SECTION = 'defaultProvider';
 const THINKING_SECTION = 'thinking';
 
 export class ModelCatalogService implements IModelCatalogService {
@@ -152,6 +154,8 @@ export class ModelCatalogService implements IModelCatalogService {
       getConfig: async () => this.readUserConfigShape(),
       removeProvider: (providerId) => this.removeProviderForRefresh(providerId),
       setConfig: (patch) => this.applyRefreshPatch(patch),
+      replaceModelCatalog: (expected, next) =>
+        this.replaceModelCatalogForRefresh(expected, next),
       resolveOAuthToken: (providerName, oauthRef) => this.resolveOAuthToken(providerName, oauthRef),
       // Mirrors ModelResolverService: only the User-Agent leaves the host, so
       // device identity never reaches third-party registry endpoints.
@@ -167,14 +171,18 @@ export class ModelCatalogService implements IModelCatalogService {
   private readUserConfigShape(): ManagedKimiConfigShape {
     const providers =
       this.config.inspect<Record<string, ProviderConfig>>(PROVIDERS_SECTION).userValue ?? {};
-    const models =
-      this.config.inspect<Record<string, ModelAlias>>(MODELS_SECTION).userValue ?? {};
+    const models = this.config.inspect<Record<string, ModelAlias>>(MODELS_SECTION).userValue;
+    const defaultProvider = this.config.inspect<string>(DEFAULT_PROVIDER_SECTION).userValue;
     const defaultModel = this.config.inspect<string>(DEFAULT_MODEL_SECTION).userValue;
     const thinking =
       this.config.inspect<ManagedKimiConfigShape['thinking']>(THINKING_SECTION).userValue;
     return {
       providers: { ...providers } as ManagedKimiConfigShape['providers'],
-      models: { ...models } as ManagedKimiConfigShape['models'],
+      models:
+        models === undefined
+          ? undefined
+          : ({ ...models } as ManagedKimiConfigShape['models']),
+      defaultProvider,
       defaultModel,
       thinking: thinking === undefined ? undefined : { ...thinking },
     };
@@ -197,6 +205,31 @@ export class ModelCatalogService implements IModelCatalogService {
       providers: restProviders,
       models: restModels,
     } as ManagedKimiConfigShape;
+  }
+
+  private async replaceModelCatalogForRefresh(
+    expected: ManagedKimiModelCatalogSnapshot,
+    next: ManagedKimiModelCatalogSnapshot,
+  ): Promise<ManagedKimiConfigShape> {
+    await this.config.replaceMany(
+      {
+        [PROVIDERS_SECTION]: next.providers,
+        [MODELS_SECTION]: next.models,
+        [DEFAULT_PROVIDER_SECTION]: next.defaultProvider,
+        [DEFAULT_MODEL_SECTION]: next.defaultModel,
+        [THINKING_SECTION]: next.thinking,
+      },
+      {
+        expected: {
+          [PROVIDERS_SECTION]: expected.providers,
+          [MODELS_SECTION]: expected.models,
+          [DEFAULT_PROVIDER_SECTION]: expected.defaultProvider,
+          [DEFAULT_MODEL_SECTION]: expected.defaultModel,
+          [THINKING_SECTION]: expected.thinking,
+        },
+      },
+    );
+    return this.readUserConfigShape();
   }
 
   private async applyRefreshPatch(patch: ManagedKimiConfigShape): Promise<ManagedKimiConfigShape> {

--- a/packages/agent-core-v2/test/app/auth/auth.test.ts
+++ b/packages/agent-core-v2/test/app/auth/auth.test.ts
@@ -3,6 +3,7 @@
  * its dependency on the `provider` domain, and the managed OAuth provider
  * model refresh, using a fake `IOAuthToolkit` so no real network or token
  * storage is exercised.
+ * Run: pnpm --filter @moonshot-ai/agent-core-v2 exec vitest run test/app/auth/auth.test.ts
  */
 
 import { afterEach, beforeEach, describe, expect, it, vi, type Mock } from 'vitest';
@@ -28,17 +29,26 @@ import { IWebSearchProviderService } from '#/app/auth/webSearch/webSearch';
 import { WebSearchProviderService } from '#/app/auth/webSearch/webSearchService';
 import { IAuthLegacyService } from '#/app/authLegacy/authLegacy';
 import { AuthLegacyService } from '#/app/authLegacy/authLegacyService';
-import { IConfigService } from '#/app/config/config';
-import { ConfigRegistry } from '#/app/config/configService';
+import { IBootstrapService } from '#/app/bootstrap/bootstrap';
+import { IConfigRegistry, IConfigService } from '#/app/config/config';
+import { ConfigRegistry, ConfigService } from '#/app/config/configService';
 import { type DomainEvent, IEventService } from '#/app/event/event';
 import { ILogService } from '#/_base/log/log';
 import { IHostRequestHeaders } from '#/app/model/hostRequestHeaders';
+import '#/app/model/configSection';
 import { MODELS_SECTION, type ModelAlias } from '#/app/model/model';
 import { IPlatformService, type PlatformConfig } from '#/app/platform/platform';
 import { IProviderService, type ProviderConfig, type ProvidersChangedEvent } from '#/app/provider/provider';
+import '#/app/provider/configSection';
+import { ProviderService } from '#/app/provider/providerService';
+import { InMemoryStorageService } from '#/persistence/backends/memory/inMemoryStorageService';
+import { TomlAtomicDocumentStore } from '#/persistence/backends/node-fs/atomicDocumentStore';
+import { IAtomicTomlDocumentStore } from '#/persistence/interface/atomicDocumentStore';
+import { IFileSystemStorageService } from '#/persistence/interface/storage';
 
-import { registerBootstrapServices } from '../bootstrap/stubs';
+import { registerBootstrapServices, stubBootstrap } from '../bootstrap/stubs';
 import { registerTelemetryServices } from '../telemetry/stubs';
+import { stubLog } from '../../_base/log/stubs';
 
 const OAUTH_PROVIDER = 'managed:kimi-code';
 const NON_OAUTH_PROVIDER = 'openai-main';
@@ -88,12 +98,14 @@ describe('OAuthService', () => {
   let providers: Record<string, ProviderConfig>;
   let models: Record<string, ModelAlias>;
   let services: Record<string, unknown> | undefined;
+  let defaultProvider: string | undefined;
   let defaultModel: string | undefined;
   let thinking: { enabled?: boolean; effort?: string } | undefined;
   let toolkit: FakeToolkit;
   let providerSet: ReturnType<typeof vi.fn>;
   let configSet: ReturnType<typeof vi.fn>;
   let configReplace: ReturnType<typeof vi.fn>;
+  let configReplaceMany: ReturnType<typeof vi.fn>;
   let events: DomainEvent[];
   let providerChangedEmitter: Emitter<ProvidersChangedEvent>;
 
@@ -113,6 +125,7 @@ describe('OAuthService', () => {
     });
     models = {};
     services = undefined;
+    defaultProvider = undefined;
     defaultModel = undefined;
     thinking = undefined;
     configSet = vi.fn(async (domain: string, value: unknown) => {
@@ -141,6 +154,25 @@ describe('OAuthService', () => {
       }
       throw new Error(`unexpected config replace: ${domain}`);
     });
+    configReplaceMany = vi.fn(async (replacements: Readonly<Record<string, unknown>>) => {
+      for (const [domain, value] of Object.entries(replacements)) {
+        if (domain === 'providers') {
+          providers = value as Record<string, ProviderConfig>;
+        } else if (domain === 'models') {
+          models = (value ?? {}) as Record<string, ModelAlias>;
+        } else if (domain === 'services') {
+          services = value as Record<string, unknown> | undefined;
+        } else if (domain === 'defaultProvider') {
+          defaultProvider = value as string | undefined;
+        } else if (domain === 'defaultModel') {
+          defaultModel = value as string | undefined;
+        } else if (domain === 'thinking') {
+          thinking = value as { enabled?: boolean; effort?: string } | undefined;
+        } else {
+          throw new Error(`unexpected config replacement: ${domain}`);
+        }
+      }
+    });
     events = [];
     toolkit = {
       login: vi.fn<(...args: any[]) => any>(),
@@ -167,6 +199,7 @@ describe('OAuthService', () => {
           })) as IConfigService['inspect'],
           set: configSet as unknown as IConfigService['set'],
           replace: configReplace as unknown as IConfigService['replace'],
+          replaceMany: configReplaceMany as unknown as IConfigService['replaceMany'],
           reload: vi.fn().mockResolvedValue(undefined) as unknown as IConfigService['reload'],
           onDidChangeConfiguration: (() => ({ dispose: () => { } })) as IConfigService['onDidChangeConfiguration'],
           onDidSectionChange: (() => ({ dispose: () => { } })) as IConfigService['onDidSectionChange'],
@@ -197,7 +230,7 @@ describe('OAuthService', () => {
   }
 
   function configBacking(): Record<string, unknown> {
-    return { providers, models, services, defaultModel, thinking };
+    return { providers, models, services, defaultProvider, defaultModel, thinking };
   }
 
   function stubManagedModelsFetch(): ReturnType<typeof vi.fn> {
@@ -411,7 +444,10 @@ describe('OAuthService', () => {
       }),
     );
     expect(fetchMock).toHaveBeenCalledTimes(1);
-    expect(configSet).toHaveBeenCalledWith('defaultModel', 'kimi-code/kimi-k2');
+    expect(configReplaceMany).toHaveBeenCalledWith(
+      expect.objectContaining({ defaultModel: 'kimi-code/kimi-k2' }),
+      expect.any(Object),
+    );
   });
 
   it('startLogin returns authenticated when model refresh fails on the already-authenticated fast path', async () => {
@@ -434,7 +470,7 @@ describe('OAuthService', () => {
         oauth: EXAMPLE_COM_SCOPED_REF,
       }),
     );
-    expect(configSet).not.toHaveBeenCalledWith('defaultModel', expect.any(String));
+    expect(configReplaceMany).not.toHaveBeenCalled();
   });
 
   it('keeps a device-code login authenticated when model fetch is unavailable after authorization', async () => {
@@ -452,7 +488,7 @@ describe('OAuthService', () => {
     });
     await vi.waitFor(() => expect(svc.getFlow(OAUTH_PROVIDER)?.status).toBe('authenticated'));
     expect(fetchMock).toHaveBeenCalledTimes(1);
-    expect(configSet).not.toHaveBeenCalledWith('defaultModel', expect.any(String));
+    expect(configReplaceMany).not.toHaveBeenCalled();
   });
 
   it('refreshes managed models and sets the default model after a device-code login succeeds', async () => {
@@ -474,13 +510,15 @@ describe('OAuthService', () => {
         oauth: EXAMPLE_COM_SCOPED_REF,
       }),
     );
-    expect(configReplace).toHaveBeenCalledWith(
-      'models',
+    expect(configReplaceMany).toHaveBeenCalledWith(
       expect.objectContaining({
-        'kimi-code/kimi-k2': expect.objectContaining({ model: 'kimi-k2' }),
+        models: expect.objectContaining({
+          'kimi-code/kimi-k2': expect.objectContaining({ model: 'kimi-k2' }),
+        }),
+        defaultModel: 'kimi-code/kimi-k2',
       }),
+      expect.any(Object),
     );
-    expect(configSet).toHaveBeenCalledWith('defaultModel', 'kimi-code/kimi-k2');
   });
 
   it('keeps an in-flight OAuth flow alive when unrelated providers change', async () => {
@@ -541,9 +579,15 @@ describe('OAuthService', () => {
     // key does not match its (host, baseUrl) environment, so the env-derived
     // scoped slot is the one cleared (v1 parity).
     expect(toolkit.logout).toHaveBeenCalledWith(OAUTH_PROVIDER, EXAMPLE_COM_SCOPED_REF);
-    expect(configReplace).toHaveBeenCalledWith('providers', {
-      [NON_OAUTH_PROVIDER]: { type: 'openai', apiKey: 'sk-test' },
-    });
+    expect(configReplaceMany).toHaveBeenCalledTimes(1);
+    expect(configReplaceMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        providers: {
+          [NON_OAUTH_PROVIDER]: { type: 'openai', apiKey: 'sk-test' },
+        },
+      }),
+      expect.any(Object),
+    );
   });
 
   it('logout removes managed provider models and dangling defaults', async () => {
@@ -559,6 +603,7 @@ describe('OAuthService', () => {
         maxContextSize: 8192,
       },
     };
+    defaultProvider = OAUTH_PROVIDER;
     defaultModel = 'kimi-code/kimi-k2';
     thinking = { enabled: true };
     const svc = createService();
@@ -566,18 +611,33 @@ describe('OAuthService', () => {
     const result = await svc.logout(OAUTH_PROVIDER);
 
     expect(result).toEqual({ logged_out: true, provider: OAUTH_PROVIDER });
-    expect(configReplace).toHaveBeenCalledWith('providers', {
-      [NON_OAUTH_PROVIDER]: { type: 'openai', apiKey: 'sk-test' },
-    });
-    expect(configReplace).toHaveBeenCalledWith('models', {
-      'custom-default': {
-        provider: NON_OAUTH_PROVIDER,
-        model: 'gpt-4o',
-        maxContextSize: 8192,
+    expect(configReplaceMany).toHaveBeenCalledTimes(1);
+    expect(configReplaceMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        providers: {
+          [NON_OAUTH_PROVIDER]: { type: 'openai', apiKey: 'sk-test' },
+        },
+        models: {
+          'custom-default': {
+            provider: NON_OAUTH_PROVIDER,
+            model: 'gpt-4o',
+            maxContextSize: 8192,
+          },
+        },
+        defaultProvider: undefined,
+        defaultModel: undefined,
+        thinking: undefined,
+      }),
+      {
+        expected: expect.objectContaining({
+          defaultProvider: OAUTH_PROVIDER,
+          defaultModel: 'kimi-code/kimi-k2',
+          thinking: { enabled: true },
+        }),
       },
-    });
-    expect(configSet).toHaveBeenCalledWith('defaultModel', undefined);
-    expect(configSet).toHaveBeenCalledWith('thinking', undefined);
+    );
+    expect(configReplace).not.toHaveBeenCalled();
+    expect(configSet).not.toHaveBeenCalled();
   });
 
   it('logout removes managed web services while preserving unrelated services', async () => {
@@ -603,20 +663,55 @@ describe('OAuthService', () => {
       provider: OAUTH_PROVIDER,
     });
 
-    expect(configReplace).toHaveBeenCalledWith('services', {
-      customService: {
-        baseUrl: 'https://service.example.com',
-      },
-    });
+    expect(configReplaceMany).toHaveBeenCalledTimes(1);
+    expect(configReplaceMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        services: {
+          customService: {
+            baseUrl: 'https://service.example.com',
+          },
+        },
+      }),
+      expect.any(Object),
+    );
   });
 
-  it('logout surfaces managed provider cleanup write failures', async () => {
+  it('logout leaves config state unchanged when atomic cleanup fails', async () => {
     const failure = new Error('config write failed');
-    configReplace.mockRejectedValueOnce(failure);
+    const before = structuredClone(configBacking());
+    configReplaceMany.mockRejectedValueOnce(failure);
     const svc = createService();
 
     await expect(svc.logout(OAUTH_PROVIDER)).rejects.toThrow('config write failed');
+    expect(configBacking()).toEqual(before);
+    expect(configReplace).not.toHaveBeenCalled();
+    expect(configSet).not.toHaveBeenCalled();
     expect(toolkit.logout).toHaveBeenCalledWith(OAUTH_PROVIDER, EXAMPLE_COM_SCOPED_REF);
+  });
+
+  it('logout preserves a concurrent catalog edit when cleanup CAS rejects', async () => {
+    configReplaceMany.mockImplementationOnce(() => {
+      providers = {
+        ...providers,
+        concurrent: { type: 'openai', apiKey: 'sk-concurrent' },
+      };
+      throw Object.assign(new Error('configuration changed'), { code: 'config.invalid' });
+    });
+    const svc = createService();
+
+    await expect(svc.logout(OAUTH_PROVIDER)).rejects.toMatchObject({ code: 'config.invalid' });
+
+    expect(providers).toEqual({
+      [OAUTH_PROVIDER]: {
+        type: 'kimi',
+        baseUrl: 'https://api.example.com',
+        oauth: { storage: 'file', key: 'oauth/kimi-code' },
+      },
+      [NON_OAUTH_PROVIDER]: { type: 'openai', apiKey: 'sk-test' },
+      concurrent: { type: 'openai', apiKey: 'sk-concurrent' },
+    });
+    expect(configReplace).not.toHaveBeenCalled();
+    expect(configSet).not.toHaveBeenCalled();
   });
 
   it('status reports loggedIn based on the cached access token', async () => {
@@ -663,7 +758,7 @@ describe('OAuthService', () => {
     expect(events).toEqual([]);
   });
 
-  it('refreshOAuthProviderModels fetches models and writes back the changed sections', async () => {
+  it('refreshOAuthProviderModels commits a changed catalog in one atomic replacement', async () => {
     const fetchMock = vi.fn().mockResolvedValue({
       ok: true,
       json: async () => ({
@@ -691,21 +786,33 @@ describe('OAuthService', () => {
         removed: 0,
       },
     ]);
-    expect(configReplace).toHaveBeenCalledWith(
-      'providers',
-      expect.objectContaining({ [OAUTH_PROVIDER]: expect.objectContaining({ type: 'kimi' }) }),
-    );
-    expect(configReplace).toHaveBeenCalledWith(
-      'models',
+    expect(configReplaceMany).toHaveBeenCalledTimes(1);
+    expect(configReplaceMany).toHaveBeenCalledWith(
       expect.objectContaining({
-        'kimi-code/kimi-k2': expect.objectContaining({ model: 'kimi-k2' }),
+        providers: expect.objectContaining({
+          [OAUTH_PROVIDER]: expect.objectContaining({ type: 'kimi' }),
+        }),
+        models: expect.objectContaining({
+          'kimi-code/kimi-k2': expect.objectContaining({ model: 'kimi-k2' }),
+        }),
+        defaultProvider: undefined,
+        defaultModel: 'kimi-code/kimi-k2',
+        thinking: { enabled: true },
       }),
+      {
+        expected: {
+          providers: expect.objectContaining({
+            [OAUTH_PROVIDER]: expect.objectContaining({ type: 'kimi' }),
+          }),
+          models: {},
+          defaultProvider: undefined,
+          defaultModel: undefined,
+          thinking: undefined,
+        },
+      },
     );
-    expect(configSet).toHaveBeenCalledWith('defaultModel', 'kimi-code/kimi-k2');
-    // Regression: the `[thinking] enabled` value computed by the shared oauth
-    // apply logic must be persisted, not dropped (previously only the legacy
-    // `default_thinking` key was written).
-    expect(configSet).toHaveBeenCalledWith('thinking', { enabled: true });
+    expect(configReplace).not.toHaveBeenCalled();
+    expect(configSet).not.toHaveBeenCalled();
     expect(events).toEqual([
       {
         type: 'event.model_catalog.changed',
@@ -745,6 +852,98 @@ describe('OAuthService', () => {
     // chain holds the second run until the first finishes, so the peak stays 1.
     expect(maxInFlight).toBe(1);
     expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('OAuthService persisted config integration', () => {
+  let disposables: DisposableStore;
+  let ix: TestInstantiationService;
+
+  beforeEach(() => {
+    disposables = new DisposableStore();
+    ix = createServices(disposables, {
+      base: [registerTelemetryServices],
+      additionalServices: (reg) => {
+        reg.defineInstance(IBootstrapService, stubBootstrap('/tmp/kimi-oauth-integration'));
+        reg.defineInstance(ILogService, stubLog());
+        reg.defineInstance(IFileSystemStorageService, new InMemoryStorageService());
+        reg.define(IAtomicTomlDocumentStore, TomlAtomicDocumentStore);
+        reg.defineInstance(IConfigRegistry, new ConfigRegistry());
+        reg.define(IConfigService, ConfigService);
+        reg.define(IProviderService, ProviderService);
+        reg.definePartialInstance(IEventService, { publish: () => {} });
+        reg.definePartialInstance(IOAuthToolkit, {
+          login: vi.fn().mockResolvedValue({ providerName: OAUTH_PROVIDER, ok: true }),
+          logout: vi.fn().mockResolvedValue({ providerName: OAUTH_PROVIDER, ok: true }),
+          tokenProvider: vi.fn().mockReturnValue({
+            getAccessToken: async () => 'access-token',
+          }),
+        });
+        reg.define(IOAuthService, OAuthService);
+      },
+    });
+  });
+
+  afterEach(() => {
+    disposables.dispose();
+    vi.unstubAllGlobals();
+  });
+
+  it('refreshes models after the first OAuth provision when no models section exists', async () => {
+    const config = ix.get(IConfigService);
+    await config.ready;
+    expect(config.inspect('providers').userValue).toBeUndefined();
+    expect(config.inspect('models').userValue).toBeUndefined();
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          data: [
+            {
+              id: 'kimi-k2',
+              context_length: 131072,
+              supports_reasoning: true,
+              display_name: 'Kimi K2',
+            },
+          ],
+        }),
+      }),
+    );
+
+    await expect(ix.get(IOAuthService).startLogin(OAUTH_PROVIDER)).resolves.toMatchObject({
+      provider: OAUTH_PROVIDER,
+      status: 'authenticated',
+    });
+    expect(config.inspect<Record<string, ProviderConfig>>('providers').userValue).toHaveProperty(
+      OAUTH_PROVIDER,
+    );
+    expect(config.inspect<Record<string, ModelAlias>>('models').userValue).toEqual({
+      'kimi-code/kimi-k2': expect.objectContaining({
+        provider: OAUTH_PROVIDER,
+        model: 'kimi-k2',
+      }),
+    });
+  });
+
+  it('cleans a stale default provider when the persisted providers section is absent', async () => {
+    const config = ix.get(IConfigService);
+    await config.ready;
+    await config.replace('defaultProvider', OAUTH_PROVIDER);
+    expect(config.inspect('providers').userValue).toBeUndefined();
+
+    await expect(ix.get(IOAuthService).logout(OAUTH_PROVIDER)).resolves.toEqual({
+      logged_out: true,
+      provider: OAUTH_PROVIDER,
+    });
+    await config.reload();
+
+    expect(config.inspect('defaultProvider').userValue).toBeUndefined();
+    expect(config.inspect('providers').userValue).toEqual({});
+    const persisted = await ix
+      .get(IAtomicTomlDocumentStore)
+      .get<Record<string, unknown>>('', 'config.toml');
+    expect(persisted).not.toHaveProperty('providers');
   });
 });
 

--- a/packages/agent-core-v2/test/app/config/config.test.ts
+++ b/packages/agent-core-v2/test/app/config/config.test.ts
@@ -1,5 +1,6 @@
 /**
- * Scenario: agent-facing config projection, owner-registered sections, and env overlays.
+ * Scenario: agent-facing config projection, owner-registered sections, env overlays,
+ * and atomic persisted replacement.
  *
  * Exercises the public profile/config surfaces and resolves the real
  * `ConfigService` with TOML document storage while stubbing host and model
@@ -9,7 +10,7 @@
 
 import type { ModelCapability } from '#/app/llmProtocol/capability';
 import type { ToolCall } from '#/app/llmProtocol/message';
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { IAgentProfileService, type ResolvedAgentProfile } from '#/agent/profile/profile';
 import { AGENT_WIRE_PROTOCOL_VERSION } from '#/agent/wireRecord/wireRecord';
@@ -365,6 +366,104 @@ describe('ConfigService env overlay (live)', () => {
     expect(config.get<CronConfig>('cron').disabled).toBe(false);
 
     disposables.dispose();
+  });
+});
+
+describe('ConfigService atomic replacement', () => {
+  let disposables: DisposableStore;
+  let ix: TestInstantiationService;
+  let registry: ConfigRegistry;
+  let storage: InMemoryStorageService;
+  let config: IConfigService;
+
+  beforeEach(async () => {
+    disposables = new DisposableStore();
+    ix = disposables.add(new TestInstantiationService());
+    registry = new ConfigRegistry();
+    storage = new InMemoryStorageService();
+    ix.stub(ILogService, stubLog());
+    ix.stub(IBootstrapService, stubBootstrap('/tmp/kimi-cfg'));
+    ix.stub(IFileSystemStorageService, storage);
+    ix.set(IAtomicTomlDocumentStore, new SyncDescriptor(TomlAtomicDocumentStore));
+    ix.stub(IConfigRegistry, registry);
+    ix.set(IConfigService, new SyncDescriptor(ConfigService));
+    config = ix.get(IConfigService);
+    await config.ready;
+  });
+
+  afterEach(() => {
+    disposables.dispose();
+  });
+
+  it('persists all replaceMany sections with one document write', async () => {
+    const write = vi.spyOn(storage, 'write');
+
+    await config.replaceMany({ alpha: { value: 1 }, beta: 'two' });
+
+    expect(write).toHaveBeenCalledTimes(1);
+    expect(config.inspect('alpha').userValue).toEqual({ value: 1 });
+    expect(config.inspect('beta').userValue).toBe('two');
+  });
+
+  it('rejects a stale expected snapshot without persisting replacements', async () => {
+    await config.replaceMany({ alpha: { value: 1 }, beta: 'two' });
+    const write = vi.spyOn(storage, 'write');
+
+    await expect(
+      config.replaceMany(
+        { alpha: { value: 2 }, beta: 'changed' },
+        { expected: { alpha: { value: 0 }, beta: 'two' } },
+      ),
+    ).rejects.toMatchObject({ code: 'config.invalid' });
+
+    expect(write).not.toHaveBeenCalled();
+    expect(config.inspect('alpha').userValue).toEqual({ value: 1 });
+    expect(config.inspect('beta').userValue).toBe('two');
+  });
+
+  it('reports replaceMany conflicts without exposing config contents', async () => {
+    await config.replaceMany({ credential: 'current-secret' });
+
+    const error = await config
+      .replaceMany(
+        { credential: 'next-secret' },
+        { expected: { credential: 'stale-secret' } },
+      )
+      .catch((error: unknown) => error);
+
+    expect(error).toMatchObject({ code: 'config.invalid' });
+    expect((error as Error).message).not.toMatch(/current-secret|next-secret|stale-secret/);
+  });
+
+  it('leaves every section unchanged when one replacement fails validation', async () => {
+    registry.registerSection('validated', {
+      parse(value: unknown): number {
+        if (typeof value !== 'number') throw new Error('expected a number');
+        return value;
+      },
+    });
+    await config.replaceMany({ alpha: 'before', validated: 1 });
+    const write = vi.spyOn(storage, 'write');
+
+    await expect(
+      config.replaceMany({ alpha: 'after', validated: 'invalid' }),
+    ).rejects.toThrow('expected a number');
+
+    expect(write).not.toHaveBeenCalled();
+    expect(config.inspect('alpha').userValue).toBe('before');
+    expect(config.inspect('validated').userValue).toBe(1);
+  });
+
+  it('keeps in-memory sections unchanged when the document write fails', async () => {
+    await config.replaceMany({ alpha: 'before', beta: 1 });
+    vi.spyOn(storage, 'write').mockRejectedValueOnce(new Error('storage unavailable'));
+
+    await expect(
+      config.replaceMany({ alpha: 'after', beta: 2 }),
+    ).rejects.toThrow('storage unavailable');
+
+    expect(config.inspect('alpha').userValue).toBe('before');
+    expect(config.inspect('beta').userValue).toBe(1);
   });
 });
 

--- a/packages/agent-core-v2/test/app/modelCatalog/modelCatalog.test.ts
+++ b/packages/agent-core-v2/test/app/modelCatalog/modelCatalog.test.ts
@@ -1,11 +1,12 @@
 /**
- * `modelCatalog` domain tests — covers the catalog projection, default-model
- * selection, and coded not-found errors.
+ * `modelCatalog` domain tests — covers catalog projection, default-model
+ * selection, coded not-found errors, and atomic remote-catalog refresh.
  *
  * Uses the flat `TestInstantiationService` harness with real `ModelService` /
  * `ProviderService` collaborators over an in-memory config stub, a stubbed
- * `IOAuthService`, and the SUT registered by interface. The managed-provider
- * refresh is covered in `auth/auth.test.ts`.
+ * `IOAuthService`, and the SUT registered by interface. Managed-provider refresh
+ * is covered in `auth/auth.test.ts`.
+ * Run: pnpm --filter @moonshot-ai/agent-core-v2 exec vitest run test/app/modelCatalog/modelCatalog.test.ts
  */
 
 import { KIMI_CODE_PROVIDER_NAME } from '@moonshot-ai/kimi-code-oauth';
@@ -13,23 +14,34 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { DisposableStore } from '#/_base/di/lifecycle';
 import { createServices, type TestInstantiationService } from '#/_base/di/test';
+import { ILogService } from '#/_base/log/log';
 import { IOAuthService } from '#/app/auth/auth';
+import { IBootstrapService } from '#/app/bootstrap/bootstrap';
 import { IConfigRegistry, IConfigService } from '#/app/config/config';
-import { ConfigRegistry } from '#/app/config/configService';
+import { ConfigRegistry, ConfigService } from '#/app/config/configService';
 import { isError2 } from '#/errors';
 import { IEventService } from '#/app/event/event';
 import { MODEL_CATALOG_SECTION } from '#/app/modelCatalog/configSection';
 import { IModelCatalogService } from '#/app/modelCatalog/modelCatalog';
 import { ModelCatalogService } from '#/app/modelCatalog/modelCatalogService';
 import { IModelService, type ModelAlias } from '#/app/model/model';
+import '#/app/model/configSection';
 import { HostRequestHeaders, IHostRequestHeaders } from '#/app/model/hostRequestHeaders';
 import { ModelService } from '#/app/model/modelService';
 import { IProviderService, type ProviderConfig } from '#/app/provider/provider';
+import '#/app/provider/configSection';
 import { ProviderService } from '#/app/provider/providerService';
+import { InMemoryStorageService } from '#/persistence/backends/memory/inMemoryStorageService';
+import { TomlAtomicDocumentStore } from '#/persistence/backends/node-fs/atomicDocumentStore';
+import { IAtomicTomlDocumentStore } from '#/persistence/interface/atomicDocumentStore';
+import { IFileSystemStorageService } from '#/persistence/interface/storage';
+import { stubBootstrap } from '../bootstrap/stubs';
+import { stubLog } from '../../_base/log/stubs';
 
 interface Backing {
   providers: Record<string, ProviderConfig>;
   models: Record<string, ModelAlias>;
+  defaultProvider?: string;
   defaultModel?: string;
   thinking?: { enabled?: boolean; effort?: string };
 }
@@ -60,6 +72,7 @@ function seedBacking(): Backing {
       },
       gpt4o: { provider: 'openai', model: 'gpt-4o', maxContextSize: 128000 },
     },
+    defaultProvider: 'kimi',
     defaultModel: 'k2',
   };
 }
@@ -70,6 +83,7 @@ describe('ModelCatalogService', () => {
   let backing: Backing;
   let configSet: ReturnType<typeof vi.fn>;
   let configReplace: ReturnType<typeof vi.fn>;
+  let configReplaceMany: ReturnType<typeof vi.fn>;
   let getCachedAccessToken: ReturnType<typeof vi.fn>;
   let resolveTokenProvider: ReturnType<typeof vi.fn>;
   let publishEvent: ReturnType<typeof vi.fn>;
@@ -89,6 +103,18 @@ describe('ModelCatalogService', () => {
     configReplace = vi.fn().mockImplementation(async (domain: string, value: unknown) => {
       (backing as unknown as Record<string, unknown>)[domain] = value;
     });
+    configReplaceMany = vi.fn().mockImplementation(
+      async (replacements: Readonly<Record<string, unknown>>) => {
+        const values = backing as unknown as Record<string, unknown>;
+        for (const [domain, value] of Object.entries(replacements)) {
+          if (value === undefined) {
+            delete values[domain];
+          } else {
+            values[domain] = value;
+          }
+        }
+      },
+    );
     publishEvent = vi.fn();
 
     ix = createServices(disposables, {
@@ -104,6 +130,7 @@ describe('ModelCatalogService', () => {
           })) as IConfigService['inspect'],
           set: configSet as unknown as IConfigService['set'],
           replace: configReplace as unknown as IConfigService['replace'],
+          replaceMany: configReplaceMany as unknown as IConfigService['replaceMany'],
           reload: vi.fn().mockResolvedValue(undefined) as unknown as IConfigService['reload'],
           onDidChangeConfiguration: (() => ({ dispose: () => {} })) as IConfigService['onDidChangeConfiguration'],
           onDidSectionChange: (() => ({ dispose: () => {} })) as IConfigService['onDidSectionChange'],
@@ -357,5 +384,143 @@ describe('ModelCatalogService', () => {
         headers: expect.objectContaining({ 'User-Agent': 'kimi-code-cli/test' }),
       }),
     );
+  });
+
+  it('refreshProviderModels commits a changed catalog through one atomic replacement', async () => {
+    backing.providers = {
+      acme: {
+        type: 'openai',
+        apiKey: 'sk-acme',
+        source: {
+          kind: 'apiJson',
+          url: 'https://registry.example.test/api.json',
+          apiKey: 'sk-registry',
+        },
+      },
+    };
+    backing.models = {
+      'acme/old': {
+        provider: 'acme',
+        model: 'old',
+        maxContextSize: 32000,
+      },
+    };
+    backing.defaultProvider = 'acme';
+    backing.defaultModel = 'acme/old';
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(
+        async () =>
+          new Response(
+            JSON.stringify({
+              acme: {
+                id: 'acme',
+                name: 'Acme',
+                api: 'https://acme.example.test/v1',
+                type: 'openai',
+                models: { next: { id: 'next', name: 'Next' } },
+              },
+            }),
+            { headers: { 'Content-Type': 'application/json' } },
+          ),
+      ),
+    );
+
+    await catalog().refreshProviderModels({ scope: 'all' });
+
+    expect(configReplaceMany).toHaveBeenCalledTimes(1);
+    expect(configReplaceMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        providers: expect.objectContaining({ acme: expect.any(Object) }),
+        models: expect.objectContaining({ 'acme/next': expect.any(Object) }),
+        defaultProvider: 'acme',
+      }),
+      {
+        expected: expect.objectContaining({
+          providers: expect.objectContaining({ acme: expect.any(Object) }),
+          models: expect.objectContaining({ 'acme/old': expect.any(Object) }),
+          defaultProvider: 'acme',
+          defaultModel: 'acme/old',
+        }),
+      },
+    );
+    expect(configReplace).not.toHaveBeenCalled();
+    expect(configSet).not.toHaveBeenCalled();
+  });
+});
+
+describe('ModelCatalogService persisted config integration', () => {
+  let disposables: DisposableStore;
+  let ix: TestInstantiationService;
+
+  beforeEach(() => {
+    disposables = new DisposableStore();
+    ix = createServices(disposables, {
+      additionalServices: (reg) => {
+        reg.defineInstance(IBootstrapService, stubBootstrap('/tmp/kimi-model-catalog-integration'));
+        reg.defineInstance(ILogService, stubLog());
+        reg.defineInstance(IFileSystemStorageService, new InMemoryStorageService());
+        reg.define(IAtomicTomlDocumentStore, TomlAtomicDocumentStore);
+        reg.defineInstance(IConfigRegistry, new ConfigRegistry());
+        reg.define(IConfigService, ConfigService);
+        reg.definePartialInstance(IOAuthService, {});
+        reg.definePartialInstance(IEventService, { publish: () => {} });
+        reg.define(IModelService, ModelService);
+        reg.define(IProviderService, ProviderService);
+        reg.define(IModelCatalogService, ModelCatalogService);
+        reg.defineInstance(
+          IHostRequestHeaders,
+          new HostRequestHeaders({ 'User-Agent': 'kimi-code-cli/test' }),
+        );
+      },
+    });
+  });
+
+  afterEach(() => {
+    disposables.dispose();
+    vi.unstubAllGlobals();
+  });
+
+  it('refreshes a provider catalog when the persisted models section is absent', async () => {
+    const config = ix.get(IConfigService);
+    await config.ready;
+    await config.replace('providers', {
+      acme: {
+        type: 'openai',
+        apiKey: 'sk-acme',
+        source: {
+          kind: 'apiJson',
+          url: 'https://registry.example.test/api.json',
+          apiKey: 'sk-registry',
+        },
+      },
+    });
+    expect(config.inspect('models').userValue).toBeUndefined();
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(
+        async () =>
+          new Response(
+            JSON.stringify({
+              acme: {
+                id: 'acme',
+                name: 'Acme',
+                api: 'https://acme.example.test/v1',
+                type: 'openai',
+                models: { next: { id: 'next', name: 'Next' } },
+              },
+            }),
+            { headers: { 'Content-Type': 'application/json' } },
+          ),
+      ),
+    );
+
+    await expect(ix.get(IModelCatalogService).refreshProviderModels({ scope: 'all' })).resolves.toMatchObject({
+      changed: [{ provider_id: 'acme', added: 1, removed: 0 }],
+      failed: [],
+    });
+    expect(config.inspect<Record<string, ModelAlias>>('models').userValue).toEqual({
+      'acme/next': expect.objectContaining({ provider: 'acme', model: 'next' }),
+    });
   });
 });

--- a/packages/agent-core/src/agent/tool/index.ts
+++ b/packages/agent-core/src/agent/tool/index.ts
@@ -46,6 +46,7 @@ interface PendingMcpDiscovery {
 
 export class ToolManager {
   protected builtinTools: Map<string, BuiltinTool> = new Map();
+  private builtinToolsInitialized = false;
   protected readonly userTools: Map<string, ExecutableTool> = new Map();
   protected readonly mcpTools: Map<string, McpToolEntry> = new Map();
   private loopToolsOverride: readonly ExecutableTool[] | undefined;
@@ -85,9 +86,7 @@ export class ToolManager {
 
   constructor(protected readonly agent: Agent) {
     this.attachMcpTools();
-    if (agent.config.hasProvider) {
-      this.initializeBuiltinTools();
-    }
+    this.ensureBuiltinToolsInitialized();
   }
 
   protected get toolStore(): ToolStore {
@@ -135,6 +134,7 @@ export class ToolManager {
     commandId?: string,
   ): Promise<{ stdout: string; stderr: string; isError?: boolean; backgrounded?: boolean }> {
     this.agent.context.appendBashInput(command);
+    this.ensureBuiltinToolsInitialized();
     const bash = this.builtinTools.get('Bash');
     if (bash === undefined) {
       const error = 'Bash tool is not available.';
@@ -665,6 +665,7 @@ export class ToolManager {
   }
 
   data(): readonly ToolInfo[] {
+    this.ensureBuiltinToolsInitialized();
     return Array.from(this.toolInfos());
   }
 
@@ -672,7 +673,12 @@ export class ToolManager {
     return { ...this.store };
   }
 
-  initializeBuiltinTools() {
+  private ensureBuiltinToolsInitialized(): void {
+    if (this.builtinToolsInitialized || !this.agent.config.hasProvider) return;
+    this.initializeBuiltinTools();
+  }
+
+  initializeBuiltinTools(): void {
     const {
       kaos,
       toolServices,
@@ -760,6 +766,7 @@ export class ToolManager {
         .filter((tool) => !!tool)
         .map((tool) => [tool.name, tool] as const),
     );
+    this.builtinToolsInitialized = true;
   }
 
   refreshBuiltinTools(): void {
@@ -830,6 +837,7 @@ export class ToolManager {
 
   get loopTools(): readonly ExecutableTool[] {
     if (this.loopToolsOverride !== undefined) return this.loopToolsOverride;
+    this.ensureBuiltinToolsInitialized();
     const disclosure = this.progressiveDisclosure;
     const enabledMcpNames = [...this.mcpTools.keys()].filter((name) =>
       this.isMcpToolEnabled(name),

--- a/packages/agent-core/src/rpc/core-api.ts
+++ b/packages/agent-core/src/rpc/core-api.ts
@@ -381,6 +381,19 @@ export interface RemoveKimiProviderPayload {
   readonly providerId: string;
 }
 
+export interface KimiModelCatalogSnapshot {
+  readonly providers: KimiConfig['providers'];
+  readonly models: KimiConfig['models'];
+  readonly defaultProvider: KimiConfig['defaultProvider'];
+  readonly defaultModel: KimiConfig['defaultModel'];
+  readonly thinking: KimiConfig['thinking'];
+}
+
+export interface ReplaceKimiModelCatalogPayload {
+  readonly expected: KimiModelCatalogSnapshot;
+  readonly next: KimiModelCatalogSnapshot;
+}
+
 export interface GetCronTasksResult {
   readonly tasks: readonly CronTaskSnapshot[];
 }
@@ -456,6 +469,7 @@ export interface CoreAPI extends SessionAPIWithId {
   getConfigDiagnostics: (payload: EmptyPayload) => ConfigDiagnostics;
   setKimiConfig: (payload: SetKimiConfigPayload) => KimiConfig;
   removeKimiProvider: (payload: RemoveKimiProviderPayload) => KimiConfig;
+  replaceKimiModelCatalog: (payload: ReplaceKimiModelCatalogPayload) => KimiConfig;
   createSession: (payload: CreateSessionPayload) => SessionSummary;
   closeSession: (payload: CloseSessionPayload) => void;
   archiveSession: (payload: ArchiveSessionPayload) => void;

--- a/packages/agent-core/src/rpc/core-impl.ts
+++ b/packages/agent-core/src/rpc/core-impl.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from 'node:crypto';
 import { homedir } from 'node:os';
+import { isDeepStrictEqual } from 'node:util';
 
 import { ErrorCodes, KimiError } from '#/errors';
 import { getRootLogger, log } from '#/logging/logger';
@@ -14,6 +15,7 @@ import { resolveThinkingEffort } from '../agent/config/thinking';
 import { Agent } from '../agent';
 import {
   ensureKimiHome,
+  applyEnvModelConfig,
   loadRuntimeConfigSafe,
   mergeConfigPatch,
   readConfigFileForUpdate,
@@ -91,9 +93,11 @@ import type {
   ListWorkspaceSkillsPayload,
   McpServerInfo,
   McpStartupMetrics,
+  KimiModelCatalogSnapshot,
   PluginInfo,
   PluginSummary,
   PromptPayload,
+  ReplaceKimiModelCatalogPayload,
   RunShellCommandPayload,
   ReconnectMcpServerPayload,
   RegisterToolPayload,
@@ -137,6 +141,23 @@ type SessionAgentPayload<T> = SessionScopedPayload<AgentScopedPayload<T>>;
 type RenameSessionRequest = SessionScopedPayload<RenameSessionPayload>;
 type UpdateSessionMetadataRequest = SessionScopedPayload<UpdateSessionMetadataPayload>;
 
+function kimiModelCatalogSnapshot(
+  config: KimiConfig | KimiModelCatalogSnapshot,
+): KimiModelCatalogSnapshot {
+  return {
+    providers: config.providers,
+    models: config.models,
+    defaultProvider: config.defaultProvider,
+    defaultModel: config.defaultModel,
+    thinking: config.thinking,
+  };
+}
+
+function isPromiseLike(value: unknown): value is PromiseLike<unknown> {
+  if ((typeof value !== 'object' || value === null) && typeof value !== 'function') return false;
+  return typeof (value as { readonly then?: unknown }).then === 'function';
+}
+
 export interface KimiCoreOptions {
   readonly homeDir?: string | undefined;
   readonly configPath?: string | undefined;
@@ -159,6 +180,7 @@ export class KimiCore implements PromisableMethods<CoreAPI> {
   private runtime: ToolServices | undefined;
   private config: KimiConfig;
   private configWarnings: readonly string[] = [];
+  private configMutationChain: Promise<unknown> = Promise.resolve();
   private readonly runtimeOverride: ToolServices | undefined;
   private readonly userHomeDir: string;
   private readonly kimiRequestHeaders: Record<string, string> | undefined;
@@ -573,41 +595,85 @@ export class KimiCore implements PromisableMethods<CoreAPI> {
     return { warnings: this.configWarnings };
   }
 
+  async mutateKimiConfig<TResult>(update: (config: KimiConfig) => TResult): Promise<TResult> {
+    return this.enqueueConfigMutation(async () => {
+      const config = this.readConfigForWrite();
+      const result = update(config);
+      if (isPromiseLike(result)) {
+        void Promise.resolve(result).catch(() => undefined);
+        throw new TypeError('Config update callback must be synchronous.');
+      }
+      await writeConfigFile(this.configPath, config);
+      this.reloadRuntimeConfig();
+      return result;
+    });
+  }
+
   async setKimiConfig(input: SetKimiConfigPayload): Promise<KimiConfig> {
-    const config = mergeConfigPatch(this.readConfigForWrite(), input);
-    await writeConfigFile(this.configPath, config);
-    return this.reloadRuntimeConfig();
+    return this.enqueueConfigMutation(async () => {
+      const config = mergeConfigPatch(this.readConfigForWrite(), input);
+      await writeConfigFile(this.configPath, config);
+      return this.reloadRuntimeConfig();
+    });
   }
 
   async removeKimiProvider(input: RemoveKimiProviderPayload): Promise<KimiConfig> {
-    const config = this.readConfigForWrite();
-    delete config.providers[input.providerId];
+    return this.enqueueConfigMutation(async () => {
+      const config = this.readConfigForWrite();
+      delete config.providers[input.providerId];
 
-    let removedDefault = false;
-    const existingModels = config.models ?? {};
-    for (const [key, model] of Object.entries(existingModels)) {
-      if (
-        typeof model === 'object' &&
-        model !== null &&
-        !Array.isArray(model) &&
-        model['provider'] === input.providerId
-      ) {
-        delete existingModels[key];
-        if (config.defaultModel === key) removedDefault = true;
+      let removedDefault = false;
+      const existingModels = config.models ?? {};
+      for (const [key, model] of Object.entries(existingModels)) {
+        if (
+          typeof model === 'object' &&
+          model !== null &&
+          !Array.isArray(model) &&
+          model['provider'] === input.providerId
+        ) {
+          delete existingModels[key];
+          if (config.defaultModel === key) removedDefault = true;
+        }
       }
-    }
-    config.models = existingModels;
+      config.models = existingModels;
 
-    if (removedDefault) {
-      config.defaultModel = undefined;
-    }
+      if (removedDefault) {
+        config.defaultModel = undefined;
+      }
 
-    if (config.defaultProvider === input.providerId) {
-      config.defaultProvider = undefined;
-    }
+      if (config.defaultProvider === input.providerId) {
+        config.defaultProvider = undefined;
+      }
 
-    await writeConfigFile(this.configPath, config);
-    return this.reloadRuntimeConfig();
+      await writeConfigFile(this.configPath, config);
+      return this.reloadRuntimeConfig();
+    });
+  }
+
+  async replaceKimiModelCatalog(
+    input: ReplaceKimiModelCatalogPayload,
+  ): Promise<KimiConfig> {
+    return this.enqueueConfigMutation(async () => {
+      const config = this.readConfigForWrite();
+      const current = kimiModelCatalogSnapshot(applyEnvModelConfig(config));
+      const expected = kimiModelCatalogSnapshot(input.expected);
+      if (!isDeepStrictEqual(current, expected)) {
+        throw new KimiError(
+          ErrorCodes.CONFIG_INVALID,
+          'Model catalog changed while provider models were refreshing; retry the refresh.',
+          { details: { reason: 'stale_model_catalog' } },
+        );
+      }
+
+      const next = kimiModelCatalogSnapshot(input.next);
+      config.providers = next.providers;
+      config.models = next.models;
+      config.defaultProvider = next.defaultProvider;
+      config.defaultModel = next.defaultModel;
+      config.thinking = next.thinking;
+      await writeConfigFile(this.configPath, config);
+      return this.reloadRuntimeConfig();
+    });
   }
 
   prompt({ sessionId, ...payload }: SessionAgentPayload<PromptPayload>) {
@@ -1073,6 +1139,15 @@ export class KimiCore implements PromisableMethods<CoreAPI> {
 
   private readConfigForWrite(): KimiConfig {
     return readConfigFileForUpdate(this.configPath);
+  }
+
+  private enqueueConfigMutation<T>(operation: () => Promise<T>): Promise<T> {
+    const run = this.configMutationChain.then(operation);
+    this.configMutationChain = run.then(
+      () => undefined,
+      () => undefined,
+    );
+    return run;
   }
 
   private reloadRuntimeConfig(): KimiConfig {

--- a/packages/agent-core/src/services/auth/managedAuth.ts
+++ b/packages/agent-core/src/services/auth/managedAuth.ts
@@ -45,11 +45,16 @@ export interface ServicesAuthFacade {
   readonly resolveOAuthTokenProvider: OAuthTokenProviderResolver;
 }
 
+export type ServicesConfigAtomicUpdate = <TResult>(
+  update: (config: KimiConfig) => TResult,
+) => Promise<TResult>;
+
 class ServicesManagedAuthFacade implements ServicesAuthFacade {
   private readonly toolkit: KimiOAuthToolkit<ServicesManagedConfig>;
 
   constructor(
     private readonly options: Pick<IEnvironmentService, 'homeDir' | 'configPath'>,
+    atomicUpdate?: ServicesConfigAtomicUpdate,
   ) {
     this.toolkit = new KimiOAuthToolkit<ServicesManagedConfig>({
       homeDir: options.homeDir,
@@ -59,6 +64,7 @@ class ServicesManagedAuthFacade implements ServicesAuthFacade {
         write: async (config) => {
           await writeConfigFile(options.configPath, config);
         },
+        atomicUpdate,
         apply: applyManagedKimiCodeConfig,
         remove: applyManagedKimiCodeLogoutConfig,
       },
@@ -169,6 +175,7 @@ class ServicesManagedAuthFacade implements ServicesAuthFacade {
 
 export function createManagedAuthFacade(
   env: Pick<IEnvironmentService, 'homeDir' | 'configPath'>,
+  atomicUpdate?: ServicesConfigAtomicUpdate,
 ): ServicesAuthFacade {
-  return new ServicesManagedAuthFacade(env);
+  return new ServicesManagedAuthFacade(env, atomicUpdate);
 }

--- a/packages/agent-core/src/services/coreProcess/coreProcess.ts
+++ b/packages/agent-core/src/services/coreProcess/coreProcess.ts
@@ -30,6 +30,7 @@
  */
 
 import { createDecorator } from '../../di';
+import type { KimiConfig } from '../../config';
 import type { CoreRPC, KimiCoreOptions } from '../../rpc';
 import type { TelemetryClient } from '../../telemetry';
 import { type KimiHostIdentity } from '@moonshot-ai/kimi-code-oauth';
@@ -74,6 +75,10 @@ export interface ICoreProcessService {
    * compression uses the same settings (and reloads) as the core's own tools.
    */
   readonly imageLimits?: ImageLimits | undefined;
+
+  readonly atomicConfigUpdate?: <TResult>(
+    update: (config: KimiConfig) => TResult,
+  ) => Promise<TResult>;
 
   /**
    * Resolves once `KimiCore` is fully constructed and the SDK side of the

--- a/packages/agent-core/src/services/coreProcess/coreProcessService.ts
+++ b/packages/agent-core/src/services/coreProcess/coreProcessService.ts
@@ -3,6 +3,7 @@
  */
 
 import { createRPC, KimiCore } from '../../rpc';
+import type { KimiConfig } from '../../config';
 import type { ImageLimits } from '../../tools/support/image-limits';
 import { Disposable, registerSingleton, SyncDescriptor } from '../../di';
 import type { CoreAPI, CoreRPC, SDKAPI } from '../../rpc';
@@ -36,6 +37,10 @@ export class CoreProcessService extends Disposable implements ICoreProcessServic
   public readonly kimiRequestHeaders: Record<string, string> | undefined;
 
   public readonly telemetry: TelemetryClient;
+
+  public readonly atomicConfigUpdate = <TResult>(
+    update: (config: KimiConfig) => TResult,
+  ): Promise<TResult> => this._core.mutateKimiConfig(update);
 
   /** The core's owner-scoped [image] limits; see ICoreProcessService. */
   public get imageLimits(): ImageLimits {

--- a/packages/agent-core/src/services/modelCatalog/modelCatalogService.ts
+++ b/packages/agent-core/src/services/modelCatalog/modelCatalogService.ts
@@ -1,5 +1,6 @@
 import { Disposable, InstantiationType, registerSingleton } from '../../di';
 import type { KimiConfig, ProviderConfig } from '../../config';
+import type { KimiModelCatalogSnapshot } from '../../rpc/core-api';
 import type {
   ModelCatalogItem,
   ProviderCatalogItem,
@@ -148,6 +149,11 @@ export class ModelCatalogService
       getConfig: () => this._readConfig(),
       removeProvider: (providerId) => this.core.rpc.removeKimiProvider({ providerId }),
       setConfig: (patch) => this.core.rpc.setKimiConfig(patch as Record<string, unknown>),
+      replaceModelCatalog: (expected, next) =>
+        this.core.rpc.replaceKimiModelCatalog({
+          expected: expected as unknown as KimiModelCatalogSnapshot,
+          next: next as unknown as KimiModelCatalogSnapshot,
+        }),
       resolveOAuthToken: (providerName, oauthRef) =>
         this._resolveOAuthToken(providerName, oauthRef),
       userAgent: this.core.kimiRequestHeaders?.['User-Agent'],

--- a/packages/agent-core/src/services/oauth/oauthService.ts
+++ b/packages/agent-core/src/services/oauth/oauthService.ts
@@ -20,6 +20,7 @@ import type {
 import { ulid } from 'ulid';
 
 import { createManagedAuthFacade, type ServicesAuthFacade } from '../auth/managedAuth';
+import { ICoreProcessService } from '../coreProcess/coreProcess';
 import { IEnvironmentService } from '../environment/environment';
 import { IOAuthService } from './oauth';
 
@@ -80,15 +81,18 @@ export class OAuthService extends Disposable implements IOAuthService {
   private readonly _authFacade: ServicesAuthFacade;
   private readonly _flows: DisposableMap<string, FlowState>;
 
-  constructor(@IEnvironmentService private readonly env: IEnvironmentService) {
+  constructor(
+    @IEnvironmentService private readonly env: IEnvironmentService,
+    @ICoreProcessService core: ICoreProcessService,
+  ) {
     super();
     this._flows = this._register(new DisposableMap<string, FlowState>());
-    this._authFacade = createManagedAuthFacade(env);
+    this._authFacade = createManagedAuthFacade(env, core.atomicConfigUpdate);
   }
 
   /** @internal Test-only factory that injects a mock facade. */
   static _createForTest(env: IEnvironmentService, facade: ServicesAuthFacade): OAuthService {
-    const svc = new (OAuthService as any)(env) as OAuthService;
+    const svc = new (OAuthService as any)(env, {}) as OAuthService;
     (svc as any)._authFacade = facade;
     return svc;
   }

--- a/packages/agent-core/test/agent/tool.test.ts
+++ b/packages/agent-core/test/agent/tool.test.ts
@@ -1,3 +1,9 @@
+/**
+ * Scenario: agent tool registration, exposure, execution, and output budgeting.
+ * Responsibilities: expose active tools, route calls, enforce hooks, and preserve model-facing output.
+ * Wiring: real Agent components with the scripted LLM as the external boundary.
+ * Run: pnpm --filter @moonshot-ai/agent-core exec vitest run test/agent/tool.test.ts
+ */
 import { existsSync, mkdtempSync, readFileSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -6,7 +12,9 @@ import type { ToolCall } from '@moonshot-ai/kosong';
 import { describe, expect, it, vi } from 'vitest';
 
 import { budgetToolResultForModel } from '../../src/agent/turn/tool-result-budget';
+import type { KimiConfig } from '../../src/config';
 import { HookEngine } from '../../src/session/hooks';
+import { ProviderManager } from '../../src/session/provider-manager';
 import type { SessionSubagentHost } from '../../src/session/subagent-host';
 import { FLAG_DEFINITIONS, FlagResolver } from '../../src/flags';
 import { createFakeKaos } from '../tools/fixtures/fake-kaos';
@@ -227,6 +235,69 @@ describe('Agent tools', () => {
         user: text "Which tools are active?"
     `);
     await ctx.expectResumeMatches();
+  });
+
+  it('includes active builtin tools in the first LLM request when the provider recovers after configuration', async () => {
+    let providerConfig: KimiConfig = {
+      providers: {},
+      models: {
+        'recovering-model': {
+          provider: 'recovering-provider',
+          model: 'recovering-model',
+          maxContextSize: 1_000_000,
+        },
+      },
+    };
+    const ctx = testAgent({
+      providerManager: new ProviderManager({ config: () => providerConfig }),
+    });
+    ctx.configure({
+      tools: ['Write', 'Bash'],
+      provider: { type: 'kimi', apiKey: 'test-key', model: 'recovering-model' },
+    });
+    providerConfig = {
+      ...providerConfig,
+      providers: {
+        'recovering-provider': { type: 'kimi', apiKey: 'test-key' },
+      },
+    };
+
+    ctx.mockNextResponse({ type: 'text', text: 'ready' });
+    await ctx.rpc.prompt({ input: [{ type: 'text', text: 'Which tools are active?' }] });
+    await ctx.untilTurnEnd();
+
+    expect(ctx.llmCalls[0]?.tools.map((tool) => tool.name)).toEqual(['Bash', 'Write']);
+  });
+
+  it('keeps the first LLM request tool-less when the provider recovers with no active tools', async () => {
+    let providerConfig: KimiConfig = {
+      providers: {},
+      models: {
+        'recovering-model': {
+          provider: 'recovering-provider',
+          model: 'recovering-model',
+          maxContextSize: 1_000_000,
+        },
+      },
+    };
+    const ctx = testAgent({
+      providerManager: new ProviderManager({ config: () => providerConfig }),
+    });
+    ctx.configure({
+      provider: { type: 'kimi', apiKey: 'test-key', model: 'recovering-model' },
+    });
+    providerConfig = {
+      ...providerConfig,
+      providers: {
+        'recovering-provider': { type: 'kimi', apiKey: 'test-key' },
+      },
+    };
+
+    ctx.mockNextResponse({ type: 'text', text: 'ready' });
+    await ctx.rpc.prompt({ input: [{ type: 'text', text: 'Continue without tools.' }] });
+    await ctx.untilTurnEnd();
+
+    expect(ctx.llmCalls[0]?.tools).toEqual([]);
   });
 
   it('disables Bash background mode unless task management tools are active', async () => {

--- a/packages/agent-core/test/rpc/config-rpc.test.ts
+++ b/packages/agent-core/test/rpc/config-rpc.test.ts
@@ -1,3 +1,11 @@
+/**
+ * Core configuration RPC scenarios: strict reads preserve the last good state,
+ * mutations serialize, and model-catalog snapshots commit atomically with
+ * optimistic conflict protection.
+ * Wiring: real KimiCore and filesystem persistence with only the RPC peer stubbed.
+ * Run: pnpm --filter @moonshot-ai/agent-core exec vitest run test/rpc/config-rpc.test.ts
+ */
+
 import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
@@ -5,6 +13,8 @@ import path from 'node:path';
 import { afterEach, describe, expect, it } from 'vitest';
 
 import { KimiCore } from '../../src/rpc/core-impl';
+import type { KimiModelCatalogSnapshot } from '../../src/rpc/core-api';
+import type { KimiConfig } from '../../src/config';
 
 const tempDirs: string[] = [];
 
@@ -25,6 +35,16 @@ async function makeHome(configToml?: string): Promise<string> {
 
 function makeCore(home: string): KimiCore {
   return new KimiCore(async () => ({}) as never, { homeDir: home });
+}
+
+function catalogSnapshot(config: KimiConfig): KimiModelCatalogSnapshot {
+  return {
+    providers: config.providers,
+    models: config.models,
+    defaultProvider: config.defaultProvider,
+    defaultModel: config.defaultModel,
+    thinking: config.thinking,
+  };
 }
 
 const VALID_TOML = `
@@ -169,5 +189,124 @@ read_byte_budget = 131072
     await core.getKimiConfig({ reload: true });
     expect(core.imageLimits.maxEdgePx()).toBe(2000);
     expect(core.imageLimits.readByteBudget()).toBe(256 * 1024);
+  });
+});
+
+describe('KimiCore configuration mutations', () => {
+  it('preserves both changes when independent config mutations are submitted concurrently', async () => {
+    const core = makeCore(await makeHome(VALID_TOML));
+
+    await Promise.all([
+      core.setKimiConfig({ defaultPlanMode: true }),
+      core.setKimiConfig({ thinking: { enabled: true } }),
+    ]);
+
+    await expect(core.getKimiConfig({ reload: true })).resolves.toMatchObject({
+      defaultPlanMode: true,
+      thinking: { enabled: true },
+    });
+  });
+
+  it('keeps the writer usable after rejecting an asynchronous config updater', async () => {
+    const core = makeCore(await makeHome(VALID_TOML));
+    const asynchronousUpdate = (async (config: KimiConfig) => {
+      config.defaultPlanMode = true;
+    }) as unknown as (config: KimiConfig) => never;
+
+    await expect(core.mutateKimiConfig(asynchronousUpdate)).rejects.toThrow(/synchronous/i);
+    await core.setKimiConfig({ thinking: { enabled: true } });
+
+    await expect(core.getKimiConfig({ reload: true })).resolves.toMatchObject({
+      thinking: { enabled: true },
+    });
+    expect((await core.getKimiConfig({})).defaultPlanMode).not.toBe(true);
+  });
+
+  it('replaces the complete model catalog while preserving unrelated config', async () => {
+    const core = makeCore(
+      await makeHome(`default_provider = "kimi"
+${VALID_TOML}
+
+[thinking]
+enabled = true
+
+[image]
+max_edge_px = 1400
+`),
+    );
+    const expected = catalogSnapshot(await core.getKimiConfig({}));
+
+    const updated = await core.replaceKimiModelCatalog({
+      expected,
+      next: {
+        providers: {
+          replacement: {
+            type: 'openai',
+            apiKey: 'YOUR_API_KEY',
+          },
+        },
+        models: {
+          replacement: {
+            provider: 'replacement',
+            model: 'replacement-model',
+            maxContextSize: 262144,
+          },
+        },
+        defaultProvider: undefined,
+        defaultModel: undefined,
+        thinking: undefined,
+      },
+    });
+
+    expect(catalogSnapshot(updated)).toEqual({
+      providers: {
+        replacement: {
+          type: 'openai',
+          apiKey: 'YOUR_API_KEY',
+        },
+      },
+      models: {
+        replacement: {
+          provider: 'replacement',
+          model: 'replacement-model',
+          maxContextSize: 262144,
+        },
+      },
+      defaultProvider: undefined,
+      defaultModel: undefined,
+      thinking: undefined,
+    });
+    expect(updated.image).toEqual({ maxEdgePx: 1400 });
+  });
+
+  it('rejects a stale catalog replacement without overwriting the newer config', async () => {
+    const core = makeCore(await makeHome(VALID_TOML));
+    const expected = catalogSnapshot(await core.getKimiConfig({}));
+    await core.setKimiConfig({
+      models: {
+        userAdded: {
+          provider: 'kimi',
+          model: 'user-added',
+          maxContextSize: 64000,
+        },
+      },
+    });
+
+    await expect(
+      core.replaceKimiModelCatalog({
+        expected,
+        next: {
+          providers: {},
+          models: {},
+          defaultProvider: undefined,
+          defaultModel: undefined,
+          thinking: undefined,
+        },
+      }),
+    ).rejects.toThrow(/changed while provider models were refreshing/i);
+
+    const kept = await core.getKimiConfig({ reload: true });
+    expect(kept.models?.['userAdded']).toMatchObject({ model: 'user-added' });
+    expect(kept.providers['kimi']).toBeDefined();
   });
 });

--- a/packages/agent-core/test/services/coreProcessService.test.ts
+++ b/packages/agent-core/test/services/coreProcessService.test.ts
@@ -1,8 +1,14 @@
+/**
+ * Core process service scenarios: peer RPC routing, lifecycle, DI composition, and config writes.
+ * Wiring: real KimiCore with in-memory peer services and an isolated filesystem home.
+ * Run: pnpm --filter @moonshot-ai/agent-core exec vitest run test/services/coreProcessService.test.ts
+ */
+
 import { mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import {
   SyncDescriptor,
@@ -24,6 +30,7 @@ import {
   IEventService,
   ILogService,
   ICoreProcessService,
+  IOAuthService,
   IQuestionService,
 } from '../../src/services';
 
@@ -131,6 +138,14 @@ function makeEnv(homeDir: string): IEnvironmentService {
   };
 }
 
+function deferred(): { readonly promise: Promise<void>; readonly resolve: () => void } {
+  let resolve!: () => void;
+  const promise = new Promise<void>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+  return { promise, resolve };
+}
+
 describe('BridgeClientAPI', () => {
   it('routes emitEvent / requestApproval / requestQuestion / toolCall to peer services', async () => {
     const { eventService, approvalService, questionService, logService } = makePeers();
@@ -211,6 +226,37 @@ describe('CoreProcessService direct construction', () => {
       const info = await core.rpc.getCoreInfo({});
       expect(info).toHaveProperty('version');
       expect(typeof info.version).toBe('string');
+    } finally {
+      core.dispose();
+    }
+  });
+
+  it('preserves both writes when atomic auth config and config RPC overlap', async () => {
+    const { eventService, approvalService, questionService, logService } = makePeers();
+    const core = new CoreProcessService(
+      {},
+      makeEnv(tmpHome),
+      eventService,
+      approvalService,
+      questionService,
+      logService,
+    );
+    const authUpdateEntered = deferred();
+    try {
+      await core.ready();
+      const authUpdate = core.atomicConfigUpdate((config) => {
+        config.defaultPlanMode = true;
+        authUpdateEntered.resolve();
+      });
+      await authUpdateEntered.promise;
+      const rpcUpdate = core.rpc.setKimiConfig({ thinking: { enabled: true } });
+
+      await Promise.all([authUpdate, rpcUpdate]);
+
+      await expect(core.rpc.getKimiConfig({ reload: true })).resolves.toMatchObject({
+        defaultPlanMode: true,
+        thinking: { enabled: true },
+      });
     } finally {
       core.dispose();
     }
@@ -297,6 +343,34 @@ describe('singleton registry composition', () => {
       } finally {
         core.dispose();
       }
+    } finally {
+      ix.dispose();
+    }
+  });
+
+  it('routes OAuth cleanup through the CoreProcess config writer resolved by DI', async () => {
+    const { eventService, approvalService, questionService } = makePeers();
+    const ix = new TestInstantiationService();
+    for (const [id, descriptor] of getSingletonServiceDescriptors()) {
+      ix.set(id, descriptor);
+    }
+    ix.stub(IEventService, eventService);
+    ix.stub(IApprovalService, approvalService);
+    ix.stub(IQuestionService, questionService);
+    ix.stub(IEnvironmentService, makeEnv(tmpHome));
+    ix.stub(ILogService, new NoopLogService());
+
+    try {
+      const core = ix.get(ICoreProcessService);
+      await core.ready();
+      if (core.atomicConfigUpdate === undefined) {
+        throw new Error('Expected CoreProcessService to expose its atomic config writer.');
+      }
+      const atomicConfigUpdate = vi.spyOn(core, 'atomicConfigUpdate');
+
+      await ix.get(IOAuthService).logout();
+
+      expect(atomicConfigUpdate).toHaveBeenCalledOnce();
     } finally {
       ix.dispose();
     }

--- a/packages/agent-core/test/services/model-catalog-service.test.ts
+++ b/packages/agent-core/test/services/model-catalog-service.test.ts
@@ -1,3 +1,10 @@
+/**
+ * Model-catalog service scenarios: catalog reads and refreshes traverse the
+ * core RPC boundary, publish protocol events, and persist refreshes atomically.
+ * Wiring: real service orchestration with RPC, OAuth, fetch, and event boundaries stubbed.
+ * Run: pnpm --filter @moonshot-ai/agent-core exec vitest run test/services/model-catalog-service.test.ts
+ */
+
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import type {
@@ -5,6 +12,7 @@ import type {
   GetKimiConfigPayload,
   KimiConfig,
   KimiConfigPatch,
+  ReplaceKimiModelCatalogPayload,
   SetKimiConfigPayload,
 } from '../../src';
 import { KIMI_CODE_PROVIDER_NAME } from '@moonshot-ai/kimi-code-oauth';
@@ -40,10 +48,12 @@ function makeCore(configRef: { current: KimiConfig }): {
   getCalls: GetKimiConfigPayload[];
   setCalls: KimiConfigPatch[];
   removeCalls: string[];
+  replaceCalls: ReplaceKimiModelCatalogPayload[];
 } {
   const getCalls: GetKimiConfigPayload[] = [];
   const setCalls: KimiConfigPatch[] = [];
   const removeCalls: string[] = [];
+  const replaceCalls: ReplaceKimiModelCatalogPayload[] = [];
   const rpc: Partial<CoreRPC> = {
     getKimiConfig: vi.fn(async (payload: GetKimiConfigPayload) => {
       getCalls.push(payload);
@@ -78,6 +88,14 @@ function makeCore(configRef: { current: KimiConfig }): {
       };
       return configRef.current;
     }),
+    replaceKimiModelCatalog: vi.fn(async (payload: ReplaceKimiModelCatalogPayload) => {
+      replaceCalls.push(payload);
+      configRef.current = {
+        ...configRef.current,
+        ...payload.next,
+      };
+      return configRef.current;
+    }),
   };
   return {
     core: {
@@ -89,6 +107,7 @@ function makeCore(configRef: { current: KimiConfig }): {
     getCalls,
     setCalls,
     removeCalls,
+    replaceCalls,
   };
 }
 
@@ -256,7 +275,7 @@ describe('ModelCatalogService', () => {
         },
       },
     };
-    const { core, removeCalls, setCalls } = makeCore(configRef);
+    const { core, removeCalls, setCalls, replaceCalls } = makeCore(configRef);
     const fetchMock = vi.fn(async () => new Response(JSON.stringify({
       data: [
         {
@@ -277,8 +296,10 @@ describe('ModelCatalogService', () => {
       failed: [],
     });
 
-    expect(removeCalls).toEqual([KIMI_CODE_PROVIDER_NAME]);
-    expect(setCalls.at(-1)).toMatchObject({
+    expect(removeCalls).toEqual([]);
+    expect(setCalls).toEqual([]);
+    expect(replaceCalls).toHaveLength(1);
+    expect(replaceCalls[0]?.next).toMatchObject({
       defaultModel: 'kimi-code/kimi-for-coding',
       thinking: { enabled: true },
       models: {
@@ -311,7 +332,7 @@ describe('ModelCatalogService', () => {
         },
       },
     };
-    const { core, setCalls } = makeCore(configRef);
+    const { core, replaceCalls } = makeCore(configRef);
     vi.stubGlobal(
       'fetch',
       vi.fn(async () =>
@@ -332,9 +353,10 @@ describe('ModelCatalogService', () => {
 
     await svc.refreshOAuthProviderModels();
 
-    const last = setCalls.at(-1) as Record<string, unknown>;
-    const providers = last['providers'] as Record<string, { type: string; baseUrl: string }>;
-    const models = last['models'] as Record<string, { provider: string; protocol?: string }>;
+    const last = replaceCalls.at(-1)?.next;
+    if (last === undefined) throw new Error('Expected an atomic model-catalog replacement.');
+    const providers = last.providers;
+    const models = last.models ?? {};
     // Provider type/baseUrl stay on the kimi wire + REST base; the anthropic
     // transport is carried on the model alias for per-model resolution.
     expect(providers[KIMI_CODE_PROVIDER_NAME]?.type).toBe('kimi');

--- a/packages/node-sdk/src/auth.ts
+++ b/packages/node-sdk/src/auth.ts
@@ -90,6 +90,9 @@ export interface KimiAuthFacadeOptions {
   readonly homeDir: string;
   readonly configPath: string;
   readonly identity?: KimiHostIdentity | undefined;
+  readonly atomicConfigUpdate?: <TResult>(
+    update: (config: KimiConfig) => TResult,
+  ) => Promise<TResult>;
   readonly onConfigUpdated?: ((config: KimiConfig) => void) | undefined;
   readonly onRefresh?: ((outcome: OAuthRefreshOutcome) => void) | undefined;
 }
@@ -112,6 +115,7 @@ export class KimiAuthFacade {
         write: async (config) => {
           await writeConfigFile(options.configPath, config);
         },
+        atomicUpdate: options.atomicConfigUpdate,
         apply: applyManagedKimiCodeConfig,
         remove: applyManagedKimiCodeLogoutConfig,
       },

--- a/packages/node-sdk/src/kimi-harness.ts
+++ b/packages/node-sdk/src/kimi-harness.ts
@@ -19,6 +19,7 @@ import type {
   GetConfigOptions,
   KimiConfig,
   KimiConfigPatch,
+  KimiModelCatalogSnapshot,
   KimiHostIdentity,
   ListSessionsOptions,
   RenameSessionInput,
@@ -259,6 +260,14 @@ export class KimiHarness {
 
   async removeProvider(providerId: string): Promise<KimiConfig> {
     return this.rpc.removeProvider(providerId);
+  }
+
+  /** Replace the complete model catalog only when it still matches `expected`. */
+  async replaceModelCatalog(
+    expected: KimiModelCatalogSnapshot,
+    next: KimiModelCatalogSnapshot,
+  ): Promise<KimiConfig> {
+    return this.rpc.replaceModelCatalog(expected, next);
   }
 
   async close(): Promise<void> {

--- a/packages/node-sdk/src/rpc.ts
+++ b/packages/node-sdk/src/rpc.ts
@@ -36,6 +36,7 @@ import type {
   GoalToolResult,
   KimiConfig,
   KimiConfigPatch,
+  KimiModelCatalogSnapshot,
   ListSessionsOptions,
   McpServerInfo,
   McpStartupMetrics,
@@ -233,6 +234,15 @@ export abstract class SDKRpcClientBase {
   async removeProvider(providerId: string): Promise<KimiConfig> {
     const rpc = await this.getRpc();
     return rpc.removeKimiProvider({ providerId });
+  }
+
+  /** Replace the complete model catalog only when it still matches `expected`. */
+  async replaceModelCatalog(
+    expected: KimiModelCatalogSnapshot,
+    next: KimiModelCatalogSnapshot,
+  ): Promise<KimiConfig> {
+    const rpc = await this.getRpc();
+    return rpc.replaceKimiModelCatalog({ expected, next });
   }
 
   async prompt(input: SessionPromptRpcInput): Promise<void> {

--- a/packages/node-sdk/src/sdk-rpc-client.ts
+++ b/packages/node-sdk/src/sdk-rpc-client.ts
@@ -64,6 +64,7 @@ export class SDKRpcClient extends SDKRpcClientBase {
       configPath: this.configPath,
       identity: this.identity,
       onRefresh: options.onOAuthRefresh,
+      atomicConfigUpdate: (update) => this.core.mutateKimiConfig(update),
     });
 
     void getRootLogger().configure(resolveLoggingConfig({ homeDir: this.homeDir }));

--- a/packages/node-sdk/src/types.ts
+++ b/packages/node-sdk/src/types.ts
@@ -39,6 +39,7 @@ export type {
   GoalToolResult,
   KimiConfig,
   KimiConfigPatch,
+  KimiModelCatalogSnapshot,
   LoopControl,
   McpServerInfo,
   McpStartupMetrics,

--- a/packages/node-sdk/test/auth-facade.test.ts
+++ b/packages/node-sdk/test/auth-facade.test.ts
@@ -1,3 +1,10 @@
+/**
+ * SDK auth scenarios: managed credential resolution, login/logout provisioning, and
+ * serialization with model-catalog writes.
+ * Wiring: real auth facade, SDK core, token storage, and filesystem; fetch is the only stub.
+ * Run: pnpm --filter @moonshot-ai/kimi-code-sdk exec vitest run test/auth-facade.test.ts
+ */
+
 import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -15,7 +22,14 @@ import {
 } from '@moonshot-ai/kimi-code-oauth';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { createKimiHarness, ErrorCodes, KimiError } from '#/index';
+import {
+  createKimiHarness,
+  ErrorCodes,
+  KimiError,
+  SDKRpcClient,
+  type KimiConfig,
+  type KimiModelCatalogSnapshot,
+} from '#/index';
 
 import { ProviderManager } from '../../agent-core/src/session/provider-manager';
 import { TEST_IDENTITY } from './test-identity';
@@ -42,6 +56,67 @@ function freshToken(): TokenInfo {
     tokenType: 'Bearer',
     expiresIn: 3600,
   };
+}
+
+function deferred(): { readonly promise: Promise<void>; readonly resolve: () => void } {
+  let resolve!: () => void;
+  const promise = new Promise<void>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+  return { promise, resolve };
+}
+
+function catalogSnapshot(config: KimiConfig): KimiModelCatalogSnapshot {
+  return {
+    providers: config.providers,
+    models: config.models,
+    defaultProvider: config.defaultProvider,
+    defaultModel: config.defaultModel,
+    thinking: config.thinking,
+  };
+}
+
+const CUSTOM_CONFIG = `
+default_model = "custom-model"
+
+[providers.custom]
+type = "openai"
+api_key = "YOUR_API_KEY"
+
+[models.custom-model]
+provider = "custom"
+model = "custom-model"
+max_context_size = 64000
+`;
+
+function stubManagedModels(
+  contextLength = 262144,
+  gate?: {
+    readonly requested: () => void;
+    readonly release: Promise<void>;
+  },
+): void {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(
+      async () => {
+        gate?.requested();
+        await gate?.release;
+        return new Response(
+          JSON.stringify({
+            data: [
+              {
+                id: 'kimi-for-coding',
+                context_length: contextLength,
+                supports_reasoning: true,
+              },
+            ],
+          }),
+          { status: 200, headers: { 'Content-Type': 'application/json' } },
+        );
+      },
+    ),
+  );
 }
 
 beforeEach(async () => {
@@ -262,6 +337,106 @@ oauth = { storage = "file", key = "${oauthKey}", oauth_host = "https://auth.dev.
       storage: 'file',
       key: 'oauth/kimi-code',
     });
+  });
+
+  it('rejects a catalog replacement whose snapshot predates auth provisioning', async () => {
+    await new FileTokenStorage(join(homeDir, 'credentials')).save('kimi-code', freshToken());
+    const configPath = join(homeDir, 'config.toml');
+    await writeFile(configPath, CUSTOM_CONFIG);
+    stubManagedModels();
+    const rpc = new SDKRpcClient({ homeDir, identity: TEST_IDENTITY });
+    const expected = catalogSnapshot(await rpc.getConfig());
+
+    await rpc.auth.login();
+
+    const replaceCatalog = rpc.replaceModelCatalog(expected, {
+      providers: {
+        replacement: { type: 'openai', apiKey: 'YOUR_API_KEY' },
+      },
+      models: {
+        replacement: {
+          provider: 'replacement',
+          model: 'replacement-model',
+          maxContextSize: 128000,
+        },
+      },
+      defaultProvider: undefined,
+      defaultModel: 'replacement',
+      thinking: undefined,
+    });
+
+    await expect(replaceCatalog).rejects.toMatchObject({
+      code: ErrorCodes.CONFIG_INVALID,
+      details: { reason: 'stale_model_catalog' },
+    });
+    const config = await rpc.getConfig({ reload: true });
+    expect(config.providers[KIMI_CODE_PROVIDER_NAME]).toBeDefined();
+    expect(config.providers['custom']).toBeDefined();
+    expect(config.providers['replacement']).toBeUndefined();
+  });
+
+  it('preserves a catalog committed while auth is still loading managed models', async () => {
+    await new FileTokenStorage(join(homeDir, 'credentials')).save('kimi-code', freshToken());
+    const configPath = join(homeDir, 'config.toml');
+    await writeFile(configPath, CUSTOM_CONFIG);
+    const modelsRequested = deferred();
+    const releaseModels = deferred();
+    stubManagedModels(262144, {
+      requested: modelsRequested.resolve,
+      release: releaseModels.promise,
+    });
+    const rpc = new SDKRpcClient({ homeDir, identity: TEST_IDENTITY });
+    const atomicConfigUpdate = vi.spyOn(rpc.core, 'mutateKimiConfig');
+    const expected = catalogSnapshot(await rpc.getConfig());
+    const login = rpc.auth.login();
+    await modelsRequested.promise;
+    const catalogUpdate = rpc.replaceModelCatalog(expected, {
+      providers: {
+        ...expected.providers,
+        replacement: {
+          type: 'openai',
+          apiKey: 'YOUR_API_KEY',
+        },
+      },
+      models: {
+        ...expected.models,
+        replacement: {
+          provider: 'replacement',
+          model: 'replacement-model',
+          maxContextSize: 128000,
+        },
+      },
+      defaultProvider: expected.defaultProvider,
+      defaultModel: expected.defaultModel,
+      thinking: expected.thinking,
+    });
+    await catalogUpdate;
+    releaseModels.resolve();
+    await login;
+
+    expect(atomicConfigUpdate).toHaveBeenCalledOnce();
+    const config = await rpc.getConfig({ reload: true });
+    expect(config.providers['replacement']).toMatchObject({ apiKey: 'YOUR_API_KEY' });
+    expect(config.models?.['replacement']).toMatchObject({ model: 'replacement-model' });
+    expect(config.providers[KIMI_CODE_PROVIDER_NAME]).toBeDefined();
+    expect(config.models?.['kimi-code/kimi-for-coding']).toBeDefined();
+  });
+
+  it('allows the next config mutation when auth provisioning fails before persistence', async () => {
+    await new FileTokenStorage(join(homeDir, 'credentials')).save('kimi-code', freshToken());
+    const configPath = join(homeDir, 'config.toml');
+    await writeFile(configPath, CUSTOM_CONFIG);
+    stubManagedModels(0);
+    const rpc = new SDKRpcClient({ homeDir, identity: TEST_IDENTITY });
+
+    await expect(rpc.auth.login()).rejects.toThrow();
+    await rpc.setConfig({ defaultPlanMode: true });
+
+    const config = await rpc.getConfig({ reload: true });
+    expect(config.defaultPlanMode).toBe(true);
+    expect(config.providers['custom']).toBeDefined();
+    expect(config.providers[KIMI_CODE_PROVIDER_NAME]).toBeUndefined();
+    expect(config.models?.['kimi-code/kimi-for-coding']).toBeUndefined();
   });
 
   it('logs in against the configured scoped OAuth host and base URL when env is absent', async () => {

--- a/packages/node-sdk/test/config.test.ts
+++ b/packages/node-sdk/test/config.test.ts
@@ -1,3 +1,9 @@
+/**
+ * SDK config scenarios: TOML fidelity and public harness mutation behavior.
+ * Wiring: real SDK RPC/core stack over isolated temporary config files.
+ * Run: pnpm --filter @moonshot-ai/kimi-code-sdk exec vitest run test/config.test.ts
+ */
+
 import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -294,6 +300,62 @@ describe('KimiHarness config API', () => {
     expect(text).toContain('theme = "dark"');
     expect(text).toContain('GOOGLE_CLOUD_PROJECT = "project-1"');
     expect(text).toContain('claim_stale_after_ms = 15000');
+  });
+
+  it('replaces the model catalog through the public harness while preserving unrelated config', async () => {
+    const homeDir = await makeTempDir();
+    const configPath = join(homeDir, 'config.toml');
+    await writeFile(configPath, `default_provider = "kimi-for-coding"\n${COMPLETE_TOML}`, 'utf-8');
+    const harness = createKimiHarness({ homeDir, identity: TEST_IDENTITY });
+    const current = await harness.getConfig();
+
+    const updated = await harness.replaceModelCatalog(
+      {
+        providers: current.providers,
+        models: current.models,
+        defaultProvider: current.defaultProvider,
+        defaultModel: current.defaultModel,
+        thinking: current.thinking,
+      },
+      {
+        providers: {
+          replacement: {
+            type: 'openai',
+            apiKey: 'YOUR_API_KEY',
+          },
+        },
+        models: {
+          replacement: {
+            provider: 'replacement',
+            model: 'replacement-model',
+            maxContextSize: 262144,
+          },
+        },
+        defaultProvider: undefined,
+        defaultModel: undefined,
+        thinking: undefined,
+      },
+    );
+
+    expect(updated).toMatchObject({
+      providers: {
+        replacement: {
+          type: 'openai',
+          apiKey: 'YOUR_API_KEY',
+        },
+      },
+      models: {
+        replacement: {
+          provider: 'replacement',
+          model: 'replacement-model',
+        },
+      },
+      services: current.services,
+    });
+    expect(updated.defaultProvider).toBeUndefined();
+    expect(updated.defaultModel).toBeUndefined();
+    expect(updated.thinking).toBeUndefined();
+    expect(updated.raw?.['theme']).toBe('dark');
   });
 
   it('does not write invalid config patches', async () => {

--- a/packages/oauth/src/index.ts
+++ b/packages/oauth/src/index.ts
@@ -163,6 +163,7 @@ export type {
 
 export { refreshProviderModels } from './refreshProviderModels';
 export type {
+  ManagedKimiModelCatalogSnapshot,
   ProviderChange,
   RefreshProviderHost,
   RefreshProviderOptions,

--- a/packages/oauth/src/managed-kimi-code.ts
+++ b/packages/oauth/src/managed-kimi-code.ts
@@ -173,6 +173,7 @@ export interface ManagedKimiThinkingShape {
 export interface ManagedKimiConfigShape {
   providers: Record<string, ManagedKimiProviderConfig | Record<string, unknown>>;
   models?: Record<string, ManagedKimiModelAlias | Record<string, unknown>> | undefined;
+  defaultProvider?: string;
   defaultModel?: string | undefined;
   thinking?: ManagedKimiThinkingShape | undefined;
   services?: ManagedKimiServicesConfig | undefined;
@@ -182,6 +183,7 @@ export interface ManagedKimiConfigShape {
 export interface ManagedKimiConfigAdapter<TConfig> {
   read(): Promise<TConfig> | TConfig;
   write(config: TConfig): Promise<void> | void;
+  atomicUpdate?<TResult>(update: (config: TConfig) => TResult): Promise<TResult> | TResult;
   apply(
     config: TConfig,
     input: {
@@ -726,6 +728,10 @@ export function clearManagedKimiCodeConfig(
     defaultModelCleared = true;
   }
 
+  if (config.defaultProvider === KIMI_CODE_PROVIDER_NAME) {
+    config.defaultProvider = undefined;
+  }
+
   const removedServices: string[] = [];
   if (config.services?.moonshotSearch !== undefined) {
     delete config.services.moonshotSearch;
@@ -764,15 +770,22 @@ export async function provisionManagedKimiCodeConfig<TConfig>(
   options: ProvisionManagedKimiCodeConfigOptions<TConfig>,
 ): Promise<ManagedKimiCodeProvisionResult> {
   const models = await fetchManagedKimiCodeModels(options);
-  const config = await options.adapter.read();
-  const applied = options.adapter.apply(config, {
-    models,
-    baseUrl: options.baseUrl,
-    oauthKey: options.oauthKey,
-    oauthHost: options.oauthHost,
-    preserveDefaultModel: options.preserveDefaultModel,
-  });
-  await options.adapter.write(config);
+  const apply = (config: TConfig): ManagedKimiCodeApplyResult =>
+    options.adapter.apply(config, {
+      models,
+      baseUrl: options.baseUrl,
+      oauthKey: options.oauthKey,
+      oauthHost: options.oauthHost,
+      preserveDefaultModel: options.preserveDefaultModel,
+    });
+  let applied: ManagedKimiCodeApplyResult;
+  if (options.adapter.atomicUpdate === undefined) {
+    const config = await options.adapter.read();
+    applied = apply(config);
+    await options.adapter.write(config);
+  } else {
+    applied = await options.adapter.atomicUpdate(apply);
+  }
   return {
     providerName: KIMI_CODE_PROVIDER_NAME,
     defaultModel: applied.defaultModel,

--- a/packages/oauth/src/refreshProviderModels.ts
+++ b/packages/oauth/src/refreshProviderModels.ts
@@ -32,6 +32,10 @@ export interface RefreshProviderHost {
   getConfig(): Promise<ManagedKimiConfigShape>;
   removeProvider(providerId: string): Promise<ManagedKimiConfigShape>;
   setConfig(patch: ManagedKimiConfigShape): Promise<ManagedKimiConfigShape>;
+  replaceModelCatalog?(
+    expected: ManagedKimiModelCatalogSnapshot,
+    next: ManagedKimiModelCatalogSnapshot,
+  ): Promise<ManagedKimiConfigShape>;
   resolveOAuthToken(providerName: string, oauthRef?: ManagedKimiOAuthRef): Promise<string>;
   /**
    * Product User-Agent sent on custom-registry (api.json) fetches, e.g.
@@ -39,6 +43,14 @@ export interface RefreshProviderHost {
    * default (`User-Agent: node`).
    */
   readonly userAgent?: string;
+}
+
+export interface ManagedKimiModelCatalogSnapshot {
+  readonly providers: ManagedKimiConfigShape['providers'];
+  readonly models: ManagedKimiConfigShape['models'];
+  readonly defaultProvider: string | undefined;
+  readonly defaultModel: string | undefined;
+  readonly thinking: ManagedKimiConfigShape['thinking'];
 }
 
 export interface ProviderChange {
@@ -295,9 +307,7 @@ function restoreDefaultSelection(
 }
 
 // `apply*` may leave `defaultModel` pointing at an alias that no longer exists
-// (e.g. the previously-selected model was dropped from the registry). The host's
-// `setConfig` deep-merge cannot clear a key, so the matching `removeProvider`
-// call handles disk cleanup while this drops the dangling reference in memory.
+// (e.g. the previously-selected model was dropped from the registry).
 function clampDanglingDefault(config: ManagedKimiConfigShape): void {
   if (config.defaultModel !== undefined && readModel(config, config.defaultModel) === undefined) {
     config.defaultModel = undefined;
@@ -312,6 +322,41 @@ function clearDefaultThinkingWhenDefaultRemoved(
   if (previousDefaultModel !== undefined && config.defaultModel === undefined) {
     config.thinking = undefined;
   }
+}
+
+function modelCatalogSnapshot(
+  config: ManagedKimiConfigShape,
+): ManagedKimiModelCatalogSnapshot {
+  return {
+    providers: config.providers,
+    models: config.models,
+    defaultProvider: config.defaultProvider,
+    defaultModel: config.defaultModel,
+    thinking: config.thinking,
+  };
+}
+
+async function persistModelCatalog(
+  host: RefreshProviderHost,
+  current: ManagedKimiConfigShape,
+  next: ManagedKimiConfigShape,
+  providersToRemove: readonly string[],
+): Promise<ManagedKimiConfigShape> {
+  const expectedCatalog = modelCatalogSnapshot(current);
+  const nextCatalog = modelCatalogSnapshot(next);
+  if (host.replaceModelCatalog !== undefined) {
+    return host.replaceModelCatalog(expectedCatalog, nextCatalog);
+  }
+  for (const providerId of providersToRemove) {
+    await host.removeProvider(providerId);
+  }
+  return host.setConfig({
+    providers: nextCatalog.providers,
+    models: nextCatalog.models,
+    defaultProvider: nextCatalog.defaultProvider,
+    defaultModel: nextCatalog.defaultModel,
+    thinking: nextCatalog.thinking,
+  });
 }
 
 function pickDefaultModel(
@@ -343,8 +388,9 @@ function pickDefaultModel(
  *  2. Open platforms (moonshot-cn, moonshot-ai, …) — platform catalog fetch.
  *  3. Custom registries (models.dev-style, keyed by `provider.source`).
  *
- * Each branch diffs old vs new and only writes when something actually changed
- * (`removeProvider` then `setConfig`). Failures are collected per-provider and
+ * Each branch diffs old vs new and only writes when something actually changed.
+ * Hosts with `replaceModelCatalog` commit the catalog atomically; legacy hosts
+ * retain the remove-then-set fallback. Failures are collected per-provider and
  * never abort the whole refresh. Pass `providerId` to scope the refresh to a
  * single provider; pass `scope: 'oauth'` to refresh only the managed provider.
  */
@@ -411,13 +457,7 @@ export async function refreshProviderModels(
             collectModelIdsForAliases(config, refreshedAliasKeys),
             collectModelIdsForAliases(next, refreshedAliasKeys),
           );
-          await host.removeProvider(KIMI_CODE_PROVIDER_NAME);
-          config = await host.setConfig({
-            providers: next.providers,
-            models: next.models,
-            defaultModel: next.defaultModel,
-            thinking: next.thinking,
-          });
+          config = await persistModelCatalog(host, config, next, [KIMI_CODE_PROVIDER_NAME]);
           changed.push({
             providerId: KIMI_CODE_PROVIDER_NAME,
             providerName: 'Kimi Code',
@@ -486,13 +526,7 @@ export async function refreshProviderModels(
           collectModelIdsForAliases(config, refreshedAliasKeys),
           collectModelIdsForAliases(next, refreshedAliasKeys),
         );
-        await host.removeProvider(providerId);
-        config = await host.setConfig({
-          providers: next.providers,
-          models: next.models,
-          defaultModel: next.defaultModel,
-          thinking: next.thinking,
-        });
+        config = await persistModelCatalog(host, config, next, [providerId]);
         changed.push({
           providerId,
           providerName: platform.name,
@@ -626,15 +660,12 @@ export async function refreshProviderModels(
         restoreDefaultSelection(next, config.defaultModel, config.thinking?.enabled);
         clampDanglingDefault(next);
         clearDefaultThinkingWhenDefaultRemoved(next, config.defaultModel);
-        for (const providerId of providersToRemoveBeforeSet) {
-          await host.removeProvider(providerId);
-        }
-        config = await host.setConfig({
-          providers: next.providers,
-          models: next.models,
-          defaultModel: next.defaultModel,
-          thinking: next.thinking,
-        });
+        config = await persistModelCatalog(
+          host,
+          config,
+          next,
+          [...providersToRemoveBeforeSet],
+        );
         for (const change of changedProviders) {
           changed.push({
             providerId: change.providerId,

--- a/packages/oauth/src/toolkit.ts
+++ b/packages/oauth/src/toolkit.ts
@@ -232,9 +232,14 @@ export class KimiOAuthToolkit<TConfig = unknown> {
     const oauthKey = oauthRef?.key ?? this.defaultOAuthKey(undefined, oauthHost);
     await this.managerFor(name, oauthKey, oauthHost).logout();
     if (this.configAdapter?.remove !== undefined && name === KIMI_CODE_PROVIDER_NAME) {
-      const config = await this.configAdapter.read();
-      this.configAdapter.remove(config);
-      await this.configAdapter.write(config);
+      const remove = this.configAdapter.remove.bind(this.configAdapter);
+      if (this.configAdapter.atomicUpdate === undefined) {
+        const config = await this.configAdapter.read();
+        remove(config);
+        await this.configAdapter.write(config);
+      } else {
+        await this.configAdapter.atomicUpdate(remove);
+      }
     }
     return { providerName: name, ok: true };
   }

--- a/packages/oauth/test/managed-kimi-code.test.ts
+++ b/packages/oauth/test/managed-kimi-code.test.ts
@@ -1,3 +1,9 @@
+/**
+ * Managed Kimi Code scenarios: model discovery, provisioning, refresh merge, and logout cleanup.
+ * Wiring: real config transforms with fetch as the only external boundary.
+ * Run: pnpm --filter @moonshot-ai/kimi-code-oauth exec vitest run test/managed-kimi-code.test.ts
+ */
+
 import { describe, expect, it, vi } from 'vitest';
 
 import {
@@ -271,6 +277,36 @@ describe('provisionManagedKimiCodeConfig', () => {
       oauth: { storage: 'file', key: 'oauth/kimi-code' },
     });
     expect(Object.keys(config.services ?? {})).toEqual(['moonshotSearch', 'moonshotFetch']);
+  });
+
+  it('commits provisioning through the adapter atomic update when available', async () => {
+    const config: ManagedKimiConfigShape = { providers: {} };
+    const read = vi.fn(() => config);
+    const write = vi.fn();
+    let atomicUpdateCalls = 0;
+    const atomicUpdate = <TResult>(
+      update: (target: ManagedKimiConfigShape) => TResult,
+    ): TResult => {
+      atomicUpdateCalls += 1;
+      return update(config);
+    };
+
+    const result = await provisionManagedKimiCodeConfig<ManagedKimiConfigShape>({
+      accessToken: 'oauth-access-token',
+      fetchImpl: vi.fn(async () => makeModelsResponse()) as unknown as typeof fetch,
+      adapter: {
+        read,
+        write,
+        atomicUpdate,
+        apply: applyManagedKimiCodeConfig,
+      },
+    });
+
+    expect(result.defaultModel).toBe('kimi-code/kimi-for-coding');
+    expect(config.providers[KIMI_CODE_PROVIDER_NAME]).toBeDefined();
+    expect(atomicUpdateCalls).toBe(1);
+    expect(read).not.toHaveBeenCalled();
+    expect(write).not.toHaveBeenCalled();
   });
 
   it('writes scoped OAuth refs when provisioning against a non-default environment', async () => {
@@ -790,6 +826,7 @@ describe('provisionManagedKimiCodeConfig', () => {
           apiKey: 'sk-existing',
         },
       },
+      defaultProvider: KIMI_CODE_PROVIDER_NAME,
       defaultModel: 'kimi-code/kimi-for-coding',
       models: {
         'kimi-code/kimi-for-coding': {
@@ -829,6 +866,7 @@ describe('provisionManagedKimiCodeConfig', () => {
     });
     expect(config.providers[KIMI_CODE_PROVIDER_NAME]).toBeUndefined();
     expect(config.providers['custom']).toMatchObject({ apiKey: 'sk-existing' });
+    expect(config.defaultProvider).toBeUndefined();
     expect(config.defaultModel).toBeUndefined();
     expect(config.models?.['kimi-code/kimi-for-coding']).toBeUndefined();
     expect(config.models?.['custom-default']).toMatchObject({ provider: 'custom' });

--- a/packages/oauth/test/toolkit.test.ts
+++ b/packages/oauth/test/toolkit.test.ts
@@ -1,3 +1,9 @@
+/**
+ * OAuth toolkit scenarios: credential lifecycle, managed config provisioning, and cleanup.
+ * Wiring: in-memory token storage and config adapters with fetch as the external boundary.
+ * Run: pnpm --filter @moonshot-ai/kimi-code-oauth exec vitest run test/toolkit.test.ts
+ */
+
 import { join } from 'node:path';
 
 import { afterEach, describe, expect, it, vi } from 'vitest';
@@ -643,7 +649,9 @@ describe('KimiOAuthToolkit', () => {
   it('removes managed config on logout when an adapter supports cleanup', async () => {
     const storage = new MemoryTokenStorage();
     storage.tokens.set('kimi-code', token('access-1'));
-    const config = { providers: { [KIMI_CODE_PROVIDER_NAME]: { type: 'kimi' } } };
+    const config: { providers: Record<string, { type: string } | undefined> } = {
+      providers: { [KIMI_CODE_PROVIDER_NAME]: { type: 'kimi' } },
+    };
     const write = vi.fn();
     const remove = vi.fn();
     const toolkit = new KimiOAuthToolkit({
@@ -666,5 +674,41 @@ describe('KimiOAuthToolkit', () => {
     expect(remove).toHaveBeenCalledWith(config);
     expect(write).toHaveBeenCalledWith(config);
     await expect(storage.load('kimi-code')).resolves.toBeUndefined();
+  });
+
+  it('removes managed config through the adapter atomic update when available', async () => {
+    const storage = new MemoryTokenStorage();
+    storage.tokens.set('kimi-code', token('access-1'));
+    const config = { providers: { [KIMI_CODE_PROVIDER_NAME]: { type: 'kimi' } } };
+    const read = vi.fn(() => config);
+    const write = vi.fn();
+    const remove = vi.fn((target: typeof config) => {
+      Reflect.deleteProperty(target.providers, KIMI_CODE_PROVIDER_NAME);
+    });
+    let atomicUpdateCalls = 0;
+    const atomicUpdate = <TResult>(update: (target: typeof config) => TResult): TResult => {
+      atomicUpdateCalls += 1;
+      return update(config);
+    };
+    const toolkit = new KimiOAuthToolkit<typeof config>({
+      homeDir: join('/tmp', 'kimi-oauth-toolkit-test'),
+      identity: TEST_IDENTITY,
+      storage,
+      now: () => 100,
+      configAdapter: {
+        read,
+        write,
+        atomicUpdate,
+        apply: () => ({ defaultModel: 'kimi-code/kimi-for-coding', defaultThinking: true }),
+        remove,
+      },
+    });
+
+    await toolkit.logout();
+
+    expect(config.providers[KIMI_CODE_PROVIDER_NAME]).toBeUndefined();
+    expect(atomicUpdateCalls).toBe(1);
+    expect(read).not.toHaveBeenCalled();
+    expect(write).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Related Issue

No linked issue. This fixes a reproducible production session where configured tools were omitted from model requests.

## Problem

The TUI could start a background provider-model refresh before the session runtime was ready. The v1 refresh path removed a provider and restored its catalog in separate writes, exposing a temporary provider-less configuration. A session created in that window skipped builtin-tool initialization permanently, so subsequent LLM requests carried an empty tool list even though tools were configured.

Independent model-catalog and OAuth configuration writes could also overwrite one another or leave dangling default selections.

## What changed

- Start background provider refresh only after a fresh, resumed, picker-selected, or OAuth-recovered session is runtime-ready, and only once per TUI instance.
- Lazily initialize builtin tools before first use when a provider becomes available after agent construction.
- Replace provider/model catalogs atomically with optimistic conflict detection in both engines.
- Serialize v1 configuration mutations and route OAuth provisioning and cleanup through the same writer.
- Preserve missing-section semantics, clear dangling defaults on logout, and retain compatible fallbacks for legacy hosts.
- Add persisted-storage, public SDK, DI wiring, startup-ordering, stale-snapshot, rollback, and first-request tool regression coverage.

## Validation

- Full tests: agent-core 3763 passed; node SDK 194 passed; OAuth 254 passed; CLI 2282 passed; agent-core-v2 3306 passed.
- Type checks passed for all five affected packages.
- Changed-file type-aware lint: 0 errors.
- v2 domain-layer lint passed.
- `git diff --check` passed.
- Release changeset included.
- No user documentation update is needed because this restores the documented tool lifecycle and startup refresh behavior.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.