### PR TITLE
chore: remove stale changeset for removed server package

### DIFF
--- a/.changeset/stabilize-approval-test-cleanup.md
+++ b/.changeset/stabilize-approval-test-cleanup.md
@@ -1,5 +1,0 @@
----
-"@moonshot-ai/server": patch
----
-
-Stabilize server approval end-to-end test cleanup after daemon shutdown.


### PR DESCRIPTION
## Related Issue

No related issue — see the problem description below.

## Problem

The legacy `@moonshot-ai/server` package was removed from the workspace, but `.changeset/stabilize-approval-test-cleanup.md` still referenced it in its frontmatter. A changeset pointing at a non-existent package is dead release metadata and can break `changeset version` / release tooling.

## What changed

Delete `.changeset/stabilize-approval-test-cleanup.md`. The change it described (stabilizing server approval e2e test cleanup) lived entirely in the removed package, so there is nothing left to release or retarget.

Verified that no other file under `.changeset/` references `@moonshot-ai/server`, and that every package name in the remaining changeset frontmatter and in `config.json`'s `ignore` list still exists in the workspace.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works. (N/A — changeset metadata cleanup only.)
- [x] Ran `gen-changesets` skill, or this PR needs no changeset. (No package source changed; nothing to release.)
- [x] Ran `gen-docs` skill, or this PR needs no doc update. (No user-facing behavior change.)
