### PR TITLE
fix(agent-core-v2): keep invalidated OAuth flows observable during login

### DIFF
--- a/.changeset/fix-oauth-login-invalidation.md
+++ b/.changeset/fix-oauth-login-invalidation.md
@@ -1,5 +1,6 @@
 ---
+"@moonshot-ai/agent-core-v2": patch
 "@moonshot-ai/kimi-code": patch
 ---
 
-Fix OAuth login hanging after successful browser authorization when the provider configuration changed during sign-in, and strip trailing slashes from the KIMI_CODE_BASE_URL override.
+Fix OAuth login hanging after browser authorization when the provider configuration changes during sign-in.

--- a/.changeset/fix-oauth-login-invalidation.md
+++ b/.changeset/fix-oauth-login-invalidation.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Fix OAuth login hanging after successful browser authorization when the provider configuration changed during sign-in, and strip trailing slashes from the KIMI_CODE_BASE_URL override.

--- a/packages/agent-core-v2/src/app/auth/authService.ts
+++ b/packages/agent-core-v2/src/app/auth/authService.ts
@@ -423,18 +423,8 @@ export class OAuthService extends Disposable implements IOAuthService {
     if (affected.size === 0) return;
     for (const state of this.flows.values()) {
       if (!affected.has(state.provider)) continue;
-      // Terminal flows keep their retention — deleting them here would void
-      // the TERMINAL_RETENTION_MS window clients rely on to observe outcomes.
       if (state.status !== 'pending') continue;
       state.controller.abort();
-      // Transition the status instead of deleting from the map: the
-      // `state.status !== 'pending'` guards in handleSuccess /
-      // finalizeAuthentication then observe the invalidation even when it
-      // lands in the microtask gap after toolkit.login resolved (an abort
-      // is inert once the final poll returned). A bare delete left those
-      // guards blind and let setTerminal write 'authenticated' onto an
-      // orphaned state the client could never see. handleFailure does not
-      // run for this flow, so record the reason here.
       state.errorMessage = 'Provider configuration changed during login.';
       this.setTerminal(state, 'cancelled');
     }

--- a/packages/agent-core-v2/src/app/auth/authService.ts
+++ b/packages/agent-core-v2/src/app/auth/authService.ts
@@ -423,13 +423,20 @@ export class OAuthService extends Disposable implements IOAuthService {
     if (affected.size === 0) return;
     for (const state of this.flows.values()) {
       if (!affected.has(state.provider)) continue;
-      if (state.status === 'pending') {
-        state.controller.abort();
-      }
-      if (state.gcTimer !== undefined) {
-        clearTimeout(state.gcTimer);
-      }
-      this.flows.delete(state.provider);
+      // Terminal flows keep their retention — deleting them here would void
+      // the TERMINAL_RETENTION_MS window clients rely on to observe outcomes.
+      if (state.status !== 'pending') continue;
+      state.controller.abort();
+      // Transition the status instead of deleting from the map: the
+      // `state.status !== 'pending'` guards in handleSuccess /
+      // finalizeAuthentication then observe the invalidation even when it
+      // lands in the microtask gap after toolkit.login resolved (an abort
+      // is inert once the final poll returned). A bare delete left those
+      // guards blind and let setTerminal write 'authenticated' onto an
+      // orphaned state the client could never see. handleFailure does not
+      // run for this flow, so record the reason here.
+      state.errorMessage = 'Provider configuration changed during login.';
+      this.setTerminal(state, 'cancelled');
     }
   }
 

--- a/packages/agent-core-v2/test/app/auth/auth.test.ts
+++ b/packages/agent-core-v2/test/app/auth/auth.test.ts
@@ -492,7 +492,52 @@ describe('OAuthService', () => {
 
     providerChangedEmitter.fire({ added: [], removed: [OAUTH_PROVIDER], changed: [] });
 
-    expect(svc.getFlow(OAUTH_PROVIDER)).toBeUndefined();
+    // The flow transitions to a visible terminal status and stays observable
+    // for the retention window instead of vanishing from the map.
+    const flow = svc.getFlow(OAUTH_PROVIDER);
+    expect(flow?.status).toBe('cancelled');
+    expect(flow?.error_message).toBe('Provider configuration changed during login.');
+  });
+
+  it('marks an in-flight OAuth flow cancelled (not vanished) when its provider config changes', async () => {
+    toolkit.login.mockImplementation((_provider, options) => {
+      options.onDeviceCode(deviceAuth);
+      return new Promise(() => { });
+    });
+    const svc = createService();
+    await svc.startLogin(OAUTH_PROVIDER);
+    expect(svc.getFlow(OAUTH_PROVIDER)?.status).toBe('pending');
+
+    providerChangedEmitter.fire({ added: [], removed: [], changed: [OAUTH_PROVIDER] });
+
+    const flow = svc.getFlow(OAUTH_PROVIDER);
+    expect(flow?.status).toBe('cancelled');
+    expect(flow?.error_message).toBe('Provider configuration changed during login.');
+  });
+
+  it('does not finalize a login whose provider changed after toolkit.login resolved', async () => {
+    // The microtask gap: the login promise has resolved but the .then
+    // handlers (handleSuccess) have not run yet. An invalidation landing in
+    // this window must still be observed — a bare map delete here is
+    // invisible to the finalization guards and would strand the flow:
+    // setTerminal would write 'authenticated' onto a state getFlow can
+    // never return.
+    let resolveLogin!: (value: { providerName: string; ok: true }) => void;
+    toolkit.login.mockImplementation((_provider, options) => {
+      options.onDeviceCode(deviceAuth);
+      return new Promise((resolve) => {
+        resolveLogin = resolve;
+      });
+    });
+    const svc = createService();
+    await svc.startLogin(OAUTH_PROVIDER);
+    expect(svc.getFlow(OAUTH_PROVIDER)?.status).toBe('pending');
+
+    resolveLogin({ providerName: OAUTH_PROVIDER, ok: true });
+    // Synchronous window: loginPromise settled, .then microtasks pending.
+    providerChangedEmitter.fire({ added: [], removed: [], changed: [OAUTH_PROVIDER] });
+
+    await vi.waitFor(() => expect(svc.getFlow(OAUTH_PROVIDER)?.status).toBe('cancelled'));
   });
 
   it('cancelLogin aborts a pending flow and marks it cancelled', async () => {

--- a/packages/agent-core-v2/test/app/auth/auth.test.ts
+++ b/packages/agent-core-v2/test/app/auth/auth.test.ts
@@ -492,8 +492,6 @@ describe('OAuthService', () => {
 
     providerChangedEmitter.fire({ added: [], removed: [OAUTH_PROVIDER], changed: [] });
 
-    // The flow transitions to a visible terminal status and stays observable
-    // for the retention window instead of vanishing from the map.
     const flow = svc.getFlow(OAUTH_PROVIDER);
     expect(flow?.status).toBe('cancelled');
     expect(flow?.error_message).toBe('Provider configuration changed during login.');
@@ -516,12 +514,6 @@ describe('OAuthService', () => {
   });
 
   it('does not finalize a login whose provider changed after toolkit.login resolved', async () => {
-    // The microtask gap: the login promise has resolved but the .then
-    // handlers (handleSuccess) have not run yet. An invalidation landing in
-    // this window must still be observed — a bare map delete here is
-    // invisible to the finalization guards and would strand the flow:
-    // setTerminal would write 'authenticated' onto a state getFlow can
-    // never return.
     let resolveLogin!: (value: { providerName: string; ok: true }) => void;
     toolkit.login.mockImplementation((_provider, options) => {
       options.onDeviceCode(deviceAuth);
@@ -534,7 +526,6 @@ describe('OAuthService', () => {
     expect(svc.getFlow(OAUTH_PROVIDER)?.status).toBe('pending');
 
     resolveLogin({ providerName: OAUTH_PROVIDER, ok: true });
-    // Synchronous window: loginPromise settled, .then microtasks pending.
     providerChangedEmitter.fire({ added: [], removed: [], changed: [OAUTH_PROVIDER] });
 
     await vi.waitFor(() => expect(svc.getFlow(OAUTH_PROVIDER)?.status).toBe('cancelled'));

--- a/packages/oauth/src/managed-usage.ts
+++ b/packages/oauth/src/managed-usage.ts
@@ -31,11 +31,15 @@ export function isManagedKimiCode(providerKey?: string | null): boolean {
 }
 
 export function kimiCodeBaseUrl(): string {
-  return process.env['KIMI_CODE_BASE_URL'] ?? DEFAULT_KIMI_CODE_BASE_URL;
+  // Single source of truth for the canonical base-url shape: normalize the
+  // env override here instead of letting a trailing slash leak into the
+  // persisted provider entry, where a later normalized rewrite would diff
+  // against it and emit a spurious providers-changed event during login.
+  return (process.env['KIMI_CODE_BASE_URL'] ?? DEFAULT_KIMI_CODE_BASE_URL).replace(/\/+$/, '');
 }
 
 export function kimiCodeUsageUrl(): string {
-  return `${kimiCodeBaseUrl().replace(/\/+$/, '')}/usages`;
+  return `${kimiCodeBaseUrl()}/usages`;
 }
 
 export interface UsageRow {

--- a/packages/oauth/test/managed-usage.test.ts
+++ b/packages/oauth/test/managed-usage.test.ts
@@ -5,11 +5,26 @@ import {
   formatDuration,
   formatResetTime,
   isManagedKimiCode,
+  kimiCodeBaseUrl,
+  kimiCodeUsageUrl,
   parseManagedUsagePayload,
 } from '../src/managed-usage';
 
 afterEach(() => {
   vi.unstubAllGlobals();
+  vi.unstubAllEnvs();
+});
+
+describe('kimiCodeBaseUrl', () => {
+  it('strips trailing slashes from the KIMI_CODE_BASE_URL override', () => {
+    // The env value must be normalized at the source: provision persists it
+    // verbatim while the model refresh rewrites it normalized, and the
+    // deep-equal diff between the two shapes would fire a spurious
+    // providers-changed event mid-login.
+    vi.stubEnv('KIMI_CODE_BASE_URL', 'https://gw.example.com/');
+    expect(kimiCodeBaseUrl()).toBe('https://gw.example.com');
+    expect(kimiCodeUsageUrl()).toBe('https://gw.example.com/usages');
+  });
 });
 
 describe('isManagedKimiCode', () => {


### PR DESCRIPTION
## Related Issue

No linked issue — the problem is explained below.

## Problem

When the provider configuration changed while a device-code OAuth login was in flight (e.g. a managed-provider model refresh rewriting the persisted config mid-login), `OAuthService.invalidateFlows()` deleted the flow from the map outright. Two consequences:

1. Terminal flows lost their `TERMINAL_RETENTION_MS` observability window.
2. If the invalidation landed in the microtask gap after `toolkit.login` resolved but before `handleSuccess` ran, the `state.status !== 'pending'` guards there could not observe it (an abort is inert once the final poll returned). `setTerminal` then wrote `authenticated` onto an orphaned state that `getFlow` could never return — the login hung after a successful browser authorization.

A related trigger: a `KIMI_CODE_BASE_URL` override with a trailing slash was persisted verbatim by provision but rewritten normalized by the model refresh, and the deep-equal diff between the two shapes fired a spurious providers-changed event during login.

## What changed

- `invalidateFlows()` now transitions affected pending flows to a visible `cancelled` terminal status (with an explanatory `error_message`) instead of deleting them, mirroring the existing `abortExisting()` behavior; non-pending flows keep their retention window.
- `kimiCodeBaseUrl()` strips trailing slashes from the `KIMI_CODE_BASE_URL` env override at the source, so the persisted and the rewritten provider configs share the same canonical shape.
- Tests: three new cases in `auth.test.ts` (provider removed, provider changed, and the post-resolve microtask gap) and a normalization test in `managed-usage.test.ts`.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.