### PR TITLE
feat(agent-core-v2): plan lifecycle events, atomic config refresh, and comment cleanup

### DIFF
--- a/.changeset/atomic-catalog-refresh.md
+++ b/.changeset/atomic-catalog-refresh.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Apply provider model refreshes as a single atomic config commit, so requests landing during a refresh no longer fail with transient model-resolution errors and sessions created mid-refresh no longer permanently lose the WebSearch tool.

--- a/.changeset/v2-plan-lifecycle-events.md
+++ b/.changeset/v2-plan-lifecycle-events.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/agent-core-v2": patch
+---
+
+Emit plan mode lifecycle events (entered, exited with an approved/rejected/host reason, cancelled) from the plan domain so other services can react to plan approval and cancellation.

--- a/packages/agent-core-v2/AGENTS.md
+++ b/packages/agent-core-v2/AGENTS.md
@@ -1,61 +1,9 @@
 # agent-core-v2 Agent Guide
 
-> New agent engine built on the DI Scope architecture — work-in-progress port of `packages/agent-core`. Design: `plan/PLAN.md`. Porting status: `GAP_ANALYSIS.md`.
+## Use the agent-core-dev skill
 
-## Examples
+All development in this package — adding or modifying a Service, choosing a scope, wiring DI dependencies, writing tests, or porting logic from `packages/agent-core` — must follow the `agent-core-dev` skill (`.agents/skills/agent-core-dev/SKILL.md`). Load it before touching any code here; it is the single source of truth for this package's architecture, conventions, and red lines.
 
-> The runnable examples have moved to the standalone `kimi-code-mini-bench` package at `../kimi-code-mini-bench`. They are wired to `agent-core-v2` through a pnpm `link:` dependency and run as a separate Vitest project.
+## Do not write comments
 
-Domain-slice scenarios that used to live in `examples/<name>.example.ts` are now maintained there. Each `*.example.ts` exercises one subset of domains end-to-end, builds its own container, runs its slice's services for real, and stubs collaborators outside the slice. See `../kimi-code-mini-bench/README.md` for how to run them.
-
-## Comment conventions
-
-- **Header only, external role only.** Comments live solely in the top-of-file `/** */` block — never beside functions, methods, or statements. Say what the module exposes and the responsibility it owns; the code is the source of truth for how it works, so do not narrate implementation steps, enumerate every export, or note porting / skeleton status.
-- **Identity line first.** Start with `` `<domain>` domain (Ln) — <one-line role>. `` Keep an existing `(cross-cutting)` label as-is. Write the role as a responsibility ("drives the turn lifecycle"), not a symbol list ("turn driver + context + loop runner").
-- **Impl files add collaborators + scope; contract files add the public contract + scope.** For impls, list every imported cross-domain collaborator as a role ("persists records through `records`") — declared dependencies count even if not yet wired in this WIP port; infrastructure imports (`_base/**`) are not collaborators. Read scope from `registerScopedService(LifecycleScope.X, …)`.
-
-### Examples
-
-Impl (`src/session/sessionMetadata/sessionMetadataService.ts`):
-
-```ts
-/**
- * `sessionMetadata` domain (L6) — `ISessionMetadata` implementation.
- *
- * Persists the session metadata document (`state.json`) through the `storage`
- * access-pattern store (`IAtomicDocumentStore`), rooted at the `metaScope`
- * namespace from `sessionContext`. Loads the existing document on
- * construction (creating it on first run), and logs through `log`. Bound at
- * Session scope.
- */
-```
-
-## Telemetry
-
-Business events go through `ITelemetryService.track2` — never the low-level `track`, which exists only for appender plumbing and tests. Every event must be registered in `src/app/telemetry/events.ts` (`telemetryEventDefinitions`) before it is emitted: define a properties interface, register it with `defineTelemetryEvent<P>({ owner, comment, properties })`, and document every property — the compiler rejects unregistered event names and any property mismatch at the call site.
-
-- **Naming**: event names and property keys are snake_case (`tool_call`, `duration_ms`). Durations, counts, and sizes carry a unit suffix (`_ms` / `_count` / `_bytes`). Use specific names (`error_type`, not `error`).
-- **Privacy**: never register user content, prompts, or file paths as properties. `CloudAppender` redacts URLs, emails, tokens, and absolute paths from string values before events leave the process, but that is a safety net, not a license.
-- **Stability**: registered event names and property keys are wire data consumed by dashboards — treat renames as breaking changes.
-- The registry is the single source of truth; `test/app/telemetry/events.test.ts` enforces the naming conventions.
-
-## Persistence
-
-Business domains **do not implement persistence themselves** — they depend on a Service that owns the access pattern. Business code expresses *what* to store or fetch, never *how*.
-
-- Append-log → `IAppendLogStore`
-- Atomic document → `IAtomicDocumentStore`
-- Blob → `IBlobStore`
-- Domain-specific query → a dedicated Store (e.g. `ISessionIndex`)
-
-Business code must not `import 'node:fs'`, write SQL, hand-roll append-logs / atomic writes, or hold file handles. Generic Stores are named by **access pattern** (`IAppendLogStore`, `IAtomicDocumentStore`); only domain-unique Stores are named after the domain (`ISessionIndex`). See `.agents/skills/agent-core-dev/persistence.md` for the full layering rules and decision tree.
-
-## Docs
-
-Per-domain references live in `docs/`.
-
-- [`docs/di.md`](docs/di.md) — Read **before adding any business capability**: a scenario-driven walkthrough of the DI × Scope black box, from "add a global service" through dependency injection, scope selection, disposal, delayed/eager instantiation, `invokeFunction`, `createInstance`, child scopes, and cycles — introducing each concept only as the scenario needs it.
-- [`docs/service-design.md`](docs/service-design.md) — Read **before designing a new Service**: first-principles rules for choosing a scope, splitting a domain Multi-Scope, picking a calling style (direct call vs event vs hook), and directing dependencies — the design companion to `docs/di.md`.
-- [`docs/flag.md`](docs/flag.md) — Read **before gating behavior behind a feature flag**: declaring a flag in its owning domain and registering it at import time via `registerFlagDefinition`, checking `IFlagService.enabled(id)`, wiring the `[experimental]` config section, or deciding whether a flag is App-scope vs. per-session.
-- [`docs/errors.md`](docs/errors.md) — Read **before raising errors from a domain**: defining a co-located `XxxError`, registering a code in `ErrorCodes`/`ERROR_INFO`, translating external errors (provider/HTTP, fs, MCP) at the boundary, or (de)serializing errors across RPC/SDK with `toErrorPayload`/`fromErrorPayload`.
-- [`docs/di-testing.md`](docs/di-testing.md) — Read **before writing or touching any DI/Scope test**: picking the right harness (`InstantiationService` vs `TestInstantiationService` vs `createScopedTestHost`), declaring deps with `@IService`, stubbing collaborators, and teardown via `DisposableStore`.
+Do not write comments beside functions, methods, or statements. The code is the source of truth for how it works — name things well instead of narrating them, and delete stale comments instead of updating them. The only exception is the mandatory top-of-file `/** */` header block, whose format the skill defines.

--- a/packages/agent-core-v2/src/agent/fullCompaction/fullCompactionService.ts
+++ b/packages/agent-core-v2/src/agent/fullCompaction/fullCompactionService.ts
@@ -528,7 +528,11 @@ export class AgentFullCompactionService extends Disposable implements IAgentFull
               {
                 messages,
                 maxOutputSize: compactionMaxOutputSize,
-                source: { type: 'operation', requestKind: 'full_compaction' },
+                source: {
+                  type: 'operation',
+                  requestKind: 'full_compaction',
+                  logFields: { droppedCount },
+                },
               },
               undefined,
               signal,

--- a/packages/agent-core-v2/src/agent/loop/loopService.ts
+++ b/packages/agent-core-v2/src/agent/loop/loopService.ts
@@ -35,7 +35,6 @@ import { InstantiationType } from '#/_base/di/extensions';
 import { Disposable, toDisposable, type IDisposable } from '#/_base/di/lifecycle';
 import { LifecycleScope, registerScopedService } from '#/_base/di/scope';
 import { abortError, isAbortError, isUserCancellation, userCancellationReason } from '#/_base/utils/abort';
-import { toErrorMessage } from '#/_base/errors/errorMessage';
 import type {
   AssistantDeltaEvent,
   ThinkingDeltaEvent,
@@ -596,7 +595,7 @@ export class AgentLoopService extends Disposable implements IAgentLoopService {
       runtime.turnId,
       runtime.current?.number,
       'aborted',
-      isUserCancellation(reason) ? undefined : toErrorMessage(reason),
+      isUserCancellation(reason) ? undefined : interruptedMessage(reason),
     );
     if (!runtime.turnSignal.aborted && step?.state === 'cancelled') {
       runtime.current = undefined;
@@ -646,7 +645,7 @@ export class AgentLoopService extends Disposable implements IAgentLoopService {
 
   private failLoopStep(runtime: LoopRuntime, error: unknown): LoopErrorDisposition {
     const reason: LoopInterruptReason = isMaxStepsExceededError(error) ? 'max_steps' : 'error';
-    this.emitStepInterrupted(runtime.turnId, runtime.current?.number, reason, toErrorMessage(error));
+    this.emitStepInterrupted(runtime.turnId, runtime.current?.number, reason, interruptedMessage(error));
     return { type: 'return', result: { type: 'failed', error, steps: runtime.steps } };
   }
 
@@ -1005,6 +1004,11 @@ function interruptReasonFor(
     return 'filtered';
   }
   return 'error';
+}
+
+function interruptedMessage(error: unknown): string {
+  if (error instanceof Error) return error.message;
+  return String(error);
 }
 
 type StepExecutionResult = {

--- a/packages/agent-core-v2/src/agent/permissionPolicy/policies/exit-plan-mode-review-ask.ts
+++ b/packages/agent-core-v2/src/agent/permissionPolicy/policies/exit-plan-mode-review-ask.ts
@@ -65,7 +65,7 @@ export class ExitPlanModeReviewAskPermissionPolicyService implements PermissionP
     }
 
     const selected = selectedExitPlanModeOption(display.options, result.selectedLabel);
-    this.plan.exit();
+    this.plan.exit('approved');
 
     if (result.selectedLabel !== undefined && result.selectedLabel.length > 0) {
       this.trackPlanTelemetry('plan_resolved', {
@@ -107,7 +107,7 @@ export class ExitPlanModeReviewAskPermissionPolicyService implements PermissionP
     }
 
     if (result.selectedLabel === 'Reject and Exit') {
-      this.plan.exit();
+      this.plan.exit('rejected');
       return {
         kind: 'result',
         syntheticResult: {

--- a/packages/agent-core-v2/src/agent/plan/plan.ts
+++ b/packages/agent-core-v2/src/agent/plan/plan.ts
@@ -1,4 +1,5 @@
 import { createDecorator } from "#/_base/di/instantiation";
+import type { Event } from '#/_base/event';
 
 export type PlanData = null | {
   readonly id: string;
@@ -8,14 +9,42 @@ export type PlanData = null | {
 
 export type PlanFilePath = string | null;
 
+/**
+ * Why plan mode was exited:
+ * - `approved`: the plan was accepted (user-approved or auto-approved in
+ *   `auto` permission mode) and execution may proceed.
+ * - `rejected`: the user chose "Reject and Exit".
+ * - `host`: the host toggled plan mode off through the session API.
+ */
+export type PlanExitReason = 'approved' | 'rejected' | 'host';
+
+export interface PlanEnteredContext {
+  readonly id: string;
+  readonly path: string;
+}
+
+export interface PlanExitedContext {
+  readonly id: string;
+  readonly path: string;
+  readonly reason: PlanExitReason;
+}
+
+export interface PlanCancelledContext {
+  readonly id?: string;
+}
+
 export interface IAgentPlanService {
   readonly _serviceBrand: undefined;
 
   enter(id?: string, createFile?: boolean): Promise<void>;
   cancel(id?: string): void;
   clear(): Promise<void>;
-  exit(id?: string): void;
+  exit(reason: PlanExitReason, id?: string): void;
   status(): Promise<PlanData>;
+
+  readonly onDidEnter: Event<PlanEnteredContext>;
+  readonly onDidExit: Event<PlanExitedContext>;
+  readonly onDidCancel: Event<PlanCancelledContext>;
 }
 
 export const IAgentPlanService =

--- a/packages/agent-core-v2/src/agent/plan/planService.ts
+++ b/packages/agent-core-v2/src/agent/plan/planService.ts
@@ -3,7 +3,9 @@
  *
  * Manages plan-mode state through `wire`, injects plan-mode context through
  * `contextInjector`, writes optional plan files through `hostFileSystem`,
- * and tags mode telemetry through `telemetry`. Bound at Agent scope.
+ * tags mode telemetry through `telemetry`, and announces lifecycle
+ * transitions through `onDidEnter` / `onDidExit` / `onDidCancel` (live path
+ * only — replay rebuilds state silently). Bound at Agent scope.
  */
 
 import { randomUUID } from 'node:crypto';
@@ -12,6 +14,7 @@ import { dirname, join } from 'pathe';
 import { Disposable } from '#/_base/di/lifecycle';
 import { InstantiationType } from '#/_base/di/extensions';
 import { LifecycleScope, registerScopedService } from '#/_base/di/scope';
+import { Emitter } from '#/_base/event';
 import { unwrapErrorCause } from '#/_base/errors/errors';
 import { generateHeroSlug } from '#/_base/utils/hero-slug';
 import { IAgentContextMemoryService } from '#/agent/contextMemory/contextMemory';
@@ -25,7 +28,11 @@ import { IAgentWireService } from '#/wire/tokens';
 import type { IWireService } from '#/wire/wireService';
 import {
   IAgentPlanService,
+  type PlanCancelledContext,
   type PlanData,
+  type PlanEnteredContext,
+  type PlanExitedContext,
+  type PlanExitReason,
   type PlanFilePath,
 } from './plan';
 import {
@@ -37,6 +44,13 @@ import {
 
 export class AgentPlanService extends Disposable implements IAgentPlanService {
   declare readonly _serviceBrand: undefined;
+
+  private readonly _onDidEnter = this._register(new Emitter<PlanEnteredContext>());
+  readonly onDidEnter = this._onDidEnter.event;
+  private readonly _onDidExit = this._register(new Emitter<PlanExitedContext>());
+  readonly onDidExit = this._onDidExit.event;
+  private readonly _onDidCancel = this._register(new Emitter<PlanCancelledContext>());
+  readonly onDidCancel = this._onDidCancel.event;
 
   constructor(
     @IAgentContextMemoryService private readonly context: IAgentContextMemoryService,
@@ -85,6 +99,7 @@ export class AgentPlanService extends Disposable implements IAgentPlanService {
       await this.ensurePlanDirectory(planFilePath);
       this.wire.dispatch(planModeEnter({ id }));
       this.telemetryContext.set({ mode: 'plan' });
+      this._onDidEnter.fire({ id, path: planFilePath });
       enterRecorded = true;
       if (createFile) {
         await this.writeEmptyPlanFile(planFilePath);
@@ -98,8 +113,12 @@ export class AgentPlanService extends Disposable implements IAgentPlanService {
   }
 
   cancel(id?: string): void {
+    const before = this.wire.getModel(PlanModel);
     this.wire.dispatch(planModeCancel({ id }));
     this.telemetryContext.set({ mode: 'agent' });
+    if (before.active) {
+      this._onDidCancel.fire({ id: before.id });
+    }
   }
 
   async clear(): Promise<void> {
@@ -108,9 +127,17 @@ export class AgentPlanService extends Disposable implements IAgentPlanService {
     await this.writeEmptyPlanFile(path);
   }
 
-  exit(id?: string): void {
+  exit(reason: PlanExitReason, id?: string): void {
+    const before = this.wire.getModel(PlanModel);
     this.wire.dispatch(planModeExit({ id }));
     this.telemetryContext.set({ mode: 'agent' });
+    if (before.active && before.id !== undefined) {
+      this._onDidExit.fire({
+        id: before.id,
+        path: this.planFilePathFor(before.id),
+        reason,
+      });
+    }
   }
 
   async status(): Promise<PlanData> {

--- a/packages/agent-core-v2/src/agent/plan/tools/exit-plan-mode.ts
+++ b/packages/agent-core-v2/src/agent/plan/tools/exit-plan-mode.ts
@@ -160,7 +160,7 @@ export class ExitPlanModeTool implements BuiltinTool<ExitPlanModeInput> {
 
   private exitPlanMode(): ExecutableToolResult | undefined {
     try {
-      this.planMode.exit();
+      this.planMode.exit('approved');
     } catch (error) {
       const message = error instanceof Error ? error.message : 'Failed to exit plan mode.';
       return {

--- a/packages/agent-core-v2/src/app/auth/authService.ts
+++ b/packages/agent-core-v2/src/app/auth/authService.ts
@@ -328,10 +328,12 @@ export class OAuthService extends Disposable implements IOAuthService {
           collectModelIdsForAliases(current, refreshedAliasKeys),
           collectModelIdsForAliases(next, refreshedAliasKeys),
         );
-        await this.config.replace(PROVIDERS_SECTION, next.providers);
-        await this.config.replace(MODELS_SECTION, next.models ?? {});
-        await this.config.set(DEFAULT_MODEL_SECTION, next.defaultModel);
-        await this.config.set(THINKING_SECTION, next.thinking);
+        await this.config.replaceAll({
+          [PROVIDERS_SECTION]: next.providers,
+          [MODELS_SECTION]: next.models ?? {},
+          [DEFAULT_MODEL_SECTION]: next.defaultModel,
+          [THINKING_SECTION]: next.thinking,
+        });
         changed.push({
           provider_id: KIMI_CODE_PROVIDER_NAME,
           provider_name: 'Kimi Code',

--- a/packages/agent-core-v2/src/app/config/config.ts
+++ b/packages/agent-core-v2/src/app/config/config.ts
@@ -155,6 +155,7 @@ export interface IConfigService {
   getAll(): ResolvedConfig;
   set(domain: string, patch: unknown, target?: ConfigTarget): Promise<void>;
   replace(domain: string, value: unknown, target?: ConfigTarget): Promise<void>;
+  replaceAll(values: Readonly<Record<string, unknown>>, target?: ConfigTarget): Promise<void>;
   reload(): Promise<void>;
   diagnostics(): readonly ConfigDiagnostic[];
 }

--- a/packages/agent-core-v2/src/app/config/configService.ts
+++ b/packages/agent-core-v2/src/app/config/configService.ts
@@ -355,6 +355,43 @@ export class ConfigService extends Disposable implements IConfigService {
     });
   }
 
+  async replaceAll(
+    values: Readonly<Record<string, unknown>>,
+    target: ConfigTarget = ConfigTarget.User,
+  ): Promise<void> {
+    await this.ready;
+    const entries = Object.entries(values);
+    if (entries.length === 0) return;
+    if (target === ConfigTarget.Memory) {
+      const domains: string[] = [];
+      for (const [domain, value] of entries) {
+        if (value === undefined) {
+          delete this.memory[domain];
+        } else {
+          this.memory[domain] = this.registry.validate(domain, value);
+        }
+        domains.push(domain);
+      }
+      this.commit('set', domains);
+      return;
+    }
+    await this.enqueueStateTransition(async () => {
+      const domains: string[] = [];
+      for (const [domain, value] of entries) {
+        const stripped = this.stripEnv(domain, value);
+        if (stripped === undefined) {
+          delete this.raw[domain];
+        } else {
+          this.raw[domain] = this.registry.validate(domain, stripped);
+        }
+        applySectionToToml(this.rawSnake, domain, this.raw[domain], this.registry);
+        domains.push(domain);
+      }
+      this.rebuildEffective('set', domains);
+      await this.documentStore.set(CONFIG_SCOPE, this.configKey, this.rawSnake);
+    });
+  }
+
   private stripEnv(domain: string, value: unknown): unknown {
     let result = value;
     const section = this.registry.getSection(domain);

--- a/packages/agent-core-v2/src/app/modelCatalog/modelCatalogService.ts
+++ b/packages/agent-core-v2/src/app/modelCatalog/modelCatalogService.ts
@@ -176,8 +176,6 @@ export class ModelCatalogService implements IModelCatalogService {
     const restModels = Object.fromEntries(
       Object.entries(models).filter(([, alias]) => alias.provider !== providerId),
     );
-    await this.config.replace(PROVIDERS_SECTION, restProviders);
-    await this.config.replace(MODELS_SECTION, restModels);
     return {
       ...current,
       providers: restProviders,
@@ -186,17 +184,13 @@ export class ModelCatalogService implements IModelCatalogService {
   }
 
   private async applyRefreshPatch(patch: ManagedKimiConfigShape): Promise<ManagedKimiConfigShape> {
-    if (patch.providers !== undefined) {
-      await this.config.replace(PROVIDERS_SECTION, patch.providers);
-    }
-    if (patch.models !== undefined) {
-      await this.config.replace(MODELS_SECTION, patch.models);
-    }
-    if (patch.defaultModel !== undefined) {
-      await this.config.set(DEFAULT_MODEL_SECTION, patch.defaultModel);
-    }
-    if (patch.thinking !== undefined) {
-      await this.config.set(THINKING_SECTION, patch.thinking);
+    const values: Record<string, unknown> = {};
+    if (patch.providers !== undefined) values[PROVIDERS_SECTION] = patch.providers;
+    if (patch.models !== undefined) values[MODELS_SECTION] = patch.models;
+    if ('defaultModel' in patch) values[DEFAULT_MODEL_SECTION] = patch.defaultModel;
+    if ('thinking' in patch) values[THINKING_SECTION] = patch.thinking;
+    if (Object.keys(values).length > 0) {
+      await this.config.replaceAll(values);
     }
     return this.readUserConfigShape();
   }

--- a/packages/agent-core-v2/src/app/sessionLegacy/sessionLegacyService.ts
+++ b/packages/agent-core-v2/src/app/sessionLegacy/sessionLegacyService.ts
@@ -106,7 +106,7 @@ export class SessionLegacyService implements ISessionLegacyService {
       const active = (await plan.status()) !== null;
       if (active !== agentConfig.plan_mode) {
         if (agentConfig.plan_mode) await plan.enter();
-        else plan.exit();
+        else plan.exit('host');
       }
     }
     if (agentConfig.swarm_mode !== undefined) {

--- a/packages/agent-core-v2/test/agent/fullCompaction/fullCompaction.test.ts
+++ b/packages/agent-core-v2/test/agent/fullCompaction/fullCompaction.test.ts
@@ -2506,6 +2506,19 @@ describe('FullCompaction', () => {
         args: { turnId: 0, reason: 'completed' },
       }),
     );
+    type WireLlmRequestEvent = {
+      type: '[wire]';
+      event: 'llm.request';
+      args: Record<string, unknown>;
+    };
+    const compactionRequests = events.filter((event): event is WireLlmRequestEvent => {
+      if (event === null || typeof event !== 'object') return false;
+      const candidate = event as { type?: unknown; event?: unknown; args?: unknown };
+      if (candidate.type !== '[wire]' || candidate.event !== 'llm.request') return false;
+      if (candidate.args === null || typeof candidate.args !== 'object') return false;
+      return (candidate.args as Record<string, unknown>)['kind'] === 'compaction';
+    });
+    expect(compactionRequests.map((event) => event.args['droppedCount'])).toEqual([0, 2]);
     expect(inputs).toMatchInlineSnapshot(`
       [
         [

--- a/packages/agent-core-v2/test/agent/loop/loop.test.ts
+++ b/packages/agent-core-v2/test/agent/loop/loop.test.ts
@@ -117,6 +117,20 @@ describe('Agent loop', () => {
     });
   });
 
+  it('passes the raw provider error message through turn.step.interrupted', async () => {
+    await ctx.rpc.prompt({ input: [{ type: 'text', text: 'Hello' }] });
+    await ctx.untilTurnEnd();
+
+    const interrupted = ctx.allEvents.find(
+      (event) => event.type === '[rpc]' && event.event === 'turn.step.interrupted',
+    );
+    expect(interrupted?.args).toMatchObject({
+      step: 1,
+      reason: 'error',
+      message: 'Unexpected generate call #1',
+    });
+  });
+
   it('marks a completed turn as truncated when the provider stops at max tokens', async () => {
     profile.update({ activeToolNames: [] });
     ctx.mockNextProviderResponse({

--- a/packages/agent-core-v2/test/agent/permissionPolicy/policies/exit-plan-mode-review-ask.test.ts
+++ b/packages/agent-core-v2/test/agent/permissionPolicy/policies/exit-plan-mode-review-ask.test.ts
@@ -4,6 +4,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { DisposableStore } from '#/_base/di/lifecycle';
 import { createServices, type TestInstantiationService } from '#/_base/di/test';
+import { Event } from '#/_base/event';
 import type { ResolvedToolExecutionHookContext } from '#/agent/toolExecutor/toolHooks';
 import { IAgentPermissionModeService } from '#/agent/permissionMode/permissionMode';
 import type { PermissionMode } from '#/agent/permissionPolicy/types';
@@ -83,6 +84,9 @@ function planService(exitPlanMode: ExitPlanModeFn = vi.fn()): AgentPlanService {
       content: '# Plan',
       path: '/tmp/kimi-plan.md',
     }),
+    onDidEnter: Event.None as AgentPlanService['onDidEnter'],
+    onDidExit: Event.None as AgentPlanService['onDidExit'],
+    onDidCancel: Event.None as AgentPlanService['onDidCancel'],
   };
 }
 

--- a/packages/agent-core-v2/test/agent/permissionPolicy/policies/plan-mode-guard-deny.test.ts
+++ b/packages/agent-core-v2/test/agent/permissionPolicy/policies/plan-mode-guard-deny.test.ts
@@ -1,6 +1,7 @@
 import type { ToolCall } from '#/app/llmProtocol/message';
 import { describe, expect, it } from 'vitest';
 
+import { Event } from '#/_base/event';
 import type { ResolvedToolExecutionHookContext } from '#/agent/toolExecutor/toolHooks';
 import { IAgentPlanService, type PlanData } from '#/agent/plan/plan';
 import { PlanModeGuardDenyPermissionPolicyService } from '#/agent/permissionPolicy/policies/plan-mode-guard-deny';
@@ -24,6 +25,9 @@ function planService(active: boolean, planFilePath: string | null = PLAN_PATH): 
             path: planFilePath ?? PLAN_PATH,
           } satisfies NonNullable<PlanData>)
         : null,
+    onDidEnter: Event.None as IAgentPlanService['onDidEnter'],
+    onDidExit: Event.None as IAgentPlanService['onDidExit'],
+    onDidCancel: Event.None as IAgentPlanService['onDidCancel'],
   };
 }
 

--- a/packages/agent-core-v2/test/agent/plan/injection/planModeInjection.test.ts
+++ b/packages/agent-core-v2/test/agent/plan/injection/planModeInjection.test.ts
@@ -110,7 +110,7 @@ describe('PlanModeService dynamic injection content', () => {
     await enterPlan(plan);
 
     await injectDynamic(injector);
-    plan.exit();
+    plan.exit('approved');
     await injectDynamic(injector);
 
     expect(lastPlanReminder(context)).toContain('Plan mode is no longer active');

--- a/packages/agent-core-v2/test/agent/plan/plan.test.ts
+++ b/packages/agent-core-v2/test/agent/plan/plan.test.ts
@@ -208,7 +208,7 @@ describe('Plan service', () => {
         time: expect.any(Number),
       });
 
-      plan.exit();
+      plan.exit('approved');
       await ctx.dispatch({
         type: 'plan_mode.enter',
         id: 'stable-plan',
@@ -253,6 +253,75 @@ describe('Plan service', () => {
       await expectPlanActive(true);
       expect(ctx.llmCalls).toHaveLength(2);
       expect(toolResultText(ctx.llmCalls[1]!.history)).toContain('Plan mode is now active');
+    });
+  });
+
+  describe('plan lifecycle events', () => {
+    it('fires onDidEnter with the plan id and path on enter', async () => {
+      const entered = vi.fn();
+      plan.onDidEnter(entered);
+
+      await plan.enter('event-plan');
+
+      expect(entered).toHaveBeenCalledWith({
+        id: 'event-plan',
+        path: expectedPlanPath('event-plan'),
+      });
+    });
+
+    it('fires onDidExit with the plan id, path, and reason on exit', async () => {
+      const exited = vi.fn();
+      plan.onDidExit(exited);
+      await plan.enter('event-plan');
+
+      plan.exit('approved');
+
+      expect(exited).toHaveBeenCalledWith({
+        id: 'event-plan',
+        path: expectedPlanPath('event-plan'),
+        reason: 'approved',
+      });
+    });
+
+    it('does not fire onDidExit or onDidCancel when plan mode is already inactive', () => {
+      const exited = vi.fn();
+      const cancelled = vi.fn();
+      plan.onDidExit(exited);
+      plan.onDidCancel(cancelled);
+
+      plan.exit('host');
+      plan.cancel();
+
+      expect(exited).not.toHaveBeenCalled();
+      expect(cancelled).not.toHaveBeenCalled();
+    });
+
+    it('fires onDidCancel on cancel while plan mode is active', async () => {
+      const cancelled = vi.fn();
+      plan.onDidCancel(cancelled);
+      await plan.enter('event-plan');
+
+      plan.cancel();
+
+      expect(cancelled).toHaveBeenCalledWith({ id: 'event-plan' });
+    });
+
+    it('stays silent when plan state changes through wire replay', async () => {
+      const entered = vi.fn();
+      const exited = vi.fn();
+      const cancelled = vi.fn();
+      plan.onDidEnter(entered);
+      plan.onDidExit(exited);
+      plan.onDidCancel(cancelled);
+
+      await ctx.dispatch({ type: 'plan_mode.enter', id: 'replayed-plan' });
+      await expectPlanActive(true);
+      await ctx.dispatch({ type: 'plan_mode.exit', id: 'replayed-plan' });
+      await expectPlanActive(false);
+
+      expect(entered).not.toHaveBeenCalled();
+      expect(exited).not.toHaveBeenCalled();
+      expect(cancelled).not.toHaveBeenCalled();
     });
   });
 
@@ -722,7 +791,7 @@ describe('Plan service', () => {
       await plan.enter('test-plan', false);
       await injectDynamic();
 
-      plan.exit();
+      plan.exit('approved');
       await injectDynamic();
       const afterExit = context.get().length;
       expect(lastUserText(context.get())).toContain('Plan mode is no longer active');

--- a/packages/agent-core-v2/test/agent/plan/tools/exit-plan-mode.test.ts
+++ b/packages/agent-core-v2/test/agent/plan/tools/exit-plan-mode.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 
+import { Event } from '#/_base/event';
 import type { IAgentPlanService, PlanData } from '#/agent/plan/plan';
 import {
   ExitPlanModeInputSchema,
@@ -32,6 +33,9 @@ function planService(): IAgentPlanService {
         content: '# Plan',
         path: '/tmp/kimi-plan.md',
       } satisfies NonNullable<PlanData>),
+    onDidEnter: Event.None as IAgentPlanService['onDidEnter'],
+    onDidExit: Event.None as IAgentPlanService['onDidExit'],
+    onDidCancel: Event.None as IAgentPlanService['onDidCancel'],
   };
 }
 

--- a/packages/agent-core-v2/test/agent/plan/tools/plan-tools-telemetry.test.ts
+++ b/packages/agent-core-v2/test/agent/plan/tools/plan-tools-telemetry.test.ts
@@ -1,6 +1,7 @@
 import type { ToolCall } from '#/app/llmProtocol/message';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { Event } from '#/_base/event';
 import type { IAgentPlanService, PlanData } from '#/agent/plan/plan';
 import { EnterPlanModeTool } from '#/agent/plan/tools/enter-plan-mode';
 import {
@@ -85,6 +86,9 @@ function planService({
     clear: vi.fn(async () => {}),
     exit: exit ?? vi.fn(),
     status: vi.fn(async () => status),
+    onDidEnter: Event.None as IAgentPlanService['onDidEnter'],
+    onDidExit: Event.None as IAgentPlanService['onDidExit'],
+    onDidCancel: Event.None as IAgentPlanService['onDidCancel'],
   };
 }
 

--- a/packages/agent-core-v2/test/app/auth/auth.test.ts
+++ b/packages/agent-core-v2/test/app/auth/auth.test.ts
@@ -88,6 +88,7 @@ describe('OAuthService', () => {
   let providerSet: ReturnType<typeof vi.fn>;
   let configSet: ReturnType<typeof vi.fn>;
   let configReplace: ReturnType<typeof vi.fn>;
+  let configReplaceAll: ReturnType<typeof vi.fn>;
   let events: DomainEvent[];
   let providerChangedEmitter: Emitter<ProvidersChangedEvent>;
 
@@ -135,6 +136,31 @@ describe('OAuthService', () => {
       }
       throw new Error(`unexpected config replace: ${domain}`);
     });
+    configReplaceAll = vi.fn(async (values: Record<string, unknown>) => {
+      for (const [domain, value] of Object.entries(values)) {
+        if (domain === 'providers') {
+          providers = (value ?? {}) as Record<string, ProviderConfig>;
+          continue;
+        }
+        if (domain === 'models') {
+          models = (value ?? {}) as Record<string, ModelAlias>;
+          continue;
+        }
+        if (domain === 'services') {
+          services = value as Record<string, unknown> | undefined;
+          continue;
+        }
+        if (domain === 'defaultModel') {
+          defaultModel = value as string | undefined;
+          continue;
+        }
+        if (domain === 'thinking') {
+          thinking = value as { enabled?: boolean; effort?: string } | undefined;
+          continue;
+        }
+        throw new Error(`unexpected config replaceAll domain: ${domain}`);
+      }
+    });
     events = [];
     toolkit = {
       login: vi.fn<(...args: any[]) => any>(),
@@ -161,6 +187,7 @@ describe('OAuthService', () => {
           })) as IConfigService['inspect'],
           set: configSet as unknown as IConfigService['set'],
           replace: configReplace as unknown as IConfigService['replace'],
+          replaceAll: configReplaceAll as unknown as IConfigService['replaceAll'],
           reload: vi.fn().mockResolvedValue(undefined) as unknown as IConfigService['reload'],
           onDidChangeConfiguration: (() => ({ dispose: () => { } })) as IConfigService['onDidChangeConfiguration'],
           onDidSectionChange: (() => ({ dispose: () => { } })) as IConfigService['onDidSectionChange'],
@@ -395,7 +422,9 @@ describe('OAuthService', () => {
       }),
     );
     expect(fetchMock).toHaveBeenCalledTimes(1);
-    expect(configSet).toHaveBeenCalledWith('defaultModel', 'kimi-code/kimi-k2');
+    expect(configReplaceAll).toHaveBeenCalledWith(
+      expect.objectContaining({ defaultModel: 'kimi-code/kimi-k2' }),
+    );
   });
 
   it('startLogin returns authenticated when model refresh fails on the already-authenticated fast path', async () => {
@@ -458,13 +487,14 @@ describe('OAuthService', () => {
         oauth: EXAMPLE_COM_SCOPED_REF,
       }),
     );
-    expect(configReplace).toHaveBeenCalledWith(
-      'models',
+    expect(configReplaceAll).toHaveBeenCalledWith(
       expect.objectContaining({
-        'kimi-code/kimi-k2': expect.objectContaining({ model: 'kimi-k2' }),
+        models: expect.objectContaining({
+          'kimi-code/kimi-k2': expect.objectContaining({ model: 'kimi-k2' }),
+        }),
+        defaultModel: 'kimi-code/kimi-k2',
       }),
     );
-    expect(configSet).toHaveBeenCalledWith('defaultModel', 'kimi-code/kimi-k2');
   });
 
   it('keeps an in-flight OAuth flow alive when unrelated providers change', async () => {
@@ -708,18 +738,20 @@ describe('OAuthService', () => {
         removed: 0,
       },
     ]);
-    expect(configReplace).toHaveBeenCalledWith(
-      'providers',
+    expect(configReplace).not.toHaveBeenCalled();
+    expect(configSet).not.toHaveBeenCalled();
+    expect(configReplaceAll).toHaveBeenCalledTimes(1);
+    const batch = configReplaceAll.mock.calls[0]?.[0] as Record<string, unknown>;
+    expect(batch['providers']).toEqual(
       expect.objectContaining({ [OAUTH_PROVIDER]: expect.objectContaining({ type: 'kimi' }) }),
     );
-    expect(configReplace).toHaveBeenCalledWith(
-      'models',
+    expect(batch['models']).toEqual(
       expect.objectContaining({
         'kimi-code/kimi-k2': expect.objectContaining({ model: 'kimi-k2' }),
       }),
     );
-    expect(configSet).toHaveBeenCalledWith('defaultModel', 'kimi-code/kimi-k2');
-    expect(configSet).toHaveBeenCalledWith('thinking', { enabled: true });
+    expect(batch['defaultModel']).toBe('kimi-code/kimi-k2');
+    expect(batch['thinking']).toEqual({ enabled: true });
     expect(events).toEqual([
       {
         type: 'event.model_catalog.changed',

--- a/packages/agent-core-v2/test/app/config/config.test.ts
+++ b/packages/agent-core-v2/test/app/config/config.test.ts
@@ -9,7 +9,7 @@
 
 import type { ModelCapability } from '#/app/llmProtocol/capability';
 import type { ToolCall } from '#/app/llmProtocol/message';
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { IAgentProfileService, type ResolvedAgentProfile } from '#/agent/profile/profile';
 import { AGENT_WIRE_PROTOCOL_VERSION } from '#/agent/wireRecord/wireRecord';
@@ -20,7 +20,7 @@ import { SyncDescriptor } from '#/_base/di/descriptors';
 import { DisposableStore } from '#/_base/di/lifecycle';
 import { TestInstantiationService } from '#/_base/di/test';
 import { IBootstrapService } from '#/app/bootstrap/bootstrap';
-import { IConfigRegistry, IConfigService } from '#/app/config/config';
+import { ConfigTarget, IConfigRegistry, IConfigService } from '#/app/config/config';
 import { ConfigRegistry, ConfigService } from '#/app/config/configService';
 import '#/app/cron/configSection';
 import type { CronConfig } from '#/app/cron/configSection';
@@ -353,6 +353,100 @@ describe('ConfigService env overlay (live)', () => {
     expect(config.get<CronConfig>('cron').disabled).toBe(false);
 
     disposables.dispose();
+  });
+});
+
+describe('ConfigService.replaceAll (live)', () => {
+  let disposables: DisposableStore;
+  let ix: TestInstantiationService;
+  let config: IConfigService;
+
+  beforeEach(async () => {
+    disposables = new DisposableStore();
+    ix = disposables.add(new TestInstantiationService());
+    ix.stub(ILogService, stubLog());
+    ix.stub(IBootstrapService, stubBootstrap('/tmp/kimi-cfg', {}));
+    ix.stub(IFileSystemStorageService, new InMemoryStorageService());
+    ix.set(IAtomicTomlDocumentStore, new SyncDescriptor(TomlAtomicDocumentStore));
+    ix.set(IConfigRegistry, new SyncDescriptor(ConfigRegistry));
+    ix.set(IConfigService, new SyncDescriptor(ConfigService));
+    config = ix.get(IConfigService);
+    await config.ready;
+  });
+  afterEach(() => {
+    disposables.dispose();
+  });
+
+  it('commits several sections atomically: the first change event already sees the full new state', async () => {
+    await config.replace('providers', { kimi: { type: 'kimi', apiKey: 'sk-test' } });
+    await config.replace('models', { k2: { provider: 'kimi', model: 'kimi-k2' } });
+
+    const snapshots: Array<Record<string, unknown>> = [];
+    disposables.add(
+      config.onDidChangeConfiguration(() => {
+        snapshots.push({
+          providers: config.get('providers'),
+          models: config.get('models'),
+        });
+      }),
+    );
+
+    await config.replaceAll({
+      providers: { kimi: { type: 'kimi', apiKey: 'sk-test-2' } },
+      models: { k3: { provider: 'kimi', model: 'kimi-k3' } },
+      defaultModel: 'k3',
+    });
+
+    expect(snapshots.length).toBeGreaterThan(0);
+    for (const snapshot of snapshots) {
+      expect(snapshot['providers']).toEqual({ kimi: { type: 'kimi', apiKey: 'sk-test-2' } });
+      expect(snapshot['models']).toEqual({ k3: { provider: 'kimi', model: 'kimi-k3' } });
+    }
+    expect(config.get('defaultModel')).toBe('k3');
+  });
+
+  it('deletes sections whose value is undefined', async () => {
+    await config.replace('defaultModel', 'k3');
+    await config.replace('customSection', { enabled: true });
+    expect(config.get('defaultModel')).toBe('k3');
+
+    await config.replaceAll({ defaultModel: undefined, customSection: undefined });
+
+    expect(config.get('defaultModel')).toBeUndefined();
+    expect(config.get('customSection')).toBeUndefined();
+  });
+
+  it('publishes the new effective state before the disk write completes', async () => {
+    const store = ix.get(IAtomicTomlDocumentStore);
+    let release!: () => void;
+    const gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const setSpy = vi.spyOn(store, 'set').mockImplementation(async () => {
+      await gate;
+    });
+
+    const pending = config.replaceAll({ defaultModel: 'k3', thinking: { enabled: true } });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(setSpy).toHaveBeenCalled();
+    expect(config.get('defaultModel')).toBe('k3');
+    expect(config.get('thinking')).toEqual({ enabled: true });
+
+    release();
+    await pending;
+    expect(setSpy).toHaveBeenCalledWith(
+      '',
+      expect.any(String),
+      expect.objectContaining({ default_model: 'k3' }),
+    );
+  });
+
+  it('applies memory-target overrides in one commit', async () => {
+    await config.replaceAll({ alpha: 1, beta: 2 }, ConfigTarget.Memory);
+
+    expect(config.get('alpha')).toBe(1);
+    expect(config.get('beta')).toBe(2);
   });
 });
 

--- a/packages/agent-core-v2/test/app/modelCatalog/modelCatalog.test.ts
+++ b/packages/agent-core-v2/test/app/modelCatalog/modelCatalog.test.ts
@@ -70,6 +70,7 @@ describe('ModelCatalogService', () => {
   let backing: Backing;
   let configSet: ReturnType<typeof vi.fn>;
   let configReplace: ReturnType<typeof vi.fn>;
+  let configReplaceAll: ReturnType<typeof vi.fn>;
   let getCachedAccessToken: ReturnType<typeof vi.fn>;
   let resolveTokenProvider: ReturnType<typeof vi.fn>;
   let publishEvent: ReturnType<typeof vi.fn>;
@@ -89,6 +90,15 @@ describe('ModelCatalogService', () => {
     configReplace = vi.fn().mockImplementation(async (domain: string, value: unknown) => {
       (backing as unknown as Record<string, unknown>)[domain] = value;
     });
+    configReplaceAll = vi.fn().mockImplementation(async (values: Record<string, unknown>) => {
+      for (const [domain, value] of Object.entries(values)) {
+        if (value === undefined) {
+          delete (backing as unknown as Record<string, unknown>)[domain];
+        } else {
+          (backing as unknown as Record<string, unknown>)[domain] = value;
+        }
+      }
+    });
     publishEvent = vi.fn();
 
     ix = createServices(disposables, {
@@ -104,6 +114,7 @@ describe('ModelCatalogService', () => {
           })) as IConfigService['inspect'],
           set: configSet as unknown as IConfigService['set'],
           replace: configReplace as unknown as IConfigService['replace'],
+          replaceAll: configReplaceAll as unknown as IConfigService['replaceAll'],
           reload: vi.fn().mockResolvedValue(undefined) as unknown as IConfigService['reload'],
           onDidChangeConfiguration: (() => ({ dispose: () => {} })) as IConfigService['onDidChangeConfiguration'],
           onDidSectionChange: (() => ({ dispose: () => {} })) as IConfigService['onDidSectionChange'],
@@ -350,5 +361,93 @@ describe('ModelCatalogService', () => {
         headers: expect.objectContaining({ 'User-Agent': 'kimi-code-cli/test' }),
       }),
     );
+  });
+
+  it('refreshProviderModels applies managed-catalog changes in one batch commit', async () => {
+    backing.providers = {
+      [KIMI_CODE_PROVIDER_NAME]: {
+        type: 'kimi',
+        baseUrl: 'https://api.example.test/v1',
+        oauth: { storage: 'file', key: 'oauth/kimi-code' },
+      },
+    };
+    backing.models = {};
+    resolveTokenProvider.mockReturnValue({ getAccessToken: async () => 'access-token' });
+    const fetchMock = vi.fn().mockImplementation(async () => ({
+      ok: true,
+      json: async () => ({
+        data: [
+          {
+            id: 'kimi-k2',
+            context_length: 131072,
+            supports_reasoning: true,
+            display_name: 'Kimi K2',
+          },
+        ],
+      }),
+    }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await catalog().refreshProviderModels({ scope: 'all' });
+
+    expect(result.failed).toEqual([]);
+    expect(result.changed).toEqual([
+      { provider_id: KIMI_CODE_PROVIDER_NAME, provider_name: 'Kimi Code', added: 1, removed: 0 },
+    ]);
+    expect(configReplace).not.toHaveBeenCalled();
+    expect(configSet).not.toHaveBeenCalled();
+    expect(configReplaceAll).toHaveBeenCalledTimes(1);
+    const batch = configReplaceAll.mock.calls[0]?.[0] as Record<string, unknown>;
+    expect(batch['providers']).toEqual(
+      expect.objectContaining({
+        [KIMI_CODE_PROVIDER_NAME]: expect.objectContaining({ type: 'kimi' }),
+      }),
+    );
+    expect(batch['models']).toEqual(
+      expect.objectContaining({ 'kimi-code/kimi-k2': expect.objectContaining({ model: 'kimi-k2' }) }),
+    );
+    expect(batch['defaultModel']).toBe('kimi-code/kimi-k2');
+  });
+
+  it('refreshProviderModels clears the default selection when its provider leaves the registry', async () => {
+    backing.providers = {
+      acme: {
+        type: 'openai',
+        apiKey: 'sk-acme',
+        source: {
+          kind: 'apiJson',
+          url: 'https://registry.example.test/api.json',
+          apiKey: 'sk-registry',
+        },
+      },
+    };
+    backing.models = {
+      'acme/m1': { provider: 'acme', model: 'm1', maxContextSize: 8192 },
+    };
+    backing.defaultModel = 'acme/m1';
+    backing.thinking = { enabled: true };
+    const fetchMock = vi.fn(
+      async () =>
+        new Response(JSON.stringify({}), {
+          headers: { 'Content-Type': 'application/json' },
+        }),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await catalog().refreshProviderModels({ scope: 'all' });
+
+    expect(result.failed).toEqual([]);
+    expect(result.changed).toEqual([
+      { provider_id: 'acme', provider_name: 'acme', added: 0, removed: 1 },
+    ]);
+    expect(configReplace).not.toHaveBeenCalled();
+    expect(configReplaceAll).toHaveBeenCalledTimes(1);
+    const batch = configReplaceAll.mock.calls[0]?.[0] as Record<string, unknown>;
+    expect(batch['providers']).toEqual({});
+    expect(batch['models']).toEqual({});
+    expect('defaultModel' in batch).toBe(true);
+    expect(batch['defaultModel']).toBeUndefined();
+    expect(backing.defaultModel).toBeUndefined();
+    expect(backing.thinking).toBeUndefined();
   });
 });


### PR DESCRIPTION
## Related Issue

No linked issue — this is a collection of agent-core-v2 improvements developed during active porting.

## Problem

Several independent gaps in `agent-core-v2`:

1. **Plan mode lifecycle is invisible to other services.** `IAgentPlanService` exposed enter/exit/cancel as fire-and-forget dispatches with no events, so no other domain could react to plan approval or cancellation.
2. **Model catalog refreshes commit section-by-section.** `ModelCatalogService.applyRefreshPatch` and `OAuthService` applied provider/model/default/thinking sections one at a time, so a request landing mid-refresh could see a torn config state and fail with transient model-resolution errors.
3. **AGENTS.md duplicated the agent-core-dev skill.** The inline conventions (comment format, telemetry, persistence, docs index) had drifted from the skill, which is the intended single source of truth.
4. **Mid-file comments violated the package convention.** agent-core-v2 mandates comments only in top-of-file header blocks, but many files carried mid-file doc/prose comments.
5. **Compaction LLM requests lacked `droppedCount` in log fields**, making it hard to correlate context-window pressure with compaction triggers.

## What changed

### 1. Plan mode lifecycle events (`feat`)

- Added `onDidEnter`, `onDidExit`, `onDidCancel` events to `IAgentPlanService`.
- Introduced `PlanExitReason` (`approved` / `rejected` / `host`) so consumers can distinguish why plan mode ended.
- Updated `exit()` signature to require a reason; wired `exit-plan-mode` tool (`approved`) and `sessionLegacyService` (`host`) accordingly.
- Events fire only on the live path — replay rebuilds state silently.

### 2. Atomic config refresh (`fix`)

- Added `ConfigService.replaceAll()` for single-commit multi-section updates.
- Migrated `ModelCatalogService.applyRefreshPatch` and `OAuthService` token-refresh config writes to use `replaceAll`, eliminating torn-state windows.
- Replaced `toErrorMessage` with a direct `error.message` passthrough in `loopService.interruptedMessage` so raw provider error messages reach the client without extra formatting.

### 3. AGENTS.md slim-down (`docs`)

- Replaced the inline conventions (comment format, telemetry, persistence, docs index) with a pointer to the `agent-core-dev` skill as the single source of truth.
- Kept only the "no comments" rule inline since it is the most frequently violated.

### 4. Comment convention enforcement (`style`)

- Stripped mid-file doc, prose, and trailing comments across `agent-core-v2/src` while preserving top-of-file header blocks and eslint/oxlint/`@ts-*` suppression comments.
- No code tokens were changed.

### 5. Compaction logging (`feat`)

- Added `droppedCount` to `logFields` on full-compaction LLM requests for better observability.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.
