### PR TITLE
test(agent-core-v2): deflake full compaction retry-count tests

### DIFF
--- a/packages/agent-core-v2/test/agent/fullCompaction/fullCompaction.test.ts
+++ b/packages/agent-core-v2/test/agent/fullCompaction/fullCompaction.test.ts
@@ -848,8 +848,12 @@ describe('FullCompaction', () => {
     vi.useFakeTimers();
     const records: TelemetryRecord[] = [];
     const inputs: string[][] = [];
-    const generate = realKosongGenerate((_attempt, history) => {
+    const firstResponse = deferred<void>();
+    const generate = realKosongGenerate((attempt, history) => {
       inputs.push(inputHistorySnapshot(history));
+      if (attempt === 1) {
+        firstResponse.resolve();
+      }
       return mockStreamedMessage([
         { type: 'think', think: 'Still only thinking, no summary produced.' },
       ]);
@@ -864,6 +868,7 @@ describe('FullCompaction', () => {
     const failed = ctx.once('error');
 
     await ctx.rpc.beginCompaction({});
+    await firstResponse.promise;
     await vi.advanceTimersByTimeAsync(60_000);
     await failed;
 
@@ -1092,9 +1097,13 @@ describe('FullCompaction', () => {
   it('reports compaction retry_count when retryable generation failures are exhausted', async () => {
     vi.useFakeTimers();
     const records: TelemetryRecord[] = [];
+    const firstAttemptFailed = deferred<void>();
     let attempts = 0;
     const generate: GenerateFn = async () => {
       attempts += 1;
+      if (attempts === 1) {
+        firstAttemptFailed.resolve();
+      }
       throw new APIConnectionError('socket hang up');
     };
     const ctx = testAgent({ generate, telemetry: recordingTelemetry(records) });
@@ -1107,6 +1116,7 @@ describe('FullCompaction', () => {
     const failed = ctx.once('error');
 
     await ctx.rpc.beginCompaction({});
+    await firstAttemptFailed.promise;
     await vi.advanceTimersByTimeAsync(60_000);
     await failed;
 


### PR DESCRIPTION
## Related Issue

None — flaky test fix. The problem is explained below.

## Problem

Two full-compaction retry tests in `packages/agent-core-v2/test/agent/fullCompaction/fullCompaction.test.ts` advance fake timers immediately after `beginCompaction`, assuming the compaction chain has reached its first retry sleep by the time sinon scans for pending timers. Under CI load that assumption can break: sinon's `tickAsync` finds no pending timer, jumps the fake clock straight to the end of the 60s window, and the retry `setTimeout` scheduled afterwards lands outside the window and never fires. The compaction never completes, `await failed` hangs, and vitest kills the test at the 5s timeout.

Observed in PR #1661's `test (4)` shard: `reports compaction retry_count when retryable generation failures are exhausted` timed out even though that PR only touched kap-server CORS; a job retry passed.

## What changed

Test-only change in `packages/agent-core-v2/test/agent/fullCompaction/fullCompaction.test.ts`:

- `reports compaction retry_count when retryable generation failures are exhausted` (the one that timed out): resolve a `deferred` on the first generate call and await it before `advanceTimersByTimeAsync`.
- `fails after exhausting retries when the model only ever returns thinking content`: same structural hole, same fix, to avoid the next flake report.

Both now match the pattern the other six fake-timer retry tests in the same file already use: wait for the first attempt to actually run, then advance fake time. No production code touched.

Verified: the file's 66 tests pass locally; `oxlint --type-aware` is clean.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset — test-only change, no package output affected.
- [x] Ran `gen-docs` skill, or this PR needs no doc update — no user-facing behavior change.