### PR TITLE
feat(agent-core-v2): make /init runs cancellable

### DIFF
--- a/packages/agent-core-v2/src/session/sessionInit/sessionInit.ts
+++ b/packages/agent-core-v2/src/session/sessionInit/sessionInit.ts
@@ -21,6 +21,13 @@ export interface ISessionInitService {
   readonly _serviceBrand: undefined;
 
   generateAgentsMd(): Promise<void>;
+
+  /**
+   * Abort the in-flight `/init` run, if any. No-op when idle — callers like
+   * the turn-cancel path (Ctrl+C) invoke it unconditionally alongside the
+   * main agent's own turn cancel.
+   */
+  cancelInit(): void;
 }
 
 export const ISessionInitService: ServiceIdentifier<ISessionInitService> =

--- a/packages/agent-core-v2/src/session/sessionInit/sessionInitService.ts
+++ b/packages/agent-core-v2/src/session/sessionInit/sessionInitService.ts
@@ -16,10 +16,14 @@
  * Port of v1 `Session.generateAgentsMd()`. The main-agent lookup is a hard
  * precondition (`AGENT_NOT_FOUND`, like v1's `requireMainAgent`); only the
  * spawn / reload / reminder path is wrapped into `SESSION_INIT_FAILED`.
+ * `cancelInit` aborts the in-flight run through the same `AbortSignal` the
+ * run was launched with; user cancellations propagate unwrapped (never as
+ * `SESSION_INIT_FAILED`) so callers can tell "aborted" from "failed".
  */
 
 import { InstantiationType } from '#/_base/di/extensions';
 import { LifecycleScope, registerScopedService } from '#/_base/di/scope';
+import { isAbortError, isUserCancellation, userCancellationReason } from '#/_base/utils/abort';
 import { IBootstrapService } from '#/app/bootstrap/bootstrap';
 import { IHostEnvironment } from '#/os/interface/hostEnvironment';
 import { IHostFileSystem } from '#/os/interface/hostFileSystem';
@@ -43,6 +47,9 @@ const INIT_DESCRIPTION = 'Initialize AGENTS.md';
 export class SessionInitService implements ISessionInitService {
   declare readonly _serviceBrand: undefined;
 
+  /** Abort handle of the in-flight `/init` run; `undefined` while idle. */
+  private initRun: AbortController | undefined;
+
   constructor(
     @IAgentLifecycleService private readonly lifecycle: IAgentLifecycleService,
     @IHostFileSystem private readonly fs: IHostFileSystem,
@@ -50,19 +57,24 @@ export class SessionInitService implements ISessionInitService {
     @IBootstrapService private readonly bootstrap: IBootstrapService,
   ) {}
 
+  cancelInit(): void {
+    this.initRun?.abort(userCancellationReason());
+  }
+
   async generateAgentsMd(): Promise<void> {
     const main = this.lifecycle.getHandle(MAIN_AGENT_ID);
     if (main === undefined) {
       throw new Error2(ErrorCodes.AGENT_NOT_FOUND, 'Main agent was not found');
     }
 
+    const controller = new AbortController();
+    this.initRun = controller;
     try {
       const own = main.accessor.get(IAgentProfileService).data();
       if (own.modelAlias === undefined) {
         throw new Error2(ErrorCodes.SESSION_INIT_FAILED, 'Main agent has no model bound');
       }
       const permissionMode = main.accessor.get(IAgentPermissionModeService).mode;
-      const controller = new AbortController();
 
       const child = await this.lifecycle.create({
         binding: {
@@ -106,6 +118,11 @@ export class SessionInitService implements ISessionInitService {
         });
       await main.accessor.get(IAgentWireRecordService).flush();
     } catch (error) {
+      // User cancellations (Ctrl+C → cancelInit) must surface as aborts, not
+      // as init failures — the TUI resets quietly on `isAbortError`.
+      if (isUserCancellation(error) || isAbortError(error)) {
+        throw error;
+      }
       if (error instanceof Error2 && error.code === ErrorCodes.SESSION_INIT_FAILED) {
         throw error;
       }
@@ -114,6 +131,10 @@ export class SessionInitService implements ISessionInitService {
         error instanceof Error ? error.message : 'Init failed',
         { cause: error },
       );
+    } finally {
+      if (this.initRun === controller) {
+        this.initRun = undefined;
+      }
     }
   }
 }

--- a/packages/agent-core-v2/test/session/sessionInit/sessionInit.test.ts
+++ b/packages/agent-core-v2/test/session/sessionInit/sessionInit.test.ts
@@ -3,6 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { SyncDescriptor } from '#/_base/di/descriptors';
 import { DisposableStore } from '#/_base/di/lifecycle';
 import { TestInstantiationService } from '#/_base/di/test';
+import { UserCancellationError } from '#/_base/utils/abort';
 import { IBootstrapService } from '#/app/bootstrap/bootstrap';
 import { IEventBus } from '#/app/event/eventBus';
 import { ITelemetryService } from '#/app/telemetry/telemetry';
@@ -181,5 +182,35 @@ describe('SessionInitService', () => {
     const error = await svc.generateAgentsMd().catch((e) => e);
     expect(error).toBeInstanceOf(Error2);
     expect((error as Error2).code).toBe(ErrorCodes.AGENT_NOT_FOUND);
+  });
+
+  it('cancelInit aborts the in-flight run without wrapping the cancellation', async () => {
+    run.mockImplementationOnce((agentId: string, _req: unknown, opts: { signal: AbortSignal }) => ({
+      agentId,
+      turn: {},
+      // The real lifecycle rejects the run completion when the launch signal
+      // aborts; mirror that so the service-level propagation is exercised.
+      completion: new Promise<{ summary: string }>((_resolve, reject) => {
+        opts.signal.addEventListener('abort', () => reject(opts.signal.reason));
+      }),
+    }));
+    const svc = ix.get(ISessionInitService);
+
+    const pending = svc.generateAgentsMd();
+    await vi.waitFor(() => expect(run).toHaveBeenCalled());
+    svc.cancelInit();
+
+    const error = await pending.catch((e) => e);
+    // Surfaces as a user cancellation (TUI resets quietly on isAbortError),
+    // never as SESSION_INIT_FAILED, and without a subagent.failed event.
+    expect(error).toBeInstanceOf(UserCancellationError);
+    expect(events).not.toContainEqual(
+      expect.objectContaining({ type: 'subagent.failed', subagentId: 'agent-0' }),
+    );
+  });
+
+  it('cancelInit is a no-op when no init run is in flight', () => {
+    const svc = ix.get(ISessionInitService);
+    expect(() => svc.cancelInit()).not.toThrow();
   });
 });


### PR DESCRIPTION
## Related Issue

No tracking issue — the problem is explained below.

## Problem

In the v2 engine, `/init` (`SessionInitService.generateAgentsMd`) spawns a `coder` subagent through `agentLifecycle.run` with an `AbortController` that is a local of `generateAgentsMd`. Nothing outside the service can reach it, so there is no way to cancel an init run: a client's cancel path (e.g. Ctrl+C in a TUI) only cancels the main agent's loop turn, which does not exist during `/init`. The run simply continues to completion. This was hit by the tui-v2 client, the first v2 consumer that exposes `/init`.

## What changed

- `ISessionInitService` gains `cancelInit()`. The service keeps the in-flight run's `AbortController` on the instance (assigned before the run, cleared in `finally`), and `cancelInit()` aborts it with a user-cancellation reason. It is a no-op while idle, so callers can invoke it unconditionally alongside the main agent's turn cancel.
- `generateAgentsMd` no longer wraps cancellations into `SESSION_INIT_FAILED`: `UserCancellationError` / `AbortError` propagate unwrapped (and `mirrorAgentRun` suppresses the `subagent.failed` event for them), so callers can distinguish "aborted" from "failed".
- Added tests: cancellation propagates unwrapped without a failure event, and `cancelInit` is a no-op when idle.

This is additive only — no existing signatures change. Verified: package typecheck clean, full agent-core-v2 suite passes (236 files / 3302 tests), `lint:domain` OK.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.