### PR TITLE
fix: emit turn_id on turn_started/ended/interrupted telemetry

### DIFF
--- a/packages/agent-core-v2/src/agent/loop/loopService.ts
+++ b/packages/agent-core-v2/src/agent/loop/loopService.ts
@@ -369,7 +369,7 @@ export class AgentLoopService extends Disposable implements IAgentLoopService {
     const { mode, provider_type, protocol } = telemetryContext;
     let result: TurnResult | undefined;
     try {
-      const started: TurnStartedTelemetryEvent = { mode, provider_type, protocol };
+      const started: TurnStartedTelemetryEvent = { turn_id: turn.id, mode, provider_type, protocol };
       turnTelemetry.track2('turn_started', started);
       result = await this.run({
         turnId: turn.id,
@@ -397,6 +397,7 @@ export class AgentLoopService extends Disposable implements IAgentLoopService {
         if (error !== undefined) this.eventBus.publish({ type: 'error', ...error });
         if (result.type !== 'completed') {
           const interrupted: TurnInterruptedEvent = {
+            turn_id: turn.id,
             at_step: result.steps,
             mode,
             interrupt_reason: interruptReasonFor(result),
@@ -407,6 +408,7 @@ export class AgentLoopService extends Disposable implements IAgentLoopService {
         }
       }
       const ended: TurnEndedTelemetryEvent = {
+        turn_id: turn.id,
         reason: result?.type ?? 'failed',
         duration_ms: Date.now() - startedAt,
         mode,

--- a/packages/agent-core-v2/src/app/telemetry/events.ts
+++ b/packages/agent-core-v2/src/app/telemetry/events.ts
@@ -391,7 +391,7 @@ export const telemetryEventDefinitions = {
     owner: 'kimi-code',
     comment: 'A turn starts running.',
     properties: {
-      turn_id: 'Turn index within the session',
+      turn_id: 'Per-agent turn index (main or subagent); not unique across agents in the same session',
       mode: 'Agent mode the turn runs in',
       provider_type: 'Provider protocol type',
       protocol: 'Request protocol',
@@ -401,7 +401,7 @@ export const telemetryEventDefinitions = {
     owner: 'kimi-code',
     comment: 'A running turn is interrupted.',
     properties: {
-      turn_id: 'Turn index within the session',
+      turn_id: 'Per-agent turn index (main or subagent); not unique across agents in the same session',
       at_step: 'Step index the turn reached before interruption',
       mode: 'Agent mode the turn ran in',
       interrupt_reason: 'Why the turn was interrupted',
@@ -413,7 +413,7 @@ export const telemetryEventDefinitions = {
     owner: 'kimi-code',
     comment: 'A turn ends, unconditionally.',
     properties: {
-      turn_id: 'Turn index within the session',
+      turn_id: 'Per-agent turn index (main or subagent); not unique across agents in the same session',
       reason: 'How the turn ended',
       duration_ms: 'Turn wall-clock time in milliseconds',
       mode: 'Agent mode the turn ran in',
@@ -425,7 +425,7 @@ export const telemetryEventDefinitions = {
     owner: 'kimi-code',
     comment: 'A tool call finishes execution.',
     properties: {
-      turn_id: 'Turn index within the session',
+      turn_id: 'Per-agent turn index (main or subagent); not unique across agents in the same session',
       tool_call_id: 'Provider-assigned tool call id',
       tool_name: 'Registered tool name',
       outcome: 'Execution outcome',
@@ -663,7 +663,7 @@ export const telemetryEventDefinitions = {
     owner: 'kimi-code',
     comment: 'A duplicate tool call is detected.',
     properties: {
-      turn_id: 'Turn index within the session',
+      turn_id: 'Per-agent turn index (main or subagent); not unique across agents in the same session',
       step_no: 'Step index within the turn',
       tool_call_id: 'Provider-assigned tool call id',
       tool_name: 'Registered tool name',

--- a/packages/agent-core-v2/src/app/telemetry/events.ts
+++ b/packages/agent-core-v2/src/app/telemetry/events.ts
@@ -43,12 +43,14 @@ export type StrictPropertyCheck<T, E> = string extends keyof T
     : never;
 
 export interface TurnStartedEvent {
+  turn_id: number;
   mode: 'agent' | 'plan';
   provider_type?: string;
   protocol?: string;
 }
 
 export interface TurnInterruptedEvent {
+  turn_id: number;
   at_step: number;
   mode: 'agent' | 'plan';
   interrupt_reason: 'user_cancelled' | 'aborted' | 'max_steps' | 'error' | 'filtered' | 'blocked';
@@ -57,6 +59,7 @@ export interface TurnInterruptedEvent {
 }
 
 export interface TurnEndedEvent {
+  turn_id: number;
   reason: 'completed' | 'cancelled' | 'failed';
   duration_ms: number;
   mode: 'agent' | 'plan';
@@ -388,6 +391,7 @@ export const telemetryEventDefinitions = {
     owner: 'kimi-code',
     comment: 'A turn starts running.',
     properties: {
+      turn_id: 'Turn index within the session',
       mode: 'Agent mode the turn runs in',
       provider_type: 'Provider protocol type',
       protocol: 'Request protocol',
@@ -397,6 +401,7 @@ export const telemetryEventDefinitions = {
     owner: 'kimi-code',
     comment: 'A running turn is interrupted.',
     properties: {
+      turn_id: 'Turn index within the session',
       at_step: 'Step index the turn reached before interruption',
       mode: 'Agent mode the turn ran in',
       interrupt_reason: 'Why the turn was interrupted',
@@ -408,6 +413,7 @@ export const telemetryEventDefinitions = {
     owner: 'kimi-code',
     comment: 'A turn ends, unconditionally.',
     properties: {
+      turn_id: 'Turn index within the session',
       reason: 'How the turn ended',
       duration_ms: 'Turn wall-clock time in milliseconds',
       mode: 'Agent mode the turn ran in',

--- a/packages/agent-core-v2/test/agent/loop/loop.test.ts
+++ b/packages/agent-core-v2/test/agent/loop/loop.test.ts
@@ -598,11 +598,12 @@ describe('turn telemetry', () => {
 
       expect(records).toContainEqual({
         event: 'turn_started',
-        properties: { mode: 'agent', provider_type: 'kimi', protocol: 'kimi' },
+        properties: { turn_id: 0, mode: 'agent', provider_type: 'kimi', protocol: 'kimi' },
       });
       expect(records).toContainEqual({
         event: 'turn_ended',
         properties: expect.objectContaining({
+          turn_id: 0,
           reason: 'completed',
           duration_ms: expect.any(Number),
           mode: 'agent',
@@ -630,6 +631,7 @@ describe('turn telemetry', () => {
       expect(records).toContainEqual({
         event: 'turn_interrupted',
         properties: expect.objectContaining({
+          turn_id: 0,
           at_step: 1,
           mode: 'agent',
           interrupt_reason: 'filtered',
@@ -677,7 +679,7 @@ describe('turn telemetry', () => {
 
         expect(records).toContainEqual({
           event: 'turn_interrupted',
-          properties: expect.objectContaining({ interrupt_reason: expected, mode: 'agent' }),
+          properties: expect.objectContaining({ turn_id: 0, interrupt_reason: expected, mode: 'agent' }),
         });
         expect(records).toContainEqual({
           event: 'turn_ended',

--- a/packages/agent-core/src/agent/turn/index.ts
+++ b/packages/agent-core/src/agent/turn/index.ts
@@ -1046,6 +1046,7 @@ export class TurnFlow {
       this.toolCallDupType.delete(event.toolCallId);
       const outcome = telemetryToolOutcome(event.result);
       const properties: Record<string, TelemetryPropertyValue> = {
+        turn_id: turnId,
         tool_name: started.name,
         outcome,
         duration_ms: Date.now() - started.startedAt,

--- a/packages/agent-core/src/agent/turn/index.ts
+++ b/packages/agent-core/src/agent/turn/index.ts
@@ -515,7 +515,7 @@ export class TurnFlow {
     const telemetryMode = this.telemetryMode();
     this.telemetryModeByTurn.set(turnId, telemetryMode);
     this.currentStepByTurn.set(turnId, 0);
-    this.agent.telemetry.track('turn_started', { mode: telemetryMode, ...this.requestProtocolProps() });
+    this.agent.telemetry.track('turn_started', { turn_id: turnId, mode: telemetryMode, ...this.requestProtocolProps() });
     this.agent.fullCompaction.resetForTurn();
     this.agent.usage.beginTurn();
     this.agent.emitEvent({ type: 'turn.started', turnId, origin });
@@ -613,6 +613,7 @@ export class TurnFlow {
       });
     }
     this.agent.telemetry.track('turn_ended', {
+      turn_id: turnId,
       reason: ended.reason,
       duration_ms: ended.durationMs,
       mode: this.telemetryModeByTurn.get(turnId) ?? this.telemetryMode(),
@@ -1104,6 +1105,7 @@ export class TurnFlow {
     if (this.interruptedTelemetryTurnIds.has(turnId)) return;
     this.interruptedTelemetryTurnIds.add(turnId);
     this.agent.telemetry.track('turn_interrupted', {
+      turn_id: turnId,
       mode: this.telemetryModeByTurn.get(turnId) ?? this.telemetryMode(),
       at_step: atStep,
       interrupt_reason: interruptReason,

--- a/packages/agent-core/test/agent/turn.test.ts
+++ b/packages/agent-core/test/agent/turn.test.ts
@@ -546,6 +546,7 @@ describe('Agent turn flow', () => {
     expect(ended).toEqual({
       event: 'turn_ended',
       properties: expect.objectContaining({
+        turn_id: 0,
         mode: 'agent',
         reason: 'completed',
         provider_type: 'kimi',
@@ -625,6 +626,7 @@ describe('Agent turn flow', () => {
     expect(records).toContainEqual({
       event: 'tool_call',
       properties: expect.objectContaining({
+        turn_id: 0,
         tool_name: 'Bash',
         outcome: 'success',
         dup_type: 'cross_step',
@@ -702,6 +704,7 @@ describe('Agent turn flow', () => {
     expect(records).toContainEqual({
       event: 'tool_call',
       properties: expect.objectContaining({
+        turn_id: 0,
         tool_name: 'MissingTool',
         outcome: 'error',
         dup_type: 'normal',
@@ -2096,6 +2099,7 @@ describe('Agent turn flow', () => {
     expect(records).toContainEqual({
       event: 'tool_call',
       properties: expect.objectContaining({
+        turn_id: 0,
         tool_name: 'Bash',
         outcome: 'cancelled',
         dup_type: 'normal',

--- a/packages/agent-core/test/agent/turn.test.ts
+++ b/packages/agent-core/test/agent/turn.test.ts
@@ -409,11 +409,11 @@ describe('Agent turn flow', () => {
 
     expect(records).toContainEqual({
       event: 'turn_started',
-      properties: { mode: 'agent' },
+      properties: { turn_id: 0, mode: 'agent' },
     });
     expect(records).toContainEqual({
       event: 'turn_interrupted',
-      properties: { mode: 'agent', at_step: 0, interrupt_reason: 'error' },
+      properties: { turn_id: 0, mode: 'agent', at_step: 0, interrupt_reason: 'error' },
     });
   });
 


### PR DESCRIPTION
## Related Issue

No linked issue — the problem is explained below.

## Problem

The turn lifecycle telemetry events (`turn_started`, `turn_ended`, `turn_interrupted`) never carried the turn id, while `tool_call` (in v2) and `tool_call_dedup_detected` (in both engines) did. Any analysis correlating a turn's start, end, or interruption back to its tool calls had nothing to join on. The gap existed in both `packages/agent-core` (v1) and `packages/agent-core-v2` — and in v1 even `tool_call` itself lacked the turn id, so adding it to the turn lifecycle events alone still left the primary turn ↔ tool-call join impossible.

A second caveat, verified against the downstream analytics project and production telemetry: `turn_id` is a **per-agent** counter in both engines — the main agent and every subagent number their own turns from 0 — while events carry only a session-level `session_id`. In sessions that spawn subagents (about a fifth of production sessions), `(session_id, turn_id)` is therefore **not unique**: the main agent's turn 0 and each subagent's turn 0 collide. Until an explicit agent dimension lands (follow-up work), per-turn joins in such sessions must additionally group or filter by agent.

## What changed

- **v1** (`packages/agent-core`): add `turn_id` (already in scope) to the three `track()` calls in `TurnFlow` and to the `tool_call` event emitted by `trackToolLifecycle`, matching the existing key/value convention used by `tool_call_dedup_detected`; extend the strict `turn_started`/`turn_interrupted` assertions plus the existing `tool_call` and `turn_ended` assertions to cover it.
- **v2** (`packages/agent-core-v2`): add `turn_id: number` to the `TurnStartedEvent` / `TurnInterruptedEvent` / `TurnEndedEvent` interfaces and the telemetry registry property docs; pass `turn_id: turn.id` in `AgentLoopService`'s three `track2()` calls, matching the `ToolCallEvent` convention; extend the turn telemetry assertions in `loop.test.ts` to cover it. Also correct the `turn_id` doc on all five registry entries that carry it: it previously read "Turn index within the session", but the id is a per-agent index and is not unique across agents in the same session.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset. (No changeset: telemetry-only property addition.)
- [x] Ran `gen-docs` skill, or this PR needs no doc update. (No doc update: internal telemetry schema, no user-facing behavior change.)
