### PR TITLE
fix(agent-core-v2): project support_efforts and default_effort in the model catalog

### DIFF
--- a/.changeset/v2-model-catalog-efforts.md
+++ b/.changeset/v2-model-catalog-efforts.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/agent-core-v2": patch
+---
+
+Fix the v2 model catalog response omitting support_efforts and default_effort, restoring thinking-effort selection for clients connected to the v2 backend.

--- a/packages/agent-core-v2/src/app/modelCatalog/modelCatalog.ts
+++ b/packages/agent-core-v2/src/app/modelCatalog/modelCatalog.ts
@@ -21,6 +21,7 @@ import type {
 import { createDecorator, type ServiceIdentifier } from '#/_base/di/instantiation';
 
 import type { ModelAlias } from '#/app/model/model';
+import { effectiveModelConfig } from '#/app/model/modelAuth';
 import type { ProviderConfig } from '#/app/provider/provider';
 
 export type RefreshProviderModelsScope = 'all' | 'oauth';
@@ -51,12 +52,15 @@ export interface ProviderCredentialState {
 }
 
 export function toProtocolModel(modelId: string, alias: ModelAlias): ModelCatalogItem {
+  const effective = effectiveModelConfig(alias);
   return {
-    provider: alias.provider ?? '',
+    provider: effective.provider ?? '',
     model: modelId,
-    display_name: alias.displayName ?? alias.model ?? modelId,
-    max_context_size: alias.maxContextSize ?? 0,
-    capabilities: alias.capabilities,
+    display_name: effective.displayName ?? effective.model ?? modelId,
+    max_context_size: effective.maxContextSize ?? 0,
+    capabilities: effective.capabilities,
+    support_efforts: effective.supportEfforts,
+    default_effort: effective.defaultEffort,
   };
 }
 

--- a/packages/agent-core-v2/test/app/modelCatalog/modelCatalog.test.ts
+++ b/packages/agent-core-v2/test/app/modelCatalog/modelCatalog.test.ts
@@ -159,6 +159,34 @@ describe('ModelCatalogService', () => {
     ]);
   });
 
+  it('projects support_efforts and default_effort from the model config', async () => {
+    backing.models['k2'] = {
+      ...backing.models['k2'],
+      supportEfforts: ['low', 'high', 'max'],
+      defaultEffort: 'max',
+    };
+    const [k2] = await catalog().listModels();
+    expect(k2).toMatchObject({
+      model: 'k2',
+      support_efforts: ['low', 'high', 'max'],
+      default_effort: 'max',
+    });
+  });
+
+  it('projects effort fields from overrides when present', async () => {
+    backing.models['k2'] = {
+      ...backing.models['k2'],
+      supportEfforts: ['low', 'high'],
+      defaultEffort: 'high',
+      overrides: { supportEfforts: ['low', 'high', 'max'], defaultEffort: 'max' },
+    };
+    const [k2] = await catalog().listModels();
+    expect(k2).toMatchObject({
+      support_efforts: ['low', 'high', 'max'],
+      default_effort: 'max',
+    });
+  });
+
   it('lists providers with per-provider models, default model, and credential state', async () => {
     await expect(catalog().listProviders()).resolves.toEqual([
       {


### PR DESCRIPTION
## Related Issue

No linked issue — the problem is explained below.

## Problem

The v2 backend's model catalog (`/models`) response drops `support_efforts` and `default_effort`, even though the protocol wire schema defines both fields and models declare them in config (e.g. `support_efforts = ["low","high","max"]`, `default_effort = "max"`). Clients connected to the v2 backend — the web UI or any non-TUI consumer — receive `undefined` for the effort fields and cannot render thinking-effort selection (the web UI falls back to a plain on/off toggle). The v1 catalog projection emits both fields, so this is a v1/v2 parity gap on a surface that claims wire compatibility.

## What changed

- `packages/agent-core-v2/src/app/modelCatalog/modelCatalog.ts`: `toProtocolModel` now applies `effectiveModelConfig` (the v2 counterpart of v1's `effectiveModelAlias`, which merges config `overrides`) and projects `support_efforts` / `default_effort` alongside the existing fields, matching the v1 projection field-for-field.
- `packages/agent-core-v2/test/app/modelCatalog/modelCatalog.test.ts`: two new projection tests — effort fields declared directly on the model config, and effective effort values when `overrides` replace them.
- Changeset: `@moonshot-ai/agent-core-v2` patch.

Verified: `lint:domain`, `typecheck`, and the full agent-core-v2 test suite (3337 tests) pass.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.
