### PR TITLE
fix(agent-core-v2): preserve goal completion summaries and error messages

### DIFF
--- a/.changeset/fix-goal-and-loop-events.md
+++ b/.changeset/fix-goal-and-loop-events.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Preserve goal completion summaries and show untyped LLM errors without an internal error-code prefix in step interruption events.

--- a/packages/agent-core-v2/src/agent/goal/goalService.ts
+++ b/packages/agent-core-v2/src/agent/goal/goalService.ts
@@ -635,6 +635,7 @@ export class AgentGoalService extends Disposable implements IAgentGoalService {
 
   private cancelPendingContinuation(): void {
     const pending = this.pendingContinuation;
+    if (pending?.turnId === this.liveTurnId) return;
     this.pendingContinuation = undefined;
     pending?.receipt.abort();
   }

--- a/packages/agent-core-v2/src/agent/goal/goalService.ts
+++ b/packages/agent-core-v2/src/agent/goal/goalService.ts
@@ -417,7 +417,7 @@ export class AgentGoalService extends Disposable implements IAgentGoalService {
     const snapshot = this.toSnapshot(completed);
     this.emitCompletion(completed, snapshot, input.reason, actor);
     this.trackStatusChanged(completed, actor);
-    this.clearInternal(actor);
+    this.clearInternal(actor, { preserveLiveContinuation: true });
     return snapshot;
   }
 
@@ -633,9 +633,9 @@ export class AgentGoalService extends Disposable implements IAgentGoalService {
     return status.state === 'idle' && !status.hasPendingRequests;
   }
 
-  private cancelPendingContinuation(): void {
+  private cancelPendingContinuation(preserveLiveContinuation = false): void {
     const pending = this.pendingContinuation;
-    if (pending?.turnId === this.liveTurnId) return;
+    if (preserveLiveContinuation && pending?.turnId === this.liveTurnId) return;
     this.pendingContinuation = undefined;
     pending?.receipt.abort();
   }
@@ -673,10 +673,10 @@ export class AgentGoalService extends Disposable implements IAgentGoalService {
 
   private clearInternal(
     actor: GoalActor,
-    opts: { readonly emit?: boolean; readonly track?: boolean } = {},
+    opts: { readonly emit?: boolean; readonly track?: boolean; readonly preserveLiveContinuation?: boolean } = {},
   ): void {
     if (this.goalState === null) return;
-    this.cancelPendingContinuation();
+    this.cancelPendingContinuation(opts.preserveLiveContinuation === true);
     this.wallClockResumedAt = undefined;
     this.wire.dispatch(clearGoal({}));
     if (opts.emit !== false) this.emitGoalUpdated(null);

--- a/packages/agent-core-v2/src/agent/loop/loopService.ts
+++ b/packages/agent-core-v2/src/agent/loop/loopService.ts
@@ -646,7 +646,9 @@ export class AgentLoopService extends Disposable implements IAgentLoopService {
 
   private failLoopStep(runtime: LoopRuntime, error: unknown): LoopErrorDisposition {
     const reason: LoopInterruptReason = isMaxStepsExceededError(error) ? 'max_steps' : 'error';
-    this.emitStepInterrupted(runtime.turnId, runtime.current?.number, reason, toErrorMessage(error));
+    const interruptedError =
+      isError2(error) && error.code === ErrorCodes.INTERNAL && error.cause !== undefined ? error.cause : error;
+    this.emitStepInterrupted(runtime.turnId, runtime.current?.number, reason, toErrorMessage(interruptedError));
     return { type: 'return', result: { type: 'failed', error, steps: runtime.steps } };
   }
 

--- a/packages/agent-core-v2/test/agent/goal/goal.test.ts
+++ b/packages/agent-core-v2/test/agent/goal/goal.test.ts
@@ -13,7 +13,7 @@ import { USER_PROMPT_ORIGIN } from '#/agent/contextMemory/types';
 import { IAgentGoalService } from '#/agent/goal/goal';
 import { type AgentGoalService } from '#/agent/goal/goalService';
 import { UpdateGoalTool, UpdateGoalToolInputSchema } from '#/agent/goal/tools/update-goal';
-import { IAgentLoopService, type AfterStepContext, type Turn } from '#/agent/loop/loop';
+import { IAgentLoopService, type AfterStepContext, type EnqueueReceipt, type Step, type Turn } from '#/agent/loop/loop';
 import { MessageStepRequest } from '#/agent/loop/stepRequest';
 import { IAgentToolExecutorService } from '#/agent/toolExecutor/toolExecutor';
 import { IAgentUsageService } from '#/agent/usage/usage';
@@ -584,6 +584,28 @@ describe('AgentGoalService core workflow hooks', () => {
     await ctx?.dispose();
   });
 
+  async function startLiveContinuation(): Promise<ReturnType<typeof vi.fn<() => boolean>>> {
+    const abort = vi.fn<() => boolean>(() => true);
+    const turn: Turn = { ...makeTurn(41), result: new Promise<never>(() => {}) };
+    const step: Step = {
+      id: 'goal-continuation',
+      turnId: turn.id,
+      state: 'queued',
+      signal: turn.signal,
+      result: Promise.resolve({ type: 'completed' }),
+      cancel: () => true,
+    };
+    const receipt: EnqueueReceipt = { assigned: Promise.resolve({ turn, step }), abort };
+    vi.spyOn(loopService, 'enqueue').mockReturnValue(receipt);
+
+    await goals.createGoal({ objective: 'finish the task' });
+    await goals.markBlocked({ reason: 'need credentials' });
+    await goals.resumeGoal({ continueIfBlocked: true });
+    await Promise.resolve();
+    eventBus.publish({ type: 'turn.started', turnId: turn.id, origin: USER_PROMPT_ORIGIN });
+    return abort;
+  }
+
   it('starts a continuation when a user resumes an idle blocked goal', async () => {
     await goals.createGoal({ objective: 'finish the task' });
     await goals.markBlocked({ reason: 'need credentials' });
@@ -597,6 +619,30 @@ describe('AgentGoalService core workflow hooks', () => {
       kind: 'system_trigger',
       name: 'goal_continuation',
     });
+  });
+
+  it('aborts a live continuation when the user pauses the goal', async () => {
+    const abort = await startLiveContinuation();
+
+    await goals.pauseGoal();
+
+    expect(abort).toHaveBeenCalledOnce();
+  });
+
+  it('aborts a live continuation when the user cancels the goal', async () => {
+    const abort = await startLiveContinuation();
+
+    await goals.cancelGoal();
+
+    expect(abort).toHaveBeenCalledOnce();
+  });
+
+  it('aborts a live continuation when the user replaces the goal', async () => {
+    const abort = await startLiveContinuation();
+
+    await goals.createGoal({ objective: 'new task', replace: true });
+
+    expect(abort).toHaveBeenCalledOnce();
   });
 
   it.each(['turn', 'token', 'wall-clock'] as const)(

--- a/packages/agent-core-v2/test/agent/goal/goal.test.ts
+++ b/packages/agent-core-v2/test/agent/goal/goal.test.ts
@@ -298,6 +298,7 @@ describe('AgentGoalService', () => {
         name: 'UpdateGoal',
         arguments: JSON.stringify({ status: 'complete' }),
       });
+      ctx.mockNextResponse({ type: 'text', text: 'Goal completed.' });
       const endedTurnIds: number[] = [];
       const endedTurnReasons: string[] = [];
       const continuationTurnIds: number[] = [];
@@ -327,7 +328,7 @@ describe('AgentGoalService', () => {
       await vi.waitFor(() => {
         expect(endedTurnIds).toHaveLength(2);
       });
-      expect(ctx.llmCalls).toHaveLength(2);
+      expect(ctx.llmCalls).toHaveLength(3);
       expect(continuationTurnIds).toEqual(endedTurnIds);
       expect(endedTurnReasons).toEqual(['completed', 'completed']);
       expect(goals.getGoal().goal).toBeNull();

--- a/packages/agent-core-v2/test/agent/goal/injection/goalInjection.test.ts
+++ b/packages/agent-core-v2/test/agent/goal/injection/goalInjection.test.ts
@@ -342,6 +342,26 @@ describe('GoalInjection integration', () => {
       expect(await flushedGoalReminderRecords(ctx, persistence)).toHaveLength(2);
     });
 
+    it('requests a final model response when a continuation completes the goal', async () => {
+      profile.update({ activeToolNames: ['UpdateGoal'] });
+      await goals.createGoal({ objective: 'Finish the task' });
+
+      ctx.mockNextResponse({ type: 'text', text: 'Working on it.' });
+      ctx.mockNextResponse({
+        type: 'function',
+        id: 'call_complete_goal',
+        name: 'UpdateGoal',
+        arguments: JSON.stringify({ status: 'complete' }),
+      });
+      ctx.mockNextResponse({ type: 'text', text: 'Finished and verified.' });
+
+      await ctx.rpc.prompt({ input: [{ type: 'text', text: 'Start.' }] });
+      await ctx.untilTurnEnd();
+      await ctx.untilTurnEnd();
+
+      expect(ctx.llmCalls).toHaveLength(3);
+    });
+
     it('writes no goal record when there is no active goal', async () => {
       await injectDynamic(injector);
 

--- a/packages/agent-core-v2/test/agent/loop/loop.test.ts
+++ b/packages/agent-core-v2/test/agent/loop/loop.test.ts
@@ -215,6 +215,23 @@ describe('Agent loop', () => {
     );
   });
 
+  it('reports an untyped LLM error message without an internal-code prefix', async () => {
+    profile.update({ activeToolNames: [] });
+
+    await ctx.rpc.prompt({ input: [{ type: 'text', text: 'Hello' }] });
+    await ctx.untilTurnEnd();
+
+    expect(ctx.allEvents).toContainEqual(
+      expect.objectContaining({
+        event: 'turn.step.interrupted',
+        args: expect.objectContaining({
+          reason: 'error',
+          message: 'Unexpected generate call #1',
+        }),
+      }),
+    );
+  });
+
   it('does not run loop error handlers for aborted turns', async () => {
     let called = false;
     loop.registerLoopErrorHandler({


### PR DESCRIPTION
## Related Issue

No linked issue. This is a focused, reproduction-backed fix for two agent-core-v2 parity bugs.

## Problem

Completing a goal during its resumed continuation could abort the live continuation before it emitted the assistant's completion summary. Separately, a generic LLM error was translated to `internal` and exposed in `turn.step.interrupted` as `[internal] …`, instead of the underlying error message.

## What changed

- Keep the live turn's pending continuation intact during goal cleanup, so it can finish and emit its final summary.
- When publishing a step interruption for an internal wrapper with a cause, render the underlying error message; other coded errors keep their existing rendering.
- Add regression tests for both paths and a CLI patch changeset.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.