### PR TITLE
test(kap-server): use agent lifecycle get in blocked goal rig

### DIFF
--- a/packages/kap-server/test/sessions.test.ts
+++ b/packages/kap-server/test/sessions.test.ts
@@ -20,6 +20,7 @@ import {
   IEventBus,
   IEventService,
   ISessionLifecycleService,
+  MAIN_AGENT_ID,
   type ServiceIdentifier,
 } from '@moonshot-ai/agent-core-v2';
 import { sessionWarningsResponseSchema } from '@moonshot-ai/protocol';
@@ -229,7 +230,7 @@ describe('server-v2 /api/v1/sessions', () => {
       .get(ISessionLifecycleService)
       .get(id);
     if (session === undefined) throw new Error('expected a live session');
-    const agent = session.accessor.get(IAgentLifecycleService).getHandle('main');
+    const agent = session.accessor.get(IAgentLifecycleService).get(MAIN_AGENT_ID);
     if (agent === undefined) throw new Error('expected a live main agent');
 
     const eventBus = agent.accessor.get(IEventBus);


### PR DESCRIPTION
## Related Issue

No linked issue — this fixes a typecheck and test regression already present on `main`.

## Problem

The blocked-goal continuation tests call `IAgentLifecycleService.getHandle('main')`, but the v2 service exposes the agent lookup as `get(agentId)`. This causes the repository typecheck to fail and prevents the affected kap-server test shard from passing.

## What changed

- Replaced the stale `getHandle('main')` call with `get(MAIN_AGENT_ID)` in the shared blocked-goal test setup.
- Reused the exported `MAIN_AGENT_ID` constant instead of duplicating the agent id string.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset (test-only fix).
- [x] Ran `gen-docs` skill, or this PR needs no doc update.
