### PR TITLE
test(kap-server): fix sessions test using removed getHandle API

### DIFF
--- a/packages/kap-server/test/sessions.test.ts
+++ b/packages/kap-server/test/sessions.test.ts
@@ -229,7 +229,7 @@ describe('server-v2 /api/v1/sessions', () => {
       .get(ISessionLifecycleService)
       .get(id);
     if (session === undefined) throw new Error('expected a live session');
-    const agent = session.accessor.get(IAgentLifecycleService).getHandle('main');
+    const agent = session.accessor.get(IAgentLifecycleService).get('main');
     if (agent === undefined) throw new Error('expected a live main agent');
 
     const eventBus = agent.accessor.get(IEventBus);


### PR DESCRIPTION
## Related Issue

No linked issue — this fixes a CI failure on main (run [29310725642](https://github.com/MoonshotAI/kimi-code/actions/runs/29310725642)).

## Problem

The agent lifecycle refactor (#1624) renamed the agent lookup on `IAgentLifecycleService` from `getHandle(id)` to `get(id)`. `createBlockedGoalRig` in `packages/kap-server/test/sessions.test.ts` still called `getHandle('main')`, which broke:

- the typecheck job (`TS2339: Property 'getHandle' does not exist`, plus a cascading implicit-`any`)
- the two blocked-goal resume tests (`TypeError: getHandle is not a function`)

## What changed

One line: `getHandle('main')` → `get('main')` in the test rig. Verified locally: `tsgo` passes for `packages/kap-server` and all 53 tests in `sessions.test.ts` pass.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works. (This PR fixes an existing test; no new tests needed.)
- [x] Ran `gen-changesets` skill, or this PR needs no changeset. (Test-only change — no changeset per skill rule 5.)
- [x] Ran `gen-docs` skill, or this PR needs no doc update. (No user-facing change.)