### PR TITLE
feat(acp): add /undo builtin and kimi/session fork, close, steer extension methods

### DIFF
--- a/.changeset/acp-steer-fork-kaos.md
+++ b/.changeset/acp-steer-fork-kaos.md
@@ -1,0 +1,7 @@
+---
+"@moonshot-ai/agent-core": minor
+"@moonshot-ai/kimi-code-sdk": minor
+"@moonshot-ai/acp-adapter": minor
+---
+
+ACP: add the `kimi/session/steer` extension method — it injects a pending user message into the session's active turn (consumed at the next step boundary, in-flight tool calls and subagents undisturbed) and resolves `{ steered: false, reason: 'no_active_turn' }` instead of erroring when no turn is running, so clients can fall back to `session/prompt`. Also route `kimi/session/fork` through the same kaos pair as `session/new` when the client advertises fs capabilities: the kernel gains `forkSessionWithOverrides` and the SDK a matching `forkSessionWithKaos` passthrough, so forked sessions keep routing file I/O to the ACP client instead of silently falling back to the kernel's local filesystem.

--- a/.changeset/acp-steer-fork-kaos.md
+++ b/.changeset/acp-steer-fork-kaos.md
@@ -1,7 +1,6 @@
 ---
-"@moonshot-ai/agent-core": minor
+"@moonshot-ai/kimi-code": minor
 "@moonshot-ai/kimi-code-sdk": minor
-"@moonshot-ai/acp-adapter": minor
 ---
 
 ACP: add the `kimi/session/steer` extension method — it injects a pending user message into the session's active turn (consumed at the next step boundary, in-flight tool calls and subagents undisturbed) and resolves `{ steered: false, reason: 'no_active_turn' }` instead of erroring when no turn is running, so clients can fall back to `session/prompt`. Also route `kimi/session/fork` through the same kaos pair as `session/new` when the client advertises fs capabilities: the kernel gains `forkSessionWithOverrides` and the SDK a matching `forkSessionWithKaos` passthrough, so forked sessions keep routing file I/O to the ACP client instead of silently falling back to the kernel's local filesystem.

--- a/.changeset/acp-undo-fork-close.md
+++ b/.changeset/acp-undo-fork-close.md
@@ -1,0 +1,6 @@
+---
+"@moonshot-ai/kimi-code": minor
+"@moonshot-ai/kimi-code-sdk": minor
+---
+
+ACP: add the `/undo [count]` built-in slash command (drives the SDK's `undoHistory`, refused while a turn is running) and two `kimi/*` extension methods: `kimi/session/fork` (fork a session into an ephemeral, promptable copy for btw-style side conversations) and `kimi/session/close` (close a session, with `archive: true` to also archive the on-disk directory). The SDK gains `KimiHarness.archiveSession` and an `rpc.archiveSession` passthrough for the archive path.

--- a/.changeset/acp-undo-precheck.md
+++ b/.changeset/acp-undo-precheck.md
@@ -1,5 +1,5 @@
 ---
-"@moonshot-ai/acp-adapter": patch
+"@moonshot-ai/kimi-code": patch
 ---
 
 ACP: pre-check `/undo [count]` availability against the live context before calling the kernel, mirroring the web backend's `canUndoHistory` guard. An over-large count (or one crossing a compaction boundary) is now refused up front with the kernel's own message wording, instead of the kernel partially deleting history and only then throwing `REQUEST_INVALID`.

--- a/.changeset/acp-undo-precheck.md
+++ b/.changeset/acp-undo-precheck.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/acp-adapter": patch
+---
+
+ACP: pre-check `/undo [count]` availability against the live context before calling the kernel, mirroring the web backend's `canUndoHistory` guard. An over-large count (or one crossing a compaction boundary) is now refused up front with the kernel's own message wording, instead of the kernel partially deleting history and only then throwing `REQUEST_INVALID`.

--- a/docs/en/reference/kimi-acp.md
+++ b/docs/en/reference/kimi-acp.md
@@ -68,6 +68,31 @@ The spec divides methods into a **stable** surface and an evolving **unstable** 
 
 All methods not listed above return `methodNotFound`.
 
+## Extension methods (`kimi/*` namespace)
+
+Adapter-owned extensions live in the `kimi/*` namespace so they never collide with future ACP spec methods. Unknown extension methods return `methodNotFound (-32601)`.
+
+| Method | Params | Returns | Description |
+| --- | --- | --- | --- |
+| `kimi/session/fork` | `{ sessionId }` | `{ sessionId }` | Forks the session into an ephemeral copy and registers it as a first-class ACP session the client can `session/prompt` normally (btw-style side conversation that cannot pollute the source context). Rejected while the source has an active turn. Inherits the source session's model/thinking state; ACP-supplied MCP servers are not carried over. |
+| `kimi/session/close` | `{ sessionId, archive? }` | `{}` | Closes the session and drops it from the adapter. With `archive: true` the on-disk session directory is archived as well (the fork cleanup path); otherwise the session stays resumable. |
+
+## Built-in slash commands
+
+Slash commands sent as plain-text `session/prompt` blocks are intercepted by the adapter. Advertised to the client via `available_commands_update` after every `session/new` / `session/load` / `session/resume`:
+
+| Command | Args | Description |
+| --- | --- | --- |
+| `/compact` | `<optional instruction>` | Compacts the conversation context, with an optional custom summarization instruction |
+| `/undo` | `<optional count>` | Undoes the last N turns (default 1); refused while a turn is running |
+| `/status` | — | Shows current session status |
+| `/usage` | — | Shows session token usage |
+| `/mcp` | — | Shows MCP server status |
+| `/tasks` | — | Lists background tasks |
+| `/help` | — | Shows available ACP commands |
+
+Unknown slash commands are answered locally with an "unknown command" notice instead of being forwarded to the model.
+
 ## MCP Forwarding
 
 When an ACP client provides `mcpServers` in `session/new` or `session/load`, the adapter layer performs the following conversions:

--- a/docs/en/reference/kimi-acp.md
+++ b/docs/en/reference/kimi-acp.md
@@ -74,8 +74,9 @@ Adapter-owned extensions live in the `kimi/*` namespace so they never collide wi
 
 | Method | Params | Returns | Description |
 | --- | --- | --- | --- |
-| `kimi/session/fork` | `{ sessionId }` | `{ sessionId }` | Forks the session into an ephemeral copy and registers it as a first-class ACP session the client can `session/prompt` normally (btw-style side conversation that cannot pollute the source context). Rejected while the source has an active turn. Inherits the source session's model/thinking state; ACP-supplied MCP servers are not carried over. |
+| `kimi/session/fork` | `{ sessionId }` | `{ sessionId }` | Forks the session into an ephemeral copy and registers it as a first-class ACP session the client can `session/prompt` normally (btw-style side conversation that cannot pollute the source context). Rejected while the source has an active turn. Inherits the source session's model/thinking state; when the client advertises `fs.readTextFile` / `fs.writeTextFile`, the fork routes file I/O through the same ACP reverse-RPC kaos pair as `session/new`. ACP-supplied MCP servers are not carried over. |
 | `kimi/session/close` | `{ sessionId, archive? }` | `{}` | Closes the session and drops it from the adapter. With `archive: true` the on-disk session directory is archived as well (the fork cleanup path); otherwise the session stays resumable. |
+| `kimi/session/steer` | `{ sessionId, prompt }` | `{ steered: true }` or `{ steered: false, reason: 'no_active_turn' }` | Injects a pending user message (`prompt` is a `ContentBlock[]`, same shape as `session/prompt`) into the session's active turn; the model consumes it at the next step boundary while in-flight tool calls and subagents run on undisturbed. With no active turn it resolves to `{ steered: false, reason: 'no_active_turn' }` instead of erroring — the client is expected to fall back to `session/prompt`. |
 
 ## Built-in slash commands
 
@@ -84,7 +85,7 @@ Slash commands sent as plain-text `session/prompt` blocks are intercepted by the
 | Command | Args | Description |
 | --- | --- | --- |
 | `/compact` | `<optional instruction>` | Compacts the conversation context, with an optional custom summarization instruction |
-| `/undo` | `<optional count>` | Undoes the last N turns (default 1); refused while a turn is running |
+| `/undo` | `<optional count>` | Undoes the last N turns (default 1); refused while a turn is running, or up front when fewer than N prompts are undoable in the active context (e.g. after a compaction) |
 | `/status` | — | Shows current session status |
 | `/usage` | — | Shows session token usage |
 | `/mcp` | — | Shows MCP server status |

--- a/docs/zh/reference/kimi-acp.md
+++ b/docs/zh/reference/kimi-acp.md
@@ -68,6 +68,32 @@ kimi acp
 
 上述未列出的方法一律返回 `methodNotFound`。
 
+## 扩展方法（`kimi/*` 命名空间）
+
+适配器自有的扩展方法放在 `kimi/*` 命名空间，避免与未来 ACP 规范方法冲突。未知的扩展方法返回 `methodNotFound (-32601)`。
+
+| 方法 | 参数 | 返回 | 说明 |
+| --- | --- | --- | --- |
+| `kimi/session/fork` | `{ sessionId }` | `{ sessionId }` | 把会话 fork 成一个临时副本，并注册为一等 ACP 会话，客户端可照常 `session/prompt`（btw 式旁路对话，不会污染源上下文）。源会话有活跃 turn 时拒绝。继承源会话的 model/thinking 状态；客户端声明 `fs.readTextFile` / `fs.writeTextFile` 能力时，fork 与 `session/new` 一样走同一对 ACP reverse-RPC kaos 路由文件 I/O。不携带 ACP 侧提供的 MCP servers。 |
+| `kimi/session/close` | `{ sessionId, archive? }` | `{}` | 关闭会话并从适配器移除。`archive: true` 时一并归档磁盘会话目录（fork 的清理路径）；否则会话仍可恢复。 |
+| `kimi/session/steer` | `{ sessionId, prompt }` | `{ steered: true }` 或 `{ steered: false, reason: 'no_active_turn' }` | 把一条待处理的用户消息（`prompt` 为 `ContentBlock[]`，与 `session/prompt` 同构）注入当前活跃 turn；模型在下一个 step 边界消费，在途工具调用和 subagent 不受影响。无活跃 turn 时不报错，返回 `{ steered: false, reason: 'no_active_turn' }`，客户端应回退到 `session/prompt`。 |
+
+## 内置斜杠命令
+
+以纯文本 `session/prompt` 块发送的斜杠命令会被适配器拦截。每次 `session/new` / `session/load` / `session/resume` 之后通过 `available_commands_update` 公告给客户端：
+
+| 命令 | 参数 | 说明 |
+| --- | --- | --- |
+| `/compact` | `<可选指令>` | 压缩会话上下文，可附带自定义总结指令 |
+| `/undo` | `<可选 count>` | 撤销最近 N 个 turn（默认 1）；turn 运行中拒绝；活跃上下文中可撤销的 prompt 不足 N 个时（如 compaction 之后）预先拒绝 |
+| `/status` | — | 显示当前会话状态 |
+| `/usage` | — | 显示会话 token 用量 |
+| `/mcp` | — | 显示 MCP server 状态 |
+| `/tasks` | — | 列出后台任务 |
+| `/help` | — | 显示可用 ACP 命令 |
+
+未知斜杠命令在本地回复一条 "unknown command" 提示，不会转发给模型。
+
 ## MCP 转发
 
 ACP 客户端在 `session/new` 或 `session/load` 中提供 `mcpServers` 时，适配层做如下转换：

--- a/packages/acp-adapter/src/builtin-commands.ts
+++ b/packages/acp-adapter/src/builtin-commands.ts
@@ -7,6 +7,11 @@ export const ACP_BUILTIN_SLASH_COMMANDS = [
     input: { hint: '<optional custom summarization instructions>' },
   },
   {
+    name: 'undo',
+    description: 'Undo the last N turns of conversation (default 1)',
+    input: { hint: '<optional count>' },
+  },
+  {
     name: 'status',
     description: 'Show current session status',
   },

--- a/packages/acp-adapter/src/server.ts
+++ b/packages/acp-adapter/src/server.ts
@@ -20,6 +20,7 @@ import {
   type AvailableCommand,
   type CancelNotification,
   type ClientCapabilities,
+  type ContentBlock,
   type Implementation,
   type InitializeRequest,
   type InitializeResponse,
@@ -753,6 +754,12 @@ export class AcpServer implements Agent {
    *   - `kimi/session/close` — close a session and drop it from the
    *     adapter; `archive: true` also archives the on-disk directory
    *     (the btw fork cleanup path).
+   *   - `kimi/session/steer` — inject a pending user message into the
+   *     session's active turn; the model consumes it at the next step
+   *     boundary while in-flight tool calls and subagents run on
+   *     undisturbed. With no active turn the method resolves to
+   *     `{ steered: false, reason: 'no_active_turn' }` instead of
+   *     erroring, so the client can fall back to `session/prompt`.
    */
   async extMethod(
     method: string,
@@ -763,6 +770,9 @@ export class AcpServer implements Agent {
     }
     if (method === 'kimi/session/close') {
       return this.closeSessionExt(params);
+    }
+    if (method === 'kimi/session/steer') {
+      return this.steerSessionExt(params);
     }
     throw RequestError.methodNotFound(method);
   }
@@ -778,6 +788,12 @@ export class AcpServer implements Agent {
    * thinking state. ACP-supplied MCP servers are NOT carried over —
    * `resumeSession` rebuilds MCP from the on-disk config only; forks
    * that need caller-supplied MCP servers are a follow-up.
+   *
+   * When the client advertised `fs.readTextFile` / `fs.writeTextFile`,
+   * the fork is resumed through an {@link AcpKaos} pair (reverse-RPC tool
+   * kaos + local persistence kaos), exactly like `session/new` — so file
+   * I/O inside the fork routes to the same client instead of silently
+   * falling back to the kernel's process-wide {@link LocalKaos}.
    *
    * Forks accumulate on disk until the client archives them via
    * `kimi/session/close` with `archive: true`.
@@ -802,9 +818,18 @@ export class AcpServer implements Agent {
         'AcpServer is missing its AgentSideConnection',
       );
     }
+    // Pre-mint the fork id so the optional AcpKaos carries the reverse-RPC
+    // channel of the session the kernel is about to resume — same boundary-
+    // injection pattern as `newSession`.
+    const forkId = `session_${randomUUID()}`;
+    const acpKaos = await this.maybeBuildAcpKaos(forkId);
+    const persistenceKaos = acpKaos === undefined ? undefined : await this.ensureInnerKaos();
     const fork = await this.harness.forkSession({
       id: sessionId,
+      forkId,
       title: `Fork of ${sessionId}`,
+      kaos: acpKaos,
+      persistenceKaos,
     });
     const acpSession = new AcpSession(
       this.conn,
@@ -846,6 +871,38 @@ export class AcpServer implements Agent {
       await this.harness.closeSession(sessionId);
     }
     return {};
+  }
+
+  /**
+   * `kimi/session/steer` — forward a pending user message to
+   * {@link AcpSession.steer}, which injects it into the session's active
+   * turn. The result is the steer outcome verbatim:
+   * `{ steered: true }`, or `{ steered: false, reason: 'no_active_turn' }`
+   * when the session has no running turn (the client is expected to fall
+   * back to `session/prompt` in that case).
+   */
+  private async steerSessionExt(
+    params: Record<string, unknown>,
+  ): Promise<Record<string, unknown>> {
+    const sessionId = params['sessionId'];
+    if (typeof sessionId !== 'string' || sessionId.length === 0) {
+      throw RequestError.invalidParams(
+        undefined,
+        'kimi/session/steer requires a string sessionId',
+      );
+    }
+    const acpSession = this.sessions.get(sessionId);
+    if (acpSession === undefined) {
+      throw RequestError.invalidParams(undefined, `Unknown session: ${sessionId}`);
+    }
+    const prompt = params['prompt'];
+    if (!Array.isArray(prompt) || prompt.length === 0) {
+      throw RequestError.invalidParams(
+        undefined,
+        'kimi/session/steer requires a non-empty prompt array of content blocks',
+      );
+    }
+    return acpSession.steer(prompt as readonly ContentBlock[]);
   }
 
   /**

--- a/packages/acp-adapter/src/server.ts
+++ b/packages/acp-adapter/src/server.ts
@@ -739,23 +739,113 @@ export class AcpServer implements Agent {
   }
 
   /**
-   * Stub the ACP `ext/<method>` extension surface. The interface
-   * declares both `extMethod` and `extNotification` as optional, but
-   * implementing them explicitly with a structured `MethodNotFound`
-   * response gives clients a uniform failure shape (mirrors the
-   * `authenticate` pattern at {@link AcpServer.authenticate}) — some
-   * clients treat "method absent on the agent" differently from an
-   * explicit error reply.
+   * ACP `ext/<method>` extension surface. Unknown methods get a
+   * structured `MethodNotFound` response (mirrors the `authenticate`
+   * pattern at {@link AcpServer.authenticate}) so clients can
+   * distinguish "method absent on the agent" from a transport failure.
    *
-   * Future work (PLAN D9): route slash-command bridge / model-list /
-   * mode-list extensions through here once the adapter has access to
-   * the kimi-code app's registry. Phase 11 keeps it as a no-op stub.
+   * Adapter-owned methods live in the `kimi/*` namespace, kept clear of
+   * the ACP spec's core `session/*` methods:
+   *
+   *   - `kimi/session/fork`  — fork a session into an ephemeral copy
+   *     (btw-style side conversation) and register it as a first-class
+   *     ACP session the client can prompt normally.
+   *   - `kimi/session/close` — close a session and drop it from the
+   *     adapter; `archive: true` also archives the on-disk directory
+   *     (the btw fork cleanup path).
    */
   async extMethod(
     method: string,
-    _params: Record<string, unknown>,
+    params: Record<string, unknown>,
   ): Promise<Record<string, unknown>> {
+    if (method === 'kimi/session/fork') {
+      return this.forkSessionExt(params);
+    }
+    if (method === 'kimi/session/close') {
+      return this.closeSessionExt(params);
+    }
     throw RequestError.methodNotFound(method);
+  }
+
+  /**
+   * `kimi/session/fork` — fork an existing session into a new copy and
+   * register it as a first-class ACP session so the client can drive it
+   * with the normal `session/prompt` streaming/tool surface. The
+   * kernel-level fork copies the context/history and rejects while the
+   * source has an active turn (SESSION_FORK_ACTIVE_TURN).
+   *
+   * The fork inherits the source AcpSession's adapter-side model /
+   * thinking state. ACP-supplied MCP servers are NOT carried over —
+   * `resumeSession` rebuilds MCP from the on-disk config only; forks
+   * that need caller-supplied MCP servers are a follow-up.
+   *
+   * Forks accumulate on disk until the client archives them via
+   * `kimi/session/close` with `archive: true`.
+   */
+  private async forkSessionExt(
+    params: Record<string, unknown>,
+  ): Promise<Record<string, unknown>> {
+    const sessionId = params['sessionId'];
+    if (typeof sessionId !== 'string' || sessionId.length === 0) {
+      throw RequestError.invalidParams(
+        undefined,
+        'kimi/session/fork requires a string sessionId',
+      );
+    }
+    const source = this.sessions.get(sessionId);
+    if (source === undefined) {
+      throw RequestError.invalidParams(undefined, `Unknown session: ${sessionId}`);
+    }
+    if (!this.conn) {
+      throw RequestError.internalError(
+        undefined,
+        'AcpServer is missing its AgentSideConnection',
+      );
+    }
+    const fork = await this.harness.forkSession({
+      id: sessionId,
+      title: `Fork of ${sessionId}`,
+    });
+    const acpSession = new AcpSession(
+      this.conn,
+      fork,
+      this.clientCapabilities,
+      this.makeTelemetryTrack(),
+      source.currentModelId,
+      this.harness,
+      source.currentThinkingEnabled,
+    );
+    this.sessions.set(fork.id, acpSession);
+    this.scheduleAvailableCommandsUpdate(fork.id);
+    return { sessionId: fork.id };
+  }
+
+  /**
+   * `kimi/session/close` — close a session and drop it from the
+   * adapter's session table. With `archive: true` the on-disk session
+   * directory is archived too (the btw fork cleanup path); otherwise
+   * the session stays resumable.
+   */
+  private async closeSessionExt(
+    params: Record<string, unknown>,
+  ): Promise<Record<string, unknown>> {
+    const sessionId = params['sessionId'];
+    if (typeof sessionId !== 'string' || sessionId.length === 0) {
+      throw RequestError.invalidParams(
+        undefined,
+        'kimi/session/close requires a string sessionId',
+      );
+    }
+    if (!this.sessions.has(sessionId)) {
+      throw RequestError.invalidParams(undefined, `Unknown session: ${sessionId}`);
+    }
+    this.sessions.delete(sessionId);
+    if (params['archive'] === true) {
+      await this.harness.archiveSession(sessionId);
+    } else {
+      await this.harness.closeSession(sessionId);
+    }
+    return {};
   }
 
   /**

--- a/packages/acp-adapter/src/server.ts
+++ b/packages/acp-adapter/src/server.ts
@@ -902,6 +902,23 @@ export class AcpServer implements Agent {
         'kimi/session/steer requires a non-empty prompt array of content blocks',
       );
     }
+    // Element-level guard so malformed blocks fail as invalidParams here
+    // instead of surfacing as a downstream TypeError (internal error).
+    for (const block of prompt as readonly unknown[]) {
+      const candidate = block as { type?: unknown; text?: unknown } | null;
+      const valid =
+        candidate !== null &&
+        typeof candidate === 'object' &&
+        typeof candidate.type === 'string' &&
+        candidate.type.length > 0 &&
+        (candidate.type !== 'text' || typeof candidate.text === 'string');
+      if (!valid) {
+        throw RequestError.invalidParams(
+          undefined,
+          'kimi/session/steer prompt blocks must be objects with a string type (text blocks require string text)',
+        );
+      }
+    }
     return acpSession.steer(prompt as readonly ContentBlock[]);
   }
 

--- a/packages/acp-adapter/src/session.ts
+++ b/packages/acp-adapter/src/session.ts
@@ -8,6 +8,7 @@ import {
   type PromptResponse,
   type SessionModeId,
 } from '@agentclientprotocol/sdk';
+import { isRealUserInput } from '@moonshot-ai/agent-core';
 import {
   ErrorCodes,
   log,
@@ -786,6 +787,59 @@ export class AcpSession {
     return this.runTurnBody(sessionId, conn, () => this.session.prompt(parts));
   }
 
+  /**
+   * `kimi/session/steer` — inject a pending user message into the
+   * session's active turn. The kernel buffers the input and the model
+   * consumes it at the next step boundary; in-flight tool calls and
+   * subagents are not interrupted. The content pipeline (ACP blocks →
+   * prompt parts → image compression) is identical to {@link prompt}.
+   *
+   * Returns `{ steered: true }` once the input lands in the kernel's
+   * steer buffer. When no turn is active there is nothing to steer
+   * into: rather than erroring, the method returns
+   * `{ steered: false, reason: 'no_active_turn' }` so the client can
+   * fall back to a normal `session/prompt`.
+   *
+   * The no-active-turn signal is the adapter-tracked
+   * {@link currentTurnId} — the same guard `/undo` uses. It must live
+   * adapter-side because the embedded v1 kernel's `Turn.steer` never
+   * rejects for a missing turn: with no active turn it LAUNCHES a fresh
+   * one, which is exactly what this method's contract promises not to
+   * do. The `prompt.not_found` catch is forward-compat for hosts whose
+   * steer RPC rejects with that code (the v2/protocol stack's
+   * PROMPT_NOT_FOUND) instead of launching.
+   */
+  async steer(
+    blocks: readonly ContentBlock[],
+  ): Promise<{ steered: true } | { steered: false; reason: 'no_active_turn' }> {
+    if (this.currentTurnId === undefined) {
+      return { steered: false, reason: 'no_active_turn' };
+    }
+    const sessionDir = this.session.summary?.sessionDir;
+    const track = this.track;
+    const parts = await compressPromptImageParts(acpBlocksToPromptParts(blocks), {
+      originalsDir:
+        sessionDir === undefined ? undefined : sessionMediaOriginalsDir(sessionDir),
+      maxImageEdgePx: this.harness?.imageLimits?.maxEdgePx(),
+      telemetry:
+        track === undefined
+          ? undefined
+          : {
+              track: (event, properties) =>
+                track(event, properties === undefined ? undefined : { ...properties }),
+            },
+    });
+    try {
+      await this.session.steer(parts);
+    } catch (error) {
+      if (isPromptNotFoundError(error)) {
+        return { steered: false, reason: 'no_active_turn' };
+      }
+      throw error;
+    }
+    return { steered: true };
+  }
+
   private async runBuiltInCommand(
     name: AcpBuiltinSlashCommandName,
     args: string,
@@ -916,6 +970,14 @@ export class AcpSession {
    * `undoHistory` mutates the context synchronously with no active-turn
    * check in the kernel, so an undo landing mid-turn would splice the
    * history the in-flight turn is still reading.
+   *
+   * Also pre-flights availability before calling the kernel: the kernel's
+   * `ContextMemory.undo` deletes messages as it walks and only throws
+   * REQUEST_INVALID when it runs out of undoable prompts, so an
+   * over-large `count` would silently drop part of the history before
+   * failing. The pre-check mirrors the web backend's
+   * `sessionService.undo` (which calls `canUndoHistory` first) and
+   * refuses up front with the kernel's own message wording.
    */
   private async runUndoCommand(args: string): Promise<void> {
     if (this.currentTurnId !== undefined) {
@@ -934,7 +996,33 @@ export class AcpSession {
       }
       count = parsed;
     }
-    await this.session.undoHistory(count);
+    const context = await this.session.getContext();
+    const availability = checkUndoAvailability(context.history, count);
+    if (!availability.ok) {
+      await this.emitLocalCommandMessage(
+        formatUndoUnavailableMessage(
+          count,
+          availability.undoableCount,
+          availability.stoppedAtBoundary,
+        ),
+      );
+      return;
+    }
+    try {
+      await this.session.undoHistory(count);
+    } catch (error) {
+      // Race fallback: a compaction (or a concurrent undo) landing
+      // between the pre-check and the kernel call can still trip the
+      // kernel's REQUEST_INVALID guard — after it partially deleted
+      // messages. Surface the kernel's message verbatim so the user sees
+      // how much was actually undoable, rather than the generic
+      // `/undo failed:` wrapper from `runBuiltInCommand`.
+      if (error instanceof Error && error.message.startsWith('Cannot undo')) {
+        await this.emitLocalCommandMessage(error.message);
+        return;
+      }
+      throw error;
+    }
     await this.emitLocalCommandMessage(
       count === 1 ? 'Undid the last turn.' : `Undid the last ${count} turns.`,
     );
@@ -1441,6 +1529,83 @@ type CompactionOutcome =
 
 function errorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
+}
+
+/**
+ * Availability of an `/undo` of `count` turns over a context history.
+ * `ok` mirrors agent-core's `canUndoHistory` exactly (a compaction
+ * boundary means "cannot undo" even when some prompts were found);
+ * `undoableCount` / `stoppedAtBoundary` feed the refusal message.
+ */
+interface UndoAvailability {
+  readonly ok: boolean;
+  readonly undoableCount: number;
+  readonly stoppedAtBoundary: boolean;
+}
+
+/**
+ * Mirror of agent-core's `canUndoHistory`
+ * (`packages/agent-core/src/services/session/sessionService.ts:56-69`) —
+ * the same walk the web backend runs before calling `undoHistory` —
+ * extended to also report how far the walk got so the refusal can reuse
+ * the kernel's message wording. Walks the history from the tail: skips
+ * injections, stops (unsuccessfully) at a compaction summary, and counts
+ * real user inputs until `count` is reached.
+ */
+function checkUndoAvailability(
+  history: readonly ContextMessage[],
+  count: number,
+): UndoAvailability {
+  let found = 0;
+  for (let i = history.length - 1; i >= 0; i--) {
+    const message = history[i];
+    if (message === undefined) continue;
+    if (message.origin?.kind === 'injection') continue;
+    if (message.origin?.kind === 'compaction_summary') {
+      return { ok: false, undoableCount: found, stoppedAtBoundary: true };
+    }
+    if (isRealUserInput(message)) {
+      found++;
+      if (found >= count) {
+        return { ok: true, undoableCount: found, stoppedAtBoundary: false };
+      }
+    }
+  }
+  return { ok: false, undoableCount: found, stoppedAtBoundary: false };
+}
+
+/**
+ * Mirror of the kernel's private `formatUndoUnavailableMessage`
+ * (`packages/agent-core/src/agent/context/index.ts:753-764`) so the
+ * pre-check refusal reads byte-identical to the error the kernel would
+ * have thrown (after partially deleting history) without the pre-check.
+ */
+function formatUndoUnavailableMessage(
+  requestedCount: number,
+  undoableCount: number,
+  stoppedAtCompaction: boolean,
+): string {
+  const reason = stoppedAtCompaction ? ' after the last compaction' : '';
+  return `Cannot undo ${formatPromptCount(requestedCount)}; only ${formatPromptCount(undoableCount)} can be undone in the active context${reason}.`;
+
+  function formatPromptCount(count: number): string {
+    return `${String(count)} ${count === 1 ? 'prompt' : 'prompts'}`;
+  }
+}
+
+/**
+ * v1 (`@moonshot-ai/agent-core`) has no PROMPT_NOT_FOUND error code —
+ * its `Turn.steer` buffers into the active turn and never throws for a
+ * missing prompt. The literal `'prompt.not_found'` wire code comes from
+ * the v2/protocol stack; matching on the string keeps the guard correct
+ * for hosts that surface the v2 error without inventing a v1 code.
+ */
+function isPromptNotFoundError(error: unknown): boolean {
+  return (
+    error !== null &&
+    typeof error === 'object' &&
+    (error as { code?: unknown }).code === 'prompt.not_found'
+  );
 }
 
 function formatHelpReport(commands: readonly AvailableCommand[]): string {

--- a/packages/acp-adapter/src/session.ts
+++ b/packages/acp-adapter/src/session.ts
@@ -800,14 +800,24 @@ export class AcpSession {
    * `{ steered: false, reason: 'no_active_turn' }` so the client can
    * fall back to a normal `session/prompt`.
    *
-   * The no-active-turn signal is the adapter-tracked
-   * {@link currentTurnId} — the same guard `/undo` uses. It must live
-   * adapter-side because the embedded v1 kernel's `Turn.steer` never
-   * rejects for a missing turn: with no active turn it LAUNCHES a fresh
-   * one, which is exactly what this method's contract promises not to
-   * do. The `prompt.not_found` catch is forward-compat for hosts whose
-   * steer RPC rejects with that code (the v2/protocol stack's
-   * PROMPT_NOT_FOUND) instead of launching.
+   * The no-active-turn gate is best-effort, not a closed-loop
+   * guarantee. It reads the adapter-tracked {@link currentTurnId} — the
+   * same guard `/undo` uses — because the embedded v1 kernel has no
+   * idle-rejecting steer variant: with no active turn its `Turn.steer`
+   * LAUNCHES a fresh one, which is exactly what this method's contract
+   * promises not to do. The gate is re-checked after the
+   * image-compression await to shrink the race window, but the RPC hop
+   * into the kernel leaves a residual gap that cannot be closed
+   * adapter-side. The `prompt.not_found` catch only fires for hosts on
+   * the v2/protocol stack, whose steer RPC rejects with that code
+   * (PROMPT_NOT_FOUND) instead of launching.
+   *
+   * Known blind spot: `currentTurnId` tracks client-prompted turns
+   * only. Turns the kernel starts on its own — e.g. from background
+   * task or cron completion notifications — are invisible to the
+   * adapter, so steer can report `no_active_turn` while such a turn is
+   * running. Closing that gap needs a kernel-side turn-state query
+   * (follow-up).
    */
   async steer(
     blocks: readonly ContentBlock[],
@@ -829,6 +839,14 @@ export class AcpSession {
                 track(event, properties === undefined ? undefined : { ...properties }),
             },
     });
+    // Re-check after the compression await: image payloads make that
+    // I/O window milliseconds wide, and a turn ending inside it would
+    // otherwise hit the v1 kernel's launch-a-fresh-turn path while this
+    // method still reports `{ steered: true }`. The RPC hop below keeps
+    // a theoretical gap that cannot be closed adapter-side.
+    if (this.currentTurnId === undefined) {
+      return { steered: false, reason: 'no_active_turn' };
+    }
     try {
       await this.session.steer(parts);
     } catch (error) {

--- a/packages/acp-adapter/src/session.ts
+++ b/packages/acp-adapter/src/session.ts
@@ -795,6 +795,9 @@ export class AcpSession {
         case 'compact':
           await this.runCompactCommand(args);
           break;
+        case 'undo':
+          await this.runUndoCommand(args);
+          break;
         case 'status':
           await this.emitLocalCommandMessage(formatStatusReport(await this.session.getStatus()));
           break;
@@ -903,6 +906,38 @@ export class AcpSession {
     } finally {
       unsubscribe?.();
     }
+  }
+
+  /**
+   * Built-in `/undo [count]` — drop the last `count` turns from the
+   * conversation context via the SDK's `undoHistory` (the same RPC the
+   * TUI's `/undo` drives). Guarded against running turns: unlike
+   * `/compact` (which has its own blocked/cancelled lifecycle events),
+   * `undoHistory` mutates the context synchronously with no active-turn
+   * check in the kernel, so an undo landing mid-turn would splice the
+   * history the in-flight turn is still reading.
+   */
+  private async runUndoCommand(args: string): Promise<void> {
+    if (this.currentTurnId !== undefined) {
+      await this.emitLocalCommandMessage('Cannot undo while a turn is running.');
+      return;
+    }
+    const trimmed = args.trim();
+    let count = 1;
+    if (trimmed.length > 0) {
+      const parsed = Number(trimmed);
+      if (!Number.isInteger(parsed) || parsed <= 0) {
+        await this.emitLocalCommandMessage(
+          'Usage: /undo [count], where count is a positive integer.',
+        );
+        return;
+      }
+      count = parsed;
+    }
+    await this.session.undoHistory(count);
+    await this.emitLocalCommandMessage(
+      count === 1 ? 'Undid the last turn.' : `Undid the last ${count} turns.`,
+    );
   }
 
   /**

--- a/packages/acp-adapter/test/ext-methods.test.ts
+++ b/packages/acp-adapter/test/ext-methods.test.ts
@@ -376,4 +376,24 @@ describe('AcpServer kimi/session/steer', () => {
       client.extMethod('kimi/session/steer', { sessionId, prompt: [] }),
     ).rejects.toMatchObject({ code: -32602 });
   });
+
+  it('rejects malformed prompt blocks with invalidParams', async () => {
+    const { harness } = makeSteerHarness();
+    const client = wireUp(harness);
+
+    const { sessionId } = await client.newSession({ cwd: '/tmp/work', mcpServers: [] });
+
+    // null element.
+    await expect(
+      client.extMethod('kimi/session/steer', { sessionId, prompt: [null] }),
+    ).rejects.toMatchObject({ code: -32602 });
+    // text block without text.
+    await expect(
+      client.extMethod('kimi/session/steer', { sessionId, prompt: [{ type: 'text' }] }),
+    ).rejects.toMatchObject({ code: -32602 });
+    // primitive element.
+    await expect(
+      client.extMethod('kimi/session/steer', { sessionId, prompt: ['text'] }),
+    ).rejects.toMatchObject({ code: -32602 });
+  });
 });

--- a/packages/acp-adapter/test/ext-methods.test.ts
+++ b/packages/acp-adapter/test/ext-methods.test.ts
@@ -13,8 +13,9 @@ import {
   type WriteTextFileRequest,
   type WriteTextFileResponse,
 } from '@agentclientprotocol/sdk';
-import type { KimiHarness, Session } from '@moonshot-ai/kimi-code-sdk';
+import type { Event, KimiHarness, Session } from '@moonshot-ai/kimi-code-sdk';
 
+import { AcpKaos } from '../src/kaos-acp';
 import { AcpServer } from '../src/server';
 import { AUTHED_STATUS, makeModelsMap } from './_helpers/harness-stubs';
 
@@ -84,12 +85,19 @@ describe('AcpServer ext method surface', () => {
 });
 
 describe('AcpServer kimi/session/* extension methods', () => {
+  interface ForkCall {
+    id: string;
+    forkId?: string;
+    title?: string;
+    kaos?: unknown;
+    persistenceKaos?: unknown;
+  }
+
   interface ForkHarness {
     harness: KimiHarness;
-    forkCalls: Array<{ id: string; title?: string }>;
+    forkCalls: ForkCall[];
     closeCalls: string[];
     archiveCalls: string[];
-    forkSessionId: string;
   }
 
   function makeSessionStub(id: string): Session {
@@ -103,10 +111,12 @@ describe('AcpServer kimi/session/* extension methods', () => {
   }
 
   function makeForkHarness(sourceSessionId: string): ForkHarness {
-    const forkCalls: Array<{ id: string; title?: string }> = [];
+    const forkCalls: ForkCall[] = [];
     const closeCalls: string[] = [];
     const archiveCalls: string[] = [];
-    const forkSessionId = 'sess-fork-1';
+    // Fallback id for callers that do not pre-mint a forkId; the adapter
+    // always does, so the stub mirrors the kernel by preferring input.forkId.
+    const fallbackForkId = 'sess-fork-1';
     const harness = {
       auth: { status: async () => AUTHED_STATUS },
       createSession: async (options: { id?: string }) =>
@@ -116,9 +126,9 @@ describe('AcpServer kimi/session/* extension methods', () => {
         defaultModel: 'kimi-coder',
         models: makeModelsMap([{ id: 'kimi-coder', name: 'Kimi Coder' }]),
       }),
-      forkSession: async (input: { id: string; title?: string }) => {
+      forkSession: async (input: ForkCall) => {
         forkCalls.push(input);
-        return makeSessionStub(forkSessionId);
+        return makeSessionStub(input.forkId ?? fallbackForkId);
       },
       closeSession: async (id: string) => {
         closeCalls.push(id);
@@ -127,11 +137,11 @@ describe('AcpServer kimi/session/* extension methods', () => {
         archiveCalls.push(id);
       },
     } as unknown as KimiHarness;
-    return { harness, forkCalls, closeCalls, archiveCalls, forkSessionId };
+    return { harness, forkCalls, closeCalls, archiveCalls };
   }
 
   it('kimi/session/fork forks via the harness and registers a promptable ACP session', async () => {
-    const { harness, forkCalls, forkSessionId } = makeForkHarness('sess-src');
+    const { harness, forkCalls } = makeForkHarness('sess-src');
     const { agentStream, clientStream } = makeInMemoryStreamPair();
 
     let server: AcpServer | undefined;
@@ -144,10 +154,55 @@ describe('AcpServer kimi/session/* extension methods', () => {
     const { sessionId } = await client.newSession({ cwd: '/tmp/work', mcpServers: [] });
     const result = await client.extMethod('kimi/session/fork', { sessionId });
 
-    expect(result).toEqual({ sessionId: forkSessionId });
-    expect(forkCalls).toEqual([{ id: sessionId, title: `Fork of ${sessionId}` }]);
+    const forkCall = forkCalls[0];
+    expect(result).toEqual({ sessionId: forkCall?.forkId });
+    expect(forkCall).toMatchObject({ id: sessionId, title: `Fork of ${sessionId}` });
+    expect(forkCall?.forkId).toEqual(expect.any(String));
+    // Without an `initialize` fs capability the fork must NOT get a kaos
+    // pair — the kernel falls back to its process-wide LocalKaos.
+    expect(forkCall?.kaos).toBeUndefined();
+    expect(forkCall?.persistenceKaos).toBeUndefined();
     // The fork is registered as a first-class ACP session.
-    expect(server?.getSession(forkSessionId)?.id).toBe(forkSessionId);
+    expect(server?.getSession(forkCall!.forkId!)?.id).toBe(forkCall!.forkId!);
+  });
+
+  it('kimi/session/fork threads an AcpKaos pair when the client advertises fs capabilities', async () => {
+    const { harness, forkCalls } = makeForkHarness('sess-src');
+    const { agentStream, clientStream } = makeInMemoryStreamPair();
+
+    new AgentSideConnection((c) => new AcpServer(harness, c), agentStream);
+    const client = new ClientSideConnection((_a) => new StubClient(), clientStream);
+
+    await client.initialize({
+      protocolVersion: 1,
+      clientCapabilities: { fs: { readTextFile: true, writeTextFile: true } },
+    });
+    const { sessionId } = await client.newSession({ cwd: '/tmp/work', mcpServers: [] });
+    await client.extMethod('kimi/session/fork', { sessionId });
+
+    const forkCall = forkCalls[0];
+    expect(forkCall?.kaos).toBeInstanceOf(AcpKaos);
+    expect(forkCall?.persistenceKaos).toBeDefined();
+    expect(forkCall?.persistenceKaos).not.toBe(forkCall?.kaos);
+    expect(forkCall?.forkId).toEqual(expect.any(String));
+  });
+
+  it('kimi/session/fork omits the kaos pair when the client has no fs capability', async () => {
+    const { harness, forkCalls } = makeForkHarness('sess-src');
+    const { agentStream, clientStream } = makeInMemoryStreamPair();
+
+    new AgentSideConnection((c) => new AcpServer(harness, c), agentStream);
+    const client = new ClientSideConnection((_a) => new StubClient(), clientStream);
+
+    await client.initialize({
+      protocolVersion: 1,
+      clientCapabilities: { fs: { readTextFile: false, writeTextFile: false } },
+    });
+    const { sessionId } = await client.newSession({ cwd: '/tmp/work', mcpServers: [] });
+    await client.extMethod('kimi/session/fork', { sessionId });
+
+    expect(forkCalls[0]?.kaos).toBeUndefined();
+    expect(forkCalls[0]?.persistenceKaos).toBeUndefined();
   });
 
   it('kimi/session/fork rejects an unknown sessionId with invalidParams', async () => {
@@ -166,7 +221,7 @@ describe('AcpServer kimi/session/* extension methods', () => {
   });
 
   it('kimi/session/close drops the session; archive:true archives the directory', async () => {
-    const { harness, closeCalls, archiveCalls, forkSessionId } = makeForkHarness('sess-src');
+    const { harness, closeCalls, archiveCalls } = makeForkHarness('sess-src');
     const { agentStream, clientStream } = makeInMemoryStreamPair();
 
     let server: AcpServer | undefined;
@@ -177,15 +232,148 @@ describe('AcpServer kimi/session/* extension methods', () => {
     const client = new ClientSideConnection((_a) => new StubClient(), clientStream);
 
     const { sessionId } = await client.newSession({ cwd: '/tmp/work', mcpServers: [] });
-    await client.extMethod('kimi/session/fork', { sessionId });
+    const forkResult = (await client.extMethod('kimi/session/fork', { sessionId })) as {
+      sessionId: string;
+    };
+    const forkId = forkResult.sessionId;
 
-    await client.extMethod('kimi/session/close', { sessionId: forkSessionId, archive: true });
-    expect(archiveCalls).toEqual([forkSessionId]);
+    await client.extMethod('kimi/session/close', { sessionId: forkId, archive: true });
+    expect(archiveCalls).toEqual([forkId]);
     expect(closeCalls).toEqual([]);
-    expect(server?.getSession(forkSessionId)).toBeUndefined();
+    expect(server?.getSession(forkId)).toBeUndefined();
 
     await client.extMethod('kimi/session/close', { sessionId });
     expect(closeCalls).toEqual([sessionId]);
     expect(server?.getSession(sessionId)).toBeUndefined();
+  });
+});
+
+describe('AcpServer kimi/session/steer', () => {
+  interface SteerHarness {
+    harness: KimiHarness;
+    steerCalls: unknown[][];
+  }
+
+  /**
+   * Stub harness whose session can hold a turn open: `prompt()` emits
+   * `turn.started` and never `turn.ended`, so the adapter's
+   * `currentTurnId` stays set (the same busy-turn setup as the `/undo`
+   * test in session-slash.test.ts).
+   */
+  function makeSteerHarness(opts?: { steerError?: Error }): SteerHarness {
+    const steerCalls: unknown[][] = [];
+    const listeners = new Set<(event: Event) => void>();
+    const sessionId = 'sess-steer-src';
+    const session = {
+      id: sessionId,
+      prompt: async () => {
+        await Promise.resolve();
+        for (const fn of listeners) {
+          fn({ type: 'turn.started', sessionId, agentId: 'main', turnId: 1 } as Event);
+        }
+      },
+      steer: async (parts: readonly unknown[]) => {
+        if (opts?.steerError !== undefined) throw opts.steerError;
+        steerCalls.push([...parts]);
+      },
+      cancel: async () => undefined,
+      onEvent: (fn: (event: Event) => void) => {
+        listeners.add(fn);
+        return () => {
+          listeners.delete(fn);
+        };
+      },
+      listSkills: async () => [],
+    } as unknown as Session;
+    const harness = {
+      auth: { status: async () => AUTHED_STATUS },
+      createSession: async () => session,
+      getConfig: async () => ({
+        providers: {},
+        defaultModel: 'kimi-coder',
+        models: makeModelsMap([{ id: 'kimi-coder', name: 'Kimi Coder' }]),
+      }),
+    } as unknown as KimiHarness;
+    return { harness, steerCalls };
+  }
+
+  function wireUp(harness: KimiHarness): ClientSideConnection {
+    const { agentStream, clientStream } = makeInMemoryStreamPair();
+    new AgentSideConnection((c) => new AcpServer(harness, c), agentStream);
+    return new ClientSideConnection((_a) => new StubClient(), clientStream);
+  }
+
+  it('steers a pending user message into the active turn', async () => {
+    const { harness, steerCalls } = makeSteerHarness();
+    const client = wireUp(harness);
+
+    const { sessionId } = await client.newSession({ cwd: '/tmp/work', mcpServers: [] });
+    // Fire-and-forget: the stub turn never ends, so this prompt stays in
+    // flight and the adapter keeps `currentTurnId` set.
+    void client.prompt({ sessionId, prompt: [{ type: 'text', text: 'run something long' }] });
+    // Let the turn.started event reach the adapter before steering.
+    await new Promise((r) => setTimeout(r, 20));
+
+    const result = await client.extMethod('kimi/session/steer', {
+      sessionId,
+      prompt: [{ type: 'text', text: 'keep going' }],
+    });
+
+    expect(result).toEqual({ steered: true });
+    expect(steerCalls).toEqual([[{ type: 'text', text: 'keep going' }]]);
+  });
+
+  it('resolves to no_active_turn instead of erroring when no turn is running', async () => {
+    const { harness, steerCalls } = makeSteerHarness();
+    const client = wireUp(harness);
+
+    const { sessionId } = await client.newSession({ cwd: '/tmp/work', mcpServers: [] });
+    const result = await client.extMethod('kimi/session/steer', {
+      sessionId,
+      prompt: [{ type: 'text', text: 'keep going' }],
+    });
+
+    expect(result).toEqual({ steered: false, reason: 'no_active_turn' });
+    expect(steerCalls).toEqual([]);
+  });
+
+  it('maps a prompt.not_found steer rejection to no_active_turn', async () => {
+    const steerError = Object.assign(new Error('no active prompt to steer into'), {
+      code: 'prompt.not_found',
+    });
+    const { harness, steerCalls } = makeSteerHarness({ steerError });
+    const client = wireUp(harness);
+
+    const { sessionId } = await client.newSession({ cwd: '/tmp/work', mcpServers: [] });
+    void client.prompt({ sessionId, prompt: [{ type: 'text', text: 'run something long' }] });
+    await new Promise((r) => setTimeout(r, 20));
+
+    const result = await client.extMethod('kimi/session/steer', {
+      sessionId,
+      prompt: [{ type: 'text', text: 'keep going' }],
+    });
+
+    expect(result).toEqual({ steered: false, reason: 'no_active_turn' });
+    expect(steerCalls).toEqual([]);
+  });
+
+  it('rejects unknown sessions and missing/empty prompts with invalidParams', async () => {
+    const { harness } = makeSteerHarness();
+    const client = wireUp(harness);
+
+    const { sessionId } = await client.newSession({ cwd: '/tmp/work', mcpServers: [] });
+
+    await expect(
+      client.extMethod('kimi/session/steer', {
+        sessionId: 'nope',
+        prompt: [{ type: 'text', text: 'hi' }],
+      }),
+    ).rejects.toMatchObject({ code: -32602 });
+    await expect(client.extMethod('kimi/session/steer', { sessionId })).rejects.toMatchObject({
+      code: -32602,
+    });
+    await expect(
+      client.extMethod('kimi/session/steer', { sessionId, prompt: [] }),
+    ).rejects.toMatchObject({ code: -32602 });
   });
 });

--- a/packages/acp-adapter/test/ext-methods.test.ts
+++ b/packages/acp-adapter/test/ext-methods.test.ts
@@ -13,9 +13,10 @@ import {
   type WriteTextFileRequest,
   type WriteTextFileResponse,
 } from '@agentclientprotocol/sdk';
-import type { KimiHarness } from '@moonshot-ai/kimi-code-sdk';
+import type { KimiHarness, Session } from '@moonshot-ai/kimi-code-sdk';
 
 import { AcpServer } from '../src/server';
+import { AUTHED_STATUS, makeModelsMap } from './_helpers/harness-stubs';
 
 class StubClient implements Client {
   async requestPermission(_p: RequestPermissionRequest): Promise<RequestPermissionResponse> {
@@ -79,5 +80,112 @@ describe('AcpServer ext method surface', () => {
     await expect(client.extMethod('myorg.unsupported', {})).rejects.toMatchObject({
       code: -32601,
     });
+  });
+});
+
+describe('AcpServer kimi/session/* extension methods', () => {
+  interface ForkHarness {
+    harness: KimiHarness;
+    forkCalls: Array<{ id: string; title?: string }>;
+    closeCalls: string[];
+    archiveCalls: string[];
+    forkSessionId: string;
+  }
+
+  function makeSessionStub(id: string): Session {
+    return {
+      id,
+      prompt: async () => undefined,
+      cancel: async () => undefined,
+      onEvent: () => () => undefined,
+      listSkills: async () => [],
+    } as unknown as Session;
+  }
+
+  function makeForkHarness(sourceSessionId: string): ForkHarness {
+    const forkCalls: Array<{ id: string; title?: string }> = [];
+    const closeCalls: string[] = [];
+    const archiveCalls: string[] = [];
+    const forkSessionId = 'sess-fork-1';
+    const harness = {
+      auth: { status: async () => AUTHED_STATUS },
+      createSession: async (options: { id?: string }) =>
+        makeSessionStub(options.id ?? sourceSessionId),
+      getConfig: async () => ({
+        providers: {},
+        defaultModel: 'kimi-coder',
+        models: makeModelsMap([{ id: 'kimi-coder', name: 'Kimi Coder' }]),
+      }),
+      forkSession: async (input: { id: string; title?: string }) => {
+        forkCalls.push(input);
+        return makeSessionStub(forkSessionId);
+      },
+      closeSession: async (id: string) => {
+        closeCalls.push(id);
+      },
+      archiveSession: async (id: string) => {
+        archiveCalls.push(id);
+      },
+    } as unknown as KimiHarness;
+    return { harness, forkCalls, closeCalls, archiveCalls, forkSessionId };
+  }
+
+  it('kimi/session/fork forks via the harness and registers a promptable ACP session', async () => {
+    const { harness, forkCalls, forkSessionId } = makeForkHarness('sess-src');
+    const { agentStream, clientStream } = makeInMemoryStreamPair();
+
+    let server: AcpServer | undefined;
+    new AgentSideConnection((c) => {
+      server = new AcpServer(harness, c);
+      return server;
+    }, agentStream);
+    const client = new ClientSideConnection((_a) => new StubClient(), clientStream);
+
+    const { sessionId } = await client.newSession({ cwd: '/tmp/work', mcpServers: [] });
+    const result = await client.extMethod('kimi/session/fork', { sessionId });
+
+    expect(result).toEqual({ sessionId: forkSessionId });
+    expect(forkCalls).toEqual([{ id: sessionId, title: `Fork of ${sessionId}` }]);
+    // The fork is registered as a first-class ACP session.
+    expect(server?.getSession(forkSessionId)?.id).toBe(forkSessionId);
+  });
+
+  it('kimi/session/fork rejects an unknown sessionId with invalidParams', async () => {
+    const { harness } = makeForkHarness('sess-src');
+    const { agentStream, clientStream } = makeInMemoryStreamPair();
+
+    new AgentSideConnection((c) => new AcpServer(harness, c), agentStream);
+    const client = new ClientSideConnection((_a) => new StubClient(), clientStream);
+
+    await expect(
+      client.extMethod('kimi/session/fork', { sessionId: 'nope' }),
+    ).rejects.toMatchObject({ code: -32602 });
+    await expect(client.extMethod('kimi/session/fork', {})).rejects.toMatchObject({
+      code: -32602,
+    });
+  });
+
+  it('kimi/session/close drops the session; archive:true archives the directory', async () => {
+    const { harness, closeCalls, archiveCalls, forkSessionId } = makeForkHarness('sess-src');
+    const { agentStream, clientStream } = makeInMemoryStreamPair();
+
+    let server: AcpServer | undefined;
+    new AgentSideConnection((c) => {
+      server = new AcpServer(harness, c);
+      return server;
+    }, agentStream);
+    const client = new ClientSideConnection((_a) => new StubClient(), clientStream);
+
+    const { sessionId } = await client.newSession({ cwd: '/tmp/work', mcpServers: [] });
+    await client.extMethod('kimi/session/fork', { sessionId });
+
+    await client.extMethod('kimi/session/close', { sessionId: forkSessionId, archive: true });
+    expect(archiveCalls).toEqual([forkSessionId]);
+    expect(closeCalls).toEqual([]);
+    expect(server?.getSession(forkSessionId)).toBeUndefined();
+
+    await client.extMethod('kimi/session/close', { sessionId });
+    expect(closeCalls).toEqual([sessionId]);
+    expect(server?.getSession(sessionId)).toBeUndefined();
   });
 });

--- a/packages/acp-adapter/test/session-slash.test.ts
+++ b/packages/acp-adapter/test/session-slash.test.ts
@@ -14,7 +14,7 @@ import {
   type WriteTextFileRequest,
   type WriteTextFileResponse,
 } from '@agentclientprotocol/sdk';
-import type { Event, KimiHarness, Session } from '@moonshot-ai/kimi-code-sdk';
+import type { ContextMessage, Event, KimiHarness, Session } from '@moonshot-ai/kimi-code-sdk';
 
 import { AcpServer } from '../src/server';
 import { AUTHED_STATUS } from './_helpers/harness-stubs';
@@ -56,10 +56,16 @@ function makeInMemoryStreamPair(): {
  * `listSkills` returns a single Prompt skill so the AcpServer's
  * `available_commands_update` resolver also populates the per-session
  * `skillCommandMap` that {@link AcpSession.prompt} consults.
+ *
+ * `getContext` feeds the `/undo` pre-check: `opts.history` defaults to
+ * three plain user messages (all real user input — no `origin`), so
+ * `/undo` and `/undo 3` pass the pre-check unless a test overrides the
+ * history to exercise a refusal.
  */
 function makeFakeSession(
   sessionId: string,
   script: readonly Event[],
+  opts?: { history?: readonly ContextMessage[] },
 ): {
   session: Session;
   calls: {
@@ -74,6 +80,12 @@ function makeFakeSession(
     activate: [] as Array<{ name: string; args?: string | undefined }>,
     undoHistory: [] as number[],
   };
+  const history =
+    opts?.history ??
+    ([1, 2, 3].map((n) => ({
+      role: 'user',
+      content: [{ type: 'text', text: `user message ${n}` }],
+    })) as unknown as readonly ContextMessage[]);
   const emit = async (): Promise<void> => {
     await Promise.resolve();
     for (const ev of script) {
@@ -93,6 +105,7 @@ function makeFakeSession(
     undoHistory: async (count: number) => {
       calls.undoHistory.push(count);
     },
+    getContext: async () => ({ history, tokenCount: 0 }),
     cancel: async () => undefined,
     onEvent: (fn: (event: Event) => void) => {
       listeners.add(fn);
@@ -474,5 +487,88 @@ describe('AcpSession slash routing', () => {
       )
       .map((n) => (n.update as { content?: { text?: string } }).content?.text ?? '');
     expect(texts.some((t) => t.includes('Cannot undo while a turn is running.'))).toBe(true);
+  });
+
+  it('refuses `/undo N` up front when fewer than N prompts are undoable', async () => {
+    const sessionId = 'sess-slash-undo-short';
+    // Default stub history: 3 real user messages → `/undo 5` must be
+    // refused by the pre-check WITHOUT calling undoHistory (the kernel
+    // would otherwise delete 3 turns and only then throw).
+    const { session, calls } = makeFakeSession(sessionId, [endedTurn(sessionId)]);
+    const harness = {
+      auth: { status: async () => AUTHED_STATUS },
+      createSession: async () => session,
+    } as unknown as KimiHarness;
+
+    const { agentStream, clientStream } = makeInMemoryStreamPair();
+    new AgentSideConnection((c) => new AcpServer(harness, c), agentStream);
+    const collecting = new CollectingClient();
+    const client = new ClientSideConnection(() => collecting, clientStream);
+
+    await client.newSession({ cwd: '/tmp/x', mcpServers: [] });
+    await waitForAvailableCommands(collecting);
+
+    await client.prompt({ sessionId, prompt: [textBlock('/undo 5')] });
+
+    expect(calls.undoHistory).toEqual([]);
+    const texts = collecting.updates
+      .filter(
+        (n) =>
+          (n.update as { sessionUpdate?: string }).sessionUpdate === 'agent_message_chunk',
+      )
+      .map((n) => (n.update as { content?: { text?: string } }).content?.text ?? '');
+    expect(
+      texts.some(
+        (t) =>
+          t === 'Cannot undo 5 prompts; only 3 prompts can be undone in the active context.',
+      ),
+    ).toBe(true);
+  });
+
+  it('refuses `/undo N` at a compaction boundary with the kernel wording', async () => {
+    const sessionId = 'sess-slash-undo-boundary';
+    const history = [
+      { role: 'user', content: [{ type: 'text', text: 'before compaction' }] },
+      {
+        role: 'user',
+        content: [{ type: 'text', text: 'summary of compacted history' }],
+        origin: { kind: 'compaction_summary' },
+      },
+      { role: 'user', content: [{ type: 'text', text: 'recent one' }] },
+      { role: 'user', content: [{ type: 'text', text: 'recent two' }] },
+    ] as unknown as readonly ContextMessage[];
+    const { session, calls } = makeFakeSession(sessionId, [endedTurn(sessionId)], { history });
+    const harness = {
+      auth: { status: async () => AUTHED_STATUS },
+      createSession: async () => session,
+    } as unknown as KimiHarness;
+
+    const { agentStream, clientStream } = makeInMemoryStreamPair();
+    new AgentSideConnection((c) => new AcpServer(harness, c), agentStream);
+    const collecting = new CollectingClient();
+    const client = new ClientSideConnection(() => collecting, clientStream);
+
+    await client.newSession({ cwd: '/tmp/x', mcpServers: [] });
+    await waitForAvailableCommands(collecting);
+
+    // Two real user prompts sit after the compaction summary; `/undo 3`
+    // must stop at the boundary and refuse with the kernel's
+    // "after the last compaction" suffix.
+    await client.prompt({ sessionId, prompt: [textBlock('/undo 3')] });
+
+    expect(calls.undoHistory).toEqual([]);
+    const texts = collecting.updates
+      .filter(
+        (n) =>
+          (n.update as { sessionUpdate?: string }).sessionUpdate === 'agent_message_chunk',
+      )
+      .map((n) => (n.update as { content?: { text?: string } }).content?.text ?? '');
+    expect(
+      texts.some(
+        (t) =>
+          t ===
+          'Cannot undo 3 prompts; only 2 prompts can be undone in the active context after the last compaction.',
+      ),
+    ).toBe(true);
   });
 });

--- a/packages/acp-adapter/test/session-slash.test.ts
+++ b/packages/acp-adapter/test/session-slash.test.ts
@@ -65,12 +65,14 @@ function makeFakeSession(
   calls: {
     prompt: number;
     activate: Array<{ name: string; args?: string | undefined }>;
+    undoHistory: number[];
   };
 } {
   const listeners = new Set<(event: Event) => void>();
   const calls = {
     prompt: 0,
     activate: [] as Array<{ name: string; args?: string | undefined }>,
+    undoHistory: [] as number[],
   };
   const emit = async (): Promise<void> => {
     await Promise.resolve();
@@ -87,6 +89,9 @@ function makeFakeSession(
     activateSkill: async (name: string, args?: string | undefined) => {
       calls.activate.push({ name, args });
       await emit();
+    },
+    undoHistory: async (count: number) => {
+      calls.undoHistory.push(count);
     },
     cancel: async () => undefined,
     onEvent: (fn: (event: Event) => void) => {
@@ -370,5 +375,104 @@ describe('AcpSession slash routing', () => {
     expect(text).toContain('Session status:');
     expect(text).toContain('Model: mock-model');
     expect(text).toContain('Context: 1,234 / 200,000 (0.6%)');
+  });
+
+  it('routes built-in `/undo [count]` to Session.undoHistory', async () => {
+    const sessionId = 'sess-slash-undo';
+    const { session, calls } = makeFakeSession(sessionId, [endedTurn(sessionId)]);
+    const harness = {
+      auth: { status: async () => AUTHED_STATUS },
+      createSession: async () => session,
+    } as unknown as KimiHarness;
+
+    const { agentStream, clientStream } = makeInMemoryStreamPair();
+    new AgentSideConnection((c) => new AcpServer(harness, c), agentStream);
+    const collecting = new CollectingClient();
+    const client = new ClientSideConnection(() => collecting, clientStream);
+
+    await client.newSession({ cwd: '/tmp/x', mcpServers: [] });
+    await waitForAvailableCommands(collecting);
+
+    await client.prompt({ sessionId, prompt: [textBlock('/undo')] });
+    await client.prompt({ sessionId, prompt: [textBlock('/undo 3')] });
+
+    expect(calls.prompt).toBe(0);
+    expect(calls.undoHistory).toEqual([1, 3]);
+    const texts = collecting.updates
+      .filter(
+        (n) =>
+          (n.update as { sessionUpdate?: string }).sessionUpdate === 'agent_message_chunk',
+      )
+      .map((n) => (n.update as { content?: { text?: string } }).content?.text ?? '');
+    expect(texts.some((t) => t.includes('Undid the last turn.'))).toBe(true);
+    expect(texts.some((t) => t.includes('Undid the last 3 turns.'))).toBe(true);
+  });
+
+  it('rejects a malformed `/undo` count with a usage message', async () => {
+    const sessionId = 'sess-slash-undo-usage';
+    const { session, calls } = makeFakeSession(sessionId, [endedTurn(sessionId)]);
+    const harness = {
+      auth: { status: async () => AUTHED_STATUS },
+      createSession: async () => session,
+    } as unknown as KimiHarness;
+
+    const { agentStream, clientStream } = makeInMemoryStreamPair();
+    new AgentSideConnection((c) => new AcpServer(harness, c), agentStream);
+    const collecting = new CollectingClient();
+    const client = new ClientSideConnection(() => collecting, clientStream);
+
+    await client.newSession({ cwd: '/tmp/x', mcpServers: [] });
+    await waitForAvailableCommands(collecting);
+
+    await client.prompt({ sessionId, prompt: [textBlock('/undo zero')] });
+
+    expect(calls.undoHistory).toEqual([]);
+    const reply = collecting.updates.find(
+      (n) =>
+        (n.update as { sessionUpdate?: string }).sessionUpdate === 'agent_message_chunk',
+    );
+    const text = (reply!.update as { content?: { text?: string } }).content?.text ?? '';
+    expect(text).toContain('Usage: /undo [count]');
+  });
+
+  it('refuses `/undo` while a turn is running', async () => {
+    const sessionId = 'sess-slash-undo-busy';
+    // Script emits turn.started but never turn.ended — the first prompt
+    // stays in flight and the adapter keeps `currentTurnId` set.
+    const started = {
+      type: 'turn.started',
+      sessionId,
+      agentId: 'main',
+      turnId: 1,
+    } as Event;
+    const { session, calls } = makeFakeSession(sessionId, [started]);
+    const harness = {
+      auth: { status: async () => AUTHED_STATUS },
+      createSession: async () => session,
+    } as unknown as KimiHarness;
+
+    const { agentStream, clientStream } = makeInMemoryStreamPair();
+    new AgentSideConnection((c) => new AcpServer(harness, c), agentStream);
+    const collecting = new CollectingClient();
+    const client = new ClientSideConnection(() => collecting, clientStream);
+
+    await client.newSession({ cwd: '/tmp/x', mcpServers: [] });
+    await waitForAvailableCommands(collecting);
+
+    // Fire-and-forget: the turn never ends, so this prompt never resolves.
+    void client.prompt({ sessionId, prompt: [textBlock('run something long')] });
+    // Let the turn.started event reach the adapter before /undo fires.
+    await new Promise((r) => setTimeout(r, 20));
+
+    await client.prompt({ sessionId, prompt: [textBlock('/undo')] });
+
+    expect(calls.undoHistory).toEqual([]);
+    const texts = collecting.updates
+      .filter(
+        (n) =>
+          (n.update as { sessionUpdate?: string }).sessionUpdate === 'agent_message_chunk',
+      )
+      .map((n) => (n.update as { content?: { text?: string } }).content?.text ?? '');
+    expect(texts.some((t) => t.includes('Cannot undo while a turn is running.'))).toBe(true);
   });
 });

--- a/packages/acp-adapter/test/session-slash.test.ts
+++ b/packages/acp-adapter/test/session-slash.test.ts
@@ -60,12 +60,13 @@ function makeInMemoryStreamPair(): {
  * `getContext` feeds the `/undo` pre-check: `opts.history` defaults to
  * three plain user messages (all real user input — no `origin`), so
  * `/undo` and `/undo 3` pass the pre-check unless a test overrides the
- * history to exercise a refusal.
+ * history to exercise a refusal. `opts.undoError` makes `undoHistory`
+ * reject after recording the call, for the post-precheck race fallback.
  */
 function makeFakeSession(
   sessionId: string,
   script: readonly Event[],
-  opts?: { history?: readonly ContextMessage[] },
+  opts?: { history?: readonly ContextMessage[]; undoError?: Error },
 ): {
   session: Session;
   calls: {
@@ -104,6 +105,7 @@ function makeFakeSession(
     },
     undoHistory: async (count: number) => {
       calls.undoHistory.push(count);
+      if (opts?.undoError !== undefined) throw opts.undoError;
     },
     getContext: async () => ({ history, tokenCount: 0 }),
     cancel: async () => undefined,
@@ -568,6 +570,177 @@ describe('AcpSession slash routing', () => {
         (t) =>
           t ===
           'Cannot undo 3 prompts; only 2 prompts can be undone in the active context after the last compaction.',
+      ),
+    ).toBe(true);
+  });
+
+  it('surfaces the kernel "Cannot undo" race error verbatim, without the /undo failed wrapper', async () => {
+    const sessionId = 'sess-slash-undo-race';
+    // Pre-check passes (3 undoable prompts), but the kernel throws its
+    // REQUEST_INVALID guard anyway — a compaction (or concurrent undo)
+    // landed between the pre-check and the kernel call. The adapter must
+    // relay the kernel's wording so the user sees what was actually
+    // undoable, not the generic `/undo failed:` wrapper.
+    const { session, calls } = makeFakeSession(sessionId, [endedTurn(sessionId)], {
+      undoError: new Error(
+        'Cannot undo 3 prompts; only 2 prompts can be undone in the active context.',
+      ),
+    });
+    const harness = {
+      auth: { status: async () => AUTHED_STATUS },
+      createSession: async () => session,
+    } as unknown as KimiHarness;
+
+    const { agentStream, clientStream } = makeInMemoryStreamPair();
+    new AgentSideConnection((c) => new AcpServer(harness, c), agentStream);
+    const collecting = new CollectingClient();
+    const client = new ClientSideConnection(() => collecting, clientStream);
+
+    await client.newSession({ cwd: '/tmp/x', mcpServers: [] });
+    await waitForAvailableCommands(collecting);
+
+    await client.prompt({ sessionId, prompt: [textBlock('/undo 2')] });
+
+    expect(calls.undoHistory).toEqual([2]);
+    const texts = collecting.updates
+      .filter(
+        (n) =>
+          (n.update as { sessionUpdate?: string }).sessionUpdate === 'agent_message_chunk',
+      )
+      .map((n) => (n.update as { content?: { text?: string } }).content?.text ?? '');
+    expect(
+      texts.some(
+        (t) => t === 'Cannot undo 3 prompts; only 2 prompts can be undone in the active context.',
+      ),
+    ).toBe(true);
+    expect(texts.some((t) => t.startsWith('/undo failed:'))).toBe(false);
+    expect(texts.some((t) => t.includes('Undid the last'))).toBe(false);
+  });
+
+  it('wraps non-"Cannot undo" undoHistory failures with /undo failed:', async () => {
+    const sessionId = 'sess-slash-undo-boom';
+    const { session, calls } = makeFakeSession(sessionId, [endedTurn(sessionId)], {
+      undoError: new Error('boom'),
+    });
+    const harness = {
+      auth: { status: async () => AUTHED_STATUS },
+      createSession: async () => session,
+    } as unknown as KimiHarness;
+
+    const { agentStream, clientStream } = makeInMemoryStreamPair();
+    new AgentSideConnection((c) => new AcpServer(harness, c), agentStream);
+    const collecting = new CollectingClient();
+    const client = new ClientSideConnection(() => collecting, clientStream);
+
+    await client.newSession({ cwd: '/tmp/x', mcpServers: [] });
+    await waitForAvailableCommands(collecting);
+
+    await client.prompt({ sessionId, prompt: [textBlock('/undo 2')] });
+
+    expect(calls.undoHistory).toEqual([2]);
+    const texts = collecting.updates
+      .filter(
+        (n) =>
+          (n.update as { sessionUpdate?: string }).sessionUpdate === 'agent_message_chunk',
+      )
+      .map((n) => (n.update as { content?: { text?: string } }).content?.text ?? '');
+    expect(texts.some((t) => t === '/undo failed: boom')).toBe(true);
+  });
+
+  it('counts only real prompts for `/undo N`: injections are skipped, not counted or blocking', async () => {
+    const sessionId = 'sess-slash-undo-injection';
+    const userMessage = (text: string): ContextMessage =>
+      ({
+        role: 'user',
+        content: [{ type: 'text', text }],
+      }) as unknown as ContextMessage;
+    const injection = (role: 'user' | 'assistant', text: string): ContextMessage =>
+      ({
+        role,
+        content: [{ type: 'text', text }],
+        origin: { kind: 'injection' },
+      }) as unknown as ContextMessage;
+    // Three real prompts interleaved with injections: `/undo 3` must
+    // pass the pre-check — injections neither count towards N nor stop
+    // the walk.
+    const history = [
+      userMessage('user message 1'),
+      injection('user', 'injected reminder'),
+      userMessage('user message 2'),
+      injection('assistant', 'injected notice'),
+      userMessage('user message 3'),
+    ] as unknown as readonly ContextMessage[];
+    const { session, calls } = makeFakeSession(sessionId, [endedTurn(sessionId)], { history });
+    const harness = {
+      auth: { status: async () => AUTHED_STATUS },
+      createSession: async () => session,
+    } as unknown as KimiHarness;
+
+    const { agentStream, clientStream } = makeInMemoryStreamPair();
+    new AgentSideConnection((c) => new AcpServer(harness, c), agentStream);
+    const collecting = new CollectingClient();
+    const client = new ClientSideConnection(() => collecting, clientStream);
+
+    await client.newSession({ cwd: '/tmp/x', mcpServers: [] });
+    await waitForAvailableCommands(collecting);
+
+    await client.prompt({ sessionId, prompt: [textBlock('/undo 3')] });
+
+    expect(calls.undoHistory).toEqual([3]);
+    const texts = collecting.updates
+      .filter(
+        (n) =>
+          (n.update as { sessionUpdate?: string }).sessionUpdate === 'agent_message_chunk',
+      )
+      .map((n) => (n.update as { content?: { text?: string } }).content?.text ?? '');
+    expect(texts.some((t) => t.includes('Undid the last 3 turns.'))).toBe(true);
+  });
+
+  it('refuses `/undo N` against an injection-only tail with the real-prompt count', async () => {
+    const sessionId = 'sess-slash-undo-injection-short';
+    // Two real prompts plus injections: `/undo 3` must be refused with
+    // the count of real prompts (2), injections contributing nothing.
+    const history = [
+      { role: 'user', content: [{ type: 'text', text: 'user message 1' }] },
+      {
+        role: 'user',
+        content: [{ type: 'text', text: 'injected reminder' }],
+        origin: { kind: 'injection' },
+      },
+      { role: 'user', content: [{ type: 'text', text: 'user message 2' }] },
+      {
+        role: 'assistant',
+        content: [{ type: 'text', text: 'injected notice' }],
+        origin: { kind: 'injection' },
+      },
+    ] as unknown as readonly ContextMessage[];
+    const { session, calls } = makeFakeSession(sessionId, [endedTurn(sessionId)], { history });
+    const harness = {
+      auth: { status: async () => AUTHED_STATUS },
+      createSession: async () => session,
+    } as unknown as KimiHarness;
+
+    const { agentStream, clientStream } = makeInMemoryStreamPair();
+    new AgentSideConnection((c) => new AcpServer(harness, c), agentStream);
+    const collecting = new CollectingClient();
+    const client = new ClientSideConnection(() => collecting, clientStream);
+
+    await client.newSession({ cwd: '/tmp/x', mcpServers: [] });
+    await waitForAvailableCommands(collecting);
+
+    await client.prompt({ sessionId, prompt: [textBlock('/undo 3')] });
+
+    expect(calls.undoHistory).toEqual([]);
+    const texts = collecting.updates
+      .filter(
+        (n) =>
+          (n.update as { sessionUpdate?: string }).sessionUpdate === 'agent_message_chunk',
+      )
+      .map((n) => (n.update as { content?: { text?: string } }).content?.text ?? '');
+    expect(
+      texts.some(
+        (t) =>
+          t === 'Cannot undo 3 prompts; only 2 prompts can be undone in the active context.',
       ),
     ).toBe(true);
   });

--- a/packages/acp-adapter/test/slash.test.ts
+++ b/packages/acp-adapter/test/slash.test.ts
@@ -94,6 +94,11 @@ describe('slash', () => {
         args: 'summarize aggressively',
       });
       expect(detectSlashIntent('/status', map)).toEqual({ kind: 'builtin', name: 'status', args: '' });
+      expect(detectSlashIntent('/undo 3', map)).toEqual({
+        kind: 'builtin',
+        name: 'undo',
+        args: '3',
+      });
     });
 
     it('falls back to passthrough for non-slash text', () => {

--- a/packages/agent-core/src/rpc/core-impl.ts
+++ b/packages/agent-core/src/rpc/core-impl.ts
@@ -569,6 +569,13 @@ export class KimiCore implements PromisableMethods<CoreAPI> {
   }
 
   async forkSession(input: ForkSessionPayload): Promise<ResumeSessionResult> {
+    return this.forkSessionWithOverrides(input, {});
+  }
+
+  async forkSessionWithOverrides(
+    input: ForkSessionPayload,
+    overrides: { kaos?: Kaos; persistenceKaos?: Kaos },
+  ): Promise<ResumeSessionResult> {
     const source = await this.sessionStore.get(input.sessionId);
     const active = this.sessions.get(source.id);
     if (active?.hasActiveTurn === true) {
@@ -591,7 +598,10 @@ export class KimiCore implements PromisableMethods<CoreAPI> {
       metadata: input.metadata,
       turnIndex: input.turnIndex,
     });
-    return this.resumeSession({ sessionId: id });
+    // The fork resumes through the override-aware path so an ACP-style
+    // caller's kaos pair (reverse-RPC bridge + local persistence) reaches
+    // the forked session exactly as it would in createSession/resumeSession.
+    return this.resumeSessionWithOverrides({ sessionId: id }, overrides);
   }
 
   async listSessions(input: ListSessionsPayload = {}): Promise<readonly SessionSummary[]> {

--- a/packages/agent-core/test/harness/runtime.test.ts
+++ b/packages/agent-core/test/harness/runtime.test.ts
@@ -267,6 +267,87 @@ micro_compaction = false
     expect(session?.getAdditionalDirs()).toContain(normalize(sharedDir));
   });
 
+  // Sibling of the createSession regression above, for the fork path:
+  // `forkSessionWithOverrides` must thread the kaos pair into the fork's
+  // resume — the ACP adapter's `kimi/session/fork` relies on it,
+  // otherwise the fork silently falls back to the process-wide LocalKaos
+  // and stops routing file I/O to the client.
+  it('threads kaos overrides through forkSessionWithOverrides into the forked session', async () => {
+    tmp = await mkdtemp(join(tmpdir(), 'kimi-core-runtime-'));
+    const homeDir = join(tmp, 'home');
+    const workDir = join(tmp, 'work');
+    const sharedDir = join(tmp, 'shared');
+    await mkdir(homeDir, { recursive: true });
+    await mkdir(join(workDir, '.git'), { recursive: true });
+    await mkdir(join(workDir, '.kimi-code'), { recursive: true });
+    await mkdir(sharedDir, { recursive: true });
+    await writeFile(
+      join(workDir, '.kimi-code', 'local.toml'),
+      `[workspace]\nadditional_dir = ["../shared"]\n`,
+    );
+    await writeFile(join(homeDir, 'config.toml'), baseModelConfig());
+
+    const [coreRpc, sdkRpc] = createRPC<CoreAPI, SDKAPI>();
+    const core = new KimiCore(coreRpc, { homeDir });
+    await sdkRpc({
+      emitEvent: vi.fn(),
+      requestApproval: vi.fn(async (): Promise<ApprovalResponse> => ({ decision: 'rejected' })),
+      requestQuestion: vi.fn(async () => null),
+      toolCall: vi.fn(async () => ({ output: '' })),
+    });
+
+    const source = await core.createSessionWithOverrides(
+      { id: 'ses_runtime_fork_kaos_source', workDir, model: 'default-mock' },
+      { kaos: testKaos, persistenceKaos: testKaos },
+    );
+
+    // Tool-kaos double for the fork: rejects local.toml reads (so a
+    // regression routing the workspace config through the tool kaos
+    // fails loudly) and records withCwd calls (so the override reaching
+    // the forked Session ctor is directly observable).
+    const withCwdCalls: string[] = [];
+    const toolKaos = new Proxy(testKaos, {
+      get(target, prop, receiver) {
+        if (prop === 'readText') {
+          return (
+            path: string,
+            options?: { encoding?: BufferEncoding; errors?: 'strict' | 'replace' | 'ignore' },
+          ) => {
+            if (path.endsWith('local.toml')) {
+              return Promise.reject(
+                new Error(`fork tool kaos must not read ${path} (issue #988)`),
+              );
+            }
+            return target.readText(path, options);
+          };
+        }
+        if (prop === 'withCwd') {
+          return (cwd: string) => {
+            withCwdCalls.push(cwd);
+            return target.withCwd(cwd);
+          };
+        }
+        const value = Reflect.get(target, prop, receiver);
+        return typeof value === 'function'
+          ? (value as (...args: unknown[]) => unknown).bind(target)
+          : value;
+      },
+    });
+
+    const forked = await core.forkSessionWithOverrides(
+      { sessionId: source.id, id: 'ses_runtime_fork_kaos_child' },
+      { kaos: toolKaos, persistenceKaos: testKaos },
+    );
+
+    const forkSession = core.sessions.get(forked.id);
+    expect(forkSession).toBeDefined();
+    // local.toml was read through the persistence kaos (a tool-kaos read
+    // would have rejected), so the workspace additional dir landed.
+    expect(forkSession?.getAdditionalDirs()).toContain(normalize(sharedDir));
+    // The tool kaos override reached the forked Session ctor.
+    expect(withCwdCalls.length).toBeGreaterThan(0);
+  });
+
   it('uses the shared OAuth resolver for Moonshot service tokens', async () => {
     tmp = await mkdtemp(join(tmpdir(), 'kimi-core-runtime-'));
     const homeDir = join(tmp, 'home');

--- a/packages/node-sdk/src/kimi-harness.ts
+++ b/packages/node-sdk/src/kimi-harness.ts
@@ -230,6 +230,18 @@ export class KimiHarness {
     await this.rpc.deleteSession({ sessionId });
   }
 
+  /**
+   * Close (if active) and archive the on-disk session directory so it
+   * disappears from the session list. Used by the ACP adapter to clean
+   * up ephemeral fork sessions (btw) — `closeSession` alone would leave
+   * the fork dir on disk forever.
+   */
+  async archiveSession(id: string): Promise<void> {
+    const normalized = normalizeSessionId(id);
+    await this.activeSessions.get(normalized)?.close();
+    await this.rpc.archiveSession({ sessionId: normalized });
+  }
+
   async renameSession(input: RenameSessionInput): Promise<void> {
     await this.rpc.renameSession(input);
     this.activeSessions.get(input.id)?.emitMetaUpdated({ title: input.title });

--- a/packages/node-sdk/src/kimi-harness.ts
+++ b/packages/node-sdk/src/kimi-harness.ts
@@ -194,13 +194,22 @@ export class KimiHarness {
   }
 
   async forkSession(input: ForkSessionInput): Promise<Session> {
-    const summary = await this.rpc.forkSession({
-      id: normalizeSessionId(input.id),
-      forkId: input.forkId,
-      title: input.title,
-      metadata: input.metadata,
-      turnIndex: input.turnIndex,
-    });
+    const { kaos, persistenceKaos, ...forkInput } = input;
+    const normalizedInput = {
+      id: normalizeSessionId(forkInput.id),
+      forkId: forkInput.forkId,
+      title: forkInput.title,
+      metadata: forkInput.metadata,
+      turnIndex: forkInput.turnIndex,
+    };
+    const summary =
+      kaos === undefined && persistenceKaos === undefined
+        ? await this.rpc.forkSession(normalizedInput)
+        : await this.rpc.forkSessionWithKaos(
+            normalizedInput,
+            kaos ?? persistenceKaos as Kaos,
+            persistenceKaos,
+          );
     const session = new Session({
       id: summary.id,
       workDir: summary.workDir,

--- a/packages/node-sdk/src/rpc.ts
+++ b/packages/node-sdk/src/rpc.ts
@@ -204,6 +204,11 @@ export abstract class SDKRpcClientBase {
     return rpc.deleteSession({ sessionId: input.sessionId });
   }
 
+  async archiveSession(input: SessionIdRpcInput): Promise<void> {
+    const rpc = await this.getRpc();
+    return rpc.archiveSession({ sessionId: input.sessionId });
+  }
+
   async listSessions(input: ListSessionsOptions = {}): Promise<readonly SessionSummary[]> {
     const rpc = await this.getRpc();
     return rpc.listSessions(input);

--- a/packages/node-sdk/src/rpc.ts
+++ b/packages/node-sdk/src/rpc.ts
@@ -194,6 +194,16 @@ export abstract class SDKRpcClientBase {
     });
   }
 
+  async forkSessionWithKaos(
+    input: ForkSessionInput,
+    kaos: Kaos,
+    persistenceKaos?: Kaos,
+  ): Promise<SessionSummary> {
+    void kaos;
+    void persistenceKaos;
+    return this.forkSession(input);
+  }
+
   async closeSession(input: SessionIdRpcInput): Promise<void> {
     const rpc = await this.getRpc();
     return rpc.closeSession({ sessionId: input.sessionId });

--- a/packages/node-sdk/src/sdk-rpc-client.ts
+++ b/packages/node-sdk/src/sdk-rpc-client.ts
@@ -21,6 +21,7 @@ import { KimiHarness } from '#/kimi-harness';
 import { ClientAPI, SDKRpcClientBase } from '#/rpc';
 import type {
   CreateSessionOptions,
+  ForkSessionInput,
   KimiHarnessOptions,
   KimiHostIdentity,
   OAuthRefreshOutcome,
@@ -122,6 +123,23 @@ export class SDKRpcClient extends SDKRpcClientBase {
   ): Promise<ResumedSessionSummary> {
     return this.core.resumeSessionWithOverrides(
       { ...input, sessionId: input.id },
+      { kaos, persistenceKaos },
+    );
+  }
+
+  override async forkSessionWithKaos(
+    input: ForkSessionInput,
+    kaos: Kaos,
+    persistenceKaos?: Kaos,
+  ): Promise<SessionSummary> {
+    return this.core.forkSessionWithOverrides(
+      {
+        sessionId: input.id,
+        id: input.forkId,
+        title: input.title,
+        metadata: input.metadata,
+        turnIndex: input.turnIndex,
+      },
       { kaos, persistenceKaos },
     );
   }

--- a/packages/node-sdk/src/types.ts
+++ b/packages/node-sdk/src/types.ts
@@ -159,6 +159,8 @@ export interface ForkSessionInput {
    * preserve the existing full-session fork behavior.
    */
   readonly turnIndex?: number;
+  readonly kaos?: Kaos | undefined;
+  readonly persistenceKaos?: Kaos | undefined;
 }
 
 export interface ExportSessionInput {

--- a/packages/node-sdk/test/create-session-transport.test.ts
+++ b/packages/node-sdk/test/create-session-transport.test.ts
@@ -6,7 +6,7 @@ import { join } from 'node:path';
 import type { Kaos } from '@moonshot-ai/kaos';
 import { createKimiHarness, KimiHarness } from '#/index';
 import type { KimiError } from '#/index';
-import type { ResumeSessionInput, ResumedSessionSummary } from '#/types';
+import type { ForkSessionInput, ResumeSessionInput, ResumedSessionSummary } from '#/types';
 import { SDKRpcClientBase } from '#/rpc';
 import { afterEach, describe, expect, it } from 'vitest';
 
@@ -53,6 +53,7 @@ max_context_size = 1000
 
 class StubRpc extends SDKRpcClientBase {
   resumeCalls: Array<{ input: ResumeSessionInput; kaos: Kaos; persistenceKaos?: Kaos }> = [];
+  forkCalls: Array<{ input: ForkSessionInput; kaos?: Kaos; persistenceKaos?: Kaos }> = [];
 
   protected async getRpc(): Promise<never> {
     throw new Error('not used');
@@ -85,6 +86,28 @@ class StubRpc extends SDKRpcClientBase {
         custom: {},
       },
       agents: {},
+    };
+  }
+
+  override async forkSession(input: ForkSessionInput) {
+    this.forkCalls.push({ input });
+    return {
+      id: input.forkId ?? 'ses_fork_stub',
+      workDir: '/tmp/work',
+      sessionDir: '/tmp/session',
+      createdAt: 1,
+      updatedAt: 1,
+    };
+  }
+
+  override async forkSessionWithKaos(input: ForkSessionInput, kaos: Kaos, persistenceKaos?: Kaos) {
+    this.forkCalls.push({ input, kaos, persistenceKaos });
+    return {
+      id: input.forkId ?? 'ses_fork_stub',
+      workDir: '/tmp/work',
+      sessionDir: '/tmp/session',
+      createdAt: 1,
+      updatedAt: 1,
     };
   }
 }
@@ -771,6 +794,39 @@ effort = "medium"
       kaos,
       persistenceKaos: undefined,
     });
+  });
+
+  it('routes forkSession kaos overrides through forkSessionWithKaos only when set', async () => {
+    const records: TelemetryRecord[] = [];
+    const rpc = new StubRpc();
+    const harness = new KimiHarness(rpc, {
+      homeDir: '/tmp/home',
+      configPath: '/tmp/config.toml',
+      auth: { status: async () => ({ providers: [] }) } as never,
+      telemetry: recordingTelemetry(records),
+      ensureConfigFile: async () => undefined,
+      onClose: () => undefined,
+    });
+
+    const kaos = {} as Kaos;
+    const persistenceKaos = {} as Kaos;
+
+    await harness.forkSession({ id: 'ses_src', forkId: 'ses_fork_with_kaos', kaos, persistenceKaos });
+    expect(rpc.forkCalls).toHaveLength(1);
+    expect(rpc.forkCalls[0]).toMatchObject({
+      input: { id: 'ses_src', forkId: 'ses_fork_with_kaos' },
+      kaos,
+      persistenceKaos,
+    });
+
+    // Without kaos fields the call stays on the plain forkSession path.
+    await harness.forkSession({ id: 'ses_src', forkId: 'ses_fork_plain' });
+    expect(rpc.forkCalls).toHaveLength(2);
+    expect(rpc.forkCalls[1]).toMatchObject({
+      input: { id: 'ses_src', forkId: 'ses_fork_plain' },
+    });
+    expect(rpc.forkCalls[1]?.kaos).toBeUndefined();
+    expect(rpc.forkCalls[1]?.persistenceKaos).toBeUndefined();
   });
 });
 

--- a/packages/node-sdk/test/session-cancel.test.ts
+++ b/packages/node-sdk/test/session-cancel.test.ts
@@ -1,6 +1,7 @@
-import { writeFile } from 'node:fs/promises';
-import { join } from 'node:path';
+import { mkdir, writeFile } from 'node:fs/promises';
+import { dirname, join } from 'node:path';
 
+import { LocalKaos, type Environment } from '@moonshot-ai/kaos';
 import type * as KosongModule from '@moonshot-ai/kosong';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
@@ -151,6 +152,38 @@ describe('KimiHarness.forkSession', () => {
       await harness.close();
     }
   });
+
+  it('forks through forkSessionWithKaos when kaos overrides are supplied', async () => {
+    const homeDir = await makeTempDir(tempDirs, 'kimi-sdk-fork-kaos-home-');
+    const workDir = await makeTempDir(tempDirs, 'kimi-sdk-fork-kaos-work-');
+    await writeFakeModelConfig(homeDir);
+    const harness = createKimiHarness({ homeDir, identity: TEST_IDENTITY });
+
+    try {
+      const source = await harness.createSession({ id: 'ses_fork_kaos_source', workDir });
+      await source.setPlanMode(true);
+      const sourcePlan = await source.getPlan();
+      if (sourcePlan === null) throw new Error('expected source plan');
+      await mkdir(dirname(sourcePlan.path), { recursive: true });
+      await writeFile(sourcePlan.path, 'source plan', 'utf-8');
+
+      const fork = await harness.forkSession({
+        id: source.id,
+        forkId: 'ses_fork_kaos_child',
+        kaos: testLocalKaos(),
+        persistenceKaos: testLocalKaos(),
+      });
+
+      expect(fork.id).toBe('ses_fork_kaos_child');
+      // The source's plan file is copied into the fork's own session
+      // dir through the supplied kaos pair — not aliased to the source.
+      const forkPlan = await fork.getPlan();
+      expect(forkPlan).toMatchObject({ content: 'source plan' });
+      expect(forkPlan?.path).not.toBe(sourcePlan.path);
+    } finally {
+      await harness.close();
+    }
+  });
 });
 
 async function writeFakeModelConfig(homeDir: string): Promise<void> {
@@ -171,6 +204,24 @@ max_context_size = 1000
 `,
     'utf-8',
   );
+}
+
+// `LocalKaos`'s constructor is `private` at the TS level only — build a
+// fresh instance around a stub `osEnv` (the same bypass as agent-core's
+// `test/fixtures/test-kaos.ts`) so the test stays hermetic: no host
+// login-shell or environment probing.
+const TEST_OS_ENV: Environment = {
+  osKind: 'Linux',
+  osArch: 'x86_64',
+  osVersion: 'test',
+  shellName: 'bash',
+  shellPath: '/bin/bash',
+};
+
+type LocalKaosCtor = new (osEnv: Environment) => LocalKaos;
+
+function testLocalKaos(): LocalKaos {
+  return new (LocalKaos as unknown as LocalKaosCtor)(TEST_OS_ENV);
 }
 
 function waitForAbort(signal: AbortSignal | undefined): Promise<void> {


### PR DESCRIPTION
## Related Issue

Resolve #1685

## Problem

See linked issue. In short: ACP clients (and hosts embedding `kimi acp`) cannot undo history, cannot create an ephemeral fork for btw-style side conversations, and cannot steer a pending user message into a running turn — even though the SDK/kernel already support all three (`undoHistory`, `forkSession`, `steer`).

## What changed

**`/undo [count]` built-in slash command** (`acp-adapter`)

- Advertised like the other built-ins via `available_commands_update`; intercepted in `AcpSession.prompt` through the existing slash-intent routing.
- Drives `Session.undoHistory(count)` — the same RPC the TUI's `/undo` uses. Default count 1; malformed counts get a usage message.
- Refused while a turn is running: the kernel's `context.undo` has no active-turn guard, so the adapter checks its own `currentTurnId` before splicing history out from under an in-flight turn.
- Availability is pre-checked against the live context (`getContext` + a `canUndoHistory` walk mirroring the web backend) and refused up front with the kernel's own message wording — the kernel's `ContextMemory.undo` deletes as it walks and only throws `REQUEST_INVALID` when it runs out of undoable prompts, so an over-large count would otherwise partially delete history before failing. A race fallback between pre-check and kernel call surfaces the kernel message verbatim.

**`kimi/session/fork` extension method** (`{ sessionId } -> { sessionId }`)

- Forks via `KimiHarness.forkSession` and registers the fork as a first-class ACP session, so clients drive it with the normal `session/prompt` streaming/tool surface — no new prompt path.
- Inherits the source ACP session's adapter-side model/thinking state; the kernel-level fork copies context/history and keeps its `SESSION_FORK_ACTIVE_TURN` rejection.
- Routes file I/O through the same `AcpKaos`/persistence pair as `session/new` when the client advertises `fs.readTextFile`/`fs.writeTextFile`: the kernel gains `forkSessionWithOverrides` and the SDK a matching `ForkSessionInput.kaos` + `forkSessionWithKaos` passthrough, so forked sessions keep talking to the client's filesystem instead of silently falling back to the kernel's `LocalKaos`.

**`kimi/session/close` extension method** (`{ sessionId, archive? }`)

- Closes and drops a session from the adapter table. With `archive: true` it also archives the on-disk directory — the cleanup path for btw forks, which would otherwise accumulate forever.

**`kimi/session/steer` extension method** (`{ sessionId, prompt: ContentBlock[] } -> { steered: true } | { steered: false, reason: 'no_active_turn' }`)

- Injects a pending user message into the session's active turn via `Session.steer` — the model consumes it at the next step boundary while in-flight tool calls and subagents run on undisturbed. The content pipeline (blocks → prompt parts → image compression) is identical to `session/prompt`.
- With no active turn the method resolves `{ steered: false, reason: 'no_active_turn' }` instead of erroring, so the client can fall back to `session/prompt`. The gate reads the adapter-tracked `currentTurnId` and is best-effort (re-checked after the compression await): the v1 kernel has no idle-rejecting steer variant — with no active turn its `Turn.steer` launches a fresh one — so a residual RPC-hop race is documented in code. Kernel-started turns (background/cron completion) are a known blind spot; closing it needs a kernel turn-state query (follow-up).
- Params are validated element-by-element (`invalidParams` on malformed blocks), matching the `sessionId` checks of fork/close.

**node-sdk**

- `rpc.archiveSession` passthrough + `KimiHarness.archiveSession(id)` (agent-core already implements `archiveSession`; it just was not wired through the SDK).
- `ForkSessionInput.kaos` / `persistenceKaos` + `forkSessionWithKaos` passthrough (mirrors the create/resume kaos-override chain).

**Docs & release**

- `docs/en/reference/kimi-acp.md` and `docs/zh/reference/kimi-acp.md` both carry the extension-methods table (fork/close/steer) and the built-in slash-commands table.
- Changesets: `@moonshot-ai/kimi-code` minor (fork/close/undo, and steer+fork-kaos) + patch (undo pre-check); `@moonshot-ai/kimi-code-sdk` minor.

**Tests** (acp-adapter 313 tests, kimi-sdk 192 tests, all passing; typecheck + oxlint clean)

- Slash parsing: `/undo 3` detected as builtin.
- `/undo` / `/undo 3` call `undoHistory(1)` / `undoHistory(3)` without invoking `Session.prompt`; malformed count yields the usage message; `/undo` during an in-flight turn is refused; over-large counts and compaction boundaries are refused by the pre-check with the kernel's exact wording (`undoHistory` not called); injection messages are skipped by the walk; a racing kernel `Cannot undo` error surfaces verbatim instead of the `/undo failed:` wrapper.
- `kimi/session/fork` roundtrip over the wire: forks via the harness and registers a promptable session; with fs capabilities advertised the fork carries an `AcpKaos`/persistence pair and a pre-minted `forkId`; unknown/missing `sessionId` → `invalidParams (-32602)`. SDK-level integration test drives `harness.forkSession({ kaos, persistenceKaos })` against an in-process kernel and asserts `fork.id === forkId` with source content copied.
- `kimi/session/close`: drops the session; `archive: true` routes to `archiveSession`, default routes to `closeSession`.
- `kimi/session/steer`: happy path converts blocks and returns `{ steered: true }`; no active turn → `{ steered: false, reason: 'no_active_turn' }`; a `prompt.not_found` kernel rejection maps to the same; missing/empty/malformed `prompt` → `invalidParams`.

**Known limitation** (documented in code + issue): ACP-supplied `mcpServers` are not carried into forks — `resumeSession` rebuilds MCP from the on-disk config only. Follow-up if needed.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.
