### PR TITLE
fix(agent-core): re-register builtin tools when provider resolves late

### DIFF
--- a/.changeset/fix-late-provider-builtin-tools.md
+++ b/.changeset/fix-late-provider-builtin-tools.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Fix built-in tools being unavailable when the model provider becomes ready after the session starts.

--- a/packages/agent-core/src/agent/tool/index.ts
+++ b/packages/agent-core/src/agent/tool/index.ts
@@ -830,6 +830,23 @@ export class ToolManager {
 
   get loopTools(): readonly ExecutableTool[] {
     if (this.loopToolsOverride !== undefined) return this.loopToolsOverride;
+    // Self-heal an empty builtin table. The constructor and every config-
+    // mutation checkpoint gate initializeBuiltinTools() on hasProvider, but a
+    // provider that becomes resolvable asynchronously (OAuth / managed
+    // free-tokens model registration) trips none of them — without this the
+    // agent runs with zero tools while the system prompt still advertises them.
+    // loopTools is re-read before every step, so the table is populated on the
+    // first step after the provider resolves. Steady state short-circuits on
+    // `builtinTools.size === 0`, so hasProvider is not evaluated per read.
+    if (this.builtinTools.size === 0 && this.agent.config.hasProvider) {
+      try {
+        this.initializeBuiltinTools();
+      } catch (error) {
+        this.agent.log.warn('lazy initializeBuiltinTools failed; will retry on next read', {
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
+    }
     const disclosure = this.progressiveDisclosure;
     const enabledMcpNames = [...this.mcpTools.keys()].filter((name) =>
       this.isMcpToolEnabled(name),

--- a/packages/agent-core/test/agent/tool.test.ts
+++ b/packages/agent-core/test/agent/tool.test.ts
@@ -6,7 +6,9 @@ import type { ToolCall } from '@moonshot-ai/kosong';
 import { describe, expect, it, vi } from 'vitest';
 
 import { budgetToolResultForModel } from '../../src/agent/turn/tool-result-budget';
+import type { KimiConfig } from '../../src/config';
 import { HookEngine } from '../../src/session/hooks';
+import { ProviderManager } from '../../src/session/provider-manager';
 import type { SessionSubagentHost } from '../../src/session/subagent-host';
 import { FLAG_DEFINITIONS, FlagResolver } from '../../src/flags';
 import { createFakeKaos } from '../tools/fixtures/fake-kaos';
@@ -267,6 +269,40 @@ describe('Agent tools', () => {
     ctx.configure({ tools: ['AgentSwarm'] });
 
     expect(ctx.agent.tools.loopTools.some((tool) => tool.name === 'AgentSwarm')).toBe(true);
+  });
+
+  it('self-heals the builtin tool table when the provider becomes resolvable after construction', () => {
+    // The ProviderManager reads this live config; it starts with no model or
+    // provider, so hasProvider is false at Agent construction and
+    // initializeBuiltinTools() is skipped — the state the asynchronous
+    // free-tokens / OAuth model registration produces.
+    const liveConfig: KimiConfig = { providers: {}, models: {} };
+    const ctx = testAgent({
+      providerManager: new ProviderManager({ config: () => liveConfig }),
+    });
+
+    // Aim at a model that cannot resolve yet and enable some tools. Neither call
+    // runs a gated re-init because hasProvider is still false, so the enabled
+    // tools have no builtin backing and are not dispatchable.
+    ctx.agent.config.update({ modelAlias: 'late-model' });
+    ctx.agent.tools.setActiveTools(['Bash', 'Read', 'Glob']);
+    expect(ctx.agent.tools.loopTools.some((tool) => tool.name === 'Bash')).toBe(false);
+
+    // The provider registers asynchronously: the config the ProviderManager reads
+    // now resolves the model, but no agent config.update fires, so none of the
+    // hasProvider-gated checkpoints re-run initializeBuiltinTools().
+    liveConfig.providers['late-provider'] = { type: 'kimi', apiKey: 'late-key' };
+    liveConfig.models!['late-model'] = {
+      provider: 'late-provider',
+      model: 'late-model',
+      maxContextSize: 1_000_000,
+      capabilities: [],
+    };
+
+    // loopTools self-heals on read: the builtin table is populated and the
+    // enabled tools become dispatchable instead of reporting "Tool not found".
+    const names = ctx.agent.tools.loopTools.map((tool) => tool.name);
+    expect(names).toEqual(expect.arrayContaining(['Bash', 'Read', 'Glob']));
   });
 
   it('routes registered user tools through tool.call request/response', async () => {


### PR DESCRIPTION
## Related Issue

N/A — no linked issue; the problem is explained below.

## Problem

When the model provider becomes resolvable only *after* the session/agent has started — e.g. OAuth login or managed free-tokens model registration completing asynchronously — the agent runs with zero builtin tools. The system prompt still advertises the standard tools (Read/Bash/Glob/...), so the model emits tool calls, but every call fails with `Tool "X" not found`. The agent cannot read files, run commands, or use any builtin tool until the session is restarted/resumed (which rebuilds the table in a fresh process).

## What changed

**Root cause.** `initializeBuiltinTools()` populates the executable tool table, but it is gated on `hasProvider` at every call site (ToolManager constructor, config update, skills-loaded, kaos-set). A provider that becomes resolvable asynchronously trips none of those checkpoints, so the table stays empty for the whole process — while the system prompt (which is independent of the table) keeps advertising the tools.

**Fix.** `loopTools` — which is re-read before every step — now self-heals: when the builtin table is empty but a provider is resolvable, it runs `initializeBuiltinTools()` on the spot, so the table is populated on the first step after the provider resolves. Steady state short-circuits on the empty-table check, so `hasProvider` is not re-evaluated per read (no per-step cost); a failure is logged and retried on the next read.

Poll-on-read is deliberate: the async registration path mutates the config the provider resolver reads without emitting any agent-level config event, so an event-driven re-init hook would not fire.

**Tests.** Added a regression test that builds an agent whose provider is initially unresolvable (empty live config), enables tools (table stays empty), then registers the provider asynchronously and asserts `loopTools` self-heals and the tools become dispatchable. Verified it fails without the fix and passes with it; the surrounding tool/turn/loop/mcp suites (230 tests) and `tsc --noEmit` are green.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.
