### PR TITLE
test(agent-core-v2): add lifecycle create stub to sessionLegacy status test

### DIFF
--- a/packages/agent-core-v2/test/app/sessionLegacy/sessionLegacy.test.ts
+++ b/packages/agent-core-v2/test/app/sessionLegacy/sessionLegacy.test.ts
@@ -83,6 +83,9 @@ describe('Session legacy status (best-effort runtime state)', () => {
       dispose: () => {},
     };
     const agents = {
+      // create is create-or-get for explicit ids: this session's main agent
+      // already exists, so return it as-is (same as whenReady).
+      create: () => Promise.resolve(agent),
       whenReady: () => Promise.resolve(agent),
     } as unknown as IAgentLifecycleService;
     const session: ISessionScopeHandle = {


### PR DESCRIPTION
## Related Issue

None — fixes a red `main` (CI `test (4)`), problem explained below.

## Problem

Since #1625 (`d158e0a7a`), `main`'s CI fails in `agent-core-v2 test/app/sessionLegacy/sessionLegacy.test.ts`:

```
TypeError: session.accessor.get(...).create is not a function
 ❯ ensureMainAgent src/session/agentLifecycle/mainAgent.ts:32
 ❯ SessionLegacyService.resolveMainAgent src/app/sessionLegacy/sessionLegacyService.ts:145
```

#1625 changed `SessionLegacyService.status()` to resolve the main agent through `ensureMainAgent()`, which calls `IAgentLifecycleService.create()`. The test's hand-rolled lifecycle stub predates that path and only implements `whenReady`, so the scenario errors before any assertion runs. `main`'s own CI (`test (4)` shard) has been red since that merge, and every open PR inherits the failure.

## What changed

Test-only: add `create` to the stub, returning the scenario's existing main agent. This matches the real service's create-or-get contract for explicit ids (`create` joins an in-flight creation and returns an already-created main agent as-is), which is exactly what this session models — a persisted session whose main agent already exists. No implementation code touched; the new status path is the intended behavior.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works (this IS the test fix; full `agent-core-v2` suite passes locally).
- [x] Ran `gen-changesets` skill, or this PR needs no changeset (test-only change).
- [x] Ran `gen-docs` skill, or this PR needs no doc update.
