### PR TITLE
fix(server): version reporting and session format fixes

### DIFF
--- a/.changeset/fix-session-format-backward-compat.md
+++ b/.changeset/fix-session-format-backward-compat.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Fix sessions created by newer builds being listed but failing to open in older CLI builds on the same machine; new sessions are now written so both versions can resume them.

--- a/.changeset/server-version-from-cli.md
+++ b/.changeset/server-version-from-cli.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Fix `kimi server` reporting the internal server package version instead of the CLI version in its metadata; the web UI settings now show the CLI version.

--- a/.changeset/web-message-history-real-times.md
+++ b/.changeset/web-message-history-real-times.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+web: Show each message's actual send time in chat history after reloading a session, instead of the session creation time.

--- a/apps/kimi-code/src/cli/sub/server/run.ts
+++ b/apps/kimi-code/src/cli/sub/server/run.ts
@@ -401,6 +401,9 @@ async function runServerInProcess(
   const v2 = await startServer({
     host: options.host,
     port: options.port,
+    // Report the CLI's product version as `server_version` (/meta, web UI)
+    // rather than kap-server's private package version.
+    version,
     logLevel: options.logLevel,
     logger,
     debugEndpoints: options.debugEndpoints,

--- a/packages/agent-core-v2/src/agent/wireRecord/wireRecord.ts
+++ b/packages/agent-core-v2/src/agent/wireRecord/wireRecord.ts
@@ -24,6 +24,16 @@ export interface WireRecordRestoreResult {
 export interface IAgentWireRecordService {
   readonly _serviceBrand: undefined;
 
+  /**
+   * Ensure the on-disk wire log starts with the `metadata` envelope: append it
+   * when the log is still empty (fresh agent), no-op otherwise. Called at
+   * agent creation so the log always satisfies v1's replay invariant — v1's
+   * `AgentRecords.replay()` hard-rejects a non-empty log whose first record is
+   * not `metadata`, and sessions on a shared `KIMI_CODE_HOME` must stay
+   * readable by both engines. Legacy envelope-less logs (written before this
+   * existed) are healed by `restore()`, never here.
+   */
+  seal(): Promise<void>;
   getRecords(): readonly PersistedWireRecord[];
   restore(
     records?: readonly PersistedWireRecord[],

--- a/packages/agent-core-v2/src/agent/wireRecord/wireRecordService.ts
+++ b/packages/agent-core-v2/src/agent/wireRecord/wireRecordService.ts
@@ -3,9 +3,13 @@
  *
  * Restores and retains the owning agent's wire journal, applies protocol
  * migrations, rejects non-empty unversioned logs, and awaits durable atomic
- * rewrites before restore completes. Tracks live records through `wire`, uses
- * `agent/scopeContext` for storage addressing, and persists through the
- * `appendLog` access-pattern store. Bound at Agent scope.
+ * rewrites before restore completes. Seals fresh logs with the `metadata`
+ * envelope at creation (`seal`) so released v1 builds — whose replay
+ * hard-rejects envelope-less logs — can read sessions on a shared
+ * `KIMI_CODE_HOME`; legacy envelope-less logs are healed on `restore`.
+ * Tracks live records through `wire`, uses `agent/scopeContext` for storage
+ * addressing, and persists through the `appendLog` access-pattern store.
+ * Bound at Agent scope.
  */
 
 import { relative } from 'pathe';
@@ -13,6 +17,7 @@ import { relative } from 'pathe';
 import { InstantiationType } from '#/_base/di/extensions';
 import { Disposable } from '#/_base/di/lifecycle';
 import { LifecycleScope, registerScopedService } from '#/_base/di/scope';
+import { onUnexpectedError } from '#/_base/errors/unexpectedError';
 import { IAgentScopeContext } from '#/agent/scopeContext/scopeContext';
 import { IAppendLogStore } from '#/persistence/interface/appendLogStore';
 import { IAgentWireService } from '#/wire/tokens';
@@ -62,6 +67,14 @@ export class AgentWireRecordService extends Disposable implements IAgentWireReco
 
   getRecords(): readonly PersistedWireRecord[] {
     return [...this.records];
+  }
+
+  async seal(): Promise<void> {
+    if (this.log === undefined) return;
+    if (await hasAnyRecord(this.log, this.wireScope, WIRE_RECORD_FILENAME)) return;
+    this.log.append(this.wireScope, WIRE_RECORD_FILENAME, metadataRecord(), {
+      onError: onUnexpectedError,
+    });
   }
 
   async restore(
@@ -159,6 +172,14 @@ registerScopedService(
 
 function isWireRecordMetadata(record: PersistedWireRecord): record is WireRecordMetadata {
   return record.type === 'metadata' && typeof record['protocol_version'] === 'string';
+}
+
+async function hasAnyRecord(log: IAppendLogStore, scope: string, key: string): Promise<boolean> {
+  for await (const record of log.read(scope, key)) {
+    void record;
+    return true;
+  }
+  return false;
 }
 
 export const WIRE_RECORD_FILENAME = 'wire.jsonl';

--- a/packages/agent-core-v2/src/session/agentLifecycle/agentLifecycleService.ts
+++ b/packages/agent-core-v2/src/session/agentLifecycle/agentLifecycleService.ts
@@ -55,6 +55,7 @@ import { IImageConfigBridge } from '#/agent/media/imageConfigBridge';
 import { IAgentMcpService } from '#/agent/mcp/mcp';
 import { IAgentExternalHooksService } from '#/agent/externalHooks/externalHooks';
 import { IAgentPluginService } from '#/agent/plugin/agentPlugin';
+import { IAgentWireRecordService } from '#/agent/wireRecord/wireRecord';
 import { ISessionInteractionService } from '#/session/interaction/interaction';
 import {
   type AgentListFilter,
@@ -168,6 +169,11 @@ export class AgentLifecycleService extends Disposable implements IAgentLifecycle
     ) as IAgentScopeHandle;
     this.handles.set(agentId, handle);
     try {
+      // Seal the wire log with the metadata envelope before any op can be
+      // dispatched: v1's replay hard-rejects envelope-less logs, and sessions
+      // on a shared KIMI_CODE_HOME must stay readable by released v1 builds.
+      // No-op when the log already has records (resume / forked copies).
+      await handle.accessor.get(IAgentWireRecordService).seal();
       await this.sessionMetadata.registerAgent(agentId, {
         homedir: agentHomedir,
         type: agentId === 'main' ? 'main' : 'sub',
@@ -182,10 +188,9 @@ export class AgentLifecycleService extends Disposable implements IAgentLifecycle
       // Bootstrap (profile binding and the force-instantiated observer
       // services) is complete: drive the activity kernel `initializing → idle`
       // so the agent can admit turns. Until this point `begin` rejects with
-      // `activity.initializing`. The wire log's metadata envelope is NOT
-      // seeded here — `wireRecord.restore()` heals envelope-less logs on
-      // resume (prepend + rewrite), so creation stays free of log-format
-      // concerns.
+      // `activity.initializing`. The wire log was already sealed with its
+      // metadata envelope above; `wireRecord.restore()` heals any legacy
+      // envelope-less log on resume (prepend + rewrite).
       handle.accessor.get(IAgentActivityService).markReady();
       return handle;
     } catch (error) {

--- a/packages/agent-core-v2/src/session/sessionMetadata/sessionMetadataService.ts
+++ b/packages/agent-core-v2/src/session/sessionMetadata/sessionMetadataService.ts
@@ -141,6 +141,11 @@ export class SessionMetadata extends Disposable implements ISessionMetadata {
       createdAt: now,
       updatedAt: now,
       archived: false,
+      // Seed the maps v1 reads unconditionally on resume (`agents['main']` in
+      // v1's Session.resume()); v1 also defaults both on fresh sessions, so a
+      // v2-created state.json stays openable by released v1 builds.
+      agents: {},
+      custom: {},
     };
     await this.store.set(this.scope, META_KEY, this.data);
     this.log.debug('session metadata created', { sessionId: this.ctx.sessionId });

--- a/packages/agent-core-v2/test/agent/contextMemory/stubs.ts
+++ b/packages/agent-core-v2/test/agent/contextMemory/stubs.ts
@@ -24,6 +24,7 @@ import { IAgentWireRecordService } from '#/agent/wireRecord/wireRecord';
 export function stubWireRecord(): IAgentWireRecordService {
   return {
     _serviceBrand: undefined,
+    seal: () => Promise.resolve(),
     restore: () => Promise.resolve({}),
     flush: () => Promise.resolve(),
     close: () => Promise.resolve(),

--- a/packages/agent-core-v2/test/agent/wireRecord/persistence.test.ts
+++ b/packages/agent-core-v2/test/agent/wireRecord/persistence.test.ts
@@ -294,6 +294,69 @@ describe('wire record append-log persistence', () => {
   });
 });
 
+describe('AgentWireRecordService seal', () => {
+  it('appends the metadata envelope to an empty log', async () => {
+    const { dir, log } = await createFileAppendLogHarness();
+    const svc = createWireRecordHarness(log);
+
+    await svc.seal();
+    await log.close();
+
+    const lines = await readLines(join(dir, SCOPE, KEY));
+    expect(lines).toHaveLength(1);
+    expect(JSON.parse(lines[0]!)).toMatchObject({
+      type: 'metadata',
+      protocol_version: AGENT_WIRE_PROTOCOL_VERSION,
+    });
+  });
+
+  it('is a no-op on a non-empty log', async () => {
+    const { dir, log } = await createFileAppendLogHarness();
+    log.append(SCOPE, KEY, {
+      type: 'turn.prompt',
+      input: [{ type: 'text', text: 'existing' }],
+      origin: { kind: 'user' },
+    });
+    await log.flush();
+    const svc = createWireRecordHarness(log);
+
+    await svc.seal();
+    await log.close();
+
+    const lines = await readLines(join(dir, SCOPE, KEY));
+    expect(lines).toHaveLength(1);
+    expect(JSON.parse(lines[0]!)['type']).toBe('turn.prompt');
+  });
+
+  it('seals only once across repeated calls', async () => {
+    const { dir, log } = await createFileAppendLogHarness();
+    const svc = createWireRecordHarness(log);
+
+    await svc.seal();
+    await svc.seal();
+    await log.close();
+
+    const lines = await readLines(join(dir, SCOPE, KEY));
+    expect(lines).toHaveLength(1);
+  });
+
+  it('restore after seal keeps the sealed log untouched', async () => {
+    const { dir, log } = await createFileAppendLogHarness();
+    const svc = createWireRecordHarness(log);
+
+    await svc.seal();
+    await svc.restore();
+    await log.close();
+
+    const lines = await readLines(join(dir, SCOPE, KEY));
+    expect(lines).toHaveLength(1);
+    expect(JSON.parse(lines[0]!)).toMatchObject({
+      type: 'metadata',
+      protocol_version: AGENT_WIRE_PROTOCOL_VERSION,
+    });
+  });
+});
+
 describe('AgentWireRecordService migration rewrite', () => {
   async function seedLegacyLog(storage: InMemoryStorageService): Promise<IAppendLogStore> {
     const log = createAppendLogHarness(storage);

--- a/packages/agent-core-v2/test/app/sessionExport/sessionExport.test.ts
+++ b/packages/agent-core-v2/test/app/sessionExport/sessionExport.test.ts
@@ -916,6 +916,7 @@ function stubAgentLifecycle(agents: readonly IAgentScopeHandle[]): IAgentLifecyc
 function stubAgentWire(flush: () => Promise<void> = async () => {}): IAgentWireRecordService {
   return {
     _serviceBrand: undefined,
+    seal: async () => {},
     getRecords: () => [],
     restore: async () => ({}),
     flush,

--- a/packages/agent-core-v2/test/session/agentLifecycle/agentLifecycle.test.ts
+++ b/packages/agent-core-v2/test/session/agentLifecycle/agentLifecycle.test.ts
@@ -28,6 +28,7 @@ import { SessionSubagentService } from '#/session/subagent/subagentService';
 import '#/activity/agentActivityService';
 import '#/agent/mcp/mcpService';
 import '#/agent/wireRecord/agentWireService';
+import '#/agent/wireRecord/wireRecordService';
 import { IAgentTaskService } from '#/agent/task/task';
 import { ISessionCronService } from '#/session/cron/sessionCronService';
 import '#/agent/toolDedupe/toolDedupeService';
@@ -42,7 +43,10 @@ import { IAppendLogStore } from '#/persistence/interface/appendLogStore';
 import { IAtomicDocumentStore } from '#/persistence/interface/atomicDocumentStore';
 import { ISessionContext } from '#/session/sessionContext/sessionContext';
 import { ISessionMetadata } from '#/session/sessionMetadata/sessionMetadata';
-import { type PersistedWireRecord } from '#/agent/wireRecord/wireRecord';
+import {
+  AGENT_WIRE_PROTOCOL_VERSION,
+  type PersistedWireRecord,
+} from '#/agent/wireRecord/wireRecord';
 import { IAgentToolExecutorService } from '#/agent/toolExecutor/toolExecutor';
 import { IAgentLoopService } from '#/agent/loop/loop';
 import { ITelemetryService } from '#/app/telemetry/telemetry';
@@ -324,6 +328,34 @@ describe('AgentLifecycleService', () => {
     });
   });
 
+  it('seals a fresh wire log with the metadata envelope as the first record', async () => {
+    const log = recordingAppendLog();
+    ix.stub(IAppendLogStore, log.store);
+    const svc = ix.get(IAgentLifecycleService);
+
+    await svc.create({ agentId: 'main' });
+
+    expect(log.appended[0]).toMatchObject({
+      type: 'metadata',
+      protocol_version: AGENT_WIRE_PROTOCOL_VERSION,
+    });
+  });
+
+  it('does not re-seal a wire log that already has records', async () => {
+    const existing: PersistedWireRecord = {
+      type: 'turn.prompt',
+      input: [{ type: 'text', text: 'existing' }],
+      origin: { kind: 'user' },
+    } as unknown as PersistedWireRecord;
+    const log = recordingAppendLog([existing]);
+    ix.stub(IAppendLogStore, log.store);
+    const svc = ix.get(IAgentLifecycleService);
+
+    await svc.create({ agentId: 'main' });
+
+    expect(log.appended.some((record) => record.type === 'metadata')).toBe(false);
+  });
+
   it('leaves permission mode at the default when permissionMode is omitted', async () => {
     const svc = ix.get(IAgentLifecycleService);
 
@@ -442,12 +474,16 @@ describe('AgentLifecycleService', () => {
 
   it('exposes the in-flight handle and yields it idle after bootstrap', async () => {
     let releaseRegister!: () => void;
-    registerAgent.mockImplementationOnce(
-      () =>
-        new Promise<void>((resolve) => {
-          releaseRegister = resolve;
-        }),
-    );
+    let registerStarted!: () => void;
+    const registerCalled = new Promise<void>((resolve) => {
+      registerStarted = resolve;
+    });
+    registerAgent.mockImplementationOnce(() => {
+      registerStarted();
+      return new Promise<void>((resolve) => {
+        releaseRegister = resolve;
+      });
+    });
     const svc = ix.get(IAgentLifecycleService);
     const create = svc.create({ agentId: 'main' });
 
@@ -456,6 +492,9 @@ describe('AgentLifecycleService', () => {
     expect(early!.accessor.get(IAgentActivityService).lane()).toBe('initializing');
 
     const joined = svc.create({ agentId: 'main' });
+    // doCreate awaits the wire-log seal before registerAgent, so the mock is
+    // invoked a few microtasks after create() — wait for the actual call.
+    await registerCalled;
     releaseRegister();
     const handle = await joined;
     await create;

--- a/packages/agent-core-v2/test/session/sessionMetadata/sessionMetadata.test.ts
+++ b/packages/agent-core-v2/test/session/sessionMetadata/sessionMetadata.test.ts
@@ -51,7 +51,14 @@ describe('SessionMetadata', () => {
 
   it('creates an initial document on first read', async () => {
     const meta = ix.get(ISessionMetadata);
-    expect(await meta.read()).toMatchObject({ id: 's1', archived: false });
+    expect(await meta.read()).toMatchObject({
+      id: 's1',
+      archived: false,
+      // Seeded so released v1 builds can open a v2-created state.json
+      // (v1's Session.resume() indexes `agents` unconditionally).
+      agents: {},
+      custom: {},
+    });
     expect((await meta.read()).createdAt).toBeGreaterThan(0);
   });
 

--- a/packages/kap-server/src/services/snapshot/snapshotReader.ts
+++ b/packages/kap-server/src/services/snapshot/snapshotReader.ts
@@ -76,6 +76,7 @@ interface TranscriptCacheEntry {
   readonly size: number;
   readonly mtimeMs: number;
   readonly messages: ContextMessage[];
+  readonly times: readonly (number | undefined)[];
 }
 
 interface LocatedSession {
@@ -106,9 +107,18 @@ export class SnapshotReader implements ISnapshotReader {
     const offset = hasMore ? full.length - SNAPSHOT_MESSAGE_PAGE_SIZE : 0;
     const page = hasMore ? full.slice(offset) : full;
     await this.rehydrateBlobRefs(page, join(located.sessionDir, AGENTS_DIR, MAIN_AGENT_ID, BLOBS_DIR));
-    const items = page.map((msg, i) =>
-      toProtocolMessage(sid, offset + i, msg, located.meta.createdAt),
-    );
+    // `created_at` prefers the real per-record time stamped onto wire.jsonl at
+    // dispatch; records predating the stamp (or the `metadata` envelope) fall
+    // back to the synthesized `session.createdAt + index`, clamped so the
+    // page stays strictly increasing (mirrors `MessageLegacyService.list`).
+    let previousMs = Number.NEGATIVE_INFINITY;
+    const items = page.map((msg, i) => {
+      const index = offset + i;
+      const baseMs = transcript.times[index] ?? located.meta.createdAt + index;
+      const createdAtMs = Math.max(previousMs + 1, baseMs);
+      previousMs = createdAtMs;
+      return toProtocolMessage(sid, index, msg, located.meta.createdAt, createdAtMs);
+    });
 
     const live = core.accessor.get(ISessionLifecycleService).get(sid);
     const status = this.resolveStatus(live);
@@ -180,6 +190,7 @@ export class SnapshotReader implements ISnapshotReader {
     sessionDir: string,
   ): Promise<{
     messages: ContextMessage[];
+    times: readonly (number | undefined)[];
     tag: 'hit' | 'miss' | 'shrink_invalidate' | 'enoent';
     wireBytes: number;
   }> {
@@ -192,7 +203,7 @@ export class SnapshotReader implements ISnapshotReader {
     }
     if (info === undefined) {
       this.transcriptCache.delete(sid);
-      return { messages: [], tag: 'enoent', wireBytes: 0 };
+      return { messages: [], times: [], tag: 'enoent', wireBytes: 0 };
     }
 
     const cached = this.transcriptCache.get(sid);
@@ -200,7 +211,7 @@ export class SnapshotReader implements ISnapshotReader {
       // LRU touch.
       this.transcriptCache.delete(sid);
       this.transcriptCache.set(sid, cached);
-      return { messages: cached.messages, tag: 'hit', wireBytes: info.size };
+      return { messages: cached.messages, times: cached.times, tag: 'hit', wireBytes: info.size };
     }
 
     const tag: 'miss' | 'shrink_invalidate' =
@@ -208,14 +219,15 @@ export class SnapshotReader implements ISnapshotReader {
     if (cached !== undefined) this.transcriptCache.delete(sid);
 
     const records = await readWireRecords(wirePath);
-    const messages = [...reduceContextTranscript(records).entries];
-    this.transcriptCache.set(sid, { size: info.size, mtimeMs: info.mtimeMs, messages });
+    const { entries, times } = reduceContextTranscript(records);
+    const messages = [...entries];
+    this.transcriptCache.set(sid, { size: info.size, mtimeMs: info.mtimeMs, messages, times });
     while (this.transcriptCache.size > this.deps.config.cacheLimit) {
       const oldest = this.transcriptCache.keys().next().value;
       if (oldest === undefined) break;
       this.transcriptCache.delete(oldest);
     }
-    return { messages, tag, wireBytes: info.size };
+    return { messages, times, tag, wireBytes: info.size };
   }
 
   private resolveStatus(

--- a/packages/kap-server/src/start.ts
+++ b/packages/kap-server/src/start.ts
@@ -115,6 +115,13 @@ export interface ServerStartOptions {
    * the API server without the web UI.
    */
   readonly webAssetsDir?: string;
+  /**
+   * Host product version, reported as `server_version` (GET /api/v1/meta), in
+   * the OpenAPI document, session exports, the lock / instance registry, and
+   * the default User-Agent. Defaults to kap-server's own package version;
+   * embedding hosts (the CLI) should pass their own version.
+   */
+  readonly version?: string;
 }
 
 export interface RunningServer {
@@ -161,7 +168,7 @@ export async function startServer(opts: ServerStartOptions = {}): Promise<Runnin
   //     multiple servers can share the homeDir; port conflicts are resolved by
   //     the `port + 1` retry below instead of the lock.
   // Either handle is released on close and on any boot refusal below.
-  const hostVersion = getServerVersion();
+  const hostVersion = opts.version ?? getServerVersion();
   let lockHandle: AcquireLockResult | undefined;
   let registration: InstanceRegistration | undefined;
   if (isMultiServerEnabled(process.env)) {
@@ -323,7 +330,7 @@ export async function startServer(opts: ServerStartOptions = {}): Promise<Runnin
     config: loadSnapshotConfig(),
   });
 
-  const serverVersion = getServerVersion();
+  const serverVersion = hostVersion;
 
   async function registerOpenApi(): Promise<void> {
     const { default: swagger } = await import('@fastify/swagger');

--- a/packages/kap-server/test/boot.test.ts
+++ b/packages/kap-server/test/boot.test.ts
@@ -80,6 +80,35 @@ describe('server-v2 boot', () => {
     expect(oauthBody.data).toBeNull();
   });
 
+  it('reports opts.version as server_version instead of the package version', async () => {
+    home = await mkdtemp(join(tmpdir(), 'kimi-server-v2-version-'));
+    server = await startServer({
+      host: '127.0.0.1',
+      port: 0,
+      homeDir: home,
+      logLevel: 'silent',
+      version: '9.9.9-host',
+    });
+
+    const base = `http://127.0.0.1:${server.port}`;
+    const meta = await authedFetch(server, base, '/api/v1/meta');
+    const metaBody = await meta.json() as {
+      code: number;
+      data: { server_version: string };
+    };
+    expect(metaBody.data.server_version).toBe('9.9.9-host');
+
+    // The host version is also what the lock advertises to status/ps clients.
+    const stored = JSON.parse(
+      await readFile(join(home, 'server', 'lock'), 'utf8'),
+    ) as LockContents;
+    expect(stored.host_version).toBe('9.9.9-host');
+
+    // ... and it backs the default product User-Agent.
+    const defaults = server.core.accessor.get(IHostRequestHeaders);
+    expect(defaults.headers['User-Agent']).toBe('kimi-code-cli/9.9.9-host');
+  });
+
   it('seeds a default product User-Agent that opts.seeds can override', async () => {
     home = await mkdtemp(join(tmpdir(), 'kimi-server-v2-ua-'));
     server = await startServer({

--- a/packages/kap-server/test/snapshotReader.unit.test.ts
+++ b/packages/kap-server/test/snapshotReader.unit.test.ts
@@ -382,6 +382,58 @@ describe('SnapshotReader.read', () => {
     expect((snap.messages.items.at(-1)!.content[0] as { text: string }).text).toBe('m149');
   });
 
+  it('uses the wire record time as created_at, falling back and clamping to stay increasing', async () => {
+    const f = await makeFixtureAsync();
+    const createdAt = 1700000000000;
+    const t0 = 1700001000000;
+    await seedSession(f, 'sess_times', { createdAt });
+    await writeWire(f.sessionDir('sess_times'), [
+      { type: 'context.append_message', message: userMessage('one'), time: t0 },
+      // No time stamp → falls back to createdAt + index, which is earlier than
+      // the previous real time and gets clamped to previous + 1.
+      { type: 'context.append_message', message: userMessage('two') },
+      // A time stamp EARLIER than the previous entry → clamped to previous + 1.
+      { type: 'context.append_message', message: userMessage('three'), time: t0 - 5000 },
+    ]);
+    const snap = await f.reader.read('sess_times');
+    expect(snap.messages.items.map((m) => Date.parse(m.created_at))).toEqual([t0, t0 + 1, t0 + 2]);
+  });
+
+  it('synthesizes created_at from session createdAt + index when no record carries a time', async () => {
+    const f = await makeFixtureAsync();
+    const createdAt = 1700000000000;
+    await seedSession(f, 'sess_no_times', { createdAt });
+    await writeWire(f.sessionDir('sess_no_times'), [
+      { type: 'context.append_message', message: userMessage('a') },
+      { type: 'context.append_message', message: userMessage('b') },
+    ]);
+    const snap = await f.reader.read('sess_no_times');
+    expect(snap.messages.items.map((m) => Date.parse(m.created_at))).toEqual([
+      createdAt,
+      createdAt + 1,
+    ]);
+  });
+
+  it('maps record times by global index across the page offset', async () => {
+    const f = await makeFixtureAsync();
+    const createdAt = 1700000000000;
+    const base = 1700002000000;
+    await seedSession(f, 'sess_times_paged', { createdAt });
+    await writeWire(
+      f.sessionDir('sess_times_paged'),
+      Array.from({ length: 102 }, (_, i) => ({
+        type: 'context.append_message' as const,
+        message: userMessage(`m${i}`),
+        time: base + i * 1000,
+      })),
+    );
+    const snap = await f.reader.read('sess_times_paged');
+    expect(snap.messages.items).toHaveLength(100);
+    // The page starts at global index 2, so the first item carries record[2]'s time.
+    expect(Date.parse(snap.messages.items[0]!.created_at)).toBe(base + 2000);
+    expect(Date.parse(snap.messages.items.at(-1)!.created_at)).toBe(base + 101 * 1000);
+  });
+
   it('normalizes a v1-layout state.json (ISO timestamps, no id)', async () => {
     const f = await makeFixtureAsync();
     await seedSession(f, 'sess_v1', {


### PR DESCRIPTION
## Related Issue

No linked issue — this PR bundles three small server-side fixes; each problem is described below.

## Problem

1. **Wrong `server_version`.** kap-server reported its own package version as `server_version` (in `/api/v1/meta`, OpenAPI, session exports, the lock registry, and the default User-Agent). Since the server is shipped embedded in the CLI, the version users and telemetry see should be the CLI product version.
2. **v2-created sessions not resumable by v1 builds.** Sessions created by the new agent-core-v2 engine failed to load in older v1 builds: fresh wire logs lacked the leading metadata envelope that v1 replay requires (first record must be metadata), and v2-created `state.json` lacked the `agents`/`custom` maps that v1 `Session.resume()` indexes into.
3. **Synthetic timestamps in snapshot history.** The snapshot history endpoint fabricated message `created_at` values (`session.createdAt + index`) instead of showing when each message was actually sent.

## What changed

### 1. Report CLI version as `server_version`

- `startServer` now accepts `opts.version`, which is reported as `server_version` everywhere (`/meta`, OpenAPI, session exports, lock registry, default User-Agent); it defaults to kap-server's own package version when not provided.
- `apps/kimi-code` passes the CLI product version when starting the embedded server.
- Added a boot test covering `/api/v1/meta`, the lock file, and the User-Agent header.

### 2. Make new sessions resumable by older v1 builds

- Added `wireRecord.seal()`, which writes the metadata envelope at agent creation so fresh logs satisfy v1 replay's first-record-must-be-metadata invariant.
- `AgentLifecycleService.create` seals the wire log before any op dispatch; it is a no-op when the log already has records (resume / forked copies).
- Session metadata now seeds empty `agents`/`custom` maps so v1 `Session.resume()` can index `agents['main']` on a v2-created `state.json`.
- Added seal unit tests and lifecycle sealing tests.

### 3. Show real message send times in snapshot history

- `snapshotReader` now reads per-record times stamped on `wire.jsonl` (via `reduceContextTranscript`) and caches them alongside the transcript messages.
- Each record's real dispatch time is preferred for `created_at`; records without a stamp fall back to `session.createdAt + index`, clamped so the page stays strictly increasing (mirroring `MessageLegacyService.list`).
- Added tests for fallback, clamping, and the page-offset index mapping.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.
