### PR TITLE
fix(agent-core-v2): isolate replaced goals

### DIFF
--- a/.changeset/isolate-replaced-goals.md
+++ b/.changeset/isolate-replaced-goals.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Prevent late activity from replaced goals from changing or consuming the budget of replacement goals.

--- a/packages/agent-core-v2/src/agent/goal/goal.ts
+++ b/packages/agent-core-v2/src/agent/goal/goal.ts
@@ -25,6 +25,7 @@ export interface IAgentGoalService {
   readonly _serviceBrand: undefined;
 
   getGoal(): GoalToolResult;
+  isGoalToolTarget(turnId: number, goalId: string): boolean;
   createGoal(input: CreateGoalInput, actor?: GoalActor): Promise<GoalSnapshot>;
   pauseGoal(input?: GoalReasonInput, actor?: GoalActor): Promise<GoalSnapshot>;
   resumeGoal(input?: ResumeGoalInput, actor?: GoalActor): Promise<GoalSnapshot>;

--- a/packages/agent-core-v2/src/agent/goal/goalService.ts
+++ b/packages/agent-core-v2/src/agent/goal/goalService.ts
@@ -722,9 +722,9 @@ export class AgentGoalService extends Disposable implements IAgentGoalService {
   private isStaleGoalToolCall(ctx: ToolBeforeExecuteContext): boolean {
     const toolName = ctx.toolCall.name;
     if (!isGoalMutationTool(toolName)) return false;
-    if (isTerminalUpdateAfterEarlierReplacement(ctx)) return true;
     const goalId = this.goalTurnTarget(ctx.turnId);
     if (goalId === undefined) return false;
+    if (isTerminalUpdateAfterEarlierReplacement(ctx)) return true;
     return this.goalState?.goalId !== goalId;
   }
 

--- a/packages/agent-core-v2/src/agent/goal/goalService.ts
+++ b/packages/agent-core-v2/src/agent/goal/goalService.ts
@@ -43,6 +43,7 @@ import { ContinuationStepRequest, MessageStepRequest } from '#/agent/loop/stepRe
 import { IAgentSystemReminderService } from '#/agent/systemReminder/systemReminder';
 import type { ExecutableToolResult } from '#/tool/toolContract';
 import { IAgentToolExecutorService } from '#/agent/toolExecutor/toolExecutor';
+import type { ToolBeforeExecuteContext } from '#/agent/toolExecutor/toolHooks';
 import { IAgentUsageService, type UsageRecordedContext } from '#/agent/usage/usage';
 import type { GoalBudgetProperties } from '#/app/telemetry/events';
 import { ITelemetryService } from '#/app/telemetry/telemetry';
@@ -253,7 +254,7 @@ export class AgentGoalService extends Disposable implements IAgentGoalService {
     );
     this._register(
       toolExecutor.hooks.onBeforeExecuteTool.register('goal-budget-reject', async (ctx, next) => {
-        if (this.isStaleGoalToolCall(ctx.turnId, ctx.toolCall.name)) {
+        if (this.isStaleGoalToolCall(ctx)) {
           ctx.decision = { syntheticResult: { output: GOAL_STALE_TOOL_RESULT } };
           return;
         }
@@ -718,9 +719,11 @@ export class AgentGoalService extends Disposable implements IAgentGoalService {
     return state?.status === 'active' && state.goalId === goalId;
   }
 
-  private isStaleGoalToolCall(turnId: number, toolName: string): boolean {
+  private isStaleGoalToolCall(ctx: ToolBeforeExecuteContext): boolean {
+    const toolName = ctx.toolCall.name;
     if (!isGoalMutationTool(toolName)) return false;
-    const goalId = this.goalTurnTarget(turnId);
+    if (isTerminalUpdateAfterEarlierReplacement(ctx)) return true;
+    const goalId = this.goalTurnTarget(ctx.turnId);
     if (goalId === undefined) return false;
     return this.goalState?.goalId !== goalId;
   }
@@ -898,6 +901,25 @@ function matchesGoal(state: GoalState, goalId: string | undefined): boolean {
 
 function isGoalMutationTool(toolName: string): boolean {
   return toolName === 'CreateGoal' || toolName === 'UpdateGoal' || toolName === 'SetGoalBudget';
+}
+
+function isTerminalUpdateAfterEarlierReplacement(ctx: ToolBeforeExecuteContext): boolean {
+  if (ctx.toolCall.name !== 'UpdateGoal' || !isPlainRecord(ctx.args)) return false;
+  const status = ctx.args['status'];
+  if (status !== 'complete' && status !== 'blocked') return false;
+  const currentIndex = ctx.toolCalls.findIndex((call) => call.id === ctx.toolCall.id);
+  if (currentIndex <= 0) return false;
+  return ctx.toolCalls.slice(0, currentIndex).some(isGoalReplacementCall);
+}
+
+function isGoalReplacementCall(call: ToolBeforeExecuteContext['toolCall']): boolean {
+  if (call.name !== 'CreateGoal' || call.arguments === null) return false;
+  try {
+    const args = JSON.parse(call.arguments) as unknown;
+    return isPlainRecord(args) && args['replace'] === true;
+  } catch {
+    return false;
+  }
 }
 
 function goalBudgetBlockReason(budget: GoalBudgetReport): string | undefined {

--- a/packages/agent-core-v2/src/agent/goal/goalService.ts
+++ b/packages/agent-core-v2/src/agent/goal/goalService.ts
@@ -24,7 +24,7 @@
 
 import { randomUUID } from 'node:crypto';
 
-import type { TurnEndedEvent } from '@moonshot-ai/protocol';
+import type { TurnEndedEvent, TurnStartedEvent } from '@moonshot-ai/protocol';
 import { Disposable } from '#/_base/di/lifecycle';
 import { InstantiationType } from '#/_base/di/extensions';
 import { LifecycleScope, registerScopedService } from '#/_base/di/scope';
@@ -115,6 +115,8 @@ const GOAL_BUDGET_STOP_REMINDER = [
 
 const GOAL_BUDGET_TOOLS_REJECTED_MESSAGE =
   'Goal budget exhausted; tool calls are rejected. Write your final message.';
+const GOAL_STALE_TOOL_RESULT =
+  'Goal changed since this turn started; ignored stale goal tool call.';
 
 const GOAL_CONTINUATION_PROMPT = [
   'Continue working toward the active goal.',
@@ -154,6 +156,7 @@ interface GoalForkNoticeState {
 
 interface PendingContinuation {
   readonly receipt: EnqueueReceipt;
+  readonly goalId: string;
   turnId?: number;
 }
 
@@ -183,17 +186,22 @@ function isGoalForkClearedReminder(message: ContextMessage | undefined): boolean
   );
 }
 
+function isGoalContinuationOrigin(origin: TurnStartedEvent['origin']): boolean {
+  return origin.kind === 'system_trigger' && origin.name === 'goal_continuation';
+}
+
 export class AgentGoalService extends Disposable implements IAgentGoalService {
   declare readonly _serviceBrand: undefined;
 
   private wallClockResumedAt?: number;
   private liveTurnId?: number;
-  private readonly goalDrivenTurns = new Set<number>();
+  private readonly goalDrivenTurns = new Map<number, string>();
   private readonly countedGoalTurns = new Set<number>();
   private readonly goalStarterTurns = new Set<number>();
-  private readonly goalOutcomeToolResultTurns = new Set<number>();
+  private readonly goalOutcomeToolResultTurns = new Map<number, string>();
   private readonly goalOutcomeContinuationTurns = new Set<number>();
   private readonly budgetGraceTurns = new Set<number>();
+  private readonly pendingContinuationGoals = new Map<number, string>();
   private pendingContinuation?: PendingContinuation;
 
   constructor(
@@ -223,7 +231,9 @@ export class AgentGoalService extends Disposable implements IAgentGoalService {
       }),
     );
     this._register(
-      this.eventBus.subscribe('turn.started', (e) => this.handleTurnLaunched(e.turnId)),
+      this.eventBus.subscribe('turn.started', (e) => {
+        this.handleTurnLaunched(e.turnId, e.origin);
+      }),
     );
     this._register(
       usageService.onDidRecord((ctx) => this.handleUsageRecorded(ctx)),
@@ -242,6 +252,10 @@ export class AgentGoalService extends Disposable implements IAgentGoalService {
     );
     this._register(
       toolExecutor.hooks.onBeforeExecuteTool.register('goal-budget-reject', async (ctx, next) => {
+        if (this.isStaleGoalToolCall(ctx.turnId, ctx.toolCall.name)) {
+          ctx.decision = { syntheticResult: { output: GOAL_STALE_TOOL_RESULT } };
+          return;
+        }
         if (this.budgetGraceTurns.has(ctx.turnId)) {
           ctx.decision = {
             syntheticResult: { output: GOAL_BUDGET_TOOLS_REJECTED_MESSAGE },
@@ -253,16 +267,21 @@ export class AgentGoalService extends Disposable implements IAgentGoalService {
     );
     this._register(
       toolExecutor.hooks.onDidExecuteTool.register('goal-outcome-tool-result', async (ctx, next) => {
-        if (isTerminalUpdateGoalResult(ctx.toolCall.name, ctx.args, ctx.result)) {
-          this.goalOutcomeToolResultTurns.add(ctx.turnId);
+        const goalId = this.goalDrivenTurns.get(ctx.turnId);
+        if (
+          goalId !== undefined &&
+          isTerminalUpdateGoalResult(ctx.toolCall.name, ctx.args, ctx.result)
+        ) {
+          this.goalOutcomeToolResultTurns.set(ctx.turnId, goalId);
         }
         await next();
       }),
     );
     this._register(
       this.eventBus.subscribe('turn.ended', (e) => {
+        const goalId = this.goalDrivenTurns.get(e.turnId);
         void this.handleTurnEnded(e.turnId, { reason: e.reason, error: e.error }).catch((error) =>
-          this.settleGoalAfterContinuationFailure(error),
+          this.settleGoalAfterContinuationFailure(error, goalId),
         );
       }),
     );
@@ -364,9 +383,9 @@ export class AgentGoalService extends Disposable implements IAgentGoalService {
     if (budgetBlocked !== null) return budgetBlocked;
     if (this.canLaunchContinuation()) {
       try {
-        this.launchContinuationTurn();
+        this.launchContinuationTurn(state.goalId);
       } catch (error) {
-        await this.settleGoalAfterContinuationFailure(error);
+        await this.settleGoalAfterContinuationFailure(error, state.goalId);
         throw error;
       }
     }
@@ -456,9 +475,9 @@ export class AgentGoalService extends Disposable implements IAgentGoalService {
     return this.accountTokenUsage(tokenDelta);
   }
 
-  private accountTokenUsage(tokenDelta: number): GoalSnapshot | null {
+  private accountTokenUsage(tokenDelta: number, goalId?: string): GoalSnapshot | null {
     const state = this.goalState;
-    if (state === null || state.status !== 'active') return null;
+    if (state === null || state.status !== 'active' || !matchesGoal(state, goalId)) return null;
     const tokensUsed = state.tokensUsed + Math.max(0, tokenDelta);
     this.wire.dispatch(updateGoal({ tokensUsed }));
     const next = this.requireState();
@@ -466,8 +485,12 @@ export class AgentGoalService extends Disposable implements IAgentGoalService {
   }
 
   async incrementTurn(): Promise<GoalSnapshot | null> {
+    return this.incrementGoalTurn();
+  }
+
+  private incrementGoalTurn(goalId?: string): GoalSnapshot | null {
     const state = this.goalState;
-    if (state === null || state.status !== 'active') return null;
+    if (state === null || state.status !== 'active' || !matchesGoal(state, goalId)) return null;
     const turnsUsed = state.turnsUsed + 1;
     this.wire.dispatch(updateGoal({ turnsUsed }));
     const next = this.requireState();
@@ -476,12 +499,20 @@ export class AgentGoalService extends Disposable implements IAgentGoalService {
     return this.blockIfBudgetReached(next) ?? this.toSnapshot(next);
   }
 
-  private handleTurnLaunched(turnId: number): void {
+  private handleTurnLaunched(turnId: number, origin: TurnStartedEvent['origin']): void {
     this.liveTurnId = turnId;
-    const state = this.goalState;
-    if (state?.status === 'active' && this.blockIfBudgetReached(state) === null) {
-      this.goalDrivenTurns.add(turnId);
+    if (!this.goalDrivenTurns.has(turnId)) {
+      const state = this.goalState;
+      const continuationGoalId = isGoalContinuationOrigin(origin)
+        ? this.pendingContinuationGoals.get(turnId)
+        : undefined;
+      if (continuationGoalId !== undefined && state?.goalId !== continuationGoalId) {
+        this.goalDrivenTurns.set(turnId, continuationGoalId);
+      } else if (state?.status === 'active' && this.blockIfBudgetReached(state) === null) {
+        this.goalDrivenTurns.set(turnId, state.goalId);
+      }
     }
+    this.pendingContinuationGoals.delete(turnId);
     this.goalOutcomeToolResultTurns.delete(turnId);
     this.goalOutcomeContinuationTurns.delete(turnId);
   }
@@ -489,22 +520,27 @@ export class AgentGoalService extends Disposable implements IAgentGoalService {
   private adoptStarterTurn(): void {
     const turnId = this.liveTurnId;
     if (turnId === undefined || this.goalDrivenTurns.has(turnId)) return;
-    this.goalDrivenTurns.add(turnId);
+    const state = this.goalState;
+    if (state === null || state.status !== 'active') return;
+    this.goalDrivenTurns.set(turnId, state.goalId);
     this.countedGoalTurns.add(turnId);
     this.goalStarterTurns.add(turnId);
   }
 
   private async handleBeforeStep(ctx: BeforeStepContext): Promise<void> {
-    if (!this.goalDrivenTurns.has(ctx.turnId)) return;
+    const goalId = this.goalDrivenTurns.get(ctx.turnId);
+    if (goalId === undefined) return;
     if (this.countedGoalTurns.has(ctx.turnId)) return;
     this.countedGoalTurns.add(ctx.turnId);
-    await this.incrementTurn();
+    this.incrementGoalTurn(goalId);
   }
 
   private handleUsageRecorded(ctx: UsageRecordedContext): void {
     const source = ctx.source;
-    if (source?.type !== 'turn' || !this.goalDrivenTurns.has(source.turnId)) return;
-    this.accountTokenUsage(ctx.usage.output);
+    if (source?.type !== 'turn') return;
+    const goalId = this.goalDrivenTurns.get(source.turnId);
+    if (goalId === undefined) return;
+    this.accountTokenUsage(ctx.usage.output, goalId);
   }
 
   private handleAfterStep(ctx: AfterStepContext): void {
@@ -513,10 +549,12 @@ export class AgentGoalService extends Disposable implements IAgentGoalService {
   }
 
   private stopAfterBudgetReached(ctx: AfterStepContext): boolean {
+    const goalId = this.goalDrivenTurns.get(ctx.turnId);
     const state = this.goalState;
     if (
-      !this.goalDrivenTurns.has(ctx.turnId) ||
+      goalId === undefined ||
       state === null ||
+      state.goalId !== goalId ||
       !this.toSnapshot(state).budget.overBudget
     ) {
       return false;
@@ -540,7 +578,12 @@ export class AgentGoalService extends Disposable implements IAgentGoalService {
 
   private enqueueGoalOutcomeContinuation(ctx: AfterStepContext): void {
     if (this.goalOutcomeContinuationTurns.has(ctx.turnId)) return;
-    if (!this.goalOutcomeToolResultTurns.delete(ctx.turnId)) return;
+    const goalId = this.goalDrivenTurns.get(ctx.turnId);
+    const outcomeGoalId = this.goalOutcomeToolResultTurns.get(ctx.turnId);
+    this.goalOutcomeToolResultTurns.delete(ctx.turnId);
+    if (goalId === undefined || outcomeGoalId !== goalId) return;
+    const state = this.goalState;
+    if (state !== null && state.goalId !== goalId) return;
     this.goalOutcomeContinuationTurns.add(ctx.turnId);
     const maxSteps = this.config.get<LoopControl>(LOOP_CONTROL_SECTION)?.maxStepsPerTurn;
     if (!hasStepBudgetRemaining(maxSteps, ctx.step)) return;
@@ -551,38 +594,45 @@ export class AgentGoalService extends Disposable implements IAgentGoalService {
     turnId: number,
     result: Pick<TurnEndedEvent, 'reason' | 'error'>,
   ): Promise<void> {
-    const starterTurn = this.clearTurnTracking(turnId);
+    const { goalId, starterTurn } = this.clearTurnTracking(turnId);
+    if (goalId === undefined) return;
     if (
       result.reason === 'blocked' ||
       result.reason === 'cancelled' ||
       result.reason === 'failed'
     ) {
-      await this.settleAbnormalTurn(result);
+      await this.settleAbnormalTurn(result, goalId);
       return;
     }
-    if (starterTurn) await this.incrementTurn();
+    if (starterTurn) this.incrementGoalTurn(goalId);
 
     const state = this.goalState;
-    if (state === null || state.status !== 'active') return;
+    if (state === null || state.status !== 'active' || state.goalId !== goalId) return;
     if (this.blockIfBudgetReached(state) !== null) return;
-    this.launchContinuationTurn();
+    this.launchContinuationTurn(goalId);
   }
 
-  private clearTurnTracking(turnId: number): boolean {
+  private clearTurnTracking(
+    turnId: number,
+  ): { readonly goalId?: string; readonly starterTurn: boolean } {
     if (this.pendingContinuation?.turnId === turnId) this.pendingContinuation = undefined;
     if (this.liveTurnId === turnId) this.liveTurnId = undefined;
+    const goalId = this.goalDrivenTurns.get(turnId);
     const starterTurn = this.goalStarterTurns.delete(turnId);
     this.goalDrivenTurns.delete(turnId);
     this.countedGoalTurns.delete(turnId);
     this.goalOutcomeToolResultTurns.delete(turnId);
     this.goalOutcomeContinuationTurns.delete(turnId);
     this.budgetGraceTurns.delete(turnId);
-    return starterTurn;
+    this.pendingContinuationGoals.delete(turnId);
+    return { goalId, starterTurn };
   }
 
   private async settleAbnormalTurn(
     result: Pick<TurnEndedEvent, 'reason' | 'error'>,
+    goalId: string,
   ): Promise<boolean> {
+    if (!this.isActiveGoal(goalId)) return false;
     if (result.reason === 'blocked') {
       await this.markBlocked({ reason: 'Blocked by UserPromptSubmit hook' });
       return true;
@@ -598,7 +648,11 @@ export class AgentGoalService extends Disposable implements IAgentGoalService {
     return false;
   }
 
-  private async settleGoalAfterContinuationFailure(error: unknown): Promise<void> {
+  private async settleGoalAfterContinuationFailure(
+    error: unknown,
+    goalId: string | undefined,
+  ): Promise<void> {
+    if (goalId === undefined || !this.isActiveGoal(goalId)) return;
     try {
       const reason = pauseReasonWithMessage(
         GOAL_CONTINUATION_FAILURE_PAUSE_PREFIX,
@@ -608,7 +662,8 @@ export class AgentGoalService extends Disposable implements IAgentGoalService {
     } catch {}
   }
 
-  private launchContinuationTurn(): void {
+  private launchContinuationTurn(goalId: string): void {
+    if (!this.isActiveGoal(goalId)) return;
     if (this.pendingContinuation !== undefined) return;
     const message: ContextMessage = {
       role: 'user',
@@ -621,14 +676,18 @@ export class AgentGoalService extends Disposable implements IAgentGoalService {
       admission: 'newTurn',
     });
     const receipt = this.loopService.enqueue(request);
-    const pending: PendingContinuation = { receipt };
+    const pending: PendingContinuation = { receipt, goalId };
     this.pendingContinuation = pending;
     void receipt.assigned
       .then(({ turn }) => {
-        if (this.pendingContinuation === pending) pending.turnId = turn.id;
+        pending.turnId = turn.id;
+        if (!this.goalDrivenTurns.has(turn.id)) {
+          this.pendingContinuationGoals.set(turn.id, pending.goalId);
+        }
         return turn.result;
       })
       .finally(() => {
+        if (pending.turnId !== undefined) this.pendingContinuationGoals.delete(pending.turnId);
         if (this.pendingContinuation === pending) this.pendingContinuation = undefined;
       });
   }
@@ -637,6 +696,18 @@ export class AgentGoalService extends Disposable implements IAgentGoalService {
     if (this.liveTurnId !== undefined || this.pendingContinuation !== undefined) return false;
     const status = this.loopService.status();
     return status.state === 'idle' && !status.hasPendingRequests;
+  }
+
+  private isActiveGoal(goalId: string): boolean {
+    const state = this.goalState;
+    return state?.status === 'active' && state.goalId === goalId;
+  }
+
+  private isStaleGoalToolCall(turnId: number, toolName: string): boolean {
+    if (!isGoalMutationTool(toolName)) return false;
+    const goalId = this.goalDrivenTurns.get(turnId);
+    if (goalId === undefined) return false;
+    return this.goalState?.goalId !== goalId;
   }
 
   private cancelPendingContinuation(preserveLiveContinuation = false): void {
@@ -800,6 +871,14 @@ function computeBudgetReport(state: GoalState, wallClockMs: number): GoalBudgetR
     wallClockBudgetReached,
     overBudget: tokenBudgetReached || turnBudgetReached || wallClockBudgetReached,
   };
+}
+
+function matchesGoal(state: GoalState, goalId: string | undefined): boolean {
+  return goalId === undefined || state.goalId === goalId;
+}
+
+function isGoalMutationTool(toolName: string): boolean {
+  return toolName === 'UpdateGoal' || toolName === 'SetGoalBudget';
 }
 
 function goalBudgetBlockReason(budget: GoalBudgetReport): string | undefined {

--- a/packages/agent-core-v2/src/agent/goal/goalService.ts
+++ b/packages/agent-core-v2/src/agent/goal/goalService.ts
@@ -788,13 +788,13 @@ export class AgentGoalService extends Disposable implements IAgentGoalService {
     const wallClockMs = this.settleWallClock(state);
     if (status === 'active') {
       this.wallClockResumedAt = Date.now();
-      this.adoptStarterTurn(actor);
     } else if (state.status === 'active') {
       this.cancelPendingContinuation();
       this.wallClockResumedAt = undefined;
     }
     this.wire.dispatch(updateGoal({ status, reason, wallClockMs, actor }));
     const next = this.requireState();
+    if (status === 'active') this.adoptStarterTurn(actor);
     this.emitGoalUpdated(this.toSnapshot(next), { kind: 'lifecycle', status, reason, actor });
     this.trackStatusChanged(next, actor);
     return this.toSnapshot(next);

--- a/packages/agent-core-v2/src/agent/goal/goalService.ts
+++ b/packages/agent-core-v2/src/agent/goal/goalService.ts
@@ -304,6 +304,10 @@ export class AgentGoalService extends Disposable implements IAgentGoalService {
     return this.toSnapshot(state);
   }
 
+  isGoalToolTarget(turnId: number, goalId: string): boolean {
+    return this.goalTurnTargets.get(turnId) === goalId;
+  }
+
   async createGoal(input: CreateGoalInput, actor: GoalActor = 'user'): Promise<GoalSnapshot> {
     const objective = this.validateObjective(input.objective);
     this.prepareForGoalCreation(input.replace === true);
@@ -526,12 +530,8 @@ export class AgentGoalService extends Disposable implements IAgentGoalService {
     const state = this.goalState;
     if (state === null || state.status !== 'active') return;
     const goalId = this.goalDrivenTurns.get(turnId);
-    if (goalId !== undefined) {
-      if (actor === 'model' && goalId !== state.goalId) {
-        this.goalTurnTargets.set(turnId, state.goalId);
-      }
-      return;
-    }
+    if (actor === 'model') this.goalTurnTargets.set(turnId, state.goalId);
+    if (goalId !== undefined) return;
     this.goalDrivenTurns.set(turnId, state.goalId);
     this.countedGoalTurns.add(turnId);
     this.goalStarterTurns.add(turnId);
@@ -724,7 +724,6 @@ export class AgentGoalService extends Disposable implements IAgentGoalService {
     if (!isGoalMutationTool(toolName)) return false;
     const goalId = this.goalTurnTarget(ctx.turnId);
     if (goalId === undefined) return false;
-    if (isTerminalUpdateAfterEarlierReplacement(ctx)) return true;
     return this.goalState?.goalId !== goalId;
   }
 
@@ -901,25 +900,6 @@ function matchesGoal(state: GoalState, goalId: string | undefined): boolean {
 
 function isGoalMutationTool(toolName: string): boolean {
   return toolName === 'CreateGoal' || toolName === 'UpdateGoal' || toolName === 'SetGoalBudget';
-}
-
-function isTerminalUpdateAfterEarlierReplacement(ctx: ToolBeforeExecuteContext): boolean {
-  if (ctx.toolCall.name !== 'UpdateGoal' || !isPlainRecord(ctx.args)) return false;
-  const status = ctx.args['status'];
-  if (status !== 'complete' && status !== 'blocked') return false;
-  const currentIndex = ctx.toolCalls.findIndex((call) => call.id === ctx.toolCall.id);
-  if (currentIndex <= 0) return false;
-  return ctx.toolCalls.slice(0, currentIndex).some(isGoalReplacementCall);
-}
-
-function isGoalReplacementCall(call: ToolBeforeExecuteContext['toolCall']): boolean {
-  if (call.name !== 'CreateGoal' || call.arguments === null) return false;
-  try {
-    const args = JSON.parse(call.arguments) as unknown;
-    return isPlainRecord(args) && args['replace'] === true;
-  } catch {
-    return false;
-  }
 }
 
 function goalBudgetBlockReason(budget: GoalBudgetReport): string | undefined {

--- a/packages/agent-core-v2/src/agent/goal/goalService.ts
+++ b/packages/agent-core-v2/src/agent/goal/goalService.ts
@@ -202,6 +202,7 @@ export class AgentGoalService extends Disposable implements IAgentGoalService {
   private readonly goalOutcomeContinuationTurns = new Set<number>();
   private readonly budgetGraceTurns = new Set<number>();
   private readonly pendingContinuationGoals = new Map<number, string>();
+  private readonly goalTurnTargets = new Map<number, string>();
   private pendingContinuation?: PendingContinuation;
 
   constructor(
@@ -267,7 +268,7 @@ export class AgentGoalService extends Disposable implements IAgentGoalService {
     );
     this._register(
       toolExecutor.hooks.onDidExecuteTool.register('goal-outcome-tool-result', async (ctx, next) => {
-        const goalId = this.goalDrivenTurns.get(ctx.turnId);
+        const goalId = this.goalTurnTarget(ctx.turnId);
         if (
           goalId !== undefined &&
           isTerminalUpdateGoalResult(ctx.toolCall.name, ctx.args, ctx.result)
@@ -279,7 +280,7 @@ export class AgentGoalService extends Disposable implements IAgentGoalService {
     );
     this._register(
       this.eventBus.subscribe('turn.ended', (e) => {
-        const goalId = this.goalDrivenTurns.get(e.turnId);
+        const goalId = this.goalTurnTarget(e.turnId);
         void this.handleTurnEnded(e.turnId, { reason: e.reason, error: e.error }).catch((error) =>
           this.settleGoalAfterContinuationFailure(error, goalId),
         );
@@ -313,7 +314,7 @@ export class AgentGoalService extends Disposable implements IAgentGoalService {
       }),
     );
     this.wallClockResumedAt = Date.now();
-    this.adoptStarterTurn();
+    this.adoptStarterTurn(actor);
     const state = this.requireState();
     this.emitGoalUpdated(this.toSnapshot(state));
     this.telemetry.track2('goal_created', { actor, replace: input.replace === true });
@@ -501,6 +502,7 @@ export class AgentGoalService extends Disposable implements IAgentGoalService {
 
   private handleTurnLaunched(turnId: number, origin: TurnStartedEvent['origin']): void {
     this.liveTurnId = turnId;
+    this.goalTurnTargets.delete(turnId);
     if (!this.goalDrivenTurns.has(turnId)) {
       const state = this.goalState;
       const continuationGoalId = isGoalContinuationOrigin(origin)
@@ -517,11 +519,18 @@ export class AgentGoalService extends Disposable implements IAgentGoalService {
     this.goalOutcomeContinuationTurns.delete(turnId);
   }
 
-  private adoptStarterTurn(): void {
+  private adoptStarterTurn(actor: GoalActor): void {
     const turnId = this.liveTurnId;
-    if (turnId === undefined || this.goalDrivenTurns.has(turnId)) return;
+    if (turnId === undefined) return;
     const state = this.goalState;
     if (state === null || state.status !== 'active') return;
+    const goalId = this.goalDrivenTurns.get(turnId);
+    if (goalId !== undefined) {
+      if (actor === 'model' && goalId !== state.goalId) {
+        this.goalTurnTargets.set(turnId, state.goalId);
+      }
+      return;
+    }
     this.goalDrivenTurns.set(turnId, state.goalId);
     this.countedGoalTurns.add(turnId);
     this.goalStarterTurns.add(turnId);
@@ -549,7 +558,7 @@ export class AgentGoalService extends Disposable implements IAgentGoalService {
   }
 
   private stopAfterBudgetReached(ctx: AfterStepContext): boolean {
-    const goalId = this.goalDrivenTurns.get(ctx.turnId);
+    const goalId = this.goalTurnTarget(ctx.turnId);
     const state = this.goalState;
     if (
       goalId === undefined ||
@@ -578,7 +587,7 @@ export class AgentGoalService extends Disposable implements IAgentGoalService {
 
   private enqueueGoalOutcomeContinuation(ctx: AfterStepContext): void {
     if (this.goalOutcomeContinuationTurns.has(ctx.turnId)) return;
-    const goalId = this.goalDrivenTurns.get(ctx.turnId);
+    const goalId = this.goalTurnTarget(ctx.turnId);
     const outcomeGoalId = this.goalOutcomeToolResultTurns.get(ctx.turnId);
     this.goalOutcomeToolResultTurns.delete(ctx.turnId);
     if (goalId === undefined || outcomeGoalId !== goalId) return;
@@ -594,30 +603,35 @@ export class AgentGoalService extends Disposable implements IAgentGoalService {
     turnId: number,
     result: Pick<TurnEndedEvent, 'reason' | 'error'>,
   ): Promise<void> {
-    const { goalId, starterTurn } = this.clearTurnTracking(turnId);
-    if (goalId === undefined) return;
+    const { goalId, lifecycleGoalId, starterTurn } = this.clearTurnTracking(turnId);
+    if (goalId === undefined || lifecycleGoalId === undefined) return;
     if (
       result.reason === 'blocked' ||
       result.reason === 'cancelled' ||
       result.reason === 'failed'
     ) {
-      await this.settleAbnormalTurn(result, goalId);
+      await this.settleAbnormalTurn(result, lifecycleGoalId);
       return;
     }
     if (starterTurn) this.incrementGoalTurn(goalId);
 
     const state = this.goalState;
-    if (state === null || state.status !== 'active' || state.goalId !== goalId) return;
+    if (state === null || state.status !== 'active' || state.goalId !== lifecycleGoalId) return;
     if (this.blockIfBudgetReached(state) !== null) return;
-    this.launchContinuationTurn(goalId);
+    this.launchContinuationTurn(lifecycleGoalId);
   }
 
   private clearTurnTracking(
     turnId: number,
-  ): { readonly goalId?: string; readonly starterTurn: boolean } {
+  ): {
+    readonly goalId?: string;
+    readonly lifecycleGoalId?: string;
+    readonly starterTurn: boolean;
+  } {
     if (this.pendingContinuation?.turnId === turnId) this.pendingContinuation = undefined;
     if (this.liveTurnId === turnId) this.liveTurnId = undefined;
     const goalId = this.goalDrivenTurns.get(turnId);
+    const lifecycleGoalId = this.goalTurnTarget(turnId);
     const starterTurn = this.goalStarterTurns.delete(turnId);
     this.goalDrivenTurns.delete(turnId);
     this.countedGoalTurns.delete(turnId);
@@ -625,7 +639,8 @@ export class AgentGoalService extends Disposable implements IAgentGoalService {
     this.goalOutcomeContinuationTurns.delete(turnId);
     this.budgetGraceTurns.delete(turnId);
     this.pendingContinuationGoals.delete(turnId);
-    return { goalId, starterTurn };
+    this.goalTurnTargets.delete(turnId);
+    return { goalId, lifecycleGoalId, starterTurn };
   }
 
   private async settleAbnormalTurn(
@@ -705,9 +720,13 @@ export class AgentGoalService extends Disposable implements IAgentGoalService {
 
   private isStaleGoalToolCall(turnId: number, toolName: string): boolean {
     if (!isGoalMutationTool(toolName)) return false;
-    const goalId = this.goalDrivenTurns.get(turnId);
+    const goalId = this.goalTurnTarget(turnId);
     if (goalId === undefined) return false;
     return this.goalState?.goalId !== goalId;
+  }
+
+  private goalTurnTarget(turnId: number): string | undefined {
+    return this.goalTurnTargets.get(turnId) ?? this.goalDrivenTurns.get(turnId);
   }
 
   private cancelPendingContinuation(preserveLiveContinuation = false): void {
@@ -769,7 +788,7 @@ export class AgentGoalService extends Disposable implements IAgentGoalService {
     const wallClockMs = this.settleWallClock(state);
     if (status === 'active') {
       this.wallClockResumedAt = Date.now();
-      this.adoptStarterTurn();
+      this.adoptStarterTurn(actor);
     } else if (state.status === 'active') {
       this.cancelPendingContinuation();
       this.wallClockResumedAt = undefined;

--- a/packages/agent-core-v2/src/agent/goal/goalService.ts
+++ b/packages/agent-core-v2/src/agent/goal/goalService.ts
@@ -878,7 +878,7 @@ function matchesGoal(state: GoalState, goalId: string | undefined): boolean {
 }
 
 function isGoalMutationTool(toolName: string): boolean {
-  return toolName === 'UpdateGoal' || toolName === 'SetGoalBudget';
+  return toolName === 'CreateGoal' || toolName === 'UpdateGoal' || toolName === 'SetGoalBudget';
 }
 
 function goalBudgetBlockReason(budget: GoalBudgetReport): string | undefined {

--- a/packages/agent-core-v2/src/agent/goal/tools/create-goal.ts
+++ b/packages/agent-core-v2/src/agent/goal/tools/create-goal.ts
@@ -46,11 +46,19 @@ export class CreateGoalTool implements BuiltinTool<CreateGoalToolInput> {
   ) {}
 
   resolveExecution(args: CreateGoalToolInput): ToolExecution {
+    const goalAtResolution = this.goal.getGoal().goal;
     return {
       description: 'Creating a goal',
       display: this.resolveGoalStartDisplay(args),
       approvalRule: this.name,
-      execute: async () => {
+      execute: async ({ turnId }) => {
+        const currentGoal = this.goal.getGoal().goal;
+        if (
+          currentGoal?.goalId !== goalAtResolution?.goalId &&
+          (currentGoal === null || !this.goal.isGoalToolTarget(turnId, currentGoal.goalId))
+        ) {
+          return { output: 'Goal not created: the current goal changed.' };
+        }
         const snapshot = await this.goal.createGoal(
           {
             objective: args.objective,

--- a/packages/agent-core-v2/src/agent/goal/tools/set-goal-budget.ts
+++ b/packages/agent-core-v2/src/agent/goal/tools/set-goal-budget.ts
@@ -14,7 +14,7 @@ import type { BuiltinTool, ToolExecution } from '#/tool/toolContract';
 import { registerTool } from '#/agent/toolRegistry/toolContribution';
 
 import { IAgentGoalService } from '#/agent/goal/goal';
-import type { GoalBudgetLimits } from '#/agent/goal/types';
+import type { GoalBudgetLimits, GoalSnapshot } from '#/agent/goal/types';
 import DESCRIPTION from './set-goal-budget.md?raw';
 
 const MIN_REASONABLE_TIME_BUDGET_MS = 1_000;
@@ -40,7 +40,11 @@ export class SetGoalBudgetTool implements BuiltinTool<SetGoalBudgetToolInput> {
   resolveExecution(args: SetGoalBudgetToolInput): ToolExecution {
     const normalizedArgs = normalizeBudgetInput(args);
     const budget = budgetLimitsFromInput(normalizedArgs);
-    const overBudgetAfterSet = budget !== null && this.wouldExceedBudget(budget);
+    const goalAtResolution = this.goal.getGoal().goal;
+    const overBudgetAfterSet =
+      budget !== null &&
+      goalAtResolution !== null &&
+      this.wouldExceedBudget(goalAtResolution, budget);
     return {
       description: `Setting goal budget: ${formatBudget(
         normalizedArgs.value,
@@ -49,8 +53,12 @@ export class SetGoalBudgetTool implements BuiltinTool<SetGoalBudgetToolInput> {
       stopBatchAfterThis: overBudgetAfterSet,
       approvalRule: this.name,
       execute: async () => {
-        if (this.goal.getGoal().goal === null) {
+        const currentGoal = this.goal.getGoal().goal;
+        if (goalAtResolution === null && currentGoal === null) {
           return { output: 'Goal budget not set: no current goal.' };
+        }
+        if (goalAtResolution === null || currentGoal?.goalId !== goalAtResolution.goalId) {
+          return { output: 'Goal budget not set: the current goal changed.' };
         }
         if (budget === null) {
           return {
@@ -75,9 +83,7 @@ export class SetGoalBudgetTool implements BuiltinTool<SetGoalBudgetToolInput> {
     };
   }
 
-  private wouldExceedBudget(newLimits: GoalBudgetLimits): boolean {
-    const goal = this.goal.getGoal().goal;
-    if (goal === null) return false;
+  private wouldExceedBudget(goal: GoalSnapshot, newLimits: GoalBudgetLimits): boolean {
     const current = goal.budget;
     const turnBudget = newLimits.turnBudget ?? current.turnBudget;
     const tokenBudget = newLimits.tokenBudget ?? current.tokenBudget;

--- a/packages/agent-core-v2/src/agent/goal/tools/set-goal-budget.ts
+++ b/packages/agent-core-v2/src/agent/goal/tools/set-goal-budget.ts
@@ -54,10 +54,10 @@ export class SetGoalBudgetTool implements BuiltinTool<SetGoalBudgetToolInput> {
       approvalRule: this.name,
       execute: async () => {
         const currentGoal = this.goal.getGoal().goal;
-        if (goalAtResolution === null && currentGoal === null) {
+        if (currentGoal === null) {
           return { output: 'Goal budget not set: no current goal.' };
         }
-        if (goalAtResolution === null || currentGoal?.goalId !== goalAtResolution.goalId) {
+        if (goalAtResolution !== null && currentGoal.goalId !== goalAtResolution.goalId) {
           return { output: 'Goal budget not set: the current goal changed.' };
         }
         if (budget === null) {

--- a/packages/agent-core-v2/src/agent/goal/tools/set-goal-budget.ts
+++ b/packages/agent-core-v2/src/agent/goal/tools/set-goal-budget.ts
@@ -52,12 +52,15 @@ export class SetGoalBudgetTool implements BuiltinTool<SetGoalBudgetToolInput> {
       )}`,
       stopBatchAfterThis: overBudgetAfterSet,
       approvalRule: this.name,
-      execute: async () => {
+      execute: async ({ turnId }) => {
         const currentGoal = this.goal.getGoal().goal;
         if (currentGoal === null) {
           return { output: 'Goal budget not set: no current goal.' };
         }
-        if (goalAtResolution !== null && currentGoal.goalId !== goalAtResolution.goalId) {
+        if (
+          currentGoal.goalId !== goalAtResolution?.goalId &&
+          !this.goal.isGoalToolTarget(turnId, currentGoal.goalId)
+        ) {
           return { output: 'Goal budget not set: the current goal changed.' };
         }
         if (budget === null) {

--- a/packages/agent-core-v2/src/agent/goal/tools/set-goal-budget.ts
+++ b/packages/agent-core-v2/src/agent/goal/tools/set-goal-budget.ts
@@ -57,6 +57,9 @@ export class SetGoalBudgetTool implements BuiltinTool<SetGoalBudgetToolInput> {
         if (currentGoal === null) {
           return { output: 'Goal budget not set: no current goal.' };
         }
+        if (goalAtResolution !== null && currentGoal.goalId !== goalAtResolution.goalId) {
+          return { output: 'Goal budget not set: the current goal changed.' };
+        }
         if (budget === null) {
           return {
             output:

--- a/packages/agent-core-v2/src/agent/goal/tools/set-goal-budget.ts
+++ b/packages/agent-core-v2/src/agent/goal/tools/set-goal-budget.ts
@@ -57,9 +57,6 @@ export class SetGoalBudgetTool implements BuiltinTool<SetGoalBudgetToolInput> {
         if (currentGoal === null) {
           return { output: 'Goal budget not set: no current goal.' };
         }
-        if (goalAtResolution !== null && currentGoal.goalId !== goalAtResolution.goalId) {
-          return { output: 'Goal budget not set: the current goal changed.' };
-        }
         if (budget === null) {
           return {
             output:

--- a/packages/agent-core-v2/src/agent/goal/tools/update-goal.ts
+++ b/packages/agent-core-v2/src/agent/goal/tools/update-goal.ts
@@ -60,10 +60,10 @@ export class UpdateGoalTool implements BuiltinTool<UpdateGoalToolInput> {
       approvalRule: this.name,
       execute: async () => {
         const goalAtExecution = this.goal.getGoal().goal;
-        if (currentGoal === null) {
+        if (goalAtExecution === null || (currentGoal === null && status === 'active')) {
           return { output: missingGoalOutput(status) };
         }
-        if (goalAtExecution?.goalId !== currentGoal.goalId) {
+        if (currentGoal !== null && goalAtExecution.goalId !== currentGoal.goalId) {
           return { output: changedGoalOutput(status) };
         }
         if (status === 'active') {

--- a/packages/agent-core-v2/src/agent/goal/tools/update-goal.ts
+++ b/packages/agent-core-v2/src/agent/goal/tools/update-goal.ts
@@ -59,10 +59,14 @@ export class UpdateGoalTool implements BuiltinTool<UpdateGoalToolInput> {
       stopBatchAfterThis: status !== 'active' && goalIsActive,
       approvalRule: this.name,
       execute: async () => {
+        const goalAtExecution = this.goal.getGoal().goal;
+        if (currentGoal === null) {
+          return { output: missingGoalOutput(status) };
+        }
+        if (goalAtExecution?.goalId !== currentGoal.goalId) {
+          return { output: changedGoalOutput(status) };
+        }
         if (status === 'active') {
-          if (currentGoal === null) {
-            return { output: 'Goal not resumed: no current goal.' };
-          }
           await this.goal.resumeGoal({}, 'model');
           return { output: 'Goal resumed.' };
         }
@@ -91,6 +95,18 @@ export class UpdateGoalTool implements BuiltinTool<UpdateGoalToolInput> {
 
 function isUpdateGoalStatus(status: unknown): status is UpdateGoalToolInput['status'] {
   return status === 'active' || status === 'complete' || status === 'blocked';
+}
+
+function missingGoalOutput(status: UpdateGoalToolInput['status']): string {
+  if (status === 'active') return 'Goal not resumed: no current goal.';
+  if (status === 'complete') return 'Goal not completed: no active goal.';
+  return 'Goal not blocked: no active goal.';
+}
+
+function changedGoalOutput(status: UpdateGoalToolInput['status']): string {
+  if (status === 'active') return 'Goal not resumed: the current goal changed.';
+  if (status === 'complete') return 'Goal not completed: the current goal changed.';
+  return 'Goal not blocked: the current goal changed.';
 }
 
 registerTool(UpdateGoalTool, {

--- a/packages/agent-core-v2/src/agent/goal/tools/update-goal.ts
+++ b/packages/agent-core-v2/src/agent/goal/tools/update-goal.ts
@@ -58,12 +58,15 @@ export class UpdateGoalTool implements BuiltinTool<UpdateGoalToolInput> {
       description: `Setting goal status: ${status}`,
       stopBatchAfterThis: status !== 'active' && goalIsActive,
       approvalRule: this.name,
-      execute: async () => {
+      execute: async ({ turnId }) => {
         const goalAtExecution = this.goal.getGoal().goal;
         if (goalAtExecution === null || (currentGoal === null && status === 'active')) {
           return { output: missingGoalOutput(status) };
         }
-        if (currentGoal !== null && goalAtExecution.goalId !== currentGoal.goalId) {
+        if (
+          goalAtExecution.goalId !== currentGoal?.goalId &&
+          !this.goal.isGoalToolTarget(turnId, goalAtExecution.goalId)
+        ) {
           return { output: changedGoalOutput(status) };
         }
         if (status === 'active') {

--- a/packages/agent-core-v2/test/agent/goal/goal.test.ts
+++ b/packages/agent-core-v2/test/agent/goal/goal.test.ts
@@ -694,6 +694,7 @@ describe('AgentGoalService core workflow hooks', () => {
   });
 
   it.each([
+    { name: 'CreateGoal', args: { objective: 'late task', replace: true } },
     { name: 'UpdateGoal', args: { status: 'complete' } },
     { name: 'SetGoalBudget', args: { value: 5, unit: 'turns' } },
   ])('rejects a stale $name call from a replaced goal turn', async ({ name, args }) => {

--- a/packages/agent-core-v2/test/agent/goal/goal.test.ts
+++ b/packages/agent-core-v2/test/agent/goal/goal.test.ts
@@ -642,6 +642,59 @@ describe('AgentGoalService core workflow hooks', () => {
     });
   });
 
+  it.each([{ status: 'paused' as const }, { status: 'blocked' as const }])(
+    'queues a continuation when a live non-goal turn resumes a $status goal',
+    async ({ status }) => {
+      await goals.createGoal({ objective: 'finish the task' });
+      if (status === 'paused') {
+        await goals.pauseGoal();
+      } else {
+        await goals.markBlocked({ reason: 'need credentials' });
+      }
+      const turn = makeTurn(49);
+      eventBus.publish({ type: 'turn.started', turnId: turn.id, origin: USER_PROMPT_ORIGIN });
+      await loopService.hooks.onWillBeginStep.run({
+        turnId: turn.id,
+        step: 1,
+        signal: turn.signal,
+      });
+
+      await goals.resumeGoal();
+      endTurn(eventBus, turn);
+
+      await vi.waitFor(() => {
+        expect(loopService.launches).toHaveLength(1);
+      });
+      expect(loopService.drainNextBatch(context)).toBeDefined();
+      expect(context.get().at(-1)?.origin).toEqual({
+        kind: 'system_trigger',
+        name: 'goal_continuation',
+      });
+    },
+  );
+
+  it('records a live non-goal turn against the paused goal it resumes', async () => {
+    await goals.createGoal({ objective: 'finish the task' });
+    await goals.pauseGoal();
+    const turn = makeTurn(50);
+    eventBus.publish({ type: 'turn.started', turnId: turn.id, origin: USER_PROMPT_ORIGIN });
+    await loopService.hooks.onWillBeginStep.run({
+      turnId: turn.id,
+      step: 1,
+      signal: turn.signal,
+    });
+
+    await goals.resumeGoal();
+    recordStepUsage(usageService, goals, turn, { ...zeroUsage, output: 5 });
+    endTurn(eventBus, turn);
+
+    expect(goals.getGoal().goal).toMatchObject({
+      status: 'active',
+      turnsUsed: 1,
+      tokensUsed: 5,
+    });
+  });
+
   it('aborts a live continuation when the user pauses the goal', async () => {
     const abort = await startLiveContinuation();
 

--- a/packages/agent-core-v2/test/agent/goal/goal.test.ts
+++ b/packages/agent-core-v2/test/agent/goal/goal.test.ts
@@ -16,6 +16,7 @@ import { UpdateGoalTool, UpdateGoalToolInputSchema } from '#/agent/goal/tools/up
 import { IAgentLoopService, type AfterStepContext, type EnqueueReceipt, type Step, type Turn } from '#/agent/loop/loop';
 import { MessageStepRequest } from '#/agent/loop/stepRequest';
 import { IAgentToolExecutorService } from '#/agent/toolExecutor/toolExecutor';
+import type { ToolBeforeExecuteContext } from '#/agent/toolExecutor/toolHooks';
 import { IAgentUsageService } from '#/agent/usage/usage';
 import type { WireRecord } from '#/wire/record';
 import { type DomainEvent, IEventBus } from '#/app/event/eventBus';
@@ -643,6 +644,146 @@ describe('AgentGoalService core workflow hooks', () => {
     await goals.createGoal({ objective: 'new task', replace: true });
 
     expect(abort).toHaveBeenCalledOnce();
+  });
+
+  it('keeps a replacement goal isolated from late user-turn accounting', async () => {
+    await goals.createGoal({ objective: 'old task' });
+    const oldTurn = makeTurn(42);
+    eventBus.publish({ type: 'turn.started', turnId: oldTurn.id, origin: USER_PROMPT_ORIGIN });
+
+    const replacement = await goals.createGoal({ objective: 'new task', replace: true });
+    await loopService.hooks.onWillBeginStep.run({
+      turnId: oldTurn.id,
+      step: 1,
+      signal: oldTurn.signal,
+    });
+    recordStepUsage(usageService, goals, oldTurn, { ...zeroUsage, output: 5 });
+    endTurn(eventBus, oldTurn);
+
+    expect(goals.getGoal().goal).toMatchObject({
+      goalId: replacement.goalId,
+      status: 'active',
+      turnsUsed: 0,
+      tokensUsed: 0,
+    });
+    expect(loopService.hasPendingRequests()).toBe(false);
+    expect(loopService.launches).toEqual([]);
+  });
+
+  it('ignores a late outcome continuation from a replaced goal user turn', async () => {
+    await goals.createGoal({ objective: 'old task' });
+    const oldTurn = makeTurn(45);
+    eventBus.publish({ type: 'turn.started', turnId: oldTurn.id, origin: USER_PROMPT_ORIGIN });
+    const replacement = await goals.createGoal({ objective: 'new task', replace: true });
+
+    await runTerminalUpdateGoalResult(toolExecutor, oldTurn, 'complete', 'old outcome');
+    await loopService.hooks.onDidFinishStep.run({
+      turnId: oldTurn.id,
+      step: 1,
+      signal: oldTurn.signal,
+      usage: zeroUsage,
+      finishReason: 'completed',
+      stopTurn: false,
+    });
+
+    expect(loopService.hasPendingRequests()).toBe(false);
+    expect(goals.getGoal().goal).toMatchObject({
+      goalId: replacement.goalId,
+      status: 'active',
+    });
+  });
+
+  it.each([
+    { name: 'UpdateGoal', args: { status: 'complete' } },
+    { name: 'SetGoalBudget', args: { value: 5, unit: 'turns' } },
+  ])('rejects a stale $name call from a replaced goal turn', async ({ name, args }) => {
+    await goals.createGoal({ objective: 'old task' });
+    const oldTurn = makeTurn(46);
+    eventBus.publish({ type: 'turn.started', turnId: oldTurn.id, origin: USER_PROMPT_ORIGIN });
+    const replacement = await goals.createGoal({ objective: 'new task', replace: true });
+    const toolCall: ToolCall = {
+      type: 'function',
+      id: 'call_stale_goal_tool',
+      name,
+      arguments: JSON.stringify(args),
+    };
+    const before: ToolBeforeExecuteContext = {
+      turnId: oldTurn.id,
+      signal: oldTurn.signal,
+      toolCall,
+      toolCalls: [toolCall],
+      args,
+      execution: { approvalRule: name, execute: async () => ({ output: 'executed' }) },
+    };
+
+    await toolExecutor.hooks.onBeforeExecuteTool.run(before);
+
+    expect(before.decision?.syntheticResult).toEqual({
+      output: 'Goal changed since this turn started; ignored stale goal tool call.',
+    });
+    expect(goals.getGoal().goal).toMatchObject({
+      goalId: replacement.goalId,
+      status: 'active',
+      turnsUsed: 0,
+      tokensUsed: 0,
+    });
+  });
+
+  it.each([
+    { reason: 'cancelled' as const },
+    { reason: 'failed' as const, error: new Error('old turn failed') },
+  ])('keeps a replacement goal active after the replaced goal turn ends as $reason', async (result) => {
+    await goals.createGoal({ objective: 'old task' });
+    const oldTurn = makeTurn(43);
+    eventBus.publish({ type: 'turn.started', turnId: oldTurn.id, origin: USER_PROMPT_ORIGIN });
+    const replacement = await goals.createGoal({ objective: 'new task', replace: true });
+
+    endTurn(eventBus, oldTurn, result);
+
+    expect(goals.getGoal().goal).toMatchObject({
+      goalId: replacement.goalId,
+      status: 'active',
+      turnsUsed: 0,
+      tokensUsed: 0,
+    });
+  });
+
+  it.each([
+    { reason: 'completed' as const },
+    { reason: 'failed' as const, error: new Error('old continuation failed') },
+  ])('keeps a replacement goal isolated when the replaced goal continuation settles as $reason', async (result) => {
+    await goals.createGoal({ objective: 'old task' });
+    const oldUserTurn = makeTurn(44);
+    eventBus.publish({ type: 'turn.started', turnId: oldUserTurn.id, origin: USER_PROMPT_ORIGIN });
+    await runGoalStep(loopService, oldUserTurn);
+    endTurn(eventBus, oldUserTurn);
+    await vi.waitFor(() => {
+      expect(loopService.launches).toHaveLength(1);
+    });
+
+    const continuationTurn = makeTurn(loopService.launches[0]!);
+    eventBus.publish({
+      type: 'turn.started',
+      turnId: continuationTurn.id,
+      origin: { kind: 'system_trigger', name: 'goal_continuation' },
+    });
+    const replacement = await goals.createGoal({ objective: 'new task', replace: true });
+
+    await loopService.hooks.onWillBeginStep.run({
+      turnId: continuationTurn.id,
+      step: 1,
+      signal: continuationTurn.signal,
+    });
+    recordStepUsage(usageService, goals, continuationTurn, { ...zeroUsage, output: 7 });
+    endTurn(eventBus, continuationTurn, result);
+
+    expect(goals.getGoal().goal).toMatchObject({
+      goalId: replacement.goalId,
+      status: 'active',
+      turnsUsed: 0,
+      tokensUsed: 0,
+    });
+    expect(loopService.launches).toHaveLength(1);
   });
 
   it.each(['turn', 'token', 'wall-clock'] as const)(

--- a/packages/agent-core-v2/test/agent/goal/goal.test.ts
+++ b/packages/agent-core-v2/test/agent/goal/goal.test.ts
@@ -15,7 +15,10 @@ import { type AgentGoalService } from '#/agent/goal/goalService';
 import { UpdateGoalTool, UpdateGoalToolInputSchema } from '#/agent/goal/tools/update-goal';
 import { IAgentLoopService, type AfterStepContext, type EnqueueReceipt, type Step, type Turn } from '#/agent/loop/loop';
 import { MessageStepRequest } from '#/agent/loop/stepRequest';
-import { IAgentToolExecutorService } from '#/agent/toolExecutor/toolExecutor';
+import {
+  IAgentToolExecutorService,
+  type ToolExecutionResult,
+} from '#/agent/toolExecutor/toolExecutor';
 import type { ToolBeforeExecuteContext } from '#/agent/toolExecutor/toolHooks';
 import { IAgentUsageService } from '#/agent/usage/usage';
 import type { WireRecord } from '#/wire/record';
@@ -29,6 +32,7 @@ import {
   InMemoryWireRecordPersistence,
   agentService,
   createTestAgent,
+  permissionModeServices,
   telemetryServices,
   testAgent,
   wireRecordPersistenceServices,
@@ -126,6 +130,21 @@ async function runTerminalUpdateGoalResult(
     args: { status },
     result: { output, stopTurn: true },
   });
+}
+
+async function executeToolCall(
+  toolExecutor: IAgentToolExecutorService,
+  turn: Turn,
+  toolCall: ToolCall,
+): Promise<ToolExecutionResult[]> {
+  const results: ToolExecutionResult[] = [];
+  for await (const result of toolExecutor.execute([toolCall], {
+    turnId: turn.id,
+    signal: turn.signal,
+  })) {
+    results.push(result);
+  }
+  return results;
 }
 
 function endTurn(
@@ -573,6 +592,7 @@ describe('AgentGoalService core workflow hooks', () => {
     loopService = stubLoopWithHooks();
     ctx = createTestAgent(
       agentService(IAgentLoopService, loopService),
+      permissionModeServices('auto'),
     );
     context = ctx.get(IAgentContextMemoryService);
     goals = ctx.get(IAgentGoalService);
@@ -644,6 +664,62 @@ describe('AgentGoalService core workflow hooks', () => {
     await goals.createGoal({ objective: 'new task', replace: true });
 
     expect(abort).toHaveBeenCalledOnce();
+  });
+
+  it('queues a continuation for a replacement goal created by its current goal turn', async () => {
+    await goals.createGoal({ objective: 'old task' });
+    const turn = makeTurn(47);
+    eventBus.publish({ type: 'turn.started', turnId: turn.id, origin: USER_PROMPT_ORIGIN });
+    await loopService.hooks.onWillBeginStep.run({
+      turnId: turn.id,
+      step: 1,
+      signal: turn.signal,
+    });
+    const toolCall: ToolCall = {
+      type: 'function',
+      id: 'call_replace_goal',
+      name: 'CreateGoal',
+      arguments: JSON.stringify({ objective: 'new task', replace: true }),
+    };
+    const results = await executeToolCall(toolExecutor, turn, toolCall);
+    expect(results[0]?.result.isError).not.toBe(true);
+
+    endTurn(eventBus, turn);
+
+    await vi.waitFor(() => {
+      expect(loopService.launches).toHaveLength(1);
+    });
+    expect(goals.getGoal().goal).toMatchObject({ objective: 'new task', status: 'active' });
+    expect(loopService.drainNextBatch(context)).toBeDefined();
+    expect(context.get().at(-1)?.origin).toEqual({
+      kind: 'system_trigger',
+      name: 'goal_continuation',
+    });
+  });
+
+  it('does not charge a same-turn replacement goal for usage owned by the prior goal', async () => {
+    await goals.createGoal({ objective: 'old task' });
+    const turn = makeTurn(48);
+    eventBus.publish({ type: 'turn.started', turnId: turn.id, origin: USER_PROMPT_ORIGIN });
+    await loopService.hooks.onWillBeginStep.run({
+      turnId: turn.id,
+      step: 1,
+      signal: turn.signal,
+    });
+    const toolCall: ToolCall = {
+      type: 'function',
+      id: 'call_replace_goal',
+      name: 'CreateGoal',
+      arguments: JSON.stringify({ objective: 'new task', replace: true }),
+    };
+    await executeToolCall(toolExecutor, turn, toolCall);
+
+    recordStepUsage(usageService, goals, turn, { ...zeroUsage, output: 5 });
+
+    expect(goals.getGoal().goal).toMatchObject({
+      objective: 'new task',
+      tokensUsed: 0,
+    });
   });
 
   it('keeps a replacement goal isolated from late user-turn accounting', async () => {

--- a/packages/agent-core-v2/test/agent/goal/tools/goal-tools.test.ts
+++ b/packages/agent-core-v2/test/agent/goal/tools/goal-tools.test.ts
@@ -128,6 +128,20 @@ describe('goal tools', () => {
     });
   });
 
+  it('SetGoalBudget does not apply a no-goal execution to an externally created goal', async () => {
+    const execution = setGoalBudgetTool.resolveExecution({ value: 5, unit: 'turns' });
+    if (execution.isError === true) throw new Error('execution should not be an error');
+    const created = await goals.createGoal({ objective: 'external task' });
+
+    const result = await execution.execute({ turnId: 0, toolCallId: 'call_old_budget', signal });
+
+    expect(result.output).toBe('Goal budget not set: the current goal changed.');
+    expect(goals.getGoal().goal).toMatchObject({
+      goalId: created.goalId,
+      budget: { turnBudget: null },
+    });
+  });
+
   it('SetGoalBudget ignores a stale call from a replaced goal turn', async () => {
     await goals.createGoal({ objective: 'old task' });
     eventBus.publish({ type: 'turn.started', turnId: 1, origin: USER_PROMPT_ORIGIN });
@@ -148,6 +162,8 @@ describe('goal tools', () => {
   });
 
   it('SetGoalBudget applies a delayed execution to a goal created earlier in the same batch', async () => {
+    eventBus.publish({ type: 'turn.started', turnId: 2, origin: USER_PROMPT_ORIGIN });
+
     const results = await executeGoalCalls(
       [
         goalToolCall('call_create', 'CreateGoal', { objective: 'new task' }),
@@ -165,7 +181,7 @@ describe('goal tools', () => {
     });
   });
 
-  it('SetGoalBudget ignores a same-batch call resolved before replacing the current goal', async () => {
+  it('SetGoalBudget applies a same-batch budget to the replacement goal', async () => {
     await goals.createGoal({ objective: 'old task' });
     eventBus.publish({ type: 'turn.started', turnId: 3, origin: USER_PROMPT_ORIGIN });
 
@@ -178,11 +194,11 @@ describe('goal tools', () => {
     );
 
     expect(results.find((result) => result.toolName === 'SetGoalBudget')?.result.output).toBe(
-      'Goal budget not set: the current goal changed.',
+      'Goal budget set: 5 turns.',
     );
     expect(goals.getGoal().goal).toMatchObject({
       objective: 'new task',
-      budget: { turnBudget: null },
+      budget: { turnBudget: 5 },
     });
   });
 
@@ -252,27 +268,48 @@ describe('goal tools', () => {
     });
   });
 
-  it('UpdateGoal lets later calls run when an earlier same-batch call replaces its goal', async () => {
-    await goals.createGoal({ objective: 'old task' });
-    eventBus.publish({ type: 'turn.started', turnId: 4, origin: USER_PROMPT_ORIGIN });
+  it('UpdateGoal does not apply a no-goal outcome to an externally created goal', async () => {
+    const execution = updateGoalTool.resolveExecution({ status: 'complete' });
+    if (execution.isError === true) throw new Error('execution should not be an error');
+    const created = await goals.createGoal({ objective: 'external task' });
 
-    const results = await executeGoalCalls(
-      [
-        goalToolCall('call_replace', 'CreateGoal', { objective: 'new task', replace: true }),
-        goalToolCall('call_old_outcome', 'UpdateGoal', { status: 'complete' }),
-        goalToolCall('call_get_replacement', 'GetGoal', {}),
-      ],
-      4,
-    );
+    const result = await execution.execute({
+      turnId: 0,
+      toolCallId: 'call_old_outcome',
+      signal,
+    });
 
-    expect(results.find((result) => result.toolName === 'UpdateGoal')?.result.output).toBe(
-      'Goal changed since this turn started; ignored stale goal tool call.',
-    );
-    expect(results.find((result) => result.toolName === 'GetGoal')?.result.output).toContain(
-      '"objective": "new task"',
-    );
-    expect(goals.getGoal().goal).toMatchObject({ objective: 'new task', status: 'active' });
+    expect(result.output).toBe('Goal not completed: the current goal changed.');
+    expect(result.stopTurn).toBeFalsy();
+    expect(goals.getGoal().goal).toMatchObject({
+      goalId: created.goalId,
+      status: 'active',
+    });
   });
+
+  it.each([
+    ['complete', null, 'Goal completed successfully'],
+    ['blocked', 'blocked', 'Goal blocked.'],
+  ] as const)(
+    'UpdateGoal applies %s to a goal replaced earlier in the same batch',
+    async (updateStatus, expectedCurrentStatus, expectedOutput) => {
+      await goals.createGoal({ objective: 'old task' });
+      eventBus.publish({ type: 'turn.started', turnId: 4, origin: USER_PROMPT_ORIGIN });
+
+      const results = await executeGoalCalls(
+        [
+          goalToolCall('call_replace', 'CreateGoal', { objective: 'new task', replace: true }),
+          goalToolCall('call_outcome', 'UpdateGoal', { status: updateStatus }),
+        ],
+        4,
+      );
+
+      const outcome = results.find((result) => result.toolName === 'UpdateGoal')?.result;
+      expect(outcome?.output).toContain(expectedOutput);
+      expect(outcome?.stopTurn).toBe(true);
+      expect(goals.getGoal().goal?.status ?? null).toBe(expectedCurrentStatus);
+    },
+  );
 
   it.each([
     ['complete', null, 'Goal completed successfully'],

--- a/packages/agent-core-v2/test/agent/goal/tools/goal-tools.test.ts
+++ b/packages/agent-core-v2/test/agent/goal/tools/goal-tools.test.ts
@@ -28,6 +28,7 @@ import {
   type ToolExecutionResult,
 } from '#/agent/toolExecutor/toolExecutor';
 import { getToolContributions } from '#/agent/toolRegistry/toolContribution';
+import { IAgentToolRegistryService } from '#/agent/toolRegistry/toolRegistry';
 import { IEventBus } from '#/app/event/eventBus';
 
 import {
@@ -64,6 +65,49 @@ describe('goal tools', () => {
 
   afterEach(async () => {
     await ctx.dispose();
+  });
+
+  it('CreateGoal does not apply a delayed execution to a replacement goal', async () => {
+    await goals.createGoal({ objective: 'old task' });
+    eventBus.publish({ type: 'turn.started', turnId: 6, origin: USER_PROMPT_ORIGIN });
+    const tool = ctx.get(IAgentToolRegistryService).resolve('CreateGoal');
+    if (tool === undefined) throw new Error('CreateGoal should be registered');
+    const execution = await tool.resolveExecution({ objective: 'stale task', replace: true });
+    if (execution.isError === true) throw new Error('execution should not be an error');
+    const replacement = await goals.createGoal({ objective: 'new task', replace: true });
+
+    const result = await execution.execute({
+      turnId: 6,
+      toolCallId: 'call_old_create',
+      signal,
+    });
+
+    expect(result.output).toBe('Goal not created: the current goal changed.');
+    expect(goals.getGoal().goal).toMatchObject({
+      goalId: replacement.goalId,
+      objective: 'new task',
+    });
+  });
+
+  it('CreateGoal does not apply a no-goal execution to an externally created goal', async () => {
+    eventBus.publish({ type: 'turn.started', turnId: 7, origin: USER_PROMPT_ORIGIN });
+    const tool = ctx.get(IAgentToolRegistryService).resolve('CreateGoal');
+    if (tool === undefined) throw new Error('CreateGoal should be registered');
+    const execution = await tool.resolveExecution({ objective: 'stale task', replace: true });
+    if (execution.isError === true) throw new Error('execution should not be an error');
+    const created = await goals.createGoal({ objective: 'external task' });
+
+    const result = await execution.execute({
+      turnId: 7,
+      toolCallId: 'call_old_create',
+      signal,
+    });
+
+    expect(result.output).toBe('Goal not created: the current goal changed.');
+    expect(goals.getGoal().goal).toMatchObject({
+      goalId: created.goalId,
+      objective: 'external task',
+    });
   });
 
   it('SetGoalBudget reports no current goal without failing', async () => {

--- a/packages/agent-core-v2/test/agent/goal/tools/goal-tools.test.ts
+++ b/packages/agent-core-v2/test/agent/goal/tools/goal-tools.test.ts
@@ -1,3 +1,9 @@
+/**
+ * Scenario: model-facing goal tool validation and delayed execution.
+ * Responsibilities: verify goal commands target the goal selected when execution is resolved.
+ * Wiring: real goal service; loop is stubbed at the agent boundary.
+ * Run: `pnpm --filter @moonshot-ai/agent-core-v2 exec vitest run test/agent/goal/tools/goal-tools.test.ts`.
+ */
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 import type { ServicesAccessor } from '#/_base/di/instantiation';
@@ -92,6 +98,21 @@ describe('goal tools', () => {
     });
   });
 
+  it('SetGoalBudget does not apply a delayed execution to a replacement goal', async () => {
+    await goals.createGoal({ objective: 'old task' });
+    const execution = setGoalBudgetTool.resolveExecution({ value: 5, unit: 'turns' });
+    if (execution.isError === true) throw new Error('execution should not be an error');
+    const replacement = await goals.createGoal({ objective: 'new task', replace: true });
+
+    const result = await execution.execute({ turnId: 0, toolCallId: 'call_old_budget', signal });
+
+    expect(result.output).toBe('Goal budget not set: the current goal changed.');
+    expect(goals.getGoal().goal).toMatchObject({
+      goalId: replacement.goalId,
+      budget: { turnBudget: null },
+    });
+  });
+
   it('UpdateGoal accepts only active / complete / blocked statuses', () => {
     for (const status of ['active', 'complete', 'blocked']) {
       expect(UpdateGoalToolInputSchema.safeParse({ status }).success).toBe(true);
@@ -140,6 +161,22 @@ describe('goal tools', () => {
     expect(result.output).toContain('Goal blocked.');
     expect(result.output).toContain('Worked');
     expect(result.output).toContain('concrete blocker');
+  });
+
+  it('UpdateGoal does not apply a delayed outcome to a replacement goal', async () => {
+    await goals.createGoal({ objective: 'old task' });
+    const execution = updateGoalTool.resolveExecution({ status: 'complete' });
+    if (execution.isError === true) throw new Error('execution should not be an error');
+    const replacement = await goals.createGoal({ objective: 'new task', replace: true });
+
+    const result = await execution.execute({ turnId: 0, toolCallId: 'call_old_outcome', signal });
+
+    expect(result.output).toBe('Goal not completed: the current goal changed.');
+    expect(result.stopTurn).toBeFalsy();
+    expect(goals.getGoal().goal).toMatchObject({
+      goalId: replacement.goalId,
+      status: 'active',
+    });
   });
 
   it('UpdateGoal reports no active goal when completing/blocking/resuming without one', async () => {

--- a/packages/agent-core-v2/test/agent/goal/tools/goal-tools.test.ts
+++ b/packages/agent-core-v2/test/agent/goal/tools/goal-tools.test.ts
@@ -113,6 +113,20 @@ describe('goal tools', () => {
     });
   });
 
+  it('SetGoalBudget applies a delayed execution to a goal created earlier in the same batch', async () => {
+    const execution = setGoalBudgetTool.resolveExecution({ value: 5, unit: 'turns' });
+    if (execution.isError === true) throw new Error('execution should not be an error');
+    const created = await goals.createGoal({ objective: 'new task' });
+
+    const result = await execution.execute({ turnId: 0, toolCallId: 'call_new_budget', signal });
+
+    expect(result.output).toBe('Goal budget set: 5 turns.');
+    expect(goals.getGoal().goal).toMatchObject({
+      goalId: created.goalId,
+      budget: { turnBudget: 5 },
+    });
+  });
+
   it('UpdateGoal accepts only active / complete / blocked statuses', () => {
     for (const status of ['active', 'complete', 'blocked']) {
       expect(UpdateGoalToolInputSchema.safeParse({ status }).success).toBe(true);

--- a/packages/agent-core-v2/test/agent/goal/tools/goal-tools.test.ts
+++ b/packages/agent-core-v2/test/agent/goal/tools/goal-tools.test.ts
@@ -7,6 +7,7 @@
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 import type { ServicesAccessor } from '#/_base/di/instantiation';
+import type { ToolCall } from '#/app/llmProtocol/message';
 import {
   compileToolArgsValidator,
   validateToolArgs,
@@ -22,10 +23,19 @@ import {
 } from '#/agent/goal/tools/update-goal';
 import { IAgentLoopService } from '#/agent/loop/loop';
 import { IAgentScopeContext } from '#/agent/scopeContext/scopeContext';
+import {
+  IAgentToolExecutorService,
+  type ToolExecutionResult,
+} from '#/agent/toolExecutor/toolExecutor';
 import { getToolContributions } from '#/agent/toolRegistry/toolContribution';
 import { IEventBus } from '#/app/event/eventBus';
 
-import { agentService, createTestAgent, type TestAgentContext } from '../../../harness';
+import {
+  agentService,
+  createTestAgent,
+  permissionModeServices,
+  type TestAgentContext,
+} from '../../../harness';
 import { stubLoopWithHooks } from '../../loop/stubs';
 
 const signal = new AbortController().signal;
@@ -35,14 +45,19 @@ describe('goal tools', () => {
   let goals: IAgentGoalService;
   let loopService: IAgentLoopService;
   let eventBus: IEventBus;
+  let toolExecutor: IAgentToolExecutorService;
   let setGoalBudgetTool: SetGoalBudgetTool;
   let updateGoalTool: UpdateGoalTool;
 
   beforeEach(() => {
     loopService = stubLoopWithHooks({ hasActiveTurn: true });
-    ctx = createTestAgent(agentService(IAgentLoopService, loopService));
+    ctx = createTestAgent(
+      agentService(IAgentLoopService, loopService),
+      permissionModeServices('auto'),
+    );
     goals = ctx.get(IAgentGoalService);
     eventBus = ctx.get(IEventBus);
+    toolExecutor = ctx.get(IAgentToolExecutorService);
     setGoalBudgetTool = new SetGoalBudgetTool(goals);
     updateGoalTool = new UpdateGoalTool(goals);
   });
@@ -98,15 +113,19 @@ describe('goal tools', () => {
     });
   });
 
-  it('SetGoalBudget does not apply a delayed execution to a replacement goal', async () => {
+  it('SetGoalBudget ignores a stale call from a replaced goal turn', async () => {
     await goals.createGoal({ objective: 'old task' });
-    const execution = setGoalBudgetTool.resolveExecution({ value: 5, unit: 'turns' });
-    if (execution.isError === true) throw new Error('execution should not be an error');
+    eventBus.publish({ type: 'turn.started', turnId: 1, origin: USER_PROMPT_ORIGIN });
     const replacement = await goals.createGoal({ objective: 'new task', replace: true });
 
-    const result = await execution.execute({ turnId: 0, toolCallId: 'call_old_budget', signal });
+    const results = await executeGoalCalls(
+      [goalToolCall('call_old_budget', 'SetGoalBudget', { value: 5, unit: 'turns' })],
+      1,
+    );
 
-    expect(result.output).toBe('Goal budget not set: the current goal changed.');
+    expect(results[0]?.result.output).toBe(
+      'Goal changed since this turn started; ignored stale goal tool call.',
+    );
     expect(goals.getGoal().goal).toMatchObject({
       goalId: replacement.goalId,
       budget: { turnBudget: null },
@@ -123,6 +142,27 @@ describe('goal tools', () => {
     expect(result.output).toBe('Goal budget set: 5 turns.');
     expect(goals.getGoal().goal).toMatchObject({
       goalId: created.goalId,
+      budget: { turnBudget: 5 },
+    });
+  });
+
+  it('SetGoalBudget applies a limit to a replacement goal created earlier in the same batch', async () => {
+    await goals.createGoal({ objective: 'old task' });
+    eventBus.publish({ type: 'turn.started', turnId: 2, origin: USER_PROMPT_ORIGIN });
+
+    const results = await executeGoalCalls(
+      [
+        goalToolCall('call_replace', 'CreateGoal', { objective: 'new task', replace: true }),
+        goalToolCall('call_budget', 'SetGoalBudget', { value: 5, unit: 'turns' }),
+      ],
+      2,
+    );
+
+    expect(results.find((result) => result.toolName === 'SetGoalBudget')?.result.output).toBe(
+      'Goal budget set: 5 turns.',
+    );
+    expect(goals.getGoal().goal).toMatchObject({
+      objective: 'new task',
       budget: { turnBudget: 5 },
     });
   });
@@ -218,6 +258,25 @@ describe('goal tools', () => {
       step: 1,
       signal: abortController.signal,
     });
+  }
+
+  async function executeGoalCalls(
+    calls: ToolCall[],
+    turnId: number,
+  ): Promise<ToolExecutionResult[]> {
+    const results: ToolExecutionResult[] = [];
+    for await (const result of toolExecutor.execute(calls, { turnId, signal })) {
+      results.push(result);
+    }
+    return results;
+  }
+
+  function goalToolCall(
+    id: string,
+    name: 'CreateGoal' | 'SetGoalBudget',
+    args: Record<string, unknown>,
+  ): ToolCall {
+    return { type: 'function', id, name, arguments: JSON.stringify(args) };
   }
 });
 

--- a/packages/agent-core-v2/test/agent/goal/tools/goal-tools.test.ts
+++ b/packages/agent-core-v2/test/agent/goal/tools/goal-tools.test.ts
@@ -252,6 +252,28 @@ describe('goal tools', () => {
     });
   });
 
+  it('UpdateGoal lets later calls run when an earlier same-batch call replaces its goal', async () => {
+    await goals.createGoal({ objective: 'old task' });
+    eventBus.publish({ type: 'turn.started', turnId: 4, origin: USER_PROMPT_ORIGIN });
+
+    const results = await executeGoalCalls(
+      [
+        goalToolCall('call_replace', 'CreateGoal', { objective: 'new task', replace: true }),
+        goalToolCall('call_old_outcome', 'UpdateGoal', { status: 'complete' }),
+        goalToolCall('call_get_replacement', 'GetGoal', {}),
+      ],
+      4,
+    );
+
+    expect(results.find((result) => result.toolName === 'UpdateGoal')?.result.output).toBe(
+      'Goal changed since this turn started; ignored stale goal tool call.',
+    );
+    expect(results.find((result) => result.toolName === 'GetGoal')?.result.output).toContain(
+      '"objective": "new task"',
+    );
+    expect(goals.getGoal().goal).toMatchObject({ objective: 'new task', status: 'active' });
+  });
+
   it('UpdateGoal reports no active goal when completing/blocking/resuming without one', async () => {
     const done = updateGoalTool.resolveExecution({ status: 'complete' });
     if (done.isError === true) throw new Error('execution should not be an error');
@@ -292,7 +314,7 @@ describe('goal tools', () => {
 
   function goalToolCall(
     id: string,
-    name: 'CreateGoal' | 'SetGoalBudget',
+    name: 'CreateGoal' | 'GetGoal' | 'SetGoalBudget' | 'UpdateGoal',
     args: Record<string, unknown>,
   ): ToolCall {
     return { type: 'function', id, name, arguments: JSON.stringify(args) };

--- a/packages/agent-core-v2/test/agent/goal/tools/goal-tools.test.ts
+++ b/packages/agent-core-v2/test/agent/goal/tools/goal-tools.test.ts
@@ -274,6 +274,29 @@ describe('goal tools', () => {
     expect(goals.getGoal().goal).toMatchObject({ objective: 'new task', status: 'active' });
   });
 
+  it.each([
+    ['complete', null, 'Goal completed successfully'],
+    ['blocked', 'blocked', 'Goal blocked.'],
+  ] as const)(
+    'UpdateGoal applies %s when the goal was created earlier in the same batch',
+    async (updateStatus, expectedCurrentStatus, expectedOutput) => {
+      eventBus.publish({ type: 'turn.started', turnId: 5, origin: USER_PROMPT_ORIGIN });
+
+      const results = await executeGoalCalls(
+        [
+          goalToolCall('call_create', 'CreateGoal', { objective: 'new task' }),
+          goalToolCall('call_outcome', 'UpdateGoal', { status: updateStatus }),
+        ],
+        5,
+      );
+
+      const outcome = results.find((result) => result.toolName === 'UpdateGoal')?.result;
+      expect(outcome?.output).toContain(expectedOutput);
+      expect(outcome?.stopTurn).toBe(true);
+      expect(goals.getGoal().goal?.status ?? null).toBe(expectedCurrentStatus);
+    },
+  );
+
   it('UpdateGoal reports no active goal when completing/blocking/resuming without one', async () => {
     const done = updateGoalTool.resolveExecution({ status: 'complete' });
     if (done.isError === true) throw new Error('execution should not be an error');

--- a/packages/agent-core-v2/test/agent/goal/tools/goal-tools.test.ts
+++ b/packages/agent-core-v2/test/agent/goal/tools/goal-tools.test.ts
@@ -284,7 +284,7 @@ describe('goal tools', () => {
 
       const results = await executeGoalCalls(
         [
-          goalToolCall('call_create', 'CreateGoal', { objective: 'new task' }),
+          goalToolCall('call_create', 'CreateGoal', { objective: 'new task', replace: true }),
           goalToolCall('call_outcome', 'UpdateGoal', { status: updateStatus }),
         ],
         5,

--- a/packages/agent-core-v2/test/agent/goal/tools/goal-tools.test.ts
+++ b/packages/agent-core-v2/test/agent/goal/tools/goal-tools.test.ts
@@ -113,6 +113,21 @@ describe('goal tools', () => {
     });
   });
 
+  it('SetGoalBudget does not apply a delayed execution to a replacement goal', async () => {
+    await goals.createGoal({ objective: 'old task' });
+    const execution = setGoalBudgetTool.resolveExecution({ value: 5, unit: 'turns' });
+    if (execution.isError === true) throw new Error('execution should not be an error');
+    const replacement = await goals.createGoal({ objective: 'new task', replace: true });
+
+    const result = await execution.execute({ turnId: 0, toolCallId: 'call_old_budget', signal });
+
+    expect(result.output).toBe('Goal budget not set: the current goal changed.');
+    expect(goals.getGoal().goal).toMatchObject({
+      goalId: replacement.goalId,
+      budget: { turnBudget: null },
+    });
+  });
+
   it('SetGoalBudget ignores a stale call from a replaced goal turn', async () => {
     await goals.createGoal({ objective: 'old task' });
     eventBus.publish({ type: 'turn.started', turnId: 1, origin: USER_PROMPT_ORIGIN });
@@ -133,26 +148,9 @@ describe('goal tools', () => {
   });
 
   it('SetGoalBudget applies a delayed execution to a goal created earlier in the same batch', async () => {
-    const execution = setGoalBudgetTool.resolveExecution({ value: 5, unit: 'turns' });
-    if (execution.isError === true) throw new Error('execution should not be an error');
-    const created = await goals.createGoal({ objective: 'new task' });
-
-    const result = await execution.execute({ turnId: 0, toolCallId: 'call_new_budget', signal });
-
-    expect(result.output).toBe('Goal budget set: 5 turns.');
-    expect(goals.getGoal().goal).toMatchObject({
-      goalId: created.goalId,
-      budget: { turnBudget: 5 },
-    });
-  });
-
-  it('SetGoalBudget applies a limit to a replacement goal created earlier in the same batch', async () => {
-    await goals.createGoal({ objective: 'old task' });
-    eventBus.publish({ type: 'turn.started', turnId: 2, origin: USER_PROMPT_ORIGIN });
-
     const results = await executeGoalCalls(
       [
-        goalToolCall('call_replace', 'CreateGoal', { objective: 'new task', replace: true }),
+        goalToolCall('call_create', 'CreateGoal', { objective: 'new task' }),
         goalToolCall('call_budget', 'SetGoalBudget', { value: 5, unit: 'turns' }),
       ],
       2,
@@ -164,6 +162,27 @@ describe('goal tools', () => {
     expect(goals.getGoal().goal).toMatchObject({
       objective: 'new task',
       budget: { turnBudget: 5 },
+    });
+  });
+
+  it('SetGoalBudget ignores a same-batch call resolved before replacing the current goal', async () => {
+    await goals.createGoal({ objective: 'old task' });
+    eventBus.publish({ type: 'turn.started', turnId: 3, origin: USER_PROMPT_ORIGIN });
+
+    const results = await executeGoalCalls(
+      [
+        goalToolCall('call_replace', 'CreateGoal', { objective: 'new task', replace: true }),
+        goalToolCall('call_budget', 'SetGoalBudget', { value: 5, unit: 'turns' }),
+      ],
+      3,
+    );
+
+    expect(results.find((result) => result.toolName === 'SetGoalBudget')?.result.output).toBe(
+      'Goal budget not set: the current goal changed.',
+    );
+    expect(goals.getGoal().goal).toMatchObject({
+      objective: 'new task',
+      budget: { turnBudget: null },
     });
   });
 


### PR DESCRIPTION
## Related Issue

No linked issue; the problem is described below.

## Problem

Replacing goal A with goal B while A still had an active user turn or automatic continuation allowed late asynchronous work from A to resolve against the current goal. As a result, A's usage, turn accounting, terminal outcome, cancellation or failure handling, and continuation scheduling could mutate, charge, pause, block, or drive B.

The root cause was that goal lifecycle hooks tracked only turn IDs and read the current goal when callbacks settled, without preserving the goal identity that owned the turn.

## What changed

- Bind every goal-driven turn, pending continuation, and terminal goal outcome to the originating goal ID.
- Ignore late usage, turn-end, cancellation, failure, outcome, and continuation work when that identity no longer matches the active goal.
- Reject delayed CreateGoal, UpdateGoal, and SetGoalBudget mutations from replaced-goal turns.
- Preserve the valid same-batch CreateGoal then SetGoalBudget sequence while rejecting budget execution against a different pre-existing goal.
- Add regression coverage for replacement during user turns, completed and failed automatic continuations, stale outcome delivery, delayed goal tool execution, and same-batch goal creation plus budgeting.

The change stays within the Agent-scoped goal service. It does not change persistence records, wire contracts, public APIs, or the loop scheduler.

## Validation

- `pnpm --filter @moonshot-ai/agent-core-v2 lint:domain`
- `pnpm --filter @moonshot-ai/agent-core-v2 typecheck`
- `pnpm --filter @moonshot-ai/agent-core-v2 test` (237 files, 3363 tests)
- Type-aware oxlint on changed TypeScript files (0 errors)
- `pnpm exec changeset status`
- `git diff --check`

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.