### PR TITLE
feat(web,server): allow file preview for system temp paths

### DIFF
--- a/apps/kimi-web/src/composables/useFilePreview.ts
+++ b/apps/kimi-web/src/composables/useFilePreview.ts
@@ -66,6 +66,10 @@ export function useFilePreview({ client, detailTarget }: UseFilePreviewOptions) 
     return out.join('/');
   }
 
+  function isSystemTempPath(path: string): boolean {
+    return /^\/(tmp|var\/tmp|dev\/shm)\b/.test(path);
+  }
+
   function normalizePreviewPath(inputPath: string): { path: string } | { error: string } {
     const raw = inputPath.trim();
     if (!raw) return { error: t('filePreview.errors.emptyPath') };
@@ -76,8 +80,14 @@ export function useFilePreview({ client, detailTarget }: UseFilePreviewOptions) 
       return { error: t('filePreview.errors.outsideWorkspace') };
     }
 
-    const cwd = trimTrailingSlash(client.status.value.cwd);
+    // Allow absolute paths inside system temp directories (e.g. /tmp/...)
     if (raw.startsWith('/')) {
+      if (isSystemTempPath(raw)) {
+        const normalized = normalizeRelativePath(raw);
+        return normalized ? { path: raw } : { error: t('filePreview.errors.emptyPath') };
+      }
+
+      const cwd = trimTrailingSlash(client.status.value.cwd);
       if (!cwd || (raw !== cwd && !raw.startsWith(`${cwd}/`))) {
         return { error: t('filePreview.errors.outsideWorkspace') };
       }

--- a/packages/agent-core/src/services/fs/fsPathSafety.ts
+++ b/packages/agent-core/src/services/fs/fsPathSafety.ts
@@ -1,5 +1,6 @@
 
 
+import os from 'node:os';
 import { promises as fs } from 'node:fs';
 import path from 'node:path';
 
@@ -115,4 +116,53 @@ function toPosixRelative(cwd: string, absolute: string): string {
   if (rel === '') return '.';
 
   return rel.split(path.sep).join('/');
+}
+
+/**
+ * Determine whether a path resides inside a system temporary directory.
+ * Covers cross-platform defaults (/tmp, /var/tmp, /dev/shm, os.tmpdir()).
+ */
+export function isTempPath(inputPath: string): boolean {
+  const normalized = path.normalize(inputPath);
+  const tmpDir = path.normalize(os.tmpdir());
+  const prefixes = [
+    '/tmp',
+    '/var/tmp',
+    '/dev/shm',
+    tmpDir,
+  ];
+  for (const p of prefixes) {
+    if (normalized === p || normalized.startsWith(p + path.sep)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * Resolve a path that is known to be inside a system temp directory.
+ * Mirrors the shape of resolveSafePath but skips cwd containment checks.
+ * Rejects paths with '..' segments for safety.
+ */
+export async function resolveTempPath(
+  inputPath: string,
+): Promise<PathSafetyResult> {
+  if (inputPath === '' || inputPath === '/') {
+    throw new FsPathEscapesError(inputPath, 'empty');
+  }
+
+  const segments = inputPath.split(/[/\\]+/);
+  if (segments.some((s) => s === '..')) {
+    throw new FsPathEscapesError(inputPath, 'dotdot_segment');
+  }
+
+  if (!isTempPath(inputPath)) {
+    throw new FsPathEscapesError(inputPath, 'resolved_outside_cwd', 'not a temp path');
+  }
+
+  const resolved = path.resolve(inputPath);
+  return {
+    absolute: resolved,
+    relative: resolved,
+  };
 }

--- a/packages/agent-core/src/services/fs/fsService.ts
+++ b/packages/agent-core/src/services/fs/fsService.ts
@@ -32,7 +32,7 @@ import {
   type FsDownloadResolved,
   type FsPathResolved,
 } from './fs';
-import { FsPathEscapesError, resolveSafePath } from './fsPathSafety';
+import { FsPathEscapesError, resolveSafePath, resolveTempPath } from './fsPathSafety';
 
 const FS_READ_MAX_BYTES = 10 * 1024 * 1024;
 
@@ -55,6 +55,26 @@ export class FsService extends Disposable implements IFsService {
   override dispose(): void {
     this.gitignoreCache.clear();
     super.dispose();
+  }
+
+  /**
+   * Try resolveSafePath first; if the path is absolute and inside a system
+   * temp directory, fall back to resolveTempPath. This lets web clients
+   * preview files written to /tmp (or platform equivalents) without escaping
+   * the session workspace for normal relative paths.
+   */
+  private async resolveWithTempFallback(
+    cwd: string,
+    inputPath: string,
+  ): Promise<{ absolute: string; relative: string }> {
+    try {
+      return await resolveSafePath(cwd, inputPath);
+    } catch (err) {
+      if (err instanceof FsPathEscapesError && err.reason === 'absolute') {
+        return resolveTempPath(inputPath);
+      }
+      throw err;
+    }
   }
 
   async list(sessionId: string, req: FsListRequest): Promise<FsListResponse> {
@@ -163,7 +183,7 @@ export class FsService extends Disposable implements IFsService {
   async read(sessionId: string, req: FsReadRequest): Promise<FsReadResponse> {
     const session = await this.sessions.get(sessionId);
     const cwd = session.metadata.cwd;
-    const safe = await resolveSafePath(cwd, req.path);
+    const safe = await this.resolveWithTempFallback(cwd, req.path);
 
     let st: import('node:fs').Stats;
     try {
@@ -358,7 +378,7 @@ export class FsService extends Disposable implements IFsService {
   ): Promise<FsDownloadResolved> {
     const session = await this.sessions.get(sessionId);
     const cwd = session.metadata.cwd;
-    const safe = await resolveSafePath(cwd, relPath);
+    const safe = await this.resolveWithTempFallback(cwd, relPath);
     let st: import('node:fs').Stats;
     try {
       st = await fs.stat(safe.absolute);
@@ -392,7 +412,7 @@ export class FsService extends Disposable implements IFsService {
   ): Promise<FsPathResolved> {
     const session = await this.sessions.get(sessionId);
     const cwd = session.metadata.cwd;
-    const safe = await resolveSafePath(cwd, relPath);
+    const safe = await this.resolveWithTempFallback(cwd, relPath);
     let st: import('node:fs').Stats;
     try {
       st = await fs.stat(safe.absolute);

--- a/packages/agent-core/src/services/fs/index.ts
+++ b/packages/agent-core/src/services/fs/index.ts
@@ -35,5 +35,7 @@ export { FsWatcherService } from './fsWatcherService';
 export {
   FsPathEscapesError,
   resolveSafePath,
+  isTempPath,
+  resolveTempPath,
   type PathSafetyResult,
 } from './fsPathSafety';

--- a/packages/agent-core/src/services/index.ts
+++ b/packages/agent-core/src/services/index.ts
@@ -77,6 +77,8 @@ export { FsWatcherService } from './fs/fsWatcherService';
 export {
   FsPathEscapesError,
   resolveSafePath,
+  isTempPath,
+  resolveTempPath,
 } from './fs/fsPathSafety';
 export type { PathSafetyResult } from './fs/fsPathSafety';
 

--- a/packages/agent-core/test/services/fs-path-safety.test.ts
+++ b/packages/agent-core/test/services/fs-path-safety.test.ts
@@ -1,0 +1,110 @@
+import { mkdtempSync, rmSync, symlinkSync, writeFileSync, mkdirSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import {
+  FsPathEscapesError,
+  resolveSafePath,
+  isTempPath,
+  resolveTempPath,
+} from '@moonshot-ai/agent-core';
+
+describe('isTempPath', () => {
+  it('returns true for /tmp paths', () => {
+    expect(isTempPath('/tmp')).toBe(true);
+    expect(isTempPath('/tmp/')).toBe(true);
+    expect(isTempPath('/tmp/foo')).toBe(true);
+    expect(isTempPath('/tmp/foo/bar')).toBe(true);
+  });
+
+  it('returns true for /var/tmp paths', () => {
+    expect(isTempPath('/var/tmp')).toBe(true);
+    expect(isTempPath('/var/tmp/file.txt')).toBe(true);
+  });
+
+  it('returns true for /dev/shm paths', () => {
+    expect(isTempPath('/dev/shm')).toBe(true);
+    expect(isTempPath('/dev/shm/shared')).toBe(true);
+  });
+
+  it('returns true for os.tmpdir() paths', () => {
+    const t = tmpdir();
+    expect(isTempPath(t)).toBe(true);
+    expect(isTempPath(join(t, 'sub'))).toBe(true);
+  });
+
+  it('returns false for non-temp paths', () => {
+    expect(isTempPath('/')).toBe(false);
+    expect(isTempPath('/home')).toBe(false);
+    expect(isTempPath('/usr/local')).toBe(false);
+    expect(isTempPath('/tmpfoo')).toBe(false);
+    expect(isTempPath('/var/tmpfoo')).toBe(false);
+  });
+});
+
+describe('resolveTempPath', () => {
+  it('resolves a simple temp file', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'fs-temp-'));
+    const file = join(dir, 'test.txt');
+    writeFileSync(file, 'hello');
+    const result = await resolveTempPath(file);
+    expect(result.absolute).toBe(file);
+    expect(result.relative).toBe(file);
+    rmSync(dir, { recursive: true });
+  });
+
+  it('rejects empty path', async () => {
+    await expect(resolveTempPath('')).rejects.toBeInstanceOf(FsPathEscapesError);
+  });
+
+  it('rejects path with ..', async () => {
+    await expect(resolveTempPath('/tmp/../etc/passwd')).rejects.toBeInstanceOf(FsPathEscapesError);
+  });
+
+  it('rejects non-temp path', async () => {
+    await expect(resolveTempPath('/etc/passwd')).rejects.toBeInstanceOf(FsPathEscapesError);
+  });
+});
+
+describe('resolveSafePath + temp fallback', () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), 'fs-safe-'));
+  });
+
+  afterEach(() => {
+    rmSync(tempDir, { recursive: true });
+  });
+
+  it('resolves relative paths inside cwd', async () => {
+    const result = await resolveSafePath(tempDir, 'foo.txt');
+    expect(result.absolute).toBe(join(tempDir, 'foo.txt'));
+    expect(result.relative).toBe('foo.txt');
+  });
+
+  it('rejects absolute paths outside cwd', async () => {
+    await expect(resolveSafePath(tempDir, '/etc/passwd')).rejects.toBeInstanceOf(FsPathEscapesError);
+  });
+
+  it('resolves symlinks inside cwd', async () => {
+    const target = join(tempDir, 'real.txt');
+    const link = join(tempDir, 'link.txt');
+    writeFileSync(target, 'hello');
+    symlinkSync(target, link);
+    const result = await resolveSafePath(tempDir, 'link.txt');
+    expect(result.absolute).toBe(target);
+    // resolveSafePath resolves symlinks to their real path for safety
+    expect(result.relative).toBe('real.txt');
+  });
+
+  it('rejects symlinks outside cwd', async () => {
+    const outside = mkdtempSync(join(tmpdir(), 'outside-'));
+    const link = join(tempDir, 'escape.txt');
+    symlinkSync(outside, link);
+    await expect(resolveSafePath(tempDir, 'escape.txt')).rejects.toBeInstanceOf(FsPathEscapesError);
+    rmSync(outside, { recursive: true });
+  });
+});


### PR DESCRIPTION
## Problem

When the agent writes files to system temp directories (e.g. /tmp), web clients cannot preview them because:

1. FsService rejects absolute paths outside the session workspace via resolveSafePath
2. useFilePreview rejects absolute paths that are not inside the workspace cwd

This is a re-implementation of #1351, which failed CI due to lint issues and became incompatible after upstream removed the v1 server package.

## Solution

1. Add isTempPath and resolveTempPath to fsPathSafety.ts for temp directory resolution without cwd containment checks
2. Add resolveWithTempFallback to FsService that tries resolveSafePath first, then falls back to resolveTempPath for absolute paths in system temp directories
3. Use resolveWithTempFallback in FsService.read, download, and resolvePath
4. Update useFilePreview.normalizePreviewPath to allow absolute paths in /tmp, /var/tmp, /dev/shm
5. Add unit tests in packages/agent-core/test/services/fs-path-safety.test.ts

## Checklist

- [x] I have read the CONTRIBUTING document.
- [x] Added tests for new behavior.
- [x] Local tests pass.