### PR TITLE
fix(web): show errors for failed actions and add daemon request/operation logging

### DIFF
--- a/.changeset/server-error-and-operation-logging.md
+++ b/.changeset/server-error-and-operation-logging.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Log failed requests, WebSocket auth rejections, shutdowns, and key operations (abort, cancel, approvals, config changes) in the web UI server so daemon problems can be diagnosed from its logs.

--- a/.changeset/web-operation-error-feedback.md
+++ b/.changeset/web-operation-error-feedback.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+web: Surface server error details when actions such as stopping a session, archiving, or toggling modes fail, instead of failing silently, and log every operation failure to the console and the exported web log.

--- a/apps/kimi-web/src/components/Sidebar.vue
+++ b/apps/kimi-web/src/components/Sidebar.vue
@@ -571,6 +571,7 @@ async function chooseBackend(name: BackendName): Promise<void> {
   }
   const next = await switchDevBackend(name);
   if (next === null) {
+    console.warn('[kimi-web] dev backend switch failed:', name);
     closeBackendMenu();
     return;
   }

--- a/apps/kimi-web/src/components/dialogs/LoginDialog.vue
+++ b/apps/kimi-web/src/components/dialogs/LoginDialog.vue
@@ -71,6 +71,9 @@ const props = defineProps<{
 
 type Step = 'starting' | 'device-code' | 'success' | 'expired' | 'error';
 const step = ref<Step>('starting');
+// True when the error step came from repeated poll failures (daemon gone)
+// rather than startOAuthLogin failing (unsupported endpoint) — picks the copy.
+const pollError = ref(false);
 
 interface FlowData {
   flowId: string;
@@ -87,6 +90,11 @@ const copied = ref(false);
 
 let pollTimer: ReturnType<typeof setTimeout> | null = null;
 let countdownTimer: ReturnType<typeof setInterval> | null = null;
+// Consecutive failed polls (onPollOAuthLogin returned null). A single null can
+// be a transient blip; several in a row means the daemon is gone and polling
+// forever would strand the user on "waiting for authorization".
+let consecutivePollFailures = 0;
+const MAX_CONSECUTIVE_POLL_FAILURES = 3;
 
 // -------------------------------------------------------------------------
 // Lifecycle
@@ -107,6 +115,8 @@ onUnmounted(() => {
 async function startFlow(): Promise<void> {
   stopTimers();
   flow.value = null;
+  pollError.value = false;
+  consecutivePollFailures = 0;
   step.value = 'starting';
 
   const result = await props.onStartOAuthLogin();
@@ -158,18 +168,32 @@ function scheduleNextPoll(intervalSec: number): void {
   if (pollTimer) clearTimeout(pollTimer);
   pollTimer = setTimeout(async () => {
     const result = await props.onPollOAuthLogin();
-    if (result?.status === 'authenticated') {
+    if (result === null) {
+      // Poll failed (or no active flow). Keep polling through transient
+      // blips, but give up with an explicit error after several in a row.
+      consecutivePollFailures += 1;
+      if (consecutivePollFailures >= MAX_CONSECUTIVE_POLL_FAILURES) {
+        stopTimers();
+        pollError.value = true;
+        step.value = 'error';
+        return;
+      }
+      scheduleNextPoll(intervalSec);
+      return;
+    }
+    consecutivePollFailures = 0;
+    if (result.status === 'authenticated') {
       stopTimers();
       step.value = 'success';
       setTimeout(() => {
         emit('success');
         emit('close');
       }, 1200);
-    } else if (result?.status === 'expired' || result?.status === 'cancelled') {
+    } else if (result.status === 'expired' || result.status === 'cancelled') {
       stopTimers();
       step.value = 'expired';
     } else {
-      // pending or null — keep polling
+      // pending — keep polling
       scheduleNextPoll(intervalSec);
     }
   }, intervalSec * 1000);
@@ -289,12 +313,16 @@ function formatSeconds(s: number): string {
       </div>
     </template>
 
-    <!-- Error (endpoint missing or network failure) -->
+    <!-- Error (endpoint missing, network failure, or repeated poll failures) -->
     <template v-else-if="step === 'error'">
       <div class="center-body">
         <AuthStateIcon kind="error" />
-        <span class="center-text warn-text">{{ t('login.errorTitle') }}</span>
-        <span class="center-hint">{{ t('login.errorHint') }}</span>
+        <span class="center-text warn-text">
+          {{ pollError ? t('login.pollErrorTitle') : t('login.errorTitle') }}
+        </span>
+        <span class="center-hint">
+          {{ pollError ? t('login.pollErrorHint') : t('login.errorHint') }}
+        </span>
       </div>
       <div class="actions">
         <Button variant="primary" @click="retryFlow">{{ t('login.retry') }}</Button>

--- a/apps/kimi-web/src/composables/client/useModelProviderState.ts
+++ b/apps/kimi-web/src/composables/client/useModelProviderState.ts
@@ -426,7 +426,10 @@ export function useModelProviderState(
     try {
       const api = getKimiWebApi();
       return await api.pollOAuthLogin();
-    } catch {
+    } catch (err) {
+      // The dialog counts consecutive nulls and gives up after a few; keep the
+      // cause in the log so a dead daemon is diagnosable.
+      console.warn('[kimi-web] pollOAuthLogin failed', err);
       return null;
     }
   }

--- a/apps/kimi-web/src/composables/client/useWorkspaceState.ts
+++ b/apps/kimi-web/src/composables/client/useWorkspaceState.ts
@@ -596,7 +596,10 @@ export function useWorkspaceState(rawState: ExtendedState, deps: UseWorkspaceSta
       // daemons while /sessions still works. Fall back to the legacy global
       // walk so history still shows and mergedWorkspaces can derive workspaces
       // from session cwds, instead of rendering a blank sidebar.
-      const fallback = await listAllSessionsGlobal().catch(() => [] as AppSession[]);
+      const fallback = await listAllSessionsGlobal().catch((err) => {
+        console.warn('[kimi-web] global session fallback load failed', err);
+        return [] as AppSession[];
+      });
       rawState.sessionsHasMoreByWorkspace = {};
       rawState.sessionsCursorByWorkspace = {};
       rawState.sessionsInitialCountByWorkspace = {};
@@ -605,10 +608,13 @@ export function useWorkspaceState(rawState: ExtendedState, deps: UseWorkspaceSta
     }
     const pages = await Promise.all(
       workspaces.map((w) =>
-        loadInitialSessionsForWorkspace(w.id).catch(() => ({
-          workspaceId: w.id,
-          page: { items: [] as AppSession[], hasMore: false },
-        })),
+        loadInitialSessionsForWorkspace(w.id).catch((err) => {
+          console.warn('[kimi-web] initial session load failed for workspace', w.id, err);
+          return {
+            workspaceId: w.id,
+            page: { items: [] as AppSession[], hasMore: false },
+          };
+        }),
       ),
     );
     const loaded: AppSession[] = [];
@@ -693,7 +699,10 @@ export function useWorkspaceState(rawState: ExtendedState, deps: UseWorkspaceSta
    *  first search; a no-op once the full list is loaded. */
   async function loadAllSessions(): Promise<void> {
     if (rawState.sessionsFullyLoaded) return;
-    const sessions = await listAllSessionsGlobal().catch(() => null);
+    const sessions = await listAllSessionsGlobal().catch((err) => {
+      console.warn('[kimi-web] loadAllSessions failed; search covers only loaded sessions', err);
+      return null;
+    });
     if (sessions === null) return;
     setSessionsPreservingLiveUsage(sessions);
     rawState.sessionsFullyLoaded = true;
@@ -1140,7 +1149,9 @@ export function useWorkspaceState(rawState: ExtendedState, deps: UseWorkspaceSta
       upsertWorkspacePreserveOrder(ws);
       openWorkspaceDraft(ws.id);
       return true;
-    } catch {
+    } catch (err) {
+      // The caller shows an inline error in the picker; keep the cause in the log.
+      console.warn('[kimi-web] addWorkspaceByPath failed for', trimmed, err);
       return false;
     }
   }
@@ -2079,8 +2090,9 @@ export function useWorkspaceState(rawState: ExtendedState, deps: UseWorkspaceSta
     // Best-effort registry cleanup; ignore failures (the hide already took effect).
     try {
       await getKimiWebApi().deleteWorkspace(id);
-    } catch {
+    } catch (err) {
       // registry delete is optional — the sidebar hide is what the user sees.
+      console.warn('[kimi-web] deleteWorkspace registry cleanup failed for', id, err);
     }
     rawState.workspaces = rawState.workspaces.filter((w) => w.id !== id && w.root !== root);
     if (removingActiveWorkspace || activeSessionInRemovedWorkspace) {
@@ -2374,7 +2386,8 @@ export function useWorkspaceState(rawState: ExtendedState, deps: UseWorkspaceSta
         size: result.size,
         lineCount: result.lineCount,
       };
-    } catch {
+    } catch (err) {
+      console.warn('[kimi-web] readFileContent failed for', path, err);
       return null;
     }
   }

--- a/apps/kimi-web/src/composables/useFilePreview.ts
+++ b/apps/kimi-web/src/composables/useFilePreview.ts
@@ -134,14 +134,10 @@ export function useFilePreview({ client, detailTarget }: UseFilePreviewOptions) 
       if (result) {
         previewFile.value = { ...result, path: result.path || normalized.path };
       } else {
-        previewFile.value = {
-          path: normalized.path,
-          content: '',
-          encoding: 'utf-8',
-          mime: 'text/plain',
-          isBinary: false,
-          size: 0,
-        };
+        // readFileContent swallows daemon failures into null — show the error
+        // state instead of a misleading 0-byte "empty file" (the cause is
+        // already console.warn'd in readFileContent).
+        previewError.value = t('filePreview.errors.loadFailed');
       }
     } catch (err) {
       if (requestSeq !== previewRequestSeq) return;

--- a/apps/kimi-web/src/composables/useKimiWebClient.ts
+++ b/apps/kimi-web/src/composables/useKimiWebClient.ts
@@ -696,10 +696,12 @@ async function refreshSessionGoal(sessionId: string): Promise<void> {
  *  session and immediately persisting its draft modes, so a concurrent session
  *  switch can't write the patch to the wrong session.
  *
- *  Returns the update promise (errors swallowed — the UI already updated
- *  optimistically). Most callers fire-and-forget via `void persistSessionProfile(...)`;
- *  call sites that must order strictly after the profile (e.g. a skill
- *  activation that can't carry its own modes) await it. */
+ *  Returns the update promise. Failures are surfaced via pushOperationFailure
+ *  (the UI already updated optimistically, so the user must be told when the
+ *  daemon did not apply the change); the promise itself never rejects. Most
+ *  callers fire-and-forget via `void persistSessionProfile(...)`; call sites
+ *  that must order strictly after the profile (e.g. a skill activation that
+ *  can't carry its own modes) await it. */
 function persistSessionProfile(patch: {
   model?: string;
   permissionMode?: string;
@@ -714,8 +716,10 @@ function persistSessionProfile(patch: {
   // Promise.resolve wrap: tolerate a sync/undefined return (e.g. test mocks).
   return Promise.resolve(getKimiWebApi().updateSession(sid, patch))
     .then(() => refreshSessionStatus(sid))
-    .catch(() => {
-      /* ignore — local state already reflects the change */
+    .catch((err) => {
+      // Local state already reflects the change; tell the user (and the log)
+      // that the daemon did not persist it.
+      pushOperationFailure('persistSessionProfile', err, { sessionId: sid });
     });
 }
 
@@ -1228,6 +1232,21 @@ function pushOperationFailure(
   err: unknown,
   opts?: { title?: string; message?: string; sessionId?: string },
 ): void {
+  // Always-on logging: a surfaced failure must be diagnosable from the console
+  // and from the exported web log (session export), not just from the toast.
+  console.error(`[kimi-web] operation failed: ${operation}`, err);
+  const api = isDaemonApiError(err);
+  const network = isDaemonNetworkError(err);
+  traceKeyEvent('operation:failed', {
+    sessionId: opts?.sessionId,
+    status: 'failed',
+    operation,
+    errorName: err instanceof Error ? err.name : typeof err,
+    errorCode: api ? err.code : undefined,
+    requestId: api || network ? err.requestId : undefined,
+    phase: network ? err.phase : undefined,
+    httpStatus: network ? err.status : undefined,
+  });
   pushWarning(operationFailureNotice(operation, err, opts));
 }
 

--- a/apps/kimi-web/src/composables/useKimiWebClient.ts
+++ b/apps/kimi-web/src/composables/useKimiWebClient.ts
@@ -1234,7 +1234,6 @@ function pushOperationFailure(
 ): void {
   // Always-on logging: a surfaced failure must be diagnosable from the console
   // and from the exported web log (session export), not just from the toast.
-  // Logging stays unconditional even when the toast below is deduped.
   console.error(`[kimi-web] operation failed: ${operation}`, err);
   const api = isDaemonApiError(err);
   const network = isDaemonNetworkError(err);
@@ -1248,18 +1247,7 @@ function pushOperationFailure(
     phase: network ? err.phase : undefined,
     httpStatus: network ? err.status : undefined,
   });
-  const notice = operationFailureNotice(operation, err, opts);
-  // Anti-flood: while the same operation's identical failure is still visible
-  // (error toasts auto-dismiss after ~12s), don't stack a duplicate. Repeated
-  // clicks on a failing action — or a multi-step flow failing at every step —
-  // then surface exactly one toast instead of a wall of them.
-  const duplicate = rawState.warnings.some((w) => {
-    if (typeof w !== 'object' || w === null || w.severity !== 'error') return false;
-    if (w.title !== notice.title || w.message !== notice.message) return false;
-    const wOperation = w.details?.find((d) => d.label === 'operation')?.value;
-    return wOperation === operation;
-  });
-  if (!duplicate) pushWarning(notice);
+  pushWarning(operationFailureNotice(operation, err, opts));
 }
 
 // Goal-specific protocol error codes (40913–40918). The daemon now returns

--- a/apps/kimi-web/src/composables/useKimiWebClient.ts
+++ b/apps/kimi-web/src/composables/useKimiWebClient.ts
@@ -1234,6 +1234,7 @@ function pushOperationFailure(
 ): void {
   // Always-on logging: a surfaced failure must be diagnosable from the console
   // and from the exported web log (session export), not just from the toast.
+  // Logging stays unconditional even when the toast below is deduped.
   console.error(`[kimi-web] operation failed: ${operation}`, err);
   const api = isDaemonApiError(err);
   const network = isDaemonNetworkError(err);
@@ -1247,7 +1248,18 @@ function pushOperationFailure(
     phase: network ? err.phase : undefined,
     httpStatus: network ? err.status : undefined,
   });
-  pushWarning(operationFailureNotice(operation, err, opts));
+  const notice = operationFailureNotice(operation, err, opts);
+  // Anti-flood: while the same operation's identical failure is still visible
+  // (error toasts auto-dismiss after ~12s), don't stack a duplicate. Repeated
+  // clicks on a failing action — or a multi-step flow failing at every step —
+  // then surface exactly one toast instead of a wall of them.
+  const duplicate = rawState.warnings.some((w) => {
+    if (typeof w !== 'object' || w === null || w.severity !== 'error') return false;
+    if (w.title !== notice.title || w.message !== notice.message) return false;
+    const wOperation = w.details?.find((d) => d.label === 'operation')?.value;
+    return wOperation === operation;
+  });
+  if (!duplicate) pushWarning(notice);
 }
 
 // Goal-specific protocol error codes (40913–40918). The daemon now returns

--- a/apps/kimi-web/src/debug/trace.ts
+++ b/apps/kimi-web/src/debug/trace.ts
@@ -55,6 +55,7 @@ const EXPORT_TRACE_EVENTS = [
   'session:snapshot:start',
   'session:snapshot:accepted',
   'session:snapshot:failed',
+  'operation:failed',
   'window:error',
   'window:unhandled-rejection',
   'ws:connection',
@@ -68,6 +69,8 @@ type ExportTraceEvent = (typeof EXPORT_TRACE_EVENTS)[number];
 export interface ExportTraceMetadata {
   sessionId?: string;
   status?: string;
+  /** Client operation name (e.g. 'archiveSession') for operation:failed. */
+  operation?: string;
   seq?: number;
   durationMs?: number;
   messageCount?: number;
@@ -226,6 +229,7 @@ function pushExportTrace(event: string, info?: ExportTraceMetadata): void {
       event: event as ExportTraceEvent,
       sessionId: exportString(info?.sessionId),
       status: exportString(info?.status),
+      operation: exportString(info?.operation),
       seq: exportNumber(info?.seq),
       durationMs: exportNumber(info?.durationMs),
       messageCount: exportNumber(info?.messageCount),

--- a/apps/kimi-web/src/i18n/locales/en/login.ts
+++ b/apps/kimi-web/src/i18n/locales/en/login.ts
@@ -19,4 +19,6 @@ export default {
   closeBtn: 'Close',
   errorTitle: 'The current daemon does not support login yet',
   errorHint: 'Please upgrade kimi-code and try again',
+  pollErrorTitle: 'Lost connection to the daemon',
+  pollErrorHint: 'Authorization polling failed repeatedly. Check the kimi-code process and try again.',
 } as const;

--- a/apps/kimi-web/src/i18n/locales/zh/login.ts
+++ b/apps/kimi-web/src/i18n/locales/zh/login.ts
@@ -19,4 +19,6 @@ export default {
   closeBtn: '关闭',
   errorTitle: '当前 daemon 暂不支持登录',
   errorHint: '请升级 kimi-code 后重试',
+  pollErrorTitle: '与 daemon 的连接已断开',
+  pollErrorHint: '授权轮询连续失败，请检查 kimi-code 进程后重试',
 } as const;

--- a/packages/kap-server/src/lib/requestLog.ts
+++ b/packages/kap-server/src/lib/requestLog.ts
@@ -1,0 +1,20 @@
+/**
+ * Per-request pino logger access for route handlers whose request type is
+ * structurally narrowed (`defineRoute` declares only the fields a handler
+ * uses). At runtime every handler receives a real Fastify request, which
+ * always carries `log` — the same pattern `error-handler.ts` relies on.
+ */
+
+import type { Logger } from 'pino';
+
+/** Minimal pino surface used by route handlers. */
+export type RequestLogger = Pick<Logger, 'info' | 'warn' | 'error'>;
+
+/**
+ * Extract Fastify's per-request logger from a narrowed route-handler request.
+ * Returns `undefined` only for hand-rolled test doubles that never install a
+ * logger — callers should use optional chaining.
+ */
+export function requestLog(req: { id: string }): RequestLogger | undefined {
+  return (req as { log?: RequestLogger }).log;
+}

--- a/packages/kap-server/src/middleware/rateLimit.ts
+++ b/packages/kap-server/src/middleware/rateLimit.ts
@@ -23,6 +23,8 @@ export interface AuthFailureLimiterOptions {
   readonly windowMs?: number;
   /** Ban duration in ms once the threshold is hit. Default `60_000`. */
   readonly banMs?: number;
+  /** Emits a warn line when a source crosses into a ban. */
+  readonly logger?: { warn(obj: unknown, msg: string): void };
 }
 
 /** Minimal surface consumed by `createAuthHook`. */
@@ -87,7 +89,14 @@ export function createAuthFailureLimiter(
       }
       entry.count += 1;
       if (entry.count >= maxFailures) {
+        const wasBanned = entry.bannedUntil > now;
         entry.bannedUntil = now + banMs;
+        if (!wasBanned) {
+          opts?.logger?.warn(
+            { ip, bannedUntil: entry.bannedUntil },
+            'too many failed auth attempts; source temporarily banned',
+          );
+        }
       }
     },
     isBanned(ip: string): boolean {

--- a/packages/kap-server/src/routes/approvals.ts
+++ b/packages/kap-server/src/routes/approvals.ts
@@ -48,6 +48,7 @@ import {
 import { z } from 'zod';
 
 import { errEnvelope, okEnvelope } from '../envelope';
+import { requestLog } from '../lib/requestLog';
 import { defineRoute } from '../middleware/defineRoute';
 
 interface ApprovalRouteHost {
@@ -170,6 +171,11 @@ export function registerApprovalsRoutes(app: ApprovalRouteHost, core: Scope): vo
         selectedLabel: body.selected_label,
       };
       handle.accessor.get(ISessionApprovalService).decide(approval_id, response);
+      // Security-sensitive: record who resolved what, and how.
+      requestLog(req)?.info(
+        { session_id, approval_id, decision: response.decision, scope: response.scope },
+        'approval decided',
+      );
       reply.send(
         okEnvelope({ resolved: true as const, resolved_at: new Date().toISOString() }, req.id),
       );

--- a/packages/kap-server/src/routes/config.ts
+++ b/packages/kap-server/src/routes/config.ts
@@ -35,6 +35,7 @@ import {
 import type { ConfigResponse } from '@moonshot-ai/protocol';
 
 import { errEnvelope, okEnvelope } from '../envelope';
+import { requestLog } from '../lib/requestLog';
 import { defineRoute } from '../middleware/defineRoute';
 
 type ProviderResponse = ConfigResponse['providers'][string];
@@ -103,16 +104,20 @@ export function registerConfigRoutes(app: ConfigRouteHost, core: Scope): void {
           await config.set(domain, camelPatch[domain]);
         }
         const response = toConfigResponse(config.getAll());
+        const changedFields = Object.keys(req.body as Record<string, unknown>);
         core.accessor.get(IEventService).publish({
           type: 'event.config.changed',
           payload: {
-            changedFields: Object.keys(req.body as Record<string, unknown>),
+            changedFields,
             config: response,
           },
         });
+        // Only the changed field *names* — values may carry secrets.
+        requestLog(req)?.info({ changedFields }, 'config updated');
         reply.send(okEnvelope(response, req.id));
       } catch (error) {
         const message = error instanceof Error ? error.message : String(error);
+        requestLog(req)?.error({ err: error }, 'config update failed');
         reply.send(errEnvelope(ErrorCode.VALIDATION_FAILED, message, req.id));
       }
     },

--- a/packages/kap-server/src/routes/files.ts
+++ b/packages/kap-server/src/routes/files.ts
@@ -31,6 +31,7 @@ import {
 } from '@moonshot-ai/protocol';
 import { z } from 'zod';
 
+import { requestLog } from '../lib/requestLog';
 import { defineRoute } from '../middleware/defineRoute';
 
 interface FilesRouteHost {
@@ -129,7 +130,7 @@ export function registerFilesRoutes(app: FilesRouteHost, core: Scope): void {
             } catch {
               // best-effort cleanup of the truncated blob
             }
-            sendMappedError(reply as unknown as FilesReply, req.id, new Error2(
+            sendMappedError(reply as unknown as FilesReply, req, new Error2(
               ErrorCodes.FILE_TOO_LARGE,
               `upload size exceeds limit ${DEFAULT_MAX_UPLOAD_BYTES} bytes`,
             ));
@@ -137,10 +138,10 @@ export function registerFilesRoutes(app: FilesRouteHost, core: Scope): void {
           }
           reply.send(okEnvelope(meta, req.id));
         } catch (error) {
-          sendMappedError(reply as unknown as FilesReply, req.id, error);
+          sendMappedError(reply as unknown as FilesReply, req, error);
         }
       } catch (error) {
-        sendMappedError(reply as unknown as FilesReply, req.id, error);
+        sendMappedError(reply as unknown as FilesReply, req, error);
       }
     },
   );
@@ -194,7 +195,7 @@ export function registerFilesRoutes(app: FilesRouteHost, core: Scope): void {
         r.header('content-length', size).code(200);
         return r.send(file.stream()) as unknown as void;
       } catch (error) {
-        sendMappedError(reply as unknown as FilesReply, req.id, error);
+        sendMappedError(reply as unknown as FilesReply, req, error);
         return;
       }
     },
@@ -219,9 +220,10 @@ export function registerFilesRoutes(app: FilesRouteHost, core: Scope): void {
         const { file_id } = req.params;
         const store = core.accessor.get(IFileService);
         await store.delete(file_id);
+        requestLog(req)?.info({ file_id }, 'file deleted');
         reply.send(okEnvelope({ deleted: true as const }, req.id));
       } catch (error) {
-        sendMappedError(reply as unknown as FilesReply, req.id, error);
+        sendMappedError(reply as unknown as FilesReply, req, error);
       }
     },
   );
@@ -232,7 +234,8 @@ export function registerFilesRoutes(app: FilesRouteHost, core: Scope): void {
   );
 }
 
-function sendMappedError(reply: FilesReply, requestId: string, err: unknown): void {
+function sendMappedError(reply: FilesReply, req: { id: string }, err: unknown): void {
+  const requestId = req.id;
   if (err instanceof Error2 && err.code === ErrorCodes.FILE_NOT_FOUND) {
     reply.code(404).send(errEnvelope(ErrorCode.FILE_NOT_FOUND, 'file not found', requestId));
     return;
@@ -250,6 +253,7 @@ function sendMappedError(reply: FilesReply, requestId: string, err: unknown): vo
     reply.code(413).send(errEnvelope(ErrorCode.FILE_TOO_LARGE, 'upload too large (>50MB)', requestId));
     return;
   }
+  requestLog(req)?.error({ err }, 'file request failed');
   reply
     .code(500)
     .send(

--- a/packages/kap-server/src/routes/fs.ts
+++ b/packages/kap-server/src/routes/fs.ts
@@ -43,6 +43,7 @@ import {
   openInAppCommandFor,
   revealFileCommandFor,
 } from '../lib/fileLaunch';
+import { requestLog } from '../lib/requestLog';
 import { defineRoute } from '../middleware/defineRoute';
 
 interface FsRouteHost {
@@ -200,7 +201,7 @@ export function registerFsRoutes(app: FsRouteHost, core: Scope): void {
             return;
         }
       } catch (err) {
-        sendMappedError(reply, req.id, err);
+        sendMappedError(reply, req, err);
       }
     },
   );
@@ -258,7 +259,7 @@ export function registerFsRoutes(app: FsRouteHost, core: Scope): void {
       try {
         resolved = await resolveFs(core, session_id).resolveDownload(relPath);
       } catch (err) {
-        sendMappedError(reply, req.id, err);
+        sendMappedError(reply, req, err);
         return;
       }
 
@@ -289,7 +290,11 @@ export function registerFsRoutes(app: FsRouteHost, core: Scope): void {
           start: range.start,
           end: range.end,
         });
-        stream.on('error', () => {
+        stream.on('error', (error: unknown) => {
+          requestLog(req)?.warn(
+            { session_id, path: relPath, err: error },
+            'fs download stream error',
+          );
           try {
             stream.destroy();
           } catch {
@@ -301,7 +306,11 @@ export function registerFsRoutes(app: FsRouteHost, core: Scope): void {
 
       r.code(200).header('content-length', String(resolved.size));
       const stream = createReadStream(resolved.absolute);
-      stream.on('error', () => {
+      stream.on('error', (error: unknown) => {
+        requestLog(req)?.warn(
+          { session_id, path: relPath, err: error },
+          'fs download stream error',
+        );
         try {
           stream.destroy();
         } catch {
@@ -463,6 +472,10 @@ async function handleOpenIn(core: Scope, sessionId: string, req: Req, reply: Rep
       }),
     );
   } catch (err) {
+    requestLog(req)?.warn(
+      { session_id: sessionId, app_id: body.app_id, err },
+      'fs open-in launch failed',
+    );
     reply.send(
       errEnvelope(
         ErrorCode.INTERNAL_ERROR,
@@ -479,7 +492,9 @@ async function handleOpenIn(core: Scope, sessionId: string, req: Req, reply: Rep
 // Error mapping — domain Error2 codes → protocol wire codes.
 // ---------------------------------------------------------------------------
 
-function sendMappedError(reply: Reply, requestId: string, err: unknown): void {
+function sendMappedError(reply: Reply, req: { id: string }, err: unknown): void {
+  const requestId = req.id;
+  const log = requestLog(req);
   if (isError2(err)) {
     switch (err.code) {
       case ErrorCodes.FS_PATH_ESCAPES:
@@ -530,6 +545,7 @@ function sendMappedError(reply: Reply, requestId: string, err: unknown): void {
         return;
     }
   }
+  log?.error({ err }, 'fs request failed');
   reply.send(
     errEnvelope(
       ErrorCode.INTERNAL_ERROR,

--- a/packages/kap-server/src/routes/messages.ts
+++ b/packages/kap-server/src/routes/messages.ts
@@ -27,6 +27,7 @@ import {
 import { z } from 'zod';
 
 import { errEnvelope, okEnvelope } from '../envelope';
+import { requestLog } from '../lib/requestLog';
 import { defineRoute } from '../middleware/defineRoute';
 
 interface MessageRouteHost {
@@ -102,7 +103,7 @@ export function registerMessagesRoutes(app: MessageRouteHost, core: Scope): void
         const page = await core.accessor.get(IMessageLegacyService).list(session_id, req.query);
         reply.send(okEnvelope(page, req.id));
       } catch (err) {
-        sendMappedError(reply, req.id, err);
+        sendMappedError(reply, req, err);
       }
     },
   );
@@ -133,7 +134,7 @@ export function registerMessagesRoutes(app: MessageRouteHost, core: Scope): void
         const message = await core.accessor.get(IMessageLegacyService).get(session_id, message_id);
         reply.send(okEnvelope(message, req.id));
       } catch (err) {
-        sendMappedError(reply, req.id, err);
+        sendMappedError(reply, req, err);
       }
     },
   );
@@ -152,9 +153,11 @@ export function registerMessagesRoutes(app: MessageRouteHost, core: Scope): void
  */
 function sendMappedError(
   reply: { send(payload: unknown): unknown },
-  requestId: string,
+  req: { id: string },
   err: unknown,
 ): void {
+  const requestId = req.id;
+  const log = requestLog(req);
   if (isError2(err)) {
     switch (err.code) {
       case 'session.not_found':
@@ -165,6 +168,7 @@ function sendMappedError(
         return;
     }
   }
+  log?.error({ err }, 'message request failed');
   reply.send(
     errEnvelope(ErrorCode.INTERNAL_ERROR, err instanceof Error ? err.message : String(err), requestId, err instanceof Error ? err.stack : undefined),
   );

--- a/packages/kap-server/src/routes/oauth.ts
+++ b/packages/kap-server/src/routes/oauth.ts
@@ -24,6 +24,7 @@ import {
 import { z } from 'zod';
 
 import { okEnvelope } from '../envelope';
+import { requestLog } from '../lib/requestLog';
 import { defineRoute } from '../middleware/defineRoute';
 
 interface RouteHost {
@@ -71,6 +72,7 @@ export function registerOAuthRoutes(app: RouteHost, core: Scope): void {
     },
     async (req, reply) => {
       const result = await core.accessor.get(IOAuthService).startLogin(req.body.provider);
+      requestLog(req)?.info({ provider: req.body.provider, action: 'login' }, 'oauth login started');
       reply.send(okEnvelope(result, req.id));
     },
   );
@@ -113,6 +115,10 @@ export function registerOAuthRoutes(app: RouteHost, core: Scope): void {
     },
     async (req, reply) => {
       const result = await core.accessor.get(IOAuthService).cancelLogin(req.query.provider);
+      requestLog(req)?.info(
+        { provider: req.query.provider, action: 'cancel_login' },
+        'oauth login cancelled',
+      );
       reply.send(okEnvelope(result, req.id));
     },
   );
@@ -134,6 +140,7 @@ export function registerOAuthRoutes(app: RouteHost, core: Scope): void {
     },
     async (req, reply) => {
       const result = await core.accessor.get(IOAuthService).logout(req.body.provider);
+      requestLog(req)?.info({ provider: req.body.provider, action: 'logout' }, 'oauth logout');
       reply.send(okEnvelope(result, req.id));
     },
   );

--- a/packages/kap-server/src/routes/prompts.ts
+++ b/packages/kap-server/src/routes/prompts.ts
@@ -59,6 +59,7 @@ import {
 import { z } from 'zod';
 
 import { errEnvelope, okEnvelope } from '../envelope';
+import { requestLog } from '../lib/requestLog';
 import { defineRoute } from '../middleware/defineRoute';
 import { ensureMainAgent, MAIN_AGENT_ID } from '../transport/mainAgent';
 import { parseActionSuffix } from './action-suffix';
@@ -152,7 +153,7 @@ export function registerPromptsRoutes(app: PromptRouteHost, core: Scope): void {
         const result = projectPromptList((await resolvePrompt(core, session_id)).prompt.list());
         reply.send(okEnvelope(result, req.id));
       } catch (error) {
-        sendMappedError(reply, req.id, error);
+        sendMappedError(reply, req, error);
       }
     },
   );
@@ -215,7 +216,7 @@ export function registerPromptsRoutes(app: PromptRouteHost, core: Scope): void {
         } });
         reply.send(okEnvelope(projectPromptHandle(handle), req.id));
       } catch (error) {
-        sendMappedError(reply, req.id, error);
+        sendMappedError(reply, req, error);
       }
     },
   );
@@ -244,7 +245,7 @@ export function registerPromptsRoutes(app: PromptRouteHost, core: Scope): void {
         await resolved.prompt.steer(req.body.prompt_ids);
         reply.send(okEnvelope({ steered: true, prompt_ids: [...req.body.prompt_ids] }, req.id));
       } catch (error) {
-        sendMappedError(reply, req.id, error);
+        sendMappedError(reply, req, error);
       }
     },
   );
@@ -281,13 +282,14 @@ export function registerPromptsRoutes(app: PromptRouteHost, core: Scope): void {
         const resolved = await resolvePrompt(core, session_id);
         if (parsed.action === 'abort') {
           resolved.prompt.abort(parsed.id);
+          requestLog(req)?.info({ session_id, prompt_id: parsed.id }, 'prompt aborted');
           reply.send(okEnvelope({ aborted: true }, req.id));
         } else {
           await resolved.prompt.steer([parsed.id]);
           reply.send(okEnvelope({ steered: true, prompt_ids: [parsed.id] }, req.id));
         }
       } catch (error) {
-        sendMappedError(reply, req.id, error);
+        sendMappedError(reply, req, error);
       }
     },
   );
@@ -561,9 +563,11 @@ function escapeAttribute(value: string): string {
 
 function sendMappedError(
   reply: { send(payload: unknown): unknown },
-  requestId: string,
+  req: { id: string },
   err: unknown,
 ): void {
+  const requestId = req.id;
+  const log = requestLog(req);
   if (isError2(err)) {
     switch (err.code) {
       case 'session.not_found':
@@ -605,6 +609,7 @@ function sendMappedError(
       case 'auth.token_missing': {
         const details = authProviderDetails(err);
         if (details === undefined) {
+          log?.error({ err }, 'prompt request failed');
           reply.send(
             errEnvelope(
               ErrorCode.INTERNAL_ERROR,
@@ -627,6 +632,7 @@ function sendMappedError(
       case 'auth.token_unauthorized': {
         const details = authProviderDetails(err);
         if (details === undefined) {
+          log?.error({ err }, 'prompt request failed');
           reply.send(
             errEnvelope(
               ErrorCode.INTERNAL_ERROR,
@@ -658,6 +664,7 @@ function sendMappedError(
         return;
     }
   }
+  log?.error({ err }, 'prompt request failed');
   reply.send(
     errEnvelope(
       ErrorCode.INTERNAL_ERROR,

--- a/packages/kap-server/src/routes/questions.ts
+++ b/packages/kap-server/src/routes/questions.ts
@@ -69,6 +69,7 @@ import {
 import { z } from 'zod';
 
 import { errEnvelope, okEnvelope } from '../envelope';
+import { requestLog } from '../lib/requestLog';
 import { defineRoute } from '../middleware/defineRoute';
 import { parseActionSuffix } from './action-suffix';
 
@@ -201,6 +202,10 @@ export function registerQuestionsRoutes(app: QuestionRouteHost, core: Scope): vo
 
       if (action === 'dismiss') {
         questions.dismiss(questionId);
+        requestLog(req)?.info(
+          { session_id, question_id: questionId, action: 'dismiss' },
+          'question dismissed',
+        );
         reply.send({
           code: ErrorCode.QUESTION_DISMISSED, // 40909
           msg: `question ${questionId} dismissed`,
@@ -243,6 +248,10 @@ export function registerQuestionsRoutes(app: QuestionRouteHost, core: Scope): vo
         toWireQuestion(pendingInteraction, session_id),
       );
       questions.answer(questionId, result);
+      requestLog(req)?.info(
+        { session_id, question_id: questionId, action: 'answer' },
+        'question answered',
+      );
       reply.send(
         okEnvelope({ resolved: true as const, resolved_at: new Date().toISOString() }, req.id),
       );

--- a/packages/kap-server/src/routes/sessionExport.ts
+++ b/packages/kap-server/src/routes/sessionExport.ts
@@ -25,6 +25,7 @@ import {
   exportSessionRequestSchema,
 } from '@moonshot-ai/protocol';
 
+import { requestLog } from '../lib/requestLog';
 import { defineRoute } from '../middleware/defineRoute';
 
 const MAX_WEB_SESSION_EXPORT_BYTES = 64 * 1024 * 1024;
@@ -166,7 +167,7 @@ export function registerSessionExportRoute(
           stream?.destroy();
         }
         await cleanup();
-        if (!aborted) sendMappedError(response, req.id, error);
+        if (!aborted) sendMappedError(response, req, error);
       } finally {
         if (!streaming) response.raw.off('close', onResponseClose);
       }
@@ -184,7 +185,8 @@ function sanitizeSessionId(sessionId: string): string {
   return sessionId.replaceAll(/[^A-Za-z0-9_-]/g, '_').slice(0, 48) || 'session';
 }
 
-function sendMappedError(reply: SessionExportReply, requestId: string, error: unknown): void {
+function sendMappedError(reply: SessionExportReply, req: { id: string }, error: unknown): void {
+  const requestId = req.id;
   if (isError2(error)) {
     if (error.code === ErrorCodes.SESSION_NOT_FOUND) {
       reply.send(errEnvelope(ErrorCode.SESSION_NOT_FOUND, error.message, requestId));
@@ -201,6 +203,7 @@ function sendMappedError(reply: SessionExportReply, requestId: string, error: un
       return;
     }
   }
+  requestLog(req)?.error({ err: error }, 'session export failed');
   reply.send(
     errEnvelope(
       ErrorCode.INTERNAL_ERROR,

--- a/packages/kap-server/src/routes/sessions.ts
+++ b/packages/kap-server/src/routes/sessions.ts
@@ -121,6 +121,7 @@ import type { Session, SessionStatus } from '@moonshot-ai/protocol';
 import { z } from 'zod';
 
 import { errEnvelope, okEnvelope } from '../envelope';
+import { requestLog } from '../lib/requestLog';
 import { defineRoute } from '../middleware/defineRoute';
 import { ensureMainAgent } from '../transport/mainAgent';
 import { parseActionSuffix } from './action-suffix';
@@ -322,7 +323,7 @@ export function registerSessionsRoutes(app: SessionRouteHost, core: Scope): void
         });
         reply.send(okEnvelope(session, req.id));
       } catch (error) {
-        sendMappedError(reply, req.id, error);
+        sendMappedError(reply, req, error);
       }
     },
   );
@@ -577,7 +578,7 @@ export function registerSessionsRoutes(app: SessionRouteHost, core: Scope): void
         }
         reply.send(okEnvelope(session, req.id));
       } catch (error) {
-        sendMappedError(reply, req.id, error);
+        sendMappedError(reply, req, error);
       }
     },
   );
@@ -650,6 +651,10 @@ export function registerSessionsRoutes(app: SessionRouteHost, core: Scope): void
             type: 'event.session.created',
             payload: { agentId: 'main', sessionId: session.id, session },
           });
+          requestLog(req)?.info(
+            { session_id: parsed.id, action: 'fork', new_session_id: session.id },
+            'session action completed',
+          );
           reply.send(okEnvelope(session, req.id));
           return;
         }
@@ -663,6 +668,7 @@ export function registerSessionsRoutes(app: SessionRouteHost, core: Scope): void
           agent.accessor
             .get(IAgentFullCompactionService)
             .begin({ source: 'manual', instruction: normalizeOptional(body.instruction) });
+          requestLog(req)?.info({ session_id: parsed.id, action: 'compact' }, 'session action completed');
           reply.send(okEnvelope({}, req.id));
           return;
         }
@@ -677,6 +683,7 @@ export function registerSessionsRoutes(app: SessionRouteHost, core: Scope): void
           // (cross-domain) and is reused here verbatim.
           agent.accessor.get(IAgentPromptService).undo(body.count);
           const history = agent.accessor.get(IAgentContextMemoryService).get();
+          requestLog(req)?.info({ session_id: parsed.id, action: 'undo' }, 'session action completed');
           const [summary, status] = await Promise.all([
             core.accessor.get(ISessionIndex).get(parsed.id),
             legacy.status(parsed.id),
@@ -703,6 +710,7 @@ export function registerSessionsRoutes(app: SessionRouteHost, core: Scope): void
           // No turnId → cancel whatever turn is active; a safe no-op when idle.
           // v1 always reports success once the session exists.
           await agent.accessor.get(IAgentRPCService).cancel({});
+          requestLog(req)?.info({ session_id: parsed.id, action: 'abort' }, 'session action completed');
           reply.send(okEnvelope({ aborted: true }, req.id));
           return;
         }
@@ -735,6 +743,7 @@ export function registerSessionsRoutes(app: SessionRouteHost, core: Scope): void
             ctx.cwd,
             resolveSessionStatus(core, meta.id),
           );
+          requestLog(req)?.info({ session_id: parsed.id, action: 'restore' }, 'session action completed');
           reply.send(okEnvelope(session, req.id));
           return;
         }
@@ -747,9 +756,10 @@ export function registerSessionsRoutes(app: SessionRouteHost, core: Scope): void
           throw new Error2(ErrorCodes.SESSION_NOT_FOUND, `session ${parsed.id} does not exist`);
         }
         await core.accessor.get(ISessionLifecycleService).archive(parsed.id);
+        requestLog(req)?.info({ session_id: parsed.id, action: 'archive' }, 'session action completed');
         reply.send(okEnvelope({ archived: true }, req.id));
       } catch (error) {
-        sendMappedError(reply, req.id, error);
+        sendMappedError(reply, req, error);
       }
     },
   );
@@ -832,7 +842,7 @@ export function registerSessionsRoutes(app: SessionRouteHost, core: Scope): void
             : projected;
         reply.send(okEnvelope({ items, has_more: slice.length > pageSize }, req.id));
       } catch (error) {
-        sendMappedError(reply, req.id, error);
+        sendMappedError(reply, req, error);
       }
     },
   );
@@ -882,7 +892,7 @@ export function registerSessionsRoutes(app: SessionRouteHost, core: Scope): void
         });
         reply.send(okEnvelope(session, req.id));
       } catch (error) {
-        sendMappedError(reply, req.id, error);
+        sendMappedError(reply, req, error);
       }
     },
   );
@@ -911,7 +921,7 @@ export function registerSessionsRoutes(app: SessionRouteHost, core: Scope): void
         const status = await core.accessor.get(ISessionLegacyService).status(session_id);
         reply.send(okEnvelope(status, req.id));
       } catch (error) {
-        sendMappedError(reply, req.id, error);
+        sendMappedError(reply, req, error);
       }
     },
   );
@@ -940,7 +950,7 @@ export function registerSessionsRoutes(app: SessionRouteHost, core: Scope): void
         const goal = await core.accessor.get(ISessionLegacyService).goal(session_id);
         reply.send(okEnvelope(goal, req.id));
       } catch (error) {
-        sendMappedError(reply, req.id, error);
+        sendMappedError(reply, req, error);
       }
     },
   );
@@ -993,7 +1003,7 @@ export function registerSessionsRoutes(app: SessionRouteHost, core: Scope): void
               ];
         reply.send(okEnvelope({ warnings }, req.id));
       } catch (error) {
-        sendMappedError(reply, req.id, error);
+        sendMappedError(reply, req, error);
       }
     },
   );
@@ -1149,9 +1159,11 @@ function buildValidationEnvelope(
 
 function sendMappedError(
   reply: { send(payload: unknown): unknown },
-  requestId: string,
+  req: { id: string },
   err: unknown,
 ): void {
+  const requestId = req.id;
+  const log = requestLog(req);
   if (isError2(err)) {
     switch (err.code) {
       case 'session.not_found':
@@ -1202,6 +1214,7 @@ function sendMappedError(
         return;
     }
   }
+  log?.error({ err }, 'session request failed');
   reply.send(
     errEnvelope(
       ErrorCode.INTERNAL_ERROR,

--- a/packages/kap-server/src/routes/shutdown.ts
+++ b/packages/kap-server/src/routes/shutdown.ts
@@ -10,6 +10,7 @@
 import { z } from 'zod';
 
 import { okEnvelope } from '../envelope';
+import { requestLog } from '../lib/requestLog';
 import { defineRoute } from '../middleware/defineRoute';
 
 interface ShutdownRouteHost {
@@ -40,6 +41,10 @@ export function registerShutdownRoutes(
       tags: ['meta'],
     },
     (req, reply) => {
+      requestLog(req)?.info(
+        { remoteAddress: (req as unknown as { ip?: string }).ip },
+        'shutdown requested',
+      );
       reply.send(okEnvelope({ ok: true }, req.id));
       // Let the response flush before tearing the server down.
       setImmediate(() => opts.onShutdown());

--- a/packages/kap-server/src/routes/skills.ts
+++ b/packages/kap-server/src/routes/skills.ts
@@ -103,6 +103,7 @@ import {
 import { z } from 'zod';
 
 import { errEnvelope, okEnvelope } from '../envelope';
+import { requestLog } from '../lib/requestLog';
 import { defineRoute } from '../middleware/defineRoute';
 import { ensureMainAgent } from '../transport/mainAgent';
 import { parseActionSuffix } from './action-suffix';
@@ -283,6 +284,7 @@ export function registerSkillsRoutes(app: SkillsRouteHost, core: Scope): void {
         await agent.accessor
           .get(IAgentSkillService)
           .activate({ name: parsed.id, args: req.body.args });
+        requestLog(req)?.info({ session_id, skill_name: parsed.id }, 'skill activated');
         reply.send(okEnvelope({ activated: true, skill_name: parsed.id }, req.id));
       } catch (err) {
         sendMappedError(reply, req.id, err);

--- a/packages/kap-server/src/routes/tasks.ts
+++ b/packages/kap-server/src/routes/tasks.ts
@@ -57,6 +57,7 @@ import type { Task, TaskKind, TaskStatus } from '@moonshot-ai/protocol';
 import { z } from 'zod';
 
 import { errEnvelope, okEnvelope } from '../envelope';
+import { requestLog } from '../lib/requestLog';
 import { defineRoute } from '../middleware/defineRoute';
 import { ensureMainAgent } from '../transport/mainAgent';
 import { parseActionSuffix } from './action-suffix';
@@ -256,6 +257,7 @@ export function registerTasksRoutes(app: TasksRouteHost, core: Scope): void {
       }
 
       await resolved.tasks?.stop(task_id);
+      requestLog(req)?.info({ session_id, task_id }, 'task cancelled');
       reply.send(okEnvelope({ cancelled: true as const }, req.id));
     },
   );

--- a/packages/kap-server/src/routes/terminals.ts
+++ b/packages/kap-server/src/routes/terminals.ts
@@ -38,6 +38,7 @@ import {
 import { z } from 'zod';
 
 import { errEnvelope, okEnvelope } from '../envelope';
+import { requestLog } from '../lib/requestLog';
 import { defineRoute } from '../middleware/defineRoute';
 import { parseActionSuffix } from './action-suffix';
 
@@ -139,6 +140,7 @@ export function registerTerminalsRoutes(app: TerminalsRouteHost, core: Scope): v
       try {
         const { session_id } = req.params;
         const terminal = await (await resolveTerminal(core, session_id)).create(req.body);
+        requestLog(req)?.info({ session_id, terminal_id: terminal.id }, 'terminal created');
         reply.send(okEnvelope(terminal, req.id));
       } catch (err) {
         sendMappedError(reply, req.id, err);
@@ -211,6 +213,7 @@ export function registerTerminalsRoutes(app: TerminalsRouteHost, core: Scope): v
           return;
         }
         const result = await (await resolveTerminal(core, session_id)).close(parsed.id);
+        requestLog(req)?.info({ session_id, terminal_id: parsed.id }, 'terminal closed');
         reply.send(okEnvelope(result, req.id));
       } catch (err) {
         sendMappedError(reply, req.id, err);

--- a/packages/kap-server/src/routes/workspaces.ts
+++ b/packages/kap-server/src/routes/workspaces.ts
@@ -46,6 +46,7 @@ import { isAbsolute, join } from 'node:path';
 import { z } from 'zod';
 
 import { errEnvelope, okEnvelope } from '../envelope';
+import { requestLog } from '../lib/requestLog';
 import { defineRoute } from '../middleware/defineRoute';
 
 interface WorkspaceRouteHost {
@@ -207,6 +208,7 @@ export function registerWorkspacesRoutes(app: WorkspaceRouteHost, core: Scope): 
         return;
       }
       await registry.delete(workspace_id);
+      requestLog(req)?.info({ workspace_id }, 'workspace deleted');
       reply.send(okEnvelope({ deleted: true as const }, req.id));
     },
   );

--- a/packages/kap-server/src/services/guiStore/guiStoreService.ts
+++ b/packages/kap-server/src/services/guiStore/guiStoreService.ts
@@ -10,6 +10,13 @@ import { parse as parseToml, stringify as stringifyToml } from 'smol-toml';
 
 import { IGuiStoreService } from './guiStore';
 
+/** Minimal logger surface — keeps the store decoupled from the server logger. */
+export interface GuiStoreLogger {
+  warn(obj: unknown, msg: string): void;
+}
+
+const noopLogger: GuiStoreLogger = { warn: () => {} };
+
 function emptyStore(): Record<string, string> {
   return Object.create(null) as Record<string, string>;
 }
@@ -18,10 +25,12 @@ export class GuiStoreService implements IGuiStoreService {
   readonly _serviceBrand: undefined;
 
   private readonly filePath: string;
+  private readonly logger: GuiStoreLogger;
   private queue: Promise<void> = Promise.resolve();
 
-  constructor(homeDir: string) {
+  constructor(homeDir: string, logger?: GuiStoreLogger) {
     this.filePath = join(homeDir, 'gui.toml');
+    this.logger = logger ?? noopLogger;
   }
 
   async getItem(key: string): Promise<string | null> {
@@ -82,7 +91,11 @@ export class GuiStoreService implements IGuiStoreService {
         if (typeof v === 'string') out[k] = v;
       }
       return out;
-    } catch {
+    } catch (error) {
+      this.logger.warn(
+        { filePath: this.filePath, err: error },
+        'gui.toml parse failed; using an empty store',
+      );
       return emptyStore();
     }
   }

--- a/packages/kap-server/src/start.ts
+++ b/packages/kap-server/src/start.ts
@@ -203,10 +203,12 @@ export async function startServer(opts: ServerStartOptions = {}): Promise<Runnin
   const enableShutdown = exposureClass === 'loopback' || opts.allowRemoteShutdown === true;
   const enableTerminals = exposureClass === 'loopback' || opts.allowRemoteTerminals === true;
   const debugEndpoints = exposureClass === 'loopback' && opts.debugEndpoints === true;
-  const authFailureLimiter = exposureClass === 'loopback' ? undefined : createAuthFailureLimiter();
+  const logger = opts.logger ?? createServerLogger({ level: opts.logLevel ?? 'info' });
+  const authFailureLimiter =
+    exposureClass === 'loopback' ? undefined : createAuthFailureLimiter({ logger });
 
   const configPath = resolveConfigPath({ homeDir, configPath: opts.configPath });
-  const guiStore = new GuiStoreService(homeDir);
+  const guiStore = new GuiStoreService(homeDir, logger);
   let authTokenService: IAuthTokenService;
   // Whether a password credential is configured (only meaningful for the real,
   // non-injected auth impl). Drives the token-only warning on a public bind.
@@ -244,7 +246,6 @@ export async function startServer(opts: ServerStartOptions = {}): Promise<Runnin
     ...(opts.seeds ?? []),
   ]);
 
-  const logger = opts.logger ?? createServerLogger({ level: opts.logLevel ?? 'info' });
   if (exposureClass !== 'loopback') {
     logger.warn(
       { host, exposureClass },
@@ -395,7 +396,7 @@ export async function startServer(opts: ServerStartOptions = {}): Promise<Runnin
     enableTerminals,
     guiStore,
     onShutdown: () => {
-      void close();
+      void close().catch((err: unknown) => logger.error({ err }, 'server close failed'));
     },
     connectionRegistry,
     broadcaster,
@@ -404,7 +405,7 @@ export async function startServer(opts: ServerStartOptions = {}): Promise<Runnin
   });
 
   registerRpcRoutes(app, core, { token: opts.rpcToken });
-  const wssV2 = registerWs(core, { validateCredential, registry: connectionRegistry });
+  const wssV2 = registerWs(core, { validateCredential, registry: connectionRegistry, logger });
   const wssV1 = registerWsV1(core, {
     validateCredential,
     registry: connectionRegistry,
@@ -432,11 +433,19 @@ export async function startServer(opts: ServerStartOptions = {}): Promise<Runnin
     // Origin is present-only: a missing Origin is treated as a non-browser
     // client and allowed.
     if (!hostCheck.isAllowed(req.headers.host)) {
+      logger.warn(
+        { remoteAddress: req.socket.remoteAddress, path: url, reason: 'host_not_allowed' },
+        'ws upgrade rejected',
+      );
       (socket as Socket).write('HTTP/1.1 403 Forbidden\r\nConnection: close\r\n\r\n');
       (socket as Socket).destroy();
       return;
     }
     if (!isOriginAllowed(req.headers.origin, req.headers.host, allowedOrigins)) {
+      logger.warn(
+        { remoteAddress: req.socket.remoteAddress, path: url, reason: 'origin_not_allowed' },
+        'ws upgrade rejected',
+      );
       (socket as Socket).write('HTTP/1.1 403 Forbidden\r\nConnection: close\r\n\r\n');
       (socket as Socket).destroy();
       return;
@@ -453,11 +462,28 @@ export async function startServer(opts: ServerStartOptions = {}): Promise<Runnin
       if (candidate !== null) {
         try {
           ok = await validateCredential(candidate);
-        } catch {
+        } catch (error) {
+          logger.warn(
+            {
+              err: error,
+              remoteAddress: req.socket.remoteAddress,
+              path: url,
+              reason: 'credential_validation_error',
+            },
+            'ws upgrade rejected',
+          );
           ok = false;
         }
       }
       if (!ok) {
+        logger.warn(
+          {
+            remoteAddress: req.socket.remoteAddress,
+            path: url,
+            reason: candidate === null ? 'missing_credential' : 'invalid_credential',
+          },
+          'ws upgrade rejected',
+        );
         (socket as Socket).write('HTTP/1.1 401 Unauthorized\r\nConnection: close\r\n\r\n');
         (socket as Socket).destroy();
         return;
@@ -472,7 +498,9 @@ export async function startServer(opts: ServerStartOptions = {}): Promise<Runnin
     }
   };
   app.server.on('upgrade', (req, socket, head) => {
-    void handleUpgrade(req, socket, head);
+    void handleUpgrade(req, socket, head).catch((error: unknown) =>
+      logger.error({ err: error }, 'ws upgrade handler failed'),
+    );
   });
 
   app.addHook('onClose', async () => {

--- a/packages/kap-server/src/transport/registerRpcRoutes.ts
+++ b/packages/kap-server/src/transport/registerRpcRoutes.ts
@@ -15,8 +15,9 @@
  */
 
 import type { Scope } from '@moonshot-ai/agent-core-v2';
-import { okEnvelope } from '@moonshot-ai/protocol';
+import { ErrorCode, okEnvelope } from '@moonshot-ai/protocol';
 
+import { requestLog } from '../lib/requestLog';
 import type { ScopeKind } from './channel';
 import { describeChannels } from './channelRegistry';
 import { dispatch } from './dispatcher';
@@ -116,7 +117,16 @@ function makeHandler(
       );
       return reply.send(okEnvelope(result, requestId));
     } catch (error) {
-      return reply.send(mapError(error, requestId));
+      const envelope = mapError(error, requestId);
+      // 50001 (including the 30s call timeout) is a server-side failure — log
+      // at error; mapped business codes (4xxxx) are expected client outcomes.
+      const log = requestLog(req);
+      if (envelope.code === ErrorCode.INTERNAL_ERROR) {
+        log?.error({ err: error, service, method }, 'rpc dispatch failed');
+      } else {
+        log?.warn({ err: error, service, method }, 'rpc dispatch failed');
+      }
+      return reply.send(envelope);
     }
   };
 }

--- a/packages/kap-server/src/transport/ws/registerWs.ts
+++ b/packages/kap-server/src/transport/ws/registerWs.ts
@@ -15,7 +15,7 @@ import { WebSocketServer } from 'ws';
 
 import type { CredentialValidator } from '../../services/auth/credentials';
 import { type IConnectionRegistry } from './connectionRegistry';
-import { WsConnection } from './wsConnection';
+import { WsConnection, type WsConnectionLogger } from './wsConnection';
 import { selectWsBearerProtocol } from './bearerProtocol';
 
 export interface RegisterWsOptions {
@@ -24,6 +24,8 @@ export interface RegisterWsOptions {
   readonly callTimeoutMs?: number;
   /** Registry that tracks live connections; populated by this module. */
   readonly registry: IConnectionRegistry;
+  /** Per-connection logger forwarded to {@link WsConnection}. */
+  readonly logger?: WsConnectionLogger;
 }
 
 export const WS_PATH = '/api/v2/ws';
@@ -40,6 +42,7 @@ export function registerWs(core: Scope, opts: RegisterWsOptions): WebSocketServe
       callTimeoutMs: opts.callTimeoutMs,
       remoteAddress: req.socket.remoteAddress ?? null,
       userAgent: req.headers['user-agent'] ?? null,
+      logger: opts.logger,
     });
     registry.add(conn);
     socket.on('close', () => registry.remove(conn.id));

--- a/packages/kap-server/src/transport/ws/v1/sessionEventBroadcaster.ts
+++ b/packages/kap-server/src/transport/ws/v1/sessionEventBroadcaster.ts
@@ -377,7 +377,9 @@ export class SessionEventBroadcaster {
         session: payload.session,
         agentId: 'main',
         sessionId: payload.sessionId,
-      } as Event);
+      } as Event).catch((error: unknown) =>
+        this.logDispatchError(payload.sessionId, 'event.session.created', error),
+      );
       return;
     }
     if (event.type === 'session.meta.updated') {
@@ -398,7 +400,9 @@ export class SessionEventBroadcaster {
         ...payload,
         agentId: 'main',
         sessionId,
-      } as Event);
+      } as Event).catch((error: unknown) =>
+        this.logDispatchError(sessionId, 'session.meta.updated', error),
+      );
     }
   }
 
@@ -406,7 +410,7 @@ export class SessionEventBroadcaster {
     const state = await this.ensureGlobalState();
     state.queue = state.queue
       .then(() => this.dispatch(state, event, isVolatileEventType(event.type)))
-      .catch(() => {});
+      .catch((error: unknown) => this.logDispatchDropped(state.sessionId, event.type, error));
   }
 
   /**
@@ -431,7 +435,7 @@ export class SessionEventBroadcaster {
     if (state === undefined) return;
     state.queue = state.queue
       .then(() => this.dispatch(state, event, isVolatileEventType(event.type)))
-      .catch(() => {});
+      .catch((error: unknown) => this.logDispatchDropped(state.sessionId, event.type, error));
   }
 
   private attachAgents(sessionId: string, session: ISessionScopeHandle, state: SessionState): void {
@@ -523,7 +527,7 @@ export class SessionEventBroadcaster {
         } as unknown as Event;
         state.queue = state.queue
           .then(() => this.dispatch(state, wireEvent, true))
-          .catch(() => {});
+          .catch((error: unknown) => this.logDispatchDropped(state.sessionId, wireEvent.type, error));
       }
       return;
     }
@@ -555,7 +559,7 @@ export class SessionEventBroadcaster {
     const volatile = isVolatileSignal(event.type);
     state.queue = state.queue
       .then(() => this.dispatch(state, wireEvent, volatile))
-      .catch(() => {});
+      .catch((error: unknown) => this.logDispatchDropped(state.sessionId, wireEvent.type, error));
     if (agentId === MAIN_AGENT_ID && event.type === 'turn.ended') {
       // Emit completion after the turn event. Pending interactions remain higher
       // priority; otherwise failed/cancelled/blocked turns abort and all others
@@ -573,7 +577,7 @@ export class SessionEventBroadcaster {
     if (legacy !== undefined) {
       state.queue = state.queue
         .then(() => this.dispatch(state, legacy, volatile))
-        .catch(() => {});
+        .catch((error: unknown) => this.logDispatchDropped(state.sessionId, legacy.type, error));
     }
   }
 
@@ -621,7 +625,9 @@ export class SessionEventBroadcaster {
   }
 
   private enqueueDurable(state: SessionState, event: Event): void {
-    state.queue = state.queue.then(() => this.dispatch(state, event, false)).catch(() => {});
+    state.queue = state.queue
+      .then(() => this.dispatch(state, event, false))
+      .catch((error: unknown) => this.logDispatchDropped(state.sessionId, event.type, error));
   }
 
   private enqueueStatusChanged(state: SessionState, status: SessionStatus): void {
@@ -642,7 +648,34 @@ export class SessionEventBroadcaster {
           false,
         );
       })
-      .catch(() => {});
+      .catch((error: unknown) =>
+        this.logDispatchDropped(state.sessionId, 'event.session.status_changed', error),
+      );
+  }
+
+  /**
+   * Log a rejected `dispatchSessionEvent` promise — the session's scope was
+   * torn down mid-dispatch, or a non-disposed error escaped `ensureState`.
+   */
+  private logDispatchError(sessionId: string, eventType: string, error: unknown): void {
+    const logger = this.opts.logger;
+    if (logger === undefined) return;
+    if (logger.error !== undefined) {
+      logger.error({ sessionId, eventType, err: error }, 'session event dispatch failed');
+    } else {
+      logger.warn({ sessionId, eventType, err: error }, 'session event dispatch failed');
+    }
+  }
+
+  /**
+   * A queued dispatch rejected: the event is permanently lost (and, for durable
+   * events, the seq is skipped). Warn instead of swallowing it silently.
+   */
+  private logDispatchDropped(sessionId: string, eventType: string, error: unknown): void {
+    this.opts.logger?.warn(
+      { sessionId, eventType, err: error },
+      'session event dispatch failed; event dropped',
+    );
   }
 
   private async dispatch(state: SessionState, event: Event, volatile: boolean): Promise<void> {

--- a/packages/kap-server/src/transport/ws/v1/sessionEventJournal.ts
+++ b/packages/kap-server/src/transport/ws/v1/sessionEventJournal.ts
@@ -67,6 +67,7 @@ export interface JournalEntry {
 /** Minimal logger surface — keeps the journal decoupled from the server logger. */
 export interface JournalLogger {
   warn(obj: unknown, msg: string): void;
+  error?(obj: unknown, msg: string): void;
 }
 
 const noopLogger: JournalLogger = { warn: () => {} };

--- a/packages/kap-server/src/transport/ws/wsConnection.ts
+++ b/packages/kap-server/src/transport/ws/wsConnection.ts
@@ -19,6 +19,7 @@
  */
 
 import { ErrorCodes, Error2, type IDisposable, type Scope } from '@moonshot-ai/agent-core-v2';
+import { ErrorCode } from '@moonshot-ai/protocol';
 import { ulid } from 'ulid';
 import type { RawData, WebSocket } from 'ws';
 
@@ -31,6 +32,14 @@ import type { CallMessage, ListenMessage, ServerMessage } from './wsProtocol';
 import { clientMessageSchema } from './wsProtocol';
 
 const DEFAULT_CALL_TIMEOUT_MS = 30_000;
+
+/** Minimal logger surface — keeps the connection decoupled from the server logger. */
+export interface WsConnectionLogger {
+  warn(obj: unknown, msg: string): void;
+  error(obj: unknown, msg: string): void;
+}
+
+const noopLogger: WsConnectionLogger = { warn: () => {}, error: () => {} };
 
 interface PendingEntry {
   /** Dispose the listener / drop the call result. */
@@ -54,6 +63,8 @@ export interface WsConnectionOptions {
   readonly remoteAddress: string | null;
   /** `User-Agent` header from the upgrade request. Null when absent. */
   readonly userAgent: string | null;
+  /** Server-side logger for dispatch / serialization / socket failures. */
+  readonly logger?: WsConnectionLogger;
 }
 
 export class WsConnection {
@@ -65,6 +76,7 @@ export class WsConnection {
   private readonly core: Scope;
   private readonly validateCredential?: CredentialValidator;
   private readonly callTimeoutMs: number;
+  private readonly logger: WsConnectionLogger;
 
   private closed = false;
   private gotHello = false;
@@ -82,10 +94,14 @@ export class WsConnection {
     this.core = opts.core;
     this.validateCredential = opts.validateCredential;
     this.callTimeoutMs = opts.callTimeoutMs ?? DEFAULT_CALL_TIMEOUT_MS;
+    this.logger = opts.logger ?? noopLogger;
 
     this.socket.on('message', (data: RawData) => this.onMessage(data));
     this.socket.on('close', () => this.onClose());
-    this.socket.on('error', () => this.onClose());
+    this.socket.on('error', (err) => {
+      this.logger.warn({ err, connId: this.id }, 'ws socket error');
+      this.onClose();
+    });
 
     this.send({ type: 'ready' });
   }
@@ -203,6 +219,14 @@ export class WsConnection {
       if (settled || this.closed) return;
       this.pending.delete(msg.id);
       const env = mapError(error, msg.id);
+      // 50001 (incl. call timeout) is a server-side failure; mapped business
+      // codes are expected client outcomes — mirror the REST RPC route.
+      const ctx = { err: error, connId: this.id, service: msg.service, method: msg.method };
+      if (env.code === ErrorCode.INTERNAL_ERROR) {
+        this.logger.error(ctx, 'ws rpc call failed');
+      } else {
+        this.logger.warn(ctx, 'ws rpc call failed');
+      }
       this.send({ type: 'error', id: msg.id, code: env.code, msg: env.msg });
     }
   }
@@ -253,6 +277,12 @@ export class WsConnection {
       }
     } catch (error) {
       const env = mapError(error, msg.id);
+      const ctx = { err: error, connId: this.id, service: msg.service, event: msg.event };
+      if (env.code === ErrorCode.INTERNAL_ERROR) {
+        this.logger.error(ctx, 'ws listen failed');
+      } else {
+        this.logger.warn(ctx, 'ws listen failed');
+      }
       this.send({ type: 'error', id: msg.id, code: env.code, msg: env.msg });
       return;
     }
@@ -329,6 +359,12 @@ export class WsConnection {
       this.send({ type: 'event', id, eventId, data: wire });
     } catch (error) {
       const env = mapError(error, id);
+      // Serialization failures cancel the whole listen subscription below —
+      // log so the dropped event stream is diagnosable.
+      this.logger.warn(
+        { err: error, connId: this.id, event },
+        'ws event send failed; subscription cancelled',
+      );
       this.send({ type: 'error', id, code: env.code, msg: env.msg });
       this.cancel(id);
     }


### PR DESCRIPTION
## Related Issue

No linked issue — the problem is explained below.

## Problem

In the web UI, many actions failed silently: clicking stop/archive, toggling plan/swarm/permission mode, OAuth login polling, and file preview could all fail with no visible feedback and no log anywhere. On the server side, several blind spots made these failures undiagnosable:

- Routes that map errors to envelope codes themselves (prompts, sessions, fs, messages, files, sessionExport) never logged them — including the 50001 internal-error fallback.
- The whole `/api/v2` REST RPC surface and the v2 WS connection logged nothing on dispatch failure or timeout.
- WS upgrade auth rejections (401/403) bypass Fastify hooks and produced no log at all.
- Key operations (abort, cancel, approval decisions, archive, shutdown, config changes) left no trace in `server.log`.
- Three `void promise` sites could crash the process with an unhandled rejection.

## What changed

**Web UI** (`apps/kimi-web`):

- `pushOperationFailure` (the shared error-toast path used by stop/archive/send/approve/etc.) now also writes `console.error` and an always-on `operation:failed` trace event that lands in the exported web log, with error code, request id, and HTTP status.
- Silent failure sites fixed: mode/permission/thinking toggles now toast when the daemon rejects the profile update; file preview shows an error state instead of a fake empty file; OAuth login polling gives up with an explicit error page after repeated failures instead of spinning forever; workspace/session-load fallbacks and the dev-backend switch log warnings.

**Server** (`packages/kap-server`):

- The 50001 fallback in the six self-mapping routes now logs at error level; `POST /config` and `/api/v2` RPC dispatch failures are logged (error for internal/timeout, warn for business codes).
- The v2 WS connection takes a logger and logs call/listen/send failures; WS upgrade 401/403 rejections are logged with remote address and reason.
- The v1 session-event broadcaster's seven empty catches (which silently dropped events and skipped seqs) now warn, and the three unhandled-rejection sites log instead of crashing.
- Info-level lines for key operations: prompt/session abort, task cancel, approval decisions (with decision and scope), archive/restore/compact/undo/fork, question answer/dismiss, terminal create/close, skill activate, workspace/file delete, OAuth login/logout, config changes (field names only, never values), and shutdown requests.
- Rate-limit bans, `gui.toml` parse failures, download-stream errors, and open-in-app launch failures now warn.

Approach: logging only where the information was previously unrecoverable — the existing per-request access log already carries envelope codes, so new logs add session/operation context rather than duplicating it.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [ ] I have added tests that prove my feature works. (Logging-only change; existing suites pass: kimi-web 492 tests + typecheck, kap-server 630 tests + typecheck.)
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update. (No new flags or config; docs already cover `--log-level` and server logs.)
