### PR TITLE
feat(kimi-code): keep print-mode goal runs alive until the goal settles

### DIFF
--- a/.changeset/align-print-background-policy.md
+++ b/.changeset/align-print-background-policy.md
@@ -2,4 +2,4 @@
 "@moonshot-ai/kimi-code": patch
 ---
 
-Align the print-mode background-task policy across engines: `print_background_mode` and `print_max_turns` now take effect for `kimi -p` on the experimental engine, with the same exit / drain / steer semantics and defaults as the default engine.
+Align the print-mode run lifecycle across engines: `print_background_mode` and `print_max_turns` now take effect for `kimi -p` on the experimental engine, with the same exit / drain / steer semantics and defaults as the default engine, and `kimi -p "/goal ..."` now stays alive until the goal reaches a terminal state instead of exiting after the first turn.

--- a/apps/kimi-code/src/cli/v2/run-v2-print.ts
+++ b/apps/kimi-code/src/cli/v2/run-v2-print.ts
@@ -86,6 +86,8 @@ import {
 const PROMPT_UI_MODE = 'print';
 const DEFAULT_PRINT_WAIT_CEILING_S = 3600;
 const DEFAULT_PRINT_MAX_TURNS = 50;
+/** Re-check `goalActive` at least this often while waiting for goal turns. */
+const GOAL_WAIT_POLL_MS = 250;
 
 export async function runV2Print(
   opts: CLIOptions,
@@ -604,11 +606,15 @@ export async function applyPrintBackgroundPolicy(
   if (input.goalActive !== undefined) {
     const goalDeadline = input.now() + input.ceilingS * 1000;
     while (input.goalActive()) {
+      // Also wake on a short poll: a goal can leave `active` without any
+      // further turn.ended (budget block at a turn boundary, or a pause after
+      // a continuation-launch failure), which would otherwise hang the run
+      // until the ceiling.
       const ended = await input.turnEndings.next(
-        goalDeadline - input.now(),
+        Math.min(goalDeadline - input.now(), GOAL_WAIT_POLL_MS),
         input.skipTurnId,
       );
-      if (ended === null) {
+      if (ended === null && input.now() >= goalDeadline) {
         input.warn(`print goal wait ceiling reached (${input.ceilingS}s), finishing`);
         return;
       }

--- a/apps/kimi-code/src/cli/v2/run-v2-print.ts
+++ b/apps/kimi-code/src/cli/v2/run-v2-print.ts
@@ -373,6 +373,7 @@ async function runNativeTurn(
     if (result.type === 'completed') {
       const configService = app.accessor.get(IConfigService);
       const taskConfig = resolveAgentTaskConfig(configService);
+      const goalService = agent.accessor.get(IAgentGoalService);
       try {
         await applyPrintBackgroundPolicy({
           mode: resolvePrintBackgroundMode(configService),
@@ -384,6 +385,7 @@ async function runNativeTurn(
           skipTurnId: turn.id,
           warn: (message) => stderr.write(`Warning: ${message}\n`),
           now: () => Date.now(),
+          goalActive: () => goalService.getGoal().goal?.status === 'active',
         });
       } catch (error) {
         // A steered turn that fails fails the run (v1 parity). Anything else
@@ -537,9 +539,11 @@ export function createPrintTurnEndings(): PrintTurnEndings & {
             // oxlint-disable-next-line promise/no-multiple-resolved -- `settled` guards the single resolve; the rule cannot see it
             resolve(value);
           };
-          const timer = setTimeout(() => {
-            settle(null);
-          }, ms);
+          const timer = Number.isFinite(ms)
+            ? setTimeout(() => {
+                settle(null);
+              }, ms)
+            : undefined;
           waiter = settle;
         });
       for (;;) {
@@ -571,11 +575,21 @@ export interface PrintBackgroundPolicyInput {
   readonly skipTurnId: number;
   readonly warn: (message: string) => void;
   readonly now: () => number;
+  /**
+   * Reports whether an agent goal is still `active`. v2 drives goal
+   * continuation as new turns (v1 keeps a single turn alive), so a `-p` goal
+   * run must stay alive until the goal leaves `active`, independent of the
+   * background policy.
+   */
+  readonly goalActive?: () => boolean;
 }
 
 /**
  * Apply the print-mode (`kimi -p`) background-task policy after the main turn
  * completes. Mirrors v1's `Session.handlePrintMainTurnCompleted`:
+ *  - goal    : while a goal is `active`, keep waiting for its continuation
+ *              turns (bounded by `ceilingS` as a safety net), regardless of
+ *              the background mode; the goal summary drives the exit code.
  *  - 'exit'  : return immediately (default).
  *  - 'drain' : suppress + drain background tasks, then return.
  *  - 'steer' : while background tasks are still pending, stay alive so task
@@ -587,6 +601,21 @@ export interface PrintBackgroundPolicyInput {
 export async function applyPrintBackgroundPolicy(
   input: PrintBackgroundPolicyInput,
 ): Promise<void> {
+  if (input.goalActive !== undefined) {
+    const goalDeadline = input.now() + input.ceilingS * 1000;
+    while (input.goalActive()) {
+      const ended = await input.turnEndings.next(
+        goalDeadline - input.now(),
+        input.skipTurnId,
+      );
+      if (ended === null) {
+        input.warn(`print goal wait ceiling reached (${input.ceilingS}s), finishing`);
+        return;
+      }
+      // A continuation turn that does not complete pauses/blocks the goal, so
+      // the loop condition exits on the next check.
+    }
+  }
   if (input.mode === 'exit') return;
   if (input.mode === 'drain') {
     await input.drain();

--- a/apps/kimi-code/test/cli/run-v2-print.test.ts
+++ b/apps/kimi-code/test/cli/run-v2-print.test.ts
@@ -208,6 +208,7 @@ describe('applyPrintBackgroundPolicy', () => {
   });
 
   it('warns and returns when the goal wait hits the ceiling', async () => {
+    let now = 0;
     const warn = vi.fn();
     await applyPrintBackgroundPolicy({
       mode: 'exit',
@@ -215,15 +216,45 @@ describe('applyPrintBackgroundPolicy', () => {
       maxTurns: 50,
       countPending: () => 0,
       drain: async () => {},
-      // Empty script: no continuation turn ever ends.
-      turnEndings: scriptedTurnEndings([]),
+      // No continuation turn ever ends; the poll interval elapses each time.
+      turnEndings: {
+        next: async () => {
+          now = 10_001;
+          return null;
+        },
+      },
       skipTurnId: 1,
       warn,
-      now: () => Date.now(),
+      now: () => now,
       goalActive: () => true,
     });
     expect(warn).toHaveBeenCalledTimes(1);
     expect(warn.mock.calls[0]?.[0]).toContain('goal wait ceiling');
+  });
+
+  it('exits the goal wait promptly when the goal settles without a turn ending', async () => {
+    let active = true;
+    const warn = vi.fn();
+    await applyPrintBackgroundPolicy({
+      mode: 'exit',
+      ceilingS: 3600,
+      maxTurns: 50,
+      countPending: () => 0,
+      drain: async () => {},
+      // Poll interval elapses; the goal settles (paused/blocked) mid-wait
+      // without producing a turn.ended.
+      turnEndings: {
+        next: async () => {
+          active = false;
+          return null;
+        },
+      },
+      skipTurnId: 1,
+      warn,
+      now: () => Date.now(),
+      goalActive: () => active,
+    });
+    expect(warn).not.toHaveBeenCalled();
   });
 });
 

--- a/apps/kimi-code/test/cli/run-v2-print.test.ts
+++ b/apps/kimi-code/test/cli/run-v2-print.test.ts
@@ -176,6 +176,55 @@ describe('applyPrintBackgroundPolicy', () => {
       }),
     ).rejects.toThrow(PrintSteeredTurnFailedError);
   });
+
+  it('waits for goal continuation turns before applying the mode', async () => {
+    let active = true;
+    let consumed = 0;
+    const drain = vi.fn(async () => {});
+    await applyPrintBackgroundPolicy({
+      mode: 'drain',
+      ceilingS: 60,
+      maxTurns: 50,
+      countPending: () => 0,
+      drain,
+      turnEndings: scriptedTurnEndings([
+        { event: ending(2), apply: () => { consumed += 1; } },
+        {
+          event: ending(3),
+          apply: () => {
+            consumed += 1;
+            active = false;
+          },
+        },
+      ]),
+      skipTurnId: 1,
+      warn: () => {},
+      now: () => Date.now(),
+      goalActive: () => active,
+    });
+    // Both continuation turns ended before the mode ('drain') ran.
+    expect(consumed).toBe(2);
+    expect(drain).toHaveBeenCalledTimes(1);
+  });
+
+  it('warns and returns when the goal wait hits the ceiling', async () => {
+    const warn = vi.fn();
+    await applyPrintBackgroundPolicy({
+      mode: 'exit',
+      ceilingS: 10,
+      maxTurns: 50,
+      countPending: () => 0,
+      drain: async () => {},
+      // Empty script: no continuation turn ever ends.
+      turnEndings: scriptedTurnEndings([]),
+      skipTurnId: 1,
+      warn,
+      now: () => Date.now(),
+      goalActive: () => true,
+    });
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(warn.mock.calls[0]?.[0]).toContain('goal wait ceiling');
+  });
 });
 
 describe('createPrintTurnEndings', () => {


### PR DESCRIPTION
## Related Issue

No linked issue — the problem is explained below. (This is the one remaining piece of #1710, which duplicated the already-merged #1704 and was closed.)

## Problem

On the experimental engine (agent-core-v2), `kimi -p "/goal ..."` exited right after the first turn even when the goal was still `active`. v2 drives goal continuation by launching **new** turns (v1 keeps a single turn alive across the whole goal), and the print runner only awaited the first turn's result, so the cleanup path cancelled the continuation turn milliseconds after it started — multi-turn goals could never complete in print mode. This contradicts the documented headless-goal contract ("the goal driver keeps the prompt's turn-run alive across continuation turns until the goal reaches a terminal state").

## What changed

- The print background policy (`applyPrintBackgroundPolicy`) gains a `goalActive` probe: while a goal is `active`, the run keeps waiting for continuation turns regardless of the `print_background_mode`, bounded by `print_wait_ceiling_s` as a safety net (with a warning if hit). Once the goal reaches a terminal state, the normal exit / drain / steer policy applies, and the goal summary still drives the exit code.
- The `turn.ended` collector accepts a non-finite wait budget (no timer) used by the goal wait.
- Unit tests cover waiting through continuation turns and the goal-wait ceiling; verified end-to-end with the SEA build: a 3-turn counting goal completes (`Goal [complete] (turns: 3)`, exit 0), a 1-turn budget blocks the goal (`Goal [blocked]`, exit 3).

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.
