### PR TITLE
test(klient): add real-server smoke coverage

### DIFF
--- a/packages/klient/README.md
+++ b/packages/klient/README.md
@@ -52,3 +52,38 @@ automatically after an unexpected close (active `listen`s are re-subscribed;
 in-flight calls reject). The bearer token rides the
 `kimi-code.bearer.<token>` subprotocol, so the transport works unchanged in
 browsers.
+
+## Real-server smoke checks
+
+Run the transport smoke against a real server (the model phase is opt-in). It
+creates and archives a fixture session, and therefore touches the selected
+workspace's persisted metadata:
+
+```sh
+KIMI_SERVER_URL=http://127.0.0.1:58627 \
+KIMI_SERVER_TOKEN=YOUR_SERVER_TOKEN \
+pnpm smoke
+
+KIMI_SMOKE_MODEL=YOUR_MODEL pnpm smoke
+```
+
+The history smoke checks persisted sessions before warming one, including the
+cold-session regression where an indexed session is unavailable through the v2
+session scope. It sends no explicit mutation request. When `KIMI_SMOKE_MARKER`
+is set, the v1 message read resumes the session and may persist server-side
+legacy metadata migrations:
+
+```sh
+KIMI_SERVER_URL=http://127.0.0.1:58627 \
+KIMI_SERVER_TOKEN=YOUR_SERVER_TOKEN \
+KIMI_SMOKE_EXPECT_SESSION_ID=YOUR_SESSION_ID \
+KIMI_SMOKE_MARKER=YOUR_MARKER \
+KIMI_SMOKE_REQUIRE_HISTORY=1 \
+pnpm smoke:history
+```
+
+`KIMI_SMOKE_EXPECT_CWD` can select a session by working directory instead of
+`KIMI_SMOKE_EXPECT_SESSION_ID`. The transport smoke creates its fixture in the
+first registered workspace; set `KIMI_SMOKE_CWD` when a different server-local
+folder is required. Omit `KIMI_SERVER_TOKEN` only for a server started with
+authentication bypassed.

--- a/packages/klient/examples/basic.ts
+++ b/packages/klient/examples/basic.ts
@@ -11,7 +11,7 @@ import { HttpChannel, Klient, SessionIndexClient } from '@moonshot-ai/klient';
 import { ISessionIndex } from '@moonshot-ai/agent-core-v2/app/sessionIndex/sessionIndex';
 import { ISessionMetadata } from '@moonshot-ai/agent-core-v2/session/sessionMetadata/sessionMetadata';
 
-const BASE = process.env.KIMI_SERVER_URL ?? 'http://127.0.0.1:58627';
+const BASE = process.env['KIMI_SERVER_URL'] ?? 'http://127.0.0.1:58627';
 
 async function createSessionViaV1(cwd: string): Promise<string> {
   const res = await fetch(`${BASE}/api/v1/sessions`, {

--- a/packages/klient/examples/inspect-init.ts
+++ b/packages/klient/examples/inspect-init.ts
@@ -31,7 +31,10 @@ console.log('agents in metadata:', agentIds);
 for (const agentId of ['main', ...agentIds.filter((id) => id !== 'main')]) {
   const agent = client.session(sid).agent(agentId);
   try {
-    const mode = await agent.service(IAgentPermissionModeService).mode();
+    // Klient maps property reads to zero-argument RPC calls at runtime.
+    const mode = await (
+      agent.service(IAgentPermissionModeService) as unknown as { mode(): Promise<string> }
+    ).mode();
     // `get()` is sync in the shared interface but async over the wire.
     const context = await Promise.resolve(agent.service(IAgentContextMemoryService).get());
     console.log(`\n== agent ${agentId} == mode=${mode} messages=${context.length}`);

--- a/packages/klient/examples/session-history-smoke.ts
+++ b/packages/klient/examples/session-history-smoke.ts
@@ -1,0 +1,307 @@
+import assert from 'node:assert/strict';
+
+import { Klient } from '@moonshot-ai/klient';
+import { IAgentContextMemoryService } from '@moonshot-ai/agent-core-v2/agent/contextMemory/contextMemory';
+import {
+  ISessionIndex,
+  type SessionSummary,
+} from '@moonshot-ai/agent-core-v2/app/sessionIndex/sessionIndex';
+import {
+  IWorkspaceRegistry,
+  type Workspace,
+} from '@moonshot-ai/agent-core-v2/app/workspaceRegistry/workspaceRegistry';
+import { ISessionMetadata } from '@moonshot-ai/agent-core-v2/session/sessionMetadata/sessionMetadata';
+
+interface Envelope<T> {
+  readonly code: number;
+  readonly msg: string;
+  readonly data: T;
+}
+
+interface V1Workspace {
+  readonly id: string;
+  readonly root: string;
+  readonly session_count: number;
+}
+
+interface V1Session {
+  readonly id: string;
+  readonly workspace_id: string;
+  readonly metadata?: { readonly cwd?: string };
+  readonly archived?: boolean;
+}
+
+interface V1Message {
+  readonly id: string;
+  readonly role: string;
+  readonly content: readonly unknown[];
+}
+
+function optionalEnv(name: string): string | undefined {
+  const value = process.env[name];
+  return value === undefined || value === '' ? undefined : value;
+}
+
+const baseUrl = (process.env['KIMI_SERVER_URL'] ?? 'http://127.0.0.1:58627').replace(/\/$/, '');
+const token = optionalEnv('KIMI_SERVER_TOKEN');
+const expectedSessionId = optionalEnv('KIMI_SMOKE_EXPECT_SESSION_ID');
+const expectedCwd = optionalEnv('KIMI_SMOKE_EXPECT_CWD');
+const marker = optionalEnv('KIMI_SMOKE_MARKER');
+const requireHistory = /^(1|true|yes)$/i.test(process.env['KIMI_SMOKE_REQUIRE_HISTORY'] ?? 'false');
+
+function authHeaders(): Headers {
+  const result = new Headers();
+  if (token !== undefined) result.set('authorization', `Bearer ${token}`);
+  return result;
+}
+
+async function v1<T>(path: string): Promise<T> {
+  const response = await fetch(`${baseUrl}/api/v1${path}`, { headers: authHeaders() });
+  const envelope = (await response.json()) as Envelope<T>;
+  assert.equal(response.ok, true, `v1 ${path} returned HTTP ${String(response.status)}`);
+  assert.equal(envelope.code, 0, `v1 ${path}: ${String(envelope.code)} ${envelope.msg}`);
+  return envelope.data;
+}
+
+function sortedStrings(values: Iterable<string>): readonly string[] {
+  return [...values].toSorted((a, b) => a.localeCompare(b));
+}
+
+function canonicalPath(value: string): string {
+  const slashed = value.replaceAll('\\', '/').replace(/\/+$/, '');
+  const rooted = /^[A-Za-z]:$/.test(slashed) ? `${slashed}/` : slashed;
+  return /^(?:[A-Za-z]:\/|\/\/)/.test(rooted) ? rooted.toLowerCase() : rooted;
+}
+
+function duplicates(values: readonly string[]): readonly string[] {
+  const counts = new Map<string, number>();
+  for (const value of values) counts.set(value, (counts.get(value) ?? 0) + 1);
+  return sortedStrings([...counts].filter(([, count]) => count > 1).map(([value]) => value));
+}
+
+function diagnoseAliases(values: readonly string[]): readonly string[] {
+  const groups = new Map<string, Set<string>>();
+  for (const value of values) {
+    const canonical = canonicalPath(value);
+    const group = groups.get(canonical) ?? new Set<string>();
+    group.add(value);
+    groups.set(canonical, group);
+  }
+  return sortedStrings(
+    [...groups.values()]
+      .filter((group) => group.size > 1)
+      .map((group) => sortedStrings(group).join(' <> ')),
+  );
+}
+
+function text(value: unknown): string {
+  if (typeof value === 'string') return value;
+  if (Array.isArray(value)) return value.map(text).join('\n');
+  if (value !== null && typeof value === 'object') {
+    const record = value as Record<string, unknown>;
+    if (typeof record['text'] === 'string') return record['text'];
+    return Object.values(record).map(text).join('\n');
+  }
+  return '';
+}
+
+async function listAllV1Sessions(): Promise<readonly V1Session[]> {
+  const items: V1Session[] = [];
+  let beforeId: string | undefined;
+  for (;;) {
+    const query = new URLSearchParams({ include_archive: 'true', page_size: '100' });
+    if (beforeId !== undefined) query.set('before_id', beforeId);
+    const page = await v1<{ readonly items: readonly V1Session[]; readonly has_more: boolean }>(
+      `/sessions?${query.toString()}`,
+    );
+    items.push(...page.items);
+    if (!page.has_more) return items;
+    const next = page.items.at(-1)?.id;
+    assert.ok(next !== undefined && next !== beforeId, 'v1 session pagination did not advance');
+    beforeId = next;
+  }
+}
+
+async function listAllV1Messages(sessionId: string): Promise<readonly V1Message[]> {
+  const items: V1Message[] = [];
+  let beforeId: string | undefined;
+  for (;;) {
+    const query = new URLSearchParams({ page_size: '100' });
+    if (beforeId !== undefined) query.set('before_id', beforeId);
+    const page = await v1<{ readonly items: readonly V1Message[]; readonly has_more: boolean }>(
+      `/sessions/${encodeURIComponent(sessionId)}/messages?${query.toString()}`,
+    );
+    items.push(...page.items);
+    if (!page.has_more) return items;
+    const next = page.items.at(-1)?.id;
+    assert.ok(next !== undefined && next !== beforeId, 'v1 message pagination did not advance');
+    beforeId = next;
+  }
+}
+
+function selectColdSession(sessions: readonly SessionSummary[]): SessionSummary | undefined {
+  if (expectedSessionId !== undefined) {
+    const selected = sessions.find((session) => session.id === expectedSessionId);
+    assert.ok(selected, `expected session ${expectedSessionId} is absent from the global index`);
+    return selected;
+  }
+  if (expectedCwd !== undefined) {
+    const canonicalExpected = canonicalPath(expectedCwd);
+    const matches = sessions.filter(
+      (session) => session.cwd !== undefined && canonicalPath(session.cwd) === canonicalExpected,
+    );
+    assert.equal(matches.length, 1, `expected cwd must identify exactly one session; found ${String(matches.length)}`);
+    return matches[0];
+  }
+  return sessions[0];
+}
+
+function report(label: string, values: readonly string[]): void {
+  console.log(`${label}: ${values.length === 0 ? 'none' : values.join(', ')}`);
+}
+
+async function main(): Promise<void> {
+  console.log(`server: ${baseUrl}`);
+  const client = new Klient({ url: baseUrl, token });
+  const index = client.core(ISessionIndex);
+
+  // This must be the first session operation: capture the durable global index
+  // before any session-scoped call can materialize a cold session.
+  const globalPage = await index.list({ includeArchived: true });
+  const sessions = globalPage.items;
+  assert.ok(Array.isArray(sessions), 'global ISessionIndex.list did not return items');
+  if (requireHistory || expectedSessionId !== undefined || expectedCwd !== undefined || marker !== undefined) {
+    assert.ok(sessions.length > 0, 'historical sessions are required but the global index is empty');
+  }
+  console.log(`global index before warm-up: ${String(sessions.length)} sessions`);
+  const failures: string[] = [];
+
+  // Regression probe: this intentionally fails while the v2 dispatcher only
+  // looks up live scopes instead of resuming an indexed cold session.
+  const cold = selectColdSession(sessions);
+  if (cold !== undefined) {
+    try {
+      const metadata = await client.session(cold.id).service(ISessionMetadata).read();
+      assert.equal(metadata.id, cold.id, 'cold ISessionMetadata.read returned the wrong session');
+      assert.equal(metadata.cwd, cold.cwd, 'cold metadata cwd differs from the index');
+      assert.equal(metadata.archived, cold.archived, 'cold metadata archived flag differs from the index');
+      console.log(`PASS cold ISessionMetadata.read (${cold.id})`);
+    } catch (error) {
+      const message = `cold session ${cold.id} is globally indexed but unavailable through session scope: ${error instanceof Error ? error.message : String(error)}`;
+      failures.push(message);
+      console.error(`FAIL ${message}`);
+    }
+  } else {
+    console.log('SKIP cold metadata read (no history found)');
+  }
+
+  const registry = client.core(IWorkspaceRegistry);
+  const workspaces = await registry.list();
+  const workspaceById = new Map(workspaces.map((workspace) => [workspace.id, workspace]));
+  const workspaceIds = new Set([
+    ...workspaces.map((workspace) => workspace.id),
+    ...sessions.map((session) => session.workspaceId),
+  ]);
+
+  for (const workspaceId of workspaceIds) {
+    const filtered = await index.list({ workspaceId, includeArchived: true });
+    const workspaceSessions: readonly SessionSummary[] = sessions.filter(
+      (session: SessionSummary) => session.workspaceId === workspaceId,
+    );
+    assert.deepEqual(
+      filtered.items.map((session) => session.id).toSorted((a, b) => a.localeCompare(b)),
+      workspaceSessions.map((session: SessionSummary) => session.id).toSorted((a, b) => a.localeCompare(b)),
+      `workspace-filtered index mismatch for ${workspaceId}`,
+    );
+    const active = workspaceSessions.filter((session: SessionSummary) => !session.archived).length;
+    assert.equal(await index.countActive(workspaceId), active, `countActive mismatch for ${workspaceId}`);
+  }
+  console.log(`PASS workspace-filtered list/countActive (${String(workspaceIds.size)} workspace ids)`);
+
+  const [v1WorkspacePage, v1Sessions] = await Promise.all([
+    v1<{ readonly items: readonly V1Workspace[] }>('/workspaces'),
+    listAllV1Sessions(),
+  ]);
+  const v1Workspaces = v1WorkspacePage.items;
+  assert.deepEqual(
+    v1Workspaces.map((workspace) => workspace.id).toSorted((a, b) => a.localeCompare(b)),
+    workspaces.map((workspace) => workspace.id).toSorted((a, b) => a.localeCompare(b)),
+    'v1 and IWorkspaceRegistry workspace ids differ',
+  );
+  for (const workspace of v1Workspaces) {
+    assert.equal(workspace.root, workspaceById.get(workspace.id)?.root, `v1 root mismatch for ${workspace.id}`);
+    assert.equal(
+      workspace.session_count,
+      sessions.filter((session) => session.workspaceId === workspace.id).length,
+      `v1 session_count mismatch for ${workspace.id}`,
+    );
+  }
+  assert.deepEqual(
+    v1Sessions.map((session) => session.id).toSorted((a, b) => a.localeCompare(b)),
+    sessions.map((session) => session.id).toSorted((a, b) => a.localeCompare(b)),
+    'v1 and ISessionIndex session ids differ',
+  );
+  console.log('PASS v1 workspace/session cross-check');
+
+  const orphanIds = sessions
+    .filter((session) => !workspaceById.has(session.workspaceId))
+    .map((session) => session.id)
+    .toSorted((a, b) => a.localeCompare(b));
+  const allPaths = [
+    ...workspaces.map((workspace: Workspace) => workspace.root),
+    ...sessions.flatMap((session) => (session.cwd === undefined ? [] : [session.cwd])),
+  ];
+  const pathAliases = diagnoseAliases(allPaths);
+  const duplicateIndexIds = duplicates(sessions.map((session) => session.id));
+  const duplicateV1Ids = duplicates(v1Sessions.map((session) => session.id));
+  const duplicateWorkspaceIds = duplicates(workspaces.map((workspace) => workspace.id));
+  const duplicateWorkspaceRoots = duplicates(
+    workspaces.map((workspace) => canonicalPath(workspace.root)),
+  );
+  report('orphan sessions', orphanIds);
+  report('Windows/canonical path aliases', pathAliases);
+  report('duplicate index session ids', duplicateIndexIds);
+  report('duplicate v1 session ids', duplicateV1Ids);
+  report('duplicate workspace ids', duplicateWorkspaceIds);
+  report('duplicate canonical workspace roots', duplicateWorkspaceRoots);
+  if (orphanIds.length > 0) failures.push(`orphan sessions: ${orphanIds.join(', ')}`);
+  if (pathAliases.length > 0) failures.push(`Windows/canonical path aliases: ${pathAliases.join(', ')}`);
+  if (duplicateIndexIds.length > 0) failures.push(`duplicate index session ids: ${duplicateIndexIds.join(', ')}`);
+  if (duplicateV1Ids.length > 0) failures.push(`duplicate v1 session ids: ${duplicateV1Ids.join(', ')}`);
+  if (duplicateWorkspaceIds.length > 0) failures.push(`duplicate workspace ids: ${duplicateWorkspaceIds.join(', ')}`);
+  if (duplicateWorkspaceRoots.length > 0) {
+    failures.push(`duplicate canonical workspace roots: ${duplicateWorkspaceRoots.join(', ')}`);
+  }
+
+  if (marker !== undefined) {
+    assert.ok(cold, 'KIMI_SMOKE_MARKER requires a selected historical session');
+    // The v1 read resumes the session first; only then query the materialized
+    // agent scope. This avoids racing a cold v2 scope lookup against resume.
+    const v1Messages = await listAllV1Messages(cold.id);
+    const context = await Promise.resolve(
+      client.session(cold.id).agent('main').service(IAgentContextMemoryService).get(),
+    );
+    const v1Matches = v1Messages.filter((message) => text(message.content).includes(marker));
+    const contextMatches = context.filter((message) => text(message.content).includes(marker));
+    assert.ok(v1Matches.length > 0, `marker ${JSON.stringify(marker)} absent from v1 messages`);
+    assert.ok(contextMatches.length > 0, `marker ${JSON.stringify(marker)} absent from agent context`);
+    assert.deepEqual(
+      sortedStrings(v1Matches.map((message) => message.role)),
+      sortedStrings(contextMatches.map((message) => message.role)),
+      'marker message roles differ between v1 messages and agent context',
+    );
+    console.log(`PASS marker cross-check (${String(v1Matches.length)} matching messages)`);
+  }
+
+  if (failures.length > 0) {
+    throw new Error(`history audit found ${String(failures.length)} issue(s):\n- ${failures.join('\n- ')}`);
+  }
+  console.log('HISTORY SMOKE PASSED');
+}
+
+try {
+  await main();
+} catch (error) {
+  console.error('HISTORY SMOKE FAILED:', error instanceof Error ? error.stack ?? error.message : error);
+  process.exitCode = 1;
+}

--- a/packages/klient/examples/smoke.ts
+++ b/packages/klient/examples/smoke.ts
@@ -1,0 +1,285 @@
+import assert from 'node:assert/strict';
+
+import { Klient, RPCError } from '@moonshot-ai/klient';
+import { IAgentContextMemoryService } from '@moonshot-ai/agent-core-v2/agent/contextMemory/contextMemory';
+import { IAgentContextSizeService } from '@moonshot-ai/agent-core-v2/agent/contextSize/contextSize';
+import { IAgentPermissionModeService } from '@moonshot-ai/agent-core-v2/agent/permissionMode/permissionMode';
+import { IAgentProfileService } from '@moonshot-ai/agent-core-v2/agent/profile/profile';
+import { IAgentTaskService } from '@moonshot-ai/agent-core-v2/agent/task/task';
+import { IAgentToolRegistryService } from '@moonshot-ai/agent-core-v2/agent/toolRegistry/toolRegistry';
+import { IAgentUsageService } from '@moonshot-ai/agent-core-v2/agent/usage/usage';
+import { ISessionIndex } from '@moonshot-ai/agent-core-v2/app/sessionIndex/sessionIndex';
+import { IWorkspaceRegistry } from '@moonshot-ai/agent-core-v2/app/workspaceRegistry/workspaceRegistry';
+import { ISessionActivity } from '@moonshot-ai/agent-core-v2/session/sessionActivity/sessionActivity';
+import { ISessionMetadata } from '@moonshot-ai/agent-core-v2/session/sessionMetadata/sessionMetadata';
+import { ISessionWorkspaceContext } from '@moonshot-ai/agent-core-v2/session/workspaceContext/workspaceContext';
+
+interface Envelope<T> {
+  readonly code: number;
+  readonly msg: string;
+  readonly data: T;
+  readonly request_id?: string;
+}
+
+interface ChannelDescriptor {
+  readonly name: string;
+  readonly scope: 'app' | 'session' | 'agent';
+  readonly methods: readonly { readonly name: string; readonly kind: string }[];
+}
+
+interface WireMessage {
+  readonly role: string;
+  readonly content: readonly { readonly type: string; readonly text?: string }[];
+}
+
+function optionalEnv(name: string): string | undefined {
+  const value = process.env[name];
+  return value === undefined || value === '' ? undefined : value;
+}
+
+const baseUrl = (process.env['KIMI_SERVER_URL'] ?? 'http://127.0.0.1:58627').replace(/\/$/, '');
+const token = optionalEnv('KIMI_SERVER_TOKEN');
+const model = optionalEnv('KIMI_SMOKE_MODEL');
+
+function headers(extra?: RequestInit['headers'], authToken = token): Headers {
+  const result = new Headers(extra);
+  if (authToken !== undefined) result.set('authorization', `Bearer ${authToken}`);
+  return result;
+}
+
+async function apiFetch<T>(
+  version: 'v1' | 'v2',
+  path: string,
+  init: RequestInit = {},
+  authToken = token,
+): Promise<{ readonly response: Response; readonly envelope: Envelope<T> }> {
+  const response = await fetch(`${baseUrl}/api/${version}${path}`, {
+    ...init,
+    headers: headers(init.headers, authToken),
+  });
+  const envelope = (await response.json()) as Envelope<T>;
+  return { response, envelope };
+}
+
+async function v1<T>(path: string, init: RequestInit = {}): Promise<T> {
+  const { response, envelope } = await apiFetch<T>('v1', path, init);
+  assert.equal(response.ok, true, `v1 ${path} returned HTTP ${String(response.status)}`);
+  assert.equal(envelope.code, 0, `v1 ${path}: ${String(envelope.code)} ${envelope.msg}`);
+  return envelope.data;
+}
+
+async function v2<T>(path: string, init: RequestInit = {}): Promise<T> {
+  const { response, envelope } = await apiFetch<T>('v2', path, init);
+  assert.equal(response.ok, true, `v2 ${path} returned HTTP ${String(response.status)}`);
+  assert.equal(envelope.code, 0, `v2 ${path}: ${String(envelope.code)} ${envelope.msg}`);
+  return envelope.data;
+}
+
+function textOf(messages: readonly WireMessage[]): string {
+  return messages.flatMap((message) => message.content.map((part) => part.text ?? '')).join('\n');
+}
+
+async function waitForModelReply(sessionId: string, marker: string): Promise<void> {
+  const deadline = Date.now() + 120_000;
+  while (Date.now() < deadline) {
+    const page = await v1<{ readonly items: readonly WireMessage[] }>(
+      `/sessions/${encodeURIComponent(sessionId)}/messages?page_size=100`,
+    );
+    if (page.items.some((message) => message.role === 'assistant' && textOf([message]).includes(marker))) {
+      return;
+    }
+    await new Promise<void>((resolve) => {
+      setTimeout(resolve, 500);
+    });
+  }
+  throw new Error(`timed out waiting for model reply containing ${JSON.stringify(marker)}`);
+}
+
+async function expectRpcError(label: string, operation: () => Promise<unknown>, code: number): Promise<void> {
+  try {
+    await operation();
+    assert.fail(`${label} unexpectedly succeeded`);
+  } catch (error) {
+    assert.ok(error instanceof RPCError, `${label} did not throw RPCError`);
+    assert.equal(error.code, code, `${label} returned unexpected RPC code`);
+  }
+}
+
+async function main(): Promise<void> {
+  console.log(`server: ${baseUrl}`);
+  console.log(`auth:   ${token === undefined ? 'not configured' : 'bearer token'}`);
+  console.log(`model:  ${model ?? 'disabled (transport-only smoke)'}`);
+
+  const channels = await v2<readonly ChannelDescriptor[]>('/channels');
+  for (const expected of ['sessionIndex', 'sessionMetadata', 'agentContextMemoryService']) {
+    assert.ok(channels.some((channel) => channel.name === expected), `missing v2 channel ${expected}`);
+  }
+  assert.ok(
+    channels.find((channel) => channel.name === 'sessionIndex')?.methods.some((method) => method.name === 'list'),
+    'sessionIndex.list is not exposed',
+  );
+  console.log(`PASS /api/v2/channels (${String(channels.length)} channels)`);
+
+  if (token !== undefined) {
+    const badAuth = await apiFetch<unknown>('v2', '/channels', {}, `${token}-invalid`);
+    assert.ok(
+      !badAuth.response.ok || badAuth.envelope.code !== 0,
+      'an invalid bearer token unexpectedly accessed /api/v2/channels',
+    );
+    console.log('PASS invalid bearer token rejected');
+  } else {
+    console.log('SKIP invalid bearer token (KIMI_SERVER_TOKEN is unset)');
+  }
+
+  const client = new Klient({ url: baseUrl, token });
+  const index = client.core(ISessionIndex);
+  const initial = await index.list({ includeArchived: true });
+  assert.ok(Array.isArray(initial.items), 'HTTP core sessionIndex.list did not return items');
+  const workspaces = await client.core(IWorkspaceRegistry).list();
+  assert.ok(Array.isArray(workspaces), 'HTTP core workspaceRegistry.list did not return an array');
+  console.log(
+    `PASS Klient HTTP core (${String(initial.items.length)} sessions, ${String(workspaces.length)} workspaces)`,
+  );
+
+  await expectRpcError(
+    'unknown method',
+    () => (index as unknown as { missingMethod(): Promise<unknown> }).missingMethod(),
+    40001,
+  );
+  const wrongScope = await apiFetch<unknown>('v2', '/sessionMetadata/read', { method: 'POST' });
+  assert.equal(wrongScope.envelope.code, 40001, 'session service at core scope must be rejected');
+  console.log('PASS unknown method and wrong scope rejected');
+
+  const cwd = process.env['KIMI_SMOKE_CWD'] ?? workspaces[0]?.root;
+  assert.ok(
+    cwd !== undefined,
+    'no registered workspace; set KIMI_SMOKE_CWD to a directory on the server',
+  );
+  const created = await v1<{ readonly id: string }>('/sessions', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ title: 'Klient smoke session', metadata: { cwd } }),
+  });
+  const sessionId = created.id;
+  assert.ok(sessionId.length > 0, 'v1 session creation returned an empty id');
+  console.log(`created owned session ${sessionId} in ${cwd}`);
+
+  try {
+    const session = client.session(sessionId);
+    const metadata = session.service(ISessionMetadata);
+    const before = await metadata.read();
+    assert.equal(before.id, sessionId);
+    assert.equal(before.cwd, cwd);
+    await metadata.setTitle('Klient smoke verified');
+    const after = await metadata.read();
+    assert.equal(after.title, 'Klient smoke verified');
+
+    const activity = session.service(ISessionActivity);
+    assert.equal(await Promise.resolve(activity.status()), 'idle');
+    assert.equal(await Promise.resolve(activity.isIdle()), true);
+    const workspace = session.service(ISessionWorkspaceContext);
+    const resolvedCwd = await Promise.resolve(workspace.resolve('.'));
+    assert.equal(await Promise.resolve(workspace.isWithin(resolvedCwd)), true);
+    console.log('PASS Klient HTTP session metadata/activity/workspace');
+
+    const agent = session.agent('main');
+    const context = await Promise.resolve(agent.service(IAgentContextMemoryService).get());
+    const tasks = await Promise.resolve(agent.service(IAgentTaskService).list(false, 20));
+    const usage = await Promise.resolve(agent.service(IAgentUsageService).status());
+    const contextSize = await Promise.resolve(agent.service(IAgentContextSizeService).get());
+    const tools = await Promise.resolve(agent.service(IAgentToolRegistryService).list());
+    const profile = await Promise.resolve(agent.service(IAgentProfileService).data());
+    const permissionMode = await (
+      agent.service(IAgentPermissionModeService) as unknown as { mode(): Promise<string> }
+    ).mode();
+    assert.ok(Array.isArray(context), 'HTTP agent context get did not return an array');
+    assert.ok(Array.isArray(tasks), 'HTTP agent task list did not return an array');
+    assert.ok(usage !== null && typeof usage === 'object', 'HTTP agent usage status is invalid');
+    assert.equal(typeof contextSize.size, 'number');
+    assert.ok(Array.isArray(tools), 'HTTP agent tool list did not return an array');
+    assert.equal(typeof profile.cwd, 'string');
+    assert.ok(['manual', 'auto', 'yolo'].includes(permissionMode));
+    console.log('PASS Klient HTTP agent context/task/usage/profile/tools/permission');
+
+    const ws = client.ws();
+    let resolveEvent: (event: unknown) => void = () => {};
+    const eventReceived = new Promise<unknown>((resolve) => {
+      resolveEvent = resolve;
+    });
+    const listenErrors: unknown[] = [];
+    const errorSubscription = ws.onDidListenError((error) => listenErrors.push(error));
+    const subscription = ws.listen('events', resolveEvent);
+    try {
+      const wsIndex = await ws.core(ISessionIndex).get(sessionId);
+      assert.equal(wsIndex?.id, sessionId);
+      assert.equal(ws.state, 'open');
+      const wsMeta = await ws.session(sessionId).service(ISessionMetadata).read();
+      assert.equal(wsMeta.id, sessionId);
+      const wsContext = await Promise.resolve(
+        ws.session(sessionId).agent('main').service(IAgentContextMemoryService).get(),
+      );
+      assert.ok(Array.isArray(wsContext), 'WebSocket agent context get did not return an array');
+      await new Promise<void>((resolve) => {
+        setTimeout(resolve, 100);
+      });
+      await v1(`/sessions/${encodeURIComponent(sessionId)}/profile`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ title: 'Klient smoke WebSocket event' }),
+      });
+      await Promise.race([
+        eventReceived,
+        new Promise<never>((_, reject) => {
+          setTimeout(() => {
+            reject(new Error('timed out waiting for a WebSocket core event'));
+          }, 5_000);
+        }),
+      ]);
+      assert.deepEqual(listenErrors, [], 'WebSocket subscription reported an error');
+    } finally {
+      subscription.dispose();
+      errorSubscription.dispose();
+      ws.close();
+    }
+    console.log('PASS Klient WebSocket core/session/agent calls and event subscription');
+
+    if (model !== undefined) {
+      const marker = `KLlENT_SMOKE_${Date.now().toString(36)}`;
+      await client
+        .session(sessionId)
+        .agent('main')
+        .service(IAgentProfileService)
+        .setModel(model);
+      const submitted = await v1<{ readonly prompt_id: string }>(
+        `/sessions/${encodeURIComponent(sessionId)}/prompts`,
+        {
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({
+            content: [{ type: 'text', text: `Reply with exactly: ${marker}` }],
+            model,
+          }),
+        },
+      );
+      assert.ok(submitted.prompt_id.length > 0, 'model prompt returned an empty prompt id');
+      await waitForModelReply(sessionId, marker);
+      console.log('PASS optional minimal model prompt');
+    }
+  } finally {
+    const archived = await v1<{ readonly archived: boolean }>(
+      `/sessions/${encodeURIComponent(sessionId)}:archive`,
+      { method: 'POST', headers: { 'content-type': 'application/json' }, body: '{}' },
+    );
+    assert.equal(archived.archived, true, 'owned smoke session was not archived');
+    console.log('PASS owned session archived');
+  }
+
+  console.log('SMOKE PASSED');
+}
+
+try {
+  await main();
+} catch (error) {
+  console.error('SMOKE FAILED:', error instanceof Error ? error.stack ?? error.message : error);
+  process.exitCode = 1;
+}

--- a/packages/klient/package.json
+++ b/packages/klient/package.json
@@ -24,8 +24,11 @@
   },
   "scripts": {
     "build": "tsdown",
-    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "typecheck": "tsc -p tsconfig.json --noEmit && pnpm typecheck:examples",
+    "typecheck:examples": "tsc -p tsconfig.examples.json --noEmit",
     "test": "vitest run",
+    "smoke": "tsx examples/smoke.ts",
+    "smoke:history": "tsx examples/session-history-smoke.ts",
     "clean": "rm -rf dist"
   },
   "dependencies": {

--- a/packages/klient/tsconfig.examples.json
+++ b/packages/klient/tsconfig.examples.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../tsconfig.json",
+  "include": ["examples/**/*.ts", "../agent-core-v2/src"]
+}


### PR DESCRIPTION
## Related Issue

No linked issue. The Klient package had unit coverage for its transports but no repeatable smoke checks against a real kap-server, especially for persisted sessions across the v1-to-v2 engine transition.

## Problem

Klient examples mostly printed responses without assertions and were not included in package type checking. This made it difficult to verify HTTP and WebSocket behavior across core, session, and agent scopes, or to distinguish an actually missing session from a persisted cold session that the v2 dispatcher cannot materialize.

## What changed

- Add a real-server transport smoke script covering authentication, channel discovery, HTTP and WebSocket calls, event subscriptions, scoped services, error paths, fixture cleanup, and an optional model prompt.
- Add a persisted-session history smoke script covering global and workspace indexes, v1/v2 projections, Windows path aliases, duplicate/orphan detection, cold-session access, and optional message/context markers.
- Add dedicated examples type checking and include it in the package's normal `typecheck` command.
- Document remote-server usage, required environment variables, and persistence side effects.
- Fix existing examples so all examples pass the new type-check configuration.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset. Tests/examples-only change; no release bump is needed.
- [x] Ran `gen-docs` skill, or this PR needs no doc update. Package README usage was updated; user documentation is unaffected.

## Verification

- `pnpm --filter @moonshot-ai/klient test`
- `pnpm --filter @moonshot-ai/klient typecheck`
- `pnpm --filter @moonshot-ai/klient build`
- `pnpm exec oxlint --type-aware examples/smoke.ts examples/session-history-smoke.ts examples/inspect-init.ts`
- Windows real-server transport smoke passed against Kimi Code 0.24.1.
- The history smoke reproduced an indexed cold session returning `session.not_found` through the v2 session scope while workspace and v1 projections remained intact.
