### PR TITLE
fix(web): make code block copy work over plain HTTP

### DIFF
--- a/.changeset/fix-web-code-block-copy.md
+++ b/.changeset/fix-web-code-block-copy.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+web: Fix code block copy buttons when the web UI is served over plain HTTP.

--- a/apps/kimi-web/src/components/chat/Markdown.vue
+++ b/apps/kimi-web/src/components/chat/Markdown.vue
@@ -338,6 +338,15 @@ const codeBlockProps = {
   loading: false,
 };
 
+function copyCodeBlockFallback(code: string): void {
+  // markstream emits `copy` even when it skipped the write because the
+  // Clipboard API is unavailable. Reuse our plain-HTTP fallback in that case,
+  // while avoiding a duplicate write after markstream succeeds on HTTPS.
+  const clipboard = typeof navigator !== 'undefined' ? navigator.clipboard : undefined;
+  if (clipboard && typeof clipboard.writeText === 'function') return;
+  void copyTextToClipboard(code);
+}
+
 // Root cause for the "large session turns into code skeletons" failure:
 // markstream mounts every code block in the loaded transcript, then shiki has
 // to tokenize all of them. `loading: false` removes the visible skeleton gate,
@@ -437,6 +446,7 @@ function copyDiff(code: string, idx: number) {
         :smooth-streaming="streaming"
         :batch-rendering="allowBatchRender"
         :defer-nodes-until-visible="false"
+        @copy="copyCodeBlockFallback"
       />
 
       <!-- ```diff fence → local renderer (preserves +/- markers + colours) -->


### PR DESCRIPTION
## Related Issue

No linked issue; this is a focused, reproducible bug fix.

## Problem

Code blocks rendered by `markstream-vue` silently skip the clipboard write when Kimi Web is served over plain HTTP and the browser does not expose `navigator.clipboard`. The component still shows its copied state, so users see successful feedback while the clipboard remains unchanged. The existing plain-HTTP fallback was only used by locally rendered diff blocks.

## What changed

- Handle the renderer's `copy` event and reuse Kimi Web's existing clipboard fallback when the Clipboard API is unavailable.
- Skip the fallback when the renderer already copied through the Clipboard API, avoiding duplicate writes on secure origins.
- Add a patch changeset for the CLI-bundled web UI.

## Verification

- `pnpm --filter @moonshot-ai/kimi-web test -- clipboard.test.ts` (28 files, 492 tests)
- `pnpm --filter @moonshot-ai/kimi-web typecheck`
- `pnpm --filter @moonshot-ai/kimi-web build`
- `pnpm --filter @moonshot-ai/kimi-web check:style` (baseline mode, no new finding)
- `pnpm exec oxlint --type-aware apps/kimi-web/src/components/chat/Markdown.vue`
- Manual LAN HTTP browser check with `isSecureContext=false` and `navigator.clipboard.writeText` unavailable; clicking the code-block copy button wrote the exact code text to the clipboard.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] Existing tests and the manual browser check above prove the fix works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.
