### PR TITLE
fix(web): use upward chevron for dock card expand buttons

### DIFF
--- a/.changeset/fix-web-plan-expand-icon.md
+++ b/.changeset/fix-web-plan-expand-icon.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+web: Use an upward chevron for the plan review card's expand button so the icon matches the direction the card opens.

--- a/.changeset/fix-web-plan-expand-icon.md
+++ b/.changeset/fix-web-plan-expand-icon.md
@@ -2,4 +2,4 @@
 "@moonshot-ai/kimi-code": patch
 ---
 
-web: Use an upward chevron for the plan review card's expand button so the icon matches the direction the card opens.
+web: Use an upward chevron for the expand button on minimized plan review and question cards so the icon matches the direction the cards open.

--- a/apps/kimi-web/src/components/chat/ApprovalCard.vue
+++ b/apps/kimi-web/src/components/chat/ApprovalCard.vue
@@ -198,7 +198,7 @@ onUnmounted(() => document.removeEventListener('keydown', handleKeydown));
           :label="minimized ? t('question.expand') : t('question.minimize')"
           @click="minimized = !minimized"
         >
-          <Icon v-if="minimized" name="chevron-down" size="md" />
+          <Icon v-if="minimized" name="chevron-up" size="md" />
           <Icon v-else name="minus" size="md" />
         </IconButton>
       </div>

--- a/apps/kimi-web/src/components/chat/QuestionCard.vue
+++ b/apps/kimi-web/src/components/chat/QuestionCard.vue
@@ -283,7 +283,7 @@ onUnmounted(() => document.removeEventListener('keydown', handleKeydown));
           :label="minimized ? t('question.expand') : t('question.minimize')"
           @click="minimized = !minimized"
         >
-          <Icon v-if="minimized" name="chevron-down" size="md" />
+          <Icon v-if="minimized" name="chevron-up" size="md" />
           <Icon v-else name="minus" size="md" />
         </IconButton>
       </div>

--- a/apps/kimi-web/src/lib/icons.ts
+++ b/apps/kimi-web/src/lib/icons.ts
@@ -47,6 +47,7 @@ import RiArrowGoBackLine from '~icons/ri/arrow-go-back-line';
 import RiArrowRightLine from '~icons/ri/arrow-right-line';
 import RiArrowRightSLine from '~icons/ri/arrow-right-s-line';
 import RiArrowUpLine from '~icons/ri/arrow-up-line';
+import RiArrowUpSLine from '~icons/ri/arrow-up-s-line';
 import RiBracesLine from '~icons/ri/braces-line';
 import RiCalendarCloseLine from '~icons/ri/calendar-close-line';
 import RiCalendarScheduleLine from '~icons/ri/calendar-schedule-line';
@@ -117,6 +118,7 @@ import RawArrowGoBackLine from '~icons/ri/arrow-go-back-line?raw';
 import RawArrowRightLine from '~icons/ri/arrow-right-line?raw';
 import RawArrowRightSLine from '~icons/ri/arrow-right-s-line?raw';
 import RawArrowUpLine from '~icons/ri/arrow-up-line?raw';
+import RawArrowUpSLine from '~icons/ri/arrow-up-s-line?raw';
 import RawBracesLine from '~icons/ri/braces-line?raw';
 import RawCalendarCloseLine from '~icons/ri/calendar-close-line?raw';
 import RawCalendarScheduleLine from '~icons/ri/calendar-schedule-line?raw';
@@ -188,6 +190,7 @@ export type IconName =
   | 'log-in'
   | 'chevron-down'
   | 'chevron-right'
+  | 'chevron-up'
   | 'arrow-up'
   | 'arrow-down'
   | 'arrow-right'
@@ -272,6 +275,7 @@ export const ICONS: Record<IconName, IconEntry> = {
   'log-in': entry(RiLoginBoxLine, RawLoginBoxLine),
   'chevron-down': entry(RiArrowDownSLine, RawArrowDownSLine),
   'chevron-right': entry(RiArrowRightSLine, RawArrowRightSLine),
+  'chevron-up': entry(RiArrowUpSLine, RawArrowUpSLine),
   'arrow-up': entry(RiArrowUpLine, RawArrowUpLine),
   'arrow-down': entry(RiArrowDownLine, RawArrowDownLine),
   'arrow-right': entry(RiArrowRightLine, RawArrowRightLine),
@@ -368,6 +372,7 @@ export const ICON_GROUPS: ReadonlyArray<readonly [string, readonly IconName[]]> 
     [
       'chevron-down',
       'chevron-right',
+      'chevron-up',
       'arrow-up',
       'arrow-down',
       'arrow-right',


### PR DESCRIPTION
## Related Issue

No issue — small UI polish, problem explained below.

## Problem

In the web UI, the plan review card (shown when the agent exits plan mode) and the question card live in the bottom dock. When either card is minimized to a thin bar, its expand button showed a downward chevron — but the card unfolds upward from the dock, so the icon pointed the wrong way.

## What changed

- Registered a `chevron-up` icon (Remix `arrow-up-s-line`) in the web icon registry.
- The minimized plan review card's and question card's expand buttons now use `chevron-up` instead of `chevron-down`, matching the direction the cards open. The expanded state's `minus` (minimize) icon is unchanged.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [ ] I have added tests that prove my feature works. (one-line icon swaps; existing suite passes)
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.