### PR TITLE
fix(kimi-web): don't abort session on Escape when dialog is open

### DIFF
--- a/apps/kimi-web/src/components/chat/ConversationPane.vue
+++ b/apps/kimi-web/src/components/chat/ConversationPane.vue
@@ -15,6 +15,7 @@ import Spinner from '../ui/Spinner.vue';
 import Tooltip from '../ui/Tooltip.vue';
 import { getVisibleWorkspaces } from '../../lib/workspacePicker';
 import { safeRemove, STORAGE_KEYS } from '../../lib/storage';
+import { openDialogCount } from '../../composables/dialogStack';
 
 const { t } = useI18n();
 
@@ -1166,7 +1167,12 @@ function handleInterrupt(): void {
 }
 
 function onKeyDown(event: KeyboardEvent): void {
-  if (event.key === 'Escape' && (props.running || props.sending)) {
+  if (event.key !== 'Escape') return;
+  // When a design-system Dialog is open, Escape is owned by the dialog (e.g.
+  // to close AddWorkspace/Settings). Don't let it bubble down and abort the
+  // running session behind the overlay.
+  if (openDialogCount.value > 0) return;
+  if (props.running || props.sending) {
     event.preventDefault();
     handleInterrupt();
   }


### PR DESCRIPTION
## Related Issue

Fixes #1538

## Problem

In kimi-web, pressing `Escape` to close a dialog (e.g. the session search opened by Cmd/Ctrl+K) also bubbles the event down to `ConversationPane`, which treats `Escape` as a manual interrupt and stops the running session.

## What changed

In `ConversationPane.vue`, the document `keydown` handler now returns early when any design-system dialog is open (`openDialogCount.value > 0`). This lets dialogs own the `Escape` key and prevents accidental session aborts.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset. <!-- private kimi-web package, no release artifact affected -->
- [x] Ran `gen-docs` skill, or this PR needs no doc update.

## Verification

- `pnpm --filter @moonshot-ai/kimi-web typecheck` passes
- `pnpm --filter @moonshot-ai/kimi-web test` passes (492 tests)
- `pnpm lint apps/kimi-web/src/components/chat/ConversationPane.vue` passes
