### PR TITLE
fix(kimi): normalize malformed MCP required fields

### DIFF
--- a/.changeset/fix-kimi-mcp-required-schema.md
+++ b/.changeset/fix-kimi-mcp-required-schema.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Fix Kimi-compatible APIs rejecting MCP tools with malformed required fields.

--- a/packages/agent-core-v2/src/app/llmProtocol/providers/kimi-schema.ts
+++ b/packages/agent-core-v2/src/app/llmProtocol/providers/kimi-schema.ts
@@ -110,6 +110,7 @@ function ensureKimiPropertyTypes(schema: Record<string, unknown>): Record<string
   if (!isRecord(normalized)) {
     throw new Error('JSON Schema root must normalize to an object.');
   }
+  removeUnknownRequiredProperties(normalized);
   recurseSchema(normalized);
   return normalized;
 }
@@ -304,7 +305,25 @@ function normalizeProperty(node: unknown): void {
     }
   }
 
+  removeUnknownRequiredProperties(node);
   recurseSchema(node);
+}
+
+function removeUnknownRequiredProperties(node: Record<string, unknown>): void {
+  const properties = node['properties'];
+  const required = node['required'];
+  if (!isRecord(properties) || !Array.isArray(required)) {
+    return;
+  }
+
+  const knownRequired = required.filter(
+    (name): name is string => typeof name === 'string' && hasOwn(properties, name),
+  );
+  if (knownRequired.length === 0) {
+    delete node['required'];
+    return;
+  }
+  node['required'] = knownRequired;
 }
 
 function removeIrrelevantStructureKeys(

--- a/packages/agent-core-v2/test/app/llmProtocol/providers/kimi-schema.test.ts
+++ b/packages/agent-core-v2/test/app/llmProtocol/providers/kimi-schema.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from 'vitest';
+
+import { normalizeKimiToolSchema } from '#/app/llmProtocol/providers/kimi-schema';
+
+describe('normalizeKimiToolSchema', () => {
+  it('removes required entries that have no matching property in the root schema', () => {
+    const normalized = normalizeKimiToolSchema({
+      type: 'object',
+      properties: {
+        path: { type: 'string' },
+      },
+      required: ['path', 'missing'],
+    });
+
+    expect(normalized['required']).toEqual(['path']);
+  });
+
+  it('removes required entries that have no matching property in nested object schemas', () => {
+    const normalized = normalizeKimiToolSchema({
+      type: 'object',
+      properties: {
+        workFlow: {
+          type: 'array',
+          items: {
+            type: 'object',
+            properties: {
+              codec: { type: 'string' },
+            },
+            required: ['codec', 'codecType'],
+          },
+        },
+      },
+    });
+
+    expect(normalized).toMatchObject({
+      properties: {
+        workFlow: {
+          items: {
+            required: ['codec'],
+          },
+        },
+      },
+    });
+  });
+
+  it('removes required when none of its entries match the declared properties', () => {
+    const normalized = normalizeKimiToolSchema({
+      type: 'object',
+      properties: {
+        workFlow: {
+          type: 'object',
+          properties: {
+            codec: { type: 'string' },
+          },
+          required: ['codecType'],
+        },
+      },
+    });
+
+    expect(normalized).toMatchObject({
+      properties: {
+        workFlow: {
+          properties: {
+            codec: { type: 'string' },
+          },
+        },
+      },
+    });
+    const workFlow = (normalized['properties'] as Record<string, unknown>)['workFlow'];
+    expect(workFlow).not.toHaveProperty('required');
+  });
+
+  it('preserves required when the schema declares no properties', () => {
+    const normalized = normalizeKimiToolSchema({
+      type: 'object',
+      required: ['dynamicField'],
+      additionalProperties: { type: 'string' },
+    });
+
+    expect(normalized['required']).toEqual(['dynamicField']);
+  });
+});


### PR DESCRIPTION
## Related Issue

Fixes #1610

## Problem

An MCP server can advertise an object schema whose `required` list names a field absent from its `properties`. The Kimi provider forwarded that malformed tool schema to Kimi-compatible APIs, whose strict validator rejects the entire request before the model can respond.

## What changed

- Normalize root and nested object schemas before sending tools to the Kimi provider.
- Retain only `required` entries declared in the same `properties` object.
- Remove `required` when no declared fields remain, avoiding an invalid empty array.
- Leave schemas without `properties` unchanged, so dynamic-field schemas retain their requirements.
- Add focused regression coverage and a CLI patch changeset.

## Reproduction and validation

Reproduced locally on macOS (Darwin 25.5.0, arm64) with Node.js 24.18.0 and pnpm 10.33.0.

Before the fix, a nested MCP schema with `required: ['codec', 'codecType']` and only `codec` declared preserved the invalid `codecType` entry; the regression assertion failed.

After the fix:

- `pnpm -C packages/agent-core-v2 exec vitest run test/app/llmProtocol/providers/kimi-schema.test.ts` — 1 file, 4 tests passed.
- `pnpm -C packages/agent-core-v2 run typecheck` — passed.
- `pnpm -C packages/agent-core-v2 test` — 239 files, 3,467 tests passed.
- `pnpm exec oxlint --type-aware packages/agent-core-v2/src/app/llmProtocol/providers/kimi-schema.ts packages/agent-core-v2/test/app/llmProtocol/providers/kimi-schema.test.ts` — 0 warnings, 0 errors.
- `git diff --check origin/main...HEAD` — passed.
- `pnpm exec changeset status --since=origin/main` — reports a patch bump for `@moonshot-ai/kimi-code`.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill and added a patch changeset.
- [x] Ran `gen-docs` skill; no user-documentation update is needed because no command, configuration, or documented workflow changed.
