### PR TITLE
fix(agent-core-v2): run stdio node plugins with the bundled Electron Node on Electron hosts

### DIFF
--- a/packages/agent-core-v2/src/app/plugin/manager.ts
+++ b/packages/agent-core-v2/src/app/plugin/manager.ts
@@ -651,6 +651,19 @@ function withPluginMcpRuntime(
     KIMI_PLUGIN_ROOT: pluginRoot,
   };
 
+  if (config.command === 'node' && isElectron()) {
+    // Electron host: run the entry with the bundled Node (`ELECTRON_RUN_AS_NODE`)
+    // instead of the CLI's `__plugin_run_node` subcommand, which only the CLI
+    // binary implements (Electron would try to open it as an app and fail).
+    return {
+      ...config,
+      command: process.execPath,
+      args: config.args ?? [],
+      cwd: config.cwd ?? pluginRoot,
+      env: { ...env, ELECTRON_RUN_AS_NODE: '1' },
+    };
+  }
+
   if (config.command === 'node' && isKimiNativeBinary()) {
     return {
       ...config,
@@ -662,6 +675,10 @@ function withPluginMcpRuntime(
   }
 
   return { ...config, cwd: config.cwd ?? pluginRoot, env };
+}
+
+function isElectron(): boolean {
+  return typeof process.versions['electron'] === 'string';
 }
 
 function isKimiNativeBinary(): boolean {

--- a/packages/agent-core-v2/test/app/plugin/manager-consumption.test.ts
+++ b/packages/agent-core-v2/test/app/plugin/manager-consumption.test.ts
@@ -754,4 +754,60 @@ describe('PluginManager consumption plane', () => {
     await rm(cdnSource, { recursive: true, force: true });
     await rm(ghSource, { recursive: true, force: true });
   });
+
+  it('enabledMcpServers() runs stdio node plugins via the bundled Electron Node under an Electron host', async () => {
+    const home = await makeKimiHome();
+    const root = await makePlugin('demo', {
+      mcpServers: { data: { command: 'node', args: ['./bin/data.mjs'] } },
+    });
+    const manager = new PluginManager({ kimiHomeDir: home });
+    await manager.load();
+    await manager.install(root);
+    const managedRoot = await managedPluginRoot(manager, 'demo');
+
+    const originalElectron = process.versions['electron'];
+    process.versions['electron'] = '33.4.11';
+    try {
+      const server = manager.enabledMcpServers()['plugin-demo:data'];
+      expect(server).toEqual(
+        expect.objectContaining({
+          command: process.execPath,
+          args: ['./bin/data.mjs'],
+          cwd: managedRoot,
+          env: expect.objectContaining({
+            KIMI_CODE_HOME: home,
+            KIMI_PLUGIN_ROOT: managedRoot,
+            ELECTRON_RUN_AS_NODE: '1',
+          }),
+        }),
+      );
+      // An Electron host must not be routed through the CLI's `__plugin_run_node`
+      // subcommand (which only the CLI binary implements).
+      expect(JSON.stringify(server)).not.toContain('__plugin_run_node');
+    } finally {
+      if (originalElectron === undefined) delete process.versions['electron'];
+      else process.versions['electron'] = originalElectron;
+    }
+  });
+
+  it('enabledMcpServers() leaves stdio node plugins on system node outside Electron / CLI binary', async () => {
+    const home = await makeKimiHome();
+    const root = await makePlugin('demo', {
+      mcpServers: { data: { command: 'node', args: ['./bin/data.mjs'] } },
+    });
+    const manager = new PluginManager({ kimiHomeDir: home });
+    await manager.load();
+    await manager.install(root);
+
+    // Plain node host (tests run under node): not Electron, not the CLI native
+    // binary, so the config passes through unchanged (command stays `node`).
+    const server = manager.enabledMcpServers()['plugin-demo:data'];
+    expect(server).toEqual(
+      expect.objectContaining({
+        command: 'node',
+        args: ['./bin/data.mjs'],
+      }),
+    );
+    expect(JSON.stringify(server)).not.toContain('ELECTRON_RUN_AS_NODE');
+  });
 });


### PR DESCRIPTION
## Related Issue

None — this fixes a host-integration bug hit when the v2 server is embedded in an Electron main process. The problem is explained below.

## Problem

`withPluginMcpRuntime` decides how to launch a stdio `node` MCP plugin based on `isKimiNativeBinary()` (`process.execPath` not starting with `node`). That heuristic only distinguishes "kimi CLI native binary" from "plain node". Under **Electron**, `process.execPath` is the Electron binary (also not `node`-prefixed), so it is misdetected as the CLI native binary.

The plugin manager then spawns the plugin as `[<Electron binary>, __plugin_run_node, entry]`. `__plugin_run_node` is a hidden subcommand that only the kimi CLI binary implements, so Electron tries to open it as an app and fails with `Unable to find Electron app at …/__plugin_run_node`. Any stdio `node` plugin (e.g. a managed datasource plugin in the shared `~/.kimi-code` home) triggers this on every agent operation.

## What changed

Scoped to `packages/agent-core-v2/src/app/plugin/manager.ts`:

- Add `isElectron()` detection via `process.versions.electron` (the reliable Electron signal).
- On an Electron host, a stdio `node` plugin now runs as `[<Electron binary>, entry]` with `ELECTRON_RUN_AS_NODE=1` in its env — the plugin executes with Electron's own bundled Node, with no dependency on a system `node` and no `__plugin_run_node` subcommand.
- The CLI native binary path (`[binary, __plugin_run_node, entry]`) and the plain-node path (`[node, entry]`) are unchanged.

Tests (`test/app/plugin/manager-consumption.test.ts`):

- Electron host → config is `[execPath, entry]` with `ELECTRON_RUN_AS_NODE=1` and no `__plugin_run_node`.
- Non-Electron / non-CLI-binary host → config passes through unchanged (`command` stays `node`).

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my fix works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset — `@moonshot-ai/agent-core-v2` is private/unpublished (`private: true`), so no changeset is required.
- [x] Ran `gen-docs` skill, or this PR needs no doc update — internal runtime fix, no doc changes needed.
