### PR TITLE
refactor(agent-core-v2): remove dead ExecutableToolResult.message field

### DIFF
--- a/.changeset/remove-dead-tool-result-message.md
+++ b/.changeset/remove-dead-tool-result-message.md
@@ -1,5 +1,0 @@
----
-"@moonshot-ai/kimi-code": patch
----
-
-Remove the unused tool result message field that was never surfaced to users or the model.

--- a/.changeset/remove-dead-tool-result-message.md
+++ b/.changeset/remove-dead-tool-result-message.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Remove the unused tool result message field that was never surfaced to users or the model.

--- a/packages/agent-core-v2/src/agent/questionTools/tools/ask-user.ts
+++ b/packages/agent-core-v2/src/agent/questionTools/tools/ask-user.ts
@@ -213,7 +213,6 @@ export class AskUserQuestionTool implements BuiltinTool<AskUserQuestionInput> {
         'next_step: Use TaskOutput with this task_id for a non-blocking status/answer snapshot.\n' +
         'next_step: Use TaskStop only if the question should be cancelled.\n' +
         'human_shell_hint: The pending question is also visible in /tasks.',
-      message: `Started ${taskId}`,
     };
   }
 

--- a/packages/agent-core-v2/src/agent/task/tools/task-output.ts
+++ b/packages/agent-core-v2/src/agent/task/tools/task-output.ts
@@ -157,7 +157,6 @@ export class TaskOutputTool implements BuiltinTool<TaskOutputInput> {
     return {
       output: lines.join('\n'),
       isError: false,
-      message: 'Task snapshot retrieved.',
     };
   }
 }

--- a/packages/agent-core-v2/src/agent/toolExecutor/toolExecutorService.ts
+++ b/packages/agent-core-v2/src/agent/toolExecutor/toolExecutorService.ts
@@ -587,7 +587,6 @@ export class AgentToolExecutorService implements IAgentToolExecutorService {
     const effectiveResult = normalizeToolResult(coercedResult);
     const finalResult: ToolResult = {
       ...effectiveResult,
-      message: coercedResult.message ?? result.message,
       description: result.description,
       display: result.display,
       approvalRule: result.approvalRule,

--- a/packages/agent-core-v2/src/os/backends/node-local/tools/bash.ts
+++ b/packages/agent-core-v2/src/os/backends/node-local/tools/bash.ts
@@ -453,9 +453,7 @@ export class BashTool implements BuiltinTool<BashInput> {
 
     const foregroundResult = builder.ok('');
     const foregroundOutput = foregroundResult.output.length > 0 ? foregroundResult.output : '';
-    const message = backgroundResultMessage(labels.title, foregroundResult.message);
     const result: ExecutableToolResult & {
-      readonly message: string;
       readonly brief: string;
       readonly truncated: boolean;
     } = {
@@ -464,7 +462,6 @@ export class BashTool implements BuiltinTool<BashInput> {
         foregroundOutput.length === 0
           ? metadata
           : `${metadata}\n\nforeground_output:\n${foregroundOutput}`,
-      message,
       brief: labels.brief,
       truncated: foregroundResult.truncated,
     };
@@ -495,12 +492,6 @@ export class BashTool implements BuiltinTool<BashInput> {
 }
 
 registerTool(BashTool);
-
-function backgroundResultMessage(title: string, suffix: string): string {
-  const normalized = title.endsWith('.') ? title : `${title}.`;
-  if (suffix.length === 0) return normalized;
-  return suffix.endsWith('.') ? `${normalized} ${suffix}` : `${normalized} ${suffix}.`;
-}
 
 function formatTimeoutLabel(timeoutMs: number): string {
   return timeoutMs % 1000 === 0 ? `${String(timeoutMs / 1000)}s` : `${String(timeoutMs)}ms`;

--- a/packages/agent-core-v2/src/session/cron/tools/cron-create.ts
+++ b/packages/agent-core-v2/src/session/cron/tools/cron-create.ts
@@ -201,7 +201,6 @@ export class CronCreateTool implements BuiltinTool<CronCreateInput> {
         return {
           output: formatOutput(output),
           isError: false,
-          message: `Scheduled cron ${task.id}`,
         };
       },
     };

--- a/packages/agent-core-v2/src/tool/result-builder.ts
+++ b/packages/agent-core-v2/src/tool/result-builder.ts
@@ -21,11 +21,10 @@ export interface ToolResultBuilderOptions {
 }
 
 export type ExecutableToolResultBuilderResult = (
-  | ExecutableToolSuccessResult
   | ExecutableToolErrorResult
+  | ExecutableToolSuccessResult
 ) & {
   readonly output: string;
-  readonly message: string;
   readonly truncated: boolean;
   readonly brief?: string;
 };
@@ -126,7 +125,6 @@ export class ToolResultBuilder {
             ? `${output}${finalMessage}`
             : `${output}\n${finalMessage}`
         : output,
-      message: finalMessage,
       truncated: this.truncationHappened,
       brief: options.brief,
     };
@@ -152,7 +150,6 @@ export class ToolResultBuilder {
             : output.endsWith('\n')
               ? `${output}${finalMessage}`
               : `${output}\n${finalMessage}`,
-      message: finalMessage,
       truncated: this.truncationHappened,
       brief: options.brief,
     };

--- a/packages/agent-core-v2/src/tool/toolContract.ts
+++ b/packages/agent-core-v2/src/tool/toolContract.ts
@@ -39,7 +39,6 @@ export interface ExecutableToolSuccessResult {
   readonly output: ExecutableToolOutput;
   readonly isError?: false | undefined;
   readonly stopTurn?: boolean | undefined;
-  readonly message?: string | undefined;
   readonly truncated?: boolean | undefined;
   readonly note?: string;
   readonly delivery?: ToolDelivery | undefined;
@@ -48,7 +47,6 @@ export interface ExecutableToolSuccessResult {
 export interface ExecutableToolErrorResult {
   readonly output: ExecutableToolOutput;
   readonly isError: true;
-  readonly message?: string | undefined;
   readonly stopTurn?: boolean | undefined;
   readonly truncated?: boolean | undefined;
   readonly note?: string;

--- a/packages/agent-core-v2/test/agent/questionTools/tools/ask-user.test.ts
+++ b/packages/agent-core-v2/test/agent/questionTools/tools/ask-user.test.ts
@@ -442,7 +442,6 @@ describe('AskUserQuestionTool', () => {
       expect(result.output).toContain('task_id: q_test_task_id');
       expect(result.output).toContain('automatic_notification: true');
       expect(result.output).toContain('/tasks');
-
       expect(registerTask).toHaveBeenCalledOnce();
       expect(registerTask.mock.calls[0]![1]).toMatchObject({ detached: true });
       expect(getTask).toHaveBeenCalledWith('q_test_task_id');

--- a/packages/agent-core-v2/test/agent/questionTools/tools/ask-user.test.ts
+++ b/packages/agent-core-v2/test/agent/questionTools/tools/ask-user.test.ts
@@ -442,7 +442,7 @@ describe('AskUserQuestionTool', () => {
       expect(result.output).toContain('task_id: q_test_task_id');
       expect(result.output).toContain('automatic_notification: true');
       expect(result.output).toContain('/tasks');
-      expect(result.message).toBe('Started q_test_task_id');
+
       expect(registerTask).toHaveBeenCalledOnce();
       expect(registerTask.mock.calls[0]![1]).toMatchObject({ detached: true });
       expect(getTask).toHaveBeenCalledWith('q_test_task_id');

--- a/packages/agent-core-v2/test/agent/task/tools/task-tools.test.ts
+++ b/packages/agent-core-v2/test/agent/task/tools/task-tools.test.ts
@@ -441,7 +441,7 @@ describe('TaskOutputTool', () => {
     );
     const output = outputString(result);
 
-    expect(result).toMatchObject({ isError: false, message: 'Task snapshot retrieved.' });
+    expect(result).toMatchObject({ isError: false });
     expect(output).toContain('retrieval_status: success');
     expect(output).toContain('status: completed');
     expect(output).toContain('[output]\nDETACHED-PAYLOAD-LINE');

--- a/packages/agent-core-v2/test/os/backends/node-local/tools/bash.test.ts
+++ b/packages/agent-core-v2/test/os/backends/node-local/tools/bash.test.ts
@@ -823,7 +823,7 @@ describe('BashTool', () => {
     expect(result).toMatchObject({
       output: 'ok\n',
       isError: false,
-      message: 'Command executed successfully.',
+
     });
   });
 
@@ -863,7 +863,7 @@ describe('BashTool', () => {
     expect(result).toMatchObject({
       output: 'ok\n',
       isError: false,
-      message: 'Command executed successfully.',
+
     });
   });
 
@@ -875,7 +875,7 @@ describe('BashTool', () => {
 
     expect(result).toMatchObject({
       isError: true,
-      message: 'Command failed with exit code: 2.',
+
       brief: 'Failed with exit code: 2',
     });
     expect(result.output).toContain('boom\n');
@@ -891,7 +891,7 @@ describe('BashTool', () => {
     expect(result).toMatchObject({
       output: 'out\nwarn\n',
       isError: false,
-      message: 'Command executed successfully.',
+
     });
   });
 
@@ -905,7 +905,7 @@ describe('BashTool', () => {
 
     expect(result).toMatchObject({
       isError: true,
-      message: 'Command failed with exit code: 2.',
+
       brief: 'Failed with exit code: 2',
     });
     expect(result.output).toContain('partial\nboom\n');
@@ -928,7 +928,7 @@ describe('BashTool', () => {
 
     expect(result).toMatchObject({
       isError: true,
-      message: 'wait failed',
+
       brief: 'wait failed',
     });
     expect(result.output).toContain('partial output\nwait failed');
@@ -953,7 +953,7 @@ describe('BashTool', () => {
       expect(result).toMatchObject({
         isError: false,
         output: 'err-first\nout-second\nerr-third\n',
-        message: 'Command executed successfully.',
+  
       });
     } finally {
       vi.useRealTimers();
@@ -986,7 +986,7 @@ describe('BashTool', () => {
       expect(proc.kill).not.toHaveBeenCalled();
       expect(result).toMatchObject({
         isError: false,
-        message: expect.stringContaining('timed out and moved to background'),
+
       });
       expect(result.output).toContain('task_id: bash-');
       resolveWait(0);
@@ -1120,7 +1120,7 @@ describe('BashTool', () => {
 
     expect(result.output).toContain('[...truncated]');
     expect(result.output).toContain('Output is truncated');
-    expect((result as { message?: string }).message).toContain('Output is truncated');
+
   });
 
   it('marks the truncated output buffer with a "[...truncated]" sentinel at the cut point', async () => {
@@ -1330,7 +1330,7 @@ describe('BashTool background mode', () => {
     expect(result.output).toContain(`task_id: ${task.taskId}`);
     expect(result.output).toContain('automatic_notification: true');
     expect(result.output).toContain('do NOT wait, poll, or call TaskOutput');
-    expect(result).toMatchObject({ message: 'Task moved to background.' });
+
     expect((result as { brief?: string }).brief).toBe(`Backgrounded ${task.taskId}`);
     expect(service.getTask(task.taskId)).toMatchObject({ detached: true });
     await vi.waitFor(async () => {
@@ -1404,7 +1404,7 @@ describe('BashTool background mode', () => {
       expect(proc.kill).not.toHaveBeenCalled();
       expect(result).toMatchObject({
         isError: false,
-        message: expect.stringContaining('timed out and moved to background'),
+
         brief: expect.stringContaining('after timeout'),
       });
       const taskId = /^task_id: (\S+)/m.exec(result.output as string)?.[1];
@@ -1532,7 +1532,7 @@ describe('BashTool background mode', () => {
 
     expect(result.output).toMatch(/task_id: bash-[0-9a-z]{8}/);
     expect(result.output).toContain('automatic_notification: true');
-    expect(result).toMatchObject({ message: 'Background task started.' });
+
     expect((result as { brief?: string }).brief).toMatch(/^Started bash-[0-9a-z]{8}$/);
     expect(result.output).toContain('do NOT wait, poll, or call TaskOutput on it');
     expect(result.output).not.toContain('block=false');

--- a/packages/agent-core-v2/test/os/backends/node-local/tools/bash.test.ts
+++ b/packages/agent-core-v2/test/os/backends/node-local/tools/bash.test.ts
@@ -823,7 +823,6 @@ describe('BashTool', () => {
     expect(result).toMatchObject({
       output: 'ok\n',
       isError: false,
-
     });
   });
 
@@ -863,7 +862,6 @@ describe('BashTool', () => {
     expect(result).toMatchObject({
       output: 'ok\n',
       isError: false,
-
     });
   });
 
@@ -875,7 +873,6 @@ describe('BashTool', () => {
 
     expect(result).toMatchObject({
       isError: true,
-
       brief: 'Failed with exit code: 2',
     });
     expect(result.output).toContain('boom\n');
@@ -891,7 +888,6 @@ describe('BashTool', () => {
     expect(result).toMatchObject({
       output: 'out\nwarn\n',
       isError: false,
-
     });
   });
 
@@ -905,7 +901,6 @@ describe('BashTool', () => {
 
     expect(result).toMatchObject({
       isError: true,
-
       brief: 'Failed with exit code: 2',
     });
     expect(result.output).toContain('partial\nboom\n');
@@ -928,7 +923,6 @@ describe('BashTool', () => {
 
     expect(result).toMatchObject({
       isError: true,
-
       brief: 'wait failed',
     });
     expect(result.output).toContain('partial output\nwait failed');
@@ -953,7 +947,6 @@ describe('BashTool', () => {
       expect(result).toMatchObject({
         isError: false,
         output: 'err-first\nout-second\nerr-third\n',
-  
       });
     } finally {
       vi.useRealTimers();
@@ -986,7 +979,6 @@ describe('BashTool', () => {
       expect(proc.kill).not.toHaveBeenCalled();
       expect(result).toMatchObject({
         isError: false,
-
       });
       expect(result.output).toContain('task_id: bash-');
       resolveWait(0);
@@ -1120,7 +1112,6 @@ describe('BashTool', () => {
 
     expect(result.output).toContain('[...truncated]');
     expect(result.output).toContain('Output is truncated');
-
   });
 
   it('marks the truncated output buffer with a "[...truncated]" sentinel at the cut point', async () => {
@@ -1330,7 +1321,6 @@ describe('BashTool background mode', () => {
     expect(result.output).toContain(`task_id: ${task.taskId}`);
     expect(result.output).toContain('automatic_notification: true');
     expect(result.output).toContain('do NOT wait, poll, or call TaskOutput');
-
     expect((result as { brief?: string }).brief).toBe(`Backgrounded ${task.taskId}`);
     expect(service.getTask(task.taskId)).toMatchObject({ detached: true });
     await vi.waitFor(async () => {
@@ -1404,7 +1394,6 @@ describe('BashTool background mode', () => {
       expect(proc.kill).not.toHaveBeenCalled();
       expect(result).toMatchObject({
         isError: false,
-
         brief: expect.stringContaining('after timeout'),
       });
       const taskId = /^task_id: (\S+)/m.exec(result.output as string)?.[1];
@@ -1532,7 +1521,6 @@ describe('BashTool background mode', () => {
 
     expect(result.output).toMatch(/task_id: bash-[0-9a-z]{8}/);
     expect(result.output).toContain('automatic_notification: true');
-
     expect((result as { brief?: string }).brief).toMatch(/^Started bash-[0-9a-z]{8}$/);
     expect(result.output).toContain('do NOT wait, poll, or call TaskOutput on it');
     expect(result.output).not.toContain('block=false');

--- a/packages/agent-core-v2/test/os/backends/node-local/tools/grep.test.ts
+++ b/packages/agent-core-v2/test/os/backends/node-local/tools/grep.test.ts
@@ -1745,7 +1745,7 @@ describe('GrepTool', () => {
     expect(dataLines).toHaveLength(3);
     expect(output).toContain('Found 30 total occurrences across 10 files.');
     expect(output).toContain('Results truncated to 3 lines (total: 10). Use offset=3 to see more.');
-    expect((result as { message?: string }).message ?? '').not.toContain('Found');
+
   });
 
   it('truncates extremely long rg output with a byte-level safety cap message', async () => {
@@ -1758,9 +1758,7 @@ describe('GrepTool', () => {
       context({ pattern: 'match', output_mode: 'content', head_limit: 0 }),
     );
 
-    const message = (result as { message?: unknown }).message;
-    expect(typeof message).toBe('string');
-    expect(message).toContain('Output is truncated');
+    expect(result.output).toContain('Output is truncated');
   });
 
   it('matches a pattern spanning a newline when multiline is set', async () => {

--- a/packages/agent-core-v2/test/os/backends/node-local/tools/grep.test.ts
+++ b/packages/agent-core-v2/test/os/backends/node-local/tools/grep.test.ts
@@ -1745,7 +1745,6 @@ describe('GrepTool', () => {
     expect(dataLines).toHaveLength(3);
     expect(output).toContain('Found 30 total occurrences across 10 files.');
     expect(output).toContain('Results truncated to 3 lines (total: 10). Use offset=3 to see more.');
-
   });
 
   it('truncates extremely long rg output with a byte-level safety cap message', async () => {

--- a/packages/agent-core-v2/test/tool/result-builder.test.ts
+++ b/packages/agent-core-v2/test/tool/result-builder.test.ts
@@ -11,7 +11,7 @@ describe('ToolResultBuilder', () => {
 
     const result = builder.ok('Operation completed');
     expect(result.output).toBe('Hello world');
-    expect(result.message).toBe('Operation completed.');
+    expect(result.truncated).toBe(false);
     expect(builder.nChars).toBe(11);
   });
 
@@ -24,10 +24,8 @@ describe('ToolResultBuilder', () => {
 
     const result = builder.ok('Operation completed');
     expect(result.output).toContain('Hello[...truncated]');
-    expect(result.output).toContain('Output is truncated');
+    expect(result.output).toContain('Operation completed.');
     expect(result.output.endsWith('Output is truncated to fit in the message.')).toBe(true);
-    expect(result.message).toContain('Operation completed.');
-    expect(result.message).toContain('Output is truncated');
     expect(result.truncated).toBe(true);
   });
 
@@ -38,7 +36,7 @@ describe('ToolResultBuilder', () => {
 
     const result = builder.ok();
     expect(result.output).toContain('[...truncated]');
-    expect(result.message).toContain('Output is truncated');
+    expect(result.output).toContain('Output is truncated');
   });
 
   it('respects both per-line and per-buffer limits at once', () => {
@@ -51,7 +49,7 @@ describe('ToolResultBuilder', () => {
 
     const result = builder.ok();
     expect(result.output).toContain('[...truncated]');
-    expect(result.message).toContain('Output is truncated');
+    expect(result.output).toContain('Output is truncated');
   });
 
   it('tracks nChars as the buffer grows', () => {
@@ -88,7 +86,7 @@ describe('ToolResultBuilder', () => {
 
     const result = builder.ok();
     expect(result.output).toContain('Hello\n[...truncated]');
-    expect(result.message).toContain('Output is truncated');
+    expect(result.output).toContain('Output is truncated');
   });
 
   it('keeps unterminated trailing text in output', () => {
@@ -115,7 +113,6 @@ describe('ToolResultBuilder', () => {
 
     expect(result.output).toContain('Some output');
     expect(result.output).toContain('Something went wrong');
-    expect(result.message).toBe('Something went wrong');
   });
 
   it('preserves the truncation hint on error', () => {
@@ -125,8 +122,8 @@ describe('ToolResultBuilder', () => {
     const result = builder.error('Command failed');
 
     expect(result.output).toContain('[...truncated]');
-    expect(result.message).toContain('Command failed');
-    expect(result.message).toContain('Output is truncated');
+    expect(result.output).toContain('Command failed');
+    expect(result.output).toContain('Output is truncated');
   });
 
   it('returns executable output with critical messages included', () => {
@@ -136,8 +133,8 @@ describe('ToolResultBuilder', () => {
     const result = builder.ok('Operation completed');
 
     expect(result.output).toContain('[...truncated]');
+    expect(result.output).toContain('Operation completed.');
     expect(result.output).toContain('Output is truncated');
-    expect(result.message).toContain('Output is truncated');
   });
 
   it('keeps normal success messages out of non-empty output', () => {
@@ -147,6 +144,5 @@ describe('ToolResultBuilder', () => {
     const result = builder.ok('Command executed successfully.');
 
     expect(result.output).toBe('ok\n');
-    expect(result.message).toBe('Command executed successfully.');
   });
 });


### PR DESCRIPTION
The `message` field on `ExecutableToolSuccessResult` and `ExecutableToolErrorResult` was written by tools but never read by the UI or exposed to the model, making it completely dead weight.

This PR removes it from the tool contract, result builder, and all tool implementations in `agent-core-v2`, and updates tests accordingly. v1 (`agent-core`) is intentionally left untouched.

Internal change entering the CLI bundle, so the changeset targets `@moonshot-ai/kimi-code`.