### PR TITLE
fix(kosong): serialize reasoning-only assistant content

### DIFF
--- a/.changeset/fix-reasoning-only-resume.md
+++ b/.changeset/fix-reasoning-only-resume.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Fix resumed reasoning-only sessions with OpenAI-compatible providers.

--- a/packages/kosong/src/providers/openai-legacy.ts
+++ b/packages/kosong/src/providers/openai-legacy.ts
@@ -212,6 +212,8 @@ function convertMessage(
       result.content = nonThinkParts
         .map((p) => convertContentPart(p))
         .filter((p): p is OpenAIContentPart => p !== null);
+    } else if (message.role === 'assistant' && message.toolCalls.length === 0) {
+      result.content = '';
     }
   }
 

--- a/packages/kosong/test/openai-legacy.test.ts
+++ b/packages/kosong/test/openai-legacy.test.ts
@@ -1389,6 +1389,26 @@ describe('OpenAILegacyChatProvider', () => {
       });
     });
 
+    it('includes empty content for reasoning-only assistant messages without tool calls', async () => {
+      const provider = createProvider({ model: 'deepseek-reasoner' });
+      const history: Message[] = [
+        {
+          role: 'assistant',
+          content: [{ type: 'think', think: 'reasoning before the crash' }],
+          toolCalls: [],
+        },
+      ];
+
+      const body = await captureRequestBody(provider, '', [], history);
+      const messages = body['messages'] as Record<string, unknown>[];
+
+      expect(messages[0]).toEqual({
+        role: 'assistant',
+        content: '',
+        reasoning_content: 'reasoning before the crash',
+      });
+    });
+
     it('serializes an explicitly empty ThinkPart to reasoning_content', async () => {
       const provider = createProvider({ model: 'deepseek-reasoner' });
       const history: Message[] = [


### PR DESCRIPTION
## Related Issue

Resolve #1404

## Problem

If a process exits after recording non-empty reasoning but before producing answer text or a tool call, resume reconstructs an assistant history entry with reasoning only. The OpenAI-compatible adapter preserves the reasoning field but otherwise emits neither content nor tool_calls, which strict providers reject on the next request.

## What changed

- In the OpenAI legacy adapter, serialize explicit empty content only for assistant entries that have no visible content and no tool calls, while preserving the separate reasoning field.
- Add regression coverage for the non-empty reasoning-only interruption shape from #1404.

## Scope and related work

- #1968 is merged and repairs vacuous messages whose thinking is empty or whitespace-only; it does not cover a non-empty ThinkPart.
- #1882 handles a completely empty interrupted assistant tail.
- #2172 proposes a broader resume/projection-level repair for the same non-empty thinking interruption and may be preferable for providers that reject an explicit empty string.

This PR intentionally remains the focused provider-serialization alternative so maintainers can choose the desired repair layer without mixing the broader resume changes into this diff.

## Validation

- OpenAI legacy provider tests: 78 passed
- Full test suite: 18,116 passed; expected skips, todos, and expected failures only
- Full monorepo typecheck: passed
- Full monorepo lint: 0 errors; changed files have 0 warnings
- Changeset validation and git diff check: passed

## Checklist

- [x] I have read the CONTRIBUTING document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran gen-changesets skill, and included a patch changeset.
- [x] This focused compatibility fix needs no documentation update.