### PR TITLE
fix(kap-server): derive session title from first skill slash command

### DIFF
--- a/.changeset/skill-first-message-title.md
+++ b/.changeset/skill-first-message-title.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+web: Fix the session title not being generated when the first message is a skill slash command.

--- a/packages/kap-server/src/routes/skills.ts
+++ b/packages/kap-server/src/routes/skills.ts
@@ -42,6 +42,9 @@
  *                    `skill_activation` origin. The returned `Turn` handle is
  *                    discarded; clients follow progress via the `skill.activated`
  *                    + `turn.*` events emitted by the service on the WS stream.
+ *                    The edge then applies the prompt-metadata update
+ *                    (`applyPromptMetadataUpdate`) so a first `/<skill>`
+ *                    message titles the session, matching the native RPC path.
  *
  * **Model projection**: `SkillDefinition` (v2) → protocol `SkillDescriptor`,
  * byte-for-byte with v1's `toProtocolSkill`
@@ -72,9 +75,11 @@ import {
   IAgentSkillService,
   IBootstrapService,
   IConfigService,
+  IEventService,
   IPluginService,
   ISessionIndex,
   ISessionLifecycleService,
+  ISessionMetadata,
   ISessionSkillCatalog,
   ISkillCatalogRuntimeOptions,
   ISkillDiscovery,
@@ -83,8 +88,10 @@ import {
   isError2,
   MERGE_ALL_AVAILABLE_SKILLS_SECTION,
   SKILL_SOURCE_PRIORITY,
+  applyPromptMetadataUpdate,
   configuredRoots,
   projectRoots,
+  promptMetadataTextFromSkill,
   userRoots,
   type ISessionScopeHandle,
   type Scope,
@@ -284,6 +291,16 @@ export function registerSkillsRoutes(app: SkillsRouteHost, core: Scope): void {
         await agent.accessor
           .get(IAgentSkillService)
           .activate({ name: parsed.id, args: req.body.args });
+        // Keep the easy-title behavior of the native RPC / TUI path: a first
+        // `/<skill>` message titles the session (same as routes/prompts.ts).
+        await applyPromptMetadataUpdate(
+          {
+            metadata: resolved.handle.accessor.get(ISessionMetadata),
+            eventService: core.accessor.get(IEventService),
+            sessionId: session_id,
+          },
+          promptMetadataTextFromSkill({ name: parsed.id, args: req.body.args }),
+        );
         requestLog(req)?.info({ session_id, skill_name: parsed.id }, 'skill activated');
         reply.send(okEnvelope({ activated: true, skill_name: parsed.id }, req.id));
       } catch (err) {

--- a/packages/kap-server/test/skills.test.ts
+++ b/packages/kap-server/test/skills.test.ts
@@ -217,6 +217,21 @@ describe('server-v2 /api/v1 skills', () => {
       });
     });
 
+    it('derives the session title from the first skill activation', async () => {
+      const id = await createSession();
+      await createMainAgent(id);
+
+      const activated = await postJson<{ activated: boolean; skill_name: string }>(
+        `/api/v1/sessions/${id}/skills/update-config:activate`,
+        { args: '--help' },
+      );
+      expect(activated.body.code).toBe(0);
+
+      const got = await getJson<{ title: string }>(`/api/v1/sessions/${id}`);
+      expect(got.body.code).toBe(0);
+      expect(got.body.data.title).toBe('/update-config --help');
+    });
+
     it('returns 40415 for an unknown skill', async () => {
       const id = await createSession();
       await createMainAgent(id);


### PR DESCRIPTION
## Related Issue

No linked issue — the problem is explained below.

## Problem

When a session's first message is a skill slash command sent through the v1 REST API (`POST /sessions/{id}/skills/{name}:activate`, used by the web UI), the session title is never derived from that message: the session stays at the "New Session" placeholder until a later plain prompt overwrites it with an unrelated title.

The TUI / native RPC path already titles such sessions (`/<skill> <args>`), because the legacy session RPC applies a prompt-metadata update on `activateSkill`. The kap-server v1 port of the route bypassed that path and called the skill service directly, dropping the metadata update the old v1 server got for free.

## What changed

- `packages/kap-server/src/routes/skills.ts`: after a successful activation, apply the same `applyPromptMetadataUpdate` + `promptMetadataTextFromSkill` used by the native RPC path, so a first `/<skill>` message titles the session. It is a no-op for custom titles and failed activations.
- `packages/kap-server/test/skills.test.ts`: added a test asserting the session title is derived from the first skill activation.
- Added a patch changeset (the symptom is visible in the bundled web UI).

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.
