### PR TITLE
style(agent-core-v2): fold retry-budget note into the file header

### DIFF
--- a/packages/agent-core-v2/src/_base/utils/retry.ts
+++ b/packages/agent-core-v2/src/_base/utils/retry.ts
@@ -1,15 +1,14 @@
 /**
  * `_base` retry helpers — exponential and server-directed backoff, abortable
  * sleeps, and error-field extraction shared by retry policies (the loop's
- * `stepRetry` plugin, full-compaction's self-managed resends).
+ * `stepRetry` plugin, full-compaction's self-managed resends). The default
+ * budget is 10 attempts per step (kept in sync with v1
+ * `agent-core/loop/retry.ts`): the 500ms ×2 ramp capped at 32s waits out
+ * multi-minute provider overload (sustained 429s) before a turn fails.
  */
 
 import { abortable } from '#/_base/utils/abort';
 
-// Default retry budget per step: 10 attempts (9 retries). Kept in sync with
-// v1 (`agent-core/loop/retry.ts`): the exponential ramp below climbs 0.5s,
-// 1s, 2s … up to the 32s cap, giving roughly 2–3 minutes of total wait to
-// ride out a typical provider overload window (sustained 429s).
 export const DEFAULT_MAX_RETRY_ATTEMPTS = 10;
 
 const BASE_DELAY_MS = 500;


### PR DESCRIPTION
## Related Issue

Follow-up to #1740 (Codex review comment).

## Problem

The retry-budget comment added in #1740 sits beside an exported constant in `packages/agent-core-v2/src/_base/utils/retry.ts`, but `packages/agent-core-v2/AGENTS.md` requires comments to live only in the top-of-file `/** */` block, never beside functions, methods, or statements. #1740 was merged before this fix could be pushed.

## What changed

Fold the default-budget rationale into the file header and remove the standalone comment. Comment-only change; no behavior difference, no changeset needed.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [ ] I have added tests that prove my feature works. (N/A — comment-only change)
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.
