### PR TITLE
fix(agent-core-v2): correct goal lifecycle error guidance

### DIFF
--- a/.changeset/fix-goal-error-guidance.md
+++ b/.changeset/fix-goal-error-guidance.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Correct the guidance text shown when a goal cannot be paused or resumed.

--- a/packages/agent-core-v2/src/agent/goal/errors.ts
+++ b/packages/agent-core-v2/src/agent/goal/errors.ts
@@ -44,7 +44,7 @@ export const GoalErrors = {
       title: 'Invalid goal status transition',
       retryable: false,
       public: true,
-      action: 'Use a status allowed for this actor (complete, blocked, or impossible).',
+      action: 'Only an active goal can be paused; resume a blocked goal with `/goal resume`.',
     },
     'goal.metadata_reserved': {
       title: 'Goal metadata is reserved',
@@ -56,7 +56,7 @@ export const GoalErrors = {
       title: 'Goal is not resumable',
       retryable: false,
       public: true,
-      action: 'Only paused goals can be resumed.',
+      action: 'Only paused or blocked goals can be resumed.',
     },
     'goal.unsupported_agent': {
       title: 'Goals are unavailable for subagents',

--- a/packages/agent-core-v2/src/agent/goal/goalService.ts
+++ b/packages/agent-core-v2/src/agent/goal/goalService.ts
@@ -326,13 +326,6 @@ export class AgentGoalService extends Disposable implements IAgentGoalService {
     return { goal: state === null ? null : this.toSnapshot(state) };
   }
 
-  getActiveGoal(): GoalSnapshot | null {
-    this.assertSupportedAgent();
-    const state = this.goalState;
-    if (state === null || state.status !== 'active') return null;
-    return this.toSnapshot(state);
-  }
-
   isGoalToolTarget(turnId: number, goalId: string): boolean {
     this.assertSupportedAgent();
     return this.goalTurnTargets.get(turnId) === goalId;

--- a/packages/agent-core-v2/test/agent/goal/goal.test.ts
+++ b/packages/agent-core-v2/test/agent/goal/goal.test.ts
@@ -1505,7 +1505,7 @@ describe('goal error catalog metadata', () => {
       title: 'Invalid goal status transition',
       retryable: false,
       public: true,
-      action: 'Use a status allowed for this actor (complete, blocked, or impossible).',
+      action: 'Only an active goal can be paused; resume a blocked goal with `/goal resume`.',
     });
     expect(errorInfo('goal.metadata_reserved')).toEqual({
       title: 'Goal metadata is reserved',
@@ -1517,7 +1517,7 @@ describe('goal error catalog metadata', () => {
       title: 'Goal is not resumable',
       retryable: false,
       public: true,
-      action: 'Only paused goals can be resumed.',
+      action: 'Only paused or blocked goals can be resumed.',
     });
     expect(errorInfo('goal.unsupported_agent')).toEqual({
       title: 'Goals are unavailable for subagents',


### PR DESCRIPTION
## Related Issue

None — the problem is explained below.

## Problem

While aligning the goal mode implementation between `agent-core` (v1) and `agent-core-v2`, two user-facing error guidance texts in the v2 goal error catalog were found to contradict the actual behavior (both were inherited verbatim from v1):

- `goal.status_invalid` suggested statuses `(complete, blocked, or impossible)` — `impossible` is not a goal status, and the code is only thrown when pausing a non-active goal, so the advice did not match the failure.
- `goal.not_resumable` claimed "Only paused goals can be resumed", but `resumeGoal` accepts both `paused` and `blocked` goals (covered by existing tests in both engines).

The v1 package carries the same two texts; this PR intentionally fixes v2 only, since v1 behavior/text is the migration baseline and is left untouched.

## What changed

- Corrected the two `action` guidance strings in the v2 goal error catalog and updated the catalog assertions accordingly.
- Removed a dead goal service method in v2 that has no callers in the v2 architecture (its v1 counterpart's caller did not survive the port); not part of the service interface, so no consumer impact.
- Added a `patch` changeset for `@moonshot-ai/kimi-code` (the change reaches the CLI through the bundled server engine).

Validation: goal-domain tests (163) and the full `@moonshot-ai/agent-core-v2` suite (238 files / 3474 tests) pass; `tsc --noEmit` and `lint:domain` are clean.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.
