### PR TITLE
fix(web): confirm dialogs respond to Enter and await async actions

### DIFF
--- a/.changeset/web-confirm-dialog-async-loading.md
+++ b/.changeset/web-confirm-dialog-async-loading.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+web: Fix Enter not confirming modal confirmation dialogs in dev builds, and keep the dialog open with a loading state until the confirmed action (such as archiving a session) completes.

--- a/apps/kimi-web/src/App.vue
+++ b/apps/kimi-web/src/App.vue
@@ -27,6 +27,7 @@ import GlobalLoading from './components/GlobalLoading.vue';
 import DebugPanel from './debug/DebugPanel.vue';
 import { isTraceEnabled } from './debug/trace';
 import { useKimiWebClient } from './composables/useKimiWebClient';
+import { useConfirmDialog } from './composables/useConfirmDialog';
 import { useAuthGate } from './composables/useAuthGate';
 import { usePageTitle } from './composables/usePageTitle';
 import { useSidebarLayout } from './composables/useSidebarLayout';
@@ -72,6 +73,7 @@ provide(
   (toolCallId: string): SwarmMember[] => client.swarmMembersByToolCallId.value.get(toolCallId) ?? [],
 );
 const { t } = useI18n();
+const { confirm } = useConfirmDialog();
 
 // KAP/daemon debug panel — opt-in via ?debug=1 or localStorage kimi-web.debug=1.
 const debugEnabled = isTraceEnabled();
@@ -411,12 +413,41 @@ async function handleAddProvider(input: { type: string; apiKey?: string; baseUrl
   await client.addProvider(input);
 }
 
-async function handleDeleteProvider(id: string): Promise<void> {
-  await client.deleteProvider(id);
-}
-
 async function handleRefreshProvider(id: string): Promise<void> {
   await client.refreshProvider(id);
+}
+
+// Destructive session/workspace/provider actions confirm through the shared
+// modal here (the menu components only emit the intent). Each passes its work
+// as the dialog `action`, so the dialog stays open with a loading state until
+// the operation settles. All three client calls toast their own errors and
+// never reject.
+async function confirmArchiveSession(id: string): Promise<void> {
+  await confirm({
+    title: t('sidebar.archive'),
+    message: t('sidebar.archiveConfirm'),
+    variant: 'danger',
+    action: () => client.archiveSession(id),
+  });
+}
+
+async function confirmDeleteWorkspace(id: string): Promise<void> {
+  const name = client.workspacesView.value.find((w) => w.id === id)?.name ?? id;
+  await confirm({
+    title: t('sidebar.removeWorkspace'),
+    message: t('workspace.removeWorkspaceConfirm', { name }),
+    variant: 'danger',
+    action: () => client.deleteWorkspace(id),
+  });
+}
+
+async function confirmDeleteProvider(id: string): Promise<void> {
+  await confirm({
+    title: t('providers.delete'),
+    message: t('providers.confirmDelete'),
+    variant: 'danger',
+    action: () => client.deleteProvider(id),
+  });
 }
 
 async function handleUpdateConfig(patch: Partial<AppConfig>): Promise<void> {
@@ -706,11 +737,11 @@ function openPr(url: string): void {
         @select-workspace="client.openWorkspace($event)"
         @add-workspace="showAddWorkspace = true"
         @rename="(id, title) => client.renameSession(id, title)"
-        @archive="(id) => client.archiveSession(id)"
+        @archive="confirmArchiveSession($event)"
         @fork="(id) => client.forkSession(id)"
         @export="(id) => client.exportSession(id)"
         @rename-workspace="(id, name) => client.renameWorkspace(id, name)"
-        @delete-workspace="(id) => client.deleteWorkspace(id)"
+        @delete-workspace="confirmDeleteWorkspace($event)"
         @reorder-workspaces="client.reorderWorkspaces($event)"
         @set-workspace-sort-mode="client.setWorkspaceSortMode($event)"
         @load-more-sessions="(id) => void client.loadMoreSessions(id)"
@@ -812,7 +843,7 @@ function openPr(url: string): void {
       @refresh-git-status="client.activeSessionId.value && client.loadGitStatus(client.activeSessionId.value)"
       @rename-session="(id, title) => client.renameSession(id, title)"
       @fork-session="(id) => client.forkSession(id)"
-      @archive-session="(id) => client.archiveSession(id)"
+      @archive-session="confirmArchiveSession($event)"
       @export-session="(id) => client.exportSession(id)"
       @compact="client.compact()"
       @pick-model="openModelPicker()"
@@ -991,7 +1022,7 @@ function openPr(url: string): void {
       :unavailable="providersUnavailable"
       @add="handleAddProvider($event)"
       @refresh="handleRefreshProvider($event)"
-      @delete="handleDeleteProvider($event)"
+      @delete="confirmDeleteProvider($event)"
       @open-login="() => { showProviders = false; openLogin(); }"
       @close="showProviders = false"
     />
@@ -1056,8 +1087,8 @@ function openPr(url: string): void {
       @create-in-workspace="handleCreateSessionInWorkspace($event)"
       @add-workspace="showAddWorkspace = true"
       @rename="(id, title) => client.renameSession(id, title)"
-      @archive="(id) => client.archiveSession(id)"
-      @delete-workspace="(id) => client.deleteWorkspace(id)"
+      @archive="confirmArchiveSession($event)"
+      @delete-workspace="confirmDeleteWorkspace($event)"
       @load-more="(id) => void client.loadMoreSessions(id)"
     />
 

--- a/apps/kimi-web/src/components/SessionRow.vue
+++ b/apps/kimi-web/src/components/SessionRow.vue
@@ -8,7 +8,6 @@ import type { Session } from '../types';
 import { copyTextToClipboard } from '../lib/clipboard';
 import Spinner from './ui/Spinner.vue';
 import Badge from './ui/Badge.vue';
-import { useConfirmDialog } from '../composables/useConfirmDialog';
 import IconButton from './ui/IconButton.vue';
 import Menu from './ui/Menu.vue';
 import MenuItem from './ui/MenuItem.vue';
@@ -16,7 +15,6 @@ import Icon from './ui/Icon.vue';
 import Tooltip from './ui/Tooltip.vue';
 
 const { t } = useI18n();
-const { confirm } = useConfirmDialog();
 
 const props = withDefaults(
   defineProps<{
@@ -168,18 +166,11 @@ function exportRow(): void {
   emit('export', props.session.id);
 }
 
-// Archive confirm — modal, consistent with remove-workspace.
-async function startArchive(): Promise<void> {
+// Archive — the modal confirm and the async work live in App.vue
+// (confirmArchiveSession); the row only emits the intent.
+function startArchive(): void {
   closeMenu();
-  if (
-    await confirm({
-      title: t('sidebar.archive'),
-      message: t('sidebar.archiveConfirm'),
-      variant: 'danger',
-    })
-  ) {
-    emit('archive', props.session.id);
-  }
+  emit('archive', props.session.id);
 }
 
 // Expose closeMenu so the parent can close on outside-click.

--- a/apps/kimi-web/src/components/Sidebar.vue
+++ b/apps/kimi-web/src/components/Sidebar.vue
@@ -30,10 +30,8 @@ import Kbd from './ui/Kbd.vue';
 import Menu from './ui/Menu.vue';
 import MenuItem from './ui/MenuItem.vue';
 import Pill from './ui/Pill.vue';
-import { useConfirmDialog } from '../composables/useConfirmDialog';
 
 const { t } = useI18n();
-const { confirm } = useConfirmDialog();
 
 // Dev-only affordance: when the page is served by the Vite dev server, the
 // logo turns yellow and a backend pill next to the brand shows the engine
@@ -371,19 +369,12 @@ function startRenameFromMenu(): void {
   closeGhMenu();
 }
 
-async function deleteFromMenu(): Promise<void> {
+function deleteFromMenu(): void {
   const ws = ghMenuTarget.value;
   if (!ws) return;
   closeGhMenu();
-  if (
-    await confirm({
-      title: t('sidebar.removeWorkspace'),
-      message: t('workspace.removeWorkspaceConfirm', { name: ws.name }),
-      variant: 'danger',
-    })
-  ) {
-    emit('deleteWorkspace', ws.id);
-  }
+  // The modal confirm + async delete live in App.vue (confirmDeleteWorkspace).
+  emit('deleteWorkspace', ws.id);
 }
 
 // ---------------------------------------------------------------------------
@@ -449,17 +440,10 @@ function startRenameWs(ws: WorkspaceView): void {
   closeWsMenu();
 }
 
-async function deleteWs(ws: WorkspaceView): Promise<void> {
+function deleteWs(ws: WorkspaceView): void {
   closeWsMenu();
-  if (
-    await confirm({
-      title: t('sidebar.removeWorkspace'),
-      message: t('workspace.removeWorkspaceConfirm', { name: ws.name }),
-      variant: 'danger',
-    })
-  ) {
-    emit('deleteWorkspace', ws.id);
-  }
+  // The modal confirm + async delete live in App.vue (confirmDeleteWorkspace).
+  emit('deleteWorkspace', ws.id);
 }
 
 // ---------------------------------------------------------------------------

--- a/apps/kimi-web/src/components/chat/ChatHeader.vue
+++ b/apps/kimi-web/src/components/chat/ChatHeader.vue
@@ -12,10 +12,8 @@ import MenuItem from '../ui/MenuItem.vue';
 import IconButton from '../ui/IconButton.vue';
 import Icon from '../ui/Icon.vue';
 import Tooltip from '../ui/Tooltip.vue';
-import { useConfirmDialog } from '../../composables/useConfirmDialog';
 
 const { t } = useI18n();
-const { confirm } = useConfirmDialog();
 
 const props = defineProps<{
   sessionId?: string;
@@ -210,21 +208,13 @@ function exportSession(): void {
 }
 
 // ---------------------------------------------------------------------------
-// Archive — modal confirm (the header has no session row to swap, so use the
-// shared ConfirmDialog instead of the inline strip used in SessionRow).
+// Archive — the modal confirm and the async work live in App.vue
+// (confirmArchiveSession); the header only emits the intent.
 // ---------------------------------------------------------------------------
-async function startArchive(): Promise<void> {
+function startArchive(): void {
   if (!props.sessionId) return;
   closeMenu();
-  if (
-    await confirm({
-      title: t('header.archiveSession'),
-      message: t('sidebar.archiveConfirm'),
-      variant: 'danger',
-    })
-  ) {
-    emit('archiveSession', props.sessionId);
-  }
+  emit('archiveSession', props.sessionId);
 }
 </script>
 

--- a/apps/kimi-web/src/components/dialogs/ConfirmDialog.vue
+++ b/apps/kimi-web/src/components/dialogs/ConfirmDialog.vue
@@ -3,17 +3,10 @@
      Dialog (height auto, right-aligned footer). The single confirmation surface
      for user actions — driven app-wide by useConfirmDialog(). -->
 <script setup lang="ts">
-import { onBeforeUnmount, ref } from 'vue';
+import { onBeforeUnmount } from 'vue';
 import { useI18n } from 'vue-i18n';
 import Dialog from '../ui/Dialog.vue';
 import Button from '../ui/Button.vue';
-
-const confirmButtonRef = ref<InstanceType<typeof Button> | null>(null);
-
-function confirmButtonElement(): HTMLElement | null {
-  const el = confirmButtonRef.value?.$el;
-  return el instanceof HTMLElement ? el : null;
-}
 
 const props = withDefaults(defineProps<{
   open: boolean;
@@ -37,6 +30,10 @@ const emit = defineEmits<{
 const { t } = useI18n();
 
 function onCancel(): void {
+  // While the confirm action runs (loading), every cancel path — Cancel
+  // button, header close, Esc, overlay click — is inert so the dialog can't
+  // be dismissed out from under the in-flight work.
+  if (props.loading) return;
   emit('update:open', false);
   emit('cancel');
 }
@@ -70,11 +67,17 @@ onBeforeUnmount(() => {
 </script>
 
 <template>
+  <!-- initial-focus uses a selector, not the Button component's $el: Button
+       has a template-root comment, so in dev builds it renders as a fragment
+       whose $el is a text node (unfocusable) — focus would fall back to the
+       header close button and Enter would cancel instead of confirm. -->
   <Dialog
     :open="open"
     :title="title"
     height="auto"
-    :initial-focus="confirmButtonElement"
+    initial-focus=".confirm-dialog__confirm"
+    :close-on-esc="!loading"
+    :close-on-overlay="!loading"
     @update:open="emit('update:open', $event)"
     @close="onCancel"
   >
@@ -84,7 +87,7 @@ onBeforeUnmount(() => {
         {{ cancelLabel ?? t('common.cancel') }}
       </Button>
       <Button
-        ref="confirmButtonRef"
+        class="confirm-dialog__confirm"
         :variant="variant"
         :loading="loading"
         @click="emit('confirm')"

--- a/apps/kimi-web/src/components/dialogs/ConfirmDialogHost.vue
+++ b/apps/kimi-web/src/components/dialogs/ConfirmDialogHost.vue
@@ -5,7 +5,13 @@
 import { useConfirmDialog } from '../../composables/useConfirmDialog';
 import ConfirmDialog from './ConfirmDialog.vue';
 
-const { current, settle } = useConfirmDialog();
+const { current, busy, settle, runAction } = useConfirmDialog();
+
+// runAction never rejects (a failing action rejects the confirm() promise
+// instead), so the floating promise is safe to drop here.
+function onConfirm(): void {
+  void runAction();
+}
 </script>
 
 <template>
@@ -16,7 +22,8 @@ const { current, settle } = useConfirmDialog();
     :confirm-label="current?.confirmLabel"
     :cancel-label="current?.cancelLabel"
     :variant="current?.variant"
-    @confirm="settle(true)"
+    :loading="busy"
+    @confirm="onConfirm"
     @cancel="settle(false)"
   />
 </template>

--- a/apps/kimi-web/src/components/mobile/MobileSwitcherSheet.vue
+++ b/apps/kimi-web/src/components/mobile/MobileSwitcherSheet.vue
@@ -9,7 +9,6 @@ import { ref } from 'vue';
 import { useI18n } from 'vue-i18n';
 import type { Session, WorkspaceGroup, WorkspaceView } from '../../types';
 import { copyTextToClipboard } from '../../lib/clipboard';
-import { useConfirmDialog } from '../../composables/useConfirmDialog';
 import BottomSheet from '../dialogs/BottomSheet.vue';
 import IconButton from '../ui/IconButton.vue';
 import Icon from '../ui/Icon.vue';
@@ -18,7 +17,6 @@ import MenuItem from '../ui/MenuItem.vue';
 import Tooltip from '../ui/Tooltip.vue';
 
 const { t } = useI18n();
-const { confirm } = useConfirmDialog();
 
 const props = withDefaults(
   defineProps<{
@@ -45,7 +43,7 @@ const emit = defineEmits<{
   addWorkspace: [];
   rename: [id: string, title: string];
   archive: [id: string];
-  /** NOTE: needs `@delete-workspace="client.deleteWorkspace($event)"` wiring in App.vue. */
+  /** NOTE: App.vue wires this to confirmDeleteWorkspace (modal confirm + async delete). */
   deleteWorkspace: [workspaceId: string];
   loadMore: [workspaceId: string];
 }>();
@@ -152,23 +150,16 @@ function onRename(s: Session): void {
   const title = next?.trim();
   if (title) emit('rename', s.id, title);
 }
-async function onArchive(id: string): Promise<void> {
+function onArchive(id: string): void {
   menuFor.value = null;
-  if (
-    await confirm({
-      title: t('sidebar.archive'),
-      message: t('sidebar.archiveConfirm'),
-      variant: 'danger',
-    })
-  ) {
-    emit('archive', id);
-  }
+  // The modal confirm + async archive live in App.vue (confirmArchiveSession).
+  emit('archive', id);
 }
 
 // ---------------------------------------------------------------------------
 // Per-workspace "…" menu: copy path + delete workspace. Copy path is handled
-// locally, like the desktop sidebar; delete is confirmed via modal then
-// emitted to the parent.
+// locally, like the desktop sidebar; delete is emitted to the parent (App.vue
+// owns the modal confirm + async delete).
 // ---------------------------------------------------------------------------
 const wsMenuFor = ref<string | null>(null);
 
@@ -180,17 +171,9 @@ function onCopyWsPath(ws: WorkspaceView): void {
   void copyTextToClipboard(ws.root);
   wsMenuFor.value = null;
 }
-async function onDeleteWorkspace(ws: WorkspaceView): Promise<void> {
+function onDeleteWorkspace(ws: WorkspaceView): void {
   wsMenuFor.value = null;
-  if (
-    await confirm({
-      title: t('sidebar.removeWorkspace'),
-      message: t('workspace.removeWorkspaceConfirm', { name: ws.name }),
-      variant: 'danger',
-    })
-  ) {
-    emit('deleteWorkspace', ws.id);
-  }
+  emit('deleteWorkspace', ws.id);
 }
 </script>
 

--- a/apps/kimi-web/src/components/settings/ProviderManager.vue
+++ b/apps/kimi-web/src/components/settings/ProviderManager.vue
@@ -14,10 +14,8 @@ import Input from '../ui/Input.vue';
 import Select from '../ui/Select.vue';
 import Icon from '../ui/Icon.vue';
 import Tooltip from '../ui/Tooltip.vue';
-import { useConfirmDialog } from '../../composables/useConfirmDialog';
 
 const { t } = useI18n();
-const { confirm } = useConfirmDialog();
 
 const dialogRef = ref<HTMLElement | null>(null);
 // Move focus into the dialog on open; restore it to the opener on close.
@@ -43,17 +41,10 @@ const emit = defineEmits<{
 // Delete confirmation
 // -------------------------------------------------------------------------
 
-// Delete confirmation — modal, consistent with remove-workspace.
-async function onDeleteProvider(id: string): Promise<void> {
-  if (
-    await confirm({
-      title: t('providers.delete'),
-      message: t('providers.confirmDelete'),
-      variant: 'danger',
-    })
-  ) {
-    emit('delete', id);
-  }
+// Delete — the modal confirm and the async delete live in App.vue
+// (confirmDeleteProvider); the manager only emits the intent.
+function onDeleteProvider(id: string): void {
+  emit('delete', id);
 }
 
 // -------------------------------------------------------------------------

--- a/apps/kimi-web/src/composables/useConfirmDialog.ts
+++ b/apps/kimi-web/src/composables/useConfirmDialog.ts
@@ -60,6 +60,10 @@ async function runAction(): Promise<void> {
 }
 
 function confirm(options: ConfirmOptions): Promise<boolean> {
+  // A confirmed action is still in flight: a second dialog can't supersede the
+  // busy one (it would inherit the global busy state and open inert), so the
+  // new request resolves unconfirmed instead.
+  if (busy.value) return Promise.resolve(false);
   // If a confirm is already open, treat it as cancelled before showing the new
   // one so its caller isn't left hanging.
   if (current.value) settle(false);

--- a/apps/kimi-web/src/composables/useConfirmDialog.ts
+++ b/apps/kimi-web/src/composables/useConfirmDialog.ts
@@ -13,34 +13,67 @@ export type ConfirmOptions = {
   confirmLabel?: string;
   cancelLabel?: string;
   variant?: ConfirmVariant;
+  /** Async work started when the user confirms. While it runs, the dialog
+   *  stays open with the confirm button in a loading state (cancel / Esc /
+   *  overlay-click are suppressed), then closes and resolves true. A
+   *  rejection closes the dialog and rethrows to the confirm() caller. */
+  action?: () => unknown;
 };
 
 type ConfirmRequest = ConfirmOptions & {
   resolve: (ok: boolean) => void;
+  reject: (err: unknown) => void;
 };
 
 const current = ref<ConfirmRequest | null>(null);
+/** True while a confirmed request's `action` is still running. */
+const busy = ref(false);
 
 function settle(ok: boolean): void {
   const req = current.value;
-  if (!req) return;
+  if (!req || busy.value) return;
   current.value = null;
   req.resolve(ok);
+}
+
+/** Invoked by the host when the user confirms. Runs the request's `action`
+ *  (keeping the dialog open with a loading state until it settles), or just
+ *  resolves true when the request has none. Never rejects. */
+async function runAction(): Promise<void> {
+  const req = current.value;
+  if (!req || busy.value) return;
+  if (!req.action) {
+    settle(true);
+    return;
+  }
+  busy.value = true;
+  try {
+    await req.action();
+    if (current.value === req) current.value = null;
+    req.resolve(true);
+  } catch (error) {
+    if (current.value === req) current.value = null;
+    req.reject(error);
+  } finally {
+    busy.value = false;
+  }
 }
 
 function confirm(options: ConfirmOptions): Promise<boolean> {
   // If a confirm is already open, treat it as cancelled before showing the new
   // one so its caller isn't left hanging.
   if (current.value) settle(false);
-  return new Promise<boolean>((resolve) => {
-    current.value = { ...options, resolve };
+  return new Promise<boolean>((resolve, reject) => {
+    current.value = { ...options, resolve, reject };
   });
 }
 
 export function useConfirmDialog(): {
   current: typeof current;
+  busy: typeof busy;
   confirm: typeof confirm;
   settle: typeof settle;
+  runAction: typeof runAction;
 } {
-  return { current, confirm, settle };
+  return { current, busy, confirm, settle, runAction };
 }

--- a/apps/kimi-web/test/confirm-dialog.test.ts
+++ b/apps/kimi-web/test/confirm-dialog.test.ts
@@ -115,4 +115,27 @@ describe('useConfirmDialog', () => {
     await runAction();
     expect(busy.value).toBe(false);
   });
+
+  it('resolves a new confirm false instead of superseding while an action runs', async () => {
+    const action = deferred();
+    const first = confirm({
+      title: 'First',
+      action: () => action.promise,
+    });
+    void runAction();
+    expect(busy.value).toBe(true);
+
+    // The second confirm can't replace the busy dialog (it would open inert
+    // under the global busy state) — it resolves unconfirmed immediately and
+    // leaves the in-flight request untouched.
+    const second = confirm({ title: 'Second' });
+    await expect(second).resolves.toBe(false);
+    expect(current.value?.title).toBe('First');
+    expect(busy.value).toBe(true);
+
+    action.resolve();
+    await expect(first).resolves.toBe(true);
+    expect(busy.value).toBe(false);
+    expect(current.value).toBeNull();
+  });
 });

--- a/apps/kimi-web/test/confirm-dialog.test.ts
+++ b/apps/kimi-web/test/confirm-dialog.test.ts
@@ -1,0 +1,118 @@
+// apps/kimi-web/test/confirm-dialog.test.ts
+// Logic tests for the useConfirmDialog singleton: boolean confirm/cancel,
+// supersede, and the async `action` flow (busy state, close-on-settle,
+// rejection propagation).
+import { beforeEach, describe, expect, it } from 'vitest';
+import { useConfirmDialog } from '../src/composables/useConfirmDialog';
+
+function deferred<T = void>(): {
+  promise: Promise<T>;
+  resolve: (value: T | PromiseLike<T>) => void;
+  reject: (err?: unknown) => void;
+} {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (err?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+describe('useConfirmDialog', () => {
+  const { current, busy, confirm, settle, runAction } = useConfirmDialog();
+
+  beforeEach(() => {
+    // Drop any pending request so tests don't leak into each other.
+    settle(false);
+  });
+
+  it('resolves true on confirm without an action', async () => {
+    const p = confirm({ title: 'Archive?' });
+    expect(current.value?.title).toBe('Archive?');
+    await runAction();
+    expect(current.value).toBeNull();
+    await expect(p).resolves.toBe(true);
+  });
+
+  it('resolves false on cancel', async () => {
+    const p = confirm({ title: 'Archive?' });
+    settle(false);
+    expect(current.value).toBeNull();
+    await expect(p).resolves.toBe(false);
+  });
+
+  it('cancels a pending request when a new confirm supersedes it', async () => {
+    const first = confirm({ title: 'First' });
+    const second = confirm({ title: 'Second' });
+    await expect(first).resolves.toBe(false);
+    expect(current.value?.title).toBe('Second');
+    settle(true);
+    await expect(second).resolves.toBe(true);
+  });
+
+  it('keeps the dialog open (busy) while the action runs, then closes', async () => {
+    const action = deferred();
+    let ran = false;
+    const p = confirm({
+      title: 'Archive?',
+      action: async () => {
+        ran = true;
+        await action.promise;
+      },
+    });
+
+    void runAction();
+    expect(ran).toBe(true);
+    expect(busy.value).toBe(true);
+    // Still open while the action is in flight.
+    expect(current.value).not.toBeNull();
+    // Cancel is inert while busy.
+    settle(false);
+    expect(current.value).not.toBeNull();
+
+    action.resolve();
+    await p;
+    expect(busy.value).toBe(false);
+    expect(current.value).toBeNull();
+    await expect(p).resolves.toBe(true);
+  });
+
+  it('closes and rejects the confirm() promise when the action fails', async () => {
+    const failure = new Error('boom');
+    const p = confirm({
+      title: 'Archive?',
+      action: () => Promise.reject(failure),
+    });
+    // Attach the rejection expectation before running so no unhandled
+    // rejection can escape between ticks.
+    const assertion = expect(p).rejects.toBe(failure);
+    await runAction();
+    expect(busy.value).toBe(false);
+    expect(current.value).toBeNull();
+    await assertion;
+  });
+
+  it('ignores a duplicate confirm while an action is running', async () => {
+    const action = deferred();
+    let runs = 0;
+    const p = confirm({
+      title: 'Archive?',
+      action: async () => {
+        runs += 1;
+        await action.promise;
+      },
+    });
+    void runAction();
+    await runAction(); // no-op: busy
+    expect(runs).toBe(1);
+    action.resolve();
+    await p;
+  });
+
+  it('runAction without a pending request is a no-op', async () => {
+    expect(current.value).toBeNull();
+    await runAction();
+    expect(busy.value).toBe(false);
+  });
+});


### PR DESCRIPTION
## Related Issue

No linked issue — the problem is described below.

## Problem

In the web UI, modal confirmation dialogs (e.g. archive session) had two issues:

1. Pressing Enter did not confirm the dialog. The initial focus was resolved from the Button component's `$el`, but Button has a template-root comment, so in dev builds it renders as a fragment whose `$el` is a text node. Focus fell back to the header close button, so Enter cancelled the dialog instead of confirming it.
2. The confirmed action (archive session, remove workspace, delete provider) ran only after the dialog closed, with no in-dialog feedback — the dialog should stay open with a loading state until the async work settles.

## What changed

- The confirm dialog resolves its initial focus with a CSS selector on the confirm button instead of the component `$el`, so Enter confirms in both dev and production builds.
- `useConfirmDialog` now accepts an async `action`: while it runs, the dialog stays open with the confirm button loading, and cancel / Esc / overlay-click are suppressed. A rejection closes the dialog and rethrows to the caller.
- The archive-session / remove-workspace / delete-provider confirmations moved from the menu components (SessionRow, ChatHeader, Sidebar, MobileSwitcherSheet, ProviderManager) into App.vue, so the dialog can await the actual client call; those components now only emit the intent. Undo / goal / swarm confirmations keep the simpler boolean flow.
- Added logic tests for the confirm flow (busy state, supersede, rejection, re-entry).

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.