### PR TITLE
chore: downgrade unreleased changesets to patch

### DIFF
--- a/.changeset/check-kimi-code-docs-skill.md
+++ b/.changeset/check-kimi-code-docs-skill.md
@@ -1,5 +1,5 @@
 ---
-"@moonshot-ai/kimi-code": minor
+"@moonshot-ai/kimi-code": patch
 ---
 
 Add a builtin `check-kimi-code-docs` skill that answers Kimi Code product questions (CLI usage, configuration, membership, error codes) against the official documentation with source links. It triggers automatically on product questions, or run `/check-kimi-code-docs`.

--- a/.changeset/print-mode-steer-defaults.md
+++ b/.changeset/print-mode-steer-defaults.md
@@ -1,5 +1,5 @@
 ---
-"@moonshot-ai/kimi-code": minor
+"@moonshot-ai/kimi-code": patch
 ---
 
 In print mode (`kimi -p`), keep the run alive by default while background tasks are pending and feed each completion back to the main agent as a new turn, with an effectively unbounded wait ceiling and turn cap and a 72-hour subagent timeout. Set `print_background_mode = "exit"` (or `"drain"`) to restore the previous exit-after-one-turn behavior.

--- a/.changeset/print-no-background-timeouts.md
+++ b/.changeset/print-no-background-timeouts.md
@@ -1,5 +1,5 @@
 ---
-"@moonshot-ai/kimi-code": minor
+"@moonshot-ai/kimi-code": patch
 ---
 
 In print mode (`kimi -p`), background Bash tasks and subagents no longer have a timeout by default — they run until they finish or the model stops them, and a foreground Bash command that times out is moved to the background without a new deadline. Interactive defaults are unchanged; tune per mode with `bash_task_timeout_s` under `[background]` or `timeout_ms` under `[subagent]` (`0` = no timeout).


### PR DESCRIPTION
## Related Issue

No linked issue — this is a release-metadata cleanup.

## Problem

Three unreleased changesets were marked as `minor` bumps for `@moonshot-ai/kimi-code`, but the upcoming release should treat these changes as patch-level so the version bump stays minimal.

## What changed

Downgraded the bump level from `minor` to `patch` in three changeset files:

- `.changeset/print-no-background-timeouts.md`
- `.changeset/check-kimi-code-docs-skill.md`
- `.changeset/print-mode-steer-defaults.md`

No code or behavior changes — only changeset metadata. All other unreleased changesets were already `patch`.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [ ] I have added tests that prove my feature works. (N/A — changeset metadata only)
- [x] Ran `gen-changesets` skill, or this PR needs no changeset. (This PR only edits existing changesets)
- [x] Ran `gen-docs` skill, or this PR needs no doc update. (No user-facing behavior change)