### PR TITLE
fix(kap-server): close auth bypass via percent-encoded API paths

### DIFF
--- a/.changeset/fix-kap-server-auth-encoded-path.md
+++ b/.changeset/fix-kap-server-auth-encoded-path.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Fix the web server bearer-token check being bypassed by percent-encoded API paths (e.g. `/%61pi/v1/…`), which allowed unauthenticated access to every API route.

--- a/.changeset/fix-sessionfs-symlink-escape.md
+++ b/.changeset/fix-sessionfs-symlink-escape.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Fix the session filesystem API following symlinks that point outside the workspace, which allowed reading, listing, creating, and downloading host files beyond the session directory through a planted symlink.

--- a/.changeset/fix-symlinked-workspace-root.md
+++ b/.changeset/fix-symlinked-workspace-root.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Fix sessions failing to be created when the workspace directory is given through a symlink, which the v2 engine rejected as "not a directory".

--- a/packages/agent-core-v2/src/app/workspaceRegistry/workspaceRegistryService.ts
+++ b/packages/agent-core-v2/src/app/workspaceRegistry/workspaceRegistryService.ts
@@ -31,9 +31,12 @@
  * `createOrTouch` is the single choke point every workspace/session creation
  * funnels through, so it owns the root-existence contract: the root must be
  * an existing directory on the host filesystem, otherwise it throws
- * `fs.path_not_found` (mirrors v1's `WorkspaceRootNotFoundError`). The rebuild
- * and merge paths bypass the check on purpose — they catalog where sessions
- * *were*, not where new ones may open. Bound at App scope.
+ * `fs.path_not_found` (mirrors v1's `WorkspaceRootNotFoundError`). The
+ * directory probe follows symlinks (`IHostFileSystem.stat` is lstat-based, so
+ * a symlink-form root is re-checked through `realpath`), while the workspace
+ * identity stays lexical — v1 deliberately never realpaths the root either.
+ * The rebuild and merge paths bypass the check on purpose — they catalog
+ * where sessions *were*, not where new ones may open. Bound at App scope.
  */
 
 import { basename, isAbsolute } from 'pathe';
@@ -100,6 +103,13 @@ export class WorkspaceRegistryService implements IWorkspaceRegistry {
           throw new Error2(ErrorCodes.FS_PATH_NOT_FOUND, `workspace root ${root} does not exist`);
         }
         throw error;
+      }
+      if (!stat.isDirectory) {
+        try {
+          stat = await this.hostFs.stat(await this.hostFs.realpath(root));
+        } catch {
+          // Fall through to the not-a-directory error below.
+        }
       }
       if (!stat.isDirectory) {
         throw new Error2(ErrorCodes.FS_PATH_NOT_FOUND, `workspace root ${root} is not a directory`);

--- a/packages/agent-core-v2/src/os/backends/node-local/hostFsService.ts
+++ b/packages/agent-core-v2/src/os/backends/node-local/hostFsService.ts
@@ -5,7 +5,17 @@
  * Bound at App scope.
  */
 
-import { appendFile, lstat, open, readFile, readdir, mkdir, rm, writeFile } from 'node:fs/promises';
+import {
+  appendFile,
+  lstat,
+  open,
+  readFile,
+  readdir,
+  mkdir,
+  realpath as nodeRealpath,
+  rm,
+  writeFile,
+} from 'node:fs/promises';
 
 import { InstantiationType } from '#/_base/di/extensions';
 import { LifecycleScope, registerScopedService } from '#/_base/di/scope';
@@ -220,6 +230,14 @@ export class HostFileSystem implements IHostFileSystem {
       await rm(path, { recursive: true, force: true });
     } catch (error) {
       throw toHostFsError(error, { path, op: 'remove' });
+    }
+  }
+
+  async realpath(path: string): Promise<string> {
+    try {
+      return await nodeRealpath(path);
+    } catch (error) {
+      throw toHostFsError(error, { path, op: 'realpath' });
     }
   }
 }

--- a/packages/agent-core-v2/src/os/interface/hostFileSystem.ts
+++ b/packages/agent-core-v2/src/os/interface/hostFileSystem.ts
@@ -3,8 +3,10 @@
  *
  * Defines the `IHostFileSystem` used by the program side (persistence, skill
  * loading, workspace registry) and the os file tools to read and write files on
- * the real local disk, plus the stat/entry models. App-scoped — one shared
- * instance.
+ * the real local disk, plus the stat/entry models. `realpath` canonicalizes a
+ * path by resolving every symlink component (Node `fs.realpath` semantics) and
+ * rejects with `os.fs.not_found` for a missing path; consumers use it to make
+ * lexical path confinement symlink-aware. App-scoped — one shared instance.
  */
 
 import { createDecorator, type ServiceIdentifier } from '#/_base/di/instantiation';
@@ -46,6 +48,7 @@ export interface IHostFileSystem {
   readdir(path: string): Promise<readonly HostDirEntry[]>;
   mkdir(path: string, options?: { readonly recursive?: boolean }): Promise<void>;
   remove(path: string): Promise<void>;
+  realpath(path: string): Promise<string>;
 }
 
 export const IHostFileSystem: ServiceIdentifier<IHostFileSystem> =

--- a/packages/agent-core-v2/src/session/sessionFs/fsService.ts
+++ b/packages/agent-core-v2/src/session/sessionFs/fsService.ts
@@ -9,11 +9,13 @@
  * `IGitService`; this service only confines paths and computes repo-relative
  * paths before calling it.
  *
- * Path confinement is lexical (`ISessionWorkspaceContext.isWithin`); it does not
- * follow symlinks, matching the rest of v2 (`_base/tools/policies/path-access.ts`).
+ * Path confinement applies the lexical `ISessionWorkspaceContext.isWithin`
+ * check first, then re-verifies the candidate through `IHostFileSystem.realpath`
+ * (resolving the longest existing prefix, so not-yet-created paths still work):
+ * a symlink inside the workspace must not steer fs actions to files outside it.
  */
 
-import { basename, extname, isAbsolute, join, relative, sep } from 'node:path';
+import { basename, dirname, extname, isAbsolute, join, relative, sep } from 'node:path';
 
 import {
   ErrorCode,
@@ -46,7 +48,7 @@ import ignore, { type Ignore } from 'ignore';
 
 import { InstantiationType } from '#/_base/di/extensions';
 import { LifecycleScope, registerScopedService } from '#/_base/di/scope';
-import { ErrorCodes, Error2, unwrapErrorCause } from '#/errors';
+import { ErrorCodes, Error2, isError2, unwrapErrorCause } from '#/errors';
 import { IGitService } from '#/app/git/git';
 import { ITelemetryService } from '#/app/telemetry/telemetry';
 import { IHostFileSystem, type HostDirEntry, type HostFileStat } from '#/os/interface/hostFileSystem';
@@ -97,7 +99,7 @@ export class SessionFsService implements ISessionFsService {
   }
 
   async list(req: FsListRequest): Promise<FsListResponse> {
-    const abs = this.resolveWithin(req.path);
+    const abs = await this.resolveWithin(req.path);
     const rel = this.toRel(abs);
 
     let topStat: HostFileStat;
@@ -189,7 +191,7 @@ export class SessionFsService implements ISessionFsService {
   }
 
   async read(req: FsReadRequest): Promise<FsReadResponse> {
-    const abs = this.resolveWithin(req.path);
+    const abs = await this.resolveWithin(req.path);
     const rel = this.toRel(abs);
 
     let st: HostFileStat;
@@ -289,7 +291,7 @@ export class SessionFsService implements ISessionFsService {
   }
 
   async stat(req: FsStatRequest): Promise<FsStatResponse> {
-    const abs = this.resolveWithin(req.path);
+    const abs = await this.resolveWithin(req.path);
     const rel = this.toRel(abs);
     let st: HostFileStat;
     try {
@@ -302,10 +304,12 @@ export class SessionFsService implements ISessionFsService {
   }
 
   async statMany(req: FsStatManyRequest): Promise<FsStatManyResponse> {
-    const resolved = req.paths.map((p) => {
-      const abs = this.resolveWithin(p);
-      return { raw: p, rel: this.toRel(abs), abs };
-    });
+    const resolved = await Promise.all(
+      req.paths.map(async (p) => {
+        const abs = await this.resolveWithin(p);
+        return { raw: p, rel: this.toRel(abs), abs };
+      }),
+    );
 
     const entries: Record<string, FsEntry | null> = {};
     await Promise.all(
@@ -323,7 +327,7 @@ export class SessionFsService implements ISessionFsService {
   }
 
   async mkdir(req: FsMkdirRequest): Promise<FsMkdirResponse> {
-    const abs = this.resolveWithin(req.path);
+    const abs = await this.resolveWithin(req.path);
     const rel = this.toRel(abs);
     try {
       await this.hostFs.mkdir(abs, { recursive: req.recursive });
@@ -346,7 +350,7 @@ export class SessionFsService implements ISessionFsService {
   }
 
   async resolvePath(relPath: string): Promise<FsPathResolved> {
-    const abs = this.resolveWithin(relPath);
+    const abs = await this.resolveWithin(relPath);
     const rel = this.toRel(abs);
     let st: HostFileStat;
     try {
@@ -358,7 +362,7 @@ export class SessionFsService implements ISessionFsService {
   }
 
   async resolveDownload(relPath: string): Promise<FsDownloadResolved> {
-    const abs = this.resolveWithin(relPath);
+    const abs = await this.resolveWithin(relPath);
     const rel = this.toRel(abs);
     let st: HostFileStat;
     try {
@@ -442,7 +446,7 @@ export class SessionFsService implements ISessionFsService {
     if (req.paths !== undefined && req.paths.length > 0) {
       filter = new Set();
       for (const p of req.paths) {
-        filter.add(this.toRel(this.resolveWithin(p)));
+        filter.add(this.toRel(await this.resolveWithin(p)));
       }
     }
 
@@ -451,7 +455,7 @@ export class SessionFsService implements ISessionFsService {
 
   async diff(req: FsDiffRequest): Promise<FsDiffResponse> {
     const cwd = this.workspace.workDir;
-    const abs = this.resolveWithin(req.path);
+    const abs = await this.resolveWithin(req.path);
     return this.git.diff(cwd, this.toRel(abs), abs);
   }
 
@@ -669,7 +673,43 @@ export class SessionFsService implements ISessionFsService {
     return this.rgResolution;
   }
 
-  private resolveWithin(inputPath: string): string {
+  private realRootsCache: { readonly key: string; readonly roots: readonly string[] } | undefined;
+
+  private async realRoots(): Promise<readonly string[]> {
+    const dirs = [this.workspace.workDir, ...this.workspace.additionalDirs];
+    const key = dirs.join('\n');
+    if (this.realRootsCache?.key === key) return this.realRootsCache.roots;
+    const roots: string[] = [];
+    for (const dir of dirs) {
+      try {
+        roots.push(await this.hostFs.realpath(dir));
+      } catch {
+        roots.push(dir);
+      }
+    }
+    this.realRootsCache = { key, roots };
+    return roots;
+  }
+
+  private async realpathExistingPrefix(abs: string): Promise<string> {
+    const tail: string[] = [];
+    let current = abs;
+    for (let i = 0; i < 256; i++) {
+      try {
+        const real = await this.hostFs.realpath(current);
+        return tail.length === 0 ? real : join(real, ...tail.reverse());
+      } catch (err) {
+        if (!isMissingPathError(err)) throw err;
+        const parent = dirname(current);
+        if (parent === current) return abs;
+        tail.push(basename(current));
+        current = parent;
+      }
+    }
+    return abs;
+  }
+
+  private async resolveWithin(inputPath: string): Promise<string> {
     if (inputPath === '' || inputPath === '/') {
       throw new Error2(ErrorCodes.FS_PATH_ESCAPES, `path "${inputPath}" rejected (empty)`, {
         details: { path: inputPath, reason: 'empty' },
@@ -691,6 +731,15 @@ export class SessionFsService implements ISessionFsService {
       throw new Error2(ErrorCodes.FS_PATH_ESCAPES, `path "${inputPath}" escapes workspace`, {
         details: { path: inputPath, reason: 'resolved_outside' },
       });
+    }
+    const resolved = await this.realpathExistingPrefix(abs);
+    const roots = await this.realRoots();
+    if (!roots.some((root) => isInsideOrEqual(resolved, root))) {
+      throw new Error2(
+        ErrorCodes.FS_PATH_ESCAPES,
+        `path "${inputPath}" escapes workspace through a symlink`,
+        { details: { path: inputPath, reason: 'symlink_outside' } },
+      );
     }
     return abs;
   }
@@ -903,6 +952,24 @@ function errnoCode(err: unknown): string | undefined {
     return typeof c === 'string' ? c : undefined;
   }
   return undefined;
+}
+
+function isMissingPathError(err: unknown): boolean {
+  if (isError2(err)) {
+    return (
+      err.code === ErrorCodes.OS_FS_NOT_FOUND || err.code === ErrorCodes.OS_FS_NOT_DIRECTORY
+    );
+  }
+  const code = errnoCode(err);
+  return code === 'ENOENT' || code === 'ENOTDIR';
+}
+
+function isInsideOrEqual(child: string, parent: string): boolean {
+  const rel = relative(parent, child);
+  if (rel === '') return true;
+  if (rel.startsWith('..')) return false;
+  if (isAbsolute(rel)) return false;
+  return true;
 }
 
 function mapFsError(err: unknown, inputPath: string): Error {

--- a/packages/agent-core-v2/test/app/workspaceRegistry/workspaceRegistryService.test.ts
+++ b/packages/agent-core-v2/test/app/workspaceRegistry/workspaceRegistryService.test.ts
@@ -382,6 +382,16 @@ describe('WorkspaceRegistryService (file-backed)', () => {
     expect(await build().list()).toEqual([]);
   });
 
+  it('accepts createOrTouch when the root is given through a symlink', async () => {
+    const real = join(homeDir, 'real-root');
+    await fsp.mkdir(real, { recursive: true });
+    const link = join(homeDir, 'link-root');
+    await fsp.symlink(real, link, 'dir');
+    const ws = await build().createOrTouch(link);
+    expect(ws.root).toBe(link);
+    expect(ws.id).toBe(encodeWorkDirKey(link));
+  });
+
   it('rejects createOrTouch when a parent of the root is not a directory', async () => {
     const file = join(homeDir, 'a-file.txt');
     await fsp.writeFile(file, 'hi', 'utf8');

--- a/packages/agent-core-v2/test/os/backends/node-local/tools/grep.test.ts
+++ b/packages/agent-core-v2/test/os/backends/node-local/tools/grep.test.ts
@@ -142,6 +142,7 @@ function createTestFs(kaos: FakeKaos): IHostFileSystem {
     readdir: () => notImplemented('readdir'),
     mkdir: () => notImplemented('mkdir'),
     remove: () => notImplemented('remove'),
+    realpath: () => notImplemented('realpath'),
   };
 }
 

--- a/packages/agent-core-v2/test/session/sessionFs/fsService.test.ts
+++ b/packages/agent-core-v2/test/session/sessionFs/fsService.test.ts
@@ -39,7 +39,11 @@ function stubWorkspace(): ISessionWorkspaceContext {
   };
 }
 
-function fakeFs(files: Record<string, string>, symlinks: readonly string[] = []): IHostFileSystem {
+function fakeFs(
+  files: Record<string, string>,
+  symlinks: readonly string[] = [],
+  symlinkTargets: Record<string, string> = {},
+): IHostFileSystem {
   const fileMap = new Map<string, string>();
   const dirSet = new Set<string>([WORK_DIR]);
   const addAncestors = (rel: string): void => {
@@ -55,6 +59,13 @@ function fakeFs(files: Record<string, string>, symlinks: readonly string[] = [])
   const symlinkSet = new Set<string>();
   for (const rel of symlinks) {
     symlinkSet.add(join(WORK_DIR, rel));
+    addAncestors(rel);
+  }
+  const symlinkTargetMap = new Map<string, string>();
+  for (const [rel, target] of Object.entries(symlinkTargets)) {
+    const abs = join(WORK_DIR, rel);
+    symlinkTargetMap.set(abs, target);
+    symlinkSet.add(abs);
     addAncestors(rel);
   }
   const isDir = (p: string): boolean => p === WORK_DIR || dirSet.has(p);
@@ -162,6 +173,29 @@ function fakeFs(files: Record<string, string>, symlinks: readonly string[] = [])
       dirSet.add(p);
     },
     remove: async () => {},
+    realpath: async (p) => {
+      let current = p;
+      for (let i = 0; i < 40; i++) {
+        let longest: string | undefined;
+        for (const linkPath of symlinkTargetMap.keys()) {
+          if (
+            (current === linkPath || current.startsWith(`${linkPath}/`)) &&
+            (longest === undefined || linkPath.length > longest.length)
+          ) {
+            longest = linkPath;
+          }
+        }
+        if (longest === undefined) {
+          if (current === p) {
+            if (p === WORK_DIR || fileMap.has(p) || isDir(p) || symlinkSet.has(p)) return p;
+            throw enoent(p);
+          }
+          return current;
+        }
+        current = symlinkTargetMap.get(longest)! + current.slice(longest.length);
+      }
+      return current;
+    },
   };
 }
 
@@ -291,11 +325,12 @@ function makeSession(
   git: IGitService = defaultGitStub(),
   symlinks: readonly string[] = [],
   runner?: ISessionProcessRunner,
+  symlinkTargets: Record<string, string> = {},
 ): ISessionFsService {
   host = createScopedTestHost();
   const session = host.child(LifecycleScope.Session, 's1', [
     stubPair(ISessionWorkspaceContext, stubWorkspace()),
-    stubPair(IHostFileSystem, fakeFs(files, symlinks)),
+    stubPair(IHostFileSystem, fakeFs(files, symlinks, symlinkTargets)),
     stubPair(ISessionProcessRunner, runner ?? fakeRunner(handler)),
     stubPair(ITelemetryService, telemetryStub(events)),
     stubPair(IGitService, git),
@@ -709,5 +744,86 @@ describe('SessionFsService.resolveDownload', () => {
   it('throws fs.is_directory for a directory', async () => {
     const fs = makeSession({ 'src/a.ts': '' }, emptyHandler);
     await expect(fs.resolveDownload('src')).rejects.toMatchObject({ code: 'fs.is_directory' });
+  });
+});
+
+describe('SessionFsService symlink confinement', () => {
+  const escapeTargets = { docs: '/outside' };
+
+  function escapeSession(): ISessionFsService {
+    return makeSession(
+      { 'src/a.ts': '' },
+      emptyHandler,
+      [],
+      defaultGitStub(),
+      [],
+      undefined,
+      escapeTargets,
+    );
+  }
+
+  it('rejects reads that escape through a symlinked directory', async () => {
+    const fs = escapeSession();
+    await expect(
+      fs.read({ path: 'docs/secret.txt', offset: 0, length: 1024, encoding: 'utf-8' }),
+    ).rejects.toMatchObject({ code: 'fs.path_escapes' });
+  });
+
+  it('rejects list through a symlinked directory', async () => {
+    const fs = escapeSession();
+    await expect(
+      fs.list({
+        path: 'docs',
+        depth: 1,
+        limit: 200,
+        show_hidden: false,
+        follow_gitignore: false,
+        sort: 'name_asc',
+        include_git_status: false,
+      }),
+    ).rejects.toMatchObject({ code: 'fs.path_escapes' });
+  });
+
+  it('rejects stat, mkdir, resolvePath and resolveDownload through a symlinked directory', async () => {
+    const fs = escapeSession();
+    await expect(fs.stat({ path: 'docs/secret.txt' })).rejects.toMatchObject({
+      code: 'fs.path_escapes',
+    });
+    await expect(fs.mkdir({ path: 'docs/newdir', recursive: true })).rejects.toMatchObject({
+      code: 'fs.path_escapes',
+    });
+    await expect(fs.resolvePath('docs/secret.txt')).rejects.toMatchObject({
+      code: 'fs.path_escapes',
+    });
+    await expect(fs.resolveDownload('docs/secret.txt')).rejects.toMatchObject({
+      code: 'fs.path_escapes',
+    });
+  });
+
+  it('rejects statMany when any path escapes through a symlinked directory', async () => {
+    const fs = escapeSession();
+    await expect(fs.statMany({ paths: ['docs/secret.txt'] })).rejects.toMatchObject({
+      code: 'fs.path_escapes',
+    });
+  });
+
+  it('still allows a symlink whose target stays inside the workspace', async () => {
+    const fs = makeSession(
+      { 'real/a.txt': 'hi' },
+      emptyHandler,
+      [],
+      defaultGitStub(),
+      [],
+      undefined,
+      { link: '/repo/real' },
+    );
+    const entry = await fs.stat({ path: 'link' });
+    expect(entry.kind).toBe('symlink');
+  });
+
+  it('still resolves ordinary in-workspace paths', async () => {
+    const fs = makeSession({ 'src/a.ts': 'content' }, emptyHandler);
+    const res = await fs.read({ path: 'src/a.ts', offset: 0, length: 1024, encoding: 'utf-8' });
+    expect(res.content).toBe('content');
   });
 });

--- a/packages/agent-core-v2/test/session/workspaceCommand/workspaceCommand.test.ts
+++ b/packages/agent-core-v2/test/session/workspaceCommand/workspaceCommand.test.ts
@@ -133,6 +133,11 @@ class MemoryHostFs implements IHostFileSystem {
     this.files.delete(path);
     this.dirs.delete(path);
   }
+
+  async realpath(path: string): Promise<string> {
+    if (this.files.has(path) || this.dirs.has(path)) return path;
+    throw enoent(path);
+  }
 }
 
 function enoent(path: string): NodeJS.ErrnoException {

--- a/packages/agent-core-v2/test/tools/fixtures/fake-exec.ts
+++ b/packages/agent-core-v2/test/tools/fixtures/fake-exec.ts
@@ -29,6 +29,7 @@ export function createFakeHostFs(overrides: Partial<IHostFileSystem> = {}): IHos
     readdir: () => notImplemented('FakeHostFs.readdir'),
     mkdir: () => notImplemented('FakeHostFs.mkdir'),
     remove: () => notImplemented('FakeHostFs.remove'),
+    realpath: () => notImplemented('FakeHostFs.realpath'),
   };
   return { ...fs, ...overrides };
 }

--- a/packages/kap-server/src/middleware/auth.ts
+++ b/packages/kap-server/src/middleware/auth.ts
@@ -30,6 +30,24 @@ export interface AuthHookOptions {
 }
 
 /**
+ * Decode the request path the same way the router does before matching.
+ *
+ * `req.url` is the raw, still percent-encoded URL, while find-my-way matches
+ * routes against the decoded path — so a raw `/%61pi/…` reaches the `/api/…`
+ * handlers. Checking the decoded path keeps the auth decision aligned with
+ * routing. Returns `null` when the path cannot be decoded, in which case the
+ * caller must fail closed.
+ */
+function decodeRequestPath(rawUrl: string): string | null {
+  const path = rawUrl.split('?', 1)[0] ?? rawUrl;
+  try {
+    return decodeURIComponent(path);
+  } catch {
+    return null;
+  }
+}
+
+/**
  * Default bypass policy — the security boundary.
  *
  * Bypassed (no token required):
@@ -47,7 +65,11 @@ function defaultIsBypassed(req: FastifyRequest): boolean {
   if (req.method === 'OPTIONS') {
     return true;
   }
-  const path = req.url.split('?', 1)[0] ?? req.url;
+  const path = decodeRequestPath(req.url);
+  if (path === null) {
+    // Fail closed: an undecodable path must never skip authentication.
+    return false;
+  }
   if (req.method === 'GET' && path === '/api/v1/healthz') {
     return true;
   }

--- a/packages/kap-server/test/fs.test.ts
+++ b/packages/kap-server/test/fs.test.ts
@@ -1,4 +1,4 @@
-import { chmod, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { chmod, mkdtemp, rm, symlink, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
@@ -223,6 +223,26 @@ describe('server-v2 /api/v1/sessions/{sid}/fs:*', () => {
     const id = await createSession();
     const body = await postFs<null>(id, 'stat', { path: '../etc/passwd' });
     expect(body.code).toBe(ErrorCode.FS_PATH_ESCAPES_SESSION);
+  });
+
+  it('rejects reads and downloads that escape the workspace through a symlink', async () => {
+    const outside = await mkdtemp(join(tmpdir(), 'kimi-server-v2-fs-outside-'));
+    try {
+      await writeFile(join(outside, 'secret.txt'), 'top-secret');
+      await symlink(outside, join(work!, 'docs'), 'dir');
+      const id = await createSession();
+
+      const body = await postFs<null>(id, 'read', { path: 'docs/secret.txt' });
+      expect(body.code).toBe(ErrorCode.FS_PATH_ESCAPES_SESSION);
+
+      const res = await fetch(`${base}/api/v1/sessions/${id}/fs/docs/secret.txt:download`, {
+        headers: authHeaders(server as RunningServer),
+      } as never);
+      const downloadBody = (await res.json()) as Envelope<null>;
+      expect(downloadBody.code).toBe(ErrorCode.FS_PATH_ESCAPES_SESSION);
+    } finally {
+      await rm(outside, { recursive: true, force: true });
+    }
   });
 
   it('GET fs/{path}:download streams the file and honors If-None-Match', async () => {

--- a/packages/kap-server/test/fs.test.ts
+++ b/packages/kap-server/test/fs.test.ts
@@ -245,6 +245,29 @@ describe('server-v2 /api/v1/sessions/{sid}/fs:*', () => {
     }
   });
 
+  it('serves fs actions when the session cwd itself goes through a symlink', async () => {
+    const link = join(tmpdir(), `kimi-server-v2-fs-cwd-link-${process.pid}`);
+    await symlink(work!, link, 'dir');
+    try {
+      const res = await fetch(`${base}/api/v1/sessions`, {
+        method: 'POST',
+        headers: authHeaders(server as RunningServer, { 'content-type': 'application/json' }),
+        body: JSON.stringify({ metadata: { cwd: link } }),
+      } as never);
+      const body = (await res.json()) as Envelope<{ id: string }>;
+      expect(body.code).toBe(0);
+
+      await writeFile(join(work!, 'via-link.txt'), 'through-link');
+      const read = await postFs<{ content: string }>(body.data.id, 'read', {
+        path: 'via-link.txt',
+      });
+      expect(read.code).toBe(0);
+      expect(read.data.content).toBe('through-link');
+    } finally {
+      await rm(link, { force: true });
+    }
+  });
+
   it('GET fs/{path}:download streams the file and honors If-None-Match', async () => {
     await writeFile(join(work!, 'a.txt'), 'download-me');
     const id = await createSession();

--- a/packages/kap-server/test/rateLimit.test.ts
+++ b/packages/kap-server/test/rateLimit.test.ts
@@ -97,6 +97,54 @@ describe('createAuthHook rate limiting', () => {
   });
 });
 
+describe('createAuthHook bypass policy (URL encoding)', () => {
+  let app: FastifyInstance;
+
+  beforeEach(async () => {
+    app = buildApp(undefined);
+    await app.ready();
+  });
+
+  afterEach(async () => {
+    await app.close();
+  });
+
+  it('requires a token for percent-encoded /api/ paths', async () => {
+    // The router matches these against /api/v1/sessions; the auth hook must
+    // see the same decoded path instead of bypassing on the raw URL.
+    for (const url of ['/%61pi/v1/sessions', '/%61%70%69/v1/sessions']) {
+      const res = await app.inject({ method: 'GET', url });
+      expect(res.statusCode).toBe(401);
+    }
+  });
+
+  it('serves percent-encoded /api/ paths with a valid token', async () => {
+    const res = await app.inject({
+      method: 'GET',
+      url: '/%61pi/v1/sessions',
+      headers: { authorization: `Bearer ${TOKEN}` },
+    });
+    expect(res.statusCode).toBe(200);
+  });
+
+  it('requires a token for percent-encoded meta documents', async () => {
+    const res = await app.inject({ method: 'GET', url: '/%6fpenapi.json' });
+    expect(res.statusCode).toBe(401);
+  });
+
+  it('still bypasses non-API paths without a token', async () => {
+    // No static route is registered, so a bypassed request falls through to
+    // the router's 404 instead of being rejected with 401.
+    const res = await app.inject({ method: 'GET', url: '/index.html' });
+    expect(res.statusCode).toBe(404);
+  });
+
+  it('still bypasses the healthz probe when percent-encoded', async () => {
+    const res = await app.inject({ method: 'GET', url: '/%61pi/v1/healthz' });
+    expect(res.statusCode).toBe(404);
+  });
+});
+
 describe('createAuthFailureLimiter (unit)', () => {
   afterEach(() => {
     vi.useRealTimers();


### PR DESCRIPTION
## Related Issue

No linked issue — the problem is explained below.

## Problem

The kap-server auth hook decided whether a request could skip bearer-token authentication by inspecting `req.url` — the raw, still percent-encoded URL. The router (find-my-way), however, matches routes against the decoded path. A request to `/%61pi/v1/sessions` (percent-encoded `/api/v1/sessions`) therefore failed the hook's `/api/` prefix check, skipped authentication, yet still matched the `/api/v1/sessions` route — giving unauthenticated clients access to every API route.

## What changed

- `packages/kap-server/src/middleware/auth.ts`: decode the request path (query string stripped) with `decodeURIComponent` before applying the bypass policy, so the auth decision sees the same path the router matches against. If the path cannot be decoded, fail closed — the request is never treated as bypassed.
- `packages/kap-server/test/rateLimit.test.ts`: regression tests covering percent-encoded `/api/` paths (401 without a token, 200 with a valid token), a percent-encoded meta document, the percent-encoded healthz probe (still bypassed), and non-API paths (still bypassed).
- Added a patch changeset for `@moonshot-ai/kimi-code`.

Keeping the decode at the single point where the bypass policy is evaluated aligns the auth decision with routing semantics, instead of special-casing encoded variants in every bypass rule.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.
