### PR TITLE
fix(web): dedupe background subagent rows in the agents dock

### DIFF
--- a/.changeset/fix-web-task-output-backfill.md
+++ b/.changeset/fix-web-task-output-backfill.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+web: Fix completed background subagents losing their final output after a session reload, and retry the output backfill when a transient fetch failure occurs.

--- a/.changeset/wet-melons-fold.md
+++ b/.changeset/wet-melons-fold.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+web: Fix a background subagent showing up as two identical rows in the agents dock panel during streaming.

--- a/apps/kimi-web/src/api/daemon/agentEventProjector.ts
+++ b/apps/kimi-web/src/api/daemon/agentEventProjector.ts
@@ -1120,6 +1120,44 @@ export function createAgentProjector(): AgentProjector {
             : typeof info.command === 'string'
               ? info.command
               : i18n.global.t('tasks.defaultDescription');
+        // A background subagent registers into the background-task store under
+        // a fresh task id that differs from its agent id. Record the task id on
+        // the existing WS-owned row (keyed by agent id) instead of adding a
+        // second row — REST `/tasks` returns the same agent keyed by task id,
+        // and keepLiveSubagents folds that copy into this row.
+        if (info.kind === 'agent') {
+          const agentId = typeof info.agentId === 'string' ? info.agentId : undefined;
+          const existing =
+            agentId !== undefined && agentId.length > 0
+              ? s.subagentMeta.get(agentId)
+              : undefined;
+          if (agentId !== undefined && existing !== undefined) {
+            const task = patchSubagent(s, sessionId, agentId, {
+              backgroundTaskId: taskId,
+              runInBackground: true,
+            });
+            if (task) out.push({ type: 'taskCreated', sessionId, task });
+          } else {
+            // The spawn event never reached this client (subscribed late) — key
+            // the row by the background task id so the REST poll dedupes it.
+            out.push({
+              type: 'taskCreated',
+              sessionId,
+              task: {
+                id: taskId,
+                sessionId,
+                kind: 'subagent',
+                description,
+                status: 'running',
+                createdAt: startedAt ?? new Date().toISOString(),
+                startedAt,
+                subagentPhase: 'queued',
+                runInBackground: true,
+              },
+            });
+          }
+          break;
+        }
         const command = typeof info.command === 'string' ? info.command : undefined;
         out.push({
           type: 'taskCreated',

--- a/apps/kimi-web/src/api/daemon/agentEventProjector.ts
+++ b/apps/kimi-web/src/api/daemon/agentEventProjector.ts
@@ -1126,20 +1126,24 @@ export function createAgentProjector(): AgentProjector {
         // second row — REST `/tasks` returns the same agent keyed by task id,
         // and keepLiveSubagents folds that copy into this row.
         if (info.kind === 'agent') {
-          const agentId = typeof info.agentId === 'string' ? info.agentId : undefined;
-          const existing =
-            agentId !== undefined && agentId.length > 0
-              ? s.subagentMeta.get(agentId)
+          const agentId =
+            typeof info.agentId === 'string' && info.agentId.length > 0
+              ? info.agentId
               : undefined;
-          if (agentId !== undefined && existing !== undefined) {
+          if (agentId !== undefined) {
+            // Key by agent id even when the spawn event never reached this
+            // client (subscribed late): later agent-scoped progress frames are
+            // routed by agent id, and seeding subagentMeta here keeps them on
+            // this one row instead of synthesizing a second one.
             const task = patchSubagent(s, sessionId, agentId, {
+              description,
               backgroundTaskId: taskId,
               runInBackground: true,
             });
             if (task) out.push({ type: 'taskCreated', sessionId, task });
           } else {
-            // The spawn event never reached this client (subscribed late) — key
-            // the row by the background task id so the REST poll dedupes it.
+            // No agent id — nothing to link; key the row by the background
+            // task id so the REST poll dedupes it.
             out.push({
               type: 'taskCreated',
               sessionId,

--- a/apps/kimi-web/src/api/daemon/eventReducer.ts
+++ b/apps/kimi-web/src/api/daemon/eventReducer.ts
@@ -582,6 +582,7 @@ export function reduceAppEvent(
           parentToolCallId: event.task.parentToolCallId ?? previous.parentToolCallId,
           subagentType: event.task.subagentType ?? previous.subagentType,
           runInBackground: event.task.runInBackground ?? previous.runInBackground,
+          backgroundTaskId: event.task.backgroundTaskId ?? previous.backgroundTaskId,
         };
         next.tasksBySession[sid] = patched;
       }

--- a/apps/kimi-web/src/api/types.ts
+++ b/apps/kimi-web/src/api/types.ts
@@ -333,6 +333,12 @@ export interface AppTask {
    *  the dock: the dock lists background subagents, while foreground subagents
    *  render inline in the message flow as the `Agent` tool card. */
   runInBackground?: boolean;
+  /** The id this same subagent has in the server's background-task store
+   *  (REST `/tasks`), learned from the `task.started` registration event. The
+   *  WS event stream keys the agent by agent id while REST keys it by task id;
+   *  this links the two so the REST copy can be folded into this row and so
+   *  cancel can target the id REST actually knows. */
+  backgroundTaskId?: string;
 }
 
 // ---------------------------------------------------------------------------

--- a/apps/kimi-web/src/composables/client/useTaskPoller.ts
+++ b/apps/kimi-web/src/composables/client/useTaskPoller.ts
@@ -78,10 +78,11 @@ export function useTaskPoller(
               bytes: withOutput.outputBytes,
             });
           }
+          // Only a definitive response marks the task as fetched — a transient
+          // failure must leave it eligible for a later backfill.
+          fetchedTerminalTaskOutputIds.add(task.id);
         } catch {
           // Task may have finished between listTasks and getTask; ignore.
-        } finally {
-          fetchedTerminalTaskOutputIds.add(task.id);
         }
       }),
     );
@@ -92,7 +93,15 @@ export function useTaskPoller(
     rawState.tasksBySession = {
       ...rawState.tasksBySession,
       [sessionId]: existing.map((t) => {
-        const polled = outputByTaskId.get(t.id);
+        // Output was fetched by REST task id; a background subagent row folded
+        // into its WS agent-id row (keepLiveSubagents) is matched via
+        // backgroundTaskId, otherwise its final output would be dropped here
+        // and never refetched (the REST id is already marked as fetched).
+        const polled =
+          outputByTaskId.get(t.id) ??
+          (t.backgroundTaskId !== undefined
+            ? outputByTaskId.get(t.backgroundTaskId)
+            : undefined);
         if (!polled) return t;
         return { ...t, outputPreview: polled.preview, outputBytes: polled.bytes };
       }),
@@ -145,12 +154,13 @@ export function useTaskPoller(
               bytes: withOutput.outputBytes,
             });
           }
-        } catch {
-          // Task may have finished between listTasks and getTask; ignore.
-        } finally {
+          // Mark as fetched only on a definitive response; a transient failure
+          // stays eligible for the next poll.
           if (isTerminal) {
             fetchedTerminalTaskOutputIds.add(task.id);
           }
+        } catch {
+          // Task may have finished between listTasks and getTask; ignore.
         }
       }),
     );

--- a/apps/kimi-web/src/composables/client/useWorkspaceState.ts
+++ b/apps/kimi-web/src/composables/client/useWorkspaceState.ts
@@ -1914,7 +1914,11 @@ export function useWorkspaceState(rawState: ExtendedState, deps: UseWorkspaceSta
     pendingTaskCancellations[taskId] = true;
     try {
       const api = getKimiWebApi();
-      await api.cancelTask(sid, taskId);
+      // A background subagent row is keyed by agent id, but REST `/tasks` only
+      // knows its background-task id.
+      const restTaskId = (rawState.tasksBySession[sid] ?? []).find((t) => t.id === taskId)
+        ?.backgroundTaskId;
+      await api.cancelTask(sid, restTaskId ?? taskId);
       // Update task status locally
       const list = rawState.tasksBySession[sid] ?? [];
       rawState.tasksBySession = {

--- a/apps/kimi-web/src/lib/taskMerge.ts
+++ b/apps/kimi-web/src/lib/taskMerge.ts
@@ -14,11 +14,37 @@ import type { AppTask } from '../api/types';
  *
  * Keep WS-owned subagent tasks that REST omits, so the REST refresh only governs
  * background tasks. REST stays authoritative for anything it does return.
+ *
+ * One exception: REST DOES return background subagents — keyed by their
+ * background-task id, while the WS stream keys the same agent by agent id
+ * (`backgroundTaskId` links the two, set from the `task.started`
+ * registration). Fold the REST copy into the WS-owned row so one agent does
+ * not surface as two rows; REST still corrects a terminal status the WS row
+ * may have missed while disconnected.
  */
 export function keepLiveSubagents(restBased: AppTask[], existing: AppTask[]): AppTask[] {
   const restIds = new Set(restBased.map((t) => t.id));
   const liveSubagents = existing.filter((t) => t.kind === 'subagent' && !restIds.has(t.id));
-  return liveSubagents.length === 0 ? restBased : [...restBased, ...liveSubagents];
+  if (liveSubagents.length === 0) return restBased;
+  const restById = new Map(restBased.map((t) => [t.id, t] as const));
+  const foldedRestIds = new Set<string>();
+  const merged = liveSubagents.map((live) => {
+    const rest =
+      live.backgroundTaskId !== undefined ? restById.get(live.backgroundTaskId) : undefined;
+    if (rest === undefined) return live;
+    foldedRestIds.add(rest.id);
+    return {
+      ...live,
+      // Terminal-stickiness: never let a lagging poll flip a finished row back
+      // to running, but let REST complete a row whose finish event was missed.
+      status: live.status === 'running' ? rest.status : live.status,
+      completedAt: live.completedAt ?? rest.completedAt,
+      outputPreview: live.outputPreview ?? rest.outputPreview,
+      outputBytes: live.outputBytes ?? rest.outputBytes,
+    };
+  });
+  const rest = restBased.filter((t) => !foldedRestIds.has(t.id));
+  return [...rest, ...merged];
 }
 
 /**

--- a/apps/kimi-web/src/lib/taskMerge.ts
+++ b/apps/kimi-web/src/lib/taskMerge.ts
@@ -33,11 +33,22 @@ export function keepLiveSubagents(restBased: AppTask[], existing: AppTask[]): Ap
       live.backgroundTaskId !== undefined ? restById.get(live.backgroundTaskId) : undefined;
     if (rest === undefined) return live;
     foldedRestIds.add(rest.id);
+    // True when the fold — not the event stream — is what makes the row terminal.
+    const restCompletesLiveRow = live.status === 'running' && rest.status !== 'running';
     return {
       ...live,
       // Terminal-stickiness: never let a lagging poll flip a finished row back
       // to running, but let REST complete a row whose finish event was missed.
       status: live.status === 'running' ? rest.status : live.status,
+      // toAgentMember prefers subagentPhase over status, so sync it too —
+      // otherwise the detail panel badge keeps showing a stale Working/Queued.
+      // The phase enum has no 'cancelled'; the dock already styles cancelled
+      // rows as failed.
+      subagentPhase: restCompletesLiveRow
+        ? rest.status === 'completed'
+          ? 'completed'
+          : 'failed'
+        : live.subagentPhase,
       completedAt: live.completedAt ?? rest.completedAt,
       // REST output is authoritative once present: agent tasks persist their
       // result at completion, and a previously folded preview would otherwise

--- a/apps/kimi-web/src/lib/taskMerge.ts
+++ b/apps/kimi-web/src/lib/taskMerge.ts
@@ -39,8 +39,11 @@ export function keepLiveSubagents(restBased: AppTask[], existing: AppTask[]): Ap
       // to running, but let REST complete a row whose finish event was missed.
       status: live.status === 'running' ? rest.status : live.status,
       completedAt: live.completedAt ?? rest.completedAt,
-      outputPreview: live.outputPreview ?? rest.outputPreview,
-      outputBytes: live.outputBytes ?? rest.outputBytes,
+      // REST output is authoritative once present: agent tasks persist their
+      // result at completion, and a previously folded preview would otherwise
+      // freeze the detail panel's Result.
+      outputPreview: rest.outputPreview ?? live.outputPreview,
+      outputBytes: rest.outputBytes ?? live.outputBytes,
     };
   });
   const rest = restBased.filter((t) => !foldedRestIds.has(t.id));

--- a/apps/kimi-web/test/agent-event-projector.test.ts
+++ b/apps/kimi-web/test/agent-event-projector.test.ts
@@ -338,7 +338,7 @@ describe('background subagent task registration', () => {
     ]);
   });
 
-  it('keys the row by the background task id when the spawn event was missed', () => {
+  it('keys a late registration by agent id so later progress frames stay on one row', () => {
     const projector = createAgentProjector();
     const events = projector.project(
       'task.started',
@@ -348,6 +348,52 @@ describe('background subagent task registration', () => {
           kind: 'agent',
           detached: true,
           agentId: 'agent-1',
+          description: 'Explore repo',
+          startedAt: 1767225600000,
+        },
+      },
+      's1',
+    );
+
+    expect(events).toEqual([
+      {
+        type: 'taskCreated',
+        sessionId: 's1',
+        task: expect.objectContaining({
+          id: 'agent-1',
+          kind: 'subagent',
+          description: 'Explore repo',
+          runInBackground: true,
+          backgroundTaskId: 'task-9',
+        }),
+      },
+    ]);
+
+    // A later agent-scoped progress frame must not synthesize a second row.
+    const progress = projector.project(
+      'assistant.delta',
+      { agentId: 'agent-1', delta: 'Hi' },
+      's1',
+    );
+    expect(progress).toContainEqual(
+      expect.objectContaining({ type: 'taskProgress', taskId: 'agent-1' }),
+    );
+    const created = progress.filter((e) => e.type === 'taskCreated');
+    expect(created).toHaveLength(1);
+    expect(created[0]).toMatchObject({
+      task: { id: 'agent-1', backgroundTaskId: 'task-9' },
+    });
+  });
+
+  it('falls back to the task id when the registration carries no agent id', () => {
+    const projector = createAgentProjector();
+    const events = projector.project(
+      'task.started',
+      {
+        info: {
+          taskId: 'task-9',
+          kind: 'agent',
+          detached: true,
           description: 'Explore repo',
           startedAt: 1767225600000,
         },

--- a/apps/kimi-web/test/agent-event-projector.test.ts
+++ b/apps/kimi-web/test/agent-event-projector.test.ts
@@ -296,3 +296,101 @@ describe('step-boundary delta alignment', () => {
     );
   });
 });
+
+
+describe('background subagent task registration', () => {
+  it('folds task.started (kind agent) into the spawned row instead of adding a second row', () => {
+    const projector = createAgentProjector();
+    projector.project(
+      'subagent.spawned',
+      { subagentId: 'agent-1', description: 'Explore repo', runInBackground: true },
+      's1',
+    );
+
+    const events = projector.project(
+      'task.started',
+      {
+        info: {
+          taskId: 'task-9',
+          kind: 'agent',
+          detached: true,
+          agentId: 'agent-1',
+          description: 'Explore repo',
+          startedAt: 1767225600000,
+        },
+      },
+      's1',
+    );
+
+    // A single patch of the WS-owned row — never a second (bash) task row.
+    expect(events).toEqual([
+      {
+        type: 'taskCreated',
+        sessionId: 's1',
+        task: expect.objectContaining({
+          id: 'agent-1',
+          kind: 'subagent',
+          description: 'Explore repo',
+          runInBackground: true,
+          backgroundTaskId: 'task-9',
+        }),
+      },
+    ]);
+  });
+
+  it('keys the row by the background task id when the spawn event was missed', () => {
+    const projector = createAgentProjector();
+    const events = projector.project(
+      'task.started',
+      {
+        info: {
+          taskId: 'task-9',
+          kind: 'agent',
+          detached: true,
+          agentId: 'agent-1',
+          description: 'Explore repo',
+          startedAt: 1767225600000,
+        },
+      },
+      's1',
+    );
+
+    expect(events).toEqual([
+      {
+        type: 'taskCreated',
+        sessionId: 's1',
+        task: expect.objectContaining({
+          id: 'task-9',
+          kind: 'subagent',
+          description: 'Explore repo',
+          runInBackground: true,
+        }),
+      },
+    ]);
+  });
+
+  it('keeps projecting process tasks as bash rows', () => {
+    const projector = createAgentProjector();
+    const events = projector.project(
+      'task.started',
+      {
+        info: {
+          taskId: 'task-1',
+          kind: 'process',
+          description: 'npm test',
+          command: 'npm test',
+          startedAt: 1767225600000,
+        },
+      },
+      's1',
+    );
+
+    expect(events).toEqual([
+      {
+        type: 'taskCreated',
+        sessionId: 's1',
+        task: expect.objectContaining({ id: 'task-1', kind: 'bash', command: 'npm test' }),
+      },
+    ]);
+  });
+});

--- a/apps/kimi-web/test/lib-logic.test.ts
+++ b/apps/kimi-web/test/lib-logic.test.ts
@@ -822,4 +822,26 @@ describe('keepLiveSubagents', () => {
     const [merged] = keepLiveSubagents(rest, [live]);
     expect(merged?.status).toBe('completed');
   });
+
+  it('keeps newer REST output flowing into an already-folded row', () => {
+    // The live row carries a preview folded in by an earlier poll; the fresh
+    // REST row has the final persisted output and must win.
+    const live = subagent('agent-1', {
+      runInBackground: true,
+      backgroundTaskId: 'task-9',
+      outputPreview: 'stale tail',
+      outputBytes: 100,
+    });
+    const rest = [
+      subagent('task-9', {
+        runInBackground: true,
+        status: 'completed',
+        outputPreview: 'final result',
+        outputBytes: 200,
+      }),
+    ];
+    const [merged] = keepLiveSubagents(rest, [live]);
+    expect(merged?.outputPreview).toBe('final result');
+    expect(merged?.outputBytes).toBe(200);
+  });
 });

--- a/apps/kimi-web/test/lib-logic.test.ts
+++ b/apps/kimi-web/test/lib-logic.test.ts
@@ -796,7 +796,11 @@ describe('keepLiveSubagents', () => {
   });
 
   it('lets REST complete a live row whose finish event was missed', () => {
-    const live = subagent('agent-1', { runInBackground: true, backgroundTaskId: 'task-9' });
+    const live = subagent('agent-1', {
+      runInBackground: true,
+      backgroundTaskId: 'task-9',
+      subagentPhase: 'working',
+    });
     const rest = [
       subagent('task-9', {
         runInBackground: true,
@@ -807,8 +811,22 @@ describe('keepLiveSubagents', () => {
     ];
     const [merged] = keepLiveSubagents(rest, [live]);
     expect(merged?.status).toBe('completed');
+    // The detail panel prefers subagentPhase over status — it must follow too.
+    expect(merged?.subagentPhase).toBe('completed');
     expect(merged?.completedAt).toBe('2026-01-01T00:01:00.000Z');
     expect(merged?.outputPreview).toBe('done');
+  });
+
+  it('maps a REST-cancelled row to the failed phase (the enum has no cancelled)', () => {
+    const live = subagent('agent-1', {
+      runInBackground: true,
+      backgroundTaskId: 'task-9',
+      subagentPhase: 'working',
+    });
+    const rest = [subagent('task-9', { runInBackground: true, status: 'cancelled' })];
+    const [merged] = keepLiveSubagents(rest, [live]);
+    expect(merged?.status).toBe('cancelled');
+    expect(merged?.subagentPhase).toBe('failed');
   });
 
   it('never lets a lagging poll flip a finished row back to running', () => {

--- a/apps/kimi-web/test/lib-logic.test.ts
+++ b/apps/kimi-web/test/lib-logic.test.ts
@@ -9,7 +9,7 @@ import { buildDiffLines } from '../src/lib/diffLines';
 import { buildEditDiffLines } from '../src/lib/toolDiff';
 import { createCoalescedAsyncRunner } from '../src/lib/snapshotSync';
 import { mergeSnapshotMessages } from '../src/lib/snapshotMessages';
-import { mergeSnapshotSubagents } from '../src/lib/taskMerge';
+import { keepLiveSubagents, mergeSnapshotSubagents } from '../src/lib/taskMerge';
 import { normalizeToolName, toolSummary } from '../src/lib/toolMeta';
 import { collapsePrompt, humanizeCron } from '../src/lib/cronHumanize';
 import {
@@ -750,5 +750,76 @@ describe('mergeSnapshotSubagents', () => {
   it('returns the existing list untouched when the roster is empty', () => {
     const existing = [subagent('a1')];
     expect(mergeSnapshotSubagents([], existing)).toBe(existing);
+  });
+});
+
+
+describe('keepLiveSubagents', () => {
+  function subagent(id: string, overrides: Partial<AppTask> = {}): AppTask {
+    return {
+      id,
+      sessionId: 's1',
+      kind: 'subagent',
+      description: `task ${id}`,
+      status: 'running',
+      createdAt: '2026-01-01T00:00:00.000Z',
+      ...overrides,
+    };
+  }
+
+  it('returns the REST list untouched when no live-only subagent exists', () => {
+    const rest = [subagent('a1')];
+    expect(keepLiveSubagents(rest, [subagent('a1')])).toBe(rest);
+  });
+
+  it('keeps WS-only swarm subagents that REST omits', () => {
+    const rest: AppTask[] = [];
+    const merged = keepLiveSubagents(rest, [subagent('a1')]);
+    expect(merged.map((t) => t.id)).toEqual(['a1']);
+  });
+
+  it('folds a REST background-subagent row into the WS row keyed by agent id', () => {
+    // The same background subagent: WS keys it by agent id, REST by task id.
+    const live = subagent('agent-1', {
+      runInBackground: true,
+      backgroundTaskId: 'task-9',
+      outputLines: ['step 1'],
+      text: 'partial',
+    });
+    const rest = [subagent('task-9', { runInBackground: true })];
+    const merged = keepLiveSubagents(rest, [live]);
+    expect(merged).toHaveLength(1);
+    expect(merged[0]?.id).toBe('agent-1');
+    expect(merged[0]?.outputLines).toEqual(['step 1']);
+    expect(merged[0]?.text).toBe('partial');
+    expect(merged[0]?.backgroundTaskId).toBe('task-9');
+  });
+
+  it('lets REST complete a live row whose finish event was missed', () => {
+    const live = subagent('agent-1', { runInBackground: true, backgroundTaskId: 'task-9' });
+    const rest = [
+      subagent('task-9', {
+        runInBackground: true,
+        status: 'completed',
+        completedAt: '2026-01-01T00:01:00.000Z',
+        outputPreview: 'done',
+      }),
+    ];
+    const [merged] = keepLiveSubagents(rest, [live]);
+    expect(merged?.status).toBe('completed');
+    expect(merged?.completedAt).toBe('2026-01-01T00:01:00.000Z');
+    expect(merged?.outputPreview).toBe('done');
+  });
+
+  it('never lets a lagging poll flip a finished row back to running', () => {
+    const live = subagent('agent-1', {
+      runInBackground: true,
+      backgroundTaskId: 'task-9',
+      status: 'completed',
+      completedAt: '2026-01-01T00:01:00.000Z',
+    });
+    const rest = [subagent('task-9', { runInBackground: true, status: 'running' })];
+    const [merged] = keepLiveSubagents(rest, [live]);
+    expect(merged?.status).toBe('completed');
   });
 });

--- a/apps/kimi-web/test/task-poller.test.ts
+++ b/apps/kimi-web/test/task-poller.test.ts
@@ -1,0 +1,121 @@
+// Scenario: terminal-output backfill for background tasks (useTaskPoller).
+// Responsibilities: folded background-subagent rows must receive the output
+// fetched under their REST task id, and a transient getTask failure must not
+// permanently suppress later backfills.
+// Wiring: the composable is real; daemon requests are stubbed.
+// Run: pnpm --filter @moonshot-ai/kimi-web exec vitest run test/task-poller.test.ts
+
+import { computed } from 'vue';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { AppTask } from '../src/api/types';
+import { createInitialState } from '../src/api/daemon/eventReducer';
+import { useTaskPoller } from '../src/composables/client/useTaskPoller';
+import type { ExtendedState } from '../src/composables/useKimiWebClient';
+
+const apiMock = vi.hoisted(() => ({
+  listTasks: vi.fn(),
+  getTask: vi.fn(),
+}));
+
+vi.mock('../src/api', () => ({
+  getKimiWebApi: () => apiMock,
+}));
+
+function createState(tasks: AppTask[]): ExtendedState {
+  return {
+    ...createInitialState(),
+    activeSessionId: 'sess_1',
+    tasksBySession: { sess_1: tasks },
+  } as unknown as ExtendedState;
+}
+
+function subagent(id: string, overrides: Partial<AppTask> = {}): AppTask {
+  return {
+    id,
+    sessionId: 'sess_1',
+    kind: 'subagent',
+    description: `task ${id}`,
+    status: 'running',
+    createdAt: '2026-01-01T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+/** The same background subagent as seen on the two channels: WS keys it by
+    agent id, REST by background-task id (`backgroundTaskId` links them).
+    The live row is already completed so the poller's 1s output polling does
+    not start racing the one-off backfill under test. */
+function liveRow(): AppTask {
+  return subagent('agent-1', {
+    runInBackground: true,
+    backgroundTaskId: 'task-9',
+    status: 'completed',
+    completedAt: '2026-01-01T00:01:00.000Z',
+  });
+}
+function restRow(overrides: Partial<AppTask> = {}): AppTask {
+  return subagent('task-9', {
+    runInBackground: true,
+    status: 'completed',
+    completedAt: '2026-01-01T00:01:00.000Z',
+    ...overrides,
+  });
+}
+
+describe('useTaskPoller terminal-output backfill', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('attaches output fetched under the REST id to the folded agent-id row', async () => {
+    const state = createState([liveRow()]);
+    apiMock.listTasks.mockResolvedValue([restRow()]);
+    apiMock.getTask.mockResolvedValue(
+      restRow({ outputPreview: 'final result', outputBytes: 2048 }),
+    );
+
+    const poller = useTaskPoller(state, computed(() => []));
+    await poller.loadTasksForSession('sess_1');
+
+    expect(apiMock.getTask).toHaveBeenCalledWith(
+      'sess_1',
+      'task-9',
+      expect.objectContaining({ withOutput: true }),
+    );
+    const rows = state.tasksBySession['sess_1'] ?? [];
+    expect(rows.map((t) => t.id)).toEqual(['agent-1']);
+    expect(rows[0]?.status).toBe('completed');
+    expect(rows[0]?.outputPreview).toBe('final result');
+    expect(rows[0]?.outputBytes).toBe(2048);
+  });
+
+  it('fetches terminal output only once for a task', async () => {
+    const state = createState([liveRow()]);
+    apiMock.listTasks.mockResolvedValue([restRow()]);
+    apiMock.getTask.mockResolvedValue(
+      restRow({ outputPreview: 'final result', outputBytes: 2048 }),
+    );
+
+    const poller = useTaskPoller(state, computed(() => []));
+    await poller.loadTasksForSession('sess_1');
+    await poller.loadTasksForSession('sess_1');
+
+    expect(apiMock.getTask).toHaveBeenCalledTimes(1);
+  });
+
+  it('retries the backfill on a later load after a transient getTask failure', async () => {
+    const state = createState([liveRow()]);
+    apiMock.listTasks.mockResolvedValue([restRow()]);
+    apiMock.getTask
+      .mockRejectedValueOnce(new Error('network blip'))
+      .mockResolvedValue(restRow({ outputPreview: 'final result', outputBytes: 2048 }));
+
+    const poller = useTaskPoller(state, computed(() => []));
+    await poller.loadTasksForSession('sess_1');
+    expect(state.tasksBySession['sess_1']?.[0]?.outputPreview).toBeUndefined();
+
+    await poller.loadTasksForSession('sess_1');
+    expect(apiMock.getTask).toHaveBeenCalledTimes(2);
+    expect(state.tasksBySession['sess_1']?.[0]?.outputPreview).toBe('final result');
+  });
+});


### PR DESCRIPTION
## Related Issue

No linked issue — the problem is explained below.

## Problem

During streaming, while a background subagent (`Agent` tool with `run_in_background: true`) is running, opening the agents panel in the bottom dock shows two identical rows for the same agent.

Root cause: the server gives a background subagent two different ids — the agent id (delivered by the WS `subagent.spawned` event) and a fresh task id in the main agent's background-task store (served by REST `/tasks`, and broadcast in the `task.started` registration event). The web client kept one row per id: the WS projector added a row keyed by agent id, then the 1-second REST poll (active while tasks run, i.e. during streaming) returned the same agent keyed by task id. The merge only dedupes by exact id, so both rows survived — and both pass the dock's `kind === 'subagent' && runInBackground` filter. The snapshot-roster path already avoids this duplication (it deliberately excludes background subagents); the live WS + poll path had no equivalent reconciliation.

## What changed

- The `task.started` event for `kind: 'agent'` carries both ids. The projector now records the task id on the existing WS-owned row as `backgroundTaskId` instead of projecting a second row (which was also mis-typed as `kind: 'bash'`).
- The REST/WS task merge (`keepLiveSubagents`) folds a REST row whose id matches a live row's `backgroundTaskId` into that row. REST can still correct a terminal status the WS row missed, but a lagging poll never flips a finished row back to running.
- Cancel resolves `backgroundTaskId` first, so the stop button keeps targeting the id REST actually knows.
- Side effects of the same fix: background subagents no longer flash in the bash panel before the first poll, and a detached foreground subagent (Ctrl+B) now appears in the dock as a single row with live progress.

Tests: projector fold + late-subscribe fallback + unchanged process-task behavior; merge fold + terminal-stickiness cases. Full kimi-web suite (534 tests) and `vue-tsc` pass.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.
