### PR TITLE
fix: close two silent-exit vectors around unhandled rejections

### DIFF
--- a/.changeset/fix-image-paste-rejection-exit.md
+++ b/.changeset/fix-image-paste-rejection-exit.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Fix the CLI exiting unexpectedly when reading an image from the clipboard fails; it now falls back to pasting text.

--- a/.changeset/fix-rejection-crash-telemetry.md
+++ b/.changeset/fix-rejection-crash-telemetry.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Report crash telemetry for unhandled promise rejections, so exits they cause are no longer invisible.

--- a/apps/kimi-code/src/tui/components/editor/custom-editor.ts
+++ b/apps/kimi-code/src/tui/components/editor/custom-editor.ts
@@ -397,12 +397,21 @@ export class CustomEditor extends Editor {
       }
       if (this.onPasteImage !== undefined) {
         const handler = this.onPasteImage;
-        void handler().then((handled) => {
-          if (!handled) {
-            this.onTextPaste?.();
-            super.handleInput.call(this, normalized);
-          }
-        });
+        const pasteAsText = (): void => {
+          this.onTextPaste?.();
+          super.handleInput.call(this, normalized);
+        };
+        void handler().then(
+          (handled) => {
+            if (!handled) pasteAsText();
+          },
+          () => {
+            // A rejecting image-paste handler must not leak an unhandled
+            // rejection (the CLI turns those into a silent exit) — treat it
+            // the same as "no image available" and fall back to text paste.
+            pasteAsText();
+          },
+        );
         return;
       }
     }

--- a/apps/kimi-code/test/tui/components/editor/custom-editor.test.ts
+++ b/apps/kimi-code/test/tui/components/editor/custom-editor.test.ts
@@ -587,6 +587,34 @@ describe('CustomEditor paste marker expansion', () => {
     editor.handleInput('x');
     expect(editor.getText()).toContain('x');
   });
+
+  it('falls back to the text paste path when the image paste handler rejects', async () => {
+    const editor = makeEditor();
+    const onTextPaste = vi.fn();
+    editor.onTextPaste = onTextPaste;
+    editor.onPasteImage = vi.fn(async () => {
+      throw new Error('clipboard backend broken');
+    });
+
+    // Regression: a rejecting onPasteImage must not leak an unhandled
+    // rejection — the CLI's crash path turns those into a silent exit.
+    const rejections: unknown[] = [];
+    const onRejection = (reason: unknown): void => {
+      rejections.push(reason);
+    };
+    process.on('unhandledRejection', onRejection);
+    try {
+      editor.handleInput(process.platform === 'win32' ? '\u001Bv' : '\u0016');
+      await new Promise((resolve) => {
+        setImmediate(resolve);
+      });
+
+      expect(onTextPaste).toHaveBeenCalledOnce();
+      expect(rejections).toHaveLength(0);
+    } finally {
+      process.off('unhandledRejection', onRejection);
+    }
+  });
 });
 
 describe('CustomEditor shortcut telemetry hooks', () => {

--- a/packages/telemetry/src/crash.ts
+++ b/packages/telemetry/src/crash.ts
@@ -7,6 +7,7 @@ let installed = false;
 let installedUncaughtHandler:
   | ((error: Error, origin: NodeJS.UncaughtExceptionOrigin) => void)
   | null = null;
+let installedRejectionHandler: ((reason: unknown) => void) | null = null;
 
 export function setCrashPhase(nextPhase: CrashPhase): void {
   phase = nextPhase;
@@ -17,11 +18,14 @@ export function installCrashHandlers(): () => void {
 }
 
 export function installCrashHandlersForClient(client: TelemetryClient): () => void {
-  if (installed && installedUncaughtHandler !== null) {
+  if (installed && installedUncaughtHandler !== null && installedRejectionHandler !== null) {
     return () => {
       uninstallCrashHandlers();
     };
   }
+  // Rejections recorded by the rejection handler below and then rethrown to
+  // preserve Node's default crash; the monitor must not report them twice.
+  const recordedRejections = new WeakSet<object>();
   const trackCrash = (errorType: string, source: string) => {
     try {
       client.track('crash', {
@@ -36,9 +40,28 @@ export function installCrashHandlersForClient(client: TelemetryClient): () => vo
   };
   installedUncaughtHandler = (error, origin) => {
     if (isAbortError(error)) return;
+    if (recordedRejections.has(error)) return;
     trackCrash(error.name || error.constructor.name, origin);
   };
   process.on('uncaughtExceptionMonitor', installedUncaughtHandler);
+  // `uncaughtExceptionMonitor` never fires for a rejection that has a
+  // listener — and the TUI always registers one, converting the rejection
+  // into a silent exit(1) with no telemetry at all. Observe rejections
+  // directly so those crashes still leave a trace. Registering a real
+  // listener suppresses Node's default crash-on-rejection, so when we are
+  // the only listener (print / server modes) rethrow to preserve it; the
+  // dedupe set above keeps the monitor from double-reporting that path.
+  installedRejectionHandler = (reason: unknown) => {
+    const soleListener = process.listenerCount('unhandledRejection') === 1;
+    if (!isAbortError(reason)) {
+      trackCrash(rejectionErrorType(reason), 'unhandledRejection');
+      if (reason instanceof Error) recordedRejections.add(reason);
+    }
+    if (soleListener) {
+      throw reason;
+    }
+  };
+  process.on('unhandledRejection', installedRejectionHandler);
   installed = true;
   return () => {
     uninstallCrashHandlers();
@@ -50,8 +73,17 @@ export function uninstallCrashHandlers(): void {
   if (installedUncaughtHandler !== null) {
     process.off('uncaughtExceptionMonitor', installedUncaughtHandler);
   }
+  if (installedRejectionHandler !== null) {
+    process.off('unhandledRejection', installedRejectionHandler);
+  }
   installedUncaughtHandler = null;
+  installedRejectionHandler = null;
   installed = false;
+}
+
+function rejectionErrorType(reason: unknown): string {
+  if (reason instanceof Error) return reason.name || reason.constructor.name;
+  return typeof reason;
 }
 
 function isAbortError(reason: unknown): boolean {

--- a/packages/telemetry/src/crash.ts
+++ b/packages/telemetry/src/crash.ts
@@ -25,7 +25,8 @@ export function installCrashHandlersForClient(client: TelemetryClient): () => vo
   }
   // Rejections recorded by the rejection handler below and then rethrown to
   // preserve Node's default crash; the monitor must not report them twice.
-  const recordedRejections = new WeakSet<object>();
+  // A Set (not WeakSet) so primitive reasons dedupe by value too.
+  const recordedRejections = new Set<unknown>();
   const trackCrash = (errorType: string, source: string) => {
     try {
       client.track('crash', {
@@ -41,7 +42,9 @@ export function installCrashHandlersForClient(client: TelemetryClient): () => vo
   installedUncaughtHandler = (error, origin) => {
     if (isAbortError(error)) return;
     if (recordedRejections.has(error)) return;
-    trackCrash(error.name || error.constructor.name, origin);
+    // `error` is typed Error but can be anything a rejection rethrow sent
+    // through (primitives, null) — classify it null-safely.
+    trackCrash(crashErrorType(error), origin);
   };
   process.on('uncaughtExceptionMonitor', installedUncaughtHandler);
   // `uncaughtExceptionMonitor` never fires for a rejection that has a
@@ -54,8 +57,8 @@ export function installCrashHandlersForClient(client: TelemetryClient): () => vo
   installedRejectionHandler = (reason: unknown) => {
     const soleListener = process.listenerCount('unhandledRejection') === 1;
     if (!isAbortError(reason)) {
-      trackCrash(rejectionErrorType(reason), 'unhandledRejection');
-      if (reason instanceof Error) recordedRejections.add(reason);
+      trackCrash(crashErrorType(reason), 'unhandledRejection');
+      recordedRejections.add(reason);
     }
     if (soleListener) {
       throw reason;
@@ -81,7 +84,7 @@ export function uninstallCrashHandlers(): void {
   installed = false;
 }
 
-function rejectionErrorType(reason: unknown): string {
+function crashErrorType(reason: unknown): string {
   if (reason instanceof Error) return reason.name || reason.constructor.name;
   return typeof reason;
 }

--- a/packages/telemetry/test/telemetry.test.ts
+++ b/packages/telemetry/test/telemetry.test.ts
@@ -1106,6 +1106,95 @@ describe('crash handler', () => {
     }
   });
 
+  it('dedupes rethrown non-Error rejection reasons at the uncaught monitor', () => {
+    const client = new TelemetryClient();
+    const transport = new RecordingTransport();
+    client.attachSink(makeSink(transport));
+    setCrashPhase('runtime');
+    const others = process.listeners('unhandledRejection');
+    process.removeAllListeners('unhandledRejection');
+    installCrashHandlersForClient(client);
+    const reason = { code: 'E' };
+    try {
+      let caught: unknown;
+      try {
+        (process.emit as (event: string, ...args: unknown[]) => boolean)(
+          'unhandledRejection',
+          reason,
+          Promise.resolve(),
+        );
+      } catch (error) {
+        caught = error;
+      }
+      expect(caught).toBe(reason);
+
+      // The plain-object reason is rethrown through the monitor; it must be
+      // deduped there, not reported as a second crash.
+      (process.emit as (event: string, ...args: unknown[]) => boolean)(
+        'uncaughtExceptionMonitor',
+        reason,
+        'uncaughtException',
+      );
+      expect(transport.saved).toHaveLength(1);
+      expect(transport.saved[0]?.[0]).toMatchObject({
+        event: 'crash',
+        properties: {
+          error_type: 'object',
+          where: 'runtime',
+          source: 'unhandledRejection',
+        },
+      });
+    } finally {
+      uninstallCrashHandlers();
+      for (const listener of others) {
+        process.on('unhandledRejection', listener as (...args: unknown[]) => void);
+      }
+    }
+  });
+
+  it('dedupes null rejection reasons and classifies monitor crashes null-safely', () => {
+    const client = new TelemetryClient();
+    const transport = new RecordingTransport();
+    client.attachSink(makeSink(transport));
+    setCrashPhase('runtime');
+    const others = process.listeners('unhandledRejection');
+    process.removeAllListeners('unhandledRejection');
+    installCrashHandlersForClient(client);
+    try {
+      let caught: unknown = 'not-thrown';
+      try {
+        (process.emit as (event: string, ...args: unknown[]) => boolean)(
+          'unhandledRejection',
+          null,
+          Promise.resolve(),
+        );
+      } catch (error) {
+        caught = error;
+      }
+      expect(caught).toBe(null);
+
+      // The rethrown null reaches the monitor: deduped, and the error-type
+      // classification must not itself throw on null/undefined.
+      expect(() => {
+        emitCrash(null as unknown as Error);
+      }).not.toThrow();
+      expect(transport.saved).toHaveLength(1);
+      expect(transport.saved[0]?.[0]).toMatchObject({
+        event: 'crash',
+        properties: {
+          error_type: 'object',
+          where: 'runtime',
+          source: 'unhandledRejection',
+        },
+      });
+    } finally {
+      uninstallCrashHandlers();
+      for (const listener of others) {
+        process.on('unhandledRejection', listener as (...args: unknown[]) => void);
+      }
+    }
+  });
+
   it('ignores aborted-operation errors', () => {
     const client = new TelemetryClient();
     const transport = new RecordingTransport();

--- a/packages/telemetry/test/telemetry.test.ts
+++ b/packages/telemetry/test/telemetry.test.ts
@@ -1000,7 +1000,7 @@ describe('crash handler', () => {
     ]);
   });
 
-  it('does not register duplicate monitor listeners when installed twice', () => {
+  it('does not register duplicate listeners when installed twice', () => {
     const client = new TelemetryClient();
     const beforeUncaught = process.listenerCount('uncaughtExceptionMonitor');
     const beforeRejection = process.listenerCount('unhandledRejection');
@@ -1009,11 +1009,101 @@ describe('crash handler', () => {
     const uninstallSecond = installCrashHandlersForClient(client);
 
     expect(process.listenerCount('uncaughtExceptionMonitor')).toBe(beforeUncaught + 1);
-    expect(process.listenerCount('unhandledRejection')).toBe(beforeRejection);
+    expect(process.listenerCount('unhandledRejection')).toBe(beforeRejection + 1);
     uninstallSecond();
     uninstallFirst();
     expect(process.listenerCount('uncaughtExceptionMonitor')).toBe(beforeUncaught);
     expect(process.listenerCount('unhandledRejection')).toBe(beforeRejection);
+  });
+
+  it('observes and records unhandled rejections when another handler owns the lifecycle', () => {
+    const client = new TelemetryClient();
+    const transport = new RecordingTransport();
+    client.attachSink(makeSink(transport));
+    setCrashPhase('runtime');
+    installCrashHandlersForClient(client);
+    // The TUI registers its own rejection handler; while one exists the
+    // crash handler must observe (not rethrow) so the lifecycle is untouched.
+    const owner = (): void => {};
+    process.on('unhandledRejection', owner);
+    try {
+      (process.emit as (event: string, ...args: unknown[]) => boolean)(
+        'unhandledRejection',
+        new TypeError('promise failed'),
+        Promise.resolve(),
+      );
+    } finally {
+      process.off('unhandledRejection', owner);
+    }
+
+    expect(transport.saved[0]?.[0]).toMatchObject({
+      event: 'crash',
+      properties: {
+        error_type: 'TypeError',
+        where: 'runtime',
+        source: 'unhandledRejection',
+      },
+    });
+  });
+
+  it('ignores aborted-operation rejections while observing', () => {
+    const client = new TelemetryClient();
+    const transport = new RecordingTransport();
+    client.attachSink(makeSink(transport));
+    installCrashHandlersForClient(client);
+    const owner = (): void => {};
+    process.on('unhandledRejection', owner);
+    try {
+      (process.emit as (event: string, ...args: unknown[]) => boolean)(
+        'unhandledRejection',
+        new DOMException('The operation was aborted.', 'AbortError'),
+        Promise.resolve(),
+      );
+    } finally {
+      process.off('unhandledRejection', owner);
+    }
+
+    expect(transport.saved).toHaveLength(0);
+  });
+
+  it('rethrows when it is the only rejection listener, recording the crash exactly once', () => {
+    const client = new TelemetryClient();
+    const transport = new RecordingTransport();
+    client.attachSink(makeSink(transport));
+    setCrashPhase('runtime');
+    // Vitest keeps its own rejection listeners; temporarily drop every
+    // listener so the crash handler is the sole one, as in print/server mode.
+    const others = process.listeners('unhandledRejection');
+    process.removeAllListeners('unhandledRejection');
+    installCrashHandlersForClient(client);
+    const reason = new TypeError('promise failed');
+    try {
+      expect(() =>
+        (process.emit as (event: string, ...args: unknown[]) => boolean)(
+          'unhandledRejection',
+          reason,
+          Promise.resolve(),
+        ),
+      ).toThrow(reason);
+
+      // Tracked once as a rejection; when the rethrow later surfaces at the
+      // uncaughtException monitor it must not be reported a second time.
+      expect(transport.saved[0]?.[0]).toMatchObject({
+        event: 'crash',
+        properties: {
+          error_type: 'TypeError',
+          where: 'runtime',
+          source: 'unhandledRejection',
+        },
+      });
+      emitCrash(reason);
+      expect(transport.saved).toHaveLength(1);
+    } finally {
+      uninstallCrashHandlers();
+      for (const listener of others) {
+        process.on('unhandledRejection', listener as (...args: unknown[]) => void);
+      }
+    }
   });
 
   it('ignores aborted-operation errors', () => {


### PR DESCRIPTION
## Related Issue

No linked issue — the problem is explained below (from the same user report that led to #1757).

## Problem

A user on 0.24.2 hit repeated "the CLI exited by itself" events — twice in ~80 minutes, once mid-stream, once idle — with zero diagnostics anywhere: nothing in the log, nothing in crash telemetry, no shell signal message, non-zero exit code. Analysis showed every graceful-exit and signal path is ruled out, leaving the TUI's `uncaughtException` / `unhandledRejection` crash path as the only consistent mechanism. That path leaves no evidence by design: the log line is dropped on exit (fixed in #1757), and crash telemetry only listens on `uncaughtExceptionMonitor`, which **never fires for a rejection that has a listener** — and the TUI always registers one, so `unhandledRejection` exits are completely invisible.

While auditing always-on async callbacks that can reject in both streaming and idle states, we also found a concrete crash vector: the Ctrl+V clipboard-image dispatch chains off the async handler with no rejection branch, so any failure inside it becomes an unhandled rejection and takes the whole CLI down via the path above.

## What changed

- **Crash telemetry now observes `unhandledRejection` directly.** Registering a real listener would suppress Node's default crash-on-rejection in modes that have no handler of their own (print / server), so when the crash handler is the only listener it rethrows — preserving the default non-zero exit, deduped so the monitor does not double-report. When another handler owns the lifecycle (the TUI), it records the crash without interfering.
- **Ctrl+V image paste: a rejecting handler now falls back to the normal text-paste path** (same as "no image available") instead of leaking an unhandled rejection.
- Tests: rejection is recorded when another handler exists; AbortError rejections are ignored; sole-listener rethrow keeps Node's default exit semantics and is recorded exactly once; the existing duplicate-registration test now also covers the new listener; editor test proves a rejecting paste handler produces no unhandled rejection and still pastes text.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.
