### PR TITLE
fix(web): keep the sidebar resize handle above the chat composer background

### DIFF
--- a/.changeset/fix-web-sidebar-resize-handle.md
+++ b/.changeset/fix-web-sidebar-resize-handle.md
@@ -2,4 +2,4 @@
 "@moonshot-ai/kimi-code": patch
 ---
 
-web: Fix the sidebar resize handle being hidden behind the chat composer background, so the full blue bar shows on hover and the strip stays draggable.
+web: Fix the sidebar resize handle being covered by the chat composer background.

--- a/.changeset/fix-web-sidebar-resize-handle.md
+++ b/.changeset/fix-web-sidebar-resize-handle.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+web: Fix the sidebar resize handle being hidden behind the chat composer background, so the full blue bar shows on hover and the strip stays draggable.

--- a/apps/kimi-web/src/components/ResizeHandle.vue
+++ b/apps/kimi-web/src/components/ResizeHandle.vue
@@ -69,7 +69,9 @@ watch(dragging, (d) => emit('update:dragging', d));
   touch-action: none;
   /* sits over the 1px column border so the whole 4px strip is grabbable */
   margin: 0 -2px;
-  z-index: var(--z-sticky);
+  /* above pane-level sticky chrome (chat dock, headers at --z-sticky): its 2px
+     overhang into the neighbour pane must stay visible and grabbable */
+  z-index: var(--z-dropdown);
 }
 .rh-bar {
   position: absolute;

--- a/apps/kimi-web/src/views/DesignSystemView.vue
+++ b/apps/kimi-web/src/views/DesignSystemView.vue
@@ -1449,7 +1449,7 @@ onUnmounted(() => {
               <tbody>
                 <tr><td>Width / cursor</td><td>4px / <code>col-resize</code></td></tr>
                 <tr><td>Normal / active</td><td>transparent / <code>accent</code> fill</td></tr>
-                <tr><td>Layer</td><td><code>--z-sticky</code>, over the column border</td></tr>
+                <tr><td>Layer</td><td><code>--z-dropdown</code>, above pane-level sticky chrome (chat dock at <code>--z-sticky</code>) so the overhang stays visible and grabbable</td></tr>
                 <tr><td>Behavior</td><td>panel width follows the pointer 1:1 while dragging (the parent disables transitions to avoid lag); on release it is persisted to localStorage</td></tr>
               </tbody>
             </table>


### PR DESCRIPTION
## Related Issue

None — this is a clear, reproducible bug fix, so the problem is explained below per CONTRIBUTING.

## Problem

In the web UI, hovering the sidebar resize strip only shows a sliver of the blue highlight: the chat composer's dock paints its opaque background over the half of the 4px strip that overhangs the conversation column, so the strip looks cut off and is hard to grab.

Root cause: both the composer dock (`z-index: var(--z-sticky)` = 100) and the resize handle (also 100) compete in the same stacking context, and the dock comes later in DOM order, so its background paints over the handle.

## What changed

Raise the resize handle's `z-index` from `--z-sticky` (100) to `--z-dropdown` (200), so the full strip stays visible and draggable above pane-level sticky chrome (the composer dock and in-pane sticky headers at 100) while remaining under tooltips, overlays, and dropdown menus. One-line change in `ResizeHandle.vue` plus an explanatory comment.

Verified in a live browser against a local server: with a session open and the composer dock spanning the conversation column, the handle is the topmost element at its conversation-side half and the full blue bar renders on hover. `typecheck`, `check:style`, and `oxlint` pass for the web app.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [ ] I have added tests that prove my feature works. (Pure CSS stacking change; the web package has no component-test infrastructure. Verified live in browser instead — see above.)
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update. (Bug fix restoring intended behavior; no documented behavior changes.)