### PR TITLE
fix: honor explicit thinking off on OpenAI-compatible providers

### DIFF
--- a/.changeset/fix-openai-legacy-thinking-off.md
+++ b/.changeset/fix-openai-legacy-thinking-off.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Honor an explicit thinking "off" on OpenAI-compatible (chat completions) providers: it used to be indistinguishable from "never configured", so the history-based auto `reasoning_effort` injection kept the model reasoning (and could leak the field to models that reject it). The provider now also reports the actual current thinking effort ("on"/"off") instead of recording "off" for both.

--- a/packages/agent-core-v2/src/app/llmProtocol/providers/openai-legacy.ts
+++ b/packages/agent-core-v2/src/app/llmProtocol/providers/openai-legacy.ts
@@ -433,7 +433,7 @@ export class OpenAILegacyChatProvider implements ChatProvider {
   private _baseUrl: string | undefined;
   private _defaultHeaders: Record<string, string> | undefined;
   private _reasoningKey: string | undefined;
-  private _reasoningEffort: string | undefined;
+  private _thinkingEffort: ThinkingEffort | undefined;
   private _generationKwargs: OpenAILegacyGenerationKwargs;
   private _toolMessageConversion: ToolMessageConversion;
   private _client: OpenAI | undefined;
@@ -452,7 +452,7 @@ export class OpenAILegacyChatProvider implements ChatProvider {
       normalizedReasoningKey !== undefined && normalizedReasoningKey.length > 0
         ? normalizedReasoningKey
         : undefined;
-    this._reasoningEffort = undefined;
+    this._thinkingEffort = undefined;
     this._generationKwargs =
       options.maxTokens !== undefined ? completionTokenKwargs(this._model, options.maxTokens) : {};
     this._toolMessageConversion = options.toolMessageConversion ?? null;
@@ -467,8 +467,7 @@ export class OpenAILegacyChatProvider implements ChatProvider {
   }
 
   get thinkingEffort(): ThinkingEffort | null {
-    if (this._reasoningEffort === undefined) return null;
-    return this._reasoningEffort === 'none' ? 'off' : this._reasoningEffort;
+    return this._thinkingEffort ?? null;
   }
 
   get maxCompletionTokens(): number | undefined {
@@ -506,9 +505,19 @@ export class OpenAILegacyChatProvider implements ChatProvider {
       this._generationKwargs,
     );
 
-    let reasoningEffort: string | undefined = this._reasoningEffort;
+    // 'off' and 'on' have no wire encoding; only a concrete effort is passed
+    // through. An explicit 'off' must also suppress the history-based
+    // auto-enable below (issue #1616), so it stays distinguishable from
+    // "never configured".
+    const effort = this._thinkingEffort;
+    let reasoningEffort: string | undefined =
+      effort === undefined || effort === 'off' || effort === 'on' ? undefined : effort;
 
-    if (reasoningEffort === undefined && kwargs['reasoning_effort'] === undefined) {
+    if (
+      reasoningEffort === undefined &&
+      effort !== 'off' &&
+      kwargs['reasoning_effort'] === undefined
+    ) {
       const hasThinkPart = history.some((message) =>
         message.content.some((part) => part.type === 'think'),
       );
@@ -560,9 +569,8 @@ export class OpenAILegacyChatProvider implements ChatProvider {
   }
 
   withThinking(effort: ThinkingEffort): OpenAILegacyChatProvider {
-    const reasoningEffort = effort === 'off' || effort === 'on' ? undefined : effort;
     const clone = this._clone();
-    clone._reasoningEffort = reasoningEffort;
+    clone._thinkingEffort = effort;
     return clone;
   }
 

--- a/packages/agent-core-v2/test/app/llmProtocol/providers/openai-legacy.test.ts
+++ b/packages/agent-core-v2/test/app/llmProtocol/providers/openai-legacy.test.ts
@@ -1,0 +1,144 @@
+/**
+ * Scenario: OpenAI-compatible (chat completions) thinking effort encoding.
+ * Responsibilities: encode withThinking onto the wire, keep an explicit 'off'
+ * distinct from "never configured", and report the accurate effort.
+ * Wiring: real v2 OpenAILegacy adapter with only the remote SDK client boundary
+ * replaced by mocks.
+ * Run: pnpm exec vitest run packages/agent-core-v2/test/app/llmProtocol/providers/openai-legacy.test.ts
+ */
+import type { Message } from '#/app/llmProtocol/message';
+import { OpenAILegacyChatProvider } from '#/app/llmProtocol/providers/openai-legacy';
+import { describe, expect, it, vi } from 'vitest';
+
+const USER_TURN: Message = {
+  role: 'user',
+  content: [{ type: 'text', text: 'Think' }],
+  toolCalls: [],
+};
+
+const THINK_HISTORY: Message[] = [
+  { role: 'user', content: [{ type: 'text', text: 'Hello' }], toolCalls: [] },
+  {
+    role: 'assistant',
+    content: [
+      { type: 'think', think: 'Thinking...' },
+      { type: 'text', text: 'Hi!' },
+    ],
+    toolCalls: [],
+  },
+  { role: 'user', content: [{ type: 'text', text: 'How are you?' }], toolCalls: [] },
+];
+
+function createProvider(model = 'gpt-4.1'): OpenAILegacyChatProvider {
+  return new OpenAILegacyChatProvider({
+    model,
+    apiKey: 'test-key',
+    stream: false,
+  });
+}
+
+function makeChatCompletionResponse(model = 'test-model') {
+  return {
+    id: 'chatcmpl-test123',
+    object: 'chat.completion',
+    created: 1234567890,
+    model,
+    choices: [
+      {
+        index: 0,
+        message: { role: 'assistant', content: 'Hello' },
+        finish_reason: 'stop',
+      },
+    ],
+    usage: { prompt_tokens: 10, completion_tokens: 5, total_tokens: 15 },
+  };
+}
+
+async function captureRequestBody(
+  provider: OpenAILegacyChatProvider,
+  history: Message[],
+): Promise<Record<string, unknown>> {
+  let capturedBody: Record<string, unknown> | undefined;
+  (
+    provider as unknown as { _client: { chat: { completions: { create: unknown } } } }
+  )._client.chat.completions.create = vi.fn().mockImplementation((params: unknown) => {
+    capturedBody = params as Record<string, unknown>;
+    return Promise.resolve(makeChatCompletionResponse());
+  });
+
+  const stream = await provider.generate('', [], history);
+  for await (const part of stream) void part;
+
+  if (capturedBody === undefined) {
+    throw new Error('Expected provider.generate() to call chat.completions.create');
+  }
+  return capturedBody;
+}
+
+describe('OpenAILegacyChatProvider withThinking', () => {
+  it('passes a concrete effort through verbatim and reports it', async () => {
+    const provider = createProvider().withThinking('high');
+
+    const body = await captureRequestBody(provider, [USER_TURN]);
+    expect(body['reasoning_effort']).toBe('high');
+    expect(provider.thinkingEffort).toBe('high');
+  });
+
+  it('reports a null thinkingEffort until withThinking is called', () => {
+    expect(createProvider().thinkingEffort).toBeNull();
+  });
+
+  it('sends no reasoning_effort for "on" without ThinkPart history and reports "on"', async () => {
+    const provider = createProvider().withThinking('on');
+
+    const body = await captureRequestBody(provider, [USER_TURN]);
+    expect(body['reasoning_effort']).toBeUndefined();
+    expect(provider.thinkingEffort).toBe('on');
+  });
+
+  it('sends no reasoning_effort for "off" and reports "off"', async () => {
+    const provider = createProvider().withThinking('off');
+
+    const body = await captureRequestBody(provider, [USER_TURN]);
+    expect(body['reasoning_effort']).toBeUndefined();
+    expect(provider.thinkingEffort).toBe('off');
+  });
+
+  it('clears a concrete effort set earlier when turned off', async () => {
+    const provider = createProvider().withThinking('high').withThinking('off');
+    expect(provider.thinkingEffort).toBe('off');
+
+    const body = await captureRequestBody(provider, [USER_TURN]);
+    expect(body['reasoning_effort']).toBeUndefined();
+  });
+
+  it('auto-injects reasoning_effort when ThinkPart history exists and thinking is unconfigured', async () => {
+    // Issue #1616: strict OpenAI-compatible gateways require a paired
+    // reasoning_effort when the history carries reasoning_content.
+    const body = await captureRequestBody(createProvider(), THINK_HISTORY);
+    expect(body['reasoning_effort']).toBe('medium');
+  });
+
+  it('still auto-injects reasoning_effort for an explicit "on"', async () => {
+    const body = await captureRequestBody(createProvider().withThinking('on'), THINK_HISTORY);
+    expect(body['reasoning_effort']).toBe('medium');
+  });
+
+  it('does not auto-inject reasoning_effort when thinking was explicitly turned off', async () => {
+    // An explicit withThinking('off') is not "never configured": with thinking
+    // off, the auto-enable must not switch reasoning back on (or leak the field
+    // to models that reject it).
+    const provider = createProvider().withThinking('off');
+
+    const body = await captureRequestBody(provider, THINK_HISTORY);
+    expect(body['reasoning_effort']).toBeUndefined();
+    expect(provider.thinkingEffort).toBe('off');
+  });
+
+  it('does not overwrite reasoning_effort pinned via withGenerationKwargs', async () => {
+    const provider = createProvider().withGenerationKwargs({ reasoning_effort: 'high' });
+
+    const body = await captureRequestBody(provider, THINK_HISTORY);
+    expect(body['reasoning_effort']).toBe('high');
+  });
+});

--- a/packages/agent-core-v2/test/app/protocol/protocolAdapterRegistry.test.ts
+++ b/packages/agent-core-v2/test/app/protocol/protocolAdapterRegistry.test.ts
@@ -92,9 +92,7 @@ describe('ProtocolAdapterRegistry', () => {
       apiKey: 'sk',
     });
 
-    expect(Reflect.get(provider.withThinking('max'), '_reasoningEffort')).toBe('max');
     expect(provider.withThinking('max').thinkingEffort).toBe('max');
-    expect(Reflect.get(provider.withThinking('medium'), '_reasoningEffort')).toBe('medium');
     expect(provider.withThinking('medium').thinkingEffort).toBe('medium');
   });
 

--- a/packages/kosong/src/providers/openai-legacy.ts
+++ b/packages/kosong/src/providers/openai-legacy.ts
@@ -482,7 +482,7 @@ export class OpenAILegacyChatProvider implements ChatProvider {
   private _baseUrl: string | undefined;
   private _defaultHeaders: Record<string, string> | undefined;
   private _reasoningKey: string | undefined;
-  private _reasoningEffort: string | undefined;
+  private _thinkingEffort: ThinkingEffort | undefined;
   private _generationKwargs: OpenAILegacyGenerationKwargs;
   private _toolMessageConversion: ToolMessageConversion;
   private _client: OpenAI | undefined;
@@ -505,7 +505,7 @@ export class OpenAILegacyChatProvider implements ChatProvider {
       normalizedReasoningKey !== undefined && normalizedReasoningKey.length > 0
         ? normalizedReasoningKey
         : undefined;
-    this._reasoningEffort = undefined;
+    this._thinkingEffort = undefined;
     this._generationKwargs =
       options.maxTokens !== undefined ? completionTokenKwargs(this._model, options.maxTokens) : {};
     this._toolMessageConversion = options.toolMessageConversion ?? null;
@@ -520,8 +520,7 @@ export class OpenAILegacyChatProvider implements ChatProvider {
   }
 
   get thinkingEffort(): ThinkingEffort | null {
-    if (this._reasoningEffort === undefined) return null;
-    return this._reasoningEffort === 'none' ? 'off' : this._reasoningEffort;
+    return this._thinkingEffort ?? null;
   }
 
   get modelParameters(): Record<string, unknown> {
@@ -555,16 +554,27 @@ export class OpenAILegacyChatProvider implements ChatProvider {
       this._generationKwargs,
     );
 
-    // Determine reasoning_effort
-    let reasoningEffort: string | undefined = this._reasoningEffort;
+    // Determine reasoning_effort. 'off' and 'on' have no wire encoding on
+    // chat-completions APIs, so they send no reasoning_effort field; only a
+    // concrete effort (low/medium/high/...) is passed through verbatim.
+    const effort = this._thinkingEffort;
+    let reasoningEffort: string | undefined =
+      effort === undefined || effort === 'off' || effort === 'on' ? undefined : effort;
 
     // Auto-enable reasoning_effort when the history contains ThinkPart but reasoning
     // was not explicitly configured. This prevents server validation errors from APIs
     // (e.g. One API) that require reasoning_effort when messages contain reasoning_content.
     // Skip when the caller already pinned reasoning_effort via withGenerationKwargs —
-    // their value would otherwise be silently overwritten below.
+    // their value would otherwise be silently overwritten below. An explicit 'off'
+    // from withThinking is honored as well: with thinking turned off the
+    // auto-enable must not silently switch reasoning back on (or leak the field
+    // to models that reject it).
     // See: https://github.com/MoonshotAI/kimi-code/issues/1616
-    if (reasoningEffort === undefined && kwargs['reasoning_effort'] === undefined) {
+    if (
+      reasoningEffort === undefined &&
+      effort !== 'off' &&
+      kwargs['reasoning_effort'] === undefined
+    ) {
       const hasThinkPart = history.some((message) =>
         message.content.some((part) => part.type === 'think'),
       );
@@ -618,9 +628,11 @@ export class OpenAILegacyChatProvider implements ChatProvider {
   }
 
   withThinking(effort: ThinkingEffort): OpenAILegacyChatProvider {
-    const reasoningEffort = effort === 'off' || effort === 'on' ? undefined : effort;
     const clone = this._clone();
-    clone._reasoningEffort = reasoningEffort;
+    // Store the requested effort verbatim; the wire encoding is derived per
+    // request so an explicit 'off' stays distinguishable from "never
+    // configured" (which the history-based auto-enable relies on).
+    clone._thinkingEffort = effort;
     return clone;
   }
 

--- a/packages/kosong/test/openai-legacy.test.ts
+++ b/packages/kosong/test/openai-legacy.test.ts
@@ -992,6 +992,43 @@ describe('OpenAILegacyChatProvider', () => {
       expect(maxBody['reasoning_effort']).toBe('max');
       expect(xhighBody['reasoning_effort']).toBe('xhigh');
     });
+
+    it('.withThinking("off") sends no reasoning_effort and reports "off"', async () => {
+      const provider = createProvider().withThinking('off');
+      const history: Message[] = [
+        { role: 'user', content: [{ type: 'text', text: 'Think' }], toolCalls: [] },
+      ];
+      const body = await captureRequestBody(provider, '', [], history);
+
+      expect(body['reasoning_effort']).toBeUndefined();
+      expect(provider.thinkingEffort).toBe('off');
+    });
+
+    it('.withThinking("on") sends no reasoning_effort without ThinkPart history and reports "on"', async () => {
+      const provider = createProvider().withThinking('on');
+      const history: Message[] = [
+        { role: 'user', content: [{ type: 'text', text: 'Think' }], toolCalls: [] },
+      ];
+      const body = await captureRequestBody(provider, '', [], history);
+
+      expect(body['reasoning_effort']).toBeUndefined();
+      expect(provider.thinkingEffort).toBe('on');
+    });
+
+    it('reports a null thinkingEffort until withThinking is called', () => {
+      expect(createProvider().thinkingEffort).toBeNull();
+    });
+
+    it('.withThinking("off") clears a concrete effort set earlier', async () => {
+      const provider = createProvider().withThinking('high').withThinking('off');
+      expect(provider.thinkingEffort).toBe('off');
+
+      const history: Message[] = [
+        { role: 'user', content: [{ type: 'text', text: 'Think' }], toolCalls: [] },
+      ];
+      const body = await captureRequestBody(provider, '', [], history);
+      expect(body['reasoning_effort']).toBeUndefined();
+    });
   });
 
   describe('auto reasoning_effort', () => {
@@ -1081,6 +1118,52 @@ describe('OpenAILegacyChatProvider', () => {
       const body = await captureRequestBody(provider, '', [], history);
 
       expect(body['reasoning_effort']).toBe('high');
+    });
+
+    it('does not auto-inject reasoning_effort when thinking was explicitly turned off', async () => {
+      // An explicit withThinking('off') is not the same as "never configured":
+      // with thinking off, auto-injection must not silently switch reasoning
+      // back on (or leak reasoning_effort to models that reject the field).
+      const provider = createProvider({ model: 'some-model' }).withThinking('off');
+      const history: Message[] = [
+        { role: 'user', content: [{ type: 'text', text: 'Hello' }], toolCalls: [] },
+        {
+          role: 'assistant',
+          content: [
+            { type: 'think', think: 'Thinking...' },
+            { type: 'text', text: 'Hi!' },
+          ],
+          toolCalls: [],
+        },
+        { role: 'user', content: [{ type: 'text', text: 'How are you?' }], toolCalls: [] },
+      ];
+      const body = await captureRequestBody(provider, '', [], history);
+
+      expect(body['reasoning_effort']).toBeUndefined();
+      expect(provider.thinkingEffort).toBe('off');
+    });
+
+    it('still auto-injects reasoning_effort for an explicit "on"', async () => {
+      // 'on' keeps the #1616 behavior: thinking enabled without a concrete
+      // effort still pairs reasoning_effort with ThinkPart history so strict
+      // OpenAI-compatible gateways don't 400.
+      const provider = createProvider({ model: 'some-model' }).withThinking('on');
+      const history: Message[] = [
+        { role: 'user', content: [{ type: 'text', text: 'Hello' }], toolCalls: [] },
+        {
+          role: 'assistant',
+          content: [
+            { type: 'think', think: 'Thinking...' },
+            { type: 'text', text: 'Hi!' },
+          ],
+          toolCalls: [],
+        },
+        { role: 'user', content: [{ type: 'text', text: 'How are you?' }], toolCalls: [] },
+      ];
+      const body = await captureRequestBody(provider, '', [], history);
+
+      expect(body['reasoning_effort']).toBe('medium');
+      expect(provider.thinkingEffort).toBe('on');
     });
   });
 


### PR DESCRIPTION
## Related Issue

No linked issue. Follow-up hardening on top of the #1616 auto-injection workaround; relates to the reasoning-effort audit that also produced #1765.

## Problem

On OpenAI-compatible (chat completions) providers, an explicit thinking "off" collapsed to the same internal state as "never configured": `withThinking('off')` stored `undefined`, exactly like a provider that never saw `withThinking`. The history-based auto `reasoning_effort` injection (introduced for #1616) could not tell the two apart, so:

- With think parts in history, a session whose thinking was explicitly turned **Off** still sent `reasoning_effort: 'medium'` — the UI said Off while the model kept reasoning (and billing for it).
- Switching from a reasoning model to one that rejects the field (e.g. plain gpt-4o) leaked `reasoning_effort` into the next request, producing a 400.
- `thinkingEffort` reported `null` for 'on', 'off', and unset alike, so request records fell back to `'off'` and mislabeled an active 'on' as 'off'.

## What changed

- `OpenAILegacyChatProvider` (both the kosong copy and the vendored agent-core-v2 copy) now stores the requested effort verbatim in `_thinkingEffort`; the wire encoding is derived per request: 'off'/'on' send no field, concrete efforts pass through unchanged.
- The #1616 auto-injection now skips an explicit 'off' (still fires for 'on' and for "never configured", preserving the original workaround where it belongs).
- `thinkingEffort` returns the actual effort, fixing records/telemetry that previously logged 'off' for 'on'.
- Deliberately kept: no `reasoning_effort: 'none'` is sent — OpenAI's support for that value is model-dependent, and a blind 'none' would replace one incompatibility with another.
- Tests: 6 new cases in the existing kosong suite; a new 9-case suite for the vendored agent-core-v2 copy (previously untested); updated two registry assertions that reflected on the removed private field.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.