### PR TITLE
chore: drop changesets merged with the klient facade (#1768)

### DIFF
--- a/.changeset/kap-server-v2-model-channels.md
+++ b/.changeset/kap-server-v2-model-channels.md
@@ -1,6 +1,0 @@
----
-"@moonshot-ai/kap-server": minor
-"@moonshot-ai/kimi-code": patch
----
-
-Expose the model registry and model catalog services on the server's v2 RPC surface so remote clients can manage model configuration and read the provider/model catalog.

--- a/.changeset/klient-global-facade-catalog.md
+++ b/.changeset/klient-global-facade-catalog.md
@@ -1,5 +1,0 @@
----
-"@moonshot-ai/klient": minor
----
-
-Add `models`, `catalog`, and `hostFs` sections to the global facade for model configuration, the provider/model catalog, and host folder browsing, plus a `models.changed` event, `flags.enabledIds()`, and caching of the `env()` snapshot. `auth.refreshProviderModels()` is deprecated in favor of `catalog.refresh({ scope: 'oauth' })`.


### PR DESCRIPTION
## Related Issue

Follow-up to #1768 (merged inadvertently with its release changesets).

## Problem

#1768 landed with two pending changesets (`klient-global-facade-catalog.md` bumping `@moonshot-ai/klient` minor, and `kap-server-v2-model-channels.md` bumping `@moonshot-ai/kap-server` minor + `@moonshot-ai/kimi-code` patch). The klient facade is meant to ship in a later feature release, so the next automated release must not pick up version bumps and changelog entries for it now.

## What changed

- Delete `.changeset/klient-global-facade-catalog.md`.
- Delete `.changeset/kap-server-v2-model-channels.md`.

No code changes — the feature itself stays on `main` as merged in #1768.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.
