### PR TITLE
feat(tui): prepend ReadMediaFile hint when video attachments are present

### DIFF
--- a/apps/kimi-code/src/tui/utils/image-placeholder.ts
+++ b/apps/kimi-code/src/tui/utils/image-placeholder.ts
@@ -89,6 +89,17 @@ export function extractMediaAttachments(
   const tail = text.slice(cursor);
   pushText(parts, tail);
 
+  // When video attachments are present, prepend a prompt hint so the model
+  // knows to use ReadMediaFile rather than writing Python frame-extraction scripts.
+  if (videoAttachmentIds.length > 0) {
+    parts.unshift({
+      type: 'text',
+      text:
+        'Use the ReadMediaFile tool to read and analyze the attached video directly. ' +
+        'Do not write Python scripts or Bash commands to extract frames.',
+    });
+  }
+
   return {
     // Text-only submissions drop the synthesised parts array — the
     // caller's contract is "parts is meaningful iff hasMedia", and

--- a/apps/kimi-code/test/tui/input/image-placeholder.test.ts
+++ b/apps/kimi-code/test/tui/input/image-placeholder.test.ts
@@ -103,12 +103,19 @@ describe('extractMediaAttachments', () => {
       const r = extractMediaAttachments(text, store);
       expect(r.imageAttachmentIds).toEqual([1]);
       expect(r.videoAttachmentIds).toEqual([2]);
-      expect(r.parts[0]).toEqual({ type: 'text', text: 'first ' });
-      expect(r.parts[1]).toEqual({
+      // First part is the video hint (because video is present)
+      expect(r.parts[0]).toEqual({
+        type: 'text',
+        text:
+          'Use the ReadMediaFile tool to read and analyze the attached video directly. ' +
+          'Do not write Python scripts or Bash commands to extract frames.',
+      });
+      expect(r.parts[1]).toEqual({ type: 'text', text: 'first ' });
+      expect(r.parts[2]).toEqual({
         type: 'image_url',
         imageUrl: { url: 'data:image/png;base64,AQ==' },
       });
-      const cachePath = videoPathFromParts(r.parts);
+      const cachePath = videoPathFromParts(r.parts.slice(3));
       expect(cachePath.startsWith(getCacheDir())).toBe(true);
       expect(readFileSync(cachePath, 'utf8')).toBe('video-bytes');
     } finally {
@@ -145,8 +152,9 @@ describe('extractMediaAttachments', () => {
       // The filename drives the cache label; `&` must be escaped in the attribute.
       const att = store.addVideo('video/mp4', srcVideo, 'a&b.mp4');
       const r = extractMediaAttachments(att.placeholder, store);
-      expect(r.parts).toHaveLength(1);
-      const text = (r.parts[0] as TextPart).text;
+      expect(r.parts).toHaveLength(2);
+      // First part is the video hint; second part is the actual tag.
+      const text = (r.parts[1] as TextPart).text;
       expect(text).toMatch(/<video path="[^"]+a&amp;b\.mp4"><\/video>/);
     } finally {
       cleanup();
@@ -165,7 +173,15 @@ describe('extractMediaAttachments', () => {
       const r = extractMediaAttachments(att.placeholder, store);
       expect(r.hasMedia).toBe(true);
       expect(r.videoAttachmentIds).toEqual([1]);
-      const cachePath = videoPathFromParts(r.parts);
+      expect(r.parts).toHaveLength(2);
+      // First part is the video hint
+      expect(r.parts[0]).toEqual({
+        type: 'text',
+        text:
+          'Use the ReadMediaFile tool to read and analyze the attached video directly. ' +
+          'Do not write Python scripts or Bash commands to extract frames.',
+      });
+      const cachePath = videoPathFromParts(r.parts.slice(1));
       // The tag points at the cache, not the original source path.
       expect(cachePath.startsWith(getCacheDir())).toBe(true);
       expect(cachePath).not.toBe(srcVideo);


### PR DESCRIPTION
When users attach a video to a prompt, the model sometimes tries to write Python or Bash scripts to extract frames instead of using the built-in ReadMediaFile tool.

This change prepends a short prompt hint to the message parts whenever video attachments are detected, explicitly asking the model to use ReadMediaFile for direct video analysis.

**Changes:**
- Modified \"extractMediaAttachments\" in \"image-placeholder.ts\" to prepend a hint text part when videoAttachmentIds.length > 0
- Updated unit tests in \"image-placeholder.test.ts\" to expect the new hint part

**Test results:**
- All 19 tests in image-placeholder.test.ts pass

Fixes P0 task: Kimi CLI 视频分析希望默认调用 ReadMediaFile 而不是写 Python 切帧