### PR TITLE
refactor: remove git detection from workspace wire and folder browse

### DIFF
--- a/.changeset/web-drop-workspace-git-badges.md
+++ b/.changeset/web-drop-workspace-git-badges.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+web: Remove per-workspace git repo badges and branch labels; branch, PR, and diff status remain shown for the active session.

--- a/apps/kimi-web/src/api/daemon/client.ts
+++ b/apps/kimi-web/src/api/daemon/client.ts
@@ -1175,8 +1175,6 @@ export class DaemonKimiWebApi implements KimiWebApi {
           name: e.name,
           path: e.path,
           isDir: e.is_dir,
-          isGitRepo: e.is_git_repo,
-          branch: e.branch,
         })),
       };
     } catch {

--- a/apps/kimi-web/src/api/daemon/mappers.ts
+++ b/apps/kimi-web/src/api/daemon/mappers.ts
@@ -117,8 +117,6 @@ export function toAppWorkspace(wire: WireWorkspace): AppWorkspace {
     id: wire.id,
     root: wire.root,
     name: wire.name,
-    isGitRepo: wire.is_git_repo,
-    branch: wire.branch ?? undefined,
     lastOpenedAt: wire.last_opened_at,
     sessionCount: wire.session_count,
   };

--- a/apps/kimi-web/src/api/daemon/wire.ts
+++ b/apps/kimi-web/src/api/daemon/wire.ts
@@ -158,8 +158,6 @@ export interface WireWorkspace {
   id: string;
   root: string;
   name: string;
-  is_git_repo: boolean;
-  branch: string | null;
   last_opened_at?: string;
   session_count: number;
 }
@@ -168,8 +166,6 @@ export interface WireFsBrowseEntry {
   name: string;
   path: string;
   is_dir: boolean;
-  is_git_repo: boolean;
-  branch?: string;
 }
 
 export interface WireFsBrowseResult {

--- a/apps/kimi-web/src/api/types.ts
+++ b/apps/kimi-web/src/api/types.ts
@@ -120,10 +120,6 @@ export interface AppWorkspace {
   root: string;
   /** Display name — defaults to basename(root), may be renamed on the daemon. */
   name: string;
-  /** Whether root is inside a git repository. */
-  isGitRepo: boolean;
-  /** Current branch, when known. */
-  branch?: string;
   /** ISO timestamp of when this workspace was last opened. */
   lastOpenedAt?: string;
   /** Number of sessions belonging to this workspace. */
@@ -135,8 +131,6 @@ export interface FsBrowseEntry {
   name: string;
   path: string;
   isDir: boolean;
-  isGitRepo: boolean;
-  branch?: string;
 }
 
 export interface FsBrowseResult {

--- a/apps/kimi-web/src/components/dialogs/AddWorkspaceDialog.vue
+++ b/apps/kimi-web/src/components/dialogs/AddWorkspaceDialog.vue
@@ -22,7 +22,6 @@ import Dialog from '../ui/Dialog.vue';
 import Button from '../ui/Button.vue';
 import IconButton from '../ui/IconButton.vue';
 import Spinner from '../ui/Spinner.vue';
-import Badge from '../ui/Badge.vue';
 import Icon from '../ui/Icon.vue';
 import Tooltip from '../ui/Tooltip.vue';
 
@@ -62,7 +61,7 @@ const entries = ref<FsBrowseEntry[]>([]);
 // dialog never resizes while searching.
 const filter = ref('');
 const searching = ref(false);
-interface SearchHit { path: string; name: string; rel: string; isGitRepo?: boolean; branch?: string }
+interface SearchHit { path: string; name: string; rel: string }
 const searchResults = ref<SearchHit[]>([]);
 const isSearching = computed(() => filter.value.trim().length > 0);
 let searchToken = 0;
@@ -137,7 +136,7 @@ async function runSearch(query: string): Promise<void> {
       if (!e.isDir) continue;
       const rel = e.path.startsWith(root) ? e.path.slice(root.length).replace(/^\/+/, '') : e.path;
       if (fuzzyMatch(q, rel || e.name)) {
-        hits.push({ path: e.path, name: e.name, rel: rel || e.name, isGitRepo: e.isGitRepo, branch: e.branch });
+        hits.push({ path: e.path, name: e.name, rel: rel || e.name });
         if (hits.length >= SEARCH_MAX_RESULTS) break;
       }
       if (node.depth + 1 < SEARCH_MAX_DEPTH) queue.push({ path: e.path, depth: node.depth + 1 });
@@ -419,9 +418,6 @@ onUnmounted(() => {
             >
               <Icon class="dir-icon" name="folder-closed" size="sm" />
               <span class="folder-name">{{ c.name }}</span>
-              <Badge v-if="c.isGitRepo" variant="info" size="sm">
-                {{ t('workspace.gitTag') }}<span v-if="c.branch" class="git-branch"> {{ c.branch }}</span>
-              </Badge>
             </button>
             <div v-if="pathCandidates.length === 0" class="fl-empty fl-error">
               {{ t('workspace.noPathMatch', { parent: pathParent }) }}
@@ -442,9 +438,6 @@ onUnmounted(() => {
           >
             <Icon class="dir-icon" name="folder-closed" size="sm" />
             <span class="folder-name search-rel">{{ hit.rel }}</span>
-            <Badge v-if="hit.isGitRepo" variant="info" size="sm">
-              {{ t('workspace.gitTag') }}<span v-if="hit.branch" class="git-branch"> {{ hit.branch }}</span>
-            </Badge>
           </button>
           <div v-if="!searching && searchResults.length === 0" class="fl-empty">{{ t('workspace.noFilterMatch', { q: filter.trim() }) }}</div>
           <div v-else-if="searching && searchResults.length === 0" class="fl-loading">{{ t('workspace.searching') }}</div>
@@ -460,9 +453,6 @@ onUnmounted(() => {
           >
             <Icon class="dir-icon" name="folder-closed" size="sm" />
             <span class="folder-name">{{ entry.name }}</span>
-            <Badge v-if="entry.isGitRepo" variant="info" size="sm">
-              {{ t('workspace.gitTag') }}<span v-if="entry.branch" class="git-branch"> {{ entry.branch }}</span>
-            </Badge>
           </button>
           <div v-if="entries.length === 0" class="fl-empty">{{ t('workspace.noSubfolders') }}</div>
         </template>
@@ -603,7 +593,6 @@ onUnmounted(() => {
   white-space: nowrap;
   color: var(--color-text);
 }
-.git-branch { color: var(--color-text-muted); }
 
 /* Degraded mode (daemon can't browse): compact hint under the input box. */
 .degraded-hint {

--- a/apps/kimi-web/src/components/mobile/MobileSwitcherSheet.vue
+++ b/apps/kimi-web/src/components/mobile/MobileSwitcherSheet.vue
@@ -1,7 +1,7 @@
 <!-- apps/kimi-web/src/components/mobile/MobileSwitcherSheet.vue -->
 <!-- Mobile switcher bottom sheet, mirroring the desktop sidebar: a "+ New
      chat" row, then collapsible workspace groups (folder icon + name +
-     branch/path sub-line + per-group "+") with their session rows beneath.
+     path sub-line + per-group "+") with their session rows beneath.
      Tapping a session selects it AND closes the sheet; tapping a group header
      folds it, same as the desktop sidebar. -->
 <script setup lang="ts">
@@ -211,7 +211,7 @@ function onDeleteWorkspace(ws: WorkspaceView): void {
           <div class="mgh-main">
             <span class="mgh-name">{{ g.workspace.name }}</span>
             <Tooltip :text="g.workspace.root">
-              <span class="mgh-path">{{ g.workspace.branch || g.workspace.shortPath }}</span>
+              <span class="mgh-path">{{ g.workspace.shortPath }}</span>
             </Tooltip>
           </div>
 

--- a/apps/kimi-web/src/composables/useKimiWebClient.ts
+++ b/apps/kimi-web/src/composables/useKimiWebClient.ts
@@ -2282,8 +2282,6 @@ const mergedWorkspaces = computed<AppWorkspace[]>(() =>
     workspaces: rawState.workspaces,
     sessions: rawState.sessions,
     hiddenWorkspaceRoots: rawState.hiddenWorkspaceRoots,
-    activeRoot: rawState.sessions.find((s) => s.id === rawState.activeSessionId)?.cwd,
-    activeBranch: gitInfo.value?.branch ?? null,
     sessionsHasMoreByWorkspace: rawState.sessionsHasMoreByWorkspace,
   }),
 );
@@ -2342,7 +2340,6 @@ const workspacesView = computed<WorkspaceView[]>(() => {
     name: w.name,
     root: w.root,
     shortPath: shortenHome(w.root, rawState.fsHome),
-    branch: w.branch,
     sessionCount: w.sessionCount,
   }));
   if (workspaceSortMode.value === 'recent') {

--- a/apps/kimi-web/src/i18n/locales/en/workspace.ts
+++ b/apps/kimi-web/src/i18n/locales/en/workspace.ts
@@ -34,7 +34,6 @@ export default {
   searching: 'Searching…',
   noFilterMatch: 'No subfolders match “{q}”',
   noSubfolders: 'No subfolders here',
-  gitTag: 'git',
   browseHint: 'Click a folder to enter it, then "Open this folder" to add it as a workspace.',
   // Path entry (absolute path typed into the same box)
   checkingPath: 'Checking path…',

--- a/apps/kimi-web/src/i18n/locales/zh/workspace.ts
+++ b/apps/kimi-web/src/i18n/locales/zh/workspace.ts
@@ -34,7 +34,6 @@ export default {
   searching: '搜索中…',
   noFilterMatch: '没有匹配「{q}」的子文件夹',
   noSubfolders: '此处没有子文件夹',
-  gitTag: 'git',
   browseHint: '点击文件夹进入，再点"打开此文件夹"将其添加为工作区。',
   // Path entry (absolute path typed into the same box)
   checkingPath: '检查路径…',

--- a/apps/kimi-web/src/lib/mergeWorkspaces.ts
+++ b/apps/kimi-web/src/lib/mergeWorkspaces.ts
@@ -24,10 +24,6 @@ export interface MergeWorkspacesInput {
   sessions: Pick<AppSession, 'id' | 'cwd' | 'workspaceId'>[];
   /** Root paths the user removed from the sidebar. */
   hiddenWorkspaceRoots: string[];
-  /** cwd of the active session, used to hint the branch on the active workspace. */
-  activeRoot: string | undefined;
-  /** Live git branch of the active session, or null when unknown. */
-  activeBranch: string | null;
   /** Per-workspace "server has more sessions" flag; false means the local
    *  session count is exact. */
   sessionsHasMoreByWorkspace: Record<string, boolean>;
@@ -43,8 +39,6 @@ export function mergeWorkspaces(input: MergeWorkspacesInput): AppWorkspace[] {
     workspaces,
     sessions,
     hiddenWorkspaceRoots,
-    activeRoot,
-    activeBranch,
     sessionsHasMoreByWorkspace,
   } = input;
 
@@ -73,7 +67,6 @@ export function mergeWorkspaces(input: MergeWorkspacesInput): AppWorkspace[] {
         id: s.workspaceId ?? root,
         root,
         name: basename(root),
-        isGitRepo: false,
         sessionCount: 0,
       });
     }
@@ -111,9 +104,7 @@ export function mergeWorkspaces(input: MergeWorkspacesInput): AppWorkspace[] {
       sessionsHasMoreByWorkspace[w.id] === false
         ? localCount
         : Math.max(w.sessionCount, localCount);
-    let branch = w.branch;
-    if (!branch && activeBranch && activeRoot === w.root) branch = activeBranch;
-    result.push({ ...w, sessionCount: count, branch });
+    result.push({ ...w, sessionCount: count });
   }
   return result;
 }

--- a/apps/kimi-web/src/types.ts
+++ b/apps/kimi-web/src/types.ts
@@ -60,8 +60,6 @@ export interface WorkspaceView {
   root: string;
   /** Home-shortened path for dim display, e.g. `~/code/kimi-code-web`. */
   shortPath: string;
-  /** Current branch, when known. */
-  branch?: string;
   /** Number of sessions in this workspace. */
   sessionCount: number;
 }

--- a/apps/kimi-web/test/event-batcher.test.ts
+++ b/apps/kimi-web/test/event-batcher.test.ts
@@ -697,7 +697,6 @@ describe('useKimiWebClient (resync integration)', () => {
           id: 'workspace-1',
           root: '/workspace',
           name: 'Workspace',
-          isGitRepo: false,
           sessionCount: 1,
         },
       ]),

--- a/apps/kimi-web/test/workspace-state.test.ts
+++ b/apps/kimi-web/test/workspace-state.test.ts
@@ -190,7 +190,7 @@ function installStorage(storage: Storage): void {
 }
 
 function workspace(id: string, root: string, name: string) {
-  return { id, root, name, isGitRepo: false, sessionCount: 0 };
+  return { id, root, name, sessionCount: 0 };
 }
 
 function questionRequest(questionId: string): AppQuestionRequest {
@@ -416,14 +416,12 @@ describe('mergeWorkspaces', () => {
       workspaces: [
         // Server orders by last_opened_at desc, so the most recently opened
         // (typically the canonical re-add) comes first.
-        { id: 'wd_current', root: '/agent/GEO', name: 'GEO', isGitRepo: false, sessionCount: 0 },
-        { id: 'wd_legacy', root: '/agent/GEO', name: 'GEO', isGitRepo: false, sessionCount: 0 },
+        { id: 'wd_current', root: '/agent/GEO', name: 'GEO', sessionCount: 0 },
+        { id: 'wd_legacy', root: '/agent/GEO', name: 'GEO', sessionCount: 0 },
       ],
       // A session whose daemon workspace_id points at the dropped (legacy) entry.
       sessions: [{ id: 's1', cwd: '/agent/GEO', workspaceId: 'wd_legacy' }],
       hiddenWorkspaceRoots: [],
-      activeRoot: undefined,
-      activeBranch: null,
       sessionsHasMoreByWorkspace: { wd_current: false },
     });
 
@@ -438,15 +436,13 @@ describe('mergeWorkspaces', () => {
   it('keeps distinct roots separate and appends derived cwds after real ones', () => {
     const result = mergeWorkspaces({
       workspaces: [
-        { id: 'wd_a', root: '/agent/A', name: 'A', isGitRepo: false, sessionCount: 1 },
+        { id: 'wd_a', root: '/agent/A', name: 'A', sessionCount: 1 },
       ],
       sessions: [
         { id: 's1', cwd: '/agent/A', workspaceId: 'wd_a' },
         { id: 's2', cwd: '/agent/B', workspaceId: 'wd_b' },
       ],
       hiddenWorkspaceRoots: [],
-      activeRoot: undefined,
-      activeBranch: null,
       sessionsHasMoreByWorkspace: {},
     });
 
@@ -457,12 +453,10 @@ describe('mergeWorkspaces', () => {
   it('hides workspaces whose root the user removed', () => {
     const result = mergeWorkspaces({
       workspaces: [
-        { id: 'wd_a', root: '/agent/A', name: 'A', isGitRepo: false, sessionCount: 1 },
+        { id: 'wd_a', root: '/agent/A', name: 'A', sessionCount: 1 },
       ],
       sessions: [{ id: 's1', cwd: '/agent/A', workspaceId: 'wd_a' }],
       hiddenWorkspaceRoots: ['/agent/A'],
-      activeRoot: undefined,
-      activeBranch: null,
       sessionsHasMoreByWorkspace: {},
     });
 
@@ -551,7 +545,6 @@ describe('useWorkspaceState — addWorkspaceByPath', () => {
       id: 'wd_abc',
       root: '/abs/path',
       name: 'path',
-      isGitRepo: false,
       sessionCount: 0,
     };
     apiMock.addWorkspace.mockResolvedValue(registered);
@@ -731,7 +724,7 @@ describe('useWorkspaceState — cancelTask', () => {
 });
 
 describe('useWorkspaceState — startSessionAndActivateSkill', () => {
-  const registered = { id: 'wd_1', root: '/abs/path', name: 'A', isGitRepo: false, sessionCount: 0 };
+  const registered = { id: 'wd_1', root: '/abs/path', name: 'A', sessionCount: 0 };
   const newSession = { ...createSession(), id: 'sess_new', workspaceId: 'wd_1', cwd: '/abs/path' };
 
   beforeEach(() => {
@@ -873,7 +866,7 @@ describe('useWorkspaceState — startSessionAndActivateSkill', () => {
 });
 
 describe('useWorkspaceState — createGoal from an empty composer', () => {
-  const registered = { id: 'wd_1', root: '/abs/path', name: 'A', isGitRepo: false, sessionCount: 0 };
+  const registered = { id: 'wd_1', root: '/abs/path', name: 'A', sessionCount: 0 };
   const newSession = { ...createSession(), id: 'sess_new', workspaceId: 'wd_1', cwd: '/abs/path' };
 
   beforeEach(() => {
@@ -1047,7 +1040,7 @@ describe('useWorkspaceState — createGoal from an empty composer', () => {
 });
 
 describe('useWorkspaceState — startSessionAndOpenSideChat', () => {
-  const registered = { id: 'wd_1', root: '/abs/path', name: 'A', isGitRepo: false, sessionCount: 0 };
+  const registered = { id: 'wd_1', root: '/abs/path', name: 'A', sessionCount: 0 };
   const newSession = { ...createSession(), id: 'sess_new', workspaceId: 'wd_1', cwd: '/abs/path' };
 
   beforeEach(() => {

--- a/packages/agent-core-v2/src/app/hostFolderBrowser/hostFolderBrowser.ts
+++ b/packages/agent-core-v2/src/app/hostFolderBrowser/hostFolderBrowser.ts
@@ -25,8 +25,6 @@ export const fsBrowseEntrySchema = z.object({
   name: z.string().min(1),
   path: z.string().min(1),
   is_dir: z.literal(true),
-  is_git_repo: z.boolean(),
-  branch: z.string().optional(),
 });
 export type FsBrowseEntry = z.infer<typeof fsBrowseEntrySchema>;
 

--- a/packages/agent-core-v2/src/app/hostFolderBrowser/hostFolderBrowserService.ts
+++ b/packages/agent-core-v2/src/app/hostFolderBrowser/hostFolderBrowserService.ts
@@ -5,10 +5,10 @@
  * `recent_roots` from the process-wide `IWorkspaceRegistry`. Bound at App
  * scope. Mirrors the v1 `WorkspaceFsService` behaviour so the `/api/v1`
  * transport stays wire-compatible: realpath resolution, directory-only
- * entries, git metadata, dot-last sorting, and `parent` resolution.
+ * entries, dot-last sorting, and `parent` resolution.
  */
 
-import { lstat, readFile, readdir, realpath } from 'node:fs/promises';
+import { readdir, realpath } from 'node:fs/promises';
 import { homedir } from 'node:os';
 import { dirname, isAbsolute, join } from 'node:path';
 
@@ -51,20 +51,13 @@ export class HostFolderBrowser implements IHostFolderBrowser {
       throw mapFsError(err, realTarget);
     }
 
-    const dirOnly = dirents.filter((d) => d.isDirectory());
-    const entries: FsBrowseEntry[] = await Promise.all(
-      dirOnly.map(async (d) => {
-        const childAbs = join(realTarget, d.name);
-        const git = await detectGit(childAbs);
-        return {
-          name: d.name,
-          path: childAbs,
-          is_dir: true as const,
-          is_git_repo: git.is_git_repo,
-          branch: git.branch ?? undefined,
-        };
-      }),
-    );
+    const entries: FsBrowseEntry[] = dirents
+      .filter((d) => d.isDirectory())
+      .map((d) => ({
+        name: d.name,
+        path: join(realTarget, d.name),
+        is_dir: true as const,
+      }));
 
     entries.sort(compareBrowseEntries);
 
@@ -100,51 +93,6 @@ function compareBrowseEntries(a: FsBrowseEntry, b: FsBrowseEntry): number {
   const bDot = b.name.startsWith('.');
   if (aDot !== bDot) return aDot ? 1 : -1;
   return a.name.localeCompare(b.name);
-}
-
-interface GitInfo {
-  readonly is_git_repo: boolean;
-  readonly branch: string | null;
-}
-
-async function detectGit(root: string): Promise<GitInfo> {
-  let dotGit;
-  try {
-    dotGit = await lstat(join(root, '.git'));
-  } catch {
-    return { is_git_repo: false, branch: null };
-  }
-
-  let gitDir: string;
-  if (dotGit.isDirectory()) {
-    gitDir = join(root, '.git');
-  } else if (dotGit.isFile()) {
-    let text: string;
-    try {
-      text = await readFile(join(root, '.git'), 'utf8');
-    } catch {
-      return { is_git_repo: false, branch: null };
-    }
-    const m = /^gitdir:\s*(.+)$/m.exec(text);
-    if (m === null) return { is_git_repo: false, branch: null };
-    const ref = m[1] ?? '';
-    if (ref === '') return { is_git_repo: false, branch: null };
-    gitDir = ref.trim();
-    if (!gitDir.startsWith('/')) {
-      gitDir = join(root, gitDir);
-    }
-  } else {
-    return { is_git_repo: false, branch: null };
-  }
-
-  let head: string;
-  try {
-    head = (await readFile(join(gitDir, 'HEAD'), 'utf8')).trim();
-  } catch {
-    return { is_git_repo: true, branch: null };
-  }
-  const ref = /^ref:\s*refs\/heads\/(.+)$/.exec(head);
-  return { is_git_repo: true, branch: ref ? (ref[1] ?? null) : null };
 }
 
 registerScopedService(

--- a/packages/agent-core/src/services/index.ts
+++ b/packages/agent-core/src/services/index.ts
@@ -86,7 +86,7 @@ export {
   WorkspaceRootNotFoundError,
 } from './workspace/workspaceRegistry';
 export type { WorkspacePatch } from './workspace/workspaceRegistry';
-export { WorkspaceRegistryService, detectGit } from './workspace/workspaceRegistryService';
+export { WorkspaceRegistryService } from './workspace/workspaceRegistryService';
 export {
   IWorkspaceFsService,
   WorkspaceFsNotAbsoluteError,

--- a/packages/agent-core/src/services/workspace/index.ts
+++ b/packages/agent-core/src/services/workspace/index.ts
@@ -4,7 +4,7 @@ export {
   WorkspaceRootNotFoundError,
   type WorkspacePatch,
 } from './workspaceRegistry';
-export { WorkspaceRegistryService, detectGit } from './workspaceRegistryService';
+export { WorkspaceRegistryService } from './workspaceRegistryService';
 export {
   IWorkspaceFsService,
   WorkspaceFsNotAbsoluteError,

--- a/packages/agent-core/src/services/workspace/workspaceFsService.ts
+++ b/packages/agent-core/src/services/workspace/workspaceFsService.ts
@@ -16,7 +16,6 @@ import {
   WorkspaceFsNotFoundError,
   WorkspaceFsPermissionError,
 } from './workspaceFs';
-import { detectGit } from './workspaceRegistryService';
 
 export class WorkspaceFsService extends Disposable implements IWorkspaceFsService {
   readonly _serviceBrand: undefined;
@@ -46,22 +45,11 @@ export class WorkspaceFsService extends Disposable implements IWorkspaceFsServic
     }
     const dirOnly = dirents.filter((d) => d.isDirectory());
 
-    const entries: FsBrowseEntry[] = await Promise.all(
-      dirOnly.map(async (d) => {
-        const childAbs = join(realTarget, d.name);
-        const git = await detectGit(childAbs);
-        const base: FsBrowseEntry = {
-          name: d.name,
-          path: childAbs,
-          is_dir: true,
-          is_git_repo: git.is_git_repo,
-        };
-        if (git.branch !== null) {
-          return { ...base, branch: git.branch };
-        }
-        return base;
-      }),
-    );
+    const entries: FsBrowseEntry[] = dirOnly.map((d) => ({
+      name: d.name,
+      path: join(realTarget, d.name),
+      is_dir: true,
+    }));
 
     entries.sort(compareBrowseEntries);
 

--- a/packages/agent-core/src/services/workspace/workspaceRegistryService.ts
+++ b/packages/agent-core/src/services/workspace/workspaceRegistryService.ts
@@ -243,16 +243,12 @@ export class WorkspaceRegistryService extends Disposable implements IWorkspaceRe
     entry: WorkspaceRegistryEntry,
     sessionCount?: number,
   ): Promise<Workspace> {
-    const [{ is_git_repo, branch }, session_count] = await Promise.all([
-      detectGit(entry.root),
-      sessionCount ?? countActiveSessions(join(this.sessionsDir, workspaceId)),
-    ]);
+    const session_count =
+      sessionCount ?? (await countActiveSessions(join(this.sessionsDir, workspaceId)));
     return {
       id: workspaceId,
       root: entry.root,
       name: entry.name,
-      is_git_repo,
-      branch,
       created_at: entry.created_at,
       last_opened_at: entry.last_opened_at,
       session_count,
@@ -305,52 +301,6 @@ export class WorkspaceRegistryService extends Disposable implements IWorkspaceRe
     if (this._store.isDisposed) return;
     super.dispose();
   }
-}
-
-export interface GitInfo {
-  is_git_repo: boolean;
-  branch: string | null;
-}
-
-export async function detectGit(root: string): Promise<GitInfo> {
-  let dotGit: Stats;
-  try {
-    dotGit = await fsp.lstat(join(root, '.git'));
-  } catch {
-    return { is_git_repo: false, branch: null };
-  }
-
-  let gitDir: string;
-  if (dotGit.isDirectory()) {
-    gitDir = join(root, '.git');
-  } else if (dotGit.isFile()) {
-    let text: string;
-    try {
-      text = await fsp.readFile(join(root, '.git'), 'utf8');
-    } catch {
-      return { is_git_repo: false, branch: null };
-    }
-    const m = /^gitdir:\s*(.+)$/m.exec(text);
-    if (m === null) return { is_git_repo: false, branch: null };
-    const ref = m[1] ?? '';
-    if (ref === '') return { is_git_repo: false, branch: null };
-    gitDir = ref.trim();
-
-    if (!gitDir.startsWith('/')) {
-      gitDir = join(root, gitDir);
-    }
-  } else {
-    return { is_git_repo: false, branch: null };
-  }
-
-  let head: string;
-  try {
-    head = (await fsp.readFile(join(gitDir, 'HEAD'), 'utf8')).trim();
-  } catch {
-    return { is_git_repo: true, branch: null };
-  }
-  const ref = /^ref:\s*refs\/heads\/(.+)$/.exec(head);
-  return { is_git_repo: true, branch: ref ? (ref[1] ?? null) : null };
 }
 
 async function countActiveSessions(dir: string): Promise<number> {

--- a/packages/kap-server/src/protocol/workspace.ts
+++ b/packages/kap-server/src/protocol/workspace.ts
@@ -14,8 +14,6 @@ export const workspaceSchema = z.object({
   id: workspaceIdSchema,
   root: z.string().min(1),
   name: z.string().min(1).max(100),
-  is_git_repo: z.boolean(),
-  branch: z.string().nullable(),
   created_at: isoDateTimeSchema,
   last_opened_at: isoDateTimeSchema,
   session_count: z.number().int().nonnegative(),

--- a/packages/kap-server/src/routes/workspaceFs.ts
+++ b/packages/kap-server/src/routes/workspaceFs.ts
@@ -14,7 +14,7 @@
  *
  * Routes (registered exactly as v1 declares them):
  *
- *   GET /fs::browse?path=<abs-path>   list sub-directories (+ git metadata)
+ *   GET /fs::browse?path=<abs-path>   list sub-directories
  *   GET /fs::home                     $HOME + recent workspace roots
  *
  * **Wire path vs source path.** The source path strings carry a double colon

--- a/packages/kap-server/src/routes/workspaces.ts
+++ b/packages/kap-server/src/routes/workspaces.ts
@@ -3,7 +3,7 @@
  *
  * Implements the v1 `/api/v1/workspaces` wire contract on top of
  * `agent-core-v2` services. Backed by `IWorkspaceRegistry` (Core scope) for the
- * catalog, `IHostFileSystem` to validate roots and detect git, and
+ * catalog, `IHostFileSystem` to validate roots, and
  * `ISessionIndex` to derive `session_count`.
  *
  *   GET    /workspaces                    list
@@ -14,10 +14,6 @@
  * **Wire fidelity**: the v1 `workspaceSchema` carries more fields than v2's
  * `Workspace` (`{ id, root, name, createdAt, lastOpenedAt }`). The handler
  * projects the v2 record onto the v1 shape, deriving the extra fields:
- *   - `is_git_repo` / `branch` — best-effort `.git` detection; `branch` is
- *     parsed from `.git/HEAD` (`ref: refs/heads/<branch>`), resolving the
- *     real git dir through a `.git` file for worktrees/submodules. Matches the
- *     v1 `agent-core` probe.
  *   - `created_at` / `last_opened_at` — from the registry's in-memory
  *     timestamps (reset on restart; the registry is still a skeleton).
  *   - `session_count` — count of persisted sessions for the workspace.
@@ -30,7 +26,7 @@ import {
   type Scope,
   type Workspace,
 } from '@moonshot-ai/agent-core-v2';
-import { isAbsolute, join } from 'node:path';
+import { isAbsolute } from 'node:path';
 
 import { z } from 'zod';
 
@@ -224,58 +220,15 @@ export function registerWorkspacesRoutes(app: WorkspaceRouteHost, core: Scope): 
 // ---------------------------------------------------------------------------
 
 async function toWireWorkspace(core: Scope, ws: Workspace): Promise<WorkspaceWire> {
-  const [git, sessionCount] = await Promise.all([
-    detectGit(core, ws.root),
-    countSessions(core, ws.id),
-  ]);
+  const sessionCount = await countSessions(core, ws.id);
   return {
     id: ws.id,
     root: ws.root,
     name: ws.name,
-    is_git_repo: git.isGitRepo,
-    branch: git.branch,
     created_at: new Date(ws.createdAt).toISOString(),
     last_opened_at: new Date(ws.lastOpenedAt).toISOString(),
     session_count: sessionCount,
   };
-}
-
-async function detectGit(
-  core: Scope,
-  root: string,
-): Promise<{ isGitRepo: boolean; branch: string | null }> {
-  // Mirror the v1 `agent-core` git probe: confirm `.git`, resolve the real git
-  // dir (a `.git` *file* in worktrees/submodules points at it via `gitdir:`),
-  // then read `<gitDir>/HEAD` and peel off `ref: refs/heads/<branch>`. Every
-  // step is best-effort so a missing/unreadable piece degrades to `null`
-  // rather than failing the projection.
-  const hostFs = core.accessor.get(IHostFileSystem);
-
-  const dotGit = await hostFs.stat(join(root, '.git')).catch(() => null);
-  if (dotGit === null) {
-    return { isGitRepo: false, branch: null };
-  }
-
-  let gitDir: string;
-  if (dotGit.isDirectory) {
-    gitDir = join(root, '.git');
-  } else if (dotGit.isFile) {
-    const text = await hostFs.readText(join(root, '.git')).catch(() => null);
-    const ref = (text === null ? '' : /^gitdir:\s*(.+)$/m.exec(text)?.[1] ?? '').trim();
-    if (ref === '') {
-      return { isGitRepo: false, branch: null };
-    }
-    gitDir = ref.startsWith('/') ? ref : join(root, ref);
-  } else {
-    return { isGitRepo: false, branch: null };
-  }
-
-  const head = await hostFs.readText(join(gitDir, 'HEAD')).catch(() => null);
-  if (head === null) {
-    return { isGitRepo: true, branch: null };
-  }
-  const branch = /^ref:\s*refs\/heads\/(.+)$/.exec(head.trim())?.[1] ?? null;
-  return { isGitRepo: true, branch };
 }
 
 async function countSessions(core: Scope, workspaceId: string): Promise<number> {

--- a/packages/kap-server/test/workspaceFs.test.ts
+++ b/packages/kap-server/test/workspaceFs.test.ts
@@ -19,8 +19,6 @@ interface BrowseEntryWire {
   name: string;
   path: string;
   is_dir: true;
-  is_git_repo: boolean;
-  branch?: string;
 }
 
 interface BrowseWire {
@@ -129,26 +127,7 @@ describe('server-v2 /api/v1 fs folder picker', () => {
     for (const entry of body.data.entries) {
       expect(entry.is_dir).toBe(true);
       expect(entry.path).toBe(join(await realpath(root), entry.name));
-      expect(typeof entry.is_git_repo).toBe('boolean');
     }
-  });
-
-  it('annotates git repositories with the current branch', async () => {
-    const root = home as string;
-    const repo = join(root, 'repo');
-    await mkdir(join(repo, '.git'), { recursive: true });
-    await writeFile(join(repo, '.git', 'HEAD'), 'ref: refs/heads/main\n');
-    await mkdir(join(root, 'plain'));
-
-    const { body } = await getJson<BrowseWire>(
-      `/api/v1/fs:browse?path=${encodeURIComponent(root)}`,
-    );
-    expect(body.code).toBe(0);
-    const byName = new Map(body.data.entries.map((e) => [e.name, e]));
-    expect(byName.get('repo')?.is_git_repo).toBe(true);
-    expect(byName.get('repo')?.branch).toBe('main');
-    expect(byName.get('plain')?.is_git_repo).toBe(false);
-    expect(byName.get('plain')?.branch).toBeUndefined();
   });
 
   it('sorts dot-directories after regular ones', async () => {

--- a/packages/kap-server/test/workspaces.test.ts
+++ b/packages/kap-server/test/workspaces.test.ts
@@ -1,4 +1,4 @@
-import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { mkdtemp, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
@@ -19,8 +19,6 @@ interface WorkspaceWire {
   id: string;
   root: string;
   name: string;
-  is_git_repo: boolean;
-  branch: string | null;
   created_at: string;
   last_opened_at: string;
   session_count: number;
@@ -100,12 +98,6 @@ describe('server-v2 /api/v1/workspaces', () => {
     return { status: res.status, body: (await res.json()) as Envelope<T> };
   }
 
-  /** Lay down a minimal git fixture: `.git/HEAD` referring to a branch. */
-  async function makeGitRepo(root: string, branch: string): Promise<void> {
-    await mkdir(join(root, '.git'), { recursive: true });
-    await writeFile(join(root, '.git', 'HEAD'), `ref: refs/heads/${branch}\n`, 'utf8');
-  }
-
   it('creates a workspace with the full wire shape', async () => {
     const root = home as string;
     const { status, body } = await postJson<WorkspaceWire>('/api/v1/workspaces', {
@@ -117,43 +109,9 @@ describe('server-v2 /api/v1/workspaces', () => {
     expect(body.data.root).toBe(root);
     expect(body.data.name).toBe('proj');
     expect(body.data.id).toMatch(/^wd_[a-z0-9._-]+_[0-9a-f]{12}$/);
-    expect(typeof body.data.is_git_repo).toBe('boolean');
-    expect(body.data.branch).toBeNull();
     expect(typeof body.data.session_count).toBe('number');
     expect(Number.isNaN(Date.parse(body.data.created_at))).toBe(false);
     expect(Number.isNaN(Date.parse(body.data.last_opened_at))).toBe(false);
-  });
-
-  it('resolves branch from .git/HEAD (and null when detached)', async () => {
-    const repo = join(home as string, 'repo');
-    await makeGitRepo(repo, 'feature/x');
-    const created = await postJson<WorkspaceWire>('/api/v1/workspaces', { root: repo });
-    expect(created.body.data.is_git_repo).toBe(true);
-    expect(created.body.data.branch).toBe('feature/x');
-
-    const detached = join(home as string, 'detached');
-    await mkdir(join(detached, '.git'), { recursive: true });
-    await writeFile(
-      join(detached, '.git', 'HEAD'),
-      '0123456789abcdef0123456789abcdef01234567\n',
-      'utf8',
-    );
-    const det = await postJson<WorkspaceWire>('/api/v1/workspaces', { root: detached });
-    expect(det.body.data.is_git_repo).toBe(true);
-    expect(det.body.data.branch).toBeNull();
-  });
-
-  it('resolves branch through a .git worktree file', async () => {
-    const root = join(home as string, 'worktree');
-    const realGitDir = join(home as string, 'real-git');
-    await mkdir(realGitDir, { recursive: true });
-    await writeFile(join(realGitDir, 'HEAD'), 'ref: refs/heads/wt-branch\n', 'utf8');
-    await mkdir(root, { recursive: true });
-    await writeFile(join(root, '.git'), `gitdir: ${realGitDir}\n`, 'utf8');
-
-    const { body } = await postJson<WorkspaceWire>('/api/v1/workspaces', { root });
-    expect(body.data.is_git_repo).toBe(true);
-    expect(body.data.branch).toBe('wt-branch');
   });
 
   it('derives the default name from the root when name is omitted', async () => {

--- a/packages/klient/src/contract/global/hostFs.ts
+++ b/packages/klient/src/contract/global/hostFs.ts
@@ -12,8 +12,6 @@ export const fsBrowseEntrySchema = z.object({
   name: z.string().min(1),
   path: z.string().min(1),
   is_dir: z.literal(true),
-  is_git_repo: z.boolean(),
-  branch: z.string().optional(),
 });
 
 export const fsBrowseResponseSchema = z.object({

--- a/packages/protocol/src/__tests__/events.test.ts
+++ b/packages/protocol/src/__tests__/events.test.ts
@@ -182,8 +182,6 @@ describe('events / display re-exports', () => {
       id: 'wd_project_123456abcdef',
       root: '/tmp/project',
       name: 'project',
-      is_git_repo: true,
-      branch: 'main',
       created_at: '2026-06-11T00:00:00.000Z',
       last_opened_at: '2026-06-11T00:00:00.000Z',
       session_count: 1,

--- a/packages/protocol/src/__tests__/rest-fs-browse.test.ts
+++ b/packages/protocol/src/__tests__/rest-fs-browse.test.ts
@@ -24,23 +24,11 @@ describe('fsBrowseQuerySchema', () => {
 });
 
 describe('fsBrowseEntrySchema', () => {
-  it('round-trips a non-git dir entry without branch', () => {
+  it('round-trips a dir entry', () => {
     const entry = {
       name: 'src',
       path: '/Users/foo/code/src',
       is_dir: true as const,
-      is_git_repo: false,
-    };
-    expect(fsBrowseEntrySchema.parse(entry)).toEqual(entry);
-  });
-
-  it('round-trips a git dir entry with branch', () => {
-    const entry = {
-      name: 'kimi-code',
-      path: '/Users/foo/code/kimi-code',
-      is_dir: true as const,
-      is_git_repo: true,
-      branch: 'main',
     };
     expect(fsBrowseEntrySchema.parse(entry)).toEqual(entry);
   });
@@ -50,7 +38,6 @@ describe('fsBrowseEntrySchema', () => {
       name: 'README.md',
       path: '/Users/foo/code/README.md',
       is_dir: false,
-      is_git_repo: false,
     };
     expect(fsBrowseEntrySchema.safeParse(bad).success).toBe(false);
   });
@@ -66,8 +53,6 @@ describe('fsBrowseResponseSchema', () => {
           name: 'kimi-code',
           path: '/Users/foo/code/kimi-code',
           is_dir: true as const,
-          is_git_repo: true,
-          branch: 'main',
         },
       ],
     };

--- a/packages/protocol/src/__tests__/rest-workspace.test.ts
+++ b/packages/protocol/src/__tests__/rest-workspace.test.ts
@@ -13,8 +13,6 @@ const sampleWorkspace: Workspace = {
   id: 'wd_kimi-code_0123456789ab',
   root: '/Users/foo/code/kimi-code',
   name: 'kimi-code',
-  is_git_repo: true,
-  branch: 'main',
   created_at: '2026-06-08T09:00:00.000Z',
   last_opened_at: '2026-06-08T09:30:00.000Z',
   session_count: 3,
@@ -47,11 +45,6 @@ describe('workspaceIdSchema', () => {
 describe('workspaceSchema', () => {
   it('round-trips a fully populated Workspace', () => {
     expect(workspaceSchema.parse(sampleWorkspace)).toEqual(sampleWorkspace);
-  });
-
-  it('accepts branch=null (detached HEAD / no git)', () => {
-    const detached = { ...sampleWorkspace, is_git_repo: true, branch: null };
-    expect(workspaceSchema.parse(detached).branch).toBeNull();
   });
 
   it('rejects name longer than 100 chars', () => {

--- a/packages/protocol/src/rest/fsBrowse.ts
+++ b/packages/protocol/src/rest/fsBrowse.ts
@@ -22,8 +22,6 @@ export const fsBrowseEntrySchema = z.object({
   name: z.string().min(1),
   path: z.string().min(1),
   is_dir: z.literal(true),
-  is_git_repo: z.boolean(),
-  branch: z.string().optional(),
 });
 export type FsBrowseEntry = z.infer<typeof fsBrowseEntrySchema>;
 

--- a/packages/protocol/src/workspace.ts
+++ b/packages/protocol/src/workspace.ts
@@ -14,8 +14,6 @@ export const workspaceSchema = z.object({
   id: workspaceIdSchema,
   root: z.string().min(1),
   name: z.string().min(1).max(100),
-  is_git_repo: z.boolean(),
-  branch: z.string().nullable(),
   created_at: isoDateTimeSchema,
   last_opened_at: isoDateTimeSchema,
   session_count: z.number().int().nonnegative(),


### PR DESCRIPTION
## Related Issue

None — the problem is explained below.

## Problem

Workspace list responses and folder-browser (`fs:browse`) entries each carried best-effort git metadata (`is_git_repo`, `branch`) that required a `.git` / `HEAD` probe on every request, duplicated across both server generations (v1 and v2). The web UI consumed it only to render per-workspace git badges and branch labels — duplicating the branch/PR/diff status already shown for the active session, which comes from the dedicated session-level git status endpoint with proper caching. Two branch sources also disagreed in edge cases (worktrees, detached HEAD, stale values).

## What changed

- Removed `is_git_repo` / `branch` from the workspace wire schema and the `fs:browse` entry schema (shared protocol, the kap-server vendored copy, and the klient contract), and from both servers' workspace hydration and folder-browse paths; deleted all server-side `detectGit` probing plus the now-unused `GitInfo` types and re-exports.
- Web: removed the git badges in the add-workspace dialog and folder browser, the per-workspace branch line in the mobile workspace switcher (falls back to the path), and the corresponding wire/type/mapper fields and locale strings. The chat header keeps showing branch, PR, and diff status from the active session's git status, unchanged.
- The session-level git status endpoint remains the single source of git/PR information and is behaviorally untouched.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.
