### PR TITLE
fix(oauth): include the transport root cause in connection error messages

### DIFF
--- a/.changeset/oauth-connection-error-cause.md
+++ b/.changeset/oauth-connection-error-cause.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Include the underlying network cause (DNS failure, refused connection, TLS or timeout errors) in OAuth connection error messages instead of a bare "fetch failed".

--- a/packages/oauth/src/errors.ts
+++ b/packages/oauth/src/errors.ts
@@ -16,8 +16,8 @@
  */
 
 export class OAuthError extends Error {
-  constructor(message: string) {
-    super(message);
+  constructor(message: string, options?: ErrorOptions) {
+    super(message, options);
     this.name = 'OAuthError';
   }
 }
@@ -30,8 +30,8 @@ export class OAuthUnauthorizedError extends OAuthError {
 }
 
 export class OAuthConnectionError extends OAuthError {
-  constructor(message: string) {
-    super(message);
+  constructor(message: string, options?: ErrorOptions) {
+    super(message, options);
     this.name = 'OAuthConnectionError';
   }
 }

--- a/packages/oauth/src/oauth.ts
+++ b/packages/oauth/src/oauth.ts
@@ -82,7 +82,8 @@ async function postForm(
     });
   } catch (error) {
     throw new OAuthConnectionError(
-      `OAuth request to ${url} failed: ${error instanceof Error ? error.message : String(error)}`,
+      `OAuth request to ${url} failed: ${describeFetchFailure(error)}`,
+      { cause: error },
     );
   }
   const status = response.status;
@@ -94,6 +95,23 @@ async function postForm(
     // Non-JSON response — leave data empty; caller interprets by status.
   }
   return { status, data };
+}
+
+/**
+ * Flatten a fetch rejection into a readable message. undici throws a generic
+ * `TypeError: fetch failed` and hides the real reason (DNS, refused, TLS,
+ * timeout) in a nested `cause` chain — walk it so the surfaced message names
+ * the actual failure instead of just "fetch failed".
+ */
+function describeFetchFailure(error: unknown): string {
+  if (!(error instanceof Error)) return String(error);
+  const messages = new Set<string>();
+  let current: Error | undefined = error;
+  while (current !== undefined) {
+    messages.add(current.message);
+    current = current.cause instanceof Error ? current.cause : undefined;
+  }
+  return [...messages].join(': ');
 }
 
 // ── requestDeviceAuthorization ────────────────────────────────────────

--- a/packages/oauth/test/oauth.test.ts
+++ b/packages/oauth/test/oauth.test.ts
@@ -575,6 +575,27 @@ describe('refreshAccessToken', () => {
     ).rejects.toBeInstanceOf(OAuthConnectionError);
   });
 
+  it('names the transport root cause in the connection error message', async () => {
+    const badConfig: OAuthFlowConfig = {
+      ...flowConfig(),
+      oauthHost: 'http://127.0.0.1:1', // reserved port, ECONNREFUSED
+    };
+
+    const failure = await refreshToken(badConfig, 'rt', {
+      maxRetries: 1,
+      backoffMs: () => 0,
+    }).catch((error: unknown) => error);
+
+    expect(failure).toBeInstanceOf(OAuthConnectionError);
+    const error = failure as OAuthConnectionError;
+    expect(error.cause).toBeInstanceOf(Error);
+    // The undici root cause (e.g. `connect ECONNREFUSED 127.0.0.1:1`) must be
+    // visible in the surfaced message, not just the generic "fetch failed".
+    const rootCause = error.cause instanceof Error ? error.cause : undefined;
+    expect(rootCause?.message).toBeTruthy();
+    expect(error.message).toContain(rootCause?.message);
+  });
+
   it('sends grant_type=refresh_token + refresh_token', async () => {
     server.enqueue('/api/oauth/token', {
       status: 200,


### PR DESCRIPTION
## Related Issue

No issue — the problem is explained in the next section.

## Problem

When the OAuth device flow hits a transport-level failure, users only see:

    OAuth request to https://auth.kimi.com/api/oauth/device_authorization failed: fetch failed

`fetch failed` is the generic undici `TypeError` — the real reason (DNS failure, connection refused, TLS interception, timeout) lives in the nested `error.cause` chain, which the previous code discarded. This makes reports like "cannot log in with OAuth" undiagnosable without reproducing locally: nobody can tell whether the user's network needs a proxy, the OAuth host is blocked, or certificates are being intercepted. This was reported in the wild by a VS Code extension user.

## What changed

- `OAuthError` / `OAuthConnectionError` now accept standard `ErrorOptions`, and `postForm` (`src/oauth.ts`) throws the connection error with `{ cause: error }` attached, so log stacks show the full `Caused by:` chain.
- The surfaced message now walks the cause chain (`describeFetchFailure`) and includes the root reason, e.g.:
  `OAuth request to ... failed: fetch failed: connect ECONNREFUSED 127.0.0.1:1` — deduplicated, non-Error throwables fall back to `String(error)`.
- Behavior for callers is unchanged: same error class, so retry/refresh logic that branches on `OAuthConnectionError`/status codes is unaffected.
- Added a test asserting the root cause appears in the message and that `.cause` preserves the original rejection.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset. (Changeset included: `@moonshot-ai/kimi-code` patch — the change enters the CLI bundle and improves `kimi` login error messages; the oauth workspace itself is private/unpublished.)
- [x] Ran `gen-docs` skill, or this PR needs no doc update. (Error-message wording only, no documented behavior change.)
