### PR TITLE
fix(tui): dismiss /btw panel before cancelling compaction on Esc and Ctrl+C

### DIFF
--- a/.changeset/btw-panel-compaction-priority.md
+++ b/.changeset/btw-panel-compaction-priority.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Fix Esc and Ctrl+C cancelling compaction instead of closing an open /btw panel.

--- a/apps/kimi-code/src/tui/controllers/editor-keyboard.ts
+++ b/apps/kimi-code/src/tui/controllers/editor-keyboard.ts
@@ -129,21 +129,23 @@ export class EditorKeyboardController {
         return;
       }
 
-      if (host.state.appState.isCompacting) {
-        this.clearPendingExit();
-
-        if (this.clearEditorTextIfPresent()) return;
-
-        this.cancelCurrentCompaction();
-        return;
-      }
-
+      // The btw panel stacks above the transcript, so Ctrl+C cancels/closes it
+      // before touching an in-flight compaction or stream.
       if (host.btwPanelController.cancelRunning()) {
         this.clearPendingExit();
         return;
       }
       if (host.btwPanelController.closeOrCancel()) {
         this.clearPendingExit();
+        return;
+      }
+
+      if (host.state.appState.isCompacting) {
+        this.clearPendingExit();
+
+        if (this.clearEditorTextIfPresent()) return;
+
+        this.cancelCurrentCompaction();
         return;
       }
 
@@ -184,12 +186,14 @@ export class EditorKeyboardController {
         this.clearPendingUndoEsc();
         return;
       }
-      if (host.state.appState.isCompacting) {
-        this.cancelCurrentCompaction();
+      // The btw panel stacks above the transcript, so Esc dismisses it before
+      // touching an in-flight compaction or stream.
+      if (host.btwPanelController.closeOrCancel()) {
         this.clearPendingUndoEsc();
         return;
       }
-      if (host.btwPanelController.closeOrCancel()) {
+      if (host.state.appState.isCompacting) {
+        this.cancelCurrentCompaction();
         this.clearPendingUndoEsc();
         return;
       }

--- a/apps/kimi-code/test/tui/controllers/editor-keyboard.test.ts
+++ b/apps/kimi-code/test/tui/controllers/editor-keyboard.test.ts
@@ -12,16 +12,24 @@ interface Harness {
   readonly editor: Record<string, ((...args: never[]) => unknown) | undefined>;
   readonly openUndoSelector: ReturnType<typeof vi.fn>;
   readonly cancelRunningShellCommand: ReturnType<typeof vi.fn>;
+  readonly cancelCompaction: ReturnType<typeof vi.fn>;
+  readonly btwCancelRunning: ReturnType<typeof vi.fn>;
+  readonly btwCloseOrCancel: ReturnType<typeof vi.fn>;
 }
 
 function createHarness(options: { streamingPhase?: string; isCompacting?: boolean } = {}): Harness {
   const editor: Record<string, ((...args: never[]) => unknown) | undefined> = {
     setHistoryFilter: vi.fn() as unknown as (...args: never[]) => unknown,
     setInputMode: vi.fn() as unknown as (...args: never[]) => unknown,
+    getText: vi.fn(() => '') as unknown as (...args: never[]) => unknown,
+    setText: vi.fn() as unknown as (...args: never[]) => unknown,
   };
   const openUndoSelector = vi.fn();
   const cancelRunningShellCommand = vi.fn();
-  const session = { cancel: vi.fn(async () => {}) };
+  const cancelCompaction = vi.fn(async () => {});
+  const btwCancelRunning = vi.fn(() => false);
+  const btwCloseOrCancel = vi.fn(() => false);
+  const session = { cancel: vi.fn(async () => {}), cancelCompaction };
 
   const host = {
     state: {
@@ -35,7 +43,7 @@ function createHarness(options: { streamingPhase?: string; isCompacting?: boolea
       ui: { requestRender: vi.fn() },
     },
     session,
-    btwPanelController: { closeOrCancel: vi.fn(() => false) },
+    btwPanelController: { cancelRunning: btwCancelRunning, closeOrCancel: btwCloseOrCancel },
     openUndoSelector,
     cancelRunningShellCommand,
   } as unknown as EditorKeyboardHost;
@@ -46,12 +54,26 @@ function createHarness(options: { streamingPhase?: string; isCompacting?: boolea
   );
   controller.install();
 
-  return { host, editor, openUndoSelector, cancelRunningShellCommand };
+  return {
+    host,
+    editor,
+    openUndoSelector,
+    cancelRunningShellCommand,
+    cancelCompaction,
+    btwCancelRunning,
+    btwCloseOrCancel,
+  };
 }
 
 function pressEscape(editor: Harness['editor']): void {
   const handler = editor['onEscape'];
   if (handler === undefined) throw new Error('onEscape handler not installed');
+  (handler as () => void)();
+}
+
+function pressCtrlC(editor: Harness['editor']): void {
+  const handler = editor['onCtrlC'];
+  if (handler === undefined) throw new Error('onCtrlC handler not installed');
   (handler as () => void)();
 }
 
@@ -120,6 +142,70 @@ describe('EditorKeyboardController double-Esc undo', () => {
     expect(cancelRunningShellCommand).toHaveBeenCalled();
     const session = host.session as unknown as { cancel: ReturnType<typeof vi.fn> };
     expect(session.cancel).toHaveBeenCalled();
+  });
+});
+
+describe('EditorKeyboardController btw panel priority', () => {
+  it('Esc closes the btw panel first while compacting, without cancelling compaction', () => {
+    const { editor, btwCloseOrCancel, cancelCompaction } = createHarness({ isCompacting: true });
+    btwCloseOrCancel.mockReturnValue(true);
+
+    pressEscape(editor);
+
+    expect(btwCloseOrCancel).toHaveBeenCalledOnce();
+    expect(cancelCompaction).not.toHaveBeenCalled();
+  });
+
+  it('Esc cancels compaction on the next press once the btw panel is gone', () => {
+    const { editor, btwCloseOrCancel, cancelCompaction } = createHarness({ isCompacting: true });
+    btwCloseOrCancel.mockReturnValueOnce(true);
+
+    pressEscape(editor);
+    expect(cancelCompaction).not.toHaveBeenCalled();
+
+    pressEscape(editor);
+    expect(cancelCompaction).toHaveBeenCalledOnce();
+  });
+
+  it('Esc cancels compaction directly when no btw panel is open', () => {
+    const { editor, btwCloseOrCancel, cancelCompaction } = createHarness({ isCompacting: true });
+
+    pressEscape(editor);
+
+    expect(btwCloseOrCancel).toHaveBeenCalledOnce();
+    expect(cancelCompaction).toHaveBeenCalledOnce();
+  });
+
+  it('Ctrl+C cancels a running btw question first while compacting', () => {
+    const { editor, btwCancelRunning, cancelCompaction } = createHarness({ isCompacting: true });
+    btwCancelRunning.mockReturnValue(true);
+
+    pressCtrlC(editor);
+
+    expect(btwCancelRunning).toHaveBeenCalledOnce();
+    expect(cancelCompaction).not.toHaveBeenCalled();
+  });
+
+  it('Ctrl+C closes an idle btw panel while compacting, without cancelling compaction', () => {
+    const { editor, btwCloseOrCancel, cancelCompaction } = createHarness({ isCompacting: true });
+    btwCloseOrCancel.mockReturnValue(true);
+
+    pressCtrlC(editor);
+
+    expect(btwCloseOrCancel).toHaveBeenCalledOnce();
+    expect(cancelCompaction).not.toHaveBeenCalled();
+  });
+
+  it('Ctrl+C cancels compaction when no btw panel is open', () => {
+    const { editor, btwCancelRunning, btwCloseOrCancel, cancelCompaction } = createHarness({
+      isCompacting: true,
+    });
+
+    pressCtrlC(editor);
+
+    expect(btwCancelRunning).toHaveBeenCalledOnce();
+    expect(btwCloseOrCancel).toHaveBeenCalledOnce();
+    expect(cancelCompaction).toHaveBeenCalledOnce();
   });
 });
 


### PR DESCRIPTION
## Related Issue

No linked issue — the problem is explained below.

## Problem

While a compaction is running, opening a /btw side question and pressing Esc (or Ctrl+C) cancels the in-progress compaction instead of dismissing the /btw panel. The editor keyboard handler checked the compacting state before the open /btw panel, so the panel stayed mounted and the compaction was aborted — the user had to press Esc again to actually close the panel.

## What changed

Reordered the Esc and Ctrl+C handling so an open /btw panel is handled first: Esc dismisses the panel, and Ctrl+C cancels a running /btw question (then closes the panel) — all without touching the compaction. Compaction is only cancelled once no /btw panel is open, which matches the "dismiss the topmost UI layer first" expectation. This fits Kimi Code because it only reorders existing handler branches in the TUI keyboard controller; no SDK or core behavior changes. Added controller tests covering both keys with the panel open, gone, and absent.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.