### PR TITLE
chore(ci): remove the VSIX package audit job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,48 +28,6 @@ jobs:
       - name: Smoke test CLI bundle
         run: pnpm -C apps/kimi-code run smoke
 
-  vscode-vsix-package:
-    name: VSIX package audit (${{ matrix.target }})
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - os: ubuntu-latest
-            target: all
-          - os: macos-latest
-            target: darwin-arm64
-          - os: windows-latest
-            target: win32-x64
-
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: pnpm/action-setup@v6
-
-      - uses: actions/setup-node@v6
-        with:
-          node-version-file: .nvmrc
-          cache: pnpm
-
-      - run: pnpm install --frozen-lockfile
-      - name: Build and audit target VSIX
-        run: pnpm --filter kimi-code run package:platform -- --target "${{ matrix.target }}"
-      - name: Run installed VSIX Extension Host smoke (Linux)
-        if: runner.os == 'Linux'
-        run: xvfb-run -a pnpm --filter kimi-code run test:extension-host -- --version 1.100.0
-      - name: Run installed VSIX Extension Host smoke on stable (Linux)
-        if: runner.os == 'Linux'
-        run: xvfb-run -a pnpm --filter kimi-code run test:extension-host -- --version stable
-      - name: Run installed VSIX Extension Host smoke
-        if: runner.os != 'Linux'
-        run: pnpm --filter kimi-code run test:extension-host -- --version 1.100.0
-      - uses: actions/upload-artifact@v4
-        with:
-          name: vscode-vsix-${{ matrix.target }}
-          path: apps/vscode/artifacts/vsix/*.vsix
-          if-no-files-found: error
-
   test:
     runs-on: ubuntu-latest
     strategy:


### PR DESCRIPTION
## Related Issue

No issue — CI cleanup.

## Problem

The per-PR `vscode-vsix-package` matrix job is being retired. It built and audited VSIX packages on three OSes (Ubuntu/macOS/Windows), ran extension-host smoke tests, and uploaded the `.vsix` artifacts on every PR and push to main.

## What changed

Removed the `vscode-vsix-package` job from `.github/workflows/ci.yml`. Nothing else in CI references it.

VSIX packaging and verification remain fully available locally / on demand:

- `pnpm --filter kimi-code run package:platform` — build + audit all targets
- `pnpm --filter kimi-code run test:extension-host` — install the VSIX in a real extension host

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works. (CI-only change; workflow YAML validated locally.)
- [x] Ran `gen-changesets` skill, or this PR needs no changeset. (No package output affected.)
- [x] Ran `gen-docs` skill, or this PR needs no doc update. (No user-facing behavior change.)