### PR TITLE
feat: persist 5h and weekly plan quota in TUI footer and web sidebar

### DIFF
--- a/.changeset/persistent-plan-quota-display.md
+++ b/.changeset/persistent-plan-quota-display.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": minor
+---
+
+Show the 5-hour and weekly plan quota persistently: the TUI footer now renders a compact `5h: X% 1w: Y%` readout next to the context meter (fetched on session start and refreshed by `/usage` and `/status`), and the web sidebar gets a "Plan usage" card above the session list with per-window progress bars and a manual refresh, backed by a new `GET /api/v1/usages` route.

--- a/apps/kimi-code/src/tui/commands/info.ts
+++ b/apps/kimi-code/src/tui/commands/info.ts
@@ -121,6 +121,7 @@ interface ManagedUsageResult {
 export async function showUsage(host: SlashCommandHost): Promise<void> {
   const sessionUsage = await loadSessionUsageReport(host);
   const managedUsage = await loadManagedUsageReport(host);
+  syncManagedUsageToState(host, managedUsage);
   const reportArgs = {
     sessionUsage: sessionUsage.usage,
     sessionUsageError: sessionUsage.error,
@@ -140,6 +141,7 @@ export async function showStatusReport(host: SlashCommandHost): Promise<void> {
     loadRuntimeStatusReport(host),
     loadManagedUsageReport(host),
   ]);
+  syncManagedUsageToState(host, managedUsage);
   const appState = host.state.appState;
   const reportArgs = {
     version: appState.version,
@@ -214,4 +216,19 @@ async function loadManagedUsageReport(host: SlashCommandHost): Promise<ManagedUs
     return { error: res.message };
   }
   return { usage: { summary: res.summary, limits: res.limits, extraUsage: res.extraUsage } };
+}
+
+/**
+ * Mirror the latest managed-usage fetch into appState so the footer quota
+ * readout refreshes at the same time as the /usage or /status panel.
+ */
+function syncManagedUsageToState(
+  host: SlashCommandHost,
+  result: ManagedUsageResult | undefined,
+): void {
+  if (result === undefined) return;
+  host.setAppState({
+    managedUsage: result.usage ?? null,
+    managedUsageError: result.error ?? null,
+  });
 }

--- a/apps/kimi-code/src/tui/components/chrome/footer.ts
+++ b/apps/kimi-code/src/tui/components/chrome/footer.ts
@@ -25,9 +25,11 @@ import {
 } from '#/utils/git/git-status';
 import {
   formatTokenCount,
+  ratioSeverity,
   usagePercent,
   usagePercentFromRatio,
 } from '#/utils/usage/usage-format';
+import type { ManagedUsageReport, ManagedUsageRow } from '../messages/usage-panel';
 
 const MAX_CWD_SEGMENTS = 3;
 const GOAL_TIMER_INTERVAL_MS = 1_000;
@@ -170,6 +172,43 @@ function formatContextStatus(usage: number, tokens?: number, maxTokens?: number)
     return `context: ${pct}% (${formatTokenCount(tokens)}/${formatTokenCount(maxTokens)})`;
   }
   return `context: ${String(usagePercentFromRatio(usage))}%`;
+}
+
+type SeverityToken = 'success' | 'warning' | 'error';
+
+function severityToken(sev: 'ok' | 'warn' | 'danger'): SeverityToken {
+  return sev === 'danger' ? 'error' : sev === 'warn' ? 'warning' : 'success';
+}
+
+/**
+ * Footer plan-quota readout, e.g. `5h: 40% 1w: 12%`. Compact enough to share
+ * line 2 with the context meter. The weekly summary row comes first (summary
+ * slot), then each window limit (incl. the 5h one) in arrival order. Every
+ * window is coloured by its own severity so a near-cap 5h limit stands out
+ * even when the weekly budget is comfortable.
+ */
+function formatManagedUsageStatus(
+  usage: ManagedUsageReport | null | undefined,
+  error: string | null | undefined,
+  colors: ColorPalette,
+): string | null {
+  if (error !== null && error !== undefined) {
+    return chalk.hex(colors.error)(`quota: ${error}`);
+  }
+  if (usage === null || usage === undefined) return null;
+
+  const rows: ManagedUsageRow[] = [];
+  if (usage.summary !== null) rows.push(usage.summary);
+  rows.push(...usage.limits);
+  if (rows.length === 0) return null;
+
+  const parts = rows.map((row) => {
+    const pct = usagePercent(row.used, row.limit);
+    const label = row.label.replace(/\s+limit$/i, '');
+    const token = severityToken(ratioSeverity(row.limit > 0 ? row.used / row.limit : 0));
+    return chalk.hex(colors[token])(`${label}: ${String(pct)}%`);
+  });
+  return parts.join(' ');
 }
 
 export function formatFooterGitBadge(status: GitStatus, colors: ColorPalette): string {
@@ -332,26 +371,31 @@ export class FooterComponent implements Component {
       line1 = truncateToWidth(leftLine, width, '…');
     }
 
-    // ── Line 2: transient hint (bottom-left) + context (right) ──
+    // ── Line 2: transient hint / plan quota (bottom-left) + context (right) ──
     const contextText = formatContextStatus(
       state.contextUsage,
       state.contextTokens,
       state.maxContextTokens,
     );
     const contextWidth = visibleWidth(contextText);
+    // A transient hint (e.g. the exit double-tap prompt) outranks the quota
+    // readout for the left slot — it is short-lived and user-actionable.
+    const quotaText = this.transientHint
+      ? null
+      : formatManagedUsageStatus(state.managedUsage, state.managedUsageError, colors);
+    const leftText = this.transientHint
+      ? chalk.hex(colors.warning).bold(this.transientHint)
+      : quotaText;
     let line2: string;
-    if (this.transientHint) {
-      const maxHintWidth = Math.max(0, width - contextWidth - 1);
-      const shownHint =
-        visibleWidth(this.transientHint) <= maxHintWidth
-          ? this.transientHint
-          : truncateToWidth(this.transientHint, maxHintWidth, '…');
-      const hintWidth = visibleWidth(shownHint);
-      const pad = Math.max(0, width - hintWidth - contextWidth);
-      line2 =
-        chalk.hex(colors.warning).bold(shownHint) +
-        ' '.repeat(pad) +
-        chalk.hex(colors.text)(contextText);
+    if (leftText !== null) {
+      const maxLeftWidth = Math.max(0, width - contextWidth - 1);
+      const shownLeft =
+        visibleWidth(leftText) <= maxLeftWidth
+          ? leftText
+          : truncateToWidth(leftText, maxLeftWidth, '…');
+      const leftWidth = visibleWidth(shownLeft);
+      const pad = Math.max(0, width - leftWidth - contextWidth);
+      line2 = shownLeft + ' '.repeat(pad) + chalk.hex(colors.text)(contextText);
     } else {
       const leftPad = Math.max(0, width - contextWidth);
       line2 = ' '.repeat(leftPad) + chalk.hex(colors.text)(contextText);

--- a/apps/kimi-code/src/tui/kimi-tui.ts
+++ b/apps/kimi-code/src/tui/kimi-tui.ts
@@ -94,6 +94,7 @@ import {
   MAIN_AGENT_ID,
   NO_ACTIVE_SESSION_MESSAGE,
   PRODUCT_NAME,
+  isManagedUsageProvider,
 } from './constant/kimi-tui';
 import { CHROME_GUTTER } from './constant/rendering';
 import { MAX_TERMINAL_TITLE_LENGTH } from './constant/terminal';
@@ -230,6 +231,8 @@ function createInitialAppState(input: KimiTUIStartupInput): AppState {
     goal: null,
     mcpServersSummary: null,
     banner: undefined,
+    managedUsage: undefined,
+    managedUsageError: null,
   };
 }
 
@@ -1536,6 +1539,39 @@ export class KimiTUI {
       goal: goalResult.goal,
     });
     this.syncAdditionalDirs(session);
+    void this.refreshManagedUsage();
+  }
+
+  /**
+   * Pull the plan quota (5h/weekly windows) for the managed provider and cache
+   * it in appState so the footer can render it persistently. Fire-and-forget:
+   * failures land in `managedUsageError` and never block session sync.
+   */
+  async refreshManagedUsage(): Promise<void> {
+    const alias = this.state.appState.model;
+    const providerKey = this.state.appState.availableModels[alias]?.provider;
+    if (!isManagedUsageProvider(providerKey)) {
+      if (
+        this.state.appState.managedUsage !== undefined ||
+        this.state.appState.managedUsageError != null
+      ) {
+        this.setAppState({ managedUsage: undefined, managedUsageError: null });
+      }
+      return;
+    }
+    try {
+      const res = await this.harness.auth.getManagedUsage(providerKey);
+      if (res.kind === 'error') {
+        this.setAppState({ managedUsage: null, managedUsageError: res.message });
+        return;
+      }
+      this.setAppState({
+        managedUsage: { summary: res.summary, limits: res.limits, extraUsage: res.extraUsage },
+        managedUsageError: null,
+      });
+    } catch (error) {
+      this.setAppState({ managedUsage: null, managedUsageError: formatErrorMessage(error) });
+    }
   }
 
   // Apply --auto/--yolo/--plan startup flags to a resumed session. The resumed

--- a/apps/kimi-code/src/tui/types.ts
+++ b/apps/kimi-code/src/tui/types.ts
@@ -10,6 +10,7 @@ import type {
 } from '@moonshot-ai/kimi-code-sdk';
 
 import type { NotificationsConfig, UpgradePreferences } from './config';
+import type { ManagedUsageReport } from './components/messages/usage-panel';
 import type { PendingApproval, PendingQuestion } from './reverse-rpc/types';
 import type { ColorToken, ThemeName } from './theme';
 
@@ -60,6 +61,10 @@ export interface AppState {
   mcpServersSummary: string | null;
   /** Optional banner shown below the welcome panel; null means no banner to render. */
   banner?: BannerState | null;
+  /** Cached plan quota (5h/weekly windows) for the footer; undefined until first fetch. */
+  managedUsage?: ManagedUsageReport | null;
+  /** Last managed-usage fetch error, surfaced in the footer instead of percentages. */
+  managedUsageError?: string | null;
 }
 
 export interface ToolCallBlockData {

--- a/apps/kimi-web/src/api/daemon/client.ts
+++ b/apps/kimi-web/src/api/daemon/client.ts
@@ -7,6 +7,7 @@ import { traceKeyEvent } from '../../debug/trace';
 import type {
   AppConfig,
   AppGoal,
+  AppManagedUsageResult,
   AppMessage,
   AppMessageRole,
   AppModel,
@@ -83,6 +84,7 @@ import type {
   WireSessionSnapshot,
   WireWorkspace,
   WireLogoutResult,
+  WireManagedUsageResult,
 } from './wire';
 import { DaemonEventSocket } from './ws';
 
@@ -1357,6 +1359,14 @@ export class DaemonKimiWebApi implements KimiWebApi {
   async logout(): Promise<{ loggedOut: boolean }> {
     const data = await this.http.post<WireLogoutResult>('/oauth/logout', {});
     return { loggedOut: data.logged_out };
+  }
+
+  async getManagedUsage(): Promise<AppManagedUsageResult> {
+    const data = await this.http.get<WireManagedUsageResult>('/usages');
+    if (data.kind === 'error') {
+      return { kind: 'error', summary: null, limits: [], message: data.message };
+    }
+    return { kind: 'ok', summary: data.summary, limits: data.limits };
   }
 
   // -------------------------------------------------------------------------

--- a/apps/kimi-web/src/api/daemon/wire.ts
+++ b/apps/kimi-web/src/api/daemon/wire.ts
@@ -483,6 +483,26 @@ export interface WireLogoutResult {
 }
 
 // ---------------------------------------------------------------------------
+// Managed usage wire DTOs (`GET /usages`)
+// ---------------------------------------------------------------------------
+
+export interface WireManagedUsageRow {
+  label: string;
+  used: number;
+  limit: number;
+  resetHint?: string;
+}
+
+export type WireManagedUsageResult =
+  | {
+      kind: 'ok';
+      summary: WireManagedUsageRow | null;
+      limits: WireManagedUsageRow[];
+      extraUsage: unknown;
+    }
+  | { kind: 'error'; message: string };
+
+// ---------------------------------------------------------------------------
 // File upload wire DTOs
 // ---------------------------------------------------------------------------
 

--- a/apps/kimi-web/src/api/types.ts
+++ b/apps/kimi-web/src/api/types.ts
@@ -697,6 +697,23 @@ export interface AppSessionWarning {
   severity: 'info' | 'warning' | 'error';
 }
 
+export interface AppManagedUsageRow {
+  label: string;
+  used: number;
+  limit: number;
+  resetHint?: string;
+}
+
+export interface AppManagedUsageResult {
+  kind: 'ok' | 'error';
+  /** Weekly window (1w); null when the platform returns no summary. */
+  summary: AppManagedUsageRow | null;
+  /** Window limits, incl. the 5h one. */
+  limits: AppManagedUsageRow[];
+  /** Present only when kind === 'error'. */
+  message?: string;
+}
+
 export interface KimiWebApi {
   getHealth(): Promise<{ status: 'ok'; uptimeSec: number }>;
   getMeta(): Promise<{ serverVersion: string; serverId: string; startedAt: string; capabilities: Record<string, boolean>; openInApps: string[]; dangerousBypassAuth: boolean; backend: 'v1' | 'v2' }>;
@@ -801,6 +818,8 @@ export interface KimiWebApi {
   } | null>;
   cancelOAuthLogin(): Promise<{ cancelled: boolean; status: string }>;
   logout(): Promise<{ loggedOut: boolean }>;
+  /** Managed plan quota (5h/weekly windows) — GET /usages. */
+  getManagedUsage(): Promise<AppManagedUsageResult>;
 }
 
 /** Result of `startOAuthLogin()`, mirroring the wire discriminated union. */

--- a/apps/kimi-web/src/components/QuotaCard.vue
+++ b/apps/kimi-web/src/components/QuotaCard.vue
@@ -1,0 +1,211 @@
+<!-- apps/kimi-web/src/components/QuotaCard.vue -->
+<!-- Persistent plan-quota card shown at the top of the sidebar. Fetches the
+     managed 5h/weekly windows on mount and renders each with a severity-tinted
+     progress bar, so the current budget pressure is visible without running a
+     command. Hidden entirely when the provider has no managed quota (signed
+     out or non-managed provider). -->
+<script setup lang="ts">
+import { computed, onMounted, ref } from 'vue';
+import { useI18n } from 'vue-i18n';
+import { getKimiWebApi } from '../api';
+import type { AppManagedUsageResult, AppManagedUsageRow } from '../api/types';
+
+const { t } = useI18n();
+
+const result = ref<AppManagedUsageResult | null>(null);
+const loading = ref(false);
+const failed = ref(false);
+
+type Severity = 'ok' | 'warn' | 'danger';
+
+function severityOf(row: AppManagedUsageRow): Severity {
+  if (row.limit <= 0) return 'ok';
+  const ratio = row.used / row.limit;
+  if (ratio >= 0.85) return 'danger';
+  if (ratio >= 0.5) return 'warn';
+  return 'ok';
+}
+
+function pctOf(row: AppManagedUsageRow): number {
+  if (row.limit <= 0) return 0;
+  return Math.min(100, Math.max(0, Math.ceil((row.used / row.limit) * 100)));
+}
+
+function shortLabel(label: string): string {
+  return label.replace(/\s+limit$/i, '');
+}
+
+// Weekly summary first (1w), then each window limit (incl. 5h) in arrival order.
+const rows = computed<AppManagedUsageRow[]>(() => {
+  const r = result.value;
+  if (r === null || r.kind !== 'ok') return [];
+  const out: AppManagedUsageRow[] = [];
+  if (r.summary !== null) out.push(r.summary);
+  out.push(...r.limits);
+  return out;
+});
+
+const visible = computed(() => rows.value.length > 0 || failed.value);
+const errorMessage = computed(() =>
+  result.value?.kind === 'error' ? (result.value.message ?? t('status.quotaUnavailable')) : '',
+);
+
+async function refresh(): Promise<void> {
+  if (loading.value) return;
+  loading.value = true;
+  try {
+    const data = await getKimiWebApi().getManagedUsage();
+    result.value = data;
+    failed.value = false;
+  } catch {
+    failed.value = true;
+    result.value = null;
+  } finally {
+    loading.value = false;
+  }
+}
+
+onMounted(() => {
+  void refresh();
+});
+</script>
+
+<template>
+  <div v-if="visible" class="quota-card">
+    <div class="quota-head">
+      <span class="quota-title">{{ t('status.quotaTitle') }}</span>
+      <button
+        class="quota-refresh"
+        type="button"
+        :disabled="loading"
+        @click="refresh"
+      >
+        {{ loading ? t('status.quotaRefreshing') : t('status.quotaRefresh') }}
+      </button>
+    </div>
+
+    <div v-if="failed || result?.kind === 'error'" class="quota-error">
+      <span class="quota-error-text">{{ errorMessage || t('status.quotaUnavailable') }}</span>
+      <button class="quota-retry" type="button" @click="refresh">{{ t('status.quotaRetry') }}</button>
+    </div>
+
+    <div v-else class="quota-rows">
+      <div v-for="row in rows" :key="row.label" class="quota-row">
+        <div class="quota-row-top">
+          <span class="quota-label">{{ shortLabel(row.label) }}</span>
+          <span class="quota-pct" :data-sev="severityOf(row)">
+            {{ t('status.quotaUsed', { pct: pctOf(row) }) }}
+          </span>
+        </div>
+        <div class="quota-bar">
+          <i
+            :data-sev="severityOf(row)"
+            :style="{ width: pctOf(row) + '%' }"
+          ></i>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.quota-card {
+  margin: 0 var(--space-3) var(--space-2);
+  padding: var(--space-3);
+  border: 1px solid var(--color-line);
+  border-radius: var(--radius-lg);
+  background: var(--color-surface);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  font-family: var(--font-ui);
+}
+
+.quota-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-2);
+}
+.quota-title {
+  font-size: var(--text-xs);
+  font-weight: var(--weight-semibold);
+  color: var(--color-text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+.quota-refresh,
+.quota-retry {
+  border: none;
+  background: transparent;
+  color: var(--color-accent);
+  font-size: var(--text-xs);
+  font-weight: var(--weight-medium);
+  cursor: pointer;
+  padding: 2px 4px;
+  border-radius: var(--radius-sm);
+}
+.quota-refresh:hover:not(:disabled),
+.quota-retry:hover {
+  background: var(--color-surface-sunken);
+}
+.quota-refresh:disabled {
+  opacity: 0.5;
+  cursor: default;
+}
+
+.quota-rows {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+.quota-row-top {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: var(--space-2);
+}
+.quota-label {
+  font-size: var(--text-sm);
+  color: var(--color-text);
+  font-weight: var(--weight-medium);
+}
+.quota-pct {
+  font-size: var(--text-xs);
+  color: var(--color-text-muted);
+}
+.quota-pct[data-sev='warn'] { color: var(--color-warning); }
+.quota-pct[data-sev='danger'] { color: var(--color-danger); }
+
+.quota-bar {
+  width: 100%;
+  height: 5px;
+  margin-top: 3px;
+  border-radius: var(--radius-full);
+  background: var(--color-line);
+  overflow: hidden;
+}
+.quota-bar i {
+  display: block;
+  height: 100%;
+  border-radius: var(--radius-full);
+  background: var(--color-accent);
+  transition: width var(--duration-base) var(--ease-out);
+}
+.quota-bar i[data-sev='warn'] { background: var(--color-warning); }
+.quota-bar i[data-sev='danger'] { background: var(--color-danger); }
+
+.quota-error {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-2);
+}
+.quota-error-text {
+  font-size: var(--text-xs);
+  color: var(--color-text-muted);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+</style>

--- a/apps/kimi-web/src/components/Sidebar.vue
+++ b/apps/kimi-web/src/components/Sidebar.vue
@@ -22,6 +22,7 @@ import {
 import { moveInOrder, type DropPosition, type WorkspaceSortMode } from '../lib/workspaceOrder';
 import type { Session, WorkspaceGroup as WorkspaceGroupType, WorkspaceView } from '../types';
 import SearchSessionsDialog from './dialogs/SearchSessionsDialog.vue';
+import QuotaCard from './QuotaCard.vue';
 import WorkspaceGroup from './WorkspaceGroup.vue';
 import { isMacosDesktop } from '../lib/desktopFlag';
 import IconButton from './ui/IconButton.vue';
@@ -712,6 +713,9 @@ onBeforeUnmount(() => {
           <Kbd :keys="sessionSearchKeys" />
         </button>
       </div>
+
+      <!-- Plan quota — persistent 5h/weekly indicator above the session list -->
+      <QuotaCard />
 
       <!-- Session list — grouped by workspace -->
       <div class="sessions" @scroll="onSessionsScroll">

--- a/apps/kimi-web/src/i18n/locales/en/status.ts
+++ b/apps/kimi-web/src/i18n/locales/en/status.ts
@@ -62,4 +62,12 @@ export default {
   activityAwaitingQuestion: 'Awaiting answer',
   interrupt: 'Interrupt',
   runningShort: 'in progress',
+  // Plan quota card (5h / weekly windows)
+  quotaTitle: 'Plan usage',
+  quotaRefresh: 'Refresh',
+  quotaRefreshing: 'Refreshing…',
+  quotaRetry: 'Retry',
+  quotaUsed: '{pct}% used',
+  quotaWeeklyLabel: 'Weekly',
+  quotaUnavailable: 'Unavailable',
 } as const;

--- a/apps/kimi-web/src/i18n/locales/zh/status.ts
+++ b/apps/kimi-web/src/i18n/locales/zh/status.ts
@@ -62,4 +62,12 @@ export default {
   activityAwaitingQuestion: '等待回答',
   interrupt: '中断',
   runningShort: '进行中',
+  // 套餐配额卡片（5 小时 / 每周窗口）
+  quotaTitle: '套餐用量',
+  quotaRefresh: '刷新',
+  quotaRefreshing: '刷新中…',
+  quotaRetry: '重试',
+  quotaUsed: '已用 {pct}%',
+  quotaWeeklyLabel: '每周',
+  quotaUnavailable: '不可用',
 };

--- a/packages/agent-core-v2/src/app/auth/auth.ts
+++ b/packages/agent-core-v2/src/app/auth/auth.ts
@@ -11,6 +11,7 @@
  */
 
 import type {
+  AuthManagedUsageResult,
   BearerTokenProvider,
   KimiOAuthLoginOptions,
   KimiOAuthLoginResult,
@@ -62,6 +63,8 @@ export interface IOAuthToolkit {
     oauthRef?: KimiOAuthTokenRef,
   ): Promise<string | undefined>;
   tokenProvider(providerName?: string, oauthRef?: KimiOAuthTokenRef): BearerTokenProvider;
+  /** Plan quota (5h/weekly windows) for the managed provider. */
+  getManagedUsage(providerName?: string): Promise<AuthManagedUsageResult>;
 }
 
 export const IOAuthToolkit: ServiceIdentifier<IOAuthToolkit> =

--- a/packages/kap-server/src/routes/registerApiV1Routes.ts
+++ b/packages/kap-server/src/routes/registerApiV1Routes.ts
@@ -38,6 +38,7 @@ import { registerSkillsRoutes } from './skills';
 import { registerTasksRoutes } from './tasks';
 import { registerTerminalsRoutes } from './terminals';
 import { registerToolsRoutes } from './tools';
+import { registerUsagesRoute } from './usages';
 import { registerWorkspaceFsRoutes } from './workspaceFs';
 import { registerWorkspacesRoutes } from './workspaces';
 
@@ -92,6 +93,7 @@ export async function registerApiV1Routes(
 
       registerAuthRoute(apiV1 as unknown as Parameters<typeof registerAuthRoute>[0], core);
       registerOAuthRoutes(apiV1 as unknown as Parameters<typeof registerOAuthRoutes>[0], core);
+      registerUsagesRoute(apiV1 as unknown as Parameters<typeof registerUsagesRoute>[0], core);
       registerConfigRoutes(apiV1 as unknown as Parameters<typeof registerConfigRoutes>[0], core);
       registerModelCatalogRoutes(
         apiV1 as unknown as Parameters<typeof registerModelCatalogRoutes>[0],

--- a/packages/kap-server/src/routes/usages.ts
+++ b/packages/kap-server/src/routes/usages.ts
@@ -1,0 +1,80 @@
+/**
+ * `GET /usages` — managed plan quota snapshot.
+ *
+ * Returns the 5h/weekly rolling-window limits (plus the booster wallet) for
+ * the managed Kimi provider, so web/IDE clients can render a persistent quota
+ * indicator without shelling out to the CLI. The data comes from the platform
+ * `GET /usages` endpoint via `IOAuthToolkit.getManagedUsage`, already parsed
+ * into the `ParsedManagedUsage` shape (`summary` = weekly, `limits[]` = the
+ * window limits incl. the 5h one).
+ *
+ * When the active provider is not the managed one (or the user is signed
+ * out), the toolkit call fails and the route returns the error message inside
+ * a success envelope with a `kind: 'error'` marker — clients render the
+ * message instead of percentages. This mirrors the CLI footer, which shows
+ * `quota: <error>` rather than failing the whole panel.
+ */
+
+import { IOAuthToolkit, type Scope } from '@moonshot-ai/agent-core-v2';
+import { z } from 'zod';
+
+import { okEnvelope } from '../envelope';
+import { defineRoute } from '../middleware/defineRoute';
+
+interface RouteHost {
+  get(
+    path: string,
+    options: { schema?: Record<string, unknown> },
+    handler: (
+      req: { id: string },
+      reply: { send(payload: unknown): void },
+    ) => Promise<void> | void,
+  ): unknown;
+}
+
+const usageRowSchema = z.object({
+  label: z.string(),
+  used: z.number(),
+  limit: z.number(),
+  resetHint: z.string().optional(),
+});
+
+const boosterWalletSchema = z.object({
+  balanceCents: z.number(),
+  totalCents: z.number(),
+  monthlyChargeLimitEnabled: z.boolean(),
+  monthlyChargeLimitCents: z.number(),
+  monthlyUsedCents: z.number(),
+  currency: z.string(),
+});
+
+const managedUsageOkSchema = z.object({
+  kind: z.literal('ok'),
+  summary: usageRowSchema.nullable(),
+  limits: z.array(usageRowSchema),
+  extraUsage: boosterWalletSchema.nullable(),
+});
+
+const managedUsageErrorSchema = z.object({
+  kind: z.literal('error'),
+  message: z.string(),
+});
+
+const managedUsageResultSchema = z.union([managedUsageOkSchema, managedUsageErrorSchema]);
+
+export function registerUsagesRoute(app: RouteHost, core: Scope): void {
+  const route = defineRoute(
+    {
+      method: 'GET',
+      path: '/usages',
+      success: { data: managedUsageResultSchema },
+      description: 'Get managed plan quota (5h/weekly windows)',
+      tags: ['auth'],
+    },
+    async (req, reply) => {
+      const result = await core.accessor.get(IOAuthToolkit).getManagedUsage();
+      reply.send(okEnvelope(result, req.id));
+    },
+  );
+  app.get(route.path, route.options, route.handler as Parameters<RouteHost['get']>[2]);
+}

--- a/packages/kap-server/test/__snapshots__/apiSurface.snapshot.test.ts.snap
+++ b/packages/kap-server/test/__snapshots__/apiSurface.snapshot.test.ts.snap
@@ -174,6 +174,10 @@ exports[`API surface snapshot > matches the documented v2 route table and meta e
     ],
     [
       "GET",
+      "/api/v1/usages",
+    ],
+    [
+      "GET",
       "/api/v1/workspaces",
     ],
     [


### PR DESCRIPTION
## What

The managed `GET /usages` endpoint already returns both rolling windows (the weekly summary and the 5h window in `limits[]`), but they were only reachable behind `/usage` and `/status`. This surfaces them **persistently** in both UIs.

### TUI
- Footer line 2 now shows a compact `5h: X% 1w: Y%` readout next to the context meter, each window coloured by its own severity (green/yellow/red).
- The report is cached in `AppState`, fetched fire-and-forget on session sync (`refreshManagedUsage`), and refreshed whenever `/usage` or `/status` runs.

### Web
- New `GET /api/v1/usages` route in kap-server, backed by `IOAuthToolkit.getManagedUsage` (interface now declares it).
- New `QuotaCard` component pinned above the sidebar session list: per-window progress bars, reset hints, and a manual Refresh button. Fetches once on mount.
- `getManagedUsage()` added to the web API client + wire/App types; EN/ZH i18n strings.

Both UIs hide the quota entirely for non-managed providers / signed-out users and degrade to an error hint instead of failing.

## Testing
- `pnpm typecheck` clean across all packages.
- Footer/usage-panel, agent-core-v2 auth, kap-server (660), oauth managed-usage tests all pass; API-surface snapshot updated for the new route.
- Verified live against a managed account: 5h/weekly percentages render in both the TUI footer and the web sidebar.

Includes a changeset (`@moonshot-ai/kimi-code` minor).