### PR TITLE
fix: clear config defaults via delete-capable replace writes

### DIFF
--- a/.changeset/clear-defaults-via-replace.md
+++ b/.changeset/clear-defaults-via-replace.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Fix the daemon leaving a stale default provider or default model behind when the default provider is removed or after OAuth logout.

--- a/packages/agent-core-v2/src/app/auth/authService.ts
+++ b/packages/agent-core-v2/src/app/auth/authService.ts
@@ -510,8 +510,10 @@ export class OAuthService extends Disposable implements IOAuthService {
       await this.config.replace(SERVICES_SECTION, next.services);
     }
     if (cleanup.defaultModelCleared) {
-      await this.config.set(DEFAULT_MODEL_SECTION, undefined);
-      await this.config.set(THINKING_SECTION, undefined);
+      // `set()` cannot delete: its deepMerge resolves an undefined patch back
+      // to the existing base value. `replace()` removes the section instead.
+      await this.config.replace(DEFAULT_MODEL_SECTION, undefined);
+      await this.config.replace(THINKING_SECTION, undefined);
     }
   }
 

--- a/packages/agent-core-v2/src/app/provider/providerService.ts
+++ b/packages/agent-core-v2/src/app/provider/providerService.ts
@@ -64,7 +64,9 @@ export class ProviderService extends Disposable implements IProviderService {
     const { [name]: _removed, ...rest } = current;
     await this.config.replace(PROVIDERS_SECTION, rest);
     if (this.config.get<string>(DEFAULT_PROVIDER_SECTION) === name) {
-      await this.config.set(DEFAULT_PROVIDER_SECTION, undefined);
+      // `set()` cannot delete: its deepMerge resolves an undefined patch back
+      // to the existing base value. `replace()` removes the section instead.
+      await this.config.replace(DEFAULT_PROVIDER_SECTION, undefined);
     }
   }
 }

--- a/packages/agent-core-v2/test/app/auth/auth.test.ts
+++ b/packages/agent-core-v2/test/app/auth/auth.test.ts
@@ -133,6 +133,14 @@ describe('OAuthService', () => {
         services = value as Record<string, unknown> | undefined;
         return;
       }
+      if (domain === 'defaultModel') {
+        defaultModel = value as string | undefined;
+        return;
+      }
+      if (domain === 'thinking') {
+        thinking = value as { enabled?: boolean; effort?: string } | undefined;
+        return;
+      }
       throw new Error(`unexpected config replace: ${domain}`);
     });
     events = [];
@@ -593,8 +601,11 @@ describe('OAuthService', () => {
         maxContextSize: 8192,
       },
     });
-    expect(configSet).toHaveBeenCalledWith('defaultModel', undefined);
-    expect(configSet).toHaveBeenCalledWith('thinking', undefined);
+    // Clearing must go through `replace` — `set()`'s deepMerge cannot delete.
+    expect(configReplace).toHaveBeenCalledWith('defaultModel', undefined);
+    expect(configReplace).toHaveBeenCalledWith('thinking', undefined);
+    expect(defaultModel).toBeUndefined();
+    expect(thinking).toBeUndefined();
   });
 
   it('logout removes managed web services while preserving unrelated services', async () => {

--- a/packages/agent-core-v2/test/app/provider/provider.test.ts
+++ b/packages/agent-core-v2/test/app/provider/provider.test.ts
@@ -118,7 +118,8 @@ describe('ProviderService', () => {
     expect(configReplace).toHaveBeenCalledWith(PROVIDERS_SECTION, {
       p2: { type: 'kimi' },
     });
-    expect(configSet).toHaveBeenCalledWith('defaultProvider', undefined);
+    // Clearing must go through `replace` — `set()`'s deepMerge cannot delete.
+    expect(configReplace).toHaveBeenCalledWith('defaultProvider', undefined);
   });
 
   it('delete leaves defaultProvider when removing a different provider', async () => {
@@ -127,7 +128,7 @@ describe('ProviderService', () => {
     defaultProvider = 'p2';
     const svc = ix.get(IProviderService);
     await svc.delete('p1');
-    expect(configSet).not.toHaveBeenCalled();
+    expect(configReplace).toHaveBeenCalledTimes(1);
   });
 
   it('forwards providers section changes as onDidChangeProviders with a diff', () => {


### PR DESCRIPTION
## Related Issue

None — the problem is explained below. (Found while reviewing #1824.)

## Problem

In the agent-core-v2 daemon, removing the default provider or logging out of the managed OAuth account is supposed to clear the dangling defaults (`default_provider`, or `default_model` + `thinking`). The code called `IConfigService.set(section, undefined)` for those clears — but `set()` deep-merges, and for a scalar section its `deepMerge` resolves an `undefined` patch back to the existing base value (`patch ?? base`), so the "cleared" value is written straight back. In production the stale default survives forever; the unit tests passed only because their config stub assigns `undefined` directly.

## What changed

- `ProviderService.delete`: clear `defaultProvider` via `config.replace()` instead of `config.set()`.
- `AuthService` OAuth-logout cleanup: clear `defaultModel` and `thinking` via `config.replace()` instead of `config.set()`.
- `replace()` is the delete-capable write path: an explicit `undefined` removes the section from the persisted config (`stripEnv → undefined → delete`), which is exactly the semantic these call sites need.
- Tests: updated call-site assertions (`set` → `replace`), extended the auth test's `configReplace` stub to the two cleared sections, and added a live-`ConfigService` test pinning the contract — `set(undefined)` keeps the value, `replace(undefined)` deletes it — so the real merge semantics are covered, not just the stub behavior.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my fix works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.
