### PR TITLE
fix(vscode): allow editor mentions for files outside the working directory

### DIFF
--- a/apps/vscode/src/bridge-handler.ts
+++ b/apps/vscode/src/bridge-handler.ts
@@ -217,11 +217,14 @@ export class BridgeHandler {
     // documents (untitled:, git:, ...) have no meaningful path to mention.
     if (workDirUri === null || documentUri.scheme !== workDirUri.scheme) return null;
     const filePath = relativeWorkspacePath(workDirUri, documentUri) ?? documentUri.fsPath;
+    // Quote paths containing spaces, as the CLI/TUI mention completers do, so
+    // whitespace cannot split the path; any line range goes after the quote.
+    const mentionTarget = filePath.includes(" ") ? `"${filePath}"` : filePath;
 
-    if (selection.isEmpty) return `@${filePath}`;
+    if (selection.isEmpty) return `@${mentionTarget}`;
     return selection.start.line === selection.end.line
-      ? `@${filePath}:${selection.start.line + 1}`
-      : `@${filePath}:${selection.start.line + 1}-${selection.end.line + 1}`;
+      ? `@${mentionTarget}:${selection.start.line + 1}`
+      : `@${mentionTarget}:${selection.start.line + 1}-${selection.end.line + 1}`;
   }
 
   captureFileBaseline(

--- a/apps/vscode/src/bridge-handler.ts
+++ b/apps/vscode/src/bridge-handler.ts
@@ -210,14 +210,18 @@ export class BridgeHandler {
     selection: vscode.Selection,
   ): Promise<string | null> {
     const workDirUri = this.getWorkDirUri(webviewId);
-    if (workDirUri === null || !(await isWorkspacePathContained(workDirUri, documentUri))) return null;
-    const relativePath = relativeWorkspacePath(workDirUri, documentUri);
-    if (relativePath === undefined) return null;
+    // Mirror the CLI/TUI: no UI-level directory gate on mentions. Inside the
+    // working directory the mention is relative; outside it (for example a
+    // file under the session's additionalDirs) it falls back to the absolute
+    // path, and the session's tool layer decides readability. Virtual
+    // documents (untitled:, git:, ...) have no meaningful path to mention.
+    if (workDirUri === null || documentUri.scheme !== workDirUri.scheme) return null;
+    const filePath = relativeWorkspacePath(workDirUri, documentUri) ?? documentUri.fsPath;
 
-    if (selection.isEmpty) return `@${relativePath}`;
+    if (selection.isEmpty) return `@${filePath}`;
     return selection.start.line === selection.end.line
-      ? `@${relativePath}:${selection.start.line + 1}`
-      : `@${relativePath}:${selection.start.line + 1}-${selection.end.line + 1}`;
+      ? `@${filePath}:${selection.start.line + 1}`
+      : `@${filePath}:${selection.start.line + 1}-${selection.end.line + 1}`;
   }
 
   captureFileBaseline(

--- a/apps/vscode/test/workspace-paths.test.ts
+++ b/apps/vscode/test/workspace-paths.test.ts
@@ -1,6 +1,7 @@
 /**
- * Scenario: Webview file paths stay inside the selected working directory.
- * Responsibilities: directory/search/open/mention paths are scoped, normalized, and symlink-safe.
+ * Scenario: Webview file paths and the selected working directory.
+ * Responsibilities: directory/search/open paths are scoped, normalized, and symlink-safe;
+ * editor mentions use relative paths inside the working directory and absolute paths outside.
  * Wiring: real temporary local files plus the public handler/bridge surfaces;
  * VS Code host APIs are the only stubbed boundary.
  * Run: pnpm --filter kimi-code exec vitest run --config vitest.config.ts test/workspace-paths.test.ts
@@ -343,7 +344,7 @@ describe("Webview workspace paths (selected-directory containment)", () => {
     expect(mention).toBe("@src/inside.ts");
   });
 
-  it("omits an editor mention when the file is outside the selected working directory", async () => {
+  it("builds an absolute editor mention when the file is outside the selected working directory", async () => {
     const workDir = join(root, "project", "subproject");
     const sibling = join(root, "project", "sibling.ts");
     await mkdir(workDir, { recursive: true });
@@ -354,6 +355,35 @@ describe("Webview workspace paths (selected-directory containment)", () => {
     const mention = await bridge.getEditorMention(
       "view-1",
       vscodeHost.Uri.file(sibling) as vscode.Uri,
+      emptySelection(),
+    );
+
+    expect(mention).toBe(`@${sibling}`);
+  });
+
+  it("builds an absolute editor mention when the file is outside the workspace root", async () => {
+    const otherRoot = await mkdtemp(join(tmpdir(), "kimi-vscode-mention-outside-"));
+    extraRoots.push(otherRoot);
+    const outside = join(otherRoot, "App.java");
+    await writeFile(outside, "class App {}");
+    const bridge = createBridge();
+
+    const mention = await bridge.getEditorMention(
+      "view-1",
+      vscodeHost.Uri.file(outside) as vscode.Uri,
+      emptySelection(),
+    );
+
+    expect(mention).toBe(`@${outside}`);
+  });
+
+  it("omits an editor mention for a document that is not on the workspace file system", async () => {
+    const bridge = createBridge();
+    const untitled = vscodeHost.Uri.from({ scheme: "untitled", path: "Untitled-1" });
+
+    const mention = await bridge.getEditorMention(
+      "view-1",
+      untitled as vscode.Uri,
       emptySelection(),
     );
 

--- a/apps/vscode/test/workspace-paths.test.ts
+++ b/apps/vscode/test/workspace-paths.test.ts
@@ -377,6 +377,39 @@ describe("Webview workspace paths (selected-directory containment)", () => {
     expect(mention).toBe(`@${outside}`);
   });
 
+  it("quotes an absolute editor mention whose path contains spaces", async () => {
+    const otherRoot = await mkdtemp(join(tmpdir(), "kimi vscode mention space-"));
+    extraRoots.push(otherRoot);
+    const outside = join(otherRoot, "App.java");
+    await writeFile(outside, "class App {}");
+    const bridge = createBridge();
+
+    const mention = await bridge.getEditorMention(
+      "view-1",
+      vscodeHost.Uri.file(outside) as vscode.Uri,
+      emptySelection(),
+    );
+
+    expect(mention).toBe(`@"${outside}"`);
+  });
+
+  it("places the line range after the closing quote of a mention with spaces", async () => {
+    const workDir = join(root, "project");
+    const inside = join(workDir, "some dir", "inside.ts");
+    await mkdir(join(workDir, "some dir"), { recursive: true });
+    await writeFile(inside, "inside");
+    const bridge = createBridge();
+    await bridge.handle({ id: "set", method: Methods.SetWorkDir, params: { workDir } }, "view-1");
+
+    const mention = await bridge.getEditorMention(
+      "view-1",
+      vscodeHost.Uri.file(inside) as vscode.Uri,
+      { isEmpty: false, start: { line: 2 }, end: { line: 4 } } as vscode.Selection,
+    );
+
+    expect(mention).toBe('@"some dir/inside.ts":3-5');
+  });
+
   it("omits an editor mention for a document that is not on the workspace file system", async () => {
     const bridge = createBridge();
     const untitled = vscodeHost.Uri.from({ scheme: "untitled", path: "Untitled-1" });


### PR DESCRIPTION
## Related Issue

No linked issue — this comes from a user report; the problem is explained below.

## Problem

In a multi-root workspace, the session working directory is the first workspace folder. Using **Kimi Code: Insert Current File** (Alt+K) on any file from another root always fails with "The active file is outside the selected working directory." Configuring `workspace.additional_dir` in `.kimi-code/local.toml` makes the session able to read/write those files, but the mention still refuses, because the extension gated mentions on the session working directory only and never consulted the session's additionalDirs. The same false rejection happened for any file outside a custom selected working directory, even inside a single-root workspace. The CLI/TUI has no such gate: `@` completion covers the working directory plus additionalDirs, and any typed `@path` is passed through with readability decided by the session's tool layer.

## What changed

- Editor mentions no longer UI-gate on the working directory, matching the CLI/TUI: a file inside the working directory still mentions as a relative path; a file outside it (another workspace root, an additionalDir, anywhere on disk) mentions as an absolute path, and the session's tool layer decides readability.
- Still returns null (and shows the existing warning) when no workspace folder is open, or when the active document is virtual (untitled:, git:, etc.) and therefore has no meaningful path to reference.
- Tests: the outdated rejection case now asserts an absolute-path mention; added cases for a file outside the workspace root entirely and for a virtual (untitled) document.

No changeset: the VS Code extension is a private package released manually via `chore(vscode): release` commits, and no extension change has ever carried a changeset in this repo.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.