### PR TITLE
feat(vscode): conversation undo with exclusive, broadcast-pushed transcript refresh

### DIFF
--- a/apps/vscode/shared/bridge.ts
+++ b/apps/vscode/shared/bridge.ts
@@ -200,7 +200,9 @@ function validateParams(method: RpcMethod, params: unknown): boolean {
     case Methods.SetWorkDir:
       return isPlainObject(params) && (params["workDir"] === null || typeof params["workDir"] === "string");
     case Methods.LoadKimiSessionHistory:
-      return hasNonEmptyString(params, "kimiSessionId");
+      return isPlainObject(params)
+        && isNonEmptyString(params["kimiSessionId"])
+        && isOptionalType(params["reload"], "boolean");
     case Methods.DeleteKimiSession:
       return hasNonEmptyString(params, "sessionId");
     case Methods.ForkKimiSession:

--- a/apps/vscode/shared/bridge.ts
+++ b/apps/vscode/shared/bridge.ts
@@ -97,6 +97,7 @@ export const Events = {
   FileChangesUpdated: "fileChangesUpdated",
   RollbackInput: "rollbackInput",
   LoginUrl: "loginUrl",
+  ConversationHistoryChanged: "conversationHistoryChanged",
 } as const;
 
 const rpcMethods = new Set<string>(Object.values(Methods));

--- a/apps/vscode/shared/bridge.ts
+++ b/apps/vscode/shared/bridge.ts
@@ -200,9 +200,7 @@ function validateParams(method: RpcMethod, params: unknown): boolean {
     case Methods.SetWorkDir:
       return isPlainObject(params) && (params["workDir"] === null || typeof params["workDir"] === "string");
     case Methods.LoadKimiSessionHistory:
-      return isPlainObject(params)
-        && isNonEmptyString(params["kimiSessionId"])
-        && isOptionalType(params["reload"], "boolean");
+      return hasNonEmptyString(params, "kimiSessionId");
     case Methods.DeleteKimiSession:
       return hasNonEmptyString(params, "sessionId");
     case Methods.ForkKimiSession:

--- a/apps/vscode/shared/bridge.ts
+++ b/apps/vscode/shared/bridge.ts
@@ -37,6 +37,7 @@ export const Methods = {
   ResetSession: "resetSession",
   SetPlanMode: "setPlanMode",
   SteerChat: "steerChat",
+  UndoChat: "undoChat",
   RespondApproval: "respondApproval",
 
   GetKimiSessions: "getKimiSessions",
@@ -183,6 +184,12 @@ function validateParams(method: RpcMethod, params: unknown): boolean {
       return hasBoolean(params, "enabled");
     case Methods.SteerChat:
       return isPlainObject(params) && isContent(params["content"]);
+    case Methods.UndoChat:
+      return params === undefined || (
+        isPlainObject(params)
+        && (params["count"] === undefined
+          || (Number.isInteger(params["count"]) && (params["count"] as number) >= 1))
+      );
     case Methods.GetProjectFiles:
       return params === undefined || (
         isPlainObject(params)

--- a/apps/vscode/src/handlers/chat.handler.ts
+++ b/apps/vscode/src/handlers/chat.handler.ts
@@ -4,8 +4,9 @@ import { isKimiError } from "@moonshot-ai/kimi-code-sdk";
 import { Events, Methods } from "../../shared/bridge";
 import type { ApprovalResponse, ContentPart } from "../../shared/legacy-sdk";
 import { getUserMessage } from "../../shared/errors";
-import type { ErrorPhase } from "../../shared/types";
+import type { ErrorPhase, UIStreamEvent } from "../../shared/types";
 import { VSCodeSettings } from "../config/vscode-settings";
+import { replaySessionToWebviewEvents } from "../runtime/replay-adapter";
 import type { SessionRuntime } from "../runtime/session-runtime";
 import { isWorkspacePathContained, relativeWorkspacePath } from "../utils/workspace-path";
 import { parseHostSlashCommand, runHostSlashCommand } from "./slash-command";
@@ -133,7 +134,10 @@ const streamChat: Handler<StreamChatParams, { done: boolean }> = async (params, 
 
 const abortChat: Handler<void, { aborted: boolean }> = async (_, ctx) => {
   const runtime = ctx.getSession();
-  if (runtime !== undefined) await runtime.cancel();
+  // Do not claim an abort when there is no runtime to cancel — the webview
+  // would otherwise show the task as stopped while the engine keeps running.
+  if (runtime === undefined) return { aborted: false };
+  await runtime.cancel();
   return { aborted: true };
 };
 
@@ -160,6 +164,22 @@ const steerChat: Handler<{ content: string | ContentPart[] }, { ok: boolean }> =
   return { ok: true };
 };
 
+const undoChat: Handler<{ count?: number }, { events: UIStreamEvent[] }> = async (params, ctx) => {
+  const runtime = ctx.getSession();
+  if (runtime === undefined) throw new Error("There is no conversation to undo.");
+  const requested = Number(params?.count);
+  const count = Number.isFinite(requested) && requested >= 1 ? Math.floor(requested) : 1;
+  await runtime.undoHistory(count);
+
+  // Return a fresh replay so the webview can re-render the truncated
+  // conversation, mirroring how LoadKimiSessionHistory re-hydrates views.
+  const resumeState = runtime.session.getResumeState();
+  if (resumeState?.agents["main"] === undefined) {
+    throw new Error("Session history is unavailable.");
+  }
+  return { events: replaySessionToWebviewEvents(resumeState, runtime.id) };
+};
+
 const resetSession: Handler<void, { ok: boolean }> = async (_, ctx) => {
   const runtime = ctx.getSession();
   if (runtime !== undefined) injectedEditorContextSessions.delete(runtime.id);
@@ -175,6 +195,7 @@ export const chatHandlers: Record<string, Handler<any, any>> = {
   [Methods.RespondQuestion]: respondQuestion,
   [Methods.SetPlanMode]: setPlanMode,
   [Methods.SteerChat]: steerChat,
+  [Methods.UndoChat]: undoChat,
   [Methods.ResetSession]: resetSession,
 };
 

--- a/apps/vscode/src/handlers/chat.handler.ts
+++ b/apps/vscode/src/handlers/chat.handler.ts
@@ -4,10 +4,9 @@ import { isKimiError } from "@moonshot-ai/kimi-code-sdk";
 import { Events, Methods } from "../../shared/bridge";
 import type { ApprovalResponse, ContentPart } from "../../shared/legacy-sdk";
 import { getUserMessage } from "../../shared/errors";
-import type { ErrorPhase, UIStreamEvent } from "../../shared/types";
+import type { ErrorPhase } from "../../shared/types";
 import { VSCodeSettings } from "../config/vscode-settings";
 import { normalizeEffort } from "../runtime/kimi-runtime";
-import { replaySessionToWebviewEvents } from "../runtime/replay-adapter";
 import type { SessionRuntime } from "../runtime/session-runtime";
 import { isWorkspacePathContained, relativeWorkspacePath } from "../utils/workspace-path";
 import { parseHostSlashCommand, runHostSlashCommand } from "./slash-command";
@@ -177,23 +176,15 @@ const steerChat: Handler<{ content: string | ContentPart[] }, { ok: boolean }> =
   return { ok: true };
 };
 
-const undoChat: Handler<{ count?: number }, { events: UIStreamEvent[] }> = async (params, ctx) => {
+const undoChat: Handler<{ count?: number }, { ok: boolean }> = async (params, ctx) => {
   const runtime = ctx.getSession();
   if (runtime === undefined) throw new Error("There is no conversation to undo.");
   const requested = Number(params?.count);
   const count = Number.isFinite(requested) && requested >= 1 ? Math.floor(requested) : 1;
+  // The runtime broadcasts ConversationHistoryChanged to every subscribed
+  // view on success; each view rehydrates via LoadKimiSessionHistory.
   await runtime.undoHistory(count);
-
-  // Refresh the SDK's cached resume state before replaying: undoHistory
-  // mutates the engine but does not update the cache, which would otherwise
-  // replay the pre-undo conversation (resumed sessions) or be absent
-  // entirely (sessions created in this process).
-  await runtime.session.reloadSession();
-  const resumeState = runtime.session.getResumeState();
-  if (resumeState?.agents["main"] === undefined) {
-    throw new Error("Session history is unavailable.");
-  }
-  return { events: replaySessionToWebviewEvents(resumeState, runtime.id) };
+  return { ok: true };
 };
 
 const resetSession: Handler<void, { ok: boolean }> = async (_, ctx) => {

--- a/apps/vscode/src/handlers/chat.handler.ts
+++ b/apps/vscode/src/handlers/chat.handler.ts
@@ -6,6 +6,7 @@ import type { ApprovalResponse, ContentPart } from "../../shared/legacy-sdk";
 import { getUserMessage } from "../../shared/errors";
 import type { ErrorPhase, UIStreamEvent } from "../../shared/types";
 import { VSCodeSettings } from "../config/vscode-settings";
+import { normalizeEffort } from "../runtime/kimi-runtime";
 import { replaySessionToWebviewEvents } from "../runtime/replay-adapter";
 import type { SessionRuntime } from "../runtime/session-runtime";
 import { isWorkspacePathContained, relativeWorkspacePath } from "../utils/workspace-path";
@@ -102,11 +103,23 @@ const streamChat: Handler<StreamChatParams, { done: boolean }> = async (params, 
   }
 
   try {
+    // Attach no longer overwrites session modes with the configured defaults
+    // (resumed sessions keep their own), so apply the model/effort that the
+    // composer submitted with this prompt before the turn starts.
     const status = await runtime.session.getStatus();
+    let model = status.model;
+    if (params.model && model !== params.model) {
+      await runtime.session.setModel(params.model);
+      model = params.model;
+    }
+    const effort = normalizeEffort(params.effort ?? (params.thinking === true ? "on" : "off"));
+    if (status.thinkingEffort !== effort) {
+      await runtime.session.setThinking(effort);
+    }
     if (params.planMode !== undefined && status.planMode !== params.planMode) {
       await runtime.session.setPlanMode(params.planMode);
     }
-    runtime.announceSessionStart(status.model);
+    runtime.announceSessionStart(model);
   } catch (error) {
     emitCaughtError(ctx, error, "preflight", runtime.id);
     return { done: false };
@@ -171,8 +184,11 @@ const undoChat: Handler<{ count?: number }, { events: UIStreamEvent[] }> = async
   const count = Number.isFinite(requested) && requested >= 1 ? Math.floor(requested) : 1;
   await runtime.undoHistory(count);
 
-  // Return a fresh replay so the webview can re-render the truncated
-  // conversation, mirroring how LoadKimiSessionHistory re-hydrates views.
+  // Refresh the SDK's cached resume state before replaying: undoHistory
+  // mutates the engine but does not update the cache, which would otherwise
+  // replay the pre-undo conversation (resumed sessions) or be absent
+  // entirely (sessions created in this process).
+  await runtime.session.reloadSession();
   const resumeState = runtime.session.getResumeState();
   if (resumeState?.agents["main"] === undefined) {
     throw new Error("Session history is unavailable.");

--- a/apps/vscode/src/handlers/session.handler.ts
+++ b/apps/vscode/src/handlers/session.handler.ts
@@ -17,7 +17,6 @@ const SESSION_ID = /^[A-Za-z0-9][A-Za-z0-9_-]{0,127}$/;
 
 interface LoadHistoryParams {
   kimiSessionId: string;
-  reload?: boolean;
 }
 
 interface DeleteSessionParams {
@@ -136,12 +135,6 @@ export const sessionHandlers: Record<string, Handler<any, any>> = {
 
     let history: ReturnType<typeof replaySessionToWebviewEvents>;
     try {
-      // When the caller knows the conversation was mutated (undo), refresh the
-      // SDK's cached resume state at the replay source — otherwise an attached
-      // runtime replays the pre-mutation transcript from its stale cache.
-      if (params.reload === true) {
-        await runtime.session.reloadSession();
-      }
       const resumeState = runtime.session.getResumeState();
       if (resumeState?.agents["main"] === undefined) {
         throw new Error("Session history is unavailable.");

--- a/apps/vscode/src/handlers/session.handler.ts
+++ b/apps/vscode/src/handlers/session.handler.ts
@@ -17,6 +17,7 @@ const SESSION_ID = /^[A-Za-z0-9][A-Za-z0-9_-]{0,127}$/;
 
 interface LoadHistoryParams {
   kimiSessionId: string;
+  reload?: boolean;
 }
 
 interface DeleteSessionParams {
@@ -135,6 +136,12 @@ export const sessionHandlers: Record<string, Handler<any, any>> = {
 
     let history: ReturnType<typeof replaySessionToWebviewEvents>;
     try {
+      // When the caller knows the conversation was mutated (undo), refresh the
+      // SDK's cached resume state at the replay source — otherwise an attached
+      // runtime replays the pre-mutation transcript from its stale cache.
+      if (params.reload === true) {
+        await runtime.session.reloadSession();
+      }
       const resumeState = runtime.session.getResumeState();
       if (resumeState?.agents["main"] === undefined) {
         throw new Error("Session history is unavailable.");

--- a/apps/vscode/src/runtime/kimi-runtime.ts
+++ b/apps/vscode/src/runtime/kimi-runtime.ts
@@ -267,7 +267,7 @@ async function applySessionSettings(
   }
 }
 
-function normalizeEffort(effort: string): ThinkingEffort {
+export function normalizeEffort(effort: string): ThinkingEffort {
   return (effort.trim() || "off") as ThinkingEffort;
 }
 

--- a/apps/vscode/src/runtime/kimi-runtime.ts
+++ b/apps/vscode/src/runtime/kimi-runtime.ts
@@ -256,14 +256,11 @@ async function applySessionSettings(
   legacyApproval: LegacyApprovalFlags,
 ): Promise<void> {
   const status = await session.getStatus();
-  if (options.model && status.model !== options.model) {
-    await session.setModel(options.model);
-  }
-  // Thinking effort is applied only when the session is created (see
-  // openSession). An existing session keeps its own effort — the global
-  // config value is a default for new sessions, matching CLI/TUI resume
-  // semantics. Effort changes made in the picker reach the active session
-  // through the SaveConfig handler instead.
+  // Model and thinking effort are applied only when the session is created
+  // (see openSession). An existing session keeps its own — the global config
+  // values are defaults for new sessions, matching CLI/TUI resume semantics.
+  // Changes made in the pickers reach the active session through the
+  // SaveConfig handler instead.
   const permission = corePermissionForLegacyApproval(legacyApproval);
   if (status.permission !== permission) {
     await session.setPermission(permission);

--- a/apps/vscode/src/runtime/session-runtime.ts
+++ b/apps/vscode/src/runtime/session-runtime.ts
@@ -327,7 +327,11 @@ export class SessionRuntime {
   }
 
   async cancel(): Promise<void> {
-    if (this.closed || !this.hasActiveWork) return;
+    // Always reach the engine, even when the host believes nothing is active.
+    // The host-side bookkeeping can drift from engine truth after an abnormal
+    // error path; session.cancel() is a harmless no-op when the engine is
+    // idle, but it is the only way to recover a turn the host lost track of.
+    if (this.closed) return;
     this.reverseRpc.cancelAll("Turn cancelled");
     const cancellingHostAction = this.hostActionActive;
     const hostActionId = this.activeHostActionId;
@@ -345,6 +349,19 @@ export class SessionRuntime {
     ]);
     const failure = results.find((result): result is PromiseRejectedResult => result.status === "rejected");
     if (failure !== undefined) throw failure.reason;
+  }
+
+  /**
+   * Drop the last `count` user turns from the conversation, matching the
+   * CLI's /undo. Only meaningful while idle; the engine itself reports when
+   * there is nothing (or a compaction boundary) left to undo.
+   */
+  async undoHistory(count: number): Promise<void> {
+    this.ensureOpen();
+    if (this.isBusy) {
+      throw new Error("Wait for the current response to finish before undoing.");
+    }
+    await this.session.undoHistory(count);
   }
 
   /**

--- a/apps/vscode/src/runtime/session-runtime.ts
+++ b/apps/vscode/src/runtime/session-runtime.ts
@@ -353,15 +353,31 @@ export class SessionRuntime {
 
   /**
    * Drop the last `count` user turns from the conversation, matching the
-   * CLI's /undo. Only meaningful while idle; the engine itself reports when
-   * there is nothing (or a compaction boundary) left to undo.
+   * CLI's /undo. Runs as one exclusive operation: undo + reload are seized so
+   * a double-click or an incoming prompt cannot race the truncation. Every
+   * subscribed view is notified to re-hydrate its transcript afterwards;
+   * a reload failure only downgrades that refresh to a best-effort one —
+   * the undo itself has already landed in the engine.
    */
   async undoHistory(count: number): Promise<void> {
     this.ensureOpen();
     if (this.isBusy) {
       throw new Error("Wait for the current response to finish before undoing.");
     }
-    await this.session.undoHistory(count);
+    this.exclusiveActionActive = true;
+    try {
+      await this.session.undoHistory(count);
+      try {
+        await this.session.reloadSession();
+      } catch (error) {
+        this.log("Failed to reload the session after undo; views rehydrate from persisted records", error);
+      }
+      for (const webviewId of this.webviewIds) {
+        this.broadcast(Events.ConversationHistoryChanged, { sessionId: this.id }, webviewId);
+      }
+    } finally {
+      this.exclusiveActionActive = false;
+    }
   }
 
   /**

--- a/apps/vscode/src/runtime/session-runtime.ts
+++ b/apps/vscode/src/runtime/session-runtime.ts
@@ -353,11 +353,12 @@ export class SessionRuntime {
 
   /**
    * Drop the last `count` user turns from the conversation, matching the
-   * CLI's /undo. Runs as one exclusive operation so a double-click or an
-   * incoming prompt cannot race the truncation. Every subscribed view is
-   * told to re-hydrate afterwards; the actual replay refresh happens at the
-   * LoadKimiSessionHistory source (with reload), where each view reconciles
-   * against persisted records.
+   * CLI's /undo. Runs as one exclusive operation (undo + a single history
+   * reload) so a double-click or an incoming prompt cannot race the
+   * truncation, and so every subscribed view replays the same freshly
+   * reloaded state instead of each issuing its own reload RPC. A failed
+   * reload propagates: the undo already landed in the engine, so the caller
+   * must see the failure instead of views silently replaying stale cache.
    */
   async undoHistory(count: number): Promise<void> {
     this.ensureOpen();
@@ -367,6 +368,7 @@ export class SessionRuntime {
     this.exclusiveActionActive = true;
     try {
       await this.session.undoHistory(count);
+      await this.session.reloadSession();
       for (const webviewId of this.webviewIds) {
         this.broadcast(Events.ConversationHistoryChanged, { sessionId: this.id }, webviewId);
       }

--- a/apps/vscode/src/runtime/session-runtime.ts
+++ b/apps/vscode/src/runtime/session-runtime.ts
@@ -353,11 +353,11 @@ export class SessionRuntime {
 
   /**
    * Drop the last `count` user turns from the conversation, matching the
-   * CLI's /undo. Runs as one exclusive operation: undo + reload are seized so
-   * a double-click or an incoming prompt cannot race the truncation. Every
-   * subscribed view is notified to re-hydrate its transcript afterwards;
-   * a reload failure only downgrades that refresh to a best-effort one —
-   * the undo itself has already landed in the engine.
+   * CLI's /undo. Runs as one exclusive operation so a double-click or an
+   * incoming prompt cannot race the truncation. Every subscribed view is
+   * told to re-hydrate afterwards; the actual replay refresh happens at the
+   * LoadKimiSessionHistory source (with reload), where each view reconciles
+   * against persisted records.
    */
   async undoHistory(count: number): Promise<void> {
     this.ensureOpen();
@@ -367,11 +367,6 @@ export class SessionRuntime {
     this.exclusiveActionActive = true;
     try {
       await this.session.undoHistory(count);
-      try {
-        await this.session.reloadSession();
-      } catch (error) {
-        this.log("Failed to reload the session after undo; views rehydrate from persisted records", error);
-      }
       for (const webviewId of this.webviewIds) {
         this.broadcast(Events.ConversationHistoryChanged, { sessionId: this.id }, webviewId);
       }

--- a/apps/vscode/src/runtime/session-runtime.ts
+++ b/apps/vscode/src/runtime/session-runtime.ts
@@ -22,6 +22,7 @@ import {
   legacyApprovalMetadata,
   type LegacyApprovalFlags,
 } from "./legacy-approval";
+import { replaySessionToWebviewEvents } from "./replay-adapter";
 import { ReverseRpcController } from "./reverse-rpc";
 
 export type RuntimeBroadcast = (event: string, data: unknown, webviewId?: string) => void;
@@ -353,12 +354,13 @@ export class SessionRuntime {
 
   /**
    * Drop the last `count` user turns from the conversation, matching the
-   * CLI's /undo. Runs as one exclusive operation (undo + a single history
-   * reload) so a double-click or an incoming prompt cannot race the
-   * truncation, and so every subscribed view replays the same freshly
-   * reloaded state instead of each issuing its own reload RPC. A failed
-   * reload propagates: the undo already landed in the engine, so the caller
-   * must see the failure instead of views silently replaying stale cache.
+   * CLI's /undo. Runs as one exclusive operation: undo, a single history
+   * reload, and one replay computation. The fresh transcript is then pushed
+   * to every subscribed view in the broadcast payload itself — views apply
+   * it locally and never call back into the engine, so nothing can race
+   * reloads or re-attach a view to the wrong session. A failed reload is
+   * reported distinctly: the undo already landed, so it must not look like
+   * a plain "undo failed".
    */
   async undoHistory(count: number): Promise<void> {
     this.ensureOpen();
@@ -368,9 +370,22 @@ export class SessionRuntime {
     this.exclusiveActionActive = true;
     try {
       await this.session.undoHistory(count);
-      await this.session.reloadSession();
+      try {
+        await this.session.reloadSession();
+      } catch (error) {
+        const detail = error instanceof Error ? error.message : String(error);
+        throw new Error(
+          `Undo applied, but refreshing the conversation failed: ${detail}. Use Reset Kimi to reconcile.`,
+          { cause: error },
+        );
+      }
+      const resumeState = this.session.getResumeState();
+      if (resumeState?.agents["main"] === undefined) {
+        throw new Error("Session history is unavailable.");
+      }
+      const events = replaySessionToWebviewEvents(resumeState, this.id);
       for (const webviewId of this.webviewIds) {
-        this.broadcast(Events.ConversationHistoryChanged, { sessionId: this.id }, webviewId);
+        this.broadcast(Events.ConversationHistoryChanged, { sessionId: this.id, events }, webviewId);
       }
     } finally {
       this.exclusiveActionActive = false;

--- a/apps/vscode/test/bridge-handler.test.ts
+++ b/apps/vscode/test/bridge-handler.test.ts
@@ -130,6 +130,37 @@ describe("Webview RPC boundary (validates requests before host dispatch)", () =>
     expect(showLogs).not.toHaveBeenCalled();
   });
 
+  it("reports aborted: false when the view has no runtime to cancel", async () => {
+    const result = await bridge.handle({ id: "rpc-1", method: Methods.AbortChat }, "view-1");
+
+    expect(result).toEqual({ id: "rpc-1", result: { aborted: false } });
+  });
+
+  it("cancels the view's runtime when aborting a chat", async () => {
+    const cancel = vi.fn(async () => undefined);
+    vi.spyOn(bridge.runtime, "getSessionForView").mockReturnValue({ cancel } as never);
+
+    const result = await bridge.handle({ id: "rpc-1", method: Methods.AbortChat }, "view-1");
+
+    expect(result).toEqual({ id: "rpc-1", result: { aborted: true } });
+    expect(cancel).toHaveBeenCalledOnce();
+  });
+
+  it("rejects undoChat when the view has no runtime", async () => {
+    const result = await bridge.handle({ id: "rpc-1", method: Methods.UndoChat }, "view-1");
+
+    expect(result).toEqual({ id: "rpc-1", error: "There is no conversation to undo." });
+  });
+
+  it("rejects an invalid undoChat count at the boundary", async () => {
+    const result = await bridge.handle(
+      { id: "rpc-1", method: Methods.UndoChat, params: { count: 0 } },
+      "view-1",
+    );
+
+    expect(result).toEqual({ id: "rpc-1", error: "Invalid bridge params for method: undoChat" });
+  });
+
   it.each(["missingMethod", "toString", "constructor", "__proto__"])(
     "does not dispatch the unknown or prototype method %s",
     async (method) => {

--- a/apps/vscode/test/bridge-handler.test.ts
+++ b/apps/vscode/test/bridge-handler.test.ts
@@ -440,9 +440,45 @@ describe("Webview RPC boundary (validates requests before host dispatch)", () =>
     );
     expect(next).toEqual({ id: "rpc-2", result: { ok: true } });
   });
+
+  it("reloads the resumed session before replaying when reload is requested", async () => {
+    const order: string[] = [];
+    const session = createResumedSession("session-1", root, order);
+    host.harness.resumeSession.mockResolvedValueOnce(session as never);
+
+    const result = await bridge.handle(
+      {
+        id: "rpc-1",
+        method: Methods.LoadKimiSessionHistory,
+        params: { kimiSessionId: "session-1", reload: true },
+      },
+      "view-1",
+    );
+
+    expect(result).toMatchObject({ id: "rpc-1" });
+    expect(order.indexOf("reloadSession")).toBeGreaterThanOrEqual(0);
+    expect(order.indexOf("reloadSession")).toBeLessThan(order.indexOf("getResumeState"));
+  });
+
+  it("does not reload the session for a plain history load", async () => {
+    const order: string[] = [];
+    const session = createResumedSession("session-1", root, order);
+    host.harness.resumeSession.mockResolvedValueOnce(session as never);
+
+    await bridge.handle(
+      {
+        id: "rpc-1",
+        method: Methods.LoadKimiSessionHistory,
+        params: { kimiSessionId: "session-1" },
+      },
+      "view-1",
+    );
+
+    expect(order).not.toContain("reloadSession");
+  });
 });
 
-function createResumedSession(id: string, workDir: string) {
+function createResumedSession(id: string, workDir: string, callOrder?: string[]) {
   const close = vi.fn(async () => undefined);
   const summary = {
     id,
@@ -457,35 +493,42 @@ function createResumedSession(id: string, workDir: string) {
     workDir,
     summary,
     close,
-    getResumeState: () => ({
-      sessionMetadata: { agents: {} },
-      agents: {
-        main: {
-          type: "main",
-          config: {
-            cwd: workDir,
-            modelAlias: "test-model",
-            modelCapabilities: {
-              image_in: false,
-              video_in: false,
-              audio_in: false,
-              thinking: false,
-              tool_use: true,
-              max_context_tokens: 128_000,
+    getResumeState: () => {
+      callOrder?.push("getResumeState");
+      return {
+        sessionMetadata: { agents: {} },
+        agents: {
+          main: {
+            type: "main",
+            config: {
+              cwd: workDir,
+              modelAlias: "test-model",
+              modelCapabilities: {
+                image_in: false,
+                video_in: false,
+                audio_in: false,
+                thinking: false,
+                tool_use: true,
+                max_context_tokens: 128_000,
+              },
+              thinkingEffort: "off",
+              systemPrompt: "",
             },
-            thinkingEffort: "off",
-            systemPrompt: "",
+            context: { history: [], tokenCount: 0 },
+            replay: [],
+            permission: { mode: "manual", rules: [] },
+            plan: null,
+            usage: {},
+            tools: [],
+            background: [],
           },
-          context: { history: [], tokenCount: 0 },
-          replay: [],
-          permission: { mode: "manual", rules: [] },
-          plan: null,
-          usage: {},
-          tools: [],
-          background: [],
         },
-      },
-    }),
+      };
+    },
+    reloadSession: async () => {
+      callOrder?.push("reloadSession");
+      return summary;
+    },
     getStatus: async () => ({ permission: "manual" }),
     setPermission: async () => undefined,
     updateMetadata: async () => undefined,

--- a/apps/vscode/test/bridge-handler.test.ts
+++ b/apps/vscode/test/bridge-handler.test.ts
@@ -440,45 +440,9 @@ describe("Webview RPC boundary (validates requests before host dispatch)", () =>
     );
     expect(next).toEqual({ id: "rpc-2", result: { ok: true } });
   });
-
-  it("reloads the resumed session before replaying when reload is requested", async () => {
-    const order: string[] = [];
-    const session = createResumedSession("session-1", root, order);
-    host.harness.resumeSession.mockResolvedValueOnce(session as never);
-
-    const result = await bridge.handle(
-      {
-        id: "rpc-1",
-        method: Methods.LoadKimiSessionHistory,
-        params: { kimiSessionId: "session-1", reload: true },
-      },
-      "view-1",
-    );
-
-    expect(result).toMatchObject({ id: "rpc-1" });
-    expect(order.indexOf("reloadSession")).toBeGreaterThanOrEqual(0);
-    expect(order.indexOf("reloadSession")).toBeLessThan(order.indexOf("getResumeState"));
-  });
-
-  it("does not reload the session for a plain history load", async () => {
-    const order: string[] = [];
-    const session = createResumedSession("session-1", root, order);
-    host.harness.resumeSession.mockResolvedValueOnce(session as never);
-
-    await bridge.handle(
-      {
-        id: "rpc-1",
-        method: Methods.LoadKimiSessionHistory,
-        params: { kimiSessionId: "session-1" },
-      },
-      "view-1",
-    );
-
-    expect(order).not.toContain("reloadSession");
-  });
 });
 
-function createResumedSession(id: string, workDir: string, callOrder?: string[]) {
+function createResumedSession(id: string, workDir: string) {
   const close = vi.fn(async () => undefined);
   const summary = {
     id,
@@ -493,42 +457,35 @@ function createResumedSession(id: string, workDir: string, callOrder?: string[])
     workDir,
     summary,
     close,
-    getResumeState: () => {
-      callOrder?.push("getResumeState");
-      return {
-        sessionMetadata: { agents: {} },
-        agents: {
-          main: {
-            type: "main",
-            config: {
-              cwd: workDir,
-              modelAlias: "test-model",
-              modelCapabilities: {
-                image_in: false,
-                video_in: false,
-                audio_in: false,
-                thinking: false,
-                tool_use: true,
-                max_context_tokens: 128_000,
-              },
-              thinkingEffort: "off",
-              systemPrompt: "",
+    getResumeState: () => ({
+      sessionMetadata: { agents: {} },
+      agents: {
+        main: {
+          type: "main",
+          config: {
+            cwd: workDir,
+            modelAlias: "test-model",
+            modelCapabilities: {
+              image_in: false,
+              video_in: false,
+              audio_in: false,
+              thinking: false,
+              tool_use: true,
+              max_context_tokens: 128_000,
             },
-            context: { history: [], tokenCount: 0 },
-            replay: [],
-            permission: { mode: "manual", rules: [] },
-            plan: null,
-            usage: {},
-            tools: [],
-            background: [],
+            thinkingEffort: "off",
+            systemPrompt: "",
           },
+          context: { history: [], tokenCount: 0 },
+          replay: [],
+          permission: { mode: "manual", rules: [] },
+          plan: null,
+          usage: {},
+          tools: [],
+          background: [],
         },
-      };
-    },
-    reloadSession: async () => {
-      callOrder?.push("reloadSession");
-      return summary;
-    },
+      },
+    }),
     getStatus: async () => ({ permission: "manual" }),
     setPermission: async () => undefined,
     updateMetadata: async () => undefined,

--- a/apps/vscode/test/kimi-harness.integration.test.ts
+++ b/apps/vscode/test/kimi-harness.integration.test.ts
@@ -1018,6 +1018,17 @@ describe("VS Code Kimi harness integration (shares one in-process SDK home)", ()
     await expect(runtime.session.getContext()).resolves.toEqual({ history: [], tokenCount: 0 });
   });
 
+  it("undoes the last user turn on a real session", async () => {
+    const rig = await createRuntimeRig();
+    routeSuccessfulPrompt(rig.provider);
+    const runtime = await openRuntimeSession(rig);
+    await expect(runtime.prompt("hello")).resolves.toEqual({ status: "finished" });
+
+    await runtime.undoHistory(1);
+
+    await expect(runtime.session.getContext()).resolves.toMatchObject({ history: [] });
+  });
+
   it("toggles plan mode through the public session without calling the model", async () => {
     const rig = await createRuntimeRig();
     const runtime = await openRuntimeSession(rig);

--- a/apps/vscode/test/kimi-harness.integration.test.ts
+++ b/apps/vscode/test/kimi-harness.integration.test.ts
@@ -1102,11 +1102,11 @@ describe("VS Code Kimi harness integration (shares one in-process SDK home)", ()
     );
 
     expect(result).toEqual({ ok: true });
-    expect(rig.broadcasts).toContainEqual({
-      event: Events.ConversationHistoryChanged,
-      data: { sessionId: runtime.id },
-      webviewId: "view-1",
-    });
+    const notice = rig.broadcasts.find((record) => record.event === Events.ConversationHistoryChanged);
+    expect(notice).toMatchObject({ webviewId: "view-1" });
+    const events = (notice?.data as { events: Array<{ type: string }> }).events;
+    expect(Array.isArray(events)).toBe(true);
+    expect(events.some((event) => event.type === "TurnBegin")).toBe(false);
     await expect(runtime.session.getContext()).resolves.toMatchObject({ history: [] });
   });
 
@@ -1124,11 +1124,9 @@ describe("VS Code Kimi harness integration (shares one in-process SDK home)", ()
     );
 
     expect(result).toEqual({ ok: true });
-    expect(rig.broadcasts).toContainEqual({
-      event: Events.ConversationHistoryChanged,
-      data: { sessionId: created.id },
-      webviewId: "view-1",
-    });
+    const notice = rig.broadcasts.find((record) => record.event === Events.ConversationHistoryChanged);
+    expect(notice).toMatchObject({ webviewId: "view-1" });
+    expect((notice?.data as { sessionId: string }).sessionId).toBe(created.id);
     await expect(runtime.session.getContext()).resolves.toMatchObject({ history: [] });
   });
 

--- a/apps/vscode/test/kimi-harness.integration.test.ts
+++ b/apps/vscode/test/kimi-harness.integration.test.ts
@@ -1101,7 +1101,12 @@ describe("VS Code Kimi harness integration (shares one in-process SDK home)", ()
       { getSession: () => runtime, logError: () => undefined } as unknown as HandlerContext,
     );
 
-    expect(Array.isArray((result as { events: unknown[] }).events)).toBe(true);
+    expect(result).toEqual({ ok: true });
+    expect(rig.broadcasts).toContainEqual({
+      event: Events.ConversationHistoryChanged,
+      data: { sessionId: runtime.id },
+      webviewId: "view-1",
+    });
     await expect(runtime.session.getContext()).resolves.toMatchObject({ history: [] });
   });
 
@@ -1118,8 +1123,13 @@ describe("VS Code Kimi harness integration (shares one in-process SDK home)", ()
       { getSession: () => runtime, logError: () => undefined } as unknown as HandlerContext,
     );
 
-    const events = (result as { events: Array<{ type: string }> }).events;
-    expect(events.some((event) => event.type === "TurnBegin")).toBe(false);
+    expect(result).toEqual({ ok: true });
+    expect(rig.broadcasts).toContainEqual({
+      event: Events.ConversationHistoryChanged,
+      data: { sessionId: created.id },
+      webviewId: "view-1",
+    });
+    await expect(runtime.session.getContext()).resolves.toMatchObject({ history: [] });
   });
 
   it("toggles plan mode through the public session without calling the model", async () => {

--- a/apps/vscode/test/kimi-harness.integration.test.ts
+++ b/apps/vscode/test/kimi-harness.integration.test.ts
@@ -22,6 +22,9 @@ vi.mock("vscode", () => ({
     showWarningMessage: async () => undefined,
     showTextDocument: async () => undefined,
   },
+  workspace: {
+    getConfiguration: () => ({ get: (_key: string, fallback: unknown) => fallback }),
+  },
 }));
 
 import {
@@ -35,6 +38,7 @@ import {
   type UpdateMCPServerRequest,
 } from "../shared/legacy-sdk";
 import { configHandlers } from "../src/handlers/config.handler";
+import { chatHandlers } from "../src/handlers/chat.handler";
 import { mcpHandlers } from "../src/handlers/mcp.handler";
 import { parseHostSlashCommand, runHostSlashCommand } from "../src/handlers/slash-command";
 import type { HandlerContext } from "../src/handlers/types";
@@ -80,7 +84,7 @@ afterEach(async () => {
   }
 });
 
-async function createRuntimeRig(): Promise<RuntimeRig> {
+async function createRuntimeRig(extraAliases: readonly string[] = []): Promise<RuntimeRig> {
   const rootDir = await mkdtemp(join(tmpdir(), "kimi-vscode-harness-"));
   const homeDir = join(rootDir, "home");
   const workDir = join(rootDir, "workspace");
@@ -94,7 +98,7 @@ async function createRuntimeRig(): Promise<RuntimeRig> {
     await provider.close();
   };
 
-  await writeProviderConfig(homeDir, `${provider.baseUrl}/v1`);
+  await writeProviderConfig(homeDir, `${provider.baseUrl}/v1`, extraAliases);
   const version = await readExtensionVersion();
   const broadcasts: BroadcastRecord[] = [];
   const logs: LogRecord[] = [];
@@ -184,7 +188,23 @@ async function readExtensionVersion(): Promise<string> {
   return parsed.version;
 }
 
-async function writeProviderConfig(homeDir: string, baseUrl: string): Promise<void> {
+async function writeProviderConfig(
+  homeDir: string,
+  baseUrl: string,
+  extraAliases: readonly string[] = [],
+): Promise<void> {
+  const extra = extraAliases
+    .map(
+      (alias) => `
+[models."${alias}"]
+provider = "local"
+model = "mock-model"
+max_context_size = 128000
+capabilities = ["thinking"]
+support_efforts = ["low", "high"]
+`,
+    )
+    .join("\n");
   await writeFile(
     join(homeDir, "config.toml"),
     `default_model = "${MODEL_ALIAS}"
@@ -198,7 +218,7 @@ api_key = "${PROVIDER_TOKEN}"
 provider = "local"
 model = "mock-model"
 max_context_size = 128000
-
+${extra}
 [loop_control]
 max_retries_per_step = 1
 `,
@@ -268,6 +288,30 @@ async function openRuntimeSession(rig: RuntimeRig, sessionId?: string, yoloMode 
     effort: "off",
     yoloMode,
   });
+}
+
+function streamChatContext(rig: RuntimeRig): HandlerContext {
+  return {
+    workDir: rig.workDir,
+    webviewId: "view-1",
+    broadcast: (event: string, data: unknown, webviewId?: string) => {
+      rig.broadcasts.push({ event, data, webviewId });
+    },
+    getOrCreateSession: async (model: string, effort: string, sessionId?: string) =>
+      rig.runtime.openSession({
+        webviewId: "view-1",
+        workDir: rig.workDir,
+        ...(sessionId === undefined ? {} : { sessionId }),
+        model,
+        effort,
+        yoloMode: false,
+      }),
+    getSession: () => rig.runtime.getSessionForView("view-1"),
+    saveAllDirty: async () => undefined,
+    logError: (message: string, error: unknown) => {
+      rig.logs.push({ message, error });
+    },
+  } as unknown as HandlerContext;
 }
 
 function streamEvents(broadcasts: readonly BroadcastRecord[]): unknown[] {
@@ -1027,6 +1071,55 @@ describe("VS Code Kimi harness integration (shares one in-process SDK home)", ()
     await runtime.undoHistory(1);
 
     await expect(runtime.session.getContext()).resolves.toMatchObject({ history: [] });
+  });
+
+  it("applies the composer-submitted model before the turn starts", async () => {
+    const rig = await createRuntimeRig(["vscode-alt"]);
+    routeSuccessfulPrompt(rig.provider);
+    const runtime = await openRuntimeSession(rig);
+
+    const result = await chatHandlers[Methods.StreamChat]!(
+      { content: "hi", model: "vscode-alt", effort: "high" },
+      streamChatContext(rig),
+    );
+
+    expect(result).toEqual({ done: true });
+    await expect(runtime.session.getStatus()).resolves.toMatchObject({
+      model: "vscode-alt",
+      thinkingEffort: "high",
+    });
+  });
+
+  it("returns a fresh replay when undoing in a session created during this process", async () => {
+    const rig = await createRuntimeRig();
+    routeSuccessfulPrompt(rig.provider);
+    const runtime = await openRuntimeSession(rig);
+    await expect(runtime.prompt("hello")).resolves.toEqual({ status: "finished" });
+
+    const result = await chatHandlers[Methods.UndoChat]!(
+      {},
+      { getSession: () => runtime, logError: () => undefined } as unknown as HandlerContext,
+    );
+
+    expect(Array.isArray((result as { events: unknown[] }).events)).toBe(true);
+    await expect(runtime.session.getContext()).resolves.toMatchObject({ history: [] });
+  });
+
+  it("does not replay the pre-undo conversation when undoing a resumed session", async () => {
+    const rig = await createRuntimeRig();
+    routeSuccessfulPrompt(rig.provider);
+    const created = await openRuntimeSession(rig);
+    await expect(created.prompt("hello")).resolves.toEqual({ status: "finished" });
+    await rig.runtime.detachView("view-1");
+
+    const runtime = await openRuntimeSession(rig, created.id);
+    const result = await chatHandlers[Methods.UndoChat]!(
+      {},
+      { getSession: () => runtime, logError: () => undefined } as unknown as HandlerContext,
+    );
+
+    const events = (result as { events: Array<{ type: string }> }).events;
+    expect(events.some((event) => event.type === "TurnBegin")).toBe(false);
   });
 
   it("toggles plan mode through the public session without calling the model", async () => {

--- a/apps/vscode/test/kimi-runtime.test.ts
+++ b/apps/vscode/test/kimi-runtime.test.ts
@@ -343,13 +343,14 @@ describe("Kimi runtime (owns shared SDK sessions for Webviews)", () => {
     expect(boundary.handlerInstallations).toEqual({ approval: 1, question: 1 });
   });
 
-  it("updates the SDK model when the resumed session has a different model", async () => {
+  it("preserves the resumed session's model instead of reapplying the configured default", async () => {
     const { runtime, sdk } = createRuntime();
     const session = sdk.addSession("saved-1", "/workspace", { model: "old-model" });
 
-    await runtime.openSession(openOptions({ sessionId: "saved-1", model: "new-model" }));
+    const opened = await runtime.openSession(openOptions({ sessionId: "saved-1", model: "new-model" }));
 
-    expect(session.setModels).toEqual(["new-model"]);
+    expect(session.setModels).toEqual([]);
+    await expect(opened.session.getStatus()).resolves.toMatchObject({ model: "old-model" });
   });
 
   it("preserves the resumed session's thinking effort instead of reapplying the configured default", async () => {

--- a/apps/vscode/test/session-runtime.test.ts
+++ b/apps/vscode/test/session-runtime.test.ts
@@ -45,6 +45,7 @@ interface FakeSessionBoundary {
   readonly subscriptionCount: () => number;
   readonly cancelCount: () => number;
   readonly cancelCompactionCount: () => number;
+  readonly undoCounts: readonly number[];
   readonly closeCount: () => number;
   emit(event: Event): void;
   rejectNextPrompt(error: Error): void;
@@ -69,6 +70,7 @@ function createFakeSession(): FakeSessionBoundary {
   let subscriptions = 0;
   let cancellations = 0;
   let compactionCancellations = 0;
+  const undoCounts: number[] = [];
   let closes = 0;
   let permission: PermissionMode = "manual";
 
@@ -115,6 +117,9 @@ function createFakeSession(): FakeSessionBoundary {
     async cancelCompaction() {
       compactionCancellations += 1;
     },
+    async undoHistory(count: number) {
+      undoCounts.push(count);
+    },
     async getStatus() {
       return {
         thinkingEffort: "off",
@@ -152,6 +157,7 @@ function createFakeSession(): FakeSessionBoundary {
     subscriptionCount: () => subscriptions,
     cancelCount: () => cancellations,
     cancelCompactionCount: () => compactionCancellations,
+    undoCounts,
     closeCount: () => closes,
     emit(event) {
       for (const listener of listeners) listener(event);
@@ -506,6 +512,32 @@ describe("session runtime (adapts one SDK session for subscribed Webviews)", () 
     await runtime.cancel();
 
     expect(sdk.cancelCount()).toBe(1);
+  });
+
+  it("still reaches the SDK cancel when the host lost track of active work", async () => {
+    const { runtime, sdk } = createRuntime();
+
+    await runtime.cancel();
+
+    expect(sdk.cancelCount()).toBe(1);
+  });
+
+  it("forwards undoHistory to the SDK while the session is idle", async () => {
+    const { runtime, sdk } = createRuntime();
+
+    await runtime.undoHistory(2);
+
+    expect([...sdk.undoCounts]).toEqual([2]);
+  });
+
+  it("rejects undoHistory while a response is still generating", async () => {
+    const { runtime, sdk } = createRuntime();
+    void runtime.prompt("hello");
+
+    await expect(runtime.undoHistory(1)).rejects.toThrow(
+      "Wait for the current response to finish before undoing.",
+    );
+    expect(sdk.undoCounts).toEqual([]);
   });
 
   it("converts legacy media keys when steering an active response", async () => {

--- a/apps/vscode/test/session-runtime.test.ts
+++ b/apps/vscode/test/session-runtime.test.ts
@@ -133,6 +133,37 @@ function createFakeSession(): FakeSessionBoundary {
       reloads += 1;
       return summary;
     },
+    getResumeState() {
+      return {
+        sessionMetadata: { agents: {} },
+        agents: {
+          main: {
+            type: "main",
+            config: {
+              cwd: "/workspace",
+              modelAlias: "test-model",
+              modelCapabilities: {
+                image_in: false,
+                video_in: false,
+                audio_in: false,
+                thinking: false,
+                tool_use: true,
+                max_context_tokens: 128_000,
+              },
+              thinkingEffort: "off",
+              systemPrompt: "",
+            },
+            context: { history: [], tokenCount: 0 },
+            replay: [],
+            permission: { mode: "manual", rules: [] },
+            plan: null,
+            usage: {},
+            tools: [],
+            background: [],
+          },
+        },
+      };
+    },
     async getStatus() {
       return {
         thinkingEffort: "off",
@@ -539,36 +570,35 @@ describe("session runtime (adapts one SDK session for subscribed Webviews)", () 
     expect(sdk.cancelCount()).toBe(1);
   });
 
-  it("forwards undoHistory to the SDK while the session is idle and notifies views", async () => {
+  it("forwards undoHistory to the SDK while the session is idle and pushes the fresh transcript", async () => {
     const { runtime, sdk, broadcasts } = createRuntime();
 
     await runtime.undoHistory(2);
 
     expect([...sdk.undoCounts]).toEqual([2]);
     expect(sdk.reloadCount()).toBe(1);
-    expect(broadcasts).toContainEqual({
-      event: Events.ConversationHistoryChanged,
-      data: { sessionId: "session-1" },
-      webviewId: "view-1",
-    });
+    const notice = broadcasts.find((record) => record.event === Events.ConversationHistoryChanged);
+    expect(notice).toMatchObject({ webviewId: "view-1" });
+    expect((notice?.data as { sessionId: string; events: unknown[] }).sessionId).toBe("session-1");
+    expect(Array.isArray((notice?.data as { events: unknown[] }).events)).toBe(true);
   });
 
-  it("propagates a failed post-undo reload without broadcasting, then releases the guard", async () => {
+  it("marks the undo as applied when only the post-undo refresh fails, then releases the guard", async () => {
     const { runtime, sdk, broadcasts } = createRuntime();
     sdk.rejectNextReload(new Error("provider broke"));
 
-    await expect(runtime.undoHistory(1)).rejects.toThrow("provider broke");
+    await expect(runtime.undoHistory(1)).rejects.toThrow(
+      "Undo applied, but refreshing the conversation failed: provider broke",
+    );
     expect(broadcasts).not.toContainEqual(
       expect.objectContaining({ event: Events.ConversationHistoryChanged }),
     );
 
     await runtime.undoHistory(1);
     expect([...sdk.undoCounts]).toEqual([1, 1]);
-    expect(broadcasts).toContainEqual({
-      event: Events.ConversationHistoryChanged,
-      data: { sessionId: "session-1" },
-      webviewId: "view-1",
-    });
+    expect(broadcasts).toContainEqual(
+      expect.objectContaining({ event: Events.ConversationHistoryChanged, webviewId: "view-1" }),
+    );
   });
 
   it("rejects undoHistory while a response is still generating", async () => {

--- a/apps/vscode/test/session-runtime.test.ts
+++ b/apps/vscode/test/session-runtime.test.ts
@@ -46,6 +46,7 @@ interface FakeSessionBoundary {
   readonly cancelCount: () => number;
   readonly cancelCompactionCount: () => number;
   readonly undoCounts: readonly number[];
+  readonly reloadCount: () => number;
   readonly closeCount: () => number;
   emit(event: Event): void;
   rejectNextPrompt(error: Error): void;
@@ -71,6 +72,7 @@ function createFakeSession(): FakeSessionBoundary {
   let cancellations = 0;
   let compactionCancellations = 0;
   const undoCounts: number[] = [];
+  let reloads = 0;
   let closes = 0;
   let permission: PermissionMode = "manual";
 
@@ -120,6 +122,10 @@ function createFakeSession(): FakeSessionBoundary {
     async undoHistory(count: number) {
       undoCounts.push(count);
     },
+    async reloadSession() {
+      reloads += 1;
+      return summary;
+    },
     async getStatus() {
       return {
         thinkingEffort: "off",
@@ -158,6 +164,7 @@ function createFakeSession(): FakeSessionBoundary {
     cancelCount: () => cancellations,
     cancelCompactionCount: () => compactionCancellations,
     undoCounts,
+    reloadCount: () => reloads,
     closeCount: () => closes,
     emit(event) {
       for (const listener of listeners) listener(event);
@@ -522,12 +529,18 @@ describe("session runtime (adapts one SDK session for subscribed Webviews)", () 
     expect(sdk.cancelCount()).toBe(1);
   });
 
-  it("forwards undoHistory to the SDK while the session is idle", async () => {
-    const { runtime, sdk } = createRuntime();
+  it("forwards undoHistory to the SDK while the session is idle and notifies views", async () => {
+    const { runtime, sdk, broadcasts } = createRuntime();
 
     await runtime.undoHistory(2);
 
     expect([...sdk.undoCounts]).toEqual([2]);
+    expect(sdk.reloadCount()).toBe(1);
+    expect(broadcasts).toContainEqual({
+      event: Events.ConversationHistoryChanged,
+      data: { sessionId: "session-1" },
+      webviewId: "view-1",
+    });
   });
 
   it("rejects undoHistory while a response is still generating", async () => {
@@ -538,6 +551,44 @@ describe("session runtime (adapts one SDK session for subscribed Webviews)", () 
       "Wait for the current response to finish before undoing.",
     );
     expect(sdk.undoCounts).toEqual([]);
+  });
+
+  it("rejects a second undo while the first one is still running", async () => {
+    const { runtime, sdk } = createRuntime();
+    let releaseUndo!: () => void;
+    const gate = new Promise<void>((resolve) => {
+      releaseUndo = resolve;
+    });
+    const fakeSession = sdk.session as unknown as { undoHistory: (count: number) => Promise<void> };
+    const original = fakeSession.undoHistory.bind(fakeSession);
+    let calls = 0;
+    fakeSession.undoHistory = (count: number) => {
+      calls += 1;
+      return calls === 1 ? gate.then(() => original(count)) : original(count);
+    };
+
+    const first = runtime.undoHistory(1);
+    await expect(runtime.undoHistory(1)).rejects.toThrow(
+      "Wait for the current response to finish before undoing.",
+    );
+
+    releaseUndo();
+    await first;
+    expect(calls).toBe(1);
+  });
+
+  it("still notifies views when the post-undo reload fails", async () => {
+    const { runtime, sdk, broadcasts } = createRuntime();
+    const fakeSession = sdk.session as unknown as { reloadSession: () => Promise<unknown> };
+    fakeSession.reloadSession = () => Promise.reject(new Error("provider broke"));
+
+    await runtime.undoHistory(1);
+
+    expect(broadcasts).toContainEqual({
+      event: Events.ConversationHistoryChanged,
+      data: { sessionId: "session-1" },
+      webviewId: "view-1",
+    });
   });
 
   it("converts legacy media keys when steering an active response", async () => {

--- a/apps/vscode/test/session-runtime.test.ts
+++ b/apps/vscode/test/session-runtime.test.ts
@@ -46,7 +46,6 @@ interface FakeSessionBoundary {
   readonly cancelCount: () => number;
   readonly cancelCompactionCount: () => number;
   readonly undoCounts: readonly number[];
-  readonly reloadCount: () => number;
   readonly closeCount: () => number;
   emit(event: Event): void;
   rejectNextPrompt(error: Error): void;
@@ -72,7 +71,6 @@ function createFakeSession(): FakeSessionBoundary {
   let cancellations = 0;
   let compactionCancellations = 0;
   const undoCounts: number[] = [];
-  let reloads = 0;
   let closes = 0;
   let permission: PermissionMode = "manual";
 
@@ -122,10 +120,6 @@ function createFakeSession(): FakeSessionBoundary {
     async undoHistory(count: number) {
       undoCounts.push(count);
     },
-    async reloadSession() {
-      reloads += 1;
-      return summary;
-    },
     async getStatus() {
       return {
         thinkingEffort: "off",
@@ -164,7 +158,6 @@ function createFakeSession(): FakeSessionBoundary {
     cancelCount: () => cancellations,
     cancelCompactionCount: () => compactionCancellations,
     undoCounts,
-    reloadCount: () => reloads,
     closeCount: () => closes,
     emit(event) {
       for (const listener of listeners) listener(event);
@@ -535,7 +528,6 @@ describe("session runtime (adapts one SDK session for subscribed Webviews)", () 
     await runtime.undoHistory(2);
 
     expect([...sdk.undoCounts]).toEqual([2]);
-    expect(sdk.reloadCount()).toBe(1);
     expect(broadcasts).toContainEqual({
       event: Events.ConversationHistoryChanged,
       data: { sessionId: "session-1" },
@@ -575,20 +567,6 @@ describe("session runtime (adapts one SDK session for subscribed Webviews)", () 
     releaseUndo();
     await first;
     expect(calls).toBe(1);
-  });
-
-  it("still notifies views when the post-undo reload fails", async () => {
-    const { runtime, sdk, broadcasts } = createRuntime();
-    const fakeSession = sdk.session as unknown as { reloadSession: () => Promise<unknown> };
-    fakeSession.reloadSession = () => Promise.reject(new Error("provider broke"));
-
-    await runtime.undoHistory(1);
-
-    expect(broadcasts).toContainEqual({
-      event: Events.ConversationHistoryChanged,
-      data: { sessionId: "session-1" },
-      webviewId: "view-1",
-    });
   });
 
   it("converts legacy media keys when steering an active response", async () => {

--- a/apps/vscode/test/session-runtime.test.ts
+++ b/apps/vscode/test/session-runtime.test.ts
@@ -46,6 +46,8 @@ interface FakeSessionBoundary {
   readonly cancelCount: () => number;
   readonly cancelCompactionCount: () => number;
   readonly undoCounts: readonly number[];
+  readonly reloadCount: () => number;
+  rejectNextReload(error: Error): void;
   readonly closeCount: () => number;
   emit(event: Event): void;
   rejectNextPrompt(error: Error): void;
@@ -71,6 +73,8 @@ function createFakeSession(): FakeSessionBoundary {
   let cancellations = 0;
   let compactionCancellations = 0;
   const undoCounts: number[] = [];
+  let reloads = 0;
+  let nextReloadError: Error | undefined;
   let closes = 0;
   let permission: PermissionMode = "manual";
 
@@ -120,6 +124,15 @@ function createFakeSession(): FakeSessionBoundary {
     async undoHistory(count: number) {
       undoCounts.push(count);
     },
+    async reloadSession() {
+      if (nextReloadError !== undefined) {
+        const error = nextReloadError;
+        nextReloadError = undefined;
+        throw error;
+      }
+      reloads += 1;
+      return summary;
+    },
     async getStatus() {
       return {
         thinkingEffort: "off",
@@ -158,6 +171,10 @@ function createFakeSession(): FakeSessionBoundary {
     cancelCount: () => cancellations,
     cancelCompactionCount: () => compactionCancellations,
     undoCounts,
+    reloadCount: () => reloads,
+    rejectNextReload(error: Error) {
+      nextReloadError = error;
+    },
     closeCount: () => closes,
     emit(event) {
       for (const listener of listeners) listener(event);
@@ -528,6 +545,25 @@ describe("session runtime (adapts one SDK session for subscribed Webviews)", () 
     await runtime.undoHistory(2);
 
     expect([...sdk.undoCounts]).toEqual([2]);
+    expect(sdk.reloadCount()).toBe(1);
+    expect(broadcasts).toContainEqual({
+      event: Events.ConversationHistoryChanged,
+      data: { sessionId: "session-1" },
+      webviewId: "view-1",
+    });
+  });
+
+  it("propagates a failed post-undo reload without broadcasting, then releases the guard", async () => {
+    const { runtime, sdk, broadcasts } = createRuntime();
+    sdk.rejectNextReload(new Error("provider broke"));
+
+    await expect(runtime.undoHistory(1)).rejects.toThrow("provider broke");
+    expect(broadcasts).not.toContainEqual(
+      expect.objectContaining({ event: Events.ConversationHistoryChanged }),
+    );
+
+    await runtime.undoHistory(1);
+    expect([...sdk.undoCounts]).toEqual([1, 1]);
     expect(broadcasts).toContainEqual({
       event: Events.ConversationHistoryChanged,
       data: { sessionId: "session-1" },

--- a/apps/vscode/webview-ui/src/App.tsx
+++ b/apps/vscode/webview-ui/src/App.tsx
@@ -46,6 +46,21 @@ function MainContent({ onAuthAction }: { onAuthAction: () => void }) {
           toast.error(error instanceof Error ? error.message : String(error));
         });
       }),
+      // The runtime broadcasts this after a conversation-level mutation
+      // (e.g. undo); every subscribed view rehydrates so no webview keeps
+      // showing a transcript the engine already truncated.
+      bridge.on(Events.ConversationHistoryChanged, ({ sessionId: changedSessionId }: { sessionId: string }) => {
+        const store = useChatStore.getState();
+        if (store.sessionId !== changedSessionId) return;
+        void (async () => {
+          try {
+            const events = await bridge.loadSessionHistory(changedSessionId);
+            await store.loadSession(changedSessionId, events);
+          } catch (error) {
+            toast.error(`Failed to reload the conversation: ${error instanceof Error ? error.message : String(error)}`);
+          }
+        })();
+      }),
     ];
     return () => unsubs.forEach((u) => u());
   }, [setMCPServers, setExtensionConfig, startNewConversation]);

--- a/apps/vscode/webview-ui/src/App.tsx
+++ b/apps/vscode/webview-ui/src/App.tsx
@@ -53,7 +53,7 @@ function MainContent({ onAuthAction }: { onAuthAction: () => void }) {
         if (useChatStore.getState().sessionId !== changedSessionId) return;
         void (async () => {
           try {
-            const events = await bridge.loadSessionHistory(changedSessionId, true);
+            const events = await bridge.loadSessionHistory(changedSessionId);
             // The user may have switched conversations while the history was
             // loading — never yank the UI back to a session they have left.
             const store = useChatStore.getState();

--- a/apps/vscode/webview-ui/src/App.tsx
+++ b/apps/vscode/webview-ui/src/App.tsx
@@ -50,11 +50,14 @@ function MainContent({ onAuthAction }: { onAuthAction: () => void }) {
       // (e.g. undo); every subscribed view rehydrates so no webview keeps
       // showing a transcript the engine already truncated.
       bridge.on(Events.ConversationHistoryChanged, ({ sessionId: changedSessionId }: { sessionId: string }) => {
-        const store = useChatStore.getState();
-        if (store.sessionId !== changedSessionId) return;
+        if (useChatStore.getState().sessionId !== changedSessionId) return;
         void (async () => {
           try {
-            const events = await bridge.loadSessionHistory(changedSessionId);
+            const events = await bridge.loadSessionHistory(changedSessionId, true);
+            // The user may have switched conversations while the history was
+            // loading — never yank the UI back to a session they have left.
+            const store = useChatStore.getState();
+            if (store.sessionId !== changedSessionId) return;
             await store.loadSession(changedSessionId, events);
           } catch (error) {
             toast.error(`Failed to reload the conversation: ${error instanceof Error ? error.message : String(error)}`);

--- a/apps/vscode/webview-ui/src/App.tsx
+++ b/apps/vscode/webview-ui/src/App.tsx
@@ -46,24 +46,19 @@ function MainContent({ onAuthAction }: { onAuthAction: () => void }) {
           toast.error(error instanceof Error ? error.message : String(error));
         });
       }),
-      // The runtime broadcasts this after a conversation-level mutation
-      // (e.g. undo); every subscribed view rehydrates so no webview keeps
-      // showing a transcript the engine already truncated.
-      bridge.on(Events.ConversationHistoryChanged, ({ sessionId: changedSessionId }: { sessionId: string }) => {
-        if (useChatStore.getState().sessionId !== changedSessionId) return;
-        void (async () => {
-          try {
-            const events = await bridge.loadSessionHistory(changedSessionId);
-            // The user may have switched conversations while the history was
-            // loading — never yank the UI back to a session they have left.
-            const store = useChatStore.getState();
-            if (store.sessionId !== changedSessionId) return;
-            await store.loadSession(changedSessionId, events);
-          } catch (error) {
+      // The runtime pushes the freshly replayed transcript with this event
+      // (e.g. after undo); views just apply it locally — no round trip back
+      // into the engine that could re-attach this view to a stale session.
+      bridge.on(
+        Events.ConversationHistoryChanged,
+        ({ sessionId: changedSessionId, events }: { sessionId: string; events: UIStreamEvent[] }) => {
+          const store = useChatStore.getState();
+          if (store.sessionId !== changedSessionId) return;
+          void store.loadSession(changedSessionId, events).catch((error: unknown) => {
             toast.error(`Failed to reload the conversation: ${error instanceof Error ? error.message : String(error)}`);
-          }
-        })();
-      }),
+          });
+        },
+      ),
     ];
     return () => unsubs.forEach((u) => u());
   }, [setMCPServers, setExtensionConfig, startNewConversation]);

--- a/apps/vscode/webview-ui/src/components/inputarea/InputArea.tsx
+++ b/apps/vscode/webview-ui/src/components/inputarea/InputArea.tsx
@@ -1,6 +1,6 @@
 import { Fragment, useRef, useMemo, useState, useEffect, useCallback } from "react";
 import { useMemoizedFn } from "ahooks";
-import { IconSend, IconPlayerStop, IconChevronDown, IconPlus } from "@tabler/icons-react";
+import { IconSend, IconPlayerStop, IconChevronDown, IconPlus, IconArrowBackUp } from "@tabler/icons-react";
 import { Button } from "@/components/ui/button";
 import {
   DropdownMenu,
@@ -50,7 +50,7 @@ export function InputArea({ onAuthAction }: InputAreaProps) {
   const [cursorPos, setCursorPos] = useState(0);
   const [previewMedia, setPreviewMedia] = useState<string | null>(null);
 
-  const { isStreaming, sendMessage, abort, draftMedia, removeDraftMedia, hasProcessingMedia, getMediaInConversation, pendingInput, planMode } = useChatStore();
+  const { isStreaming, sendMessage, abort, draftMedia, removeDraftMedia, hasProcessingMedia, getMediaInConversation, pendingInput, planMode, undoLastTurn, sessionId, messages } = useChatStore();
   const { currentModel, thinkingEffort, updateModel, toggleThinking, selectThinkingEffort, models, extensionConfig, getCurrentThinkingMode } = useSettingsStore();
 
   const isProcessing = hasProcessingMedia();
@@ -463,6 +463,21 @@ export function InputArea({ onAuthAction }: InputAreaProps) {
             </div>
 
             <div className="flex items-center gap-2 shrink-0">
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Button
+                    variant="ghost"
+                    size="icon-xs"
+                    onClick={() => void undoLastTurn()}
+                    disabled={isStreaming || sessionId === null || messages.length === 0}
+                    className="text-muted-foreground"
+                  >
+                    <IconArrowBackUp className="size-3.5" />
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent>Undo last turn</TooltipContent>
+              </Tooltip>
+
               <Tooltip>
                 <TooltipTrigger asChild>
                   <Button variant="ghost" size="icon-xs" onClick={handleAddButtonClick} className="text-muted-foreground">

--- a/apps/vscode/webview-ui/src/services/bridge.ts
+++ b/apps/vscode/webview-ui/src/services/bridge.ts
@@ -231,8 +231,8 @@ class Bridge {
     return this.call<{ ok: boolean; workDir: string | null }>(Methods.BrowseWorkDir);
   }
 
-  loadSessionHistory(sessionId: string) {
-    return this.call<UIStreamEvent[]>(Methods.LoadKimiSessionHistory, { kimiSessionId: sessionId });
+  loadSessionHistory(sessionId: string, reload = false) {
+    return this.call<UIStreamEvent[]>(Methods.LoadKimiSessionHistory, { kimiSessionId: sessionId, reload });
   }
 
   deleteSession(sessionId: string) {

--- a/apps/vscode/webview-ui/src/services/bridge.ts
+++ b/apps/vscode/webview-ui/src/services/bridge.ts
@@ -231,8 +231,8 @@ class Bridge {
     return this.call<{ ok: boolean; workDir: string | null }>(Methods.BrowseWorkDir);
   }
 
-  loadSessionHistory(sessionId: string, reload = false) {
-    return this.call<UIStreamEvent[]>(Methods.LoadKimiSessionHistory, { kimiSessionId: sessionId, reload });
+  loadSessionHistory(sessionId: string) {
+    return this.call<UIStreamEvent[]>(Methods.LoadKimiSessionHistory, { kimiSessionId: sessionId });
   }
 
   deleteSession(sessionId: string) {

--- a/apps/vscode/webview-ui/src/services/bridge.ts
+++ b/apps/vscode/webview-ui/src/services/bridge.ts
@@ -192,7 +192,7 @@ class Bridge {
   }
 
   undoChat(count = 1) {
-    return this.call<{ events: import("shared/types").UIStreamEvent[] }>(Methods.UndoChat, { count });
+    return this.call<{ ok: boolean }>(Methods.UndoChat, { count });
   }
 
   resetSession() {

--- a/apps/vscode/webview-ui/src/services/bridge.ts
+++ b/apps/vscode/webview-ui/src/services/bridge.ts
@@ -191,6 +191,10 @@ class Bridge {
     return this.call<{ aborted: boolean }>(Methods.AbortChat);
   }
 
+  undoChat(count = 1) {
+    return this.call<{ events: import("shared/types").UIStreamEvent[] }>(Methods.UndoChat, { count });
+  }
+
   resetSession() {
     return this.call<{ ok: boolean }>(Methods.ResetSession);
   }

--- a/apps/vscode/webview-ui/src/stores/chat.store.ts
+++ b/apps/vscode/webview-ui/src/stores/chat.store.ts
@@ -337,8 +337,9 @@ export const useChatStore = create<ChatState>((set, get) => ({
     const { sessionId, isStreaming } = get();
     if (sessionId === null || isStreaming) return;
     try {
-      const { events } = await bridge.undoChat(1);
-      await get().loadSession(sessionId, events);
+      await bridge.undoChat(1);
+      // All views (this one included) reload through the
+      // ConversationHistoryChanged broadcast from the runtime.
       toast.success("Undid the last turn.");
     } catch (error) {
       toast.error(`Failed to undo: ${error instanceof Error ? error.message : String(error)}`);

--- a/apps/vscode/webview-ui/src/stores/chat.store.ts
+++ b/apps/vscode/webview-ui/src/stores/chat.store.ts
@@ -106,6 +106,7 @@ export interface ChatState {
   retryLastMessage: () => void;
   processEvent: (event: UIStreamEvent) => void;
   loadSession: (sessionId: string, events: UIStreamEvent[]) => Promise<void>;
+  undoLastTurn: () => Promise<void>;
   startNewConversation: () => Promise<void>;
   abort: () => void;
   addDraftMedia: (id: string, dataUri?: string) => void;
@@ -330,6 +331,18 @@ export const useChatStore = create<ChatState>((set, get) => ({
       }),
     );
     useApprovalStore.getState().clearRequests();
+  },
+
+  undoLastTurn: async () => {
+    const { sessionId, isStreaming } = get();
+    if (sessionId === null || isStreaming) return;
+    try {
+      const { events } = await bridge.undoChat(1);
+      await get().loadSession(sessionId, events);
+      toast.success("Undid the last turn.");
+    } catch (error) {
+      toast.error(`Failed to undo: ${error instanceof Error ? error.message : String(error)}`);
+    }
   },
 
   startNewConversation: async () => {


### PR DESCRIPTION
## Related Issue

No issue — this is a feature parity addition for the VS Code extension. **Scope note:** the underlying bug fixes (reliable cancel, preserved session model on attach) were split into #1845 to land promptly; this PR is the remaining `feat`: conversation undo.

## Problem

The CLI has `/undo` (double-Esc) to drop the last user turns and rewind the conversation; the VS Code extension exposed fork and file-level undo, but no way to rewind the conversation itself, even though the SDK already supports `session.undoHistory(count)`. Users reported "还无法回退" as a top pain point.

## What changed

- **New `undoChat` bridge method + `SessionRuntime.undoHistory(count)`**: guarded to idle sessions, matching `session.undoHistory(count)` semantics (last N user turns; engine reports compaction-boundary/nothing-to-undo errors, surfaced via toast).
- **Undo runs as one exclusive session operation** (same guard class as fork): undo + a single history `reloadSession` + one replay computation. Double-clicking the button or sending a prompt mid-undo is rejected instead of removing extra turns or mixing states.
- **The fresh transcript is pushed to every subscribed view in the `ConversationHistoryChanged` broadcast payload** — webviews apply it locally with no engine round trip, so a view can never be re-attached to a stale session or race another view's reload. A failed post-undo reload is worded distinctly (`Undo applied, but refreshing the conversation failed: ... Use Reset Kimi to reconcile.`) so it can never be mistaken for "nothing was undone".
- **UI**: an "Undo last turn" toolbar button in the composer (disabled while streaming or with an empty conversation).

Tests: undo exclusivity (second undo rejected while the first is pending), busy-turn rejection, transcript push in the broadcast payload, distinct reload-failure wording + guard release, boundary validation for `undoChat` params, and end-to-end integration tests that prompt a real session (fresh and resumed) and verify the engine truncation and the pushed transcript.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset. (No changeset: vscode-extension-only change, nothing enters the CLI bundle.)
- [x] Ran `gen-docs` skill, or this PR needs no doc update. (CLI-parity UX; no user-facing docs affected.)
