### PR TITLE
fix(agent-core-v2): follow symlinks when loading AGENTS.md and reading files

### DIFF
--- a/.changeset/fix-agents-md-symlink.md
+++ b/.changeset/fix-agents-md-symlink.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Fix AGENTS.md files installed as symbolic links being ignored by the web backend.

--- a/packages/agent-core-v2/src/agent/profile/context.ts
+++ b/packages/agent-core-v2/src/agent/profile/context.ts
@@ -197,7 +197,7 @@ async function pathExists(deps: ProfileContextDeps, path: string): Promise<boole
 
 async function isFile(deps: ProfileContextDeps, path: string): Promise<boolean> {
   try {
-    const stat = await deps.fs.stat(path);
+    const stat = await deps.fs.stat(path, { followSymlinks: true });
     return stat.isFile;
   } catch {
     return false;

--- a/packages/agent-core-v2/src/os/backends/node-local/hostFsService.ts
+++ b/packages/agent-core-v2/src/os/backends/node-local/hostFsService.ts
@@ -14,6 +14,7 @@ import {
   mkdir,
   realpath as nodeRealpath,
   rm,
+  stat as nodeStat,
   writeFile,
 } from 'node:fs/promises';
 
@@ -187,9 +188,9 @@ export class HostFileSystem implements IHostFileSystem {
     }
   }
 
-  async stat(path: string): Promise<HostFileStat> {
+  async stat(path: string, options?: { followSymlinks?: boolean }): Promise<HostFileStat> {
     try {
-      const s = await lstat(path);
+      const s = options?.followSymlinks === true ? await nodeStat(path) : await lstat(path);
       return {
         isFile: s.isFile(),
         isDirectory: s.isDirectory(),

--- a/packages/agent-core-v2/src/os/interface/hostFileSystem.ts
+++ b/packages/agent-core-v2/src/os/interface/hostFileSystem.ts
@@ -44,7 +44,8 @@ export interface IHostFileSystem {
     options?: { encoding?: BufferEncoding; errors?: TextDecodeErrors },
   ): AsyncGenerator<string>;
   createExclusive(path: string, data: Uint8Array): Promise<boolean>;
-  stat(path: string): Promise<HostFileStat>;
+  /** Stats the entry itself (Node `lstat` semantics) unless `followSymlinks` resolves links to their target. */
+  stat(path: string, options?: { followSymlinks?: boolean }): Promise<HostFileStat>;
   readdir(path: string): Promise<readonly HostDirEntry[]>;
   mkdir(path: string, options?: { readonly recursive?: boolean }): Promise<void>;
   remove(path: string): Promise<void>;

--- a/packages/agent-core-v2/test/agent/profile/context.test.ts
+++ b/packages/agent-core-v2/test/agent/profile/context.test.ts
@@ -1,4 +1,4 @@
-import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { mkdir, mkdtemp, rm, symlink, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'pathe';
 
@@ -72,6 +72,26 @@ describe('loadAgentsMd user-level discovery', () => {
     const result = await loadAgentsMd({ fs, homeDir }, homeDir);
 
     expect(result.split('home branded').length - 1).toBe(1);
+  });
+});
+
+describe('loadAgentsMd symlinked files', () => {
+  it('follows symlinks when loading user-level and project-level AGENTS.md', async () => {
+    const targetDir = await mkdtemp(join(tmpdir(), 'kimi-agents-target-'));
+    extraDirs.push(targetDir);
+    const brandTarget = join(targetDir, 'brand-AGENTS.md');
+    const projectTarget = join(targetDir, 'project-AGENTS.md');
+    await writeFile(brandTarget, 'brand via symlink', 'utf-8');
+    await writeFile(projectTarget, 'project via symlink', 'utf-8');
+
+    await mkdir(join(homeDir, '.kimi-code'), { recursive: true });
+    await symlink(brandTarget, join(homeDir, '.kimi-code', 'AGENTS.md'));
+    await symlink(projectTarget, join(workDir, 'AGENTS.md'));
+
+    const result = await loadAgentsMd({ fs, homeDir }, workDir);
+
+    expect(result).toContain('brand via symlink');
+    expect(result).toContain('project via symlink');
   });
 });
 


### PR DESCRIPTION
## Related Issue

None — the problem is described below.

## Problem

The v2 engine's filesystem `stat` used `lstat` semantics, so symbolic links were never counted as regular files. Two user-visible consequences in the web backend (a common dotfiles setup is installing config/instruction files as symlinks):

- AGENTS.md instruction files installed as symlinks were silently dropped while assembling the system prompt.
- The `Read` tool rejected symlinked files with `"<path>" is not a file.`, and `ReadMediaFile` size checks measured the symlink itself instead of its target.

The CLI (v1 engine) follows symlinks and handles such files correctly, so CLI and web behavior diverged.

## What changed

- `IHostFileSystem.stat` accepts an optional `followSymlinks` flag; the default keeps the previous `lstat` semantics, so other consumers (e.g. directory listings that need to detect symlinks) are unaffected.
- The AGENTS.md loader, `Read`, and `ReadMediaFile` now stat with `followSymlinks`, matching the v1 CLI behavior.
- Added regression tests covering symlinked user-level and project-level AGENTS.md files, plus an assertion that the `Read` tool stats with `followSymlinks`.

Skill discovery and MCP config loading were audited for the same problem and are not affected: they use `node:fs` directly, which already follows symlinks.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.
