### PR TITLE
fix(agent-core-v2): follow symlinks in read and media tools

### DIFF
--- a/.changeset/fix-read-tool-symlink.md
+++ b/.changeset/fix-read-tool-symlink.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Fix the web backend's file-reading tools mishandling symbolic links: Read rejected them as not regular files, and media size checks measured the link instead of its target.

--- a/packages/agent-core-v2/src/agent/media/tools/read-media.ts
+++ b/packages/agent-core-v2/src/agent/media/tools/read-media.ts
@@ -329,7 +329,7 @@ export class ReadMediaFileTool implements BuiltinTool<ReadMediaFileInput> {
         };
       }
 
-      const stat = await this.fs.stat(safePath);
+      const stat = await this.fs.stat(safePath, { followSymlinks: true });
       if (stat.size === 0) {
         return { isError: true, output: `"${args.path}" is empty.` };
       }

--- a/packages/agent-core-v2/src/os/backends/node-local/tools/read.ts
+++ b/packages/agent-core-v2/src/os/backends/node-local/tools/read.ts
@@ -280,7 +280,7 @@ export class ReadTool implements BuiltinTool<ReadInput> {
     try {
       let stat: Awaited<ReturnType<IHostFileSystem['stat']>>;
       try {
-        stat = await this.fs.stat(safePath);
+        stat = await this.fs.stat(safePath, { followSymlinks: true });
       } catch (error) {
         if (isFileNotFoundError(error)) {
           return { isError: true, output: `"${args.path}" does not exist.` };

--- a/packages/agent-core-v2/test/os/backends/node-local/tools/read.test.ts
+++ b/packages/agent-core-v2/test/os/backends/node-local/tools/read.test.ts
@@ -222,6 +222,16 @@ describe('ReadTool', () => {
     });
   });
 
+  it('stats with followSymlinks so symlinked files stay readable', async () => {
+    const { fs, stat } = createSpiedFs('alpha\n');
+    const tool = new ReadTool(fs, createTestEnv(), PERMISSIVE_WORKSPACE);
+
+    const result = await execute(tool, { path: '/tmp/a.txt' });
+
+    expect(result.isError).not.toBe(true);
+    expect(stat).toHaveBeenCalledWith('/tmp/a.txt', { followSymlinks: true });
+  });
+
   it('normalizes pure CRLF files to the LF model view', async () => {
     const tool = toolWithContent('alpha\r\nbeta\r\n');
 


### PR DESCRIPTION
## Related Issue

Follow-up to #1840 (same root cause; that PR only covered AGENTS.md loading before it was merged).

## Problem

The v2 engine's filesystem `stat` uses `lstat` semantics, so symbolic links are not counted as regular files. Two user-visible consequences in the web backend (installing files as symlinks is a common dotfiles setup):

- The `Read` tool rejects symlinked files with `"<path>" is not a file.`
- `ReadMediaFile` size checks measure the symlink itself instead of its target, so oversized media behind a symlink bypasses the size limit.

The CLI (v1 engine) follows symlinks and handles such files correctly, so CLI and web behavior diverge.

## What changed

- `Read` and `ReadMediaFile` now stat with the `followSymlinks` option introduced in #1840, matching the v1 CLI behavior.
- Added a regression test asserting `Read` stats with `followSymlinks`.

Skill discovery and MCP config loading were audited for the same problem and are not affected: they use `node:fs` directly, which already follows symlinks.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.
