### PR TITLE
fix: escape * and ? in glob-to-regex and add runtime type check for candidatesTokenCount

### DIFF
--- a/packages/agent-core-v2/src/_base/execEnv/globPattern.ts
+++ b/packages/agent-core-v2/src/_base/execEnv/globPattern.ts
@@ -43,7 +43,7 @@ export function globPatternToRegex(pattern: string, caseSensitive: boolean): Reg
       case '\\': {
         if (i + 1 < pattern.length) {
           const next = pattern.charAt(i + 1);
-          regex += next.replaceAll(/[{}()+.\\[\]^$|]/g, '\\$&');
+          regex += next.replaceAll(/[{}()+.\\[\]^$|*?]/g, '\\$&');
           i++;
         } else {
           regex += '\\\\';

--- a/packages/agent-core-v2/src/app/llmProtocol/providers/google-genai.ts
+++ b/packages/agent-core-v2/src/app/llmProtocol/providers/google-genai.ts
@@ -543,7 +543,7 @@ export class GoogleGenAIStreamedMessage implements StreamedMessage {
           : 0;
       this._usage = {
         inputOther: Math.max(promptTokenCount - cachedContentTokenCount, 0),
-        output: (usageMetadata['candidatesTokenCount'] as number) ?? 0,
+        output: typeof usageMetadata['candidatesTokenCount'] === 'number' ? usageMetadata['candidatesTokenCount'] : 0,
         inputCacheRead: cachedContentTokenCount,
         inputCacheCreation: 0,
       };

--- a/packages/kaos/src/internal.ts
+++ b/packages/kaos/src/internal.ts
@@ -220,7 +220,7 @@ export function globPatternToRegex(pattern: string, caseSensitive: boolean): Reg
       case '\\': {
         if (i + 1 < pattern.length) {
           const next = pattern.charAt(i + 1);
-          regex += next.replaceAll(/[{}()+.\\[\]^$|]/g, '\\$&');
+          regex += next.replaceAll(/[{}()+.\\[\]^$|*?]/g, '\\$&');
           // Advance past the escaped character so it is not processed
           // again as a regex metacharacter. match literally.
           i++;

--- a/packages/kosong/src/providers/google-genai.ts
+++ b/packages/kosong/src/providers/google-genai.ts
@@ -632,7 +632,7 @@ export class GoogleGenAIStreamedMessage implements StreamedMessage {
           : 0;
       this._usage = {
         inputOther: Math.max(promptTokenCount - cachedContentTokenCount, 0),
-        output: (usageMetadata['candidatesTokenCount'] as number) ?? 0,
+        output: typeof usageMetadata['candidatesTokenCount'] === 'number' ? usageMetadata['candidatesTokenCount'] : 0,
         inputCacheRead: cachedContentTokenCount,
         inputCacheCreation: 0,
       };


### PR DESCRIPTION
## Problem

Two independent bugs:

### 1. `globPatternToRegex` missing `*` and `?` in regex escape character class

In the backslash-escape branch of `globPatternToRegex`, the regex metacharacter set `[{}()+.\\[\]^$|]` does not include `*` and `?`. When a glob pattern contains `\*` or `\?` (backslash-escaped literals), the resulting regex leaves `*` or `?` unescaped, turning them into quantifiers instead of literal matches.

**Affected files:**
- `packages/kaos/src/internal.ts` (line 223)
- `packages/agent-core-v2/src/_base/execEnv/globPattern.ts` (line 46)

### 2. Unsafe type assertion for `candidatesTokenCount`

`(usageMetadata['candidatesTokenCount'] as number) ?? 0` — the `as number` cast silences TypeScript but does not protect at runtime. If the field is `undefined`, the cast produces `undefined` (not `number`), and `??` correctly falls back to `0` only by accident of JS semantics. If the field is a non-number truthy value, it passes through unchecked. The adjacent `promptTokenCount` and `cachedContentTokenCount` fields already use a proper `typeof` guard; this field should match.

**Affected files:**
- `packages/kosong/src/providers/google-genai.ts` (line 635)
- `packages/agent-core-v2/src/app/llmProtocol/providers/google-genai.ts` (line 546)

## Fix

1. Added `*?` to the regex character class: `[{}()+.\\[\]^$|*?]`
2. Replaced `(usageMetadata['candidatesTokenCount'] as number) ?? 0` with `typeof usageMetadata['candidatesTokenCount'] === 'number' ? usageMetadata['candidatesTokenCount'] : 0`