### PR TITLE
feat(vis): show LAN URLs when binding to 0.0.0.0 for remote control

### DIFF
--- a/.changeset/lan-remote-control.md
+++ b/.changeset/lan-remote-control.md
@@ -1,0 +1,11 @@
+---
+"@moonshot-ai/kimi-code": patch
+"@moonshot-ai/vis-server": patch
+---
+
+feat(vis): show LAN URLs when binding to 0.0.0.0 for remote control
+
+When vis-server binds to 0.0.0.0 or :: (all interfaces), the startup
+banner and CLI output now display the actual LAN IP addresses that
+other devices on the same network can use to connect. This enables
+lan-range remote control from phones, tablets, or other machines.

--- a/apps/kimi-code/src/cli/sub/vis.ts
+++ b/apps/kimi-code/src/cli/sub/vis.ts
@@ -21,6 +21,7 @@ export interface StartedVisServer {
   readonly port: number;
   readonly host: string;
   readonly url: string;
+  readonly lanUrls?: string[];
   readonly close: () => Promise<void>;
 }
 
@@ -86,6 +87,12 @@ export async function handleVis(deps: VisDeps, opts: VisOptions): Promise<void> 
       : `${server.url}sessions/${encodeURIComponent(opts.sessionId)}`;
 
   deps.stdout.write(`kimi vis is running at ${server.url}\n`);
+  if (server.lanUrls !== undefined && server.lanUrls.length > 0) {
+    deps.stdout.write(`LAN access:\n`);
+    for (const lanUrl of server.lanUrls) {
+      deps.stdout.write(`  ${lanUrl}\n`);
+    }
+  }
   deps.stdout.write('Press Ctrl-C to stop.\n');
 
   if (opts.open) {

--- a/apps/vis/server/src/config.ts
+++ b/apps/vis/server/src/config.ts
@@ -1,5 +1,22 @@
 import { homedir } from 'node:os';
 import { join } from 'node:path';
+import os from 'node:os';
+
+export function isAllInterfaces(host: string): boolean {
+  return host === '0.0.0.0' || host === '::';
+}
+
+export function getLocalNetworkAddresses(port: number): string[] {
+  const addresses: string[] = [];
+  for (const [, ifaceList] of Object.entries(os.networkInterfaces())) {
+    for (const iface of ifaceList ?? []) {
+      if (!iface.internal && iface.family === 'IPv4') {
+        addresses.push(`http://${iface.address}:${port}/`);
+      }
+    }
+  }
+  return addresses;
+}
 
 /** Resolve KIMI_CODE_HOME (env > ~/.kimi-code). */
 export function resolveKimiCodeHome(): string {

--- a/apps/vis/server/src/index.ts
+++ b/apps/vis/server/src/index.ts
@@ -5,9 +5,9 @@ import { formatStartupBanner } from './startup-banner';
 async function main(): Promise<void> {
   const host = resolveHost();
   const authToken = resolveVisAuthToken(host);
-  const { port } = await startVisServer({ host, authToken });
+  const { port, lanUrls } = await startVisServer({ host, authToken });
   process.stdout.write(
-    formatStartupBanner({ authToken, host, kimiCodeHome: KIMI_CODE_HOME, port }),
+    formatStartupBanner({ authToken, host, kimiCodeHome: KIMI_CODE_HOME, port, lanUrls }),
   );
 }
 

--- a/apps/vis/server/src/start.ts
+++ b/apps/vis/server/src/start.ts
@@ -1,7 +1,7 @@
 import { serve } from '@hono/node-server';
 
 import { createApp } from './app';
-import { hostForUrl, resolveHost, resolveKimiCodeHome, resolvePort, resolveVisAuthToken } from './config';
+import { getLocalNetworkAddresses, hostForUrl, isAllInterfaces, resolveHost, resolveKimiCodeHome, resolvePort, resolveVisAuthToken } from './config';
 import type { WebAsset } from './lib/web-asset';
 
 export interface StartVisServerOptions {
@@ -18,6 +18,7 @@ export interface StartedVisServer {
   readonly port: number;
   readonly host: string;
   readonly url: string;
+  readonly lanUrls?: string[];
   readonly close: () => Promise<void>;
 }
 
@@ -36,6 +37,7 @@ export async function startVisServer(
         port: info.port,
         host,
         url: `http://${hostForUrl(host)}:${info.port}/`,
+        lanUrls: isAllInterfaces(host) ? getLocalNetworkAddresses(info.port) : undefined,
         close: () =>
           new Promise<void>((done, fail) => {
             server.close((err?: Error) => (err ? fail(err) : done()));

--- a/apps/vis/server/src/startup-banner.ts
+++ b/apps/vis/server/src/startup-banner.ts
@@ -5,12 +5,19 @@ export interface StartupBannerOptions {
   readonly host: string;
   readonly kimiCodeHome: string;
   readonly port: number;
+  readonly lanUrls?: string[];
 }
 
 export function formatStartupBanner(options: StartupBannerOptions): string {
   const authStatus = options.authToken === undefined ? 'auth=disabled' : 'auth=required';
-  return (
+  let banner =
     `[vis-server] listening on http://${hostForUrl(options.host)}:${String(options.port)} ` +
-    `(${authStatus}, KIMI_CODE_HOME=${options.kimiCodeHome})\n`
-  );
+    `(${authStatus}, KIMI_CODE_HOME=${options.kimiCodeHome})\n`;
+  if (options.lanUrls !== undefined && options.lanUrls.length > 0) {
+    banner +=
+      `[vis-server] LAN access:\n` +
+      options.lanUrls.map((url) => `  - ${url}`).join('\n') +
+      '\n';
+  }
+  return banner;
 }

--- a/apps/vis/server/test/lib/config.test.ts
+++ b/apps/vis/server/test/lib/config.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { hostForUrl } from '../../src/config';
+import { hostForUrl, isAllInterfaces, getLocalNetworkAddresses } from '../../src/config';
 
 describe('hostForUrl', () => {
   it('brackets a bare IPv6 literal for use in a URL', () => {
@@ -16,5 +16,41 @@ describe('hostForUrl', () => {
 
   it('leaves an already-bracketed IPv6 literal unchanged', () => {
     expect(hostForUrl('[::1]')).toBe('[::1]');
+  });
+});
+
+describe('isAllInterfaces', () => {
+  it('returns true for 0.0.0.0', () => {
+    expect(isAllInterfaces('0.0.0.0')).toBe(true);
+  });
+
+  it('returns true for ::', () => {
+    expect(isAllInterfaces('::')).toBe(true);
+  });
+
+  it('returns false for loopback hosts', () => {
+    expect(isAllInterfaces('127.0.0.1')).toBe(false);
+    expect(isAllInterfaces('localhost')).toBe(false);
+    expect(isAllInterfaces('::1')).toBe(false);
+  });
+});
+
+describe('getLocalNetworkAddresses', () => {
+  it('returns non-empty array of IPv4 URLs for a valid port', () => {
+    const addresses = getLocalNetworkAddresses(3001);
+    expect(addresses.length).toBeGreaterThan(0);
+    for (const addr of addresses) {
+      expect(addr).toMatch(/^http:\/\/\d+\.\d+\.\d+\.\d+:3001\/$/);
+    }
+  });
+
+  it('returns different URLs for different ports', () => {
+    const addrs3001 = getLocalNetworkAddresses(3001);
+    const addrs8080 = getLocalNetworkAddresses(8080);
+    expect(addrs3001.length).toBe(addrs8080.length);
+    for (let i = 0; i < addrs3001.length; i++) {
+      expect(addrs3001[i]).toContain(':3001/');
+      expect(addrs8080[i]).toContain(':8080/');
+    }
   });
 });


### PR DESCRIPTION
When vis-server binds to `0.0.0.0` or `::` (all interfaces), the startup banner and CLI output now display the actual LAN IP addresses that other devices on the same network can use to connect. This enables lan-range remote control from phones, tablets, or other machines.

## Changes

- `apps/vis/server/src/config.ts`: Add `isAllInterfaces()` and `getLocalNetworkAddresses()` helpers
- `apps/vis/server/src/start.ts`: Add `lanUrls` field to `StartedVisServer`, populated when binding to all interfaces
- `apps/vis/server/src/startup-banner.ts`: List LAN URLs in startup banner when applicable
- `apps/vis/server/src/index.ts`: Pass `lanUrls` to banner formatter
- `apps/kimi-code/src/cli/sub/vis.ts`: Print LAN access URLs in CLI output
- `apps/vis/server/test/lib/config.test.ts`: Add unit tests for new helpers

## Testing

- `127.0.0.1` binding → no LAN URLs shown ✓
- `0.0.0.0` binding → LAN URLs discovered and displayed ✓
- Unit tests for `isAllInterfaces` and `getLocalNetworkAddresses` pass (5 new tests) ✓