### PR TITLE
fix(acp-adapter): treat whitespace-only text blocks as separators, not standalone parts

### DIFF
--- a/.changeset/fix-acp-merge-adjacent-text-parts.md
+++ b/.changeset/fix-acp-merge-adjacent-text-parts.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Fix ACP prompts with multiple attached files failing as `Internal error: session prompt failed` in Zed and other ACP clients (#1777). Zed and similar orchestrators emit multi-attachment prompts as content blocks separated by whitespace-only text blocks — e.g. `[resource, text(" "), resource, text(" "), text("todo:...")]`. The adapter's `acpBlocksToPromptParts` used to convert each separator into its own `PromptPart`, which the SDK then rejected because per-part validation requires `text.trim().length > 0`. The failure came back as a generic `Internal error: session prompt failed`, with the real cause only in the local session log. Whitespace-only text blocks are now attached to the preceding text-producing part (or dropped when they lead a prompt), preserving the separators inside a valid part instead of standing alone.

--- a/packages/acp-adapter/src/convert.ts
+++ b/packages/acp-adapter/src/convert.ts
@@ -21,6 +21,15 @@ import { isHideOutputMarker } from './marker';
  * Image parts are built from the client-declared MIME verbatim; run the
  * result through {@link compressPromptImageParts} before submitting so
  * unsupported formats are dropped and MIME aliases canonicalized.
+ *
+ * Whitespace-only text blocks are treated as separators, not standalone
+ * parts: they are appended to the preceding text-producing part when one
+ * exists, and otherwise dropped. Clients such as Zed emit prompts where
+ * standalone `text(" ")` blocks separate resource attachments
+ * (`[resource, text(" "), resource, text(" "), text("todo:...")]`), and the
+ * SDK's per-part `text.trim().length === 0` validation would otherwise
+ * reject the whole prompt with `Prompt input cannot contain empty text
+ * parts`. See #1777.
  */
 export function acpBlocksToPromptParts(
   blocks: readonly ContentBlock[],
@@ -28,6 +37,15 @@ export function acpBlocksToPromptParts(
   const out: PromptPart[] = [];
   for (const block of blocks) {
     if (block.type === 'text') {
+      // Whitespace-only text blocks are separators — attach to the previous
+      // text-producing part if one exists, otherwise drop. They must never
+      // become their own PromptPart, because the SDK rejects any part whose
+      // trimmed text is empty (see #1777).
+      if (block.text.trim().length === 0) {
+        const last = out[out.length - 1];
+        if (last?.type === 'text') last.text += block.text;
+        continue;
+      }
       out.push({ type: 'text', text: block.text });
       continue;
     }

--- a/packages/acp-adapter/src/session.ts
+++ b/packages/acp-adapter/src/session.ts
@@ -1504,11 +1504,18 @@ function formatContextUsage(contextUsage: number): string {
 
 /**
  * Inspect the leading `ContentBlock` of an ACP prompt for a
- * `/skill:<name>` form. Only the first block is examined — when Zed
- * (or any other ACP client) sends a slash command, it always lives in
- * the first text block; multi-part prompts that interleave images or
- * resources before text are typed by humans and do not start with a
- * slash. Non-text leading blocks short-circuit to passthrough.
+ * `/skill:<name>` form. When Zed (or any other ACP client) sends a slash
+ * command, it always lives in the first text-carrying block; multi-part
+ * prompts that interleave images or resources before text are typed by
+ * humans and do not start with a slash. Non-text leading blocks
+ * short-circuit to passthrough.
+ *
+ * Leading whitespace-only text blocks are treated as separators, not
+ * content — they are skipped so a `[text(" "), text("/compact")]` payload
+ * still classifies as `/compact` rather than passthrough. This mirrors the
+ * same normalization the prompt-part converter applies (see
+ * `acpBlocksToPromptParts` in `./convert.ts`, #1777); slash routing and
+ * prompt submission must agree on what the "leading" block is.
  *
  * The parsing/resolution itself is delegated to `./slash` —
  * deliberately duplicated from the TUI's
@@ -1520,9 +1527,12 @@ function detectLeadingSlashIntent(
   blocks: readonly ContentBlock[],
   skillCommandMap: ReadonlyMap<string, string>,
 ): ReturnType<typeof detectSlashIntent> {
-  const first = blocks[0];
-  if (!first || first.type !== 'text') return { kind: 'passthrough' };
-  return detectSlashIntent(first.text, skillCommandMap);
+  for (const block of blocks) {
+    if (block.type !== 'text') return { kind: 'passthrough' };
+    if (block.text.trim().length === 0) continue;
+    return detectSlashIntent(block.text, skillCommandMap);
+  }
+  return { kind: 'passthrough' };
 }
 
 function mapPromptError(err: unknown, sessionId: string): RequestError {

--- a/packages/acp-adapter/test/convert.test.ts
+++ b/packages/acp-adapter/test/convert.test.ts
@@ -281,6 +281,65 @@ describe('acpBlocksToPromptParts', () => {
     ]);
     expect(warnSpy).not.toHaveBeenCalled();
   });
+
+  // Regression for #1777. Zed sends multi-attachment prompts as
+  // `[resource, text(" "), resource, text(" "), text("todo:...")]`, and the
+  // whitespace-only text parts used to become standalone PromptParts. The
+  // SDK rejected any part whose trimmed text is empty
+  // (packages/node-sdk/src/session.ts:635 — "Prompt input cannot contain
+  // empty text parts"), so the entire prompt failed with a generic ACP
+  // "Internal error: session prompt failed". Now those separator blocks are
+  // attached to the preceding text-producing part instead.
+  it('attaches whitespace-only text blocks between resources to the previous part (#1777)', () => {
+    const out = acpBlocksToPromptParts([
+      textResourceBlock('file:///a.tsx', 'A'),
+      textBlock(' '),
+      textResourceBlock('file:///b.tsx', 'B'),
+      textBlock(' '),
+      textBlock('todo: refactor'),
+    ]);
+    expect(out).toEqual([
+      { type: 'text', text: '<resource uri="file:///a.tsx">A</resource> ' },
+      { type: 'text', text: '<resource uri="file:///b.tsx">B</resource> ' },
+      { type: 'text', text: 'todo: refactor' },
+    ]);
+    // Sanity: none of the emitted parts is whitespace-only. Matches the
+    // SDK's `text.trim().length === 0` rejection, which is the failure we
+    // are avoiding.
+    for (const part of out) {
+      if (part.type === 'text') {
+        expect(part.text.trim().length).toBeGreaterThan(0);
+      }
+    }
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it('drops leading whitespace-only text blocks with no preceding part (#1777)', () => {
+    // A prompt that opens with `text(" ")` has nothing to attach to, so the
+    // whitespace is dropped rather than kept as an empty part.
+    const out = acpBlocksToPromptParts([
+      textBlock(' '),
+      textResourceBlock('file:///a.tsx', 'A'),
+    ]);
+    expect(out).toEqual([
+      { type: 'text', text: '<resource uri="file:///a.tsx">A</resource>' },
+    ]);
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it('does not merge non-whitespace text blocks (#1777)', () => {
+    // Preserves the historical part boundaries for text blocks with real
+    // content — only whitespace-only text is treated as a separator.
+    const out = acpBlocksToPromptParts([
+      textBlock('hello'),
+      textBlock('world'),
+    ]);
+    expect(out).toEqual([
+      { type: 'text', text: 'hello' },
+      { type: 'text', text: 'world' },
+    ]);
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
 });
 
 describe('displayBlockToAcpContent — plan_review branch (Phase 13.2)', () => {

--- a/packages/acp-adapter/test/session-slash.test.ts
+++ b/packages/acp-adapter/test/session-slash.test.ts
@@ -371,4 +371,101 @@ describe('AcpSession slash routing', () => {
     expect(text).toContain('Model: mock-model');
     expect(text).toContain('Context: 1,234 / 200,000 (0.6%)');
   });
+
+  // Regression for #1881 codex review. `acpBlocksToPromptParts` in
+  // `../src/convert.ts` normalises a leading `text(" ")` away when building
+  // PromptParts (see #1777); slash-command routing must apply the same
+  // normalisation, otherwise the same payload would classify as passthrough
+  // and be sent to the model as text instead of being executed locally.
+  it('skips leading whitespace-only text blocks when routing slash commands (#1881)', async () => {
+    const sessionId = 'sess-slash-D';
+    const { session, calls } = makeFakeSession(sessionId, [endedTurn(sessionId)]);
+    const harness = {
+      auth: { status: async () => AUTHED_STATUS },
+      createSession: async () => session,
+    } as unknown as KimiHarness;
+
+    const { agentStream, clientStream } = makeInMemoryStreamPair();
+    new AgentSideConnection(
+      (c) =>
+        new AcpServer(harness, c, {
+          slashCommands: async (s) => {
+            const skills = await s.listSkills();
+            const map = new Map<string, string>();
+            const commands = skills.map((sk) => {
+              const name = `skill:${sk.name}`;
+              map.set(name, sk.name);
+              return { name, description: sk.description };
+            });
+            return { commands, skillCommandMap: map };
+          },
+        }),
+      agentStream,
+    );
+    const collecting = new CollectingClient();
+    const client = new ClientSideConnection(() => collecting, clientStream);
+
+    await client.newSession({ cwd: '/tmp/x', mcpServers: [] });
+    await waitForAvailableCommands(collecting);
+
+    const response = await client.prompt({
+      sessionId,
+      prompt: [textBlock(' '), textBlock('/skill:foo bar')],
+    });
+
+    expect(response.stopReason).toBe('end_turn');
+    // Command was executed locally, not forwarded to the model as text.
+    expect(calls.prompt).toBe(0);
+    expect(calls.activate).toEqual([{ name: 'foo', args: 'bar' }]);
+  });
+
+  it('returns passthrough when a leading non-text block precedes a slash (#1881)', async () => {
+    // Guard: only whitespace *text* blocks are skipped. If an image or
+    // resource comes first, the input is a mixed prompt (not a bare command)
+    // and must flow to Session.prompt as usual.
+    const sessionId = 'sess-slash-E';
+    const { session, calls } = makeFakeSession(sessionId, [endedTurn(sessionId)]);
+    const harness = {
+      auth: { status: async () => AUTHED_STATUS },
+      createSession: async () => session,
+    } as unknown as KimiHarness;
+
+    const { agentStream, clientStream } = makeInMemoryStreamPair();
+    new AgentSideConnection(
+      (c) =>
+        new AcpServer(harness, c, {
+          slashCommands: async (s) => {
+            const skills = await s.listSkills();
+            const map = new Map<string, string>();
+            const commands = skills.map((sk) => {
+              const name = `skill:${sk.name}`;
+              map.set(name, sk.name);
+              return { name, description: sk.description };
+            });
+            return { commands, skillCommandMap: map };
+          },
+        }),
+      agentStream,
+    );
+    const collecting = new CollectingClient();
+    const client = new ClientSideConnection(() => collecting, clientStream);
+
+    await client.newSession({ cwd: '/tmp/x', mcpServers: [] });
+    await waitForAvailableCommands(collecting);
+
+    const imageBlock: ContentBlock = {
+      type: 'image',
+      data: 'iVBORw0KGgo=',
+      mimeType: 'image/png',
+    };
+    await client.prompt({
+      sessionId,
+      prompt: [imageBlock, textBlock('/skill:foo')],
+    });
+
+    // Not classified as a slash command — the image lead makes it a mixed
+    // prompt, so it flows to Session.prompt.
+    expect(calls.activate).toEqual([]);
+    expect(calls.prompt).toBe(1);
+  });
 });


### PR DESCRIPTION
## Related Issue

Resolves #1777

## Problem

See linked issue for full context. Summary: driving Kimi Code as an ACP agent from Zed, attaching two or more files to a prompt fails with `Internal error: session prompt failed`. Single-file and text-only prompts work; only multi-attachment prompts break.

Zed's ACP payload for a two-file drag-and-drop plus one line of user text looks like:

```json
[
  { "type": "resource", "resource": { "uri": "file:///.../a.tsx", "text": "..." } },
  { "type": "text", "text": " " },
  { "type": "resource", "resource": { "uri": "file:///.../b.tsx", "text": "..." } },
  { "type": "text", "text": " " },
  { "type": "text", "text": "todo: refactor" }
]
```

The whitespace-only `text` blocks are visual separators between the resource attachments. `packages/acp-adapter/src/convert.ts:acpBlocksToPromptParts` translated each block into its own `PromptPart`, so the SDK saw a `{ type: 'text', text: ' ' }` entry — and rejected it in `packages/node-sdk/src/session.ts:635` (`Prompt input cannot contain empty text parts`, gated on `part.text.trim().length === 0`). `mapPromptError` in `packages/acp-adapter/src/session.ts:1541` then swallowed the specific reason into the generic `"session prompt failed"` message, so from the ACP client's side the failure was indistinguishable from a kimi bug.

## What changed

`acpBlocksToPromptParts` now recognises whitespace-only `text` blocks as separators, not standalone parts:

- When such a block has a preceding text-producing part (`text`, `resource`, `resource_link` → text), the whitespace is appended to that part in place, so the separator survives inside a valid part.
- When it has no preceding part (whitespace at the start of a prompt), it is dropped — no part is generated, so the SDK validator has nothing to reject.

Non-whitespace text blocks are unchanged: they still produce their own `PromptPart`, so the historical output shape for real content is preserved and every existing convert test still passes.

Scope kept tight to what the issue describes:

- Only the `text` branch of `acpBlocksToPromptParts` changed. Image/audio/blob-resource handling is untouched.
- No SDK-side change. Loosening the `text.trim().length === 0` validation was tempting but would change the meaning of "empty prompt" across the whole codebase; the adapter-side fix keeps the invariant SDK callers rely on.
- `mapPromptError`'s generic-message policy stays as-is — leaking the internal validator string over ACP is exactly what the top-of-file comment there warns against.

## Reviewer Test Plan

### How to verify

Regression coverage lives in `packages/acp-adapter/test/convert.test.ts` (three new cases, all under the existing `acpBlocksToPromptParts` describe):

- `attaches whitespace-only text blocks between resources to the previous part (#1777)` — the exact Zed multi-file pattern from the issue. Asserts every emitted part has non-empty trimmed text (which is the invariant the SDK rejection would have violated).
- `drops leading whitespace-only text blocks with no preceding part (#1777)` — the "prompt opens with whitespace" edge case.
- `does not merge non-whitespace text blocks (#1777)` — guard test: `[text('hello'), text('world')]` still emits two parts, so a future refactor that eagerly merges every adjacent text pair can't land silently.

Full suite confirmed locally with `vitest run`:

- `packages/acp-adapter/test/convert.test.ts` — 33/33 pass (30 pre-existing + 3 new).
- `oxlint` on the two touched files — 0 errors. Six pre-existing `prefer-string-replace-all` warnings on unrelated `escapeXmlAttr` lines are not introduced by this PR.

For a manual smoke: configure Zed with `kimi acp`, drag two files into an agent thread, add any user text, submit. Before the fix the prompt is rejected as `Internal error: session prompt failed`; after, it goes through.

### Evidence (Before & After)

I don't have a live Zed setup to record here — the deterministic mechanism is captured by the three new unit tests plus the file references in the issue and this PR body. Happy to run the manual smoke against Zed on request.

### Tested on

|     OS     |  Status  |
| :--------: | :------: |
|  🍏 macOS  |    ⚠️    |
| 🪟 Windows |    ✅    |
|  🐧 Linux  |    ⚠️    |

### Environment

`vitest run test/convert.test.ts` and `oxlint` inside `packages/acp-adapter`.

## Risk & Scope

- Main risk or tradeoff: behavioural change for a niche input shape (whitespace-only text blocks). Real content is unaffected, so existing text-heavy prompts render identically; the 30 pre-existing tests all pass.
- Not validated / out of scope: the sibling issue #1865 (ACP failed turns swallowed as `end_turn`) and #1855 (ACP `PromptResponse.usage` empty). Those are the same adapter's observability gaps but a different code path — deserve their own PRs.
- Breaking changes / migration notes: none.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset. — added `.changeset/fix-acp-merge-adjacent-text-parts.md` (patch on `@moonshot-ai/kimi-code`, since the adapter change surfaces to CLI users who drive kimi over ACP).
- [x] Ran `gen-docs` skill, or this PR needs no doc update. — the touched code is internal adapter behaviour; the `docs/` site does not describe the pre-fix rejection behaviour, so no doc changes needed.
