### PR TITLE
feat(acp-adapter): forward context-window usage as ACP usage_update session updates

### DIFF
--- a/.changeset/acp-usage-update.md
+++ b/.changeset/acp-usage-update.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Forward context-window usage over ACP as `usage_update` session updates ({used, size}, deduped per turn), so ACP clients can render a live context gauge — previously context usage was only visible in the interactive TUI and the `/status` slash text.

--- a/packages/acp-adapter/src/events-map.ts
+++ b/packages/acp-adapter/src/events-map.ts
@@ -8,6 +8,7 @@ import type {
   ToolKind,
 } from '@agentclientprotocol/sdk';
 import type {
+  AgentStatusUpdatedEvent,
   AssistantDeltaEvent,
   ThinkingDeltaEvent,
   ToolCallDeltaEvent,
@@ -79,6 +80,35 @@ export function turnEndReasonToStopReason(
     case 'blocked':
       return 'refusal';
   }
+}
+
+/**
+ * Build an ACP `session/update` notification with a `usage_update`
+ * payload from an SDK `agent.status.updated` event.
+ *
+ * agent-core emits `agent.status.updated` whenever the context token
+ * count changes (see agent-core `context/index.ts`), carrying
+ * `contextTokens` / `maxContextTokens`. ACP's `usage_update` variant
+ * (`{ used, size }`, types.gen.d.ts `UsageUpdate`) is the wire-level
+ * counterpart, so clients can render a live context-window gauge.
+ *
+ * Returns `null` when the event does not carry a usable pair — status
+ * events also fire for plan/permission/model changes where the token
+ * fields may be absent, and a `size` of 0 would make every consumer
+ * divide by zero.
+ */
+export function statusToUsageUpdateSessionUpdate(
+  sessionId: string,
+  event: AgentStatusUpdatedEvent,
+): SessionNotification | null {
+  const used = event.contextTokens;
+  const size = event.maxContextTokens;
+  if (typeof used !== 'number' || !Number.isFinite(used) || used < 0) return null;
+  if (typeof size !== 'number' || !Number.isFinite(size) || size <= 0) return null;
+  return {
+    sessionId,
+    update: { sessionUpdate: 'usage_update', used, size },
+  };
 }
 
 /**

--- a/packages/acp-adapter/src/session.ts
+++ b/packages/acp-adapter/src/session.ts
@@ -45,6 +45,7 @@ import {
   assistantDeltaToSessionUpdate,
   configOptionUpdateNotification,
   planFromDisplayBlock,
+  statusToUsageUpdateSessionUpdate,
   stringifyArgs,
   thinkingDeltaToSessionUpdate,
   toolCallDeltaToSessionUpdate,
@@ -932,6 +933,10 @@ export class AcpSession {
       // Keyed on the **SDK** `toolCallId` (not the ACP-prefixed one)
       // because the SDK delta events only carry the raw id.
       const argsByToolCall = new Map<string, { args: string }>();
+      // Last context-usage pair pushed as a wire `usage_update` this turn.
+      // Turn-scoped on purpose: a fresh turn re-sends the current value so
+      // a client that (re)connected between turns still gets a baseline.
+      let lastSentUsage: { used: number; size: number } | undefined;
       // Set of **wire-level** (turn-prefixed) tool-call ids for which
       // we have already sent the `tool_call` CREATE notification. The
       // agent-core actually emits `tool.call.delta` events BEFORE
@@ -1028,6 +1033,30 @@ export class AcpSession {
                 error: err instanceof Error ? err.message : String(err),
               });
             });
+          return;
+        }
+        if (event.type === 'agent.status.updated') {
+          if (!isFromMainAgent(event)) return;
+          const note = statusToUsageUpdateSessionUpdate(sessionId, event);
+          if (note === null) return;
+          // Status events also fire for plan/permission/model changes with
+          // an unchanged token count — only push when the pair moved, so
+          // the wire doesn't carry redundant usage_update notifications.
+          const usage = note.update as { used: number; size: number };
+          if (
+            lastSentUsage !== undefined &&
+            lastSentUsage.used === usage.used &&
+            lastSentUsage.size === usage.size
+          ) {
+            return;
+          }
+          lastSentUsage = { used: usage.used, size: usage.size };
+          conn.sessionUpdate(note).catch((err) => {
+            log.warn('acp: failed to push usage_update', {
+              sessionId,
+              error: err instanceof Error ? err.message : String(err),
+            });
+          });
           return;
         }
         if (event.type === 'tool.call.started') {

--- a/packages/acp-adapter/test/session-prompt.test.ts
+++ b/packages/acp-adapter/test/session-prompt.test.ts
@@ -147,6 +147,62 @@ describe('AcpServer session/prompt', () => {
     expect(unsubscribeCount()).toBe(1);
   });
 
+  it('forwards agent.status.updated context tokens as deduped usage_update notifications', async () => {
+    const sessionId = 'sess-U';
+    const { session } = makeScriptedSession(sessionId, [
+      // Baseline pair → must be pushed.
+      { type: 'agent.status.updated', contextTokens: 1000, maxContextTokens: 200_000 } as Event,
+      // Same pair again (e.g. permission toggle re-emits status) → deduped.
+      { type: 'agent.status.updated', contextTokens: 1000, maxContextTokens: 200_000 } as Event,
+      // Subagent status → filtered out, never pushed.
+      {
+        type: 'agent.status.updated',
+        agentId: 'sub-1',
+        contextTokens: 999_999,
+        maxContextTokens: 200_000,
+      } as Event,
+      // Missing token fields (model-change status) → skipped.
+      { type: 'agent.status.updated', model: 'kimi-k2' } as Event,
+      // Token count moved → pushed.
+      { type: 'agent.status.updated', contextTokens: 5000, maxContextTokens: 200_000 } as Event,
+      { type: 'turn.ended', sessionId, agentId: 'main', turnId: 1, reason: 'completed' } as Event,
+    ]);
+    const harness = {
+      auth: { status: async () => AUTHED_STATUS },
+      createSession: async () => session,
+    } as unknown as KimiHarness;
+
+    const { agentStream, clientStream } = makeInMemoryStreamPair();
+    new AgentSideConnection((c) => new AcpServer(harness, c), agentStream);
+    const collecting = new CollectingClient();
+    const client = new ClientSideConnection(() => collecting, clientStream);
+
+    await client.newSession({ cwd: '/tmp/x', mcpServers: [] });
+
+    const response = await client.prompt({ sessionId, prompt: [textBlock('hi')] });
+    expect(response.stopReason).toBe('end_turn');
+
+    await new Promise((resolve) => setTimeout(resolve, 20));
+
+    const usageUpdates = collecting.promptUpdates.filter(
+      (n) => (n.update as { sessionUpdate?: string }).sessionUpdate === 'usage_update',
+    );
+    expect(usageUpdates).toHaveLength(2);
+    expect(usageUpdates[0]?.update).toMatchObject({
+      sessionUpdate: 'usage_update',
+      used: 1000,
+      size: 200_000,
+    });
+    expect(usageUpdates[1]?.update).toMatchObject({
+      sessionUpdate: 'usage_update',
+      used: 5000,
+      size: 200_000,
+    });
+    for (const note of usageUpdates) {
+      expect(note.sessionId).toBe(sessionId);
+    }
+  });
+
   it('resolves with cancelled stopReason when turn.ended reason is cancelled', async () => {
     const sessionId = 'sess-B';
     const { session, unsubscribeCount } = makeScriptedSession(sessionId, [


### PR DESCRIPTION
## Problem

Context-window usage is visible in the interactive TUI (which subscribes in-process to `agent.status.updated`), but the ACP surface never emits it: the adapter's event map only translates message/thought/tool/plan events, so ACP clients (Zed, IDE integrations, headless bridges) have no way to render a live context gauge. The only ACP-visible form is the plain text of the `/status` and `/usage` slash commands.

The ACP spec already defines the wire-level counterpart: the `usage_update` session update variant (`{ used, size }`, present in `@agentclientprotocol/sdk` 0.23 `types.gen.d.ts`), which Kimi never sends.

## Change

- `events-map.ts`: new `statusToUsageUpdateSessionUpdate()` mapping `agent.status.updated` → `usage_update` with `used = contextTokens`, `size = maxContextTokens`. Returns `null` for status events that don't carry a usable pair (model/plan/permission-only updates, `size <= 0`).
- `session.ts`: forward main-agent status events through that mapping inside the prompt loop, deduped per turn on an unchanged `(used, size)` pair — status events also fire for plan/permission toggles where the token count didn't move, and those shouldn't hit the wire. Turn-scoped dedupe on purpose: a fresh turn re-sends the current value so a client that (re)connected between turns still gets a baseline. Subagent status events are filtered out.

## Testing

- New unit test covering: baseline pair pushed, unchanged pair deduped, subagent filtered, token-less status skipped, moved pair pushed (`session-prompt.test.ts`).
- Full `packages/acp-adapter` suite: 36 files / 308 tests pass.
- Live verification: drove a real `kimi acp` session over stdio; the turn emitted `usage_update {"used":23810,"size":1048576}` alongside the usual chunks, and `stopReason` behavior is unchanged (`usage_update` is meta-only for clients that ignore it).