### PR TITLE
fix(web): widen ordered-list padding to unclip double-digit numbers

### DIFF
--- a/.changeset/web-ol-number-padding.md
+++ b/.changeset/web-ol-number-padding.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+web: Widen ordered-list padding so double-digit list numbers ("10.") are no longer clipped.

--- a/apps/kimi-web/src/components/chat/Markdown.vue
+++ b/apps/kimi-web/src/components/chat/Markdown.vue
@@ -575,6 +575,11 @@ function copyDiff(code: string, idx: number) {
   padding-left: 1.4em;
   margin: 0.6em 0;
 }
+/* Ordered lists need a wider gutter: 1.4em clips double-digit numbers
+   ("10." loses its "1"); unordered bullet markers are narrow. */
+.md :deep(ol) {
+  padding-left: 2em;
+}
 .md :deep(li) {
   margin: 0.3em 0;
 }


### PR DESCRIPTION
The shared list rule in `Markdown.vue` sets `padding-left: 1.4em` on both `ul` and `ol`. That gutter only fits a single digit, so any ordered list with 10+ items renders "**0.**" where "**10.**" should be (the leading "1" is clipped).

### Before / After

| | padding | "10." renders as |
|---|---|---|
| Before | 1.4em | "0." (leading digit clipped) |
| After | 2em (ol only) | "10." |

The fix gives `ol` its own `padding-left: 2em`; `ul` stays at 1.4em since bullet markers are narrow.