### PR TITLE
fix(web): require reaching the true bottom before re-engaging scroll follow

### DIFF
--- a/.changeset/web-scroll-follow-reengage.md
+++ b/.changeset/web-scroll-follow-reengage.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+web: Re-engage the scroll auto-follow only when reaching the true bottom (or via the new-message pill) — reading near the streaming tail no longer yanks the view to the bottom on small downward scrolls.

--- a/apps/kimi-web/src/components/chat/ConversationPane.vue
+++ b/apps/kimi-web/src/components/chat/ConversationPane.vue
@@ -481,8 +481,12 @@ const following = ref(true);
 const showPill = ref(false);
 
 /** Within this many pixels from the bottom counts as "at the bottom" —
-    scrolling DOWN into this zone re-enables the follow. */
-const BOTTOM_THRESHOLD = 80;
+    scrolling fully INTO it re-enables the follow. Kept deliberately small:
+    a large threshold re-engaged the follow while users were still reading
+    the streaming tail, yanking them back to the bottom on any small
+    downward scroll. Re-follow now requires reaching the bottom (or
+    clicking the new-message pill). */
+const BOTTOM_THRESHOLD = 8;
 const USER_ACTION_FOLLOW_LOCK_MS = 1000;
 
 function distanceFromBottom(): number {


### PR DESCRIPTION
## Problem

The auto-follow state machine in `ConversationPane.vue` detaches correctly when the user scrolls up (`following = false`), but re-engages when the user scrolls back down anywhere within **80px** of the bottom:

```ts
} else if (dist <= BOTTOM_THRESHOLD && top > lastScrollTop + 1) {
  following.value = true;
}
```

During streaming, the content a user is reading is almost always **inside** that 80px zone (the latest turn). When they scroll down even a few pixels to keep reading, the follow re-arms and the next delta batch snaps the view back to the bottom — repeatedly. Result: "the page keeps climbing and I can't read what I want".

## Fix

Lower the re-engage threshold to **8px**, so following resumes only when the user deliberately scrolls to the actual bottom, or clicks the new-message pill (unchanged). Detach-on-scroll-up behavior is untouched.

## Test

1. Start a long streaming reply.
2. Scroll up a few screens to read history.
3. Scroll down a little (still far from the bottom) — view now stays put (before: yanked to bottom).
4. Scroll fully to the bottom — follow re-engages (unchanged).