### PR TITLE
fix(pi-tui): make debug logging robust on Windows

### DIFF
--- a/.changeset/fix-pi-tui-debug-redraw-log-dir.md
+++ b/.changeset/fix-pi-tui-debug-redraw-log-dir.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/pi-tui": patch
+---
+
+Fix a crash when `PI_DEBUG_REDRAW=1` is set on a machine that has never written to `~/.pi/agent` before: the debug-redraw logger wrote to that directory without creating it first, so the first full redraw threw an uncaught `ENOENT` and silently killed the whole TUI. The logger now creates the directory before appending, and never lets a logging failure crash rendering.

--- a/.changeset/fix-pi-tui-debug-redraw-log-dir.md
+++ b/.changeset/fix-pi-tui-debug-redraw-log-dir.md
@@ -2,4 +2,4 @@
 "@moonshot-ai/pi-tui": patch
 ---
 
-Fix a crash when `PI_DEBUG_REDRAW=1` is set on a machine that has never written to `~/.pi/agent` before: the debug-redraw logger wrote to that directory without creating it first, so the first full redraw threw an uncaught `ENOENT` and silently killed the whole TUI. The logger now creates the directory before appending, and never lets a logging failure crash rendering.
+Fix a crash when `PI_DEBUG_REDRAW=1` is set on a machine that has never used `~/.pi/agent` before.

--- a/.changeset/fix-pi-tui-debug-redraw-log-dir.md
+++ b/.changeset/fix-pi-tui-debug-redraw-log-dir.md
@@ -2,4 +2,4 @@
 "@moonshot-ai/pi-tui": patch
 ---
 
-Fix a crash when `PI_DEBUG_REDRAW=1` is set on a machine that has never used `~/.pi/agent` before.
+Make the TUI's debug logging robust on Windows: the `PI_DEBUG_REDRAW` and `PI_TUI_DEBUG` diagnostics no longer crash the render loop on a filesystem error, and `PI_TUI_DEBUG` writes render dumps to the OS temp dir instead of a hardcoded `/tmp`.

--- a/packages/pi-tui/src/tui.ts
+++ b/packages/pi-tui/src/tui.ts
@@ -1353,7 +1353,13 @@ export class TUI extends Container {
 			if (!debugRedraw) return;
 			const logPath = path.join(os.homedir(), ".pi", "agent", "pi-debug.log");
 			const msg = `[${new Date().toISOString()}] fullRender: ${reason} (prev=${this.previousLines.length}, new=${newLines.length}, height=${height})\n`;
-			fs.appendFileSync(logPath, msg);
+
+			try {
+				fs.mkdirSync(path.dirname(logPath), { recursive: true });
+				fs.appendFileSync(logPath, msg);
+			} catch {
+				// never let debug logging break rendering
+			}
 		};
 
 		// First render - just output everything without clearing (assumes clean screen)

--- a/packages/pi-tui/src/tui.ts
+++ b/packages/pi-tui/src/tui.ts
@@ -1572,8 +1572,7 @@ export class TUI extends Container {
 		buffer += "\x1b[?2026l"; // End synchronized output
 
 		if (process.env['PI_TUI_DEBUG'] === "1") {
-			const debugDir = "/tmp/tui";
-			fs.mkdirSync(debugDir, { recursive: true });
+			const debugDir = path.join(os.tmpdir(), "tui");
 			const debugPath = path.join(debugDir, `render-${Date.now()}-${Math.random().toString(36).slice(2)}.log`);
 			const debugData = [
 				`firstChanged: ${firstChanged}`,
@@ -1597,7 +1596,13 @@ export class TUI extends Container {
 				"=== buffer ===",
 				JSON.stringify(buffer),
 			].join("\n");
-			fs.writeFileSync(debugPath, debugData);
+
+			try {
+				fs.mkdirSync(debugDir, { recursive: true });
+				fs.writeFileSync(debugPath, debugData);
+			} catch {
+				//never let debug logging break rendering.
+			}
 		}
 
 		// Write entire buffer at once

--- a/packages/pi-tui/test/tui-render.test.ts
+++ b/packages/pi-tui/test/tui-render.test.ts
@@ -1,4 +1,7 @@
 import assert from "node:assert";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
 import { describe, it } from "node:test";
 import type { Terminal as XtermTerminalType } from "@xterm/headless";
 import { Image } from "../src/components/image.ts";
@@ -399,6 +402,43 @@ describe("TUI resize handling", () => {
 		assert.ok(tui.fullRedraws > initialRedraws, "Width change should trigger full redraw");
 
 		tui.stop();
+	});
+});
+
+describe("TUI debug redraw logging", () => {
+	it("does not crash the render loop when the debug-redraw log directory is missing", async () => {
+		const fakeHome = await fs.mkdtemp(path.join(os.tmpdir(), "pi-tui-debug-redraw-"));
+		try {
+			// `fakeHome` exists but `fakeHome/.pi/agent` does not — this mirrors a
+			// fresh machine that has never written to ~/.pi/agent before.
+			await withEnv({ PI_DEBUG_REDRAW: "1", HOME: fakeHome, USERPROFILE: fakeHome }, async () => {
+				const terminal = new VirtualTerminal(40, 10);
+				const tui = new TUI(terminal);
+				const component = new TestComponent();
+				tui.addChild(component);
+
+				component.lines = ["Line 0", "Line 1"];
+				tui.start();
+				await terminal.waitForRender();
+
+				// A width change forces `logRedraw` to run, which previously threw
+				// ENOENT (missing parent directory) and crashed the whole TUI as an
+				// uncaughtException.
+				terminal.resize(60, 10);
+				await terminal.waitForRender();
+
+				const viewport = terminal.getViewport();
+				assert.ok(viewport[0]?.includes("Line 0"), "TUI keeps rendering after the debug log write");
+
+				tui.stop();
+			});
+
+			const logPath = path.join(fakeHome, ".pi", "agent", "pi-debug.log");
+			const contents = await fs.readFile(logPath, "utf8");
+			assert.ok(contents.includes("terminal width changed"), "the debug log should still be written");
+		} finally {
+			await fs.rm(fakeHome, { recursive: true, force: true });
+		}
 	});
 });
 

--- a/packages/pi-tui/test/tui-render.test.ts
+++ b/packages/pi-tui/test/tui-render.test.ts
@@ -405,7 +405,7 @@ describe("TUI resize handling", () => {
 	});
 });
 
-describe("TUI debug redraw logging", () => {
+describe("TUI debug logging", () => {
 	it("does not crash the render loop when the debug-redraw log directory is missing", async () => {
 		const fakeHome = await fs.mkdtemp(path.join(os.tmpdir(), "pi-tui-debug-redraw-"));
 		try {
@@ -438,6 +438,38 @@ describe("TUI debug redraw logging", () => {
 			assert.ok(contents.includes("terminal width changed"), "the debug log should still be written");
 		} finally {
 			await fs.rm(fakeHome, { recursive: true, force: true });
+		}
+	});
+
+	it("writes PI_TUI_DEBUG render dumps into the OS temp dir, not a hardcoded /tmp", async () => {
+		const fakeTmp = await fs.mkdtemp(path.join(os.tmpdir(), "pi-tui-debug-render-"));
+		try {
+			await withEnv(
+				{ PI_TUI_DEBUG: "1", TMPDIR: fakeTmp, TEMP: fakeTmp, TMP: fakeTmp },
+				async () => {
+					const terminal = new VirtualTerminal(40, 10);
+					const tui = new TUI(terminal);
+					const component = new TestComponent();
+					tui.addChild(component);
+					component.lines = ["Line 0", "Line 1"];
+					tui.start();
+					await terminal.waitForRender();
+					component.lines = ["Line 0", "CHANGED"];
+					tui.requestRender();
+					await terminal.waitForRender();
+					const viewport = terminal.getViewport();
+					assert.ok(viewport[1]?.includes("CHANGED"), "TUI keeps rendering with PI_TUI_DEBUG on");
+					tui.stop();
+				},
+			);
+			const dumpDir = path.join(fakeTmp, "tui");
+			const files = await fs.readdir(dumpDir);
+			assert.ok(
+				files.some((name) => name.startsWith("render-")),
+				"a render dump should be written under the OS temp dir",
+			);
+		} finally {
+			await fs.rm(fakeTmp, { recursive: true, force: true });
 		}
 	});
 });


### PR DESCRIPTION
## Related Issue

No related issue — found while trying to reproduce #1705 using pi-tui's debug flags, which turned out to have their own bugs on Windows.

## Problem

pi-tui has two env-gated diagnostic writers in `tui.ts`, and both are unsafe — a filesystem failure crashes the whole TUI with no console output (it only surfaces in `~/.kimi-code/logs/kimi-code.log`), because an uncaught exception mid-render is caught by the shell crash handler and silently exits:

1. **`PI_DEBUG_REDRAW=1`** writes to `~/.pi/agent/pi-debug.log` via `fs.appendFileSync` without creating the parent directory. On any machine that has never used `~/.pi/agent`, the first full redraw throws `ENOENT` and the TUI dies. Trace:

ERROR uncaughtException, restoring terminal and exiting error="Error: ENOENT: no such file or directory, open 'C:\Users<user>.pi\agent\pi-debug.log'"

2. **`PI_TUI_DEBUG=1`** dumps render state to a hardcoded `"/tmp/tui"`. On Windows that path resolves to the current drive's root (e.g. `C:\tmp\tui`) instead of the real temp location, and the block has no error guard — an unwritable target throws and crashes the TUI the same way.

## What changed

- `PI_DEBUG_REDRAW`: create the log directory (`fs.mkdirSync(..., { recursive: true })`) before appending, wrapped in try/catch. 
- `PI_TUI_DEBUG`: write to `os.tmpdir()` instead of a hardcoded `/tmp`,
and wrap the mkdir/write in try/catch.

Both now follow the "diagnostic logging must never crash the app" convention already used elsewhere in this codebase (e.g. the update-preflight logger, and the sibling `terminal.ts` write logger). Added regression tests for both: one points HOME at a fresh temp dir (so `.pi/agent` is missing) and asserts the render loop survives; the other redirects `os.tmpdir()` and asserts the dump lands in the OS temp dir, not `/tmp`. Both tests fail without the fix.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.