### PR TITLE
fix(mcp): pin remote MCP transports to HTTP/1.1 for Cloudflare compatibility

### DIFF
--- a/.changeset/mcp-http1-remote-transports.md
+++ b/.changeset/mcp-http1-remote-transports.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Fix remote MCP servers over HTTP/2 hanging during startup: the stream and requests now use HTTP/1.1 connections.

--- a/packages/agent-core-v2/src/agent/mcp/client-http.ts
+++ b/packages/agent-core-v2/src/agent/mcp/client-http.ts
@@ -43,7 +43,6 @@ export class HttpMcpClient implements MCPClient {
 
     this.transport = new StreamableHTTPClientTransport(new URL(config.url), {
       requestInit: headers !== undefined ? { headers } : undefined,
-      // Default fetch pins HTTP/1.1 (see client-remote.ts); tests inject their own.
       fetch: options.fetch ?? createMcpFetch(),
       authProvider: options.oauthProvider,
     });

--- a/packages/agent-core-v2/src/agent/mcp/client-http.ts
+++ b/packages/agent-core-v2/src/agent/mcp/client-http.ts
@@ -12,7 +12,7 @@ import {
   type UnexpectedCloseListener,
   type UnexpectedCloseReason,
 } from './client-shared';
-import { buildMcpRemoteHeaders } from './client-remote';
+import { buildMcpRemoteHeaders, createMcpFetch } from './client-remote';
 import type { MCPClient, MCPToolDefinition, MCPToolResult } from './types';
 
 export interface HttpMcpClientOptions {
@@ -43,7 +43,8 @@ export class HttpMcpClient implements MCPClient {
 
     this.transport = new StreamableHTTPClientTransport(new URL(config.url), {
       requestInit: headers !== undefined ? { headers } : undefined,
-      fetch: options.fetch,
+      // Default fetch pins HTTP/1.1 (see client-remote.ts); tests inject their own.
+      fetch: options.fetch ?? createMcpFetch(),
       authProvider: options.oauthProvider,
     });
     this.client = new Client({

--- a/packages/agent-core-v2/src/agent/mcp/client-remote.ts
+++ b/packages/agent-core-v2/src/agent/mcp/client-remote.ts
@@ -1,7 +1,20 @@
+/**
+ * `mcp` domain — shared helpers for the remote (HTTP/SSE) MCP transports.
+ *
+ * Owns bearer-token header construction and the default `fetch` for remote
+ * MCP traffic. The fetch is pinned to HTTP/1.1 (undici `allowH2: false`,
+ * including through HTTP CONNECT proxies): Node's global fetch negotiates
+ * HTTP/2, and undici then queues stream-bodied POSTs behind the in-flight
+ * standalone SSE GET stream without dispatching them (undici client-h2
+ * `busy()` guard, nodejs/undici#5524), hanging the MCP startup handshake
+ * until `startupTimeoutMs` fires. Callers may still inject a custom `fetch`
+ * (tests) or dispatcher (e.g. an H2-capable agent to reproduce the stall).
+ */
+
 import type { McpRemoteServerConfig, McpServerConfig } from './config-schema';
 import { ErrorCodes, Error2 } from '#/errors';
 import { createProxyDispatcher } from '#/_base/utils/proxy';
-import { Agent, fetch as undiciFetch, type Dispatcher } from 'undici';
+import { Agent, EnvHttpProxyAgent, fetch as undiciFetch, type Dispatcher } from 'undici';
 
 export function buildMcpRemoteHeaders(
   config: McpRemoteServerConfig,
@@ -30,33 +43,19 @@ export function isRemoteMcpConfig(config: McpServerConfig): config is McpRemoteS
   return config.transport === 'http' || config.transport === 'sse';
 }
 
-// Node's global fetch negotiates HTTP/2 (undici `allowH2` defaults to true).
-// When the MCP SDK's streamable-HTTP transport then opens its standalone SSE
-// GET stream and sends POSTs over that one H2 connection, Cloudflare-hosted
-// MCP servers (including Cloudflare's own docs endpoint) stall the POST
-// indefinitely while the GET stream is open — the startup handshake times out
-// before `tools/list` ever resolves. Pinning remote MCP traffic to HTTP/1.1
-// puts the stream and the POSTs on separate connections, which every
-// spec-compliant server handles.
-//
-// When a proxy is configured the proxy dispatcher is used as-is: undici's
-// CONNECT tunnels already speak HTTP/1.1 to the origin, so proxied traffic
-// never hits the H2 stall.
 let sharedMcpDispatcher: Dispatcher | undefined;
 
 function getMcpDispatcher(): Dispatcher {
   if (sharedMcpDispatcher === undefined) {
-    sharedMcpDispatcher = createProxyDispatcher(process.env) ?? new Agent({ allowH2: false });
+    sharedMcpDispatcher =
+      createProxyDispatcher(process.env, {
+        makeHttpAgent: ({ httpProxy, httpsProxy, noProxy }) =>
+          new EnvHttpProxyAgent({ httpProxy, httpsProxy, noProxy, allowH2: false }),
+      }) ?? new Agent({ allowH2: false });
   }
   return sharedMcpDispatcher;
 }
 
-/**
- * `fetch` for remote MCP transports, pinned to HTTP/1.1 for direct
- * connections (see above). Tests can inject their own fetch via the client
- * options, or a custom dispatcher here, e.g. an H2-capable agent to
- * reproduce the stall this works around.
- */
 export function createMcpFetch(dispatcher: Dispatcher = getMcpDispatcher()): typeof fetch {
   return ((input: unknown, init?: object) =>
     undiciFetch(input as Parameters<typeof undiciFetch>[0], {

--- a/packages/agent-core-v2/src/agent/mcp/client-remote.ts
+++ b/packages/agent-core-v2/src/agent/mcp/client-remote.ts
@@ -1,5 +1,7 @@
 import type { McpRemoteServerConfig, McpServerConfig } from './config-schema';
 import { ErrorCodes, Error2 } from '#/errors';
+import { createProxyDispatcher } from '#/_base/utils/proxy';
+import { Agent, fetch as undiciFetch, type Dispatcher } from 'undici';
 
 export function buildMcpRemoteHeaders(
   config: McpRemoteServerConfig,
@@ -26,4 +28,39 @@ export function buildMcpRemoteHeaders(
 
 export function isRemoteMcpConfig(config: McpServerConfig): config is McpRemoteServerConfig {
   return config.transport === 'http' || config.transport === 'sse';
+}
+
+// Node's global fetch negotiates HTTP/2 (undici `allowH2` defaults to true).
+// When the MCP SDK's streamable-HTTP transport then opens its standalone SSE
+// GET stream and sends POSTs over that one H2 connection, Cloudflare-hosted
+// MCP servers (including Cloudflare's own docs endpoint) stall the POST
+// indefinitely while the GET stream is open — the startup handshake times out
+// before `tools/list` ever resolves. Pinning remote MCP traffic to HTTP/1.1
+// puts the stream and the POSTs on separate connections, which every
+// spec-compliant server handles.
+//
+// When a proxy is configured the proxy dispatcher is used as-is: undici's
+// CONNECT tunnels already speak HTTP/1.1 to the origin, so proxied traffic
+// never hits the H2 stall.
+let sharedMcpDispatcher: Dispatcher | undefined;
+
+function getMcpDispatcher(): Dispatcher {
+  if (sharedMcpDispatcher === undefined) {
+    sharedMcpDispatcher = createProxyDispatcher(process.env) ?? new Agent({ allowH2: false });
+  }
+  return sharedMcpDispatcher;
+}
+
+/**
+ * `fetch` for remote MCP transports, pinned to HTTP/1.1 for direct
+ * connections (see above). Tests can inject their own fetch via the client
+ * options, or a custom dispatcher here, e.g. an H2-capable agent to
+ * reproduce the stall this works around.
+ */
+export function createMcpFetch(dispatcher: Dispatcher = getMcpDispatcher()): typeof fetch {
+  return ((input: unknown, init?: object) =>
+    undiciFetch(input as Parameters<typeof undiciFetch>[0], {
+      ...init,
+      dispatcher,
+    })) as unknown as typeof fetch;
 }

--- a/packages/agent-core-v2/src/agent/mcp/client-sse.ts
+++ b/packages/agent-core-v2/src/agent/mcp/client-sse.ts
@@ -43,7 +43,6 @@ export class SseMcpClient implements MCPClient {
 
     this.transport = new SSEClientTransport(new URL(config.url), {
       requestInit: headers !== undefined ? { headers } : undefined,
-      // Default fetch pins HTTP/1.1 (see client-remote.ts); tests inject their own.
       fetch: options.fetch ?? createMcpFetch(),
       authProvider: options.oauthProvider,
     });

--- a/packages/agent-core-v2/src/agent/mcp/client-sse.ts
+++ b/packages/agent-core-v2/src/agent/mcp/client-sse.ts
@@ -12,7 +12,7 @@ import {
   type UnexpectedCloseListener,
   type UnexpectedCloseReason,
 } from './client-shared';
-import { buildMcpRemoteHeaders } from './client-remote';
+import { buildMcpRemoteHeaders, createMcpFetch } from './client-remote';
 import type { MCPClient, MCPToolDefinition, MCPToolResult } from './types';
 
 export interface SseMcpClientOptions {
@@ -43,7 +43,8 @@ export class SseMcpClient implements MCPClient {
 
     this.transport = new SSEClientTransport(new URL(config.url), {
       requestInit: headers !== undefined ? { headers } : undefined,
-      fetch: options.fetch,
+      // Default fetch pins HTTP/1.1 (see client-remote.ts); tests inject their own.
+      fetch: options.fetch ?? createMcpFetch(),
       authProvider: options.oauthProvider,
     });
     this.client = new Client({

--- a/packages/agent-core-v2/test/agent/mcp/client-http.test.ts
+++ b/packages/agent-core-v2/test/agent/mcp/client-http.test.ts
@@ -202,19 +202,12 @@ describe('HttpMcpClient', () => {
 });
 
 describe('HTTP/1.1 pinning (createMcpFetch)', () => {
-  // Reproduces the failure mode of Cloudflare-hosted MCP servers (observed
-  // with Cloudflare's own docs endpoint): an HTTP/2 server that answers
-  // `initialize` and holds the standalone SSE GET stream open, but never
-  // answers POSTs that arrive while that GET stream is open on the same H2
-  // connection. Over H2 the handshake connects but `listTools` hangs; the
-  // H1.1-pinned fetch puts the requests on separate connections and succeeds.
   it('hangs over HTTP/2 and succeeds over the pinned HTTP/1.1 fetch', async () => {
     const server = await startStallingH2McpServer();
     cleanups.push(server.close);
 
     const config = { transport: 'http' as const, url: server.url };
 
-    // Baseline: an H2-capable agent hits the same stall as Node's global fetch.
     const h2Agent = new Agent({ allowH2: true, connect: { rejectUnauthorized: false } });
     cleanups.push(() => h2Agent.destroy());
     const h2Client = new HttpMcpClient(config, { fetch: createMcpFetch(h2Agent) });
@@ -229,7 +222,6 @@ describe('HTTP/1.1 pinning (createMcpFetch)', () => {
       await h2Client.close();
     }
 
-    // The H1.1-pinned default fetch avoids the stall.
     const h1Agent = new Agent({ allowH2: false, connect: { rejectUnauthorized: false } });
     cleanups.push(() => h1Agent.destroy());
     const h1Client = new HttpMcpClient(config, { fetch: createMcpFetch(h1Agent) });

--- a/packages/agent-core-v2/test/agent/mcp/client-http.test.ts
+++ b/packages/agent-core-v2/test/agent/mcp/client-http.test.ts
@@ -1,9 +1,11 @@
 import { afterEach, describe, expect, it } from 'vitest';
+import { Agent } from 'undici';
 
 import { ErrorCodes, Error2 } from '#/errors';
 import { buildMcpHttpHeaders, HttpMcpClient, isTerminalTransportError } from '#/agent/mcp/client-http';
+import { createMcpFetch } from '#/agent/mcp/client-remote';
 
-import { startInProcessHttpMcpServer } from './stubs';
+import { startInProcessHttpMcpServer, startStallingH2McpServer } from './stubs';
 
 const cleanups: Array<() => Promise<void> | void> = [];
 
@@ -197,4 +199,46 @@ describe('HttpMcpClient', () => {
       await client.close();
     }
   }, 15000);
+});
+
+describe('HTTP/1.1 pinning (createMcpFetch)', () => {
+  // Reproduces the failure mode of Cloudflare-hosted MCP servers (observed
+  // with Cloudflare's own docs endpoint): an HTTP/2 server that answers
+  // `initialize` and holds the standalone SSE GET stream open, but never
+  // answers POSTs that arrive while that GET stream is open on the same H2
+  // connection. Over H2 the handshake connects but `listTools` hangs; the
+  // H1.1-pinned fetch puts the requests on separate connections and succeeds.
+  it('hangs over HTTP/2 and succeeds over the pinned HTTP/1.1 fetch', async () => {
+    const server = await startStallingH2McpServer();
+    cleanups.push(server.close);
+
+    const config = { transport: 'http' as const, url: server.url };
+
+    // Baseline: an H2-capable agent hits the same stall as Node's global fetch.
+    const h2Agent = new Agent({ allowH2: true, connect: { rejectUnauthorized: false } });
+    cleanups.push(() => h2Agent.destroy());
+    const h2Client = new HttpMcpClient(config, { fetch: createMcpFetch(h2Agent) });
+    try {
+      await h2Client.connect();
+      const stalled = await Promise.race([
+        h2Client.listTools().then(() => 'resolved' as const),
+        new Promise<'timeout'>((resolve) => setTimeout(() => resolve('timeout'), 3000)),
+      ]);
+      expect(stalled).toBe('timeout');
+    } finally {
+      await h2Client.close();
+    }
+
+    // The H1.1-pinned default fetch avoids the stall.
+    const h1Agent = new Agent({ allowH2: false, connect: { rejectUnauthorized: false } });
+    cleanups.push(() => h1Agent.destroy());
+    const h1Client = new HttpMcpClient(config, { fetch: createMcpFetch(h1Agent) });
+    try {
+      await h1Client.connect();
+      const tools = await h1Client.listTools();
+      expect(tools.map((t) => t.name)).toEqual(['echo']);
+    } finally {
+      await h1Client.close();
+    }
+  }, 30000);
 });

--- a/packages/agent-core-v2/test/agent/mcp/stubs.ts
+++ b/packages/agent-core-v2/test/agent/mcp/stubs.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from 'node:crypto';
 import { createServer, type Server } from 'node:http';
+import { createSecureServer } from 'node:http2';
 import type { AddressInfo } from 'node:net';
 
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
@@ -201,6 +202,161 @@ function listen(server: Server): Promise<void> {
   return new Promise((resolve) => {
     server.listen(0, '127.0.0.1', resolve);
   });
+}
+
+const H2_STALL_TEST_CERT = `-----BEGIN CERTIFICATE-----
+MIIDJTCCAg2gAwIBAgIUDoSXEvr8xtqEm9NGkEfpabMw8CUwDQYJKoZIhvcNAQEL
+BQAwFDESMBAGA1UEAwwJbG9jYWxob3N0MB4XDTI2MDcxOTA3NTQyOVoXDTM2MDcx
+NjA3NTQyOVowFDESMBAGA1UEAwwJbG9jYWxob3N0MIIBIjANBgkqhkiG9w0BAQEF
+AAOCAQ8AMIIBCgKCAQEApdJUKNqaXWXo9dEEwEky2BNqbzzv20scyB/Tp1KaQvGn
+n9L9ZVlEUM3HLRu1GcOp7OS6lu97PC3SZypHbUOQrw+iN540hef0jpXGUquxW2/R
+NTbdaG7XHyBTOBOtPipRT83ikYPtBh0nBgD/s41y5LSyetMsQ9T5IkJ3IIGUxim1
+heNifKujm0belDADGJ48iwqQv6d14nHHePIZESZ73E1QLw4D0TNQG0ei+gj3OnLz
+DzgizEUzw8UVEsjOkdpbUc/JRpN5Fsn1qG3lRu37Ob4lbs0ymEZSmbj6h0Nx9TSF
+9ldRg5vq5eq/X+duMh9rXambe4BRmYPSiNXlFjD2MQIDAQABo28wbTAdBgNVHQ4E
+FgQUoC+OxUv9E65b/9G8bU/+w6DE1dQwHwYDVR0jBBgwFoAUoC+OxUv9E65b/9G8
+bU/+w6DE1dQwDwYDVR0TAQH/BAUwAwEB/zAaBgNVHREEEzARgglsb2NhbGhvc3SH
+BH8AAAEwDQYJKoZIhvcNAQELBQADggEBAGy3Obij9yhEYTi7wo7x2SqSrIiHJFhl
+NKXmGE8UqXitWsOWZ3cwHEPdofRYwXLmtkGuWYG1QLuuQN36wD/6jgAUGcuR2Ezk
+ZKe5Xq6/kxCst+RXzWGIe5ktz349/Jc+u52p73y4dJxAImdEjLm30HI7k6oKAN/2
+Vb8qBFwCWImPICiUhMW+e9O9f4mFI/A5BbNeeI4zrpZoSDb9FhLPmkdE2T/PNcTQ
+bClPGKoWApLJGNFEpPVX9/N+vwxAOAxiKqVq13gCrXgWHCeVwdfaRG8xzuBJ0Ysg
+CgFL/dPQMJBQhBYBpsFuz7M4z9Q5zUFRPxkzxs4JgSdZ/YZ7cI0g2+0=
+-----END CERTIFICATE-----`;
+
+const H2_STALL_TEST_KEY = `-----BEGIN PRIVATE KEY-----
+MIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQCl0lQo2ppdZej1
+0QTASTLYE2pvPO/bSxzIH9OnUppC8aef0v1lWURQzcctG7UZw6ns5LqW73s8LdJn
+KkdtQ5CvD6I3njSF5/SOlcZSq7Fbb9E1Nt1obtcfIFM4E60+KlFPzeKRg+0GHScG
+AP+zjXLktLJ60yxD1PkiQncggZTGKbWF42J8q6ObRt6UMAMYnjyLCpC/p3Xiccd4
+8hkRJnvcTVAvDgPRM1AbR6L6CPc6cvMPOCLMRTPDxRUSyM6R2ltRz8lGk3kWyfWo
+beVG7fs5viVuzTKYRlKZuPqHQ3H1NIX2V1GDm+rl6r9f524yH2tdqZt7gFGZg9KI
+1eUWMPYxAgMBAAECggEAB1MgYRKbnX242eeS+7xwA2/uHxOfGRMlu72o1NwMUOHe
++0DFF92RgTaUcldmO0kI6pwwQCZmzZciPhOLHADkn/sDOcziTzpFCP8Fh5V/zC/H
+BcBSl5WdKTSSwH12r7I2V8ha1lMwcePxRe20MytPydmlMFGU2Q/hYQ70Yf+fVwEi
+mzIuSZpPoqUfETeCtqQ1/ZDb3fe9Y11bLnTGymOEXcjJajCHUNomscK9rTwo6+NI
+gxZpi/koZpR0QzRbBpEQs/alw3pR8HY1jk+rQS0u70vFm5YbrduKerD7QMbJbtnY
+9TfTWg8sSwyrImLS4makPQMIjeiW6nI8RVhVQ3vovQKBgQDVWa0owcyN+/sRMRIU
+njfNMZAk2+DdfyGldFuYntb19rlJ0aQYzH+/qNGSpZCwXffyI6ZqemNMOgDxPwGv
+nBPDNpKSWRrDEJvNDMOadP832UwyfIgxLQwvL7HUX6Nccz0iS0a7ONE8FKV6PIPn
+lO1HF215ZLNiwUJ+AFsHjLLuHQKBgQDG+FgFtSEi0SunVP2WNe6OJKlVJDmcw241
+xPNrt4wCYXxd4lKurqV4W4TjjJnd3/Z4JNAS8S/yzoqXvwA4NOKgAPG0ORv/o9jG
+7U+snbwGBMLIiMCfh2cAgBKintsoz23aHZZRXtdbNWCyZan+/ih0HSZDRUA32UBc
+QZ91crD8JQKBgEEzEpPuBdEuPF/Ymynp4Cu5Bc/90g5el620jXlqsU6hg6Znhrp9
+ZFzx/nnOVxVO4kMBWg4YMNhOsZMIKj+8dt2lg81tpZwPK03SpMRDFOvAYGTdYdGF
+br/M14+LWqUaIoikcI0uo+K0fI2KiNTw0kJzimUavSdk4CkZergn61aRAoGBAJSO
+sAny5z67tkBFsOEKe4cd0GCFn45wTEVRO/5dGOheKSFf7iQGuf1XN60+OVPz+G5T
+7hd2hTphBBGwxlUxB1Q34D+TtFf22dANN8PGMbC8tUJM+KUjz8AL394Thca+uWJ1
+XNp8WYb8H6qTRY3h7gpkCUGI3x3T074OMSTb8VERAoGAeqgZdLE2Y3nvmlHWZlb0
+fdiiaKKBNHICLYSNa4uW0a5rWSVw+cWgJYFvmFkz5DuTJkAOyLukNouC3TYUWcTe
+al9H7C0WYMmTbMeDrJa0/UgHBkuxkCua2W8Z69x0g14vR4ni21DaGXomNQXS9R8k
+pN9iHuSv+UDZLidheNnLqOY=
+-----END PRIVATE KEY-----`;
+
+/**
+ * Mimics the wire behavior of Cloudflare-hosted MCP servers that broke
+ * remote MCP startup: over a single HTTP/2 connection, `initialize` is
+ * answered and the standalone GET SSE stream is held open, but a POST
+ * (e.g. `tools/list`) sent while that GET stream is open is never answered.
+ * HTTP/1.1 requests are always answered.
+ */
+export async function startStallingH2McpServer(): Promise<{ url: string; close: () => Promise<void> }> {
+  const initializeResult = (id: unknown) =>
+    `event: message\ndata: ${JSON.stringify({
+      result: {
+        protocolVersion: '2025-11-25',
+        capabilities: { tools: { listChanged: true } },
+        serverInfo: { name: 'h2-stall-mock', version: '0.0.1' },
+      },
+      jsonrpc: '2.0',
+      id,
+    })}\n\n`;
+  const toolsResult = (id: unknown) =>
+    `event: message\ndata: ${JSON.stringify({
+      result: {
+        tools: [
+          {
+            name: 'echo',
+            description: 'Echoes text',
+            inputSchema: { type: 'object', properties: { text: { type: 'string' } } },
+          },
+        ],
+      },
+      jsonrpc: '2.0',
+      id,
+    })}\n\n`;
+
+  const server = createSecureServer({
+    allowHTTP1: true,
+    cert: H2_STALL_TEST_CERT,
+    key: H2_STALL_TEST_KEY,
+  });
+
+  // HTTP/2 requests arrive on the 'stream' event.
+  server.on('stream', (stream, headers) => {
+    const method = headers[':method'];
+    if (method === 'GET') {
+      // Standalone SSE stream: respond and hold it open, never writing.
+      stream.respond({ ':status': 200, 'content-type': 'text/event-stream', 'cache-control': 'no-cache' });
+      return;
+    }
+    let body = '';
+    stream.on('data', (chunk: Buffer) => (body += chunk.toString()));
+    stream.on('end', () => {
+      const message = JSON.parse(body) as { method?: string; id?: unknown };
+      if (message.method === 'initialize') {
+        stream.respond({ ':status': 200, 'content-type': 'text/event-stream' });
+        stream.end(initializeResult(message.id));
+        return;
+      }
+      if (message.method === 'notifications/initialized') {
+        stream.respond({ ':status': 202 });
+        stream.end();
+        return;
+      }
+      // The stall: over H2, post-handshake POSTs (tools/list, tools/call)
+      // are never answered. The real-world trigger is the standalone GET
+      // stream being open on the same connection; because the SDK opens it
+      // asynchronously, keying on the stream directly would make this mimic
+      // racy, so it stalls all post-handshake H2 POSTs deterministically.
+      return;
+    });
+  });
+
+  // HTTP/1.1 requests also arrive on the compat 'request' event (H2 requests
+  // fire both 'stream' and 'request'; only handle 1.x here). Always answered.
+  server.on('request', (req, res) => {
+    if (req.httpVersionMajor !== 1 || res.headersSent) return;
+    if (req.method === 'GET') {
+      res.writeHead(200, { 'content-type': 'text/event-stream', 'cache-control': 'no-cache' });
+      // Hold the stream open; an empty write flushes headers without a body chunk.
+      res.write('');
+      return;
+    }
+    let body = '';
+    req.on('data', (chunk: Buffer) => (body += chunk.toString()));
+    req.on('end', () => {
+      const message = JSON.parse(body) as { method?: string; id?: unknown };
+      if (message.method === 'notifications/initialized') {
+        res.writeHead(202).end();
+        return;
+      }
+      res.writeHead(200, { 'content-type': 'text/event-stream' });
+      res.end(message.method === 'initialize' ? initializeResult(message.id) : toolsResult(message.id));
+    });
+  });
+
+  await new Promise<void>((resolve) => {
+    server.listen(0, '127.0.0.1', resolve);
+  });
+  const port = (server.address() as AddressInfo).port;
+
+  return {
+    url: `https://localhost:${port}/mcp`,
+    async close() {
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    },
+  };
 }
 
 export function closeServer(server: Server): Promise<void> {

--- a/packages/agent-core-v2/test/agent/mcp/stubs.ts
+++ b/packages/agent-core-v2/test/agent/mcp/stubs.ts
@@ -253,13 +253,6 @@ al9H7C0WYMmTbMeDrJa0/UgHBkuxkCua2W8Z69x0g14vR4ni21DaGXomNQXS9R8k
 pN9iHuSv+UDZLidheNnLqOY=
 -----END PRIVATE KEY-----`;
 
-/**
- * Mimics the wire behavior of Cloudflare-hosted MCP servers that broke
- * remote MCP startup: over a single HTTP/2 connection, `initialize` is
- * answered and the standalone GET SSE stream is held open, but a POST
- * (e.g. `tools/list`) sent while that GET stream is open is never answered.
- * HTTP/1.1 requests are always answered.
- */
 export async function startStallingH2McpServer(): Promise<{ url: string; close: () => Promise<void> }> {
   const initializeResult = (id: unknown) =>
     `event: message\ndata: ${JSON.stringify({
@@ -292,11 +285,9 @@ export async function startStallingH2McpServer(): Promise<{ url: string; close: 
     key: H2_STALL_TEST_KEY,
   });
 
-  // HTTP/2 requests arrive on the 'stream' event.
   server.on('stream', (stream, headers) => {
     const method = headers[':method'];
     if (method === 'GET') {
-      // Standalone SSE stream: respond and hold it open, never writing.
       stream.respond({ ':status': 200, 'content-type': 'text/event-stream', 'cache-control': 'no-cache' });
       return;
     }
@@ -314,22 +305,14 @@ export async function startStallingH2McpServer(): Promise<{ url: string; close: 
         stream.end();
         return;
       }
-      // The stall: over H2, post-handshake POSTs (tools/list, tools/call)
-      // are never answered. The real-world trigger is the standalone GET
-      // stream being open on the same connection; because the SDK opens it
-      // asynchronously, keying on the stream directly would make this mimic
-      // racy, so it stalls all post-handshake H2 POSTs deterministically.
       return;
     });
   });
 
-  // HTTP/1.1 requests also arrive on the compat 'request' event (H2 requests
-  // fire both 'stream' and 'request'; only handle 1.x here). Always answered.
   server.on('request', (req, res) => {
     if (req.httpVersionMajor !== 1 || res.headersSent) return;
     if (req.method === 'GET') {
       res.writeHead(200, { 'content-type': 'text/event-stream', 'cache-control': 'no-cache' });
-      // Hold the stream open; an empty write flushes headers without a body chunk.
       res.write('');
       return;
     }
@@ -352,7 +335,7 @@ export async function startStallingH2McpServer(): Promise<{ url: string; close: 
   const port = (server.address() as AddressInfo).port;
 
   return {
-    url: `https://localhost:${port}/mcp`,
+    url: `https://127.0.0.1:${port}/mcp`,
     async close() {
       await new Promise<void>((resolve) => server.close(() => resolve()));
     },

--- a/packages/agent-core/src/mcp/client-http.ts
+++ b/packages/agent-core/src/mcp/client-http.ts
@@ -12,7 +12,7 @@ import {
   type UnexpectedCloseListener,
   type UnexpectedCloseReason,
 } from './client-shared';
-import { buildMcpRemoteHeaders } from './client-remote';
+import { buildMcpRemoteHeaders, createMcpFetch } from './client-remote';
 import type { MCPClient, MCPToolDefinition, MCPToolResult } from './types';
 
 export interface HttpMcpClientOptions {
@@ -69,7 +69,8 @@ export class HttpMcpClient implements MCPClient {
 
     this.transport = new StreamableHTTPClientTransport(new URL(config.url), {
       requestInit: headers !== undefined ? { headers } : undefined,
-      fetch: options.fetch,
+      // Default fetch pins HTTP/1.1 (see client-remote.ts); tests inject their own.
+      fetch: options.fetch ?? createMcpFetch(),
       authProvider: options.oauthProvider,
     });
     this.client = new Client({

--- a/packages/agent-core/src/mcp/client-remote.ts
+++ b/packages/agent-core/src/mcp/client-remote.ts
@@ -1,5 +1,7 @@
 import type { McpRemoteServerConfig, McpServerConfig } from '#/config/schema';
 import { ErrorCodes, KimiError } from '#/errors';
+import { createProxyDispatcher } from '#/utils/proxy';
+import { Agent, fetch as undiciFetch, type Dispatcher } from 'undici';
 
 export function buildMcpRemoteHeaders(
   config: McpRemoteServerConfig,
@@ -29,4 +31,39 @@ export function buildMcpRemoteHeaders(
 
 export function isRemoteMcpConfig(config: McpServerConfig): config is McpRemoteServerConfig {
   return config.transport === 'http' || config.transport === 'sse';
+}
+
+// Node's global fetch negotiates HTTP/2 (undici `allowH2` defaults to true).
+// When the MCP SDK's streamable-HTTP transport then opens its standalone SSE
+// GET stream and sends POSTs over that one H2 connection, Cloudflare-hosted
+// MCP servers (including Cloudflare's own docs endpoint) stall the POST
+// indefinitely while the GET stream is open — the startup handshake times out
+// before `tools/list` ever resolves. Pinning remote MCP traffic to HTTP/1.1
+// puts the stream and the POSTs on separate connections, which every
+// spec-compliant server handles.
+//
+// When a proxy is configured the proxy dispatcher is used as-is: undici's
+// CONNECT tunnels already speak HTTP/1.1 to the origin, so proxied traffic
+// never hits the H2 stall.
+let sharedMcpDispatcher: Dispatcher | undefined;
+
+function getMcpDispatcher(): Dispatcher {
+  if (sharedMcpDispatcher === undefined) {
+    sharedMcpDispatcher = createProxyDispatcher() ?? new Agent({ allowH2: false });
+  }
+  return sharedMcpDispatcher;
+}
+
+/**
+ * `fetch` for remote MCP transports, pinned to HTTP/1.1 for direct
+ * connections (see above). Tests can inject their own fetch via the client
+ * options, or a custom dispatcher here, e.g. an H2-capable agent to
+ * reproduce the stall this works around.
+ */
+export function createMcpFetch(dispatcher: Dispatcher = getMcpDispatcher()): typeof fetch {
+  return ((input: unknown, init?: object) =>
+    undiciFetch(input as Parameters<typeof undiciFetch>[0], {
+      ...init,
+      dispatcher,
+    })) as unknown as typeof fetch;
 }

--- a/packages/agent-core/src/mcp/client-remote.ts
+++ b/packages/agent-core/src/mcp/client-remote.ts
@@ -1,7 +1,7 @@
 import type { McpRemoteServerConfig, McpServerConfig } from '#/config/schema';
 import { ErrorCodes, KimiError } from '#/errors';
 import { createProxyDispatcher } from '#/utils/proxy';
-import { Agent, fetch as undiciFetch, type Dispatcher } from 'undici';
+import { Agent, EnvHttpProxyAgent, fetch as undiciFetch, type Dispatcher } from 'undici';
 
 export function buildMcpRemoteHeaders(
   config: McpRemoteServerConfig,
@@ -35,21 +35,26 @@ export function isRemoteMcpConfig(config: McpServerConfig): config is McpRemoteS
 
 // Node's global fetch negotiates HTTP/2 (undici `allowH2` defaults to true).
 // When the MCP SDK's streamable-HTTP transport then opens its standalone SSE
-// GET stream and sends POSTs over that one H2 connection, Cloudflare-hosted
-// MCP servers (including Cloudflare's own docs endpoint) stall the POST
-// indefinitely while the GET stream is open — the startup handshake times out
-// before `tools/list` ever resolves. Pinning remote MCP traffic to HTTP/1.1
-// puts the stream and the POSTs on separate connections, which every
-// spec-compliant server handles.
+// GET stream on that H2 connection, undici queues every later stream-bodied
+// POST behind the in-flight GET and never dispatches it (undici client-h2
+// `busy()` guard; nodejs/undici#5524, fixed but not yet released). The GET
+// stream never ends, so `tools/list` hangs until the startup handshake times
+// out. Pinning remote MCP traffic to HTTP/1.1 puts the stream and the POSTs
+// on separate connections, which every spec-compliant server handles.
 //
-// When a proxy is configured the proxy dispatcher is used as-is: undici's
-// CONNECT tunnels already speak HTTP/1.1 to the origin, so proxied traffic
-// never hits the H2 stall.
+// The pin must also reach proxy dispatchers: undici's EnvHttpProxyAgent /
+// ProxyAgent negotiate H2 to the origin after the CONNECT tunnel as well.
+// (The SOCKS path builds its own Agent with a plain connector — HTTP/1.1 by
+// construction — so only the HTTP-proxy factory needs the flag.)
 let sharedMcpDispatcher: Dispatcher | undefined;
 
 function getMcpDispatcher(): Dispatcher {
   if (sharedMcpDispatcher === undefined) {
-    sharedMcpDispatcher = createProxyDispatcher() ?? new Agent({ allowH2: false });
+    sharedMcpDispatcher =
+      createProxyDispatcher(process.env, {
+        makeHttpAgent: ({ httpProxy, httpsProxy, noProxy }) =>
+          new EnvHttpProxyAgent({ httpProxy, httpsProxy, noProxy, allowH2: false }),
+      }) ?? new Agent({ allowH2: false });
   }
   return sharedMcpDispatcher;
 }

--- a/packages/agent-core/src/mcp/client-sse.ts
+++ b/packages/agent-core/src/mcp/client-sse.ts
@@ -12,7 +12,7 @@ import {
   type UnexpectedCloseListener,
   type UnexpectedCloseReason,
 } from './client-shared';
-import { buildMcpRemoteHeaders } from './client-remote';
+import { buildMcpRemoteHeaders, createMcpFetch } from './client-remote';
 import type { MCPClient, MCPToolDefinition, MCPToolResult } from './types';
 
 export interface SseMcpClientOptions {
@@ -62,7 +62,8 @@ export class SseMcpClient implements MCPClient {
 
     this.transport = new SSEClientTransport(new URL(config.url), {
       requestInit: headers !== undefined ? { headers } : undefined,
-      fetch: options.fetch,
+      // Default fetch pins HTTP/1.1 (see client-remote.ts); tests inject their own.
+      fetch: options.fetch ?? createMcpFetch(),
       authProvider: options.oauthProvider,
     });
     this.client = new Client({

--- a/packages/agent-core/test/mcp/client-http.test.ts
+++ b/packages/agent-core/test/mcp/client-http.test.ts
@@ -1,9 +1,11 @@
 import { randomUUID } from 'node:crypto';
 import { createServer, type Server } from 'node:http';
+import { createSecureServer } from 'node:http2';
 import type { AddressInfo } from 'node:net';
 
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
+import { Agent } from 'undici';
 import { afterEach, describe, expect, it } from 'vitest';
 import { z } from 'zod';
 
@@ -13,6 +15,7 @@ import {
   HttpMcpClient,
   isTerminalTransportError,
 } from '../../src/mcp/client-http';
+import { createMcpFetch } from '../../src/mcp/client-remote';
 
 const cleanups: Array<() => Promise<void> | void> = [];
 
@@ -269,3 +272,196 @@ describe('HttpMcpClient', () => {
     }
   }, 15000);
 });
+
+describe('HTTP/1.1 pinning (createMcpFetch)', () => {
+  // Reproduces the failure mode of Cloudflare-hosted MCP servers (observed
+  // with Cloudflare's own docs endpoint): an HTTP/2 server that answers
+  // `initialize` and holds the standalone SSE GET stream open, but never
+  // answers POSTs that arrive while that GET stream is open on the same H2
+  // connection. Over H2 the handshake connects but `listTools` hangs; the
+  // H1.1-pinned fetch puts the requests on separate connections and succeeds.
+  it('hangs over HTTP/2 and succeeds over the pinned HTTP/1.1 fetch', async () => {
+    const server = await startStallingH2McpServer();
+    cleanups.push(server.close);
+
+    const config = { transport: 'http' as const, url: server.url };
+
+    // Baseline: an H2-capable agent hits the same stall as Node's global fetch.
+    const h2Agent = new Agent({ allowH2: true, connect: { rejectUnauthorized: false } });
+    cleanups.push(() => h2Agent.destroy());
+    const h2Client = new HttpMcpClient(config, { fetch: createMcpFetch(h2Agent) });
+    try {
+      await h2Client.connect();
+      const stalled = await Promise.race([
+        h2Client.listTools().then(() => 'resolved' as const),
+        new Promise<'timeout'>((resolve) => setTimeout(() => resolve('timeout'), 3000)),
+      ]);
+      expect(stalled).toBe('timeout');
+    } finally {
+      await h2Client.close();
+    }
+
+    // The H1.1-pinned default fetch avoids the stall.
+    const h1Agent = new Agent({ allowH2: false, connect: { rejectUnauthorized: false } });
+    cleanups.push(() => h1Agent.destroy());
+    const h1Client = new HttpMcpClient(config, { fetch: createMcpFetch(h1Agent) });
+    try {
+      await h1Client.connect();
+      const tools = await h1Client.listTools();
+      expect(tools.map((t) => t.name)).toEqual(['echo']);
+    } finally {
+      await h1Client.close();
+    }
+  }, 30000);
+});
+
+const H2_STALL_TEST_CERT = `-----BEGIN CERTIFICATE-----
+MIIDJTCCAg2gAwIBAgIUDoSXEvr8xtqEm9NGkEfpabMw8CUwDQYJKoZIhvcNAQEL
+BQAwFDESMBAGA1UEAwwJbG9jYWxob3N0MB4XDTI2MDcxOTA3NTQyOVoXDTM2MDcx
+NjA3NTQyOVowFDESMBAGA1UEAwwJbG9jYWxob3N0MIIBIjANBgkqhkiG9w0BAQEF
+AAOCAQ8AMIIBCgKCAQEApdJUKNqaXWXo9dEEwEky2BNqbzzv20scyB/Tp1KaQvGn
+n9L9ZVlEUM3HLRu1GcOp7OS6lu97PC3SZypHbUOQrw+iN540hef0jpXGUquxW2/R
+NTbdaG7XHyBTOBOtPipRT83ikYPtBh0nBgD/s41y5LSyetMsQ9T5IkJ3IIGUxim1
+heNifKujm0belDADGJ48iwqQv6d14nHHePIZESZ73E1QLw4D0TNQG0ei+gj3OnLz
+DzgizEUzw8UVEsjOkdpbUc/JRpN5Fsn1qG3lRu37Ob4lbs0ymEZSmbj6h0Nx9TSF
+9ldRg5vq5eq/X+duMh9rXambe4BRmYPSiNXlFjD2MQIDAQABo28wbTAdBgNVHQ4E
+FgQUoC+OxUv9E65b/9G8bU/+w6DE1dQwHwYDVR0jBBgwFoAUoC+OxUv9E65b/9G8
+bU/+w6DE1dQwDwYDVR0TAQH/BAUwAwEB/zAaBgNVHREEEzARgglsb2NhbGhvc3SH
+BH8AAAEwDQYJKoZIhvcNAQELBQADggEBAGy3Obij9yhEYTi7wo7x2SqSrIiHJFhl
+NKXmGE8UqXitWsOWZ3cwHEPdofRYwXLmtkGuWYG1QLuuQN36wD/6jgAUGcuR2Ezk
+ZKe5Xq6/kxCst+RXzWGIe5ktz349/Jc+u52p73y4dJxAImdEjLm30HI7k6oKAN/2
+Vb8qBFwCWImPICiUhMW+e9O9f4mFI/A5BbNeeI4zrpZoSDb9FhLPmkdE2T/PNcTQ
+bClPGKoWApLJGNFEpPVX9/N+vwxAOAxiKqVq13gCrXgWHCeVwdfaRG8xzuBJ0Ysg
+CgFL/dPQMJBQhBYBpsFuz7M4z9Q5zUFRPxkzxs4JgSdZ/YZ7cI0g2+0=
+-----END CERTIFICATE-----`;
+
+const H2_STALL_TEST_KEY = `-----BEGIN PRIVATE KEY-----
+MIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQCl0lQo2ppdZej1
+0QTASTLYE2pvPO/bSxzIH9OnUppC8aef0v1lWURQzcctG7UZw6ns5LqW73s8LdJn
+KkdtQ5CvD6I3njSF5/SOlcZSq7Fbb9E1Nt1obtcfIFM4E60+KlFPzeKRg+0GHScG
+AP+zjXLktLJ60yxD1PkiQncggZTGKbWF42J8q6ObRt6UMAMYnjyLCpC/p3Xiccd4
+8hkRJnvcTVAvDgPRM1AbR6L6CPc6cvMPOCLMRTPDxRUSyM6R2ltRz8lGk3kWyfWo
+beVG7fs5viVuzTKYRlKZuPqHQ3H1NIX2V1GDm+rl6r9f524yH2tdqZt7gFGZg9KI
+1eUWMPYxAgMBAAECggEAB1MgYRKbnX242eeS+7xwA2/uHxOfGRMlu72o1NwMUOHe
++0DFF92RgTaUcldmO0kI6pwwQCZmzZciPhOLHADkn/sDOcziTzpFCP8Fh5V/zC/H
+BcBSl5WdKTSSwH12r7I2V8ha1lMwcePxRe20MytPydmlMFGU2Q/hYQ70Yf+fVwEi
+mzIuSZpPoqUfETeCtqQ1/ZDb3fe9Y11bLnTGymOEXcjJajCHUNomscK9rTwo6+NI
+gxZpi/koZpR0QzRbBpEQs/alw3pR8HY1jk+rQS0u70vFm5YbrduKerD7QMbJbtnY
+9TfTWg8sSwyrImLS4makPQMIjeiW6nI8RVhVQ3vovQKBgQDVWa0owcyN+/sRMRIU
+njfNMZAk2+DdfyGldFuYntb19rlJ0aQYzH+/qNGSpZCwXffyI6ZqemNMOgDxPwGv
+nBPDNpKSWRrDEJvNDMOadP832UwyfIgxLQwvL7HUX6Nccz0iS0a7ONE8FKV6PIPn
+lO1HF215ZLNiwUJ+AFsHjLLuHQKBgQDG+FgFtSEi0SunVP2WNe6OJKlVJDmcw241
+xPNrt4wCYXxd4lKurqV4W4TjjJnd3/Z4JNAS8S/yzoqXvwA4NOKgAPG0ORv/o9jG
+7U+snbwGBMLIiMCfh2cAgBKintsoz23aHZZRXtdbNWCyZan+/ih0HSZDRUA32UBc
+QZ91crD8JQKBgEEzEpPuBdEuPF/Ymynp4Cu5Bc/90g5el620jXlqsU6hg6Znhrp9
+ZFzx/nnOVxVO4kMBWg4YMNhOsZMIKj+8dt2lg81tpZwPK03SpMRDFOvAYGTdYdGF
+br/M14+LWqUaIoikcI0uo+K0fI2KiNTw0kJzimUavSdk4CkZergn61aRAoGBAJSO
+sAny5z67tkBFsOEKe4cd0GCFn45wTEVRO/5dGOheKSFf7iQGuf1XN60+OVPz+G5T
+7hd2hTphBBGwxlUxB1Q34D+TtFf22dANN8PGMbC8tUJM+KUjz8AL394Thca+uWJ1
+XNp8WYb8H6qTRY3h7gpkCUGI3x3T074OMSTb8VERAoGAeqgZdLE2Y3nvmlHWZlb0
+fdiiaKKBNHICLYSNa4uW0a5rWSVw+cWgJYFvmFkz5DuTJkAOyLukNouC3TYUWcTe
+al9H7C0WYMmTbMeDrJa0/UgHBkuxkCua2W8Z69x0g14vR4ni21DaGXomNQXS9R8k
+pN9iHuSv+UDZLidheNnLqOY=
+-----END PRIVATE KEY-----`;
+
+/**
+ * Mimics the wire behavior of Cloudflare-hosted MCP servers that broke
+ * remote MCP startup: over a single HTTP/2 connection, `initialize` is
+ * answered and the standalone GET SSE stream is held open, but a POST
+ * (e.g. `tools/list`) sent while that GET stream is open is never answered.
+ * HTTP/1.1 requests are always answered.
+ */
+async function startStallingH2McpServer(): Promise<{ url: string; close: () => Promise<void> }> {
+  const initializeResult = (id: unknown) =>
+    `event: message\ndata: ${JSON.stringify({
+      result: {
+        protocolVersion: '2025-11-25',
+        capabilities: { tools: { listChanged: true } },
+        serverInfo: { name: 'h2-stall-mock', version: '0.0.1' },
+      },
+      jsonrpc: '2.0',
+      id,
+    })}\n\n`;
+  const toolsResult = (id: unknown) =>
+    `event: message\ndata: ${JSON.stringify({
+      result: {
+        tools: [
+          {
+            name: 'echo',
+            description: 'Echoes text',
+            inputSchema: { type: 'object', properties: { text: { type: 'string' } } },
+          },
+        ],
+      },
+      jsonrpc: '2.0',
+      id,
+    })}\n\n`;
+
+  const server = createSecureServer({ allowHTTP1: true, cert: H2_STALL_TEST_CERT, key: H2_STALL_TEST_KEY });
+
+  // HTTP/2 requests arrive on the 'stream' event.
+  server.on('stream', (stream, headers) => {
+    const method = headers[':method'];
+    if (method === 'GET') {
+      // Standalone SSE stream: respond and hold it open, never writing.
+      stream.respond({ ':status': 200, 'content-type': 'text/event-stream', 'cache-control': 'no-cache' });
+      return;
+    }
+    let body = '';
+    stream.on('data', (chunk: Buffer) => (body += chunk.toString()));
+    stream.on('end', () => {
+      const message = JSON.parse(body) as { method?: string; id?: unknown };
+      if (message.method === 'initialize') {
+        stream.respond({ ':status': 200, 'content-type': 'text/event-stream' });
+        stream.end(initializeResult(message.id));
+        return;
+      }
+      if (message.method === 'notifications/initialized') {
+        stream.respond({ ':status': 202 });
+        stream.end();
+        return;
+      }
+      // The stall: over H2, post-handshake POSTs (tools/list, tools/call)
+      // are never answered. The real-world trigger is the standalone GET
+      // stream being open on the same connection; because the SDK opens it
+      // asynchronously, keying on the stream directly would make this mimic
+      // racy, so it stalls all post-handshake H2 POSTs deterministically.
+      return;
+    });
+  });
+
+  // HTTP/1.1 requests also arrive on the compat 'request' event (H2 requests
+  // fire both 'stream' and 'request'; only handle 1.x here). Always answered.
+  server.on('request', (req, res) => {
+    if (req.httpVersionMajor !== 1 || res.headersSent) return;
+    if (req.method === 'GET') {
+      res.writeHead(200, { 'content-type': 'text/event-stream', 'cache-control': 'no-cache' });
+      // Hold the stream open; an empty write flushes headers without a body chunk.
+      res.write('');
+      return;
+    }
+    let body = '';
+    req.on('data', (chunk: Buffer) => (body += chunk.toString()));
+    req.on('end', () => {
+      const message = JSON.parse(body) as { method?: string; id?: unknown };
+      if (message.method === 'notifications/initialized') {
+        res.writeHead(202).end();
+        return;
+      }
+      res.writeHead(200, { 'content-type': 'text/event-stream' });
+      res.end(message.method === 'initialize' ? initializeResult(message.id) : toolsResult(message.id));
+    });
+  });
+
+  await new Promise<void>((resolve) => {
+    server.listen(0, '127.0.0.1', resolve);
+  });
+  const port = (server.address() as AddressInfo).port;
+
+  return {
+    url: `https://localhost:${port}/mcp`,
+    async close() {
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    },
+  };
+}

--- a/packages/agent-core/test/mcp/client-http.test.ts
+++ b/packages/agent-core/test/mcp/client-http.test.ts
@@ -459,7 +459,7 @@ async function startStallingH2McpServer(): Promise<{ url: string; close: () => P
   const port = (server.address() as AddressInfo).port;
 
   return {
-    url: `https://localhost:${port}/mcp`,
+    url: `https://127.0.0.1:${port}/mcp`,
     async close() {
       await new Promise<void>((resolve) => server.close(() => resolve()));
     },


### PR DESCRIPTION
## Related Issue

No linked issue in this repo — the problem is explained below. This is a clear, reproducible bug fix with a focused diff (per CONTRIBUTING). Reported upstream to Cloudflare at [cloudflare/agents#1965](https://github.com/cloudflare/agents/issues/1965), whose investigation confirmed the root cause is the known undici client bug [nodejs/undici#5524](https://github.com/nodejs/undici/issues/5524), fixed upstream by [nodejs/undici#5538](https://github.com/nodejs/undici/pull/5538) but not yet released in a Node version.

## Problem

Remote (streamable HTTP) MCP servers hosted on Cloudflare fail to connect: the server is marked `failed` after the startup timeout (`Timed out after 30000ms`) even though the endpoint is healthy and other MCP clients connect to it fine.

Root cause, reproduced at the wire level:

1. Node's global `fetch` negotiates **HTTP/2** (undici `allowH2` defaults to true).
2. The MCP SDK's `StreamableHTTPClientTransport` opens its standalone SSE `GET` stream after `initialize` and keeps it open (spec-compliant).
3. Undici's H2 client then queues later stream-bodied `POST` requests (e.g. `tools/list`) behind the in-flight GET and **never dispatches them** (the `busy()` guard in `client-h2.js`). `connect()` succeeds, but `tools/list` hangs indefinitely until `startupTimeoutMs` fires — the server's tools never become available.

I swept 14 popular hosted MCP endpoints with the SDK's exact startup sequence (`initialize` → `notifications/initialized` → standalone GET stream → `tools/list`) using Node's default H2-capable fetch:

| Result | Endpoints |
|---|---|
| **Stall** | 2 Cloudflare-hosted servers, including Cloudflare's own first-party docs MCP |
| Unaffected | Linear, Notion, Sentry, Stripe, Vercel, Figma, PayPal, Supabase, Hugging Face, Context7, DeepWiki, GitMCP |

Every affected case completes in ~100ms when the same sequence runs over HTTP/1.1. The unaffected servers either reject the standalone GET stream (405), require auth up front (instant 401), or tolerate the multiplexing. (Auth-gated endpoints were only tested up to the 401 boundary.)

## What changed

- `agent-core` / `agent-core-v2` `mcp/client-remote.ts`: added `createMcpFetch()`, a `fetch` for remote MCP transports backed by an undici `Agent({ allowH2: false })`, pinning MCP traffic to HTTP/1.1 so the SSE stream and POSTs travel on separate connections. When proxy env vars are configured it uses the existing `createProxyDispatcher()` with the same `allowH2: false` pin passed through the HTTP-proxy agent factory — undici's `EnvHttpProxyAgent`/`ProxyAgent` also negotiate H2 to the origin after the CONNECT tunnel (verified against a local CONNECT proxy). The SOCKS path is HTTP/1.1 by construction.
- `client-http.ts` / `client-sse.ts` (both engines): the SDK transports now default to this fetch (`options.fetch ?? createMcpFetch()`). Injected fetches (tests) and the OAuth flow are unaffected.
- Regression test in both engines: a local HTTP/2 TLS server that mimics the failure mode (answers `initialize`, holds the GET stream open, never answers post-handshake POSTs over H2). An H2 agent stalls; the pinned H1.1 fetch connects and lists tools.

Why this approach: the bug is in the HTTP client layer, but until the undici fix ships in the Node versions users run, the client-side pin is the only lever available — and HTTP/1.1 is valid for every spec-compliant MCP server. The change is confined to the MCP remote-transport fetch, so nothing else in the app is affected; MCP traffic (a few JSON-RPC POSTs plus one long-lived stream) gains nothing measurable from H2 multiplexing, and the fix unbreaks a whole class of Cloudflare-hosted servers.

Verification (all run locally):

- New regression tests pass in both `agent-core` and `agent-core-v2`.
- Full suites pass: 3924 tests (agent-core), 3613 tests (agent-core-v2); `tsc --noEmit` and `oxlint` clean.
- End-to-end against a live Cloudflare-hosted MCP endpoint with the built `HttpMcpClient`: connect + `tools/list` succeed in ~1s (previously timed out after 30s).

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.
