### PR TITLE
fix(kimi-web): ignore non-string markdown copy payloads

### DIFF
--- a/.changeset/fix-web-copy-clipboard-event.md
+++ b/.changeset/fix-web-copy-clipboard-event.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Fix kimi web code-block copy writing "[object ClipboardEvent]" when a non-string copy payload is emitted.

--- a/apps/kimi-web/src/components/chat/Markdown.vue
+++ b/apps/kimi-web/src/components/chat/Markdown.vue
@@ -16,7 +16,7 @@ import { useIsDark } from '../../composables/useIsDark';
 import type { FilePreviewRequest } from '../../types';
 import { collectFilePathAliases, findFilePathLinks } from '../../lib/filePathLinks';
 import { markdownRenderPlan } from '../../lib/markdownPerformance';
-import { copyTextToClipboard } from '../../lib/clipboard';
+import { asCopyableText, copyTextToClipboard } from '../../lib/clipboard';
 import * as katexWorkerModule from 'markstream-vue/workers/katexRenderer.worker?worker&type=module';
 import * as mermaidWorkerModule from 'markstream-vue/workers/mermaidParser.worker?worker&type=module';
 import Tooltip from '../ui/Tooltip.vue';
@@ -338,10 +338,14 @@ const codeBlockProps = {
   loading: false,
 };
 
-function copyCodeBlockFallback(code: string): void {
+function copyCodeBlockFallback(payload: unknown): void {
   // markstream emits `copy` even when it skipped the write because the
   // Clipboard API is unavailable. Reuse our plain-HTTP fallback in that case,
   // while avoiding a duplicate write after markstream succeeds on HTTPS.
+  // Also ignore non-string payloads (e.g. native ClipboardEvent) — coercing
+  // those would write the literal "[object ClipboardEvent]" to the clipboard.
+  const code = asCopyableText(payload);
+  if (!code) return;
   const clipboard = typeof navigator !== 'undefined' ? navigator.clipboard : undefined;
   if (clipboard && typeof clipboard.writeText === 'function') return;
   void copyTextToClipboard(code);

--- a/apps/kimi-web/src/lib/clipboard.ts
+++ b/apps/kimi-web/src/lib/clipboard.ts
@@ -10,6 +10,17 @@
 // first and fall back to a temporary <textarea> + `document.execCommand`.
 
 /**
+ * Normalize payloads from markstream `@copy` (and similar) handlers.
+ *
+ * Some renderers emit a native `ClipboardEvent` on the same channel as the
+ * code-string payload. Coercing that object to a string yields the useless
+ * clipboard value `[object ClipboardEvent]`, so callers must reject non-strings.
+ */
+export function asCopyableText(payload: unknown): string | null {
+  return typeof payload === 'string' && payload.length > 0 ? payload : null;
+}
+
+/**
  * Copy `text` to the system clipboard.
  *
  * Resolves to `true` when the copy succeeded and `false` otherwise. Never

--- a/apps/kimi-web/test/clipboard.test.ts
+++ b/apps/kimi-web/test/clipboard.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { copyTextToClipboard } from '../src/lib/clipboard';
+import { asCopyableText, copyTextToClipboard } from '../src/lib/clipboard';
 
 // The web test suite runs in the default node environment (no jsdom), so we
 // mock the tiny `navigator` / `document` surface that the helper touches.
@@ -38,6 +38,20 @@ function installNavigator(clipboard: unknown): void {
 
 afterEach(() => {
   vi.unstubAllGlobals();
+});
+
+describe('asCopyableText', () => {
+  it('returns non-empty strings', () => {
+    expect(asCopyableText('hello')).toBe('hello');
+  });
+
+  it('rejects empty strings and non-strings', () => {
+    expect(asCopyableText('')).toBeNull();
+    expect(asCopyableText(undefined)).toBeNull();
+    expect(asCopyableText({ type: 'copy' })).toBeNull();
+    // Simulate a native ClipboardEvent-like object that stringifies badly.
+    expect(asCopyableText({ toString: () => '[object ClipboardEvent]' })).toBeNull();
+  });
 });
 
 describe('copyTextToClipboard', () => {


### PR DESCRIPTION
## Related Issue

Resolve https://github.com/MoonshotAI/kimi-code/issues/1812

## Problem

See linked issue. Copying a code block in `kimi web` could put the literal string `[object ClipboardEvent]` on the clipboard.

## What changed

- Added `asCopyableText()` to accept only non-empty string copy payloads
- `Markdown.vue` `copyCodeBlockFallback` now ignores non-string `@copy` payloads (for example a native `ClipboardEvent`) before the HTTP clipboard fallback runs
- Unit tests for `asCopyableText`
- Patch changeset for the CLI bundle that ships the web UI

## Checklist

- [x] I have read the CONTRIBUTING document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.


Made with [Cursor](https://cursor.com)