### PR TITLE
feat: scope thinking effort to the current session

### DIFF
--- a/.changeset/thinking-effort-session-scoped.md
+++ b/.changeset/thinking-effort-session-scoped.md
@@ -2,4 +2,4 @@
 "@moonshot-ai/kimi-code": minor
 ---
 
-Thinking effort picks now persist only up to `xhigh` — `max` is session-only, and a previously persisted `max` is migrated to `high` once. The web UI restores each session's own level when switching sessions and seeds new sessions from the per-model pick.
+Thinking effort picks now persist only below the model's highest declared level — the top tier is session-only, and a previously persisted `max` is migrated to `high` once. The web UI restores each session's own level when switching sessions and seeds new sessions from the per-model pick.

--- a/.changeset/thinking-effort-session-scoped.md
+++ b/.changeset/thinking-effort-session-scoped.md
@@ -2,4 +2,4 @@
 "@moonshot-ai/kimi-code": minor
 ---
 
-Switching effort applies to the current session only — thinking effort is no longer persisted.
+Thinking effort picks now persist only up to `xhigh` — `max` is session-only, and a previously persisted `max` is migrated to `high` once. The web UI restores each session's own level when switching sessions and seeds new sessions from the per-model pick.

--- a/.changeset/thinking-effort-session-scoped.md
+++ b/.changeset/thinking-effort-session-scoped.md
@@ -2,4 +2,4 @@
 "@moonshot-ai/kimi-code": minor
 ---
 
-Thinking effort picks now persist only below the model's highest declared level — the top tier is session-only, and a previously persisted `max` is migrated to `high` once. The web UI restores each session's own level when switching sessions and seeds new sessions from the per-model pick.
+Thinking effort picks now persist only below the model's highest declared level — the top tier is session-only, and a previously persisted `max` is migrated to `high` once. The web UI restores each session's own level when switching sessions and starts new sessions at the model's default.

--- a/.changeset/thinking-effort-session-scoped.md
+++ b/.changeset/thinking-effort-session-scoped.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": minor
+---
+
+Switching effort applies to the current session only — thinking effort is no longer persisted.

--- a/.changeset/thinking-effort-session-scoped.md
+++ b/.changeset/thinking-effort-session-scoped.md
@@ -2,4 +2,4 @@
 "@moonshot-ai/kimi-code": minor
 ---
 
-Thinking effort picks now persist only below the model's highest declared level — the top tier is session-only, and a previously persisted `max` is migrated to `high` once. The web UI restores each session's own level when switching sessions and starts new sessions at the model's default.
+Thinking effort persists only levels below the model's top tier (max).

--- a/apps/kimi-code/src/tui/commands/config.ts
+++ b/apps/kimi-code/src/tui/commands/config.ts
@@ -526,7 +526,11 @@ async function persistModelSelection(
 ): Promise<boolean> {
   const config = await host.harness.getConfig({ reload: true });
   const patch = thinkingEffortToConfig(effort);
-  if (config.defaultModel === alias && config.thinking?.enabled === patch.enabled) {
+  if (
+    config.defaultModel === alias &&
+    config.thinking?.enabled === patch.enabled &&
+    config.thinking?.effort === patch.effort
+  ) {
     return false;
   }
   await host.harness.setConfig({

--- a/apps/kimi-code/src/tui/commands/config.ts
+++ b/apps/kimi-code/src/tui/commands/config.ts
@@ -494,7 +494,12 @@ async function performModelSwitch(
   let persisted = false;
   if (persist) {
     try {
-      persisted = await persistModelSelection(host, effectiveAlias, effectiveEffort);
+      persisted = await persistModelSelection(
+        host,
+        effectiveAlias,
+        effectiveEffort,
+        effectiveEffortChanged,
+      );
     } catch (error) {
       const msg = formatErrorMessage(error);
       host.showError(`Switched to ${displayName}, but failed to save default: ${msg}`);
@@ -523,17 +528,21 @@ async function persistModelSelection(
   host: SlashCommandHost,
   alias: string,
   effort: ThinkingEffort,
+  effortChanged: boolean,
 ): Promise<boolean> {
   const config = await host.harness.getConfig({ reload: true });
   const model = host.state.appState.availableModels[alias];
-  const patch = thinkingEffortToConfig(
+  const full = thinkingEffortToConfig(
     effort,
     model === undefined ? undefined : effectiveModelForHost(host, model).supportEfforts,
   );
+  // Re-confirming the effort shown when the picker opened is not an explicit
+  // choice — persist the model but leave the stored effort preference alone.
+  const patch = effortChanged ? full : { enabled: full.enabled };
   if (
     config.defaultModel === alias &&
     config.thinking?.enabled === patch.enabled &&
-    config.thinking?.effort === patch.effort
+    (!effortChanged || config.thinking?.effort === patch.effort)
   ) {
     return false;
   }

--- a/apps/kimi-code/src/tui/commands/config.ts
+++ b/apps/kimi-code/src/tui/commands/config.ts
@@ -526,11 +526,7 @@ async function persistModelSelection(
 ): Promise<boolean> {
   const config = await host.harness.getConfig({ reload: true });
   const patch = thinkingEffortToConfig(effort);
-  if (
-    config.defaultModel === alias &&
-    config.thinking?.enabled === patch.enabled &&
-    config.thinking?.effort === patch.effort
-  ) {
+  if (config.defaultModel === alias && config.thinking?.enabled === patch.enabled) {
     return false;
   }
   await host.harness.setConfig({

--- a/apps/kimi-code/src/tui/commands/config.ts
+++ b/apps/kimi-code/src/tui/commands/config.ts
@@ -60,7 +60,7 @@ function currentTuiConfig(host: SlashCommandHost): TuiConfig {
   };
 }
 
-function effectiveModelForHost(host: SlashCommandHost, model: ModelAlias): ModelAlias {
+export function effectiveModelForHost(host: SlashCommandHost, model: ModelAlias): ModelAlias {
   const providerType = host.state.appState.availableProviders[model.provider]?.type;
   // Flat models (no named provider, e.g. inline base_url served by a v2
   // backend) have no provider entry to look up; their own protocol declaration

--- a/apps/kimi-code/src/tui/commands/config.ts
+++ b/apps/kimi-code/src/tui/commands/config.ts
@@ -525,7 +525,11 @@ async function persistModelSelection(
   effort: ThinkingEffort,
 ): Promise<boolean> {
   const config = await host.harness.getConfig({ reload: true });
-  const patch = thinkingEffortToConfig(effort);
+  const model = host.state.appState.availableModels[alias];
+  const patch = thinkingEffortToConfig(
+    effort,
+    model === undefined ? undefined : effectiveModelForHost(host, model).supportEfforts,
+  );
   if (
     config.defaultModel === alias &&
     config.thinking?.enabled === patch.enabled &&

--- a/apps/kimi-code/src/tui/commands/provider.ts
+++ b/apps/kimi-code/src/tui/commands/provider.ts
@@ -261,7 +261,10 @@ async function setDefaultModel(
 ): Promise<void> {
   await host.harness.setConfig({
     defaultModel: alias,
-    thinking: thinkingEffortToConfig(effort),
+    thinking: thinkingEffortToConfig(
+      effort,
+      host.state.appState.availableModels[alias]?.supportEfforts,
+    ),
   });
   await host.authFlow.refreshConfigAfterLogin();
   host.track('model_switch', { model: alias });

--- a/apps/kimi-code/src/tui/commands/provider.ts
+++ b/apps/kimi-code/src/tui/commands/provider.ts
@@ -30,6 +30,7 @@ import { TabbedModelSelectorComponent } from '../components/dialogs/tabbed-model
 import { DEFAULT_OAUTH_PROVIDER_NAME } from '../constant/kimi-tui';
 import { formatErrorMessage } from '../utils/event-payload';
 import { thinkingEffortToConfig } from '../utils/thinking-config';
+import { effectiveModelForHost } from './config';
 import {
   promptApiKey,
   promptCatalogProviderSelection,
@@ -259,11 +260,16 @@ async function setDefaultModel(
   alias: string,
   effort: ThinkingEffort,
 ): Promise<void> {
+  // Resolve efforts the same way the /model path does (effectiveModelForHost
+  // applies overrides and the protocol-profile inference): catalog entries for
+  // e.g. Anthropic models declare no support_efforts on the alias, and without
+  // the inference a top-tier pick would slip through as a persisted effort.
+  const model = host.state.appState.availableModels[alias];
   await host.harness.setConfig({
     defaultModel: alias,
     thinking: thinkingEffortToConfig(
       effort,
-      host.state.appState.availableModels[alias]?.supportEfforts,
+      model === undefined ? undefined : effectiveModelForHost(host, model).supportEfforts,
     ),
   });
   await host.authFlow.refreshConfigAfterLogin();

--- a/apps/kimi-code/src/tui/utils/thinking-config.ts
+++ b/apps/kimi-code/src/tui/utils/thinking-config.ts
@@ -7,18 +7,15 @@ export function isThinkingOn(effort: ThinkingEffort): boolean {
 
 /**
  * Project a thinking effort to the `[thinking]` config patch persisted to
- * config.toml. `'off'` disables thinking; a concrete effort enables thinking
- * and records it as the global effort preference. `'on'` is the boolean-model
- * on-signal rather than a declared effort, so it only persists `enabled` —
- * boolean models resolve back to `'on'` at runtime via `defaultThinkingEffortFor`.
+ * config.toml. Only the boolean `enabled` flag is persisted — picking a model
+ * or thinking mode in the TUI no longer records the concrete effort. Boolean
+ * models resolve back to `'on'` at runtime via `defaultThinkingEffortFor`, and
+ * effort-capable models fall back to their own default effort.
  */
 export function thinkingEffortToConfig(effort: ThinkingEffort): {
   enabled: boolean;
-  effort?: string;
 } {
-  if (effort === 'off') return { enabled: false };
-  if (effort === 'on') return { enabled: true };
-  return { enabled: true, effort };
+  return { enabled: effort !== 'off' };
 }
 
 /**

--- a/apps/kimi-code/src/tui/utils/thinking-config.ts
+++ b/apps/kimi-code/src/tui/utils/thinking-config.ts
@@ -6,16 +6,31 @@ export function isThinkingOn(effort: ThinkingEffort): boolean {
 }
 
 /**
+ * Effort levels eligible for persistence to config.toml, on the canonical
+ * scale `low/medium/high/xhigh/max`. `max` and any level outside the scale
+ * (custom provider-declared names) are session-only: they work at runtime but
+ * only the boolean toggle is persisted, so the most expensive tier never
+ * becomes the global default for every new session.
+ */
+export const PERSISTABLE_THINKING_EFFORTS: readonly string[] = ['low', 'medium', 'high', 'xhigh'];
+
+/**
  * Project a thinking effort to the `[thinking]` config patch persisted to
- * config.toml. Only the boolean `enabled` flag is persisted — picking a model
- * or thinking mode in the TUI no longer records the concrete effort. Boolean
- * models resolve back to `'on'` at runtime via `defaultThinkingEffortFor`, and
- * effort-capable models fall back to their own default effort.
+ * config.toml. `'off'` disables thinking; `'on'` is the boolean-model
+ * on-signal rather than a declared effort, so it only persists `enabled` —
+ * boolean models resolve back to `'on'` at runtime via
+ * `defaultThinkingEffortFor`. A concrete effort persists as the global default
+ * when it is in {@link PERSISTABLE_THINKING_EFFORTS}; anything above it is
+ * session-only and only `enabled` is recorded.
  */
 export function thinkingEffortToConfig(effort: ThinkingEffort): {
   enabled: boolean;
+  effort?: string;
 } {
-  return { enabled: effort !== 'off' };
+  if (effort === 'off') return { enabled: false };
+  if (effort === 'on') return { enabled: true };
+  if (PERSISTABLE_THINKING_EFFORTS.includes(effort)) return { enabled: true, effort };
+  return { enabled: true };
 }
 
 /**

--- a/apps/kimi-code/src/tui/utils/thinking-config.ts
+++ b/apps/kimi-code/src/tui/utils/thinking-config.ts
@@ -6,31 +6,30 @@ export function isThinkingOn(effort: ThinkingEffort): boolean {
 }
 
 /**
- * Effort levels eligible for persistence to config.toml, on the canonical
- * scale `low/medium/high/xhigh/max`. `max` and any level outside the scale
- * (custom provider-declared names) are session-only: they work at runtime but
- * only the boolean toggle is persisted, so the most expensive tier never
- * becomes the global default for every new session.
- */
-export const PERSISTABLE_THINKING_EFFORTS: readonly string[] = ['low', 'medium', 'high', 'xhigh'];
-
-/**
  * Project a thinking effort to the `[thinking]` config patch persisted to
  * config.toml. `'off'` disables thinking; `'on'` is the boolean-model
  * on-signal rather than a declared effort, so it only persists `enabled` —
  * boolean models resolve back to `'on'` at runtime via
- * `defaultThinkingEffortFor`. A concrete effort persists as the global default
- * when it is in {@link PERSISTABLE_THINKING_EFFORTS}; anything above it is
- * session-only and only `enabled` is recorded.
+ * `defaultThinkingEffortFor`. A concrete effort persists as the global
+ * default, EXCEPT the model's highest declared level — the last entry of
+ * `support_efforts` (the list is ordered by strength, the same assumption
+ * the `middleOf` default-effort resolution makes) — which is session-only
+ * and records just `enabled`, so the most expensive tier never becomes the
+ * global default for every new session. When the model's levels are unknown
+ * the concrete effort is persisted as-is.
  */
-export function thinkingEffortToConfig(effort: ThinkingEffort): {
+export function thinkingEffortToConfig(
+  effort: ThinkingEffort,
+  supportEfforts?: readonly string[],
+): {
   enabled: boolean;
   effort?: string;
 } {
   if (effort === 'off') return { enabled: false };
   if (effort === 'on') return { enabled: true };
-  if (PERSISTABLE_THINKING_EFFORTS.includes(effort)) return { enabled: true, effort };
-  return { enabled: true };
+  const top = supportEfforts?.at(-1);
+  if (top !== undefined && effort === top) return { enabled: true };
+  return { enabled: true, effort };
 }
 
 /**

--- a/apps/kimi-code/test/tui/kimi-tui-message-flow.test.ts
+++ b/apps/kimi-code/test/tui/kimi-tui-message-flow.test.ts
@@ -4713,6 +4713,116 @@ command = "vim"
     expect(session.setThinking).not.toHaveBeenCalled();
   });
 
+  it('does not write config when re-confirming the current effort in the picker', async () => {
+    const session = makeSession({
+      getStatus: vi.fn(async () => ({
+        model: 'k2',
+        thinkingEffort: 'high',
+        permission: 'manual',
+        planMode: false,
+        contextTokens: 0,
+        maxContextTokens: 100,
+        contextUsage: 0,
+      })),
+    });
+    const setConfig = vi.fn(async () => ({ providers: {} }));
+    const { driver } = await makeDriver(session, {
+      getConfig: vi.fn(async () => ({
+        models: {
+          k2: {
+            provider: 'managed:kimi-code',
+            model: 'kimi-k2',
+            maxContextSize: 100,
+            displayName: 'Kimi K2',
+            capabilities: ['thinking'],
+            supportEfforts: ['low', 'high', 'max'],
+            defaultEffort: 'high',
+          },
+        },
+        defaultModel: 'k2',
+        // No persisted effort: re-confirming the shown level must not turn the
+        // runtime default into a stored preference.
+        thinking: { enabled: true },
+      })),
+      setConfig,
+    });
+
+    driver.handleUserInput('/effort');
+
+    await vi.waitFor(() => {
+      expect(driver.state.editorContainer.children[0]).toBeInstanceOf(EffortSelectorComponent);
+    });
+    (driver.state.editorContainer.children[0] as EffortSelectorComponent).handleInput('\r');
+
+    await vi.waitFor(() => {
+      expect(renderTranscript(driver)).toContain('Already using Kimi K2 with thinking high.');
+    });
+    expect(setConfig).not.toHaveBeenCalled();
+    expect(session.setThinking).not.toHaveBeenCalled();
+  });
+
+  it('persists only the model when a switch keeps the same effort', async () => {
+    let switched = false;
+    const session = makeSession({
+      getStatus: vi.fn(async () => ({
+        model: switched ? 'turbo' : 'k2',
+        thinkingEffort: 'high',
+        permission: 'manual',
+        planMode: false,
+        contextTokens: 0,
+        maxContextTokens: 100,
+        contextUsage: 0,
+      })),
+      setModel: vi.fn(async () => {
+        switched = true;
+      }),
+    });
+    const setConfig = vi.fn(async () => ({ providers: {} }));
+    const { driver } = await makeDriver(session, {
+      getConfig: vi.fn(async () => ({
+        models: {
+          k2: {
+            provider: 'managed:kimi-code',
+            model: 'kimi-k2',
+            maxContextSize: 100,
+            displayName: 'Kimi K2',
+            capabilities: ['thinking'],
+            supportEfforts: ['low', 'high', 'max'],
+            defaultEffort: 'high',
+          },
+          turbo: {
+            provider: 'managed:kimi-code',
+            model: 'kimi-turbo',
+            maxContextSize: 100,
+            displayName: 'Turbo',
+            capabilities: ['thinking'],
+            supportEfforts: ['low', 'high', 'max'],
+            defaultEffort: 'high',
+          },
+        },
+        defaultModel: 'k2',
+        thinking: { enabled: true, effort: 'high' },
+      })),
+      setConfig,
+    });
+
+    driver.handleUserInput('/model turbo');
+
+    await vi.waitFor(() => {
+      expect(driver.state.editorContainer.children[0]).toBeInstanceOf(TabbedModelSelectorComponent);
+    });
+    (driver.state.editorContainer.children[0] as TabbedModelSelectorComponent).handleInput('\r');
+
+    // The effort matches the value shown when the picker opened, so the patch
+    // carries no effort key; the stored preference stays as-is via the merge.
+    await vi.waitFor(() => {
+      expect(setConfig).toHaveBeenCalledWith({
+        defaultModel: 'turbo',
+        thinking: { enabled: true },
+      });
+    });
+  });
+
   it('refreshes only OAuth provider models before opening /model picker', async () => {
     const { driver } = await makeDriver(makeSession(), {
       getConfig: vi.fn(async () => ({

--- a/apps/kimi-code/test/tui/kimi-tui-message-flow.test.ts
+++ b/apps/kimi-code/test/tui/kimi-tui-message-flow.test.ts
@@ -4667,7 +4667,7 @@ command = "vim"
     await vi.waitFor(() => {
       expect(setConfig).toHaveBeenCalledWith({
         defaultModel: 'turbo',
-        thinking: { enabled: true },
+        thinking: { enabled: true, effort: 'mid' },
       });
     });
     expect(driver.state.appState.model).toBe('turbo');

--- a/apps/kimi-code/test/tui/kimi-tui-message-flow.test.ts
+++ b/apps/kimi-code/test/tui/kimi-tui-message-flow.test.ts
@@ -4667,7 +4667,7 @@ command = "vim"
     await vi.waitFor(() => {
       expect(setConfig).toHaveBeenCalledWith({
         defaultModel: 'turbo',
-        thinking: { enabled: true, effort: 'mid' },
+        thinking: { enabled: true },
       });
     });
     expect(driver.state.appState.model).toBe('turbo');

--- a/apps/kimi-code/test/tui/utils/thinking-config.test.ts
+++ b/apps/kimi-code/test/tui/utils/thinking-config.test.ts
@@ -9,13 +9,12 @@ import {
 describe('thinkingEffortToConfig', () => {
   it.each([
     ['off', { enabled: false }],
-    // 'on' is the boolean-model on-signal, not a declared effort. It must not
-    // be persisted as `thinking.effort` — boolean models have no effort concept
-    // and resolve back to 'on' at runtime via defaultThinkingEffortFor.
+    // Only the boolean `enabled` flag is persisted — selecting a model or
+    // thinking mode in the TUI no longer records the concrete effort.
     ['on', { enabled: true }],
-    ['low', { enabled: true, effort: 'low' }],
-    ['high', { enabled: true, effort: 'high' }],
-    ['max', { enabled: true, effort: 'max' }],
+    ['low', { enabled: true }],
+    ['high', { enabled: true }],
+    ['max', { enabled: true }],
   ] as const)('maps %s → %o', (effort, expected) => {
     expect(thinkingEffortToConfig(effort)).toEqual(expected);
   });

--- a/apps/kimi-code/test/tui/utils/thinking-config.test.ts
+++ b/apps/kimi-code/test/tui/utils/thinking-config.test.ts
@@ -13,15 +13,27 @@ describe('thinkingEffortToConfig', () => {
     // be persisted as `thinking.effort` — boolean models have no effort concept
     // and resolve back to 'on' at runtime via defaultThinkingEffortFor.
     ['on', { enabled: true }],
-    // Whitelisted levels persist as the global default; 'max' and unknown
-    // names are session-only and record only the boolean toggle.
     ['low', { enabled: true, effort: 'low' }],
     ['high', { enabled: true, effort: 'high' }],
-    ['xhigh', { enabled: true, effort: 'xhigh' }],
-    ['max', { enabled: true }],
-    ['ultra', { enabled: true }],
-  ] as const)('maps %s → %o', (effort, expected) => {
+    ['max', { enabled: true, effort: 'max' }],
+  ] as const)('maps %s → %o without model efforts', (effort, expected) => {
     expect(thinkingEffortToConfig(effort)).toEqual(expected);
+  });
+
+  it.each([
+    // The model's highest declared level (last support_efforts entry) is
+    // session-only; anything below it persists as the global default.
+    ['low', { enabled: true, effort: 'low' }],
+    ['high', { enabled: true, effort: 'high' }],
+    ['max', { enabled: true }],
+    // Undeclared values persist as-is (the provider validates them).
+    ['ultra', { enabled: true, effort: 'ultra' }],
+  ] as const)('maps %s → %o for [low, high, max]', (effort, expected) => {
+    expect(thinkingEffortToConfig(effort, ['low', 'high', 'max'])).toEqual(expected);
+  });
+
+  it('treats a single declared level as the top tier', () => {
+    expect(thinkingEffortToConfig('max', ['max'])).toEqual({ enabled: true });
   });
 });
 

--- a/apps/kimi-code/test/tui/utils/thinking-config.test.ts
+++ b/apps/kimi-code/test/tui/utils/thinking-config.test.ts
@@ -9,12 +9,17 @@ import {
 describe('thinkingEffortToConfig', () => {
   it.each([
     ['off', { enabled: false }],
-    // Only the boolean `enabled` flag is persisted — selecting a model or
-    // thinking mode in the TUI no longer records the concrete effort.
+    // 'on' is the boolean-model on-signal, not a declared effort. It must not
+    // be persisted as `thinking.effort` — boolean models have no effort concept
+    // and resolve back to 'on' at runtime via defaultThinkingEffortFor.
     ['on', { enabled: true }],
-    ['low', { enabled: true }],
-    ['high', { enabled: true }],
+    // Whitelisted levels persist as the global default; 'max' and unknown
+    // names are session-only and record only the boolean toggle.
+    ['low', { enabled: true, effort: 'low' }],
+    ['high', { enabled: true, effort: 'high' }],
+    ['xhigh', { enabled: true, effort: 'xhigh' }],
     ['max', { enabled: true }],
+    ['ultra', { enabled: true }],
   ] as const)('maps %s → %o', (effort, expected) => {
     expect(thinkingEffortToConfig(effort)).toEqual(expected);
   });

--- a/apps/kimi-web/src/api/daemon/agentEventProjector.ts
+++ b/apps/kimi-web/src/api/daemon/agentEventProjector.ts
@@ -962,6 +962,12 @@ export function createAgentProjector(): AgentProjector {
           // for a "make a plan" prompt). Carry it so the composer's plan toggle
           // reflects the agent's real state, not just the user's manual choice.
           planMode: p?.planMode === true ? true : p?.planMode === false ? false : undefined,
+          // The session's own thinking level, so per-session state stays in sync
+          // across clients (same treatment as plan/swarm above).
+          thinking:
+            typeof p?.thinkingEffort === 'string' && p.thinkingEffort.length > 0
+              ? p.thinkingEffort
+              : undefined,
         });
         break;
       }

--- a/apps/kimi-web/src/api/types.ts
+++ b/apps/kimi-web/src/api/types.ts
@@ -426,7 +426,7 @@ export type AppEvent =
       lastTurnReason?: 'completed' | 'cancelled' | 'failed';
     }
   | { type: 'sessionMetaUpdated'; sessionId: string; title?: string; lastPrompt?: string }
-  | { type: 'sessionUsageUpdated'; sessionId: string; usage: AppSessionUsage; model?: string; swarmMode?: boolean; planMode?: boolean }
+  | { type: 'sessionUsageUpdated'; sessionId: string; usage: AppSessionUsage; model?: string; swarmMode?: boolean; planMode?: boolean; thinking?: string }
   | { type: 'historyCompacted'; sessionId: string; beforeSeq: number; reason: string; summaryMessageId?: string }
   | { type: 'compactionStarted'; sessionId: string; trigger: 'manual' | 'auto'; instruction?: string }
   | { type: 'compactionCompleted'; sessionId: string; tokensBefore?: number; tokensAfter?: number; summary?: string }

--- a/apps/kimi-web/src/composables/client/useModelProviderState.ts
+++ b/apps/kimi-web/src/composables/client/useModelProviderState.ts
@@ -543,14 +543,11 @@ export function useModelProviderState(
   }
 
   /** Persist and apply a new extended-thinking level (also pushed to the active
-   *  session profile so the daemon's /status reflects it; still sent per-prompt).
-   *  Re-confirming the level already shown is not an explicit choice, so the
-   *  daemon-wide default is left untouched in that case. */
+   *  session profile so the daemon's /status reflects it; still sent per-prompt). */
   function setThinking(level: ThinkingLevel): void {
-    const prev = rawState.thinking;
     const next = applyThinkingLevel(level);
     void persistSessionProfile({ thinking: next });
-    if (next !== undefined && next !== prev) persistGlobalThinking(next);
+    if (next !== undefined) persistGlobalThinking(next);
   }
 
   return {

--- a/apps/kimi-web/src/composables/client/useModelProviderState.ts
+++ b/apps/kimi-web/src/composables/client/useModelProviderState.ts
@@ -543,11 +543,14 @@ export function useModelProviderState(
   }
 
   /** Persist and apply a new extended-thinking level (also pushed to the active
-   *  session profile so the daemon's /status reflects it; still sent per-prompt). */
+   *  session profile so the daemon's /status reflects it; still sent per-prompt).
+   *  Re-confirming the level already shown is not an explicit choice, so the
+   *  daemon-wide default is left untouched in that case. */
   function setThinking(level: ThinkingLevel): void {
+    const prev = rawState.thinking;
     const next = applyThinkingLevel(level);
     void persistSessionProfile({ thinking: next });
-    if (next !== undefined) persistGlobalThinking(next);
+    if (next !== undefined && next !== prev) persistGlobalThinking(next);
   }
 
   return {

--- a/apps/kimi-web/src/composables/client/useModelProviderState.ts
+++ b/apps/kimi-web/src/composables/client/useModelProviderState.ts
@@ -182,6 +182,28 @@ export function useModelProviderState(
     return model === undefined ? undefined : thinkingLevelForSession(sessionId, model);
   }
 
+  /**
+   * Submission-time resolution: when the session's own level has not been
+   * folded from /status yet (the cold window right after a reload or a
+   * session switch), wait for that fold first. Resolving straight to the
+   * catalog default here would not just display wrong — the prompt carries
+   * the level to the daemon, which writes it into the session profile and
+   * permanently overwrites the level the session actually ran at.
+   */
+  async function resolveThinkingForPrompt(
+    sessionId: string | null | undefined,
+    modelId: string | undefined,
+  ): Promise<ThinkingLevel | undefined> {
+    if (
+      sessionId !== null &&
+      sessionId !== undefined &&
+      rawState.thinkingBySession[sessionId] === undefined
+    ) {
+      await refreshSessionStatus(sessionId);
+    }
+    return thinkingLevelForSessionId(sessionId, modelId);
+  }
+
   function applyThinkingLevel(level: ThinkingLevel | undefined): ThinkingLevel | undefined {
     // The explicit-picker path (setThinking). Model switches (setModel) and
     // passive resolution update rawState.thinking in-memory the same way, but
@@ -429,7 +451,7 @@ export function useModelProviderState(
       const rawModel = rawState.sessions.find((s) => s.id === sid)?.model;
       const skillModel = (rawModel && rawModel.length > 0 ? rawModel : rawState.defaultModel) ?? undefined;
       const persisted = await persistSessionProfile(
-        { thinking: thinkingLevelForSessionId(sid, skillModel) ?? rawState.thinking },
+        { thinking: (await resolveThinkingForPrompt(sid, skillModel)) ?? rawState.thinking },
         sid,
       );
       if (!persisted) throw PROFILE_PERSIST_FAILED;
@@ -566,6 +588,7 @@ export function useModelProviderState(
     setModel,
     thinkingLevelForModelId,
     thinkingLevelForSessionId,
+    resolveThinkingForPrompt,
     toggleStarModel,
     activateSkill,
     addProvider,

--- a/apps/kimi-web/src/composables/client/useModelProviderState.ts
+++ b/apps/kimi-web/src/composables/client/useModelProviderState.ts
@@ -257,7 +257,9 @@ export function useModelProviderState(
    *  values (e.g. the loadModels default pin) — only for user actions. */
   function persistGlobalThinking(level: ThinkingLevel): void {
     void getKimiWebApi()
-      .setConfig({ thinking: thinkingLevelToConfig(level) })
+      .setConfig({
+        thinking: thinkingLevelToConfig(level, modelById(currentModelId())?.supportEfforts),
+      })
       .catch((error: unknown) => pushOperationFailure('setConfig', error));
   }
 

--- a/apps/kimi-web/src/composables/client/useModelProviderState.ts
+++ b/apps/kimi-web/src/composables/client/useModelProviderState.ts
@@ -79,12 +79,6 @@ export interface UseModelProviderStateDeps {
    *  order strictly after the profile must NOT proceed on false. */
   persistSessionProfile: (patch: PersistSessionProfilePatch, sessionId?: string) => Promise<boolean>;
   activity: ComputedRef<ActivityState>;
-  /** Read the persisted thinking pick for a model (undefined = never picked
-   *  for that model). Storage is keyed by model id and seeds NEW sessions —
-   *  a session's own daemon-reported level always wins once it exists. */
-  loadThinkingForModel: (modelId: string) => ThinkingLevel | undefined;
-  /** Persist an explicit thinking pick under the given model id. */
-  saveThinkingToStorage: (modelId: string, level: ThinkingLevel) => void;
   /** Replace one session in place (matched by id). Owned by the facade so the
    *  model module never assigns rawState.sessions directly. */
   updateSession: (id: string, update: (session: AppSession) => AppSession) => void;
@@ -104,8 +98,6 @@ export function useModelProviderState(
     refreshSessionStatus,
     persistSessionProfile,
     activity,
-    loadThinkingForModel,
-    saveThinkingToStorage,
     updateSession,
     updateSessionMessages,
   } = deps;
@@ -147,20 +139,6 @@ export function useModelProviderState(
     return modelById(rawModel)?.id ?? rawModel ?? undefined;
   }
 
-  /**
-   * The level a model should run at when no per-session state exists (the
-   * new-session seed): the user's stored pick for THIS model when the model
-   * still declares it, else the model's catalog default. Validation against
-   * the catalog entry is what keeps a stale or foreign level (picked for
-   * another model, or dropped by a catalog update) from reaching the UI and
-   * the daemon.
-   */
-  function thinkingLevelForModel(model: AppModel): ThinkingLevel {
-    const stored = loadThinkingForModel(model.id);
-    if (stored !== undefined && levelDeclaredBy(model, stored)) return stored;
-    return defaultThinkingLevelFor(model);
-  }
-
   /** thinkingLevelForModel by model id, for paths that submit a prompt for a
    *  session other than the active one (queued drain, steer): the level must
    *  come from the prompt's OWN model, not from rawState.thinking, which always
@@ -169,16 +147,16 @@ export function useModelProviderState(
   function thinkingLevelForModelId(modelId: string | undefined): ThinkingLevel | undefined {
     if (modelId === undefined) return undefined;
     const model = modelById(modelId);
-    return model === undefined ? undefined : thinkingLevelForModel(model);
+    return model === undefined ? undefined : defaultThinkingLevelFor(model);
   }
 
   /**
    * The level a session should run at: the session's OWN daemon-reported level
    * (thinkingBySession — fed by /status folds and explicit picks) when the
-   * model still declares it, else the per-model seed (thinkingLevelForModel).
-   * Per-session state wins so a session keeps the level it actually ran with —
-   * picking 'high' in one session must not retroactively change another
-   * session that ran 'max'.
+   * model still declares it, else the model's catalog default. Per-session
+   * state wins so a session keeps the level it actually ran with — picking
+   * 'high' in one session must not retroactively change another session that
+   * ran 'max'.
    */
   function thinkingLevelForSession(
     sessionId: string | null | undefined,
@@ -189,7 +167,7 @@ export function useModelProviderState(
         ? undefined
         : rawState.thinkingBySession[sessionId];
     if (sessionLevel !== undefined && levelDeclaredBy(model, sessionLevel)) return sessionLevel;
-    return thinkingLevelForModel(model);
+    return defaultThinkingLevelFor(model);
   }
 
   /** thinkingLevelForSession by session + model id, for prompt submission
@@ -205,16 +183,11 @@ export function useModelProviderState(
   }
 
   function applyThinkingLevel(level: ThinkingLevel | undefined): ThinkingLevel | undefined {
-    // The explicit-picker path (setThinking) — the ONLY writer of the
-    // per-model storage. Model switches (setModel) and passive resolution
-    // update rawState.thinking in-memory instead, so a level the user never
-    // actually picked (e.g. a derived catalog default) is never mistaken for
-    // a stored choice. Persisted under the CURRENT model id — keying storage
-    // by model keeps a pick from leaking onto models that never declared it.
-    // Only concrete levels are persisted; "no preference" stays in-memory.
+    // The explicit-picker path (setThinking). Model switches (setModel) and
+    // passive resolution update rawState.thinking in-memory the same way, but
+    // only an explicit pick is pushed to the session profile and the daemon
+    // config — a derived catalog default must not masquerade as a user choice.
     rawState.thinking = level;
-    const modelId = currentModelId();
-    if (level !== undefined && modelId !== undefined) saveThinkingToStorage(modelId, level);
     // Mirror the pick into the session's own entry so the per-session
     // resolution (and any later /status fold) agrees with what the user just
     // chose — the daemon profile write lands via persistSessionProfile.
@@ -291,10 +264,9 @@ export function useModelProviderState(
       const api = getKimiWebApi();
       models.value = await api.listModels();
       // Resolve the active session's level: its own daemon-reported level when
-      // still declared, else the stored per-model pick, else the catalog
-      // default. Always re-resolved (not just when unset) so a level carried
-      // over from another model can't outlive the catalog refresh that makes
-      // it invalid.
+      // still declared, else the model's catalog default. Always re-resolved
+      // (not just when unset) so a level carried over from another model can't
+      // outlive the catalog refresh that makes it invalid.
       const active = modelById(currentModelId());
       if (active !== undefined) {
         rawState.thinking = thinkingLevelForSession(rawState.activeSessionId, active);
@@ -333,20 +305,15 @@ export function useModelProviderState(
       ? rawState.sessions.find((s) => s.id === sid)?.model
       : undefined;
     const isSwitch = currentModelId() !== (targetModel?.id ?? modelId);
-    // On a real switch, restore the target model's own stored pick when still
-    // declared; otherwise its catalog default (see thinkingLevelForModelSwitch).
-    const nextThinking = thinkingLevelForModelSwitch(
-      targetModel,
-      prevThinking,
-      isSwitch,
-      targetModel === undefined ? undefined : loadThinkingForModel(targetModel.id),
-    );
+    // On a real switch, pre-select the target model's catalog default (see
+    // thinkingLevelForModelSwitch); re-selecting keeps the live level.
+    const nextThinking = thinkingLevelForModelSwitch(targetModel, prevThinking, isSwitch);
     if (!sid) {
       // New-session draft (onboarding composer): no backend session to update.
       // Remember the pick — startSessionAndSendPrompt applies it at create time.
       // In-memory only: a model switch is not a thinking pick, so nothing is
-      // persisted (a derived default would otherwise masquerade as an explicit
-      // choice later). Storage writes stay with setThinking.
+      // persisted beyond the in-memory level (a derived default would otherwise
+      // masquerade as an explicit choice later).
       draftModel.value = modelId;
       rawState.thinking = nextThinking;
       if (nextThinking !== prevThinking && nextThinking !== undefined) {

--- a/apps/kimi-web/src/composables/client/useModelProviderState.ts
+++ b/apps/kimi-web/src/composables/client/useModelProviderState.ts
@@ -79,6 +79,12 @@ export interface UseModelProviderStateDeps {
    *  order strictly after the profile must NOT proceed on false. */
   persistSessionProfile: (patch: PersistSessionProfilePatch, sessionId?: string) => Promise<boolean>;
   activity: ComputedRef<ActivityState>;
+  /** Read the persisted thinking pick for a model (undefined = never picked
+   *  for that model). Storage is keyed by model id and seeds NEW sessions —
+   *  a session's own daemon-reported level always wins once it exists. */
+  loadThinkingForModel: (modelId: string) => ThinkingLevel | undefined;
+  /** Persist an explicit thinking pick under the given model id. */
+  saveThinkingToStorage: (modelId: string, level: ThinkingLevel) => void;
   /** Replace one session in place (matched by id). Owned by the facade so the
    *  model module never assigns rawState.sessions directly. */
   updateSession: (id: string, update: (session: AppSession) => AppSession) => void;
@@ -98,6 +104,8 @@ export function useModelProviderState(
     refreshSessionStatus,
     persistSessionProfile,
     activity,
+    loadThinkingForModel,
+    saveThinkingToStorage,
     updateSession,
     updateSessionMessages,
   } = deps;
@@ -139,6 +147,20 @@ export function useModelProviderState(
     return modelById(rawModel)?.id ?? rawModel ?? undefined;
   }
 
+  /**
+   * The level a model should run at when no per-session state exists (the
+   * new-session seed): the user's stored pick for THIS model when the model
+   * still declares it, else the model's catalog default. Validation against
+   * the catalog entry is what keeps a stale or foreign level (picked for
+   * another model, or dropped by a catalog update) from reaching the UI and
+   * the daemon.
+   */
+  function thinkingLevelForModel(model: AppModel): ThinkingLevel {
+    const stored = loadThinkingForModel(model.id);
+    if (stored !== undefined && levelDeclaredBy(model, stored)) return stored;
+    return defaultThinkingLevelFor(model);
+  }
+
   /** thinkingLevelForModel by model id, for paths that submit a prompt for a
    *  session other than the active one (queued drain, steer): the level must
    *  come from the prompt's OWN model, not from rawState.thinking, which always
@@ -147,16 +169,16 @@ export function useModelProviderState(
   function thinkingLevelForModelId(modelId: string | undefined): ThinkingLevel | undefined {
     if (modelId === undefined) return undefined;
     const model = modelById(modelId);
-    return model === undefined ? undefined : defaultThinkingLevelFor(model);
+    return model === undefined ? undefined : thinkingLevelForModel(model);
   }
 
   /**
    * The level a session should run at: the session's OWN daemon-reported level
    * (thinkingBySession — fed by /status folds and explicit picks) when the
-   * model still declares it, else the model's catalog default. Per-session
-   * state wins so a session keeps the level it actually ran with — picking
-   * 'high' in one session must not retroactively change another session that
-   * ran 'max'.
+   * model still declares it, else the per-model seed (thinkingLevelForModel).
+   * Per-session state wins so a session keeps the level it actually ran with —
+   * picking 'high' in one session must not retroactively change another
+   * session that ran 'max'.
    */
   function thinkingLevelForSession(
     sessionId: string | null | undefined,
@@ -167,7 +189,7 @@ export function useModelProviderState(
         ? undefined
         : rawState.thinkingBySession[sessionId];
     if (sessionLevel !== undefined && levelDeclaredBy(model, sessionLevel)) return sessionLevel;
-    return defaultThinkingLevelFor(model);
+    return thinkingLevelForModel(model);
   }
 
   /** thinkingLevelForSession by session + model id, for prompt submission
@@ -183,11 +205,16 @@ export function useModelProviderState(
   }
 
   function applyThinkingLevel(level: ThinkingLevel | undefined): ThinkingLevel | undefined {
-    // The explicit-picker path (setThinking). Model switches (setModel) and
-    // passive resolution update rawState.thinking in-memory the same way, but
-    // only an explicit pick is pushed to the session profile and the daemon
-    // config — a derived catalog default must not masquerade as a user choice.
+    // The explicit-picker path (setThinking) — the ONLY writer of the
+    // per-model storage. Model switches (setModel) and passive resolution
+    // update rawState.thinking in-memory instead, so a level the user never
+    // actually picked (e.g. a derived catalog default) is never mistaken for
+    // a stored choice. Persisted under the CURRENT model id — keying storage
+    // by model keeps a pick from leaking onto models that never declared it.
+    // Only concrete levels are persisted; "no preference" stays in-memory.
     rawState.thinking = level;
+    const modelId = currentModelId();
+    if (level !== undefined && modelId !== undefined) saveThinkingToStorage(modelId, level);
     // Mirror the pick into the session's own entry so the per-session
     // resolution (and any later /status fold) agrees with what the user just
     // chose — the daemon profile write lands via persistSessionProfile.
@@ -262,9 +289,10 @@ export function useModelProviderState(
       const api = getKimiWebApi();
       models.value = await api.listModels();
       // Resolve the active session's level: its own daemon-reported level when
-      // still declared, else the model's catalog default. Always re-resolved
-      // (not just when unset) so a level carried over from another model can't
-      // outlive the catalog refresh that makes it invalid.
+      // still declared, else the stored per-model pick, else the catalog
+      // default. Always re-resolved (not just when unset) so a level carried
+      // over from another model can't outlive the catalog refresh that makes
+      // it invalid.
       const active = modelById(currentModelId());
       if (active !== undefined) {
         rawState.thinking = thinkingLevelForSession(rawState.activeSessionId, active);
@@ -303,15 +331,20 @@ export function useModelProviderState(
       ? rawState.sessions.find((s) => s.id === sid)?.model
       : undefined;
     const isSwitch = currentModelId() !== (targetModel?.id ?? modelId);
-    // On a real switch, pre-select the target model's catalog default (see
-    // thinkingLevelForModelSwitch); re-selecting keeps the live level.
-    const nextThinking = thinkingLevelForModelSwitch(targetModel, prevThinking, isSwitch);
+    // On a real switch, restore the target model's own stored pick when still
+    // declared; otherwise its catalog default (see thinkingLevelForModelSwitch).
+    const nextThinking = thinkingLevelForModelSwitch(
+      targetModel,
+      prevThinking,
+      isSwitch,
+      targetModel === undefined ? undefined : loadThinkingForModel(targetModel.id),
+    );
     if (!sid) {
       // New-session draft (onboarding composer): no backend session to update.
       // Remember the pick — startSessionAndSendPrompt applies it at create time.
       // In-memory only: a model switch is not a thinking pick, so nothing is
-      // persisted beyond the in-memory level (a derived default would otherwise
-      // masquerade as an explicit choice later).
+      // persisted (a derived default would otherwise masquerade as an explicit
+      // choice later). Storage writes stay with setThinking.
       draftModel.value = modelId;
       rawState.thinking = nextThinking;
       if (nextThinking !== prevThinking && nextThinking !== undefined) {

--- a/apps/kimi-web/src/composables/client/useModelProviderState.ts
+++ b/apps/kimi-web/src/composables/client/useModelProviderState.ts
@@ -79,11 +79,6 @@ export interface UseModelProviderStateDeps {
    *  order strictly after the profile must NOT proceed on false. */
   persistSessionProfile: (patch: PersistSessionProfilePatch, sessionId?: string) => Promise<boolean>;
   activity: ComputedRef<ActivityState>;
-  /** Read the persisted thinking pick for a model (undefined = never picked
-   *  for that model). Storage is keyed by model id. */
-  loadThinkingForModel: (modelId: string) => ThinkingLevel | undefined;
-  /** Persist an explicit thinking pick under the given model id. */
-  saveThinkingToStorage: (modelId: string, level: ThinkingLevel) => void;
   /** Replace one session in place (matched by id). Owned by the facade so the
    *  model module never assigns rawState.sessions directly. */
   updateSession: (id: string, update: (session: AppSession) => AppSession) => void;
@@ -103,8 +98,6 @@ export function useModelProviderState(
     refreshSessionStatus,
     persistSessionProfile,
     activity,
-    loadThinkingForModel,
-    saveThinkingToStorage,
     updateSession,
     updateSessionMessages,
   } = deps;
@@ -146,19 +139,6 @@ export function useModelProviderState(
     return modelById(rawModel)?.id ?? rawModel ?? undefined;
   }
 
-  /**
-   * The level a model should run at: the user's stored pick for THIS model when
-   * the model still declares it, else the model's catalog default. Validation
-   * against the catalog entry is what keeps a stale or foreign level (picked
-   * for another model, or dropped by a catalog update) from reaching the UI and
-   * the daemon.
-   */
-  function thinkingLevelForModel(model: AppModel): ThinkingLevel {
-    const stored = loadThinkingForModel(model.id);
-    if (stored !== undefined && levelDeclaredBy(model, stored)) return stored;
-    return defaultThinkingLevelFor(model);
-  }
-
   /** thinkingLevelForModel by model id, for paths that submit a prompt for a
    *  session other than the active one (queued drain, steer): the level must
    *  come from the prompt's OWN model, not from rawState.thinking, which always
@@ -167,37 +147,79 @@ export function useModelProviderState(
   function thinkingLevelForModelId(modelId: string | undefined): ThinkingLevel | undefined {
     if (modelId === undefined) return undefined;
     const model = modelById(modelId);
-    return model === undefined ? undefined : thinkingLevelForModel(model);
+    return model === undefined ? undefined : defaultThinkingLevelFor(model);
+  }
+
+  /**
+   * The level a session should run at: the session's OWN daemon-reported level
+   * (thinkingBySession — fed by /status folds and explicit picks) when the
+   * model still declares it, else the model's catalog default. Per-session
+   * state wins so a session keeps the level it actually ran with — picking
+   * 'high' in one session must not retroactively change another session that
+   * ran 'max'.
+   */
+  function thinkingLevelForSession(
+    sessionId: string | null | undefined,
+    model: AppModel,
+  ): ThinkingLevel {
+    const sessionLevel =
+      sessionId === null || sessionId === undefined
+        ? undefined
+        : rawState.thinkingBySession[sessionId];
+    if (sessionLevel !== undefined && levelDeclaredBy(model, sessionLevel)) return sessionLevel;
+    return defaultThinkingLevelFor(model);
+  }
+
+  /** thinkingLevelForSession by session + model id, for prompt submission
+   *  paths (send, steer, side chat). Undefined when the model id is not in the
+   *  catalog (caller falls back to the active value, same as before). */
+  function thinkingLevelForSessionId(
+    sessionId: string | null | undefined,
+    modelId: string | undefined,
+  ): ThinkingLevel | undefined {
+    if (modelId === undefined) return undefined;
+    const model = modelById(modelId);
+    return model === undefined ? undefined : thinkingLevelForSession(sessionId, model);
   }
 
   function applyThinkingLevel(level: ThinkingLevel | undefined): ThinkingLevel | undefined {
-    // The explicit-picker path (setThinking) — the ONLY writer of thinking
-    // storage. Model switches (setModel) and passive resolution update
-    // rawState.thinking in-memory instead, so a level the user never actually
-    // picked (e.g. a derived catalog default) is never mistaken for a stored
-    // choice. Persisted under the CURRENT model id — per-model storage keeps a
-    // pick from leaking onto models that never declared it. Only concrete
-    // levels are persisted; "no preference" stays in-memory.
+    // The explicit-picker path (setThinking). Model switches (setModel) and
+    // passive resolution update rawState.thinking in-memory the same way, but
+    // only an explicit pick is pushed to the session profile and the daemon
+    // config — a derived catalog default must not masquerade as a user choice.
     rawState.thinking = level;
-    const modelId = currentModelId();
-    if (level !== undefined && modelId !== undefined) saveThinkingToStorage(modelId, level);
+    // Mirror the pick into the session's own entry so the per-session
+    // resolution (and any later /status fold) agrees with what the user just
+    // chose — the daemon profile write lands via persistSessionProfile.
+    const sid = rawState.activeSessionId;
+    if (level !== undefined && sid !== null && sid !== undefined) {
+      rawState.thinkingBySession = { ...rawState.thinkingBySession, [sid]: level };
+    }
     return level;
   }
 
-  // The active model can change WITHOUT a picker action: switching sessions,
-  // the snapshot adopting another session, or the catalog/default arriving
-  // late. Re-resolve the level for the new model so a pick made for one model
-  // is never submitted to — or rendered on — another (a foreign level used to
-  // leave the composer showing nothing selected with no way to switch). The
-  // picker path (setModel) applies the same resolution synchronously, so the
-  // watcher's re-resolution after it is an idempotent no-op.
+  // The displayed level tracks the ACTIVE session, and the active session or
+  // its model can change WITHOUT a picker action: switching sessions, the
+  // snapshot adopting another session, a /status fold arriving late, or the
+  // catalog/default arriving late. Re-resolve on any of these so a pick made
+  // for one session/model is never submitted to — or rendered on — another (a
+  // foreign level used to leave the composer showing nothing selected with no
+  // way to switch). The picker paths (setThinking/setModel) apply the same
+  // resolution synchronously, so the watcher's re-resolution after them is an
+  // idempotent no-op.
   watch(
-    () => currentModelId(),
-    (id, prevId) => {
-      if (id === undefined || id === prevId) return;
-      const model = modelById(id);
+    [
+      () => rawState.activeSessionId,
+      () => currentModelId(),
+      () => {
+        const sid = rawState.activeSessionId;
+        return sid === null || sid === undefined ? undefined : rawState.thinkingBySession[sid];
+      },
+    ],
+    () => {
+      const model = modelById(currentModelId());
       if (model === undefined) return;
-      rawState.thinking = thinkingLevelForModel(model);
+      rawState.thinking = thinkingLevelForSession(rawState.activeSessionId, model);
     },
   );
 
@@ -239,13 +261,14 @@ export function useModelProviderState(
     try {
       const api = getKimiWebApi();
       models.value = await api.listModels();
-      // Resolve the active model's level: the stored pick for THIS model when
-      // still declared, else the catalog default. In-memory only — localStorage
-      // stays reserved for levels the user actually picked. Always re-resolved
+      // Resolve the active session's level: its own daemon-reported level when
+      // still declared, else the model's catalog default. Always re-resolved
       // (not just when unset) so a level carried over from another model can't
       // outlive the catalog refresh that makes it invalid.
       const active = modelById(currentModelId());
-      if (active !== undefined) rawState.thinking = thinkingLevelForModel(active);
+      if (active !== undefined) {
+        rawState.thinking = thinkingLevelForSession(rawState.activeSessionId, active);
+      }
     } catch (err) {
       pushOperationFailure('loadModels', err);
     }
@@ -280,20 +303,15 @@ export function useModelProviderState(
       ? rawState.sessions.find((s) => s.id === sid)?.model
       : undefined;
     const isSwitch = currentModelId() !== (targetModel?.id ?? modelId);
-    // On a real switch, restore the target model's own stored pick when still
-    // declared; otherwise its catalog default (see thinkingLevelForModelSwitch).
-    const nextThinking = thinkingLevelForModelSwitch(
-      targetModel,
-      prevThinking,
-      isSwitch,
-      targetModel === undefined ? undefined : loadThinkingForModel(targetModel.id),
-    );
+    // On a real switch, pre-select the target model's catalog default (see
+    // thinkingLevelForModelSwitch); re-selecting keeps the live level.
+    const nextThinking = thinkingLevelForModelSwitch(targetModel, prevThinking, isSwitch);
     if (!sid) {
       // New-session draft (onboarding composer): no backend session to update.
       // Remember the pick — startSessionAndSendPrompt applies it at create time.
       // In-memory only: a model switch is not a thinking pick, so nothing is
-      // persisted (a derived default would otherwise masquerade as an explicit
-      // choice later). Storage writes stay with setThinking.
+      // persisted beyond the in-memory level (a derived default would otherwise
+      // masquerade as an explicit choice later).
       draftModel.value = modelId;
       rawState.thinking = nextThinking;
       if (nextThinking !== prevThinking && nextThinking !== undefined) {
@@ -306,6 +324,11 @@ export function useModelProviderState(
     updateSession(sid, (s) => ({ ...s, model: modelId }));
     if (nextThinking !== prevThinking) {
       rawState.thinking = nextThinking;
+      // Keep the session's own entry in sync optimistically — the /status echo
+      // after the profile write folds the authoritative value back in.
+      if (nextThinking !== undefined) {
+        rawState.thinkingBySession = { ...rawState.thinkingBySession, [sid]: nextThinking };
+      }
     }
     try {
       await getKimiWebApi().updateSession(sid, {
@@ -320,6 +343,9 @@ export function useModelProviderState(
       updateSession(sid, (s) => ({ ...s, model: prevSessionModel ?? s.model }));
       if (nextThinking !== prevThinking) {
         rawState.thinking = prevThinking;
+        if (prevThinking !== undefined) {
+          rawState.thinkingBySession = { ...rawState.thinkingBySession, [sid]: prevThinking };
+        }
       }
       pushOperationFailure('setModel', err, { sessionId: sid });
       return false;
@@ -401,7 +427,7 @@ export function useModelProviderState(
       const rawModel = rawState.sessions.find((s) => s.id === sid)?.model;
       const skillModel = (rawModel && rawModel.length > 0 ? rawModel : rawState.defaultModel) ?? undefined;
       const persisted = await persistSessionProfile(
-        { thinking: thinkingLevelForModelId(skillModel) ?? rawState.thinking },
+        { thinking: thinkingLevelForSessionId(sid, skillModel) ?? rawState.thinking },
         sid,
       );
       if (!persisted) throw PROFILE_PERSIST_FAILED;
@@ -537,6 +563,7 @@ export function useModelProviderState(
     loadProviders,
     setModel,
     thinkingLevelForModelId,
+    thinkingLevelForSessionId,
     toggleStarModel,
     activateSkill,
     addProvider,

--- a/apps/kimi-web/src/composables/client/useSideChat.ts
+++ b/apps/kimi-web/src/composables/client/useSideChat.ts
@@ -23,10 +23,13 @@ export interface UseSideChatDeps {
   nextOptimisticMsgId: () => string;
   connectEventsIfNeeded: () => void;
   getEventConn: () => KimiEventConnection | null;
-  /** Resolve the thinking level for an arbitrary model id (its stored pick
-   *  when still declared, else its catalog default); undefined when the model
-   *  is not in the catalog. */
-  thinkingLevelForModelId: (modelId: string | undefined) => ThinkingLevel | undefined;
+  /** Resolve the thinking level for a session + model id: the session's own
+   *  daemon-reported level when still declared, else the per-model resolution;
+   *  undefined when the model is not in the catalog. */
+  thinkingLevelForSessionId: (
+    sessionId: string | null,
+    modelId: string | undefined,
+  ) => ThinkingLevel | undefined;
 }
 
 export function useSideChat(rawState: ExtendedState, deps: UseSideChatDeps) {
@@ -35,7 +38,7 @@ export function useSideChat(rawState: ExtendedState, deps: UseSideChatDeps) {
     nextOptimisticMsgId,
     connectEventsIfNeeded,
     getEventConn,
-    thinkingLevelForModelId,
+    thinkingLevelForSessionId,
   } = deps;
 
   const sideChatTargetBySession = ref<Record<string, { agentId: string }>>({});
@@ -212,10 +215,11 @@ export function useSideChat(rawState: ExtendedState, deps: UseSideChatDeps) {
       // first-turn reflects the same draft/runtime controls the UI shows — the
       // parent session profile mirrors them, but the prompt itself is the only
       // thing the daemon reads for this turn. Thinking is resolved against the
-      // PARENT's own model (stored pick when declared, else its default) —
-      // never the active-session rawState.thinking: startBtw above may have
-      // spanned a session switch that changed what the active view resolved
-      // to (see submitPromptInternal in useWorkspaceState).
+      // PARENT session + its model (the session's own level when declared,
+      // else its stored pick, else its default) — never the active-session
+      // rawState.thinking: startBtw above may have spanned a session switch
+      // that changed what the active view resolved to (see
+      // submitPromptInternal in useWorkspaceState).
       const promptSession = rawState.sessions.find((s) => s.id === sid);
       const model =
         (promptSession?.model && promptSession.model.length > 0
@@ -225,7 +229,7 @@ export function useSideChat(rawState: ExtendedState, deps: UseSideChatDeps) {
         content: [{ type: 'text', text: trimmed }],
         agentId,
         model,
-        thinking: thinkingLevelForModelId(model) ?? rawState.thinking,
+        thinking: thinkingLevelForSessionId(sid, model) ?? rawState.thinking,
         permissionMode: rawState.permission,
         planMode: rawState.planModeBySession[sid] ?? false,
         swarmMode: rawState.swarmModeBySession[sid] ?? false,

--- a/apps/kimi-web/src/composables/client/useSideChat.ts
+++ b/apps/kimi-web/src/composables/client/useSideChat.ts
@@ -23,13 +23,13 @@ export interface UseSideChatDeps {
   nextOptimisticMsgId: () => string;
   connectEventsIfNeeded: () => void;
   getEventConn: () => KimiEventConnection | null;
-  /** Resolve the thinking level for a session + model id: the session's own
-   *  daemon-reported level when still declared, else the per-model resolution;
-   *  undefined when the model is not in the catalog. */
-  thinkingLevelForSessionId: (
+  /** Resolve the thinking level for a prompt submission: waits for the
+   *  session's own /status fold when it has not landed yet, then resolves the
+   *  session + model level; undefined when the model is not in the catalog. */
+  resolveThinkingForPrompt: (
     sessionId: string | null,
     modelId: string | undefined,
-  ) => ThinkingLevel | undefined;
+  ) => Promise<ThinkingLevel | undefined>;
 }
 
 export function useSideChat(rawState: ExtendedState, deps: UseSideChatDeps) {
@@ -38,7 +38,7 @@ export function useSideChat(rawState: ExtendedState, deps: UseSideChatDeps) {
     nextOptimisticMsgId,
     connectEventsIfNeeded,
     getEventConn,
-    thinkingLevelForSessionId,
+    resolveThinkingForPrompt,
   } = deps;
 
   const sideChatTargetBySession = ref<Record<string, { agentId: string }>>({});
@@ -229,7 +229,7 @@ export function useSideChat(rawState: ExtendedState, deps: UseSideChatDeps) {
         content: [{ type: 'text', text: trimmed }],
         agentId,
         model,
-        thinking: thinkingLevelForSessionId(sid, model) ?? rawState.thinking,
+        thinking: (await resolveThinkingForPrompt(sid, model)) ?? rawState.thinking,
         permissionMode: rawState.permission,
         planMode: rawState.planModeBySession[sid] ?? false,
         swarmMode: rawState.swarmModeBySession[sid] ?? false,

--- a/apps/kimi-web/src/composables/client/useWorkspaceState.ts
+++ b/apps/kimi-web/src/composables/client/useWorkspaceState.ts
@@ -1078,6 +1078,12 @@ export function useWorkspaceState(rawState: ExtendedState, deps: UseWorkspaceSta
   async function createDraftSession(workspaceId: string): Promise<string | null> {
     const ws = mergedWorkspaces.value.find((w) => w.id === workspaceId);
     if (!ws) return null;
+    // Capture the draft thinking level BEFORE any await: a concurrent session
+    // switch during creation re-resolves rawState.thinking for the other
+    // active session, which would otherwise seed the new session with that
+    // session's effort. Seeded into the new session's own entry below, the
+    // first prompt/skill submits the pick and the daemon profile follows.
+    const draftThinking = rawState.thinking;
     const api = getKimiWebApi();
     let workspaceIdForCreate: string | undefined;
     let cwdForCreate = ws.root;
@@ -1104,12 +1110,6 @@ export function useWorkspaceState(rawState: ExtendedState, deps: UseWorkspaceSta
         : session;
     upsertSessionFront(created);
     selectWorkspace(session.workspaceId ?? workspaceIdForCreate ?? workspaceId);
-    // Capture the draft thinking level BEFORE selectSession: its watcher
-    // re-resolves rawState.thinking for the new session (no per-session entry
-    // yet → the catalog default), which would otherwise drop a level the user
-    // picked on the empty composer. Seeded into the session's own entry below,
-    // the first prompt/skill submits the pick and the daemon profile follows.
-    const draftThinking = rawState.thinking;
     // NOTE: do NOT mark this session known-empty. Unlike "open a new empty
     // session" (createSession), here we immediately act on it: keeping
     // sessionLoading=true through the snapshot avoids flashing the empty-session

--- a/apps/kimi-web/src/composables/client/useWorkspaceState.ts
+++ b/apps/kimi-web/src/composables/client/useWorkspaceState.ts
@@ -1537,7 +1537,7 @@ export function useWorkspaceState(rawState: ExtendedState, deps: UseWorkspaceSta
         // tracks whatever session the user is looking at now: a queue drain for
         // a background session would otherwise submit the level of the session
         // the user switched to since enqueueing.
-        thinking: modelProvider.thinkingLevelForSessionId(sid, model) ?? rawState.thinking,
+        thinking: (await modelProvider.resolveThinkingForPrompt(sid, model)) ?? rawState.thinking,
         permissionMode: rawState.permission,
         planMode,
         swarmMode,
@@ -1713,7 +1713,7 @@ export function useWorkspaceState(rawState: ExtendedState, deps: UseWorkspaceSta
         model,
         // Resolved against this prompt's own session + model, same as a normal
         // send (see submitPromptInternal).
-        thinking: modelProvider.thinkingLevelForSessionId(sid, model) ?? rawState.thinking,
+        thinking: (await modelProvider.resolveThinkingForPrompt(sid, model)) ?? rawState.thinking,
         permissionMode: rawState.permission,
         planMode: rawState.planModeBySession[sid] ?? false,
         swarmMode: rawState.swarmModeBySession[sid] ?? false,

--- a/apps/kimi-web/src/composables/client/useWorkspaceState.ts
+++ b/apps/kimi-web/src/composables/client/useWorkspaceState.ts
@@ -1104,6 +1104,12 @@ export function useWorkspaceState(rawState: ExtendedState, deps: UseWorkspaceSta
         : session;
     upsertSessionFront(created);
     selectWorkspace(session.workspaceId ?? workspaceIdForCreate ?? workspaceId);
+    // Capture the draft thinking level BEFORE selectSession: its watcher
+    // re-resolves rawState.thinking for the new session (no per-session entry
+    // yet → the catalog default), which would otherwise drop a level the user
+    // picked on the empty composer. Seeded into the session's own entry below,
+    // the first prompt/skill submits the pick and the daemon profile follows.
+    const draftThinking = rawState.thinking;
     // NOTE: do NOT mark this session known-empty. Unlike "open a new empty
     // session" (createSession), here we immediately act on it: keeping
     // sessionLoading=true through the snapshot avoids flashing the empty-session
@@ -1118,6 +1124,9 @@ export function useWorkspaceState(rawState: ExtendedState, deps: UseWorkspaceSta
     // awaiting the snapshot, the setters would otherwise read the then-current
     // activeSessionId and pollute that session while this one loses the modes.
     const sid = session.id;
+    if (draftThinking !== undefined) {
+      rawState.thinkingBySession = { ...rawState.thinkingBySession, [sid]: draftThinking };
+    }
     if (draftModes.planMode) {
       rawState.planModeBySession = { ...rawState.planModeBySession, [sid]: true };
       savePlanModeToStorage();

--- a/apps/kimi-web/src/composables/client/useWorkspaceState.ts
+++ b/apps/kimi-web/src/composables/client/useWorkspaceState.ts
@@ -1522,12 +1522,13 @@ export function useWorkspaceState(rawState: ExtendedState, deps: UseWorkspaceSta
       const result = await api.submitPrompt(sid, {
         content,
         model,
-        // Resolved against THIS prompt's model (its stored pick when declared,
-        // else its catalog default) — never the active-session rawState.thinking,
-        // which tracks whatever session the user is looking at now: a queue
-        // drain for a background session would otherwise submit the level of
-        // the session the user switched to since enqueueing.
-        thinking: modelProvider.thinkingLevelForModelId(model) ?? rawState.thinking,
+        // Resolved against THIS prompt's session + model: the session's own
+        // daemon-reported level when declared, else the model's stored pick or
+        // catalog default — never the active-session rawState.thinking, which
+        // tracks whatever session the user is looking at now: a queue drain for
+        // a background session would otherwise submit the level of the session
+        // the user switched to since enqueueing.
+        thinking: modelProvider.thinkingLevelForSessionId(sid, model) ?? rawState.thinking,
         permissionMode: rawState.permission,
         planMode,
         swarmMode,
@@ -1701,9 +1702,9 @@ export function useWorkspaceState(rawState: ExtendedState, deps: UseWorkspaceSta
       const result = await api.submitPrompt(sid, {
         content,
         model,
-        // Resolved against this prompt's own model, same as a normal send (see
-        // submitPromptInternal).
-        thinking: modelProvider.thinkingLevelForModelId(model) ?? rawState.thinking,
+        // Resolved against this prompt's own session + model, same as a normal
+        // send (see submitPromptInternal).
+        thinking: modelProvider.thinkingLevelForSessionId(sid, model) ?? rawState.thinking,
         permissionMode: rawState.permission,
         planMode: rawState.planModeBySession[sid] ?? false,
         swarmMode: rawState.swarmModeBySession[sid] ?? false,

--- a/apps/kimi-web/src/composables/useKimiWebClient.ts
+++ b/apps/kimi-web/src/composables/useKimiWebClient.ts
@@ -1948,8 +1948,8 @@ const sideChat = useSideChat(rawState, {
   connectEventsIfNeeded,
   getEventConn: () => eventConn,
   // modelProvider is defined further below; deferred like eventConn above.
-  thinkingLevelForSessionId: (sessionId, modelId) =>
-    modelProvider.thinkingLevelForSessionId(sessionId, modelId),
+  resolveThinkingForPrompt: (sessionId, modelId) =>
+    modelProvider.resolveThinkingForPrompt(sessionId, modelId),
 });
 
 const activeAppTasks = computed<AppTask[]>(() => {

--- a/apps/kimi-web/src/composables/useKimiWebClient.ts
+++ b/apps/kimi-web/src/composables/useKimiWebClient.ts
@@ -22,10 +22,8 @@ import {
   loadUnread,
   loadWorkspaceOrder,
   loadWorkspaceSort,
-  safeGetJson,
   safeGetString,
   safeRemove,
-  safeSetJson,
   safeSetString,
   saveUnread,
   saveWorkspaceOrder,
@@ -110,27 +108,11 @@ import type {
 
 const PERMISSION_STORAGE_KEY = STORAGE_KEYS.permission;
 const ACTIVE_WORKSPACE_KEY = STORAGE_KEYS.activeWorkspace;
-const THINKING_STORAGE_KEY = STORAGE_KEYS.thinking;
 const PLAN_MODE_STORAGE_KEY = STORAGE_KEYS.planMode;
 const SWARM_MODE_STORAGE_KEY = STORAGE_KEYS.swarmMode;
 const GOAL_MODE_STORAGE_KEY = STORAGE_KEYS.goalMode;
 const SESSION_NOT_FOUND_CODE = 40401;
 const ONBOARDED_STORAGE_KEY = STORAGE_KEYS.onboarded;
-// Thinking levels are persisted PER MODEL: `kimi-web.thinking` holds a JSON map
-// of model id → level. A persisted level may be any non-empty effort string:
-// the reserved 'off'/'on', or a model-declared level (e.g. 'low'/'high'/'max').
-// Since the set of legal levels comes from each model's support_efforts, we
-// can't whitelist values — only guard against corrupted localStorage with a
-// charset + length check, and let the resolution in useModelProviderState drop
-// entries the model no longer declares. Per-model storage is what keeps a level
-// picked for one model (e.g. 'low' on an effort model) from leaking onto a
-// model that never declared it (e.g. a max-only always-on model) — the old
-// global format did exactly that, leaving the composer showing nothing selected
-// with no way to switch. The legacy pre-map format (a single global level,
-// stored raw) is not discarded: it becomes a fallback for any model that
-// declares it (see hydrateThinkingPicks), so an existing user's preference
-// survives the upgrade while a max-only model still can't be trapped by it.
-const PERSISTED_THINKING_LEVEL_RE = /^[a-zA-Z0-9][a-zA-Z0-9_-]{0,31}$/;
 
 // Appearance types + logic live in ./client/useAppearance; re-exported here so
 // existing `import type { ColorScheme, Accent } from './useKimiWebClient'`
@@ -144,6 +126,9 @@ safeRemove(STORAGE_KEYS.codeFont);
 // look. Clear the old persisted key so users who once picked one aren't frozen
 // on a value the UI no longer reads.
 safeRemove(STORAGE_KEYS.theme);
+// The per-model thinking pick store was dropped in favor of the daemon's
+// per-session thinking state — clear the old key so stale picks can't linger.
+safeRemove(STORAGE_KEYS.thinking);
 
 function loadPermissionFromStorage(): PermissionMode {
   try {
@@ -161,69 +146,6 @@ function savePermissionToStorage(mode: PermissionMode): void {
   } catch {
     // ignore
   }
-}
-
-function loadThinkingMap(): Record<string, ThinkingLevel> {
-  const parsed = safeGetJson<unknown>(THINKING_STORAGE_KEY);
-  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return {};
-  const out: Record<string, ThinkingLevel> = {};
-  for (const [id, value] of Object.entries(parsed as Record<string, unknown>)) {
-    if (typeof value === 'string' && PERSISTED_THINKING_LEVEL_RE.test(value)) {
-      out[id] = value as ThinkingLevel;
-    }
-  }
-  return out;
-}
-
-// Legacy pre-map format: a single global level stored raw via safeSetString
-// (not JSON). It fails JSON.parse in loadThinkingMap above — detect it from the
-// raw string instead of dropping the user's preference on upgrade.
-function loadLegacyThinkingValue(): ThinkingLevel | undefined {
-  const raw = safeGetString(THINKING_STORAGE_KEY);
-  return raw && PERSISTED_THINKING_LEVEL_RE.test(raw) ? (raw as ThinkingLevel) : undefined;
-}
-
-// Map key for the migrated legacy value — never a real model id. Kept INSIDE
-// the map (not a sidecar variable) so the first per-model write, which rewrites
-// the raw legacy string into map format, carries the fallback forward instead
-// of deleting it for every model without its own entry.
-const LEGACY_THINKING_PICK_KEY = '*';
-
-// The RUNTIME source of truth for per-model picks is this in-memory map,
-// hydrated from localStorage once at startup. Explicit picks update it first
-// (see saveThinkingToStorage), so a pick takes effect even when persistence is
-// unavailable (storage policy/quota — safeSetJson swallows those failures),
-// and so a pick made later in ANOTHER tab can never change what this tab
-// displays or submits mid-session. localStorage is hydration + best-effort
-// persistence only: written with a read-modify-write merge (same pattern as
-// saveUnread) so concurrent tabs' entries survive, and re-read from scratch on
-// the next startup.
-const thinkingPicks: Record<string, ThinkingLevel> = loadThinkingMap();
-if (Object.keys(thinkingPicks).length === 0) {
-  const legacy = loadLegacyThinkingValue();
-  if (legacy !== undefined) thinkingPicks[LEGACY_THINKING_PICK_KEY] = legacy;
-}
-
-function loadThinkingForModel(modelId: string): ThinkingLevel | undefined {
-  // Per-model entries win; the '*' entry is the migrated legacy pre-map global
-  // pick — useModelProviderState validates it against each model's catalog
-  // entry, so it only ever applies to models that declare it (a max-only model
-  // still falls through to its default).
-  return thinkingPicks[modelId] ?? thinkingPicks[LEGACY_THINKING_PICK_KEY];
-}
-
-function saveThinkingToStorage(modelId: string, level: ThinkingLevel): void {
-  thinkingPicks[modelId] = level;
-  // Delta write (same pattern as saveUnread): overlay only the CHANGED entry —
-  // overlaying this tab's whole in-memory snapshot would revert another tab's
-  // newer pick for any model this tab still holds a stale copy of. The one
-  // extra entry carried along is the migrated legacy '*' fallback, so the
-  // first write rewrites it into map format rather than dropping it.
-  const map = loadThinkingMap();
-  const legacy = thinkingPicks[LEGACY_THINKING_PICK_KEY];
-  if (legacy !== undefined) map[LEGACY_THINKING_PICK_KEY] = legacy;
-  map[modelId] = level;
-  safeSetJson(THINKING_STORAGE_KEY, map);
 }
 
 // Plan / swarm / goal modes are per-session. Each is persisted as a compact
@@ -377,11 +299,18 @@ export interface ExtendedState extends KimiClientState {
   workspaceName: string;
   connection: ConnectionState;
   permission: PermissionMode;
-  /** The thinking level shown and submitted. Resolved per model by
-   *  useModelProviderState (the model's stored pick when still declared, else
-   *  its catalog default) once the catalog/session is known — undefined only
+  /** The thinking level shown and submitted for the ACTIVE session. Resolved by
+   *  useModelProviderState: the session's own daemon-reported level
+   *  (`thinkingBySession`) when the model still declares it, else the model's
+   *  stored per-model pick, else its catalog default — undefined only
    *  transiently before that, so display and submission always agree. */
   thinking: ThinkingLevel | undefined;
+  /** The session's own thinking level as reported by the daemon (GET
+   *  /sessions/{id}/status `thinking_level` and WS `agent.status.updated`),
+   *  keyed by session id. Per-session state wins over the per-model
+   *  localStorage pick: a session keeps the level it actually ran with, so
+   *  switching sessions never leaks one session's pick into another. */
+  thinkingBySession: Record<string, ThinkingLevel>;
   /** Plan-mode toggle per session. Bound to a session (not global) so toggling
    *  it in one session does not affect another. */
   planModeBySession: Record<string, boolean>;
@@ -459,10 +388,11 @@ const rawState: ExtendedState = reactive({
   workspaceName: 'kimi-web',
   connection: 'disconnected' as ConnectionState,
   permission: loadPermissionFromStorage(),
-  // Resolved per model once the catalog/session is known (loadModels and the
-  // active-model watcher in useModelProviderState) — storage is keyed by model
-  // id, which isn't known this early.
+  // Resolved per session/model once the catalog/session is known (loadModels
+  // and the active-session watcher in useModelProviderState) — the per-session
+  // map below starts empty and is fed by /status folds.
   thinking: undefined,
+  thinkingBySession: {},
   planModeBySession: loadModeMapFromStorage(PLAN_MODE_STORAGE_KEY),
   swarmModeBySession: loadModeMapFromStorage(SWARM_MODE_STORAGE_KEY),
   goalModeBySession: loadModeMapFromStorage(GOAL_MODE_STORAGE_KEY),
@@ -689,6 +619,7 @@ function forgetSession(sessionId: string): void {
   delete rawState.planModeBySession[sessionId];
   delete rawState.swarmModeBySession[sessionId];
   delete rawState.goalModeBySession[sessionId];
+  delete rawState.thinkingBySession[sessionId];
   savePlanModeToStorage();
   saveSwarmModeToStorage();
   saveGoalModeToStorage();
@@ -736,6 +667,14 @@ async function refreshSessionStatus(sessionId: string): Promise<void> {
   }));
   rawState.swarmModeBySession = { ...rawState.swarmModeBySession, [sessionId]: st.swarmMode };
   rawState.planModeBySession = { ...rawState.planModeBySession, [sessionId]: st.planMode };
+  // Fold the session's own thinking level too — per-session state wins over the
+  // per-model storage pick (see thinkingBySession on ExtendedState).
+  if (st.thinkingEffort.length > 0) {
+    rawState.thinkingBySession = {
+      ...rawState.thinkingBySession,
+      [sessionId]: st.thinkingEffort as ThinkingLevel,
+    };
+  }
 }
 
 /**
@@ -921,6 +860,12 @@ function applyEvent(event: ReturnType<typeof toAppEvent>, sessionId: string, seq
     }
     if (event.planMode !== undefined) {
       rawState.planModeBySession = { ...rawState.planModeBySession, [event.sessionId]: event.planMode };
+    }
+    if (event.thinking !== undefined) {
+      rawState.thinkingBySession = {
+        ...rawState.thinkingBySession,
+        [event.sessionId]: event.thinking as ThinkingLevel,
+      };
     }
   }
 }
@@ -2003,7 +1948,8 @@ const sideChat = useSideChat(rawState, {
   connectEventsIfNeeded,
   getEventConn: () => eventConn,
   // modelProvider is defined further below; deferred like eventConn above.
-  thinkingLevelForModelId: (modelId) => modelProvider.thinkingLevelForModelId(modelId),
+  thinkingLevelForSessionId: (sessionId, modelId) =>
+    modelProvider.thinkingLevelForSessionId(sessionId, modelId),
 });
 
 const activeAppTasks = computed<AppTask[]>(() => {
@@ -2222,8 +2168,6 @@ const modelProvider = useModelProviderState(rawState, {
   refreshSessionStatus,
   persistSessionProfile,
   activity,
-  loadThinkingForModel,
-  saveThinkingToStorage,
   updateSession,
   updateSessionMessages,
 });

--- a/apps/kimi-web/src/composables/useKimiWebClient.ts
+++ b/apps/kimi-web/src/composables/useKimiWebClient.ts
@@ -22,8 +22,10 @@ import {
   loadUnread,
   loadWorkspaceOrder,
   loadWorkspaceSort,
+  safeGetJson,
   safeGetString,
   safeRemove,
+  safeSetJson,
   safeSetString,
   saveUnread,
   saveWorkspaceOrder,
@@ -108,11 +110,29 @@ import type {
 
 const PERMISSION_STORAGE_KEY = STORAGE_KEYS.permission;
 const ACTIVE_WORKSPACE_KEY = STORAGE_KEYS.activeWorkspace;
+const THINKING_STORAGE_KEY = STORAGE_KEYS.thinking;
 const PLAN_MODE_STORAGE_KEY = STORAGE_KEYS.planMode;
 const SWARM_MODE_STORAGE_KEY = STORAGE_KEYS.swarmMode;
 const GOAL_MODE_STORAGE_KEY = STORAGE_KEYS.goalMode;
 const SESSION_NOT_FOUND_CODE = 40401;
 const ONBOARDED_STORAGE_KEY = STORAGE_KEYS.onboarded;
+// Thinking levels are persisted PER MODEL: `kimi-web.thinking` holds a JSON map
+// of model id → level. A persisted level may be any non-empty effort string:
+// the reserved 'off'/'on', or a model-declared level (e.g. 'low'/'high'/'max').
+// Since the set of legal levels comes from each model's support_efforts, we
+// can't whitelist values — only guard against corrupted localStorage with a
+// charset + length check, and let the resolution in useModelProviderState drop
+// entries the model no longer declares. Per-model storage is only the SEED for
+// a session that has no level of its own yet (a new-session draft): once the
+// daemon reports a session's level, that per-session value wins (see
+// thinkingBySession), so a pick can never leak INTO an existing session — and
+// keying storage by model keeps a pick for one model (e.g. 'low' on an effort
+// model) from leaking onto a model that never declared it (e.g. a max-only
+// always-on model). The legacy pre-map format (a single global level, stored
+// raw) is not discarded: it becomes a fallback for any model that declares it
+// (see hydrateThinkingPicks), so an existing user's preference survives the
+// upgrade while a max-only model still can't be trapped by it.
+const PERSISTED_THINKING_LEVEL_RE = /^[a-zA-Z0-9][a-zA-Z0-9_-]{0,31}$/;
 
 // Appearance types + logic live in ./client/useAppearance; re-exported here so
 // existing `import type { ColorScheme, Accent } from './useKimiWebClient'`
@@ -126,9 +146,6 @@ safeRemove(STORAGE_KEYS.codeFont);
 // look. Clear the old persisted key so users who once picked one aren't frozen
 // on a value the UI no longer reads.
 safeRemove(STORAGE_KEYS.theme);
-// The per-model thinking pick store was dropped in favor of the daemon's
-// per-session thinking state — clear the old key so stale picks can't linger.
-safeRemove(STORAGE_KEYS.thinking);
 
 function loadPermissionFromStorage(): PermissionMode {
   try {
@@ -146,6 +163,69 @@ function savePermissionToStorage(mode: PermissionMode): void {
   } catch {
     // ignore
   }
+}
+
+function loadThinkingMap(): Record<string, ThinkingLevel> {
+  const parsed = safeGetJson<unknown>(THINKING_STORAGE_KEY);
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return {};
+  const out: Record<string, ThinkingLevel> = {};
+  for (const [id, value] of Object.entries(parsed as Record<string, unknown>)) {
+    if (typeof value === 'string' && PERSISTED_THINKING_LEVEL_RE.test(value)) {
+      out[id] = value as ThinkingLevel;
+    }
+  }
+  return out;
+}
+
+// Legacy pre-map format: a single global level stored raw via safeSetString
+// (not JSON). It fails JSON.parse in loadThinkingMap above — detect it from the
+// raw string instead of dropping the user's preference on upgrade.
+function loadLegacyThinkingValue(): ThinkingLevel | undefined {
+  const raw = safeGetString(THINKING_STORAGE_KEY);
+  return raw && PERSISTED_THINKING_LEVEL_RE.test(raw) ? (raw as ThinkingLevel) : undefined;
+}
+
+// Map key for the migrated legacy value — never a real model id. Kept INSIDE
+// the map (not a sidecar variable) so the first per-model write, which rewrites
+// the raw legacy string into map format, carries the fallback forward instead
+// of deleting it for every model without its own entry.
+const LEGACY_THINKING_PICK_KEY = '*';
+
+// The RUNTIME source of truth for per-model picks is this in-memory map,
+// hydrated from localStorage once at startup. Explicit picks update it first
+// (see saveThinkingToStorage), so a pick takes effect even when persistence is
+// unavailable (storage policy/quota — safeSetJson swallows those failures),
+// and so a pick made later in ANOTHER tab can never change what this tab
+// displays or submits mid-session. localStorage is hydration + best-effort
+// persistence only: written with a read-modify-write merge (same pattern as
+// saveUnread) so concurrent tabs' entries survive, and re-read from scratch on
+// the next startup.
+const thinkingPicks: Record<string, ThinkingLevel> = loadThinkingMap();
+if (Object.keys(thinkingPicks).length === 0) {
+  const legacy = loadLegacyThinkingValue();
+  if (legacy !== undefined) thinkingPicks[LEGACY_THINKING_PICK_KEY] = legacy;
+}
+
+function loadThinkingForModel(modelId: string): ThinkingLevel | undefined {
+  // Per-model entries win; the '*' entry is the migrated legacy pre-map global
+  // pick — useModelProviderState validates it against each model's catalog
+  // entry, so it only ever applies to models that declare it (a max-only model
+  // still falls through to its default).
+  return thinkingPicks[modelId] ?? thinkingPicks[LEGACY_THINKING_PICK_KEY];
+}
+
+function saveThinkingToStorage(modelId: string, level: ThinkingLevel): void {
+  thinkingPicks[modelId] = level;
+  // Delta write (same pattern as saveUnread): overlay only the CHANGED entry —
+  // overlaying this tab's whole in-memory snapshot would revert another tab's
+  // newer pick for any model this tab still holds a stale copy of. The one
+  // extra entry carried along is the migrated legacy '*' fallback, so the
+  // first write rewrites it into map format rather than dropping it.
+  const map = loadThinkingMap();
+  const legacy = thinkingPicks[LEGACY_THINKING_PICK_KEY];
+  if (legacy !== undefined) map[LEGACY_THINKING_PICK_KEY] = legacy;
+  map[modelId] = level;
+  safeSetJson(THINKING_STORAGE_KEY, map);
 }
 
 // Plan / swarm / goal modes are per-session. Each is persisted as a compact
@@ -2168,6 +2248,8 @@ const modelProvider = useModelProviderState(rawState, {
   refreshSessionStatus,
   persistSessionProfile,
   activity,
+  loadThinkingForModel,
+  saveThinkingToStorage,
   updateSession,
   updateSessionMessages,
 });

--- a/apps/kimi-web/src/composables/useKimiWebClient.ts
+++ b/apps/kimi-web/src/composables/useKimiWebClient.ts
@@ -22,10 +22,8 @@ import {
   loadUnread,
   loadWorkspaceOrder,
   loadWorkspaceSort,
-  safeGetJson,
   safeGetString,
   safeRemove,
-  safeSetJson,
   safeSetString,
   saveUnread,
   saveWorkspaceOrder,
@@ -110,26 +108,11 @@ import type {
 
 const PERMISSION_STORAGE_KEY = STORAGE_KEYS.permission;
 const ACTIVE_WORKSPACE_KEY = STORAGE_KEYS.activeWorkspace;
-const THINKING_STORAGE_KEY = STORAGE_KEYS.thinking;
 const PLAN_MODE_STORAGE_KEY = STORAGE_KEYS.planMode;
 const SWARM_MODE_STORAGE_KEY = STORAGE_KEYS.swarmMode;
 const GOAL_MODE_STORAGE_KEY = STORAGE_KEYS.goalMode;
 const SESSION_NOT_FOUND_CODE = 40401;
 const ONBOARDED_STORAGE_KEY = STORAGE_KEYS.onboarded;
-// Thinking levels are persisted PER MODEL: `kimi-web.thinking` holds a JSON map
-// of model id → level. A persisted level may be any non-empty effort string:
-// the reserved 'off'/'on', or a model-declared level (e.g. 'low'/'high'/'max').
-// Since the set of legal levels comes from each model's support_efforts, we
-// can't whitelist values — only guard against corrupted localStorage with a
-// charset + length check, and let the resolution in useModelProviderState drop
-// entries the model no longer declares. Per-model storage is only the SEED for
-// a session that has no level of its own yet (a new-session draft): once the
-// daemon reports a session's level, that per-session value wins (see
-// thinkingBySession), so a pick can never leak INTO an existing session — and
-// keying storage by model keeps a pick for one model (e.g. 'low' on an effort
-// model) from leaking onto a model that never declared it (e.g. a max-only
-// always-on model).
-const PERSISTED_THINKING_LEVEL_RE = /^[a-zA-Z0-9][a-zA-Z0-9_-]{0,31}$/;
 
 // Appearance types + logic live in ./client/useAppearance; re-exported here so
 // existing `import type { ColorScheme, Accent } from './useKimiWebClient'`
@@ -143,6 +126,9 @@ safeRemove(STORAGE_KEYS.codeFont);
 // look. Clear the old persisted key so users who once picked one aren't frozen
 // on a value the UI no longer reads.
 safeRemove(STORAGE_KEYS.theme);
+// The per-model thinking pick store was dropped in favor of the daemon's
+// per-session thinking state — clear the old key so stale picks can't linger.
+safeRemove(STORAGE_KEYS.thinking);
 
 function loadPermissionFromStorage(): PermissionMode {
   try {
@@ -160,44 +146,6 @@ function savePermissionToStorage(mode: PermissionMode): void {
   } catch {
     // ignore
   }
-}
-
-function loadThinkingMap(): Record<string, ThinkingLevel> {
-  const parsed = safeGetJson<unknown>(THINKING_STORAGE_KEY);
-  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return {};
-  const out: Record<string, ThinkingLevel> = {};
-  for (const [id, value] of Object.entries(parsed as Record<string, unknown>)) {
-    if (typeof value === 'string' && PERSISTED_THINKING_LEVEL_RE.test(value)) {
-      out[id] = value as ThinkingLevel;
-    }
-  }
-  return out;
-}
-
-// The RUNTIME source of truth for per-model picks is this in-memory map,
-// hydrated from localStorage once at startup. Explicit picks update it first
-// (see saveThinkingToStorage), so a pick takes effect even when persistence is
-// unavailable (storage policy/quota — safeSetJson swallows those failures),
-// and so a pick made later in ANOTHER tab can never change what this tab
-// displays or submits mid-session. localStorage is hydration + best-effort
-// persistence only: written with a read-modify-write merge (same pattern as
-// saveUnread) so concurrent tabs' entries survive, and re-read from scratch on
-// the next startup. Anything that is not a model-id map (e.g. the legacy raw
-// single-level string) is discarded rather than applied to every model.
-const thinkingPicks: Record<string, ThinkingLevel> = loadThinkingMap();
-
-function loadThinkingForModel(modelId: string): ThinkingLevel | undefined {
-  return thinkingPicks[modelId];
-}
-
-function saveThinkingToStorage(modelId: string, level: ThinkingLevel): void {
-  thinkingPicks[modelId] = level;
-  // Delta write (same pattern as saveUnread): overlay only the CHANGED entry —
-  // overlaying this tab's whole in-memory snapshot would revert another tab's
-  // newer pick for any model this tab still holds a stale copy of.
-  const map = loadThinkingMap();
-  map[modelId] = level;
-  safeSetJson(THINKING_STORAGE_KEY, map);
 }
 
 // Plan / swarm / goal modes are per-session. Each is persisted as a compact
@@ -2220,8 +2168,6 @@ const modelProvider = useModelProviderState(rawState, {
   refreshSessionStatus,
   persistSessionProfile,
   activity,
-  loadThinkingForModel,
-  saveThinkingToStorage,
   updateSession,
   updateSessionMessages,
 });

--- a/apps/kimi-web/src/composables/useKimiWebClient.ts
+++ b/apps/kimi-web/src/composables/useKimiWebClient.ts
@@ -128,10 +128,7 @@ const ONBOARDED_STORAGE_KEY = STORAGE_KEYS.onboarded;
 // thinkingBySession), so a pick can never leak INTO an existing session — and
 // keying storage by model keeps a pick for one model (e.g. 'low' on an effort
 // model) from leaking onto a model that never declared it (e.g. a max-only
-// always-on model). The legacy pre-map format (a single global level, stored
-// raw) is not discarded: it becomes a fallback for any model that declares it
-// (see hydrateThinkingPicks), so an existing user's preference survives the
-// upgrade while a max-only model still can't be trapped by it.
+// always-on model).
 const PERSISTED_THINKING_LEVEL_RE = /^[a-zA-Z0-9][a-zA-Z0-9_-]{0,31}$/;
 
 // Appearance types + logic live in ./client/useAppearance; re-exported here so
@@ -177,20 +174,6 @@ function loadThinkingMap(): Record<string, ThinkingLevel> {
   return out;
 }
 
-// Legacy pre-map format: a single global level stored raw via safeSetString
-// (not JSON). It fails JSON.parse in loadThinkingMap above — detect it from the
-// raw string instead of dropping the user's preference on upgrade.
-function loadLegacyThinkingValue(): ThinkingLevel | undefined {
-  const raw = safeGetString(THINKING_STORAGE_KEY);
-  return raw && PERSISTED_THINKING_LEVEL_RE.test(raw) ? (raw as ThinkingLevel) : undefined;
-}
-
-// Map key for the migrated legacy value — never a real model id. Kept INSIDE
-// the map (not a sidecar variable) so the first per-model write, which rewrites
-// the raw legacy string into map format, carries the fallback forward instead
-// of deleting it for every model without its own entry.
-const LEGACY_THINKING_PICK_KEY = '*';
-
 // The RUNTIME source of truth for per-model picks is this in-memory map,
 // hydrated from localStorage once at startup. Explicit picks update it first
 // (see saveThinkingToStorage), so a pick takes effect even when persistence is
@@ -199,31 +182,20 @@ const LEGACY_THINKING_PICK_KEY = '*';
 // displays or submits mid-session. localStorage is hydration + best-effort
 // persistence only: written with a read-modify-write merge (same pattern as
 // saveUnread) so concurrent tabs' entries survive, and re-read from scratch on
-// the next startup.
+// the next startup. Anything that is not a model-id map (e.g. the legacy raw
+// single-level string) is discarded rather than applied to every model.
 const thinkingPicks: Record<string, ThinkingLevel> = loadThinkingMap();
-if (Object.keys(thinkingPicks).length === 0) {
-  const legacy = loadLegacyThinkingValue();
-  if (legacy !== undefined) thinkingPicks[LEGACY_THINKING_PICK_KEY] = legacy;
-}
 
 function loadThinkingForModel(modelId: string): ThinkingLevel | undefined {
-  // Per-model entries win; the '*' entry is the migrated legacy pre-map global
-  // pick — useModelProviderState validates it against each model's catalog
-  // entry, so it only ever applies to models that declare it (a max-only model
-  // still falls through to its default).
-  return thinkingPicks[modelId] ?? thinkingPicks[LEGACY_THINKING_PICK_KEY];
+  return thinkingPicks[modelId];
 }
 
 function saveThinkingToStorage(modelId: string, level: ThinkingLevel): void {
   thinkingPicks[modelId] = level;
   // Delta write (same pattern as saveUnread): overlay only the CHANGED entry —
   // overlaying this tab's whole in-memory snapshot would revert another tab's
-  // newer pick for any model this tab still holds a stale copy of. The one
-  // extra entry carried along is the migrated legacy '*' fallback, so the
-  // first write rewrites it into map format rather than dropping it.
+  // newer pick for any model this tab still holds a stale copy of.
   const map = loadThinkingMap();
-  const legacy = thinkingPicks[LEGACY_THINKING_PICK_KEY];
-  if (legacy !== undefined) map[LEGACY_THINKING_PICK_KEY] = legacy;
   map[modelId] = level;
   safeSetJson(THINKING_STORAGE_KEY, map);
 }

--- a/apps/kimi-web/src/lib/modelThinking.test.ts
+++ b/apps/kimi-web/src/lib/modelThinking.test.ts
@@ -1,6 +1,6 @@
 import { computed, nextTick, reactive } from 'vue';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import type { AppModel, AppSession, ThinkingLevel } from '../api/types';
+import type { AppModel, AppSession } from '../api/types';
 import {
   useModelProviderState,
   type UseModelProviderStateDeps,
@@ -132,19 +132,6 @@ describe('modelThinking', () => {
       expect(thinkingLevelForModelSwitch(undefined, undefined, true)).toBeUndefined();
     });
 
-    it('restores the stored pick when the target model declares it', () => {
-      expect(thinkingLevelForModelSwitch(effortModel, 'off', true, 'max')).toBe('max');
-      expect(thinkingLevelForModelSwitch(effortModel, 'high', true, 'off')).toBe('off');
-    });
-
-    it('falls back to the target default when the stored pick is not declared', () => {
-      expect(thinkingLevelForModelSwitch(maxOnlyModel, 'low', true, 'low')).toBe('max');
-      expect(thinkingLevelForModelSwitch(booleanModel, 'off', true, 'low')).toBe('on');
-    });
-
-    it('ignores the stored pick when re-selecting the current model', () => {
-      expect(thinkingLevelForModelSwitch(effortModel, 'off', false, 'max')).toBe('off');
-    });
   });
 
   describe('effectiveThinkingLevel', () => {
@@ -269,12 +256,7 @@ describe('useModelProviderState thinking on model selection', () => {
     defaultEffort: 'max',
   };
 
-  // Per-model thinking storage, wired into the deps the same way the facade
-  // wires localStorage: tests seed storedThinkingLevels and assert writes via
-  // saveThinkingToStorageMock.
-  const saveThinkingToStorageMock = vi.fn();
   const persistSessionProfileMock = vi.fn();
-  let storedThinkingLevels: Record<string, ThinkingLevel>;
 
   beforeEach(() => {
     apiMock.updateSession.mockReset();
@@ -285,10 +267,8 @@ describe('useModelProviderState thinking on model selection', () => {
     apiMock.setConfig.mockResolvedValue({});
     apiMock.activateSkill.mockReset();
     apiMock.activateSkill.mockResolvedValue({});
-    saveThinkingToStorageMock.mockReset();
     persistSessionProfileMock.mockReset();
     persistSessionProfileMock.mockResolvedValue(true);
-    storedThinkingLevels = {};
   });
 
   function createState(options: {
@@ -311,8 +291,6 @@ describe('useModelProviderState thinking on model selection', () => {
       refreshSessionStatus: vi.fn().mockResolvedValue(undefined),
       persistSessionProfile: persistSessionProfileMock,
       activity: computed(() => 'idle'),
-      loadThinkingForModel: (modelId) => storedThinkingLevels[modelId],
-      saveThinkingToStorage: saveThinkingToStorageMock,
       updateSession: (id, update) => {
         state.sessions = state.sessions.map((session) =>
           session.id === id ? update(session) : session,
@@ -374,9 +352,8 @@ describe('useModelProviderState thinking on model selection', () => {
 
   it('applies the resolved level to the session profile before activating a skill', async () => {
     // Skill activation carries no thinking — the daemon runs at the session
-    // profile effort. The restored per-model level must be persisted there
-    // first, or the skill runs at a stale profile effort the UI no longer shows.
-    storedThinkingLevels = { [effortAppModel.id]: 'low' };
+    // profile effort. The resolved level must be persisted there first, or the
+    // skill runs at a stale profile effort the UI no longer shows.
     const state = createState({
       activeSession: { id: 'session-1', model: effortAppModel.id },
       defaultModel: booleanAppModel.id,
@@ -385,7 +362,7 @@ describe('useModelProviderState thinking on model selection', () => {
 
     await provider.activateSkill('gen-changesets');
 
-    expect(persistSessionProfileMock).toHaveBeenCalledWith({ thinking: 'low' }, 'session-1');
+    expect(persistSessionProfileMock).toHaveBeenCalledWith({ thinking: 'high' }, 'session-1');
     expect(apiMock.activateSkill).toHaveBeenCalledWith('session-1', 'gen-changesets', undefined);
     // The profile write precedes the activation, mirroring the new-session path.
     const persistOrder = persistSessionProfileMock.mock.invocationCallOrder[0]!;
@@ -413,8 +390,7 @@ describe('useModelProviderState thinking on model selection', () => {
   it('resolves an empty session model through the default model before activating a skill', async () => {
     // The daemon's profile echo can leave session.model '' — the same fallback
     // the prompt/BTW/steer paths apply must hold here too, or the profile gets
-    // the raw active level instead of the target session model's pick.
-    storedThinkingLevels = { [effortAppModel.id]: 'low' };
+    // the raw active level instead of the target session model's default.
     const state = createState({
       activeSession: { id: 'session-1', model: '' },
       defaultModel: effortAppModel.id,
@@ -423,7 +399,7 @@ describe('useModelProviderState thinking on model selection', () => {
 
     await provider.activateSkill('gen-changesets');
 
-    expect(persistSessionProfileMock).toHaveBeenCalledWith({ thinking: 'low' }, 'session-1');
+    expect(persistSessionProfileMock).toHaveBeenCalledWith({ thinking: 'high' }, 'session-1');
     expect(apiMock.activateSkill).toHaveBeenCalledWith('session-1', 'gen-changesets', undefined);
   });
 
@@ -435,30 +411,6 @@ describe('useModelProviderState thinking on model selection', () => {
     await provider.loadModels();
 
     expect(state.thinking).toBe('high');
-  });
-
-  it('keeps a stored preference when loading models', async () => {
-    const state = createState({ defaultModel: effortAppModel.id });
-    storedThinkingLevels = { [effortAppModel.id]: 'max' };
-    state.thinking = 'max';
-    const provider = createModelProvider(state);
-
-    await provider.loadModels();
-
-    expect(state.thinking).toBe('max');
-  });
-
-  it('drops a stored per-model level the active model does not declare', async () => {
-    // A 'low' stored for another model must not leak onto a max-only always-on
-    // model — resolution falls back to the model default.
-    const state = createState({ defaultModel: maxOnlyAppModel.id });
-    storedThinkingLevels = { [maxOnlyAppModel.id]: 'low' };
-    state.thinking = 'low';
-    const provider = createModelProvider(state);
-
-    await provider.loadModels();
-
-    expect(state.thinking).toBe('max');
   });
 
   it('drops a session level the active model does not declare', async () => {
@@ -477,55 +429,6 @@ describe('useModelProviderState thinking on model selection', () => {
     expect(state.thinking).toBe('max');
   });
 
-  it('restores the target model stored pick on a switch', async () => {
-    const state = createState({ defaultModel: booleanAppModel.id });
-    storedThinkingLevels = { [effortAppModel.id]: 'max' };
-    const provider = createModelProvider(state);
-
-    await provider.setModel(effortAppModel.id);
-
-    expect(state.thinking).toBe('max');
-    // 'max' is session-only: the global config records just the toggle.
-    expect(apiMock.setConfig).toHaveBeenCalledWith({ thinking: { enabled: true } });
-  });
-
-  it('persists the thinking pick under the current model id', () => {
-    const state = createState({ defaultModel: effortAppModel.id });
-    const provider = createModelProvider(state);
-
-    provider.setThinking('max');
-
-    expect(saveThinkingToStorageMock).toHaveBeenCalledWith(effortAppModel.id, 'max');
-  });
-
-  it('does not persist a derived default on model switch — storage stays pick-only', async () => {
-    const state = createState({ defaultModel: booleanAppModel.id });
-    const provider = createModelProvider(state);
-
-    await provider.setModel(effortAppModel.id);
-
-    // The in-memory level follows the switch (catalog default 'high')...
-    expect(state.thinking).toBe('high');
-    // ...but nothing is written to storage: a level the user never explicitly
-    // picked must not masquerade as a stored choice (it would override a future
-    // catalog default change). Only setThinking writes.
-    expect(saveThinkingToStorageMock).not.toHaveBeenCalled();
-  });
-
-  it('does not persist the rolled-back level when a switch fails', async () => {
-    const state = createState({
-      activeSession: { id: 'session-1', model: booleanAppModel.id },
-      defaultModel: booleanAppModel.id,
-    });
-    apiMock.updateSession.mockRejectedValueOnce(new Error('daemon unreachable'));
-    const provider = createModelProvider(state);
-
-    const switched = await provider.setModel(effortAppModel.id);
-
-    expect(switched).toBe(false);
-    expect(saveThinkingToStorageMock).not.toHaveBeenCalled();
-  });
-
   it('re-resolves the level when the active session switches to another model', async () => {
     const state = reactive(
       createState({
@@ -538,13 +441,12 @@ describe('useModelProviderState thinking on model selection', () => {
       { id: 'session-2', model: effortAppModel.id },
     ] as AppSession[];
     state.thinking = 'max';
-    storedThinkingLevels = { [effortAppModel.id]: 'low' };
     createModelProvider(state);
 
     state.activeSessionId = 'session-2';
     await nextTick();
-    // No session level of its own yet — the stored per-model seed applies.
-    expect(state.thinking).toBe('low');
+    // No session level of its own yet — the catalog default applies.
+    expect(state.thinking).toBe('high');
 
     // Switching back resolves the max-only model's own level again.
     state.activeSessionId = 'session-1';

--- a/apps/kimi-web/src/lib/modelThinking.test.ts
+++ b/apps/kimi-web/src/lib/modelThinking.test.ts
@@ -285,7 +285,7 @@ describe('useModelProviderState thinking on model selection', () => {
     } as ExtendedState;
   }
 
-  function createModelProvider(state: ExtendedState) {
+  function createModelProvider(state: ExtendedState, depOverrides: Partial<UseModelProviderStateDeps> = {}) {
     const deps: UseModelProviderStateDeps = {
       pushOperationFailure: vi.fn(),
       refreshSessionStatus: vi.fn().mockResolvedValue(undefined),
@@ -297,6 +297,7 @@ describe('useModelProviderState thinking on model selection', () => {
         );
       },
       updateSessionMessages: vi.fn(),
+      ...depOverrides,
     };
     const provider = useModelProviderState(state, deps);
     provider.models.value = [effortAppModel, booleanAppModel, maxOnlyAppModel];
@@ -591,5 +592,36 @@ describe('useModelProviderState thinking on model selection', () => {
 
     expect(switched).toBe(false);
     expect(apiMock.setConfig).not.toHaveBeenCalled();
+  });
+
+  it('waits for the status fold when the session level has not landed', async () => {
+    const state = createState({
+      activeSession: { id: 'session-1', model: effortAppModel.id },
+      defaultModel: effortAppModel.id,
+    });
+    const refreshSessionStatus = vi.fn(async () => {
+      state.thinkingBySession = { 'session-1': 'max' };
+    });
+    const provider = createModelProvider(state, { refreshSessionStatus });
+
+    const level = await provider.resolveThinkingForPrompt('session-1', effortAppModel.id);
+
+    expect(refreshSessionStatus).toHaveBeenCalledWith('session-1');
+    expect(level).toBe('max');
+  });
+
+  it('does not refetch status when the session level is already known', async () => {
+    const state = createState({
+      activeSession: { id: 'session-1', model: effortAppModel.id },
+      defaultModel: effortAppModel.id,
+    });
+    state.thinkingBySession = { 'session-1': 'max' };
+    const refreshSessionStatus = vi.fn(async () => undefined);
+    const provider = createModelProvider(state, { refreshSessionStatus });
+
+    const level = await provider.resolveThinkingForPrompt('session-1', effortAppModel.id);
+
+    expect(refreshSessionStatus).not.toHaveBeenCalled();
+    expect(level).toBe('max');
   });
 });

--- a/apps/kimi-web/src/lib/modelThinking.test.ts
+++ b/apps/kimi-web/src/lib/modelThinking.test.ts
@@ -561,16 +561,6 @@ describe('useModelProviderState thinking on model selection', () => {
     expect(apiMock.setConfig).toHaveBeenCalledWith({ thinking: { enabled: true } });
   });
 
-  it('does not write the global thinking config when re-confirming the current level', async () => {
-    const state = createState({ defaultModel: effortAppModel.id });
-    state.thinking = 'max';
-    const provider = createModelProvider(state);
-
-    provider.setThinking('max');
-
-    expect(apiMock.setConfig).not.toHaveBeenCalled();
-  });
-
   it('persists the thinking pick as the global default on a model switch', async () => {
     const state = createState({ defaultModel: booleanAppModel.id });
     const provider = createModelProvider(state);

--- a/apps/kimi-web/src/lib/modelThinking.test.ts
+++ b/apps/kimi-web/src/lib/modelThinking.test.ts
@@ -1,6 +1,6 @@
 import { computed, nextTick, reactive } from 'vue';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import type { AppModel, AppSession } from '../api/types';
+import type { AppModel, AppSession, ThinkingLevel } from '../api/types';
 import {
   useModelProviderState,
   type UseModelProviderStateDeps,
@@ -132,6 +132,19 @@ describe('modelThinking', () => {
       expect(thinkingLevelForModelSwitch(undefined, undefined, true)).toBeUndefined();
     });
 
+    it('restores the stored pick when the target model declares it', () => {
+      expect(thinkingLevelForModelSwitch(effortModel, 'off', true, 'max')).toBe('max');
+      expect(thinkingLevelForModelSwitch(effortModel, 'high', true, 'off')).toBe('off');
+    });
+
+    it('falls back to the target default when the stored pick is not declared', () => {
+      expect(thinkingLevelForModelSwitch(maxOnlyModel, 'low', true, 'low')).toBe('max');
+      expect(thinkingLevelForModelSwitch(booleanModel, 'off', true, 'low')).toBe('on');
+    });
+
+    it('ignores the stored pick when re-selecting the current model', () => {
+      expect(thinkingLevelForModelSwitch(effortModel, 'off', false, 'max')).toBe('off');
+    });
   });
 
   describe('effectiveThinkingLevel', () => {
@@ -206,8 +219,15 @@ describe('modelThinking', () => {
       expect(thinkingLevelToConfig('on')).toEqual({ enabled: true });
     });
 
-    it('records only enabled for concrete efforts', () => {
+    it('persists whitelisted concrete efforts as the global default', () => {
+      expect(thinkingLevelToConfig('low')).toEqual({ enabled: true, effort: 'low' });
+      expect(thinkingLevelToConfig('high')).toEqual({ enabled: true, effort: 'high' });
+      expect(thinkingLevelToConfig('xhigh')).toEqual({ enabled: true, effort: 'xhigh' });
+    });
+
+    it('records only enabled for max and unknown levels', () => {
       expect(thinkingLevelToConfig('max')).toEqual({ enabled: true });
+      expect(thinkingLevelToConfig('ultra')).toEqual({ enabled: true });
     });
   });
 });
@@ -239,7 +259,13 @@ describe('useModelProviderState thinking on model selection', () => {
     defaultEffort: 'max',
   };
 
+  // Per-model thinking storage, wired into the deps the same way the facade
+  // wires localStorage: tests seed storedThinkingLevels and assert writes via
+  // saveThinkingToStorageMock.
+  const saveThinkingToStorageMock = vi.fn();
   const persistSessionProfileMock = vi.fn();
+  let storedThinkingLevels: Record<string, ThinkingLevel>;
+  let legacyThinkingPick: ThinkingLevel | undefined;
 
   beforeEach(() => {
     apiMock.updateSession.mockReset();
@@ -250,8 +276,11 @@ describe('useModelProviderState thinking on model selection', () => {
     apiMock.setConfig.mockResolvedValue({});
     apiMock.activateSkill.mockReset();
     apiMock.activateSkill.mockResolvedValue({});
+    saveThinkingToStorageMock.mockReset();
     persistSessionProfileMock.mockReset();
     persistSessionProfileMock.mockResolvedValue(true);
+    storedThinkingLevels = {};
+    legacyThinkingPick = undefined;
   });
 
   function createState(options: {
@@ -274,6 +303,8 @@ describe('useModelProviderState thinking on model selection', () => {
       refreshSessionStatus: vi.fn().mockResolvedValue(undefined),
       persistSessionProfile: persistSessionProfileMock,
       activity: computed(() => 'idle'),
+      loadThinkingForModel: (modelId) => storedThinkingLevels[modelId] ?? legacyThinkingPick,
+      saveThinkingToStorage: saveThinkingToStorageMock,
       updateSession: (id, update) => {
         state.sessions = state.sessions.map((session) =>
           session.id === id ? update(session) : session,
@@ -335,8 +366,9 @@ describe('useModelProviderState thinking on model selection', () => {
 
   it('applies the resolved level to the session profile before activating a skill', async () => {
     // Skill activation carries no thinking — the daemon runs at the session
-    // profile effort. The resolved level must be persisted there first, or the
-    // skill runs at a stale profile effort the UI no longer shows.
+    // profile effort. The restored per-model level must be persisted there
+    // first, or the skill runs at a stale profile effort the UI no longer shows.
+    storedThinkingLevels = { [effortAppModel.id]: 'low' };
     const state = createState({
       activeSession: { id: 'session-1', model: effortAppModel.id },
       defaultModel: booleanAppModel.id,
@@ -345,7 +377,7 @@ describe('useModelProviderState thinking on model selection', () => {
 
     await provider.activateSkill('gen-changesets');
 
-    expect(persistSessionProfileMock).toHaveBeenCalledWith({ thinking: 'high' }, 'session-1');
+    expect(persistSessionProfileMock).toHaveBeenCalledWith({ thinking: 'low' }, 'session-1');
     expect(apiMock.activateSkill).toHaveBeenCalledWith('session-1', 'gen-changesets', undefined);
     // The profile write precedes the activation, mirroring the new-session path.
     const persistOrder = persistSessionProfileMock.mock.invocationCallOrder[0]!;
@@ -373,7 +405,8 @@ describe('useModelProviderState thinking on model selection', () => {
   it('resolves an empty session model through the default model before activating a skill', async () => {
     // The daemon's profile echo can leave session.model '' — the same fallback
     // the prompt/BTW/steer paths apply must hold here too, or the profile gets
-    // the raw active level instead of the target session model's default.
+    // the raw active level instead of the target session model's pick.
+    storedThinkingLevels = { [effortAppModel.id]: 'low' };
     const state = createState({
       activeSession: { id: 'session-1', model: '' },
       defaultModel: effortAppModel.id,
@@ -382,7 +415,7 @@ describe('useModelProviderState thinking on model selection', () => {
 
     await provider.activateSkill('gen-changesets');
 
-    expect(persistSessionProfileMock).toHaveBeenCalledWith({ thinking: 'high' }, 'session-1');
+    expect(persistSessionProfileMock).toHaveBeenCalledWith({ thinking: 'low' }, 'session-1');
     expect(apiMock.activateSkill).toHaveBeenCalledWith('session-1', 'gen-changesets', undefined);
   });
 
@@ -394,6 +427,66 @@ describe('useModelProviderState thinking on model selection', () => {
     await provider.loadModels();
 
     expect(state.thinking).toBe('high');
+  });
+
+  it('treats a legacy pre-map pick as a fallback only for models that declare it', async () => {
+    // Upgrade migration: the facade serves the old global pick for models
+    // without their own entry; validation keeps it off models that can't run it.
+    legacyThinkingPick = 'low';
+
+    const effortState = createState({
+      activeSession: { id: 'session-1', model: effortAppModel.id },
+      defaultModel: effortAppModel.id,
+    });
+    const effortProvider = createModelProvider(effortState);
+    await effortProvider.loadModels();
+    expect(effortState.thinking).toBe('low');
+
+    const maxOnlyState = createState({
+      activeSession: { id: 'session-1', model: maxOnlyAppModel.id },
+      defaultModel: maxOnlyAppModel.id,
+    });
+    const maxOnlyProvider = createModelProvider(maxOnlyState);
+    await maxOnlyProvider.loadModels();
+    expect(maxOnlyState.thinking).toBe('max');
+  });
+
+  it('lets a per-model entry win over the legacy pre-map pick', async () => {
+    legacyThinkingPick = 'low';
+    storedThinkingLevels = { [effortAppModel.id]: 'high' };
+    const state = createState({
+      activeSession: { id: 'session-1', model: effortAppModel.id },
+      defaultModel: effortAppModel.id,
+    });
+    const provider = createModelProvider(state);
+
+    await provider.loadModels();
+
+    expect(state.thinking).toBe('high');
+  });
+
+  it('keeps a stored preference when loading models', async () => {
+    const state = createState({ defaultModel: effortAppModel.id });
+    storedThinkingLevels = { [effortAppModel.id]: 'max' };
+    state.thinking = 'max';
+    const provider = createModelProvider(state);
+
+    await provider.loadModels();
+
+    expect(state.thinking).toBe('max');
+  });
+
+  it('drops a stored per-model level the active model does not declare', async () => {
+    // A 'low' stored for another model must not leak onto a max-only always-on
+    // model — resolution falls back to the model default.
+    const state = createState({ defaultModel: maxOnlyAppModel.id });
+    storedThinkingLevels = { [maxOnlyAppModel.id]: 'low' };
+    state.thinking = 'low';
+    const provider = createModelProvider(state);
+
+    await provider.loadModels();
+
+    expect(state.thinking).toBe('max');
   });
 
   it('drops a session level the active model does not declare', async () => {
@@ -412,6 +505,55 @@ describe('useModelProviderState thinking on model selection', () => {
     expect(state.thinking).toBe('max');
   });
 
+  it('restores the target model stored pick on a switch', async () => {
+    const state = createState({ defaultModel: booleanAppModel.id });
+    storedThinkingLevels = { [effortAppModel.id]: 'max' };
+    const provider = createModelProvider(state);
+
+    await provider.setModel(effortAppModel.id);
+
+    expect(state.thinking).toBe('max');
+    // 'max' is session-only: the global config records just the toggle.
+    expect(apiMock.setConfig).toHaveBeenCalledWith({ thinking: { enabled: true } });
+  });
+
+  it('persists the thinking pick under the current model id', () => {
+    const state = createState({ defaultModel: effortAppModel.id });
+    const provider = createModelProvider(state);
+
+    provider.setThinking('max');
+
+    expect(saveThinkingToStorageMock).toHaveBeenCalledWith(effortAppModel.id, 'max');
+  });
+
+  it('does not persist a derived default on model switch — storage stays pick-only', async () => {
+    const state = createState({ defaultModel: booleanAppModel.id });
+    const provider = createModelProvider(state);
+
+    await provider.setModel(effortAppModel.id);
+
+    // The in-memory level follows the switch (catalog default 'high')...
+    expect(state.thinking).toBe('high');
+    // ...but nothing is written to storage: a level the user never explicitly
+    // picked must not masquerade as a stored choice (it would override a future
+    // catalog default change). Only setThinking writes.
+    expect(saveThinkingToStorageMock).not.toHaveBeenCalled();
+  });
+
+  it('does not persist the rolled-back level when a switch fails', async () => {
+    const state = createState({
+      activeSession: { id: 'session-1', model: booleanAppModel.id },
+      defaultModel: booleanAppModel.id,
+    });
+    apiMock.updateSession.mockRejectedValueOnce(new Error('daemon unreachable'));
+    const provider = createModelProvider(state);
+
+    const switched = await provider.setModel(effortAppModel.id);
+
+    expect(switched).toBe(false);
+    expect(saveThinkingToStorageMock).not.toHaveBeenCalled();
+  });
+
   it('re-resolves the level when the active session switches to another model', async () => {
     const state = reactive(
       createState({
@@ -424,12 +566,13 @@ describe('useModelProviderState thinking on model selection', () => {
       { id: 'session-2', model: effortAppModel.id },
     ] as AppSession[];
     state.thinking = 'max';
+    storedThinkingLevels = { [effortAppModel.id]: 'low' };
     createModelProvider(state);
 
     state.activeSessionId = 'session-2';
     await nextTick();
-    // No session level of its own yet — the catalog default applies.
-    expect(state.thinking).toBe('high');
+    // No session level of its own yet — the stored per-model seed applies.
+    expect(state.thinking).toBe('low');
 
     // Switching back resolves the max-only model's own level again.
     state.activeSessionId = 'session-1';
@@ -550,7 +693,7 @@ describe('useModelProviderState thinking on model selection', () => {
 
     await provider.setModel(effortAppModel.id);
 
-    expect(apiMock.setConfig).toHaveBeenCalledWith({ thinking: { enabled: true } });
+    expect(apiMock.setConfig).toHaveBeenCalledWith({ thinking: { enabled: true, effort: 'high' } });
   });
 
   it('does not write the global thinking config when re-selecting the current model', async () => {

--- a/apps/kimi-web/src/lib/modelThinking.test.ts
+++ b/apps/kimi-web/src/lib/modelThinking.test.ts
@@ -561,6 +561,16 @@ describe('useModelProviderState thinking on model selection', () => {
     expect(apiMock.setConfig).toHaveBeenCalledWith({ thinking: { enabled: true } });
   });
 
+  it('does not write the global thinking config when re-confirming the current level', async () => {
+    const state = createState({ defaultModel: effortAppModel.id });
+    state.thinking = 'max';
+    const provider = createModelProvider(state);
+
+    provider.setThinking('max');
+
+    expect(apiMock.setConfig).not.toHaveBeenCalled();
+  });
+
   it('persists the thinking pick as the global default on a model switch', async () => {
     const state = createState({ defaultModel: booleanAppModel.id });
     const provider = createModelProvider(state);

--- a/apps/kimi-web/src/lib/modelThinking.test.ts
+++ b/apps/kimi-web/src/lib/modelThinking.test.ts
@@ -275,7 +275,6 @@ describe('useModelProviderState thinking on model selection', () => {
   const saveThinkingToStorageMock = vi.fn();
   const persistSessionProfileMock = vi.fn();
   let storedThinkingLevels: Record<string, ThinkingLevel>;
-  let legacyThinkingPick: ThinkingLevel | undefined;
 
   beforeEach(() => {
     apiMock.updateSession.mockReset();
@@ -290,7 +289,6 @@ describe('useModelProviderState thinking on model selection', () => {
     persistSessionProfileMock.mockReset();
     persistSessionProfileMock.mockResolvedValue(true);
     storedThinkingLevels = {};
-    legacyThinkingPick = undefined;
   });
 
   function createState(options: {
@@ -313,7 +311,7 @@ describe('useModelProviderState thinking on model selection', () => {
       refreshSessionStatus: vi.fn().mockResolvedValue(undefined),
       persistSessionProfile: persistSessionProfileMock,
       activity: computed(() => 'idle'),
-      loadThinkingForModel: (modelId) => storedThinkingLevels[modelId] ?? legacyThinkingPick,
+      loadThinkingForModel: (modelId) => storedThinkingLevels[modelId],
       saveThinkingToStorage: saveThinkingToStorageMock,
       updateSession: (id, update) => {
         state.sessions = state.sessions.map((session) =>
@@ -432,42 +430,6 @@ describe('useModelProviderState thinking on model selection', () => {
   it('pins the catalog default in memory when no thinking preference exists', async () => {
     const state = createState({ defaultModel: effortAppModel.id });
     state.thinking = undefined;
-    const provider = createModelProvider(state);
-
-    await provider.loadModels();
-
-    expect(state.thinking).toBe('high');
-  });
-
-  it('treats a legacy pre-map pick as a fallback only for models that declare it', async () => {
-    // Upgrade migration: the facade serves the old global pick for models
-    // without their own entry; validation keeps it off models that can't run it.
-    legacyThinkingPick = 'low';
-
-    const effortState = createState({
-      activeSession: { id: 'session-1', model: effortAppModel.id },
-      defaultModel: effortAppModel.id,
-    });
-    const effortProvider = createModelProvider(effortState);
-    await effortProvider.loadModels();
-    expect(effortState.thinking).toBe('low');
-
-    const maxOnlyState = createState({
-      activeSession: { id: 'session-1', model: maxOnlyAppModel.id },
-      defaultModel: maxOnlyAppModel.id,
-    });
-    const maxOnlyProvider = createModelProvider(maxOnlyState);
-    await maxOnlyProvider.loadModels();
-    expect(maxOnlyState.thinking).toBe('max');
-  });
-
-  it('lets a per-model entry win over the legacy pre-map pick', async () => {
-    legacyThinkingPick = 'low';
-    storedThinkingLevels = { [effortAppModel.id]: 'high' };
-    const state = createState({
-      activeSession: { id: 'session-1', model: effortAppModel.id },
-      defaultModel: effortAppModel.id,
-    });
     const provider = createModelProvider(state);
 
     await provider.loadModels();

--- a/apps/kimi-web/src/lib/modelThinking.test.ts
+++ b/apps/kimi-web/src/lib/modelThinking.test.ts
@@ -219,15 +219,25 @@ describe('modelThinking', () => {
       expect(thinkingLevelToConfig('on')).toEqual({ enabled: true });
     });
 
-    it('persists whitelisted concrete efforts as the global default', () => {
-      expect(thinkingLevelToConfig('low')).toEqual({ enabled: true, effort: 'low' });
-      expect(thinkingLevelToConfig('high')).toEqual({ enabled: true, effort: 'high' });
-      expect(thinkingLevelToConfig('xhigh')).toEqual({ enabled: true, effort: 'xhigh' });
+    it('persists levels below the model top tier as the global default', () => {
+      expect(thinkingLevelToConfig('low', ['low', 'high', 'max'])).toEqual({
+        enabled: true,
+        effort: 'low',
+      });
+      expect(thinkingLevelToConfig('high', ['low', 'high', 'max'])).toEqual({
+        enabled: true,
+        effort: 'high',
+      });
     });
 
-    it('records only enabled for max and unknown levels', () => {
-      expect(thinkingLevelToConfig('max')).toEqual({ enabled: true });
-      expect(thinkingLevelToConfig('ultra')).toEqual({ enabled: true });
+    it('records only enabled for the model top tier', () => {
+      expect(thinkingLevelToConfig('max', ['low', 'high', 'max'])).toEqual({ enabled: true });
+      expect(thinkingLevelToConfig('max', ['max'])).toEqual({ enabled: true });
+    });
+
+    it('persists concrete levels as-is when the model levels are unknown', () => {
+      expect(thinkingLevelToConfig('max')).toEqual({ enabled: true, effort: 'max' });
+      expect(thinkingLevelToConfig('ultra')).toEqual({ enabled: true, effort: 'ultra' });
     });
   });
 });

--- a/apps/kimi-web/src/lib/modelThinking.test.ts
+++ b/apps/kimi-web/src/lib/modelThinking.test.ts
@@ -1,6 +1,6 @@
 import { computed, nextTick, reactive } from 'vue';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import type { AppModel, AppSession, ThinkingLevel } from '../api/types';
+import type { AppModel, AppSession } from '../api/types';
 import {
   useModelProviderState,
   type UseModelProviderStateDeps,
@@ -132,19 +132,6 @@ describe('modelThinking', () => {
       expect(thinkingLevelForModelSwitch(undefined, undefined, true)).toBeUndefined();
     });
 
-    it('restores the stored pick when the target model declares it', () => {
-      expect(thinkingLevelForModelSwitch(effortModel, 'off', true, 'max')).toBe('max');
-      expect(thinkingLevelForModelSwitch(effortModel, 'high', true, 'off')).toBe('off');
-    });
-
-    it('falls back to the target default when the stored pick is not declared', () => {
-      expect(thinkingLevelForModelSwitch(maxOnlyModel, 'low', true, 'low')).toBe('max');
-      expect(thinkingLevelForModelSwitch(booleanModel, 'off', true, 'low')).toBe('on');
-    });
-
-    it('ignores the stored pick when re-selecting the current model', () => {
-      expect(thinkingLevelForModelSwitch(effortModel, 'off', false, 'max')).toBe('off');
-    });
   });
 
   describe('effectiveThinkingLevel', () => {
@@ -219,8 +206,8 @@ describe('modelThinking', () => {
       expect(thinkingLevelToConfig('on')).toEqual({ enabled: true });
     });
 
-    it('records concrete efforts as the global default', () => {
-      expect(thinkingLevelToConfig('max')).toEqual({ enabled: true, effort: 'max' });
+    it('records only enabled for concrete efforts', () => {
+      expect(thinkingLevelToConfig('max')).toEqual({ enabled: true });
     });
   });
 });
@@ -252,13 +239,7 @@ describe('useModelProviderState thinking on model selection', () => {
     defaultEffort: 'max',
   };
 
-  // Per-model thinking storage, wired into the deps the same way the facade
-  // wires localStorage: tests seed storedThinkingLevels and assert writes via
-  // saveThinkingToStorageMock.
-  const saveThinkingToStorageMock = vi.fn();
   const persistSessionProfileMock = vi.fn();
-  let storedThinkingLevels: Record<string, ThinkingLevel>;
-  let legacyThinkingPick: ThinkingLevel | undefined;
 
   beforeEach(() => {
     apiMock.updateSession.mockReset();
@@ -269,11 +250,8 @@ describe('useModelProviderState thinking on model selection', () => {
     apiMock.setConfig.mockResolvedValue({});
     apiMock.activateSkill.mockReset();
     apiMock.activateSkill.mockResolvedValue({});
-    saveThinkingToStorageMock.mockReset();
     persistSessionProfileMock.mockReset();
     persistSessionProfileMock.mockResolvedValue(true);
-    storedThinkingLevels = {};
-    legacyThinkingPick = undefined;
   });
 
   function createState(options: {
@@ -284,6 +262,7 @@ describe('useModelProviderState thinking on model selection', () => {
       activeSessionId: options.activeSession?.id ?? null,
       sessions: options.activeSession ? [options.activeSession] : [],
       thinking: 'off',
+      thinkingBySession: {},
       defaultModel: options.defaultModel,
       inFlightBySession: {},
     } as ExtendedState;
@@ -295,8 +274,6 @@ describe('useModelProviderState thinking on model selection', () => {
       refreshSessionStatus: vi.fn().mockResolvedValue(undefined),
       persistSessionProfile: persistSessionProfileMock,
       activity: computed(() => 'idle'),
-      loadThinkingForModel: (modelId) => storedThinkingLevels[modelId] ?? legacyThinkingPick,
-      saveThinkingToStorage: saveThinkingToStorageMock,
       updateSession: (id, update) => {
         state.sessions = state.sessions.map((session) =>
           session.id === id ? update(session) : session,
@@ -320,12 +297,12 @@ describe('useModelProviderState thinking on model selection', () => {
 
   it('keeps thinking off when re-selecting an explicit new-session draft model', async () => {
     const state = createState({ defaultModel: booleanAppModel.id });
-    // In the app the draft pick and its 'off' level both went through setModel,
-    // so storage already holds the model's pick when it is re-selected.
-    storedThinkingLevels = { [effortAppModel.id]: 'off' };
     const provider = createModelProvider(state);
-    provider.draftModel.value = effortAppModel.id;
 
+    // Switch the draft to the effort model (catalog default applies), then
+    // explicitly turn thinking off — re-selecting the same model must keep it.
+    await provider.setModel(effortAppModel.id);
+    provider.setThinking('off');
     await provider.setModel(effortAppModel.id);
 
     expect(state.thinking).toBe('off');
@@ -356,39 +333,10 @@ describe('useModelProviderState thinking on model selection', () => {
     expect(state.thinking).toBe('high');
   });
 
-  it('does not persist a derived default on model switch — storage stays pick-only', async () => {
-    const state = createState({ defaultModel: booleanAppModel.id });
-    const provider = createModelProvider(state);
-
-    await provider.setModel(effortAppModel.id);
-
-    // The in-memory level follows the switch (catalog default 'high')...
-    expect(state.thinking).toBe('high');
-    // ...but nothing is written to storage: a level the user never explicitly
-    // picked must not masquerade as a stored choice (it would override a future
-    // catalog default change). Only setThinking writes.
-    expect(saveThinkingToStorageMock).not.toHaveBeenCalled();
-  });
-
-  it('does not persist the rolled-back level when a switch fails', async () => {
-    const state = createState({
-      activeSession: { id: 'session-1', model: booleanAppModel.id },
-      defaultModel: booleanAppModel.id,
-    });
-    apiMock.updateSession.mockRejectedValueOnce(new Error('daemon unreachable'));
-    const provider = createModelProvider(state);
-
-    const switched = await provider.setModel(effortAppModel.id);
-
-    expect(switched).toBe(false);
-    expect(saveThinkingToStorageMock).not.toHaveBeenCalled();
-  });
-
   it('applies the resolved level to the session profile before activating a skill', async () => {
     // Skill activation carries no thinking — the daemon runs at the session
-    // profile effort. The restored per-model level must be persisted there
-    // first, or the skill runs at a stale profile effort the UI no longer shows.
-    storedThinkingLevels = { [effortAppModel.id]: 'low' };
+    // profile effort. The resolved level must be persisted there first, or the
+    // skill runs at a stale profile effort the UI no longer shows.
     const state = createState({
       activeSession: { id: 'session-1', model: effortAppModel.id },
       defaultModel: booleanAppModel.id,
@@ -397,7 +345,7 @@ describe('useModelProviderState thinking on model selection', () => {
 
     await provider.activateSkill('gen-changesets');
 
-    expect(persistSessionProfileMock).toHaveBeenCalledWith({ thinking: 'low' }, 'session-1');
+    expect(persistSessionProfileMock).toHaveBeenCalledWith({ thinking: 'high' }, 'session-1');
     expect(apiMock.activateSkill).toHaveBeenCalledWith('session-1', 'gen-changesets', undefined);
     // The profile write precedes the activation, mirroring the new-session path.
     const persistOrder = persistSessionProfileMock.mock.invocationCallOrder[0]!;
@@ -425,8 +373,7 @@ describe('useModelProviderState thinking on model selection', () => {
   it('resolves an empty session model through the default model before activating a skill', async () => {
     // The daemon's profile echo can leave session.model '' — the same fallback
     // the prompt/BTW/steer paths apply must hold here too, or the profile gets
-    // the raw active level instead of the target session model's pick.
-    storedThinkingLevels = { [effortAppModel.id]: 'low' };
+    // the raw active level instead of the target session model's default.
     const state = createState({
       activeSession: { id: 'session-1', model: '' },
       defaultModel: effortAppModel.id,
@@ -435,44 +382,8 @@ describe('useModelProviderState thinking on model selection', () => {
 
     await provider.activateSkill('gen-changesets');
 
-    expect(persistSessionProfileMock).toHaveBeenCalledWith({ thinking: 'low' }, 'session-1');
+    expect(persistSessionProfileMock).toHaveBeenCalledWith({ thinking: 'high' }, 'session-1');
     expect(apiMock.activateSkill).toHaveBeenCalledWith('session-1', 'gen-changesets', undefined);
-  });
-
-  it('treats a legacy pre-map pick as a fallback only for models that declare it', async () => {
-    // Upgrade migration: the facade serves the old global pick for models
-    // without their own entry; validation keeps it off models that can't run it.
-    legacyThinkingPick = 'low';
-
-    const effortState = createState({
-      activeSession: { id: 'session-1', model: effortAppModel.id },
-      defaultModel: effortAppModel.id,
-    });
-    const effortProvider = createModelProvider(effortState);
-    await effortProvider.loadModels();
-    expect(effortState.thinking).toBe('low');
-
-    const maxOnlyState = createState({
-      activeSession: { id: 'session-1', model: maxOnlyAppModel.id },
-      defaultModel: maxOnlyAppModel.id,
-    });
-    const maxOnlyProvider = createModelProvider(maxOnlyState);
-    await maxOnlyProvider.loadModels();
-    expect(maxOnlyState.thinking).toBe('max');
-  });
-
-  it('lets a per-model entry win over the legacy pre-map pick', async () => {
-    legacyThinkingPick = 'low';
-    storedThinkingLevels = { [effortAppModel.id]: 'high' };
-    const state = createState({
-      activeSession: { id: 'session-1', model: effortAppModel.id },
-      defaultModel: effortAppModel.id,
-    });
-    const provider = createModelProvider(state);
-
-    await provider.loadModels();
-
-    expect(state.thinking).toBe('high');
   });
 
   it('pins the catalog default in memory when no thinking preference exists', async () => {
@@ -485,48 +396,20 @@ describe('useModelProviderState thinking on model selection', () => {
     expect(state.thinking).toBe('high');
   });
 
-  it('keeps a stored preference when loading models', async () => {
-    const state = createState({ defaultModel: effortAppModel.id });
-    storedThinkingLevels = { [effortAppModel.id]: 'max' };
-    state.thinking = 'max';
-    const provider = createModelProvider(state);
-
-    await provider.loadModels();
-
-    expect(state.thinking).toBe('max');
-  });
-
-  it('drops a stored level the active model does not declare', async () => {
-    // The reported bug: a 'low' picked for another model must not leak onto a
-    // max-only always-on model — resolution falls back to the model default.
-    const state = createState({ defaultModel: maxOnlyAppModel.id });
-    storedThinkingLevels = { [maxOnlyAppModel.id]: 'low' };
+  it('drops a session level the active model does not declare', async () => {
+    // A level the session ran with must not leak onto a model that cannot run
+    // it — resolution falls back to the model default.
+    const state = createState({
+      activeSession: { id: 'session-1', model: maxOnlyAppModel.id },
+      defaultModel: maxOnlyAppModel.id,
+    });
+    state.thinkingBySession = { 'session-1': 'low' };
     state.thinking = 'low';
     const provider = createModelProvider(state);
 
     await provider.loadModels();
 
     expect(state.thinking).toBe('max');
-  });
-
-  it('restores the target model stored pick on a switch', async () => {
-    const state = createState({ defaultModel: booleanAppModel.id });
-    storedThinkingLevels = { [effortAppModel.id]: 'max' };
-    const provider = createModelProvider(state);
-
-    await provider.setModel(effortAppModel.id);
-
-    expect(state.thinking).toBe('max');
-    expect(apiMock.setConfig).toHaveBeenCalledWith({ thinking: { enabled: true, effort: 'max' } });
-  });
-
-  it('persists the thinking pick under the current model id', () => {
-    const state = createState({ defaultModel: effortAppModel.id });
-    const provider = createModelProvider(state);
-
-    provider.setThinking('max');
-
-    expect(saveThinkingToStorageMock).toHaveBeenCalledWith(effortAppModel.id, 'max');
   });
 
   it('re-resolves the level when the active session switches to another model', async () => {
@@ -541,17 +424,105 @@ describe('useModelProviderState thinking on model selection', () => {
       { id: 'session-2', model: effortAppModel.id },
     ] as AppSession[];
     state.thinking = 'max';
-    storedThinkingLevels = { [effortAppModel.id]: 'low' };
     createModelProvider(state);
 
     state.activeSessionId = 'session-2';
     await nextTick();
-    expect(state.thinking).toBe('low');
+    // No session level of its own yet — the catalog default applies.
+    expect(state.thinking).toBe('high');
 
     // Switching back resolves the max-only model's own level again.
     state.activeSessionId = 'session-1';
     await nextTick();
     expect(state.thinking).toBe('max');
+  });
+
+  it('restores the session own daemon level when switching sessions on the same model', async () => {
+    const state = reactive(
+      createState({
+        activeSession: { id: 'session-1', model: effortAppModel.id },
+        defaultModel: effortAppModel.id,
+      }),
+    ) as ExtendedState;
+    state.sessions = [
+      { id: 'session-1', model: effortAppModel.id },
+      { id: 'session-2', model: effortAppModel.id },
+    ] as AppSession[];
+    // session-2 ran at max (folded from /status); the current view shows
+    // high — the session's own level must win.
+    state.thinkingBySession = { 'session-2': 'max' };
+    state.thinking = 'high';
+    createModelProvider(state);
+
+    state.activeSessionId = 'session-2';
+    await nextTick();
+    expect(state.thinking).toBe('max');
+  });
+
+  it('re-resolves the active session when its daemon level arrives after the switch', async () => {
+    const state = reactive(
+      createState({
+        activeSession: { id: 'session-1', model: effortAppModel.id },
+        defaultModel: effortAppModel.id,
+      }),
+    ) as ExtendedState;
+    state.sessions = [
+      { id: 'session-1', model: effortAppModel.id },
+      { id: 'session-2', model: effortAppModel.id },
+    ] as AppSession[];
+    state.thinking = 'high';
+    createModelProvider(state);
+
+    // Before the /status fold lands, the catalog default is shown.
+    state.activeSessionId = 'session-2';
+    await nextTick();
+    expect(state.thinking).toBe('high');
+
+    // The fold (refreshSessionStatus / WS) updates the active session's entry.
+    state.thinkingBySession = { 'session-2': 'max' };
+    await nextTick();
+    expect(state.thinking).toBe('max');
+  });
+
+  it('falls back to the model default when the session level is not declared by the model', async () => {
+    const lowHighAppModel: AppModel = {
+      id: 'provider/low-high-model',
+      provider: 'provider',
+      model: 'low-high-model',
+      maxContextSize: 128_000,
+      capabilities: ['thinking'],
+      supportEfforts: ['low', 'high'],
+      defaultEffort: 'high',
+    };
+    const state = reactive(
+      createState({
+        activeSession: { id: 'session-1', model: lowHighAppModel.id },
+        defaultModel: lowHighAppModel.id,
+      }),
+    ) as ExtendedState;
+    state.sessions = [
+      { id: 'session-1', model: lowHighAppModel.id },
+      { id: 'session-2', model: lowHighAppModel.id },
+    ] as AppSession[];
+    state.thinkingBySession = { 'session-2': 'max' };
+    const provider = createModelProvider(state);
+    provider.models.value = [...provider.models.value, lowHighAppModel];
+
+    state.activeSessionId = 'session-2';
+    await nextTick();
+    expect(state.thinking).toBe('high');
+  });
+
+  it('mirrors an explicit setThinking pick into the session own entry', () => {
+    const state = createState({
+      activeSession: { id: 'session-1', model: effortAppModel.id },
+      defaultModel: effortAppModel.id,
+    });
+    const provider = createModelProvider(state);
+
+    provider.setThinking('max');
+
+    expect(state.thinkingBySession['session-1']).toBe('max');
   });
 
   it('does not write the global thinking config for the loadModels default pin', async () => {
@@ -570,7 +541,7 @@ describe('useModelProviderState thinking on model selection', () => {
 
     provider.setThinking('max');
 
-    expect(apiMock.setConfig).toHaveBeenCalledWith({ thinking: { enabled: true, effort: 'max' } });
+    expect(apiMock.setConfig).toHaveBeenCalledWith({ thinking: { enabled: true } });
   });
 
   it('persists the thinking pick as the global default on a model switch', async () => {
@@ -579,7 +550,7 @@ describe('useModelProviderState thinking on model selection', () => {
 
     await provider.setModel(effortAppModel.id);
 
-    expect(apiMock.setConfig).toHaveBeenCalledWith({ thinking: { enabled: true, effort: 'high' } });
+    expect(apiMock.setConfig).toHaveBeenCalledWith({ thinking: { enabled: true } });
   });
 
   it('does not write the global thinking config when re-selecting the current model', async () => {

--- a/apps/kimi-web/src/lib/modelThinking.ts
+++ b/apps/kimi-web/src/lib/modelThinking.ts
@@ -105,32 +105,49 @@ export function effectiveThinkingLevel(
 }
 
 /**
+ * Effort levels eligible for persistence to config.toml, on the canonical
+ * scale `low/medium/high/xhigh/max` — the same mapping the TUI persists
+ * (thinkingEffortToConfig). `max` and any level outside the scale (custom
+ * provider-declared names) are session-only: they work at runtime but only
+ * the boolean toggle is persisted, so the most expensive tier never becomes
+ * the global default for every new session.
+ */
+export const PERSISTABLE_THINKING_EFFORTS: readonly string[] = ['low', 'medium', 'high', 'xhigh'];
+
+/**
  * Project a thinking level onto the daemon's `[thinking]` config section —
- * the same mapping the TUI persists (thinkingEffortToConfig): only the boolean
- * `enabled` flag is persisted. Picking a model or thinking level no longer
- * records the concrete effort; boolean models resolve back to 'on' at runtime
- * and effort-capable models fall back to their own default effort.
+ * the same mapping the TUI persists (thinkingEffortToConfig): 'off' disables
+ * thinking, boolean 'on' records only `enabled` (boolean models resolve back
+ * to 'on' at runtime), and a concrete effort is recorded as the global
+ * default when it is in {@link PERSISTABLE_THINKING_EFFORTS}.
  */
 export function thinkingLevelToConfig(level: ThinkingLevel): {
   enabled: boolean;
+  effort?: string;
 } {
-  return { enabled: level !== 'off' };
+  if (level === 'off') return { enabled: false };
+  if (level === 'on') return { enabled: true };
+  if (PERSISTABLE_THINKING_EFFORTS.includes(level)) return { enabled: true, effort: level };
+  return { enabled: true };
 }
 
 /**
  * Thinking level to use when the user picks a model in the switcher.
  * Mirrors the TUI model picker: re-selecting the current model keeps the live
  * level untouched (including "no preference"). Switching onto a different model
- * pre-selects that model's catalog default level. The carried-over level is
- * never coerced onto the target model.
+ * restores that model's own stored pick when the model still declares it
+ * (per-model seed), and otherwise pre-selects the model's default level.
+ * The carried-over level is never coerced onto the target model.
  */
 export function thinkingLevelForModelSwitch(
   model: ModelThinkingInfo | undefined,
   currentLevel: ThinkingLevel | undefined,
   isSwitch: boolean,
+  storedLevel?: ThinkingLevel,
 ): ThinkingLevel | undefined {
   // Target model unknown (catalog not loaded yet): keep the current level
   // as-is rather than guessing at capabilities.
   if (!isSwitch || model === undefined) return currentLevel;
+  if (storedLevel !== undefined && levelDeclaredBy(model, storedLevel)) return storedLevel;
   return defaultThinkingLevelFor(model);
 }

--- a/apps/kimi-web/src/lib/modelThinking.ts
+++ b/apps/kimi-web/src/lib/modelThinking.ts
@@ -106,37 +106,31 @@ export function effectiveThinkingLevel(
 
 /**
  * Project a thinking level onto the daemon's `[thinking]` config section —
- * the same mapping the TUI persists (thinkingEffortToConfig): 'off' disables
- * thinking, a concrete effort records it as the global default, and boolean
- * 'on' records only `enabled` (boolean models resolve back to 'on' at
- * runtime).
+ * the same mapping the TUI persists (thinkingEffortToConfig): only the boolean
+ * `enabled` flag is persisted. Picking a model or thinking level no longer
+ * records the concrete effort; boolean models resolve back to 'on' at runtime
+ * and effort-capable models fall back to their own default effort.
  */
 export function thinkingLevelToConfig(level: ThinkingLevel): {
   enabled: boolean;
-  effort?: string;
 } {
-  if (level === 'off') return { enabled: false };
-  if (level === 'on') return { enabled: true };
-  return { enabled: true, effort: level };
+  return { enabled: level !== 'off' };
 }
 
 /**
  * Thinking level to use when the user picks a model in the switcher.
  * Mirrors the TUI model picker: re-selecting the current model keeps the live
  * level untouched (including "no preference"). Switching onto a different model
- * restores that model's own stored pick when the model still declares it
- * (per-model persistence), and otherwise pre-selects the model's default level.
- * The carried-over level is never coerced onto the target model.
+ * pre-selects that model's catalog default level. The carried-over level is
+ * never coerced onto the target model.
  */
 export function thinkingLevelForModelSwitch(
   model: ModelThinkingInfo | undefined,
   currentLevel: ThinkingLevel | undefined,
   isSwitch: boolean,
-  storedLevel?: ThinkingLevel,
 ): ThinkingLevel | undefined {
   // Target model unknown (catalog not loaded yet): keep the current level
   // as-is rather than guessing at capabilities.
   if (!isSwitch || model === undefined) return currentLevel;
-  if (storedLevel !== undefined && levelDeclaredBy(model, storedLevel)) return storedLevel;
   return defaultThinkingLevelFor(model);
 }

--- a/apps/kimi-web/src/lib/modelThinking.ts
+++ b/apps/kimi-web/src/lib/modelThinking.ts
@@ -133,19 +133,16 @@ export function thinkingLevelToConfig(
  * Thinking level to use when the user picks a model in the switcher.
  * Mirrors the TUI model picker: re-selecting the current model keeps the live
  * level untouched (including "no preference"). Switching onto a different model
- * restores that model's own stored pick when the model still declares it
- * (per-model seed), and otherwise pre-selects the model's default level.
- * The carried-over level is never coerced onto the target model.
+ * pre-selects that model's catalog default level. The carried-over level is
+ * never coerced onto the target model.
  */
 export function thinkingLevelForModelSwitch(
   model: ModelThinkingInfo | undefined,
   currentLevel: ThinkingLevel | undefined,
   isSwitch: boolean,
-  storedLevel?: ThinkingLevel,
 ): ThinkingLevel | undefined {
   // Target model unknown (catalog not loaded yet): keep the current level
   // as-is rather than guessing at capabilities.
   if (!isSwitch || model === undefined) return currentLevel;
-  if (storedLevel !== undefined && levelDeclaredBy(model, storedLevel)) return storedLevel;
   return defaultThinkingLevelFor(model);
 }

--- a/apps/kimi-web/src/lib/modelThinking.ts
+++ b/apps/kimi-web/src/lib/modelThinking.ts
@@ -105,30 +105,28 @@ export function effectiveThinkingLevel(
 }
 
 /**
- * Effort levels eligible for persistence to config.toml, on the canonical
- * scale `low/medium/high/xhigh/max` — the same mapping the TUI persists
- * (thinkingEffortToConfig). `max` and any level outside the scale (custom
- * provider-declared names) are session-only: they work at runtime but only
- * the boolean toggle is persisted, so the most expensive tier never becomes
- * the global default for every new session.
- */
-export const PERSISTABLE_THINKING_EFFORTS: readonly string[] = ['low', 'medium', 'high', 'xhigh'];
-
-/**
  * Project a thinking level onto the daemon's `[thinking]` config section —
  * the same mapping the TUI persists (thinkingEffortToConfig): 'off' disables
  * thinking, boolean 'on' records only `enabled` (boolean models resolve back
  * to 'on' at runtime), and a concrete effort is recorded as the global
- * default when it is in {@link PERSISTABLE_THINKING_EFFORTS}.
+ * default — EXCEPT the model's highest declared level (the last entry of
+ * `support_efforts`, ordered by strength), which is session-only and records
+ * just `enabled`, so the most expensive tier never becomes the global
+ * default for every new session. When the model's levels are unknown the
+ * concrete level is persisted as-is.
  */
-export function thinkingLevelToConfig(level: ThinkingLevel): {
+export function thinkingLevelToConfig(
+  level: ThinkingLevel,
+  supportEfforts?: readonly string[],
+): {
   enabled: boolean;
   effort?: string;
 } {
   if (level === 'off') return { enabled: false };
   if (level === 'on') return { enabled: true };
-  if (PERSISTABLE_THINKING_EFFORTS.includes(level)) return { enabled: true, effort: level };
-  return { enabled: true };
+  const top = supportEfforts?.at(-1);
+  if (top !== undefined && level === top) return { enabled: true };
+  return { enabled: true, effort: level };
 }
 
 /**

--- a/apps/kimi-web/src/lib/storage.ts
+++ b/apps/kimi-web/src/lib/storage.ts
@@ -10,7 +10,6 @@ export const STORAGE_KEYS = {
   // useKimiWebClient
   permission: 'kimi-web.permission',
   activeWorkspace: 'kimi-active-workspace',
-  thinking: 'kimi-web.thinking',
   planMode: 'kimi-web.plan-mode',
   swarmMode: 'kimi-web.swarm-mode',
   goalMode: 'kimi-web.goal-mode',
@@ -45,6 +44,7 @@ export const STORAGE_KEYS = {
   codeFont: 'kimi-web.code-font',
   contentAlign: 'kimi-web.content-align',
   theme: 'kimi-web.theme',
+  thinking: 'kimi-web.thinking',
 } as const;
 
 /** Per-session composer draft key. */

--- a/apps/kimi-web/src/lib/storage.ts
+++ b/apps/kimi-web/src/lib/storage.ts
@@ -10,6 +10,7 @@ export const STORAGE_KEYS = {
   // useKimiWebClient
   permission: 'kimi-web.permission',
   activeWorkspace: 'kimi-active-workspace',
+  thinking: 'kimi-web.thinking',
   planMode: 'kimi-web.plan-mode',
   swarmMode: 'kimi-web.swarm-mode',
   goalMode: 'kimi-web.goal-mode',
@@ -44,7 +45,6 @@ export const STORAGE_KEYS = {
   codeFont: 'kimi-web.code-font',
   contentAlign: 'kimi-web.content-align',
   theme: 'kimi-web.theme',
-  thinking: 'kimi-web.thinking',
 } as const;
 
 /** Per-session composer draft key. */

--- a/apps/kimi-web/test/side-chat.test.ts
+++ b/apps/kimi-web/test/side-chat.test.ts
@@ -66,7 +66,7 @@ describe('useSideChat — sendSideChatPromptOn', () => {
       nextOptimisticMsgId: () => 'msg_opt_btw',
       connectEventsIfNeeded: vi.fn(),
       getEventConn: () => null,
-      thinkingLevelForModelId: () => undefined,
+      thinkingLevelForSessionId: () => undefined,
     });
 
     await sideChat.openSideChatOn('sess_1', 'what changed?');
@@ -87,7 +87,7 @@ describe('useSideChat — sendSideChatPromptOn', () => {
   });
 
   it('falls back to the active level when the parent model has left the catalog', async () => {
-    // thinkingLevelForModelId returns undefined for a model the catalog no
+    // thinkingLevelForSessionId returns undefined for a model the catalog no
     // longer lists — the submit then keeps the active-session level (same
     // fallback as the normal prompt paths).
     apiMock.startBtw.mockReset();
@@ -102,7 +102,7 @@ describe('useSideChat — sendSideChatPromptOn', () => {
       nextOptimisticMsgId: () => 'msg_opt_btw',
       connectEventsIfNeeded: vi.fn(),
       getEventConn: () => null,
-      thinkingLevelForModelId: () => undefined,
+      thinkingLevelForSessionId: () => undefined,
     });
 
     await sideChat.openSideChatOn('sess_1', 'what changed?');
@@ -129,7 +129,7 @@ describe('useSideChat — sendSideChatPromptOn', () => {
       nextOptimisticMsgId: () => 'msg_opt_btw',
       connectEventsIfNeeded: vi.fn(),
       getEventConn: () => null,
-      thinkingLevelForModelId: (id) => (id === 'kimi-code' ? 'low' : undefined),
+      thinkingLevelForSessionId: (_sid, id) => (id === 'kimi-code' ? 'low' : undefined),
     });
 
     await sideChat.openSideChatOn('sess_1', 'what changed?');

--- a/apps/kimi-web/test/side-chat.test.ts
+++ b/apps/kimi-web/test/side-chat.test.ts
@@ -66,7 +66,7 @@ describe('useSideChat — sendSideChatPromptOn', () => {
       nextOptimisticMsgId: () => 'msg_opt_btw',
       connectEventsIfNeeded: vi.fn(),
       getEventConn: () => null,
-      thinkingLevelForSessionId: () => undefined,
+      resolveThinkingForPrompt: async () => undefined,
     });
 
     await sideChat.openSideChatOn('sess_1', 'what changed?');
@@ -87,7 +87,7 @@ describe('useSideChat — sendSideChatPromptOn', () => {
   });
 
   it('falls back to the active level when the parent model has left the catalog', async () => {
-    // thinkingLevelForSessionId returns undefined for a model the catalog no
+    // resolveThinkingForPrompt returns undefined for a model the catalog no
     // longer lists — the submit then keeps the active-session level (same
     // fallback as the normal prompt paths).
     apiMock.startBtw.mockReset();
@@ -102,7 +102,7 @@ describe('useSideChat — sendSideChatPromptOn', () => {
       nextOptimisticMsgId: () => 'msg_opt_btw',
       connectEventsIfNeeded: vi.fn(),
       getEventConn: () => null,
-      thinkingLevelForSessionId: () => undefined,
+      resolveThinkingForPrompt: async () => undefined,
     });
 
     await sideChat.openSideChatOn('sess_1', 'what changed?');
@@ -129,7 +129,7 @@ describe('useSideChat — sendSideChatPromptOn', () => {
       nextOptimisticMsgId: () => 'msg_opt_btw',
       connectEventsIfNeeded: vi.fn(),
       getEventConn: () => null,
-      thinkingLevelForSessionId: (_sid, id) => (id === 'kimi-code' ? 'low' : undefined),
+      resolveThinkingForPrompt: async (_sid, id) => (id === 'kimi-code' ? 'low' : undefined),
     });
 
     await sideChat.openSideChatOn('sess_1', 'what changed?');

--- a/apps/kimi-web/test/workspace-state.test.ts
+++ b/apps/kimi-web/test/workspace-state.test.ts
@@ -79,6 +79,7 @@ function createState(): ExtendedState {
     connection: 'connected',
     permission: 'manual',
     thinking: 'high',
+    thinkingBySession: {},
     planModeBySession: {},
     swarmModeBySession: {},
     goalModeBySession: {},
@@ -761,6 +762,21 @@ describe('useWorkspaceState — startSessionAndActivateSkill', () => {
     // session switch can't redirect it.
     expect(activateSkill).toHaveBeenCalledWith('pre-changelog', undefined, 'sess_new');
     expect(deps.pushOperationFailure).not.toHaveBeenCalled();
+  });
+
+  it('carries the draft thinking pick into the new session own entry', async () => {
+    // A level picked on the empty composer has no session to live in yet; the
+    // draft transfer seeds it so the first action submits the pick, not the
+    // catalog default.
+    const activateSkill = vi.fn().mockResolvedValue(undefined);
+    const deps = skillDeps(activateSkill);
+    const state = createState();
+    state.thinking = 'max';
+    const ws = useWorkspaceState(state, deps);
+
+    await ws.startSessionAndActivateSkill('wd_1', 'pre-changelog');
+
+    expect(state.thinkingBySession['sess_new']).toBe('max');
   });
 
   it('passes through skill args', async () => {

--- a/apps/kimi-web/test/workspace-state.test.ts
+++ b/apps/kimi-web/test/workspace-state.test.ts
@@ -117,7 +117,7 @@ function createDeps(): UseWorkspaceStateDeps {
   return {
     taskPoller: {},
     sideChat: {},
-    modelProvider: { thinkingLevelForModelId: () => undefined },
+    modelProvider: { thinkingLevelForSessionId: () => undefined },
     pushOperationFailure: vi.fn(),
     activity: computed(() => 'running'),
     sessionsKnownEmpty: new Set(),
@@ -743,7 +743,7 @@ describe('useWorkspaceState — startSessionAndActivateSkill', () => {
         skillsBySession: ref({}),
         loadSkillsForSession: vi.fn(),
         activateSkill,
-        thinkingLevelForModelId: () => undefined,
+        thinkingLevelForSessionId: () => undefined,
       } as unknown as UseWorkspaceStateDeps['modelProvider'],
       mergedWorkspaces: computed(() => [workspace('wd_1', '/abs/path', 'A')]),
     };
@@ -887,7 +887,7 @@ describe('useWorkspaceState — createGoal from an empty composer', () => {
         draftModel: ref(null),
         skillsBySession: ref({}),
         loadSkillsForSession: vi.fn(),
-        thinkingLevelForModelId: () => undefined,
+        thinkingLevelForSessionId: () => undefined,
       } as unknown as UseWorkspaceStateDeps['modelProvider'],
       // Something the goal can land in + what's visible in the sidebar.
       mergedWorkspaces: computed(() => [workspace('wd_1', '/abs/path', 'A')]),
@@ -1050,7 +1050,7 @@ describe('useWorkspaceState — startSessionAndOpenSideChat', () => {
         draftModel: ref(null),
         skillsBySession: ref({}),
         loadSkillsForSession: vi.fn(),
-        thinkingLevelForModelId: () => undefined,
+        thinkingLevelForSessionId: () => undefined,
       } as unknown as UseWorkspaceStateDeps['modelProvider'],
       mergedWorkspaces: computed(() => [workspace('wd_1', '/abs/path', 'A')]),
     };
@@ -1525,7 +1525,7 @@ describe('useWorkspaceState — snapshot prompt recovery', () => {
       ...createDeps(),
       modelProvider: {
         models: ref([]),
-        thinkingLevelForModelId: () => undefined,
+        thinkingLevelForSessionId: () => undefined,
       } as unknown as UseWorkspaceStateDeps['modelProvider'],
       ...overrides,
     };
@@ -1730,7 +1730,7 @@ describe('useWorkspaceState — snapshot prompt recovery', () => {
     state.thinking = 'max'; // the global now tracks that session's max-only model
     state.inFlightBySession = { sess_a: true };
     state.queuedBySession = { sess_a: [{ text: 'follow up', attachments: undefined }] };
-    const thinkingLevelForModelId = vi.fn((id: string | undefined) =>
+    const thinkingLevelForSessionId = vi.fn((_sid: string | null, id: string | undefined) =>
       id === 'provider/model-a' ? 'low' : undefined,
     );
     const ws = useWorkspaceState(
@@ -1738,14 +1738,14 @@ describe('useWorkspaceState — snapshot prompt recovery', () => {
       promptDeps({
         modelProvider: {
           models: ref([]),
-          thinkingLevelForModelId,
+          thinkingLevelForSessionId,
         } as unknown as UseWorkspaceStateDeps['modelProvider'],
       }),
     );
 
     ws.handleSessionSnapshot('sess_a', { inFlightTurn: null, busy: true });
 
-    expect(thinkingLevelForModelId).toHaveBeenCalledWith('provider/model-a');
+    expect(thinkingLevelForSessionId).toHaveBeenCalledWith('sess_a', 'provider/model-a');
     expect(apiMock.submitPrompt).toHaveBeenCalledWith(
       'sess_a',
       expect.objectContaining({ model: 'provider/model-a', thinking: 'low' }),
@@ -1763,7 +1763,7 @@ describe('useWorkspaceState — snapshot prompt recovery', () => {
       promptDeps({
         modelProvider: {
           models: ref([]),
-          thinkingLevelForModelId: () => undefined,
+          thinkingLevelForSessionId: () => undefined,
         } as unknown as UseWorkspaceStateDeps['modelProvider'],
       }),
     );

--- a/apps/kimi-web/test/workspace-state.test.ts
+++ b/apps/kimi-web/test/workspace-state.test.ts
@@ -779,6 +779,32 @@ describe('useWorkspaceState — startSessionAndActivateSkill', () => {
     expect(state.thinkingBySession['sess_new']).toBe('max');
   });
 
+  it('captures the draft thinking pick before the creation awaits', async () => {
+    // A concurrent session switch mid-creation re-resolves rawState.thinking
+    // for the other session — the seed must come from the pre-await capture.
+    let resolveCreate!: (session: typeof newSession) => void;
+    apiMock.createSession.mockReturnValue(
+      new Promise<typeof newSession>((r) => {
+        resolveCreate = r;
+      }),
+    );
+    const activateSkill = vi.fn().mockResolvedValue(undefined);
+    const deps = skillDeps(activateSkill);
+    const state = createState();
+    state.thinking = 'max';
+    const ws = useWorkspaceState(state, deps);
+
+    const pending = ws.startSessionAndActivateSkill('wd_1', 'pre-changelog');
+    await new Promise((r) => setTimeout(r, 0));
+    // The user switches to another session while createSession is in flight;
+    // the watcher would re-resolve rawState.thinking to that session's level.
+    state.thinking = 'low';
+    resolveCreate(newSession);
+    await pending;
+
+    expect(state.thinkingBySession['sess_new']).toBe('max');
+  });
+
   it('passes through skill args', async () => {
     const activateSkill = vi.fn().mockResolvedValue(undefined);
     const deps = skillDeps(activateSkill);

--- a/apps/kimi-web/test/workspace-state.test.ts
+++ b/apps/kimi-web/test/workspace-state.test.ts
@@ -118,7 +118,7 @@ function createDeps(): UseWorkspaceStateDeps {
   return {
     taskPoller: {},
     sideChat: {},
-    modelProvider: { thinkingLevelForSessionId: () => undefined },
+    modelProvider: { resolveThinkingForPrompt: async () => undefined },
     pushOperationFailure: vi.fn(),
     activity: computed(() => 'running'),
     sessionsKnownEmpty: new Set(),
@@ -744,7 +744,7 @@ describe('useWorkspaceState — startSessionAndActivateSkill', () => {
         skillsBySession: ref({}),
         loadSkillsForSession: vi.fn(),
         activateSkill,
-        thinkingLevelForSessionId: () => undefined,
+        resolveThinkingForPrompt: async () => undefined,
       } as unknown as UseWorkspaceStateDeps['modelProvider'],
       mergedWorkspaces: computed(() => [workspace('wd_1', '/abs/path', 'A')]),
     };
@@ -929,7 +929,7 @@ describe('useWorkspaceState — createGoal from an empty composer', () => {
         draftModel: ref(null),
         skillsBySession: ref({}),
         loadSkillsForSession: vi.fn(),
-        thinkingLevelForSessionId: () => undefined,
+        resolveThinkingForPrompt: async () => undefined,
       } as unknown as UseWorkspaceStateDeps['modelProvider'],
       // Something the goal can land in + what's visible in the sidebar.
       mergedWorkspaces: computed(() => [workspace('wd_1', '/abs/path', 'A')]),
@@ -1092,7 +1092,7 @@ describe('useWorkspaceState — startSessionAndOpenSideChat', () => {
         draftModel: ref(null),
         skillsBySession: ref({}),
         loadSkillsForSession: vi.fn(),
-        thinkingLevelForSessionId: () => undefined,
+        resolveThinkingForPrompt: async () => undefined,
       } as unknown as UseWorkspaceStateDeps['modelProvider'],
       mergedWorkspaces: computed(() => [workspace('wd_1', '/abs/path', 'A')]),
     };
@@ -1567,7 +1567,7 @@ describe('useWorkspaceState — snapshot prompt recovery', () => {
       ...createDeps(),
       modelProvider: {
         models: ref([]),
-        thinkingLevelForSessionId: () => undefined,
+        resolveThinkingForPrompt: async () => undefined,
       } as unknown as UseWorkspaceStateDeps['modelProvider'],
       ...overrides,
     };
@@ -1630,7 +1630,7 @@ describe('useWorkspaceState — snapshot prompt recovery', () => {
 
     ws.handleSessionSnapshot('sess_1', { inFlightTurn: null, busy: true });
 
-    expect(apiMock.submitPrompt).toHaveBeenCalledOnce();
+    await vi.waitFor(() => expect(apiMock.submitPrompt).toHaveBeenCalledOnce());
     expect(state.queuedBySession.sess_1).toEqual([
       { text: 'second queued', attachments: undefined },
     ]);
@@ -1653,7 +1653,7 @@ describe('useWorkspaceState — snapshot prompt recovery', () => {
     );
   });
 
-  it('drains one queued prompt when the finished turn was locally witnessed', () => {
+  it('drains one queued prompt when the finished turn was locally witnessed', async () => {
     const state = createState();
     state.queuedBySession = {
       sess_1: [
@@ -1665,7 +1665,7 @@ describe('useWorkspaceState — snapshot prompt recovery', () => {
 
     ws.finishPromptLocal('sess_1', { turnWasActive: true });
 
-    expect(apiMock.submitPrompt).toHaveBeenCalledOnce();
+    await vi.waitFor(() => expect(apiMock.submitPrompt).toHaveBeenCalledOnce());
     expect(state.queuedBySession.sess_1).toEqual([
       { text: 'second queued', attachments: undefined },
     ]);
@@ -1772,7 +1772,7 @@ describe('useWorkspaceState — snapshot prompt recovery', () => {
     state.thinking = 'max'; // the global now tracks that session's max-only model
     state.inFlightBySession = { sess_a: true };
     state.queuedBySession = { sess_a: [{ text: 'follow up', attachments: undefined }] };
-    const thinkingLevelForSessionId = vi.fn((_sid: string | null, id: string | undefined) =>
+    const resolveThinkingForPrompt = vi.fn(async (_sid: string | null, id: string | undefined) =>
       id === 'provider/model-a' ? 'low' : undefined,
     );
     const ws = useWorkspaceState(
@@ -1780,14 +1780,15 @@ describe('useWorkspaceState — snapshot prompt recovery', () => {
       promptDeps({
         modelProvider: {
           models: ref([]),
-          thinkingLevelForSessionId,
+          resolveThinkingForPrompt,
         } as unknown as UseWorkspaceStateDeps['modelProvider'],
       }),
     );
 
     ws.handleSessionSnapshot('sess_a', { inFlightTurn: null, busy: true });
 
-    expect(thinkingLevelForSessionId).toHaveBeenCalledWith('sess_a', 'provider/model-a');
+    await vi.waitFor(() => expect(apiMock.submitPrompt).toHaveBeenCalled());
+    expect(resolveThinkingForPrompt).toHaveBeenCalledWith('sess_a', 'provider/model-a');
     expect(apiMock.submitPrompt).toHaveBeenCalledWith(
       'sess_a',
       expect.objectContaining({ model: 'provider/model-a', thinking: 'low' }),
@@ -1805,13 +1806,14 @@ describe('useWorkspaceState — snapshot prompt recovery', () => {
       promptDeps({
         modelProvider: {
           models: ref([]),
-          thinkingLevelForSessionId: () => undefined,
+          resolveThinkingForPrompt: async () => undefined,
         } as unknown as UseWorkspaceStateDeps['modelProvider'],
       }),
     );
 
     ws.handleSessionSnapshot('sess_a', { inFlightTurn: null, busy: true });
 
+    await vi.waitFor(() => expect(apiMock.submitPrompt).toHaveBeenCalled());
     expect(apiMock.submitPrompt).toHaveBeenCalledWith(
       'sess_a',
       expect.objectContaining({ model: 'provider/gone-model', thinking: 'max' }),
@@ -1862,6 +1864,7 @@ describe('useWorkspaceState — snapshot prompt recovery', () => {
     ws.afterLocalTurnStartsSettle('sess_1', retrySnapshot);
     expect(retrySnapshot).not.toHaveBeenCalled();
 
+    await vi.waitFor(() => expect(apiMock.submitPrompt).toHaveBeenCalled());
     resolveSubmit({ promptId: 'prompt_new' });
     await pendingSubmit;
     expect(ws.localTurnStartState('sess_1').pending).toBe(false);
@@ -2008,6 +2011,7 @@ describe('useWorkspaceState — snapshot prompt recovery', () => {
 
     // Facade forget path (e.g. archive) while the submit is pending. The
     // daemon definitively rejects afterwards — even then, no resurrection.
+    await vi.waitFor(() => expect(apiMock.submitPrompt).toHaveBeenCalled());
     state.sessions = [];
     delete state.queuedBySession.sess_1;
     rejectSubmit(new DaemonApiError({ code: 50000, msg: 'network down', requestId: 'r' }));

--- a/packages/agent-core-v2/src/app/config/configService.ts
+++ b/packages/agent-core-v2/src/app/config/configService.ts
@@ -50,6 +50,7 @@ import {
 import { deepEqual, deepMerge, describeUnknownError, isPlainObject } from './configPure';
 import { getConfigSectionContributions } from './configSectionContributions';
 import { getConfigOverlayContributions } from './configOverlayContributions';
+import { migrateThinkingEffortMaxToHigh } from './migrations';
 import {
   applySectionToToml,
   camelToSnake,
@@ -242,7 +243,14 @@ export class ConfigService extends Disposable implements IConfigService {
     this.configKey = this.bootstrap.configKey;
     this._register(this.registry.onDidRegisterSection((e) => this.revalidateDomain(e.domain)));
     this._register(this.registry.onDidRegisterOverlay(() => this.reapplyOverlays()));
-    this.ready = this.load('load');
+    // One-shot config migrations run before the first load (best-effort, never
+    // throws): rewrites a persisted thinking.effort "max" to "high" once.
+    const { configKey } = this;
+    const { homeDir } = this.bootstrap;
+    this.ready = (async () => {
+      await migrateThinkingEffortMaxToHigh(this.documentStore, configKey, homeDir);
+      await this.load('load');
+    })();
     this._register(
       this.documentStore.watch(CONFIG_SCOPE, this.configKey)(() => {
         void this.reload();

--- a/packages/agent-core-v2/src/app/config/migrations.ts
+++ b/packages/agent-core-v2/src/app/config/migrations.ts
@@ -1,11 +1,11 @@
 /**
  * One-shot config migrations — mirror of agent-core's `config/migrations.ts`
  * (the two engines share neither code nor config abstractions, only the
- * on-disk `config.toml` and the `<home>/migrations.json` marker format).
- * Each migration runs at most once per kimi home: a marker records completion
- * (ISO timestamp), so a value the user re-sets by hand afterwards is never
- * migrated again. Best-effort and never throws — a migration must never block
- * startup.
+ * on-disk `config.toml` and the `<home>/migrations-effort.json` marker
+ * format). Each migration runs at most once per kimi home: a marker records
+ * completion (ISO timestamp), so a value the user re-sets by hand afterwards
+ * is never migrated again. Best-effort and never throws — a migration must
+ * never block startup.
  */
 import { mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { join } from 'pathe';
@@ -14,7 +14,7 @@ import { type IAtomicDocumentStore } from '#/persistence/interface/atomicDocumen
 
 import { isPlainObject } from './configPure';
 
-const MIGRATIONS_FILE = 'migrations.json';
+const MIGRATIONS_FILE = 'migrations-effort.json';
 const THINKING_EFFORT_MAX_TO_HIGH = 'thinking-effort-max-to-high';
 const CONFIG_SCOPE = '';
 

--- a/packages/agent-core-v2/src/app/config/migrations.ts
+++ b/packages/agent-core-v2/src/app/config/migrations.ts
@@ -1,0 +1,74 @@
+/**
+ * One-shot config migrations — mirror of agent-core's `config/migrations.ts`
+ * (the two engines share neither code nor config abstractions, only the
+ * on-disk `config.toml` and the `<home>/migrations.json` marker format).
+ * Each migration runs at most once per kimi home: a marker records completion
+ * (ISO timestamp), so a value the user re-sets by hand afterwards is never
+ * migrated again. Best-effort and never throws — a migration must never block
+ * startup.
+ */
+import { mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { join } from 'pathe';
+
+import { type IAtomicDocumentStore } from '#/persistence/interface/atomicDocumentStore';
+
+import { isPlainObject } from './configPure';
+
+const MIGRATIONS_FILE = 'migrations.json';
+const THINKING_EFFORT_MAX_TO_HIGH = 'thinking-effort-max-to-high';
+const CONFIG_SCOPE = '';
+
+function readMigrationMarkers(homeDir: string): Record<string, string> {
+  try {
+    const parsed: unknown = JSON.parse(readFileSync(join(homeDir, MIGRATIONS_FILE), 'utf-8'));
+    if (isPlainObject(parsed)) return parsed as Record<string, string>;
+  } catch {
+    // Missing or corrupt marker file — treated as "no migrations done".
+  }
+  return {};
+}
+
+function writeMigrationMarker(homeDir: string, key: string): void {
+  try {
+    mkdirSync(homeDir, { recursive: true, mode: 0o700 });
+    const markers = readMigrationMarkers(homeDir);
+    markers[key] = new Date().toISOString();
+    writeFileSync(join(homeDir, MIGRATIONS_FILE), `${JSON.stringify(markers, null, 2)}\n`, {
+      mode: 0o600,
+    });
+  } catch {
+    // A lost marker only means the check runs once more — harmless.
+  }
+}
+
+/**
+ * Persisted `thinking.effort = "max"` dates from when the UI recorded any pick
+ * unconditionally. `max` is session-only now, so rewrite it to `"high"` once.
+ * Skipped when the marker exists; a config document that cannot be read is
+ * left untouched AND unmarked so the next start retries. All other values —
+ * and a `max` the user writes by hand after the migration — are honored as-is.
+ */
+export async function migrateThinkingEffortMaxToHigh(
+  documentStore: IAtomicDocumentStore,
+  configKey: string,
+  homeDir: string,
+): Promise<void> {
+  try {
+    if (readMigrationMarkers(homeDir)[THINKING_EFFORT_MAX_TO_HIGH] !== undefined) return;
+    let doc: Record<string, unknown> | undefined;
+    try {
+      const data = await documentStore.get<Record<string, unknown>>(CONFIG_SCOPE, configKey);
+      doc = data !== undefined && isPlainObject(data) ? data : {};
+    } catch {
+      return; // Unreadable config: no marker, retry on the next start.
+    }
+    const thinking = doc['thinking'];
+    if (isPlainObject(thinking) && thinking['effort'] === 'max') {
+      doc['thinking'] = { ...thinking, effort: 'high' };
+      await documentStore.set(CONFIG_SCOPE, configKey, doc);
+    }
+    writeMigrationMarker(homeDir, THINKING_EFFORT_MAX_TO_HIGH);
+  } catch {
+    // Best-effort: never block startup on a migration.
+  }
+}

--- a/packages/agent-core-v2/test/app/config/config.test.ts
+++ b/packages/agent-core-v2/test/app/config/config.test.ts
@@ -740,7 +740,7 @@ describe('ConfigService thinking effort max migration', () => {
   }
 
   function readMarkers(): Record<string, string> {
-    return JSON.parse(readFileSync(join(homeDir, 'migrations.json'), 'utf-8')) as Record<
+    return JSON.parse(readFileSync(join(homeDir, 'migrations-effort.json'), 'utf-8')) as Record<
       string,
       string
     >;
@@ -762,7 +762,7 @@ describe('ConfigService thinking effort max migration', () => {
 
   it('honors a hand-set max once the marker exists', async () => {
     writeFileSync(
-      join(homeDir, 'migrations.json'),
+      join(homeDir, 'migrations-effort.json'),
       JSON.stringify({ 'thinking-effort-max-to-high': new Date().toISOString() }),
     );
     const { config, disposables } = await createMigratingConfig('[thinking]\neffort = "max"\n');

--- a/packages/agent-core-v2/test/app/config/config.test.ts
+++ b/packages/agent-core-v2/test/app/config/config.test.ts
@@ -9,6 +9,9 @@
 
 import type { ModelCapability } from '#/app/llmProtocol/capability';
 import type { ToolCall } from '#/app/llmProtocol/message';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'pathe';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 import { IAgentProfileService, type ResolvedAgentProfile } from '#/agent/profile/profile';
@@ -708,3 +711,73 @@ function toolNames(value: unknown): string[] {
     })
     .filter((name): name is string => name !== null);
 }
+
+describe('ConfigService thinking effort max migration', () => {
+  let homeDir: string;
+
+  beforeEach(() => {
+    homeDir = mkdtempSync(join(tmpdir(), 'kimi-v2-cfg-migrate-'));
+  });
+
+  afterEach(() => {
+    rmSync(homeDir, { recursive: true, force: true });
+  });
+
+  async function createMigratingConfig(toml: string) {
+    const disposables = new DisposableStore();
+    const ix = disposables.add(new TestInstantiationService());
+    const storage = new InMemoryStorageService();
+    await storage.write('', 'config.toml', new TextEncoder().encode(toml));
+    ix.stub(ILogService, stubLog());
+    ix.stub(IBootstrapService, stubBootstrap(homeDir));
+    ix.stub(IFileSystemStorageService, storage);
+    ix.set(IAtomicTomlDocumentStore, new SyncDescriptor(TomlAtomicDocumentStore));
+    ix.set(IConfigRegistry, new SyncDescriptor(ConfigRegistry));
+    ix.set(IConfigService, new SyncDescriptor(ConfigService));
+    const config = ix.get(IConfigService);
+    await config.ready;
+    return { config, disposables };
+  }
+
+  function readMarkers(): Record<string, string> {
+    return JSON.parse(readFileSync(join(homeDir, 'migrations.json'), 'utf-8')) as Record<
+      string,
+      string
+    >;
+  }
+
+  it('rewrites a persisted max to high on first load and records the marker', async () => {
+    const { config, disposables } = await createMigratingConfig(
+      '[thinking]\nenabled = true\neffort = "max"\n',
+    );
+
+    expect(config.get<ThinkingConfig>(THINKING_SECTION)).toEqual({
+      enabled: true,
+      effort: 'high',
+    });
+    expect(readMarkers()['thinking-effort-max-to-high']).toBeDefined();
+
+    disposables.dispose();
+  });
+
+  it('honors a hand-set max once the marker exists', async () => {
+    writeFileSync(
+      join(homeDir, 'migrations.json'),
+      JSON.stringify({ 'thinking-effort-max-to-high': new Date().toISOString() }),
+    );
+    const { config, disposables } = await createMigratingConfig('[thinking]\neffort = "max"\n');
+
+    expect(config.get<ThinkingConfig>(THINKING_SECTION)).toEqual({ effort: 'max' });
+
+    disposables.dispose();
+  });
+
+  it('records the marker even when nothing needs migrating', async () => {
+    const { config, disposables } = await createMigratingConfig('[thinking]\neffort = "low"\n');
+
+    expect(config.get<ThinkingConfig>(THINKING_SECTION)).toEqual({ effort: 'low' });
+    expect(readMarkers()['thinking-effort-max-to-high']).toBeDefined();
+
+    disposables.dispose();
+  });
+});

--- a/packages/agent-core/src/config/index.ts
+++ b/packages/agent-core/src/config/index.ts
@@ -1,5 +1,6 @@
 export * from './merge';
 export * from './model';
+export * from './migrations';
 export * from './path';
 export * from './print-defaults';
 export * from './resolve';

--- a/packages/agent-core/src/config/migrations.ts
+++ b/packages/agent-core/src/config/migrations.ts
@@ -1,0 +1,78 @@
+/**
+ * One-shot config migrations. Each migration runs at most once per kimi home:
+ * a marker in `<home>/migrations.json` records completion (ISO timestamp), so
+ * a value the user re-sets by hand afterwards is never migrated again. All
+ * helpers are best-effort and never throw — a migration must never block
+ * startup.
+ */
+import { existsSync, readFileSync, renameSync, writeFileSync } from 'node:fs';
+
+import { join } from 'pathe';
+import { stringify as stringifyToml } from 'smol-toml';
+
+import { ensureKimiHome } from './path';
+import { configToTomlData, readConfigFileForUpdate } from './toml';
+import { validateConfig } from './schema';
+
+const MIGRATIONS_FILE = 'migrations.json';
+const THINKING_EFFORT_MAX_TO_HIGH = 'thinking-effort-max-to-high';
+
+function readMigrationMarkers(homeDir: string): Record<string, string> {
+  try {
+    const parsed: unknown = JSON.parse(readFileSync(join(homeDir, MIGRATIONS_FILE), 'utf-8'));
+    if (parsed !== null && typeof parsed === 'object' && !Array.isArray(parsed)) {
+      return parsed as Record<string, string>;
+    }
+  } catch {
+    // Missing or corrupt marker file — treated as "no migrations done".
+  }
+  return {};
+}
+
+function writeMigrationMarker(homeDir: string, key: string): void {
+  try {
+    ensureKimiHome(homeDir);
+    const markers = readMigrationMarkers(homeDir);
+    markers[key] = new Date().toISOString();
+    writeFileSync(join(homeDir, MIGRATIONS_FILE), `${JSON.stringify(markers, null, 2)}\n`, {
+      mode: 0o600,
+    });
+  } catch {
+    // A lost marker only means the check runs once more — harmless.
+  }
+}
+
+/**
+ * Persisted `thinking.effort = "max"` dates from when the UI recorded any pick
+ * unconditionally. `max` is session-only now, so rewrite it to `"high"` once.
+ * Skipped when the marker exists; a config that cannot be parsed is left
+ * untouched AND unmarked so the next start retries. All other values — and a
+ * `max` the user writes by hand after the migration — are honored as-is.
+ */
+export function migrateThinkingEffortMaxToHigh(configPath: string, homeDir: string): void {
+  try {
+    if (readMigrationMarkers(homeDir)[THINKING_EFFORT_MAX_TO_HIGH] !== undefined) return;
+    if (!existsSync(configPath)) {
+      writeMigrationMarker(homeDir, THINKING_EFFORT_MAX_TO_HIGH);
+      return;
+    }
+    let config;
+    try {
+      config = readConfigFileForUpdate(configPath);
+    } catch {
+      return; // Unreadable config: no marker, retry on the next start.
+    }
+    if (config.thinking?.effort === 'max') {
+      const validated = validateConfig({
+        ...config,
+        thinking: { ...config.thinking, effort: 'high' },
+      });
+      const tmp = `${configPath}.migrate-${process.pid}-${Date.now()}`;
+      writeFileSync(tmp, `${stringifyToml(configToTomlData(validated))}\n`, { mode: 0o600 });
+      renameSync(tmp, configPath);
+    }
+    writeMigrationMarker(homeDir, THINKING_EFFORT_MAX_TO_HIGH);
+  } catch {
+    // Best-effort: never block startup on a migration.
+  }
+}

--- a/packages/agent-core/src/config/migrations.ts
+++ b/packages/agent-core/src/config/migrations.ts
@@ -1,9 +1,9 @@
 /**
  * One-shot config migrations. Each migration runs at most once per kimi home:
- * a marker in `<home>/migrations.json` records completion (ISO timestamp), so
- * a value the user re-sets by hand afterwards is never migrated again. All
- * helpers are best-effort and never throw — a migration must never block
- * startup.
+ * a marker in `<home>/migrations-effort.json` records completion (ISO
+ * timestamp), so a value the user re-sets by hand afterwards is never
+ * migrated again. All helpers are best-effort and never throw — a migration
+ * must never block startup.
  */
 import { existsSync, readFileSync, renameSync, writeFileSync } from 'node:fs';
 
@@ -14,7 +14,7 @@ import { ensureKimiHome } from './path';
 import { configToTomlData, readConfigFileForUpdate } from './toml';
 import { validateConfig } from './schema';
 
-const MIGRATIONS_FILE = 'migrations.json';
+const MIGRATIONS_FILE = 'migrations-effort.json';
 const THINKING_EFFORT_MAX_TO_HIGH = 'thinking-effort-max-to-high';
 
 function readMigrationMarkers(homeDir: string): Record<string, string> {

--- a/packages/agent-core/src/rpc/core-impl.ts
+++ b/packages/agent-core/src/rpc/core-impl.ts
@@ -17,6 +17,7 @@ import {
   ensureKimiHome,
   loadRuntimeConfigSafe,
   mergeConfigPatch,
+  migrateThinkingEffortMaxToHigh,
   readConfigFileForUpdate,
   normalizeAdditionalDirs,
   readWorkspaceAdditionalDirs,
@@ -238,6 +239,9 @@ export class KimiCore implements PromisableMethods<CoreAPI> {
     this.appVersion = options.appVersion;
     this.printMode = options.uiMode === 'print';
     ensureKimiHome(this.homeDir);
+    // One-shot config migrations, before the first load (best-effort, never
+    // throws): rewrites a persisted thinking.effort "max" to "high" once.
+    migrateThinkingEffortMaxToHigh(this.configPath, this.homeDir);
     // Schema errors degrade (invalid sections are dropped with warnings) so a
     // typo cannot prevent startup, but a file that cannot be used at all —
     // TOML syntax error, unreadable — fails fast: defaults-only would start

--- a/packages/agent-core/test/config/configs.test.ts
+++ b/packages/agent-core/test/config/configs.test.ts
@@ -967,7 +967,7 @@ describe('migrateThinkingEffortMaxToHigh', () => {
     'default_model = "x"\n[providers.x]\ntype = "kimi"\napi_key = "k"\n[models.x]\nprovider = "x"\nmodel = "x"\nmax_context_size = 1000\n';
 
   async function readMarkers(home: string): Promise<Record<string, string>> {
-    return JSON.parse(await readFile(join(home, 'migrations.json'), 'utf-8')) as Record<
+    return JSON.parse(await readFile(join(home, 'migrations-effort.json'), 'utf-8')) as Record<
       string,
       string
     >;
@@ -1018,6 +1018,6 @@ describe('migrateThinkingEffortMaxToHigh', () => {
 
     migrateThinkingEffortMaxToHigh(configPath, home);
 
-    await expect(readFile(join(home, 'migrations.json'), 'utf-8')).rejects.toThrow();
+    await expect(readFile(join(home, 'migrations-effort.json'), 'utf-8')).rejects.toThrow();
   });
 });

--- a/packages/agent-core/test/config/configs.test.ts
+++ b/packages/agent-core/test/config/configs.test.ts
@@ -14,6 +14,7 @@ import {
   loadRuntimeConfig,
   loadRuntimeConfigSafe,
   mergeConfigPatch,
+  migrateThinkingEffortMaxToHigh,
   parseConfigString,
   parseBooleanEnv,
   readConfigFile,
@@ -958,5 +959,65 @@ describe('applyPrintModeConfigDefaults', () => {
     expect(config.background?.bashTaskTimeoutS).toBe(30);
     expect(config.background?.keepAliveOnExit).toBe(true);
     expect(config.subagent?.timeoutMs).toBe(5000);
+  });
+});
+
+describe('migrateThinkingEffortMaxToHigh', () => {
+  const BASE =
+    'default_model = "x"\n[providers.x]\ntype = "kimi"\napi_key = "k"\n[models.x]\nprovider = "x"\nmodel = "x"\nmax_context_size = 1000\n';
+
+  async function readMarkers(home: string): Promise<Record<string, string>> {
+    return JSON.parse(await readFile(join(home, 'migrations.json'), 'utf-8')) as Record<
+      string,
+      string
+    >;
+  }
+
+  it('rewrites a persisted max to high once and records the marker', async () => {
+    const home = makeTempDir();
+    const configPath = join(home, 'config.toml');
+    await writeFile(configPath, `${BASE}[thinking]\nenabled = true\neffort = "max"\n`);
+
+    migrateThinkingEffortMaxToHigh(configPath, home);
+
+    expect(readConfigFile(configPath).thinking).toEqual({ enabled: true, effort: 'high' });
+    const markers = await readMarkers(home);
+    expect(markers['thinking-effort-max-to-high']).toBeDefined();
+
+    // A max the user writes by hand AFTER the migration is honored — the
+    // marker makes every later run a no-op.
+    await writeFile(configPath, `${BASE}[thinking]\neffort = "max"\n`);
+    migrateThinkingEffortMaxToHigh(configPath, home);
+    expect(readConfigFile(configPath).thinking?.effort).toBe('max');
+  });
+
+  it('leaves non-max values untouched and still records the marker', async () => {
+    const home = makeTempDir();
+    const configPath = join(home, 'config.toml');
+    await writeFile(configPath, `${BASE}[thinking]\neffort = "low"\n`);
+
+    migrateThinkingEffortMaxToHigh(configPath, home);
+
+    expect(readConfigFile(configPath).thinking?.effort).toBe('low');
+    const markers = await readMarkers(home);
+    expect(markers['thinking-effort-max-to-high']).toBeDefined();
+  });
+
+  it('marks a home without a config file as migrated', async () => {
+    const home = makeTempDir();
+    migrateThinkingEffortMaxToHigh(join(home, 'config.toml'), home);
+
+    const markers = await readMarkers(home);
+    expect(markers['thinking-effort-max-to-high']).toBeDefined();
+  });
+
+  it('skips an unparsable config without writing the marker', async () => {
+    const home = makeTempDir();
+    const configPath = join(home, 'config.toml');
+    await writeFile(configPath, 'not = [valid = toml\n');
+
+    migrateThinkingEffortMaxToHigh(configPath, home);
+
+    await expect(readFile(join(home, 'migrations.json'), 'utf-8')).rejects.toThrow();
   });
 });


### PR DESCRIPTION
## Related Issue

None — the problem is explained below.

## Problem

Thinking effort used to be persisted wholesale: any pick in the TUI or the web UI wrote the concrete effort to `thinking.effort` in config.toml as the global default for every future session, and the web UI additionally kept the level as a browser-wide per-model pick that leaked across sessions. Picking `max` once made every new session run at `max` forever; picking `high` in one session silently changed what an older session displayed and submitted.

## What changed

- **Picker re-confirm is not a choice (TUI).** Confirming the effort value shown when the model/effort picker opened no longer writes it to the config — only a deliberate change persists (the model itself is still saved on a switch).
- **Bounded persistence.** Picking a model or thinking level persists the concrete effort only when it is below the model's highest declared level (the last entry of its `support_efforts`). The top tier is session-only — only the boolean `thinking.enabled` toggle is saved, so the most expensive level never becomes the default for every new session. A manually configured `thinking.effort` is still honored.
- **One-time migration.** A previously persisted `thinking.effort = "max"` is rewritten to `"high"` exactly once per installation (recorded in `migrations-effort.json`); a `max` written by hand afterwards is left alone.
- **Per-session thinking in the web UI.** Each session's own daemon-reported level (session status endpoint + live status events) is restored when switching sessions and is what prompts submit, including queued and side-chat prompts. The browser-local per-model pick store is removed entirely (the stale key is cleaned up on startup); new sessions start at the model's default level.
- `KIMI_MODEL_THINKING_EFFORT` stays a pure runtime override and can never reach config.toml (covered by existing round-trip tests).
- Tests updated and added in the CLI, the web UI, and both agent engines.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update. (Docs only describe the `[thinking]` config fields, which remain valid; the persistence policy of UI picks was not documented.)



