### PR TITLE
fix(acp-adapter): replay custom tools through structured ACP channels

### DIFF
--- a/packages/acp-adapter/src/convert.ts
+++ b/packages/acp-adapter/src/convert.ts
@@ -323,3 +323,119 @@ export function toolResultToAcpContent(event: ToolResultEvent): ToolCallContent[
   if (!text) return [];
   return [{ type: 'content', content: { type: 'text', text } }];
 }
+
+// ---------------------------------------------------------------------------
+// Replay-side structured-tool helpers (fix/acp-replay-structured-tools)
+//
+// The history replay path flattens every tool into tool_call + raw output
+// text. For the three custom-tool families below the live path emits rich
+// channels (TodoList → ACP plan, AskUserQuestion → question bridge, Agent →
+// subagent events), so a raw text dump is a semantic downgrade AND a visible
+// one (JSON envelopes / agent_id preludes shown as assistant text). These
+// helpers shape the replayed args/results into the same wire semantics —
+// or return null to fall back to the generic tool_call dump.
+// ---------------------------------------------------------------------------
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+/**
+ * Extract TodoList items from a replayed call's parsed args
+ * (`{todos: [{title, status}]}` — Claude-style `{content, status:
+ * 'completed'}` variants are normalized into the kosong shape). Returns
+ * `null` when the args do not carry a well-formed todos array so the
+ * caller falls back to the generic tool_call dump.
+ */
+export function todoItemsFromToolArgs(args: unknown): ReadonlyArray<{ title: string; status: string }> | null {
+  if (!isRecord(args)) return null;
+  const todos = args['todos'];
+  if (!Array.isArray(todos)) return null;
+  const items: Array<{ title: string; status: string }> = [];
+  for (const entry of todos) {
+    if (!isRecord(entry)) return null;
+    const title = typeof entry['title'] === 'string' ? entry['title'] : typeof entry['content'] === 'string' ? entry['content'] : null;
+    const rawStatus = typeof entry['status'] === 'string' ? entry['status'] : entry['completed'] === true ? 'done' : null;
+    if (title === null || rawStatus === null) return null;
+    items.push({ title, status: rawStatus });
+  }
+  return items;
+}
+
+/**
+ * Extract AskUserQuestion prompts from a replayed call's parsed args
+ * (`{questions: [{question, ...}]}`). Returns `null` on shape mismatch
+ * (generic fallback).
+ */
+export function questionsFromToolArgs(args: unknown): readonly string[] | null {
+  if (!isRecord(args)) return null;
+  const questions = args['questions'];
+  if (!Array.isArray(questions) || questions.length === 0) return null;
+  const out: string[] = [];
+  for (const entry of questions) {
+    if (!isRecord(entry) || typeof entry['question'] !== 'string') return null;
+    out.push(entry['question']);
+  }
+  return out;
+}
+
+/**
+ * Shape an AskUserQuestion tool RESULT (`{"answers":{...}}` or
+ * `{answers:{}, note: "User dismissed…"}`) into a one-line human summary.
+ * The full JSON goes to `rawOutput` (structured over pre-rendered text,
+ * per the replay principle); content text becomes a single line:
+ * the dismiss note, or `Answered: <labels>`. Returns `null` when the
+ * text is not the question envelope (generic fallback).
+ */
+export function summarizeQuestionResult(resultText: string): { summary: string; rawOutput: string } | null {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(resultText);
+  } catch {
+    return null;
+  }
+  if (!isRecord(parsed) || !isRecord(parsed['answers'])) return null;
+  const answers = parsed['answers'];
+  const note = typeof parsed['note'] === 'string' ? parsed['note'] : null;
+  if (Object.keys(answers).length === 0) {
+    return { summary: note ?? 'Question dismissed.', rawOutput: resultText };
+  }
+  const labels: string[] = [];
+  for (const value of Object.values(answers)) {
+    if (typeof value === 'string') {
+      labels.push(value);
+    } else if (isRecord(value)) {
+      const optionId = typeof value['option_id'] === 'string' ? value['option_id'] : null;
+      const text = typeof value['text'] === 'string' ? value['text'] : null;
+      if (optionId !== null) labels.push(optionId);
+      else if (text !== null) labels.push(text);
+    }
+  }
+  const summary = labels.length > 0 ? `Answered: ${labels.join(', ')}` : 'Question answered.';
+  return { summary, rawOutput: resultText };
+}
+
+/**
+ * Strip the Agent tool's result envelope prelude
+ * (`agent_id: X\nactual_subagent_type: Y\nstatus: Z\n\n[summary]\n…`)
+ * off a replayed result, returning the subagent's final summary text
+ * only. `rawOutput` keeps the full original text. Returns `null` when
+ * no envelope is present (generic fallback).
+ */
+export function extractAgentSummary(resultText: string): { summary: string; rawOutput: string } | null {
+  if (!resultText.startsWith('agent_id: ')) return null;
+  const lines = resultText.split('\n');
+  let index = 0;
+  // Drop leading `key: value` header lines (agent_id / actual_subagent_type
+  // / status), blank lines, and the literal `[summary]` marker.
+  while (index < lines.length) {
+    const line = lines[index]!;
+    if (/^\w[\w ]*:/.test(line) || line.trim() === '' || line.trim() === '[summary]') {
+      index += 1;
+      continue;
+    }
+    break;
+  }
+  if (index === 0 || index >= lines.length) return null;
+  return { summary: lines.slice(index).join('\n').trimEnd(), rawOutput: resultText };
+}

--- a/packages/acp-adapter/src/session.ts
+++ b/packages/acp-adapter/src/session.ts
@@ -39,7 +39,14 @@ import {
 } from './builtin-commands';
 import { buildSessionConfigOptions } from './config-options';
 import { listModelsFromHarness } from './model-catalog';
-import { acpBlocksToPromptParts, compressPromptImageParts } from './convert';
+import {
+  acpBlocksToPromptParts,
+  compressPromptImageParts,
+  extractAgentSummary,
+  questionsFromToolArgs,
+  summarizeQuestionResult,
+  todoItemsFromToolArgs,
+} from './convert';
 import {
   acpToolCallId,
   assistantDeltaToSessionUpdate,
@@ -47,6 +54,7 @@ import {
   planFromDisplayBlock,
   stringifyArgs,
   thinkingDeltaToSessionUpdate,
+  todoListToSessionUpdate,
   toolCallDeltaToSessionUpdate,
   toolCallLazyCreateToSessionUpdate,
   toolCallStartedUpgradeToSessionUpdate,
@@ -546,6 +554,11 @@ export class AcpSession {
     // the assistant message that issued the call is replayed and read
     // when the tool result lands. Lives for the duration of one replay.
     const toolCallTurnIds = new Map<string, number>();
+    // Per-call replay bookkeeping for the structured-tool families
+    // (TodoList → plan, AskUserQuestion, Agent): how the call was emitted
+    // and its parsed args (needed to summarize results without re-parsing).
+    const toolCallKinds = new Map<string, 'plan' | 'question' | 'agent' | 'generic'>();
+    const toolCallArgs = new Map<string, unknown>();
 
     for (const message of agent.context.history) {
       try {
@@ -558,6 +571,14 @@ export class AcpSession {
             toolCallTurnIds.set(toolCallId, turnId);
           },
           lookupToolCallTurnId: (toolCallId) => toolCallTurnIds.get(toolCallId),
+          recordToolCallMeta: (toolCallId, kind, args) => {
+            toolCallKinds.set(toolCallId, kind);
+            toolCallArgs.set(toolCallId, args);
+          },
+          lookupToolCallMeta: (toolCallId) => ({
+            kind: toolCallKinds.get(toolCallId) ?? 'generic',
+            args: toolCallArgs.get(toolCallId),
+          }),
         });
       } catch (err) {
         log.warn('acp: replayHistory failed to emit a message; continuing', {
@@ -586,6 +607,8 @@ export class AcpSession {
       beginAssistantTurn: () => void;
       recordToolCall: (toolCallId: string) => void;
       lookupToolCallTurnId: (toolCallId: string) => number | undefined;
+      recordToolCallMeta: (toolCallId: string, kind: 'plan' | 'question' | 'agent' | 'generic', args: unknown) => void;
+      lookupToolCallMeta: (toolCallId: string) => { kind: 'plan' | 'question' | 'agent' | 'generic'; args: unknown };
     },
   ): Promise<void> {
     switch (message.role) {
@@ -610,7 +633,7 @@ export class AcpSession {
         }
         for (const toolCall of message.toolCalls ?? []) {
           ctx.recordToolCall(toolCall.id);
-          await this.replaySyntheticToolCall(toolCall, sessionId, conn, turnId);
+          await this.replaySyntheticToolCall(toolCall, sessionId, conn, turnId, ctx);
         }
         return;
       }
@@ -632,6 +655,14 @@ export class AcpSession {
           return;
         }
         const isError = message.isError === true;
+        const meta = ctx.lookupToolCallMeta(rawToolCallId);
+        if (meta.kind !== 'generic') {
+          // The call was replayed through a structured channel (plan /
+          // question bridge / Agent): shape its result to match instead of
+          // dumping the raw envelope text.
+          await this.replayStructuredToolResult(meta.kind, meta.args, message, isError, sessionId, conn, turnId, rawToolCallId);
+          return;
+        }
         await conn.sessionUpdate({
           sessionId,
           update: {
@@ -685,10 +716,26 @@ export class AcpSession {
     sessionId: string,
     conn: AgentSideConnection,
     turnId: number,
+    ctx: {
+      recordToolCallMeta: (toolCallId: string, kind: 'plan' | 'question' | 'agent' | 'generic', args: unknown) => void;
+    },
   ): Promise<void> {
     const name = toolCall.name;
     const argsRaw = toolCall.arguments;
     const parsedArgs = parseToolCallArguments(argsRaw);
+
+    // Structured replay for the custom-tool families: replay should
+    // reconstruct the SAME wire semantics the live path used (TodoList →
+    // ACP plan, AskUserQuestion / Agent → structured tool_call with
+    // rawInput/rawOutput) instead of flattening envelopes into text. On
+    // any shape mismatch the helper returns null and we fall through to
+    // the generic tool_call dump (honest, never lossy).
+    const family = await this.replayStructuredToolCall(toolCall, parsedArgs, sessionId, conn, turnId);
+    if (family !== null) {
+      ctx.recordToolCallMeta(toolCall.id, family, parsedArgs);
+      return;
+    }
+    ctx.recordToolCallMeta(toolCall.id, 'generic', parsedArgs);
     await conn.sessionUpdate(
       toolCallStartToSessionUpdate(sessionId, {
         type: 'tool.call.started',
@@ -698,6 +745,176 @@ export class AcpSession {
         args: parsedArgs,
       }),
     );
+  }
+
+  /**
+   * Replay one of the three custom-tool families through its structured
+   * channel. Returns the family tag ('plan' | 'question' | 'agent') when
+   * handled so the result side can shape its output to match, or `null`
+   * to leave the call on the generic tool_call path.
+   */
+  private async replayStructuredToolCall(
+    toolCall: NonNullable<ContextMessage['toolCalls']>[number],
+    parsedArgs: unknown,
+    sessionId: string,
+    conn: AgentSideConnection,
+    turnId: number,
+  ): Promise<'plan' | 'question' | 'agent' | null> {
+    // TodoList → ACP `plan` (the same session update the live path emits
+    // via planFromDisplayBlock). An empty list emits nothing: the wire
+    // replaces the whole plan per update, and 'plan_removed' is a
+    // separate deferred story.
+    if (toolCall.name === 'TodoList') {
+      const items = todoItemsFromToolArgs(parsedArgs);
+      if (items === null) return null;
+      const update = todoListToSessionUpdate(sessionId, turnId, items);
+      if (update !== null) {
+        await conn.sessionUpdate(update);
+      }
+      return 'plan';
+    }
+
+    // AskUserQuestion → a clean tool_call: structured rawInput (the
+    // questions), result side emits the one-line human summary with the
+    // full JSON in rawOutput. A question-bridge replay (re-asking the
+    // user through requestPermission on load) was rejected: replaying
+    // history must be side-effect-free, and the answer already exists in
+    // the transcript.
+    if (toolCall.name === 'AskUserQuestion') {
+      const questions = questionsFromToolArgs(parsedArgs);
+      if (questions === null) return null;
+      await conn.sessionUpdate({
+        sessionId,
+        update: {
+          sessionUpdate: 'tool_call',
+          toolCallId: acpToolCallId(turnId, toolCall.id),
+          title: 'AskUserQuestion',
+          kind: 'other',
+          status: 'in_progress',
+          rawInput: parsedArgs,
+          content: [
+            {
+              type: 'content',
+              content: {
+                type: 'text',
+                text: questions.length === 1 ? questions[0]! : `${questions.length} questions`,
+              },
+            },
+          ],
+        },
+      });
+      return 'question';
+    }
+
+    // Agent (subagent spawn) → clean title with type + description;
+    // result side strips the `agent_id:…\n…status:…` envelope prelude and
+    // keeps the raw envelope in rawOutput.
+    if (toolCall.name === 'Agent') {
+      const args = typeof parsedArgs === 'object' && parsedArgs !== null ? (parsedArgs as Record<string, unknown>) : {};
+      const subagentType = typeof args['subagent_type'] === 'string' && args['subagent_type'].length > 0 ? args['subagent_type'] : 'coder';
+      const description = typeof args['description'] === 'string' ? args['description'] : '';
+      await conn.sessionUpdate({
+        sessionId,
+        update: {
+          sessionUpdate: 'tool_call',
+          toolCallId: acpToolCallId(turnId, toolCall.id),
+          title: `Agent (${subagentType})${description ? `: ${description}` : ''}`,
+          kind: 'other',
+          status: 'in_progress',
+          rawInput: parsedArgs,
+          content: [{ type: 'content', content: { type: 'text', text: description } }],
+        },
+      });
+      return 'agent';
+    }
+
+    return null;
+  }
+
+  /**
+   * Emit the tool RESULT for a structured-family call, matching the call
+   * side's channel: plan results are dropped entirely (the plan update
+   * already carries the full list — no wire tool_call exists to complete);
+   * question results become a one-line summary + rawOutput JSON; Agent
+   * results become the subagent's summary text + rawOutput envelope.
+   */
+  private async replayStructuredToolResult(
+    kind: 'plan' | 'question' | 'agent',
+    args: unknown,
+    message: ContextMessage,
+    isError: boolean,
+    sessionId: string,
+    conn: AgentSideConnection,
+    turnId: number,
+    rawToolCallId: string,
+  ): Promise<void> {
+    void args;
+    if (kind === 'plan') {
+      // Nothing to emit: the ACP plan carries the whole list per update,
+      // and the 'Todo list updated…' text adds a fake assistant dump.
+      return;
+    }
+    const resultText = message.content
+      .filter((part): part is Extract<typeof part, { type: 'text' }> => part.type === 'text')
+      .map((part) => part.text)
+      .join('\n');
+
+    if (kind === 'question') {
+      const shaped = summarizeQuestionResult(resultText);
+      if (shaped === null) {
+        await this.replayGenericToolResult(message, isError, sessionId, conn, turnId, rawToolCallId);
+        return;
+      }
+      await conn.sessionUpdate({
+        sessionId,
+        update: {
+          sessionUpdate: 'tool_call_update',
+          toolCallId: acpToolCallId(turnId, rawToolCallId),
+          status: isError ? 'failed' : 'completed',
+          rawOutput: shaped.rawOutput,
+          content: [{ type: 'content', content: { type: 'text', text: shaped.summary } }],
+        },
+      });
+      return;
+    }
+
+    // kind === 'agent'
+    const shaped = extractAgentSummary(resultText);
+    if (shaped === null) {
+      await this.replayGenericToolResult(message, isError, sessionId, conn, turnId, rawToolCallId);
+      return;
+    }
+    await conn.sessionUpdate({
+      sessionId,
+      update: {
+        sessionUpdate: 'tool_call_update',
+        toolCallId: acpToolCallId(turnId, rawToolCallId),
+        status: isError ? 'failed' : 'completed',
+        rawOutput: shaped.rawOutput,
+        content: [{ type: 'content', content: { type: 'text', text: shaped.summary } }],
+      },
+    });
+  }
+
+  /** The pre-existing generic result path (raw content dump), factored so
+   *  family fallbacks reuse it verbatim. */
+  private async replayGenericToolResult(
+    message: ContextMessage,
+    isError: boolean,
+    sessionId: string,
+    conn: AgentSideConnection,
+    turnId: number,
+    rawToolCallId: string,
+  ): Promise<void> {
+    await conn.sessionUpdate({
+      sessionId,
+      update: {
+        sessionUpdate: 'tool_call_update',
+        toolCallId: acpToolCallId(turnId, rawToolCallId),
+        status: isError ? 'failed' : 'completed',
+        content: toolMessageContentToAcpToolCallContent(message.content),
+      },
+    });
   }
 
   /**

--- a/packages/acp-adapter/test/replay-structured-tools.test.ts
+++ b/packages/acp-adapter/test/replay-structured-tools.test.ts
@@ -1,0 +1,375 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  AgentSideConnection,
+  ClientSideConnection,
+  ndJsonStream,
+  type Client,
+  type ReadTextFileRequest,
+  type ReadTextFileResponse,
+  type RequestPermissionRequest,
+  type RequestPermissionResponse,
+  type SessionNotification,
+  type WriteTextFileRequest,
+  type WriteTextFileResponse,
+} from '@agentclientprotocol/sdk';
+import type { Event, KimiHarness, Session } from '@moonshot-ai/kimi-code-sdk';
+
+import { AcpServer } from '../src/server';
+import { AUTHED_STATUS, makeModelsMap } from './_helpers/harness-stubs';
+
+// Replay-side structured tools (fix/acp-replay-structured-tools): the three
+// custom-tool families must reconstruct their live-path wire semantics on
+// history replay instead of dumping raw envelopes into visible text.
+
+class CapturingClient implements Client {
+  readonly updates: SessionNotification[] = [];
+
+  get historyUpdates(): readonly SessionNotification[] {
+    return this.updates.filter(
+      (n) =>
+        (n.update as { sessionUpdate?: string }).sessionUpdate !==
+        'available_commands_update',
+    );
+  }
+
+  async requestPermission(_p: RequestPermissionRequest): Promise<RequestPermissionResponse> {
+    throw new Error('CapturingClient.requestPermission should not be called in replay test');
+  }
+  async sessionUpdate(n: SessionNotification): Promise<void> {
+    this.updates.push(n);
+  }
+  async writeTextFile(_p: WriteTextFileRequest): Promise<WriteTextFileResponse> {
+    throw new Error('CapturingClient.writeTextFile should not be called in replay test');
+  }
+  async readTextFile(_p: ReadTextFileRequest): Promise<ReadTextFileResponse> {
+    throw new Error('CapturingClient.readTextFile should not be called in replay test');
+  }
+}
+
+function makeInMemoryStreamPair(): {
+  agentStream: ReturnType<typeof ndJsonStream>;
+  clientStream: ReturnType<typeof ndJsonStream>;
+} {
+  const clientToAgent = new TransformStream<Uint8Array, Uint8Array>();
+  const agentToClient = new TransformStream<Uint8Array, Uint8Array>();
+  const agentStream = ndJsonStream(agentToClient.writable, clientToAgent.readable);
+  const clientStream = ndJsonStream(clientToAgent.writable, agentToClient.readable);
+  return { agentStream, clientStream };
+}
+
+function makeSessionWithHistory(sessionId: string, history: ReadonlyArray<unknown>): Session {
+  return {
+    id: sessionId,
+    cancel: async () => undefined,
+    prompt: async () => undefined,
+    onEvent: (_fn: (event: Event) => void) => () => undefined,
+    setApprovalHandler: () => undefined,
+    getResumeState: () => ({
+      agents: {
+        main: {
+          context: { history, tokenCount: 0 },
+        },
+      },
+    }),
+  } as unknown as Session;
+}
+
+function makeHarness(session: Session): KimiHarness {
+  return {
+    auth: {
+      status: async () => AUTHED_STATUS,
+    },
+    resumeSession: async (_input: { id: string }) => session,
+    getConfig: async () => ({
+      providers: {},
+      defaultModel: 'kimi-coder',
+      models: makeModelsMap([{ id: 'kimi-coder', name: 'Kimi Coder', thinkingSupported: true }]),
+    }),
+  } as unknown as KimiHarness;
+}
+
+async function loadAndCapture(
+  history: ReadonlyArray<unknown>,
+): Promise<readonly SessionNotification[]> {
+  const session = makeSessionWithHistory('sess-replay-structured', history);
+  const harness = makeHarness(session);
+  const { agentStream, clientStream } = makeInMemoryStreamPair();
+  new AgentSideConnection((c) => new AcpServer(harness, c), agentStream);
+  const client = new CapturingClient();
+  const clientConn = new ClientSideConnection((_a) => client, clientStream);
+
+  await clientConn.loadSession({
+    sessionId: 'sess-replay-structured',
+    cwd: '/tmp/x',
+    mcpServers: [],
+  });
+  return client.historyUpdates;
+}
+
+function toolCall(id: string, name: string, args: unknown): Record<string, unknown> {
+  return {
+    type: 'function',
+    id,
+    name,
+    arguments: JSON.stringify(args),
+  };
+}
+
+describe('replay of structured tool families', () => {
+  it('TodoList replays as an ACP plan update — never a tool_call text dump', async () => {
+    const updates = await loadAndCapture([
+      { role: 'user', content: [{ type: 'text', text: 'plan it' }], toolCalls: [] },
+      {
+        role: 'assistant',
+        content: [{ type: 'text', text: 'tracking work' }],
+        toolCalls: [
+          toolCall('tc-todo', 'TodoList', {
+            todos: [
+              { title: 'first thing', status: 'done' },
+              { title: 'second thing', status: 'in_progress' },
+              { title: 'third thing', status: 'pending' },
+            ],
+          }),
+        ],
+      },
+      {
+        role: 'tool',
+        toolCallId: 'tc-todo',
+        content: [{ type: 'text', text: 'Todo list updated successfully. Use it to track progress.' }],
+        toolCalls: [],
+      },
+    ]);
+
+    const plans = updates.filter(
+      (n) => (n.update as { sessionUpdate?: string }).sessionUpdate === 'plan',
+    );
+    expect(plans.length).toBe(1);
+    expect(plans[0]!.update).toMatchObject({
+      sessionUpdate: 'plan',
+      entries: [
+        { content: 'first thing', status: 'completed' },
+        { content: 'second thing', status: 'in_progress' },
+        { content: 'third thing', status: 'pending' },
+      ],
+    });
+
+    // No tool_call / tool_call_update for the TodoList id at all — the
+    // 'Todo list updated…' text must not leak as visible content.
+    const toolWires = updates.filter((n) => {
+      const update = n.update as { toolCallId?: string };
+      return update.toolCallId !== undefined && update.toolCallId.endsWith(':tc-todo');
+    });
+    expect(toolWires).toEqual([]);
+  });
+
+  it('AskUserQuestion replays with a clean tool_call + one-line summary + rawOutput (no JSON dump)', async () => {
+    const resultJson = JSON.stringify({
+      answers: { q1: { option_id: 'safe path' } },
+    });
+    const updates = await loadAndCapture([
+      { role: 'user', content: [{ type: 'text', text: 'choose' }], toolCalls: [] },
+      {
+        role: 'assistant',
+        content: [{ type: 'text', text: 'asking' }],
+        toolCalls: [
+          toolCall('tc-ask', 'AskUserQuestion', {
+            questions: [
+              {
+                question: 'Which approach?',
+                header: 'Approach',
+                options: [
+                  { label: 'safe path' },
+                  { label: 'fast path' },
+                ],
+              },
+            ],
+          }),
+        ],
+      },
+      {
+        role: 'tool',
+        toolCallId: 'tc-ask',
+        content: [{ type: 'text', text: resultJson }],
+        toolCalls: [],
+      },
+    ]);
+
+    const call = updates.find(
+      (n) => (n.update as { sessionUpdate?: string }).sessionUpdate === 'tool_call',
+    );
+    expect(call!.update).toMatchObject({
+      sessionUpdate: 'tool_call',
+      toolCallId: '1:tc-ask',
+      title: 'AskUserQuestion',
+      status: 'in_progress',
+    });
+    expect((call!.update as { rawInput?: unknown }).rawInput).toMatchObject({
+      questions: [{ question: 'Which approach?' }],
+    });
+
+    const result = updates.find(
+      (n) => (n.update as { sessionUpdate?: string }).sessionUpdate === 'tool_call_update',
+    );
+    expect(result!.update).toMatchObject({
+      sessionUpdate: 'tool_call_update',
+      toolCallId: '1:tc-ask',
+      status: 'completed',
+      rawOutput: resultJson,
+      content: [{ type: 'content', content: { type: 'text', text: 'Answered: safe path' } }],
+    });
+    // The JSON envelope must not appear in the visible content text.
+    const contentText = JSON.stringify((result!.update as { content?: unknown }).content);
+    expect(contentText).not.toContain('"answers"');
+    expect(contentText).not.toContain('option_id');
+  });
+
+  it('AskUserQuestion dismissal replays as the dismiss note, not the empty-answers JSON', async () => {
+    const updates = await loadAndCapture([
+      { role: 'user', content: [{ type: 'text', text: 'choose' }], toolCalls: [] },
+      {
+        role: 'assistant',
+        content: [{ type: 'text', text: 'asking' }],
+        toolCalls: [
+          toolCall('tc-ask2', 'AskUserQuestion', {
+            questions: [{ question: 'Continue?', options: [{ label: 'yes' }] }],
+          }),
+        ],
+      },
+      {
+        role: 'tool',
+        toolCallId: 'tc-ask2',
+        content: [
+          { type: 'text', text: '{"answers":{},"note":"User dismissed the question without answering."}' },
+        ],
+        toolCalls: [],
+      },
+    ]);
+    const result = updates.find(
+      (n) => (n.update as { sessionUpdate?: string }).sessionUpdate === 'tool_call_update',
+    );
+    expect(result!.update).toMatchObject({
+      content: [
+        {
+          type: 'content',
+          content: { type: 'text', text: 'User dismissed the question without answering.' },
+        },
+      ],
+    });
+  });
+
+  it('Agent replays with a clean title and summary-only content (no envelope prelude)', async () => {
+    const envelope = [
+      'agent_id: agent-0',
+      'actual_subagent_type: coder',
+      'status: completed',
+      '',
+      '[summary]',
+      'The refactor is complete and all tests pass.',
+    ].join('\n');
+    const updates = await loadAndCapture([
+      { role: 'user', content: [{ type: 'text', text: 'delegate this' }], toolCalls: [] },
+      {
+        role: 'assistant',
+        content: [{ type: 'text', text: 'spawning a subagent' }],
+        toolCalls: [
+          toolCall('tc-agent', 'Agent', {
+            subagent_type: 'coder',
+            description: 'refactor the parser',
+            prompt: 'Refactor the parser module end to end.',
+          }),
+        ],
+      },
+      {
+        role: 'tool',
+        toolCallId: 'tc-agent',
+        content: [{ type: 'text', text: envelope }],
+        toolCalls: [],
+      },
+    ]);
+
+    const call = updates.find(
+      (n) => (n.update as { sessionUpdate?: string }).sessionUpdate === 'tool_call',
+    );
+    expect(call!.update).toMatchObject({
+      sessionUpdate: 'tool_call',
+      toolCallId: '1:tc-agent',
+      title: 'Agent (coder): refactor the parser',
+      status: 'in_progress',
+    });
+    expect((call!.update as { rawInput?: unknown }).rawInput).toMatchObject({
+      subagent_type: 'coder',
+      description: 'refactor the parser',
+    });
+
+    const result = updates.find(
+      (n) => (n.update as { sessionUpdate?: string }).sessionUpdate === 'tool_call_update',
+    );
+    expect(result!.update).toMatchObject({
+      sessionUpdate: 'tool_call_update',
+      toolCallId: '1:tc-agent',
+      status: 'completed',
+      rawOutput: envelope,
+      content: [
+        {
+          type: 'content',
+          content: { type: 'text', text: 'The refactor is complete and all tests pass.' },
+        },
+      ],
+    });
+    const contentText = JSON.stringify((result!.update as { content?: unknown }).content);
+    expect(contentText).not.toContain('agent_id');
+    expect(contentText).not.toContain('actual_subagent_type');
+  });
+
+  it('generic tools (Bash) replay exactly as before — call + raw result dump', async () => {
+    const updates = await loadAndCapture([
+      { role: 'user', content: [{ type: 'text', text: 'ls' }], toolCalls: [] },
+      {
+        role: 'assistant',
+        content: [{ type: 'text', text: 'running ls' }],
+        toolCalls: [toolCall('tc-bash', 'Bash', { command: 'ls' })],
+      },
+      {
+        role: 'tool',
+        toolCallId: 'tc-bash',
+        content: [{ type: 'text', text: 'file1\nfile2' }],
+        toolCalls: [],
+      },
+    ]);
+    expect(updates[2]!.update).toMatchObject({
+      sessionUpdate: 'tool_call',
+      toolCallId: '1:tc-bash',
+      title: 'Bash',
+      kind: 'execute',
+      status: 'in_progress',
+    });
+    expect(updates[3]!.update).toMatchObject({
+      sessionUpdate: 'tool_call_update',
+      toolCallId: '1:tc-bash',
+      status: 'completed',
+      content: [{ type: 'content', content: { type: 'text', text: 'file1\nfile2' } }],
+    });
+  });
+
+  it('malformed family args fall back to the generic tool_call dump', async () => {
+    const updates = await loadAndCapture([
+      { role: 'user', content: [{ type: 'text', text: 'todo?' }], toolCalls: [] },
+      {
+        role: 'assistant',
+        content: [{ type: 'text', text: 'todo' }],
+        toolCalls: [toolCall('tc-bad-todo', 'TodoList', { notTodos: true })],
+      },
+      {
+        role: 'tool',
+        toolCallId: 'tc-bad-todo',
+        content: [{ type: 'text', text: 'Todo list updated successfully.' }],
+        toolCalls: [],
+      },
+    ]);
+    const kinds = updates.map((n) => (n.update as { sessionUpdate?: string }).sessionUpdate);
+    expect(kinds).toContain('tool_call');
+    expect(kinds).toContain('tool_call_update');
+    expect(kinds).not.toContain('plan');
+  });
+});


### PR DESCRIPTION
## Problem

The acp-adapter's **history replay path** (`replayHistory`/`replayMessage`/`replaySyntheticToolCall` in `packages/acp-adapter/src/session.ts`) flattens every tool call into `tool_call` + raw output text. The **live path** emits kimi's custom tools through rich ACP channels (TodoList → ACP `plan`, AskUserQuestion → question bridge, Agent → subagent events), so replayed history shows raw envelopes as visible assistant text. Verified against a live downstream consumer (paseo's daemon → TUI/feishu mapper): replayed transcripts render things like

- `{"answers":{},"note":"User dismissed the question without answering."}` as plain text
- `agent_id: agent-0\nactual_subagent_type: coder\nstatus: completed\n[summary]…` as plain text
- `Todo list updated successfully…` dumps

The degradation originates in the replay converter, not in downstream clients.

## Fix (replay path only — no usage reporting / emitLocalCommandMessage, that is a later batch)

Replay now reconstructs the same wire semantics the live path used:

| Family | Before | After |
|---|---|---|
| **TodoList** | tool_call + "Todo list updated…" text | args.todos parsed → same ACP `plan` session update the live path uses (`todoListToSessionUpdate`); redundant result text dropped entirely; parse failure falls back to generic |
| **AskUserQuestion** | answers-JSON dumped into content text | clean `tool_call` (title `AskUserQuestion`) with questions in `rawInput`; result = one-line human summary (`Answered: <labels>` / dismiss note) in content + full JSON in `rawOutput` |
| **Agent** (subagent) | `agent_id:…\n…status:…\n[summary]` prelude in content | clean title `Agent (<subagent_type>): <description>` with args in `rawInput`; content = subagent's final summary only, envelope kept in `rawOutput` |

**Generic principle** (also in the commit message): when the exact live channel cannot be reconstructed, prefer `rawInput`/`rawOutput` fields over pre-rendered text dumps — clients should render data, not layout. Generic tools (Bash/Read/etc.) replay exactly as before.

## Decisions worth reviewing

- **Question bridge replay was rejected**: re-asking the user through `requestPermission` on `session/load` would make history replay side-effectful; the answer already exists in the transcript, so we shape the structured result instead.
- **TodoList result is dropped, not summarized**: each call already emits the full list as a `plan` update (the wire replaces per update), so the result text is pure noise. No `plan_removed` is emitted for empty lists (same deferral as the live path).
- **Envelope stripping for Agent is defensive**: only results starting with `agent_id: ` are treated as envelopes; anything else falls back to the generic dump (honest, never lossy).

## Tests

New `packages/acp-adapter/test/replay-structured-tools.test.ts` (6 cases, server-level via the in-memory ndjson harness): TodoList→plan + no wire tool_call, AskUserQuestion summary/rawOutput + dismissal note, Agent clean title + summary-only content, generic Bash regression, malformed-args fallback. Full acp-adapter package suite: **312/312 tests pass (37 files)**; `pnpm --filter @moonshot-ai/acp-adapter typecheck` clean. Monorepo-wide suite not run (out of scope).
