### PR TITLE
feat(web): add a cache invalidation note to the model switcher

### DIFF
--- a/.changeset/web-model-switcher-cache-note.md
+++ b/.changeset/web-model-switcher-cache-note.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+web: Add a note in the model switcher that switching models or thinking effort invalidates the existing prompt cache.

--- a/apps/kimi-web/src/components/chat/Composer.vue
+++ b/apps/kimi-web/src/components/chat/Composer.vue
@@ -1201,6 +1201,9 @@ function selectModel(modelId: string): void {
           </div>
 
           <div class="md-divider" />
+          <div class="md-cache-note">{{ t('status.cacheNote') }}</div>
+
+          <div class="md-divider" />
 
           <!-- More models → open full picker -->
           <button class="md-row md-row-more" role="menuitem" @click="closeDropdown(); emit('pickModel');">
@@ -1805,6 +1808,16 @@ function selectModel(modelId: string): void {
 }
 .md-thinking.is-readonly .effort-segments {
   opacity: 0.62;
+}
+.md-cache-note {
+  /* width:0 + min-width:100% — the note never widens the shrink-to-fit
+     dropdown, but always fills its width and wraps there naturally. */
+  width: 0;
+  min-width: 100%;
+  padding: 2px 7px 4px;
+  color: var(--muted);
+  font-size: var(--ui-font-size-xs);
+  line-height: 1.4;
 }
 .md-thinking.is-readonly .effort-seg.is-active {
   background: var(--color-surface-raised);

--- a/apps/kimi-web/src/components/mobile/MobileSettingsSheet.vue
+++ b/apps/kimi-web/src/components/mobile/MobileSettingsSheet.vue
@@ -273,6 +273,10 @@ watch(
       >{{ thinkingLevel === 'off' ? t('status.planOff') : effortLabel(thinkingLevel) }}</span>
     </div>
 
+    <!-- Prompt-cache invalidation note — same text as the desktop model dropdown,
+         covering both the model row above and this thinking control. -->
+    <div class="cache-note">{{ t('status.cacheNote') }}</div>
+
     <!-- Plan mode → real toggle switch -->
     <button type="button" class="srow" @click="emit('togglePlan')">
       <span class="srow-main">
@@ -497,6 +501,14 @@ watch(
   color: var(--color-text-muted);
 }
 
+/* Prompt-cache note under the thinking row — mirrors .md-cache-note in Composer. */
+.cache-note {
+  padding: 0 var(--space-3) var(--space-2);
+  font-size: var(--text-xs);
+  color: var(--color-text-faint);
+  line-height: 1.4;
+}
+
 /* Chevron (prototype ›) — fixed icon glyph size, not part of UI font scale. */
 .chev {
   flex: none;
@@ -592,6 +604,10 @@ watch(
     padding-left: max(14px, var(--safe-left));
     padding-right: max(14px, var(--safe-right));
   }
+  .cache-note {
+    padding-left: max(14px, var(--safe-left));
+    padding-right: max(14px, var(--safe-right));
+  }
   .srow-main {
     flex: 1 1 auto;
   }
@@ -618,7 +634,8 @@ watch(
 
 .srow,
 .srow-sub,
-.srow-val { font-family: var(--sans); }
+.srow-val,
+.cache-note { font-family: var(--sans); }
 
 /* Archived sessions sub-view */
 .arch-subhead {

--- a/apps/kimi-web/src/i18n/locales/en/status.ts
+++ b/apps/kimi-web/src/i18n/locales/en/status.ts
@@ -41,6 +41,8 @@ export default {
   thinkingTooltip: 'Toggle thinking mode',
   thinkingOn: 'On',
   thinkingOff: 'Off',
+  cacheNote:
+    'Note: Switching models or thinking effort invalidates the existing prompt cache. Start a new chat to avoid extra token costs.',
   starredModels: 'Starred',
   moreModels: 'More models…',
   // Status panel

--- a/apps/kimi-web/src/i18n/locales/zh/status.ts
+++ b/apps/kimi-web/src/i18n/locales/zh/status.ts
@@ -41,6 +41,7 @@ export default {
   thinkingTooltip: '切换思考模式',
   thinkingOn: '开',
   thinkingOff: '关',
+  cacheNote: '提示：切换模型或思考程度会使已有的提示词缓存失效。建议新建对话，避免额外的 token 消耗。',
   starredModels: '收藏',
   moreModels: '更多模型…',
   // 状态面板


### PR DESCRIPTION
## Related Issue

No linked issue — the problem is explained below.

## Problem

The web model switcher lets users change the model or thinking effort mid-session, but nothing indicates that doing so invalidates the existing prompt cache, which can quietly increase token costs.

## What changed

- Added a small muted note in the model dropdown, in its own divider-separated section under the thinking-effort control: "Note: Switching models or thinking effort invalidates the existing prompt cache. Start a new chat to avoid extra token costs." (Chinese translation included.)
- The note uses `width: 0` + `min-width: 100%` so it fills the dropdown width and wraps there naturally without stretching the shrink-to-fit dropdown.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [ ] I have added tests that prove my feature works. (Static i18n text line; no behavioral logic to test.)
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.
