### PR TITLE
fix(agent-core-v2): broadcast permission mode switches to live subagents

### DIFF
--- a/.changeset/subagent-permission-mode-broadcast.md
+++ b/.changeset/subagent-permission-mode-broadcast.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Fix running subagents not observing permission mode switches made after they started.

--- a/packages/agent-core-v2/src/agent/rpc/rpcService.ts
+++ b/packages/agent-core-v2/src/agent/rpc/rpcService.ts
@@ -13,6 +13,11 @@ import { ErrorCodes, Error2 } from '#/errors';
 import { IAgentPermissionGate } from '#/agent/permissionGate/permissionGate';
 import { IAgentPermissionModeService } from '#/agent/permissionMode/permissionMode';
 import { IAgentPlanService } from '#/agent/plan/plan';
+import { IAgentScopeContext } from '#/agent/scopeContext/scopeContext';
+import {
+  IAgentLifecycleService,
+  MAIN_AGENT_ID,
+} from '#/session/agentLifecycle/agentLifecycle';
 import { IHostEnvironment } from '#/os/interface/hostEnvironment';
 import { expandCommandArguments } from '#/app/plugin/commands';
 import { IPluginService } from '#/app/plugin/plugin';
@@ -108,6 +113,8 @@ export class AgentRPCService implements IAgentRPCService {
     @ISessionMetadata private readonly metadata: ISessionMetadata,
     @ISessionContext private readonly sessionContext: ISessionContext,
     @ISessionBtwService private readonly btw: ISessionBtwService,
+    @IAgentScopeContext private readonly scopeContext: IAgentScopeContext,
+    @IAgentLifecycleService private readonly agentLifecycle: IAgentLifecycleService,
   ) { }
 
   async prompt(payload: PromptPayload): Promise<PromptLaunchResult | undefined> {
@@ -167,6 +174,12 @@ export class AgentRPCService implements IAgentRPCService {
     const wasYolo = this.permissionMode.mode === 'yolo';
     const wasAuto = this.permissionMode.mode === 'auto';
     this.permissionMode.setMode(payload.mode);
+    // A switch on the main agent is the session-level switch: fan it out so
+    // already-running subagents observe the new mode. Switches addressed to
+    // any other agent stay local to that agent.
+    if (this.scopeContext.agentId === MAIN_AGENT_ID) {
+      this.agentLifecycle.broadcastPermissionMode(payload.mode);
+    }
     const enabled = this.permissionMode.mode === 'yolo';
     if (enabled !== wasYolo) {
       this.telemetry.track2('yolo_toggle', { enabled });

--- a/packages/agent-core-v2/src/agent/rpc/rpcService.ts
+++ b/packages/agent-core-v2/src/agent/rpc/rpcService.ts
@@ -174,9 +174,6 @@ export class AgentRPCService implements IAgentRPCService {
     const wasYolo = this.permissionMode.mode === 'yolo';
     const wasAuto = this.permissionMode.mode === 'auto';
     this.permissionMode.setMode(payload.mode);
-    // A switch on the main agent is the session-level switch: fan it out so
-    // already-running subagents observe the new mode. Switches addressed to
-    // any other agent stay local to that agent.
     if (this.scopeContext.agentId === MAIN_AGENT_ID) {
       this.agentLifecycle.broadcastPermissionMode(payload.mode);
     }

--- a/packages/agent-core-v2/src/app/sessionLegacy/sessionLegacyService.ts
+++ b/packages/agent-core-v2/src/app/sessionLegacy/sessionLegacyService.ts
@@ -97,8 +97,8 @@ export class SessionLegacyService implements ISessionLegacyService {
     }
     if (agentConfig.permission_mode !== undefined) {
       agent.accessor
-        .get(IAgentPermissionModeService)
-        .setMode(agentConfig.permission_mode as PermissionMode);
+        .get(IAgentLifecycleService)
+        .broadcastPermissionMode(agentConfig.permission_mode as PermissionMode);
     }
     if (agentConfig.plan_mode !== undefined) {
       const plan = agent.accessor.get(IAgentPlanService);

--- a/packages/agent-core-v2/src/session/agentLifecycle/agentLifecycle.ts
+++ b/packages/agent-core-v2/src/session/agentLifecycle/agentLifecycle.ts
@@ -1,11 +1,13 @@
 /**
  * `agentLifecycle` domain (L6) — flat registry of the session's agents.
  *
- * Owns agent *existence* and nothing else: the creation pipeline (`create` /
- * `fork`), the registry (`get` / `list` / `remove`), and the lifecycle events.
- * Driving turns on an agent — and the hook/event surface those runs announce —
- * lives in the `subagent` domain; session-level MCP lives in the `sessionMcp`
- * domain. Session-scoped — one instance per session.
+ * Owns agent *existence* — the creation pipeline (`create` / `fork`), the
+ * registry (`get` / `list` / `remove`), and the lifecycle events — plus the
+ * session-wide fan-outs only the live registry can reach
+ * (`broadcastPermissionMode`). Driving turns on an agent — and the hook/event
+ * surface those runs announce — lives in the `subagent` domain; session-level
+ * MCP lives in the `sessionMcp` domain. Session-scoped — one instance per
+ * session.
  *
  * Invariants:
  * - The registry is flat: agents have no nesting. There is no parent/child or
@@ -25,6 +27,7 @@
 import { createDecorator, type ServiceIdentifier } from '#/_base/di/instantiation';
 import type { IAgentScopeHandle } from '#/_base/di/scope';
 import type { Event } from '#/_base/event';
+import type { PermissionMode } from '#/agent/permissionPolicy/types';
 import type { BindAgentInput } from '#/agent/profile/profile';
 
 /** The conventional id of the session's main agent. */
@@ -77,6 +80,14 @@ export interface IAgentLifecycleService {
   /** Look up a live agent by id. The handle is visible while its creation is still in flight. */
   get(agentId: string): IAgentScopeHandle | undefined;
   list(filter?: AgentListFilter): readonly IAgentScopeHandle[];
+  /**
+   * Set the permission mode on every live agent in the session. Session-level
+   * mode switches (a `setPermission` call on the main agent, the legacy
+   * `agent_config.permission_mode` patch) fan out through here so
+   * already-running subagents observe the change; each agent still journals
+   * its own `permission.set_mode` op.
+   */
+  broadcastPermissionMode(mode: PermissionMode): void;
   /** Drive an agent through disposal (reject new turns, drain, release the scope). */
   remove(agentId: string): Promise<void>;
 }

--- a/packages/agent-core-v2/src/session/agentLifecycle/agentLifecycleService.ts
+++ b/packages/agent-core-v2/src/session/agentLifecycle/agentLifecycleService.ts
@@ -8,7 +8,8 @@
  * and registers the agent in the session registry. New logs receive a metadata
  * envelope while non-empty unversioned logs are rejected. Removal awaits the
  * agent task manager's graceful exit policy before draining turns and full
- * compaction, then disposing the child scope. Bound at Session scope.
+ * compaction, then disposing the child scope. Fans session-level
+ * permission-mode switches out to every live agent. Bound at Session scope.
  *
  * No agent id is special here: the main agent is simply the agent created
  * with the conventional `MAIN_AGENT_ID`, and `fork` requires its source to
@@ -297,6 +298,12 @@ export class AgentLifecycleService extends Disposable implements IAgentLifecycle
     const prefix = filter?.prefix;
     if (prefix === undefined) return all;
     return all.filter((handle) => handle.id.startsWith(prefix));
+  }
+
+  broadcastPermissionMode(mode: PermissionMode): void {
+    for (const handle of this.handles.values()) {
+      handle.accessor.get(IAgentPermissionModeService).setMode(mode);
+    }
   }
 
   async remove(agentId: string): Promise<void> {

--- a/packages/agent-core-v2/test/agent/rpc/setPermission.test.ts
+++ b/packages/agent-core-v2/test/agent/rpc/setPermission.test.ts
@@ -1,0 +1,41 @@
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { IAgentPermissionModeService } from '#/agent/permissionMode/permissionMode';
+
+import { recordingTelemetry, type TelemetryRecord } from '../../app/telemetry/stubs';
+import { createTestAgent, telemetryServices, type TestAgentContext } from '../../harness';
+
+describe('setPermission RPC', () => {
+  let ctx: TestAgentContext;
+  let records: TelemetryRecord[];
+
+  afterEach(async () => {
+    try {
+      await ctx.expectResumeMatches();
+    } finally {
+      await ctx.dispose();
+    }
+  });
+
+  it('applies the mode to the agent and tracks the afk toggle', async () => {
+    records = [];
+    ctx = createTestAgent(telemetryServices(recordingTelemetry(records)));
+
+    await ctx.rpc.setPermission({ mode: 'auto' });
+
+    expect(ctx.get(IAgentPermissionModeService).mode).toBe('auto');
+    expect(records).toContainEqual({ event: 'afk_toggle', properties: { enabled: true } });
+  });
+
+  it('tracks the yolo toggle on enter and exit', async () => {
+    records = [];
+    ctx = createTestAgent(telemetryServices(recordingTelemetry(records)));
+
+    await ctx.rpc.setPermission({ mode: 'yolo' });
+    await ctx.rpc.setPermission({ mode: 'manual' });
+
+    expect(ctx.get(IAgentPermissionModeService).mode).toBe('manual');
+    expect(records).toContainEqual({ event: 'yolo_toggle', properties: { enabled: true } });
+    expect(records).toContainEqual({ event: 'yolo_toggle', properties: { enabled: false } });
+  });
+});

--- a/packages/agent-core-v2/test/app/gateway/gateway.test.ts
+++ b/packages/agent-core-v2/test/app/gateway/gateway.test.ts
@@ -79,6 +79,7 @@ describe('RestGateway', () => {
       get: (id) => (id === 'main' ? agentHandle : undefined),
       list: () => [agentHandle],
       remove: () => Promise.resolve(),
+      broadcastPermissionMode: () => {},
     };
     const sessionHandle: ISessionScopeHandle = {
       id: 's1',

--- a/packages/agent-core-v2/test/app/sessionExport/sessionExport.test.ts
+++ b/packages/agent-core-v2/test/app/sessionExport/sessionExport.test.ts
@@ -961,6 +961,7 @@ function stubAgentLifecycle(agents: readonly IAgentScopeHandle[]): IAgentLifecyc
     get: (agentId) => agents.find((agent) => agent.id === agentId),
     list: () => agents,
     remove: async () => {},
+    broadcastPermissionMode: () => {},
   };
 }
 function testManifest(sessionId: string): ExportSessionManifest {

--- a/packages/agent-core-v2/test/app/sessionLegacy/sessionLegacy.test.ts
+++ b/packages/agent-core-v2/test/app/sessionLegacy/sessionLegacy.test.ts
@@ -7,7 +7,7 @@
  * current model catalog.
  */
 
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { SyncDescriptor } from '#/_base/di/descriptors';
 import type { ServiceIdentifier, ServicesAccessor } from '#/_base/di/instantiation';
@@ -25,7 +25,9 @@ import { SessionLegacyService } from '#/app/sessionLegacy/sessionLegacyService';
 import { ISessionLifecycleService } from '#/app/sessionLifecycle/sessionLifecycle';
 import { IAgentActivityView } from '#/agent/activityView/activityView';
 import { IAgentLifecycleService } from '#/session/agentLifecycle/agentLifecycle';
+import { ISessionContext } from '#/session/sessionContext/sessionContext';
 import { ISessionCronService } from '#/session/cron/sessionCronService';
+import { ISessionMetadata } from '#/session/sessionMetadata/sessionMetadata';
 
 function accessor(
   entries: ReadonlyArray<readonly [ServiceIdentifier<unknown>, unknown]>,
@@ -116,5 +118,51 @@ describe('Session legacy status (best-effort runtime state)', () => {
       thinking_level: 'high',
       max_context_tokens: 0,
     });
+  });
+
+  it('fans a permission_mode patch out through the session agent registry', async () => {
+    const broadcastPermissionMode = vi.fn();
+    const agent: IAgentScopeHandle = {
+      id: 'main',
+      kind: LifecycleScope.Agent,
+      accessor: accessor([
+        [IAgentProfileService, { _serviceBrand: undefined }],
+        [IAgentLifecycleService, { broadcastPermissionMode }],
+      ]),
+      dispose: () => {},
+    };
+    const agents = {
+      create: () => Promise.resolve(agent),
+      whenReady: () => Promise.resolve(agent),
+      list: () => [agent],
+      broadcastPermissionMode,
+    } as unknown as IAgentLifecycleService;
+    const session: ISessionScopeHandle = {
+      id: 'session-test',
+      kind: LifecycleScope.Session,
+      accessor: accessor([
+        [IAgentLifecycleService, agents],
+        [
+          ISessionMetadata,
+          {
+            read: () =>
+              Promise.resolve({ id: 'session-test', createdAt: 0, updatedAt: 0, archived: false }),
+          },
+        ],
+        [ISessionContext, { workspaceId: 'ws-test', cwd: '/workspace' }],
+      ]),
+      dispose: () => {},
+    };
+    ix.stub(ISessionLifecycleService, {
+      resume: () => Promise.resolve(session),
+      get: () => session,
+    });
+    ix.set(ISessionLegacyService, new SyncDescriptor(SessionLegacyService));
+
+    await ix.get(ISessionLegacyService).updateProfile('session-test', {
+      agent_config: { permission_mode: 'yolo' },
+    });
+
+    expect(broadcastPermissionMode).toHaveBeenCalledWith('yolo');
   });
 });

--- a/packages/agent-core-v2/test/app/sessionLifecycle/sessionLifecycle.test.ts
+++ b/packages/agent-core-v2/test/app/sessionLifecycle/sessionLifecycle.test.ts
@@ -279,6 +279,7 @@ function agentLifecycleStub(): IAgentLifecycleService {
     get: () => undefined,
     list: () => [],
     remove: () => Promise.resolve(),
+    broadcastPermissionMode: () => {},
   };
 }
 

--- a/packages/agent-core-v2/test/harness/agent.ts
+++ b/packages/agent-core-v2/test/harness/agent.ts
@@ -6,7 +6,9 @@ import { createControlledPromise } from '@antfu/utils';
 import { expect, vi } from 'vitest';
 
 import { toDisposable } from '#/_base/di/lifecycle';
+import type { IAgentScopeHandle } from '#/_base/di/scope';
 import { Event } from '#/_base/event';
+import { IAgentLifecycleService } from '#/session/agentLifecycle/agentLifecycle';
 import type { PromisifyMethods } from '#/_base/utils/types';
 import { escapeXmlAttr } from '#/_base/utils/xml-escape';
 import type { AgentTaskInfo } from '#/agent/task/task';
@@ -994,6 +996,28 @@ export class AgentTestContext {
             reg.defineInstance(ISessionInteractionService, this.createInteractionService());
             reg.defineInstance(ISessionApprovalService, this.createApprovalService());
             reg.defineInstance(ISessionQuestionService, this.createQuestionService());
+            // The harness builds its single agent scope directly, so the real
+            // `AgentLifecycleService` never tracks it; the broadcast fan-out
+            // still lands on that agent to keep `setPermission` observable.
+            reg.defineInstance(IAgentLifecycleService, {
+              _serviceBrand: undefined,
+              onDidCreate: Event.None as Event<IAgentScopeHandle>,
+              onDidDispose: Event.None as Event<string>,
+              create: () =>
+                Promise.reject(
+                  new Error('IAgentLifecycleService.create is not supported in the test harness'),
+                ),
+              fork: () =>
+                Promise.reject(
+                  new Error('IAgentLifecycleService.fork is not supported in the test harness'),
+                ),
+              get: () => undefined,
+              list: () => [],
+              remove: () => Promise.resolve(),
+              broadcastPermissionMode: (mode: PermissionMode) => {
+                this.agent.accessor.get(IAgentPermissionModeService).setMode(mode);
+              },
+            } satisfies IAgentLifecycleService);
             reg.defineDescriptor(
               ISessionWorkspaceContext,
               new SyncDescriptor(SessionWorkspaceContextService),

--- a/packages/agent-core-v2/test/harness/agent.ts
+++ b/packages/agent-core-v2/test/harness/agent.ts
@@ -996,9 +996,6 @@ export class AgentTestContext {
             reg.defineInstance(ISessionInteractionService, this.createInteractionService());
             reg.defineInstance(ISessionApprovalService, this.createApprovalService());
             reg.defineInstance(ISessionQuestionService, this.createQuestionService());
-            // The harness builds its single agent scope directly, so the real
-            // `AgentLifecycleService` never tracks it; the broadcast fan-out
-            // still lands on that agent to keep `setPermission` observable.
             reg.defineInstance(IAgentLifecycleService, {
               _serviceBrand: undefined,
               onDidCreate: Event.None as Event<IAgentScopeHandle>,

--- a/packages/agent-core-v2/test/session/agentLifecycle/agentLifecycle.test.ts
+++ b/packages/agent-core-v2/test/session/agentLifecycle/agentLifecycle.test.ts
@@ -470,6 +470,27 @@ describe('AgentLifecycleService', () => {
     expect(permissionModeSetMode).not.toHaveBeenCalled();
   });
 
+  it('broadcastPermissionMode sets the mode on every live agent', async () => {
+    const svc = ix.get(IAgentLifecycleService);
+    await svc.create({ agentId: 'main' });
+    await svc.create({ agentId: 'child' });
+
+    svc.broadcastPermissionMode('yolo');
+
+    expect(permissionModeSetMode.mock.calls).toEqual([['yolo'], ['yolo']]);
+  });
+
+  it('broadcastPermissionMode skips agents that have been removed', async () => {
+    const svc = ix.get(IAgentLifecycleService);
+    await svc.create({ agentId: 'main' });
+    await svc.create({ agentId: 'child' });
+    await svc.remove('child');
+
+    svc.broadcastPermissionMode('auto');
+
+    expect(permissionModeSetMode.mock.calls).toEqual([['auto']]);
+  });
+
   it('wires MCP OAuth credentials through the session atomic document store', async () => {
     const svc = ix.get(IAgentLifecycleService);
     const main = await svc.create({ agentId: 'main' });

--- a/packages/agent-core-v2/test/session/swarm/sessionSwarm.test.ts
+++ b/packages/agent-core-v2/test/session/swarm/sessionSwarm.test.ts
@@ -1243,6 +1243,7 @@ function lifecycleStub(
     remove: async (agentId: string) => {
       handles.delete(agentId);
     },
+    broadcastPermissionMode: () => {},
   };
   return lifecycle as IAgentLifecycleService;
 }

--- a/packages/agent-core-v2/test/session/todo/sessionTodo.test.ts
+++ b/packages/agent-core-v2/test/session/todo/sessionTodo.test.ts
@@ -146,6 +146,7 @@ function makeLifecycleStub(handles: readonly IAgentScopeHandle[] = []): Lifecycl
     onDidDispose: onDidDispose.event,
     get: (id: string) => byId.get(id),
     list: () => [...byId.values()],
+    broadcastPermissionMode: () => {},
     create: async () => {
       throw new Error('not implemented');
     },

--- a/packages/agent-core-v2/test/session/workspaceCommand/workspaceCommand.test.ts
+++ b/packages/agent-core-v2/test/session/workspaceCommand/workspaceCommand.test.ts
@@ -187,6 +187,7 @@ function agentsStub(): AgentsStub {
     get: (id) => (id === MAIN_AGENT_ID && mainPresent ? mainHandle : undefined),
     list: () => [],
     remove: () => Promise.resolve(),
+    broadcastPermissionMode: () => {},
     setMain: (present) => {
       mainPresent = present;
       if (present) created.fire(mainHandle);

--- a/packages/agent-core-v2/test/tool/tool.test.ts
+++ b/packages/agent-core-v2/test/tool/tool.test.ts
@@ -283,6 +283,7 @@ function createAgentLifecycleStub(options: AgentLifecycleStubOptions = {}): Agen
     }),
     get: vi.fn((agentId) => handles.get(agentId)),
     list: vi.fn(() => [...handles.values()]),
+    broadcastPermissionMode: vi.fn(),
     remove: vi.fn(async (agentId) => {
       handles.delete(agentId);
     }),


### PR DESCRIPTION
## Related Issue

No linked issue — the problem is explained below.

## Problem

Switching the permission mode while subagents are running (e.g. toggling yolo/auto mid-session) only applied to the main agent. Subagents that were already running kept observing the old mode, so a session-level switch did not actually take effect for them. The same gap existed in the legacy `agent_config.permission_mode` patch path, which only set the mode on the main agent.

## What changed

- Added `IAgentLifecycleService.broadcastPermissionMode(mode)`, which sets the permission mode on every live agent in the session registry — the registry is the only place that can reach all live agents.
- The `setPermission` RPC now fans the mode out through this broadcast when it is addressed to the main agent (the session-level switch); switches addressed to any other agent stay local to that agent.
- The legacy `agent_config.permission_mode` patch in `SessionLegacyService` now routes through the same broadcast instead of only touching the main agent.

Each agent still journals its own `permission.set_mode` op, so per-agent resume behavior is unchanged.

Tests: new coverage for the broadcast (hits every live agent, skips removed agents), the `setPermission` RPC, and the legacy patch fan-out; existing agent-lifecycle stubs updated for the new interface member.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.
