### PR TITLE
feat(vscode): scope thinking effort to the current session

### DIFF
--- a/apps/vscode/shared/bridge.ts
+++ b/apps/vscode/shared/bridge.ts
@@ -156,7 +156,8 @@ function validateParams(method: RpcMethod, params: unknown): boolean {
       return isPlainObject(params)
         && typeof params["model"] === "string"
         && isOptionalType(params["thinking"], "boolean")
-        && isOptionalType(params["effort"], "string");
+        && isOptionalType(params["effort"], "string")
+        && isOptionalType(params["effortChanged"], "boolean");
     case Methods.AddMCPServer:
       return isMcpServerConfig(params);
     case Methods.UpdateMCPServer:

--- a/apps/vscode/shared/types.ts
+++ b/apps/vscode/shared/types.ts
@@ -4,6 +4,13 @@ export interface SessionConfig {
   model: string;
   thinking?: boolean;
   effort?: string;
+  /**
+   * Whether the user explicitly changed the effort. Re-confirming the effort
+   * already shown is not an explicit choice: the model is persisted but the
+   * stored effort preference is left alone (mirrors the TUI's
+   * persistModelSelection). Treated as true when omitted.
+   */
+  effortChanged?: boolean;
 }
 
 export interface ProjectFile {

--- a/apps/vscode/src/handlers/config.handler.ts
+++ b/apps/vscode/src/handlers/config.handler.ts
@@ -38,10 +38,27 @@ const SLASH_COMMANDS: SlashCommandInfo[] = [
 
 const saveConfig: Handler<SessionConfig, { ok: boolean }> = async (params, ctx) => {
   const effort = sessionConfigEffort(params);
-  await ctx.harness.setConfig({
-    defaultModel: params.model,
-    thinking: thinkingConfig(effort),
-  });
+  const effortChanged = params.effortChanged !== false;
+  const config = await ctx.harness.getConfig({ reload: true });
+  const model = config.models?.[params.model];
+  const full = thinkingConfig(
+    effort,
+    model === undefined ? undefined : effectiveModelAlias(model).supportEfforts,
+  );
+  // Re-confirming the effort already shown is not an explicit choice —
+  // persist the model but leave the stored effort preference alone (the TUI's
+  // persistModelSelection rule).
+  const patch = effortChanged ? full : { enabled: full.enabled };
+  if (
+    config.defaultModel !== params.model
+    || config.thinking?.enabled !== patch.enabled
+    || (effortChanged && config.thinking?.effort !== patch.effort)
+  ) {
+    await ctx.harness.setConfig({
+      defaultModel: params.model,
+      thinking: patch,
+    });
+  }
 
   const runtime = ctx.getSession();
   if (runtime !== undefined) {
@@ -138,9 +155,24 @@ function sessionConfigEffort(config: SessionConfig): ThinkingEffort {
   return config.thinking === true ? "on" : "off";
 }
 
-function thinkingConfig(effort: ThinkingEffort): { enabled: boolean; effort?: string } {
+/**
+ * Project a thinking effort to the `[thinking]` config patch persisted to
+ * config.toml — mirrors the TUI's thinkingEffortToConfig. "off" disables
+ * thinking; "on" is the boolean-model on-signal, so it only persists
+ * `enabled`. A concrete effort persists as the global default, EXCEPT the
+ * model's highest declared level — the last entry of `support_efforts` —
+ * which is session-only and records just `enabled`, so the most expensive
+ * tier never becomes the global default for every new session. When the
+ * model's levels are unknown the concrete effort is persisted as-is.
+ */
+function thinkingConfig(
+  effort: ThinkingEffort,
+  supportEfforts?: readonly string[],
+): { enabled: boolean; effort?: string } {
   if (effort === "off") return { enabled: false };
   if (effort === "on") return { enabled: true };
+  const top = supportEfforts?.at(-1);
+  if (top !== undefined && effort === top) return { enabled: true };
   return { enabled: true, effort };
 }
 

--- a/apps/vscode/test/bridge-handler.test.ts
+++ b/apps/vscode/test/bridge-handler.test.ts
@@ -25,6 +25,7 @@ const host = vi.hoisted(() => {
     homeDir: "/tmp/kimi-code-test-home",
     close: vi.fn(async () => undefined),
     getConfig: vi.fn(),
+    setConfig: vi.fn(async () => undefined),
     listSessions: vi.fn(async () => []),
     resumeSession: vi.fn(),
     forkSession: vi.fn(),
@@ -424,6 +425,91 @@ describe("Webview RPC boundary (validates requests before host dispatch)", () =>
       expect.stringContaining("Session state is invalid JSON at line 4"),
     );
     expect(next).toEqual({ id: "rpc-2", result: { ok: true } });
+  });
+});
+
+describe("Webview config saves (thinking effort persistence parity with the TUI)", () => {
+  const effortModel = {
+    provider: "managed:kimi-code",
+    model: "reasoning",
+    supportEfforts: ["low", "high", "max"],
+    defaultEffort: "high",
+  };
+
+  function mockConfig(thinking?: { enabled: boolean; effort?: string }) {
+    host.harness.getConfig.mockResolvedValue({
+      defaultModel: "kimi/reasoning",
+      thinking,
+      models: { "kimi/reasoning": effortModel },
+    } as never);
+  }
+
+  it("persists a non-top effort as the global default", async () => {
+    mockConfig();
+
+    const result = await bridge.handle(
+      { id: "rpc-1", method: Methods.SaveConfig, params: { model: "kimi/reasoning", thinking: true, effort: "high" } },
+      "view-1",
+    );
+
+    expect(result).toEqual({ id: "rpc-1", result: { ok: true } });
+    expect(host.harness.setConfig).toHaveBeenCalledWith({
+      defaultModel: "kimi/reasoning",
+      thinking: { enabled: true, effort: "high" },
+    });
+  });
+
+  it("keeps the model's top declared tier session-only", async () => {
+    mockConfig();
+
+    await bridge.handle(
+      { id: "rpc-1", method: Methods.SaveConfig, params: { model: "kimi/reasoning", thinking: true, effort: "max" } },
+      "view-1",
+    );
+
+    expect(host.harness.setConfig).toHaveBeenCalledWith({
+      defaultModel: "kimi/reasoning",
+      thinking: { enabled: true },
+    });
+  });
+
+  it("persists the concrete effort when the model's levels are unknown", async () => {
+    host.harness.getConfig.mockResolvedValue({ defaultModel: "other/model", models: {} });
+
+    await bridge.handle(
+      { id: "rpc-1", method: Methods.SaveConfig, params: { model: "custom/model", thinking: true, effort: "max" } },
+      "view-1",
+    );
+
+    expect(host.harness.setConfig).toHaveBeenCalledWith({
+      defaultModel: "custom/model",
+      thinking: { enabled: true, effort: "max" },
+    });
+  });
+
+  it("leaves the stored effort alone when the pick re-confirms the active effort", async () => {
+    mockConfig({ enabled: false, effort: "low" });
+
+    await bridge.handle(
+      { id: "rpc-1", method: Methods.SaveConfig, params: { model: "kimi/reasoning", thinking: true, effort: "high", effortChanged: false } },
+      "view-1",
+    );
+
+    expect(host.harness.setConfig).toHaveBeenCalledWith({
+      defaultModel: "kimi/reasoning",
+      thinking: { enabled: true },
+    });
+  });
+
+  it("skips the config write entirely when nothing changed", async () => {
+    mockConfig({ enabled: true, effort: "high" });
+
+    await bridge.handle(
+      { id: "rpc-1", method: Methods.SaveConfig, params: { model: "kimi/reasoning", thinking: true, effort: "high" } },
+      "view-1",
+    );
+
+    expect(host.harness.setConfig).not.toHaveBeenCalled();
   });
 });
 

--- a/apps/vscode/test/settings-store.test.ts
+++ b/apps/vscode/test/settings-store.test.ts
@@ -96,6 +96,7 @@ describe("Webview model settings persistence", () => {
       model: "proxy/shared",
       thinking: false,
       effort: "off",
+      effortChanged: false,
     });
   });
 
@@ -369,6 +370,50 @@ describe("Webview thinking effort parity with the TUI", () => {
 
     expect(useSettingsStore.getState().thinkingEffort).toBe(previous);
     expect(boundary.saveConfig).not.toHaveBeenCalled();
+  });
+
+  it("skips the config write when re-confirming the current effort", () => {
+    boundary.saveConfig.mockResolvedValue({ ok: true });
+    useSettingsStore.getState().initModels(MODELS, "reasoning", true);
+    expect(useSettingsStore.getState().thinkingEffort).toBe("high");
+    boundary.saveConfig.mockClear();
+
+    useSettingsStore.getState().selectThinkingEffort("high");
+
+    expect(useSettingsStore.getState().thinkingEffort).toBe("high");
+    expect(boundary.saveConfig).not.toHaveBeenCalled();
+  });
+
+  it("does not seed future sessions with the model's top declared tier", () => {
+    boundary.saveConfig.mockResolvedValue({ ok: true });
+    useSettingsStore.getState().initModels(MODELS, "reasoning", false);
+
+    useSettingsStore.getState().selectThinkingEffort("high");
+
+    expect(useSettingsStore.getState().thinkingEffort).toBe("high");
+    expect(boundary.saveConfig).toHaveBeenCalledWith({ model: "reasoning", thinking: true, effort: "high" });
+    expect(useSettingsStore.getState().defaultThinkingEffort).toBeUndefined();
+  });
+
+  it("seeds future sessions with a persisted non-top effort", () => {
+    boundary.saveConfig.mockResolvedValue({ ok: true });
+    useSettingsStore.getState().initModels(MODELS, "reasoning", false);
+
+    useSettingsStore.getState().selectThinkingEffort("low");
+
+    expect(useSettingsStore.getState().thinkingEffort).toBe("low");
+    expect(useSettingsStore.getState().defaultThinkingEffort).toBe("low");
+  });
+
+  it("marks the effort as changed when a model switch resolves to a different effort", () => {
+    boundary.saveConfig.mockResolvedValue({ ok: true });
+    useSettingsStore.getState().initModels(MODELS, "reasoning", true);
+    expect(useSettingsStore.getState().thinkingEffort).toBe("high");
+
+    useSettingsStore.getState().updateModel("always");
+
+    expect(useSettingsStore.getState().thinkingEffort).toBe("on");
+    expect(boundary.saveConfig).toHaveBeenCalledWith({ model: "always", thinking: true, effort: "on", effortChanged: true });
   });
 });
 

--- a/apps/vscode/webview-ui/src/components/ThinkingButton.tsx
+++ b/apps/vscode/webview-ui/src/components/ThinkingButton.tsx
@@ -11,6 +11,9 @@ interface ThinkingButtonProps {
   efforts?: string[];
   alwaysOn?: boolean;
   disabled?: boolean;
+  /** When set, rendered as a muted wrapping note below the effort options
+   * (e.g. the mid-conversation switch cache-cost notice). */
+  cacheNote?: string;
   onToggle: () => void;
   onSelectEffort: (effort: string) => void;
 }
@@ -19,7 +22,7 @@ function label(effort: string): string {
   return effort.charAt(0).toUpperCase() + effort.slice(1);
 }
 
-export function ThinkingButton({ mode, effort, efforts = [], alwaysOn = false, disabled, onToggle, onSelectEffort }: ThinkingButtonProps) {
+export function ThinkingButton({ mode, effort, efforts = [], alwaysOn = false, disabled, cacheNote, onToggle, onSelectEffort }: ThinkingButtonProps) {
   if (mode === "none") return null;
 
   const active = effort !== "off" || alwaysOn;
@@ -57,6 +60,11 @@ export function ThinkingButton({ mode, effort, efforts = [], alwaysOn = false, d
               {label(option)}
             </DropdownMenuItem>
           ))}
+          {cacheNote !== undefined && (
+            <div className="w-44 px-2 py-1.5 text-[10px] leading-snug whitespace-normal text-muted-foreground">
+              {cacheNote}
+            </div>
+          )}
         </DropdownMenuContent>
       </DropdownMenu>
     );

--- a/apps/vscode/webview-ui/src/components/inputarea/InputArea.tsx
+++ b/apps/vscode/webview-ui/src/components/inputarea/InputArea.tsx
@@ -43,6 +43,9 @@ interface InputAreaProps {
   onAuthAction?: () => void;
 }
 
+const SWITCH_CACHE_NOTE =
+  "Note: Switching models or thinking effort invalidates the existing prompt cache. Start a new conversation to avoid extra token costs.";
+
 export function InputArea({ onAuthAction }: InputAreaProps) {
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const menuRef = useRef<HTMLDivElement>(null);
@@ -50,11 +53,14 @@ export function InputArea({ onAuthAction }: InputAreaProps) {
   const [cursorPos, setCursorPos] = useState(0);
   const [previewMedia, setPreviewMedia] = useState<string | null>(null);
 
-  const { isStreaming, sendMessage, abort, draftMedia, removeDraftMedia, hasProcessingMedia, getMediaInConversation, pendingInput, planMode } = useChatStore();
+  const { isStreaming, sendMessage, abort, draftMedia, removeDraftMedia, hasProcessingMedia, getMediaInConversation, pendingInput, planMode, messages } = useChatStore();
   const { currentModel, thinkingEffort, updateModel, toggleThinking, selectThinkingEffort, models, extensionConfig, getCurrentThinkingMode } = useSettingsStore();
 
   const isProcessing = hasProcessingMedia();
   const thinkingMode = getCurrentThinkingMode();
+  // A switch from a non-empty conversation resends the accumulated context,
+  // losing the prompt cache — surface the cost note in the switcher dropdowns.
+  const hasConversationHistory = messages.some((message) => message.role === "user");
 
   const [showPlanModeConfirm, setShowPlanModeConfirm] = useState(false);
 
@@ -447,6 +453,14 @@ export function InputArea({ onAuthAction }: InputAreaProps) {
                       {showProviderGroups && groupIndex < modelGroups.length - 1 && <DropdownMenuSeparator />}
                     </Fragment>
                   ))}
+                  {hasConversationHistory && (
+                    <>
+                      <DropdownMenuSeparator />
+                      <div className="px-3 py-1.5 text-[10px] leading-snug whitespace-normal text-muted-foreground">
+                        {SWITCH_CACHE_NOTE}
+                      </div>
+                    </>
+                  )}
                 </DropdownMenuContent>
               </DropdownMenu>
 
@@ -456,6 +470,7 @@ export function InputArea({ onAuthAction }: InputAreaProps) {
                 efforts={currentModelConfig?.support_efforts}
                 alwaysOn={currentModelConfig?.capabilities.includes("always_thinking")}
                 disabled={isStreaming}
+                cacheNote={hasConversationHistory ? SWITCH_CACHE_NOTE : undefined}
                 onToggle={toggleThinking}
                 onSelectEffort={selectThinkingEffort}
               />

--- a/apps/vscode/webview-ui/src/stores/settings.store.ts
+++ b/apps/vscode/webview-ui/src/stores/settings.store.ts
@@ -205,7 +205,12 @@ export const useSettingsStore = create<SettingsState>((set, get) => ({
     const thinkingEffort = defaultEffortForModel(model, defaultThinking, defaultThinkingEffort);
     set({ currentModel: modelId, thinkingEffort });
     saveConfigWithRollback(
-      { model: modelId, thinking: thinkingEffort !== "off", effort: thinkingEffort },
+      {
+        model: modelId,
+        thinking: thinkingEffort !== "off",
+        effort: thinkingEffort,
+        effortChanged: thinkingEffort !== previousEffort,
+      },
       { currentModel, thinkingEffort: previousEffort },
       set,
     );
@@ -247,10 +252,19 @@ export const useSettingsStore = create<SettingsState>((set, get) => ({
     const alwaysOn = model.capabilities.includes("always_thinking");
     if (thinkingEffort !== "off" && thinkingEffort !== "on" && !allowed.includes(thinkingEffort)) return;
     if (alwaysOn && thinkingEffort === "off") return;
+    // Re-confirming the effort already shown is not an explicit choice —
+    // skip the state update and the config write entirely.
+    if (thinkingEffort === previousEffort) return;
     set({
       thinkingEffort,
       defaultThinking: thinkingEffort !== "off",
-      defaultThinkingEffort: thinkingEffort !== "off" && thinkingEffort !== "on" ? thinkingEffort : undefined,
+      // The model's top declared tier is session-only (only the boolean
+      // toggle is persisted), so it must not become the configured-effort
+      // seed for future sessions.
+      defaultThinkingEffort:
+        thinkingEffort !== "off" && thinkingEffort !== "on" && thinkingEffort !== allowed.at(-1)
+          ? thinkingEffort
+          : defaultThinkingEffort,
     });
     saveConfigWithRollback(
       { model: currentModel, thinking: thinkingEffort !== "off", effort: thinkingEffort },


### PR DESCRIPTION
## Related Issue

No linked issue — the problem is explained below. This ports the TUI's thinking-effort rules from #1933 (and the switch warning from #1763 / web #1940) to the VS Code extension so both surfaces behave the same.

## Problem

The VS Code extension persisted **every** concrete thinking effort pick to the global `config.toml`, including a model's highest declared tier (e.g. `max`). A top-tier pick therefore became the global default for every future session, and re-confirming the already-active effort rewrote the config on every click. The TUI has already moved to session-scoped behavior: the top tier is session-only, only the boolean thinking toggle is persisted for it, and unchanged picks skip the write entirely.

## What changed

- **Persistence parity with the TUI** (`config.handler.ts`): the `[thinking]` config patch now follows the same rules as the TUI's `thinkingEffortToConfig` — `off` persists `enabled: false`, `on` persists only `enabled: true`, and a concrete effort equal to the model's top declared `support_efforts` entry persists only `enabled: true` (session-only tier, applied to the live session via `setThinking` as before); lower tiers persist as the global default; unknown model metadata keeps the concrete effort. `saveConfig` reloads the config and skips the write when nothing changed.
- **Re-confirm is not an explicit choice**: the webview sends a new optional `effortChanged` flag on the `saveConfig` bridge message (defaults to true, wire-compatible); when false, only the model and the boolean toggle are persisted, leaving the stored effort preference (including a hand-written `config.toml` value) untouched. Selecting the already-active effort in the webview now returns early without any write.
- **Top tier does not seed future sessions** (`settings.store.ts`): a top-tier pick is no longer cached as the configured-effort seed used when switching models.
- **Cache-loss warning**: when the conversation already contains user messages, the model dropdown and the thinking-effort dropdown show a note that switching models or thinking effort invalidates the existing prompt cache and suggest starting a new conversation (same copy intent as the TUI/web warnings).
- New sessions keep following the backend-provided `default_effort`; the one-shot persisted-`max` → `high` migration from #1933 lives in agent-core and applies here unchanged.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works. (host-side `saveConfig` persistence rules in `bridge-handler.test.ts`; webview store rules in `settings-store.test.ts`)
- [x] Ran `gen-changesets` skill, or this PR needs no changeset. (VS Code extension only; the app is versioned by its own release chore, per recent vscode-only PRs.)
- [x] Ran `gen-docs` skill, or this PR needs no doc update.