### PR TITLE
feat: support max and exact version targeting for tips banner

### DIFF
--- a/.changeset/banner-version-targeting.md
+++ b/.changeset/banner-version-targeting.md
@@ -1,5 +1,0 @@
----
-"@moonshot-ai/kimi-code": patch
----
-
-Support maximum-version and exact-version targeting for the remote tips banner, alongside the existing minimum-version filter.

--- a/.changeset/banner-version-targeting.md
+++ b/.changeset/banner-version-targeting.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Support maximum-version and exact-version targeting for the remote tips banner, alongside the existing minimum-version filter.

--- a/apps/kimi-code/src/tui/banner/banner-provider.ts
+++ b/apps/kimi-code/src/tui/banner/banner-provider.ts
@@ -1,24 +1,29 @@
 import { createHash } from 'node:crypto';
 
-import { gte, valid } from 'semver';
+import { eq, gte, lt, valid } from 'semver';
 
 import { KIMI_CODE_TIPS_BANNER_URL } from '#/constant/app';
 import type { BannerDisplay, BannerState } from '#/tui/types';
 
 import type { BannerDisplayState } from './state';
 
-interface TipsBannerFallbackItem {
+interface BannerVersionFields {
+  banner_min_version?: string | null;
+  banner_max_version?: string | null;
+  banner_version?: string | null;
+}
+
+interface TipsBannerFallbackItem extends BannerVersionFields {
   banner_id?: string | null;
   enabled?: boolean;
   banner_title?: string | null;
   banner_maintext?: string;
   banner_subtext?: string | null;
-  banner_min_version?: string | null;
   banner_display?: unknown;
   banner_display_ttl_hours?: unknown;
 }
 
-interface TipsBannerJson {
+interface TipsBannerJson extends BannerVersionFields {
   banner_id?: string | null;
   banner_enabled?: boolean;
   banner_title?: string | null;
@@ -26,7 +31,6 @@ interface TipsBannerJson {
   banner_subtext?: string | null;
   banner_start_time?: string | null;
   banner_end_time?: string | null;
-  banner_min_version?: string | null;
   banner_display?: unknown;
   banner_display_ttl_hours?: unknown;
   banner_fallback_enabled?: boolean;
@@ -102,13 +106,27 @@ function isWithinWindow(start: Date | null, end: Date | null, now: Date): boolea
   return true;
 }
 
-function meetsMinVersion(minVersion: unknown, clientVersion: string): boolean {
-  if (minVersion === undefined || minVersion === null) return true;
-  if (typeof minVersion !== 'string' || minVersion.length === 0) return true;
-  const min = valid(minVersion);
+type VersionConstraintCompare = (current: string, target: string) => boolean;
+
+function meetsVersionConstraint(
+  constraint: unknown,
+  clientVersion: string,
+  compare: VersionConstraintCompare,
+): boolean {
+  if (constraint === undefined || constraint === null) return true;
+  if (typeof constraint !== 'string' || constraint.length === 0) return true;
+  const target = valid(constraint);
   const current = valid(clientVersion);
-  if (min === null || current === null) return false;
-  return gte(current, min);
+  if (target === null || current === null) return false;
+  return compare(current, target);
+}
+
+function meetsVersion(banner: BannerVersionFields, clientVersion: string): boolean {
+  return (
+    meetsVersionConstraint(banner.banner_min_version, clientVersion, gte) &&
+    meetsVersionConstraint(banner.banner_max_version, clientVersion, lt) &&
+    meetsVersionConstraint(banner.banner_version, clientVersion, eq)
+  );
 }
 
 function parseBannerDisplay(value: unknown): BannerDisplay {
@@ -179,7 +197,7 @@ function pickActiveBanner(
   now: Date,
 ): BannerState | null {
   if (json.banner_enabled !== true) return null;
-  if (!meetsMinVersion(json.banner_min_version, clientVersion)) return null;
+  if (!meetsVersion(json, clientVersion)) return null;
   const start = parseDate(json.banner_start_time);
   const end = parseDate(json.banner_end_time);
   if (!isWithinWindow(start, end, now)) return null;
@@ -209,7 +227,7 @@ function pickFallbackCandidates(
     if (typeof raw !== 'object' || raw === null) continue;
     const item = raw as TipsBannerFallbackItem;
     if (item.enabled !== true) continue;
-    if (!meetsMinVersion(item.banner_min_version, clientVersion)) continue;
+    if (!meetsVersion(item, clientVersion)) continue;
     const mainText = normalizeText(item.banner_maintext);
     if (mainText === null) continue;
     const display = parseBannerDisplay(item.banner_display);

--- a/apps/kimi-code/test/tui/banner/banner-provider.test.ts
+++ b/apps/kimi-code/test/tui/banner/banner-provider.test.ts
@@ -67,6 +67,64 @@ describe('selectBannerState', () => {
     expect(result).toBeNull();
   });
 
+  it('shows the active banner only below banner_max_version', () => {
+    const json = {
+      banner_enabled: true,
+      banner_maintext: 'Upgrade',
+      banner_max_version: '0.15.0',
+    };
+    expect(selectBannerState(json, '0.14.0', now, () => 0)).toMatchObject({
+      mainText: 'Upgrade',
+    });
+    expect(selectBannerState(json, '0.15.0', now, () => 0)).toBeNull();
+    expect(selectBannerState(json, '0.16.0', now, () => 0)).toBeNull();
+  });
+
+  it('shows the active banner only on the exact banner_version', () => {
+    const json = {
+      banner_enabled: true,
+      banner_maintext: 'Pinned',
+      banner_version: '0.14.0',
+    };
+    expect(selectBannerState(json, '0.14.0', now, () => 0)).toMatchObject({
+      mainText: 'Pinned',
+    });
+    expect(selectBannerState(json, '0.14.1', now, () => 0)).toBeNull();
+    expect(selectBannerState(json, '0.13.9', now, () => 0)).toBeNull();
+  });
+
+  it('combines min and max version as an inclusive-exclusive range', () => {
+    const json = {
+      banner_enabled: true,
+      banner_maintext: 'Range',
+      banner_min_version: '0.13.0',
+      banner_max_version: '0.15.0',
+    };
+    expect(selectBannerState(json, '0.12.9', now, () => 0)).toBeNull();
+    expect(selectBannerState(json, '0.13.0', now, () => 0)).not.toBeNull();
+    expect(selectBannerState(json, '0.14.9', now, () => 0)).not.toBeNull();
+    expect(selectBannerState(json, '0.15.0', now, () => 0)).toBeNull();
+  });
+
+  it('filters out the banner when a version constraint is not valid semver', () => {
+    for (const constraint of [
+      { banner_max_version: 'not-a-version' },
+      { banner_version: 'not-a-version' },
+    ]) {
+      const result = selectBannerState(
+        {
+          banner_enabled: true,
+          banner_maintext: 'Broken',
+          ...constraint,
+        },
+        '0.14.0',
+        now,
+        () => 0,
+      );
+      expect(result).toBeNull();
+    }
+  });
+
   it('picks a random enabled fallback when the active banner is not shown', () => {
     const result = selectBannerState(
       {
@@ -99,6 +157,24 @@ describe('selectBannerState', () => {
       () => 0,
     );
     expectAlwaysBanner(result, { tag: null, mainText: 'Old tip', subText: null });
+  });
+
+  it('filters out fallback entries by max and exact version', () => {
+    const result = selectBannerState(
+      {
+        banner_enabled: false,
+        banner_fallback_enabled: true,
+        banner_fallback_list: [
+          { enabled: true, banner_maintext: 'Too new', banner_max_version: '0.14.0' },
+          { enabled: true, banner_maintext: 'Other version', banner_version: '0.13.0' },
+          { enabled: true, banner_maintext: 'Matching', banner_version: '0.14.0' },
+        ],
+      },
+      '0.14.0',
+      now,
+      () => 0.99,
+    );
+    expectAlwaysBanner(result, { tag: null, mainText: 'Matching', subText: null });
   });
 
   it('returns null when no enabled fallback entries exist', () => {


### PR DESCRIPTION
## Related Issue

No linked issue — the problem is explained below.

## Problem

The remote tips banner can only be gated by a minimum client version (`banner_min_version`). That makes it impossible to target a banner at clients below a certain version (e.g. an upgrade reminder that should stop showing once the client is up to date) or to pin a banner to one specific version.

## What changed

Adds two optional version fields to the tips banner schema, applied to both the active banner and fallback list entries:

- `banner_max_version`: show only when the client version is strictly below this version (exclusive upper bound).
- `banner_version`: show only when the client version exactly matches this version.

All three version fields combine with AND semantics, so `banner_min_version` + `banner_max_version` forms an inclusive-exclusive range `[min, max)`. A missing or empty field means no constraint; a constraint that is not valid semver (or an unparseable client version) fails closed and hides the banner, matching the existing `banner_min_version` behavior. Older clients ignore the new fields, so a banner gated only by them shows to all versions on those clients.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.