### PR TITLE
fix(pi-tui): anchor cursor and pin height for inline images

### DIFF
--- a/.changeset/cli-inline-image-overlap.md
+++ b/.changeset/cli-inline-image-overlap.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Fix text fragments overlapping inline images and stale rows left on screen after pasting a screenshot in the terminal UI.

--- a/.changeset/pi-tui-inline-image-cursor.md
+++ b/.changeset/pi-tui-inline-image-cursor.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/pi-tui": patch
+---
+
+Anchor the cursor with save/restore around inline image draws and pin the iTerm2 image height to the reserved rows, so image rendering no longer desyncs the differential renderer's row accounting.

--- a/packages/pi-tui/src/components/image.ts
+++ b/packages/pi-tui/src/components/image.ts
@@ -90,7 +90,11 @@ export class Image implements Component {
 				if (caps.images === "kitty") {
 					// For Kitty: C=1 prevents cursor movement.
 					// Don't need the cursor movement.
-					lines = [result.sequence];
+					// Wrap in DEC save/restore cursor as a safety net: some
+					// emulators move the cursor while placing the image
+					// despite C=1, which would corrupt the TUI's row
+					// accounting. On spec-compliant terminals this is a no-op.
+					lines = [`\x1b7${result.sequence}\x1b8`];
 
 					// Return `rows` lines so TUI accounts for image height.
 					for (let i = 0; i < result.rows - 1; i++) {
@@ -99,15 +103,18 @@ export class Image implements Component {
 				} else {
 					// Return `rows` lines so TUI accounts for image height.
 					// First (rows-1) lines are empty and cleared before the image is drawn.
-					// Last line: move cursor back up, draw the image, then move back down
-					// so TUI cursor accounting stays inside the scroll area.
+					// Last line: save the cursor, move up to the first reserved row,
+					// draw the image, then restore the cursor. Terminals disagree on
+					// where the cursor lands after an inline image (iTerm2 moves it
+					// below the image, some emulators don't move it at all), so anchor
+					// it explicitly to keep the TUI's cursor accounting exact.
 					lines = [];
 					for (let i = 0; i < result.rows - 1; i++) {
 						lines.push("");
 					}
 					const rowOffset = result.rows - 1;
 					const moveUp = rowOffset > 0 ? `\x1b[${rowOffset}A` : "";
-					lines.push(moveUp + result.sequence);
+					lines.push(`\x1b7${moveUp}${result.sequence}\x1b8`);
 				}
 			} else {
 				const fallback = imageFallback(this.mimeType, this.dimensions, this.options.filename);

--- a/packages/pi-tui/src/terminal-image.ts
+++ b/packages/pi-tui/src/terminal-image.ts
@@ -454,9 +454,15 @@ export function renderImage(
 	}
 
 	if (caps.images === "iterm2") {
+		// Pin the height in cells instead of "auto". With "auto" the terminal
+		// derives the drawn height from its own cell metrics, which need not
+		// match the rows the TUI reserved (default cell dims, maxHeightCells
+		// caps, or emulators with different cell geometry) — the image then
+		// overflows or underfills its reservation and the post-draw cursor
+		// position no longer matches the TUI's row accounting.
 		const sequence = encodeITerm2(base64Data, {
 			width: size.columns,
-			height: "auto",
+			height: size.rows,
 			preserveAspectRatio: options.preserveAspectRatio ?? true,
 		});
 		return { sequence, rows: size.rows };

--- a/packages/pi-tui/test/terminal-image.test.ts
+++ b/packages/pi-tui/test/terminal-image.test.ts
@@ -453,10 +453,13 @@ describe("Kitty image cursor movement", () => {
 			const lines = image.render(4);
 			const imageId = image.getImageId();
 			assert.strictEqual(typeof imageId, "number");
-			assert.ok(lines[0].startsWith("\x1b_G"));
+			// The placement is wrapped in DEC save/restore cursor so terminals
+			// that move the cursor during placement despite C=1 cannot corrupt
+			// the TUI's row accounting.
+			assert.ok(lines[0].startsWith("\x1b7\x1b_G"));
 			assert.ok(lines[0].includes(",C=1,"));
 			assert.ok(lines[0].includes(`,i=${imageId}`));
-			assert.ok(lines[0].endsWith("\x1b\\"));
+			assert.ok(lines[0].endsWith("\x1b\\\x1b8"));
 			assert.deepStrictEqual(lines.slice(1, lines.length), [""]);
 		} finally {
 			resetCapabilitiesCache();
@@ -465,7 +468,81 @@ describe("Kitty image cursor movement", () => {
 	});
 });
 
-describe("hyperlink", () => {
+describe("iTerm2 inline image rendering", () => {
+	const iterm2Caps = { images: "iterm2", trueColor: true, hyperlinks: true } as const;
+
+	it("pins the drawn height in cells so it always matches the reserved rows", () => {
+		setCapabilities(iterm2Caps);
+		setCellDimensions({ widthPx: 10, heightPx: 10 });
+		try {
+			// 2000x1514 screenshot capped to 12 rows: with height=auto the
+			// terminal derives the height from its own cell metrics (13 rows
+			// with 9x18 cells), overflowing the 12 reserved rows.
+			const result = renderImage("AAAA", { widthPx: 2000, heightPx: 1514 }, { maxWidthCells: 40, maxHeightCells: 12 });
+			assert.ok(result);
+			assert.strictEqual(result.rows, 12);
+			assert.ok(!result.sequence.includes("height=auto"), "height must be explicit, not auto");
+			assert.ok(result.sequence.includes(`height=${result.rows}`), "height must equal the reserved rows");
+		} finally {
+			resetCapabilitiesCache();
+			setCellDimensions({ widthPx: 9, heightPx: 18 });
+		}
+	});
+
+	it("Image component anchors the cursor with DEC save/restore around the draw", () => {
+		setCapabilities(iterm2Caps);
+		setCellDimensions({ widthPx: 10, heightPx: 10 });
+		try {
+			const image = new Image(
+				"AAAA",
+				"image/png",
+				{ fallbackColor: (value) => value },
+				{ maxWidthCells: 4 },
+				{ widthPx: 40, heightPx: 40 },
+			);
+			const lines = image.render(80);
+			// 40x40px at 10x10 cells capped to maxWidthCells=4 -> 4x4 cells.
+			assert.strictEqual(lines.length, 4);
+			assert.deepStrictEqual(lines.slice(0, 3), ["", "", ""]);
+			const drawLine = lines[3]!;
+			// Save cursor on the last reserved row, move to the first row, draw,
+			// restore: the cursor ends on the last reserved row no matter where
+			// the terminal leaves it after drawing (iTerm2 moves it below the
+			// image, some emulators don't move it at all).
+			assert.ok(drawLine.startsWith("\x1b7\x1b[3A"), "should save the cursor, then move up to the first row");
+			assert.ok(drawLine.includes("\x1b]1337;File="));
+			assert.ok(drawLine.endsWith("\x1b8"), "should restore the cursor after the draw");
+			// The wrapped line must still be recognized as an image line so the
+			// TUI skips width-truncation and style resets for it.
+			assert.ok(isImageLine(drawLine));
+		} finally {
+			resetCapabilitiesCache();
+			setCellDimensions({ widthPx: 9, heightPx: 18 });
+		}
+	});
+
+	it("single-row iTerm2 images omit the cursor-up but keep the save/restore anchor", () => {
+		setCapabilities(iterm2Caps);
+		setCellDimensions({ widthPx: 10, heightPx: 10 });
+		try {
+			const image = new Image(
+				"AAAA",
+				"image/png",
+				{ fallbackColor: (value) => value },
+				{ maxWidthCells: 1, maxHeightCells: 1 },
+				{ widthPx: 40, heightPx: 40 },
+			);
+			const lines = image.render(80);
+			assert.strictEqual(lines.length, 1);
+			const drawLine = lines[0]!;
+			assert.ok(drawLine.startsWith("\x1b7"));
+			assert.ok(!drawLine.includes("\x1b[1A"));
+			assert.ok(drawLine.endsWith("\x1b8"));
+		} finally {
+			resetCapabilitiesCache();
+			setCellDimensions({ widthPx: 9, heightPx: 18 });
+		}
+	});
 	it("wraps text in OSC 8 open and close sequences", () => {
 		const result = hyperlink("click me", "https://example.com");
 		assert.strictEqual(result, "\x1b]8;;https://example.com\x1b\\click me\x1b]8;;\x1b\\");


### PR DESCRIPTION
## Summary

Inline images (pasted screenshots rendered in the transcript) can corrupt the TUI's row accounting: after an image is drawn, the hardware cursor ends up on a different row than the renderer's model expects. Every subsequent differential write then lands on the wrong rows — visible as text fragments overlapping the image area and stale rows that never get cleared, until the next full redraw.

Two independent assumptions in the iTerm2 path cause this, plus one hardening gap in the Kitty path:

## Root cause

**1. `height=auto` makes the drawn row count unpredictable** (`renderImage` in `packages/pi-tui/src/terminal-image.ts`)

The TUI reserves `size.rows` lines for the image, computed by `calculateImageCellSize` from pi-tui's cell dimensions (default `9x18` until the terminal answers the cell-size query, and capped by `maxHeightCells`). But the escape sequence tells the terminal `height=auto`, so the *terminal* derives the drawn height from `width=<columns>` cells and **its own** cell metrics and aspect handling. These need not agree. Example: a 2000x1514 screenshot capped at `maxHeightCells: 12` reserves 12 rows, but with `9x18` cells and `width=32` an aspect-derived draw is `ceil(32 * 9/18 * 1514/2000) = 13` rows — one row more than reserved.

**2. The post-draw cursor position is assumed, not anchored** (`Image.render` in `packages/pi-tui/src/components/image.ts`)

For iTerm2 the component moves the cursor up to the first reserved row, emits the image, and assumes the cursor comes back to the last reserved row. That assumption holds only when the terminal leaves the cursor on the last drawn row **and** drawn rows == reserved rows. Real terminals differ: iTerm2 advances the cursor past the drawn image, and some emulators (e.g. SwiftTerm) line-feed once per drawn row, landing one row *below* the image. Any deviation desyncs every relative cursor move the differential renderer issues afterwards.

**3. Kitty `C=1` is not honored by all emulators** (same file)

The Kitty path relies on `C=1` ("don't move the cursor") — spec-correct, and fine on kitty/Ghostty/WezTerm. Emulators that move the cursor during placement anyway break the same accounting.

## Fix

- `renderImage` now emits `height=<size.rows>` (cells) instead of `height=auto` for iTerm2, so the drawn image always fits exactly the rows the TUI reserved (`preserveAspectRatio` still applies — the image is fit inside the `columns x rows` box, same as the Kitty `c=`/`r=` box).
- `Image.render` wraps both the Kitty and the iTerm2 draw in DEC save/restore cursor (`ESC 7` / `ESC 8`): save on the last reserved row, move to the draw position, draw, restore. The cursor deterministically returns to the row the TUI's model expects, regardless of terminal behavior. On spec-compliant terminals this is a no-op.

No other callers of `renderImage` exist besides the `Image` component.

## Test plan

- [x] `packages/pi-tui` suite passes: 712 tests (`node --test test/*.test.ts`)
- [x] New tests in `packages/pi-tui/test/terminal-image.test.ts`:
  - iTerm2 `renderImage` pins `height=<rows>`, never `height=auto` (uses the 2000x1514 / 12-row-cap overflow case)
  - iTerm2 `Image.render` emits `ESC 7` + cursor-up + OSC 1337 + `ESC 8` on the last of `rows` lines, and the wrapped line is still detected by `isImageLine`
  - single-row iTerm2 images omit the cursor-up but keep the save/restore anchor
- [x] Existing Kitty placement test updated to expect the save/restore wrapper (regression protection for the Kitty path)
- [x] `apps/kimi-code` image tests pass (`image-thumbnail`, `user-message`, `image-placeholder`: 25 tests)
- [x] `tsc --noEmit` clean for `pi-tui`; `oxlint --type-aware` reports no new warnings on changed files

<details><summary>Before/after: iTerm2 draw line for a 4-row image</summary>

Before:

```
\x1b[3A\x1b]1337;File=inline=1;width=4;height=auto;preserveAspectRatio=1:<b64>\x07
```

After:

```
\x1b7\x1b[3A\x1b]1337;File=inline=1;width=4;height=4;preserveAspectRatio=1:<b64>\x07\x1b8
```

The cursor is now guaranteed to be back on the last reserved row after the draw, and the image cannot exceed its 4 reserved rows.

</details>
