### PR TITLE
fix(pi-tui): skip Kitty keyboard protocol on Windows Terminal to prevent Cyrillic doubling

### DIFF
--- a/.changeset/strict-teams-attend.md
+++ b/.changeset/strict-teams-attend.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/pi-tui": patch
+---
+
+fix(pi-tui): skip Kitty keyboard protocol on Windows Terminal to prevent Cyrillic doubling

--- a/packages/pi-tui/src/terminal.ts
+++ b/packages/pi-tui/src/terminal.ts
@@ -241,7 +241,6 @@ export class ProcessTerminal implements Terminal {
 	private queryAndEnableKittyProtocol(): void {
 		this.setupStdinBuffer();
 		process.stdin.on("data", this.stdinDataHandler!);
-		this.keyboardProtocolPushed = true;
 		this.clearKeyboardProtocolNegotiationBuffer();
 
 		// Windows Terminal: skip Kitty keyboard protocol to avoid Cyrillic doubling.
@@ -253,6 +252,7 @@ export class ProcessTerminal implements Terminal {
 			return;
 		}
 
+		this.keyboardProtocolPushed = true;
 		process.stdout.write(KITTY_KEYBOARD_PROTOCOL_QUERY);
 	}
 

--- a/packages/pi-tui/src/terminal.ts
+++ b/packages/pi-tui/src/terminal.ts
@@ -41,6 +41,21 @@ export function isAppleTerminalSession(): boolean {
 	return process.platform === "darwin" && process.env['TERM_PROGRAM'] === "Apple_Terminal";
 }
 
+/**
+ * Detect Windows Terminal by checking for the WT_SESSION environment variable.
+ * Windows Terminal sets WT_SESSION to a unique GUID for every tab.
+ * Exclude SSH sessions (where the terminal is remote, not local WT).
+ */
+function isWindowsTerminal(): boolean {
+	return (
+		process.platform === "win32" &&
+		Boolean(process.env['WT_SESSION']) &&
+		!process.env['SSH_CONNECTION'] &&
+		!process.env['SSH_CLIENT'] &&
+		!process.env['SSH_TTY']
+	);
+}
+
 export function normalizeAppleTerminalInput(data: string, isAppleTerminal: boolean, isShiftPressed: boolean): string {
 	if (isAppleTerminal && data === "\r" && isShiftPressed) return APPLE_TERMINAL_SHIFT_ENTER_SEQUENCE;
 	return data;
@@ -216,12 +231,28 @@ export class ProcessTerminal implements Terminal {
 	 * - 1 = disambiguate escape codes
 	 * - 2 = report event types (press/repeat/release)
 	 * - 4 = report alternate keys (shifted key, base layout key)
+	 *
+	 * On Windows Terminal, Kitty keyboard protocol with flag 4 (alternate keys)
+	 * causes Cyrillic and other non-Latin characters to be double-processed:
+	 * the terminal sends both the CSI-u sequence AND the raw character, resulting
+	 * in doubled input. Skip Kitty protocol on Windows Terminal and fall back to
+	 * modifyOtherKeys instead.
 	 */
 	private queryAndEnableKittyProtocol(): void {
 		this.setupStdinBuffer();
 		process.stdin.on("data", this.stdinDataHandler!);
 		this.keyboardProtocolPushed = true;
 		this.clearKeyboardProtocolNegotiationBuffer();
+
+		// Windows Terminal: skip Kitty keyboard protocol to avoid Cyrillic doubling.
+		// The terminal sends CSI-u sequences for non-Latin characters when Kitty
+		// protocol flag 4 (alternate keys) is active, but also sends the raw
+		// character, causing every Cyrillic keystroke to be inserted twice.
+		if (isWindowsTerminal()) {
+			this.enableModifyOtherKeys();
+			return;
+		}
+
 		process.stdout.write(KITTY_KEYBOARD_PROTOCOL_QUERY);
 	}
 

--- a/packages/pi-tui/test/terminal.test.ts
+++ b/packages/pi-tui/test/terminal.test.ts
@@ -31,7 +31,7 @@ describe("ProcessTerminal Kitty keyboard protocol negotiation", () => {
 		cleanup(): void;
 	};
 
-	function setupNegotiation(): NegotiationHarness {
+	function setupNegotiation(options?: { windowsTerminal?: boolean }): NegotiationHarness {
 		const terminal = new ProcessTerminal();
 		const writes: string[] = [];
 		let input: string | undefined;
@@ -39,6 +39,12 @@ describe("ProcessTerminal Kitty keyboard protocol negotiation", () => {
 		let cleaned = false;
 		const previousWrite = process.stdout.write;
 		const previousOn = process.stdin.on;
+		const previousWtSession = process.env['WT_SESSION'];
+		if (options?.windowsTerminal) {
+			process.env['WT_SESSION'] = 'test-guid-1234';
+		} else {
+			delete process.env['WT_SESSION'];
+		}
 
 		process.stdout.write = ((chunk: string | Uint8Array) => {
 			writes.push(String(chunk));
@@ -76,6 +82,11 @@ describe("ProcessTerminal Kitty keyboard protocol negotiation", () => {
 				} finally {
 					process.stdout.write = previousWrite;
 					process.stdin.on = previousOn;
+					if (previousWtSession === undefined) {
+						delete process.env['WT_SESSION'];
+					} else {
+						process.env['WT_SESSION'] = previousWtSession;
+					}
 					setKittyProtocolActive(false);
 				}
 			},
@@ -94,25 +105,15 @@ describe("ProcessTerminal Kitty keyboard protocol negotiation", () => {
 	});
 
 	it("skips Kitty protocol and enables modifyOtherKeys on Windows Terminal (WT_SESSION)", () => {
-		const previousWtSession = process.env['WT_SESSION'];
-		process.env['WT_SESSION'] = 'test-guid-1234';
+		const harness = setupNegotiation({ windowsTerminal: true });
 		try {
-			const harness = setupNegotiation();
-			try {
-				// Should NOT send Kitty query; should enable modifyOtherKeys instead
-				assert.equal(harness.writes[0], "\x1b[>4;2m");
-				assert.equal(harness.writes.includes("\x1b[>7u\x1b[?u\x1b[c"), false);
-				assert.equal(harness.terminal.kittyProtocolActive, false);
-				assert.equal(harness.terminal.modifyOtherKeysActive, true);
-			} finally {
-				harness.cleanup();
-			}
+			// Should NOT send Kitty query; should enable modifyOtherKeys instead
+			assert.equal(harness.writes[0], "\x1b[>4;2m");
+			assert.equal(harness.writes.includes("\x1b[>7u\x1b[?u\x1b[c"), false);
+			assert.equal(harness.terminal.kittyProtocolActive, false);
+			assert.equal(harness.terminal.modifyOtherKeysActive, true);
 		} finally {
-			if (previousWtSession === undefined) {
-				delete process.env['WT_SESSION'];
-			} else {
-				process.env['WT_SESSION'] = previousWtSession;
-			}
+			harness.cleanup();
 		}
 	});
 

--- a/packages/pi-tui/test/terminal.test.ts
+++ b/packages/pi-tui/test/terminal.test.ts
@@ -93,6 +93,29 @@ describe("ProcessTerminal Kitty keyboard protocol negotiation", () => {
 		}
 	});
 
+	it("skips Kitty protocol and enables modifyOtherKeys on Windows Terminal (WT_SESSION)", () => {
+		const previousWtSession = process.env['WT_SESSION'];
+		process.env['WT_SESSION'] = 'test-guid-1234';
+		try {
+			const harness = setupNegotiation();
+			try {
+				// Should NOT send Kitty query; should enable modifyOtherKeys instead
+				assert.equal(harness.writes[0], "\x1b[>4;2m");
+				assert.equal(harness.writes.includes("\x1b[>7u\x1b[?u\x1b[c"), false);
+				assert.equal(harness.terminal.kittyProtocolActive, false);
+				assert.equal(harness.terminal.modifyOtherKeysActive, true);
+			} finally {
+				harness.cleanup();
+			}
+		} finally {
+			if (previousWtSession === undefined) {
+				delete process.env['WT_SESSION'];
+			} else {
+				process.env['WT_SESSION'] = previousWtSession;
+			}
+		}
+	});
+
 	it("activates Kitty mode for non-zero negotiated flags", () => {
 		const harness = setupNegotiation();
 		try {


### PR DESCRIPTION
## Problem

When typing Cyrillic (or other non-Latin) characters in kimi-code running in **Windows Terminal**, every character appears doubled (e.g., \ппррииввеетт\ instead of \привет\). This only happens in Windows Terminal — git-bash and cmd work fine.

## Root Cause

Windows Terminal with Kitty keyboard protocol **flag 4** (alternate keys) emits CSI-u sequences for non-Latin characters AND the raw character byte. The pi-tui framework processes both, resulting in each keystroke being inserted twice.

English ASCII characters are unaffected because they don't trigger the alternate-key CSI-u path.

## Fix

Detect Windows Terminal via the \WT_SESSION\ environment variable (set by Windows Terminal for every tab) and skip Kitty keyboard protocol negotiation entirely, falling back to \modifyOtherKeys\ (xterm-style CSI 27;mod;code~ sequences) which handles all characters correctly.

### Changes

- **\packages/pi-tui/src/terminal.ts\**: Added \isWindowsTerminal()\ helper that checks \WT_SESSION\ (excluding SSH sessions). Modified \queryAndEnableKittyProtocol()\ to skip Kitty protocol and enable \modifyOtherKeys\ when running in Windows Terminal.
- **\packages/pi-tui/test/terminal.test.ts\**: Added test verifying that when \WT_SESSION\ is set, the terminal skips the Kitty query and enables \modifyOtherKeys\ instead.

## Testing

- All 13 existing + new tests pass (\
ode --test test/terminal.test.ts\)
- Manually verified: built and installed patched kimi.exe, Cyrillic input no longer doubles in Windows Terminal

Fixes #1978