### PR TITLE
fix(agent-core-v2): surface a warning when a skill fails to load

### DIFF
--- a/.changeset/skill-load-failed-warning.md
+++ b/.changeset/skill-load-failed-warning.md
@@ -1,0 +1,7 @@
+---
+"@moonshot-ai/kimi-code": patch
+"@moonshot-ai/agent-core-v2": patch
+"@moonshot-ai/kap-server": patch
+---
+
+Fix a skill with a `SKILL.md` that fails to parse (e.g. invalid frontmatter) being dropped from the skill list with no signal. A session-start warning now names the skill file and the reason it was not loaded.

--- a/.changeset/skill-load-failed-warning.md
+++ b/.changeset/skill-load-failed-warning.md
@@ -1,7 +1,8 @@
 ---
 "@moonshot-ai/kimi-code": patch
+"@moonshot-ai/agent-core": patch
 "@moonshot-ai/agent-core-v2": patch
 "@moonshot-ai/kap-server": patch
 ---
 
-Fix a skill with a `SKILL.md` that fails to parse (e.g. invalid frontmatter) being dropped from the skill list with no signal. A session-start warning now names the skill file and the reason it was not loaded.
+Fix a skill with a `SKILL.md` that fails to parse (e.g. invalid frontmatter) being dropped from the skill list with no signal. A session-start warning now names the skill file and the reason it was not loaded, in both the CLI/TUI engine and `kimi web`/print mode.

--- a/packages/agent-core-v2/src/app/skillCatalog/fileSkillDiscovery.ts
+++ b/packages/agent-core-v2/src/app/skillCatalog/fileSkillDiscovery.ts
@@ -183,6 +183,13 @@ async function parseAndRegister(input: {
       });
     } else if (error instanceof SkillParseError) {
       input.warn?.(`Skipping invalid skill at ${input.skillMdPath}: ${error.message}`, error);
+      // Also record it as skipped (not just logged) so it surfaces as a
+      // session warning instead of vanishing silently.
+      input.skipped.push({
+        path: input.skillMdPath,
+        type: 'invalid-frontmatter',
+        reason: error.message,
+      });
     } else {
       input.warn?.(`Skipping skill at ${input.skillMdPath} due to unexpected error`, error);
     }

--- a/packages/agent-core-v2/test/app/skillCatalog/fileSkillDiscovery.test.ts
+++ b/packages/agent-core-v2/test/app/skillCatalog/fileSkillDiscovery.test.ts
@@ -217,12 +217,36 @@ describe('FileSkillDiscovery', () => {
     const result = await discover([skillRoot('skills')]);
 
     expect(result.skills).toEqual([]);
+    expect(result.skipped).toEqual([
+      {
+        path: skillMdPath,
+        type: 'invalid-frontmatter',
+        reason: `Missing frontmatter in ${skillMdPath}`,
+      },
+    ]);
     expect(warnings).toEqual([
       {
         message: `Skipping invalid skill at ${skillMdPath}: Missing frontmatter in ${skillMdPath}`,
         payload: expect.any(Error),
       },
     ]);
+  });
+
+  it('skips (rather than silently drops) a description with an unquoted colon that breaks YAML', async () => {
+    // Regression for #1972: a `description` containing a bare "word: word"
+    // (e.g. "Triggers on: ...") is invalid as a plain YAML scalar, so the
+    // frontmatter fails to parse. The skill used to vanish with no signal
+    // beyond a log line nobody sees; it must now show up in `skipped`.
+    await writeSkill(
+      'skills/codebase-memory/SKILL.md',
+      'name: codebase-memory\ndescription: Explore the codebase. Triggers on: find callers of, trace the call chain.',
+    );
+
+    const result = await discover([skillRoot('skills')]);
+
+    expect(result.skills).toEqual([]);
+    expect(result.skipped).toHaveLength(1);
+    expect(result.skipped[0]?.type).toBe('invalid-frontmatter');
   });
 
   it('records a skill with an unsupported type as skipped instead of warning', async () => {

--- a/packages/agent-core/src/session/index.ts
+++ b/packages/agent-core/src/session/index.ts
@@ -802,6 +802,17 @@ export class Session {
       });
     }
     warnings.push(...this.computeSecondaryModelWarnings());
+    // Surface any skill that got dropped during catalog load (invalid
+    // frontmatter, unsupported `type`, …) instead of leaving it silently
+    // missing from the skill list.
+    await this.skillsReady;
+    for (const skipped of this.skills.getSkippedByPolicy()) {
+      warnings.push({
+        code: 'skill-load-failed',
+        message: `Skill at ${skipped.path} was not loaded: ${skipped.reason}`,
+        severity: 'warning',
+      });
+    }
     return warnings;
   }
 

--- a/packages/agent-core/src/skill/scanner.ts
+++ b/packages/agent-core/src/skill/scanner.ts
@@ -407,6 +407,13 @@ async function parseAndRegister(input: {
       });
     } else if (error instanceof SkillParseError) {
       input.warn(`Skipping invalid skill at ${input.skillMdPath}: ${error.message}`, error);
+      // Also record it as skipped (not just logged) so it surfaces as a
+      // session warning instead of vanishing silently.
+      input.skip({
+        path: input.skillMdPath,
+        type: 'invalid-frontmatter',
+        reason: error.message,
+      });
     } else {
       input.warn(`Skipping skill at ${input.skillMdPath} due to unexpected error`, error);
     }

--- a/packages/agent-core/test/harness/skill-session.test.ts
+++ b/packages/agent-core/test/harness/skill-session.test.ts
@@ -611,6 +611,29 @@ describe('HarnessAPI session skills', () => {
     });
   });
 
+  it('reports a skill-load-failed session warning for a SKILL.md that fails to parse', async () => {
+    // Regression for #1972: an unquoted colon in `description` (e.g.
+    // "Triggers on: ...") makes the frontmatter invalid YAML, and the skill
+    // used to be dropped with no signal reaching the TUI, which calls this
+    // same `getSessionWarnings` RPC at session start.
+    await writeSkill('broken', [
+      '---',
+      'name: broken',
+      'description: Explore the codebase. Triggers on: find callers of.',
+      '---',
+      '',
+      'Body.',
+    ]);
+    const { rpc } = await createTestRpc();
+    const created = await rpc.createSession({ id: 'ses_skill_warning', workDir });
+
+    const warnings = await rpc.getSessionWarnings({ sessionId: created.id });
+
+    const skillWarning = warnings.find((warning) => warning.code === 'skill-load-failed');
+    expect(skillWarning?.message).toContain('broken/SKILL.md');
+    expect(skillWarning?.severity).toBe('warning');
+  });
+
   it('rejects missing and non-inline skills with structured errors', async () => {
     const { core, rpc } = await createTestRpc();
     const created = await rpc.createSession({ id: 'ses_skill_errors', workDir });

--- a/packages/agent-core/test/skill/scanner.test.ts
+++ b/packages/agent-core/test/skill/scanner.test.ts
@@ -196,6 +196,34 @@ describe('skill discovery', () => {
     expect(warnings.some((message) => message.includes('"name"'))).toBe(true);
     expect(warnings.some((message) => message.includes('"description"'))).toBe(true);
   });
+
+  it('reports a skill with unparseable frontmatter as skipped, not just warned', async () => {
+    // Regression for #1972: a `description` containing a bare "word: word"
+    // (e.g. "Triggers on: ...") is invalid as a plain YAML scalar, so the
+    // frontmatter fails to parse. The skill used to vanish with only a log
+    // line nobody sees; it must now show up in the skipped list too.
+    const { repoDir } = await makeWorkspace();
+    const projectRoot = path.join(repoDir, '.kimi-code', 'skills');
+    await writeSkill(projectRoot, path.join('codebase-memory', 'SKILL.md'), [
+      '---',
+      'name: codebase-memory',
+      'description: Explore the codebase. Triggers on: find callers of.',
+      '---',
+      '',
+      'Body.',
+    ]);
+
+    const skipped: { path: string; type: string; reason: string }[] = [];
+    const skills = await discoverSkills({
+      roots: [{ path: projectRoot, source: 'project' }],
+      onSkippedByPolicy: (skill) => skipped.push(skill),
+    });
+
+    expect(skills).toEqual([]);
+    expect(skipped).toHaveLength(1);
+    expect(skipped[0]?.type).toBe('invalid-frontmatter');
+    expect(skipped[0]?.path).toContain('codebase-memory/SKILL.md');
+  });
 });
 
 describe('discoverSkills shape and ordering', () => {

--- a/packages/kap-server/src/routes/sessions.ts
+++ b/packages/kap-server/src/routes/sessions.ts
@@ -38,11 +38,15 @@
  * `GET /sessions/{id}/warnings` surfaces session-level notices in the v1
  * `{ code, message, severity }` wire shape: the `agents-md-oversized` warning
  * (projected from the main agent's `IAgentProfileService.getAgentsMdWarning()`
- * — computed and cached when the agent binds a profile) and the
- * secondary-model early-validation warning (projected from the Session-scope
+ * — computed and cached when the agent binds a profile), the secondary-model
+ * early-validation warning (projected from the Session-scope
  * `ISessionSecondaryModelWarningService` — computed and cached when the main
- * agent is created). An unbound main agent or a valid/unset secondary model
- * yields an empty list, matching v1's "no warning" case.
+ * agent is created), and one `skill-load-failed` entry per
+ * `ISessionSkillCatalog` `getSkippedByPolicy()` result whose `SKILL.md` failed
+ * to parse (invalid frontmatter, unsupported `type`, …), so a skill dropped
+ * during load is reported instead of vanishing silently. An unbound main agent,
+ * a valid/unset secondary model, and a clean catalog together yield an empty
+ * list, matching v1's "no warning" case.
  *
  * **Wire fidelity**: mirrors v1's `toProtocolSession`
  * (`packages/agent-core/src/services/session/session.ts`), which populates
@@ -89,6 +93,7 @@ import {
   ISessionMetadata,
   ISessionLegacyService,
   ISessionSecondaryModelWarningService,
+  ISessionSkillCatalog,
   IEventService,
   IWorkspaceAliases,
   IWorkspaceService,
@@ -1011,6 +1016,18 @@ export function registerSessionsRoutes(app: SessionRouteHost, core: Scope): void
         const secondaryModelWarning = session.accessor
           .get(ISessionSecondaryModelWarningService)
           .getSecondaryModelWarning();
+
+        // Surface any skill that got dropped during catalog load (invalid
+        // frontmatter, unsupported `type`, …) instead of leaving it silently
+        // missing from the skill list.
+        const skillCatalog = session.accessor.get(ISessionSkillCatalog);
+        await skillCatalog.ready;
+        const skillWarnings = skillCatalog.catalog.getSkippedByPolicy().map((skipped) => ({
+          code: 'skill-load-failed',
+          message: `Skill at ${skipped.path} was not loaded: ${skipped.reason}`,
+          severity: 'warning' as const,
+        }));
+
         const warnings = [
           ...(agentsMdWarning === undefined
             ? []
@@ -1030,6 +1047,7 @@ export function registerSessionsRoutes(app: SessionRouteHost, core: Scope): void
                   severity: 'warning' as const,
                 },
               ]),
+          ...skillWarnings,
         ];
         reply.send(okEnvelope({ warnings }, req.id));
       } catch (error) {

--- a/packages/kap-server/test/sessions.test.ts
+++ b/packages/kap-server/test/sessions.test.ts
@@ -792,6 +792,30 @@ describe('server-v2 /api/v1/sessions', () => {
     expect(sessionWarningsResponseSchema.parse(body.data)).toEqual({ warnings: [] });
   });
 
+  it('reports a skill-load-failed warning for a SKILL.md that fails to parse', async () => {
+    // Regression for #1972: an unquoted colon in `description` (e.g.
+    // "Triggers on: ...") makes the frontmatter invalid YAML, and the skill
+    // used to be dropped with no signal reaching the user.
+    const cwd = home as string;
+    const skillDir = join(cwd, '.kimi-code', 'skills', 'broken');
+    await mkdir(skillDir, { recursive: true });
+    await writeFile(
+      join(skillDir, 'SKILL.md'),
+      '---\nname: broken\ndescription: Explore the codebase. Triggers on: find callers of.\n---\n\nbody\n',
+    );
+
+    const created = await postJson<SessionWire>('/api/v1/sessions', { metadata: { cwd } });
+    const { status, body } = await getJson<{
+      warnings: { code: string; message: string; severity: string }[];
+    }>(`/api/v1/sessions/${created.body.data.id}/warnings`);
+
+    expect(status).toBe(200);
+    expect(body.code).toBe(0);
+    const skillWarning = body.data.warnings.find((w) => w.code === 'skill-load-failed');
+    expect(skillWarning?.message).toContain(join(skillDir, 'SKILL.md'));
+    expect(sessionWarningsResponseSchema.parse(body.data).warnings).toContainEqual(skillWarning);
+  });
+
   it('returns 40401 for warnings of a missing session', async () => {
     const { body } = await getJson<null>('/api/v1/sessions/sess_missing_warnings/warnings');
     expect(body.code).toBe(40401);


### PR DESCRIPTION
## Related Issue

Resolve #1972

## Problem

I dug into the report and the trigger turns out not to be a length limit — there is no length cap on `description` anywhere in the skill loader. The actual repro is a YAML gotcha: a `description` that contains an unquoted `word: word` sequence (e.g. `"...Triggers on: explore the codebase..."`) is invalid as a plain YAML scalar, so the frontmatter fails to parse. I confirmed this directly against the parser's `js-yaml` call — the 453-char example from the issue throws `bad indentation of a mapping entry`, while a 453-char description with no colon parses fine, and the "fix" the reporter found (shortening the description) happened to also remove the colon.

Regardless of the exact trigger, the reported symptom is real: any `SKILL.md` whose frontmatter fails to parse is dropped from the skill list, and the only trace is a `log.warn()` call that goes to the internal rotating log file — nothing a user sees during a normal session.

## What changed

This repo runs two engines side by side, and the fix has to land in both:

- `packages/agent-core-v2/src/app/skillCatalog/fileSkillDiscovery.ts`: when a skill's frontmatter fails to parse, it's now also recorded as a skipped skill (the same mechanism already used for unsupported skill types), in addition to the existing log line.
- `packages/kap-server/src/routes/sessions.ts`: `GET /sessions/{id}/warnings` now also includes one `skill-load-failed` entry per skipped skill, naming the file and the parse error. This is the path used by `kimi web` and by `kimi -p` under `KIMI_CODE_EXPERIMENTAL_FLAG`.
- `packages/agent-core/src/skill/scanner.ts`: the byte-identical fix on the v1 engine — a `SkillParseError` now also records the skipped skill instead of only logging it.
- `packages/agent-core/src/session/index.ts`: `Session.getSessionWarnings()` now includes the same `skill-load-failed` entries, sourced from the session's own skill registry (`getSkippedByPolicy()`), mirroring the kap-server route above.

An earlier version of this PR only touched the v2/kap-server side and claimed the TUI required no changes because "it already calls this endpoint." That was wrong: the interactive TUI (`apps/kimi-code/src/tui/kimi-tui.ts`) calls `session.getSessionWarnings()` on the `@moonshot-ai/kimi-code-sdk` client, which binds to an in-process `KimiCore` from `@moonshot-ai/agent-core` (v1), not to `kap-server` — `kap-server`/v2 is only reached by `kimi web` and by `kimi -p` under the experimental flag. Since the reporter hit this in the plain interactive TUI, only the v2 fix would never have surfaced their warning. Both engines are fixed now.

I kept this scoped to `SkillParseError` (invalid/missing frontmatter, missing required fields) since that's the class of failure in the issue. I left the catch-all "unexpected error" branch alone in both engines — its message is intentionally vague and not something worth surfacing as a normal warning.

## Checklist

- [x] I have read the CONTRIBUTING document.
- [x] I have linked a related issue.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill.
- [ ] Ran `gen-docs` skill, or this PR needs no doc update — no new user-facing surface was added (the warning endpoint and its wire shape already existed for `agents-md-oversized`), so I did not touch `docs/`.
