### PR TITLE
fix(tui): hide system-trigger messages in resume replay

### DIFF
--- a/.changeset/goal-replay-leak.md
+++ b/.changeset/goal-replay-leak.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Fix goal mode continuation prompts leaking into the transcript when resuming a session.

--- a/apps/kimi-code/src/tui/controllers/session-replay.ts
+++ b/apps/kimi-code/src/tui/controllers/session-replay.ts
@@ -301,17 +301,10 @@ export class SessionReplayRenderer {
       this.renderCronMissed(context, message);
       return;
     }
-    if (isGoalForkClearedSystemReminder(message)) {
-      return;
-    }
-    const goalReminder = goalOutcomeReminderFromSystemMessage(message);
-    if (goalReminder !== null) {
-      if (goalReminder !== undefined) {
-        this.flushAssistant(context);
-        this.host.appendTranscriptEntry(
-          replayEntry(context, 'assistant', goalReminder, 'markdown'),
-        );
-      }
+    // System-trigger messages (goal continuation prompts, goal outcome
+    // reminders, stop-hook reasons, …) are model-facing only: the live event
+    // stream never renders them, so replay must not leak them either.
+    if (message.origin?.kind === 'system_trigger') {
       return;
     }
 
@@ -739,18 +732,6 @@ function goalLifecycleReplayContent(change: GoalReplayLifecycleChange): string {
 
 function isModelBlockedGoalLifecycle(change: GoalReplayLifecycleChange): boolean {
   return change.status === 'blocked' && change.actor === 'model';
-}
-
-function goalOutcomeReminderFromSystemMessage(message: ContextMessage): string | undefined | null {
-  if (message.origin?.kind !== 'system_trigger') return null;
-  if (message.origin.name !== 'goal_completion' && message.origin.name !== 'goal_blocked') {
-    return null;
-  }
-  return undefined;
-}
-
-function isGoalForkClearedSystemReminder(message: ContextMessage): boolean {
-  return message.origin?.kind === 'system_trigger' && message.origin.name === 'goal_fork_cleared';
 }
 
 function extractCronPrompt(text: string): string {

--- a/apps/kimi-code/test/tui/message-replay.test.ts
+++ b/apps/kimi-code/test/tui/message-replay.test.ts
@@ -501,6 +501,38 @@ describe('KimiTUI resume message replay', () => {
     expect(content).not.toContain('Write a concise final message for the user');
   });
 
+  it('does not replay system-trigger prompts such as goal continuation as user messages', async () => {
+    const driver = await replayIntoDriver([
+      message(
+        'user',
+        [
+          {
+            type: 'text',
+            text: 'Continue working toward the active goal. Keep the self-audit brief.',
+          },
+        ],
+        { origin: { kind: 'system_trigger', name: 'goal_continuation' } },
+      ),
+      message(
+        'user',
+        [
+          {
+            type: 'text',
+            text: '<system-reminder>\nThe goal was cancelled.\n</system-reminder>',
+          },
+        ],
+        { origin: { kind: 'system_trigger', name: 'goal_cancelled' } },
+      ),
+      message('assistant', [{ type: 'text', text: 'Working on it.' }]),
+    ]);
+
+    expect(driver.state.transcriptEntries.filter((entry) => entry.kind === 'user')).toEqual([]);
+    const transcript = stripAnsi(driver.state.transcriptContainer.render(140).join('\n'));
+    expect(transcript).not.toContain('Continue working toward the active goal');
+    expect(transcript).not.toContain('The goal was cancelled');
+    expect(transcript).toContain('Working on it.');
+  });
+
   it('does not replay the model-blocked lifecycle marker when the follow-up is replayed', async () => {
     const driver = await replayIntoDriver([
       goalReplay(


### PR DESCRIPTION
## Related Issue

N/A — the problem is explained below.

## Problem

When resuming a session that ran in goal mode, the replay leaks goal mode's internal continuation prompt ("Continue working toward the active goal…") into the transcript as a user message. Each goal turn injects this prompt as a user message carrying a `system_trigger` origin; it is model-facing only and the live TUI never renders it. Resume replay, however, only filtered three specific `system_trigger` names (`goal_completion`, `goal_blocked`, `goal_fork_cleared`), so the continuation prompt fell through to the default branch and rendered as a user message.

## What changed

- Resume replay now skips all user messages with a `system_trigger` origin (goal continuation prompts, goal outcome/cancel reminders, stop-hook reasons, etc.). This matches the live render path and the markdown exporter, which already treat these messages as internal.
- Removed the two goal-specific `system_trigger` filters made redundant by the general rule.
- Added a regression test covering goal continuation and goal cancellation messages.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.