### PR TITLE
fix(agent-core-v2): reconnect dropped MCP servers on tool call failure

### DIFF
--- a/.changeset/mcp-tool-call-reconnect.md
+++ b/.changeset/mcp-tool-call-reconnect.md
@@ -2,4 +2,4 @@
 "@moonshot-ai/kimi-code": patch
 ---
 
-Reconnect a dropped MCP server connection automatically when one of its tools is called, and retry the call once. A server whose connection dies between turns no longer loses its tools from the tool list — they stay available and the next call heals the connection instead of failing with "tool not found".
+Reconnect a dropped MCP server connection automatically when one of its tools is called, and retry the call once.

--- a/.changeset/mcp-tool-call-reconnect.md
+++ b/.changeset/mcp-tool-call-reconnect.md
@@ -2,4 +2,4 @@
 "@moonshot-ai/kimi-code": patch
 ---
 
-Reconnect a dropped MCP server connection automatically when one of its tools is called, and retry the call once.
+Reconnect a dropped MCP server connection automatically when one of its tools is called, and retry the call once. A server whose connection dies between turns no longer loses its tools from the tool list — they stay available and the next call heals the connection instead of failing with "tool not found".

--- a/.changeset/mcp-tool-call-reconnect.md
+++ b/.changeset/mcp-tool-call-reconnect.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Reconnect a dropped MCP server connection automatically when one of its tools is called, and retry the call once.

--- a/packages/agent-core-v2/src/agent/mcp/client-http.ts
+++ b/packages/agent-core-v2/src/agent/mcp/client-http.ts
@@ -7,6 +7,7 @@ import {
   buildRequestOptions,
   KIMI_MCP_CLIENT_NAME,
   KIMI_MCP_CLIENT_VERSION,
+  MCP_LIVENESS_PROBE_TIMEOUT_MS,
   toMcpToolDefinition,
   toMcpToolResult,
   type UnexpectedCloseListener,
@@ -101,6 +102,10 @@ export class HttpMcpClient implements MCPClient {
     const requestOptions = buildRequestOptions(this.toolCallTimeoutMs, signal);
     const result = await this.client.callTool({ name, arguments: args }, undefined, requestOptions);
     return toMcpToolResult(result);
+  }
+
+  async ping(signal?: AbortSignal): Promise<void> {
+    await this.client.ping(buildRequestOptions(MCP_LIVENESS_PROBE_TIMEOUT_MS, signal));
   }
 
   private async closeStartedClient(): Promise<void> {

--- a/packages/agent-core-v2/src/agent/mcp/client-shared.ts
+++ b/packages/agent-core-v2/src/agent/mcp/client-shared.ts
@@ -1,5 +1,5 @@
 import { getCoreVersion } from '#/_base/version';
-import { ErrorCode } from '@modelcontextprotocol/sdk/types.js';
+import { ErrorCode, McpError } from '@modelcontextprotocol/sdk/types.js';
 
 import type { MCPToolDefinition, MCPToolResult } from './types';
 
@@ -18,6 +18,12 @@ export function isMcpConnectionClosedError(error: unknown): boolean {
     error instanceof Error &&
     (error as Error & { readonly code?: unknown }).code === ErrorCode.ConnectionClosed
   );
+}
+
+export function isMcpTransportFailure(error: unknown): boolean {
+  if (!(error instanceof Error)) return false;
+  if (isMcpConnectionClosedError(error)) return true;
+  return !(error instanceof McpError);
 }
 
 export interface McpRequestOptions {

--- a/packages/agent-core-v2/src/agent/mcp/client-shared.ts
+++ b/packages/agent-core-v2/src/agent/mcp/client-shared.ts
@@ -1,7 +1,7 @@
 import { getCoreVersion } from '#/_base/version';
 import { ErrorCode, McpError } from '@modelcontextprotocol/sdk/types.js';
 
-import type { MCPToolDefinition, MCPToolResult } from './types';
+import type { MCPClient, MCPToolDefinition, MCPToolResult } from './types';
 
 export const KIMI_MCP_CLIENT_NAME = 'kimi-code';
 export const KIMI_MCP_CLIENT_VERSION = getCoreVersion();
@@ -24,6 +24,50 @@ export function isMcpTransportFailure(error: unknown): boolean {
   if (!(error instanceof Error)) return false;
   if (isMcpConnectionClosedError(error)) return true;
   return !(error instanceof McpError);
+}
+
+/**
+ * Timeout for the liveness probe sent after an ambiguous tool-call failure.
+ * Kept short: the probe runs on an already-failed call, so it must not add
+ * anywhere near a tool-call timeout to the turn.
+ */
+export const MCP_LIVENESS_PROBE_TIMEOUT_MS = 5_000;
+
+/**
+ * True when the error is a client-side validation failure of an otherwise
+ * well-formed JSON-RPC response: the SDK rejects with a `ZodError` when the
+ * result of `tools/call` does not match `CallToolResultSchema`
+ * (shared/protocol.js rejects with `parseResult.error`). The server did
+ * answer, so reconnecting is pointless — but the error is not an `McpError`,
+ * so `isMcpTransportFailure` alone cannot tell it apart from a dead
+ * transport. Matched by name because the repo carries more than one zod
+ * copy, which makes `instanceof` unreliable.
+ */
+export function isMcpMalformedResultError(error: unknown): boolean {
+  return error instanceof Error && error.name === 'ZodError';
+}
+
+/**
+ * Probes whether the client's transport is still usable by sending a ping.
+ * A server that answers in any way — including `MethodNotFound`, a JSON-RPC
+ * error, or an unparseable result — counts as alive; only errors that prove
+ * the bytes never made a round trip (closed connection, fetch failures) or
+ * a probe that itself timed out (alive socket, unresponsive server) count
+ * as dead. Never rejects; an abort surfaces as a dead verdict and is the
+ * caller's job to detect via the signal.
+ */
+export async function probeMcpLiveness(client: MCPClient, signal: AbortSignal): Promise<boolean> {
+  try {
+    await client.ping(signal);
+    return true;
+  } catch (error) {
+    if (isMcpConnectionClosedError(error)) return false;
+    if (isMcpMalformedResultError(error)) return true;
+    if (error instanceof McpError) {
+      return (error as Error & { readonly code?: unknown }).code !== ErrorCode.RequestTimeout;
+    }
+    return false;
+  }
 }
 
 export interface McpRequestOptions {

--- a/packages/agent-core-v2/src/agent/mcp/client-shared.ts
+++ b/packages/agent-core-v2/src/agent/mcp/client-shared.ts
@@ -1,4 +1,5 @@
 import { getCoreVersion } from '#/_base/version';
+import { ErrorCode } from '@modelcontextprotocol/sdk/types.js';
 
 import type { MCPToolDefinition, MCPToolResult } from './types';
 
@@ -11,6 +12,13 @@ export interface UnexpectedCloseReason {
 }
 
 export type UnexpectedCloseListener = (reason: UnexpectedCloseReason) => void;
+
+export function isMcpConnectionClosedError(error: unknown): boolean {
+  return (
+    error instanceof Error &&
+    (error as Error & { readonly code?: unknown }).code === ErrorCode.ConnectionClosed
+  );
+}
 
 export interface McpRequestOptions {
   readonly timeout?: number;

--- a/packages/agent-core-v2/src/agent/mcp/client-sse.ts
+++ b/packages/agent-core-v2/src/agent/mcp/client-sse.ts
@@ -7,6 +7,7 @@ import {
   buildRequestOptions,
   KIMI_MCP_CLIENT_NAME,
   KIMI_MCP_CLIENT_VERSION,
+  MCP_LIVENESS_PROBE_TIMEOUT_MS,
   toMcpToolDefinition,
   toMcpToolResult,
   type UnexpectedCloseListener,
@@ -101,6 +102,10 @@ export class SseMcpClient implements MCPClient {
     const requestOptions = buildRequestOptions(this.toolCallTimeoutMs, signal);
     const result = await this.client.callTool({ name, arguments: args }, undefined, requestOptions);
     return toMcpToolResult(result);
+  }
+
+  async ping(signal?: AbortSignal): Promise<void> {
+    await this.client.ping(buildRequestOptions(MCP_LIVENESS_PROBE_TIMEOUT_MS, signal));
   }
 
   private async closeStartedClient(): Promise<void> {

--- a/packages/agent-core-v2/src/agent/mcp/client-stdio.ts
+++ b/packages/agent-core-v2/src/agent/mcp/client-stdio.ts
@@ -9,6 +9,7 @@ import {
   buildRequestOptions,
   KIMI_MCP_CLIENT_NAME,
   KIMI_MCP_CLIENT_VERSION,
+  MCP_LIVENESS_PROBE_TIMEOUT_MS,
   toMcpToolDefinition,
   toMcpToolResult,
   type UnexpectedCloseListener,
@@ -113,6 +114,10 @@ export class StdioMcpClient implements MCPClient {
     const requestOptions = buildRequestOptions(this.toolCallTimeoutMs, signal);
     const result = await this.client.callTool({ name, arguments: args }, undefined, requestOptions);
     return toMcpToolResult(result);
+  }
+
+  async ping(signal?: AbortSignal): Promise<void> {
+    await this.client.ping(buildRequestOptions(MCP_LIVENESS_PROBE_TIMEOUT_MS, signal));
   }
 
   private async closeStartedClient(): Promise<void> {

--- a/packages/agent-core-v2/src/agent/mcp/connection-manager.ts
+++ b/packages/agent-core-v2/src/agent/mcp/connection-manager.ts
@@ -68,6 +68,7 @@ export interface McpConnectionManagerOptions {
 export class McpConnectionManager {
   private readonly entries = new Map<string, InternalEntry>();
   private readonly listeners = new Set<McpStatusListener>();
+  private readonly inFlightReconnects = new Map<string, Promise<void>>();
   private initialLoad: Promise<void> = Promise.resolve();
   private initialLoadAttemptId = 0;
   private initialLoadStartedAt: number | undefined;
@@ -230,6 +231,18 @@ export class McpConnectionManager {
     entry.error = undefined;
     this.emit(entry);
     await this.connectOne(entry, attemptId);
+  }
+
+  reconnectAndJoin(name: string): Promise<void> {
+    const existing = this.inFlightReconnects.get(name);
+    if (existing !== undefined) return existing;
+    const work = this.reconnect(name).finally(() => {
+      if (this.inFlightReconnects.get(name) === work) {
+        this.inFlightReconnects.delete(name);
+      }
+    });
+    this.inFlightReconnects.set(name, work);
+    return work;
   }
 
   async shutdown(): Promise<void> {

--- a/packages/agent-core-v2/src/agent/mcp/mcpService.ts
+++ b/packages/agent-core-v2/src/agent/mcp/mcpService.ts
@@ -7,6 +7,7 @@ import type { Tool as KosongTool } from '#/app/llmProtocol/tool';
 import { Disposable, type IDisposable } from "#/_base/di/lifecycle";
 import type { KimiErrorPayload } from '#/_base/errors/serialize';
 import { ErrorCodes, makeErrorPayload } from "#/errors";
+import { abortable } from '#/_base/utils/abort';
 import { IEventBus } from '#/app/event/eventBus';
 import { ITelemetryService } from '#/app/telemetry/telemetry';
 import { sessionMediaOriginalsDir } from '#/agent/media/image-originals';
@@ -131,23 +132,24 @@ export class AgentMcpService extends Disposable implements IAgentMcpService {
     signal?.throwIfAborted();
   }
 
-  /**
-   * Lazy reconnect behind a failing tool call: dedupes concurrent reconnects
-   * of the same server (parallel tool calls on a dead transport all fail at
-   * once) and resolves to the fresh client when the server came back.
-   */
   private reconnectForToolCall(serverName: string, signal?: AbortSignal): Promise<MCPClient | undefined> {
     const inFlight = this.reconnectingByServer.get(serverName);
-    if (inFlight !== undefined) return inFlight;
+    const work = inFlight ?? this.startToolCallReconnect(serverName);
+    return signal === undefined ? work : abortable(work, signal);
+  }
+
+  private startToolCallReconnect(serverName: string): Promise<MCPClient | undefined> {
     const work = (async () => {
-      try {
-        await this.reconnect(serverName, signal);
-        return this.resolved(serverName)?.client;
-      } finally {
-        this.reconnectingByServer.delete(serverName);
-      }
+      await this.reconnect(serverName);
+      return this.resolved(serverName)?.client;
     })();
     this.reconnectingByServer.set(serverName, work);
+    const clearInFlight = () => {
+      if (this.reconnectingByServer.get(serverName) === work) {
+        this.reconnectingByServer.delete(serverName);
+      }
+    };
+    void work.then(clearInFlight, clearInFlight);
     return work;
   }
 
@@ -288,6 +290,7 @@ export class AgentMcpService extends Disposable implements IAgentMcpService {
           createMcpTool(qualified, tool, client, {
             originalsDir: sessionMediaOriginalsDir(this.sessionContext.sessionDir),
             telemetry: this.telemetry,
+            isConnectionLost: () => this.resolved(serverName)?.client !== client,
             reconnect: (signal) => this.reconnectForToolCall(serverName, signal),
           }),
           { source: 'mcp' },

--- a/packages/agent-core-v2/src/agent/mcp/mcpService.ts
+++ b/packages/agent-core-v2/src/agent/mcp/mcpService.ts
@@ -69,6 +69,7 @@ export class AgentMcpService extends Disposable implements IAgentMcpService {
   declare readonly _serviceBrand: undefined;
   private readonly mcpTools = new Map<string, McpToolRegistration>();
   private readonly mcpToolsByServer = new Map<string, string[]>();
+  private readonly reconnectingByServer = new Map<string, Promise<MCPClient | undefined>>();
   private readonly pendingDiscoveries: Array<() => void> = [];
   private discoveryWritesReady = false;
 
@@ -128,6 +129,26 @@ export class AgentMcpService extends Disposable implements IAgentMcpService {
     signal?.throwIfAborted();
     await this.sessionMcp.connectionManager().reconnect(name);
     signal?.throwIfAborted();
+  }
+
+  /**
+   * Lazy reconnect behind a failing tool call: dedupes concurrent reconnects
+   * of the same server (parallel tool calls on a dead transport all fail at
+   * once) and resolves to the fresh client when the server came back.
+   */
+  private reconnectForToolCall(serverName: string, signal?: AbortSignal): Promise<MCPClient | undefined> {
+    const inFlight = this.reconnectingByServer.get(serverName);
+    if (inFlight !== undefined) return inFlight;
+    const work = (async () => {
+      try {
+        await this.reconnect(serverName, signal);
+        return this.resolved(serverName)?.client;
+      } finally {
+        this.reconnectingByServer.delete(serverName);
+      }
+    })();
+    this.reconnectingByServer.set(serverName, work);
+    return work;
   }
 
   onStatusChange(listener: Parameters<IAgentMcpService['onStatusChange']>[0]) {
@@ -267,6 +288,7 @@ export class AgentMcpService extends Disposable implements IAgentMcpService {
           createMcpTool(qualified, tool, client, {
             originalsDir: sessionMediaOriginalsDir(this.sessionContext.sessionDir),
             telemetry: this.telemetry,
+            reconnect: (signal) => this.reconnectForToolCall(serverName, signal),
           }),
           { source: 'mcp' },
         ),

--- a/packages/agent-core-v2/src/agent/mcp/mcpService.ts
+++ b/packages/agent-core-v2/src/agent/mcp/mcpService.ts
@@ -188,16 +188,15 @@ export class AgentMcpService extends Disposable implements IAgentMcpService {
       this.registerNeedsAuthMcpServer(entry);
       return;
     }
-    if (entry.status === 'failed') {
-      this.unregisterMcpServer(entry.name);
-      this.eventBus.publish({
-        type: 'tool.list.updated',
-        reason: 'mcp.failed',
-        serverName: entry.name,
-      });
+    if (entry.status === 'failed' || entry.status === 'pending') {
+      // Keep the server's tools registered while it is down or reconnecting.
+      // The captured client is closed, so the next call fails fast at the
+      // transport layer and the tool adapter's reconnect-and-retry path heals
+      // the connection — a dropped server surfaces as a slow call instead of
+      // "tool not found" for the rest of the session.
       return;
     }
-    if (entry.status === 'disabled' || entry.status === 'pending') {
+    if (entry.status === 'disabled') {
       const removed = this.unregisterMcpServer(entry.name);
       if (removed) {
         this.eventBus.publish({

--- a/packages/agent-core-v2/src/agent/mcp/mcpService.ts
+++ b/packages/agent-core-v2/src/agent/mcp/mcpService.ts
@@ -70,7 +70,6 @@ export class AgentMcpService extends Disposable implements IAgentMcpService {
   declare readonly _serviceBrand: undefined;
   private readonly mcpTools = new Map<string, McpToolRegistration>();
   private readonly mcpToolsByServer = new Map<string, string[]>();
-  private readonly reconnectingByServer = new Map<string, Promise<MCPClient | undefined>>();
   private readonly pendingDiscoveries: Array<() => void> = [];
   private discoveryWritesReady = false;
 
@@ -132,25 +131,24 @@ export class AgentMcpService extends Disposable implements IAgentMcpService {
     signal?.throwIfAborted();
   }
 
-  private reconnectForToolCall(serverName: string, signal?: AbortSignal): Promise<MCPClient | undefined> {
-    const inFlight = this.reconnectingByServer.get(serverName);
-    const work = inFlight ?? this.startToolCallReconnect(serverName);
+  private reconnectForToolCall(
+    serverName: string,
+    staleClient: MCPClient,
+    signal?: AbortSignal,
+  ): Promise<MCPClient | undefined> {
+    const work = this.joinHealedOrReconnect(serverName, staleClient);
     return signal === undefined ? work : abortable(work, signal);
   }
 
-  private startToolCallReconnect(serverName: string): Promise<MCPClient | undefined> {
-    const work = (async () => {
-      await this.reconnect(serverName);
-      return this.resolved(serverName)?.client;
-    })();
-    this.reconnectingByServer.set(serverName, work);
-    const clearInFlight = () => {
-      if (this.reconnectingByServer.get(serverName) === work) {
-        this.reconnectingByServer.delete(serverName);
-      }
-    };
-    void work.then(clearInFlight, clearInFlight);
-    return work;
+  private async joinHealedOrReconnect(
+    serverName: string,
+    staleClient: MCPClient,
+  ): Promise<MCPClient | undefined> {
+    const healed = this.resolved(serverName)?.client;
+    if (healed !== undefined && healed !== staleClient) return healed;
+    await this.sessionMcp.connectionManager().reconnectAndJoin(serverName);
+    const current = this.resolved(serverName)?.client;
+    return current !== undefined && current !== staleClient ? current : undefined;
   }
 
   onStatusChange(listener: Parameters<IAgentMcpService['onStatusChange']>[0]) {
@@ -290,8 +288,7 @@ export class AgentMcpService extends Disposable implements IAgentMcpService {
           createMcpTool(qualified, tool, client, {
             originalsDir: sessionMediaOriginalsDir(this.sessionContext.sessionDir),
             telemetry: this.telemetry,
-            isConnectionLost: () => this.resolved(serverName)?.client !== client,
-            reconnect: (signal) => this.reconnectForToolCall(serverName, signal),
+            reconnect: (signal) => this.reconnectForToolCall(serverName, client, signal),
           }),
           { source: 'mcp' },
         ),

--- a/packages/agent-core-v2/src/agent/mcp/tools/mcp.ts
+++ b/packages/agent-core-v2/src/agent/mcp/tools/mcp.ts
@@ -3,11 +3,11 @@
  *
  * Each tool exposed by a connected MCP server is adapted into an
  * `ExecutableTool` whose `resolveExecution` forwards the call to the client
- * and normalizes the result. When the call throws because the transport
- * died (e.g. the stdio process exited), the adapter reconnects the server
- * through `options.reconnect` once and retries the call on the fresh
- * client, so a dropped connection surfaces as a slow call instead of a
- * failed turn.
+ * and normalizes the result. When the call fails at the transport layer
+ * (the stdio process exited, the remote server restarted, the client was
+ * already closed), the adapter reconnects the server through
+ * `options.reconnect` once and retries the call on the fresh client, so a
+ * dropped connection surfaces as a slow call instead of a failed turn.
  */
 
 import type { Tool as KosongTool } from '#/app/llmProtocol/tool';
@@ -18,12 +18,11 @@ import { isAbortError } from '#/_base/utils/abort';
 import type { ExecutableTool, ExecutableToolContext, ExecutableToolResult } from '#/tool/toolContract';
 import { mcpResultToExecutableOutput } from '#/agent/mcp/output';
 import type { MCPClient, MCPToolResult } from '#/agent/mcp/types';
-import { isMcpConnectionClosedError } from '#/agent/mcp/client-shared';
+import { isMcpTransportFailure } from '#/agent/mcp/client-shared';
 
 interface McpToolOptions {
   readonly originalsDir?: string;
   readonly telemetry?: ITelemetryService;
-  readonly isConnectionLost?: () => boolean;
   readonly reconnect?: (signal?: AbortSignal) => Promise<MCPClient | undefined>;
 }
 
@@ -69,10 +68,9 @@ async function retryAfterReconnect(
   const reconnect = options.reconnect;
   if (
     reconnect === undefined ||
-    options.isConnectionLost?.() !== true ||
-    !isMcpConnectionClosedError(error) ||
     context.signal.aborted ||
-    isAbortError(error)
+    isAbortError(error) ||
+    !isMcpTransportFailure(error)
   ) {
     throw error;
   }

--- a/packages/agent-core-v2/src/agent/mcp/tools/mcp.ts
+++ b/packages/agent-core-v2/src/agent/mcp/tools/mcp.ts
@@ -3,11 +3,24 @@
  *
  * Each tool exposed by a connected MCP server is adapted into an
  * `ExecutableTool` whose `resolveExecution` forwards the call to the client
- * and normalizes the result. When the call fails at the transport layer
- * (the stdio process exited, the remote server restarted, the client was
- * already closed), the adapter reconnects the server through
- * `options.reconnect` once and retries the call on the fresh client, so a
- * dropped connection surfaces as a slow call instead of a failed turn.
+ * and normalizes the result. When a call fails, the adapter picks one of
+ * three recoveries based on why it failed:
+ *
+ * - The server answered (a JSON-RPC error, or a response that failed
+ *   client-side schema validation) → the error is rethrown; reconnecting
+ *   would not change the answer.
+ * - The failure is ambiguous (a raw fetch/socket error) → the client is
+ *   probed with a ping: alive means a transient blip and the call is
+ *   retried once in place; dead means the transport is gone.
+ * - The transport is provably dead (the SDK fired `onclose`, or the probe
+ *   failed) → the server is reconnected once through `options.reconnect`
+ *   and the call retried on the fresh client, so a dropped connection
+ *   surfaces as a slow call instead of a failed turn.
+ *
+ * Retries are at-least-once: if the transport died after the server
+ * processed the call but before the response arrived, the retry may
+ * duplicate side effects. There is no protocol-level dedup across
+ * reconnects, so this trade-off is accepted deliberately.
  */
 
 import type { Tool as KosongTool } from '#/app/llmProtocol/tool';
@@ -18,7 +31,12 @@ import { isAbortError } from '#/_base/utils/abort';
 import type { ExecutableTool, ExecutableToolContext, ExecutableToolResult } from '#/tool/toolContract';
 import { mcpResultToExecutableOutput } from '#/agent/mcp/output';
 import type { MCPClient, MCPToolResult } from '#/agent/mcp/types';
-import { isMcpTransportFailure } from '#/agent/mcp/client-shared';
+import {
+  isMcpConnectionClosedError,
+  isMcpMalformedResultError,
+  isMcpTransportFailure,
+  probeMcpLiveness,
+} from '#/agent/mcp/client-shared';
 
 interface McpToolOptions {
   readonly originalsDir?: string;
@@ -45,7 +63,7 @@ export function createMcpTool(
         try {
           result = await callTool(client, args, context.signal);
         } catch (error) {
-          result = await retryAfterReconnect(error, args, context, options, callTool);
+          result = await retryAfterReconnect(error, client, args, context, options, callTool);
         }
         return normalizeMcpToolResult(
           await mcpResultToExecutableOutput(result, qualifiedName, {
@@ -60,20 +78,49 @@ export function createMcpTool(
 
 async function retryAfterReconnect(
   error: unknown,
+  client: MCPClient,
   args: unknown,
   context: Pick<ExecutableToolContext, 'signal' | 'onUpdate'>,
   options: McpToolOptions,
   callTool: (client: MCPClient, args: unknown, signal: AbortSignal) => Promise<MCPToolResult>,
 ): Promise<MCPToolResult> {
   const reconnect = options.reconnect;
-  if (
-    reconnect === undefined ||
+  // Errors that can never be fixed by a retry: user cancellation, and the
+  // server having answered — a JSON-RPC error (`McpError`, including a tool
+  // call timeout) or a malformed result that failed schema validation.
+  const isUnrecoverable = (e: unknown): boolean =>
     context.signal.aborted ||
-    isAbortError(error) ||
-    !isMcpTransportFailure(error)
-  ) {
+    isAbortError(e) ||
+    !isMcpTransportFailure(e) ||
+    isMcpMalformedResultError(e);
+  if (reconnect === undefined || isUnrecoverable(error)) {
     throw error;
   }
+
+  // A ConnectionClosed error is a measured death (the SDK already fired
+  // `onclose` and rejected every pending request), so it goes straight to
+  // reconnect. Anything else is ambiguous about whether the transport
+  // still works — probe it instead of guessing from the error's type.
+  let failure = error;
+  if (!isMcpConnectionClosedError(failure)) {
+    const alive = await probeMcpLiveness(client, context.signal);
+    context.signal.throwIfAborted();
+    if (alive) {
+      // The transport is fine and the failure was transient: retry once in
+      // place instead of paying a full reconnect for a network blip. If the
+      // transport dies between probe and retry, fall through to reconnect —
+      // still capped at one reconnect per call.
+      try {
+        return await callTool(client, args, context.signal);
+      } catch (retryError) {
+        if (isUnrecoverable(retryError)) {
+          throw retryError;
+        }
+        failure = retryError;
+      }
+    }
+  }
+
   context.onUpdate?.({ kind: 'status', text: 'MCP connection lost — reconnecting…' });
   let freshClient: MCPClient | undefined;
   try {
@@ -83,12 +130,12 @@ async function retryAfterReconnect(
       throw reconnectError;
     }
     throw new Error(
-      `${toErrorMessage(error)} (reconnecting the MCP server also failed: ${toErrorMessage(reconnectError)})`,
+      `${toErrorMessage(failure)} (reconnecting the MCP server also failed: ${toErrorMessage(reconnectError)})`,
       { cause: reconnectError },
     );
   }
   if (freshClient === undefined) {
-    throw error;
+    throw failure;
   }
   return callTool(freshClient, args, context.signal);
 }

--- a/packages/agent-core-v2/src/agent/mcp/tools/mcp.ts
+++ b/packages/agent-core-v2/src/agent/mcp/tools/mcp.ts
@@ -3,19 +3,31 @@
  *
  * Each tool exposed by a connected MCP server is adapted into an
  * `ExecutableTool` whose `resolveExecution` forwards the call to the client
- * and normalizes the result.
+ * and normalizes the result. When the call throws because the transport
+ * died (e.g. the stdio process exited), the adapter reconnects the server
+ * through `options.reconnect` once and retries the call on the fresh
+ * client, so a dropped connection surfaces as a slow call instead of a
+ * failed turn.
  */
 
 import type { Tool as KosongTool } from '#/app/llmProtocol/tool';
 import type { ITelemetryService } from '#/app/telemetry/telemetry';
+import { toErrorMessage } from '#/errors';
+import { isAbortError } from '#/_base/utils/abort';
 
-import type { ExecutableTool, ExecutableToolResult } from '#/tool/toolContract';
+import type { ExecutableTool, ExecutableToolContext, ExecutableToolResult } from '#/tool/toolContract';
 import { mcpResultToExecutableOutput } from '#/agent/mcp/output';
-import type { MCPClient } from '#/agent/mcp/types';
+import type { MCPClient, MCPToolResult } from '#/agent/mcp/types';
 
 interface McpToolOptions {
   readonly originalsDir?: string;
   readonly telemetry?: ITelemetryService;
+  /**
+   * Reconnect the owning server and return its fresh client, `undefined`
+   * when the server did not come back. Called at most once per execution,
+   * only when the original call threw a non-abort error.
+   */
+  readonly reconnect?: (signal?: AbortSignal) => Promise<MCPClient | undefined>;
 }
 
 export function createMcpTool(
@@ -24,6 +36,8 @@ export function createMcpTool(
   client: MCPClient,
   options: McpToolOptions = {},
 ): ExecutableTool {
+  const callTool = (activeClient: MCPClient, args: unknown, signal: AbortSignal) =>
+    activeClient.callTool(tool.name, (args ?? {}) as Record<string, unknown>, signal);
   return {
     name: qualifiedName,
     description: tool.description,
@@ -31,11 +45,12 @@ export function createMcpTool(
     resolveExecution: (args) => ({
       approvalRule: qualifiedName,
       execute: async (context) => {
-        const result = await client.callTool(
-          tool.name,
-          (args ?? {}) as Record<string, unknown>,
-          context.signal,
-        );
+        let result;
+        try {
+          result = await callTool(client, args, context.signal);
+        } catch (error) {
+          result = await retryAfterReconnect(error, args, context, options, callTool);
+        }
         return normalizeMcpToolResult(
           await mcpResultToExecutableOutput(result, qualifiedName, {
             originalsDir: options.originalsDir,
@@ -45,6 +60,33 @@ export function createMcpTool(
       },
     }),
   };
+}
+
+async function retryAfterReconnect(
+  error: unknown,
+  args: unknown,
+  context: Pick<ExecutableToolContext, 'signal' | 'onUpdate'>,
+  options: McpToolOptions,
+  callTool: (client: MCPClient, args: unknown, signal: AbortSignal) => Promise<MCPToolResult>,
+): Promise<MCPToolResult> {
+  const reconnect = options.reconnect;
+  if (reconnect === undefined || context.signal.aborted || isAbortError(error)) {
+    throw error;
+  }
+  context.onUpdate?.({ kind: 'status', text: 'MCP connection lost — reconnecting…' });
+  let freshClient: MCPClient | undefined;
+  try {
+    freshClient = await reconnect(context.signal);
+  } catch (reconnectError) {
+    throw new Error(
+      `${toErrorMessage(error)} (reconnecting the MCP server also failed: ${toErrorMessage(reconnectError)})`,
+      { cause: reconnectError },
+    );
+  }
+  if (freshClient === undefined) {
+    throw error;
+  }
+  return callTool(freshClient, args, context.signal);
 }
 
 function normalizeMcpToolResult(result: {

--- a/packages/agent-core-v2/src/agent/mcp/tools/mcp.ts
+++ b/packages/agent-core-v2/src/agent/mcp/tools/mcp.ts
@@ -18,15 +18,12 @@ import { isAbortError } from '#/_base/utils/abort';
 import type { ExecutableTool, ExecutableToolContext, ExecutableToolResult } from '#/tool/toolContract';
 import { mcpResultToExecutableOutput } from '#/agent/mcp/output';
 import type { MCPClient, MCPToolResult } from '#/agent/mcp/types';
+import { isMcpConnectionClosedError } from '#/agent/mcp/client-shared';
 
 interface McpToolOptions {
   readonly originalsDir?: string;
   readonly telemetry?: ITelemetryService;
-  /**
-   * Reconnect the owning server and return its fresh client, `undefined`
-   * when the server did not come back. Called at most once per execution,
-   * only when the original call threw a non-abort error.
-   */
+  readonly isConnectionLost?: () => boolean;
   readonly reconnect?: (signal?: AbortSignal) => Promise<MCPClient | undefined>;
 }
 
@@ -70,7 +67,13 @@ async function retryAfterReconnect(
   callTool: (client: MCPClient, args: unknown, signal: AbortSignal) => Promise<MCPToolResult>,
 ): Promise<MCPToolResult> {
   const reconnect = options.reconnect;
-  if (reconnect === undefined || context.signal.aborted || isAbortError(error)) {
+  if (
+    reconnect === undefined ||
+    options.isConnectionLost?.() !== true ||
+    !isMcpConnectionClosedError(error) ||
+    context.signal.aborted ||
+    isAbortError(error)
+  ) {
     throw error;
   }
   context.onUpdate?.({ kind: 'status', text: 'MCP connection lost — reconnecting…' });
@@ -78,6 +81,9 @@ async function retryAfterReconnect(
   try {
     freshClient = await reconnect(context.signal);
   } catch (reconnectError) {
+    if (context.signal.aborted || isAbortError(reconnectError)) {
+      throw reconnectError;
+    }
     throw new Error(
       `${toErrorMessage(error)} (reconnecting the MCP server also failed: ${toErrorMessage(reconnectError)})`,
       { cause: reconnectError },

--- a/packages/agent-core-v2/src/agent/mcp/types.ts
+++ b/packages/agent-core-v2/src/agent/mcp/types.ts
@@ -49,6 +49,13 @@ export interface MCPClient {
     args: Record<string, unknown>,
     signal?: AbortSignal,
   ): Promise<MCPToolResult>;
+  /**
+   * Sends a protocol-level `ping` with a short built-in timeout, so a hung
+   * server rejects instead of blocking. Used to probe liveness after an
+   * ambiguous call failure; a server that answers in any way — even with
+   * `MethodNotFound` — proves the transport is usable.
+   */
+  ping(signal?: AbortSignal): Promise<void>;
 }
 
 export function assertMcpInputSchema(

--- a/packages/agent-core-v2/test/agent/mcp/connection-manager.test.ts
+++ b/packages/agent-core-v2/test/agent/mcp/connection-manager.test.ts
@@ -254,6 +254,51 @@ describe('McpConnectionManager', () => {
     }
   });
 
+  it('reconnectAndJoin joins an in-flight reconnect instead of starting a second one', async () => {
+    const cm = new McpConnectionManager();
+    const seen: Array<{ name: string; status: McpServerEntry['status'] }> = [];
+    cm.onStatusChange((entry) => {
+      seen.push({ name: entry.name, status: entry.status });
+    });
+    const delayedMockServer = `setTimeout(() => import(${JSON.stringify(
+      pathToFileURL(stdioFixture).href,
+    )}), 250)`;
+
+    try {
+      await cm.connectAll({
+        slow: {
+          transport: 'stdio',
+          command: process.execPath,
+          args: ['-e', delayedMockServer],
+          startupTimeoutMs: 5_000,
+        },
+      });
+      seen.length = 0;
+
+      await Promise.all([cm.reconnectAndJoin('slow'), cm.reconnectAndJoin('slow')]);
+
+      expect(cm.get('slow')?.status).toBe('connected');
+      expect(seen.filter((event) => event.name === 'slow').map((event) => event.status)).toEqual([
+        'pending',
+        'connected',
+      ]);
+    } finally {
+      await cm.shutdown();
+    }
+  }, 20000);
+
+  it('reconnectAndJoin rejects for unknown servers', async () => {
+    const cm = new McpConnectionManager();
+    try {
+      await expect(cm.reconnectAndJoin('nope')).rejects.toBeInstanceOf(Error2);
+      await expect(cm.reconnectAndJoin('nope')).rejects.toMatchObject({
+        code: 'mcp.server_not_found',
+      });
+    } finally {
+      await cm.shutdown();
+    }
+  });
+
   it('shutdown clears entries and is idempotent', async () => {
     const cm = new McpConnectionManager();
     await cm.connectAll({ alpha: stdioConfig() });

--- a/packages/agent-core-v2/test/agent/mcp/mcp.test.ts
+++ b/packages/agent-core-v2/test/agent/mcp/mcp.test.ts
@@ -7,6 +7,7 @@ import { SyncDescriptor } from '#/_base/di/descriptors';
 import { DisposableStore, toDisposable } from '#/_base/di/lifecycle';
 import { TestInstantiationService } from '#/_base/di/test';
 import { Event } from '#/_base/event';
+import { abortError } from '#/_base/utils/abort';
 import { type DomainEvent, IEventBus } from '#/app/event/eventBus';
 import { ITelemetryService } from '#/app/telemetry/telemetry';
 import type { McpConnectionManager, McpServerEntry } from '#/agent/mcp/connection-manager';
@@ -61,6 +62,7 @@ class FakeMcpManager {
   }
 
   resolved(name: string): ResolvedServer | undefined {
+    if (this.entries.get(name)?.status !== 'connected') return undefined;
     return this.resolvedEntries.get(name);
   }
 
@@ -68,7 +70,11 @@ class FakeMcpManager {
     return name === 'needs-auth' ? 'https://example.com/mcp' : undefined;
   }
 
-  async reconnect(): Promise<void> {}
+  reconnectHandler: (name: string) => Promise<void> = async () => {};
+
+  async reconnect(name: string): Promise<void> {
+    await this.reconnectHandler(name);
+  }
 
   async waitForInitialLoad(): Promise<void> {}
 
@@ -358,6 +364,161 @@ describe('AgentMcpService', () => {
     });
     expect(result.isError).toBeUndefined();
     expect(result.output).toBe('hello world');
+  });
+
+  function throwingClient(base: MCPClient = fakeMcpClient()): MCPClient {
+    return {
+      listTools: () => base.listTools(),
+      async callTool() {
+        throw new Error('Connection closed');
+      },
+    };
+  }
+
+  function countingClient(base: MCPClient, counter: { calls: number }): MCPClient {
+    return {
+      listTools: () => base.listTools(),
+      callTool: (name, args, signal) => {
+        counter.calls += 1;
+        return base.callTool(name, args, signal);
+      },
+    };
+  }
+
+  it('reconnects the server and retries the call once when the transport dies', async () => {
+    const manager = new FakeMcpManager();
+    const deadClient = throwingClient();
+    const freshCounter = { calls: 0 };
+    const freshClient = countingClient(fakeMcpClient(), freshCounter);
+    let reconnects = 0;
+    manager.reconnectHandler = async (name) => {
+      reconnects += 1;
+      manager.setResolved(name, freshClient, await discoverTools(freshClient));
+      manager.connect(name);
+    };
+    manager.setResolved('s', deadClient, await discoverTools(deadClient));
+    createService(manager);
+    manager.connect('s');
+
+    const echo = ix.get(IAgentToolRegistryService).resolve('mcp__s__echo');
+    const result = await executeTool(echo!, {
+      turnId: 1,
+      toolCallId: 'tc-reconnect',
+      args: { text: 'hello again' },
+      signal: new AbortController().signal,
+    });
+
+    expect(result.isError).toBeUndefined();
+    expect(result.output).toBe('hello again');
+    expect(freshCounter.calls).toBe(1);
+    expect(reconnects).toBe(1);
+  });
+
+  it('rethrows the original error when the server does not come back', async () => {
+    const manager = new FakeMcpManager();
+    const deadClient = throwingClient();
+    manager.reconnectHandler = async (name) => {
+      manager.fail(name);
+    };
+    manager.setResolved('s', deadClient, await discoverTools(deadClient));
+    createService(manager);
+    manager.connect('s');
+
+    const echo = ix.get(IAgentToolRegistryService).resolve('mcp__s__echo');
+    await expect(
+      executeTool(echo!, {
+        turnId: 1,
+        toolCallId: 'tc-still-dead',
+        args: { text: 'hi' },
+        signal: new AbortController().signal,
+      }),
+    ).rejects.toThrow('Connection closed');
+    expect(ix.get(IAgentToolRegistryService).list().filter((tool) => tool.source === 'mcp')).toEqual([]);
+  });
+
+  it('reports both errors when the reconnect attempt itself fails', async () => {
+    const manager = new FakeMcpManager();
+    const deadClient = throwingClient();
+    manager.reconnectHandler = async () => {
+      throw new Error('spawn failed');
+    };
+    manager.setResolved('s', deadClient, await discoverTools(deadClient));
+    createService(manager);
+    manager.connect('s');
+
+    const echo = ix.get(IAgentToolRegistryService).resolve('mcp__s__echo');
+    await expect(
+      executeTool(echo!, {
+        turnId: 1,
+        toolCallId: 'tc-reconnect-fails',
+        args: { text: 'hi' },
+        signal: new AbortController().signal,
+      }),
+    ).rejects.toThrow(/Connection closed .*spawn failed/);
+  });
+
+  it('does not reconnect when the call was aborted', async () => {
+    const manager = new FakeMcpManager();
+    const base = fakeMcpClient();
+    const abortingClient: MCPClient = {
+      listTools: () => base.listTools(),
+      async callTool() {
+        throw abortError('This operation was aborted');
+      },
+    };
+    let reconnects = 0;
+    manager.reconnectHandler = async () => {
+      reconnects += 1;
+    };
+    manager.setResolved('s', abortingClient, await discoverTools(abortingClient));
+    createService(manager);
+    manager.connect('s');
+
+    const echo = ix.get(IAgentToolRegistryService).resolve('mcp__s__echo');
+    await expect(
+      executeTool(echo!, {
+        turnId: 1,
+        toolCallId: 'tc-aborted',
+        args: { text: 'hi' },
+        signal: new AbortController().signal,
+      }),
+    ).rejects.toThrow('This operation was aborted');
+    expect(reconnects).toBe(0);
+  });
+
+  it('dedupes concurrent reconnects from parallel failing tool calls', async () => {
+    const manager = new FakeMcpManager();
+    const deadClient = throwingClient();
+    const freshClient = fakeMcpClient();
+    let reconnects = 0;
+    manager.reconnectHandler = async (name) => {
+      reconnects += 1;
+      manager.setResolved(name, freshClient, await discoverTools(freshClient));
+      manager.connect(name);
+    };
+    manager.setResolved('s', deadClient, await discoverTools(deadClient));
+    createService(manager);
+    manager.connect('s');
+
+    const registry = ix.get(IAgentToolRegistryService);
+    const [echoResult, noopResult] = await Promise.all([
+      executeTool(registry.resolve('mcp__s__echo')!, {
+        turnId: 1,
+        toolCallId: 'tc-par-1',
+        args: { text: 'one' },
+        signal: new AbortController().signal,
+      }),
+      executeTool(registry.resolve('mcp__s__noop')!, {
+        turnId: 1,
+        toolCallId: 'tc-par-2',
+        args: {},
+        signal: new AbortController().signal,
+      }),
+    ]);
+
+    expect(echoResult.output).toBe('one');
+    expect(noopResult.output).toBe('ok');
+    expect(reconnects).toBe(1);
   });
 
   it('truncates oversized MCP text output through the wrapped tool path', async () => {

--- a/packages/agent-core-v2/test/agent/mcp/mcp.test.ts
+++ b/packages/agent-core-v2/test/agent/mcp/mcp.test.ts
@@ -1,7 +1,7 @@
 import type { ContentPart } from '#/app/llmProtocol/message';
 import type { Tool as KosongTool } from '#/app/llmProtocol/tool';
 import { Jimp } from 'jimp';
-import { ErrorCode, McpError } from '@modelcontextprotocol/sdk/types.js';
+import { CallToolResultSchema, ErrorCode, McpError } from '@modelcontextprotocol/sdk/types.js';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 import { SyncDescriptor } from '#/_base/di/descriptors';
@@ -392,6 +392,9 @@ describe('AgentMcpService', () => {
         onCall?.();
         throw makeError();
       },
+      async ping() {
+        throw makeError();
+      },
     };
   }
 
@@ -402,6 +405,7 @@ describe('AgentMcpService', () => {
         counter.calls += 1;
         return base.callTool(name, args, signal);
       },
+      ping: (signal) => base.ping(signal),
     };
   }
 
@@ -453,6 +457,7 @@ describe('AgentMcpService', () => {
       async callTool() {
         throw new McpError(ErrorCode.InvalidParams, 'Invalid tool arguments');
       },
+      ping: () => base.ping(),
     };
     let reconnects = 0;
     manager.reconnectHandler = async () => {
@@ -525,6 +530,7 @@ describe('AgentMcpService', () => {
       async callTool() {
         throw abortError('This operation was aborted');
       },
+      ping: () => base.ping(),
     };
     let reconnects = 0;
     manager.reconnectHandler = async () => {
@@ -691,6 +697,151 @@ describe('AgentMcpService', () => {
     expect(reconnects).toBe(0);
   });
 
+  it('rethrows a malformed tool result without reconnecting or retrying when the server answered', async () => {
+    const manager = new FakeMcpManager();
+    const base = fakeMcpClient();
+    const malformed = CallToolResultSchema.safeParse({ content: [{ text: 'missing type' }] });
+    if (malformed.success) throw new Error('expected the fixture result to fail validation');
+    let calls = 0;
+    const client: MCPClient = {
+      listTools: () => base.listTools(),
+      ping: () => base.ping(),
+      async callTool() {
+        calls += 1;
+        throw malformed.error;
+      },
+    };
+    let reconnects = 0;
+    manager.reconnectHandler = async () => {
+      reconnects += 1;
+    };
+    manager.setResolved('s', client, await discoverTools(client));
+    createService(manager);
+    manager.connect('s');
+
+    const echo = ix.get(IAgentToolRegistryService).resolve('mcp__s__echo');
+    await expect(
+      executeTool(echo!, {
+        turnId: 1,
+        toolCallId: 'tc-malformed-result',
+        args: { text: 'hi' },
+        signal: new AbortController().signal,
+      }),
+    ).rejects.toBe(malformed.error);
+    expect(calls).toBe(1);
+    expect(reconnects).toBe(0);
+  });
+
+  it('retries a transient transport failure in place without reconnecting', async () => {
+    const manager = new FakeMcpManager();
+    const base = fakeMcpClient();
+    let calls = 0;
+    const flakyClient: MCPClient = {
+      listTools: () => base.listTools(),
+      ping: () => base.ping(),
+      callTool: (name, args, signal) => {
+        calls += 1;
+        if (calls === 1) return Promise.reject(new TypeError('fetch failed'));
+        return base.callTool(name, args, signal);
+      },
+    };
+    let reconnects = 0;
+    manager.reconnectHandler = async () => {
+      reconnects += 1;
+    };
+    manager.setResolved('s', flakyClient, await discoverTools(flakyClient));
+    createService(manager);
+    manager.connect('s');
+
+    const echo = ix.get(IAgentToolRegistryService).resolve('mcp__s__echo');
+    const result = await executeTool(echo!, {
+      turnId: 1,
+      toolCallId: 'tc-transient',
+      args: { text: 'hello again' },
+      signal: new AbortController().signal,
+    });
+
+    expect(result.isError).toBeUndefined();
+    expect(result.output).toBe('hello again');
+    expect(calls).toBe(2);
+    expect(reconnects).toBe(0);
+  });
+
+  it('reconnects when the transport failure persists past a successful probe', async () => {
+    const manager = new FakeMcpManager();
+    const base = fakeMcpClient();
+    let calls = 0;
+    const deadClient: MCPClient = {
+      listTools: () => base.listTools(),
+      ping: () => base.ping(),
+      async callTool() {
+        calls += 1;
+        throw new TypeError('fetch failed');
+      },
+    };
+    const freshClient = fakeMcpClient();
+    let reconnects = 0;
+    manager.reconnectHandler = async (name) => {
+      reconnects += 1;
+      manager.setResolved(name, freshClient, await discoverTools(freshClient));
+      manager.connect(name);
+    };
+    manager.setResolved('s', deadClient, await discoverTools(deadClient));
+    createService(manager);
+    manager.connect('s');
+
+    const echo = ix.get(IAgentToolRegistryService).resolve('mcp__s__echo');
+    const result = await executeTool(echo!, {
+      turnId: 1,
+      toolCallId: 'tc-persistent-transport',
+      args: { text: 'hello again' },
+      signal: new AbortController().signal,
+    });
+
+    expect(result.isError).toBeUndefined();
+    expect(result.output).toBe('hello again');
+    expect(calls).toBe(2);
+    expect(reconnects).toBe(1);
+  });
+
+  it('abandons the retry when the call is aborted during the liveness probe', async () => {
+    const manager = new FakeMcpManager();
+    const base = fakeMcpClient();
+    const probeStarted = deferred<void>();
+    const releaseProbe = deferred<void>();
+    const client: MCPClient = {
+      listTools: () => base.listTools(),
+      async ping() {
+        probeStarted.resolve();
+        await releaseProbe.promise;
+      },
+      async callTool() {
+        throw new TypeError('fetch failed');
+      },
+    };
+    let reconnects = 0;
+    manager.reconnectHandler = async () => {
+      reconnects += 1;
+    };
+    manager.setResolved('s', client, await discoverTools(client));
+    createService(manager);
+    manager.connect('s');
+
+    const echo = ix.get(IAgentToolRegistryService).resolve('mcp__s__echo');
+    const controller = new AbortController();
+    const call = executeTool(echo!, {
+      turnId: 1,
+      toolCallId: 'tc-abort-during-probe',
+      args: { text: 'hi' },
+      signal: controller.signal,
+    });
+    await probeStarted.promise;
+    controller.abort(new Error('cancelled by test'));
+    releaseProbe.resolve();
+    await expect(call).rejects.toThrow('cancelled by test');
+    expect(reconnects).toBe(0);
+  });
+
   it('truncates oversized MCP text output through the wrapped tool path', async () => {
     const manager = new FakeMcpManager();
     const client: MCPClient = {
@@ -709,6 +860,7 @@ describe('AgentMcpService', () => {
           isError: false,
         };
       },
+      async ping() {},
     };
     manager.setResolved('s', client, await discoverTools(client));
     createService(manager);
@@ -744,6 +896,7 @@ describe('AgentMcpService', () => {
           isError: false,
         };
       },
+      async ping() {},
     };
     manager.setResolved('s', client, await discoverTools(client));
     createService(manager);
@@ -790,6 +943,7 @@ describe('AgentMcpService', () => {
           isError: false,
         };
       },
+      async ping() {},
     };
     manager.setResolved('s', client, await discoverTools(client));
     createService(manager);
@@ -837,6 +991,7 @@ describe('AgentMcpService', () => {
         receivedSignal = signal;
         return { content: [{ type: 'text', text: String(args['text']) }], isError: false };
       },
+      async ping() {},
     };
     manager.setResolved('s', client, await discoverTools(client));
     createService(manager);

--- a/packages/agent-core-v2/test/agent/mcp/mcp.test.ts
+++ b/packages/agent-core-v2/test/agent/mcp/mcp.test.ts
@@ -77,6 +77,20 @@ class FakeMcpManager {
     await this.reconnectHandler(name);
   }
 
+  private readonly inFlightReconnects = new Map<string, Promise<void>>();
+
+  reconnectAndJoin(name: string): Promise<void> {
+    const existing = this.inFlightReconnects.get(name);
+    if (existing !== undefined) return existing;
+    const work = this.reconnect(name).finally(() => {
+      if (this.inFlightReconnects.get(name) === work) {
+        this.inFlightReconnects.delete(name);
+      }
+    });
+    this.inFlightReconnects.set(name, work);
+    return work;
+  }
+
   async waitForInitialLoad(): Promise<void> {}
 
   initialLoadDurationMs(): number {
@@ -367,12 +381,16 @@ describe('AgentMcpService', () => {
     expect(result.output).toBe('hello world');
   });
 
-  function throwingClient(base: MCPClient = fakeMcpClient(), onCall?: () => void): MCPClient {
+  function throwingClient(
+    base: MCPClient = fakeMcpClient(),
+    onCall?: () => void,
+    makeError: () => Error = () => new McpError(ErrorCode.ConnectionClosed, 'Connection closed'),
+  ): MCPClient {
     return {
       listTools: () => base.listTools(),
       async callTool() {
         onCall?.();
-        throw new McpError(ErrorCode.ConnectionClosed, 'Connection closed');
+        throw makeError();
       },
     };
   }
@@ -607,6 +625,70 @@ describe('AgentMcpService', () => {
     reconnectReleased.resolve();
     await expect(secondCall).resolves.toMatchObject({ output: 'ok' });
     expect(reconnects).toBe(1);
+  });
+
+  it('reconnects and retries when the call fails with a raw transport error the manager did not observe', async () => {
+    const manager = new FakeMcpManager();
+    const deadClient = throwingClient(
+      fakeMcpClient(),
+      undefined,
+      () => new TypeError('fetch failed'),
+    );
+    const freshClient = fakeMcpClient();
+    let reconnects = 0;
+    manager.reconnectHandler = async (name) => {
+      reconnects += 1;
+      manager.setResolved(name, freshClient, await discoverTools(freshClient));
+      manager.connect(name);
+    };
+    manager.setResolved('s', deadClient, await discoverTools(deadClient));
+    createService(manager);
+    manager.connect('s');
+
+    const echo = ix.get(IAgentToolRegistryService).resolve('mcp__s__echo');
+    const result = await executeTool(echo!, {
+      turnId: 1,
+      toolCallId: 'tc-raw-transport',
+      args: { text: 'hello again' },
+      signal: new AbortController().signal,
+    });
+
+    expect(result.isError).toBeUndefined();
+    expect(result.output).toBe('hello again');
+    expect(reconnects).toBe(1);
+  });
+
+  it('retries on the healed client without reconnecting again when the server already came back', async () => {
+    const manager = new FakeMcpManager();
+    const deadClient = throwingClient(fakeMcpClient(), undefined, () => new Error('Not connected'));
+    const freshClient = fakeMcpClient();
+    let reconnects = 0;
+    manager.reconnectHandler = async () => {
+      reconnects += 1;
+    };
+    manager.setResolved('s', deadClient, await discoverTools(deadClient));
+    createService(manager);
+    manager.connect('s');
+
+    const registry = ix.get(IAgentToolRegistryService);
+    const staleEcho = registry.resolve('mcp__s__echo');
+
+    // Resolve the stale tool first, then heal the server the way a parallel
+    // call's reconnect would: the resolved entry swaps to a fresh client and
+    // the registry re-seeds, leaving `staleEcho` bound to the dead client.
+    manager.setResolved('s', freshClient, await discoverTools(freshClient));
+    manager.connect('s');
+
+    const result = await executeTool(staleEcho!, {
+      turnId: 1,
+      toolCallId: 'tc-healed',
+      args: { text: 'late call' },
+      signal: new AbortController().signal,
+    });
+
+    expect(result.isError).toBeUndefined();
+    expect(result.output).toBe('late call');
+    expect(reconnects).toBe(0);
   });
 
   it('truncates oversized MCP text output through the wrapped tool path', async () => {

--- a/packages/agent-core-v2/test/agent/mcp/mcp.test.ts
+++ b/packages/agent-core-v2/test/agent/mcp/mcp.test.ts
@@ -1,6 +1,7 @@
 import type { ContentPart } from '#/app/llmProtocol/message';
 import type { Tool as KosongTool } from '#/app/llmProtocol/tool';
 import { Jimp } from 'jimp';
+import { ErrorCode, McpError } from '@modelcontextprotocol/sdk/types.js';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 import { SyncDescriptor } from '#/_base/di/descriptors';
@@ -366,11 +367,12 @@ describe('AgentMcpService', () => {
     expect(result.output).toBe('hello world');
   });
 
-  function throwingClient(base: MCPClient = fakeMcpClient()): MCPClient {
+  function throwingClient(base: MCPClient = fakeMcpClient(), onCall?: () => void): MCPClient {
     return {
       listTools: () => base.listTools(),
       async callTool() {
-        throw new Error('Connection closed');
+        onCall?.();
+        throw new McpError(ErrorCode.ConnectionClosed, 'Connection closed');
       },
     };
   }
@@ -385,9 +387,20 @@ describe('AgentMcpService', () => {
     };
   }
 
+  function deferred<T>(): {
+    readonly promise: Promise<T>;
+    readonly resolve: (value: T | PromiseLike<T>) => void;
+  } {
+    let resolvePromise!: (value: T | PromiseLike<T>) => void;
+    const promise = new Promise<T>((resolve) => {
+      resolvePromise = resolve;
+    });
+    return { promise, resolve: resolvePromise };
+  }
+
   it('reconnects the server and retries the call once when the transport dies', async () => {
     const manager = new FakeMcpManager();
-    const deadClient = throwingClient();
+    const deadClient = throwingClient(fakeMcpClient(), () => manager.fail('s'));
     const freshCounter = { calls: 0 };
     const freshClient = countingClient(fakeMcpClient(), freshCounter);
     let reconnects = 0;
@@ -414,9 +427,38 @@ describe('AgentMcpService', () => {
     expect(reconnects).toBe(1);
   });
 
+  it('returns a non-transport MCP error without reconnecting the server', async () => {
+    const manager = new FakeMcpManager();
+    const base = fakeMcpClient();
+    const client: MCPClient = {
+      listTools: () => base.listTools(),
+      async callTool() {
+        throw new McpError(ErrorCode.InvalidParams, 'Invalid tool arguments');
+      },
+    };
+    let reconnects = 0;
+    manager.reconnectHandler = async () => {
+      reconnects += 1;
+    };
+    manager.setResolved('s', client, await discoverTools(client));
+    createService(manager);
+    manager.connect('s');
+
+    const echo = ix.get(IAgentToolRegistryService).resolve('mcp__s__echo');
+    await expect(
+      executeTool(echo!, {
+        turnId: 1,
+        toolCallId: 'tc-non-transport-error',
+        args: { text: 'hi' },
+        signal: new AbortController().signal,
+      }),
+    ).rejects.toThrow('Invalid tool arguments');
+    expect(reconnects).toBe(0);
+  });
+
   it('rethrows the original error when the server does not come back', async () => {
     const manager = new FakeMcpManager();
-    const deadClient = throwingClient();
+    const deadClient = throwingClient(fakeMcpClient(), () => manager.fail('s'));
     manager.reconnectHandler = async (name) => {
       manager.fail(name);
     };
@@ -438,7 +480,7 @@ describe('AgentMcpService', () => {
 
   it('reports both errors when the reconnect attempt itself fails', async () => {
     const manager = new FakeMcpManager();
-    const deadClient = throwingClient();
+    const deadClient = throwingClient(fakeMcpClient(), () => manager.fail('s'));
     manager.reconnectHandler = async () => {
       throw new Error('spawn failed');
     };
@@ -488,7 +530,7 @@ describe('AgentMcpService', () => {
 
   it('dedupes concurrent reconnects from parallel failing tool calls', async () => {
     const manager = new FakeMcpManager();
-    const deadClient = throwingClient();
+    const deadClient = throwingClient(fakeMcpClient(), () => manager.fail('s'));
     const freshClient = fakeMcpClient();
     let reconnects = 0;
     manager.reconnectHandler = async (name) => {
@@ -501,14 +543,16 @@ describe('AgentMcpService', () => {
     manager.connect('s');
 
     const registry = ix.get(IAgentToolRegistryService);
+    const echo = registry.resolve('mcp__s__echo');
+    const noop = registry.resolve('mcp__s__noop');
     const [echoResult, noopResult] = await Promise.all([
-      executeTool(registry.resolve('mcp__s__echo')!, {
+      executeTool(echo!, {
         turnId: 1,
         toolCallId: 'tc-par-1',
         args: { text: 'one' },
         signal: new AbortController().signal,
       }),
-      executeTool(registry.resolve('mcp__s__noop')!, {
+      executeTool(noop!, {
         turnId: 1,
         toolCallId: 'tc-par-2',
         args: {},
@@ -518,6 +562,50 @@ describe('AgentMcpService', () => {
 
     expect(echoResult.output).toBe('one');
     expect(noopResult.output).toBe('ok');
+    expect(reconnects).toBe(1);
+  });
+
+  it('keeps the shared reconnect alive when one parallel call is aborted', async () => {
+    const manager = new FakeMcpManager();
+    const reconnectStarted = deferred<void>();
+    const reconnectReleased = deferred<void>();
+    const deadClient = throwingClient(fakeMcpClient(), () => manager.fail('s'));
+    const freshClient = fakeMcpClient();
+    let reconnects = 0;
+    manager.reconnectHandler = async (name) => {
+      reconnects += 1;
+      reconnectStarted.resolve();
+      await reconnectReleased.promise;
+      manager.setResolved(name, freshClient, await discoverTools(freshClient));
+      manager.connect(name);
+    };
+    manager.setResolved('s', deadClient, await discoverTools(deadClient));
+    createService(manager);
+    manager.connect('s');
+
+    const registry = ix.get(IAgentToolRegistryService);
+    const echo = registry.resolve('mcp__s__echo');
+    const noop = registry.resolve('mcp__s__noop');
+    const firstController = new AbortController();
+    const firstCall = executeTool(echo!, {
+      turnId: 1,
+      toolCallId: 'tc-par-abort-1',
+      args: { text: 'one' },
+      signal: firstController.signal,
+    });
+    const secondCall = executeTool(noop!, {
+      turnId: 1,
+      toolCallId: 'tc-par-abort-2',
+      args: {},
+      signal: new AbortController().signal,
+    });
+
+    await reconnectStarted.promise;
+    firstController.abort(new Error('cancelled by test'));
+    await expect(firstCall).rejects.toThrow('cancelled by test');
+
+    reconnectReleased.resolve();
+    await expect(secondCall).resolves.toMatchObject({ output: 'ok' });
     expect(reconnects).toBe(1);
   });
 

--- a/packages/agent-core-v2/test/agent/mcp/mcp.test.ts
+++ b/packages/agent-core-v2/test/agent/mcp/mcp.test.ts
@@ -157,6 +157,14 @@ class FakeMcpManager {
     this.emit(entry);
   }
 
+  pending(name: string): void {
+    const current = this.entries.get(name);
+    if (current === undefined) return;
+    const entry: McpServerEntry = { ...current, status: 'pending', toolCount: 0 };
+    this.entries.set(name, entry);
+    this.emit(entry);
+  }
+
   disconnect(name: string): void {
     const current = this.entries.get(name);
     if (current === undefined) return;
@@ -449,6 +457,42 @@ describe('AgentMcpService', () => {
     expect(reconnects).toBe(1);
   });
 
+  it('heals a server that died between turns when its tool is called again', async () => {
+    const manager = new FakeMcpManager();
+    const deadClient = throwingClient(fakeMcpClient());
+    const freshCounter = { calls: 0 };
+    const freshClient = countingClient(fakeMcpClient(), freshCounter);
+    let reconnects = 0;
+    manager.reconnectHandler = async (name) => {
+      reconnects += 1;
+      manager.setResolved(name, freshClient, await discoverTools(freshClient));
+      manager.connect(name);
+    };
+    manager.setResolved('s', deadClient, await discoverTools(deadClient));
+    createService(manager);
+    manager.connect('s');
+
+    // The connection drops while no call is in flight: the manager marks the
+    // server failed. The tools must stay registered so the next call reaches
+    // the adapter and its reconnect-and-retry path instead of failing with
+    // "tool not found".
+    manager.fail('s');
+
+    const echo = ix.get(IAgentToolRegistryService).resolve('mcp__s__echo');
+    expect(echo).toBeDefined();
+    const result = await executeTool(echo!, {
+      turnId: 1,
+      toolCallId: 'tc-between-turns',
+      args: { text: 'back from the dead' },
+      signal: new AbortController().signal,
+    });
+
+    expect(result.isError).toBeUndefined();
+    expect(result.output).toBe('back from the dead');
+    expect(freshCounter.calls).toBe(1);
+    expect(reconnects).toBe(1);
+  });
+
   it('returns a non-transport MCP error without reconnecting the server', async () => {
     const manager = new FakeMcpManager();
     const base = fakeMcpClient();
@@ -498,7 +542,9 @@ describe('AgentMcpService', () => {
         signal: new AbortController().signal,
       }),
     ).rejects.toThrow('Connection closed');
-    expect(ix.get(IAgentToolRegistryService).list().filter((tool) => tool.source === 'mcp')).toEqual([]);
+    // The tools stay registered after the failed reconnect so a later call
+    // can try healing the server again instead of hitting "tool not found".
+    expect(ix.get(IAgentToolRegistryService).list().filter((tool) => tool.source === 'mcp')).toHaveLength(2);
   });
 
   it('reports both errors when the reconnect attempt itself fails', async () => {
@@ -1031,7 +1077,7 @@ describe('AgentMcpService', () => {
     ]);
   });
 
-  it('emits tool.list.updated(mcp.failed) when a connected server fails', async () => {
+  it('keeps tools registered when a connected server fails so later calls can heal', async () => {
     const manager = new FakeMcpManager();
     const client = fakeMcpClient();
     manager.setResolved('s', client, await discoverTools(client));
@@ -1040,13 +1086,30 @@ describe('AgentMcpService', () => {
     manager.connect('s');
     manager.fail('s');
 
-    expect(ix.get(IAgentToolRegistryService).list().filter((tool) => tool.source === 'mcp')).toEqual([]);
+    expect(ix.get(IAgentToolRegistryService).list().filter((tool) => tool.source === 'mcp')).toHaveLength(2);
+    expect(events).not.toContainEqual(
+      expect.objectContaining({ type: 'tool.list.updated', reason: 'mcp.failed' }),
+    );
     expect(events).toContainEqual(
       expect.objectContaining({
-        type: 'tool.list.updated',
-        reason: 'mcp.failed',
-        serverName: 's',
+        type: 'mcp.server.status',
+        server: expect.objectContaining({ name: 's', status: 'failed' }),
       }),
+    );
+  });
+
+  it('keeps tools registered while the server is reconnecting', async () => {
+    const manager = new FakeMcpManager();
+    const client = fakeMcpClient();
+    manager.setResolved('s', client, await discoverTools(client));
+    createService(manager);
+
+    manager.connect('s');
+    manager.pending('s');
+
+    expect(ix.get(IAgentToolRegistryService).list().filter((tool) => tool.source === 'mcp')).toHaveLength(2);
+    expect(events).not.toContainEqual(
+      expect.objectContaining({ type: 'tool.list.updated', reason: 'mcp.disconnected' }),
     );
   });
 

--- a/packages/agent-core-v2/test/agent/mcp/output.test.ts
+++ b/packages/agent-core-v2/test/agent/mcp/output.test.ts
@@ -536,6 +536,7 @@ describe('createMcpTool', () => {
       async callTool() {
         return { content: [{ type: 'text', text: 'ok' }], isError: false };
       },
+      async ping() {},
     } satisfies MCPClient;
     const tool = createMcpTool(
       'mcp__server__tool',

--- a/packages/agent-core-v2/test/agent/mcp/stubs.ts
+++ b/packages/agent-core-v2/test/agent/mcp/stubs.ts
@@ -77,6 +77,7 @@ export function fakeMcpClient(
       }
       return { content: [{ type: 'text', text: 'ok' }], isError: false };
     },
+    async ping() {},
   };
 }
 


### PR DESCRIPTION
## Related Issue

No linked issue — the problem is explained below. Related: #1168 (asks for MCP status/manual control; this PR only adds automatic recovery, it does not resolve that request).

## Problem

MCP servers connect once when a session starts. If a connection drops mid-session (the stdio process exits, a remote server restarts, etc.), the next call to one of its tools fails outright, and the server's tools disappear from the tool list for every later turn. There was no automatic recovery: the model saw a failed tool call and permanently lost the capability for the rest of the session.

## What changed

When an MCP tool call throws because the transport died, the tool now reconnects its server once and retries the call on the fresh client, so a dropped connection surfaces as a slow call instead of a failed turn. This fits the existing lifecycle: the session-scoped connection manager already owns reconnects and status events, so the adapter only bridges the failing call to that path.

- Parallel tool calls failing on the same dead server share a single reconnect instead of restarting it once per call.
- User aborts bypass the retry, so cancellation stays responsive.
- If the reconnect itself fails, the tool reports both the original error and the reconnect failure; existing failed/disconnected status events and tool-list updates are unchanged.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.

