### PR TITLE
fix(vscode): reduce webview streaming re-render churn

### DIFF
--- a/apps/vscode/src/handlers/file.handler.ts
+++ b/apps/vscode/src/handlers/file.handler.ts
@@ -165,6 +165,10 @@ const getImageDataUri: Handler<FilePathParams, string | null> = async ({ filePat
   const mime = IMAGE_MIME_TYPES[path.extname(resolved.relativePath).toLowerCase()];
   if (!mime) return null;
   try {
+    // Same cap as the media picker: an oversized image inlined as a data URI
+    // would live in the webview DOM (and its decoded bitmap) forever.
+    const stat = await vscode.workspace.fs.stat(resolved.uri);
+    if (stat.size > 10 * 1024 * 1024) return null;
     const bytes = await vscode.workspace.fs.readFile(resolved.uri);
     return `data:${mime};base64,${Buffer.from(bytes).toString("base64")}`;
   } catch {

--- a/apps/vscode/webview-ui/src/components/ChatArea.tsx
+++ b/apps/vscode/webview-ui/src/components/ChatArea.tsx
@@ -23,7 +23,8 @@ function ScrollButton() {
 }
 
 function MessageList() {
-  const { messages, isStreaming } = useChatStore();
+  const messages = useChatStore((s) => s.messages);
+  const isStreaming = useChatStore((s) => s.isStreaming);
 
   return (
     <>
@@ -43,9 +44,9 @@ function MessageList() {
 }
 
 export function ChatArea() {
-  const { messages } = useChatStore();
+  const messageCount = useChatStore((s) => s.messages.length);
 
-  if (messages.length === 0) {
+  if (messageCount === 0) {
     return (
       <div className="h-full flex items-center justify-center relative">
         <WelcomeScreen />

--- a/apps/vscode/webview-ui/src/components/ChatMessage.tsx
+++ b/apps/vscode/webview-ui/src/components/ChatMessage.tsx
@@ -1,4 +1,4 @@
-import { useState, Fragment } from "react";
+import { useState, Fragment, memo } from "react";
 import { IconLoader3, IconGitFork } from "@tabler/icons-react";
 import { cn } from "@/lib/utils";
 import { Content } from "@/lib/content";
@@ -146,7 +146,9 @@ interface ForkButtonProps {
 function ForkButton({ turnIndex, className }: ForkButtonProps) {
   const [showConfirm, setShowConfirm] = useState(false);
   const [isForking, setIsForking] = useState(false);
-  const { sessionId, isStreaming, loadSession } = useChatStore();
+  const sessionId = useChatStore((s) => s.sessionId);
+  const isStreaming = useChatStore((s) => s.isStreaming);
+  const loadSession = useChatStore((s) => s.loadSession);
 
   const handleFork = () => {
     if (!sessionId || turnIndex < 0) return;
@@ -234,7 +236,7 @@ function UserMessage({ message }: { message: ChatMessageType }) {
 
 function AssistantMessage({ message, turnIndex, isStreaming }: { message: ChatMessageType; turnIndex?: number; isStreaming?: boolean }) {
   const [previewMedia, setPreviewMedia] = useState<string | null>(null);
-  const { isCompacting } = useChatStore();
+  const isCompacting = useChatStore((s) => s.isCompacting);
 
   const steps = message.steps || [];
   const hasSteps = steps.length > 0;
@@ -330,9 +332,9 @@ function hasMessageContent(message: ChatMessageType): boolean {
   return message.steps?.some((s) => s.items.length > 0) ?? false;
 }
 
-export function ChatMessage({ message, turnIndex, isStreaming }: ChatMessageProps) {
+export const ChatMessage = memo(function ChatMessage({ message, turnIndex, isStreaming }: ChatMessageProps) {
   if (message.role === "user") {
     return <UserMessage message={message} />;
   }
   return <AssistantMessage message={message} turnIndex={turnIndex} isStreaming={isStreaming} />;
-}
+});

--- a/apps/vscode/webview-ui/src/components/CompactionCard.tsx
+++ b/apps/vscode/webview-ui/src/components/CompactionCard.tsx
@@ -2,7 +2,7 @@ import { IconLoader2 } from "@tabler/icons-react";
 import { useChatStore } from "@/stores";
 
 export function CompactionCard() {
-  const { isCompacting } = useChatStore();
+  const isCompacting = useChatStore((s) => s.isCompacting);
 
   return (
     <div className="rounded-lg border border-border bg-muted/20 overflow-hidden">


### PR DESCRIPTION
## Related Issue

N/A — this came from a user crash report; the problem is explained below.

## Problem

A user reported that the VS Code window hosting the Kimi Code webview OOM-crashed (white screen) within minutes of activating a session. Investigating the webview code surfaced two concrete memory/render pressure sources:

- Chat components subscribed to the entire chat store (`useChatStore()` with no selector). Every streaming delta therefore re-rendered the whole message list — every settled assistant message re-ran step grouping, `JSON.parse` of tool arguments, and markdown work — so CPU and GC pressure grew linearly with conversation length.
- `getImageDataUri` inlined local images of any size as base64 data URIs that then live in the webview DOM (plus decoded bitmaps) indefinitely.

## What changed

- `ChatArea`, `ChatMessage`, `CompactionCard`: subscribe to narrow store slices (`messages`, `isStreaming`, `isCompacting`, `sessionId`, ...) instead of the whole store, and memoize `ChatMessage`. Message objects are referentially stable thanks to immer, so settled messages now skip re-rendering on each streaming delta; only the actively streaming message updates.
- `getImageDataUri`: stat the file first and cap at 10 MB, matching the existing media picker limit. Oversized images fall back to the existing load-failure placeholder in the markdown renderer.

No behavior change beyond the oversized-image guard. Verified: `typecheck`, the full vitest suite (297 tests), and the production build all pass.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works. (Existing suite of 297 tests covers these components; the change only narrows subscriptions and memoizes — no new observable behavior to test.)
- [x] Ran `gen-changesets` skill, or this PR needs no changeset. (No changeset: the VS Code extension ships through its manual changelog/vsix flow — see `chore(vscode): release 0.6.4` — and nothing here enters the CLI bundle.)
- [x] Ran `gen-docs` skill, or this PR needs no doc update. (Internal rendering fix; no documented user-facing behavior changes.)
