### PR TITLE
fix(tui): remove red coloring from code syntax highlighting

### DIFF
--- a/.changeset/tui-code-highlight-no-red.md
+++ b/.changeset/tui-code-highlight-no-red.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Remove red coloring from syntax highlighting in code previews and markdown code blocks.

--- a/apps/kimi-code/src/tui/components/media/code-highlight.ts
+++ b/apps/kimi-code/src/tui/components/media/code-highlight.ts
@@ -7,6 +7,8 @@ import { extname } from 'node:path';
 
 import { highlight, supportsLanguage } from 'cli-highlight';
 
+import { codeHighlightTheme } from '#/tui/theme/highlight-theme';
+
 const EXT_LANG_MAP: Record<string, string> = {
   ts: 'typescript',
   tsx: 'typescript',
@@ -45,7 +47,7 @@ export function highlightLines(code: string, lang: string | undefined): string[]
   const normalizedLang = lang?.trim().toLowerCase();
   if (!normalizedLang || !supportsLanguage(normalizedLang)) return code.split('\n');
   try {
-    return highlight(code, { language: normalizedLang, ignoreIllegals: true }).split('\n');
+    return highlight(code, { language: normalizedLang, ignoreIllegals: true, theme: codeHighlightTheme }).split('\n');
   } catch {
     return code.split('\n');
   }

--- a/apps/kimi-code/src/tui/theme/highlight-theme.ts
+++ b/apps/kimi-code/src/tui/theme/highlight-theme.ts
@@ -1,0 +1,17 @@
+/**
+ * Shared cli-highlight theme for code previews (Write/Edit tool calls,
+ * approval panels) and markdown code blocks.
+ *
+ * cli-highlight's DEFAULT_THEME paints `string`, `regexp` and `deletion`
+ * tokens red; reset exactly those tokens to `plain` so highlighted code
+ * contains no red at all. Tokens not listed here fall back to DEFAULT_THEME.
+ */
+
+import { plain } from 'cli-highlight';
+import type { Theme } from 'cli-highlight';
+
+export const codeHighlightTheme: Theme = {
+  string: plain,
+  regexp: plain,
+  deletion: plain,
+};

--- a/apps/kimi-code/src/tui/theme/pi-tui-theme.ts
+++ b/apps/kimi-code/src/tui/theme/pi-tui-theme.ts
@@ -13,6 +13,7 @@ import chalk from 'chalk';
 import { highlight, supportsLanguage } from 'cli-highlight';
 
 import { currentTheme } from './theme';
+import { codeHighlightTheme } from './highlight-theme';
 
 // pi-tui's renderer emits literal "### " / "#### " / ... markers for h3-h6
 // headings (h1/h2 are rendered without the `#` prefix). The prefix arrives
@@ -51,7 +52,7 @@ export function createMarkdownTheme(options?: { transient?: boolean }): Markdown
       const language =
         normalizedLang !== undefined && supportsLanguage(normalizedLang) ? normalizedLang : 'text';
       try {
-        const highlighted = highlight(code, { language, ignoreIllegals: true });
+        const highlighted = highlight(code, { language, ignoreIllegals: true, theme: codeHighlightTheme });
         return highlighted.split('\n');
       } catch {
         return code.split('\n');

--- a/apps/kimi-code/test/tui/components/media/code-highlight.test.ts
+++ b/apps/kimi-code/test/tui/components/media/code-highlight.test.ts
@@ -1,8 +1,14 @@
+import { createRequire } from 'node:module';
+import { dirname } from 'node:path';
+
 import { describe, expect, it } from 'vitest';
 
 import { highlightLines, langFromPath } from '#/tui/components/media/code-highlight';
+import { codeHighlightTheme } from '#/tui/theme/highlight-theme';
 
 import { captureProcessWrite } from '../../../helpers/process';
+
+const ESC = String.fromCodePoint(27);
 
 describe('code-highlight', () => {
   it('maps known file extensions to supported highlight languages', () => {
@@ -21,6 +27,34 @@ describe('code-highlight', () => {
       expect(stderr.text()).not.toContain('Could not find the language');
     } finally {
       stderr.restore();
+    }
+  });
+
+  it('resets red tokens to plain styling', () => {
+    for (const token of ['string', 'regexp', 'deletion'] as const) {
+      expect(codeHighlightTheme[token]?.('code')).toBe('code');
+    }
+  });
+
+  it('emits no red SGR for strings, regexps and diff deletions', () => {
+    // cli-highlight styles through its own chalk v4 instance; force colors on
+    // so the assertions below observe real SGR sequences.
+    const req = createRequire(import.meta.url);
+    const chalkV4 = req(
+      req.resolve('chalk', { paths: [dirname(req.resolve('cli-highlight'))] }),
+    ) as { level: number };
+    const prevLevel = chalkV4.level;
+    chalkV4.level = 1;
+    try {
+      const js = highlightLines("const s = 'str';\nconst r = /re+/g;", 'javascript').join('\n');
+      expect(js).not.toContain(`${ESC}[31m`);
+      expect(js).toContain(`${ESC}[34m`); // keywords stay highlighted
+
+      const diff = highlightLines('+ added\n- removed', 'diff').join('\n');
+      expect(diff).not.toContain(`${ESC}[31m`);
+      expect(diff).toContain(`${ESC}[32m`); // additions stay green
+    } finally {
+      chalkV4.level = prevLevel;
     }
   });
 });


### PR DESCRIPTION
## Related Issue

No linked issue — the problem is explained below.

## Problem

Code syntax highlighting in the TUI (Write/Edit tool previews, approval panels, and assistant markdown code blocks) renders strings, regular expressions, and `diff`-block deletions in red. This comes from `cli-highlight`'s default theme, which maps those tokens to `chalk.red`. The result is alarm-red noise all over ordinary code output, and red should not appear in code highlighting at all.

## What changed

- Add a shared `cli-highlight` theme that resets exactly the three red tokens (`string`, `regexp`, `deletion`) to `plain`; every other token keeps the library default, so the rest of the highlighting is untouched.
- Route both highlight paths — tool-call file previews and the pi-tui markdown `highlightCode` — through this theme so behavior is consistent.
- Add tests asserting the three tokens are identity-styled and that, with colors forced on, highlighted JS strings/regexps and diff deletions emit no red SGR while keywords (blue) and diff additions (green) remain colored.

This approach fits Kimi Code because it keeps the change inside the theme layer (`src/tui/theme/`) as the single source of truth for color, without forking the highlight library or touching renderers.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.
