### PR TITLE
fix(agent-core-v2): clear dangling defaultModel and thinking on managed logout

### DIFF
--- a/packages/agent-core-v2/src/app/auth/authService.ts
+++ b/packages/agent-core-v2/src/app/auth/authService.ts
@@ -329,8 +329,11 @@ export class OAuthService extends Disposable implements IOAuthService {
         );
         await this.config.replace(PROVIDERS_SECTION, next.providers);
         await this.config.replace(MODELS_SECTION, next.models ?? {});
-        await this.config.set(DEFAULT_MODEL_SECTION, next.defaultModel);
-        await this.config.set(THINKING_SECTION, next.thinking);
+        // defaultModel/thinking hold the final computed values — write them
+        // with replace (set-undefined cannot delete; set-object would merge
+        // stale keys into the previous thinking config).
+        await this.config.replace(DEFAULT_MODEL_SECTION, next.defaultModel);
+        await this.config.replace(THINKING_SECTION, next.thinking);
         changed.push({
           provider_id: KIMI_CODE_PROVIDER_NAME,
           provider_name: 'Kimi Code',
@@ -509,8 +512,12 @@ export class OAuthService extends Disposable implements IOAuthService {
       await this.config.replace(SERVICES_SECTION, next.services);
     }
     if (cleanup.defaultModelCleared) {
-      await this.config.set(DEFAULT_MODEL_SECTION, undefined);
-      await this.config.set(THINKING_SECTION, undefined);
+      // Delete, not merge: `set(domain, undefined)` resolves back to the base
+      // value by design — only `replace(domain, undefined)` actually removes
+      // the key, and leaving defaultModel dangling to a just-removed managed
+      // model keeps /api/v1/auth reporting ready=true after logout.
+      await this.config.replace(DEFAULT_MODEL_SECTION, undefined);
+      await this.config.replace(THINKING_SECTION, undefined);
     }
   }
 

--- a/packages/agent-core-v2/src/kosong/provider/providerService.ts
+++ b/packages/agent-core-v2/src/kosong/provider/providerService.ts
@@ -68,7 +68,10 @@ export class ProviderService extends Disposable implements IProviderService {
     const { [name]: _removed, ...rest } = current;
     await this.config.replace(PROVIDERS_SECTION, rest);
     if (this.config.get<string>(DEFAULT_PROVIDER_SECTION) === name) {
-      await this.config.set(DEFAULT_PROVIDER_SECTION, undefined);
+      // Delete, not merge: `set(domain, undefined)` resolves back to the base
+      // value by design — only `replace(domain, undefined)` removes the key,
+      // otherwise the default-provider id dangles to a deleted provider.
+      await this.config.replace(DEFAULT_PROVIDER_SECTION, undefined);
     }
   }
 }

--- a/packages/agent-core-v2/test/app/auth/auth.test.ts
+++ b/packages/agent-core-v2/test/app/auth/auth.test.ts
@@ -136,6 +136,14 @@ describe('OAuthService', () => {
         services = value as Record<string, unknown> | undefined;
         return;
       }
+      if (domain === 'defaultModel') {
+        defaultModel = value as string | undefined;
+        return;
+      }
+      if (domain === 'thinking') {
+        thinking = value as { enabled?: boolean; effort?: string } | undefined;
+        return;
+      }
       throw new Error(`unexpected config replace: ${domain}`);
     });
     events = [];
@@ -398,7 +406,7 @@ describe('OAuthService', () => {
       }),
     );
     expect(fetchMock).toHaveBeenCalledTimes(1);
-    expect(configSet).toHaveBeenCalledWith('defaultModel', 'kimi-code/kimi-k2');
+    expect(configReplace).toHaveBeenCalledWith('defaultModel', 'kimi-code/kimi-k2');
   });
 
   it('startLogin returns authenticated when model refresh fails on the already-authenticated fast path', async () => {
@@ -421,7 +429,7 @@ describe('OAuthService', () => {
         oauth: EXAMPLE_COM_SCOPED_REF,
       }),
     );
-    expect(configSet).not.toHaveBeenCalledWith('defaultModel', expect.any(String));
+    expect(configReplace).not.toHaveBeenCalledWith('defaultModel', expect.any(String));
   });
 
   it('keeps a device-code login authenticated when model fetch is unavailable after authorization', async () => {
@@ -439,7 +447,7 @@ describe('OAuthService', () => {
     });
     await vi.waitFor(() => expect(svc.getFlow(OAUTH_PROVIDER)?.status).toBe('authenticated'));
     expect(fetchMock).toHaveBeenCalledTimes(1);
-    expect(configSet).not.toHaveBeenCalledWith('defaultModel', expect.any(String));
+    expect(configReplace).not.toHaveBeenCalledWith('defaultModel', expect.any(String));
   });
 
   it('refreshes managed models and sets the default model after a device-code login succeeds', async () => {
@@ -467,7 +475,7 @@ describe('OAuthService', () => {
         'kimi-code/kimi-k2': expect.objectContaining({ model: 'kimi-k2' }),
       }),
     );
-    expect(configSet).toHaveBeenCalledWith('defaultModel', 'kimi-code/kimi-k2');
+    expect(configReplace).toHaveBeenCalledWith('defaultModel', 'kimi-code/kimi-k2');
   });
 
   it('keeps an in-flight OAuth flow alive when unrelated providers change', async () => {
@@ -596,8 +604,8 @@ describe('OAuthService', () => {
         maxContextSize: 8192,
       },
     });
-    expect(configSet).toHaveBeenCalledWith('defaultModel', undefined);
-    expect(configSet).toHaveBeenCalledWith('thinking', undefined);
+    expect(configReplace).toHaveBeenCalledWith('defaultModel', undefined);
+    expect(configReplace).toHaveBeenCalledWith('thinking', undefined);
   });
 
   it('logout removes managed web services while preserving unrelated services', async () => {
@@ -721,8 +729,8 @@ describe('OAuthService', () => {
         'kimi-code/kimi-k2': expect.objectContaining({ model: 'kimi-k2' }),
       }),
     );
-    expect(configSet).toHaveBeenCalledWith('defaultModel', 'kimi-code/kimi-k2');
-    expect(configSet).toHaveBeenCalledWith('thinking', { enabled: true });
+    expect(configReplace).toHaveBeenCalledWith('defaultModel', 'kimi-code/kimi-k2');
+    expect(configReplace).toHaveBeenCalledWith('thinking', { enabled: true });
     expect(events).toEqual([
       {
         type: 'event.model_catalog.changed',

--- a/packages/agent-core-v2/test/app/provider/provider.test.ts
+++ b/packages/agent-core-v2/test/app/provider/provider.test.ts
@@ -118,7 +118,7 @@ describe('ProviderService', () => {
     expect(configReplace).toHaveBeenCalledWith(PROVIDERS_SECTION, {
       p2: { type: 'kimi' },
     });
-    expect(configSet).toHaveBeenCalledWith('defaultProvider', undefined);
+    expect(configReplace).toHaveBeenCalledWith('defaultProvider', undefined);
   });
 
   it('delete leaves defaultProvider when removing a different provider', async () => {
@@ -127,7 +127,7 @@ describe('ProviderService', () => {
     defaultProvider = 'p2';
     const svc = ix.get(IProviderService);
     await svc.delete('p1');
-    expect(configSet).not.toHaveBeenCalled();
+    expect(configReplace).not.toHaveBeenCalledWith('defaultProvider', expect.anything());
   });
 
   it('forwards providers section changes as onDidChangeProviders with a diff', () => {


### PR DESCRIPTION
## Related Issue

No linked issue — this is a clear, reproducible bug fix; the problem is explained below.

## Problem

After signing out of the managed Kimi account (`POST /api/v1/oauth/logout`), `GET /api/v1/auth` keeps reporting `ready: true` whenever any other provider is configured. The deprovision removes the managed provider and its models from `config.toml`, but leaves `default_model` (and `thinking`) behind — dangling to a model that no longer exists. Desktop/web clients then keep rendering "signed in" (no visible feedback for the logout), and the default model points at nothing.

Root cause: the deprovision cleared these keys via `config.set(domain, undefined)`. `set()` deep-merges, and `deepMerge`'s `patch ?? base` fallback resolves an `undefined` patch back to the base value — a silent no-op (this exact behavior is pinned by `test/app/config/config.test.ts`). Only `replace(domain, undefined)` actually deletes a key.

## What changed

- `app/auth/authService.ts` — the managed-provider deprovision now deletes `defaultModel` / `thinking` with `config.replace(domain, undefined)`. The managed-model refresh path also writes these with `replace`: they hold final computed values, and `set` would both merge stale keys into the previous thinking config and fail to clear them when the computed value is `undefined`.
- `kosong/provider/providerService.ts` — `delete()` now clears a dangling `defaultProvider` id via `replace` as well (same latent bug on that path).
- Tests updated: the auth/provider stubs previously encoded the *intended* (not actual) `set(undefined)` semantics, so the suite couldn't see the bug. Assertions now pin the `replace`-based deletes.

Verified: `agent-core-v2` full suite (3872 tests) green; logout on a live server now removes `default_model`/`thinking` from `config.toml` and `/api/v1/auth` flips to `ready: false` with third-party providers present.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.