### PR TITLE
feat(kap-server): add GET /api/v1/oauth/usage for managed account plan usage

### DIFF
--- a/packages/agent-core-v2/src/app/auth/auth.ts
+++ b/packages/agent-core-v2/src/app/auth/auth.ts
@@ -11,6 +11,7 @@
  */
 
 import type {
+  AuthManagedUsageResult,
   BearerTokenProvider,
   KimiOAuthLoginOptions,
   KimiOAuthLoginResult,
@@ -45,6 +46,7 @@ export interface IOAuthService {
   logout(provider?: string): Promise<OAuthLogoutResponse>;
   status(provider?: string): Promise<AuthStatus>;
   refreshOAuthProviderModels(): Promise<RefreshOAuthProviderModelsResponse>;
+  getManagedUsage(provider?: string): Promise<AuthManagedUsageResult>;
   resolveTokenProvider(provider: string, oauthRef?: OAuthRef): BearerTokenProvider | undefined;
   getCachedAccessToken(provider: string, oauthRef?: OAuthRef): Promise<string | undefined>;
 }
@@ -62,6 +64,10 @@ export interface IOAuthToolkit {
     oauthRef?: KimiOAuthTokenRef,
   ): Promise<string | undefined>;
   tokenProvider(providerName?: string, oauthRef?: KimiOAuthTokenRef): BearerTokenProvider;
+  getManagedUsage(
+    providerName?: string,
+    options?: { readonly oauthRef?: KimiOAuthTokenRef; readonly baseUrl?: string },
+  ): Promise<AuthManagedUsageResult>;
 }
 
 export const IOAuthToolkit: ServiceIdentifier<IOAuthToolkit> =

--- a/packages/agent-core-v2/src/app/auth/authService.ts
+++ b/packages/agent-core-v2/src/app/auth/authService.ts
@@ -27,6 +27,7 @@ import {
   resolveKimiCodeLoginAuth,
   resolveKimiCodeOAuthRef,
   resolveKimiCodeRuntimeAuth,
+  type AuthManagedUsageResult,
   type BearerTokenProvider,
   type DeviceAuthorization,
   type ManagedKimiConfigShape,
@@ -258,6 +259,21 @@ export class OAuthService extends Disposable implements IOAuthService {
 
   getCachedAccessToken(provider: string, oauthRef?: OAuthRef): Promise<string | undefined> {
     return this.toolkit.getCachedAccessToken(provider, this.resolveRuntimeOAuthRef(provider, oauthRef));
+  }
+
+  getManagedUsage(provider = KIMI_CODE_PROVIDER_NAME): Promise<AuthManagedUsageResult> {
+    // Same resolution path as the managed model refresh: env-aware base url +
+    // oauth ref, so a self-hosted/proxied login environment reports its own
+    // usage endpoint. The toolkit handles token freshness and error mapping.
+    const configured = this.providerService.get(provider);
+    const auth = resolveKimiCodeRuntimeAuth({
+      configuredBaseUrl: configured?.baseUrl,
+      configuredOAuthRef: configured?.oauth,
+    });
+    return this.toolkit.getManagedUsage(provider, {
+      oauthRef: auth.oauthRef,
+      baseUrl: auth.baseUrl,
+    });
   }
 
   refreshOAuthProviderModels(): Promise<RefreshOAuthProviderModelsResponse> {

--- a/packages/agent-core-v2/src/app/auth/oauthProtocol.ts
+++ b/packages/agent-core-v2/src/app/auth/oauthProtocol.ts
@@ -107,3 +107,47 @@ export const refreshOAuthProviderModelsResponseSchema = z.object({
 export type RefreshOAuthProviderModelsResponse = z.infer<
   typeof refreshOAuthProviderModelsResponseSchema
 >;
+
+// ---------------------------------------------------------------------------
+// Managed-account usage (`GET /v1/oauth/usage`) — mirrors the toolkit's
+// `AuthManagedUsageResult` (camelCase domain model → snake_case wire DTO).
+// ---------------------------------------------------------------------------
+
+export const usageRowSchema = z.object({
+  label: z.string(),
+  used: z.number().int(),
+  limit: z.number().int(),
+  reset_hint: z.string().optional(),
+});
+export type UsageRow = z.infer<typeof usageRowSchema>;
+
+export const boosterWalletSchema = z.object({
+  balance_cents: z.number().int(),
+  total_cents: z.number().int(),
+  monthly_charge_limit_enabled: z.boolean(),
+  monthly_charge_limit_cents: z.number().int(),
+  monthly_used_cents: z.number().int(),
+  currency: z.string(),
+});
+export type BoosterWallet = z.infer<typeof boosterWalletSchema>;
+
+export const managedUsageOkSchema = z.object({
+  kind: z.literal('ok'),
+  summary: usageRowSchema.nullable(),
+  limits: z.array(usageRowSchema),
+  extra_usage: boosterWalletSchema.nullable(),
+});
+export type ManagedUsageOk = z.infer<typeof managedUsageOkSchema>;
+
+export const managedUsageErrorSchema = z.object({
+  kind: z.literal('error'),
+  message: z.string(),
+  status: z.number().int().optional(),
+});
+export type ManagedUsageError = z.infer<typeof managedUsageErrorSchema>;
+
+export const managedUsageResultSchema = z.discriminatedUnion('kind', [
+  managedUsageOkSchema,
+  managedUsageErrorSchema,
+]);
+export type ManagedUsageResult = z.infer<typeof managedUsageResultSchema>;

--- a/packages/agent-core-v2/test/app/auth/auth.test.ts
+++ b/packages/agent-core-v2/test/app/auth/auth.test.ts
@@ -77,6 +77,7 @@ interface FakeToolkit {
   readonly logout: ReturnType<typeof vi.fn>;
   readonly getCachedAccessToken: ReturnType<typeof vi.fn>;
   readonly tokenProvider: ReturnType<typeof vi.fn>;
+  readonly getManagedUsage: ReturnType<typeof vi.fn>;
 }
 
 describe('OAuthService', () => {
@@ -144,6 +145,7 @@ describe('OAuthService', () => {
       logout: vi.fn().mockResolvedValue({ providerName: OAUTH_PROVIDER, ok: true }),
       getCachedAccessToken: vi.fn().mockResolvedValue(undefined),
       tokenProvider: vi.fn().mockReturnValue({ getAccessToken: async () => 'access-token' }),
+      getManagedUsage: vi.fn().mockResolvedValue({ kind: 'error', message: 'not configured' }),
     };
     ix = createServices(disposables, {
       base: [registerBootstrapServices, registerTelemetryServices],
@@ -668,6 +670,18 @@ describe('OAuthService', () => {
       configuredOAuthRef: { storage: 'file', key: 'stale-key' },
     }).oauthRef;
     expect(toolkit.tokenProvider).toHaveBeenCalledWith(OAUTH_PROVIDER, expectedRef);
+  });
+
+  it('getManagedUsage resolves the managed runtime auth and delegates to the toolkit', async () => {
+    const usage = { kind: 'ok' as const, summary: null, limits: [], extraUsage: null };
+    toolkit.getManagedUsage.mockResolvedValue(usage);
+    const svc = createService();
+
+    await expect(svc.getManagedUsage(OAUTH_PROVIDER)).resolves.toBe(usage);
+    expect(toolkit.getManagedUsage).toHaveBeenCalledWith(OAUTH_PROVIDER, {
+      oauthRef: EXAMPLE_COM_SCOPED_REF,
+      baseUrl: 'https://api.example.com',
+    });
   });
 
   it('refreshOAuthProviderModels returns an empty result when no Kimi Code provider is configured', async () => {

--- a/packages/kap-server/src/routes/oauth.ts
+++ b/packages/kap-server/src/routes/oauth.ts
@@ -13,10 +13,13 @@
 
 import { IOAuthService, type Scope } from '@moonshot-ai/agent-core-v2';
 import {
+  managedUsageResultSchema,
   oauthFlowSnapshotSchema,
   oauthFlowStartSchema,
   oauthLoginCancelResponseSchema,
   oauthLogoutResponseSchema,
+  type ManagedUsageResult,
+  type UsageRow,
 } from '@moonshot-ai/agent-core-v2/app/auth/oauthProtocol';
 import { z } from 'zod';
 
@@ -151,4 +154,55 @@ export function registerOAuthRoutes(app: RouteHost, core: Scope): void {
     logoutRoute.options,
     logoutRoute.handler as Parameters<RouteHost['post']>[2],
   );
+
+  // GET /oauth/usage — managed-account plan usage (limits + booster wallet) ---
+  const usageRoute = defineRoute(
+    {
+      method: 'GET',
+      path: '/oauth/usage',
+      querystring: oauthLoginQuerySchema,
+      success: { data: managedUsageResultSchema },
+      description: 'Get the managed account usage summary',
+      tags: ['auth'],
+    },
+    async (req, reply) => {
+      const result = await core.accessor.get(IOAuthService).getManagedUsage(req.query.provider);
+      reply.send(okEnvelope(toWireUsage(result), req.id));
+    },
+  );
+  app.get(
+    usageRoute.path,
+    usageRoute.options,
+    usageRoute.handler as Parameters<RouteHost['get']>[2],
+  );
+}
+
+/** Domain (camelCase) → wire (snake_case) mapping for the usage payload. */
+function toWireUsage(result: ManagedUsageDomainResult): ManagedUsageResult {
+  if (result.kind === 'error') {
+    return { kind: 'error', message: result.message, status: result.status };
+  }
+  return {
+    kind: 'ok',
+    summary: result.summary === null ? null : toWireUsageRow(result.summary),
+    limits: result.limits.map(toWireUsageRow),
+    extra_usage:
+      result.extraUsage === null
+        ? null
+        : {
+            balance_cents: result.extraUsage.balanceCents,
+            total_cents: result.extraUsage.totalCents,
+            monthly_charge_limit_enabled: result.extraUsage.monthlyChargeLimitEnabled,
+            monthly_charge_limit_cents: result.extraUsage.monthlyChargeLimitCents,
+            monthly_used_cents: result.extraUsage.monthlyUsedCents,
+            currency: result.extraUsage.currency,
+          },
+  };
+}
+
+type ManagedUsageDomainResult = Awaited<ReturnType<IOAuthService['getManagedUsage']>>;
+type DomainUsageRow = { label: string; used: number; limit: number; resetHint?: string };
+
+function toWireUsageRow(row: DomainUsageRow): UsageRow {
+  return { label: row.label, used: row.used, limit: row.limit, reset_hint: row.resetHint };
 }

--- a/packages/kap-server/test/__snapshots__/apiSurface.snapshot.test.ts.snap
+++ b/packages/kap-server/test/__snapshots__/apiSurface.snapshot.test.ts.snap
@@ -106,6 +106,10 @@ exports[`API surface snapshot > matches the documented v2 route table and meta e
     ],
     [
       "GET",
+      "/api/v1/oauth/usage",
+    ],
+    [
+      "GET",
       "/api/v1/providers",
     ],
     [

--- a/packages/kap-server/test/modelCatalog.test.ts
+++ b/packages/kap-server/test/modelCatalog.test.ts
@@ -304,6 +304,7 @@ describe('server-v2 /api/v1 model/provider catalog', () => {
       },
       status: async () => ({ loggedIn: false }),
       refreshOAuthProviderModels,
+      getManagedUsage: async () => ({ kind: 'error' as const, message: 'unused' }),
       resolveTokenProvider: () => undefined,
       getCachedAccessToken: async () => undefined,
     };

--- a/packages/kap-server/test/oauthUsage.test.ts
+++ b/packages/kap-server/test/oauthUsage.test.ts
@@ -1,0 +1,134 @@
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import {
+  IOAuthService,
+  type IOAuthService as IOAuthServiceType,
+  type ScopeSeed,
+} from '@moonshot-ai/agent-core-v2';
+import {
+  managedUsageResultSchema,
+  type ManagedUsageResult,
+} from '@moonshot-ai/agent-core-v2/app/auth/oauthProtocol';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { type RunningServer, startServer } from '../src/start';
+import { authHeaders } from './helpers/auth';
+
+interface Envelope<T> {
+  code: number;
+  msg: string;
+  data: T;
+  request_id: string;
+}
+
+describe('server-v2 GET /api/v1/oauth/usage', () => {
+  let server: RunningServer | undefined;
+  let home: string | undefined;
+  let base: string;
+
+  beforeEach(async () => {
+    home = await mkdtemp(join(tmpdir(), 'kimi-server-v2-oauth-usage-'));
+  });
+
+  afterEach(async () => {
+    if (server !== undefined) {
+      await server.close();
+      server = undefined;
+    }
+    if (home !== undefined) {
+      await rm(home, { recursive: true, force: true });
+      home = undefined;
+    }
+  });
+
+  function oauthStub(getManagedUsage: IOAuthServiceType['getManagedUsage']): IOAuthServiceType {
+    return {
+      _serviceBrand: undefined,
+      startLogin: async () => {
+        throw new Error('unused');
+      },
+      getFlow: () => undefined,
+      cancelLogin: async () => {
+        throw new Error('unused');
+      },
+      logout: async () => {
+        throw new Error('unused');
+      },
+      status: async () => ({ loggedIn: false }),
+      refreshOAuthProviderModels: async () => ({ changed: [], unchanged: [], failed: [] }),
+      getManagedUsage,
+      resolveTokenProvider: () => undefined,
+      getCachedAccessToken: async () => undefined,
+    };
+  }
+
+  async function boot(seeds: ScopeSeed): Promise<void> {
+    server = await startServer({
+      host: '127.0.0.1',
+      port: 0,
+      homeDir: home,
+      logLevel: 'silent',
+      seeds,
+    });
+    base = `http://127.0.0.1:${server.port}`;
+  }
+
+  async function getUsage(query = ''): Promise<ManagedUsageResult> {
+    const res = await fetch(`${base}/api/v1/oauth/usage${query}`, {
+      headers: authHeaders(server as RunningServer),
+    } as never);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as Envelope<ManagedUsageResult>;
+    expect(body.code).toBe(0);
+    return managedUsageResultSchema.parse(body.data);
+  }
+
+  it('maps the ok usage payload to the snake_case wire shape', async () => {
+    const getManagedUsage = vi.fn(async () => ({
+      kind: 'ok' as const,
+      summary: { label: 'Weekly limit', used: 40, limit: 1000, resetHint: 'resets in 2d' },
+      limits: [{ label: '5h limit', used: 1, limit: 100 }],
+      extraUsage: {
+        balanceCents: 500,
+        totalCents: 1000,
+        monthlyChargeLimitEnabled: true,
+        monthlyChargeLimitCents: 2000,
+        monthlyUsedCents: 1500,
+        currency: 'CNY',
+      },
+    }));
+    await boot([[IOAuthService, oauthStub(getManagedUsage)]] as unknown as ScopeSeed);
+
+    expect(await getUsage()).toEqual({
+      kind: 'ok',
+      summary: { label: 'Weekly limit', used: 40, limit: 1000, reset_hint: 'resets in 2d' },
+      limits: [{ label: '5h limit', used: 1, limit: 100 }],
+      extra_usage: {
+        balance_cents: 500,
+        total_cents: 1000,
+        monthly_charge_limit_enabled: true,
+        monthly_charge_limit_cents: 2000,
+        monthly_used_cents: 1500,
+        currency: 'CNY',
+      },
+    });
+  });
+
+  it('passes through the error payload and forwards the provider query', async () => {
+    const getManagedUsage = vi.fn(async (_provider?: string) => ({
+      kind: 'error' as const,
+      message: 'Authorization failed.',
+      status: 401,
+    }));
+    await boot([[IOAuthService, oauthStub(getManagedUsage)]] as unknown as ScopeSeed);
+
+    expect(await getUsage('?provider=managed%3Akimi-code')).toEqual({
+      kind: 'error',
+      message: 'Authorization failed.',
+      status: 401,
+    });
+    expect(getManagedUsage).toHaveBeenCalledWith('managed:kimi-code');
+  });
+});


### PR DESCRIPTION
## Related Issue

No linked issue — requested by the desktop/web clients directly (see below).

## Problem

The desktop and web clients want to show a "Plan Usage" section (like the TUI's `/usage` command) in the settings account page, but the managed-account usage data is only reachable in-process: the TUI calls `KimiOAuthToolkit.getManagedUsage()` directly, while kap-server exposes no route for it. Clients that only speak REST (the desktop renderer, the web UI) have no way to fetch plan limits or the booster wallet.

## What changed

- `agent-core-v2` — `IOAuthService.getManagedUsage(provider?)` now exposes the toolkit's existing `getManagedUsage` (token freshness + `/usages` fetch + payload parsing), resolving the env-aware base url and oauth ref the same way the managed model refresh does. The method is also declared on `IOAuthToolkit`.
- `kap-server` — new route `GET /api/v1/oauth/usage` (optional `?provider=` query, matching the other `/oauth/*` routes). The response is the toolkit's discriminated result mapped to a snake_case wire DTO (`managedUsageResultSchema` in `oauthProtocol.ts`): `{ kind: 'ok', summary, limits, extra_usage } | { kind: 'error', message, status? }` — clients can render inline states (not signed in / endpoint unavailable / fetch failed) without a hard HTTP failure.
- Tests: service-level delegation test, route-level wire-mapping and error-passthrough tests, API-surface snapshot updated.

Verified: `agent-core-v2` auth suite (56) and full `kap-server` suite (681) green.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.
