### PR TITLE
test(agent-core-v2): make the test suite pass on Windows

### DIFF
--- a/.changeset/windows-test-compat.md
+++ b/.changeset/windows-test-compat.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/agent-core-v2": patch
+---
+
+Make the agent-core-v2 test suite pass on Windows: shell-portable hook test commands, platform-aware path expectations, yazl-based test archives, and capability probes for symlink/mode-bit tests.

--- a/packages/agent-core-v2/test/agent/externalHooks/runner.test.ts
+++ b/packages/agent-core-v2/test/agent/externalHooks/runner.test.ts
@@ -3,11 +3,9 @@ import { describe, expect, it } from 'vitest';
 import { buildHookSpawnOptions, runHook } from '#/agent/externalHooks/runner';
 import { HostProcessService } from '#/os/backends/node-local/hostProcessService';
 
-const hostProcess = new HostProcessService();
+import { nodeScriptCommand as nodeCommand } from '../../harness/nodeScriptCommand';
 
-function nodeCommand(source: string): string {
-  return `node -e ${JSON.stringify(source.replace(/\s*\n\s*/g, ' '))}`;
-}
+const hostProcess = new HostProcessService();
 
 describe('runHook process runner', () => {
   it('returns allow when the hook exits 0 and captures stdout', async () => {

--- a/packages/agent-core-v2/test/agent/fullCompaction/fullCompaction.test.ts
+++ b/packages/agent-core-v2/test/agent/fullCompaction/fullCompaction.test.ts
@@ -37,6 +37,7 @@ import { estimateTokensForMessages } from '#/kosong/contract/tokens';
 import { recordingTelemetry, type TelemetryRecord } from '../../app/telemetry/stubs';
 import type { TestAgentContext, TestAgentOptions, TestAgentServiceOverride } from '../../harness';
 import { appServices, createCommandRunner, execEnvServices, hostEnvironmentServices, sessionServices, testAgent } from '../../harness';
+import { nodeScriptCommand } from '../../harness/nodeScriptCommand';
 import {
   IAgentFullCompactionService,
   IModelOAuthTokens,
@@ -3080,7 +3081,6 @@ function messageText(message: Message | undefined): string {
 }
 
 function hookPayloadLoggerCommand(logPath: string): string {
-  const scriptPath = `${logPath}.cjs`;
   const script = [
     "const fs = require('node:fs');",
     "let input = '';",
@@ -3089,8 +3089,7 @@ function hookPayloadLoggerCommand(logPath: string): string {
     `  fs.appendFileSync(${JSON.stringify(logPath)}, JSON.stringify(JSON.parse(input)) + '\\n');`,
     '});',
   ].join('');
-  writeFileSync(scriptPath, script);
-  return `${process.execPath} ${scriptPath}`;
+  return nodeScriptCommand(script);
 }
 
 function readHookPayloads(logPath: string): Array<Record<string, unknown>> {

--- a/packages/agent-core-v2/test/agent/mcp/stubs.ts
+++ b/packages/agent-core-v2/test/agent/mcp/stubs.ts
@@ -18,8 +18,6 @@ import type {
   ToolExecution,
 } from '#/tool/toolContract';
 
-// Use fileURLToPath, not URL.pathname: on Windows .pathname yields a
-// leading-slash path like "/D:/..." which Node resolves as "D:\D:\...".
 export const fixturesDir = fileURLToPath(new URL('./fixtures/', import.meta.url));
 export const stdioFixture = fileURLToPath(new URL('./fixtures/mock-stdio-server.mjs', import.meta.url));
 export const cwdStdioFixture = fileURLToPath(new URL('./fixtures/cwd-stdio-server.mjs', import.meta.url));

--- a/packages/agent-core-v2/test/agent/mcp/stubs.ts
+++ b/packages/agent-core-v2/test/agent/mcp/stubs.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from 'node:crypto';
 import { createServer, type Server } from 'node:http';
 import type { AddressInfo } from 'node:net';
+import { fileURLToPath } from 'node:url';
 
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { SSEServerTransport } from '@modelcontextprotocol/sdk/server/sse.js';
@@ -17,26 +18,24 @@ import type {
   ToolExecution,
 } from '#/tool/toolContract';
 
-export const fixturesDir = new URL('./fixtures/', import.meta.url).pathname;
-export const stdioFixture = new URL('./fixtures/mock-stdio-server.mjs', import.meta.url).pathname;
-export const cwdStdioFixture = new URL('./fixtures/cwd-stdio-server.mjs', import.meta.url).pathname;
-export const slowStdioFixture = new URL('./fixtures/slow-stdio-server.mjs', import.meta.url).pathname;
-export const slowToolStdioFixture = new URL(
-  './fixtures/slow-tool-stdio-server.mjs',
-  import.meta.url,
-).pathname;
-export const hangingListStdioFixture = new URL(
-  './fixtures/hanging-list-stdio-server.mjs',
-  import.meta.url,
-).pathname;
-export const crashAfterConnectFixture = new URL(
-  './fixtures/crash-after-connect-stdio-server.mjs',
-  import.meta.url,
-).pathname;
-export const stderrThenExitFixture = new URL(
-  './fixtures/stderr-then-exit-stdio-server.mjs',
-  import.meta.url,
-).pathname;
+// Use fileURLToPath, not URL.pathname: on Windows .pathname yields a
+// leading-slash path like "/D:/..." which Node resolves as "D:\D:\...".
+export const fixturesDir = fileURLToPath(new URL('./fixtures/', import.meta.url));
+export const stdioFixture = fileURLToPath(new URL('./fixtures/mock-stdio-server.mjs', import.meta.url));
+export const cwdStdioFixture = fileURLToPath(new URL('./fixtures/cwd-stdio-server.mjs', import.meta.url));
+export const slowStdioFixture = fileURLToPath(new URL('./fixtures/slow-stdio-server.mjs', import.meta.url));
+export const slowToolStdioFixture = fileURLToPath(
+  new URL('./fixtures/slow-tool-stdio-server.mjs', import.meta.url),
+);
+export const hangingListStdioFixture = fileURLToPath(
+  new URL('./fixtures/hanging-list-stdio-server.mjs', import.meta.url),
+);
+export const crashAfterConnectFixture = fileURLToPath(
+  new URL('./fixtures/crash-after-connect-stdio-server.mjs', import.meta.url),
+);
+export const stderrThenExitFixture = fileURLToPath(
+  new URL('./fixtures/stderr-then-exit-stdio-server.mjs', import.meta.url),
+);
 
 export function createMemoryMcpOAuthStore(): McpOAuthStore {
   const data = new Map<string, unknown>();

--- a/packages/agent-core-v2/test/agent/profile/context.test.ts
+++ b/packages/agent-core-v2/test/agent/profile/context.test.ts
@@ -17,6 +17,24 @@ let homeDir: string;
 let workDir: string;
 let extraDirs: string[];
 
+// Windows only allows creating symlinks with elevated privileges or Developer
+// Mode enabled; skip the test when the filesystem rejects the operation.
+async function symlinkOrSkip(
+  target: string,
+  path: string,
+  ctx: { skip: (message?: string) => never },
+): Promise<void> {
+  try {
+    await symlink(target, path);
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException).code;
+    if (code === 'EPERM' || code === 'ENOTSUP' || code === 'EACCES') {
+      ctx.skip(`symlinks are not permitted in this environment (${code})`);
+    }
+    throw err;
+  }
+}
+
 beforeEach(async () => {
   homeDir = await mkdtemp(join(tmpdir(), 'kimi-agents-home-'));
   workDir = await mkdtemp(join(tmpdir(), 'kimi-agents-work-'));
@@ -76,7 +94,7 @@ describe('loadAgentsMd user-level discovery', () => {
 });
 
 describe('loadAgentsMd symlinked files', () => {
-  it('follows symlinks when loading user-level and project-level AGENTS.md', async () => {
+  it('follows symlinks when loading user-level and project-level AGENTS.md', async (ctx) => {
     const targetDir = await mkdtemp(join(tmpdir(), 'kimi-agents-target-'));
     extraDirs.push(targetDir);
     const brandTarget = join(targetDir, 'brand-AGENTS.md');
@@ -85,8 +103,8 @@ describe('loadAgentsMd symlinked files', () => {
     await writeFile(projectTarget, 'project via symlink', 'utf-8');
 
     await mkdir(join(homeDir, '.kimi-code'), { recursive: true });
-    await symlink(brandTarget, join(homeDir, '.kimi-code', 'AGENTS.md'));
-    await symlink(projectTarget, join(workDir, 'AGENTS.md'));
+    await symlinkOrSkip(brandTarget, join(homeDir, '.kimi-code', 'AGENTS.md'), ctx);
+    await symlinkOrSkip(projectTarget, join(workDir, 'AGENTS.md'), ctx);
 
     const result = await loadAgentsMd({ fs, homeDir }, workDir);
 
@@ -96,10 +114,10 @@ describe('loadAgentsMd symlinked files', () => {
 });
 
 describe('loadAgentsMd unreadable paths', () => {
-  it('warns when an instruction file exists but is a dangling symlink', async () => {
+  it('warns when an instruction file exists but is a dangling symlink', async (ctx) => {
     const brandHome = await mkdtemp(join(tmpdir(), 'kimi-agents-brand-'));
     extraDirs.push(brandHome);
-    await symlink(join(workDir, 'missing-target.md'), join(workDir, 'AGENTS.md'));
+    await symlinkOrSkip(join(workDir, 'missing-target.md'), join(workDir, 'AGENTS.md'), ctx);
 
     const result = await prepareSystemPromptContext({ fs, homeDir }, workDir, brandHome);
 

--- a/packages/agent-core-v2/test/agent/profile/context.test.ts
+++ b/packages/agent-core-v2/test/agent/profile/context.test.ts
@@ -17,8 +17,6 @@ let homeDir: string;
 let workDir: string;
 let extraDirs: string[];
 
-// Windows only allows creating symlinks with elevated privileges or Developer
-// Mode enabled; skip the test when the filesystem rejects the operation.
 async function symlinkOrSkip(
   target: string,
   path: string,

--- a/packages/agent-core-v2/test/agent/task/persist.test.ts
+++ b/packages/agent-core-v2/test/agent/task/persist.test.ts
@@ -28,6 +28,9 @@ import { IFileSystemStorageService } from '#/persistence/interface/storage';
 const SESSION_SCOPE = 'session';
 const AGENT_SCOPE = `${SESSION_SCOPE}/agents/main`;
 
+// Windows ignores POSIX mode bits on mkdir, so the 0700 assertion is POSIX-only.
+const isWin = process.platform === 'win32';
+
 let disposables: DisposableStore;
 let sessionDir: string;
 let docs: IAtomicDocumentStore;
@@ -130,7 +133,7 @@ describe('AgentTaskPersistence', () => {
     expect(all.map((task) => task.taskId)).toEqual(['bash-11111111']);
   });
 
-  it('writeTask creates tasks dir with mode 0700', async () => {
+  it.skipIf(isWin)('writeTask creates tasks dir with mode 0700', async () => {
     await persistence.writeTask(sample());
     const st = await stat(join(sessionDir, SESSION_SCOPE, 'tasks'));
     // eslint-disable-next-line no-bitwise

--- a/packages/agent-core-v2/test/agent/task/persist.test.ts
+++ b/packages/agent-core-v2/test/agent/task/persist.test.ts
@@ -5,6 +5,8 @@
  * resolved by interface, covering primary writes, local-first reads, the
  * previous v2 session-root fallback, and exact output paths. Run with
  * `pnpm --filter @moonshot-ai/agent-core-v2 exec vitest run test/agent/task/persist.test.ts`.
+ * Windows ignores POSIX mode bits on mkdir, so the 0700 directory-mode
+ * assertion is POSIX-only (`it.skipIf(isWin)`).
  */
 
 import { mkdir, rm, stat, writeFile } from 'node:fs/promises';
@@ -28,7 +30,6 @@ import { IFileSystemStorageService } from '#/persistence/interface/storage';
 const SESSION_SCOPE = 'session';
 const AGENT_SCOPE = `${SESSION_SCOPE}/agents/main`;
 
-// Windows ignores POSIX mode bits on mkdir, so the 0700 assertion is POSIX-only.
 const isWin = process.platform === 'win32';
 
 let disposables: DisposableStore;

--- a/packages/agent-core-v2/test/agent/toolResultTruncation/toolResultTruncation.test.ts
+++ b/packages/agent-core-v2/test/agent/toolResultTruncation/toolResultTruncation.test.ts
@@ -1,6 +1,7 @@
 import { mkdtemp, readFile, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
-import { join } from 'node:path';
+
+import { join } from 'pathe';
 
 import { DisposableStore } from '#/_base/di/lifecycle';
 import { TestInstantiationService } from '#/_base/di/test';

--- a/packages/agent-core-v2/test/app/agentFileCatalog/agentRoots.test.ts
+++ b/packages/agent-core-v2/test/app/agentFileCatalog/agentRoots.test.ts
@@ -9,7 +9,7 @@
 import { mkdtemp, mkdir, realpath, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 
-import { join } from 'pathe';
+import { join, normalize } from 'pathe';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 import {
@@ -129,10 +129,10 @@ describe('agentRoots', () => {
       const paths = roots.map((r) => r.path);
 
       expect(roots.every((r) => r.source === 'extra')).toBe(true);
-      expect(paths).toContain(await realpath(homeDir));
-      expect(paths).toContain(await realpath(join(homeDir, 'team')));
-      expect(paths).toContain(await realpath(absDir));
-      expect(paths).toContain(await realpath(join(root, 'relative')));
+      expect(paths).toContain(normalize(await realpath(homeDir)));
+      expect(paths).toContain(normalize(await realpath(join(homeDir, 'team'))));
+      expect(paths).toContain(normalize(await realpath(absDir)));
+      expect(paths).toContain(normalize(await realpath(join(root, 'relative'))));
     });
 
     it('propagates filesystem-unavailable failures while probing a root', async () => {
@@ -186,7 +186,9 @@ describe('agentRoots', () => {
         (message) => warnings.push(message),
       );
 
-      expect(roots.map((candidate) => candidate.path)).toEqual([await realpath(availableDir)]);
+      expect(roots.map((candidate) => candidate.path)).toEqual([
+        normalize(await realpath(availableDir)),
+      ]);
       expect(warnings.some((warning) => warning.includes(blockedDir))).toBe(true);
     });
   });

--- a/packages/agent-core-v2/test/app/externalHooksRunner/externalHooksRunner.test.ts
+++ b/packages/agent-core-v2/test/app/externalHooksRunner/externalHooksRunner.test.ts
@@ -5,10 +5,7 @@ import type { ContentPart } from '#/kosong/contract/message';
 import { describe, expect, it, vi } from 'vitest';
 
 import { makeHookRunner } from '../../agent/externalHooks/runner-stub';
-
-function nodeCommand(source: string): string {
-  return `node -e ${JSON.stringify(source.replaceAll(/\s*\n\s*/g, ' '))}`;
-}
+import { nodeScriptCommand as nodeCommand } from '../../harness/nodeScriptCommand';
 
 describe('ExternalHooksRunnerService', () => {
   it('fires a hook whose matcher regex matches the matcher value', async () => {

--- a/packages/agent-core-v2/test/app/externalHooksRunner/integration.test.ts
+++ b/packages/agent-core-v2/test/app/externalHooksRunner/integration.test.ts
@@ -62,10 +62,7 @@ import { SessionExternalHooksService } from '#/session/externalHooks/externalHoo
 import { stubBootstrap } from '../bootstrap/stubs';
 import { stubLoopWithHooks, stubToolExecutor } from '../../agent/loop/stubs';
 import { registerTestAgentWireServices } from '../../wire/stubs';
-
-function nodeCommand(source: string): string {
-  return `node -e ${JSON.stringify(source.replaceAll(/\s*\n\s*/g, ' '))}`;
-}
+import { nodeScriptCommand as nodeCommand } from '../../harness/nodeScriptCommand';
 
 function stdinScript(body: string): string {
   return nodeCommand([

--- a/packages/agent-core-v2/test/app/plugin/archive.test.ts
+++ b/packages/agent-core-v2/test/app/plugin/archive.test.ts
@@ -1,12 +1,12 @@
-import { execFileSync } from 'node:child_process';
-import { readFile } from 'node:fs/promises';
-import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises';
+import { mkdtemp, mkdir, readFile, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 import { extractZip } from '#/app/plugin/archive';
+
+import { zipDirectoryToBuffer } from '../../harness/zipArchive';
 
 describe('plugin archive extraction', () => {
   let dir: string;
@@ -25,7 +25,7 @@ describe('plugin archive extraction', () => {
     await mkdir(nested, { recursive: true });
     await writeFile(join(nested, 'kimi.plugin.json'), JSON.stringify({ name: 'zip-demo' }), 'utf8');
     const zipPath = join(dir, 'plugin.zip');
-    execFileSync('zip', ['-qr', zipPath, '.'], { cwd: source });
+    await writeFile(zipPath, await zipDirectoryToBuffer(source));
 
     const outDir = join(dir, 'out');
     const detectedRoot = await extractZip(await readFile(zipPath), outDir);

--- a/packages/agent-core-v2/test/app/plugin/manager-consumption.test.ts
+++ b/packages/agent-core-v2/test/app/plugin/manager-consumption.test.ts
@@ -7,7 +7,6 @@
  * test/app/plugin/manager-consumption.test.ts`.
  */
 
-import { execFileSync } from 'node:child_process';
 import { createServer } from 'node:http';
 import { mkdir, mkdtemp, readdir, readFile, realpath, rm, stat, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
@@ -17,6 +16,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { PluginManager } from '#/app/plugin/manager';
 
+import { zipDirectoryToBuffer } from '../../harness/zipArchive';
 import { stubSkill } from '../skillCatalog/stubs';
 
 async function isolatedTmpdir(): Promise<string> {
@@ -92,11 +92,7 @@ async function makePlugin(
 }
 
 async function zipDir(sourceRoot: string): Promise<Buffer> {
-  const zipPath = path.join(tmpdir(), `plugin-${Date.now()}-${Math.random().toString(36).slice(2)}.zip`);
-  execFileSync('zip', ['-qr', zipPath, '.'], { cwd: sourceRoot });
-  const buffer = await readFile(zipPath);
-  await rm(zipPath, { force: true });
-  return buffer;
+  return zipDirectoryToBuffer(sourceRoot);
 }
 
 async function serveOnce(buffer: Buffer): Promise<string> {

--- a/packages/agent-core-v2/test/app/plugin/manager.test.ts
+++ b/packages/agent-core-v2/test/app/plugin/manager.test.ts
@@ -6,7 +6,6 @@
  * Run: pnpm --filter @moonshot-ai/agent-core-v2 exec vitest run test/app/plugin/manager.test.ts
  */
 
-import { execFileSync } from 'node:child_process';
 import { createServer } from 'node:http';
 import { mkdtemp, mkdir, readFile, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
@@ -15,6 +14,8 @@ import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { PluginManager } from '#/app/plugin/manager';
+
+import { zipDirectoryToBuffer } from '../../harness/zipArchive';
 
 describe('PluginManager', () => {
   let home: string;
@@ -108,7 +109,7 @@ describe('PluginManager', () => {
     });
     try {
       await writeFile(join(sourceRoot, 'kimi.plugin.json'), JSON.stringify({ name: 'zip-plugin' }), 'utf8');
-      execFileSync('zip', ['-qr', zipPath, '.'], { cwd: sourceRoot });
+      await writeFile(zipPath, await zipDirectoryToBuffer(sourceRoot));
       await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
       const address = server.address();
       if (address === null || typeof address === 'string') throw new Error('bad server address');
@@ -131,7 +132,7 @@ describe('PluginManager', () => {
     const zipPath = join(tmpdir(), `plugin-github-${Date.now()}.zip`);
     try {
       await writeFile(join(sourceRoot, 'kimi.plugin.json'), JSON.stringify({ name: 'github-plugin' }), 'utf8');
-      execFileSync('zip', ['-qr', zipPath, '.'], { cwd: sourceRoot });
+      await writeFile(zipPath, await zipDirectoryToBuffer(sourceRoot));
       const zip = await readFile(zipPath);
       const fetchMock = vi.fn(async (input: Parameters<typeof fetch>[0]) => {
         const url =

--- a/packages/agent-core-v2/test/app/sessionExport/sessionExport.test.ts
+++ b/packages/agent-core-v2/test/app/sessionExport/sessionExport.test.ts
@@ -56,6 +56,7 @@ import { ISessionMetadata, type SessionMeta } from '#/session/sessionMetadata/se
 import { stubBootstrap } from '../bootstrap/stubs';
 import { stubLog } from '../../_base/log/stubs';
 import { stubAgentWire } from '../../wire/stubs';
+import { canCreateSymlinks } from '../../harness/symlinkSupport';
 
 const fsOpenHook = vi.hoisted(() => ({
   afterOpen: undefined as ((path: string, handle: FileHandle) => Promise<void>) | undefined,
@@ -609,7 +610,8 @@ describe('sessionExport', () => {
     await expect(readdir(tmp)).resolves.toEqual([]);
   });
 
-  it('does not follow an output symlink swapped during compression', async () => {
+  it('does not follow an output symlink swapped during compression', async (ctx) => {
+    if (!(await canCreateSymlinks())) ctx.skip();
     const tmp = await mkdtemp(join(tmpdir(), 'session-export-test-'));
     const statePath = join(tmp, 'state.json');
     const safeTarget = join(tmp, 'safe-output');

--- a/packages/agent-core-v2/test/app/sessionLifecycle/sessionLifecycle.test.ts
+++ b/packages/agent-core-v2/test/app/sessionLifecycle/sessionLifecycle.test.ts
@@ -996,7 +996,7 @@ describe('SessionLifecycleService', () => {
         stubPair(IProjectLocalConfigService, projectLocalConfigStub(['/tmp/extra'])),
       ]);
       const h = await svc.create({ sessionId: 's1', workDir: '/tmp/proj' });
-      expect(dirsOf(h)).toEqual(['/tmp/extra']);
+      expect(dirsOf(h)).toEqual([resolve('/tmp/extra')]);
     });
 
     it('merges caller additionalDirs and resolves relative paths against workDir', async () => {
@@ -1006,7 +1006,7 @@ describe('SessionLifecycleService', () => {
         workDir: '/tmp/proj',
         additionalDirs: ['../sibling', '/abs/dir'],
       });
-      expect(dirsOf(h)).toEqual(['/tmp/sibling', '/abs/dir']);
+      expect(dirsOf(h)).toEqual([resolve('/tmp/sibling'), resolve('/abs/dir')]);
     });
 
     it('deduplicates project-local and caller dirs after resolving', async () => {
@@ -1018,7 +1018,7 @@ describe('SessionLifecycleService', () => {
         workDir: '/tmp/proj',
         additionalDirs: ['../shared', '/tmp/other'],
       });
-      expect(dirsOf(h)).toEqual(['/tmp/shared', '/tmp/other']);
+      expect(dirsOf(h)).toEqual([resolve('/tmp/shared'), resolve('/tmp/other')]);
     });
 
     it('supports multiple project-local and caller additionalDirs', async () => {
@@ -1030,7 +1030,7 @@ describe('SessionLifecycleService', () => {
         workDir: '/tmp/proj',
         additionalDirs: ['/tmp/c', '/tmp/d'],
       });
-      expect(dirsOf(h)).toEqual(['/tmp/a', '/tmp/b', '/tmp/c', '/tmp/d']);
+      expect(dirsOf(h)).toEqual([resolve('/tmp/a'), resolve('/tmp/b'), resolve('/tmp/c'), resolve('/tmp/d')]);
     });
 
     it('loads project-local dirs when resuming a closed session', async () => {
@@ -1067,7 +1067,7 @@ describe('SessionLifecycleService', () => {
       const h = await svc.resume('s1');
 
       expect(h).toBeDefined();
-      expect(dirsOf(h!)).toEqual(['/tmp/extra']);
+      expect(dirsOf(h!)).toEqual([resolve('/tmp/extra')]);
     });
 
     it('fork inherits project-local dirs', async () => {
@@ -1089,7 +1089,7 @@ describe('SessionLifecycleService', () => {
       await svc.create({ sessionId: 'src', workDir: '/tmp/proj' });
       const target = await svc.fork({ sourceSessionId: 'src', newSessionId: 'dst' });
 
-      expect(dirsOf(target)).toEqual(['/tmp/extra']);
+      expect(dirsOf(target)).toEqual([resolve('/tmp/extra')]);
     });
 
     it('create mints a session_-prefixed lowercase id when none is supplied', async () => {

--- a/packages/agent-core-v2/test/app/skillCatalog/skillRoots.test.ts
+++ b/packages/agent-core-v2/test/app/skillCatalog/skillRoots.test.ts
@@ -1,7 +1,7 @@
 import { mkdtemp, mkdir, realpath, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 
-import { join } from 'pathe';
+import { join, normalize } from 'pathe';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 import { configuredRoots, projectRoots, userRoots } from '#/app/skillCatalog/skillRoots';
@@ -107,10 +107,10 @@ describe('skillRoots', () => {
       const paths = roots.map((root) => root.path);
 
       expect(roots.every((root) => root.source === 'extra')).toBe(true);
-      expect(paths).toContain(await realpath(homeDir));
-      expect(paths).toContain(await realpath(join(homeDir, 'notes')));
-      expect(paths).toContain(await realpath(absDir));
-      expect(paths).toContain(await realpath(join(root, 'relative')));
+      expect(paths).toContain(normalize(await realpath(homeDir)));
+      expect(paths).toContain(normalize(await realpath(join(homeDir, 'notes'))));
+      expect(paths).toContain(normalize(await realpath(absDir)));
+      expect(paths).toContain(normalize(await realpath(join(root, 'relative'))));
     });
   });
 });

--- a/packages/agent-core-v2/test/app/workspace/workspaceService.test.ts
+++ b/packages/agent-core-v2/test/app/workspace/workspaceService.test.ts
@@ -24,6 +24,8 @@ import { WorkspaceService } from '#/app/workspace/workspaceService';
 import { FileWorkspacePersistence } from '#/app/workspace/fileWorkspacePersistence';
 import { IWorkspacePersistence, type PersistedWorkspaceEntry } from '#/app/workspace/workspacePersistence';
 
+import { canCreateSymlinks } from '../../harness/symlinkSupport';
+
 interface SessionIndexLine {
   readonly sessionId: string;
   readonly sessionDir: string;
@@ -393,7 +395,8 @@ describe('WorkspaceService (file-backed)', () => {
     expect(await build().list()).toEqual([]);
   });
 
-  it('accepts createOrTouch when the root is given through a symlink', async () => {
+  it('accepts createOrTouch when the root is given through a symlink', async (ctx) => {
+    if (!(await canCreateSymlinks())) ctx.skip();
     const real = join(homeDir, 'real-root');
     await fsp.mkdir(real, { recursive: true });
     const link = join(homeDir, 'link-root');

--- a/packages/agent-core-v2/test/harness/nodeScriptCommand.ts
+++ b/packages/agent-core-v2/test/harness/nodeScriptCommand.ts
@@ -1,0 +1,40 @@
+/**
+ * Test helper — build a shell command that runs an inline Node.js script on
+ * any platform.
+ *
+ * `node -e "<script>"` does not survive `shell: true` on Windows: cmd.exe
+ * toggles its quoting state at every `"` (it does not understand `\"`),
+ * shredding a script that contains double quotes into multiple arguments.
+ * Writing the script to a temp file and invoking `node <file>` avoids shell
+ * quoting entirely on both cmd.exe and POSIX shells.
+ */
+
+import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+const scriptDir = join(tmpdir(), `kimi-test-scripts-${process.pid}`);
+let scriptCounter = 0;
+let cleanupRegistered = false;
+
+/** Quote one path for safe passage through cmd.exe and POSIX shells. */
+function quotePath(path: string): string {
+  return `"${path}"`;
+}
+
+/**
+ * Write `source` to a unique temp script file and return a shell command
+ * string that executes it with the current Node.js binary.
+ */
+export function nodeScriptCommand(source: string): string {
+  mkdirSync(scriptDir, { recursive: true });
+  if (!cleanupRegistered) {
+    cleanupRegistered = true;
+    process.on('exit', () => {
+      rmSync(scriptDir, { recursive: true, force: true });
+    });
+  }
+  const scriptPath = join(scriptDir, `script-${scriptCounter++}.cjs`);
+  writeFileSync(scriptPath, source, 'utf8');
+  return `${quotePath(process.execPath)} ${quotePath(scriptPath)}`;
+}

--- a/packages/agent-core-v2/test/harness/nodeScriptCommand.ts
+++ b/packages/agent-core-v2/test/harness/nodeScriptCommand.ts
@@ -7,6 +7,12 @@
  * shredding a script that contains double quotes into multiple arguments.
  * Writing the script to a temp file and invoking `node <file>` avoids shell
  * quoting entirely on both cmd.exe and POSIX shells.
+ *
+ * `nodeScriptCommand(source)` writes `source` to a unique temp `.cjs` file
+ * (CommonJS, so `require` works) under the OS temp dir — cleaned up on
+ * process exit — and returns the quoted command string; `quotePath(path)`
+ * wraps one path in double quotes, which both cmd.exe and POSIX shells treat
+ * as literal (backslashes included).
  */
 
 import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
@@ -17,15 +23,10 @@ const scriptDir = join(tmpdir(), `kimi-test-scripts-${process.pid}`);
 let scriptCounter = 0;
 let cleanupRegistered = false;
 
-/** Quote one path for safe passage through cmd.exe and POSIX shells. */
 function quotePath(path: string): string {
   return `"${path}"`;
 }
 
-/**
- * Write `source` to a unique temp script file and return a shell command
- * string that executes it with the current Node.js binary.
- */
 export function nodeScriptCommand(source: string): string {
   mkdirSync(scriptDir, { recursive: true });
   if (!cleanupRegistered) {

--- a/packages/agent-core-v2/test/harness/symlinkSupport.ts
+++ b/packages/agent-core-v2/test/harness/symlinkSupport.ts
@@ -1,0 +1,38 @@
+/**
+ * Test helper — probe whether the current process may create symlinks.
+ *
+ * On Windows, `fs.symlink` requires SeCreateSymbolicLinkPrivilege (an
+ * elevated shell or Developer Mode); without it the call rejects with EPERM.
+ * Symlink-dependent tests should probe once and skip when unsupported:
+ *
+ * ```ts
+ * it('follows symlinks', async (ctx) => {
+ *   if (!(await canCreateSymlinks())) ctx.skip();
+ *   // …
+ * });
+ * ```
+ */
+
+import { mkdtemp, rm, symlink, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+let probe: Promise<boolean> | undefined;
+
+/** Resolve once to whether symlink creation works in this environment. */
+export function canCreateSymlinks(): Promise<boolean> {
+  probe ??= (async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'kimi-symlink-probe-'));
+    try {
+      const target = join(dir, 'target.txt');
+      await writeFile(target, 'probe', 'utf8');
+      await symlink(target, join(dir, 'link.txt'));
+      return true;
+    } catch {
+      return false;
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  })();
+  return probe;
+}

--- a/packages/agent-core-v2/test/harness/symlinkSupport.ts
+++ b/packages/agent-core-v2/test/harness/symlinkSupport.ts
@@ -3,7 +3,8 @@
  *
  * On Windows, `fs.symlink` requires SeCreateSymbolicLinkPrivilege (an
  * elevated shell or Developer Mode); without it the call rejects with EPERM.
- * Symlink-dependent tests should probe once and skip when unsupported:
+ * `canCreateSymlinks()` probes once and caches the result, so
+ * symlink-dependent tests can skip when unsupported:
  *
  * ```ts
  * it('follows symlinks', async (ctx) => {
@@ -19,7 +20,6 @@ import { join } from 'node:path';
 
 let probe: Promise<boolean> | undefined;
 
-/** Resolve once to whether symlink creation works in this environment. */
 export function canCreateSymlinks(): Promise<boolean> {
   probe ??= (async () => {
     const dir = await mkdtemp(join(tmpdir(), 'kimi-symlink-probe-'));

--- a/packages/agent-core-v2/test/harness/zipArchive.ts
+++ b/packages/agent-core-v2/test/harness/zipArchive.ts
@@ -1,0 +1,40 @@
+/**
+ * Test helper — build a zip archive of a directory without external tools.
+ *
+ * `zip -qr out.zip .` spawns the Info-ZIP CLI, which is not available on
+ * Windows. yazl (already a dependency) produces the same layout in pure
+ * JavaScript: every file under the source root, recursively, named by its
+ * forward-slash relative path.
+ */
+
+import { readdir } from 'node:fs/promises';
+import path from 'node:path';
+
+import { ZipFile } from 'yazl';
+
+/** Zip every file under `sourceRoot` (recursively) and return the archive bytes. */
+export async function zipDirectoryToBuffer(sourceRoot: string): Promise<Buffer> {
+  const zip = new ZipFile();
+  for (const file of await collectFiles(sourceRoot)) {
+    zip.addFile(file, path.relative(sourceRoot, file).split(path.sep).join('/'));
+  }
+  zip.end();
+  return new Promise<Buffer>((resolve, reject) => {
+    const chunks: Buffer[] = [];
+    zip.outputStream.on('data', (chunk: Buffer) => {
+      chunks.push(chunk);
+    });
+    zip.outputStream.on('end', () => {
+      resolve(Buffer.concat(chunks));
+    });
+    zip.outputStream.on('error', reject);
+  });
+}
+
+async function collectFiles(root: string): Promise<string[]> {
+  const entries = await readdir(root, { recursive: true, withFileTypes: true });
+  return entries
+    .filter((entry) => entry.isFile())
+    .map((entry) => path.join(entry.parentPath, entry.name))
+    .sort();
+}

--- a/packages/agent-core-v2/test/harness/zipArchive.ts
+++ b/packages/agent-core-v2/test/harness/zipArchive.ts
@@ -3,8 +3,9 @@
  *
  * `zip -qr out.zip .` spawns the Info-ZIP CLI, which is not available on
  * Windows. yazl (already a dependency) produces the same layout in pure
- * JavaScript: every file under the source root, recursively, named by its
- * forward-slash relative path.
+ * JavaScript: `zipDirectoryToBuffer(sourceRoot)` zips every file under the
+ * source root recursively, named by its forward-slash relative path, and
+ * resolves to the archive bytes.
  */
 
 import { readdir } from 'node:fs/promises';
@@ -12,7 +13,6 @@ import path from 'node:path';
 
 import { ZipFile } from 'yazl';
 
-/** Zip every file under `sourceRoot` (recursively) and return the archive bytes. */
 export async function zipDirectoryToBuffer(sourceRoot: string): Promise<Buffer> {
   const zip = new ZipFile();
   for (const file of await collectFiles(sourceRoot)) {

--- a/packages/agent-core-v2/test/os/backends/node-local/hostFsService.test.ts
+++ b/packages/agent-core-v2/test/os/backends/node-local/hostFsService.test.ts
@@ -6,6 +6,8 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 import { HostFileSystem } from '#/os/backends/node-local/hostFsService';
 
+import { canCreateSymlinks } from '../../../harness/symlinkSupport';
+
 let dir: string;
 let fs: HostFileSystem;
 
@@ -19,7 +21,8 @@ afterEach(async () => {
 });
 
 describe('HostFileSystem stat / lstat', () => {
-  it('stat follows a symlink to a regular file while lstat stats the link', async () => {
+  it('stat follows a symlink to a regular file while lstat stats the link', async (ctx) => {
+    if (!(await canCreateSymlinks())) ctx.skip();
     const target = join(dir, 'target.txt');
     await writeFile(target, 'hello', 'utf-8');
     const link = join(dir, 'link.txt');
@@ -34,7 +37,8 @@ describe('HostFileSystem stat / lstat', () => {
     expect(lst.isFile).toBe(false);
   });
 
-  it('stat follows a symlink to a directory', async () => {
+  it('stat follows a symlink to a directory', async (ctx) => {
+    if (!(await canCreateSymlinks())) ctx.skip();
     const target = join(dir, 'subdir');
     await mkdir(target);
     const link = join(dir, 'dirlink');
@@ -44,7 +48,8 @@ describe('HostFileSystem stat / lstat', () => {
     expect((await fs.lstat(link)).isDirectory).toBe(false);
   });
 
-  it('stat rejects a dangling symlink while lstat still stats the link', async () => {
+  it('stat rejects a dangling symlink while lstat still stats the link', async (ctx) => {
+    if (!(await canCreateSymlinks())) ctx.skip();
     const link = join(dir, 'dangling');
     await symlink(join(dir, 'missing'), link);
 

--- a/packages/agent-core-v2/test/os/backends/node-local/tools/glob.test.ts
+++ b/packages/agent-core-v2/test/os/backends/node-local/tools/glob.test.ts
@@ -13,6 +13,7 @@ import os from 'node:os';
 import path from 'node:path';
 import { Readable, type Writable } from 'node:stream';
 
+import { normalize } from 'pathe';
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { ensureRgPath, type RgProbe } from '#/os/backends/node-local/tools/rgLocator';
@@ -949,7 +950,7 @@ describe('GlobTool integration (real ripgrep)', () => {
 
       const result = await execute(tool, { pattern: '*.ts', path: externalDir });
 
-      expect(result.output).toBe(extFile);
+      expect(result.output).toBe(normalize(extFile));
     } finally {
       await fs.rm(externalDir, { recursive: true, force: true });
     }

--- a/packages/agent-core-v2/test/session/sessionFs/fsService.test.ts
+++ b/packages/agent-core-v2/test/session/sessionFs/fsService.test.ts
@@ -1,5 +1,6 @@
-import { isAbsolute, join, relative, resolve } from 'node:path';
 import { Readable, Writable } from 'node:stream';
+
+import { isAbsolute, join, relative, resolve } from 'pathe';
 
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
@@ -69,12 +70,16 @@ function fakeFs(
     addAncestors(rel);
   }
   const isDir = (p: string): boolean => p === WORK_DIR || dirSet.has(p);
+  // SessionFsService joins paths with node:path, which yields backslashes on
+  // Windows; normalize incoming paths so this fake's '/'-based lookups work.
+  const norm = (p: string): string => p.replace(/\\/g, '/');
   const enoent = (p: string): NodeJS.ErrnoException => {
     const err = new Error(`ENOENT: ${p}`) as NodeJS.ErrnoException;
     err.code = 'ENOENT';
     return err;
   };
-  const lstatImpl = async (p: string) => {
+  const lstatImpl = async (rawPath: string) => {
+    const p = norm(rawPath);
     if (fileMap.has(p)) {
       return {
         isFile: true,
@@ -95,14 +100,14 @@ function fakeFs(
   return {
     _serviceBrand: undefined,
     readText: async (p) => {
-      const c = fileMap.get(p);
+      const c = fileMap.get(norm(p));
       if (c === undefined) throw enoent(p);
       return c;
     },
     writeText: async () => {},
     appendText: async () => {},
     readBytes: async (p, n) => {
-      const c = fileMap.get(p);
+      const c = fileMap.get(norm(p));
       if (c === undefined) throw enoent(p);
       const buf = Buffer.from(c);
       return buf.subarray(0, n ?? buf.length);
@@ -113,7 +118,7 @@ function fakeFs(
     createExclusive: async () => false,
     lstat: lstatImpl,
     stat: async (p) => {
-      let cur = p;
+      let cur = norm(p);
       for (let hops = 0; hops < 10 && symlinkSet.has(cur); hops += 1) {
         const target = symlinkTargetMap.get(cur);
         if (target === undefined) break;
@@ -121,7 +126,8 @@ function fakeFs(
       }
       return lstatImpl(cur);
     },
-    readdir: async (p) => {
+    readdir: async (rawPath) => {
+      const p = norm(rawPath);
       if (!isDir(p)) throw enoent(p);
       const prefix = `${p}/`;
       const children = new Map<string, HostDirEntry>();
@@ -155,7 +161,8 @@ function fakeFs(
       for (const s of symlinkSet) visit(s, 'symlink');
       return [...children.values()];
     },
-    mkdir: async (p, options) => {
+    mkdir: async (rawPath, options) => {
+      const p = norm(rawPath);
       const recursive = options?.recursive ?? false;
       const exists = isDir(p) || fileMap.has(p);
       if (recursive) {
@@ -183,7 +190,8 @@ function fakeFs(
       dirSet.add(p);
     },
     remove: async () => {},
-    realpath: async (p) => {
+    realpath: async (rawPath) => {
+      const p = norm(rawPath);
       let current = p;
       for (let i = 0; i < 40; i++) {
         let longest: string | undefined;

--- a/packages/agent-core-v2/test/session/sessionFs/fsService.test.ts
+++ b/packages/agent-core-v2/test/session/sessionFs/fsService.test.ts
@@ -70,8 +70,6 @@ function fakeFs(
     addAncestors(rel);
   }
   const isDir = (p: string): boolean => p === WORK_DIR || dirSet.has(p);
-  // SessionFsService joins paths with node:path, which yields backslashes on
-  // Windows; normalize incoming paths so this fake's '/'-based lookups work.
   const norm = (p: string): string => p.replace(/\\/g, '/');
   const enoent = (p: string): NodeJS.ErrnoException => {
     const err = new Error(`ENOENT: ${p}`) as NodeJS.ErrnoException;

--- a/packages/agent-core-v2/test/session/sessionSkillCatalog/skillCatalog.test.ts
+++ b/packages/agent-core-v2/test/session/sessionSkillCatalog/skillCatalog.test.ts
@@ -10,7 +10,7 @@
 import { mkdtemp, mkdir, realpath, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 
-import { join } from 'pathe';
+import { join, normalize } from 'pathe';
 import { describe, expect, it } from 'vitest';
 
 import { createScopedTestHost, stubPair } from '#/_base/di/test';
@@ -189,7 +189,7 @@ async function withSkillCatalogWorkspace(
   const skillRoot = join(workDir, '.kimi-code', 'skills');
   await mkdir(skillRoot, { recursive: true });
   try {
-    await run({ workDir, skillRoot: await realpath(skillRoot) });
+    await run({ workDir, skillRoot: normalize(await realpath(skillRoot)) });
   } finally {
     await rm(workDir, { recursive: true, force: true });
   }

--- a/packages/agent-core-v2/test/session/workspaceCommand/workspaceCommand.test.ts
+++ b/packages/agent-core-v2/test/session/workspaceCommand/workspaceCommand.test.ts
@@ -32,10 +32,6 @@ import { SessionWorkspaceContextService } from '#/session/workspaceContext/works
 
 import { stubContextMemory, type StubContextMemory } from '../../agent/contextMemory/stubs';
 
-// The node-fs config backend normalizes through pathe (forward slashes) while
-// the session workspace context resolves through node:path (platform
-// separators). Derive both forms from the same POSIX literals so expectations
-// track the implementation on Windows and stay identical on POSIX.
 function slashForm(path: string): string {
   return normalizeSlash(resolveOsPath(path));
 }

--- a/packages/agent-core-v2/test/session/workspaceCommand/workspaceCommand.test.ts
+++ b/packages/agent-core-v2/test/session/workspaceCommand/workspaceCommand.test.ts
@@ -1,3 +1,6 @@
+import { resolve as resolveOsPath } from 'node:path';
+
+import { normalize as normalizeSlash } from 'pathe';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 import { DisposableStore } from '#/_base/di/lifecycle';
@@ -29,10 +32,23 @@ import { SessionWorkspaceContextService } from '#/session/workspaceContext/works
 
 import { stubContextMemory, type StubContextMemory } from '../../agent/contextMemory/stubs';
 
-const WORK_DIR = '/repo/work';
+// The node-fs config backend normalizes through pathe (forward slashes) while
+// the session workspace context resolves through node:path (platform
+// separators). Derive both forms from the same POSIX literals so expectations
+// track the implementation on Windows and stay identical on POSIX.
+function slashForm(path: string): string {
+  return normalizeSlash(resolveOsPath(path));
+}
+
+function osForm(path: string): string {
+  return resolveOsPath(path);
+}
+
+const WORK_DIR = slashForm('/repo/work');
 const EXTRA_DIR = `${WORK_DIR}/extra`;
 const DIR_A = `${WORK_DIR}/a`;
 const DIR_B = `${WORK_DIR}/b`;
+const OS_EXTRA_DIR = osForm(EXTRA_DIR);
 
 class MemoryHostFs implements IHostFileSystem {
   declare readonly _serviceBrand: undefined;
@@ -198,8 +214,8 @@ function agentsStub(): AgentsStub {
 function bootstrapStub(): IBootstrapService {
   return {
     _serviceBrand: undefined,
-    homeDir: '/home/test',
-    osHomeDir: '/users/test',
+    homeDir: slashForm('/home/test'),
+    osHomeDir: slashForm('/users/test'),
   } as IBootstrapService;
 }
 
@@ -271,8 +287,8 @@ describe('SessionWorkspaceCommandService', () => {
 
     expect(result.persisted).toBe(true);
     expect(result.configPath).toBe(`${WORK_DIR}/.kimi-code/local.toml`);
-    expect(result.additionalDirs).toContain(EXTRA_DIR);
-    expect(workspace.additionalDirs).toContain(EXTRA_DIR);
+    expect(result.additionalDirs).toContain(OS_EXTRA_DIR);
+    expect(workspace.additionalDirs).toContain(OS_EXTRA_DIR);
 
     const written = fs.files.get(`${WORK_DIR}/.kimi-code/local.toml`);
     expect(written).toContain('additional_dir');
@@ -297,7 +313,7 @@ describe('SessionWorkspaceCommandService', () => {
     const result = await svc.addAdditionalDir({ path: 'extra', persist: false });
 
     expect(result.persisted).toBe(false);
-    expect(workspace.additionalDirs).toContain(EXTRA_DIR);
+    expect(workspace.additionalDirs).toContain(OS_EXTRA_DIR);
     expect(fs.files.has(`${WORK_DIR}/.kimi-code/local.toml`)).toBe(false);
 
     expect(agents.mainContext.messages).toHaveLength(1);
@@ -351,8 +367,8 @@ describe('SessionWorkspaceCommandService', () => {
     const [, secondResult] = await Promise.all([first, second]);
 
     expect(overlappingReads).toEqual([]);
-    expect(secondResult.additionalDirs).toEqual([DIR_A, DIR_B]);
-    expect(workspace.additionalDirs).toEqual([DIR_A, DIR_B]);
+    expect(secondResult.additionalDirs).toEqual([osForm(DIR_A), osForm(DIR_B)]);
+    expect(workspace.additionalDirs).toEqual([osForm(DIR_A), osForm(DIR_B)]);
 
     const written = fs.files.get(`${WORK_DIR}/.kimi-code/local.toml`);
     expect(written).toContain(DIR_A);
@@ -360,7 +376,7 @@ describe('SessionWorkspaceCommandService', () => {
   });
 
   it('resolves caller-relative dirs against the session workDir when project root is above it', async () => {
-    const projectRoot = '/repo/project';
+    const projectRoot = slashForm('/repo/project');
     const workDir = `${projectRoot}/apps/foo`;
     const sharedDir = `${workDir}/shared`;
     const { svc, fs, workspace } = build([sharedDir], true, workDir, `${projectRoot}/.git`);
@@ -369,13 +385,13 @@ describe('SessionWorkspaceCommandService', () => {
 
     expect(result.projectRoot).toBe(projectRoot);
     expect(result.configPath).toBe(`${projectRoot}/.kimi-code/local.toml`);
-    expect(result.additionalDirs).toEqual([sharedDir]);
-    expect(workspace.additionalDirs).toEqual([sharedDir]);
+    expect(result.additionalDirs).toEqual([osForm(sharedDir)]);
+    expect(workspace.additionalDirs).toEqual([osForm(sharedDir)]);
     expect(fs.files.get(`${projectRoot}/.kimi-code/local.toml`)).toContain(sharedDir);
   });
 
   it('keeps a dangling .git symlink as the local project-root marker', async () => {
-    const ancestorRoot = '/repo/project';
+    const ancestorRoot = slashForm('/repo/project');
     const workDir = `${ancestorRoot}/apps/foo`;
     const sharedDir = `${workDir}/shared`;
     const { svc, fs } = build([sharedDir], true, workDir, `${ancestorRoot}/.git`);
@@ -389,7 +405,7 @@ describe('SessionWorkspaceCommandService', () => {
   });
 
   it('resolves session-only relative dirs against the session workDir when project root is above it', async () => {
-    const projectRoot = '/repo/project';
+    const projectRoot = slashForm('/repo/project');
     const workDir = `${projectRoot}/apps/foo`;
     const sharedDir = `${workDir}/shared`;
     const { svc, fs, workspace } = build([sharedDir], true, workDir, `${projectRoot}/.git`);
@@ -398,23 +414,23 @@ describe('SessionWorkspaceCommandService', () => {
 
     expect(result.projectRoot).toBe(projectRoot);
     expect(result.configPath).toBe(`${projectRoot}/.kimi-code/local.toml`);
-    expect(result.additionalDirs).toEqual([sharedDir]);
-    expect(workspace.additionalDirs).toEqual([sharedDir]);
+    expect(result.additionalDirs).toEqual([osForm(sharedDir)]);
+    expect(workspace.additionalDirs).toEqual([osForm(sharedDir)]);
     expect(fs.files.has(`${projectRoot}/.kimi-code/local.toml`)).toBe(false);
   });
 
   it('expands home-relative dirs against the OS home like v1', async () => {
-    const homeDir = '/users/test/shared';
+    const homeDir = slashForm('/users/test/shared');
     const { svc, workspace } = build([homeDir], true);
 
     const result = await svc.addAdditionalDir({ path: '~/shared', persist: false });
 
-    expect(result.additionalDirs).toEqual([homeDir]);
-    expect(workspace.additionalDirs).toEqual([homeDir]);
+    expect(result.additionalDirs).toEqual([osForm(homeDir)]);
+    expect(workspace.additionalDirs).toEqual([osForm(homeDir)]);
   });
 
   it('treats project-root stat errors as absent git markers like v1', async () => {
-    const projectRoot = '/repo';
+    const projectRoot = slashForm('/repo');
     const { svc, fs } = build([EXTRA_DIR], true, WORK_DIR, `${projectRoot}/.git`);
     const error = new Error('EACCES: cannot stat .git') as NodeJS.ErrnoException;
     error.code = 'EACCES';

--- a/packages/agent-core-v2/test/tool/tool.test.ts
+++ b/packages/agent-core-v2/test/tool/tool.test.ts
@@ -1,6 +1,6 @@
 import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
-import { join } from 'node:path';
+import { join } from 'pathe';
 import { Readable, type Writable } from 'node:stream';
 
 import { LifecycleScope, type IAgentScopeHandle } from '#/_base/di/scope';
@@ -18,6 +18,7 @@ import { IAgentTaskService } from '#/agent/task/task';
 import { IAgentContextMemoryService } from '#/agent/contextMemory/contextMemory';
 import { IAgentContextSizeService } from '#/agent/contextSize/contextSize';
 import { makeHookRunner } from '../agent/externalHooks/runner-stub';
+import { nodeScriptCommand } from '../harness/nodeScriptCommand';
 import { IAgentProfileService } from '#/agent/profile/profile';
 import { IAgentPermissionModeService } from '#/agent/permissionMode/permissionMode';
 import { ToolAccesses, type ExecutableTool } from '#/tool/toolContract';
@@ -2137,12 +2138,14 @@ describe('Agent tools', () => {
           {
             event: 'PreToolUse',
             matcher: 'Bash',
-            command: "echo 'blocked by PreToolUse' >&2; exit 2",
+            command: nodeScriptCommand(
+              "console.error('blocked by PreToolUse'); process.exit(2);",
+            ),
           },
           {
             event: 'PostToolUseFailure',
             matcher: 'Bash',
-            command: 'exit 0',
+            command: nodeScriptCommand('process.exit(0);'),
           },
         ],
         {
@@ -2737,7 +2740,7 @@ function hookErrorMessageAssertCommand(expected: string): string {
     '  process.exit(2);',
     '});',
   ].join('');
-  return `node -e ${JSON.stringify(script)}`;
+  return nodeScriptCommand(script);
 }
 
 function hookPayloadAssertCommand(expected: {
@@ -2773,5 +2776,5 @@ function hookPayloadAssertCommand(expected: {
     '});',
     "process.on('uncaughtException', (error) => { console.error(error.message); process.exit(2); });",
   ].filter((line) => line.length > 0).join('');
-  return `node -e ${JSON.stringify(script)}`;
+  return nodeScriptCommand(script);
 }


### PR DESCRIPTION
## Problem

The `agent-core-v2` test suite currently fails **98 tests across 23 files** on Windows (Node 24, Windows 11) while passing on POSIX. All failures are platform assumptions in test code — no product bugs were found. This PR makes the suite fully green on Windows without weakening a single assertion, and keeps every test passing unchanged on POSIX.

This is also a first step toward re-enabling the `test-windows` CI job disabled in #1144 (for the `agent-core-v2` package; other packages may still have Windows failures to address separately).

## Root causes and fixes (one commit per family)

1. **Hook test commands are not shell-portable** — hook tests spawn commands via `spawn(shell: true)`, which is cmd.exe on Windows. POSIX constructs (`echo ... >&2; exit 2`) and `node -e "<script>"` with JSON.stringify quoting both break: cmd.exe toggles quoting at every `"` (it does not understand `\"`), shredding scripts that contain double quotes. → New `test/harness/nodeScriptCommand.ts` writes the script to a temp `.cjs` file and invokes `node` on it — no shell quoting on either platform.

2. **fsService fake-fs path mismatch** — stubs keyed paths with POSIX literals / `node:path` join while session services resolve with `node:path` (drive letters on Windows) and normalize with `pathe`. → Unify the test file on `pathe` and normalize fake-fs lookup keys.

3. **MCP stdio fake servers fail to start** — fixture paths were built with `URL.pathname`, which yields `/D:/...` on Windows. → `fileURLToPath` (platform-aware, identical on POSIX).

4. **Plugin tests shell out to the `zip` CLI** — Info-ZIP does not exist on Windows. → New `test/harness/zipArchive.ts` builds the same archive layout with `yazl` (already a dependency).

5. **Hard-coded POSIX path expectations** (sessionLifecycle, workspaceCommand) — expected values like `/tmp/extra` resolve to `D:\tmp\extra` on Windows. → Derive expectations with `resolve`/`normalize` from the same literals; byte-identical values on POSIX.

6. **Remaining files** — pathe-align path expectations with implementation output (agentRoots, skillRoots, skillCatalog, glob, toolResultTruncation); probe symlink capability at runtime and skip when unavailable (hostFsService, profile/context, workspaceRegistry, sessionExport) via new `test/harness/symlinkSupport.ts` — on Developer-Mode Windows and POSIX these tests still run in full; skip the POSIX mkdir mode-bit assertion on Windows (persist), matching an existing `fileStorageService` precedent; route the fullCompaction hook command through `nodeScriptCommand`.

## Scope

- **Test code only** — `packages/agent-core-v2/test/`, plus two new harness helpers. Zero changes under `src/`.
- No assertion was weakened: skips are capability probes (symlink privilege, POSIX mode bits) that still execute fully where the capability exists; everything else derives expectations per platform with identical values on POSIX.

## Verification

- Windows 11, Node v24.18.0: `pnpm -C packages/agent-core-v2 typecheck` clean; `pnpm vitest run` → **3864 passed | 14 skipped (capability probes) | 0 failed** (previously 98 failed).
- POSIX: unchanged by construction (pathe normalize is a no-op on POSIX paths; `fileURLToPath`/`resolve` produce identical values; capability probes only skip when the capability is genuinely absent). CI will confirm.

## Checklist

- [x] I have read the CONTRIBUTING document.
- [x] Changeset included (`@moonshot-ai/agent-core-v2` patch).
- [x] Tests pass locally (see Verification).