### PR TITLE
refactor(agent-core-v2): drop pass-through methods from AgentRPCService

### DIFF
--- a/apps/kimi-inspect/src/channel/client.ts
+++ b/apps/kimi-inspect/src/channel/client.ts
@@ -7,7 +7,7 @@
  *   const client = createInspectClient({ url: 'http://127.0.0.1:58627' });
  *   await client.core(ISessionIndex).list({});
  *   await client.session('s1').service(ISessionMetadata).read();
- *   await client.session('s1').agent('main').service(IAgentRPCService).getModel();
+ *   await client.session('s1').agent('main').service(IAgentRPCService).cancel({});
  *
  * The `agent-core-v2` service token is the whole key: its type parameter `T`
  * types the returned proxy, and its decorator id (`String(id)`) is the channel

--- a/apps/kimi-inspect/src/panels.ts
+++ b/apps/kimi-inspect/src/panels.ts
@@ -272,8 +272,6 @@ export const AGENT_PANELS: readonly ServicePanelDef[] = [
         input: 'Steps',
         run: (svc, n) => call(svc, 'undoHistory', { count: Number(n) }),
       },
-      { label: 'beginCompaction', run: (svc) => call(svc, 'beginCompaction', {}) },
-      { label: 'clearContext', danger: true, run: (svc) => call(svc, 'clearContext', {}) },
     ],
   },
 ];

--- a/packages/agent-core-v2/src/agent/rpc/core-api.ts
+++ b/packages/agent-core-v2/src/agent/rpc/core-api.ts
@@ -10,9 +10,7 @@
  * profile support.
  */
 
-import type { AgentConfigData } from '#/agent/profile/profile';
 import type { AgentContextData } from '#/agent/contextMemory/types';
-import type { AgentTaskInfo } from '#/agent/task/task';
 import type {
   GoalBudgetLimits,
   GoalBudgetReport,
@@ -22,8 +20,7 @@ import type {
   GoalStatus,
   GoalToolResult,
 } from '#/agent/goal/types';
-import type { PermissionData, PermissionMode } from '#/agent/permissionPolicy/types';
-import type { PlanData } from '#/agent/plan/plan';
+import type { PermissionMode } from '#/agent/permissionPolicy/types';
 import type { SwarmModeTrigger } from '#/agent/swarm/swarm';
 import type { ToolInfo } from '#/tool/toolContract';
 import type { ResolvedConfig } from '#/app/config/config';
@@ -33,7 +30,6 @@ import type { ResumeSessionResult } from '#/agent/replayBuilder/types';
 import type { SessionMeta } from '#/session/sessionMetadata/sessionMetadata';
 import type { ContentPart } from '#/kosong/contract/message';
 import type { SessionWarning } from '#/app/sessionLegacy/sessionProtocol';
-import type { UsageStatus } from '#/agent/usage/usage';
 
 import type { ExportSessionPayload, ExportSessionResult } from '#/app/sessionExport/sessionExport';
 import type { PluginCommandDef, PluginInfo, PluginSummary, ReloadSummary } from '#/app/plugin/types';
@@ -315,45 +311,15 @@ export interface PromptLaunchResult {
 
 export interface AgentAPI {
   prompt: (payload: PromptPayload) => PromptLaunchResult | undefined;
-  runShellCommand: (payload: RunShellCommandPayload) => ShellCommandResult;
-  cancelShellCommand: (payload: CancelShellCommandPayload) => void;
   steer: (payload: SteerPayload) => PromptLaunchResult | undefined;
   cancel: (payload: CancelPayload) => void;
   undoHistory: (payload: UndoHistoryPayload) => number;
-  setThinking: (payload: SetThinkingPayload) => void;
   setPermission: (payload: SetPermissionPayload) => void;
-  setModel: (payload: SetModelPayload) => SetModelResult;
-  getModel: (payload: EmptyPayload) => string;
-  enterPlan: (payload: EmptyPayload) => void;
-  cancelPlan: (payload: CancelPlanPayload) => void;
-  clearPlan: (payload: EmptyPayload) => void;
-  enterSwarm: (payload: EnterSwarmPayload) => void;
-  exitSwarm: (payload: EmptyPayload) => void;
-  getSwarmMode: (payload: EmptyPayload) => boolean;
-  startBtw: (payload: EmptyPayload) => string;
-  beginCompaction: (payload: BeginCompactionPayload) => void;
   cancelCompaction: (payload: EmptyPayload) => void;
-  registerTool: (payload: RegisterToolPayload) => void;
-  unregisterTool: (payload: UnregisterToolPayload) => void;
-  setActiveTools: (payload: SetActiveToolsPayload) => void;
-  stopTask: (payload: StopTaskPayload) => void;
-  detachTask: (payload: DetachTaskPayload) => AgentTaskInfo | undefined;
-  clearContext: (payload: EmptyPayload) => void;
   activateSkill: (payload: ActivateSkillPayload) => void;
   activatePluginCommand: (payload: ActivatePluginCommandPayload) => void;
-  createGoal: (payload: CreateGoalPayload) => GoalSnapshot;
-  getGoal: (payload: EmptyPayload) => GoalToolResult;
-  pauseGoal: (payload: EmptyPayload) => GoalSnapshot;
-  resumeGoal: (payload: EmptyPayload) => GoalSnapshot;
-  cancelGoal: (payload: EmptyPayload) => GoalSnapshot;
-  getTaskOutput: (payload: GetTaskOutputPayload) => string;
   getContext: (payload: EmptyPayload) => AgentContextData;
-  getConfig: (payload: EmptyPayload) => AgentConfigData;
-  getPermission: (payload: EmptyPayload) => PermissionData;
-  getPlan: (payload: EmptyPayload) => PlanData;
-  getUsage: (payload: EmptyPayload) => UsageStatus;
   getTools: (payload: EmptyPayload) => readonly ToolInfo[];
-  getTasks: (payload: GetTasksPayload) => readonly AgentTaskInfo[];
 }
 
 type AgentAPIWithId = WithAgentId<AgentAPI>;

--- a/packages/agent-core-v2/src/agent/rpc/rpcService.ts
+++ b/packages/agent-core-v2/src/agent/rpc/rpcService.ts
@@ -2,65 +2,39 @@ import { randomUUID } from 'node:crypto';
 
 import { InstantiationType } from '#/_base/di/extensions';
 import { LifecycleScope, registerScopedService } from '#/_base/di/scope';
-import { IAgentTaskService } from '#/agent/task/task';
 import { IAgentContextMemoryService } from '#/agent/contextMemory/contextMemory';
 import { IAgentContextSizeService } from '#/agent/contextSize/contextSize';
 import { IAgentFullCompactionService } from '#/agent/fullCompaction/fullCompaction';
-import { IAgentGoalService } from '#/agent/goal/goal';
 import { IEventBus } from '#/app/event/eventBus';
 import { IEventService } from '#/app/event/event';
 import { ErrorCodes, Error2 } from '#/errors';
-import { IAgentPermissionGate } from '#/agent/permissionGate/permissionGate';
 import { IAgentPermissionModeService } from '#/agent/permissionMode/permissionMode';
-import { IAgentPlanService } from '#/agent/plan/plan';
 import { IAgentScopeContext } from '#/agent/scopeContext/scopeContext';
 import {
   IAgentLifecycleService,
   MAIN_AGENT_ID,
 } from '#/session/agentLifecycle/agentLifecycle';
-import { IHostEnvironment } from '#/os/interface/hostEnvironment';
 import { expandCommandArguments } from '#/app/plugin/commands';
 import { IPluginService } from '#/app/plugin/plugin';
-import { IAgentProfileService, ProfileError } from '#/agent/profile/profile';
+import { ProfileError } from '#/agent/profile/profile';
 import { IAgentToolPolicyService } from '#/agent/toolPolicy/toolPolicy';
 import { IAgentPromptService } from '#/agent/prompt/prompt';
-import { IAgentShellCommandService } from '#/agent/shellCommand/shellCommand';
 import { ISessionMetadata } from '#/session/sessionMetadata/sessionMetadata';
 import { ISessionContext } from '#/session/sessionContext/sessionContext';
-import { ISessionBtwService } from '#/session/btw/btw';
 import { IAgentSkillService } from '#/agent/skill/skill';
-import { IAgentSwarmService } from '#/agent/swarm/swarm';
 import { ITelemetryService } from '#/app/telemetry/telemetry';
 import { IAgentToolRegistryService } from '#/agent/toolRegistry/toolRegistry';
 import { IAgentLoopService } from '#/agent/loop/loop';
-import { IAgentUsageService } from '#/agent/usage/usage';
-import { IAgentUserToolService } from '#/agent/userTool/userTool';
 import type {
   ActivatePluginCommandPayload,
   ActivateSkillPayload,
-  BeginCompactionPayload,
   CancelPayload,
-  CancelPlanPayload,
-  CreateGoalPayload,
-  DetachTaskPayload,
   EmptyPayload,
-  EnterSwarmPayload,
-  GetTaskOutputPayload,
-  GetTasksPayload,
   PromptLaunchResult,
   PromptPayload,
-  RegisterToolPayload,
-  RunShellCommandPayload,
-  ShellCommandResult,
-  CancelShellCommandPayload,
-  SetActiveToolsPayload,
-  SetModelPayload,
   SetPermissionPayload,
-  SetThinkingPayload,
   SteerPayload,
-  StopTaskPayload,
   UndoHistoryPayload,
-  UnregisterToolPayload,
 } from './core-api';
 import { IAgentRPCService } from './rpc';
 import {
@@ -90,31 +64,20 @@ export class AgentRPCService implements IAgentRPCService {
 
   constructor(
     @IAgentPromptService private readonly promptService: IAgentPromptService,
-    @IAgentShellCommandService private readonly shellCommand: IAgentShellCommandService,
     @IAgentLoopService private readonly loop: IAgentLoopService,
-    @IAgentProfileService private readonly profile: IAgentProfileService,
     @IAgentToolPolicyService private readonly toolPolicy: IAgentToolPolicyService,
     @IAgentPermissionModeService private readonly permissionMode: IAgentPermissionModeService,
-    @IAgentPermissionGate private readonly permission: IAgentPermissionGate,
-    @IAgentPlanService private readonly planMode: IAgentPlanService,
-    @IAgentSwarmService private readonly swarmMode: IAgentSwarmService,
     @IAgentFullCompactionService private readonly fullCompaction: IAgentFullCompactionService,
-    @IAgentUserToolService private readonly userTools: IAgentUserToolService,
     @IAgentToolRegistryService private readonly toolRegistry: IAgentToolRegistryService,
-    @IHostEnvironment private readonly hostEnv: IHostEnvironment,
-    @IAgentTaskService private readonly tasks: IAgentTaskService,
     @IAgentContextMemoryService private readonly context: IAgentContextMemoryService,
     @IAgentContextSizeService private readonly contextSize: IAgentContextSizeService,
     @IAgentSkillService private readonly skills: IAgentSkillService,
-    @IAgentUsageService private readonly usage: IAgentUsageService,
     @ITelemetryService private readonly telemetry: ITelemetryService,
-    @IAgentGoalService private readonly goal: IAgentGoalService,
     @IEventBus private readonly eventBus: IEventBus,
     @IEventService private readonly eventService: IEventService,
     @IPluginService private readonly plugins: IPluginService,
     @ISessionMetadata private readonly metadata: ISessionMetadata,
     @ISessionContext private readonly sessionContext: ISessionContext,
-    @ISessionBtwService private readonly btw: ISessionBtwService,
     @IAgentScopeContext private readonly scopeContext: IAgentScopeContext,
     @IAgentLifecycleService private readonly agentLifecycle: IAgentLifecycleService,
   ) { }
@@ -140,14 +103,6 @@ export class AgentRPCService implements IAgentRPCService {
     if (handle.state === 'pending') return undefined;
     const turn = await handle.launched;
     return turn === undefined ? undefined : { turn_id: turn.id };
-  }
-
-  async runShellCommand(payload: RunShellCommandPayload): Promise<ShellCommandResult> {
-    return this.shellCommand.run(payload);
-  }
-
-  cancelShellCommand(payload: CancelShellCommandPayload): void {
-    this.shellCommand.cancel(payload.commandId);
   }
 
   async steer(payload: SteerPayload): Promise<PromptLaunchResult | undefined> {
@@ -178,10 +133,6 @@ export class AgentRPCService implements IAgentRPCService {
     return undone;
   }
 
-  setThinking(payload: SetThinkingPayload): void {
-    this.profile.setThinking(payload.level);
-  }
-
   setPermission(payload: SetPermissionPayload): void {
     const wasYolo = this.permissionMode.mode === 'yolo';
     const wasAuto = this.permissionMode.mode === 'auto';
@@ -199,46 +150,6 @@ export class AgentRPCService implements IAgentRPCService {
     }
   }
 
-  setModel(payload: SetModelPayload) {
-    return this.profile.setModel(payload.model);
-  }
-
-  getModel(_payload: EmptyPayload): string {
-    return this.profile.getModel();
-  }
-
-  enterPlan(_payload: EmptyPayload): Promise<void> {
-    return this.planMode.enter();
-  }
-
-  cancelPlan(payload: CancelPlanPayload): void {
-    this.planMode.cancel(payload.id);
-  }
-
-  clearPlan(_payload: EmptyPayload): Promise<void> {
-    return this.planMode.clear();
-  }
-
-  enterSwarm(payload: EnterSwarmPayload): void {
-    this.swarmMode.enter(payload.trigger);
-  }
-
-  exitSwarm(_payload: EmptyPayload): void {
-    this.swarmMode.exit();
-  }
-
-  getSwarmMode(_payload: EmptyPayload): boolean {
-    return this.swarmMode.isActive;
-  }
-
-  startBtw(_payload: EmptyPayload): Promise<string> {
-    return this.btw.start();
-  }
-
-  beginCompaction(payload: BeginCompactionPayload): void {
-    this.fullCompaction.begin({ source: 'manual', instruction: payload.instruction });
-  }
-
   cancelCompaction(_payload: EmptyPayload): void {
     const active = this.fullCompaction.compacting;
     if (active !== null) {
@@ -248,34 +159,6 @@ export class AgentRPCService implements IAgentRPCService {
       });
     }
     active?.abortController.abort();
-  }
-
-  registerTool(payload: RegisterToolPayload): void {
-    this.userTools.register(payload);
-  }
-
-  unregisterTool(payload: UnregisterToolPayload): void {
-    this.userTools.unregister(payload.name);
-  }
-
-  setActiveTools(payload: SetActiveToolsPayload): void {
-    this.profile.update({ activeToolNames: payload.names });
-  }
-
-  stopTask(payload: StopTaskPayload): void {
-    if (payload.reason === undefined) {
-      void this.tasks.stopByUser(payload.taskId);
-      return;
-    }
-    void this.tasks.stop(payload.taskId, payload.reason);
-  }
-
-  detachTask(payload: DetachTaskPayload) {
-    return this.tasks.detach(payload.taskId);
-  }
-
-  clearContext(_payload: EmptyPayload): void {
-    this.promptService.clear();
   }
 
   async activateSkill(payload: ActivateSkillPayload): Promise<void> {
@@ -332,51 +215,11 @@ export class AgentRPCService implements IAgentRPCService {
     );
   }
 
-  createGoal(payload: CreateGoalPayload) {
-    return this.goal.createGoal(payload);
-  }
-
-  getGoal(_payload: EmptyPayload) {
-    return this.goal.getGoal();
-  }
-
-  pauseGoal(_payload: EmptyPayload) {
-    return this.goal.pauseGoal();
-  }
-
-  resumeGoal(_payload: EmptyPayload) {
-    return this.goal.resumeGoal();
-  }
-
-  cancelGoal(_payload: EmptyPayload) {
-    return this.goal.cancelGoal();
-  }
-
-  getTaskOutput(payload: GetTaskOutputPayload): Promise<string> {
-    return this.tasks.readOutput(payload.taskId, payload.tail);
-  }
-
   getContext(_payload: EmptyPayload) {
     return {
       history: this.context.get(),
       tokenCount: this.contextSize.get().measured,
     };
-  }
-
-  getConfig(_payload: EmptyPayload) {
-    return this.profile.data();
-  }
-
-  getPermission(_payload: EmptyPayload) {
-    return this.permission.data();
-  }
-
-  getPlan(_payload: EmptyPayload) {
-    return this.planMode.status();
-  }
-
-  getUsage(_payload: EmptyPayload) {
-    return this.usage.status();
   }
 
   getTools(_payload: EmptyPayload) {
@@ -386,10 +229,6 @@ export class AgentRPCService implements IAgentRPCService {
       active: this.toolPolicy.isToolActive(tool.name, tool.source),
       source: tool.source,
     }));
-  }
-
-  getTasks(payload: GetTasksPayload) {
-    return this.tasks.list(payload.activeOnly ?? false, payload.limit);
   }
 }
 

--- a/packages/agent-core-v2/test/harness/agent.ts
+++ b/packages/agent-core-v2/test/harness/agent.ts
@@ -9,7 +9,7 @@ import { toDisposable } from '#/_base/di/lifecycle';
 import type { IAgentScopeHandle } from '#/_base/di/scope';
 import { Emitter, Event } from '#/_base/event';
 import { IAgentLifecycleService } from '#/session/agentLifecycle/agentLifecycle';
-import type { PromisifyMethods } from '#/_base/utils/types';
+import type { Promisable, PromisifyMethods } from '#/_base/utils/types';
 import { escapeXmlAttr } from '#/_base/utils/xml-escape';
 import type { AgentTaskInfo } from '#/agent/task/task';
 import { IAgentBlobService } from '#/agent/blob/agentBlobService';
@@ -25,13 +25,36 @@ import { IAgentGoalService } from '#/agent/goal/goal';
 import { AgentGoalService } from '#/agent/goal/goalService';
 import { ISessionMcpService } from '#/session/mcp/sessionMcp';
 import type { McpConnectionManager } from '#/agent/mcp/connection-manager';
-import type { PermissionMode } from '#/agent/permissionPolicy/types';
+import type { PermissionData, PermissionMode } from '#/agent/permissionPolicy/types';
 import type { PermissionRule } from '#/agent/permissionRules/permissionRules';
-import { IAgentPlanService } from '#/agent/plan/plan';
-import { IAgentProfileService } from '#/agent/profile/profile';
+import { IAgentPlanService, type PlanData } from '#/agent/plan/plan';
+import { IAgentProfileService, type AgentConfigData } from '#/agent/profile/profile';
 import { IAgentToolPolicyService } from '#/agent/toolPolicy/toolPolicy';
 import { IAgentPromptService } from '#/agent/prompt/prompt';
-import type { AgentAPI } from '#/agent/rpc/core-api';
+import type {
+  AgentAPI,
+  BeginCompactionPayload,
+  CancelPlanPayload,
+  CancelShellCommandPayload,
+  CreateGoalPayload,
+  DetachTaskPayload,
+  EmptyPayload,
+  EnterSwarmPayload,
+  GetTaskOutputPayload,
+  GetTasksPayload,
+  GoalSnapshot,
+  GoalToolResult,
+  RegisterToolPayload,
+  RunShellCommandPayload,
+  SetActiveToolsPayload,
+  SetModelPayload,
+  SetModelResult,
+  SetThinkingPayload,
+  ShellCommandResult,
+  StopTaskPayload,
+  UnregisterToolPayload,
+} from '#/agent/rpc/core-api';
+import { type UsageStatus } from '#/agent/usage/usage';
 import { IAgentSkillService } from '#/agent/skill/skill';
 import { AgentSkillService } from '#/agent/skill/skillService';
 import { IAgentToolDedupeService } from '#/agent/toolDedupe/toolDedupe';
@@ -85,9 +108,11 @@ import {
   IAgentPermissionModeService,
   IAgentPermissionRulesService,
   IHostFileSystem,
+  ISessionBtwService,
   ISessionContext,
   ISessionProcessRunner,
   IAgentScopeContext,
+  IAgentShellCommandService,
   IAgentStepRetryService,
   IAgentLoopContinuationService,
   IAgentSwarmService,
@@ -258,7 +283,46 @@ type RpcPromise<T> = Promise<T> & {
   reject(reason?: unknown): void;
 };
 
-type PromiseAgentAPI = PromisifyMethods<AgentAPI>;
+/**
+ * Wire signatures of the methods removed from `AgentAPI` for being pure
+ * forwards to domain services. The harness keeps `ctx.rpc` backward
+ * compatible by re-declaring them here and adapting each onto the
+ * corresponding domain service in `createPromiseAgentApi`.
+ */
+interface AgentRpcPassthroughAPI {
+  runShellCommand: (payload: RunShellCommandPayload) => Promisable<ShellCommandResult>;
+  cancelShellCommand: (payload: CancelShellCommandPayload) => void;
+  setThinking: (payload: SetThinkingPayload) => void;
+  setModel: (payload: SetModelPayload) => Promisable<SetModelResult>;
+  getModel: (payload: EmptyPayload) => string;
+  enterPlan: (payload: EmptyPayload) => Promisable<void>;
+  cancelPlan: (payload: CancelPlanPayload) => void;
+  clearPlan: (payload: EmptyPayload) => Promisable<void>;
+  enterSwarm: (payload: EnterSwarmPayload) => void;
+  exitSwarm: (payload: EmptyPayload) => void;
+  getSwarmMode: (payload: EmptyPayload) => boolean;
+  startBtw: (payload: EmptyPayload) => Promisable<string>;
+  beginCompaction: (payload: BeginCompactionPayload) => void;
+  registerTool: (payload: RegisterToolPayload) => void;
+  unregisterTool: (payload: UnregisterToolPayload) => void;
+  setActiveTools: (payload: SetActiveToolsPayload) => void;
+  stopTask: (payload: StopTaskPayload) => void;
+  detachTask: (payload: DetachTaskPayload) => AgentTaskInfo | undefined;
+  clearContext: (payload: EmptyPayload) => void;
+  createGoal: (payload: CreateGoalPayload) => Promisable<GoalSnapshot>;
+  getGoal: (payload: EmptyPayload) => GoalToolResult;
+  pauseGoal: (payload: EmptyPayload) => Promisable<GoalSnapshot>;
+  resumeGoal: (payload: EmptyPayload) => Promisable<GoalSnapshot>;
+  cancelGoal: (payload: EmptyPayload) => Promisable<GoalSnapshot>;
+  getTaskOutput: (payload: GetTaskOutputPayload) => Promisable<string>;
+  getConfig: (payload: EmptyPayload) => AgentConfigData;
+  getPermission: (payload: EmptyPayload) => PermissionData;
+  getPlan: (payload: EmptyPayload) => Promisable<PlanData>;
+  getUsage: (payload: EmptyPayload) => UsageStatus;
+  getTasks: (payload: GetTasksPayload) => readonly AgentTaskInfo[];
+}
+
+type PromiseAgentAPI = PromisifyMethods<AgentAPI & AgentRpcPassthroughAPI>;
 type GenerateFn = typeof kosongGenerate;
 
 type TestToolResult = ExecutableToolResult & {
@@ -1346,8 +1410,7 @@ export class AgentTestContext {
   }
 
   clearContext(): void {
-    const rpcMethods = this.get(IAgentRPCService);
-    void rpcMethods.clearContext({});
+    this.get(IAgentPromptService).clear();
   }
 
   undoHistory(count: number): number {
@@ -1812,9 +1875,11 @@ export class AgentTestContext {
   }
 
   private createPromiseAgentApi(agent: IAgentRPCService): PromiseAgentAPI {
+    const passthrough = this.createRpcPassthroughAdapters();
     return new Proxy(agent, {
       get(proxyTarget, property, receiver) {
-        const value = Reflect.get(proxyTarget, property, receiver);
+        const override = Reflect.get(passthrough, property) as unknown;
+        const value = override ?? Reflect.get(proxyTarget, property, receiver);
         if (typeof value !== 'function') return value;
         return (payload: unknown) => {
           try {
@@ -1825,6 +1890,62 @@ export class AgentTestContext {
         };
       },
     }) as unknown as PromiseAgentAPI;
+  }
+
+  /**
+   * Adapters for the wire methods removed from `AgentRPCService` as pure
+   * forwards. Each mirrors the forward the RPC service used to implement
+   * (including the `beginCompaction` manual source, the `stopTask` reason
+   * branch, and the `setActiveTools` profile mapping).
+   */
+  private createRpcPassthroughAdapters(): AgentRpcPassthroughAPI {
+    return {
+      runShellCommand: (payload) => this.get(IAgentShellCommandService).run(payload),
+      cancelShellCommand: (payload) =>
+        this.get(IAgentShellCommandService).cancel(payload.commandId),
+      setThinking: (payload) => this.get(IAgentProfileService).setThinking(payload.level),
+      setModel: (payload) => this.get(IAgentProfileService).setModel(payload.model),
+      getModel: () => this.get(IAgentProfileService).getModel(),
+      enterPlan: () => this.get(IAgentPlanService).enter(),
+      cancelPlan: (payload) => this.get(IAgentPlanService).cancel(payload.id),
+      clearPlan: () => this.get(IAgentPlanService).clear(),
+      enterSwarm: (payload) => this.get(IAgentSwarmService).enter(payload.trigger),
+      exitSwarm: () => this.get(IAgentSwarmService).exit(),
+      getSwarmMode: () => this.get(IAgentSwarmService).isActive,
+      startBtw: () => this.get(ISessionBtwService).start(),
+      beginCompaction: (payload) =>
+        this.get(IAgentFullCompactionService).begin({
+          source: 'manual',
+          instruction: payload.instruction,
+        }),
+      registerTool: (payload) => this.get(IAgentUserToolService).register(payload),
+      unregisterTool: (payload) => this.get(IAgentUserToolService).unregister(payload.name),
+      setActiveTools: (payload) =>
+        this.get(IAgentProfileService).update({ activeToolNames: payload.names }),
+      stopTask: (payload) => {
+        const tasks = this.get(IAgentTaskService);
+        if (payload.reason === undefined) {
+          void tasks.stopByUser(payload.taskId);
+          return;
+        }
+        void tasks.stop(payload.taskId, payload.reason);
+      },
+      detachTask: (payload) => this.get(IAgentTaskService).detach(payload.taskId),
+      clearContext: () => this.get(IAgentPromptService).clear(),
+      createGoal: (payload) => this.get(IAgentGoalService).createGoal(payload),
+      getGoal: () => this.get(IAgentGoalService).getGoal(),
+      pauseGoal: () => this.get(IAgentGoalService).pauseGoal(),
+      resumeGoal: () => this.get(IAgentGoalService).resumeGoal(),
+      cancelGoal: () => this.get(IAgentGoalService).cancelGoal(),
+      getTaskOutput: (payload) =>
+        this.get(IAgentTaskService).readOutput(payload.taskId, payload.tail),
+      getConfig: () => this.get(IAgentProfileService).data(),
+      getPermission: () => this.get(IAgentPermissionGate).data(),
+      getPlan: () => this.get(IAgentPlanService).status(),
+      getUsage: () => this.get(IAgentUsageService).status(),
+      getTasks: (payload) =>
+        this.get(IAgentTaskService).list(payload.activeOnly ?? false, payload.limit),
+    };
   }
 
   private appendUserText(text: string): void {

--- a/packages/kap-server/test/rpc.test.ts
+++ b/packages/kap-server/test/rpc.test.ts
@@ -7,6 +7,7 @@ import {
   IAgentGoalService,
   IAgentLifecycleService,
   IAgentRPCService,
+  IAgentShellCommandService,
   IAppendLogStore,
   IEventService,
   IPluginService,
@@ -380,13 +381,13 @@ describe('server-v2 /api/v1/debug RPC', () => {
     expect(meta.body.data.lastPrompt).toBe('should not become the title');
   });
 
-  it('runs a shell command through the RPC facade', async () => {
+  it('runs a shell command through the shell command service', async () => {
     const id = await createSession(home as string);
     await createMainAgent(id);
 
     const { body } = await call<{ stdout: string; stderr: string; isError?: boolean }>(
       'POST',
-      rpc('agent', IAgentRPCService, 'runShellCommand', { sid: id, aid: 'main' }),
+      rpc('agent', IAgentShellCommandService, 'run', { sid: id, aid: 'main' }),
       { command: 'printf hello' },
     );
     expect(body.code).toBe(0);

--- a/packages/klient/src/contract/agent/rpc.ts
+++ b/packages/klient/src/contract/agent/rpc.ts
@@ -1,10 +1,13 @@
 /**
  * `agentRPCService` — the per-agent RPC surface. Mirrors the `AgentAPI`
  * subset of `agent-core-v2/agent/rpc/core-api.ts`; every method takes one
- * payload object. `PromptPayload.input` mirrors the `PromptPart` subset of
- * `ContentPart` (text / image_url / video_url) from
- * `agent-core-v2/kosong/contract/message.ts`. Task wire shapes mirror the
- * `TaskInfo` union in `protocol/src/events.ts`.
+ * payload object. Only the methods still implemented by the engine's RPC
+ * facade live here — the domain services the facade calls directly
+ * (shellCommand / profile / usage / plan / task) have their own contracts in
+ * `agent/services.ts`, reusing the payload/result schemas below.
+ * `PromptPayload.input` mirrors the `PromptPart` subset of `ContentPart`
+ * (text / image_url / video_url) from `agent-core-v2/kosong/contract/message.ts`.
+ * Task wire shapes mirror the `TaskInfo` union in `protocol/src/events.ts`.
  */
 
 import { z } from 'zod';
@@ -192,27 +195,6 @@ export const agentRpcContract = {
   prompt: { input: z.tuple([promptPayloadSchema]), output: maybe(promptLaunchResultSchema) },
   steer: { input: z.tuple([steerPayloadSchema]), output: maybe(promptLaunchResultSchema) },
   cancel: { input: z.tuple([cancelPayloadSchema]), output: noResult },
-  runShellCommand: {
-    input: z.tuple([runShellCommandPayloadSchema]),
-    output: shellCommandResultSchema,
-  },
-  cancelShellCommand: {
-    input: z.tuple([cancelShellCommandPayloadSchema]),
-    output: noResult,
-  },
-  getModel: { input: z.tuple([emptyPayloadSchema]), output: z.string() },
-  setModel: { input: z.tuple([setModelPayloadSchema]), output: setModelResultSchema },
   setPermission: { input: z.tuple([setPermissionPayloadSchema]), output: noResult },
-  getUsage: { input: z.tuple([emptyPayloadSchema]), output: usageStatusSchema },
   getContext: { input: z.tuple([emptyPayloadSchema]), output: agentContextDataSchema },
-  getPlan: { input: z.tuple([emptyPayloadSchema]), output: planDataSchema },
-  enterPlan: { input: z.tuple([emptyPayloadSchema]), output: noResult },
-  clearPlan: { input: z.tuple([emptyPayloadSchema]), output: noResult },
-  cancelPlan: { input: z.tuple([cancelPlanPayloadSchema]), output: noResult },
-  getTasks: {
-    input: z.tuple([getTasksPayloadSchema]),
-    output: z.array(agentTaskInfoSchema),
-  },
-  stopTask: { input: z.tuple([stopTaskPayloadSchema]), output: noResult },
-  getTaskOutput: { input: z.tuple([getTaskOutputPayloadSchema]), output: z.string() },
 } satisfies ServiceContract;

--- a/packages/klient/src/contract/agent/services.ts
+++ b/packages/klient/src/contract/agent/services.ts
@@ -1,0 +1,59 @@
+/**
+ * Agent-scope domain service contracts. These mirror the positional-arg
+ * signatures of the engine's domain Services (shellCommand / profile / usage /
+ * plan / task) that the agent facade calls directly; payload and result
+ * schemas are shared with `agent/rpc.ts` (they mirror the same wire shapes).
+ */
+
+import { z } from 'zod';
+
+import { maybe, noResult } from '../helpers.js';
+import type { ServiceContract } from '../types.js';
+import {
+  agentTaskInfoSchema,
+  planDataSchema,
+  runShellCommandPayloadSchema,
+  setModelResultSchema,
+  shellCommandResultSchema,
+  usageStatusSchema,
+} from './rpc.js';
+
+export const agentShellCommandContract = {
+  run: {
+    input: z.tuple([runShellCommandPayloadSchema]),
+    output: shellCommandResultSchema,
+  },
+  cancel: { input: z.tuple([z.string()]), output: noResult },
+} satisfies ServiceContract;
+
+export const agentProfileContract = {
+  getModel: { input: z.tuple([]), output: z.string() },
+  setModel: { input: z.tuple([z.string()]), output: setModelResultSchema },
+} satisfies ServiceContract;
+
+export const agentUsageContract = {
+  status: { input: z.tuple([]), output: usageStatusSchema },
+} satisfies ServiceContract;
+
+export const agentPlanContract = {
+  status: { input: z.tuple([]), output: planDataSchema },
+  enter: { input: z.tuple([]), output: noResult },
+  clear: { input: z.tuple([]), output: noResult },
+  cancel: { input: z.tuple([z.string().optional()]), output: noResult },
+} satisfies ServiceContract;
+
+export const agentTaskContract = {
+  list: {
+    input: z.tuple([z.boolean().optional(), z.number().optional()]),
+    output: z.array(agentTaskInfoSchema),
+  },
+  stopByUser: { input: z.tuple([z.string()]), output: maybe(agentTaskInfoSchema) },
+  stop: {
+    input: z.tuple([z.string(), z.string().optional()]),
+    output: maybe(agentTaskInfoSchema),
+  },
+  readOutput: {
+    input: z.tuple([z.string(), z.number().optional()]),
+    output: z.string(),
+  },
+} satisfies ServiceContract;

--- a/packages/klient/src/contract/index.ts
+++ b/packages/klient/src/contract/index.ts
@@ -9,6 +9,13 @@
 import type { KlientContract } from './types.js';
 import { agentActivityViewContract } from './agent/activity.js';
 import { agentRpcContract } from './agent/rpc.js';
+import {
+  agentPlanContract,
+  agentProfileContract,
+  agentShellCommandContract,
+  agentTaskContract,
+  agentUsageContract,
+} from './agent/services.js';
 import { authContract, authSummaryContract } from './global/auth.js';
 import { catalogContract } from './global/catalog.js';
 import { providerDiscoveryContract } from './global/providerDiscovery.js';
@@ -51,6 +58,11 @@ export const globalContract: KlientContract = {
   // agent scope
   agentRPCService: agentRpcContract,
   agentActivityView: agentActivityViewContract,
+  agentShellCommandService: agentShellCommandContract,
+  agentProfileService: agentProfileContract,
+  agentUsageService: agentUsageContract,
+  agentPlanService: agentPlanContract,
+  agentTaskService: agentTaskContract,
 };
 
 export type { KlientContract, ProcedureContract, ServiceContract } from './types.js';

--- a/packages/klient/src/core/facade/agent.ts
+++ b/packages/klient/src/core/facade/agent.ts
@@ -1,26 +1,33 @@
 /**
- * The agent facade — one `session.agent(id)` handle over the `agentRPCService`
- * channel (the single agent-scope facade service the wire exposes). Prompt
- * streaming is NOT on this interface: it flows through the agent's `events`
- * hub (`turn.*`, `assistant.delta`, `tool.call.*`, `prompt.completed`, …).
+ * The agent facade — one `session.agent(id)` handle over the agent-scope
+ * services the wire exposes. Turn-driving calls (prompt / steer / cancel) go
+ * through the `agentRPCService` channel; shell commands, model, usage, plan,
+ * and task calls go straight to their domain services. Prompt streaming is
+ * NOT on this interface: it flows through the agent's `events` hub
+ * (`turn.*`, `assistant.delta`, `tool.call.*`, `prompt.completed`, …).
  */
 
 import type { IAgentRPCService } from '@moonshot-ai/agent-core-v2/agent/rpc/rpc';
+import type { IAgentPlanService } from '@moonshot-ai/agent-core-v2/agent/plan/plan';
+import type { IAgentProfileService } from '@moonshot-ai/agent-core-v2/agent/profile/profile';
+import type { IAgentShellCommandService } from '@moonshot-ai/agent-core-v2/agent/shellCommand/shellCommand';
+import type { IAgentTaskService } from '@moonshot-ai/agent-core-v2/agent/task/task';
+import type { IAgentUsageService } from '@moonshot-ai/agent-core-v2/agent/usage/usage';
 import type { ContentPart } from '@moonshot-ai/agent-core-v2/kosong/contract/message';
 import type { PermissionMode } from '@moonshot-ai/agent-core-v2/agent/permissionPolicy/types';
 
 import type { ScopeRef } from '../channel.js';
 import type { ScopedCaller } from './session.js';
 
-// Wire-type aliases derived through the RPC interface (keeps klient free of
-// protocol-package imports).
+// Wire-type aliases derived through the engine service interfaces (keeps
+// klient free of protocol-package imports).
 export type PromptLaunchResult = Awaited<ReturnType<IAgentRPCService['prompt']>>;
-export type ShellCommandResult = Awaited<ReturnType<IAgentRPCService['runShellCommand']>>;
-export type SetModelResult = Awaited<ReturnType<IAgentRPCService['setModel']>>;
-export type UsageStatus = Awaited<ReturnType<IAgentRPCService['getUsage']>>;
+export type ShellCommandResult = Awaited<ReturnType<IAgentShellCommandService['run']>>;
+export type SetModelResult = Awaited<ReturnType<IAgentProfileService['setModel']>>;
+export type UsageStatus = Awaited<ReturnType<IAgentUsageService['status']>>;
 export type AgentContextData = Awaited<ReturnType<IAgentRPCService['getContext']>>;
-export type PlanData = Awaited<ReturnType<IAgentRPCService['getPlan']>>;
-export type AgentTaskInfo = Awaited<ReturnType<IAgentRPCService['getTasks']>>[number];
+export type PlanData = Awaited<ReturnType<IAgentPlanService['status']>>;
+export type AgentTaskInfo = Awaited<ReturnType<IAgentTaskService['list']>>[number];
 
 export interface AgentFacade {
   prompt(input: {
@@ -53,19 +60,34 @@ export function createAgentFacade(call: ScopedCaller, scope: ScopeRef): AgentFac
     prompt: (input) => rpc('prompt', input) as Promise<PromptLaunchResult>,
     steer: (input) => rpc('steer', input) as Promise<PromptLaunchResult>,
     cancel: (input) => rpc('cancel', input ?? {}) as Promise<void>,
-    runShellCommand: (input) => rpc('runShellCommand', input) as Promise<ShellCommandResult>,
-    cancelShellCommand: (input) => rpc('cancelShellCommand', input) as Promise<void>,
-    getModel: () => rpc('getModel', {}) as Promise<string>,
-    setModel: (model) => rpc('setModel', { model }) as Promise<SetModelResult>,
+    runShellCommand: (input) =>
+      call(scope, 'agentShellCommandService', 'run', [input]) as Promise<ShellCommandResult>,
+    cancelShellCommand: (input) =>
+      call(scope, 'agentShellCommandService', 'cancel', [input.commandId]) as Promise<void>,
+    getModel: () => call(scope, 'agentProfileService', 'getModel', []) as Promise<string>,
+    setModel: (model) =>
+      call(scope, 'agentProfileService', 'setModel', [model]) as Promise<SetModelResult>,
     setPermission: (mode) => rpc('setPermission', { mode }) as Promise<void>,
-    getUsage: () => rpc('getUsage', {}) as Promise<UsageStatus>,
+    getUsage: () => call(scope, 'agentUsageService', 'status', []) as Promise<UsageStatus>,
     getContext: () => rpc('getContext', {}) as Promise<AgentContextData>,
-    getPlan: () => rpc('getPlan', {}) as Promise<PlanData>,
-    enterPlan: () => rpc('enterPlan', {}) as Promise<void>,
-    clearPlan: () => rpc('clearPlan', {}) as Promise<void>,
-    cancelPlan: (input) => rpc('cancelPlan', input ?? {}) as Promise<void>,
-    getTasks: (input) => rpc('getTasks', input ?? {}) as Promise<readonly AgentTaskInfo[]>,
-    stopTask: (input) => rpc('stopTask', input) as Promise<void>,
-    getTaskOutput: (input) => rpc('getTaskOutput', input) as Promise<string>,
+    getPlan: () => call(scope, 'agentPlanService', 'status', []) as Promise<PlanData>,
+    enterPlan: () => call(scope, 'agentPlanService', 'enter', []) as Promise<void>,
+    clearPlan: () => call(scope, 'agentPlanService', 'clear', []) as Promise<void>,
+    cancelPlan: (input) =>
+      call(scope, 'agentPlanService', 'cancel', [input?.id]) as Promise<void>,
+    getTasks: (input) =>
+      call(scope, 'agentTaskService', 'list', [
+        input?.activeOnly ?? false,
+        input?.limit,
+      ]) as Promise<readonly AgentTaskInfo[]>,
+    stopTask: async (input) => {
+      if (input.reason === undefined) {
+        await call(scope, 'agentTaskService', 'stopByUser', [input.taskId]);
+        return;
+      }
+      await call(scope, 'agentTaskService', 'stop', [input.taskId, input.reason]);
+    },
+    getTaskOutput: (input) =>
+      call(scope, 'agentTaskService', 'readOutput', [input.taskId, input.tail]) as Promise<string>,
   };
 }

--- a/packages/klient/src/transports/memory/serviceRegistry.ts
+++ b/packages/klient/src/transports/memory/serviceRegistry.ts
@@ -29,6 +29,11 @@ import { ISessionApprovalService } from '@moonshot-ai/agent-core-v2/session/appr
 import { ISessionQuestionService } from '@moonshot-ai/agent-core-v2/session/question/question';
 import { IAgentRPCService } from '@moonshot-ai/agent-core-v2/agent/rpc/rpc';
 import { IAgentActivityView } from '@moonshot-ai/agent-core-v2/agent/activityView/activityView';
+import { IAgentPlanService } from '@moonshot-ai/agent-core-v2/agent/plan/plan';
+import { IAgentProfileService } from '@moonshot-ai/agent-core-v2/agent/profile/profile';
+import { IAgentShellCommandService } from '@moonshot-ai/agent-core-v2/agent/shellCommand/shellCommand';
+import { IAgentTaskService } from '@moonshot-ai/agent-core-v2/agent/task/task';
+import { IAgentUsageService } from '@moonshot-ai/agent-core-v2/agent/usage/usage';
 
 /** Wire service name (decorator id string) → token. */
 export const serviceTokens: Readonly<Record<string, ServiceIdentifier<unknown>>> = {
@@ -52,6 +57,11 @@ export const serviceTokens: Readonly<Record<string, ServiceIdentifier<unknown>>>
   sessionQuestionService: ISessionQuestionService,
   agentRPCService: IAgentRPCService,
   agentActivityView: IAgentActivityView,
+  agentShellCommandService: IAgentShellCommandService,
+  agentProfileService: IAgentProfileService,
+  agentUsageService: IAgentUsageService,
+  agentPlanService: IAgentPlanService,
+  agentTaskService: IAgentTaskService,
 };
 
 export { IEventService };

--- a/packages/klient/test/contract-parity.ts
+++ b/packages/klient/test/contract-parity.ts
@@ -26,8 +26,19 @@ import type { TurnEndReason } from '@moonshot-ai/agent-core-v2/agent/loop/turnEv
 import type { PlanData } from '@moonshot-ai/agent-core-v2/agent/plan/plan';
 import type {
   AgentAPI,
+  CancelPlanPayload,
+  CancelShellCommandPayload,
+  EmptyPayload,
+  GetTaskOutputPayload,
+  GetTasksPayload,
   PromptPart,
+  RunShellCommandPayload,
+  SetModelPayload,
+  SetModelResult,
+  ShellCommandResult,
+  StopTaskPayload,
 } from '@moonshot-ai/agent-core-v2/agent/rpc/core-api';
+import type { UsageStatus } from '@moonshot-ai/agent-core-v2/agent/usage/usage';
 import type { ISessionScopeHandle } from '@moonshot-ai/agent-core-v2/_base/di/scope';
 import type {
   CreateChildSessionOptions,
@@ -462,25 +473,17 @@ const _agentActivityState: AssertEngineToWire<typeof agentActivityStateSchema, A
   true;
 
 // ── agent scope (rpc.ts) ────────────────────────────────────────────────────
-// Payload/result types are reached through the `AgentAPI` interface so the
-// assertions track the exact methods the contract mirrors.
+// Payload/result types for the remaining `AgentAPI` methods are reached
+// through the interface so the assertions track the exact methods the
+// contract mirrors; payloads of the domain services the facade calls
+// directly (shellCommand / profile / usage / plan / task) are imported from
+// `core-api.ts` (they no longer have `AgentAPI` entries).
 type PromptPayload = Parameters<AgentAPI['prompt']>[0];
 type PromptLaunchResult = NonNullable<ReturnType<AgentAPI['prompt']>>;
 type SteerPayload = Parameters<AgentAPI['steer']>[0];
 type CancelPayload = Parameters<AgentAPI['cancel']>[0];
-type RunShellCommandPayload = Parameters<AgentAPI['runShellCommand']>[0];
-type ShellCommandResult = ReturnType<AgentAPI['runShellCommand']>;
-type CancelShellCommandPayload = Parameters<AgentAPI['cancelShellCommand']>[0];
-type SetModelPayload = Parameters<AgentAPI['setModel']>[0];
-type SetModelResult = ReturnType<AgentAPI['setModel']>;
 type SetPermissionPayload = Parameters<AgentAPI['setPermission']>[0];
-type UsageStatus = ReturnType<AgentAPI['getUsage']>;
 type TokenUsage = NonNullable<UsageStatus['total']>;
-type GetTasksPayload = Parameters<AgentAPI['getTasks']>[0];
-type StopTaskPayload = Parameters<AgentAPI['stopTask']>[0];
-type GetTaskOutputPayload = Parameters<AgentAPI['getTaskOutput']>[0];
-type CancelPlanPayload = Parameters<AgentAPI['cancelPlan']>[0];
-type EmptyPayload = Parameters<AgentAPI['getModel']>[0];
 
 const _emptyPayload: AssertWire<typeof emptyPayloadSchema, EmptyPayload> = true;
 const _promptPart: AssertWire<typeof promptPartSchema, PromptPart> = true;


### PR DESCRIPTION
## Related Issue

No linked issue — this is an internal refactor, explained below.

## Problem

`AgentRPCService` (the agent-scope wire facade in agent-core-v2) had grown to 40 methods, about 30 of which were pure one-line forwards to domain services (`IAgentProfileService`, `IAgentPlanService`, `IAgentTaskService`, etc.). The extra indirection adds wire surface, contract schemas, and constructor coupling without adding behavior, and it obscures which methods actually contain orchestration logic.

## What changed

- Trimmed `AgentRPCService` / `AgentAPI` to the 10 methods that contain real logic (`prompt`, `steer`, `cancel`, `undoHistory`, `setPermission`, `cancelCompaction`, `activateSkill`, `activatePluginCommand`, `getContext`, `getTools`); constructor dependencies drop from 28 to 17 (including the previously unused `IHostEnvironment`).
- klient's agent facade keeps its public API unchanged but now routes the removed methods directly to the domain services (`agentShellCommandService`, `agentProfileService`, `agentUsageService`, `agentPlanService`, `agentTaskService`), backed by new zod wire contracts and service-token registrations.
- The agent-core-v2 test harness keeps the `ctx.rpc` surface fully backward compatible via passthrough adapters, so no test call sites changed.
- kap-server's rpc test now exercises `runShellCommand` through `IAgentShellCommandService`; the kimi-inspect RPC panel drops the `beginCompaction` / `clearContext` actions that no longer exist on the service.

The remaining methods will be addressed in a follow-up by sinking their orchestration logic into the owning domain services, after which the whole `rpc/` facade directory can go away.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.
