### PR TITLE
fix(agent-core): surface skill parse failures as session warnings

### DIFF
--- a/.changeset/skill-load-warning.md
+++ b/.changeset/skill-load-warning.md
@@ -1,0 +1,6 @@
+---
+"@moonshot-ai/agent-core": patch
+"@moonshot-ai/kimi-code": patch
+---
+
+Surface a warning when a skill file fails to parse at session start, instead of dropping it silently. The warning names the offending file and appears in the TUI status line.

--- a/packages/agent-core/src/session/index.ts
+++ b/packages/agent-core/src/session/index.ts
@@ -694,6 +694,14 @@ export class Session {
         severity: 'warning',
       });
     }
+    await this.skillsReady;
+    for (const warning of this.skills.getLoadWarnings()) {
+      warnings.push({
+        code: 'skill-load-failed',
+        message: warning.message,
+        severity: 'warning',
+      });
+    }
     return warnings;
   }
 

--- a/packages/agent-core/src/skill/registry.ts
+++ b/packages/agent-core/src/skill/registry.ts
@@ -23,11 +23,16 @@ export interface SkillRegistryOptions {
   readonly sessionId?: string;
 }
 
+export interface SkillLoadWarning {
+  readonly message: string;
+}
+
 export class SessionSkillRegistry implements AgentSkillRegistry {
   private readonly byName = new Map<string, SkillDefinition>();
   private readonly byPluginAndName = new Map<string, SkillDefinition>();
   private readonly roots: string[] = [];
   private readonly skipped: SkippedSkill[] = [];
+  private readonly warnings: SkillLoadWarning[] = [];
   private readonly discoverImpl: typeof discoverSkills;
   private readonly onWarning: (message: string, cause?: unknown) => void;
   readonly sessionId?: string;
@@ -45,7 +50,10 @@ export class SessionSkillRegistry implements AgentSkillRegistry {
 
     const skills = await this.discoverImpl({
       roots,
-      onWarning: this.onWarning,
+      onWarning: (message, cause) => {
+        this.warnings.push({ message });
+        this.onWarning(message, cause);
+      },
       onSkippedByPolicy: (skill) => this.skipped.push(skill),
       onDiscoveredSkill: (skill) => {
         this.indexPluginSkill(skill);
@@ -123,6 +131,10 @@ export class SessionSkillRegistry implements AgentSkillRegistry {
 
   getSkippedByPolicy(): readonly SkippedSkill[] {
     return [...this.skipped];
+  }
+
+  getLoadWarnings(): readonly SkillLoadWarning[] {
+    return [...this.warnings];
   }
 
   getKimiSkillsDescription(): string {

--- a/packages/agent-core/test/skill/registry.test.ts
+++ b/packages/agent-core/test/skill/registry.test.ts
@@ -1,4 +1,8 @@
-import { describe, expect, it } from 'vitest';
+import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'pathe';
+
+import { afterEach, describe, expect, it } from 'vitest';
 
 import { SessionSkillRegistry } from '../../src/skill';
 import type { SkillDefinition, SkillSource } from '../../src/skill';
@@ -160,4 +164,98 @@ function sectionFor(rendered: string, header: string): string {
   if (start === -1) return '';
   const next = rendered.indexOf('### ', start + header.length);
   return next === -1 ? rendered.slice(start) : rendered.slice(start, next);
+}
+
+const tempDirs: string[] = [];
+
+afterEach(async () => {
+  for (const dir of tempDirs.splice(0)) {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+describe('SessionSkillRegistry load warnings', () => {
+  it('collects a warning when a skill file fails to parse', async () => {
+    const root = await mkdtemp(path.join(tmpdir(), 'kimi-skill-registry-'));
+    tempDirs.push(root);
+    // Directory-form SKILL.md with a missing required "name" field triggers a
+    // SkillParseError (not an unsupported-type skip), which must surface as a
+    // load warning instead of being silently dropped.
+    await writeSkill(root, path.join('broken', 'SKILL.md'), [
+      '---',
+      'description: missing the name field',
+      '---',
+      'body',
+    ]);
+
+    const registry = new SessionSkillRegistry();
+    await registry.loadRoots([{ path: root, source: 'project' }]);
+
+    expect(registry.listSkills()).toEqual([]);
+    const warnings = registry.getLoadWarnings();
+    expect(warnings.length).toBeGreaterThan(0);
+    expect(warnings.some((w) => w.message.includes('broken'))).toBe(true);
+  });
+
+  it('collects a warning for malformed YAML frontmatter', async () => {
+    const root = await mkdtemp(path.join(tmpdir(), 'kimi-skill-registry-'));
+    tempDirs.push(root);
+    // "description: foo: bar" is not a valid YAML plain scalar — the second
+    // ": " turns the line into an ambiguous mapping, which js-yaml rejects.
+    await writeSkill(root, path.join('bad-yaml', 'SKILL.md'), [
+      '---',
+      'name: bad-yaml',
+      'description: foo: bar',
+      '---',
+      'body',
+    ]);
+
+    const registry = new SessionSkillRegistry();
+    await registry.loadRoots([{ path: root, source: 'user' }]);
+
+    expect(registry.listSkills()).toEqual([]);
+    expect(registry.getLoadWarnings().length).toBeGreaterThan(0);
+  });
+
+  it('produces no warning when all skills parse cleanly', async () => {
+    const root = await mkdtemp(path.join(tmpdir(), 'kimi-skill-registry-'));
+    tempDirs.push(root);
+    await writeSkill(root, path.join('good', 'SKILL.md'), [
+      '---',
+      'name: good',
+      'description: A fine skill',
+      '---',
+      'body',
+    ]);
+
+    const registry = new SessionSkillRegistry();
+    await registry.loadRoots([{ path: root, source: 'project' }]);
+
+    expect(registry.listSkills().map((s) => s.name)).toEqual(['good']);
+    expect(registry.getLoadWarnings()).toEqual([]);
+  });
+
+  it('still forwards warnings to the onWarning callback', async () => {
+    const root = await mkdtemp(path.join(tmpdir(), 'kimi-skill-registry-'));
+    tempDirs.push(root);
+    await writeSkill(root, path.join('broken', 'SKILL.md'), [
+      '---',
+      'description: missing the name field',
+      '---',
+      'body',
+    ]);
+
+    const received: string[] = [];
+    const registry = new SessionSkillRegistry({ onWarning: (m) => received.push(m) });
+    await registry.loadRoots([{ path: root, source: 'project' }]);
+
+    expect(registry.getLoadWarnings().length).toBeGreaterThan(0);
+    expect(received.length).toBeGreaterThan(0);
+  });
+});
+
+async function writeSkill(root: string, relativePath: string, lines: readonly string[]): Promise<void> {
+  const target = path.join(root, relativePath);
+  await mkdir(path.dirname(target), { recursive: true });
+  await writeFile(target, lines.join('\n'));
 }


### PR DESCRIPTION
## Related Issue

Resolve #1972

## Problem

A skill file that fails to parse at session start (malformed YAML frontmatter, missing required `name`/`description` fields, or an unsupported `type`) is **silently dropped** — it does not appear in the skill list and no warning or error is emitted. The only way to discover the failure is to notice the skill is missing and bisect the frontmatter by hand.

The reporter observed that long `description` values triggered the drop and assumed a length limit, but the real trigger is that longer plain-scalar descriptions are more likely to contain a character sequence that breaks YAML parsing (e.g. a `": "` inside the value). Quoting the description fixes it because it becomes a valid YAML quoted scalar — confirming the root cause is a swallowed parse failure, not a length cap.

Two code defects caused the silence:

1. `SessionSkillRegistry` is constructed without an `onWarning` callback, so the default no-op `() => {}` is used. The skill scanner catches `SkillParseError` and forwards it to `warn(...)`, but that call goes nowhere.
2. `Session.getSession.getSessionWarnings()` only checks the AGENTS.md size warning and never reads the skill layer, so even if warnings were collected they would never reach the TUI.

## What changed

- **`SessionSkillRegistry`** now collects skill parse failures into an internal `warnings` list (new `getLoadWarnings()` method), in addition to still forwarding to the optional external `onWarning` callback. This means every `SessionSkillRegistry` instance — including the live session one that previously passed no callback — captures load failures.
- **`Session.getSessionWarnings()`** now `await`s `skillsReady` (so discovery has completed) and surfaces each collected skill warning with `code: "skill-load-failed"`. The TUI already polls `getSessionWarnings()` and renders each entry on the status line, so the warning is now visible to the user naming the offending file.

No changes to the TUI are needed — the existing `showSessionWarnings` path picks up the new warnings automatically. Unsupported skill types (a deliberate skip, not a failure) are intentionally excluded, matching the existing `agents-md-oversized` warning style.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [ ] Ran `gen-docs` skill, or this PR needs no doc update.