### PR TITLE
docs: add Eden AI (EU, OpenAI-compatible) provider example

### DIFF
--- a/docs/en/configuration/providers.md
+++ b/docs/en/configuration/providers.md
@@ -93,6 +93,24 @@ base_url = "https://api.openai.com/v1"
 api_key = "sk-xxxxx"
 ```
 
+### Example: Eden AI (EU gateway, OpenAI-compatible)
+
+[Eden AI](https://www.edenai.co) is a French, EU-based gateway that exposes 700+ models from many vendors (OpenAI, Anthropic, Mistral, Google, …) behind a single OpenAI-compatible key — handy when you want one credential, unified billing, and EU/GDPR data residency. Because it speaks the OpenAI Chat Completions protocol, configure it with `type = "openai"` and point `base_url` at the Eden AI endpoint. Models use a `provider/model` naming scheme.
+
+```toml
+[providers.edenai]
+type = "openai"
+base_url = "https://api.edenai.run/v3"   # EU residency: https://api.eu.edenai.run/v3
+api_key = "your-edenai-key"
+
+[models."edenai-gpt-4o-mini"]
+provider = "edenai"
+model = "openai/gpt-4o-mini"   # provider/model, e.g. anthropic/claude-haiku-4-5
+max_context_size = 128000
+```
+
+Create or manage keys on the [Eden AI API settings page](https://app.edenai.run/admin/api-settings/features-preferences). See the [Eden AI documentation](https://www.edenai.co/docs) for the full model catalog and the `provider/model` identifiers.
+
 ## `openai_responses`
 
 Corresponds to OpenAI's newer Responses API, always operating in streaming mode. Configuration is the same as `openai`.


### PR DESCRIPTION
## What

Adds a worked configuration example for [Eden AI](https://www.edenai.co) under the `openai` provider type in `configuration/providers.md`.

Eden AI is a French, EU-based, GDPR-compliant gateway that exposes 700+ models from many vendors (OpenAI, Anthropic, Mistral, Google, …) behind a single OpenAI-compatible key. Since it speaks the OpenAI Chat Completions protocol, it plugs into Kimi Code with `type = "openai"` and a custom `base_url` — no code change needed. This just documents the exact `config.toml` so users don't have to reverse-engineer the endpoint and the `provider/model` naming.

## Verification

The example was tested live against `https://api.edenai.run/v3/chat/completions`:

- `openai/gpt-4o-mini` → HTTP 200
- `mistral/mistral-large-latest` (EU model) → HTTP 200

## Notes

- Documentation-only change (allowed to open directly per CONTRIBUTING).
- I help maintain integrations at Eden AI; happy to keep this page current.
- Opening a separate issue to ask whether you'd want Eden AI as a *known provider* in `/provider` (code), before writing any code.
