### PR TITLE
docs(changelog): sync 0.29.0 from apps/kimi-code/CHANGELOG.md

### DIFF
--- a/docs/en/release-notes/changelog.md
+++ b/docs/en/release-notes/changelog.md
@@ -6,6 +6,37 @@ outline: 2
 
 This page documents the changes in each Kimi Code CLI release.
 
+## 0.29.0 (2026-07-22)
+
+### Features
+
+- web: Support defining agents in Markdown files, declaring system prompt, name, description, and tool permissions. [Details](https://moonshotai.github.io/kimi-code/en/customization/agents.html#agent-file-format)
+- web: Permanently override the main agent's system prompt with SYSTEM.md. [Details](https://moonshotai.github.io/kimi-code/en/customization/agents.html#overriding-the-main-agent-s-system-prompt-with-system-md)
+- web: Globally enable or disable tools across all sessions via config.toml. [Details](https://moonshotai.github.io/kimi-code/en/configuration/config-files.html#tools)
+- Videos attached to a prompt now reach the model together with the prompt, with no extra tool round trip.
+- Support selecting a thinking effort level from ACP clients.
+- Add environment variable overrides for agent loop and background task limits.
+
+### Polish
+
+- Import many more providers from the models.dev catalog.
+- Improve TUI performance and resume speed for long-running sessions.
+- Reconnect a dropped MCP server connection automatically when one of its tools is called, and retry the call once.
+- Remove red coloring from syntax highlighting in code previews and markdown code blocks.
+- Add a reminder for third-party install sources to use the official installer in the update prompt.
+
+### Bug Fixes
+
+- Fix sessions getting stuck with a provider "message must not be empty" error after a content-filtered response.
+- Fix cancelled model requests being wrapped as retryable provider errors.
+- Fix thinking levels being offered for models that do not support them.
+- Fix config environment overrides being persisted into config.toml while the env var is set.
+- Send the session prompt cache key to OpenAI and OpenAI Responses providers.
+- Fix ReadMediaFile failing on videos when the provider has no file upload channel.
+- Fix goal mode continuation prompts leaking into the transcript when resuming a session.
+- web: Show transparent images over a checkerboard canvas.
+- Remove references to the non-existent `kimi resume` command from the scheduled-task tool descriptions.
+
 ## 0.28.1 (2026-07-20)
 
 ### Features

--- a/docs/zh/release-notes/changelog.md
+++ b/docs/zh/release-notes/changelog.md
@@ -6,6 +6,37 @@ outline: 2
 
 本页记录 Kimi Code CLI 每个版本的变更内容。
 
+## 0.29.0（2026-07-22）
+
+### 新功能
+
+- web: 支持 Markdown 文件定义 agent，声明 system prompt、名称、描述和工具权限。[查看文档](https://moonshotai.github.io/kimi-code/en/customization/agents.html#agent-file-format)
+- web: 可通过 SYSTEM.md 永久覆盖主 agent 的系统提示。[查看文档](https://moonshotai.github.io/kimi-code/en/customization/agents.html#overriding-the-main-agent-s-system-prompt-with-system-md)
+- web: 可通过 config.toml 在所有会话中统一启用/禁用工具。[查看文档](https://moonshotai.github.io/kimi-code/en/configuration/config-files.html#tools)
+- 附加到提示词的视频现在会随提示词一起送达模型，无需额外的工具轮次。
+- ACP 客户端现支持选择思考强度。
+- 新增 Agent 循环与后台任务限制的环境变量覆盖：`KIMI_LOOP_MAX_STEPS_PER_TURN`、`KIMI_LOOP_MAX_RETRIES_PER_STEP` 和 `KIMI_CODE_BACKGROUND_MAX_RUNNING_TASKS`。
+
+### 优化
+
+- 从 models.dev 目录导入更多供应商。
+- 提升 TUI 在长会话中的性能与恢复速度。
+- 当 MCP 服务器的某个工具被调用时，若连接已断开可自动重连，并自动重试一次该调用。
+- 移除代码预览与 Markdown 代码块语法高亮中的红色配色。
+- 在更新提示中为第三方安装来源增加使用官方安装器的提醒。
+
+### 修复
+
+- 修复内容过滤响应后，会话卡住并报 "message must not be empty" 错误的问题。
+- 修复被取消的模型请求被包装为可重试的供应商错误的问题。
+- 修复为不支持的模型提供思考强度选项的问题。
+- 修复环境变量覆盖值在环境变量设置期间被持久化到 config.toml 的问题。
+- 将会话提示词缓存键发送给 OpenAI 与 OpenAI Responses 供应商。
+- 修复当供应商没有文件上传通道时 `ReadMediaFile` 处理视频失败的问题。
+- 修复恢复会话时目标模式续行提示词泄漏到对话记录中的问题。
+- web: 在透明图片下方显示棋盘格画布。
+- 移除定时任务工具描述中对不存在的 `kimi resume` 命令的引用。
+
 ## 0.28.1（2026-07-20）
 
 ### 新功能


### PR DESCRIPTION
## Related Issue

N/A — post-release docs maintenance

## Problem

The docs-site changelog has not yet been synced for `0.29.0` after the npm release.

## What changed

- Synced `0.29.0` from `apps/kimi-code/CHANGELOG.md` into `docs/en/release-notes/changelog.md`
- Translated the new English increment into `docs/zh/release-notes/changelog.md`
- Verified with `pnpm --filter kimi-code-docs run build`

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [ ] I have added tests that prove my feature works. (N/A — docs-only sync)
- [x] Ran `gen-changesets` skill, or this PR needs no changeset. (No changeset — docs sync is out of bundle)
- [x] Ran `gen-docs` skill, or this PR needs no doc update. (This PR is the dedicated changelog sync)