### PR TITLE
fix(fs): list files inside untracked directories in git status

### DIFF
--- a/.changeset/git-status-untracked-all.md
+++ b/.changeset/git-status-untracked-all.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/agent-core-v2": patch
+---
+
+Fix git status collapsing untracked directories: files created inside an untracked directory now appear individually in the Changes panel instead of being hidden behind the directory entry.

--- a/packages/agent-core-v2/src/app/git/gitService.ts
+++ b/packages/agent-core-v2/src/app/git/gitService.ts
@@ -2,7 +2,9 @@
  * `git` domain (L1) — `IGitService` implementation.
  *
  * Runs `git status` / `git diff` (and `gh pr view`) against a repository on
- * the local disk. Process spawning goes through the App-scope
+ * the local disk; status passes `--untracked-files=all` so files inside
+ * untracked directories surface individually instead of collapsing into the
+ * directory entry. Process spawning goes through the App-scope
  * `IHostProcessService` from `os/interface`, and the single path-existence
  * probe in `diff` goes through `IHostFileSystem`; no Node platform API is
  * imported directly. Bound at App scope — it owns no Session dependency, so
@@ -45,7 +47,7 @@ export class GitService implements IGitService {
       throw this.gitUnavailable(cwd, inside.stderr.trim() || `git rev-parse exit ${inside.exitCode}`);
     }
 
-    const porc = await this.runCommand('git', ['status', '--porcelain=v1', '--branch'], cwd);
+    const porc = await this.runCommand('git', ['status', '--porcelain=v1', '--branch', '--untracked-files=all'], cwd);
     if (porc.exitCode !== 0) {
       throw this.gitUnavailable(cwd, porc.stderr.trim() || `git status exit ${porc.exitCode}`);
     }

--- a/packages/agent-core-v2/test/app/git/gitService.test.ts
+++ b/packages/agent-core-v2/test/app/git/gitService.test.ts
@@ -1,5 +1,5 @@
 import { execFileSync } from 'node:child_process';
-import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
@@ -90,6 +90,16 @@ describe('GitService', () => {
 
       const result = await service.status(repo, new Set(['a.txt']));
       expect(result.entries).toEqual({ 'a.txt': 'modified' });
+    });
+
+    it('lists files inside untracked directories individually', async () => {
+      writeFileSync(join(repo, 'a.txt'), 'a\n');
+      commitAll('init');
+      mkdirSync(join(repo, 'newdir'), { recursive: true });
+      writeFileSync(join(repo, 'newdir', 'b.txt'), 'b\n');
+
+      const result = await service.status(repo);
+      expect(result.entries).toEqual({ 'newdir/b.txt': 'untracked' });
     });
 
     it('throws FS_GIT_UNAVAILABLE when not a repo', async () => {


### PR DESCRIPTION
## Problem

`git status --porcelain=v1` defaults to `untracked-files=normal`, which collapses untracked directories to a single `?? dir/` entry. A new file inside an untracked directory (e.g. `docs/new.md`) never surfaces in the Changes panel — only the collapsed directory row appears, and the actual file is invisible.

## Fix

Pass `--untracked-files=all` to the status command in `GitService.status` so entries are reported per file. Ignored paths (node_modules, build output) are unaffected — gitignore still applies.

## Tests

- New regression test: `lists files inside untracked directories individually` (fails without the flag: entries collapse to `newdir/`).
- `@moonshot-ai/agent-core-v2`: 258 files / 3917 tests pass, typecheck + domain lint OK.

Changeset: patch (`@moonshot-ai/agent-core-v2`).
