### PR TITLE
fix(kosong): conservative max_tokens fallback for custom Anthropic-compatible endpoints

### DIFF
--- a/.changeset/anthropic-max-tokens-fallback.md
+++ b/.changeset/anthropic-max-tokens-fallback.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Fix 400 rejections from Anthropic-compatible providers that enforce a lower max_tokens output limit than the default 128000 fallback. Custom endpoints now use a conservative 32768 default, and a rejected request is automatically retried with the provider's declared limit.

--- a/packages/agent-core-v2/src/agent/llmRequester/llmRequesterService.ts
+++ b/packages/agent-core-v2/src/agent/llmRequester/llmRequesterService.ts
@@ -8,8 +8,10 @@
  * params, then drives a bounded request chain through the `ModelRequester`
  * resolved from `IModelCatalog`: one primary `requester.request(input, signal,
  * params)` attempt plus projection rebuilds for request structure or media
- * compatibility; general retry policy remains in the loop's `stepRetry`
- * plugin. Before each request the projected messages pass through `media`'s
+ * compatibility and a one-shot completion-budget clamp when the provider
+ * rejects `max_tokens` (the server-declared ceiling is remembered per model,
+ * so each model pays for at most one rejected-and-resent request); general
+ * retry policy remains in the loop's `stepRetry` plugin. Before each request the projected messages pass through `media`'s
  * video resolver, which rewrites every `kimi-file://` prompt-video reference
  * to a provider-acceptable part (uploaded `ms://`, inline base64, or a
  * `<video path>` tag) so the internal reference never reaches the wire. When a
@@ -53,6 +55,7 @@ import {
   isImageFormatError,
   isRecoverableRequestStructureError,
   isRetryableGenerateError,
+  parseMaxTokensLimit,
 } from '#/kosong/contract/errors';
 import { type Message } from '#/kosong/contract/message';
 import { type ThinkingEffort } from '#/kosong/contract/provider';
@@ -147,6 +150,8 @@ export class AgentLLMRequesterService implements IAgentLLMRequesterService {
   private readonly mediaDegradedTurns = new Set<number>();
   private readonly mediaStrippedTurns = new Map<number, MediaStripSnapshot>();
   private readonly emittedThinkingEffortWarnings = new Set<string>();
+  /** Server-declared `max_tokens` ceilings learned from a rejected request, keyed by wire model name. */
+  private readonly maxTokensClamps = new Map<string, number>();
 
   constructor(
     @IAgentContextMemoryService private readonly context: IAgentContextMemoryService,
@@ -284,6 +289,7 @@ export class AgentLLMRequesterService implements IAgentLLMRequesterService {
   ): Promise<AgentLLMRequestFinish> {
     const shaped = this.toolSelect.shapeHistory(request.messages);
     let mediaStripSnapshot = this.mediaStripSnapshotForTurn(request.source);
+    let params = this.applyMaxTokensClamp(request.model.name, request.params);
     const requestInput = (projection: RequestProjection) => {
       return {
         systemPrompt: request.systemPrompt,
@@ -325,7 +331,7 @@ export class AgentLLMRequesterService implements IAgentLLMRequesterService {
         modelName: request.model.name,
         modelAlias: request.modelAlias,
         thinkingEffort: request.thinkingEffort,
-        maxTokens: effectiveMaxCompletionTokens(request.params),
+        maxTokens: effectiveMaxCompletionTokens(params),
         systemPrompt: input.systemPrompt,
         tools: input.tools,
         messages: input.messages,
@@ -350,7 +356,7 @@ export class AgentLLMRequesterService implements IAgentLLMRequesterService {
       };
 
       for await (const event of request.requester.request(input, signal, {
-        ...request.params,
+        ...params,
         onTraceId: setTraceId,
       })) {
         switch (event.type) {
@@ -457,6 +463,26 @@ export class AgentLLMRequesterService implements IAgentLLMRequesterService {
           projection = 'strict';
           continue;
         }
+        if (raw instanceof APIStatusError && raw.statusCode === 400) {
+          const maxTokensLimit = parseMaxTokensLimit(raw.message);
+          if (
+            maxTokensLimit !== null &&
+            maxTokensLimit < (params.maxCompletionTokens ?? Number.POSITIVE_INFINITY)
+          ) {
+            signal?.throwIfAborted();
+            this.log.warn(
+              'provider rejected the completion-token budget; resending with clamped max tokens',
+              {
+                model: request.model.name,
+                maxTokens: maxTokensLimit,
+                ...request.logFields,
+              },
+            );
+            this.maxTokensClamps.set(request.model.name, maxTokensLimit);
+            params = { ...params, maxCompletionTokens: maxTokensLimit };
+            continue;
+          }
+        }
         throw error;
       }
     }
@@ -524,6 +550,15 @@ export class AgentLLMRequesterService implements IAgentLLMRequesterService {
       if (id < source.turnId) set.delete(id);
     }
     set.add(source.turnId);
+  }
+
+  private applyMaxTokensClamp(modelName: string, params: ModelRequestParams): ModelRequestParams {
+    const clamp = this.maxTokensClamps.get(modelName);
+    if (clamp === undefined) return params;
+    return {
+      ...params,
+      maxCompletionTokens: Math.min(clamp, params.maxCompletionTokens ?? clamp),
+    };
   }
 
   private resolveRequest(overrides: AgentLLMRequestOverrides): ResolvedLLMRequest {

--- a/packages/agent-core-v2/src/kosong/contract/errors.ts
+++ b/packages/agent-core-v2/src/kosong/contract/errors.ts
@@ -255,24 +255,22 @@ const CONTEXT_OVERFLOW_MESSAGE_PATTERNS = [
   /request.*exceed(?:ed|s|ing)?.*model token limit/,
 ] as const;
 
-/**
- * Messages from providers that reject `max_tokens` above their actual output
- * ceiling. Matched against the full error message text (which includes the
- * provider's JSON body). Each pattern should anchor on `max_tokens` to avoid
- * false positives from context-overflow messages.
- */
 const MAX_TOKENS_LIMIT_MESSAGE_PATTERNS: readonly RegExp[] = [
-  // volcano / ark: "expected a value <= 32768"
   /max_tokens[\s\S]{0,200}expected a value\s*<=\s*(\d+)/i,
-  // generic: "max_tokens must be at most N" / "max_tokens cannot exceed N"
   /max_tokens[\s\S]{0,200}(?:must be at most|cannot exceed|maximum value[^\d]*)\s*(\d+)/i,
-  // anthropic native: "max_tokens: <model> max output tokens is N"
+  /max_tokens[\s\S]{0,200}(?:less than or equal to|<=)\s*(\d+)/i,
   /max_tokens[\s\S]{0,200}max output tokens is\s*(\d+)/i,
 ];
 
 /**
  * Parse the provider's actual max_tokens ceiling from a 400 error message.
  * Returns the parsed limit, or null if no max_tokens limit pattern matched.
+ * Patterns are matched against the full error message text (which includes
+ * the provider's JSON body) and each anchors on `max_tokens` to avoid false
+ * positives from context-overflow messages. Recognized wordings: volcano/ark
+ * "expected a value <= N"; "must be at most N" / "cannot exceed N" /
+ * "maximum value … N"; "must be less than or equal to N" and the bare "<= N"
+ * form; Anthropic-native "max output tokens is N".
  */
 export function parseMaxTokensLimit(message: string): number | null {
   for (const pattern of MAX_TOKENS_LIMIT_MESSAGE_PATTERNS) {

--- a/packages/agent-core-v2/src/kosong/contract/errors.ts
+++ b/packages/agent-core-v2/src/kosong/contract/errors.ts
@@ -255,6 +255,36 @@ const CONTEXT_OVERFLOW_MESSAGE_PATTERNS = [
   /request.*exceed(?:ed|s|ing)?.*model token limit/,
 ] as const;
 
+/**
+ * Messages from providers that reject `max_tokens` above their actual output
+ * ceiling. Matched against the full error message text (which includes the
+ * provider's JSON body). Each pattern should anchor on `max_tokens` to avoid
+ * false positives from context-overflow messages.
+ */
+const MAX_TOKENS_LIMIT_MESSAGE_PATTERNS: readonly RegExp[] = [
+  // volcano / ark: "expected a value <= 32768"
+  /max_tokens[\s\S]{0,200}expected a value\s*<=\s*(\d+)/i,
+  // generic: "max_tokens must be at most N" / "max_tokens cannot exceed N"
+  /max_tokens[\s\S]{0,200}(?:must be at most|cannot exceed|maximum value[^\d]*)\s*(\d+)/i,
+  // anthropic native: "max_tokens: <model> max output tokens is N"
+  /max_tokens[\s\S]{0,200}max output tokens is\s*(\d+)/i,
+];
+
+/**
+ * Parse the provider's actual max_tokens ceiling from a 400 error message.
+ * Returns the parsed limit, or null if no max_tokens limit pattern matched.
+ */
+export function parseMaxTokensLimit(message: string): number | null {
+  for (const pattern of MAX_TOKENS_LIMIT_MESSAGE_PATTERNS) {
+    const match = pattern.exec(message);
+    if (match?.[1]) {
+      const limit = parseInt(match[1], 10);
+      if (Number.isFinite(limit) && limit > 0) return limit;
+    }
+  }
+  return null;
+}
+
 const PROVIDER_RATE_LIMIT_MESSAGE_PATTERNS = [
   /(?:apistatuserror.*429|429.*apistatuserror)/,
   /429.*too many requests/,

--- a/packages/agent-core-v2/src/kosong/provider/bases/anthropic/anthropic.ts
+++ b/packages/agent-core-v2/src/kosong/provider/bases/anthropic/anthropic.ts
@@ -207,6 +207,8 @@ const CEILING_BY_FAMILY_VERSION: Readonly<Record<string, number>> = {
 };
 
 const FALLBACK_MAX_TOKENS = 128000;
+/** Conservative fallback for custom endpoints whose actual output ceiling is unknown. */
+const CUSTOM_ENDPOINT_FALLBACK_MAX_TOKENS = 32768;
 
 function lookupClaudeCeiling(version: AnthropicModelVersion): number | undefined {
   const { family, major, minor } = version;
@@ -219,11 +221,18 @@ function lookupClaudeCeiling(version: AnthropicModelVersion): number | undefined
   return CEILING_BY_FAMILY_VERSION[`${family}-${major}`];
 }
 
-export function resolveDefaultMaxTokens(model: string, override?: number): number {
+export function resolveDefaultMaxTokens(model: string, override?: number, baseUrl?: string): number {
   const parsed = parseAnthropicModelVersion(model, true);
   const ceiling = parsed === null ? undefined : lookupClaudeCeiling(parsed);
   if (ceiling === undefined) {
-    return override ?? FALLBACK_MAX_TOKENS;
+    if (override !== undefined) return override;
+    // Custom endpoint + unrecognized model: the 128k Claude-4 fallback is too
+    // aggressive for most Anthropic-compatible providers (32768 is the most
+    // common ceiling). Use the conservative value; the user can still override
+    // via defaultMaxTokens (max_output_size in config).
+    const isCustomEndpoint =
+      baseUrl !== undefined && baseUrl !== '' && !baseUrl.includes('api.anthropic.com');
+    return isCustomEndpoint ? CUSTOM_ENDPOINT_FALLBACK_MAX_TOKENS : FALLBACK_MAX_TOKENS;
   }
   return override === undefined ? ceiling : Math.min(override, ceiling);
 }
@@ -821,7 +830,9 @@ export class AnthropicChatProvider implements ChatProvider {
     this._client = this._apiKey === undefined ? undefined : this._buildClient(this._apiKey);
     this._explicitMaxTokens = options.defaultMaxTokens !== undefined;
     this._generationKwargs = {
-      max_tokens: options.defaultMaxTokens ?? resolveDefaultMaxTokens(options.model),
+      max_tokens:
+        options.defaultMaxTokens ??
+        resolveDefaultMaxTokens(options.model, undefined, options.baseUrl),
       betaFeatures: options.betaFeatures ?? [INTERLEAVED_THINKING_BETA],
     };
   }
@@ -927,7 +938,7 @@ export class AnthropicChatProvider implements ChatProvider {
         cap = Math.min(cap, options.maxContextTokens - options.usedContextTokens);
       }
       cap = Math.max(1, cap);
-      const requestedCap = resolveDefaultMaxTokens(this._model, cap);
+      const requestedCap = resolveDefaultMaxTokens(this._model, cap, this._baseUrl);
       const existingCap = kwargs.max_tokens;
       kwargs = {
         ...kwargs,

--- a/packages/agent-core-v2/test/agent/llmRequester/llmRequesterService.test.ts
+++ b/packages/agent-core-v2/test/agent/llmRequester/llmRequesterService.test.ts
@@ -51,6 +51,7 @@ import { IModelCatalog, type Model } from '#/kosong/model/catalog';
 import {
   type ModelRequestEvent,
   type ModelRequestInput,
+  type ModelRequestParams,
   type ModelRequester,
 } from '#/kosong/model/modelRequester';
 import { ITelemetryService } from '#/app/telemetry/telemetry';
@@ -613,6 +614,97 @@ describe('AgentLLMRequesterService media-degraded resend', () => {
       expect(calls.value).toBe(1);
       expect(degradedCalls).toBe(0);
     }
+  });
+});
+
+describe('AgentLLMRequesterService max-tokens clamp resend', () => {
+  // The harness budget is the stub model's 1000-token context window, so the
+  // server-declared ceiling must sit below it for the clamp to lower anything.
+  const MAX_TOKENS_400 = new APIStatusError(400, 'max_tokens: 128000, expected a value <= 512');
+
+  function createMaxTokensRequester(
+    calls: { value: number },
+    capturedParams: Array<ModelRequestParams | undefined>,
+    errors: readonly (Error | undefined)[],
+  ): ModelRequester {
+    const model: Model = {
+      id: 'm',
+      name: 'wire-model',
+      aliases: [],
+      protocol: 'anthropic',
+      baseUrl: 'https://example.test',
+      headers: {},
+      capabilities,
+      maxContextSize: 1000,
+      alwaysThinking: false,
+      providerName: 'p',
+      authProvider: { getAuth: async () => undefined },
+    };
+    return {
+      model,
+      request: async function* (_input, _signal, params) {
+        const index = calls.value;
+        calls.value += 1;
+        capturedParams.push(params);
+        const error = errors[index];
+        if (error !== undefined) throw error;
+        yield {
+          type: 'finish',
+          message: { role: 'assistant', content: [{ type: 'text', text: 'ok' }], toolCalls: [] },
+          providerFinishReason: 'completed',
+          rawFinishReason: 'stop',
+          id: 'resp-1',
+        };
+      },
+    };
+  }
+
+  it('resends once with the server-declared max_tokens ceiling', async () => {
+    const calls = { value: 0 };
+    const capturedParams: Array<ModelRequestParams | undefined> = [];
+    const requester = createMaxTokensRequester(calls, capturedParams, [
+      MAX_TOKENS_400,
+      undefined,
+    ]);
+    const { service } = createService(requester, undefined);
+
+    const result = await service.request();
+
+    expect(result.message.content).toEqual([{ type: 'text', text: 'ok' }]);
+    expect(calls.value).toBe(2);
+    expect(capturedParams[0]?.maxCompletionTokens).toBeGreaterThan(512);
+    expect(capturedParams[1]?.maxCompletionTokens).toBe(512);
+  });
+
+  it('stops after one clamp resend when the clamped request is rejected again', async () => {
+    const calls = { value: 0 };
+    const capturedParams: Array<ModelRequestParams | undefined> = [];
+    const requester = createMaxTokensRequester(calls, capturedParams, [
+      MAX_TOKENS_400,
+      MAX_TOKENS_400,
+    ]);
+    const { service } = createService(requester, undefined);
+
+    await expect(service.request()).rejects.toMatchObject({ statusCode: 400 });
+    expect(calls.value).toBe(2);
+  });
+
+  it('applies the remembered clamp to later requests for the same model', async () => {
+    const calls = { value: 0 };
+    const capturedParams: Array<ModelRequestParams | undefined> = [];
+    const requester = createMaxTokensRequester(calls, capturedParams, [
+      MAX_TOKENS_400,
+      undefined,
+      undefined,
+    ]);
+    const { service } = createService(requester, undefined);
+
+    await service.request({ source: { type: 'turn', turnId: 1, step: 1 } });
+    expect(calls.value).toBe(2);
+
+    await service.request({ source: { type: 'turn', turnId: 2, step: 1 } });
+    expect(calls.value).toBe(3);
+    expect(capturedParams[2]?.maxCompletionTokens).toBe(512);
   });
 });
 

--- a/packages/agent-core-v2/test/kosong/contract/errors.test.ts
+++ b/packages/agent-core-v2/test/kosong/contract/errors.test.ts
@@ -200,6 +200,11 @@ describe('parseMaxTokensLimit', () => {
     expect(parseMaxTokensLimit('Max_Tokens: 99999 but max output tokens is 12000')).toBe(12000);
   });
 
+  it('parses the "less than or equal to" and bare "<=" forms', () => {
+    expect(parseMaxTokensLimit('max_tokens must be less than or equal to 4096')).toBe(4096);
+    expect(parseMaxTokensLimit('max_tokens <= 2048')).toBe(2048);
+  });
+
   it('returns null when no recognizable positive limit is present', () => {
     expect(parseMaxTokensLimit('max_tokens must be positive')).toBeNull();
     expect(parseMaxTokensLimit('some unrelated validation problem')).toBeNull();

--- a/packages/agent-core-v2/test/kosong/contract/errors.test.ts
+++ b/packages/agent-core-v2/test/kosong/contract/errors.test.ts
@@ -23,6 +23,7 @@ import {
   isAbortError,
   isRetryableGenerateError,
   normalizeAPIStatusError,
+  parseMaxTokensLimit,
   throwIfAbortError,
 } from '#/kosong/contract/errors';
 
@@ -181,5 +182,27 @@ describe('classifyApiError', () => {
   it('falls back to other for unknown values', () => {
     expect(classifyApiError(new Error('boom')).kind).toBe('other');
     expect(classifyApiError('boom').kind).toBe('other');
+  });
+});
+
+describe('parseMaxTokensLimit', () => {
+  it('parses the "expected a value <= N" form', () => {
+    expect(parseMaxTokensLimit('max_tokens: 128000, expected a value <= 8192')).toBe(8192);
+  });
+
+  it('parses the "must be at most", "cannot exceed", and "maximum value" forms', () => {
+    expect(parseMaxTokensLimit('max_tokens: value must be at most 32768')).toBe(32768);
+    expect(parseMaxTokensLimit('max_tokens cannot exceed 16384 for this model')).toBe(16384);
+    expect(parseMaxTokensLimit('max_tokens: maximum value is 64000')).toBe(64000);
+  });
+
+  it('parses the "max output tokens is N" form case-insensitively', () => {
+    expect(parseMaxTokensLimit('Max_Tokens: 99999 but max output tokens is 12000')).toBe(12000);
+  });
+
+  it('returns null when no recognizable positive limit is present', () => {
+    expect(parseMaxTokensLimit('max_tokens must be positive')).toBeNull();
+    expect(parseMaxTokensLimit('some unrelated validation problem')).toBeNull();
+    expect(parseMaxTokensLimit('max_tokens: expected a value <= 0')).toBeNull();
   });
 });

--- a/packages/agent-core-v2/test/kosong/provider/composition.test.ts
+++ b/packages/agent-core-v2/test/kosong/provider/composition.test.ts
@@ -949,6 +949,28 @@ describe('Anthropic max-tokens profile', () => {
     expect(resolveDefaultMaxTokens('totally-unknown-model')).toBe(128000);
   });
 
+  it('defaults unknown models on custom endpoints to a conservative ceiling', () => {
+    expect(
+      resolveDefaultMaxTokens('totally-unknown-model', undefined, 'https://proxy.example.test/v1'),
+    ).toBe(32768);
+  });
+
+  it('keeps the 128000 fallback for unknown models on the official endpoint or no endpoint', () => {
+    expect(
+      resolveDefaultMaxTokens('totally-unknown-model', undefined, 'https://api.anthropic.com'),
+    ).toBe(128000);
+    expect(resolveDefaultMaxTokens('totally-unknown-model', undefined, '')).toBe(128000);
+  });
+
+  it('does not let a custom endpoint displace an explicit override or a known ceiling', () => {
+    expect(resolveDefaultMaxTokens('unknown-model', 12345, 'https://proxy.example.test/v1')).toBe(
+      12345,
+    );
+    expect(
+      resolveDefaultMaxTokens('claude-opus-4-7', undefined, 'https://proxy.example.test/v1'),
+    ).toBe(128000);
+  });
+
   it('sends the profile default as max_tokens when no explicit defaultMaxTokens is set', async () => {
     const provider = new AnthropicChatProvider({
       model: 'claude-opus-4-7',
@@ -998,6 +1020,19 @@ describe('Anthropic max-tokens profile', () => {
     const { params } = await captureAnthropicBody(provider, { maxCompletionTokens: 5000 });
 
     expect(params['max_tokens']).toBe(999999);
+  });
+
+  it('seeds the conservative fallback for unknown models on custom endpoints', async () => {
+    const provider = new AnthropicChatProvider({
+      model: 'totally-unknown-model',
+      apiKey: 'sk-probe',
+      baseUrl: 'https://proxy.example.test/v1',
+      stream: false,
+    });
+
+    const { params } = await captureAnthropicBody(provider);
+
+    expect(params['max_tokens']).toBe(32768);
   });
 });
 

--- a/packages/kosong/src/errors.ts
+++ b/packages/kosong/src/errors.ts
@@ -323,6 +323,36 @@ const CONTEXT_OVERFLOW_MESSAGE_PATTERNS = [
   /request.*exceed(?:ed|s|ing)?.*model token limit/,
 ] as const;
 
+/**
+ * Messages from providers that reject `max_tokens` above their actual output
+ * ceiling. Matched against the full error message text (which includes the
+ * provider's JSON body). Each pattern should anchor on `max_tokens` to avoid
+ * false positives from context-overflow messages.
+ */
+const MAX_TOKENS_LIMIT_MESSAGE_PATTERNS: readonly RegExp[] = [
+  // volcano / ark: "expected a value <= 32768"
+  /max_tokens[\s\S]{0,200}expected a value\s*<=\s*(\d+)/i,
+  // generic: "max_tokens must be at most N" / "max_tokens cannot exceed N"
+  /max_tokens[\s\S]{0,200}(?:must be at most|cannot exceed|maximum value[^\d]*)\s*(\d+)/i,
+  // anthropic native: "max_tokens: <model> max output tokens is N"
+  /max_tokens[\s\S]{0,200}max output tokens is\s*(\d+)/i,
+];
+
+/**
+ * Parse the provider's actual max_tokens ceiling from a 400 error message.
+ * Returns the parsed limit, or null if no max_tokens limit pattern matched.
+ */
+export function parseMaxTokensLimit(message: string): number | null {
+  for (const pattern of MAX_TOKENS_LIMIT_MESSAGE_PATTERNS) {
+    const match = pattern.exec(message);
+    if (match?.[1]) {
+      const limit = parseInt(match[1], 10);
+      if (Number.isFinite(limit) && limit > 0) return limit;
+    }
+  }
+  return null;
+}
+
 const PROVIDER_RATE_LIMIT_MESSAGE_PATTERNS = [
   /(?:apistatuserror.*429|429.*apistatuserror)/,
   /429.*too many requests/,

--- a/packages/kosong/src/errors.ts
+++ b/packages/kosong/src/errors.ts
@@ -334,6 +334,8 @@ const MAX_TOKENS_LIMIT_MESSAGE_PATTERNS: readonly RegExp[] = [
   /max_tokens[\s\S]{0,200}expected a value\s*<=\s*(\d+)/i,
   // generic: "max_tokens must be at most N" / "max_tokens cannot exceed N"
   /max_tokens[\s\S]{0,200}(?:must be at most|cannot exceed|maximum value[^\d]*)\s*(\d+)/i,
+  // "must be less than or equal to N" / bare "<= N" form
+  /max_tokens[\s\S]{0,200}(?:less than or equal to|<=)\s*(\d+)/i,
   // anthropic native: "max_tokens: <model> max output tokens is N"
   /max_tokens[\s\S]{0,200}max output tokens is\s*(\d+)/i,
 ];

--- a/packages/kosong/src/providers/anthropic.ts
+++ b/packages/kosong/src/providers/anthropic.ts
@@ -222,6 +222,8 @@ const CEILING_BY_FAMILY_VERSION: Readonly<Record<string, number>> = {
 };
 
 const FALLBACK_MAX_TOKENS = 128000;
+/** Conservative fallback for custom endpoints whose actual output ceiling is unknown. */
+const CUSTOM_ENDPOINT_FALLBACK_MAX_TOKENS = 32768;
 
 function lookupClaudeCeiling(version: AnthropicModelVersion): number | undefined {
   const { family, major, minor } = version;
@@ -252,13 +254,22 @@ function lookupClaudeCeiling(version: AnthropicModelVersion): number | undefined
  *      the override is clamped to the documented Messages-API ceiling
  *      so we never send a value the server would reject.
  *   3. With no override and no recognized version, fall back to
- *      {@link FALLBACK_MAX_TOKENS}.
+ *      {@link FALLBACK_MAX_TOKENS} — or the conservative
+ *      {@link CUSTOM_ENDPOINT_FALLBACK_MAX_TOKENS} when `baseUrl` points at a
+ *      custom (non-Anthropic) endpoint, whose actual output ceiling is unknown
+ *      and is most commonly 32768.
  */
-export function resolveDefaultMaxTokens(model: string, override?: number): number {
+export function resolveDefaultMaxTokens(model: string, override?: number, baseUrl?: string): number {
   const parsed = parseAnthropicModelVersion(model, true);
   const ceiling = parsed === null ? undefined : lookupClaudeCeiling(parsed);
   if (ceiling === undefined) {
-    return override ?? FALLBACK_MAX_TOKENS;
+    if (override !== undefined) return override;
+    // Custom endpoint + unrecognized model: the 128k Claude-4 fallback is too
+    // aggressive for most Anthropic-compatible providers (32768 is the most
+    // common ceiling). Use the conservative value; the user can still override
+    // via defaultMaxTokens (max_output_size in config).
+    const isCustomEndpoint = baseUrl !== undefined && baseUrl !== '' && !baseUrl.includes('api.anthropic.com');
+    return isCustomEndpoint ? CUSTOM_ENDPOINT_FALLBACK_MAX_TOKENS : FALLBACK_MAX_TOKENS;
   }
   return override === undefined ? ceiling : Math.min(override, ceiling);
 }
@@ -920,7 +931,7 @@ export class AnthropicChatProvider implements ChatProvider {
     this._client = this._apiKey === undefined ? undefined : this._buildClient(this._apiKey);
     this._explicitMaxTokens = options.defaultMaxTokens !== undefined;
     this._generationKwargs = {
-      max_tokens: options.defaultMaxTokens ?? resolveDefaultMaxTokens(options.model),
+      max_tokens: options.defaultMaxTokens ?? resolveDefaultMaxTokens(options.model, undefined, options.baseUrl),
       betaFeatures: options.betaFeatures ?? [INTERLEAVED_THINKING_BETA],
     };
   }
@@ -1270,7 +1281,7 @@ export class AnthropicChatProvider implements ChatProvider {
   }
 
   withMaxCompletionTokens(maxCompletionTokens: number): AnthropicChatProvider {
-    const requestedCap = resolveDefaultMaxTokens(this._model, maxCompletionTokens);
+    const requestedCap = resolveDefaultMaxTokens(this._model, maxCompletionTokens, this._baseUrl);
     const existingCap = this._generationKwargs.max_tokens;
     const clone = this._withGenerationKwargs({
       max_tokens:

--- a/packages/kosong/test/anthropic.test.ts
+++ b/packages/kosong/test/anthropic.test.ts
@@ -3408,6 +3408,32 @@ describe('resolveDefaultMaxTokens', () => {
     expect(resolveDefaultMaxTokens('vendor-opus-4-7-preview')).toBe(128000);
     expect(resolveDefaultMaxTokens('vendor-opus-4-7-preview', 8000)).toBe(8000);
   });
+
+  it('uses the conservative 32k fallback for a custom endpoint with an unrecognized model', () => {
+    expect(
+      resolveDefaultMaxTokens('some-custom-model', undefined, 'https://ark.cn-beijing.volces.com/api/v3'),
+    ).toBe(32768);
+    expect(resolveDefaultMaxTokens('gpt-5', undefined, 'https://my-proxy.example.test')).toBe(32768);
+  });
+
+  it('keeps the 128k fallback for the official Anthropic endpoint with an unrecognized model', () => {
+    expect(resolveDefaultMaxTokens('gpt-5', undefined, 'https://api.anthropic.com')).toBe(128000);
+    expect(resolveDefaultMaxTokens('totally-unknown-model', undefined, undefined)).toBe(128000);
+  });
+
+  it('still applies the documented ceiling for a Claude model on a custom endpoint', () => {
+    expect(resolveDefaultMaxTokens('claude-opus-4-7', undefined, 'https://my-proxy.example.test')).toBe(
+      128000,
+    );
+    expect(resolveDefaultMaxTokens('claude-3-opus', undefined, 'https://my-proxy.example.test')).toBe(4096);
+  });
+
+  it('honors the user override over the custom-endpoint fallback', () => {
+    expect(resolveDefaultMaxTokens('some-custom-model', 16000, 'https://my-proxy.example.test')).toBe(
+      16000,
+    );
+    expect(resolveDefaultMaxTokens('some-custom-model', 8192, undefined)).toBe(8192);
+  });
 });
 
 describe('AnthropicChatProvider constructor max_tokens', () => {

--- a/packages/kosong/test/errors.test.ts
+++ b/packages/kosong/test/errors.test.ts
@@ -703,6 +703,11 @@ describe('parseMaxTokensLimit', () => {
     ).toBe(4096);
   });
 
+  it('parses the "less than or equal to" and bare "<=" wordings', () => {
+    expect(parseMaxTokensLimit('400 Bad Request: max_tokens must be less than or equal to 4096')).toBe(4096);
+    expect(parseMaxTokensLimit('400 Bad Request: max_tokens <= 2048')).toBe(2048);
+  });
+
   it('returns null for messages without a max_tokens limit', () => {
     expect(parseMaxTokensLimit('400 Bad Request: invalid api key')).toBeNull();
     // A context-overflow message must not be mistaken for a max_tokens ceiling.

--- a/packages/kosong/test/errors.test.ts
+++ b/packages/kosong/test/errors.test.ts
@@ -13,6 +13,7 @@ import {
   isRetryableGenerateError,
   isToolExchangeAdjacencyError,
   normalizeAPIStatusError,
+  parseMaxTokensLimit,
 } from '#/errors';
 import { describe, expect, it } from 'vitest';
 
@@ -676,5 +677,37 @@ describe('isImageFormatError', () => {
     expect(
       isRetryableGenerateError(new APIStatusError(400, 'unsupported image format')),
     ).toBe(false);
+  });
+});
+
+describe('parseMaxTokensLimit', () => {
+  it('parses the volcano / ark "expected a value <= N" wording', () => {
+    expect(
+      parseMaxTokensLimit(
+        '400 {"error":{"code":"InvalidParameter","message":"The parameter max_tokens expected a value <= 32768, got 128000."}}',
+      ),
+    ).toBe(32768);
+  });
+
+  it('parses the generic "must be at most N" wording', () => {
+    expect(parseMaxTokensLimit('400 Bad Request: max_tokens must be at most 8192')).toBe(8192);
+  });
+
+  it('parses the generic "cannot exceed N" wording', () => {
+    expect(parseMaxTokensLimit('400 Bad Request: max_tokens cannot exceed 4096')).toBe(4096);
+  });
+
+  it('parses the Anthropic native "max output tokens is N" wording', () => {
+    expect(
+      parseMaxTokensLimit('max_tokens: claude-3-haiku-20240307 max output tokens is 4096'),
+    ).toBe(4096);
+  });
+
+  it('returns null for messages without a max_tokens limit', () => {
+    expect(parseMaxTokensLimit('400 Bad Request: invalid api key')).toBeNull();
+    // A context-overflow message must not be mistaken for a max_tokens ceiling.
+    expect(
+      parseMaxTokensLimit('prompt is too long: the maximum context length is 200000 tokens'),
+    ).toBeNull();
   });
 });


### PR DESCRIPTION
## Related Issue

Resolve #2062

## Problem

See linked issue.

## What changed

Two-layer fix in both v1 (`packages/kosong`) and v2 (`packages/agent-core-v2`):

**1. Conservative fallback for custom endpoints**

`resolveDefaultMaxTokens` now accepts an optional `baseUrl` parameter. When the endpoint is custom (non-`api.anthropic.com`) and the model isn't a recognized Claude, the fallback drops from 128000 to 32768 — the most common output ceiling among Anthropic-compatible providers. Explicit `defaultMaxTokens` (from `max_output_size` in config) and known Claude ceilings are unaffected.

**2. Error-driven recovery**

When a 400 response mentions a `max_tokens` limit (e.g., `"expected a value <= 32768"`), the new `parseMaxTokensLimit` function extracts the provider's declared ceiling. In the v2 request loop, the completion budget is clamped and the request retried once. The discovered limit is cached per model, so subsequent requests start pre-clamped — each model pays for at most one rejected request.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.
```
