### PR TITLE
fix(session): recover concatenated session index records

### DIFF
--- a/.changeset/recover-concatenated-session-index.md
+++ b/.changeset/recover-concatenated-session-index.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Allow sessions to resume when adjacent index records are missing a newline.

--- a/packages/agent-core-v2/src/app/sessionIndex/legacySessionIndexPersistence.ts
+++ b/packages/agent-core-v2/src/app/sessionIndex/legacySessionIndexPersistence.ts
@@ -1,0 +1,134 @@
+/**
+ * `sessionIndex` domain (L2) — legacy v1 session-index persistence boundary.
+ *
+ * Owns the fixed storage address, UTF-8 physical-line framing, conservative
+ * adjacent-container recovery, and schema projection. The exported names
+ * preserve the existing package-root compatibility surface.
+ */
+
+import { isAbsolute } from 'pathe';
+
+import type { IFileSystemStorageService } from '#/persistence/interface/storage';
+
+export const SESSION_INDEX_SCOPE = '';
+export const SESSION_INDEX_KEY = 'session_index.jsonl';
+const textDecoder = new TextDecoder();
+
+export interface SessionIndexLine {
+  readonly sessionId: string;
+  readonly sessionDir: string;
+  readonly workDir: string;
+}
+
+export async function readSessionIndexEntries(
+  storage: IFileSystemStorageService,
+): Promise<SessionIndexLine[]> {
+  const bytes = await storage.read(SESSION_INDEX_SCOPE, SESSION_INDEX_KEY);
+  if (bytes === undefined) return [];
+  const entries: SessionIndexLine[] = [];
+  for (const physicalLine of textDecoder.decode(bytes).split(/\r?\n/)) {
+    const line = physicalLine.trim();
+    if (line === '') continue;
+    for (const entry of parseRecords(line)) entries.push(entry);
+  }
+  return entries;
+}
+
+export async function readSessionIndexWorkDirs(
+  storage: IFileSystemStorageService,
+): Promise<readonly string[]> {
+  const workDirs: string[] = [];
+  for (const entry of await readSessionIndexEntries(storage)) {
+    if (isAbsolute(entry.workDir)) workDirs.push(entry.workDir);
+  }
+  return workDirs;
+}
+
+export function parseSessionIndexLine(line: string): SessionIndexLine | undefined {
+  try {
+    return entryFromJson(JSON.parse(line) as unknown);
+  } catch {
+    return undefined;
+  }
+}
+
+function parseRecords(line: string): SessionIndexLine[] {
+  const entry = parseSessionIndexLine(line);
+  if (entry !== undefined) return [entry];
+
+  const entries: SessionIndexLine[] = [];
+  for (const candidate of scanJsonContainers(line)) {
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(candidate) as unknown;
+    } catch {
+      break;
+    }
+    const candidateEntry = entryFromJson(parsed);
+    if (candidateEntry !== undefined) entries.push(candidateEntry);
+  }
+  return entries;
+}
+
+function* scanJsonContainers(line: string): Iterable<string> {
+  let offset = 0;
+  while (offset < line.length) {
+    while (offset < line.length && isJsonWhitespace(line[offset]!)) offset++;
+    if (offset >= line.length) return;
+    const opener = line[offset]!;
+    if (opener !== '{' && opener !== '[') return;
+
+    const start = offset;
+    const closers = [opener === '{' ? '}' : ']'];
+    let inString = false;
+    let escaped = false;
+    let completed = false;
+    for (let cursor = offset + 1; cursor < line.length; cursor++) {
+      const char = line[cursor]!;
+      if (inString) {
+        if (escaped) escaped = false;
+        else if (char === '\\') escaped = true;
+        else if (char === '"') inString = false;
+        continue;
+      }
+      if (char === '"') {
+        inString = true;
+        continue;
+      }
+      if (char === '{') closers.push('}');
+      else if (char === '[') closers.push(']');
+      else if (char === '}' || char === ']') {
+        if (closers.at(-1) !== char) return;
+        closers.pop();
+      }
+      if (closers.length === 0) {
+        yield line.slice(start, cursor + 1);
+        offset = cursor + 1;
+        completed = true;
+        break;
+      }
+    }
+    if (!completed) return;
+  }
+}
+
+function isJsonWhitespace(char: string): boolean {
+  return char === ' ' || char === '\t' || char === '\n' || char === '\r';
+}
+
+function entryFromJson(parsed: unknown): SessionIndexLine | undefined {
+  if (typeof parsed !== 'object' || parsed === null) return undefined;
+  const entry = parsed as Record<string, unknown>;
+  if (
+    typeof entry['sessionId'] !== 'string' ||
+    typeof entry['sessionDir'] !== 'string' ||
+    typeof entry['workDir'] !== 'string'
+  ) {
+    return undefined;
+  }
+  return {
+    sessionId: entry['sessionId'],
+    sessionDir: entry['sessionDir'],
+    workDir: entry['workDir'],
+  };
+}

--- a/packages/agent-core-v2/src/app/sessionIndex/legacySessionIndexStore.ts
+++ b/packages/agent-core-v2/src/app/sessionIndex/legacySessionIndexStore.ts
@@ -1,0 +1,20 @@
+/**
+ * `sessionIndex` domain (L2) — private legacy v1 session-index Store contract.
+ *
+ * Exposes an App-scoped, read-only projection of validated legacy entries to
+ * Workspace consumers; the implementation delegates to the domain's legacy
+ * persistence leaf.
+ */
+
+import { createDecorator, type ServiceIdentifier } from '#/_base/di/instantiation';
+
+import type { SessionIndexLine } from './legacySessionIndexPersistence';
+
+export interface ILegacySessionIndexStore {
+  readonly _serviceBrand: undefined;
+
+  readEntries(): Promise<readonly SessionIndexLine[]>;
+}
+
+export const ILegacySessionIndexStore: ServiceIdentifier<ILegacySessionIndexStore> =
+  createDecorator<ILegacySessionIndexStore>('legacySessionIndexStore');

--- a/packages/agent-core-v2/src/app/sessionIndex/legacySessionIndexStoreService.ts
+++ b/packages/agent-core-v2/src/app/sessionIndex/legacySessionIndexStoreService.ts
@@ -1,0 +1,36 @@
+/**
+ * `sessionIndex` domain (L2) — legacy v1 session-index Store implementation.
+ *
+ * Delegates legacy persistence decoding to the domain's persistence leaf.
+ * Depends only on App-scoped filesystem storage and is bound at App scope.
+ */
+
+import { InstantiationType } from '#/_base/di/extensions';
+import { LifecycleScope, registerScopedService } from '#/_base/di/scope';
+import { IFileSystemStorageService } from '#/persistence/interface/storage';
+
+import { ILegacySessionIndexStore } from './legacySessionIndexStore';
+import {
+  readSessionIndexEntries,
+  type SessionIndexLine,
+} from './legacySessionIndexPersistence';
+
+export class LegacySessionIndexStoreService implements ILegacySessionIndexStore {
+  declare readonly _serviceBrand: undefined;
+
+  constructor(
+    @IFileSystemStorageService private readonly storage: IFileSystemStorageService,
+  ) {}
+
+  readEntries(): Promise<readonly SessionIndexLine[]> {
+    return readSessionIndexEntries(this.storage);
+  }
+}
+
+registerScopedService(
+  LifecycleScope.App,
+  ILegacySessionIndexStore,
+  LegacySessionIndexStoreService,
+  InstantiationType.Eager,
+  'sessionIndex',
+);

--- a/packages/agent-core-v2/src/app/workspace/workspaceAlias.ts
+++ b/packages/agent-core-v2/src/app/workspace/workspaceAlias.ts
@@ -6,41 +6,21 @@
  * `encodeWorkDirKey` outputs). These helpers enumerate or collapse those
  * spellings without owning any state: `collectAliasIds` expands one root to
  * every id that addresses it, `dedupeByRoot` collapses a catalog to one
- * representative per directory, and the session-index readers parse the
- * legacy v1 `session_index.jsonl`. Shared by `WorkspaceService` (delete and
+ * representative per directory. Shared by `WorkspaceService` (delete and
  * list) and `WorkspaceAliasesService` (`resolveAliasIds`).
  */
 
-import { isAbsolute } from 'pathe';
-
 import { encodeWorkDirKey, workspaceRootKey } from '#/_base/utils/workdir-slug';
-import type { IFileSystemStorageService } from '#/persistence/interface/storage';
 
 import type { Workspace } from './workspace';
 
-// Legacy v1 session index, read for the one-shot rebuild and for alias
-// folding (session-index-only id spellings). Empty scope resolves to
-// `<homeDir>/<key>` (join skips empty segments).
-export const SESSION_INDEX_SCOPE = '';
-export const SESSION_INDEX_KEY = 'session_index.jsonl';
-
-const textDecoder = new TextDecoder();
-
-export interface SessionIndexLine {
-  readonly sessionId: string;
-  readonly sessionDir: string;
+interface WorkspaceAliasSource {
   readonly workDir: string;
 }
 
-/**
- * Every id identifying `root`'s directory: all registered spellings plus
- * `workDir` spellings recorded only in `session_index.jsonl` (legacy split
- * buckets that were never registered). Read-only — ids/buckets are never
- * rewritten.
- */
 export function collectAliasIds(
   workspaces: readonly Workspace[],
-  sessionIndexEntries: readonly SessionIndexLine[],
+  sessionIndexEntries: readonly WorkspaceAliasSource[],
   root: string,
 ): string[] {
   const rootKey = workspaceRootKey(root);
@@ -54,25 +34,12 @@ export function collectAliasIds(
   for (const ws of workspaces) {
     if (workspaceRootKey(ws.root) === rootKey) add(ws.id);
   }
-  // Legacy split buckets may exist under spellings never registered: fold in
-  // every session-index `workDir` that identifies the same directory.
   for (const line of sessionIndexEntries) {
     if (workspaceRootKey(line.workDir) === rootKey) add(encodeWorkDirKey(line.workDir));
   }
   return ids;
 }
 
-/**
- * Collapse registered workspaces that identify the same directory. The
- * persisted catalog (v1-compatible `workspaces.json`) can hold legacy entries
- * whose id was computed by an older `encodeWorkDirKey` (e.g. realpath-based on
- * Windows) for the same folder, and Windows roots additionally differ by
- * casing or slash spelling, so one directory may map to multiple ids. Entries
- * merge on the `workspaceRootKey` identity key; prefer the entry whose id
- * matches the canonical key computed on its own root string so current
- * sessions' `workspace_id` still resolves and the same folder is not listed
- * twice.
- */
 export function dedupeByRoot(byId: ReadonlyMap<string, Workspace>): Workspace[] {
   const byRoot = new Map<string, Workspace>();
   for (const ws of byId.values()) {
@@ -88,58 +55,4 @@ export function dedupeByRoot(byId: ReadonlyMap<string, Workspace>): Workspace[] 
     }
   }
   return [...byRoot.values()];
-}
-
-/**
- * Parse the legacy v1 session index. Blank and malformed lines are skipped
- * individually so one bad record never fails the whole file (matches the
- * rebuild's tolerance).
- */
-export async function readSessionIndexEntries(
-  storage: IFileSystemStorageService,
-): Promise<SessionIndexLine[]> {
-  const bytes = await storage.read(SESSION_INDEX_SCOPE, SESSION_INDEX_KEY);
-  if (bytes === undefined) return [];
-  const entries: SessionIndexLine[] = [];
-  for (const line of textDecoder.decode(bytes).split(/\r?\n/)) {
-    const trimmed = line.trim();
-    if (trimmed === '') continue;
-    const entry = parseSessionIndexLine(trimmed);
-    if (entry === undefined) continue;
-    entries.push(entry);
-  }
-  return entries;
-}
-
-export async function readSessionIndexWorkDirs(
-  storage: IFileSystemStorageService,
-): Promise<readonly string[]> {
-  const workDirs: string[] = [];
-  for (const entry of await readSessionIndexEntries(storage)) {
-    if (!isAbsolute(entry.workDir)) continue;
-    workDirs.push(entry.workDir);
-  }
-  return workDirs;
-}
-
-export function parseSessionIndexLine(line: string): SessionIndexLine | undefined {
-  try {
-    const parsed = JSON.parse(line) as unknown;
-    if (typeof parsed !== 'object' || parsed === null) return undefined;
-    const entry = parsed as Partial<SessionIndexLine>;
-    if (
-      typeof entry.sessionId !== 'string' ||
-      typeof entry.sessionDir !== 'string' ||
-      typeof entry.workDir !== 'string'
-    ) {
-      return undefined;
-    }
-    return {
-      sessionId: entry.sessionId,
-      sessionDir: entry.sessionDir,
-      workDir: entry.workDir,
-    };
-  } catch {
-    return undefined;
-  }
 }

--- a/packages/agent-core-v2/src/app/workspace/workspaceService.ts
+++ b/packages/agent-core-v2/src/app/workspace/workspaceService.ts
@@ -15,7 +15,7 @@
  * still lost there.
  *
  * Once per process, the first operation triggers the startup sync with the
- * legacy `<homeDir>/session_index.jsonl`:
+ * legacy v1 session index through `ILegacySessionIndexStore`:
  *
  * 1. No usable catalog file → one-shot rebuild (one workspace per distinct
  *    absolute `workDir`), persisted.
@@ -63,17 +63,12 @@ import { basename, isAbsolute } from 'pathe';
 import { InstantiationType } from '#/_base/di/extensions';
 import { LifecycleScope, registerScopedService } from '#/_base/di/scope';
 import { encodeWorkDirKey, workspaceRootKey } from '#/_base/utils/workdir-slug';
+import { ILegacySessionIndexStore } from '#/app/sessionIndex/legacySessionIndexStore';
 import { ErrorCodes, Error2, unwrapErrorCause } from '#/errors';
 import { IHostFileSystem } from '#/os/interface/hostFileSystem';
-import { IFileSystemStorageService } from '#/persistence/interface/storage';
 
 import { IWorkspaceService, type Workspace, type WorkspaceUpdate } from './workspace';
-import {
-  collectAliasIds,
-  dedupeByRoot,
-  readSessionIndexEntries,
-  readSessionIndexWorkDirs,
-} from './workspaceAlias';
+import { collectAliasIds, dedupeByRoot } from './workspaceAlias';
 import { IWorkspacePersistence, type WorkspaceCatalog } from './workspacePersistence';
 
 export class WorkspaceService implements IWorkspaceService {
@@ -85,7 +80,7 @@ export class WorkspaceService implements IWorkspaceService {
 
   constructor(
     @IWorkspacePersistence private readonly store: IWorkspacePersistence,
-    @IFileSystemStorageService private readonly storage: IFileSystemStorageService,
+    @ILegacySessionIndexStore private readonly legacySessionIndex: ILegacySessionIndexStore,
     @IHostFileSystem private readonly hostFs: IHostFileSystem,
   ) {}
 
@@ -194,14 +189,11 @@ export class WorkspaceService implements IWorkspaceService {
       // aliases must die with it — a sibling spelling left registered (or
       // resurrectable from the session index) would resurface as this
       // directory's representative on the next list().
+      const sessionIndexEntries = await this.legacySessionIndex.readEntries();
       let root = catalog.workspaces.find((ws) => ws.id === id)?.root;
-      if (root === undefined) {
-        // Derived/unknown id: recover its spelling from the session index so
-        // the whole alias set can still be tombstoned.
-        root = (await readSessionIndexEntries(this.storage)).find(
-          (line) => encodeWorkDirKey(line.workDir) === id,
-        )?.workDir;
-      }
+      root ??= sessionIndexEntries.find(
+        (line) => encodeWorkDirKey(line.workDir) === id,
+      )?.workDir;
       if (root === undefined) {
         await this.store.save({
           workspaces: catalog.workspaces.filter((ws) => ws.id !== id),
@@ -210,11 +202,7 @@ export class WorkspaceService implements IWorkspaceService {
         return;
       }
       const rootKey = workspaceRootKey(root);
-      const aliasIds = collectAliasIds(
-        catalog.workspaces,
-        await readSessionIndexEntries(this.storage),
-        root,
-      );
+      const aliasIds = collectAliasIds(catalog.workspaces, sessionIndexEntries, root);
       await this.store.save({
         workspaces: catalog.workspaces.filter((ws) => workspaceRootKey(ws.root) !== rootKey),
         deletedIds: [...new Set([...catalog.deletedIds, ...aliasIds])],
@@ -257,7 +245,8 @@ export class WorkspaceService implements IWorkspaceService {
   ): Promise<boolean> {
     let changed = false;
     const now = Date.now();
-    for (const workDir of await readSessionIndexWorkDirs(this.storage)) {
+    for (const { workDir } of await this.legacySessionIndex.readEntries()) {
+      if (!isAbsolute(workDir)) continue;
       const id = encodeWorkDirKey(workDir);
       if (byId.has(id) || deletedIds.has(id)) continue;
       byId.set(id, {
@@ -279,7 +268,7 @@ export class WorkspaceService implements IWorkspaceService {
     // directory (Windows) collapse here too. First seen wins — the id stays
     // `encodeWorkDirKey` of that first-seen workDir string.
     const seenRootKeys = new Set<string>();
-    for (const entry of await readSessionIndexEntries(this.storage)) {
+    for (const entry of await this.legacySessionIndex.readEntries()) {
       if (!isAbsolute(entry.workDir)) continue;
       const rootKey = workspaceRootKey(entry.workDir);
       if (seenRootKeys.has(rootKey)) continue;

--- a/packages/agent-core-v2/src/app/workspaceAliases/workspaceAliasesService.ts
+++ b/packages/agent-core-v2/src/app/workspaceAliases/workspaceAliasesService.ts
@@ -3,25 +3,22 @@
  *
  * Resolves every id spelling of one physical directory by folding the
  * registered catalog (by `workspaceRootKey`) together with `workDir`
- * spellings recorded only in the legacy `session_index.jsonl`, through the
- * shared `workspaceAlias` helpers. The catalog is reached through
- * `IWorkspaceService.get` first — its once-per-process session-index sync
- * (`ensureMerged`) must have run before the raw catalog is read from
- * `IWorkspacePersistence` — and the raw (un-deduped) catalog is required
- * because `IWorkspaceService.list` collapses sibling spellings to one
- * representative, which would defeat the alias enumeration. Read-only: no id
- * or bucket is ever rewritten here. Bound at App scope.
+ * spellings recorded only in the legacy v1 session index, through
+ * `ILegacySessionIndexStore` and the pure `workspaceAlias` helpers. The
+ * catalog is reached through `IWorkspaceService.get` first: its
+ * once-per-process session-index sync (`ensureMerged`) must have run before
+ * the raw catalog is read from `IWorkspacePersistence`. The raw, un-deduped
+ * catalog is required because `IWorkspaceService.list` collapses sibling
+ * spellings to one representative, which would defeat alias enumeration.
+ * Read-only; bound at App scope.
  */
 
 import { InstantiationType } from '#/_base/di/extensions';
 import { LifecycleScope, registerScopedService } from '#/_base/di/scope';
+import { ILegacySessionIndexStore } from '#/app/sessionIndex/legacySessionIndexStore';
 import { IWorkspaceService } from '#/app/workspace/workspace';
-import {
-  collectAliasIds,
-  readSessionIndexEntries,
-} from '#/app/workspace/workspaceAlias';
+import { collectAliasIds } from '#/app/workspace/workspaceAlias';
 import { IWorkspacePersistence } from '#/app/workspace/workspacePersistence';
-import { IFileSystemStorageService } from '#/persistence/interface/storage';
 
 import { IWorkspaceAliases } from './workspaceAliases';
 
@@ -31,19 +28,16 @@ export class WorkspaceAliasesService implements IWorkspaceAliases {
   constructor(
     @IWorkspaceService private readonly workspaces: IWorkspaceService,
     @IWorkspacePersistence private readonly store: IWorkspacePersistence,
-    @IFileSystemStorageService private readonly storage: IFileSystemStorageService,
+    @ILegacySessionIndexStore private readonly legacySessionIndex: ILegacySessionIndexStore,
   ) {}
 
   async resolveAliasIds(id: string): Promise<readonly string[]> {
-    // Goes through the workspace service so the once-per-process session-index
-    // sync has run before the raw catalog is read below.
     const entry = await this.workspaces.get(id);
-    // Unknown ids stay singletons so callers keep their not-found semantics.
     if (entry === undefined) return [id];
     const catalog = (await this.store.load()) ?? { workspaces: [], deletedIds: [] };
     return collectAliasIds(
       catalog.workspaces,
-      await readSessionIndexEntries(this.storage),
+      await this.legacySessionIndex.readEntries(),
       entry.root,
     );
   }

--- a/packages/agent-core-v2/src/index.ts
+++ b/packages/agent-core-v2/src/index.ts
@@ -3,6 +3,8 @@
  * layer) so importing the package loads all scoped-registry registrations.
  */
 
+import '#/app/sessionIndex/legacySessionIndexStoreService';
+
 export * from '#/_base/di/descriptors';
 export * from '#/_base/di/errors';
 export * from '#/_base/di/extensions';
@@ -75,6 +77,14 @@ export type {
   KimiThinkingConfig,
 } from '#/kosong/provider/providers/kimi/kimi.contrib';
 
+export {
+  SESSION_INDEX_KEY,
+  SESSION_INDEX_SCOPE,
+  parseSessionIndexLine,
+  readSessionIndexEntries,
+  readSessionIndexWorkDirs,
+  type SessionIndexLine,
+} from '#/app/sessionIndex/legacySessionIndexPersistence';
 export * from '#/app/sessionIndex/sessionIndex';
 export * from '#/app/sessionIndex/sessionIndexService';
 export * from '#/session/sessionMetadata/sessionMetadata';

--- a/packages/agent-core-v2/test/app/sessionIndex/legacySessionIndexStore.test.ts
+++ b/packages/agent-core-v2/test/app/sessionIndex/legacySessionIndexStore.test.ts
@@ -1,0 +1,114 @@
+/**
+ * Scenario: legacy session-index bytes are projected through the private App
+ * Store.
+ * Responsibilities: enforce physical-line recovery and the schema trust boundary.
+ * Wiring: flat DI with the production Store and an in-memory storage backend.
+ * Run from packages/agent-core-v2:
+ *   pnpm exec vitest run test/app/sessionIndex/legacySessionIndexStore.test.ts
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { DisposableStore } from '#/_base/di/lifecycle';
+import { createServices, type TestInstantiationService } from '#/_base/di/test';
+import { ILegacySessionIndexStore } from '#/app/sessionIndex/legacySessionIndexStore';
+import { LegacySessionIndexStoreService } from '#/app/sessionIndex/legacySessionIndexStoreService';
+import {
+  SESSION_INDEX_KEY,
+  SESSION_INDEX_SCOPE,
+  type SessionIndexLine,
+} from '#/app/sessionIndex/legacySessionIndexPersistence';
+import { InMemoryStorageService } from '#/persistence/backends/memory/inMemoryStorageService';
+import { IFileSystemStorageService } from '#/persistence/interface/storage';
+
+const textEncoder = new TextEncoder();
+
+function entry(sessionId: string, workDir = `/tmp/${sessionId}`): SessionIndexLine {
+  return {
+    sessionId,
+    sessionDir: `sessions/example/${sessionId}`,
+    workDir,
+  };
+}
+
+describe('LegacySessionIndexStoreService', () => {
+  let disposables: DisposableStore;
+  let ix: TestInstantiationService;
+  let storage: InMemoryStorageService;
+
+  beforeEach(() => {
+    disposables = new DisposableStore();
+    storage = new InMemoryStorageService();
+    ix = createServices(disposables, {
+      additionalServices: (reg) => {
+        reg.defineInstance(IFileSystemStorageService, storage);
+        reg.define(ILegacySessionIndexStore, LegacySessionIndexStoreService);
+      },
+    });
+  });
+
+  afterEach(() => {
+    disposables.dispose();
+  });
+
+  function store(): ILegacySessionIndexStore {
+    return ix.get(ILegacySessionIndexStore);
+  }
+
+  async function seed(raw: string): Promise<void> {
+    await storage.write(SESSION_INDEX_SCOPE, SESSION_INDEX_KEY, textEncoder.encode(raw));
+  }
+
+  it('recovers adjacent records with nested containers and escaped strings', async () => {
+    const first = {
+      ...entry('first', '/tmp/项目-}{-"quoted"-\\'),
+      ignored: { nested: [{ value: 'still }{ inside a string' }] },
+    };
+    const second = entry('second');
+    await seed(`${JSON.stringify(first)}${JSON.stringify(second)}`);
+
+    await expect(store().readEntries()).resolves.toEqual([
+      entry('first', '/tmp/项目-}{-"quoted"-\\'),
+      second,
+    ]);
+  });
+
+  it('stops at garbage or malformed JSON within each physical line', async () => {
+    const first = entry('before-garbage');
+    const second = entry('before-malformed');
+    await seed(
+      `${JSON.stringify(first)}garbage${JSON.stringify(entry('after-garbage'))}\n` +
+        `${JSON.stringify(second)}{"sessionId":}${JSON.stringify(entry('after-malformed'))}`,
+    );
+
+    await expect(store().readEntries()).resolves.toEqual([first, second]);
+  });
+
+  it('continues at the next physical line after a truncated adjacent record', async () => {
+    const first = entry('complete-prefix');
+    const second = entry('next-line');
+    await seed(
+      `${JSON.stringify(first)}{"sessionId":"truncated\r\n${JSON.stringify(second)}\r\n`,
+    );
+
+    await expect(store().readEntries()).resolves.toEqual([first, second]);
+  });
+
+  it('skips complete schema-invalid containers and continues scanning', async () => {
+    const first = entry('before-invalid-schema');
+    const second = entry('after-invalid-schema');
+    await seed(`${JSON.stringify(first)}{}[]${JSON.stringify(second)}`);
+
+    await expect(store().readEntries()).resolves.toEqual([first, second]);
+  });
+
+  it('reaches the final record in a large concatenated physical line', async () => {
+    const repeated = JSON.stringify(entry('repeated'));
+    const final = entry('final');
+    await seed(`${repeated.repeat(150_000)}${JSON.stringify(final)}`);
+
+    const entries = await store().readEntries();
+    expect(entries).toHaveLength(150_001);
+    expect(entries.at(-1)).toEqual(final);
+  });
+});

--- a/packages/agent-core-v2/test/app/workspace/workspaceService.test.ts
+++ b/packages/agent-core-v2/test/app/workspace/workspaceService.test.ts
@@ -12,6 +12,8 @@ import {
 } from '#/_base/di/scope';
 import { createScopedTestHost, stubPair } from '#/_base/di/test';
 import { encodeWorkDirKey, workspaceRootKey } from '#/_base/utils/workdir-slug';
+import { ILegacySessionIndexStore } from '#/app/sessionIndex/legacySessionIndexStore';
+import { LegacySessionIndexStoreService } from '#/app/sessionIndex/legacySessionIndexStoreService';
 import { ErrorCodes, Error2 } from '#/errors';
 import { HostFileSystem } from '#/os/backends/node-local/hostFsService';
 import { IHostFileSystem } from '#/os/interface/hostFileSystem';
@@ -36,6 +38,13 @@ describe('WorkspaceService (file-backed)', () => {
 
   beforeEach(async () => {
     _clearScopedRegistryForTests();
+    registerScopedService(
+      LifecycleScope.App,
+      ILegacySessionIndexStore,
+      LegacySessionIndexStoreService,
+      InstantiationType.Eager,
+      'sessionIndex',
+    );
     registerScopedService(
       LifecycleScope.App,
       IWorkspacePersistence,

--- a/packages/agent-core-v2/test/app/workspaceAliases/workspaceAliasesService.test.ts
+++ b/packages/agent-core-v2/test/app/workspaceAliases/workspaceAliasesService.test.ts
@@ -1,3 +1,9 @@
+/**
+ * Scenario: workspace aliases remain addressable across legacy index spellings.
+ * Responsibilities: resolve registered and index-only aliases through the App-scoped service.
+ * Wiring: file-backed workspace persistence plus a stub legacy-index Store.
+ * Run: pnpm vitest run packages/agent-core-v2/test/app/workspaceAliases/workspaceAliasesService.test.ts
+ */
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 import { promises as fsp } from 'node:fs';
@@ -12,6 +18,7 @@ import {
 } from '#/_base/di/scope';
 import { createScopedTestHost, stubPair } from '#/_base/di/test';
 import { encodeWorkDirKey } from '#/_base/utils/workdir-slug';
+import { ILegacySessionIndexStore } from '#/app/sessionIndex/legacySessionIndexStore';
 import { HostFileSystem } from '#/os/backends/node-local/hostFsService';
 import { IHostFileSystem } from '#/os/interface/hostFileSystem';
 import { JsonAtomicDocumentStore } from '#/persistence/backends/node-fs/atomicDocumentStore';
@@ -36,6 +43,7 @@ interface SessionIndexLine {
 
 describe('WorkspaceAliasesService (file-backed)', () => {
   let homeDir: string;
+  let sessionIndexEntries: readonly SessionIndexLine[];
   let currentHost: ReturnType<typeof createScopedTestHost> | undefined;
 
   beforeEach(async () => {
@@ -62,6 +70,7 @@ describe('WorkspaceAliasesService (file-backed)', () => {
       'workspaceAliases',
     );
     homeDir = await fsp.mkdtemp(join(os.tmpdir(), 'ws-aliases-'));
+    sessionIndexEntries = [];
   });
 
   afterEach(async () => {
@@ -76,14 +85,13 @@ describe('WorkspaceAliasesService (file-backed)', () => {
       stubPair(IFileSystemStorageService, fileStorage),
       stubPair(IAtomicDocumentStore, new JsonAtomicDocumentStore(fileStorage)),
       stubPair(IHostFileSystem, hostFs),
+      stubPair(ILegacySessionIndexStore, {
+        _serviceBrand: undefined,
+        readEntries: () => Promise.resolve(sessionIndexEntries),
+      }),
     ]);
     currentHost = host;
     return host.app.accessor.get(IWorkspaceAliases);
-  }
-
-  async function seedSessionIndex(entries: SessionIndexLine[]): Promise<void> {
-    const text = `${entries.map((e) => JSON.stringify(e)).join('\n')}\n`;
-    await fsp.writeFile(join(homeDir, 'session_index.jsonl'), text, 'utf8');
   }
 
   async function writeWorkspacesJson(
@@ -125,9 +133,8 @@ describe('WorkspaceAliasesService (file-backed)', () => {
   });
 
   it('resolveAliasIds folds in session-index-only spellings of the same root', async () => {
-    // The sibling bucket's spelling was never registered: only the legacy
-    // session index remembers it. Malformed index lines are skipped, never
-    // thrown.
+    // Trigger the one-shot workspace merge before the sibling spelling appears.
+    // The later lookup must therefore read it from the live legacy-index Store.
     const typedRoot = 'C:\\Users\\Foo\\Proj';
     const typedId = encodeWorkDirKey(typedRoot);
     const indexOnlyId = encodeWorkDirKey('c:\\Users\\Foo\\Proj');
@@ -139,14 +146,14 @@ describe('WorkspaceAliasesService (file-backed)', () => {
         last_opened_at: '2026-01-01T00:00:00.000Z',
       },
     });
-    await seedSessionIndex([
+    const aliases = build();
+    await expect(aliases.resolveAliasIds(typedId)).resolves.toEqual([typedId]);
+
+    sessionIndexEntries = [
       { sessionId: 's1', sessionDir: 'sessions/a/s1', workDir: typedRoot },
       { sessionId: 's2', sessionDir: 'sessions/b/s2', workDir: 'c:\\Users\\Foo\\Proj' },
       { sessionId: 's3', sessionDir: 'sessions/c/s3', workDir: join(homeDir, 'unrelated') },
-    ]);
-    await fsp.appendFile(join(homeDir, 'session_index.jsonl'), 'not-json\n{}\n', 'utf8');
-
-    const aliases = build();
+    ];
     expect((await aliases.resolveAliasIds(typedId)).toSorted()).toEqual(
       [typedId, indexOnlyId].toSorted(),
     );

--- a/packages/agent-core/src/session/store/session-index.ts
+++ b/packages/agent-core/src/session/store/session-index.ts
@@ -73,52 +73,112 @@ export async function readSessionIndex(
   for (const line of raw.split(/\r?\n/)) {
     const trimmed = line.trim();
     if (trimmed === '') continue;
-    const record = parseIndexLine(trimmed);
-    if (record === undefined) continue;
-    if ('deleted' in record) {
-      result.delete(record.sessionId);
-      continue;
+    for (const record of parseIndexRecords(trimmed)) {
+      if ('deleted' in record) {
+        result.delete(record.sessionId);
+        continue;
+      }
+      const entry = record;
+      const sessionDir = normalizeWorkDir(entry.sessionDir);
+      if (!isAbsolute(entry.sessionDir)) continue;
+      if (!isPathInside(sessionsDir, sessionDir)) continue;
+      if (basename(sessionDir) !== entry.sessionId) continue;
+      // `workDir` is no longer authoritative: summaries prefer the workDir stored
+      // in each session's self-describing state.json, so a stale or relocated
+      // index workDir must not drop an otherwise valid entry.
+      result.set(entry.sessionId, {
+        sessionId: entry.sessionId,
+        sessionDir,
+        workDir: entry.workDir,
+      });
     }
-    const entry = record;
-    const sessionDir = normalizeWorkDir(entry.sessionDir);
-    if (!isAbsolute(entry.sessionDir)) continue;
-    if (!isPathInside(sessionsDir, sessionDir)) continue;
-    if (basename(sessionDir) !== entry.sessionId) continue;
-    // `workDir` is no longer authoritative: summaries prefer the workDir stored
-    // in each session's self-describing state.json, so a stale or relocated
-    // index workDir must not drop an otherwise valid entry.
-    result.set(entry.sessionId, {
-      sessionId: entry.sessionId,
-      sessionDir,
-      workDir: entry.workDir,
-    });
   }
   return result;
 }
 
+function parseIndexRecords(line: string): SessionIndexRecord[] {
+  const record = parseIndexLine(line);
+  if (record !== undefined) return [record];
+
+  const records: SessionIndexRecord[] = [];
+  for (const candidate of scanJsonContainers(line)) {
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(candidate) as unknown;
+    } catch {
+      break;
+    }
+    const candidateRecord = indexRecordFromJson(parsed);
+    if (candidateRecord !== undefined) records.push(candidateRecord);
+  }
+  return records;
+}
+
+function* scanJsonContainers(line: string): Iterable<string> {
+  let offset = 0;
+  while (offset < line.length) {
+    while (offset < line.length && /[\t\n\r ]/.test(line[offset]!)) offset++;
+    if (offset >= line.length) return;
+    const opener = line[offset]!;
+    if (opener !== '{' && opener !== '[') return;
+
+    const start = offset;
+    const closers = [opener === '{' ? '}' : ']'];
+    let inString = false;
+    let escaped = false;
+    let completed = false;
+    for (let cursor = offset + 1; cursor < line.length; cursor++) {
+      const char = line[cursor]!;
+      if (inString) {
+        if (escaped) escaped = false;
+        else if (char === '\\') escaped = true;
+        else if (char === '"') inString = false;
+        continue;
+      }
+      if (char === '"') {
+        inString = true;
+        continue;
+      }
+      if (char === '{') closers.push('}');
+      else if (char === '[') closers.push(']');
+      else if (char === '}' || char === ']') {
+        if (closers.at(-1) !== char) return;
+        closers.pop();
+      }
+      if (closers.length === 0) {
+        yield line.slice(start, cursor + 1);
+        offset = cursor + 1;
+        completed = true;
+        break;
+      }
+    }
+    if (!completed) return;
+  }
+}
+
 function parseIndexLine(line: string): SessionIndexRecord | undefined {
   try {
-    const parsed = JSON.parse(line) as unknown;
-    if (typeof parsed !== 'object' || parsed === null) return undefined;
-    const entry = parsed as Partial<SessionIndexEntry & SessionIndexDeletion>;
-    if (typeof entry.sessionId !== 'string') return undefined;
-    if (entry.deleted === true) {
-      return { sessionId: entry.sessionId, deleted: true };
-    }
-    if (
-      typeof entry.sessionDir !== 'string' ||
-      typeof entry.workDir !== 'string'
-    ) {
-      return undefined;
-    }
-    return {
-      sessionId: entry.sessionId,
-      sessionDir: entry.sessionDir,
-      workDir: entry.workDir,
-    };
+    return indexRecordFromJson(JSON.parse(line) as unknown);
   } catch {
     return undefined;
   }
+}
+
+function indexRecordFromJson(parsed: unknown): SessionIndexRecord | undefined {
+  if (typeof parsed !== 'object' || parsed === null) return undefined;
+  const entry = parsed as Partial<SessionIndexEntry & SessionIndexDeletion>;
+  if (typeof entry.sessionId !== 'string') return undefined;
+  if (entry.deleted === true) {
+    return { sessionId: entry.sessionId, deleted: true };
+  }
+  if (typeof entry.sessionDir !== 'string' || typeof entry.workDir !== 'string') {
+    return undefined;
+  }
+  return {
+    sessionId: entry.sessionId,
+    sessionDir: entry.sessionDir,
+    workDir: entry.workDir,
+  };
 }
 
 function isPathInside(parent: string, child: string): boolean {

--- a/packages/agent-core/test/session/store.test.ts
+++ b/packages/agent-core/test/session/store.test.ts
@@ -230,6 +230,103 @@ describe('SessionStore', () => {
   });
 
   describe('readSessionIndex', () => {
+    it('keeps adjacent entries when their newline separator is missing', async () => {
+      // Delimiter-like text and an escaped quote in a field must not be mistaken
+      // for the boundary between the two top-level records.
+      const firstWorkDir = await trackWorkDir('concatenated-first');
+      const firstIndexWorkDir = `${firstWorkDir}}{-"quoted`;
+      const secondWorkDir = await trackWorkDir('concatenated-second');
+      const firstSessionId = 'session_concatenated_first';
+      const secondSessionId = 'session_concatenated_second';
+      const firstSessionDir = await seedSessionDir(homeDir, firstWorkDir, firstSessionId);
+      const secondSessionDir = await seedSessionDir(homeDir, secondWorkDir, secondSessionId);
+
+      await writeFile(
+        join(homeDir, 'session_index.jsonl'),
+        `${JSON.stringify({
+          sessionId: firstSessionId,
+          sessionDir: firstSessionDir,
+          workDir: firstIndexWorkDir,
+          ignored: { delimiter: '}{', nested: [{ closingBracket: ']' }] },
+        })}${JSON.stringify({
+          sessionId: secondSessionId,
+          sessionDir: secondSessionDir,
+          workDir: secondWorkDir,
+        })}\n`,
+        'utf-8',
+      );
+
+      await expect(store.get(firstSessionId)).resolves.toMatchObject({ id: firstSessionId });
+      await expect(store.get(secondSessionId)).resolves.toMatchObject({ id: secondSessionId });
+    });
+
+    it('keeps complete entries before a truncated adjacent record', async () => {
+      const workDir = await trackWorkDir('truncated-tail');
+      const sessionId = 'session_before_truncated_tail';
+      const sessionDir = await seedSessionDir(homeDir, workDir, sessionId);
+      await writeFile(
+        join(homeDir, 'session_index.jsonl'),
+        `${JSON.stringify({ sessionId, sessionDir, workDir })}{"sessionId":"truncated`,
+        'utf-8',
+      );
+
+      await expect(store.get(sessionId)).resolves.toMatchObject({ id: sessionId });
+    });
+
+    it('recovers only the complete prefix before garbage on the same line', async () => {
+      const firstWorkDir = await trackWorkDir('before-garbage');
+      const skippedWorkDir = await trackWorkDir('after-garbage');
+      const firstSessionId = 'session_before_garbage';
+      const skippedSessionId = 'session_after_garbage';
+      const firstSessionDir = await seedSessionDir(homeDir, firstWorkDir, firstSessionId);
+      const skippedSessionDir = await seedSessionDir(homeDir, skippedWorkDir, skippedSessionId);
+      const entry = (sessionId: string, sessionDir: string, workDir: string): string =>
+        JSON.stringify({ sessionId, sessionDir, workDir });
+      await writeFile(
+        join(homeDir, 'session_index.jsonl'),
+        `${entry(firstSessionId, firstSessionDir, firstWorkDir)}garbage${entry(
+          skippedSessionId,
+          skippedSessionDir,
+          skippedWorkDir,
+        )}\n`,
+        'utf-8',
+      );
+
+      const index = await readSessionIndex(homeDir, store.sessionsDir);
+      expect(index.has(firstSessionId)).toBe(true);
+      expect(index.has(skippedSessionId)).toBe(false);
+    });
+
+    it('continues reading valid records after a corrupted physical line', async () => {
+      const workDir = await trackWorkDir('after-corrupted-line');
+      const sessionId = 'session_after_corrupted_line';
+      const sessionDir = await seedSessionDir(homeDir, workDir, sessionId);
+      await writeFile(
+        join(homeDir, 'session_index.jsonl'),
+        `garbage\n${JSON.stringify({ sessionId, sessionDir, workDir })}\n`,
+        'utf-8',
+      );
+
+      const index = await readSessionIndex(homeDir, store.sessionsDir);
+      expect(index.has(sessionId)).toBe(true);
+    });
+
+    it('applies a deletion record concatenated after its live entry', async () => {
+      const workDir = await trackWorkDir('concatenated-deletion');
+      const sessionId = 'session_concatenated_deletion';
+      const sessionDir = await seedSessionDir(homeDir, workDir, sessionId);
+      await writeFile(
+        join(homeDir, 'session_index.jsonl'),
+        `${JSON.stringify({ sessionId, sessionDir, workDir })}${JSON.stringify({
+          sessionId,
+          deleted: true,
+        })}\n`,
+        'utf-8',
+      );
+
+      expect((await readSessionIndex(homeDir, store.sessionsDir)).has(sessionId)).toBe(false);
+    });
+
     it('keeps an entry whose index workDir is non-absolute, using state.json workDir', async () => {
       const workDir = await trackWorkDir('relaxed');
       const sessionId = 'session_relaxed';

--- a/packages/node-sdk/test/session-plan-compact-usage-resume.test.ts
+++ b/packages/node-sdk/test/session-plan-compact-usage-resume.test.ts
@@ -1,3 +1,7 @@
+// Exercises public session lifecycle APIs through the real in-process harness and
+// local persistence; the configured model endpoint is never contacted.
+// Run: pnpm vitest run packages/node-sdk/test/session-plan-compact-usage-resume.test.ts
+
 import { mkdir, readFile, readdir, writeFile } from 'node:fs/promises';
 import { dirname, join } from 'node:path';
 
@@ -154,6 +158,52 @@ describe('Session plan, compact, usage, and resume APIs', () => {
       expect(harness.getSession(created.id)).toBe(resumed);
     } finally {
       await harness.close();
+    }
+  });
+
+  it('resumes both persisted sessions when adjacent index records have no newline', async () => {
+    const homeDir = await makeTempDir(tempDirs, 'kimi-sdk-resume-index-home-');
+    const firstWorkDir = await makeTempDir(tempDirs, 'kimi-sdk-resume-index-work-');
+    const secondWorkDir = await makeTempDir(tempDirs, 'kimi-sdk-resume-index-work-');
+    const createdHarness = createKimiHarness({ homeDir, identity: TEST_IDENTITY });
+
+    try {
+      await createdHarness.createSession({
+        id: 'ses_resume_index_first',
+        workDir: firstWorkDir,
+      });
+      await createdHarness.createSession({
+        id: 'ses_resume_index_second',
+        workDir: secondWorkDir,
+      });
+    } finally {
+      await createdHarness.close();
+    }
+
+    const indexPath = join(homeDir, 'session_index.jsonl');
+    const records = (await readFile(indexPath, 'utf-8'))
+      .split(/\r?\n/)
+      .filter((line) => line.length > 0);
+    if (records.length !== 2) {
+      throw new Error(`expected two session index records, received ${records.length}`);
+    }
+    await writeFile(indexPath, `${records.join('')}\n`, 'utf-8');
+
+    const resumedHarness = createKimiHarness({ homeDir, identity: TEST_IDENTITY });
+    try {
+      const first = await resumedHarness.resumeSession({ id: 'ses_resume_index_first' });
+      const second = await resumedHarness.resumeSession({ id: 'ses_resume_index_second' });
+
+      expect([first.id, second.id]).toEqual([
+        'ses_resume_index_first',
+        'ses_resume_index_second',
+      ]);
+      expect([first.workDir, second.workDir]).toEqual([
+        toPosix(firstWorkDir),
+        toPosix(secondWorkDir),
+      ]);
+    } finally {
+      await resumedHarness.close();
     }
   });
 


### PR DESCRIPTION
## Related Issue

Resolve #1925

## Problem

If two `session_index.jsonl` records lose their newline separator, the reader drops both as invalid JSON. The session directory remains intact, but resume returns `session.not_found`.

The writer-side trigger is still unknown, so this change is limited to read-time recovery.

## What changed

- Keep `JSON.parse` as the single-record fast path. On failure, scan adjacent JSON containers with correct nesting, string, and escape handling.
- Apply complete records in file order through the existing path checks. Stop at malformed data, then continue with the next physical line.
- Put the v2 compatibility reader behind a private App-scoped Store. Workspace services consume validated entries and no longer know about bytes or JSONL framing.

```mermaid
flowchart LR
  I[session_index.jsonl] --> V1[v1 SessionStore reader]
  I --> S[v2 legacy-index Store]
  S --> W[Workspace services]
```

Here `A` and `B` are complete records:

| Input | Recovered |
| --- | --- |
| `A\nB` | `A`, `B` |
| `AB` | `A`, `B` |
| `A` + truncated `B` | `A` |
| `A` + garbage + `B` | `A` |

Recovery does not rewrite the index.

## Validation

- v1: 31 focused and 3,983 full-suite tests passed.
- v2: 33 focused and 3,960 full-suite tests passed, including a 150,000-record line.
- Public SDK resume regression: 8 passed, 1 todo. Full node-sdk suite: 231 passed, 1 todo.
- Three package typechecks, v2 domain lint, type-aware lint, klient smoke, changeset status, and `git diff --check` passed.

The original Windows writer-side trigger was not reproduced. Tests use the missing-separator shape from the issue.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.
