### PR TITLE
fix(kap-server): cache successful password verification

### DIFF
--- a/.changeset/cache-password-verification.md
+++ b/.changeset/cache-password-verification.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Cache recent successful server password checks to avoid repeating bcrypt work for every authenticated request.

--- a/packages/kap-server/src/services/auth/authTokenService.ts
+++ b/packages/kap-server/src/services/auth/authTokenService.ts
@@ -7,13 +7,14 @@
  * fixed-token impl via `startServer({ serviceOverrides })`, and so `start.ts`
  * (M5.1) can wire the real async-built instance at boot.
  *
- * `isValid` is async because password verification (`bcrypt.compare`) is
- * async — the token path is synchronous, but the interface must await both.
+ * `isValid` is async because a password cache miss runs `bcrypt.compare`.
+ * Persistent-token and cached-password checks remain fast behind the same
+ * interface.
  */
 
 import { createDecorator } from '@moonshot-ai/agent-core-v2';
 
-import { verifyPassword } from './password';
+import { createPasswordVerifier } from './password';
 import type { TokenStore } from './tokenStore';
 
 export interface IAuthTokenService {
@@ -24,8 +25,8 @@ export interface IAuthTokenService {
 
   /**
    * True when `candidate` matches the persistent token OR verifies against the
-   * configured password hash. Constant-time on the token path; bcrypt on the
-   * password path.
+   * configured password hash. Constant-time on the token path; bcrypt on a
+   * password-cache miss.
    */
   isValid(candidate: string): Promise<boolean>;
 }
@@ -46,11 +47,13 @@ export function createAuthTokenService(deps: {
   readonly tokenStore: TokenStore;
   readonly passwordHash: string | undefined;
 }): IAuthTokenService {
+  const passwordVerifier = createPasswordVerifier(deps.passwordHash);
   return {
     _serviceBrand: undefined,
     getToken: () => deps.tokenStore.getToken(),
-    isValid: async (candidate) =>
-      deps.tokenStore.isValid(candidate) ||
-      (await verifyPassword(candidate, deps.passwordHash)),
+    isValid: async (candidate) => {
+      if (deps.tokenStore.isValid(candidate)) return true;
+      return passwordVerifier(candidate);
+    },
   };
 }

--- a/packages/kap-server/src/services/auth/credentials.ts
+++ b/packages/kap-server/src/services/auth/credentials.ts
@@ -31,10 +31,9 @@ export function createCredentialValidator(
   rpcToken?: string,
 ): CredentialValidator {
   return async (candidate) => {
-    if (await authTokenService.isValid(candidate)) return true;
     if (rpcToken !== undefined && candidate.length > 0 && timingSafeMatch(candidate, rpcToken)) {
       return true;
     }
-    return false;
+    return authTokenService.isValid(candidate);
   };
 }

--- a/packages/kap-server/src/services/auth/password.ts
+++ b/packages/kap-server/src/services/auth/password.ts
@@ -1,8 +1,16 @@
+import { createHmac, randomBytes, timingSafeEqual } from 'node:crypto';
+
 import bcrypt from 'bcryptjs';
 
 const { compare, hash } = bcrypt;
 
 const BCRYPT_COST = 12;
+const PASSWORD_VERIFICATION_CACHE_TTL_MS = 5 * 60_000;
+
+interface PasswordVerifierOptions {
+  readonly compare?: (candidate: string, passwordHash: string) => Promise<boolean>;
+  readonly now?: () => number;
+}
 
 export async function resolvePasswordHash(
   env: NodeJS.ProcessEnv = process.env,
@@ -14,12 +22,71 @@ export async function resolvePasswordHash(
   return hash(plaintext, BCRYPT_COST);
 }
 
-export async function verifyPassword(
-  candidate: string,
+/**
+ * Build a process-local password verifier with a short success cache.
+ *
+ * The cache holds only a random-key HMAC of the successful candidate, never
+ * the password itself or a reusable unkeyed digest. Its five-minute lifetime
+ * starts after bcrypt succeeds and is not extended by cache hits. Concurrent
+ * callers with the same candidate share one bcrypt comparison; distinct
+ * candidates remain independent. Pending entries are removed on settlement.
+ */
+export function createPasswordVerifier(
   passwordHash: string | undefined,
-): Promise<boolean> {
+  options?: PasswordVerifierOptions,
+): (candidate: string) => Promise<boolean> {
   if (passwordHash === undefined) {
-    return false;
+    return async () => false;
   }
-  return compare(candidate, passwordHash);
+
+  const comparePassword = options?.compare ?? compare;
+  const now = options?.now ?? Date.now;
+  const hmacKey = randomBytes(32);
+  const inFlightVerifications = new Map<string, Promise<boolean>>();
+  let successfulVerification:
+    | { readonly digest: Buffer; readonly expiresAt: number }
+    | undefined;
+
+  const verify = async (candidate: string): Promise<boolean> => {
+    const digest = createHmac('sha256', hmacKey).update(candidate).digest();
+    const digestKey = digest.toString('base64');
+    const currentTime = now();
+    if (
+      successfulVerification !== undefined &&
+      successfulVerification.expiresAt <= currentTime
+    ) {
+      successfulVerification = undefined;
+    }
+    if (
+      successfulVerification !== undefined &&
+      timingSafeEqual(digest, successfulVerification.digest)
+    ) {
+      return true;
+    }
+
+    const inFlight = inFlightVerifications.get(digestKey);
+    if (inFlight !== undefined) {
+      return inFlight;
+    }
+
+    const verification = (async () => {
+      const valid = await comparePassword(candidate, passwordHash);
+      if (valid) {
+        successfulVerification = {
+          digest,
+          expiresAt: now() + PASSWORD_VERIFICATION_CACHE_TTL_MS,
+        };
+      }
+      return valid;
+    })();
+    inFlightVerifications.set(digestKey, verification);
+    try {
+      return await verification;
+    } finally {
+      if (inFlightVerifications.get(digestKey) === verification) {
+        inFlightVerifications.delete(digestKey);
+      }
+    }
+  };
+  return verify;
 }

--- a/packages/kap-server/test/authTokenStore.test.ts
+++ b/packages/kap-server/test/authTokenStore.test.ts
@@ -1,3 +1,10 @@
+/**
+ * Scenario: persistent server credentials and password verification.
+ * Responsibilities: private token storage, rotation, password caching, and auth composition.
+ * Wiring: real filesystem/crypto/bcrypt; comparator and clock seams are controlled where needed.
+ * Run: pnpm --filter @moonshot-ai/kap-server exec vitest run test/authTokenStore.test.ts
+ */
+
 import {
   chmodSync,
   existsSync,
@@ -10,7 +17,7 @@ import {
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import {
   PrivateFileTooPermissiveError,
@@ -23,7 +30,8 @@ import {
 } from '../src/services/auth/persistentToken';
 import { createTokenStore } from '../src/services/auth/tokenStore';
 import { createAuthTokenService } from '../src/services/auth/authTokenService';
-import { resolvePasswordHash, verifyPassword } from '../src/services/auth/password';
+import { createCredentialValidator } from '../src/services/auth/credentials';
+import { createPasswordVerifier, resolvePasswordHash } from '../src/services/auth/password';
 
 let tmpDir: string;
 
@@ -168,17 +176,122 @@ describe('password', () => {
     expect(await resolvePasswordHash({ KIMI_CODE_PASSWORD: '' })).toBeUndefined();
   });
 
-  it('hashes a set password with bcrypt and verifies correctly', async () => {
+  it('hashes a set password with bcrypt and verifies it through the cached verifier', async () => {
     const passwordHash = await resolvePasswordHash({
       KIMI_CODE_PASSWORD: 'correct-horse-battery-staple',
     });
+    const verify = createPasswordVerifier(passwordHash);
     expect(passwordHash?.startsWith('$2')).toBe(true);
-    expect(await verifyPassword('correct-horse-battery-staple', passwordHash)).toBe(true);
-    expect(await verifyPassword('wrong-password', passwordHash)).toBe(false);
+    expect(await verify('correct-horse-battery-staple')).toBe(true);
+    expect(await verify('wrong-password')).toBe(false);
   });
 
-  it('verifyPassword returns false when the hash is undefined', async () => {
-    expect(await verifyPassword('anything', undefined)).toBe(false);
+  it('returns false without consulting the comparator when the hash is undefined', async () => {
+    const compare = vi.fn(async () => true);
+    const verify = createPasswordVerifier(undefined, { compare });
+
+    expect(await verify('anything')).toBe(false);
+    expect(compare).not.toHaveBeenCalled();
+  });
+
+  it('runs a fresh comparison when the prior password verdict was false', async () => {
+    const compare = vi.fn(async () => false);
+    const verify = createPasswordVerifier('password-hash', { compare });
+
+    expect(await verify('wrong-password')).toBe(false);
+    expect(await verify('wrong-password')).toBe(false);
+    expect(compare).toHaveBeenCalledTimes(2);
+  });
+
+  it('returns a cached success when the verified candidate is checked again', async () => {
+    const compare = vi.fn(async () => true);
+    const verify = createPasswordVerifier('password-hash', { compare });
+
+    expect(await verify('correct-password')).toBe(true);
+    expect(await verify('correct-password')).toBe(true);
+    expect(compare).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps a cached successful candidate isolated from a failed candidate', async () => {
+    const compare = vi.fn(async (candidate: string) => candidate === 'correct-password');
+    const verify = createPasswordVerifier('password-hash', { compare });
+
+    expect(await verify('correct-password')).toBe(true);
+    expect(await verify('wrong-password')).toBe(false);
+    expect(await verify('correct-password')).toBe(true);
+    expect(compare).toHaveBeenCalledTimes(2);
+  });
+
+  it('runs one comparison when the same invalid candidate overlaps', async () => {
+    let settleComparison!: (valid: boolean) => void;
+    const comparison = new Promise<boolean>((resolve) => {
+      settleComparison = resolve;
+    });
+    const compare = vi.fn(() => comparison);
+    const verify = createPasswordVerifier('password-hash', { compare });
+
+    const first = verify('wrong-password');
+    const second = verify('wrong-password');
+    expect(compare).toHaveBeenCalledTimes(1);
+
+    settleComparison(false);
+    await expect(Promise.all([first, second])).resolves.toEqual([false, false]);
+  });
+
+  it('starts independent comparisons when distinct candidates overlap', async () => {
+    let settleFirst!: (valid: boolean) => void;
+    let settleSecond!: (valid: boolean) => void;
+    const compare = vi.fn((candidate: string) => new Promise<boolean>((resolve) => {
+      if (candidate === 'first-password') {
+        settleFirst = resolve;
+      } else {
+        settleSecond = resolve;
+      }
+    }));
+    const verify = createPasswordVerifier('password-hash', { compare });
+
+    const first = verify('first-password');
+    const second = verify('second-password');
+    expect(compare).toHaveBeenCalledTimes(2);
+
+    settleFirst(true);
+    settleSecond(false);
+    await expect(first).resolves.toBe(true);
+    await expect(second).resolves.toBe(false);
+  });
+
+  it('returns a fresh verdict when the prior in-flight comparison throws', async () => {
+    let attempts = 0;
+    const compare = vi.fn(async () => {
+      attempts += 1;
+      if (attempts === 1) {
+        throw new Error('bcrypt failed');
+      }
+      return true;
+    });
+    const verify = createPasswordVerifier('password-hash', { compare });
+
+    await expect(verify('correct-password')).rejects.toThrow('bcrypt failed');
+    await expect(verify('correct-password')).resolves.toBe(true);
+    expect(compare).toHaveBeenCalledTimes(2);
+  });
+
+  it('revalidates at the fixed expiry when intervening cache hits occur', async () => {
+    let now = 0;
+    const compare = vi.fn(async () => true);
+    const verify = createPasswordVerifier('password-hash', {
+      compare,
+      now: () => now,
+    });
+
+    expect(await verify('correct-password')).toBe(true);
+    now = 5 * 60_000 - 1;
+    expect(await verify('correct-password')).toBe(true);
+    expect(compare).toHaveBeenCalledTimes(1);
+
+    now = 5 * 60_000;
+    expect(await verify('correct-password')).toBe(true);
+    expect(compare).toHaveBeenCalledTimes(2);
   });
 });
 
@@ -223,5 +336,24 @@ describe('createAuthTokenService', () => {
     expect(await svc.isValid(store.getToken())).toBe(true);
     expect(await svc.isValid('any-password')).toBe(false);
     await store.dispose();
+  });
+});
+
+describe('createCredentialValidator', () => {
+  it('accepts the rpcToken without consulting the auth token service', async () => {
+    const isValid = vi.fn(async () => {
+      throw new Error('auth token service should not be called');
+    });
+    const validate = createCredentialValidator(
+      {
+        _serviceBrand: undefined,
+        getToken: () => 'persistent-token',
+        isValid,
+      },
+      'rpc-token',
+    );
+
+    await expect(validate('rpc-token')).resolves.toBe(true);
+    expect(isValid).not.toHaveBeenCalled();
   });
 });

--- a/packages/kap-server/test/hostExposure.e2e.test.ts
+++ b/packages/kap-server/test/hostExposure.e2e.test.ts
@@ -5,7 +5,7 @@
  *   - public-bind gate (refuse without `--insecure-no-tls`; token-only warning
  *     logged on a non-loopback boot without a password);
  *   - real password path (`Authorization: Bearer <password>` → 200 via
- *     `verifyPassword`; wrong / missing credentials → 401);
+ *     the configured password verifier; wrong / missing credentials → 401);
  *   - auth-failure rate limit (10 bad tokens → 429 on the 11th) on a real bind;
  *   - security response headers on a non-loopback response.
  */
@@ -93,7 +93,7 @@ describe('public-bind gate', () => {
   });
 });
 
-describe('real password path (verifyPassword)', () => {
+describe('real password path', () => {
   async function bootPublic(): Promise<RunningServer> {
     process.env['KIMI_CODE_PASSWORD'] = 'test-pw';
     const home = await tmpHome();

--- a/packages/kap-server/test/wsUpgradeAuth.test.ts
+++ b/packages/kap-server/test/wsUpgradeAuth.test.ts
@@ -20,6 +20,7 @@ import { type RunningServer, startServer } from '../src/start';
 import { fixedTokenAuth } from './helpers/fixedAuth';
 
 const TOKEN = 'test-token';
+const RPC_TOKEN = 'rpc-token';
 
 function rawToString(data: RawData): string {
   if (typeof data === 'string') return data;
@@ -87,6 +88,7 @@ describe('WS upgrade auth', () => {
       homeDir: home,
       logLevel: 'silent',
       authTokenService: fixedTokenAuth(TOKEN),
+      rpcToken: RPC_TOKEN,
     });
     v1Url = `ws://127.0.0.1:${server.port}/api/v1/ws`;
   });
@@ -125,6 +127,14 @@ describe('WS upgrade auth', () => {
     it('accepts a valid Authorization bearer header', async () => {
       const { ws, firstFrame } = await openConn(url(), {
         headers: { Authorization: `Bearer ${TOKEN}` },
+      });
+      sockets.push(ws);
+      expect(firstFrame).toMatchObject({ type: firstType });
+    });
+
+    it('accepts the rpcToken as a bearer subprotocol', async () => {
+      const { ws, firstFrame } = await openConn(url(), {
+        protocols: [`kimi-code.bearer.${RPC_TOKEN}`],
       });
       sockets.push(ws);
       expect(firstFrame).toMatchObject({ type: firstType });


### PR DESCRIPTION
## Related Issue

Resolve #1904

## Problem

Each password-authenticated REST or WebSocket request ran cost-12 bcrypt again. This made Kimi Web startup and refresh slow on low-power hosts.

## What changed

```mermaid
flowchart LR
  A[Bearer credential] --> B{RPC token?}
  B -->|yes| F[Accept]
  B -->|no| C{Persistent token?}
  C -->|yes| F
  C -->|no| D{Recent password HMAC?}
  D -->|yes| F
  D -->|no| E[bcrypt.compare]
  E -->|valid| F
  E -->|invalid| G[Reject]
```

The verifier keeps one successful candidate for five minutes as a process-local, keyed HMAC. It stores neither plaintext nor an unkeyed digest. Cache hits do not extend expiry, failures are not cached, and overlapping checks of the same candidate share one bcrypt comparison. Both token paths bypass bcrypt.

## Validation

- Focused auth, RPC, and WebSocket tests: 78 passed. Full kap-server suite: 722 passed.
- Typecheck, type-aware lint, CLI production build, bundle smoke, and `git diff --check` passed.
- A real server smoke covered persistent and RPC tokens, first and cached password REST, password WebSocket auth, and rejected credentials. It observed 223 ms for the first password check and 2 ms for the cache hit; this is not a benchmark.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.
