### PR TITLE
fix(tui): prioritize exit command completion

### DIFF
--- a/.changeset/rank-exit-command-first.md
+++ b/.changeset/rank-exit-command-first.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Show `/exit` first when `/ex` matches multiple slash commands.

--- a/apps/kimi-code/src/tui/commands/registry.ts
+++ b/apps/kimi-code/src/tui/commands/registry.ts
@@ -401,7 +401,7 @@ export const BUILTIN_SLASH_COMMANDS = [
     name: 'exit',
     aliases: ['quit', 'q'],
     description: 'Exit the application',
-    priority: 20,
+    priority: 80,
   },
   {
     name: 'version',

--- a/apps/kimi-code/test/tui/components/editor/file-mention-provider.test.ts
+++ b/apps/kimi-code/test/tui/components/editor/file-mention-provider.test.ts
@@ -1,3 +1,8 @@
+// Scenario: slash-command and file-mention autocomplete.
+// Responsibilities: rank command matches and resolve path suggestions through the real provider.
+// Wiring: isolated temporary directories; fd is the only optional external boundary.
+// Run: pnpm --filter @moonshot-ai/kimi-code exec vitest run test/tui/components/editor/file-mention-provider.test.ts
+
 import { spawnSync } from 'node:child_process';
 import { mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
@@ -6,6 +11,7 @@ import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { FileMentionProvider } from '#/tui/components/editor/file-mention-provider';
+import { BUILTIN_SLASH_COMMANDS, sortSlashCommands } from '#/tui/commands';
 
 function ctrl(): AbortSignal {
   return new AbortController().signal;
@@ -161,6 +167,19 @@ describe('FileMentionProvider', () => {
       value: 'new',
       label: 'new (clear)',
     });
+  });
+
+  it('ranks exit first when /ex matches multiple built-in commands', async () => {
+    const commands = sortSlashCommands(BUILTIN_SLASH_COMMANDS).map((command) => ({
+      name: command.name,
+      aliases: command.aliases,
+      description: command.description,
+    }));
+    const provider = new FileMentionProvider(commands, workDir, NO_FD);
+
+    const result = await provider.getSuggestions(['/ex'], 0, 3, { signal: ctrl() });
+
+    expect(result?.items[0]?.value).toBe('exit');
   });
 
   it('prefers exact alias matches over fuzzy skill matches', async () => {


### PR DESCRIPTION
## Related Issue

Resolve #2007

## Problem

See linked issue.

## What changed

- Raise the built-in `/exit` command to the common-command priority so it appears first for equal-score `/ex` matches.
- Add regression coverage through the real slash-command registry and autocomplete provider.
- Keep the fuzzy matching algorithm and unrelated command ordering unchanged.

## Verification

- CLI test suite: 2,378 passed, 5 skipped
- TypeScript check passed for `apps/kimi-code`
- Type-aware oxlint completed with no errors

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.