### PR TITLE
fix(mcp): keep stdio child no-proxy entries runtime-safe

### DIFF
--- a/.changeset/quiet-pandas-rest.md
+++ b/.changeset/quiet-pandas-rest.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Fix Python-based MCP servers failing to start under HTTP proxies while preserving Node launchers' IPv6 loopback bypass.

--- a/packages/agent-core-v2/src/mcpCore/client-stdio.ts
+++ b/packages/agent-core-v2/src/mcpCore/client-stdio.ts
@@ -54,7 +54,7 @@ export class StdioMcpClient implements MCPClient {
     this.transport = new StdioClientTransport({
       command: config.command,
       args: config.args,
-      env: mergeStdioEnv(config.env),
+      env: mergeStdioEnv(config.env, process.env, config.command, config.args),
       cwd: resolveStdioCwd(config.cwd, options.defaultCwd),
       stderr: 'pipe',
     });
@@ -188,6 +188,8 @@ function resolveStdioCwd(configCwd: string | undefined, defaultCwd: string | und
 export function mergeStdioEnv(
   configEnv?: Record<string, string>,
   parentEnv: Readonly<Record<string, string | undefined>> = process.env,
+  command = '',
+  args: readonly string[] = [],
 ): Record<string, string> {
   const merged: Record<string, string> = {};
   for (const [key, value] of Object.entries(parentEnv)) {
@@ -196,5 +198,39 @@ export function mergeStdioEnv(
   if (configEnv !== undefined) Object.assign(merged, configEnv);
   Object.assign(merged, proxyEnvForChild(merged));
   reconcileChildNoProxy(merged, configEnv);
+  if (
+    !usesNodeEnvProxy(command, args) &&
+    !explicitlyKeepsBracketedIpv6(configEnv) &&
+    !explicitlyKeepsBracketedIpv6(parentEnv)
+  ) {
+    for (const key of ['NO_PROXY', 'no_proxy'] as const) {
+      const value = merged[key];
+      if (value !== undefined && value !== '*') {
+        merged[key] = value
+          .split(',')
+          .filter((host) => host.trim() !== '[::1]')
+          .join(',');
+      }
+    }
+  }
   return merged;
+}
+
+const NODE_ENV_PROXY_COMMAND_RE =
+  /^(?:node(?:\.exe)?|nodejs(?:\.exe)?|corepack(?:\.cmd)?|npm(?:\.cmd)?|npx(?:\.cmd)?|pnpm(?:\.cmd)?|yarn(?:\.cmd)?|tsx(?:\.cmd)?|ts-node(?:\.cmd)?|.+\.(?:c|m)?js)$/i;
+const NODE_ENV_PROXY_WRAPPER_RE =
+  /^(?:ba|z|fi)?sh$|^(?:env|cmd(?:\.exe)?|powershell(?:\.exe)?|pwsh(?:\.exe)?|docker|podman|nix-shell)$/i;
+const NODE_ENV_PROXY_ARGUMENT_RE =
+  /(?:^|[\\/\s"'=])(?:node(?:\.exe)?|nodejs(?:\.exe)?|corepack(?:\.cmd)?|npm(?:\.cmd)?|npx(?:\.cmd)?|pnpm(?:\.cmd)?|yarn(?:\.cmd)?|tsx(?:\.cmd)?|ts-node(?:\.cmd)?|[^\s"']+\.(?:c|m)?js)(?=$|[\s"';])/i;
+
+function usesNodeEnvProxy(command: string, args: readonly string[]): boolean {
+  const executable = command.split(/[\\/]/).at(-1) ?? '';
+  if (NODE_ENV_PROXY_COMMAND_RE.test(executable)) return true;
+  return NODE_ENV_PROXY_WRAPPER_RE.test(executable) && args.some((arg) => NODE_ENV_PROXY_ARGUMENT_RE.test(arg));
+}
+
+function explicitlyKeepsBracketedIpv6(env?: Readonly<Record<string, string | undefined>>): boolean {
+  return [env?.['no_proxy'], env?.['NO_PROXY']].some((value) =>
+    value?.split(',').some((host) => host.trim() === '[::1]'),
+  );
 }

--- a/packages/agent-core-v2/src/mcpCore/client-stdio.ts
+++ b/packages/agent-core-v2/src/mcpCore/client-stdio.ts
@@ -7,6 +7,8 @@ import type { McpServerStdioConfig } from './config-schema';
 import { proxyEnvForChild, reconcileChildNoProxy } from '#/_base/utils/proxy';
 import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
+import { closeSync, openSync, readSync } from 'node:fs';
+import { delimiter } from 'node:path';
 import { isAbsolute, resolve } from 'pathe';
 
 import {
@@ -51,11 +53,12 @@ export class StdioMcpClient implements MCPClient {
     if (config.executor !== undefined && config.executor !== 'local') {
       throw new Error2(ErrorCodes.NOT_IMPLEMENTED, `MCP stdio executor '${config.executor}' is not yet implemented`);
     }
+    const cwd = resolveStdioCwd(config.cwd, options.defaultCwd);
     this.transport = new StdioClientTransport({
       command: config.command,
       args: config.args,
-      env: mergeStdioEnv(config.env, process.env, config.command, config.args),
-      cwd: resolveStdioCwd(config.cwd, options.defaultCwd),
+      env: mergeStdioEnv(config.env, process.env, config.command, config.args, cwd),
+      cwd,
       stderr: 'pipe',
     });
     this.transport.stderr?.on('data', (chunk: Buffer | string) => {
@@ -190,6 +193,7 @@ export function mergeStdioEnv(
   parentEnv: Readonly<Record<string, string | undefined>> = process.env,
   command = '',
   args: readonly string[] = [],
+  cwd?: string,
 ): Record<string, string> {
   const merged: Record<string, string> = {};
   for (const [key, value] of Object.entries(parentEnv)) {
@@ -199,7 +203,7 @@ export function mergeStdioEnv(
   Object.assign(merged, proxyEnvForChild(merged));
   reconcileChildNoProxy(merged, configEnv);
   if (
-    !usesNodeEnvProxy(command, args) &&
+    !usesNodeEnvProxy(command, args, merged, cwd) &&
     !explicitlyKeepsBracketedIpv6(configEnv) &&
     !explicitlyKeepsBracketedIpv6(parentEnv)
   ) {
@@ -222,11 +226,47 @@ const NODE_ENV_PROXY_WRAPPER_RE =
   /^(?:ba|z|fi)?sh$|^(?:env|cmd(?:\.exe)?|powershell(?:\.exe)?|pwsh(?:\.exe)?|docker|podman|nix-shell)$/i;
 const NODE_ENV_PROXY_ARGUMENT_RE =
   /(?:^|[\\/\s"'=])(?:node(?:\.exe)?|nodejs(?:\.exe)?|corepack(?:\.cmd)?|npm(?:\.cmd)?|npx(?:\.cmd)?|pnpm(?:\.cmd)?|yarn(?:\.cmd)?|tsx(?:\.cmd)?|ts-node(?:\.cmd)?|[^\s"']+\.(?:c|m)?js)(?=$|[\s"';])/i;
+const NODE_SHEBANG_RE = /^#![^\r\n]*(?:[/\s])node(?:js)?(?:\s|$)/i;
 
-function usesNodeEnvProxy(command: string, args: readonly string[]): boolean {
+function usesNodeEnvProxy(
+  command: string,
+  args: readonly string[],
+  env: Readonly<Record<string, string | undefined>>,
+  cwd?: string,
+): boolean {
   const executable = command.split(/[\\/]/).at(-1) ?? '';
   if (NODE_ENV_PROXY_COMMAND_RE.test(executable)) return true;
-  return NODE_ENV_PROXY_WRAPPER_RE.test(executable) && args.some((arg) => NODE_ENV_PROXY_ARGUMENT_RE.test(arg));
+  if (NODE_ENV_PROXY_WRAPPER_RE.test(executable) && args.some((arg) => NODE_ENV_PROXY_ARGUMENT_RE.test(arg))) {
+    return true;
+  }
+  return hasNodeShebang(command, env, cwd);
+}
+
+function hasNodeShebang(
+  command: string,
+  env: Readonly<Record<string, string | undefined>>,
+  cwd?: string,
+): boolean {
+  const baseCwd = cwd ?? process.cwd();
+  const candidates = /[\\/]/.test(command)
+    ? [resolve(baseCwd, command)]
+    : (env['PATH'] ?? env['Path'] ?? '')
+        .split(delimiter)
+        .filter(Boolean)
+        .map((directory) => resolve(baseCwd, directory, command));
+  for (const candidate of candidates) {
+    let descriptor: number | undefined;
+    try {
+      descriptor = openSync(candidate, 'r');
+      const buffer = Buffer.alloc(256);
+      const bytesRead = readSync(descriptor, buffer, 0, buffer.length, 0);
+      if (NODE_SHEBANG_RE.test(buffer.toString('utf8', 0, bytesRead))) return true;
+    } catch {
+    } finally {
+      if (descriptor !== undefined) closeSync(descriptor);
+    }
+  }
+  return false;
 }
 
 function explicitlyKeepsBracketedIpv6(env?: Readonly<Record<string, string | undefined>>): boolean {

--- a/packages/agent-core-v2/test/mcpCore/client-stdio.test.ts
+++ b/packages/agent-core-v2/test/mcpCore/client-stdio.test.ts
@@ -1,4 +1,4 @@
-import { mkdirSync, mkdtempSync, realpathSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, realpathSync, writeFileSync } from 'node:fs';
 import { rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'pathe';
@@ -321,6 +321,30 @@ describe('mergeStdioEnv', () => {
         args,
       );
       expect(merged['NO_PROXY']).toBe('localhost,127.0.0.1,::1,[::1]');
+    }
+  });
+
+  it('keeps bracketed IPv6 loopback for extensionless Node shebang launchers', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'kimi-mcp-v2-node-bin-'));
+    const launcher = join(dir, 'my-mcp');
+    writeFileSync(launcher, '#!/usr/bin/env node\n');
+    try {
+      for (const { command, cwd } of [
+        { command: launcher, cwd: undefined },
+        { command: 'my-mcp', cwd: undefined },
+        { command: './my-mcp', cwd: dir },
+      ]) {
+        const merged = mergeStdioEnv(
+          { HTTP_PROXY: 'http://corp:3128' },
+          { PATH: dir },
+          command,
+          [],
+          cwd,
+        );
+        expect(merged['NO_PROXY']).toBe('localhost,127.0.0.1,::1,[::1]');
+      }
+    } finally {
+      await rm(dir, { recursive: true, force: true });
     }
   });
 

--- a/packages/agent-core-v2/test/mcpCore/client-stdio.test.ts
+++ b/packages/agent-core-v2/test/mcpCore/client-stdio.test.ts
@@ -304,8 +304,43 @@ describe('mergeStdioEnv', () => {
     const merged = mergeStdioEnv({ HTTP_PROXY: 'http://corp:3128' }, { PATH: '/usr/bin' });
     expect(merged['HTTP_PROXY']).toBe('http://corp:3128');
     expect(merged['NODE_USE_ENV_PROXY']).toBe('1');
-    expect(merged['NO_PROXY']).toBe('localhost,127.0.0.1,::1,[::1]');
+    expect(merged['NO_PROXY']).toBe('localhost,127.0.0.1,::1');
     expect(merged['PATH']).toBe('/usr/bin');
+  });
+
+  it('keeps bracketed IPv6 loopback for direct and wrapped Node launchers', () => {
+    for (const { command, args } of [
+      { command: 'node', args: [] },
+      { command: 'bash', args: ['-c', 'node server.js'] },
+      { command: 'cmd.exe', args: ['/c', '"C:\\Program Files\\nodejs\\node.exe" server.js'] },
+    ]) {
+      const merged = mergeStdioEnv(
+        { HTTP_PROXY: 'http://corp:3128' },
+        { PATH: '/usr/bin' },
+        command,
+        args,
+      );
+      expect(merged['NO_PROXY']).toBe('localhost,127.0.0.1,::1,[::1]');
+    }
+  });
+
+  it('keeps portable IPv6 syntax for a non-Node shell child', () => {
+    const merged = mergeStdioEnv(
+      { HTTP_PROXY: 'http://corp:3128' },
+      { PATH: '/usr/bin' },
+      'bash',
+      ['-c', 'python server.py'],
+    );
+    expect(merged['NO_PROXY']).toBe('localhost,127.0.0.1,::1');
+  });
+
+  it('honors an explicit bracketed IPv6 override', () => {
+    const merged = mergeStdioEnv(
+      { HTTP_PROXY: 'http://corp:3128', NO_PROXY: 'internal,[::1]' },
+      { PATH: '/usr/bin' },
+      'uvx',
+    );
+    expect(merged['NO_PROXY']).toBe('internal,[::1],localhost,127.0.0.1,::1');
   });
 
   it('does not inject NODE_USE_ENV_PROXY when no proxy is configured', () => {

--- a/packages/agent-core/src/mcp/client-stdio.ts
+++ b/packages/agent-core/src/mcp/client-stdio.ts
@@ -65,7 +65,7 @@ export class StdioMcpClient implements MCPClient {
     this.transport = new StdioClientTransport({
       command: config.command,
       args: config.args,
-      env: mergeStdioEnv(config.env),
+      env: mergeStdioEnv(config.env, process.env, config.command, config.args),
       cwd: resolveStdioCwd(config.cwd, options.defaultCwd),
       stderr: 'pipe',
     });
@@ -252,10 +252,15 @@ function isWindowsAbsolutePath(value: string): boolean {
 // version that supports the flag — ≥22.21 or ≥24.5). It is computed from the
 // MERGED env so a proxy declared only in `config.env` is honored too.
 // `reconcileChildNoProxy` then mirrors a single-casing `NO_PROXY` override onto
-// both casings so it isn't shadowed by the injected value.
+// both casings so it isn't shadowed by the injected value. Known Node launchers
+// retain bracketed IPv6 loopback because Node's env proxy requires it; arbitrary
+// runtimes receive the portable bare form unless their config explicitly keeps
+// `[::1]`.
 export function mergeStdioEnv(
   configEnv?: Record<string, string>,
   parentEnv: Readonly<Record<string, string | undefined>> = process.env,
+  command = '',
+  args: readonly string[] = [],
 ): Record<string, string> {
   const merged: Record<string, string> = {};
   for (const [key, value] of Object.entries(parentEnv)) {
@@ -264,5 +269,39 @@ export function mergeStdioEnv(
   if (configEnv !== undefined) Object.assign(merged, configEnv);
   Object.assign(merged, proxyEnvForChild(merged));
   reconcileChildNoProxy(merged, configEnv);
+  if (
+    !usesNodeEnvProxy(command, args) &&
+    !explicitlyKeepsBracketedIpv6(configEnv) &&
+    !explicitlyKeepsBracketedIpv6(parentEnv)
+  ) {
+    for (const key of ['NO_PROXY', 'no_proxy'] as const) {
+      const value = merged[key];
+      if (value !== undefined && value !== '*') {
+        merged[key] = value
+          .split(',')
+          .filter((host) => host.trim() !== '[::1]')
+          .join(',');
+      }
+    }
+  }
   return merged;
+}
+
+const NODE_ENV_PROXY_COMMAND_RE =
+  /^(?:node(?:\.exe)?|nodejs(?:\.exe)?|corepack(?:\.cmd)?|npm(?:\.cmd)?|npx(?:\.cmd)?|pnpm(?:\.cmd)?|yarn(?:\.cmd)?|tsx(?:\.cmd)?|ts-node(?:\.cmd)?|.+\.(?:c|m)?js)$/i;
+const NODE_ENV_PROXY_WRAPPER_RE =
+  /^(?:ba|z|fi)?sh$|^(?:env|cmd(?:\.exe)?|powershell(?:\.exe)?|pwsh(?:\.exe)?|docker|podman|nix-shell)$/i;
+const NODE_ENV_PROXY_ARGUMENT_RE =
+  /(?:^|[\\/\s"'=])(?:node(?:\.exe)?|nodejs(?:\.exe)?|corepack(?:\.cmd)?|npm(?:\.cmd)?|npx(?:\.cmd)?|pnpm(?:\.cmd)?|yarn(?:\.cmd)?|tsx(?:\.cmd)?|ts-node(?:\.cmd)?|[^\s"']+\.(?:c|m)?js)(?=$|[\s"';])/i;
+
+function usesNodeEnvProxy(command: string, args: readonly string[]): boolean {
+  const executable = command.split(/[\\/]/).at(-1) ?? '';
+  if (NODE_ENV_PROXY_COMMAND_RE.test(executable)) return true;
+  return NODE_ENV_PROXY_WRAPPER_RE.test(executable) && args.some((arg) => NODE_ENV_PROXY_ARGUMENT_RE.test(arg));
+}
+
+function explicitlyKeepsBracketedIpv6(env?: Readonly<Record<string, string | undefined>>): boolean {
+  return [env?.['no_proxy'], env?.['NO_PROXY']].some((value) =>
+    value?.split(',').some((host) => host.trim() === '[::1]'),
+  );
 }

--- a/packages/agent-core/src/mcp/client-stdio.ts
+++ b/packages/agent-core/src/mcp/client-stdio.ts
@@ -3,7 +3,8 @@ import type { McpServerStdioConfig } from '#/config/schema';
 import { proxyEnvForChild, reconcileChildNoProxy } from '#/utils/proxy';
 import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
-import { win32 } from 'node:path';
+import { closeSync, openSync, readSync } from 'node:fs';
+import { delimiter, win32 } from 'node:path';
 import { isAbsolute, resolve } from 'pathe';
 
 import {
@@ -62,11 +63,12 @@ export class StdioMcpClient implements MCPClient {
     if (config.executor !== undefined && config.executor !== 'local') {
       throw new KimiError(ErrorCodes.NOT_IMPLEMENTED, `MCP stdio executor '${config.executor}' is not yet implemented`);
     }
+    const cwd = resolveStdioCwd(config.cwd, options.defaultCwd);
     this.transport = new StdioClientTransport({
       command: config.command,
       args: config.args,
-      env: mergeStdioEnv(config.env, process.env, config.command, config.args),
-      cwd: resolveStdioCwd(config.cwd, options.defaultCwd),
+      env: mergeStdioEnv(config.env, process.env, config.command, config.args, cwd),
+      cwd,
       stderr: 'pipe',
     });
     // `stderr: 'pipe'` means we MUST drain the stream — otherwise the child
@@ -261,6 +263,7 @@ export function mergeStdioEnv(
   parentEnv: Readonly<Record<string, string | undefined>> = process.env,
   command = '',
   args: readonly string[] = [],
+  cwd?: string,
 ): Record<string, string> {
   const merged: Record<string, string> = {};
   for (const [key, value] of Object.entries(parentEnv)) {
@@ -270,7 +273,7 @@ export function mergeStdioEnv(
   Object.assign(merged, proxyEnvForChild(merged));
   reconcileChildNoProxy(merged, configEnv);
   if (
-    !usesNodeEnvProxy(command, args) &&
+    !usesNodeEnvProxy(command, args, merged, cwd) &&
     !explicitlyKeepsBracketedIpv6(configEnv) &&
     !explicitlyKeepsBracketedIpv6(parentEnv)
   ) {
@@ -293,11 +296,47 @@ const NODE_ENV_PROXY_WRAPPER_RE =
   /^(?:ba|z|fi)?sh$|^(?:env|cmd(?:\.exe)?|powershell(?:\.exe)?|pwsh(?:\.exe)?|docker|podman|nix-shell)$/i;
 const NODE_ENV_PROXY_ARGUMENT_RE =
   /(?:^|[\\/\s"'=])(?:node(?:\.exe)?|nodejs(?:\.exe)?|corepack(?:\.cmd)?|npm(?:\.cmd)?|npx(?:\.cmd)?|pnpm(?:\.cmd)?|yarn(?:\.cmd)?|tsx(?:\.cmd)?|ts-node(?:\.cmd)?|[^\s"']+\.(?:c|m)?js)(?=$|[\s"';])/i;
+const NODE_SHEBANG_RE = /^#![^\r\n]*(?:[/\s])node(?:js)?(?:\s|$)/i;
 
-function usesNodeEnvProxy(command: string, args: readonly string[]): boolean {
+function usesNodeEnvProxy(
+  command: string,
+  args: readonly string[],
+  env: Readonly<Record<string, string | undefined>>,
+  cwd?: string,
+): boolean {
   const executable = command.split(/[\\/]/).at(-1) ?? '';
   if (NODE_ENV_PROXY_COMMAND_RE.test(executable)) return true;
-  return NODE_ENV_PROXY_WRAPPER_RE.test(executable) && args.some((arg) => NODE_ENV_PROXY_ARGUMENT_RE.test(arg));
+  if (NODE_ENV_PROXY_WRAPPER_RE.test(executable) && args.some((arg) => NODE_ENV_PROXY_ARGUMENT_RE.test(arg))) {
+    return true;
+  }
+  return hasNodeShebang(command, env, cwd);
+}
+
+function hasNodeShebang(
+  command: string,
+  env: Readonly<Record<string, string | undefined>>,
+  cwd?: string,
+): boolean {
+  const baseCwd = cwd ?? process.cwd();
+  const candidates = /[\\/]/.test(command)
+    ? [resolve(baseCwd, command)]
+    : (env['PATH'] ?? env['Path'] ?? '')
+        .split(delimiter)
+        .filter(Boolean)
+        .map((directory) => resolve(baseCwd, directory, command));
+  for (const candidate of candidates) {
+    let descriptor: number | undefined;
+    try {
+      descriptor = openSync(candidate, 'r');
+      const buffer = Buffer.alloc(256);
+      const bytesRead = readSync(descriptor, buffer, 0, buffer.length, 0);
+      if (NODE_SHEBANG_RE.test(buffer.toString('utf8', 0, bytesRead))) return true;
+    } catch {
+    } finally {
+      if (descriptor !== undefined) closeSync(descriptor);
+    }
+  }
+  return false;
 }
 
 function explicitlyKeepsBracketedIpv6(env?: Readonly<Record<string, string | undefined>>): boolean {

--- a/packages/agent-core/test/mcp/client-stdio.test.ts
+++ b/packages/agent-core/test/mcp/client-stdio.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, realpathSync } from 'node:fs';
+import { mkdtempSync, realpathSync, writeFileSync } from 'node:fs';
 import { rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { dirname, join } from 'pathe';
@@ -330,6 +330,30 @@ describe('mergeStdioEnv', () => {
       expect(merged['NO_PROXY']).toBe('localhost,127.0.0.1,::1,[::1]');
     },
   );
+
+  it('keeps bracketed IPv6 loopback for extensionless Node shebang launchers', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'kimi-mcp-node-bin-'));
+    const launcher = join(dir, 'my-mcp');
+    writeFileSync(launcher, '#!/usr/bin/env node\n');
+    try {
+      for (const { command, cwd } of [
+        { command: launcher, cwd: undefined },
+        { command: 'my-mcp', cwd: undefined },
+        { command: './my-mcp', cwd: dir },
+      ]) {
+        const merged = mergeStdioEnv(
+          { HTTP_PROXY: 'http://corp:3128' },
+          { PATH: dir },
+          command,
+          [],
+          cwd,
+        );
+        expect(merged['NO_PROXY']).toBe('localhost,127.0.0.1,::1,[::1]');
+      }
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
 
   for (const { command, args } of [
     { command: 'bash', args: ['-c', 'node server.js'] },

--- a/packages/agent-core/test/mcp/client-stdio.test.ts
+++ b/packages/agent-core/test/mcp/client-stdio.test.ts
@@ -315,8 +315,65 @@ describe('mergeStdioEnv', () => {
     const merged = mergeStdioEnv({ HTTP_PROXY: 'http://corp:3128' }, { PATH: '/usr/bin' });
     expect(merged['HTTP_PROXY']).toBe('http://corp:3128');
     expect(merged['NODE_USE_ENV_PROXY']).toBe('1');
-    expect(merged['NO_PROXY']).toBe('localhost,127.0.0.1,::1,[::1]');
+    expect(merged['NO_PROXY']).toBe('localhost,127.0.0.1,::1');
     expect(merged['PATH']).toBe('/usr/bin');
+  });
+
+  it.each(['node', 'NODE.EXE', 'npm.cmd', 'pnpm', '/tools/server.mjs'])(
+    'keeps bracketed IPv6 loopback for Node launcher %s',
+    (command) => {
+      const merged = mergeStdioEnv(
+        { HTTP_PROXY: 'http://corp:3128' },
+        { PATH: '/usr/bin' },
+        command,
+      );
+      expect(merged['NO_PROXY']).toBe('localhost,127.0.0.1,::1,[::1]');
+    },
+  );
+
+  for (const { command, args } of [
+    { command: 'bash', args: ['-c', 'node server.js'] },
+    { command: '/usr/bin/env', args: ['node', 'server.js'] },
+    { command: 'cmd.exe', args: ['/c', '"C:\\Program Files\\nodejs\\node.exe" server.js'] },
+    { command: 'docker', args: ['exec', 'app', 'node', 'server.js'] },
+  ]) {
+    it(`keeps bracketed IPv6 loopback for wrapped Node launcher ${command}`, () => {
+      const merged = mergeStdioEnv(
+        { HTTP_PROXY: 'http://corp:3128' },
+        { PATH: '/usr/bin' },
+        command,
+        args,
+      );
+      expect(merged['NO_PROXY']).toBe('localhost,127.0.0.1,::1,[::1]');
+    });
+  }
+
+  it('keeps portable IPv6 syntax for a non-Node shell child', () => {
+    const merged = mergeStdioEnv(
+      { HTTP_PROXY: 'http://corp:3128' },
+      { PATH: '/usr/bin' },
+      'bash',
+      ['-c', 'python server.py'],
+    );
+    expect(merged['NO_PROXY']).toBe('localhost,127.0.0.1,::1');
+  });
+
+  it('honors an explicit bracketed IPv6 override for other launchers', () => {
+    const merged = mergeStdioEnv(
+      { HTTP_PROXY: 'http://corp:3128', NO_PROXY: 'internal,[::1]' },
+      { PATH: '/usr/bin' },
+      'uvx',
+    );
+    expect(merged['NO_PROXY']).toBe('internal,[::1],localhost,127.0.0.1,::1');
+  });
+
+  it('honors a bracketed IPv6 entry inherited from the parent', () => {
+    const merged = mergeStdioEnv(
+      { HTTP_PROXY: 'http://corp:3128' },
+      { PATH: '/usr/bin', NO_PROXY: 'parent,[::1]' },
+      'custom-node-wrapper',
+    );
+    expect(merged['NO_PROXY']).toBe('parent,[::1],localhost,127.0.0.1,::1');
   });
 
   it('does not inject NODE_USE_ENV_PROXY when no proxy is configured', () => {


### PR DESCRIPTION
## Related Issue

Fixes #1931

## Problem

When an HTTP proxy is configured, stdio MCP children inherit `[::1]` in both `NO_PROXY` casings. Python `httpx` treats that entry as an invalid port and exits before the MCP handshake. Removing it unconditionally would instead regress Node's IPv6 loopback bypass when `NODE_USE_ENV_PROXY=1`.

## What changed

- pass the stdio command and arguments into child environment construction in both agent engines
- keep `[::1]` for direct and commonly wrapped Node launchers and JavaScript entry points
- emit the portable bare `::1` form for other runtimes, while honoring explicit parent or per-server bracketed overrides
- add a patch changeset and regression coverage for portable, Node, wrapped-Node, and explicit-override paths

No documentation update is needed because the public proxy configuration and precedence are unchanged.

## Testing

- `pnpm exec vitest run test/mcp/client-stdio.test.ts` in `packages/agent-core` — 29 passed
- `pnpm exec vitest run test/agent/mcp/client-stdio.test.ts` in `packages/agent-core-v2` — 20 passed
- `pnpm --filter @moonshot-ai/agent-core test` — 3,990 passed, 3 expected failures, 30 skipped, 1 todo
- `pnpm --filter @moonshot-ai/agent-core-v2 test` — 3,958 passed
- typecheck for both agent-core packages — passed
- changed-file type-aware lint — 0 warnings, 0 errors
- root `pnpm lint` — 0 errors (existing warnings only)
- Python `httpx.Client()` reproducer — bracketed child value fails; portable child value succeeds
- Node 24.15 local IPv6 fetch with an unreachable proxy — bracketed Node value returns `200 ok`; bare value attempts the proxy and fails

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.
