### PR TITLE
fix(provider): ensure OpenAI tool schemas use array required

### DIFF
--- a/.changeset/openai-tool-required-array.md
+++ b/.changeset/openai-tool-required-array.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Fix OpenAI-compatible providers rejecting tool schemas when `required` is missing or not an array (Moonshot-flavored JSON Schema).

--- a/packages/agent-core-v2/src/kosong/provider/bases/openai/openai-common.ts
+++ b/packages/agent-core-v2/src/kosong/provider/bases/openai/openai-common.ts
@@ -87,15 +87,49 @@ export type OpenAIToolParam = {
   };
 };
 
+/**
+ * Convert a kosong `Tool` to OpenAI tool format.
+ *
+ * OpenAI-compatible relays that forward to Moonshot backends validate tool
+ * parameters as Moonshot-flavored JSON Schema. Ensure `required` is always an
+ * array on object schemas so those gateways do not reject the request with:
+ * `required must be an array`.
+ */
 export function toolToOpenAI(tool: Tool): OpenAIToolParam {
   return {
     type: 'function',
     function: {
       name: tool.name,
       description: tool.description,
-      parameters: tool.parameters,
+      parameters: ensureObjectRequiredArrays(tool.parameters),
     },
   };
+}
+
+/**
+ * Walk a JSON Schema and force `required` to `[]` when a node has
+ * `type: "object"` but `required` is missing or not an array.
+ */
+export function ensureObjectRequiredArrays(
+  schema: Record<string, unknown> | undefined,
+): Record<string, unknown> | undefined {
+  if (schema === undefined) return undefined;
+  const cloned = structuredClone(schema) as unknown;
+  walkEnsureRequired(cloned);
+  return cloned as Record<string, unknown>;
+}
+
+function walkEnsureRequired(node: unknown): void {
+  if (Array.isArray(node)) {
+    for (const child of node) walkEnsureRequired(child);
+    return;
+  }
+  if (typeof node !== 'object' || node === null) return;
+  const obj = node as Record<string, unknown>;
+  if (obj['type'] === 'object' && !Array.isArray(obj['required'])) {
+    obj['required'] = [];
+  }
+  for (const child of Object.values(obj)) walkEnsureRequired(child);
 }
 
 export function convertOpenAIError(error: unknown): ChatProviderError {

--- a/packages/kosong/src/providers/openai-common.ts
+++ b/packages/kosong/src/providers/openai-common.ts
@@ -77,6 +77,11 @@ export interface OpenAIToolParam {
 
 /**
  * Convert a kosong `Tool` to OpenAI tool format.
+ *
+ * OpenAI-compatible relays that forward to Moonshot backends validate tool
+ * parameters as Moonshot-flavored JSON Schema. Ensure `required` is always an
+ * array on object schemas so those gateways do not reject the request with:
+ * `required must be an array`.
  */
 export function toolToOpenAI(tool: Tool): OpenAIToolParam {
   return {
@@ -84,9 +89,35 @@ export function toolToOpenAI(tool: Tool): OpenAIToolParam {
     function: {
       name: tool.name,
       description: tool.description,
-      parameters: tool.parameters,
+      parameters: ensureObjectRequiredArrays(tool.parameters),
     },
   };
+}
+
+/**
+ * Walk a JSON Schema and force `required` to `[]` when a node has
+ * `type: "object"` but `required` is missing or not an array.
+ */
+export function ensureObjectRequiredArrays(
+  schema: Record<string, unknown> | undefined,
+): Record<string, unknown> | undefined {
+  if (schema === undefined) return undefined;
+  const cloned = structuredClone(schema) as unknown;
+  walkEnsureRequired(cloned);
+  return cloned as Record<string, unknown>;
+}
+
+function walkEnsureRequired(node: unknown): void {
+  if (Array.isArray(node)) {
+    for (const child of node) walkEnsureRequired(child);
+    return;
+  }
+  if (typeof node !== 'object' || node === null) return;
+  const obj = node as Record<string, unknown>;
+  if (obj['type'] === 'object' && !Array.isArray(obj['required'])) {
+    obj['required'] = [];
+  }
+  for (const child of Object.values(obj)) walkEnsureRequired(child);
 }
 
 /**

--- a/packages/kosong/test/providers/openai-common-tool-schema.test.ts
+++ b/packages/kosong/test/providers/openai-common-tool-schema.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from 'vitest';
+import { ensureObjectRequiredArrays, toolToOpenAI } from '#/providers/openai-common';
+import type { Tool } from '#/tool';
+
+describe('toolToOpenAI schema compatibility', () => {
+  it('forces missing required to [] on object tool parameters', () => {
+    const tool: Tool = {
+      name: 'demo',
+      description: 'demo tool',
+      parameters: {
+        type: 'object',
+        properties: {
+          path: { type: 'string' },
+        },
+      },
+    };
+
+    const converted = toolToOpenAI(tool);
+    expect(converted.function.parameters).toEqual({
+      type: 'object',
+      properties: {
+        path: { type: 'string' },
+      },
+      required: [],
+    });
+  });
+
+  it('forces non-array required to []', () => {
+    const tool: Tool = {
+      name: 'demo',
+      description: 'demo tool',
+      parameters: {
+        type: 'object',
+        properties: {
+          path: { type: 'string' },
+        },
+        // Invalid for Moonshot-flavored schema; some generators emit boolean-style required.
+        required: true as unknown as string[],
+      },
+    };
+
+    const converted = toolToOpenAI(tool);
+    expect(converted.function.parameters?.['required']).toEqual([]);
+  });
+
+  it('preserves valid required arrays and nested object schemas', () => {
+    const tool: Tool = {
+      name: 'demo',
+      description: 'demo tool',
+      parameters: {
+        type: 'object',
+        properties: {
+          nested: {
+            type: 'object',
+            properties: {
+              id: { type: 'string' },
+            },
+          },
+        },
+        required: ['nested'],
+      },
+    };
+
+    const converted = toolToOpenAI(tool);
+    expect(converted.function.parameters).toEqual({
+      type: 'object',
+      properties: {
+        nested: {
+          type: 'object',
+          properties: {
+            id: { type: 'string' },
+          },
+          required: [],
+        },
+      },
+      required: ['nested'],
+    });
+  });
+});
+
+describe('ensureObjectRequiredArrays', () => {
+  it('returns undefined for undefined input', () => {
+    expect(ensureObjectRequiredArrays(undefined)).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

- OpenAI-compatible relays that forward to Moonshot backends validate tool parameters as **Moonshot-flavored JSON Schema**.
- With `providers.*.type = "openai"`, `toolToOpenAI` previously passed tool `parameters` through unchanged.
- If any object schema had missing / non-array `required`, the upstream returns:

```
400 Invalid request: ***.***.parameters is not a valid moonshot flavored json schema
details: <At path 'required': required must be an array>
```

- This PR makes `toolToOpenAI` force `required: []` on `type: "object"` nodes when `required` is missing or not an array (both `packages/kosong` and `packages/agent-core-v2`).
- The `type = "kimi"` path already runs `normalizeKimiToolSchema`; this closes the gap for the OpenAI wire used by third-party relays.

## Test plan

- [x] `pnpm --filter @moonshot-ai/kosong exec vitest run test/providers/openai-common-tool-schema.test.ts`
- [ ] CI full suite on this PR
- [ ] Manual: `kimi` with `type = "openai"` against a Moonshot-strict relay, ensure tool-enabled turns no longer 400 on `required`

## Notes

This is a focused wire-format compatibility fix. It does not change Anthropic/Google tool conversion.