### PR TITLE
chore: remove superpowers toolbar tip

### DIFF
--- a/.changeset/remove-superpowers-tip.md
+++ b/.changeset/remove-superpowers-tip.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Remove the toolbar tip that suggested trying the "superpowers" plugin.

--- a/apps/kimi-code/src/tui/constant/tips.ts
+++ b/apps/kimi-code/src/tui/constant/tips.ts
@@ -20,7 +20,6 @@ export const WORKING_TIPS: readonly ToolbarTip[] = [
   { text: '/tasks to check progress and status for background tasks', priority: 2 },
   { text: '/init: generate AGENTS.md', priority: 2 },
   { text: 'Try /dance for a hidden Easter egg' },
-  { text: '/plugins: manage plugins — try the "superpowers" plugin', solo: true, priority: 3 },
   {
     text: '/plugins: manage plugins — try the "Kimi Datasource" for reliable financial, economic, and academic data',
     solo: true,


### PR DESCRIPTION
<!--
Thank you for your contribution to Kimi Code!
Please open an issue before sending a feature PR — PRs without prior discussion may be closed without review.

See https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md for more.
-->

## Related Issue

No related issue. This is a small wording cleanup.

## Problem

One of the rotating toolbar tips behind the composing spinner still recommended trying the "superpowers" plugin. This tip is no longer desired.

## What changed

- Removed the `superpowers` plugin tip from `apps/kimi-code/src/tui/constant/tips.ts`.
- Added a changeset so the CLI release notes reflect the wording change.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.
