### PR TITLE
fix: echo thinking under the reasoning field the endpoint actually uses

### DIFF
--- a/.changeset/reasoning-field-dialect.md
+++ b/.changeset/reasoning-field-dialect.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Fix loss of thinking content with OpenAI-compatible endpoints that return reasoning under a different field name (e.g. newer vLLM); the reasoning field is now detected per endpoint and echoed back on follow-up requests.

--- a/packages/agent-core-v2/src/kosong/provider/bases/openai/openai-legacy.ts
+++ b/packages/agent-core-v2/src/kosong/provider/bases/openai/openai-legacy.ts
@@ -72,6 +72,7 @@ import {
   type ToolMessageConversion,
   toolToOpenAI,
 } from './openai-common';
+import { ReasoningKeyDialect } from './reasoning-key';
 import {
   mergeRequestHeaders,
   requireProviderApiKey,
@@ -79,8 +80,11 @@ import {
 } from '../request-auth';
 import { normalizeToolCallIdsForProvider, sanitizeToolCallId } from '../tool-call-id';
 
-const KNOWN_REASONING_KEYS = ['reasoning_content', 'reasoning_details', 'reasoning'] as const;
-const DEFAULT_OUTBOUND_REASONING_KEY = KNOWN_REASONING_KEYS[0];
+// Inbound: scan the known reasoning field names in priority order; first
+// string value wins. Outbound: echo the dialect the endpoint actually spoke
+// (detected by ReasoningKeyDialect), defaulting to `reasoning_content`. Both
+// arms can be pinned by an explicit key — operator config (`reasoning_key`)
+// or a trait's `reasoningKey` declaration.
 
 const CHAT_COMPLETIONS_MAX_OUTPUT_TOKENS_CEILING = 128 * 1024;
 
@@ -166,20 +170,6 @@ interface OpenAIToolCallOut {
   function: { name: string; arguments: string | null };
 }
 
-function extractReasoningContent(
-  source: unknown,
-  explicitKey: string | undefined,
-): string | undefined {
-  if (typeof source !== 'object' || source === null) return undefined;
-  const record = source as Record<string, unknown>;
-  const keys: readonly string[] = explicitKey !== undefined ? [explicitKey] : KNOWN_REASONING_KEYS;
-  for (const key of keys) {
-    const value = record[key];
-    if (typeof value === 'string') return value;
-  }
-  return undefined;
-}
-
 function usesMaxCompletionTokens(model: string): boolean {
   const normalized = model.toLowerCase();
   return /^o\d(?:$|[-.])/.test(normalized) || /^gpt-5(?:$|[-.])/.test(normalized);
@@ -225,7 +215,7 @@ function responseFormatToOpenAI(format: ResponseFormat): Record<string, unknown>
 
 function convertMessage(
   message: Message,
-  reasoningKey: string | undefined,
+  reasoningKey: string,
   toolMessageConversion: ToolMessageConversion,
   preserveThinking: boolean,
   allowToolResultExtraction: boolean,
@@ -291,8 +281,10 @@ function convertMessage(
     result.tool_call_id = message.toolCallId;
   }
 
+  // Round-trip thinking under the dialect the endpoint actually spoke
+  // (detected from inbound responses; defaults to `reasoning_content`).
   if (hasReasoningPart || (preserveThinking && message.role === 'assistant')) {
-    result[reasoningKey ?? DEFAULT_OUTBOUND_REASONING_KEY] = reasoningContent;
+    result[reasoningKey] = reasoningContent;
   }
 
   return result;
@@ -348,7 +340,7 @@ function appendToolResultMediaMessage(
 
 function convertHistoryMessages(
   history: readonly Message[],
-  reasoningKey: string | undefined,
+  reasoningKey: string,
   toolMessageConversion: ToolMessageConversion,
   preserveThinking: boolean,
 ): OpenAIMessage[] {
@@ -380,7 +372,7 @@ export class OpenAILegacyStreamedMessage implements StreamedMessage {
   constructor(
     response: OpenAI.Chat.ChatCompletion | AsyncIterable<OpenAI.Chat.ChatCompletionChunk>,
     isStream: boolean,
-    reasoningKey: string | undefined,
+    reasoningKeyDialect: ReasoningKeyDialect,
     private readonly _traceId: string | null,
     private readonly _extractUsageHook?:
       | ((chunk: Record<string, unknown>) => Record<string, unknown> | null | undefined)
@@ -389,12 +381,12 @@ export class OpenAILegacyStreamedMessage implements StreamedMessage {
     if (isStream) {
       this._iter = this._convertStreamResponse(
         response as AsyncIterable<OpenAI.Chat.ChatCompletionChunk>,
-        reasoningKey,
+        reasoningKeyDialect,
       );
     } else {
       this._iter = this._convertNonStreamResponse(
         response as OpenAI.Chat.ChatCompletion,
-        reasoningKey,
+        reasoningKeyDialect,
       );
     }
   }
@@ -441,7 +433,7 @@ export class OpenAILegacyStreamedMessage implements StreamedMessage {
 
   private async *_convertNonStreamResponse(
     response: OpenAI.Chat.ChatCompletion,
-    reasoningKey: string | undefined,
+    reasoningKeyDialect: ReasoningKeyDialect,
   ): AsyncGenerator<StreamedMessagePart> {
     this._id = response.id;
     this._captureUsage(response as unknown as Record<string, unknown>, response.usage);
@@ -450,7 +442,9 @@ export class OpenAILegacyStreamedMessage implements StreamedMessage {
     const message = response.choices[0]?.message;
     if (!message) return;
 
-    const reasoning = extractReasoningContent(message, reasoningKey);
+    // Reasoning content: honor the explicit key when set, otherwise scan the
+    // de facto field set and remember the dialect for outbound echo.
+    const reasoning = reasoningKeyDialect.observe(message);
     if (reasoning !== undefined) {
       yield { type: 'think', think: reasoning } satisfies StreamedMessagePart;
     }
@@ -474,7 +468,7 @@ export class OpenAILegacyStreamedMessage implements StreamedMessage {
 
   private async *_convertStreamResponse(
     response: AsyncIterable<OpenAI.Chat.ChatCompletionChunk>,
-    reasoningKey: string | undefined,
+    reasoningKeyDialect: ReasoningKeyDialect,
   ): AsyncGenerator<StreamedMessagePart> {
     const bufferedToolCalls = new Map<number | string, BufferedChatCompletionToolCall>();
 
@@ -499,7 +493,9 @@ export class OpenAILegacyStreamedMessage implements StreamedMessage {
 
         const delta = choice.delta;
 
-        const reasoning = extractReasoningContent(delta, reasoningKey);
+        // Reasoning content: honor the explicit key when set, otherwise scan
+        // the de facto field set and remember the dialect for outbound echo.
+        const reasoning = reasoningKeyDialect.observe(delta);
         if (reasoning !== undefined) {
           yield { type: 'think', think: reasoning } satisfies StreamedMessagePart;
         }
@@ -528,7 +524,7 @@ export class OpenAILegacyChatProvider implements ChatProvider {
   private readonly _apiKey: string | undefined;
   private readonly _baseUrl: string | undefined;
   private readonly _defaultHeaders: Record<string, string> | undefined;
-  private readonly _reasoningKey: string | undefined;
+  private readonly _reasoningKeyDialect: ReasoningKeyDialect;
   private readonly _offEffort: string | undefined;
   private readonly _thinkingEffort: ThinkingEffort | undefined;
   private readonly _generationKwargs: OpenAILegacyGenerationKwargs;
@@ -557,10 +553,14 @@ export class OpenAILegacyChatProvider implements ChatProvider {
     this._stream = options.stream ?? true;
     this._hooks = options.hooks;
     const normalizedReasoningKey = options.reasoningKey?.trim();
-    this._reasoningKey =
+    // An explicit key — operator config or a trait declaration — pins the
+    // dialect and disables detection; with neither, the dialect is learned
+    // from inbound responses (defaulting to `reasoning_content`).
+    this._reasoningKeyDialect = new ReasoningKeyDialect(
       normalizedReasoningKey !== undefined && normalizedReasoningKey.length > 0
         ? normalizedReasoningKey
-        : this._hooks?.reasoningKey?.();
+        : this._hooks?.reasoningKey?.(),
+    );
     this._thinkingEffort = options.thinkingEffort;
     this._offEffort = options.offEffort;
     this._generationKwargs = normalizeGenerationKwargs(
@@ -603,6 +603,8 @@ export class OpenAILegacyChatProvider implements ChatProvider {
     // reasoning field; the hook reads the already-seeded kwargs (e.g. the
     // thinking config a withThinking hook just encoded).
     const preserveThinking = this._hooks?.preserveThinking?.(kwargs) ?? false;
+    // Outbound reasoning field: the dialect the endpoint actually spoke.
+    const reasoningKey = this._reasoningKeyDialect.outboundKey();
 
     const messages: Record<string, unknown>[] = [];
     if (systemPrompt) {
@@ -617,7 +619,7 @@ export class OpenAILegacyChatProvider implements ChatProvider {
       // Trait mode: the tool-declaration-only skip and the tool-result media
       // extraction are handed over to the trait wholesale.
       for (const msg of normalizedHistory) {
-        const converted = convertMessage(msg, this._reasoningKey, null, preserveThinking, false);
+        const converted = convertMessage(msg, reasoningKey, null, preserveThinking, false);
         const shaped = convertMessageHook(msg, converted);
         if (shaped !== null) {
           messages.push(shaped);
@@ -627,7 +629,7 @@ export class OpenAILegacyChatProvider implements ChatProvider {
       messages.push(
         ...convertHistoryMessages(
           normalizedHistory,
-          this._reasoningKey,
+          reasoningKey,
           this._toolMessageConversion,
           preserveThinking,
         ),
@@ -680,7 +682,7 @@ export class OpenAILegacyChatProvider implements ChatProvider {
           | OpenAI.Chat.ChatCompletion
           | AsyncIterable<OpenAI.Chat.ChatCompletionChunk>,
         this._stream,
-        this._reasoningKey,
+        this._reasoningKeyDialect,
         parseTraceId(response.headers),
         this._hooks?.extractUsage,
       );

--- a/packages/agent-core-v2/src/kosong/provider/bases/openai/reasoning-key.ts
+++ b/packages/agent-core-v2/src/kosong/provider/bases/openai/reasoning-key.ts
@@ -1,0 +1,87 @@
+/**
+ * The OpenAI-compatible Chat Completions ecosystem never standardized a wire
+ * field for reasoning/thinking content. Three names circulate in the wild:
+ *
+ * - `reasoning_content` — DeepSeek's original convention, used by the Moonshot
+ *   Kimi API, pre-rename vLLM, and most OpenAI-compatible gateways.
+ * - `reasoning_details` — OpenRouter.
+ * - `reasoning` — OpenAI's GPT-OSS guidance; current vLLM renamed to this
+ *   (vllm-project/vllm#27752) and its request side accepts ONLY this name
+ *   (vllm-project/vllm#38488).
+ *
+ * Inbound we accept any of them via a priority scan; outbound we echo back the
+ * dialect the peer actually spoke, learned per endpoint by ReasoningKeyDialect.
+ */
+
+// Inbound scan order; the first entry doubles as the default outbound dialect
+// before any observation. Both arms can be pinned by an explicit key (see
+// ReasoningKeyDialect).
+export const KNOWN_REASONING_KEYS = [
+  'reasoning_content',
+  'reasoning_details',
+  'reasoning',
+] as const;
+
+export type ReasoningKey = (typeof KNOWN_REASONING_KEYS)[number];
+
+export const DEFAULT_REASONING_KEY: ReasoningKey = KNOWN_REASONING_KEYS[0];
+
+/**
+ * Find the reasoning text on an inbound chat-completions message or stream
+ * delta, returning the wire key it was found under. With `explicitKey`, only
+ * that key is consulted. Non-string values are skipped (vLLM's compatibility
+ * placeholder `reasoning_content: null`, OpenRouter's array-shaped
+ * `reasoning_details`).
+ */
+export function extractReasoning(
+  source: unknown,
+  explicitKey?: string,
+): { key: string; value: string } | undefined {
+  if (typeof source !== 'object' || source === null) return undefined;
+  const record = source as Record<string, unknown>;
+  const keys: readonly string[] = explicitKey !== undefined ? [explicitKey] : KNOWN_REASONING_KEYS;
+  for (const key of keys) {
+    const value = record[key];
+    if (typeof value === 'string') return { key, value };
+  }
+  return undefined;
+}
+
+/**
+ * Per-endpoint reasoning-field dialect: observes inbound responses, remembers
+ * which wire key carried reasoning, and echoes that key when serializing
+ * thinking back into outbound messages ("reply in the dialect the peer
+ * spoke"). Detection never clears: a response without reasoning keeps the
+ * last known dialect, and a peer that switches dialects mid-session is
+ * adapted to on its next observation.
+ *
+ * Precedence: an explicit constructor key always wins and disables detection;
+ * otherwise the last observed key; otherwise `DEFAULT_REASONING_KEY`. The
+ * explicit key comes from operator config (`reasoning_key`) or a trait's
+ * `reasoningKey` declaration — both assert a hard protocol fact about the
+ * endpoint. The dialect cell itself is plain instance state: one composed
+ * provider serves one endpoint, so detection simply lives on the instance.
+ */
+export class ReasoningKeyDialect {
+  private _detected: string | undefined;
+
+  constructor(private readonly _explicitKey?: string) {}
+
+  /**
+   * Extract reasoning text from an inbound message or stream delta, remembering
+   * the key it arrived under (unless an explicit key pins the dialect).
+   */
+  observe(source: unknown): string | undefined {
+    const found = extractReasoning(source, this._explicitKey);
+    if (found === undefined) return undefined;
+    if (this._explicitKey === undefined) {
+      this._detected = found.key;
+    }
+    return found.value;
+  }
+
+  /** The wire key to serialize thinking content into on outbound messages. */
+  outboundKey(): string {
+    return this._explicitKey ?? this._detected ?? DEFAULT_REASONING_KEY;
+  }
+}

--- a/packages/agent-core-v2/src/kosong/provider/providers/kimi/kimi.contrib.ts
+++ b/packages/agent-core-v2/src/kosong/provider/providers/kimi/kimi.contrib.ts
@@ -31,12 +31,15 @@
  *       round-trips from the contract message into the wire shape (the base
  *       conversion never emits `extras`), and message-level `tools`
  *       declarations are embedded into the message;
- *     - reasoning: `reasoningKey` names the wire field carrying reasoning
- *       content (`reasoning_content`, used for both inbound extraction and
- *       outbound replay); `preserveThinking` force-replays it in a
- *       `keep: 'all'` session with thinking not disabled — it reads the
- *       already-seeded request kwargs (the thinking config `withThinking`
- *       just encoded), so it decides per request, not per instance;
+ *     - reasoning: the trait deliberately does NOT pin `reasoningKey` — the
+ *       base auto-detects the endpoint's reasoning dialect from inbound
+ *       responses (`reasoning_content` by default, `reasoning` on newer vLLM)
+ *       and echoes that field on outbound replay; operator config
+ *       (`reasoning_key`) or a trait declaration still pins when present.
+ *       `preserveThinking` force-replays the field in a `keep: 'all'` session
+ *       with thinking not disabled — it reads the already-seeded request
+ *       kwargs (the thinking config `withThinking` just encoded), so it
+ *       decides per request, not per instance;
  *     - usage: `extractUsage` finds the usage payload of a Kimi stream chunk
  *       either at the top level (the base's default location) or inside
  *       `choices[0].usage`; returning `undefined` defers to the base default
@@ -84,8 +87,6 @@ import { normalizeKimiToolSchema } from './kimi-schema';
 export const KIMI_API_KEY_ENV = 'KIMI_API_KEY';
 export const KIMI_BASE_URL_ENV = 'KIMI_BASE_URL';
 export const KIMI_DEFAULT_BASE_URL = 'https://api.moonshot.ai/v1';
-
-export const KIMI_REASONING_KEY = 'reasoning_content';
 
 const INTERLEAVED_THINKING_BETA = 'interleaved-thinking-2025-05-14';
 
@@ -198,8 +199,6 @@ export const kimiOpenAITrait: ProtocolTrait = {
     }
     return undefined;
   },
-
-  reasoningKey: () => KIMI_REASONING_KEY,
 
   withMaxCompletionTokens: (maxCompletionTokens) => ({
     max_completion_tokens: maxCompletionTokens,

--- a/packages/agent-core-v2/test/kosong/provider/composition.test.ts
+++ b/packages/agent-core-v2/test/kosong/provider/composition.test.ts
@@ -735,6 +735,135 @@ describe('per-turn intent wire encoding (behavior probes)', () => {
   });
 });
 
+describe('reasoning dialect (behavior probes)', () => {
+  it('yields think parts from the `reasoning` wire field', async () => {
+    const provider = registry.createChatProvider({
+      protocol: 'openai',
+      providerType: 'kimi',
+      modelName: 'kimi-k2',
+      apiKey: 'sk-probe',
+    });
+
+    const client = sdkClient(provider) as { chat: { completions: { create: unknown } } };
+    client.chat.completions.create = vi.fn().mockImplementation(() => {
+      async function* chunks(): AsyncIterable<unknown> {
+        yield { id: 'chatcmpl-probe', choices: [{ index: 0, delta: { reasoning: 'hmm' } }] };
+        yield {
+          id: 'chatcmpl-probe',
+          choices: [{ index: 0, delta: { content: 'ok' }, finish_reason: 'stop' }],
+        };
+      }
+      return {
+        withResponse: () =>
+          Promise.resolve({ data: chunks(), response: { headers: new Headers() } }),
+      };
+    });
+
+    const parts: unknown[] = [];
+    for await (const part of await provider.generate('', [], PROBE_HISTORY)) {
+      parts.push(part);
+    }
+    expect(parts).toEqual([
+      { type: 'think', think: 'hmm' },
+      { type: 'text', text: 'ok' },
+    ]);
+  });
+
+  it('echoes thinking under `reasoning` after the endpoint spoke it', async () => {
+    const provider = registry.createChatProvider({
+      protocol: 'openai',
+      providerType: 'kimi',
+      modelName: 'kimi-k2',
+      apiKey: 'sk-probe',
+    });
+
+    const captured: Array<Record<string, unknown>> = [];
+    const client = sdkClient(provider) as { chat: { completions: { create: unknown } } };
+    client.chat.completions.create = vi.fn().mockImplementation((params: unknown) => {
+      captured.push(params as Record<string, unknown>);
+      async function* chunks(): AsyncIterable<unknown> {
+        yield { id: 'chatcmpl-probe', choices: [{ index: 0, delta: { reasoning: 'hmm' } }] };
+        yield {
+          id: 'chatcmpl-probe',
+          choices: [{ index: 0, delta: { content: 'ok' }, finish_reason: 'stop' }],
+        };
+      }
+      return {
+        withResponse: () =>
+          Promise.resolve({ data: chunks(), response: { headers: new Headers() } }),
+      };
+    });
+
+    // Detection happens while draining the first response.
+    await drain(await provider.generate('', [], PROBE_HISTORY));
+
+    await drain(await provider.generate('', [], THINK_HISTORY));
+
+    const messages = captured[1]?.['messages'] as Array<Record<string, unknown>>;
+    expect(messages[0]).toMatchObject({ reasoning: 'earlier reasoning' });
+    expect(messages[0]).not.toHaveProperty('reasoning_content');
+  });
+
+  it('kimi composition defaults to reasoning_content before any detection', async () => {
+    const provider = registry.createChatProvider({
+      protocol: 'openai',
+      providerType: 'kimi',
+      modelName: 'kimi-k2',
+      apiKey: 'sk-probe',
+    });
+
+    // The probe stream carries no reasoning field, so nothing is detected.
+    const body = await captureOpenAIBody(provider, undefined, THINK_HISTORY);
+
+    const messages = body['messages'] as Array<Record<string, unknown>>;
+    expect(messages[0]).toMatchObject({ reasoning_content: 'earlier reasoning' });
+  });
+
+  it('an explicit reasoningKey pins the dialect against detection', async () => {
+    const provider = new OpenAILegacyChatProvider({
+      model: 'gpt-4.1',
+      apiKey: 'sk-probe',
+      stream: false,
+      reasoningKey: 'custom_key',
+    });
+
+    const captured: Array<Record<string, unknown>> = [];
+    const client = sdkClient(provider) as { chat: { completions: { create: unknown } } };
+    client.chat.completions.create = vi.fn().mockImplementation((params: unknown) => {
+      captured.push(params as Record<string, unknown>);
+      return {
+        withResponse: () =>
+          Promise.resolve({
+            data: {
+              id: 'chatcmpl-probe',
+              choices: [
+                {
+                  index: 0,
+                  message: { role: 'assistant', content: 'ok', reasoning: 'hmm' },
+                  finish_reason: 'stop',
+                },
+              ],
+            },
+            response: { headers: new Headers() },
+          }),
+      };
+    });
+
+    // With an explicit key, only that key is read inbound: a `reasoning`
+    // field is not picked up, and detection stays out of the way.
+    const firstParts: unknown[] = [];
+    for await (const part of await provider.generate('', [], PROBE_HISTORY)) {
+      firstParts.push(part);
+    }
+    expect(firstParts).toEqual([{ type: 'text', text: 'ok' }]);
+
+    await drain(await provider.generate('', [], THINK_HISTORY));
+
+    const messages = captured[1]?.['messages'] as Array<Record<string, unknown>>;
+    expect(messages[0]).toMatchObject({ custom_key: 'earlier reasoning' });
+  });
+});
+
 const CONTACT_SCHEMA = {
   type: 'object',
   properties: { name: { type: 'string' } },

--- a/packages/agent-core-v2/test/kosong/provider/kimi.test.ts
+++ b/packages/agent-core-v2/test/kosong/provider/kimi.test.ts
@@ -9,8 +9,9 @@
  *  - `kimiOpenAITrait.convertMessage`: empty-content assistant tool messages
  *    drop `content`; `tool_calls[].extras` round-trips; message-level
  *    `tools` embed;
- *  - `kimiOpenAITrait.reasoningKey` / `preserveThinking`: reasoning field is
- *    `reasoning_content`; force-replay only `keep: 'all'` sessions with
+ *  - reasoning: the trait does NOT pin a `reasoningKey` — the base
+ *    auto-detects the endpoint's dialect, defaulting to `reasoning_content`;
+ *    `preserveThinking` force-replays only `keep: 'all'` sessions with
  *    thinking not disabled;
  *  - `kimiOpenAITrait.extractUsage`: usage at the top level or
  *    `choices[0].usage`;
@@ -140,8 +141,11 @@ describe('kimiOpenAITrait.convertMessage', () => {
 });
 
 describe('kimiOpenAITrait reasoning hooks', () => {
-  it('declares reasoning_content as the reasoning field', () => {
-    expect(call(kimiOpenAITrait.reasoningKey, context)).toBe('reasoning_content');
+  it('does not pin a reasoning field — the base detects the endpoint dialect', () => {
+    // Detection defaults to `reasoning_content` (Kimi's native field) and
+    // adapts to peers that speak `reasoning` (newer vLLM); a trait pin would
+    // disable that adaptation. Operator config `reasoning_key` still pins.
+    expect(kimiOpenAITrait.reasoningKey).toBeUndefined();
   });
 
   it('force-replays reasoning only in keep:all sessions with thinking enabled', () => {
@@ -289,7 +293,6 @@ describe('trait objects are plain declarations', () => {
       'endpoint',
       'extractUsage',
       'preserveThinking',
-      'reasoningKey',
       'strictThinkingValidation',
       'uploadVideo',
       'withMaxCompletionTokens',

--- a/packages/agent-core/src/agent/config/index.ts
+++ b/packages/agent-core/src/agent/config/index.ts
@@ -162,6 +162,17 @@ export class ConfigState {
     return provider;
   }
 
+  /**
+   * Memo of the base provider built by {@link provider}, keyed by config
+   * content. The morphs applied per access (withThinking, sampling,
+   * thinking.keep) clone the base, and the clones share provider-level state
+   * — the OpenAI client and the reasoning-field dialect detected from inbound
+   * responses. Rebuilding the base per access would silently reset that
+   * dialect on every turn; a config change (model switch, credential refresh)
+   * changes the key and rebuilds cleanly.
+   */
+  private providerMemo: { key: string; provider: ChatProvider } | undefined;
+
   get provider(): ChatProvider {
     // All provider-level request config is applied here so every request built
     // from config.provider — the main loop AND full-history compaction — carries it:
@@ -172,7 +183,12 @@ export class ConfigState {
     //   - thinking.keep: env KIMI_MODEL_THINKING_KEEP > config thinking.keep > default "all"
     //     (only while thinking is on). Drives Kimi's `thinking.keep` and, on the
     //     Anthropic path, a `context_management` `clear_thinking_20251015` edit.
-    const provider = createProvider(this.providerConfig).withThinking(this.thinkingEffort);
+    const providerConfig = this.providerConfig;
+    const memoKey = JSON.stringify(providerConfig);
+    if (this.providerMemo?.key !== memoKey) {
+      this.providerMemo = { key: memoKey, provider: createProvider(providerConfig) };
+    }
+    const provider = this.providerMemo.provider.withThinking(this.thinkingEffort);
     const withSampling = applyKimiEnvSamplingParams(provider);
     const configKeep = this.agent.kimiConfig?.thinking?.keep;
     const withKimiKeep = applyKimiEnvThinkingKeep(

--- a/packages/agent-core/test/agent/config-state.test.ts
+++ b/packages/agent-core/test/agent/config-state.test.ts
@@ -693,3 +693,48 @@ describe('ConfigState.provider applies global KIMI_MODEL_* request config', () =
     }
   });
 });
+
+describe('ConfigState.provider memo (reasoning dialect survives turns)', () => {
+  function kimiAgentWithTwoModels() {
+    const config: KimiConfig = {
+      providers: { kimi: { type: 'kimi', apiKey: 'test-key' } },
+      models: {
+        'kimi-code': { provider: 'kimi', model: 'kimi-code', maxContextSize: 128_000 },
+        'kimi-code-2': { provider: 'kimi', model: 'kimi-code-2', maxContextSize: 128_000 },
+      },
+    };
+    return testAgent({
+      initialConfig: config,
+      providerManager: new ProviderManager({ config }),
+    });
+  }
+
+  it('shares the reasoning-dialect cell across repeated accesses with unchanged config', () => {
+    const ctx = kimiAgentWithTwoModels();
+    ctx.agent.config.update({ modelAlias: 'kimi-code' });
+
+    const first = ctx.agent.config.provider;
+    const second = ctx.agent.config.provider;
+
+    // Each access returns a fresh morph clone, but the clones share the
+    // dialect cell learned from inbound responses — without the memo, the
+    // dialect detected on one turn would be lost before the next request.
+    expect(first).not.toBe(second);
+    expect(Reflect.get(first as object, '_reasoningKeyDialect')).toBe(
+      Reflect.get(second as object, '_reasoningKeyDialect'),
+    );
+  });
+
+  it('rebuilds the base provider (fresh dialect cell) when the resolved config changes', () => {
+    const ctx = kimiAgentWithTwoModels();
+    ctx.agent.config.update({ modelAlias: 'kimi-code' });
+    const before = ctx.agent.config.provider;
+
+    ctx.agent.config.update({ modelAlias: 'kimi-code-2' });
+    const after = ctx.agent.config.provider;
+
+    expect(Reflect.get(after as object, '_reasoningKeyDialect')).not.toBe(
+      Reflect.get(before as object, '_reasoningKeyDialect'),
+    );
+  });
+});

--- a/packages/kosong/src/providers/kimi.ts
+++ b/packages/kosong/src/providers/kimi.ts
@@ -31,6 +31,7 @@ import {
   type OpenAIToolParam,
   toolToOpenAI,
 } from './openai-common';
+import { ReasoningKeyDialect, type ReasoningKey } from './reasoning-key';
 import {
   mergeRequestHeaders,
   requireProviderApiKey,
@@ -94,6 +95,8 @@ interface OpenAIMessage {
   tool_call_id?: string | undefined;
   name?: string | undefined;
   reasoning_content?: string | undefined;
+  reasoning_details?: string | undefined;
+  reasoning?: string | undefined;
   /** Message-level tool declarations (`messages[].tools`), see convertMessage. */
   tools?: OpenAIToolParam[] | undefined;
 }
@@ -113,7 +116,11 @@ function isEffectivelyEmptyContent(parts: ContentPart[]): boolean {
   return true;
 }
 
-function convertMessage(message: Message, preservedThinkingEnabled: boolean): OpenAIMessage {
+function convertMessage(
+  message: Message,
+  preservedThinkingEnabled: boolean,
+  reasoningKey: ReasoningKey,
+): OpenAIMessage {
   let reasoningContent = '';
   let hasReasoningPart = false;
   const nonThinkParts: ContentPart[] = [];
@@ -168,7 +175,10 @@ function convertMessage(message: Message, preservedThinkingEnabled: boolean): Op
   }
 
   if (hasReasoningPart || (preservedThinkingEnabled && message.role === 'assistant')) {
-    result.reasoning_content = reasoningContent;
+    // Echo thinking back under the dialect the endpoint spoke (detected from
+    // inbound responses; defaults to `reasoning_content`). Newer vLLM dropped
+    // `reasoning_content` on its request side and only honors `reasoning`.
+    result[reasoningKey] = reasoningContent;
   }
 
   // Message-level tool declarations: a system message carrying `tools` loads
@@ -257,6 +267,7 @@ class KimiStreamedMessage implements StreamedMessage {
     response: OpenAI.Chat.ChatCompletion | AsyncIterable<OpenAI.Chat.ChatCompletionChunk>,
     isStream: boolean,
     private readonly _traceId: string | null,
+    private readonly _reasoningKeyDialect: ReasoningKeyDialect,
   ) {
     if (isStream) {
       this._iter = this._convertStreamResponse(
@@ -309,10 +320,12 @@ class KimiStreamedMessage implements StreamedMessage {
     const message = response.choices[0]?.message;
     if (!message) return;
 
-    // reasoning_content (Moonshot proprietary)
-    const rc = (message as unknown as Record<string, unknown>)['reasoning_content'];
-    if (typeof rc === 'string') {
-      yield { type: 'think', think: rc } satisfies StreamedMessagePart;
+    // Reasoning dialect: accept any known wire key and remember which one the
+    // endpoint used, so the next request echoes thinking back under the same
+    // field (newer vLLM renamed `reasoning_content` to `reasoning`).
+    const reasoning = this._reasoningKeyDialect.observe(message);
+    if (reasoning !== undefined) {
+      yield { type: 'think', think: reasoning } satisfies StreamedMessagePart;
     }
 
     if (message.content) {
@@ -367,10 +380,10 @@ class KimiStreamedMessage implements StreamedMessage {
 
         const delta = choice.delta;
 
-        // reasoning_content (Moonshot proprietary)
-        const rc = (delta as unknown as Record<string, unknown>)['reasoning_content'];
-        if (typeof rc === 'string') {
-          yield { type: 'think', think: rc } satisfies StreamedMessagePart;
+        // Reasoning dialect: same detection as the non-stream path.
+        const reasoning = this._reasoningKeyDialect.observe(delta);
+        if (reasoning !== undefined) {
+          yield { type: 'think', think: reasoning } satisfies StreamedMessagePart;
         }
 
         // text content
@@ -412,6 +425,7 @@ export class KimiChatProvider implements ChatProvider {
   private _client: OpenAI | undefined;
   private _clientFactory: ((auth: ProviderRequestAuth) => OpenAI) | undefined;
   private _files: KimiFiles | undefined;
+  private _reasoningKeyDialect: ReasoningKeyDialect;
 
   constructor(options: KimiOptions) {
     const apiKey = options.apiKey ?? process.env['KIMI_API_KEY'];
@@ -430,6 +444,7 @@ export class KimiChatProvider implements ChatProvider {
             baseURL: this._baseUrl,
             defaultHeaders: this._defaultHeaders,
           });
+    this._reasoningKeyDialect = new ReasoningKeyDialect();
   }
 
   get modelName(): string {
@@ -486,9 +501,12 @@ export class KimiChatProvider implements ChatProvider {
     const thinking = this._generationKwargs.extra_body?.thinking;
     const preservedThinkingEnabled =
       thinking?.keep === 'all' && thinking.type !== 'disabled';
+    // The kimi provider never pins an explicit reasoning key, so the dialect
+    // always resolves to one of the known wire keys.
+    const reasoningKey = this._reasoningKeyDialect.outboundKey() as ReasoningKey;
     const normalizedHistory = normalizeToolCallIdsForProvider(history, KIMI_TOOL_CALL_ID_POLICY);
     for (const msg of normalizedHistory) {
-      messages.push(convertMessage(msg, preservedThinkingEnabled));
+      messages.push(convertMessage(msg, preservedThinkingEnabled, reasoningKey));
     }
 
     const kwargs: Record<string, unknown> = {
@@ -558,6 +576,7 @@ export class KimiChatProvider implements ChatProvider {
           | AsyncIterable<OpenAI.Chat.ChatCompletionChunk>,
         this._stream,
         parseTraceId(response.headers),
+        this._reasoningKeyDialect,
       );
     } catch (error: unknown) {
       throw convertOpenAIError(error);
@@ -654,6 +673,9 @@ export class KimiChatProvider implements ChatProvider {
     // a closed socket. Keep `_client` shared and never mutate it after
     // construction; instead build a new KimiChatProvider when a real new
     // client is required.
+    // `_reasoningKeyDialect` is shared for the same reason: the dialect
+    // learned from a response on any per-step clone must steer the next
+    // request's outbound reasoning key.
     return clone;
   }
 }

--- a/packages/kosong/src/providers/openai-legacy.ts
+++ b/packages/kosong/src/providers/openai-legacy.ts
@@ -31,6 +31,7 @@ import {
   convertChatCompletionStreamToolCall,
   type BufferedChatCompletionToolCall,
 } from './chat-completions-stream';
+import { ReasoningKeyDialect } from './reasoning-key';
 import {
   mergeRequestHeaders,
   requireProviderApiKey,
@@ -42,11 +43,10 @@ import {
   type ToolCallIdPolicy,
 } from './tool-call-id';
 
-// Inbound: scan in priority order; first string value wins. Outbound: the first
-// entry doubles as the default field we serialize ThinkPart back into. Both
-// arms can be overridden by an explicit `reasoningKey` on the provider config.
-const KNOWN_REASONING_KEYS = ['reasoning_content', 'reasoning_details', 'reasoning'] as const;
-const DEFAULT_OUTBOUND_REASONING_KEY = KNOWN_REASONING_KEYS[0];
+// Inbound: scan the known reasoning field names in priority order; first
+// string value wins. Outbound: echo the dialect the endpoint actually spoke
+// (detected by ReasoningKeyDialect), defaulting to `reasoning_content`. Both
+// arms can be pinned by an explicit `reasoningKey` on the provider config.
 
 /**
  * Hard upper bound on `max_tokens` for OpenAI-compatible chat-completions
@@ -72,20 +72,6 @@ function responseFormatToOpenAI(format: ResponseFormat): Record<string, unknown>
       description: format.jsonSchema.description,
     },
   };
-}
-
-function extractReasoningContent(
-  source: unknown,
-  explicitKey: string | undefined,
-): string | undefined {
-  if (typeof source !== 'object' || source === null) return undefined;
-  const record = source as Record<string, unknown>;
-  const keys: readonly string[] = explicitKey !== undefined ? [explicitKey] : KNOWN_REASONING_KEYS;
-  for (const key of keys) {
-    const value = record[key];
-    if (typeof value === 'string') return value;
-  }
-  return undefined;
 }
 
 export interface OpenAILegacyOptions {
@@ -171,7 +157,7 @@ function normalizeGenerationKwargs(
 
 function convertMessage(
   message: Message,
-  reasoningKey: string | undefined,
+  reasoningKey: string,
   toolMessageConversion: ToolMessageConversion,
 ): OpenAIMessage {
   let reasoningContent = '';
@@ -245,13 +231,14 @@ function convertMessage(
     result.tool_call_id = message.toolCallId;
   }
 
-  // Round-trip thinking content back to the server. Default to the de facto
-  // `reasoning_content` field so OpenAI-compatible reasoners (DeepSeek, Qwen,
-  // One API gateways) work without per-provider configuration. Servers that
-  // don't understand the field ignore it; servers that require a specific
-  // field can override via the explicit `reasoningKey`.
+  // Round-trip thinking content back to the server under the dialect the
+  // endpoint actually spoke (detected from inbound responses; defaults to the
+  // de facto `reasoning_content` so OpenAI-compatible reasoners — DeepSeek,
+  // Qwen, One API gateways — work out of the box). Servers that don't
+  // understand the field ignore it; an explicit `reasoningKey` config pins
+  // the dialect instead of detecting it.
   if (hasReasoningPart) {
-    result[reasoningKey ?? DEFAULT_OUTBOUND_REASONING_KEY] = reasoningContent;
+    result[reasoningKey] = reasoningContent;
   }
 
   return result;
@@ -310,7 +297,7 @@ function appendToolResultMediaMessage(
 
 function convertHistoryMessages(
   history: readonly Message[],
-  reasoningKey: string | undefined,
+  reasoningKey: string,
   toolMessageConversion: ToolMessageConversion,
 ): OpenAIMessage[] {
   const messages: OpenAIMessage[] = [];
@@ -343,17 +330,17 @@ export class OpenAILegacyStreamedMessage implements StreamedMessage {
   constructor(
     response: OpenAI.Chat.ChatCompletion | AsyncIterable<OpenAI.Chat.ChatCompletionChunk>,
     isStream: boolean,
-    reasoningKey: string | undefined,
+    reasoningKeyDialect: ReasoningKeyDialect,
   ) {
     if (isStream) {
       this._iter = this._convertStreamResponse(
         response as AsyncIterable<OpenAI.Chat.ChatCompletionChunk>,
-        reasoningKey,
+        reasoningKeyDialect,
       );
     } else {
       this._iter = this._convertNonStreamResponse(
         response as OpenAI.Chat.ChatCompletion,
-        reasoningKey,
+        reasoningKeyDialect,
       );
     }
   }
@@ -386,7 +373,7 @@ export class OpenAILegacyStreamedMessage implements StreamedMessage {
 
   private async *_convertNonStreamResponse(
     response: OpenAI.Chat.ChatCompletion,
-    reasoningKey: string | undefined,
+    reasoningKeyDialect: ReasoningKeyDialect,
   ): AsyncGenerator<StreamedMessagePart> {
     this._id = response.id;
     if (response.usage) {
@@ -398,8 +385,8 @@ export class OpenAILegacyStreamedMessage implements StreamedMessage {
     if (!message) return;
 
     // Reasoning content: honor the explicit key when set, otherwise scan the
-    // de facto field set so hand-written configs work without it.
-    const reasoning = extractReasoningContent(message, reasoningKey);
+    // de facto field set and remember the dialect for outbound echo.
+    const reasoning = reasoningKeyDialect.observe(message);
     if (reasoning !== undefined) {
       yield { type: 'think', think: reasoning } satisfies StreamedMessagePart;
     }
@@ -423,7 +410,7 @@ export class OpenAILegacyStreamedMessage implements StreamedMessage {
 
   private async *_convertStreamResponse(
     response: AsyncIterable<OpenAI.Chat.ChatCompletionChunk>,
-    reasoningKey: string | undefined,
+    reasoningKeyDialect: ReasoningKeyDialect,
   ): AsyncGenerator<StreamedMessagePart> {
     const bufferedToolCalls = new Map<number | string, BufferedChatCompletionToolCall>();
 
@@ -453,8 +440,8 @@ export class OpenAILegacyStreamedMessage implements StreamedMessage {
         const delta = choice.delta;
 
         // Reasoning content: honor the explicit key when set, otherwise scan
-        // the de facto field set so hand-written configs work without it.
-        const reasoning = extractReasoningContent(delta, reasoningKey);
+        // the de facto field set and remember the dialect for outbound echo.
+        const reasoning = reasoningKeyDialect.observe(delta);
         if (reasoning !== undefined) {
           yield { type: 'think', think: reasoning } satisfies StreamedMessagePart;
         }
@@ -495,7 +482,7 @@ export class OpenAILegacyChatProvider implements ChatProvider {
   private _apiKey: string | undefined;
   private _baseUrl: string | undefined;
   private _defaultHeaders: Record<string, string> | undefined;
-  private _reasoningKey: string | undefined;
+  private _reasoningKeyDialect: ReasoningKeyDialect;
   private _thinkingEffort: ThinkingEffort | undefined;
   private _offEffort: string | undefined;
   private _generationKwargs: OpenAILegacyGenerationKwargs;
@@ -516,10 +503,11 @@ export class OpenAILegacyChatProvider implements ChatProvider {
     // would otherwise disable the default field scan and route reads/writes
     // through an empty property name.
     const normalizedReasoningKey = options.reasoningKey?.trim();
-    this._reasoningKey =
+    this._reasoningKeyDialect = new ReasoningKeyDialect(
       normalizedReasoningKey !== undefined && normalizedReasoningKey.length > 0
         ? normalizedReasoningKey
-        : undefined;
+        : undefined,
+    );
     this._thinkingEffort = undefined;
     this._offEffort = options.offEffort;
     this._generationKwargs = {
@@ -566,7 +554,11 @@ export class OpenAILegacyChatProvider implements ChatProvider {
       OPENAI_CHAT_TOOL_CALL_ID_POLICY,
     );
     messages.push(
-      ...convertHistoryMessages(normalizedHistory, this._reasoningKey, this._toolMessageConversion),
+      ...convertHistoryMessages(
+        normalizedHistory,
+        this._reasoningKeyDialect.outboundKey(),
+        this._toolMessageConversion,
+      ),
     );
 
     const kwargs: Record<string, unknown> = normalizeGenerationKwargs(
@@ -648,7 +640,7 @@ export class OpenAILegacyChatProvider implements ChatProvider {
         createParams as unknown as OpenAI.Chat.ChatCompletionCreateParamsNonStreaming,
         options?.signal ? { signal: options.signal } : undefined,
       )) as unknown as OpenAI.Chat.ChatCompletion | AsyncIterable<OpenAI.Chat.ChatCompletionChunk>;
-      return new OpenAILegacyStreamedMessage(response, this._stream, this._reasoningKey);
+      return new OpenAILegacyStreamedMessage(response, this._stream, this._reasoningKeyDialect);
     } catch (error: unknown) {
       throw convertOpenAIError(error);
     }
@@ -691,6 +683,9 @@ export class OpenAILegacyChatProvider implements ChatProvider {
       this,
     );
     clone._generationKwargs = { ...this._generationKwargs };
+    // `_reasoningKeyDialect` stays shared by reference: the dialect learned
+    // from a response on any per-step clone must steer the next request's
+    // outbound reasoning key.
     return clone;
   }
 

--- a/packages/kosong/src/providers/reasoning-key.ts
+++ b/packages/kosong/src/providers/reasoning-key.ts
@@ -1,0 +1,89 @@
+/**
+ * The OpenAI-compatible Chat Completions ecosystem never standardized a wire
+ * field for reasoning/thinking content. Three names circulate in the wild:
+ *
+ * - `reasoning_content` — DeepSeek's original convention, used by the Moonshot
+ *   Kimi API, pre-rename vLLM, and most OpenAI-compatible gateways.
+ * - `reasoning_details` — OpenRouter.
+ * - `reasoning` — OpenAI's GPT-OSS guidance; current vLLM renamed to this
+ *   (vllm-project/vllm#27752) and its request side accepts ONLY this name
+ *   (vllm-project/vllm#38488).
+ *
+ * Inbound we accept any of them via a priority scan; outbound we echo back the
+ * dialect the peer actually spoke, learned per endpoint by ReasoningKeyDialect.
+ */
+
+// Inbound scan order; the first entry doubles as the default outbound dialect
+// before any observation. Both arms can be pinned by an explicit key (see
+// ReasoningKeyDialect).
+export const KNOWN_REASONING_KEYS = [
+  'reasoning_content',
+  'reasoning_details',
+  'reasoning',
+] as const;
+
+export type ReasoningKey = (typeof KNOWN_REASONING_KEYS)[number];
+
+export const DEFAULT_REASONING_KEY: ReasoningKey = KNOWN_REASONING_KEYS[0];
+
+/**
+ * Find the reasoning text on an inbound chat-completions message or stream
+ * delta, returning the wire key it was found under. With `explicitKey`, only
+ * that key is consulted. Non-string values are skipped (vLLM's compatibility
+ * placeholder `reasoning_content: null`, OpenRouter's array-shaped
+ * `reasoning_details`).
+ */
+export function extractReasoning(
+  source: unknown,
+  explicitKey?: string,
+): { key: string; value: string } | undefined {
+  if (typeof source !== 'object' || source === null) return undefined;
+  const record = source as Record<string, unknown>;
+  const keys: readonly string[] = explicitKey !== undefined ? [explicitKey] : KNOWN_REASONING_KEYS;
+  for (const key of keys) {
+    const value = record[key];
+    if (typeof value === 'string') return { key, value };
+  }
+  return undefined;
+}
+
+/**
+ * Per-endpoint reasoning-field dialect: observes inbound responses, remembers
+ * which wire key carried reasoning, and echoes that key when serializing
+ * thinking back into outbound messages ("reply in the dialect the peer
+ * spoke"). Detection never clears: a response without reasoning keeps the
+ * last known dialect, and a peer that switches dialects mid-session is
+ * adapted to on its next observation.
+ *
+ * Precedence: an explicit constructor key always wins and disables detection;
+ * otherwise the last observed key; otherwise `DEFAULT_REASONING_KEY`.
+ *
+ * The dialect is a property of the endpoint, not of one provider clone.
+ * Providers clone per generate step (budget clamping, withThinking), so the
+ * instance must be shared by reference across clones — the providers'
+ * `Object.assign`-based `_clone()` does that automatically, same as the
+ * shared `_client`.
+ */
+export class ReasoningKeyDialect {
+  private _detected: string | undefined;
+
+  constructor(private readonly _explicitKey?: string) {}
+
+  /**
+   * Extract reasoning text from an inbound message or stream delta, remembering
+   * the key it arrived under (unless an explicit key pins the dialect).
+   */
+  observe(source: unknown): string | undefined {
+    const found = extractReasoning(source, this._explicitKey);
+    if (found === undefined) return undefined;
+    if (this._explicitKey === undefined) {
+      this._detected = found.key;
+    }
+    return found.value;
+  }
+
+  /** The wire key to serialize thinking content into on outbound messages. */
+  outboundKey(): string {
+    return this._explicitKey ?? this._detected ?? DEFAULT_REASONING_KEY;
+  }
+}

--- a/packages/kosong/test/kimi.test.ts
+++ b/packages/kosong/test/kimi.test.ts
@@ -1284,6 +1284,206 @@ describe('KimiChatProvider', () => {
         },
       ]);
     });
+
+    it('yields reasoning as ThinkPart (vLLM wire field)', async () => {
+      const provider = createProvider();
+      (provider as any)._client.chat.completions.create = vi.fn().mockImplementation(() =>
+        mockCreateResult({
+          id: 'chatcmpl-123',
+          choices: [
+            {
+              message: {
+                role: 'assistant',
+                content: 'The answer is 4.',
+                reasoning: 'Let me think about this...',
+              },
+            },
+          ],
+          usage: { prompt_tokens: 10, completion_tokens: 5, total_tokens: 15 },
+        }),
+      );
+
+      const stream = await provider.generate('', [], []);
+      const parts = [];
+      for await (const part of stream) parts.push(part);
+
+      expect(parts).toEqual([
+        { type: 'think', think: 'Let me think about this...' },
+        { type: 'text', text: 'The answer is 4.' },
+      ]);
+    });
+
+    it('prefers reasoning_content when both fields are present', async () => {
+      const provider = createProvider();
+      (provider as any)._client.chat.completions.create = vi.fn().mockImplementation(() =>
+        mockCreateResult({
+          id: 'chatcmpl-123',
+          choices: [
+            {
+              message: {
+                role: 'assistant',
+                content: 'A',
+                reasoning_content: 'from reasoning_content',
+                reasoning: 'from reasoning',
+              },
+            },
+          ],
+        }),
+      );
+
+      const stream = await provider.generate('', [], []);
+      const parts = [];
+      for await (const part of stream) parts.push(part);
+
+      expect(parts).toEqual([
+        { type: 'think', think: 'from reasoning_content' },
+        { type: 'text', text: 'A' },
+      ]);
+    });
+
+    it('falls back to reasoning when reasoning_content is null', async () => {
+      // Current vLLM emits a compatibility `reasoning_content: null` alongside
+      // the real `reasoning` string; the null must fall through.
+      const provider = createProvider();
+      (provider as any)._client.chat.completions.create = vi.fn().mockImplementation(() =>
+        mockCreateResult({
+          id: 'chatcmpl-123',
+          choices: [
+            {
+              message: {
+                role: 'assistant',
+                content: 'A',
+                reasoning_content: null,
+                reasoning: 'from reasoning',
+              },
+            },
+          ],
+        }),
+      );
+
+      const stream = await provider.generate('', [], []);
+      const parts = [];
+      for await (const part of stream) parts.push(part);
+
+      expect(parts).toEqual([
+        { type: 'think', think: 'from reasoning' },
+        { type: 'text', text: 'A' },
+      ]);
+    });
+  });
+
+  describe('reasoning key dialect', () => {
+    const THINK_HISTORY: Message[] = [
+      {
+        role: 'assistant',
+        content: [
+          { type: 'think', think: 'hmm' },
+          { type: 'text', text: 'ok' },
+        ],
+        toolCalls: [],
+      },
+    ];
+
+    it('echoes thinking under reasoning after a non-stream response used that field', async () => {
+      const provider = createProvider();
+      const captured: Array<Record<string, unknown>> = [];
+      (provider as any)._client.chat.completions.create = vi
+        .fn()
+        .mockImplementation((params: unknown) => {
+          captured.push(params as Record<string, unknown>);
+          return mockCreateResult({
+            id: 'chatcmpl-r',
+            choices: [
+              { message: { role: 'assistant', content: 'ok', reasoning: 'hmm' } },
+            ],
+          });
+        });
+
+      // Detection happens while draining the first response.
+      const first = await provider.generate('', [], []);
+      for await (const part of first) void part;
+
+      const second = await provider.generate('', [], THINK_HISTORY);
+      for await (const part of second) void part;
+
+      const messages = captured[1]?.['messages'] as Array<Record<string, unknown>>;
+      expect(messages[0]).toEqual({ role: 'assistant', content: 'ok', reasoning: 'hmm' });
+    });
+
+    it('detects the dialect from streaming deltas and echoes it on the next request', async () => {
+      const provider = createProvider(true);
+      const captured: Array<Record<string, unknown>> = [];
+      (provider as any)._client.chat.completions.create = vi
+        .fn()
+        .mockImplementation((params: unknown) => {
+          captured.push(params as Record<string, unknown>);
+          async function* chunks(): AsyncIterable<Record<string, unknown>> {
+            yield { id: 'chatcmpl-s', choices: [{ index: 0, delta: { reasoning: 'hmm' } }] };
+            yield {
+              id: 'chatcmpl-s',
+              choices: [{ index: 0, delta: { content: 'ok' }, finish_reason: 'stop' }],
+            };
+          }
+          return mockCreateResult(chunks());
+        });
+
+      const first = await provider.generate('', [], []);
+      const firstParts = [];
+      for await (const part of first) firstParts.push(part);
+      expect(firstParts).toEqual([
+        { type: 'think', think: 'hmm' },
+        { type: 'text', text: 'ok' },
+      ]);
+
+      const second = await provider.generate('', [], THINK_HISTORY);
+      for await (const part of second) void part;
+
+      const messages = captured[1]?.['messages'] as Array<Record<string, unknown>>;
+      expect(messages[0]).toEqual({ role: 'assistant', content: 'ok', reasoning: 'hmm' });
+    });
+
+    it('defaults to reasoning_content before any detection', async () => {
+      const provider = createProvider();
+      let captured: Record<string, unknown> | undefined;
+      (provider as any)._client.chat.completions.create = vi
+        .fn()
+        .mockImplementation((params: unknown) => {
+          captured = params as Record<string, unknown>;
+          return mockCreateResult(makeChatCompletionResponse('kimi-k2'));
+        });
+
+      const stream = await provider.generate('', [], THINK_HISTORY);
+      for await (const part of stream) void part;
+
+      const messages = captured?.['messages'] as Array<Record<string, unknown>>;
+      expect(messages[0]).toEqual({ role: 'assistant', content: 'ok', reasoning_content: 'hmm' });
+    });
+
+    it('dialect detected on a per-step clone steers the original provider', async () => {
+      const original = createProvider();
+      const captured: Array<Record<string, unknown>> = [];
+      (original as any)._client.chat.completions.create = vi
+        .fn()
+        .mockImplementation((params: unknown) => {
+          captured.push(params as Record<string, unknown>);
+          return mockCreateResult({
+            id: 'chatcmpl-r',
+            choices: [{ message: { role: 'assistant', content: 'ok', reasoning: 'hmm' } }],
+          });
+        });
+
+      // The per-step clone shares `_client` (mocked above) and must also share
+      // the dialect cell: learning on the clone steers the original.
+      const clone = original.withMaxCompletionTokens(2048);
+      const first = await clone.generate('', [], []);
+      for await (const part of first) void part;
+
+      const second = await original.generate('', [], THINK_HISTORY);
+      for await (const part of second) void part;
+
+      const messages = captured[1]?.['messages'] as Array<Record<string, unknown>>;
+      expect(messages[0]).toEqual({ role: 'assistant', content: 'ok', reasoning: 'hmm' });
+    });
   });
 
   describe('trace id capture', () => {

--- a/packages/kosong/test/openai-common-errors.test.ts
+++ b/packages/kosong/test/openai-common-errors.test.ts
@@ -14,6 +14,7 @@ import {
   convertOpenAIError,
 } from '#/providers/openai-common';
 import { OpenAILegacyChatProvider, OpenAILegacyStreamedMessage } from '#/providers/openai-legacy';
+import { ReasoningKeyDialect } from '#/providers/reasoning-key';
 import {
   APIError as OpenAIAPIError,
   APIConnectionError as OpenAIConnectionError,
@@ -252,7 +253,7 @@ describe('OpenAI streaming error propagation', () => {
     const msg = new OpenAILegacyStreamedMessage(
       failingStream() as AsyncIterable<never>,
       true,
-      undefined,
+      new ReasoningKeyDialect(),
     );
 
     await expect(async () => {
@@ -270,7 +271,7 @@ describe('OpenAI streaming error propagation', () => {
       const msg2 = new OpenAILegacyStreamedMessage(
         failingStream2() as AsyncIterable<never>,
         true,
-        undefined,
+        new ReasoningKeyDialect(),
       );
       for await (const _ of msg2) {
         void _;
@@ -319,7 +320,7 @@ describe('OpenAI streaming: undici terminated mid-stream', () => {
     const msg = new OpenAILegacyStreamedMessage(
       terminatedStream() as AsyncIterable<never>,
       true,
-      undefined,
+      new ReasoningKeyDialect(),
     );
 
     let caught: unknown;

--- a/packages/kosong/test/openai-legacy.test.ts
+++ b/packages/kosong/test/openai-legacy.test.ts
@@ -590,6 +590,153 @@ describe('OpenAILegacyChatProvider', () => {
         { role: 'user', content: 'Thanks!' },
       ]);
     });
+
+    it('defaults to reasoning_content before any detection', async () => {
+      const provider = createProvider();
+      const history: Message[] = [
+        {
+          role: 'assistant',
+          content: [
+            { type: 'think', think: 'Thinking...' },
+            { type: 'text', text: '4.' },
+          ],
+          toolCalls: [],
+        },
+      ];
+      const body = await captureRequestBody(provider, '', [], history);
+
+      const messages = body['messages'] as Array<Record<string, unknown>>;
+      expect(messages[0]).toEqual({
+        role: 'assistant',
+        content: '4.',
+        reasoning_content: 'Thinking...',
+      });
+    });
+
+    it('echoes thinking under the dialect detected from the response', async () => {
+      const provider = createProvider();
+      const captured: Array<Record<string, unknown>> = [];
+      (provider as any)._client.chat.completions.create = vi
+        .fn()
+        .mockImplementation((params: unknown) => {
+          captured.push(params as Record<string, unknown>);
+          return Promise.resolve({
+            id: 'chatcmpl-r',
+            choices: [
+              {
+                index: 0,
+                message: { role: 'assistant', content: 'ok', reasoning: 'hmm' },
+                finish_reason: 'stop',
+              },
+            ],
+          });
+        });
+
+      // Detection happens while draining the first response.
+      const first = await provider.generate('', [], []);
+      for await (const part of first) void part;
+
+      const history: Message[] = [
+        {
+          role: 'assistant',
+          content: [
+            { type: 'think', think: 'hmm' },
+            { type: 'text', text: 'ok' },
+          ],
+          toolCalls: [],
+        },
+      ];
+      const second = await provider.generate('', [], history);
+      for await (const part of second) void part;
+
+      const messages = captured[1]?.['messages'] as Array<Record<string, unknown>>;
+      expect(messages[0]).toEqual({ role: 'assistant', content: 'ok', reasoning: 'hmm' });
+    });
+
+    it('explicit reasoningKey pins the dialect against detection', async () => {
+      const provider = createProvider({ reasoningKey: 'custom_reasoning' });
+      const captured: Array<Record<string, unknown>> = [];
+      (provider as any)._client.chat.completions.create = vi
+        .fn()
+        .mockImplementation((params: unknown) => {
+          captured.push(params as Record<string, unknown>);
+          return Promise.resolve({
+            id: 'chatcmpl-r',
+            choices: [
+              {
+                index: 0,
+                message: { role: 'assistant', content: 'ok', reasoning: 'hmm' },
+                finish_reason: 'stop',
+              },
+            ],
+          });
+        });
+
+      // With an explicit key, only that key is read inbound: a `reasoning`
+      // field is not picked up, and detection stays out of the way.
+      const first = await provider.generate('', [], []);
+      const firstParts = [];
+      for await (const part of first) firstParts.push(part);
+      expect(firstParts).toEqual([{ type: 'text', text: 'ok' }]);
+
+      const history: Message[] = [
+        {
+          role: 'assistant',
+          content: [
+            { type: 'think', think: 'hmm' },
+            { type: 'text', text: 'ok' },
+          ],
+          toolCalls: [],
+        },
+      ];
+      const second = await provider.generate('', [], history);
+      for await (const part of second) void part;
+
+      const messages = captured[1]?.['messages'] as Array<Record<string, unknown>>;
+      expect(messages[0]).toEqual({ role: 'assistant', content: 'ok', custom_reasoning: 'hmm' });
+    });
+
+    it('dialect detected on a per-step clone steers the original provider', async () => {
+      const original = createProvider();
+      const captured: Array<Record<string, unknown>> = [];
+      (original as any)._client.chat.completions.create = vi
+        .fn()
+        .mockImplementation((params: unknown) => {
+          captured.push(params as Record<string, unknown>);
+          return Promise.resolve({
+            id: 'chatcmpl-r',
+            choices: [
+              {
+                index: 0,
+                message: { role: 'assistant', content: 'ok', reasoning: 'hmm' },
+                finish_reason: 'stop',
+              },
+            ],
+          });
+        });
+
+      // The per-step clone shares `_client` (mocked above) and must also share
+      // the dialect cell: learning on the clone steers the original.
+      const clone = original.withGenerationKwargs({ max_tokens: 2048 });
+      const first = await clone.generate('', [], []);
+      for await (const part of first) void part;
+
+      const history: Message[] = [
+        {
+          role: 'assistant',
+          content: [
+            { type: 'think', think: 'hmm' },
+            { type: 'text', text: 'ok' },
+          ],
+          toolCalls: [],
+        },
+      ];
+      const second = await original.generate('', [], history);
+      for await (const part of second) void part;
+
+      const messages = captured[1]?.['messages'] as Array<Record<string, unknown>>;
+      expect(messages[0]).toEqual({ role: 'assistant', content: 'ok', reasoning: 'hmm' });
+    });
   });
 
   describe('generation kwargs', () => {


### PR DESCRIPTION
## Related Issue

No linked issue — the problem is explained below.

## Problem

OpenAI-compatible endpoints disagree on the wire field that carries reasoning/thinking content: `reasoning_content` (DeepSeek/Moonshot convention, older vLLM) versus `reasoning` (OpenAI's GPT-OSS guidance, current vLLM — renamed in vllm-project/vllm#27752; its request side accepts ONLY `reasoning` and silently drops `reasoning_content`, vllm-project/vllm#38488).

Our chat-completions providers read and wrote only `reasoning_content`. Against newer vLLM (and any peer that speaks `reasoning`): response thinking was silently dropped, and because nothing thinking-shaped entered the context, later requests also sent nothing back — multi-turn runs against vLLM-served thinking models lost reasoning entirely.

## What changed

Per-endpoint **dialect detection + echo**: inbound responses are scanned in priority order (`reasoning_content` → `reasoning_details` → `reasoning`, first string value wins, non-strings skipped), the key that actually carried reasoning is remembered, and outbound messages serialize thinking under the same key — defaulting to `reasoning_content` before any detection, so behavior against the Moonshot endpoint and older vLLM is byte-identical to before. An explicit `reasoningKey` / `reasoning_key` config still pins the dialect and disables detection, preserving the existing escape hatch.

- **kosong**: new shared `reasoning-key` module; wired into the kimi and openai-legacy providers; the dialect cell is shared by reference across per-step provider clones (same pattern as the shared OpenAI client).
- **agent-core-v2**: same mechanism ported into the vendored openai-legacy base; the kimi trait no longer pins `reasoningKey` — its pinned value equals the detection default, so Moonshot behavior is unchanged while vLLM endpoints now self-adapt. Trait-declared or operator-configured keys still pin.
- **agent-core (v1)**: memoize the base provider behind `ConfigState.provider` (keyed by config content). Previously every access rebuilt the provider, which would have reset the detected dialect every turn; morph clones and config-change rebuilds behave exactly as before.

Tests: parse fallback, both-fields priority, `reasoning_content: null` fall-through, stream/non-stream echo, explicit-pin immunity, clone/cross-access dialect propagation in all three packages; full suites pass (kosong, agent-core, agent-core-v2). Also verified end to end over real HTTP against a mock server playing new-vLLM / Moonshot personalities, including a full kap-server session where the second request echoes thinking under the endpoint's field.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.
