### PR TITLE
fix(kimi-web): render inline KaTeX math with conservative $...$ delimiters

### DIFF
--- a/.changeset/wise-pandas-shout.md
+++ b/.changeset/wise-pandas-shout.md
@@ -1,0 +1,5 @@
+---
+'@moonshot-ai/kimi-code': patch
+---
+
+Fix the web UI not rendering inline KaTeX math. Single-dollar inline formulas (`$…$`) now render through KaTeX, while prices, env vars, and shell paths (`$5`, `$PATH`, `$HOME/bin`) stay literal via conservative pandoc-style delimiter rules.

--- a/apps/kimi-web/src/components/chat/Markdown.vue
+++ b/apps/kimi-web/src/components/chat/Markdown.vue
@@ -11,12 +11,16 @@ import {
   setMermaidWorker,
   clearMermaidWorker,
 } from 'markstream-vue';
-import type { MarkdownIt } from 'markstream-vue';
 import { useIsDark } from '../../composables/useIsDark';
 import type { FilePreviewRequest } from '../../types';
 import { collectFilePathAliases, findFilePathLinks } from '../../lib/filePathLinks';
 import { markdownRenderPlan } from '../../lib/markdownPerformance';
 import { copyCodeBlockFallback, copyTextToClipboard } from '../../lib/clipboard';
+// Inline math (`$…$`): enableInlineMath swaps markstream's built-in `math`
+// rule for a conservative pandoc-style variant (see lib/mathInline.ts) so
+// `$…$` formulas render through KaTeX without false-positiving on prices,
+// env vars, and shell paths. `math_block` (the $$ block rule) is untouched.
+import { enableInlineMath } from '../../lib/mathInline';
 import * as katexWorkerModule from 'markstream-vue/workers/katexRenderer.worker?worker&type=module';
 import * as mermaidWorkerModule from 'markstream-vue/workers/mermaidParser.worker?worker&type=module';
 import Tooltip from '../ui/Tooltip.vue';
@@ -63,15 +67,6 @@ clearMermaidWorker();
 
 setKaTeXWorker(new katexWorkerModule.default());
 setMermaidWorker(new mermaidWorkerModule.default());
-
-// Only `$$…$$` display math is rendered; single `$` inline math is disabled so
-// prices, env vars, and shell paths (`$5`, `$PATH`, `$HOME/bin`) stay literal
-// without any escaping or code-detection gymnastics. `math_block` (the $$ rule)
-// is left enabled.
-function disableInlineMath(md: MarkdownIt): MarkdownIt {
-  md.inline.ruler.disable('math');
-  return md;
-}
 
 const { t } = useI18n();
 
@@ -425,7 +420,7 @@ function copyDiff(code: string, idx: number) {
       <MarkdownRender
         v-if="seg.kind === 'md'"
         :content="seg.text"
-        :custom-markdown-it="disableInlineMath"
+        :custom-markdown-it="enableInlineMath"
         mode="chat"
         :code-renderer="renderPlan.codeRenderer"
         :is-dark="isDark"
@@ -693,6 +688,13 @@ function copyDiff(code: string, idx: number) {
      formula (e.g. integral/sum subscripts) */
   padding: 2px 0 6px;
   margin: 0.6em 0;
+}
+
+/* Progressive inline math: while a formula streams in unclosed, KaTeX may
+   not parse the partial source yet — MathInlineNode shows the raw text plus
+   a spinner. The raw text alone is the honest state, so hide the spinner. */
+.md :deep(.math-inline__loading) {
+  display: none;
 }
 
 /* Blockquote */

--- a/apps/kimi-web/src/lib/mathInline.test.ts
+++ b/apps/kimi-web/src/lib/mathInline.test.ts
@@ -1,0 +1,318 @@
+// apps/kimi-web/src/lib/mathInline.test.ts
+import { describe, expect, it } from 'vitest';
+import { mathInline, type MathInlineState } from './mathInline';
+
+interface Seg {
+  kind: 'text' | 'math';
+  text: string;
+  markup?: string;
+  loading?: boolean;
+}
+
+// Minimal stand-in for markdown-it's inline tokenizer: at each position the
+// math rule gets first shot (it sits before `escape` in the real chain);
+// `\x` is consumed as two literal chars the way the escape rule would, and
+// everything else stays literal text. Real code spans are consumed by
+// markdown-it's backticks rule before `$` inside them is ever reached, so
+// the harness doesn't need to model them.
+function scan(src: string, final = true): Seg[] {
+  const segs: Seg[] = [];
+  let text = '';
+  const pushed: { content: string; markup: string; loading?: boolean }[] = [];
+  const state: MathInlineState = {
+    src,
+    pos: 0,
+    env: final ? { __markstreamFinal: true } : {},
+    push: () => {
+      const token: { content: string; markup: string; loading?: boolean } = {
+        content: '',
+        markup: '',
+      };
+      pushed.push(token);
+      return token;
+    },
+  };
+  while (state.pos < src.length) {
+    const pushedBefore = pushed.length;
+    if (mathInline(state, false)) {
+      if (text) {
+        segs.push({ kind: 'text', text });
+        text = '';
+      }
+      const token = pushed[pushedBefore];
+      segs.push({
+        kind: 'math',
+        text: token?.content ?? '',
+        markup: token?.markup ?? '',
+        ...(token?.loading ? { loading: true } : {}),
+      });
+    } else if (src[state.pos] === '\\' && state.pos + 1 < src.length) {
+      text += src.slice(state.pos, state.pos + 2);
+      state.pos += 2;
+    } else {
+      text += src[state.pos];
+      state.pos += 1;
+    }
+  }
+  if (text) segs.push({ kind: 'text', text });
+  return segs;
+}
+
+function math(src: string): Seg[] {
+  return scan(src).filter((s) => s.kind === 'math');
+}
+
+describe('mathInline', () => {
+  it('renders $…$ inline formulas', () => {
+    expect(math('At time $t$, the matrix $\\Sigma_t$ only uses $\\leq t-1$ of information')).toEqual([
+      { kind: 'math', text: 't', markup: '$' },
+      { kind: 'math', text: '\\Sigma_t', markup: '$' },
+      { kind: 'math', text: '\\leq t-1', markup: '$' },
+    ]);
+  });
+
+  it('treats CJK characters as word characters for delimiter adjacency', () => {
+    expect(math('矩阵 $\\Sigma_t$ 的特征值')).toEqual([
+      { kind: 'math', text: '\\Sigma_t', markup: '$' },
+    ]);
+  });
+
+  it('renders a formula containing brackets and commands', () => {
+    expect(math('$\\sum_t [\\log\\det\\Sigma_t + r_t^\\top\\Sigma_t^{-1}r_t]$')).toEqual([
+      {
+        kind: 'math',
+        text: '\\sum_t [\\log\\det\\Sigma_t + r_t^\\top\\Sigma_t^{-1}r_t]',
+        markup: '$',
+      },
+    ]);
+  });
+
+  it('keeps prices literal', () => {
+    expect(math('sell it for $5 flat')).toEqual([]);
+    expect(math('between $5 and $10 dollars')).toEqual([]);
+    expect(math('$5 plus $10')).toEqual([]);
+    expect(math('$1,000.50 成交')).toEqual([]);
+  });
+
+  it('keeps env vars and shell paths literal', () => {
+    expect(math('$PATH')).toEqual([]);
+    expect(math('echo $HOME/bin and $PATH')).toEqual([]);
+  });
+
+  it('keeps bare numbers literal even when closed', () => {
+    expect(math('$100$')).toEqual([]);
+  });
+
+  it('allows math that starts with a digit', () => {
+    expect(math('$3+4=7$')).toEqual([{ kind: 'math', text: '3+4=7', markup: '$' }]);
+  });
+
+  it('rejects a closing $ followed by a digit', () => {
+    expect(math('$x$2')).toEqual([]);
+  });
+
+  it('rejects a closing $ preceded by a space', () => {
+    expect(math('$x $ and nothing after')).toEqual([]);
+  });
+
+  it('never pairs a literal dollar with a later formula (PR review regression)', () => {
+    // A candidate closer that fails the delimiter rules must ABANDON the
+    // opener — skipping it would let `$5` consume the closer of `$x$`.
+    expect(math('Costs $5 and variable $x$')).toEqual([
+      { kind: 'math', text: 'x', markup: '$' },
+    ]);
+    expect(math('price $5 then $x_1$ and $x_2$')).toEqual([
+      { kind: 'math', text: 'x_1', markup: '$' },
+      { kind: 'math', text: 'x_2', markup: '$' },
+    ]);
+    // `$x$2` stays literal (closer followed by a digit) without dragging the
+    // later `$y$` down with it.
+    expect(math('$x$2 and $y$')).toEqual([{ kind: 'math', text: 'y', markup: '$' }]);
+  });
+
+  it('keeps escaped dollars literal', () => {
+    expect(math('\\$x$ is not a formula')).toEqual([]);
+  });
+
+  it('rejects content containing a backtick', () => {
+    expect(math('$a `b` c$')).toEqual([]);
+  });
+
+  it('rejects an unclosed $', () => {
+    expect(math('formula $x never closes')).toEqual([]);
+  });
+
+  it('renders inline $$…$$', () => {
+    expect(math('inline $$e^{i\\pi}+1=0$$ done')).toEqual([
+      { kind: 'math', text: 'e^{i\\pi}+1=0', markup: '$$' },
+    ]);
+  });
+
+  it('renders \\(...\\)', () => {
+    expect(math('inline \\(\\alpha+\\beta\\) done')).toEqual([
+      { kind: 'math', text: '\\alpha+\\beta', markup: '\\(\\)' },
+    ]);
+  });
+
+  it('does not push a token in silent mode', () => {
+    let pushed = 0;
+    const state: MathInlineState = {
+      src: '$x$',
+      pos: 0,
+      push: () => {
+        pushed++;
+        return { content: '', markup: '' };
+      },
+    };
+    expect(mathInline(state, true)).toBe(true);
+    expect(pushed).toBe(0);
+  });
+});
+
+describe('mathInline streaming (unclosed $)', () => {
+  function run(src: string, final: boolean) {
+    const pushed: { content: string; markup: string; loading?: boolean }[] = [];
+    const state: MathInlineState = {
+      src,
+      pos: 0,
+      env: final ? { __markstreamFinal: true } : {},
+      push: () => {
+        const token: { content: string; markup: string; loading?: boolean } = {
+          content: '',
+          markup: '',
+        };
+        pushed.push(token);
+        return token;
+      },
+    };
+    const matched = mathInline(state, false);
+    return { matched, token: pushed[0], pos: state.pos };
+  }
+
+  it('progressively renders partial content with a TeX command', () => {
+    const r = run('$\\Sigma_t + r_t', false);
+    expect(r.matched).toBe(true);
+    expect(r.token).toMatchObject({
+      content: '\\Sigma_t + r_t',
+      markup: '$',
+      loading: true,
+    });
+    expect(r.pos).toBe('$\\Sigma_t + r_t'.length);
+  });
+
+  it('keeps partial content without a TeX signal literal', () => {
+    for (const src of ['$5', '$PATH', '$x', '$HOME/bin', '$3+4=7']) {
+      expect(run(src, false).matched, src).toBe(false);
+    }
+  });
+
+  it('stops the partial content at a line break', () => {
+    const r = run('$\\Sig\ntrailing prose', false);
+    expect(r.matched).toBe(true);
+    expect(r.token?.content).toBe('\\Sig');
+    expect(r.pos).toBe('$\\Sig'.length);
+  });
+
+  it('never renders partial math in settled messages', () => {
+    expect(run('$\\Sigma_t', true).matched).toBe(false);
+  });
+});
+
+// --- Property-based fuzzing -------------------------------------------------
+// Not a proof, but the pragmatic equivalent for a scanner this size: pin the
+// invariants that define "correct" and hammer them with adversarial inputs.
+// The invariant set directly targets the failure class found in PR review
+// (a literal `$` pairing with a later formula's closer): invariant (2d)
+// forbids math spans from crossing ANY unescaped dollar.
+
+function mulberry32(seed: number): () => number {
+  // oxlint-disable-next-line prefer-math-trunc -- uint32 wrap is intentional
+  let a = seed >>> 0;
+  return () => {
+    // oxlint-disable-next-line prefer-math-trunc -- uint32 wrap is intentional
+    a = (a + 0x6d2b79f5) >>> 0;
+    let t = a;
+    t = Math.imul(t ^ (t >>> 15), t | 1);
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+    // oxlint-disable-next-line prefer-math-trunc -- uint32 wrap is intentional
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+const FRAGMENTS = [
+  '$5', '$x$', '$\\Sigma_t$', '$PATH', '$HOME/bin:$PATH', '$', ' ', '10',
+  'and', '\\(a\\)', '$$b$$', '\\$', '`c$d`', '\n', '$x_1$', '$100$',
+  '$3+4=7$', ' Costs ', 'vars', '$MY_VAR', '${PATH}', '$x$2',
+];
+const ALPHABET = '$$$$0125 ,\\abcxyz_^={}()`\n.t';
+
+function genStructured(rnd: () => number): string {
+  const n = 1 + Math.floor(rnd() * 8);
+  let s = '';
+  for (let i = 0; i < n; i++) s += FRAGMENTS[Math.floor(rnd() * FRAGMENTS.length)];
+  return s;
+}
+
+function genNoise(rnd: () => number): string {
+  const n = 1 + Math.floor(rnd() * 60);
+  let s = '';
+  for (let i = 0; i < n; i++) s += ALPHABET[Math.floor(rnd() * ALPHABET.length)];
+  return s;
+}
+
+/** Rebuild the source from segments — must be perfectly lossless. Loading
+    (unclosed) math has no closing delimiter in the source. */
+function reconstruct(segs: Seg[]): string {
+  return segs
+    .map((s) => {
+      if (s.kind === 'text') return s.text;
+      if (s.loading) return `$${s.text}`;
+      if (s.markup === '$$') return `$$${s.text}$$`;
+      if (s.markup === '\\(\\)') return `\\(${s.text}\\)`;
+      return `$${s.text}$`;
+    })
+    .join('');
+}
+
+function expectInvariants(src: string, final: boolean): void {
+  const segs = scan(src, final);
+  // (1) Lossless round-trip: tokenization never drops, alters, or reorders
+  // a single character.
+  expect(reconstruct(segs), `round-trip failed for ${JSON.stringify(src)}`).toBe(src);
+  for (const seg of segs) {
+    if (seg.kind !== 'math') continue;
+    const label = `seg ${JSON.stringify(seg)} in ${JSON.stringify(src)} (final=${final})`;
+    // (2a) non-empty content
+    expect(seg.text.trim(), label).not.toBe('');
+    // (2b) no backtick (code-span crossing)
+    expect(seg.text.includes('`'), label).toBe(false);
+    if (seg.loading) {
+      // (3) loading math only while streaming, and only with a TeX signal
+      expect(final, label).toBe(false);
+      expect(/\\[a-zA-Z]/.test(seg.text), label).toBe(true);
+      continue;
+    }
+    if (seg.markup !== '$') continue;
+    // (2c) delimiter adjacency: content never starts/ends with whitespace
+    expect(/^\s|\s$/.test(seg.text), label).toBe(false);
+    // (2d) no unescaped `$` — math spans never cross another dollar
+    expect(seg.text.replaceAll('\\$', '').includes('$'), label).toBe(false);
+    // (2e) bare numbers stay currency
+    expect(/^\d[\d,]*(?:\.\d+)?$/.test(seg.text.trim()), label).toBe(false);
+  }
+}
+
+describe('mathInline fuzz (invariants)', () => {
+  const ITERATIONS = 20_000;
+  for (const [name, gen] of [
+    ['structured', genStructured],
+    ['noise', genNoise],
+  ] as const) {
+    for (const final of [true, false]) {
+      it(`holds for ${ITERATIONS} ${name} inputs (final=${final})`, () => {
+        const rnd = mulberry32(final ? 0x5eed1 : 0x5eed2);
+        for (let i = 0; i < ITERATIONS; i++) expectInvariants(gen(rnd), final);
+      });
+    }
+  }
+});

--- a/apps/kimi-web/src/lib/mathInline.ts
+++ b/apps/kimi-web/src/lib/mathInline.ts
@@ -1,0 +1,140 @@
+// apps/kimi-web/src/lib/mathInline.ts
+import type { MarkdownIt } from 'markstream-vue';
+
+// Inline math (`$…$`). markstream's built-in `math` rule is swapped for a
+// conservative pandoc-style variant so `$…$` formulas (e.g. `$\Sigma_t$`)
+// render through KaTeX without false-positiving on prices, env vars, and
+// shell paths (`$5`, `$PATH`, `$HOME/bin`). Guards: the opening delimiter
+// must be followed by a non-space character; a closing `$` must be preceded
+// by a non-space, must not be followed by a digit, and the content must not
+// be a bare number (currency) or contain a backtick. `$$…$$` and `\(...\)`
+// inline forms are preserved, and `math_block` (the $$ block rule) is
+// untouched. While streaming, an unclosed `$` still renders progressively —
+// but only when the partial content is unambiguously TeX (see
+// loadingInlineMath); anything else stays literal until it closes.
+export interface MathInlineState {
+  src: string;
+  pos: number;
+  env?: Record<string, unknown>;
+  push: (
+    type: string,
+    tag: string,
+    nesting: number,
+  ) => { content: string; markup: string; raw?: string; loading?: boolean };
+}
+
+function isEscapedAt(src: string, idx: number): boolean {
+  let count = 0;
+  for (let i = idx - 1; i >= 0 && src[i] === '\\'; i--) count++;
+  return count % 2 === 1;
+}
+
+// Currency amounts (`$5`, `$1,000.50`) are text, not math.
+const BARE_NUMBER_RE = /^\d[\d,]*(?:\.\d+)?$/;
+
+// Signal for progressive (streaming) rendering: a backslash command is the
+// one TeX signal with zero overlap with prices and shell syntax — `_`, `^`,
+// `=`, and `{}` all appear in env vars and shell expansions (`$MY_VAR`,
+// `$PATH=$HOME`, `${PATH}`), so they would flash shell text as math.
+const TEX_COMMAND_RE = /\\[a-zA-Z]/;
+
+// Streaming best-effort: no closing `$` yet. Render progressively only when
+// the partial content is unambiguously TeX; MathInlineNode falls back to the
+// raw source when KaTeX can't parse a partial formula, so a half-typed
+// `$\Sigma_` degrades gracefully. Settled messages (`__markstreamFinal`)
+// never take this branch — an unclosed `$` there stays literal forever.
+function loadingInlineMath(state: MathInlineState, silent: boolean): boolean {
+  if (state.env?.__markstreamFinal) return false;
+  const rest = state.src.slice(state.pos + 1);
+  // Stop at the first line break so trailing prose isn't swallowed.
+  const nl = rest.indexOf('\n');
+  const partial = nl === -1 ? rest : rest.slice(0, nl);
+  if (!TEX_COMMAND_RE.test(partial) || partial.includes('`')) return false;
+  if (!silent) {
+    const token = state.push('math_inline', 'math', 0);
+    token.content = partial;
+    token.markup = '$';
+    token.raw = state.src.slice(state.pos, state.pos + 1 + partial.length);
+    token.loading = true;
+  }
+  state.pos = state.pos + 1 + partial.length;
+  return true;
+}
+
+export function mathInline(state: MathInlineState, silent: boolean): boolean {
+  const src = state.src;
+  const pos = state.pos;
+
+  let openLen = 0;
+  let close = '';
+  if (src.startsWith('\\(', pos)) {
+    openLen = 2;
+    close = '\\)';
+  } else if (src[pos] === '$') {
+    if (src[pos + 1] === '$') {
+      openLen = 2;
+      close = '$$';
+    } else {
+      openLen = 1;
+      close = '$';
+    }
+  } else {
+    return false;
+  }
+
+  // pandoc rule: the opening delimiter must be followed by a non-space.
+  const first = src[pos + openLen];
+  if (first === undefined || /\s/.test(first)) return false;
+
+  let end = pos + openLen;
+  for (;;) {
+    end = src.indexOf(close, end);
+    if (end === -1) {
+      // Streaming progressive render — single `$` only; `$$` blocks have
+      // their own loading path in math_block, and `\(` is rare enough to
+      // just wait for its close.
+      if (close === '$') return loadingInlineMath(state, silent);
+      return false;
+    }
+    if (isEscapedAt(src, end)) {
+      end += close.length;
+      continue;
+    }
+    if (close === '$') {
+      // A `$` that fails the closer rules (part of a `$$` pair, preceded by
+      // a space, or followed by a digit) ABANDONS this opener instead of
+      // being skipped: scanning past it would let a literal dollar consume
+      // the closer of a later formula (`Costs $5 and variable $x$` must not
+      // become one math span). Abandoning keeps math content free of
+      // unescaped `$` — spans never cross.
+      if (
+        src[end + 1] === '$' ||
+        src[end - 1] === '$' ||
+        /\s/.test(src[end - 1] ?? '') ||
+        /\d/.test(src[end + 1] ?? '')
+      ) {
+        return false;
+      }
+    }
+    break;
+  }
+
+  const content = src.slice(pos + openLen, end);
+  if (!content.trim() || content.includes('`')) return false;
+  if (close === '$' && BARE_NUMBER_RE.test(content.trim())) return false;
+
+  if (!silent) {
+    const token = state.push('math_inline', 'math', 0);
+    token.content = content;
+    token.markup = close === '\\)' ? '\\(\\)' : close;
+    token.raw = src.slice(pos, end + close.length);
+    token.loading = false;
+  }
+  state.pos = end + close.length;
+  return true;
+}
+
+export function enableInlineMath(md: MarkdownIt): MarkdownIt {
+  md.inline.ruler.at('math', mathInline);
+  return md;
+}


### PR DESCRIPTION
## Related Issue

Resolve #1804

## Problem

See linked issue. In short: kimi web disables markstream's inline `math` rule entirely (`disableInlineMath` in `Markdown.vue`), so `$...$` inline formulas — the form models emit most — render as raw source. Only standalone `$$...$$` blocks render.

## What changed

`Markdown.vue` no longer disables the inline `math` rule; it replaces it (`md.inline.ruler.at('math', …)`) with a conservative pandoc-style variant (`apps/kimi-web/src/lib/mathInline.ts`):

- the opening delimiter must be followed by a non-space character;
- a closing `$` must be preceded by a non-space and must **not** be followed by a digit; a candidate closer that fails these rules **abandons the opener** (no scanning across it), so math content never contains an unescaped `$` — spans never cross;
- the content must be non-empty, contain no backtick, and not be a bare number (`$100$` stays a currency amount, while `$3+4=7$` still renders);
- `\(...\)` and inline `$$...$$` keep working; `math_block` is untouched;
- **while streaming**, an unclosed `$` still renders progressively — but only when the partial content is unambiguously TeX (details below).

### Why this rule set (trade-off analysis)

`$` carries no type information in plain text, so any rule here is a heuristic — the question is which errors you accept. Options considered:

| Option | Verdict |
| --- | --- |
| Keep inline math disabled (status quo) | Real formulas degrade to raw source — the reported bug |
| Re-enable markstream's built-in rule as-is | Accepts any closed `$...$` with no delimiter-adjacency checks: `$HOME/bin and $PATH` (two env vars in one sentence) becomes "math". Its mid-stream loading math has the same problem: any lone `$` with math-ish text after it flickers as a formula |
| Enable only `\(...\)` (the proposal in #1804) | Unambiguous, but models overwhelmingly emit `$...$`; fixes a fraction of real output |
| **pandoc delimiter rules (this PR)** | The GitHub / GitLab / VS Code markdown-math standard; covers real `$...$` math and the common false-positive shapes |
| pandoc + content sniffing (require TeX signals like `\cmd`, `^`, `_`, `=`) | Kills the residual `$HOME/bin:$PATH` edge, but also kills legitimate signal-free formulas (`$x$`, `$t$`, `$D/R$`); every exception carved out makes the rule set more special-cased |
| Try KaTeX render, fall back to text on error | Doesn't discriminate — `HOME/bin:` is valid TeX and renders "successfully" |

The chosen rule set is the pandoc standard plus one extra guard (bare-number content ⇒ currency). It is a sweet spot because the realistic false-positive shapes line up with what the rules already reject:

- **Prices** (`$5`, `$5 and $10`, `$1,000.50`) — no valid closing delimiter, closing `$` followed by a digit, or bare-number content;
- **Env vars & paths in prose** (`$PATH`, `$HOME/bin and $PATH`) — no closing `$`, or closing `$` preceded by a space;
- **Env vars & paths in code spans** (`` `$HOME/bin:$PATH` `` — how models actually write shell content) — never reach the math rule at all: markdown-it's backticks rule consumes the whole span first, and the backtick guard stops a math span from closing *across* a code span.

Known residual edge: bare-text `$HOME/bin:$PATH` (no backticks, closing `$` adjacent to a non-space) still parses as math — identical behavior to pandoc and GitHub; the escape hatch is `\$`, as on those platforms.

### Streaming: guarded progressive rendering

The built-in rule rendered *any* unclosed `$...` as loading math mid-stream; the naive fix would be to wait for the closing `$` and accept the raw-text flash. This PR keeps progressive rendering but guards it harder than the closed case, since partial content has no closing delimiter to vouch for it:

- only a **backslash command** (`\Sigma`, `\frac`, …) qualifies as the TeX signal — the one signal with zero overlap with prices and shell syntax (`_`, `^`, `=`, `{}` all appear in `$MY_VAR`, `$PATH=$HOME`, `${PATH}`);
- the partial render stops at the first line break, so trailing prose is never swallowed;
- settled messages (`__markstreamFinal`) never take this path — an unclosed `$` in history stays literal;
- when KaTeX can't parse a partial formula yet, `MathInlineNode`'s fallback shows the raw source (its loading spinner is hidden via CSS — the raw text alone is the honest state).

Net effect: `$\Sigma_t + \cdots$` renders live as it streams; `$5`, `$PATH`, `$x` never flash as math; simple signal-free formulas like `$r_t$` appear the moment they close.

### Testing

- `apps/kimi-web/src/lib/mathInline.test.ts`: 19 unit tests — real formulas, prices, env vars, escaped dollars, unclosed `$` (settled vs. streaming), TeX-signal gating, line-break cutoff, silent mode, `$$...$$`, `\(...\)`, and a regression test for the opener-abandon semantics found in review;
- property-based fuzzing in the same file: 80k seeded adversarial inputs (structured fragments + character noise, settled and streaming) asserting lossless round-trip, delimiter adjacency, no backtick/`$` crossing, bare-number rejection, and TeX-signal gating of loading math;
- verified through the real parser (`getMarkdown` + `parseMarkdownToStructure`) that inputs like `$\Sigma_t$`, `$\leq t-1$`, `$w^\top\Sigma w$` produce `math_inline` nodes while `$5`, `$PATH`, `$HOME/bin and $PATH` stay literal — including inside `**bold**` spans, which exercise markstream's strong/math token fixups;
- `pnpm --filter kimi-web typecheck`, `pnpm --filter kimi-web test`, `pnpm --filter kimi-web build`, and `oxlint` all green; manually verified in the running web app.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset. (Changeset included: `@moonshot-ai/kimi-code` patch — kimi-web is internal, but its build output ships inside the CLI bundle.)
- [x] Ran `gen-docs` skill, or this PR needs no doc update. (No doc update: bug fix restoring expected rendering; no docs page documents math delimiters.)


