### PR TITLE
feat(cli): add update check to kimi doctor

### DIFF
--- a/.changeset/doctor-version-check.md
+++ b/.changeset/doctor-version-check.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Add an update check to `kimi doctor`, shown as a `version` row in the default run. Run `kimi doctor` to see whether the CLI is up to date.

--- a/apps/kimi-code/src/cli/commands.ts
+++ b/apps/kimi-code/src/cli/commands.ts
@@ -118,7 +118,7 @@ export function createProgram(
   registerAcpCommand(program);
   registerWebCommand(program);
   registerLoginCommand(program);
-  registerDoctorCommand(program);
+  registerDoctorCommand(program, version);
   registerVisCommand(program);
   registerMigrateCommand(program, onMigrate);
   program

--- a/apps/kimi-code/src/cli/sub/doctor.ts
+++ b/apps/kimi-code/src/cli/sub/doctor.ts
@@ -8,8 +8,12 @@ import {
   type KimiConfigValidationIssue,
 } from '@moonshot-ai/kimi-code-sdk';
 import type { Command } from 'commander';
+import { valid } from 'semver';
 import { z } from 'zod';
 
+import { refreshUpdateCache } from '#/cli/update/refresh';
+import { selectUpdateTarget } from '#/cli/update/select';
+import type { UpdateCache } from '#/cli/update/types';
 import { getTuiConfigPath, parseTuiConfig } from '#/tui/config';
 
 interface WritableLike {
@@ -29,6 +33,7 @@ export interface DoctorDeps {
   readonly fileExists?: (path: string) => boolean;
   readonly readTextFile?: (path: string) => Promise<string>;
   readonly validateConfigToml?: (text: string, path: string) => MaybePromise<void>;
+  readonly refreshUpdateCache?: () => Promise<UpdateCache>;
 }
 
 export interface DoctorOptions {
@@ -44,9 +49,9 @@ interface CheckSpec {
 }
 
 interface CheckResult {
-  readonly label: CheckSpec['label'];
+  readonly label: CheckSpec['label'] | 'version';
   readonly path: string;
-  readonly status: 'OK' | 'SKIP' | 'ERROR';
+  readonly status: 'OK' | 'SKIP' | 'WARN' | 'ERROR';
   readonly message?: string;
 }
 
@@ -60,13 +65,22 @@ interface ResolvedDoctorDeps {
   readonly fileExists: (path: string) => boolean;
   readonly readTextFile: (path: string) => Promise<string>;
   readonly validateConfigToml: (text: string, path: string) => MaybePromise<void>;
+  readonly refreshUpdateCache: () => Promise<UpdateCache>;
 }
 
-export async function handleDoctor(deps: DoctorDeps, options: DoctorOptions): Promise<number> {
+export async function handleDoctor(
+  deps: DoctorDeps,
+  options: DoctorOptions,
+  currentVersion: string,
+): Promise<number> {
   const resolved = resolveDeps(deps);
   const cwd = resolved.cwd();
   const specs = await buildCheckSpecs(resolved, options, cwd);
-  const results = await Promise.all(specs.map((spec) => checkTomlFile(resolved, spec)));
+  const checks: Promise<CheckResult>[] = specs.map((spec) => checkTomlFile(resolved, spec));
+  if (options.target === undefined) {
+    checks.push(checkVersion(resolved, currentVersion));
+  }
+  const results = await Promise.all(checks);
 
   const issueCount = results.filter((result) => result.status === 'ERROR').length;
   const text = issueCount === 0 ? formatSuccess(results) : formatFailure(results, issueCount);
@@ -78,12 +92,16 @@ export async function handleDoctor(deps: DoctorDeps, options: DoctorOptions): Pr
   return issueCount === 0 ? 0 : 1;
 }
 
-export function registerDoctorCommand(parent: Command, deps?: Partial<DoctorDeps>): void {
+export function registerDoctorCommand(
+  parent: Command,
+  version: string,
+  deps?: Partial<DoctorDeps>,
+): void {
   const doctor = parent
     .command('doctor')
     .description('Validate Kimi Code configuration files.')
     .action(async () => {
-      await runDoctorCommand(deps, {});
+      await runDoctorCommand(deps, {}, version);
     });
 
   doctor
@@ -91,7 +109,7 @@ export function registerDoctorCommand(parent: Command, deps?: Partial<DoctorDeps
     .description('Validate config.toml.')
     .argument('[path]', 'Validate this file as config.toml instead of the default path.')
     .action(async (path: string | undefined) => {
-      await runDoctorCommand(deps, { target: 'config', path });
+      await runDoctorCommand(deps, { target: 'config', path }, version);
     });
 
   doctor
@@ -99,16 +117,17 @@ export function registerDoctorCommand(parent: Command, deps?: Partial<DoctorDeps
     .description('Validate tui.toml.')
     .argument('[path]', 'Validate this file as tui.toml instead of the default path.')
     .action(async (path: string | undefined) => {
-      await runDoctorCommand(deps, { target: 'tui', path });
+      await runDoctorCommand(deps, { target: 'tui', path }, version);
     });
 }
 
 async function runDoctorCommand(
   deps: Partial<DoctorDeps> | undefined,
   options: DoctorOptions,
+  version: string,
 ): Promise<void> {
   const resolved = resolveDeps(deps);
-  const code = await handleDoctor(resolved, options);
+  const code = await handleDoctor(resolved, options, version);
   if (code !== 0) resolved.exit(code);
 }
 
@@ -131,6 +150,7 @@ function resolveDeps(deps: Partial<DoctorDeps> | DoctorDeps | undefined): Resolv
     validateConfigToml:
       deps?.validateConfigToml ??
       ((text, filePath) => getConfigRpc().validateConfigToml({ text, filePath })),
+    refreshUpdateCache: deps?.refreshUpdateCache ?? (() => refreshUpdateCache()),
   };
 }
 
@@ -216,6 +236,42 @@ async function checkTomlFile(deps: ResolvedDoctorDeps, spec: CheckSpec): Promise
   }
 }
 
+async function checkVersion(
+  deps: ResolvedDoctorDeps,
+  currentVersion: string,
+): Promise<CheckResult> {
+  const display = currentVersion.startsWith('v') ? currentVersion : `v${currentVersion}`;
+  let cache: UpdateCache;
+  try {
+    cache = await deps.refreshUpdateCache();
+  } catch (error) {
+    return {
+      label: 'version',
+      path: display,
+      status: 'WARN',
+      message: `Failed to check for updates: ${error instanceof Error ? error.message : String(error)}`,
+    };
+  }
+  if (valid(currentVersion) === null) {
+    return {
+      label: 'version',
+      path: display,
+      status: 'WARN',
+      message: 'Current version is not valid semver (non-release build?); comparison skipped.',
+    };
+  }
+  const target = selectUpdateTarget(currentVersion, cache.latest);
+  if (target === null) {
+    return { label: 'version', path: `${display} (up to date)`, status: 'OK' };
+  }
+  return {
+    label: 'version',
+    path: `${display} → v${target.version} available`,
+    status: 'WARN',
+    message: 'Run `kimi update` to upgrade.',
+  };
+}
+
 async function resolveConfigTargetPath(
   deps: ResolvedDoctorDeps,
   input: string | undefined,
@@ -242,7 +298,7 @@ function formatSuccess(results: readonly CheckResult[]): string {
     '',
     ...formatResults(results),
     '',
-    'All checked config files are valid.',
+    'No configuration issues found.',
     '',
   ].join('\n');
 }

--- a/apps/kimi-code/test/cli/doctor.test.ts
+++ b/apps/kimi-code/test/cli/doctor.test.ts
@@ -10,8 +10,20 @@ import {
   registerDoctorCommand,
   type DoctorDeps,
 } from '#/cli/sub/doctor';
+import type { UpdateCache } from '#/cli/update/types';
 
 let dir: string;
+
+const CURRENT_VERSION = '1.0.0';
+
+function upToDateCache(latest = CURRENT_VERSION): Promise<UpdateCache> {
+  return Promise.resolve({
+    source: 'cdn',
+    checkedAt: new Date(0).toISOString(),
+    latest,
+    manifest: null,
+  });
+}
 
 beforeEach(async () => {
   dir = join(tmpdir(), `kimi-doctor-${Date.now()}-${Math.random().toString(36).slice(2)}`);
@@ -42,6 +54,7 @@ function makeDeps(): {
         exitCodes.push(code);
         throw new Error(`exit ${String(code)}`);
       },
+      refreshUpdateCache: upToDateCache,
     },
     stdout,
     stderr,
@@ -91,7 +104,7 @@ describe('kimi doctor', () => {
   it('skips missing default config files without failing', async () => {
     const { deps, stdout, stderr } = makeDeps();
 
-    const code = await handleDoctor(deps, {});
+    const code = await handleDoctor(deps, {}, CURRENT_VERSION);
 
     expect(code).toBe(0);
     expect(stderr.join('')).toBe('');
@@ -104,7 +117,7 @@ describe('kimi doctor', () => {
   it('checks only config.toml when the config target is selected', async () => {
     const { deps, stdout, stderr } = makeDeps();
 
-    const code = await handleDoctor(deps, { target: 'config' });
+    const code = await handleDoctor(deps, { target: 'config' }, CURRENT_VERSION);
 
     expect(code).toBe(0);
     expect(stderr.join('')).toBe('');
@@ -116,7 +129,7 @@ describe('kimi doctor', () => {
   it('checks only tui.toml when the tui target is selected', async () => {
     const { deps, stdout, stderr } = makeDeps();
 
-    const code = await handleDoctor(deps, { target: 'tui' });
+    const code = await handleDoctor(deps, { target: 'tui' }, CURRENT_VERSION);
 
     expect(code).toBe(0);
     expect(stderr.join('')).toBe('');
@@ -128,7 +141,7 @@ describe('kimi doctor', () => {
   it('treats a missing explicit target path as an error', async () => {
     const { deps, stdout, stderr } = makeDeps();
 
-    const code = await handleDoctor(deps, { target: 'config', path: './missing.toml' });
+    const code = await handleDoctor(deps, { target: 'config', path: './missing.toml' }, CURRENT_VERSION);
 
     expect(code).toBe(1);
     expect(stdout.join('')).toBe('');
@@ -144,7 +157,7 @@ describe('kimi doctor', () => {
     await writeValidConfig(configPath);
     const { deps, stdout, stderr, exitCodes } = makeDeps();
     const program = new Command('kimi');
-    registerDoctorCommand(program, deps);
+    registerDoctorCommand(program, CURRENT_VERSION, deps);
 
     await program.parseAsync(['node', 'kimi', 'doctor', 'config', './candidate-config.toml']);
 
@@ -153,7 +166,7 @@ describe('kimi doctor', () => {
     const out = stdout.join('');
     expect(out).toContain(`OK config.toml  ${configPath}`);
     expect(out).not.toContain('tui.toml');
-    expect(out).toContain('All checked config files are valid.');
+    expect(out).toContain('No configuration issues found.');
   });
 
   it('does not resolve the default config path when an explicit config path is provided', async () => {
@@ -169,6 +182,7 @@ describe('kimi doctor', () => {
         },
       },
       { target: 'config', path: './candidate-config.toml' },
+      CURRENT_VERSION,
     );
 
     expect(code).toBe(0);
@@ -181,7 +195,7 @@ describe('kimi doctor', () => {
     await writeValidTuiConfig(tuiConfigPath);
     const { deps, stdout, stderr, exitCodes } = makeDeps();
     const program = new Command('kimi');
-    registerDoctorCommand(program, deps);
+    registerDoctorCommand(program, CURRENT_VERSION, deps);
 
     await program.parseAsync(['node', 'kimi', 'doctor', 'tui', './candidate-tui.toml']);
 
@@ -190,7 +204,7 @@ describe('kimi doctor', () => {
     const out = stdout.join('');
     expect(out).toContain(`OK tui.toml     ${tuiConfigPath}`);
     expect(out).not.toContain('config.toml');
-    expect(out).toContain('All checked config files are valid.');
+    expect(out).toContain('No configuration issues found.');
   });
 
   it('aggregates config.toml and tui.toml parse errors', async () => {
@@ -210,7 +224,7 @@ max_context_size = 0
     await writeFile(join(dir, 'tui.toml'), 'editor = 123\n', 'utf-8');
     const { deps, stdout, stderr } = makeDeps();
 
-    const code = await handleDoctor(deps, {});
+    const code = await handleDoctor(deps, {}, CURRENT_VERSION);
 
     expect(code).toBe(1);
     expect(stdout.join('')).toBe('');
@@ -235,7 +249,7 @@ enabled = "yes"
     );
     const { deps, stderr } = makeDeps();
 
-    const code = await handleDoctor(deps, { target: 'tui' });
+    const code = await handleDoctor(deps, { target: 'tui' }, CURRENT_VERSION);
 
     expect(code).toBe(1);
     const err = stderr.join('');
@@ -260,11 +274,118 @@ max_context_size = "large"
     );
     const { deps, stderr } = makeDeps();
 
-    const code = await handleDoctor(deps, { target: 'config' });
+    const code = await handleDoctor(deps, { target: 'config' }, CURRENT_VERSION);
 
     expect(code).toBe(1);
     const err = stderr.join('');
     expect(err).toContain('Validation issues:');
     expect(err).toContain('models.kimi.max_context_size:');
+  });
+
+  it('reports an up-to-date version as OK in the default run', async () => {
+    const { deps, stdout, stderr } = makeDeps();
+
+    const code = await handleDoctor(deps, {}, CURRENT_VERSION);
+
+    expect(code).toBe(0);
+    expect(stderr.join('')).toBe('');
+    expect(stdout.join('')).toContain(`OK version      v${CURRENT_VERSION} (up to date)`);
+  });
+
+  it('warns about a newer version without failing', async () => {
+    const { deps, stdout, stderr } = makeDeps();
+
+    const code = await handleDoctor(
+      { ...deps, refreshUpdateCache: () => upToDateCache('1.1.0') },
+      {},
+      CURRENT_VERSION,
+    );
+
+    expect(code).toBe(0);
+    expect(stderr.join('')).toBe('');
+    const out = stdout.join('');
+    expect(out).toContain(`WARN version      v${CURRENT_VERSION} → v1.1.0 available`);
+    expect(out).toContain('Run `kimi update` to upgrade.');
+    expect(out).toContain('No configuration issues found.');
+  });
+
+  it('warns instead of failing when the update check fails', async () => {
+    const { deps, stdout, stderr } = makeDeps();
+
+    const code = await handleDoctor(
+      {
+        ...deps,
+        refreshUpdateCache: () => Promise.reject(new Error('CDN unreachable')),
+      },
+      {},
+      CURRENT_VERSION,
+    );
+
+    expect(code).toBe(0);
+    expect(stderr.join('')).toBe('');
+    const out = stdout.join('');
+    expect(out).toContain(`WARN version      v${CURRENT_VERSION}`);
+    expect(out).toContain('Failed to check for updates: CDN unreachable');
+  });
+
+  it('warns instead of comparing when the current version is not valid semver', async () => {
+    const { deps, stdout } = makeDeps();
+
+    const code = await handleDoctor(deps, {}, 'dev');
+
+    expect(code).toBe(0);
+    const out = stdout.join('');
+    expect(out).toContain('WARN version      vdev');
+    expect(out).toContain('comparison skipped');
+  });
+
+  it('does not run the version check for targeted runs', async () => {
+    const { deps, stdout } = makeDeps();
+
+    const code = await handleDoctor(
+      {
+        ...deps,
+        refreshUpdateCache: () => {
+          throw new Error('version check should not run');
+        },
+      },
+      { target: 'config' },
+      CURRENT_VERSION,
+    );
+
+    expect(code).toBe(0);
+    expect(stdout.join('')).not.toContain('version');
+  });
+
+  it('counts only config errors as issues when the version check warns', async () => {
+    await writeFile(
+      join(dir, 'config.toml'),
+      `
+[providers.kimi]
+type = "kimi"
+
+[models.kimi]
+provider = "kimi"
+model = "kimi"
+max_context_size = 0
+`,
+      'utf-8',
+    );
+    const { deps, stderr } = makeDeps();
+
+    const code = await handleDoctor(
+      {
+        ...deps,
+        refreshUpdateCache: () => upToDateCache('1.1.0'),
+      },
+      {},
+      CURRENT_VERSION,
+    );
+
+    expect(code).toBe(1);
+    const err = stderr.join('');
+    expect(err).toContain('Kimi doctor found 1 issue.');
+    expect(err).toContain('ERROR config.toml');
+    expect(err).toContain('WARN version');
   });
 });

--- a/docs/en/reference/kimi-command.md
+++ b/docs/en/reference/kimi-command.md
@@ -205,9 +205,11 @@ kimi doctor
 
 | Command | Description |
 | --- | --- |
-| `kimi doctor` | Validate the default `config.toml` and `tui.toml` |
+| `kimi doctor` | Validate the default `config.toml` and `tui.toml`, and check whether the CLI is up to date |
 | `kimi doctor config [path]` | Validate only `config.toml`, using `path` instead of the default file when provided |
 | `kimi doctor tui [path]` | Validate only `tui.toml`, using `path` instead of the default file when provided |
+
+The default run also performs the same update check as `kimi update` and reports it as a `version` row: `OK` when the CLI is up to date, `WARN` when a newer version exists (with a hint to run `kimi update`), when the check fails (for example offline), or when the current version is not a release build. A `WARN` result never affects the exit code.
 
 When an explicit path is passed, the file must exist. The command exits with `0` when all checked files are valid or skipped, and `1` when any requested file is missing or invalid.
 

--- a/docs/zh/reference/kimi-command.md
+++ b/docs/zh/reference/kimi-command.md
@@ -205,9 +205,11 @@ kimi doctor
 
 | 命令 | 说明 |
 | --- | --- |
-| `kimi doctor` | 校验默认 `config.toml` 和 `tui.toml` |
+| `kimi doctor` | 校验默认 `config.toml` 和 `tui.toml`，并检查 CLI 是否为最新版本 |
 | `kimi doctor config [path]` | 只校验 `config.toml`；传入 `path` 时使用该文件而不是默认文件 |
 | `kimi doctor tui [path]` | 只校验 `tui.toml`；传入 `path` 时使用该文件而不是默认文件 |
+
+默认运行还会执行与 `kimi update` 相同的更新检查，结果显示为一行 `version`：已是最新显示 `OK`；有更新版本（附 `kimi update` 提示）、检查失败（例如离线）或当前版本不是正式发布构建时显示 `WARN`。`WARN` 结果不影响退出码。
 
 显式传入路径时，文件必须存在。所有被检查的文件都有效或被跳过时，退出码为 `0`；任何指定文件缺失或配置无效时，退出码为 `1`。
 


### PR DESCRIPTION
## Related Issue

No linked issue — the problem is explained below.

## Problem

`kimi doctor` only validated `config.toml` / `tui.toml`. There was no way to tell from a diagnostic run whether the CLI itself is outdated — users had to know about and run `kimi update` separately.

## What changed

The default `kimi doctor` run now also checks whether the CLI is up to date, reusing the exact path `kimi update` uses (`refreshUpdateCache` → CDN `latest.json` with plain-text `/latest` fallback, semver `gt` comparison, no rollout gating). The result is rendered as a `version` row in the check table:

- `OK version      v1.2.3 (up to date)` — already latest
- `WARN version      v1.2.3 → v1.3.0 available` + `Run \`kimi update\` to upgrade.` — newer release exists
- `WARN` + `Failed to check for updates: ...` — offline / CDN failure
- `WARN` + `comparison skipped` — current version is not valid semver (non-release build)

Semantics:

- `WARN` never affects the exit code — exit `1` remains reserved for config validation errors.
- Only the default run includes the check; `kimi doctor config [path]` / `kimi doctor tui [path]` stay purely local.
- `KIMI_CODE_NO_AUTO_UPDATE` is ignored, consistent with `kimi update` (it only gates *automatic* updates, not manual diagnostics).

Tests cover all four version outcomes, that warnings don't count as issues, and that targeted runs skip the check. Bilingual `kimi doctor` docs and changeset included.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.