### PR TITLE
feat(agent-core): defer registered user tools

### DIFF
--- a/.changeset/defer-user-tools.md
+++ b/.changeset/defer-user-tools.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Allow hosts to defer registered user-tool schemas until needed. Set `disclosure: "deferred"` when registering a tool.

--- a/packages/agent-core-v2/docs/wire-manifest.d.ts
+++ b/packages/agent-core-v2/docs/wire-manifest.d.ts
@@ -524,6 +524,7 @@ interface ToolsRegisterUserToolPayload {
   name: string;
   description: string;
   parameters: Record<string, unknown>;
+  disclosure?: 'inline' | 'deferred';
 }
 
 /**

--- a/packages/agent-core-v2/src/agent/rpc/core-api.ts
+++ b/packages/agent-core-v2/src/agent/rpc/core-api.ts
@@ -22,7 +22,7 @@ import type {
 } from '#/agent/goal/types';
 import type { PermissionMode } from '#/agent/permissionPolicy/types';
 import type { SwarmModeTrigger } from '#/agent/swarm/swarm';
-import type { ToolInfo } from '#/tool/toolContract';
+import type { ToolDisclosure, ToolInfo } from '#/tool/toolContract';
 import type { ResolvedConfig } from '#/app/config/config';
 import type { McpServerConfig } from '#/agent/mcp/config-schema';
 import type { ExperimentalFeatureState } from '#/app/flag/flag';
@@ -171,6 +171,7 @@ export interface RegisterToolPayload {
   readonly name: string;
   readonly description: string;
   readonly parameters: Record<string, unknown>;
+  readonly disclosure?: ToolDisclosure;
 }
 export interface UnregisterToolPayload {
   readonly name: string;

--- a/packages/agent-core-v2/src/agent/toolRegistry/builtinToolsRegistrar.ts
+++ b/packages/agent-core-v2/src/agent/toolRegistry/builtinToolsRegistrar.ts
@@ -54,7 +54,12 @@ export class AgentBuiltinToolsRegistrar extends Disposable implements IAgentBuil
           ctor,
           ...(staticArgs as []),
         );
-        this._register(toolRegistry.register(tool, { source: options.source }));
+        this._register(
+          toolRegistry.register(tool, {
+            source: options.source,
+            disclosure: options.disclosure,
+          }),
+        );
       }
     });
   }

--- a/packages/agent-core-v2/src/agent/toolRegistry/toolContribution.ts
+++ b/packages/agent-core-v2/src/agent/toolRegistry/toolContribution.ts
@@ -21,7 +21,11 @@
  */
 
 import type { ServicesAccessor } from '#/_base/di/instantiation';
-import type { ExecutableTool, ToolSource } from '#/tool/toolContract';
+import type {
+  ExecutableTool,
+  ToolDisclosure,
+  ToolSource,
+} from '#/tool/toolContract';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type AnyExecutableTool = ExecutableTool<any>;
@@ -31,6 +35,7 @@ export type ToolCtor<T extends AnyExecutableTool = AnyExecutableTool> = new (...
 
 export interface ToolContributionOptions {
   readonly source?: ToolSource;
+  readonly disclosure?: ToolDisclosure;
   readonly when?: (accessor: ServicesAccessor) => boolean;
   readonly staticArgs?: (accessor: ServicesAccessor) => readonly unknown[];
 }

--- a/packages/agent-core-v2/src/agent/toolRegistry/toolRegistry.ts
+++ b/packages/agent-core-v2/src/agent/toolRegistry/toolRegistry.ts
@@ -10,10 +10,16 @@
 
 import { createDecorator } from '#/_base/di/instantiation';
 import { type IDisposable } from '#/_base/di/lifecycle';
-import type { ExecutableTool, ToolInfo, ToolSource } from '#/tool/toolContract';
+import type {
+  ExecutableTool,
+  ToolDisclosure,
+  ToolInfo,
+  ToolSource,
+} from '#/tool/toolContract';
 
 export interface ToolRegistrationOptions {
   readonly source?: ToolSource;
+  readonly disclosure?: ToolDisclosure;
 }
 
 export interface ToolReference {

--- a/packages/agent-core-v2/src/agent/toolRegistry/toolRegistryService.ts
+++ b/packages/agent-core-v2/src/agent/toolRegistry/toolRegistryService.ts
@@ -1,7 +1,12 @@
 import { toDisposable, type IDisposable } from "#/_base/di/lifecycle";
 import { InstantiationType } from '#/_base/di/extensions';
 import { LifecycleScope, registerScopedService } from '#/_base/di/scope';
-import type { ExecutableTool, ToolInfo, ToolSource } from '#/tool/toolContract';
+import type {
+  ExecutableTool,
+  ToolDisclosure,
+  ToolInfo,
+  ToolSource,
+} from '#/tool/toolContract';
 import {
   IAgentToolRegistryService,
   type ToolReference,
@@ -11,6 +16,7 @@ import {
 interface ToolEntry {
   readonly tool: ExecutableTool;
   readonly source: ToolSource;
+  readonly disclosure?: ToolDisclosure;
 }
 
 export class AgentToolRegistryService implements IAgentToolRegistryService {
@@ -19,7 +25,7 @@ export class AgentToolRegistryService implements IAgentToolRegistryService {
 
   register(tool: ExecutableTool, options: ToolRegistrationOptions = {}): IDisposable {
     const source = options.source ?? 'builtin';
-    const entry: ToolEntry = { tool, source };
+    const entry: ToolEntry = { tool, source, disclosure: options.disclosure };
     this.unregisterTool(tool.name);
     this.tools.set(tool.name, entry);
 
@@ -32,11 +38,12 @@ export class AgentToolRegistryService implements IAgentToolRegistryService {
 
   list(): readonly ToolInfo[] {
     return [...this.tools.values()]
-      .map(({ tool, source }) => ({
+      .map(({ tool, source, disclosure }) => ({
         name: tool.name,
         description: tool.description,
         parameters: tool.parameters,
         source,
+        disclosure,
       }))
       .toSorted((a, b) => a.name.localeCompare(b.name));
   }

--- a/packages/agent-core-v2/src/agent/toolSelect/toolSelect.ts
+++ b/packages/agent-core-v2/src/agent/toolSelect/toolSelect.ts
@@ -2,7 +2,8 @@
  * `toolSelect` domain (L4) — progressive tool disclosure contract.
  *
  * Defines the Agent-scope service that shapes provider-visible tool/history
- * views, loads selected MCP schemas, and reports loadable-tool announcements.
+ * views, loads selected dynamic schemas, and reports loadable-tool
+ * announcements.
  */
 
 import { createDecorator, type ServiceIdentifier } from '#/_base/di/instantiation';

--- a/packages/agent-core-v2/src/agent/toolSelect/toolSelectService.ts
+++ b/packages/agent-core-v2/src/agent/toolSelect/toolSelectService.ts
@@ -2,7 +2,7 @@
  * `toolSelect` domain (L4) — `IAgentToolSelectService` implementation.
  *
  * Shapes the provider-visible tool and history views for progressive tool
- * disclosure, loads MCP schemas into `contextMemory`, and exposes
+ * disclosure, loads dynamic schemas into `contextMemory`, and exposes
  * loadable-tools announcement text. Reads live tools from `toolRegistry`,
  * active-tool and capability state from `profile`, gates through `flag`,
  * hooks into `toolExecutor`, and listens to context lifecycle events through
@@ -19,7 +19,7 @@ import { IAgentContextMemoryService } from '#/agent/contextMemory/contextMemory'
 import type { ContextMessage } from '#/agent/contextMemory/types';
 import { IAgentProfileService } from '#/agent/profile/profile';
 import { IAgentToolPolicyService } from '#/agent/toolPolicy/toolPolicy';
-import type { ToolInfo } from '#/tool/toolContract';
+import { isMcpToolName, type ToolInfo } from '#/tool/toolContract';
 import { IAgentToolExecutorService } from '#/agent/toolExecutor/toolExecutor';
 import { IAgentToolRegistryService } from '#/agent/toolRegistry/toolRegistry';
 
@@ -94,7 +94,7 @@ export class AgentToolSelectService extends Disposable implements IAgentToolSele
         shaped.push(entry);
         continue;
       }
-      if (entry.source !== 'mcp') {
+      if (!this.isDynamicallyLoadable(entry)) {
         shaped.push(entry);
         continue;
       }
@@ -156,8 +156,8 @@ export class AgentToolSelectService extends Disposable implements IAgentToolSele
 
   private shouldIntercept(name: string): boolean {
     if (!this.enabled()) return false;
-    const source = this.toolRegistry.list().find((info) => info.name === name)?.source;
-    if (source !== 'mcp') return false;
+    const info = this.toolRegistry.list().find((entry) => entry.name === name);
+    if (info === undefined || !this.isDynamicallyLoadable(info)) return false;
     if (!this.loadableToolNames().includes(name)) return false;
     return !this.activeLoadedToolNames().has(name);
   }
@@ -172,16 +172,26 @@ export class AgentToolSelectService extends Disposable implements IAgentToolSele
     if (!this.enabled()) return undefined;
     if (this.toolRegistry.resolve(name) !== undefined) return undefined;
     if (!this.loadedToolNames().has(name)) return undefined;
+    if (isMcpToolName(name)) {
+      return (
+        `Tool "${name}" was loaded but its MCP server is currently disconnected. ` +
+        'It may become available again when the server reconnects; do not retry immediately.'
+      );
+    }
     return (
-      `Tool "${name}" was loaded but its MCP server is currently disconnected. ` +
-      'It may become available again when the server reconnects; do not retry immediately.'
+      `Tool "${name}" was loaded but is no longer registered. ` +
+      'Do not retry it unless it becomes available again.'
     );
   }
 
   private loadableToolNames(): string[] {
     return this.toolRegistry
       .list()
-      .filter((info) => info.source === 'mcp' && this.toolPolicy.isToolActive(info.name, info.source))
+      .filter(
+        (info) =>
+          this.isDynamicallyLoadable(info) &&
+          this.toolPolicy.isToolActive(info.name, info.source),
+      )
       .map((info) => info.name)
       .toSorted((a, b) => a.localeCompare(b));
   }
@@ -206,7 +216,14 @@ export class AgentToolSelectService extends Disposable implements IAgentToolSele
   }
 
   private isLoadedToolActive(name: string): boolean {
-    return this.toolPolicy.isToolActive(name, 'mcp');
+    const info = this.toolRegistry.list().find((entry) => entry.name === name);
+    if (info !== undefined) return this.toolPolicy.isToolActive(name, info.source);
+    if (isMcpToolName(name)) return this.toolPolicy.isToolActive(name, 'mcp');
+    return true;
+  }
+
+  private isDynamicallyLoadable(info: ToolInfo): boolean {
+    return info.source === 'mcp' || info.disclosure === 'deferred';
   }
 
   private shapeActiveHistory(messages: readonly ContextMessage[]): readonly ContextMessage[] {

--- a/packages/agent-core-v2/src/agent/toolSelect/toolSelectService.ts
+++ b/packages/agent-core-v2/src/agent/toolSelect/toolSelectService.ts
@@ -217,7 +217,12 @@ export class AgentToolSelectService extends Disposable implements IAgentToolSele
 
   private isLoadedToolActive(name: string): boolean {
     const info = this.toolRegistry.list().find((entry) => entry.name === name);
-    if (info !== undefined) return this.toolPolicy.isToolActive(name, info.source);
+    if (info !== undefined) {
+      return (
+        this.isDynamicallyLoadable(info) &&
+        this.toolPolicy.isToolActive(name, info.source)
+      );
+    }
     if (isMcpToolName(name)) return this.toolPolicy.isToolActive(name, 'mcp');
     return false;
   }

--- a/packages/agent-core-v2/src/agent/toolSelect/toolSelectService.ts
+++ b/packages/agent-core-v2/src/agent/toolSelect/toolSelectService.ts
@@ -219,7 +219,7 @@ export class AgentToolSelectService extends Disposable implements IAgentToolSele
     const info = this.toolRegistry.list().find((entry) => entry.name === name);
     if (info !== undefined) return this.toolPolicy.isToolActive(name, info.source);
     if (isMcpToolName(name)) return this.toolPolicy.isToolActive(name, 'mcp');
-    return true;
+    return false;
   }
 
   private isDynamicallyLoadable(info: ToolInfo): boolean {

--- a/packages/agent-core-v2/src/agent/toolSelect/tools/select-tools.ts
+++ b/packages/agent-core-v2/src/agent/toolSelect/tools/select-tools.ts
@@ -2,8 +2,8 @@
  * `toolSelect` domain (L4) — `select_tools`, the load-by-exact-name primitive
  * of progressive tool disclosure.
  *
- * Registers the built-in tool that lets the model load MCP schemas named in
- * loadable-tools announcements. Delegates loading to
+ * Registers the built-in tool that lets the model load dynamic schemas named
+ * in loadable-tools announcements. Delegates loading to
  * `IAgentToolSelectService`; offered by the shaped tool view only while the
  * disclosure gate is open.
  */

--- a/packages/agent-core-v2/src/agent/userTool/userTool.ts
+++ b/packages/agent-core-v2/src/agent/userTool/userTool.ts
@@ -1,9 +1,11 @@
 import { createDecorator } from '#/_base/di/instantiation';
+import type { ToolDisclosure } from '#/tool/toolContract';
 
 export interface UserToolRegistration {
   readonly name: string;
   readonly description: string;
   readonly parameters: Record<string, unknown>;
+  readonly disclosure?: ToolDisclosure;
 }
 
 export interface IAgentUserToolService {

--- a/packages/agent-core-v2/src/agent/userTool/userToolOps.ts
+++ b/packages/agent-core-v2/src/agent/userTool/userToolOps.ts
@@ -40,7 +40,8 @@ function equalRegistration(a: UserToolRegistration, b: UserToolRegistration): bo
   return (
     a.name === b.name &&
     a.description === b.description &&
-    a.parameters === b.parameters
+    a.parameters === b.parameters &&
+    a.disclosure === b.disclosure
   );
 }
 

--- a/packages/agent-core-v2/src/agent/userTool/userToolService.ts
+++ b/packages/agent-core-v2/src/agent/userTool/userToolService.ts
@@ -102,7 +102,12 @@ export class AgentUserToolService extends Disposable implements IAgentUserToolSe
         execute: (context) => this.executeUserTool(context, name, args),
       }),
     };
-    this.registrations.set(name, this._register(this.registry.register(tool, { source: 'user' })));
+    this.registrations.set(
+      name,
+      this._register(
+        this.registry.register(tool, { source: 'user', disclosure: input.disclosure }),
+      ),
+    );
     if (options?.activate === false) return;
     this.profile.addActiveTool(name);
   }

--- a/packages/agent-core-v2/src/tool/toolContract.ts
+++ b/packages/agent-core-v2/src/tool/toolContract.ts
@@ -92,12 +92,14 @@ export interface ExecutableTool<Input = unknown> extends Tool {
 }
 
 export type ToolSource = 'builtin' | 'user' | 'mcp';
+export type ToolDisclosure = 'inline' | 'deferred';
 
 export interface ToolDefinition {
   readonly name: string;
   readonly description: string;
   readonly parameters?: Record<string, unknown>;
   readonly source?: ToolSource;
+  readonly disclosure?: ToolDisclosure;
   readonly info?: Record<string, unknown>;
 }
 

--- a/packages/agent-core-v2/test/agent/toolSelect/toolSelect.e2e.test.ts
+++ b/packages/agent-core-v2/test/agent/toolSelect/toolSelect.e2e.test.ts
@@ -1,8 +1,8 @@
 /**
  * Scenario (v1 `tool-select.e2e.test.ts` headline parity): progressive tool
- * disclosure converges the provider-visible table, keeps it byte-stable
- * across loads, makes a loaded tool dispatchable the next step, and
- * self-heals the loaded-ledger across undo.
+ * disclosure converges the provider-visible table for MCP and opted-in user
+ * tools, keeps it byte-stable across loads, makes a loaded tool dispatchable
+ * the next step, and self-heals the loaded-ledger across undo.
  *
  * Responsibilities: assert v1 contract at the provider wire, not via service
  * internals: the manifest announcement reaches the model, `select_tools`
@@ -28,11 +28,13 @@ import { IAgentToolRegistryService } from '#/agent/toolRegistry/toolRegistry';
 import { TOOL_SELECT_FLAG_ENV } from '#/agent/toolSelect/flag';
 import { IAgentToolSelectService } from '#/agent/toolSelect/toolSelect';
 import { IAgentToolSelectAnnouncementsService } from '#/agent/toolSelect/toolSelectAnnouncements';
+import { IAgentUserToolService } from '#/agent/userTool/userTool';
 import '#/agent/toolSelect/tools/select-tools';
 
 import { createTestAgent, type TestAgentContext } from '../../harness';
 
 const MCP_ALPHA = 'mcp__srv__alpha';
+const DASHBOARD_TOOL = 'dashboard_create';
 
 const DISCLOSURE_CAPABILITIES = {
   image_in: false,
@@ -170,6 +172,54 @@ describe('progressive tool disclosure end-to-end', () => {
     expect(wireEvents(ctx, 'llm.tools_snapshot')).toHaveLength(1);
 
     expect(alpha.calls).toBe(1);
+  });
+
+  it('loads and dispatches a user tool registered through the domain service', async () => {
+    ctx.get(IAgentUserToolService).register({
+      name: DASHBOARD_TOOL,
+      description: 'Create a dashboard.',
+      parameters: {
+        type: 'object',
+        properties: { title: { type: 'string' } },
+        required: ['title'],
+        additionalProperties: false,
+      },
+      disclosure: 'deferred',
+    });
+    ctx.mockNextResponse(selectToolsCall('call_select_1', [DASHBOARD_TOOL]));
+    ctx.mockNextResponse({
+      type: 'function',
+      id: 'call_dashboard_1',
+      name: DASHBOARD_TOOL,
+      arguments: JSON.stringify({ title: 'Operations' }),
+    });
+    ctx.mockNextResponse({ type: 'text', text: 'done' });
+
+    await ctx.rpc.prompt({ input: [{ type: 'text', text: 'create a dashboard' }] });
+    await ctx.untilToolCall({ output: 'dashboard-created' });
+    await ctx.untilTurnEnd();
+
+    const firstWire = ctx.llmCalls[0]!;
+    expect(toolNames(firstWire.tools)).not.toContain(DASHBOARD_TOOL);
+    expect(historyText(firstWire.history)).toContain(DASHBOARD_TOOL);
+
+    const secondWire = ctx.llmCalls[1]!;
+    const injected = secondWire.history.find((message) =>
+      message.tools?.some((tool) => tool.name === DASHBOARD_TOOL),
+    );
+    expect(injected?.tools?.find((tool) => tool.name === DASHBOARD_TOOL)?.parameters).toEqual({
+      type: 'object',
+      properties: { title: { type: 'string' } },
+      required: ['title'],
+      additionalProperties: false,
+    });
+    expect(secondWire.tools).toEqual(firstWire.tools);
+    expect(historyText(ctx.get(IAgentContextMemoryService).get())).toContain(
+      `Loaded: ${DASHBOARD_TOOL}`,
+    );
+    expect(historyText(ctx.get(IAgentContextMemoryService).get())).toContain(
+      'dashboard-created',
+    );
   });
 
   it('re-injects a selected schema after undo slices the tail of the loaded exchange', async () => {

--- a/packages/agent-core-v2/test/agent/toolSelect/toolSelectService.test.ts
+++ b/packages/agent-core-v2/test/agent/toolSelect/toolSelectService.test.ts
@@ -644,6 +644,27 @@ describe('AgentToolSelectService view shaping (gate open)', () => {
       USER_DEFERRED,
     ]);
   });
+
+  it('shapeHistory removes a deferred schema after re-registering the user tool inline', () => {
+    const h = createHarness();
+    registerUser(h, new EchoTool(USER_DEFERRED), 'deferred');
+    h.contextMemory.history.push(schemaMessage(USER_DEFERRED));
+    registerUser(h, new EchoTool(USER_DEFERRED));
+
+    expect(h.sut.shapeHistory(h.contextMemory.get())).toEqual([]);
+    const inline = h.sut
+      .shapeTools(h.registry.list())
+      .find((entry) => entry.name === USER_DEFERRED);
+    expect(inline).toEqual(
+      expect.objectContaining({ name: USER_DEFERRED, disclosure: undefined }),
+    );
+    expect(inline?.deferred).toBeUndefined();
+    expect(h.sut.load([USER_DEFERRED])).toEqual({
+      toLoad: [],
+      alreadyAvailable: [],
+      unknown: [USER_DEFERRED],
+    });
+  });
 });
 
 describe('AgentToolSelectService.load', () => {

--- a/packages/agent-core-v2/test/agent/toolSelect/toolSelectService.test.ts
+++ b/packages/agent-core-v2/test/agent/toolSelect/toolSelectService.test.ts
@@ -37,7 +37,11 @@ import { IAgentToolPolicyService } from '#/agent/toolPolicy/toolPolicy';
 import { IAgentScopeContext, makeAgentScopeContext } from '#/agent/scopeContext/scopeContext';
 import { IAgentSystemReminderService } from '#/agent/systemReminder/systemReminder';
 import { AgentSystemReminderService } from '#/agent/systemReminder/systemReminderService';
-import type { ExecutableTool, ToolExecution } from '#/tool/toolContract';
+import type {
+  ExecutableTool,
+  ToolDisclosure,
+  ToolExecution,
+} from '#/tool/toolContract';
 import { IAgentToolExecutorService, type ToolExecutionResult } from '#/agent/toolExecutor/toolExecutor';
 import { AgentToolExecutorService } from '#/agent/toolExecutor/toolExecutorService';
 import { IAgentToolRegistryService } from '#/agent/toolRegistry/toolRegistry';
@@ -59,6 +63,8 @@ const MCP_ALPHA = 'mcp__srv__alpha';
 const MCP_BETA = 'mcp__srv__beta';
 const MCP_GAMMA = 'mcp__srv__gamma';
 const MCP_GONE = 'mcp__srv__gone';
+const USER_DEFERRED = 'dashboard_create';
+const USER_INLINE = 'echo_inline';
 const REQUIRED_PAYLOAD_PARAMETERS = {
   type: 'object',
   required: ['payload'],
@@ -378,6 +384,16 @@ function registerBuiltin(h: Harness, tool: EchoTool): void {
   disposables.add(h.registry.register(tool, { source: 'builtin' }));
 }
 
+function registerUser(
+  h: Harness,
+  tool: EchoTool,
+  disclosure?: ToolDisclosure,
+): IDisposable {
+  const registration = h.registry.register(tool, { source: 'user', disclosure });
+  disposables.add(registration);
+  return registration;
+}
+
 async function announce(h: Harness, step = 1): Promise<string | undefined> {
   const before = h.contextMemory.appended.length;
   await h.loop.hooks.onWillBeginStep.run({
@@ -466,6 +482,16 @@ describe('AgentToolSelectService S0 baseline (gate closed)', () => {
     expect(shaped.every((entry) => entry.deferred === undefined)).toBe(true);
   });
 
+  it('keeps deferred user tools inline while the disclosure gate is closed', () => {
+    const h = createHarness();
+    registerUser(h, new EchoTool(USER_DEFERRED), 'deferred');
+
+    const shaped = h.sut.shapeTools(h.registry.list());
+
+    expect(shaped.map((entry) => entry.name)).toContain(USER_DEFERRED);
+    expect(shaped.find((entry) => entry.name === USER_DEFERRED)?.deferred).toBeUndefined();
+  });
+
   it('shapeTools applies profile filtering and removes select_tools while the gate is closed', () => {
     const h = createHarness();
     registerBuiltin(h, new EchoTool());
@@ -533,6 +559,22 @@ describe('AgentToolSelectService view shaping (gate open)', () => {
     expect(byName.get(MCP_ALPHA)?.deferred).toBe(true);
     expect(byName.get('Echo')?.deferred).toBeUndefined();
     expect(byName.get(SELECT_TOOLS_TOOL_NAME)?.deferred).toBeUndefined();
+  });
+
+  it('defers only opted-in user tools and restores them after selection', () => {
+    const h = createHarness();
+    registerUser(h, new EchoTool(USER_DEFERRED), 'deferred');
+    registerUser(h, new EchoTool(USER_INLINE));
+
+    const beforeLoad = h.sut.shapeTools(h.registry.list());
+    expect(beforeLoad.map((entry) => entry.name)).toContain(USER_INLINE);
+    expect(beforeLoad.map((entry) => entry.name)).not.toContain(USER_DEFERRED);
+
+    h.contextMemory.history.push(schemaMessage(USER_DEFERRED));
+    const afterLoad = h.sut.shapeTools(h.registry.list());
+    expect(afterLoad.map((entry) => entry.name)).toContain(USER_DEFERRED);
+    expect(afterLoad.find((entry) => entry.name === USER_DEFERRED)?.deferred).toBe(true);
+    expect(afterLoad.find((entry) => entry.name === USER_INLINE)?.deferred).toBeUndefined();
   });
 
   it('keeps select_tools visible when the profile omits it while hiding inactive tools', () => {
@@ -608,6 +650,20 @@ describe('AgentToolSelectService.load', () => {
     expect(appended.role).toBe('system');
     expect(appended.tools?.map((tool) => tool.name)).toEqual([MCP_BETA]);
     expect(appended.origin).toEqual({ kind: 'injection', variant: DYNAMIC_TOOL_SCHEMA_VARIANT });
+  });
+
+  it('loads the schema of an opted-in user tool', () => {
+    const h = createHarness();
+    registerUser(h, new EchoTool(USER_DEFERRED), 'deferred');
+
+    expect(h.sut.load([USER_DEFERRED])).toEqual({
+      toLoad: [USER_DEFERRED],
+      alreadyAvailable: [],
+      unknown: [],
+    });
+    expect(h.contextMemory.appended[0]?.tools?.map((tool) => tool.name)).toEqual([
+      USER_DEFERRED,
+    ]);
   });
 
   it('sorts the injected schemas by name', () => {
@@ -801,6 +857,21 @@ describe('AgentToolSelectService executor interception', () => {
     expect(results[0]!.result.output).toBe('echo ok');
     expect(echo.calls).toBe(1);
   });
+
+  it('intercepts an unloaded deferred user tool and runs it after selection', async () => {
+    const h = createExecutorHarness();
+    const dashboard = new EchoTool(USER_DEFERRED);
+    registerUser(h, dashboard, 'deferred');
+
+    const beforeLoad = await execute(h, toolCall('call-1', USER_DEFERRED));
+    expect(beforeLoad[0]!.result.output).toContain('is available but not loaded');
+    expect(dashboard.calls).toBe(0);
+
+    h.contextMemory.history.push(schemaMessage(USER_DEFERRED));
+    const afterLoad = await execute(h, toolCall('call-2', USER_DEFERRED));
+    expect(afterLoad[0]!.result.output).toBe('echo ok');
+    expect(dashboard.calls).toBe(1);
+  });
 });
 
 describe('AgentToolSelectService missing tool wording', () => {
@@ -825,6 +896,20 @@ describe('AgentToolSelectService missing tool wording', () => {
     const h = createExecutorHarness();
     const results = await execute(h, toolCall('call-1', MCP_GONE));
     expect(results[0]!.result.output).toBe(`Tool "${MCP_GONE}" not found`);
+  });
+
+  it('reports a loaded user tool that is no longer registered', async () => {
+    const h = createExecutorHarness();
+    const registration = registerUser(h, new EchoTool(USER_DEFERRED), 'deferred');
+    h.contextMemory.history.push(schemaMessage(USER_DEFERRED));
+    registration.dispose();
+
+    const results = await execute(h, toolCall('call-1', USER_DEFERRED));
+
+    expect(results[0]!.result.output).toBe(
+      `Tool "${USER_DEFERRED}" was loaded but is no longer registered. ` +
+        'Do not retry it unless it becomes available again.',
+    );
   });
 });
 

--- a/packages/agent-core-v2/test/agent/toolSelect/toolSelectService.test.ts
+++ b/packages/agent-core-v2/test/agent/toolSelect/toolSelectService.test.ts
@@ -627,6 +627,23 @@ describe('AgentToolSelectService view shaping (gate open)', () => {
       MCP_BETA,
     ]);
   });
+
+  it('shapeHistory removes a deferred user schema after unregister', () => {
+    const h = createHarness();
+    const registration = registerUser(h, new EchoTool(USER_DEFERRED), 'deferred');
+    h.contextMemory.history.push(schemaMessage(USER_DEFERRED));
+    registration.dispose();
+
+    expect(h.sut.shapeHistory(h.contextMemory.get())).toEqual([]);
+    expect(h.sut.load([USER_DEFERRED])).toEqual({
+      toLoad: [],
+      alreadyAvailable: [],
+      unknown: [USER_DEFERRED],
+    });
+    expect(h.contextMemory.get()[0]?.tools?.map((tool) => tool.name)).toEqual([
+      USER_DEFERRED,
+    ]);
+  });
 });
 
 describe('AgentToolSelectService.load', () => {

--- a/packages/agent-core-v2/test/agent/userTool/userTool.test.ts
+++ b/packages/agent-core-v2/test/agent/userTool/userTool.test.ts
@@ -32,6 +32,12 @@ const toolB: UserToolRegistration = {
   description: 'Echo the input.',
   parameters: { type: 'object', properties: { text: { type: 'string' } } },
 };
+const deferredTool: UserToolRegistration = {
+  name: 'DashboardCreate',
+  description: 'Create a dashboard.',
+  parameters: { type: 'object', properties: { title: { type: 'string' } } },
+  disclosure: 'deferred',
+};
 
 interface ProfileStub {
   readonly active: Set<string>;
@@ -116,6 +122,22 @@ describe('AgentUserToolService (wire-backed)', () => {
     expect(records.every((record) => 'payload' in record === false)).toBe(true);
   });
 
+  it('preserves deferred disclosure in the wire model and runtime registry', async () => {
+    svc.register(deferredTool);
+
+    expect(modelOf(wire).get(deferredTool.name)).toEqual(deferredTool);
+    expect(registry.list().find((tool) => tool.name === deferredTool.name)?.disclosure).toBe(
+      'deferred',
+    );
+    expect(await readRecords()).toEqual([
+      {
+        type: 'tools.register_user_tool',
+        ...deferredTool,
+        time: expect.any(Number),
+      },
+    ]);
+  });
+
   it('unregister persists a flat record and removes the tool live', async () => {
     svc.register(toolA);
     svc.unregister(toolA.name);
@@ -175,6 +197,19 @@ describe('AgentUserToolService (wire-backed)', () => {
     const before = modelOf(wire);
     svc.register(toolA);
     expect(modelOf(wire)).toBe(before);
+  });
+
+  it('treats a disclosure change as a new registration state', () => {
+    svc.register(toolA);
+    const before = modelOf(wire);
+
+    svc.register({ ...toolA, disclosure: 'deferred' });
+
+    expect(modelOf(wire)).not.toBe(before);
+    expect(modelOf(wire).get(toolA.name)?.disclosure).toBe('deferred');
+    expect(registry.list().find((tool) => tool.name === toolA.name)?.disclosure).toBe(
+      'deferred',
+    );
   });
 
   it('replay rebuilds the model silently and onDidRestore re-registers tools after replay', async () => {

--- a/packages/agent-core-v2/test/os/backends/node-local/tools/grep.test.ts
+++ b/packages/agent-core-v2/test/os/backends/node-local/tools/grep.test.ts
@@ -281,12 +281,12 @@ afterEach(() => {
 });
 
 describe('GrepTool', () => {
-  it('registers through the production tool contribution and DI path', () => {
+  it('registers contribution metadata through the production DI path', () => {
     const savedContributions = [...getToolContributions()];
     const disposables = new DisposableStore();
     try {
       _clearToolContributionsForTests();
-      registerTool(ProductionGrepTool);
+      registerTool(ProductionGrepTool, { source: 'user', disclosure: 'deferred' });
 
       const ix = createServices(disposables, {
         strict: true,
@@ -308,9 +308,11 @@ describe('GrepTool', () => {
 
       ix.get(IAgentBuiltinToolsRegistrar);
       const tool = ix.get(IAgentToolRegistryService).resolve('Grep');
+      const info = ix.get(IAgentToolRegistryService).list().find((entry) => entry.name === 'Grep');
 
       expect(tool).toBeInstanceOf(ProductionGrepTool);
       expect(tool?.name).toBe('Grep');
+      expect(info).toMatchObject({ source: 'user', disclosure: 'deferred' });
     } finally {
       disposables.dispose();
       _clearToolContributionsForTests();

--- a/packages/agent-core/src/agent/context/index.ts
+++ b/packages/agent-core/src/agent/context/index.ts
@@ -457,7 +457,9 @@ export class ContextMemory {
     // project() strips `origin`, the only anchor for the announcements.
     // setModel never rewrites history, so a mid-session switch
     // degrades/upgrades losslessly.
-    const shaped = this.agent.toolSelectEnabled ? messages : stripDynamicToolContext(messages);
+    const shaped = this.agent.toolSelectEnabled
+      ? this.agent.tools.shapeDynamicToolHistory(messages)
+      : stripDynamicToolContext(messages);
     const anomalies: ProjectionAnomaly[] = [];
     const result = project(this.agent.microCompaction.compact(shaped), {
       ...options,

--- a/packages/agent-core/src/agent/index.ts
+++ b/packages/agent-core/src/agent/index.ts
@@ -63,7 +63,13 @@ import type { ToolServices } from '../tools/support/services';
 
 export type { AgentRecord, AgentRecordPersistence } from './records';
 export type { SwarmModeTrigger } from './swarm';
-export type { BuiltinTool, ToolInfo, ToolSource, UserToolRegistration } from './tool';
+export type {
+  BuiltinTool,
+  ToolDisclosure,
+  ToolInfo,
+  ToolSource,
+  UserToolRegistration,
+} from './tool';
 export * from './goal';
 
 export type AgentType = 'main' | 'sub' | 'independent';

--- a/packages/agent-core/src/agent/tool/index.ts
+++ b/packages/agent-core/src/agent/tool/index.ts
@@ -6,6 +6,7 @@ import type { Agent } from '..';
 import {
   collectLoadedDynamicToolNames,
 } from '../context/dynamic-tools';
+import type { ContextMessage } from '../context/types';
 import { makeErrorPayload } from '../../errors';
 import type { ExecutableTool, ToolUpdate } from '../../loop';
 import { createMcpAuthTool } from '../../mcp/auth-tool';
@@ -260,6 +261,7 @@ export class ToolManager {
     });
     this.userTools.delete(name);
     this.deferredUserTools.delete(name);
+    this.pendingLoadedDynamicTools.delete(name);
     this.enabledTools.delete(name);
   }
 
@@ -575,8 +577,8 @@ export class ToolManager {
   }
 
   /**
-   * The loaded-tools ledger: every name whose full definition has been
-   * delivered to the conversation via a `tools`-carrying message, plus the
+   * The active loaded-tools ledger: every still-loadable name whose full
+   * definition has been delivered via a `tools`-carrying message, plus the
    * defer-window pending set. History is the single source of truth, so the
    * ledger survives resume (records replay rebuilds the history), keeps its
    * state across undo (schema messages have `injection` origin and are not
@@ -584,9 +586,54 @@ export class ToolManager {
    * the folded history — the model re-selects what it still needs).
    */
   loadedDynamicToolNames(): ReadonlySet<string> {
+    const names = this.allLoadedDynamicToolNames();
+    for (const name of names) {
+      if (!this.isLoadedDynamicToolActive(name)) names.delete(name);
+    }
+    return names;
+  }
+
+  shapeDynamicToolHistory(messages: readonly ContextMessage[]): readonly ContextMessage[] {
+    let shaped: ContextMessage[] | undefined;
+    for (let i = 0; i < messages.length; i += 1) {
+      const message = messages[i]!;
+      const tools = message.tools;
+      if (tools === undefined || tools.length === 0) {
+        if (shaped !== undefined) shaped.push(message);
+        continue;
+      }
+
+      const kept = tools.filter((tool) => this.isLoadedDynamicToolActive(tool.name));
+      if (kept.length === tools.length) {
+        if (shaped !== undefined) shaped.push(message);
+        continue;
+      }
+      shaped ??= messages.slice(0, i);
+      if (kept.length > 0) {
+        shaped.push({ ...message, tools: kept });
+        continue;
+      }
+
+      const { tools: _tools, ...rest } = message;
+      void _tools;
+      if (rest.content.length > 0 || rest.toolCalls.length > 0) shaped.push(rest);
+    }
+    return shaped ?? messages;
+  }
+
+  private allLoadedDynamicToolNames(): Set<string> {
     const names = collectLoadedDynamicToolNames(this.agent.context.history);
     for (const name of this.pendingLoadedDynamicTools) names.add(name);
     return names;
+  }
+
+  private isLoadedDynamicToolActive(name: string): boolean {
+    if (isMcpToolName(name)) return true;
+    return (
+      this.deferredUserTools.has(name) &&
+      this.userTools.has(name) &&
+      this.enabledTools.has(name)
+    );
   }
 
   /** Mark names loaded ahead of their schema message landing in history. */
@@ -643,7 +690,7 @@ export class ToolManager {
   missingToolMessage(name: string): string | undefined {
     if (!this.progressiveDisclosure) return undefined;
     const registered = this.loadableDynamicToolNames().includes(name);
-    const loaded = this.loadedDynamicToolNames().has(name);
+    const loaded = this.allLoadedDynamicToolNames().has(name);
     if (registered && !loaded) {
       return (
         `Tool "${name}" is available but not loaded. ` +

--- a/packages/agent-core/src/agent/tool/index.ts
+++ b/packages/agent-core/src/agent/tool/index.ts
@@ -47,6 +47,7 @@ interface PendingMcpDiscovery {
 export class ToolManager {
   protected builtinTools: Map<string, BuiltinTool> = new Map();
   protected readonly userTools: Map<string, ExecutableTool> = new Map();
+  private readonly deferredUserTools = new Set<string>();
   protected readonly mcpTools: Map<string, McpToolEntry> = new Map();
   private loopToolsOverride: readonly ExecutableTool[] | undefined;
   /** server name → list of qualified tool names registered for that server. */
@@ -244,6 +245,11 @@ export class ToolManager {
       },
     };
     this.userTools.set(name, tool);
+    if (input.disclosure === 'deferred') {
+      this.deferredUserTools.add(name);
+    } else {
+      this.deferredUserTools.delete(name);
+    }
     this.enabledTools.add(name);
   }
 
@@ -253,6 +259,7 @@ export class ToolManager {
       name,
     });
     this.userTools.delete(name);
+    this.deferredUserTools.delete(name);
     this.enabledTools.delete(name);
   }
 
@@ -263,6 +270,7 @@ export class ToolManager {
         name: tool.name,
         description: tool.description,
         parameters: tool.parameters,
+        disclosure: parent.deferredUserTools.has(tool.name) ? 'deferred' : undefined,
       });
     }
   }
@@ -541,7 +549,7 @@ export class ToolManager {
   }
 
   /**
-   * Whether MCP tools are disclosed progressively: kept out of the top-level
+   * Whether tools are disclosed progressively: kept out of the top-level
    * `tools[]` and loaded on demand via select_tools. Reads the agent's single
    * three-gate decision point.
    */
@@ -551,14 +559,19 @@ export class ToolManager {
 
   /**
    * Names the model may select right now: registered MCP tools that pass the
-   * profile's `mcp__*` access patterns, sorted for byte-stable announcements.
+   * profile's `mcp__*` access patterns, plus active user tools that explicitly
+   * opt into deferred disclosure, sorted for byte-stable announcements.
    * In disclosure mode the patterns keep their permission-filter role but stop
    * feeding the top-level `tools[]`.
    */
   loadableDynamicToolNames(): string[] {
-    return [...this.mcpTools.keys()]
-      .filter((name) => this.isMcpToolEnabled(name))
-      .toSorted((a, b) => a.localeCompare(b));
+    const names = new Set(
+      [...this.mcpTools.keys()].filter((name) => this.isMcpToolEnabled(name)),
+    );
+    for (const name of this.deferredUserTools) {
+      if (this.userTools.has(name) && this.enabledTools.has(name)) names.add(name);
+    }
+    return [...names].toSorted((a, b) => a.localeCompare(b));
   }
 
   /**
@@ -603,16 +616,21 @@ export class ToolManager {
   }
 
   /**
-   * Plain schema snapshot of a registered MCP tool, read from the live
+   * Plain schema snapshot of a loadable dynamic tool, read from the live
    * registry (never from history) at injection time.
    */
-  getMcpToolSchema(name: string): Tool | undefined {
-    const entry = this.mcpTools.get(name);
-    if (entry === undefined) return undefined;
+  getDynamicToolSchema(name: string): Tool | undefined {
+    const userTool =
+      this.deferredUserTools.has(name) && this.enabledTools.has(name)
+        ? this.userTools.get(name)
+        : undefined;
+    const mcpTool = this.isMcpToolEnabled(name) ? this.mcpTools.get(name)?.tool : undefined;
+    const tool = userTool ?? mcpTool;
+    if (tool === undefined) return undefined;
     return {
-      name: entry.tool.name,
-      description: entry.tool.description,
-      parameters: entry.tool.parameters,
+      name: tool.name,
+      description: tool.description,
+      parameters: tool.parameters,
     };
   }
 
@@ -624,8 +642,7 @@ export class ToolManager {
    */
   missingToolMessage(name: string): string | undefined {
     if (!this.progressiveDisclosure) return undefined;
-    if (!isMcpToolName(name)) return undefined;
-    const registered = this.mcpTools.has(name) && this.isMcpToolEnabled(name);
+    const registered = this.loadableDynamicToolNames().includes(name);
     const loaded = this.loadedDynamicToolNames().has(name);
     if (registered && !loaded) {
       return (
@@ -633,10 +650,16 @@ export class ToolManager {
         `Call select_tools with ["${name}"] first, then call the tool.`
       );
     }
-    if (!registered && loaded) {
+    if (!registered && loaded && isMcpToolName(name)) {
       return (
         `Tool "${name}" was loaded but its MCP server is currently disconnected. ` +
         'It may become available again when the server reconnects; do not retry immediately.'
+      );
+    }
+    if (!registered && loaded) {
+      return (
+        `Tool "${name}" was loaded but is no longer registered or active. ` +
+        'Do not retry it unless it becomes available again.'
       );
     }
     return undefined;
@@ -874,17 +897,23 @@ export class ToolManager {
     );
     // Progressive disclosure splits "the model can see this tool" from "the
     // core can execute it": the top-level request view stays the immutable
-    // core set + select_tools, while loaded MCP tools join the executable
+    // core set + select_tools, while loaded dynamic tools join the executable
     // table as deferred extras — dispatchable, but stripped from the outbound
     // top-level tools[] by kosong generate(). With disclosure off this is the
     // inline behavior, byte for byte.
     const loadedSet = disclosure ? this.loadedDynamicToolNames() : undefined;
+    const enabledNames =
+      loadedSet === undefined
+        ? [...this.enabledTools]
+        : [...this.enabledTools].filter(
+            (name) => !this.deferredUserTools.has(name) || loadedSet.has(name),
+          );
     const mcpNames =
       loadedSet === undefined
         ? enabledMcpNames
         : enabledMcpNames.filter((name) => loadedSet.has(name));
     const selectToolsName = disclosure ? [b.SELECT_TOOLS_TOOL_NAME] : [];
-    return uniq([...this.enabledTools, ...selectToolsName, ...mcpNames])
+    return uniq([...enabledNames, ...selectToolsName, ...mcpNames])
       .toSorted((a, b) => a.localeCompare(b))
       // select_tools is exposed exclusively through the disclosure gate — a
       // profile or setActiveTools listing the name explicitly must not
@@ -897,9 +926,11 @@ export class ToolManager {
           this.mcpTools.get(name)?.tool ??
           this.builtinTools.get(name);
         if (tool === undefined) return undefined;
-        // MCP entries are plain object literals, so the spread keeps the
+        const deferred =
+          disclosure && (this.mcpTools.has(name) || this.deferredUserTools.has(name));
+        // Dynamic entries are plain object literals, so the spread keeps the
         // execution closure intact while adding the wire-strip marker.
-        return disclosure && this.mcpTools.has(name) ? { ...tool, deferred: true as const } : tool;
+        return deferred ? { ...tool, deferred: true as const } : tool;
       })
       .filter((tool) => !!tool);
   }

--- a/packages/agent-core/src/agent/tool/types.ts
+++ b/packages/agent-core/src/agent/tool/types.ts
@@ -1,6 +1,7 @@
 import type { ExecutableTool } from '../../loop';
 
 export type ToolSource = 'builtin' | 'user' | 'mcp';
+export type ToolDisclosure = 'inline' | 'deferred';
 
 export type BuiltinTool<Input = unknown> = ExecutableTool<Input>;
 
@@ -8,6 +9,7 @@ export interface UserToolRegistration {
   readonly name: string;
   readonly description: string;
   readonly parameters: Record<string, unknown>;
+  readonly disclosure?: ToolDisclosure;
 }
 
 export interface ToolInfo {

--- a/packages/agent-core/src/rpc/core-api.ts
+++ b/packages/agent-core/src/rpc/core-api.ts
@@ -14,7 +14,7 @@ import type {
 import type { PermissionData, PermissionMode } from '#/agent/permission';
 import type { PlanData } from '#/agent/plan';
 import type { SwarmModeTrigger } from '#/agent/swarm';
-import type { ToolInfo } from '#/agent/tool';
+import type { ToolDisclosure, ToolInfo } from '#/agent/tool';
 import type { KimiConfig, KimiConfigPatch, McpServerConfig } from '#/config';
 import type { ExperimentalFeatureState } from '#/flags';
 import type { ResumeSessionResult } from '#/rpc/resumed';
@@ -263,6 +263,7 @@ export interface RegisterToolPayload {
   readonly name: string;
   readonly description: string;
   readonly parameters: Record<string, unknown>;
+  readonly disclosure?: ToolDisclosure;
 }
 export interface UnregisterToolPayload {
   readonly name: string;

--- a/packages/agent-core/src/tools/builtin/select-tools.ts
+++ b/packages/agent-core/src/tools/builtin/select-tools.ts
@@ -1,11 +1,12 @@
 /**
  * select_tools — the load-by-exact-name primitive of progressive tool
- * disclosure. MCP tool schemas stay out of the immutable top-level `tools[]`;
- * the model reads the `<tools_added>/<tools_removed>` announcements, calls
- * this tool with exact names, and the full definitions are appended to the
- * conversation as a `role: 'system'` message carrying `tools` (the
- * `messages[].tools` wire contract). Loaded tools become executable the very
- * next step: the loop re-reads the executable tool table per step.
+ * disclosure. Dynamic tool schemas stay out of the immutable top-level
+ * `tools[]`; the model reads the `<tools_added>/<tools_removed>`
+ * announcements, calls this tool with exact names, and the full definitions
+ * are appended to the conversation as a `role: 'system'` message carrying
+ * `tools` (the `messages[].tools` wire contract). Loaded tools become
+ * executable the very next step: the loop re-reads the executable tool table
+ * per step.
  *
  * Registered only when `agent.toolSelectEnabled` (capability × flag gate) and
  * deliberately NOT main-agent-only — subagents get the same disclosure.
@@ -98,7 +99,7 @@ export class SelectToolsTool implements BuiltinTool<SelectToolsInput> {
           // the loaded set, after which a re-select injects the new schema.
           toLoad.sort((a, b) => a.localeCompare(b));
           const tools = toLoad
-            .map((name) => manager.getMcpToolSchema(name))
+            .map((name) => manager.getDynamicToolSchema(name))
             .filter((tool): tool is NonNullable<typeof tool> => tool !== undefined);
           this.agent.context.appendMessage({
             role: 'system',

--- a/packages/agent-core/test/agent/tool-select.e2e.test.ts
+++ b/packages/agent-core/test/agent/tool-select.e2e.test.ts
@@ -368,6 +368,48 @@ describe('disclosure mode — select_tools three branches and dispatch', () => {
     await ctx.expectResumeMatches();
   });
 
+  it('stops exposing a loaded deferred user tool after unregister', async () => {
+    const ctx = testAgent({ experimentalFlags: toolSelectFlagOn() });
+    ctx.configure({
+      tools: ['Read'],
+      provider: DISCLOSURE_PROVIDER,
+      modelCapabilities: DISCLOSURE_CAPABILITIES,
+    });
+    await ctx.rpc.setPermission({ mode: 'yolo' });
+    await registerDeferredDashboard(ctx);
+
+    ctx.mockNextResponse(
+      { type: 'text', text: 'loading dashboard tool' },
+      selectCall('call-1', [DASHBOARD_TOOL]),
+    );
+    ctx.mockNextResponse({ type: 'text', text: 'loaded' });
+    await runTurn(ctx, 'load the dashboard tool');
+    expect(schemaMessages(ctx)).toHaveLength(1);
+
+    await ctx.rpc.unregisterTool({ name: DASHBOARD_TOOL });
+    expect(ctx.agent.tools.loadedDynamicToolNames().has(DASHBOARD_TOOL)).toBe(false);
+
+    ctx.mockNextResponse(
+      { type: 'text', text: 'calling removed tool' },
+      dashboardCall('call-2', 'Operations'),
+    );
+    ctx.mockNextResponse({ type: 'text', text: 'done' });
+    await runTurn(ctx, 'continue');
+
+    const firstCallAfterRemoval = ctx.llmCalls.at(-2)!;
+    expect(
+      firstCallAfterRemoval.history.some((message) =>
+        message.tools?.some((tool) => tool.name === DASHBOARD_TOOL),
+      ),
+    ).toBe(false);
+    expect(firstCallAfterRemoval.tools.map((tool) => tool.name)).not.toContain(DASHBOARD_TOOL);
+    expect(historyText(ctx)).toContain(`<tools_removed>\n${DASHBOARD_TOOL}\n</tools_removed>`);
+    expect(toolResultTexts(ctx).join('\n')).toContain(
+      `Tool "${DASHBOARD_TOOL}" was loaded but is no longer registered or active.`,
+    );
+    expect(schemaMessages(ctx)).toHaveLength(1);
+  });
+
   it('keeps the top-level tools snapshot stable across select_tools loads', async () => {
     const persistence = new InMemoryAgentRecordPersistence();
     const ctx = testAgent({ experimentalFlags: toolSelectFlagOn(), persistence });

--- a/packages/agent-core/test/agent/tool-select.e2e.test.ts
+++ b/packages/agent-core/test/agent/tool-select.e2e.test.ts
@@ -2,9 +2,11 @@
  * select_tools progressive disclosure — end-to-end agent tests.
  *
  * Uses the scripted-generate harness: real ToolManager/turn loop/context, fake
- * LLM. The three-condition gate (model capability.dynamically_loaded_tools ×
- * capability.tool_use × `tool-select` flag) is driven through the alias
- * capability declarations and an injected FlagResolver.
+ * LLM. Covers both MCP tools and host-registered user tools that opt into
+ * deferred disclosure. The three-condition gate (model
+ * capability.dynamically_loaded_tools × capability.tool_use × `tool-select`
+ * flag) is driven through the alias capability declarations and an injected
+ * FlagResolver.
  *
  * The first block pins the gate-closed regression baseline (S0): with any
  * gate closed, the outbound request keeps the inline shape byte-for-byte.
@@ -48,6 +50,7 @@ const INLINE_CAPABILITIES = {
 } as const;
 
 const GRAFANA_TOOL = 'mcp__grafana__query_range';
+const DASHBOARD_TOOL = 'dashboard_create';
 
 function toolSelectFlagOn(): FlagResolver {
   return new FlagResolver({}, FLAG_DEFINITIONS, { 'tool-select': true });
@@ -97,6 +100,20 @@ async function registerGrafana(
   );
 }
 
+async function registerDeferredDashboard(ctx: TestAgentContext): Promise<void> {
+  await ctx.rpc.registerTool({
+    name: DASHBOARD_TOOL,
+    description: 'Create a dashboard.',
+    parameters: {
+      type: 'object',
+      properties: { title: { type: 'string' } },
+      required: ['title'],
+      additionalProperties: false,
+    },
+    disclosure: 'deferred',
+  });
+}
+
 async function disclosureAgent(
   callLog: Array<[string, unknown]> = [],
 ): Promise<TestAgentContext> {
@@ -125,6 +142,15 @@ function mcpCall(id: string, query: string): ToolCall {
     id,
     name: GRAFANA_TOOL,
     arguments: JSON.stringify({ query }),
+  };
+}
+
+function dashboardCall(id: string, title: string): ToolCall {
+  return {
+    type: 'function',
+    id,
+    name: DASHBOARD_TOOL,
+    arguments: JSON.stringify({ title }),
   };
 }
 
@@ -190,6 +216,27 @@ describe('gate closed — inline regression baseline (S0)', () => {
     ctx.mockNextResponse({ type: 'text', text: 'hello' });
     await runTurn(ctx, 'hi');
     expect(ctx.llmCalls[0]!.tools.map((t) => t.name)).toContain(GRAFANA_TOOL);
+    expect(historyText(ctx)).not.toContain('<tools_added>');
+  });
+
+  it('keeps deferred user tools inline when disclosure is unavailable', async () => {
+    const ctx = testAgent({ experimentalFlags: toolSelectFlagOff() });
+    ctx.configure({
+      tools: ['Read'],
+      provider: DISCLOSURE_PROVIDER,
+      modelCapabilities: DISCLOSURE_CAPABILITIES,
+    });
+    await registerDeferredDashboard(ctx);
+
+    expect(ctx.agent.tools.loopTools.map((tool) => tool.name)).toContain(DASHBOARD_TOOL);
+    expect(
+      ctx.agent.tools.loopTools.find((tool) => tool.name === DASHBOARD_TOOL)?.deferred,
+    ).toBeUndefined();
+
+    ctx.mockNextResponse({ type: 'text', text: 'ready' });
+    await runTurn(ctx, 'hi');
+
+    expect(ctx.llmCalls[0]!.tools.map((tool) => tool.name)).toContain(DASHBOARD_TOOL);
     expect(historyText(ctx)).not.toContain('<tools_added>');
   });
 });
@@ -273,6 +320,52 @@ describe('disclosure mode — select_tools three branches and dispatch', () => {
     const step2 = ctx.llmCalls[1]!;
     expect(step2.tools.map((t) => t.name).some((n) => n.startsWith('mcp__'))).toBe(false);
     expect(step2.history.some((m) => m.tools !== undefined && m.tools.length > 0)).toBe(true);
+  });
+
+  it('loads and dispatches an opted-in user tool through the existing host RPC', async () => {
+    const ctx = testAgent({ experimentalFlags: toolSelectFlagOn() });
+    ctx.configure({
+      tools: ['Read'],
+      provider: DISCLOSURE_PROVIDER,
+      modelCapabilities: DISCLOSURE_CAPABILITIES,
+    });
+    await ctx.rpc.setPermission({ mode: 'yolo' });
+    await registerDeferredDashboard(ctx);
+
+    expect(ctx.agent.tools.loopTools.map((tool) => tool.name)).not.toContain(DASHBOARD_TOOL);
+
+    ctx.mockNextResponse(
+      { type: 'text', text: 'loading dashboard tool' },
+      selectCall('call-1', [DASHBOARD_TOOL]),
+    );
+    ctx.mockNextResponse(
+      { type: 'text', text: 'creating dashboard' },
+      dashboardCall('call-2', 'Operations'),
+    );
+    ctx.mockNextResponse({ type: 'text', text: 'done' });
+    await ctx.rpc.prompt({ input: [{ type: 'text', text: 'create a dashboard' }] });
+    await ctx.untilToolCall({ output: 'dashboard-created' });
+    await ctx.untilTurnEnd();
+
+    expect(ctx.llmCalls[0]!.tools.map((tool) => tool.name)).not.toContain(DASHBOARD_TOOL);
+    expect(JSON.stringify(ctx.llmCalls[0]!.history)).toContain(DASHBOARD_TOOL);
+    const injected = ctx.llmCalls[1]!.history.find((message) =>
+      message.tools?.some((tool) => tool.name === DASHBOARD_TOOL),
+    );
+    expect(injected?.tools?.find((tool) => tool.name === DASHBOARD_TOOL)?.parameters).toEqual({
+      type: 'object',
+      properties: { title: { type: 'string' } },
+      required: ['title'],
+      additionalProperties: false,
+    });
+    expect(ctx.llmCalls[1]!.tools.map((tool) => tool.name)).not.toContain(DASHBOARD_TOOL);
+    expect(toolResultTexts(ctx)).toContainEqual(`Loaded: ${DASHBOARD_TOOL}`);
+    expect(toolResultTexts(ctx)).toContainEqual('dashboard-created');
+    expect(
+      ctx.agent.tools.loopTools.find((tool) => tool.name === DASHBOARD_TOOL)?.deferred,
+    ).toBe(true);
+
+    await ctx.expectResumeMatches();
   });
 
   it('keeps the top-level tools snapshot stable across select_tools loads', async () => {


### PR DESCRIPTION
## Related Issue

No linked issue. This follows a maintainer request to let hosts defer selected registered tool schemas.

## Problem

`select_tools` only progressively disclosed MCP tools. Hosts with large registered user-tool surfaces had to expose every schema inline, increasing prompt size even when most tools were irrelevant.

## What changed

- Added optional `disclosure: "inline" | "deferred"` metadata to registered user tools, defaulting to `inline`.
- Made deferred host/user tools discoverable and loadable through `select_tools` in both agent-core v1 and v2.
- Propagated disclosure through v2 user-tool state, direct registry registration, and module-level `registerTool`.
- Preserved inline fallback when the model capability or feature flag gate is closed.
- Added persistence, inheritance, removal, provider-wire, and execution coverage.
- Added a changeset for `@moonshot-ai/kimi-code`; no CLI-facing documentation update is needed.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.