### PR TITLE
fix(web): preserve selected text when copying over HTTP

### DIFF
--- a/.changeset/fix-web-clipboard-paste.md
+++ b/.changeset/fix-web-clipboard-paste.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+web: Fix copying selected chat text over plain HTTP from replacing the clipboard with an event placeholder.

--- a/apps/kimi-web/src/components/chat/Markdown.vue
+++ b/apps/kimi-web/src/components/chat/Markdown.vue
@@ -16,7 +16,7 @@ import { useIsDark } from '../../composables/useIsDark';
 import type { FilePreviewRequest } from '../../types';
 import { collectFilePathAliases, findFilePathLinks } from '../../lib/filePathLinks';
 import { markdownRenderPlan } from '../../lib/markdownPerformance';
-import { copyTextToClipboard } from '../../lib/clipboard';
+import { copyCodeBlockFallback, copyTextToClipboard } from '../../lib/clipboard';
 import * as katexWorkerModule from 'markstream-vue/workers/katexRenderer.worker?worker&type=module';
 import * as mermaidWorkerModule from 'markstream-vue/workers/mermaidParser.worker?worker&type=module';
 import Tooltip from '../ui/Tooltip.vue';
@@ -337,15 +337,6 @@ const codeBlockProps = {
   showFontSizeButtons: false,
   loading: false,
 };
-
-function copyCodeBlockFallback(code: string): void {
-  // markstream emits `copy` even when it skipped the write because the
-  // Clipboard API is unavailable. Reuse our plain-HTTP fallback in that case,
-  // while avoiding a duplicate write after markstream succeeds on HTTPS.
-  const clipboard = typeof navigator !== 'undefined' ? navigator.clipboard : undefined;
-  if (clipboard && typeof clipboard.writeText === 'function') return;
-  void copyTextToClipboard(code);
-}
 
 // Root cause for the "large session turns into code skeletons" failure:
 // markstream mounts every code block in the loaded transcript, then shiki has

--- a/apps/kimi-web/src/lib/clipboard.ts
+++ b/apps/kimi-web/src/lib/clipboard.ts
@@ -30,6 +30,18 @@ export async function copyTextToClipboard(text: string): Promise<boolean> {
   return legacyCopy(text);
 }
 
+/**
+ * Complete markstream's code-block copy on plain HTTP without intercepting
+ * native selection-copy events that bubble through MarkdownRender.
+ */
+export function copyCodeBlockFallback(payload: unknown): void {
+  if (typeof payload !== 'string') return;
+
+  const clipboard = typeof navigator !== 'undefined' ? navigator.clipboard : undefined;
+  if (clipboard && typeof clipboard.writeText === 'function') return;
+  void copyTextToClipboard(payload);
+}
+
 function legacyCopy(text: string): boolean {
   if (typeof document === 'undefined' || typeof document.execCommand !== 'function') {
     return false;

--- a/apps/kimi-web/test/clipboard.test.ts
+++ b/apps/kimi-web/test/clipboard.test.ts
@@ -1,8 +1,9 @@
+// Scenario: clipboard writes in secure and plain-HTTP web contexts.
+// Responsibilities: preserve native selection copies and provide the legacy
+// code-block fallback. The test stubs only navigator/document browser APIs.
+// Run: pnpm --filter @moonshot-ai/kimi-web test -- clipboard.test.ts
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { copyTextToClipboard } from '../src/lib/clipboard';
-
-// The web test suite runs in the default node environment (no jsdom), so we
-// mock the tiny `navigator` / `document` surface that the helper touches.
+import { copyCodeBlockFallback, copyTextToClipboard } from '../src/lib/clipboard';
 
 interface FakeDocument {
   execCommand: ReturnType<typeof vi.fn>;
@@ -76,5 +77,28 @@ describe('copyTextToClipboard', () => {
     installDocument(false);
 
     await expect(copyTextToClipboard('nope')).resolves.toBe(false);
+  });
+});
+
+describe('code-block copy fallback', () => {
+  it('does not overwrite selected text when a native copy event bubbles on plain HTTP', () => {
+    installNavigator(undefined);
+    const doc = installDocument(true);
+    const copyEvent = { toString: () => '[object ClipboardEvent]' };
+
+    copyCodeBlockFallback(copyEvent);
+
+    expect(doc.execCommand).not.toHaveBeenCalled();
+    expect(doc.textarea.value).toBe('');
+  });
+
+  it('copies emitted code text when the Clipboard API is unavailable', () => {
+    installNavigator(undefined);
+    const doc = installDocument(true);
+
+    copyCodeBlockFallback('const host = "example.test";');
+
+    expect(doc.execCommand).toHaveBeenCalledWith('copy');
+    expect(doc.textarea.value).toBe('const host = "example.test";');
   });
 });


### PR DESCRIPTION
<!--
Thank you for your contribution to Kimi Code!
Please open an issue before sending a feature PR — PRs without prior discussion may be closed without review.

See https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md for more.
-->

## Related Issue

No tracking issue — the regression was reported through user feedback; the problem is described below.

## Problem

Since #1714 (v0.27.0), copying selected chat text over plain HTTP replaces the clipboard contents with `[object ClipboardEvent]` instead of the selected text.

Root cause chain:

1. #1714 added `@copy="copyCodeBlockFallback"` to `<MarkdownRender>` so code-block copy keeps working over plain HTTP, where `navigator.clipboard` is unavailable.
2. markstream-vue's NodeRenderer forwards `onCopy` to every block-level child, but `ParagraphNode` and `InlineCodeNode` do not declare `emits: ["copy"]`. Vue 3 attrs fallthrough therefore registers `onCopy` as a native DOM `copy` listener on the `<p>` root element.
3. When the user copies selected text inside a paragraph, the native `ClipboardEvent` is intercepted by that listener and re-emitted up the tree as the component `copy` event, so the fallback handler receives the event object instead of a code string.
4. Over HTTPS this is harmless because the fallback early-returns when `navigator.clipboard.writeText` exists. Over plain HTTP it falls through to the legacy `<textarea>` + `execCommand` path, where assigning the event to `textarea.value` stringifies it to `"[object ClipboardEvent]"` and overwrites the user's real selection.

This matches the reports: inline code reproduces consistently (it always lives inside a `<p>`), while headings/lists/tables declare `emits` and are unaffected; Thinking blocks are unaffected because they are not rendered through markstream.

## What changed

- Moved the plain-HTTP fallback from `Markdown.vue` into `clipboard.ts` as `copyCodeBlockFallback(payload: unknown)`.
- Non-string payloads (the bubbled native `ClipboardEvent`) are discarded, so the browser's default selection copy proceeds untouched; genuine code-block copy emits (strings) still get the legacy fallback.
- Added regression tests covering both cases over plain HTTP.

The durable fix belongs upstream (markstream-vue should declare `emits: ["copy"]` on `ParagraphNode` / `InlineCodeNode`); this PR stops the clipboard clobbering in the meantime.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.
