### PR TITLE
fix(web): unify permission mode order and risk colors across settings surfaces

### DIFF
--- a/.changeset/web-agent-permission-order.md
+++ b/.changeset/web-agent-permission-order.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+web: Reorder default permission options in Agent settings from safest to most permissive.

--- a/.changeset/web-agent-permission-order.md
+++ b/.changeset/web-agent-permission-order.md
@@ -2,4 +2,4 @@
 "@moonshot-ai/kimi-code": patch
 ---
 
-web: Reorder permission modes from safest to most permissive in Agent settings and the mobile permission cycle.
+web: Order permission modes from safest to most permissive across settings surfaces, and fix the swapped yolo/auto risk colors in the status panel and mobile settings.

--- a/.changeset/web-agent-permission-order.md
+++ b/.changeset/web-agent-permission-order.md
@@ -2,4 +2,4 @@
 "@moonshot-ai/kimi-code": patch
 ---
 
-web: Reorder default permission options in Agent settings from safest to most permissive.
+web: Reorder permission modes from safest to most permissive in Agent settings and the mobile permission cycle.

--- a/apps/kimi-web/src/components/chat/StatusPanel.vue
+++ b/apps/kimi-web/src/components/chat/StatusPanel.vue
@@ -52,10 +52,11 @@ function permLabel(p: PermissionMode): string {
   return t('status.permissionManual');
 }
 
+// Risk progression matches the Composer: yolo = warning, auto = danger.
 const permColor = computed(() => {
   const p = props.status.permission;
-  if (p === 'yolo') return 'var(--color-danger)';
-  if (p === 'auto') return 'var(--color-warning)';
+  if (p === 'yolo') return 'var(--color-warning)';
+  if (p === 'auto') return 'var(--color-danger)';
   return 'var(--color-text)';
 });
 

--- a/apps/kimi-web/src/components/mobile/MobileSettingsSheet.vue
+++ b/apps/kimi-web/src/components/mobile/MobileSettingsSheet.vue
@@ -71,7 +71,9 @@ function onColorScheme(v: string): void {
   emit('setColorScheme', v as ColorScheme);
 }
 
-const PERM_MODES: PermissionMode[] = ['manual', 'auto', 'yolo'];
+// Tap-to-cycle order follows the same safest → most permissive progression
+// as the Composer menu and Agent settings (manual → yolo → auto).
+const PERM_MODES: PermissionMode[] = ['manual', 'yolo', 'auto'];
 
 // Identity is the model id — display/model names can collide across providers.
 const currentModel = computed<AppModel | undefined>(() =>

--- a/apps/kimi-web/src/components/mobile/MobileSettingsSheet.vue
+++ b/apps/kimi-web/src/components/mobile/MobileSettingsSheet.vue
@@ -96,10 +96,11 @@ const thinkingOptions = computed(() =>
 const planOn = computed<boolean>(() => props.planMode === true);
 const swarmOn = computed<boolean>(() => props.swarmMode === true);
 
+// Risk progression matches the Composer: yolo = warning, auto = danger.
 const permColor = computed<string>(() => {
   const p = props.status.permission;
-  if (p === 'yolo') return 'var(--color-danger)';
-  if (p === 'auto') return 'var(--color-warning)';
+  if (p === 'yolo') return 'var(--color-warning)';
+  if (p === 'auto') return 'var(--color-danger)';
   return 'var(--color-text-muted)';
 });
 /** Permission sub-line, e.g. "manual · confirm every tool". */

--- a/apps/kimi-web/src/components/settings/SettingsDialog.vue
+++ b/apps/kimi-web/src/components/settings/SettingsDialog.vue
@@ -85,7 +85,7 @@ const daemonEndpoint = serverEndpointLabel();
 const backendLabel = computed(() =>
   props.backend === 'v2' ? 'v2 (kap-server)' : 'v1 (server)',
 );
-const permissionModes = ['manual', 'auto', 'yolo'] as const;
+const permissionModes = ['manual', 'yolo', 'auto'] as const;
 // Reuse the Composer's permission labels (status.permission*) so the
 // default-permission names stay in sync with the toolbar.
 const permissionLabelKey: Record<(typeof permissionModes)[number], string> = {


### PR DESCRIPTION
## Related Issue

No linked issue — the problem is explained below.

## Problem

In Agent settings, the default permission mode selector showed options in the order `manual → auto → yolo`. This is neither ordered by risk/permissiveness nor consistent with the Composer toolbar, which lists them as `manual → yolo → auto`.

- `manual`: ask for approval on every tool action (safest)
- `yolo`: auto-approve tool actions, but still ask questions (middle)
- `auto`: fully autonomous, no questions asked (most permissive)

Placing `auto` between `manual` and `yolo` made the risk progression hard to read at a glance.

## What changed

- Reordered `permissionModes` in `apps/kimi-web/src/components/settings/SettingsDialog.vue` from `['manual', 'auto', 'yolo']` to `['manual', 'yolo', 'auto']`.
- This matches the order already used in the Composer permission menu and arranges the modes from safest to most permissive.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works. (N/A — small UI ordering change)
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.

## Screenshots

| Before | After |
|--------|-------|
| ![Before](https://raw.githubusercontent.com/bowenliang123/kimi-code/web/agent-permission-order/.github/assets/pr-2125-permission-before.png) | ![After](https://raw.githubusercontent.com/bowenliang123/kimi-code/web/agent-permission-order/.github/assets/pr-2125-permission-after.png) |
