### PR TITLE
fix(cli): make kimi web and rotate-token access URLs clickable

### DIFF
--- a/.changeset/clickable-web-urls.md
+++ b/.changeset/clickable-web-urls.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Make `kimi web` and `kimi web rotate-token` access URLs clickable in supported terminals.

--- a/apps/kimi-code/src/cli/sub/web/rotate-token.ts
+++ b/apps/kimi-code/src/cli/sub/web/rotate-token.ts
@@ -12,6 +12,7 @@ import type { Command } from 'commander';
 
 import { darkColors } from '#/tui/theme/colors';
 import { getDataDir } from '#/utils/paths';
+import { toTerminalHyperlink } from '#/utils/terminal-hyperlink';
 
 import { accessUrlLines, splitTokenFragment } from './access-urls';
 
@@ -39,13 +40,15 @@ export function registerRotateTokenCommand(server: Command): void {
         const instance = await getLiveServerInstance();
         if (instance !== undefined) {
           for (const { label, url: href } of accessUrlLines(instance.host, instance.port, token)) {
-            // De-emphasize the `#token=…` fragment so the host/port stands out.
+            // De-emphasize the `#token=…` fragment so the host/port stands out,
+            // and wrap the whole URL in an OSC 8 terminal hyperlink for
+            // click-to-open support in supported terminals.
             const [base, frag] = splitTokenFragment(href);
-            const rendered =
+            const display =
               frag === ''
                 ? chalk.hex(darkColors.accent)(base)
                 : chalk.hex(darkColors.accent)(base) + chalk.hex(darkColors.textDim)(frag);
-            process.stdout.write(`  ${chalk.dim(label)}${rendered}\n`);
+            process.stdout.write(`  ${chalk.dim(label)}${toTerminalHyperlink(display, href)}\n`);
           }
         }
       } catch (error) {

--- a/apps/kimi-code/src/cli/sub/web/run.ts
+++ b/apps/kimi-code/src/cli/sub/web/run.ts
@@ -21,6 +21,7 @@ import { getNativeWebAssetsDir } from '#/native/web-assets';
 import { darkColors } from '#/tui/theme/colors';
 import { openUrl as defaultOpenUrl } from '#/utils/open-url';
 import { getDataDir } from '#/utils/paths';
+import { toTerminalHyperlink } from '#/utils/terminal-hyperlink';
 
 import { initializeServerTelemetry } from '../../telemetry';
 import {
@@ -200,7 +201,8 @@ function formatReadyLine(
   const notice = dangerousBypassAuth
     ? `${formatDangerNoticeLines().join('\n')}\n`
     : '';
-  return `${notice}Kimi server: ${buildOpenableUrl(origin, token)}\n`;
+  const href = buildOpenableUrl(origin, token);
+  return `${notice}Kimi server: ${toTerminalHyperlink(href, href)}\n`;
 }
 
 /**
@@ -372,10 +374,12 @@ export function formatReadyBanner(
   const label = (text: string): string => chalk.bold.hex(darkColors.textDim)(text);
   const url = (text: string): string => chalk.hex(darkColors.accent)(text);
   // Render the `#token=…` fragment in a de-emphasized gray so the host/port
-  // stands out while the full URL stays selectable for copying.
+  // stands out while the full URL stays selectable for copying. Wrap the whole
+  // line in an OSC 8 terminal hyperlink so supported terminals can click to open.
   const urlWithDimToken = (href: string): string => {
     const [base, frag] = splitTokenFragment(href);
-    return frag === '' ? url(base) : url(base) + dim(frag);
+    const display = frag === '' ? url(base) : url(base) + dim(frag);
+    return toTerminalHyperlink(display, href);
   };
 
   const port = Number(new URL(origin).port);

--- a/apps/kimi-code/test/cli/web/web.test.ts
+++ b/apps/kimi-code/test/cli/web/web.test.ts
@@ -27,7 +27,9 @@ vi.mock('node:child_process', async (importOriginal) => {
 });
 
 function stripAnsi(text: string): string {
-  return text.replaceAll(/\[[0-9;]*m/g, '');
+  return text
+    .replaceAll(/\[[0-9;]*m/g, '')
+    .replaceAll(/]8;[^]*/g, '');
 }
 
 function makeProgram(): Command {


### PR DESCRIPTION
## Related Issue

No linked issue.

## Problem

When running `kimi web` or `kimi web rotate-token`, the printed Local/Network access URLs contain the bearer-token fragment but are plain text. Users have to manually select and copy the URL into a browser; in supported terminals there is no click-to-open affordance.

## What changed

Wrap the access URLs in OSC 8 terminal hyperlinks using the existing `toTerminalHyperlink` utility, so terminals that support the sequence (iTerm2, VS Code terminal, Windows Terminal, etc.) render the URL as clickable. The hyperlink target is the full URL including the `#token=` fragment, so clicking opens the authenticated Web UI directly.

- `apps/kimi-code/src/cli/sub/web/run.ts`: ready banner and one-line ready output now emit hyperlinks.
- `apps/kimi-code/src/cli/sub/web/rotate-token.ts`: re-printed access links after rotation also emit hyperlinks.
- `apps/kimi-code/test/cli/web/web.test.ts`: updated the `stripAnsi` helper to strip OSC 8 escape sequences so plain-text assertions keep passing.

### Before

```
  Local:    http://127.0.0.1:58627/#token=abc123
  Network:  http://192.168.1.5:58627/#token=abc123
```

The URL is plain text; the user must select and copy it into a browser.

### After

In supported terminals the same line is now an OSC 8 hyperlinks (clickable to open links in browser) :

```
  Local:    http://127.0.0.1:58627/#token=abc123
  Network:  http://192.168.1.5:58627/#token=abc123
```

⌘/Ctrl-clicking the link opens the authenticated Web UI directly. The visible text and token handling are unchanged; only the underlying escape sequence is added.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.
