### PR TITLE
chore: prune non-user-facing changesets

### DIFF
--- a/.agents/skills/gen-changesets/SKILL.md
+++ b/.agents/skills/gen-changesets/SKILL.md
@@ -18,18 +18,26 @@ All other `@moonshot-ai/*` packages are treated as internal packages, including 
 1. **Inspect the actual changes first.** Use `git status` / `git diff --name-only` to identify which packages were actually changed.
 2. **List packages that changesets can release.** If a changed package is ignored in `.changeset/config.json`, do not put that ignored package in frontmatter together with a non-ignored package; changesets rejects mixed ignored/non-ignored frontmatter.
 3. **Map ignored internal changes to the affected released package.** If an ignored internal package changes CLI output or behavior, list `@moonshot-ai/kimi-code` and describe the actual user-visible or release-artifact change in the changelog text.
-4. **Internal package source changes that enter the CLI bundle must manually list the CLI.** `@moonshot-ai/kimi-code` inline-bundles `@moonshot-ai/*` source, but those internal packages are devDependencies from the CLI's perspective, so changesets will not automatically propagate bumps. If a change enters the CLI output, list `@moonshot-ai/kimi-code`.
+4. **Internal package source changes that enter the CLI bundle must manually list the CLI — when they get a changeset at all.** `@moonshot-ai/kimi-code` inline-bundles `@moonshot-ai/*` source, but those internal packages are devDependencies from the CLI's perspective, so changesets will not automatically propagate bumps. If a change enters the CLI output and is user-perceivable, list `@moonshot-ai/kimi-code`. See rule 6 for when to skip the changeset entirely.
    - **Web app (`@moonshot-ai/kimi-web`) changes always enter the CLI bundle.** `@moonshot-ai/kimi-web` is ignored by changesets (see `.changeset/config.json`) and cannot be mixed with `@moonshot-ai/kimi-code` in one changeset frontmatter. Describe the web change in the changelog text, but list `@moonshot-ai/kimi-code` so the CLI release carries the bundled `dist-web` output.
 5. **Docs-only and tests-only changes usually do not need a changeset.** README, internal docs, and `test/` changes that do not enter package output do not trigger a CLI bump.
-6. `@moonshot-ai/vis` / `vis-server` / `vis-web` are ignored by changesets and should not be handled. `@moonshot-ai/kimi-inspect` (a private dev app that never ships) is likewise ignored and must never appear in a changeset frontmatter.
+6. **Skip changes users cannot perceive — write no changeset at all.** The CLI changelog is user-facing; a changeset is a changelog entry, not a shipping gate. Internal changes merged to `main` still ship in the next release triggered by any user-facing changeset, so skipping the changeset loses nothing. Do not write changesets for:
+   - `agent-core-v2` internal architecture: new services, refactors, config-persistence or journal/wire mechanisms.
+   - `kap-server` WebSocket / REST protocol changes consumed only by the bundled web UI, kimi-inspect, or other dev tooling (new endpoints, subscribe protocols, stream baselines). A web-facing feature they back gets its own `web:` entry instead.
+   - Behavior that only takes effect on the experimental engine (e.g. experimental `kimi -p`), unless it exposes documented user configuration such as a `config.toml` section or env vars that also work on a shipped surface (TUI or `kimi web`).
+   - When unsure whether users can perceive a change, ask before writing.
+7. `@moonshot-ai/vis` / `vis-server` / `vis-web` are ignored by changesets and should not be handled. `@moonshot-ai/kimi-inspect` (a private dev app that never ships) is likewise ignored and must never appear in a changeset frontmatter.
 
 ## Workflow
 
 1. List the changed packages and check whether each one is ignored by `.changeset/config.json`.
-2. Choose a bump level for each package.
-3. If an ignored internal package change enters the CLI bundle, put `@moonshot-ai/kimi-code` in frontmatter instead of mixing the ignored package into the same changeset.
-4. Create a short kebab-case file under `.changeset/`.
-5. Split unrelated changes into separate changesets; keep one logical change in one file.
+2. Decide whether the change is user-perceivable (Core Rule 6); if not, stop — no changeset.
+3. Choose a bump level for each package.
+4. If an ignored internal package change enters the CLI bundle, put `@moonshot-ai/kimi-code` in frontmatter instead of mixing the ignored package into the same changeset.
+5. Create a short kebab-case file under `.changeset/`.
+6. Split unrelated changes into separate changesets; keep one logical change in one file.
+
+Before a release, review the accumulated `.changeset/` entries against Core Rule 6 and prune non-user-facing ones; the release PR regenerates from `.changeset/` on `main`, so deleting a changeset removes its changelog entry without affecting the shipped code.
 
 Format:
 
@@ -51,6 +59,8 @@ Format:
 | `major` | Breaking changes: incompatible config changes, renamed or removed commands/arguments, behavior semantics changes, and similar |
 
 When in doubt between `patch` and `minor`: if the change improves an existing feature and the user-facing impact is small, choose `patch` even when the change is technically "new". Reserve `minor` for a substantial new capability that introduces something users could not do before.
+
+New configuration surface is not automatically `minor`. Additions to an existing feature's configuration — env var overlays, config-file fallbacks, global defaults under per-item settings — are `patch`. Examples: a global default MCP timeout when per-server timeouts already exist; env-based credentials for a service already configurable in `config.toml`.
 
 ### Major Rule
 
@@ -211,6 +221,8 @@ Fix the transcript jumping to the top when scrolling up through history during s
 ## Red Flags
 
 - You are about to write `major` without asking the user.
+- You are writing a changeset for something users cannot perceive — `agent-core-v2` internals, `kap-server` WS/REST protocol plumbing, experimental-engine-only behavior. Skip the changeset instead (Core Rule 6).
+- A new env var overlay or config fallback for an existing feature is bumped `minor` — configuration additions to existing features are `patch`.
 - A new user-facing feature entry has no usage hint, or the hint runs to multiple lines and explains design rationale.
 - You guessed wording for a change you do not understand instead of asking the user whether you may dig into the repo.
 - Internal package source enters the CLI bundle, but `@moonshot-ai/kimi-code` is missing.

--- a/.changeset/align-v2-print-run-lifecycle.md
+++ b/.changeset/align-v2-print-run-lifecycle.md
@@ -1,5 +1,0 @@
----
-"@moonshot-ai/kimi-code": patch
----
-
-Align `kimi -p` on the experimental engine with the default engine's run lifecycle: the print background policy now defaults to steer with no practical turn or time cap, background task and per-turn step limits are lifted unless configured, and the run stays alive while cron tasks still have future fires so their steered turns can run.

--- a/.changeset/kosong-persistence-bridge.md
+++ b/.changeset/kosong-persistence-bridge.md
@@ -1,5 +1,0 @@
----
-"@moonshot-ai/kimi-code": patch
----
-
-Decouple provider and model management from config persistence on the experimental engine: the runtime keeps its own provider/model registry, and a dedicated sync layer hydrates it from config.toml at startup and writes runtime changes (added providers, discovered models, default-model selection) back to disk.

--- a/.changeset/mcp-global-timeouts.md
+++ b/.changeset/mcp-global-timeouts.md
@@ -1,5 +1,5 @@
 ---
-"@moonshot-ai/kimi-code": minor
+"@moonshot-ai/kimi-code": patch
 ---
 
 Add global default MCP server timeouts in `config.toml` and env vars.

--- a/.changeset/plan-revision-blobs.md
+++ b/.changeset/plan-revision-blobs.md
@@ -1,5 +1,0 @@
----
-"@moonshot-ai/kimi-code": patch
----
-
-Record plan content as versioned facts: each plan review submission offloads the document to a versioned per-agent plan directory and journals a reference record, so the transcript surfaces plan revisions (marker + badge with review path) and rebuilds them after restarts.

--- a/.changeset/session-work-changed-global-push.md
+++ b/.changeset/session-work-changed-global-push.md
@@ -1,5 +1,0 @@
----
-"@moonshot-ai/kimi-code": patch
----
-
-Push every session's work status (busy, pending interaction, last turn outcome) to all connected WebSocket clients without requiring a per-session subscription, and serve the same aggregate on the session list API.

--- a/.changeset/slim-reset-baseline.md
+++ b/.changeset/slim-reset-baseline.md
@@ -1,5 +1,0 @@
----
-"@moonshot-ai/kimi-code": patch
----
-
-Stop embedding historical turns in the transcript WS baseline reset; it now carries only global state and the stream watermark, and clients page history through the REST transcript API.

--- a/.changeset/transcript-event-dedup.md
+++ b/.changeset/transcript-event-dedup.md
@@ -1,5 +1,0 @@
----
-"@moonshot-ai/kimi-code": minor
----
-
-Extend the transcript protocol with step usage and timing, streamed tool input and progress, subagent outcomes, agent status, and the prompt queue; WebSocket connections subscribed to the transcript protocol no longer receive the equivalent legacy session events.

--- a/.changeset/transcript-filter-decouple.md
+++ b/.changeset/transcript-filter-decouple.md
@@ -1,5 +1,0 @@
----
-"@moonshot-ai/kimi-code": patch
----
-
-Decouple the transcript WebSocket stream from the legacy agent filter: transcript frames are now governed by the per-agent transcript grades alone, so a connection no longer silently drops transcript data for agents missing from its event allowlist.

--- a/.changeset/transcript-plan-endpoint.md
+++ b/.changeset/transcript-plan-endpoint.md
@@ -1,5 +1,0 @@
----
-"@moonshot-ai/kimi-code": minor
----
-
-Add a server endpoint to look up the plan content and review outcome of ExitPlanMode calls. Query `GET /api/v1/sessions/{session_id}/transcript/plan` with `agent_id`, plus an optional `tool_call_id` to narrow to one call.

--- a/.changeset/transcript-subscribe-v2.md
+++ b/.changeset/transcript-subscribe-v2.md
@@ -1,5 +1,0 @@
----
-"@moonshot-ai/kimi-code": minor
----
-
-Move transcript stream subscriptions on the server WebSocket protocol to a dedicated `subscribe_v2` control frame paired with an agent-grained `unsubscribe_v2`; the `transcript` and `transcript_since` fields on `client_hello` and `subscribe` are no longer accepted.

--- a/.changeset/transcript-user-messages.md
+++ b/.changeset/transcript-user-messages.md
@@ -1,5 +1,0 @@
----
-"@moonshot-ai/kimi-code": minor
----
-
-Add a session API endpoint that returns all turn-opening user messages of a session, grouped per agent. Query `GET /api/v1/sessions/{session_id}/transcript/user-messages` (optionally with `?agent_id=` for a single agent) to fetch them.

--- a/.changeset/web-services-env-config.md
+++ b/.changeset/web-services-env-config.md
@@ -1,5 +1,5 @@
 ---
-"@moonshot-ai/kimi-code": minor
+"@moonshot-ai/kimi-code": patch
 ---
 
 Add environment variables to configure the web search and web fetch services without OAuth login.

--- a/.changeset/wire-facts-cold-fold.md
+++ b/.changeset/wire-facts-cold-fold.md
@@ -1,5 +1,0 @@
----
-"@moonshot-ai/kimi-code": patch
----
-
-Persist task lifecycle and interaction records in session wire journals, and rebuild tasks, interactions, todos, and goal/plan meta when loading a cold transcript, so transcript state survives server restarts (older sessions are unaffected).


### PR DESCRIPTION
## Related Issue

None — release hygiene; see Problem below.

## Problem

The accumulated unpublished changesets contained many entries that CLI users cannot perceive: `agent-core-v2` internal architecture, `kap-server` WebSocket/REST protocol changes and new endpoints consumed only by the bundled web UI / kimi-inspect, and behavior that only takes effect on the experimental engine. Left in place, they would clutter the user-facing release changelog. Two remaining entries were also bumped `minor` despite only adding env var / config fallbacks to existing features.

## What changed

- Deleted 11 non-user-facing changesets. The underlying changes are already merged to `main` and still ship with the next user-facing release; removing a changeset only drops its changelog entry.
- Downgraded `mcp-global-timeouts` and `web-services-env-config` from `minor` to `patch`: both extend existing configuration surfaces (a global default under per-server MCP timeouts; env overlays for the existing `[services]` section), which is not a substantial new capability.
- Updated the `gen-changesets` skill so future changesets follow the same criteria:
  - New Core Rule 6: skip changesets for changes users cannot perceive (v2 internals, kap-server protocol plumbing, experimental-engine-only behavior without documented user configuration), with a note that skipped changes still ride the next release.
  - Workflow: decide user-perceivability before choosing a bump level, and prune accumulated `.changeset/` entries before a release (the release PR regenerates from `main`).
  - Bump levels: configuration additions to existing features (env overlays, config fallbacks, global defaults) are `patch`, with examples.

The remaining 5 changesets are all `patch`, so the next release is a patch release covering: global MCP timeouts, web service env vars, subagent secondary model, the reasoning-field fix for OpenAI-compatible endpoints, and the superpowers tip removal.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works. (N/A — release tooling and agent-skill docs only)
- [x] Ran `gen-changesets` skill, or this PR needs no changeset. (No changeset: this PR is changeset maintenance itself.)
- [x] Ran `gen-docs` skill, or this PR needs no doc update. (No user-facing behavior change.)
