### PR TITLE
perf: stream wire.jsonl reads to reduce peak memory consumption

### DIFF
--- a/.changeset/stream-wire-jsonl-reads.md
+++ b/.changeset/stream-wire-jsonl-reads.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Read session wire logs line-by-line instead of loading whole files into memory, cutting peak memory when serving session snapshots, history transcripts, and debug exports of long sessions.

--- a/packages/agent-core/src/services/message/transcript.ts
+++ b/packages/agent-core/src/services/message/transcript.ts
@@ -49,7 +49,7 @@
 import { readFile } from 'node:fs/promises';
 import path from 'node:path';
 
-import type { AgentRecord } from '../../agent/records';
+import { FileSystemAgentRecordPersistence, type AgentRecord } from '../../agent/records';
 import type { ContextMessage } from '../../agent/context';
 import type { ExecutableToolResult, LoopRecordedEvent } from '../../loop';
 import {
@@ -324,27 +324,16 @@ function rawToolResultContent(output: ExecutableToolResult['output']): ContentPa
 }
 
 /**
- * Parse a `wire.jsonl` file. A torn FINAL line (crash mid-flush) is dropped,
- * matching `FileSystemAgentRecordPersistence.read`; corruption anywhere else
- * throws so the caller can fall back to the live context view.
+ * Parse a `wire.jsonl` file. Streams the file line-by-line through the same
+ * crash-tolerant reader as `FileSystemAgentRecordPersistence.read` — a torn
+ * FINAL line (crash mid-flush) is dropped; corruption anywhere else throws so
+ * the caller can fall back to the live context view. A missing file yields no
+ * records (same as a fresh log).
  */
 export async function readWireRecords(wirePath: string): Promise<AgentRecord[]> {
-  const raw = await readFile(wirePath, 'utf8');
-  const lines = raw.split('\n');
   const records: AgentRecord[] = [];
-  for (let i = 0; i < lines.length; i++) {
-    let line = lines[i]!;
-    if (line.endsWith('\r')) line = line.slice(0, -1);
-    if (line.length === 0) continue;
-    try {
-      records.push(JSON.parse(line) as AgentRecord);
-    } catch (parseError) {
-      if (i === lines.length - 1) break;
-      throw new Error(
-        `wire.jsonl: corrupted line ${i + 1} in ${wirePath}: ${String(parseError)}`,
-        { cause: parseError },
-      );
-    }
+  for await (const record of new FileSystemAgentRecordPersistence(wirePath).read()) {
+    records.push(record);
   }
   return records;
 }

--- a/packages/agent-core/src/session/export/wire-scan.ts
+++ b/packages/agent-core/src/session/export/wire-scan.ts
@@ -1,4 +1,5 @@
-import { readFile } from 'node:fs/promises';
+import { createReadStream } from 'node:fs';
+import { createInterface } from 'node:readline';
 import { join } from 'pathe';
 
 export interface SessionWireScan {
@@ -9,50 +10,52 @@ export interface SessionWireScan {
 }
 
 export async function scanSessionWire(sessionDir: string): Promise<SessionWireScan> {
-  let raw: string;
-  try {
-    raw = await readFile(join(sessionDir, 'wire.jsonl'), 'utf-8');
-  } catch {
-    return {};
-  }
-
   let firstActivityMs: number | undefined;
   let lastActivityMs: number | undefined;
   let lastUserMessageMs: number | undefined;
   let firstUserInput: string | undefined;
 
-  for (const line of raw.split('\n')) {
-    const trimmed = line.trim();
-    if (trimmed.length === 0) continue;
-    let parsed: unknown;
-    try {
-      parsed = JSON.parse(trimmed) as unknown;
-    } catch {
-      continue;
-    }
-    if (typeof parsed !== 'object' || parsed === null) continue;
-    const record = parsed as {
-      type?: unknown;
-      time?: unknown;
-      userInput?: unknown;
-    };
-    const timeMs = typeof record.time === 'number' ? normalizeTimestampMs(record.time) : undefined;
-    if (timeMs !== undefined) {
-      firstActivityMs ??= timeMs;
-      lastActivityMs = timeMs;
-    }
-    if (record.type === 'turn_begin') {
+  try {
+    // Stream line-by-line: export-time scans must not hold the whole log
+    // (plus a per-line string array) in memory. A missing/unreadable file
+    // degrades to an empty scan, matching the old readFile catch-all.
+    const input = createReadStream(join(sessionDir, 'wire.jsonl'), { encoding: 'utf8' });
+    const lines = createInterface({ input, crlfDelay: Infinity });
+    for await (const line of lines) {
+      const trimmed = line.trim();
+      if (trimmed.length === 0) continue;
+      let parsed: unknown;
+      try {
+        parsed = JSON.parse(trimmed) as unknown;
+      } catch {
+        continue;
+      }
+      if (typeof parsed !== 'object' || parsed === null) continue;
+      const record = parsed as {
+        type?: unknown;
+        time?: unknown;
+        userInput?: unknown;
+      };
+      const timeMs = typeof record.time === 'number' ? normalizeTimestampMs(record.time) : undefined;
       if (timeMs !== undefined) {
-        lastUserMessageMs = timeMs;
+        firstActivityMs ??= timeMs;
+        lastActivityMs = timeMs;
       }
-      if (
-        firstUserInput === undefined &&
-        typeof record.userInput === 'string' &&
-        record.userInput.trim().length > 0
-      ) {
-        firstUserInput = record.userInput;
+      if (record.type === 'turn_begin') {
+        if (timeMs !== undefined) {
+          lastUserMessageMs = timeMs;
+        }
+        if (
+          firstUserInput === undefined &&
+          typeof record.userInput === 'string' &&
+          record.userInput.trim().length > 0
+        ) {
+          firstUserInput = record.userInput;
+        }
       }
     }
+  } catch {
+    return {};
   }
 
   return {

--- a/packages/kap-server/src/services/snapshot/snapshotReader.ts
+++ b/packages/kap-server/src/services/snapshot/snapshotReader.ts
@@ -18,6 +18,7 @@
  * resolve to empty / `'idle'` (a cold session owns no runtime interaction).
  */
 
+import { createReadStream } from 'node:fs';
 import { readFile, stat as fsStat } from 'node:fs/promises';
 import { join } from 'node:path';
 
@@ -282,30 +283,60 @@ interface ContextRecord {
 }
 
 /**
- * Parse a `wire.jsonl` file. A torn final line (crash mid-flush) is dropped;
- * corruption anywhere else throws so the route surfaces 50001. The leading
- * `metadata` envelope and any non-`context.*` record are returned as-is and
- * filtered by the reducer's `default` branch.
+ * Parse a `wire.jsonl` file. Streams the file line-by-line (chunk-buffered,
+ * never the whole file plus a per-line string array in memory — cold snapshot
+ * and transcript rebuilds read logs that can reach hundreds of MB). A torn
+ * final line (crash mid-flush) is dropped; corruption anywhere else throws so
+ * the route surfaces 50001. The leading `metadata` envelope and any
+ * non-`context.*` record are returned as-is and filtered by the reducer's
+ * `default` branch. Missing file rejects with ENOENT, same as `readFile`.
  */
 export async function readWireRecords(wirePath: string): Promise<ContextRecord[]> {
-  const raw = await readFile(wirePath, 'utf8');
-  const lines = raw.split('\n');
   const records: ContextRecord[] = [];
-  for (let i = 0; i < lines.length; i++) {
-    let line = lines[i]!;
-    if (line.endsWith('\r')) line = line.slice(0, -1);
-    if (line.length === 0) continue;
-    try {
-      records.push(JSON.parse(line) as ContextRecord);
-    } catch (parseError) {
-      if (i === lines.length - 1) break;
-      throw new Error(
-        `wire.jsonl: corrupted line ${i + 1} in ${wirePath}: ${String(parseError)}`,
-        { cause: parseError },
+  let buffered = '';
+  let lineNumber = 0;
+  const stream = createReadStream(wirePath, { encoding: 'utf8' });
+  for await (const chunk of stream) {
+    buffered += chunk;
+    let newlineIndex = buffered.indexOf('\n');
+    while (newlineIndex !== -1) {
+      const record = parseWireLine(
+        buffered.slice(0, newlineIndex),
+        ++lineNumber,
+        wirePath,
+        false,
       );
+      buffered = buffered.slice(newlineIndex + 1);
+      if (record !== undefined) records.push(record);
+      newlineIndex = buffered.indexOf('\n');
     }
   }
+  if (buffered.length > 0) {
+    const record = parseWireLine(buffered, ++lineNumber, wirePath, true);
+    if (record !== undefined) records.push(record);
+  }
   return records;
+}
+
+function parseWireLine(
+  raw: string,
+  lineNumber: number,
+  wirePath: string,
+  allowTruncated: boolean,
+): ContextRecord | undefined {
+  const line = raw.endsWith('\r') ? raw.slice(0, -1) : raw;
+  if (line.length === 0) return undefined;
+  try {
+    return JSON.parse(line) as ContextRecord;
+  } catch (parseError) {
+    // Tolerate a truncated trailing line — last write may have crashed
+    // mid-flush; everything before is still well-formed.
+    if (allowTruncated) return undefined;
+    throw new Error(
+      `wire.jsonl: corrupted line ${lineNumber} in ${wirePath}: ${String(parseError)}`,
+      { cause: parseError },
+    );
+  }
 }
 
 async function resolveBlobRef(


### PR DESCRIPTION
## Related Issue

No linked issue — the problem is explained below.

## Problem
As the current situation, the `wire.jsonl` file is:
- Agent-level: each agent’s append-only event journal, used to restore its conversation, tool activity, configuration, tasks, and runtime state.
- Apend-only:New records are appended whenever a persistent agent event occurs, such as a prompt, model output, tool call/result, state change, or usage update.
- No compaction: Context compaction reduces the model’s active context but does not remove old wire records, so the file continues to grow.

So it's a key to improve the reading performance, as it's never compacted and repeatedly read.

Three `wire.jsonl` readers still load the whole log into memory before parsing a single record:

- `SnapshotReader.readWireRecords` (kap-server) — backs `GET /sessions/{sid}/snapshot` and the cold transcript rebuild; session wire logs routinely reach tens to hundreds of MB.
- `readWireRecords` (agent-core `services/message/transcript.ts`) — backs the daemon message-history view.
- `scanSessionWire` (agent-core `session/export/wire-scan.ts`) — backs debug-bundle export activity scans.

Each one did `readFile` + `raw.split('\n')`, so a read transiently held the raw file string **plus** a per-line string array **plus** the parsed records — roughly 3× the file size in peak heap on a server that holds many sessions.

## What changed

Convert all three to streaming line-by-line reads, reusing existing components where semantics allow:

- **kap-server `SnapshotReader.readWireRecords`**: chunk-buffered line framing over `createReadStream` (the same pattern already used by `FileSystemAgentRecordPersistence`, v2 `AppendLogStore`, and `sessionEventJournal`). The exact error contract is preserved: a torn final line is dropped, corruption anywhere else throws `wire.jsonl: corrupted line N in <path>` with identical line numbering, and a missing file still rejects with `ENOENT` (the cold-snapshot route depends on it). A hand-rolled splitter is used instead of `node:readline` deliberately: readline cannot distinguish "last line without a trailing newline" (torn, must be dropped) from "last line with one" (corrupt, must throw).
- **agent-core `readWireRecords`**: delegates to the canonical `FileSystemAgentRecordPersistence.read()` async generator it always claimed to mirror — identical crash tolerance, no duplicated framing logic. One deliberate semantic alignment: a missing file now yields zero records (same as the persistence reader) instead of rejecting; every caller pre-`stat`s the file and treats unreadable as "fall back to live view", so behavior is unchanged in practice.
- **agent-core `scanSessionWire`**: `node:readline` over `createReadStream` (this scan tolerates all malformed lines, so readline's final-line blindness is a non-issue). Missing/unreadable file still degrades to an empty scan.

No behavior change otherwise: same records returned, same per-line tolerance, same reducer inputs. Existing unit tests cover the contract (`message-transcript.test.ts`, `snapshotReader.unit.test.ts` — torn-line drop, mid-file corruption throw, blobref rehydration, snapshot cache); full `agent-core` (3996) and `kap-server` (737) suites pass.

## Benchmark

Fixtures: synthetic `wire.jsonl` at 1 / 10 / 50 / 240 / 500 MB with realistic record shapes (`context.append_message`, `context.append_loop_event`, `turn_begin`; ~1,340 records per MB). Each implementation runs in a fresh process, 5 runs per cell, median reported; heap sampled in-process. macOS, Node 24.

`readWireRecords` (old `readFile`+split vs new streaming):

| file size | wall old | wall new | peak Δheap old | peak Δheap new | peak Δ |
|---|---|---|---|---|---|
| 1 MB | 4 ms | 7 ms | 3.3 MB | 2.3 MB | −30% |
| 10 MB | 25 ms | 29 ms | 32.7 MB | 22.9 MB | −30% |
| 50 MB | 101 ms | 120 ms | 112.9 MB | 100.4 MB | −11% |
| 240 MB | 491 ms | 489 ms | 779.2 MB | 327.3 MB | **−58%** |
| 500 MB | 1070 ms | 982 ms | 1127 MB | 641.5 MB | **−43%** |

`scanSessionWire` (old vs new):

| file size | wall old | wall new | peak Δheap old | peak Δheap new | peak Δ |
|---|---|---|---|---|---|
| 1 MB | 4 ms | 8 ms | 3.4 MB | 1.2 MB | −65% |
| 10 MB | 24 ms | 28 ms | 27.9 MB | 2.9 MB | −90% |
| 50 MB | 99 ms | 106 ms | 162.3 MB | 4.1 MB | −97% |
| 240 MB | 448 ms | 450 ms | 555.8 MB | 8.5 MB | **−98%** |
| 500 MB | 942 ms | 928 ms | 1045.4 MB | 15.8 MB | **−98%** |

Reading the tables:

- **Small files (the common case)**: streaming adds ~3–4 ms of fixed stream-setup overhead — invisible in practice (snapshot reads are `(size, mtime)`-cached, so this cost is paid once per file change, not per request). Memory win is modest because the file is small anyway.
- **Large files (the painful case)**: peak heap drops ~2× for `readWireRecords` and ~65× for `scanSessionWire`; the scan's peak stays ~flat (1.2 → 15.8 MB across 1 → 500 MB) instead of growing linearly with the log.
- **Wall time is parity, then flips**: at 500 MB the streaming readers are actually *faster* (982 vs 1070 ms; 928 vs 942 ms) — the old version's multi-hundred-MB single allocations start costing more than chunking does. The workload is `JSON.parse`-bound and both implementations parse every line identically.
- The remaining peak in `readWireRecords` (327 MB at 240 MB) is the returned records array itself — eliminating it requires reducer-level streaming (see below).

Follow-ups deliberately left out of this PR:

- Reducer-level streaming: `reduceWireRecords` already accepts `Iterable`; widening it and v2's `reduceContextTranscript` to `AsyncIterable` would let `readWireTranscript` / the snapshot cache fold records as they stream, removing the retained records array entirely (up to another ~2× on the numbers above). That touches public reducer signatures in two packages (apiSurface snapshot), so it deserves its own PR.
- The hand-rolled line-framing loop now exists in 4 places across 3 packages; not worth a cross-package util for ~15 lines, but worth revisiting together with the reducer streaming.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works. (Behavior-preserving change; covered by existing unit tests, full suites pass.)
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update. (Internal perf/memory change, no user-facing behavior or docs impact.)
