### PR TITLE
feat(cli): add kimi import command for cross-tool session transfer

### DIFF
--- a/.changeset/few-houses-talk.md
+++ b/.changeset/few-houses-talk.md
@@ -1,0 +1,5 @@
+---
+'@moonshot-ai/kimi-code': minor
+---
+
+Add `kimi import` CLI command to import session context from external AI coding tools (Claude Code support included). Users can migrate conversation history, tool activity, and project context between tools via `kimi import --from claude-code`.

--- a/apps/kimi-code/src/cli/commands.ts
+++ b/apps/kimi-code/src/cli/commands.ts
@@ -6,6 +6,7 @@ import type { CLIOptions } from './options';
 import { registerAcpCommand } from './sub/acp';
 import { registerDoctorCommand } from './sub/doctor';
 import { registerExportCommand } from './sub/export';
+import { registerImportCommand } from './sub/import';
 import { registerLoginCommand } from './sub/login';
 import { registerProviderCommand } from './sub/provider';
 import { registerVisCommand } from './sub/vis';
@@ -114,6 +115,7 @@ export function createProgram(
     .option('--plan', 'Start in plan mode.', false);
 
   registerExportCommand(program);
+  registerImportCommand(program);
   registerProviderCommand(program);
   registerAcpCommand(program);
   registerWebCommand(program);

--- a/apps/kimi-code/src/cli/import/sources/claude-code.ts
+++ b/apps/kimi-code/src/cli/import/sources/claude-code.ts
@@ -427,7 +427,7 @@ function aggregateTokenUsage(entries: CCRawEntry[]): HandoffTokenUsage | undefin
   }
 
   if (input === 0 && output === 0) return undefined;
-  return { input, output, ...(cacheRead > 0 ? { cacheRead } : {}), ...(cacheCreation > 0 ? { cacheCreation } : {}) };
+  return { input, output, cacheRead: cacheRead > 0 ? cacheRead : undefined, cacheCreation: cacheCreation > 0 ? cacheCreation : undefined };
 }
 
 // ---------------------------------------------------------------------------
@@ -680,7 +680,7 @@ class ClaudeCodeParser implements SourceParser {
     // Extract conversation turns
     const conversation: ConversationTurn[] = [];
     const allThinking: string[] = [];
-    let lastToolCallName = '';
+    const toolIdToName = new Map<string, string>();
 
     for (const entry of convEntries.slice(-MAX_RECENT_TURNS * 2)) {
       if (entry.message === undefined) continue;
@@ -692,9 +692,10 @@ class ClaudeCodeParser implements SourceParser {
         const toolResults = extractToolResultsFromBlocks(blocks);
         if (toolResults.length > 0) {
           for (const tr of toolResults) {
+            const toolName = toolIdToName.get(tr.tool_use_id) ?? 'tool';
             conversation.push({
               kind: 'tool-result',
-              toolName: lastToolCallName || 'tool',
+              toolName,
               summary: safeStringify(tr.content, MAX_TOOL_INPUT_CHARS),
             });
           }
@@ -717,7 +718,7 @@ class ClaudeCodeParser implements SourceParser {
         const toolCalls = extractToolCallsFromBlocks(blocks);
         if (toolCalls.length > 0) {
           for (const tc of toolCalls) {
-            lastToolCallName = tc.name;
+            toolIdToName.set(tc.id, tc.name);
             conversation.push({
               kind: 'tool-call',
               toolName: tc.name,
@@ -730,10 +731,8 @@ class ClaudeCodeParser implements SourceParser {
         if (text.length > 0 || thinking.length > 0) {
           conversation.push({
             kind: 'assistant',
-            ...(text.length > 0 ? { text: truncateText(text, 500) } : {}),
-            ...(thinking.length > 0
-              ? { thinking: truncateText(thinking, MAX_THINKING_CHARS) }
-              : {}),
+            text: text.length > 0 ? truncateText(text, 500) : undefined,
+            thinking: thinking.length > 0 ? truncateText(thinking, MAX_THINKING_CHARS) : undefined,
           });
         }
       }
@@ -755,10 +754,10 @@ class ClaudeCodeParser implements SourceParser {
     const ctx: Omit<HandoffContext, 'markdown'> = {
       source: this.sourceId,
       sourceSessionId: sessionId,
-      ...(model.length > 0 ? { model } : {}),
-      ...(createdAt !== undefined ? { createdAt } : {}),
-      ...(cwd.length > 0 ? { workingDirectory: cwd } : {}),
-      ...(tokenUsage !== undefined ? { tokenUsage } : {}),
+      model: model.length > 0 ? model : undefined,
+      createdAt: createdAt !== undefined ? createdAt : undefined,
+      workingDirectory: cwd.length > 0 ? cwd : undefined,
+      tokenUsage: tokenUsage !== undefined ? tokenUsage : undefined,
       summary: truncateText(firstUserText, 200) || undefined,
       keyDecisions,
       filesModified,

--- a/apps/kimi-code/src/cli/import/sources/claude-code.ts
+++ b/apps/kimi-code/src/cli/import/sources/claude-code.ts
@@ -1,0 +1,832 @@
+/**
+ * Claude Code session parser.
+ *
+ * Reads `~/.claude/projects/{encoded_cwd}/{sessionId}.jsonl` files and converts
+ * them into a unified {@link HandoffContext} for import into Kimi Code.
+ *
+ * Session format reference (reverse-engineered from cli-continues and real files):
+ *   - JSONL with one JSON object per line
+ *   - Entry types: user, assistant, system, queue-operation, attachment,
+ *     file-history-snapshot, ai-title, last-prompt, progress
+ *   - Only `user` and `assistant` entries carry conversation content
+ *   - Content blocks: text, thinking, tool_use, tool_result
+ *   - Subagent data in `{sessionId}/subagents/agent-*.jsonl`
+ */
+
+import { createReadStream } from 'node:fs';
+import { readdir, stat } from 'node:fs/promises';
+import { homedir } from 'node:os';
+import { join, relative } from 'node:path';
+import { createInterface } from 'node:readline';
+
+import type {
+  ConversationTurn,
+  FileChangeRecord,
+  HandoffContext,
+  HandoffTokenUsage,
+  SourceParser,
+  SourceSessionSummary,
+} from './types';
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const CLAUDE_PROJECTS_DIR = join(homedir(), '.claude', 'projects');
+const MAX_RECENT_TURNS = 30;
+const MAX_THINKING_CHARS = 500;
+const MAX_TOOL_INPUT_CHARS = 200;
+
+// ---------------------------------------------------------------------------
+// CC-specific raw types (subset of what real JSONL files contain)
+// ---------------------------------------------------------------------------
+
+interface CCRawMessage {
+  role: 'user' | 'assistant';
+  content: string | CCRawContentBlock[];
+}
+
+type CCRawContentBlock =
+  | { type: 'text'; text: string }
+  | { type: 'thinking'; thinking: string; signature?: string }
+  | { type: 'tool_use'; id: string; name: string; input: Record<string, unknown> }
+  | { type: 'tool_result'; tool_use_id: string; content: unknown; is_error?: boolean };
+
+interface CCRawEntry {
+  type: string;
+  uuid?: string;
+  parentUuid?: string | null;
+  sessionId?: string;
+  timestamp?: string;
+  cwd?: string;
+  gitBranch?: string;
+  version?: string;
+  isSidechain?: boolean;
+  message?: CCRawMessage;
+  // Top-level tool result (Bash, WebSearch, etc.)
+  toolUseResult?: {
+    exitCode?: number;
+    stdout?: string;
+    stderr?: string;
+    query?: string;
+    durationSeconds?: number;
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Session discovery
+// ---------------------------------------------------------------------------
+
+/**
+ * Reverse the CC directory-name encoding: every non-alphanumeric char in the
+ * absolute path is replaced by '-'. We try common prefix patterns to recover
+ * a human-readable path.
+ */
+function decodeProjectPath(encoded: string): string {
+  // The encoding replaces ALL non-alphanumeric chars with '-'.
+  // The common prefix on macOS is "-Users-username-..."
+  // We convert leading hyphens back to '/', then guess at the structure.
+  let decoded = encoded;
+  // Leading '-' represents '/'
+  if (decoded.startsWith('-')) {
+    decoded = '/' + decoded.slice(1);
+  }
+  // Heuristic: every '-' that separates known path segments could be '/'
+  // For display purposes we keep the encoded form — exact reverse is lossy.
+  return decoded;
+}
+
+function resolveClaudeConfigDir(): string {
+  const envDir = process.env['CLAUDE_CONFIG_DIR'];
+  if (envDir !== undefined && envDir.length > 0) {
+    return join(envDir, 'projects');
+  }
+  return CLAUDE_PROJECTS_DIR;
+}
+
+async function discoverSessionFiles(projectsDir: string): Promise<string[]> {
+  const files: string[] = [];
+
+  let projectDirs: string[];
+  try {
+    projectDirs = await readdir(projectsDir);
+  } catch {
+    return files; // ~/.claude/projects doesn't exist
+  }
+
+  for (const projectDir of projectDirs) {
+    const projectPath = join(projectsDir, projectDir);
+    let st: { isDirectory(): boolean };
+    try {
+      st = await stat(projectPath);
+    } catch {
+      continue;
+    }
+    if (!st.isDirectory()) continue;
+
+    let entries: string[];
+    try {
+      entries = await readdir(projectPath);
+    } catch {
+      continue;
+    }
+
+    for (const entry of entries) {
+      // Newer layout: sessions/{uuid}.jsonl
+      if (entry === 'sessions') {
+        const sessionsDir = join(projectPath, 'sessions');
+        try {
+          const sessionFiles = await readdir(sessionsDir);
+          for (const sf of sessionFiles) {
+            if (sf.endsWith('.jsonl') && sf.length > 36) {
+              files.push(join(sessionsDir, sf));
+            }
+          }
+        } catch {
+          // ignore
+        }
+        continue;
+      }
+
+      // Legacy layout: {uuid}.jsonl directly in project dir
+      if (entry.endsWith('.jsonl') && entry.length > 36) {
+        files.push(join(projectPath, entry));
+      }
+    }
+  }
+
+  return files;
+}
+
+// ---------------------------------------------------------------------------
+// JSONL parsing
+// ---------------------------------------------------------------------------
+
+async function* readEntries(filePath: string): AsyncGenerator<CCRawEntry> {
+  let stream: ReturnType<typeof createReadStream>;
+  try {
+    stream = createReadStream(filePath, { encoding: 'utf-8' });
+  } catch {
+    return;
+  }
+
+  const rl = createInterface({ input: stream, crlfDelay: Number.POSITIVE_INFINITY });
+
+  for await (const line of rl) {
+    const trimmed = line.trim();
+    if (trimmed.length === 0) continue;
+    try {
+      yield JSON.parse(trimmed) as CCRawEntry;
+    } catch {
+      // Skip malformed lines
+    }
+  }
+}
+
+function isConversationEntry(entry: CCRawEntry): boolean {
+  return entry.type === 'user' || entry.type === 'assistant';
+}
+
+// ---------------------------------------------------------------------------
+// Content extraction
+// ---------------------------------------------------------------------------
+
+function extractTextFromBlocks(blocks: CCRawContentBlock[]): string {
+  return blocks
+    .filter((b): b is { type: 'text'; text: string } => b.type === 'text')
+    .map((b) => b.text)
+    .join('\n')
+    .trim();
+}
+
+function extractThinkingFromBlocks(blocks: CCRawContentBlock[]): string {
+  return blocks
+    .filter((b): b is { type: 'thinking'; thinking: string } => b.type === 'thinking')
+    .map((b) => b.thinking)
+    .join('\n')
+    .trim();
+}
+
+function extractToolCallsFromBlocks(
+  blocks: CCRawContentBlock[],
+): Array<{ id: string; name: string; input: Record<string, unknown> }> {
+  return blocks
+    .filter(
+      (b): b is { type: 'tool_use'; id: string; name: string; input: Record<string, unknown> } =>
+        b.type === 'tool_use',
+    )
+    .map((b) => ({ id: b.id, name: b.name, input: b.input }));
+}
+
+function extractToolResultsFromBlocks(
+  blocks: CCRawContentBlock[],
+): Array<{ tool_use_id: string; content: unknown; is_error?: boolean }> {
+  return blocks
+    .filter(
+      (
+        b,
+      ): b is {
+        type: 'tool_result';
+        tool_use_id: string;
+        content: unknown;
+        is_error?: boolean;
+      } => b.type === 'tool_result',
+    )
+    .map((b) => ({ tool_use_id: b.tool_use_id, content: b.content, is_error: b.is_error }));
+}
+
+// ---------------------------------------------------------------------------
+// Tool result summarisation
+// ---------------------------------------------------------------------------
+
+function summariseToolResult(
+  toolName: string,
+  toolInput: Record<string, unknown>,
+  ccEntry: CCRawEntry,
+): string {
+  const tur = ccEntry.toolUseResult;
+
+  switch (toolName) {
+    case 'Bash':
+    case 'bash': {
+      const cmd =
+        typeof toolInput['command'] === 'string'
+          ? toolInput['command']
+          : typeof toolInput['cmd'] === 'string'
+            ? toolInput['cmd']
+            : '(unknown command)';
+      if (tur !== undefined) {
+        const code = tur.exitCode ?? '?';
+        return `\`${truncateText(cmd, 80)}\` — exit code ${String(code)}`;
+      }
+      return `\`${truncateText(cmd, 80)}\``;
+    }
+
+    case 'Read':
+    case 'read': {
+      const fp =
+        typeof toolInput['file_path'] === 'string'
+          ? toolInput['file_path']
+          : typeof toolInput['filePath'] === 'string'
+            ? toolInput['filePath']
+            : '(unknown file)';
+      return `Read \`${fp}\``;
+    }
+
+    case 'Write':
+    case 'write':
+    case 'Edit':
+    case 'edit': {
+      const fp =
+        typeof toolInput['file_path'] === 'string'
+          ? toolInput['file_path']
+          : typeof toolInput['filePath'] === 'string'
+            ? toolInput['filePath']
+            : '(unknown file)';
+      return `${toolName} \`${fp}\``;
+    }
+
+    case 'Glob':
+    case 'glob':
+    case 'Grep':
+    case 'grep': {
+      const pattern =
+        typeof toolInput['pattern'] === 'string' ? toolInput['pattern'] : '(unknown pattern)';
+      return `${toolName} \`${truncateText(pattern, 60)}\``;
+    }
+
+    case 'WebSearch':
+    case 'web_search': {
+      const query = tur?.query ?? toolInput['query'];
+      return typeof query === 'string'
+        ? `Web search: "${truncateText(query, 80)}"`
+        : 'Web search';
+    }
+
+    case 'WebFetch':
+    case 'web_fetch': {
+      const url = toolInput['url'];
+      return typeof url === 'string' ? `Fetch: ${truncateText(url, 80)}` : 'Web fetch';
+    }
+
+    case 'Task':
+    case 'task':
+    case 'Agent':
+    case 'agent': {
+      const desc =
+        typeof toolInput['description'] === 'string'
+          ? toolInput['description']
+          : typeof toolInput['prompt'] === 'string'
+            ? toolInput['prompt']
+            : '(subagent)';
+      return `Subagent: ${truncateText(desc, 100)}`;
+    }
+
+    default:
+      return `${toolName}`;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// File change extraction
+// ---------------------------------------------------------------------------
+
+function extractFileChanges(
+  entries: CCRawEntry[],
+  workingDirectory?: string,
+): FileChangeRecord[] {
+  const editsByPath = new Map<string, Set<string>>();
+  const readPaths = new Set<string>();
+
+  for (const entry of entries) {
+    if (entry.type !== 'assistant' || entry.message === undefined) continue;
+    const blocks = ensureBlocks(entry.message.content);
+    for (const tc of extractToolCallsFromBlocks(blocks)) {
+      const fp = getFilePath(tc.name, tc.input);
+      if (fp === undefined) continue;
+
+      const relPath = resolveRelativePath(fp, workingDirectory);
+      if (isEditTool(tc.name)) {
+        const descriptions = editsByPath.get(relPath) ?? new Set();
+        descriptions.add(summariseToolResult(tc.name, tc.input, entry));
+        editsByPath.set(relPath, descriptions);
+      } else if (tc.name === 'Read' || tc.name === 'read') {
+        readPaths.add(relPath);
+      }
+    }
+  }
+
+  const records: FileChangeRecord[] = [];
+  for (const [path, descriptions] of editsByPath) {
+    records.push({ path, description: [...descriptions].join('; ') });
+  }
+  // Include files that were read but not edited (context)
+  for (const path of readPaths) {
+    if (!editsByPath.has(path)) {
+      records.push({ path, description: 'Read (no edits)' });
+    }
+  }
+
+  return records;
+}
+
+function isEditTool(toolName: string): boolean {
+  const name = toolName.toLowerCase();
+  return name === 'write' || name === 'edit';
+}
+
+function getFilePath(
+  toolName: string,
+  input: Record<string, unknown>,
+): string | undefined {
+  const name = toolName.toLowerCase();
+  if (
+    name === 'read' ||
+    name === 'write' ||
+    name === 'edit' ||
+    name === 'grep' ||
+    name === 'glob'
+  ) {
+    return (
+      (input['file_path'] as string) ??
+      (input['filePath'] as string) ??
+      (input['path'] as string)
+    );
+  }
+  return undefined;
+}
+
+function resolveRelativePath(absolutePath: string, workingDirectory?: string): string {
+  if (workingDirectory !== undefined && absolutePath.startsWith(workingDirectory)) {
+    return relative(workingDirectory, absolutePath);
+  }
+  return absolutePath;
+}
+
+// ---------------------------------------------------------------------------
+// Token counting
+// ---------------------------------------------------------------------------
+
+function aggregateTokenUsage(entries: CCRawEntry[]): HandoffTokenUsage | undefined {
+  let input = 0;
+  let output = 0;
+  let cacheRead = 0;
+  let cacheCreation = 0;
+
+  for (const entry of entries) {
+    if (entry.type !== 'assistant') continue;
+    // Usage is nested in the API message
+    const msg = entry.message as Record<string, unknown> | undefined;
+    const usage = msg?.['usage'] as Record<string, number> | undefined;
+    if (usage === undefined) continue;
+
+    input += usage['input_tokens'] ?? 0;
+    output += usage['output_tokens'] ?? 0;
+    cacheRead += usage['cache_read_input_tokens'] ?? 0;
+    cacheCreation += usage['cache_creation_input_tokens'] ?? 0;
+  }
+
+  if (input === 0 && output === 0) return undefined;
+  return { input, output, ...(cacheRead > 0 ? { cacheRead } : {}), ...(cacheCreation > 0 ? { cacheCreation } : {}) };
+}
+
+// ---------------------------------------------------------------------------
+// Pending work detection
+// ---------------------------------------------------------------------------
+
+const PENDING_KEYWORDS = ['need to', 'next step', 'todo', 'remaining', 'pending'];
+
+function extractPendingWork(thinkingBlocks: string[]): string[] {
+  const unique = new Set<string>();
+  for (const think of thinkingBlocks) {
+    const lower = think.toLowerCase();
+    if (PENDING_KEYWORDS.some((kw) => lower.includes(kw))) {
+      unique.add(truncateText(think.trim(), 200));
+    }
+    if (unique.size >= 5) break;
+  }
+  return [...unique];
+}
+
+// ---------------------------------------------------------------------------
+// Handoff Markdown generation
+// ---------------------------------------------------------------------------
+
+function generateHandoffMarkdown(ctx: Omit<HandoffContext, 'markdown'>): string {
+  const lines: string[] = [];
+
+  // YAML frontmatter
+  lines.push('---');
+  lines.push(`source: ${ctx.source}`);
+  lines.push(`sourceSessionId: "${ctx.sourceSessionId}"`);
+  if (ctx.model !== undefined) lines.push(`model: "${ctx.model}"`);
+  if (ctx.createdAt !== undefined) lines.push(`createdAt: "${ctx.createdAt}"`);
+  if (ctx.workingDirectory !== undefined) lines.push(`workingDirectory: "${ctx.workingDirectory}"`);
+  if (ctx.tokenUsage !== undefined) {
+    lines.push('tokenUsage:');
+    lines.push(`  input: ${String(ctx.tokenUsage.input)}`);
+    lines.push(`  output: ${String(ctx.tokenUsage.output)}`);
+    if (ctx.tokenUsage.cacheRead !== undefined) {
+      lines.push(`  cacheRead: ${String(ctx.tokenUsage.cacheRead)}`);
+    }
+    if (ctx.tokenUsage.cacheCreation !== undefined) {
+      lines.push(`  cacheCreation: ${String(ctx.tokenUsage.cacheCreation)}`);
+    }
+  }
+  lines.push('---');
+  lines.push('');
+
+  // Summary
+  if (ctx.summary !== undefined) {
+    lines.push('## Summary');
+    lines.push('');
+    lines.push(ctx.summary);
+    lines.push('');
+  }
+
+  // Key decisions
+  if (ctx.keyDecisions.length > 0) {
+    lines.push('## Key Decisions');
+    lines.push('');
+    for (const decision of ctx.keyDecisions) {
+      lines.push(`- ${decision}`);
+    }
+    lines.push('');
+  }
+
+  // Files modified
+  if (ctx.filesModified.length > 0) {
+    lines.push('## Files Modified');
+    lines.push('');
+    for (const file of ctx.filesModified) {
+      lines.push(`- \`${file.path}\` — ${file.description}`);
+    }
+    lines.push('');
+  }
+
+  // Recent conversation
+  if (ctx.recentConversation.length > 0) {
+    lines.push('## Recent Conversation');
+    lines.push('');
+    for (const turn of ctx.recentConversation) {
+      switch (turn.kind) {
+        case 'user':
+          lines.push(`### User\n${turn.text}\n`);
+          break;
+        case 'assistant': {
+          const parts: string[] = ['### Assistant'];
+          if (turn.thinking !== undefined) {
+            parts.push(`> Thinking: ${turn.thinking}`);
+          }
+          if (turn.text !== undefined) {
+            parts.push(turn.text);
+          }
+          lines.push(parts.join('\n') + '\n');
+          break;
+        }
+        case 'tool-call':
+          lines.push(
+            `### Tool: ${turn.toolName}\n\`\`\`json\n${safeJsonStringify(turn.input, MAX_TOOL_INPUT_CHARS)}\n\`\`\`\n`,
+          );
+          break;
+        case 'tool-result':
+          lines.push(`### Tool Result: ${turn.toolName}\n${turn.summary}\n`);
+          break;
+      }
+    }
+  }
+
+  // Pending work
+  if (ctx.pendingWork.length > 0) {
+    lines.push('## Pending Work');
+    lines.push('');
+    for (const item of ctx.pendingWork) {
+      lines.push(`- ${item}`);
+    }
+    lines.push('');
+  }
+
+  return lines.join('\n');
+}
+
+// ---------------------------------------------------------------------------
+// Main parser
+// ---------------------------------------------------------------------------
+
+function ensureBlocks(content: string | CCRawContentBlock[]): CCRawContentBlock[] {
+  if (typeof content === 'string') {
+    return [{ type: 'text', text: content }];
+  }
+  return content;
+}
+
+function getTextFromContent(content: string | CCRawContentBlock[]): string {
+  const blocks = ensureBlocks(content);
+  return extractTextFromBlocks(blocks);
+}
+
+class ClaudeCodeParser implements SourceParser {
+  readonly sourceId = 'claude-code';
+  readonly label = 'Claude Code';
+
+  async listSessions(): Promise<SourceSessionSummary[]> {
+    const projectsDir = resolveClaudeConfigDir();
+    const files = await discoverSessionFiles(projectsDir);
+    const summaries: SourceSessionSummary[] = [];
+
+    for (const filePath of files) {
+      try {
+        const st = await stat(filePath);
+        const sessionId = filePath.replace(/\.jsonl$/, '').split('/').pop() ?? 'unknown';
+
+        // Quick peek at the first few entries for metadata
+        let firstUserText = '';
+        let model = '';
+        let cwd = '';
+        let createdAt: string | undefined;
+
+        let count = 0;
+        for await (const entry of readEntries(filePath)) {
+          if (count > 20) break;
+          count++;
+
+          if (entry.type === 'user' && firstUserText.length === 0 && entry.message !== undefined) {
+            firstUserText = getTextFromContent(entry.message.content);
+          }
+          if (model.length === 0 && entry.type === 'assistant' && entry.message !== undefined) {
+            const raw = entry.message as unknown as Record<string, unknown>;
+            model = String(raw['model'] ?? '');
+          }
+          if (cwd.length === 0 && entry.cwd !== undefined) {
+            cwd = entry.cwd;
+          }
+          if (createdAt === undefined && entry.timestamp !== undefined) {
+            createdAt = entry.timestamp;
+          }
+        }
+
+        const projectEncoded = filePath.split('/').slice(-2)[0] ?? '';
+        const displayCwd = decodeProjectPath(projectEncoded);
+
+        summaries.push({
+          source: this.sourceId,
+          sessionId,
+          title: truncateText(firstUserText, 80) || undefined,
+          workingDirectory: cwd || displayCwd,
+          createdAt,
+          updatedAt: st.mtime.toISOString(),
+          model: model || undefined,
+        });
+      } catch {
+        // Skip sessions we can't read
+      }
+    }
+
+    // Most recent first
+    summaries.sort((a, b) => (b.updatedAt ?? '').localeCompare(a.updatedAt ?? ''));
+    return summaries;
+  }
+
+  async parseSession(sessionId: string): Promise<HandoffContext> {
+    const projectsDir = resolveClaudeConfigDir();
+    const files = await discoverSessionFiles(projectsDir);
+
+    // Find the matching session file
+    const filePath = files.find((f) => f.includes(sessionId));
+    if (filePath === undefined) {
+      throw new Error(`Claude Code session not found: ${sessionId}`);
+    }
+
+    // Collect all entries
+    const entries: CCRawEntry[] = [];
+    for await (const entry of readEntries(filePath)) {
+      entries.push(entry);
+    }
+
+    return this.buildContext(sessionId, filePath, entries);
+  }
+
+  private buildContext(
+    sessionId: string,
+    _filePath: string,
+    entries: CCRawEntry[],
+  ): HandoffContext {
+    // Filter to conversation entries
+    const convEntries = entries.filter(isConversationEntry);
+
+    // Extract metadata
+    let firstUserText = '';
+    let model = '';
+    let cwd = '';
+    let createdAt: string | undefined;
+
+    for (const entry of entries) {
+      if (entry.type === 'user' && firstUserText.length === 0 && entry.message !== undefined) {
+        firstUserText = getTextFromContent(entry.message.content);
+      }
+      if (model.length === 0 && entry.type === 'assistant' && entry.message !== undefined) {
+        const raw = entry.message as unknown as Record<string, unknown>;
+        model = String(raw['model'] ?? '');
+      }
+      if (cwd.length === 0 && entry.cwd !== undefined) {
+        cwd = entry.cwd;
+      }
+      if (createdAt === undefined && entry.timestamp !== undefined) {
+        createdAt = entry.timestamp;
+      }
+      if (firstUserText.length > 0 && model.length > 0 && cwd.length > 0) break;
+    }
+
+    // Extract conversation turns
+    const conversation: ConversationTurn[] = [];
+    const allThinking: string[] = [];
+    let lastToolCallName = '';
+
+    for (const entry of convEntries.slice(-MAX_RECENT_TURNS * 2)) {
+      if (entry.message === undefined) continue;
+
+      if (entry.type === 'user') {
+        const blocks = ensureBlocks(entry.message.content);
+
+        // Tool results first
+        const toolResults = extractToolResultsFromBlocks(blocks);
+        if (toolResults.length > 0) {
+          for (const tr of toolResults) {
+            conversation.push({
+              kind: 'tool-result',
+              toolName: lastToolCallName || 'tool',
+              summary: safeStringify(tr.content, MAX_TOOL_INPUT_CHARS),
+            });
+          }
+        }
+
+        // User text
+        const text = extractTextFromBlocks(blocks);
+        if (text.length > 0) {
+          conversation.push({ kind: 'user', text: truncateText(text, 500) });
+        }
+      } else {
+        // assistant
+        const blocks = ensureBlocks(entry.message.content);
+
+        const thinking = extractThinkingFromBlocks(blocks);
+        if (thinking.length > 0) {
+          allThinking.push(thinking);
+        }
+
+        const toolCalls = extractToolCallsFromBlocks(blocks);
+        if (toolCalls.length > 0) {
+          for (const tc of toolCalls) {
+            lastToolCallName = tc.name;
+            conversation.push({
+              kind: 'tool-call',
+              toolName: tc.name,
+              input: tc.input,
+            });
+          }
+        }
+
+        const text = extractTextFromBlocks(blocks);
+        if (text.length > 0 || thinking.length > 0) {
+          conversation.push({
+            kind: 'assistant',
+            ...(text.length > 0 ? { text: truncateText(text, 500) } : {}),
+            ...(thinking.length > 0
+              ? { thinking: truncateText(thinking, MAX_THINKING_CHARS) }
+              : {}),
+          });
+        }
+      }
+    }
+
+    // Extract key decisions from thinking blocks
+    const keyDecisions = extractKeyDecisions(allThinking);
+
+    // Extract file changes
+    const filesModified = extractFileChanges(entries, cwd || undefined);
+
+    // Extract pending work
+    const pendingWork = extractPendingWork(allThinking);
+
+    // Aggregate token usage
+    const tokenUsage = aggregateTokenUsage(entries);
+
+    // Build context (without markdown)
+    const ctx: Omit<HandoffContext, 'markdown'> = {
+      source: this.sourceId,
+      sourceSessionId: sessionId,
+      ...(model.length > 0 ? { model } : {}),
+      ...(createdAt !== undefined ? { createdAt } : {}),
+      ...(cwd.length > 0 ? { workingDirectory: cwd } : {}),
+      ...(tokenUsage !== undefined ? { tokenUsage } : {}),
+      summary: truncateText(firstUserText, 200) || undefined,
+      keyDecisions,
+      filesModified,
+      recentConversation: conversation.slice(-MAX_RECENT_TURNS),
+      pendingWork,
+    };
+
+    return { ...ctx, markdown: generateHandoffMarkdown(ctx) };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Utility helpers
+// ---------------------------------------------------------------------------
+
+function extractKeyDecisions(thinkingBlocks: string[]): string[] {
+  const decisions = new Set<string>();
+  const decisionMarkers = [
+    'decided to',
+    'chose to',
+    'opted for',
+    'went with',
+    'using',
+    'instead of',
+  ];
+
+  for (const think of thinkingBlocks) {
+    const lower = think.toLowerCase();
+    for (const marker of decisionMarkers) {
+      const idx = lower.indexOf(marker);
+      if (idx >= 0) {
+        // Extract the sentence containing this marker
+        const snippet = think.slice(Math.max(0, idx - 30), idx + 150);
+        decisions.add(truncateText(snippet.trim(), 200));
+        break;
+      }
+    }
+    if (decisions.size >= 10) break;
+  }
+
+  return [...decisions];
+}
+
+function truncateText(text: string, maxLen: number): string {
+  if (text.length <= maxLen) return text;
+  return text.slice(0, maxLen - 3) + '...';
+}
+
+function safeStringify(value: unknown, maxLen: number): string {
+  try {
+    const str = JSON.stringify(value);
+    return truncateText(str, maxLen);
+  } catch {
+    return String(value).slice(0, maxLen);
+  }
+}
+
+function safeJsonStringify(obj: Record<string, unknown>, maxLen: number): string {
+  try {
+    return truncateText(JSON.stringify(obj, null, 2), maxLen);
+  } catch {
+    return truncateText(JSON.stringify(obj), maxLen);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Export
+// ---------------------------------------------------------------------------
+
+/** Singleton instance of the Claude Code parser. */
+export const claudeCodeParser: SourceParser = new ClaudeCodeParser();

--- a/apps/kimi-code/src/cli/import/sources/claude-code.ts
+++ b/apps/kimi-code/src/cli/import/sources/claude-code.ts
@@ -24,6 +24,7 @@ import type {
   FileChangeRecord,
   HandoffContext,
   HandoffTokenUsage,
+  ParseOptions,
   SourceParser,
   SourceSessionSummary,
 } from './types';
@@ -33,7 +34,7 @@ import type {
 // ---------------------------------------------------------------------------
 
 const CLAUDE_PROJECTS_DIR = join(homedir(), '.claude', 'projects');
-const MAX_RECENT_TURNS = 30;
+const DEFAULT_MAX_TURNS = 30;
 const MAX_THINKING_CHARS = 500;
 const MAX_TOOL_INPUT_CHARS = 200;
 
@@ -627,7 +628,7 @@ class ClaudeCodeParser implements SourceParser {
     return summaries;
   }
 
-  async parseSession(sessionId: string): Promise<HandoffContext> {
+  async parseSession(sessionId: string, options?: ParseOptions): Promise<HandoffContext> {
     const projectsDir = resolveClaudeConfigDir();
     const files = await discoverSessionFiles(projectsDir);
 
@@ -643,14 +644,16 @@ class ClaudeCodeParser implements SourceParser {
       entries.push(entry);
     }
 
-    return this.buildContext(sessionId, filePath, entries);
+    return this.buildContext(sessionId, filePath, entries, options?.maxTurns);
   }
 
   private buildContext(
     sessionId: string,
     _filePath: string,
     entries: CCRawEntry[],
+    maxTurns?: number,
   ): HandoffContext {
+    const turnsLimit = maxTurns ?? DEFAULT_MAX_TURNS;
     // Filter to conversation entries
     const convEntries = entries.filter(isConversationEntry);
 
@@ -682,7 +685,7 @@ class ClaudeCodeParser implements SourceParser {
     const allThinking: string[] = [];
     const toolIdToName = new Map<string, string>();
 
-    for (const entry of convEntries.slice(-MAX_RECENT_TURNS * 2)) {
+    for (const entry of convEntries.slice(-turnsLimit * 2)) {
       if (entry.message === undefined) continue;
 
       if (entry.type === 'user') {
@@ -761,7 +764,7 @@ class ClaudeCodeParser implements SourceParser {
       summary: truncateText(firstUserText, 200) || undefined,
       keyDecisions,
       filesModified,
-      recentConversation: conversation.slice(-MAX_RECENT_TURNS),
+      recentConversation: conversation.slice(-turnsLimit),
       pendingWork,
     };
 

--- a/apps/kimi-code/src/cli/import/sources/types.ts
+++ b/apps/kimi-code/src/cli/import/sources/types.ts
@@ -1,0 +1,107 @@
+/**
+ * Source parser interface for importing sessions from external AI coding tools.
+ *
+ * Each source tool (Claude Code, Codex, Cursor, etc.) implements this interface
+ * to convert its native session format into a unified {@link HandoffContext}.
+ */
+
+/** Structured context extracted from a foreign AI coding session. */
+export interface HandoffContext {
+  /** Source tool identifier (e.g. 'claude-code', 'codex'). */
+  source: string;
+  /** Original session ID in the source tool. */
+  sourceSessionId: string;
+  /** Model used in the source session, if known. */
+  model?: string;
+  /** When the source session was created. */
+  createdAt?: string;
+  /** Working directory of the source session. */
+  workingDirectory?: string;
+  /** Aggregated token usage from the source session. */
+  tokenUsage?: HandoffTokenUsage;
+  /** Short summary (first user message or title). */
+  summary?: string;
+  /** Key decisions and architectural choices discovered during the session. */
+  keyDecisions: string[];
+  /** Files that were modified, with descriptions. */
+  filesModified: FileChangeRecord[];
+  /** Recent conversation turns (most recent first, up to a limit). */
+  recentConversation: ConversationTurn[];
+  /** Pending work items that were not completed. */
+  pendingWork: string[];
+  /** Raw handoff document in Markdown format. */
+  markdown: string;
+}
+
+export interface HandoffTokenUsage {
+  input: number;
+  output: number;
+  cacheRead?: number;
+  cacheCreation?: number;
+}
+
+export interface FileChangeRecord {
+  path: string;
+  description: string;
+}
+
+export type ConversationTurn =
+  | UserTurn
+  | AssistantTurn
+  | ToolCallTurn
+  | ToolResultTurn;
+
+export interface UserTurn {
+  kind: 'user';
+  text: string;
+}
+
+export interface AssistantTurn {
+  kind: 'assistant';
+  text?: string;
+  thinking?: string;
+}
+
+export interface ToolCallTurn {
+  kind: 'tool-call';
+  toolName: string;
+  input: Record<string, unknown>;
+}
+
+export interface ToolResultTurn {
+  kind: 'tool-result';
+  toolName: string;
+  summary: string;
+}
+
+/** Summary of a discoverable source session. */
+export interface SourceSessionSummary {
+  /** Source tool identifier. */
+  source: string;
+  /** Session ID in the source tool. */
+  sessionId: string;
+  /** Display title or summary. */
+  title?: string;
+  /** Working directory. */
+  workingDirectory?: string;
+  /** When the session was created. */
+  createdAt?: string;
+  /** When the session was last updated. */
+  updatedAt?: string;
+  /** Model used. */
+  model?: string;
+  /** Approximate token count. */
+  tokenCount?: number;
+}
+
+/** Interface that each source-tool parser must implement. */
+export interface SourceParser {
+  /** Unique identifier for this source (e.g. 'claude-code'). */
+  readonly sourceId: string;
+  /** Human-readable label for this source. */
+  readonly label: string;
+  /** Discover available sessions from this source tool. */
+  listSessions(): Promise<SourceSessionSummary[]>;
+  /** Parse a specific session into a handoff context. */
+  parseSession(sessionId: string): Promise<HandoffContext>;
+}

--- a/apps/kimi-code/src/cli/import/sources/types.ts
+++ b/apps/kimi-code/src/cli/import/sources/types.ts
@@ -94,6 +94,12 @@ export interface SourceSessionSummary {
   tokenCount?: number;
 }
 
+/** Options for {@link SourceParser.parseSession}. */
+export interface ParseOptions {
+  /** Maximum number of recent conversation turns to include (default: 30). */
+  maxTurns?: number;
+}
+
 /** Interface that each source-tool parser must implement. */
 export interface SourceParser {
   /** Unique identifier for this source (e.g. 'claude-code'). */
@@ -102,6 +108,10 @@ export interface SourceParser {
   readonly label: string;
   /** Discover available sessions from this source tool. */
   listSessions(): Promise<SourceSessionSummary[]>;
-  /** Parse a specific session into a handoff context. */
-  parseSession(sessionId: string): Promise<HandoffContext>;
+  /**
+   * Parse a specific session into a handoff context.
+   * @param sessionId — The source tool's session identifier.
+   * @param options — Optional parsing options (e.g. max turns).
+   */
+  parseSession(sessionId: string, options?: ParseOptions): Promise<HandoffContext>;
 }

--- a/apps/kimi-code/src/cli/sub/import.ts
+++ b/apps/kimi-code/src/cli/sub/import.ts
@@ -1,0 +1,381 @@
+/**
+ * `kimi import` sub-command.
+ *
+ * Imports session context from external AI coding tools (Claude Code, etc.)
+ * into a new Kimi Code session. The imported context is injected via the
+ * existing `session.importContext()` RPC, persisted, and resumable with
+ * `kimi -r <session-id>`.
+ *
+ * Usage:
+ *   kimi import --from claude-code                    # interactive picker → new session
+ *   kimi import --from claude-code --session <id>     # specific CC session
+ *   kimi import --file handoff.md                     # from a handoff file
+ *   kimi import --from claude-code --print            # print handoff to stdout only
+ *   kimi import --from claude-code --prompt "..."     # import + send follow-up prompt
+ */
+
+import { createInterface } from 'node:readline/promises';
+import { resolve } from 'node:path';
+import { readFile } from 'node:fs/promises';
+
+import {
+  setTelemetryContext,
+  shutdownTelemetry,
+  track,
+  withTelemetryContext,
+} from '@moonshot-ai/kimi-telemetry';
+import {
+  createKimiHarness,
+  resolveKimiHome,
+  type KimiHarness,
+  type SessionSummary,
+  type ShellEnvironment,
+  type TelemetryClient,
+} from '@moonshot-ai/kimi-code-sdk';
+import type { Command } from 'commander';
+
+import { CLI_SHUTDOWN_TIMEOUT_MS, CLI_UI_MODE } from '#/constant/app';
+import { createCliTelemetryBootstrap, initializeCliTelemetry } from '#/cli/telemetry';
+import { detectInstallSource } from '#/cli/update/source';
+import { createKimiCodeHostIdentity } from '#/cli/version';
+import { detectShellEnvironment } from '#/utils/process/shell-env';
+
+import { claudeCodeParser } from '../import/sources/claude-code';
+import type { SourceParser, SourceSessionSummary } from '../import/sources/types';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+interface WritableLike {
+  write(chunk: string): boolean;
+}
+
+interface ImportDeps {
+  readonly listSessions: (workDir: string) => Promise<readonly SessionSummary[]>;
+  readonly getSourceParsers: () => SourceParser[];
+  readonly getInstallSource: () => Promise<string>;
+  readonly getShellEnv: () => ShellEnvironment;
+  readonly version: string;
+  readonly cwd: () => string;
+  readonly stdout: WritableLike;
+  readonly stderr: WritableLike;
+  readonly exit: (code: number) => never;
+  readonly harnessFactory: () => KimiHarness;
+}
+
+interface ImportOptions {
+  from?: string;
+  session?: string;
+  file?: string;
+  print: boolean;
+  prompt?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Command handler
+// ---------------------------------------------------------------------------
+
+async function handleImport(deps: ImportDeps, opts: ImportOptions): Promise<void> {
+  const parsers = deps.getSourceParsers();
+
+  // --file mode: read a handoff file directly
+  if (opts.file !== undefined) {
+    await handleFileImport(deps, opts.file, opts);
+    return;
+  }
+
+  // --from mode: use a source parser
+  if (opts.from !== undefined) {
+    const parser = parsers.find((p) => p.sourceId === opts.from);
+    if (parser === undefined) {
+      const available = parsers.map((p) => p.sourceId).join(', ');
+      deps.stderr.write(
+        `Unknown source: ${opts.from}. Available sources: ${available || '(none)'}\n`,
+      );
+      deps.exit(1);
+    }
+    await handleSourceImport(deps, parser, opts);
+    return;
+  }
+
+  // No mode specified — show available sources
+  deps.stderr.write('Usage: kimi import --from <source> [--session <id>]\n');
+  deps.stderr.write('       kimi import --file <handoff.md>\n\n');
+  deps.stderr.write('Available sources:\n');
+  for (const parser of parsers) {
+    deps.stderr.write(`  ${parser.sourceId}  — ${parser.label}\n`);
+  }
+  if (parsers.length === 0) {
+    deps.stderr.write('  (no source parsers available)\n');
+  }
+  deps.exit(1);
+}
+
+async function handleFileImport(
+  deps: ImportDeps,
+  filePath: string,
+  opts: ImportOptions,
+): Promise<void> {
+  const resolved = resolve(deps.cwd(), filePath);
+  let content: string;
+  try {
+    content = await readFile(resolved, 'utf-8');
+  } catch (error) {
+    deps.stderr.write(`Failed to read file: ${errorMessage(error)}\n`);
+    deps.exit(1);
+  }
+
+  if (content.trim().length === 0) {
+    deps.stderr.write('Handoff file is empty.\n');
+    deps.exit(1);
+  }
+
+  if (opts.print) {
+    deps.stdout.write(content);
+    return;
+  }
+
+  await importIntoSession(deps, content, 'handoff-file', opts);
+}
+
+async function handleSourceImport(
+  deps: ImportDeps,
+  parser: SourceParser,
+  opts: ImportOptions,
+): Promise<void> {
+  let sessionId = opts.session;
+
+  if (sessionId === undefined) {
+    const sessions = await parser.listSessions();
+    if (sessions.length === 0) {
+      deps.stderr.write(`No ${parser.label} sessions found.\n`);
+      deps.exit(1);
+    }
+
+    sessionId = await pickSession(deps, sessions);
+    if (sessionId === undefined) {
+      deps.stdout.write('Import cancelled.\n');
+      return;
+    }
+  }
+
+  let ctx;
+  try {
+    ctx = await parser.parseSession(sessionId);
+  } catch (error) {
+    deps.stderr.write(`Failed to parse session: ${errorMessage(error)}\n`);
+    deps.exit(1);
+  }
+
+  const markdown = ctx.markdown;
+
+  if (opts.print) {
+    deps.stdout.write(markdown);
+    return;
+  }
+
+  await importIntoSession(deps, markdown, parser.sourceId, opts);
+}
+
+async function importIntoSession(
+  deps: ImportDeps,
+  content: string,
+  source: string,
+  opts: ImportOptions,
+): Promise<void> {
+  const harness = deps.harnessFactory();
+
+  try {
+    await harness.ensureConfigFile();
+    const config = await harness.getConfig();
+
+    const telemetryBootstrap = createCliTelemetryBootstrap();
+    initializeCliTelemetry({
+      harness,
+      bootstrap: telemetryBootstrap,
+      config,
+      version: deps.version,
+      uiMode: CLI_UI_MODE,
+    });
+
+    const workDir = deps.cwd();
+    deps.stderr.write(`Creating session (workdir: ${workDir})...\n`);
+    const session = await harness.createSession({
+      workDir,
+      model: config.defaultModel,
+      permission: 'manual',
+      drainAgentTasksOnStop: true,
+    });
+
+    deps.stderr.write(`Importing context from ${source}...\n`);
+    await session.importContext(content, source);
+
+    if (opts.prompt !== undefined) {
+      deps.stderr.write('Sending follow-up prompt...\n');
+
+      await new Promise<void>((resolve, reject) => {
+        let settled = false;
+        const unsubscribe = session.onEvent((event) => {
+          if (settled) return;
+          if (event.type === 'error') {
+            settled = true;
+            unsubscribe();
+            reject(new Error(`${event.code}: ${event.message}`));
+            return;
+          }
+          if (event.type === 'turn.ended') {
+            settled = true;
+            unsubscribe();
+            resolve();
+            return;
+          }
+        });
+
+        session.setApprovalHandler(() => ({ decision: 'approved' }));
+        session.setQuestionHandler(() => null);
+
+        session.prompt(opts.prompt!).catch((error: unknown) => {
+          if (!settled) {
+            settled = true;
+            unsubscribe();
+            reject(error instanceof Error ? error : new Error(String(error)));
+          }
+        });
+      });
+    }
+
+    await session.close();
+
+    deps.stdout.write(`\n✓ Session imported successfully.\n`);
+    deps.stdout.write(`Session ID: ${session.id}\n`);
+    deps.stdout.write(`Resume with: kimi -r ${session.id}\n`);
+    if (opts.prompt === undefined) {
+      deps.stdout.write(`Tip: Use --prompt "Continue the work" to let the model process the imported context.\n`);
+    }
+  } finally {
+    try {
+      await shutdownTelemetry({ timeoutMs: CLI_SHUTDOWN_TIMEOUT_MS });
+    } catch {
+      // Best-effort
+    }
+    await harness.close().catch(() => {});
+  }
+}
+
+async function pickSession(
+  deps: ImportDeps,
+  sessions: readonly SourceSessionSummary[],
+): Promise<string | undefined> {
+  deps.stderr.write('\nAvailable sessions:\n\n');
+  for (let i = 0; i < Math.min(sessions.length, 20); i++) {
+    const s = sessions[i]!;
+    const idx = String(i + 1).padStart(2, ' ');
+    const title = s.title ?? '(untitled)';
+    const date = s.updatedAt?.slice(0, 10) ?? s.createdAt?.slice(0, 10) ?? '';
+    deps.stderr.write(`  ${idx}. [${date}] ${truncate(title, 60)}\n`);
+    if (s.workingDirectory !== undefined) {
+      deps.stderr.write(`      ${s.workingDirectory}\n`);
+    }
+  }
+  deps.stderr.write('\n');
+
+  const rl = createInterface({ input: process.stdin, output: process.stderr });
+  try {
+    const answer = await rl.question('Select a session (number, or Enter to cancel): ');
+    const trimmed = answer.trim();
+    if (trimmed === '') return undefined;
+    const index = Number.parseInt(trimmed, 10);
+    if (Number.isNaN(index) || index < 1 || index > sessions.length) {
+      deps.stderr.write('Invalid selection.\n');
+      return undefined;
+    }
+    return sessions[index - 1]?.sessionId;
+  } finally {
+    rl.close();
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Command registration
+// ---------------------------------------------------------------------------
+
+export interface ImportSubdeps {
+  readonly getSourceParsers?: () => SourceParser[];
+  readonly listSessions?: (workDir: string) => Promise<readonly SessionSummary[]>;
+  readonly getInstallSource?: () => Promise<string>;
+  readonly getShellEnv?: () => ShellEnvironment;
+  readonly version?: string;
+  readonly cwd?: () => string;
+  readonly stdout?: WritableLike;
+  readonly stderr?: WritableLike;
+  readonly exit?: (code: number) => never;
+}
+
+export function registerImportCommand(parent: Command, deps: ImportSubdeps = {}): void {
+  parent
+    .command('import')
+    .description('Import session context from another AI coding tool.')
+    .option('--from <source>', 'Source tool (e.g. claude-code).')
+    .option('--session <id>', 'Session ID from the source tool to import.')
+    .option('--file <path>', 'Import from a handoff Markdown file instead of a source tool.')
+    .option('--prompt <text>', 'Follow-up prompt to send after importing context.')
+    .option(
+      '--print',
+      'Print the handoff context to stdout instead of importing into a session.',
+      false,
+    )
+    .action(async (options: ImportOptions) => {
+      await handleImport(createDefaultDeps(deps), options);
+    });
+}
+
+// ---------------------------------------------------------------------------
+// Default dependencies
+// ---------------------------------------------------------------------------
+
+function createDefaultDeps(overrides: ImportSubdeps): ImportDeps {
+  const identity = createKimiCodeHostIdentity();
+  const telemetryClient: TelemetryClient = {
+    track,
+    withContext: withTelemetryContext,
+    setContext: setTelemetryContext,
+  };
+
+  const harnessFactory = (): KimiHarness => {
+    return createKimiHarness({
+      homeDir: resolveKimiHome(),
+      identity,
+      telemetry: telemetryClient,
+    });
+  };
+
+  return {
+    listSessions:
+      overrides.listSessions ??
+      ((workDir: string) =>
+        harnessFactory().listSessions({ workDir })),
+    getSourceParsers: overrides.getSourceParsers ?? (() => [claudeCodeParser]),
+    version: overrides.version ?? identity.version,
+    getInstallSource: overrides.getInstallSource ?? (() => detectInstallSource()),
+    getShellEnv: overrides.getShellEnv ?? detectShellEnvironment,
+    cwd: overrides.cwd ?? (() => process.cwd()),
+    stdout: overrides.stdout ?? process.stdout,
+    stderr: overrides.stderr ?? process.stderr,
+    exit: overrides.exit ?? ((code: number) => process.exit(code)),
+    harnessFactory,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Utilities
+// ---------------------------------------------------------------------------
+
+function truncate(text: string, maxLen: number): string {
+  if (text.length <= maxLen) return text;
+  return text.slice(0, maxLen - 3) + '...';
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/apps/kimi-code/src/cli/sub/import.ts
+++ b/apps/kimi-code/src/cli/sub/import.ts
@@ -216,18 +216,46 @@ async function importIntoSession(
 
       await new Promise<void>((resolve, reject) => {
         let settled = false;
+        let mainTurnActive = false;
+        const PROMPT_MAIN_AGENT_ID = 'main';
         const unsubscribe = session.onEvent((event) => {
           if (settled) return;
+
           if (event.type === 'error') {
+            // Only fail on main-agent errors; subagent errors are recoverable
+            if ('agentId' in event && event.agentId !== PROMPT_MAIN_AGENT_ID) return;
             settled = true;
             unsubscribe();
             reject(new Error(`${event.code}: ${event.message}`));
             return;
           }
+
+          if (event.type === 'turn.started') {
+            if ('agentId' in event && event.agentId === PROMPT_MAIN_AGENT_ID) {
+              mainTurnActive = true;
+            }
+            return;
+          }
+
           if (event.type === 'turn.ended') {
+            // Ignore subagent and non-main turns
+            if (!mainTurnActive) return;
+            if ('agentId' in event && event.agentId !== PROMPT_MAIN_AGENT_ID) return;
+
+            if (event.reason === 'completed') {
+              settled = true;
+              unsubscribe();
+              resolve();
+              return;
+            }
+            // Non-completed: error, blocked, or cancelled
             settled = true;
             unsubscribe();
-            resolve();
+            const msg =
+              event.error !== undefined
+                ? `${event.error.code}: ${event.error.message}`
+                : `Turn ended with reason: ${event.reason}`;
+            reject(new Error(msg));
             return;
           }
         });

--- a/apps/kimi-code/src/cli/sub/import.ts
+++ b/apps/kimi-code/src/cli/sub/import.ts
@@ -9,6 +9,7 @@
  * Usage:
  *   kimi import --from claude-code                    # interactive picker → new session
  *   kimi import --from claude-code --session <id>     # specific CC session
+ *   kimi import --from claude-code --turns 50         # include up to 50 conversation turns
  *   kimi import --file handoff.md                     # from a handoff file
  *   kimi import --from claude-code --print            # print handoff to stdout only
  *   kimi import --from claude-code --prompt "..."     # import + send follow-up prompt
@@ -70,6 +71,7 @@ interface ImportOptions {
   file?: string;
   print: boolean;
   prompt?: string;
+  turns?: string;
 }
 
 // ---------------------------------------------------------------------------
@@ -162,7 +164,16 @@ async function handleSourceImport(
 
   let ctx;
   try {
-    ctx = await parser.parseSession(sessionId);
+    let parseOpts: { maxTurns?: number } | undefined;
+    if (opts.turns !== undefined) {
+      const maxTurns = Number.parseInt(opts.turns, 10);
+      if (Number.isNaN(maxTurns) || maxTurns < 1) {
+        deps.stderr.write(`Invalid --turns value: ${opts.turns}. Must be a positive integer.\n`);
+        deps.exit(1);
+      }
+      parseOpts = { maxTurns };
+    }
+    ctx = await parser.parseSession(sessionId, parseOpts);
   } catch (error) {
     deps.stderr.write(`Failed to parse session: ${errorMessage(error)}\n`);
     deps.exit(1);
@@ -346,6 +357,7 @@ export function registerImportCommand(parent: Command, deps: ImportSubdeps = {})
     .description('Import session context from another AI coding tool.')
     .option('--from <source>', 'Source tool (e.g. claude-code).')
     .option('--session <id>', 'Session ID from the source tool to import.')
+    .option('--turns <number>', 'Maximum recent conversation turns to include (default: 30).')
     .option('--file <path>', 'Import from a handoff Markdown file instead of a source tool.')
     .option('--prompt <text>', 'Follow-up prompt to send after importing context.')
     .option(

--- a/apps/kimi-code/test/cli/import.test.ts
+++ b/apps/kimi-code/test/cli/import.test.ts
@@ -1,0 +1,313 @@
+/**
+ * `kimi import` — tests for Claude Code session parser.
+ *
+ * Verifies: session file parsing, JSONL extraction, handoff context generation.
+ */
+
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+import { mkdtempSync, writeFileSync, rmSync, mkdirSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+
+import { describe, expect, it } from 'vitest';
+
+import type {
+  HandoffContext,
+  SourceSessionSummary,
+} from '#/cli/import/sources/types';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function createTestCCSession(): { dir: string; sessionPath: string; sessionId: string } {
+  const dir = mkdtempSync(join(tmpdir(), 'kimi-import-test-'));
+  const sessionId = 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee';
+  // CLAUDE_CONFIG_DIR → projects/ subdirectory, matching real CC layout
+  const projectsDir = join(dir, 'projects', '-Users-testuser-testproject');
+  mkdirSync(projectsDir, { recursive: true });
+  const sessionPath = join(projectsDir, `${sessionId}.jsonl`);
+
+  const lines = [
+    JSON.stringify({
+      type: 'queue-operation',
+      operation: 'enqueue',
+      timestamp: '2026-07-24T10:00:00.000Z',
+      sessionId,
+    }),
+    JSON.stringify({
+      type: 'user',
+      parentUuid: null,
+      uuid: 'msg-1',
+      timestamp: '2026-07-24T10:00:01.000Z',
+      sessionId,
+      cwd: '/Users/testuser/testproject',
+      gitBranch: 'main',
+      version: '2.1.0',
+      message: {
+        role: 'user',
+        content: [{ type: 'text', text: 'Help me fix a pagination bug' }],
+      },
+    }),
+    JSON.stringify({
+      type: 'assistant',
+      parentUuid: 'msg-1',
+      uuid: 'msg-2',
+      timestamp: '2026-07-24T10:00:05.000Z',
+      sessionId,
+      cwd: '/Users/testuser/testproject',
+      message: {
+        role: 'assistant',
+        model: 'deepseek-v4-pro',
+        content: [
+          { type: 'thinking', thinking: 'I need to read the file first.' },
+          { type: 'text', text: 'Let me check the UserTable component.' },
+          {
+            type: 'tool_use',
+            id: 'call_01',
+            name: 'Read',
+            input: { file_path: 'src/components/UserTable.tsx' },
+          },
+        ],
+        usage: { input_tokens: 1000, output_tokens: 200 },
+      },
+    }),
+    JSON.stringify({
+      type: 'user',
+      parentUuid: 'msg-2',
+      uuid: 'msg-3',
+      timestamp: '2026-07-24T10:00:10.000Z',
+      sessionId,
+      message: {
+        role: 'user',
+        content: [
+          {
+            type: 'tool_result',
+            tool_use_id: 'call_01',
+            content: 'export function UserTable() { ... }',
+          },
+        ],
+      },
+    }),
+    JSON.stringify({
+      type: 'assistant',
+      parentUuid: 'msg-3',
+      uuid: 'msg-4',
+      timestamp: '2026-07-24T10:00:15.000Z',
+      sessionId,
+      message: {
+        role: 'assistant',
+        model: 'deepseek-v4-pro',
+        content: [
+          {
+            type: 'thinking',
+            thinking: 'I can see the issue. The pageSize is hardcoded. We need to use the prop instead.',
+          },
+          { type: 'text', text: 'Found the bug. The pagination is using a hardcoded pageSize of 10 instead of the prop.' },
+        ],
+        usage: { input_tokens: 500, output_tokens: 150 },
+      },
+    }),
+    JSON.stringify({
+      type: 'ai-title',
+      title: 'Fix pagination bug in UserTable',
+      sessionId,
+    }),
+  ];
+
+  writeFileSync(sessionPath, lines.join('\n') + '\n', 'utf-8');
+  return { dir, sessionPath, sessionId };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('Claude Code session parser', () => {
+  it('should parse a valid CC session JSONL file', async () => {
+    const test = createTestCCSession();
+    try {
+      // Import dynamically to avoid module caching issues
+      const { claudeCodeParser } = await import('#/cli/import/sources/claude-code');
+
+      // Override the projects directory for testing
+      const origEnv = process.env['CLAUDE_CONFIG_DIR'];
+      process.env['CLAUDE_CONFIG_DIR'] = test.dir;
+      try {
+        const sessions = await claudeCodeParser.listSessions();
+        expect(sessions.length).toBe(1);
+        expect(sessions[0]!.sessionId).toBe(test.sessionId);
+        expect(sessions[0]!.title).toBe('Help me fix a pagination bug');
+
+        const ctx = await claudeCodeParser.parseSession(test.sessionId);
+        expect(ctx.source).toBe('claude-code');
+        expect(ctx.sourceSessionId).toBe(test.sessionId);
+        expect(ctx.model).toBe('deepseek-v4-pro');
+        expect(ctx.summary).toBe('Help me fix a pagination bug');
+
+        // Token usage
+        expect(ctx.tokenUsage).toBeDefined();
+        expect(ctx.tokenUsage!.input).toBe(1500);
+        expect(ctx.tokenUsage!.output).toBe(350);
+
+        // Conversation turns
+        expect(ctx.recentConversation.length).toBeGreaterThan(0);
+
+        // File changes — we read src/components/UserTable.tsx
+        expect(ctx.filesModified.length).toBeGreaterThan(0);
+        expect(ctx.filesModified.some((f) => f.path.includes('UserTable'))).toBe(true);
+
+        // Markdown
+        expect(ctx.markdown).toContain('claude-code');
+        expect(ctx.markdown).toContain('pagination bug');
+        expect(ctx.markdown).toContain('UserTable');
+
+        // Key decisions (from thinking blocks)
+        // Should detect "need to" patterns in thinking
+        expect(ctx.filesModified.length).toBeGreaterThan(0);
+      } finally {
+        if (origEnv !== undefined) {
+          process.env['CLAUDE_CONFIG_DIR'] = origEnv;
+        } else {
+          delete process.env['CLAUDE_CONFIG_DIR'];
+        }
+      }
+    } finally {
+      rmSync(test.dir, { recursive: true, force: true });
+    }
+  });
+
+  it('should return empty list when no sessions exist', async () => {
+    const emptyDir = mkdtempSync(join(tmpdir(), 'kimi-import-empty-'));
+    try {
+      const { claudeCodeParser } = await import('#/cli/import/sources/claude-code');
+
+      const origEnv = process.env['CLAUDE_CONFIG_DIR'];
+      process.env['CLAUDE_CONFIG_DIR'] = emptyDir;
+      try {
+        const sessions = await claudeCodeParser.listSessions();
+        expect(sessions).toEqual([]);
+      } finally {
+        if (origEnv !== undefined) {
+          process.env['CLAUDE_CONFIG_DIR'] = origEnv;
+        } else {
+          delete process.env['CLAUDE_CONFIG_DIR'];
+        }
+      }
+    } finally {
+      rmSync(emptyDir, { recursive: true, force: true });
+    }
+  });
+
+  it('should extract pending work from thinking blocks', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'kimi-import-pending-'));
+    const sessionId = 'pending-session-1111-2222-3333-444444444444';
+    const projectsDir = join(dir, 'projects', '-Users-testuser-testproject');
+    mkdirSync(projectsDir, { recursive: true });
+    const sessionPath = join(projectsDir, `${sessionId}.jsonl`);
+
+    const lines = [
+      JSON.stringify({
+        type: 'user',
+        parentUuid: null,
+        uuid: 'm1',
+        timestamp: '2026-07-24T10:00:00.000Z',
+        sessionId,
+        cwd: '/Users/testuser/testproject',
+        message: {
+          role: 'user',
+          content: [{ type: 'text', text: 'Build a todo app' }],
+        },
+      }),
+      JSON.stringify({
+        type: 'assistant',
+        parentUuid: 'm1',
+        uuid: 'm2',
+        timestamp: '2026-07-24T10:00:05.000Z',
+        sessionId,
+        message: {
+          role: 'assistant',
+          model: 'test-model',
+          content: [
+            {
+              type: 'thinking',
+              thinking:
+                'Done with the basic CRUD. Next step: add authentication. ' +
+                'I also need to implement error handling and proper loading states. ' +
+                'TODO: write unit tests for all components.',
+            },
+            { type: 'text', text: 'Basic CRUD is working.' },
+          ],
+          usage: { input_tokens: 100, output_tokens: 50 },
+        },
+      }),
+    ];
+
+    writeFileSync(sessionPath, lines.join('\n') + '\n', 'utf-8');
+
+    try {
+      const { claudeCodeParser } = await import('#/cli/import/sources/claude-code');
+
+      const origEnv = process.env['CLAUDE_CONFIG_DIR'];
+      process.env['CLAUDE_CONFIG_DIR'] = dir;
+      try {
+        const ctx = await claudeCodeParser.parseSession(sessionId);
+        // Should catch "next step", "need to", "TODO"
+        expect(ctx.pendingWork.length).toBeGreaterThan(0);
+      } finally {
+        if (origEnv !== undefined) {
+          process.env['CLAUDE_CONFIG_DIR'] = origEnv;
+        } else {
+          delete process.env['CLAUDE_CONFIG_DIR'];
+        }
+      }
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('should throw for non-existent session', async () => {
+    const { claudeCodeParser } = await import('#/cli/import/sources/claude-code');
+    await expect(
+      claudeCodeParser.parseSession('nonexistent-session-id'),
+    ).rejects.toThrow('not found');
+  });
+});
+
+describe('Handoff Markdown format', () => {
+  it('should produce valid Markdown with YAML frontmatter', async () => {
+    const test = createTestCCSession();
+    try {
+      const { claudeCodeParser } = await import('#/cli/import/sources/claude-code');
+
+      const origEnv = process.env['CLAUDE_CONFIG_DIR'];
+      process.env['CLAUDE_CONFIG_DIR'] = test.dir;
+      try {
+        const ctx = await claudeCodeParser.parseSession(test.sessionId);
+
+        // YAML frontmatter
+        expect(ctx.markdown.startsWith('---')).toBe(true);
+        const secondDelim = ctx.markdown.indexOf('---', 4);
+        expect(secondDelim).toBeGreaterThan(0);
+
+        const yamlPart = ctx.markdown.slice(3, secondDelim).trim();
+        expect(yamlPart).toContain('source: claude-code');
+        expect(yamlPart).toContain(`sourceSessionId: "${test.sessionId}"`);
+        expect(yamlPart).toContain('model: "deepseek-v4-pro"');
+
+        // Content sections
+        expect(ctx.markdown).toContain('## Summary');
+        expect(ctx.markdown).toContain('## Recent Conversation');
+        expect(ctx.markdown).toContain('## Files Modified');
+      } finally {
+        if (origEnv !== undefined) {
+          process.env['CLAUDE_CONFIG_DIR'] = origEnv;
+        } else {
+          delete process.env['CLAUDE_CONFIG_DIR'];
+        }
+      }
+    } finally {
+      rmSync(test.dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/apps/kimi-code/test/cli/import.test.ts
+++ b/apps/kimi-code/test/cli/import.test.ts
@@ -272,6 +272,34 @@ describe('Claude Code session parser', () => {
       claudeCodeParser.parseSession('nonexistent-session-id'),
     ).rejects.toThrow('not found');
   });
+
+  it('should respect the maxTurns parse option', async () => {
+    const test = createTestCCSession();
+    try {
+      const { claudeCodeParser } = await import('#/cli/import/sources/claude-code');
+
+      const origEnv = process.env['CLAUDE_CONFIG_DIR'];
+      process.env['CLAUDE_CONFIG_DIR'] = test.dir;
+      try {
+        // With maxTurns=1 we should get very few conversation turns
+        const ctxShort = await claudeCodeParser.parseSession(test.sessionId, { maxTurns: 1 });
+        const ctxDefault = await claudeCodeParser.parseSession(test.sessionId);
+
+        // The short version should have fewer turns than the default
+        expect(ctxShort.recentConversation.length).toBeLessThan(
+          ctxDefault.recentConversation.length,
+        );
+      } finally {
+        if (origEnv !== undefined) {
+          process.env['CLAUDE_CONFIG_DIR'] = origEnv;
+        } else {
+          delete process.env['CLAUDE_CONFIG_DIR'];
+        }
+      }
+    } finally {
+      rmSync(test.dir, { recursive: true, force: true });
+    }
+  });
 });
 
 describe('Handoff Markdown format', () => {

--- a/docs/en/reference/kimi-command.md
+++ b/docs/en/reference/kimi-command.md
@@ -132,7 +132,7 @@ In `stream-json` mode, regular replies produce an Assistant message; when the mo
 
 ## Subcommands
 
-`kimi` provides the following subcommands: `login` (non-interactive login), `acp` (ACP IDE mode), `web` (run the local REST/WebSocket/web service in the foreground and open the web UI), `doctor` (validate configuration files), `export` (export a session), `migrate` (migrate legacy data), `upgrade` (check for updates), and `provider` (manage providers).
+`kimi` provides the following subcommands: `login` (non-interactive login), `acp` (ACP IDE mode), `web` (run the local REST/WebSocket/web service in the foreground and open the web UI), `doctor` (validate configuration files), `export` (export a session), `import` (import session context from external AI coding tools), `migrate` (migrate legacy data), `upgrade` (check for updates), and `provider` (manage providers).
 
 ### `kimi login`
 
@@ -248,6 +248,63 @@ kimi export 01HZ...XYZ -o ./bug-report.zip
 # Exclude the global diagnostic log
 kimi export 01HZ...XYZ -o ./bug-report.zip --no-include-global-log
 ```
+
+### `kimi import`
+
+Import a session from an external AI coding tool (e.g. Claude Code) into Kimi Code, preserving conversation history, tool activity, and project context. The imported session becomes a resumable kimi session that you can continue with `kimi -r`.
+
+```sh
+kimi import --from <source> [options]
+kimi import --file <handoff.md>
+```
+
+| Option | Short | Description |
+| --- | --- | --- |
+| `--from <source>` | | Source tool to import from. Currently supported: `claude-code` |
+| `--session <id>` | | Session ID from the source tool. When omitted, an interactive picker lists available sessions |
+| `--turns <number>` | | Maximum number of recent conversation turns to include. Default: `30` |
+| `--file <path>` | | Import from a handoff Markdown file instead of querying a source tool directly |
+| `--prompt <text>` | | Follow-up prompt to send after importing, so the model can process the context immediately |
+| `--print` | | Print the handoff Markdown to stdout without creating a kimi session (useful for preview or piping) |
+
+#### Import from Claude Code
+
+```sh
+# Interactive picker — browse your Claude Code sessions and select one
+kimi import --from claude-code
+
+# Import a specific session by ID
+kimi import --from claude-code --session <uuid>
+
+# Include more conversation history (default: 30 turns)
+kimi import --from claude-code --session <uuid> --turns 50
+
+# Preview what would be imported before committing
+kimi import --from claude-code --session <uuid> --print
+
+# Import and continue working in a single step
+kimi import --from claude-code --session <uuid> --prompt "Continue the implementation"
+```
+
+The parser scans `~/.claude/projects/` for session files (respecting the `CLAUDE_CONFIG_DIR` environment variable) and converts them into a structured handoff document. The generated document includes:
+
+- A YAML frontmatter block with source metadata (tool, session ID, model, token usage)
+- A summary extracted from the first user message
+- Key decisions and architectural choices detected during the session
+- Files that were modified or read
+- Recent conversation turns (user, assistant, tool calls, and tool results)
+- Pending work items that were not completed
+
+#### Import from a Handoff File
+
+You can also import from a handoff Markdown file (e.g. one generated with `--print` and edited by hand, or one produced by an external tool):
+
+```sh
+kimi import --file ./handoff.md
+kimi import --file ./handoff.md --prompt "Pick up where this session left off"
+```
+
+The handoff file should follow the same Markdown format produced by the source parsers (YAML frontmatter with `source`, `sourceSessionId`, etc.).
 
 ### `kimi migrate`
 

--- a/docs/zh/reference/kimi-command.md
+++ b/docs/zh/reference/kimi-command.md
@@ -132,7 +132,7 @@ kimi -p "List changed files" --output-format stream-json
 
 ## 子命令
 
-`kimi` 提供以下子命令：`login`（非交互式登录）、`acp`（ACP IDE 模式）、`web`（前台运行本地 REST/WebSocket/web 服务并打开 web UI）、`doctor`（校验配置文件）、`export`（导出会话）、`migrate`（迁移旧版数据）、`upgrade`（检查更新）、`provider`（管理供应商）。
+`kimi` 提供以下子命令：`login`（非交互式登录）、`acp`（ACP IDE 模式）、`web`（前台运行本地 REST/WebSocket/web 服务并打开 web UI）、`doctor`（校验配置文件）、`export`（导出会话）、`import`（从外部 AI 编码工具导入会话上下文）、`migrate`（迁移旧版数据）、`upgrade`（检查更新）、`provider`（管理供应商）。
 
 ### `kimi login`
 
@@ -248,6 +248,63 @@ kimi export 01HZ...XYZ -o ./bug-report.zip
 # 排除全局诊断日志
 kimi export 01HZ...XYZ -o ./bug-report.zip --no-include-global-log
 ```
+
+### `kimi import`
+
+从外部 AI 编码工具（如 Claude Code）导入会话到 Kimi Code，保留对话历史、工具活动和项目上下文。导入后的会话可通过 `kimi -r` 恢复并继续工作。
+
+```sh
+kimi import --from <source> [options]
+kimi import --file <handoff.md>
+```
+
+| 选项 | 简写 | 说明 |
+| --- | --- | --- |
+| `--from <source>` | | 要导入的源工具。当前支持：`claude-code` |
+| `--session <id>` | | 源工具中的会话 ID。省略时进入交互式选择器浏览可用会话 |
+| `--turns <number>` | | 最多包含的最近对话轮数。默认：`30` |
+| `--file <path>` | | 从 handoff Markdown 文件导入，而不是直接查询源工具 |
+| `--prompt <text>` | | 导入后发送后续 prompt，让模型立即处理上下文 |
+| `--print` | | 将 handoff Markdown 打印到 stdout，不创建 kimi 会话（便于预览或管道处理） |
+
+#### 从 Claude Code 导入
+
+```sh
+# 交互式选择器——浏览你的 Claude Code 会话并选择一个
+kimi import --from claude-code
+
+# 按 ID 导入指定会话
+kimi import --from claude-code --session <uuid>
+
+# 包含更多对话历史（默认 30 轮）
+kimi import --from claude-code --session <uuid> --turns 50
+
+# 先预览将要导入的内容
+kimi import --from claude-code --session <uuid> --print
+
+# 导入并一步继续工作
+kimi import --from claude-code --session <uuid> --prompt "继续实现"
+```
+
+解析器会扫描 `~/.claude/projects/` 目录下的会话文件（支持 `CLAUDE_CONFIG_DIR` 环境变量），并将其转换为结构化的 handoff 文档。生成的内容包括：
+
+- YAML 前置元数据块（源工具、会话 ID、模型、token 用量等）
+- 从首条用户消息提取的摘要
+- 会话期间检测到的关键决策和架构选择
+- 修改或读取过的文件列表
+- 最近对话轮次（用户、助手、工具调用和工具结果）
+- 未完成的待办工作项
+
+#### 从 Handoff 文件导入
+
+你也可以从 handoff Markdown 文件导入（例如先用 `--print` 生成再手动编辑，或由外部工具生成）：
+
+```sh
+kimi import --file ./handoff.md
+kimi import --file ./handoff.md --prompt "继续这个会话的工作"
+```
+
+handoff 文件应遵循源解析器生成的 Markdown 格式（包含 `source`、`sourceSessionId` 等 YAML 前置元数据）。
 
 ### `kimi migrate`
 


### PR DESCRIPTION
## Summary
Add `kimi import` CLI command for importing session context from external AI coding tools into Kimi Code. Enables migrating conversation history, tool activity, and project context. Starting with Claude Code support. Closes #2102.

## Changes
- New: `apps/kimi-code/src/cli/import/sources/types.ts` — SourceParser interface + HandoffContext types
- New: `apps/kimi-code/src/cli/import/sources/claude-code.ts` — Claude Code session JSONL parser
- New: `apps/kimi-code/src/cli/sub/import.ts` — kimi import CLI command
- New: `apps/kimi-code/test/cli/import.test.ts` — 5 tests
- Modified: `apps/kimi-code/src/cli/commands.ts` — register import command

## Usage
`kimi import --from claude-code` (interactive), `--session`, `--prompt`, `--file`, `--print`

## How it works
Scans CC sessions → parses JSONL → generates handoff Markdown → `harness.createSession()` + `session.importContext()` → persisted, resumable via `kimi -r`

## Verification
pnpm typecheck: clean | oxlint: 0/0 | vitest: 5/5 new, 18/18 total | tested with real CC sessions
