### PR TITLE
refactor(agent-core-v2): drop definition-level capability resolution

### DIFF
--- a/packages/agent-core-v2/src/kosong/protocol/protocolBase.ts
+++ b/packages/agent-core-v2/src/kosong/protocol/protocolBase.ts
@@ -42,8 +42,8 @@ export interface ProtocolBaseDefinition {
   readonly id: ProtocolBaseId;
   /**
    * The base's own capability catalog — the final fallback of capability
-   * resolution (definition → traits → base). Absent or `undefined` means the
-   * base knows nothing about the model.
+   * resolution (traits → base). Absent or `undefined` means the base knows
+   * nothing about the model.
    */
   capability?(modelName: string): ModelCapability | undefined;
   createChatProvider(context: ProtocolBaseContext): ChatProvider;

--- a/packages/agent-core-v2/src/kosong/protocol/protocolTrait.ts
+++ b/packages/agent-core-v2/src/kosong/protocol/protocolTrait.ts
@@ -193,9 +193,9 @@ export interface ProtocolTrait {
   reasoningKey?(ctx: TraitContext): string | undefined;
 
   /**
-   * Declared capability for one model. Resolution order is definition →
-   * traits → base: the registry asks traits in order (last declarer wins)
-   * and falls back to the base catalog when every hook returns `undefined`.
+   * Declared capability for one model. Resolution order is traits → base:
+   * the registry asks traits in order (last declarer wins) and falls back to
+   * the base catalog when every hook returns `undefined`.
    */
   capability?(modelName: string, ctx: TraitContext): ModelCapability | undefined;
 

--- a/packages/agent-core-v2/src/kosong/provider/protocolAdapterRegistry.ts
+++ b/packages/agent-core-v2/src/kosong/provider/protocolAdapterRegistry.ts
@@ -18,9 +18,8 @@
  *    full adapter config (identity resolution knows only
  *    `(protocol, providerType)`; composition needs the real config) and
  *    delegates to the registered base's contrib factory.
- *  - `resolveCapability` — the fixed fallback chain: pair definition → trait
- *    capability hooks (last declarer wins) → the base's own catalog →
- *    `UNKNOWN_CAPABILITY`.
+ *  - `resolveCapability` — the fixed fallback chain: trait capability hooks
+ *    (last declarer wins) → the base's own catalog → `UNKNOWN_CAPABILITY`.
  *
  * Bound at App scope, eager.
  */
@@ -106,18 +105,6 @@ export class ProtocolAdapterRegistry implements IProtocolAdapterRegistry {
     modelName: string,
     providerType?: string,
   ): ExplainedCapability {
-    const definition =
-      providerType === undefined ? undefined : getProviderDefinition(providerType, protocol);
-    if (definition?.capability !== undefined) {
-      return {
-        capability: definition.capability,
-        source: {
-          kind: 'builtin',
-          detail: `provider definition '${providerType}' (pair with protocol '${protocol}')`,
-        },
-      };
-    }
-
     const identity = this.resolveAdapterIdentity(protocol, providerType);
     let traitCapability: ModelCapability | undefined;
     for (const { trait, context } of identity.traits) {

--- a/packages/agent-core-v2/src/kosong/provider/providerDefinition.ts
+++ b/packages/agent-core-v2/src/kosong/provider/providerDefinition.ts
@@ -5,14 +5,13 @@
  * where do its key/url come from": the protocol base this registration
  * composes with, its deviation traits (applying to that protocol only), its
  * endpoint fallback chain, how much of the host's request headers it
- * receives, how its models are discovered, and its declared capability.
- * Registration happens once per vendor × protocol pair, in the vendor's
- * `*.contrib.ts` side-effect module: a vendor running over several
- * transports registers one definition per protocol (Kimi composes with
- * `openai` on its native transport and registers a second definition over
- * `anthropic`). Vendor-level facts (endpoint, host headers, model source,
- * capability) are declared identically on every registration of the same id
- * via shared constants, so id-level queries can read any of them.
+ * receives, and how its models are discovered. Registration happens once per
+ * vendor × protocol pair, in the vendor's `*.contrib.ts` side-effect module:
+ * a vendor running over several transports registers one definition per
+ * protocol (Kimi composes with `openai` on its native transport and registers
+ * a second definition over `anthropic`). Vendor-level facts (endpoint, host
+ * headers, model source) are declared identically on every registration of
+ * the same id via shared constants, so id-level queries can read any of them.
  *
  * `resolveProviderEndpoint` is the single authority on the endpoint fallback
  * chain: definition-level `endpoint` first, otherwise the aggregation of the
@@ -20,7 +19,6 @@
  * bag (defaulting to `process.env`).
  */
 
-import type { ModelCapability } from '#/kosong/contract/capability';
 import type { Protocol, ProtocolAdapterConfig } from '#/kosong/protocol/protocol';
 import type {
   ProtocolEndpoint,
@@ -49,11 +47,6 @@ export interface ProviderDefinition {
   readonly hostHeaders?: 'full' | 'user-agent';
   /** How the runtime should discover the vendor's models. */
   readonly modelSource?: ModelSource;
-  /**
-   * Declared capability. Resolution order is definition → traits → base:
-   * when present this wins outright — even when it is `UNKNOWN_CAPABILITY`.
-   */
-  readonly capability?: ModelCapability;
 }
 
 const providerDefinitions = new Map<string, Map<Protocol, ProviderDefinition>>();

--- a/packages/agent-core-v2/src/kosong/provider/providers/kimi/kimi.contrib.ts
+++ b/packages/agent-core-v2/src/kosong/provider/providers/kimi/kimi.contrib.ts
@@ -59,10 +59,12 @@
  *    (warning + pass-through).
  *
  * Vendor-level facts — the endpoint fallback chain, full host-header
- * forwarding, OAuth-catalog model discovery, and the UNKNOWN capability
- * declaration (Kimi model capabilities come from the catalog, not from
- * client-side tables) — are shared constants declared identically on both
- * registrations, so id-level queries read either one.
+ * forwarding, and OAuth-catalog model discovery — are shared constants
+ * declared identically on both registrations, so id-level queries read
+ * either one. Kimi declares no vendor-level capability: model capabilities
+ * come from the catalog, not from client-side tables (Kimi model ids never
+ * match the protocol bases' builtin catalogs, so the detected layer answers
+ * UNKNOWN on its own).
  *
  * Deliberately absent (do not reintroduce): a 64-char tool-call-id policy
  * (the base default is identical), an extra-body deep-merge morph, and a
@@ -70,7 +72,6 @@
  * base's `'openai'`).
  */
 
-import { UNKNOWN_CAPABILITY } from '#/kosong/contract/capability';
 import type { ContentPart } from '#/kosong/contract/message';
 import type { Tool } from '#/kosong/contract/tool';
 import type {
@@ -307,7 +308,6 @@ registerProviderDefinition({
   endpoint: kimiEndpoint,
   hostHeaders: 'full',
   modelSource: 'oauth-catalog',
-  capability: UNKNOWN_CAPABILITY,
 });
 
 registerProviderDefinition({
@@ -317,5 +317,4 @@ registerProviderDefinition({
   endpoint: kimiEndpoint,
   hostHeaders: 'full',
   modelSource: 'oauth-catalog',
-  capability: UNKNOWN_CAPABILITY,
 });

--- a/packages/agent-core-v2/test/kosong/provider/composition.test.ts
+++ b/packages/agent-core-v2/test/kosong/provider/composition.test.ts
@@ -40,7 +40,7 @@
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { isUnknownCapability, UNKNOWN_CAPABILITY } from '#/kosong/contract/capability';
+import { isUnknownCapability } from '#/kosong/contract/capability';
 import { APIConnectionError } from '#/kosong/contract/errors';
 import type { Message } from '#/kosong/contract/message';
 import type {
@@ -282,10 +282,6 @@ describe('resolveProviderBaseId', () => {
 });
 
 describe('resolveCapability', () => {
-  it('lets the definition win outright — kimi is UNKNOWN even though the base knows gpt models', () => {
-    expect(registry.resolveCapability('openai', 'gpt-4o', 'kimi')).toBe(UNKNOWN_CAPABILITY);
-  });
-
   it('falls back to trait capability hooks before the base catalog', () => {
     const fromTrait = registry.resolveCapability('openai', 'special-model', 'cap-vendor');
     expect(fromTrait.image_in).toBe(true);
@@ -298,16 +294,20 @@ describe('resolveCapability', () => {
     expect(isUnknownCapability(registry.resolveCapability('openai', 'mystery-model'))).toBe(true);
     expect(registry.resolveCapability('anthropic', 'claude-opus-4-1').thinking).toBe(true);
   });
+
+  it('kimi declares no vendor-level capability — the base catalog answers instead', () => {
+    // Kimi model ids never match the bases' builtin catalogs, so the detected
+    // layer still answers UNKNOWN for them; an id the base does know (gpt-4o)
+    // now resolves through the base catalog rather than being suppressed by a
+    // vendor-level UNKNOWN declaration.
+    expect(isUnknownCapability(registry.resolveCapability('openai', 'kimi-for-coding', 'kimi'))).toBe(
+      true,
+    );
+    expect(registry.resolveCapability('openai', 'gpt-4o', 'kimi').image_in).toBe(true);
+  });
 });
 
 describe('explainCapability', () => {
-  it('reports the definition level when the pair declares a capability', () => {
-    const { capability, source } = registry.explainCapability('openai', 'gpt-4o', 'kimi');
-    expect(capability).toBe(UNKNOWN_CAPABILITY);
-    expect(source.kind).toBe('builtin');
-    expect(source.detail).toContain("'kimi'");
-  });
-
   it('reports the trait level when a trait hook answers', () => {
     const { capability, source } = registry.explainCapability('openai', 'special-model', 'cap-vendor');
     expect(capability.image_in).toBe(true);
@@ -455,7 +455,6 @@ describe('kimi provider definitions', () => {
       });
       expect(definition?.hostHeaders).toBe('full');
       expect(definition?.modelSource).toBe('oauth-catalog');
-      expect(definition?.capability).toBe(UNKNOWN_CAPABILITY);
     }
   });
 


### PR DESCRIPTION
## Related Issue

No linked issue — the problem is explained below.

## Problem

Capability resolution in the kosong provider layer used to consult the provider definition as one step in the chain. This let a vendor-level `UNKNOWN_CAPABILITY` declaration in the kimi contrib definitions suppress capabilities for model ids that the protocol base catalog already knows, producing wrong capability results for those models.

## What changed

Capability resolution now falls back from trait hooks (last declarer wins) to the protocol base catalog, and finally to `UNKNOWN_CAPABILITY`; the definition layer is removed from the chain.

- Remove `ProviderDefinition.capability` and the definition branch in `ProtocolAdapterRegistry.explainCapability`.
- The kimi contrib definitions drop their `UNKNOWN_CAPABILITY` declarations, so base-known model ids resolve through the base catalog instead of being suppressed by a vendor-level `UNKNOWN`.
- Update the composition tests for the new resolution order.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.
