### PR TITLE
fix: resolve model capabilities from bundled catalog

### DIFF
--- a/.changeset/fallback-bundled-model-capabilities.md
+++ b/.changeset/fallback-bundled-model-capabilities.md
@@ -2,4 +2,4 @@
 "@moonshot-ai/kimi-code": patch
 ---
 
-Fix capability detection for configured models by using bundled catalog metadata, with explicit catalog provider and model overrides for compatible endpoints.
+Fix capability detection for configured models by using bundled catalog metadata, with an explicit catalog provider override for compatible endpoints.

--- a/.changeset/fallback-bundled-model-capabilities.md
+++ b/.changeset/fallback-bundled-model-capabilities.md
@@ -2,4 +2,4 @@
 "@moonshot-ai/kimi-code": patch
 ---
 
-Fix capability detection for manually configured models by falling back to the bundled model catalog.
+Fix capability detection for configured models by using bundled catalog metadata, with explicit catalog provider and model overrides for compatible endpoints.

--- a/.changeset/fallback-bundled-model-capabilities.md
+++ b/.changeset/fallback-bundled-model-capabilities.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Fix capability detection for manually configured models by falling back to the bundled model catalog.

--- a/docs/en/configuration/config-files.md
+++ b/docs/en/configuration/config-files.md
@@ -149,7 +149,6 @@ Each entry in the `models` table defines a model alias (the name used in `defaul
 | --- | --- | --- | --- |
 | `provider` | `string` | Yes | Name of the provider to use; must be defined in `providers` |
 | `model` | `string` | Yes | Model identifier sent to the server when calling the API |
-| `catalog_model` | `string` | No | Exact model id used for capability lookup under the provider's `catalog_provider`. Omit it when `model` is already the canonical models.dev id; set it when the server-facing name is a deployment alias |
 | `max_context_size` | `integer` | Yes | Maximum context length in tokens; must be at least 1 |
 | `max_input_size` | `integer` | No | Declared per-request input limit when it sits below the total window (e.g. gpt-5: 400k window, 272k input). Compaction, context-overflow checks, and usage ratios prefer it; completion budgeting keeps the total window. Resolution clamps it to `max_context_size` |
 | `max_output_size` | `integer` | No | Per-request output token cap (maps to `max_tokens`). Currently only the `anthropic` provider honors it. When set for a Claude model, this explicit value overrides the built-in server-side maximum |

--- a/docs/en/configuration/config-files.md
+++ b/docs/en/configuration/config-files.md
@@ -124,6 +124,7 @@ Each entry in the `providers` table defines an API provider, keyed by a unique n
 | Field | Type | Required | Description |
 | --- | --- | --- | --- |
 | `type` | `string` | Yes | Provider type: `kimi`, `anthropic`, `openai`, `openai_responses`, `google-genai`, `vertexai` |
+| `catalog_provider` | `string` | No | Exact provider id in the bundled [models.dev](https://models.dev/) snapshot used for capability metadata. It does not change the API protocol selected by `type`. Usually written automatically by `/provider`; set it by hand for an OpenAI-compatible third-party provider such as `deepseek` |
 | `api_key` | `string` | No | API key, written in plain text in the config file |
 | `base_url` | `string` | No | API base URL |
 | `oauth` | `table` | No | OAuth credential reference (`storage` and `key` fields); injected automatically by the login flow — normally no need to write this by hand |
@@ -148,6 +149,7 @@ Each entry in the `models` table defines a model alias (the name used in `defaul
 | --- | --- | --- | --- |
 | `provider` | `string` | Yes | Name of the provider to use; must be defined in `providers` |
 | `model` | `string` | Yes | Model identifier sent to the server when calling the API |
+| `catalog_model` | `string` | No | Exact model id used for capability lookup under the provider's `catalog_provider`. Omit it when `model` is already the canonical models.dev id; set it when the server-facing name is a deployment alias |
 | `max_context_size` | `integer` | Yes | Maximum context length in tokens; must be at least 1 |
 | `max_input_size` | `integer` | No | Declared per-request input limit when it sits below the total window (e.g. gpt-5: 400k window, 272k input). Compaction, context-overflow checks, and usage ratios prefer it; completion budgeting keeps the total window. Resolution clamps it to `max_context_size` |
 | `max_output_size` | `integer` | No | Per-request output token cap (maps to `max_tokens`). Currently only the `anthropic` provider honors it. When set for a Claude model, this explicit value overrides the built-in server-side maximum |

--- a/docs/en/configuration/providers.md
+++ b/docs/en/configuration/providers.md
@@ -15,7 +15,7 @@ The `type` field in the `providers` table determines which protocol implementati
 | `google-genai` | Google GenAI | Gemini API |
 | `vertexai` | Google GenAI on Vertex | Google Cloud Vertex AI |
 
-All providers communicate with models in streaming mode by default. Capabilities such as thinking, vision, and tool use are matched automatically by model name prefix — you typically do not need to declare them manually.
+All providers communicate with models in streaming mode by default. Kimi Code first reads capability metadata from its bundled models.dev snapshot, then falls back to built-in model matchers. For an official endpoint, `type` selects the corresponding catalog provider automatically. For a third-party endpoint that only shares a protocol, set `catalog_provider` explicitly; `type` continues to control the API protocol.
 
 **Credential priority**: `api_key` direct field > `[providers.<name>.env]` sub-table key > if both are absent, startup fails with an error. The CLI does not fall back to shell environment variables for credentials — see [Config overrides: provider credentials](./overrides.md#provider-credentials).
 
@@ -59,7 +59,7 @@ api_key = "sk-xxxxx"
 
 ## `anthropic`
 
-For connecting to the Claude API. Kimi Code auto-detects vision, tool call, and Thinking capabilities from the bundled models.dev catalog, then falls back to its built-in model matchers. Only custom models that neither source covers need `capabilities` declared explicitly on `[models.<alias>]`.
+For connecting to the Claude API. The default `anthropic` catalog identity lets Kimi Code auto-detect vision, tool call, and Thinking capabilities from the bundled models.dev snapshot before falling back to its built-in model matchers. Only custom models that neither source covers need `capabilities` declared explicitly on `[models.<alias>]`.
 
 - Default `base_url`: follows Anthropic SDK default
 - Credential key names: `ANTHROPIC_API_KEY`, `ANTHROPIC_BASE_URL`
@@ -92,6 +92,24 @@ type = "openai"
 base_url = "https://api.openai.com/v1"
 api_key = "sk-xxxxx"
 ```
+
+For an OpenAI-compatible third-party endpoint, keep `type = "openai"` because it controls the wire protocol, and set `catalog_provider` to the exact models.dev provider id used for capability metadata. If the endpoint exposes a deployment alias instead of the canonical model id, set `catalog_model` on that model entry:
+
+```toml
+[providers.deepseek]
+type = "openai"
+catalog_provider = "deepseek"
+base_url = "https://api.deepseek.com"
+api_key = "sk-xxxxx"
+
+[models.production-reasoner]
+provider = "deepseek"
+model = "production-reasoner"
+catalog_model = "deepseek-reasoner"
+max_context_size = 128000
+```
+
+This lookup is exact within the selected provider. Kimi Code does not guess a vendor from the provider name or scan other providers for a matching model id. If the endpoint already uses `deepseek-reasoner`, omit `catalog_model`.
 
 ## `openai_responses`
 

--- a/docs/en/configuration/providers.md
+++ b/docs/en/configuration/providers.md
@@ -59,7 +59,7 @@ api_key = "sk-xxxxx"
 
 ## `anthropic`
 
-For connecting to the Claude API. Standard Claude models automatically enable vision, tool use, and Thinking (where supported); custom or uncovered models need `capabilities` declared explicitly on `[models.<alias>]`.
+For connecting to the Claude API. Kimi Code auto-detects vision, tool call, and Thinking capabilities from the bundled models.dev catalog, then falls back to its built-in model matchers. Only custom models that neither source covers need `capabilities` declared explicitly on `[models.<alias>]`.
 
 - Default `base_url`: follows Anthropic SDK default
 - Credential key names: `ANTHROPIC_API_KEY`, `ANTHROPIC_BASE_URL`

--- a/docs/en/configuration/providers.md
+++ b/docs/en/configuration/providers.md
@@ -93,7 +93,7 @@ base_url = "https://api.openai.com/v1"
 api_key = "sk-xxxxx"
 ```
 
-For an OpenAI-compatible third-party endpoint, keep `type = "openai"` because it controls the wire protocol, and set `catalog_provider` to the exact models.dev provider id used for capability metadata. If the endpoint exposes a deployment alias instead of the canonical model id, set `catalog_model` on that model entry:
+For an OpenAI-compatible third-party endpoint, keep `type = "openai"` because it controls the wire protocol, and set `catalog_provider` to the exact models.dev provider id used for capability metadata:
 
 ```toml
 [providers.deepseek]
@@ -102,14 +102,13 @@ catalog_provider = "deepseek"
 base_url = "https://api.deepseek.com"
 api_key = "sk-xxxxx"
 
-[models.production-reasoner]
+[models."deepseek/v4-pro"]
 provider = "deepseek"
-model = "production-reasoner"
-catalog_model = "deepseek-reasoner"
-max_context_size = 128000
+model = "deepseek-v4-pro"
+max_context_size = 1000000
 ```
 
-This lookup is exact within the selected provider. Kimi Code does not guess a vendor from the provider name or scan other providers for a matching model id. If the endpoint already uses `deepseek-reasoner`, omit `catalog_model`.
+Kimi Code looks up the configured `model` within the selected catalog provider. It does not guess a vendor from the local provider name or scan unrelated providers for a matching model id. If a gateway replaces the canonical model id with an arbitrary deployment alias, declare capabilities explicitly instead.
 
 ## `openai_responses`
 

--- a/docs/zh/configuration/config-files.md
+++ b/docs/zh/configuration/config-files.md
@@ -124,6 +124,7 @@ timeout = 5
 | 字段 | 类型 | 必填 | 说明 |
 | --- | --- | --- | --- |
 | `type` | `string` | 是 | 供应商类型：`kimi`、`anthropic`、`openai`、`openai_responses`、`google-genai`、`vertexai` |
+| `catalog_provider` | `string` | 否 | 随 CLI 发布的 [models.dev](https://models.dev/) 快照中的精确供应商 ID，用于读取能力元数据，不会改变 `type` 选择的 API 协议。通常由 `/provider` 自动写入；手动配置 DeepSeek 等 OpenAI 兼容供应商时可显式设置，例如 `deepseek` |
 | `api_key` | `string` | 否 | API 密钥，明文写在配置文件里 |
 | `base_url` | `string` | 否 | API 基础 URL |
 | `oauth` | `table` | 否 | OAuth 凭据引用（`storage`、`key` 两个字段），由登录流程自动注入，通常无需手写 |
@@ -148,6 +149,7 @@ KIMI_BASE_URL = "https://api.moonshot.ai/v1"
 | --- | --- | --- | --- |
 | `provider` | `string` | 是 | 使用的供应商名称，必须在 `providers` 中定义 |
 | `model` | `string` | 是 | 调用 API 时实际传给服务端的模型 ID |
+| `catalog_model` | `string` | 否 | 在供应商的 `catalog_provider` 下查能力时使用的精确模型 ID。`model` 已经是 models.dev 中的规范 ID 时可省略；服务端使用部署别名时需要设置 |
 | `max_context_size` | `integer` | 是 | 最大上下文长度（token 数），必须 ≥ 1 |
 | `max_input_size` | `integer` | 否 | 模型声明的单次请求输入上限（当低于总窗口时，如 gpt-5 的 400k 窗口 / 272k 输入）。压缩、上下文溢出检查和用量比率优先使用它；补全预算仍使用总窗口。解析时会被钳制到不超过 `max_context_size` |
 | `max_output_size` | `integer` | 否 | 单次请求的输出 token 上限（对应 `max_tokens`）。目前仅 `anthropic` 供应商读取。为 Claude 模型设置后，这个显式值会覆盖内置的服务端最大值 |

--- a/docs/zh/configuration/config-files.md
+++ b/docs/zh/configuration/config-files.md
@@ -149,7 +149,6 @@ KIMI_BASE_URL = "https://api.moonshot.ai/v1"
 | --- | --- | --- | --- |
 | `provider` | `string` | 是 | 使用的供应商名称，必须在 `providers` 中定义 |
 | `model` | `string` | 是 | 调用 API 时实际传给服务端的模型 ID |
-| `catalog_model` | `string` | 否 | 在供应商的 `catalog_provider` 下查能力时使用的精确模型 ID。`model` 已经是 models.dev 中的规范 ID 时可省略；服务端使用部署别名时需要设置 |
 | `max_context_size` | `integer` | 是 | 最大上下文长度（token 数），必须 ≥ 1 |
 | `max_input_size` | `integer` | 否 | 模型声明的单次请求输入上限（当低于总窗口时，如 gpt-5 的 400k 窗口 / 272k 输入）。压缩、上下文溢出检查和用量比率优先使用它；补全预算仍使用总窗口。解析时会被钳制到不超过 `max_context_size` |
 | `max_output_size` | `integer` | 否 | 单次请求的输出 token 上限（对应 `max_tokens`）。目前仅 `anthropic` 供应商读取。为 Claude 模型设置后，这个显式值会覆盖内置的服务端最大值 |

--- a/docs/zh/configuration/providers.md
+++ b/docs/zh/configuration/providers.md
@@ -15,7 +15,7 @@ Kimi Code CLI 支持同时接入多家 LLM 平台——用 Kimi Code 托管服�
 | `google-genai` | Google GenAI | Gemini API |
 | `vertexai` | Google GenAI on Vertex | Google Cloud Vertex AI |
 
-所有供应商默认以流式方式与模型交互。thinking、视觉、工具调用等能力按模型名前缀自动匹配，通常不需要手动声明。
+所有供应商默认以流式方式与模型交互。Kimi Code 会先从随 CLI 发布的 models.dev 快照读取能力元数据，再回退到内置模型匹配规则。对官方端点，`type` 会自动选择对应的目录供应商；对只是共用协议的第三方端点，需要显式设置 `catalog_provider`，而 `type` 仍只负责选择 API 协议。
 
 **凭证优先级**：`api_key` 直接字段 > `[providers.<name>.env]` 子表键 > 两者都缺时启动报错。CLI 不会从 shell 环境变量自动取凭证——详见[配置覆盖：供应商凭证](./overrides.md#供应商凭证)。
 
@@ -59,7 +59,7 @@ api_key = "sk-xxxxx"
 
 ## `anthropic`
 
-用于对接 Claude API。Kimi Code 会先从随 CLI 发布的 models.dev 目录快照中自动识别视觉、工具调用及 Thinking 能力，再回退到内置模型匹配规则；只有两者都无法覆盖的自定义模型，才需要在 `[models.<alias>]` 里显式声明 `capabilities`。
+用于对接 Claude API。默认的 `anthropic` 目录身份让 Kimi Code 先从随 CLI 发布的 models.dev 快照中自动识别视觉、工具调用及 Thinking 能力，再回退到内置模型匹配规则；只有两者都无法覆盖的自定义模型，才需要在 `[models.<alias>]` 里显式声明 `capabilities`。
 
 - 默认 `base_url`：跟随 Anthropic SDK 默认值
 - 凭证键名：`ANTHROPIC_API_KEY`、`ANTHROPIC_BASE_URL`
@@ -92,6 +92,24 @@ type = "openai"
 base_url = "https://api.openai.com/v1"
 api_key = "sk-xxxxx"
 ```
+
+配置 OpenAI 兼容的第三方端点时，保留 `type = "openai"`，因为它决定在线协议；同时把 `catalog_provider` 设为 models.dev 中用于读取能力元数据的精确供应商 ID。如果端点暴露的是部署别名而不是规范模型 ID，再在模型条目上设置 `catalog_model`：
+
+```toml
+[providers.deepseek]
+type = "openai"
+catalog_provider = "deepseek"
+base_url = "https://api.deepseek.com"
+api_key = "sk-xxxxx"
+
+[models.production-reasoner]
+provider = "deepseek"
+model = "production-reasoner"
+catalog_model = "deepseek-reasoner"
+max_context_size = 128000
+```
+
+查找只会在指定供应商内精确进行。Kimi Code 不会根据配置中的供应商名称猜厂商，也不会扫描其他供应商寻找同名模型。如果端点本来就使用 `deepseek-reasoner`，可以省略 `catalog_model`。
 
 ## `openai_responses`
 

--- a/docs/zh/configuration/providers.md
+++ b/docs/zh/configuration/providers.md
@@ -59,7 +59,7 @@ api_key = "sk-xxxxx"
 
 ## `anthropic`
 
-用于对接 Claude API。标准 Claude 模型自动启用视觉、工具调用及 Thinking（如支持）；自定义或未覆盖的模型需在 `[models.<alias>]` 里显式声明 `capabilities`。
+用于对接 Claude API。Kimi Code 会先从随 CLI 发布的 models.dev 目录快照中自动识别视觉、工具调用及 Thinking 能力，再回退到内置模型匹配规则；只有两者都无法覆盖的自定义模型，才需要在 `[models.<alias>]` 里显式声明 `capabilities`。
 
 - 默认 `base_url`：跟随 Anthropic SDK 默认值
 - 凭证键名：`ANTHROPIC_API_KEY`、`ANTHROPIC_BASE_URL`

--- a/docs/zh/configuration/providers.md
+++ b/docs/zh/configuration/providers.md
@@ -93,7 +93,7 @@ base_url = "https://api.openai.com/v1"
 api_key = "sk-xxxxx"
 ```
 
-配置 OpenAI 兼容的第三方端点时，保留 `type = "openai"`，因为它决定在线协议；同时把 `catalog_provider` 设为 models.dev 中用于读取能力元数据的精确供应商 ID。如果端点暴露的是部署别名而不是规范模型 ID，再在模型条目上设置 `catalog_model`：
+配置 OpenAI 兼容的第三方端点时，保留 `type = "openai"`，因为它决定在线协议；同时把 `catalog_provider` 设为 models.dev 中用于读取能力元数据的精确供应商 ID：
 
 ```toml
 [providers.deepseek]
@@ -102,14 +102,13 @@ catalog_provider = "deepseek"
 base_url = "https://api.deepseek.com"
 api_key = "sk-xxxxx"
 
-[models.production-reasoner]
+[models."deepseek/v4-pro"]
 provider = "deepseek"
-model = "production-reasoner"
-catalog_model = "deepseek-reasoner"
-max_context_size = 128000
+model = "deepseek-v4-pro"
+max_context_size = 1000000
 ```
 
-查找只会在指定供应商内精确进行。Kimi Code 不会根据配置中的供应商名称猜厂商，也不会扫描其他供应商寻找同名模型。如果端点本来就使用 `deepseek-reasoner`，可以省略 `catalog_model`。
+Kimi Code 会在指定的目录供应商中查找配置的 `model`。它不会根据本地供应商名称猜厂商，也不会扫描其他供应商寻找同名模型。如果网关把规范模型 ID 换成任意部署别名，请改为显式声明能力。
 
 ## `openai_responses`
 

--- a/packages/agent-core-v2/docs/config-manifest.toml
+++ b/packages/agent-core-v2/docs/config-manifest.toml
@@ -220,7 +220,6 @@ merge_all_available_skills = true
   # aliases: string[]
   # provider: string
   # model: string
-  # catalog_model: string
   # max_context_size: integer
   # max_input_size: integer
   # max_output_size: integer

--- a/packages/agent-core-v2/docs/config-manifest.toml
+++ b/packages/agent-core-v2/docs/config-manifest.toml
@@ -220,6 +220,7 @@ merge_all_available_skills = true
   # aliases: string[]
   # provider: string
   # model: string
+  # catalog_model: string
   # max_context_size: integer
   # max_input_size: integer
   # max_output_size: integer
@@ -276,6 +277,7 @@ merge_all_available_skills = true
   # base_url: string
   # custom_headers: record<string, string>
   # default_model: string
+  # catalog_provider: string
   # type: string
   # api_key: string
   # oauth: object

--- a/packages/agent-core-v2/src/app/kosongConfig/configSection.ts
+++ b/packages/agent-core-v2/src/app/kosongConfig/configSection.ts
@@ -199,7 +199,6 @@ const ModelBaseSchema = z.object({
 
   provider: z.string().optional(),
   model: z.string().optional(),
-  catalogModel: z.string().min(1).optional(),
   maxContextSize: z.number().int().min(1).optional(),
   maxInputSize: z.number().int().min(1).optional(),
   maxOutputSize: z.number().int().min(1).optional(),
@@ -223,7 +222,6 @@ export const ModelOverrideSchema = ModelBaseSchema.omit({
   aliases: true,
   provider: true,
   model: true,
-  catalogModel: true,
   betaApi: true,
 }).partial();
 

--- a/packages/agent-core-v2/src/app/kosongConfig/configSection.ts
+++ b/packages/agent-core-v2/src/app/kosongConfig/configSection.ts
@@ -72,6 +72,7 @@ export const ProviderConfigSchema = z.object({
   baseUrl: z.string().optional(),
   customHeaders: StringRecordSchema.optional(),
   defaultModel: z.string().optional(),
+  catalogProvider: z.string().min(1).optional(),
 
   type: ProviderTypeSchema.optional(),
   apiKey: z.string().optional(),
@@ -198,6 +199,7 @@ const ModelBaseSchema = z.object({
 
   provider: z.string().optional(),
   model: z.string().optional(),
+  catalogModel: z.string().min(1).optional(),
   maxContextSize: z.number().int().min(1).optional(),
   maxInputSize: z.number().int().min(1).optional(),
   maxOutputSize: z.number().int().min(1).optional(),
@@ -221,6 +223,7 @@ export const ModelOverrideSchema = ModelBaseSchema.omit({
   aliases: true,
   provider: true,
   model: true,
+  catalogModel: true,
   betaApi: true,
 }).partial();
 

--- a/packages/agent-core-v2/src/app/kosongConfig/modelsDev.ts
+++ b/packages/agent-core-v2/src/app/kosongConfig/modelsDev.ts
@@ -1,7 +1,8 @@
 /**
  * `kosongConfig` domain (L3) — the third-party models.dev directory: its
  * api.json schema mirrored as types, plus the normalization that turns a
- * directory entry into an import decision.
+ * directory entry into an import decision or resolves one model's capability
+ * from a bundled snapshot.
  *
  * models.dev is an EXTERNAL schema that evolves on its own, so its mirror
  * lives here in the app layer, NOT in kosong — kosong's type surface stays
@@ -122,6 +123,14 @@ const KNOWN_WIRE_TYPES = [
 
 /** The enumerated subset of {@link ProviderType} the models.dev import knows. */
 type KnownWireType = (typeof KNOWN_WIRE_TYPES)[number];
+
+const MODELS_DEV_CAPABILITY_PROVIDER_IDS: Partial<Record<KnownWireType, readonly string[]>> = {
+  anthropic: ['anthropic'],
+  openai: ['openai'],
+  openai_responses: ['openai'],
+  'google-genai': ['google'],
+  vertexai: ['google-vertex', 'google-vertex-anthropic'],
+};
 
 function isWireType(value: unknown): value is KnownWireType {
   return typeof value === 'string' && (KNOWN_WIRE_TYPES as readonly string[]).includes(value);
@@ -442,6 +451,65 @@ export function modelsDevProviderModels(entry: ModelsDevProviderEntry): ModelsDe
       }
       return model;
     });
+}
+
+function normalizeModelsDevPlatformKey(key: string): string {
+  return key
+    .toLowerCase()
+    .replace(/^(?:us|eu|apac|global)\./, '')
+    .replace(/^(?:anthropic|ai21|amazon|cohere|deepseek|meta|mistral|writer)\./, '')
+    .replace(/-v\d+(?::\d+)?$/, '');
+}
+
+function normalizeModelsDevDeploymentKey(key: string): string {
+  return normalizeModelsDevPlatformKey(key).replace(/@.*$/, '');
+}
+
+function normalizeModelsDevFamilyKey(key: string): string {
+  return normalizeModelsDevDeploymentKey(key)
+    .replace(/-\d{8}$/, '')
+    .replace(/-\d{4}-\d{2}-\d{2}$/, '');
+}
+
+export interface ModelsDevCapabilityMatch {
+  readonly capability: ModelCapability;
+  readonly providerId: string;
+}
+
+export function getModelsDevModelCapability(
+  catalog: ModelsDevCatalog | undefined,
+  wire: ProviderType,
+  modelName: string,
+): ModelsDevCapabilityMatch | undefined {
+  if (catalog === undefined || !isWireType(wire)) return undefined;
+  const providerIds = MODELS_DEV_CAPABILITY_PROVIDER_IDS[wire];
+  if (providerIds === undefined) return undefined;
+  for (const providerId of providerIds) {
+    const models = catalog[providerId]?.models;
+    if (models === undefined) continue;
+    const exact = models[modelName] ?? models[modelName.toLowerCase()];
+    if (exact !== undefined) {
+      const model = modelsDevModelToCapability(exact);
+      if (model !== undefined) return { capability: model.capability, providerId };
+    }
+  }
+  for (const normalize of [
+    normalizeModelsDevPlatformKey,
+    normalizeModelsDevDeploymentKey,
+    normalizeModelsDevFamilyKey,
+  ]) {
+    const target = normalize(modelName);
+    for (const providerId of providerIds) {
+      const models = catalog[providerId]?.models;
+      if (models === undefined) continue;
+      for (const [key, entry] of Object.entries(models)) {
+        if (normalize(key) !== target) continue;
+        const model = modelsDevModelToCapability(entry);
+        if (model !== undefined) return { capability: model.capability, providerId };
+      }
+    }
+  }
+  return undefined;
 }
 
 /**

--- a/packages/agent-core-v2/src/app/kosongConfig/modelsDev.ts
+++ b/packages/agent-core-v2/src/app/kosongConfig/modelsDev.ts
@@ -124,12 +124,13 @@ const KNOWN_WIRE_TYPES = [
 /** The enumerated subset of {@link ProviderType} the models.dev import knows. */
 type KnownWireType = (typeof KNOWN_WIRE_TYPES)[number];
 
-const MODELS_DEV_CAPABILITY_PROVIDER_IDS: Partial<Record<KnownWireType, readonly string[]>> = {
-  anthropic: ['anthropic'],
-  openai: ['openai'],
-  openai_responses: ['openai'],
-  'google-genai': ['google'],
-  vertexai: ['google-vertex', 'google-vertex-anthropic'],
+const DEFAULT_MODELS_DEV_PROVIDER_BY_TYPE: Readonly<Record<string, string>> = {
+  anthropic: 'anthropic',
+  openai: 'openai',
+  openai_responses: 'openai',
+  'google-genai': 'google',
+  vertexai: 'google-vertex',
+  kimi: 'moonshotai',
 };
 
 function isWireType(value: unknown): value is KnownWireType {
@@ -476,22 +477,32 @@ export interface ModelsDevCapabilityMatch {
   readonly providerId: string;
 }
 
+export function resolveModelsDevCapabilityProvider(query: {
+  readonly protocol: ProviderType;
+  readonly providerType?: string;
+  readonly catalogProvider?: string;
+  readonly vertexai?: boolean;
+}): string | undefined {
+  return (
+    query.catalogProvider ??
+    (query.vertexai === true
+      ? 'google-vertex'
+      : DEFAULT_MODELS_DEV_PROVIDER_BY_TYPE[query.providerType ?? query.protocol])
+  );
+}
+
 export function getModelsDevModelCapability(
   catalog: ModelsDevCatalog | undefined,
-  wire: ProviderType,
+  providerId: string,
   modelName: string,
 ): ModelsDevCapabilityMatch | undefined {
-  if (catalog === undefined || !isWireType(wire)) return undefined;
-  const providerIds = MODELS_DEV_CAPABILITY_PROVIDER_IDS[wire];
-  if (providerIds === undefined) return undefined;
-  for (const providerId of providerIds) {
-    const models = catalog[providerId]?.models;
-    if (models === undefined) continue;
-    const exact = models[modelName] ?? models[modelName.toLowerCase()];
-    if (exact !== undefined) {
-      const model = modelsDevModelToCapability(exact);
-      if (model !== undefined) return { capability: model.capability, providerId };
-    }
+  if (catalog === undefined) return undefined;
+  const models = catalog[providerId]?.models;
+  if (models === undefined) return undefined;
+  const exact = models[modelName] ?? models[modelName.toLowerCase()];
+  if (exact !== undefined) {
+    const model = modelsDevModelToCapability(exact);
+    if (model !== undefined) return { capability: model.capability, providerId };
   }
   for (const normalize of [
     normalizeModelsDevPlatformKey,
@@ -499,14 +510,10 @@ export function getModelsDevModelCapability(
     normalizeModelsDevFamilyKey,
   ]) {
     const target = normalize(modelName);
-    for (const providerId of providerIds) {
-      const models = catalog[providerId]?.models;
-      if (models === undefined) continue;
-      for (const [key, entry] of Object.entries(models)) {
-        if (normalize(key) !== target) continue;
-        const model = modelsDevModelToCapability(entry);
-        if (model !== undefined) return { capability: model.capability, providerId };
-      }
+    for (const [key, entry] of Object.entries(models)) {
+      if (normalize(key) !== target) continue;
+      const model = modelsDevModelToCapability(entry);
+      if (model !== undefined) return { capability: model.capability, providerId };
     }
   }
   return undefined;

--- a/packages/agent-core-v2/src/app/kosongConfig/modelsDevCapability.contrib.ts
+++ b/packages/agent-core-v2/src/app/kosongConfig/modelsDevCapability.contrib.ts
@@ -1,0 +1,33 @@
+/**
+ * `app/kosongConfig` domain (L3) — contributes the bundled models.dev
+ * snapshot as a capability source without making the L2 provider domain
+ * depend on app configuration. The multi-megabyte snapshot is parsed lazily
+ * on the first lookup and never refreshed from the network.
+ */
+
+import { registerModelCapabilityResolver } from '#/kosong/provider/modelCapabilityResolver';
+
+import { BUILT_IN_MODELS_DEV_JSON } from './builtInModelsDev';
+import {
+  getModelsDevModelCapability,
+  type ModelsDevCatalog,
+} from './modelsDev';
+import { loadBuiltInModelsDevCatalog } from './modelsDevUpstream';
+
+let catalog: ModelsDevCatalog | undefined | null = null;
+
+registerModelCapabilityResolver(({ protocol, providerType, modelName }) => {
+  if (catalog === null) {
+    catalog = loadBuiltInModelsDevCatalog(BUILT_IN_MODELS_DEV_JSON);
+  }
+  const wire = providerType === 'vertexai' ? providerType : protocol;
+  const match = getModelsDevModelCapability(catalog, wire, modelName);
+  if (match === undefined) return undefined;
+  return {
+    capability: match.capability,
+    source: {
+      kind: 'builtin',
+      detail: `models.dev built-in snapshot provider '${match.providerId}'`,
+    },
+  };
+});

--- a/packages/agent-core-v2/src/app/kosongConfig/modelsDevCapability.contrib.ts
+++ b/packages/agent-core-v2/src/app/kosongConfig/modelsDevCapability.contrib.ts
@@ -28,11 +28,7 @@ registerModelCapabilityResolver((query) => {
     vertexai: query.providerOptions?.vertexai,
   });
   if (providerId === undefined) return undefined;
-  const match = getModelsDevModelCapability(
-    catalog,
-    providerId,
-    query.catalogModel ?? query.modelName,
-  );
+  const match = getModelsDevModelCapability(catalog, providerId, query.modelName);
   if (match === undefined) return undefined;
   return {
     capability: match.capability,

--- a/packages/agent-core-v2/src/app/kosongConfig/modelsDevCapability.contrib.ts
+++ b/packages/agent-core-v2/src/app/kosongConfig/modelsDevCapability.contrib.ts
@@ -11,17 +11,28 @@ import { BUILT_IN_MODELS_DEV_JSON } from './builtInModelsDev';
 import {
   getModelsDevModelCapability,
   type ModelsDevCatalog,
+  resolveModelsDevCapabilityProvider,
 } from './modelsDev';
 import { loadBuiltInModelsDevCatalog } from './modelsDevUpstream';
 
 let catalog: ModelsDevCatalog | undefined | null = null;
 
-registerModelCapabilityResolver(({ protocol, providerType, modelName }) => {
+registerModelCapabilityResolver((query) => {
   if (catalog === null) {
     catalog = loadBuiltInModelsDevCatalog(BUILT_IN_MODELS_DEV_JSON);
   }
-  const wire = providerType === 'vertexai' ? providerType : protocol;
-  const match = getModelsDevModelCapability(catalog, wire, modelName);
+  const providerId = resolveModelsDevCapabilityProvider({
+    protocol: query.protocol,
+    providerType: query.providerType,
+    catalogProvider: query.catalogProvider,
+    vertexai: query.providerOptions?.vertexai,
+  });
+  if (providerId === undefined) return undefined;
+  const match = getModelsDevModelCapability(
+    catalog,
+    providerId,
+    query.catalogModel ?? query.modelName,
+  );
   if (match === undefined) return undefined;
   return {
     capability: match.capability,

--- a/packages/agent-core-v2/src/app/kosongConfig/modelsDevImportService.ts
+++ b/packages/agent-core-v2/src/app/kosongConfig/modelsDevImportService.ts
@@ -194,9 +194,12 @@ export class ModelsDevImportService implements IModelsDevImportService {
     // `undefined` when the wire needs none, so a stale on-disk value is
     // really cleared. The global default pointers are deliberately left
     // alone.
-    const provider: ProviderConfig = { type: resolution.wire };
-    provider.baseUrl = resolution.baseUrl;
-    provider.apiKey = options.apiKey ?? existing?.apiKey;
+    const provider: ProviderConfig = {
+      type: resolution.wire,
+      catalogProvider: catalogId,
+      baseUrl: resolution.baseUrl,
+      apiKey: options.apiKey ?? existing?.apiKey,
+    };
     await config.replace(PROVIDERS_SECTION, { ...providers, [targetId]: provider });
 
     // Two-pass alias swap: pass 1 drops the provider's aliases for real

--- a/packages/agent-core-v2/src/index.ts
+++ b/packages/agent-core-v2/src/index.ts
@@ -98,6 +98,7 @@ export * from '#/kosong/protocol/protocolBase';
 export * from '#/kosong/protocol/protocolTrait';
 import '#/app/kosongConfig/envOverlay';
 import '#/app/kosongConfig/secondaryModelOverlay';
+import '#/app/kosongConfig/modelsDevCapability.contrib';
 export * from '#/kosong/model/completionBudget';
 export * from '#/kosong/model/hostRequestHeaders';
 export * from '#/kosong/model/model';

--- a/packages/agent-core-v2/src/kosong/model/catalogService.ts
+++ b/packages/agent-core-v2/src/kosong/model/catalogService.ts
@@ -22,7 +22,7 @@
  * credential env fallbacks resolve through `resolveProviderEndpoint` against
  * the config env bag; host-header forwarding follows the vendor definition's
  * `hostHeaders`; capability detection receives the resolved provider mode and
- * explicit models.dev catalog coordinates separately from wire identity.
+ * explicit models.dev provider identity separately from wire identity.
  *
  * Caching (load-bearing): assembled entries are invalidated ONLY by the
  * model/provider config-change events. Tests that mutate config
@@ -391,7 +391,6 @@ export class ModelCatalog extends Disposable implements IModelCatalog {
       providerType,
       {
         catalogProvider: providerConfig?.catalogProvider,
-        catalogModel: model.catalogModel,
         providerOptions,
       },
     );

--- a/packages/agent-core-v2/src/kosong/model/catalogService.ts
+++ b/packages/agent-core-v2/src/kosong/model/catalogService.ts
@@ -21,8 +21,8 @@
  * referenced provider vendor's declared `baseProtocol`; endpoint and
  * credential env fallbacks resolve through `resolveProviderEndpoint` against
  * the config env bag; host-header forwarding follows the vendor definition's
- * `hostHeaders`; capability detection is `resolveCapability(protocol, name,
- * providerType)`.
+ * `hostHeaders`; capability detection receives the resolved provider mode and
+ * explicit models.dev catalog coordinates separately from wire identity.
  *
  * Caching (load-bearing): assembled entries are invalidated ONLY by the
  * model/provider config-change events. Tests that mutate config
@@ -379,10 +379,21 @@ export class ModelCatalog extends Disposable implements IModelCatalog {
       );
     }
 
+    const providerOptions = buildProtocolProviderOptions(
+      model,
+      protocol,
+      providerConfig,
+      resolvedBaseUrl,
+    );
     const explainedCapability = this.protocolRegistry.explainCapability(
       protocol,
       wireName,
       providerType,
+      {
+        catalogProvider: providerConfig?.catalogProvider,
+        catalogModel: model.catalogModel,
+        providerOptions,
+      },
     );
     trace.capture(TRACE.detectedCapability, explainedCapability.capability);
     trace.capture(TRACE.capabilitySource, explainedCapability.source);
@@ -391,12 +402,6 @@ export class ModelCatalog extends Disposable implements IModelCatalog {
       explainedCapability.capability,
       model.maxContextSize,
       model.maxInputSize,
-    );
-    const providerOptions = buildProtocolProviderOptions(
-      model,
-      protocol,
-      providerConfig,
-      resolvedBaseUrl,
     );
     if (providerOptions !== undefined) {
       attributeProviderOptions(trace, providerOptions, providerConfig?.env);

--- a/packages/agent-core-v2/src/kosong/model/inspection.ts
+++ b/packages/agent-core-v2/src/kosong/model/inspection.ts
@@ -491,7 +491,7 @@ function attributeCapabilities(
       );
       continue;
     }
-    if (detected?.[key] === true) {
+    if (detected !== undefined && detectedSource.kind !== 'none') {
       sources.set(path, detectedSource);
       continue;
     }

--- a/packages/agent-core-v2/src/kosong/model/model.ts
+++ b/packages/agent-core-v2/src/kosong/model/model.ts
@@ -20,9 +20,10 @@
  *
  * `name` is the wire-facing model identifier sent to the endpoint; `model` is
  * the legacy spelling of the same field (at least one is required at resolve
- * time). `aliases` is a free-form list of routing keys; callers may request
- * "claude-sonnet-4" and the router picks any Model whose name or aliases
- * match (many-to-many).
+ * time). `catalogModel` can separately name the canonical models.dev entry
+ * used for metadata. `aliases` is a free-form list of routing keys; callers
+ * may request "claude-sonnet-4" and the router picks any Model whose name or
+ * aliases match (many-to-many).
  *
  * `protocol` names one of the four real wire protocols (no vendor entries —
  * a vendor such as `kimi` is expressed as the referenced provider's free-form
@@ -75,6 +76,7 @@ export interface ModelRecord {
 
   provider?: string;
   model?: string;
+  catalogModel?: string;
   maxContextSize?: number;
   maxInputSize?: number;
   maxOutputSize?: number;

--- a/packages/agent-core-v2/src/kosong/model/model.ts
+++ b/packages/agent-core-v2/src/kosong/model/model.ts
@@ -20,10 +20,9 @@
  *
  * `name` is the wire-facing model identifier sent to the endpoint; `model` is
  * the legacy spelling of the same field (at least one is required at resolve
- * time). `catalogModel` can separately name the canonical models.dev entry
- * used for metadata. `aliases` is a free-form list of routing keys; callers
- * may request "claude-sonnet-4" and the router picks any Model whose name or
- * aliases match (many-to-many).
+ * time). `aliases` is a free-form list of routing keys; callers may request
+ * "claude-sonnet-4" and the router picks any Model whose name or aliases
+ * match (many-to-many).
  *
  * `protocol` names one of the four real wire protocols (no vendor entries —
  * a vendor such as `kimi` is expressed as the referenced provider's free-form
@@ -76,7 +75,6 @@ export interface ModelRecord {
 
   provider?: string;
   model?: string;
-  catalogModel?: string;
   maxContextSize?: number;
   maxInputSize?: number;
   maxOutputSize?: number;

--- a/packages/agent-core-v2/src/kosong/protocol/protocol.ts
+++ b/packages/agent-core-v2/src/kosong/protocol/protocol.ts
@@ -120,10 +120,9 @@ export interface IProtocolAdapterRegistry {
   resolveProviderBaseId(protocol: Protocol, providerType?: string): ProtocolBaseId;
 
   /**
-   * Capability resolution with the fixed fallback chain: pair definition's
-   * declared capability → trait `capability` hooks (last declarer wins) →
-   * the base's own catalog. `UNKNOWN_CAPABILITY` when nothing knows the
-   * model.
+   * Capability resolution with the fixed fallback chain: trait `capability`
+   * hooks (last declarer wins) → registered external sources → the base's own
+   * catalog. `UNKNOWN_CAPABILITY` when nothing knows the model.
    */
   resolveCapability(
     protocol: Protocol,
@@ -133,9 +132,8 @@ export interface IProtocolAdapterRegistry {
 
   /**
    * The provenance-preserving twin of `resolveCapability` — the same chain,
-   * but reports which level answered (definition / trait / base / none), so
-   * inspection views can attribute a detected capability instead of just
-   * serving it.
+   * but reports which source answered, so inspection views can attribute a
+   * detected capability instead of just serving it.
    */
   explainCapability(
     protocol: Protocol,

--- a/packages/agent-core-v2/src/kosong/protocol/protocol.ts
+++ b/packages/agent-core-v2/src/kosong/protocol/protocol.ts
@@ -88,6 +88,12 @@ export interface ExplainedCapability {
   readonly source: InspectionSource;
 }
 
+export interface CapabilityResolutionContext {
+  readonly catalogProvider?: string;
+  readonly catalogModel?: string;
+  readonly providerOptions?: ProtocolProviderOptions;
+}
+
 export interface IProtocolAdapterRegistry {
   readonly _serviceBrand: undefined;
 
@@ -128,6 +134,7 @@ export interface IProtocolAdapterRegistry {
     protocol: Protocol,
     modelName: string,
     providerType?: string,
+    context?: CapabilityResolutionContext,
   ): ModelCapability;
 
   /**
@@ -139,6 +146,7 @@ export interface IProtocolAdapterRegistry {
     protocol: Protocol,
     modelName: string,
     providerType?: string,
+    context?: CapabilityResolutionContext,
   ): ExplainedCapability;
 
   /**

--- a/packages/agent-core-v2/src/kosong/protocol/protocol.ts
+++ b/packages/agent-core-v2/src/kosong/protocol/protocol.ts
@@ -90,7 +90,6 @@ export interface ExplainedCapability {
 
 export interface CapabilityResolutionContext {
   readonly catalogProvider?: string;
-  readonly catalogModel?: string;
   readonly providerOptions?: ProtocolProviderOptions;
 }
 

--- a/packages/agent-core-v2/src/kosong/provider/modelCapabilityResolver.ts
+++ b/packages/agent-core-v2/src/kosong/provider/modelCapabilityResolver.ts
@@ -6,9 +6,13 @@
  */
 
 import { toDisposable, type IDisposable } from '#/_base/di/lifecycle';
-import type { ExplainedCapability, Protocol } from '#/kosong/protocol/protocol';
+import type {
+  CapabilityResolutionContext,
+  ExplainedCapability,
+  Protocol,
+} from '#/kosong/protocol/protocol';
 
-export interface ModelCapabilityQuery {
+export interface ModelCapabilityQuery extends CapabilityResolutionContext {
   readonly protocol: Protocol;
   readonly providerType?: string;
   readonly modelName: string;

--- a/packages/agent-core-v2/src/kosong/provider/modelCapabilityResolver.ts
+++ b/packages/agent-core-v2/src/kosong/provider/modelCapabilityResolver.ts
@@ -1,0 +1,41 @@
+/**
+ * `kosong/provider` domain (L2) — extension point for capability sources
+ * owned by higher layers. Resolvers run after protocol traits but before
+ * protocol-base static catalogs. Registration returns a disposable so tests
+ * and embedding hosts can restore process-global state.
+ */
+
+import { toDisposable, type IDisposable } from '#/_base/di/lifecycle';
+import type { ExplainedCapability, Protocol } from '#/kosong/protocol/protocol';
+
+export interface ModelCapabilityQuery {
+  readonly protocol: Protocol;
+  readonly providerType?: string;
+  readonly modelName: string;
+}
+
+export type ModelCapabilityResolver = (
+  query: ModelCapabilityQuery,
+) => ExplainedCapability | undefined;
+
+const resolvers: ModelCapabilityResolver[] = [];
+
+export function registerModelCapabilityResolver(
+  resolver: ModelCapabilityResolver,
+): IDisposable {
+  resolvers.push(resolver);
+  return toDisposable(() => {
+    const index = resolvers.lastIndexOf(resolver);
+    if (index >= 0) resolvers.splice(index, 1);
+  });
+}
+
+export function explainRegisteredModelCapability(
+  query: ModelCapabilityQuery,
+): ExplainedCapability | undefined {
+  for (let index = resolvers.length - 1; index >= 0; index -= 1) {
+    const explained = resolvers[index]?.(query);
+    if (explained !== undefined) return explained;
+  }
+  return undefined;
+}

--- a/packages/agent-core-v2/src/kosong/provider/protocolAdapterRegistry.ts
+++ b/packages/agent-core-v2/src/kosong/provider/protocolAdapterRegistry.ts
@@ -19,7 +19,8 @@
  *    `(protocol, providerType)`; composition needs the real config) and
  *    delegates to the registered base's contrib factory.
  *  - `resolveCapability` — the fixed fallback chain: trait capability hooks
- *    (last declarer wins) → the base's own catalog → `UNKNOWN_CAPABILITY`.
+ *    (last declarer wins) → registered external sources →
+ *    the base's own catalog → `UNKNOWN_CAPABILITY`.
  *
  * Bound at App scope, eager.
  */
@@ -44,6 +45,7 @@ import {
 } from '#/kosong/protocol/protocolBase';
 import type { ProtocolTrait, ResolvedTrait, TraitContext } from '#/kosong/protocol/protocolTrait';
 
+import { explainRegisteredModelCapability } from './modelCapabilityResolver';
 import { getProviderDefinition } from './providerDefinition';
 
 /**
@@ -123,6 +125,13 @@ export class ProtocolAdapterRegistry implements IProtocolAdapterRegistry {
         },
       };
     }
+
+    const registeredCapability = explainRegisteredModelCapability({
+      protocol,
+      providerType,
+      modelName,
+    });
+    if (registeredCapability !== undefined) return registeredCapability;
 
     const baseCapability = getProtocolBase(identity.baseId)?.capability?.(modelName);
     if (baseCapability !== undefined) {

--- a/packages/agent-core-v2/src/kosong/provider/protocolAdapterRegistry.ts
+++ b/packages/agent-core-v2/src/kosong/provider/protocolAdapterRegistry.ts
@@ -33,6 +33,7 @@ import { ChatProviderError } from '#/kosong/contract/errors';
 import type { ChatProvider } from '#/kosong/contract/provider';
 import {
   IProtocolAdapterRegistry,
+  type CapabilityResolutionContext,
   type ExplainedCapability,
   type Protocol,
   type ProtocolAdapterConfig,
@@ -98,14 +99,20 @@ export class ProtocolAdapterRegistry implements IProtocolAdapterRegistry {
     return protocol;
   }
 
-  resolveCapability(protocol: Protocol, modelName: string, providerType?: string): ModelCapability {
-    return this.explainCapability(protocol, modelName, providerType).capability;
+  resolveCapability(
+    protocol: Protocol,
+    modelName: string,
+    providerType?: string,
+    context?: CapabilityResolutionContext,
+  ): ModelCapability {
+    return this.explainCapability(protocol, modelName, providerType, context).capability;
   }
 
   explainCapability(
     protocol: Protocol,
     modelName: string,
     providerType?: string,
+    context?: CapabilityResolutionContext,
   ): ExplainedCapability {
     const identity = this.resolveAdapterIdentity(protocol, providerType);
     let traitCapability: ModelCapability | undefined;
@@ -130,6 +137,9 @@ export class ProtocolAdapterRegistry implements IProtocolAdapterRegistry {
       protocol,
       providerType,
       modelName,
+      catalogProvider: context?.catalogProvider,
+      catalogModel: context?.catalogModel,
+      providerOptions: context?.providerOptions,
     });
     if (registeredCapability !== undefined) return registeredCapability;
 

--- a/packages/agent-core-v2/src/kosong/provider/protocolAdapterRegistry.ts
+++ b/packages/agent-core-v2/src/kosong/provider/protocolAdapterRegistry.ts
@@ -138,7 +138,6 @@ export class ProtocolAdapterRegistry implements IProtocolAdapterRegistry {
       providerType,
       modelName,
       catalogProvider: context?.catalogProvider,
-      catalogModel: context?.catalogModel,
       providerOptions: context?.providerOptions,
     });
     if (registeredCapability !== undefined) return registeredCapability;

--- a/packages/agent-core-v2/src/kosong/provider/provider.ts
+++ b/packages/agent-core-v2/src/kosong/provider/provider.ts
@@ -11,7 +11,8 @@
  * enumerated at the type level. Validation happens at resolve time against
  * the provider-definition registry (`getProviderDefinition`), which is what
  * allows external packages to register new vendors without touching this
- * contract.
+ * contract. `catalogProvider` is a separate, optional models.dev provider id:
+ * it selects metadata only and never changes the wire protocol.
  *
  * Owns the `ProviderConfig` / `OAuthRef` types and the in-memory provider
  * registry contract; App-scoped. Kosong has no persistence — it defines
@@ -46,6 +47,7 @@ export interface ProviderConfig {
   baseUrl?: string;
   customHeaders?: Record<string, string>;
   defaultModel?: string;
+  catalogProvider?: string;
 
   type?: ProviderType;
   apiKey?: string;

--- a/packages/agent-core-v2/test/app/config/config.test.ts
+++ b/packages/agent-core-v2/test/app/config/config.test.ts
@@ -47,11 +47,14 @@ import {
 } from '#/agent/loop/configSection';
 import {
   MODELS_SECTION,
+  PROVIDERS_SECTION,
   SECONDARY_MODEL_EFFORT_ENV,
   SECONDARY_MODEL_ENV,
   SECONDARY_MODEL_SECTION,
   THINKING_SECTION,
 } from '#/app/kosongConfig/configSection';
+import type { ModelRecord } from '#/kosong/model/model';
+import type { ProviderConfig } from '#/kosong/provider/provider';
 import { type ThinkingConfig } from '#/kosong/model/thinking';
 import {
   KEEP_ALIVE_ON_EXIT_ENV,
@@ -405,6 +408,45 @@ describe('Agent config', () => {
 });
 
 describe('ConfigService env overlay (live)', () => {
+  it('loads explicit catalog coordinates from snake-case TOML fields', async () => {
+    const disposables = new DisposableStore();
+    const ix = disposables.add(new TestInstantiationService());
+    const storage = new InMemoryStorageService();
+    await storage.write(
+      '',
+      'config.toml',
+      new TextEncoder().encode(
+        '[providers.deepseek]\ntype = "openai"\ncatalog_provider = "deepseek"\n' +
+          '[models.production]\nprovider = "deepseek"\nmodel = "deployment-name"\n' +
+          'catalog_model = "deepseek-reasoner"\n',
+      ),
+    );
+    ix.stub(ILogService, stubLog());
+    ix.stub(IBootstrapService, stubBootstrap('/tmp/kimi-cfg'));
+    ix.stub(IFileSystemStorageService, storage);
+    ix.set(IAtomicTomlDocumentStore, new SyncDescriptor(TomlAtomicDocumentStore));
+    ix.set(IConfigRegistry, new SyncDescriptor(ConfigRegistry));
+    ix.set(IConfigService, new SyncDescriptor(ConfigService));
+    const config = ix.get(IConfigService);
+    await config.ready;
+
+    expect(
+      config.get<Record<string, ProviderConfig>>(PROVIDERS_SECTION)['deepseek'],
+    ).toMatchObject({
+      type: 'openai',
+      catalogProvider: 'deepseek',
+    });
+    expect(
+      config.get<Record<string, ModelRecord>>(MODELS_SECTION)['production'],
+    ).toMatchObject({
+      provider: 'deepseek',
+      model: 'deployment-name',
+      catalogModel: 'deepseek-reasoner',
+    });
+
+    disposables.dispose();
+  });
+
   it('re-applies env bindings on every get()', async () => {
     const env: Record<string, string> = { KIMI_DISABLE_CRON: '0' };
     const disposables = new DisposableStore();

--- a/packages/agent-core-v2/test/app/config/config.test.ts
+++ b/packages/agent-core-v2/test/app/config/config.test.ts
@@ -408,7 +408,7 @@ describe('Agent config', () => {
 });
 
 describe('ConfigService env overlay (live)', () => {
-  it('loads explicit catalog coordinates from snake-case TOML fields', async () => {
+  it('loads an explicit catalog provider from snake-case TOML', async () => {
     const disposables = new DisposableStore();
     const ix = disposables.add(new TestInstantiationService());
     const storage = new InMemoryStorageService();
@@ -417,8 +417,7 @@ describe('ConfigService env overlay (live)', () => {
       'config.toml',
       new TextEncoder().encode(
         '[providers.deepseek]\ntype = "openai"\ncatalog_provider = "deepseek"\n' +
-          '[models.production]\nprovider = "deepseek"\nmodel = "deployment-name"\n' +
-          'catalog_model = "deepseek-reasoner"\n',
+          '[models.production]\nprovider = "deepseek"\nmodel = "deepseek-reasoner"\n',
       ),
     );
     ix.stub(ILogService, stubLog());
@@ -440,8 +439,7 @@ describe('ConfigService env overlay (live)', () => {
       config.get<Record<string, ModelRecord>>(MODELS_SECTION)['production'],
     ).toMatchObject({
       provider: 'deepseek',
-      model: 'deployment-name',
-      catalogModel: 'deepseek-reasoner',
+      model: 'deepseek-reasoner',
     });
 
     disposables.dispose();

--- a/packages/agent-core-v2/test/app/kosongConfig/modelsDevImport.test.ts
+++ b/packages/agent-core-v2/test/app/kosongConfig/modelsDevImport.test.ts
@@ -6,6 +6,8 @@
  *    `provider.catalog_entry_not_found`;
  *  - a failed upstream fetch with no built-in snapshot throws
  *    `provider.catalog_unavailable`;
+ *  - capability lookup prefers exact keys, normalizes platform model ids,
+ *    and leaves misses to lower fallback sources;
  *  - `importModelsDevProvider` writes the provider + model aliases through
  *    `config.replace` (never the default pointers), keeps the stored api_key
  *    on a re-import without one, and rejects OAuth-managed providers and
@@ -21,6 +23,7 @@ import { afterEach, describe, expect, it } from 'vitest';
 import { createScopedTestHost } from '#/_base/di/test';
 import { Error2, isError2 } from '#/_base/errors/errors';
 import { IConfigService } from '#/app/config/config';
+import { getModelsDevModelCapability } from '#/app/kosongConfig/modelsDev';
 import {
   resetModelsDevUpstreamForTest,
   setModelsDevUpstreamForTest,
@@ -100,6 +103,104 @@ const REGISTRY_DOC = {
     },
   },
 } as const;
+
+describe('getModelsDevModelCapability', () => {
+  it('prefers an exact model key over normalized variants', () => {
+    const catalog = {
+      anthropic: {
+        models: {
+          'claude-example': {
+            id: 'claude-example',
+            limit: { context: 100_000 },
+            modalities: { input: ['text'], output: ['text'] },
+          },
+          'claude-example-20260724': {
+            id: 'claude-example-20260724',
+            limit: { context: 200_000 },
+            reasoning: true,
+            modalities: { input: ['text'], output: ['text'] },
+          },
+        },
+      },
+    };
+
+    expect(
+      getModelsDevModelCapability(catalog, 'anthropic', 'claude-example-20260724'),
+    ).toMatchObject({
+      providerId: 'anthropic',
+      capability: { thinking: true, max_context_tokens: 200_000 },
+    });
+  });
+
+  it('normalizes platform model ids', () => {
+    const catalog = {
+      anthropic: {
+        models: {
+          'claude-example': {
+            id: 'claude-example',
+            limit: { context: 200_000 },
+            tool_call: true,
+            modalities: { input: ['text', 'image'], output: ['text'] },
+          },
+        },
+      },
+    };
+
+    expect(
+      getModelsDevModelCapability(
+        catalog,
+        'anthropic',
+        'us.anthropic.claude-example-v1:0',
+      ),
+    ).toMatchObject({
+      providerId: 'anthropic',
+      capability: { image_in: true, tool_use: true },
+    });
+  });
+
+  it('preserves an explicit date while normalizing a platform model id', () => {
+    const match = getModelsDevModelCapability(
+      {
+        anthropic: {
+          models: {
+            'claude-example-20250101': {
+              id: 'claude-example-20250101',
+              limit: { context: 200_000 },
+              modalities: { input: ['text', 'image'], output: ['text'] },
+            },
+            'claude-example-20250202': {
+              id: 'claude-example-20250202',
+              limit: { context: 200_000 },
+              modalities: { input: ['text', 'audio'], output: ['text'] },
+            },
+          },
+        },
+      },
+      'anthropic',
+      'us.anthropic.claude-example-20250202-v1:0',
+    );
+
+    expect(match).toMatchObject({
+      providerId: 'anthropic',
+      capability: { image_in: false, audio_in: true },
+    });
+  });
+
+  it('leaves a miss unresolved', () => {
+    const catalog = {
+      anthropic: {
+        models: {
+          'claude-example': {
+            id: 'claude-example',
+            limit: { context: 200_000 },
+          },
+        },
+      },
+    };
+
+    expect(getModelsDevModelCapability(catalog, 'openai', 'claude-example')).toBeUndefined();
+  });
+});
 
 function fetchJson(doc: unknown): typeof fetch {
   return (async () =>

--- a/packages/agent-core-v2/test/app/kosongConfig/modelsDevImport.test.ts
+++ b/packages/agent-core-v2/test/app/kosongConfig/modelsDevImport.test.ts
@@ -23,7 +23,10 @@ import { afterEach, describe, expect, it } from 'vitest';
 import { createScopedTestHost } from '#/_base/di/test';
 import { Error2, isError2 } from '#/_base/errors/errors';
 import { IConfigService } from '#/app/config/config';
-import { getModelsDevModelCapability } from '#/app/kosongConfig/modelsDev';
+import {
+  getModelsDevModelCapability,
+  resolveModelsDevCapabilityProvider,
+} from '#/app/kosongConfig/modelsDev';
 import {
   resetModelsDevUpstreamForTest,
   setModelsDevUpstreamForTest,
@@ -202,6 +205,38 @@ describe('getModelsDevModelCapability', () => {
   });
 });
 
+describe('resolveModelsDevCapabilityProvider', () => {
+  it('uses an explicit catalog provider before protocol defaults', () => {
+    expect(
+      resolveModelsDevCapabilityProvider({
+        protocol: 'openai',
+        providerType: 'openai',
+        catalogProvider: 'deepseek',
+      }),
+    ).toBe('deepseek');
+  });
+
+  it('maps compatible protocols to their official catalog providers', () => {
+    expect(resolveModelsDevCapabilityProvider({ protocol: 'openai' })).toBe('openai');
+    expect(
+      resolveModelsDevCapabilityProvider({
+        protocol: 'openai',
+        providerType: 'kimi',
+      }),
+    ).toBe('moonshotai');
+  });
+
+  it('uses the Vertex catalog when the google-genai provider runs in Vertex mode', () => {
+    expect(
+      resolveModelsDevCapabilityProvider({
+        protocol: 'google-genai',
+        providerType: 'google-genai',
+        vertexai: true,
+      }),
+    ).toBe('google-vertex');
+  });
+});
+
 function fetchJson(doc: unknown): typeof fetch {
   return (async () =>
     new Response(JSON.stringify(doc), {
@@ -320,6 +355,7 @@ describe('IModelsDevImportService', () => {
     const providers = config.inspect<ProvidersSection>(PROVIDERS_SECTION).userValue ?? {};
     expect(providers['openai']).toMatchObject({
       type: 'openai',
+      catalogProvider: 'openai',
       baseUrl: 'https://api.openai.com/v1',
       apiKey: 'sk-test',
     });

--- a/packages/agent-core-v2/test/kosong/model/catalog.test.ts
+++ b/packages/agent-core-v2/test/kosong/model/catalog.test.ts
@@ -319,7 +319,7 @@ describe('Model assembly (pure data)', () => {
     }
   });
 
-  it('passes Vertex mode and explicit catalog coordinates to capability sources', () => {
+  it('passes Vertex mode and explicit catalog provider to capability sources', () => {
     let captured: ModelCapabilityQuery | undefined;
     const registration = registerModelCapabilityResolver((query) => {
       captured = query;
@@ -346,8 +346,7 @@ describe('Model assembly (pure data)', () => {
       models: {
         v: {
           provider: 'vertex',
-          model: 'deployment-name',
-          catalogModel: 'gemini-canonical',
+          model: 'gemini-canonical',
           maxContextSize: 1_000,
         },
       },
@@ -358,9 +357,8 @@ describe('Model assembly (pure data)', () => {
       expect(captured).toMatchObject({
         protocol: 'google-genai',
         providerType: 'google-genai',
-        modelName: 'deployment-name',
+        modelName: 'gemini-canonical',
         catalogProvider: 'google-vertex',
-        catalogModel: 'gemini-canonical',
         providerOptions: {
           vertexai: true,
           project: 'my-project',

--- a/packages/agent-core-v2/test/kosong/model/catalog.test.ts
+++ b/packages/agent-core-v2/test/kosong/model/catalog.test.ts
@@ -33,6 +33,7 @@ import '#/kosong/provider/bases/anthropic/index';
 import '#/kosong/provider/bases/google-genai/index';
 import '#/kosong/provider/bases/openai/index';
 import '#/kosong/provider/protocolAdapterRegistry';
+import { registerModelCapabilityResolver } from '#/kosong/provider/modelCapabilityResolver';
 import '#/kosong/provider/providers/kimi/kimi.contrib';
 import '#/kosong/provider/providers/standard.contrib';
 import {
@@ -513,6 +514,78 @@ describe('headers merge order', () => {
 });
 
 describe('ModelCatalog inspect', () => {
+  it('attributes snapshot false values to the snapshot instead of none', () => {
+    const registration = registerModelCapabilityResolver(({ modelName }) =>
+      modelName === 'gpt-4o'
+        ? {
+            capability: {
+              image_in: false,
+              video_in: false,
+              audio_in: true,
+              thinking: false,
+              tool_use: false,
+              max_context_tokens: 128_000,
+            },
+            source: { kind: 'builtin', detail: 'test models.dev snapshot' },
+          }
+        : undefined,
+    );
+    const { host, catalog } = createHost({
+      providers: { openai: { type: 'openai', apiKey: 'sk-test' } },
+      models: {
+        model: { provider: 'openai', model: 'gpt-4o', maxContextSize: 128_000 },
+      },
+    });
+    try {
+      const view = catalog.inspect('model');
+      expect(view.resolved.capabilities.image_in).toBe(false);
+      expect(view.sources['resolved.capabilities.image_in']).toMatchObject({
+        kind: 'builtin',
+        detail: 'test models.dev snapshot',
+      });
+    } finally {
+      host.dispose();
+      registration.dispose();
+    }
+  });
+
+  it('attributes a user capability above a snapshot false value', () => {
+    const registration = registerModelCapabilityResolver(({ modelName }) =>
+      modelName === 'gpt-4o'
+        ? {
+            capability: {
+              image_in: false,
+              video_in: false,
+              audio_in: false,
+              thinking: false,
+              tool_use: false,
+              max_context_tokens: 128_000,
+            },
+            source: { kind: 'builtin', detail: 'test models.dev snapshot' },
+          }
+        : undefined,
+    );
+    const { host, catalog } = createHost({
+      providers: { openai: { type: 'openai', apiKey: 'sk-test' } },
+      models: {
+        model: {
+          provider: 'openai',
+          model: 'gpt-4o',
+          maxContextSize: 128_000,
+          capabilities: ['image_in'],
+        },
+      },
+    });
+    try {
+      const view = catalog.inspect('model');
+      expect(view.resolved.capabilities.image_in).toBe(true);
+      expect(view.sources['resolved.capabilities.image_in']).toMatchObject({ kind: 'config' });
+    } finally {
+      host.dispose();
+      registration.dispose();
+    }
+  });
+
   it('builds the god object with per-field provenance (kimi structured model)', () => {
     const { host, catalog } = createHost(kimiSections);
     try {

--- a/packages/agent-core-v2/test/kosong/model/catalog.test.ts
+++ b/packages/agent-core-v2/test/kosong/model/catalog.test.ts
@@ -33,7 +33,10 @@ import '#/kosong/provider/bases/anthropic/index';
 import '#/kosong/provider/bases/google-genai/index';
 import '#/kosong/provider/bases/openai/index';
 import '#/kosong/provider/protocolAdapterRegistry';
-import { registerModelCapabilityResolver } from '#/kosong/provider/modelCapabilityResolver';
+import {
+  type ModelCapabilityQuery,
+  registerModelCapabilityResolver,
+} from '#/kosong/provider/modelCapabilityResolver';
 import '#/kosong/provider/providers/kimi/kimi.contrib';
 import '#/kosong/provider/providers/standard.contrib';
 import {
@@ -313,6 +316,60 @@ describe('Model assembly (pure data)', () => {
       expect(catalog.get('g').providerOptions).toBeUndefined();
     } finally {
       host.dispose();
+    }
+  });
+
+  it('passes Vertex mode and explicit catalog coordinates to capability sources', () => {
+    let captured: ModelCapabilityQuery | undefined;
+    const registration = registerModelCapabilityResolver((query) => {
+      captured = query;
+      return {
+        capability: {
+          image_in: true,
+          video_in: false,
+          audio_in: false,
+          thinking: true,
+          tool_use: true,
+          max_context_tokens: 1_000,
+        },
+        source: { kind: 'builtin', detail: 'test catalog source' },
+      };
+    });
+    const { host, catalog } = createHost({
+      providers: {
+        vertex: {
+          type: 'google-genai',
+          catalogProvider: 'google-vertex',
+          env: { GOOGLE_CLOUD_PROJECT: 'my-project', GOOGLE_CLOUD_LOCATION: 'us-central1' },
+        },
+      },
+      models: {
+        v: {
+          provider: 'vertex',
+          model: 'deployment-name',
+          catalogModel: 'gemini-canonical',
+          maxContextSize: 1_000,
+        },
+      },
+    });
+
+    try {
+      expect(catalog.get('v').capabilities.thinking).toBe(true);
+      expect(captured).toMatchObject({
+        protocol: 'google-genai',
+        providerType: 'google-genai',
+        modelName: 'deployment-name',
+        catalogProvider: 'google-vertex',
+        catalogModel: 'gemini-canonical',
+        providerOptions: {
+          vertexai: true,
+          project: 'my-project',
+          location: 'us-central1',
+        },
+      });
+    } finally {
+      host.dispose();
+      registration.dispose();
     }
   });
 

--- a/packages/agent-core-v2/test/kosong/provider/composition.test.ts
+++ b/packages/agent-core-v2/test/kosong/provider/composition.test.ts
@@ -344,7 +344,6 @@ describe('resolveCapability', () => {
     try {
       registry.resolveCapability('google-genai', 'deployment-name', 'google-genai', {
         catalogProvider: 'google-vertex',
-        catalogModel: 'gemini-canonical',
         providerOptions: { vertexai: true, project: 'example-project' },
       });
       expect(captured).toMatchObject({
@@ -352,7 +351,6 @@ describe('resolveCapability', () => {
         providerType: 'google-genai',
         modelName: 'deployment-name',
         catalogProvider: 'google-vertex',
-        catalogModel: 'gemini-canonical',
         providerOptions: { vertexai: true, project: 'example-project' },
       });
     } finally {

--- a/packages/agent-core-v2/test/kosong/provider/composition.test.ts
+++ b/packages/agent-core-v2/test/kosong/provider/composition.test.ts
@@ -333,6 +333,32 @@ describe('resolveCapability', () => {
       registration.dispose();
     }
   });
+
+  it('forwards explicit catalog identity and provider mode to capability sources', () => {
+    let captured: Parameters<Parameters<typeof registerModelCapabilityResolver>[0]>[0] | undefined;
+    const registration = registerModelCapabilityResolver((query) => {
+      captured = query;
+      return undefined;
+    });
+
+    try {
+      registry.resolveCapability('google-genai', 'deployment-name', 'google-genai', {
+        catalogProvider: 'google-vertex',
+        catalogModel: 'gemini-canonical',
+        providerOptions: { vertexai: true, project: 'example-project' },
+      });
+      expect(captured).toMatchObject({
+        protocol: 'google-genai',
+        providerType: 'google-genai',
+        modelName: 'deployment-name',
+        catalogProvider: 'google-vertex',
+        catalogModel: 'gemini-canonical',
+        providerOptions: { vertexai: true, project: 'example-project' },
+      });
+    } finally {
+      registration.dispose();
+    }
+  });
 });
 
 describe('explainCapability', () => {

--- a/packages/agent-core-v2/test/kosong/provider/composition.test.ts
+++ b/packages/agent-core-v2/test/kosong/provider/composition.test.ts
@@ -60,6 +60,7 @@ import '#/kosong/provider/bases/openai/index';
 import { OpenAIResponsesChatProvider } from '#/kosong/provider/bases/openai/openai-responses';
 import { OpenAILegacyChatProvider } from '#/kosong/provider/bases/openai/openai-legacy';
 import { ProtocolAdapterRegistry } from '#/kosong/provider/protocolAdapterRegistry';
+import { registerModelCapabilityResolver } from '#/kosong/provider/modelCapabilityResolver';
 import {
   getProviderDefinition,
   getProviderDefinitions,
@@ -304,6 +305,33 @@ describe('resolveCapability', () => {
       true,
     );
     expect(registry.resolveCapability('openai', 'gpt-4o', 'kimi').image_in).toBe(true);
+  });
+
+  it('uses a registered capability source before the base catalog', () => {
+    const registration = registerModelCapabilityResolver(({ modelName }) =>
+      modelName === 'gpt-4o'
+        ? {
+            capability: {
+              image_in: false,
+              video_in: false,
+              audio_in: true,
+              thinking: false,
+              tool_use: false,
+              max_context_tokens: 128_000,
+            },
+            source: { kind: 'builtin', detail: 'test catalog snapshot' },
+          }
+        : undefined,
+    );
+
+    try {
+      expect(registry.resolveCapability('openai', 'gpt-4o')).toMatchObject({
+        image_in: false,
+        audio_in: true,
+      });
+    } finally {
+      registration.dispose();
+    }
   });
 });
 

--- a/packages/agent-core/src/config/schema.ts
+++ b/packages/agent-core/src/config/schema.ts
@@ -26,6 +26,7 @@ const StringRecordSchema = z.record(z.string(), z.string());
 
 export const ProviderConfigSchema = z.object({
   type: ProviderTypeSchema,
+  catalogProvider: z.string().min(1).optional(),
   apiKey: z.string().optional(),
   baseUrl: z.string().optional(),
   defaultModel: z.string().optional(),
@@ -40,6 +41,7 @@ export type ProviderConfig = z.infer<typeof ProviderConfigSchema>;
 const ModelAliasBaseSchema = z.object({
   provider: z.string(),
   model: z.string(),
+  catalogModel: z.string().min(1).optional(),
   maxContextSize: z.number().int().min(1),
   // Declared prompt/input cap when below the total window (e.g. gpt-5: 400k
   // window, 272k input). Compaction and other prompt-budget checks prefer it
@@ -78,6 +80,7 @@ const ModelAliasBaseSchema = z.object({
 export const ModelAliasOverrideSchema = ModelAliasBaseSchema.omit({
   provider: true,
   model: true,
+  catalogModel: true,
   protocol: true,
   betaApi: true,
   baseUrl: true,

--- a/packages/agent-core/src/config/schema.ts
+++ b/packages/agent-core/src/config/schema.ts
@@ -41,7 +41,6 @@ export type ProviderConfig = z.infer<typeof ProviderConfigSchema>;
 const ModelAliasBaseSchema = z.object({
   provider: z.string(),
   model: z.string(),
-  catalogModel: z.string().min(1).optional(),
   maxContextSize: z.number().int().min(1),
   // Declared prompt/input cap when below the total window (e.g. gpt-5: 400k
   // window, 272k input). Compaction and other prompt-budget checks prefer it
@@ -80,7 +79,6 @@ const ModelAliasBaseSchema = z.object({
 export const ModelAliasOverrideSchema = ModelAliasBaseSchema.omit({
   provider: true,
   model: true,
-  catalogModel: true,
   protocol: true,
   betaApi: true,
   baseUrl: true,

--- a/packages/agent-core/src/session/built-in-catalog.ts
+++ b/packages/agent-core/src/session/built-in-catalog.ts
@@ -1,0 +1,27 @@
+/**
+ * Lazily parses the models.dev snapshot injected into the final CLI bundle.
+ * Package builds and source tests have no injected value and return undefined.
+ */
+
+import type { Catalog } from '@moonshot-ai/kosong';
+
+declare const __KIMI_CODE_BUILT_IN_CATALOG__: string | undefined;
+
+let catalog: Catalog | undefined | null = null;
+
+export function loadBuiltInCatalog(): Catalog | undefined {
+  if (catalog !== null) return catalog;
+  if (
+    typeof __KIMI_CODE_BUILT_IN_CATALOG__ !== 'string' ||
+    __KIMI_CODE_BUILT_IN_CATALOG__.length === 0
+  ) {
+    catalog = undefined;
+    return catalog;
+  }
+  try {
+    catalog = JSON.parse(__KIMI_CODE_BUILT_IN_CATALOG__) as Catalog;
+  } catch {
+    catalog = undefined;
+  }
+  return catalog;
+}

--- a/packages/agent-core/src/session/provider-manager.ts
+++ b/packages/agent-core/src/session/provider-manager.ts
@@ -24,6 +24,15 @@ import { ErrorCodes, isKimiError, KimiError } from '../errors';
 
 import { loadBuiltInCatalog } from './built-in-catalog';
 
+const DEFAULT_CATALOG_PROVIDER_BY_TYPE: Readonly<Partial<Record<ProviderType, string>>> = {
+  anthropic: 'anthropic',
+  openai: 'openai',
+  openai_responses: 'openai',
+  'google-genai': 'google',
+  vertexai: 'google-vertex',
+  kimi: 'moonshotai',
+};
+
 export interface BearerTokenProvider {
   getAccessToken(options?: { readonly force?: boolean }): Promise<string>;
 }
@@ -158,7 +167,12 @@ export class ProviderManager implements ModelProvider {
     return {
       providerName,
       provider,
-      modelCapabilities: resolveModelCapabilities(effectiveAlias, provider, this.catalog),
+      modelCapabilities: resolveModelCapabilities(
+        effectiveAlias,
+        provider,
+        this.catalog,
+        providerConfig.catalogProvider ?? DEFAULT_CATALOG_PROVIDER_BY_TYPE[providerConfig.type],
+      ),
       alwaysThinking: (effectiveAlias.capabilities ?? []).some(
         (c) => c.trim().toLowerCase() === 'always_thinking',
       ),
@@ -249,10 +263,13 @@ function resolveModelCapabilities(
   alias: ModelAlias,
   provider: KosongProviderConfig,
   catalog?: Catalog,
+  catalogProvider?: string,
 ): ModelCapability {
   const declared = new Set((alias.capabilities ?? []).map((c) => c.trim().toLowerCase()));
   const detected =
-    getCatalogModelCapability(catalog, provider.type, provider.model) ??
+    (catalogProvider === undefined
+      ? undefined
+      : getCatalogModelCapability(catalog, catalogProvider, alias.catalogModel ?? provider.model)) ??
     getModelCapability(provider.type, provider.model);
 
   return {

--- a/packages/agent-core/src/session/provider-manager.ts
+++ b/packages/agent-core/src/session/provider-manager.ts
@@ -269,7 +269,7 @@ function resolveModelCapabilities(
   const detected =
     (catalogProvider === undefined
       ? undefined
-      : getCatalogModelCapability(catalog, catalogProvider, alias.catalogModel ?? provider.model)) ??
+      : getCatalogModelCapability(catalog, catalogProvider, provider.model)) ??
     getModelCapability(provider.type, provider.model);
 
   return {

--- a/packages/agent-core/src/session/provider-manager.ts
+++ b/packages/agent-core/src/session/provider-manager.ts
@@ -1,6 +1,16 @@
 import type { Logger } from '#/logging/types';
-import type { ProviderConfig as KosongProviderConfig, ModelCapability, ProviderRequestAuth } from '@moonshot-ai/kosong';
-import { APIStatusError, getModelCapability, UNKNOWN_CAPABILITY } from '@moonshot-ai/kosong';
+import type {
+  Catalog,
+  ProviderConfig as KosongProviderConfig,
+  ModelCapability,
+  ProviderRequestAuth,
+} from '@moonshot-ai/kosong';
+import {
+  APIStatusError,
+  getCatalogModelCapability,
+  getModelCapability,
+  UNKNOWN_CAPABILITY,
+} from '@moonshot-ai/kosong';
 import { parseKimiCodeCustomHeaders } from '@moonshot-ai/kimi-code-oauth';
 import {
   effectiveModelAlias,
@@ -11,6 +21,8 @@ import {
   type ProviderType,
 } from '../config';
 import { ErrorCodes, isKimiError, KimiError } from '../errors';
+
+import { loadBuiltInCatalog } from './built-in-catalog';
 
 export interface BearerTokenProvider {
   getAccessToken(options?: { readonly force?: boolean }): Promise<string>;
@@ -38,6 +50,7 @@ export interface ResolvedRuntimeProvider {
 
 interface ProviderManagerOptions {
   readonly config: KimiConfig | (() => KimiConfig);
+  readonly catalog?: Catalog | (() => Catalog | undefined);
   readonly kimiRequestHeaders?: Record<string, string>;
   readonly resolveOAuthTokenProvider?: OAuthTokenProviderResolver;
   readonly promptCacheKey?: string;
@@ -82,6 +95,11 @@ export class SingleModelProvider implements ModelProvider {
 
 export class ProviderManager implements ModelProvider {
   constructor(private readonly options: ProviderManagerOptions) {}
+
+  private get catalog(): Catalog | undefined {
+    const { catalog = loadBuiltInCatalog } = this.options;
+    return typeof catalog === 'function' ? catalog() : catalog;
+  }
 
   private get config(): KimiConfig {
     const { config } = this.options;
@@ -140,7 +158,7 @@ export class ProviderManager implements ModelProvider {
     return {
       providerName,
       provider,
-      modelCapabilities: resolveModelCapabilities(effectiveAlias, provider),
+      modelCapabilities: resolveModelCapabilities(effectiveAlias, provider, this.catalog),
       alwaysThinking: (effectiveAlias.capabilities ?? []).some(
         (c) => c.trim().toLowerCase() === 'always_thinking',
       ),
@@ -230,9 +248,12 @@ export class ProviderManager implements ModelProvider {
 function resolveModelCapabilities(
   alias: ModelAlias,
   provider: KosongProviderConfig,
+  catalog?: Catalog,
 ): ModelCapability {
   const declared = new Set((alias.capabilities ?? []).map((c) => c.trim().toLowerCase()));
-  const detected = getModelCapability(provider.type, provider.model);
+  const detected =
+    getCatalogModelCapability(catalog, provider.type, provider.model) ??
+    getModelCapability(provider.type, provider.model);
 
   return {
     image_in: declared.has('image_in') || detected.image_in,

--- a/packages/agent-core/test/config/configs.test.ts
+++ b/packages/agent-core/test/config/configs.test.ts
@@ -71,6 +71,7 @@ theme = "dark"
 
 [providers."managed:kimi-code"]
 type = "kimi"
+catalog_provider = "moonshotai"
 base_url = "https://api.kimi.com/coding/v1"
 api_key = "sk-file"
 custom_headers = { "X-Test" = "1" }
@@ -81,6 +82,7 @@ GOOGLE_CLOUD_PROJECT = "project-1"
 [models."kimi-code/kimi-for-coding"]
 provider = "managed:kimi-code"
 model = "kimi-for-coding"
+catalog_model = "kimi-k3"
 max_context_size = 262144
 capabilities = ["image_in", "thinking", "video_in"]
 display_name = "Kimi for Coding"
@@ -163,6 +165,7 @@ describe('harness config TOML loader', () => {
     expect(config.telemetry).toBe(false);
     expect(config.providers['managed:kimi-code']).toMatchObject({
       type: 'kimi',
+      catalogProvider: 'moonshotai',
       baseUrl: 'https://api.kimi.com/coding/v1',
       apiKey: 'sk-file',
       env: { GOOGLE_CLOUD_PROJECT: 'project-1' },
@@ -171,6 +174,7 @@ describe('harness config TOML loader', () => {
     expect(config.models?.['kimi-code/kimi-for-coding']).toMatchObject({
       provider: 'managed:kimi-code',
       model: 'kimi-for-coding',
+      catalogModel: 'kimi-k3',
       maxContextSize: 262144,
       capabilities: ['image_in', 'thinking', 'video_in'],
       displayName: 'Kimi for Coding',
@@ -370,6 +374,8 @@ removed_flag = true
     const text = await readFile(configPath, 'utf-8');
     expect(text).toContain('default_model = "kimi-code/kimi-for-coding"');
     expect(text).toContain('default_permission_mode = "auto"');
+    expect(text).toContain('catalog_provider = "moonshotai"');
+    expect(text).toContain('catalog_model = "kimi-k3"');
     expect(text).toContain('extra_skill_dirs = [ "~/team-skills", ".agents/team-skills" ]');
     expect(text).toContain('telemetry = false');
     expect(text).not.toContain('default_yolo');

--- a/packages/agent-core/test/config/configs.test.ts
+++ b/packages/agent-core/test/config/configs.test.ts
@@ -82,7 +82,6 @@ GOOGLE_CLOUD_PROJECT = "project-1"
 [models."kimi-code/kimi-for-coding"]
 provider = "managed:kimi-code"
 model = "kimi-for-coding"
-catalog_model = "kimi-k3"
 max_context_size = 262144
 capabilities = ["image_in", "thinking", "video_in"]
 display_name = "Kimi for Coding"
@@ -174,7 +173,6 @@ describe('harness config TOML loader', () => {
     expect(config.models?.['kimi-code/kimi-for-coding']).toMatchObject({
       provider: 'managed:kimi-code',
       model: 'kimi-for-coding',
-      catalogModel: 'kimi-k3',
       maxContextSize: 262144,
       capabilities: ['image_in', 'thinking', 'video_in'],
       displayName: 'Kimi for Coding',
@@ -375,7 +373,6 @@ removed_flag = true
     expect(text).toContain('default_model = "kimi-code/kimi-for-coding"');
     expect(text).toContain('default_permission_mode = "auto"');
     expect(text).toContain('catalog_provider = "moonshotai"');
-    expect(text).toContain('catalog_model = "kimi-k3"');
     expect(text).toContain('extra_skill_dirs = [ "~/team-skills", ".agents/team-skills" ]');
     expect(text).toContain('telemetry = false');
     expect(text).not.toContain('default_yolo');

--- a/packages/agent-core/test/harness/runtime-provider.test.ts
+++ b/packages/agent-core/test/harness/runtime-provider.test.ts
@@ -149,6 +149,53 @@ describe('resolveRuntimeProvider model metadata', () => {
     });
   });
 
+  it('uses explicit catalog coordinates for an OpenAI-compatible provider', () => {
+    const resolved = resolveRuntimeProvider({
+      config: {
+        ...BASE_CONFIG,
+        providers: {
+          deepseek: {
+            type: 'openai',
+            catalogProvider: 'deepseek',
+            apiKey: 'test-key',
+          },
+        },
+        models: {
+          custom: {
+            provider: 'deepseek',
+            model: 'production-reasoner',
+            catalogModel: 'deepseek-reasoner',
+            maxContextSize: 128_000,
+          },
+        },
+      },
+      model: 'custom',
+      catalog: {
+        deepseek: {
+          models: {
+            'deepseek-reasoner': {
+              id: 'deepseek-reasoner',
+              limit: { context: 128_000 },
+              reasoning: true,
+              tool_call: true,
+              modalities: { input: ['text'], output: ['text'] },
+            },
+          },
+        },
+      },
+    });
+
+    expect(resolved.provider).toMatchObject({
+      type: 'openai',
+      model: 'production-reasoner',
+    });
+    expect(resolved.modelCapabilities).toMatchObject({
+      thinking: true,
+      tool_use: true,
+      max_context_tokens: 128_000,
+    });
+  });
+
   it('falls back to the legacy static table when the catalog misses', () => {
     const resolved = resolveRuntimeProvider({
       config: {

--- a/packages/agent-core/test/harness/runtime-provider.test.ts
+++ b/packages/agent-core/test/harness/runtime-provider.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest';
+import type { Catalog } from '@moonshot-ai/kosong';
 
 import type { KimiConfig, ModelAlias } from '../../src/config';
 import { ErrorCodes, KimiError } from '../../src/errors';
@@ -13,9 +14,11 @@ function resolveRuntimeProvider(input: {
   readonly model?: string;
   readonly kimiRequestHeaders?: Record<string, string>;
   readonly promptCacheKey?: string;
+  readonly catalog?: Catalog;
 }): ReturnType<ProviderManager['resolveProviderConfig']> {
   const manager = new ProviderManager({
     config: input.config,
+    catalog: input.catalog,
     kimiRequestHeaders: input.kimiRequestHeaders,
     promptCacheKey: input.promptCacheKey,
   });
@@ -106,6 +109,104 @@ describe('resolveRuntimeProvider model metadata', () => {
       tool_use: true,
       max_context_tokens: 200000,
     });
+  });
+
+  it('uses catalog capabilities before the legacy static table', () => {
+    const resolved = resolveRuntimeProvider({
+      config: {
+        ...BASE_CONFIG,
+        providers: {
+          openai: { type: 'openai', apiKey: 'test-key' },
+        },
+        models: {
+          custom: {
+            provider: 'openai',
+            model: 'gpt-4o',
+            maxContextSize: 123_456,
+          },
+        },
+      },
+      model: 'custom',
+      catalog: {
+        openai: {
+          models: {
+            'gpt-4o': {
+              id: 'gpt-4o',
+              limit: { context: 128_000 },
+              tool_call: false,
+              modalities: { input: ['text', 'audio'], output: ['text'] },
+            },
+          },
+        },
+      },
+    });
+
+    expect(resolved.modelCapabilities).toMatchObject({
+      image_in: false,
+      audio_in: true,
+      tool_use: false,
+      max_context_tokens: 123_456,
+    });
+  });
+
+  it('falls back to the legacy static table when the catalog misses', () => {
+    const resolved = resolveRuntimeProvider({
+      config: {
+        ...BASE_CONFIG,
+        providers: {
+          openai: { type: 'openai', apiKey: 'test-key' },
+        },
+        models: {
+          custom: {
+            provider: 'openai',
+            model: 'gpt-4o',
+            maxContextSize: 128_000,
+          },
+        },
+      },
+      model: 'custom',
+      catalog: {},
+    });
+
+    expect(resolved.modelCapabilities).toMatchObject({
+      image_in: true,
+      tool_use: true,
+      max_context_tokens: 128_000,
+    });
+  });
+
+  it('keeps user-declared capabilities above the catalog snapshot', () => {
+    const resolved = resolveRuntimeProvider({
+      config: {
+        ...BASE_CONFIG,
+        providers: {
+          anthropic: { type: 'anthropic', apiKey: 'test-key' },
+        },
+        models: {
+          custom: {
+            provider: 'anthropic',
+            model: 'claude-example',
+            maxContextSize: 200_000,
+            capabilities: ['tool_use'],
+          },
+        },
+      },
+      model: 'custom',
+      catalog: {
+        anthropic: {
+          models: {
+            'claude-example': {
+              id: 'claude-example',
+              limit: { context: 200_000 },
+              tool_call: false,
+              modalities: { input: ['text'], output: ['text'] },
+            },
+          },
+        },
+      },
+    });
+
+    expect(resolved.modelCapabilities.tool_use).toBe(true);
   });
 
   it('uses config Kimi capabilities without requiring an api key during OAuth setup', () => {

--- a/packages/agent-core/test/harness/runtime-provider.test.ts
+++ b/packages/agent-core/test/harness/runtime-provider.test.ts
@@ -149,7 +149,7 @@ describe('resolveRuntimeProvider model metadata', () => {
     });
   });
 
-  it('uses explicit catalog coordinates for an OpenAI-compatible provider', () => {
+  it('uses an explicit catalog provider for an OpenAI-compatible provider', () => {
     const resolved = resolveRuntimeProvider({
       config: {
         ...BASE_CONFIG,
@@ -163,8 +163,7 @@ describe('resolveRuntimeProvider model metadata', () => {
         models: {
           custom: {
             provider: 'deepseek',
-            model: 'production-reasoner',
-            catalogModel: 'deepseek-reasoner',
+            model: 'deepseek-reasoner',
             maxContextSize: 128_000,
           },
         },
@@ -187,7 +186,7 @@ describe('resolveRuntimeProvider model metadata', () => {
 
     expect(resolved.provider).toMatchObject({
       type: 'openai',
-      model: 'production-reasoner',
+      model: 'deepseek-reasoner',
     });
     expect(resolved.modelCapabilities).toMatchObject({
       thinking: true,

--- a/packages/kosong/src/catalog.ts
+++ b/packages/kosong/src/catalog.ts
@@ -103,6 +103,14 @@ const KNOWN_WIRE_TYPES = [
   'vertexai',
 ] as const satisfies readonly ProviderType[];
 
+const CATALOG_CAPABILITY_PROVIDER_IDS: Partial<Record<ProviderType, readonly string[]>> = {
+  anthropic: ['anthropic'],
+  openai: ['openai'],
+  openai_responses: ['openai'],
+  'google-genai': ['google'],
+  vertexai: ['google-vertex', 'google-vertex-anthropic'],
+};
+
 function isWireType(value: unknown): value is ProviderType {
   return typeof value === 'string' && (KNOWN_WIRE_TYPES as readonly string[]).includes(value);
 }
@@ -433,6 +441,65 @@ export function catalogProviderModels(entry: CatalogProviderEntry): CatalogModel
       }
       return model;
     });
+}
+
+function normalizeCatalogPlatformKey(key: string): string {
+  return key
+    .toLowerCase()
+    .replace(/^(?:us|eu|apac|global)\./, '')
+    .replace(/^(?:anthropic|ai21|amazon|cohere|deepseek|meta|mistral|writer)\./, '')
+    .replace(/-v\d+(?::\d+)?$/, '');
+}
+
+function normalizeCatalogDeploymentKey(key: string): string {
+  return normalizeCatalogPlatformKey(key).replace(/@.*$/, '');
+}
+
+function normalizeCatalogFamilyKey(key: string): string {
+  return normalizeCatalogDeploymentKey(key)
+    .replace(/-\d{8}$/, '')
+    .replace(/-\d{4}-\d{2}-\d{2}$/, '');
+}
+
+/**
+ * Looks up a model's capability in a models.dev-style catalog snapshot.
+ * Exact keys win over normalized platform variants. A miss stays undefined
+ * so runtime callers can continue to their built-in table.
+ */
+export function getCatalogModelCapability(
+  catalog: Catalog | undefined,
+  wire: ProviderType,
+  modelName: string,
+): ModelCapability | undefined {
+  if (catalog === undefined) return undefined;
+  const providerIds = CATALOG_CAPABILITY_PROVIDER_IDS[wire];
+  if (providerIds === undefined) return undefined;
+  for (const providerId of providerIds) {
+    const models = catalog[providerId]?.models;
+    if (models === undefined) continue;
+    const exact = models[modelName] ?? models[modelName.toLowerCase()];
+    if (exact !== undefined) {
+      const model = catalogModelToCapability(exact);
+      if (model !== undefined) return model.capability;
+    }
+  }
+  for (const normalize of [
+    normalizeCatalogPlatformKey,
+    normalizeCatalogDeploymentKey,
+    normalizeCatalogFamilyKey,
+  ]) {
+    const target = normalize(modelName);
+    for (const providerId of providerIds) {
+      const models = catalog[providerId]?.models;
+      if (models === undefined) continue;
+      for (const [key, entry] of Object.entries(models)) {
+        if (normalize(key) !== target) continue;
+        const model = catalogModelToCapability(entry);
+        if (model !== undefined) return model.capability;
+      }
+    }
+  }
+  return undefined;
 }
 
 /**

--- a/packages/kosong/src/catalog.ts
+++ b/packages/kosong/src/catalog.ts
@@ -103,14 +103,6 @@ const KNOWN_WIRE_TYPES = [
   'vertexai',
 ] as const satisfies readonly ProviderType[];
 
-const CATALOG_CAPABILITY_PROVIDER_IDS: Partial<Record<ProviderType, readonly string[]>> = {
-  anthropic: ['anthropic'],
-  openai: ['openai'],
-  openai_responses: ['openai'],
-  'google-genai': ['google'],
-  vertexai: ['google-vertex', 'google-vertex-anthropic'],
-};
-
 function isWireType(value: unknown): value is ProviderType {
   return typeof value === 'string' && (KNOWN_WIRE_TYPES as readonly string[]).includes(value);
 }
@@ -468,20 +460,16 @@ function normalizeCatalogFamilyKey(key: string): string {
  */
 export function getCatalogModelCapability(
   catalog: Catalog | undefined,
-  wire: ProviderType,
+  providerId: string,
   modelName: string,
 ): ModelCapability | undefined {
   if (catalog === undefined) return undefined;
-  const providerIds = CATALOG_CAPABILITY_PROVIDER_IDS[wire];
-  if (providerIds === undefined) return undefined;
-  for (const providerId of providerIds) {
-    const models = catalog[providerId]?.models;
-    if (models === undefined) continue;
-    const exact = models[modelName] ?? models[modelName.toLowerCase()];
-    if (exact !== undefined) {
-      const model = catalogModelToCapability(exact);
-      if (model !== undefined) return model.capability;
-    }
+  const models = catalog[providerId]?.models;
+  if (models === undefined) return undefined;
+  const exact = models[modelName] ?? models[modelName.toLowerCase()];
+  if (exact !== undefined) {
+    const model = catalogModelToCapability(exact);
+    if (model !== undefined) return model.capability;
   }
   for (const normalize of [
     normalizeCatalogPlatformKey,
@@ -489,14 +477,10 @@ export function getCatalogModelCapability(
     normalizeCatalogFamilyKey,
   ]) {
     const target = normalize(modelName);
-    for (const providerId of providerIds) {
-      const models = catalog[providerId]?.models;
-      if (models === undefined) continue;
-      for (const [key, entry] of Object.entries(models)) {
-        if (normalize(key) !== target) continue;
-        const model = catalogModelToCapability(entry);
-        if (model !== undefined) return model.capability;
-      }
+    for (const [key, entry] of Object.entries(models)) {
+      if (normalize(key) !== target) continue;
+      const model = catalogModelToCapability(entry);
+      if (model !== undefined) return model.capability;
     }
   }
   return undefined;

--- a/packages/kosong/src/index.ts
+++ b/packages/kosong/src/index.ts
@@ -40,6 +40,7 @@ export type { ModelCapability } from './capability';
 // Model catalog (models.dev-style) metadata
 export {
   catalogBaseUrl,
+  getCatalogModelCapability,
   catalogModelToCapability,
   catalogProviderModels,
   inferWireType,

--- a/packages/kosong/test/catalog.test.ts
+++ b/packages/kosong/test/catalog.test.ts
@@ -651,7 +651,7 @@ describe('getCatalogModelCapability', () => {
     expect(capability).toMatchObject({ image_in: false, audio_in: true });
   });
 
-  it('returns undefined for an unmapped wire', () => {
+  it('returns undefined for an unknown provider id', () => {
     const catalog = {
       anthropic: {
         models: {
@@ -663,7 +663,7 @@ describe('getCatalogModelCapability', () => {
       },
     };
 
-    expect(getCatalogModelCapability(catalog, 'kimi', 'claude-example')).toBeUndefined();
+    expect(getCatalogModelCapability(catalog, 'missing-provider', 'claude-example')).toBeUndefined();
   });
 });
 

--- a/packages/kosong/test/catalog.test.ts
+++ b/packages/kosong/test/catalog.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'vitest';
 import {
   adaptBaseUrlForWire,
   catalogBaseUrl,
+  getCatalogModelCapability,
   catalogModelToCapability,
   catalogProviderModels,
   inferWireType,
@@ -572,6 +573,97 @@ describe('catalogModelToCapability', () => {
     expect(
       catalogModelToCapability({ id: 'new', status: 'beta', limit: { context: 1000 } })?.id,
     ).toBe('new');
+  });
+});
+
+describe('getCatalogModelCapability', () => {
+  it('prefers an exact model key over normalized platform variants', () => {
+    const capability = getCatalogModelCapability(
+      {
+        anthropic: {
+          models: {
+            'claude-example': {
+              id: 'claude-example',
+              limit: { context: 100_000 },
+              modalities: { input: ['text'], output: ['text'] },
+            },
+            'claude-example-20260724': {
+              id: 'claude-example-20260724',
+              limit: { context: 200_000 },
+              reasoning: true,
+              modalities: { input: ['text'], output: ['text'] },
+            },
+          },
+        },
+      },
+      'anthropic',
+      'claude-example-20260724',
+    );
+
+    expect(capability).toMatchObject({ thinking: true, max_context_tokens: 200_000 });
+  });
+
+  it('normalizes Bedrock model ids', () => {
+    const catalog = {
+      anthropic: {
+        models: {
+          'claude-example': {
+            id: 'claude-example',
+            limit: { context: 200_000 },
+            tool_call: true,
+            modalities: { input: ['text', 'image'], output: ['text'] },
+          },
+        },
+      },
+    };
+
+    expect(
+      getCatalogModelCapability(
+        catalog,
+        'anthropic',
+        'us.anthropic.claude-example-v1:0',
+      ),
+    ).toMatchObject({ image_in: true, tool_use: true });
+  });
+
+  it('preserves an explicit date while normalizing a Bedrock model id', () => {
+    const capability = getCatalogModelCapability(
+      {
+        anthropic: {
+          models: {
+            'claude-example-20250101': {
+              id: 'claude-example-20250101',
+              limit: { context: 200_000 },
+              modalities: { input: ['text', 'image'], output: ['text'] },
+            },
+            'claude-example-20250202': {
+              id: 'claude-example-20250202',
+              limit: { context: 200_000 },
+              modalities: { input: ['text', 'audio'], output: ['text'] },
+            },
+          },
+        },
+      },
+      'anthropic',
+      'us.anthropic.claude-example-20250202-v1:0',
+    );
+
+    expect(capability).toMatchObject({ image_in: false, audio_in: true });
+  });
+
+  it('returns undefined for an unmapped wire', () => {
+    const catalog = {
+      anthropic: {
+        models: {
+          'claude-example': {
+            id: 'claude-example',
+            limit: { context: 200_000 },
+          },
+        },
+      },
+    };
+
+    expect(getCatalogModelCapability(catalog, 'kimi', 'claude-example')).toBeUndefined();
   });
 });
 

--- a/packages/node-sdk/src/catalog.ts
+++ b/packages/node-sdk/src/catalog.ts
@@ -133,6 +133,7 @@ export function applyCatalogProvider(
 ): { defaultModel: string } {
   config.providers[options.providerId] = {
     type: options.wire,
+    catalogProvider: options.providerId,
     baseUrl: options.baseUrl,
     apiKey: options.apiKey,
   };

--- a/packages/node-sdk/test/catalog.test.ts
+++ b/packages/node-sdk/test/catalog.test.ts
@@ -106,7 +106,11 @@ describe('applyCatalogProvider', () => {
     });
 
     expect(result.defaultModel).toBe('anthropic/m1');
-    expect(config.providers['anthropic']).toMatchObject({ type: 'anthropic', apiKey: 'sk' });
+    expect(config.providers['anthropic']).toMatchObject({
+      type: 'anthropic',
+      catalogProvider: 'anthropic',
+      apiKey: 'sk',
+    });
     expect(config.models?.['anthropic/m1']).toMatchObject({
       provider: 'anthropic',
       model: 'm1',


### PR DESCRIPTION
## Related issue

Related: #2023

Follow-up to #2036, where the model catalog review exposed that thinking profiles and general capabilities can drift independently. This also carries the capability-fallback direction from #1660 onto the current v1/v2 architecture.

@RealKai42, could you take a look since this follows the catalog/capability review in #2036?

## Problem

When a configured model does not declare every capability, runtime detection can fall through to hand-maintained static matchers even though the bundled models.dev snapshot already has the metadata.

Protocol identity is not enough to choose the right catalog provider. For example, the provider in #2023 must use `type = "openai"` to speak the OpenAI-compatible protocol, but its capability metadata belongs under the `deepseek` provider in models.dev. Treating `type` as both protocol and catalog vendor either misses the metadata or requires unsafe guessing.

## What changed

- Add an optional `catalog_provider` to provider config. It selects the exact models.dev provider used for capability metadata without changing the API protocol selected by `type`.
- Keep the compatibility policy deliberately narrow:
  - an explicit `catalog_provider` wins;
  - official provider types use their known models.dev provider by default;
  - the configured `model` is looked up only within that provider;
  - Kimi Code never guesses from the local provider name or scans unrelated vendors;
  - existing static matchers remain the final fallback before `UNKNOWN`.
- Persist the original models.dev provider id when `/provider` imports a catalog entry, including when the user chooses a different local provider name.
- Pass the catalog provider and resolved provider mode through the v2 capability resolver. Existing `google-genai` configurations running in Vertex mode now use the `google-vertex` snapshot instead of the ordinary Google snapshot.
- Keep context/input/output limits owned by model configuration; the snapshot fallback only supplies model capabilities.
- Document the new field and the exact DeepSeek configuration from #2023 in both locales.

For the manual setup in #2023, adding `catalog_provider = "deepseek"` selects the right metadata while keeping `type = "openai"`. If a gateway replaces the canonical models.dev model id with an arbitrary deployment alias, the user must continue to declare capabilities explicitly.

## Verification

- After the final simplification, 313 focused `agent-core` / `agent-core-v2` tests passed.
- Typechecks passed for `agent-core`, `agent-core-v2`, `node-sdk`, and the CLI.
- `agent-core-v2` domain lint and config-manifest check passed.
- The bilingual docs build passed.
- A read-only final diff audit confirmed that the removed model-level catalog override no longer appears in the schema, runtime, manifest, tests, or docs, while `catalog_provider` remains intact.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.
