### PR TITLE
fix(nix): validate leaf workspaces in flake sync check

### DIFF
--- a/.github/workflows/nix-build.yml
+++ b/.github/workflows/nix-build.yml
@@ -40,7 +40,7 @@ jobs:
             echo "<!-- nix-workspace-sync-bot -->"
             echo "❌ flake.nix workspace lists out of sync"
             echo ""
-            echo "The recursive workspace dependencies of \`apps/kimi-code\` do not match \`flake.nix\`. Please run \`node scripts/check-nix-workspace.mjs\` locally for details."
+            echo "One or more pnpm workspace packages are missing from \`flake.nix\`. Please run \`node scripts/check-nix-workspace.mjs\` locally for details."
             echo ""
             echo "Typical fix: add the missing package name to \`workspaceNames\` and its path to \`workspacePaths\` in \`flake.nix\`."
             echo "EOF"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,7 +42,7 @@ This is a TypeScript monorepo built for agent-assisted development. Keep the roo
   - `pnpm-workspace.yaml` uses globs (`packages/*`, `apps/*`), so most packages land there automatically; `flake.nix` is fully manual and is where omissions happen.
   - Missing a path in `flake.nix`'s `workspacePaths` will silently drop files from the Nix build's `src` fileset.
   - Missing a name in `flake.nix`'s `workspaceNames` will break `pnpmConfigHook` because dependencies for that workspace will not be fetched.
-- The automated "Check flake.nix workspace sync" (`scripts/check-nix-workspace.mjs`) only validates the transitive dependency **closure of `@moonshot-ai/kimi-code`**. A leaf package outside that closure (e.g. an e2e package nobody imports) slips through even when it is missing from `flake.nix`. A green check is therefore NOT proof that `flake.nix` is fully in sync — keep it updated by hand on every add/remove, do not rely on the check to catch omissions.
+- The automated "Check flake.nix workspace sync" (`scripts/check-nix-workspace.mjs`) validates that every named workspace discovered from `pnpm-workspace.yaml` appears in both `workspaceNames` and `workspacePaths`. It catches missing Nix entries but does not reject stale extra entries, so keep both lists updated when packages are removed.
 
 ## General Coding Rules
 

--- a/apps/kimi-code/test/scripts/check-nix-workspace.test.ts
+++ b/apps/kimi-code/test/scripts/check-nix-workspace.test.ts
@@ -1,0 +1,77 @@
+import { spawnSync } from 'node:child_process';
+import {
+  copyFileSync,
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+const REPO_ROOT = resolve(import.meta.dirname, '../../../..');
+const CHECK_SCRIPT = join(REPO_ROOT, 'scripts/check-nix-workspace.mjs');
+
+function writeWorkspacePackage(root: string, path: string, name: string) {
+  const packageDir = join(root, path);
+  mkdirSync(packageDir, { recursive: true });
+  writeFileSync(
+    join(packageDir, 'package.json'),
+    `${JSON.stringify({ name, private: true }, null, 2)}\n`,
+  );
+}
+
+describe('check-nix-workspace.mjs', () => {
+  it('rejects a leaf workspace missing from flake.nix', () => {
+    const fixtureRoot = mkdtempSync(join(tmpdir(), 'kimi-code-nix-workspace-'));
+
+    try {
+      const fixtureScript = join(
+        fixtureRoot,
+        'scripts/check-nix-workspace.mjs',
+      );
+      mkdirSync(join(fixtureRoot, 'scripts'), { recursive: true });
+      copyFileSync(CHECK_SCRIPT, fixtureScript);
+
+      writeFileSync(
+        join(fixtureRoot, 'pnpm-workspace.yaml'),
+        ['packages:', '  - apps/*', '  - packages/*', ''].join('\n'),
+      );
+      writeWorkspacePackage(
+        fixtureRoot,
+        'apps/kimi-code',
+        '@moonshot-ai/kimi-code',
+      );
+      writeWorkspacePackage(
+        fixtureRoot,
+        'packages/leaf-package',
+        '@moonshot-ai/leaf-package',
+      );
+      writeFileSync(
+        join(fixtureRoot, 'flake.nix'),
+        `{
+  workspacePaths = [
+    ./apps/kimi-code
+  ];
+  workspaceNames = [
+    "@moonshot-ai/kimi-code"
+  ];
+}
+`,
+      );
+
+      const result = spawnSync(process.execPath, [fixtureScript], {
+        cwd: fixtureRoot,
+        encoding: 'utf8',
+      });
+
+      expect(result.status).toBe(1);
+      expect(result.stderr).toContain('@moonshot-ai/leaf-package');
+      expect(result.stderr).toContain('./packages/leaf-package');
+    } finally {
+      rmSync(fixtureRoot, { recursive: true, force: true });
+    }
+  });
+});

--- a/scripts/check-nix-workspace.mjs
+++ b/scripts/check-nix-workspace.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 /**
- * Recursively resolve workspace dependencies starting from apps/kimi-code
- * and verify they are all present in flake.nix workspaceNames/workspacePaths.
+ * Verify every named pnpm workspace is present in flake.nix
+ * workspaceNames/workspacePaths.
  *
  * Exit code 0 if everything is in sync, 1 otherwise.
  */
@@ -11,7 +11,6 @@ import { resolve, join } from "node:path";
 
 const ROOT = resolve(import.meta.dirname, "..");
 const FLAKE_NIX = join(ROOT, "flake.nix");
-const START_PKG = "@moonshot-ai/kimi-code";
 
 /**
  * Parse pnpm-workspace.yaml to get workspace directory globs.
@@ -81,46 +80,6 @@ function buildWorkspaceMap(dirs) {
 }
 
 /**
- * Recursively collect all workspace dependencies (transitive closure).
- */
-function resolveWorkspaceDeps(workspaceMap, startName) {
-  const visited = new Set();
-  const closure = new Set();
-
-  function visit(name) {
-    if (visited.has(name)) return;
-    visited.add(name);
-
-    const dir = workspaceMap.get(name);
-    if (!dir) return;
-
-    const pkgPath = join(ROOT, dir, "package.json");
-    const pkg = JSON.parse(readFileSync(pkgPath, "utf8"));
-    const depSections = [
-      pkg.dependencies,
-      pkg.devDependencies,
-      pkg.peerDependencies,
-    ];
-
-    for (const section of depSections) {
-      if (!section) continue;
-      for (const [depName, specifier] of Object.entries(section)) {
-        if (
-          typeof specifier === "string" &&
-          (specifier.includes("workspace") || specifier.startsWith("link:"))
-        ) {
-          closure.add(depName);
-          visit(depName);
-        }
-      }
-    }
-  }
-
-  visit(startName);
-  return closure;
-}
-
-/**
  * Parse workspaceNames and workspacePaths from flake.nix.
  */
 function parseFlakeNix() {
@@ -162,36 +121,23 @@ function main() {
   const dirs = expandGlobsSafe(globs);
   const workspaceMap = buildWorkspaceMap(dirs);
 
-  if (!workspaceMap.has(START_PKG)) {
-    console.error(`Start package ${START_PKG} not found in workspace.`);
-    process.exit(1);
-  }
-
-  const closure = resolveWorkspaceDeps(workspaceMap, START_PKG);
   /** @type {string[]} */
-  const closureNames = [...closure].sort((a, b) => a.localeCompare(b));
+  const workspaceNames = [...workspaceMap.keys()].sort((a, b) =>
+    a.localeCompare(b)
+  );
 
   const flake = parseFlakeNix();
   const flakeNameSet = new Set(flake.names);
   const flakePathSet = new Set(flake.paths);
 
-  const missingNames = closureNames.filter((n) => !flakeNameSet.has(n));
+  const missingNames = workspaceNames.filter((n) => !flakeNameSet.has(n));
   /** @type {Array<{name: string, path: string}>} */
   const missingPaths = [];
-  for (const name of closureNames) {
+  for (const name of workspaceNames) {
     const dir = workspaceMap.get(name);
     if (dir && !flakePathSet.has(`./${dir}`)) {
       missingPaths.push({ name, path: `./${dir}` });
     }
-  }
-
-  // Also check that the start package itself is in flake.nix
-  if (!flakeNameSet.has(START_PKG)) {
-    missingNames.unshift(START_PKG);
-  }
-  const startDir = workspaceMap.get(START_PKG);
-  if (startDir && !flakePathSet.has(`./${startDir}`)) {
-    missingPaths.unshift({ name: START_PKG, path: `./${startDir}` });
   }
 
   const ok = missingNames.length === 0 && missingPaths.length === 0;
@@ -234,7 +180,7 @@ function main() {
   }
 
   console.log(
-    `✅ All ${closureNames.length} recursive workspace dependencies are present in flake.nix.`
+    `✅ All ${workspaceNames.length} workspace packages are present in flake.nix.`
   );
 }
 


### PR DESCRIPTION
## Related Issue

No linked issue — this is a focused CI/build validation bug already documented in `AGENTS.md`.

## Problem

`pnpm-workspace.yaml` is the source of truth for workspace membership, while `flake.nix` maintains matching hardcoded `workspacePaths` and `workspaceNames` lists.

`scripts/check-nix-workspace.mjs` currently validates only the transitive workspace dependency closure of `@moonshot-ai/kimi-code`. A leaf workspace that is not referenced by the CLI can therefore be omitted from `flake.nix` while the workspace-sync check still exits successfully.

That false green can leave workspace files out of the Nix source set or leave `pnpmConfigHook` without the workspace dependency metadata it needs.

## What changed

- Validate every named workspace discovered from `pnpm-workspace.yaml`, rather than only the CLI dependency closure.
- Add a black-box regression test with an unreferenced leaf workspace omitted from `flake.nix`.
- Update the Nix workflow comment and repository maintenance guidance to describe the expanded check.

The existing workspace discovery, `flake.nix` parsing, error format, and success/failure exit codes remain unchanged.

This intentionally checks for pnpm workspaces missing from `flake.nix`; it does not reject stale extra entries that exist only in `flake.nix`.

## Verification

- [x] `pnpm -C apps/kimi-code exec vitest run test/scripts/check-nix-workspace.test.ts` (fails on the old implementation with `result.status` 0 instead of 1; passes after the fix)
- [x] `node scripts/check-nix-workspace.mjs` (`✅ All 23 workspace packages are present in flake.nix.`)
- [x] `pnpm lint` (0 errors)
- [x] `pnpm typecheck`
- [x] `pnpm test` — 2 pre-existing failures in `packages/kosong/test/e2e/google-genai-adapter.test.ts` and `google-genai-error-mapping.test.ts`; both reproduce identically on a clean `upstream/main` checkout and are unrelated to this diff. All other tests pass (15247 passed).
- [x] `git diff --check`

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove the fix works.
- [x] Ran `gen-changesets`, or this PR needs no changeset.
- [x] Ran `gen-docs`, or this PR needs no user-facing documentation update.
