### PR TITLE
fix(oauth): switch default model on explicit login

### DIFF
--- a/.changeset/fix-oauth-login-default-model.md
+++ b/.changeset/fix-oauth-login-default-model.md
@@ -1,0 +1,6 @@
+---
+"@moonshot-ai/kimi-code": patch
+"@moonshot-ai/kimi-code-sdk": patch
+---
+
+Fix OAuth login retaining an API key model as the default after switching back to Kimi Code.

--- a/packages/node-sdk/test/auth-facade.test.ts
+++ b/packages/node-sdk/test/auth-facade.test.ts
@@ -203,8 +203,23 @@ oauth = { storage = "file", key = "${oauthKey}", oauth_host = "https://auth.dev.
     });
   });
 
-  it('provisions SDK config using an existing Kimi OAuth token', async () => {
+  it('switches an API default when logging in with an existing Kimi OAuth token', async () => {
     await new FileTokenStorage(join(homeDir, 'credentials')).save('kimi-code', freshToken());
+    await writeFile(
+      join(homeDir, 'config.toml'),
+      `
+default_model = "api-provider/api-model"
+
+[providers.api-provider]
+type = "kimi"
+api_key = "YOUR_API_KEY"
+
+[models."api-provider/api-model"]
+provider = "api-provider"
+model = "api-model"
+max_context_size = 262144
+`,
+    );
     const fetchMock = vi.fn<FetchMock>(
       async (_input, _init) =>
         new Response(
@@ -257,6 +272,10 @@ oauth = { storage = "file", key = "${oauthKey}", oauth_host = "https://auth.dev.
       type: 'kimi',
       apiKey: '',
       oauth: { storage: 'file', key: 'oauth/kimi-code' },
+    });
+    expect(config.providers['api-provider']).toMatchObject({ apiKey: 'YOUR_API_KEY' });
+    expect(config.models?.['api-provider/api-model']).toMatchObject({
+      provider: 'api-provider',
     });
     expect(config.services?.moonshotSearch?.oauth).toEqual({
       storage: 'file',

--- a/packages/oauth/src/managed-kimi-code.ts
+++ b/packages/oauth/src/managed-kimi-code.ts
@@ -200,6 +200,7 @@ export interface ManagedKimiConfigAdapter<TConfig> {
       readonly oauthKey?: string | undefined;
       readonly oauthHost?: string | undefined;
       readonly preserveDefaultModel?: boolean | undefined;
+      readonly preserveNonManagedDefaultModel?: boolean;
     },
   ): ManagedKimiCodeApplyResult;
   remove?(config: TConfig): void;
@@ -213,6 +214,7 @@ export interface ProvisionManagedKimiCodeConfigOptions<TConfig> {
   readonly oauthKey?: string | undefined;
   readonly oauthHost?: string | undefined;
   readonly preserveDefaultModel?: boolean | undefined;
+  readonly preserveNonManagedDefaultModel?: boolean;
   readonly fetchImpl?: typeof fetch | undefined;
   readonly headers?: Record<string, string> | undefined;
 }
@@ -568,6 +570,7 @@ export function applyManagedKimiCodeConfig(
     readonly oauthKey?: string | undefined;
     readonly oauthHost?: string | undefined;
     readonly preserveDefaultModel?: boolean | undefined;
+    readonly preserveNonManagedDefaultModel?: boolean;
   },
 ): ManagedKimiCodeApplyResult {
   if (options.models.length === 0) {
@@ -585,6 +588,7 @@ export function applyManagedKimiCodeConfig(
   const existingModels = config.models ?? {};
   const selectedDefault = selectDefaultModel(config, options.models, {
     preserveExisting: options.preserveDefaultModel === true,
+    preserveNonManaged: options.preserveNonManagedDefaultModel !== false,
   });
 
   config.providers[KIMI_CODE_PROVIDER_NAME] = {
@@ -734,7 +738,10 @@ function forcedThinking(
 function selectDefaultModel(
   config: ManagedKimiConfigShape,
   models: readonly ManagedKimiCodeModelInfo[],
-  options: { readonly preserveExisting: boolean },
+  options: {
+    readonly preserveExisting: boolean;
+    readonly preserveNonManaged: boolean;
+  },
 ): SelectedDefaultModel {
   const firstModel = models[0];
   if (firstModel === undefined) {
@@ -751,7 +758,12 @@ function selectDefaultModel(
   if (
     options.preserveExisting &&
     currentDefault !== undefined &&
-    canPreserveDefaultModel(existingModels, currentDefault, managedModels)
+    canPreserveDefaultModel(
+      existingModels,
+      currentDefault,
+      managedModels,
+      options.preserveNonManaged,
+    )
   ) {
     const preservedModel = managedModels.get(currentDefault);
     return {
@@ -773,8 +785,10 @@ function canPreserveDefaultModel(
   existingModels: Record<string, ManagedKimiModelAlias | Record<string, unknown>>,
   defaultModel: string,
   managedModels: ReadonlyMap<string, ManagedKimiCodeModelInfo>,
+  preserveNonManaged: boolean,
 ): boolean {
   if (managedModels.has(defaultModel)) return true;
+  if (!preserveNonManaged) return false;
   const existing = existingModels[defaultModel];
   return isRecord(existing) && existing['provider'] !== KIMI_CODE_PROVIDER_NAME;
 }
@@ -846,6 +860,7 @@ export async function provisionManagedKimiCodeConfig<TConfig>(
     oauthKey: options.oauthKey,
     oauthHost: options.oauthHost,
     preserveDefaultModel: options.preserveDefaultModel,
+    preserveNonManagedDefaultModel: options.preserveNonManagedDefaultModel,
   });
   await options.adapter.write(config);
   return {

--- a/packages/oauth/src/toolkit.ts
+++ b/packages/oauth/src/toolkit.ts
@@ -195,7 +195,7 @@ export class KimiOAuthToolkit<TConfig = unknown> {
           preserveDefaultModel: hadToken,
           // Re-login keeps an existing managed model selection, but must not
           // leave another provider as default after Kimi Code was selected.
-          preserveNonManagedDefaultModel: false,
+          preserveNonManagedDefaultModel: name !== KIMI_CODE_PROVIDER_NAME,
           fetchImpl: this.fetchImpl,
           headers: this.identityHeaders(),
         });

--- a/packages/oauth/src/toolkit.ts
+++ b/packages/oauth/src/toolkit.ts
@@ -193,6 +193,9 @@ export class KimiOAuthToolkit<TConfig = unknown> {
           oauthKey,
           oauthHost,
           preserveDefaultModel: hadToken,
+          // Re-login keeps an existing managed model selection, but must not
+          // leave another provider as default after Kimi Code was selected.
+          preserveNonManagedDefaultModel: false,
           fetchImpl: this.fetchImpl,
           headers: this.identityHeaders(),
         });

--- a/packages/oauth/test/managed-kimi-code.test.ts
+++ b/packages/oauth/test/managed-kimi-code.test.ts
@@ -1023,6 +1023,7 @@ describe('supports_thinking_type', () => {
       accessToken: 'oauth-access-token',
       fetchImpl: vi.fn(async () => makeThinkingTypeModelsResponse()) as unknown as typeof fetch,
       preserveDefaultModel: true,
+      preserveNonManagedDefaultModel: false,
       adapter: {
         read: () => config,
         write: vi.fn(),

--- a/packages/oauth/test/toolkit.test.ts
+++ b/packages/oauth/test/toolkit.test.ts
@@ -332,7 +332,18 @@ describe('KimiOAuthToolkit', () => {
     expect(write).toHaveBeenCalledWith(config);
   });
 
-  it('replaces an existing API default during login', async () => {
+  it.each([
+    {
+      description: 'replaces an existing API default during Kimi Code login',
+      providerName: undefined,
+      expectedDefaultModel: 'kimi-code/kimi-for-coding',
+    },
+    {
+      description: 'preserves an existing API default during another provider login',
+      providerName: 'custom-provider',
+      expectedDefaultModel: 'api-provider/api-model',
+    },
+  ])('$description', async ({ providerName, expectedDefaultModel }) => {
     const storage = new MemoryTokenStorage();
     const fetchImpl = vi.fn(async () => managedModelsResponse()) as unknown as typeof fetch;
     const config: ManagedKimiConfigShape = {
@@ -365,12 +376,12 @@ describe('KimiOAuthToolkit', () => {
     });
 
     storage.tokens.set('kimi-code', token('access-1'));
-    await expect(toolkit.login()).resolves.toMatchObject({
+    await expect(toolkit.login(providerName)).resolves.toMatchObject({
       provision: {
-        defaultModel: 'kimi-code/kimi-for-coding',
+        defaultModel: expectedDefaultModel,
       },
     });
-    expect(config.defaultModel).toBe('kimi-code/kimi-for-coding');
+    expect(config.defaultModel).toBe(expectedDefaultModel);
   });
 
   it.each([401, 402])(

--- a/packages/oauth/test/toolkit.test.ts
+++ b/packages/oauth/test/toolkit.test.ts
@@ -332,6 +332,47 @@ describe('KimiOAuthToolkit', () => {
     expect(write).toHaveBeenCalledWith(config);
   });
 
+  it('replaces an existing API default during login', async () => {
+    const storage = new MemoryTokenStorage();
+    const fetchImpl = vi.fn(async () => managedModelsResponse()) as unknown as typeof fetch;
+    const config: ManagedKimiConfigShape = {
+      providers: {
+        'api-provider': {
+          type: 'kimi',
+          apiKey: 'YOUR_API_KEY',
+        },
+      },
+      defaultModel: 'api-provider/api-model',
+      models: {
+        'api-provider/api-model': {
+          provider: 'api-provider',
+          model: 'api-model',
+          maxContextSize: 262144,
+        },
+      },
+    };
+    const toolkit = new KimiOAuthToolkit({
+      homeDir: join('/tmp', 'kimi-oauth-toolkit-test'),
+      identity: TEST_IDENTITY,
+      storage,
+      now: () => 100,
+      fetchImpl,
+      configAdapter: {
+        read: () => config,
+        write: vi.fn(),
+        apply: applyManagedKimiCodeConfig,
+      },
+    });
+
+    storage.tokens.set('kimi-code', token('access-1'));
+    await expect(toolkit.login()).resolves.toMatchObject({
+      provision: {
+        defaultModel: 'kimi-code/kimi-for-coding',
+      },
+    });
+    expect(config.defaultModel).toBe('kimi-code/kimi-for-coding');
+  });
+
   it.each([401, 402])(
     'force-refreshes a stored token when managed model provisioning rejects cached auth with HTTP %i',
     async (status) => {


### PR DESCRIPTION
## Related Issue

Resolves #2151

## Problem

After switching from Kimi Code OAuth to an API key, selecting Kimi Code OAuth from `/login` in a new session can leave the API key model as the default. The login appears successful, but requests continue to use the API key until the user logs out first.

## What changed

- Preserve the current default during an explicit OAuth login only when it is still a valid managed Kimi Code model.
- Replace a non-managed API default when the user explicitly selects Kimi Code OAuth.
- Keep background model refresh behavior unchanged so it does not replace defaults from other providers.
- Add OAuth toolkit and SDK regression coverage for the persisted-token scenario while verifying that the existing API provider configuration is retained.
- Add patch changesets for the CLI and SDK. No public API signatures were changed.

## Verification

- `vitest run packages/oauth/test/toolkit.test.ts packages/oauth/test/managed-kimi-code.test.ts packages/node-sdk/test/auth-facade.test.ts` — 84 tests passed.
- `pnpm run build`
- `pnpm run lint`
- `pnpm run sherif`
- CI-equivalent `tsgo` checks for the OAuth and SDK packages.

No documentation update is needed because this fix restores the existing provider-selection behavior and introduces no new command, option, or configuration.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.
