### PR TITLE
fix(kosong): clamp uncached OpenAI input usage

### DIFF
--- a/.changeset/calm-usage-count.md
+++ b/.changeset/calm-usage-count.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Prevent partial OpenAI-compatible usage reports from producing negative uncached input token counts.

--- a/packages/agent-core-v2/src/kosong/provider/bases/openai/openai-common.ts
+++ b/packages/agent-core-v2/src/kosong/provider/bases/openai/openai-common.ts
@@ -172,7 +172,7 @@ export function extractUsage(usage: unknown): TokenUsage | null {
   }
 
   return {
-    inputOther: promptTokens - cached,
+    inputOther: Math.max(promptTokens - cached, 0),
     output: completionTokens,
     inputCacheRead: cached,
     inputCacheCreation: 0,

--- a/packages/agent-core-v2/src/kosong/provider/bases/openai/openai-responses.ts
+++ b/packages/agent-core-v2/src/kosong/provider/bases/openai/openai-responses.ts
@@ -705,7 +705,7 @@ export class OpenAIResponsesStreamedMessage implements StreamedMessage {
     const details = readObjectField(usage, 'input_tokens_details');
     const cached = details ? (readNumberField(details, 'cached_tokens') ?? 0) : 0;
     this._usage = {
-      inputOther: inputTokens - cached,
+      inputOther: Math.max(inputTokens - cached, 0),
       output: outputTokens,
       inputCacheRead: cached,
       inputCacheCreation: 0,

--- a/packages/agent-core-v2/test/kosong/provider/composition.test.ts
+++ b/packages/agent-core-v2/test/kosong/provider/composition.test.ts
@@ -57,7 +57,11 @@ import {
 import '#/kosong/provider/bases/google-genai/index';
 import { GoogleGenAIChatProvider } from '#/kosong/provider/bases/google-genai/google-genai';
 import '#/kosong/provider/bases/openai/index';
-import { OpenAIResponsesChatProvider } from '#/kosong/provider/bases/openai/openai-responses';
+import { extractUsage } from '#/kosong/provider/bases/openai/openai-common';
+import {
+  OpenAIResponsesChatProvider,
+  OpenAIResponsesStreamedMessage,
+} from '#/kosong/provider/bases/openai/openai-responses';
 import { OpenAILegacyChatProvider } from '#/kosong/provider/bases/openai/openai-legacy';
 import { ProtocolAdapterRegistry } from '#/kosong/provider/protocolAdapterRegistry';
 import {
@@ -661,6 +665,46 @@ async function captureResponsesBody(
   if (captured === undefined) throw new Error('expected responses.create to be called');
   return captured;
 }
+
+describe('OpenAI usage normalization', () => {
+  it('keeps Chat Completions uncached input non-negative when cached tokens lack a prompt total', () => {
+    expect(
+      extractUsage({
+        completion_tokens: 5,
+        prompt_tokens_details: { cached_tokens: 10 },
+      }),
+    ).toEqual({
+      inputOther: 0,
+      output: 5,
+      inputCacheRead: 10,
+      inputCacheCreation: 0,
+    });
+  });
+
+  it('keeps Responses uncached input non-negative when cached tokens lack an input total', async () => {
+    const stream = new OpenAIResponsesStreamedMessage(
+      {
+        id: 'resp_partial_usage',
+        status: 'completed',
+        output: [],
+        usage: {
+          output_tokens: 5,
+          input_tokens_details: { cached_tokens: 10 },
+        },
+      },
+      false,
+    );
+
+    await drain(stream);
+
+    expect(stream.usage).toEqual({
+      inputOther: 0,
+      output: 5,
+      inputCacheRead: 10,
+      inputCacheCreation: 0,
+    });
+  });
+});
 
 describe('per-turn intent wire encoding (behavior probes)', () => {
   it('encodes cacheKey + thinking + budget on the Kimi wire as prompt_cache_key + expanded thinking, never reasoning_effort', async () => {

--- a/packages/kosong/src/providers/openai-common.ts
+++ b/packages/kosong/src/providers/openai-common.ts
@@ -190,7 +190,7 @@ export function extractUsage(usage: unknown): TokenUsage | null {
   }
 
   return {
-    inputOther: promptTokens - cached,
+    inputOther: Math.max(promptTokens - cached, 0),
     output: completionTokens,
     inputCacheRead: cached,
     inputCacheCreation: 0,

--- a/packages/kosong/src/providers/openai-responses.ts
+++ b/packages/kosong/src/providers/openai-responses.ts
@@ -718,7 +718,7 @@ export class OpenAIResponsesStreamedMessage implements StreamedMessage {
     const details = readObjectField(usage, 'input_tokens_details');
     const cached = details ? (readNumberField(details, 'cached_tokens') ?? 0) : 0;
     this._usage = {
-      inputOther: inputTokens - cached,
+      inputOther: Math.max(inputTokens - cached, 0),
       output: outputTokens,
       inputCacheRead: cached,
       inputCacheCreation: 0,

--- a/packages/kosong/test/kimi.test.ts
+++ b/packages/kosong/test/kimi.test.ts
@@ -2162,6 +2162,19 @@ describe('extractUsage', () => {
     });
   });
 
+  it('keeps uncached input non-negative when cached tokens are reported without prompt tokens', () => {
+    const usage = extractUsage({
+      completion_tokens: 20,
+      prompt_tokens_details: { cached_tokens: 50 },
+    });
+    expect(usage).toEqual({
+      inputOther: 0,
+      output: 20,
+      inputCacheRead: 50,
+      inputCacheCreation: 0,
+    });
+  });
+
   it('returns null for null/undefined', () => {
     const undef: unknown = undefined;
     expect(extractUsage(null)).toBeNull();

--- a/packages/kosong/test/openai-responses.test.ts
+++ b/packages/kosong/test/openai-responses.test.ts
@@ -1205,6 +1205,32 @@ describe('OpenAIResponsesChatProvider', () => {
       });
     });
 
+    it('keeps uncached input non-negative when cached tokens are reported without input tokens', async () => {
+      const stream = new OpenAIResponsesStreamedMessage(
+        {
+          id: 'resp_partial_usage',
+          status: 'completed',
+          output: [],
+          usage: {
+            output_tokens: 5,
+            input_tokens_details: { cached_tokens: 10 },
+          },
+        },
+        false,
+      );
+
+      for await (const part of stream) {
+        void part;
+      }
+
+      expect(stream.usage).toEqual({
+        inputOther: 0,
+        output: 5,
+        inputCacheRead: 10,
+        inputCacheCreation: 0,
+      });
+    });
+
     it('yields ToolCall from non-stream response with function_call output item', async () => {
       const provider = createProvider();
       (provider as any)._stream = false;


### PR DESCRIPTION
## Related Issue

No linked issue. This is a focused fix for a reproducible OpenAI-compatible usage edge case.

## Problem

When a compatible endpoint reports cached-token details but omits the aggregate prompt/input token count, both OpenAI adapters default the aggregate to zero and then subtract the cache count. That produces a negative `inputOther`, which cancels the reported cache usage when total input is calculated.

| Usage projection | Before | After |
| --- | ---: | ---: |
| Reported aggregate input | 0 | 0 |
| Reported cache read | 10 | 10 |
| Derived uncached input | -10 | 0 |
| Calculated total input | 0 | 10 |

Official OpenAI usage objects include the aggregate token fields, so this primarily hardens compatibility with partial responses from OpenAI-compatible endpoints.

## What changed

- Clamp derived uncached input tokens at zero for Chat Completions and Responses usage parsing.
- Apply the same correction to the legacy and v2 provider implementations.
- Add regressions for cache details reported without aggregate prompt/input totals.
- Preserve the provider-reported cache and output counts unchanged.

## Test plan

- `pnpm vitest run packages/kosong/test/kimi.test.ts packages/kosong/test/openai-responses.test.ts packages/agent-core-v2/test/kosong/provider/composition.test.ts` (239 passed)
- `pnpm vitest run --project kosong` (1,336 passed)
- `pnpm vitest run packages/agent-core-v2/test/agent/mcp/output.test.ts` (39 passed)
- `pnpm --filter @moonshot-ai/kosong typecheck`
- `pnpm --filter @moonshot-ai/agent-core-v2 typecheck`
- `pnpm --filter @moonshot-ai/agent-core-v2 lint:domain`
- `pnpm --filter @moonshot-ai/kosong build`
- `pnpm --filter @moonshot-ai/agent-core-v2 build`

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.
