### PR TITLE
fix(agent-core-v2): observe aborted source rejections

### DIFF
--- a/packages/agent-core-v2/src/_base/utils/abort.ts
+++ b/packages/agent-core-v2/src/_base/utils/abort.ts
@@ -31,15 +31,28 @@ export function isUserCancellation(value: unknown): value is UserCancellationErr
 }
 
 export function abortable<T>(promise: Promise<T>, signal: AbortSignal): Promise<T> {
-  if (signal.aborted) return Promise.reject(abortReason(signal));
   return new Promise<T>((resolve, reject) => {
     const onAbort = () => {
       reject(abortReason(signal));
     };
-    signal.addEventListener('abort', onAbort, { once: true });
-    promise.then(resolve, reject).finally(() => {
+    const cleanup = () => {
       signal.removeEventListener('abort', onAbort);
-    });
+    };
+    promise.then(
+      (value) => {
+        cleanup();
+        resolve(value);
+      },
+      (error: unknown) => {
+        cleanup();
+        reject(error);
+      },
+    );
+    if (signal.aborted) {
+      onAbort();
+      return;
+    }
+    signal.addEventListener('abort', onAbort, { once: true });
   });
 }
 

--- a/packages/agent-core-v2/test/_base/utils/abort.test.ts
+++ b/packages/agent-core-v2/test/_base/utils/abort.test.ts
@@ -1,3 +1,10 @@
+/**
+ * Covers abort classification and promise ownership for abort-signal helpers.
+ *
+ * Uses real AbortController and Node rejection events. Run with:
+ * pnpm --filter @moonshot-ai/agent-core-v2 exec vitest run test/_base/utils/abort.test.ts
+ */
+
 import { describe, expect, it } from 'vitest';
 
 import {
@@ -38,6 +45,32 @@ describe('abortable', () => {
     controller.abort(reason);
 
     await expect(abortable(Promise.resolve('ok'), controller.signal)).rejects.toBe(reason);
+  });
+
+  it('observes the source rejection when the signal is already aborted', async () => {
+    const controller = new AbortController();
+    const reason = userCancellationReason();
+    controller.abort(reason);
+    const sourceError = new Error('source failed');
+    let rejectSource: (reason: unknown) => void = () => {};
+    const source = new Promise<never>((_resolve, reject) => {
+      rejectSource = reject;
+    });
+    let sourceWasUnhandled = false;
+    const onUnhandledRejection = (_reason: unknown, promise: Promise<unknown>): void => {
+      if (promise === source) sourceWasUnhandled = true;
+    };
+    process.on('unhandledRejection', onUnhandledRejection);
+
+    try {
+      await expect(abortable(source, controller.signal)).rejects.toBe(reason);
+      rejectSource(sourceError);
+      await new Promise<void>((resolve) => setImmediate(resolve));
+    } finally {
+      process.off('unhandledRejection', onUnhandledRejection);
+    }
+
+    expect(sourceWasUnhandled).toBe(false);
   });
 
   it('rejects with the signal reason when aborted while pending', async () => {


### PR DESCRIPTION
## Related Issue

No linked issue. This is a focused fix for deterministic promise ownership behavior in the internal v2 engine.

## Problem

When `abortable()` receives an already-aborted signal, it rejects its returned promise before attaching handlers to the supplied source promise. If that source rejects later, Node emits `unhandledRejection`; with the default `throw` policy, that can terminate the process.

The MCP reconnect path can create reconnect work before wrapping it with the tool execution signal, making it the clearest affected caller.

```text
already-aborted signal ──> caller receives AbortError
                                  │
source work continues ────────────┴──> later rejection
                                          │
                              before: unhandled
                              after:  observed by abortable
```

## What changed

- Attach source settlement handlers before checking whether cancellation has already won.
- Remove the abort listener on either source settlement path without creating a detached cleanup promise.
- Add a regression test that observes the actual Node `unhandledRejection` boundary for the supplied source promise.

This does not attempt to cancel the source operation; it preserves the existing contract while retaining ownership of its eventual rejection.

## Test plan

- `pnpm --filter @moonshot-ai/agent-core-v2 exec vitest run test/_base/utils/abort.test.ts --reporter=verbose` — 9 passed
- `pnpm --filter @moonshot-ai/agent-core-v2 test` — 4,082 passed
- `pnpm --filter @moonshot-ai/agent-core-v2 typecheck` — passed
- `pnpm --filter @moonshot-ai/agent-core-v2 lint:domain` — passed for 938 files
- `pnpm exec oxlint --type-aware packages/agent-core-v2/src/_base/utils/abort.ts packages/agent-core-v2/test/_base/utils/abort.test.ts` — 0 warnings, 0 errors

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove the fix works.
- [x] Ran `gen-changesets`; no changeset is needed for an internal-only `agent-core-v2` change.
- [x] No user documentation update is needed for this internal utility fix.