### PR TITLE
fix(web): preserve streamed text spacing

### DIFF
--- a/.changeset/fix-web-stream-text-wrapping.md
+++ b/.changeset/fix-web-stream-text-wrapping.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+web: Fix streamed assistant text rendering with unintended line breaks between chunks.

--- a/apps/kimi-web/src/composables/messagesToTurns.ts
+++ b/apps/kimi-web/src/composables/messagesToTurns.ts
@@ -641,8 +641,11 @@ export function messagesToTurns(
           g.textParts.push(c.text);
           // Append to a trailing text block, else open a new one — so a tool
           // call between two text segments splits them into separate blocks.
+          // Stream chunks already contain the model's whitespace (including
+          // paragraph breaks). Inserting a newline here turns token-sized
+          // chunks into one line per word, especially for Chinese output.
           const last = g.blocks.at(-1);
-          if (last && last.kind === 'text') last.text += '\n' + c.text;
+          if (last && last.kind === 'text') last.text += c.text;
           else g.blocks.push({ kind: 'text', text: c.text });
         }
       } else if (c.type === 'thinking') {
@@ -651,7 +654,7 @@ export function messagesToTurns(
           // Ordered block too: thinking renders WHERE it happened in the turn,
           // merging consecutive segments (same rule as text blocks above).
           const last = g.blocks.at(-1);
-          if (last && last.kind === 'thinking') last.thinking += '\n' + c.thinking;
+          if (last && last.kind === 'thinking') last.thinking += c.thinking;
           else g.blocks.push({ kind: 'thinking', thinking: c.thinking });
         }
       } else if (c.type === 'toolUse') {

--- a/apps/kimi-web/test/turn-logic.test.ts
+++ b/apps/kimi-web/test/turn-logic.test.ts
@@ -102,6 +102,28 @@ describe('messagesToTurns', () => {
     expect(turns.map((turn) => turn.text)).toEqual(['one', 'two']);
   });
 
+  it('preserves whitespace when merging streamed text around empty thinking parts', () => {
+    const turns = messagesToTurns(
+      [
+        message('a1', 'assistant', [
+          { type: 'text', text: 'one' },
+          { type: 'thinking', thinking: '' },
+          { type: 'text', text: ' ' },
+          { type: 'thinking', thinking: '' },
+          { type: 'text', text: 'two' },
+          { type: 'thinking', thinking: '' },
+          { type: 'text', text: ' ' },
+          { type: 'text', text: 'three' },
+        ]),
+      ],
+      [],
+      undefined,
+      false,
+    );
+
+    expect(turns[0]?.blocks).toEqual([{ kind: 'text', text: 'one two three' }]);
+  });
+
   it('renders compaction summaries as divider turns', () => {
     const turns = messagesToTurns(
       [


### PR DESCRIPTION
## Related Issue

fix #2184 
fix #2323 

## Problem

In `apps/kimi-web`, streamed assistant text and thinking segments were merged with a hardcoded `'\n'` between consecutive chunks. Because stream chunks already carry the model's own whitespace (including paragraph breaks), this inserted newline turned token-sized chunks into one word per line — most visible for Chinese output, where tokens carry no trailing space.

## What changed

In `apps/kimi-web/src/composables/messagesToTurns.ts`, stop inserting `'\n'` when appending to a trailing text/thinking block. Concatenate the chunk text directly so the model's original whitespace is preserved. The block-splitting behavior (a tool call between two text segments still splits them into separate blocks) is unchanged.

Added a test in `apps/kimi-web/test/turn-logic.test.ts` covering streamed text merged around empty thinking parts, asserting the result is `'one two three'` rather than newline-separated fragments.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.