### PR TITLE
fix(vscode): recognize dark high-contrast themes

### DIFF
--- a/apps/vscode/webview-ui/src/main.tsx
+++ b/apps/vscode/webview-ui/src/main.tsx
@@ -3,7 +3,10 @@ import { createRoot } from "react-dom/client";
 import App from "./App";
 
 function syncTheme() {
-  const isDark = document.body.classList.contains("vscode-dark");
+  const isDark =
+    document.body.classList.contains("vscode-dark") ||
+    (document.body.classList.contains("vscode-high-contrast") &&
+      !document.body.classList.contains("vscode-high-contrast-light"));
   document.documentElement.classList.toggle("dark", isDark);
 }
 


### PR DESCRIPTION
## Related Issue

Resolve #2158

## Problem

The VS Code webview only treated `vscode-dark` as a dark theme, so dark high-contrast themes rendered using the light UI theme.

## What changed

Treat `vscode-high-contrast` as dark while explicitly keeping `vscode-high-contrast-light` light. VS Code adds the generic high-contrast class to light high-contrast themes for backward compatibility.

## Validation

- [x] `pnpm -C apps/vscode run typecheck`
- [x] `pnpm -C apps/vscode run build:webview`
- [x] Verified dark, dark high contrast, light, and light high contrast class combinations
- [ ] `pnpm -C apps/vscode run test` — 293 passed; 3 unrelated Windows path tests failed

## Checklist

- [x] I have read the CONTRIBUTING document.
- [x] I have linked a related issue.
- [ ] I have added tests that prove my feature works.
- [x] Ran `gen-changesets`; this private VS Code package change needs no changeset.
- [x] No documentation update is required.