### PR TITLE
fix(kosong/kimi): move parent type into anyOf/oneOf/allOf items

### DIFF
--- a/packages/kosong/src/providers/kimi-schema.ts
+++ b/packages/kosong/src/providers/kimi-schema.ts
@@ -116,8 +116,9 @@ const NUMERIC_STRUCTURE_KEYS = new Set([
  * a provider-compatibility normalizer, not a complete JSON Schema compiler:
  * it resolves local refs, preserves combinator nodes, infers obvious
  * scalar/object/array types, and falls back to `string` only for nested
- * typeless property schemas. The root schema object is treated as a container
- * and is not itself normalized.
+ * typeless property schemas. It also rewrites nodes that declare `type`
+ * alongside a combinator (`anyOf` / `oneOf` / `allOf`), which Moonshot
+ * rejects, by moving the parent `type` into each combinator item.
  */
 export function normalizeKimiToolSchema(schema: Record<string, unknown>): Record<string, unknown> {
   return ensureKimiPropertyTypes(derefJsonSchema(schema));
@@ -128,8 +129,34 @@ function ensureKimiPropertyTypes(schema: Record<string, unknown>): Record<string
   if (!isRecord(normalized)) {
     throw new Error('JSON Schema root must normalize to an object.');
   }
+  fixCombinatorParentType(normalized);
   recurseSchema(normalized);
   return normalized;
+}
+
+/**
+ * Moonshot's tool validator rejects schemas that declare `type` on the same
+ * node as a combinator (`anyOf` / `oneOf` / `allOf`): the type must live on
+ * each combinator item instead. Distribute the parent `type` into items that
+ * lack one and drop it from the parent. Since the parent `type` constrained
+ * every variant anyway, copying it into each item preserves the semantics.
+ */
+function fixCombinatorParentType(node: unknown): void {
+  if (!isRecord(node) || !hasOwn(node, 'type')) {
+    return;
+  }
+  for (const key of ['anyOf', 'oneOf', 'allOf']) {
+    const items = node[key];
+    if (!Array.isArray(items) || items.length === 0) {
+      continue;
+    }
+    for (const item of items) {
+      if (isRecord(item) && !hasOwn(item, 'type')) {
+        item['type'] = node['type'];
+      }
+    }
+    delete node['type'];
+  }
 }
 
 function hasUnresolvedDefinitionRef(node: unknown, bucketKey: string): boolean {
@@ -299,6 +326,8 @@ function normalizeProperty(node: unknown): void {
   if (!isRecord(node)) {
     return;
   }
+
+  fixCombinatorParentType(node);
 
   if (!hasOwn(node, 'type') && !hasAnyKey(node, TYPE_COMPLETION_SKIP_KEYS)) {
     const enumValues = node['enum'];


### PR DESCRIPTION
## Problem

Moonshot's server-side tool schema validator rejects JSON Schemas that declare `type` on the same node as a combinator:

```
[provider.api_error] 400 tools.function.parameters is not a valid moonshot flavored json schema,
details: <At path 'root': when using anyOf, type should be defined in anyOf items instead of the parent schema>
```

Any tool whose parameter schema has `type` alongside `anyOf` / `oneOf` / `allOf` — whether at the root (e.g. `{ "type": "object", "properties": {...}, "anyOf": [...] }`) or nested under `properties` / `not` / `if`-`then`-`else` — is sent to the API unmodified and the request fails with HTTP 400.

## Root cause

`normalizeKimiToolSchema` in `packages/kosong/src/providers/kimi-schema.ts` fills in missing `type` fields, but:

1. **The root schema object is never normalized** — `ensureKimiPropertyTypes` only calls `recurseSchema`, which visits child schemas but not the root node itself.
2. **No node handles the type+combinator rule**, so such schemas pass through unchanged.

Refs #792 (same bug class, different validator detail).

## Fix

Add `fixCombinatorParentType(node)`: when a node declares both `type` and a combinator (`anyOf` / `oneOf` / `allOf`), copy the parent `type` into each combinator item that lacks one and delete it from the parent. Since the parent `type` constrained every variant anyway, distributing it into the items preserves the schema's semantics. Items that already declare their own `type` are left untouched.

It is called on the root (in `ensureKimiPropertyTypes`) and on every visited node (in `normalizeProperty`), so all combinator positions covered by `CHILD_SCHEMA_SLOTS` are handled. `TYPE_COMPLETION_SKIP_KEYS` already includes the combinator keywords, so the existing type-inference logic does not re-add a parent `type` afterwards.

## Verification

Ran the patched normalizer against the failing shapes:

- `{type:"object", properties:{...}, anyOf:[{required:["input"]},{required:["runInput"]}]}`
  → `anyOf:[{required:["input"],type:"object"},{required:["runInput"],type:"object"}]`, parent `type` removed ✓
- nested `{type:"object", anyOf:[...]}` under `properties.<name>` → fixed recursively ✓
- items that already declare their own `type` → preserved; only the parent `type` is dropped ✓

Note: I validated against the built dist output of this package; a maintainer may want to add a unit test case to the kosong test suite covering the type+combinator rule.