### PR TITLE
fix(test): remove shell-escaped newline from hooks runner test

### DIFF
--- a/packages/agent-core-v2/test/app/externalHooksRunner/externalHooksRunner.test.ts
+++ b/packages/agent-core-v2/test/app/externalHooksRunner/externalHooksRunner.test.ts
@@ -204,7 +204,7 @@ describe('ExternalHooksRunnerService', () => {
   });
 
   it('does not dedupe hooks that share a command but have different cwd', async () => {
-    const command = nodeCommand('process.stdout.write(process.cwd() + "\\n");');
+    const command = nodeCommand('process.stdout.write(process.cwd());');
     const runner = makeHookRunner([
       { event: 'Stop', command, timeout: 5, cwd: process.cwd() },
       { event: 'Stop', command, timeout: 5, cwd: tmpdir() },


### PR DESCRIPTION
## Related Issue

N/A (small test-only fix < 100 lines)

## Description

The `externalHooksRunner` test "does not dedupe hooks that share a command but have different cwd" appends `"\\n"` to `process.stdout.write(process.cwd())` via shell escaping. On Windows, cmd.exe misinterprets the escaped sequence and outputs the literal two characters `\n` instead of a newline, causing `.trim()` to fail to strip it and the assertion to fail.

Since the assertion already applies `.trim()` to the stdout, the trailing newline is unnecessary. Removing it makes the test pass on both Unix and Windows.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked the related issue, if any.
- [x] I have added tests that prove my fix is effective or that my feature works.
