### PR TITLE
fix(agent-core): probe pid liveness before marking restored tasks lost

### DIFF
--- a/.changeset/task-liveness-probe.md
+++ b/.changeset/task-liveness-probe.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Probe pid liveness before marking restored background tasks as lost. Resuming a session whose tasks were still running in another process no longer reports those tasks as `lost`, which previously invited the model to resume them and start a duplicate worker alongside the live one.

--- a/packages/agent-core-v2/src/agent/task/pidAlive.ts
+++ b/packages/agent-core-v2/src/agent/task/pidAlive.ts
@@ -1,0 +1,17 @@
+/**
+ * `process.kill(pid, 0)` liveness probe for a persisted task pid. True if the
+ * pid exists, false on `ESRCH`. `EPERM` (process exists, different owner) and
+ * any other errno report alive, so an ambiguous probe never causes a live
+ * task to be reclassified as lost. Mirrors the probe in
+ * `packages/kap-server/src/instanceRegistry.ts`.
+ */
+export function pidAlive(pid: number): boolean {
+  if (!Number.isInteger(pid) || pid <= 0) return false;
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException).code;
+    return code !== 'ESRCH';
+  }
+}

--- a/packages/agent-core-v2/src/agent/task/taskService.ts
+++ b/packages/agent-core-v2/src/agent/task/taskService.ts
@@ -60,6 +60,7 @@ import {
 import { resolveAgentTaskConfig } from './configSection';
 import { AgentTaskPersistence } from './persist';
 import { taskKey, TaskNotified, TaskStarted, TaskTerminated, TaskWaitDelivered } from './taskOps';
+import { pidAlive } from '#/agent/task/pidAlive';
 import { formatTaskList } from '#/agent/tools/task/task-list/taskListTool';
 import '#/agent/tools/task/task-output/taskOutputTool';
 import '#/agent/tools/task/task-stop/taskStopTool';
@@ -934,6 +935,7 @@ export class AgentTaskService extends Disposable implements IAgentTaskService {
     const persistence = this.persistence;
     for (const [taskId, info] of this.ghosts) {
       if (TERMINAL_STATUSES.has(info.status)) continue;
+      if (info.kind === 'process' && pidAlive(info.pid)) continue;
       const updated: AgentTaskInfo = {
         ...info,
         status: 'lost',

--- a/packages/agent-core-v2/test/agent/task/pidAlive.test.ts
+++ b/packages/agent-core-v2/test/agent/task/pidAlive.test.ts
@@ -1,0 +1,57 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { pidAlive } from '#/agent/task/pidAlive';
+
+function killError(code: string): NodeJS.ErrnoException {
+  const err = new Error(code) as NodeJS.ErrnoException;
+  err.code = code;
+  return err;
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('pidAlive', () => {
+  it('reports the current process as alive', () => {
+    expect(pidAlive(process.pid)).toBe(true);
+  });
+
+  it('rejects pids that cannot identify a process', () => {
+    expect(pidAlive(0)).toBe(false);
+    expect(pidAlive(-1)).toBe(false);
+    expect(pidAlive(1.5)).toBe(false);
+    expect(pidAlive(Number.NaN)).toBe(false);
+  });
+
+  it('treats ESRCH as dead', () => {
+    vi.spyOn(process, 'kill').mockImplementation(() => {
+      throw killError('ESRCH');
+    });
+
+    expect(pidAlive(4242)).toBe(false);
+  });
+
+  it('treats EPERM as alive — the process exists but belongs to another user', () => {
+    vi.spyOn(process, 'kill').mockImplementation(() => {
+      throw killError('EPERM');
+    });
+
+    expect(pidAlive(4242)).toBe(true);
+  });
+
+  it('assumes alive on an unrecognised errno rather than clobbering a live task', () => {
+    vi.spyOn(process, 'kill').mockImplementation(() => {
+      throw killError('EINVAL');
+    });
+
+    expect(pidAlive(4242)).toBe(true);
+  });
+
+  it('probes with signal 0 so it never disturbs the target', () => {
+    const kill = vi.spyOn(process, 'kill').mockReturnValue(true);
+
+    expect(pidAlive(4242)).toBe(true);
+    expect(kill).toHaveBeenCalledWith(4242, 0);
+  });
+});

--- a/packages/agent-core-v2/test/agent/task/reconcile.test.ts
+++ b/packages/agent-core-v2/test/agent/task/reconcile.test.ts
@@ -2,12 +2,13 @@ import { mkdir, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'pathe';
 
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import {
   IAgentTaskService,
   type AgentTaskInfo,
 } from '#/agent/task/task';
+import { pidAlive } from '#/agent/task/pidAlive';
 import { IEventBus } from '#/app/event/eventBus';
 import {
   taskServices,
@@ -19,6 +20,10 @@ import {
   createAgentTaskPersistence,
   type TaskServiceTestManager,
 } from './stubs';
+
+vi.mock('#/agent/task/pidAlive', () => ({
+  pidAlive: vi.fn(() => false),
+}));
 
 let sessionDir: string;
 let persistence: ReturnType<typeof createAgentTaskPersistence>;
@@ -41,6 +46,7 @@ function persistedProcess(
 }
 
 beforeEach(async () => {
+  vi.mocked(pidAlive).mockReturnValue(false);
   sessionDir = join(
     tmpdir(),
     `kimi-bg-reconcile-${Date.now()}-${Math.random().toString(36).slice(2)}`,
@@ -261,6 +267,63 @@ describe('AgentTaskService — loadFromDisk + reconcile', () => {
           (event) => (event as { type?: string }).type === 'task.terminated',
         ),
       ).toHaveLength(1);
+    });
+
+    it('keeps a ghost running when its process is still alive', async () => {
+      vi.mocked(pidAlive).mockReturnValue(true);
+      await persistence.writeTask(
+        persistedProcess({
+          taskId: 'bash-alive000',
+          command: 'sleep 9999',
+          description: 'still running elsewhere',
+          pid: 4242,
+        }),
+      );
+
+      await background.loadFromDisk();
+      await background.reconcile();
+
+      expect(pidAlive).toHaveBeenCalledWith(4242);
+      expect(background.getTask('bash-alive000')).toMatchObject({
+        taskId: 'bash-alive000',
+        status: 'running',
+      });
+      expect(await persistence.readTask('bash-alive000')).toMatchObject({
+        taskId: 'bash-alive000',
+        status: 'running',
+      });
+      expect(
+        emittedEvents.filter(
+          (event) => (event as { type?: string }).type === 'task.terminated',
+        ),
+      ).toEqual([]);
+    });
+
+    it('marks only the dead process lost when a live one shares the session', async () => {
+      vi.mocked(pidAlive).mockImplementation((pid: number) => pid === 4242);
+      await persistence.writeTask(
+        persistedProcess({ taskId: 'bash-alive001', pid: 4242 }),
+      );
+      await persistence.writeTask(
+        persistedProcess({ taskId: 'bash-dead0001', pid: 99999 }),
+      );
+
+      await background.loadFromDisk();
+      await background.reconcile();
+
+      expect(await persistence.readTask('bash-alive001')).toMatchObject({
+        status: 'running',
+      });
+      expect(await persistence.readTask('bash-dead0001')).toMatchObject({
+        status: 'lost',
+      });
+      const terminationEvents = emittedEvents.filter(
+        (event) => (event as { type?: string }).type === 'task.terminated',
+      );
+      expect(terminationEvents).toHaveLength(1);
+      expect(terminationEvents[0]).toMatchObject({
+        info: { taskId: 'bash-dead0001', status: 'lost' },
+      });
     });
 
     it('restores terminal ghost notifications into context', async () => {


### PR DESCRIPTION
## Related Issue

Resolve #1924

## Problem

See linked issue.

In short: when a session is restored, `markLoadedTasksLost` reclassifies every non-terminal ghost task as `lost` without checking whether the task's process is still running. If a second process resumes a session whose tasks are still alive, the first process's tasks are marked `lost` — and the `resume_hint` lists `task.lost` as a recovery case that the model may resume, so a duplicate worker gets started alongside the one that is still running.

The material for the check is already on disk: `ProcessTaskInfo` carries `pid`, and `persist.ts` round-trips it.

## What changed

- Added `packages/agent-core-v2/src/agent/task/pidAlive.ts`: a `process.kill(pid, 0)` probe. `ESRCH` means dead; `EPERM` means the process exists but belongs to another user, so it counts as alive; any other errno assumes alive so a live task is never clobbered. This mirrors the probe already used by the server-side instance registry (`packages/kap-server/src/instanceRegistry.ts`).
- `markLoadedTasksLost` now skips ghosts of kind `process` whose pid is still alive. Everything else is unchanged: terminal statuses are still skipped, dead process tasks are still marked `lost`, and non-process kinds (which have no pid to probe) keep their previous behaviour.

Scope note: this is the small, self-contained half of the problem. It does not add a per-session cross-process lock, and agent-kind tasks still have no pid to probe — those were raised as larger design options in the issue and are deliberately left out of this PR.

## Testing

- New `test/agent/task/pidAlive.test.ts` covers the probe directly: current pid alive, non-positive/non-integer pids rejected, `ESRCH` dead, `EPERM` alive, unknown errno alive, and that it probes with signal `0` so the target is never disturbed.
- `test/agent/task/reconcile.test.ts` gains two regression tests: a ghost whose process is alive stays `running` and emits no `task.terminated`, and with one live and one dead ghost only the dead one is marked `lost`.
- The existing reconcile tests previously depended on whichever pids happened to exist on the machine running them (one fixture used `pid: 1`, which is alive on Linux). They now mock the probe to a dead pid by default, so their expectations are deterministic and unchanged.
- Verified the tests actually bite: reverting only the skip line in `markLoadedTasksLost` fails exactly the two new reconcile tests, with the original nine still passing.
- `pnpm test` for `packages/agent-core-v2/test/agent/task/`: 200 passed. `pnpm lint`, `pnpm typecheck` and `pnpm sherif` are clean. Three plugin test files (`app/plugin/archive`, `manager`, `manager-consumption`, 11 tests) fail identically on unmodified `main` in my environment, so they are pre-existing and unrelated.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset. — patch changeset added for `@moonshot-ai/kimi-code`, since this internal-package fix changes user-visible CLI behaviour.
- [x] Ran `gen-docs` skill, or this PR needs no doc update. — no documented behaviour changes; `lost` keeps its meaning, it is just no longer applied to a live task.
