### PR TITLE
docs(cli): document that --prompt runs in auto permission mode

### DIFF
--- a/.changeset/prompt-auto-permission-docs.md
+++ b/.changeset/prompt-auto-permission-docs.md
@@ -2,4 +2,4 @@
 "@moonshot-ai/kimi-code": patch
 ---
 
-Document that `-p` / `--prompt` runs in auto permission mode, so tool calls are approved without prompting regardless of `default_permission_mode`.
+Document that `-p` / `--prompt` runs in auto permission mode, so tool calls are approved without prompting regardless of `default_permission_mode`. `deny` rules in `[[permission.rules]]` still block.

--- a/.changeset/prompt-auto-permission-docs.md
+++ b/.changeset/prompt-auto-permission-docs.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Document that `-p` / `--prompt` runs in auto permission mode, so tool calls are approved without prompting regardless of `default_permission_mode`.

--- a/apps/kimi-code/src/cli/commands.ts
+++ b/apps/kimi-code/src/cli/commands.ts
@@ -59,7 +59,7 @@ export function createProgram(
     .addOption(
       new Option(
         '-p, --prompt <prompt>',
-        'Run one prompt non-interactively and print the response.',
+        'Run one prompt non-interactively and print the response. Runs in auto permission mode: tool calls are approved without prompting.',
       ),
     )
     .addOption(

--- a/apps/kimi-code/src/cli/commands.ts
+++ b/apps/kimi-code/src/cli/commands.ts
@@ -59,7 +59,7 @@ export function createProgram(
     .addOption(
       new Option(
         '-p, --prompt <prompt>',
-        'Run one prompt non-interactively and print the response. Runs in auto permission mode: tool calls are approved without prompting.',
+        'Run one prompt non-interactively and print the response. Runs in auto permission mode: tool calls are approved without prompting, except where a permission deny rule blocks them.',
       ),
     )
     .addOption(

--- a/docs/en/configuration/config-files.md
+++ b/docs/en/configuration/config-files.md
@@ -98,7 +98,7 @@ Fields in the config file fall into two categories: **top-level scalars** that d
 | Field | Type | Default | Description |
 | --- | --- | --- | --- |
 | `default_model` | `string` | — | Default model alias; must be defined in `models` |
-| `default_permission_mode` | `string` | `manual` | Default permission mode for new sessions; one of `manual` (prompt each time), `yolo` (auto-approve tool actions, but the agent may still ask questions), or `auto` (fully autonomous — the agent decides everything without asking) |
+| `default_permission_mode` | `string` | `manual` | Default permission mode for new sessions; one of `manual` (prompt each time), `yolo` (auto-approve tool actions, but the agent may still ask questions), or `auto` (fully autonomous — the agent decides everything without asking). Non-interactive runs (`-p` / `--prompt`) always use `auto` regardless of this setting |
 | `default_plan_mode` | `boolean` | `false` | Whether new sessions start in Plan mode (produce a plan before executing) by default |
 | `merge_all_available_skills` | `boolean` | `true` | Whether to merge Agent Skills from all available directories |
 | `extra_skill_dirs` | `array<string>` | — | Extra skill search directories, layered on top of the default directories |

--- a/docs/en/configuration/config-files.md
+++ b/docs/en/configuration/config-files.md
@@ -98,7 +98,7 @@ Fields in the config file fall into two categories: **top-level scalars** that d
 | Field | Type | Default | Description |
 | --- | --- | --- | --- |
 | `default_model` | `string` | — | Default model alias; must be defined in `models` |
-| `default_permission_mode` | `string` | `manual` | Default permission mode for new sessions; one of `manual` (prompt each time), `yolo` (auto-approve tool actions, but the agent may still ask questions), or `auto` (fully autonomous — the agent decides everything without asking). Non-interactive runs (`-p` / `--prompt`) always use `auto` regardless of this setting |
+| `default_permission_mode` | `string` | `manual` | Default permission mode for new sessions; one of `manual` (prompt each time), `yolo` (auto-approve tool actions, but the agent may still ask questions), or `auto` (fully autonomous — the agent decides everything without asking). Non-interactive runs (`-p` / `--prompt`) always use `auto` regardless of this setting; `deny` rules still apply |
 | `default_plan_mode` | `boolean` | `false` | Whether new sessions start in Plan mode (produce a plan before executing) by default |
 | `merge_all_available_skills` | `boolean` | `true` | Whether to merge Agent Skills from all available directories |
 | `extra_skill_dirs` | `array<string>` | — | Extra skill search directories, layered on top of the default directories |

--- a/docs/en/configuration/overrides.md
+++ b/docs/en/configuration/overrides.md
@@ -59,7 +59,7 @@ Options passed at startup have the highest priority and apply only to the curren
 | `--auto` | Start in auto permission mode: fully autonomous, the agent will not ask questions |
 | `--plan` | Start in Plan mode |
 | `-m, --model <model>` | Use a specific model alias for this session |
-| `-p, --prompt <prompt>` | Run in non-interactive mode: execute a single prompt and exit. Runs in auto permission mode, so tool calls are approved without prompting regardless of `default_permission_mode` |
+| `-p, --prompt <prompt>` | Run in non-interactive mode: execute a single prompt and exit. Runs in auto permission mode, so tool calls are approved without prompting regardless of `default_permission_mode`; `deny` rules in `[[permission.rules]]` still block |
 | `--output-format <format>` | Output format for `-p` mode: `text` or `stream-json` |
 | `--skills-dir <dir>` | Replace auto-discovered Skills directories (repeatable; applies to this session only) |
 

--- a/docs/en/configuration/overrides.md
+++ b/docs/en/configuration/overrides.md
@@ -59,14 +59,14 @@ Options passed at startup have the highest priority and apply only to the curren
 | `--auto` | Start in auto permission mode: fully autonomous, the agent will not ask questions |
 | `--plan` | Start in Plan mode |
 | `-m, --model <model>` | Use a specific model alias for this session |
-| `-p, --prompt <prompt>` | Run in non-interactive mode: execute a single prompt and exit |
+| `-p, --prompt <prompt>` | Run in non-interactive mode: execute a single prompt and exit. Runs in auto permission mode, so tool calls are approved without prompting regardless of `default_permission_mode` |
 | `--output-format <format>` | Output format for `-p` mode: `text` or `stream-json` |
 | `--skills-dir <dir>` | Replace auto-discovered Skills directories (repeatable; applies to this session only) |
 
 Mutual exclusion rules (startup fails if violated):
 
 - `--output-format` can only be used with `-p`
-- `--prompt` cannot be combined with `--yolo` or `--plan`
+- `--prompt` cannot be combined with `--yolo`, `--auto`, or `--plan`
 - `--continue` and `--session` cannot be used together
 - In non-prompt mode, `--yolo` and `--plan` cannot be combined with `--continue` or `--session`
 

--- a/docs/zh/configuration/config-files.md
+++ b/docs/zh/configuration/config-files.md
@@ -98,7 +98,7 @@ timeout = 5
 | 字段 | 类型 | 默认值 | 说明 |
 | --- | --- | --- | --- |
 | `default_model` | `string` | — | 默认模型别名，必须在 `models` 中定义 |
-| `default_permission_mode` | `string` | `manual` | 新会话的默认权限模式，可选 `manual`（逐次询问）、`yolo`（自动批准工具操作，Agent 仍可能提问）、`auto`（完全自主，Agent 自己做决定，不再提问）。非交互运行（`-p` / `--prompt`）始终使用 `auto`，不受该配置影响 |
+| `default_permission_mode` | `string` | `manual` | 新会话的默认权限模式，可选 `manual`（逐次询问）、`yolo`（自动批准工具操作，Agent 仍可能提问）、`auto`（完全自主，Agent 自己做决定，不再提问）。非交互运行（`-p` / `--prompt`）始终使用 `auto`，不受该配置影响；`deny` 规则仍然生效 |
 | `default_plan_mode` | `boolean` | `false` | 新会话是否默认以 Plan 模式（先出计划再执行）启动 |
 | `merge_all_available_skills` | `boolean` | `true` | 是否合并所有目录中的 Agent Skills |
 | `extra_skill_dirs` | `array<string>` | — | 额外 Skill 搜索目录，叠加到默认目录之上 |

--- a/docs/zh/configuration/config-files.md
+++ b/docs/zh/configuration/config-files.md
@@ -98,7 +98,7 @@ timeout = 5
 | 字段 | 类型 | 默认值 | 说明 |
 | --- | --- | --- | --- |
 | `default_model` | `string` | — | 默认模型别名，必须在 `models` 中定义 |
-| `default_permission_mode` | `string` | `manual` | 新会话的默认权限模式，可选 `manual`（逐次询问）、`yolo`（自动批准工具操作，Agent 仍可能提问）、`auto`（完全自主，Agent 自己做决定，不再提问） |
+| `default_permission_mode` | `string` | `manual` | 新会话的默认权限模式，可选 `manual`（逐次询问）、`yolo`（自动批准工具操作，Agent 仍可能提问）、`auto`（完全自主，Agent 自己做决定，不再提问）。非交互运行（`-p` / `--prompt`）始终使用 `auto`，不受该配置影响 |
 | `default_plan_mode` | `boolean` | `false` | 新会话是否默认以 Plan 模式（先出计划再执行）启动 |
 | `merge_all_available_skills` | `boolean` | `true` | 是否合并所有目录中的 Agent Skills |
 | `extra_skill_dirs` | `array<string>` | — | 额外 Skill 搜索目录，叠加到默认目录之上 |

--- a/docs/zh/configuration/overrides.md
+++ b/docs/zh/configuration/overrides.md
@@ -59,7 +59,7 @@ Kimi Code CLI 有三个地方可以影响运行参数：配置文件、命令行
 | `--auto` | 以 auto 权限模式启动：完全自主，Agent 不会向用户提问 |
 | `--plan` | 以 Plan 模式启动 |
 | `-m, --model <model>` | 指定本次使用的模型别名 |
-| `-p, --prompt <prompt>` | 非交互模式：执行单条提示词后退出。以 auto 权限模式运行，工具调用会被自动批准，不受 `default_permission_mode` 影响 |
+| `-p, --prompt <prompt>` | 非交互模式：执行单条提示词后退出。以 auto 权限模式运行，工具调用会被自动批准，不受 `default_permission_mode` 影响；`[[permission.rules]]` 中的 `deny` 规则仍然生效 |
 | `--output-format <format>` | `-p` 模式的输出格式：`text` 或 `stream-json` |
 | `--skills-dir <dir>` | 替换自动发现的 Skills 目录（可重复，仅本次生效） |
 

--- a/docs/zh/configuration/overrides.md
+++ b/docs/zh/configuration/overrides.md
@@ -59,14 +59,14 @@ Kimi Code CLI 有三个地方可以影响运行参数：配置文件、命令行
 | `--auto` | 以 auto 权限模式启动：完全自主，Agent 不会向用户提问 |
 | `--plan` | 以 Plan 模式启动 |
 | `-m, --model <model>` | 指定本次使用的模型别名 |
-| `-p, --prompt <prompt>` | 非交互模式：执行单条提示词后退出 |
+| `-p, --prompt <prompt>` | 非交互模式：执行单条提示词后退出。以 auto 权限模式运行，工具调用会被自动批准，不受 `default_permission_mode` 影响 |
 | `--output-format <format>` | `-p` 模式的输出格式：`text` 或 `stream-json` |
 | `--skills-dir <dir>` | 替换自动发现的 Skills 目录（可重复，仅本次生效） |
 
 互斥规则（违反时启动报错）：
 
 - `--output-format` 只能配合 `-p` 使用
-- `--prompt` 不能同时用 `--yolo` 或 `--plan`
+- `--prompt` 不能同时用 `--yolo`、`--auto` 或 `--plan`
 - `--continue` 和 `--session` 不能同时用
 - 非 prompt 模式下，`--yolo` 和 `--plan` 不能配合 `--continue` 或 `--session`
 


### PR DESCRIPTION
## Related Issue

Resolve #2099

## Problem

See linked issue.

Non-interactive runs force auto permission mode, so every tool call is approved without prompting regardless of `default_permission_mode`. This is deliberate — a non-interactive run has nobody to answer an approval prompt — but it was never written down, and `-y/--yolo` and `--auto` read as the explicit opt-ins, so `-p` looks like it should inherit the documented `manual` default.

Both engines do it:

- v1 — `forcePromptPermission` in `apps/kimi-code/src/cli/run-prompt.ts`
- v2 — `forceAuto` in `apps/kimi-code/src/cli/v2/run-v2-print.ts`

While writing this up I also found that the documented mutual-exclusion list is incomplete: `apps/kimi-code/src/cli/options.ts` rejects `--prompt` combined with `--yolo`, `--auto` *and* `--plan`, but the docs list only `--yolo` and `--plan`.

## What changed

Documentation only — no behaviour change.

- `-p, --prompt` help text now states that it runs in auto permission mode and that tool calls are approved without prompting.
- `docs/{en,zh}/configuration/overrides.md`: the `-p, --prompt` row says the same, and `--auto` is added to the mutual-exclusion list so it matches what `options.ts` actually enforces.
- `docs/{en,zh}/configuration/config-files.md`: the `default_permission_mode` row notes that non-interactive runs always use `auto` regardless of the setting.

The issue offered two possible resolutions — respect `default_permission_mode`, or document the auto-approval. This PR takes the documentation route, since the current behaviour looks intentional and changing it would break unattended `-p` users. Happy to follow up with the behavioural change instead if you'd prefer that direction.

## Testing

No behaviour change, so there is nothing new to test. `pnpm lint` and `pnpm typecheck` are clean, and no test or snapshot asserts on the `-p` help string.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works. — documentation and one help string; no behaviour to test.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset. — patch changeset added for `@moonshot-ai/kimi-code`, since the CLI help text is user-visible.
- [x] Ran `gen-docs` skill, or this PR needs no doc update. — this PR *is* the doc update; both `en` and `zh` are covered.
