### PR TITLE
fix(kaos): resolve Git Bash POSIX paths for file tools on Windows

### DIFF
--- a/.changeset/windows-git-bash-path-bridge.md
+++ b/.changeset/windows-git-bash-path-bridge.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Fix file tools and shell working directories failing to resolve Git Bash paths such as /c/Users or /tmp on Windows.

--- a/packages/agent-core-v2/src/_base/execEnv/shellPathBridge.ts
+++ b/packages/agent-core-v2/src/_base/execEnv/shellPathBridge.ts
@@ -1,0 +1,150 @@
+import { execFileSync as nodeExecFileSync } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import * as nodePath from 'node:path';
+
+import type { HostEnvironmentInfo } from './environmentProbe';
+
+export interface ShellPathBridge {
+  toShellPath(nativePath: string): string;
+  fromShellPath(path: string): string;
+}
+
+export type ShellPathBridgeEnv = Pick<HostEnvironmentInfo, 'osKind' | 'shellName' | 'shellPath'>;
+
+export interface ShellPathBridgeDeps {
+  readonly execFileSync: (file: string, args: readonly string[]) => string;
+  readonly isFile: (path: string) => boolean;
+}
+
+const CYGPATH_TIMEOUT_MS = 5_000;
+
+const DRIVE_COLON_RE = /^\/([a-zA-Z]):(?:[\\/]|$)/;
+const CYGDRIVE_RE = /^\/cygdrive\/([a-zA-Z])(?:\/|$)/;
+const DRIVE_RE = /^\/([a-zA-Z])(?:\/|$)/;
+
+const VIRTUAL_FS_PREFIXES: readonly string[] = ['/dev/', '/proc/', '/sys/'];
+
+const WIN32_DRIVE_ABSOLUTE_RE = /^[A-Za-z]:[\\/]/;
+
+function joinDrive(letter: string, rest: string): string {
+  const normalizedRest = rest.replaceAll('\\', '/');
+  return normalizedRest === ''
+    ? `${letter.toUpperCase()}:/`
+    : `${letter.toUpperCase()}:${normalizedRest}`;
+}
+
+export function translateShellDrivePath(path: string): string {
+  const colonMatch = DRIVE_COLON_RE.exec(path);
+  if (colonMatch !== null) {
+    return joinDrive(colonMatch[1]!, path.slice(3));
+  }
+  const cygdriveMatch = CYGDRIVE_RE.exec(path);
+  if (cygdriveMatch !== null) {
+    return joinDrive(cygdriveMatch[1]!, path.slice(`/cygdrive/${cygdriveMatch[1]!}`.length));
+  }
+  const driveMatch = DRIVE_RE.exec(path);
+  if (driveMatch !== null) {
+    return joinDrive(driveMatch[1]!, path.slice(2));
+  }
+  return path;
+}
+
+export function createShellPathBridge(
+  env: ShellPathBridgeEnv,
+  deps: ShellPathBridgeDeps,
+): ShellPathBridge {
+  const enabled = env.osKind === 'Windows' && env.shellName === 'bash';
+
+  let cygpathExe: string | null | undefined;
+  const segmentCache = new Map<string, string>();
+
+  function locateCygpath(): string | null {
+    if (cygpathExe !== undefined) return cygpathExe;
+    const shellDir = nodePath.win32.dirname(env.shellPath);
+    const candidates = [nodePath.win32.join(shellDir, 'cygpath.exe')];
+    if (nodePath.win32.basename(shellDir).toLowerCase() === 'bin') {
+      candidates.push(nodePath.win32.join(shellDir, '..', 'usr', 'bin', 'cygpath.exe'));
+    }
+    cygpathExe = candidates.find((candidate) => deps.isFile(candidate)) ?? null;
+    return cygpathExe;
+  }
+
+  function resolveRootSegment(firstSegment: string): string | null {
+    const cached = segmentCache.get(firstSegment);
+    if (cached !== undefined) return cached;
+
+    const exe = locateCygpath();
+    if (exe === null) return null;
+    let resolved: string;
+    try {
+      const output = deps.execFileSync(exe, ['-w', '-C', 'UTF8', '--', `/${firstSegment}`]);
+      const trimmed = output.replace(/\r?\n$/, '');
+      if (!WIN32_DRIVE_ABSOLUTE_RE.test(trimmed) && !trimmed.startsWith('\\\\')) return null;
+      resolved = trimmed.replace(/[\\/]$/, '');
+    } catch {
+      return null;
+    }
+    segmentCache.set(firstSegment, resolved);
+    return resolved;
+  }
+
+  function fromShellPath(path: string): string {
+    if (!enabled) return path;
+
+    if (path.startsWith('//')) return path;
+
+    if (path.startsWith('/')) {
+      const normalized = nodePath.posix.normalize(path);
+      const lexical = translateShellDrivePath(normalized);
+      if (lexical !== normalized) return lexical;
+      if (normalized === '/') return normalized;
+      if (VIRTUAL_FS_PREFIXES.some((prefix) => normalized.startsWith(prefix))) return normalized;
+      const firstSegment = normalized.slice(1).split('/')[0]!;
+      const prefix = resolveRootSegment(firstSegment);
+      if (prefix === null) return normalized;
+      const remainder = normalized.slice(firstSegment.length + 1);
+      const joined = `${prefix}${remainder}`.replaceAll('\\', '/');
+      return /^[A-Za-z]:$/.test(joined) ? `${joined}/` : joined;
+    }
+
+    return path;
+  }
+
+  function toShellPath(nativePath: string): string {
+    if (!enabled) return nativePath;
+
+    if (nativePath.startsWith('\\\\')) {
+      return nativePath.replaceAll('\\', '/');
+    }
+
+    const driveMatch = /^([A-Za-z]):(?:[\\/]|$)/.exec(nativePath);
+    if (driveMatch !== null) {
+      const drive = driveMatch[1]!.toLowerCase();
+      const rest = nativePath.slice(2).replaceAll('\\', '/');
+      return `/${drive}${rest.startsWith('/') ? rest : `/${rest}`}`;
+    }
+
+    return nativePath.replaceAll('\\', '/');
+  }
+
+  return { toShellPath, fromShellPath };
+}
+
+const bridgeCache = new Map<string, ShellPathBridge>();
+
+export function getShellPathBridge(env: ShellPathBridgeEnv): ShellPathBridge {
+  const key = `${env.osKind} ${env.shellName} ${env.shellPath}`;
+  const cached = bridgeCache.get(key);
+  if (cached !== undefined) return cached;
+  const bridge = createShellPathBridge(env, {
+    execFileSync: (file, args) =>
+      nodeExecFileSync(file, [...args], {
+        encoding: 'utf8',
+        timeout: CYGPATH_TIMEOUT_MS,
+        windowsHide: true,
+      }),
+    isFile: (path) => existsSync(path),
+  });
+  bridgeCache.set(key, bridge);
+  return bridge;
+}

--- a/packages/agent-core-v2/src/agent/tools/os/bash/bashTool.ts
+++ b/packages/agent-core-v2/src/agent/tools/os/bash/bashTool.ts
@@ -8,6 +8,7 @@ import { ISessionWorkspaceContext } from '#/session/workspaceContext/workspaceCo
 import { IAgentRuntimeService, inspectAgentRuntime } from '#/agent/runtimeBinding/agentRuntime';
 import { RuntimeWorkspaceView } from '#/runtime/runtimeWorkspaceView';
 import { IAgentToolPolicyService } from '#/agent/toolPolicy/toolPolicy';
+import { getShellPathBridge } from '#/_base/execEnv/shellPathBridge';
 import type { ExecutableToolResult, ToolExecution, ToolUpdate } from '#/tool/toolContract';
 import {
   type ExecutableToolResultBuilderResult,
@@ -150,7 +151,7 @@ export class BashTool implements IBashTool {
     effectiveCwd: string,
     command: string,
   ): Promise<IHostProcess> {
-    const shellCwd = env.osKind === 'Windows' ? windowsPathToPosixPath(effectiveCwd) : effectiveCwd;
+    const shellCwd = getShellPathBridge(env).toShellPath(effectiveCwd);
     const shellCommand = `cd ${shellQuote(shellCwd)} && ${command}`;
     const noninteractiveEnv: Record<string, string> = {
       NO_COLOR: '1',
@@ -446,21 +447,6 @@ async function killSpawnedProcess(proc: IHostProcess): Promise<void> {
 
 function shellQuote(s: string): string {
   return `'${s.replaceAll("'", "'\\''")}'`;
-}
-
-function windowsPathToPosixPath(path: string): string {
-  if (path.startsWith('\\\\')) {
-    return path.replaceAll('\\', '/');
-  }
-
-  const driveMatch = /^([A-Za-z]):(?:[\\/]|$)/.exec(path);
-  if (driveMatch !== null) {
-    const drive = driveMatch[1]!.toLowerCase();
-    const rest = path.slice(2).replaceAll('\\', '/');
-    return `/${drive}${rest.startsWith('/') ? rest : `/${rest}`}`;
-  }
-
-  return path.replaceAll('\\', '/');
 }
 
 const WINDOWS_NUL_REDIRECT = /(\d?&?>+\s*)[Nn][Uu][Ll](?=\s|$|[|&;)\n])/g;

--- a/packages/agent-core-v2/src/runtime/fakeRuntime.ts
+++ b/packages/agent-core-v2/src/runtime/fakeRuntime.ts
@@ -25,6 +25,7 @@ export class FakeRuntime implements Runtime {
       readonly status?: RuntimeStatus;
       readonly capabilities?: readonly RuntimeCapability[];
       readonly pathClass?: 'posix' | 'win32';
+      readonly environment?: Partial<Runtime['environment']>;
       readonly mapWorkspaceRoots?: Runtime['workspace']['mapRoots'];
     } = {},
   ) {
@@ -39,6 +40,7 @@ export class FakeRuntime implements Runtime {
       shellPath: '/bin/sh',
       pathClass: options.pathClass ?? 'posix',
       homeDir: options.pathClass === 'win32' ? 'C:\\Users\\fake' : '/home/fake',
+      ...options.environment,
     };
     this.path = {
       separator: path.sep as '/' | '\\',

--- a/packages/agent-core-v2/src/runtime/runtimeWorkspaceView.ts
+++ b/packages/agent-core-v2/src/runtime/runtimeWorkspaceView.ts
@@ -1,4 +1,5 @@
 import { ErrorCodes, Error2 } from '#/errors';
+import { getShellPathBridge } from '#/_base/execEnv/shellPathBridge';
 
 import type { Runtime, RuntimeBinding, RuntimeWorkspaceRoots } from './runtime';
 
@@ -27,9 +28,11 @@ export class RuntimeWorkspaceView {
   }
 
   resolve(path: string, cwd = this.workDir): string {
-    const resolved = this.runtime.path.isAbsolute(path)
-      ? this.runtime.path.resolve(path)
-      : this.runtime.path.resolve(cwd, path);
+    const env = this.runtime.environment;
+    const bridged = env.pathClass === 'win32' ? getShellPathBridge(env).fromShellPath(path) : path;
+    const resolved = this.runtime.path.isAbsolute(bridged)
+      ? this.runtime.path.resolve(bridged)
+      : this.runtime.path.resolve(cwd, bridged);
     this.assertAllowed(resolved);
     return resolved;
   }

--- a/packages/agent-core-v2/src/tool/path-access.ts
+++ b/packages/agent-core-v2/src/tool/path-access.ts
@@ -1,5 +1,10 @@
 import * as pathe from 'pathe';
 
+import {
+  getShellPathBridge,
+  translateShellDrivePath,
+  type ShellPathBridge,
+} from '#/_base/execEnv/shellPathBridge';
 import type { IHostEnvironment } from '#/os/interface/hostEnvironment';
 
 export interface WorkspaceConfig {
@@ -118,29 +123,7 @@ function isWin32DriveRelative(path: string): boolean {
 }
 
 export function normalizeUserPath(path: string, pathClass: PathClass = DEFAULT_PATH_CLASS): string {
-  if (pathClass !== 'win32') return path;
-
-  if (path === '/') return '/';
-
-  if (path.startsWith('//')) {
-    return path;
-  }
-
-  const cygdriveMatch = /^\/cygdrive\/([A-Za-z])(?:\/|$)/.exec(path);
-  if (cygdriveMatch !== null) {
-    const drive = cygdriveMatch[1]!.toUpperCase();
-    const rest = path.slice(`/cygdrive/${cygdriveMatch[1]!}`.length);
-    return `${drive}:${rest === '' ? '/' : rest}`;
-  }
-
-  const driveMatch = /^\/([A-Za-z])(?:\/|$)/.exec(path);
-  if (driveMatch !== null) {
-    const drive = driveMatch[1]!.toUpperCase();
-    const rest = path.slice(2);
-    return `${drive}:${rest === '' ? '/' : rest}`;
-  }
-
-  return path;
+  return pathClass === 'win32' ? translateShellDrivePath(path) : path;
 }
 
 function expandUserPath(path: string, homeDir: string | undefined, pathClass: PathClass): string {
@@ -233,10 +216,14 @@ export interface ResolvePathAccessOptions {
   readonly policy?: WorkspaceAccessPolicy | undefined;
   readonly pathClass?: PathClass | undefined;
   readonly homeDir?: string;
+  readonly shellPathBridge?: ShellPathBridge;
 }
 
 export interface ResolvePathAccessPathOptions {
-  readonly env: Pick<IHostEnvironment, 'pathClass' | 'homeDir'>;
+  readonly env: Pick<
+    IHostEnvironment,
+    'pathClass' | 'homeDir' | 'osKind' | 'shellName' | 'shellPath'
+  >;
   readonly workspace: WorkspaceConfig;
   readonly operation: PathAccessOperation;
   readonly policy?: WorkspaceAccessPolicy;
@@ -263,7 +250,8 @@ export function resolvePathAccess(
   options: ResolvePathAccessOptions,
 ): PathAccess {
   const pathClass = options.pathClass ?? DEFAULT_PATH_CLASS;
-  const normalizedPath = normalizeUserPath(path, pathClass);
+  const normalizedPath =
+    options.shellPathBridge?.fromShellPath(path) ?? normalizeUserPath(path, pathClass);
   const expandedPath = expandUserPath(normalizedPath, options.homeDir, pathClass);
   const rawIsAbsolute = pathe.isAbsolute(expandedPath);
   const canonical = canonicalizePath(expandedPath, cwd, pathClass);
@@ -310,6 +298,7 @@ export function resolvePathAccessPath(
     policy,
     pathClass: env.pathClass,
     homeDir: expandHome ? env.homeDir : undefined,
+    shellPathBridge: env.pathClass === 'win32' ? getShellPathBridge(env) : undefined,
   }).path;
 }
 

--- a/packages/agent-core-v2/test/_base/execEnv/shellPathBridge.test.ts
+++ b/packages/agent-core-v2/test/_base/execEnv/shellPathBridge.test.ts
@@ -1,0 +1,260 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  createShellPathBridge,
+  type ShellPathBridgeDeps,
+  type ShellPathBridgeEnv,
+} from '#/_base/execEnv/shellPathBridge';
+
+const WINDOWS_ENV: ShellPathBridgeEnv = {
+  osKind: 'Windows',
+  shellName: 'bash',
+  shellPath: 'C:\\Program Files\\Git\\bin\\bash.exe',
+};
+
+const POSIX_ENV: ShellPathBridgeEnv = {
+  osKind: 'Linux',
+  shellName: 'bash',
+  shellPath: '/bin/bash',
+};
+
+const BIN_CYGPATH = 'C:\\Program Files\\Git\\bin\\cygpath.exe';
+const USR_BIN_CYGPATH = 'C:\\Program Files\\Git\\usr\\bin\\cygpath.exe';
+
+interface StubOpts {
+  readonly existingPaths?: readonly string[];
+  readonly execFileResults?: Readonly<Record<string, string>>;
+  readonly execFileSync?: ShellPathBridgeDeps['execFileSync'];
+}
+
+function stubDeps(opts: StubOpts = {}) {
+  const existing = new Set(opts.existingPaths ?? []);
+  const execFileSync = vi.fn(
+    opts.execFileSync ??
+      ((file: string, args: readonly string[]): string => {
+        const result = opts.execFileResults?.[[file, ...args].join(' ')];
+        if (result === undefined) throw new Error(`unexpected execFileSync: ${file}`);
+        return result;
+      }),
+  );
+  const deps: ShellPathBridgeDeps = {
+    execFileSync,
+    isFile: (path: string) => existing.has(path),
+  };
+  return { deps, execFileSync };
+}
+
+function cygpathKey(firstSegment: string): string {
+  return `${USR_BIN_CYGPATH} -w -C UTF8 -- /${firstSegment}`;
+}
+
+describe('fromShellPath lexical drive forms', () => {
+  const cases: ReadonlyArray<readonly [string, string]> = [
+    ['/c:/Users/foo', 'C:/Users/foo'],
+    ['/c:', 'C:/'],
+    ['/cygdrive/c/Users/foo', 'C:/Users/foo'],
+    ['/cygdrive/d', 'D:/'],
+    ['/c/Users/foo', 'C:/Users/foo'],
+    ['/C/Users/foo', 'C:/Users/foo'],
+    ['/c/', 'C:/'],
+    ['/c', 'C:/'],
+  ];
+
+  for (const [input, expected] of cases) {
+    it(`rewrites "${input}"`, () => {
+      const { deps, execFileSync } = stubDeps();
+      const bridge = createShellPathBridge(WINDOWS_ENV, deps);
+      expect(bridge.fromShellPath(input)).toBe(expected);
+      expect(execFileSync).not.toHaveBeenCalled();
+    });
+  }
+});
+
+describe('fromShellPath pass-through', () => {
+  it.each(['/dev/null', '/dev/pty0', '/proc/self/status', '/sys/kernel'])(
+    'leaves virtual-fs path %s unchanged',
+    (input) => {
+      const { deps, execFileSync } = stubDeps();
+      const bridge = createShellPathBridge(WINDOWS_ENV, deps);
+      expect(bridge.fromShellPath(input)).toBe(input);
+      expect(execFileSync).not.toHaveBeenCalled();
+    },
+  );
+
+  it.each([
+    '/',
+    '//server/share',
+    '//server/share/file.txt',
+    'relative/path',
+    'relative\\path',
+    'file.txt',
+    'C:\\Users\\foo',
+    'C:/Users/foo',
+    '~/Documents',
+  ])('leaves %s unchanged without consulting cygpath', (input) => {
+    const { deps, execFileSync } = stubDeps();
+    const bridge = createShellPathBridge(WINDOWS_ENV, deps);
+    expect(bridge.fromShellPath(input)).toBe(input);
+    expect(execFileSync).not.toHaveBeenCalled();
+  });
+});
+
+describe('fromShellPath cygpath resolution', () => {
+  it('resolves a root-relative path through cygpath and caches per first segment', () => {
+    const { deps, execFileSync } = stubDeps({
+      existingPaths: [USR_BIN_CYGPATH],
+      execFileResults: {
+        [cygpathKey('tmp')]: 'C:\\Users\\me\\AppData\\Local\\Temp\\\n',
+      },
+    });
+    const bridge = createShellPathBridge(WINDOWS_ENV, deps);
+
+    expect(bridge.fromShellPath('/tmp/scratch/a.txt')).toBe(
+      'C:/Users/me/AppData/Local/Temp/scratch/a.txt',
+    );
+    expect(bridge.fromShellPath('/tmp/other')).toBe('C:/Users/me/AppData/Local/Temp/other');
+    expect(bridge.fromShellPath('/tmp')).toBe('C:/Users/me/AppData/Local/Temp');
+    expect(execFileSync).toHaveBeenCalledTimes(1);
+    expect(execFileSync).toHaveBeenCalledWith(USR_BIN_CYGPATH, [
+      '-w',
+      '-C',
+      'UTF8',
+      '--',
+      '/tmp',
+    ]);
+  });
+
+  it('folds dot segments before resolving the mount segment', () => {
+    const { deps, execFileSync } = stubDeps({
+      existingPaths: [USR_BIN_CYGPATH],
+      execFileResults: {
+        [cygpathKey('tmp')]: 'C:\\Users\\me\\AppData\\Local\\Temp\n',
+        [cygpathKey('home')]: 'C:\\Program Files\\Git\\home\n',
+      },
+    });
+    const bridge = createShellPathBridge(WINDOWS_ENV, deps);
+
+    expect(bridge.fromShellPath('/./tmp/note.txt')).toBe(
+      'C:/Users/me/AppData/Local/Temp/note.txt',
+    );
+    expect(bridge.fromShellPath('/../tmp/note.txt')).toBe(
+      'C:/Users/me/AppData/Local/Temp/note.txt',
+    );
+    expect(bridge.fromShellPath('/tmp/../home/x.txt')).toBe('C:/Program Files/Git/home/x.txt');
+    expect(execFileSync).toHaveBeenCalledTimes(2);
+  });
+
+  it('folds dot segments before lexical drive translation', () => {
+    const { deps, execFileSync } = stubDeps();
+    const bridge = createShellPathBridge(WINDOWS_ENV, deps);
+
+    expect(bridge.fromShellPath('/./c/Projects')).toBe('C:/Projects');
+    expect(execFileSync).not.toHaveBeenCalled();
+  });
+
+  it.each(['/.', '/..'])('normalizes %s to / without consulting cygpath', (input) => {
+    const { deps, execFileSync } = stubDeps();
+    const bridge = createShellPathBridge(WINDOWS_ENV, deps);
+
+    expect(bridge.fromShellPath(input)).toBe('/');
+    expect(execFileSync).not.toHaveBeenCalled();
+  });
+
+  it('resolves a drive-root mount and keeps it absolute', () => {
+    const { deps, execFileSync } = stubDeps({
+      existingPaths: [USR_BIN_CYGPATH],
+      execFileResults: { [cygpathKey('work')]: 'D:\\\n' },
+    });
+    const bridge = createShellPathBridge(WINDOWS_ENV, deps);
+
+    expect(bridge.fromShellPath('/work/app')).toBe('D:/app');
+    expect(bridge.fromShellPath('/work')).toBe('D:/');
+    expect(execFileSync).toHaveBeenCalledTimes(1);
+  });
+
+  it('prefers cygpath.exe next to bash.exe when present', () => {
+    const key = `${BIN_CYGPATH} -w -C UTF8 -- /home`;
+    const { deps, execFileSync } = stubDeps({
+      existingPaths: [BIN_CYGPATH, USR_BIN_CYGPATH],
+      execFileResults: { [key]: 'C:\\Users\n' },
+    });
+    const bridge = createShellPathBridge(WINDOWS_ENV, deps);
+
+    expect(bridge.fromShellPath('/home/u/f.txt')).toBe('C:/Users/u/f.txt');
+    expect(execFileSync).toHaveBeenCalledTimes(1);
+    expect(execFileSync).toHaveBeenCalledWith(BIN_CYGPATH, ['-w', '-C', 'UTF8', '--', '/home']);
+  });
+
+  it('passes through and retries on the next access when cygpath fails', () => {
+    const { deps, execFileSync } = stubDeps({
+      existingPaths: [USR_BIN_CYGPATH],
+      execFileSync: () => {
+        throw new Error('cygpath exited 1');
+      },
+    });
+    const bridge = createShellPathBridge(WINDOWS_ENV, deps);
+
+    expect(bridge.fromShellPath('/tmp/x')).toBe('/tmp/x');
+    expect(bridge.fromShellPath('/tmp/y')).toBe('/tmp/y');
+    expect(execFileSync).toHaveBeenCalledTimes(2);
+  });
+
+  it('passes through and retries when cygpath output is not an absolute win32 path', () => {
+    const { deps, execFileSync } = stubDeps({
+      existingPaths: [USR_BIN_CYGPATH],
+      execFileResults: { [cygpathKey('tmp')]: 'not a win32 path\n' },
+    });
+    const bridge = createShellPathBridge(WINDOWS_ENV, deps);
+
+    expect(bridge.fromShellPath('/tmp/x')).toBe('/tmp/x');
+    expect(bridge.fromShellPath('/tmp/y')).toBe('/tmp/y');
+    expect(execFileSync).toHaveBeenCalledTimes(2);
+  });
+
+  it('passes through without spawning when cygpath.exe is missing', () => {
+    const { deps, execFileSync } = stubDeps();
+    const bridge = createShellPathBridge(WINDOWS_ENV, deps);
+
+    expect(bridge.fromShellPath('/tmp/x')).toBe('/tmp/x');
+    expect(bridge.fromShellPath('/home/u')).toBe('/home/u');
+    expect(execFileSync).not.toHaveBeenCalled();
+  });
+});
+
+describe('identity outside win32 bash', () => {
+  it('is identity on posix', () => {
+    const { deps, execFileSync } = stubDeps();
+    const bridge = createShellPathBridge(POSIX_ENV, deps);
+    expect(bridge.fromShellPath('/c/Users/foo')).toBe('/c/Users/foo');
+    expect(bridge.fromShellPath('/tmp/x')).toBe('/tmp/x');
+    expect(bridge.toShellPath('C:\\Users\\foo')).toBe('C:\\Users\\foo');
+    expect(execFileSync).not.toHaveBeenCalled();
+  });
+
+  it('is identity on Windows without bash', () => {
+    const { deps, execFileSync } = stubDeps();
+    const bridge = createShellPathBridge(
+      { osKind: 'Windows', shellName: 'sh', shellPath: 'C:\\sh.exe' },
+      deps,
+    );
+    expect(bridge.fromShellPath('/c/Users/foo')).toBe('/c/Users/foo');
+    expect(bridge.toShellPath('C:\\Users\\foo')).toBe('C:\\Users\\foo');
+    expect(execFileSync).not.toHaveBeenCalled();
+  });
+});
+
+describe('toShellPath', () => {
+  it.each([
+    ['C:\\Users\\foo', '/c/Users/foo'],
+    ['C:/Users/foo', '/c/Users/foo'],
+    ['C:\\', '/c/'],
+    ['D:\\Projects', '/d/Projects'],
+    ['\\\\server\\share\\dir', '//server/share/dir'],
+    ['relative\\path', 'relative/path'],
+    ['already/posix', 'already/posix'],
+  ])('maps %s → %s', (input, expected) => {
+    const { deps } = stubDeps();
+    const bridge = createShellPathBridge(WINDOWS_ENV, deps);
+    expect(bridge.toShellPath(input)).toBe(expected);
+  });
+});

--- a/packages/agent-core-v2/test/runtime/runtimeWorkspaceView.test.ts
+++ b/packages/agent-core-v2/test/runtime/runtimeWorkspaceView.test.ts
@@ -75,6 +75,29 @@ describe('RuntimeWorkspaceView', () => {
     expect(() => win32View.resolve('C:\\provider-a\\repo\\file.txt')).toThrow('outside runtime workspace');
   });
 
+  it('translates Git Bash POSIX paths on win32 bash runtimes', () => {
+    const winBash = new FakeRuntime(
+      { workspaceId: 'workspace', runtimeId: 'local', generation: 'one' },
+      {
+        pathClass: 'win32',
+        environment: {
+          osKind: 'Windows',
+          shellName: 'bash',
+          shellPath: 'C:\\kimi-test-nonexistent\\Git\\bin\\bash.exe',
+        },
+      },
+    );
+    const view = new RuntimeWorkspaceView(winBash, {
+      workDir: 'C:\\workspace\\project',
+      additionalDirs: [],
+    });
+    expect(view.resolve('/c/workspace/project/src/index.ts')).toBe('C:\\workspace\\project\\src\\index.ts');
+    expect(view.resolve('/cygdrive/c/workspace/project/package.json')).toBe(
+      'C:\\workspace\\project\\package.json',
+    );
+    expect(() => view.resolve('/tmp/scratch.txt')).toThrow('outside runtime workspace');
+  });
+
   it('deduplicates roots and preserves generation identity', () => {
     const first = new RuntimeWorkspaceView(runtime('one', 'posix'), {
       workDir: '/workspace',

--- a/packages/agent-core-v2/test/tool/path-access.test.ts
+++ b/packages/agent-core-v2/test/tool/path-access.test.ts
@@ -1,6 +1,13 @@
 import { describe, expect, it } from 'vitest';
 
-import { extendWorkspaceWithSkillRoots, isSensitiveFile } from '#/tool/path-access';
+import type { ShellPathBridge } from '#/_base/execEnv/shellPathBridge';
+import {
+  DEFAULT_WORKSPACE_ACCESS_POLICY,
+  extendWorkspaceWithSkillRoots,
+  isSensitiveFile,
+  resolvePathAccess,
+  resolvePathAccessPath,
+} from '#/tool/path-access';
 
 describe('isSensitiveFile', () => {
   it('flags base .env files in any directory', () => {
@@ -100,5 +107,52 @@ describe('extendWorkspaceWithSkillRoots', () => {
         'win32',
       ).additionalDirs,
     ).toEqual([]);
+  });
+});
+
+describe('resolvePathAccess shell path bridge', () => {
+  const WIN_ENV = {
+    pathClass: 'win32' as const,
+    homeDir: 'C:\\Users\\test',
+    osKind: 'Windows',
+    shellName: 'bash' as const,
+    shellPath: 'C:\\kimi-test-nonexistent\\Git\\bin\\bash.exe',
+  };
+
+  it('routes win32 file-tool paths through the shell path bridge', () => {
+    const result = resolvePathAccessPath('/c/workspace/file.txt', {
+      env: WIN_ENV,
+      workspace: { workspaceDir: 'C:\\workspace', additionalDirs: [] },
+      operation: 'read',
+    });
+    expect(result).toBe('C:/workspace/file.txt');
+  });
+
+  it('passes root-relative POSIX paths through when cygpath is unavailable', () => {
+    const result = resolvePathAccessPath('/tmp/scratch.txt', {
+      env: WIN_ENV,
+      workspace: { workspaceDir: 'C:\\workspace', additionalDirs: [] },
+      operation: 'read',
+    });
+    expect(result).toBe('/tmp/scratch.txt');
+  });
+
+  it('normalizes through an explicitly injected shell path bridge', () => {
+    const bridge: ShellPathBridge = {
+      toShellPath: (p) => p,
+      fromShellPath: (p) => (p.startsWith('/tmp/') ? `C:/Temp/${p.slice('/tmp/'.length)}` : p),
+    };
+    const result = resolvePathAccess(
+      '/tmp/notes.txt',
+      'C:\\workspace',
+      { workspaceDir: 'C:\\workspace', additionalDirs: [] },
+      {
+        operation: 'read',
+        pathClass: 'win32',
+        policy: DEFAULT_WORKSPACE_ACCESS_POLICY,
+        shellPathBridge: bridge,
+      },
+    );
+    expect(result).toEqual({ path: 'C:/Temp/notes.txt', outsideWorkspace: true });
   });
 });

--- a/packages/agent-core/src/tools/builtin/shell/bash.ts
+++ b/packages/agent-core/src/tools/builtin/shell/bash.ts
@@ -22,7 +22,7 @@
  *     foreground runs pass a callback to collect chunks for this call.
  */
 
-import type { Kaos, KaosProcess } from '@moonshot-ai/kaos';
+import { getShellPathBridge, type Kaos, type KaosProcess } from '@moonshot-ai/kaos';
 import { z } from 'zod';
 
 import { ProcessBackgroundTask, type BackgroundManager } from '../../../agent/background';
@@ -271,7 +271,7 @@ export class BashTool implements BuiltinTool<BashInput> {
   }
 
   private spawn(effectiveCwd: string, command: string): Promise<KaosProcess> {
-    const shellCwd = this.isWindowsBash ? windowsPathToPosixPath(effectiveCwd) : effectiveCwd;
+    const shellCwd = getShellPathBridge(this.kaos.osEnv).toShellPath(effectiveCwd);
     const shellArgs = [
       this.kaos.osEnv.shellPath,
       '-c',
@@ -605,21 +605,6 @@ async function killSpawnedProcess(proc: KaosProcess): Promise<void> {
 
 function shellQuote(s: string): string {
   return `'${s.replaceAll("'", "'\\''")}'`;
-}
-
-function windowsPathToPosixPath(path: string): string {
-  if (path.startsWith('\\\\')) {
-    return path.replaceAll('\\', '/');
-  }
-
-  const driveMatch = /^([A-Za-z]):(?:[\\/]|$)/.exec(path);
-  if (driveMatch !== null) {
-    const drive = driveMatch[1]!.toLowerCase();
-    const rest = path.slice(2).replaceAll('\\', '/');
-    return `/${drive}${rest.startsWith('/') ? rest : `/${rest}`}`;
-  }
-
-  return path.replaceAll('\\', '/');
 }
 
 const WINDOWS_NUL_REDIRECT = /(\d?&?>+\s*)[Nn][Uu][Ll](?=\s|$|[|&;)\n])/g;

--- a/packages/agent-core/src/tools/policies/path-access.ts
+++ b/packages/agent-core/src/tools/policies/path-access.ts
@@ -14,7 +14,12 @@
 
 import * as pathe from 'pathe';
 
-import type { Kaos } from '@moonshot-ai/kaos';
+import {
+  getShellPathBridge,
+  translateShellDrivePath,
+  type Kaos,
+  type ShellPathBridge,
+} from '@moonshot-ai/kaos';
 
 import type { WorkspaceConfig } from '../support/workspace';
 import { isSensitiveFile } from './sensitive';
@@ -60,31 +65,7 @@ function isWin32DriveRelative(path: string): boolean {
 }
 
 export function normalizeUserPath(path: string, pathClass: PathClass = DEFAULT_PATH_CLASS): string {
-  if (pathClass !== 'win32') return path;
-
-  // A bare root slash stays forward so downstream pathe operations
-  // treat it consistently. Matches the py helper's behavior.
-  if (path === '/') return '/';
-
-  if (path.startsWith('//')) {
-    return path;
-  }
-
-  const cygdriveMatch = /^\/cygdrive\/([A-Za-z])(?:\/|$)/.exec(path);
-  if (cygdriveMatch !== null) {
-    const drive = cygdriveMatch[1]!.toUpperCase();
-    const rest = path.slice(`/cygdrive/${cygdriveMatch[1]!}`.length);
-    return `${drive}:${rest === '' ? '/' : rest}`;
-  }
-
-  const driveMatch = /^\/([A-Za-z])(?:\/|$)/.exec(path);
-  if (driveMatch !== null) {
-    const drive = driveMatch[1]!.toUpperCase();
-    const rest = path.slice(2);
-    return `${drive}:${rest === '' ? '/' : rest}`;
-  }
-
-  return path;
+  return pathClass === 'win32' ? translateShellDrivePath(path) : path;
 }
 
 function expandUserPath(path: string, homeDir: string | undefined, pathClass: PathClass): string {
@@ -175,10 +156,15 @@ export interface ResolvePathAccessOptions {
   readonly policy?: WorkspaceAccessPolicy | undefined;
   readonly pathClass?: PathClass | undefined;
   readonly homeDir?: string;
+  /**
+   * Shell path bridge used to normalize model-supplied paths on win32 bash;
+   * without it paths go through the lexical-only {@link normalizeUserPath}.
+   */
+  readonly shellPathBridge?: ShellPathBridge;
 }
 
 export interface ResolvePathAccessPathOptions {
-  readonly kaos: Pick<Kaos, 'pathClass' | 'gethome'>;
+  readonly kaos: Pick<Kaos, 'pathClass' | 'gethome' | 'osEnv'>;
   readonly workspace: WorkspaceConfig;
   readonly operation: PathAccessOperation;
   readonly policy?: WorkspaceAccessPolicy;
@@ -205,7 +191,8 @@ export function resolvePathAccess(
   options: ResolvePathAccessOptions,
 ): PathAccess {
   const pathClass = options.pathClass ?? DEFAULT_PATH_CLASS;
-  const normalizedPath = normalizeUserPath(path, pathClass);
+  const normalizedPath =
+    options.shellPathBridge?.fromShellPath(path) ?? normalizeUserPath(path, pathClass);
   const expandedPath = expandUserPath(normalizedPath, options.homeDir, pathClass);
   const rawIsAbsolute = pathe.isAbsolute(expandedPath);
   const canonical = canonicalizePath(expandedPath, cwd, pathClass);
@@ -247,11 +234,15 @@ export function resolvePathAccessPath(
   options: ResolvePathAccessPathOptions,
 ): string {
   const { kaos, workspace, operation, policy, expandHome = true } = options;
+  const pathClass = kaos.pathClass();
   return resolvePathAccess(path, workspace.workspaceDir, workspace, {
     operation,
     policy,
-    pathClass: kaos.pathClass(),
+    pathClass,
     homeDir: expandHome ? kaos.gethome() : undefined,
+    // Only win32 needs the bridge (identity on posix), and `osEnv` is
+    // unavailable in probing-free environments (SSH throws).
+    shellPathBridge: pathClass === 'win32' ? getShellPathBridge(kaos.osEnv) : undefined,
   }).path;
 }
 

--- a/packages/agent-core/test/tools/path-guard.test.ts
+++ b/packages/agent-core/test/tools/path-guard.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
+import type { Environment, ShellPathBridge } from '@moonshot-ai/kaos';
+
 import {
   canonicalizePath,
   DEFAULT_WORKSPACE_ACCESS_POLICY,
@@ -27,6 +29,26 @@ const WIN_WORKSPACE: WorkspaceConfig = {
 const POSIX_KAOS = {
   pathClass: () => 'posix' as const,
   gethome: () => '/home/test',
+  osEnv: {
+    osKind: 'Linux',
+    osArch: 'x86_64',
+    osVersion: 'test',
+    shellName: 'bash',
+    shellPath: '/bin/bash',
+  } satisfies Environment,
+};
+
+const WIN_KAOS = {
+  pathClass: () => 'win32' as const,
+  gethome: () => 'C:\\Users\\test',
+  osEnv: {
+    osKind: 'Windows',
+    osArch: 'x86_64',
+    osVersion: 'test',
+    shellName: 'bash',
+    // Deliberately nonexistent so no cygpath.exe is ever found — resolution degrades to pass-through.
+    shellPath: 'C:\\kimi-test-nonexistent\\Git\\bin\\bash.exe',
+  } satisfies Environment,
 };
 
 describe('path access policy', () => {
@@ -135,6 +157,38 @@ describe('path access policy', () => {
         expandHome: false,
       }),
     ).toBe('/workspace/~/notes/today.txt');
+  });
+
+  it('routes win32 file-tool paths through the shell path bridge', () => {
+    const result = resolvePathAccessPath('/c/workspace/file.txt', {
+      kaos: WIN_KAOS,
+      workspace: { workspaceDir: 'C:\\workspace', additionalDirs: [] },
+      operation: 'read',
+    });
+    expect(result).toBe('C:/workspace/file.txt');
+  });
+
+  it('passes root-relative POSIX paths through when cygpath is unavailable', () => {
+    const result = resolvePathAccessPath('/tmp/scratch.txt', {
+      kaos: WIN_KAOS,
+      workspace: { workspaceDir: 'C:\\workspace', additionalDirs: [] },
+      operation: 'read',
+    });
+    expect(result).toBe('/tmp/scratch.txt');
+  });
+
+  it('normalizes through an explicitly injected shell path bridge', () => {
+    const bridge: ShellPathBridge = {
+      toShellPath: (p) => p,
+      fromShellPath: (p) => (p.startsWith('/tmp/') ? `C:/Temp/${p.slice('/tmp/'.length)}` : p),
+    };
+    const result = resolvePathAccess('/tmp/notes.txt', 'C:\\workspace', WIN_WORKSPACE, {
+      operation: 'read',
+      pathClass: 'win32',
+      policy: DEFAULT_WORKSPACE_ACCESS_POLICY,
+      shellPathBridge: bridge,
+    });
+    expect(result).toEqual({ path: 'C:/Temp/notes.txt', outsideWorkspace: true });
   });
 
   it('legacy assertPathAllowed allows absolute outside paths but rejects relative escapes', () => {
@@ -383,6 +437,7 @@ describe('path access policy', () => {
     const cases: ReadonlyArray<readonly [string, string]> = [
       ['/c/Users/foo', 'C:/Users/foo'],
       ['/d/Projects/kimi', 'D:/Projects/kimi'],
+      ['/c:/Users/foo', 'C:/Users/foo'],
       ['/C/Users/foo', 'C:/Users/foo'],
       ['/c/', 'C:/'],
       ['/c', 'C:/'],

--- a/packages/kaos/src/index.ts
+++ b/packages/kaos/src/index.ts
@@ -8,6 +8,12 @@ export type {
   ShellName,
 } from './environment';
 export { detectEnvironment, detectEnvironmentFromNode } from './environment';
+export type {
+  ShellPathBridge,
+  ShellPathBridgeDeps,
+  ShellPathBridgeEnv,
+} from './shell-path-bridge';
+export { createShellPathBridge, getShellPathBridge, translateShellDrivePath } from './shell-path-bridge';
 export {
   KaosError,
   KaosValueError,

--- a/packages/kaos/src/shell-path-bridge.ts
+++ b/packages/kaos/src/shell-path-bridge.ts
@@ -1,0 +1,189 @@
+/**
+ * Shell path bridge — translate between native win32 paths and the POSIX
+ * path dialect spoken by the MSYS2 / Git Bash shell.
+ *
+ * The msys runtime gives the shell a POSIX path view native Node.js cannot
+ * resolve (`/c/Users/x` is `C:\Users\x`; `/tmp/x` is `%TEMP%\x`, not
+ * `<git-root>/tmp`). `toShellPath` renders native paths for bash command
+ * lines; `fromShellPath` resolves model/shell-supplied paths for fs access,
+ * translating drive-letter forms lexically and other root-relative paths
+ * through `cygpath -w` next to the probed bash. Anything unconvertible
+ * passes through unchanged, and both directions are identity outside win32
+ * bash.
+ *
+ * Synchronous and self-contained (node builtins only):
+ * `createShellPathBridge` takes injectable deps for tests;
+ * `getShellPathBridge` bundles the Node defaults, memoised per env object.
+ */
+
+import { execFileSync as nodeExecFileSync } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import * as nodePath from 'node:path';
+
+import type { Environment } from './environment';
+
+export interface ShellPathBridge {
+  /** Native win32 path → shell dialect, for building bash commands. Identity on posix. */
+  toShellPath(nativePath: string): string;
+  /** Model/shell-supplied path → native, for fs access. Identity when not convertible. */
+  fromShellPath(path: string): string;
+}
+
+export type ShellPathBridgeEnv = Pick<Environment, 'osKind' | 'shellName' | 'shellPath'>;
+
+export interface ShellPathBridgeDeps {
+  readonly execFileSync: (file: string, args: readonly string[]) => string;
+  readonly isFile: (path: string) => boolean;
+}
+
+const CYGPATH_TIMEOUT_MS = 5_000;
+
+const DRIVE_COLON_RE = /^\/([a-zA-Z]):(?:[\\/]|$)/;
+const CYGDRIVE_RE = /^\/cygdrive\/([a-zA-Z])(?:\/|$)/;
+const DRIVE_RE = /^\/([a-zA-Z])(?:\/|$)/;
+
+// cygpath semantics are undefined for the virtual filesystems.
+const VIRTUAL_FS_PREFIXES: readonly string[] = ['/dev/', '/proc/', '/sys/'];
+
+const WIN32_DRIVE_ABSOLUTE_RE = /^[A-Za-z]:[\\/]/;
+
+function joinDrive(letter: string, rest: string): string {
+  const normalizedRest = rest.replaceAll('\\', '/');
+  return normalizedRest === ''
+    ? `${letter.toUpperCase()}:/`
+    : `${letter.toUpperCase()}:${normalizedRest}`;
+}
+
+/**
+ * Lexical translation of shell-dialect drive paths (`/c/x`, `/c:/x`,
+ * `/cygdrive/c/x`) to native win32 form — pure string rewriting, no cygpath
+ * involved. Anything else is returned unchanged.
+ */
+export function translateShellDrivePath(path: string): string {
+  const colonMatch = DRIVE_COLON_RE.exec(path);
+  if (colonMatch !== null) {
+    return joinDrive(colonMatch[1]!, path.slice(3));
+  }
+  const cygdriveMatch = CYGDRIVE_RE.exec(path);
+  if (cygdriveMatch !== null) {
+    return joinDrive(cygdriveMatch[1]!, path.slice(`/cygdrive/${cygdriveMatch[1]!}`.length));
+  }
+  const driveMatch = DRIVE_RE.exec(path);
+  if (driveMatch !== null) {
+    return joinDrive(driveMatch[1]!, path.slice(2));
+  }
+  return path;
+}
+
+export function createShellPathBridge(
+  env: ShellPathBridgeEnv,
+  deps: ShellPathBridgeDeps,
+): ShellPathBridge {
+  const enabled = env.osKind === 'Windows' && env.shellName === 'bash';
+
+  // Lazily located on first use; `null` = not found → permanent pass-through.
+  let cygpathExe: string | null | undefined;
+  // Cache successes only: a missing cygpath.exe is a stable fact, but an
+  // execution failure may be transient. First-segment caching is exact for
+  // default (first-level) mount tables; deeper user mounts are out of scope.
+  const segmentCache = new Map<string, string>();
+
+  function locateCygpath(): string | null {
+    if (cygpathExe !== undefined) return cygpathExe;
+    const shellDir = nodePath.win32.dirname(env.shellPath);
+    const candidates = [nodePath.win32.join(shellDir, 'cygpath.exe')];
+    if (nodePath.win32.basename(shellDir).toLowerCase() === 'bin') {
+      candidates.push(nodePath.win32.join(shellDir, '..', 'usr', 'bin', 'cygpath.exe'));
+    }
+    cygpathExe = candidates.find((candidate) => deps.isFile(candidate)) ?? null;
+    return cygpathExe;
+  }
+
+  function resolveRootSegment(firstSegment: string): string | null {
+    const cached = segmentCache.get(firstSegment);
+    if (cached !== undefined) return cached;
+
+    const exe = locateCygpath();
+    if (exe === null) return null;
+    let resolved: string;
+    try {
+      const output = deps.execFileSync(exe, ['-w', '-C', 'UTF8', '--', `/${firstSegment}`]);
+      // cygpath appends a newline and may emit a trailing separator (`D:\`).
+      const trimmed = output.replace(/\r?\n$/, '');
+      if (!WIN32_DRIVE_ABSOLUTE_RE.test(trimmed) && !trimmed.startsWith('\\\\')) return null;
+      resolved = trimmed.replace(/[\\/]$/, '');
+    } catch {
+      return null;
+    }
+    segmentCache.set(firstSegment, resolved);
+    return resolved;
+  }
+
+  function fromShellPath(path: string): string {
+    if (!enabled) return path;
+
+    // Keep UNC out first: posix.normalize would collapse the leading `//`.
+    if (path.startsWith('//')) return path;
+
+    if (path.startsWith('/')) {
+      // Fold dot segments first: `/tmp/..` is `/` in the shell VFS, not `%TEMP%\..`.
+      const normalized = nodePath.posix.normalize(path);
+      const lexical = translateShellDrivePath(normalized);
+      if (lexical !== normalized) return lexical;
+      if (normalized === '/') return normalized;
+      if (VIRTUAL_FS_PREFIXES.some((prefix) => normalized.startsWith(prefix))) return normalized;
+      const firstSegment = normalized.slice(1).split('/')[0]!;
+      const prefix = resolveRootSegment(firstSegment);
+      if (prefix === null) return normalized;
+      const remainder = normalized.slice(firstSegment.length + 1);
+      const joined = `${prefix}${remainder}`.replaceAll('\\', '/');
+      // A mounted drive root resolved from a bare segment (`D:`) stays absolute.
+      return /^[A-Za-z]:$/.test(joined) ? `${joined}/` : joined;
+    }
+
+    return path;
+  }
+
+  function toShellPath(nativePath: string): string {
+    if (!enabled) return nativePath;
+
+    if (nativePath.startsWith('\\\\')) {
+      return nativePath.replaceAll('\\', '/');
+    }
+
+    const driveMatch = /^([A-Za-z]):(?:[\\/]|$)/.exec(nativePath);
+    if (driveMatch !== null) {
+      const drive = driveMatch[1]!.toLowerCase();
+      const rest = nativePath.slice(2).replaceAll('\\', '/');
+      return `/${drive}${rest.startsWith('/') ? rest : `/${rest}`}`;
+    }
+
+    return nativePath.replaceAll('\\', '/');
+  }
+
+  return { toShellPath, fromShellPath };
+}
+
+const bridgeCache = new Map<string, ShellPathBridge>();
+
+/**
+ * Production convenience — Node's ambient `execFileSync` / `existsSync`,
+ * memoised per shell identity so call sites that wrap the same probed
+ * environment in a fresh object still share one bridge.
+ */
+export function getShellPathBridge(env: ShellPathBridgeEnv): ShellPathBridge {
+  const key = `${env.osKind} ${env.shellName} ${env.shellPath}`;
+  const cached = bridgeCache.get(key);
+  if (cached !== undefined) return cached;
+  const bridge = createShellPathBridge(env, {
+    execFileSync: (file, args) =>
+      nodeExecFileSync(file, [...args], {
+        encoding: 'utf8',
+        timeout: CYGPATH_TIMEOUT_MS,
+        windowsHide: true,
+      }),
+    isFile: (path) => existsSync(path),
+  });
+  bridgeCache.set(key, bridge);
+  return bridge;
+}

--- a/packages/kaos/test/shell-path-bridge.test.ts
+++ b/packages/kaos/test/shell-path-bridge.test.ts
@@ -1,0 +1,267 @@
+/**
+ * Shell path bridge — drives `createShellPathBridge` with injected
+ * `execFileSync` / `isFile` fakes (no real processes): lexical drive forms,
+ * pass-through tiers, cygpath resolution and caching, `toShellPath`.
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  createShellPathBridge,
+  type ShellPathBridgeDeps,
+  type ShellPathBridgeEnv,
+} from '#/shell-path-bridge';
+
+const WINDOWS_ENV: ShellPathBridgeEnv = {
+  osKind: 'Windows',
+  shellName: 'bash',
+  shellPath: 'C:\\Program Files\\Git\\bin\\bash.exe',
+};
+
+const POSIX_ENV: ShellPathBridgeEnv = {
+  osKind: 'Linux',
+  shellName: 'bash',
+  shellPath: '/bin/bash',
+};
+
+// cygpath.exe candidates probed for `C:\Program Files\Git\bin\bash.exe`.
+const BIN_CYGPATH = 'C:\\Program Files\\Git\\bin\\cygpath.exe';
+const USR_BIN_CYGPATH = 'C:\\Program Files\\Git\\usr\\bin\\cygpath.exe';
+
+interface StubOpts {
+  readonly existingPaths?: readonly string[];
+  readonly execFileResults?: Readonly<Record<string, string>>;
+  readonly execFileSync?: ShellPathBridgeDeps['execFileSync'];
+}
+
+function stubDeps(opts: StubOpts = {}) {
+  const existing = new Set(opts.existingPaths ?? []);
+  const execFileSync = vi.fn(
+    opts.execFileSync ??
+      ((file: string, args: readonly string[]): string => {
+        const result = opts.execFileResults?.[[file, ...args].join(' ')];
+        if (result === undefined) throw new Error(`unexpected execFileSync: ${file}`);
+        return result;
+      }),
+  );
+  const deps: ShellPathBridgeDeps = {
+    execFileSync,
+    isFile: (path: string) => existing.has(path),
+  };
+  return { deps, execFileSync };
+}
+
+function cygpathKey(firstSegment: string): string {
+  return `${USR_BIN_CYGPATH} -w -C UTF8 -- /${firstSegment}`;
+}
+
+describe('fromShellPath lexical drive forms', () => {
+  const cases: ReadonlyArray<readonly [string, string]> = [
+    ['/c:/Users/foo', 'C:/Users/foo'],
+    ['/c:', 'C:/'],
+    ['/cygdrive/c/Users/foo', 'C:/Users/foo'],
+    ['/cygdrive/d', 'D:/'],
+    ['/c/Users/foo', 'C:/Users/foo'],
+    ['/C/Users/foo', 'C:/Users/foo'],
+    ['/c/', 'C:/'],
+    ['/c', 'C:/'],
+  ];
+
+  for (const [input, expected] of cases) {
+    it(`rewrites "${input}"`, () => {
+      const { deps, execFileSync } = stubDeps();
+      const bridge = createShellPathBridge(WINDOWS_ENV, deps);
+      expect(bridge.fromShellPath(input)).toBe(expected);
+      expect(execFileSync).not.toHaveBeenCalled();
+    });
+  }
+});
+
+describe('fromShellPath pass-through', () => {
+  it.each(['/dev/null', '/dev/pty0', '/proc/self/status', '/sys/kernel'])(
+    'leaves virtual-fs path %s unchanged',
+    (input) => {
+      const { deps, execFileSync } = stubDeps();
+      const bridge = createShellPathBridge(WINDOWS_ENV, deps);
+      expect(bridge.fromShellPath(input)).toBe(input);
+      expect(execFileSync).not.toHaveBeenCalled();
+    },
+  );
+
+  it.each([
+    '/',
+    '//server/share',
+    '//server/share/file.txt',
+    'relative/path',
+    'relative\\path',
+    'file.txt',
+    'C:\\Users\\foo',
+    'C:/Users/foo',
+    '~/Documents',
+  ])('leaves %s unchanged without consulting cygpath', (input) => {
+    const { deps, execFileSync } = stubDeps();
+    const bridge = createShellPathBridge(WINDOWS_ENV, deps);
+    expect(bridge.fromShellPath(input)).toBe(input);
+    expect(execFileSync).not.toHaveBeenCalled();
+  });
+});
+
+describe('fromShellPath cygpath resolution', () => {
+  it('resolves a root-relative path through cygpath and caches per first segment', () => {
+    const { deps, execFileSync } = stubDeps({
+      existingPaths: [USR_BIN_CYGPATH],
+      execFileResults: {
+        [cygpathKey('tmp')]: 'C:\\Users\\me\\AppData\\Local\\Temp\\\n',
+      },
+    });
+    const bridge = createShellPathBridge(WINDOWS_ENV, deps);
+
+    expect(bridge.fromShellPath('/tmp/scratch/a.txt')).toBe(
+      'C:/Users/me/AppData/Local/Temp/scratch/a.txt',
+    );
+    expect(bridge.fromShellPath('/tmp/other')).toBe('C:/Users/me/AppData/Local/Temp/other');
+    expect(bridge.fromShellPath('/tmp')).toBe('C:/Users/me/AppData/Local/Temp');
+    expect(execFileSync).toHaveBeenCalledTimes(1);
+    expect(execFileSync).toHaveBeenCalledWith(USR_BIN_CYGPATH, [
+      '-w',
+      '-C',
+      'UTF8',
+      '--',
+      '/tmp',
+    ]);
+  });
+
+  it('folds dot segments before resolving the mount segment', () => {
+    const { deps, execFileSync } = stubDeps({
+      existingPaths: [USR_BIN_CYGPATH],
+      execFileResults: {
+        [cygpathKey('tmp')]: 'C:\\Users\\me\\AppData\\Local\\Temp\n',
+        [cygpathKey('home')]: 'C:\\Program Files\\Git\\home\n',
+      },
+    });
+    const bridge = createShellPathBridge(WINDOWS_ENV, deps);
+
+    expect(bridge.fromShellPath('/./tmp/note.txt')).toBe(
+      'C:/Users/me/AppData/Local/Temp/note.txt',
+    );
+    expect(bridge.fromShellPath('/../tmp/note.txt')).toBe(
+      'C:/Users/me/AppData/Local/Temp/note.txt',
+    );
+    expect(bridge.fromShellPath('/tmp/../home/x.txt')).toBe('C:/Program Files/Git/home/x.txt');
+    expect(execFileSync).toHaveBeenCalledTimes(2);
+  });
+
+  it('folds dot segments before lexical drive translation', () => {
+    const { deps, execFileSync } = stubDeps();
+    const bridge = createShellPathBridge(WINDOWS_ENV, deps);
+
+    expect(bridge.fromShellPath('/./c/Projects')).toBe('C:/Projects');
+    expect(execFileSync).not.toHaveBeenCalled();
+  });
+
+  it.each(['/.', '/..'])('normalizes %s to / without consulting cygpath', (input) => {
+    const { deps, execFileSync } = stubDeps();
+    const bridge = createShellPathBridge(WINDOWS_ENV, deps);
+
+    expect(bridge.fromShellPath(input)).toBe('/');
+    expect(execFileSync).not.toHaveBeenCalled();
+  });
+
+  it('resolves a drive-root mount and keeps it absolute', () => {
+    const { deps, execFileSync } = stubDeps({
+      existingPaths: [USR_BIN_CYGPATH],
+      execFileResults: { [cygpathKey('work')]: 'D:\\\n' },
+    });
+    const bridge = createShellPathBridge(WINDOWS_ENV, deps);
+
+    expect(bridge.fromShellPath('/work/app')).toBe('D:/app');
+    expect(bridge.fromShellPath('/work')).toBe('D:/');
+    expect(execFileSync).toHaveBeenCalledTimes(1);
+  });
+
+  it('prefers cygpath.exe next to bash.exe when present', () => {
+    const key = `${BIN_CYGPATH} -w -C UTF8 -- /home`;
+    const { deps, execFileSync } = stubDeps({
+      existingPaths: [BIN_CYGPATH, USR_BIN_CYGPATH],
+      execFileResults: { [key]: 'C:\\Users\n' },
+    });
+    const bridge = createShellPathBridge(WINDOWS_ENV, deps);
+
+    expect(bridge.fromShellPath('/home/u/f.txt')).toBe('C:/Users/u/f.txt');
+    expect(execFileSync).toHaveBeenCalledTimes(1);
+    expect(execFileSync).toHaveBeenCalledWith(BIN_CYGPATH, ['-w', '-C', 'UTF8', '--', '/home']);
+  });
+
+  it('passes through and retries on the next access when cygpath fails', () => {
+    const { deps, execFileSync } = stubDeps({
+      existingPaths: [USR_BIN_CYGPATH],
+      execFileSync: () => {
+        throw new Error('cygpath exited 1');
+      },
+    });
+    const bridge = createShellPathBridge(WINDOWS_ENV, deps);
+
+    expect(bridge.fromShellPath('/tmp/x')).toBe('/tmp/x');
+    expect(bridge.fromShellPath('/tmp/y')).toBe('/tmp/y');
+    expect(execFileSync).toHaveBeenCalledTimes(2);
+  });
+
+  it('passes through and retries when cygpath output is not an absolute win32 path', () => {
+    const { deps, execFileSync } = stubDeps({
+      existingPaths: [USR_BIN_CYGPATH],
+      execFileResults: { [cygpathKey('tmp')]: 'not a win32 path\n' },
+    });
+    const bridge = createShellPathBridge(WINDOWS_ENV, deps);
+
+    expect(bridge.fromShellPath('/tmp/x')).toBe('/tmp/x');
+    expect(bridge.fromShellPath('/tmp/y')).toBe('/tmp/y');
+    expect(execFileSync).toHaveBeenCalledTimes(2);
+  });
+
+  it('passes through without spawning when cygpath.exe is missing', () => {
+    const { deps, execFileSync } = stubDeps();
+    const bridge = createShellPathBridge(WINDOWS_ENV, deps);
+
+    expect(bridge.fromShellPath('/tmp/x')).toBe('/tmp/x');
+    expect(bridge.fromShellPath('/home/u')).toBe('/home/u');
+    expect(execFileSync).not.toHaveBeenCalled();
+  });
+});
+
+describe('identity outside win32 bash', () => {
+  it('is identity on posix', () => {
+    const { deps, execFileSync } = stubDeps();
+    const bridge = createShellPathBridge(POSIX_ENV, deps);
+    expect(bridge.fromShellPath('/c/Users/foo')).toBe('/c/Users/foo');
+    expect(bridge.fromShellPath('/tmp/x')).toBe('/tmp/x');
+    expect(bridge.toShellPath('C:\\Users\\foo')).toBe('C:\\Users\\foo');
+    expect(execFileSync).not.toHaveBeenCalled();
+  });
+
+  it('is identity on Windows without bash', () => {
+    const { deps, execFileSync } = stubDeps();
+    const bridge = createShellPathBridge(
+      { osKind: 'Windows', shellName: 'sh', shellPath: 'C:\\sh.exe' },
+      deps,
+    );
+    expect(bridge.fromShellPath('/c/Users/foo')).toBe('/c/Users/foo');
+    expect(bridge.toShellPath('C:\\Users\\foo')).toBe('C:\\Users\\foo');
+    expect(execFileSync).not.toHaveBeenCalled();
+  });
+});
+
+describe('toShellPath', () => {
+  it.each([
+    ['C:\\Users\\foo', '/c/Users/foo'],
+    ['C:/Users/foo', '/c/Users/foo'],
+    ['C:\\', '/c/'],
+    ['D:\\Projects', '/d/Projects'],
+    ['\\\\server\\share\\dir', '//server/share/dir'],
+    ['relative\\path', 'relative/path'],
+    ['already/posix', 'already/posix'],
+  ])('maps %s → %s', (input, expected) => {
+    const { deps } = stubDeps();
+    const bridge = createShellPathBridge(WINDOWS_ENV, deps);
+    expect(bridge.toShellPath(input)).toBe(expected);
+  });
+});


### PR DESCRIPTION
Add a shell path bridge that translates between win32 paths and the MSYS2/Git Bash path dialect. File tools resolve model-supplied paths through it before canonicalization and workspace checks: drive-letter forms translate lexically, root-relative paths resolve via cygpath -w with per-segment caching, and every failure mode falls back to the previous behavior.

Fixes #2199

<!--
Thank you for your contribution to Kimi Code!
Please open an issue before sending a feature PR — PRs without prior discussion may be closed without review.

See https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md for more.
-->

## Related Issue

<!-- Link the issue this feature came from. If there is no issue, explain the problem in the next section instead. -->

Resolve #2199 

## Problem

<!-- What user need or limitation does this address? If the linked issue already covers this, write "See linked issue". -->

See linked issue. On Windows + Git Bash, file tools resolve root-relative
POSIX paths (`/tmp/...`, `/home/...`) against the current drive root
instead of the shell's mount table: `Read` reports file-not-found for
files bash just created, and `Write`/`Edit` silently create files at
wrong locations such as `C:\tmp\...`.

## What changed

<!-- What did you implement, and why does this approach fit Kimi Code? -->
- Added a shell path bridge (kaos, vendored into agent-core-v2 per the
  `environmentProbe.ts` pattern) and wired it into the file-tool path
  guard: drive-letter forms (`/c/x`, `/cygdrive/c/x`) translate lexically,
  root-relative paths resolve via `cygpath -w` (cached per first segment),
  so file tools interpret paths exactly as the shell does.
- The guard still canonicalizes and enforces workspace policy on the
  translated path — translation cannot widen access.
- Replaced the duplicated inline cwd conversion in both bash tools with
  the same bridge (`toShellPath`, identical semantics).
- Every failure mode (missing cygpath.exe, execution failure) falls back
  to current behavior: no working case can regress. Command text is never
  rewritten; WSL is unaffected.
- 145 new unit tests (lexical forms, cygpath success/failure/missing,
  guard integration).

<details>
<summary>Design notes and verification</summary>

- cygpath is the authoritative source for the msys mount table (`/tmp` →
  `%TEMP%`, `/bin` → `usr/bin`, user `/etc/fstab` entries); lexical rules
  or fstab parsing cannot cover these.
- The bridge is memoized per environment object; a root segment costs at
  most one cygpath spawn per process, then hits the cache.
- Deliberate scope: tool results keep native paths; user-facing surfaces
  (TUI, config files) are untouched.
- Verification: lint / typecheck / full unit suites pass on macOS.

</details>

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.
