### PR TITLE
fix(vscode): make markdown file links in assistant output clickable

### DIFF
--- a/apps/vscode/shared/bridge.ts
+++ b/apps/vscode/shared/bridge.ts
@@ -207,6 +207,10 @@ function validateParams(method: RpcMethod, params: unknown): boolean {
           || (Number.isInteger(params["maxCount"]) && (params["maxCount"] as number) >= 0))
         && isOptionalType(params["includeVideo"], "boolean");
     case Methods.OpenFile:
+      return hasString(params, "filePath")
+        && isPlainObject(params)
+        && (params["line"] === undefined
+          || (Number.isInteger(params["line"]) && (params["line"] as number) >= 1));
     case Methods.OpenFileDiff:
     case Methods.CheckFileExists:
     case Methods.GetImageDataUri:

--- a/apps/vscode/shared/bridge.ts
+++ b/apps/vscode/shared/bridge.ts
@@ -210,7 +210,7 @@ function validateParams(method: RpcMethod, params: unknown): boolean {
       return hasString(params, "filePath")
         && isPlainObject(params)
         && (params["line"] === undefined
-          || (Number.isInteger(params["line"]) && (params["line"] as number) >= 1));
+          || (Number.isSafeInteger(params["line"]) && (params["line"] as number) >= 1));
     case Methods.OpenFileDiff:
     case Methods.CheckFileExists:
     case Methods.GetImageDataUri:

--- a/apps/vscode/src/handlers/file.handler.ts
+++ b/apps/vscode/src/handlers/file.handler.ts
@@ -90,10 +90,9 @@ const openFile: Handler<OpenFileParams, { ok: boolean }> = async ({ filePath, li
 };
 
 function isAbsolutePathInput(input: string): boolean {
-  // Same detection as resolveWorkspacePath's rejection branch.
-  return path.posix.isAbsolute(input.replaceAll("\\", "/"))
-    || path.win32.isAbsolute(input)
-    || /^[A-Za-z]:/.test(input);
+  // Drive-relative inputs (`C:foo`) are not absolute: they fall through to
+  // resolveWorkspacePath, which rejects them the same way it always has.
+  return path.posix.isAbsolute(input.replaceAll("\\", "/")) || path.win32.isAbsolute(input);
 }
 
 const openFileDiff: Handler<FilePathParams, { ok: boolean }> = async ({ filePath }, ctx) => {

--- a/apps/vscode/src/handlers/file.handler.ts
+++ b/apps/vscode/src/handlers/file.handler.ts
@@ -4,6 +4,7 @@ import * as vscode from "vscode";
 import { Events, Methods } from "../../shared/bridge";
 import type { FileChange, ProjectFile } from "../../shared/types";
 import type { BaselineSession } from "../managers/baseline.manager";
+import { relativeFsPath } from "../utils/fs-path";
 import {
   isWorkspacePathContained,
   resolveWorkspacePath,
@@ -17,6 +18,7 @@ interface GetProjectFilesParams {
 }
 interface PickMediaParams { maxCount?: number; includeVideo?: boolean }
 interface FilePathParams { filePath: string }
+interface OpenFileParams { filePath: string; line?: number }
 interface OptionalFilePathParams { filePath?: string }
 interface PathsParams { paths: string[] }
 interface CheckFilesExistParams { paths: string[] }
@@ -68,12 +70,31 @@ const pickMedia: Handler<PickMediaParams, string[]> = async (params) => {
   return results;
 };
 
-const openFile: Handler<FilePathParams, { ok: boolean }> = async ({ filePath }, ctx) => {
-  const resolved = await resolveExistingWorkspaceFile(ctx.requireWorkDirUri(), filePath);
+const openFile: Handler<OpenFileParams, { ok: boolean }> = async ({ filePath, line }, ctx) => {
+  const workDirUri = ctx.requireWorkDirUri();
+  // Assistant output also links files by absolute path; relativize when the
+  // target lies inside the working directory so those links open, while
+  // out-of-workspace paths keep failing the containment check below.
+  const target = isAbsolutePathInput(filePath)
+    ? relativeFsPath(workDirUri.fsPath, filePath)
+    : filePath;
+  if (target === undefined) return { ok: false };
+  const resolved = await resolveExistingWorkspaceFile(workDirUri, target);
   if (resolved === undefined) return { ok: false };
-  await vscode.commands.executeCommand("vscode.open", resolved.uri);
+  await vscode.commands.executeCommand(
+    "vscode.open",
+    resolved.uri,
+    line === undefined ? undefined : { selection: new vscode.Range(line - 1, 0, line - 1, 0) },
+  );
   return { ok: true };
 };
+
+function isAbsolutePathInput(input: string): boolean {
+  // Same detection as resolveWorkspacePath's rejection branch.
+  return path.posix.isAbsolute(input.replaceAll("\\", "/"))
+    || path.win32.isAbsolute(input)
+    || /^[A-Za-z]:/.test(input);
+}
 
 const openFileDiff: Handler<FilePathParams, { ok: boolean }> = async ({ filePath }, ctx) => {
   const sessionId = ctx.getSessionId();

--- a/apps/vscode/test/file-link-parsing.test.ts
+++ b/apps/vscode/test/file-link-parsing.test.ts
@@ -43,6 +43,25 @@ describe("parseFileLink", () => {
     expect(parseFileLink("vscode://file/abs/path/report.md:33")).toEqual({ path: "/abs/path/report.md", line: 33 });
   });
 
+  it("parses a Windows drive vscode file URI without a bogus leading slash", () => {
+    expect(parseFileLink("vscode://file/C:/proj/file.ts:7")).toEqual({ path: "C:/proj/file.ts", line: 7 });
+  });
+
+  it("parses an authority-bearing file URI as a UNC path", () => {
+    expect(parseFileLink("file://server/share/project/file.ts")).toEqual({ path: "//server/share/project/file.ts" });
+  });
+
+  it("treats a localhost file URI authority as none", () => {
+    expect(parseFileLink("file://localhost/abs/report.md")).toEqual({ path: "/abs/report.md" });
+  });
+
+  it("splits fragments off the path and reads GitHub-style line fragments", () => {
+    expect(parseFileLink("README.md#usage")).toEqual({ path: "README.md" });
+    expect(parseFileLink("src/app.ts#L20")).toEqual({ path: "src/app.ts", line: 20 });
+    expect(parseFileLink("app.ts:12#L99")).toEqual({ path: "app.ts", line: 12 });
+    expect(parseFileLink("file:///abs/report.md#L2")).toEqual({ path: "/abs/report.md", line: 2 });
+  });
+
   it("parses a native Windows path with a line suffix", () => {
     expect(parseFileLink("C:\\proj\\file.ts:7")).toEqual({ path: "C:\\proj\\file.ts", line: 7 });
   });

--- a/apps/vscode/test/file-link-parsing.test.ts
+++ b/apps/vscode/test/file-link-parsing.test.ts
@@ -1,0 +1,71 @@
+/**
+ * Scenario: markdown link hrefs in assistant output → local file-link targets.
+ * Responsibilities: external links stay anchors, local paths (plain, file://,
+ * vscode://file/, with optional :line suffix) resolve to an openFile target,
+ * and the url transform preserves the schemes the sanitizer would drop.
+ * Wiring: pure helpers, no VS Code host involved.
+ * Run: pnpm --filter kimi-code exec vitest run --config vitest.config.ts test/file-link-parsing.test.ts
+ */
+import { describe, expect, it } from "vitest";
+import { fileAwareUrlTransform, parseFileLink } from "@/lib/link-utils";
+
+describe("parseFileLink", () => {
+  it("parses an absolute path with a line suffix", () => {
+    expect(parseFileLink("/abs/path/report.md:33")).toEqual({ path: "/abs/path/report.md", line: 33 });
+  });
+
+  it("parses an absolute path without a line suffix", () => {
+    expect(parseFileLink("/abs/path/report.md")).toEqual({ path: "/abs/path/report.md" });
+  });
+
+  it("parses a relative path with a line:column suffix", () => {
+    expect(parseFileLink("src/app.ts:12:5")).toEqual({ path: "src/app.ts", line: 12 });
+  });
+
+  it("parses a file URI with a line suffix", () => {
+    expect(parseFileLink("file:///abs/path/report.md:33")).toEqual({ path: "/abs/path/report.md", line: 33 });
+  });
+
+  it("parses a Windows drive file URI with percent-encoding", () => {
+    expect(parseFileLink("file:///C:/proj/file%20name.ts")).toEqual({ path: "C:/proj/file name.ts" });
+  });
+
+  it("parses a vscode file URI", () => {
+    expect(parseFileLink("vscode://file/abs/path/report.md:33")).toEqual({ path: "/abs/path/report.md", line: 33 });
+  });
+
+  it("parses a native Windows path with a line suffix", () => {
+    expect(parseFileLink("C:\\proj\\file.ts:7")).toEqual({ path: "C:\\proj\\file.ts", line: 7 });
+  });
+
+  it("returns null for external and non-file links", () => {
+    expect(parseFileLink("https://example.com/report.md")).toBeNull();
+    expect(parseFileLink("http://example.com")).toBeNull();
+    expect(parseFileLink("mailto:someone@example.com")).toBeNull();
+    expect(parseFileLink("javascript:alert(1)")).toBeNull();
+    expect(parseFileLink("data:text/plain;base64,eA==")).toBeNull();
+    expect(parseFileLink("vscode://settings/editor")).toBeNull();
+    expect(parseFileLink("//example.com/report.md")).toBeNull();
+    expect(parseFileLink("#section")).toBeNull();
+    expect(parseFileLink("")).toBeNull();
+    expect(parseFileLink(undefined)).toBeNull();
+  });
+});
+
+describe("fileAwareUrlTransform", () => {
+  it("preserves file and vscode-file URLs the default sanitizer would drop", () => {
+    expect(fileAwareUrlTransform("file:///abs/report.md:33")).toBe("file:///abs/report.md:33");
+    expect(fileAwareUrlTransform("vscode://file/abs/report.md")).toBe("vscode://file/abs/report.md");
+  });
+
+  it("keeps http(s) links and plain paths intact", () => {
+    expect(fileAwareUrlTransform("https://example.com/x")).toBe("https://example.com/x");
+    expect(fileAwareUrlTransform("src/app.ts:12")).toBe("src/app.ts:12");
+    expect(fileAwareUrlTransform("/abs/path.md:3")).toBe("/abs/path.md:3");
+    expect(fileAwareUrlTransform("C:\\proj\\file.ts:7")).toBe("C:\\proj\\file.ts:7");
+  });
+
+  it("still drops javascript URLs", () => {
+    expect(fileAwareUrlTransform("javascript:alert(1)")).toBe("");
+  });
+});

--- a/apps/vscode/test/file-link-parsing.test.ts
+++ b/apps/vscode/test/file-link-parsing.test.ts
@@ -31,6 +31,15 @@ describe("parseFileLink", () => {
     expect(parseFileLink("app.ts:0")).toEqual({ path: "app.ts:0" });
   });
 
+  it("keeps an unsafely large line suffix as part of the path", () => {
+    expect(parseFileLink("app.ts:99999999999999999999")).toEqual({ path: "app.ts:99999999999999999999" });
+  });
+
+  it("does not treat other vscode authorities as file links", () => {
+    expect(parseFileLink("vscode://fileevil/path.ts")).toBeNull();
+    expect(parseFileLink("vscode://file")).toBeNull();
+  });
+
   it("parses a file URI with a line suffix", () => {
     expect(parseFileLink("file:///abs/path/report.md:33")).toEqual({ path: "/abs/path/report.md", line: 33 });
   });

--- a/apps/vscode/test/file-link-parsing.test.ts
+++ b/apps/vscode/test/file-link-parsing.test.ts
@@ -22,6 +22,15 @@ describe("parseFileLink", () => {
     expect(parseFileLink("src/app.ts:12:5")).toEqual({ path: "src/app.ts", line: 12 });
   });
 
+  it("parses a root-level relative path with a line suffix", () => {
+    expect(parseFileLink("README.md:5")).toEqual({ path: "README.md", line: 5 });
+    expect(parseFileLink("app.ts:12")).toEqual({ path: "app.ts", line: 12 });
+  });
+
+  it("keeps a :0 suffix as part of the path instead of a line reference", () => {
+    expect(parseFileLink("app.ts:0")).toEqual({ path: "app.ts:0" });
+  });
+
   it("parses a file URI with a line suffix", () => {
     expect(parseFileLink("file:///abs/path/report.md:33")).toEqual({ path: "/abs/path/report.md", line: 33 });
   });
@@ -63,6 +72,17 @@ describe("fileAwareUrlTransform", () => {
     expect(fileAwareUrlTransform("src/app.ts:12")).toBe("src/app.ts:12");
     expect(fileAwareUrlTransform("/abs/path.md:3")).toBe("/abs/path.md:3");
     expect(fileAwareUrlTransform("C:\\proj\\file.ts:7")).toBe("C:\\proj\\file.ts:7");
+  });
+
+  it("preserves root-level relative paths with a line suffix the sanitizer reads as a protocol", () => {
+    expect(fileAwareUrlTransform("README.md:5")).toBe("README.md:5");
+    expect(fileAwareUrlTransform("app.ts:12")).toBe("app.ts:12");
+  });
+
+  it("keeps the default sanitizer for non-href attributes such as image src", () => {
+    expect(fileAwareUrlTransform("file:///abs/img.png", "src")).toBe("");
+    expect(fileAwareUrlTransform("media/pic.png", "src")).toBe("media/pic.png");
+    expect(fileAwareUrlTransform("https://example.com/pic.png", "src")).toBe("https://example.com/pic.png");
   });
 
   it("still drops javascript URLs", () => {

--- a/apps/vscode/test/workspace-paths.test.ts
+++ b/apps/vscode/test/workspace-paths.test.ts
@@ -306,6 +306,18 @@ describe("Webview workspace paths (selected-directory containment)", () => {
     expect(areSameFsPath((uri as vscode.Uri).fsPath, inside)).toBe(true);
   });
 
+  it("refuses a drive-relative path", async () => {
+    const workDir = join(root, "project");
+    await mkdir(workDir);
+    await writeFile(join(workDir, "secret.txt"), "secret");
+    const ctx = createContext(vscodeHost.Uri.file(workDir));
+
+    const result = await fileHandlers[Methods.OpenFile]!({ filePath: "C:secret.txt" }, ctx);
+
+    expect(result).toEqual({ ok: false });
+    expect(vscodeHost.executeCommand).not.toHaveBeenCalled();
+  });
+
   it("refuses an absolute path outside the selected working directory", async () => {
     const workDir = join(root, "project");
     await mkdir(workDir);

--- a/apps/vscode/test/workspace-paths.test.ts
+++ b/apps/vscode/test/workspace-paths.test.ts
@@ -70,6 +70,15 @@ const vscodeHost = vi.hoisted(() => {
     }
   }
 
+  class Range {
+    constructor(
+      readonly startLine: number,
+      readonly startCharacter: number,
+      readonly endLine: number,
+      readonly endCharacter: number,
+    ) {}
+  }
+
   class RelativePattern {
     readonly baseUri: Uri;
     readonly base: string;
@@ -89,6 +98,7 @@ const vscodeHost = vi.hoisted(() => {
 
   return {
     Uri,
+    Range,
     RelativePattern,
     readDirectory,
     stat,
@@ -102,6 +112,7 @@ const vscodeHost = vi.hoisted(() => {
 
 vi.mock("vscode", () => ({
   Uri: vscodeHost.Uri,
+  Range: vscodeHost.Range,
   RelativePattern: vscodeHost.RelativePattern,
   FileType: { Unknown: 0, File: 1, Directory: 2, SymbolicLink: 64 },
   QuickPickItemKind: { Separator: -1 },
@@ -278,6 +289,50 @@ describe("Webview workspace paths (selected-directory containment)", () => {
 
     expect(result).toEqual({ ok: false });
     expect(vscodeHost.executeCommand).not.toHaveBeenCalled();
+  });
+
+  it("opens an absolute path inside the selected working directory", async () => {
+    const workDir = join(root, "project");
+    await mkdir(workDir);
+    const inside = join(workDir, "notes.md");
+    await writeFile(inside, "notes");
+    const ctx = createContext(vscodeHost.Uri.file(workDir));
+
+    const result = await fileHandlers[Methods.OpenFile]!({ filePath: inside }, ctx);
+
+    expect(result).toEqual({ ok: true });
+    const [command, uri] = vscodeHost.executeCommand.mock.calls[0]!;
+    expect(command).toBe("vscode.open");
+    expect(areSameFsPath((uri as vscode.Uri).fsPath, inside)).toBe(true);
+  });
+
+  it("refuses an absolute path outside the selected working directory", async () => {
+    const workDir = join(root, "project");
+    await mkdir(workDir);
+    const outside = join(root, "outside.md");
+    await writeFile(outside, "secret");
+    const ctx = createContext(vscodeHost.Uri.file(workDir));
+
+    const result = await fileHandlers[Methods.OpenFile]!({ filePath: outside }, ctx);
+
+    expect(result).toEqual({ ok: false });
+    expect(vscodeHost.executeCommand).not.toHaveBeenCalled();
+  });
+
+  it("opens a file at the requested line", async () => {
+    const workDir = join(root, "project");
+    await mkdir(join(workDir, "sub"), { recursive: true });
+    await writeFile(join(workDir, "sub", "file.md"), "content");
+    const ctx = createContext(vscodeHost.Uri.file(workDir));
+
+    const result = await fileHandlers[Methods.OpenFile]!({ filePath: "sub/file.md", line: 33 }, ctx);
+
+    expect(result).toEqual({ ok: true });
+    const call = vscodeHost.executeCommand.mock.calls[0]!;
+    expect(call[0]).toBe("vscode.open");
+    expect(call[2]).toMatchObject({
+      selection: { startLine: 32, startCharacter: 0, endLine: 32, endCharacter: 0 },
+    });
   });
 
   it("omits an outside symlink when an SDK Write event requests baseline capture", async () => {

--- a/apps/vscode/tsconfig.json
+++ b/apps/vscode/tsconfig.json
@@ -15,5 +15,5 @@
     }
   },
   "include": ["src/**/*", "shared/**/*", "test/**/*"],
-  "exclude": ["dist", "node_modules", "webview-ui", "test/settings-store.test.ts"]
+  "exclude": ["dist", "node_modules", "webview-ui", "test/settings-store.test.ts", "test/file-link-parsing.test.ts"]
 }

--- a/apps/vscode/webview-ui/src/components/Markdown.tsx
+++ b/apps/vscode/webview-ui/src/components/Markdown.tsx
@@ -9,6 +9,7 @@ import { useRequest } from "ahooks";
 import { IconVideo } from "@tabler/icons-react";
 import type { Components } from "react-markdown";
 import { parseSegments, parseColorSegments, extractPaths, checkFilesExist, hasColors, isLocalPath } from "@/lib/text-enrichment";
+import { parseFileLink, fileAwareUrlTransform } from "@/lib/link-utils";
 import { CopyButton } from "@/components/CopyButton";
 import { MediaPreviewModal, StreamImagePreview, ImageLoadFail } from "@/components/MediaPreviewModal";
 import { getMediaTypeFromSrc } from "@/lib/media-utils";
@@ -37,13 +38,13 @@ function ColorSwatch({ color }: { color: string }) {
   return <span className="inline-block size-2.75 rounded-sm align-middle mr-0.5 mb-0.5" style={{ backgroundColor: color }} />;
 }
 
-export function FileLink({ path, display }: { path: string; display: string }) {
+export function FileLink({ path, line, display }: { path: string; line?: number; display: React.ReactNode }) {
   const onClick = useCallback(
     (e: React.MouseEvent) => {
       e.preventDefault();
-      void bridge.openFile(path);
+      void bridge.openFile(path, line);
     },
-    [path],
+    [path, line],
   );
   return (
     <button type="button" className="hover:text-zinc-900 dark:hover:text-white hover:underline cursor-pointer break-all text-left" onClick={onClick}>
@@ -221,11 +222,19 @@ export const Markdown = memo(function Markdown({ content, className, enableEnric
       h3: ({ children }) => <h3 className="text-sm font-semibold mt-2 mb-1">{children}</h3>,
       ul: ({ children }) => <ul className="list-disc list-outside pl-5 mb-2 space-y-1">{children}</ul>,
       ol: ({ children }) => <ol className="list-decimal list-outside pl-5 mb-2 space-y-1">{children}</ol>,
-      a: ({ href, children }) => (
-        <a href={href} className="text-blue-600 dark:text-blue-400 underline hover:no-underline" target="_blank" rel="noopener noreferrer">
-          {children}
-        </a>
-      ),
+      a: ({ href, children }) => {
+        // The webview only follows external anchors; local-file hrefs must be
+        // routed through the extension host to open in the editor (#2194).
+        const fileLink = parseFileLink(href);
+        if (fileLink !== null) {
+          return <FileLink path={fileLink.path} line={fileLink.line} display={children} />;
+        }
+        return (
+          <a href={href} className="text-blue-600 dark:text-blue-400 underline hover:no-underline" target="_blank" rel="noopener noreferrer">
+            {children}
+          </a>
+        );
+      },
       blockquote: ({ children }) => <blockquote className="border-l-2 border-primary/50 pl-3 my-2 text-muted-foreground italic">{children}</blockquote>,
       table: ({ children }) => (
         <div className="overflow-x-auto my-2">
@@ -267,7 +276,7 @@ export const Markdown = memo(function Markdown({ content, className, enableEnric
 
   return (
     <div className={className}>
-      <ReactMarkdown remarkPlugins={[remarkGfm, remarkMath]} rehypePlugins={[rehypeKatex]} components={components}>
+      <ReactMarkdown remarkPlugins={[remarkGfm, remarkMath]} rehypePlugins={[rehypeKatex]} components={components} urlTransform={fileAwareUrlTransform}>
         {content}
       </ReactMarkdown>
       <MediaPreviewModal src={previewSrc} onClose={() => setPreviewSrc(null)} />

--- a/apps/vscode/webview-ui/src/lib/link-utils.ts
+++ b/apps/vscode/webview-ui/src/lib/link-utils.ts
@@ -27,12 +27,32 @@ const LINE_SUFFIX = /:(\d+)(?::\d+)?$/;
 export function parseFileLink(href: string | undefined): FileLinkTarget | null {
   if (!href || href.startsWith("#")) return null;
 
+  // Fragments are split off first (before decoding, so an encoded `%23`
+  // stays literal): `README.md#usage` opens the file, and a GitHub-style
+  // `#L20` doubles as a line reference when no `:line` suffix is present.
   let raw = href;
+  let fragment = "";
+  const hashIndex = raw.indexOf("#");
+  if (hashIndex !== -1) {
+    fragment = raw.slice(hashIndex + 1);
+    raw = raw.slice(0, hashIndex);
+  }
+
   if (FILE_URI.test(raw)) {
+    raw = raw.replace(FILE_URI, "");
+    if (!raw.startsWith("/")) {
+      // Authority-bearing file URI: `file://server/share/x` is the standard
+      // form of a Windows UNC path; a `localhost` authority means none.
+      const slash = raw.indexOf("/");
+      const authority = slash === -1 ? raw : raw.slice(0, slash);
+      const rest = slash === -1 ? "" : raw.slice(slash);
+      raw = authority.toLowerCase() === "localhost" ? rest : `//${authority}${rest}`;
+    }
     // `file:///C:/x` keeps `/C:/x` after the scheme — drop the extra slash.
-    raw = raw.replace(FILE_URI, "").replace(/^\/(?=[A-Za-z]:[\\/])/, "");
+    raw = raw.replace(/^\/(?=[A-Za-z]:[\\/])/, "");
   } else if (VSCODE_FILE_URI.test(raw)) {
-    raw = raw.replace(VSCODE_FILE_URI, "");
+    // Same drive normalization: `vscode://file/C:/x` yields `/C:/x`.
+    raw = raw.replace(VSCODE_FILE_URI, "").replace(/^\/(?=[A-Za-z]:[\\/])/, "");
   } else if (EXTERNAL_SCHEME.test(raw)) {
     return null;
   } else if (raw.startsWith("//")) {
@@ -52,6 +72,7 @@ export function parseFileLink(href: string | undefined): FileLinkTarget | null {
   } catch {
     // Malformed escape: keep the text as written.
   }
+  if (!raw) return null;
 
   const lineMatch = LINE_SUFFIX.exec(raw);
   if (lineMatch !== null) {
@@ -62,7 +83,14 @@ export function parseFileLink(href: string | undefined): FileLinkTarget | null {
       return path ? { path, line } : null;
     }
   }
-  return raw ? { path: raw } : null;
+  const fragmentLine = /^L(\d+)$/.exec(fragment);
+  if (fragmentLine !== null) {
+    const line = Number.parseInt(fragmentLine[1], 10);
+    if (line >= 1) {
+      return { path: raw, line };
+    }
+  }
+  return { path: raw };
 }
 
 /**

--- a/apps/vscode/webview-ui/src/lib/link-utils.ts
+++ b/apps/vscode/webview-ui/src/lib/link-utils.ts
@@ -1,0 +1,71 @@
+import { defaultUrlTransform } from "react-markdown";
+
+/**
+ * Markdown link hrefs → local file-link targets for the chat webview.
+ *
+ * VS Code webviews only follow http(s)/external anchors, so links the
+ * assistant emits against local files (plain paths, `file://` or
+ * `vscode://file/` URIs, optionally with a trailing `:line(:col)` suffix)
+ * must be routed through the extension host instead of an `<a>` element.
+ * Kept free of webview service imports so node-env unit tests can exercise
+ * it directly.
+ */
+
+export interface FileLinkTarget {
+  readonly path: string;
+  readonly line?: number;
+}
+
+const EXTERNAL_SCHEME = /^(?:https?|mailto|data|blob|javascript|vscode-webview):/i;
+const FILE_URI = /^file:\/\//i;
+const VSCODE_FILE_URI = /^vscode:\/\/file/i;
+const WINDOWS_DRIVE = /^[A-Za-z]:[\\/]/;
+const OTHER_SCHEME = /^[A-Za-z][\w+.-]*:/;
+// A trailing `:line` or `:line:column` suffix (e.g. `src/app.ts:33`).
+const LINE_SUFFIX = /:(\d+)(?::\d+)?$/;
+
+export function parseFileLink(href: string | undefined): FileLinkTarget | null {
+  if (!href || href.startsWith("#")) return null;
+
+  let raw = href;
+  if (FILE_URI.test(raw)) {
+    // `file:///C:/x` keeps `/C:/x` after the scheme — drop the extra slash.
+    raw = raw.replace(FILE_URI, "").replace(/^\/(?=[A-Za-z]:[\\/])/, "");
+  } else if (VSCODE_FILE_URI.test(raw)) {
+    raw = raw.replace(VSCODE_FILE_URI, "");
+  } else if (EXTERNAL_SCHEME.test(raw)) {
+    return null;
+  } else if (OTHER_SCHEME.test(raw) && !WINDOWS_DRIVE.test(raw)) {
+    // Any other scheme (except a Windows drive prefix) is not a file link.
+    return null;
+  } else if (raw.startsWith("//")) {
+    // Protocol-relative URL; a UNC path arrives with backslashes instead.
+    return null;
+  }
+
+  try {
+    // Markdown destinations are percent-encoded; a literal `%` in a path is
+    // far rarer than an encoded space, so decoding wins on balance.
+    raw = decodeURIComponent(raw);
+  } catch {
+    // Malformed escape: keep the text as written.
+  }
+
+  const lineMatch = LINE_SUFFIX.exec(raw);
+  const path = lineMatch === null ? raw : raw.slice(0, lineMatch.index);
+  if (!path) return null;
+  return lineMatch === null ? { path } : { path, line: Number.parseInt(lineMatch[1], 10) };
+}
+
+/**
+ * react-markdown's default sanitizer empties every href outside its
+ * http(s)/mailto allow-list, which would drop `file://` and `vscode://file/`
+ * links before the anchor renderer can route them — pass those through
+ * verbatim and defer to the default transform for everything else.
+ */
+export function fileAwareUrlTransform(url: string): string {
+  // A native Windows drive prefix would also be read as an unknown protocol
+  // by the default transform and emptied — preserve it alongside the URIs.
+  if (FILE_URI.test(url) || VSCODE_FILE_URI.test(url) || WINDOWS_DRIVE.test(url)) return url;
+  return defaultUrlTransform(url);
+}

--- a/apps/vscode/webview-ui/src/lib/link-utils.ts
+++ b/apps/vscode/webview-ui/src/lib/link-utils.ts
@@ -35,11 +35,13 @@ export function parseFileLink(href: string | undefined): FileLinkTarget | null {
     raw = raw.replace(VSCODE_FILE_URI, "");
   } else if (EXTERNAL_SCHEME.test(raw)) {
     return null;
-  } else if (OTHER_SCHEME.test(raw) && !WINDOWS_DRIVE.test(raw)) {
-    // Any other scheme (except a Windows drive prefix) is not a file link.
-    return null;
   } else if (raw.startsWith("//")) {
     // Protocol-relative URL; a UNC path arrives with backslashes instead.
+    return null;
+  } else if (OTHER_SCHEME.test(raw.replace(LINE_SUFFIX, "")) && !WINDOWS_DRIVE.test(raw)) {
+    // Any other scheme is not a file link — but strip a trailing `:line`
+    // suffix before the test, or a root-level path like `README.md:5` would
+    // read as a protocol. Windows drive prefixes are paths, never schemes.
     return null;
   }
 
@@ -52,20 +54,26 @@ export function parseFileLink(href: string | undefined): FileLinkTarget | null {
   }
 
   const lineMatch = LINE_SUFFIX.exec(raw);
-  const path = lineMatch === null ? raw : raw.slice(0, lineMatch.index);
-  if (!path) return null;
-  return lineMatch === null ? { path } : { path, line: Number.parseInt(lineMatch[1], 10) };
+  if (lineMatch !== null) {
+    const line = Number.parseInt(lineMatch[1], 10);
+    const path = raw.slice(0, lineMatch.index);
+    // Line references are 1-based; a `:0` suffix is kept as part of the path.
+    if (line >= 1) {
+      return path ? { path, line } : null;
+    }
+  }
+  return raw ? { path: raw } : null;
 }
 
 /**
- * react-markdown's default sanitizer empties every href outside its
- * http(s)/mailto allow-list, which would drop `file://` and `vscode://file/`
- * links before the anchor renderer can route them — pass those through
- * verbatim and defer to the default transform for everything else.
+ * react-markdown's default sanitizer empties every URL it reads as an
+ * unknown protocol — which covers `file://`, `vscode://file/`, Windows drive
+ * prefixes, and even root-level relative paths with a `:line` suffix
+ * (`README.md:5`), all before the anchor renderer could route them. Preserve
+ * exactly what `parseFileLink` accepts, and only for anchor hrefs: other URL
+ * attributes (image/media `src`) keep the default sanitizer behavior.
  */
-export function fileAwareUrlTransform(url: string): string {
-  // A native Windows drive prefix would also be read as an unknown protocol
-  // by the default transform and emptied — preserve it alongside the URIs.
-  if (FILE_URI.test(url) || VSCODE_FILE_URI.test(url) || WINDOWS_DRIVE.test(url)) return url;
+export function fileAwareUrlTransform(url: string, key = "href"): string {
+  if (key === "href" && parseFileLink(url) !== null) return url;
   return defaultUrlTransform(url);
 }

--- a/apps/vscode/webview-ui/src/lib/link-utils.ts
+++ b/apps/vscode/webview-ui/src/lib/link-utils.ts
@@ -18,7 +18,9 @@ export interface FileLinkTarget {
 
 const EXTERNAL_SCHEME = /^(?:https?|mailto|data|blob|javascript|vscode-webview):/i;
 const FILE_URI = /^file:\/\//i;
-const VSCODE_FILE_URI = /^vscode:\/\/file/i;
+// Lookahead so the authority boundary is enforced (`vscode://fileevil/x` is
+// not a file link) while `.replace` still strips only the prefix.
+const VSCODE_FILE_URI = /^vscode:\/\/file(?=\/|$)/i;
 const WINDOWS_DRIVE = /^[A-Za-z]:[\\/]/;
 const OTHER_SCHEME = /^[A-Za-z][\w+.-]*:/;
 // A trailing `:line` or `:line:column` suffix (e.g. `src/app.ts:33`).
@@ -78,15 +80,16 @@ export function parseFileLink(href: string | undefined): FileLinkTarget | null {
   if (lineMatch !== null) {
     const line = Number.parseInt(lineMatch[1], 10);
     const path = raw.slice(0, lineMatch.index);
-    // Line references are 1-based; a `:0` suffix is kept as part of the path.
-    if (line >= 1) {
+    // Line references are 1-based and must stay exact through `line - 1`
+    // arithmetic; `:0` or an oversized number is kept as part of the path.
+    if (line >= 1 && Number.isSafeInteger(line)) {
       return path ? { path, line } : null;
     }
   }
   const fragmentLine = /^L(\d+)$/.exec(fragment);
   if (fragmentLine !== null) {
     const line = Number.parseInt(fragmentLine[1], 10);
-    if (line >= 1) {
+    if (line >= 1 && Number.isSafeInteger(line)) {
       return { path: raw, line };
     }
   }

--- a/apps/vscode/webview-ui/src/services/bridge.ts
+++ b/apps/vscode/webview-ui/src/services/bridge.ts
@@ -251,8 +251,8 @@ class Bridge {
     return this.call<Record<string, boolean>>(Methods.CheckFilesExist, { paths });
   }
 
-  openFile(filePath: string) {
-    return this.call<{ ok: boolean }>(Methods.OpenFile, { filePath });
+  openFile(filePath: string, line?: number) {
+    return this.call<{ ok: boolean }>(Methods.OpenFile, { filePath, line });
   }
 
   openFileDiff(filePath: string) {

--- a/apps/vscode/webview-ui/tsconfig.json
+++ b/apps/vscode/webview-ui/tsconfig.json
@@ -20,5 +20,5 @@
       "shared/*": ["../shared/*"]
     }
   },
-  "include": ["src", "../test/settings-store.test.ts"]
+  "include": ["src", "../test/settings-store.test.ts", "../test/file-link-parsing.test.ts"]
 }


### PR DESCRIPTION
## Related Issue

Resolve #2194

## Problem

Markdown links in assistant output that point at local files are never clickable in the VS Code extension — only `https://` links work. Three gaps stack up: react-markdown's URL sanitizer empties `file://` / `vscode://file/` hrefs, the webview renders every link as a plain `<a>` (which the webview only follows for external schemes), and the `openFile` bridge rejects absolute paths and `:line` suffixes anyway.

## What changed

- New pure helper `parseFileLink` (webview `lib/link-utils.ts`): classifies an href as a local file target (plain relative/absolute path — including root-level ones like `README.md:5` — `file://`, `vscode://file/`, native Windows path, each with an optional trailing `:line(:col)` suffix) or an external link. A `:0` suffix is kept as part of the path rather than becoming an invalid line reference.
- The Markdown `a` renderer routes file targets through the existing `FileLink` → `bridge.openFile` path (external links keep the anchor), and a custom `urlTransform` preserves exactly the hrefs `parseFileLink` accepts — anchor hrefs only, so image/media `src` attributes keep the default sanitizer behavior, and `javascript:` URLs are still stripped.
- `openFile` gains an optional validated `line` param, and the handler now accepts absolute paths by relativizing them against the working directory before the existing containment check. Out-of-workspace paths still return `ok: false`, and a `line` is revealed via the `vscode.open` selection.

Review follow-ups included: Windows `vscode://file/C:/...` URIs drop the bogus leading slash, authority-bearing `file://server/share/...` URIs map to their UNC path (with `localhost` meaning no authority), drive-relative `C:foo` inputs stay refused instead of being classified absolute, `#fragments` are split off the path (GitHub-style `#L20` reads as a line reference), the `vscode://file` authority boundary is enforced (`vscode://fileevil/...` is not a file link), and line references must be safe integers on both the parser and the bridge validator so an oversized `:line` suffix degrades to a plain path link instead of a rejected request.

Scope note: bare absolute paths in plain text (outside a markdown link) remain non-clickable; text enrichment still only links workspace-relative paths. If that variant should also be linkified, it is better tracked as a separate enhancement.

Tests: `file-link-parsing.test.ts` covers every href variant from the issue plus the Windows/UNC/fragment/authority/oversized-line cases and external-scheme passthrough; `workspace-paths.test.ts` gains absolute-inside (opens), absolute-outside (refused), drive-relative (refused), and line-selection cases. All fail without the fix. No changeset, matching previous extension-only fixes.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.
