### PR TITLE
fix(vscode): use node:crypto randomUUID for webview view IDs

### DIFF
--- a/apps/vscode/src/KimiWebviewProvider.ts
+++ b/apps/vscode/src/KimiWebviewProvider.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from "node:crypto";
 import * as vscode from "vscode";
 import type { KimiHarness } from "@moonshot-ai/kimi-code-sdk";
 import { Events } from "../shared/bridge";
@@ -49,7 +50,7 @@ export class KimiWebviewProvider implements vscode.WebviewViewProvider {
   }
 
   resolveWebviewView(webviewView: vscode.WebviewView): void {
-    const webviewId = `sidebar_${crypto.randomUUID()}`;
+    const webviewId = `sidebar_${randomUUID()}`;
     this.setupWebview(webviewId, webviewView.webview);
 
     webviewView.onDidDispose(() => {
@@ -59,7 +60,7 @@ export class KimiWebviewProvider implements vscode.WebviewViewProvider {
   }
 
   createPanel(): vscode.WebviewPanel {
-    const webviewId = `panel_${crypto.randomUUID()}`;
+    const webviewId = `panel_${randomUUID()}`;
 
     const panel = vscode.window.createWebviewPanel("kimiPanel", "Kimi Code", vscode.ViewColumn.One, {
       enableScripts: true,


### PR DESCRIPTION
## Related Issue

No linked issue — this is a clear, reproducible crash reported by a user; the problem is explained below.

## Problem

Extension builds up to 0.5.10 declare `"engines": { "vscode": "^1.70.0" }`, so the marketplace happily installs them on older VS Code releases (e.g. 1.85.2, whose extension host runs Node 18). `KimiWebviewProvider.resolveWebviewView()` / `createPanel()` call the **global** `crypto.randomUUID()`, which only exists in extension hosts running Node >= 20. On those clients the call throws before the sidebar renders, and the user just sees:

```
An error occurred while loading view: kimi.webview
```

Observed on VS Code 1.85.2 with extension 0.5.10 (window `renderer.log`):

```
[error] crypto is not defined: ReferenceError: crypto is not defined
    at vn.resolveWebviewView (.../moonshot-ai.kimi-code-0.5.10-win32-x64/dist/extension.js:25:12091)
```

`main` has since raised `engines.vscode` to `^1.100.0`, so new installs are gated — but older VS Code clients are still served the broken 0.5.x builds, and relying on an implicit Web Crypto global in extension-host code stays fragile (it is not part of the `node` runtime contract the code actually runs against). This may also be worth cherry-picking if a 0.5.x hotfix is ever published.

## What changed

`apps/vscode/src/KimiWebviewProvider.ts`: import `randomUUID` from `node:crypto` (available since Node 14.17) instead of the global `crypto`, matching the existing pattern in `apps/vscode/src/runtime/reverse-rpc.ts`. Behavior is identical on supported VS Code versions; the code no longer depends on the runtime exposing Web Crypto as a global.

Verified: `pnpm typecheck`, `pnpm exec oxlint src/KimiWebviewProvider.ts` (0 errors), and the extension test suite (14 files, 297 tests, all passing).

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works. (No new tests — behavior-preserving fix; ran the existing apps/vscode suite, 297/297 passing.)
- [x] Ran `gen-changesets` skill, or this PR needs no changeset. (No changeset — the VS Code extension is versioned and released outside the changesets flow.)
- [x] Ran `gen-docs` skill, or this PR needs no doc update. (No user-facing docs change.)
