### PR TITLE
fix(agent-core-v2): skip known legacy wire records on restore

### DIFF
--- a/.changeset/skip-legacy-wire-records.md
+++ b/.changeset/skip-legacy-wire-records.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Fix spurious "Unknown wire record type" errors when restoring sessions whose history contains records the engine deliberately no longer replays, such as those from the retired micro-compaction experiment.

--- a/packages/agent-core-v2/src/wire/wireService.ts
+++ b/packages/agent-core-v2/src/wire/wireService.ts
@@ -6,7 +6,11 @@
  * including creation-time sealing, metadata, migrations, atomic healing
  * rewrites, blob dehydration and rehydration plus an ordered post-restore hook.
  * It is bound at Agent scope because the aggregate identity is the Agent
- * identity.
+ * identity. Replay silently skips `LEGACY_RECORD_TYPES` — journal vocabulary
+ * this engine knows of but deliberately does not replay: records of retired
+ * features (micro compaction) and v1-only bookkeeping it recomputes live
+ * (context token counts). Genuinely unknown types are still reported, and
+ * healing rewrites preserve legacy records for readers that understand them.
  */
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
@@ -48,6 +52,11 @@ import {
 } from './record';
 
 const MAX_DRAIN = 100;
+
+const LEGACY_RECORD_TYPES: ReadonlySet<string> = new Set([
+  'micro_compaction.apply',
+  'context.update_token_count',
+]);
 
 export class CycleError extends WireError {
   constructor(readonly depth: number, readonly opTypes: readonly string[]) {
@@ -213,7 +222,9 @@ export class WireService extends Disposable implements IWireService {
   private replayRecord(record: WireRecord, index: number): void {
     const descriptor = OP_REGISTRY.get(record.type);
     if (descriptor === undefined) {
-      this.reportSkippedRecord(record.type, index);
+      if (!LEGACY_RECORD_TYPES.has(record.type)) {
+        this.reportSkippedRecord(record.type, index);
+      }
       return;
     }
     const payload = descriptor.schema.safeParse(wireRecordToPayload(record));

--- a/packages/agent-core-v2/test/wire/wire-compat.test.ts
+++ b/packages/agent-core-v2/test/wire/wire-compat.test.ts
@@ -125,4 +125,61 @@ describe('wire.jsonl round-trip', () => {
     );
     expect(replayTarget.wire.getModel(TagsModel)).toEqual(live.wire.getModel(TagsModel));
   });
+
+  it('replays past legacy record types without reporting them', async () => {
+    const dir = await makeDir();
+    const storage = new FileStorageService(dir);
+    const target = makeContainer(storage, 'legacy-replay');
+    const records: WireRecord[] = [
+      { type: 'micro_compaction.apply', cutoff: 2, time: 1 },
+      { type: 'context.update_token_count', tokenCount: 5, time: 2 },
+      { type: 'compat.counter.set', value: 3, time: 3 },
+    ];
+
+    const unexpected: unknown[] = [];
+    setUnexpectedErrorHandler((error) => unexpected.push(error));
+    try {
+      await restoreTestAgentWire(
+        target.wire,
+        target.log,
+        testWireScope(SCOPE, 'legacy-replay'),
+        records,
+      );
+    } finally {
+      resetUnexpectedErrorHandler();
+    }
+
+    expect(unexpected).toEqual([]);
+    expect(target.wire.getModel(CounterModel)).toEqual({ value: 3 });
+  });
+
+  it('skips legacy records in a metadata-first journal and preserves them through the healing rewrite', async () => {
+    const dir = await makeDir();
+    const storage = new FileStorageService(dir);
+    const target = makeContainer(storage, 'legacy-metadata');
+    const scope = testWireScope(SCOPE, 'legacy-metadata');
+    const records: WireRecord[] = [
+      { type: 'metadata', protocol_version: '1.4', created_at: 1 },
+      { type: 'micro_compaction.apply', cutoff: 2, time: 1 },
+      { type: 'compat.counter.set', value: 3, time: 2 },
+    ];
+
+    const unexpected: unknown[] = [];
+    setUnexpectedErrorHandler((error) => unexpected.push(error));
+    try {
+      await restoreTestAgentWire(target.wire, target.log, scope, records);
+    } finally {
+      resetUnexpectedErrorHandler();
+    }
+
+    expect(unexpected).toEqual([]);
+    expect(target.wire.getModel(CounterModel)).toEqual({ value: 3 });
+
+    const rewritten: WireRecord[] = [];
+    for await (const record of target.log.read<WireRecord>(scope, AGENT_WIRE_RECORD_KEY)) {
+      rewritten.push(record);
+    }
+    expect(rewritten[0]).toMatchObject({ type: 'metadata', protocol_version: '1.5' });
+    expect(rewritten.some((record) => record.type === 'micro_compaction.apply')).toBe(true);
+  });
 });


### PR DESCRIPTION
## Related Issue

Resolve #2003

## Problem

Resuming a session whose `wire.jsonl` was written by an earlier version reports unexpected errors during restore:

```
[unexpected] WireError: Unknown wire record type 'micro_compaction.apply' skipped during restore
```

`micro_compaction.apply` was persisted by the micro-compaction experiment while it was live. The feature has since been retired (removed from the v1 engine in #1317), and the v2 engine never registered an op for it, so `WireService.replayRecord` treats every occurrence as an unknown record and routes it through `onUnexpectedError` — once per record, which for a long session means hundreds of reports (the linked issue shows `index: 1035`), even though skipping the record is exactly the intended outcome.

`context.update_token_count` is in the same situation: v1-only bookkeeping (v1 still writes it on the import-context path) that v2 deliberately does not replay because it recomputes context size live.

Reproduced against the 0.29.1 release build (v2 print mode) by adding a `micro_compaction.apply` record to a session journal: restore prints the exact error and stack from the issue. With this patch, the same session restores silently.

## What changed

`WireService.replayRecord` now consults a small allowlist (`LEGACY_RECORD_TYPES`) before reporting a skipped record. The two legacy types are still skipped, but silently; genuinely unknown types keep raising `wire.unknown_record`, so the report stays meaningful for real journal corruption or version skew. The journal itself is untouched — healing rewrites preserve legacy records, since the v1 engine and the vis replay tooling still understand them.

Two cases added to the existing wire-compat round-trip suite: a journal carrying both legacy types restores with no unexpected error while later records still replay, and a metadata-first 1.4 journal keeps its legacy record through the healing rewrite while its metadata upgrades to 1.5.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.
