### PR TITLE
fix(agent-core): suppress the spurious error event for step-capped goal turns

### DIFF
--- a/.changeset/goal-step-cap-error-banner.md
+++ b/.changeset/goal-step-cap-error-banner.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Stop showing a spurious error banner when a goal turn reaches the per-turn step limit (`loop_control.max_steps_per_turn`) during autonomous goal pursuit; the limit is expected control flow there and still surfaces for ordinary turns.

--- a/packages/agent-core/src/agent/turn/index.ts
+++ b/packages/agent-core/src/agent/turn/index.ts
@@ -633,7 +633,14 @@ export class TurnFlow {
           inputData: { errorType: summary.name, errorMessage: summary.message },
         });
         ended = { type: 'turn.ended', turnId, reason: 'failed', error: summary, durationMs: Date.now() - startedAt };
-        errorEvent = { type: 'error', ...summary };
+        // A goal-driven turn cut by the per-turn step limit is expected
+        // control flow — the goal driver immediately continues with a fresh
+        // continuation turn — so it must not raise the standalone error event
+        // that hosts render as an actionable failure. `turn.ended` and the
+        // `turn.interrupted` loop event still report the cap.
+        if (!(isMaxStepsExceededError(error) && this.agent.goal.getActiveGoal() !== null)) {
+          errorEvent = { type: 'error', ...summary };
+        }
         if (this.shouldTrackApiError(turnId)) {
           const classification = classifyApiError(error, summary);
           const properties: Record<string, TelemetryPropertyValue> = {

--- a/packages/agent-core/test/agent/turn.test.ts
+++ b/packages/agent-core/test/agent/turn.test.ts
@@ -1875,6 +1875,15 @@ describe('Agent turn flow', () => {
         }),
       }),
     );
+    // Without an active goal the cap is a user-facing failure: the standalone
+    // error event (suppressed for goal-driven turns) is emitted right after
+    // turn.ended.
+    expect(ctx.newEvents()).toContainEqual(
+      expect.objectContaining({
+        event: 'error',
+        args: expect.objectContaining({ code: 'loop.max_steps_exceeded' }),
+      }),
+    );
   });
 
   describe('loop control env overrides', () => {

--- a/packages/agent-core/test/harness/goal-session.test.ts
+++ b/packages/agent-core/test/harness/goal-session.test.ts
@@ -523,6 +523,9 @@ describe('goal session end-to-end', () => {
           ErrorCodes.LOOP_MAX_STEPS_EXCEEDED,
     );
     expect(maxStepEnds).toHaveLength(2);
+    // Capped goal turns are expected control flow: no standalone error event
+    // is emitted for hosts to render as an actionable failure.
+    expect(events.filter((event) => event['type'] === 'error')).toEqual([]);
     // The cap never pauses or blocks the goal: no stopped status is ever
     // emitted, and the goal completes (record cleared) in the third turn.
     expect(


### PR DESCRIPTION
## Related Issue

Follow-up to #2210 (which made goal pursuit continue across the per-turn step limit). The problem is explained below.

## Problem

After #2210, a goal turn that hits `loop_control.max_steps_per_turn` no longer pauses the goal — but the TUI still renders a red, actionable error banner for every capped turn:

```
Error: [loop.max_steps_exceeded] Turn exceeded maxSteps=3. …
If this persists, run '/export-debug-zip' and share the file with us for diagnosis.
```

Root cause: `runOneTurn`'s catch path emits a standalone `error` event for *any* failed turn (in addition to `turn.ended{reason:'failed'}` and the `turn.interrupted{reason:'max_steps'}` loop event). The TUI's session-error handler renders that event as an actionable failure. For goal-driven turns the cap is expected control flow — the driver immediately starts the next continuation turn — so the banner is pure noise that makes an intentional limit look like a malfunction.

## What changed

- In v1 `TurnFlow.runOneTurn`, the standalone `error` event is no longer emitted when the failure is `loop.max_steps_exceeded` **and** a goal is active (i.e. exactly the turns the goal driver will continue). Everything else is preserved: `turn.ended{reason:'failed', error:…}`, the `turn.interrupted{reason:'max_steps'}` loop event, the `StopFailure` hook, and API-error telemetry.
- Ordinary (non-goal) turns still emit the standalone error event — a user's prompt cut by the cap must keep surfacing.
- Tests: the v1 goal harness test now asserts capped goal turns produce zero standalone `error` events; the existing non-goal max-steps test now asserts the event is still emitted (right after `turn.ended`).
- Includes a changeset (`@moonshot-ai/kimi-code`, patch).

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.
