### PR TITLE
fix(kap-server): flush public and control WS frames immediately

### DIFF
--- a/packages/kap-server/src/transport/ws/v1/sessionEventBroadcaster.ts
+++ b/packages/kap-server/src/transport/ws/v1/sessionEventBroadcaster.ts
@@ -122,9 +122,12 @@ export interface SessionSnapshotState {
   subagents: SnapshotSubagent[];
 }
 
+/** Internal transport lane: only subscription traffic enters the timed buffer. */
+export type BroadcastDelivery = 'subscription' | 'immediate';
+
 /** A connection (or test double) that receives sequenced envelopes. */
 export interface BroadcastTarget {
-  send(envelope: EventEnvelope): void;
+  send(envelope: EventEnvelope, delivery?: BroadcastDelivery): void;
 }
 
 /**
@@ -1208,7 +1211,7 @@ export class SessionEventBroadcaster {
       for (const target of this.allTargets()) recipients.add(target);
       for (const target of recipients) {
         try {
-          target.send(envelope);
+          target.send(envelope, 'immediate');
         } catch {
           // best-effort fan-out; a broken target is dropped, not fatal
         }

--- a/packages/kap-server/src/transport/ws/v1/wsConnectionV1.ts
+++ b/packages/kap-server/src/transport/ws/v1/wsConnectionV1.ts
@@ -44,6 +44,7 @@ import {
 } from './protocol';
 import {
   type AgentFilter,
+  type BroadcastDelivery,
   type BroadcastTarget,
   type ResyncReason,
   type SessionEventBroadcaster,
@@ -56,9 +57,10 @@ const DEFAULT_MAX_BUFFER_SIZE = 1000;
 /** Per-session subscription state held by the connection (see `TargetSubscription`). */
 type SessionSubscription = TargetSubscription;
 
-// Outbound send buffer — coalesces a burst of frames (notably high-frequency
-// volatile text deltas) into fewer `socket.send` calls and applies backpressure
-// when the peer is not draining fast enough. See `flush()` / `coalesceFrames`.
+// Subscription-event send buffer — coalesces a burst of frames (notably
+// high-frequency volatile text deltas) within one render-frame-sized window.
+// Public/control frames are immediate barriers: they enter the same FIFO and
+// flush any earlier subscription frames so cross-channel order stays intact.
 const DEFAULT_FLUSH_INTERVAL_MS = 16;
 const DEFAULT_MAX_BATCH_SIZE = 64;
 const DEFAULT_HIGH_WATER_MARK_BYTES = 1 << 20; // 1 MiB
@@ -88,9 +90,9 @@ export interface WsConnectionV1Options {
   readonly userAgent: string | null;
   readonly logger?: JournalLogger;
   readonly maxBufferSize?: number;
-  /** Delay before a buffered batch is flushed; coalesces frames within the window. */
+  /** Delay before buffered subscription events are flushed. */
   readonly flushIntervalMs?: number;
-  /** Flush immediately once this many frames are queued, even before the interval. */
+  /** Flush subscription events once this many frames are queued. */
   readonly maxBatchSize?: number;
   /** `socket.bufferedAmount` above which flushing is deferred (backpressure). */
   readonly highWaterMarkBytes?: number;
@@ -156,7 +158,7 @@ export class WsConnectionV1 implements BroadcastTarget {
     // connection without any subscription; session/agent events stay
     // subscribe-gated via `broadcaster.subscribe`.
     this.broadcaster.addGlobalTarget(this);
-    this.sendFrame(
+    this.sendImmediateFrame(
       buildServerHello({
         ws_connection_id: this.id,
         protocol_version: WS_PROTOCOL_VERSION,
@@ -174,9 +176,10 @@ export class WsConnectionV1 implements BroadcastTarget {
     return Array.from(this.subscriptions.keys()).sort();
   }
 
-  /** BroadcastTarget — forward a sequenced envelope to the socket. */
-  send(envelope: EventEnvelope): void {
-    this.sendFrame(envelope);
+  /** BroadcastTarget — buffer subscription traffic; public traffic is a FIFO barrier. */
+  send(envelope: EventEnvelope, delivery: BroadcastDelivery = 'subscription'): void {
+    if (delivery === 'immediate') this.sendImmediateFrame(envelope);
+    else this.sendSubscribedFrame(envelope);
   }
 
   private onMessage(data: RawData): void {
@@ -253,7 +256,7 @@ export class WsConnectionV1 implements BroadcastTarget {
       );
     }
 
-    this.sendFrame(
+    this.sendImmediateFrame(
       buildAck(frame.id ?? '', 0, 'success', {
         accepted_subscriptions: accepted,
         resync_required: resyncRequired,
@@ -286,7 +289,7 @@ export class WsConnectionV1 implements BroadcastTarget {
       );
     }
 
-    this.sendFrame(
+    this.sendImmediateFrame(
       buildAck(frame.id ?? '', 0, 'success', {
         accepted,
         not_found: notFound,
@@ -307,7 +310,7 @@ export class WsConnectionV1 implements BroadcastTarget {
   private async onSubscribeV2(frame: InboundFrame): Promise<void> {
     const parsed = transcriptSubscribeV2PayloadSchema.safeParse(frame.payload ?? {});
     if (!parsed.success) {
-      this.sendFrame(buildAck(frame.id ?? '', 1, 'invalid subscribe_v2 payload', {}));
+      this.sendImmediateFrame(buildAck(frame.id ?? '', 1, 'invalid subscribe_v2 payload', {}));
       return;
     }
     const sid = parsed.data.session_id;
@@ -326,7 +329,7 @@ export class WsConnectionV1 implements BroadcastTarget {
       { accepted, resyncRequired, serverCursors, notFound },
     );
 
-    this.sendFrame(
+    this.sendImmediateFrame(
       buildAck(frame.id ?? '', 0, 'success', {
         accepted,
         not_found: notFound,
@@ -347,7 +350,7 @@ export class WsConnectionV1 implements BroadcastTarget {
   private async onUnsubscribeV2(frame: InboundFrame): Promise<void> {
     const parsed = unsubscribeV2PayloadSchema.safeParse(frame.payload ?? {});
     if (!parsed.success) {
-      this.sendFrame(buildAck(frame.id ?? '', 1, 'invalid unsubscribe_v2 payload', {}));
+      this.sendImmediateFrame(buildAck(frame.id ?? '', 1, 'invalid unsubscribe_v2 payload', {}));
       return;
     }
     const sid = parsed.data.session_id;
@@ -363,7 +366,7 @@ export class WsConnectionV1 implements BroadcastTarget {
       });
     }
 
-    this.sendFrame(
+    this.sendImmediateFrame(
       buildAck(frame.id ?? '', 0, 'success', {
         accepted: [sid],
         not_found: [],
@@ -379,7 +382,7 @@ export class WsConnectionV1 implements BroadcastTarget {
       this.broadcaster.unsubscribe(sid, this);
       this.subscriptions.delete(sid);
     }
-    this.sendFrame(
+    this.sendImmediateFrame(
       buildAck(frame.id ?? '', 0, 'success', {
         accepted: [],
         not_found: [],
@@ -394,7 +397,7 @@ export class WsConnectionV1 implements BroadcastTarget {
     const paths = asStringArray(payload['paths']);
     const bridge = this.fsWatchBridge;
     if (bridge === undefined) {
-      this.sendFrame(buildAck(frame.id ?? '', 1, 'fs watch unavailable', {}));
+      this.sendImmediateFrame(buildAck(frame.id ?? '', 1, 'fs watch unavailable', {}));
       return;
     }
     let result;
@@ -403,14 +406,14 @@ export class WsConnectionV1 implements BroadcastTarget {
         ? await bridge.addWatch(this, sessionId, paths)
         : await bridge.removeWatch(this, sessionId, paths);
     } catch (error) {
-      this.sendFrame(
+      this.sendImmediateFrame(
         buildAck(frame.id ?? '', 1, 'internal error', {
           message: error instanceof Error ? error.message : String(error),
         }),
       );
       return;
     }
-    this.sendFrame(
+    this.sendImmediateFrame(
       buildAck(frame.id ?? '', result.code, result.msg, {
         watched_paths: result.watched_paths ?? [],
         current_count: result.current_count ?? 0,
@@ -472,12 +475,12 @@ export class WsConnectionV1 implements BroadcastTarget {
   ): Promise<void> {
     const result = await this.broadcaster.getBufferedSince(sid, cursor, filter, transcriptGrades);
     if (result.resyncRequired !== false) {
-      this.sendFrame(
+      this.sendImmediateFrame(
         buildResyncRequired(sid, result.resyncRequired as ResyncReason, result.currentSeq, result.epoch),
       );
       resyncRequired.push(sid);
     } else {
-      for (const { envelope } of result.events) this.sendFrame(envelope);
+      for (const { envelope } of result.events) this.sendSubscribedFrame(envelope);
     }
     serverCursors[sid] = { seq: result.currentSeq, epoch: result.epoch };
   }
@@ -497,14 +500,15 @@ export class WsConnectionV1 implements BroadcastTarget {
       ok = false;
     }
     if (!ok) {
-      this.sendFrame(buildAck(frame.id ?? '', 40112, 'unauthorized', {}));
+      this.sendImmediateFrame(buildAck(frame.id ?? '', 40112, 'unauthorized', {}));
       this.close();
       return false;
     }
     return true;
   }
 
-  private sendFrame(msg: unknown): void {
+  /** Queue an event delivered through `subscribe` / `subscribe_v2`. */
+  private sendSubscribedFrame(msg: unknown): void {
     if (this.closed) return;
     this.outbound.push(msg);
     if (this.outbound.length >= this.maxBatchSize) {
@@ -513,6 +517,16 @@ export class WsConnectionV1 implements BroadcastTarget {
       return;
     }
     this.scheduleFlush();
+  }
+
+  /**
+   * Public/control frames do not start a timer. They join the FIFO and flush it
+   * immediately, so no later frame can overtake earlier subscription traffic.
+   */
+  private sendImmediateFrame(msg: unknown): void {
+    if (this.closed) return;
+    this.outbound.push(msg);
+    this.flush();
   }
 
   private scheduleFlush(): void {

--- a/packages/kap-server/test/sessionEventBroadcaster.test.ts
+++ b/packages/kap-server/test/sessionEventBroadcaster.test.ts
@@ -37,6 +37,7 @@ import type { AgentEvent } from '../src/transport/ws/v1/events';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import {
+  type BroadcastDelivery,
   type BroadcastTarget,
   SessionEventBroadcaster,
 } from '../src/transport/ws/v1/sessionEventBroadcaster';
@@ -382,9 +383,23 @@ function agentEvent(type: string, extra: Record<string, unknown> = {}): AgentEve
   return { type, ...extra } as unknown as AgentEvent;
 }
 
-function collectingTarget(): { target: BroadcastTarget; envelopes: EventEnvelope[] } {
+function collectingTarget(): {
+  target: BroadcastTarget;
+  envelopes: EventEnvelope[];
+  deliveries: BroadcastDelivery[];
+} {
   const envelopes: EventEnvelope[] = [];
-  return { target: { send: (e) => envelopes.push(e) }, envelopes };
+  const deliveries: BroadcastDelivery[] = [];
+  return {
+    target: {
+      send: (envelope, delivery = 'subscription') => {
+        envelopes.push(envelope);
+        deliveries.push(delivery);
+      },
+    },
+    envelopes,
+    deliveries,
+  };
 }
 
 // A real turn yields the event loop between `turn.started` and `turn.ended`,
@@ -425,7 +440,7 @@ describe('SessionEventBroadcaster', () => {
     const main = lc.addAgent('main');
     sessions.set('s1', lc);
 
-    const { target, envelopes } = collectingTarget();
+    const { target, envelopes, deliveries } = collectingTarget();
     expect(await bc.subscribe('s1', target)).toBe(true);
 
     main.bus.emit(agentEvent('turn.started', { turnId: 1 }));
@@ -451,6 +466,16 @@ describe('SessionEventBroadcaster', () => {
     });
     expect(envelopes.every((e) => e.epoch === envelopes[0]!.epoch)).toBe(true);
     expect(durable[1]!.volatile).toBeUndefined();
+    expect(
+      envelopes.flatMap((envelope, index) =>
+        envelope.volatile === true ? [] : [[envelope.type, deliveries[index]]],
+      ),
+    ).toEqual([
+      ['turn.started', 'subscription'],
+      ['event.session.work_changed', 'immediate'],
+      ['turn.ended', 'subscription'],
+      ['event.session.work_changed', 'immediate'],
+    ]);
   });
 
   it('fans out volatile events with the current watermark + offset, not journaled', async () => {
@@ -895,6 +920,7 @@ describe('SessionEventBroadcaster', () => {
         type: 'event.session.created',
         session_id: 's1',
       });
+      expect(globalView.deliveries).toEqual(['immediate']);
     });
 
     it('delivers work_changed to a global-only target while a subscriber drives the session', async () => {
@@ -1701,6 +1727,7 @@ describe('SessionEventBroadcaster', () => {
           session_id: 's1',
           payload: { agent_id: 'main', has_more_older: false, snapshot: { items: [] } },
         });
+        expect(view.deliveries).toEqual(['subscription']);
       }
       expect(transcriptEnvelopes(plainView.envelopes)).toHaveLength(0);
 

--- a/packages/kap-server/test/wsConnectionV1.test.ts
+++ b/packages/kap-server/test/wsConnectionV1.test.ts
@@ -636,25 +636,40 @@ describe('WsConnectionV1 outbound buffer', () => {
     vi.useRealTimers();
   });
 
-  it('buffers server_hello and flushes it after the interval', async () => {
+  it('sends server_hello immediately', () => {
     const socket = new FakeSocket();
     const conn = makeConn(socket, { flushIntervalMs: 16 });
-    expect(socket.sent).toHaveLength(0);
-    await vi.advanceTimersByTimeAsync(16);
-    expect(socket.frames().map((f) => (f as { type: string }).type)).toContain('server_hello');
+    expect(socket.frames().map((f) => (f as { type: string }).type)).toEqual(['server_hello']);
     conn.close();
   });
 
-  it('coalesces adjacent deltas into one socket.send', async () => {
+  it('buffers subscribe_v2 transcript frames without merging them', async () => {
     const socket = new FakeSocket();
     const conn = makeConn(socket, { flushIntervalMs: 16 });
-    await vi.advanceTimersByTimeAsync(16); // flush server_hello
+    socket.sent = [];
+
+    conn.send(durable('transcript.reset', 's1', 7));
+    conn.send(durable('transcript.ops', 's1', 8));
+    expect(socket.sent).toHaveLength(0);
+    await vi.advanceTimersByTimeAsync(15);
+    expect(socket.sent).toHaveLength(0);
+    await vi.advanceTimersByTimeAsync(1);
+
+    const frames = socket.frames() as Array<{ type: string; seq: number }>;
+    expect(frames.map((frame) => frame.type)).toEqual(['transcript.reset', 'transcript.ops']);
+    expect(frames.map((frame) => frame.seq)).toEqual([7, 8]);
+    conn.close();
+  });
+
+  it('coalesces adjacent subscribed deltas into one socket.send', async () => {
+    const socket = new FakeSocket();
+    const conn = makeConn(socket, { flushIntervalMs: 16 });
     socket.sent = [];
 
     conn.send(delta('s1', 'main', 1, 'Hello', 0));
     conn.send(delta('s1', 'main', 1, ' ', 5));
     conn.send(delta('s1', 'main', 1, 'world', 6));
-    expect(socket.sent).toHaveLength(0); // still buffered
+    expect(socket.sent).toHaveLength(0);
     await vi.advanceTimersByTimeAsync(16);
 
     const frames = socket.frames();
@@ -666,15 +681,36 @@ describe('WsConnectionV1 outbound buffer', () => {
     conn.close();
   });
 
-  it('flushes immediately once the batch reaches maxBatchSize', async () => {
+  it('sends public events immediately and preserves FIFO with subscribed events', async () => {
+    const socket = new FakeSocket();
+    const conn = makeConn(socket, { flushIntervalMs: 16 });
+    socket.sent = [];
+
+    conn.send(delta('s1', 'main', 1, 'before', 0));
+    expect(socket.sent).toHaveLength(0);
+    conn.send(durable('event.session.work_changed', 's1', 2), 'immediate');
+
+    expect(socket.frames().map((f) => (f as { type: string }).type)).toEqual([
+      'assistant.delta',
+      'event.session.work_changed',
+    ]);
+    await vi.advanceTimersByTimeAsync(16);
+    expect(socket.sent).toHaveLength(2);
+    conn.close();
+  });
+
+  it('flushes immediately once the subscribed batch reaches maxBatchSize', () => {
     const socket = new FakeSocket();
     const conn = makeConn(socket, { flushIntervalMs: 1000, maxBatchSize: 3 });
-    // constructor already queued server_hello (1); two deltas bring it to 3.
+    socket.sent = [];
+
     conn.send(delta('s1', 'main', 1, 'a', 0));
     conn.send(delta('s1', 'main', 1, 'b', 1));
-    // No timer advanced — flush must have happened synchronously.
-    const types = socket.frames().map((f) => (f as { type: string }).type);
-    expect(types).toEqual(['server_hello', 'assistant.delta']);
+    conn.send(delta('s1', 'main', 1, 'c', 2));
+
+    const frames = socket.frames();
+    expect(frames).toHaveLength(1);
+    expect((frames[0] as { payload: { delta: string } }).payload.delta).toBe('abc');
     conn.close();
   });
 
@@ -684,53 +720,45 @@ describe('WsConnectionV1 outbound buffer', () => {
       flushIntervalMs: 16,
       highWaterMarkBytes: 100,
     });
-    await vi.advanceTimersByTimeAsync(16); // flush server_hello
     socket.sent = [];
 
-    socket.bufferedAmount = 200; // above the watermark
+    socket.bufferedAmount = 200;
     conn.send(delta('s1', 'main', 1, 'Hello', 0));
-    await vi.advanceTimersByTimeAsync(16); // flush attempted → deferred
+    await vi.advanceTimersByTimeAsync(16);
     expect(socket.sent).toHaveLength(0);
 
-    // More deltas arrive while deferred — they merge into the queued frame.
     conn.send(delta('s1', 'main', 1, ' world', 5));
-    await vi.advanceTimersByTimeAsync(5); // backpressure retry, still high
+    await vi.advanceTimersByTimeAsync(5);
     expect(socket.sent).toHaveLength(0);
 
-    socket.bufferedAmount = 0; // peer drained
-    await vi.advanceTimersByTimeAsync(5); // retry succeeds
+    socket.bufferedAmount = 0;
+    await vi.advanceTimersByTimeAsync(5);
     const frames = socket.frames();
     expect(frames).toHaveLength(1);
     expect((frames[0] as { payload: { delta: string } }).payload.delta).toBe('Hello world');
     conn.close();
   });
 
-  it('force-flushes buffered frames on close', async () => {
+  it('force-flushes buffered subscription frames on close', () => {
     const socket = new FakeSocket();
     const conn = makeConn(socket, { flushIntervalMs: 1000 });
-    // server_hello is still buffered (interval not elapsed).
+    socket.sent = [];
+
     conn.send(delta('s1', 'main', 1, 'tail', 0));
     expect(socket.sent).toHaveLength(0);
 
     conn.close();
-    const types = socket.frames().map((f) => (f as { type: string }).type);
-    expect(types).toContain('server_hello');
-    expect(types).toContain('assistant.delta');
-    const tail = socket
-      .frames()
-      .find((f) => (f as { type: string }).type === 'assistant.delta') as {
-      payload: { delta: string };
-    };
-    expect(tail.payload.delta).toBe('tail');
+    const frames = socket.frames();
+    expect(frames).toHaveLength(1);
+    expect((frames[0] as { payload: { delta: string } }).payload.delta).toBe('tail');
   });
 
   it('drops buffered frames when the socket is already closed at flush time', async () => {
     const socket = new FakeSocket();
     const conn = makeConn(socket, { flushIntervalMs: 16 });
-    await vi.advanceTimersByTimeAsync(16); // flush server_hello
     socket.sent = [];
 
-    socket.readyState = socket.CLOSED; // peer went away
+    socket.readyState = socket.CLOSED;
     conn.send(delta('s1', 'main', 1, 'lost', 0));
     await vi.advanceTimersByTimeAsync(16);
     expect(socket.sent).toHaveLength(0);


### PR DESCRIPTION
## Related Issue

No linked issue — the problem is explained in the next section.

## Problem

On the `/api/v1/ws` connection, every outbound frame went through the timed coalescing buffer that exists for high-frequency subscription traffic (streamed text deltas). Control and public frames — `server_hello`, subscribe/unsubscribe acks, `resync_required`, and global session events such as `session.work_changed` — could sit in that buffer for a whole flush window before reaching the client, adding avoidable latency to the handshake and ack responses and delaying global events behind buffered subscription traffic.

## What changed

- Split the connection's outbound path into two delivery lanes: subscription events keep the timed coalescing buffer (batching, backpressure, and delta merging are unchanged), while public/control frames join the same FIFO and flush it immediately — sent right away without overtaking earlier buffered subscription frames.
- The broadcaster marks global fan-out deliveries with a new `immediate` delivery marker; session-scoped subscription deliveries keep the buffered lane.
- Tests updated and extended to cover: immediate `server_hello`, buffered-but-unmerged transcript frames, FIFO ordering across the two lanes, batch-size flush, backpressure deferral, and flush-on-close.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.
