### PR TITLE
fix(kosong): skip empty reasoning fields in OpenAI-compatible streams

### DIFF
--- a/.changeset/tidy-rivers-merge.md
+++ b/.changeset/tidy-rivers-merge.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Fix streamed assistant replies rendering one token per line with OpenAI-compatible providers that pad empty reasoning fields into every chunk.

--- a/packages/kosong/src/providers/openai-legacy.ts
+++ b/packages/kosong/src/providers/openai-legacy.ts
@@ -386,11 +386,17 @@ export class OpenAILegacyStreamedMessage implements StreamedMessage {
 
     // Reasoning content: honor the explicit key when set, otherwise scan the
     // de facto field set and remember the dialect for outbound echo.
-    // Skip empty strings: some gateways pad every content-phase chunk with an
-    // empty reasoning field, which would otherwise interleave empty think
-    // parts between text deltas and defeat sequential merging downstream.
+    // Skip empty strings on pure content messages: some gateways pad every
+    // content-phase chunk with an empty reasoning field, which would otherwise
+    // interleave empty think parts between text deltas and defeat sequential
+    // merging downstream. Tool-call messages keep the empty marker so the
+    // reasoning field is replayed on continuation, as some reasoning
+    // endpoints require.
     const reasoning = reasoningKeyDialect.observe(message);
-    if (reasoning !== undefined && reasoning.length > 0) {
+    if (
+      reasoning !== undefined &&
+      (reasoning.length > 0 || (message.tool_calls?.length ?? 0) > 0)
+    ) {
       yield { type: 'think', think: reasoning } satisfies StreamedMessagePart;
     }
 
@@ -444,11 +450,18 @@ export class OpenAILegacyStreamedMessage implements StreamedMessage {
 
         // Reasoning content: honor the explicit key when set, otherwise scan
         // the de facto field set and remember the dialect for outbound echo.
-        // Skip empty strings: some gateways pad every content-phase chunk with
-        // an empty reasoning field, which would otherwise interleave empty
-        // think parts between text deltas and defeat sequential merging.
+        // Skip empty strings on content-only chunks: some gateways pad every
+        // content-phase chunk with an empty reasoning field, which would
+        // otherwise interleave empty think parts between text deltas and
+        // defeat sequential merging. Tool-call chunks keep the empty marker
+        // so the reasoning field is replayed on continuation, as some
+        // reasoning endpoints require; adjacent empty think parts merge into
+        // one, so at most a single marker survives.
         const reasoning = reasoningKeyDialect.observe(delta);
-        if (reasoning !== undefined && reasoning.length > 0) {
+        if (
+          reasoning !== undefined &&
+          (reasoning.length > 0 || (delta.tool_calls?.length ?? 0) > 0)
+        ) {
           yield { type: 'think', think: reasoning } satisfies StreamedMessagePart;
         }
 

--- a/packages/kosong/src/providers/openai-legacy.ts
+++ b/packages/kosong/src/providers/openai-legacy.ts
@@ -386,8 +386,11 @@ export class OpenAILegacyStreamedMessage implements StreamedMessage {
 
     // Reasoning content: honor the explicit key when set, otherwise scan the
     // de facto field set and remember the dialect for outbound echo.
+    // Skip empty strings: some gateways pad every content-phase chunk with an
+    // empty reasoning field, which would otherwise interleave empty think
+    // parts between text deltas and defeat sequential merging downstream.
     const reasoning = reasoningKeyDialect.observe(message);
-    if (reasoning !== undefined) {
+    if (reasoning !== undefined && reasoning.length > 0) {
       yield { type: 'think', think: reasoning } satisfies StreamedMessagePart;
     }
 
@@ -441,8 +444,11 @@ export class OpenAILegacyStreamedMessage implements StreamedMessage {
 
         // Reasoning content: honor the explicit key when set, otherwise scan
         // the de facto field set and remember the dialect for outbound echo.
+        // Skip empty strings: some gateways pad every content-phase chunk with
+        // an empty reasoning field, which would otherwise interleave empty
+        // think parts between text deltas and defeat sequential merging.
         const reasoning = reasoningKeyDialect.observe(delta);
-        if (reasoning !== undefined) {
+        if (reasoning !== undefined && reasoning.length > 0) {
           yield { type: 'think', think: reasoning } satisfies StreamedMessagePart;
         }
 

--- a/packages/kosong/test/openai-legacy.test.ts
+++ b/packages/kosong/test/openai-legacy.test.ts
@@ -1469,7 +1469,11 @@ describe('OpenAILegacyChatProvider', () => {
       ]);
     });
 
-    it('yields an empty ThinkPart from an explicitly empty streaming reasoning field', async () => {
+    it('skips empty streaming reasoning fields instead of yielding empty ThinkParts', async () => {
+      // Some OpenAI-compatible gateways pad every content-phase chunk with an
+      // empty reasoning field. Yielding empty ThinkParts would interleave them
+      // between text deltas and defeat sequential merging (symptom downstream:
+      // one text part per token).
       const provider = new OpenAILegacyChatProvider({
         model: 'deepseek-reasoner',
         apiKey: 'test-key',
@@ -1488,7 +1492,45 @@ describe('OpenAILegacyChatProvider', () => {
       const parts: StreamedMessagePart[] = [];
       for await (const part of stream) parts.push(part);
 
-      expect(parts).toEqual([{ type: 'think', think: '' }]);
+      expect(parts).toEqual([]);
+    });
+
+    it('does not interleave empty ThinkParts between text deltas when chunks pad empty reasoning', async () => {
+      const provider = new OpenAILegacyChatProvider({
+        model: 'some-reasoning-model',
+        apiKey: 'test-key',
+        stream: true,
+      });
+
+      async function* mockedStream(): AsyncIterable<Record<string, unknown>> {
+        yield {
+          id: 'c1',
+          choices: [{ index: 0, delta: { content: '', reasoning_content: 'think 1' } }],
+        };
+        yield {
+          id: 'c1',
+          choices: [{ index: 0, delta: { content: 'Hello', reasoning_content: '' } }],
+        };
+        yield {
+          id: 'c1',
+          choices: [{ index: 0, delta: { content: ' world', reasoning_content: '' } }],
+        };
+        yield { id: 'c1', choices: [{ index: 0, delta: {}, finish_reason: 'stop' }] };
+      }
+
+      (provider as any)._client.chat.completions.create = vi
+        .fn()
+        .mockResolvedValue(mockedStream());
+
+      const stream = await provider.generate('', [], []);
+      const parts: StreamedMessagePart[] = [];
+      for await (const part of stream) parts.push(part);
+
+      expect(parts).toEqual([
+        { type: 'think', think: 'think 1' },
+        { type: 'text', text: 'Hello' },
+        { type: 'text', text: ' world' },
+      ]);
     });
 
     it('treats blank reasoning_key as unset so defaults still apply', async () => {
@@ -1838,7 +1880,7 @@ describe('OpenAILegacyChatProvider — non-stream response parsing', () => {
     ]);
   });
 
-  it('yields an empty ThinkPart when the non-stream reasoning field is explicitly empty', async () => {
+  it('skips an explicitly empty non-stream reasoning field', async () => {
     const provider = new OpenAILegacyChatProvider({
       model: 'deepseek-reasoner',
       apiKey: 'test-key',
@@ -1855,7 +1897,7 @@ describe('OpenAILegacyChatProvider — non-stream response parsing', () => {
       }),
     );
 
-    expect(parts).toEqual([{ type: 'think', think: '' }]);
+    expect(parts).toEqual([]);
   });
 
   it('non-stream response yields ToolCall parts when tool_calls present', async () => {

--- a/packages/kosong/test/openai-legacy.test.ts
+++ b/packages/kosong/test/openai-legacy.test.ts
@@ -1533,6 +1533,45 @@ describe('OpenAILegacyChatProvider', () => {
       ]);
     });
 
+    it('preserves the empty reasoning marker on streaming tool-call chunks', async () => {
+      // Reasoning endpoints may require the reasoning field to be replayed on
+      // tool-call continuation; the empty marker must survive so the outbound
+      // message keeps carrying the reasoning field.
+      const provider = new OpenAILegacyChatProvider({
+        model: 'some-reasoning-model',
+        apiKey: 'test-key',
+        stream: true,
+      });
+
+      async function* mockedStream(): AsyncIterable<Record<string, unknown>> {
+        yield {
+          id: 'c1',
+          choices: [
+            {
+              index: 0,
+              delta: {
+                reasoning_content: '',
+                tool_calls: [
+                  { id: 'call_1', index: 0, function: { name: 'foo', arguments: '{}' } },
+                ],
+              },
+            },
+          ],
+        };
+        yield { id: 'c1', choices: [{ index: 0, delta: {}, finish_reason: 'tool_calls' }] };
+      }
+
+      (provider as any)._client.chat.completions.create = vi
+        .fn()
+        .mockResolvedValue(mockedStream());
+
+      const stream = await provider.generate('', [], []);
+      const parts: StreamedMessagePart[] = [];
+      for await (const part of stream) parts.push(part);
+
+      expect(parts.filter((p) => p.type === 'think')).toEqual([{ type: 'think', think: '' }]);
+    });
+
     it('treats blank reasoning_key as unset so defaults still apply', async () => {
       // ModelAliasSchema accepts `reasoning_key = ""` (z.string().optional()).
       // A blank value must not route reads/writes through an empty property
@@ -1898,6 +1937,32 @@ describe('OpenAILegacyChatProvider — non-stream response parsing', () => {
     );
 
     expect(parts).toEqual([]);
+  });
+
+  it('preserves the empty reasoning marker on a non-stream tool-call response', async () => {
+    // Reasoning endpoints may require the reasoning field to be replayed on
+    // tool-call continuation; the empty marker must survive so the outbound
+    // message keeps carrying the reasoning field.
+    const provider = new OpenAILegacyChatProvider({
+      model: 'deepseek-reasoner',
+      apiKey: 'test-key',
+      stream: false,
+      reasoningKey: 'reasoning_content',
+    });
+
+    const parts = await collectFromMockedResponse(
+      provider,
+      makeNonStreamResponse({
+        role: 'assistant',
+        content: null,
+        reasoning_content: '',
+        tool_calls: [
+          { id: 'call_1', type: 'function', function: { name: 'foo', arguments: '{}' } },
+        ],
+      }),
+    );
+
+    expect(parts.filter((p) => p.type === 'think')).toEqual([{ type: 'think', think: '' }]);
   });
 
   it('non-stream response yields ToolCall parts when tool_calls present', async () => {

--- a/packages/kosong/test/openai-legacy.test.ts
+++ b/packages/kosong/test/openai-legacy.test.ts
@@ -1533,6 +1533,48 @@ describe('OpenAILegacyChatProvider', () => {
       ]);
     });
 
+    it('assembles one merged text part through generate() when chunks pad empty reasoning', async () => {
+      // End-to-end invariant behind the per-token-line-breaks bug: after the
+      // stream is drained and merged, the reply must be a single text part.
+      const provider = new OpenAILegacyChatProvider({
+        model: 'some-reasoning-model',
+        apiKey: 'test-key',
+        stream: true,
+      });
+
+      async function* mockedStream(): AsyncIterable<Record<string, unknown>> {
+        yield {
+          id: 'c1',
+          choices: [{ index: 0, delta: { content: '', reasoning_content: 'think 1' } }],
+        };
+        yield {
+          id: 'c1',
+          choices: [{ index: 0, delta: { content: 'Hello', reasoning_content: '' } }],
+        };
+        yield {
+          id: 'c1',
+          choices: [{ index: 0, delta: { content: ' world', reasoning_content: '' } }],
+        };
+        yield { id: 'c1', choices: [{ index: 0, delta: {}, finish_reason: 'stop' }] };
+      }
+
+      (provider as any)._client.chat.completions.create = vi
+        .fn()
+        .mockResolvedValue(mockedStream());
+
+      const result = await generate(
+        provider,
+        '',
+        [],
+        [{ role: 'user', content: [{ type: 'text', text: 'hi' }], toolCalls: [] }],
+      );
+
+      expect(result.message.content).toEqual([
+        { type: 'think', think: 'think 1' },
+        { type: 'text', text: 'Hello world' },
+      ]);
+    });
+
     it('preserves the empty reasoning marker on streaming tool-call chunks', async () => {
       // Reasoning endpoints may require the reasoning field to be replayed on
       // tool-call continuation; the empty marker must survive so the outbound


### PR DESCRIPTION
## Related Issue

Resolve #2226

## Problem

See linked issue. In short: some OpenAI-compatible gateways pad every content-phase stream chunk with an empty reasoning field (`"reasoning_content":""`). The provider yielded an empty `think` part per chunk, which interleaved between text deltas and defeated sequential part merging — so streamed replies rendered one token per line in the TUI.

## What changed

**Fix** — In the OpenAI chat-completions provider (`openai-legacy`), skip empty reasoning strings at both yield sites (stream and non-stream), **except when the message/chunk carries `tool_calls`**. Rationale for the exception: #1676 established that reasoning backends can reject continuations when the reasoning field is omitted from assistant tool-call messages, so the empty marker on tool-call turns is load-bearing and is preserved exactly. Adjacent empty think parts merge into one, so at most a single marker survives per turn. Content-only turns — the case that produced the per-token rendering bug — no longer emit empty think parts at all.

**Why at the provider layer** — dropping the padding at the yield site protects every downstream consumer (message assembly, persisted history, transcript projection, TUI). Fixing it in `mergeInPlace` instead would still persist semantically empty think parts into session history.

**Scope audit** — the other kosong adapters were checked for the same hazard: `anthropic` and `openai-responses` empty think parts carry protocol significance (thinking-block signatures, reasoning-item boundaries) and are not produced by per-chunk padding; `kimi`'s first-party API does not pad empty reasoning fields; `google-genai` yields think parts only from real thought text. `agent-core-v2` now builds its model wire layer on kosong, so this single fix covers both engines.

**Tests** — updated the two tests that asserted the old empty-ThinkPart behavior, and added regression coverage for: skipping empty streaming reasoning fields, no interleaving between text deltas (GLM-style chunks), preserving the empty marker on streaming tool-call chunks, preserving it on non-stream tool-call responses, and an end-to-end `generate()` assertion that the assembled message contains exactly one merged text part.

**Changeset** — `@moonshot-ai/kimi-code`, patch.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.
