### PR TITLE
fix(acp): support multi-question prompts

### DIFF
--- a/.changeset/fix-acp-multi-question-prompts.md
+++ b/.changeset/fix-acp-multi-question-prompts.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Fix ACP clients dropping questions after the first prompt and preserve multi-select answers and skipped-question notes.

--- a/packages/acp-adapter/src/question.ts
+++ b/packages/acp-adapter/src/question.ts
@@ -4,58 +4,35 @@ import type {
 } from '@agentclientprotocol/sdk';
 import type { QuestionAnswers, QuestionItem } from '@moonshot-ai/kimi-code-sdk';
 
-/**
- * `optionId` namespace for the AskUserQuestion bridge.
- *
- * The wire-level `PermissionOption.optionId` is opaque to the client (it
- * round-trips back via `RequestPermissionResponse.outcome.optionId`), so
- * the adapter is free to pick any stable string. We embed the
- * `questionIndex` in the prefix so multi-question support (when it
- * arrives — Phase 13.1 still degrades to single-question) does not need
- * a wire-format change: `q0_opt_*` / `q1_opt_*` are already
- * non-conflicting. The skip option follows the same scheme so a single
- * regex (`/^q(\d+)_(opt_(\d+)|skip)$/`) can parse any future surface.
- */
 function optOptionId(questionIndex: number, optionIndex: number): string {
   return `q${questionIndex}_opt_${optionIndex}`;
+}
+
+function doneOptionId(questionIndex: number): string {
+  return `q${questionIndex}_done`;
 }
 
 function skipOptionId(questionIndex: number): string {
   return `q${questionIndex}_skip`;
 }
 
-/**
- * Map a tool-side {@link QuestionItem} into ACP
- * {@link PermissionOption}[].
- *
- * Layout:
- *  - One `allow_once` option per `question.options[i]` (label preserved
- *    verbatim — it is the same string we surface back to the SDK as a
- *    `QuestionAnswers` value, so any UI normalisation belongs on the
- *    tool side, not here).
- *  - One trailing `reject_once` "Skip" option so the user can dismiss
- *    the prompt without forcing an answer. The SDK's ask-user tool
- *    already understands dismissal (`packages/agent-core/src/tools/builtin/collaboration/ask-user.ts:126`
- *    emits `question_dismissed` and resolves with a null result); the
- *    Skip surface is the user-facing path into that branch.
- *
- * `questionIndex` is currently always `0` (Phase 13.1 degrades
- * multi-question to single-question), but the namespace is wired in so
- * future multi-question support is a pure handler change with no wire
- * format break.
- *
- * Returned `readonly` because callers treat it as a constant lookup
- * table — they do not mutate it.
- */
 export function questionItemToPermissionOptions(
   question: QuestionItem,
   questionIndex: number,
+  selectedOptions: ReadonlySet<number> = new Set<number>(),
 ): readonly PermissionOption[] {
   const options: PermissionOption[] = question.options.map((opt, i) => ({
     optionId: optOptionId(questionIndex, i),
-    name: opt.label,
+    name: selectedOptions.has(i) ? `✓ ${opt.label}` : opt.label,
     kind: 'allow_once' as const,
   }));
+  if (question.multiSelect === true && selectedOptions.size > 0) {
+    options.push({
+      optionId: doneOptionId(questionIndex),
+      name: 'Done',
+      kind: 'allow_once' as const,
+    });
+  }
   options.push({
     optionId: skipOptionId(questionIndex),
     name: 'Skip',
@@ -64,36 +41,38 @@ export function questionItemToPermissionOptions(
   return options;
 }
 
-/**
- * Reverse-map an ACP {@link RequestPermissionResponse} into a tool-side
- * {@link QuestionAnswers} payload, returning `null` when the user
- * dismissed (skip, cancel) or selected an unknown option.
- *
- * Dismissal semantics align with the existing ask-user tool path:
- * `null` causes the SDK to resolve the tool with the canonical
- * "user dismissed" branch (mirrors `rpc.ts:567` — `requestQuestion`
- * returning `null` is the dismissed signal).
- *
- * Defensive on out-of-bounds / unknown optionIds: returning `null`
- * rather than throwing keeps the bridge robust against stale or custom
- * options surfaced by the client.
- */
+export type QuestionPermissionOutcome =
+  | { readonly kind: 'option'; readonly optionIndex: number }
+  | { readonly kind: 'done' }
+  | { readonly kind: 'skip' }
+  | { readonly kind: 'cancelled' };
+
+export function permissionResponseToQuestionOutcome(
+  question: QuestionItem,
+  questionIndex: number,
+  response: RequestPermissionResponse,
+): QuestionPermissionOutcome {
+  if (response.outcome.outcome === 'cancelled') return { kind: 'cancelled' };
+  const optionId = response.outcome.optionId;
+  if (optionId === skipOptionId(questionIndex)) return { kind: 'skip' };
+  if (question.multiSelect === true && optionId === doneOptionId(questionIndex)) {
+    return { kind: 'done' };
+  }
+  const match = new RegExp(`^q${String(questionIndex)}_opt_(\\d+)$`).exec(optionId);
+  if (!match) return { kind: 'cancelled' };
+  const optionIndex = Number(match[1]);
+  if (!Number.isInteger(optionIndex) || optionIndex < 0 || !question.options[optionIndex]) {
+    return { kind: 'cancelled' };
+  }
+  return { kind: 'option', optionIndex };
+}
+
 export function outcomeToQuestionAnswer(
   question: QuestionItem,
   response: RequestPermissionResponse,
 ): QuestionAnswers | null {
-  if (response.outcome.outcome === 'cancelled') return null;
-  const optionId = response.outcome.optionId;
-  // Skip — explicit dismissal path; treat the same as `cancelled`.
-  if (optionId === skipOptionId(0)) return null;
-  // Selected option — parse the `q0_opt_<i>` shape and look up the
-  // matching label. Reject anything that does not match the namespace
-  // (or whose index is out of bounds) defensively rather than crashing.
-  const match = /^q0_opt_(\d+)$/.exec(optionId);
-  if (!match) return null;
-  const optionIndex = Number(match[1]);
-  if (!Number.isInteger(optionIndex) || optionIndex < 0) return null;
-  const selected = question.options[optionIndex];
-  if (!selected) return null;
+  const outcome = permissionResponseToQuestionOutcome(question, 0, response);
+  if (outcome.kind !== 'option') return null;
+  const selected = question.options[outcome.optionIndex]!;
   return { [question.question]: selected.label };
 }

--- a/packages/acp-adapter/src/session.ts
+++ b/packages/acp-adapter/src/session.ts
@@ -21,7 +21,9 @@ import {
   type McpServerInfo,
   type PromptPart,
   type QuestionAnswers,
+  type QuestionItem,
   type QuestionRequest,
+  type QuestionResult,
   type Session,
   type SessionStatus,
   type SessionUsage,
@@ -56,7 +58,10 @@ import {
   turnEndReasonToStopReason,
 } from './events-map';
 import { acpModeToToggles, DEFAULT_MODE_ID, isAcpModeId, type AcpModeId } from './modes';
-import { outcomeToQuestionAnswer, questionItemToPermissionOptions } from './question';
+import {
+  permissionResponseToQuestionOutcome,
+  questionItemToPermissionOptions,
+} from './question';
 import { detectSlashIntent } from './slash';
 
 /**
@@ -70,6 +75,10 @@ export type TelemetryTrackFn = (
   event: string,
   properties?: Record<string, unknown>,
 ) => void;
+
+function formatQuestionCount(count: number): string {
+  return `${String(count)} ${count === 1 ? 'question' : 'questions'}`;
+}
 
 /**
  * Adapter-side wrapper around a {@link Session} from the Kimi node SDK.
@@ -1347,86 +1356,138 @@ export class AcpSession {
     }
   }
 
-  /**
-   * Bridge an SDK {@link QuestionRequest} (the AskUserQuestion tool's
-   * reverse-RPC) through the same ACP
-   * `session/request_permission` surface used by approvals.
-   *
-   * ACP currently has no dedicated `session/request_question` method, so
-   * the adapter re-uses `requestPermission` and tags the options with a
-   * `q{n}_*` namespace so the round-trip is unambiguous.
-   *
-   * Degradation rules:
-   *  - `req.questions.length > 1` → only the first question is asked;
-   *    telemetry records the dropped count so we can observe how often
-   *    multi-question prompts land in the wild.
-   *  - `q.multiSelect === true` → still asked as single-select; the
-   *    SDK's ask-user tool tolerates a single-key answer for a multi-
-   *    select prompt so this is a graceful narrow rather than a hard
-   *    fail.
-   *
-   * Error policy mirrors {@link handleApproval}: any RPC failure logs
-   * a warning and returns `null` so the SDK resolves the tool with the
-   * canonical "user dismissed" branch (`rpc.ts:567`). Returning `null`
-   * is strictly safer than fabricating an answer the user did not give.
-   */
-  private async handleQuestion(req: QuestionRequest): Promise<QuestionAnswers | null> {
+  private async handleQuestion(req: QuestionRequest): Promise<QuestionResult> {
     const questions = req.questions;
     if (questions.length === 0) {
-      // Pathological input — log and dismiss. No telemetry: the SDK
-      // would never emit an empty `questions` payload in practice.
       log.warn('acp: handleQuestion received empty questions array', {
         sessionId: this.id,
       });
       return null;
     }
-    if (questions.length > 1) {
-      log.warn('acp: handleQuestion degrading to first question only', {
-        sessionId: this.id,
-        dropped: questions.length - 1,
-      });
-      this.emitTelemetry('question_degraded', {
-        reason: 'multi_question',
-        dropped: questions.length - 1,
-      });
-    }
-    const q = questions[0]!;
-    if (q.multiSelect === true) {
-      this.emitTelemetry('question_degraded', { reason: 'multi_select' });
-    }
-    const options = questionItemToPermissionOptions(q, 0);
     const rawToolCallId = req.toolCallId ?? 'ask-user';
     const toolCallId =
       this.currentTurnId !== undefined
         ? acpToolCallId(this.currentTurnId, rawToolCallId)
         : rawToolCallId;
+    const answers: QuestionAnswers = {};
+    const skippedQuestions: string[] = [];
+    const clientUnansweredQuestions: string[] = [];
+    let questionIndex = 0;
     try {
+      for (; questionIndex < questions.length; questionIndex++) {
+        const question = questions[questionIndex]!;
+        const result = await this.handleQuestionItem(
+          question,
+          questionIndex,
+          questions.length,
+          toolCallId,
+        );
+        if (result.answer !== undefined) {
+          answers[question.question] = result.answer;
+        } else {
+          skippedQuestions.push(question.question);
+        }
+        if (result.cancelRemaining) {
+          skippedQuestions.push(
+            ...questions.slice(questionIndex + 1).map((item) => item.question),
+          );
+          break;
+        }
+      }
+    } catch (error) {
+      clientUnansweredQuestions.push(
+        ...questions.slice(questionIndex).map((item) => item.question),
+      );
+      log.warn('acp: requestPermission (question) failed; dismissing remaining questions', {
+        sessionId: this.id,
+        toolCallId: req.toolCallId,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+
+    const answered = Object.keys(answers).length;
+    if (answered === 0) {
+      this.emitTelemetry('question_dismissed');
+    } else {
+      this.emitTelemetry('question_answered', { answered });
+    }
+    const noteParts: string[] = [];
+    if (skippedQuestions.length > 0) {
+      noteParts.push(
+        `User skipped ${formatQuestionCount(skippedQuestions.length)}: ${skippedQuestions.map((question) => JSON.stringify(question)).join(', ')}.`,
+      );
+    }
+    if (clientUnansweredQuestions.length > 0) {
+      noteParts.push(
+        `The client stopped before ${formatQuestionCount(clientUnansweredQuestions.length)} could be answered.`,
+      );
+    }
+    if (noteParts.length === 0) return answers;
+    return {
+      answers,
+      note: noteParts.join(' '),
+    };
+  }
+
+  private async handleQuestionItem(
+    question: QuestionItem,
+    questionIndex: number,
+    questionCount: number,
+    toolCallId: string,
+  ): Promise<{ readonly answer?: string; readonly cancelRemaining: boolean }> {
+    const selectedOptions = new Set<number>();
+    while (true) {
+      const options = questionItemToPermissionOptions(
+        question,
+        questionIndex,
+        selectedOptions,
+      );
       const response = await this.conn.requestPermission({
         sessionId: this.id,
         options: [...options],
         toolCall: {
           toolCallId,
-          title: 'AskUserQuestion',
-          content: [{ type: 'content', content: { type: 'text', text: q.question } }],
+          title:
+            questionCount === 1
+              ? 'AskUserQuestion'
+              : `AskUserQuestion (${String(questionIndex + 1)}/${String(questionCount)})`,
+          content: [
+            { type: 'content', content: { type: 'text', text: question.question } },
+          ],
         },
       });
-      const answer = outcomeToQuestionAnswer(q, response);
-      if (answer === null) {
-        // Dismissed via skip / cancel / unknown optionId — telemetry
-        // matches the ask-user tool's existing `question_dismissed`
-        // event so dashboards stay coherent.
-        this.emitTelemetry('question_dismissed');
-      } else {
-        this.emitTelemetry('question_answered', { answered: Object.keys(answer).length });
+      const outcome = permissionResponseToQuestionOutcome(
+        question,
+        questionIndex,
+        response,
+      );
+      if (outcome.kind === 'cancelled') {
+        return { cancelRemaining: true };
       }
-      return answer;
-    } catch (err) {
-      log.warn('acp: requestPermission (question) failed; dismissing', {
-        sessionId: this.id,
-        toolCallId: req.toolCallId,
-        error: err instanceof Error ? err.message : String(err),
-      });
-      return null;
+      if (outcome.kind === 'skip') {
+        return { cancelRemaining: false };
+      }
+      if (outcome.kind === 'done') {
+        if (selectedOptions.size === 0) {
+          return { cancelRemaining: true };
+        }
+        const answer = question.options
+          .filter((_option, optionIndex) => selectedOptions.has(optionIndex))
+          .map((option) => option.label)
+          .join(', ');
+        return { answer, cancelRemaining: false };
+      }
+      if (question.multiSelect !== true) {
+        return {
+          answer: question.options[outcome.optionIndex]!.label,
+          cancelRemaining: false,
+        };
+      }
+      if (selectedOptions.has(outcome.optionIndex)) {
+        selectedOptions.delete(outcome.optionIndex);
+      } else {
+        selectedOptions.add(outcome.optionIndex);
+      }
     }
   }
 

--- a/packages/acp-adapter/test/question.test.ts
+++ b/packages/acp-adapter/test/question.test.ts
@@ -5,7 +5,11 @@ import type {
 import type { QuestionItem } from '@moonshot-ai/kimi-code-sdk';
 import { describe, expect, it } from 'vitest';
 
-import { outcomeToQuestionAnswer, questionItemToPermissionOptions } from '../src/question';
+import {
+  outcomeToQuestionAnswer,
+  permissionResponseToQuestionOutcome,
+  questionItemToPermissionOptions,
+} from '../src/question';
 
 const sampleQuestion: QuestionItem = {
   question: 'Pick a flavour',
@@ -62,6 +66,18 @@ describe('questionItemToPermissionOptions', () => {
       kind: 'reject_once',
     });
   });
+
+  it('marks selected multi-select options and exposes Done after the first choice', () => {
+    const multi: QuestionItem = { ...sampleQuestion, multiSelect: true };
+    const opts = questionItemToPermissionOptions(multi, 2, new Set([0, 2]));
+    expect(opts.map((option) => [option.optionId, option.name])).toEqual([
+      ['q2_opt_0', '✓ Vanilla'],
+      ['q2_opt_1', 'Chocolate'],
+      ['q2_opt_2', '✓ Mint chip'],
+      ['q2_done', 'Done'],
+      ['q2_skip', 'Skip'],
+    ]);
+  });
 });
 
 describe('outcomeToQuestionAnswer', () => {
@@ -97,5 +113,24 @@ describe('outcomeToQuestionAnswer', () => {
 
   it('defensively maps an out-of-bounds index to null', () => {
     expect(outcomeToQuestionAnswer(sampleQuestion, selected('q0_opt_99'))).toBeNull();
+  });
+
+  it('parses question-indexed options, Done, Skip, and cancellation', () => {
+    const multi: QuestionItem = { ...sampleQuestion, multiSelect: true };
+    expect(permissionResponseToQuestionOutcome(multi, 2, selected('q2_opt_1'))).toEqual({
+      kind: 'option',
+      optionIndex: 1,
+    });
+    expect(permissionResponseToQuestionOutcome(multi, 2, selected('q2_done'))).toEqual({
+      kind: 'done',
+    });
+    expect(permissionResponseToQuestionOutcome(multi, 2, selected('q2_skip'))).toEqual({
+      kind: 'skip',
+    });
+    expect(
+      permissionResponseToQuestionOutcome(multi, 2, {
+        outcome: { outcome: 'cancelled' },
+      }),
+    ).toEqual({ kind: 'cancelled' });
   });
 });

--- a/packages/acp-adapter/test/session-question-handler.test.ts
+++ b/packages/acp-adapter/test/session-question-handler.test.ts
@@ -63,6 +63,7 @@ function makeQuestionSession(sessionId: string): {
  */
 class CapturingConn {
   readonly permissionRequests: RequestPermissionRequest[] = [];
+  replies: Array<RequestPermissionResponse | Error> = [];
   reply: RequestPermissionResponse = {
     outcome: { outcome: 'selected', optionId: 'q0_opt_0' },
   };
@@ -73,7 +74,9 @@ class CapturingConn {
     if (this.shouldThrow) {
       throw new Error('client unreachable');
     }
-    return this.reply;
+    const nextReply = this.replies.shift();
+    if (nextReply instanceof Error) throw nextReply;
+    return nextReply ?? this.reply;
   }
   async sessionUpdate(): Promise<void> {
     /* not exercised */
@@ -166,7 +169,7 @@ describe('AcpSession.handleQuestion', () => {
     expect(trackCalls).toEqual([{ event: 'question_answered', properties: { answered: 1 } }]);
   });
 
-  it('skip: q0_skip resolves to null with question_dismissed telemetry', async () => {
+  it('skip: q0_skip resolves with a skipped-question note', async () => {
     const { conn, raw } = makeConn();
     const handle = makeQuestionSession('s-q-skip');
     raw.reply = { outcome: { outcome: 'selected', optionId: 'q0_skip' } };
@@ -174,11 +177,14 @@ describe('AcpSession.handleQuestion', () => {
 
     const answer = await handle.invokeHandler(makeReq());
 
-    expect(answer).toBeNull();
+    expect(answer).toEqual({
+      answers: {},
+      note: 'User skipped 1 question: "哪个口味？".',
+    });
     expect(trackCalls).toEqual([{ event: 'question_dismissed', properties: undefined }]);
   });
 
-  it('cancelled: outcome cancelled resolves to null with question_dismissed', async () => {
+  it('cancelled: reports the current and remaining questions as skipped', async () => {
     const { conn, raw } = makeConn();
     const handle = makeQuestionSession('s-q-cancel');
     raw.reply = { outcome: { outcome: 'cancelled' } };
@@ -186,14 +192,21 @@ describe('AcpSession.handleQuestion', () => {
 
     const answer = await handle.invokeHandler(makeReq());
 
-    expect(answer).toBeNull();
+    expect(answer).toEqual({
+      answers: {},
+      note: 'User skipped 1 question: "哪个口味？".',
+    });
     expect(trackCalls).toEqual([{ event: 'question_dismissed', properties: undefined }]);
   });
 
-  it('multi-question degradation: 3 questions → only first asked + question_degraded', async () => {
+  it('asks every question in order and returns all non-skipped answers', async () => {
     const { conn, raw } = makeConn();
     const handle = makeQuestionSession('s-q-multi');
-    raw.reply = { outcome: { outcome: 'selected', optionId: 'q0_opt_1' } };
+    raw.replies = [
+      { outcome: { outcome: 'selected', optionId: 'q0_opt_1' } },
+      { outcome: { outcome: 'selected', optionId: 'q1_opt_0' } },
+      { outcome: { outcome: 'selected', optionId: 'q2_skip' } },
+    ];
     new AcpSession(conn, handle.session, undefined, track);
 
     const extra1: QuestionItem = { question: 'Q2', options: [{ label: 'a' }] };
@@ -202,24 +215,36 @@ describe('AcpSession.handleQuestion', () => {
       makeReq({ questions: [sampleQuestion, extra1, extra2] }),
     );
 
-    expect(answer).toEqual({ '哪个口味？': '巧克力' });
-    expect(raw.permissionRequests).toHaveLength(1);
-    // Telemetry: degraded(multi_question) first, then answered.
-    expect(trackCalls).toEqual([
-      { event: 'question_degraded', properties: { reason: 'multi_question', dropped: 2 } },
-      { event: 'question_answered', properties: { answered: 1 } },
+    expect(answer).toEqual({
+      answers: { '哪个口味？': '巧克力', Q2: 'a' },
+      note: 'User skipped 1 question: "Q3".',
+    });
+    expect(raw.permissionRequests).toHaveLength(3);
+    expect(raw.permissionRequests.map((request) => request.toolCall.title)).toEqual([
+      'AskUserQuestion (1/3)',
+      'AskUserQuestion (2/3)',
+      'AskUserQuestion (3/3)',
     ]);
-    // log.warn fired with the dropped count.
-    expect(warnSpy).toHaveBeenCalledWith(
-      expect.stringContaining('degrading to first question only'),
-      expect.objectContaining({ dropped: 2 }),
-    );
+    expect(raw.permissionRequests.map((request) => request.options[0]?.optionId)).toEqual([
+      'q0_opt_0',
+      'q1_opt_0',
+      'q2_opt_0',
+    ]);
+    expect(trackCalls).toEqual([
+      { event: 'question_answered', properties: { answered: 2 } },
+    ]);
+    expect(warnSpy).not.toHaveBeenCalled();
   });
 
-  it('multiSelect degradation: still asks the question + question_degraded', async () => {
+  it('toggles multi-select choices until Done and returns the remaining selections', async () => {
     const { conn, raw } = makeConn();
     const handle = makeQuestionSession('s-q-multisel');
-    raw.reply = { outcome: { outcome: 'selected', optionId: 'q0_opt_0' } };
+    raw.replies = [
+      { outcome: { outcome: 'selected', optionId: 'q0_opt_0' } },
+      { outcome: { outcome: 'selected', optionId: 'q0_opt_1' } },
+      { outcome: { outcome: 'selected', optionId: 'q0_opt_0' } },
+      { outcome: { outcome: 'selected', optionId: 'q0_done' } },
+    ];
     new AcpSession(conn, handle.session, undefined, track);
 
     const multi: QuestionItem = {
@@ -232,15 +257,87 @@ describe('AcpSession.handleQuestion', () => {
       questions: [multi],
     });
 
-    expect(answer).toEqual({ 'Pick any': 'a' });
-    expect(raw.permissionRequests).toHaveLength(1);
+    expect(answer).toEqual({ 'Pick any': 'b' });
+    expect(raw.permissionRequests).toHaveLength(4);
+    expect(raw.permissionRequests[1]?.options.map((option) => option.name)).toEqual([
+      '✓ a',
+      'b',
+      'Done',
+      'Skip',
+    ]);
+    expect(raw.permissionRequests[2]?.options.map((option) => option.name)).toEqual([
+      '✓ a',
+      '✓ b',
+      'Done',
+      'Skip',
+    ]);
+    expect(raw.permissionRequests[3]?.options.map((option) => option.name)).toEqual([
+      'a',
+      '✓ b',
+      'Done',
+      'Skip',
+    ]);
     expect(trackCalls).toEqual([
-      { event: 'question_degraded', properties: { reason: 'multi_select' } },
       { event: 'question_answered', properties: { answered: 1 } },
     ]);
   });
 
-  it('requestPermission throw → log.warn + null', async () => {
+  it('continues to later questions after Skip', async () => {
+    const { conn, raw } = makeConn();
+    const handle = makeQuestionSession('s-q-skip-continue');
+    raw.replies = [
+      { outcome: { outcome: 'selected', optionId: 'q0_skip' } },
+      { outcome: { outcome: 'selected', optionId: 'q1_opt_0' } },
+    ];
+    new AcpSession(conn, handle.session, undefined, track);
+
+    const answer = await handle.invokeHandler(
+      makeReq({
+        questions: [
+          sampleQuestion,
+          { question: 'Q2', options: [{ label: 'second answer' }] },
+        ],
+      }),
+    );
+
+    expect(answer).toEqual({
+      answers: { Q2: 'second answer' },
+      note: 'User skipped 1 question: "哪个口味？".',
+    });
+    expect(raw.permissionRequests).toHaveLength(2);
+    expect(trackCalls).toEqual([
+      { event: 'question_answered', properties: { answered: 1 } },
+    ]);
+  });
+
+  it('distinguishes a skipped question from a later client failure', async () => {
+    const { conn, raw } = makeConn();
+    const handle = makeQuestionSession('s-q-skip-then-throw');
+    raw.replies = [
+      { outcome: { outcome: 'selected', optionId: 'q0_skip' } },
+      new Error('client unreachable'),
+    ];
+    new AcpSession(conn, handle.session, undefined, track);
+
+    const answer = await handle.invokeHandler(
+      makeReq({
+        questions: [
+          sampleQuestion,
+          { question: 'Q2', options: [{ label: 'second answer' }] },
+        ],
+      }),
+    );
+
+    expect(answer).toEqual({
+      answers: {},
+      note:
+        'User skipped 1 question: "哪个口味？". ' +
+        'The client stopped before 1 question could be answered.',
+    });
+    expect(raw.permissionRequests).toHaveLength(2);
+  });
+
+  it('requestPermission throw logs a warning and returns a client-stopped note', async () => {
     const { conn, raw } = makeConn();
     const handle = makeQuestionSession('s-q-throw');
     raw.shouldThrow = true;
@@ -248,14 +345,17 @@ describe('AcpSession.handleQuestion', () => {
 
     const answer = await handle.invokeHandler(makeReq());
 
-    expect(answer).toBeNull();
+    expect(answer).toEqual({
+      answers: {},
+      note: 'The client stopped before 1 question could be answered.',
+    });
     expect(warnSpy).toHaveBeenCalledWith(
       expect.stringContaining('requestPermission (question) failed'),
       expect.objectContaining({ toolCallId: 'tc-ask-1' }),
     );
-    // No question_answered / question_dismissed emitted on throw — the
-    // RPC failure is its own observability path (log.warn above).
-    expect(trackCalls).toEqual([]);
+    expect(trackCalls).toEqual([
+      { event: 'question_dismissed', properties: undefined },
+    ]);
   });
 
   it('no track sink: handler still runs without emitting telemetry', async () => {

--- a/packages/agent-core-v2/src/agent/tools/ask-user-question/askUserQuestionTool.ts
+++ b/packages/agent-core-v2/src/agent/tools/ask-user-question/askUserQuestionTool.ts
@@ -187,7 +187,7 @@ export class AskUserQuestionTool implements IAskUserQuestionTool {
           trace_id: trace?.traceId,
         };
         this.telemetry.track2('question_dismissed', properties);
-        return dismissedQuestionResult();
+        return dismissedQuestionResult(normalized?.note);
       }
 
       const properties: QuestionAnsweredEvent = {
@@ -198,7 +198,7 @@ export class AskUserQuestionTool implements IAskUserQuestionTool {
       this.telemetry.track2('question_answered', properties);
       return {
         isError: false,
-        output: JSON.stringify({ answers: normalized.answers }),
+        output: JSON.stringify({ answers: normalized.answers, note: normalized.note }),
       };
     } catch (error) {
       if (isAbortError(error) || signal.aborted) throw error;
@@ -227,24 +227,29 @@ function questionDescription(questions: AskUserQuestionInput['questions']): stri
   return `${label} (+${String(questions.length - 1)} more)`;
 }
 
-function dismissedQuestionResult(): ExecutableToolResult {
+function dismissedQuestionResult(note = QUESTION_DISMISSED_MESSAGE): ExecutableToolResult {
   return {
     isError: false,
     output: JSON.stringify({
       answers: {},
-      note: QUESTION_DISMISSED_MESSAGE,
+      note,
     }),
   };
 }
 
 function normalizeQuestionResult(
   result: QuestionResult,
-): { readonly answers: QuestionAnswers; readonly method?: QuestionAnswerMethod | undefined } | null {
+): {
+  readonly answers: QuestionAnswers;
+  readonly method?: QuestionAnswerMethod | undefined;
+  readonly note?: string | undefined;
+} | null {
   if (result === null) return null;
   if (isQuestionResponse(result)) {
     return {
       answers: result.answers,
       method: result.method,
+      note: result.note,
     };
   }
   return { answers: result };

--- a/packages/agent-core-v2/src/session/question/question.ts
+++ b/packages/agent-core-v2/src/session/question/question.ts
@@ -40,6 +40,7 @@ export type QuestionAnswers = Record<string, string | true>;
 export interface QuestionResponse {
   readonly answers: QuestionAnswers;
   readonly method?: QuestionAnswerMethod;
+  readonly note?: string;
 }
 
 export type QuestionResult = null | QuestionAnswers | QuestionResponse;

--- a/packages/agent-core-v2/test/agent/questionTools/tools/ask-user.test.ts
+++ b/packages/agent-core-v2/test/agent/questionTools/tools/ask-user.test.ts
@@ -321,6 +321,29 @@ describe('AskUserQuestionTool', () => {
     });
   });
 
+  it('preserves a skipped-question note in the tool output', async () => {
+    const { tool } = makeTool({
+      request: async () => ({
+        answers: { 'Which database?': 'SQLite' },
+        note: 'User skipped 1 question: "Which cache?".',
+      }),
+    });
+
+    const result = await executeTool(tool, {
+      turnId: 0,
+      toolCallId: 'call_question',
+      args: input(),
+      signal,
+    });
+
+    expect(result.output).toBe(
+      JSON.stringify({
+        answers: { 'Which database?': 'SQLite' },
+        note: 'User skipped 1 question: "Which cache?".',
+      }),
+    );
+  });
+
   it('merges the request trace id into question telemetry', async () => {
     const { tool, telemetryTrack } = makeTool();
 

--- a/packages/agent-core/src/rpc/sdk-api.ts
+++ b/packages/agent-core/src/rpc/sdk-api.ts
@@ -48,6 +48,7 @@ export type QuestionAnswers = Record<string, string | true>;
 export interface QuestionResponse {
   readonly answers: QuestionAnswers;
   readonly method?: QuestionAnswerMethod | undefined;
+  readonly note?: string | undefined;
 }
 
 export type QuestionResult = null | QuestionAnswers | QuestionResponse;

--- a/packages/agent-core/src/services/question/question.ts
+++ b/packages/agent-core/src/services/question/question.ts
@@ -239,7 +239,7 @@ export function toAgentCoreResponse(
       }
     }
   }
-  const out: InProcessQuestionResponse = { answers: flattened };
+  const out: InProcessQuestionResponse = { answers: flattened, note: resp.note };
   if (resp.method !== undefined) {
     // SCHEMAS §6.2 protocol allows 'click' as a method; agent-core's in-process
     // `QuestionAnswerMethod` is `'enter' | 'space' | 'number_key'` (NO 'click').

--- a/packages/agent-core/src/tools/builtin/collaboration/ask-user.ts
+++ b/packages/agent-core/src/tools/builtin/collaboration/ask-user.ts
@@ -210,7 +210,7 @@ export class AskUserQuestionTool implements BuiltinTool<AskUserQuestionInput> {
         this.agent.telemetry.track('question_dismissed', {
           trace_id: traceId,
         });
-        return dismissedQuestionResult();
+        return dismissedQuestionResult(normalized?.note);
       }
 
       const properties: Record<string, TelemetryPropertyValue> = {
@@ -221,7 +221,7 @@ export class AskUserQuestionTool implements BuiltinTool<AskUserQuestionInput> {
       this.agent.telemetry.track('question_answered', properties);
       return {
         isError: false,
-        output: JSON.stringify({ answers: normalized.answers }),
+        output: JSON.stringify({ answers: normalized.answers, note: normalized.note }),
       };
     } catch (error) {
       if (isAbortError(error) || signal.aborted) throw error;
@@ -289,12 +289,12 @@ export class AskUserQuestionTool implements BuiltinTool<AskUserQuestionInput> {
   }
 }
 
-function dismissedQuestionResult(): ExecutableToolResult {
+function dismissedQuestionResult(note = QUESTION_DISMISSED_MESSAGE): ExecutableToolResult {
   return {
     isError: false,
     output: JSON.stringify({
       answers: {},
-      note: QUESTION_DISMISSED_MESSAGE,
+      note,
     }),
   };
 }
@@ -314,12 +314,17 @@ function questionDescription(questions: AskUserQuestionInput['questions']): stri
 
 function normalizeQuestionResult(
   result: QuestionResult,
-): { readonly answers: QuestionAnswers; readonly method?: QuestionAnswerMethod | undefined } | null {
+): {
+  readonly answers: QuestionAnswers;
+  readonly method?: QuestionAnswerMethod | undefined;
+  readonly note?: string | undefined;
+} | null {
   if (result === null) return null;
   if (isQuestionResponse(result)) {
     return {
       answers: result.answers,
       method: result.method,
+      note: result.note,
     };
   }
   return { answers: result };

--- a/packages/agent-core/test/services/question-adapter.test.ts
+++ b/packages/agent-core/test/services/question-adapter.test.ts
@@ -248,10 +248,12 @@ describe('question-adapter · toAgentCoreResponse · id → text translation', (
           q_1: { kind: 'skipped' },
         },
         method: 'click',
+        note: 'User skipped one question.',
       },
       request,
     );
     expect(inProc.answers).toEqual({ 'Which animal?': 'Hippopotamus' });
+    expect(inProc.note).toBe('User skipped one question.');
     // method 'click' is NOT in agent-core's in-process method union — dropped.
     expect((inProc as { method?: string }).method).toBeUndefined();
   });

--- a/packages/agent-core/test/tools/ask-user.test.ts
+++ b/packages/agent-core/test/tools/ask-user.test.ts
@@ -285,6 +285,29 @@ describe('AskUserQuestionTool', () => {
     });
   });
 
+  it('preserves a skipped-question note in the tool output', async () => {
+    const { tool } = makeTool({
+      requestQuestion: async () => ({
+        answers: { 'Which database?': 'SQLite' },
+        note: 'User skipped 1 question: "Which cache?".',
+      }),
+    });
+
+    const result = await executeTool(tool, {
+      turnId: '0',
+      toolCallId: 'call_question',
+      args: input(),
+      signal,
+    });
+
+    expect(result.output).toBe(
+      JSON.stringify({
+        answers: { 'Which database?': 'SQLite' },
+        note: 'User skipped 1 question: "Which cache?".',
+      }),
+    );
+  });
+
   it('starts a background question task and stores the eventual answer in task output', async () => {
     vi.stubEnv('KIMI_CODE_EXPERIMENTAL_FLAG', '1');
 

--- a/packages/kap-server/src/routes/questions.ts
+++ b/packages/kap-server/src/routes/questions.ts
@@ -375,8 +375,13 @@ function toInProcessResponse(
         break;
     }
   }
-  const out: { answers: QuestionAnswers; method?: 'enter' | 'space' | 'number_key' } = {
+  const out: {
+    answers: QuestionAnswers;
+    method?: 'enter' | 'space' | 'number_key';
+    note?: string;
+  } = {
     answers: flattened,
+    note: resp.note,
   };
   if (resp.method !== undefined && resp.method !== 'click') {
     // Protocol allows 'click'; the in-process method does not — drop it to

--- a/packages/kap-server/test/questions.test.ts
+++ b/packages/kap-server/test/questions.test.ts
@@ -289,9 +289,13 @@ describe('server-v2 /api/v1/sessions/{sid}/questions', () => {
         q_0: { kind: 'skipped' },
         q_1: { kind: 'skipped' },
       },
+      note: 'User skipped both questions.',
     });
 
-    await expect(resultPromise).resolves.toEqual({ answers: {} });
+    await expect(resultPromise).resolves.toEqual({
+      answers: {},
+      note: 'User skipped both questions.',
+    });
   });
 
   it('dismisses a pending question', async () => {


### PR DESCRIPTION
## Related Issue

No linked issue; this is a directly reproducible bug in the ACP question bridge.

## Problem

When `AskUserQuestion` supplied two or more questions through an ACP client, the adapter intentionally forwarded only the first question. It also treated `multi_select` questions as single-select. The omitted questions were absent from the tool result without a note, so the model could not distinguish a user skip from a question that was never presented.

## What changed

- Ask every question sequentially through `session/request_permission`, with progress in the tool-call title.
- Implement multi-select as repeatable option toggles followed by an explicit `Done` action.
- Continue after an explicit `Skip`, stop after cancellation, and preserve separate notes for user-skipped questions and questions left unanswered by a client failure.
- Propagate optional question notes through both agent engines and the KAP question adapter.
- Add a CLI patch changeset and regression coverage for multi-question ordering, multi-select toggling, skip continuation, mixed skip/client-failure reporting, and note propagation.

## Verification

- Affected focused tests: 6 files / 84 tests passed; the final ACP follow-up suite passed 2 files / 20 tests.
- Type checks passed for `@moonshot-ai/acp-adapter`, `@moonshot-ai/agent-core`, `@moonshot-ai/agent-core-v2`, and `@moonshot-ai/kap-server`.
- Full ACP adapter suite passed: 36 files / 329 tests.
- Full repository lint completed with 0 errors (existing warnings remain).
- A source-built `kimi acp` probe displayed both questions, collected two multi-select choices, and returned both answers. A second probe skipped the later question and returned an explicit skipped-question note.
- A full `agent-core` run completed with 3,994 passing tests; 9 unchanged image-compression tests exceeded their 5-second timeout in this environment.

The existing tool reference already documents support for 1–4 questions and `multi_select`, so this restores the ACP implementation to that contract and needs no user-doc wording change. The local `gen-docs` workflow could not run its changelog sync because its required `docs/scripts/sync-changelog.mjs` file is absent from this checkout.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.
