### PR TITLE
chore: drop the changelog entry for the experimental secondary-model API

### DIFF
--- a/.changeset/config-api-secondary-model.md
+++ b/.changeset/config-api-secondary-model.md
@@ -1,5 +1,0 @@
----
-"@moonshot-ai/kimi-code": patch
----
-
-Allow updating the subagent secondary model through the configuration API.


### PR DESCRIPTION
## Related Issue

Follow-up to #2228.

## Problem

PR #2228 shipped with a changeset that would add a user-facing changelog entry ("Allow updating the subagent secondary model through the configuration API"). The secondary-model feature itself is still experimental — gated behind `KIMI_CODE_EXPERIMENTAL_SECONDARY_MODEL` and ignored by the interactive TUI — so the change should not be announced in the release notes yet.

## What changed

- Deleted `.changeset/config-api-secondary-model.md`. The config API support itself stays merged; a changelog entry can be re-added when the secondary-model feature actually ships (e.g. alongside its GA announcement).

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works. (N/A — changeset removal only, no behavior change.)
- [x] Ran `gen-changesets` skill, or this PR needs no changeset. (No changeset — this PR removes one.)
- [x] Ran `gen-docs` skill, or this PR needs no doc update. (No doc update needed.)
