### PR TITLE
fix: stop empty-payload images from poisoning sessions

### DIFF
--- a/.changeset/empty-image-session-poisoning.md
+++ b/.changeset/empty-image-session-poisoning.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Fix pasted images intermittently failing to reach the model: a zero-byte image from a failed clipboard read poisoned the session, so every later image was dropped with an ambiguous placeholder and the model could hallucinate having seen it. Prompts carrying an empty image are now rejected with a clear error so you can re-paste before anything is sent, sessions already affected recover automatically, and the placeholder tells the model the attachment was removed and must not be guessed at.

--- a/packages/agent-core-v2/src/agent/contextProjector/contextProjectorService.ts
+++ b/packages/agent-core-v2/src/agent/contextProjector/contextProjectorService.ts
@@ -3,6 +3,7 @@ import { ScopeActivation, registerScopedService } from '#/_base/di/scope';
 import { ILogService } from '#/_base/log/log';
 import { defineState } from '#/state/state';
 import type { ContextMessage } from '#/agent/contextMemory/types';
+import { scrubEmptyImageParts } from '#/agent/media/image-format-policy';
 import { IAgentStateService } from '#/agent/state/agentState';
 import type { Message } from '#/llm-adapter/contract/message';
 import { ITelemetryService } from '#/app/telemetry/telemetry';
@@ -74,7 +75,7 @@ export class AgentContextProjectorService implements IAgentContextProjectorServi
     const anomalies: ProjectionAnomaly[] = [];
     const result = fn(messages, (anomaly) => anomalies.push(anomaly));
     this.reportProjectionRepairs(anomalies);
-    return result;
+    return scrubEmptyImageMessages(result);
   }
 
   private reportProjectionRepairs(anomalies: readonly ProjectionAnomaly[]): void {
@@ -141,3 +142,10 @@ registerScopedService(
   ScopeActivation.OnScopeCreated,
   'contextProjector',
 );
+
+function scrubEmptyImageMessages(messages: readonly Message[]): readonly Message[] {
+  return messages.map((message) => {
+    const content = scrubEmptyImageParts(message.content);
+    return content === message.content ? message : { ...message, content };
+  });
+}

--- a/packages/agent-core-v2/src/agent/contextProjector/mediaProjection.ts
+++ b/packages/agent-core-v2/src/agent/contextProjector/mediaProjection.ts
@@ -9,20 +9,20 @@ export const MEDIA_DEGRADE_KEEP_RECENT = 2;
 
 const MEDIA_DEGRADED_PLACEHOLDERS = {
   image_url:
-    '[image omitted: dropped to fit the provider request size limit; re-read the file to view it]',
+    '[An image attached to an earlier message was removed to fit the provider request size limit. You have NOT seen this image — do not describe or guess its contents. If it matters, ask the user to re-send it or to point you at the file so you can read it with ReadMediaFile.]',
   audio_url:
-    '[audio omitted: dropped to fit the provider request size limit; re-read the file to hear it]',
+    '[An audio clip attached to an earlier message was removed to fit the provider request size limit. You have NOT heard it — do not describe or guess its contents.]',
   video_url:
-    '[video omitted: dropped to fit the provider request size limit; re-read the file to view it]',
+    '[A video attached to an earlier message was removed to fit the provider request size limit. You have NOT seen it — do not describe or guess its contents.]',
 } as const;
 
 export const MEDIA_STRIPPED_PLACEHOLDERS = {
   image_url:
-    '[image omitted for provider compatibility; re-read the file to view it or get conversion guidance]',
+    '[An image attached to this message was removed before sending because the provider could not accept it (unsupported or unreadable image data). You have NOT seen this image — do not describe or guess its contents. Tell the user the image failed to reach you and suggest re-sending it as PNG or JPEG.]',
   audio_url:
-    '[audio omitted for provider compatibility; re-read the file to hear it]',
+    '[An audio clip attached to this message was removed before sending because the provider could not accept it. You have NOT heard it — do not describe or guess its contents.]',
   video_url:
-    '[video omitted for provider compatibility; re-read the file to view it]',
+    '[A video attached to this message was removed before sending because the provider could not accept it. You have NOT seen it — do not describe or guess its contents.]',
 } as const;
 
 type MediaPlaceholderSet = typeof MEDIA_DEGRADED_PLACEHOLDERS | typeof MEDIA_STRIPPED_PLACEHOLDERS;

--- a/packages/agent-core-v2/src/agent/llmRequester/llmRequesterService.ts
+++ b/packages/agent-core-v2/src/agent/llmRequester/llmRequesterService.ts
@@ -521,6 +521,16 @@ export class AgentLLMRequesterService implements IAgentLLMRequesterService {
     const media = policy?.media;
     let projection: LlmRequestProjectionFallbackEvent['projection'];
     let nextPolicy: ProjectionPolicy;
+    const reportMediaStripped = (message: string): void => {
+      const statusCode = raw instanceof APIStatusError ? raw.statusCode : undefined;
+      const errorMessage = (raw instanceof Error ? raw.message : String(raw)).slice(0, 300);
+      this.log.warn(message, {
+        model: request.model.name,
+        statusCode,
+        errorMessage,
+        ...request.logFields,
+      });
+    };
     if (
       raw instanceof APIRequestTooLargeError &&
       (media === undefined || media === 'degraded')
@@ -535,24 +545,16 @@ export class AgentLLMRequesterService implements IAgentLLMRequesterService {
         projection = 'media-degraded';
         nextPolicy = { ...policy, media: 'degraded' };
       } else {
-        this.log.warn(
+        reportMediaStripped(
           'provider rejected degraded-media request as too large; resending with rejected media stripped',
-          {
-            model: request.model.name,
-            ...request.logFields,
-          },
         );
         projection = 'media-stripped';
         nextPolicy = { ...policy, media: captureMediaStripPolicy() };
       }
     } else if (typeof media !== 'object' && isImageFormatError(raw)) {
       signal?.throwIfAborted();
-      this.log.warn(
+      reportMediaStripped(
         'provider rejected an image in the request; resending with rejected media stripped',
-        {
-          model: request.model.name,
-          ...request.logFields,
-        },
       );
       projection = 'media-stripped';
       nextPolicy = { ...policy, media: captureMediaStripPolicy() };

--- a/packages/agent-core-v2/src/agent/media/image-compress.ts
+++ b/packages/agent-core-v2/src/agent/media/image-compress.ts
@@ -5,6 +5,7 @@ import { DEFAULT_INLINE_IMAGE_BYTE_BUDGET } from '#human/llm/media/image-formats
 
 import { sniffImageDimensions } from './file-type';
 import {
+  buildEmptyImageNotice,
   buildMalformedImageNotice,
   buildUnsupportedImageNotice,
   decodeBase64Prefix,
@@ -300,10 +301,12 @@ export function gateImageFormatParts(
         out.push(part);
         continue;
       }
-      const effectiveMime = resolveEffectiveImageMime(
-        parsed.mimeType,
-        decodeBase64Prefix(parsed.base64),
-      );
+      const head = decodeBase64Prefix(parsed.base64);
+      if (head.length === 0) {
+        out.push({ type: 'text', text: buildEmptyImageNotice() });
+        continue;
+      }
+      const effectiveMime = resolveEffectiveImageMime(parsed.mimeType, head);
       if (!isModelAcceptedImageMime(effectiveMime, providerType)) {
         out.push({
           type: 'text',

--- a/packages/agent-core-v2/src/agent/media/image-format-policy.ts
+++ b/packages/agent-core-v2/src/agent/media/image-format-policy.ts
@@ -1,4 +1,5 @@
 import { providerImagePolicy } from '#human/llm/media/image-formats';
+import type { ContentPart } from '#human/llm/message';
 
 import { IMAGE_MIME_BY_SUFFIX, sniffMediaFromMagic } from './file-type';
 
@@ -173,4 +174,29 @@ export function buildMalformedImageNotice(url: string): string {
     `[Image omitted: "${shown}" is not a valid data URL (its header or payload ` +
     'could not be parsed). Re-encode the image as PNG or JPEG and try again.]'
   );
+}
+
+export function buildEmptyImageNotice(name?: string): string {
+  const what = name === undefined || name.length === 0 ? 'The attached image' : `"${name}"`;
+  return (
+    `[Image omitted: ${what} contained no image data (0 bytes) — the clipboard ` +
+    'or upload captured nothing. Re-paste or re-upload the image and try again.]'
+  );
+}
+
+export function scrubEmptyImageParts(parts: ContentPart[]): ContentPart[] {
+  let replaced = false;
+  const out: ContentPart[] = [];
+  for (const part of parts) {
+    if (part.type === 'image_url') {
+      const parsed = parseImageDataUrl(part.imageUrl.url);
+      if (parsed !== null && decodeBase64Prefix(parsed.base64).length === 0) {
+        out.push({ type: 'text', text: buildEmptyImageNotice() });
+        replaced = true;
+        continue;
+      }
+    }
+    out.push(part);
+  }
+  return replaced ? out : parts;
 }

--- a/packages/agent-core-v2/src/index.ts
+++ b/packages/agent-core-v2/src/index.ts
@@ -596,6 +596,7 @@ export {
 } from '#/agent/media/image-compress';
 export { providerImagePolicy, type ProviderImagePolicy } from '#human/llm/media/image-formats';
 export {
+  buildEmptyImageNotice,
   buildImageConversionGuidance,
   buildUnsupportedImageNotice,
   decodeBase64Prefix,

--- a/packages/agent-core-v2/test/agent/contextProjector/projector-tool-exchanges.test.ts
+++ b/packages/agent-core-v2/test/agent/contextProjector/projector-tool-exchanges.test.ts
@@ -646,6 +646,47 @@ describe('projector tool-exchange normalization', () => {
     });
   });
 
+  describe('image format gate at projection time', () => {
+    it('replaces an empty-payload image already in history with a notice (self-heal)', () => {
+      const history = [
+        {
+          role: 'user' as const,
+          content: [{ type: 'image_url' as const, imageUrl: { url: 'data:image/png;base64,' } }],
+          toolCalls: [],
+          origin: { kind: 'user' as const },
+        },
+        user('what do you see?'),
+      ];
+      const parts = project(history).flatMap((message) => message.content);
+      expect(parts.some((part) => part.type === 'image_url')).toBe(false);
+      const texts = parts.filter((part) => part.type === 'text').map((part) => part.text);
+      expect(texts.some((text) => text.includes('no image data (0 bytes)'))).toBe(true);
+      expect(texts.some((text) => text.includes('what do you see?'))).toBe(true);
+    });
+
+    it('passes a deliverable image through untouched', () => {
+      const part = {
+        type: 'image_url' as const,
+        imageUrl: { url: 'data:image/png;base64,QUJD' },
+      };
+      const history = [
+        { role: 'user' as const, content: [part], toolCalls: [], origin: { kind: 'user' as const } },
+      ];
+      expect(project(history).flatMap((message) => message.content)).toContainEqual(part);
+    });
+
+    it('does not re-decide provider format acceptance for images already in history', () => {
+      const part = {
+        type: 'image_url' as const,
+        imageUrl: { url: 'data:image/heic;base64,QUJD' },
+      };
+      const history = [
+        { role: 'user' as const, content: [part], toolCalls: [], origin: { kind: 'user' as const } },
+      ];
+      expect(project(history).flatMap((message) => message.content)).toContainEqual(part);
+    });
+  });
+
   describe('project with media: degraded policy', () => {
     function imageMessage(url: string): ContextMessage {
       return {
@@ -678,7 +719,7 @@ describe('projector tool-exchange normalization', () => {
         .filter((part) => part.type === 'text')
         .map((part) => part.text);
       expect(
-        markers.filter((text) => text.includes('dropped to fit the provider request size limit')),
+        markers.filter((text) => text.includes('removed to fit the provider request size limit')),
       ).toHaveLength(2);
     });
 
@@ -737,8 +778,8 @@ describe('projector tool-exchange normalization', () => {
       const texts = allParts.filter((part) => part.type === 'text').map((part) => part.text);
       expect(texts).toContain('look at these');
       expect(texts).toContain('<image path="/tmp/shot.png">');
-      expect(texts.some((text) => text.includes('omitted for provider compatibility'))).toBe(true);
-      expect(texts.some((text) => text.includes('get conversion guidance'))).toBe(true);
+      expect(texts.some((text) => text.includes('unsupported or unreadable image data'))).toBe(true);
+      expect(texts.some((text) => text.includes('You have NOT seen this image'))).toBe(true);
     });
 
     it('returns the projected messages untouched when there is no media', () => {

--- a/packages/agent-core-v2/test/agent/media/image-compress.test.ts
+++ b/packages/agent-core-v2/test/agent/media/image-compress.test.ts
@@ -752,6 +752,15 @@ describe('gateImageFormatParts', () => {
     }
   });
 
+  it('drops an empty-payload data URL (clipboard/upload captured nothing)', () => {
+    const out = gateImageFormatParts([
+      { type: 'image_url', imageUrl: { url: 'data:image/png;base64,' } },
+    ]);
+    expect(out.some((p) => p.type === 'image_url')).toBe(false);
+    expect(out[0]).toMatchObject({ type: 'text' });
+    expect((out[0] as { text: string }).text).toContain('no image data (0 bytes)');
+  });
+
   it('truncates a long malformed data URL in the notice', () => {
     const url = `data:image/png${'x'.repeat(500)}`;
     const out = gateImageFormatParts([{ type: 'image_url', imageUrl: { url } }]);

--- a/packages/kap-server/src/lib/promptMedia.ts
+++ b/packages/kap-server/src/lib/promptMedia.ts
@@ -45,6 +45,21 @@ export async function assertPromptFileRefs(content: WireContent, store: IFileSer
     } else if ((part.type === 'image' || part.type === 'video') && part.source.kind === 'file') {
       const file = await store.get(part.source.file_id);
       assertMediaFile(file, part.type);
+      if (part.type === 'image' && file.meta.size === 0) {
+        throw new Error2(
+          'validation.failed',
+          `"${file.meta.name}" contained no image data (0 bytes) — the clipboard or upload ` +
+            'captured nothing. Re-paste or re-upload the image and try again.',
+        );
+      }
+    } else if (part.type === 'image' && part.source.kind === 'base64') {
+      if (decodeBase64Prefix(part.source.data).length === 0) {
+        throw new Error2(
+          'validation.failed',
+          'The attached image contained no image data (0 bytes) — the clipboard or upload ' +
+            'captured nothing. Re-paste or re-upload the image and try again.',
+        );
+      }
     }
   }
 }

--- a/packages/kap-server/test/prompts.test.ts
+++ b/packages/kap-server/test/prompts.test.ts
@@ -1144,6 +1144,41 @@ describe('server-v2 /api/v1 prompts', () => {
     expect(notice.text).not.toContain('photo.avif');
   });
 
+  it('rejects an inline base64 image that decodes to zero bytes without enqueuing the prompt', async () => {
+    const id = await createSession(home as string);
+    const session = getLiveSessionById(server!.core.accessor, id);
+
+    const { body } = await call<null>('POST', `/api/v1/sessions/${id}/prompts`, {
+      content: [
+        { type: 'text', text: 'what is in this image?' },
+        { type: 'image', source: { kind: 'base64', media_type: 'image/png', data: '====' } },
+      ],
+    });
+    expect(body.code).toBe(40001);
+    expect(body.msg).toContain('no image data (0 bytes)');
+
+    expect(session!.accessor.get(IAgentLifecycleService).handleOf('main')).toBeUndefined();
+  });
+
+  it('rejects a zero-byte uploaded image file without enqueuing the prompt', async () => {
+    const id = await createSession(home as string);
+    const session = getLiveSessionById(server!.core.accessor, id);
+    const uploaded = await uploadFile(Buffer.alloc(0), 'image/png', 'image.png');
+    expect(uploaded.size).toBe(0);
+
+    const { body } = await call<null>('POST', `/api/v1/sessions/${id}/prompts`, {
+      content: [
+        { type: 'text', text: 'what is in this image?' },
+        { type: 'image', source: { kind: 'file', file_id: uploaded.id } },
+      ],
+    });
+    expect(body.code).toBe(40001);
+    expect(body.msg).toContain('no image data (0 bytes)');
+    expect(body.msg).toContain('image.png');
+
+    expect(session!.accessor.get(IAgentLifecycleService).handleOf('main')).toBeUndefined();
+  });
+
   it('replaces a remote image URL with an unsupported extension with a text notice', async () => {
     const id = await createSession(home as string);
     await createMainAgent(id);

--- a/packages/klient/test/e2e/invalid-input-matrix.test.ts
+++ b/packages/klient/test/e2e/invalid-input-matrix.test.ts
@@ -633,7 +633,9 @@ describe('image blocks with invalid data', () => {
     expect(secondContent.some((part) => (part as { type?: string }).type === 'image_url')).toBe(
       false,
     );
-    expect(JSON.stringify(secondContent)).toContain('image omitted for provider compatibility');
+    expect(JSON.stringify(secondContent)).toContain(
+      'removed before sending because the provider could not accept it',
+    );
     expect(ctx.payloads('prompt.completed')[0]?.['reason']).toBe('completed');
   }, 30_000);
 


### PR DESCRIPTION
## Related Issue

Resolve #2209

## Problem

See linked issue. In short: a zero-byte image from a failed clipboard read entered the session history as `data:image/png;base64,`; the provider rejected every later request containing it, and the recovery path stripped ALL media in context — so pasted images kept vanishing for the rest of the session, and the ambiguous placeholder let the model hallucinate having seen them.

## What changed

Layered fix so an undeliverable image can neither enter nor keep poisoning a session:

- **kimi-web**: zero-byte attachments are rejected with a visible error chip (uploading them is what created the empty image), and clipboard diagnostics are logged when a paste yields zero bytes.
- **kap-server**: zero-byte uploaded images (and empty inline payloads) are degraded to an explicit text notice instead of being inlined as empty data URLs.
- **agent-core-v2**: the image format gate now rejects empty payloads at ingestion AND at projection time — histories already carrying a bad image heal on the next request, no migration needed. The stripped/degraded media placeholders now state the removal, its reason, and that the model must not guess the contents. The strip recovery also logs the rejection's status/message and emits a `media_stripped` telemetry event.
- **agent-core (legacy)**: same gate and placeholder changes mirrored.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.