### PR TITLE
feat(tui): show session token usage in the footer

### DIFF
--- a/.changeset/footer-session-token-usage.md
+++ b/.changeset/footer-session-token-usage.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Show cumulative session token usage next to the context indicator in the footer, with a live `+~N` estimate ticking while the model streams. It appears automatically after the first model reply.

--- a/apps/kimi-code/src/tui/components/chrome/footer.ts
+++ b/apps/kimi-code/src/tui/components/chrome/footer.ts
@@ -3,7 +3,7 @@
  *
  * Layout:
  *   Line 1: [yolo] [plan] <model> <cwd>  <git-badge>  <shortcut hints>
- *   Line 2: context: N% (tokens/max)
+ *   Line 2: context: N% (tokens/max) · used: Nk[+~Nk]
  */
 
 import type { Component } from '@moonshot-ai/pi-tui';
@@ -172,6 +172,25 @@ function formatContextStatus(usage: number, tokens?: number, maxTokens?: number)
   return `context: ${String(usagePercentFromRatio(usage))}%`;
 }
 
+/**
+ * Footer suffix with the session's cumulative token consumption, appended
+ * right after the context readout. While the model streams, a live estimate
+ * of the in-flight output appears as a `+~N` suffix (or `~N` before the
+ * first official report). Hidden entirely when both are zero/undefined so a
+ * fresh session's footer stays clean.
+ */
+function formatSessionUsageSuffix(
+  tokensUsed: number | undefined,
+  streamingEstimate: number | undefined,
+): string {
+  const hasBase = tokensUsed !== undefined && tokensUsed > 0;
+  const hasLive = streamingEstimate !== undefined && streamingEstimate > 0;
+  if (!hasBase && !hasLive) return '';
+  if (!hasBase) return ` · used: ~${formatTokenCount(streamingEstimate ?? 0)}`;
+  const base = ` · used: ${formatTokenCount(tokensUsed)}`;
+  return hasLive ? `${base}+~${formatTokenCount(streamingEstimate)}` : base;
+}
+
 export function formatFooterGitBadge(status: GitStatus, colors: ColorPalette): string {
   const base = chalk.hex(colors.textDim)(formatGitBadgeBase(status));
   if (status.pullRequest === null) return base;
@@ -332,29 +351,27 @@ export class FooterComponent implements Component {
       line1 = truncateToWidth(leftLine, width, '…');
     }
 
-    // ── Line 2: transient hint (bottom-left) + context (right) ──
-    const contextText = formatContextStatus(
-      state.contextUsage,
-      state.contextTokens,
-      state.maxContextTokens,
-    );
-    const contextWidth = visibleWidth(contextText);
+    // ── Line 2: transient hint (bottom-left) + context + session usage (right) ──
+    const statusText =
+      formatContextStatus(state.contextUsage, state.contextTokens, state.maxContextTokens) +
+      formatSessionUsageSuffix(state.sessionTokensUsed, state.streamingTokensEstimated);
+    const statusWidth = visibleWidth(statusText);
     let line2: string;
     if (this.transientHint) {
-      const maxHintWidth = Math.max(0, width - contextWidth - 1);
+      const maxHintWidth = Math.max(0, width - statusWidth - 1);
       const shownHint =
         visibleWidth(this.transientHint) <= maxHintWidth
           ? this.transientHint
           : truncateToWidth(this.transientHint, maxHintWidth, '…');
       const hintWidth = visibleWidth(shownHint);
-      const pad = Math.max(0, width - hintWidth - contextWidth);
+      const pad = Math.max(0, width - hintWidth - statusWidth);
       line2 =
         chalk.hex(colors.warning).bold(shownHint) +
         ' '.repeat(pad) +
-        chalk.hex(colors.text)(contextText);
+        chalk.hex(colors.text)(statusText);
     } else {
-      const leftPad = Math.max(0, width - contextWidth);
-      line2 = ' '.repeat(leftPad) + chalk.hex(colors.text)(contextText);
+      const leftPad = Math.max(0, width - statusWidth);
+      line2 = ' '.repeat(leftPad) + chalk.hex(colors.text)(statusText);
     }
 
     return [truncateToWidth(line1, width), truncateToWidth(line2, width)];

--- a/apps/kimi-code/src/tui/controllers/session-event-handler.ts
+++ b/apps/kimi-code/src/tui/controllers/session-event-handler.ts
@@ -71,6 +71,7 @@ import { currentTheme } from '#/tui/theme';
 import type { ColorToken } from '#/tui/theme';
 import { errorReportHintLine } from '../constant/feedback';
 import { formatStepDebugTiming } from '#/utils/usage/debug-timing';
+import { estimateStreamTokens, totalTokensConsumed } from '#/utils/usage/usage-format';
 import { nextTranscriptId } from '../utils/transcript-id';
 import type { BtwPanelController } from './btw-panel';
 import { isPluginMcpToolName, PluginUpdateNotifier } from './plugin-update-notifier';
@@ -162,6 +163,12 @@ export class SessionEventHandler {
   private queuedGoalPromotionPending = false;
   private queuedGoalPromotionInFlight = false;
   private queuedGoalPromotionTimer: ReturnType<typeof setTimeout> | undefined;
+  /**
+   * Live output-token estimate for the in-flight stream, accumulated from
+   * deltas. Mirrored into `AppState.streamingTokensEstimated`; reset on turn
+   * begin, on session reset, and when an official usage record lands.
+   */
+  private streamingTokensEstimated = 0;
 
   resetRuntimeState(): void {
     this.backgroundTasks.clear();
@@ -181,6 +188,19 @@ export class SessionEventHandler {
     this.queuedGoalPromotionInFlight = false;
     this.clearQueuedGoalPromotionTimer();
     this.stopAllMcpServerStatusSpinners();
+    this.streamingTokensEstimated = 0;
+  }
+
+  /**
+   * Accumulate streamed text into the live token estimate and mirror it into
+   * AppState so the footer's `+~N` suffix ticks while the model generates.
+   */
+  private bumpStreamingEstimate(text: string | undefined): void {
+    if (text === undefined || text.length === 0) return;
+    this.streamingTokensEstimated += estimateStreamTokens(text);
+    if (this.streamingTokensEstimated !== this.host.state.appState.streamingTokensEstimated) {
+      this.host.setAppState({ streamingTokensEstimated: this.streamingTokensEstimated });
+    }
   }
 
   clearAgentSwarmProgress(): void {
@@ -313,6 +333,7 @@ export class SessionEventHandler {
 
   private handleTurnBegin(event: TurnStartedEvent): void {
     this.currentTurnHasAssistantText = false;
+    this.streamingTokensEstimated = 0;
     if (event.origin?.kind === 'plugin_command') {
       this.pluginCommandTurns.set(String(event.turnId), event.origin.pluginId);
     }
@@ -327,6 +348,7 @@ export class SessionEventHandler {
     this.host.setAppState({
       streamingPhase: 'waiting',
       streamingStartTime: Date.now(),
+      streamingTokensEstimated: 0,
     });
   }
 
@@ -481,6 +503,7 @@ export class SessionEventHandler {
 
   private handleThinkingDelta(event: ThinkingDeltaEvent): void {
     const { state, streamingUI } = this.host;
+    this.bumpStreamingEstimate(event.delta);
     // Encrypted / redacted reasoning (e.g. Kimi over the Anthropic-compatible
     // protocol) streams thinking deltas whose visible text is empty — only an
     // opaque signature rides along. Models also occasionally stream whitespace-
@@ -500,6 +523,7 @@ export class SessionEventHandler {
 
   private handleAssistantDelta(event: AssistantDeltaEvent): void {
     const { state, streamingUI } = this.host;
+    this.bumpStreamingEstimate(event.delta);
     if (streamingUI.hasThinkingDraft()) {
       streamingUI.flushThinkingToTranscript('idle');
     }
@@ -571,6 +595,9 @@ export class SessionEventHandler {
 
   private handleToolCallDelta(event: ToolCallDeltaEvent): void {
     if (event.toolCallId.length === 0) return;
+    // Tool-call arguments are model output too; count them in the live
+    // estimate. `name` is skipped — it may repeat on later deltas.
+    this.bumpStreamingEstimate(event.argumentsPart);
     const { state, streamingUI } = this.host;
     streamingUI.accumulateToolCallDelta(event.toolCallId, event.name, event.argumentsPart);
     const preview = streamingUI.getStreamingToolCallPreview(event.toolCallId);
@@ -658,6 +685,13 @@ export class SessionEventHandler {
     }
     if (event.model !== undefined) patch.model = event.model;
     if (event.thinkingEffort !== undefined) patch.thinkingEffort = event.thinkingEffort;
+    if (event.usage?.total !== undefined) {
+      patch.sessionTokensUsed = totalTokensConsumed(event.usage.total);
+      // The official record folds in everything streamed so far; restart the
+      // live estimate from zero so the footer flips from "+~N" back to exact.
+      this.streamingTokensEstimated = 0;
+      patch.streamingTokensEstimated = 0;
+    }
     if (Object.keys(patch).length > 0) this.host.setAppState(patch);
     if (event.swarmMode === false) {
       this.host.state.swarmModeEntry = undefined;

--- a/apps/kimi-code/src/tui/controllers/session-event-handler.ts
+++ b/apps/kimi-code/src/tui/controllers/session-event-handler.ts
@@ -71,7 +71,11 @@ import { currentTheme } from '#/tui/theme';
 import type { ColorToken } from '#/tui/theme';
 import { errorReportHintLine } from '../constant/feedback';
 import { formatStepDebugTiming } from '#/utils/usage/debug-timing';
-import { estimateStreamTokens, totalTokensConsumed } from '#/utils/usage/usage-format';
+import {
+  countStreamChars,
+  estimateStreamTokensFromCounts,
+  totalTokensConsumed,
+} from '#/utils/usage/usage-format';
 import { nextTranscriptId } from '../utils/transcript-id';
 import type { BtwPanelController } from './btw-panel';
 import { isPluginMcpToolName, PluginUpdateNotifier } from './plugin-update-notifier';
@@ -164,11 +168,14 @@ export class SessionEventHandler {
   private queuedGoalPromotionInFlight = false;
   private queuedGoalPromotionTimer: ReturnType<typeof setTimeout> | undefined;
   /**
-   * Live output-token estimate for the in-flight stream, accumulated from
-   * deltas. Mirrored into `AppState.streamingTokensEstimated`; reset on turn
-   * begin, on session reset, and when an official usage record lands.
+   * Live output-token estimate inputs for the in-flight stream: cumulative
+   * character counts accumulated from deltas. The estimate is derived from
+   * the totals (never rounded per delta) and mirrored into
+   * `AppState.streamingTokensEstimated`; reset on turn begin, on session
+   * reset, on turn end, and when an official usage record lands.
    */
-  private streamingTokensEstimated = 0;
+  private streamingAsciiChars = 0;
+  private streamingNonAsciiChars = 0;
 
   resetRuntimeState(): void {
     this.backgroundTasks.clear();
@@ -188,18 +195,32 @@ export class SessionEventHandler {
     this.queuedGoalPromotionInFlight = false;
     this.clearQueuedGoalPromotionTimer();
     this.stopAllMcpServerStatusSpinners();
-    this.streamingTokensEstimated = 0;
+    this.resetStreamingEstimate();
+  }
+
+  /** Zero the cumulative character counts behind the live token estimate. */
+  private resetStreamingEstimate(): void {
+    this.streamingAsciiChars = 0;
+    this.streamingNonAsciiChars = 0;
   }
 
   /**
    * Accumulate streamed text into the live token estimate and mirror it into
    * AppState so the footer's `+~N` suffix ticks while the model generates.
+   * Character counts accumulate across deltas and rounding happens only on
+   * the totals — chunk-size-independent.
    */
   private bumpStreamingEstimate(text: string | undefined): void {
     if (text === undefined || text.length === 0) return;
-    this.streamingTokensEstimated += estimateStreamTokens(text);
-    if (this.streamingTokensEstimated !== this.host.state.appState.streamingTokensEstimated) {
-      this.host.setAppState({ streamingTokensEstimated: this.streamingTokensEstimated });
+    const { ascii, nonAscii } = countStreamChars(text);
+    this.streamingAsciiChars += ascii;
+    this.streamingNonAsciiChars += nonAscii;
+    const estimate = estimateStreamTokensFromCounts(
+      this.streamingAsciiChars,
+      this.streamingNonAsciiChars,
+    );
+    if (estimate !== this.host.state.appState.streamingTokensEstimated) {
+      this.host.setAppState({ streamingTokensEstimated: estimate });
     }
   }
 
@@ -333,7 +354,7 @@ export class SessionEventHandler {
 
   private handleTurnBegin(event: TurnStartedEvent): void {
     this.currentTurnHasAssistantText = false;
-    this.streamingTokensEstimated = 0;
+    this.resetStreamingEstimate();
     if (event.origin?.kind === 'plugin_command') {
       this.pluginCommandTurns.set(String(event.turnId), event.origin.pluginId);
     }
@@ -372,6 +393,13 @@ export class SessionEventHandler {
 
   private handleTurnEnd(event: TurnEndedEvent, sendQueued: (item: QueuedMessage) => void): void {
     this.host.streamingUI.flushNow();
+    // A cancelled/failed turn never records usage for the in-flight step, so
+    // the usage-gated reset never runs; always clear the live estimate here
+    // or a stale "+~N" would linger as though output were still streaming.
+    this.resetStreamingEstimate();
+    if ((this.host.state.appState.streamingTokensEstimated ?? 0) > 0) {
+      this.host.setAppState({ streamingTokensEstimated: 0 });
+    }
     if (event.reason === 'cancelled') {
       this.markActiveAgentSwarmsCancelled();
     }
@@ -689,7 +717,7 @@ export class SessionEventHandler {
       patch.sessionTokensUsed = totalTokensConsumed(event.usage.total);
       // The official record folds in everything streamed so far; restart the
       // live estimate from zero so the footer flips from "+~N" back to exact.
-      this.streamingTokensEstimated = 0;
+      this.resetStreamingEstimate();
       patch.streamingTokensEstimated = 0;
     }
     if (Object.keys(patch).length > 0) this.host.setAppState(patch);

--- a/apps/kimi-code/src/tui/kimi-tui.ts
+++ b/apps/kimi-code/src/tui/kimi-tui.ts
@@ -31,6 +31,7 @@ import { getInputHistoryFile } from '#/utils/paths';
 import { detectFdPath, ensureFdPath } from '#/utils/process/fd-detect';
 import { quoteShellArg } from '#/utils/shell-quote';
 import { restoreTerminalModes } from '#/utils/terminal-restore';
+import { totalTokensConsumed } from '#/utils/usage/usage-format';
 
 import { BannerProvider } from './banner/banner-provider';
 import { readBannerDisplayState, writeBannerDisplayState } from './banner/state';
@@ -1578,6 +1579,9 @@ export class KimiTUI {
       contextTokens: status.contextTokens,
       maxContextTokens: status.maxContextTokens,
       contextUsage: status.contextUsage,
+      sessionTokensUsed:
+        status.usage?.total !== undefined ? totalTokensConsumed(status.usage.total) : undefined,
+      streamingTokensEstimated: 0,
       sessionTitle: session.summary?.title ?? null,
       goal: goalResult.goal,
     });

--- a/apps/kimi-code/src/tui/types.ts
+++ b/apps/kimi-code/src/tui/types.ts
@@ -41,6 +41,19 @@ export interface AppState {
   contextUsage: number;
   contextTokens: number;
   maxContextTokens: number;
+  /**
+   * Cumulative tokens consumed by this session (all input classes + output),
+   * summed from the agent's usage records. Undefined until the first usage
+   * report arrives, so fresh sessions show no footer counter yet.
+   */
+  sessionTokensUsed?: number;
+  /**
+   * Estimated output tokens of the in-flight model stream, accumulated from
+   * assistant/thinking/tool-argument deltas since the last official usage
+   * report. Rendered as a `+~N` suffix on the footer's usage counter and
+   * reset to 0 on turn begin and whenever a usage record lands.
+   */
+  streamingTokensEstimated?: number;
   isCompacting: boolean;
   isReplaying: boolean;
   streamingPhase: 'idle' | 'waiting' | 'thinking' | 'composing' | 'shell';

--- a/apps/kimi-code/src/utils/usage/usage-format.ts
+++ b/apps/kimi-code/src/utils/usage/usage-format.ts
@@ -17,23 +17,33 @@ export function totalTokensConsumed(usage: TokenUsage): number {
 }
 
 /**
- * Rough token estimate for streamed text — the same character heuristic
- * agent-core uses (`packages/agent-core/src/utils/tokens.ts`): ASCII at
- * ~4 chars per token, everything else (CJK etc.) at ~1 char per token.
+ * Count ASCII vs non-ASCII characters in a chunk of streamed text. Callers
+ * accumulate these counts across deltas and derive the live token estimate
+ * from the cumulative totals — rounding per delta instead would overcount
+ * up to 4x when providers emit small ASCII chunks.
+ */
+export function countStreamChars(text: string): { ascii: number; nonAscii: number } {
+  let ascii = 0;
+  let nonAscii = 0;
+  for (const char of text) {
+    if (char.codePointAt(0)! <= 127) {
+      ascii++;
+    } else {
+      nonAscii++;
+    }
+  }
+  return { ascii, nonAscii };
+}
+
+/**
+ * Rough token estimate from cumulative streamed character counts — the same
+ * character heuristic agent-core uses (`packages/agent-core/src/utils/tokens.ts`):
+ * ASCII at ~4 chars per token, everything else (CJK etc.) at ~1 char per token.
  * Only used for the live in-flight estimate in the footer; the official
  * usage record always supersedes it when the step completes.
  */
-export function estimateStreamTokens(text: string): number {
-  let asciiCount = 0;
-  let nonAsciiCount = 0;
-  for (const char of text) {
-    if (char.codePointAt(0)! <= 127) {
-      asciiCount++;
-    } else {
-      nonAsciiCount++;
-    }
-  }
-  return Math.ceil(asciiCount / 4) + nonAsciiCount;
+export function estimateStreamTokensFromCounts(asciiChars: number, nonAsciiChars: number): number {
+  return Math.ceil(asciiChars / 4) + nonAsciiChars;
 }
 
 /**

--- a/apps/kimi-code/src/utils/usage/usage-format.ts
+++ b/apps/kimi-code/src/utils/usage/usage-format.ts
@@ -5,6 +5,37 @@
  * command itself chalks the colour afterwards.
  */
 
+import type { TokenUsage } from '@moonshot-ai/kimi-code-sdk';
+
+/**
+ * Grand total tokens consumed: every input class (uncached, cache-read,
+ * cache-creation) plus output. Matches `grandTotal` in `@moonshot-ai/kosong`,
+ * re-implemented here so the TUI app does not need a direct kosong dependency.
+ */
+export function totalTokensConsumed(usage: TokenUsage): number {
+  return usage.inputOther + usage.inputCacheRead + usage.inputCacheCreation + usage.output;
+}
+
+/**
+ * Rough token estimate for streamed text — the same character heuristic
+ * agent-core uses (`packages/agent-core/src/utils/tokens.ts`): ASCII at
+ * ~4 chars per token, everything else (CJK etc.) at ~1 char per token.
+ * Only used for the live in-flight estimate in the footer; the official
+ * usage record always supersedes it when the step completes.
+ */
+export function estimateStreamTokens(text: string): number {
+  let asciiCount = 0;
+  let nonAsciiCount = 0;
+  for (const char of text) {
+    if (char.codePointAt(0)! <= 127) {
+      asciiCount++;
+    } else {
+      nonAsciiCount++;
+    }
+  }
+  return Math.ceil(asciiCount / 4) + nonAsciiCount;
+}
+
 /**
  * Format a token count in 1024-based units: context sizes are powers of
  * two, so 262144 reads as "256k", not "262.1k". k values at or above

--- a/apps/kimi-code/test/tui/components/panels/footer-context.test.ts
+++ b/apps/kimi-code/test/tui/components/panels/footer-context.test.ts
@@ -130,6 +130,72 @@ describe('FooterComponent — context NaN resilience', () => {
     expect(strip(line2 ?? '')).toContain('context: 0%');
   });
 
+  it('hides the session-usage suffix until the first usage report', () => {
+    const fc = new FooterComponent(baseState({ sessionTokensUsed: undefined }));
+    const out = strip(fc.render(200).join(''));
+    expect(out).not.toContain('used:');
+  });
+
+  it('hides the session-usage suffix for zero consumption', () => {
+    const fc = new FooterComponent(baseState({ sessionTokensUsed: 0 }));
+    const out = strip(fc.render(200).join(''));
+    expect(out).not.toContain('used:');
+  });
+
+  it('renders session usage next to the context readout in 1024 units', () => {
+    const fc = new FooterComponent(
+      baseState({
+        contextUsage: 0.427,
+        contextTokens: 430_080,
+        maxContextTokens: 1_048_576,
+        sessionTokensUsed: 46_285,
+      }),
+    );
+    const out = strip(fc.render(200).join(''));
+    expect(out).toMatch(/context: 42% \(420k\/1M\) · used: 45\.2k/);
+  });
+
+  it('renders multi-megabyte session usage with the M suffix', () => {
+    const fc = new FooterComponent(baseState({ sessionTokensUsed: 2_500_000 }));
+    const out = strip(fc.render(200).join(''));
+    expect(out).toContain('used: 2.4M');
+  });
+
+  it('keeps the transient hint alongside context and session usage', () => {
+    const footer = new FooterComponent(baseState({ sessionTokensUsed: 1024 }));
+
+    footer.setTransientHint('Press Ctrl-C again to exit');
+
+    const [, line2] = footer.render(120);
+    expect(strip(line2 ?? '')).toContain('Press Ctrl-C again to exit');
+    expect(strip(line2 ?? '')).toContain('context: 0%');
+    expect(strip(line2 ?? '')).toContain('used: 1k');
+  });
+
+  it('appends the live streaming estimate as a +~N suffix while generating', () => {
+    const fc = new FooterComponent(
+      baseState({ sessionTokensUsed: 46_285, streamingTokensEstimated: 358 }),
+    );
+    const out = strip(fc.render(200).join(''));
+    expect(out).toContain('used: 45.2k+~358');
+  });
+
+  it('shows a tilde-only estimate before the first official usage report', () => {
+    const fc = new FooterComponent(baseState({ streamingTokensEstimated: 512 }));
+    const out = strip(fc.render(200).join(''));
+    expect(out).toContain('used: ~512');
+    expect(out).not.toContain('+~');
+  });
+
+  it('drops the +~N suffix once the live estimate resets to zero', () => {
+    const fc = new FooterComponent(
+      baseState({ sessionTokensUsed: 1024, streamingTokensEstimated: 0 }),
+    );
+    const out = strip(fc.render(200).join(''));
+    expect(out).toContain('used: 1k');
+    expect(out).not.toContain('+~');
+  });
+
   it('highlights the pull request badge separately from git status text', () => {
     const previousLevel = chalk.level;
     chalk.level = 3;

--- a/apps/kimi-code/test/utils/usage/usage-format.test.ts
+++ b/apps/kimi-code/test/utils/usage/usage-format.test.ts
@@ -1,6 +1,8 @@
 import { describe, it, expect } from 'vitest';
 
 import {
+  countStreamChars,
+  estimateStreamTokensFromCounts,
   formatTokenCount,
   renderProgressBar,
   ratioSeverity,
@@ -132,5 +134,31 @@ describe('ratioSeverity', () => {
   it('red at or above 0.85', () => {
     expect(ratioSeverity(0.85)).toBe('danger');
     expect(ratioSeverity(1)).toBe('danger');
+  });
+});
+
+describe('countStreamChars + estimateStreamTokensFromCounts', () => {
+  it('splits ASCII and non-ASCII characters', () => {
+    expect(countStreamChars('hello世界')).toEqual({ ascii: 5, nonAscii: 2 });
+    expect(countStreamChars('')).toEqual({ ascii: 0, nonAscii: 0 });
+  });
+
+  it('estimates ASCII at ~4 chars/token and non-ASCII at ~1 char/token', () => {
+    expect(estimateStreamTokensFromCounts(8, 3)).toBe(5);
+    expect(estimateStreamTokensFromCounts(1, 0)).toBe(1);
+    expect(estimateStreamTokensFromCounts(0, 0)).toBe(0);
+  });
+
+  it('cumulative counts stay chunk-size-independent (no per-delta rounding drift)', () => {
+    // Five one-character ASCII deltas: estimated per delta this would round
+    // up to 5 tokens; the cumulative estimate rounds once on the totals.
+    let ascii = 0;
+    let nonAscii = 0;
+    for (const chunk of ['h', 'e', 'l', 'l', 'o']) {
+      const c = countStreamChars(chunk);
+      ascii += c.ascii;
+      nonAscii += c.nonAscii;
+    }
+    expect(estimateStreamTokensFromCounts(ascii, nonAscii)).toBe(2);
   });
 });


### PR DESCRIPTION
## Related Issue

Resolve #2257

## Problem

See linked issue.

## What changed

The footer now renders the session's cumulative token usage next to the context indicator: `context: 3% (21.8k/1M) · used: 45.2k`.

- The exact counter comes from data that already flows to clients but was never rendered: `usage.total` on `agent.status.updated` events (summed across all input classes + output), plus the `getStatus()` snapshot so resumed sessions show it immediately.
- While the model streams, a live estimate of the in-flight output ticks as a `+~N` suffix, accumulated from assistant/thinking/tool-argument deltas using the same character heuristic the engine already uses for transient context estimates (ASCII ~4 chars/token, CJK ~1 char/token). Providers only report usage when a response completes, so the suffix is explicitly marked as an estimate and folds back to zero when each step's official usage record lands.
- The counter stays hidden until the first usage report (or when both values are zero), so a fresh session's footer stays clean. The transient-hint line's width accounting was updated to cover the longer right-side text.

Tests: new cases in the footer's context test file cover hidden-before-first-report, zero suppression, 1024-unit formatting, the `+~N` and `~N` forms, and coexistence with the transient hint. The footer suite and the TUI message-flow suite pass, and typecheck is clean.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.
