### PR TITLE
fix(web): show real media size in the preview panel instead of 0 B

### DIFF
--- a/.changeset/media-preview-size.md
+++ b/.changeset/media-preview-size.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+web: show the real image size in the media preview panel instead of "0 B" — recover it from the data URL or the fetched blob when the media metadata carries no byte count, and use a generic "Image"/"Video" label instead of "ReadMediaFile image" for uploaded attachments

--- a/apps/kimi-web/src/composables/useFilePreview.ts
+++ b/apps/kimi-web/src/composables/useFilePreview.ts
@@ -1,0 +1,279 @@
+// apps/kimi-web/src/composables/useFilePreview.ts
+// File preview: download / path normalization / request-sequence guard. Claims
+// the 'file' slot of the shared right-side detail layer.
+
+import { computed, ref, watch, type Ref } from 'vue';
+import { useI18n } from 'vue-i18n';
+import { getKimiWebApi } from '../api';
+import type { FileData, FilePreviewRequest, ToolMedia } from '../types';
+import type { useKimiWebClient } from './useKimiWebClient';
+
+type KimiWebClient = ReturnType<typeof useKimiWebClient>;
+
+/** Which occupant currently owns the shared right-side detail layer. */
+export type DetailTarget = 'file' | 'diff' | 'thinking' | 'compaction' | 'agent' | 'toolDiff' | 'btw';
+
+/** Whether a url can feed a native <video>/<img> src. A provider reference like
+ *  `ms://…` has no local bytes and only yields a broken player, so it's treated
+ *  as non-loadable and falls through to the no-preview card. */
+export function isPlayableMediaUrl(url: string): boolean {
+  return /^(?:https?:|blob:|data:)/i.test(url);
+}
+
+export interface UseFilePreviewOptions {
+  client: KimiWebClient;
+  detailTarget: Ref<DetailTarget | null>;
+}
+
+export function useFilePreview({ client, detailTarget }: UseFilePreviewOptions) {
+  const { t } = useI18n();
+
+  const previewTarget = ref<FilePreviewRequest | null>(null);
+  const previewFile = ref<FileData | null>(null);
+  const previewLoading = ref(false);
+  const previewError = ref<string | null>(null);
+  // Normalized workspace-relative path of the currently-open preview. Used for
+  // the download URL so it matches the server's relative-path contract even when
+  // the user opened the preview from an absolute path in the chat.
+  const previewNormalizedPath = ref<string | null>(null);
+  // Incremented on every openFilePreview call so a slower earlier request can't
+  // overwrite the result of a later one (request-sequence guard).
+  let previewRequestSeq = 0;
+  // Authenticated blob URL backing the current media preview, when the media
+  // came from the file store (a bare getFileUrl 401s in <img> under daemon
+  // auth). Revoked when the preview is replaced or closed.
+  let mediaObjectUrl: string | null = null;
+  function revokeMediaObjectUrl(): void {
+    if (mediaObjectUrl !== null) {
+      URL.revokeObjectURL(mediaObjectUrl);
+      mediaObjectUrl = null;
+    }
+  }
+
+  const previewDownloadUrl = computed(() => {
+    const path = previewNormalizedPath.value;
+    return path ? client.getFileDownloadUrl(path) : null;
+  });
+  const previewExternalActions = computed(() => previewTarget.value !== null);
+
+  function trimTrailingSlash(path: string): string {
+    return path.length > 1 ? path.replace(/\/+$/, '') : path;
+  }
+
+  function normalizeRelativePath(path: string): string {
+    const out: string[] = [];
+    for (const part of path.split(/[\\/]+/)) {
+      if (!part || part === '.') continue;
+      if (part === '..') {
+        out.pop();
+        continue;
+      }
+      out.push(part);
+    }
+    return out.join('/');
+  }
+
+  function normalizePreviewPath(inputPath: string): { path: string } | { error: string } {
+    const raw = inputPath.trim();
+    if (!raw) return { error: t('filePreview.errors.emptyPath') };
+    if (/^[a-z][a-z0-9+.-]*:\/\//i.test(raw)) {
+      return { error: t('filePreview.errors.unsupportedPath') };
+    }
+    if (raw.startsWith('~')) {
+      return { error: t('filePreview.errors.outsideWorkspace') };
+    }
+
+    const cwd = trimTrailingSlash(client.status.value.cwd);
+    if (raw.startsWith('/')) {
+      if (!cwd || (raw !== cwd && !raw.startsWith(`${cwd}/`))) {
+        return { error: t('filePreview.errors.outsideWorkspace') };
+      }
+      const relative = raw === cwd ? '' : raw.slice(cwd.length + 1);
+      if (relative.split(/[\\/]+/).includes('..')) {
+        return { error: t('filePreview.errors.outsideWorkspace') };
+      }
+      const path = normalizeRelativePath(relative);
+      return path ? { path } : { error: t('filePreview.errors.isDirectory') };
+    }
+
+    if (raw.split(/[\\/]+/).includes('..')) {
+      return { error: t('filePreview.errors.outsideWorkspace') };
+    }
+
+    const path = normalizeRelativePath(raw);
+    return path ? { path } : { error: t('filePreview.errors.emptyPath') };
+  }
+
+  async function openFilePreview(target: FilePreviewRequest): Promise<void> {
+    // Clicking the link for the already-open file toggles the panel closed.
+    const current = previewTarget.value;
+    if (
+      detailTarget.value === 'file' &&
+      current &&
+      current.path === target.path &&
+      current.line === target.line
+    ) {
+      closeFilePreview();
+      return;
+    }
+    const requestSeq = ++previewRequestSeq;
+    revokeMediaObjectUrl();
+    detailTarget.value = 'file';
+    previewFile.value = null;
+    previewError.value = null;
+    previewLoading.value = true;
+    previewTarget.value = target;
+    previewNormalizedPath.value = null;
+
+    const normalized = normalizePreviewPath(target.path);
+    if ('error' in normalized) {
+      previewLoading.value = false;
+      previewError.value = normalized.error;
+      return;
+    }
+    previewNormalizedPath.value = normalized.path;
+
+    try {
+      const result = await client.readFileContent(normalized.path);
+      // A newer openFilePreview started while this one was in flight — discard
+      // the stale result so the right-side panel shows the latest file.
+      if (requestSeq !== previewRequestSeq) return;
+      if (result) {
+        previewFile.value = { ...result, path: result.path || normalized.path };
+      } else {
+        // readFileContent swallows daemon failures into null — show the error
+        // state instead of a misleading 0-byte "empty file" (the cause is
+        // already console.warn'd in readFileContent).
+        previewError.value = t('filePreview.errors.loadFailed');
+      }
+    } catch (err) {
+      if (requestSeq !== previewRequestSeq) return;
+      previewError.value = err instanceof Error ? err.message : t('filePreview.errors.loadFailed');
+    } finally {
+      if (requestSeq === previewRequestSeq) {
+        previewLoading.value = false;
+      }
+    }
+  }
+
+  function mimeFromDataUrl(url: string): string | undefined {
+    const match = /^data:([^;,]+)/i.exec(url);
+    return match?.[1];
+  }
+
+  // Decoded byte length of a base64 data: URL — media parts arriving as data
+  // URLs (user uploads rehydrated from the blob store, ReadMediaFile results)
+  // carry no explicit size, but the preview header should still show one.
+  function bytesFromDataUrl(url: string): number | undefined {
+    const match = /^data:[^;,]+;base64,(.*)$/is.exec(url);
+    const b64 = match?.[1];
+    if (b64 === undefined) return undefined;
+    const padding = b64.endsWith('==') ? 2 : b64.endsWith('=') ? 1 : 0;
+    return Math.floor((b64.length * 3) / 4) - padding;
+  }
+
+  function openMediaPreview(media: ToolMedia): void {
+    if (media.kind !== 'image' && media.kind !== 'video') return;
+    const seq = ++previewRequestSeq;
+    revokeMediaObjectUrl();
+    detailTarget.value = 'file';
+    previewTarget.value = null;
+    previewNormalizedPath.value = null;
+    previewError.value = null;
+    const isVideo = media.kind === 'video';
+    const base = {
+      path: media.path ?? (isVideo ? t('composer.attachmentVideo') : t('composer.attachmentImage')),
+      content: '',
+      encoding: 'utf-8' as const,
+      mime: media.mimeType ?? mimeFromDataUrl(media.url) ?? (isVideo ? 'video/*' : 'image/*'),
+      isBinary: true,
+      size: media.bytes ?? bytesFromDataUrl(media.url) ?? 0,
+    };
+    // The raw URL 401s under daemon auth (browsers load media without the
+    // Bearer token), so fetch the bytes with auth and preview a blob URL.
+    if (media.fileId) {
+      previewLoading.value = true;
+      previewFile.value = base;
+      void getKimiWebApi().getFileBlob(media.fileId).then((blob) => {
+        if (seq !== previewRequestSeq) return;
+        // The user may have switched to another detail panel while this was in
+        // flight — don't create (and leak) a blob URL for a hidden panel.
+        if (detailTarget.value !== 'file' || !previewFile.value) {
+          previewLoading.value = false;
+          return;
+        }
+        mediaObjectUrl = URL.createObjectURL(blob);
+        // media.bytes was unknown (e.g. a pasted upload) — the fetched blob is
+        // the first place the real size shows up.
+        previewFile.value = {
+          ...previewFile.value,
+          sourceUrl: mediaObjectUrl,
+          size: previewFile.value.size > 0 ? previewFile.value.size : blob.size,
+        };
+        previewLoading.value = false;
+      }).catch(() => {
+        if (seq !== previewRequestSeq) return;
+        // Fall back to the raw URL so the user sees an honest broken state.
+        if (previewFile.value) previewFile.value = { ...previewFile.value, sourceUrl: media.url };
+        previewLoading.value = false;
+      });
+    } else {
+      previewLoading.value = false;
+      // A non-loadable url (e.g. a provider `ms://` reference with no local
+      // bytes) can't feed a <video>/<img> src — leave sourceUrl unset so the
+      // preview shows the no-preview card instead of a broken player.
+      previewFile.value = isPlayableMediaUrl(media.url) ? { ...base, sourceUrl: media.url } : base;
+    }
+  }
+
+  function resetFilePreview(): void {
+    // Invalidate any in-flight authenticated media fetch so it doesn't create a
+    // blob URL after the panel is gone (which would leak until the next preview).
+    previewRequestSeq += 1;
+    previewTarget.value = null;
+    previewNormalizedPath.value = null;
+    previewFile.value = null;
+    previewError.value = null;
+    previewLoading.value = false;
+    revokeMediaObjectUrl();
+  }
+
+  function closeFilePreview(): void {
+    resetFilePreview();
+    if (detailTarget.value === 'file') detailTarget.value = null;
+  }
+
+  // Revoke/close the preview when the user switches to another detail panel
+  // (useDetailPanel only flips detailTarget and does not call closeFilePreview),
+  // so an in-flight or already-shown blob URL isn't held while the file panel
+  // is hidden.
+  watch(detailTarget, (target, oldTarget) => {
+    if (oldTarget === 'file' && target !== 'file') resetFilePreview();
+  });
+
+  function openPreviewInEditor(): void {
+    const path = previewFile.value?.path ?? previewTarget.value?.path;
+    if (!path) return;
+    void client.openWorkspaceFile(path, previewTarget.value?.line);
+  }
+
+  function revealPreviewFile(): void {
+    const path = previewFile.value?.path ?? previewTarget.value?.path;
+    if (!path) return;
+    void client.revealWorkspaceFile(path);
+  }
+
+  return {
+    previewTarget,
+    previewFile,
+    previewLoading,
+    previewError,
+    previewDownloadUrl,
+    previewExternalActions,
+    openFilePreview,
+    openMediaPreview,
+    closeFilePreview,
+    openPreviewInEditor,
+    revealPreviewFile,
+  };
+}

--- a/apps/kimi-web/src/composables/useFilePreview.ts
+++ b/apps/kimi-web/src/composables/useFilePreview.ts
@@ -164,8 +164,11 @@ export function useFilePreview({ client, detailTarget }: UseFilePreviewOptions) 
   // Decoded byte length of a base64 data: URL — media parts arriving as data
   // URLs (user uploads rehydrated from the blob store, ReadMediaFile results)
   // carry no explicit size, but the preview header should still show one.
+  // The mediatype may carry parameters (`data:image/svg+xml;charset=utf-8;
+  // base64,…`) — per RFC 2397 `;base64` is the last token before the comma,
+  // so match the metadata loosely and anchor on that marker.
   function bytesFromDataUrl(url: string): number | undefined {
-    const match = /^data:[^;,]+;base64,(.*)$/is.exec(url);
+    const match = /^data:[^,]*;base64,(.*)$/is.exec(url);
     const b64 = match?.[1];
     if (b64 === undefined) return undefined;
     const padding = b64.endsWith('==') ? 2 : b64.endsWith('=') ? 1 : 0;

--- a/apps/kimi-web/test/media-preview-size.test.ts
+++ b/apps/kimi-web/test/media-preview-size.test.ts
@@ -41,6 +41,15 @@ describe('openMediaPreview size', () => {
     expect(previewFile.value?.mime).toBe('image/png');
   });
 
+  it('handles data: URLs with mediatype parameters (RFC 2397)', () => {
+    const { previewFile, openMediaPreview } = setup();
+    const b64 = Buffer.alloc(1024).toString('base64');
+    const media: ToolMedia = { kind: 'image', url: `data:image/svg+xml;charset=utf-8;base64,${b64}` };
+    openMediaPreview(media);
+    expect(previewFile.value?.size).toBe(1024);
+    expect(previewFile.value?.mime).toBe('image/svg+xml');
+  });
+
   it('prefers explicit media.bytes over the data: URL estimate', () => {
     const { previewFile, openMediaPreview } = setup();
     const media: ToolMedia = { kind: 'image', url: dataUrl(1024), bytes: 42 };

--- a/apps/kimi-web/test/media-preview-size.test.ts
+++ b/apps/kimi-web/test/media-preview-size.test.ts
@@ -1,0 +1,77 @@
+// apps/kimi-web/test/media-preview-size.test.ts
+// The media preview header shows `size` — for user-uploaded media the
+// ToolMedia carries no bytes, so openMediaPreview must recover the size from
+// the data: URL (rehydrated uploads) or from the fetched blob (file-store
+// media), instead of falling back to a misleading "0 B".
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { ref } from 'vue';
+import { useFilePreview } from '../src/composables/useFilePreview';
+import type { ToolMedia } from '../src/types';
+
+vi.mock('vue-i18n', () => ({ useI18n: () => ({ t: (key: string) => key }) }));
+
+const getFileBlob = vi.fn();
+vi.mock('../src/api', () => ({ getKimiWebApi: () => ({ getFileBlob }) }));
+
+function setup() {
+  return useFilePreview({
+    client: {} as never,
+    detailTarget: ref(null),
+  });
+}
+
+function dataUrl(bytes: number): string {
+  return `data:image/png;base64,${Buffer.alloc(bytes).toString('base64')}`;
+}
+
+describe('openMediaPreview size', () => {
+  beforeEach(() => {
+    getFileBlob.mockReset();
+    (globalThis.URL as unknown as { createObjectURL: unknown }).createObjectURL = vi
+      .fn()
+      .mockReturnValue('blob:mock-url');
+    (globalThis.URL as unknown as { revokeObjectURL: unknown }).revokeObjectURL = vi.fn();
+  });
+
+  it('recovers the size from a data: URL when media.bytes is missing', () => {
+    const { previewFile, openMediaPreview } = setup();
+    const media: ToolMedia = { kind: 'image', url: dataUrl(1024) };
+    openMediaPreview(media);
+    expect(previewFile.value?.size).toBe(1024);
+    expect(previewFile.value?.mime).toBe('image/png');
+  });
+
+  it('prefers explicit media.bytes over the data: URL estimate', () => {
+    const { previewFile, openMediaPreview } = setup();
+    const media: ToolMedia = { kind: 'image', url: dataUrl(1024), bytes: 42 };
+    openMediaPreview(media);
+    expect(previewFile.value?.size).toBe(42);
+  });
+
+  it('fills the size from the fetched blob for file-store media', async () => {
+    getFileBlob.mockResolvedValue(new Blob([Buffer.alloc(500)]));
+    const { previewFile, openMediaPreview } = setup();
+    const media: ToolMedia = { kind: 'image', url: 'https://daemon/files/f_1', fileId: 'f_1' };
+    openMediaPreview(media);
+    expect(previewFile.value?.size).toBe(0); // unknown until the blob lands
+    await vi.waitFor(() => expect(previewFile.value?.size).toBe(500));
+    expect(previewFile.value?.sourceUrl).toBe('blob:mock-url');
+  });
+
+  it('keeps a known media.bytes instead of overwriting it with the blob size', async () => {
+    getFileBlob.mockResolvedValue(new Blob([Buffer.alloc(500)]));
+    const { previewFile, openMediaPreview } = setup();
+    const media: ToolMedia = { kind: 'image', url: 'https://daemon/files/f_1', fileId: 'f_1', bytes: 42 };
+    openMediaPreview(media);
+    await vi.waitFor(() => expect(previewFile.value?.sourceUrl).toBe('blob:mock-url'));
+    expect(previewFile.value?.size).toBe(42);
+  });
+
+  it('falls back to a generic localized label when the media has no path', () => {
+    const { previewFile, openMediaPreview } = setup();
+    openMediaPreview({ kind: 'image', url: dataUrl(1) });
+    expect(previewFile.value?.path).toBe('composer.attachmentImage');
+    openMediaPreview({ kind: 'video', url: dataUrl(1) });
+    expect(previewFile.value?.path).toBe('composer.attachmentVideo');
+  });
+});


### PR DESCRIPTION
## Related Issue

Resolve #2260

## Problem

See linked issue. Clicking an uploaded image attachment in the web chat opens a preview panel that always shows **0 B** (and a misleading "ReadMediaFile image" label for unnamed uploads), because the `ToolMedia` built from a `TurnAttachment` carries no byte count and rehydrated blob-store images arrive as bare `data:` URLs.

## What changed

In `openMediaPreview` (`apps/kimi-web/src/composables/useFilePreview.ts`):

- recover the exact byte size from a `data:` URL (base64 decode length) when `media.bytes` is absent;
- for file-store media (`fileId`), fill the size from `blob.size` once the authenticated fetch lands;
- explicit `media.bytes` always wins;
- fall back to the generic localized Image/Video labels instead of "ReadMediaFile image" when the media has no path.

Adds `apps/kimi-web/test/media-preview-size.test.ts` (5 tests covering the data-URL path, the blob path, precedence of explicit bytes, and the label fallback). Full kimi-web suite (658 tests) and `vue-tsc` typecheck pass.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.