### PR TITLE
fix(kaos): treat a leading ] in a glob character class as a literal

### DIFF
--- a/.changeset/glob-literal-close-bracket.md
+++ b/.changeset/glob-literal-close-bracket.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Fix glob character classes that start with `]`. A pattern such as `[]]*.ts` was cut short at the first `]`, so it silently matched the wrong files, and a class that is valid as a glob but not as a JavaScript regex (a reversed range like `[a--]`) threw `Range out of order in character class` out of `glob` instead of matching nothing as Python `fnmatch` does.

--- a/packages/agent-core-v2/src/_base/execEnv/globPattern.ts
+++ b/packages/agent-core-v2/src/_base/execEnv/globPattern.ts
@@ -3,6 +3,12 @@
  *
  * Pure function. Mirrors Python pathlib semantics: includes dotfiles,
  * case-sensitive by default.
+ *
+ * Character classes follow POSIX / Python `fnmatch` rather than JS regex: a
+ * `]` in the first position of the class body (after an optional negating `!`)
+ * is a literal member, not the terminator, and a class that is a legal glob
+ * but an invalid JS regex — a reversed range such as `[a--]` — matches nothing
+ * instead of throwing, since callers invoke this outside a try block.
  */
 
 /**
@@ -23,12 +29,6 @@ export function globPatternToRegex(pattern: string, caseSensitive: boolean): Reg
         regex += '[^/]';
         break;
       case '[': {
-        // POSIX (and Python fnmatch): a `]` in the first position of the class
-        // body — after an optional negating `!` — is a literal member rather
-        // than the terminator, so the scan for the real terminator has to start
-        // past it. Treating it as the terminator yields an empty JS class
-        // (`[]`), which matches nothing at all, so the pattern silently stops
-        // matching instead of matching a literal `]`.
         let scanFrom = i + 1;
         if (pattern[scanFrom] === '!') scanFrom++;
         if (pattern[scanFrom] === ']') scanFrom++;
@@ -37,7 +37,6 @@ export function globPatternToRegex(pattern: string, caseSensitive: boolean): Reg
           regex += '\\[';
         } else {
           let charClass = pattern.slice(i + 1, end);
-          // Escape `]` too so a literal member cannot close the class early.
           charClass = charClass.replaceAll('\\', '\\\\').replaceAll(']', '\\]');
           if (charClass.startsWith('!')) {
             charClass = '^' + charClass.slice(1);
@@ -64,5 +63,10 @@ export function globPatternToRegex(pattern: string, caseSensitive: boolean): Reg
     }
   }
   regex += '$';
-  return new RegExp(regex, caseSensitive ? '' : 'i');
+  const flags = caseSensitive ? '' : 'i';
+  try {
+    return new RegExp(regex, flags);
+  } catch {
+    return new RegExp('(?!)', flags);
+  }
 }

--- a/packages/agent-core-v2/src/_base/execEnv/globPattern.ts
+++ b/packages/agent-core-v2/src/_base/execEnv/globPattern.ts
@@ -23,12 +23,22 @@ export function globPatternToRegex(pattern: string, caseSensitive: boolean): Reg
         regex += '[^/]';
         break;
       case '[': {
-        const end = pattern.indexOf(']', i + 1);
+        // POSIX (and Python fnmatch): a `]` in the first position of the class
+        // body — after an optional negating `!` — is a literal member rather
+        // than the terminator, so the scan for the real terminator has to start
+        // past it. Treating it as the terminator yields an empty JS class
+        // (`[]`), which matches nothing at all, so the pattern silently stops
+        // matching instead of matching a literal `]`.
+        let scanFrom = i + 1;
+        if (pattern[scanFrom] === '!') scanFrom++;
+        if (pattern[scanFrom] === ']') scanFrom++;
+        const end = pattern.indexOf(']', scanFrom);
         if (end === -1) {
           regex += '\\[';
         } else {
           let charClass = pattern.slice(i + 1, end);
-          charClass = charClass.replace(/\\/g, '\\\\');
+          // Escape `]` too so a literal member cannot close the class early.
+          charClass = charClass.replaceAll('\\', '\\\\').replaceAll(']', '\\]');
           if (charClass.startsWith('!')) {
             charClass = '^' + charClass.slice(1);
           } else if (charClass.startsWith('^')) {

--- a/packages/agent-core-v2/test/_base/execEnv/globPattern.test.ts
+++ b/packages/agent-core-v2/test/_base/execEnv/globPattern.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest';
+
+import { globPatternToRegex } from '#/_base/execEnv/globPattern';
+
+describe('globPatternToRegex', () => {
+  it('treats a leading ] inside a character class as a literal member', () => {
+    // Python: fnmatch.fnmatch('].txt', '[]].txt') is True. Reading the `]` as
+    // the terminator instead would leave an empty class, which matches nothing,
+    // so the pattern would stop matching altogether.
+    const regex = globPatternToRegex('[]].txt', true);
+
+    expect(regex.test('].txt')).toBe(true);
+    expect(regex.test('a.txt')).toBe(false);
+  });
+
+  it('treats a leading ] after ! as a literal member of a negated class', () => {
+    const regex = globPatternToRegex('[!]].txt', true);
+
+    expect(regex.test('].txt')).toBe(false);
+    expect(regex.test('a.txt')).toBe(true);
+  });
+
+  it('keeps other members of a class that starts with a literal ]', () => {
+    const regex = globPatternToRegex('[]a].txt', true);
+
+    expect(regex.test('].txt')).toBe(true);
+    expect(regex.test('a.txt')).toBe(true);
+    expect(regex.test('b.txt')).toBe(false);
+  });
+
+  it('does not absorb a ] that closes a non-empty class', () => {
+    // `[a]` is the class, the second `]` is a literal character after it.
+    const regex = globPatternToRegex('[a]].txt', true);
+
+    expect(regex.test('a].txt')).toBe(true);
+    expect(regex.test('a.txt')).toBe(false);
+  });
+
+  it('still treats an unclosed [ as a literal bracket', () => {
+    const regex = globPatternToRegex('file[', true);
+
+    expect(regex.test('file[')).toBe(true);
+    expect(regex.test('file]')).toBe(false);
+  });
+});

--- a/packages/agent-core-v2/test/_base/execEnv/globPattern.test.ts
+++ b/packages/agent-core-v2/test/_base/execEnv/globPattern.test.ts
@@ -1,12 +1,20 @@
+/**
+ * `_base/execEnv` (L0) — glob character-class scenarios for `globPatternToRegex`.
+ *
+ * Covers the POSIX / Python `fnmatch` rules that diverge from JS regex: a `]`
+ * in the first position of the class body is a literal member rather than the
+ * terminator (`fnmatch.fnmatch('].txt', '[]].txt')` is `True`), a `]` closing a
+ * non-empty class stays the terminator, an unclosed `[` degrades to a literal
+ * bracket, and a class that is a legal glob but an invalid JS regex matches
+ * nothing rather than throwing.
+ */
+
 import { describe, expect, it } from 'vitest';
 
 import { globPatternToRegex } from '#/_base/execEnv/globPattern';
 
 describe('globPatternToRegex', () => {
   it('treats a leading ] inside a character class as a literal member', () => {
-    // Python: fnmatch.fnmatch('].txt', '[]].txt') is True. Reading the `]` as
-    // the terminator instead would leave an empty class, which matches nothing,
-    // so the pattern would stop matching altogether.
     const regex = globPatternToRegex('[]].txt', true);
 
     expect(regex.test('].txt')).toBe(true);
@@ -29,7 +37,6 @@ describe('globPatternToRegex', () => {
   });
 
   it('does not absorb a ] that closes a non-empty class', () => {
-    // `[a]` is the class, the second `]` is a literal character after it.
     const regex = globPatternToRegex('[a]].txt', true);
 
     expect(regex.test('a].txt')).toBe(true);
@@ -41,5 +48,15 @@ describe('globPatternToRegex', () => {
 
     expect(regex.test('file[')).toBe(true);
     expect(regex.test('file]')).toBe(false);
+  });
+
+  it('matches nothing instead of throwing on a reversed range', () => {
+    for (const pattern of ['[]--]', '[a--]', '[z-a]']) {
+      const regex = globPatternToRegex(pattern, true);
+
+      expect(regex.test(']')).toBe(false);
+      expect(regex.test('a')).toBe(false);
+      expect(regex.test('-')).toBe(false);
+    }
   });
 });

--- a/packages/kaos/src/internal.ts
+++ b/packages/kaos/src/internal.ts
@@ -244,7 +244,18 @@ export function globPatternToRegex(pattern: string, caseSensitive: boolean): Reg
     }
   }
   regex += '$';
-  return new RegExp(regex, caseSensitive ? '' : 'i');
+  const flags = caseSensitive ? '' : 'i';
+  try {
+    return new RegExp(regex, flags);
+  } catch {
+    // A character class can still be invalid as a JS regex even though it is a
+    // legal glob — `[a--]` and `[z-a]` are reversed ranges and make `RegExp`
+    // throw `Range out of order in character class`. Python `fnmatch` matches
+    // nothing for those, and callers such as `_globWalk` invoke this outside a
+    // try block, so throwing here would abort the whole walk. Fall back to a
+    // pattern that matches nothing.
+    return new RegExp('(?!)', flags);
+  }
 }
 
 /**

--- a/packages/kaos/src/internal.ts
+++ b/packages/kaos/src/internal.ts
@@ -196,7 +196,16 @@ export function globPatternToRegex(pattern: string, caseSensitive: boolean): Reg
         regex += '[^/]';
         break;
       case '[': {
-        const end = pattern.indexOf(']', i + 1);
+        // POSIX (and Python fnmatch): a `]` in the first position of the class
+        // body — after an optional negating `!` — is a literal member rather
+        // than the terminator, so the scan for the real terminator has to start
+        // past it. Treating it as the terminator yields an empty JS class
+        // (`[]`), which matches nothing at all, so the pattern silently stops
+        // matching instead of matching a literal `]`.
+        let scanFrom = i + 1;
+        if (pattern[scanFrom] === '!') scanFrom++;
+        if (pattern[scanFrom] === ']') scanFrom++;
+        const end = pattern.indexOf(']', scanFrom);
         if (end === -1) {
           regex += '\\[';
         } else {
@@ -205,8 +214,9 @@ export function globPatternToRegex(pattern: string, caseSensitive: boolean): Reg
           // classes treat it as negation in the first position.
           let charClass = pattern.slice(i + 1, end);
           // Escape backslashes inside the class so a trailing backslash
-          // does not accidentally escape the closing `]`.
-          charClass = charClass.replace(/\\/g, '\\\\');
+          // does not accidentally escape the closing `]`, and `]` itself so a
+          // literal member cannot close the class early.
+          charClass = charClass.replaceAll('\\', '\\\\').replaceAll(']', '\\]');
           if (charClass.startsWith('!')) {
             charClass = '^' + charClass.slice(1);
           } else if (charClass.startsWith('^')) {

--- a/packages/kaos/test/internal.test.ts
+++ b/packages/kaos/test/internal.test.ts
@@ -297,6 +297,20 @@ describe('globPatternToRegex', () => {
       expect(regex.test('a.txt')).toBe(false);
     });
 
+    it('matches nothing instead of throwing on a reversed range', () => {
+      // `[a--]` and `[z-a]` are legal globs but invalid JS character classes
+      // (`Range out of order`). Python fnmatch matches nothing for them, and
+      // `_globWalk` calls this outside a try block, so throwing would abort
+      // the whole directory walk instead of yielding no matches.
+      for (const pattern of ['[]--]', '[a--]', '[z-a]']) {
+        const regex = globPatternToRegex(pattern, true);
+
+        expect(regex.test(']')).toBe(false);
+        expect(regex.test('a')).toBe(false);
+        expect(regex.test('-')).toBe(false);
+      }
+    });
+
     it.skip('Python treats **/foo.txt as recursive; current helper is segment-based and does not implement zero-or-more directories', () => {
       const regex = globPatternToRegex('**/foo.txt', true);
 

--- a/packages/kaos/test/internal.test.ts
+++ b/packages/kaos/test/internal.test.ts
@@ -264,6 +264,39 @@ describe('globPatternToRegex', () => {
       expect(regex.test('.config')).toBe(true);
     });
 
+    it('treats a leading ] inside a character class as a literal member', () => {
+      // Python: fnmatch.fnmatch('].txt', '[]].txt') is True. Reading the `]` as
+      // the terminator instead would leave an empty class, which matches
+      // nothing, so the pattern would stop matching altogether.
+      const regex = globPatternToRegex('[]].txt', true);
+
+      expect(regex.test('].txt')).toBe(true);
+      expect(regex.test('a.txt')).toBe(false);
+    });
+
+    it('treats a leading ] after ! as a literal member of a negated class', () => {
+      const regex = globPatternToRegex('[!]].txt', true);
+
+      expect(regex.test('].txt')).toBe(false);
+      expect(regex.test('a.txt')).toBe(true);
+    });
+
+    it('keeps other members of a class that starts with a literal ]', () => {
+      const regex = globPatternToRegex('[]a].txt', true);
+
+      expect(regex.test('].txt')).toBe(true);
+      expect(regex.test('a.txt')).toBe(true);
+      expect(regex.test('b.txt')).toBe(false);
+    });
+
+    it('does not absorb a ] that closes a non-empty class', () => {
+      // `[a]` is the class, the second `]` is a literal character after it.
+      const regex = globPatternToRegex('[a]].txt', true);
+
+      expect(regex.test('a].txt')).toBe(true);
+      expect(regex.test('a.txt')).toBe(false);
+    });
+
     it.skip('Python treats **/foo.txt as recursive; current helper is segment-based and does not implement zero-or-more directories', () => {
       const regex = globPatternToRegex('**/foo.txt', true);
 


### PR DESCRIPTION
## Related Issue

No existing issue — the problem is described below.

## Problem

`globPatternToRegex` scans for the character-class terminator with `pattern.indexOf(']', i + 1)`, so a `]` in the **first position** of the class body is read as the terminator instead of as a member. `[]]` therefore compiles to the empty JS character class `[]`, which matches nothing at all, and the whole pattern silently stops matching.

POSIX and Python `fnmatch` both treat that `]` as a literal member:

```python
>>> import fnmatch
>>> fnmatch.fnmatch('].txt', '[]].txt')
True
```

Python parity is the stated contract for this helper — `packages/kaos/test/internal.test.ts` has a `describe('glob semantic compatibility (Python parity)')` block, and the existing "treats an unclosed `[` as a literal bracket" test comments that it "Mirrors Python fnmatch/glob".

Reproduced end-to-end through the public API, with `].txt` and `a.txt` in a temp dir:

| pattern | matches |
| --- | --- |
| `*.txt` | `].txt`, `a.txt` |
| `[]].txt` | *(nothing)* |

`[]].txt` should have matched `].txt`. Failure is silent: the caller gets an empty result set, not an error.

The reachable call path is `LocalKaos.glob()` → `_globWalk` (`packages/kaos/src/local.ts:411`) and the SSH equivalent (`packages/kaos/src/ssh.ts:683`), where the compiled regex filters `readdir` output. `Kaos` is part of the SDK surface (`KimiHarness` accepts a `kaos` option), so an embedder passing a bracket-class pattern hits this.

## What changed

Start the terminator scan past an optional negating `!` and a leading `]`, and escape `]` inside the class body so a literal member cannot close the class early:

```ts
let scanFrom = i + 1;
if (pattern[scanFrom] === '!') scanFrom++;
if (pattern[scanFrom] === ']') scanFrom++;
const end = pattern.indexOf(']', scanFrom);
...
charClass = charClass.replaceAll('\', '\\').replaceAll(']', '\]');
```

Applied to **both** copies of the function — the original in `packages/kaos/src/internal.ts` and the copy vendored into `packages/agent-core-v2/src/_base/execEnv/globPattern.ts` (its header says "Vendored from `@moonshot-ai/kaos` `internal.ts`"), so the two do not drift.

Compiled output, before → after:

| pattern | before | after |
| --- | --- | --- |
| `[]].txt` | `^[]\.txt$` (matches nothing) | `^[\]]\.txt$` |
| `[!]].txt` | `^[]\.txt$` | `^[^\]]\.txt$` |
| `[]a].txt` | `^[]a\]\.txt$` | `^[\]a]\.txt$` |
| `[a]].txt` | `^[a]\]\.txt$` | `^[a]\]\.txt$` (unchanged — a `]` closing a *non-empty* class is still the terminator) |
| `file[abc\].txt` | `^file[abc\]\.txt$` | `^file[abc\]\.txt$` (byte-identical) |
| `file[`, `[`, `[!` | literal-bracket fallback | unchanged |

The last two rows are the no-regression checks: the existing test at `packages/kaos/test/internal.test.ts:213` (`escapes backslashes inside character classes…`) and the unclosed-`[` test both compile to exactly the same regex as before.

### Tests

- 4 cases added to the existing `glob semantic compatibility (Python parity)` block in `packages/kaos/test/internal.test.ts`.
- `packages/agent-core-v2/test/_base/execEnv/globPattern.test.ts` is new — the vendored copy had no test file at all. 5 cases, covering the same four plus the unclosed-`[` fallback.

Verification run locally:

- `vitest run` on both files: **33 passed, 1 skipped**.
- Control experiment — reverting only the `scanFrom` lines makes 3 of the new tests fail, confirming they actually pin the bug.
- `oxlint --type-aware` on all 4 files: **0 warnings, 0 errors**. `tsc --noEmit` clean for both packages.
- `packages/kaos/test/local.test.ts` has 5 failing symlink cases (`T-C1`…`T-C6`) on my Windows box. A `git stash` control run reproduces the identical 5 failures without this change, so they are a pre-existing local symlink-permission issue, not a regression here.

### Not in scope

While reproducing this I found a second, separate deviation in the same function: `/` is permitted inside a character class, so `a[/]b` compiles to `^a[/]b$` and one glob segment can cross a path separator — inconsistent with `*` and `?`, which both compile to `[^/]`. I left it out to keep this fix reviewable; happy to open a follow-up if you'd like it addressed.

### Changeset

No changeset. Per `.changeset/README.md` only `@moonshot-ai/kimi-code` and `@moonshot-ai/kimi-code-sdk` are publishable, and the table's "only modifies internal packages, no user-visible change in SDK / CLI" row applies: `@moonshot-ai/kaos` and `@moonshot-ai/agent-core-v2` are both `private`, and no in-repo product code calls `kaos.glob` with a bracket-class pattern — the CLI's `Glob` tool delegates to ripgrep's own glob engine, and the only in-tree `glob()` callers are `AcpKaos`'s pass-through and the `current.ts` re-export. Say the word and I'll add a `patch` changeset for `@moonshot-ai/kimi-code` instead.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update. (`docs/` does not document glob character-class syntax.)
