### PR TITLE
fix(tui): fall back to visible PR URL on terminals without OSC 8 support

### DIFF
--- a/.changeset/warp-pr-badge-fallback.md
+++ b/.changeset/warp-pr-badge-fallback.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Fix the footer pull request badge being unclickable in terminals without OSC 8 hyperlink support (such as Warp) by falling back to a visible markdown-style link.

--- a/apps/kimi-code/src/utils/git/git-status.ts
+++ b/apps/kimi-code/src/utils/git/git-status.ts
@@ -9,6 +9,8 @@
 
 import { execFile, spawnSync } from 'node:child_process';
 
+import { supportsOsc8Hyperlinks } from '#/utils/terminal-hyperlink';
+
 const BRANCH_TTL_MS = 5_000;
 const STATUS_TTL_MS = 15_000;
 const PULL_REQUEST_TTL_MS = 60_000;
@@ -331,7 +333,12 @@ export function formatPullRequestBadge(
   options: FormatGitBadgeOptions = {},
 ): string {
   const prText = `[PR#${String(pullRequest.number)}]`;
-  return options.linkPullRequest ? toTerminalHyperlink(prText, pullRequest.url) : prText;
+  if (!options.linkPullRequest) return prText;
+  // Terminals without OSC 8 support (e.g. Warp) render hyperlinks as inert
+  // text, so print the URL in markdown-link style instead — Warp's own URL
+  // detection makes a visible URL clickable.
+  if (!supportsOsc8Hyperlinks()) return `[PR#${String(pullRequest.number)}](${pullRequest.url})`;
+  return toTerminalHyperlink(prText, pullRequest.url);
 }
 
 export function formatGitBadge(status: GitStatus, options: FormatGitBadgeOptions = {}): string {

--- a/apps/kimi-code/src/utils/terminal-hyperlink.ts
+++ b/apps/kimi-code/src/utils/terminal-hyperlink.ts
@@ -1,3 +1,21 @@
 export function toTerminalHyperlink(text: string, url: string): string {
   return `\u001B]8;;${url}\u0007${text}\u001B]8;;\u0007`;
 }
+
+/**
+ * Terminals known to lack OSC 8 hyperlink support. Warp renders the
+ * sequence as styled-but-inert text (underlined, yet clicks go nowhere),
+ * which is worse than printing the URL outright — its own URL detection
+ * makes a visible URL clickable. Everywhere else OSC 8 either works or
+ * degrades to plain text harmlessly, so this denylist stays short.
+ */
+const OSC8_UNSUPPORTED_TERM_PROGRAMS = new Set(['WarpTerminal']);
+
+/**
+ * Best-effort detection of OSC 8 hyperlink support, driven off well-known
+ * environment variables like the OSC 9 checks in
+ * `#/tui/utils/terminal-notification`.
+ */
+export function supportsOsc8Hyperlinks(env: NodeJS.ProcessEnv = process.env): boolean {
+  return !OSC8_UNSUPPORTED_TERM_PROGRAMS.has(env['TERM_PROGRAM'] ?? '');
+}

--- a/apps/kimi-code/test/utils/git/git-status.test.ts
+++ b/apps/kimi-code/test/utils/git/git-status.test.ts
@@ -11,10 +11,11 @@ vi.mock('node:child_process', () => ({
   spawnSync: mocks.spawnSync,
 }));
 
-import { createGitStatusCache, formatGitBadge } from '#/utils/git/git-status';
+import { createGitStatusCache, formatGitBadge, formatPullRequestBadge } from '#/utils/git/git-status';
 
 afterEach(() => {
   vi.useRealTimers();
+  vi.unstubAllEnvs();
   vi.clearAllMocks();
 });
 
@@ -228,6 +229,8 @@ describe('git status cache', () => {
   });
 
   it('formats pull request badges as terminal hyperlinks when requested', () => {
+    vi.stubEnv('TERM_PROGRAM', 'iTerm.app');
+
     const linked = formatGitBadge(
       {
         branch: 'feature/footer',
@@ -247,5 +250,16 @@ describe('git status cache', () => {
     expect(linked).toContain('[PR#12]');
     expect(linked).toContain('\u001B]8;;https://github.com/acme/repo/pull/12\u0007');
     expect(linked).toContain('\u001B]8;;\u0007');
+  });
+
+  it('prints the pull request URL instead of a hyperlink on terminals without OSC 8 support', () => {
+    vi.stubEnv('TERM_PROGRAM', 'WarpTerminal');
+
+    const badge = formatPullRequestBadge(
+      { number: 12, url: 'https://github.com/acme/repo/pull/12' },
+      { linkPullRequest: true },
+    );
+
+    expect(badge).toBe('[PR#12](https://github.com/acme/repo/pull/12)');
   });
 });


### PR DESCRIPTION
## Related Issue

Related to #2051 (terminal links not clickable) — this PR does not resolve it; it only covers the footer status bar's pull request badge.

## Problem

The footer renders the current branch's pull request as a `[PR#N]` badge wrapped in an OSC 8 terminal hyperlink. On terminals without OSC 8 support — notably Warp, where OSC 8 has been requested since 2021 (warpdotdev/Warp#4194) and still renders the sequence as styled-but-inert text — the badge *looks* like a link but clicking it does nothing. Warp can only make fully visible URLs clickable, via its own URL detection.

## What changed

- Add `supportsOsc8Hyperlinks()`, an env-based detection helper next to `toTerminalHyperlink`, driven by a short denylist of terminals known to lack OSC 8 support (currently just Warp). The denylist approach is deliberate: everywhere else OSC 8 either works or degrades to harmless plain text, and the list is easy to extend as other terminals surface.
- `formatPullRequestBadge` falls back to a visible markdown-style link `[PR#N](https://...)` when OSC 8 is unsupported, so Warp's own URL detection makes the URL clickable. Terminals with OSC 8 support keep the existing hidden-target hyperlink, byte for byte.
- Added a unit test for the fallback and pinned `TERM_PROGRAM` in the existing hyperlink test so it no longer depends on the developer's own terminal.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update. (No doc update needed — the footer PR badge is not covered in user docs.)