### PR TITLE
fix(web): show Write tool preview as an all-addition diff

### DIFF
--- a/.changeset/fix-write-preview-blank.md
+++ b/.changeset/fix-write-preview-blank.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+web: Fix the Write tool preview panel showing a blank diff.

--- a/apps/kimi-web/src/lib/toolDiff.ts
+++ b/apps/kimi-web/src/lib/toolDiff.ts
@@ -34,11 +34,16 @@ export function buildEditDiffLines(tool: { name: string; arg: string }): DiffVie
     if (before === undefined || after === undefined) return null;
     return buildDiffLines(before, after);
   }
-  // Write only reports the new content (and whether it appended); the client
-  // cannot tell a new file from an overwrite of an existing one. A from-empty
-  // diff would show an overwrite as "all additions, no deletions", which is
-  // misleading — so fall back to the tool output for every Write.
-  return null;
+  // Write reports the new content. Append adds to unknown existing content, so
+  // a from-args diff cannot represent it — fall back to the tool output there.
+  // Otherwise show the content as a from-empty diff so the preview panel has
+  // something to render immediately; this matches the "created file" view of a
+  // normal diff (an overwrite shows as all additions, which is imprecise but
+  // still previews exactly what the call writes).
+  if (d.mode === 'append') return null;
+  const content = typeof d.content === 'string' ? d.content : undefined;
+  if (content === undefined) return null;
+  return buildDiffLines('', content);
 }
 
 /** Pull the file path out of an Edit/Write tool call's input, if present. */

--- a/apps/kimi-web/test/lib-logic.test.ts
+++ b/apps/kimi-web/test/lib-logic.test.ts
@@ -334,8 +334,19 @@ describe('buildEditDiffLines', () => {
     expect(buildEditDiffLines({ name: 'Edit', arg })).toBeNull();
   });
 
-  it('falls back to output for every Write (new file or overwrite)', () => {
-    expect(buildEditDiffLines({ name: 'Write', arg: JSON.stringify({ path: 'a.ts', content: 'x' }) })).toBeNull();
+  it('shows Write content as an all-addition diff', () => {
+    expect(buildEditDiffLines({ name: 'Write', arg: JSON.stringify({ path: 'a.ts', content: 'x' }) })).toEqual([
+      { type: 'add', text: 'x', newNo: 1 },
+    ]);
+    expect(
+      buildEditDiffLines({ name: 'Write', arg: JSON.stringify({ path: 'a.ts', content: 'x\ny', mode: 'overwrite' }) }),
+    ).toEqual([
+      { type: 'add', text: 'x', newNo: 1 },
+      { type: 'add', text: 'y', newNo: 2 },
+    ]);
+  });
+
+  it('falls back to output for appending Writes', () => {
     expect(
       buildEditDiffLines({ name: 'Write', arg: JSON.stringify({ path: 'a.ts', content: 'x', mode: 'append' }) }),
     ).toBeNull();


### PR DESCRIPTION
## Related Issue

Resolve #2268

## Problem

See linked issue.

## What changed

`buildEditDiffLines()` in `apps/kimi-web/src/lib/toolDiff.ts` previously returned `null` for **every** Write call, so the right-side preview panel (`ToolDiffPanel.vue`) had nothing to render and showed its empty state until the raw tool output arrived. This PR distinguishes by write mode:

- **`mode: 'append'`** → still returns `null` and falls back to the tool output. An append adds to unknown existing content, so a from-args diff cannot represent it — an all-additions diff would falsely look like a new file.
- **overwrite / new file (default)** → renders the `content` argument as a from-empty diff (`buildDiffLines('', content)`), i.e. all additions. This matches the "created file" view of a normal diff, so the panel (and the `+N −M` chip on the tool card) are immediately useful. For overwrites this is imprecise (no deletions shown), but the panel's purpose is previewing what the call writes.

Tests updated in `apps/kimi-web/test/lib-logic.test.ts`: all-addition diff for overwrite/unspecified mode, `null` for append.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.
