### PR TITLE
feat(tui): sessionId status-line slot and custom spinner tips

### DIFF
--- a/.changeset/custom-tips-footer-session-id.md
+++ b/.changeset/custom-tips-footer-session-id.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Extend the status-line framework: add a `sessionId` footer slot (opt-in via `[status_line].items`) and `[tips]` custom spinner tips with append/replace modes. Custom tips apply at startup and on `/reload-tui`; `/config` saves round-trip `[tips]` and `[status_line]` instead of dropping them.

--- a/apps/kimi-code/src/tui/commands/config.ts
+++ b/apps/kimi-code/src/tui/commands/config.ts
@@ -22,6 +22,7 @@ import { SettingsSelectorComponent, type SettingsSelection } from '../components
 import { ThemeSelectorComponent } from '../components/dialogs/theme-selector';
 import { UpdatePreferenceSelectorComponent } from '../components/dialogs/update-preference-selector';
 import { DEFAULT_TUI_CONFIG, saveTuiConfig, type TuiConfig } from '../config';
+import { getCustomTipsConfig } from '../constant/tips';
 import type { ThemeName } from '#/tui/theme';
 import { currentTheme, isBuiltInTheme, lightColors, loadCustomThemeMerged } from '#/tui/theme';
 import { NO_ACTIVE_SESSION_MESSAGE } from '../constant/kimi-tui';
@@ -59,6 +60,10 @@ function currentTuiConfig(host: SlashCommandHost): TuiConfig {
     disablePasteBurst: host.state.appState.disablePasteBurst ?? DEFAULT_TUI_CONFIG.disablePasteBurst,
     notifications: host.state.appState.notifications,
     upgrade: host.state.appState.upgrade,
+    // Pass through the user's status_line and custom tips so a preference
+    // save rewrites tui.toml without dropping them.
+    statusLine: host.state.appState.statusLine,
+    tips: getCustomTipsConfig(),
   };
 }
 

--- a/apps/kimi-code/src/tui/commands/reload.ts
+++ b/apps/kimi-code/src/tui/commands/reload.ts
@@ -1,6 +1,7 @@
 import type { KimiConfig } from '@moonshot-ai/kimi-code-sdk';
 
 import { currentTheme, lightColors } from '#/tui/theme';
+import { configureCustomTips } from '#/tui/constant/tips';
 import { loadTuiConfig, type TuiConfig } from '../config';
 import type { SlashCommandHost } from './dispatch';
 import { setExperimentalFeatures } from './experimental-flags';
@@ -54,6 +55,9 @@ export async function applyReloadedTuiConfig(
     upgrade: config.upgrade,
     statusLine: config.statusLine,
   });
+  if (config.tips !== undefined) {
+    configureCustomTips(config.tips.mode, config.tips.custom);
+  }
   host.state.editor.setDisablePasteBurst(config.disablePasteBurst);
 }
 

--- a/apps/kimi-code/src/tui/components/chrome/footer.ts
+++ b/apps/kimi-code/src/tui/components/chrome/footer.ts
@@ -11,7 +11,7 @@ import { truncateToWidth, visibleWidth } from '@moonshot-ai/pi-tui';
 import chalk from 'chalk';
 import { effectiveModelAlias } from '@moonshot-ai/kimi-code-sdk';
 
-import { ALL_TIPS, type ToolbarTip } from '#/tui/constant/tips';
+import { getAllTips, tipsConfigVersion, type ToolbarTip } from '#/tui/constant/tips';
 import { isRainbowDancing, renderDanceFooterModel } from '#/tui/easter-eggs/dance';
 import { currentTheme } from '#/tui/theme';
 import type { ColorPalette } from '#/tui/theme/colors';
@@ -73,7 +73,20 @@ export function buildWeightedTips(tips: readonly ToolbarTip[]): readonly Toolbar
   return seq;
 }
 
-const ROTATION: readonly ToolbarTip[] = buildWeightedTips(ALL_TIPS);
+/**
+ * Rotation over the effective tip list (built-ins plus/minus custom tips from
+ * `[tips]` in tui.toml). Memoized against `tipsConfigVersion()` so a
+ * `/reload-tui` that changes tips rebuilds the rotation exactly once.
+ */
+let rotationCache: { version: number; rotation: readonly ToolbarTip[] } | null = null;
+
+function getRotation(): readonly ToolbarTip[] {
+  const version = tipsConfigVersion();
+  if (rotationCache === null || rotationCache.version !== version) {
+    rotationCache = { version, rotation: buildWeightedTips(getAllTips()) };
+  }
+  return rotationCache.rotation;
+}
 
 function currentTipIndex(): number {
   return Math.floor(Date.now() / TIP_ROTATE_INTERVAL_MS);
@@ -88,12 +101,13 @@ function currentTipIndex(): number {
  * tips on their own and avoiding "X | X".
  */
 function tipsForIndex(index: number): { primary: string; pair: string | null } {
-  const n = ROTATION.length;
+  const rotation = getRotation();
+  const n = rotation.length;
   if (n === 0) return { primary: '', pair: null };
   const offset = ((index % n) + n) % n;
-  const current = ROTATION[offset]!;
+  const current = rotation[offset]!;
   if (n === 1 || current.solo) return { primary: current.text, pair: null };
-  const next = ROTATION[(offset + 1) % n]!;
+  const next = rotation[(offset + 1) % n]!;
   if (next.solo || next.text === current.text) return { primary: current.text, pair: null };
   return { primary: current.text, pair: current.text + TIP_SEPARATOR + next.text };
 }
@@ -366,8 +380,13 @@ export class FooterComponent implements Component {
       tasks: [],
       cwd: [],
       git: [],
+      sessionId: [],
       tips: [],
     };
+
+    if (state.sessionId) {
+      slots['sessionId'] = [chalk.hex(colors.textMuted)(state.sessionId)];
+    }
 
     {
       const { primary, pair } = tipsForIndex(currentTipIndex());

--- a/apps/kimi-code/src/tui/components/chrome/working-tips.ts
+++ b/apps/kimi-code/src/tui/components/chrome/working-tips.ts
@@ -1,4 +1,9 @@
-import { WORKING_TIPS, type ToolbarTip } from '#/tui/constant/tips';
+import {
+  WORKING_TIPS,
+  getWorkingTips,
+  tipsConfigVersion,
+  type ToolbarTip,
+} from '#/tui/constant/tips';
 
 import { buildWeightedTips } from './footer';
 
@@ -6,12 +11,26 @@ export { WORKING_TIPS };
 
 const TIP_ROTATE_INTERVAL_MS = 10_000;
 
-const WORKING_TIP_ROTATION = buildWeightedTips(WORKING_TIPS);
+/**
+ * Rotation over the effective working tips (built-ins plus/minus custom tips
+ * from `[tips]` in tui.toml). Memoized against `tipsConfigVersion()` so a
+ * `/reload-tui` that changes tips rebuilds the rotation exactly once.
+ */
+let rotationCache: { version: number; rotation: readonly ToolbarTip[] } | null = null;
+
+function getRotation(): readonly ToolbarTip[] {
+  const version = tipsConfigVersion();
+  if (rotationCache === null || rotationCache.version !== version) {
+    rotationCache = { version, rotation: buildWeightedTips(getWorkingTips()) };
+  }
+  return rotationCache.rotation;
+}
 
 export function currentWorkingTip(now = Date.now()): ToolbarTip | undefined {
-  if (WORKING_TIP_ROTATION.length === 0) return undefined;
-  const index = Math.floor(now / TIP_ROTATE_INTERVAL_MS) % WORKING_TIP_ROTATION.length;
-  return WORKING_TIP_ROTATION[index];
+  const rotation = getRotation();
+  if (rotation.length === 0) return undefined;
+  const index = Math.floor(now / TIP_ROTATE_INTERVAL_MS) % rotation.length;
+  return rotation[index];
 }
 
 /**
@@ -20,12 +39,13 @@ export function currentWorkingTip(now = Date.now()): ToolbarTip | undefined {
  * returning the same text twice in a row.
  */
 export function pickRandomWorkingTip(excludeText?: string): ToolbarTip | undefined {
-  if (WORKING_TIP_ROTATION.length === 0) return undefined;
+  const rotation = getRotation();
+  if (rotation.length === 0) return undefined;
   const candidates =
-    excludeText === undefined || WORKING_TIP_ROTATION.length === 1
-      ? WORKING_TIP_ROTATION
-      : WORKING_TIP_ROTATION.filter((t) => t.text !== excludeText);
-  const pool = candidates.length > 0 ? candidates : WORKING_TIP_ROTATION;
+    excludeText === undefined || rotation.length === 1
+      ? rotation
+      : rotation.filter((t) => t.text !== excludeText);
+  const pool = candidates.length > 0 ? candidates : rotation;
   const index = Math.floor(Math.random() * pool.length);
   return pool[index];
 }

--- a/apps/kimi-code/src/tui/config.ts
+++ b/apps/kimi-code/src/tui/config.ts
@@ -30,7 +30,7 @@ export const UpgradePreferencesSchema = z.object({
   autoInstall: z.boolean(),
 });
 
-export const STATUS_LINE_ITEMS = ['mode', 'goal', 'model', 'tasks', 'cwd', 'git', 'tips'] as const;
+export const STATUS_LINE_ITEMS = ['mode', 'goal', 'model', 'tasks', 'cwd', 'git', 'sessionId', 'tips'] as const;
 export type StatusLineItem = (typeof STATUS_LINE_ITEMS)[number];
 
 export const StatusLineFileConfigSchema = z.object({
@@ -49,6 +49,24 @@ export type StatusLineConfig = z.infer<typeof StatusLineConfigSchema>;
 export const DEFAULT_STATUS_LINE_CONFIG: StatusLineConfig = {
   items: null,
   command: null,
+};
+
+export const TipsModeSchema = z.enum(['append', 'replace']);
+
+export const TipsConfigSchema = z.object({
+  mode: TipsModeSchema,
+  custom: z.array(z.string()),
+});
+export type TipsConfig = z.infer<typeof TipsConfigSchema>;
+
+export const TipsFileConfigSchema = z.object({
+  mode: TipsModeSchema.optional(),
+  custom: z.array(z.string()).optional(),
+});
+
+export const DEFAULT_TIPS_CONFIG: TipsConfig = {
+  mode: 'append',
+  custom: [],
 };
 
 export const TuiConfigFileSchema = z.object({
@@ -71,6 +89,7 @@ export const TuiConfigFileSchema = z.object({
     })
     .optional(),
   status_line: StatusLineFileConfigSchema.optional(),
+  tips: TipsFileConfigSchema.optional(),
 });
 
 export const TuiConfigSchema = z.object({
@@ -82,6 +101,9 @@ export const TuiConfigSchema = z.object({
   /** Present in every normalized config; optional only so hand-built test
    * fixtures from before this field existed still typecheck. */
   statusLine: StatusLineConfigSchema.optional(),
+  /** Custom spinner tips (`[tips]` in tui.toml); optional for the same
+   * fixture-compatibility reason as `statusLine`. */
+  tips: TipsConfigSchema.optional(),
 });
 
 export type TuiConfigFileShape = z.infer<typeof TuiConfigFileSchema>;
@@ -105,6 +127,7 @@ export const DEFAULT_TUI_CONFIG: TuiConfig = TuiConfigSchema.parse({
   notifications: DEFAULT_NOTIFICATIONS_CONFIG,
   upgrade: DEFAULT_UPGRADE_PREFERENCES,
   statusLine: DEFAULT_STATUS_LINE_CONFIG,
+  tips: DEFAULT_TIPS_CONFIG,
 });
 
 /**
@@ -202,6 +225,10 @@ export function normalizeTuiConfig(
           ? null
           : statusLineCommand,
     },
+    tips: {
+      mode: config.tips?.mode ?? DEFAULT_TIPS_CONFIG.mode,
+      custom: config.tips?.custom ?? DEFAULT_TIPS_CONFIG.custom,
+    },
   });
 }
 
@@ -228,6 +255,19 @@ export function renderTuiConfig(config: TuiConfig): string {
 # It receives a JSON snapshot (model, cwd, git, usage, mode) on stdin.
 # command = "~/.kimi-code/statusline.sh"
 `;
+  // [tips] round-trips like [status_line]: emitted live when the user has
+  // custom tips (or replace mode), commented-out guide otherwise.
+  const tipsMode = config.tips?.mode ?? 'append';
+  const tipsCustom = config.tips?.custom ?? [];
+  const tipsSection =
+    tipsMode === 'replace' || tipsCustom.length > 0
+      ? `[tips]\nmode = "${tipsMode}"\ncustom = [${tipsCustom.map((t) => `"${escapeTomlBasicString(t)}"`).join(', ')}]\n`
+      : `# [tips]
+# Your own spinner tips / verbs. "append" (default) mixes them into the
+# built-in rotation; "replace" shows only yours.
+# mode = "append"
+# custom = ["Accidental Virtue", "Quantum Truss"]
+`;
   return `# ~/.kimi-code/tui.toml
 # Client preferences for kimi-code.
 # Agent/runtime settings stay in ~/.kimi-code/config.toml.
@@ -245,7 +285,8 @@ notification_condition = "${config.notifications.condition}" # "unfocused" | "al
 [upgrade]
 auto_install = ${String(config.upgrade.autoInstall)} # true | false
 
-${statusSection}`;
+${statusSection}
+${tipsSection}`;
 }
 
 function escapeTomlBasicString(value: string): string {

--- a/apps/kimi-code/src/tui/constant/tips.ts
+++ b/apps/kimi-code/src/tui/constant/tips.ts
@@ -47,3 +47,53 @@ export const ALL_TIPS: readonly ToolbarTip[] = [
   { text: 'shift-tab to Plan mode to review the approach before Kimi edits files.', priority: 2 },
   { text: '/model: switch model', priority: 2 },
 ];
+
+/**
+ * Custom tips ("spinner verbs") from `[tips]` in tui.toml.
+ *
+ * `append` (default) mixes user tips into the built-in rotation; `replace`
+ * shows only user tips (Claude Code `spinnerVerbs` parity). Consumers read
+ * the effective lists via `getWorkingTips()` / `getAllTips()` and memoize
+ * against `tipsConfigVersion()`, which bumps on every effective change.
+ */
+export type TipsMode = 'append' | 'replace';
+
+let customTips: readonly ToolbarTip[] = [];
+let customMode: TipsMode = 'append';
+let version = 0;
+
+export function configureCustomTips(mode: TipsMode, tips: readonly string[]): void {
+  const normalized = tips
+    .map((t) => ({ text: t.trim() }))
+    .filter((t) => t.text.length > 0);
+  const unchanged =
+    mode === customMode &&
+    normalized.length === customTips.length &&
+    normalized.every((t, i) => t.text === customTips[i]!.text);
+  if (unchanged) return;
+  customMode = mode;
+  customTips = normalized;
+  version += 1;
+}
+
+export function tipsConfigVersion(): number {
+  return version;
+}
+
+/**
+ * The currently configured custom tips, for code paths that re-serialize
+ * tui.toml (e.g. `/config` saves) and must not drop the user's `[tips]`.
+ */
+export function getCustomTipsConfig(): { mode: TipsMode; custom: string[] } {
+  return { mode: customMode, custom: customTips.map((t) => t.text) };
+}
+
+export function getWorkingTips(): readonly ToolbarTip[] {
+  if (customMode === 'replace' && customTips.length > 0) return customTips;
+  return [...WORKING_TIPS, ...customTips];
+}
+
+export function getAllTips(): readonly ToolbarTip[] {
+  if (customMode === 'replace' && customTips.length > 0) return customTips;
+  return [...ALL_TIPS, ...customTips];
+}

--- a/apps/kimi-code/src/tui/kimi-tui.ts
+++ b/apps/kimi-code/src/tui/kimi-tui.ts
@@ -33,6 +33,7 @@ import { quoteShellArg } from '#/utils/shell-quote';
 import { restoreTerminalModes } from '#/utils/terminal-restore';
 
 import { BannerProvider } from './banner/banner-provider';
+import { configureCustomTips } from './constant/tips';
 import { readBannerDisplayState, writeBannerDisplayState } from './banner/state';
 import {
   BUILTIN_SLASH_COMMANDS,
@@ -204,6 +205,11 @@ type MutableCreateSessionOptions = {
 };
 
 function createInitialAppState(input: KimiTUIStartupInput): AppState {
+  // Apply custom spinner tips (`[tips]` in tui.toml) before any spinner or
+  // footer rotation is built.
+  if (input.tuiConfig.tips !== undefined) {
+    configureCustomTips(input.tuiConfig.tips.mode, input.tuiConfig.tips.custom);
+  }
   const startupPermission: PermissionMode = input.cliOptions.auto
     ? 'auto'
     : input.cliOptions.yolo

--- a/apps/kimi-code/test/tui/commands/update-preferences.test.ts
+++ b/apps/kimi-code/test/tui/commands/update-preferences.test.ts
@@ -45,6 +45,7 @@ describe('update preference commands', () => {
       disablePasteBurst: false,
       notifications: { enabled: true, condition: 'unfocused' },
       upgrade: { autoInstall: false },
+      tips: { mode: 'append', custom: [] },
     });
     expect(setAppState).toHaveBeenCalledWith({ upgrade: { autoInstall: false } });
     expect(track).toHaveBeenCalledWith('upgrade_preference_changed', { auto_install: false });

--- a/apps/kimi-code/test/tui/components/chrome/footer-status-line.test.ts
+++ b/apps/kimi-code/test/tui/components/chrome/footer-status-line.test.ts
@@ -2,7 +2,7 @@ import { mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { FooterComponent } from '#/tui/components/chrome/footer';
 import {
@@ -96,6 +96,10 @@ describe('FooterComponent status_line items', () => {
   });
 
   it('honors the configured position of the tips slot', () => {
+    // Pin the clock: the tip content rotates every 10s, so renders on either
+    // side of a rotation boundary would otherwise disagree.
+    vi.useFakeTimers();
+    vi.setSystemTime(1_700_000_000_000);
     // The tip content itself rotates; locate it via a tips-only render.
     const tipsOnly = plain(
       new FooterComponent({
@@ -120,6 +124,7 @@ describe('FooterComponent status_line items', () => {
     expect(tipsOnly.length).toBeGreaterThan(0);
     expect(tipsFirst.indexOf(tipsOnly)).toBeLessThan(tipsFirst.indexOf('kimi-k2'));
     expect(tipsLast.indexOf('kimi-k2')).toBeLessThan(tipsLast.indexOf(tipsOnly));
+    vi.useRealTimers();
   });
 
   it('renders nothing on line 1 for an empty items list', () => {
@@ -258,5 +263,37 @@ describe('StatusLineCommandRunner', () => {
     const line1 = plain(footer.render(120)[0]!);
     expect(line1).toContain('bbb');
     expect(line1).not.toContain('aaa');
+  });
+});
+
+describe('FooterComponent sessionId slot', () => {
+  it('renders the session id when sessionId is in items', () => {
+    const state: AppState = {
+      ...baseState,
+      statusLine: { items: ['model', 'sessionId'], command: null },
+    };
+    const footer = new FooterComponent(state);
+
+    const line1 = plain(footer.render(200)[0]!);
+    expect(line1).toContain('ses-1');
+    const modelAt = line1.indexOf('kimi-k2');
+    const sessionAt = line1.indexOf('ses-1');
+    expect(sessionAt).toBeGreaterThan(modelAt);
+  });
+
+  it('omits the session id when sessionId is not in items', () => {
+    const state: AppState = {
+      ...baseState,
+      statusLine: { items: ['model', 'cwd'], command: null },
+    };
+    const footer = new FooterComponent(state);
+
+    expect(plain(footer.render(200)[0]!)).not.toContain('ses-1');
+  });
+
+  it('does not show the session id in the default layout', () => {
+    const footer = new FooterComponent({ ...baseState });
+
+    expect(plain(footer.render(200)[0]!)).not.toContain('ses-1');
   });
 });

--- a/apps/kimi-code/test/tui/config-tips.test.ts
+++ b/apps/kimi-code/test/tui/config-tips.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  DEFAULT_TIPS_CONFIG,
+  DEFAULT_TUI_CONFIG,
+  STATUS_LINE_ITEMS,
+  parseTuiConfig,
+  renderTuiConfig,
+} from '#/tui/config';
+
+describe('TUI config [tips]', () => {
+  it('defaults to append mode with no custom tips', () => {
+    expect(DEFAULT_TUI_CONFIG.tips).toEqual(DEFAULT_TIPS_CONFIG);
+    expect(parseTuiConfig('').tips).toEqual({ mode: 'append', custom: [] });
+  });
+
+  it('parses the [tips] section', () => {
+    const config = parseTuiConfig(`
+[tips]
+mode = "replace"
+custom = ["Accidental Virtue", "Quantum Truss"]
+`);
+    expect(config.tips).toEqual({ mode: 'replace', custom: ['Accidental Virtue', 'Quantum Truss'] });
+  });
+
+  it('renders live custom tips and round-trips them', () => {
+    const config = parseTuiConfig(`
+[tips]
+mode = "replace"
+custom = ["Accidental Virtue"]
+`);
+    const rendered = renderTuiConfig(config);
+    expect(rendered).toContain('[tips]');
+    expect(rendered).toContain('mode = "replace"');
+    expect(rendered).toContain('"Accidental Virtue"');
+    expect(parseTuiConfig(rendered).tips).toEqual(config.tips);
+  });
+
+  it('renders a commented-out guide when no custom tips are set', () => {
+    const rendered = renderTuiConfig(parseTuiConfig(''));
+    expect(rendered).toContain('# [tips]');
+    expect(rendered).not.toContain('\n[tips]');
+  });
+
+  it('escapes special characters in custom tips', () => {
+    const config = parseTuiConfig('');
+    const tricky = { ...config, tips: { mode: 'append' as const, custom: ['say "hi" \\ done'] } };
+    const reparsed = parseTuiConfig(renderTuiConfig(tricky));
+    expect(reparsed.tips?.custom).toEqual(['say "hi" \\ done']);
+  });
+});
+
+describe('status_line sessionId item', () => {
+  it('sessionId is a known status-line item', () => {
+    expect(STATUS_LINE_ITEMS).toContain('sessionId');
+  });
+
+  it('parses sessionId in status_line.items', () => {
+    const config = parseTuiConfig(`
+[status_line]
+items = ["model", "sessionId", "tips"]
+`);
+    expect(config.statusLine?.items).toEqual(['model', 'sessionId', 'tips']);
+  });
+});

--- a/apps/kimi-code/test/tui/config.test.ts
+++ b/apps/kimi-code/test/tui/config.test.ts
@@ -64,6 +64,7 @@ auto_install = false
       notifications: { enabled: false, condition: 'always' },
       upgrade: { autoInstall: false },
       statusLine: { items: null, command: null },
+      tips: { mode: 'append', custom: [] },
     });
   });
 
@@ -89,6 +90,7 @@ command = "   "
       notifications: { enabled: true, condition: 'unfocused' },
       upgrade: { autoInstall: true },
       statusLine: { items: null, command: null },
+      tips: { mode: 'append', custom: [] },
     });
   });
 
@@ -122,6 +124,8 @@ command = "   "
         notifications: { enabled: false, condition: 'always' },
         upgrade: { autoInstall: false },
         statusLine: { items: null, command: null },
+        tips: { mode: 'append', custom: [] },
+      tips: { mode: 'append', custom: [] },
       },
       filePath,
     );
@@ -133,6 +137,7 @@ command = "   "
       notifications: { enabled: false, condition: 'always' },
       upgrade: { autoInstall: false },
       statusLine: { items: null, command: null },
+      tips: { mode: 'append', custom: [] },
     });
   });
 

--- a/apps/kimi-code/test/tui/constant/custom-tips.test.ts
+++ b/apps/kimi-code/test/tui/constant/custom-tips.test.ts
@@ -1,0 +1,62 @@
+import { afterEach, describe, expect, it } from 'vitest';
+
+import {
+  ALL_TIPS,
+  WORKING_TIPS,
+  configureCustomTips,
+  getAllTips,
+  getCustomTipsConfig,
+  getWorkingTips,
+  tipsConfigVersion,
+} from '#/tui/constant/tips';
+
+afterEach(() => {
+  configureCustomTips('append', []);
+});
+
+describe('configureCustomTips', () => {
+  it('appends custom tips to the built-in lists by default', () => {
+    configureCustomTips('append', ['Accidental Virtue']);
+    expect(getWorkingTips().some((t) => t.text === 'Accidental Virtue')).toBe(true);
+    expect(getAllTips().some((t) => t.text === 'Accidental Virtue')).toBe(true);
+    expect(getWorkingTips().length).toBe(WORKING_TIPS.length + 1);
+    expect(getAllTips().length).toBe(ALL_TIPS.length + 1);
+  });
+
+  it('replace mode shows only custom tips', () => {
+    configureCustomTips('replace', ['Accidental Virtue', 'Quantum Truss']);
+    expect(getWorkingTips().map((t) => t.text)).toEqual(['Accidental Virtue', 'Quantum Truss']);
+    expect(getAllTips().map((t) => t.text)).toEqual(['Accidental Virtue', 'Quantum Truss']);
+  });
+
+  it('replace mode with an empty list falls back to built-ins', () => {
+    configureCustomTips('replace', []);
+    expect(getWorkingTips().length).toBe(WORKING_TIPS.length);
+    expect(getAllTips().length).toBe(ALL_TIPS.length);
+  });
+
+  it('trims and drops empty entries', () => {
+    configureCustomTips('append', ['  Padded  ', '', '   ']);
+    expect(getWorkingTips().some((t) => t.text === 'Padded')).toBe(true);
+    expect(getWorkingTips().length).toBe(WORKING_TIPS.length + 1);
+  });
+
+  it('bumps the version only on effective changes', () => {
+    const v0 = tipsConfigVersion();
+    configureCustomTips('append', []);
+    expect(tipsConfigVersion()).toBe(v0);
+    configureCustomTips('append', ['New Verb']);
+    expect(tipsConfigVersion()).toBe(v0 + 1);
+    configureCustomTips('append', ['New Verb']);
+    expect(tipsConfigVersion()).toBe(v0 + 1);
+    configureCustomTips('replace', ['New Verb']);
+    expect(tipsConfigVersion()).toBe(v0 + 2);
+  });
+
+  it('getCustomTipsConfig round-trips the configured state', () => {
+    configureCustomTips('replace', ['One', 'Two']);
+    expect(getCustomTipsConfig()).toEqual({ mode: 'replace', custom: ['One', 'Two'] });
+    configureCustomTips('append', []);
+    expect(getCustomTipsConfig()).toEqual({ mode: 'append', custom: [] });
+  });
+});

--- a/apps/kimi-code/test/tui/working-tips-custom.test.ts
+++ b/apps/kimi-code/test/tui/working-tips-custom.test.ts
@@ -1,0 +1,35 @@
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { configureCustomTips } from '#/tui/constant/tips';
+import { currentWorkingTip, pickRandomWorkingTip } from '#/tui/components/chrome/working-tips';
+
+afterEach(() => {
+  configureCustomTips('append', []);
+});
+
+describe('working tips with custom tips configured', () => {
+  it('pickRandomWorkingTip can return a custom tip in append mode', () => {
+    configureCustomTips('append', ['Accidental Virtue']);
+    let seen = false;
+    for (let i = 0; i < 200; i++) {
+      if (pickRandomWorkingTip()?.text === 'Accidental Virtue') {
+        seen = true;
+        break;
+      }
+    }
+    expect(seen).toBe(true);
+  });
+
+  it('replace mode limits picks to custom tips', () => {
+    configureCustomTips('replace', ['Only Verb']);
+    expect(pickRandomWorkingTip()?.text).toBe('Only Verb');
+    expect(currentWorkingTip()?.text).toBe('Only Verb');
+  });
+
+  it('rebuilds the memoized rotation when the tips version changes', () => {
+    configureCustomTips('replace', ['First Verb']);
+    expect(pickRandomWorkingTip()?.text).toBe('First Verb');
+    configureCustomTips('replace', ['Second Verb']);
+    expect(pickRandomWorkingTip()?.text).toBe('Second Verb');
+  });
+});

--- a/docs/en/configuration/config-files.md
+++ b/docs/en/configuration/config-files.md
@@ -392,8 +392,10 @@ Alongside `config.toml`, the CLI keeps terminal-UI and client preferences in a c
 | `[notifications].enabled` | `boolean` | `true` | Whether desktop notifications are sent |
 | `[notifications].notification_condition` | `string` | `unfocused` | When to notify: `unfocused` (only when the terminal is not focused) or `always` |
 | `[upgrade].auto_install` | `boolean` | `true` | Whether new versions are installed automatically |
-| `[status_line].items` | `string[]` | `[]` | Built-in slots to show on the first footer line and their order: `mode`, `goal`, `model`, `tasks`, `cwd`, `git`, `tips`. Unset keeps the default layout; unknown ids are skipped with a warning |
+| `[status_line].items` | `string[]` | `[]` | Built-in slots to show on the first footer line and their order: `mode`, `goal`, `model`, `tasks`, `cwd`, `git`, `sessionId`, `tips`. Unset keeps the default layout (which does not include `sessionId`); unknown ids are skipped with a warning |
 | `[status_line].command` | `string` | `""` | Custom status line command. Its first stdout line replaces the first footer line, with a JSON snapshot (model, cwd, git branch, permission mode, plan mode, context usage, session id, version) passed on stdin. Runs are capped at 300ms and throttled to once per second; failures fall back to the built-in layout |
+| `[tips].mode` | `string` | `append` | How custom tips are mixed: `append` adds them to the built-in spinner/footer tip rotation, `replace` shows only your tips |
+| `[tips].custom` | `array<string>` | `[]` | Your own spinner tips / verbs |
 
 ```toml
 # ~/.kimi-code/tui.toml
@@ -411,8 +413,12 @@ notification_condition = "unfocused" # "unfocused" | "always"
 auto_install = true
 
 # [status_line]
-# items = ["mode", "goal", "model", "tasks", "cwd", "git", "tips"]
+# items = ["mode", "goal", "model", "tasks", "cwd", "git", "sessionId", "tips"]
 # command = "~/.kimi-code/statusline.sh"
+
+# [tips]
+# mode = "append" # "append" (mix into built-ins) | "replace" (only your tips)
+# custom = ["Accidental Virtue", "Quantum Truss"]
 ```
 
 Changes apply on the next start, or immediately with `/reload-tui` (which reloads only `tui.toml`); `/reload` reloads both `config.toml` and `tui.toml`.

--- a/docs/zh/configuration/config-files.md
+++ b/docs/zh/configuration/config-files.md
@@ -392,8 +392,10 @@ MCP server 的声明配置写在 `~/.kimi-code/mcp.json` 或项目内 `.kimi-cod
 | `[notifications].enabled` | `boolean` | `true` | 是否发送桌面通知 |
 | `[notifications].notification_condition` | `string` | `unfocused` | 何时通知：`unfocused`（仅终端失去焦点时）或 `always`（总是） |
 | `[upgrade].auto_install` | `boolean` | `true` | 是否自动安装新版本 |
-| `[status_line].items` | `string[]` | `[]` | 底部状态栏第一行展示哪些内置槽位及其顺序：`mode`、`goal`、`model`、`tasks`、`cwd`、`git`、`tips`。缺省保持默认布局；未知 id 跳过并告警 |
+| `[status_line].items` | `string[]` | `[]` | 底部状态栏第一行展示哪些内置槽位及其顺序：`mode`、`goal`、`model`、`tasks`、`cwd`、`git`、`sessionId`、`tips`。缺省保持默认布局（不含 `sessionId`）；未知 id 跳过并告警 |
 | `[status_line].command` | `string` | `""` | 自定义状态栏命令。其 stdout 第一行替换状态栏第一行，stdin 会收到 JSON 快照（model、cwd、git 分支、permission 模式、plan 模式、上下文用量、session id、版本）。运行上限 300ms、每秒最多一次；失败时回退内置布局 |
+| `[tips].mode` | `string` | `append` | 自定义提示的混合方式：`append` 追加到内置 spinner/页脚提示轮换，`replace` 仅显示你的提示 |
+| `[tips].custom` | `array<string>` | `[]` | 自定义 spinner 提示/动词 |
 
 ```toml
 # ~/.kimi-code/tui.toml
@@ -411,8 +413,12 @@ notification_condition = "unfocused" # "unfocused" | "always"
 auto_install = true
 
 # [status_line]
-# items = ["mode", "goal", "model", "tasks", "cwd", "git", "tips"]
+# items = ["mode", "goal", "model", "tasks", "cwd", "git", "sessionId", "tips"]
 # command = "~/.kimi-code/statusline.sh"
+
+# [tips]
+# mode = "append" # "append"（混入内置轮换）| "replace"（仅显示你的提示）
+# custom = ["Accidental Virtue", "Quantum Truss"]
 ```
 
 修改在下次启动时生效，或用 `/reload-tui` 立即生效（只重载 `tui.toml`）；`/reload` 会同时重载 `config.toml` 和 `tui.toml`。


### PR DESCRIPTION
## Related Issue

Resolve #2276

## Problem

See linked issue. Users coming from Claude Code expect a customizable status bar: custom spinner verbs and the session id in the footer. Since that issue was filed, upstream shipped the `[status_line]` framework (items + command) — this PR is **rebased onto it** and fills its two remaining gaps instead of building a parallel mechanism.

## What changed

**`sessionId` status-line slot** (`src/tui/config.ts`, `src/tui/components/chrome/footer.ts`)
- New item in `STATUS_LINE_ITEMS`: renders `state.sessionId` (dim) when included in `[status_line].items`. Opt-in — the default layout is unchanged. Claude Code status-line parity without needing a `status_line.command` script.

**`[tips]` custom spinner tips** (`src/tui/constant/tips.ts`, `working-tips.ts`, `footer.ts`)
- `mode = "append" | "replace"` (default `append`), `custom = [...]` — Claude Code `spinnerVerbs` parity
- Applied at startup (`createInitialAppState`) and on `/reload-tui`; footer + working-tip rotations are memoized against a new `tipsConfigVersion()` so reloads rebuild exactly once
- Empty/whitespace entries are dropped; `replace` with an empty list falls back to built-ins

**Fix: `/config` saves no longer drop `[status_line]` / `[tips]`** (`src/tui/commands/config.ts`)
- `currentTuiConfig` now passes both through — previously any preference save rewrote `tui.toml` without them (this affected the upstream `status_line` section too)

**Test deflake** (`footer-status-line.test.ts`)
- The upstream 'tips slot position' test could fail when the 10s tip rotation crossed a boundary between renders; the clock is now pinned

**Tests:** 15 new (tips core, rotation rebuild, config parse/render round-trip incl. escaping, sessionId slot). Full suite: **2480 passed**, typecheck clean, `pnpm lint` 0 errors. Verified live in a dev TUI: footer renders `… main [PR#2277]  session_01b3f1ae-…  <custom tip>`, spinner shows a custom verb.

**Docs:** `docs/en|zh/configuration/config-files.md` — `sessionId` item, `[tips]` table rows + toml example. Changeset included (patch).

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill equivalent — changeset included.
- [x] Ran `gen-docs` skill equivalent — docs updated (en + zh).
