### PR TITLE
docs: document an authenticated HTTP MCP server

### DIFF
--- a/docs/en/customization/mcp.md
+++ b/docs/en/customization/mcp.md
@@ -67,6 +67,40 @@ Plugins can also declare MCP servers in their manifest. Servers declared by a pl
 stdio entries in a project-level `.kimi-code/mcp.json` execute local commands when a session starts. Only enable these in repositories you trust.
 :::
 
+### Example: an authenticated HTTP server
+
+The optional fields above are easier to place against a concrete server. [You.com](https://you.com/docs/build-with-agents/mcp-server?utm_source=moonshotai-kimi-code&utm_medium=oss_integration&utm_campaign=2026-07-oss-integrations&utm_content=docs) serves web search over HTTP and can be connected with or without credentials:
+
+```json
+{
+  "mcpServers": {
+    "you-free": {
+      "url": "https://api.you.com/mcp?profile=free"
+    },
+    "you": {
+      "url": "https://api.you.com/mcp",
+      "bearerTokenEnvVar": "YDC_API_KEY"
+    }
+  }
+}
+```
+
+`you-free` needs no credentials and exposes `you-search` on its own. The authenticated entry reads its token from `$YDC_API_KEY` and additionally exposes `you-contents`, `you-research`, `you-discover`, and `you-balance`. To authorize through the browser instead of a static token, omit `bearerTokenEnvVar` and run `/mcp-config login you`.
+
+Use `enabledTools` to narrow a server down to the tools you actually want:
+
+```json
+{
+  "mcpServers": {
+    "you": {
+      "url": "https://api.you.com/mcp",
+      "bearerTokenEnvVar": "YDC_API_KEY",
+      "enabledTools": ["you-search", "you-contents"]
+    }
+  }
+}
+```
+
 ## Tool Naming and Permissions
 
 MCP tools are named in the format `mcp__<server>__<tool>`, for example `mcp__github__create_issue`. Permission rules support `*` and `**` wildcards, for example `mcp__github__*` matches all tools under that server. MCP tool parameters are not included in permission matching.

--- a/docs/zh/customization/mcp.md
+++ b/docs/zh/customization/mcp.md
@@ -67,6 +67,40 @@ Plugins 也可以在 manifest 中声明 MCP servers。Plugin 声明的 servers �
 项目级 `.kimi-code/mcp.json` 中的 stdio 条目会在会话启动时执行本地命令，只在你信任的仓库里启用。
 :::
 
+### 示例：带鉴权的 HTTP server
+
+结合一个真实的 server 更容易理解上面这些可选字段。[You.com](https://you.com/docs/build-with-agents/mcp-server?utm_source=moonshotai-kimi-code&utm_medium=oss_integration&utm_campaign=2026-07-oss-integrations&utm_content=docs) 通过 HTTP 提供网页搜索，可以在有凭证和无凭证两种方式下连接：
+
+```json
+{
+  "mcpServers": {
+    "you-free": {
+      "url": "https://api.you.com/mcp?profile=free"
+    },
+    "you": {
+      "url": "https://api.you.com/mcp",
+      "bearerTokenEnvVar": "YDC_API_KEY"
+    }
+  }
+}
+```
+
+`you-free` 不需要凭证，只提供 `you-search`。带鉴权的条目从 `$YDC_API_KEY` 读取 token，并额外提供 `you-contents`、`you-research`、`you-discover` 和 `you-balance`。如果想用浏览器授权而不是静态 token，去掉 `bearerTokenEnvVar` 并运行 `/mcp-config login you`。
+
+用 `enabledTools` 可以把 server 收窄到你真正需要的工具：
+
+```json
+{
+  "mcpServers": {
+    "you": {
+      "url": "https://api.you.com/mcp",
+      "bearerTokenEnvVar": "YDC_API_KEY",
+      "enabledTools": ["you-search", "you-contents"]
+    }
+  }
+}
+```
+
 ## 工具命名与权限
 
 MCP 工具按 `mcp__<server>__<tool>` 格式命名，例如 `mcp__github__create_issue`。权限规则中支持 `*` 和 `**` 通配，例如 `mcp__github__*` 命中该 server 下所有工具。MCP 工具参数不参与权限匹配。


### PR DESCRIPTION
Relates to #2279 — please read that first; this PR is subordinate to it.

**Disclosure:** I work at You.com, and this PR uses our MCP server as its example. I originally framed it as a documentation-only change, which under CONTRIBUTING is exempt from the issue-first rule. That framing was not right: a vendor example is a vendor addition regardless of which file it lands in, and it should have followed a discussion rather than preceded one. I have now opened #2279 to make the actual proposal explicit. Close this if you would rather settle the question there first.

## What it changes

`docs/en/customization/mcp.md` and `docs/zh/customization/mcp.md` gain an `### Example: an authenticated HTTP server` subsection at the end of Configuration.

The gap it addresses is real and independent of the vendor question: the optional-fields table documents `bearerTokenEnvVar` and `enabledTools`, but no example on the page uses either. The worked examples are two stdio entries and one unauthenticated HTTP entry, so anyone connecting an authenticated remote server has to infer the shape from the table alone.

If you want that gap closed without naming a vendor, say the word and I will rewrite it with a placeholder server.

## Verification

Everything asserted in the prose was checked against the live server first:

| Claim in the docs | Result |
|---|---|
| `?profile=free` connects without credentials | `tools/list` → 200, exposes `you-search` only |
| Authenticated entry exposes the other tools | adds `you-contents`, `you-research`, `you-discover`, `you-balance` |
| `bearerTokenEnvVar` is sufficient | `Authorization: Bearer $YDC_API_KEY` → 200 |
| `/mcp-config login` alternative | per the OAuth paragraph already on this page |

`npx vitepress build` passes; both locales render.

Written with AI assistance, reviewed and verified by me end to end.