### PR TITLE
feat(tui): allow shorthand aliases for managed Kimi Code models in /model

### DIFF
--- a/.changeset/kimi-code-model-alias-shorthand.md
+++ b/.changeset/kimi-code-model-alias-shorthand.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Allow `/model <alias>` to match managed Kimi Code models by shorthand. For example, `/model k3` now resolves to `kimi-code/k3`.

--- a/apps/kimi-code/src/tui/commands/config.ts
+++ b/apps/kimi-code/src/tui/commands/config.ts
@@ -248,8 +248,6 @@ export async function handleModelCommand(host: SlashCommandHost, args: string): 
     return;
   }
   const availableModels = host.state.appState.availableModels;
-  // Allow shorthand aliases like "k3" to resolve to the managed Kimi Code
-  // model "kimi-code/k3", matching what the model picker displays.
   if (availableModels[alias] === undefined && !alias.includes('/')) {
     const managedPrefix = DEFAULT_OAUTH_PROVIDER_NAME.slice('managed:'.length);
     const managedAlias = `${managedPrefix}/${alias}`;

--- a/apps/kimi-code/src/tui/commands/config.ts
+++ b/apps/kimi-code/src/tui/commands/config.ts
@@ -24,6 +24,7 @@ import { UpdatePreferenceSelectorComponent } from '../components/dialogs/update-
 import { DEFAULT_TUI_CONFIG, saveTuiConfig, type TuiConfig } from '../config';
 import type { ThemeName } from '#/tui/theme';
 import { currentTheme, isBuiltInTheme, lightColors, loadCustomThemeMerged } from '#/tui/theme';
+import { DEFAULT_OAUTH_PROVIDER_NAME } from '#/constant/app';
 import { NO_ACTIVE_SESSION_MESSAGE } from '../constant/kimi-tui';
 import { formatErrorMessage } from '../utils/event-payload';
 import { thinkingEffortToConfig } from '../utils/thinking-config';
@@ -239,14 +240,25 @@ export async function handleThemeCommand(host: SlashCommandHost, args: string): 
 }
 
 export async function handleModelCommand(host: SlashCommandHost, args: string): Promise<void> {
-  const alias = args.trim();
+  const input = args.trim();
+  let alias = input;
   await refreshModelsForPicker(host);
   if (alias.length === 0) {
     showModelPicker(host);
     return;
   }
-  if (host.state.appState.availableModels[alias] === undefined) {
-    host.showError(`Unknown model alias: ${alias}`);
+  const availableModels = host.state.appState.availableModels;
+  // Allow shorthand aliases like "k3" to resolve to the managed Kimi Code
+  // model "kimi-code/k3", matching what the model picker displays.
+  if (availableModels[alias] === undefined && !alias.includes('/')) {
+    const managedPrefix = DEFAULT_OAUTH_PROVIDER_NAME.slice('managed:'.length);
+    const managedAlias = `${managedPrefix}/${alias}`;
+    if (availableModels[managedAlias] !== undefined) {
+      alias = managedAlias;
+    }
+  }
+  if (availableModels[alias] === undefined) {
+    host.showError(`Unknown model alias: ${input}`);
     return;
   }
   showModelPicker(host, alias);

--- a/apps/kimi-code/test/tui/kimi-tui-message-flow.test.ts
+++ b/apps/kimi-code/test/tui/kimi-tui-message-flow.test.ts
@@ -5127,6 +5127,42 @@ command = "vim"
     expect(refreshProviderModels).not.toHaveBeenCalled();
   });
 
+  it('resolves /model shorthand to the managed Kimi Code alias', async () => {
+    const session = makeSession();
+    const { driver } = await makeDriver(session, {
+      getConfig: vi.fn(async () => ({
+        models: {
+          k2: {
+            provider: 'managed:kimi-code',
+            model: 'kimi-k2',
+            maxContextSize: 100,
+            displayName: 'Kimi K2',
+            capabilities: ['thinking'],
+          },
+          'kimi-code/k3': {
+            provider: 'managed:kimi-code',
+            model: 'kimi-k3',
+            maxContextSize: 100,
+            displayName: 'K3',
+            capabilities: ['thinking'],
+          },
+        },
+        defaultModel: 'k2',
+        thinking: { enabled: false },
+      })),
+    });
+
+    driver.handleUserInput('/model k3');
+
+    await vi.waitFor(() => {
+      const picker = driver.state.editorContainer.children[0];
+      expect(picker).toBeInstanceOf(TabbedModelSelectorComponent);
+      const output = stripSgr((picker as TabbedModelSelectorComponent).render(120).join('\n'));
+      expect(output).toMatch(/❯ K3\s+Kimi Code/);
+    });
+    expect(session.setModel).not.toHaveBeenCalled();
+  });
+
   it('opens /model picker after 2s when OAuth refresh is still pending', async () => {
     const { driver } = await makeDriver(makeSession(), {
       getConfig: vi.fn(async () => ({


### PR DESCRIPTION
## Related Issue

No prior issue — this is a small UX convenience improvement.

## Problem

In the TUI, `/model` accepts an alias as its argument, but the model picker shows human-readable names such as **K3** under the **Kimi Code** provider. The actual configured alias is `kimi-code/k3`, so typing `/model k3` (or `/model K3`) currently fails with `Unknown model alias: k3`. Users either have to use the interactive picker or remember the full `kimi-code/<id>` key.

## What changed

In `handleModelCommand`, when the exact alias is not found and the input contains no `/`, the command now falls back to `kimi-code/<input>`. This lets users open the model picker for managed Kimi Code models with a short, intuitive name.

- Exact aliases still take priority, so a user-defined `k3` would not be shadowed.
- Only inputs without `/` get the fallback.
- If the resolved alias exists, the model picker opens preselected so the user can still choose the thinking effort before switching.
- Added a test in `kimi-tui-message-flow.test.ts` covering the shorthand resolution.
- A changeset has been generated for `@moonshot-ai/kimi-code`.

### Usage comparison

| Before | After |
|---|---|
| `/model k3` → `Unknown model alias: k3` | `/model k3` → opens picker for `kimi-code/k3` |
| `/model K3` → `Unknown model alias: K3` | `/model K3` → `Unknown model alias: K3` (still case-sensitive; use the lowercase model id) |
| `/model kimi-code/k3` → opens picker | `/model kimi-code/k3` → still opens picker |
| `/model kimi-for-coding` → Unknown | `/model kimi-for-coding` → opens picker for `kimi-code/kimi-for-coding` |

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above. *(No issue; problem explained above.)*
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.
