### PR TITLE
web: unify context-usage tooltip format with clear context prefix

### DIFF
--- a/.changeset/unify-web-context-tooltip.md
+++ b/.changeset/unify-web-context-tooltip.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+web: Unify the composer context-usage tooltip format and add a clear "Context" prefix so users immediately know what the percentage and token counts refer to.

--- a/apps/kimi-web/src/i18n/locales/en/status.ts
+++ b/apps/kimi-web/src/i18n/locales/en/status.ts
@@ -2,7 +2,7 @@ export default {
   connectionConnected: 'Connected',
   connectionConnecting: 'Connecting…',
   connectionDisconnected: 'Disconnected',
-  ctxTooltip: 'Used {used} / {max} tokens ({pct}%)',
+  ctxTooltip: 'Context: {pct}% ( {used} / {max} )',
   modelLabel: 'Model',
   permissionManual: 'Manual',
   permissionAuto: 'Auto',

--- a/apps/kimi-web/src/i18n/locales/zh/status.ts
+++ b/apps/kimi-web/src/i18n/locales/zh/status.ts
@@ -2,7 +2,7 @@ export default {
   connectionConnected: '已连接',
   connectionConnecting: '连接中…',
   connectionDisconnected: '未连接',
-  ctxTooltip: '使用 {used} / {max} tokens ({pct}%)',
+  ctxTooltip: '上下文: {pct}% ( {used} / {max} )',
   modelLabel: '模型',
   permissionManual: '逐条确认',
   permissionAuto: '完全自主',


### PR DESCRIPTION
## Related Issue

No related issue.

## Problem

The context-usage ring hover tooltip to the left of the model selector in the web composer was not immediately scannable:


- Before: `Used 43.6k / 256k tokens (18%)`
<img width="425" height="74" alt="image" src="https://github.com/user-attachments/assets/69478d5c-0092-4907-81c7-c5dd359b1895" />


Without a clear "Context / 上下文" prefix, users had to infer what the percentage and token counts meant. The TUI already uses a clearer format (`context: 72% (183k/256k)`), so aligning the web tooltip with it improves consistency.


Without a clear "Context" prefix, users had to infer what the percentage and token counts meant.

## What changed

The added prefix makes it obvious at a glance that the tooltip shows context-window usage, and the compact parenthetical format keeps the line short.

Updated `ctxTooltip` in both `apps/kimi-web/src/i18n/locales/en/status.ts` and `zh/status.ts`:

- After: `Context: {pct}% ( {used} / {max} )`
<img width="417" height="68" alt="image" src="https://github.com/user-attachments/assets/68ef229a-2e06-48e0-bbf4-37232a4b6ab9" />

## Checklist

- [x] I have read the CONTRIBUTING document.
- [ ] I have linked a related issue, or explained the problem above.
- [ ] I have added tests that prove my feature works.
- [x] Ran gen-changesets skill.
- [x] This PR needs no doc update.
