### PR TITLE
fix(kaos): match globstar zero directories

### DIFF
--- a/.changeset/globstar-zero-directories.md
+++ b/.changeset/globstar-zero-directories.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Fix glob patterns with `**/` so they also match files in the starting directory.

--- a/packages/kaos/src/internal.ts
+++ b/packages/kaos/src/internal.ts
@@ -190,6 +190,11 @@ export function globPatternToRegex(pattern: string, caseSensitive: boolean): Reg
     if (ch === undefined) break;
     switch (ch) {
       case '*':
+        if (pattern[i + 1] === '*' && pattern[i + 2] === '/') {
+          regex += '(?:[^/]+/)*';
+          i += 2;
+          break;
+        }
         regex += '[^/]*';
         break;
       case '?':

--- a/packages/kaos/test/internal.test.ts
+++ b/packages/kaos/test/internal.test.ts
@@ -264,12 +264,21 @@ describe('globPatternToRegex', () => {
       expect(regex.test('.config')).toBe(true);
     });
 
-    it.skip('Python treats **/foo.txt as recursive; current helper is segment-based and does not implement zero-or-more directories', () => {
+    it('treats **/foo.txt as recursive with zero-or-more directories', () => {
       const regex = globPatternToRegex('**/foo.txt', true);
 
       expect(regex.test('foo.txt')).toBe(true);
       expect(regex.test('a/foo.txt')).toBe(true);
       expect(regex.test('a/b/foo.txt')).toBe(true);
+    });
+
+    it('treats middle ** segments as zero-or-more directories', () => {
+      const regex = globPatternToRegex('root/**/foo.txt', true);
+
+      expect(regex.test('root/foo.txt')).toBe(true);
+      expect(regex.test('root/a/foo.txt')).toBe(true);
+      expect(regex.test('root/a/b/foo.txt')).toBe(true);
+      expect(regex.test('other/a/foo.txt')).toBe(false);
     });
 
     it('keeps single-star matching to a single path segment', () => {


### PR DESCRIPTION
## Related Issue
No linked issue.

## Problem
`**/foo` patterns did not match files in the starting directory, so recursive globs missed valid files at the root of the search.

## What changed
Teach the glob regex helper to treat `**/` as zero-or-more directories and add coverage for both leading and middle `**/` cases.

## Checklist
- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.
