### PR TITLE
fix(node-sdk): validate catalog payloads

### DIFF
--- a/.changeset/clean-catalog-payloads.md
+++ b/.changeset/clean-catalog-payloads.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code-sdk": patch
+---
+
+Reject invalid catalog payloads consistently.

--- a/packages/node-sdk/src/catalog.ts
+++ b/packages/node-sdk/src/catalog.ts
@@ -49,10 +49,13 @@ export async function fetchCatalog(
   if (!res.ok) {
     throw new CatalogFetchError(`Failed to fetch catalog (HTTP ${res.status}).`, res.status);
   }
-  const payload: unknown = await res.json();
-  if (typeof payload !== 'object' || payload === null || Array.isArray(payload)) {
+  let payload: unknown;
+  try {
+    payload = await res.json();
+  } catch {
     throw new Error(`Unexpected catalog response from ${url}.`);
   }
+  if (!isCatalogPayload(payload)) throw new Error(`Unexpected catalog response from ${url}.`);
   return payload as Catalog;
 }
 
@@ -109,10 +112,15 @@ export interface ApplyCatalogProviderOptions {
 export function loadBuiltInCatalog(text?: string): Catalog | undefined {
   if (typeof text !== 'string' || text.length === 0) return undefined;
   try {
-    return JSON.parse(text) as Catalog;
+    const payload: unknown = JSON.parse(text);
+    return isCatalogPayload(payload) ? (payload as Catalog) : undefined;
   } catch {
     return undefined;
   }
+}
+
+function isCatalogPayload(payload: unknown): boolean {
+  return typeof payload === 'object' && payload !== null && !Array.isArray(payload);
 }
 
 /**

--- a/packages/node-sdk/test/catalog.test.ts
+++ b/packages/node-sdk/test/catalog.test.ts
@@ -18,6 +18,13 @@ function catalogResponse(body: unknown, status = 200): Response {
   });
 }
 
+function rawCatalogResponse(body: string, status = 200): Response {
+  return new Response(body, {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
 const model: CatalogModel = {
   id: 'm1',
   name: 'M1',
@@ -51,6 +58,13 @@ describe('fetchCatalog', () => {
 
   it('throws on a non-object payload', async () => {
     const fetchMock = vi.fn(async () => catalogResponse([1, 2]));
+    await expect(
+      fetchCatalog('https://x', { fetchImpl: fetchMock as unknown as typeof fetch }),
+    ).rejects.toThrow(/Unexpected catalog response/);
+  });
+
+  it('throws on invalid JSON', async () => {
+    const fetchMock = vi.fn(async () => rawCatalogResponse('{'));
     await expect(
       fetchCatalog('https://x', { fetchImpl: fetchMock as unknown as typeof fetch }),
     ).rejects.toThrow(/Unexpected catalog response/);
@@ -90,6 +104,11 @@ describe('loadBuiltInCatalog', () => {
     expect(loadBuiltInCatalog(undefined)).toBeUndefined();
     expect(loadBuiltInCatalog('')).toBeUndefined();
     expect(loadBuiltInCatalog('not-json')).toBeUndefined();
+    expect(loadBuiltInCatalog('{')).toBeUndefined();
+  });
+
+  it('returns undefined for non-object payloads', () => {
+    expect(loadBuiltInCatalog('[1, 2]')).toBeUndefined();
   });
 });
 


### PR DESCRIPTION
## Related Issue
No linked issue.

## Problem
Catalog responses could fail with raw JSON parse errors or accept non-object payloads, which made invalid responses behave inconsistently.

## What changed
Normalize catalog fetch failures, validate catalog payload shape before accepting it, and add tests for invalid JSON and malformed built-in catalog data.

## Checklist
- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.
