### PR TITLE
fix(cli): detect newer layout for bun global installs to avoid error message of unsupported package manager or layout 

### DIFF
--- a/.changeset/fix-bun-global-install-detection.md
+++ b/.changeset/fix-bun-global-install-detection.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Fix install-source detection for bun global installs by recognizing the `~/.bun/node_modules/` layout used by recent bun versions.

--- a/apps/kimi-code/src/cli/update/source.ts
+++ b/apps/kimi-code/src/cli/update/source.ts
@@ -39,7 +39,7 @@ export function detectNativeInstall(): boolean {
 // Path heuristic markers (compared in lowercase; both forward and backward slashes accepted).
 const PNPM_PATH_SEGMENT = 'pnpm/global/';
 const YARN_PATH_SEGMENTS = ['.config/yarn/global/', '/.yarn/global/'];
-const BUN_PATH_SEGMENT = '.bun/install/global/';
+const BUN_PATH_SEGMENTS = ['/.bun/install/global/', '/.bun/node_modules/'];
 // Homebrew installs formulae under its Cellar directory. Avoid matching the
 // broader /homebrew/ prefix — on Apple Silicon, npm itself lives under
 // /opt/homebrew/, so `npm install -g` paths also contain /homebrew/.
@@ -60,7 +60,9 @@ export function classifyByPathHeuristic(packageRoot: string): InstallSource | nu
   for (const seg of YARN_PATH_SEGMENTS) {
     if (normalized.includes(seg)) return 'yarn-global';
   }
-  if (normalized.includes(BUN_PATH_SEGMENT)) return 'bun-global';
+  for (const seg of BUN_PATH_SEGMENTS) {
+    if (normalized.includes(seg)) return 'bun-global';
+  }
   if (normalized.includes(HOMEBREW_PATH_SEGMENT)) return 'homebrew';
   return null;
 }

--- a/apps/kimi-code/test/cli/update/source.test.ts
+++ b/apps/kimi-code/test/cli/update/source.test.ts
@@ -41,10 +41,22 @@ describe('classifyByPathHeuristic', () => {
     ).toBe('yarn-global');
   });
 
-  it('detects bun global', () => {
+  it('detects bun global (install/global layout)', () => {
     expect(
       classifyByPathHeuristic('/Users/me/.bun/install/global/node_modules/@moonshot-ai/kimi-code'),
     ).toBe('bun-global');
+  });
+
+  it('detects bun global (node_modules layout)', () => {
+    expect(
+      classifyByPathHeuristic('/Users/me/.bun/node_modules/@moonshot-ai/kimi-code'),
+    ).toBe('bun-global');
+  });
+
+  it('does not treat a local project named foo.bun as bun global', () => {
+    expect(
+      classifyByPathHeuristic('/work/foo.bun/node_modules/@moonshot-ai/kimi-code'),
+    ).toBeNull();
   });
 
   it('detects homebrew on macOS (Cellar path)', () => {
@@ -108,10 +120,21 @@ describe('detectInstallSource', () => {
     ).resolves.toBe('yarn-global');
   });
 
-  it('returns bun-global when packageRoot matches bun heuristic', async () => {
+  it('returns bun-global when packageRoot matches bun heuristic (install/global layout)', async () => {
     await expect(
       detectInstallSource({
         getPackageRoot: () => '/Users/me/.bun/install/global/node_modules/@moonshot-ai/kimi-code',
+        getGlobalPrefix: async () => '/usr/local',
+        detectNative: () => false,
+        platform: 'darwin',
+      }),
+    ).resolves.toBe('bun-global');
+  });
+
+  it('returns bun-global when packageRoot matches bun heuristic (node_modules layout)', async () => {
+    await expect(
+      detectInstallSource({
+        getPackageRoot: () => '/Users/me/.bun/node_modules/@moonshot-ai/kimi-code',
         getGlobalPrefix: async () => '/usr/local',
         detectNative: () => false,
         platform: 'darwin',


### PR DESCRIPTION
## Related Issue

Discovered while investigating a user report that starting the TUI shows "Detected install source: unsupported package manager or layout" for a bun global installation.

## Problem
```
bw@bws-MacBook-Pro kimi-code % bun list -g | grep kimi
├── @moonshot-ai/kimi-code@0.29.2
bw@bws-MacBook-Pro kimi-code % kimi update
A newer version of @moonshot-ai/kimi-code is available (0.29.2 -> 0.31.0).
Detected install source: unsupported package manager or layout.
To update manually, run: npm install -g @moonshot-ai/kimi-code@0.31.
```


With installed `kimi` cli via `bun` with newer bun 1.3.x+ layout, the `kimi` or `kimi update` throws warning messages for "Detected install source: unsupported package manager or layout" .

Recent versions of bun install global packages under `~/.bun/node_modules/<pkg>` and create a shim in `~/.bun/bin/`. Kimi Code's install-source detection only recognized the older `~/.bun/install/global/node_modules/<pkg>` layout, so bun global installs were misclassified as `unsupported`. This caused:

- The startup warning `Detected install source: unsupported package manager or layout.`
- `kimi upgrade` falling back to a manual npm command instead of using `bun add -g`.

Both layouts are valid bun global installs and expose the CLI through `~/.bun/bin/`:

```text
# Legacy layout expected by the old code
~/.bun/
├── bin/
│   └── kimi -> ../../install/global/node_modules/@moonshot-ai/kimi-code/dist/main.mjs
└── install/global/node_modules/
    └── @moonshot-ai/kimi-code/

# Current layout used by bun 1.3.14+
~/.bun/
├── bin/
│   └── kimi -> ../../node_modules/@moonshot-ai/kimi-code/dist/main.mjs
└── node_modules/
    └── @moonshot-ai/kimi-code/
```

## What changed

- Updated `apps/kimi-code/src/cli/update/source.ts` so the bun heuristic matches both the legacy `.bun/install/global/` path and the current `.bun/node_modules/` path.
- Added unit tests in `apps/kimi-code/test/cli/update/source.test.ts` covering the real-world `~/.bun/node_modules/@moonshot-ai/kimi-code` layout.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.
