### PR TITLE
fix(oauth): point exports to compiled dist/index.mjs

### DIFF
--- a/packages/oauth/package.json
+++ b/packages/oauth/package.json
@@ -31,7 +31,7 @@
   "exports": {
     ".": {
       "types": "./src/index.ts",
-      "default": "./src/index.ts"
+      "default": "./dist/index.mjs"
     }
   },
   "scripts": {


### PR DESCRIPTION
## Related Issue

Resolve #2292

## Problem

When kimi-code builds with `onlyBundle: false` (which externalizes all dependencies), Node.js fails to resolve the `@moonshot-ai/kimi-code-oauth` package at runtime with:

```
Error [ERR_MODULE_NOT_FOUND]: Cannot find module .../packages/oauth/src/errors imported from .../packages/oauth/src/index.ts
```

The root cause is that `packages/oauth/package.json` exports `"./src/index.ts"` as default, but at runtime Node directly loads this source file, which imports `./errors` without a file extension (Node ESM requires explicit extensions for relative imports).

All other workspace packages use the same export pattern but are not affected because their `src/index.ts` does not use bare extension-less relative imports.

## What changed

Changed `exports.default` in `packages/oauth/package.json` from `"./src/index.ts"` to `"./dist/index.mjs"` — the actual compiled output produced by tsdown. The `types` field remains pointing at the source for accurate TypeScript type-checking.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [ ] I have added tests that prove my feature works. *— existing test suite covers the oauth module.*
- [ ] Ran `gen-changesets` skill, or this PR needs no changeset.
- [ ] Ran `gen-docs` skill, or this PR needs no doc update.