### PR TITLE
fix(kap-server): classify localhost case-insensitively

### DIFF
--- a/.changeset/localhost-bind-classification.md
+++ b/.changeset/localhost-bind-classification.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Classify localhost bind hosts case-insensitively.

--- a/packages/kap-server/src/security/bindClassify.ts
+++ b/packages/kap-server/src/security/bindClassify.ts
@@ -88,10 +88,11 @@ function isLinkLocalV6(host: string): boolean {
  * resolve to a public address.
  */
 export function classify(host: string, opts?: ClassifyOptions): BindClass {
-  if (host === '' || host === '0.0.0.0' || host === '::') {
+  const normalizedHost = host.toLowerCase();
+  if (host === '' || normalizedHost === '0.0.0.0' || normalizedHost === '::') {
     return opts?.bindClass ?? 'public';
   }
-  if (host === 'localhost') {
+  if (normalizedHost === 'localhost') {
     return 'loopback';
   }
   const family = net.isIP(host);

--- a/packages/kap-server/test/bindClassify.test.ts
+++ b/packages/kap-server/test/bindClassify.test.ts
@@ -4,7 +4,7 @@ import { classify } from '../src/security/bindClassify';
 
 describe('classify', () => {
   describe('loopback', () => {
-    it.each([['127.0.0.1'], ['127.255.255.255'], ['::1'], ['localhost']])(
+    it.each([['127.0.0.1'], ['127.255.255.255'], ['::1'], ['localhost'], ['LOCALHOST']])(
       '%s → loopback',
       (host) => {
         expect(classify(host)).toBe('loopback');


### PR DESCRIPTION
## Related Issue
No linked issue.

## Problem
Bind-address classification treated `localhost` as loopback only when it was lowercase, even though hostnames are case-insensitive.

## What changed
Normalize hostnames before the localhost check and add coverage for uppercase `LOCALHOST`.

## Checklist
- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.
