### PR TITLE
fix(web): reject malformed port values

### DIFF
--- a/.changeset/strict-web-port-values.md
+++ b/.changeset/strict-web-port-values.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Reject malformed port values for the web server command.

--- a/apps/kimi-code/src/cli/sub/web/shared.ts
+++ b/apps/kimi-code/src/cli/sub/web/shared.ts
@@ -95,6 +95,9 @@ function parseHost(raw: string | boolean | undefined): string {
 
 export function parsePort(raw: string | undefined, label: string, fallback: number): number {
   if (raw === undefined) return fallback;
+  if (!/^\d+$/.test(raw)) {
+    throw new Error(`error: invalid ${label} value: ${raw}`);
+  }
   const n = Number.parseInt(raw, 10);
   if (!Number.isFinite(n) || n < 0 || n > 65535) {
     throw new Error(`error: invalid ${label} value: ${raw}`);

--- a/apps/kimi-code/test/cli/web/web.test.ts
+++ b/apps/kimi-code/test/cli/web/web.test.ts
@@ -520,6 +520,8 @@ describe('shared parsers stay strict', () => {
     const { parsePort } = await import('#/cli/sub/web/shared');
     expect(() => parsePort('99999', '--port', 58627)).toThrow(/invalid --port/);
     expect(() => parsePort('-1', '--port', 58627)).toThrow(/invalid --port/);
+    expect(() => parsePort('123abc', '--port', 58627)).toThrow(/invalid --port/);
+    expect(() => parsePort('1.5', '--port', 58627)).toThrow(/invalid --port/);
     expect(parsePort(undefined, '--port', 58627)).toBe(58627);
     expect(parsePort('8080', '--port', 58627)).toBe(8080);
   });


### PR DESCRIPTION
## Related Issue
No linked issue.

## Problem
`kimi web --port` accepted partially numeric values like `123abc` because the parser used prefix parsing.

## What changed
Require the port value to contain only digits before converting it, and add CLI parser coverage for malformed values.

## Checklist
- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.
