### PR TITLE
fix(oauth): normalize device timing fields

### DIFF
--- a/.changeset/oauth-device-timing-fields.md
+++ b/.changeset/oauth-device-timing-fields.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Handle invalid OAuth device authorization timing fields safely.

--- a/packages/oauth/src/oauth.ts
+++ b/packages/oauth/src/oauth.ts
@@ -53,6 +53,13 @@ function tokenFromResponse(payload: Record<string, unknown>): TokenInfo {
   };
 }
 
+function positiveNumber(value: unknown): number | undefined {
+  if (typeof value !== 'number' && typeof value !== 'string') return undefined;
+  if (typeof value === 'string' && value.trim().length === 0) return undefined;
+  const n = Number(value);
+  return Number.isFinite(n) && n > 0 ? n : undefined;
+}
+
 /** HTTP client default timeout for OAuth requests. */
 const DEFAULT_HTTP_TIMEOUT_MS = 30_000;
 
@@ -152,8 +159,8 @@ export async function requestDeviceAuthorization(
     deviceCode,
     verificationUri: typeof data['verification_uri'] === 'string' ? data['verification_uri'] : '',
     verificationUriComplete,
-    expiresIn: data['expires_in'] !== undefined ? Number(data['expires_in']) : null,
-    interval: Number(data['interval'] ?? 5),
+    expiresIn: positiveNumber(data['expires_in']) ?? null,
+    interval: positiveNumber(data['interval']) ?? 5,
   };
 }
 

--- a/packages/oauth/test/oauth.test.ts
+++ b/packages/oauth/test/oauth.test.ts
@@ -264,6 +264,22 @@ describe('requestDeviceAuthorization', () => {
     expect(auth.interval).toBe(5);
   });
 
+  it('normalizes invalid timing fields from device authorization responses', async () => {
+    server.enqueue('/api/oauth/device_authorization', {
+      status: 200,
+      body: {
+        user_code: 'U',
+        device_code: 'D',
+        verification_uri_complete: 'https://x/y',
+        expires_in: true,
+        interval: 'soon',
+      },
+    });
+    const auth = await requestAuth();
+    expect(auth.expiresIn).toBeNull();
+    expect(auth.interval).toBe(5);
+  });
+
   it('throws OAuthError on non-200 response', async () => {
     server.enqueue('/api/oauth/device_authorization', {
       status: 500,


### PR DESCRIPTION
## Related Issue
No linked issue.

## Problem
Invalid OAuth device authorization `expires_in` or `interval` values could become `NaN`, which would pollute login timing behavior.

## What changed
Normalize timing fields to positive numbers only, fall back to safe defaults for invalid values, and add coverage for malformed responses.

## Checklist
- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.
