### PR TITLE
fix(vis): reject malformed port values

### DIFF
--- a/.changeset/strict-vis-port-values.md
+++ b/.changeset/strict-vis-port-values.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Reject malformed port values for the session visualizer command.

--- a/apps/kimi-code/src/cli/sub/vis.ts
+++ b/apps/kimi-code/src/cli/sub/vis.ts
@@ -113,15 +113,26 @@ export function registerVisCommand(parent: Command, overrides?: Partial<VisDeps>
         sessionId: string | undefined,
         options: { port?: string; host?: string; open?: boolean },
       ) => {
-        const port = options.port === undefined ? undefined : Number.parseInt(options.port, 10);
         await handleVis(createDefaultVisDeps(overrides), {
           open: options.open !== false,
-          ...(port === undefined || Number.isNaN(port) ? {} : { port }),
-          ...(options.host === undefined ? {} : { host: options.host }),
-          ...(sessionId === undefined ? {} : { sessionId }),
+          port: parseVisPort(options.port),
+          host: options.host,
+          sessionId,
         });
       },
     );
+}
+
+export function parseVisPort(raw: string | undefined): number | undefined {
+  if (raw === undefined) return undefined;
+  if (!/^\d+$/.test(raw)) {
+    throw new Error(`error: invalid --port value: ${raw}`);
+  }
+  const port = Number.parseInt(raw, 10);
+  if (!Number.isFinite(port) || port < 0 || port > 65535) {
+    throw new Error(`error: invalid --port value: ${raw}`);
+  }
+  return port;
 }
 
 function createDefaultVisDeps(overrides: Partial<VisDeps> = {}): VisDeps {

--- a/apps/kimi-code/test/cli/vis.test.ts
+++ b/apps/kimi-code/test/cli/vis.test.ts
@@ -9,7 +9,7 @@
 
 import { describe, it, expect, vi } from 'vitest';
 
-import { handleVis, type VisDeps } from '#/cli/sub/vis';
+import { handleVis, parseVisPort, type VisDeps } from '#/cli/sub/vis';
 
 function makeDeps(over: Partial<VisDeps> = {}): {
   deps: VisDeps;
@@ -110,5 +110,15 @@ describe('handleVis', () => {
     // Nothing past the failed start should run.
     expect(opened).toEqual([]);
     expect(deps.waitForShutdown).not.toHaveBeenCalled();
+  });
+});
+
+describe('parseVisPort', () => {
+  it('rejects malformed port values', () => {
+    expect(parseVisPort(undefined)).toBeUndefined();
+    expect(parseVisPort('8080')).toBe(8080);
+    expect(() => parseVisPort('123abc')).toThrow(/invalid --port/);
+    expect(() => parseVisPort('1.5')).toThrow(/invalid --port/);
+    expect(() => parseVisPort('99999')).toThrow(/invalid --port/);
   });
 });


### PR DESCRIPTION
## Related Issue
No linked issue.

## Problem
`kimi vis --port` silently ignored or partially accepted malformed port values, making invalid input hard to notice.

## What changed
Add a strict visualizer port parser, pass parsed options directly into `handleVis`, and cover malformed and out-of-range values.

## Checklist
- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.
