### PR TITLE
fix(tui): reject malformed COLORFGBG indexes

### DIFF
--- a/.changeset/strict-colorfgbg-background.md
+++ b/.changeset/strict-colorfgbg-background.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Ignore malformed COLORFGBG background color indexes during terminal theme detection.

--- a/apps/kimi-code/src/tui/theme/detect.ts
+++ b/apps/kimi-code/src/tui/theme/detect.ts
@@ -113,7 +113,8 @@ export function parseColorFgBg(value: string | undefined): ResolvedTheme | null 
   const parts = value.split(";");
   const bgRaw = parts.at(-1);
   if (bgRaw === undefined) return null;
-  const bg = parseInt(bgRaw, 10);
+  if (!/^\d+$/.test(bgRaw)) return null;
+  const bg = Number.parseInt(bgRaw, 10);
   if (!Number.isInteger(bg)) return null;
   // ANSI 0=black, 1=red, 2=green, 3=yellow, 4=blue, 5=magenta, 6=cyan, 8=bright black.
   const darkBgs = new Set([0, 1, 2, 3, 4, 5, 6, 8]);

--- a/apps/kimi-code/test/tui/terminal-theme.test.ts
+++ b/apps/kimi-code/test/tui/terminal-theme.test.ts
@@ -15,6 +15,7 @@ import {
   handleTerminalThemeInput,
   installTerminalThemeTracking,
 } from "#/tui/utils/terminal-theme";
+import { parseColorFgBg } from "#/tui/theme/detect";
 
 type InputListener = Parameters<TUIState["ui"]["addInputListener"]>[0];
 const DARK_OSC11_REPORT = "\u001B]11;rgb:2828/2c2c/3434\u0007";
@@ -171,5 +172,13 @@ describe('ColorPalette warning token', () => {
   it('resolves the correct palette by theme name', () => {
     expect(getBuiltInPalette('dark')).toBe(darkColors);
     expect(getBuiltInPalette('light')).toBe(lightColors);
+  });
+});
+
+describe("parseColorFgBg", () => {
+  it("rejects malformed background color indexes", () => {
+    expect(parseColorFgBg("0;9")).toBe("light");
+    expect(parseColorFgBg("0;9abc")).toBeNull();
+    expect(parseColorFgBg("0;1.5")).toBeNull();
   });
 });


### PR DESCRIPTION
## Related Issue
No linked issue.

## Problem
Terminal theme detection could treat malformed `COLORFGBG` background indexes like `9abc` as valid because parsing stopped at the numeric prefix.

## What changed
Require the background color index to be fully numeric before resolving the fallback theme, and add unit coverage for malformed values.

## Checklist
- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.
