### PR TITLE
fix(agent-core-v2): resolve plugin-qualified skill names

### DIFF
--- a/.changeset/qualified-plugin-skills.md
+++ b/.changeset/qualified-plugin-skills.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Fix plugin-qualified Skill invocation and report ambiguous bare plugin Skill names.

--- a/.changeset/qualified-plugin-skills.md
+++ b/.changeset/qualified-plugin-skills.md
@@ -2,4 +2,4 @@
 "@moonshot-ai/kimi-code": patch
 ---
 
-Fix plugin-qualified Skill invocation and report ambiguous bare plugin Skill names.
+Fix plugin-qualified Skill listing and invocation, and report ambiguous bare plugin Skill names.

--- a/apps/kimi-code/test/tui/commands/resolve.test.ts
+++ b/apps/kimi-code/test/tui/commands/resolve.test.ts
@@ -196,12 +196,21 @@ describe('resolveSlashCommandInput', () => {
   });
 
   it('resolves skill commands and blocks them while busy', () => {
-    const skillCommandMap = new Map([['skill:review', 'review']]);
+    const skillCommandMap = new Map([
+      ['skill:review', 'review'],
+      ['skill:alpha-plugin:review', 'alpha-plugin:review'],
+    ]);
 
     expect(resolve('/skill:review src/app.ts', { skillCommandMap })).toEqual({
       kind: 'skill',
       commandName: 'skill:review',
       skillName: 'review',
+      args: 'src/app.ts',
+    });
+    expect(resolve('/skill:alpha-plugin:review src/app.ts', { skillCommandMap })).toEqual({
+      kind: 'skill',
+      commandName: 'skill:alpha-plugin:review',
+      skillName: 'alpha-plugin:review',
       args: 'src/app.ts',
     });
     expect(resolve('/skill:review src/app.ts', { skillCommandMap, isStreaming: true })).toEqual({

--- a/apps/kimi-code/test/tui/commands/skills.test.ts
+++ b/apps/kimi-code/test/tui/commands/skills.test.ts
@@ -91,6 +91,17 @@ describe('skill slash commands', () => {
     expect(built.commandMap.get('mcp-config')).toBe('mcp-config');
   });
 
+  it('preserves a qualified plugin name through the slash-command map', () => {
+    const built = buildSkillSlashCommands([
+      skill('alpha-plugin:review', 'prompt', { source: 'extra' }),
+    ]);
+
+    expect(built.commands.map((command) => command.name)).toEqual([
+      'skill:alpha-plugin:review',
+    ]);
+    expect(built.commandMap.get('skill:alpha-plugin:review')).toBe('alpha-plugin:review');
+  });
+
   it('keeps sub-skills slash-invocable', () => {
     const built = buildSkillSlashCommands([
       skill('outer.inner', 'prompt', {

--- a/packages/agent-core-v2/docs/state-manifest.d.ts
+++ b/packages/agent-core-v2/docs/state-manifest.d.ts
@@ -1044,7 +1044,7 @@ export interface AgentStateSnapshot {
   'llmRequester.lastConfigLogSignature': string | undefined;
   'llmRequester.mediaDegradedTurns': Set<number>;
   'llmRequester.mediaStrippedTurns': Map<number, /* MediaStripSnapshot — packages/agent-core-v2/src/agent/contextProjector/contextProjector.ts */ {
-    readonly "__@mediaStripSnapshotBrand@2682": undefined;
+    readonly "__@mediaStripSnapshotBrand@2681": undefined;
   }>;
   'llmRequester.turnConfigs': Map<number, /* TurnRequestConfig — packages/agent-core-v2/src/agent/llmRequester/llmRequesterService.ts */ {
     readonly resolved: /* ProfileModelContext — packages/agent-core-v2/src/agent/profile/profile.ts */ {

--- a/packages/agent-core-v2/docs/state-manifest.d.ts
+++ b/packages/agent-core-v2/docs/state-manifest.d.ts
@@ -497,6 +497,40 @@ export interface SessionStateSnapshot {
       readonly mermaid?: string;
       readonly d2?: string;
     } | undefined;
+    resolveSkill: (name: string) => /* SkillResolution — packages/agent-core-v2/src/app/skillCatalog/types.ts */ {
+      readonly kind: 'resolved';
+      readonly skill: /* SkillDefinition — packages/agent-core-v2/src/app/skillCatalog/types.ts */ {
+        readonly name: string;
+        readonly description: string;
+        readonly path: string;
+        readonly dir: string;
+        readonly content: string;
+        readonly metadata: /* SkillMetadata — packages/agent-core-v2/src/app/skillCatalog/types.ts */ {
+          readonly name?: string;
+          readonly description?: string;
+          readonly type?: string;
+          readonly whenToUse?: string;
+          readonly disableModelInvocation?: boolean;
+          readonly isSubSkill?: boolean;
+          readonly safe?: boolean;
+          readonly arguments?: string | readonly unknown[];
+          [key: string]: unknown;
+        };
+        readonly source: /* SkillSource — packages/agent-core-v2/src/app/skillCatalog/types.ts */ 'project' | 'user' | 'extra' | 'builtin';
+        readonly plugin?: /* SkillPluginContext — packages/agent-core-v2/src/app/skillCatalog/types.ts */ {
+          readonly id: string;
+          readonly instructions?: string;
+        };
+        readonly mermaid?: string;
+        readonly d2?: string;
+      };
+      readonly canonicalName: string;
+    } | {
+      readonly kind: 'not-found';
+    } | {
+      readonly kind: 'ambiguous';
+      readonly candidates: readonly string[];
+    };
     renderSkillPrompt: (skill: /* SkillDefinition — packages/agent-core-v2/src/app/skillCatalog/types.ts */ {
       readonly name: string;
       readonly description: string;
@@ -1010,7 +1044,7 @@ export interface AgentStateSnapshot {
   'llmRequester.lastConfigLogSignature': string | undefined;
   'llmRequester.mediaDegradedTurns': Set<number>;
   'llmRequester.mediaStrippedTurns': Map<number, /* MediaStripSnapshot — packages/agent-core-v2/src/agent/contextProjector/contextProjector.ts */ {
-    readonly "__@mediaStripSnapshotBrand@2667": undefined;
+    readonly "__@mediaStripSnapshotBrand@2682": undefined;
   }>;
   'llmRequester.turnConfigs': Map<number, /* TurnRequestConfig — packages/agent-core-v2/src/agent/llmRequester/llmRequesterService.ts */ {
     readonly resolved: /* ProfileModelContext — packages/agent-core-v2/src/agent/profile/profile.ts */ {

--- a/packages/agent-core-v2/src/agent/skill/skillService.ts
+++ b/packages/agent-core-v2/src/agent/skill/skillService.ts
@@ -21,7 +21,11 @@ import { renderUserSlashSkillPrompt } from './prompt';
 import { ISessionContext } from '#/session/sessionContext/sessionContext';
 import { Disposable } from '#/_base/di/lifecycle';
 import { ErrorCodes, Error2 } from '#/errors';
-import { isUserActivatableSkillType, type SkillDefinition } from '#/app/skillCatalog/types';
+import {
+  formatAmbiguousSkillMessage,
+  isUserActivatableSkillType,
+  type SkillDefinition,
+} from '#/app/skillCatalog/types';
 import { IAgentPromptService } from '#/agent/prompt/prompt';
 import { ITelemetryService } from '#/app/telemetry/telemetry';
 import type { Turn } from '#/agent/loop/loop';
@@ -45,14 +49,21 @@ export class AgentSkillService extends Disposable implements IAgentSkillService 
 
   async activate(input: SkillActivationInput): Promise<Turn> {
     await this.skillCatalog.ready;
-    const skill = this.skillCatalog.catalog.getSkill(input.name);
-    if (skill === undefined) {
+    const resolution = this.skillCatalog.catalog.resolveSkill(input.name);
+    if (resolution.kind === 'not-found') {
       throw new Error2(ErrorCodes.SKILL_NOT_FOUND, `Skill "${input.name}" was not found`);
     }
+    if (resolution.kind === 'ambiguous') {
+      throw new Error2(
+        ErrorCodes.SKILL_NOT_FOUND,
+        formatAmbiguousSkillMessage(input.name, resolution.candidates),
+      );
+    }
+    const { canonicalName, skill } = resolution;
     if (!isUserActivatableSkillType(skill.metadata.type)) {
       throw new Error2(
         ErrorCodes.SKILL_TYPE_UNSUPPORTED,
-        `Skill "${skill.name}" cannot be activated by the user`,
+        `Skill "${canonicalName}" cannot be activated by the user`,
       );
     }
 
@@ -62,7 +73,7 @@ export class AgentSkillService extends Disposable implements IAgentSkillService 
       {
         type: 'text',
         text: renderUserSlashSkillPrompt({
-          skillName: skill.name,
+          skillName: canonicalName,
           skillArgs,
           skillContent,
           skillSource: skill.source,
@@ -75,7 +86,7 @@ export class AgentSkillService extends Disposable implements IAgentSkillService 
       {
         kind: 'skill_activation',
         activationId: randomUUID(),
-        skillName: skill.name,
+        skillName: canonicalName,
         trigger: 'user-slash',
         skillType: skill.metadata.type,
         skillPath: skill.path,

--- a/packages/agent-core-v2/src/agent/tools/skill/skillTool.ts
+++ b/packages/agent-core-v2/src/agent/tools/skill/skillTool.ts
@@ -26,7 +26,7 @@ import { IAgentSkillService } from '#/agent/skill/skill';
 import { renderModelToolSkillPrompt } from '#/agent/skill/prompt';
 import type { ExecutableToolResult, ToolDeliveryMessage, ToolExecution } from '#/tool/toolContract';
 import { registerAgentToolService } from '#/agent/toolRegistry/toolContribution';
-import { isInlineSkillType } from '#/app/skillCatalog/types';
+import { formatAmbiguousSkillMessage, isInlineSkillType } from '#/app/skillCatalog/types';
 import { ISessionSkillCatalog } from '#/session/sessionSkillCatalog/skillCatalog';
 import { ISessionContext } from '#/session/sessionContext/sessionContext';
 import { renderPrompt } from '#/_base/utils/render-prompt';
@@ -100,18 +100,22 @@ export async function executeModelSkill(
   }
 
   await catalog.ready;
-  const skill = catalog.catalog.getSkill(args.skill);
-  if (skill === undefined) {
+  const resolution = catalog.catalog.resolveSkill(args.skill);
+  if (resolution.kind === 'not-found') {
     return errorResult(`Skill "${args.skill}" not found in the current skill listing.`);
   }
+  if (resolution.kind === 'ambiguous') {
+    return errorResult(formatAmbiguousSkillMessage(args.skill, resolution.candidates));
+  }
+  const { canonicalName, skill } = resolution;
   if (skill.metadata.disableModelInvocation === true) {
     return errorResult(
-      `Skill "${args.skill}" can only be triggered by the user (model invocation is disabled).`,
+      `Skill "${canonicalName}" can only be triggered by the user (model invocation is disabled).`,
     );
   }
   if (!isInlineSkillType(skill.metadata.type)) {
     return errorResult(
-      `Skill "${skill.name}" is not an inline skill and cannot be invoked by the model in v1.`,
+      `Skill "${canonicalName}" is not an inline skill and cannot be invoked by the model in v1.`,
     );
   }
 
@@ -120,7 +124,7 @@ export async function executeModelSkill(
   const origin: SkillActivationOrigin = {
     kind: 'skill_activation',
     activationId: randomUUID(),
-    skillName: skill.name,
+    skillName: canonicalName,
     skillArgs: skillArgs.length > 0 ? skillArgs : undefined,
     trigger,
     skillType: skill.metadata.type,
@@ -134,7 +138,7 @@ export async function executeModelSkill(
       {
         type: 'text',
         text: renderModelToolSkillPrompt({
-          skillName: skill.name,
+          skillName: canonicalName,
           skillArgs,
           skillContent,
           skillSource: skill.source,
@@ -148,7 +152,7 @@ export async function executeModelSkill(
   };
   skillService.recordModelToolActivation(origin);
   return {
-    output: `Skill "${skill.name}" loaded inline. Follow its instructions.`,
+    output: `Skill "${canonicalName}" loaded inline. Follow its instructions.`,
     delivery: { kind: 'steer', message },
   };
 }

--- a/packages/agent-core-v2/src/app/skillCatalog/registry.ts
+++ b/packages/agent-core-v2/src/app/skillCatalog/registry.ts
@@ -15,10 +15,11 @@ import type {
   SkillCatalog,
   SkillDefinition,
   SkillMetadata,
+  SkillResolution,
   SkillSource,
   SkippedSkill,
 } from './types';
-import { isInlineSkillType, normalizeSkillName } from './types';
+import { canonicalSkillName, isInlineSkillType, normalizeSkillName } from './types';
 
 const LISTING_DESC_MAX = 250;
 
@@ -68,6 +69,42 @@ export class InMemorySkillCatalog implements SkillCatalog {
     return this.byPluginAndName.get(pluginSkillKey(pluginId, name));
   }
 
+  resolveSkill(name: string): SkillResolution {
+    const separator = name.indexOf(':');
+    if (separator > 0 && separator < name.length - 1) {
+      const pluginSkill = this.getPluginSkill(
+        name.slice(0, separator),
+        name.slice(separator + 1),
+      );
+      if (pluginSkill !== undefined) {
+        return {
+          kind: 'resolved',
+          skill: pluginSkill,
+          canonicalName: canonicalSkillName(pluginSkill),
+        };
+      }
+    }
+
+    const skill = this.getSkill(name);
+    if (skill === undefined) return { kind: 'not-found' };
+    if (skill.plugin === undefined) {
+      return { kind: 'resolved', skill, canonicalName: skill.name };
+    }
+
+    const candidates = this.pluginSkillsNamed(name);
+    if (candidates.length > 1) {
+      return {
+        kind: 'ambiguous',
+        candidates: candidates.map(canonicalSkillName),
+      };
+    }
+    return {
+      kind: 'resolved',
+      skill,
+      canonicalName: canonicalSkillName(skill),
+    };
+  }
+
   renderSkillPrompt(
     skill: SkillDefinition,
     rawArgs: string,
@@ -95,10 +132,12 @@ export class InMemorySkillCatalog implements SkillCatalog {
   }
 
   listInvocableSkills(): readonly SkillDefinition[] {
-    return this.listSkills().filter(
-      (skill) =>
-        skill.metadata.disableModelInvocation !== true && isInlineSkillType(skill.metadata.type),
-    );
+    return this.listInvocationCandidates()
+      .filter(
+        (skill) =>
+          skill.metadata.disableModelInvocation !== true && isInlineSkillType(skill.metadata.type),
+      )
+      .toSorted((a, b) => canonicalSkillName(a).localeCompare(canonicalSkillName(b)));
   }
 
   getSkillRoots(): readonly string[] {
@@ -135,6 +174,20 @@ export class InMemorySkillCatalog implements SkillCatalog {
     if (options.replace === true || !this.byPluginAndName.has(key)) {
       this.byPluginAndName.set(key, skill);
     }
+  }
+
+  private listInvocationCandidates(): readonly SkillDefinition[] {
+    return [
+      ...[...this.byName.values()].filter((skill) => skill.plugin === undefined),
+      ...this.byPluginAndName.values(),
+    ];
+  }
+
+  private pluginSkillsNamed(name: string): readonly SkillDefinition[] {
+    const normalizedName = normalizeSkillName(name);
+    return [...this.byPluginAndName.values()]
+      .filter((skill) => normalizeSkillName(skill.name) === normalizedName)
+      .toSorted((a, b) => canonicalSkillName(a).localeCompare(canonicalSkillName(b)));
   }
 }
 
@@ -225,7 +278,9 @@ function formatFullSkill(skill: SkillDefinition): readonly string[] {
 }
 
 function formatModelSkill(skill: SkillDefinition): readonly string[] {
-  const lines = [`- ${skill.name}: ${truncate(skill.description, LISTING_DESC_MAX)}`];
+  const lines = [
+    `- ${canonicalSkillName(skill)}: ${truncate(skill.description, LISTING_DESC_MAX)}`,
+  ];
   if (typeof skill.metadata.whenToUse === 'string' && skill.metadata.whenToUse.length > 0) {
     lines.push(`  When to use: ${skill.metadata.whenToUse}`);
   }

--- a/packages/agent-core-v2/src/app/skillCatalog/registry.ts
+++ b/packages/agent-core-v2/src/app/skillCatalog/registry.ts
@@ -128,16 +128,17 @@ export class InMemorySkillCatalog implements SkillCatalog {
   }
 
   listSkills(): readonly SkillDefinition[] {
-    return [...this.byName.values()].toSorted((a, b) => a.name.localeCompare(b.name));
+    return [
+      ...[...this.byName.values()].filter((skill) => skill.plugin === undefined),
+      ...this.byPluginAndName.values(),
+    ].toSorted((a, b) => canonicalSkillName(a).localeCompare(canonicalSkillName(b)));
   }
 
   listInvocableSkills(): readonly SkillDefinition[] {
-    return this.listInvocationCandidates()
-      .filter(
-        (skill) =>
-          skill.metadata.disableModelInvocation !== true && isInlineSkillType(skill.metadata.type),
-      )
-      .toSorted((a, b) => canonicalSkillName(a).localeCompare(canonicalSkillName(b)));
+    return this.listSkills().filter(
+      (skill) =>
+        skill.metadata.disableModelInvocation !== true && isInlineSkillType(skill.metadata.type),
+    );
   }
 
   getSkillRoots(): readonly string[] {
@@ -174,13 +175,6 @@ export class InMemorySkillCatalog implements SkillCatalog {
     if (options.replace === true || !this.byPluginAndName.has(key)) {
       this.byPluginAndName.set(key, skill);
     }
-  }
-
-  private listInvocationCandidates(): readonly SkillDefinition[] {
-    return [
-      ...[...this.byName.values()].filter((skill) => skill.plugin === undefined),
-      ...this.byPluginAndName.values(),
-    ];
   }
 
   private pluginSkillsNamed(name: string): readonly SkillDefinition[] {
@@ -274,7 +268,11 @@ function renderGroupedSkills(
 }
 
 function formatFullSkill(skill: SkillDefinition): readonly string[] {
-  return [`- ${skill.name}`, `  - Path: ${skill.path}`, `  - Description: ${skill.description}`];
+  return [
+    `- ${canonicalSkillName(skill)}`,
+    `  - Path: ${skill.path}`,
+    `  - Description: ${skill.description}`,
+  ];
 }
 
 function formatModelSkill(skill: SkillDefinition): readonly string[] {

--- a/packages/agent-core-v2/src/app/skillCatalog/types.ts
+++ b/packages/agent-core-v2/src/app/skillCatalog/types.ts
@@ -46,6 +46,18 @@ export interface SkillPluginContext {
   readonly instructions?: string;
 }
 
+export type SkillResolution =
+  | {
+      readonly kind: 'resolved';
+      readonly skill: SkillDefinition;
+      readonly canonicalName: string;
+    }
+  | { readonly kind: 'not-found' }
+  | {
+      readonly kind: 'ambiguous';
+      readonly candidates: readonly string[];
+    };
+
 export interface SkippedSkill {
   readonly path: string;
   readonly type: string;
@@ -55,6 +67,7 @@ export interface SkippedSkill {
 export interface SkillCatalog {
   getSkill(name: string): SkillDefinition | undefined;
   getPluginSkill(pluginId: string, name: string): SkillDefinition | undefined;
+  resolveSkill(name: string): SkillResolution;
   renderSkillPrompt(
     skill: SkillDefinition,
     rawArgs: string,
@@ -69,6 +82,17 @@ export interface SkillCatalog {
 
 export function normalizeSkillName(name: string): string {
   return name.toLowerCase();
+}
+
+export function canonicalSkillName(skill: SkillDefinition): string {
+  return skill.plugin === undefined ? skill.name : `${skill.plugin.id}:${skill.name}`;
+}
+
+export function formatAmbiguousSkillMessage(
+  name: string,
+  candidates: readonly string[],
+): string {
+  return `Skill "${name}" is ambiguous. Use one of these qualified names: ${candidates.map((candidate) => `"${candidate}"`).join(', ')}.`;
 }
 
 export function isInlineSkillType(type: string | undefined): boolean {

--- a/packages/agent-core-v2/test/agent/skill/skill.test.ts
+++ b/packages/agent-core-v2/test/agent/skill/skill.test.ts
@@ -33,6 +33,19 @@ const COMMIT_SKILL = stubSkill('commit', {
   source: 'user',
 });
 
+function pluginSkill(pluginId: string, name: string) {
+  const dir = `/plugins/${pluginId}/skills/${name}`;
+  return stubSkill(name, {
+    description: `${pluginId} ${name}`,
+    path: `${dir}/SKILL.md`,
+    dir,
+    content: `# ${pluginId} ${name}`,
+    metadata: {},
+    source: 'extra',
+    plugin: { id: pluginId },
+  });
+}
+
 function stubSessionContext(sessionId = 'test-session'): ISessionContext {
   return {
     _serviceBrand: undefined,
@@ -106,6 +119,34 @@ describe('AgentSkillService', () => {
       kind: 'skill_activation',
       skillName: 'commit',
     });
+  });
+
+  it('activate resolves a plugin-qualified skill and records its canonical name', async () => {
+    skills.register(pluginSkill('example-plugin', 'diagnose'));
+    const svc = ix.get(IAgentSkillService);
+
+    await svc.activate({ name: 'example-plugin:diagnose' });
+
+    expect(prompted).toHaveLength(1);
+    expect(prompted[0]!.origin).toMatchObject({
+      kind: 'skill_activation',
+      skillName: 'example-plugin:diagnose',
+    });
+    expect(prompted[0]!.content[0]).toMatchObject({
+      type: 'text',
+      text: expect.stringContaining('name="example-plugin:diagnose"'),
+    });
+  });
+
+  it('activate rejects an ambiguous bare plugin skill name with qualified candidates', async () => {
+    skills.register(pluginSkill('beta', 'review'));
+    skills.register(pluginSkill('alpha', 'review'));
+    const svc = ix.get(IAgentSkillService);
+
+    await expect(svc.activate({ name: 'review' })).rejects.toThrow(
+      'Skill "review" is ambiguous. Use one of these qualified names: "alpha:review", "beta:review".',
+    );
+    expect(prompted).toHaveLength(0);
   });
 
   it('activate throws for an unknown skill', async () => {
@@ -248,6 +289,44 @@ describe('SkillTool', () => {
     expect(result).toMatchObject({
       isError: true,
       output: 'Skill "missing" not found in the current skill listing.',
+    });
+  });
+
+  it('loads a plugin skill by its qualified name', async () => {
+    skills.register(pluginSkill('example-plugin', 'diagnose'));
+
+    const result = await executeTool(
+      makeTool(ix),
+      toolContext({ skill: 'example-plugin:diagnose' }),
+    );
+
+    expect(result).toMatchObject({
+      output:
+        'Skill "example-plugin:diagnose" loaded inline. Follow its instructions.',
+    });
+    expect(result.delivery?.message.origin).toMatchObject({
+      kind: 'skill_activation',
+      skillName: 'example-plugin:diagnose',
+    });
+    expect(result.delivery?.message.content[0]).toMatchObject({
+      type: 'text',
+      text: expect.stringContaining('name="example-plugin:diagnose"'),
+    });
+  });
+
+  it('returns qualified candidates for an ambiguous bare plugin skill name', async () => {
+    skills.register(pluginSkill('beta', 'review'));
+    skills.register(pluginSkill('alpha', 'review'));
+
+    const result = await executeTool(
+      makeTool(ix),
+      toolContext({ skill: 'review' }),
+    );
+
+    expect(result).toEqual({
+      isError: true,
+      output:
+        'Skill "review" is ambiguous. Use one of these qualified names: "alpha:review", "beta:review".',
     });
   });
 

--- a/packages/agent-core-v2/test/app/sessionLifecycle/sessionLifecycle.test.ts
+++ b/packages/agent-core-v2/test/app/sessionLifecycle/sessionLifecycle.test.ts
@@ -141,6 +141,7 @@ function skillCatalogStub(): ISessionSkillCatalog {
     catalog: {
       getSkill: () => undefined,
       getPluginSkill: () => undefined,
+      resolveSkill: () => ({ kind: 'not-found' }),
       renderSkillPrompt: () => '',
       listSkills: () => [],
       listInvocableSkills: () => [],

--- a/packages/agent-core-v2/test/app/skillCatalog/registry.test.ts
+++ b/packages/agent-core-v2/test/app/skillCatalog/registry.test.ts
@@ -129,6 +129,19 @@ describe('InMemorySkillCatalog model skill listing', () => {
     expect(rendered).not.toContain('sub-step');
   });
 
+  it('lists every plugin skill by its canonical invocation name', () => {
+    const registry = makeRegistry([
+      makeSkill('review', 'extra', 'Alpha review', undefined, { type: 'prompt' }, { id: 'alpha' }),
+      makeSkill('review', 'extra', 'Beta review', undefined, { type: 'prompt' }, { id: 'beta' }),
+    ]);
+
+    const rendered = registry.getModelSkillListing();
+
+    expect(rendered).toContain('- alpha:review: Alpha review');
+    expect(rendered).toContain('- beta:review: Beta review');
+    expect(rendered).not.toContain('\n- review:');
+  });
+
   it('returns an empty string when no skills are model-invocable', () => {
     const registry = makeRegistry([
       makeSkill('private', 'user', 'Private', undefined, {
@@ -357,6 +370,57 @@ describe('InMemorySkillCatalog plugin lookup', () => {
     expect(registry.getSkill('review')).toMatchObject({ description: 'second' });
     expect(registry.getPluginSkill('superpowers', 'review')).toMatchObject({
       description: 'second',
+    });
+  });
+
+  it('resolves a plugin-qualified name to the selected plugin skill', () => {
+    const registry = makeRegistry([
+      makeSkill('review', 'extra', 'Alpha review', undefined, {}, { id: 'alpha' }),
+      makeSkill('review', 'extra', 'Beta review', undefined, {}, { id: 'beta' }),
+    ]);
+
+    expect(registry.resolveSkill('beta:review')).toMatchObject({
+      kind: 'resolved',
+      canonicalName: 'beta:review',
+      skill: { description: 'Beta review', plugin: { id: 'beta' } },
+    });
+  });
+
+  it('keeps a bare plugin skill name as an alias when it has one candidate', () => {
+    const registry = makeRegistry([
+      makeSkill('review', 'extra', 'Plugin review', undefined, {}, { id: 'alpha' }),
+    ]);
+
+    expect(registry.resolveSkill('review')).toMatchObject({
+      kind: 'resolved',
+      canonicalName: 'alpha:review',
+      skill: { description: 'Plugin review' },
+    });
+  });
+
+  it('reports every qualified candidate for an ambiguous bare plugin skill name', () => {
+    const registry = makeRegistry([
+      makeSkill('review', 'extra', 'Beta review', undefined, {}, { id: 'beta' }),
+      makeSkill('review', 'extra', 'Alpha review', undefined, {}, { id: 'alpha' }),
+    ]);
+
+    expect(registry.resolveSkill('review')).toEqual({
+      kind: 'ambiguous',
+      candidates: ['alpha:review', 'beta:review'],
+    });
+  });
+
+  it('keeps the merged non-plugin winner available by its bare name', () => {
+    const registry = makeRegistry([
+      makeSkill('review', 'extra', 'Alpha review', undefined, {}, { id: 'alpha' }),
+      makeSkill('review', 'extra', 'Beta review', undefined, {}, { id: 'beta' }),
+    ]);
+    registry.register(makeSkill('review', 'project', 'Project review'), { replace: true });
+
+    expect(registry.resolveSkill('review')).toMatchObject({
+      kind: 'resolved',
+      canonicalName: 'review',
+      skill: { description: 'Project review', source: 'project' },
     });
   });
 });

--- a/packages/agent-core-v2/test/app/skillCatalog/registry.test.ts
+++ b/packages/agent-core-v2/test/app/skillCatalog/registry.test.ts
@@ -1,7 +1,11 @@
 import { describe, expect, it } from 'vitest';
 
 import { InMemorySkillCatalog } from '#/app/skillCatalog/registry';
-import type { SkillDefinition, SkillSource } from '#/app/skillCatalog/types';
+import {
+  canonicalSkillName,
+  type SkillDefinition,
+  type SkillSource,
+} from '#/app/skillCatalog/types';
 import { stubSkill } from './stubs';
 
 describe('InMemorySkillCatalog skill listing', () => {
@@ -90,6 +94,20 @@ describe('InMemorySkillCatalog skill listing', () => {
     expect(rendered).toContain('project version');
     expect(rendered).not.toContain('user version');
     expect(rendered).not.toContain('builtin version');
+  });
+
+  it('lists every plugin identity alongside the merged non-plugin winner', () => {
+    const registry = makeRegistry([
+      makeSkill('review', 'extra', 'Alpha review', undefined, {}, { id: 'alpha' }),
+      makeSkill('review', 'extra', 'Beta review', undefined, {}, { id: 'beta' }),
+    ]);
+    registry.register(makeSkill('review', 'project', 'Project review'), { replace: true });
+
+    expect(registry.listSkills().map(canonicalSkillName)).toEqual([
+      'alpha:review',
+      'beta:review',
+      'review',
+    ]);
   });
 
   it('registerBuiltinSkill stamps non-builtin skills as builtin', () => {

--- a/packages/agent-core-v2/test/app/skillCatalog/skill-tool-manager.test.ts
+++ b/packages/agent-core-v2/test/app/skillCatalog/skill-tool-manager.test.ts
@@ -165,6 +165,10 @@ describe('ToolManager SkillTool registration with a structural catalog', () => {
     skills = {
       getSkill: (name) => (name === skill.name ? skill : undefined),
       getPluginSkill: () => undefined,
+      resolveSkill: (name) =>
+        name === skill.name
+          ? { kind: 'resolved', skill, canonicalName: skill.name }
+          : { kind: 'not-found' },
       renderSkillPrompt: () => skill.content,
       listSkills: () => [skill],
       listInvocableSkills: () => [skill],

--- a/packages/kap-server/src/routes/skills.ts
+++ b/packages/kap-server/src/routes/skills.ts
@@ -51,7 +51,8 @@
  * (`packages/agent-core/src/services/skill/skill.ts`): only
  * `name`/`description`/`path`/`source` plus optional `type` and
  * `disable_model_invocation` are emitted; `isSubSkill` is intentionally
- * dropped.
+ * dropped. Plugin Skill names use their canonical `pluginId:skillName`
+ * identity so every listed name round-trips through the activation route.
  *
  * **Error mapping**:
  *   - unknown workspace id          → envelope `code: 40410 workspace.not_found`.
@@ -89,6 +90,7 @@ import {
   MERGE_ALL_AVAILABLE_SKILLS_SECTION,
   SKILL_SOURCE_PRIORITY,
   applyPromptMetadataUpdate,
+  canonicalSkillName,
   configuredRoots,
   projectRoots,
   promptMetadataTextFromSkill,
@@ -389,7 +391,7 @@ type SkillElement = ReturnType<ISessionSkillCatalog['catalog']['listSkills']>[nu
 
 function toProtocolSkill(skill: SkillElement): SkillDescriptor {
   const base: SkillDescriptor = {
-    name: skill.name,
+    name: canonicalSkillName(skill),
     description: skill.description,
     path: skill.path,
     source: skill.source,

--- a/packages/kap-server/test/skills.test.ts
+++ b/packages/kap-server/test/skills.test.ts
@@ -27,6 +27,7 @@ import { join } from 'node:path';
 
 import {
   IAgentLifecycleService,
+  IPluginService,
   ISessionLifecycleService,
   ISkillCatalogRuntimeOptions,
 } from '@moonshot-ai/agent-core-v2';
@@ -149,6 +150,21 @@ describe('server-v2 /api/v1 skills', () => {
     );
   }
 
+  async function seedPluginSkill(pluginId: string, name: string): Promise<string> {
+    const root = await makeWorkspaceDir();
+    const dir = join(root, 'skills', name);
+    await mkdir(dir, { recursive: true });
+    await writeFile(
+      join(root, 'kimi.plugin.json'),
+      JSON.stringify({ name: pluginId, skills: './skills/' }),
+    );
+    await writeFile(
+      join(dir, 'SKILL.md'),
+      `---\nname: ${name}\ndescription: ${pluginId} ${name}\n---\n\nPlugin skill body.\n`,
+    );
+    return root;
+  }
+
   describe('GET /api/v1/sessions/{sid}/skills', () => {
     it('returns 40401 for an unknown session', async () => {
       const { body } = await getJson<null>('/api/v1/sessions/nope/skills');
@@ -198,6 +214,34 @@ describe('server-v2 /api/v1 skills', () => {
       expect(docsSkill).toBeDefined();
       expect(docsSkill).toMatchObject({ source: 'builtin' });
       expect(docsSkill?.description.length).toBeGreaterThan(0);
+    });
+
+    it('lists colliding plugin skills under names that round-trip through activation', async () => {
+      const plugins = server!.core.accessor.get(IPluginService);
+      await plugins.installPlugin({ source: await seedPluginSkill('alpha-plugin', 'review') });
+      await plugins.installPlugin({ source: await seedPluginSkill('beta-plugin', 'review') });
+      const id = await createSession();
+      await createMainAgent(id);
+
+      const { body: listed } = await getJson<{ skills: SkillWire[] }>(
+        `/api/v1/sessions/${id}/skills`,
+      );
+      const names = listSkillsResponseSchema
+        .parse(listed.data)
+        .skills.map((skill) => skill.name)
+        .filter((name) => name.endsWith(':review'));
+      const selected = 'beta-plugin:review';
+      expect(names).toEqual(['alpha-plugin:review', selected]);
+
+      const { body: activated } = await postJson<{
+        activated: boolean;
+        skill_name: string;
+      }>(`/api/v1/sessions/${id}/skills/${encodeURIComponent(selected)}:activate`);
+      expect(activated.code).toBe(0);
+      expect(activateSkillResultSchema.parse(activated.data)).toEqual({
+        activated: true,
+        skill_name: selected,
+      });
     });
   });
 


### PR DESCRIPTION
## Related Issue

Resolve #2224

## Problem

Plugin Skills were indexed by plugin and Skill name, but model and user activation only performed bare global lookup. As a result, canonical IDs such as `plugin-id:skill-name` could not be invoked, while duplicate bare names silently depended on registration order.

## What changed

- Add one catalog resolver for qualified plugin IDs, unambiguous bare aliases, not-found results, and ambiguous bare names.
- Preserve existing merged-source priority for bare non-plugin Skills while exposing every plugin Skill under its canonical qualified ID in model, session, and workspace listings.
- Use the canonical ID in model listings, activation prompts, activation records, and tool results so listed names round-trip through the Skill tool.
- Return an actionable ambiguity error containing the sorted qualified candidates.
- Add catalog, model-tool, REST round-trip, TUI command, and user-activation regression coverage, regenerate the state manifest, and add a patch changeset.

Verification:

- `pnpm --filter @moonshot-ai/agent-core-v2 lint:domain`
- `pnpm --filter @moonshot-ai/agent-core-v2 typecheck`
- `pnpm --filter @moonshot-ai/kap-server typecheck`
- `pnpm --filter @moonshot-ai/kimi-code typecheck`
- `pnpm --filter @moonshot-ai/agent-core-v2 build`
- `pnpm --filter @moonshot-ai/agent-core-v2 test` (`270` files, `4199` tests)
- `pnpm --filter @moonshot-ai/kap-server test` (`57` files, `822` tests)
- `pnpm --filter @moonshot-ai/kimi-code test` (`183` passed / `2` skipped files, `2404` passed / `5` skipped tests)
- `pnpm changeset status`

Documentation note: I ran the `gen-docs` workflow, but it stopped at its prerequisite check because `docs/scripts/sync-changelog.mjs` is not present on `main`; no documentation files were changed.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.
