### PR TITLE
feat(web): unify running session page title spinner with MoonSpinner

### DIFF
--- a/.changeset/unify-page-title-moon-spinner.md
+++ b/.changeset/unify-page-title-moon-spinner.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+web: Unify the running-session page title spinner with the chat MoonSpinner sequence and timing.

--- a/apps/kimi-web/src/composables/usePageTitle.ts
+++ b/apps/kimi-web/src/composables/usePageTitle.ts
@@ -15,7 +15,7 @@ export interface UsePageTitleOptions {
 export function usePageTitle({ running, showAuthGate }: UsePageTitleOptions): void {
   const { t } = useI18n();
 
-  const SPINNER_FRAMES = ['◐', '◓', '◑', '◒'];
+  const SPINNER_FRAMES = ['🌑', '🌒', '🌓', '🌔', '🌕', '🌖', '🌗', '🌘'];
   const spinnerFrame = ref(0);
   let spinnerTimer: ReturnType<typeof setInterval> | null = null;
 
@@ -24,7 +24,7 @@ export function usePageTitle({ running, showAuthGate }: UsePageTitleOptions): vo
     spinnerFrame.value = 0;
     spinnerTimer = setInterval(() => {
       spinnerFrame.value = (spinnerFrame.value + 1) % SPINNER_FRAMES.length;
-    }, 250);
+    }, 120);
   }
 
   function stopSpinner(): void {


### PR DESCRIPTION
## Related Issue

No prior issue; this is a small UX consistency fix.

## Problem

When a session is running, the browser tab title shows an animated moon-phase spinner, but its emoji sequence and timing did not match the chat's `MoonSpinner` component. This made the two loading indicators feel inconsistent.

## What changed

Updated `apps/kimi-web/src/composables/usePageTitle.ts` to align the title spinner with `src/components/ui/MoonSpinner.vue`:

- Sequence: `🌑 🌒 🌓 🌔 🌕 🌖 🌗 🌘`
- Interval: 120ms

A patch-level changeset for `@moonshot-ai/kimi-code` has been added since the web app is bundled into the CLI release.

Before:
<img width="328" height="80" alt="image" src="https://github.com/user-attachments/assets/be2add2d-57ef-4624-89f5-74b2988a09af" />

After:
<img width="364" height="88" alt="image" src="https://github.com/user-attachments/assets/c98132c9-ec63-4172-a5a3-24b696dc2d36" />


## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [ ] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.