### PR TITLE
feat(server): remove the 50 MiB upload size cap and stream uploads to disk

### DIFF
--- a/.changeset/upload-no-size-cap.md
+++ b/.changeset/upload-no-size-cap.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": minor
+---
+
+Remove the 50 MB size limit on file uploads to the built-in server, so large attachments (for example in the web UI) no longer fail with an upload-too-large error. Uploads now stream to disk instead of being buffered in memory.

--- a/packages/agent-core-v2/src/_base/utils/fs.ts
+++ b/packages/agent-core-v2/src/_base/utils/fs.ts
@@ -112,3 +112,48 @@ export async function atomicWrite(
     }
   }
 }
+
+/**
+ * Streamed variant of `atomicWrite`: same tmp + fsync + rename discipline, but
+ * the content arrives as an `AsyncIterable` so arbitrarily large values never
+ * sit in memory at once.
+ */
+export async function atomicWriteStream(
+  filePath: string,
+  source: AsyncIterable<Uint8Array>,
+  mode?: number,
+): Promise<void> {
+  const hex = randomBytes(4).toString('hex');
+  const tmpPath = `${filePath}.tmp.${process.pid}.${hex}`;
+  let renamed = false;
+  try {
+    const fh = await open(tmpPath, 'w', mode);
+    try {
+      for await (const chunk of source) {
+        if (chunk.byteLength > 0) {
+          await fh.writeFile(chunk);
+        }
+      }
+      await fh.sync();
+    } finally {
+      await fh.close();
+    }
+    if (process.platform === 'win32') {
+      try {
+        await unlink(filePath);
+      } catch (error) {
+        const code = (error as NodeJS.ErrnoException).code;
+        if (code !== 'ENOENT') throw error;
+      }
+    }
+    await rename(tmpPath, filePath);
+    renamed = true;
+  } finally {
+    if (!renamed) {
+      try {
+        await unlink(tmpPath);
+      } catch {
+      }
+    }
+  }
+}

--- a/packages/agent-core-v2/src/app/file/fileService.ts
+++ b/packages/agent-core-v2/src/app/file/fileService.ts
@@ -25,8 +25,6 @@ export const fileMetaSchema = z.object({
 });
 export type FileMeta = z.infer<typeof fileMetaSchema>;
 
-export const DEFAULT_MAX_UPLOAD_BYTES = 50 * 1024 * 1024;
-
 export interface SaveOptions {
   readonly name?: string;
   readonly mimeType?: string;
@@ -57,7 +55,6 @@ export const IFileService: ServiceIdentifier<IFileService> = createDecorator<IFi
 export const FileErrors = {
   codes: {
     FILE_NOT_FOUND: 'file.not_found',
-    FILE_TOO_LARGE: 'file.too_large',
   },
   info: {
     'file.not_found': {
@@ -65,12 +62,6 @@ export const FileErrors = {
       retryable: false,
       public: true,
       action: 'Check the file_id or upload the file again.',
-    },
-    'file.too_large': {
-      title: 'Upload too large',
-      retryable: false,
-      public: true,
-      action: 'Upload a smaller file (limit is 50 MiB).',
     },
   },
 } as const satisfies ErrorDomain;
@@ -90,14 +81,6 @@ export class FileError extends Error2 {
 
 export function fileNotFoundError(fileId: string): FileError {
   return new FileError(FileErrors.codes.FILE_NOT_FOUND, `file not found: ${fileId}`, { fileId });
-}
-
-export function fileTooLargeError(seen: number, limit: number): FileError {
-  return new FileError(
-    FileErrors.codes.FILE_TOO_LARGE,
-    `upload size ${seen} bytes exceeds limit ${limit} bytes`,
-    { seen, limit },
-  );
 }
 
 export function isFileError(error: unknown, code: (typeof FileErrors.codes)[keyof typeof FileErrors.codes]): boolean {

--- a/packages/agent-core-v2/src/app/file/fileServiceImpl.ts
+++ b/packages/agent-core-v2/src/app/file/fileServiceImpl.ts
@@ -2,10 +2,12 @@
  * `file` domain (L2) — `IFileService` implementation.
  *
  * Streams uploads into the `IBlobStore` under the `files` scope and keeps a
- * JSON `FileMeta` index in the same store under the `file` scope.
- * Enforces the 50 MiB upload cap while collecting the stream, prunes the
- * index when a referenced blob is missing, and hands downloads back as a lazy
- * `Readable` over `getStream`. Bound at App scope.
+ * JSON `FileMeta` index in the same store under the `file` scope. Uploads are
+ * written incrementally (`putStream`), so their size is bounded by disk, not
+ * memory; the service counts bytes as they flow through to record
+ * `FileMeta.size`. Prunes the index when a referenced blob is missing, and
+ * hands downloads back as a lazy `Readable` over `getStream`. Bound at App
+ * scope.
  */
 
 import { randomUUID } from 'node:crypto';
@@ -16,10 +18,8 @@ import type { FileMeta } from './fileService';
 import { LifecycleScope, ScopeActivation, registerScopedService } from '#/_base/di/scope';
 import { IBlobStore } from '#/persistence/interface/blobStore';
 import {
-  DEFAULT_MAX_UPLOAD_BYTES,
   IFileService,
   fileNotFoundError,
-  fileTooLargeError,
   type FileReadRange,
   type GetResult,
   type SaveOptions,
@@ -70,26 +70,28 @@ export class FileServiceImpl implements IFileService {
     await this.ensureIndex();
 
     const id = `f_${randomUUID()}`;
-    const chunks: Buffer[] = [];
-    let bytes = 0;
-    for await (const chunk of source) {
-      const buf = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk as string);
-      bytes += buf.length;
-      if (bytes > DEFAULT_MAX_UPLOAD_BYTES) {
-        throw fileTooLargeError(bytes, DEFAULT_MAX_UPLOAD_BYTES);
+    let size = 0;
+    const counting = async function* (): AsyncIterable<Uint8Array> {
+      for await (const chunk of source) {
+        const buf = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk as string);
+        size += buf.length;
+        yield buf;
       }
-      chunks.push(buf);
+    };
+    try {
+      await this.blobs.putStream(BLOB_SCOPE, id, counting());
+    } catch (error) {
+      // best-effort cleanup of a partially written blob
+      await this.blobs.delete(BLOB_SCOPE, id).catch(() => undefined);
+      throw error;
     }
-    const data = Buffer.concat(chunks);
-
-    await this.blobs.put(BLOB_SCOPE, id, data);
 
     const now = Date.now();
     const meta: FileMeta = {
       id,
       name: options.name ?? filename,
       media_type: options.mimeType ?? 'application/octet-stream',
-      size: data.length,
+      size,
       created_at: new Date(now).toISOString(),
       ...(options.expiresInSec !== undefined
         ? { expires_at: new Date(now + options.expiresInSec * 1000).toISOString() }

--- a/packages/agent-core-v2/src/persistence/backends/memory/inMemoryStorageService.ts
+++ b/packages/agent-core-v2/src/persistence/backends/memory/inMemoryStorageService.ts
@@ -69,6 +69,28 @@ export class InMemoryStorageService implements IFileSystemStorageService {
     this.notifyWatchers(scope, key);
   }
 
+  async writeStream(
+    scope: string,
+    key: string,
+    source: AsyncIterable<Uint8Array>,
+    _options: StorageWriteOptions = {},
+  ): Promise<void> {
+    const chunks: Uint8Array[] = [];
+    let total = 0;
+    for await (const chunk of source) {
+      chunks.push(chunk);
+      total += chunk.byteLength;
+    }
+    const merged = new Uint8Array(total);
+    let offset = 0;
+    for (const chunk of chunks) {
+      merged.set(chunk, offset);
+      offset += chunk.byteLength;
+    }
+    this.bucket(scope).set(key, merged);
+    this.notifyWatchers(scope, key);
+  }
+
   async append(
     scope: string,
     key: string,

--- a/packages/agent-core-v2/src/persistence/backends/node-fs/blobStoreService.ts
+++ b/packages/agent-core-v2/src/persistence/backends/node-fs/blobStoreService.ts
@@ -19,6 +19,10 @@ export class BlobStoreService implements IBlobStore {
     await this.storage.write(scope, key, data, { atomic: true });
   }
 
+  async putStream(scope: string, key: string, source: AsyncIterable<Uint8Array>): Promise<void> {
+    await this.storage.writeStream(scope, key, source, { atomic: true });
+  }
+
   async get(scope: string, key: string): Promise<Uint8Array | undefined> {
     return this.storage.read(scope, key);
   }

--- a/packages/agent-core-v2/src/persistence/backends/node-fs/fileStorageService.ts
+++ b/packages/agent-core-v2/src/persistence/backends/node-fs/fileStorageService.ts
@@ -8,6 +8,8 @@
  * Primitives:
  *   - `write`  → `atomicWrite` (tmp + fsync + rename) followed by a directory
  *                fsync, so the replacement is both atomic and durable.
+ *   - `writeStream` → the streamed form of `write` (`atomicWriteStream`), for
+ *                values too large to buffer in memory.
  *   - `append` → `open('a')` + write + `fh.sync()` (when `durable`), plus a
  *                one-time directory fsync per scope.
  *   - `watch`  → chokidar on the parent directory, filtered to the exact key and
@@ -29,7 +31,7 @@ import { dirname, join, normalize } from 'pathe';
 import { DisposableStore, combinedDisposable, toDisposable, type IDisposable } from '#/_base/di/lifecycle';
 import { Emitter, type Event } from '#/_base/event';
 import { onUnexpectedError } from '#/_base/errors/unexpectedError';
-import { atomicWrite, syncDir } from '#/_base/utils/fs';
+import { atomicWrite, atomicWriteStream, syncDir } from '#/_base/utils/fs';
 
 import type {
   IFileSystemStorageService,
@@ -96,6 +98,22 @@ export class FileStorageService implements IFileSystemStorageService {
     try {
       await mkdir(dirname(filePath), { recursive: true, mode: this.dirMode });
       await atomicWrite(filePath, data, undefined, this.fileMode);
+      await this.syncDirOnce(dirname(filePath));
+    } catch (error) {
+      throw toStorageIoError(error, { path: filePath, op: 'write' });
+    }
+  }
+
+  async writeStream(
+    scope: string,
+    key: string,
+    source: AsyncIterable<Uint8Array>,
+    _options: StorageWriteOptions = {},
+  ): Promise<void> {
+    const filePath = this.path(scope, key);
+    try {
+      await mkdir(dirname(filePath), { recursive: true, mode: this.dirMode });
+      await atomicWriteStream(filePath, source, this.fileMode);
       await this.syncDirOnce(dirname(filePath));
     } catch (error) {
       throw toStorageIoError(error, { path: filePath, op: 'write' });

--- a/packages/agent-core-v2/src/persistence/interface/blobStore.ts
+++ b/packages/agent-core-v2/src/persistence/interface/blobStore.ts
@@ -15,6 +15,7 @@ export interface IBlobStore {
   readonly _serviceBrand: undefined;
 
   put(scope: string, key: string, data: Uint8Array): Promise<void>;
+  putStream(scope: string, key: string, source: AsyncIterable<Uint8Array>): Promise<void>;
   get(scope: string, key: string): Promise<Uint8Array | undefined>;
   getStream(scope: string, key: string, range?: BlobReadRange): AsyncIterable<Uint8Array>;
   has(scope: string, key: string): Promise<boolean>;

--- a/packages/agent-core-v2/src/persistence/interface/storage.ts
+++ b/packages/agent-core-v2/src/persistence/interface/storage.ts
@@ -13,6 +13,10 @@
  * the last value" semantics. Keeping both as first-class primitives lets each
  * implementation implement them optimally (file: `open('a')` vs tmp+rename).
  *
+ * `writeStream` is the streamed form of `write` for values too large to hold
+ * in memory: same whole-value replacement semantics (tmp + rename on the file
+ * backend), but the bytes arrive as an `AsyncIterable`.
+ *
  * The service is byte-oriented and scope/key-addressed: `scope` maps to a
  * directory, `key` maps to a filename. It knows nothing about JSON, records,
  * configs, versions or framing. Those concerns live in the typed Store facades
@@ -124,6 +128,12 @@ export interface IFileSystemStorageService {
   read(scope: string, key: string): Promise<Uint8Array | undefined>;
   readStream(scope: string, key: string, range?: StorageReadRange): AsyncIterable<Uint8Array>;
   write(scope: string, key: string, data: Uint8Array, options?: StorageWriteOptions): Promise<void>;
+  writeStream(
+    scope: string,
+    key: string,
+    source: AsyncIterable<Uint8Array>,
+    options?: StorageWriteOptions,
+  ): Promise<void>;
   append(scope: string, key: string, data: Uint8Array, options?: StorageAppendOptions): Promise<void>;
   list(scope: string, prefix?: string): Promise<readonly string[]>;
   delete(scope: string, key: string): Promise<void>;

--- a/packages/agent-core-v2/test/agent/media/videoResolver.test.ts
+++ b/packages/agent-core-v2/test/agent/media/videoResolver.test.ts
@@ -57,6 +57,11 @@ function blobStore(): IBlobStore {
     put: async (scope, key, bytes) => {
       data.set(`${scope}/${key}`, bytes);
     },
+    putStream: async (scope, key, source) => {
+      const chunks: Uint8Array[] = [];
+      for await (const chunk of source) chunks.push(chunk);
+      data.set(`${scope}/${key}`, Buffer.concat(chunks));
+    },
     get: async (scope, key) => data.get(`${scope}/${key}`),
     getStream: async function* () {},
     has: async (scope, key) => data.has(`${scope}/${key}`),

--- a/packages/agent-core-v2/test/agent/task/taskService.test.ts
+++ b/packages/agent-core-v2/test/agent/task/taskService.test.ts
@@ -152,6 +152,7 @@ describe('AgentTaskService', () => {
       read: async () => undefined,
       readStream: async function* () {},
       write: async () => {},
+      writeStream: async () => {},
       append: async () => {},
       list: async () => [],
       delete: async () => {},
@@ -802,6 +803,7 @@ describe('AgentTaskService', () => {
       read: async () => undefined,
       readStream: async function* () {},
       write: async () => {},
+      writeStream: async () => {},
       append: async (_scope: string, _key: string, chunk: Uint8Array) => {
         persistedChars += chunk.byteLength;
       },

--- a/packages/agent-core-v2/test/app/file/fileService.test.ts
+++ b/packages/agent-core-v2/test/app/file/fileService.test.ts
@@ -13,7 +13,7 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { SyncDescriptor } from '#/_base/di/descriptors';
 import { DisposableStore } from '#/_base/di/lifecycle';
 import { createServices, type TestInstantiationService } from '#/_base/di/test';
-import { DEFAULT_MAX_UPLOAD_BYTES, FileErrors, IFileService } from '#/app/file/fileService';
+import { FileErrors, IFileService } from '#/app/file/fileService';
 import { FileServiceImpl } from '#/app/file/fileServiceImpl';
 import { IFileSystemStorageService } from '#/persistence/interface/storage';
 import { InMemoryStorageService } from '#/persistence/backends/memory/inMemoryStorageService';
@@ -115,11 +115,22 @@ describe('FileServiceImpl', () => {
     });
   });
 
-  it('rejects an upload that exceeds the cap', async () => {
-    const big = Buffer.alloc(DEFAULT_MAX_UPLOAD_BYTES + 1, 0);
-    await expect(store().save(readable(big), 'big.bin')).rejects.toMatchObject({
-      code: FileErrors.codes.FILE_TOO_LARGE,
-    });
+  it('streams a multi-chunk upload and records the total size', async () => {
+    const chunks = [Buffer.from('aaa'), Buffer.from('bbbb'), Buffer.from('cc')];
+    const meta = await store().save(Readable.from(chunks), 'chunked.bin');
+
+    expect(meta.size).toBe(9);
+    const { stream } = await store().get(meta.id);
+    expect((await readAll(stream())).toString()).toBe('aaabbbbcc');
+  });
+
+  it('cleans up the blob when the source stream fails mid-upload', async () => {
+    const failing = Readable.from((async function* () {
+      yield Buffer.from('partial');
+      throw new Error('source exploded');
+    })());
+
+    await expect(store().save(failing, 'broken.bin')).rejects.toThrow('source exploded');
     expect(await backend.list('files')).toHaveLength(0);
   });
 

--- a/packages/agent-core-v2/test/persistence/backends/node-fs/appendLogStore.test.ts
+++ b/packages/agent-core-v2/test/persistence/backends/node-fs/appendLogStore.test.ts
@@ -34,6 +34,7 @@ function chunkedStorage(chunks: Uint8Array[]): IFileSystemStorageService {
       for (const c of chunks) yield c;
     },
     write: async () => {},
+    writeStream: async () => {},
     append: async () => {},
     list: async () => [],
     delete: async () => {},

--- a/packages/agent-core-v2/test/persistence/backends/node-fs/fileStorageService.test.ts
+++ b/packages/agent-core-v2/test/persistence/backends/node-fs/fileStorageService.test.ts
@@ -87,3 +87,41 @@ describe('FileStorageService — error translation', () => {
     });
   });
 });
+
+describe('FileStorageService — writeStream', () => {
+  let dir: string;
+
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), 'fss-stream-'));
+  });
+
+  afterEach(async () => {
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  it('writes a chunked source and replaces the whole value', async () => {
+    const svc = new FileStorageService(dir);
+    await svc.write('scope', 'k.bin', encoder.encode('old'));
+    await svc.writeStream('scope', 'k.bin', (async function* () {
+      yield encoder.encode('aa');
+      yield encoder.encode('bbb');
+    })());
+
+    const chunks: Uint8Array[] = [];
+    for await (const chunk of svc.readStream('scope', 'k.bin')) chunks.push(chunk);
+    expect(Buffer.concat(chunks).toString()).toBe('aabbb');
+  });
+
+  it('leaves no target file behind when the source fails mid-stream', async () => {
+    const svc = new FileStorageService(dir);
+    await expect(
+      svc.writeStream('scope', 'k.bin', (async function* () {
+        yield encoder.encode('partial');
+        throw new Error('boom');
+      })()),
+    ).rejects.toThrow();
+
+    expect(await svc.read('scope', 'k.bin')).toBeUndefined();
+    expect(await svc.list('scope')).toEqual([]);
+  });
+});

--- a/packages/kap-server/src/protocol/error-codes.ts
+++ b/packages/kap-server/src/protocol/error-codes.ts
@@ -124,7 +124,7 @@ export const ErrorCode = {
   /** 临时文件已过期 */
   FILE_EXPIRED: 41003,
 
-  /** 上传超 50MB */
+  /** 文件过大（如 session 导出超限；/files 上传不设上限） */
   FILE_TOO_LARGE: 41301,
   /** fs.read 超 10MB */
   FS_TOO_LARGE: 41302,

--- a/packages/kap-server/src/routes/files.ts
+++ b/packages/kap-server/src/routes/files.ts
@@ -6,15 +6,15 @@
  *   DELETE /files/{file_id}  delete a file → { deleted: true }
  *
  * Backed by the v2 `IFileService` (Core scope), which stores bytes in
- * `IBlobStore` and the metadata index alongside them. Mirrors the v1 server's
- * wire behavior (envelope codes 40407 / 41301, 50 MiB cap, content-disposition)
- * but resolves the store through `core.accessor.get`.
+ * `IBlobStore` and the metadata index alongside them. Uploads stream straight
+ * to the store with no size cap (local single-user deployment), and the route
+ * mirrors the v1 server's wire behavior (envelope codes 40407 / 41301,
+ * content-disposition) while resolving the store through `core.accessor.get`.
  */
 
 import multipart from '@fastify/multipart';
 
 import {
-  DEFAULT_MAX_UPLOAD_BYTES,
   ErrorCodes,
   IFileService,
   Error2,
@@ -76,7 +76,11 @@ interface FilesReply {
 export function registerFilesRoutes(app: FilesRouteHost, core: Scope): void {
   app.register(multipart, {
     limits: {
-      fileSize: DEFAULT_MAX_UPLOAD_BYTES,
+      // No upload size cap — local single-user deployment. The limit must be
+      // set explicitly: @fastify/multipart defaults `fileSize` to Fastify's
+      // `bodyLimit` (1 MiB) when it is left undefined, and silently truncates
+      // the file stream at that size.
+      fileSize: Number.MAX_SAFE_INTEGER,
       files: 1,
     },
   });
@@ -108,14 +112,9 @@ export function registerFilesRoutes(app: FilesRouteHost, core: Scope): void {
 
         const store = core.accessor.get(IFileService);
 
-        const partFile = part.file as NodeJS.ReadableStream & { truncated?: boolean };
-        let busboyTruncated = false;
-        partFile.on('limit', () => {
-          busboyTruncated = true;
-        });
         try {
           const meta = await store.save(
-            partFile as unknown as import('node:stream').Readable,
+            part.file as unknown as import('node:stream').Readable,
             part.filename,
             {
               name: nameOverride ?? part.filename,
@@ -123,18 +122,6 @@ export function registerFilesRoutes(app: FilesRouteHost, core: Scope): void {
               expiresInSec,
             },
           );
-          if (busboyTruncated || partFile.truncated === true) {
-            try {
-              await store.delete(meta.id);
-            } catch {
-              // best-effort cleanup of the truncated blob
-            }
-            sendMappedError(reply as unknown as FilesReply, req, new Error2(
-              ErrorCodes.FILE_TOO_LARGE,
-              `upload size exceeds limit ${DEFAULT_MAX_UPLOAD_BYTES} bytes`,
-            ));
-            return;
-          }
           reply.send(okEnvelope(meta, req.id));
         } catch (error) {
           sendMappedError(reply as unknown as FilesReply, req, error);
@@ -237,19 +224,6 @@ function sendMappedError(reply: FilesReply, req: { id: string }, err: unknown): 
   const requestId = req.id;
   if (err instanceof Error2 && err.code === ErrorCodes.FILE_NOT_FOUND) {
     reply.code(404).send(errEnvelope(ErrorCode.FILE_NOT_FOUND, 'file not found', requestId));
-    return;
-  }
-  if (err instanceof Error2 && err.code === ErrorCodes.FILE_TOO_LARGE) {
-    reply.code(413).send(errEnvelope(ErrorCode.FILE_TOO_LARGE, 'upload too large (>50MB)', requestId));
-    return;
-  }
-  if (
-    typeof err === 'object' &&
-    err !== null &&
-    'name' in err &&
-    (err as { name: string }).name === 'FST_REQ_FILE_TOO_LARGE'
-  ) {
-    reply.code(413).send(errEnvelope(ErrorCode.FILE_TOO_LARGE, 'upload too large (>50MB)', requestId));
     return;
   }
   requestLog(req)?.error({ err }, 'file request failed');

--- a/packages/kap-server/test/files.test.ts
+++ b/packages/kap-server/test/files.test.ts
@@ -1,11 +1,11 @@
 /**
  * `/api/v1/files` end-to-end for the v2 server.
  *
- * Mirrors the v1 server's files e2e (upload → download → delete → 404, the
- * 50 MiB cap, unknown ids, index persistence across restart, the `name`
- * override, and the missing-file validation) but boots `startServer` from
- * server-v2 and drives it through Fastify `app.inject` with hand-built
- * multipart bodies.
+ * Mirrors the v1 server's files e2e (upload → download → delete → 404,
+ * large uploads with no size cap, unknown ids, index persistence across
+ * restart, the `name` override, and the missing-file validation) but boots
+ * `startServer` from server-v2 and drives it through Fastify `app.inject`
+ * with hand-built multipart bodies.
  */
 
 import { mkdtempSync, rmSync } from 'node:fs';
@@ -168,7 +168,7 @@ describe('POST /api/v1/files (server-v2)', () => {
     expect((get2Res.json() as Envelope).code).toBe(40407);
   });
 
-  it('upload > 50MB → 41301', async () => {
+  it('uploads a file larger than the former 50 MiB cap', async () => {
     const r = await boot();
     const big = Buffer.alloc(51 * 1024 * 1024, 0);
     const mp = buildMultipart({
@@ -185,8 +185,19 @@ describe('POST /api/v1/files (server-v2)', () => {
       payload: mp.body,
       headers: { 'content-type': mp.contentType },
     });
-    expect(res.statusCode).toBe(413);
-    expect((res.json() as Envelope).code).toBe(41301);
+    expect(res.statusCode).toBe(200);
+    const env = res.json() as Envelope<{ id: string; size: number }>;
+    expect(env.code).toBe(0);
+    expect(env.data!.size).toBe(big.length);
+
+    const getRes = await appOf(r).inject({
+      method: 'GET',
+      url: `/api/v1/files/${env.data!.id}`,
+    });
+    expect(getRes.statusCode).toBe(200);
+    // `expect(buffer).toEqual(buffer)` deep-compares 51M elements and blows
+    // the heap — use the native memcmp instead.
+    expect(getRes.rawPayload.equals(big)).toBe(true);
   });
 
   it('GET / DELETE unknown file_id → 40407', async () => {

--- a/packages/protocol/src/error-codes.ts
+++ b/packages/protocol/src/error-codes.ts
@@ -109,7 +109,7 @@ export const ErrorCode = {
   /** 临时文件已过期 */
   FILE_EXPIRED: 41003,
 
-  /** 上传超 50MB */
+  /** 文件过大（如 session 导出超限；/files 上传不设上限） */
   FILE_TOO_LARGE: 41301,
   /** fs.read 超 10MB */
   FS_TOO_LARGE: 41302,

--- a/packages/protocol/src/rest/file.ts
+++ b/packages/protocol/src/rest/file.ts
@@ -2,8 +2,7 @@
  *   POST   /v1/files
  *     Request: multipart/form-data with `file` (binary), `name`
  *              (optional override), `expires_in_sec` (optional).
- *     Response data: `FileMeta` (full envelope).
- *     Errors: 41301 (>50MB).
+ *     Response data: `FileMeta` (full envelope). No upload size cap.
  *
  *   GET    /v1/files/{file_id}
  *     Response: binary stream or envelope (40407 / 41003).


### PR DESCRIPTION
## Related Issue

No linked issue — the problem is explained below.

## Problem

The built-in server's `/files` upload endpoint rejected anything over 50 MiB with an upload-too-large error, which blocked large attachments (for example videos or archives added through the web UI). The cap also acted as a memory guard: uploads were buffered fully in memory before being written to disk, so simply raising the limit would have made large uploads a memory hazard. The server targets local single-user deployments, so the concurrency/abuse rationale for a hard cap does not apply.

## What changed

- Removed the 50 MiB upload cap from the `/files` endpoint (both the multipart `fileSize` limit and the service-level check), and deleted the now-unreachable `file.too_large` error. The wire code 41301 stays in the protocol because session export still maps its own too-large error onto it.
- Made the upload path streaming end to end: added `writeStream` to the filesystem storage service and `putStream` to the blob store, writing through tmp-file + fsync + rename so a failed upload leaves no partial file behind. `FileService.save` now pipes the request body straight to disk and only counts bytes for `FileMeta.size`, so upload memory usage no longer scales with file size.
- Explicitly set the multipart `fileSize` to `Number.MAX_SAFE_INTEGER`: when left unset, `@fastify/multipart` silently falls back to Fastify's 1 MiB `bodyLimit` and truncates the file stream (caught by the e2e test).
- Tests: the former "upload > 50MB → 41301" e2e now uploads 51 MiB and round-trips it; new unit tests cover multi-chunk streaming saves, byte counting, and cleanup when the source stream fails mid-upload.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.
