### PR TITLE
fix(agent-core): count validation-rejected tool calls toward the repeat breaker

### DIFF
--- a/.changeset/dedup-register-rejected-calls.md
+++ b/.changeset/dedup-register-rejected-calls.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/agent-core": patch
+---
+
+Count validation-rejected tool calls toward the repeat breaker so reminders fire at 3/5/8 and the turn force-stops at 12.

--- a/packages/agent-core/src/agent/turn/index.ts
+++ b/packages/agent-core/src/agent/turn/index.ts
@@ -978,6 +978,11 @@ export class TurnFlow {
               return this.agent.permission.beforeToolCall(ctx);
             },
             finalizeToolResult: async (ctx) => {
+              // Calls rejected in preflight (e.g. invalid args) never reach
+              // prepareToolExecution, so register them here — otherwise the
+              // repeat breaker cannot count them and the model can re-issue
+              // the same invalid call indefinitely.
+              deduper.registerSkipped(ctx.toolCall.id, ctx.toolCall.name, ctx.args);
               // Resolve dedup BEFORE firing the PostToolUse hook so same-step
               // dups (whose ctx.result is the dedup placeholder) report the
               // original's real outcome, not an empty success.

--- a/packages/agent-core/src/agent/turn/index.ts
+++ b/packages/agent-core/src/agent/turn/index.ts
@@ -982,7 +982,12 @@ export class TurnFlow {
               // prepareToolExecution, so register them here — otherwise the
               // repeat breaker cannot count them and the model can re-issue
               // the same invalid call indefinitely.
-              deduper.registerSkipped(ctx.toolCall.id, ctx.toolCall.name, ctx.args);
+              deduper.registerSkipped(
+                ctx.toolCall.id,
+                ctx.toolCall.name,
+                ctx.args,
+                ctx.toolCall.arguments,
+              );
               // Resolve dedup BEFORE firing the PostToolUse hook so same-step
               // dups (whose ctx.result is the dedup placeholder) report the
               // original's real outcome, not an empty success.

--- a/packages/agent-core/src/agent/turn/tool-dedup.ts
+++ b/packages/agent-core/src/agent/turn/tool-dedup.ts
@@ -191,6 +191,19 @@ export class ToolCallDeduplicator {
   }
 
   /**
+   * Register a call that bypassed `prepareToolExecution` — e.g. args
+   * validation rejected it in preflight, so the prepare hook never ran. Must
+   * be called before `finalizeResult` for such calls, otherwise the repeat
+   * circuit breaker never counts rejected calls and the model can re-issue
+   * the same invalid call without ever tripping the streak. No-op when the
+   * call was already registered through the normal prepare path.
+   */
+  registerSkipped(toolCallId: string, toolName: string, args: unknown): void {
+    if (this.callKeyByCallId.has(toolCallId)) return;
+    this.checkSameStep(toolCallId, toolName, args);
+  }
+
+  /**
    * Called from `finalizeToolResult`, in provider order. For first-occurrence
    * calls, projects the consecutive streak ending at this call and, if the
    * threshold is reached, appends the system reminder, then resolves the

--- a/packages/agent-core/src/agent/turn/tool-dedup.ts
+++ b/packages/agent-core/src/agent/turn/tool-dedup.ts
@@ -2,6 +2,7 @@ import type { ContentPart } from '@moonshot-ai/kosong';
 
 import type { TelemetryClient } from '../../telemetry';
 import type { LLMRequestTrace } from '../../loop/llm';
+import { parseToolCallArguments } from '../../loop/tool-args-parse';
 import type { ExecutableToolResult } from '../../loop/types';
 
 import { canonicalTelemetryArgs } from './canonical-args';
@@ -197,10 +198,26 @@ export class ToolCallDeduplicator {
    * circuit breaker never counts rejected calls and the model can re-issue
    * the same invalid call without ever tripping the streak. No-op when the
    * call was already registered through the normal prepare path.
+   *
+   * `rawArguments` is the provider's raw arguments string. Args that failed
+   * JSON parsing were normalized to `{}` by the loop, which would key every
+   * malformed-but-different attempt identically; those are keyed on the raw
+   * text so only true re-issues count as repeats.
    */
-  registerSkipped(toolCallId: string, toolName: string, args: unknown): void {
+  registerSkipped(
+    toolCallId: string,
+    toolName: string,
+    args: unknown,
+    rawArguments?: string | null,
+  ): void {
     if (this.callKeyByCallId.has(toolCallId)) return;
-    this.checkSameStep(toolCallId, toolName, args);
+    const keyArgs =
+      rawArguments !== undefined &&
+      rawArguments !== null &&
+      parseToolCallArguments(rawArguments).parseFailed
+        ? rawArguments
+        : args;
+    this.checkSameStep(toolCallId, toolName, keyArgs);
   }
 
   /**

--- a/packages/agent-core/test/agent/turn.test.ts
+++ b/packages/agent-core/test/agent/turn.test.ts
@@ -823,6 +823,31 @@ describe('Agent turn flow', () => {
     ]);
   });
 
+  it('does not force-stop when the malformed argument text keeps changing', async () => {
+    const records: TelemetryRecord[] = [];
+    const ctx = testAgent({
+      kaos: createCommandKaos('bad'),
+      telemetry: recordingTelemetry(records),
+    });
+    ctx.configure({ tools: ['Bash'] });
+    await ctx.rpc.setPermission({ mode: 'yolo' });
+    records.length = 0;
+
+    // 12 rejected calls, each with DIFFERENT malformed raw JSON: all normalize
+    // to {} on parse failure, but they are not repeats of the same call, so
+    // the turn must not be force-stopped.
+    for (let i = 0; i < 12; i += 1) {
+      ctx.mockNextResponse(malformedBashCallWithId(`call_mal_${String(i)}`, i));
+    }
+    ctx.mockNextResponse({ type: 'text', text: 'recovered' });
+
+    await ctx.rpc.prompt({ input: [{ type: 'text', text: 'Repeat the bad call' }] });
+    await ctx.untilTurnEnd();
+
+    expect(ctx.llmCalls).toHaveLength(13);
+    expect(records.filter((entry) => entry.event === 'tool_call_repeat')).toHaveLength(0);
+  });
+
   it('fires PostToolUse for same-step dups with the original real output, not the dedup placeholder', async () => {
     // Hook command asserts the dup's PostToolUse payload carries the real
     // stdout ('dup'), not the placeholder ('').
@@ -2835,6 +2860,16 @@ function invalidBashCallWithId(id: string): ToolCall {
     id,
     name: 'Bash',
     arguments: JSON.stringify({ timeout: 60 }),
+  };
+}
+
+function malformedBashCallWithId(id: string, variant: number): ToolCall {
+  // Invalid JSON (unquoted key), unique per variant.
+  return {
+    type: 'function',
+    id,
+    name: 'Bash',
+    arguments: `{"command_${String(variant)}: "ls"`,
   };
 }
 

--- a/packages/agent-core/test/agent/turn.test.ts
+++ b/packages/agent-core/test/agent/turn.test.ts
@@ -793,6 +793,36 @@ describe('Agent turn flow', () => {
     });
   });
 
+  it('force-stops a turn that keeps re-issuing the same validation-rejected call', async () => {
+    const records: TelemetryRecord[] = [];
+    const ctx = testAgent({
+      kaos: createCommandKaos('bad'),
+      telemetry: recordingTelemetry(records),
+    });
+    ctx.configure({ tools: ['Bash'] });
+    await ctx.rpc.setPermission({ mode: 'yolo' });
+    records.length = 0;
+
+    // 12 identical calls missing the required "command": each is rejected in
+    // preflight. If the breaker did not count them, the turn would keep going
+    // and consume the 13th scripted response.
+    for (let i = 0; i < 12; i += 1) {
+      ctx.mockNextResponse(invalidBashCallWithId(`call_bad_${String(i)}`));
+    }
+    ctx.mockNextResponse({ type: 'text', text: 'must never be generated' });
+
+    await ctx.rpc.prompt({ input: [{ type: 'text', text: 'Repeat the bad call' }] });
+    await ctx.untilTurnEnd();
+
+    expect(ctx.llmCalls).toHaveLength(12);
+    const actions = records
+      .filter((entry) => entry.event === 'tool_call_repeat')
+      .map((entry) => entry.properties?.['action']);
+    expect(actions).toEqual([
+      'none', 'r1', 'r1', 'r2', 'r2', 'r2', 'r3', 'r3', 'r3', 'r3', 'stop',
+    ]);
+  });
+
   it('fires PostToolUse for same-step dups with the original real output, not the dedup placeholder', async () => {
     // Hook command asserts the dup's PostToolUse payload carries the real
     // stdout ('dup'), not the placeholder ('').
@@ -2796,6 +2826,15 @@ function bashCallWithId(id: string, command: string): ToolCall {
     id,
     name: 'Bash',
     arguments: JSON.stringify({ command, timeout: 60 }),
+  };
+}
+
+function invalidBashCallWithId(id: string): ToolCall {
+  return {
+    type: 'function',
+    id,
+    name: 'Bash',
+    arguments: JSON.stringify({ timeout: 60 }),
   };
 }
 

--- a/packages/agent-core/test/agent/turn/tool-dedup.test.ts
+++ b/packages/agent-core/test/agent/turn/tool-dedup.test.ts
@@ -573,4 +573,48 @@ describe('ToolCallDeduplicator', () => {
       expect(true).toBe(true);
     });
   });
+
+  describe('skipped registration (calls rejected before prepareToolExecution)', () => {
+    // Calls rejected in preflight (e.g. invalid args) never reach
+    // prepareToolExecution/checkSameStep; the loop registers them late via
+    // registerSkipped at finalize time so the breaker still counts them.
+    async function runRejected(
+      dedup: ToolCallDeduplicator,
+      callId: string,
+      result: ExecutableToolResult,
+    ): Promise<ExecutableToolResult> {
+      dedup.registerSkipped(callId, 'Bash', { timeout: 60 });
+      return dedup.finalizeResult(callId, 'Bash', { timeout: 60 }, result);
+    }
+
+    it('counts skipped calls toward the streak and force-stops at 12, keeping the error flag', async () => {
+      const dedup = new ToolCallDeduplicator();
+      let last: ExecutableToolResult | undefined;
+      for (let i = 0; i < 12; i += 1) {
+        dedup.beginStep();
+        last = await runRejected(dedup, `c${String(i)}`, errResult('Invalid args'));
+        dedup.endStep();
+      }
+      expect(last!.isError).toBe(true);
+      expect(last!.stopTurn).toBe(true);
+      expect(last!.output as string).toContain(REMINDER_TEXT_3.trim());
+    });
+
+    it('does not double-register a call that already went through checkSameStep', async () => {
+      const { client, events } = makeRecordingTelemetry();
+      const dedup = new ToolCallDeduplicator({ telemetry: client });
+      for (let i = 0; i < 2; i += 1) {
+        dedup.beginStep();
+        const callId = `c${String(i)}`;
+        expect(dedup.checkSameStep(callId, 'Read', { p: 1 })).toBeNull();
+        dedup.registerSkipped(callId, 'Read', { p: 1 });
+        await dedup.finalizeResult(callId, 'Read', { p: 1 }, okResult('R'));
+        dedup.endStep();
+      }
+      // Exactly one repeat at count 2 — a double registration would inflate
+      // the streak and fire the reminder one occurrence early.
+      const repeats = events.filter((e) => e.event === 'tool_call_repeat');
+      expect(repeats.map((e) => e.properties?.['repeat_count'])).toEqual([2]);
+    });
+  });
 });

--- a/packages/agent-core/test/agent/turn/tool-dedup.test.ts
+++ b/packages/agent-core/test/agent/turn/tool-dedup.test.ts
@@ -616,5 +616,35 @@ describe('ToolCallDeduplicator', () => {
       const repeats = events.filter((e) => e.event === 'tool_call_repeat');
       expect(repeats.map((e) => e.properties?.['repeat_count'])).toEqual([2]);
     });
+
+    it('counts identical malformed argument texts as repeats', async () => {
+      const { client, events } = makeRecordingTelemetry();
+      const dedup = new ToolCallDeduplicator({ telemetry: client });
+      for (let i = 0; i < 2; i += 1) {
+        dedup.beginStep();
+        const callId = `c${String(i)}`;
+        dedup.registerSkipped(callId, 'Bash', {}, '{"command":');
+        await dedup.finalizeResult(callId, 'Bash', {}, errResult('Invalid args'));
+        dedup.endStep();
+      }
+      const repeats = events.filter((e) => e.event === 'tool_call_repeat');
+      expect(repeats.map((e) => e.properties?.['repeat_count'])).toEqual([2]);
+    });
+
+    it('does not treat different malformed argument texts as the same call', async () => {
+      const { client, events } = makeRecordingTelemetry();
+      const dedup = new ToolCallDeduplicator({ telemetry: client });
+      const raws = ['{"command":', '{"comand":', '{"command": "ls"'];
+      for (let i = 0; i < 3; i += 1) {
+        dedup.beginStep();
+        const callId = `c${String(i)}`;
+        dedup.registerSkipped(callId, 'Bash', {}, raws[i]);
+        await dedup.finalizeResult(callId, 'Bash', {}, errResult('Invalid args'));
+        dedup.endStep();
+      }
+      // All three normalize to {} on parse failure, but the raw texts differ,
+      // so no repeat streak may form.
+      expect(events.filter((e) => e.event === 'tool_call_repeat')).toHaveLength(0);
+    });
   });
 });


### PR DESCRIPTION
## Related Issue

No linked issue — explained below.

## Problem

The repeat breaker only counts calls that reach `prepareToolExecution`. Calls rejected by args validation return earlier and never register, so re-issuing the same invalid call gets no reminders and no stop — the turn only ends at maxSteps, burning a provider request per step.

Reproduction (`test/agent/turn.test.ts`): 12 identical `Bash` calls missing the required `command` + one trailing text response. Before: the turn consumes the 13th generation. After: it stops at exactly 12 with the full `none → r1×2 → r2×3 → r3×4 → stop` escalation chain.

## What changed

- `tool-dedup.ts`: add `registerSkipped()` for calls that bypassed `prepareToolExecution` (no-op when already registered).
- `turn/index.ts`: call it in `finalizeToolResult`, a hook every call passes through.
- Tests: dedup-level (force-stop at 12 keeping the error flag; no double registration) and the turn-level reproduction above.

## Checklist

- [x] I have read the CONTRIBUTING document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.