### PR TITLE
feat(web): highlight selected settings options with the accent color

### DIFF
--- a/.changeset/web-settings-accent-highlight.md
+++ b/.changeset/web-settings-accent-highlight.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+web: Highlight selected settings options (theme, language, default permission) with the current accent color.

--- a/apps/kimi-web/src/components/mobile/MobileSettingsSheet.vue
+++ b/apps/kimi-web/src/components/mobile/MobileSettingsSheet.vue
@@ -341,6 +341,7 @@ watch(
           { value: 'dark', label: t('theme.dark') },
           { value: 'system', label: t('theme.system') },
         ]"
+        variant="tinted"
         @update:model-value="onColorScheme"
       />
     </div>

--- a/apps/kimi-web/src/components/settings/LanguageSwitcher.vue
+++ b/apps/kimi-web/src/components/settings/LanguageSwitcher.vue
@@ -15,5 +15,5 @@ function choose(code: string): void {
 </script>
 
 <template>
-  <SegmentedControl :model-value="locale" :options="options" @update:model-value="choose" />
+  <SegmentedControl :model-value="locale" :options="options" variant="tinted" @update:model-value="choose" />
 </template>

--- a/apps/kimi-web/src/components/settings/SettingsDialog.vue
+++ b/apps/kimi-web/src/components/settings/SettingsDialog.vue
@@ -352,6 +352,7 @@ function archiveTime(iso: string): string {
                   { value: 'dark', label: t('theme.dark') },
                   { value: 'system', label: t('theme.system') },
                 ]"
+                variant="tinted"
                 @update:model-value="emit('setColorScheme', $event as ColorScheme)"
               />
             </div>
@@ -363,6 +364,7 @@ function archiveTime(iso: string): string {
                   { value: 'blue', label: t('theme.accentBlue') },
                   { value: 'mono', label: t('theme.accentBlack') },
                 ]"
+                variant="tinted"
                 @update:model-value="emit('setAccent', $event as Accent)"
               />
             </div>
@@ -506,6 +508,7 @@ function archiveTime(iso: string): string {
                 <SegmentedControl
                   :model-value="defaultPermissionMode"
                   :options="permissionModes.map((m) => ({ value: m, label: t(permissionLabelKey[m]) }))"
+                  variant="tinted"
                   @update:model-value="setDefaultPermissionMode($event as 'manual' | 'auto' | 'yolo')"
                 />
               </div>

--- a/apps/kimi-web/src/components/ui/SegmentedControl.vue
+++ b/apps/kimi-web/src/components/ui/SegmentedControl.vue
@@ -5,13 +5,15 @@ defineProps<{
   modelValue: string;
   options: { value: string; label: string }[];
   size?: 'sm' | 'md';
+  /** `tinted` highlights the selected item with the accent color (settings option pickers). */
+  variant?: 'default' | 'tinted';
 }>();
 
 const emit = defineEmits<{ 'update:modelValue': [value: string] }>();
 </script>
 
 <template>
-  <div class="ui-seg" :class="`ui-seg--${size ?? 'md'}`" role="tablist">
+  <div class="ui-seg" :class="[`ui-seg--${size ?? 'md'}`, { 'ui-seg--tinted': variant === 'tinted' }]" role="tablist">
     <button
       v-for="opt in options"
       :key="opt.value"
@@ -53,5 +55,6 @@ const emit = defineEmits<{ 'update:modelValue': [value: string] }>();
 .ui-seg--sm .ui-seg__item { height: 24px; padding: 0 var(--space-2); font-size: var(--text-sm); }
 .ui-seg__item:hover:not(.is-on) { color: var(--color-text); }
 .ui-seg__item.is-on { background: var(--color-surface-raised); color: var(--color-text); box-shadow: var(--shadow-xs); }
+.ui-seg--tinted .ui-seg__item.is-on { background: var(--color-accent-soft); color: var(--color-accent); box-shadow: none; }
 .ui-seg__item:focus-visible { outline: none; box-shadow: var(--p-focus-ring); }
 </style>


### PR DESCRIPTION
## Related Issue

No linked issue — the problem is explained below.

## Problem

In the web settings dialog, selected options in the segmented pickers (theme, accent color, language, default permission) were highlighted with a neutral raised surface, so the selection state did not reflect the accent color the user picked (blue / mono).

## What changed

When the Accent color is selected as "Blue",

Before：

<img width="763" height="355" alt="image" src="https://github.com/user-attachments/assets/2232df2c-1d0b-43ba-ad09-ddac7d610bec" />


After：
<img width="771" height="354" alt="image" src="https://github.com/user-attachments/assets/1111a379-15e3-4ddc-b153-19a2577afb5e" />


- Added an optional `tinted` variant to the shared `SegmentedControl` component: the selected item uses `--color-accent-soft` background + `--color-accent` text, matching the settings tab style and following the active accent in both light and dark mode.
- Applied the variant (`variant="tinted"`) to the settings pickers: theme, accent color, and default permission in `SettingsDialog`, the shared `LanguageSwitcher` (also used by the mobile settings sheet), and the theme picker in `MobileSettingsSheet`.
- Left view-toggle usages (diff view, file preview, archive sort) on the neutral highlight, as the design system documents that style for toggles.
- Changeset: `patch` on `@moonshot-ai/kimi-code` (`web:` entry), since the web app ships bundled in the CLI.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [ ] I have added tests that prove my feature works. (CSS-only visual variant; verified with `vue-tsc` typecheck and oxlint.)
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update. (Minor visual tweak; no doc impact.)
