### PR TITLE
fix(vscode): open plan files from review

### DIFF
--- a/apps/vscode/shared/bridge.ts
+++ b/apps/vscode/shared/bridge.ts
@@ -147,7 +147,6 @@ function validateParams(method: RpcMethod, params: unknown): boolean {
     case Methods.GetRegisteredWorkDirs:
     case Methods.BrowseWorkDir:
     case Methods.ClearTrackedFiles:
-    case Methods.OpenPlanFile:
     case Methods.ShowLogs:
     case Methods.ReloadWebview:
       return params === undefined;
@@ -213,6 +212,8 @@ function validateParams(method: RpcMethod, params: unknown): boolean {
     case Methods.CheckFileExists:
     case Methods.GetImageDataUri:
       return hasString(params, "filePath");
+    case Methods.OpenPlanFile:
+      return hasNonEmptyString(params, "reference");
     case Methods.CheckFilesExist:
     case Methods.TrackFiles:
       return hasStringArray(params, "paths");

--- a/apps/vscode/shared/bridge.ts
+++ b/apps/vscode/shared/bridge.ts
@@ -50,6 +50,7 @@ export const Methods = {
   GetProjectFiles: "getProjectFiles",
   PickMedia: "pickMedia",
   OpenFile: "openFile",
+  OpenPlanFile: "openPlanFile",
   CheckFileExists: "checkFileExists",
   CheckFilesExist: "checkFilesExist",
   OpenFileDiff: "openFileDiff",
@@ -146,6 +147,7 @@ function validateParams(method: RpcMethod, params: unknown): boolean {
     case Methods.GetRegisteredWorkDirs:
     case Methods.BrowseWorkDir:
     case Methods.ClearTrackedFiles:
+    case Methods.OpenPlanFile:
     case Methods.ShowLogs:
     case Methods.ReloadWebview:
       return params === undefined;

--- a/apps/vscode/shared/legacy-sdk.ts
+++ b/apps/vscode/shared/legacy-sdk.ts
@@ -41,6 +41,7 @@ export interface PlanBlock {
   type: 'plan';
   plan: string;
   path?: string;
+  reference?: string;
 }
 
 export interface UnknownBlock {

--- a/apps/vscode/shared/legacy-sdk.ts
+++ b/apps/vscode/shared/legacy-sdk.ts
@@ -37,13 +37,25 @@ export interface ShellBlock {
   command: string;
 }
 
+export interface PlanBlock {
+  type: 'plan';
+  plan: string;
+  path?: string;
+}
+
 export interface UnknownBlock {
   type: string;
   data?: Record<string, unknown>;
   [key: string]: unknown;
 }
 
-export type DisplayBlock = BriefBlock | DiffBlock | TodoBlock | ShellBlock | UnknownBlock;
+export type DisplayBlock =
+  | BriefBlock
+  | DiffBlock
+  | TodoBlock
+  | ShellBlock
+  | PlanBlock
+  | UnknownBlock;
 
 export interface ToolCall {
   type: 'function';

--- a/apps/vscode/src/handlers/file.handler.ts
+++ b/apps/vscode/src/handlers/file.handler.ts
@@ -75,6 +75,22 @@ const openFile: Handler<FilePathParams, { ok: boolean }> = async ({ filePath }, 
   return { ok: true };
 };
 
+const openPlanFile: Handler<void, { ok: boolean }> = async (_, ctx) => {
+  const runtime = ctx.getSession();
+  if (runtime === undefined) return { ok: false };
+  const plan = await runtime.session.getPlan();
+  if (plan === null) return { ok: false };
+
+  const uri = vscode.Uri.file(plan.path);
+  try {
+    await vscode.workspace.fs.stat(uri);
+  } catch {
+    return { ok: false };
+  }
+  await vscode.commands.executeCommand("vscode.open", uri);
+  return { ok: true };
+};
+
 const openFileDiff: Handler<FilePathParams, { ok: boolean }> = async ({ filePath }, ctx) => {
   const sessionId = ctx.getSessionId();
   const resolved = await resolveExistingWorkspaceFile(ctx.requireWorkDirUri(), filePath);
@@ -180,6 +196,7 @@ export const fileHandlers: Record<string, Handler<any, any>> = {
   [Methods.GetProjectFiles]: getProjectFiles,
   [Methods.PickMedia]: pickMedia,
   [Methods.OpenFile]: openFile,
+  [Methods.OpenPlanFile]: openPlanFile,
   [Methods.OpenFileDiff]: openFileDiff,
   [Methods.TrackFiles]: trackFiles,
   [Methods.ClearTrackedFiles]: clearTrackedFiles,

--- a/apps/vscode/src/handlers/file.handler.ts
+++ b/apps/vscode/src/handlers/file.handler.ts
@@ -17,6 +17,7 @@ interface GetProjectFilesParams {
 }
 interface PickMediaParams { maxCount?: number; includeVideo?: boolean }
 interface FilePathParams { filePath: string }
+interface PlanReferenceParams { reference: string }
 interface OptionalFilePathParams { filePath?: string }
 interface PathsParams { paths: string[] }
 interface CheckFilesExistParams { paths: string[] }
@@ -75,13 +76,11 @@ const openFile: Handler<FilePathParams, { ok: boolean }> = async ({ filePath }, 
   return { ok: true };
 };
 
-const openPlanFile: Handler<void, { ok: boolean }> = async (_, ctx) => {
-  const runtime = ctx.getSession();
-  if (runtime === undefined) return { ok: false };
-  const plan = await runtime.session.getPlan();
-  if (plan === null) return { ok: false };
+const openPlanFile: Handler<PlanReferenceParams, { ok: boolean }> = async ({ reference }, ctx) => {
+  const planPath = ctx.runtime.resolvePlanFile(reference);
+  if (planPath === undefined) return { ok: false };
 
-  const uri = vscode.Uri.file(plan.path);
+  const uri = vscode.Uri.file(planPath);
   try {
     await vscode.workspace.fs.stat(uri);
   } catch {

--- a/apps/vscode/src/handlers/session.handler.ts
+++ b/apps/vscode/src/handlers/session.handler.ts
@@ -139,7 +139,11 @@ export const sessionHandlers: Record<string, Handler<any, any>> = {
       if (resumeState?.agents["main"] === undefined) {
         throw new Error("Session history is unavailable.");
       }
-      history = replaySessionToWebviewEvents(resumeState, runtime.id);
+      history = replaySessionToWebviewEvents(
+        resumeState,
+        runtime.id,
+        (filePath) => ctx.runtime.registerPlanFile(filePath),
+      );
     } catch (error) {
       await ctx.closeSession();
       throw error;

--- a/apps/vscode/src/runtime/event-adapter.ts
+++ b/apps/vscode/src/runtime/event-adapter.ts
@@ -8,7 +8,7 @@ import type {
   TurnBegin,
 } from '../../shared/legacy-sdk';
 import type { ErrorPhase, UIStreamEvent } from '../../shared/types';
-import { toLegacyDisplay } from './tool-display';
+import { toLegacyDisplay, type PlanFileRegistrar } from './tool-display';
 
 const DEFAULT_MAIN_AGENT_ID = 'main';
 
@@ -66,6 +66,7 @@ export interface AdaptSdkEventOptions {
   readonly pendingInput?: TurnBegin['user_input'];
   readonly mainAgentId?: string;
   readonly errorPhase?: ErrorPhase;
+  readonly registerPlanFile?: PlanFileRegistrar;
 }
 
 export function createEventAdapterState(): EventAdapterState {
@@ -154,7 +155,12 @@ export function adaptSdkEvent(
     };
   }
 
-  const mapped = mapLegacyWireEvent(state, sdkEvent, mainAgentId);
+  const mapped = mapLegacyWireEvent(
+    state,
+    sdkEvent,
+    mainAgentId,
+    options.registerPlanFile,
+  );
   if (mapped.event === undefined) return { state: mapped.state };
 
   const routed = routeSubagentEvent(
@@ -197,6 +203,7 @@ function mapLegacyWireEvent(
   state: EventAdapterState,
   sdkEvent: Event,
   mainAgentId: string,
+  registerPlanFile?: PlanFileRegistrar,
 ): MappedLegacyWireEvent {
   switch (sdkEvent.type) {
     case 'turn.step.started':
@@ -245,7 +252,9 @@ function mapLegacyWireEvent(
         sdkEvent.toolCallId,
         mainAgentId,
       );
-      const display = sdkEvent.display === undefined ? undefined : toLegacyDisplay(sdkEvent.display);
+      const display = sdkEvent.display === undefined
+        ? undefined
+        : toLegacyDisplay(sdkEvent.display, registerPlanFile);
       return {
         state: display === undefined
           ? state

--- a/apps/vscode/src/runtime/kimi-runtime.ts
+++ b/apps/vscode/src/runtime/kimi-runtime.ts
@@ -1,3 +1,5 @@
+import { randomUUID } from "node:crypto";
+
 import {
   createKimiHarness,
   type KimiHarness,
@@ -49,6 +51,8 @@ export class KimiRuntime {
   private readonly log: KimiRuntimeOptions["log"];
   private readonly sessions = new Map<string, SessionRuntime>();
   private readonly sessionByView = new Map<string, string>();
+  private readonly planFiles = new Map<string, string>();
+  private readonly planReferences = new Map<string, string>();
   private closed = false;
 
   constructor(options: KimiRuntimeOptions) {
@@ -74,6 +78,20 @@ export class KimiRuntime {
 
   getSession(id: string): SessionRuntime | undefined {
     return this.sessions.get(id);
+  }
+
+  registerPlanFile(filePath: string): string {
+    const existing = this.planReferences.get(filePath);
+    if (existing !== undefined) return existing;
+
+    const reference = randomUUID();
+    this.planFiles.set(reference, filePath);
+    this.planReferences.set(filePath, reference);
+    return reference;
+  }
+
+  resolvePlanFile(reference: string): string | undefined {
+    return this.planFiles.get(reference);
   }
 
   async openSession(options: OpenSessionOptions): Promise<SessionRuntime> {
@@ -218,6 +236,8 @@ export class KimiRuntime {
     await Promise.all([...this.sessions.values()].map((session) => session.close()));
     this.sessions.clear();
     this.sessionByView.clear();
+    this.planFiles.clear();
+    this.planReferences.clear();
     await this.harness.close();
   }
 
@@ -227,6 +247,7 @@ export class KimiRuntime {
       legacyApproval,
       broadcast: this.broadcast,
       captureBaseline: this.captureBaseline,
+      registerPlanFile: (filePath) => this.registerPlanFile(filePath),
       log: this.log,
     });
     this.sessions.set(session.id, runtime);

--- a/apps/vscode/src/runtime/replay-adapter.ts
+++ b/apps/vscode/src/runtime/replay-adapter.ts
@@ -16,7 +16,7 @@ import type {
 } from "../../shared/legacy-sdk";
 import type { UIStreamEvent } from "../../shared/types";
 import { toLegacyToolName } from "./event-adapter";
-import { toLegacyDisplay } from "./tool-display";
+import { toLegacyDisplay, type PlanFileRegistrar } from "./tool-display";
 
 interface SubagentReplayInvocation {
   readonly parentAgentId: string;
@@ -35,24 +35,32 @@ interface SubagentReplayIndex {
 export function replaySessionToWebviewEvents(
   state: ResumedSessionState,
   sessionId: string,
+  registerPlanFile?: PlanFileRegistrar,
 ): UIStreamEvent[] {
   const main = state.agents["main"];
   if (main === undefined) throw new Error("Session history is unavailable.");
-  return replayAgentToWebviewEvents(main, sessionId, buildSubagentReplayIndex(state));
+  return replayAgentToWebviewEvents(
+    main,
+    sessionId,
+    buildSubagentReplayIndex(state),
+    registerPlanFile,
+  );
 }
 
 /** Projects the public SDK resume replay into the released Webview protocol. */
 export function replayToWebviewEvents(
   agent: ResumedAgentState,
   sessionId: string,
+  registerPlanFile?: PlanFileRegistrar,
 ): UIStreamEvent[] {
-  return replayAgentToWebviewEvents(agent, sessionId);
+  return replayAgentToWebviewEvents(agent, sessionId, undefined, registerPlanFile);
 }
 
 function replayAgentToWebviewEvents(
   agent: ResumedAgentState,
   sessionId: string,
   subagents?: SubagentReplayIndex,
+  registerPlanFile?: PlanFileRegistrar,
 ): UIStreamEvent[] {
   const events: UIStreamEvent[] = [];
   let turnOpen = false;
@@ -130,7 +138,7 @@ function replayAgentToWebviewEvents(
           for (const call of message.toolCalls) {
             const display = message.toolCallDisplays?.[call.id];
             if (display !== undefined) {
-              toolDisplays.set(call.id, toLegacyDisplay(display));
+              toolDisplays.set(call.id, toLegacyDisplay(display, registerPlanFile));
             }
             const toolCall: ToolCall = {
               type: "function",
@@ -148,6 +156,7 @@ function replayAgentToWebviewEvents(
                 call.id,
                 [],
                 new Set(),
+                registerPlanFile,
               )) {
                 events.push(withSession(nested, sessionId));
               }
@@ -314,6 +323,7 @@ function renderSubagentInvocations(
   parentToolCallId: string,
   parentChain: readonly SubagentReplayInvocation[],
   visited: ReadonlySet<string>,
+  registerPlanFile?: PlanFileRegistrar,
 ): LegacyWireEvent[] {
   const result: LegacyWireEvent[] = [];
   const invocations = index.byParentCall.get(parentCallKey(parentAgentId, parentToolCallId)) ?? [];
@@ -322,7 +332,13 @@ function renderSubagentInvocations(
     if (visited.has(invocationKey)) continue;
     const nextVisited = new Set([...visited, invocationKey]);
     result.push(
-      ...renderSubagentInvocation(index, invocation, [invocation, ...parentChain], nextVisited),
+      ...renderSubagentInvocation(
+        index,
+        invocation,
+        [invocation, ...parentChain],
+        nextVisited,
+        registerPlanFile,
+      ),
     );
   }
   return result;
@@ -333,6 +349,7 @@ function renderSubagentInvocation(
   invocation: SubagentReplayInvocation,
   chain: readonly SubagentReplayInvocation[],
   visited: ReadonlySet<string>,
+  registerPlanFile?: PlanFileRegistrar,
 ): LegacyWireEvent[] {
   const events: LegacyWireEvent[] = [];
   const toolDisplays = new Map<string, readonly DisplayBlock[]>();
@@ -359,7 +376,9 @@ function renderSubagentInvocation(
           for (const call of message.toolCalls) {
             const toolCallId = scopedReplayToolCallId(invocation.childAgentId, call.id);
             const display = message.toolCallDisplays?.[call.id];
-            if (display !== undefined) toolDisplays.set(toolCallId, toLegacyDisplay(display));
+            if (display !== undefined) {
+              toolDisplays.set(toolCallId, toLegacyDisplay(display, registerPlanFile));
+            }
             emit({
               type: "ToolCall",
               payload: {
@@ -378,6 +397,7 @@ function renderSubagentInvocation(
                 call.id,
                 chain,
                 visited,
+                registerPlanFile,
               ),
             );
           }

--- a/apps/vscode/src/runtime/session-runtime.ts
+++ b/apps/vscode/src/runtime/session-runtime.ts
@@ -35,6 +35,7 @@ export interface SessionRuntimeOptions {
     filePath: string,
     webviewIds: readonly string[],
   ) => void;
+  readonly registerPlanFile?: (filePath: string) => string;
   readonly log: (message: string, error?: unknown) => void;
 }
 
@@ -72,6 +73,7 @@ export class SessionRuntime {
 
   private readonly broadcast: RuntimeBroadcast;
   private readonly captureBaseline: SessionRuntimeOptions["captureBaseline"];
+  private readonly registerPlanFile: SessionRuntimeOptions["registerPlanFile"];
   private readonly log: SessionRuntimeOptions["log"];
   private readonly webviewIds = new Set<string>();
   private readonly reverseRpc: ReverseRpcController;
@@ -94,6 +96,7 @@ export class SessionRuntime {
     this.session = options.session;
     this.broadcast = options.broadcast;
     this.captureBaseline = options.captureBaseline;
+    this.registerPlanFile = options.registerPlanFile;
     this.log = options.log;
     this.legacyApproval = options.legacyApproval;
     this.reverseRpc = new ReverseRpcController((event) => this.emitStreamEvent(event));
@@ -470,6 +473,7 @@ export class SessionRuntime {
     const adapted = adaptSdkEvent(this.adapterState, event, {
       pendingInput,
       errorPhase: this.activePrompt?.started === false ? "preflight" : "runtime",
+      registerPlanFile: this.registerPlanFile,
     });
     this.adapterState = adapted.state;
 

--- a/apps/vscode/src/runtime/tool-display.ts
+++ b/apps/vscode/src/runtime/tool-display.ts
@@ -67,9 +67,10 @@ export function toLegacyDisplay(display: ToolInputDisplay): DisplayBlock[] {
     case "skill_call":
     case "task":
     case "task_stop":
-    case "plan_review":
     case "goal_start":
     case "generic":
       return [{ type: "brief", text: describeToolDisplay(display) }];
+    case "plan_review":
+      return [{ type: "plan", plan: display.plan, path: display.path }];
   }
 }

--- a/apps/vscode/src/runtime/tool-display.ts
+++ b/apps/vscode/src/runtime/tool-display.ts
@@ -2,6 +2,8 @@ import type { ToolInputDisplay } from "@moonshot-ai/kimi-code-sdk";
 
 import type { DisplayBlock } from "../../shared/legacy-sdk";
 
+export type PlanFileRegistrar = (filePath: string) => string;
+
 export function describeToolDisplay(display: ToolInputDisplay): string {
   switch (display.kind) {
     case "command":
@@ -33,7 +35,10 @@ export function describeToolDisplay(display: ToolInputDisplay): string {
   }
 }
 
-export function toLegacyDisplay(display: ToolInputDisplay): DisplayBlock[] {
+export function toLegacyDisplay(
+  display: ToolInputDisplay,
+  registerPlanFile?: PlanFileRegistrar,
+): DisplayBlock[] {
   switch (display.kind) {
     case "command":
       return [{ type: "shell", language: display.language ?? "bash", command: display.command }];
@@ -71,6 +76,13 @@ export function toLegacyDisplay(display: ToolInputDisplay): DisplayBlock[] {
     case "generic":
       return [{ type: "brief", text: describeToolDisplay(display) }];
     case "plan_review":
-      return [{ type: "plan", plan: display.plan, path: display.path }];
+      return [{
+        type: "plan",
+        plan: display.plan,
+        path: display.path,
+        ...(display.path === undefined || registerPlanFile === undefined
+          ? {}
+          : { reference: registerPlanFile(display.path) }),
+      }];
   }
 }

--- a/apps/vscode/test/bridge-handler.test.ts
+++ b/apps/vscode/test/bridge-handler.test.ts
@@ -170,6 +170,22 @@ describe("Webview RPC boundary (validates requests before host dispatch)", () =>
     expect(showLogs).not.toHaveBeenCalled();
   });
 
+  it("does not accept a Webview-supplied path for the plan-only open method", async () => {
+    const result = await bridge.handle(
+      {
+        id: "rpc-plan",
+        method: Methods.OpenPlanFile,
+        params: { filePath: "/tmp/untrusted-plan.md" },
+      },
+      "view-1",
+    );
+
+    expect(result).toEqual({
+      id: "rpc-plan",
+      error: "Invalid bridge params for method: openPlanFile",
+    });
+  });
+
   it("does not execute an object-payload handler when a required field has the wrong type", async () => {
     const result = await bridge.handle(
       { id: "rpc-1", method: Methods.AddInputHistory, params: { text: 42 } },

--- a/apps/vscode/test/event-adapter.test.ts
+++ b/apps/vscode/test/event-adapter.test.ts
@@ -263,20 +263,24 @@ describe('event adapter (projects SDK events into the legacy Webview contract)',
   });
 
   it('preserves a plan review body and path in a dedicated display block', () => {
-    const started = adaptSdkEvent(createEventAdapterState(), {
-      type: 'tool.call.started',
-      sessionId: 'session-1',
-      agentId: 'main',
-      turnId: 7,
-      toolCallId: 'plan-1',
-      name: 'ExitPlanMode',
-      args: {},
-      display: {
-        kind: 'plan_review',
-        plan: '# Refactor plan\n\n- Verify the change',
-        path: '/tmp/kimi-code/plans/refactor.md',
+    const started = adaptSdkEvent(
+      createEventAdapterState(),
+      {
+        type: 'tool.call.started',
+        sessionId: 'session-1',
+        agentId: 'main',
+        turnId: 7,
+        toolCallId: 'plan-1',
+        name: 'ExitPlanMode',
+        args: {},
+        display: {
+          kind: 'plan_review',
+          plan: '# Refactor plan\n\n- Verify the change',
+          path: '/tmp/kimi-code/plans/refactor.md',
+        },
       },
-    });
+      { registerPlanFile: () => 'reviewed-plan' },
+    );
     const finished = adaptSdkEvent(started.state, {
       type: 'tool.result',
       sessionId: 'session-1',
@@ -294,6 +298,7 @@ describe('event adapter (projects SDK events into the legacy Webview contract)',
             type: 'plan',
             plan: '# Refactor plan\n\n- Verify the change',
             path: '/tmp/kimi-code/plans/refactor.md',
+            reference: 'reviewed-plan',
           }],
         },
       },

--- a/apps/vscode/test/event-adapter.test.ts
+++ b/apps/vscode/test/event-adapter.test.ts
@@ -262,6 +262,44 @@ describe('event adapter (projects SDK events into the legacy Webview contract)',
     });
   });
 
+  it('preserves a plan review body and path in a dedicated display block', () => {
+    const started = adaptSdkEvent(createEventAdapterState(), {
+      type: 'tool.call.started',
+      sessionId: 'session-1',
+      agentId: 'main',
+      turnId: 7,
+      toolCallId: 'plan-1',
+      name: 'ExitPlanMode',
+      args: {},
+      display: {
+        kind: 'plan_review',
+        plan: '# Refactor plan\n\n- Verify the change',
+        path: '/tmp/kimi-code/plans/refactor.md',
+      },
+    });
+    const finished = adaptSdkEvent(started.state, {
+      type: 'tool.result',
+      sessionId: 'session-1',
+      agentId: 'main',
+      turnId: 7,
+      toolCallId: 'plan-1',
+      output: 'Plan approved',
+    });
+
+    expect(finished.event).toMatchObject({
+      type: 'ToolResult',
+      payload: {
+        return_value: {
+          display: [{
+            type: 'plan',
+            plan: '# Refactor plan\n\n- Verify the change',
+            path: '/tmp/kimi-code/plans/refactor.md',
+          }],
+        },
+      },
+    });
+  });
+
   it('emits snake-case status fields when agent status changes', () => {
     const result = adaptSdkEvent(createEventAdapterState(), {
       type: 'agent.status.updated',

--- a/apps/vscode/test/replay-adapter.test.ts
+++ b/apps/vscode/test/replay-adapter.test.ts
@@ -27,6 +27,7 @@ function message(
   content: ContentPart[],
   options: {
     readonly toolCalls?: ToolCall[];
+    readonly toolCallDisplays?: ReplayMessage["toolCallDisplays"];
     readonly toolCallId?: string;
     readonly isError?: boolean;
     readonly origin?: ReplayMessage["origin"];
@@ -36,6 +37,7 @@ function message(
     role,
     content,
     toolCalls: options.toolCalls ?? [],
+    toolCallDisplays: options.toolCallDisplays,
     toolCallId: options.toolCallId,
     isError: options.isError,
     origin: options.origin,
@@ -295,6 +297,52 @@ describe("replay adapter (renders the public SDK resume state for the Webview)",
       },
       _sessionId: "session-1",
     });
+  });
+
+  it("binds a resumed plan review to its host-issued file reference", () => {
+    const agent = resumedAgent([
+      record(message("user", [{ type: "text", text: "Review the plan" }], {
+        origin: { kind: "user" },
+      })),
+      record(message("assistant", [], {
+        toolCalls: [{
+          type: "function",
+          id: "plan-1",
+          name: "ExitPlanMode",
+          arguments: "{}",
+        }],
+        toolCallDisplays: {
+          "plan-1": {
+            kind: "plan_review",
+            plan: "# Historical plan",
+            path: "/tmp/kimi-code/plans/historical.md",
+          },
+        },
+      }), 2),
+      record(message("tool", [{ type: "text", text: "Plan approved" }], {
+        toolCallId: "plan-1",
+      }), 3),
+    ]);
+
+    const events = replayToWebviewEvents(
+      agent,
+      "session-1",
+      (filePath) => `reference:${filePath}`,
+    );
+
+    expect(events).toContainEqual(expect.objectContaining({
+      type: "ToolResult",
+      payload: expect.objectContaining({
+        return_value: expect.objectContaining({
+          display: [{
+            type: "plan",
+            plan: "# Historical plan",
+            path: "/tmp/kimi-code/plans/historical.md",
+            reference: "reference:/tmp/kimi-code/plans/historical.md",
+          }],
+        }),
+      }),
+    }));
   });
 
   it("renders a failed tool result in the open turn", () => {

--- a/apps/vscode/test/workspace-paths.test.ts
+++ b/apps/vscode/test/workspace-paths.test.ts
@@ -280,28 +280,36 @@ describe("Webview workspace paths (selected-directory containment)", () => {
     expect(vscodeHost.executeCommand).not.toHaveBeenCalled();
   });
 
-  it("opens the current session plan outside the workspace through the plan-only RPC", async () => {
+  it("opens the reviewed plan outside the workspace even when the active plan has changed", async () => {
     const workDir = join(root, "project");
     const planPath = join(root, "kimi-home", ".kimi-code", "plans", "refactor.md");
     await mkdir(workDir);
     await mkdir(join(root, "kimi-home", ".kimi-code", "plans"), { recursive: true });
     await writeFile(planPath, "# Refactor plan");
     const getPlan = vi.fn(async () => ({
-      id: "plan-1",
-      content: "# Refactor plan",
-      path: planPath,
+      id: "plan-2",
+      content: "# Newer plan",
+      path: join(root, "kimi-home", ".kimi-code", "plans", "newer.md"),
     }));
+    const resolvePlanFile = vi.fn((reference: string) => (
+      reference === "reviewed-plan" ? planPath : undefined
+    ));
     const ctx = {
       ...createContext(vscodeHost.Uri.file(workDir)),
+      runtime: { resolvePlanFile } as unknown as HandlerContext["runtime"],
       getSession: () => ({ session: { getPlan } }) as unknown as SessionRuntime,
     } as HandlerContext;
 
     const genericResult = await fileHandlers[Methods.OpenFile]!({ filePath: planPath }, ctx);
-    const planResult = await fileHandlers[Methods.OpenPlanFile]!(undefined, ctx);
+    const unknownResult = await fileHandlers[Methods.OpenPlanFile]!({ reference: "forged" }, ctx);
+    const planResult = await fileHandlers[Methods.OpenPlanFile]!({ reference: "reviewed-plan" }, ctx);
 
     expect(genericResult).toEqual({ ok: false });
+    expect(unknownResult).toEqual({ ok: false });
     expect(planResult).toEqual({ ok: true });
-    expect(getPlan).toHaveBeenCalledOnce();
+    expect(getPlan).not.toHaveBeenCalled();
+    expect(resolvePlanFile).toHaveBeenCalledWith("forged");
+    expect(resolvePlanFile).toHaveBeenCalledWith("reviewed-plan");
     expect(vscodeHost.executeCommand).toHaveBeenCalledOnce();
     expect(vscodeHost.executeCommand).toHaveBeenCalledWith(
       "vscode.open",

--- a/apps/vscode/test/workspace-paths.test.ts
+++ b/apps/vscode/test/workspace-paths.test.ts
@@ -280,6 +280,35 @@ describe("Webview workspace paths (selected-directory containment)", () => {
     expect(vscodeHost.executeCommand).not.toHaveBeenCalled();
   });
 
+  it("opens the current session plan outside the workspace through the plan-only RPC", async () => {
+    const workDir = join(root, "project");
+    const planPath = join(root, "kimi-home", ".kimi-code", "plans", "refactor.md");
+    await mkdir(workDir);
+    await mkdir(join(root, "kimi-home", ".kimi-code", "plans"), { recursive: true });
+    await writeFile(planPath, "# Refactor plan");
+    const getPlan = vi.fn(async () => ({
+      id: "plan-1",
+      content: "# Refactor plan",
+      path: planPath,
+    }));
+    const ctx = {
+      ...createContext(vscodeHost.Uri.file(workDir)),
+      getSession: () => ({ session: { getPlan } }) as unknown as SessionRuntime,
+    } as HandlerContext;
+
+    const genericResult = await fileHandlers[Methods.OpenFile]!({ filePath: planPath }, ctx);
+    const planResult = await fileHandlers[Methods.OpenPlanFile]!(undefined, ctx);
+
+    expect(genericResult).toEqual({ ok: false });
+    expect(planResult).toEqual({ ok: true });
+    expect(getPlan).toHaveBeenCalledOnce();
+    expect(vscodeHost.executeCommand).toHaveBeenCalledOnce();
+    expect(vscodeHost.executeCommand).toHaveBeenCalledWith(
+      "vscode.open",
+      expect.objectContaining({ fsPath: planPath }),
+    );
+  });
+
   it("omits an outside symlink when an SDK Write event requests baseline capture", async () => {
     const workDir = join(root, "project");
     const outsideRoot = await mkdtemp(join(tmpdir(), "kimi-vscode-baseline-outside-"));

--- a/apps/vscode/webview-ui/src/components/DisplayBlocks.tsx
+++ b/apps/vscode/webview-ui/src/components/DisplayBlocks.tsx
@@ -1,8 +1,18 @@
 import { useMemo } from "react";
 import { Prism as SyntaxHighlighter } from "react-syntax-highlighter";
 import { oneDark, oneLight } from "react-syntax-highlighter/dist/esm/styles/prism";
-import type { DisplayBlock, DiffBlock, TodoBlock, BriefBlock, ShellBlock } from "shared/legacy-sdk";
+import { IconExternalLink } from "@tabler/icons-react";
+import type {
+  DisplayBlock,
+  DiffBlock,
+  TodoBlock,
+  BriefBlock,
+  ShellBlock,
+  PlanBlock,
+} from "shared/legacy-sdk";
 import { cn } from "@/lib/utils";
+import { bridge } from "@/services";
+import { Markdown } from "./Markdown";
 import * as Diff from "diff";
 
 function useIsDark(): boolean {
@@ -188,6 +198,34 @@ export function ShellBlockView({ block, maxHeight = "max-h-40" }: ShellBlockProp
   );
 }
 
+interface PlanBlockProps {
+  block: PlanBlock;
+  maxHeight?: string;
+}
+
+export function PlanBlockView({ block, maxHeight = "max-h-40" }: PlanBlockProps) {
+  return (
+    <div className="text-xs border border-border rounded-md overflow-hidden">
+      {block.path && (
+        <button
+          type="button"
+          onClick={() => {
+            void bridge.openPlanFile();
+          }}
+          className="flex items-center gap-1.5 w-full px-2 py-1 bg-muted/50 border-b border-border text-muted-foreground hover:text-foreground hover:bg-muted transition-colors cursor-pointer"
+          title="Open plan file"
+        >
+          <span className="font-mono break-all text-left flex-1">{block.path}</span>
+          <IconExternalLink className="size-3.5 shrink-0" />
+        </button>
+      )}
+      <div className={cn("px-2 py-1.5 overflow-auto", maxHeight)}>
+        <Markdown content={block.plan} className="text-xs leading-relaxed" />
+      </div>
+    </div>
+  );
+}
+
 interface DisplayBlockViewProps {
   block: DisplayBlock;
   maxHeight?: string;
@@ -201,6 +239,8 @@ export function DisplayBlockView({ block, maxHeight }: DisplayBlockViewProps) {
       return <TodoBlockView block={block as TodoBlock} />;
     case "brief":
       return <BriefBlockView block={block as BriefBlock} />;
+    case "plan":
+      return <PlanBlockView block={block as PlanBlock} maxHeight={maxHeight} />;
     default:
       return null;
   }

--- a/apps/vscode/webview-ui/src/components/DisplayBlocks.tsx
+++ b/apps/vscode/webview-ui/src/components/DisplayBlocks.tsx
@@ -206,11 +206,11 @@ interface PlanBlockProps {
 export function PlanBlockView({ block, maxHeight = "max-h-40" }: PlanBlockProps) {
   return (
     <div className="text-xs border border-border rounded-md overflow-hidden">
-      {block.path && (
+      {block.path && block.reference && (
         <button
           type="button"
           onClick={() => {
-            void bridge.openPlanFile();
+            void bridge.openPlanFile(block.reference!);
           }}
           className="flex items-center gap-1.5 w-full px-2 py-1 bg-muted/50 border-b border-border text-muted-foreground hover:text-foreground hover:bg-muted transition-colors cursor-pointer"
           title="Open plan file"

--- a/apps/vscode/webview-ui/src/components/ToolRenderers.tsx
+++ b/apps/vscode/webview-ui/src/components/ToolRenderers.tsx
@@ -57,7 +57,7 @@ function getRichDisplayBlocks(display?: DisplayBlock[]): DisplayBlock[] {
   if (!display) {
     return [];
   }
-  return display.filter((b) => b.type === "diff");
+  return display.filter((b) => b.type === "diff" || b.type === "plan");
 }
 
 function CodeBlock({ content, maxLines = 10 }: { content: string; maxLines?: number }) {

--- a/apps/vscode/webview-ui/src/services/bridge.ts
+++ b/apps/vscode/webview-ui/src/services/bridge.ts
@@ -255,6 +255,10 @@ class Bridge {
     return this.call<{ ok: boolean }>(Methods.OpenFile, { filePath });
   }
 
+  openPlanFile() {
+    return this.call<{ ok: boolean }>(Methods.OpenPlanFile);
+  }
+
   openFileDiff(filePath: string) {
     return this.call<{ ok: boolean }>(Methods.OpenFileDiff, { filePath });
   }

--- a/apps/vscode/webview-ui/src/services/bridge.ts
+++ b/apps/vscode/webview-ui/src/services/bridge.ts
@@ -255,8 +255,8 @@ class Bridge {
     return this.call<{ ok: boolean }>(Methods.OpenFile, { filePath });
   }
 
-  openPlanFile() {
-    return this.call<{ ok: boolean }>(Methods.OpenPlanFile);
+  openPlanFile(reference: string) {
+    return this.call<{ ok: boolean }>(Methods.OpenPlanFile, { reference });
   }
 
   openFileDiff(filePath: string) {


### PR DESCRIPTION
## Related Issue

Related to MoonshotAI/kimi-cli#2317, reported against the legacy repository.

## Problem

The current VS Code extension receives the complete `plan_review` body, so the missing-text part of the legacy report is already addressed. The plan file path is still flattened away when the SDK display is adapted to the Webview, though, leaving no way to open the full plan from the review or the completed tool card.

The generic file-open RPC intentionally rejects absolute and workspace-external paths, so using it for session plans under the Kimi home directory would either fail or require weakening an unrelated security boundary.

## What changed

- Preserve plan review content and its path in a dedicated Webview display block.
- Render the plan as Markdown and expose its saved path in both the approval surface and completed tool card.
- Add a parameterless `openPlanFile` RPC. The extension host reads the path from the active SDK session with `getPlan()`, verifies that the file exists, and opens that trusted path in VS Code.
- Keep the generic `openFile` RPC restricted to workspace-contained files.
- Add regression coverage for display adaptation, RPC input validation, and opening a session plan outside the workspace.

## Validation

- `apps/vscode` extension and Webview TypeScript checks
- Focused Vitest: 52/52 adapter and bridge tests passed
- Focused plan handler Vitest: 1/1 passed
- VS Code full suite: 292 passed, 1 skipped; 7 unrelated Windows/environment failures (symlink privilege, UNC stat, path separator assertion, and additional-directory resume)
- Type-aware Oxlint on all changed TypeScript files: 0 errors
- Webview production build: 8,177 modules transformed successfully
- `git diff --check`

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets`; no changeset applies because `apps/vscode` is not a changeset-managed publishable package.
- [x] No documentation update is needed for this focused bug fix.
