### PR TITLE
fix(cli): share telemetry shutdown deadline

### DIFF
--- a/.changeset/calm-ravens-share.md
+++ b/.changeset/calm-ravens-share.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Share one telemetry shutdown deadline across CLI-owned pipelines.

--- a/apps/kimi-code/src/cli/run-prompt.ts
+++ b/apps/kimi-code/src/cli/run-prompt.ts
@@ -32,6 +32,10 @@ import {
 import type { PromptHarness, PromptSession } from './prompt-session';
 import { PromptJsonWriter, PromptTranscriptWriter, writeResumeHint } from './prompt-render';
 import { createCliTelemetryBootstrap, initializeCliTelemetry } from './telemetry';
+import {
+  createTelemetryShutdownDeadline,
+  formatTelemetryShutdownWarning,
+} from './telemetry-shutdown';
 import { createKimiCodeHostIdentity } from './version';
 
 /**
@@ -153,7 +157,15 @@ export async function runPrompt(
       try {
         await restorePromptSessionPermission();
       } finally {
-        await shutdownTelemetry({ timeoutMs: CLI_SHUTDOWN_TIMEOUT_MS });
+        const telemetryDeadline = createTelemetryShutdownDeadline(
+          CLI_SHUTDOWN_TIMEOUT_MS,
+          (error) => {
+            stderr.write(formatTelemetryShutdownWarning(error));
+          },
+        );
+        await telemetryDeadline.run((remainingMs) =>
+          shutdownTelemetry({ timeoutMs: remainingMs }),
+        );
         await harness.close();
       }
     })());

--- a/apps/kimi-code/src/cli/sub/web/run.ts
+++ b/apps/kimi-code/src/cli/sub/web/run.ts
@@ -24,6 +24,7 @@ import { getDataDir } from '#/utils/paths';
 import { generateRemoteControlQr } from '#/utils/remote-control-qr';
 
 import { initializeServerTelemetry } from '../../telemetry';
+import { createTelemetryShutdownDeadline } from '../../telemetry-shutdown';
 import {
   createKimiCodeHostIdentity,
   getHostPackageRoot,
@@ -68,7 +69,7 @@ const WEB_ASSETS_DIR = 'dist-web';
 interface RoutedServer {
   readonly address: string;
   readonly logger: ServerLogger;
-  close(): Promise<void>;
+  close(options?: { readonly telemetryDeadlineMs?: number }): Promise<void>;
 }
 
 export interface WebCliOptions extends ServerCliOptions {
@@ -334,15 +335,23 @@ async function runServerInProcess(
         'foreground shutdown hook error',
       );
     }
-    try {
-      await running?.close();
-      await shutdownTelemetry({ timeoutMs: CLI_SHUTDOWN_TIMEOUT_MS });
-    } catch (error) {
-      running?.logger.error(
-        { err: error instanceof Error ? error : new Error(String(error)) },
-        'server shutdown error',
-      );
-    }
+    const telemetryDeadline = createTelemetryShutdownDeadline(
+      CLI_SHUTDOWN_TIMEOUT_MS,
+      (error) => {
+        running?.logger.error(
+          { err: error instanceof Error ? error : new Error(String(error)) },
+          'telemetry shutdown error',
+        );
+      },
+    );
+    await telemetryDeadline.run(async () =>
+      running?.close({
+        telemetryDeadlineMs: telemetryDeadline.expiresAtMs,
+      }),
+    );
+    await telemetryDeadline.run((remainingMs) =>
+      shutdownTelemetry({ timeoutMs: remainingMs }),
+    );
     process.exit(0);
   }
 
@@ -390,7 +399,7 @@ async function runServerInProcess(
   running = {
     address: `http://${v2.host}:${v2.port}`,
     logger,
-    close: () => v2.close(),
+    close: (closeOptions) => v2.close(closeOptions),
   };
 
   track('server_started', { daemon: false });

--- a/apps/kimi-code/src/cli/telemetry-shutdown.ts
+++ b/apps/kimi-code/src/cli/telemetry-shutdown.ts
@@ -1,0 +1,41 @@
+export interface TelemetryShutdownDeadline {
+  readonly expiresAtMs: number;
+  remainingMs(): number;
+  run(pipeline: (remainingMs: number) => Promise<void>): Promise<void>;
+}
+
+const TELEMETRY_SHUTDOWN_WARNING_PREFIX = 'Warning: telemetry shutdown failed:';
+
+export function formatTelemetryShutdownWarning(error: unknown): string {
+  const message = error instanceof Error ? error.message : String(error);
+  return `${TELEMETRY_SHUTDOWN_WARNING_PREFIX} ${message}\n`;
+}
+
+/**
+ * One process-exit budget shared by every telemetry pipeline owned by a CLI
+ * entrypoint. Pipelines remain independent: each receives the current budget,
+ * and a failure never prevents the next owner from attempting its cleanup.
+ */
+export function createTelemetryShutdownDeadline(
+  timeoutMs: number,
+  onError: (error: unknown) => void,
+  now: () => number = Date.now,
+): TelemetryShutdownDeadline {
+  const expiresAtMs = now() + timeoutMs;
+  const remainingMs = (): number => Math.max(0, expiresAtMs - now());
+  return {
+    expiresAtMs,
+    remainingMs,
+    run: async (pipeline) => {
+      try {
+        await pipeline(remainingMs());
+      } catch (error) {
+        try {
+          onError(error);
+        } catch {
+          // A broken stderr/logger boundary must not block later cleanup.
+        }
+      }
+    },
+  };
+}

--- a/apps/kimi-code/src/cli/v2/run-v2-print.ts
+++ b/apps/kimi-code/src/cli/v2/run-v2-print.ts
@@ -94,6 +94,10 @@ import {
   raceWithTimeout,
   requireConfiguredModel,
 } from '../run-prompt';
+import {
+  createTelemetryShutdownDeadline,
+  formatTelemetryShutdownWarning,
+} from '../telemetry-shutdown';
 import { createKimiCodeHostIdentity } from '../version';
 
 import { resolveOutputFormat } from '../options';
@@ -191,8 +195,17 @@ export async function runV2Print(
       try {
         await restorePermission();
       } finally {
+        const telemetryDeadline = createTelemetryShutdownDeadline(
+          CLI_SHUTDOWN_TIMEOUT_MS,
+          (error) => {
+            stderr.write(formatTelemetryShutdownWarning(error));
+          },
+        );
         if (telemetryService !== undefined) {
-          await raceWithTimeout(telemetryService.shutdown(), CLI_SHUTDOWN_TIMEOUT_MS);
+          const service = telemetryService;
+          await telemetryDeadline.run((remainingMs) =>
+            raceWithTimeout(service.shutdown(), remainingMs),
+          );
         }
         app.dispose();
       }

--- a/apps/kimi-code/test/cli/run-prompt.test.ts
+++ b/apps/kimi-code/test/cli/run-prompt.test.ts
@@ -361,6 +361,23 @@ describe('runPrompt', () => {
     ).rejects.toThrow('close failed');
   });
 
+  it('reports telemetry shutdown failure without changing a successful result', async () => {
+    const stdout = writer();
+    const stderr = writer();
+    mocks.shutdownTelemetry.mockRejectedValueOnce(
+      new Error('telemetry unavailable'),
+    );
+
+    await expect(
+      runPrompt(opts(), '1.2.3-test', { stdout, stderr, process: fakeProcess() }),
+    ).resolves.toBeUndefined();
+
+    expect(stderr.text()).toContain(
+      'Warning: telemetry shutdown failed: telemetry unavailable',
+    );
+    expect(mocks.harnessClose).toHaveBeenCalledOnce();
+  });
+
   it('ignores a cleanup rejection that lands after the timeout', async () => {
     vi.useFakeTimers();
     try {

--- a/apps/kimi-code/test/cli/telemetry.test.ts
+++ b/apps/kimi-code/test/cli/telemetry.test.ts
@@ -117,3 +117,90 @@ describe('initializeServerTelemetry', () => {
     );
   });
 });
+
+describe('telemetry shutdown deadline', () => {
+  it('gives each pipeline only the budget remaining from one deadline', async () => {
+    const { createTelemetryShutdownDeadline } = await import(
+      '#/cli/telemetry-shutdown'
+    );
+    let nowMs = 1_000;
+    const observedBudgets: number[] = [];
+    const deadline = createTelemetryShutdownDeadline(
+      3_000,
+      vi.fn(),
+      () => nowMs,
+    );
+
+    await deadline.run(async (remainingMs) => {
+      observedBudgets.push(remainingMs);
+      nowMs = 2_250;
+    });
+    await deadline.run(async (remainingMs) => {
+      observedBudgets.push(remainingMs);
+    });
+
+    expect(observedBudgets).toEqual([3_000, 1_750]);
+  });
+
+  it('still invokes a later pipeline with no budget after the deadline expires', async () => {
+    const { createTelemetryShutdownDeadline } = await import(
+      '#/cli/telemetry-shutdown'
+    );
+    let nowMs = 1_000;
+    const pipeline = vi.fn(async (_remainingMs: number) => {});
+    const deadline = createTelemetryShutdownDeadline(
+      3_000,
+      vi.fn(),
+      () => nowMs,
+    );
+    nowMs = 4_001;
+
+    await deadline.run(pipeline);
+
+    expect(pipeline).toHaveBeenCalledWith(0);
+  });
+
+  it('continues to a later pipeline after an earlier one rejects', async () => {
+    const { createTelemetryShutdownDeadline } = await import(
+      '#/cli/telemetry-shutdown'
+    );
+    const laterPipeline = vi.fn(async (_remainingMs: number) => {});
+    const reportError = vi.fn();
+    const deadline = createTelemetryShutdownDeadline(
+      3_000,
+      reportError,
+      () => 1_000,
+    );
+
+    await expect(
+      deadline.run(async () => {
+        throw new Error('telemetry unavailable');
+      }),
+    ).resolves.toBeUndefined();
+    await deadline.run(laterPipeline);
+
+    expect(laterPipeline).toHaveBeenCalledOnce();
+    expect(reportError).toHaveBeenCalledWith(
+      expect.objectContaining({ message: 'telemetry unavailable' }),
+    );
+  });
+
+  it('continues to a later pipeline when the error reporter also throws', async () => {
+    const { createTelemetryShutdownDeadline } = await import(
+      '#/cli/telemetry-shutdown'
+    );
+    const laterPipeline = vi.fn(async (_remainingMs: number) => {});
+    const deadline = createTelemetryShutdownDeadline(3_000, () => {
+      throw new Error('stderr unavailable');
+    });
+
+    await expect(
+      deadline.run(async () => {
+        throw new Error('telemetry unavailable');
+      }),
+    ).resolves.toBeUndefined();
+    await deadline.run(laterPipeline);
+
+    expect(laterPipeline).toHaveBeenCalledOnce();
+  });
+});

--- a/apps/kimi-code/test/cli/v2-run-print.test.ts
+++ b/apps/kimi-code/test/cli/v2-run-print.test.ts
@@ -301,6 +301,28 @@ describe('runV2Print', () => {
     expect(app.dispose).toHaveBeenCalled();
   });
 
+  it('preserves a successful print result when telemetry shutdown rejects', async () => {
+    const stdout = writer();
+    const stderr = writer();
+    const { app, agent, appServices } = makeFakeHarness();
+    const telemetry = appServices.get(ITelemetryService) as {
+      shutdown: ReturnType<typeof vi.fn>;
+    };
+    telemetry.shutdown.mockRejectedValue(new Error('telemetry unavailable'));
+    mocks.bootstrap.mockReturnValue({ app });
+    mocks.ensureMainAgent.mockResolvedValue(agent);
+
+    await expect(
+      runV2Print(opts() as never, '1.2.3-test', { stdout, stderr }),
+    ).resolves.toBeUndefined();
+
+    expect(telemetry.shutdown).toHaveBeenCalledOnce();
+    expect(app.dispose).toHaveBeenCalledOnce();
+    expect(stderr.text()).toContain(
+      'Warning: telemetry shutdown failed: telemetry unavailable',
+    );
+  });
+
   it('passes explicit skill dirs from --skillsDir into bootstrap args', async () => {
     const stdout = writer();
     const stderr = writer();

--- a/apps/kimi-code/test/cli/web/web.test.ts
+++ b/apps/kimi-code/test/cli/web/web.test.ts
@@ -651,6 +651,92 @@ describe('`kimi web` option threading', () => {
   });
 });
 
+describe('`kimi web` foreground shutdown', () => {
+  it('passes no fresh budget to host telemetry after engine shutdown expires', async () => {
+    vi.resetModules();
+    const startServer = vi.fn();
+    const shutdownTelemetry = vi.fn(async () => {});
+    const logger = { info: vi.fn(), error: vi.fn() };
+    vi.doMock('@moonshot-ai/kap-server', async () => {
+      const actual = await vi.importActual<typeof import('@moonshot-ai/kap-server')>(
+        '@moonshot-ai/kap-server',
+      );
+      return {
+        ...actual,
+        createServerLogger: vi.fn(() => logger),
+        startServer,
+      };
+    });
+    vi.doMock('@moonshot-ai/kimi-telemetry', async () => {
+      const actual = await vi.importActual<typeof import('@moonshot-ai/kimi-telemetry')>(
+        '@moonshot-ai/kimi-telemetry',
+      );
+      return { ...actual, shutdownTelemetry, track: vi.fn() };
+    });
+    vi.doMock('#/cli/telemetry', () => ({ initializeServerTelemetry: vi.fn() }));
+
+    let nowMs = 10_000;
+    const serverClose = vi.fn(async () => {
+      nowMs = 13_001;
+      throw new Error('engine telemetry unavailable');
+    });
+    startServer.mockResolvedValue({
+      host: '127.0.0.1',
+      port: 58_627,
+      close: serverClose,
+    });
+
+    const previousListeners = new Set(process.listeners('SIGINT'));
+    const exit = vi.spyOn(process, 'exit').mockImplementation((() => undefined) as never);
+    const now = vi.spyOn(Date, 'now').mockImplementation(() => nowMs);
+    let signalHandler: (() => void) | undefined;
+    try {
+      const { startServerForeground } = await import('#/cli/sub/web/run');
+      let markReady: (() => void) | undefined;
+      const ready = new Promise<void>((resolve) => {
+        markReady = resolve;
+      });
+      void startServerForeground(
+        {
+          host: '127.0.0.1',
+          port: 0,
+          logLevel: 'silent',
+          debugEndpoints: false,
+          insecureNoTls: true,
+          allowRemoteShutdown: false,
+          dangerousBypassAuth: false,
+          allowedHosts: [],
+        },
+        { onReady: () => markReady?.() },
+      );
+      await ready;
+
+      signalHandler = process
+        .listeners('SIGINT')
+        .find((listener) => !previousListeners.has(listener)) as (() => void) | undefined;
+      signalHandler?.();
+
+      await vi.waitFor(() => expect(exit).toHaveBeenCalledWith(0));
+      expect(serverClose).toHaveBeenCalledWith({ telemetryDeadlineMs: 13_000 });
+      expect(shutdownTelemetry).toHaveBeenCalledWith({ timeoutMs: 0 });
+      expect(logger.error).toHaveBeenCalledWith(
+        expect.objectContaining({
+          err: expect.objectContaining({ message: 'engine telemetry unavailable' }),
+        }),
+        'telemetry shutdown error',
+      );
+    } finally {
+      if (signalHandler !== undefined) process.removeListener('SIGINT', signalHandler);
+      now.mockRestore();
+      exit.mockRestore();
+      vi.doUnmock('@moonshot-ai/kap-server');
+      vi.doUnmock('@moonshot-ai/kimi-telemetry');
+      vi.doUnmock('#/cli/telemetry');
+      vi.resetModules();
+    }
+  });
+});
+
 describe('shared parsers stay strict', () => {
   it('rejects out-of-range --port', async () => {
     const { parsePort } = await import('#/cli/sub/web/shared');

--- a/packages/kap-server/src/start.ts
+++ b/packages/kap-server/src/start.ts
@@ -132,7 +132,11 @@ export interface RunningServer {
   readonly authTokenService: IAuthTokenService;
   readonly host: string;
   readonly port: number;
-  close(): Promise<void>;
+  close(options?: ServerCloseOptions): Promise<void>;
+}
+
+export interface ServerCloseOptions {
+  readonly telemetryDeadlineMs?: number;
 }
 
 const DEFAULT_HOST = '127.0.0.1';
@@ -291,7 +295,7 @@ export async function startServer(opts: ServerStartOptions): Promise<RunningServ
     app.addHook('onSend', createSecurityHeadersHook({ tls: false }));
   }
 
-  const close = async (): Promise<void> => {
+  const close = async (options: ServerCloseOptions = {}): Promise<void> => {
     configChangedPublisher.close();
     await app.close();
     configWarningSubscription.dispose();
@@ -300,7 +304,7 @@ export async function startServer(opts: ServerStartOptions): Promise<RunningServ
     authFailureLimiter?.dispose();
     modelCatalogRefreshScheduler.dispose();
     try {
-      await shutdownServerTelemetry(telemetry);
+      await shutdownServerTelemetry(telemetry, options.telemetryDeadlineMs);
     } catch (error) {
       logger.warn(
         { err: error instanceof Error ? error.message : String(error) },

--- a/packages/kap-server/test/boot.test.ts
+++ b/packages/kap-server/test/boot.test.ts
@@ -21,6 +21,8 @@ import { listenWithPortRetry, type RunningServer, startServer } from '../src/sta
 import { TEST_HOST_IDENTITY } from './helpers/hostIdentity';
 import { authedFetch } from './helpers/auth';
 
+const EXPIRED_TELEMETRY_DEADLINE_MAX_CLOSE_MS = 1_500;
+
 describe('server-v2 boot', () => {
   let server: RunningServer | undefined;
   let home: string | undefined;
@@ -230,6 +232,34 @@ describe('server-v2 boot', () => {
     server = undefined;
 
     expect(() => core.accessor.get(IBootstrapService)).toThrow();
+    expect(await listLiveServerInstances(home)).toEqual([]);
+  });
+
+  it('passes an expired host telemetry deadline to owned engine telemetry', async () => {
+    home = await mkdtemp(join(tmpdir(), 'kimi-server-v2-telemetry-deadline-'));
+    const auth = {
+      _serviceBrand: undefined,
+      getCachedAccessToken: () => new Promise<undefined>(() => {}),
+    } as unknown as IOAuthToolkit;
+
+    server = await startServer({
+      hostIdentity: TEST_HOST_IDENTITY,
+      host: '127.0.0.1',
+      port: 0,
+      homeDir: home,
+      logLevel: 'silent',
+      telemetry: true,
+      seeds: [[IOAuthToolkit, auth]],
+    });
+    server.core.accessor.get(ITelemetryService).track('server_probe');
+
+    const closeStartedAt = Date.now();
+    await server.close({ telemetryDeadlineMs: Date.now() });
+    server = undefined;
+
+    expect(Date.now() - closeStartedAt).toBeLessThan(
+      EXPIRED_TELEMETRY_DEADLINE_MAX_CLOSE_MS,
+    );
     expect(await listLiveServerInstances(home)).toEqual([]);
   });
 


### PR DESCRIPTION
## Related Issue

Resolve #2248

## Problem

CLI entrypoints gave each telemetry owner a fresh shutdown timeout. In `kimi web`,
the kap-server engine pipeline and the host pipeline could therefore extend total
shutdown latency beyond the configured budget. Cleanup rejection handling also
differed between print and web paths.

## What changed

- Added a shared CLI shutdown-deadline policy that computes one absolute
  deadline, passes only the remaining budget to each pipeline, reports failures,
  and continues even if a pipeline or its reporter fails.
- Applied the policy to v1 print, v2 print, and web shutdown.
- Allowed the web host to pass its absolute deadline through
  `RunningServer.close()` to kap-server's owned engine telemetry.
- Added lifecycle coverage for multiple pipelines, expired budgets, rejection,
  reporter failure, preserved exit results, and the real kap-server close path.

## Test verification (RED → GREEN)

RED on the upstream base:

```text
telemetry shutdown deadline: 3 failed
Error: Cannot find module '#/cli/telemetry-shutdown'

runPrompt:
expected stderr to contain
"Warning: telemetry shutdown failed: telemetry unavailable"

kap-server close with forwarding removed:
expected 3005 to be less than 1500
```

GREEN with this change:

```text
CLI lifecycle: 118 passed
kap-server telemetry/boot: 23 passed
combined coverage run: 141 passed
changed executable production lines: 25/25 covered (100%)
tsgo: apps/kimi-code and packages/kap-server passed
build: passed
bundle smoke: passed
```

Full local suite validation used the same five Vitest shards as CI. Shards 3,
4, and 5 passed completely. Shards 1 and 2 reproduced the environment-only
baseline failures from the missing system `zip` executable; one tree-sitter
budget test that exceeded 50 ms under contention passed in isolation in 16 ms.
The targeted suites, exact changed-package typechecks, build, smoke, sherif, and
pi-tui tests are green. The global type-aware lint process was killed by local
memory pressure, matching the upstream baseline run.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill; added a patch changeset for the CLI package.
- [x] Ran `gen-docs` skill; no documentation update is needed for this internal shutdown policy.
