### PR TITLE
chore: prune non-user-facing changesets before release

### DIFF
--- a/.changeset/bash-parser-service.md
+++ b/.changeset/bash-parser-service.md
@@ -1,5 +1,0 @@
----
-"@moonshot-ai/kimi-code": patch
----
-
-Add an internal bash parsing capability that turns shell command strings into syntax trees, in preparation for per-command permission analysis. No user-facing behavior change yet.

--- a/.changeset/dedup-register-rejected-calls.md
+++ b/.changeset/dedup-register-rejected-calls.md
@@ -2,4 +2,4 @@
 "@moonshot-ai/kimi-code": patch
 ---
 
-Stop the turn when the model keeps emitting invalid tool calls, instead of retrying them indefinitely.
+Stop the turn after repeated invalid tool calls instead of retrying indefinitely.

--- a/.changeset/dedup-register-rejected-calls.md
+++ b/.changeset/dedup-register-rejected-calls.md
@@ -1,5 +1,5 @@
 ---
-"@moonshot-ai/agent-core": patch
+"@moonshot-ai/kimi-code": patch
 ---
 
-Count validation-rejected tool calls toward the repeat breaker so reminders fire at 3/5/8 and the turn force-stops at 12.
+Stop the turn when the model keeps emitting invalid tool calls, instead of retrying them indefinitely.

--- a/.changeset/host-identity-system-prompt.md
+++ b/.changeset/host-identity-system-prompt.md
@@ -1,5 +1,0 @@
----
-"@moonshot-ai/agent-core-v2": patch
----
-
-Let embedding hosts customize the agent's product name and reply-style guidance in the system prompt when starting the server.

--- a/.changeset/plugin-quota-note.md
+++ b/.changeset/plugin-quota-note.md
@@ -2,4 +2,4 @@
 "@moonshot-ai/kimi-code": patch
 ---
 
-Show a quota consumption note after installing official plugins that bill against plan quota (such as Kimi Datasource).
+Show a quota note after installing official plugins that bill against plan quota (such as Kimi Datasource).

--- a/.changeset/plugin-update-notice.md
+++ b/.changeset/plugin-update-notice.md
@@ -2,4 +2,4 @@
 "@moonshot-ai/kimi-code": patch
 ---
 
-Show an update notice when a turn that used an outdated plugin ends and the Official Marketplace has a newer version; each new version is announced once. Run /plugins to install the latest version.
+Show an update notice when an official plugin used in the session has a newer version available. Run /plugins to install it.

--- a/.changeset/plugin-update-notice.md
+++ b/.changeset/plugin-update-notice.md
@@ -2,4 +2,4 @@
 "@moonshot-ai/kimi-code": patch
 ---
 
-Show an update notice when an official plugin used in the session has a newer version available. Run /plugins to install it.
+Show a notice when an official plugin used in the session has an update available. Run /plugins to install it.

--- a/.changeset/quota-exhausted-fail-fast.md
+++ b/.changeset/quota-exhausted-fail-fast.md
@@ -2,4 +2,4 @@
 "@moonshot-ai/kimi-code": patch
 ---
 
-Fail fast on quota/balance-exhausted HTTP 429 errors (e.g. Moonshot `exceeded_current_quota_error`, OpenAI `insufficient_quota`) instead of silently retrying for ~3 minutes. Transient rate-limit 429s keep the existing retry, backoff, and Retry-After behavior.
+Fail fast on quota- or balance-exhausted errors instead of silently retrying for ~3 minutes; temporary rate limits keep the existing retry behavior.

--- a/.changeset/quota-exhausted-fail-fast.md
+++ b/.changeset/quota-exhausted-fail-fast.md
@@ -1,6 +1,5 @@
 ---
 "@moonshot-ai/kimi-code": patch
-"@moonshot-ai/kimi-code-sdk": patch
 ---
 
 Fail fast on quota/balance-exhausted HTTP 429 errors (e.g. Moonshot `exceeded_current_quota_error`, OpenAI `insufficient_quota`) instead of silently retrying for ~3 minutes. Transient rate-limit 429s keep the existing retry, backoff, and Retry-After behavior.

--- a/.changeset/quota-exhausted-fail-fast.md
+++ b/.changeset/quota-exhausted-fail-fast.md
@@ -2,4 +2,4 @@
 "@moonshot-ai/kimi-code": patch
 ---
 
-Fail fast on quota- or balance-exhausted errors instead of silently retrying for ~3 minutes; temporary rate limits keep the existing retry behavior.
+Fail fast when account quota or balance is exhausted instead of silently retrying for ~3 minutes.

--- a/.changeset/status-line-config.md
+++ b/.changeset/status-line-config.md
@@ -2,4 +2,4 @@
 '@moonshot-ai/kimi-code': minor
 ---
 
-Customizable footer status line: compose built-in slots via `[status_line] items` in `tui.toml`, or render the first stdout line of a user script via `[status_line] command`.
+Add a customizable footer status line: compose built-in slots or render a script's output via `[status_line]` in `tui.toml`.

--- a/.changeset/status-line-config.md
+++ b/.changeset/status-line-config.md
@@ -2,4 +2,4 @@
 '@moonshot-ai/kimi-code': minor
 ---
 
-Add a customizable footer status line: compose built-in slots or render a script's output via `[status_line]` in `tui.toml`.
+Add a customizable footer status line, configured via `[status_line]` in `tui.toml`.

--- a/.changeset/structured-managed-usage.md
+++ b/.changeset/structured-managed-usage.md
@@ -1,7 +1,0 @@
----
-"@moonshot-ai/kimi-code-oauth": patch
-"@moonshot-ai/agent-core-v2": patch
-"@moonshot-ai/kap-server": patch
----
-
-Derive the /usage plan usage window labels and reset hints from structured usage data instead of preformatted text.

--- a/.changeset/upload-no-size-cap.md
+++ b/.changeset/upload-no-size-cap.md
@@ -1,5 +1,5 @@
 ---
-"@moonshot-ai/kimi-code": minor
+"@moonshot-ai/kimi-code": patch
 ---
 
-Remove the 50 MB size limit on file uploads to the built-in server, so large attachments (for example in the web UI) no longer fail with an upload-too-large error. Uploads now stream to disk instead of being buffered in memory.
+Remove the 50 MB size limit on file uploads to the built-in server, so large attachments (for example in the web UI) no longer fail with an upload-too-large error.

--- a/.changeset/upload-no-size-cap.md
+++ b/.changeset/upload-no-size-cap.md
@@ -2,4 +2,4 @@
 "@moonshot-ai/kimi-code": patch
 ---
 
-Remove the 50 MB size limit on file uploads to the built-in server, so large attachments (for example in the web UI) no longer fail with an upload-too-large error.
+Remove the 50 MB size limit on file uploads to the built-in server.

--- a/.changeset/v2-dedup-register-rejected-calls.md
+++ b/.changeset/v2-dedup-register-rejected-calls.md
@@ -1,5 +1,0 @@
----
-"@moonshot-ai/agent-core-v2": patch
----
-
-Count validation-rejected tool calls toward the repeat breaker so reminders fire at 3/5/8 and the turn force-stops at 12.


### PR DESCRIPTION
## Related Issue

No linked issue — this is release-hygiene cleanup of the accumulated `.changeset/` entries, explained below.

## Problem

Several pending changesets don't belong in the user-facing CLI changelog per the `gen-changesets` rules:

- Entries for changes users cannot perceive (Core Rule 6): internal groundwork that self-describes as "no user-facing behavior change yet", a server start option with no CLI/config surface, and a formatting refactor with unchanged output.
- A user-visible fix mapped only to private internal packages, so it would never appear in the CLI changelog.
- A changeset listing `@moonshot-ai/kimi-code-sdk` although `packages/node-sdk` was not touched by the change.
- A `minor` bump for removing an upload size limit, which is an improvement to an existing feature (`patch`).

## What changed

- Deleted `bash-parser-service.md`, `host-identity-system-prompt.md`, `structured-managed-usage.md` — changes users cannot perceive.
- Deleted `v2-dedup-register-rejected-calls.md` — duplicate of the same repeat-breaker fix on the experimental engine; one CLI entry covers it.
- `dedup-register-rejected-calls.md`: remapped `@moonshot-ai/agent-core` to `@moonshot-ai/kimi-code` (patch) and rewrote the entry in user-facing wording, so the fix is actually announced.
- `quota-exhausted-fail-fast.md`: dropped the `@moonshot-ai/kimi-code-sdk` line (node-sdk was not changed).
- `upload-no-size-cap.md`: downgraded `minor` → `patch` and removed the implementation-detail sentence.

No code changes; deleting a changeset only removes its future changelog entry.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works. (N/A — changelog entries only)
- [x] Ran `gen-changesets` skill, or this PR needs no changeset. (This PR edits changesets themselves; no new changeset needed.)
- [x] Ran `gen-docs` skill, or this PR needs no doc update. (No behavior change.)
