### PR TITLE
fix(agent-core-v2): honor configured permission rules

### DIFF
--- a/.changeset/manual-permission-rules.md
+++ b/.changeset/manual-permission-rules.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Fix `kimi web` honoring configured permission rules in manual mode.

--- a/packages/agent-core-v2/src/agent/permissionRules/permissionRulesService.ts
+++ b/packages/agent-core-v2/src/agent/permissionRules/permissionRulesService.ts
@@ -1,16 +1,19 @@
 /**
  * `permissionRules` domain (L3) — `IAgentPermissionRulesService` implementation.
  *
- * Holds the agent's permission rules and deduped session-approval patterns in the
- * `wire` `PermissionRulesModel`, mutating it only through the `permission.rules.add`
- * / `permission.record_approval_result` Ops (`wire.dispatch(...)`) and reading it
- * through `wire.getModel`. `wire.replay` rebuilds the model silently and
- * consumers read the getters instead. Bound at Agent scope.
+ * Exposes the effective permission rules by composing the user-configured
+ * `[permission]` rules from `config` with the agent's live rules in the `wire`
+ * `PermissionRulesModel`. Mutates agent state only through the
+ * `permission.rules.add` / `permission.record_approval_result` Ops
+ * (`wire.dispatch(...)`); `wire.replay` rebuilds the model silently. Bound at
+ * Agent scope.
  */
 
 import { LifecycleScope, ScopeActivation, registerScopedService } from '#/_base/di/scope';
 
+import { IConfigService } from '#/app/config/config';
 import { IWireService } from '#/wire/wire';
+import { PERMISSION_SECTION, type PermissionConfig } from './configSection';
 import {
   IAgentPermissionRulesService,
   type PermissionApprovalResultRecord,
@@ -25,10 +28,15 @@ import {
 export class AgentPermissionRulesService implements IAgentPermissionRulesService {
   declare readonly _serviceBrand: undefined;
 
-  constructor(@IWireService private readonly wire: IWireService) {}
+  constructor(
+    @IConfigService private readonly config: IConfigService,
+    @IWireService private readonly wire: IWireService,
+  ) {}
 
   get rules(): readonly PermissionRule[] {
-    return [...this.wire.getModel(PermissionRulesModel).rules];
+    const configuredRules =
+      this.config.get<PermissionConfig | undefined>(PERMISSION_SECTION)?.rules ?? [];
+    return [...configuredRules, ...this.wire.getModel(PermissionRulesModel).rules];
   }
 
   get sessionApprovalRulePatterns(): readonly string[] {

--- a/packages/agent-core-v2/test/agent/permissionPolicy/permissionPolicyService.test.ts
+++ b/packages/agent-core-v2/test/agent/permissionPolicy/permissionPolicyService.test.ts
@@ -139,6 +139,22 @@ describe('AgentPermissionPolicyService chain', () => {
     });
   });
 
+  it('approves a configured MCP tool before the manual-mode fallback', async () => {
+    rules.push({
+      decision: 'allow',
+      scope: 'user',
+      pattern: 'mcp__example__read_data',
+    });
+
+    await expect(evaluate({
+      toolName: 'mcp__example__read_data',
+      args: {},
+    })).resolves.toMatchObject({
+      policyName: 'user-configured-allow',
+      result: { kind: 'approve' },
+    });
+  });
+
   it('reuses approve-for-session before matching ask rules', async () => {
     rules.push({
       decision: 'ask',

--- a/packages/agent-core-v2/test/agent/permissionRules/permissionRules.test.ts
+++ b/packages/agent-core-v2/test/agent/permissionRules/permissionRules.test.ts
@@ -6,6 +6,7 @@ import { TestInstantiationService } from '#/_base/di/test';
 import { IAgentPermissionRulesService, type PermissionApprovalResultRecord, type PermissionRule } from '#/agent/permissionRules/permissionRules';
 import { AgentPermissionRulesService } from '#/agent/permissionRules/permissionRulesService';
 import { PermissionRulesModel } from '#/agent/permissionRules/permissionRulesOps';
+import { IConfigService } from '#/app/config/config';
 import { AppendLogStore } from '#/persistence/backends/node-fs/appendLogStore';
 import { InMemoryStorageService } from '#/persistence/backends/memory/inMemoryStorageService';
 import { IAppendLogStore } from '#/persistence/interface/appendLogStore';
@@ -36,10 +37,15 @@ let disposables: DisposableStore;
 let ix: TestInstantiationService;
 let log: IAppendLogStore;
 let svc: IAgentPermissionRulesService;
+let configuredRules: PermissionRule[];
 
 beforeEach(() => {
   disposables = new DisposableStore();
   ix = disposables.add(new TestInstantiationService());
+  configuredRules = [];
+  ix.stub(IConfigService, {
+    get: (() => ({ rules: configuredRules })) as IConfigService['get'],
+  } as unknown as IConfigService);
   ix.stub(IFileSystemStorageService, new InMemoryStorageService());
   ix.set(IAppendLogStore, new SyncDescriptor(AppendLogStore));
   ix.set(IAgentPermissionRulesService, new SyncDescriptor(AgentPermissionRulesService));
@@ -60,6 +66,13 @@ async function readRecords(): Promise<WireRecord[]> {
 }
 
 describe('AgentPermissionRulesService (wire-backed)', () => {
+  it('exposes configured rules before agent runtime rules', () => {
+    configuredRules.push(denyRule);
+    svc.addRules([allowRule]);
+
+    expect(svc.rules).toEqual([denyRule, allowRule]);
+  });
+
   it('addRules appends rules and exposes the accumulated rules', () => {
     expect(svc.rules).toEqual([]);
 


### PR DESCRIPTION
## Related Issue

Fixes #2100

## Problem

See linked issue.

## What changed

Load configured permission rules into the effective Agent permission rule view alongside live runtime rules.

This keeps configured rules outside the persisted Agent wire state, so resumed agents continue to read the current configuration without duplicating or retaining stale rules.

Added regression coverage for merging configured and runtime rules, and for approving a configured MCP tool before the manual-mode fallback.

Manually verified in `kimi web` that an MCP call prompts without an allow rule and executes without prompting after adding the matching rule.

## Checklist

- [x] I have read the CONTRIBUTING document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran gen-changesets skill, or this PR needs no changeset.
- [x] Ran gen-docs skill, or this PR needs no doc update.