### PR TITLE
fix(anthropic): omit incompatible tool schemas

### DIFF
--- a/.changeset/clean-tools-anthropic.md
+++ b/.changeset/clean-tools-anthropic.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Prevent Anthropic requests from failing when MCP tools use unsupported top-level JSON Schema combinators.

--- a/packages/agent-core-v2/src/kosong/provider/bases/anthropic/anthropic.contrib.ts
+++ b/packages/agent-core-v2/src/kosong/provider/bases/anthropic/anthropic.contrib.ts
@@ -37,6 +37,7 @@ registerProtocolBase({
             ? undefined
             : { ...config.providerOptions.metadata },
         hooks: composeAnthropicHooks(traits),
+        filterUnsupportedRootSchemas: traits.length === 0 ? undefined : false,
       }),
     });
   },

--- a/packages/agent-core-v2/src/kosong/provider/bases/anthropic/anthropic.contrib.ts
+++ b/packages/agent-core-v2/src/kosong/provider/bases/anthropic/anthropic.contrib.ts
@@ -37,7 +37,7 @@ registerProtocolBase({
             ? undefined
             : { ...config.providerOptions.metadata },
         hooks: composeAnthropicHooks(traits),
-        filterUnsupportedRootSchemas: traits.length === 0 ? undefined : false,
+        filterUnsupportedRootSchemas: config.providerType === undefined ? undefined : false,
       }),
     });
   },

--- a/packages/agent-core-v2/src/kosong/provider/bases/anthropic/anthropic.ts
+++ b/packages/agent-core-v2/src/kosong/provider/bases/anthropic/anthropic.ts
@@ -153,6 +153,7 @@ export interface AnthropicOptions {
   thinkingEffort?: ThinkingEffort | undefined;
   clientFactory?: (auth: ProviderRequestAuth) => Anthropic;
   hooks?: AnthropicHooks | undefined;
+  filterUnsupportedRootSchemas?: boolean;
 }
 
 const INTERLEAVED_THINKING_BETA = 'interleaved-thinking-2025-05-14';
@@ -400,6 +401,28 @@ function videoUrlPartToAnthropic(url: string): AnthropicVideoBlock {
 
 interface AnthropicToolParam extends AnthropicTool {
   cache_control?: { type: 'ephemeral' } | null;
+}
+
+const ANTHROPIC_UNSUPPORTED_ROOT_SCHEMA_KEYWORDS = new Set([
+  'oneOf',
+  'anyOf',
+  'allOf',
+]);
+const ANTHROPIC_API_BASE_URL = 'https://api.anthropic.com';
+const ANTHROPIC_API_BASE_URL_WITH_TRAILING_SLASH = `${ANTHROPIC_API_BASE_URL}/`;
+
+function hasAnthropicCompatibleSchema(tool: Tool): boolean {
+  return !Object.keys(tool.parameters).some((key) =>
+    ANTHROPIC_UNSUPPORTED_ROOT_SCHEMA_KEYWORDS.has(key),
+  );
+}
+
+function isOfficialAnthropicEndpoint(baseUrl: string | undefined): boolean {
+  return (
+    baseUrl === undefined ||
+    baseUrl === ANTHROPIC_API_BASE_URL ||
+    baseUrl === ANTHROPIC_API_BASE_URL_WITH_TRAILING_SLASH
+  );
 }
 
 function convertTool(tool: Tool): AnthropicToolParam {
@@ -820,6 +843,7 @@ export class AnthropicChatProvider implements ChatProvider {
   private readonly _thinkingEffort: ThinkingEffort | undefined;
   private readonly _explicitMaxTokens: boolean;
   private readonly _hooks: AnthropicHooks | undefined;
+  private readonly _filterUnsupportedRootSchemas: boolean;
 
   constructor(options: AnthropicOptions) {
     this._model = options.model;
@@ -830,6 +854,8 @@ export class AnthropicChatProvider implements ChatProvider {
     this._betaApi = options.betaApi ?? false;
     this._thinkingEffort = options.thinkingEffort;
     this._hooks = options.hooks;
+    this._filterUnsupportedRootSchemas =
+      options.filterUnsupportedRootSchemas ?? isOfficialAnthropicEndpoint(options.baseUrl);
     this._apiKey =
       options.apiKey === undefined || options.apiKey.length === 0 ? undefined : options.apiKey;
     this._baseUrl = options.baseUrl;
@@ -979,7 +1005,11 @@ export class AnthropicChatProvider implements ChatProvider {
       extraHeaders['anthropic-beta'] = betas.join(',');
     }
 
-    const anthropicTools: AnthropicToolParam[] = tools.map((t) => convertTool(t));
+    const requestTools = this._filterUnsupportedRootSchemas
+      ? tools.filter(hasAnthropicCompatibleSchema)
+      : tools;
+    const anthropicTools: AnthropicToolParam[] = requestTools
+      .map((tool) => convertTool(tool));
     if (anthropicTools.length > 0) {
       const lastTool = anthropicTools.at(-1);
       if (lastTool !== undefined) {

--- a/packages/agent-core-v2/test/kosong/provider/composition.test.ts
+++ b/packages/agent-core-v2/test/kosong/provider/composition.test.ts
@@ -61,6 +61,7 @@ import {
   isRetryableGenerateError,
 } from '#/kosong/contract/errors';
 import type { Message } from '#/kosong/contract/message';
+import type { Tool } from '#/kosong/contract/tool';
 import type {
   ChatProvider,
   GenerateOptions,
@@ -605,6 +606,7 @@ async function captureOpenAIBody(
 async function captureAnthropicBody(
   provider: ChatProvider,
   options?: GenerateOptions,
+  tools: Tool[] = [],
   history: Message[] = PROBE_HISTORY,
 ): Promise<{
   readonly params: Record<string, unknown>;
@@ -629,7 +631,7 @@ async function captureAnthropicBody(
     });
   client.messages.create = create('standard');
   client.beta.messages.create = create('beta');
-  await drain(await provider.generate('', [], history, options));
+  await drain(await provider.generate('', tools, history, options));
   if (capturedParams === undefined || via === undefined) {
     throw new Error('expected messages.create to be called');
   }
@@ -766,7 +768,7 @@ describe('reasoning-only assistant history projection', () => {
       apiKey: 'sk-probe',
     });
 
-    const { params } = await captureAnthropicBody(provider, undefined, THINK_HISTORY);
+    const { params } = await captureAnthropicBody(provider, undefined, [], THINK_HISTORY);
     const messages = params['messages'] as Array<Record<string, unknown>>;
 
     expect(messages[0]).toEqual({
@@ -852,6 +854,90 @@ describe('quota-exhausted classification through the real composition (behavior 
     expect(caught).not.toBeInstanceOf(APIProviderQuotaExhaustedError);
     expect(isRetryableGenerateError(caught)).toBe(true);
   });
+});
+
+describe('Anthropic tool schema compatibility', () => {
+  it('omits tools with unsupported root combinators and keeps compatible tools', async () => {
+    const provider = new AnthropicChatProvider({
+      model: 'claude-opus-4-6',
+      apiKey: 'sk-probe',
+      stream: false,
+    });
+    const tools: Tool[] = [
+      {
+        name: 'one_of_tool',
+        description: 'Uses oneOf.',
+        parameters: { oneOf: [{ required: ['resource_id'] }] },
+      },
+      {
+        name: 'any_of_tool',
+        description: 'Uses anyOf.',
+        parameters: { anyOf: [{ required: ['resource_id'] }] },
+      },
+      {
+        name: 'all_of_tool',
+        description: 'Uses allOf.',
+        parameters: { allOf: [{ required: ['resource_id'] }] },
+      },
+      {
+        name: 'compatible_tool',
+        description: 'Uses a regular object schema.',
+        parameters: {
+          type: 'object',
+          properties: { resource_id: { type: 'string' } },
+        },
+      },
+    ];
+    const originalTools = structuredClone(tools);
+
+    const { params } = await captureAnthropicBody(provider, undefined, tools);
+    const wireTools = params['tools'] as Array<{ name: string }>;
+
+    expect(wireTools.map((tool) => tool.name)).toEqual(['compatible_tool']);
+    expect(tools).toEqual(originalTools);
+
+    const kimiProvider = registry.createChatProvider({
+      protocol: 'anthropic',
+      providerType: 'kimi',
+      modelName: 'kimi-for-coding',
+      apiKey: 'sk-probe',
+    });
+    const { params: kimiParams } = await captureAnthropicBody(
+      kimiProvider,
+      undefined,
+      tools,
+    );
+    const kimiTools = kimiParams['tools'] as Array<{ name: string }>;
+    expect(kimiTools.map((tool) => tool.name)).toEqual(tools.map((tool) => tool.name));
+  });
+
+  it.each(['https://api.anthropic.com', 'https://api.anthropic.com/'])(
+    'filters unsupported tools for explicit official endpoint %s',
+    async (baseUrl) => {
+      const provider = new AnthropicChatProvider({
+        model: 'claude-opus-4-6',
+        apiKey: 'sk-probe',
+        baseUrl,
+        stream: false,
+      });
+      const tools: Tool[] = [
+        {
+          name: 'incompatible_tool',
+          description: 'Uses oneOf.',
+          parameters: { oneOf: [{ required: ['resource_id'] }] },
+        },
+        {
+          name: 'compatible_tool',
+          description: 'Uses a regular object schema.',
+          parameters: { type: 'object' },
+        },
+      ];
+
+      const { params } = await captureAnthropicBody(provider, undefined, tools);
+      const wireTools = params['tools'] as Array<{ name: string }>;
+      expect(wireTools.map((tool) => tool.name)).toEqual(['compatible_tool']);
+    },
+  );
 });
 
 describe('reasoning dialect (behavior probes)', () => {

--- a/packages/agent-core-v2/test/kosong/provider/composition.test.ts
+++ b/packages/agent-core-v2/test/kosong/provider/composition.test.ts
@@ -911,6 +911,30 @@ describe('Anthropic tool schema compatibility', () => {
     expect(kimiTools.map((tool) => tool.name)).toEqual(tools.map((tool) => tool.name));
   });
 
+  it('filters unsupported tools for registry-created plain anthropic providers', async () => {
+    const provider = registry.createChatProvider({
+      protocol: 'anthropic',
+      modelName: 'claude-opus-4-6',
+      apiKey: 'sk-probe',
+    });
+    const tools: Tool[] = [
+      {
+        name: 'incompatible_tool',
+        description: 'Uses oneOf.',
+        parameters: { oneOf: [{ required: ['resource_id'] }] },
+      },
+      {
+        name: 'compatible_tool',
+        description: 'Uses a regular object schema.',
+        parameters: { type: 'object' },
+      },
+    ];
+
+    const { params } = await captureAnthropicBody(provider, undefined, tools);
+    const wireTools = params['tools'] as Array<{ name: string }>;
+    expect(wireTools.map((tool) => tool.name)).toEqual(['compatible_tool']);
+  });
+
   it.each(['https://api.anthropic.com', 'https://api.anthropic.com/'])(
     'filters unsupported tools for explicit official endpoint %s',
     async (baseUrl) => {

--- a/packages/kosong/src/providers/anthropic.ts
+++ b/packages/kosong/src/providers/anthropic.ts
@@ -461,6 +461,28 @@ interface AnthropicToolParam extends AnthropicTool {
   cache_control?: { type: 'ephemeral' } | null;
 }
 
+const ANTHROPIC_UNSUPPORTED_ROOT_SCHEMA_KEYWORDS = new Set([
+  'oneOf',
+  'anyOf',
+  'allOf',
+]);
+const ANTHROPIC_API_BASE_URL = 'https://api.anthropic.com';
+const ANTHROPIC_API_BASE_URL_WITH_TRAILING_SLASH = `${ANTHROPIC_API_BASE_URL}/`;
+
+function hasAnthropicCompatibleSchema(tool: Tool): boolean {
+  return !Object.keys(tool.parameters).some((key) =>
+    ANTHROPIC_UNSUPPORTED_ROOT_SCHEMA_KEYWORDS.has(key),
+  );
+}
+
+function isOfficialAnthropicEndpoint(baseUrl: string | undefined): boolean {
+  return (
+    baseUrl === undefined ||
+    baseUrl === ANTHROPIC_API_BASE_URL ||
+    baseUrl === ANTHROPIC_API_BASE_URL_WITH_TRAILING_SLASH
+  );
+}
+
 function convertTool(tool: Tool): AnthropicToolParam {
   return {
     name: tool.name,
@@ -1076,7 +1098,11 @@ export class AnthropicChatProvider implements ChatProvider {
     }
 
     // Convert tools
-    const anthropicTools: AnthropicToolParam[] = tools.map((t) => convertTool(t));
+    const requestTools = isOfficialAnthropicEndpoint(this._baseUrl)
+      ? tools.filter(hasAnthropicCompatibleSchema)
+      : tools;
+    const anthropicTools: AnthropicToolParam[] = requestTools
+      .map((tool) => convertTool(tool));
     if (anthropicTools.length > 0) {
       const lastTool = anthropicTools.at(-1);
       if (lastTool !== undefined) {

--- a/packages/kosong/test/anthropic.test.ts
+++ b/packages/kosong/test/anthropic.test.ts
@@ -1074,6 +1074,88 @@ describe('AnthropicChatProvider', () => {
       ]);
     });
 
+    it('omits tools with unsupported root combinators and keeps compatible tools', async () => {
+      const provider = createProvider();
+      const history: Message[] = [
+        { role: 'user', content: [{ type: 'text', text: 'Process resource' }], toolCalls: [] },
+      ];
+      const tools: Tool[] = [
+        {
+          name: 'one_of_tool',
+          description: 'Uses oneOf.',
+          parameters: { oneOf: [{ required: ['resource_id'] }] },
+        },
+        {
+          name: 'any_of_tool',
+          description: 'Uses anyOf.',
+          parameters: { anyOf: [{ required: ['resource_id'] }] },
+        },
+        {
+          name: 'all_of_tool',
+          description: 'Uses allOf.',
+          parameters: { allOf: [{ required: ['resource_id'] }] },
+        },
+        {
+          name: 'compatible_tool',
+          description: 'Uses a regular object schema.',
+          parameters: {
+            type: 'object',
+            properties: { resource_id: { type: 'string' } },
+          },
+        },
+      ];
+      const originalTools = structuredClone(tools);
+
+      const body = await captureRequestBody(provider, '', tools, history);
+      const wireTools = body['tools'] as Array<{ name: string }>;
+
+      expect(wireTools.map((tool) => tool.name)).toEqual(['compatible_tool']);
+      expect(tools).toEqual(originalTools);
+
+      const customProvider = new AnthropicChatProvider({
+        model: 'compatible-model',
+        apiKey: 'test-key',
+        baseUrl: 'https://compatible.example.test',
+        defaultMaxTokens: 1024,
+        stream: false,
+      });
+      const customBody = await captureRequestBody(customProvider, '', tools, history);
+      const customTools = customBody['tools'] as Array<{ name: string }>;
+      expect(customTools.map((tool) => tool.name)).toEqual(tools.map((tool) => tool.name));
+    });
+
+    it.each(['https://api.anthropic.com', 'https://api.anthropic.com/'])(
+      'filters unsupported tools for explicit official endpoint %s',
+      async (baseUrl) => {
+        const provider = new AnthropicChatProvider({
+          model: 'claude-opus-4-6',
+          apiKey: 'test-key',
+          baseUrl,
+          defaultMaxTokens: 1024,
+          stream: false,
+        });
+        const history: Message[] = [
+          { role: 'user', content: [{ type: 'text', text: 'Process resource' }], toolCalls: [] },
+        ];
+        const tools: Tool[] = [
+          {
+            name: 'incompatible_tool',
+            description: 'Uses oneOf.',
+            parameters: { oneOf: [{ required: ['resource_id'] }] },
+          },
+          {
+            name: 'compatible_tool',
+            description: 'Uses a regular object schema.',
+            parameters: { type: 'object' },
+          },
+        ];
+
+        const body = await captureRequestBody(provider, '', tools, history);
+        const wireTools = body['tools'] as Array<{ name: string }>;
+        expect(wireTools.map((tool) => tool.name)).toEqual(['compatible_tool']);
+      },
+    );
+
     it('tool call and tool result (Anthropic wire format)', async () => {
       const provider = createProvider();
       const toolCall: ToolCall = {


### PR DESCRIPTION
## Related Issue

Resolve #2328

## Problem

Anthropic rejects a request when any MCP tool has `oneOf`, `anyOf`, or `allOf`
at the root of its input schema. Because the complete tool list is sent with
each request, one such tool prevents even an unrelated prompt from running.

## What changed

- Detect Anthropic tool schemas with an unsupported root combinator in both
  the current and legacy provider paths.
- Omit only incompatible tools from official Anthropic request shaping instead
  of rewriting their JSON Schema; compatible tools remain available, while
  Kimi compositions and custom compatible endpoints are unchanged.
- Cover both provider paths, all three root combinators, compatible-tool
  retention, Kimi/custom endpoint scoping, and input immutability.

## Test verification (RED → GREEN)

Real upstream provider-boundary RED; the issue also confirms that omitting the
offending tool makes the same Anthropic session work:

```text
APIStatusError: 400 {"type":"error","error":{"type":"invalid_request_error","message":"tools.0.custom.input_schema: input_schema does not support oneOf, allOf, or anyOf at the top level"}}
```

Full affected suite on exact `origin/main`, with both new tests applied
but no production changes:

```bash
pnpm exec vitest run \
  packages/agent-core-v2/test/kosong/provider/composition.test.ts \
  packages/kosong/test/anthropic.test.ts
```

```text
|kosong| test/anthropic.test.ts (291 tests | 3 failed)
|agent-core-v2| test/kosong/provider/composition.test.ts (69 tests | 3 failed)
Test Files  2 failed (2)
Tests  6 failed | 354 passed (360)

Expected: ["compatible_tool"]
Received: ["one_of_tool", "any_of_tool", "all_of_tool", "compatible_tool"]

For both explicit official URL forms, the same files received:
["incompatible_tool", "compatible_tool"].
```

Patched GREEN:

```bash
pnpm exec vitest run \
  packages/agent-core-v2/test/kosong/provider/composition.test.ts \
  packages/kosong/test/anthropic.test.ts
```

```text
Test Files  2 passed (2)
Tests  360 passed (360)
```

Also passed:

- `pnpm --filter @moonshot-ai/agent-core-v2 lint:domain`
- `pnpm --filter @moonshot-ai/agent-core-v2 typecheck`
- `pnpm --filter @moonshot-ai/kosong typecheck`

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.


## Review feedback verification

The registry-created plain Anthropic path now leaves `filterUnsupportedRootSchemas` unset when there is no real `providerType`, so the Anthropic base keeps its official-endpoint filtering even though the registry appends the synthetic default-headers trait.

RED for the review case:

```text
filters unsupported tools for registry-created plain anthropic providers
AssertionError: expected [ 'incompatible_tool', 'compatible_tool' ] to deeply equal [ 'compatible_tool' ]
```

GREEN after the fix:

```text
pnpm exec vitest run packages/agent-core-v2/test/kosong/provider/composition.test.ts -t "filters unsupported tools for registry-created plain anthropic providers"
Test Files 1 passed; Tests 1 passed | 69 skipped
```

Full local replay:

```text
./run-ci.sh
Test Files 2 passed; Tests 361 passed
check-domain-layers: OK (1038 files)
@moonshot-ai/agent-core-v2 typecheck: passed
@moonshot-ai/kosong typecheck: passed
```
