### PR TITLE
fix(web): prevent fallback code line number overlap

### DIFF
--- a/.changeset/fix-web-fallback-line-numbers.md
+++ b/.changeset/fix-web-fallback-line-numbers.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+web: Fix line numbers overlapping code in fallback-rendered code blocks.

--- a/.changeset/fix-web-fallback-line-numbers.md
+++ b/.changeset/fix-web-fallback-line-numbers.md
@@ -2,4 +2,4 @@
 "@moonshot-ai/kimi-code": patch
 ---
 
-web: Fix line numbers overlapping code in fallback-rendered code blocks.
+web: Fix line numbers overlapping or drifting out of alignment in fallback-rendered code blocks.

--- a/apps/kimi-web/src/components/chat/Markdown.vue
+++ b/apps/kimi-web/src/components/chat/Markdown.vue
@@ -672,15 +672,38 @@ function copyDiff(code: string, idx: number) {
 .md :deep(.code-block-content pre:not(.shiki) code) {
   color: var(--color-text);
 }
-/* markstream-vue 1.0.7's scoped fallback rule does not match the generated
-   <pre> element, so line-numbered fallback blocks do not reserve space for the
-   gutter. Keep this limited to the fallback renderer; Shiki already applies
-   the same padding to its code element. */
-.md :deep(pre.markstream-pre--line-numbers.code-pre-fallback > .markstream-pre__code) {
+/* markstream-vue 1.0.7 renders its standalone fallback as the component root,
+   but scopes the corresponding styles as though the <pre> were a descendant.
+   Restore that fallback layout here; loading fallbacks already receive the
+   equivalent global markstream rule. */
+.md :deep(pre.code-pre-fallback:not(.markstream-pre--diff-preview):not([data-markstream-code-loading='1'])) {
   box-sizing: border-box;
-  min-width: 100%;
+  width: 100%;
+  margin: 0.6em 0;
+  padding: var(--markstream-code-padding-y, 8px) var(--markstream-code-padding-x, 12px);
   padding-left: var(--markstream-code-padding-left, 52px);
-  padding-right: var(--markstream-code-padding-x, 12px);
+  overflow: auto;
+  border: 1px solid var(--color-line);
+  border-radius: var(--radius-md);
+  background: var(--color-surface-sunken);
+  box-shadow: var(--shadow-xs);
+  color: var(--color-text);
+  font-family: var(--markstream-code-font-family, var(--font-mono));
+  font-size: var(--vscode-editor-font-size, var(--text-sm));
+  font-weight: var(--weight-regular);
+  line-height: var(--vscode-editor-line-height, calc(var(--text-sm) * 1.65));
+}
+.md :deep(pre.code-pre-fallback.is-wrap:not(.markstream-pre--diff-preview)) {
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
+.md :deep(pre.code-pre-fallback:not(.markstream-pre--diff-preview) > .markstream-pre__code) {
+  min-width: 100%;
+  padding: 0;
+  border: 0;
+  background: none;
+  color: inherit;
+  font: inherit;
 }
 
 /* Links — open in a new tab (markstream handles target/rel) */

--- a/apps/kimi-web/src/components/chat/Markdown.vue
+++ b/apps/kimi-web/src/components/chat/Markdown.vue
@@ -672,6 +672,16 @@ function copyDiff(code: string, idx: number) {
 .md :deep(.code-block-content pre:not(.shiki) code) {
   color: var(--color-text);
 }
+/* markstream-vue 1.0.7's scoped fallback rule does not match the generated
+   <pre> element, so line-numbered fallback blocks do not reserve space for the
+   gutter. Keep this limited to the fallback renderer; Shiki already applies
+   the same padding to its code element. */
+.md :deep(pre.markstream-pre--line-numbers.code-pre-fallback > .markstream-pre__code) {
+  box-sizing: border-box;
+  min-width: 100%;
+  padding-left: var(--markstream-code-padding-left, 52px);
+  padding-right: var(--markstream-code-padding-x, 12px);
+}
 
 /* Links — open in a new tab (markstream handles target/rel) */
 .md :deep(a) {


### PR DESCRIPTION
## Related Issue

None. The problem is described below.

## Problem

When a fenced code block is rendered through `markstream-vue`'s line-numbered fallback, the line numbers can overlap the code text or drift out of vertical alignment.

In `markstream-vue@1.0.7`, the standalone fallback `<pre>` is rendered as the component root, while its scoped layout rules are emitted as descendant selectors. Those rules do not match that root element, so the fallback loses its gutter padding, font, and line height. The line-number gutter keeps its own metrics while the code falls back to different metrics.

## What changed

- Restored the complete standalone fallback `<pre>` layout: gutter space, typography, wrapping, overflow, border, background, and radius.
- Made the fallback child `<code>` inherit the container typography and removed child padding, preventing loading fallbacks from reserving the gutter twice.
- Excluded diff previews and left the Shiki rendering path unchanged.
- Added a patch changeset for `@moonshot-ai/kimi-code`.

## Verification

- `pnpm --filter @moonshot-ai/kimi-web check:style`
- `pnpm --filter @moonshot-ai/kimi-web typecheck`
- `pnpm --filter @moonshot-ai/kimi-web test` (34 files, 653 tests)
- `pnpm --filter @moonshot-ai/kimi-web build`
- Verified in both Moon Bright and Moon Dark themes.
- Verified standalone fallback code and gutter heights match (72 px for four lines), with gutter spacing preserved and child padding at 0.
- Verified loading fallback code and gutter heights match (198 px for eleven lines), without duplicate gutter padding.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [ ] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update. (No documentation update is needed because commands, configuration, and user workflows are unchanged.)