### PR TITLE
fix(tui): refresh task output previews

### DIFF
--- a/.changeset/fresh-task-output-preview.md
+++ b/.changeset/fresh-task-output-preview.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Keep the `/tasks` output preview fresh and show retryable output-loading errors.

--- a/apps/kimi-code/src/tui/components/dialogs/tasks-browser.ts
+++ b/apps/kimi-code/src/tui/components/dialogs/tasks-browser.ts
@@ -37,6 +37,7 @@ export interface TasksBrowserProps {
   readonly filter: TasksFilter;
   readonly selectedTaskId: string | undefined;
   readonly tailOutput: string | undefined;
+  readonly tailError?: string;
   readonly tailLoading: boolean;
   readonly flashMessage: string | undefined;
   readonly onSelect: (taskId: string) => void;
@@ -590,13 +591,16 @@ export class TasksBrowserApp extends Container implements Focusable {
 
     let body: string;
     if (this.props.tailLoading) body = '[loading…]';
+    else if (this.props.tailError !== undefined)
+      body = `Preview unavailable: ${this.props.tailError} (press R to retry)`;
     else if (this.props.tailOutput === undefined || this.props.tailOutput.length === 0)
       body = '[no output captured]';
     else body = this.props.tailOutput;
 
     const rawLines = body.split('\n');
     const tailLines = rawLines.slice(-innerHeight);
-    const styled = tailLines.map((line) => currentTheme.fg('textDim', line));
+    const color = this.props.tailError === undefined ? 'textDim' : 'error';
+    const styled = tailLines.map((line) => currentTheme.fg(color, line));
     while (styled.length < innerHeight) styled.push('');
     return this.renderFrame('Preview Output', styled, width, height);
   }

--- a/apps/kimi-code/src/tui/controllers/tasks-browser.ts
+++ b/apps/kimi-code/src/tui/controllers/tasks-browser.ts
@@ -263,8 +263,16 @@ export class TasksBrowserController {
     const selectedTask =
       browser.selectedTaskId === undefined
         ? undefined
+        : tasks.find((task) => task.taskId === browser.selectedTaskId);
+    const cachedSelectedTask =
+      browser.selectedTaskId === undefined
+        ? undefined
         : this.host.backgroundTasks.get(browser.selectedTaskId);
-    if (opts.reloadTail !== false && selectedTask?.status === 'running') {
+    if (
+      opts.reloadTail !== false &&
+      selectedTask?.status === 'running' &&
+      cachedSelectedTask?.status === 'running'
+    ) {
       this.reloadSelectedTail(browser);
     }
   }

--- a/apps/kimi-code/src/tui/controllers/tasks-browser.ts
+++ b/apps/kimi-code/src/tui/controllers/tasks-browser.ts
@@ -45,6 +45,8 @@ export type TasksBrowserState = {
   tailLoading: boolean;
   tailRequestId: number;
   tailRequestTaskId: string | undefined;
+  tailReloadPending: boolean;
+  tailFinalReloadTaskId: string | undefined;
   flashMessage: string | undefined;
   flashTimer: NodeJS.Timeout | undefined;
   pollTimer: NodeJS.Timeout | undefined;
@@ -89,6 +91,7 @@ export class TasksBrowserController {
 
     const filter: TasksFilter = 'all';
     const selectedTaskId = this.pickInitialSelection(tasks, filter);
+    const selectedTask = tasks.find((task) => task.taskId === selectedTaskId);
     const component = new TasksBrowserApp(
       {
         tasks,
@@ -123,6 +126,11 @@ export class TasksBrowserController {
       tailLoading: false,
       tailRequestId: 0,
       tailRequestTaskId: undefined,
+      tailReloadPending: false,
+      tailFinalReloadTaskId:
+        selectedTask !== undefined && selectedTask.status !== 'running'
+          ? selectedTaskId
+          : undefined,
       flashMessage: undefined,
       flashTimer: undefined,
       pollTimer,
@@ -156,7 +164,18 @@ export class TasksBrowserController {
     if (browser === undefined) return;
     const tasks = [...this.host.backgroundTasks.values()];
     this.pushProps(tasks);
-    this.reloadSelectedTail(browser);
+    const selectedTask =
+      browser.selectedTaskId === undefined
+        ? undefined
+        : this.host.backgroundTasks.get(browser.selectedTaskId);
+    if (selectedTask === undefined) return;
+    if (selectedTask.status !== 'running') {
+      if (browser.tailFinalReloadTaskId === selectedTask.taskId) return;
+      browser.tailFinalReloadTaskId = selectedTask.taskId;
+    } else {
+      browser.tailFinalReloadTaskId = undefined;
+    }
+    this.reloadSelectedTail(browser, { queueIfBusy: true });
   }
 
   async refreshOutputViewer(opts: { silent?: boolean } = {}): Promise<void> {
@@ -310,6 +329,10 @@ export class TasksBrowserController {
     browser.tailOutput = undefined;
     browser.tailError = undefined;
     browser.tailLoading = true;
+    browser.tailReloadPending = false;
+    const selectedTask = this.host.backgroundTasks.get(taskId);
+    browser.tailFinalReloadTaskId =
+      selectedTask !== undefined && selectedTask.status !== 'running' ? taskId : undefined;
     this.pushProps([...this.host.backgroundTasks.values()]);
     this.loadTail(taskId);
   }
@@ -325,7 +348,7 @@ export class TasksBrowserController {
     const browser = this.host.state.tasksBrowser;
     if (browser === undefined) return;
     this.flash('Refreshing…', 600);
-    this.reloadSelectedTail(browser);
+    this.reloadSelectedTail(browser, { queueIfBusy: true });
     void this.refresh({ reloadTail: false });
   }
 
@@ -429,8 +452,7 @@ export class TasksBrowserController {
         current.tailOutput = output;
         current.tailError = undefined;
         current.tailLoading = false;
-        current.tailRequestTaskId = undefined;
-        this.pushProps([...this.host.backgroundTasks.values()]);
+        this.finishTailLoad(current, taskId);
       })
       .catch((error: unknown) => {
         const current = state.tasksBrowser;
@@ -439,18 +461,33 @@ export class TasksBrowserController {
         if (current.selectedTaskId !== taskId) return;
         current.tailError = error instanceof Error ? error.message : String(error);
         current.tailLoading = false;
-        current.tailRequestTaskId = undefined;
-        this.pushProps([...this.host.backgroundTasks.values()]);
+        this.finishTailLoad(current, taskId);
       });
   }
 
-  private reloadSelectedTail(browser: TasksBrowserState): void {
-    if (
-      browser.selectedTaskId !== undefined &&
-      browser.tailRequestTaskId !== browser.selectedTaskId
-    ) {
-      this.loadTail(browser.selectedTaskId);
+  private finishTailLoad(browser: TasksBrowserState, taskId: string): void {
+    const reloadPending = browser.tailReloadPending;
+    browser.tailReloadPending = false;
+    browser.tailRequestTaskId = undefined;
+    this.pushProps([...this.host.backgroundTasks.values()]);
+    if (reloadPending && browser.selectedTaskId === taskId) {
+      this.loadTail(taskId);
     }
+  }
+
+  private reloadSelectedTail(
+    browser: TasksBrowserState,
+    opts: { queueIfBusy?: boolean } = {},
+  ): void {
+    const taskId = browser.selectedTaskId;
+    if (taskId === undefined) return;
+    if (browser.tailRequestTaskId === taskId) {
+      if (opts.queueIfBusy === true) {
+        browser.tailReloadPending = true;
+      }
+      return;
+    }
+    this.loadTail(taskId);
   }
 
   private flash(message: string, durationMs = 2500): void {

--- a/apps/kimi-code/src/tui/controllers/tasks-browser.ts
+++ b/apps/kimi-code/src/tui/controllers/tasks-browser.ts
@@ -9,6 +9,18 @@ import type { CustomEditor } from '../components/editor/custom-editor';
 const TASKS_POLL_INTERVAL_MS = 1_000;
 const PREVIEW_TAIL_CHARACTERS = 4_000;
 
+export interface TasksBrowserPolling {
+  start(callback: () => void, intervalMs: number): NodeJS.Timeout;
+  stop(timer: NodeJS.Timeout): void;
+}
+
+const DEFAULT_TASKS_BROWSER_POLLING: TasksBrowserPolling = {
+  start: (callback, intervalMs) => setInterval(callback, intervalMs),
+  stop: (timer) => {
+    clearInterval(timer);
+  },
+};
+
 export interface TasksBrowserHost {
   readonly state: {
     readonly tasksBrowser: TasksBrowserState | undefined;
@@ -49,7 +61,10 @@ export type TasksBrowserState = {
 };
 
 export class TasksBrowserController {
-  constructor(private readonly host: TasksBrowserHost) {}
+  constructor(
+    private readonly host: TasksBrowserHost,
+    private readonly polling: TasksBrowserPolling = DEFAULT_TASKS_BROWSER_POLLING,
+  ) {}
 
   async show(): Promise<void> {
     const { state } = this.host;
@@ -94,7 +109,7 @@ export class TasksBrowserController {
     state.ui.setFocus(component);
     state.ui.requestRender(true);
 
-    const pollTimer = setInterval(() => {
+    const pollTimer = this.polling.start(() => {
       void this.refresh({ silent: true });
     }, TASKS_POLL_INTERVAL_MS);
 
@@ -124,7 +139,7 @@ export class TasksBrowserController {
     const browser = state.tasksBrowser;
     if (browser === undefined) return;
     if (browser.viewer !== undefined) this.closeOutputViewer();
-    if (browser.pollTimer !== undefined) clearInterval(browser.pollTimer);
+    if (browser.pollTimer !== undefined) this.polling.stop(browser.pollTimer);
     if (browser.flashTimer !== undefined) clearTimeout(browser.flashTimer);
 
     state.ui.clear();
@@ -226,7 +241,11 @@ export class TasksBrowserController {
     }
     if (state.tasksBrowser !== browser) return;
     this.pushProps(tasks);
-    if (opts.reloadTail !== false) {
+    const selectedTask =
+      browser.selectedTaskId === undefined
+        ? undefined
+        : this.host.backgroundTasks.get(browser.selectedTaskId);
+    if (opts.reloadTail !== false && selectedTask?.status === 'running') {
       this.reloadSelectedTail(browser);
     }
   }

--- a/apps/kimi-code/src/tui/controllers/tasks-browser.ts
+++ b/apps/kimi-code/src/tui/controllers/tasks-browser.ts
@@ -6,6 +6,9 @@ import { TasksBrowserApp, type TasksFilter } from '../components/dialogs/tasks-b
 import type { Theme } from '#/tui/theme';
 import type { CustomEditor } from '../components/editor/custom-editor';
 
+const TASKS_POLL_INTERVAL_MS = 1_000;
+const PREVIEW_TAIL_CHARACTERS = 4_000;
+
 export interface TasksBrowserHost {
   readonly state: {
     readonly tasksBrowser: TasksBrowserState | undefined;
@@ -26,8 +29,10 @@ export type TasksBrowserState = {
   filter: TasksFilter;
   selectedTaskId: string | undefined;
   tailOutput: string | undefined;
+  tailError: string | undefined;
   tailLoading: boolean;
   tailRequestId: number;
+  tailRequestTaskId: string | undefined;
   flashMessage: string | undefined;
   flashTimer: NodeJS.Timeout | undefined;
   pollTimer: NodeJS.Timeout | undefined;
@@ -75,6 +80,7 @@ export class TasksBrowserController {
         filter,
         selectedTaskId,
         tailOutput: undefined,
+        tailError: undefined,
         tailLoading: false,
         flashMessage: undefined,
         ...this.buildCallbacks(),
@@ -90,7 +96,7 @@ export class TasksBrowserController {
 
     const pollTimer = setInterval(() => {
       void this.refresh({ silent: true });
-    }, 1000);
+    }, TASKS_POLL_INTERVAL_MS);
 
     this.host.setTasksBrowser({
       component,
@@ -98,8 +104,10 @@ export class TasksBrowserController {
       filter,
       selectedTaskId,
       tailOutput: undefined,
+      tailError: undefined,
       tailLoading: false,
       tailRequestId: 0,
+      tailRequestTaskId: undefined,
       flashMessage: undefined,
       flashTimer: undefined,
       pollTimer,
@@ -133,6 +141,7 @@ export class TasksBrowserController {
     if (browser === undefined) return;
     const tasks = [...this.host.backgroundTasks.values()];
     this.pushProps(tasks);
+    this.reloadSelectedTail(browser);
   }
 
   async refreshOutputViewer(opts: { silent?: boolean } = {}): Promise<void> {
@@ -194,7 +203,9 @@ export class TasksBrowserController {
     return candidates.find((t) => t.status === 'running')?.taskId ?? candidates[0]!.taskId;
   }
 
-  private async refresh(opts: { silent?: boolean } = {}): Promise<void> {
+  private async refresh(
+    opts: { silent?: boolean; reloadTail?: boolean } = {},
+  ): Promise<void> {
     const { state } = this.host;
     const browser = state.tasksBrowser;
     if (browser === undefined) return;
@@ -215,6 +226,9 @@ export class TasksBrowserController {
     }
     if (state.tasksBrowser !== browser) return;
     this.pushProps(tasks);
+    if (opts.reloadTail !== false) {
+      this.reloadSelectedTail(browser);
+    }
   }
 
   private pushProps(tasks: readonly BackgroundTaskInfo[]): void {
@@ -225,6 +239,7 @@ export class TasksBrowserController {
       filter: browser.filter,
       selectedTaskId: browser.selectedTaskId,
       tailOutput: browser.tailOutput,
+      tailError: browser.tailError,
       tailLoading: browser.tailLoading,
       flashMessage: browser.flashMessage,
       ...this.buildCallbacks(),
@@ -274,8 +289,9 @@ export class TasksBrowserController {
     if (browser.selectedTaskId === taskId) return;
     browser.selectedTaskId = taskId;
     browser.tailOutput = undefined;
+    browser.tailError = undefined;
     browser.tailLoading = true;
-    this.repaint();
+    this.pushProps([...this.host.backgroundTasks.values()]);
     this.loadTail(taskId);
   }
 
@@ -283,12 +299,15 @@ export class TasksBrowserController {
     const browser = this.host.state.tasksBrowser;
     if (browser === undefined) return;
     browser.filter = browser.filter === 'all' ? 'active' : 'all';
-    this.repaint();
+    this.pushProps([...this.host.backgroundTasks.values()]);
   }
 
   private handleRefresh(): void {
+    const browser = this.host.state.tasksBrowser;
+    if (browser === undefined) return;
     this.flash('Refreshing…', 600);
-    void this.refresh();
+    this.reloadSelectedTail(browser);
+    void this.refresh({ reloadTail: false });
   }
 
   private async handleStop(taskId: string): Promise<void> {
@@ -355,7 +374,7 @@ export class TasksBrowserController {
 
     const pollTimer = setInterval(() => {
       void this.refreshOutputViewer({ silent: true });
-    }, 1000);
+    }, TASKS_POLL_INTERVAL_MS);
 
     browser.viewer = {
       component: viewer,
@@ -375,31 +394,44 @@ export class TasksBrowserController {
     const session = this.host.session;
     if (session === undefined) {
       browser.tailLoading = false;
-      this.repaint();
+      this.pushProps([...this.host.backgroundTasks.values()]);
       return;
     }
 
     const requestId = ++browser.tailRequestId;
+    browser.tailRequestTaskId = taskId;
     void session
-      .getBackgroundTaskOutput(taskId, { tail: 4000 })
+      .getBackgroundTaskOutput(taskId, { tail: PREVIEW_TAIL_CHARACTERS })
       .then((output) => {
         const current = state.tasksBrowser;
         if (current === undefined) return;
         if (current !== browser || current.tailRequestId !== requestId) return;
         if (current.selectedTaskId !== taskId) return;
         current.tailOutput = output;
+        current.tailError = undefined;
         current.tailLoading = false;
-        this.repaint();
+        current.tailRequestTaskId = undefined;
+        this.pushProps([...this.host.backgroundTasks.values()]);
       })
-      .catch(() => {
+      .catch((error: unknown) => {
         const current = state.tasksBrowser;
         if (current === undefined) return;
         if (current !== browser || current.tailRequestId !== requestId) return;
         if (current.selectedTaskId !== taskId) return;
-        current.tailOutput = '';
+        current.tailError = error instanceof Error ? error.message : String(error);
         current.tailLoading = false;
-        this.repaint();
+        current.tailRequestTaskId = undefined;
+        this.pushProps([...this.host.backgroundTasks.values()]);
       });
+  }
+
+  private reloadSelectedTail(browser: TasksBrowserState): void {
+    if (
+      browser.selectedTaskId !== undefined &&
+      browser.tailRequestTaskId !== browser.selectedTaskId
+    ) {
+      this.loadTail(browser.selectedTaskId);
+    }
   }
 
   private flash(message: string, durationMs = 2500): void {
@@ -412,9 +444,9 @@ export class TasksBrowserController {
       if (current !== browser) return;
       current.flashMessage = undefined;
       current.flashTimer = undefined;
-      this.repaint();
+      this.pushProps([...this.host.backgroundTasks.values()]);
     }, durationMs);
-    this.repaint();
+    this.pushProps([...this.host.backgroundTasks.values()]);
   }
 
   private closeOutputViewer(): void {

--- a/apps/kimi-code/test/tui/tasks-browser.test.ts
+++ b/apps/kimi-code/test/tui/tasks-browser.test.ts
@@ -114,9 +114,12 @@ function controllerRig(options: {
 }): {
   controller: TasksBrowserController;
   get browser(): TasksBrowserState | undefined;
+  backgroundTasks: Map<string, BackgroundTaskInfo>;
+  poll(): void;
 } {
   let browser: TasksBrowserState | undefined;
   let children: Component[] = [];
+  let poll = () => {};
   const ui = {
     get children() {
       return children;
@@ -135,6 +138,9 @@ function controllerRig(options: {
     listBackgroundTasks: options.listTasks ?? vi.fn().mockResolvedValue(tasks),
     getBackgroundTaskOutput: options.getOutput,
   } as unknown as Session;
+  const backgroundTasks = new Map(
+    tasks.map((backgroundTask) => [backgroundTask.taskId, backgroundTask]),
+  );
   const host: TasksBrowserHost = {
     state: {
       get tasksBrowser() {
@@ -145,18 +151,26 @@ function controllerRig(options: {
       ui,
       editor: {} as CustomEditor,
     },
-    backgroundTasks: new Map(
-      tasks.map((backgroundTask) => [backgroundTask.taskId, backgroundTask]),
-    ),
+    backgroundTasks,
     session,
     showError: vi.fn(),
     setTasksBrowser(value) {
       browser = value;
     },
   };
-  const controller = new TasksBrowserController(host);
+  const controller = new TasksBrowserController(host, {
+    start(callback) {
+      poll = callback;
+      return {} as NodeJS.Timeout;
+    },
+    stop() {},
+  });
   return {
     controller,
+    backgroundTasks,
+    poll() {
+      poll();
+    },
     get browser() {
       return browser;
     },
@@ -417,6 +431,72 @@ describe('TasksBrowserController — preview freshness', () => {
         'slow process output',
       );
     });
+  });
+
+  it('does not poll output again after the selected task is terminal', async () => {
+    const completedTask = task({
+      taskId: 'bash-complete',
+      detached: true,
+      status: 'completed',
+    });
+    const getOutput = vi.fn().mockResolvedValue('final process output');
+    const rig = controllerRig({ getOutput, tasks: [completedTask] });
+    controller = rig.controller;
+
+    await controller.show();
+    await vi.waitFor(() => {
+      expect(getOutput).toHaveBeenCalledTimes(1);
+    });
+    rig.poll();
+
+    await vi.waitFor(() => {
+      expect(getOutput).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it('ignores a stale running poll after a terminal event reloads final output', async () => {
+    const stalePoll = deferred<BackgroundTaskInfo[]>();
+    const runningTask = task({
+      taskId: 'bash-transition',
+      detached: true,
+      status: 'running',
+    });
+    const listTasks = vi
+      .fn()
+      .mockResolvedValueOnce([runningTask])
+      .mockReturnValueOnce(stalePoll.promise);
+    const getOutput = vi
+      .fn()
+      .mockResolvedValueOnce('running output')
+      .mockResolvedValueOnce('final output')
+      .mockResolvedValueOnce('unexpected extra output');
+    const rig = controllerRig({ getOutput, tasks: [runningTask], listTasks });
+    controller = rig.controller;
+
+    await controller.show();
+    await vi.waitFor(() => {
+      expect(getOutput).toHaveBeenCalledTimes(1);
+    });
+    rig.poll();
+    await vi.waitFor(() => {
+      expect(listTasks).toHaveBeenCalledTimes(2);
+    });
+    rig.backgroundTasks.set(
+      runningTask.taskId,
+      task({
+        taskId: runningTask.taskId,
+        detached: true,
+        status: 'completed',
+      }),
+    );
+    controller.repaint();
+    await vi.waitFor(() => {
+      expect(getOutput).toHaveBeenCalledTimes(2);
+    });
+    stalePoll.resolve([runningTask]);
+    await stalePoll.promise;
+
+    expect(getOutput).toHaveBeenCalledTimes(2);
   });
 
   it('opens the full output viewer without applying the preview tail limit', async () => {

--- a/apps/kimi-code/test/tui/tasks-browser.test.ts
+++ b/apps/kimi-code/test/tui/tasks-browser.test.ts
@@ -433,6 +433,50 @@ describe('TasksBrowserController — preview freshness', () => {
     });
   });
 
+  it('reloads final output after a terminal event interrupts an in-flight preview', async () => {
+    const runningOutput = deferred<string>();
+    const finalOutput = deferred<string>();
+    const runningTask = task({
+      taskId: 'bash-in-flight',
+      detached: true,
+      status: 'running',
+    });
+    const getOutput = vi
+      .fn()
+      .mockReturnValueOnce(runningOutput.promise)
+      .mockReturnValueOnce(finalOutput.promise)
+      .mockResolvedValueOnce('unexpected third output');
+    const rig = controllerRig({ getOutput, tasks: [runningTask] });
+    controller = rig.controller;
+
+    await controller.show();
+    await vi.waitFor(() => {
+      expect(getOutput).toHaveBeenCalledTimes(1);
+    });
+    rig.backgroundTasks.set(
+      runningTask.taskId,
+      task({
+        taskId: runningTask.taskId,
+        detached: true,
+        status: 'completed',
+      }),
+    );
+    controller.repaint();
+    runningOutput.resolve('pre-termination output');
+
+    await vi.waitFor(() => {
+      expect(getOutput).toHaveBeenCalledTimes(2);
+    });
+    controller.repaint();
+    finalOutput.resolve('final output');
+    await vi.waitFor(() => {
+      expect(strip(rig.browser!.component.render(120).join('\n'))).toContain(
+        'final output',
+      );
+    });
+    expect(getOutput).toHaveBeenCalledTimes(2);
+  });
+
   it('does not poll output again after the selected task is terminal', async () => {
     const completedTask = task({
       taskId: 'bash-complete',

--- a/apps/kimi-code/test/tui/tasks-browser.test.ts
+++ b/apps/kimi-code/test/tui/tasks-browser.test.ts
@@ -1,13 +1,29 @@
-import type { Terminal } from '@moonshot-ai/pi-tui';
-import type { BackgroundTaskInfo, BackgroundTaskStatus } from '@moonshot-ai/kimi-code-sdk';
-import { describe, expect, it, vi } from 'vitest';
+/**
+ * Scenario: users inspect and control background tasks through the /tasks browser.
+ * Responsibilities: render task/output state, route keyboard actions, and keep previews fresh.
+ * Wiring: the real browser component/controller with only the SDK Session boundary stubbed.
+ * Run: pnpm --filter @moonshot-ai/kimi-code exec vitest run test/tui/tasks-browser.test.ts
+ */
+import type {
+  BackgroundTaskInfo,
+  BackgroundTaskStatus,
+  Session,
+} from '@moonshot-ai/kimi-code-sdk';
+import type { Component, ProcessTerminal, Terminal, TUI } from '@moonshot-ai/pi-tui';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import {
   TasksBrowserApp,
   type TasksBrowserProps,
   type TasksFilter,
 } from '@/tui/components/dialogs/tasks-browser';
-import { darkColors } from '@/tui/theme/colors';
+import {
+  TasksBrowserController,
+  type TasksBrowserHost,
+  type TasksBrowserState,
+} from '@/tui/controllers/tasks-browser';
+import type { CustomEditor } from '@/tui/components/editor/custom-editor';
+import type { Theme } from '@/tui/theme';
 
 const ANSI_SGR = /\[[0-9;]*m/g;
 function strip(text: string): string {
@@ -81,6 +97,70 @@ function makeApp(
   columns = 120,
 ): TasksBrowserApp {
   return new TasksBrowserApp(makeProps(props), fakeTerminal(rows, columns));
+}
+
+function deferred<T>(): { promise: Promise<T>; resolve: (value: T) => void } {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((onResolve) => {
+    resolve = onResolve;
+  });
+  return { promise, resolve };
+}
+
+function controllerRig(options: {
+  getOutput: ReturnType<typeof vi.fn>;
+  tasks?: BackgroundTaskInfo[];
+  listTasks?: ReturnType<typeof vi.fn>;
+}): {
+  controller: TasksBrowserController;
+  get browser(): TasksBrowserState | undefined;
+} {
+  let browser: TasksBrowserState | undefined;
+  let children: Component[] = [];
+  const ui = {
+    get children() {
+      return children;
+    },
+    clear() {
+      children = [];
+    },
+    addChild(child: Component) {
+      children.push(child);
+    },
+    setFocus: vi.fn(),
+    requestRender: vi.fn(),
+  } as unknown as TUI;
+  const tasks = options.tasks ?? [task({ taskId: 'bash-live', detached: true })];
+  const session = {
+    listBackgroundTasks: options.listTasks ?? vi.fn().mockResolvedValue(tasks),
+    getBackgroundTaskOutput: options.getOutput,
+  } as unknown as Session;
+  const host: TasksBrowserHost = {
+    state: {
+      get tasksBrowser() {
+        return browser;
+      },
+      theme: {} as Theme,
+      terminal: fakeTerminal(30) as ProcessTerminal,
+      ui,
+      editor: {} as CustomEditor,
+    },
+    backgroundTasks: new Map(
+      tasks.map((backgroundTask) => [backgroundTask.taskId, backgroundTask]),
+    ),
+    session,
+    showError: vi.fn(),
+    setTasksBrowser(value) {
+      browser = value;
+    },
+  };
+  const controller = new TasksBrowserController(host);
+  return {
+    controller,
+    get browser() {
+      return browser;
+    },
+  };
 }
 
 describe('TasksBrowserApp — full-screen rendering', () => {
@@ -203,6 +283,19 @@ describe('TasksBrowserApp — full-screen rendering', () => {
     expect(out).toContain('[loading');
   });
 
+  it('shows a preview load failure distinctly from an empty output', () => {
+    const out = strip(
+      makeApp({
+        tasks: [task({ taskId: 'bash-aaaaaaaa' })],
+        selectedTaskId: 'bash-aaaaaaaa',
+        tailError: 'permission denied',
+      })
+        .render(120)
+        .join('\n'),
+    );
+    expect(out).toContain('Preview unavailable: permission denied');
+  });
+
   it('shows empty-state copy in the Tasks pane when no tasks', () => {
     const out = strip(makeApp().render(120).join('\n'));
     expect(out).toContain('No background tasks');
@@ -273,6 +366,133 @@ describe('TasksBrowserApp — full-screen rendering', () => {
   it('falls back to a single line when the terminal is too small', () => {
     const out = strip(makeApp({}, 5, 30).render(30).join('\n'));
     expect(out).toContain('too small');
+  });
+});
+
+describe('TasksBrowserController — preview freshness', () => {
+  let controller: TasksBrowserController | undefined;
+
+  afterEach(() => {
+    controller?.close();
+    controller = undefined;
+  });
+
+  it('reloads the selected preview when task events repaint the browser', async () => {
+    const getOutput = vi
+      .fn()
+      .mockResolvedValueOnce('')
+      .mockResolvedValueOnce('agent final result');
+    const rig = controllerRig({ getOutput });
+    controller = rig.controller;
+
+    await controller.show();
+    await vi.waitFor(() => {
+      expect(getOutput).toHaveBeenCalledTimes(1);
+    });
+    controller.repaint();
+
+    await vi.waitFor(() => {
+      expect(strip(rig.browser!.component.render(120).join('\n'))).toContain(
+        'agent final result',
+      );
+    });
+  });
+
+  it('shows slow process stdout after task events repaint the browser', async () => {
+    const pendingOutput = deferred<string>();
+    const getOutput = vi.fn().mockReturnValue(pendingOutput.promise);
+    const rig = controllerRig({ getOutput });
+    controller = rig.controller;
+
+    await controller.show();
+    await vi.waitFor(() => {
+      expect(getOutput).toHaveBeenCalledTimes(1);
+    });
+    controller.repaint();
+    expect(getOutput).toHaveBeenCalledTimes(1);
+    pendingOutput.resolve('slow process output');
+
+    await vi.waitFor(() => {
+      expect(strip(rig.browser!.component.render(120).join('\n'))).toContain(
+        'slow process output',
+      );
+    });
+  });
+
+  it('opens the full output viewer without applying the preview tail limit', async () => {
+    const getOutput = vi.fn().mockResolvedValue('complete task output');
+    const rig = controllerRig({ getOutput });
+    controller = rig.controller;
+
+    await controller.show();
+    await vi.waitFor(() => {
+      expect(getOutput).toHaveBeenNthCalledWith(1, 'bash-live', { tail: 4000 });
+    });
+    rig.browser!.component.handleInput('o');
+
+    await vi.waitFor(() => {
+      expect(getOutput).toHaveBeenNthCalledWith(2, 'bash-live');
+    });
+  });
+
+  it('retries a failed preview load when the user presses R', async () => {
+    const getOutput = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('permission denied'))
+      .mockResolvedValueOnce('retry succeeded');
+    const listTasks = vi
+      .fn()
+      .mockResolvedValueOnce([task({ taskId: 'bash-live', detached: true })])
+      .mockRejectedValueOnce(new Error('metadata unavailable'));
+    const rig = controllerRig({ getOutput, listTasks });
+    controller = rig.controller;
+
+    await controller.show();
+    await vi.waitFor(() => {
+      expect(strip(rig.browser!.component.render(120).join('\n'))).toContain(
+        'Preview unavailable: permission denied',
+      );
+    });
+    rig.browser!.component.handleInput('r');
+
+    await vi.waitFor(() => {
+      expect(strip(rig.browser!.component.render(120).join('\n'))).toContain(
+        'retry succeeded',
+      );
+    });
+  });
+
+  it('ignores a stale preview response after the selected task changes', async () => {
+    const firstOutput = deferred<string>();
+    const secondOutput = deferred<string>();
+    const tasks = [
+      task({ taskId: 'bash-first', detached: true, startedAt: 1 }),
+      task({ taskId: 'bash-second', detached: true, startedAt: 2 }),
+    ];
+    const getOutput = vi.fn((taskId: string) =>
+      taskId === 'bash-first' ? firstOutput.promise : secondOutput.promise,
+    );
+    const rig = controllerRig({ getOutput, tasks });
+    controller = rig.controller;
+
+    await controller.show();
+    await vi.waitFor(() => {
+      expect(getOutput).toHaveBeenCalledWith('bash-first', { tail: 4000 });
+    });
+    rig.browser!.component.handleInput('j');
+    secondOutput.resolve('selected task output');
+    await vi.waitFor(() => {
+      expect(strip(rig.browser!.component.render(120).join('\n'))).toContain(
+        'selected task output',
+      );
+    });
+    firstOutput.resolve('stale task output');
+
+    await vi.waitFor(() => {
+      const rendered = strip(rig.browser!.component.render(120).join('\n'));
+      expect(rendered).toContain('selected task output');
+      expect(rendered).not.toContain('stale task output');
+    });
   });
 });
 

--- a/apps/kimi-code/test/tui/tasks-browser.test.ts
+++ b/apps/kimi-code/test/tui/tasks-browser.test.ts
@@ -498,6 +498,37 @@ describe('TasksBrowserController — preview freshness', () => {
     });
   });
 
+  it('stops polling output when the refreshed task list becomes terminal', async () => {
+    const runningTask = task({
+      taskId: 'bash-polled-terminal',
+      detached: true,
+      status: 'running',
+    });
+    const completedTask = task({
+      taskId: runningTask.taskId,
+      detached: true,
+      status: 'completed',
+    });
+    const listTasks = vi
+      .fn()
+      .mockResolvedValueOnce([runningTask])
+      .mockResolvedValueOnce([completedTask]);
+    const getOutput = vi.fn().mockResolvedValue('process output');
+    const rig = controllerRig({ getOutput, tasks: [runningTask], listTasks });
+    controller = rig.controller;
+
+    await controller.show();
+    await vi.waitFor(() => {
+      expect(getOutput).toHaveBeenCalledTimes(1);
+    });
+    rig.poll();
+
+    await vi.waitFor(() => {
+      expect(listTasks).toHaveBeenCalledTimes(2);
+    });
+    expect(getOutput).toHaveBeenCalledTimes(1);
+  });
+
   it('ignores a stale running poll after a terminal event reloads final output', async () => {
     const stalePoll = deferred<BackgroundTaskInfo[]>();
     const runningTask = task({


### PR DESCRIPTION
## Related Issue

Resolves #2341

## Problem

The `/tasks` Preview Output loaded only when the selection changed. Running process output and background-agent results could therefore remain stale, and an output-loading failure was displayed as if the task had produced no output.

## What changed

- Reload the selected preview from task events, polling, and the `R` shortcut while keeping one request in flight per selection.
- Keep selection/request identity guards so late responses cannot overwrite the current task.
- Show output-loading failures distinctly with an actionable retry hint.
- Preserve the 4,000-character preview tail and the unbounded full-output viewer.

## Test verification (RED → GREEN)

Upstream RED (`origin/main` with regression tests only):

```text
Test Files  1 failed (1)
Tests  3 failed | 34 passed (37)
```

The failures showed the error as `[no output captured]`, left the selected preview stale after a task event, and did not retry the preview through `R`.

Patched GREEN:

```text
Test Files  1 passed (1)
Tests  44 passed (44)
```

Additional validation:

```text
TUI suite: 125 files passed; 1721 passed | 3 skipped (1724)
Typecheck: passed
Type-aware lint: 0 warnings, 0 errors
```

## Checklist

- [x] I have read the CONTRIBUTING document.
- [x] I have linked a related issue.
- [x] I have added tests that prove the feature works.
- [x] Ran `gen-changesets`; added a patch changeset for `@moonshot-ai/kimi-code`.
- [x] Ran `gen-docs`; no documentation update is needed because the existing reference only lists `/tasks` and does not describe preview refresh behavior.


## Review feedback verification

The periodic poll now skips output reads for terminal tasks while event-driven final reloads and manual `R` retries remain enabled. A stale-running-poll regression test failed with 3 output reads before the follow-up fix and passes with exactly 2 afterward.

The follow-up terminal-event race test failed because the final reload was missing, then a strengthened variant failed because a repeated repaint caused a third read that overwrote the final output. Both now pass with exactly one final automatic reload.

The refreshed-status regression test failed with 2 output reads instead of 1 when only `listBackgroundTasks` observed termination; it now passes and polling stops when either status source is terminal.
