### PR TITLE
fix(kosong): match Kimi's standalone "Unsupported image." rejection

### DIFF
--- a/.changeset/unsupported-image-standalone-rejection.md
+++ b/.changeset/unsupported-image-standalone-rejection.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Recognize Kimi's standalone "Unsupported image." rejection so the media-stripped resend can recover stuck sessions.

--- a/packages/agent-core-v2/src/kosong/contract/errors.ts
+++ b/packages/agent-core-v2/src/kosong/contract/errors.ts
@@ -210,6 +210,7 @@ const IMAGE_FORMAT_PROVIDER_MESSAGE_PATTERNS = [
 
 const IMAGE_FORMAT_STATUS_MESSAGE_PATTERNS = [
   /unsupported image (?:url|format|type)/,
+  /unsupported image(?=\s*(?:[.!?]|$))/,
   /does not represent a valid image/,
   /could not (?:process|decode) (?:the |input )?image/,
   /unable to process (?:the |input )?image/,

--- a/packages/agent-core-v2/test/app/llmProtocol/errors.test.ts
+++ b/packages/agent-core-v2/test/app/llmProtocol/errors.test.ts
@@ -228,6 +228,9 @@ describe('isImageFormatError', () => {
       ),
     ).toBe(true);
     expect(isImageFormatError(new APIStatusError(400, 'unsupported image format'))).toBe(true);
+    expect(
+      isImageFormatError(new APIStatusError(400, 'Unsupported image. Please try another one.')),
+    ).toBe(true);
     expect(isImageFormatError(new APIStatusError(400, 'Unable to process input image'))).toBe(true);
     expect(
       isImageFormatError(
@@ -263,6 +266,9 @@ describe('isImageFormatError', () => {
 
   it('does not match image count/size/support errors that stripping media cannot fix', () => {
     expect(isImageFormatError(new APIStatusError(400, 'too many images in request'))).toBe(false);
+    expect(
+      isImageFormatError(new APIStatusError(400, 'unsupported image size exceeds the limit')),
+    ).toBe(false);
     expect(
       isImageFormatError(new APIStatusError(400, 'image dimension 5000 exceeds maximum 2048')),
     ).toBe(false);

--- a/packages/kosong/src/errors.ts
+++ b/packages/kosong/src/errors.ts
@@ -272,6 +272,11 @@ const IMAGE_FORMAT_PROVIDER_MESSAGE_PATTERNS = [
 const IMAGE_FORMAT_STATUS_MESSAGE_PATTERNS = [
   // Unsupported format — OpenAI / Moonshot "unsupported image …".
   /unsupported image (?:url|format|type)/,
+  // Standalone-sentence form — Kimi "Unsupported image. …". The
+  // lookahead keeps the deliberate boundary: phrasings that continue into a
+  // qualifier ("unsupported image size …", a count/size limit) must not
+  // match, so only punctuation- or end-terminated occurrences classify.
+  /unsupported image(?=\s*(?:[.!?]|$))/,
   // Undecodable / corrupt image data.
   /does not represent a valid image/,
   /could not (?:process|decode) (?:the |input )?image/,

--- a/packages/kosong/test/errors.test.ts
+++ b/packages/kosong/test/errors.test.ts
@@ -585,6 +585,10 @@ describe('isImageFormatError', () => {
       ),
     ).toBe(true);
     expect(isImageFormatError(new APIStatusError(400, 'unsupported image format'))).toBe(true);
+    // Kimi standalone-sentence form (actual production message)
+    expect(
+      isImageFormatError(new APIStatusError(400, 'Unsupported image. Please try another one.')),
+    ).toBe(true);
     // Gemini
     expect(isImageFormatError(new APIStatusError(400, 'Unable to process input image'))).toBe(true);
     expect(
@@ -624,6 +628,11 @@ describe('isImageFormatError', () => {
     // model blind to the user's images — hiding the real error. They must
     // surface instead of triggering a media-stripped resend.
     expect(isImageFormatError(new APIStatusError(400, 'too many images in request'))).toBe(false);
+    // Qualifier-continuing phrasing: the standalone-sentence pattern must
+    // not swallow count/size variants of "unsupported image …".
+    expect(
+      isImageFormatError(new APIStatusError(400, 'unsupported image size exceeds the limit')),
+    ).toBe(false);
     expect(
       isImageFormatError(new APIStatusError(400, 'image dimension 5000 exceeds maximum 2048')),
     ).toBe(false);


### PR DESCRIPTION
## Related Issue

No linked issue — the problem is explained below.

## Problem

A session containing an image the provider rejects with `400 Unsupported image. Please try another one.` (Kimi's production phrasing) gets permanently stuck: `isImageFormatError` does not recognize this message (the patterns only cover `unsupported image url/format/type`), so the media-stripped resend never fires and every later request fails with the same 400.

Repro: `isImageFormatError(new APIStatusError(400, 'Unsupported image. Please try another one.'))` → `false`, in both `packages/kosong` and `packages/agent-core-v2`.

## What changed

- Added `/unsupported image(?=\s*(?:[.!?]|$))/` to the classifier in both `packages/kosong/src/errors.ts` and `packages/agent-core-v2/src/kosong/contract/errors.ts`. The lookahead matches only the standalone-sentence form, preserving the deliberate boundary that count/size phrasings must not trigger a media-stripped resend.
- Added tests in both packages: the exact production message (positive) and a qualifier-continuing phrasing (negative).

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset. — changeset included: `patch` for `@moonshot-ai/kimi-code` (the two touched packages are private internals; the user-visible fix lands in the CLI bundle).
- [x] Ran `gen-docs` skill, or this PR needs no doc update.