### PR TITLE
fix(tui): preserve quotes in Windows status line commands

### DIFF
--- a/.changeset/fix-windows-status-line-quotes.md
+++ b/.changeset/fix-windows-status-line-quotes.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Fix status line commands with quoted arguments on Windows.

--- a/apps/kimi-code/src/tui/utils/status-line-command.ts
+++ b/apps/kimi-code/src/tui/utils/status-line-command.ts
@@ -43,13 +43,20 @@ export function runStatusLineCommand(
     const isWin = process.platform === 'win32';
     let child;
     try {
-      child = spawn(isWin ? (process.env['ComSpec'] ?? 'cmd.exe') : 'sh', isWin ? ['/d', '/s', '/c', command] : ['-c', command], {
-        stdio: ['pipe', 'pipe', 'ignore'],
-        env: { ...process.env, KIMI_CODE_STATUS_LINE: '1' },
-        // Own process group on POSIX so a timeout can drop the whole tree,
-        // not just the shell wrapper.
-        detached: !isWin,
-      });
+      child = spawn(
+        isWin ? (process.env['ComSpec'] ?? 'cmd.exe') : 'sh',
+        isWin ? ['/d', '/s', '/c', `"${command}"`] : ['-c', command],
+        {
+          stdio: ['pipe', 'pipe', 'ignore'],
+          env: { ...process.env, KIMI_CODE_STATUS_LINE: '1' },
+          // Own process group on POSIX so a timeout can drop the whole tree,
+          // not just the shell wrapper.
+          detached: !isWin,
+          // Preserve the nested quotes in cmd /s /c "<command>" instead of
+          // letting libuv escape them as literal backslashes.
+          windowsVerbatimArguments: isWin,
+        },
+      );
     } catch {
       finish(null);
       return;

--- a/apps/kimi-code/test/tui/components/chrome/footer-status-line.test.ts
+++ b/apps/kimi-code/test/tui/components/chrome/footer-status-line.test.ts
@@ -134,6 +134,15 @@ describe('FooterComponent status_line items', () => {
 });
 
 describe('runStatusLineCommand', () => {
+  it.runIf(process.platform === 'win32')(
+    'preserves double quotes in Windows commands',
+    async () => {
+      const command = `"${process.execPath}" -e "process.stdout.write('quoted-ok')"`;
+
+      expect(await runStatusLineCommand(command, payload)).toBe('quoted-ok');
+    },
+  );
+
   it('passes the payload as JSON on stdin and returns the first stdout line', async () => {
     const line = await runStatusLineCommand('cat', payload);
 

--- a/apps/kimi-code/test/tui/components/chrome/footer-status-line.test.ts
+++ b/apps/kimi-code/test/tui/components/chrome/footer-status-line.test.ts
@@ -139,7 +139,7 @@ describe('runStatusLineCommand', () => {
     async () => {
       const command = `"${process.execPath}" -e "process.stdout.write('quoted-ok')"`;
 
-      expect(await runStatusLineCommand(command, payload)).toBe('quoted-ok');
+      expect(await runStatusLineCommand(command, payload, 5_000)).toBe('quoted-ok');
     },
   );
 


### PR DESCRIPTION
## Related Issue

Resolves #2332

## Problem

On Windows, `status_line.command` is passed to `cmd.exe /d /s /c` as one argv element. Node/libuv escapes embedded double quotes while serializing that argument, so commands that quote an executable or a path arrive at `cmd.exe` with literal backslashes and silently produce no status line output.

## What changed

- Wrap the Windows command in the outer quote pair required by `cmd /s /c` and enable `windowsVerbatimArguments`, preserving the command's nested quotes.
- Keep the existing POSIX `sh -c` path unchanged.
- Add a Windows-only regression test that invokes the current Node executable through the real status-line spawn path with quoted arguments.
- Add a patch changeset for `@moonshot-ai/kimi-code`.

## Validation

- Windows 11 `10.0.26100`, PowerShell 7.6.3, code page 936
- Node.js 24.15.0, pnpm 10.33.0
- Focused footer status-line tests: 17 passed
- `@moonshot-ai/kimi-code` TypeScript check: passed
- Type-aware Oxlint on the changed source and test: 0 warnings, 0 errors
- `changeset status --since=origin/main`: patch bump detected
- Independent complete-diff review: `No findings.`
- Internal-identifier audit: no private paths, accounts, endpoints, or environment-specific identifiers found

No documentation update is needed: the existing `[status_line].command` documentation already describes the intended command contract, and this change restores that documented behavior on Windows without changing configuration or usage.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.