### PR TITLE
fix(agent-core-v2): preserve select_tools for disclosure

### DIFF
--- a/packages/agent-core-v2/src/agent/toolActivation/toolActivationService.ts
+++ b/packages/agent-core-v2/src/agent/toolActivation/toolActivationService.ts
@@ -4,8 +4,10 @@
  * Iterates the `toolRegistry` contribution table and, for each entry allowed
  * by the bound Profile's tool policy (`profile`), resolves the Agent-scope
  * service through the container — nothing constructs the tool before this
- * `accessor.get` — and registers the real instance into the runtime
- * registry.
+ * `accessor.get` — and registers the real instance into the runtime registry.
+ * The `select_tools` disclosure gateway remains implicitly activatable when
+ * omitted from the Profile allowlist, while an explicit Profile deny still
+ * wins; request-time policy and disclosure gating control its visibility.
  *
  * Activation runs once explicitly from `AgentLifecycleService.create` (after
  * restore and profile binding) and re-runs on every `agent.status.updated`
@@ -30,6 +32,7 @@ import { IAgentProfileService } from '#/agent/profile/profile';
 import { isToolActive } from '#/agent/toolPolicy/evaluate';
 import { IAgentToolRegistryService } from '#/agent/toolRegistry/toolRegistry';
 import { getAgentToolContributions } from '#/agent/toolRegistry/toolContribution';
+import { SELECT_TOOLS_TOOL_NAME } from '#/agent/toolSelect/toolSelect';
 
 import { IAgentToolActivationService } from './toolActivation';
 
@@ -57,7 +60,11 @@ export class AgentToolActivationService extends Disposable implements IAgentTool
       for (const { id, options } of getAgentToolContributions()) {
         const source = options.source ?? 'builtin';
         if (this.toolRegistry.resolve(options.name) !== undefined) continue;
-        if (!isToolActive(policy, options.name, source)) continue;
+        const activationPolicy =
+          options.name === SELECT_TOOLS_TOOL_NAME
+            ? { disallowedTools: data.disallowedTools }
+            : policy;
+        if (!isToolActive(activationPolicy, options.name, source)) continue;
         if (options.when !== undefined && !options.when(accessor)) continue;
         const tool = accessor.get(id);
         this._register(

--- a/packages/agent-core-v2/test/agent/toolActivation/toolActivationService.test.ts
+++ b/packages/agent-core-v2/test/agent/toolActivation/toolActivationService.test.ts
@@ -1,3 +1,14 @@
+/**
+ * Scenario: Agent-tool contributions activate lazily under the bound Profile,
+ * while the progressive-disclosure gateway remains available unless the
+ * Profile explicitly denies it.
+ *
+ * Responsibility: verify activation through the observable runtime registry
+ * using the real activation and registry services with test-only tool
+ * contributions.
+ * Run: `pnpm --filter @moonshot-ai/agent-core-v2 exec vitest run
+ * test/agent/toolActivation/toolActivationService.test.ts`.
+ */
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 import { DisposableStore, toDisposable } from '#/_base/di/lifecycle';
@@ -20,6 +31,7 @@ import {
 } from '#/agent/toolRegistry/toolContribution';
 import { IAgentToolRegistryService } from '#/agent/toolRegistry/toolRegistry';
 import { AgentToolRegistryService } from '#/agent/toolRegistry/toolRegistryService';
+import { SELECT_TOOLS_TOOL_NAME } from '#/agent/toolSelect/toolSelect';
 import type { AgentTool, ToolExecution } from '#/tool/toolContract';
 
 class StubTool implements AgentTool {
@@ -35,6 +47,7 @@ class StubTool implements AgentTool {
 const IAlphaTool = createDecorator<AgentTool>('activationTestAlphaTool');
 const IBetaTool = createDecorator<AgentTool>('activationTestBetaTool');
 const IGammaTool = createDecorator<AgentTool>('activationTestGammaTool');
+const ISelectToolsTestTool = createDecorator<AgentTool>('activationTestSelectToolsTool');
 
 let alphaConstructions = 0;
 let betaConstructions = 0;
@@ -58,6 +71,12 @@ class GammaTool extends StubTool {
   constructor() {
     super('Gamma');
     gammaConstructions += 1;
+  }
+}
+
+class SelectToolsTestTool extends StubTool {
+  constructor() {
+    super(SELECT_TOOLS_TOOL_NAME);
   }
 }
 
@@ -85,6 +104,7 @@ describe('AgentToolActivationService', () => {
         reg.define(IAlphaTool, AlphaTool);
         reg.define(IBetaTool, BetaTool);
         reg.define(IGammaTool, GammaTool);
+        reg.define(ISelectToolsTestTool, SelectToolsTestTool);
       },
     });
   }
@@ -161,6 +181,33 @@ describe('AgentToolActivationService', () => {
     expect(registry.resolve('Alpha')).toBeInstanceOf(AlphaTool);
     expect(registry.resolve('Beta')).toBeUndefined();
     expect(betaConstructions).toBe(0);
+  });
+
+  it('implicitly activates select_tools when the profile allowlist omits it', async () => {
+    profileData.activeToolNames = ['Alpha'];
+    registerAgentToolService(ISelectToolsTestTool, SelectToolsTestTool, {
+      name: SELECT_TOOLS_TOOL_NAME,
+    });
+    const ix = createActivationHost();
+
+    await ix.get(IAgentToolActivationService).activate();
+
+    expect(ix.get(IAgentToolRegistryService).resolve(SELECT_TOOLS_TOOL_NAME)).toBeInstanceOf(
+      SelectToolsTestTool,
+    );
+  });
+
+  it('honors profile disallowedTools for the implicit select_tools activation', async () => {
+    profileData.activeToolNames = ['Alpha'];
+    profileData.disallowedTools = [SELECT_TOOLS_TOOL_NAME];
+    registerAgentToolService(ISelectToolsTestTool, SelectToolsTestTool, {
+      name: SELECT_TOOLS_TOOL_NAME,
+    });
+    const ix = createActivationHost();
+
+    await ix.get(IAgentToolActivationService).activate();
+
+    expect(ix.get(IAgentToolRegistryService).resolve(SELECT_TOOLS_TOOL_NAME)).toBeUndefined();
   });
 
   it('skips contributions whose when predicate fails', async () => {

--- a/packages/agent-core-v2/test/agent/toolSelect/toolSelect.e2e.test.ts
+++ b/packages/agent-core-v2/test/agent/toolSelect/toolSelect.e2e.test.ts
@@ -9,13 +9,12 @@
  * loads a schema into the next request, the top-level table never changes
  * across loads, the record carries the disclosure gate (v1 recorder parity,
  * F2), and a tail-slicing undo re-enables re-injection (F1). Wiring:
- * testAgent harness with scripted provider, real toolSelect / executor /
- * projector / announcer services; harness builds the Agent scope without
- * `AgentLifecycleService.create`, so the eager-instantiation production
- * would do (agentLifecycleService create) is forced here the same way.
- * The flag env is stubbed before `createTestAgent` snapshots it into
- * bootstrap, and module imports register the flag / tool contributions the
- * way `src/index.ts` does in production.
+ * testAgent harness with scripted provider and real toolSelect / executor /
+ * projector / announcer services. The gateway regression applies a Profile
+ * allowlist that omits `select_tools` before contribution activation,
+ * matching production lifecycle ordering. The flag env is stubbed before
+ * `createTestAgent` snapshots it into bootstrap, and module imports register
+ * the flag / tool contributions the way `src/index.ts` does in production.
  * Run: ../../node_modules/.bin/vitest run test/toolSelect/toolSelect.e2e.test.ts
  */
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
@@ -103,6 +102,43 @@ function historyText(history: readonly ContextMessage[]): string {
     .join('\n');
 }
 
+async function createDisclosureRig(initialActiveToolNames?: readonly string[]) {
+  const ctx = createTestAgent({ initialActiveToolNames });
+  ctx.get(IAgentToolSelectService);
+  ctx.get(IAgentToolSelectAnnouncementsService);
+  ctx.get(IAgentToolExecutorService);
+  ctx.configure({ modelCapabilities: DISCLOSURE_CAPABILITIES });
+  await ctx.rpc.setPermission({ mode: 'yolo' });
+  const alpha = new StubMcpTool(MCP_ALPHA);
+  const registration = ctx.get(IAgentToolRegistryService).register(alpha, { source: 'mcp' });
+  return { ctx, alpha, registration };
+}
+
+describe('profile-bound progressive disclosure gateway', () => {
+  let ctx: TestAgentContext | undefined;
+  let registration: { dispose(): void } | undefined;
+
+  beforeEach(() => {
+    vi.stubEnv(TOOL_SELECT_FLAG_ENV, '1');
+  });
+
+  afterEach(async () => {
+    registration?.dispose();
+    vi.unstubAllEnvs();
+    await ctx?.dispose();
+  });
+
+  it('exposes select_tools to the provider when the profile allowlist omits the gateway', async () => {
+    ({ ctx, registration } = await createDisclosureRig(['mcp__*']));
+    ctx.mockNextResponse({ type: 'text', text: 'done' });
+
+    await ctx.rpc.prompt({ input: [{ type: 'text', text: 'inspect available tools' }] });
+    await ctx.untilTurnEnd();
+
+    expect(toolNames(ctx.llmCalls[0]!.tools)).toContain('select_tools');
+  });
+});
+
 describe('progressive tool disclosure end-to-end', () => {
   let ctx: TestAgentContext;
   let alpha: StubMcpTool;
@@ -110,14 +146,7 @@ describe('progressive tool disclosure end-to-end', () => {
 
   beforeEach(async () => {
     vi.stubEnv(TOOL_SELECT_FLAG_ENV, '1');
-    ctx = createTestAgent();
-    ctx.get(IAgentToolSelectService);
-    ctx.get(IAgentToolSelectAnnouncementsService);
-    ctx.get(IAgentToolExecutorService);
-    ctx.configure({ modelCapabilities: DISCLOSURE_CAPABILITIES });
-    await ctx.rpc.setPermission({ mode: 'yolo' });
-    alpha = new StubMcpTool(MCP_ALPHA);
-    registration = ctx.get(IAgentToolRegistryService).register(alpha, { source: 'mcp' });
+    ({ ctx, alpha, registration } = await createDisclosureRig());
   });
 
   afterEach(async () => {
@@ -143,7 +172,6 @@ describe('progressive tool disclosure end-to-end', () => {
 
     const firstWire = ctx.llmCalls[0]!;
     expect(toolNames(firstWire.tools)).not.toContain(MCP_ALPHA);
-    expect(toolNames(firstWire.tools)).toContain('select_tools');
     const announcementText = firstWire.history
       .map((message) =>
         message.content.map((part) => (part.type === 'text' ? part.text : '')).join(''),

--- a/packages/agent-core-v2/test/harness/agent.ts
+++ b/packages/agent-core-v2/test/harness/agent.ts
@@ -381,7 +381,7 @@ export interface TestAgentOptions {
   | Pick<IExternalHooksRunnerService, 'trigger' | 'triggerBlock' | 'fireAndForgetTrigger'>
   | undefined;
   readonly initialConfig?: Partial<KimiConfig> | undefined;
-  readonly initialActiveToolNames?: readonly string[] | undefined;
+  readonly initialActiveToolNames?: readonly string[];
   readonly autoConfigure?: boolean | undefined;
   readonly cwd?: string | undefined;
   readonly [key: string]: unknown;

--- a/packages/agent-core-v2/test/harness/agent.ts
+++ b/packages/agent-core-v2/test/harness/agent.ts
@@ -381,6 +381,7 @@ export interface TestAgentOptions {
   | Pick<IExternalHooksRunnerService, 'trigger' | 'triggerBlock' | 'fireAndForgetTrigger'>
   | undefined;
   readonly initialConfig?: Partial<KimiConfig> | undefined;
+  readonly initialActiveToolNames?: readonly string[] | undefined;
   readonly autoConfigure?: boolean | undefined;
   readonly cwd?: string | undefined;
   readonly [key: string]: unknown;
@@ -1253,6 +1254,11 @@ export class AgentTestContext {
         workspace.setWorkDir(nextCwd);
       },
     });
+    if (options.initialActiveToolNames !== undefined) {
+      this.get(IAgentProfileService).update({
+        activeToolNames: options.initialActiveToolNames,
+      });
+    }
 
     this.initializeRestorableServices();
     // Resolve the activity view so its constructor subscriptions publish
@@ -1336,10 +1342,6 @@ export class AgentTestContext {
     const permissionRules = this.get(IAgentPermissionRulesService);
     const cron = this.get(ISessionCronService);
     const plan = this.get(IAgentPlanService);
-    // Activate the AgentTool contributions before any profile allowlist is
-    // applied by `configure()` — at this point `activeToolNames` is still
-    // undefined, so every contribution whose `when` holds lands in the
-    // registry, matching the harness's historical all-tools behavior.
     void this.get(IAgentToolActivationService).activate();
     this.get(IAgentToolDedupeService);
     this.get(IAgentExternalHooksService);


### PR DESCRIPTION
## Related Issue

Resolve #2381

## Problem

In the experimental v2 engine, a profile allowlist can omit `select_tools` while deferred MCP tools are still announced. Contribution activation applied that allowlist to the gateway before the request-time disclosure policy could apply its existing carve-out. As a result, the top-level agent could be told that deferred tools exist but receive no `select_tools` schema with which to load them.

## What changed

- Keep `select_tools` activatable when it is omitted from the profile allowlist, while continuing to honor an explicit profile `disallowedTools` entry.
- Preserve the existing request-time checks for model capability, the experimental flag, global policy, the session denylist, and provider visibility.
- Add unit coverage for both implicit gateway activation and the explicit-deny boundary.
- Add a provider-wire regression test that applies the profile allowlist before contribution activation, matching production lifecycle ordering.

## Validation

- `pnpm lint` (passes with 0 errors)
- `pnpm typecheck`
- `pnpm test` (1,015 test files and 16,701 tests passed)
- `pnpm --filter @moonshot-ai/agent-core-v2 lint:domain`
- `pnpm --filter @moonshot-ai/agent-core-v2 typecheck`
- `pnpm --filter @moonshot-ai/agent-core-v2 test`
- `pnpm --filter @moonshot-ai/agent-core-v2 build`
- `pnpm --filter @moonshot-ai/kimi-code typecheck`
- `pnpm --filter @moonshot-ai/kimi-code build`
- Regression mutation check: restoring the old activation predicate makes the provider-wire regression fail with an empty tool schema; the fixed predicate passes.

No changeset is needed because this behavior is limited to the experimental v2 engine. No documentation update is needed because no command, configuration, or usage contract changed.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.
