### PR TITLE
feat(hooks): expose effective permission mode

### DIFF
--- a/.changeset/expose-hook-permission-mode.md
+++ b/.changeset/expose-hook-permission-mode.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Expose the current effective permission mode to external hooks through the optional `permission_mode` payload field.

--- a/docs/en/customization/hooks.md
+++ b/docs/en/customization/hooks.md
@@ -62,9 +62,12 @@ Each time a hook triggers, the CLI passes the following base information to the 
 {
   "hook_event_name": "PreToolUse",
   "session_id": "session_abc",
-  "cwd": "/path/to/project"
+  "cwd": "/path/to/project",
+  "permission_mode": "manual"
 }
 ```
+
+The optional `permission_mode` field reports the current effective permission mode for the agent associated with the event. Its value is `manual`, `auto`, or `yolo`, and it reflects runtime mode changes rather than only the configured default. The field is omitted when the event has no live associated agent.
 
 Specific events will also include additional fields (such as tool name and command content); see the event reference below. All field names use snake_case.
 

--- a/docs/zh/customization/hooks.md
+++ b/docs/zh/customization/hooks.md
@@ -62,9 +62,12 @@ Hook 命令的工作目录是当前会话的项目目录。非 Windows 平台上
 {
   "hook_event_name": "PreToolUse",
   "session_id": "session_abc",
-  "cwd": "/path/to/project"
+  "cwd": "/path/to/project",
+  "permission_mode": "manual"
 }
 ```
+
+可选字段 `permission_mode` 表示与该事件关联的 Agent 当前实际生效的权限模式。其值为 `manual`、`auto` 或 `yolo`，并会反映运行时的模式切换，而不只是配置中的默认值。事件没有关联的存活 Agent 时，该字段会省略。
 
 具体事件还会附带额外字段（如工具名称、命令内容），见下方事件一览。所有字段名使用下划线命名（snake_case）。
 

--- a/packages/agent-core-v2/docs/state-manifest.d.ts
+++ b/packages/agent-core-v2/docs/state-manifest.d.ts
@@ -1013,7 +1013,7 @@ export interface AgentStateSnapshot {
   'llmRequester.lastConfigLogSignature': string | undefined;
   'llmRequester.mediaDegradedTurns': Set<number>;
   'llmRequester.mediaStrippedTurns': Map<number, /* MediaStripSnapshot — packages/agent-core-v2/src/agent/contextProjector/contextProjector.ts */ {
-    readonly "__@mediaStripSnapshotBrand@2681": undefined;
+    readonly "__@mediaStripSnapshotBrand@2682": undefined;
   }>;
   'llmRequester.turnConfigs': Map<number, /* TurnRequestConfig — packages/agent-core-v2/src/agent/llmRequester/llmRequesterService.ts */ {
     readonly resolved: /* ProfileModelContext — packages/agent-core-v2/src/agent/profile/profile.ts */ {

--- a/packages/agent-core-v2/src/agent/externalHooks/externalHooksService.ts
+++ b/packages/agent-core-v2/src/agent/externalHooks/externalHooksService.ts
@@ -12,8 +12,8 @@
  * the `agentLifecycle` run slots hosted on `IAgentLifecycleService`. Appends
  * UserPromptSubmit hook results through `contextMemory`, drives Stop hook
  * continuations by enqueueing a mergeable `StepRequest` onto `loop`, and
- * passes the current session id from `sessionContext`
- * into hook runner payloads. The one mutable latch
+ * passes the current session id from `sessionContext` and the effective mode
+ * from `permissionMode` into hook runner payloads. The one mutable latch
  * (`stopHookContinuationUsed`, the Stop-hook re-entry guard) is registered
  * into `agentState` (`IAgentStateService`) and read/written through it; the
  * hook listener registrations stay ordinary disposables on the instance.
@@ -27,6 +27,7 @@ import { isPlainRecord } from '#/_base/utils/canonical-args';
 import { IAgentStateService } from '#/agent/state/agentState';
 import { IAgentTaskService, type AgentTaskNotificationContext } from '#/agent/task/task';
 import { IAgentContextMemoryService } from '#/agent/contextMemory/contextMemory';
+import { IAgentPermissionModeService } from '#/agent/permissionMode/permissionMode';
 import { USER_PROMPT_ORIGIN } from '#/agent/contextMemory/types';
 import {
   IAgentFullCompactionService,
@@ -84,6 +85,8 @@ export class AgentExternalHooksService extends Disposable implements IAgentExter
     @IInstantiationService private readonly instantiation: IInstantiationService,
     @ISessionContext private readonly sessionContext: ISessionContext,
     @IAgentStateService private readonly states: IAgentStateService,
+    @IAgentPermissionModeService
+    private readonly permissionMode: IAgentPermissionModeService,
   ) {
     super();
     this.states.register(externalHooksStopHookContinuationUsedKey);
@@ -109,6 +112,7 @@ export class AgentExternalHooksService extends Disposable implements IAgentExter
         matcherValue,
         signal,
         sessionId: this.sessionContext.sessionId,
+        permissionMode: this.permissionMode.mode,
         inputData,
       });
     } catch {}
@@ -251,6 +255,7 @@ export class AgentExternalHooksService extends Disposable implements IAgentExter
       matcherValue: ctx.toolCall.name,
       signal: ctx.signal,
       sessionId: this.sessionContext.sessionId,
+      permissionMode: this.permissionMode.mode,
       inputData: {
         toolName: ctx.toolCall.name,
         toolInput,
@@ -290,6 +295,7 @@ export class AgentExternalHooksService extends Disposable implements IAgentExter
       matcherValue: input,
       signal,
       sessionId: this.sessionContext.sessionId,
+      permissionMode: this.permissionMode.mode,
       inputData: { prompt: input, isSteer: ctx.isSteer },
     });
     signal.throwIfAborted();
@@ -358,6 +364,7 @@ export class AgentExternalHooksService extends Disposable implements IAgentExter
     const block = await this.runner.triggerBlock('Stop', {
       signal: ctx.signal,
       sessionId: this.sessionContext.sessionId,
+      permissionMode: this.permissionMode.mode,
       inputData: { stopHookActive: false },
     });
     ctx.signal.throwIfAborted();
@@ -371,6 +378,7 @@ export class AgentExternalHooksService extends Disposable implements IAgentExter
       matcherValue: ctx.trigger,
       signal,
       sessionId: this.sessionContext.sessionId,
+      permissionMode: this.permissionMode.mode,
       inputData: {
         trigger: ctx.trigger,
         tokenCount: ctx.tokenCount,

--- a/packages/agent-core-v2/src/app/externalHooksRunner/externalHooksRunner.ts
+++ b/packages/agent-core-v2/src/app/externalHooksRunner/externalHooksRunner.ts
@@ -12,6 +12,7 @@
 
 import { createDecorator, type ServiceIdentifier } from '#/_base/di/instantiation';
 import type { HookBlockDecision, HookMatcherValue, HookResult } from '#/agent/externalHooks/types';
+import type { PermissionMode } from '#/agent/permissionPolicy/types';
 
 export interface ExternalHooksRunnerTriggerArgs {
   readonly matcherValue?: HookMatcherValue;
@@ -19,6 +20,7 @@ export interface ExternalHooksRunnerTriggerArgs {
   readonly signal?: AbortSignal;
   readonly cwd?: string;
   readonly sessionId?: string;
+  readonly permissionMode?: PermissionMode;
 }
 
 export interface IExternalHooksRunnerService {

--- a/packages/agent-core-v2/src/app/externalHooksRunner/runner.ts
+++ b/packages/agent-core-v2/src/app/externalHooksRunner/runner.ts
@@ -68,12 +68,19 @@ export async function runMatchedHooks(
     callbacks.onTriggered?.(event, matcherValue, matched.length);
   } catch {}
 
-  const inputData = toHookInputData({
+  const eventInputData = { ...args.inputData };
+  delete eventInputData['permissionMode'];
+  delete eventInputData['permission_mode'];
+  const rawInputData: Record<string, unknown> = {
     hookEventName: event,
     sessionId: args.sessionId ?? '',
     cwd,
-    ...args.inputData,
-  });
+    ...eventInputData,
+  };
+  if (args.permissionMode !== undefined) {
+    rawInputData['permissionMode'] = args.permissionMode;
+  }
+  const inputData = toHookInputData(rawInputData);
 
   const startedAt = Date.now();
   const results = await Promise.all(

--- a/packages/agent-core-v2/src/session/externalHooks/externalHooksService.ts
+++ b/packages/agent-core-v2/src/session/externalHooks/externalHooksService.ts
@@ -13,11 +13,16 @@
  * the Agent-scope adapter follows against the agent behavior services. The
  * actual hook execution is delegated to the shared App-scope
  * `IExternalHooksRunnerService`; all config/plugin loading and engine lifecycle
- * live in the runner. Bound at Session scope.
+ * live in the runner. For every translated event, this adapter resolves the
+ * current effective mode from the relevant Agent scope through
+ * `agentLifecycle` and `permissionMode`: main for session lifecycle events,
+ * requester for subagent events. Bound at Session scope.
  */
 
 import { Disposable } from '#/_base/di/lifecycle';
 import { LifecycleScope, ScopeActivation, registerScopedService } from '#/_base/di/scope';
+import { IAgentPermissionModeService } from '#/agent/permissionMode/permissionMode';
+import type { PermissionMode } from '#/agent/permissionPolicy/types';
 import { IExternalHooksRunnerService } from '#/app/externalHooksRunner/externalHooksRunner';
 import {
   ISessionLifecycleService,
@@ -25,6 +30,10 @@ import {
   type SessionCreateSource,
 } from '#/app/sessionLifecycle/sessionLifecycle';
 import { ISessionContext } from '#/session/sessionContext/sessionContext';
+import {
+  IAgentLifecycleService,
+  MAIN_AGENT_ID,
+} from '#/session/agentLifecycle/agentLifecycle';
 import {
   type AgentTaskStartHookContext,
   type AgentTaskStopHookContext,
@@ -44,6 +53,7 @@ export class SessionExternalHooksService
   constructor(
     @ISessionContext private readonly context: ISessionContext,
     @ISessionLifecycleService lifecycle: ISessionLifecycleService,
+    @IAgentLifecycleService private readonly agents: IAgentLifecycleService,
     @ISessionSubagentService subagents: ISessionSubagentService,
     @IExternalHooksRunnerService private readonly runner: IExternalHooksRunnerService,
   ) {
@@ -78,6 +88,7 @@ export class SessionExternalHooksService
       matcherValue: source,
       cwd: this.context.cwd,
       sessionId: this.context.sessionId,
+      permissionMode: this.permissionMode(MAIN_AGENT_ID),
       inputData: { source },
     });
   }
@@ -87,6 +98,7 @@ export class SessionExternalHooksService
       matcherValue: reason,
       cwd: this.context.cwd,
       sessionId: this.context.sessionId,
+      permissionMode: this.permissionMode(MAIN_AGENT_ID),
       inputData: { reason },
     });
   }
@@ -96,6 +108,7 @@ export class SessionExternalHooksService
     await this.runner.trigger('SubagentStart', {
       matcherValue: ctx.agentName,
       signal: ctx.signal,
+      permissionMode: this.permissionMode(ctx.requesterAgentId),
       inputData: {
         agentName: ctx.agentName,
         prompt: ctx.prompt,
@@ -107,11 +120,17 @@ export class SessionExternalHooksService
   private notifySubagentStop(ctx: AgentTaskStopHookContext): void {
     void this.runner.fireAndForgetTrigger('SubagentStop', {
       matcherValue: ctx.agentName,
+      permissionMode: this.permissionMode(ctx.requesterAgentId),
       inputData: {
         agentName: ctx.agentName,
         response: ctx.response,
       },
     });
+  }
+
+  private permissionMode(agentId: string | undefined): PermissionMode | undefined {
+    if (agentId === undefined) return undefined;
+    return this.agents.get(agentId)?.accessor.get(IAgentPermissionModeService).mode;
   }
 }
 

--- a/packages/agent-core-v2/src/session/subagent/mirrorAgentRun.ts
+++ b/packages/agent-core-v2/src/session/subagent/mirrorAgentRun.ts
@@ -22,14 +22,13 @@
  */
 
 import type { IAgentScopeHandle } from '#/_base/di/scope';
-import { userCancellationReason } from '#/_base/utils/abort';
+import { isAbortError, userCancellationReason } from '#/_base/utils/abort';
 import { IAgentContextSizeService } from '#/agent/contextSize/contextSize';
 import { IAgentProfileService } from '#/agent/profile/profile';
 import { isProviderRateLimitError } from '#/kosong/contract/errors';
 import { type TokenUsage } from '#/kosong/contract/usage';
 import { ITelemetryService } from '#/app/telemetry/telemetry';
 import { IEventBus } from '#/app/event/eventBus';
-import { isAbortError } from '#/_base/utils/abort';
 import { IAgentLifecycleService } from '#/session/agentLifecycle/agentLifecycle';
 
 import { type AgentRunHandle, ISessionSubagentService } from './subagent';
@@ -140,6 +139,7 @@ export async function mirrorAgentRun(
     };
     try {
       await subagents?.hooks.onWillStartAgentTask.run({
+        requesterAgentId: requester.id,
         agentName: options.profileName,
         prompt: options.prompt,
         signal: options.signal,
@@ -162,6 +162,7 @@ export async function mirrorAgentRun(
       contextTokens,
     });
     subagents?.notifyAgentTaskStopped({
+      requesterAgentId: requester.id,
       agentName: options.profileName,
       response: result.summary,
     });

--- a/packages/agent-core-v2/src/session/subagent/subagent.ts
+++ b/packages/agent-core-v2/src/session/subagent/subagent.ts
@@ -43,6 +43,7 @@ export interface AgentRunHandle {
 
 /** Facts announced when an agent run this session is hosting is about to start. */
 export interface AgentTaskStartHookContext {
+  readonly requesterAgentId?: string;
   readonly agentName: string;
   readonly prompt: string;
   readonly signal: AbortSignal;
@@ -50,6 +51,7 @@ export interface AgentTaskStartHookContext {
 
 /** Facts announced when an agent run this session is hosting has stopped. */
 export interface AgentTaskStopHookContext {
+  readonly requesterAgentId?: string;
   readonly agentName: string;
   readonly response: string;
 }

--- a/packages/agent-core-v2/test/app/externalHooksRunner/externalHooksRunner.test.ts
+++ b/packages/agent-core-v2/test/app/externalHooksRunner/externalHooksRunner.test.ts
@@ -1,3 +1,9 @@
+/**
+ * Scenario: configured external hook matching and process dispatch.
+ * Responsibilities: matcher selection, stdin payloads, process outcomes, and fail-open behavior.
+ * Wiring: real runner and host process service with config/plugin inputs stubbed.
+ * Run: pnpm --filter @moonshot-ai/agent-core-v2 exec vitest run test/app/externalHooksRunner/externalHooksRunner.test.ts
+ */
 import { realpathSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 
@@ -140,6 +146,51 @@ describe('ExternalHooksRunnerService', () => {
 
     const results = await runner.trigger('SessionStart', { sessionId: 'ses_123' });
     expect(results[0]?.stdout?.trim()).toBe('SessionStart ses_123 /tmp');
+  });
+
+  it('serializes the trigger permission mode as permission_mode', async () => {
+    const runner = makeHookRunner([
+      {
+        event: 'PreToolUse',
+        command: nodeCommand([
+          'let input = "";',
+          'process.stdin.on("data", (chunk) => { input += chunk; });',
+          'process.stdin.on("end", () => {',
+          '  process.stdout.write(String(JSON.parse(input).permission_mode));',
+          '});',
+        ].join('\n')),
+        timeout: 5,
+      },
+    ]);
+
+    const results = await runner.trigger('PreToolUse', {
+      permissionMode: 'auto',
+      inputData: { permissionMode: 'manual', permission_mode: 'yolo' },
+    });
+
+    expect(results[0]?.stdout).toBe('auto');
+  });
+
+  it('omits permission_mode when no effective permission mode is available', async () => {
+    const runner = makeHookRunner([
+      {
+        event: 'SessionStart',
+        command: nodeCommand([
+          'let input = "";',
+          'process.stdin.on("data", (chunk) => { input += chunk; });',
+          'process.stdin.on("end", () => {',
+          '  process.stdout.write(String(Object.hasOwn(JSON.parse(input), "permission_mode")));',
+          '});',
+        ].join('\n')),
+        timeout: 5,
+      },
+    ]);
+
+    const results = await runner.trigger('SessionStart', {
+      inputData: { permissionMode: 'spoofed', permission_mode: 'spoofed' },
+    });
+
+    expect(results[0]?.stdout).toBe('false');
   });
 
   it('runs hooks with per-hook cwd and env overrides', async () => {

--- a/packages/agent-core-v2/test/app/externalHooksRunner/integration.test.ts
+++ b/packages/agent-core-v2/test/app/externalHooksRunner/integration.test.ts
@@ -1,3 +1,9 @@
+/**
+ * Scenario: external hook adapters and configured hook commands across App, Session, and Agent scopes.
+ * Responsibilities: event translation, runtime payload context, blocking, lifecycle, and config round-trips.
+ * Wiring: real scoped adapters/runner with process, config, plugin, and behavior-domain boundaries stubbed.
+ * Run: pnpm --filter @moonshot-ai/agent-core-v2 exec vitest run test/app/externalHooksRunner/integration.test.ts
+ */
 import { existsSync, mkdtempSync, readFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -5,8 +11,13 @@ import { join } from 'node:path';
 import { describe, expect, it } from 'vitest';
 
 import { SyncDescriptor } from '#/_base/di/descriptors';
+import type { ServiceIdentifier } from '#/_base/di/instantiation';
 import { Disposable, DisposableStore } from '#/_base/di/lifecycle';
-import type { ISessionScopeHandle } from '#/_base/di/scope';
+import {
+  type IAgentScopeHandle,
+  type ISessionScopeHandle,
+  LifecycleScope,
+} from '#/_base/di/scope';
 import {
   createServices,
   type TestInstantiationService,
@@ -32,6 +43,8 @@ import { AgentExternalHooksService } from '#/agent/externalHooks/externalHooksSe
 import { IAgentFullCompactionService } from '#/agent/fullCompaction/fullCompaction';
 import { IAgentLoopService, type AfterStepContext } from '#/agent/loop/loop';
 import { IAgentPermissionGate } from '#/agent/permissionGate/permissionGate';
+import { IAgentPermissionModeService } from '#/agent/permissionMode/permissionMode';
+import type { PermissionMode } from '#/agent/permissionPolicy/types';
 import { IAgentPromptService } from '#/agent/prompt/prompt';
 import { IAgentTaskService } from '#/agent/task/task';
 import { IAgentToolExecutorService } from '#/agent/toolExecutor/toolExecutor';
@@ -51,6 +64,7 @@ import {
 } from '#/app/sessionLifecycle/sessionLifecycle';
 import { createHooks } from '#/hooks';
 import { ISessionContext } from '#/session/sessionContext/sessionContext';
+import { IAgentLifecycleService } from '#/session/agentLifecycle/agentLifecycle';
 import {
   type AgentTaskHooks,
   type AgentTaskStopHookContext,
@@ -63,6 +77,7 @@ import { stubBootstrap } from '../bootstrap/stubs';
 import { stubLoopWithHooks, stubToolExecutor } from '../../agent/loop/stubs';
 import { registerStateServices } from '../../state/stubs';
 import { registerTestAgentWireServices } from '../../wire/stubs';
+import { stubPermissionModeService } from '../../agent/permissionMode/stubs';
 
 function nodeCommand(source: string): string {
   return `node -e ${JSON.stringify(source.replaceAll(/\s*\n\s*/g, ' '))}`;
@@ -153,6 +168,7 @@ function appendHookLogCommand(path: string): string {
     '    reason: parsed.reason,',
     '    sessionId: parsed.session_id,',
     '    cwd: parsed.cwd,',
+    '    permissionMode: parsed.permission_mode,',
     '  }) + "\\n",',
     ');',
   ].join('\n'));
@@ -179,6 +195,26 @@ function stubSessionContext(): ISessionContext {
       subKey === undefined || subKey === ''
         ? 'sessions/workspace-1/session-1'
         : `sessions/workspace-1/session-1/${subKey}`,
+  };
+}
+
+function agentHandleWithPermissionMode(
+  agentId: string,
+  mode: () => PermissionMode,
+): IAgentScopeHandle {
+  const permissionMode = stubPermissionModeService(mode);
+  return {
+    id: agentId,
+    kind: LifecycleScope.Agent,
+    accessor: {
+      get: <T>(id: ServiceIdentifier<T>): T => {
+        if (id !== IAgentPermissionModeService) {
+          throw new Error(`Unexpected Agent service: ${String(id)}`);
+        }
+        return permissionMode as unknown as T;
+      },
+    },
+    dispose: () => {},
   };
 }
 
@@ -293,6 +329,10 @@ describe('IExternalHooksRunnerService integration', () => {
           });
           reg.defineInstance(IAgentToolExecutorService, stubToolExecutor());
           reg.definePartialInstance(IAgentPermissionGate, {});
+          reg.defineInstance(
+            IAgentPermissionModeService,
+            stubPermissionModeService(() => 'manual'),
+          );
           reg.definePartialInstance(IAgentFullCompactionService, {
             hooks: createHooks(['onWillCompact']),
           });
@@ -364,18 +404,24 @@ describe('IExternalHooksRunnerService integration', () => {
         event: string;
         matcherValue?: unknown;
         inputData?: unknown;
+        permissionMode?: unknown;
       }> = [];
       const hookEngine = {
         trigger: async () => [],
         triggerBlock: async () => undefined,
         fireAndForgetTrigger: async (
           event: string,
-          args: { matcherValue?: unknown; inputData?: unknown },
+          args: {
+            matcherValue?: unknown;
+            inputData?: unknown;
+            permissionMode?: unknown;
+          },
         ) => {
           fired.push({
             event,
             matcherValue: args.matcherValue,
             inputData: args.inputData,
+            permissionMode: args.permissionMode,
           });
         },
       };
@@ -397,6 +443,10 @@ describe('IExternalHooksRunnerService integration', () => {
           });
           reg.defineInstance(IAgentToolExecutorService, stubToolExecutor());
           reg.definePartialInstance(IAgentPermissionGate, {});
+          reg.defineInstance(
+            IAgentPermissionModeService,
+            stubPermissionModeService(() => 'manual'),
+          );
           reg.definePartialInstance(IAgentFullCompactionService, {
             hooks: createHooks(['onWillCompact']),
           });
@@ -435,6 +485,7 @@ describe('IExternalHooksRunnerService integration', () => {
           event: 'PermissionRequest',
           matcherValue: 'Bash',
           inputData: requestContext,
+          permissionMode: 'manual',
         },
         {
           event: 'PermissionResult',
@@ -444,6 +495,7 @@ describe('IExternalHooksRunnerService integration', () => {
             decision: 'approved',
             selectedLabel: 'Approve once',
           },
+          permissionMode: 'manual',
         },
       ]);
     } finally {
@@ -460,35 +512,49 @@ describe('IExternalHooksRunnerService integration', () => {
         event: string;
         matcherValue?: unknown;
         inputData?: unknown;
+        permissionMode?: unknown;
       }> = [];
       const triggered: Array<{
         event: string;
         matcherValue?: unknown;
         inputData?: unknown;
         signal?: unknown;
+        permissionMode?: unknown;
       }> = [];
+      const mainAgent = agentHandleWithPermissionMode('main', () => 'auto');
       const hookEngine = {
         trigger: async (
           event: string,
-          args: { matcherValue?: unknown; inputData?: unknown; signal?: unknown },
+          args: {
+            matcherValue?: unknown;
+            inputData?: unknown;
+            signal?: unknown;
+            permissionMode?: unknown;
+          },
         ) => {
           triggered.push({
             event,
             matcherValue: args.matcherValue,
             inputData: args.inputData,
             signal: args.signal,
+            permissionMode: args.permissionMode,
           });
           return [];
         },
         triggerBlock: async () => undefined,
         fireAndForgetTrigger: async (
           event: string,
-          args: { matcherValue?: unknown; inputData?: unknown },
+          args: {
+            matcherValue?: unknown;
+            inputData?: unknown;
+            permissionMode?: unknown;
+          },
         ) => {
           fired.push({
             event,
             matcherValue: args.matcherValue,
             inputData: args.inputData,
+            permissionMode: args.permissionMode,
           });
           return [];
         },
@@ -513,6 +579,9 @@ describe('IExternalHooksRunnerService integration', () => {
                 : `sessions/workspace-1/session-1/${subKey}`,
           });
           reg.defineInstance(ISessionLifecycleService, stubSessionLifecycle());
+          reg.definePartialInstance(IAgentLifecycleService, {
+            get: (agentId) => (agentId === 'main' ? mainAgent : undefined),
+          });
           reg.definePartialInstance(ISessionSubagentService, {
             hooks: createHooks<AgentTaskHooks, keyof AgentTaskHooks>(['onWillStartAgentTask']),
             onDidStopAgentTask: stopAgentTask.event,
@@ -526,11 +595,13 @@ describe('IExternalHooksRunnerService integration', () => {
       const subagents = ix.get(ISessionSubagentService);
 
       await subagents.hooks.onWillStartAgentTask.run({
+        requesterAgentId: 'main',
         agentName: 'coder',
         prompt: 'Fix the bug',
         signal: new AbortController().signal,
       });
       stopAgentTask.fire({
+        requesterAgentId: 'main',
         agentName: 'coder',
         response: 'Bug fixed',
       });
@@ -541,6 +612,7 @@ describe('IExternalHooksRunnerService integration', () => {
           matcherValue: 'coder',
           inputData: { agentName: 'coder', prompt: 'Fix the bug' },
           signal: expect.any(AbortSignal),
+          permissionMode: 'auto',
         },
       ]);
 
@@ -551,6 +623,7 @@ describe('IExternalHooksRunnerService integration', () => {
           event: 'SubagentStop',
           matcherValue: 'coder',
           inputData: { agentName: 'coder', response: 'Bug fixed' },
+          permissionMode: 'auto',
         },
       ]);
     } finally {
@@ -601,6 +674,10 @@ describe('IExternalHooksRunnerService integration', () => {
           });
           reg.defineInstance(IAgentToolExecutorService, stubToolExecutor());
           reg.definePartialInstance(IAgentPermissionGate, {});
+          reg.defineInstance(
+            IAgentPermissionModeService,
+            stubPermissionModeService(() => 'manual'),
+          );
           reg.definePartialInstance(IAgentFullCompactionService, {
             hooks: createHooks(['onWillCompact']),
           });
@@ -830,6 +907,8 @@ describe('IExternalHooksRunnerService integration', () => {
       const command = appendHookLogCommand(path);
       const cwd = mkdtempSync(join(tmpdir(), 'session-external-hooks-cwd-'));
       const handle = {} as ISessionScopeHandle;
+      let permissionMode: PermissionMode = 'manual';
+      const mainAgent = agentHandleWithPermissionMode('main', () => permissionMode);
 
       ix = createServices(disposables, {
         strict: true,
@@ -848,6 +927,9 @@ describe('IExternalHooksRunnerService integration', () => {
                 : `sessions/workspace-1/session-1/${subKey}`,
           });
           reg.defineInstance(ISessionLifecycleService, lifecycle);
+          reg.definePartialInstance(IAgentLifecycleService, {
+            get: (agentId) => (agentId === 'main' ? mainAgent : undefined),
+          });
           reg.definePartialInstance(ISessionSubagentService, {
             hooks: createHooks<AgentTaskHooks, keyof AgentTaskHooks>(['onWillStartAgentTask']),
             onDidStopAgentTask: Event.None as Event<AgentTaskStopHookContext>,
@@ -894,6 +976,7 @@ describe('IExternalHooksRunnerService integration', () => {
         handle,
         source: 'startup',
       });
+      permissionMode = 'yolo';
       await lifecycle.hooks.onWillCloseSession.run({
         sessionId: 'session-1',
         handle,
@@ -906,18 +989,21 @@ describe('IExternalHooksRunnerService integration', () => {
           source: 'startup',
           sessionId: 'session-1',
           cwd,
+          permissionMode: 'manual',
         },
         {
           event: 'SessionStart',
           source: 'resume',
           sessionId: 'session-1',
           cwd,
+          permissionMode: 'manual',
         },
         {
           event: 'SessionEnd',
           reason: 'exit',
           sessionId: 'session-1',
           cwd,
+          permissionMode: 'yolo',
         },
       ]);
     } finally {

--- a/packages/agent-core-v2/test/tool/tool.test.ts
+++ b/packages/agent-core-v2/test/tool/tool.test.ts
@@ -1,3 +1,9 @@
+/**
+ * Scenario: Agent tool contracts and end-to-end tool execution behavior.
+ * Responsibilities: tool visibility, policy, execution, external hooks, and observable results.
+ * Wiring: real scoped Agent services with only model, process, and cross-agent boundaries stubbed.
+ * Run: pnpm --filter @moonshot-ai/agent-core-v2 exec vitest run test/tool/tool.test.ts
+ */
 import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -1147,6 +1153,7 @@ describe('Agent tool execution contract', () => {
 
   it('mirrors v1-compatible subagent lifecycle event fields', async () => {
     const lifecycle = createAgentLifecycleStub();
+    const startHook = vi.spyOn(lifecycle.hooks.onWillStartAgentTask, 'run');
     const events: DomainEvent[] = [];
     const eventBus = {
       _serviceBrand: undefined,
@@ -1177,6 +1184,7 @@ describe('Agent tool execution contract', () => {
         get: ((serviceId: unknown) => {
           if (serviceId === IEventBus) return eventBus;
           if (serviceId === IAgentLifecycleService) return lifecycle;
+          if (serviceId === ISessionSubagentService) return lifecycle;
           if (serviceId === ITelemetryService) {
             return {
               ...noopTelemetryService,
@@ -1228,6 +1236,18 @@ describe('Agent tool execution contract', () => {
       subagentId: 'agent-child',
       resultSummary: 'child result',
       contextTokens: 321,
+    });
+    expect(startHook).toHaveBeenCalledWith(
+      expect.objectContaining({
+        requesterAgentId: 'main',
+        agentName: 'explore',
+        prompt: 'Investigate',
+      }),
+    );
+    expect(lifecycle.notifyAgentTaskStopped).toHaveBeenCalledWith({
+      requesterAgentId: 'main',
+      agentName: 'explore',
+      response: 'child result',
     });
   });
 
@@ -2747,6 +2767,45 @@ describe('Agent tools', () => {
     });
   });
 
+  describe('runtime permission mode hook payload', () => {
+    let resolved: Array<[string, string, string]>;
+
+    beforeEach(async () => {
+      resolved = [];
+      const hookEngine = makeHookRunner(
+        [
+          {
+            event: 'PreToolUse',
+            matcher: 'Bash',
+            command: hookPermissionModeAssertCommand('yolo'),
+          },
+        ],
+        {
+          onResolved: (event, target, action) => {
+            resolved.push([event, target, action]);
+          },
+        },
+      );
+      ctx = createTestAgent(
+        execEnvServices({ processRunner: createCommandRunner('hook-output') }),
+        externalHookServices(hookEngine),
+      );
+      profile = ctx.get(IAgentProfileService);
+      profile.update({ activeToolNames: ['Bash'] });
+      await ctx.rpc.setPermission({ mode: 'yolo' });
+    });
+
+    it('passes the current runtime permission mode to PreToolUse hooks', async () => {
+      ctx.mockNextResponse({ type: 'text', text: 'I will run Bash.' }, bashCall());
+      ctx.mockNextResponse({ type: 'text', text: 'Bash returned hook-output.' });
+      await ctx.rpc.prompt({ input: [{ type: 'text', text: 'Run Bash' }] });
+
+      await ctx.untilTurnEnd();
+
+      expect(resolved).toEqual([['PreToolUse', 'Bash', 'allow']]);
+    });
+  });
+
   describe('failed Bash hook flow', () => {
     let resolved: Array<[string, string, string]>;
 
@@ -3245,6 +3304,20 @@ function hookErrorMessageAssertCommand(expected: string): string {
     '  const payload = JSON.parse(input);',
     `  if (payload.error?.message === ${JSON.stringify(expected)}) process.exit(0);`,
     "  console.error(payload.error?.message ?? '<missing>');",
+    '  process.exit(2);',
+    '});',
+  ].join('');
+  return `node -e ${JSON.stringify(script)}`;
+}
+
+function hookPermissionModeAssertCommand(expected: string): string {
+  const script = [
+    "let input = '';",
+    "process.stdin.on('data', (chunk) => { input += chunk; });",
+    "process.stdin.on('end', () => {",
+    '  const payload = JSON.parse(input);',
+    `  if (payload.permission_mode === ${JSON.stringify(expected)}) process.exit(0);`,
+    "  console.error(payload.permission_mode ?? '<missing>');",
     '  process.exit(2);',
     '});',
   ].join('');

--- a/packages/agent-core/src/agent/index.ts
+++ b/packages/agent-core/src/agent/index.ts
@@ -204,7 +204,6 @@ export class Agent {
     this.modelProvider = options.modelProvider;
     this.subagentHost = options.subagentHost;
     this.mcp = options.mcp;
-    this.hooks = options.hookEngine;
     this.log = options.log ?? log;
     this.telemetry = options.telemetry ?? noopTelemetryClient;
     this.experimentalFlags = options.experimentalFlags ?? new FlagResolver();
@@ -236,6 +235,10 @@ export class Agent {
     this.turn = new TurnFlow(this);
     this.injection = new InjectionManager(this);
     this.permission = new PermissionManager(this, options.permission);
+    this.hooks =
+      typeof options.hookEngine?.withPermissionMode === 'function'
+        ? options.hookEngine.withPermissionMode(() => this.permission.mode)
+        : options.hookEngine;
     this.planMode = new PlanMode(this);
     this.swarmMode = new SwarmMode(this);
     this.usage = new UsageRecorder(this);

--- a/packages/agent-core/src/session/hooks/engine.ts
+++ b/packages/agent-core/src/session/hooks/engine.ts
@@ -7,6 +7,7 @@ import type {
   HookMatcherValue,
   HookResult,
 } from './types';
+import type { PermissionMode } from '../../agent/permission';
 
 const DEFAULT_HOOK_TIMEOUT_SECONDS = 30;
 
@@ -31,6 +32,10 @@ export class HookEngine {
       result[event] = hooks.length;
     }
     return result;
+  }
+
+  withPermissionMode(getPermissionMode: () => PermissionMode): HookEngine {
+    return new PermissionModeHookEngine(this, getPermissionMode);
   }
 
   trigger(event: string, args: HookEngineTriggerArgs = {}): Promise<HookResult[]> {
@@ -70,12 +75,19 @@ export class HookEngine {
     args: HookEngineTriggerArgs,
   ): Promise<HookResult[]> {
     const matcherValue = matcherValueText(args.matcherValue);
-    const inputData = toHookInputData({
+    const eventInputData = { ...args.inputData };
+    delete eventInputData['permissionMode'];
+    delete eventInputData['permission_mode'];
+    const rawInputData: Record<string, unknown> = {
       hookEventName: event,
       sessionId: this.options.sessionId ?? '',
       cwd: this.options.cwd ?? '',
-      ...args.inputData,
-    });
+      ...eventInputData,
+    };
+    if (args.permissionMode !== undefined) {
+      rawInputData['permissionMode'] = args.permissionMode;
+    }
+    const inputData = toHookInputData(rawInputData);
     const matched = this.matchingHooks(event, matcherValue);
     if (matched.length === 0) return [];
 
@@ -127,6 +139,45 @@ export class HookEngine {
     try {
       this.options.onResolved?.(event, target, action, reason, durationMs);
     } catch {}
+  }
+}
+
+class PermissionModeHookEngine extends HookEngine {
+  constructor(
+    private readonly engine: HookEngine,
+    private readonly getPermissionMode: () => PermissionMode,
+  ) {
+    super();
+  }
+
+  override get summary(): Record<string, number> {
+    return this.engine.summary;
+  }
+
+  override trigger(event: string, args: HookEngineTriggerArgs = {}): Promise<HookResult[]> {
+    return this.engine.trigger(event, this.withContext(args));
+  }
+
+  override triggerBlock(
+    event: string,
+    args: HookEngineTriggerArgs = {},
+  ): Promise<HookBlockDecision | undefined> {
+    return this.engine.triggerBlock(event, this.withContext(args));
+  }
+
+  override fireAndForgetTrigger(
+    event: string,
+    args: HookEngineTriggerArgs = {},
+  ): Promise<HookResult[]> {
+    return this.engine.fireAndForgetTrigger(event, this.withContext(args));
+  }
+
+  private withContext(args: HookEngineTriggerArgs): HookEngineTriggerArgs {
+    try {
+      return { ...args, permissionMode: this.getPermissionMode() };
+    } catch {
+      return { ...args, permissionMode: undefined };
+    }
   }
 }
 

--- a/packages/agent-core/src/session/hooks/types.ts
+++ b/packages/agent-core/src/session/hooks/types.ts
@@ -1,4 +1,5 @@
 import type { ContentPart } from '@moonshot-ai/kosong';
+import type { PermissionMode } from '../../agent/permission';
 
 export const HOOK_EVENT_TYPES = [
   'PreToolUse',
@@ -52,6 +53,7 @@ export interface HookEngineTriggerArgs {
   readonly matcherValue?: HookMatcherValue;
   readonly inputData?: Record<string, unknown>;
   readonly signal?: AbortSignal;
+  readonly permissionMode?: PermissionMode;
 }
 
 export type HookTriggeredCallback = (event: string, target: string, count: number) => void;

--- a/packages/agent-core/src/session/index.ts
+++ b/packages/agent-core/src/session/index.ts
@@ -1354,6 +1354,7 @@ export class Session {
     await this.hookEngine.trigger('SessionStart', {
       matcherValue: source,
       inputData: { source },
+      permissionMode: this.getReadyAgent('main')?.permission.mode,
     });
   }
 
@@ -1361,6 +1362,7 @@ export class Session {
     await this.hookEngine.trigger('SessionEnd', {
       matcherValue: reason,
       inputData: { reason },
+      permissionMode: this.getReadyAgent('main')?.permission.mode,
     });
   }
 }

--- a/packages/agent-core/test/agent/tool.test.ts
+++ b/packages/agent-core/test/agent/tool.test.ts
@@ -98,6 +98,31 @@ describe('Agent tools', () => {
     expect(triggered).toEqual([['PostToolUse', 'Bash', 1]]);
   });
 
+  it('passes the current runtime permission mode to PreToolUse hooks', async () => {
+    const execWithEnv = vi.fn().mockRejectedValue(new Error('Bash boundary reached'));
+    const hookEngine = new HookEngine([
+      {
+        event: 'PreToolUse',
+        matcher: 'Bash',
+        command: hookPermissionModeAssertCommand('yolo'),
+      },
+    ]);
+    const ctx = testAgent({
+      kaos: createFakeKaos({ execWithEnv }),
+      hookEngine,
+    });
+    ctx.configure({ tools: ['Bash'] });
+    await ctx.rpc.setPermission({ mode: 'yolo' });
+
+    ctx.mockNextResponse({ type: 'text', text: 'I will run Bash.' }, bashCall());
+    ctx.mockNextResponse({ type: 'text', text: 'The Bash boundary failed.' });
+    await ctx.rpc.prompt({ input: [{ type: 'text', text: 'Run Bash' }] });
+
+    await ctx.untilTurnEnd();
+
+    expect(execWithEnv).toHaveBeenCalledOnce();
+  });
+
   it('uses builtin descriptions on tool call start events', async () => {
     const ctx = testAgent({
       kaos: createCommandKaos('ok'),
@@ -706,6 +731,20 @@ function hookErrorMessageAssertCommand(expected: string): string {
     '  const payload = JSON.parse(input);',
     `  if (payload.error?.message === ${JSON.stringify(expected)}) process.exit(0);`,
     "  console.error(payload.error?.message ?? '<missing>');",
+    '  process.exit(2);',
+    '});',
+  ].join('');
+  return `node -e ${JSON.stringify(script)}`;
+}
+
+function hookPermissionModeAssertCommand(expected: string): string {
+  const script = [
+    "let input = '';",
+    "process.stdin.on('data', (chunk) => { input += chunk; });",
+    "process.stdin.on('end', () => {",
+    '  const payload = JSON.parse(input);',
+    `  if (payload.permission_mode === ${JSON.stringify(expected)}) process.exit(0);`,
+    "  console.error(payload.permission_mode ?? '<missing>');",
     '  process.exit(2);',
     '});',
   ].join('');

--- a/packages/agent-core/test/hooks/engine.test.ts
+++ b/packages/agent-core/test/hooks/engine.test.ts
@@ -3,6 +3,7 @@ import { tmpdir } from 'node:os';
 
 import { describe, expect, it, vi } from 'vitest';
 import type { ContentPart } from '@moonshot-ai/kosong';
+import type { PermissionMode } from '../../src/agent/permission';
 
 // Dynamic-import contract: locks the public shape of the future HookEngine
 // without forcing TS module resolution to find a file that doesn't exist yet.
@@ -32,6 +33,38 @@ interface HookBlockDecision {
 
 type HookMatcherValue = string | readonly ContentPart[];
 
+interface HookEngineInstance {
+  trigger: (
+    event: string,
+    args?: {
+      matcherValue?: HookMatcherValue;
+      inputData?: Record<string, unknown>;
+      signal?: AbortSignal;
+      permissionMode?: PermissionMode;
+    },
+  ) => Promise<HookResult[]>;
+  triggerBlock: (
+    event: string,
+    args?: {
+      matcherValue?: HookMatcherValue;
+      inputData?: Record<string, unknown>;
+      signal?: AbortSignal;
+      permissionMode?: PermissionMode;
+    },
+  ) => Promise<HookBlockDecision | undefined>;
+  fireAndForgetTrigger: (
+    event: string,
+    args?: {
+      matcherValue?: HookMatcherValue;
+      inputData?: Record<string, unknown>;
+      signal?: AbortSignal;
+      permissionMode?: PermissionMode;
+    },
+  ) => Promise<HookResult[]>;
+  withPermissionMode(getPermissionMode: () => PermissionMode): HookEngineInstance;
+  summary: Record<string, number>;
+}
+
 interface HookEngineCtor {
   new (
     hooks: HookDef[],
@@ -47,33 +80,7 @@ interface HookEngineCtor {
         durationMs: number,
       ) => void;
     },
-  ): {
-    trigger: (
-      event: string,
-      args?: {
-        matcherValue?: HookMatcherValue;
-        inputData?: Record<string, unknown>;
-        signal?: AbortSignal;
-      },
-    ) => Promise<HookResult[]>;
-    triggerBlock: (
-      event: string,
-      args?: {
-        matcherValue?: HookMatcherValue;
-        inputData?: Record<string, unknown>;
-        signal?: AbortSignal;
-      },
-    ) => Promise<HookBlockDecision | undefined>;
-    fireAndForgetTrigger: (
-      event: string,
-      args?: {
-        matcherValue?: HookMatcherValue;
-        inputData?: Record<string, unknown>;
-        signal?: AbortSignal;
-      },
-    ) => Promise<HookResult[]>;
-    summary: Record<string, number>;
-  };
+  ): HookEngineInstance;
 }
 
 interface EngineModule {
@@ -227,6 +234,64 @@ describe('HookEngine', () => {
     const results = await engine.trigger('SessionStart');
 
     expect(results[0]?.stdout?.trim()).toBe('SessionStart ses_123 /tmp');
+  });
+
+  it('serializes the trigger permission mode as permission_mode', async () => {
+    const { HookEngine } = await importEngine();
+    const engine = new HookEngine([
+      {
+        event: 'PreToolUse',
+        command:
+          'node -e "let s=\\"\\";process.stdin.on(\\"data\\",d=>s+=d);process.stdin.on(\\"end\\",()=>process.stdout.write(JSON.parse(s).permission_mode));"',
+        timeout: 5,
+      },
+    ]);
+
+    const results = await engine.trigger('PreToolUse', {
+      permissionMode: 'auto',
+      inputData: { permissionMode: 'manual', permission_mode: 'yolo' },
+    });
+
+    expect(results[0]?.stdout).toBe('auto');
+  });
+
+  it('omits permission_mode when no effective permission mode is available', async () => {
+    const { HookEngine } = await importEngine();
+    const engine = new HookEngine([
+      {
+        event: 'SessionStart',
+        command:
+          'node -e "let s=\\"\\";process.stdin.on(\\"data\\",d=>s+=d);process.stdin.on(\\"end\\",()=>process.stdout.write(String(Object.hasOwn(JSON.parse(s),\\"permission_mode\\"))));"',
+        timeout: 5,
+      },
+    ]);
+
+    const results = await engine.trigger('SessionStart', {
+      inputData: { permissionMode: 'spoofed', permission_mode: 'spoofed' },
+    });
+
+    expect(results[0]?.stdout).toBe('false');
+  });
+
+  it('omits permission_mode when the effective mode cannot be read', async () => {
+    const { HookEngine } = await importEngine();
+    const engine = new HookEngine([
+      {
+        event: 'SessionStart',
+        command:
+          'node -e "let s=\\"\\";process.stdin.on(\\"data\\",d=>s+=d);process.stdin.on(\\"end\\",()=>process.stdout.write(String(Object.hasOwn(JSON.parse(s),\\"permission_mode\\"))));"',
+        timeout: 5,
+      },
+    ]).withPermissionMode(() => {
+      throw new Error('permission mode unavailable');
+    });
+
+    const results = await engine.trigger('SessionStart', {
+      permissionMode: 'auto',
+      inputData: { permissionMode: 'manual', permission_mode: 'yolo' },
+    });
+
+    expect(results[0]?.stdout).toBe('false');
   });
 
   it('treats an empty matcher string as a catch-all for any matcher value', async () => {

--- a/packages/agent-core/test/session/lifecycle-hooks.test.ts
+++ b/packages/agent-core/test/session/lifecycle-hooks.test.ts
@@ -39,7 +39,8 @@ describe('Session lifecycle hooks', () => {
       ],
     });
 
-    await session.createMain();
+    const main = await session.createMain();
+    main.permission.setMode('yolo');
     await session.close();
 
     expect(await readHookPayloads(logPath)).toMatchObject([
@@ -48,12 +49,14 @@ describe('Session lifecycle hooks', () => {
         session_id: 'session-123',
         cwd: workDir,
         source: 'startup',
+        permission_mode: 'manual',
       },
       {
         hook_event_name: 'SessionEnd',
         session_id: 'session-123',
         cwd: workDir,
         reason: 'exit',
+        permission_mode: 'yolo',
       },
     ]);
   });


### PR DESCRIPTION
## Related Issue

Resolve #2122

## Problem

External hooks could inspect the configured command and event data, but could not determine the permission mode actually in force for the associated agent. This made policy-sensitive integrations unable to distinguish `manual`, `auto`, and `yolo`, especially after a runtime mode change.

## What changed

- Add the optional `permission_mode` field to external hook payloads in both agent engines.
- Resolve the value at trigger time from the event's live agent: the current agent for agent events, the main agent for session lifecycle events, and the requester for subagent lifecycle events.
- Omit the field when no live associated agent is available.
- Prevent event-specific input data from overriding or spoofing the authoritative permission mode.
- Document the field and its runtime semantics in both English and Chinese.

## Validation

- Controlled production-CLI before/after E2E using isolated
  `KIMI_CODE_HOME` directories, a real `config.toml` `[[hooks]]` command,
  the built `dist/main.mjs`, a real hook child process reading stdin JSON,
  and a local model-protocol stub:
  - upstream `691ec4679ea19d6be8ac18f359088384ed3e446d`: successful prompt,
    but both `SessionStart` and `SessionEnd` payloads omitted
    `permission_mode`
  - fixed `2dd7d01574f0b32dfffc1a1302fe3969c2e288b4`: the same successful
    prompt emitted `permission_mode: "manual"` at startup and
    `permission_mode: "auto"` at shutdown after the prompt-mode runtime
    transition
- The same added engine acceptance tests were applied without the
  implementation to the exact upstream base: four v1 permission-mode tests,
  one v1 lifecycle integration case, three v2 permission-mode tests, and
  three v2 scoped-runner integration cases failed. All passed on this branch.
- `pnpm --filter @moonshot-ai/agent-core exec vitest run` — 4,119 passed, 30 skipped, 3 expected failures, 1 todo
- `pnpm --filter @moonshot-ai/agent-core-v2 exec vitest run` — 4,231 passed
- `pnpm --filter @moonshot-ai/agent-core typecheck`
- `pnpm --filter @moonshot-ai/agent-core-v2 typecheck`
- `pnpm --filter @moonshot-ai/agent-core build`
- `pnpm --filter @moonshot-ai/agent-core-v2 build`
- `pnpm --filter @moonshot-ai/kimi-code typecheck`
- `pnpm --filter @moonshot-ai/kimi-code build`
- `pnpm -C docs build`
- `pnpm exec oxlint --type-aware --quiet`
- `git diff --check`

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.
