### PR TITLE
fix(mcp): reinitialize expired HTTP sessions

### DIFF
--- a/.changeset/reinitialize-expired-mcp-sessions.md
+++ b/.changeset/reinitialize-expired-mcp-sessions.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Reinitialize expired Streamable HTTP MCP sessions and retry the interrupted tool call once when the server explicitly reports that the session is invalid.

--- a/packages/agent-core/src/agent/tool/index.ts
+++ b/packages/agent-core/src/agent/tool/index.ts
@@ -7,16 +7,19 @@ import {
   collectLoadedDynamicToolNames,
 } from '../context/dynamic-tools';
 import type { ContextMessage } from '../context/types';
-import { makeErrorPayload } from '../../errors';
+import { ErrorCodes, KimiError, makeErrorPayload } from '../../errors';
 import type { ExecutableTool, ToolUpdate } from '../../loop';
+import { errorMessage, isAbortError } from '../../loop/errors';
 import { createMcpAuthTool } from '../../mcp/auth-tool';
+import { isMcpSessionInvalidError } from '../../mcp/client-shared';
 import type { McpConnectionManager, McpServerEntry } from '../../mcp';
 import { mcpResultToExecutableOutput } from '../../mcp/output';
 import { isMcpToolName, qualifyMcpToolName } from '../../mcp/tool-naming';
-import type { MCPClient, MCPToolDefinition } from '../../mcp/types';
+import type { MCPClient, MCPToolDefinition, MCPToolResult } from '../../mcp/types';
 import { resolveSubagentTimeoutMs } from '../../session/subagent-host';
 import { buildSubagentModelDescriptions } from '../../session/subagent-binding';
 import { extendWorkspaceWithSkillRoots } from '../../skill';
+import { abortable } from '../../utils/abort';
 import { fingerprint } from '../llm-request-logger';
 import * as b from '../../tools/builtin';
 import type { ToolStore, ToolStoreData, ToolStoreKey } from '../../tools/store';
@@ -327,11 +330,30 @@ export class ToolManager {
               // `args` has already been JSON-parsed and schema-validated by
               // the loop's preflight (`loop/tool-call.ts`), so the MCP
               // client gets a plain object directly.
-              const result = await client.callTool(
-                tool.name,
-                (args ?? {}) as Record<string, unknown>,
+              const toolArgs = (args ?? {}) as Record<string, unknown>;
+              const callClient = await this.resolveMcpClientForCall(
+                serverName,
+                client,
                 context.signal,
               );
+              let result: MCPToolResult;
+              try {
+                result = await callClient.callTool(tool.name, toolArgs, context.signal);
+              } catch (error) {
+                if (isMcpSessionInvalidError(error)) {
+                  result = await this.retryAfterMcpSessionInvalidation(
+                    serverName,
+                    callClient,
+                    tool.name,
+                    toolArgs,
+                    context.signal,
+                    context.onUpdate,
+                    error,
+                  );
+                } else {
+                  throw error;
+                }
+              }
               return mcpResultToExecutableOutput(result, qualified, {
                 originalsDir: this.agent.mediaOriginalsDir,
                 telemetry: this.agent.telemetry,
@@ -347,6 +369,88 @@ export class ToolManager {
     }
     this.mcpToolsByServer.set(serverName, qualifiedNames);
     return { registered: qualifiedNames, collisions };
+  }
+
+  private async resolveMcpClientForCall(
+    serverName: string,
+    registeredClient: MCPClient,
+    signal: AbortSignal,
+  ): Promise<MCPClient> {
+    const mcp = this.agent.mcp;
+    if (mcp === undefined) return registeredClient;
+    const reconnect = mcp.inFlightReconnect(serverName);
+    if (reconnect !== undefined) {
+      await abortable(reconnect, signal);
+    }
+    const currentClient = mcp.resolved(serverName)?.client;
+    if (currentClient === undefined) {
+      throw new KimiError(
+        ErrorCodes.MCP_STARTUP_FAILED,
+        `MCP server is not connected: ${serverName}`,
+      );
+    }
+    return currentClient;
+  }
+
+  private async retryAfterMcpSessionInvalidation(
+    serverName: string,
+    staleClient: MCPClient,
+    toolName: string,
+    args: Record<string, unknown>,
+    signal: AbortSignal,
+    onUpdate: ((update: ToolUpdate) => void) | undefined,
+    sessionError: Error,
+  ): Promise<MCPToolResult> {
+    signal.throwIfAborted();
+    const originalError = sessionError.cause instanceof Error ? sessionError.cause : sessionError;
+    const mcp = this.agent.mcp;
+    if (mcp === undefined) throw originalError;
+
+    onUpdate?.({ kind: 'status', text: 'MCP session expired — reinitializing…' });
+    let freshClient: MCPClient | undefined;
+    try {
+      freshClient = await abortable(
+        this.joinHealedOrReconnectMcpServer(mcp, serverName, staleClient),
+        signal,
+      );
+    } catch (reconnectError) {
+      if (signal.aborted || isAbortError(reconnectError)) throw reconnectError;
+      throw new Error(
+        `${originalError.message} (reinitializing the MCP session also failed: ${errorMessage(reconnectError)})`,
+        { cause: reconnectError },
+      );
+    }
+    if (freshClient === undefined) throw originalError;
+
+    return this.callMcpToolAfterRecovery(freshClient, toolName, args, signal);
+  }
+
+  private async joinHealedOrReconnectMcpServer(
+    mcp: McpConnectionManager,
+    serverName: string,
+    staleClient: MCPClient,
+  ): Promise<MCPClient | undefined> {
+    const healed = mcp.resolved(serverName)?.client;
+    if (healed !== undefined && healed !== staleClient) return healed;
+    await mcp.reconnectAndJoin(serverName);
+    const current = mcp.resolved(serverName)?.client;
+    return current !== undefined && current !== staleClient ? current : undefined;
+  }
+
+  private async callMcpToolAfterRecovery(
+    client: MCPClient,
+    toolName: string,
+    args: Record<string, unknown>,
+    signal: AbortSignal,
+  ): Promise<MCPToolResult> {
+    try {
+      return await client.callTool(toolName, args, signal);
+    } catch (retryError) {
+      if (isMcpSessionInvalidError(retryError) && retryError.cause instanceof Error) {
+        throw retryError.cause;
+      }
+      throw retryError;
+    }
   }
 
   unregisterMcpServer(serverName: string): boolean {
@@ -405,8 +509,9 @@ export class ToolManager {
       serverName: entry.name,
       serverUrl,
       oauthService,
-      reconnect: async () => {
-        await mcp.reconnect(entry.name);
+      reconnect: async (signal) => {
+        const reconnect = mcp.reconnect(entry.name);
+        await (signal === undefined ? reconnect : abortable(reconnect, signal));
       },
     });
     this.mcpTools.set(tool.name, { tool, serverName: entry.name });

--- a/packages/agent-core/src/mcp/client-http.ts
+++ b/packages/agent-core/src/mcp/client-http.ts
@@ -1,12 +1,16 @@
 import type { McpServerHttpConfig } from '#/config/schema';
 import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import type { OAuthClientProvider } from '@modelcontextprotocol/sdk/client/auth.js';
-import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
+import {
+  StreamableHTTPClientTransport,
+  StreamableHTTPError,
+} from '@modelcontextprotocol/sdk/client/streamableHttp.js';
 
 import {
   buildRequestOptions,
   KIMI_MCP_CLIENT_NAME,
   KIMI_MCP_CLIENT_VERSION,
+  McpSessionInvalidError,
   toMcpToolDefinition,
   toMcpToolResult,
   type UnexpectedCloseListener,
@@ -141,8 +145,22 @@ export class HttpMcpClient implements MCPClient {
     signal?: AbortSignal,
   ): Promise<MCPToolResult> {
     const requestOptions = buildRequestOptions(this.toolCallTimeoutMs, signal);
-    const result = await this.client.callTool({ name, arguments: args }, undefined, requestOptions);
-    return toMcpToolResult(result);
+    try {
+      const result = await this.client.callTool(
+        { name, arguments: args },
+        undefined,
+        requestOptions,
+      );
+      return toMcpToolResult(result);
+    } catch (error) {
+      if (
+        this.transport.sessionId !== undefined &&
+        isMcpSessionInvalidResponse(error)
+      ) {
+        throw new McpSessionInvalidError(error);
+      }
+      throw error;
+    }
   }
 
   private async closeStartedClient(): Promise<void> {
@@ -214,6 +232,67 @@ export function isTerminalTransportError(error: Error): boolean {
   if (error.name === 'UnauthorizedError') return true;
   if (/Maximum reconnection attempts/i.test(error.message)) return true;
   return false;
+}
+
+/**
+ * Recognizes the two session-expiry signals used by Streamable HTTP servers:
+ *
+ * - HTTP 404, required by the MCP transport specification for a terminated
+ *   session.
+ * - A structured InvalidRequest response whose message explicitly says the
+ *   session id is invalid and the client must reinitialize. Some deployed
+ *   servers return this as HTTP 400 instead of the specification's 404.
+ *
+ * The caller additionally verifies that the transport actually owns a
+ * session id, so an unrelated endpoint-level 404 cannot trigger recovery.
+ */
+export function isMcpSessionInvalidResponse(error: unknown): error is Error {
+  if (error instanceof StreamableHTTPError) {
+    if (error.code === 404) return true;
+    if (error.code !== 400) return false;
+    const responseError = parseJsonRpcErrorFromHttpMessage(error.message);
+    return (
+      responseError?.code === -32600 &&
+      isExplicitSessionReinitializeMessage(responseError.message)
+    );
+  }
+  return false;
+}
+
+function parseJsonRpcErrorFromHttpMessage(
+  message: string,
+): { readonly code: number; readonly message: string } | undefined {
+  const marker = 'Error POSTing to endpoint:';
+  const markerIndex = message.indexOf(marker);
+  if (markerIndex === -1) return undefined;
+  const body = message.slice(markerIndex + marker.length).trim();
+  try {
+    const parsed: unknown = JSON.parse(body);
+    if (typeof parsed !== 'object' || parsed === null || !('error' in parsed)) {
+      return undefined;
+    }
+    const responseError = parsed.error;
+    if (
+      typeof responseError !== 'object' ||
+      responseError === null ||
+      !('code' in responseError) ||
+      !('message' in responseError) ||
+      typeof responseError.code !== 'number' ||
+      typeof responseError.message !== 'string'
+    ) {
+      return undefined;
+    }
+    return { code: responseError.code, message: responseError.message };
+  } catch {
+    return undefined;
+  }
+}
+
+function isExplicitSessionReinitializeMessage(message: string): boolean {
+  return (
+    /\b(?:unknown|invalid|expired)\s+session(?:\s+id)?\b/i.test(message) &&
+    /\breinitiali[sz]e\b/i.test(message)
+  );
 }
 
 export function buildMcpHttpHeaders(

--- a/packages/agent-core/src/mcp/client-shared.ts
+++ b/packages/agent-core/src/mcp/client-shared.ts
@@ -26,6 +26,22 @@ export interface UnexpectedCloseReason {
 
 export type UnexpectedCloseListener = (reason: UnexpectedCloseReason) => void;
 
+/**
+ * Internal control-flow error raised when a sessionful MCP transport says the
+ * current session no longer exists. The original SDK error is kept as the
+ * cause so callers can recover without losing the server's diagnostics.
+ */
+export class McpSessionInvalidError extends Error {
+  constructor(cause: Error) {
+    super(cause.message, { cause });
+    this.name = 'McpSessionInvalidError';
+  }
+}
+
+export function isMcpSessionInvalidError(error: unknown): error is McpSessionInvalidError {
+  return error instanceof McpSessionInvalidError;
+}
+
 export interface McpRequestOptions {
   readonly timeout?: number;
   readonly signal?: AbortSignal;

--- a/packages/agent-core/src/mcp/connection-manager.ts
+++ b/packages/agent-core/src/mcp/connection-manager.ts
@@ -129,6 +129,7 @@ export interface McpConnectionManagerOptions {
 export class McpConnectionManager {
   private readonly entries = new Map<string, InternalEntry>();
   private readonly listeners = new Set<McpStatusListener>();
+  private readonly inFlightReconnects = new Map<string, Promise<void>>();
   private initialLoad: Promise<void> = Promise.resolve();
   private initialLoadAttemptId = 0;
   private initialLoadStartedAt: number | undefined;
@@ -294,14 +295,46 @@ export class McpConnectionManager {
     await Promise.allSettled(tasks);
   }
 
-  async reconnect(name: string): Promise<void> {
+  /**
+   * Starts or joins the server's current reconnect attempt.
+   *
+   * Manual, RPC, OAuth, and tool-recovery callers all share one attempt per
+   * server. A second attempt can start only after the current promise settles;
+   * overlapping callers never replace or supersede it.
+   */
+  reconnect(name: string): Promise<void> {
+    const existing = this.inFlightReconnects.get(name);
+    if (existing !== undefined) return existing;
     const entry = this.entries.get(name);
     if (entry === undefined) {
-      throw new KimiError(ErrorCodes.MCP_SERVER_NOT_FOUND, `Unknown MCP server: ${name}`);
+      return Promise.reject(
+        new KimiError(ErrorCodes.MCP_SERVER_NOT_FOUND, `Unknown MCP server: ${name}`),
+      );
     }
     if (entry.config.enabled === false) {
-      throw new KimiError(ErrorCodes.MCP_SERVER_DISABLED, `MCP server is disabled: ${name}`);
+      return Promise.reject(
+        new KimiError(ErrorCodes.MCP_SERVER_DISABLED, `MCP server is disabled: ${name}`),
+      );
     }
+    const work = this.reconnectEntry(entry)
+      .then(() => {
+        const current = this.entries.get(name);
+        if (current?.status === 'connected') return;
+        throw new KimiError(
+          ErrorCodes.MCP_STARTUP_FAILED,
+          current?.error ?? `MCP server failed to reconnect: ${name}`,
+        );
+      })
+      .finally(() => {
+        if (this.inFlightReconnects.get(name) === work) {
+          this.inFlightReconnects.delete(name);
+        }
+      });
+    this.inFlightReconnects.set(name, work);
+    return work;
+  }
+
+  private async reconnectEntry(entry: InternalEntry): Promise<void> {
     const attemptId = this.beginConnectAttempt(entry);
     await this.closeClient(entry);
     if (!this.isCurrent(entry, attemptId)) return;
@@ -312,6 +345,14 @@ export class McpConnectionManager {
     entry.error = undefined;
     this.emit(entry);
     await this.connectOne(entry, attemptId);
+  }
+
+  reconnectAndJoin(name: string): Promise<void> {
+    return this.reconnect(name);
+  }
+
+  inFlightReconnect(name: string): Promise<void> | undefined {
+    return this.inFlightReconnects.get(name);
   }
 
   async shutdown(): Promise<void> {

--- a/packages/agent-core/test/mcp/client-http.test.ts
+++ b/packages/agent-core/test/mcp/client-http.test.ts
@@ -1,9 +1,19 @@
+/**
+ * Scenario: Streamable HTTP MCP transport setup, requests, and failures.
+ *
+ * Exercises the real HTTP client against in-process MCP servers and classifies
+ * SDK transport errors directly. Run with `pnpm --filter
+ * @moonshot-ai/agent-core exec vitest run test/mcp/client-http.test.ts`.
+ */
+
 import { randomUUID } from 'node:crypto';
 import { createServer, type Server } from 'node:http';
 import type { AddressInfo } from 'node:net';
 
+import { StreamableHTTPError } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
+import { ErrorCode, McpError } from '@modelcontextprotocol/sdk/types.js';
 import { afterEach, describe, expect, it } from 'vitest';
 import { z } from 'zod';
 
@@ -11,6 +21,7 @@ import { ErrorCodes, KimiError } from '../../src/errors';
 import {
   buildMcpHttpHeaders,
   HttpMcpClient,
+  isMcpSessionInvalidResponse,
   isTerminalTransportError,
 } from '../../src/mcp/client-http';
 
@@ -112,6 +123,75 @@ describe('buildMcpHttpHeaders', () => {
     expect(isTerminalTransportError(new Error('SSE stream disconnected: ECONNRESET'))).toBe(false);
     expect(isTerminalTransportError(new Error('fetch failed'))).toBe(false);
     expect(isTerminalTransportError(new Error('Connection closed'))).toBe(false);
+  });
+
+  it('recognizes HTTP 404 as the standard Streamable HTTP session-expiry signal', () => {
+    expect(
+      isMcpSessionInvalidResponse(
+        new StreamableHTTPError(404, 'Error POSTing to endpoint: session not found'),
+      ),
+    ).toBe(true);
+  });
+
+  it('recognizes an HTTP 400 JSON-RPC InvalidRequest response that requires reinitialization', () => {
+    const response = JSON.stringify({
+      jsonrpc: '2.0',
+      id: 1,
+      error: {
+        code: -32600,
+        message: "Unknown session id 'expired'; client should reinitialize",
+      },
+    });
+    expect(
+      isMcpSessionInvalidResponse(
+        new StreamableHTTPError(400, `Error POSTing to endpoint: ${response}`),
+      ),
+    ).toBe(true);
+  });
+
+  it.each(['Invalid session id; client should reinitialize', 'Expired session; reinitialize'])(
+    'recognizes the explicit HTTP 400 session rejection %j',
+    (message) => {
+      const response = JSON.stringify({
+        jsonrpc: '2.0',
+        id: 1,
+        error: { code: -32600, message },
+      });
+      expect(
+        isMcpSessionInvalidResponse(
+          new StreamableHTTPError(400, `Error POSTing to endpoint: ${response}`),
+        ),
+      ).toBe(true);
+    },
+  );
+
+  it('does not treat an SDK InvalidRequest as proof that an HTTP session was rejected', () => {
+    expect(
+      isMcpSessionInvalidResponse(
+        new McpError(
+          ErrorCode.InvalidRequest,
+          "Unknown session id 'expired'; client should reinitialize",
+        ),
+      ),
+    ).toBe(false);
+  });
+
+  it('does not treat unrelated InvalidRequest responses as session expiry', () => {
+    const response = JSON.stringify({
+      jsonrpc: '2.0',
+      id: 1,
+      error: { code: -32600, message: 'Invalid tool arguments' },
+    });
+    expect(
+      isMcpSessionInvalidResponse(
+        new StreamableHTTPError(400, `Error POSTing to endpoint: ${response}`),
+      ),
+    ).toBe(false);
+    expect(
+      isMcpSessionInvalidResponse(
+        new McpError(ErrorCode.InvalidRequest, 'Invalid tool arguments'),
+      ),
+    ).toBe(false);
   });
 
   it('strips case-variant authorization headers before injecting the bearer', () => {

--- a/packages/agent-core/test/mcp/connection-manager.test.ts
+++ b/packages/agent-core/test/mcp/connection-manager.test.ts
@@ -297,6 +297,73 @@ describe('McpConnectionManager', () => {
     }
   });
 
+  it('reconnectAndJoin joins an in-flight reconnect instead of starting a second one', async () => {
+    const cm = new McpConnectionManager();
+    const seen: Array<{ name: string; status: McpServerEntry['status'] }> = [];
+    cm.onStatusChange((entry) => {
+      seen.push({ name: entry.name, status: entry.status });
+    });
+
+    try {
+      await cm.connectAll({ slow: stdioConfig() });
+      seen.length = 0;
+
+      await Promise.all([cm.reconnectAndJoin('slow'), cm.reconnectAndJoin('slow')]);
+
+      expect(cm.get('slow')?.status).toBe('connected');
+      expect(seen.filter((event) => event.name === 'slow').map((event) => event.status)).toEqual([
+        'pending',
+        'connected',
+      ]);
+    } finally {
+      await cm.shutdown();
+    }
+  }, 20_000);
+
+  it('returns the public reconnect attempt when reconnectAndJoin overlaps it', async () => {
+    const cm = new McpConnectionManager();
+    const attempts: Promise<void>[] = [];
+    try {
+      await cm.connectAll({ slow: stdioConfig() });
+
+      const reconnect = cm.reconnect('slow');
+      const joined = cm.reconnectAndJoin('slow');
+      attempts.push(reconnect, joined);
+
+      expect(joined).toBe(reconnect);
+      await joined;
+    } finally {
+      await Promise.allSettled(attempts);
+      await cm.shutdown();
+    }
+  }, 20_000);
+
+  it('rejects reconnectAndJoin with mcp.startup_failed when reconnect cannot connect', async () => {
+    const cm = new McpConnectionManager();
+    try {
+      await cm.connectAll({
+        broken: { transport: 'stdio', command: '/this/path/does/not/exist/anywhere' },
+      });
+
+      await expect(cm.reconnectAndJoin('broken')).rejects.toMatchObject({
+        code: 'mcp.startup_failed',
+      });
+    } finally {
+      await cm.shutdown();
+    }
+  }, 20_000);
+
+  it('reconnectAndJoin rejects when the server name is unknown', async () => {
+    const cm = new McpConnectionManager();
+    try {
+      const reconnect = cm.reconnectAndJoin('nope');
+      await expect(reconnect).rejects.toBeInstanceOf(KimiError);
+      await expect(reconnect).rejects.toMatchObject({ code: 'mcp.server_not_found' });
+    } finally {
+      await cm.shutdown();
+    }
+  });
+
   it('shutdown clears entries and is idempotent', async () => {
     const cm = new McpConnectionManager();
     await cm.connectAll({ alpha: stdioConfig() });

--- a/packages/agent-core/test/mcp/tool-manager-mcp.test.ts
+++ b/packages/agent-core/test/mcp/tool-manager-mcp.test.ts
@@ -1,8 +1,28 @@
+/**
+ * Scenario: MCP tool registration, execution, and output projection.
+ *
+ * Exercises ToolManager through its public tool surface with real MCP clients
+ * where transport behavior matters, and transport-shaped fakes otherwise.
+ * Run with `pnpm --filter @moonshot-ai/agent-core exec vitest run
+ * test/mcp/tool-manager-mcp.test.ts`.
+ */
+
+import { randomUUID } from 'node:crypto';
+import { createServer, type IncomingMessage, type Server } from 'node:http';
+import type { AddressInfo } from 'node:net';
+
 import type { ContentPart, Tool } from '@moonshot-ai/kosong';
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
+import { ErrorCode, McpError } from '@modelcontextprotocol/sdk/types.js';
 import { describe, expect, it } from 'vitest';
+import { z } from 'zod';
 
 import type { Agent } from '../../src/agent';
 import { ToolManager } from '../../src/agent/tool';
+import type { ExecutableTool } from '../../src/loop';
+import { McpConnectionManager } from '../../src/mcp/connection-manager';
+import { AlreadyAuthorizedError, type McpOAuthService } from '../../src/mcp/oauth';
 import type { MCPClient } from '../../src/mcp/types';
 import { testAgent } from '../agent/harness/agent';
 import { executeTool } from '../tools/fixtures/execute-tool';
@@ -11,9 +31,10 @@ const MCP_OUTPUT_TRUNCATED_TEXT =
   '\n\n[Output truncated: exceeded 100000 character limit. ' +
   'Use pagination or more specific queries to get remaining content.]';
 
-function fakeAgent(calls: unknown[] = []): Agent {
+function fakeAgent(calls: unknown[] = [], mcp?: McpConnectionManager): Agent {
   return {
     records: {
+      observabilityReady: true,
       logRecord(record: unknown) {
         calls.push(record);
       },
@@ -24,6 +45,8 @@ function fakeAgent(calls: unknown[] = []): Agent {
     goal: {
       getGoal: () => ({ goal: null }),
     },
+    mcp,
+    emitEvent() {},
   } as unknown as Agent;
 }
 
@@ -56,6 +79,19 @@ function fakeClient(): MCPClient {
   };
 }
 
+function createDeferred<T>(): {
+  readonly promise: Promise<T>;
+  resolve(value: T): void;
+} {
+  let resolveValue: (value: T) => void = () => {
+    /* replaced by the Promise constructor */
+  };
+  const promise = new Promise<T>((resolve) => {
+    resolveValue = resolve;
+  });
+  return { promise, resolve: resolveValue };
+}
+
 // Mirrors `connection-manager.connectAndDiscoverTools` — projects an MCP
 // client's `listTools()` output into the kosong `Tool` shape that
 // `ToolManager.registerMcpServer` expects. Tests can hand the same client into
@@ -67,6 +103,203 @@ async function discoverTools(client: MCPClient): Promise<Tool[]> {
     description: d.description,
     parameters: d.inputSchema as Record<string, unknown>,
   }));
+}
+
+interface RestartableHttpMcpServer {
+  readonly url: string;
+  readonly initializeCount: () => number;
+  readonly invalidSessionCount: () => number;
+  readonly pauseNextInitialization: () => {
+    readonly started: Promise<void>;
+    readonly resume: () => void;
+  };
+  readonly restart: (options?: {
+    readonly invalidSessionStatus?: 400 | 404;
+    readonly rejectInitializationWith?: string;
+    readonly rejectToolCallsAfterReconnect?: boolean;
+  }) => void;
+  readonly close: () => Promise<void>;
+}
+
+async function startRestartableHttpMcpServer(): Promise<RestartableHttpMcpServer> {
+  const servers: McpServer[] = [];
+  let activeTransport: StreamableHTTPServerTransport | undefined;
+  let initializeCount = 0;
+  let invalidSessionCount = 0;
+  let invalidSessionStatus: 400 | 404 = 400;
+  let rejectInitializationWith: string | undefined;
+  let rejectToolCallsAfterReconnect = false;
+  let initializationPause:
+    | {
+        readonly started: () => void;
+        readonly resumed: Promise<void>;
+      }
+    | undefined;
+
+  const createTransport = async (): Promise<StreamableHTTPServerTransport> => {
+    const mcpServer = new McpServer({ name: 'restartable-http', version: '0.0.1' });
+    mcpServer.registerTool(
+      'echo',
+      { description: 'Echoes text', inputSchema: { text: z.string() } },
+      ({ text }) => ({ content: [{ type: 'text', text }] }),
+    );
+    const transport = new StreamableHTTPServerTransport({
+      sessionIdGenerator: () => randomUUID(),
+    });
+    await mcpServer.connect(transport);
+    servers.push(mcpServer);
+    activeTransport = transport;
+    initializeCount += 1;
+    return transport;
+  };
+
+  const httpServer: Server = createServer((req, res) => {
+    void (async () => {
+      const body = req.method === 'POST' ? await readJsonRequest(req) : undefined;
+      const method =
+        typeof body === 'object' &&
+        body !== null &&
+        'method' in body &&
+        typeof body.method === 'string'
+          ? body.method
+          : undefined;
+      const sessionId = req.headers['mcp-session-id'];
+      if (sessionId === undefined && method === 'initialize' && initializationPause !== undefined) {
+        const pause = initializationPause;
+        initializationPause = undefined;
+        pause.started();
+        await pause.resumed;
+      }
+      if (
+        sessionId === undefined &&
+        method === 'initialize' &&
+        rejectInitializationWith !== undefined
+      ) {
+        res.writeHead(503, { 'content-type': 'text/plain' });
+        res.end(rejectInitializationWith);
+        return;
+      }
+      if (
+        typeof sessionId === 'string' &&
+        (activeTransport === undefined ||
+          sessionId !== activeTransport.sessionId ||
+          (rejectToolCallsAfterReconnect && method === 'tools/call'))
+      ) {
+        invalidSessionCount += 1;
+        if (invalidSessionStatus === 404) {
+          res.writeHead(404, { 'content-type': 'text/plain' });
+          res.end(`Unknown session id '${sessionId}'`);
+          return;
+        }
+        res.writeHead(invalidSessionStatus, { 'content-type': 'application/json' });
+        res.end(
+          JSON.stringify({
+            jsonrpc: '2.0',
+            id:
+              typeof body === 'object' && body !== null && 'id' in body
+                ? body.id
+                : 1,
+            error: {
+              code: -32600,
+              message: `Unknown session id '${sessionId}' for 'tools/call'; client should reinitialize`,
+            },
+          }),
+        );
+        return;
+      }
+
+      const transport =
+        sessionId === undefined ? await createTransport() : activeTransport;
+      if (transport === undefined) {
+        throw new Error('expected an active MCP transport');
+      }
+      await transport.handleRequest(req, res, body);
+    })().catch((error: unknown) => {
+      if (res.headersSent) {
+        res.end();
+        return;
+      }
+      res.writeHead(500, { 'content-type': 'text/plain' });
+      res.end(error instanceof Error ? error.message : String(error));
+    });
+  });
+
+  await new Promise<void>((resolve) => {
+    httpServer.listen(0, '127.0.0.1', resolve);
+  });
+  const port = (httpServer.address() as AddressInfo).port;
+
+  return {
+    url: `http://127.0.0.1:${port}/mcp`,
+    initializeCount: () => initializeCount,
+    invalidSessionCount: () => invalidSessionCount,
+    pauseNextInitialization: () => {
+      const started = createSignal();
+      const resumed = createSignal();
+      initializationPause = {
+        started: started.resolve,
+        resumed: resumed.promise,
+      };
+      return {
+        started: started.promise,
+        resume: resumed.resolve,
+      };
+    },
+    restart: (options = {}) => {
+      activeTransport = undefined;
+      invalidSessionStatus = options.invalidSessionStatus ?? 400;
+      rejectInitializationWith = options.rejectInitializationWith;
+      rejectToolCallsAfterReconnect = options.rejectToolCallsAfterReconnect ?? false;
+    },
+    async close() {
+      await Promise.allSettled(servers.map((server) => server.close()));
+      await new Promise<void>((resolve, reject) => {
+        httpServer.close((error) => {
+          if (error !== undefined) reject(error);
+          else resolve();
+        });
+      });
+    },
+  };
+}
+
+async function readJsonRequest(req: IncomingMessage): Promise<unknown> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of req) {
+    chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+  }
+  if (chunks.length === 0) return undefined;
+  return JSON.parse(Buffer.concat(chunks).toString('utf8')) as unknown;
+}
+
+function createSignal(): { readonly promise: Promise<void>; readonly resolve: () => void } {
+  let resolve = () => {};
+  const promise = new Promise<void>((settle) => {
+    resolve = () => {
+      settle();
+    };
+  });
+  return { promise, resolve };
+}
+
+async function connectRestartableMcp(server: RestartableHttpMcpServer): Promise<{
+  readonly mcp: McpConnectionManager;
+  readonly tool: ExecutableTool;
+}> {
+  const mcp = new McpConnectionManager();
+  await mcp.connectAll({
+    remote: {
+      transport: 'http',
+      url: server.url,
+      startupTimeoutMs: 5_000,
+      toolTimeoutMs: 5_000,
+    },
+  });
+  const tm = new ToolManager(fakeAgent([], mcp));
+  tm.setActiveTools(['mcp__*']);
+  const tool = tm.loopTools.find((candidate) => candidate.name === 'mcp__remote__echo');
+  if (tool === undefined) throw new Error('expected the remote echo tool');
+  return { mcp, tool };
 }
 
 describe('ToolManager MCP integration', () => {
@@ -275,6 +508,281 @@ describe('ToolManager MCP integration', () => {
     expect(result.isError).toBe(false);
     expect(result.output).toBe('hello world');
   });
+
+  it('does not replay a tool call when ConnectionClosed races with a replacement client', async () => {
+    let recoveryStarted = false;
+    let replacementCalls = 0;
+    const staleClient: MCPClient = {
+      ...fakeClient(),
+      async callTool() {
+        recoveryStarted = true;
+        throw new McpError(ErrorCode.ConnectionClosed, 'Connection closed after dispatch');
+      },
+    };
+    const replacementClient: MCPClient = {
+      ...fakeClient(),
+      async callTool() {
+        replacementCalls += 1;
+        return { content: [{ type: 'text', text: 'duplicate' }], isError: false };
+      },
+    };
+    const mcp = {
+      list: () => [],
+      onStatusChange: () => () => {},
+      inFlightReconnect: () => (recoveryStarted ? Promise.resolve() : undefined),
+      resolved: () =>
+        recoveryStarted
+          ? {
+              client: replacementClient,
+              tools: [],
+              rawTools: [],
+              enabledNames: new Set<string>(),
+            }
+          : {
+              client: staleClient,
+              tools: [],
+              rawTools: [],
+              enabledNames: new Set<string>(),
+            },
+    } as unknown as McpConnectionManager;
+    const tm = new ToolManager(fakeAgent([], mcp));
+    tm.setActiveTools(['mcp__*']);
+    tm.registerMcpServer('s', staleClient, await discoverTools(staleClient));
+    const echo = tm.loopTools.find((tool) => tool.name === 'mcp__s__echo');
+
+    await expect(
+      executeTool(echo!, {
+        turnId: '1',
+        toolCallId: 'tc-ambiguous-close',
+        args: { text: 'side effect' },
+        signal: new AbortController().signal,
+      }),
+    ).rejects.toMatchObject({ code: ErrorCode.ConnectionClosed });
+    expect(replacementCalls).toBe(0);
+  });
+
+  it('waits for a public reconnect before calling the replacement client', async () => {
+    const server = await startRestartableHttpMcpServer();
+    const { mcp, tool } = await connectRestartableMcp(server);
+    const pause = server.pauseNextInitialization();
+    const reconnect = mcp.reconnect('remote');
+    try {
+      await pause.started;
+      const call = executeTool(tool, {
+        turnId: '1',
+        toolCallId: 'tc-join-public-reconnect',
+        args: { text: 'after manual reconnect' },
+        signal: new AbortController().signal,
+      });
+
+      pause.resume();
+
+      await expect(call).resolves.toMatchObject({ output: 'after manual reconnect' });
+      await reconnect;
+      expect(server.initializeCount()).toBe(2);
+    } finally {
+      pause.resume();
+      await reconnect.catch(() => {});
+      await mcp.shutdown();
+      await server.close();
+    }
+  }, 15_000);
+
+  it('aborts a caller waiting for a shared reconnect without cancelling the reconnect', async () => {
+    const server = await startRestartableHttpMcpServer();
+    const { mcp, tool } = await connectRestartableMcp(server);
+    const pause = server.pauseNextInitialization();
+    const reconnect = mcp.reconnectAndJoin('remote');
+    try {
+      await pause.started;
+      const controller = new AbortController();
+      const call = executeTool(tool, {
+        turnId: '1',
+        toolCallId: 'tc-abort-shared-reconnect',
+        args: { text: 'cancelled waiter' },
+        signal: controller.signal,
+      });
+
+      controller.abort();
+
+      await expect(call).rejects.toMatchObject({ name: 'AbortError' });
+      pause.resume();
+      await reconnect;
+      await expect(
+        executeTool(tool, {
+          turnId: '2',
+          toolCallId: 'tc-after-aborted-waiter',
+          args: { text: 'shared reconnect completed' },
+          signal: new AbortController().signal,
+        }),
+      ).resolves.toMatchObject({ output: 'shared reconnect completed' });
+    } finally {
+      pause.resume();
+      await reconnect.catch(() => {});
+      await mcp.shutdown();
+      await server.close();
+    }
+  }, 15_000);
+
+  it('aborts an OAuth waiter without cancelling the shared reconnect', async () => {
+    const reconnect = createDeferred<void>();
+    const reconnectStarted = createDeferred<void>();
+    let reconnectFinished = false;
+    void reconnect.promise.then(() => {
+      reconnectFinished = true;
+    });
+    const oauthService = {
+      beginAuthorization: async () => {
+        throw new AlreadyAuthorizedError('remote');
+      },
+    } as unknown as McpOAuthService;
+    const mcp = {
+      list: () => [
+        {
+          name: 'remote',
+          transport: 'http',
+          status: 'needs-auth',
+          toolCount: 0,
+        },
+      ],
+      onStatusChange: () => () => {},
+      oauthService,
+      getRemoteServerUrl: () => 'https://example.com/mcp',
+      reconnect: () => {
+        reconnectStarted.resolve();
+        return reconnect.promise;
+      },
+    } as unknown as McpConnectionManager;
+    const tm = new ToolManager(fakeAgent([], mcp));
+    tm.setActiveTools(['mcp__*']);
+    const auth = tm.loopTools.find((tool) => tool.name === 'mcp__remote__authenticate');
+    const controller = new AbortController();
+    const call = executeTool(auth!, {
+      turnId: '1',
+      toolCallId: 'tc-abort-oauth-reconnect',
+      args: {},
+      signal: controller.signal,
+    });
+
+    await reconnectStarted.promise;
+    controller.abort();
+    let outcome: Awaited<typeof call> | undefined;
+    void call.then((result) => {
+      outcome = result;
+    });
+    try {
+      await new Promise<void>((resolve) => {
+        setImmediate(resolve);
+      });
+      expect(outcome).toMatchObject({ isError: true });
+      expect(reconnectFinished).toBe(false);
+    } finally {
+      reconnect.resolve();
+      await reconnect.promise;
+    }
+  });
+
+  it('reinitializes a Streamable HTTP session when the server invalidates its session id', async () => {
+    const server = await startRestartableHttpMcpServer();
+    const { mcp, tool } = await connectRestartableMcp(server);
+    try {
+      expect(mcp.get('remote')?.status).toBe('connected');
+      expect(server.initializeCount()).toBe(1);
+
+      server.restart();
+      const result = await executeTool(tool, {
+        turnId: '1',
+        toolCallId: 'tc-session-reinitialized',
+        args: { text: 'after restart' },
+        signal: new AbortController().signal,
+      });
+
+      expect(result.output).toBe('after restart');
+      expect(server.initializeCount()).toBe(2);
+      expect(server.invalidSessionCount()).toBeGreaterThanOrEqual(1);
+      expect(mcp.get('remote')?.status).toBe('connected');
+
+      const nextResult = await executeTool(tool, {
+        turnId: '2',
+        toolCallId: 'tc-reconnected-session-reused',
+        args: { text: 'next call' },
+        signal: new AbortController().signal,
+      });
+      expect(nextResult.output).toBe('next call');
+      expect(server.initializeCount()).toBe(2);
+    } finally {
+      await mcp.shutdown();
+      await server.close();
+    }
+  }, 15_000);
+
+  it('reinitializes a Streamable HTTP session after the standard HTTP 404 signal', async () => {
+    const server = await startRestartableHttpMcpServer();
+    const { mcp, tool } = await connectRestartableMcp(server);
+    try {
+      server.restart({ invalidSessionStatus: 404 });
+
+      const result = await executeTool(tool, {
+        turnId: '1',
+        toolCallId: 'tc-standard-session-expiry',
+        args: { text: 'after 404' },
+        signal: new AbortController().signal,
+      });
+
+      expect(result.output).toBe('after 404');
+      expect(server.initializeCount()).toBe(2);
+      expect(server.invalidSessionCount()).toBe(1);
+      expect(mcp.get('remote')?.status).toBe('connected');
+    } finally {
+      await mcp.shutdown();
+      await server.close();
+    }
+  }, 15_000);
+
+  it('retries only once when the replacement session is also rejected', async () => {
+    const server = await startRestartableHttpMcpServer();
+    const { mcp, tool } = await connectRestartableMcp(server);
+    try {
+      server.restart({ rejectToolCallsAfterReconnect: true });
+
+      await expect(
+        executeTool(tool, {
+          turnId: '1',
+          toolCallId: 'tc-retry-still-invalid',
+          args: { text: 'never returned' },
+          signal: new AbortController().signal,
+        }),
+      ).rejects.toThrow(/Unknown session id/);
+      expect(server.initializeCount()).toBe(2);
+      expect(server.invalidSessionCount()).toBe(2);
+      expect(mcp.get('remote')?.status).toBe('connected');
+    } finally {
+      await mcp.shutdown();
+      await server.close();
+    }
+  }, 15_000);
+
+  it('reports both the expired session and a failed reinitialization', async () => {
+    const server = await startRestartableHttpMcpServer();
+    const { mcp, tool } = await connectRestartableMcp(server);
+    try {
+      server.restart({ rejectInitializationWith: 'MCP service unavailable for maintenance' });
+
+      const call = executeTool(tool, {
+        turnId: '1',
+        toolCallId: 'tc-reinitialization-failed',
+        args: { text: 'never returned' },
+        signal: new AbortController().signal,
+      });
+      await expect(call).rejects.toThrow(/Unknown session id/);
+      await expect(call).rejects.toThrow(/reinitializing the MCP session also failed/);
+      await expect(call).rejects.toThrow(/MCP service unavailable for maintenance/);
+      expect(mcp.get('remote')?.status).toBe('failed');
+    } finally {
+      await mcp.shutdown();
+      await server.close();
+    }
+  }, 15_000);
 
   it('truncates oversized MCP text output with a clear notice', async () => {
     const tm = new ToolManager(fakeAgent());


### PR DESCRIPTION
## Related Issue

Resolve #2380

## Problem

After a Streamable HTTP MCP server restarted, its old session id could remain attached to the client transport. A tool retry then sent the same expired id again instead of establishing a new session, so the server repeatedly returned `Unknown session id`.

## What changed

- Recognize a terminated session only when a sessionful Streamable HTTP transport receives the specification-defined HTTP 404 or the reported HTTP 400 / JSON-RPC `-32600` response with an explicit invalid-session and reinitialize message.
- Reinitialize the affected server and retry the interrupted tool call exactly once.
- Make manual, RPC, OAuth, and automatic recovery callers join one reconnect attempt per server.
- Resolve the current client before each call so existing tool wrappers remain valid after reconnect.
- Never transparently replay a call that fails only with `ConnectionClosed`, because its server-side outcome is unknown and replaying could duplicate side effects.
- Preserve the original session error alongside reconnect diagnostics, and allow an aborted caller to stop waiting without cancelling the shared reconnect.
- Exercise real in-process Streamable HTTP sessions as well as concurrency, abort, failed-reconnect, and false-positive cases.

## Validation

- Before/after real Streamable HTTP E2E on the exact upstream base
  `691ec4679ea19d6be8ac18f359088384ed3e446d` and fixed
  `e03fd73a947bf34668059ff694ece2566e539f8c`: the added invalid-session
  scenario failed on upstream with the server's `Unknown session id`
  response, then passed unchanged after the fix by establishing a replacement
  session and retrying the interrupted call once.
- `pnpm --filter @moonshot-ai/agent-core exec vitest run test/mcp/client-http.test.ts test/mcp/connection-manager.test.ts test/mcp/tool-manager-mcp.test.ts` — 93 passed
- `pnpm --filter @moonshot-ai/agent-core exec vitest run` — 4,133 passed, 30 skipped, 3 expected failures, 1 todo
- `pnpm --filter @moonshot-ai/agent-core typecheck`
- `pnpm --filter @moonshot-ai/agent-core build`
- `pnpm --filter @moonshot-ai/kimi-code typecheck`
- `pnpm --filter @moonshot-ai/kimi-code build`
- `node apps/kimi-code/dist/main.mjs --version`
- `pnpm exec oxlint --type-aware --quiet`
- `git diff --check`

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.
