### PR TITLE
fix(cli): make native install source description platform-aware

### DIFF
--- a/.changeset/native-install-source.md
+++ b/.changeset/native-install-source.md
@@ -1,0 +1,11 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+fix(cli): make native install source description platform-aware
+
+On macOS, script installs via the official install.sh are detected as
+"native" but the message hardcoded "native (windows). Auto-update is not
+supported on this platform." even though native non-Windows installs do
+support auto-update. Show "native (windows)" only on win32 and just
+"native" elsewhere.

--- a/apps/kimi-code/src/cli/update/preflight.ts
+++ b/apps/kimi-code/src/cli/update/preflight.ts
@@ -151,6 +151,7 @@ export function renderManualUpdateMessage(
   target: UpdateTarget,
   source: InstallSource,
   installCommand: string,
+  platform: NodeJS.Platform = process.platform,
 ): string {
   let sourceDesc: string;
   switch (source) {
@@ -164,7 +165,10 @@ export function renderManualUpdateMessage(
       sourceDesc = 'homebrew';
       break;
     case 'native':
-      sourceDesc = 'native (windows). Auto-update is not supported on this platform.';
+      sourceDesc =
+        platform === 'win32'
+          ? 'native (windows). Auto-update is not supported on this platform.'
+          : 'native';
       break;
     case 'unsupported':
       sourceDesc = 'unsupported package manager or layout.';


### PR DESCRIPTION
## Related Issue

Resolves #2391

## Problem

On macOS, `kimi upgrade` reports `Detected install source: native (windows). Auto-update is not supported on this platform.` for script installs. The native install source supports auto-update on macOS (canAutoInstall returns true for non-Windows), but the message was hardcoded to say "native (windows)" for all platforms.

## What changed

Added `platform` parameter (defaults to `process.platform`) to `renderManualUpdateMessage`. The `native` case now shows `native (windows)` only on win32, and just `native` on other platforms.

## Checklist

- [x] I have read the CONTRIBUTING document.
- [x] I have linked a related issue.
- [x] This PR needs no changeset (internal diagnostic message only).
- [x] This PR needs no doc update.