### PR TITLE
feat(kap-server): expose effective experimental flags in /meta

### DIFF
--- a/.changeset/kap-server-meta-experimental-flags.md
+++ b/.changeset/kap-server-meta-experimental-flags.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kap-server": minor
+---
+
+Expose the effective experimental-flag map as `experimental_flags` on `GET /api/v1/meta`. The field is resolved per request from `IFlagService.snapshot()`, so it covers every flag source (master env, per-flag `KIMI_CODE_EXPERIMENTAL_*` env vars, the `[experimental]` config section, defaults) and flips live when the config section is written — unlike the `experimental` section of `GET /config`, which only reflects persisted config. Clients (desktop/web UI) can use it to gate experimental features.

--- a/.changeset/kap-server-meta-experimental-flags.md
+++ b/.changeset/kap-server-meta-experimental-flags.md
@@ -1,5 +1,5 @@
 ---
-"@moonshot-ai/kap-server": minor
+"@moonshot-ai/kap-server": patch
 ---
 
-Expose the effective experimental-flag map as `experimental_flags` on `GET /api/v1/meta`. The field is resolved per request from `IFlagService.snapshot()`, so it covers every flag source (master env, per-flag `KIMI_CODE_EXPERIMENTAL_*` env vars, the `[experimental]` config section, defaults) and flips live when the config section is written — unlike the `experimental` section of `GET /config`, which only reflects persisted config. Clients (desktop/web UI) can use it to gate experimental features.
+Expose the effective experimental-flag map as `experimental_flags` on `GET /api/v1/meta`.

--- a/packages/kap-server/src/protocol/rest-meta.ts
+++ b/packages/kap-server/src/protocol/rest-meta.ts
@@ -33,6 +33,17 @@ export const metaResponseSchema = z.object({
    */
   dangerous_bypass_auth: z.boolean(),
   /**
+   * Effective experimental-flag state (flag id → enabled), resolved by the
+   * FlagService from every source (master env, per-flag env, the
+   * `[experimental]` config section, defaults). This is the *effective* state,
+   * not the persisted config section: a flag enabled via
+   * `KIMI_CODE_EXPERIMENTAL_*` env appears here but not in `GET /config`'s
+   * `experimental` map. Computed per request — config-section writes flip it
+   * live. Clients use it to gate experimental UI; older servers omit it, so
+   * treat absence as "no flags enabled".
+   */
+  experimental_flags: z.record(z.string(), z.boolean()).optional(),
+  /**
    * Backend engine generation serving this API. `'v2'` is the DI × Scope
    * engine (`@moonshot-ai/kap-server` / `agent-core-v2`); older servers omit
    * the field (treat absence as v1). Lets clients identify the backend without

--- a/packages/kap-server/src/routes/meta.ts
+++ b/packages/kap-server/src/routes/meta.ts
@@ -45,9 +45,10 @@ export interface MetaRouteOptions {
   /**
    * Resolves the effective experimental-flag map (flag id → enabled) at
    * request time. Backed by `IFlagService.snapshot()` in production; tests may
-   * stub it.
+   * stub it. May return a promise — the handler awaits it, so flag state
+   * always reflects the fully loaded config (never pre-load defaults).
    */
-  readonly getExperimentalFlags: () => Record<string, boolean>;
+  readonly getExperimentalFlags: () => Record<string, boolean> | Promise<Record<string, boolean>>;
 }
 
 export function registerMetaRoute(app: RouteHost, opts: MetaRouteOptions): void {
@@ -79,7 +80,7 @@ export function registerMetaRoute(app: RouteHost, opts: MetaRouteOptions): void 
     async (req, reply) => {
       const data: MetaResponse = {
         ...staticData,
-        experimental_flags: opts.getExperimentalFlags(),
+        experimental_flags: await opts.getExperimentalFlags(),
       };
       reply.send(okEnvelope(data, req.id));
     },

--- a/packages/kap-server/src/routes/meta.ts
+++ b/packages/kap-server/src/routes/meta.ts
@@ -11,7 +11,10 @@
  * must treat unbacked capabilities as not-yet-available until the corresponding
  * routes are wired.
  *
- * **No DI**: pure server-self info; the payload is frozen at registration time.
+ * **No DI for the static fields**: pure server-self info; that part of the
+ * payload is frozen at registration time. `experimental_flags` is the
+ * exception — flag state flips live when the `[experimental]` config section
+ * changes, so it is resolved per request through the injected getter.
  */
 
 import { okEnvelope } from '../envelope';
@@ -39,10 +42,16 @@ export interface MetaRouteOptions {
    * the web UI can skip the token prompt and connect without a credential.
    */
   readonly dangerousBypassAuth: boolean;
+  /**
+   * Resolves the effective experimental-flag map (flag id → enabled) at
+   * request time. Backed by `IFlagService.snapshot()` in production; tests may
+   * stub it.
+   */
+  readonly getExperimentalFlags: () => Record<string, boolean>;
 }
 
 export function registerMetaRoute(app: RouteHost, opts: MetaRouteOptions): void {
-  const data: MetaResponse = Object.freeze({
+  const staticData = Object.freeze({
     server_version: opts.serverVersion,
     capabilities: Object.freeze({
       websocket: true as const,
@@ -68,6 +77,10 @@ export function registerMetaRoute(app: RouteHost, opts: MetaRouteOptions): void 
       tags: ['meta'],
     },
     async (req, reply) => {
+      const data: MetaResponse = {
+        ...staticData,
+        experimental_flags: opts.getExperimentalFlags(),
+      };
       reply.send(okEnvelope(data, req.id));
     },
   );

--- a/packages/kap-server/src/routes/registerApiV1Routes.ts
+++ b/packages/kap-server/src/routes/registerApiV1Routes.ts
@@ -9,7 +9,7 @@
  * folder picker, the session filesystem, terminals, connections, shutdown).
  */
 
-import type { Scope } from '@moonshot-ai/agent-core-v2';
+import { IConfigService, type Scope } from '@moonshot-ai/agent-core-v2';
 import { IFlagService } from '@moonshot-ai/agent-core-v2/app/flag/flag';
 import type { KimiHostIdentity } from '@moonshot-ai/kimi-code-oauth';
 import { ulid } from 'ulid';
@@ -106,7 +106,15 @@ export async function registerApiV1Routes(
         serverId: ulid(),
         startedAt: new Date().toISOString(),
         dangerousBypassAuth: opts.dangerousBypassAuth === true,
-        getExperimentalFlags: () => core.accessor.get(IFlagService).snapshot(),
+        getExperimentalFlags: async () => {
+          // Same edge-facade contract as the config route: never project
+          // config-derived state before the initial load settles — an early
+          // /meta hit would otherwise advertise default/env-only flags and
+          // hide config-enabled features until the FlagService's change
+          // watcher catches up.
+          await core.accessor.get(IConfigService).ready;
+          return core.accessor.get(IFlagService).snapshot();
+        },
       });
 
       registerAuthRoute(apiV1 as unknown as Parameters<typeof registerAuthRoute>[0], core);

--- a/packages/kap-server/src/routes/registerApiV1Routes.ts
+++ b/packages/kap-server/src/routes/registerApiV1Routes.ts
@@ -10,6 +10,7 @@
  */
 
 import type { Scope } from '@moonshot-ai/agent-core-v2';
+import { IFlagService } from '@moonshot-ai/agent-core-v2/app/flag/flag';
 import type { KimiHostIdentity } from '@moonshot-ai/kimi-code-oauth';
 import { ulid } from 'ulid';
 
@@ -105,6 +106,7 @@ export async function registerApiV1Routes(
         serverId: ulid(),
         startedAt: new Date().toISOString(),
         dangerousBypassAuth: opts.dangerousBypassAuth === true,
+        getExperimentalFlags: () => core.accessor.get(IFlagService).snapshot(),
       });
 
       registerAuthRoute(apiV1 as unknown as Parameters<typeof registerAuthRoute>[0], core);

--- a/packages/kap-server/test/meta.test.ts
+++ b/packages/kap-server/test/meta.test.ts
@@ -5,7 +5,7 @@
  * master env, the `[experimental]` config section, defaults).
  */
 
-import { mkdtemp, rm } from 'node:fs/promises';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
@@ -48,8 +48,11 @@ describe('/api/v1/meta experimental_flags', () => {
     }
   });
 
-  async function boot(): Promise<string> {
+  async function boot(toml?: string): Promise<string> {
     home = await mkdtemp(join(tmpdir(), 'kimi-server-v2-meta-'));
+    if (toml !== undefined) {
+      await writeFile(join(home, 'config.toml'), toml, 'utf-8');
+    }
     server = await startServer({
       hostIdentity: TEST_HOST_IDENTITY,
       host: '127.0.0.1',
@@ -73,6 +76,16 @@ describe('/api/v1/meta experimental_flags', () => {
     const base = await boot();
     const flags = await getMetaFlags(base);
     expect(flags['secondary-model']).toBe(false);
+  });
+
+  it('reports a config-enabled flag from the very first response', async () => {
+    // Regression for the startup race: FlagService reads the `[experimental]`
+    // section from a config that loads asynchronously, so the handler awaits
+    // IConfigService.ready before snapshotting — a persisted flag must be
+    // visible even to the earliest request.
+    const base = await boot('[experimental]\nsecondary-model = true\n');
+    const flags = await getMetaFlags(base);
+    expect(flags['secondary-model']).toBe(true);
   });
 
   it('reflects a flag enabled via its KIMI_CODE_EXPERIMENTAL_* env var', async () => {

--- a/packages/kap-server/test/meta.test.ts
+++ b/packages/kap-server/test/meta.test.ts
@@ -1,0 +1,113 @@
+/**
+ * `/api/v1/meta` tests — the static server-self fields are covered by
+ * `boot.test.ts`; these focus on `experimental_flags`, the effective
+ * experimental-flag map resolved per request from every flag source (env,
+ * master env, the `[experimental]` config section, defaults).
+ */
+
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { type RunningServer, startServer } from '../src/start';
+import { TEST_HOST_IDENTITY } from './helpers/hostIdentity';
+import { authedFetch } from './helpers/auth';
+
+interface MetaBody {
+  code: number;
+  data: { experimental_flags?: Record<string, boolean> };
+}
+
+describe('/api/v1/meta experimental_flags', () => {
+  let server: RunningServer | undefined;
+  let home: string | undefined;
+
+  beforeEach(() => {
+    // Neutralize flag env vars leaking from the developer shell (e.g. a
+    // globally exported KIMI_CODE_EXPERIMENTAL_FLAG=1) so each test starts
+    // from the default-off baseline. The master env can be pinned to '0' (it
+    // only forces ON), but the per-flag env must be fully ABSENT — an
+    // explicit '0' is an env override that outranks the config section.
+    vi.stubEnv('KIMI_CODE_EXPERIMENTAL_FLAG', '0');
+    vi.stubEnv('KIMI_CODE_EXPERIMENTAL_SECONDARY_MODEL', undefined);
+  });
+
+  afterEach(async () => {
+    vi.unstubAllEnvs();
+    if (server !== undefined) {
+      await server.close();
+      server = undefined;
+    }
+    if (home !== undefined) {
+      // The query-store cache can still be flushing while we clean up; retry
+      // instead of flaking on ENOTEMPTY.
+      await rm(home, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
+      home = undefined;
+    }
+  });
+
+  async function boot(): Promise<string> {
+    home = await mkdtemp(join(tmpdir(), 'kimi-server-v2-meta-'));
+    server = await startServer({
+      hostIdentity: TEST_HOST_IDENTITY,
+      host: '127.0.0.1',
+      port: 0,
+      homeDir: home,
+      logLevel: 'silent',
+    });
+    return `http://127.0.0.1:${server.port}`;
+  }
+
+  async function getMetaFlags(base: string): Promise<Record<string, boolean>> {
+    const res = await authedFetch(server as RunningServer, base, '/api/v1/meta');
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as MetaBody;
+    expect(body.code).toBe(0);
+    expect(body.data.experimental_flags).toBeDefined();
+    return body.data.experimental_flags as Record<string, boolean>;
+  }
+
+  it('reports registered flags as off by default', async () => {
+    const base = await boot();
+    const flags = await getMetaFlags(base);
+    expect(flags['secondary-model']).toBe(false);
+  });
+
+  it('reflects a flag enabled via its KIMI_CODE_EXPERIMENTAL_* env var', async () => {
+    vi.stubEnv('KIMI_CODE_EXPERIMENTAL_SECONDARY_MODEL', '1');
+    const base = await boot();
+    const flags = await getMetaFlags(base);
+    expect(flags['secondary-model']).toBe(true);
+  });
+
+  it('flips live when the [experimental] config section is written via POST /config', async () => {
+    const base = await boot();
+    expect((await getMetaFlags(base))['secondary-model']).toBe(false);
+
+    const res = await authedFetch(server as RunningServer, base, '/api/v1/config', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ experimental: { 'secondary-model': true } }),
+    });
+    expect(res.status).toBe(200);
+
+    expect((await getMetaFlags(base))['secondary-model']).toBe(true);
+  });
+
+  it('keeps an env-forced flag on when the config section disables it', async () => {
+    vi.stubEnv('KIMI_CODE_EXPERIMENTAL_SECONDARY_MODEL', '1');
+    const base = await boot();
+
+    const res = await authedFetch(server as RunningServer, base, '/api/v1/config', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ experimental: { 'secondary-model': false } }),
+    });
+    expect(res.status).toBe(200);
+
+    // Env outranks the config section in FlagService resolution.
+    expect((await getMetaFlags(base))['secondary-model']).toBe(true);
+  });
+});


### PR DESCRIPTION
## Related Issue

No linked issue — this is the server half of the secondary-model settings UI (MoonshotAI/kimi-code-app#163); the problem is explained below.

## Problem

Experimental flags resolve from several sources (master env, per-flag `KIMI_CODE_EXPERIMENTAL_*` env vars, the `[experimental]` config section, defaults), but HTTP clients can only see the *persisted* config section via `GET /config`. A UI therefore cannot tell whether a flag is actually in effect: with `secondary-model` enabled via env, the desktop/web settings UI would hide the secondary-model section while the feature is active — or, without any effective-state source, would have to bypass the experimental gate entirely.

## What changed

`GET /api/v1/meta` now carries `experimental_flags`: the effective flag map (flag id → enabled) resolved **per request** from `IFlagService.snapshot()`, so it covers every flag source and flips live when the `[experimental]` config section is written — unlike the static persisted view in `GET /config`.

- `metaResponseSchema`: optional `experimental_flags` record (older servers omit it; clients treat absence as "no flags enabled")
- Meta route: static server-self fields stay frozen at registration; the flag map is computed per request through an injected getter
- Route registration wires `IFlagService.snapshot()` from the Core scope

Tests (`test/meta.test.ts`) cover: default-off, env-enabled, live flip via `POST /config`, and env-outranks-config — with the developer-shell `KIMI_CODE_EXPERIMENTAL_FLAG` neutralized per test. Full kap-server suite passes (922 tests).

Changeset included: `@moonshot-ai/kap-server` minor.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update. (The field is self-documented in the OpenAPI schema via `metaResponseSchema`; no manual doc page covers `/meta` fields.)
