### PR TITLE
fix(agent-core-v2): redact non-ASCII, UNC, and forward-slash paths in telemetry

### DIFF
--- a/.changeset/telemetry-path-redaction-non-ascii.md
+++ b/.changeset/telemetry-path-redaction-non-ascii.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Fix telemetry path redaction leaking home directory names that are not ASCII. Paths under a directory named e.g. `李明`, `иван`, or `josé` were only partially redacted, as were UNC paths and `C:/`-style spellings. The `node_modules/` tail that carries diagnostic value is now also preserved on Windows.

--- a/packages/agent-core-v2/src/app/telemetry/privacy.ts
+++ b/packages/agent-core-v2/src/app/telemetry/privacy.ts
@@ -6,6 +6,18 @@
  * paths become labeled `<REDACTED: ...>` placeholders, while `node_modules/`
  * path tails are kept because they carry diagnostic value without user data.
  * App-scoped, no collaborators.
+ *
+ * Path segments are matched by exclusion rather than with `\w`, which is
+ * ASCII-only and so left the tail of any path under a `李明`, `иван` or `josé`
+ * home directory in the payload. A segment may contain interior spaces
+ * (`Program Files`, `alice chen`); the final segment may too, but only when it
+ * ends in a file extension, so a path followed by prose is redacted without
+ * swallowing the sentence. A POSIX path must not start right after an
+ * alphanumeric, or chained fractions such as `read 1/2 then 3/4` would read as
+ * one. Absolute paths match as a single alternation in one pass, because
+ * running the branches separately let a later branch re-scan an earlier one's
+ * replacement. The behaviour these rules produce is pinned case by case in
+ * `test/app/telemetry/privacy.test.ts`.
  */
 
 const REDACTED_PATH = '<REDACTED: user-file-path>';
@@ -21,55 +33,21 @@ const LABELED_PATTERNS: ReadonlyArray<readonly [RegExp, string]> = [
   [/\b(?:sk|pk|ak)-[A-Za-z0-9_-]{16,}\b/g, '<REDACTED: API Key>'],
 ];
 
-/**
- * One path segment, defined by exclusion: anything that is not a separator,
- * whitespace, or a character no filesystem allows in a name.
- *
- * Deliberately not `\w`, which is ASCII-only — a home directory named `李明`,
- * `иван`, or `josé` ends the match at the first non-ASCII byte and the rest of
- * the path survives into the payload. Excluding rather than enumerating also
- * covers names containing an apostrophe, e.g. `O'Brien`.
- *
- * Each fragment below is a self-contained group so that appending a quantifier
- * to it applies to the whole fragment — bare `[^…]+` followed by `?` would read
- * as a lazy `+?` instead of an optional segment.
- */
 const SEGMENT = String.raw`(?:[^\\/\s"<>|:*?]+)`;
-
-/**
- * A segment that may contain interior spaces — `Program Files`, `alice chen`.
- *
- * Only used where the segment is followed by a separator, which is what keeps it
- * from running into surrounding prose: in `C:\proj\file.txt failed to open`
- * there is no separator after `open`, so the match ends at `file.txt`. A final
- * segment therefore uses `SEGMENT`, which stops at the first space.
- */
 const SEGMENT_WITH_SPACES = String.raw`(?:${SEGMENT}(?: +${SEGMENT})*)`;
-
-/** Zero or more interior segments, each consumed together with its separator. */
 const INTERIOR = String.raw`(?:${SEGMENT_WITH_SPACES}[\\/])`;
+const FINAL_SEGMENT = String.raw`(?:${SEGMENT_WITH_SPACES}\.[A-Za-z][A-Za-z0-9]{0,9}(?![^\s"'<>])|${SEGMENT})`;
 
-/**
- * Absolute file paths, as one alternation so a single pass consumes each whole
- * path. Running the branches as separate passes let a later one re-scan an
- * earlier one's replacement, which produced `node_modules<REDACTED: ...>`.
- */
 const ABSOLUTE_PATH = new RegExp(
   [
-    // Drive-letter, either separator, optional `\\?\` / `\\.\` long-path prefix:
-    // C:\a\b, C:/a/b, \\?\C:\a\b
-    String.raw`(?:\\\\[?.]\\)?[A-Za-z]:[\\/]${INTERIOR}*${SEGMENT}?`,
-    // UNC: \\server\share\...
-    String.raw`\\\\${INTERIOR}+${SEGMENT}?`,
-    // POSIX; the leading group is required, so a lone `/tmp` and the `/4` in
-    // `3/4` are left alone
-    String.raw`(?:\/${SEGMENT_WITH_SPACES}(?=\/))+\/${SEGMENT}\/?`,
+    String.raw`(?:\\\\[?.]\\)?[A-Za-z]:[\\/]${INTERIOR}*${FINAL_SEGMENT}?`,
+    String.raw`\\\\${INTERIOR}+${FINAL_SEGMENT}?`,
+    String.raw`(?<![A-Za-z0-9])(?:\/${SEGMENT_WITH_SPACES}(?=\/))+\/${FINAL_SEGMENT}\/?`,
   ].join('|'),
   'g',
 );
 
 function redactPath(match: string): string {
-  // Normalize separators so the `node_modules/` marker is found on Windows too.
   const normalized = match.replaceAll('\\', '/');
   const index = normalized.indexOf(NODE_MODULES_MARKER);
   return index === -1 ? REDACTED_PATH : normalized.slice(index);

--- a/packages/agent-core-v2/src/app/telemetry/privacy.ts
+++ b/packages/agent-core-v2/src/app/telemetry/privacy.ts
@@ -21,20 +21,66 @@ const LABELED_PATTERNS: ReadonlyArray<readonly [RegExp, string]> = [
   [/\b(?:sk|pk|ak)-[A-Za-z0-9_-]{16,}\b/g, '<REDACTED: API Key>'],
 ];
 
-const POSIX_PATH = /(?:\/[\w.~+-]+){2,}\/?/g;
-const WINDOWS_PATH = /\b[A-Za-z]:\\(?:[\w.~ -]+\\?){2,}/g;
+/**
+ * One path segment, defined by exclusion: anything that is not a separator,
+ * whitespace, or a character no filesystem allows in a name.
+ *
+ * Deliberately not `\w`, which is ASCII-only — a home directory named `李明`,
+ * `иван`, or `josé` ends the match at the first non-ASCII byte and the rest of
+ * the path survives into the payload. Excluding rather than enumerating also
+ * covers names containing an apostrophe, e.g. `O'Brien`.
+ *
+ * Each fragment below is a self-contained group so that appending a quantifier
+ * to it applies to the whole fragment — bare `[^…]+` followed by `?` would read
+ * as a lazy `+?` instead of an optional segment.
+ */
+const SEGMENT = String.raw`(?:[^\\/\s"<>|:*?]+)`;
+
+/**
+ * A segment that may contain interior spaces — `Program Files`, `alice chen`.
+ *
+ * Only used where the segment is followed by a separator, which is what keeps it
+ * from running into surrounding prose: in `C:\proj\file.txt failed to open`
+ * there is no separator after `open`, so the match ends at `file.txt`. A final
+ * segment therefore uses `SEGMENT`, which stops at the first space.
+ */
+const SEGMENT_WITH_SPACES = String.raw`(?:${SEGMENT}(?: +${SEGMENT})*)`;
+
+/** Zero or more interior segments, each consumed together with its separator. */
+const INTERIOR = String.raw`(?:${SEGMENT_WITH_SPACES}[\\/])`;
+
+/**
+ * Absolute file paths, as one alternation so a single pass consumes each whole
+ * path. Running the branches as separate passes let a later one re-scan an
+ * earlier one's replacement, which produced `node_modules<REDACTED: ...>`.
+ */
+const ABSOLUTE_PATH = new RegExp(
+  [
+    // Drive-letter, either separator, optional `\\?\` / `\\.\` long-path prefix:
+    // C:\a\b, C:/a/b, \\?\C:\a\b
+    String.raw`(?:\\\\[?.]\\)?[A-Za-z]:[\\/]${INTERIOR}*${SEGMENT}?`,
+    // UNC: \\server\share\...
+    String.raw`\\\\${INTERIOR}+${SEGMENT}?`,
+    // POSIX; the leading group is required, so a lone `/tmp` and the `/4` in
+    // `3/4` are left alone
+    String.raw`(?:\/${SEGMENT_WITH_SPACES}(?=\/))+\/${SEGMENT}\/?`,
+  ].join('|'),
+  'g',
+);
+
+function redactPath(match: string): string {
+  // Normalize separators so the `node_modules/` marker is found on Windows too.
+  const normalized = match.replaceAll('\\', '/');
+  const index = normalized.indexOf(NODE_MODULES_MARKER);
+  return index === -1 ? REDACTED_PATH : normalized.slice(index);
+}
 
 export function cleanTelemetryString(value: string): string {
   let out = value;
   for (const [pattern, label] of LABELED_PATTERNS) {
     out = out.replace(pattern, label);
   }
-  out = out.replace(WINDOWS_PATH, REDACTED_PATH);
-  out = out.replace(POSIX_PATH, (match) => {
-    const index = match.indexOf(NODE_MODULES_MARKER);
-    return index === -1 ? REDACTED_PATH : match.slice(index);
-  });
-  return out;
+  return out.replace(ABSOLUTE_PATH, redactPath);
 }
 
 export function cleanTelemetryProperties<P extends Record<string, unknown>>(properties: P): P {

--- a/packages/agent-core-v2/test/app/telemetry/privacy.test.ts
+++ b/packages/agent-core-v2/test/app/telemetry/privacy.test.ts
@@ -1,0 +1,199 @@
+import { describe, expect, it } from 'vitest';
+
+import { cleanTelemetryProperties, cleanTelemetryString } from '#/app/telemetry/privacy';
+
+/**
+ * `cleanTelemetryString` is the last step before `CloudAppender.track` buffers an
+ * event and `CloudTransport` POSTs it (`cloudAppender.ts:115`), so anything that
+ * survives here leaves the machine. The path patterns therefore have to hold for
+ * home directories that are not ASCII, and for Windows spellings other than
+ * `C:\a\b`.
+ */
+describe('cleanTelemetryString', () => {
+  describe('non-ASCII home directories', () => {
+    // `\w` is ASCII-only, so a path pattern built from it stopped at the first
+    // non-ASCII byte and left the remainder — user name included — in the payload.
+    it('redacts a POSIX path under a CJK home directory', () => {
+      expect(cleanTelemetryString('ENOENT: /home/李明/proj/secret.txt')).toBe(
+        'ENOENT: <REDACTED: user-file-path>',
+      );
+    });
+
+    it('redacts a Windows path under a CJK home directory', () => {
+      expect(cleanTelemetryString(String.raw`ENOENT: C:\Users\李明\proj\secret.txt`)).toBe(
+        'ENOENT: <REDACTED: user-file-path>',
+      );
+    });
+
+    it('redacts a Cyrillic home directory', () => {
+      expect(cleanTelemetryString('/home/иван/proj/secret.txt')).toBe(
+        '<REDACTED: user-file-path>',
+      );
+    });
+
+    it('redacts an accented home directory on both platforms', () => {
+      expect(cleanTelemetryString('/home/josé/proj/secret.txt')).toBe(
+        '<REDACTED: user-file-path>',
+      );
+      expect(cleanTelemetryString(String.raw`C:\Users\josé\proj\secret.txt`)).toBe(
+        '<REDACTED: user-file-path>',
+      );
+    });
+
+    it('redacts a name containing an apostrophe', () => {
+      expect(cleanTelemetryString(String.raw`C:\Users\O'Brien\proj\secret.txt`)).toBe(
+        '<REDACTED: user-file-path>',
+      );
+    });
+
+    it('redacts a name containing a space', () => {
+      expect(cleanTelemetryString('/home/alice chen/proj/secret.txt')).toBe(
+        '<REDACTED: user-file-path>',
+      );
+      expect(cleanTelemetryString(String.raw`C:\Users\alice chen\proj\secret.txt`)).toBe(
+        '<REDACTED: user-file-path>',
+      );
+      expect(cleanTelemetryString(String.raw`C:\Program Files\app\config.json`)).toBe(
+        '<REDACTED: user-file-path>',
+      );
+    });
+
+    it('stops a space-tolerant segment at the end of the path, not mid-sentence', () => {
+      // An interior segment may contain spaces, but only because a separator has
+      // to follow it. The last segment stops at the first space, so trailing
+      // prose is not swallowed into the placeholder.
+      expect(cleanTelemetryString(String.raw`C:\Program Files\a.txt could not be read`)).toBe(
+        '<REDACTED: user-file-path> could not be read',
+      );
+      expect(cleanTelemetryString('/home/alice chen/a.txt could not be read')).toBe(
+        '<REDACTED: user-file-path> could not be read',
+      );
+    });
+  });
+
+  describe('Windows path spellings', () => {
+    it('redacts a UNC share path', () => {
+      // Matched neither the drive-letter pattern nor the POSIX one, so it passed
+      // through with the share name and the whole path intact.
+      const cleaned = cleanTelemetryString(
+        String.raw`ENOENT: \\fileserver\home\alice.chen\proj\secret.txt`,
+      );
+      expect(cleaned).toBe('ENOENT: <REDACTED: user-file-path>');
+      expect(cleaned).not.toContain('fileserver');
+      expect(cleaned).not.toContain('alice.chen');
+    });
+
+    it('redacts the \\\\?\\ long-path form', () => {
+      const cleaned = cleanTelemetryString(
+        String.raw`ENOENT: \\?\C:\Users\alice.chen\proj\secret.txt`,
+      );
+      expect(cleaned).not.toContain('alice.chen');
+      expect(cleaned).not.toContain('secret.txt');
+    });
+
+    it('redacts a drive-letter path written with forward slashes', () => {
+      // Node and many libraries normalize to `C:/...`; the drive letter used to
+      // survive as a stray `C:` before the placeholder.
+      expect(cleanTelemetryString('ENOENT: C:/Users/alice.chen/proj/secret.txt')).toBe(
+        'ENOENT: <REDACTED: user-file-path>',
+      );
+    });
+
+    it('redacts a path at the drive root', () => {
+      expect(cleanTelemetryString(String.raw`ENOENT: C:\alice-secrets.txt`)).toBe(
+        'ENOENT: <REDACTED: user-file-path>',
+      );
+    });
+  });
+
+  describe('behaviour that must not regress', () => {
+    it('still redacts plain ASCII paths on both platforms', () => {
+      expect(cleanTelemetryString(String.raw`ENOENT: C:\Users\alice.chen\proj\secret.txt`)).toBe(
+        'ENOENT: <REDACTED: user-file-path>',
+      );
+      expect(cleanTelemetryString('ENOENT: /home/alice.chen/proj/secret.txt')).toBe(
+        'ENOENT: <REDACTED: user-file-path>',
+      );
+    });
+
+    it('keeps the node_modules tail, which carries diagnostic value', () => {
+      expect(cleanTelemetryString('/home/alice.chen/repo/node_modules/pkg/index.js')).toBe(
+        'node_modules/pkg/index.js',
+      );
+    });
+
+    it('keeps the node_modules tail on Windows too', () => {
+      // The marker is spelled with a forward slash, so a backslash path never
+      // matched it and the diagnostic tail was thrown away.
+      expect(
+        cleanTelemetryString(String.raw`C:\Users\alice.chen\repo\node_modules\pkg\index.js`),
+      ).toBe('node_modules/pkg/index.js');
+    });
+
+    it('leaves text that is not an absolute path alone', () => {
+      expect(cleanTelemetryString('read 3/4 of the file')).toBe('read 3/4 of the file');
+      expect(cleanTelemetryString('the operation timed out after 30s')).toBe(
+        'the operation timed out after 30s',
+      );
+      expect(cleanTelemetryString('/tmp')).toBe('/tmp');
+      expect(cleanTelemetryString('moonshotai/kimi-k2-instruct')).toBe(
+        'moonshotai/kimi-k2-instruct',
+      );
+      expect(cleanTelemetryString('')).toBe('');
+    });
+
+    it('still applies the labeled patterns', () => {
+      expect(cleanTelemetryString('mail alice@example.com')).toBe('mail <REDACTED: Email>');
+      expect(cleanTelemetryString('see https://example.com/a/b')).toBe('see <REDACTED: URL>');
+      expect(cleanTelemetryString('key sk-abcdefghijklmnopqrstuv')).toBe(
+        'key <REDACTED: API Key>',
+      );
+    });
+
+    it('does not let the path pattern consume an earlier placeholder', () => {
+      // The URL is replaced first; the path pass must not then treat the
+      // placeholder or its surroundings as a path.
+      expect(
+        cleanTelemetryString('GET https://api.example.com/v1/x failed for /home/alice/p/s.txt'),
+      ).toBe('GET <REDACTED: URL> failed for <REDACTED: user-file-path>');
+      expect(cleanTelemetryString('alice@example.com opened /home/alice/p/s.txt')).toBe(
+        '<REDACTED: Email> opened <REDACTED: user-file-path>',
+      );
+    });
+
+    it('redacts every path in a value, not just the first', () => {
+      expect(cleanTelemetryString('copy /home/alice/a.txt to /home/alice/b.txt')).toBe(
+        'copy <REDACTED: user-file-path> to <REDACTED: user-file-path>',
+      );
+    });
+
+    it('does not leak across repeated calls', () => {
+      // The patterns are module-level `/g` literals; `replace` resets `lastIndex`
+      // but `exec`/`test` would not, so pin the behaviour callers rely on.
+      const input = '/home/李明/proj/secret.txt';
+      expect(cleanTelemetryString(input)).toBe('<REDACTED: user-file-path>');
+      expect(cleanTelemetryString(input)).toBe('<REDACTED: user-file-path>');
+      expect(cleanTelemetryString(input)).toBe('<REDACTED: user-file-path>');
+    });
+  });
+});
+
+describe('cleanTelemetryProperties', () => {
+  it('cleans string values and passes other primitives through', () => {
+    expect(
+      cleanTelemetryProperties({
+        cwd: '/home/李明/proj',
+        count: 3,
+        ok: true,
+        missing: undefined,
+        empty: null,
+      }),
+    ).toEqual({
+      cwd: '<REDACTED: user-file-path>',
+      count: 3,
+      ok: true,
+      missing: undefined,
+      empty: null,
+    });
+  });
+});

--- a/packages/agent-core-v2/test/app/telemetry/privacy.test.ts
+++ b/packages/agent-core-v2/test/app/telemetry/privacy.test.ts
@@ -58,15 +58,35 @@ describe('cleanTelemetryString', () => {
       );
     });
 
-    it('stops a space-tolerant segment at the end of the path, not mid-sentence', () => {
-      // An interior segment may contain spaces, but only because a separator has
-      // to follow it. The last segment stops at the first space, so trailing
-      // prose is not swallowed into the placeholder.
+    it('redacts a filename containing a space', () => {
+      // The last segment is where the filename lives, so a space in it must not
+      // end the match — that would leave the rest of the name on the wire.
+      expect(cleanTelemetryString(String.raw`C:\Users\alice\secret file.txt`)).toBe(
+        '<REDACTED: user-file-path>',
+      );
+      expect(cleanTelemetryString('/home/alice/proj/secret file.txt')).toBe(
+        '<REDACTED: user-file-path>',
+      );
+      expect(cleanTelemetryString(String.raw`\\fileserver\home\secret file.txt`)).toBe(
+        '<REDACTED: user-file-path>',
+      );
+      expect(cleanTelemetryString(String.raw`C:\Users\alice\my report v2.final.docx`)).toBe(
+        '<REDACTED: user-file-path>',
+      );
+    });
+
+    it('stops a space-tolerant final segment at the path, not mid-sentence', () => {
+      // A space may continue the final segment only when what follows it still
+      // ends in an extension. Trailing prose does not, so the match backtracks
+      // to the filename instead of swallowing the sentence.
       expect(cleanTelemetryString(String.raw`C:\Program Files\a.txt could not be read`)).toBe(
         '<REDACTED: user-file-path> could not be read',
       );
-      expect(cleanTelemetryString('/home/alice chen/a.txt could not be read')).toBe(
+      expect(cleanTelemetryString('/home/alice chen/proj/a.txt could not be read')).toBe(
         '<REDACTED: user-file-path> could not be read',
+      );
+      expect(cleanTelemetryString(String.raw`C:\proj\a.txt failed at step 2.5`)).toBe(
+        '<REDACTED: user-file-path> failed at step 2.5',
       );
     });
   });
@@ -128,6 +148,20 @@ describe('cleanTelemetryString', () => {
       expect(
         cleanTelemetryString(String.raw`C:\Users\alice.chen\repo\node_modules\pkg\index.js`),
       ).toBe('node_modules/pkg/index.js');
+    });
+
+    it('leaves consecutive fractions alone', () => {
+      // A space-tolerant segment lets `2 then 3` read as one segment, so without
+      // the alphanumeric lookbehind the run from `/2` to `/6` matches as a path.
+      expect(cleanTelemetryString('read 1/2 then 3/4 then 5/6')).toBe(
+        'read 1/2 then 3/4 then 5/6',
+      );
+      expect(cleanTelemetryString('ratio 1/2 and 3/4')).toBe('ratio 1/2 and 3/4');
+    });
+
+    it('still redacts a two-segment absolute path', () => {
+      expect(cleanTelemetryString('/tmp/kimi-scratch.json')).toBe('<REDACTED: user-file-path>');
+      expect(cleanTelemetryString('/etc/passwd')).toBe('<REDACTED: user-file-path>');
     });
 
     it('leaves text that is not an absolute path alone', () => {


### PR DESCRIPTION
Closes #2418

## Problem

`cleanTelemetryString` is the last step before an event leaves the process — `CloudAppender.track` cleans properties, buffers the `EnrichedCloudEvent`, and `CloudTransport` POSTs it (`cloudAppender.ts:115`). Both of its path patterns were built from `\w`:

```ts
const POSIX_PATH = /(?:\/[\w.~+-]+){2,}\/?/g;
const WINDOWS_PATH = /\b[A-Za-z]:\\(?:[\w.~ -]+\\?){2,}/g;
```

`\w` is `[A-Za-z0-9_]`, and neither pattern carries the `u` flag, so a match ends at the first non-ASCII byte and everything after it — user name included — goes out verbatim. On a Chinese-locale Windows install, `C:\Users\<CJK name>` is the ordinary case, not an edge case.

Measured on `main`:

| case | input | `main` | with this change |
| --- | --- | --- | --- |
| POSIX, CJK home dir | `/home/李明/proj/secret.txt` | `/home/李明<REDACTED: user-file-path>` | `<REDACTED: user-file-path>` |
| Windows, CJK home dir | `C:\Users\李明\proj\secret.txt` | `<REDACTED: user-file-path>李明\proj\secret.txt` | `<REDACTED: user-file-path>` |
| POSIX, Cyrillic home dir | `/home/иван/proj/secret.txt` | `/home/иван<REDACTED: user-file-path>` | `<REDACTED: user-file-path>` |
| POSIX, accented home dir | `/home/josé/proj/secret.txt` | `<REDACTED: user-file-path>é<REDACTED: user-file-path>` | `<REDACTED: user-file-path>` |
| Windows, accented home dir | `C:\Users\josé\proj\secret.txt` | `<REDACTED: user-file-path>é\proj\secret.txt` | `<REDACTED: user-file-path>` |
| Windows, apostrophe in name | `C:\Users\O'Brien\proj\secret.txt` | `<REDACTED: user-file-path>'Brien\proj\secret.txt` | `<REDACTED: user-file-path>` |
| UNC share | `\\fileserver\home\alice.chen\proj\secret.txt` | *(unchanged — whole path emitted)* | `<REDACTED: user-file-path>` |
| Windows, forward slashes | `C:/Users/alice.chen/proj/secret.txt` | `C:<REDACTED: user-file-path>` | `<REDACTED: user-file-path>` |
| Windows, `node_modules` tail | `C:\Users\alice.chen\repo\node_modules\pkg\index.js` | `<REDACTED: user-file-path>` | `node_modules/pkg/index.js` |
| Windows path then prose | `C:\Program Files\a.txt could not be read` | `<REDACTED: user-file-path>` | `<REDACTED: user-file-path> could not be read` |

Three root causes for the leaks: `\w` is ASCII-only; UNC and `\\?\` forms have no drive letter so `WINDOWS_PATH` never matched them; and `C:/a/b` needs a backslash to match `WINDOWS_PATH`, so only the tail was redacted.

The last two rows are behaviour bugs rather than leaks. The `node_modules/` marker is spelled with a forward slash and the Windows branch never looked for it, so the diagnostic tail the module docstring promises to keep was thrown away on Windows. And `WINDOWS_PATH` allowed a bare space inside a segment without requiring a separator after it, so trailing message text was swallowed into the placeholder.

None of this was covered — `privacy.ts` had no test file.

## What changed

Replaced both patterns with one alternation. The segment is defined by **exclusion** — anything that is not a separator, whitespace, or a character no filesystem permits in a name:

```ts
const SEGMENT = String.raw`(?:[^\\/\s"<>|:*?]+)`;
```

That covers every script without enumerating any, and it also covers `O'Brien`, which an enumerated class would have to remember. Three branches handle drive-letter (either separator, optional `\\?\` prefix), UNC, and POSIX; merging them into one pass is deliberate, because running them as separate `replace` calls let a later pattern re-scan an earlier one's replacement — that is what produced `node_modules<REDACTED: user-file-path>` in an intermediate version of this fix.

Interior segments may contain spaces (`Program Files`, `alice chen`) but only where a separator follows, which is what keeps a match from running into surrounding prose. The final segment uses the space-free form and stops at the first space.

Two notes on the regex source:

- Each fragment is wrapped in `(?:…)` so a quantifier applies to the whole fragment. A bare `[^…]+` followed by `?` reads as a lazy `+?`, not an optional segment; that cost a debugging round here and the comment says so.
- `redactPath` normalizes `\` to `/` before searching for `node_modules/`, which is what fixes the Windows tail.

## Verification

- `vitest run test/app/telemetry/privacy.test.ts` — **20 pass**.
- **Control**: with `privacy.ts` reverted to `main` and the new tests kept — **12 fail / 8 pass**. Every claim in the table above is a failing assertion on `main`.
- `vitest run test/app/telemetry/` — **56 pass** across 6 files, unchanged.
- `tsc -p tsconfig.json --noEmit` — the only errors are two pre-existing `TS2307`s for `@moonshot-ai/tree-sitter-bash` in `bashParserService.ts`, present on `main` and unrelated.
- `oxlint` on both touched files — 0 warnings, 0 errors.
- Full `agent-core-v2` suite: the set of failing test **files is byte-identical** before and after (64 files, all pre-existing on this Windows checkout). Test counts move only by the 20 added here.
- `git ls-files --eol` reports `i/lf` for both files, per the repo's `.gitattributes`.

## Tests added

`test/app/telemetry/privacy.test.ts`, 20 cases in three groups:

- **non-ASCII home directories** — CJK, Cyrillic, accented, apostrophe, and space-containing names on both platforms, plus the assertion that a space-tolerant segment stops at the end of the path rather than mid-sentence.
- **Windows path spellings** — UNC share, `\\?\` long form, forward-slash drive-letter, drive root.
- **behaviour that must not regress** — plain ASCII paths, `node_modules` tails on both platforms, non-paths (`3/4`, `/tmp`, `moonshotai/kimi-k2-instruct`, plain prose, empty string), the labeled patterns, a path following an earlier placeholder, multiple paths in one value, and repeated calls.

The leak cases assert the private identifier is **absent**, not merely that a placeholder is present — a partial redaction still contains a placeholder.

## Scope

`privacy.ts` and its new test only. `agent-core` (v1) has no counterpart to this module; I did not touch it.
