### PR TITLE
fix(web): register /usage slash command in the command menu

### DIFF
--- a/.changeset/web-usage-slash-command.md
+++ b/.changeset/web-usage-slash-command.md
@@ -1,0 +1,6 @@
+---
+"@moonshot-ai/kimi-web": patch
+"@moonshot-ai/kimi-code": patch
+---
+
+Register the /usage slash command in kimi web so it appears in the command menu and opens the session status panel with context and cost.

--- a/apps/kimi-web/src/App.vue
+++ b/apps/kimi-web/src/App.vue
@@ -567,6 +567,9 @@ function handleCommand(cmd: string): void {
       client.setThinking(nextThinkingLevel(client.thinking.value));
       break;
     case '/status':
+    case '/usage':
+      // /usage shares the status panel: it already surfaces context tokens and
+      // session cost, which is the web equivalent of the TUI /usage report.
       showStatusPanel.value = true;
       break;
     case '/login':

--- a/apps/kimi-web/src/i18n/locales/en/commands.ts
+++ b/apps/kimi-web/src/i18n/locales/en/commands.ts
@@ -16,5 +16,6 @@ export default {
     noSession: 'Open a session before exporting it.',
   },
   status: { desc: 'View session status' },
+  usage: { desc: 'Show session tokens, context window, and cost' },
   undo: { desc: 'Undo the last message' },
 } as const;

--- a/apps/kimi-web/src/i18n/locales/zh/commands.ts
+++ b/apps/kimi-web/src/i18n/locales/zh/commands.ts
@@ -16,5 +16,6 @@ export default {
     noSession: '请先打开一个会话再导出。',
   },
   status: { desc: '查看会话状态' },
+  usage: { desc: '查看会话 token、上下文窗口与费用' },
   undo: { desc: '撤销上一条消息' },
 };

--- a/apps/kimi-web/src/lib/slashCommands.ts
+++ b/apps/kimi-web/src/lib/slashCommands.ts
@@ -37,6 +37,7 @@ export const SLASH_COMMANDS: SlashCommand[] = [
   { name: '/fork',       desc: 'commands.fork.desc' },
   { name: '/export',     desc: 'commands.export.desc' },
   { name: '/status',     desc: 'commands.status.desc' },
+  { name: '/usage',      desc: 'commands.usage.desc' },
 ];
 
 /**

--- a/apps/kimi-web/test/slash-menu.test.ts
+++ b/apps/kimi-web/test/slash-menu.test.ts
@@ -52,6 +52,12 @@ describe('useSlashMenu — update', () => {
     expect(slash.active.value).toBe(0);
   });
 
+  it('lists /usage among built-in commands', () => {
+    const { slash } = setup('/');
+    slash.update();
+    expect(slash.items.value.map((i) => i.name)).toContain('/usage');
+  });
+
   it('filters to matching commands', () => {
     const { slash } = setup('/com');
     slash.update();


### PR DESCRIPTION
## Summary
- Adds `/usage` to the kimi-web slash command menu and handler (fixes #2354).
- Opens the existing status panel (context tokens + session cost), the web equivalent of the TUI usage report.
- Adds en/zh command descriptions and a slash-menu unit test.

## Test plan
- [x] `pnpm --filter @moonshot-ai/kimi-web test` (654 passed)
- [ ] In kimi web, type `/` and confirm `usage` appears; `/usage` opens the status panel

Made with [Cursor](https://cursor.com)