### PR TITLE
feat(tui): expose thinking effort to status line commands

### DIFF
--- a/.changeset/expose-status-line-thinking-effort.md
+++ b/.changeset/expose-status-line-thinking-effort.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Expose the active thinking effort to custom status line commands.

--- a/apps/kimi-code/src/tui/components/chrome/footer.ts
+++ b/apps/kimi-code/src/tui/components/chrome/footer.ts
@@ -443,6 +443,7 @@ export class FooterComponent implements Component {
       gitBranch: this.gitCache.getStatus()?.branch ?? null,
       permissionMode: state.permissionMode,
       planMode: state.planMode,
+      thinkingEffort: state.thinkingEffort,
       contextUsage: state.contextUsage,
       contextTokens: state.contextTokens,
       maxContextTokens: state.maxContextTokens,

--- a/apps/kimi-code/src/tui/utils/status-line-command.ts
+++ b/apps/kimi-code/src/tui/utils/status-line-command.ts
@@ -10,6 +10,8 @@
 
 import { spawn } from 'node:child_process';
 
+import type { ThinkingEffort } from '@moonshot-ai/kimi-code-sdk';
+
 export const STATUS_LINE_COMMAND_TIMEOUT_MS = 300;
 export const STATUS_LINE_RERUN_INTERVAL_MS = 1_000;
 export const STATUS_LINE_MAX_CAPTURE_BYTES = 65_536;
@@ -20,6 +22,7 @@ export interface StatusLinePayload {
   gitBranch: string | null;
   permissionMode: string;
   planMode: boolean;
+  thinkingEffort: ThinkingEffort;
   contextUsage: number;
   contextTokens: number;
   maxContextTokens: number;

--- a/apps/kimi-code/test/tui/components/chrome/footer-status-line.test.ts
+++ b/apps/kimi-code/test/tui/components/chrome/footer-status-line.test.ts
@@ -47,6 +47,7 @@ const payload: StatusLinePayload = {
   gitBranch: 'main',
   permissionMode: 'manual',
   planMode: false,
+  thinkingEffort: 'off',
   contextUsage: 12,
   contextTokens: 1024,
   maxContextTokens: 8192,
@@ -175,6 +176,27 @@ describe('runStatusLineCommand', () => {
 });
 
 describe('FooterComponent status_line command', () => {
+  it('passes the effective thinking effort to the command', async () => {
+    const state: AppState = {
+      ...baseState,
+      thinkingEffort: 'max',
+      statusLine: { items: null, command: 'cat' },
+    };
+    const refreshed = Promise.withResolvers<void>();
+    const footer = new FooterComponent(state, refreshed.resolve);
+
+    try {
+      footer.render(120);
+      await refreshed.promise;
+
+      const renderedPayload = JSON.parse(plain(footer.render(1_000)[0]!));
+      expect(renderedPayload.thinkingEffort).toBe('max');
+    } finally {
+      footer.setState({ ...state, statusLine: { items: null, command: null } });
+      footer.dispose();
+    }
+  });
+
   it('swaps line 1 to the command output once it lands', async () => {
     const state: AppState = {
       ...baseState,

--- a/docs/en/configuration/config-files.md
+++ b/docs/en/configuration/config-files.md
@@ -393,7 +393,7 @@ Alongside `config.toml`, the CLI keeps terminal-UI and client preferences in a c
 | `[notifications].notification_condition` | `string` | `unfocused` | When to notify: `unfocused` (only when the terminal is not focused) or `always` |
 | `[upgrade].auto_install` | `boolean` | `true` | Whether new versions are installed automatically |
 | `[status_line].items` | `string[]` | `[]` | Built-in slots to show on the first footer line and their order: `mode`, `goal`, `model`, `tasks`, `cwd`, `git`, `tips`. Unset keeps the default layout; unknown ids are skipped with a warning |
-| `[status_line].command` | `string` | `""` | Custom status line command. Its first stdout line replaces the first footer line, with a JSON snapshot (model, cwd, git branch, permission mode, plan mode, context usage, session id, version) passed on stdin. Runs are capped at 300ms and throttled to once per second; failures fall back to the built-in layout |
+| `[status_line].command` | `string` | `""` | Custom status line command. Its first stdout line replaces the first footer line, with a JSON snapshot (model, cwd, git branch, permission mode, plan mode, thinking effort, context usage, session id, version) passed on stdin. Runs are capped at 300ms and throttled to once per second; failures fall back to the built-in layout |
 
 ```toml
 # ~/.kimi-code/tui.toml

--- a/docs/zh/configuration/config-files.md
+++ b/docs/zh/configuration/config-files.md
@@ -393,7 +393,7 @@ MCP server 的声明配置写在 `~/.kimi-code/mcp.json` 或项目内 `.kimi-cod
 | `[notifications].notification_condition` | `string` | `unfocused` | 何时通知：`unfocused`（仅终端失去焦点时）或 `always`（总是） |
 | `[upgrade].auto_install` | `boolean` | `true` | 是否自动安装新版本 |
 | `[status_line].items` | `string[]` | `[]` | 底部状态栏第一行展示哪些内置槽位及其顺序：`mode`、`goal`、`model`、`tasks`、`cwd`、`git`、`tips`。缺省保持默认布局；未知 id 跳过并告警 |
-| `[status_line].command` | `string` | `""` | 自定义状态栏命令。其 stdout 第一行替换状态栏第一行，stdin 会收到 JSON 快照（model、cwd、git 分支、permission 模式、plan 模式、上下文用量、session id、版本）。运行上限 300ms、每秒最多一次；失败时回退内置布局 |
+| `[status_line].command` | `string` | `""` | 自定义状态栏命令。其 stdout 第一行替换状态栏第一行，stdin 会收到 JSON 快照（model、cwd、git 分支、permission 模式、plan 模式、思考强度（thinking effort）、上下文用量、session id、版本）。运行上限 300ms、每秒最多一次；失败时回退内置布局 |
 
 ```toml
 # ~/.kimi-code/tui.toml


### PR DESCRIPTION
## Related Issue

Resolve #2394

## Problem

Custom status line commands receive the active model and mode data, but not the effective thinking effort shown by the built-in footer. This prevents scripts from presenting the complete active model configuration.

## What changed

- add the SDK `ThinkingEffort` value to the typed status line payload
- populate it directly from the current TUI application state
- document the JSON field in the English and Chinese configuration references
- add a patch changeset

## Test verification (RED → GREEN)

- RED on the upstream implementation with the regression test: the real `cat` subprocess returned a JSON payload whose `thinkingEffort` was `undefined` instead of `max`
- GREEN after the implementation: `footer-status-line.test.ts` passed all 17 tests
- revert proof: removing the production payload mapping reproduced the same failure, with 16 passing and 1 failing test
- the regression test waits on the component's actual refresh callback and cleans up the command runner in `finally`

Full local suite proof:

- CLI package tests: 185 files passed, 2 skipped; 2,458 tests passed, 5 skipped
- CLI typecheck and full package build passed
- changed-file type-aware lint, workspace consistency, changeset validation, and documentation build passed
- independent PR review passed
- OCR/Codex review passed after replacing a fixed-delay wait with deterministic completion signaling

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.
