### PR TITLE
fix(tui): ignore terminal status responses as input

### DIFF
--- a/.changeset/quiet-terminal-input.md
+++ b/.changeset/quiet-terminal-input.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Prevent terminal status responses from interrupting active turns.

--- a/packages/pi-tui/src/tui.ts
+++ b/packages/pi-tui/src/tui.ts
@@ -17,6 +17,10 @@ import {
 import { getCapabilities, isImageLine, setCellDimensions } from "./terminal-image.ts";
 import { extractSegments, normalizeTerminalOutput, sliceByColumn, sliceWithWidth, visibleWidth } from "./utils.ts";
 
+const TERMINAL_STATUS_RESPONSE_PATTERN =
+	/^(?:\x1b\[\?[\d;]*c|\x1b(?:P.*\x1b\\|_.*\x1b\\))$/s;
+const OSC_STATUS_RESPONSE_PATTERN = /^\x1b\].*(?:\x07|\x1b\\)$/s;
+
 /**
  * Component interface - all components must implement this
  */
@@ -826,6 +830,11 @@ export abstract class TuiBase extends Container implements TUI {
 		if (this.consumeTerminalColorSchemeReport(data)) {
 			return;
 		}
+		// Terminal query replies are control traffic, not keyboard input. Consume
+		// known replies before global listeners can interpret them as user intent.
+		if (this.consumeCellSizeResponse(data) || TERMINAL_STATUS_RESPONSE_PATTERN.test(data)) {
+			return;
+		}
 
 		if (this.inputListeners.size > 0) {
 			let current = data;
@@ -843,9 +852,9 @@ export abstract class TuiBase extends Container implements TUI {
 			}
 			data = current;
 		}
-
-		// Consume terminal cell size responses without blocking unrelated input.
-		if (this.consumeCellSizeResponse(data)) {
+		// OSC reports may be consumed by application listeners (for example,
+		// live theme tracking), but must never fall through to focused input.
+		if (OSC_STATUS_RESPONSE_PATTERN.test(data)) {
 			return;
 		}
 

--- a/packages/pi-tui/test/terminal-colors.test.ts
+++ b/packages/pi-tui/test/terminal-colors.test.ts
@@ -124,6 +124,94 @@ describe("parseTerminalColorSchemeReport", () => {
 });
 
 describe("TUI.queryTerminalBackgroundColor", () => {
+	it("filters non-OSC terminal status responses before application dispatch", () => {
+		const terminal = new TestTerminal();
+		const tui = new TuiMainScreen(terminal);
+		const component = new InputRecorder();
+		const listenerInputs: string[] = [];
+		tui.addChild(component);
+		tui.setFocus(component);
+		tui.addInputListener((data) => {
+			listenerInputs.push(data);
+			return undefined;
+		});
+		tui.start();
+		try {
+			terminal.sendInput("\x1b[6;18;8t");
+			terminal.sendInput("\x1b[?1;2;4c");
+			terminal.sendInput("\x1bP>|XTerm(390)\x1b\\");
+			terminal.sendInput("\x1b_Gi=1;OK\x1b\\");
+
+			assert.deepStrictEqual(listenerInputs, []);
+			assert.deepStrictEqual(component.inputs, []);
+		} finally {
+			tui.stop();
+		}
+	});
+
+	it("lets protocol listeners consume OSC status before focused input", () => {
+		const terminal = new TestTerminal();
+		const tui = new TuiMainScreen(terminal);
+		const component = new InputRecorder();
+		const oscStatusResponse = "\x1b]11;rgb:1515/1919/1e1e\x1b\\";
+		let observedStatus: string | undefined;
+		tui.addChild(component);
+		tui.setFocus(component);
+		tui.addInputListener((data) => {
+			if (data !== oscStatusResponse) return undefined;
+			observedStatus = data;
+			return { consume: true };
+		});
+		tui.start();
+		try {
+			terminal.sendInput(oscStatusResponse);
+
+			assert.equal(observedStatus, oscStatusResponse);
+			assert.deepStrictEqual(component.inputs, []);
+		} finally {
+			tui.stop();
+		}
+	});
+
+	it("filters unhandled OSC status before focused input", () => {
+		const terminal = new TestTerminal();
+		const tui = new TuiMainScreen(terminal);
+		const component = new InputRecorder();
+		tui.addChild(component);
+		tui.setFocus(component);
+		tui.start();
+		try {
+			terminal.sendInput("\x1b]11;rgb:1515/1919/1e1e\x1b\\");
+
+			assert.deepStrictEqual(component.inputs, []);
+		} finally {
+			tui.stop();
+		}
+	});
+
+	it("preserves keyboard and mouse input after filtering terminal status responses", () => {
+		const terminal = new TestTerminal();
+		const tui = new TuiMainScreen(terminal);
+		const component = new InputRecorder();
+		const listenerInputs: string[] = [];
+		tui.addChild(component);
+		tui.setFocus(component);
+		tui.addInputListener((data) => {
+			listenerInputs.push(data);
+			return undefined;
+		});
+		tui.start();
+		try {
+			const inputSequences = ["a", "\x1b[<0;10;5M", "\x1b[97u"];
+			for (const input of inputSequences) terminal.sendInput(input);
+
+			assert.deepStrictEqual(listenerInputs, inputSequences);
+			assert.deepStrictEqual(component.inputs, inputSequences);
+		} finally {
+			tui.stop();
+		}
+	});
+
 	it("writes OSC 11 query and resolves with the parsed RGB reply", async () => {
 		const terminal = new TestTerminal();
 		const tui: TUI = new TuiMainScreen(terminal);


### PR DESCRIPTION
## Related Issue

Resolve #2181

## Problem

Terminal query replies such as cell-size, device-attribute, DCS, APC, and OSC reports were routed as keyboard input. During an active turn, those control responses could be interpreted as user activity and interrupt the turn.

## What changed

- consume non-OSC terminal status replies before application input listeners;
- preserve OSC reports for protocol listeners such as live theme tracking, while preventing unhandled reports from reaching the focused component;
- keep ordinary keyboard, SGR mouse, and Kitty keyboard input unchanged;
- add patch changesets for pi-tui and kimi-code.

## Test verification (RED → GREEN)

- RED on the unpatched upstream path: exact cell-size (`ESC[6;18;8t`), OSC, and device-attribute (`ESC[?1;2;4c`) responses reached application/focused input handlers.
- GREEN after the patch: four regression scenarios cover non-OSC filtering, listener-consumed OSC, unhandled OSC filtering, and preservation of keyboard/mouse/Kitty input.
- Full local suite proof on Node 24.15.0:
  - clean pi-tui baseline: 715/715 passing;
  - patched pi-tui suite: 719/719 passing, 0 skipped, 0 failed;
  - patched kimi-code suite: 2,457 passing, 5 pre-existing skips, 0 failed across 187 files;
  - pi-tui typecheck/build, changed-file lint, sherif, changeset validation, and diff checks pass.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.
