### PR TITLE
fix: time out stalled LLM streams

### DIFF
--- a/.changeset/fix-stalled-llm-streams.md
+++ b/.changeset/fix-stalled-llm-streams.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Fail and retry LLM streams that stop producing data instead of waiting indefinitely.

--- a/packages/agent-core-v2/src/kosong/contract/errors.ts
+++ b/packages/agent-core-v2/src/kosong/contract/errors.ts
@@ -65,6 +65,30 @@ export class APITimeoutError extends ChatProviderError {
   }
 }
 
+export class StreamIdleTimeoutError extends APITimeoutError {
+  readonly idleTimeoutMs: number;
+  readonly elapsedMs: number;
+  readonly traceId: string | null;
+
+  constructor(
+    providerName: string,
+    modelName: string,
+    idleTimeoutMs: number,
+    elapsedMs: number,
+    traceId: string | null,
+  ) {
+    const traceHint = traceId === null ? '' : `, traceId: ${traceId}`;
+    super(
+      `LLM stream stalled for ${idleTimeoutMs}ms ` +
+        `(provider: ${providerName}, model: ${modelName}, elapsedMs: ${elapsedMs}${traceHint}).`,
+    );
+    this.name = 'StreamIdleTimeoutError';
+    this.idleTimeoutMs = idleTimeoutMs;
+    this.elapsedMs = elapsedMs;
+    this.traceId = traceId;
+  }
+}
+
 export class APIStatusError extends ChatProviderError {
   readonly statusCode: number;
   readonly requestId: string | null;

--- a/packages/agent-core-v2/src/kosong/contract/generate.ts
+++ b/packages/agent-core-v2/src/kosong/contract/generate.ts
@@ -1,4 +1,4 @@
-import { APIEmptyResponseError, createAbortError } from './errors';
+import { APIEmptyResponseError, createAbortError, StreamIdleTimeoutError } from './errors';
 import {
   isContentPart,
   isToolCall,
@@ -13,6 +13,7 @@ import type { Tool } from './tool';
 import type { TokenUsage } from './usage';
 
 type StoredToolCall = Omit<ToolCall, '_streamIndex'>;
+const DEFAULT_STREAM_IDLE_TIMEOUT_MS = 180_000;
 
 export interface GenerateResult {
   readonly id: string | null;
@@ -49,8 +50,17 @@ export async function generate(
     ? tools.filter((tool) => tool.deferred !== true)
     : tools;
 
+  const idleTimeoutMs = resolveStreamIdleTimeoutMs(options?.streamIdleTimeoutMs);
+  const watchdog = new AbortController();
+  const providerSignal =
+    options?.signal === undefined
+      ? watchdog.signal
+      : AbortSignal.any([options.signal, watchdog.signal]);
+  const providerOptions: GenerateOptions = { ...options, signal: providerSignal };
+  delete providerOptions.streamIdleTimeoutMs;
+
   options?.onRequestStart?.();
-  const stream = await provider.generate(systemPrompt, wireTools, history, options);
+  const stream = await provider.generate(systemPrompt, wireTools, history, providerOptions);
   if (stream.traceId !== undefined) {
     options?.onTraceId?.(stream.traceId);
   }
@@ -62,7 +72,13 @@ export async function generate(
   let firstPartAt: number | undefined;
   let lastResumeAt = 0;
 
-  for await (const part of stream) {
+  for await (const part of withStreamIdleTimeout(
+    stream,
+    provider,
+    watchdog,
+    options?.signal,
+    idleTimeoutMs,
+  )) {
     const arrivedAt = Date.now();
     if (firstPartAt === undefined) {
       firstPartAt = arrivedAt;
@@ -175,16 +191,99 @@ type CancelableStream = StreamedMessage & {
   return?: () => unknown;
 };
 
-async function cancelStream(stream: StreamedMessage): Promise<void> {
+function settleWithoutWaiting(action: () => unknown): void {
+  try {
+    void Promise.resolve(action()).catch(() => {});
+  } catch {}
+}
+
+function abandonStream(stream: StreamedMessage): void {
   const cancelable = stream as CancelableStream;
+  settleWithoutWaiting(() => cancelable.cancel?.());
+  settleWithoutWaiting(() => cancelable.return?.());
+}
+
+function resolveStreamIdleTimeoutMs(value?: number): number {
+  return value !== undefined && Number.isFinite(value) && value > 0
+    ? value
+    : DEFAULT_STREAM_IDLE_TIMEOUT_MS;
+}
+
+async function* withStreamIdleTimeout(
+  stream: StreamedMessage,
+  provider: ChatProvider,
+  watchdog: AbortController,
+  callerSignal: AbortSignal | undefined,
+  idleTimeoutMs: number,
+): AsyncGenerator<StreamedMessagePart> {
+  const iterator = stream[Symbol.asyncIterator]();
+  const startedAt = Date.now();
+  let completed = false;
 
   try {
-    await cancelable.cancel?.();
-  } catch {}
+    while (true) {
+      const next = iterator.next();
+      let timer: ReturnType<typeof setTimeout> | undefined;
+      let onCallerAbort: (() => void) | undefined;
+      const timeout = new Promise<never>((_, reject) => {
+        timer = setTimeout(() => {
+          reject(
+            new StreamIdleTimeoutError(
+              provider.name,
+              provider.modelName,
+              idleTimeoutMs,
+              Date.now() - startedAt,
+              stream.traceId ?? null,
+            ),
+          );
+        }, idleTimeoutMs);
+      });
+      const callerAbort =
+        callerSignal === undefined
+          ? undefined
+          : new Promise<never>((_, reject) => {
+              onCallerAbort = () => reject(createAbortError());
+              if (callerSignal.aborted) {
+                onCallerAbort();
+              } else {
+                callerSignal.addEventListener('abort', onCallerAbort, { once: true });
+              }
+            });
 
-  try {
-    await cancelable.return?.();
-  } catch {}
+      try {
+        const result =
+          callerAbort === undefined
+            ? await Promise.race([next, timeout])
+            : await Promise.race([next, timeout, callerAbort]);
+        if (result.done === true) {
+          completed = true;
+          return;
+        }
+        yield result.value;
+      } catch (error) {
+        if (callerSignal?.aborted) {
+          next.catch(() => {});
+          abandonStream(stream);
+          throw createAbortError();
+        }
+        if (error instanceof StreamIdleTimeoutError) {
+          next.catch(() => {});
+          watchdog.abort(error);
+          abandonStream(stream);
+        }
+        throw error;
+      } finally {
+        clearTimeout(timer);
+        if (onCallerAbort !== undefined) {
+          callerSignal?.removeEventListener('abort', onCallerAbort);
+        }
+      }
+    }
+  } finally {
+    if (!completed) {
+      settleWithoutWaiting(() => iterator.return?.());
+    }
+  }
 }
 
 async function throwIfAborted(signal?: AbortSignal, stream?: StreamedMessage): Promise<void> {
@@ -193,7 +292,7 @@ async function throwIfAborted(signal?: AbortSignal, stream?: StreamedMessage): P
   }
 
   if (stream !== undefined) {
-    await cancelStream(stream);
+    abandonStream(stream);
   }
 
   throw createAbortError();

--- a/packages/agent-core-v2/src/kosong/contract/provider.ts
+++ b/packages/agent-core-v2/src/kosong/contract/provider.ts
@@ -72,6 +72,7 @@ export interface VideoUploadInput {
 
 export interface GenerateOptions {
   signal?: AbortSignal;
+  streamIdleTimeoutMs?: number;
   auth?: ProviderRequestAuth;
   responseFormat?: ResponseFormat;
   cacheKey?: string;

--- a/packages/agent-core-v2/test/kosong/contract/generate.test.ts
+++ b/packages/agent-core-v2/test/kosong/contract/generate.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it, vi } from 'vitest';
 
-import { APIEmptyResponseError, isRetryableGenerateError } from '#/kosong/contract/errors';
+import {
+  APIEmptyResponseError,
+  isRetryableGenerateError,
+  StreamIdleTimeoutError,
+} from '#/kosong/contract/errors';
 import { generate, type GenerateResult } from '#/kosong/contract/generate';
 import type { Message, StreamedMessagePart, ToolCall } from '#/kosong/contract/message';
 import type {
@@ -45,6 +49,49 @@ class FakeStreamedMessage implements StreamedMessage {
   cancel(): void {
     this.cancelCalls++;
   }
+}
+
+function createStalledStream(
+  options: {
+    traceId?: string | null;
+    stallBeforeFirst?: boolean;
+    onStall?: () => void;
+    cancel?: () => unknown;
+    iteratorReturn?: () => Promise<IteratorResult<StreamedMessagePart>>;
+  } = {},
+): StreamedMessage {
+  let first = true;
+  const stream: StreamedMessage & { cancel(): unknown } = {
+    id: 'stalled-1',
+    usage: null,
+    finishReason: null,
+    rawFinishReason: null,
+    traceId: options.traceId,
+    cancel: () => options.cancel?.(),
+    [Symbol.asyncIterator]() {
+      return {
+        next(): Promise<IteratorResult<StreamedMessagePart>> {
+          if (first) {
+            first = false;
+            if (options.stallBeforeFirst !== true) {
+              return Promise.resolve({
+                done: false,
+                value: { type: 'think', think: 'partial' },
+              });
+            }
+          }
+          options.onStall?.();
+          return new Promise<never>(() => {});
+        },
+        return(): Promise<IteratorResult<StreamedMessagePart>> {
+          return (
+            options.iteratorReturn?.() ?? Promise.resolve({ done: true, value: undefined })
+          );
+        },
+      };
+    },
+  };
+  return stream;
 }
 
 interface FakeProvider {
@@ -305,6 +352,103 @@ describe('generate() abort contract', () => {
   });
 });
 
+describe('generate() stream idle deadline', () => {
+  it('throws a retryable stream timeout when no part arrives before the idle deadline', async () => {
+    const stream = createStalledStream({ traceId: 'trace-stalled' });
+    const { provider } = createFakeProvider(stream);
+    let caught: unknown;
+
+    try {
+      await generate(provider, SYSTEM_PROMPT, NO_TOOLS, HISTORY, undefined, {
+        streamIdleTimeoutMs: 10,
+      });
+    } catch (error) {
+      caught = error;
+    }
+
+    expect(caught).toBeInstanceOf(StreamIdleTimeoutError);
+    expect(caught).toMatchObject({
+      idleTimeoutMs: 10,
+      traceId: 'trace-stalled',
+    });
+    expect(isRetryableGenerateError(caught)).toBe(true);
+  });
+
+  it('throws a stream timeout when the first streamed part never arrives', async () => {
+    const stream = createStalledStream({ stallBeforeFirst: true });
+    const { provider } = createFakeProvider(stream);
+
+    await expect(
+      generate(provider, SYSTEM_PROMPT, NO_TOOLS, HISTORY, undefined, {
+        streamIdleTimeoutMs: 10,
+      }),
+    ).rejects.toBeInstanceOf(StreamIdleTimeoutError);
+  });
+
+  it('does not forward the stream idle deadline to the provider', async () => {
+    const stream = new FakeStreamedMessage([{ type: 'text', text: 'ok' }]);
+    const { provider, generateSpy } = createFakeProvider(stream);
+
+    await generate(provider, SYSTEM_PROMPT, NO_TOOLS, HISTORY, undefined, {
+      streamIdleTimeoutMs: 10,
+    });
+
+    expect(generateSpy.mock.calls[0]?.[3]).not.toHaveProperty('streamIdleTimeoutMs');
+  });
+
+  it('aborts the provider signal when the stream idle deadline expires', async () => {
+    const { provider, generateSpy } = createFakeProvider(createStalledStream());
+
+    await expect(
+      generate(provider, SYSTEM_PROMPT, NO_TOOLS, HISTORY, undefined, {
+        streamIdleTimeoutMs: 10,
+      }),
+    ).rejects.toBeInstanceOf(StreamIdleTimeoutError);
+
+    const providerOptions = generateSpy.mock.calls[0]?.[3] as GenerateOptions | undefined;
+    expect(providerOptions?.signal?.aborted).toBe(true);
+    expect(providerOptions?.signal?.reason).toBeInstanceOf(StreamIdleTimeoutError);
+  });
+
+  it('reports a stream timeout without waiting for stalled cleanup', async () => {
+    const cancel = vi.fn(() => new Promise<never>(() => {}));
+    const iteratorReturn = vi.fn(
+      () => new Promise<IteratorResult<StreamedMessagePart>>(() => {}),
+    );
+    const stream = createStalledStream({ cancel, iteratorReturn });
+    const { provider } = createFakeProvider(stream);
+
+    await expect(
+      generate(provider, SYSTEM_PROMPT, NO_TOOLS, HISTORY, undefined, {
+        streamIdleTimeoutMs: 10,
+      }),
+    ).rejects.toBeInstanceOf(StreamIdleTimeoutError);
+
+    expect(cancel).toHaveBeenCalledOnce();
+    expect(iteratorReturn).toHaveBeenCalledOnce();
+  });
+
+  it('throws AbortError when the caller aborts while the stream is stalled', async () => {
+    const controller = new AbortController();
+    const stream = createStalledStream({ onStall: () => controller.abort() });
+    const { provider } = createFakeProvider(stream);
+    let caught: unknown;
+
+    try {
+      await generate(provider, SYSTEM_PROMPT, NO_TOOLS, HISTORY, undefined, {
+        signal: controller.signal,
+        streamIdleTimeoutMs: 10,
+      });
+    } catch (error) {
+      caught = error;
+    }
+
+    expect(caught).toBeInstanceOf(DOMException);
+    expect((caught as DOMException).name).toBe('AbortError');
+    expect(isRetryableGenerateError(caught)).toBe(false);
+  });
+});
+
 describe('generate() per-turn intent passthrough', () => {
   it('passes the GenerateOptions intent fields through to the provider', async () => {
     const stream = new FakeStreamedMessage([{ type: 'text', text: 'ok' }]);
@@ -321,6 +465,7 @@ describe('generate() per-turn intent passthrough', () => {
     await generate(provider, SYSTEM_PROMPT, NO_TOOLS, HISTORY, undefined, options);
 
     expect(generateSpy).toHaveBeenCalledTimes(1);
-    expect(generateSpy.mock.calls[0]?.[3]).toBe(options);
+    expect(generateSpy.mock.calls[0]?.[3]).toMatchObject(options);
+    expect(generateSpy.mock.calls[0]?.[3]?.signal).toBeInstanceOf(AbortSignal);
   });
 });

--- a/packages/kosong/src/errors.ts
+++ b/packages/kosong/src/errors.ts
@@ -31,6 +31,33 @@ export class APITimeoutError extends ChatProviderError {
 }
 
 /**
+ * A provider stream stopped producing parts before its idle deadline.
+ */
+export class StreamIdleTimeoutError extends APITimeoutError {
+  readonly idleTimeoutMs: number;
+  readonly elapsedMs: number;
+  readonly traceId: string | null;
+
+  constructor(
+    providerName: string,
+    modelName: string,
+    idleTimeoutMs: number,
+    elapsedMs: number,
+    traceId: string | null,
+  ) {
+    const traceHint = traceId === null ? '' : `, traceId: ${traceId}`;
+    super(
+      `LLM stream stalled for ${idleTimeoutMs}ms ` +
+        `(provider: ${providerName}, model: ${modelName}, elapsedMs: ${elapsedMs}${traceHint}).`,
+    );
+    this.name = 'StreamIdleTimeoutError';
+    this.idleTimeoutMs = idleTimeoutMs;
+    this.elapsedMs = elapsedMs;
+    this.traceId = traceId;
+  }
+}
+
+/**
  * HTTP status error from the API.
  */
 export class APIStatusError extends ChatProviderError {

--- a/packages/kosong/src/generate.ts
+++ b/packages/kosong/src/generate.ts
@@ -1,4 +1,4 @@
-import { APIEmptyResponseError } from './errors';
+import { APIEmptyResponseError, StreamIdleTimeoutError } from './errors';
 import {
   isContentPart,
   isToolCall,
@@ -14,6 +14,7 @@ import type { TokenUsage } from './usage';
 
 /** Snapshot of a ToolCall excluding the internal `_streamIndex` routing field. */
 type StoredToolCall = Omit<ToolCall, '_streamIndex'>;
+const DEFAULT_STREAM_IDLE_TIMEOUT_MS = 180_000;
 
 /**
  * The result of a single {@link generate} call.
@@ -116,8 +117,17 @@ export async function generate(
     ? tools.filter((tool) => tool.deferred !== true)
     : tools;
 
+  const idleTimeoutMs = resolveStreamIdleTimeoutMs(options?.streamIdleTimeoutMs);
+  const watchdog = new AbortController();
+  const providerSignal =
+    options?.signal === undefined
+      ? watchdog.signal
+      : AbortSignal.any([options.signal, watchdog.signal]);
+  const providerOptions: GenerateOptions = { ...options, signal: providerSignal };
+  delete providerOptions.streamIdleTimeoutMs;
+
   options?.onRequestStart?.();
-  const stream = await provider.generate(systemPrompt, wireTools, history, options);
+  const stream = await provider.generate(systemPrompt, wireTools, history, providerOptions);
   // Early capture: the trace id arrives with the response headers, before the
   // stream body — and before any mid-stream abort — so hosts can attribute
   // even a cancelled stream to its server-side request.
@@ -142,7 +152,13 @@ export async function generate(
   let firstPartAt: number | undefined;
   let lastResumeAt = 0;
 
-  for await (const part of stream) {
+  for await (const part of withStreamIdleTimeout(
+    stream,
+    provider,
+    watchdog,
+    options?.signal,
+    idleTimeoutMs,
+  )) {
     const arrivedAt = Date.now();
     if (firstPartAt === undefined) {
       firstPartAt = arrivedAt;
@@ -270,20 +286,107 @@ type CancelableStream = StreamedMessage & {
   return?: () => unknown;
 };
 
-function throwAbortError(): never {
-  throw new DOMException('The operation was aborted.', 'AbortError');
+function createAbortError(): DOMException {
+  return new DOMException('The operation was aborted.', 'AbortError');
 }
 
-async function cancelStream(stream: StreamedMessage): Promise<void> {
+function throwAbortError(): never {
+  throw createAbortError();
+}
+
+function settleWithoutWaiting(action: () => unknown): void {
+  try {
+    void Promise.resolve(action()).catch(() => {});
+  } catch {}
+}
+
+function abandonStream(stream: StreamedMessage): void {
   const cancelable = stream as CancelableStream;
+  settleWithoutWaiting(() => cancelable.cancel?.());
+  settleWithoutWaiting(() => cancelable.return?.());
+}
+
+function resolveStreamIdleTimeoutMs(value?: number): number {
+  return value !== undefined && Number.isFinite(value) && value > 0
+    ? value
+    : DEFAULT_STREAM_IDLE_TIMEOUT_MS;
+}
+
+async function* withStreamIdleTimeout(
+  stream: StreamedMessage,
+  provider: ChatProvider,
+  watchdog: AbortController,
+  callerSignal: AbortSignal | undefined,
+  idleTimeoutMs: number,
+): AsyncGenerator<StreamedMessagePart> {
+  const iterator = stream[Symbol.asyncIterator]();
+  const startedAt = Date.now();
+  let completed = false;
 
   try {
-    await cancelable.cancel?.();
-  } catch {}
+    while (true) {
+      const next = iterator.next();
+      let timer: ReturnType<typeof setTimeout> | undefined;
+      let onCallerAbort: (() => void) | undefined;
+      const timeout = new Promise<never>((_, reject) => {
+        timer = setTimeout(() => {
+          reject(
+            new StreamIdleTimeoutError(
+              provider.name,
+              provider.modelName,
+              idleTimeoutMs,
+              Date.now() - startedAt,
+              stream.traceId ?? null,
+            ),
+          );
+        }, idleTimeoutMs);
+      });
+      const callerAbort =
+        callerSignal === undefined
+          ? undefined
+          : new Promise<never>((_, reject) => {
+              onCallerAbort = () => reject(createAbortError());
+              if (callerSignal.aborted) {
+                onCallerAbort();
+              } else {
+                callerSignal.addEventListener('abort', onCallerAbort, { once: true });
+              }
+            });
 
-  try {
-    await cancelable.return?.();
-  } catch {}
+      try {
+        const result =
+          callerAbort === undefined
+            ? await Promise.race([next, timeout])
+            : await Promise.race([next, timeout, callerAbort]);
+        if (result.done === true) {
+          completed = true;
+          return;
+        }
+        yield result.value;
+      } catch (error) {
+        if (callerSignal?.aborted) {
+          next.catch(() => {});
+          abandonStream(stream);
+          throw createAbortError();
+        }
+        if (error instanceof StreamIdleTimeoutError) {
+          next.catch(() => {});
+          watchdog.abort(error);
+          abandonStream(stream);
+        }
+        throw error;
+      } finally {
+        clearTimeout(timer);
+        if (onCallerAbort !== undefined) {
+          callerSignal?.removeEventListener('abort', onCallerAbort);
+        }
+      }
+    }
+  } finally {
+    if (!completed) {
+      settleWithoutWaiting(() => iterator.return?.());
+    }
+  }
 }
 
 async function throwIfAborted(signal?: AbortSignal, stream?: StreamedMessage): Promise<void> {
@@ -292,7 +395,7 @@ async function throwIfAborted(signal?: AbortSignal, stream?: StreamedMessage): P
   }
 
   if (stream !== undefined) {
-    await cancelStream(stream);
+    abandonStream(stream);
   }
 
   throwAbortError();

--- a/packages/kosong/src/index.ts
+++ b/packages/kosong/src/index.ts
@@ -86,6 +86,7 @@ export {
   isRequestTooLargeStatusError,
   isRetryableGenerateError,
   isToolExchangeAdjacencyError,
+  StreamIdleTimeoutError,
   throwIfAbortError,
 } from './errors';
 

--- a/packages/kosong/src/provider.ts
+++ b/packages/kosong/src/provider.ts
@@ -137,8 +137,13 @@ export interface GenerateOptions {
    * to their underlying HTTP client; the generate loop in
    * {@link generate | generate()} also checks the signal between streamed
    * parts.
-   */
+  */
   signal?: AbortSignal;
+  /**
+   * Maximum time to wait for the next streamed part after response headers
+   * arrive. Invalid values fall back to the default three-minute deadline.
+   */
+  streamIdleTimeoutMs?: number;
   /**
    * Request-scoped provider auth. Hosts should resolve this immediately before
    * each request/retry so providers never retain mutable credential state.

--- a/packages/kosong/test/generate.test.ts
+++ b/packages/kosong/test/generate.test.ts
@@ -1,7 +1,16 @@
-import { APIEmptyResponseError, isRetryableGenerateError } from '#/errors';
+import {
+  APIEmptyResponseError,
+  isRetryableGenerateError,
+  StreamIdleTimeoutError,
+} from '#/errors';
 import { generate } from '#/generate';
 import type { Message, StreamedMessagePart, ToolCall } from '#/message';
-import type { ChatProvider, StreamedMessage, ThinkingEffort } from '#/provider';
+import type {
+  ChatProvider,
+  GenerateOptions,
+  StreamedMessage,
+  ThinkingEffort,
+} from '#/provider';
 import type { Tool } from '#/tool';
 import type { TokenUsage } from '#/usage';
 import { describe, expect, it, vi } from 'vitest';
@@ -31,7 +40,10 @@ function createMockStream(
   };
 }
 
-function createMockProvider(stream: StreamedMessage): ChatProvider {
+function createMockProvider(
+  stream: StreamedMessage,
+  onGenerate?: (options?: GenerateOptions) => void,
+): ChatProvider {
   return {
     name: 'mock',
     modelName: 'mock-model',
@@ -40,12 +52,60 @@ function createMockProvider(stream: StreamedMessage): ChatProvider {
       _systemPrompt: string,
       _tools: Tool[],
       _history: Message[],
-    ): Promise<StreamedMessage> => stream,
+      options?: GenerateOptions,
+    ): Promise<StreamedMessage> => {
+      onGenerate?.(options);
+      return stream;
+    },
     withThinking(_effort: ThinkingEffort): ChatProvider {
       return this;
     },
   };
 }
+
+function createStalledStream(
+  options: {
+    traceId?: string | null;
+    stallBeforeFirst?: boolean;
+    onStall?: () => void;
+    cancel?: () => unknown;
+    iteratorReturn?: () => Promise<IteratorResult<StreamedMessagePart>>;
+  } = {},
+): StreamedMessage {
+  let first = true;
+  const stream: StreamedMessage & { cancel(): unknown } = {
+    id: 'stalled-1',
+    usage: null,
+    finishReason: null,
+    rawFinishReason: null,
+    traceId: options.traceId,
+    cancel: () => options.cancel?.(),
+    [Symbol.asyncIterator]() {
+      return {
+        next(): Promise<IteratorResult<StreamedMessagePart>> {
+          if (first) {
+            first = false;
+            if (options.stallBeforeFirst !== true) {
+              return Promise.resolve({
+                done: false,
+                value: { type: 'think', think: 'partial' },
+              });
+            }
+          }
+          options.onStall?.();
+          return new Promise<never>(() => {});
+        },
+        return(): Promise<IteratorResult<StreamedMessagePart>> {
+          return (
+            options.iteratorReturn?.() ?? Promise.resolve({ done: true, value: undefined })
+          );
+        },
+      };
+    },
+  };
+  return stream;
+}
+
 describe('generate()', () => {
   it('omits trace metadata when the provider does not expose it', async () => {
     const onTraceId = vi.fn();
@@ -892,6 +952,100 @@ describe('generate()', () => {
     ).rejects.toMatchObject({ name: 'AbortError' });
 
     expect(cancel).toHaveBeenCalledTimes(1);
+  });
+
+  it('throws a retryable stream timeout when no part arrives before the idle deadline', async () => {
+    const stream = createStalledStream({ traceId: 'trace-stalled' });
+    let caught: unknown;
+
+    try {
+      await generate(createMockProvider(stream), '', [], [], undefined, {
+        streamIdleTimeoutMs: 10,
+      });
+    } catch (error) {
+      caught = error;
+    }
+
+    expect(caught).toBeInstanceOf(StreamIdleTimeoutError);
+    expect(caught).toMatchObject({
+      idleTimeoutMs: 10,
+      traceId: 'trace-stalled',
+    });
+    expect(isRetryableGenerateError(caught)).toBe(true);
+  });
+
+  it('throws a stream timeout when the first streamed part never arrives', async () => {
+    const stream = createStalledStream({ stallBeforeFirst: true });
+
+    await expect(
+      generate(createMockProvider(stream), '', [], [], undefined, {
+        streamIdleTimeoutMs: 10,
+      }),
+    ).rejects.toBeInstanceOf(StreamIdleTimeoutError);
+  });
+
+  it('does not forward the stream idle deadline to the provider', async () => {
+    let providerOptions: GenerateOptions | undefined;
+    const provider = createMockProvider(
+      createMockStream([{ type: 'text', text: 'ok' }]),
+      (options) => {
+        providerOptions = options;
+      },
+    );
+
+    await generate(provider, '', [], [], undefined, { streamIdleTimeoutMs: 10 });
+
+    expect(providerOptions).not.toHaveProperty('streamIdleTimeoutMs');
+  });
+
+  it('aborts the provider signal when the stream idle deadline expires', async () => {
+    let providerSignal: AbortSignal | undefined;
+    const provider = createMockProvider(createStalledStream(), (options) => {
+      providerSignal = options?.signal;
+    });
+
+    await expect(
+      generate(provider, '', [], [], undefined, { streamIdleTimeoutMs: 10 }),
+    ).rejects.toBeInstanceOf(StreamIdleTimeoutError);
+
+    expect(providerSignal?.aborted).toBe(true);
+    expect(providerSignal?.reason).toBeInstanceOf(StreamIdleTimeoutError);
+  });
+
+  it('reports a stream timeout without waiting for stalled cleanup', async () => {
+    const cancel = vi.fn(() => new Promise<never>(() => {}));
+    const iteratorReturn = vi.fn(
+      () => new Promise<IteratorResult<StreamedMessagePart>>(() => {}),
+    );
+    const stream = createStalledStream({ cancel, iteratorReturn });
+
+    await expect(
+      generate(createMockProvider(stream), '', [], [], undefined, {
+        streamIdleTimeoutMs: 10,
+      }),
+    ).rejects.toBeInstanceOf(StreamIdleTimeoutError);
+
+    expect(cancel).toHaveBeenCalledOnce();
+    expect(iteratorReturn).toHaveBeenCalledOnce();
+  });
+
+  it('throws AbortError when the caller aborts while the stream is stalled', async () => {
+    const controller = new AbortController();
+    const stream = createStalledStream({ onStall: () => controller.abort() });
+    let caught: unknown;
+
+    try {
+      await generate(createMockProvider(stream), '', [], [], undefined, {
+        signal: controller.signal,
+        streamIdleTimeoutMs: 10,
+      });
+    } catch (error) {
+      caught = error;
+    }
+
+    expect(caught).toBeInstanceOf(DOMException);
+    expect((caught as DOMException).name).toBe('AbortError');
+    expect(isRetryableGenerateError(caught)).toBe(false);
   });
 
   it('onToolCall receives tool calls in message order', async () => {


### PR DESCRIPTION
## Related Issue

Related to #1798.

Supersedes #1799.

## Problem

Provider request timeouts stop protecting the call after response headers arrive. If the streamed response then stops producing normalized message parts, `generate()` can remain blocked in `iterator.next()` indefinitely. Existing abort checks only run between parts, so they cannot recover a turn from this state.

## What changed

- Add a per-call `streamIdleTimeoutMs` driver option with a three-minute default in both current generation contracts.
- Race every streamed `iterator.next()` against the idle deadline and the caller abort signal, covering the first part, subsequent parts, and stream completion.
- Abort the provider transport through a merged signal and throw a retryable `StreamIdleTimeoutError` with provider, model, elapsed-time, and trace metadata.
- Keep caller cancellation as the standard non-retryable `AbortError`.
- Perform stream and iterator cleanup on a best-effort basis without awaiting provider cleanup promises that may also be stalled.
- Strip the driver-only idle deadline before forwarding options to provider adapters.
- Add contract tests for first-part and inter-part stalls, retry classification, transport abort, non-blocking cleanup, caller abort precedence, and option forwarding.
- Export the new error from the `@moonshot-ai/kosong` root entry and add a CLI patch changeset.

No environment variable or new user-facing configuration surface is introduced, so the documentation audit found no user documentation update to make.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.
