### PR TITLE
fix(web): missing cache headers for web UI static assets

### DIFF
--- a/.changeset/web-assets-cache-headers.md
+++ b/.changeset/web-assets-cache-headers.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+web: Serve hashed static assets with long-lived immutable cache headers so repeat visits load faster.

--- a/packages/kap-server/src/routes/webAssets.ts
+++ b/packages/kap-server/src/routes/webAssets.ts
@@ -1,6 +1,6 @@
 import { createReadStream } from 'node:fs';
 import { stat } from 'node:fs/promises';
-import { extname, join, normalize, resolve, sep } from 'node:path';
+import { extname, join, normalize, relative, resolve, sep } from 'node:path';
 
 import type { FastifyReply, FastifyRequest } from 'fastify';
 
@@ -57,7 +57,17 @@ async function serveWebAsset(
   return reply
     .type(mimeType(filePath))
     .header('Content-Length', String(fileInfo.size))
+    .header('Cache-Control', cacheControl(assetsDir, filePath))
     .send(createReadStream(filePath));
+}
+
+// Vite emits content-hashed files under `assets/` — cache them forever.
+// Everything else (index.html, SPA fallback, favicon, ...) must revalidate.
+function cacheControl(assetsDir: string, filePath: string): string {
+  const rel = relative(resolve(assetsDir), filePath);
+  return rel.startsWith(`assets${sep}`)
+    ? 'public, max-age=31536000, immutable'
+    : 'no-cache';
 }
 
 async function resolveStaticFile(


### PR DESCRIPTION
## Related Issue

No linked issue — the problem is explained below.

## Problem

The web UI's static assets (served by kap-server's web-assets routes) are sent with only `Content-Type` and `Content-Length` — no `Cache-Control`, no `ETag`, no `Last-Modified`. Browsers therefore receive no caching guidance at all and fall back to per-browser heuristic caching, so repeat visits to `kimi web` re-download JS/CSS bundles unnecessarily (or behave inconsistently across browsers).

## What changed

One focused change in `packages/kap-server/src/routes/webAssets.ts`: `serveWebAsset` now stamps a `Cache-Control` header based on the file's location relative to the assets root:

- **`assets/` files** (Vite's content-hashed build output, e.g. `index-abc123.js`) → `Cache-Control: public, max-age=31536000, immutable`. Content changes produce a new filename/URL, so caching them for a year is safe. This is the actual win: repeat visits load JS/CSS/fonts straight from disk cache with zero network requests, including on manual refresh (`immutable`).
- **Everything else** (`index.html`, SPA fallback responses, favicon, ...) → `Cache-Control: no-cache`. The entry document must be revalidated every load so a new release is picked up immediately and starts referencing the new hashed assets.

This is the standard "entry no-cache + hashed assets immutable" deployment pattern; the distinction is trivially reliable here because Vite always emits hashed files under `dist/assets/`.

## Measured benefit

Built the real web UI (`apps/kimi-web` → dist) and served it through this route twice — once with the old code, once with the new — in a real Chrome instance, measuring transferred bytes via the Resource Timing API:

| | cold load | refresh (warm) |
|---|---|---|
| before | 2.03 MB | **2.03 MB** — every byte re-downloaded, nothing cached |
| after | 2.03 MB | **20.8 KB** — main bundle (1.53 MB), CSS (360 KB), and fonts (114 KB) all served from disk cache with zero requests |

So each repeat visit / refresh saves ~2 MB of transfer (~99% reduction; larger over the wire than these uncompressed localhost numbers since the same applies to gzipped bodies). Load time on localhost is dominated by other factors, but on any real network the difference is proportionally larger.

The remaining ~20 KB on warm loads is the `index.html` revalidation plus the root-level `favicon.ico` (17 KB, intentionally `no-cache`); adding ETag/304 support for root files could shrink that further but is out of scope here.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [ ] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.
