### PR TITLE
fix(vscode): support reviewing question answers

### DIFF
--- a/.changeset/vscode-question-dialog-review.md
+++ b/.changeset/vscode-question-dialog-review.md
@@ -1,0 +1,5 @@
+---
+"kimi-code": patch
+---
+
+Let VS Code users select multiple answers, revisit earlier questions, and review the final answer before submitting AskUserQuestion prompts.

--- a/apps/vscode/test/question-dialog.test.tsx
+++ b/apps/vscode/test/question-dialog.test.tsx
@@ -1,0 +1,106 @@
+// @vitest-environment jsdom
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { QuestionDialog } from "../webview-ui/src/components/QuestionDialog";
+
+const store = vi.hoisted(() => ({
+  pendingQuestion: {
+    id: "question-1",
+    tool_call_id: "tool-1",
+    questions: [
+      {
+        question: "Languages?",
+        options: [{ label: "Go" }, { label: "TypeScript" }],
+        multi_select: true,
+      },
+      {
+        question: "Editor?",
+        options: [{ label: "VS Code" }, { label: "Vim" }],
+        multi_select: false,
+      },
+    ],
+  },
+  respondQuestion: vi.fn<(_: Record<string, string>) => Promise<void>>(),
+}));
+
+vi.mock("@/stores", () => ({ useChatStore: () => store }));
+
+function button(container: HTMLElement, label: string): HTMLButtonElement {
+  const match = [...container.querySelectorAll("button")].find((item) =>
+    item.textContent?.includes(label),
+  );
+  if (!match) throw new Error(`button not found: ${label}`);
+  return match;
+}
+
+async function click(element: HTMLElement): Promise<void> {
+  await act(async () => {
+    element.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+  });
+}
+
+describe("QuestionDialog", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(async () => {
+    (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+    store.respondQuestion.mockReset().mockResolvedValue(undefined);
+    container = document.createElement("div");
+    document.body.append(container);
+    root = createRoot(container);
+    await act(async () => {
+      root.render(<QuestionDialog />);
+    });
+  });
+
+  afterEach(async () => {
+    await act(async () => {
+      root.unmount();
+    });
+    container.remove();
+  });
+
+  it("preserves multi and custom answers across Back and submits only explicitly", async () => {
+    await click(button(container, "Go"));
+    expect(store.respondQuestion).not.toHaveBeenCalled();
+
+    await click(button(container, "Custom response"));
+    const input = container.querySelector("input");
+    if (!input) throw new Error("custom response input not found");
+    await act(async () => {
+      const setter = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, "value")?.set;
+      setter?.call(input, "Rust");
+      input.dispatchEvent(new Event("input", { bubbles: true }));
+    });
+    await click(button(container, "Send"));
+    await click(button(container, "Next"));
+    await click(button(container, "Custom response"));
+    const editorInput = container.querySelector("input");
+    if (!editorInput) throw new Error("editor custom response input not found");
+    await act(async () => {
+      const setter = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, "value")?.set;
+      setter?.call(editorInput, "Neovim");
+      editorInput.dispatchEvent(new Event("input", { bubbles: true }));
+    });
+    await click(button(container, "Send"));
+    expect(store.respondQuestion).not.toHaveBeenCalled();
+
+    await click(button(container, "Back"));
+    expect(container.textContent).toContain("Rust");
+    await click(button(container, "Next"));
+
+    const submit = button(container, "Submit answers");
+    await act(async () => {
+      submit.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+      submit.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+
+    expect(store.respondQuestion).toHaveBeenCalledTimes(1);
+    expect(store.respondQuestion).toHaveBeenCalledWith({
+      "Languages?": "Go, Rust",
+      "Editor?": "Neovim",
+    });
+  });
+});

--- a/apps/vscode/test/question-dialog.test.tsx
+++ b/apps/vscode/test/question-dialog.test.tsx
@@ -103,4 +103,38 @@ describe("QuestionDialog", () => {
       "Editor?": "Neovim",
     });
   });
+
+  it("lets users remove a custom multi-select answer before submitting", async () => {
+    await click(button(container, "Go"));
+    await click(button(container, "Custom response"));
+    const input = container.querySelector("input");
+    if (!input) throw new Error("custom response input not found");
+    await act(async () => {
+      const setter = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, "value")?.set;
+      setter?.call(input, "Rust");
+      input.dispatchEvent(new Event("input", { bubbles: true }));
+    });
+    await click(button(container, "Send"));
+
+    await click(button(container, "Rust"));
+    const reopenedInput = container.querySelector("input");
+    if (!reopenedInput) throw new Error("reopened custom response input not found");
+    await act(async () => {
+      const setter = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, "value")?.set;
+      setter?.call(reopenedInput, "");
+      reopenedInput.dispatchEvent(new Event("input", { bubbles: true }));
+    });
+    const save = button(container, "Send");
+    expect(save.disabled).toBe(false);
+    await click(save);
+
+    await click(button(container, "Next"));
+    await click(button(container, "VS Code"));
+    await click(button(container, "Submit answers"));
+
+    expect(store.respondQuestion).toHaveBeenCalledWith({
+      "Languages?": "Go",
+      "Editor?": "VS Code",
+    });
+  });
 });

--- a/apps/vscode/test/question-flow.test.ts
+++ b/apps/vscode/test/question-flow.test.ts
@@ -65,4 +65,16 @@ describe("question flow", () => {
     expect(canAdvanceQuestion(flow, editorQuestion)).toBe(true);
     expect(flow.answers).toEqual({ "Editor?": "Neovim" });
   });
+
+  it("removes a cleared custom response while preserving selected options", () => {
+    let flow = createQuestionFlow(questions);
+    flow = toggleQuestionOption(flow, languageQuestion, "Go");
+    flow = answerQuestionWithCustom(flow, languageQuestion, "Rust");
+
+    flow = answerQuestionWithCustom(flow, languageQuestion, "");
+
+    expect(flow.answers).toEqual({ "Languages?": "Go" });
+    expect(flow.customAnswers).toEqual({});
+    expect(flow.selections["Languages?"]).toEqual(["Go"]);
+  });
 });

--- a/apps/vscode/test/question-flow.test.ts
+++ b/apps/vscode/test/question-flow.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "vitest";
+import {
+  answerQuestion,
+  answerQuestionWithCustom,
+  canAdvanceQuestion,
+  createQuestionFlow,
+  moveQuestion,
+  toggleQuestionOption,
+} from "../webview-ui/src/components/question-flow";
+
+const questions = [
+  { question: "Languages?", multi_select: true },
+  { question: "Editor?", multi_select: false },
+] as const;
+const languageQuestion = questions[0];
+const editorQuestion = questions[1];
+
+describe("question flow", () => {
+  it("keeps multi-select choices on the current question until the user advances", () => {
+    let flow = createQuestionFlow(questions);
+
+    flow = toggleQuestionOption(flow, languageQuestion, "Go");
+    flow = toggleQuestionOption(flow, languageQuestion, "TypeScript");
+
+    expect(flow.questionIndex).toBe(0);
+    expect(flow.answers).toEqual({ "Languages?": "Go, TypeScript" });
+    expect(canAdvanceQuestion(flow, languageQuestion)).toBe(true);
+  });
+
+  it("can return to an earlier question without losing either answer", () => {
+    let flow = createQuestionFlow(questions);
+    flow = answerQuestion(flow, languageQuestion, "Go");
+    flow = moveQuestion(flow, 1, questions.length);
+    flow = answerQuestion(flow, editorQuestion, "VS Code");
+
+    flow = moveQuestion(flow, -1, questions.length);
+
+    expect(flow.questionIndex).toBe(0);
+    expect(flow.answers).toEqual({ "Languages?": "Go", "Editor?": "VS Code" });
+  });
+
+  it("does not advance beyond the final review step", () => {
+    let flow = createQuestionFlow(questions);
+    flow = answerQuestion(flow, languageQuestion, "Go");
+    flow = moveQuestion(flow, 1, questions.length);
+    flow = answerQuestion(flow, editorQuestion, "VS Code");
+
+    expect(moveQuestion(flow, 1, questions.length).questionIndex).toBe(1);
+    expect(flow.answers).toEqual({ "Languages?": "Go", "Editor?": "VS Code" });
+  });
+
+  it("combines a custom response with multi-select options and restores it", () => {
+    let flow = createQuestionFlow(questions);
+    flow = toggleQuestionOption(flow, languageQuestion, "Go");
+    flow = answerQuestionWithCustom(flow, languageQuestion, "Rust");
+
+    expect(flow.answers).toEqual({ "Languages?": "Go, Rust" });
+    expect(flow.customAnswers["Languages?"]).toBe("Rust");
+    expect(flow.selections["Languages?"]).toEqual(["Go"]);
+  });
+
+  it("can advance with only a custom response", () => {
+    const flow = answerQuestionWithCustom(createQuestionFlow(questions), editorQuestion, "Neovim");
+
+    expect(canAdvanceQuestion(flow, editorQuestion)).toBe(true);
+    expect(flow.answers).toEqual({ "Editor?": "Neovim" });
+  });
+});

--- a/apps/vscode/tsconfig.json
+++ b/apps/vscode/tsconfig.json
@@ -15,5 +15,5 @@
     }
   },
   "include": ["src/**/*", "shared/**/*", "test/**/*"],
-  "exclude": ["dist", "node_modules", "webview-ui", "test/settings-store.test.ts", "test/app-init.test.ts"]
+  "exclude": ["dist", "node_modules", "webview-ui", "test/settings-store.test.ts", "test/app-init.test.ts", "test/question-dialog.test.tsx"]
 }

--- a/apps/vscode/vitest.config.ts
+++ b/apps/vscode/vitest.config.ts
@@ -9,7 +9,7 @@ export default defineConfig({
     },
   },
   test: {
-    include: ['test/**/*.test.ts'],
+    include: ['test/**/*.test.{ts,tsx}'],
     environment: 'node',
   },
 });

--- a/apps/vscode/webview-ui/src/components/QuestionDialog.tsx
+++ b/apps/vscode/webview-ui/src/components/QuestionDialog.tsx
@@ -1,81 +1,81 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef } from "react";
 import { useChatStore } from "@/stores";
 import { cn } from "@/lib/utils";
+import {
+  answerQuestionWithCustom,
+  canAdvanceQuestion,
+  createQuestionFlow,
+  moveQuestion,
+  toggleQuestionOption,
+} from "./question-flow";
 
 export function QuestionDialog() {
   const { pendingQuestion, respondQuestion } = useChatStore();
   const [customInput, setCustomInput] = useState("");
   const [showCustom, setShowCustom] = useState(false);
-  const [selectedIndex, setSelectedIndex] = useState(1);
-  const [questionIndex, setQuestionIndex] = useState(0);
-  const [answers, setAnswers] = useState<Record<string, string>>({});
-  const [multiSelected, setMultiSelected] = useState<string[]>([]);
+  const [flow, setFlow] = useState(() => createQuestionFlow([]));
+  const [submitting, setSubmitting] = useState(false);
+  const submittingRef = useRef(false);
 
   const questions = pendingQuestion?.questions ?? [];
-  const question = questions[questionIndex];
+  const question = questions[flow.questionIndex];
   const isMultiSelect = question?.multi_select === true;
-  const isLastQuestion = questionIndex + 1 >= questions.length;
 
   useEffect(() => {
     if (pendingQuestion) {
       setShowCustom(false);
       setCustomInput("");
-      setSelectedIndex(1);
-      setQuestionIndex(0);
-      setAnswers({});
-      setMultiSelected([]);
+      setFlow(createQuestionFlow(pendingQuestion.questions));
+      setSubmitting(false);
+      submittingRef.current = false;
     }
   }, [pendingQuestion?.id]);
 
   if (!pendingQuestion || !question) return null;
 
-  // Step through the questions one by one; submit all answers after the last.
-  const handleAnswer = async (answer: string) => {
-    const nextAnswers = { ...answers, [question.question]: answer };
-    if (!isLastQuestion) {
-      setAnswers(nextAnswers);
-      setQuestionIndex(questionIndex + 1);
-      setShowCustom(false);
-      setCustomInput("");
-      setSelectedIndex(1);
-      setMultiSelected([]);
-    } else {
-      await respondQuestion(nextAnswers);
+  const handleSelect = (optionLabel: string) => {
+    setFlow((current) => toggleQuestionOption(current, question, optionLabel));
+  };
+
+  const handleCustomSubmit = () => {
+    const normalizedInput = customInput.trim();
+    if (!normalizedInput && !flow.customAnswers[question.question]) return;
+    setFlow((current) => answerQuestionWithCustom(current, question, normalizedInput));
+    setShowCustom(false);
+  };
+
+  const openCustom = () => {
+    setCustomInput(flow.customAnswers[question.question] ?? "");
+    setShowCustom(true);
+  };
+
+  const submitAnswers = async () => {
+    if (submittingRef.current) return;
+    submittingRef.current = true;
+    setSubmitting(true);
+    try {
+      await respondQuestion(flow.answers);
+    } finally {
+      submittingRef.current = false;
+      setSubmitting(false);
     }
   };
 
-  const handleSelect = async (optionLabel: string) => {
-    if (isMultiSelect) {
-      setMultiSelected((prev) =>
-        prev.includes(optionLabel) ? prev.filter((value) => value !== optionLabel) : [...prev, optionLabel],
-      );
-      return;
-    }
-    await handleAnswer(optionLabel);
-  };
-
-  const handleCustomSubmit = async () => {
-    const value = customInput.trim();
-    if (!value) return;
-    if (isMultiSelect) {
-      setMultiSelected((prev) => (prev.includes(value) ? prev : [...prev, value]));
-      setCustomInput("");
-      setShowCustom(false);
-      return;
-    }
-    await handleAnswer(value);
+  const move = (offset: number) => {
+    setFlow((current) => moveQuestion(current, offset, questions.length));
+    setShowCustom(false);
+    setCustomInput("");
   };
 
   const options = question.options || [];
   const customIndex = options.length + 1;
-  const customValues = multiSelected.filter((value) => !options.some((option) => option.label === value));
 
   return (
     <div className={cn("mb-0.5 border border-blue-200 dark:border-blue-800 rounded-lg overflow-hidden bg-background flex flex-col shrink")}>
       <div className="p-2 space-y-2">
         {questions.length > 1 && (
           <div className="text-[10px] text-muted-foreground">
-            Question {questionIndex + 1} of {questions.length}
+            Question {flow.questionIndex + 1} of {questions.length}
           </div>
         )}
         {question.header && <div className="text-[10px] text-muted-foreground uppercase tracking-wide">{question.header}</div>}
@@ -83,58 +83,38 @@ export function QuestionDialog() {
         {isMultiSelect && <div className="text-[10px] text-muted-foreground">Select all that apply</div>}
         <div className="space-y-1.5">
           {options.map((option, idx) => {
-            const isChecked = isMultiSelect && multiSelected.includes(option.label);
-            const isHighlighted = selectedIndex === idx + 1;
+            const isChecked = flow.selections[question.question]?.includes(option.label) === true;
             return (
               <button
                 key={idx}
                 onClick={() => {
-                  void handleSelect(option.label);
+                  handleSelect(option.label);
                 }}
-                onMouseEnter={() => setSelectedIndex(idx + 1)}
                 className={cn(
-                  "w-full text-left px-2 py-1 rounded-md text-xs transition-colors",
-                  "border cursor-pointer",
+                  "w-full text-left px-2 py-1 rounded-md text-xs transition-colors border cursor-pointer",
                   isChecked
                     ? "bg-blue-500/15 border-blue-500"
-                    : isHighlighted
-                      ? "bg-blue-500 text-white border-blue-500"
-                      : "bg-background border-border hover:bg-muted/50",
+                    : "bg-background border-border hover:bg-muted/50",
                 )}
               >
-                <span className={cn("mr-2", isHighlighted && !isChecked ? "text-blue-200" : "text-muted-foreground")}>
-                  {isChecked ? "✓" : idx + 1}
-                </span>
+                <span className="mr-2 text-muted-foreground">{isMultiSelect && isChecked ? "✓" : idx + 1}</span>
                 <span className="font-medium">{option.label}</span>
                 {option.description && (
-                  <span className={cn("ml-2", isHighlighted && !isChecked ? "text-blue-200" : "text-muted-foreground")}>- {option.description}</span>
+                  <span className="ml-2 text-muted-foreground">- {option.description}</span>
                 )}
               </button>
             );
           })}
-          {customValues.map((value) => (
-            <button
-              key={value}
-              onClick={() => {
-                void handleSelect(value);
-              }}
-              className={cn(
-                "w-full text-left px-2 py-1 rounded-md text-xs transition-colors",
-                "border cursor-pointer bg-blue-500/15 border-blue-500",
-              )}
-            >
-              <span className="mr-2 text-muted-foreground">✓</span>
-              <span className="font-medium">{value}</span>
-            </button>
-          ))}
           {showCustom ? (
             <div className="flex gap-1.5">
               <input
                 autoFocus
                 value={customInput}
-                onChange={(e) => setCustomInput(e.target.value)}
+                onChange={(e) => {
+                  setCustomInput(e.target.value);
+                }}
                 onKeyDown={(e) => {
-                  if (e.key === "Enter") void handleCustomSubmit();
+                  if (e.key === "Enter") handleCustomSubmit();
                   if (e.key === "Escape") setShowCustom(false);
                 }}
                 placeholder="Enter your response…"
@@ -142,9 +122,9 @@ export function QuestionDialog() {
               />
               <button
                 onClick={() => {
-                  void handleCustomSubmit();
+                  handleCustomSubmit();
                 }}
-                disabled={!customInput.trim()}
+                disabled={!customInput.trim() && !flow.customAnswers[question.question]}
                 className="px-2 py-1 rounded-md text-xs bg-blue-500 text-white disabled:opacity-50 cursor-pointer"
               >
                 Send
@@ -152,27 +132,57 @@ export function QuestionDialog() {
             </div>
           ) : (
             <button
-              onClick={() => setShowCustom(true)}
-              onMouseEnter={() => setSelectedIndex(customIndex)}
+              onClick={() => {
+                openCustom();
+              }}
               className={cn(
-                "w-full text-left px-2 py-1 rounded-md text-xs transition-colors",
-                "border border-border cursor-pointer",
-                selectedIndex === customIndex ? "bg-blue-500 text-white border-blue-500" : "bg-background hover:bg-muted/50",
+                "w-full text-left px-2 py-1 rounded-md text-xs transition-colors border cursor-pointer",
+                flow.customAnswers[question.question]
+                  ? "bg-blue-500/15 border-blue-500"
+                  : "bg-background border-border hover:bg-muted/50",
               )}
             >
-              <span className={cn("mr-2", selectedIndex === customIndex ? "text-blue-200" : "text-muted-foreground")}>{customIndex}</span>
-              <span className="font-medium">Custom response…</span>
+              <span className="mr-2 text-muted-foreground">
+                {isMultiSelect && flow.customAnswers[question.question] ? "✓" : customIndex}
+              </span>
+              <span className="font-medium">
+                {flow.customAnswers[question.question] ?? "Custom response..."}
+              </span>
             </button>
           )}
-          {isMultiSelect && (
+        </div>
+        <div className="flex items-center justify-between gap-2 pt-1">
+          <button
+            type="button"
+            disabled={flow.questionIndex === 0}
+            onClick={() => {
+              move(-1);
+            }}
+            className="px-2 py-1 rounded-md text-xs border border-border disabled:opacity-50"
+          >
+            Back
+          </button>
+          {flow.questionIndex + 1 < questions.length ? (
             <button
+              type="button"
+              disabled={!canAdvanceQuestion(flow, question)}
               onClick={() => {
-                void handleAnswer(multiSelected.join(", "));
+                move(1);
               }}
-              disabled={multiSelected.length === 0}
-              className="w-full px-2 py-1 rounded-md text-xs bg-blue-500 text-white disabled:opacity-50 cursor-pointer"
+              className="px-2 py-1 rounded-md text-xs bg-blue-500 text-white disabled:opacity-50"
             >
-              {isLastQuestion ? "Submit" : "Next"}
+              Next
+            </button>
+          ) : (
+            <button
+              type="button"
+              disabled={!canAdvanceQuestion(flow, question) || submitting}
+              onClick={() => {
+                void submitAnswers();
+              }}
+              className="px-2 py-1 rounded-md text-xs bg-blue-500 text-white disabled:opacity-50"
+            >
+              {submitting ? "Submitting..." : "Submit answers"}
             </button>
           )}
         </div>

--- a/apps/vscode/webview-ui/src/components/question-flow.ts
+++ b/apps/vscode/webview-ui/src/components/question-flow.ts
@@ -33,7 +33,10 @@ export function answerQuestionWithCustom(
   question: QuestionLike,
   answer: string,
 ): QuestionFlow {
-  const customAnswers = { ...flow.customAnswers, [question.question]: answer };
+  const normalizedAnswer = answer.trim();
+  const customAnswers = normalizedAnswer
+    ? { ...flow.customAnswers, [question.question]: normalizedAnswer }
+    : withoutKey(flow.customAnswers, question.question);
   const selections = question.multi_select ? flow.selections : withoutKey(flow.selections, question.question);
   return withAnswer({ ...flow, selections, customAnswers }, question);
 }

--- a/apps/vscode/webview-ui/src/components/question-flow.ts
+++ b/apps/vscode/webview-ui/src/components/question-flow.ts
@@ -1,0 +1,96 @@
+export interface QuestionLike {
+  question: string;
+  multi_select?: boolean;
+}
+
+export interface QuestionFlow {
+  questionIndex: number;
+  answers: Record<string, string>;
+  selections: Record<string, string[]>;
+  customAnswers: Record<string, string>;
+}
+
+const ANSWER_SEPARATOR = ", ";
+
+export function createQuestionFlow(_questions: readonly QuestionLike[]): QuestionFlow {
+  return { questionIndex: 0, answers: {}, selections: {}, customAnswers: {} };
+}
+
+export function answerQuestion(
+  flow: QuestionFlow,
+  question: QuestionLike,
+  answer: string,
+): QuestionFlow {
+  return withSelections(
+    { ...flow, customAnswers: withoutKey(flow.customAnswers, question.question) },
+    question,
+    [answer],
+  );
+}
+
+export function answerQuestionWithCustom(
+  flow: QuestionFlow,
+  question: QuestionLike,
+  answer: string,
+): QuestionFlow {
+  const customAnswers = { ...flow.customAnswers, [question.question]: answer };
+  const selections = question.multi_select ? flow.selections : withoutKey(flow.selections, question.question);
+  return withAnswer({ ...flow, selections, customAnswers }, question);
+}
+
+export function toggleQuestionOption(
+  flow: QuestionFlow,
+  question: QuestionLike,
+  option: string,
+): QuestionFlow {
+  if (!question.multi_select) return answerQuestion(flow, question, option);
+  const current = flow.selections[question.question] ?? [];
+  const selections = current.includes(option)
+    ? current.filter((item) => item !== option)
+    : [...current, option];
+  return withSelections(flow, question, selections);
+}
+
+export function canAdvanceQuestion(flow: QuestionFlow, question: QuestionLike): boolean {
+  return flow.answers[question.question] !== undefined;
+}
+
+export function moveQuestion(
+  flow: QuestionFlow,
+  offset: number,
+  questionCount: number,
+): QuestionFlow {
+  const lastIndex = Math.max(0, questionCount - 1);
+  return {
+    ...flow,
+    questionIndex: Math.min(lastIndex, Math.max(0, flow.questionIndex + offset)),
+  };
+}
+
+function withSelections(
+  flow: QuestionFlow,
+  question: QuestionLike,
+  selections: string[],
+): QuestionFlow {
+  return withAnswer(
+    { ...flow, selections: { ...flow.selections, [question.question]: selections } },
+    question,
+  );
+}
+
+function withAnswer(flow: QuestionFlow, question: QuestionLike): QuestionFlow {
+  const values = [
+    ...(flow.selections[question.question] ?? []),
+    ...(flow.customAnswers[question.question] ? [flow.customAnswers[question.question]] : []),
+  ];
+  const answers = { ...flow.answers };
+  if (values.length === 0) delete answers[question.question];
+  else answers[question.question] = values.join(ANSWER_SEPARATOR);
+  return { ...flow, answers };
+}
+
+function withoutKey<T>(record: Record<string, T>, key: string): Record<string, T> {
+  const copy = { ...record };
+  delete copy[key];
+  return copy;
+}

--- a/apps/vscode/webview-ui/tsconfig.json
+++ b/apps/vscode/webview-ui/tsconfig.json
@@ -20,5 +20,5 @@
       "shared/*": ["../shared/*"]
     }
   },
-  "include": ["src", "../test/settings-store.test.ts", "../test/app-init.test.ts"]
+  "include": ["src", "../test/settings-store.test.ts", "../test/app-init.test.ts", "../test/question-dialog.test.tsx"]
 }


### PR DESCRIPTION
Fixes #2350.

## Summary

- keep AskUserQuestion choices in an explicit review flow instead of advancing or submitting on selection
- support multi-select options, custom-only answers, and combined preset/custom answers
- let users navigate back without losing selections and require an explicit final submission
- allow users to remove a previously saved custom multi-select answer while preserving preset selections
- prevent duplicate question RPCs while submission is in flight
- add reducer-level and React/jsdom interaction coverage

## Test verification (RED → GREEN)

- RED: the original flow tests failed before the question-flow implementation existed
- RED follow-up: clearing a reviewed custom answer left an empty custom key and the UI disabled saving the removal (2 focused failures)
- GREEN: targeted reducer and React interaction suite passes all 8 tests
- VS Code extension suite: 16 files / 316 tests passed
- full local suite: lint, typecheck, production build, 1,037 files and 16,905 tests passed versus the upstream baseline of 1,035 files and 16,897 tests
- independent code review: PASS

## AI assistance disclosure

This patch and PR text were AI-assisted using OpenAI Codex. The implementation was exercised with targeted UI tests and the complete local validation suite; the human contributor remains responsible for reviewing and understanding the submitted changes.
