### PR TITLE
test(agent-core-v2): disables commit.gpgsign

### DIFF
--- a/packages/agent-core-v2/test/app/git/gitService.test.ts
+++ b/packages/agent-core-v2/test/app/git/gitService.test.ts
@@ -38,6 +38,7 @@ describe('GitService', () => {
     git(repo, 'init');
     git(repo, 'config', 'user.email', 'test@example.com');
     git(repo, 'config', 'user.name', 'Test');
+    git(repo, 'config', 'commit.gpgsign', 'false');
     disposables = new DisposableStore();
     ix = createServices(disposables, {
       additionalServices: (reg) => {


### PR DESCRIPTION
Unless commit.gpgsign is disabled for these test operations, the host machine may be unnecessarily interrupted with prompts to provide a secret key.

<!--
Thank you for your contribution to Kimi Code!
Please open an issue before sending a feature PR — PRs without prior discussion may be closed without review.

See https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md for more.
-->

## Related Issue

Resolve #2474 

## Problem

See linked issue

## What changed

Configured `commit.gpgsign` to `false` for these tests.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.
