### PR TITLE
feat(tui): include terminal width in status_line.command payload

### DIFF
--- a/apps/kimi-code/src/tui/components/chrome/footer.ts
+++ b/apps/kimi-code/src/tui/components/chrome/footer.ts
@@ -278,7 +278,7 @@ export class FooterComponent implements Component {
     let line1: string;
     let customLine: string | null = null;
     if (this.statusLineRunner !== null) {
-      this.statusLineRunner.maybeRefresh(this.statusLinePayload());
+      this.statusLineRunner.maybeRefresh(this.statusLinePayload(width));
       customLine = this.statusLineRunner.current();
     }
 
@@ -435,7 +435,7 @@ export class FooterComponent implements Component {
     return slots;
   }
 
-  private statusLinePayload(): StatusLinePayload {
+  private statusLinePayload(width: number): StatusLinePayload {
     const state = this.state;
     return {
       model: modelDisplayName(state),
@@ -448,6 +448,7 @@ export class FooterComponent implements Component {
       maxContextTokens: state.maxContextTokens,
       sessionId: state.sessionId,
       version: state.version,
+      width,
     };
   }
 

--- a/apps/kimi-code/src/tui/utils/status-line-command.ts
+++ b/apps/kimi-code/src/tui/utils/status-line-command.ts
@@ -25,6 +25,12 @@ export interface StatusLinePayload {
   maxContextTokens: number;
   sessionId: string;
   version: string;
+  /**
+   * Terminal width in columns, so the command can lay out full-width
+   * (left/right-justified) status lines. Piped stdio has no TTY, so
+   * `process.stdout.columns` is unavailable to the command.
+   */
+  width: number;
 }
 
 export function runStatusLineCommand(

--- a/apps/kimi-code/test/tui/components/chrome/footer-status-line.test.ts
+++ b/apps/kimi-code/test/tui/components/chrome/footer-status-line.test.ts
@@ -52,6 +52,7 @@ const payload: StatusLinePayload = {
   maxContextTokens: 8192,
   sessionId: 'ses-1',
   version: '1.2.3',
+  width: 120,
 };
 
 function plain(text: string): string {
@@ -142,6 +143,7 @@ describe('runStatusLineCommand', () => {
     expect(parsed.model).toBe('kimi-k2');
     expect(parsed.gitBranch).toBe('main');
     expect(parsed.cwd).toBe('/tmp/project');
+    expect(parsed.width).toBe(120);
   });
 
   it('returns null on a nonzero exit', async () => {
@@ -200,6 +202,20 @@ describe('FooterComponent status_line command', () => {
     await new Promise((resolve) => setTimeout(resolve, 200));
 
     expect(plain(footer.render(120)[0]!)).toContain('kimi-k2');
+  });
+
+  it('sends the terminal width from render() in the payload', async () => {
+    const state: AppState = {
+      ...baseState,
+      statusLine: { items: null, command: 'cat' },
+    };
+    const footer = new FooterComponent(state);
+
+    // Wide render so the echoed payload JSON (width field last) is not truncated.
+    footer.render(500); // kicks the first run with width 500
+    await new Promise((resolve) => setTimeout(resolve, 300));
+
+    expect(plain(footer.render(500)[0]!)).toContain('"width":500');
   });
 });
 


### PR DESCRIPTION
## Summary

Adds `width` (terminal columns) to the JSON payload piped to `status_line.command`, closing the gap flagged in #2477.

The command is spawned with piped stdio, so `process.stdout.columns` is unavailable to it — today a status line script has no way to know the terminal width and cannot right-align or lay out full-width content (HUD-style footers with left/right-justified segments, full-width context bars, etc.). One field fixes it: `FooterComponent.render(width)` now passes its `width` through `statusLinePayload()`.

## Change

- `status-line-command.ts`: `StatusLinePayload` gains `width: number` (with a doc comment explaining why it exists)
- `footer.ts`: `statusLinePayload(width)` threaded from `render(width)`
- Test fixture updated + two assertions:
  - `runStatusLineCommand` stdin round-trip now also checks `parsed.width`
  - new end-to-end test: `render(500)` with `cat` as the command echoes the payload back, asserting the rendered line contains `"width":500`

## Verification

- `npx vitest run test/tui/components/chrome/footer-status-line.test.ts`: **13 passed / 17** — the 4 failures are pre-existing on clean `origin/main` in this Windows environment (they depend on `printf`/`sh`/`head` Unix-isms; verified identical baseline via stash) and are untouched by this change
- `npx tsc --noEmit`: clean

Backward compatible in practice: commands that ignore unknown JSON fields are unaffected.

Refs #2477 (also related: #2448, multi-line output — independent change, no overlap)