### PR TITLE
fix(agent-core): drop the bracketed [::1] from child-process NO_PROXY

### DIFF
--- a/.changeset/mcp-child-noproxy-ipv6.md
+++ b/.changeset/mcp-child-noproxy-ipv6.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Fix spawned child processes (e.g. stdio MCP servers) receiving a bracketed `[::1]` entry in `NO_PROXY`, which crashes Python httpx-based MCP servers with `Invalid port: ':1]'` whenever a proxy is configured; the child env now carries the unbracketed loopback list while the in-process dispatcher keeps the bracketed form needed by undici.

--- a/packages/agent-core-v2/src/_base/utils/proxy.ts
+++ b/packages/agent-core-v2/src/_base/utils/proxy.ts
@@ -24,6 +24,16 @@ export interface SocksProxyConfig {
 
 const LOOPBACK_NO_PROXY = ['localhost', '127.0.0.1', '::1', '[::1]'] as const;
 
+// Spawned child processes get the loopback list WITHOUT the bracketed
+// `[::1]`: Python's httpx (the HTTP client behind many MCP servers, e.g.
+// fastmcp-based ones) crashes on it with `Invalid port: ':1]'` while building
+// its proxy mounts, which kills every Python stdio MCP server at startup
+// whenever a proxy is configured. The bracketed form only exists for undici
+// 7.x's NO_PROXY parser (our own in-process dispatcher); for a child, losing
+// the bypass for literal `http://[::1]` URLs is a far smaller risk than
+// breaking every Python child outright.
+const CHILD_LOOPBACK_NO_PROXY = ['localhost', '127.0.0.1', '::1'] as const;
+
 const SOCKS_SCHEMES = new Set(['socks', 'socks4', 'socks4a', 'socks5', 'socks5h']);
 
 function schemeOf(value: string): string | undefined {
@@ -90,14 +100,17 @@ export function isProxyConfigured(env: Env): boolean {
   return hasHttpProxy(env) || resolveSocksProxy(env) !== undefined;
 }
 
-export function resolveNoProxy(env: Env): string {
+export function resolveNoProxy(
+  env: Env,
+  loopbackHosts: readonly string[] = LOOPBACK_NO_PROXY,
+): string {
   const raw = [env['no_proxy'], env['NO_PROXY']].find((value) => (value?.trim() ?? '').length > 0) ?? '';
   const hosts = raw
     .split(',')
     .map((host) => host.trim())
     .filter((host) => host.length > 0);
   if (hosts.includes('*')) return '*';
-  for (const loopback of LOOPBACK_NO_PROXY) {
+  for (const loopback of loopbackHosts) {
     if (!hosts.includes(loopback)) hosts.push(loopback);
   }
   return hosts.join(',');
@@ -232,7 +245,7 @@ export function installGlobalProxyDispatcher(
 
 export function proxyEnvForChild(env: Env): Record<string, string> {
   if (!hasHttpProxy(env)) return {};
-  const noProxy = resolveNoProxy(env);
+  const noProxy = resolveNoProxy(env, CHILD_LOOPBACK_NO_PROXY);
   const result: Record<string, string> = {
     NODE_USE_ENV_PROXY: '1',
     NO_PROXY: noProxy,
@@ -258,7 +271,7 @@ export function reconcileChildNoProxy(
     (value) => (value?.trim() ?? '').length > 0,
   );
   if (override === undefined) return;
-  const noProxy = resolveNoProxy({ no_proxy: override, NO_PROXY: override });
+  const noProxy = resolveNoProxy({ no_proxy: override, NO_PROXY: override }, CHILD_LOOPBACK_NO_PROXY);
   childEnv['NO_PROXY'] = noProxy;
   childEnv['no_proxy'] = noProxy;
 }

--- a/packages/agent-core-v2/test/_base/utils/proxy.test.ts
+++ b/packages/agent-core-v2/test/_base/utils/proxy.test.ts
@@ -130,8 +130,8 @@ describe('proxy utilities', () => {
     expect(proxyEnvForChild({ ALL_PROXY: 'socks5://127.0.0.1:1080' })).toEqual({});
     expect(proxyEnvForChild({ HTTP_PROXY: 'http://p:3128', NO_PROXY: 'corp' })).toEqual({
       NODE_USE_ENV_PROXY: '1',
-      NO_PROXY: 'corp,localhost,127.0.0.1,::1,[::1]',
-      no_proxy: 'corp,localhost,127.0.0.1,::1,[::1]',
+      NO_PROXY: 'corp,localhost,127.0.0.1,::1',
+      no_proxy: 'corp,localhost,127.0.0.1,::1',
       HTTP_PROXY: 'http://p:3128',
       http_proxy: 'http://p:3128',
     });
@@ -141,7 +141,7 @@ describe('proxy utilities', () => {
       no_proxy: 'aug',
     };
     reconcileChildNoProxy(childEnv, { no_proxy: '', NO_PROXY: 'real.corp' });
-    expect(childEnv['NO_PROXY']).toBe('real.corp,localhost,127.0.0.1,::1,[::1]');
-    expect(childEnv['no_proxy']).toBe('real.corp,localhost,127.0.0.1,::1,[::1]');
+    expect(childEnv['NO_PROXY']).toBe('real.corp,localhost,127.0.0.1,::1');
+    expect(childEnv['no_proxy']).toBe('real.corp,localhost,127.0.0.1,::1');
   });
 });

--- a/packages/agent-core-v2/test/mcpCore/client-stdio.test.ts
+++ b/packages/agent-core-v2/test/mcpCore/client-stdio.test.ts
@@ -304,7 +304,7 @@ describe('mergeStdioEnv', () => {
     const merged = mergeStdioEnv({ HTTP_PROXY: 'http://corp:3128' }, { PATH: '/usr/bin' });
     expect(merged['HTTP_PROXY']).toBe('http://corp:3128');
     expect(merged['NODE_USE_ENV_PROXY']).toBe('1');
-    expect(merged['NO_PROXY']).toBe('localhost,127.0.0.1,::1,[::1]');
+    expect(merged['NO_PROXY']).toBe('localhost,127.0.0.1,::1');
     expect(merged['PATH']).toBe('/usr/bin');
   });
 

--- a/packages/agent-core-v2/test/mcpCore/stubs.ts
+++ b/packages/agent-core-v2/test/mcpCore/stubs.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from 'node:crypto';
 import { createServer, type Server } from 'node:http';
 import type { AddressInfo } from 'node:net';
+import { fileURLToPath } from 'node:url';
 
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { SSEServerTransport } from '@modelcontextprotocol/sdk/server/sse.js';
@@ -17,26 +18,26 @@ import type {
   ToolExecution,
 } from '#/tool/toolContract';
 
-export const fixturesDir = new URL('./fixtures/', import.meta.url).pathname;
-export const stdioFixture = new URL('./fixtures/mock-stdio-server.mjs', import.meta.url).pathname;
-export const cwdStdioFixture = new URL('./fixtures/cwd-stdio-server.mjs', import.meta.url).pathname;
-export const slowStdioFixture = new URL('./fixtures/slow-stdio-server.mjs', import.meta.url).pathname;
-export const slowToolStdioFixture = new URL(
-  './fixtures/slow-tool-stdio-server.mjs',
-  import.meta.url,
-).pathname;
-export const hangingListStdioFixture = new URL(
-  './fixtures/hanging-list-stdio-server.mjs',
-  import.meta.url,
-).pathname;
-export const crashAfterConnectFixture = new URL(
-  './fixtures/crash-after-connect-stdio-server.mjs',
-  import.meta.url,
-).pathname;
-export const stderrThenExitFixture = new URL(
-  './fixtures/stderr-then-exit-stdio-server.mjs',
-  import.meta.url,
-).pathname;
+export const fixturesDir = fileURLToPath(new URL('./fixtures/', import.meta.url));
+export const stdioFixture = fileURLToPath(new URL('./fixtures/mock-stdio-server.mjs', import.meta.url));
+export const cwdStdioFixture = fileURLToPath(
+  new URL('./fixtures/cwd-stdio-server.mjs', import.meta.url),
+);
+export const slowStdioFixture = fileURLToPath(
+  new URL('./fixtures/slow-stdio-server.mjs', import.meta.url),
+);
+export const slowToolStdioFixture = fileURLToPath(
+  new URL('./fixtures/slow-tool-stdio-server.mjs', import.meta.url),
+);
+export const hangingListStdioFixture = fileURLToPath(
+  new URL('./fixtures/hanging-list-stdio-server.mjs', import.meta.url),
+);
+export const crashAfterConnectFixture = fileURLToPath(
+  new URL('./fixtures/crash-after-connect-stdio-server.mjs', import.meta.url),
+);
+export const stderrThenExitFixture = fileURLToPath(
+  new URL('./fixtures/stderr-then-exit-stdio-server.mjs', import.meta.url),
+);
 
 export function createMemoryMcpOAuthStore(): McpOAuthStore {
   const data = new Map<string, unknown>();

--- a/packages/agent-core/src/utils/proxy.ts
+++ b/packages/agent-core/src/utils/proxy.ts
@@ -30,6 +30,16 @@ export interface SocksProxyConfig {
 // normalizes brackets away — so including both covers every path.
 const LOOPBACK_NO_PROXY = ['localhost', '127.0.0.1', '::1', '[::1]'] as const;
 
+// Spawned child processes get the loopback list WITHOUT the bracketed
+// `[::1]`: Python's httpx (the HTTP client behind many MCP servers, e.g.
+// fastmcp-based ones) crashes on it with `Invalid port: ':1]'` while building
+// its proxy mounts, which kills every Python stdio MCP server at startup
+// whenever a proxy is configured. The bracketed form only exists for undici
+// 7.x's NO_PROXY parser (our own in-process dispatcher); for a child, losing
+// the bypass for literal `http://[::1]` URLs is a far smaller risk than
+// breaking every Python child outright.
+const CHILD_LOOPBACK_NO_PROXY = ['localhost', '127.0.0.1', '::1'] as const;
+
 const SOCKS_SCHEMES = new Set(['socks', 'socks4', 'socks4a', 'socks5', 'socks5h']);
 
 /** Lowercase URL scheme (without the trailing colon), or undefined if absent. */
@@ -128,8 +138,15 @@ export function isProxyConfigured(env: Env = process.env): boolean {
  * honors it as an exact-string match, so appending loopback would silently
  * defeat the user's explicit opt-out and route all non-loopback traffic
  * through the proxy.
+ *
+ * `loopbackHosts` defaults to {@link LOOPBACK_NO_PROXY}; child-process env
+ * builders pass `CHILD_LOOPBACK_NO_PROXY` instead (no bracketed `[::1]`,
+ * which crashes Python httpx children).
  */
-export function resolveNoProxy(env: Env = process.env): string {
+export function resolveNoProxy(
+  env: Env = process.env,
+  loopbackHosts: readonly string[] = LOOPBACK_NO_PROXY,
+): string {
   // Prefer the first non-blank casing; an empty `no_proxy=''` must not mask a
   // populated `NO_PROXY` (`??` would, since `''` is not nullish).
   const raw = [env['no_proxy'], env['NO_PROXY']].find((value) => (value?.trim() ?? '').length > 0) ?? '';
@@ -138,7 +155,7 @@ export function resolveNoProxy(env: Env = process.env): string {
     .map((host) => host.trim())
     .filter((host) => host.length > 0);
   if (hosts.includes('*')) return '*';
-  for (const loopback of LOOPBACK_NO_PROXY) {
+  for (const loopback of loopbackHosts) {
     if (!hosts.includes(loopback)) hosts.push(loopback);
   }
   return hosts.join(',');
@@ -335,7 +352,7 @@ export function installGlobalProxyDispatcher(
  */
 export function proxyEnvForChild(env: Env = process.env): Record<string, string> {
   if (!hasHttpProxy(env)) return {};
-  const noProxy = resolveNoProxy(env);
+  const noProxy = resolveNoProxy(env, CHILD_LOOPBACK_NO_PROXY);
   const result: Record<string, string> = {
     NODE_USE_ENV_PROXY: '1',
     NO_PROXY: noProxy,
@@ -372,7 +389,7 @@ export function reconcileChildNoProxy(
     (value) => (value?.trim() ?? '').length > 0,
   );
   if (override === undefined) return;
-  const noProxy = resolveNoProxy({ no_proxy: override, NO_PROXY: override });
+  const noProxy = resolveNoProxy({ no_proxy: override, NO_PROXY: override }, CHILD_LOOPBACK_NO_PROXY);
   childEnv['NO_PROXY'] = noProxy;
   childEnv['no_proxy'] = noProxy;
 }

--- a/packages/agent-core/test/mcp/client-stdio.test.ts
+++ b/packages/agent-core/test/mcp/client-stdio.test.ts
@@ -315,7 +315,7 @@ describe('mergeStdioEnv', () => {
     const merged = mergeStdioEnv({ HTTP_PROXY: 'http://corp:3128' }, { PATH: '/usr/bin' });
     expect(merged['HTTP_PROXY']).toBe('http://corp:3128');
     expect(merged['NODE_USE_ENV_PROXY']).toBe('1');
-    expect(merged['NO_PROXY']).toBe('localhost,127.0.0.1,::1,[::1]');
+    expect(merged['NO_PROXY']).toBe('localhost,127.0.0.1,::1');
     expect(merged['PATH']).toBe('/usr/bin');
   });
 

--- a/packages/agent-core/test/utils/proxy.test.ts
+++ b/packages/agent-core/test/utils/proxy.test.ts
@@ -61,6 +61,15 @@ describe('resolveNoProxy', () => {
   it('falls through to NO_PROXY when no_proxy is set but blank', () => {
     expect(resolveNoProxy({ no_proxy: '', NO_PROXY: 'corp' })).toBe('corp,localhost,127.0.0.1,::1,[::1]');
   });
+
+  it('honors a custom loopback list (child form drops the bracketed [::1])', () => {
+    // Child processes get the list without `[::1]`: Python's httpx crashes on
+    // the bracketed entry with `Invalid port: ':1]'`.
+    expect(resolveNoProxy({}, ['localhost', '127.0.0.1', '::1'])).toBe('localhost,127.0.0.1,::1');
+    expect(resolveNoProxy({ NO_PROXY: 'corp' }, ['localhost', '127.0.0.1', '::1'])).toBe(
+      'corp,localhost,127.0.0.1,::1',
+    );
+  });
 });
 
 describe('resolveSocksProxy', () => {
@@ -343,11 +352,20 @@ describe('proxyEnvForChild', () => {
     // the resolved value or the protection/proxying is silently defeated.
     expect(proxyEnvForChild({ HTTP_PROXY: 'http://p:3128', NO_PROXY: 'corp' })).toEqual({
       NODE_USE_ENV_PROXY: '1',
-      NO_PROXY: 'corp,localhost,127.0.0.1,::1,[::1]',
-      no_proxy: 'corp,localhost,127.0.0.1,::1,[::1]',
+      NO_PROXY: 'corp,localhost,127.0.0.1,::1',
+      no_proxy: 'corp,localhost,127.0.0.1,::1',
       HTTP_PROXY: 'http://p:3128',
       http_proxy: 'http://p:3128',
     });
+  });
+
+  it('omits the bracketed [::1] from the child NO_PROXY (Python httpx crashes on it)', () => {
+    // The bracketed form is only needed by undici 7.x's in-process dispatcher;
+    // a child must get the bare loopback list, while a user-supplied `[::1]`
+    // in the parent's own NO_PROXY is preserved verbatim.
+    const env = proxyEnvForChild({ HTTP_PROXY: 'http://p:3128', NO_PROXY: 'corp,[::1]' });
+    expect(env['NO_PROXY']).toBe('corp,[::1],localhost,127.0.0.1,::1');
+    expect(env['no_proxy']).toBe('corp,[::1],localhost,127.0.0.1,::1');
   });
 
   it('synthesizes scheme-specific proxies from an http-scheme ALL_PROXY for the child', () => {
@@ -355,8 +373,8 @@ describe('proxyEnvForChild', () => {
     // ALL_PROXY-only parent must hand the child the scheme-specific vars.
     expect(proxyEnvForChild({ ALL_PROXY: 'http://proxy:8080' })).toEqual({
       NODE_USE_ENV_PROXY: '1',
-      NO_PROXY: 'localhost,127.0.0.1,::1,[::1]',
-      no_proxy: 'localhost,127.0.0.1,::1,[::1]',
+      NO_PROXY: 'localhost,127.0.0.1,::1',
+      no_proxy: 'localhost,127.0.0.1,::1',
       HTTP_PROXY: 'http://proxy:8080',
       http_proxy: 'http://proxy:8080',
       HTTPS_PROXY: 'http://proxy:8080',
@@ -385,32 +403,32 @@ describe('reconcileChildNoProxy', () => {
     // would shadow the server config's uppercase override (undici reads
     // lowercase first); the override must also keep the loopback bypass.
     const childEnv: Record<string, string> = {
-      NO_PROXY: 'corp,localhost,127.0.0.1,::1,[::1]',
-      no_proxy: 'corp,localhost,127.0.0.1,::1,[::1]',
+      NO_PROXY: 'corp,localhost,127.0.0.1,::1',
+      no_proxy: 'corp,localhost,127.0.0.1,::1',
     };
     reconcileChildNoProxy(childEnv, { NO_PROXY: 'server.local' });
-    expect(childEnv['NO_PROXY']).toBe('server.local,localhost,127.0.0.1,::1,[::1]');
-    expect(childEnv['no_proxy']).toBe('server.local,localhost,127.0.0.1,::1,[::1]');
+    expect(childEnv['NO_PROXY']).toBe('server.local,localhost,127.0.0.1,::1');
+    expect(childEnv['no_proxy']).toBe('server.local,localhost,127.0.0.1,::1');
   });
 
   it('prefers the first non-blank casing (lowercase) and keeps loopback', () => {
     const childEnv: Record<string, string> = { NO_PROXY: 'aug', no_proxy: 'aug' };
     reconcileChildNoProxy(childEnv, { no_proxy: 'lower', NO_PROXY: 'upper' });
-    expect(childEnv['NO_PROXY']).toBe('lower,localhost,127.0.0.1,::1,[::1]');
-    expect(childEnv['no_proxy']).toBe('lower,localhost,127.0.0.1,::1,[::1]');
+    expect(childEnv['NO_PROXY']).toBe('lower,localhost,127.0.0.1,::1');
+    expect(childEnv['no_proxy']).toBe('lower,localhost,127.0.0.1,::1');
   });
 
   it('does not let a blank lowercase no_proxy mask a populated NO_PROXY', () => {
     const childEnv: Record<string, string> = { NO_PROXY: 'aug', no_proxy: 'aug' };
     reconcileChildNoProxy(childEnv, { no_proxy: '', NO_PROXY: 'real.corp' });
-    expect(childEnv['NO_PROXY']).toBe('real.corp,localhost,127.0.0.1,::1,[::1]');
-    expect(childEnv['no_proxy']).toBe('real.corp,localhost,127.0.0.1,::1,[::1]');
+    expect(childEnv['NO_PROXY']).toBe('real.corp,localhost,127.0.0.1,::1');
+    expect(childEnv['no_proxy']).toBe('real.corp,localhost,127.0.0.1,::1');
   });
 
   it('passes the "*" wildcard override through verbatim', () => {
     const childEnv: Record<string, string> = {
-      NO_PROXY: 'corp,localhost,127.0.0.1,::1,[::1]',
-      no_proxy: 'corp,localhost,127.0.0.1,::1,[::1]',
+      NO_PROXY: 'corp,localhost,127.0.0.1,::1',
+      no_proxy: 'corp,localhost,127.0.0.1,::1',
     };
     reconcileChildNoProxy(childEnv, { NO_PROXY: '*' });
     expect(childEnv['NO_PROXY']).toBe('*');


### PR DESCRIPTION
## Related Issue

Resolve #1931

## Problem

See linked issue. In short: with an HTTP(S) proxy configured, every spawned stdio MCP server inherits `NO_PROXY=localhost,127.0.0.1,::1,[::1]`. Python's httpx (used by fastmcp and many other MCP servers) crashes while parsing the bracketed `[::1]` entry (`httpx.InvalidURL: Invalid port: ':1]'`), so every Python-based MCP server fails at startup with `Connection closed` for proxy users. Reproduced locally with httpx 0.28.1.

## What changed

- The bracketed `[::1]` entry only exists for undici 7.x's NO_PROXY parser (it mis-parses a bare `::1` as host `:` port `1`), which matters for the in-process dispatcher — not for child processes. `proxyEnvForChild()` and `reconcileChildNoProxy()` now pass a reduced loopback list (`localhost,127.0.0.1,::1`) that both httpx and undici handle.
- `resolveNoProxy()` keeps its previous default (bracketed list) for the in-process dispatcher and gains an optional `loopbackHosts` parameter; existing callers are unaffected.
- Trade-off: Node children lose the proxy bypass for literal `http://[::1]` URLs — a rare edge compared to every Python child crashing at startup.
- Also includes a test-only fix (`test/mcpCore/stubs.ts`): resolve fixture paths with `fileURLToPath` so the mcpCore suites run on Windows (`new URL(...).pathname` yields `/C:/...` there).

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my fix works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset. (changeset added)
- [x] Ran `gen-docs` skill, or this PR needs no doc update. (no doc update needed)
