### PR TITLE
feat(acp-adapter): emit usage_update frames with managed quota in _meta

### DIFF
--- a/.changeset/ACP-usage-report.md
+++ b/.changeset/ACP-usage-report.md
@@ -1,0 +1,5 @@
+---
+'@moonshot-ai/acp-adapter': patch
+---
+
+Emit `usage_update` session frames. After every turn and on session open (new/load/resume) the adapter now pushes the stable `usage_update` update with `used`/`size` from the engine's session status, so ACP clients can render context occupancy without waiting for the first prompt. When the session's provider is the managed Kimi platform, the account quota (5-hour window, weekly summary, booster balance from `/usages`, fetched at most once a minute) rides along as `_meta.kimiCode.rateLimits`; clients that do not read `_meta` see an ordinary usage frame.

--- a/.changeset/ACP-usage-report.md
+++ b/.changeset/ACP-usage-report.md
@@ -1,5 +1,5 @@
 ---
-'@moonshot-ai/acp-adapter': patch
+'@moonshot-ai/kimi-code': patch
 ---
 
-Emit `usage_update` session frames. After every turn and on session open (new/load/resume) the adapter now pushes the stable `usage_update` update with `used`/`size` from the engine's session status, so ACP clients can render context occupancy without waiting for the first prompt. When the session's provider is the managed Kimi platform, the account quota (5-hour window, weekly summary, booster balance from `/usages`, fetched at most once a minute) rides along as `_meta.kimiCode.rateLimits`; clients that do not read `_meta` see an ordinary usage frame.
+ACP: emit `usage_update` session frames. After every turn and on session open (new/load/resume) the adapter now pushes the stable `usage_update` update with `used`/`size` from the engine's session status, so ACP clients can render context occupancy without waiting for the first prompt. When the session's provider is the managed Kimi platform, the account quota (5-hour window, weekly summary, booster balance from `/usages`, fetched at most once a minute) rides along as `_meta.kimiCode.rateLimits`; clients that do not read `_meta` see an ordinary usage frame.

--- a/docs/en/reference/kimi-acp.md
+++ b/docs/en/reference/kimi-acp.md
@@ -53,7 +53,7 @@ The spec divides methods into a **stable** surface and an evolving **unstable** 
 
 | Method | Implemented | Description |
 | --- | --- | --- |
-| `session/update` | Yes | Streams `agent_message_chunk` / `tool_call*` / `plan` / `config_option_update` / `available_commands_update` |
+| `session/update` | Yes | Streams `agent_message_chunk` / `tool_call*` / `plan` / `config_option_update` / `available_commands_update` / `usage_update` |
 | `session/request_permission` | Yes | Shared channel for tool approval and question elicitation |
 | `fs/read_text_file` | Yes | File reads at the kaos layer are routed to the client (advertised via `fsCapabilities`) |
 | `fs/write_text_file` | Yes | File writes at the kaos layer are routed to the client |
@@ -67,6 +67,15 @@ The spec divides methods into a **stable** surface and an evolving **unstable** 
 | Remaining 18 methods | No | Includes session lifecycle extensions, buffer sync, inline-edit prediction, provider management, etc. |
 
 All methods not listed above return `methodNotFound`.
+
+## Usage and quota (`_meta.kimiCode.rateLimits`)
+
+A stable `usage_update` update (`used` / `size` from the session status) is
+emitted after every turn and on session open (new / load / resume). When the
+session's provider is the managed Kimi platform, the frame additionally
+carries `_meta.kimiCode.rateLimits` — the account quota from `/usages`
+(5-hour window, weekly summary, optional booster balance), fetched at most
+once a minute. Clients that do not read `_meta` see an ordinary usage frame.
 
 ## MCP Forwarding
 

--- a/docs/zh/reference/kimi-acp.md
+++ b/docs/zh/reference/kimi-acp.md
@@ -53,7 +53,7 @@ kimi acp
 
 | 方法 | 状态 | 说明 |
 | --- | --- | --- |
-| `session/update` | 是 | 流式推送 `agent_message_chunk` / `tool_call*` / `plan` / `config_option_update` / `available_commands_update` |
+| `session/update` | 是 | 流式推送 `agent_message_chunk` / `tool_call*` / `plan` / `config_option_update` / `available_commands_update` / `usage_update` |
 | `session/request_permission` | 是 | 工具审批和问题 elicitation 共用此通道 |
 | `fs/read_text_file` | 是 | kaos 层文件读取路由到客户端（通过 `fsCapabilities` 公告） |
 | `fs/write_text_file` | 是 | kaos 层文件写入路由到客户端 |
@@ -67,6 +67,14 @@ kimi acp
 | 其余 18 个方法 | 否 | 包括 session 生命周期扩展、缓冲区同步、inline-edit 预测、provider 管理等 |
 
 上述未列出的方法一律返回 `methodNotFound`。
+
+## 用量与配额（`_meta.kimiCode.rateLimits`）
+
+每个轮次结束及会话打开时（new / load / resume）都会发出稳定的 `usage_update`
+更新（取自会话状态的 `used` / `size`）。当会话的 provider 为托管 Kimi 平台时，
+帧还会携带 `_meta.kimiCode.rateLimits`——来自 `/usages` 的账户配额（5 小时窗口、
+每周汇总、可选的 booster 余额），每分钟最多拉取一次。不读取 `_meta` 的客户端看到
+的仍是普通的用量帧。
 
 ## MCP 转发
 

--- a/packages/acp-adapter/src/events-map.ts
+++ b/packages/acp-adapter/src/events-map.ts
@@ -525,3 +525,48 @@ export function configOptionUpdateNotification(
     },
   };
 }
+
+/** One quota window of the managed platform's `/usages` payload. */
+export interface RateLimitRow {
+  readonly name?: string;
+  /** Human window, e.g. `5h` / `1w` — already folded by the parser. */
+  readonly window?: string;
+  readonly used: number;
+  readonly limit: number;
+  readonly resetAt?: string;
+}
+
+/** What `_meta.kimiCode.rateLimits` carries on a `usage_update` frame. */
+export interface RateLimitsReport {
+  readonly summary?: RateLimitRow;
+  readonly limits: readonly RateLimitRow[];
+  readonly booster?: {
+    readonly balanceCents: number;
+    readonly totalCents: number;
+    readonly currency: string;
+  };
+}
+
+/**
+ * Build the stable `usage_update` frame from the engine's session status,
+ * with the managed platform's quota attached as `_meta.kimiCode.rateLimits`
+ * when the provider reports it. The frame is standard (used/size); clients
+ * that do not read `_meta` still get the context ring — same extension
+ * pattern claude-agent-acp uses for its rateLimit payload.
+ */
+export function usageReportToSessionUpdate(
+  sessionId: string,
+  status: { contextTokens: number; maxContextTokens: number },
+  rateLimits?: RateLimitsReport,
+): SessionNotification {
+  return {
+    sessionId,
+    update: {
+      sessionUpdate: 'usage_update',
+      used: status.contextTokens,
+      size: status.maxContextTokens,
+      // `undefined` never reaches the wire — JSON.stringify drops the key.
+      _meta: rateLimits === undefined ? undefined : { kimiCode: { rateLimits } },
+    },
+  };
+}

--- a/packages/acp-adapter/src/server.ts
+++ b/packages/acp-adapter/src/server.ts
@@ -402,6 +402,8 @@ export class AcpServer implements Agent {
       currentThinkingEffort,
     );
     this.sessions.set(session.id, acpSession);
+    // The ring should appear on session open, not after the first turn.
+    void acpSession.emitUsageReport();
     // Phase 14 (PLAN D11) advertises both the model and mode pickers as
     // a unified `configOptions: SessionConfigOption[]` surface. The
     // dedicated Phase 12 `modes:` field is gone — see
@@ -612,6 +614,8 @@ export class AcpServer implements Agent {
       currentThinkingEffort,
       DEFAULT_MODE_ID,
     );
+    // The ring should appear on session open, not after the first turn.
+    void acpSession.emitUsageReport();
     return { session, acpSession, configOptions };
   }
 

--- a/packages/acp-adapter/src/session.ts
+++ b/packages/acp-adapter/src/session.ts
@@ -54,7 +54,9 @@ import {
   toolProgressToSessionUpdate,
   toolResultToSessionUpdate,
   turnEndReasonToStopReason,
+  usageReportToSessionUpdate,
 } from './events-map';
+import type { RateLimitsReport, RateLimitRow } from './events-map';
 import { acpModeToToggles, DEFAULT_MODE_ID, isAcpModeId, type AcpModeId } from './modes';
 import { outcomeToQuestionAnswer, questionItemToPermissionOptions } from './question';
 import { detectSlashIntent } from './slash';
@@ -544,6 +546,89 @@ export class AcpSession {
       await this.conn.sessionUpdate(configOptionUpdateNotification(this.id, snapshot));
     } catch (err) {
       log.warn('acp: failed to emit config_option_update', {
+        sessionId: this.id,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+
+  /** Quota answers move slowly; one `/usages` fetch per minute per session. */
+  private rateLimitsCache: { at: number; report: RateLimitsReport | undefined } | undefined;
+
+  /**
+   * The managed platform's quota for the session's provider, or undefined
+   * for any non-managed provider (the frame then carries no rateLimits).
+   * Best-effort: every failure mode collapses to a cached `undefined`
+   * rather than an error, because a ring that fails to load must never
+   * take the turn down with it.
+   */
+  private async loadRateLimitsReport(modelAlias?: string): Promise<RateLimitsReport | undefined> {
+    if (this.rateLimitsCache && Date.now() - this.rateLimitsCache.at < 60_000) {
+      return this.rateLimitsCache.report;
+    }
+    let report: RateLimitsReport | undefined;
+    try {
+      const auth = this.harness?.auth;
+      if (!this.harness || typeof this.harness.getConfig !== 'function' || !auth) {
+        this.rateLimitsCache = { at: Date.now(), report: undefined };
+        return undefined;
+      }
+      const config = await this.harness.getConfig();
+      const providerKey =
+        (modelAlias !== undefined ? config.models?.[modelAlias]?.provider : undefined) ??
+        config.defaultProvider;
+      // DEFAULT_OAUTH_PROVIDER_NAME in apps/kimi-code/src/constant/app.ts;
+      // only the managed platform exposes a /usages endpoint to read.
+      if (providerKey === 'managed:kimi-code') {
+        const res = await auth.getManagedUsage(providerKey);
+        if (res.kind === 'ok') {
+          const row = (r: {
+            name?: string;
+            window?: { duration: number; unit: string };
+            used: number;
+            limit: number;
+            resetAt?: string;
+          }): RateLimitRow => ({
+            name: r.name,
+            window: r.window ? `${String(r.window.duration)}${r.window.unit[0]}` : undefined,
+            used: r.used,
+            limit: r.limit,
+            resetAt: r.resetAt,
+          });
+          report = {
+            summary: res.summary === null ? undefined : row(res.summary),
+            limits: res.limits.map(row),
+            booster: res.extraUsage
+              ? {
+                  balanceCents: res.extraUsage.balanceCents,
+                  totalCents: res.extraUsage.totalCents,
+                  currency: res.extraUsage.currency,
+                }
+              : undefined,
+          };
+        }
+      }
+    } catch {
+      report = undefined;
+    }
+    this.rateLimitsCache = { at: Date.now(), report };
+    return report;
+  }
+
+  /**
+   * Push the stable `usage_update` frame (context used/size) with the
+   * managed quota in `_meta.kimiCode.rateLimits` when available. Emitted
+   * after every turn and on session open; fire-and-forget at the call
+   * sites, under the same idle-stream discipline as the other updates.
+   */
+  async emitUsageReport(): Promise<void> {
+    try {
+      if (typeof this.session.getStatus !== 'function') return;
+      const status = await this.session.getStatus();
+      const rateLimits = await this.loadRateLimitsReport(status.model);
+      await this.conn.sessionUpdate(usageReportToSessionUpdate(this.id, status, rateLimits));
+    } catch (err) {
+      log.warn('acp: failed to emit usage_update', {
         sessionId: this.id,
         error: err instanceof Error ? err.message : String(err),
       });
@@ -1229,6 +1314,10 @@ export class AcpSession {
           if (settled) return;
           if (!isFromMainAgent(event)) return;
           settled = true;
+          // Context/quota accounting is final only now — emit it after
+          // every turn, whatever the reason (fire-and-forget; a quota
+          // fetch must never hold the prompt response).
+          void this.emitUsageReport();
           if (event.reason === 'failed') {
             // Failures bubble up via the SDK `error` payload. Phase 11.1
             // upgrades the prior "log + resolve end_turn" behaviour to

--- a/packages/acp-adapter/test/session-new.test.ts
+++ b/packages/acp-adapter/test/session-new.test.ts
@@ -266,7 +266,9 @@ describe('AcpServer session/new', () => {
 
       const response = await client.newSession({ cwd: '/tmp/work', mcpServers: [] });
 
-      expect(fakeSession.getStatus).toHaveBeenCalledOnce();
+      // Once for the thinking-effort resolution, once for the usage report
+      // emitted on session open — both must tolerate the same failure.
+      expect(fakeSession.getStatus).toHaveBeenCalled();
       const thinking = response.configOptions?.find((option) => option.id === 'thinking');
       if (thinking?.type !== 'select') throw new Error('thinking option must be a select');
       expect(thinking.currentValue).toBe(expected);

--- a/packages/acp-adapter/test/usage-report.test.ts
+++ b/packages/acp-adapter/test/usage-report.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+
+import { usageReportToSessionUpdate, type RateLimitsReport } from '../src/events-map';
+
+describe('usageReportToSessionUpdate', () => {
+  it('emits the stable used/size frame', () => {
+    const note = usageReportToSessionUpdate('sess', { contextTokens: 123, maxContextTokens: 1000 });
+    expect(note.update).toMatchObject({ sessionUpdate: 'usage_update', used: 123, size: 1000 });
+    expect((note.update as { _meta?: unknown })._meta).toBeUndefined();
+  });
+
+  it('attaches rate limits under _meta.kimiCode when present', () => {
+    const rateLimits: RateLimitsReport = {
+      summary: { used: 40, limit: 1000, window: '1w', resetAt: '2026-08-03T05:20:51Z' },
+      limits: [{ name: '5h', used: 1, limit: 100, window: '5h', resetAt: '2026-08-01T10:00:00Z' }],
+      booster: { balanceCents: 500, totalCents: 1000, currency: 'USD' },
+    };
+    const note = usageReportToSessionUpdate(
+      'sess',
+      { contextTokens: 1, maxContextTokens: 10 },
+      rateLimits,
+    );
+    const meta = (note.update as { _meta?: { kimiCode?: { rateLimits?: unknown } } })._meta;
+    expect(meta?.kimiCode?.rateLimits).toEqual(rateLimits);
+  });
+});


### PR DESCRIPTION
## Related Issue

Resolve #1855 — the base `usage_update` frame. The quota layer on top is discussed in #2483.

## Problem

ACP clients cannot render context occupancy for Kimi sessions: no `usage_update` is ever emitted, so ring/gauge UIs stay hidden for Kimi while they work for Claude (whose adapter pioneered this frame, now stable in the v1 schema). Additionally, subscription quota (5-hour / weekly windows) has no machine-readable channel outside the TUI — see #2157.

## What changed

Additive only.

- A stable `usage_update` update (`used` / `size` from `Session.getStatus()` → `contextTokens` / `maxContextTokens`) is emitted after every turn (any stop reason) and on session open (new / load / resume), so clients render the ring from the start and after each turn's accounting.
- When the session's provider is the managed Kimi platform, the account quota from `/usages` (5-hour window, weekly summary, optional booster balance) rides along as `_meta.kimiCode.rateLimits` — the same `_meta` extension pattern claude-agent-acp uses for its rate-limit payload. The fetch goes through the existing SDK auth facade (`getManagedUsage`), is cached for 60s per session, and is fully best-effort: any failure just omits the meta.
- Frame shape and emission timing follow the conventions documented by the existing ecosystem (once per completed turn, on session new/load), and the `UsageUpdate` type already exists in the bundled SDK 0.23 schema, so this is a schema-native frame, not an off-schema kind.

Verified end-to-end against a live `kimi acp` server: frame on session open with `used/size` and the `rateLimits` meta populated from the real `/usages` endpoint.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.