### PR TITLE
feat(tui): make bare URLs clickable on hyperlink-capable terminals

### DIFF
--- a/.changeset/clickable-terminal-urls.md
+++ b/.changeset/clickable-terminal-urls.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": minor
+---
+
+Make bare URLs clickable (Cmd/Ctrl-click) in tool and shell output, user messages, and the login prompt on hyperlink-capable terminals such as iTerm2, kitty, Ghostty, WezTerm, Warp, and VS Code.

--- a/apps/kimi-code/src/tui/components/chrome/device-code-box.ts
+++ b/apps/kimi-code/src/tui/components/chrome/device-code-box.ts
@@ -10,6 +10,7 @@ import type { Component } from '@moonshot-ai/pi-tui';
 import { truncateToWidth, visibleWidth } from '@moonshot-ai/pi-tui';
 
 import { currentTheme } from '#/tui/theme';
+import { linkifyTerminalUrls } from '#/tui/utils/linkify';
 
 export interface DeviceCodeBoxParams {
   readonly title: string;
@@ -41,7 +42,8 @@ export class DeviceCodeBoxComponent implements Component {
       innerWidth,
       '…',
     );
-    const urlLine = truncateToWidth(currentTheme.fg('primary', url), innerWidth, '…');
+    // The one URL the user must open: make it clickable where possible.
+    const urlLine = truncateToWidth(currentTheme.fg('primary', linkifyTerminalUrls(url)), innerWidth, '…');
 
     const codeLabel = currentTheme.boldFg('textDim', 'Verification code:  ');
     const codeValue = currentTheme.boldFg('accent', code);

--- a/apps/kimi-code/src/tui/components/messages/tool-call.ts
+++ b/apps/kimi-code/src/tui/components/messages/tool-call.ts
@@ -26,6 +26,7 @@ import { createMarkdownTheme } from '#/tui/theme/pi-tui-theme';
 import type { ToolCallBlockData, ToolResultBlockData } from '#/tui/types';
 import type { TokenUsage } from '@moonshot-ai/kimi-code-sdk';
 import { appendStreamingArgsPreview } from '#/tui/utils/event-payload';
+import { linkifyTerminalUrls } from '#/tui/utils/linkify';
 import { decodeMcpToolName } from '#/tui/utils/mcp-tool-name';
 import { isRenderCacheEnabled } from '#/tui/utils/render-cache';
 import { formatTokenCount } from '#/utils/usage/usage-format';
@@ -45,7 +46,6 @@ const MAX_SUBAGENT_DESCRIPTION_LENGTH = 60;
 const APPROVED_PLAN_MARKER = '## Approved Plan:';
 const AUTO_APPROVED_PLAN_MARKER = '## Plan (auto-approved, not user-reviewed):';
 const STREAMING_PROGRESS_INTERVAL_MS = 1000;
-const PROGRESS_URL_RE = /https?:\/\/\S+/g;
 const ABORTED_MARK = '⊘';
 const MAX_LIVE_OUTPUT_CHARS = 50_000;
 
@@ -1549,9 +1549,9 @@ export class ToolCallComponent extends Container {
 
   /**
    * Render the accumulated `progressLines` between the call preview and
-   * the result body. URLs inside a line are wrapped in an OSC 8 hyperlink
-   * sequence so terminals that support it (iTerm2, Ghostty, kitty, modern
-   * Terminal.app, VS Code) make the URL Cmd-clickable and expose
+   * the result body. URLs inside a line go through the shared,
+   * capability-gated linkifier so terminals that support OSC 8 (iTerm2,
+   * Ghostty, kitty, VS Code) make the URL Cmd-clickable and expose
    * "Copy Link" via the context menu — even when pi-tui soft-wraps the
    * URL across multiple rows (pi-tui's wrapTextWithAnsi re-opens the
    * active OSC 8 link on each continuation line). Each embedded URL is
@@ -1565,14 +1565,8 @@ export class ToolCallComponent extends Container {
         this.addChild(new Text('', 2, 0));
         continue;
       }
-      PROGRESS_URL_RE.lastIndex = 0;
-      const styled = PROGRESS_URL_RE.test(raw)
-        ? raw.replace(PROGRESS_URL_RE, (url) => {
-          const visible = currentTheme.underlineFg('warning', url);
-          return `\u001B]8;;${url}\u001B\\${visible}\u001B]8;;\u001B\\`;
-        })
-        : currentTheme.dim(raw);
-      PROGRESS_URL_RE.lastIndex = 0;
+      const linkified = linkifyTerminalUrls(raw, (s) => currentTheme.underlineFg('warning', s));
+      const styled = linkified === raw ? currentTheme.dim(raw) : linkified;
       this.addChild(new Text(styled, 2, 0));
     }
   }

--- a/apps/kimi-code/src/tui/components/messages/tool-renderers/truncated.ts
+++ b/apps/kimi-code/src/tui/components/messages/tool-renderers/truncated.ts
@@ -2,6 +2,7 @@ import { Text, truncateToWidth, type Component } from '@moonshot-ai/pi-tui';
 
 import { currentTheme } from '#/tui/theme';
 import type { ColorPalette } from '#/tui/theme/colors';
+import { linkifyTerminalUrls } from '#/tui/utils/linkify';
 
 import type { ResultRenderer } from './types';
 import { PREVIEW_LINES } from './types';
@@ -56,7 +57,7 @@ export class TruncatedOutputComponent implements Component {
     this.indent = options.indent ?? DEFAULT_INDENT;
     this.expandHint = options.expandHint ?? true;
     this.tail = options.tail ?? false;
-    const cleaned = trimTrailingEmptyLines(output.split('\n')).join('\n');
+    const cleaned = linkifyTerminalUrls(trimTrailingEmptyLines(output.split('\n')).join('\n'));
     const successColor = options.color ?? 'textDim';
     this.textComponent = new Text(
       options.isError ? currentTheme.fg('error', cleaned) : currentTheme.fg(successColor, cleaned),

--- a/apps/kimi-code/src/tui/components/messages/user-message.ts
+++ b/apps/kimi-code/src/tui/components/messages/user-message.ts
@@ -8,6 +8,7 @@ import { ImageThumbnail } from '#/tui/components/media/image-thumbnail';
 import { USER_MESSAGE_BULLET } from '#/tui/constant/symbols';
 import { currentTheme } from '#/tui/theme';
 import type { ImageAttachment } from '#/tui/utils/image-attachment-store';
+import { linkifyTerminalUrls } from '#/tui/utils/linkify';
 import { isRenderCacheEnabled } from '#/tui/utils/render-cache';
 
 export class UserMessageComponent implements Component {
@@ -62,7 +63,8 @@ export class UserMessageComponent implements Component {
 
     // Text is re-dyed from the current theme; invalidate() (theme change) clears
     // the render cache so the new colours are picked up on the next render.
-    const coloredText = currentTheme.boldFg('roleUser', this.text);
+    // Bare URLs become OSC 8 links on hyperlink-capable terminals.
+    const coloredText = currentTheme.boldFg('roleUser', linkifyTerminalUrls(this.text));
     const textLines = new Text(coloredText, 0, 0).render(contentWidth);
     for (let i = 0; i < textLines.length; i++) {
       const prefix = i === 0 ? bullet : ' '.repeat(bulletWidth);

--- a/apps/kimi-code/src/tui/utils/linkify.ts
+++ b/apps/kimi-code/src/tui/utils/linkify.ts
@@ -17,7 +17,7 @@ import { toTerminalHyperlink } from '#/utils/terminal-hyperlink';
 const BARE_URL_RE = /https?:\/\/\S+/g;
 
 /** Punctuation that is sentence prose, not part of the URL. */
-const PROSE_TRAILING = '.,;:!?';
+const PROSE_TRAILING = '.,;:!?"\'`';
 
 /**
  * Split prose punctuation off the end of a regex-matched URL. Brackets are

--- a/apps/kimi-code/src/tui/utils/linkify.ts
+++ b/apps/kimi-code/src/tui/utils/linkify.ts
@@ -1,0 +1,71 @@
+/**
+ * Bare-URL linkification for transcript surfaces that render plain text
+ * (tool results, shell-mode output, user messages, login prompts).
+ *
+ * Assistant Markdown already emits OSC 8 hyperlinks for links and bare URLs
+ * on capable terminals; this utility gives the non-Markdown surfaces the
+ * same behavior through one capability-gated chokepoint. On terminals that
+ * do not support OSC 8 (Terminal.app, JetBrains, unknown) it is a no-op, so
+ * URLs stay literal and the terminal's own detection keeps working.
+ */
+
+import { getCapabilities } from '@moonshot-ai/pi-tui';
+
+import { currentTheme } from '#/tui/theme';
+import { toTerminalHyperlink } from '#/utils/terminal-hyperlink';
+
+const BARE_URL_RE = /https?:\/\/\S+/g;
+
+/** Punctuation that is sentence prose, not part of the URL. */
+const PROSE_TRAILING = '.,;:!?';
+
+/**
+ * Split prose punctuation off the end of a regex-matched URL. Brackets are
+ * only treated as prose when the URL has no matching opener, so
+ * `https://en.wikipedia.org/wiki/Foo_(bar)` survives intact.
+ */
+function splitTrailingProse(raw: string): { url: string; trailing: string } {
+  let url = raw;
+  let trailing = '';
+  while (url.length > 0) {
+    const last = url.at(-1)!;
+    if (PROSE_TRAILING.includes(last)) {
+      url = url.slice(0, -1);
+      trailing = last + trailing;
+      continue;
+    }
+    if (last === ')' && !url.includes('(')) {
+      url = url.slice(0, -1);
+      trailing = `)${trailing}`;
+      continue;
+    }
+    if (last === ']' && !url.includes('[')) {
+      url = url.slice(0, -1);
+      trailing = `]${trailing}`;
+      continue;
+    }
+    break;
+  }
+  return { url, trailing };
+}
+
+/**
+ * Wrap bare http(s) URLs in OSC 8 hyperlinks (BEL-terminated, matching the
+ * OAuth convention pi-tui's wrap utils preserve). Returns the input
+ * unchanged when the terminal cannot render hyperlinks or no URLs match.
+ *
+ * `style` customizes the linked text's look (default: underline); callers
+ * that wrap the result in a surrounding chalk color get correct nesting for
+ * free.
+ */
+export function linkifyTerminalUrls(
+  text: string,
+  style: (s: string) => string = (s) => currentTheme.underline(s),
+): string {
+  if (!getCapabilities().hyperlinks) return text;
+  return text.replace(BARE_URL_RE, (raw) => {
+    const { url, trailing } = splitTrailingProse(raw);
+    if (url.length === 0) return raw;
+    return toTerminalHyperlink(style(url), url) + trailing;
+  });
+}

--- a/apps/kimi-code/src/tui/utils/shell-output.ts
+++ b/apps/kimi-code/src/tui/utils/shell-output.ts
@@ -1,4 +1,5 @@
 import { currentTheme } from '#/tui/theme';
+import { linkifyTerminalUrls } from '#/tui/utils/linkify';
 
 // Captured command output can contain terminal control sequences — colours,
 // cursor moves, alternate-screen switches, hyperlinks, `\r` spinners, bells, …
@@ -53,9 +54,11 @@ export function formatBashOutputForDisplay(stdout: string, stderr: string, isErr
   try {
     const dim = (s: string): string => currentTheme.fg('textDim', s);
     const parts: string[] = [];
-    const cleanStdout = sanitizeShellOutput(stdout).trimEnd();
+    // Sanitized output is plain text again, so bare URLs are safe to
+    // re-linkify here (no-op on terminals without OSC 8 support).
+    const cleanStdout = linkifyTerminalUrls(sanitizeShellOutput(stdout).trimEnd());
     if (cleanStdout.length > 0) parts.push(dim(cleanStdout));
-    const cleanStderr = sanitizeShellOutput(stderr).trimEnd();
+    const cleanStderr = linkifyTerminalUrls(sanitizeShellOutput(stderr).trimEnd());
     if (cleanStderr.length > 0) {
       // Dim grey normally; red only on actual failure (so warnings on a
       // successful command are not mistaken for errors).

--- a/apps/kimi-code/test/tui/components/chrome/device-code-box.test.ts
+++ b/apps/kimi-code/test/tui/components/chrome/device-code-box.test.ts
@@ -1,5 +1,5 @@
-import { visibleWidth } from '@moonshot-ai/pi-tui';
-import { describe, expect, it } from 'vitest';
+import { resetCapabilitiesCache, setCapabilities, visibleWidth } from '@moonshot-ai/pi-tui';
+import { afterEach, describe, expect, it } from 'vitest';
 
 import { DeviceCodeBoxComponent } from '#/tui/components/chrome/device-code-box';
 import { darkColors } from '#/tui/theme/colors';
@@ -14,6 +14,10 @@ const title = 'Sign in to Kimi Code';
 const hint = 'Press Ctrl-C to cancel';
 
 describe('DeviceCodeBoxComponent', () => {
+  afterEach(() => {
+    resetCapabilitiesCache();
+  });
+
   it('renders a rounded border that frames the title, url and code', () => {
     const component = new DeviceCodeBoxComponent({
       title,
@@ -35,6 +39,23 @@ describe('DeviceCodeBoxComponent', () => {
     expect(joined).toContain(code);
     expect(joined).toContain(hint);
     expect(joined).toContain('Verification code');
+  });
+
+  it('makes the verification URL clickable on hyperlink-capable terminals', () => {
+    setCapabilities({ images: null, trueColor: true, hyperlinks: true });
+    const component = new DeviceCodeBoxComponent({ title, url, code });
+
+    const out = component.render(100).join('\n');
+    expect(out).toContain('\u001B]8;;' + url + '\u0007');
+  });
+
+  it('keeps the verification URL literal when hyperlinks are unsupported', () => {
+    setCapabilities({ images: null, trueColor: true, hyperlinks: false });
+    const component = new DeviceCodeBoxComponent({ title, url, code });
+
+    const out = component.render(100).join('\n');
+    expect(out).not.toContain('\u001B]8;');
+    expect(strip(out)).toContain(url);
   });
 
   it('truncates long urls when the terminal is narrow', () => {

--- a/apps/kimi-code/test/tui/components/messages/tool-renderers/truncated.test.ts
+++ b/apps/kimi-code/test/tui/components/messages/tool-renderers/truncated.test.ts
@@ -1,5 +1,5 @@
-import { visibleWidth } from '@moonshot-ai/pi-tui';
-import { describe, expect, it } from 'vitest';
+import { resetCapabilitiesCache, setCapabilities, visibleWidth } from '@moonshot-ai/pi-tui';
+import { afterEach, describe, expect, it } from 'vitest';
 
 import { TruncatedOutputComponent } from '#/tui/components/messages/tool-renderers/truncated';
 
@@ -86,5 +86,34 @@ describe('TruncatedOutputComponent', () => {
     const out = strip(component.render(80).join('\n'));
     expect(out).toContain('<system>literal text from a user file</system>');
     expect(out).toContain('<image path="/tmp/x.png">');
+  });
+});
+
+describe('TruncatedOutputComponent URL linkification', () => {
+  afterEach(() => {
+    resetCapabilitiesCache();
+  });
+
+  it('linkifies bare URLs in output on hyperlink-capable terminals', () => {
+    setCapabilities({ images: null, trueColor: true, hyperlinks: true });
+    const component = new TruncatedOutputComponent('pr: https://example.com/pull/1', {
+      expanded: false,
+      isError: false,
+    });
+
+    const out = component.render(80).join('\n');
+    expect(out).toContain("\u001B]8;;https://example.com/pull/1\u0007");
+  });
+
+  it('leaves URLs as plain text when hyperlinks are unsupported', () => {
+    setCapabilities({ images: null, trueColor: true, hyperlinks: false });
+    const component = new TruncatedOutputComponent('pr: https://example.com/pull/1', {
+      expanded: false,
+      isError: false,
+    });
+
+    const out = component.render(80).join('\n');
+    expect(out).not.toContain("\u001B]8;");
+    expect(strip(out)).toContain('pr: https://example.com/pull/1');
   });
 });

--- a/apps/kimi-code/test/tui/components/messages/user-message.test.ts
+++ b/apps/kimi-code/test/tui/components/messages/user-message.test.ts
@@ -90,6 +90,18 @@ describe('UserMessageComponent', () => {
     expect(imageLine).toContain('\u001B\\'); // intact Kitty terminator
   });
 
+  it('linkifies bare URLs on hyperlink-capable terminals', () => {
+    setCapabilities({ images: null, trueColor: true, hyperlinks: true });
+
+    const out = new UserMessageComponent('review https://example.com/pull/1 please', [])
+      .render(80)
+      .join('\n');
+
+    expect(out).toContain('\u001B]8;;https://example.com/pull/1\u0007');
+    const noLinks = out.replaceAll(/\u001B\]8;;[^\u0007]*\u0007/g, '');
+    expect(stripAnsi(noLinks)).toContain('review https://example.com/pull/1 please');
+  });
+
   it('omits the sparkles bullet when an empty bullet is provided', () => {
     setCapabilities({ images: null, trueColor: true, hyperlinks: true });
 

--- a/apps/kimi-code/test/tui/utils/linkify.test.ts
+++ b/apps/kimi-code/test/tui/utils/linkify.test.ts
@@ -1,0 +1,74 @@
+import { resetCapabilitiesCache, setCapabilities } from '@moonshot-ai/pi-tui';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { linkifyTerminalUrls } from '#/tui/utils/linkify';
+
+const ESC = '\u001B';
+const BEL = '\u0007';
+
+function stripAnsi(text: string): string {
+  return text
+    .replaceAll(/\u001B\]8;;[^\u0007]*\u0007/g, '')
+    .replaceAll(/\u001B\[[0-9;]*m/g, '');
+}
+
+describe('linkifyTerminalUrls', () => {
+  afterEach(() => {
+    resetCapabilitiesCache();
+  });
+
+  it('returns the input unchanged when the terminal cannot render hyperlinks', () => {
+    setCapabilities({ images: null, trueColor: true, hyperlinks: false });
+
+    const input = 'see https://example.com for details';
+    expect(linkifyTerminalUrls(input)).toBe(input);
+  });
+
+  it('wraps a bare URL in a BEL-terminated OSC 8 hyperlink', () => {
+    setCapabilities({ images: null, trueColor: true, hyperlinks: true });
+
+    const out = linkifyTerminalUrls('see https://example.com for details');
+
+    expect(out).toContain(`${ESC}]8;;https://example.com${BEL}`);
+    expect(out).toContain(`${ESC}]8;;${BEL}`);
+    // Link text stays visible and surrounding prose is untouched.
+    expect(stripAnsi(out)).toContain('see https://example.com for details');
+  });
+
+  it('linkifies multiple URLs in one string', () => {
+    setCapabilities({ images: null, trueColor: true, hyperlinks: true });
+
+    const out = linkifyTerminalUrls('open https://a.example.com then https://b.example.com/x');
+
+    expect(out).toContain(`${ESC}]8;;https://a.example.com${BEL}`);
+    expect(out).toContain(`${ESC}]8;;https://b.example.com/x${BEL}`);
+  });
+
+  it('keeps sentence punctuation outside the link', () => {
+    setCapabilities({ images: null, trueColor: true, hyperlinks: true });
+
+    const out = linkifyTerminalUrls('merged at https://example.com/pr/1.');
+
+    expect(out).toContain(`${ESC}]8;;https://example.com/pr/1${BEL}`);
+    expect(stripAnsi(out).endsWith('.')).toBe(true);
+  });
+
+  it('keeps a prose closing paren outside the link but preserves balanced parens', () => {
+    setCapabilities({ images: null, trueColor: true, hyperlinks: true });
+
+    const prose = linkifyTerminalUrls('(see https://example.com)');
+    expect(prose).toContain(`${ESC}]8;;https://example.com${BEL}`);
+    expect(stripAnsi(prose)).toBe('(see https://example.com)');
+
+    const balanced = linkifyTerminalUrls('https://example.com/wiki/Foo_(bar)');
+    expect(balanced).toContain(`${ESC}]8;;https://example.com/wiki/Foo_(bar)${BEL}`);
+  });
+
+  it('applies the custom style to the linked text', () => {
+    setCapabilities({ images: null, trueColor: true, hyperlinks: true });
+
+    const out = linkifyTerminalUrls('https://example.com', (s) => `<${s}>`);
+
+    expect(out).toContain(`${ESC}]8;;https://example.com${BEL}<https://example.com>${ESC}]8;;${BEL}`);
+  });
+});

--- a/apps/kimi-code/test/tui/utils/linkify.test.ts
+++ b/apps/kimi-code/test/tui/utils/linkify.test.ts
@@ -64,6 +64,15 @@ describe('linkifyTerminalUrls', () => {
     expect(balanced).toContain(`${ESC}]8;;https://example.com/wiki/Foo_(bar)${BEL}`);
   });
 
+  it('keeps surrounding quotes outside the link', () => {
+    setCapabilities({ images: null, trueColor: true, hyperlinks: true });
+
+    const out = linkifyTerminalUrls('echo "merged https://example.com/pull/1"');
+
+    expect(out).toContain(`${ESC}]8;;https://example.com/pull/1${BEL}`);
+    expect(stripAnsi(out)).toBe('echo "merged https://example.com/pull/1"');
+  });
+
   it('applies the custom style to the linked text', () => {
     setCapabilities({ images: null, trueColor: true, hyperlinks: true });
 

--- a/apps/kimi-code/test/tui/utils/shell-output.test.ts
+++ b/apps/kimi-code/test/tui/utils/shell-output.test.ts
@@ -1,6 +1,11 @@
-import { describe, expect, it } from 'vitest';
+import { resetCapabilitiesCache, setCapabilities } from '@moonshot-ai/pi-tui';
+import { afterEach, describe, expect, it } from 'vitest';
 
 import { formatBashOutputForDisplay, sanitizeShellOutput } from '#/tui/utils/shell-output';
+
+afterEach(() => {
+  resetCapabilitiesCache();
+});
 
 const ESC = '\u001B';
 const BEL = '\u0007';
@@ -104,5 +109,18 @@ describe('formatBashOutputForDisplay', () => {
     expect(() =>
       formatBashOutputForDisplay(undefined as unknown as string, null as unknown as string),
     ).not.toThrow();
+  });
+
+  it('re-linkifies bare URLs on hyperlink-capable terminals', () => {
+    setCapabilities({ images: null, trueColor: true, hyperlinks: true });
+    const result = formatBashOutputForDisplay('PR: https://example.com/pull/2491', '');
+    expect(result).toContain(`${ESC}]8;;https://example.com/pull/2491${BEL}`);
+  });
+
+  it('keeps URLs literal when hyperlinks are unsupported', () => {
+    setCapabilities({ images: null, trueColor: true, hyperlinks: false });
+    const result = formatBashOutputForDisplay('PR: https://example.com/pull/2491', '');
+    expect(result).not.toContain(`${ESC}]8;`);
+    expect(stripTheme(result)).toContain('PR: https://example.com/pull/2491');
   });
 });

--- a/docs/en/guides/interaction.md
+++ b/docs/en/guides/interaction.md
@@ -89,6 +89,10 @@ Press `Ctrl-G` to send the current input content to an external editor. When you
 
 Editor priority: `/editor` config → `$VISUAL` environment variable → `$EDITOR` environment variable. If none are set, run `/editor` first to choose a default.
 
+## Clickable links
+
+On terminals that support OSC 8 hyperlinks (iTerm2, kitty, Ghostty, WezTerm, Warp, VS Code, Windows Terminal, Alacritty), URLs in the conversation — assistant messages, tool and shell output, your own messages, and the login prompt — are clickable: `Cmd`-click (macOS) or `Ctrl`-click (Linux/Windows) opens them in your browser, and the terminal's context menu offers "Copy Link". On terminals without hyperlink support (such as Terminal.app), URLs stay plain text.
+
 ## Next steps
 
 - [Keyboard shortcuts](../reference/keyboard.md) — full quick-reference table of all shortcuts

--- a/docs/zh/guides/interaction.md
+++ b/docs/zh/guides/interaction.md
@@ -89,6 +89,10 @@ Agent 思考或调用工具时，输入框仍然可用，支持以下额外操�
 
 编辑器优先级：`/editor` 配置 > `$VISUAL` 环境变量 > `$EDITOR` 环境变量。未配置时可先运行 `/editor` 选择默认编辑器。
 
+## 可点击链接
+
+在支持 OSC 8 超链接的终端中（iTerm2、kitty、Ghostty、WezTerm、Warp、VS Code、Windows Terminal、Alacritty），对话中的 URL——助手消息、工具与 shell 输出、你自己发送的消息以及登录提示——都可以点击：macOS 用 `Cmd`-点击，Linux/Windows 用 `Ctrl`-点击即可在浏览器中打开，终端右键菜单也提供「复制链接」。在不支持超链接的终端（如 Terminal.app）中，URL 保持纯文本显示。
+
 ## 下一步
 
 - [键盘快捷键](../reference/keyboard.md) — 全部快捷键的完整速查表


### PR DESCRIPTION
## Related Issue

Resolve #2493

## Problem

URLs printed in the conversation are plain text — Cmd/Ctrl+click does nothing. Everyday cases: the PR link `gh pr create` prints in shell output, the OAuth device-code URL you must open to log in, a URL pasted into a prompt. Assistant Markdown already emits OSC 8 hyperlinks on capable terminals; the plain-text surfaces never got the same treatment.

## What changed

Bare URLs are now clickable across the remaining surfaces, all behind pi-tui's existing capability detection (`getCapabilities().hyperlinks` — iTerm2, kitty, Ghostty, WezTerm, Warp, VS Code, Windows Terminal, Alacritty, tmux-when-forwarding). **On terminals without OSC 8 support (Terminal.app, JetBrains, unknown), rendering is byte-identical to today** and literal URLs keep working with the terminal's own detection.

Tool output URLs underlined and clickable (dev build, capability-forced xterm — stub session, no API calls):

<img src="https://github.com/lucastononro/kimi-code/releases/download/clickable-terminal-urls-evidence/links-final.png" width="800">

### How it works

One shared, capability-gated `linkifyTerminalUrls` util (new, `src/tui/utils/linkify.ts`): wraps bare http(s) URLs in BEL-terminated OSC 8 with underline styling, and trims prose punctuation off the link target (`https://x.com/a.`, `(see https://x.com)`, while `…/Foo_(bar)` survives). Applied at the chokepoints:

- **`TruncatedOutputComponent`** — one place, covers all tool result bodies (where `gh`/CI/deploy URLs appear).
- **`formatBashOutputForDisplay`** — shell-mode (`!`) cards; sanitization still strips sequences that tools emit themselves, our own links are re-added after.
- **`UserMessageComponent`** — URLs you type are clickable too.
- **`DeviceCodeBoxComponent`** — the OAuth verification URL, the one link every user must open.
- **Tool progress lines** — migrated from an ad-hoc ungated ST-terminated emitter to the shared util (gains the capability gate and the more portable BEL terminator).

pi-tui itself is untouched — the engine's OSC 8 pass-through, wrap/re-open, and per-line reset already handle everything.

### Validation

- `apps/kimi-code` vitest suite: **2480 passed** (new util tests: capability gating, punctuation trimming, BEL terminator, custom styles; surface tests for tool output, shell output, user messages, device-code box — asserting both emission when capable and byte-identical output when not)
- `pnpm lint` clean, monorepo `pnpm typecheck` clean
- Runtime evidence: screenshot above; escape-level capture from a macOS run of the dev build confirming OSC 8 emission

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.

<!-- evidence cleanup: gh release delete clickable-terminal-urls-evidence --repo lucastononro/kimi-code --cleanup-tag --yes -->
