### PR TITLE
fix(tui): preserve fallback provider during refresh

### DIFF
--- a/.changeset/preserve-provider-fallback.md
+++ b/.changeset/preserve-provider-fallback.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Preserve the configured fallback provider when refreshing provider models.

--- a/apps/kimi-code/test/tui/utils/refresh-providers.test.ts
+++ b/apps/kimi-code/test/tui/utils/refresh-providers.test.ts
@@ -1,3 +1,9 @@
+/**
+ * Scenario: refresh configured provider models through the TUI refresh utility.
+ * Responsibilities: persist refreshed records without losing defaults or user aliases.
+ * Wiring: an in-memory persistence host with fetch and OAuth token resolution stubbed.
+ * Run: pnpm exec vitest run apps/kimi-code/test/tui/utils/refresh-providers.test.ts
+ */
 import {
   KIMI_CODE_PROVIDER_NAME,
   resolveKimiCodeOAuthKey,
@@ -37,6 +43,9 @@ function makeRefreshHost(initial: KimiConfig): {
     }
     persisted = { ...persisted, providers, models };
     if (defaultRemoved) persisted = { ...persisted, defaultModel: undefined };
+    if (persisted.defaultProvider === providerId) {
+      persisted = { ...persisted, defaultProvider: undefined };
+    }
     return structuredClone(persisted);
   });
   const setConfig = vi.fn(async (patch: Partial<KimiConfig>) => {
@@ -124,6 +133,63 @@ describe('refreshAllProviderModels', () => {
     expect(result.unchanged).toEqual([KIMI_CODE_PROVIDER_NAME]);
     expect(fetchMock).toHaveBeenCalledTimes(1);
     expect(resolveOAuthToken).toHaveBeenCalledWith(KIMI_CODE_PROVIDER_NAME, envOauthRef);
+  });
+
+  it('preserves defaultProvider when refreshing the managed OAuth provider', async () => {
+    const baseUrl = 'https://api.example.test/coding/v1';
+    const host = makeRefreshHost({
+      providers: {
+        [KIMI_CODE_PROVIDER_NAME]: {
+          type: 'kimi',
+          baseUrl,
+          apiKey: '',
+          oauth: {
+            storage: 'file',
+            key: resolveKimiCodeOAuthKey({ baseUrl }),
+          },
+        },
+      },
+      models: {
+        'kimi-code/kimi-for-coding': {
+          provider: KIMI_CODE_PROVIDER_NAME,
+          model: 'kimi-for-coding',
+          maxContextSize: 262144,
+          capabilities: ['tool_use'],
+          displayName: 'Old Kimi',
+        },
+      },
+      defaultProvider: KIMI_CODE_PROVIDER_NAME,
+      telemetry: true,
+    } as unknown as KimiConfig);
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () =>
+        new Response(
+          JSON.stringify({
+            data: [
+              {
+                id: 'kimi-for-coding',
+                context_length: 262144,
+                supports_reasoning: false,
+                display_name: 'Fresh Kimi',
+              },
+            ],
+          }),
+          { status: 200, headers: { 'Content-Type': 'application/json' } },
+        ),
+      ),
+    );
+
+    const result = await refreshAllProviderModels({
+      getConfig: async () => host.current(),
+      removeProvider: host.removeProvider,
+      setConfig: host.setConfig,
+      resolveOAuthToken: vi.fn(async () => 'access-token'),
+    });
+
+    expect(result.failed).toEqual([]);
+    expect(result.changed).toHaveLength(1);
+    expect(host.current().defaultProvider).toBe(KIMI_CODE_PROVIDER_NAME);
   });
 
   it('can refresh only the managed OAuth provider without fetching third-party registries', async () => {

--- a/packages/oauth/src/refreshProviderModels.ts
+++ b/packages/oauth/src/refreshProviderModels.ts
@@ -443,6 +443,7 @@ export async function refreshProviderModels(
             models: next.models,
             defaultModel: next.defaultModel,
             thinking: next.thinking,
+            defaultProvider: next['defaultProvider'],
           });
           changed.push({
             providerId: KIMI_CODE_PROVIDER_NAME,
@@ -522,6 +523,7 @@ export async function refreshProviderModels(
           models: next.models,
           defaultModel: next.defaultModel,
           thinking: next.thinking,
+          defaultProvider: next['defaultProvider'],
         });
         changed.push({
           providerId,
@@ -741,6 +743,7 @@ export async function refreshProviderModels(
           models: next.models,
           defaultModel: next.defaultModel,
           thinking: next.thinking,
+          defaultProvider: next['defaultProvider'],
         });
         for (const change of changedProviders) {
           changed.push({


### PR DESCRIPTION
## Related Issue

None. This is a focused, reproducible bug fix found while reviewing the current main branch.

## Problem

Provider model refreshes use a remove-then-set flow so stale model aliases can be deleted. Removing a provider also clears `defaultProvider` when it points to that provider.

The managed OAuth, open-platform, and custom-registry refresh branches rebuilt the provider successfully but omitted `defaultProvider` from the complete config patch. On the v2 atomic persistence path, that left the staged config without the configured fallback. A later provider refresh could then persist the missing value and silently remove a still-valid fallback provider.

## What changed

- Include the rebuilt `defaultProvider` value in every complete provider-refresh config patch.
- Preserve the fallback when a provider is refreshed and re-added.
- Continue clearing the fallback when a registry genuinely removes its provider, because the rebuilt config then explicitly carries `undefined`.
- Update the refresh test host to model the real removal cascade and add a regression test for managed OAuth refresh.
- Add a patch changeset for the CLI.

## Validation

- `pnpm exec vitest run apps/kimi-code/test/tui/utils/refresh-providers.test.ts apps/kimi-code/test/tui/kimi-tui-startup.test.ts` — 74 tests passed.
- `pnpm run typecheck` — passed across all packages and applications.
- `pnpm run lint` — passed with no errors (existing repository warnings remain).
- `git diff --check` and changeset status validation — passed.
- The full repository test suite was attempted, but the local environment hit unrelated image-compression/network timeouts and `EMFILE: too many open files`; the affected provider-refresh suites passed independently.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.