### PR TITLE
fix(agent-core): append PreToolUse output to context

### DIFF
--- a/.changeset/append-pretool-hook-output.md
+++ b/.changeset/append-pretool-hook-output.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Fix successful PreToolUse hook output not being added to the model context.

--- a/packages/agent-core/src/agent/permission/index.ts
+++ b/packages/agent-core/src/agent/permission/index.ts
@@ -1,5 +1,6 @@
 import type { Agent } from '..';
 import type { PrepareToolExecutionResult } from '../../loop';
+import type { RenderedHookResult } from '../../session/hooks';
 import { createPermissionDecisionPolicies } from './policies';
 import type {
   ApprovalResponse,
@@ -28,6 +29,7 @@ interface PolicyEvaluation {
 export class PermissionManager {
   readonly policies: PermissionPolicy[];
   readonly rules: PermissionRule[] = [];
+  private readonly allowedPreToolHookResults = new Map<string, RenderedHookResult>();
   private modeOverride: PermissionMode | undefined;
   private readonly parent: PermissionManager | undefined;
   private readonly localSessionApprovalRulePatterns = new Set<string>();
@@ -38,7 +40,9 @@ export class PermissionManager {
   ) {
     this.rules = [...(options.initialRules ?? [])];
     this.parent = options.parent;
-    this.policies = createPermissionDecisionPolicies(this.agent);
+    this.policies = createPermissionDecisionPolicies(this.agent, (toolCallId, result) => {
+      this.allowedPreToolHookResults.set(toolCallId, result);
+    });
   }
 
   get mode(): PermissionMode {
@@ -91,6 +95,12 @@ export class PermissionManager {
       ...this.localSessionApprovalRulePatterns,
       ...(this.parent?.sessionApprovalRulePatterns ?? []),
     ];
+  }
+
+  takeAllowedPreToolHookResult(toolCallId: string): RenderedHookResult | undefined {
+    const result = this.allowedPreToolHookResults.get(toolCallId);
+    this.allowedPreToolHookResults.delete(toolCallId);
+    return result;
   }
 
   async beforeToolCall(

--- a/packages/agent-core/src/agent/permission/policies/index.ts
+++ b/packages/agent-core/src/agent/permission/policies/index.ts
@@ -1,4 +1,5 @@
 import type { Agent } from '../..';
+import type { RenderedHookResult } from '../../../session/hooks';
 import type { PermissionPolicy } from '../types';
 import { AgentSwarmExclusiveDenyPermissionPolicy } from './agent-swarm-exclusive-deny';
 import { AutoModeApprovePermissionPolicy } from './auto-mode-approve';
@@ -25,10 +26,13 @@ import {
 import { YoloModeApprovePermissionPolicy } from './yolo-mode-approve';
 
 /** Permission policies run in order; the first non-undefined result wins. */
-export function createPermissionDecisionPolicies(agent: Agent): PermissionPolicy[] {
+export function createPermissionDecisionPolicies(
+  agent: Agent,
+  onAllowedPreToolHookResult?: (toolCallId: string, result: RenderedHookResult) => void,
+): PermissionPolicy[] {
   return [
     // PreToolUse hook returned a block → deny.
-    new PreToolCallHookPermissionPolicy(agent),
+    new PreToolCallHookPermissionPolicy(agent, onAllowedPreToolHookResult),
     // AgentSwarm is batch-exclusive and must run alone, regardless of permission mode.
     new AgentSwarmExclusiveDenyPermissionPolicy(),
     // auto mode + AskUserQuestion → deny.

--- a/packages/agent-core/src/agent/permission/policies/pre-tool-call-hook.ts
+++ b/packages/agent-core/src/agent/permission/policies/pre-tool-call-hook.ts
@@ -1,14 +1,22 @@
 import type { Agent } from '../..';
 import { isPlainRecord } from '../../turn/canonical-args';
+import {
+  renderAllowedHookResult,
+  resolveHookBlockDecision,
+  type RenderedHookResult,
+} from '../../../session/hooks';
 import type { PermissionPolicy, PermissionPolicyContext, PermissionPolicyResult } from '../types';
 
 export class PreToolCallHookPermissionPolicy implements PermissionPolicy {
   readonly name = 'pre-tool-call-hook';
 
-  constructor(private readonly agent: Agent) {}
+  constructor(
+    private readonly agent: Agent,
+    private readonly onAllowedResult?: (toolCallId: string, result: RenderedHookResult) => void,
+  ) {}
 
   async evaluate(context: PermissionPolicyContext): Promise<PermissionPolicyResult | undefined> {
-    const hookResult = await this.agent.hooks?.triggerBlock('PreToolUse', {
+    const hookResults = await this.agent.hooks?.trigger?.('PreToolUse', {
       matcherValue: context.toolCall.name,
       signal: context.signal,
       inputData: {
@@ -18,10 +26,16 @@ export class PreToolCallHookPermissionPolicy implements PermissionPolicy {
       },
     });
     context.signal.throwIfAborted();
-    if (hookResult === undefined) return;
+    if (hookResults === undefined) return;
+    const block = resolveHookBlockDecision('PreToolUse', hookResults);
+    if (block === undefined) {
+      const allowed = renderAllowedHookResult('PreToolUse', hookResults);
+      if (allowed !== undefined) this.onAllowedResult?.(context.toolCall.id, allowed);
+      return;
+    }
     return {
       kind: 'deny',
-      message: hookResult.reason,
+      message: block.reason,
     };
   }
 }

--- a/packages/agent-core/src/agent/turn/index.ts
+++ b/packages/agent-core/src/agent/turn/index.ts
@@ -978,6 +978,21 @@ export class TurnFlow {
               return this.agent.permission.beforeToolCall(ctx);
             },
             finalizeToolResult: async (ctx) => {
+              const preToolHookResult = this.agent.permission.takeAllowedPreToolHookResult(
+                ctx.toolCall.id,
+              );
+              if (preToolHookResult !== undefined) {
+                this.agent.context.appendUserMessage(
+                  [{ type: 'text', text: preToolHookResult.text }],
+                  { kind: 'hook_result', event: 'PreToolUse' },
+                );
+                this.agent.emitEvent({
+                  type: 'hook.result',
+                  turnId,
+                  hookEvent: preToolHookResult.event,
+                  content: preToolHookResult.message,
+                });
+              }
               // Calls rejected in preflight (e.g. invalid args) never reach
               // prepareToolExecution, so register them here — otherwise the
               // repeat breaker cannot count them and the model can re-issue

--- a/packages/agent-core/src/session/hooks/engine.ts
+++ b/packages/agent-core/src/session/hooks/engine.ts
@@ -45,7 +45,7 @@ export class HookEngine {
     event: string,
     args: HookEngineTriggerArgs = {},
   ): Promise<HookBlockDecision | undefined> {
-    return blockDecision(event, await this.trigger(event, args));
+    return resolveHookBlockDecision(event, await this.trigger(event, args));
   }
 
   fireAndForgetTrigger(
@@ -155,14 +155,14 @@ function aggregateResults(
   readonly action: 'allow' | 'block';
   readonly reason?: string;
 } {
-  const block = blockDecision(event, results);
+  const block = resolveHookBlockDecision(event, results);
   if (block !== undefined) {
     return { action: 'block', reason: block.reason };
   }
   return { action: 'allow' };
 }
 
-function blockDecision(
+export function resolveHookBlockDecision(
   event: string,
   results: readonly HookResult[],
 ): HookBlockDecision | undefined {

--- a/packages/agent-core/src/session/hooks/user-prompt.ts
+++ b/packages/agent-core/src/session/hooks/user-prompt.ts
@@ -13,18 +13,25 @@ export interface RenderedHookResult {
 export function renderUserPromptHookResult(
   results: readonly HookResult[] | undefined,
 ): RenderedHookResult | undefined {
+  return renderAllowedHookResult('UserPromptSubmit', results);
+}
+
+export function renderAllowedHookResult(
+  event: string,
+  results: readonly HookResult[] | undefined,
+): RenderedHookResult | undefined {
   const messages =
     results
       ?.filter((result) => result.action !== 'block')
-      ?.map(userPromptHookMessage)
+      ?.map(allowedHookMessage)
       .filter(isNonEmptyString) ??
     [];
   if (messages.length === 0) return undefined;
   const displayMessage = messages.join('\n\n');
   return {
-    event: 'UserPromptSubmit',
+    event,
     message: displayMessage,
-    text: messages.map((message) => renderHookResult('UserPromptSubmit', message)).join('\n'),
+    text: messages.map((message) => renderHookResult(event, message)).join('\n'),
   };
 }
 
@@ -51,7 +58,7 @@ export function renderUserPromptHookBlockResult(
   };
 }
 
-function userPromptHookMessage(result: HookResult): string | undefined {
+function allowedHookMessage(result: HookResult): string | undefined {
   if (result.timedOut === true || (result.exitCode !== undefined && result.exitCode !== 0)) {
     return undefined;
   }

--- a/packages/agent-core/test/agent/permission.test.ts
+++ b/packages/agent-core/test/agent/permission.test.ts
@@ -981,13 +981,10 @@ describe('Simple permission policy direct behavior', () => {
 
 describe('PreToolUse permission policy', () => {
   it('blocks before approval and records the hook policy decision', async () => {
-    const triggerBlock = vi.fn(async () => ({
-      block: true,
-      reason: 'blocked by hook',
-    }));
+    const trigger = vi.fn(async () => [{ action: 'block' as const, reason: 'blocked by hook' }]);
     const { manager, requestApproval, telemetryTrack } = makePermissionManager(
       async () => ({ decision: 'approved' }),
-      { hooks: { triggerBlock } as unknown as Agent['hooks'] },
+      { hooks: { trigger } as unknown as Agent['hooks'] },
     );
 
     await expect(manager.beforeToolCall(hookContext({ id: 'call_hook_block' }))).resolves
@@ -997,7 +994,7 @@ describe('PreToolUse permission policy', () => {
       });
 
     expect(requestApproval).not.toHaveBeenCalled();
-    expect(triggerBlock).toHaveBeenCalledWith('PreToolUse', {
+    expect(trigger).toHaveBeenCalledWith('PreToolUse', {
       matcherValue: 'Bash',
       signal: expect.any(AbortSignal),
       inputData: {
@@ -1015,13 +1012,12 @@ describe('PreToolUse permission policy', () => {
   });
 
   it.each(['auto', 'yolo'] as const)('runs before %s mode bypass', async (mode) => {
-    const triggerBlock = vi.fn(async () => ({
-      block: true,
-      reason: `${mode} hook block`,
-    }));
+    const trigger = vi.fn(async () => [
+      { action: 'block' as const, reason: `${mode} hook block` },
+    ]);
     const { manager, requestApproval, telemetryTrack } = makePermissionManager(
       async () => ({ decision: 'approved' }),
-      { hooks: { triggerBlock } as unknown as Agent['hooks'] },
+      { hooks: { trigger } as unknown as Agent['hooks'] },
     );
     manager.setMode(mode);
 
@@ -1043,10 +1039,10 @@ describe('PreToolUse permission policy', () => {
   });
 
   it('continues through later policies when the hook does not block', async () => {
-    const triggerBlock = vi.fn(async () => undefined);
+    const trigger = vi.fn(async () => []);
     const { manager, requestApproval, telemetryTrack } = makePermissionManager(
       async () => ({ decision: 'approved' }),
-      { hooks: { triggerBlock } as unknown as Agent['hooks'] },
+      { hooks: { trigger } as unknown as Agent['hooks'] },
     );
 
     await expect(manager.beforeToolCall(hookContext({ id: 'call_hook_allow' }))).resolves
@@ -1064,13 +1060,12 @@ describe('PreToolUse permission policy', () => {
   });
 
   it('passes an empty hook input object for non-plain arguments', async () => {
-    const triggerBlock = vi.fn(async () => ({
-      block: true,
-      reason: 'array args blocked',
-    }));
+    const trigger = vi.fn(async () => [
+      { action: 'block' as const, reason: 'array args blocked' },
+    ]);
     const { manager } = makePermissionManager(
       async () => ({ decision: 'approved' }),
-      { hooks: { triggerBlock } as unknown as Agent['hooks'] },
+      { hooks: { trigger } as unknown as Agent['hooks'] },
     );
 
     await manager.beforeToolCall(
@@ -1081,7 +1076,7 @@ describe('PreToolUse permission policy', () => {
       }),
     );
 
-    expect(triggerBlock).toHaveBeenCalledWith(
+    expect(trigger).toHaveBeenCalledWith(
       'PreToolUse',
       expect.objectContaining({
         inputData: {

--- a/packages/agent-core/test/agent/tool.test.ts
+++ b/packages/agent-core/test/agent/tool.test.ts
@@ -66,6 +66,37 @@ describe('Agent tools', () => {
     expect(JSON.stringify(ctx.agent.context.data().history)).toContain('blocked by PreToolUse');
   });
 
+  it('appends successful PreToolUse stdout to model context after the tool result', async () => {
+    const hookEngine = new HookEngine([
+      {
+        event: 'PreToolUse',
+        matcher: 'Bash',
+        command: 'node -e "process.stdout.write(\'UNTRUSTED-CONTENT-MARKER\')"',
+      },
+    ]);
+    const ctx = testAgent({
+      kaos: createCommandKaos('tool output'),
+      hookEngine,
+    });
+    ctx.configure({ tools: ['Bash'] });
+    await ctx.rpc.setPermission({ mode: 'auto' });
+
+    ctx.mockNextResponse({ type: 'text', text: 'I will run Bash.' }, bashCall());
+    ctx.mockNextResponse({ type: 'text', text: 'The command completed.' });
+    await ctx.rpc.prompt({ input: [{ type: 'text', text: 'Run Bash' }] });
+
+    await ctx.untilTurnEnd();
+
+    expect(ctx.llmCalls).toHaveLength(2);
+    const history = ctx.llmCalls[1]!.history;
+    const toolResultIndex = history.findIndex((message) => message.role === 'tool');
+    const hookResultIndex = history.findIndex((message) =>
+      JSON.stringify(message).includes('UNTRUSTED-CONTENT-MARKER'),
+    );
+    expect(hookResultIndex).toBeGreaterThan(toolResultIndex);
+    expect(history[hookResultIndex]?.role).toBe('user');
+  });
+
   it('emits PostToolUse after successful tools', async () => {
     const triggered: Array<[string, string, number]> = [];
     const hookEngine = new HookEngine(


### PR DESCRIPTION
## Related Issue

Resolve #2107

## Problem

Successful `PreToolUse` hooks can print additional context to stdout, but that output is currently discarded after the hook allows the tool call. As a result, the model never sees context provided by the hook.

## What changed

- Preserve successful `PreToolUse` hook results in the permission flow.
- Append non-empty hook stdout to the model context as a `<hook_result hook_event="PreToolUse">` user message after the corresponding tool result.
- Emit the existing `hook.result` event for the preserved result.
- Reuse the hook-output renderer shared with `UserPromptSubmit`.
- Add regression coverage for the context message and its ordering, and update permission-policy tests for the full hook result path.

The hook message is deferred until turn finalization so the assistant tool call remains immediately followed by its tool result, preserving valid tool-call history ordering.

## Verification

- `pnpm --filter @moonshot-ai/agent-core test -- test/agent/tool.test.ts test/agent/permission.test.ts test/session/hooks/engine.test.ts` (221 passed)
- Turn/hooks integration suite (97 passed)
- `pnpm --filter @moonshot-ai/agent-core typecheck`
- Targeted lint (0 errors; 3 existing warnings)
- `git diff --check`

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.

The existing English and Chinese hook documentation already describes successful stdout being appended to context, so no documentation update is needed.
