### PR TITLE
fix(kosong): preserve Kimi's native tool-call id format

### DIFF
--- a/.changeset/kimi-native-tool-call-id.md
+++ b/.changeset/kimi-native-tool-call-id.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Fix stuck turns with self-hosted Kimi models served through an OpenAI-compatible endpoint.

--- a/packages/agent-core-v2/src/kosong/provider/bases/openai/openai-legacy.ts
+++ b/packages/agent-core-v2/src/kosong/provider/bases/openai/openai-legacy.ts
@@ -52,12 +52,15 @@ import {
   requireProviderApiKey,
   resolveAuthBackedClient,
 } from '../request-auth';
-import { normalizeToolCallIdsForProvider, sanitizeToolCallId } from '../tool-call-id';
+import {
+  normalizeToolCallIdsForProvider,
+  sanitizeToolCallIdPreservingNative,
+} from '../tool-call-id';
 
 const CHAT_COMPLETIONS_MAX_OUTPUT_TOKENS_CEILING = 128 * 1024;
 
 export const OPENAI_CHAT_TOOL_CALL_ID_POLICY: ToolCallIdPolicy = {
-  normalize: (id) => sanitizeToolCallId(id, 64),
+  normalize: (id) => sanitizeToolCallIdPreservingNative(id, 64),
   maxLength: 64,
 };
 

--- a/packages/agent-core-v2/src/kosong/provider/bases/openai/openai-responses.ts
+++ b/packages/agent-core-v2/src/kosong/provider/bases/openai/openai-responses.ts
@@ -47,7 +47,10 @@ import {
   requireProviderApiKey,
   resolveAuthBackedClient,
 } from '../request-auth';
-import { normalizeToolCallIdsForProvider, sanitizeOpenAIResponsesCallId } from '../tool-call-id';
+import {
+  normalizeToolCallIdsForProvider,
+  sanitizeOpenAIResponsesCallIdPreservingNative,
+} from '../tool-call-id';
 
 function normalizeResponsesFinishReason(
   status: string | null | undefined,
@@ -79,7 +82,7 @@ function normalizeResponsesFinishReason(
 
 type RawObject = Record<string, unknown>;
 const OPENAI_RESPONSES_TOOL_CALL_ID_POLICY: ToolCallIdPolicy = {
-  normalize: (id) => sanitizeOpenAIResponsesCallId(id, 64),
+  normalize: (id) => sanitizeOpenAIResponsesCallIdPreservingNative(id, 64),
   maxLength: 64,
 };
 

--- a/packages/agent-core-v2/src/kosong/provider/bases/tool-call-id.ts
+++ b/packages/agent-core-v2/src/kosong/provider/bases/tool-call-id.ts
@@ -10,9 +10,33 @@ export function sanitizeToolCallId(id: string, maxLength?: number): string {
   return maxLength === undefined ? sanitized : sanitized.slice(0, maxLength);
 }
 
+const KIMI_NATIVE_TOOL_CALL_ID = /^functions\.[A-Za-z0-9_-]+:\d+$/;
+
+export function sanitizeToolCallIdPreservingNative(
+  id: string,
+  fallbackMaxLength?: number,
+): string {
+  return KIMI_NATIVE_TOOL_CALL_ID.test(id) ? id : sanitizeToolCallId(id, fallbackMaxLength);
+}
+
+function isPreservableResponsesCallId(id: string, maxLength?: number): boolean {
+  return KIMI_NATIVE_TOOL_CALL_ID.test(id) && (maxLength === undefined || id.length <= maxLength);
+}
+
 export function sanitizeOpenAIResponsesCallId(id: string, maxLength?: number): string {
   const [callId] = id.split('|', 1);
   return sanitizeToolCallId(callId ?? id, maxLength);
+}
+
+export function sanitizeOpenAIResponsesCallIdPreservingNative(
+  id: string,
+  maxLength?: number,
+): string {
+  const [callId] = id.split('|', 1);
+  const base = callId ?? id;
+  return isPreservableResponsesCallId(base, maxLength)
+    ? base
+    : sanitizeOpenAIResponsesCallId(id, maxLength);
 }
 
 export function normalizeToolCallIdsForProvider(

--- a/packages/agent-core-v2/test/kosong/provider/composition.test.ts
+++ b/packages/agent-core-v2/test/kosong/provider/composition.test.ts
@@ -622,6 +622,7 @@ async function captureGoogleBody(
 async function captureResponsesBody(
   provider: ChatProvider,
   options?: GenerateOptions,
+  history: Message[] = PROBE_HISTORY,
 ): Promise<Record<string, unknown>> {
   let captured: Record<string, unknown> | undefined;
   const client = sdkClient(provider) as { responses: { create: unknown } };
@@ -629,7 +630,7 @@ async function captureResponsesBody(
     captured = params as Record<string, unknown>;
     return Promise.resolve(responsesEventStream());
   });
-  await drain(await provider.generate('', [], PROBE_HISTORY, options));
+  await drain(await provider.generate('', [], history, options));
   if (captured === undefined) throw new Error('expected responses.create to be called');
   return captured;
 }
@@ -655,6 +656,114 @@ describe('per-turn intent wire encoding (behavior probes)', () => {
     expect(body['max_completion_tokens']).toBe(5000);
     expect(body).not.toHaveProperty('max_tokens');
     expect(body).not.toHaveProperty('reasoning_effort');
+  });
+
+  it('preserves a canonical Kimi-native tool call id end-to-end through the composed Kimi provider', async () => {
+    const provider = registry.createChatProvider({
+      protocol: 'openai',
+      providerType: 'kimi',
+      modelName: 'kimi-k2',
+      apiKey: 'sk-probe',
+    });
+
+    const history: Message[] = [
+      { role: 'user', content: [{ type: 'text', text: 'Run bash' }], toolCalls: [] },
+      {
+        role: 'assistant',
+        content: [],
+        toolCalls: [
+          { type: 'function', id: 'functions.Bash:0', name: 'Bash', arguments: '{"command":"pwd"}' },
+        ],
+      },
+      {
+        role: 'tool',
+        content: [{ type: 'text', text: '/tmp' }],
+        toolCallId: 'functions.Bash:0',
+        toolCalls: [],
+      },
+    ];
+
+    const body = await captureOpenAIBody(provider, undefined, history);
+    const messages = body['messages'] as Array<Record<string, unknown>>;
+    const assistant = messages.find((m) => m['role'] === 'assistant');
+    const toolResult = messages.find((m) => m['role'] === 'tool');
+    if (assistant === undefined || toolResult === undefined) {
+      throw new Error('expected assistant and tool messages on the wire');
+    }
+
+    const [toolCall] = assistant['tool_calls'] as Array<Record<string, unknown>>;
+    expect(toolCall?.['id']).toBe('functions.Bash:0');
+    expect(toolResult['tool_call_id']).toBe('functions.Bash:0');
+  });
+
+  it('sanitizes a non-canonical historical tool call id through the composed Kimi provider', async () => {
+    const provider = registry.createChatProvider({
+      protocol: 'openai',
+      providerType: 'kimi',
+      modelName: 'kimi-k2',
+      apiKey: 'sk-probe',
+    });
+
+    const history: Message[] = [
+      { role: 'user', content: [{ type: 'text', text: 'Run bash' }], toolCalls: [] },
+      {
+        role: 'assistant',
+        content: [],
+        toolCalls: [
+          { type: 'function', id: 'Bash:7', name: 'Bash', arguments: '{"command":"pwd"}' },
+        ],
+      },
+      {
+        role: 'tool',
+        content: [{ type: 'text', text: '/tmp' }],
+        toolCallId: 'Bash:7',
+        toolCalls: [],
+      },
+    ];
+
+    const body = await captureOpenAIBody(provider, undefined, history);
+    const messages = body['messages'] as Array<Record<string, unknown>>;
+    const assistant = messages.find((m) => m['role'] === 'assistant');
+    const toolResult = messages.find((m) => m['role'] === 'tool');
+    if (assistant === undefined || toolResult === undefined) {
+      throw new Error('expected assistant and tool messages on the wire');
+    }
+
+    const [toolCall] = assistant['tool_calls'] as Array<Record<string, unknown>>;
+    expect(toolCall?.['id']).toBe('Bash_7');
+    expect(toolResult['tool_call_id']).toBe('Bash_7');
+  });
+
+  it('preserves a canonical Kimi-native tool call id through OpenAIResponsesChatProvider.generate()', async () => {
+    const provider = new OpenAIResponsesChatProvider({ model: 'kimi-k2', apiKey: 'sk-probe' });
+
+    const history: Message[] = [
+      { role: 'user', content: [{ type: 'text', text: 'Run bash' }], toolCalls: [] },
+      {
+        role: 'assistant',
+        content: [],
+        toolCalls: [
+          { type: 'function', id: 'functions.Bash:0', name: 'Bash', arguments: '{"command":"pwd"}' },
+        ],
+      },
+      {
+        role: 'tool',
+        content: [{ type: 'text', text: '/tmp' }],
+        toolCallId: 'functions.Bash:0',
+        toolCalls: [],
+      },
+    ];
+
+    const body = await captureResponsesBody(provider, undefined, history);
+    const input = body['input'] as Array<Record<string, unknown>>;
+    const call = input.find((i) => i['type'] === 'function_call');
+    const output = input.find((i) => i['type'] === 'function_call_output');
+    if (call === undefined || output === undefined) {
+      throw new Error('expected function_call and function_call_output items on the wire');
+    }
+
+    expect(call['call_id']).toBe('functions.Bash:0');
+    expect(output['call_id']).toBe('functions.Bash:0');
   });
 
   it('encodes cacheKey on plain OpenAI as the native prompt_cache_key', async () => {

--- a/packages/kosong/src/providers/kimi.ts
+++ b/packages/kosong/src/providers/kimi.ts
@@ -40,7 +40,7 @@ import {
 } from './request-auth';
 import {
   normalizeToolCallIdsForProvider,
-  sanitizeToolCallId,
+  sanitizeToolCallIdPreservingNative,
   type ToolCallIdPolicy,
 } from './tool-call-id';
 export interface KimiOptions {
@@ -86,7 +86,7 @@ export interface ExtraBody {
   [key: string]: unknown;
 }
 const KIMI_TOOL_CALL_ID_POLICY: ToolCallIdPolicy = {
-  normalize: (id) => sanitizeToolCallId(id, 64),
+  normalize: (id) => sanitizeToolCallIdPreservingNative(id, 64),
   maxLength: 64,
 };
 interface OpenAIMessage {

--- a/packages/kosong/src/providers/openai-legacy.ts
+++ b/packages/kosong/src/providers/openai-legacy.ts
@@ -39,7 +39,7 @@ import {
 } from './request-auth';
 import {
   normalizeToolCallIdsForProvider,
-  sanitizeToolCallId,
+  sanitizeToolCallIdPreservingNative,
   type ToolCallIdPolicy,
 } from './tool-call-id';
 
@@ -54,8 +54,10 @@ import {
  * (the documented range is `[1, 131072]`).
  */
 const CHAT_COMPLETIONS_MAX_OUTPUT_TOKENS_CEILING = 128 * 1024;
+// Preserves a canonical Kimi-native id, because self-hosted Kimi is commonly served through an
+// OpenAI-compatible endpoint configured as an `openai` provider. See `KIMI_NATIVE_TOOL_CALL_ID`.
 const OPENAI_CHAT_TOOL_CALL_ID_POLICY: ToolCallIdPolicy = {
-  normalize: (id) => sanitizeToolCallId(id, 64),
+  normalize: (id) => sanitizeToolCallIdPreservingNative(id, 64),
   maxLength: 64,
 };
 

--- a/packages/kosong/src/providers/openai-responses.ts
+++ b/packages/kosong/src/providers/openai-responses.ts
@@ -36,7 +36,7 @@ import {
 } from './request-auth';
 import {
   normalizeToolCallIdsForProvider,
-  sanitizeOpenAIResponsesCallId,
+  sanitizeOpenAIResponsesCallIdPreservingNative,
   type ToolCallIdPolicy,
 } from './tool-call-id';
 
@@ -78,8 +78,10 @@ function normalizeResponsesFinishReason(
 }
 
 type RawObject = Record<string, unknown>;
+// Preserves a canonical Kimi-native id for the same reason as the chat policy; here the cap is a
+// real wire limit, so an over-long canonical id still normalizes. See `KIMI_NATIVE_TOOL_CALL_ID`.
 const OPENAI_RESPONSES_TOOL_CALL_ID_POLICY: ToolCallIdPolicy = {
-  normalize: (id) => sanitizeOpenAIResponsesCallId(id, 64),
+  normalize: (id) => sanitizeOpenAIResponsesCallIdPreservingNative(id, 64),
   maxLength: 64,
 };
 

--- a/packages/kosong/src/providers/tool-call-id.ts
+++ b/packages/kosong/src/providers/tool-call-id.ts
@@ -13,9 +13,67 @@ export function sanitizeToolCallId(id: string, maxLength?: number): string {
   return maxLength === undefined ? sanitized : sanitized.slice(0, maxLength);
 }
 
+// Kimi-K2 tool-call ids use the canonical native shape `functions.<name>:<idx>` — the exact format
+// the model is trained to see echoed back in conversation history. Sanitizing it (`.` and `:` become
+// `_`) makes the model emit reasoning with no tool call and stop the turn (`APIEmptyResponseError` /
+// `finishReason=stop`). Such an id is also a valid free-form id for OpenAI-compatible providers —
+// the transport that serves self-hosted Kimi (litellm / vLLM / SGLang / Azure) — so those policies
+// opt into preserving it verbatim, while charset-restricted providers (Anthropic,
+// `^[a-zA-Z0-9_-]+$`) keep sanitizing.
+//
+// The guard is keyed on the id shape rather than on the provider, because self-hosted Kimi is
+// configured as a plain `openai` provider and does not self-identify at the policy layer. Trade-off:
+// a Kimi-authored id replayed onto a different, stricter OpenAI-compatible backend is passed through
+// rather than sanitized.
+//
+// Refs: Moonshot's tool_call_guidance.md; vLLM's "Debugging Kimi K2 Tool-Calling" writeup.
+const KIMI_NATIVE_TOOL_CALL_ID = /^functions\.[A-Za-z0-9_-]+:\d+$/;
+
+/**
+ * Preserve a canonical native id verbatim; sanitize every other id.
+ *
+ * A preserved id is never length-capped: the chat-completions `tool_call.id` has no limit in the
+ * OpenAI schema (the 64-char cap applies to the function *name*, `^[a-zA-Z0-9_-]{1,64}$`), and a
+ * long tool name or a multi-digit `idx` must still round-trip intact. Hence `fallbackMaxLength`,
+ * which bounds the sanitized fallback only — deliberately unlike
+ * `sanitizeOpenAIResponsesCallIdPreservingNative`, whose cap is a real wire limit and therefore
+ * also gates preservation.
+ */
+export function sanitizeToolCallIdPreservingNative(
+  id: string,
+  fallbackMaxLength?: number,
+): string {
+  return KIMI_NATIVE_TOOL_CALL_ID.test(id) ? id : sanitizeToolCallId(id, fallbackMaxLength);
+}
+
+function isPreservableResponsesCallId(id: string, maxLength?: number): boolean {
+  return KIMI_NATIVE_TOOL_CALL_ID.test(id) && (maxLength === undefined || id.length <= maxLength);
+}
+
 export function sanitizeOpenAIResponsesCallId(id: string, maxLength?: number): string {
   const [callId] = id.split('|', 1);
   return sanitizeToolCallId(callId ?? id, maxLength);
+}
+
+/**
+ * Preserve a canonical native id verbatim, but only when it fits `maxLength`; sanitize every other
+ * id.
+ *
+ * Unlike the chat `tool_call.id`, the Responses `call_id` carries a real `maxLength` (64) on the
+ * wire, and a preserved id is sent untruncated — so an over-long canonical id must fall back to
+ * normalization rather than be rejected by the API.
+ */
+export function sanitizeOpenAIResponsesCallIdPreservingNative(
+  id: string,
+  maxLength?: number,
+): string {
+  // Mirror `sanitizeOpenAIResponsesCallId` and drop the `|<itemId>` suffix first, so a canonical
+  // native id survives even when the Responses transport has appended an item id.
+  const [callId] = id.split('|', 1);
+  const base = callId ?? id;
+  return isPreservableResponsesCallId(base, maxLength)
+    ? base
+    : sanitizeOpenAIResponsesCallId(id, maxLength);
 }
 
 export function normalizeToolCallIdsForProvider(

--- a/packages/kosong/test/anthropic.test.ts
+++ b/packages/kosong/test/anthropic.test.ts
@@ -1205,6 +1205,42 @@ describe('AnthropicChatProvider', () => {
       ]);
     });
 
+    it('still sanitizes a canonical Kimi-native id (Anthropic charset forbids `.`/`:`)', async () => {
+      // Anthropic tool ids must match `^[a-zA-Z0-9_-]+$`, so unlike the OpenAI/Kimi policies the
+      // Anthropic policy must NOT preserve `functions.<name>:<idx>` — it keeps rewriting it. This
+      // pins that the native-id preservation did not leak across the provider boundary (#327).
+      const provider = createProvider();
+      const history: Message[] = [
+        { role: 'user', content: [{ type: 'text', text: 'Read' }], toolCalls: [] },
+        {
+          role: 'assistant',
+          content: [],
+          toolCalls: [
+            {
+              type: 'function',
+              id: 'functions.Read:0',
+              name: 'Read',
+              arguments: '{"path":"/tmp/a"}',
+            },
+          ],
+        },
+        {
+          role: 'tool',
+          content: [{ type: 'text', text: 'ok' }],
+          toolCallId: 'functions.Read:0',
+          toolCalls: [],
+        },
+      ];
+
+      const body = await captureRequestBody(provider, '', [], history);
+      const messages = body['messages'] as Array<{ content: Array<Record<string, unknown>> }>;
+      expect(messages[1]?.content[0]).toMatchObject({ type: 'tool_use', id: 'functions_Read_0' });
+      expect(messages[2]?.content[0]).toMatchObject({
+        type: 'tool_result',
+        tool_use_id: 'functions_Read_0',
+      });
+    });
+
     it('tool call with image result wraps image source inside tool_result', async () => {
       const provider = createProvider();
       const toolCall: ToolCall = {

--- a/packages/kosong/test/kimi.test.ts
+++ b/packages/kosong/test/kimi.test.ts
@@ -453,6 +453,52 @@ describe('KimiChatProvider', () => {
       ]);
     });
 
+    it('preserves canonical native tool call ids (functions.<name>:<idx>) targeting Kimi', async () => {
+      // Kimi-K2 requires its native id format echoed back verbatim in history; sanitizing it
+      // to `functions_Read_0` makes the model reason without emitting a tool call. The pair
+      // above ("normalizes invalid historical tool call ids") pins the complementary case:
+      // a non-canonical id is still rewritten for cross-provider safety.
+      const provider = createProvider();
+      const history: Message[] = [
+        { role: 'user', content: [{ type: 'text', text: 'Read a file' }], toolCalls: [] },
+        {
+          role: 'assistant',
+          content: [],
+          toolCalls: [
+            {
+              type: 'function',
+              id: 'functions.Read:0',
+              name: 'Read',
+              arguments: '{"path":"/tmp/file"}',
+            },
+          ],
+        },
+        {
+          role: 'tool',
+          content: [{ type: 'text', text: 'content' }],
+          toolCallId: 'functions.Read:0',
+          toolCalls: [],
+        },
+      ];
+
+      const body = await captureRequestBody(provider, '', [], history);
+
+      expect(body['messages']).toEqual([
+        { role: 'user', content: 'Read a file' },
+        {
+          role: 'assistant',
+          tool_calls: [
+            {
+              type: 'function',
+              id: 'functions.Read:0',
+              function: { name: 'Read', arguments: '{"path":"/tmp/file"}' },
+            },
+          ],
+        },
+        { role: 'tool', content: 'content', tool_call_id: 'functions.Read:0' },
+      ]);
+    });
+
     it('tool call with image result', async () => {
       const provider = createProvider();
       const toolCall: ToolCall = {

--- a/packages/kosong/test/openai-legacy.test.ts
+++ b/packages/kosong/test/openai-legacy.test.ts
@@ -362,6 +362,82 @@ describe('OpenAILegacyChatProvider', () => {
       });
     });
 
+    it('preserves canonical Kimi-native tool call ids (self-hosted Kimi behind an OpenAI endpoint)', async () => {
+      // Self-hosted Kimi (litellm / vLLM / SGLang / Azure) is configured as an `openai`
+      // provider. Kimi-K2 requires its native id format `functions.<name>:<idx>` echoed back
+      // verbatim; sanitizing it to `functions_Bash_0` makes the model reason without emitting a
+      // tool call. The test above pins the complementary case: a non-canonical id is still
+      // rewritten for cross-provider safety.
+      const provider = createProvider();
+      const history: Message[] = [
+        { role: 'user', content: [{ type: 'text', text: 'Run bash' }], toolCalls: [] },
+        {
+          role: 'assistant',
+          content: [],
+          toolCalls: [
+            {
+              type: 'function',
+              id: 'functions.Bash:0',
+              name: 'Bash',
+              arguments: '{"command":"pwd"}',
+            },
+          ],
+        },
+        {
+          role: 'tool',
+          content: [{ type: 'text', text: '/tmp' }],
+          toolCallId: 'functions.Bash:0',
+          toolCalls: [],
+        },
+      ];
+
+      const body = await captureRequestBody(provider, '', [], history);
+
+      expect(body['messages']).toEqual([
+        { role: 'user', content: 'Run bash' },
+        {
+          role: 'assistant',
+          content: null,
+          tool_calls: [
+            {
+              type: 'function',
+              id: 'functions.Bash:0',
+              function: { name: 'Bash', arguments: '{"command":"pwd"}' },
+            },
+          ],
+        },
+        { role: 'tool', content: '/tmp', tool_call_id: 'functions.Bash:0' },
+      ]);
+    });
+
+    it('preserves a canonical id whose length exceeds the policy maxLength (chat tool_call.id is uncapped)', async () => {
+      // The chat policy carries maxLength: 64, but that cap is for sanitized non-canonical ids —
+      // the chat `tool_call.id` itself has no length limit (OpenAI's 64-char cap is on the function
+      // name). A long MCP tool name plus a multi-digit idx yields a 77-char canonical id that must
+      // still round-trip verbatim, or the very regression this fixes would reappear for such ids.
+      const longName = 'mcp__github__'.padEnd(64, 'x');
+      expect(longName).toHaveLength(64);
+      const longId = `functions.${longName}:12`;
+      expect(longId.length).toBeGreaterThan(64);
+      const provider = createProvider();
+      const history: Message[] = [
+        { role: 'user', content: [{ type: 'text', text: 'go' }], toolCalls: [] },
+        {
+          role: 'assistant',
+          content: [],
+          toolCalls: [{ type: 'function', id: longId, name: longName, arguments: '{}' }],
+        },
+        { role: 'tool', content: [{ type: 'text', text: 'ok' }], toolCallId: longId, toolCalls: [] },
+      ];
+
+      const body = await captureRequestBody(provider, '', [], history);
+      const messages = body['messages'] as Record<string, unknown>[];
+      const assistant = messages[1]!;
+      const toolCalls = assistant['tool_calls'] as Record<string, unknown>[];
+      expect(toolCalls[0]!['id']).toBe(longId);
+      expect(messages[2]!['tool_call_id']).toBe(longId);
+    });
+
     it('tool call with image result keeps the tool result textual and reattaches images as user input', async () => {
       // OpenAI Chat Completions `tool` messages only accept text content.
       // Even when toolMessageConversion is unset, a tool result containing

--- a/packages/kosong/test/openai-responses.test.ts
+++ b/packages/kosong/test/openai-responses.test.ts
@@ -782,6 +782,46 @@ describe('OpenAIResponsesChatProvider', () => {
       });
     });
 
+    it('preserves canonical Kimi-native tool call ids (self-hosted Kimi behind an OpenAI Responses endpoint)', async () => {
+      const provider = createProvider();
+      const history: Message[] = [
+        { role: 'user', content: [{ type: 'text', text: 'Run bash' }], toolCalls: [] },
+        {
+          role: 'assistant',
+          content: [],
+          toolCalls: [
+            {
+              type: 'function',
+              id: 'functions.Bash:0',
+              name: 'Bash',
+              arguments: '{"command":"pwd"}',
+            },
+          ],
+        },
+        {
+          role: 'tool',
+          content: [{ type: 'text', text: '/tmp' }],
+          toolCallId: 'functions.Bash:0',
+          toolCalls: [],
+        },
+      ];
+
+      const body = await captureRequestBody(provider, '', [], history);
+      const input = body['input'] as unknown[];
+
+      expect(input[1]).toEqual({
+        arguments: '{"command":"pwd"}',
+        call_id: 'functions.Bash:0',
+        name: 'Bash',
+        type: 'function_call',
+      });
+      expect(input[2]).toEqual({
+        call_id: 'functions.Bash:0',
+        output: [{ type: 'input_text', text: '/tmp' }],
+        type: 'function_call_output',
+      });
+    });
+
     it('assistant with reasoning (ThinkPart with encrypted)', async () => {
       const provider = createProvider();
       const history: Message[] = [

--- a/packages/kosong/test/tool-call-id.test.ts
+++ b/packages/kosong/test/tool-call-id.test.ts
@@ -1,0 +1,73 @@
+// Which id shapes count as canonical (preserved) vs normalized, and how the two length regimes
+// differ: the chat `tool_call.id` is uncapped so a canonical id survives at any length, while the
+// Responses `call_id` is capped at 64 so an over-long canonical id falls back to normalization.
+// End-to-end wiring through each provider is covered by the per-provider wire tests.
+import {
+  sanitizeOpenAIResponsesCallIdPreservingNative,
+  sanitizeToolCallIdPreservingNative,
+} from '#/providers/tool-call-id';
+import { describe, expect, it } from 'vitest';
+
+describe('sanitizeToolCallIdPreservingNative', () => {
+  it('preserves canonical native ids verbatim', () => {
+    expect(sanitizeToolCallIdPreservingNative('functions.Read:0', 64)).toBe('functions.Read:0');
+    expect(sanitizeToolCallIdPreservingNative('functions.web_search:12', 64)).toBe(
+      'functions.web_search:12',
+    );
+    // MCP tools are namespaced `mcp__<server>__<tool>` — all identifier chars, so their
+    // native ids are preserved like any builtin.
+    expect(sanitizeToolCallIdPreservingNative('functions.mcp__github__create_pr:3', 64)).toBe(
+      'functions.mcp__github__create_pr:3',
+    );
+  });
+
+  it('falls back to sanitizeToolCallId for non-canonical ids', () => {
+    expect(sanitizeToolCallIdPreservingNative('Read:9', 64)).toBe('Read_9'); // no `functions.`
+    expect(sanitizeToolCallIdPreservingNative('functions.Read:x', 64)).toBe('functions_Read_x'); // idx not numeric
+    expect(sanitizeToolCallIdPreservingNative('functions_Read_0', 64)).toBe('functions_Read_0'); // already sanitized
+    expect(sanitizeToolCallIdPreservingNative('call_abc123', 64)).toBe('call_abc123'); // OpenAI-style
+    // A name carrying a `.` is ambiguous under `functions.{name}:{idx}` parsing, so it is treated
+    // as non-canonical and normalized — the pre-existing behavior, no regression.
+    expect(sanitizeToolCallIdPreservingNative('functions.a.b:0', 64)).toBe('functions_a_b_0');
+  });
+
+  it('preserves a canonical id longer than maxLength (chat tool_call.id is uncapped)', () => {
+    // `functions.` (10) + 54-char name + `:0` (2) = 66 chars. OpenAI's 64-char cap is on the
+    // function *name*, not on tool_call.id, so a long canonical id must round-trip intact — the
+    // maxLength only bounds the sanitization fallback for non-canonical ids.
+    const longId = `functions.${'a'.repeat(54)}:0`;
+    expect(longId).toHaveLength(66);
+    expect(sanitizeToolCallIdPreservingNative(longId, 64)).toBe(longId);
+  });
+
+  it('preserves a canonical id with a multi-digit idx', () => {
+    expect(sanitizeToolCallIdPreservingNative('functions.Read:10', 64)).toBe('functions.Read:10');
+  });
+});
+
+describe('sanitizeOpenAIResponsesCallIdPreservingNative', () => {
+  it('preserves canonical native ids, including under a `|<itemId>` Responses suffix', () => {
+    expect(sanitizeOpenAIResponsesCallIdPreservingNative('functions.Read:0', 64)).toBe(
+      'functions.Read:0',
+    );
+    // The Responses transport can append `|<itemId>`; the canonical call-id part must still survive.
+    expect(sanitizeOpenAIResponsesCallIdPreservingNative('functions.Read:0|item_abc', 64)).toBe(
+      'functions.Read:0',
+    );
+  });
+
+  it('falls back to the responses sanitizer for non-canonical ids', () => {
+    expect(sanitizeOpenAIResponsesCallIdPreservingNative('call_abc123|item_1', 64)).toBe(
+      'call_abc123',
+    );
+    expect(sanitizeOpenAIResponsesCallIdPreservingNative('Read:9', 64)).toBe('Read_9');
+  });
+
+  it('does not preserve a shape-canonical call-id longer than maxLength', () => {
+    const longId = `functions.${'a'.repeat(54)}:0`;
+    expect(longId).toHaveLength(66);
+    const result = sanitizeOpenAIResponsesCallIdPreservingNative(longId, 64);
+    expect(result).not.toBe(longId);
+    expect(result.length).toBeLessThanOrEqual(64);
+  });
+});


### PR DESCRIPTION
Resolve #520

## Problem

See linked issue. Kimi models are trained to see tool-call ids echoed back in history in the canonical native shape `functions.<name>:<idx>`. The cross-provider id normalizer added in #327 rewrites that shape (`functions.Read:0` → `functions_Read_0`) on every provider, including the request back to Kimi itself, so the model stops recognizing its own prior tool call and replies with reasoning and no `tool_calls` — the turn dies as `APIEmptyResponseError`. Kimi served through an OpenAI-compatible endpoint is configured as a generic `openai` provider and takes that rewrite; the official endpoint masks the bug by normalizing server-side.

The session dump attached to #520 matches this path exactly: the provider is `type = "openai"` (Azure), the recorded history carries the canonical id `functions.Skill:0`, and the turn issues that tool call on step 1 and then fails on the step continuing from the tool result. That id is rewritten to `functions_Skill_0` before the follow-up request leaves, which is what this PR stops.

## What changed

A canonical native id is now passed through verbatim by the OpenAI chat-completions, OpenAI responses, and Kimi tool-call-id policies, in both the `kosong` and `agent-core-v2` engines; every other id keeps its exact current behavior. Preservation is keyed on the id shape because self-hosted Kimi does not self-identify at the policy layer, and Anthropic keeps sanitizing so #327's cross-provider fix stays intact.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.

## Appendix

### Evidence

Same real request, varying only the history id string, N=25 per row, against a self-hosted Kimi-K2 (vLLM/SGLang) endpoint:

| history id format | tool call emitted |
|---|---|
| `functions.Read:0` (canonical native) | **25 / 25** |
| `call_Read_0` (neutral) | 9 / 25 |
| `functions_Read_0` (sanitized — current behavior) | **0 / 25** |

Sampling parameters do not move this; only the id format does. Captured at the wire on that endpoint, stock kimi-code sends `functions_Read_0` on the OpenAI-provider route; with the fix it sends `functions.Read:0`, and an end-to-end run reads a file and completes the turn 5/5 with the canonical id preserved on both `tool_calls[].id` and the matching `tool_call_id`.

This matches vLLM's [Chasing 100% Accuracy: Debugging Kimi K2's Tool-Calling on vLLM](https://blog.vllm.ai/2025/10/28/Kimi-K2-Accuracy.html), whose recommended practice is to normalize history ids *to* `functions.func_name:idx` (a 4.4× success-rate gain), and Moonshot's [`tool_call_guidance.md`](https://huggingface.co/moonshotai/Kimi-K2-Thinking/blob/main/docs/tool_call_guidance.md): "The format of the tool ID is `functions.{func_name}:{idx}` … Incorrect tool-call IDs in multi-turn scenarios commonly cause tool-call failures."

### Design notes

- **Why not stop sanitizing for OpenAI entirely?** Sanitization still protects genuine cross-provider replay onto stricter backends. Preserving only the canonical shape is the smaller, lower-risk change.
- **Scope of the carve-out.** Preservation applies to any `openai`-type provider, not only Kimi, because the id shape is the only available signal. The cost is that a Kimi-authored id replayed onto a different, stricter OpenAI-compatible backend is passed through instead of sanitized; `functions.Read:0` is a valid free-form `tool_call.id` under the chat-completions spec, so a spec-compliant backend accepts it.
- **Length follows each API.** Chat Completions puts no length limit on `tool_call.id` (the 64-char cap is on the function *name*), so a canonical id is preserved at any length — a long MCP tool name or multi-digit `idx` must round-trip intact. The Responses `call_id` does carry `maxLength: 64` and is sent verbatim, so an over-long canonical id normalizes rather than being rejected at the wire. Both boundaries are pinned by tests.
- **Anthropic and Google are untouched.** Anthropic's `^[a-zA-Z0-9_-]+$` charset keeps calling `sanitizeToolCallId`, pinned by a test; Google matches on function names, not ids.
- **Only the documented canonical shape is preserved.** #327 describes Kimi ids in the bare `Write:6` form, and its tests use `Write:6` / `Read:9` / `Bash:7`. Those keep being sanitized here — the carve-out is deliberately limited to `functions.<name>:<idx>`, the shape Moonshot documents and the one the #520 dump actually carries. Widening the pattern to bare `<name>:<idx>` would match ordinary non-Kimi ids, so it is left out; if the bare form still occurs in the wild against a Kimi endpoint, it needs its own evidence and a separate change.

### What is not proven

The dump confirms the setup, the canonical id, and the failing step, and the rewrite itself is plain from the code path. It does not capture the outbound payload, so the final link — that the rewritten id is what makes this particular Azure deployment answer with reasoning only — rests on the reproduction above rather than on #520's own trace. A competing reading was raised in the issue thread, that the adapter conflates a reasoning-only stop with an empty response; that concerns error classification and is orthogonal to this fix. Confirmation from the reporter's Azure deployment would settle it.

### Known pre-existing limitation

When two Responses ids differ only by their `|<itemId>` suffix, they collapse to one call-id and the uniqueness pass suffixes the second one, which loses canonicality:

```
before this PR:  functions_Read_0   functions_Read_0_2    (both non-canonical)
after this PR:   functions.Read:0   functions.Read:0_2    (first one fixed)
```

This is the existing behavior of the shared uniqueness pass from #327, not a regression — the PR strictly improves it, and ids with distinct `idx` values are unaffected. Confining uniqueness to a single tool-call batch would fix the remainder but is a larger change to the shared normalizer, so it is left out of this fix.
