### PR TITLE
fix(web): coalesce streamed text chunks in history reloads

### DIFF
--- a/.changeset/web-history-text-coalesce.md
+++ b/.changeset/web-history-text-coalesce.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Coalesce consecutive streamed text/thinking chunks in Kimi Web history reloads without inserting newlines.

--- a/apps/kimi-web/src/composables/messagesToTurns.ts
+++ b/apps/kimi-web/src/composables/messagesToTurns.ts
@@ -635,26 +635,43 @@ export function messagesToTurns(
   }
 
   function absorbContent(g: Group, content: AppMessage['content']): void {
+    // Coalesce only within this message's consecutive same-kind parts — matching
+    // the live stream path (`text += delta`). Inserting '\n' between streamed
+    // chunks made history reloads show one line per chunk (see #2505). A new
+    // message, or a tool/thinking boundary, still opens a fresh segment so
+    // textParts.join('\n') keeps cross-message / post-tool boundaries.
+    let coalesceText = false;
+    let coalesceThinking = false;
     for (const c of content) {
       if (c.type === 'text') {
         if (c.text) {
-          g.textParts.push(c.text);
-          // Append to a trailing text block, else open a new one — so a tool
-          // call between two text segments splits them into separate blocks.
           const last = g.blocks.at(-1);
-          if (last && last.kind === 'text') last.text += '\n' + c.text;
-          else g.blocks.push({ kind: 'text', text: c.text });
+          if (coalesceText && last?.kind === 'text') {
+            last.text += c.text;
+            g.textParts[g.textParts.length - 1] += c.text;
+          } else {
+            g.textParts.push(c.text);
+            g.blocks.push({ kind: 'text', text: c.text });
+          }
+          coalesceText = true;
+          coalesceThinking = false;
         }
       } else if (c.type === 'thinking') {
         if (c.thinking) {
-          g.thinkingParts.push(c.thinking);
-          // Ordered block too: thinking renders WHERE it happened in the turn,
-          // merging consecutive segments (same rule as text blocks above).
           const last = g.blocks.at(-1);
-          if (last && last.kind === 'thinking') last.thinking += '\n' + c.thinking;
-          else g.blocks.push({ kind: 'thinking', thinking: c.thinking });
+          if (coalesceThinking && last?.kind === 'thinking') {
+            last.thinking += c.thinking;
+            g.thinkingParts[g.thinkingParts.length - 1] += c.thinking;
+          } else {
+            g.thinkingParts.push(c.thinking);
+            g.blocks.push({ kind: 'thinking', thinking: c.thinking });
+          }
+          coalesceThinking = true;
+          coalesceText = false;
         }
       } else if (c.type === 'toolUse') {
+        coalesceText = false;
+        coalesceThinking = false;
         // Single `Agent` subagent spawns and all other tools render as a normal
         // tool card: the card shows the fixed args (prompt / description) plus
         // the final result when expanded, while a subagent's live progress
@@ -677,6 +694,8 @@ export function messagesToTurns(
           g.approvalId = pendingApproval.approvalId;
         }
       } else if (c.type === 'toolResult') {
+        coalesceText = false;
+        coalesceThinking = false;
         // Update the matching tool call status within this group (both the flat
         // tools[] and the ordered block that renders it).
         const idx = g.tools.findIndex((t) => t.id === c.toolCallId);

--- a/apps/kimi-web/test/turn-logic.test.ts
+++ b/apps/kimi-web/test/turn-logic.test.ts
@@ -590,10 +590,31 @@ describe('messagesToTurns resync dedup', () => {
 
     expect(turns).toHaveLength(1);
     expect(turns[0]?.thinking).toBe('let me check');
-    expect(turns[0]?.text).toBe('I will \nrun ls');
+    expect(turns[0]?.text).toBe('I will run ls');
     expect(turns[0]?.tools).toHaveLength(1);
     // The seed's live progress survives the dedup — the persisted card had none.
     expect(turns[0]?.tools?.[0]?.output).toEqual(['total 8']);
+  });
+
+  it('coalesces consecutive streamed text chunks without inserting newlines', () => {
+    // History projection keeps one content part per stream delta; joining with
+    // '\n' made reloads show one line per chunk under white-space: pre-wrap.
+    const turns = messagesToTurns(
+      [
+        message('a1', 'assistant', [
+          { type: 'text', text: '你好！' },
+          { type: 'text', text: '我的' },
+          { type: 'text', text: '上下文' },
+        ]),
+      ],
+      [],
+      undefined,
+      false,
+    );
+
+    expect(turns).toHaveLength(1);
+    expect(turns[0]?.text).toBe('你好！我的上下文');
+    expect(turns[0]?.blocks).toEqual([{ kind: 'text', text: '你好！我的上下文' }]);
   });
 
   it('keeps the seeded message when the transcript has no copy of the current step yet', () => {


### PR DESCRIPTION
## Summary
- Coalesce consecutive text/thinking parts within a message when projecting history (no inserted newlines), matching the live `text += delta` path (fixes #2505).
- Keep cross-message / post-tool segment boundaries.

## Test plan
- [x] `pnpm exec vitest run test/turn-logic.test.ts` in `apps/kimi-web` (37 passed)

Fixes #2505