### PR TITLE
fix(web): keep code blocks stable for ultra-long plain-text lines

### DIFF
--- a/.changeset/web-codeblock-long-line-pre.md
+++ b/.changeset/web-codeblock-long-line-pre.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+web: Keep chat code blocks readable when a plain-text fence has an ultra-long line by preferring the scrollable `<pre>` renderer and constraining stream-diffs overflow.

--- a/apps/kimi-web/src/components/chat/Markdown.vue
+++ b/apps/kimi-web/src/components/chat/Markdown.vue
@@ -679,6 +679,10 @@ function copyDiff(code: string, idx: number) {
 .md :deep(.code-editor-container) {
   line-height: 1.65;
   --diffs-gap-block: var(--space-3);
+  /* Long lines must scroll inside the block; otherwise stream-diffs can overflow
+     the chat column and force a broken plain fallback path (#2495). */
+  max-width: 100%;
+  overflow-x: auto;
 }
 .md :deep(.code-editor-container diffs-container) {
   --diffs-line-height: 1.65em;

--- a/apps/kimi-web/src/lib/markdownPerformance.ts
+++ b/apps/kimi-web/src/lib/markdownPerformance.ts
@@ -10,13 +10,30 @@ const HEAVY_TEXT_CHARS = 120_000;
 const HEAVY_CODE_CHARS = 60_000;
 const HEAVY_CODE_FENCES = 32;
 const HEAVY_SINGLE_FENCE_CHARS = 30_000;
+/** stream-diffs / Monaco layout can fail on a single ultra-long line (common
+ *  in plain-text fences). Prefer the plain <pre> path so chat keeps a stable
+ *  scrollable code block instead of falling through a broken highlighter. */
+const HEAVY_SINGLE_LINE_CHARS = 512;
 
 const CODE_FENCE_RE = /(^|\n)(`{3,}|~{3,})[^\n]*\n([\s\S]*?)(?:\n)?\2(?=\n|$)/g;
+
+function longestLineLength(code: string): number {
+  let longest = 0;
+  let start = 0;
+  for (let i = 0; i <= code.length; i += 1) {
+    if (i === code.length || code.charCodeAt(i) === 10 /* \n */) {
+      longest = Math.max(longest, i - start);
+      start = i + 1;
+    }
+  }
+  return longest;
+}
 
 export function markdownRenderPlan(text: string): MarkdownRenderPlan {
   let codeFenceCount = 0;
   let codeChars = 0;
   let longestFence = 0;
+  let longestLine = 0;
   CODE_FENCE_RE.lastIndex = 0;
   let match: RegExpExecArray | null;
   while ((match = CODE_FENCE_RE.exec(text)) !== null) {
@@ -24,13 +41,15 @@ export function markdownRenderPlan(text: string): MarkdownRenderPlan {
     codeFenceCount += 1;
     codeChars += code.length;
     longestFence = Math.max(longestFence, code.length);
+    longestLine = Math.max(longestLine, longestLineLength(code));
   }
 
   const heavy =
     text.length >= HEAVY_TEXT_CHARS ||
     codeChars >= HEAVY_CODE_CHARS ||
     codeFenceCount >= HEAVY_CODE_FENCES ||
-    longestFence >= HEAVY_SINGLE_FENCE_CHARS;
+    longestFence >= HEAVY_SINGLE_FENCE_CHARS ||
+    longestLine >= HEAVY_SINGLE_LINE_CHARS;
 
   return {
     codeRenderer: heavy ? 'pre' : 'shiki',

--- a/apps/kimi-web/test/lib-logic.test.ts
+++ b/apps/kimi-web/test/lib-logic.test.ts
@@ -31,6 +31,7 @@ import AgentTool from '../src/components/chat/tool-calls/AgentTool.vue';
 import EditTool from '../src/components/chat/tool-calls/EditTool.vue';
 import GenericTool from '../src/components/chat/tool-calls/GenericTool.vue';
 import type { ToolCall } from '../src/types';
+import { markdownRenderPlan } from '../src/lib/markdownPerformance';
 import {
   clearTrace,
   installClientErrorCapture,
@@ -861,5 +862,26 @@ describe('keepLiveSubagents', () => {
     const [merged] = keepLiveSubagents(rest, [live]);
     expect(merged?.outputPreview).toBe('final result');
     expect(merged?.outputBytes).toBe(200);
+  });
+});
+
+describe('markdownRenderPlan', () => {
+  it('keeps shiki for ordinary short fences', () => {
+    const plan = markdownRenderPlan('```text\nhello\n```\n');
+    expect(plan.codeRenderer).toBe('shiki');
+    expect(plan.codeFenceCount).toBe(1);
+  });
+
+  it('uses pre when a single code line is extremely long', () => {
+    const longLine = 'x'.repeat(512);
+    const plan = markdownRenderPlan(`\`\`\`text\n${longLine}\n\`\`\`\n`);
+    expect(plan.codeRenderer).toBe('pre');
+    expect(plan.codeFenceCount).toBe(1);
+  });
+
+  it('uses pre for a heavy single fence by character count', () => {
+    const body = `${'line\n'.repeat(2000)}${'y'.repeat(20_000)}`;
+    const plan = markdownRenderPlan(`\`\`\`js\n${body}\n\`\`\`\n`);
+    expect(plan.codeRenderer).toBe('pre');
   });
 });


### PR DESCRIPTION
## Summary
- Prefer a plain `pre` for ultra-long single-line plain-text fenced blocks (≥512 chars) so the Monaco editor does not thrash layout.
- Add horizontal overflow on the code editor container.

## Test plan
- [x] `pnpm exec vitest run test/lib-logic.test.ts` in `apps/kimi-web`

Fixes #2495