### PR TITLE
fix(cli): clarify agent help and document -r session alias

### DIFF
--- a/.changeset/cli-agent-help-resume.md
+++ b/.changeset/cli-agent-help-resume.md
@@ -1,0 +1,5 @@
+---
+'@moonshot-ai/kimi-code': patch
+---
+
+Clarify `--agent` / `--agent-file` help (mutual exclusion + tool frontmatter) and document the `-r`/`--resume` session alias.

--- a/apps/kimi-code/src/cli/commands.ts
+++ b/apps/kimi-code/src/cli/commands.ts
@@ -36,13 +36,14 @@ export function createProgram(
     .addOption(
       new Option(
         '-S, --session [id]',
-        'Resume a session. With ID: resume that session. Without ID: interactively pick.',
+        'Resume a session (alias: -r, --resume). With ID: resume that session. Without ID: interactively pick.',
       ).argParser((val: string | boolean) => (val === true ? '' : (val as string))),
     )
     .addOption(
-      new Option('-r, --resume [id]')
-        .hideHelp()
-        .argParser((val: string | boolean) => (val === true ? '' : (val as string))),
+      new Option(
+        '-r, --resume [id]',
+        'Alias for --session. Resume a session by ID, or interactively pick when omitted.',
+      ).argParser((val: string | boolean) => (val === true ? '' : (val as string))),
     )
     .option('-c, --continue', 'Continue the previous session for the working directory.', false)
     .addOption(new Option('-C').hideHelp().default(false))
@@ -77,7 +78,7 @@ export function createProgram(
     .addOption(
       new Option(
         '--agent <name>',
-        'Agent profile to start the new session with. Custom profiles are discovered from agent directories or loaded via --agent-file. Cannot be combined with --session/--continue.',
+        'Agent profile name for a new session (catalog / discovered profiles). Mutually exclusive with --agent-file. Cannot be combined with --session/--continue.',
       )
         .argParser((value: string, previous: string | undefined) => {
           if (previous !== undefined) {
@@ -90,7 +91,7 @@ export function createProgram(
     .addOption(
       new Option(
         '--agent-file <path>',
-        'Load an agent definition from a Markdown file and select it for the new session. Cannot be combined with --session/--continue.',
+        'Load one agent Markdown file for a new session (tools/disallowedTools in frontmatter restrict the tool set). Mutually exclusive with --agent. Cannot be combined with --session/--continue.',
       )
         .argParser((value: string, previous: string[] | undefined) => {
           if ((previous?.length ?? 0) > 0) {

--- a/apps/kimi-code/test/cli/options.test.ts
+++ b/apps/kimi-code/test/cli/options.test.ts
@@ -404,7 +404,12 @@ describe('CLI options parsing', () => {
       const help = createProgram('0.1.0-test', () => {}, () => {}).helpInformation();
       const normalizedHelp = help.replaceAll(/\s+/g, ' ');
 
-      expect(normalizedHelp).toContain('Agent profile to start the new session with.');
+      expect(normalizedHelp).toContain('Agent profile name for a new session');
+      expect(normalizedHelp).toContain('Mutually exclusive with --agent-file');
+      expect(normalizedHelp).toContain('tools/disallowedTools in frontmatter');
+      expect(normalizedHelp).toContain('alias: -r, --resume');
+      expect(normalizedHelp).toContain('Alias for --session');
+      expect(normalizedHelp).not.toContain('loaded via --agent-file');
       expect(normalizedHelp).not.toContain('print-mode invocation');
     });
 


### PR DESCRIPTION
## Summary
- Clarify `--agent` / `--agent-file` help: mutual exclusion and that agent-file frontmatter can restrict tools (partial #2398).
- Document `-r` / `--resume` as the session resume alias.

## Test plan
- [x] `pnpm exec vitest run test/cli/options.test.ts` in `apps/kimi-code` (69 passed)

Related: #2398