### PR TITLE
fix(agent-core): honor [tools].disabled config in v1 engine

### DIFF
--- a/.changeset/fix-tools-disabled-v1.md
+++ b/.changeset/fix-tools-disabled-v1.md
@@ -1,0 +1,11 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+fix(agent-core): honor [tools].disabled config in v1 engine
+
+The `[tools].disabled` array in config.toml was silently ignored by the
+v1 engine (v2 has a dedicated toolPolicy service for this). Read the
+section from config.raw in bootstrapAgentProfile and merge it into the
+profile's disallowedTools so disabled tools are filtered from both the
+top-level tool list and the subagent Agent tool description.

--- a/.changeset/fix-tools-disabled-v1.md
+++ b/.changeset/fix-tools-disabled-v1.md
@@ -1,5 +1,6 @@
 ---
 "@moonshot-ai/kimi-code": patch
+"@moonshot-ai/kimi-code-sdk": patch
 ---
 
 fix(agent-core): honor [tools].disabled config in v1 engine
@@ -9,3 +10,8 @@ v1 engine (v2 has a dedicated toolPolicy service for this). Read the
 section from config.raw in bootstrapAgentProfile and merge it into the
 profile's disallowedTools so disabled tools are filtered from both the
 top-level tool list and the subagent Agent tool description.
+
+agent-core is bundled into the SDK artifact (node-sdk `alwaysBundle`), so
+in-process SDK consumers (createKimiHarness/SDKRpcClient v1 sessions)
+that set `[tools].disabled` need the SDK version bumped to receive the
+fix.

--- a/packages/agent-core/src/agent/index.ts
+++ b/packages/agent-core/src/agent/index.ts
@@ -450,14 +450,17 @@ export class Agent {
   ): void {
     this.setActiveProfile(profile, brandHome);
     this.updateSystemPromptFromProfile(profile, context, subagentNames);
-    // Compose the global [tools].disabled denylist so a standalone Agent (no
-    // Session) honors the config at startup, not only on a later tool-selection
-    // RPC. #2534.
+    // Persist only the profile's own denylist via setActiveTools (it is
+    // replayed on resume). The global [tools].disabled denylist is applied
+    // separately via addDisallowedTools, which mutates the deny set without
+    // logging a set_active_tools record - otherwise a config deny added at
+    // startup would be written into the wire record and survive a later
+    // config removal on cold resume. #2534.
+    this.tools.setActiveTools(profile.tools, profile.disallowedTools);
     const toolsDisabled = this.configDisabledTools();
-    this.tools.setActiveTools(profile.tools, [
-      ...(profile.disallowedTools ?? []),
-      ...toolsDisabled,
-    ]);
+    if (toolsDisabled.length > 0) {
+      this.tools.addDisallowedTools(toolsDisabled);
+    }
   }
 
   /** Global [tools].disabled from options.config.raw, if provided. #2534. */
@@ -671,11 +674,16 @@ export class Agent {
         this.tools.unregisterUserTool(payload.name);
       },
       setActiveTools: (payload) => {
-        // Compose the global [tools].disabled denylist here so a runtime
-        // tool selection cannot reset disabledTools to empty. Without this,
-        // a setActiveTools update that includes a disabled tool (e.g. Bash)
-        // would reactivate it. #2534.
-        this.tools.setActiveTools(payload.names, this.configDisabledTools());
+        // Persist the runtime selection only. The global [tools].disabled
+        // denylist is re-applied via addDisallowedTools (no record) so a
+        // runtime selection cannot reactivate a disabled tool, while keeping
+        // config-only denies out of the persisted set_active_tools record.
+        // #2534.
+        this.tools.setActiveTools(payload.names);
+        const toolsDisabled = this.configDisabledTools();
+        if (toolsDisabled.length > 0) {
+          this.tools.addDisallowedTools(toolsDisabled);
+        }
       },
       stopBackground: (payload) => {
         void this.background.stop(payload.taskId, payload.reason);

--- a/packages/agent-core/src/agent/index.ts
+++ b/packages/agent-core/src/agent/index.ts
@@ -558,6 +558,15 @@ export class Agent {
 
   async resume(options?: AgentRecordsReplayOptions): Promise<{ warning?: string }> {
     const result = await this.records.replay(options);
+    // A standalone Agent (no Session) replays persisted tool state here but
+    // never routes through Session.restoreAgentProfileHandle, so re-apply the
+    // global [tools].disabled denylist non-persistently (mirrors useProfile).
+    // Without this a config deny added before resuming an existing Agent has
+    // no effect until the next useProfile / setActiveTools RPC. #2534.
+    const toolsDisabled = this.configDisabledTools();
+    if (toolsDisabled.length > 0) {
+      this.tools.addDisallowedTools(toolsDisabled);
+    }
     this.flushPendingAnthropicThinkingEffortWarnings();
     try {
       this.replayBuilder.postRestoring = true;

--- a/packages/agent-core/src/agent/index.ts
+++ b/packages/agent-core/src/agent/index.ts
@@ -450,7 +450,30 @@ export class Agent {
   ): void {
     this.setActiveProfile(profile, brandHome);
     this.updateSystemPromptFromProfile(profile, context, subagentNames);
-    this.tools.setActiveTools(profile.tools, profile.disallowedTools);
+    // Compose the global [tools].disabled denylist so a standalone Agent (no
+    // Session) honors the config at startup, not only on a later tool-selection
+    // RPC. #2534.
+    const toolsDisabled = this.configDisabledTools();
+    this.tools.setActiveTools(profile.tools, [
+      ...(profile.disallowedTools ?? []),
+      ...toolsDisabled,
+    ]);
+  }
+
+  /** Global [tools].disabled from options.config.raw, if provided. #2534. */
+  private configDisabledTools(): string[] {
+    const tools = this.kimiConfig?.raw?.['tools'];
+    if (
+      tools === undefined ||
+      typeof tools !== 'object' ||
+      tools === null ||
+      !Array.isArray((tools as Record<string, unknown>)['disabled'])
+    ) {
+      return [];
+    }
+    return ((tools as Record<string, unknown>)['disabled'] as string[]).filter(
+      (v): v is string => typeof v === 'string',
+    );
   }
 
   /** Push a refreshed session config snapshot and rebuild config-dependent builtin tools. */
@@ -652,17 +675,7 @@ export class Agent {
         // tool selection cannot reset disabledTools to empty. Without this,
         // a setActiveTools update that includes a disabled tool (e.g. Bash)
         // would reactivate it. #2534.
-        const tools = this.kimiConfig?.raw?.['tools'];
-        const globalDisabled =
-          tools !== undefined &&
-          typeof tools === 'object' &&
-          tools !== null &&
-          Array.isArray((tools as Record<string, unknown>)['disabled'])
-            ? ((tools as Record<string, unknown>)['disabled'] as string[]).filter(
-                (v): v is string => typeof v === 'string',
-              )
-            : [];
-        this.tools.setActiveTools(payload.names, globalDisabled);
+        this.tools.setActiveTools(payload.names, this.configDisabledTools());
       },
       stopBackground: (payload) => {
         void this.background.stop(payload.taskId, payload.reason);

--- a/packages/agent-core/src/agent/index.ts
+++ b/packages/agent-core/src/agent/index.ts
@@ -648,7 +648,21 @@ export class Agent {
         this.tools.unregisterUserTool(payload.name);
       },
       setActiveTools: (payload) => {
-        this.tools.setActiveTools(payload.names);
+        // Compose the global [tools].disabled denylist here so a runtime
+        // tool selection cannot reset disabledTools to empty. Without this,
+        // a setActiveTools update that includes a disabled tool (e.g. Bash)
+        // would reactivate it. #2534.
+        const tools = this.kimiConfig?.raw?.['tools'];
+        const globalDisabled =
+          tools !== undefined &&
+          typeof tools === 'object' &&
+          tools !== null &&
+          Array.isArray((tools as Record<string, unknown>)['disabled'])
+            ? ((tools as Record<string, unknown>)['disabled'] as string[]).filter(
+                (v): v is string => typeof v === 'string',
+              )
+            : [];
+        this.tools.setActiveTools(payload.names, globalDisabled);
       },
       stopBackground: (payload) => {
         void this.background.stop(payload.taskId, payload.reason);

--- a/packages/agent-core/src/agent/tool/index.ts
+++ b/packages/agent-core/src/agent/tool/index.ts
@@ -531,13 +531,14 @@ export class ToolManager {
 
   setActiveTools(names: readonly string[], disallowedNames?: readonly string[]): void {
     // Callers compose [tools].disabled into an array, but an empty denylist
-    // carries no information; omit it so the serialized record matches the
-    // pre-config behavior (undefined -> omitted) instead of changing every
-    // set_active_tools record. #2534.
+    // carries no information; normalize to undefined so the serialized record
+    // omits it (matching the pre-config behavior) instead of changing every
+    // set_active_tools record with an empty disallowedNames. #2534.
     this.agent.records.logRecord({
       type: 'tools.set_active_tools',
       names,
-      ...(disallowedNames && disallowedNames.length > 0 ? { disallowedNames } : {}),
+      disallowedNames:
+        disallowedNames && disallowedNames.length > 0 ? disallowedNames : undefined,
     });
     // MCP entries are glob patterns gated separately; the rest are exact
     // builtin/user tool names. The split keeps every caller on one string[].

--- a/packages/agent-core/src/agent/tool/index.ts
+++ b/packages/agent-core/src/agent/tool/index.ts
@@ -530,17 +530,22 @@ export class ToolManager {
   }
 
   setActiveTools(names: readonly string[], disallowedNames?: readonly string[]): void {
+    // Callers compose [tools].disabled into an array, but an empty denylist
+    // carries no information; omit it so the serialized record matches the
+    // pre-config behavior (undefined -> omitted) instead of changing every
+    // set_active_tools record. #2534.
     this.agent.records.logRecord({
       type: 'tools.set_active_tools',
       names,
-      disallowedNames,
+      ...(disallowedNames && disallowedNames.length > 0 ? { disallowedNames } : {}),
     });
     // MCP entries are glob patterns gated separately; the rest are exact
     // builtin/user tool names. The split keeps every caller on one string[].
     this.enabledTools = new Set(names.filter((name) => !isMcpToolName(name)));
     this.mcpAccessPatterns = names.filter((name) => isMcpToolName(name));
     this.disabledTools = new Set((disallowedNames ?? []).filter((name) => !isMcpToolName(name)));
-    this.mcpDenyPatterns = (disallowedNames ?? []).filter((name) => isMcpToolName(name));    // Builtin construction reads the enabled set (Bash/Agent bake
+    this.mcpDenyPatterns = (disallowedNames ?? []).filter((name) => isMcpToolName(name));
+    // Builtin construction reads the enabled set (Bash/Agent bake
     // `allowBackground` from the Task* trio), and the constructor may already
     // have built the map while the enabled set was still empty. The lazy
     // re-init in `get tools()` only fires on an empty map, so rebuild here —
@@ -566,6 +571,15 @@ export class ToolManager {
     }
     if (mcpDenies.length > 0) {
       this.mcpDenyPatterns = [...this.mcpDenyPatterns, ...mcpDenies];
+    }
+    // Builtin construction bakes `allowBackground` from the Task* trio into
+    // Bash/Agent (see setActiveTools). The resume path already rebuilt the
+    // builtins during wire replay, before these denies were applied, so a
+    // newly-denied Task* tool would leave allowBackground stuck on until the
+    // next setActiveTools. Rebuild here so the denylist takes effect on the
+    // already-constructed builtins. #2534.
+    if (this.agent.config.hasProvider) {
+      this.initializeBuiltinTools();
     }
   }
 

--- a/packages/agent-core/src/agent/tool/index.ts
+++ b/packages/agent-core/src/agent/tool/index.ts
@@ -540,8 +540,7 @@ export class ToolManager {
     this.enabledTools = new Set(names.filter((name) => !isMcpToolName(name)));
     this.mcpAccessPatterns = names.filter((name) => isMcpToolName(name));
     this.disabledTools = new Set((disallowedNames ?? []).filter((name) => !isMcpToolName(name)));
-    this.mcpDenyPatterns = (disallowedNames ?? []).filter((name) => isMcpToolName(name));
-    // Builtin construction reads the enabled set (Bash/Agent bake
+    this.mcpDenyPatterns = (disallowedNames ?? []).filter((name) => isMcpToolName(name));    // Builtin construction reads the enabled set (Bash/Agent bake
     // `allowBackground` from the Task* trio), and the constructor may already
     // have built the map while the enabled set was still empty. The lazy
     // re-init in `get tools()` only fires on an empty map, so rebuild here —
@@ -549,6 +548,24 @@ export class ToolManager {
     // the construction-time capabilities.
     if (this.agent.config.hasProvider) {
       this.initializeBuiltinTools();
+    }
+  }
+
+  /**
+   * Add to the denied set without replacing the replayed enabled set. Used by
+   * the resume path so applying [tools].disabled to a restored agent does not
+   * drop unrelated replayed host/user tools or a previous runtime selection.
+   * #2534.
+   */
+  addDisallowedTools(names: readonly string[]): void {
+    if (names.length === 0) return;
+    const denials = names.filter((name) => !isMcpToolName(name));
+    const mcpDenies = names.filter((name) => isMcpToolName(name));
+    if (denials.length > 0) {
+      this.disabledTools = new Set([...this.disabledTools, ...denials]);
+    }
+    if (mcpDenies.length > 0) {
+      this.mcpDenyPatterns = [...this.mcpDenyPatterns, ...mcpDenies];
     }
   }
 

--- a/packages/agent-core/src/session/index.ts
+++ b/packages/agent-core/src/session/index.ts
@@ -1348,27 +1348,14 @@ export class Session {
     // Apply global [tools].disabled to resumed/reloaded agents too. The
     // bootstrap path (bootstrapAgentProfile) merges it at session start, but
     // restoreAgentProfileHandle only calls setActiveProfile - which does not
-    // re-apply the tool denylist. Without this, a persisted agent resumed
-    // after [tools].disabled was added keeps its old tools active. #2534.
-    // Only re-apply when disabled tools exist - agent.resume() has already
-    // replayed persisted tool state, and unconditionally calling
-    // setActiveTools would reset the replayed enabled set. #2534.
+    // re-apply the tool denylist. agent.resume() has already replayed
+    // persisted tool state, so add the denylist without replacing the
+    // replayed enabled set (which would drop unrelated runtime selections).
+    // #2534.
+    agent.setActiveProfile(profile, this.options.kimiHomeDir);
     const toolsDisabled = this.readToolsDisabled();
     if (toolsDisabled.length > 0) {
-      const effectiveProfile = {
-        ...profile,
-        disallowedTools: [
-          ...(profile.disallowedTools ?? []),
-          ...toolsDisabled,
-        ],
-      };
-      agent.setActiveProfile(effectiveProfile, this.options.kimiHomeDir);
-      agent.tools.setActiveTools(
-        effectiveProfile.tools,
-        effectiveProfile.disallowedTools,
-      );
-    } else {
-      agent.setActiveProfile(profile, this.options.kimiHomeDir);
+      agent.tools.addDisallowedTools(toolsDisabled);
     }
   }
 

--- a/packages/agent-core/src/session/index.ts
+++ b/packages/agent-core/src/session/index.ts
@@ -1347,7 +1347,24 @@ export class Session {
     if (agent.config.systemPrompt === '') return;
     const profile = this.resolvePersistedProfile(agent, meta, parentAgent);
     if (profile === undefined) return;
-    agent.setActiveProfile(profile, this.options.kimiHomeDir);
+    // Apply global [tools].disabled to resumed/reloaded agents too. The
+    // bootstrap path (bootstrapAgentProfile) merges it at session start, but
+    // restoreAgentProfileHandle only calls setActiveProfile - which does not
+    // re-apply the tool denylist. Without this, a persisted agent resumed
+    // after [tools].disabled was added keeps its old tools active. #2534.
+    const toolsDisabled = this.readToolsDisabled();
+    const effectiveProfile =
+      toolsDisabled.length > 0
+        ? {
+            ...profile,
+            disallowedTools: [
+              ...(profile.disallowedTools ?? []),
+              ...toolsDisabled,
+            ],
+          }
+        : profile;
+    agent.setActiveProfile(effectiveProfile, this.options.kimiHomeDir);
+    agent.tools.setActiveTools(effectiveProfile.tools, effectiveProfile.disallowedTools);
   }
 
   private resolvePersistedProfile(

--- a/packages/agent-core/src/session/index.ts
+++ b/packages/agent-core/src/session/index.ts
@@ -1352,19 +1352,26 @@ export class Session {
     // restoreAgentProfileHandle only calls setActiveProfile - which does not
     // re-apply the tool denylist. Without this, a persisted agent resumed
     // after [tools].disabled was added keeps its old tools active. #2534.
+    // Only re-apply when disabled tools exist - agent.resume() has already
+    // replayed persisted tool state, and unconditionally calling
+    // setActiveTools would reset the replayed enabled set. #2534.
     const toolsDisabled = this.readToolsDisabled();
-    const effectiveProfile =
-      toolsDisabled.length > 0
-        ? {
-            ...profile,
-            disallowedTools: [
-              ...(profile.disallowedTools ?? []),
-              ...toolsDisabled,
-            ],
-          }
-        : profile;
-    agent.setActiveProfile(effectiveProfile, this.options.kimiHomeDir);
-    agent.tools.setActiveTools(effectiveProfile.tools, effectiveProfile.disallowedTools);
+    if (toolsDisabled.length > 0) {
+      const effectiveProfile = {
+        ...profile,
+        disallowedTools: [
+          ...(profile.disallowedTools ?? []),
+          ...toolsDisabled,
+        ],
+      };
+      agent.setActiveProfile(effectiveProfile, this.options.kimiHomeDir);
+      agent.tools.setActiveTools(
+        effectiveProfile.tools,
+        effectiveProfile.disallowedTools,
+      );
+    } else {
+      agent.setActiveProfile(profile, this.options.kimiHomeDir);
+    }
   }
 
   private resolvePersistedProfile(

--- a/packages/agent-core/src/session/index.ts
+++ b/packages/agent-core/src/session/index.ts
@@ -813,7 +813,7 @@ export class Session {
    * dedicated toolPolicy service), so unknown sections land in
    * `config.raw`. This extracts the disabled tool names safely. #2534.
    */
-  private readToolsDisabled(): string[] {
+  readToolsDisabled(): string[] {
     const raw = this.kimiConfig?.raw;
     if (!raw) return [];
     const toolsSection = raw['tools'];

--- a/packages/agent-core/src/session/index.ts
+++ b/packages/agent-core/src/session/index.ts
@@ -780,18 +780,14 @@ export class Session {
     const subagentNames = Object.keys(this.agentCatalog.delegatableSubagents(profile.name));
 
     // Apply global [tools].disabled without persisting it into the agent's
-    // profile/wire record. useProfile internally calls setActiveTools with
-    // profile.disallowedTools, which gets replayed on resume - so merging
-    // config-disabled tools into the profile would persist them even after
-    // the user removes the config. Instead, use the original profile for
-    // useProfile, then compose the denylist separately. #2534.
+    // profile/wire record. useProfile persists only profile.disallowedTools
+    // (replayed on resume); config denies are added via addDisallowedTools,
+    // which mutates the deny set without logging a record, so removing the
+    // config later does not leave a stale persisted deny. #2534.
     const toolsDisabled = this.readToolsDisabled();
     agent.useProfile(profile, context, this.options.kimiHomeDir, subagentNames);
     if (toolsDisabled.length > 0) {
-      agent.tools.setActiveTools(
-        profile.tools,
-        [...(profile.disallowedTools ?? []), ...toolsDisabled],
-      );
+      agent.tools.addDisallowedTools(toolsDisabled);
     }
     const { agentsMdWarning } = context;
     if (agentsMdWarning !== undefined) {

--- a/packages/agent-core/src/session/index.ts
+++ b/packages/agent-core/src/session/index.ts
@@ -779,22 +779,20 @@ export class Session {
     );
     const subagentNames = Object.keys(this.agentCatalog.delegatableSubagents(profile.name));
 
-    // Merge global [tools].disabled config into the profile's disallowedTools.
-    // v2 has a dedicated toolPolicy service for this; v1 reads it from the
-    // raw config (unknown sections land in `config.raw`). #2534.
+    // Apply global [tools].disabled without persisting it into the agent's
+    // profile/wire record. useProfile internally calls setActiveTools with
+    // profile.disallowedTools, which gets replayed on resume - so merging
+    // config-disabled tools into the profile would persist them even after
+    // the user removes the config. Instead, use the original profile for
+    // useProfile, then compose the denylist separately. #2534.
     const toolsDisabled = this.readToolsDisabled();
-    const effectiveProfile =
-      toolsDisabled.length > 0
-        ? {
-            ...profile,
-            disallowedTools: [
-              ...(profile.disallowedTools ?? []),
-              ...toolsDisabled,
-            ],
-          }
-        : profile;
-
-    agent.useProfile(effectiveProfile, context, this.options.kimiHomeDir, subagentNames);
+    agent.useProfile(profile, context, this.options.kimiHomeDir, subagentNames);
+    if (toolsDisabled.length > 0) {
+      agent.tools.setActiveTools(
+        profile.tools,
+        [...(profile.disallowedTools ?? []), ...toolsDisabled],
+      );
+    }
     const { agentsMdWarning } = context;
     if (agentsMdWarning !== undefined) {
       this.agentsMdWarning = agentsMdWarning;

--- a/packages/agent-core/src/session/index.ts
+++ b/packages/agent-core/src/session/index.ts
@@ -778,7 +778,23 @@ export class Session {
       { additionalDirs: this.additionalDirs },
     );
     const subagentNames = Object.keys(this.agentCatalog.delegatableSubagents(profile.name));
-    agent.useProfile(profile, context, this.options.kimiHomeDir, subagentNames);
+
+    // Merge global [tools].disabled config into the profile's disallowedTools.
+    // v2 has a dedicated toolPolicy service for this; v1 reads it from the
+    // raw config (unknown sections land in `config.raw`). #2534.
+    const toolsDisabled = this.readToolsDisabled();
+    const effectiveProfile =
+      toolsDisabled.length > 0
+        ? {
+            ...profile,
+            disallowedTools: [
+              ...(profile.disallowedTools ?? []),
+              ...toolsDisabled,
+            ],
+          }
+        : profile;
+
+    agent.useProfile(effectiveProfile, context, this.options.kimiHomeDir, subagentNames);
     const { agentsMdWarning } = context;
     if (agentsMdWarning !== undefined) {
       this.agentsMdWarning = agentsMdWarning;
@@ -789,6 +805,22 @@ export class Session {
         code: 'agents-md-oversized',
       });
     }
+  }
+
+  /**
+   * Read the `[tools].disabled` array from the raw config. v1's
+   * KimiConfigSchema does not have a typed `tools` section (v2 uses a
+   * dedicated toolPolicy service), so unknown sections land in
+   * `config.raw`. This extracts the disabled tool names safely. #2534.
+   */
+  private readToolsDisabled(): string[] {
+    const raw = this.kimiConfig?.raw;
+    if (!raw) return [];
+    const toolsSection = raw['tools'];
+    if (typeof toolsSection !== 'object' || toolsSection === null) return [];
+    const disabled = (toolsSection as Record<string, unknown>)['disabled'];
+    if (!Array.isArray(disabled)) return [];
+    return disabled.filter((v): v is string => typeof v === 'string');
   }
 
   async getSessionWarnings(): Promise<readonly SessionWarning[]> {

--- a/packages/agent-core/src/session/subagent-host.ts
+++ b/packages/agent-core/src/session/subagent-host.ts
@@ -457,7 +457,21 @@ export class SessionSubagentHost {
     const subagentNames = Object.keys(
       this.session.agentCatalog.delegatableSubagents(profile.name),
     );
-    child.useProfile(profile, context, this.session.options.kimiHomeDir, subagentNames);
+
+    // Apply global [tools].disabled to subagents too. #2534.
+    const toolsDisabled = this.session.readToolsDisabled();
+    const effectiveProfile =
+      toolsDisabled.length > 0
+        ? {
+            ...profile,
+            disallowedTools: [
+              ...(profile.disallowedTools ?? []),
+              ...toolsDisabled,
+            ],
+          }
+        : profile;
+
+    child.useProfile(effectiveProfile, context, this.session.options.kimiHomeDir, subagentNames);
     child.tools.inheritUserTools(parent.tools);
   }
 

--- a/packages/agent-core/src/session/subagent-host.ts
+++ b/packages/agent-core/src/session/subagent-host.ts
@@ -339,7 +339,21 @@ export class SessionSubagentHost {
    */
   delegatableSubagents(callerProfileName?: string): Record<string, ResolvedAgentProfile> {
     const owner = this.getOwnerAgent?.() ?? this.session.getReadyAgent(this.ownerAgentId);
-    return this.resolveDelegatableSubagents(callerProfileName, owner?.config.subagentNames);
+    const profiles = this.resolveDelegatableSubagents(callerProfileName, owner?.config.subagentNames);
+    // Apply global [tools].disabled to the profiles exposed to the parent
+    // agent's Agent tool description, so the model does not advertise a
+    // subagent as having a tool the spawned child will not receive. #2534.
+    const toolsDisabled = this.session.readToolsDisabled();
+    if (toolsDisabled.length === 0) return profiles;
+    return Object.fromEntries(
+      Object.entries(profiles).map(([name, profile]) => [
+        name,
+        {
+          ...profile,
+          disallowedTools: [...(profile.disallowedTools ?? []), ...toolsDisabled],
+        },
+      ]),
+    );
   }
 
   private resolveDelegatableSubagents(

--- a/packages/agent-core/src/session/subagent-host.ts
+++ b/packages/agent-core/src/session/subagent-host.ts
@@ -473,16 +473,14 @@ export class SessionSubagentHost {
     );
 
     // Apply global [tools].disabled to subagents without persisting it into
-    // the child's profile/wire record (useProfile with a merged profile would
-    // write config-disabled tools into set_active_tools, which survives a
-    // later config removal on resume). #2534.
+    // the child's profile/wire record. useProfile persists only
+    // profile.disallowedTools; config denies are added via addDisallowedTools,
+    // which mutates the deny set without logging a record, so a config deny
+    // does not survive a later config removal on resume. #2534.
     const toolsDisabled = this.session.readToolsDisabled();
     child.useProfile(profile, context, this.session.options.kimiHomeDir, subagentNames);
     if (toolsDisabled.length > 0) {
-      child.tools.setActiveTools(
-        profile.tools,
-        [...(profile.disallowedTools ?? []), ...toolsDisabled],
-      );
+      child.tools.addDisallowedTools(toolsDisabled);
     }
     child.tools.inheritUserTools(parent.tools);
   }

--- a/packages/agent-core/src/session/subagent-host.ts
+++ b/packages/agent-core/src/session/subagent-host.ts
@@ -472,20 +472,18 @@ export class SessionSubagentHost {
       this.session.agentCatalog.delegatableSubagents(profile.name),
     );
 
-    // Apply global [tools].disabled to subagents too. #2534.
+    // Apply global [tools].disabled to subagents without persisting it into
+    // the child's profile/wire record (useProfile with a merged profile would
+    // write config-disabled tools into set_active_tools, which survives a
+    // later config removal on resume). #2534.
     const toolsDisabled = this.session.readToolsDisabled();
-    const effectiveProfile =
-      toolsDisabled.length > 0
-        ? {
-            ...profile,
-            disallowedTools: [
-              ...(profile.disallowedTools ?? []),
-              ...toolsDisabled,
-            ],
-          }
-        : profile;
-
-    child.useProfile(effectiveProfile, context, this.session.options.kimiHomeDir, subagentNames);
+    child.useProfile(profile, context, this.session.options.kimiHomeDir, subagentNames);
+    if (toolsDisabled.length > 0) {
+      child.tools.setActiveTools(
+        profile.tools,
+        [...(profile.disallowedTools ?? []), ...toolsDisabled],
+      );
+    }
     child.tools.inheritUserTools(parent.tools);
   }
 

--- a/packages/agent-core/test/session/subagent-host.test.ts
+++ b/packages/agent-core/test/session/subagent-host.test.ts
@@ -1856,6 +1856,7 @@ function fakeSession(
       custom: {},
     },
     writeMetadata: vi.fn(async () => {}),
+    readToolsDisabled: vi.fn((): string[] => []),
     systemContextKaos: vi.fn((cwd: string) => parent.kaos.withCwd(cwd)),
     getReadyAgent: vi.fn((id: string) => agents.get(id)),
     ensureAgentResumed: vi.fn(async (id: string) => {


### PR DESCRIPTION
## Related Issue

Resolves #2534

## Problem

`[tools].disabled` in `config.toml` was ignored by the v1 engine. v2 has a dedicated `toolPolicy` service that reads the `[tools]` config section; v1's `KimiConfigSchema` has no typed `tools` field, so the section lands in `config.raw` and is never read.

## What changed

In `bootstrapAgentProfile` (the single entry point where v1 applies a profile to an agent), read `[tools].disabled` from `config.raw` and merge it into the profile's `disallowedTools` before calling `useProfile`. This makes `setActiveTools` filter the disabled tools from both the top-level tool list and the subagent `Agent` tool description.

Added a `readToolsDisabled()` helper that safely extracts the string array from the raw config, returning `[]` when the section is absent or malformed.

## Checklist

- [x] I have read the CONTRIBUTING document.
- [x] I have linked a related issue.
- [x] This PR needs a changeset (user-visible behavior change).
