### PR TITLE
fix(agent-core): tolerate unreadable .git probes on UNC workspaces

### DIFF
--- a/.changeset/fix-unc-git-probe.md
+++ b/.changeset/fix-unc-git-probe.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Fix chat failing to start on Windows when the workspace is on a network share (UNC path) that is not a git repository.

--- a/packages/agent-core/src/mcp/config-loader.ts
+++ b/packages/agent-core/src/mcp/config-loader.ts
@@ -76,9 +76,11 @@ async function pathExists(filePath: string): Promise<boolean> {
   try {
     await stat(filePath);
     return true;
-  } catch (error: unknown) {
-    if (isPathMissing(error)) return false;
-    throw error;
+  } catch {
+    // Probing an optional marker file (e.g. `.git` while walking up parents)
+    // must never throw: on Windows UNC shares, stat past the share root can
+    // fail with UNKNOWN/EPERM instead of ENOENT.
+    return false;
   }
 }
 
@@ -154,11 +156,6 @@ function isWindowsAbsolutePath(value: string): boolean {
 
 function isFileNotFound(error: unknown): boolean {
   return getErrorCode(error) === 'ENOENT';
-}
-
-function isPathMissing(error: unknown): boolean {
-  const code = getErrorCode(error);
-  return code === 'ENOENT' || code === 'ENOTDIR';
 }
 
 function getErrorCode(error: unknown): unknown {

--- a/packages/agent-core/test/mcp/config-loader.test.ts
+++ b/packages/agent-core/test/mcp/config-loader.test.ts
@@ -3,10 +3,27 @@ import { mkdir, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'pathe';
 
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { ErrorCodes, KimiError } from '../../src/errors';
 import { loadMcpServers, resolveMcpJsonPaths } from '../../src/mcp/config-loader';
+
+// Lets individual tests make `.git` marker probes fail with a specific error
+// code (e.g. UNKNOWN on Windows UNC shares); everything else stats through.
+const probeFailure = vi.hoisted(() => ({ code: undefined as string | undefined }));
+
+vi.mock('node:fs/promises', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:fs/promises')>();
+  const stat = (path: Parameters<typeof actual.stat>[0], options?: Parameters<typeof actual.stat>[1]) => {
+    if (probeFailure.code !== undefined && String(path).endsWith('.git')) {
+      const error: NodeJS.ErrnoException = new Error(`unknown error, stat '${String(path)}'`);
+      error.code = probeFailure.code;
+      return Promise.reject(error);
+    }
+    return actual.stat(path, options);
+  };
+  return { ...actual, stat };
+});
 
 const tempDirs: string[] = [];
 
@@ -40,6 +57,22 @@ describe('resolveMcpJsonPaths', () => {
     expect(paths.projectRoot).toBe(join(repoRoot, '.mcp.json'));
     expect(paths.project).toBe(join(cwd, '.kimi-code', 'mcp.json'));
   });
+
+  // Windows can fail a `.git` probe past a UNC share root with UNKNOWN/EPERM
+  // instead of ENOENT; the walk must treat that as "not found" (#2540).
+  it.each(['UNKNOWN', 'EPERM'])(
+    'falls back to the cwd when .git probes fail with %s',
+    async (code) => {
+      const cwd = makeTempDir();
+      probeFailure.code = code;
+      try {
+        const paths = await resolveMcpJsonPaths({ cwd, homeDir: '/home/user/.kimi-code' });
+        expect(paths.projectRoot).toBe(join(cwd, '.mcp.json'));
+      } finally {
+        probeFailure.code = undefined;
+      }
+    },
+  );
 });
 
 describe('loadMcpServers', () => {


### PR DESCRIPTION
## Related Issue

Resolve #2540

## Problem

See linked issue. On Windows, workspaces opened via a UNC path (network share, e.g. a NAS) that are not git repositories cannot send any chat message: the project-root walk stats `\\server\.git` past the share root, Node/libuv reports `UNKNOWN` instead of `ENOENT`, and the probe helper rethrew it, failing the whole chat preflight.

## What changed

- The `.git` marker probe in the MCP config loader's project-root walk now treats any `stat` failure as "not found" instead of rethrowing non-`ENOENT`/`ENOTDIR` errors — a probe for an optional marker file should never throw. This matches the existing probe helpers elsewhere in the repo (e.g. workspace-local config, profile context) and also covers `EPERM`-style failures, not just `UNKNOWN`.
- Removed the now-unused error-code helper from the same file.
- Added regression tests that simulate `UNKNOWN` and `EPERM` probe failures and assert the walk falls back to the starting directory (platform-independent via a partial `node:fs/promises` mock).

The sibling probe copies in the agent-file root resolvers (both engines) were left untouched: their callers already catch and downgrade probe errors to warnings, so they never had this crash.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.
