### PR TITLE
fix(tui): make the /login already-logged-in notice visible

### DIFF
--- a/.changeset/login-already-logged-in-visibility.md
+++ b/.changeset/login-already-logged-in-visibility.md
@@ -1,0 +1,4 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+Render the "/login" already-logged-in confirmation in the success color instead of dim text, so the "Already logged in. Model configuration refreshed." message is clearly visible.

--- a/apps/kimi-code/src/tui/commands/auth.ts
+++ b/apps/kimi-code/src/tui/commands/auth.ts
@@ -74,7 +74,7 @@ async function handleKimiCodeOAuthLogin(host: SlashCommandHost): Promise<void> {
       already_logged_in: alreadyLoggedIn,
     });
     if (alreadyLoggedIn) {
-      host.showStatus('Already logged in. Model configuration refreshed.');
+      host.showStatus('Already logged in. Model configuration refreshed.', 'success');
     }
   } catch (error) {
     const cancelled = controller.signal.aborted;


### PR DESCRIPTION
The "Already logged in. Model configuration refreshed." confirmation was rendered with the default dim text color, so users easily missed it and assumed /login did nothing. Render it with the theme's success color, matching the success styling used by the login spinner's "✓ Logged in." line.

<!--
Thank you for your contribution to Kimi Code!
Please open an issue before sending a feature PR — PRs without prior discussion may be closed without review.

See https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md for more.
-->

## Related Issue

<!-- Link the issue this feature came from. If there is no issue, explain the problem in the next section instead. -->

Resolve #(issue_number)

## Problem

<!-- What user need or limitation does this address? If the linked issue already covers this, write "See linked issue". -->

## What changed

<!-- What did you implement, and why does this approach fit Kimi Code? -->

## Checklist

- [ ] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [ ] I have linked a related issue, or explained the problem above.
- [ ] I have added tests that prove my feature works.
- [ ] Ran `gen-changesets` skill, or this PR needs no changeset.
- [ ] Ran `gen-docs` skill, or this PR needs no doc update.
