### PR TITLE
fix(web): fix model dropdown list overflow in composer

### DIFF
--- a/.changeset/goofy-onions-hope.md
+++ b/.changeset/goofy-onions-hope.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-web": patch
+---
+
+fix(web): fix model dropdown list overflow in composer

--- a/apps/kimi-web/src/components/chat/Composer.vue
+++ b/apps/kimi-web/src/components/chat/Composer.vue
@@ -1106,6 +1106,7 @@ function selectModel(modelId: string): void {
             v-if="status"
             class="model-pill"
             :class="{ open: dropdownOpen }"
+            :title="status.model"
             role="button"
             tabindex="0"
             @click.stop="toggleDropdown"
@@ -1146,6 +1147,7 @@ function selectModel(modelId: string): void {
             :key="m.id"
             class="md-row"
             :class="{ 'is-current': m.id === status.modelId }"
+            :title="`${m.displayName ?? m.model} (${m.provider})`"
             role="menuitem"
             @click="selectModel(m.id)"
           >
@@ -1164,6 +1166,7 @@ function selectModel(modelId: string): void {
             :key="m.id"
             class="md-row"
             :class="{ 'is-current': m.id === status.modelId }"
+            :title="m.displayName ?? m.model"
             role="menuitem"
             @click="selectModel(m.id)"
           >

--- a/apps/kimi-web/src/components/chat/Composer.vue
+++ b/apps/kimi-web/src/components/chat/Composer.vue
@@ -1661,6 +1661,10 @@ function selectModel(modelId: string): void {
   right: 10px;
   z-index: var(--z-dropdown);
   min-width: 200px;
+  max-width: min(380px, calc(100vw - 32px));
+  max-height: min(440px, calc(100vh - 120px));
+  overflow-y: auto;
+  overscroll-behavior: contain;
   background: var(--color-surface-raised);
   border: 1px solid var(--color-line);
   border-radius: var(--radius-lg);
@@ -1686,6 +1690,7 @@ function selectModel(modelId: string): void {
   align-items: center;
   gap: 7px;
   width: 100%;
+  min-width: 0;
   background: none;
   border: none;
   cursor: pointer;
@@ -1729,11 +1734,19 @@ function selectModel(modelId: string): void {
 
 .md-name {
   flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 .md-provider {
   color: var(--muted);
   font-size: var(--ui-font-size-xs);
   flex: none;
+  max-width: 110px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 .md-star {
   color: var(--star);

--- a/apps/kimi-web/src/components/chat/Composer.vue
+++ b/apps/kimi-web/src/components/chat/Composer.vue
@@ -1742,8 +1742,8 @@ function selectModel(modelId: string): void {
 .md-provider {
   color: var(--muted);
   font-size: var(--ui-font-size-xs);
-  flex: none;
-  max-width: 110px;
+  flex: 0 1 auto;
+  max-width: 35%;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;


### PR DESCRIPTION
<!--
Thank you for your contribution to Kimi Code!
Please open an issue before sending a feature PR — PRs without prior discussion may be closed without review.

See https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md for more.
-->

## Related Issue

<!-- Link the issue this feature came from. If there is no issue, explain the problem in the next section instead. -->


## Problem
fix overflowing of model items in model selector list next to input on new session landing
ps elipse longer model names
<!-- What user need or limitation does this address? If the linked issue already covers this, write "See linked issue". -->

## What changed
add some css tweaks
<!-- What did you implement, and why does this approach fit Kimi Code? -->

### after
<img width="1506" height="1080" alt="Screenshot From 2026-08-03 22-22-07" src="https://github.com/user-attachments/assets/0c164826-544d-4840-a2d1-81000f0a516f" />


### before
<img width="1467" height="1080" alt="Screenshot From 2026-08-03 22-42-08" src="https://github.com/user-attachments/assets/88f7967c-4d06-4889-bfbe-91f36b7f2e82" />
<img width="1467" height="1080" alt="image" src="https://github.com/user-attachments/assets/b22391fa-12ec-4895-a1b5-9ebacd489855" />

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.
