### PR TITLE
chore(changeset): downgrade token-counting strategy entry to patch

### DIFF
--- a/.changeset/token-counting-reporting-edge.md
+++ b/.changeset/token-counting-reporting-edge.md
@@ -1,5 +1,5 @@
 ---
-"@moonshot-ai/kimi-code": minor
+"@moonshot-ai/kimi-code": patch
 ---
 
 The `[token_counting]` strategy now only selects the reported context size: `estimated` keeps provider-reported usage out of the context-size display, and `measured` no longer gets stuck retrying an oversized compaction request until it fails.


### PR DESCRIPTION
## Related Issue

N/A — release-metadata housekeeping

## Problem

The `[token_counting]` strategy changeset (from #2563) was bumped as `minor`, but the entry only refines behavior of the existing token-counting feature — `estimated` keeping provider-reported usage out of the context-size display, and `measured` no longer retrying an oversized compaction request until failure. That is fix-level impact, so it should be a `patch` bump.

## What changed

- Edited `.changeset/token-counting-reporting-edge.md` frontmatter: `"@moonshot-ai/kimi-code": minor` → `patch`.
- No code changes. Once merged, the release PR (#2469) regenerates from `.changeset/` on `main` and moves this entry to Patch Changes. The release stays a minor bump overall because the hooks changeset (#2558) remains `minor`.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [ ] I have added tests that prove my feature works. (N/A — changeset metadata only)
- [x] Ran `gen-changesets` skill, or this PR needs no changeset. (This PR only edits a pending changeset's bump level; no new changeset needed)
- [x] Ran `gen-docs` skill, or this PR needs no doc update. (No behavior change)
