### PR TITLE
docs: polish the 0.32.0 changelog and fill 0.32.0 doc gaps

### DIFF
--- a/docs/en/configuration/providers.md
+++ b/docs/en/configuration/providers.md
@@ -31,7 +31,7 @@ The manager displays providers as a list of entries grouped by source. Navigatio
 
 Two paths when adding:
 
-- **Known third-party provider**: fetches the model catalog from [models.dev](https://models.dev/), select a provider → enter an API key → select a default model. Vendors whose protocol the catalog does not declare (e.g. xai, openrouter, and other vendor-specific SDKs) are imported as OpenAI-compatible with a "guessed" note; when the catalog provides no usable endpoint, a base URL prompt appears first; proprietary protocols (Amazon Bedrock, Cohere) and unrecognized explicit protocols are refused. Deprecated and alpha-status models are excluded from the import list
+- **Known third-party provider**: fetches the model catalog from [models.dev](https://models.dev/), select a provider → enter an API key → select a default model. Vendors whose protocol the catalog does not declare (e.g. xai, openrouter, and other vendor-specific SDKs) are imported as OpenAI-compatible with a "guessed" note; when the catalog provides no usable endpoint, a base URL prompt appears first; proprietary protocols (Amazon Bedrock, Cohere) and unrecognized explicit protocols are refused. Deprecated and alpha-status models are excluded from the import list. If the public catalog is unreachable, the CLI falls back to a built-in snapshot of the catalog, so the import still works offline or in blocked networks
 - **Custom registry (api.json)**: paste a custom registry URL and Bearer token; the CLI automatically creates the `providers` / `models` entries. On later startup, providers from the same registry URL are refreshed together, so upstream provider additions, removals, and model metadata changes are synced.
 
 ::: warning

--- a/docs/en/customization/hooks.md
+++ b/docs/en/customization/hooks.md
@@ -62,6 +62,8 @@ Each time a hook triggers, the CLI passes the following base information to the 
 {
   "hook_event_name": "PreToolUse",
   "session_id": "session_abc",
+  "session_title": "Fix the login page",
+  "client_type": "kimi_code_cli",
   "cwd": "/path/to/project"
 }
 ```
@@ -99,16 +101,20 @@ Only **blockable events** (`PreToolUse`, `Stop`, `UserPromptSubmit`) have return
 | Event | Matcher matches | Supports blocking? | Description |
 | --- | --- | --- | --- |
 | `UserPromptSubmit` | The text submitted by the user | ✓ | Triggered when the user sends a message; returned text is appended to context; if blocked, the model is not called for this turn |
+| `UserPromptQueued` | The queued prompt text | — | Triggered when a message is queued while a turn is still running; the payload includes `prompt_id`, `prompt`, and `queue_length` (observation only) |
 | `PreToolUse` | Tool name | ✓ | Triggered before a tool call (before permission checks); the tool will not execute if blocked |
 | `Stop` | Empty string | ✓ | Triggered when the model is about to end the current turn; if blocked, a message can be appended to let the model continue |
+| `TurnStarted` | Turn origin kind (e.g. `user`, `task`, `system_trigger`) | — | Triggered when a new turn begins; the payload includes `turn_id`, `origin_kind`, `origin_name`, and `prompt` (observation only) |
 | `PostToolUse` | Tool name | — | Triggered after a tool executes successfully (observation only) |
 | `PostToolUseFailure` | Tool name | — | Triggered after a tool fails or is blocked (observation only) |
 | `PermissionRequest` | Tool name | — | Triggered just before waiting for user approval (observation only) |
 | `PermissionResult` | Tool name | — | Triggered after approval completes (observation only) |
-| `SessionStart` | `startup` or `resume` | — | Triggered after a new session starts or a previous session resumes |
-| `SessionEnd` | `exit` | — | Triggered after a session closes |
+| `SessionStart` | `startup` or `resume` | — | Triggered after a new session starts or a previous session resumes; the payload includes `source`, `model`, and `profile` |
+| `SessionEnd` | `exit` or `archive` | — | Triggered after a session closes; `archive` means the session was archived rather than exited |
+| `SessionHeartbeat` | Empty string | — | Triggered every 60 seconds while the session is alive; the timer only runs when this event is configured. The payload includes `uptime_ms` (observation only) |
 | `SubagentStart` | Sub-agent name | — | Triggered before a sub-agent starts running |
 | `SubagentStop` | Sub-agent name | — | Triggered after a sub-agent completes successfully (observation only) |
+| `TaskStarted` | Task kind (`agent`, `process`, or `question`) | — | Triggered when a background task starts; the payload includes `task_id`, `description`, and `detached` (observation only) |
 | `StopFailure` | Error type | — | Triggered after the current turn fails due to an error (observation only) |
 | `Interrupt` | Empty string | — | Triggered when the user interrupts the current turn (e.g. pressing Esc); not fired for timeouts or other programmatic aborts. `Stop` does not fire on interrupts, so this event fires instead. The payload includes a `reason` field (observation only) |
 | `PreCompact` | `manual` or `auto` | — | Triggered before context compaction begins; return values are completely ignored |

--- a/docs/en/reference/kimi-command.md
+++ b/docs/en/reference/kimi-command.md
@@ -343,7 +343,7 @@ kimi provider list --json | jq '.providers | keys'
 
 #### `kimi provider catalog list [providerId]`
 
-Browse the public [models.dev](https://models.dev/) model catalog without modifying any configuration. Without an argument, lists all providers along with their protocol type and model count; with a `providerId`, lists all models under that provider along with their context window and capabilities.
+Browse the public [models.dev](https://models.dev/) model catalog without modifying any configuration. Without an argument, lists all providers along with their protocol type and model count; with a `providerId`, lists all models under that provider along with their context window and capabilities. If the catalog URL cannot be reached, a built-in snapshot of the catalog is used instead.
 
 | Parameter / Option | Description |
 | --- | --- |
@@ -360,7 +360,7 @@ kimi provider catalog list anthropic
 
 #### `kimi provider catalog add <providerId>`
 
-Import a known provider directly from the catalog by ID. The protocol type, base URL, and model information are all supplied by the catalog — only an API key is required. Vendors whose protocol the catalog does not declare (e.g. xai, openrouter, and other vendor-specific SDKs) are imported as OpenAI-compatible and the output notes the guess; when the catalog provides no usable endpoint, `--base-url` is required. Proprietary protocols (e.g. Amazon Bedrock) cannot be imported.
+Import a known provider directly from the catalog by ID. The protocol type, base URL, and model information are all supplied by the catalog — only an API key is required. Vendors whose protocol the catalog does not declare (e.g. xai, openrouter, and other vendor-specific SDKs) are imported as OpenAI-compatible and the output notes the guess; when the catalog provides no usable endpoint, `--base-url` is required. Proprietary protocols (e.g. Amazon Bedrock) cannot be imported. When the public catalog is unreachable, the import uses the built-in snapshot, so it still works offline or in blocked networks.
 
 | Parameter / Option | Description |
 | --- | --- |

--- a/docs/en/release-notes/changelog.md
+++ b/docs/en/release-notes/changelog.md
@@ -10,8 +10,8 @@ This page documents the changes in each Kimi Code CLI release.
 
 ### Features
 
-- Add four hook events: `TurnStarted`, `UserPromptQueued`, `TaskStarted`, and `SessionHeartbeat`. Configure them under `[[hooks]]` in `config.toml` — see [Hooks](../customization/hooks.md) for details.
-- Add a `[token_counting]` config section to choose which token count the context-size display shows (`measured+estimated`, `measured`, or `estimated`); useful for providers that do not report token usage. Set `strategy` under `[token_counting]` in `config.toml` to switch.
+- Add four hook events: `TurnStarted`, `UserPromptQueued`, `TaskStarted`, and `SessionHeartbeat`; `SessionEnd` now also reports `archive` when a session is archived instead of exited. Configure the events under `[[hooks]]` in `config.toml` — see [Hooks](../customization/hooks.md) for details.
+- Add a `[token_counting]` config section to choose which token count the context-size display shows (`measured+estimated`, `measured`, or `estimated`); useful for providers that do not report token usage. Set `strategy` under `[token_counting]` in `config.toml` (or `KIMI_TOKEN_COUNTING_STRATEGY`) to switch.
 
 ### Polish
 

--- a/docs/en/release-notes/changelog.md
+++ b/docs/en/release-notes/changelog.md
@@ -6,6 +6,26 @@ outline: 2
 
 This page documents the changes in each Kimi Code CLI release.
 
+## 0.32.0 (2026-08-04)
+
+### Features
+
+- Add four hook events: `TurnStarted`, `UserPromptQueued`, `TaskStarted`, and `SessionHeartbeat`. Configure them under `[[hooks]]` in `config.toml` — see [Hooks](../customization/hooks.md) for details.
+- Add a `[token_counting]` config section to choose which token count the context-size display shows (`measured+estimated`, `measured`, or `estimated`); useful for providers that do not report token usage. Set `strategy` under `[token_counting]` in `config.toml` to switch.
+
+### Polish
+
+- Rename `[loop_control] max_retries_per_step` to `max_attempts_per_step`, and `max_steps_per_run` to `max_steps_per_turn`. The old keys no longer take effect and a startup warning prompts the rename in `config.toml`; the `KIMI_LOOP_MAX_RETRIES_PER_STEP` env var is deprecated in favor of `KIMI_LOOP_MAX_ATTEMPTS_PER_STEP` but still works with a warning.
+
+### Bug Fixes
+
+- Fix answers to interactive question prompts being rejected when the model provider returns tool call IDs containing colons (some OpenAI-compatible gateways).
+- Fix automatic context compaction getting stuck retrying an oversized request until it fails.
+- Fall back to the built-in models.dev catalog snapshot when the public catalog is unreachable, so importing a known provider still works offline or in blocked networks.
+- Fix the context window limit showing as 0 when no model is configured; it now falls back to the default model.
+- web: Fix dark-mode monochrome controls and align the chat composer corner radius with the design system.
+- Fix the `/login` already-logged-in confirmation being hard to read; it now uses the success color.
+
 ## 0.31.1 (2026-07-31)
 
 ### Polish

--- a/docs/en/release-notes/changelog.md
+++ b/docs/en/release-notes/changelog.md
@@ -11,11 +11,11 @@ This page documents the changes in each Kimi Code CLI release.
 ### Features
 
 - Add four hook events: `TurnStarted`, `UserPromptQueued`, `TaskStarted`, and `SessionHeartbeat`; `SessionEnd` now also reports `archive` when a session is archived instead of exited. Configure the events under `[[hooks]]` in `config.toml` — see [Hooks](../customization/hooks.md) for details.
-- Add a `[token_counting]` config section to choose which token count the context-size display shows (`measured+estimated`, `measured`, or `estimated`); useful for providers that do not report token usage. Set `strategy` under `[token_counting]` in `config.toml` (or `KIMI_TOKEN_COUNTING_STRATEGY`) to switch.
 
 ### Polish
 
 - Rename `[loop_control] max_retries_per_step` to `max_attempts_per_step`, and `max_steps_per_run` to `max_steps_per_turn`. The old keys no longer take effect and a startup warning prompts the rename in `config.toml`; the `KIMI_LOOP_MAX_RETRIES_PER_STEP` env var is deprecated in favor of `KIMI_LOOP_MAX_ATTEMPTS_PER_STEP` but still works with a warning.
+- Add a `[token_counting]` config section to choose which token count the context-size display shows (`measured+estimated`, `measured`, or `estimated`); useful for providers that do not report token usage. Set `strategy` under `[token_counting]` in `config.toml` (or `KIMI_TOKEN_COUNTING_STRATEGY`) to switch.
 
 ### Bug Fixes
 

--- a/docs/zh/configuration/providers.md
+++ b/docs/zh/configuration/providers.md
@@ -31,7 +31,7 @@ Kimi Code CLI 支持同时接入多家 LLM 平台——用 Kimi Code 托管服�
 
 添加时有两条路径：
 
-- **Known third-party provider**：从 [models.dev](https://models.dev/) 拉取模型目录，选供应商 → 输入 API 密钥 → 选默认模型。目录未声明协议类型的供应商（如 xai、openrouter 这类厂商专用 SDK）会按 OpenAI 兼容协议导入并显示 "guessed" 提示；目录没有可用端点时会先弹出 base URL 输入框；Amazon Bedrock / Cohere 等专有协议和无法识别的显式协议会被拒绝导入。已下线（deprecated）和 alpha 状态的模型不会出现在导入列表中
+- **Known third-party provider**：从 [models.dev](https://models.dev/) 拉取模型目录，选供应商 → 输入 API 密钥 → 选默认模型。目录未声明协议类型的供应商（如 xai、openrouter 这类厂商专用 SDK）会按 OpenAI 兼容协议导入并显示 "guessed" 提示；目录没有可用端点时会先弹出 base URL 输入框；Amazon Bedrock / Cohere 等专有协议和无法识别的显式协议会被拒绝导入。已下线（deprecated）和 alpha 状态的模型不会出现在导入列表中。如果公共目录不可达，CLI 会回退到内置目录快照，离线或网络受限环境下也能完成导入
 - **Custom registry (api.json)**：粘贴自定义 registry 地址和 Bearer token，CLI 自动创建 `providers` / `models` 条目。后续启动时，同一个 registry 地址下的供应商会一起刷新，因此上游新增、删除供应商以及模型元数据变化都会同步。
 
 ::: warning

--- a/docs/zh/customization/hooks.md
+++ b/docs/zh/customization/hooks.md
@@ -62,6 +62,8 @@ Hook 命令的工作目录是当前会话的项目目录。非 Windows 平台上
 {
   "hook_event_name": "PreToolUse",
   "session_id": "session_abc",
+  "session_title": "修复登录页",
+  "client_type": "kimi_code_cli",
   "cwd": "/path/to/project"
 }
 ```
@@ -99,16 +101,20 @@ Hook 命令的工作目录是当前会话的项目目录。非 Windows 平台上
 | 事件 | Matcher 匹配的是 | 会触发阻断？ | 说明 |
 | --- | --- | --- | --- |
 | `UserPromptSubmit` | 用户提交的文本内容 | ✓ | 用户发送消息时触发；返回文本会附加到上下文；若阻断，本轮不调用模型 |
+| `UserPromptQueued` | 排队消息的文本内容 | — | 上一回合仍在运行、消息进入队列时触发；payload 含 `prompt_id`、`prompt` 和 `queue_length`（观察用） |
 | `PreToolUse` | 工具名 | ✓ | 工具调用前触发（权限检查前）；阻断后工具不会执行 |
 | `Stop` | 空字符串 | ✓ | 模型准备结束本轮时触发；阻断后可追加一条消息让模型继续 |
+| `TurnStarted` | 回合来源类型（如 `user`、`task`、`system_trigger`） | — | 新回合开始时触发；payload 含 `turn_id`、`origin_kind`、`origin_name` 和 `prompt`（观察用） |
 | `PostToolUse` | 工具名 | — | 工具成功执行后触发（观察用） |
 | `PostToolUseFailure` | 工具名 | — | 工具失败或被阻断后触发（观察用） |
 | `PermissionRequest` | 工具名 | — | 即将等待用户审批前触发（观察用） |
 | `PermissionResult` | 工具名 | — | 审批结束后触发（观察用） |
-| `SessionStart` | `startup` 或 `resume` | — | 新会话启动或历史会话恢复后触发 |
-| `SessionEnd` | `exit` | — | 会话关闭后触发 |
+| `SessionStart` | `startup` 或 `resume` | — | 新会话启动或历史会话恢复后触发；payload 含 `source`、`model` 和 `profile` |
+| `SessionEnd` | `exit` 或 `archive` | — | 会话关闭后触发；`archive` 表示会话被归档而非退出 |
+| `SessionHeartbeat` | 空字符串 | — | 会话存活期间每 60 秒触发一次；仅当配置了本事件时计时器才会运行。payload 含 `uptime_ms`（观察用） |
 | `SubagentStart` | 子 Agent 名称 | — | 子 Agent 开始运行前触发 |
 | `SubagentStop` | 子 Agent 名称 | — | 子 Agent 成功完成后触发（观察用） |
+| `TaskStarted` | 任务类型（`agent`、`process` 或 `question`） | — | 后台任务启动时触发；payload 含 `task_id`、`description` 和 `detached`（观察用） |
 | `StopFailure` | 错误类型 | — | 本轮因错误失败后触发（观察用） |
 | `Interrupt` | 空字符串 | — | 用户中断本轮时触发（例如按下 Esc）；超时或其他程序性中断不会触发。中断时 `Stop` 不会触发，由本事件替代。payload 含 `reason` 字段（观察用） |
 | `PreCompact` | `manual` 或 `auto` | — | 上下文压缩开始前触发；返回值被完全忽略 |

--- a/docs/zh/reference/kimi-command.md
+++ b/docs/zh/reference/kimi-command.md
@@ -343,7 +343,7 @@ kimi provider list --json | jq '.providers | keys'
 
 #### `kimi provider catalog list [providerId]`
 
-在不修改任何配置的情况下浏览公开的 [models.dev](https://models.dev/) 模型目录。不传参数时列出所有供应商及协议类型和模型数量；传 `providerId` 时列出该供应商下所有模型的上下文窗口和能力。
+在不修改任何配置的情况下浏览公开的 [models.dev](https://models.dev/) 模型目录。不传参数时列出所有供应商及协议类型和模型数量；传 `providerId` 时列出该供应商下所有模型的上下文窗口和能力。目录地址不可达时会使用内置目录快照。
 
 | 参数 / 选项 | 说明 |
 | --- | --- |
@@ -360,7 +360,7 @@ kimi provider catalog list anthropic
 
 #### `kimi provider catalog add <providerId>`
 
-按 id 从 catalog 直接导入一个已知供应商，协议类型、base URL、模型信息均由 catalog 提供，只需提供 API key。catalog 未声明协议的供应商（如 xai、openrouter 这类厂商专用 SDK）按 OpenAI 兼容协议导入，并在输出中标注 "guessed"；catalog 未提供可用端点时需用 `--base-url` 显式指定。专有协议（如 Amazon Bedrock）无法导入。
+按 id 从 catalog 直接导入一个已知供应商，协议类型、base URL、模型信息均由 catalog 提供，只需提供 API key。catalog 未声明协议的供应商（如 xai、openrouter 这类厂商专用 SDK）按 OpenAI 兼容协议导入，并在输出中标注 "guessed"；catalog 未提供可用端点时需用 `--base-url` 显式指定。专有协议（如 Amazon Bedrock）无法导入。公共目录不可达时会回退到内置目录快照，离线或网络受限环境下也能导入。
 
 | 参数 / 选项 | 说明 |
 | --- | --- |

--- a/docs/zh/release-notes/changelog.md
+++ b/docs/zh/release-notes/changelog.md
@@ -6,6 +6,26 @@ outline: 2
 
 本页记录 Kimi Code CLI 每个版本的变更内容。
 
+## 0.32.0（2026-08-04）
+
+### 新功能
+
+- 新增 `TurnStarted`、`UserPromptQueued`、`TaskStarted` 和 `SessionHeartbeat` 四个 hook 事件，在 `config.toml` 的 `[[hooks]]` 下配置，详见 [Hooks](../customization/hooks.md)。
+- 新增 `[token_counting]` 配置节，可选择上下文大小显示使用的 token 计数来源（`measured+estimated`、`measured` 或 `estimated`），适用于不上报用量的供应商。在 `config.toml` 的 `[token_counting]` 下设置 `strategy` 即可切换。
+
+### 优化
+
+- 重命名 `[loop_control]` 配置键：`max_retries_per_step` 改为 `max_attempts_per_step`，`max_steps_per_run` 改为 `max_steps_per_turn`。旧键不再生效，启动时会警告提示改名；`KIMI_LOOP_MAX_RETRIES_PER_STEP` 环境变量已弃用，请改用 `KIMI_LOOP_MAX_ATTEMPTS_PER_STEP`，旧变量仍有效但会给出警告。
+
+### 修复
+
+- 修复部分 OpenAI 兼容网关返回含冒号的工具调用 ID 时，交互式提问无法提交答案的问题。
+- 修复上下文自动压缩因请求过大反复重试直至失败的问题。
+- models.dev 目录不可达时回退到内置快照，离线或网络受限时也能导入已知第三方供应商。
+- 修复未配置模型时上下文窗口上限显示为 0 的问题，现回退到默认模型显示。
+- web: 修复深色模式下单色控件显示异常，聊天输入框圆角与设计系统对齐。
+- 修复 `/login` 已登录确认信息难以看清的问题，现以成功色显示。
+
 ## 0.31.1（2026-07-31）
 
 ### 优化

--- a/docs/zh/release-notes/changelog.md
+++ b/docs/zh/release-notes/changelog.md
@@ -11,11 +11,11 @@ outline: 2
 ### 新功能
 
 - 新增 `TurnStarted`、`UserPromptQueued`、`TaskStarted` 和 `SessionHeartbeat` 四个 hook 事件；会话被归档（而非退出）时 `SessionEnd` 现上报为 `archive`。在 `config.toml` 的 `[[hooks]]` 下配置，详见 [Hooks](../customization/hooks.md)。
-- 新增 `[token_counting]` 配置节，可选择上下文大小显示使用的 token 计数来源（`measured+estimated`、`measured` 或 `estimated`），适用于不上报用量的供应商。在 `config.toml` 的 `[token_counting]` 下设置 `strategy`（或使用 `KIMI_TOKEN_COUNTING_STRATEGY`）即可切换。
 
 ### 优化
 
 - 重命名 `[loop_control]` 配置键：`max_retries_per_step` 改为 `max_attempts_per_step`，`max_steps_per_run` 改为 `max_steps_per_turn`。旧键不再生效，启动时会警告提示改名；`KIMI_LOOP_MAX_RETRIES_PER_STEP` 环境变量已弃用，请改用 `KIMI_LOOP_MAX_ATTEMPTS_PER_STEP`，旧变量仍有效但会给出警告。
+- 新增 `[token_counting]` 配置节，可选择上下文大小显示使用的 token 计数来源（`measured+estimated`、`measured` 或 `estimated`），适用于不上报用量的供应商。在 `config.toml` 的 `[token_counting]` 下设置 `strategy`（或使用 `KIMI_TOKEN_COUNTING_STRATEGY`）即可切换。
 
 ### 修复
 

--- a/docs/zh/release-notes/changelog.md
+++ b/docs/zh/release-notes/changelog.md
@@ -10,8 +10,8 @@ outline: 2
 
 ### 新功能
 
-- 新增 `TurnStarted`、`UserPromptQueued`、`TaskStarted` 和 `SessionHeartbeat` 四个 hook 事件，在 `config.toml` 的 `[[hooks]]` 下配置，详见 [Hooks](../customization/hooks.md)。
-- 新增 `[token_counting]` 配置节，可选择上下文大小显示使用的 token 计数来源（`measured+estimated`、`measured` 或 `estimated`），适用于不上报用量的供应商。在 `config.toml` 的 `[token_counting]` 下设置 `strategy` 即可切换。
+- 新增 `TurnStarted`、`UserPromptQueued`、`TaskStarted` 和 `SessionHeartbeat` 四个 hook 事件；会话被归档（而非退出）时 `SessionEnd` 现上报为 `archive`。在 `config.toml` 的 `[[hooks]]` 下配置，详见 [Hooks](../customization/hooks.md)。
+- 新增 `[token_counting]` 配置节，可选择上下文大小显示使用的 token 计数来源（`measured+estimated`、`measured` 或 `estimated`），适用于不上报用量的供应商。在 `config.toml` 的 `[token_counting]` 下设置 `strategy`（或使用 `KIMI_TOKEN_COUNTING_STRATEGY`）即可切换。
 
 ### 优化
 


### PR DESCRIPTION
## Related Issue

N/A — post-release docs maintenance for 0.32.0

## Problem

Follow-up fixes for the 0.32.0 docs:

- The 0.32.0 changelog block was hard to read: over-detailed entries, internal jargon (`session status updates`, "no model is bound yet"), v1/v2 engine concepts, and two internal refactor entries users cannot perceive.
- `hooks.md` (en + zh) did not document the four new 0.32.0 hook events or the enriched payloads.
- `providers.md` and `kimi-command.md` did not mention that the models.dev catalog falls back to a built-in snapshot when unreachable.

## What changed

- `docs/{en,zh}/release-notes/changelog.md`: rewrote the 0.32.0 block in a shorter, user-perception-first style — hook events entry trimmed to the essentials with a link to the Hooks page; `[token_counting]` de-emphasized and simplified; v1/v2 mentions removed; "Known third-party provider" capitalization fixed; the `/login` entry no longer quotes the full message; `/login` moved to Bug Fixes. **Deliberately omitted**: the two internal refactor entries (v1 message history serving, session snapshot endpoint assembly incl. the undocumented `KIMI_SNAPSHOT_*` knobs) — not perceivable by CLI/web users.
- `docs/{en,zh}/customization/hooks.md`: added `UserPromptQueued`, `TurnStarted`, `SessionHeartbeat`, and `TaskStarted` to the event reference; updated `SessionStart` (now carries `source`/`model`/`profile`) and `SessionEnd` (`exit` or `archive`); base payload example gains `session_title` and `client_type`.
- `docs/{en,zh}/configuration/providers.md` + `docs/{en,zh}/reference/kimi-command.md`: documented the built-in catalog snapshot fallback for known-provider import and `kimi provider catalog list/add`.
- Verified with `pnpm --filter kimi-code-docs run build`.
- Follow-up commit: restored two user-facing facts in the 0.32.0 Features entries — `SessionEnd` now reports `archive` when a session is archived instead of exited (a matcher-visible behavior change for existing hooks), and the `KIMI_TOKEN_COUNTING_STRATEGY` env toggle alongside `[token_counting] strategy`.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [ ] I have added tests that prove my feature works. (N/A — docs only)
- [x] Ran `gen-changesets` skill, or this PR needs no changeset. (No changeset — docs only, not part of the release bundle)
- [x] Ran `gen-docs` skill, or this PR needs no doc update. (This PR is the doc update)

