### PR TITLE
docs(changelog): shorten the 0.32.0 loop_control and token_counting entries

### DIFF
--- a/docs/en/release-notes/changelog.md
+++ b/docs/en/release-notes/changelog.md
@@ -14,8 +14,8 @@ This page documents the changes in each Kimi Code CLI release.
 
 ### Polish
 
-- Rename `[loop_control] max_retries_per_step` to `max_attempts_per_step`, and `max_steps_per_run` to `max_steps_per_turn`. The old keys no longer take effect and a startup warning prompts the rename in `config.toml`; the `KIMI_LOOP_MAX_RETRIES_PER_STEP` env var is deprecated in favor of `KIMI_LOOP_MAX_ATTEMPTS_PER_STEP` but still works with a warning.
-- Add a `[token_counting]` config section to choose which token count the context-size display shows (`measured+estimated`, `measured`, or `estimated`); useful for providers that do not report token usage. Set `strategy` under `[token_counting]` in `config.toml` (or `KIMI_TOKEN_COUNTING_STRATEGY`) to switch.
+- Rename two `[loop_control]` keys: `max_retries_per_step` → `max_attempts_per_step` and `max_steps_per_run` → `max_steps_per_turn`. The old keys no longer take effect and a startup warning prompts the rename; the old env var is deprecated likewise — see [`loop_control`](../configuration/config-files.md#loop-control).
+- Add a `[token_counting]` config section to choose which token count the context-size display shows (measured, estimated, or both) — useful for providers that do not report token usage. See [`token_counting`](../configuration/config-files.md#token-counting).
 
 ### Bug Fixes
 

--- a/docs/en/release-notes/changelog.md
+++ b/docs/en/release-notes/changelog.md
@@ -14,8 +14,8 @@ This page documents the changes in each Kimi Code CLI release.
 
 ### Polish
 
-- Rename two `[loop_control]` keys: `max_retries_per_step` → `max_attempts_per_step` and `max_steps_per_run` → `max_steps_per_turn`; the old keys stop working with a startup warning — see [`loop_control`](../configuration/config-files.md#loop-control).
-- Add a `[token_counting]` config section so the context-size display can use measured usage, estimates, or both — mainly for providers that don't report token usage; see [`token_counting`](../configuration/config-files.md#token-counting).
+- Rename two `[loop_control]` keys: `max_retries_per_step` → `max_attempts_per_step` and `max_steps_per_run` → `max_steps_per_turn`; the old keys stop working — see [`loop_control`](../configuration/config-files.md#loop-control).
+- Add a `[token_counting]` config section: when a provider doesn't report token usage, switch the context-size display to local estimates — see [`token_counting`](../configuration/config-files.md#token-counting).
 
 ### Bug Fixes
 

--- a/docs/en/release-notes/changelog.md
+++ b/docs/en/release-notes/changelog.md
@@ -14,8 +14,8 @@ This page documents the changes in each Kimi Code CLI release.
 
 ### Polish
 
-- Rename two `[loop_control]` keys: `max_retries_per_step` → `max_attempts_per_step` and `max_steps_per_run` → `max_steps_per_turn`. The old keys no longer take effect and a startup warning prompts the rename; the old env var is deprecated likewise — see [`loop_control`](../configuration/config-files.md#loop-control).
-- Add a `[token_counting]` config section to choose which token count the context-size display shows (measured, estimated, or both) — useful for providers that do not report token usage. See [`token_counting`](../configuration/config-files.md#token-counting).
+- Rename two `[loop_control]` keys: `max_retries_per_step` → `max_attempts_per_step` and `max_steps_per_run` → `max_steps_per_turn`; the old keys stop working with a startup warning — see [`loop_control`](../configuration/config-files.md#loop-control).
+- Add a `[token_counting]` config section so the context-size display can use measured usage, estimates, or both — mainly for providers that don't report token usage; see [`token_counting`](../configuration/config-files.md#token-counting).
 
 ### Bug Fixes
 

--- a/docs/zh/release-notes/changelog.md
+++ b/docs/zh/release-notes/changelog.md
@@ -14,8 +14,8 @@ outline: 2
 
 ### 优化
 
-- 重命名 `[loop_control]` 的两个配置键：`max_retries_per_step` → `max_attempts_per_step`、`max_steps_per_run` → `max_steps_per_turn`。旧键不再生效，启动时会给出改名警告，对应的环境变量同步弃用，详见 [`loop_control`](../configuration/config-files.md#loop-control)。
-- 新增 `[token_counting]` 配置节，可选择上下文大小显示基于哪种 token 计数（实测、估算或两者兼有），适用于不上报用量的供应商，详见 [`token_counting`](../configuration/config-files.md#token-counting)。
+- `[loop_control]` 两个配置键改名：`max_retries_per_step` → `max_attempts_per_step`、`max_steps_per_run` → `max_steps_per_turn`；旧键失效，启动时警告提示改名，详见 [`loop_control`](../configuration/config-files.md#loop-control)。
+- 新增 `[token_counting]` 配置节，上下文大小显示可选实测、估算或两者兼有，适用于不上报用量的供应商，详见 [`token_counting`](../configuration/config-files.md#token-counting)。
 
 ### 修复
 

--- a/docs/zh/release-notes/changelog.md
+++ b/docs/zh/release-notes/changelog.md
@@ -14,8 +14,8 @@ outline: 2
 
 ### 优化
 
-- 重命名 `[loop_control]` 配置键：`max_retries_per_step` 改为 `max_attempts_per_step`，`max_steps_per_run` 改为 `max_steps_per_turn`。旧键不再生效，启动时会警告提示改名；`KIMI_LOOP_MAX_RETRIES_PER_STEP` 环境变量已弃用，请改用 `KIMI_LOOP_MAX_ATTEMPTS_PER_STEP`，旧变量仍有效但会给出警告。
-- 新增 `[token_counting]` 配置节，可选择上下文大小显示使用的 token 计数来源（`measured+estimated`、`measured` 或 `estimated`），适用于不上报用量的供应商。在 `config.toml` 的 `[token_counting]` 下设置 `strategy`（或使用 `KIMI_TOKEN_COUNTING_STRATEGY`）即可切换。
+- 重命名 `[loop_control]` 的两个配置键：`max_retries_per_step` → `max_attempts_per_step`、`max_steps_per_run` → `max_steps_per_turn`。旧键不再生效，启动时会给出改名警告，对应的环境变量同步弃用，详见 [`loop_control`](../configuration/config-files.md#loop-control)。
+- 新增 `[token_counting]` 配置节，可选择上下文大小显示基于哪种 token 计数（实测、估算或两者兼有），适用于不上报用量的供应商，详见 [`token_counting`](../configuration/config-files.md#token-counting)。
 
 ### 修复
 

--- a/docs/zh/release-notes/changelog.md
+++ b/docs/zh/release-notes/changelog.md
@@ -14,8 +14,8 @@ outline: 2
 
 ### 优化
 
-- `[loop_control]` 两个配置键改名：`max_retries_per_step` → `max_attempts_per_step`、`max_steps_per_run` → `max_steps_per_turn`；旧键失效，启动时警告提示改名，详见 [`loop_control`](../configuration/config-files.md#loop-control)。
-- 新增 `[token_counting]` 配置节，上下文大小显示可选实测、估算或两者兼有，适用于不上报用量的供应商，详见 [`token_counting`](../configuration/config-files.md#token-counting)。
+- `[loop_control]` 两个配置键改名：`max_retries_per_step` → `max_attempts_per_step`、`max_steps_per_run` → `max_steps_per_turn`；旧键不再生效（启动时会有改名警告），详见 `[loop_control](../configuration/config-files.md#loop-control)`。
+- 新增 `[token_counting]` 配置节：供应商不上报 token 用量时，可将上下文大小显示切换为本地估算，详见 `[token_counting](../configuration/config-files.md#token-counting)`。
 
 ### 修复
 


### PR DESCRIPTION
## Related Issue

N/A — follow-up to #2594 (post-release docs maintenance)

## Problem

The two `Polish` entries in the 0.32.0 changelog block enumerate every old/new config key and env var inline, making them long and backtick-heavy. The details already live in `docs/{en,zh}/configuration/config-files.md`.

## What changed

- `docs/{en,zh}/release-notes/changelog.md`: rewrote the two entries to keep only the key mapping (`max_retries_per_step` → `max_attempts_per_step`, `max_steps_per_run` → `max_steps_per_turn`) plus a link to the [`loop_control`](../configuration/config-files.md#loop-control) / [`token_counting`](../configuration/config-files.md#token-counting) sections for the env-var and strategy-value details. English and Chinese pages stay 1:1 (Features 1 / Polish 2 / Bug Fixes 6).
- Verified with `pnpm run build` in `docs/`.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [ ] I have added tests that prove my feature works. (N/A — docs only)
- [x] Ran `gen-changesets` skill, or this PR needs no changeset. (No changeset — docs only, not part of the release bundle)
- [x] Ran `gen-docs` skill, or this PR needs no doc update. (This PR is the doc update)