### PR TITLE
docs(changelog): fix 0.32.0 entry formatting and doc links

### DIFF
--- a/.agents/skills/pre-changelog/SKILL.md
+++ b/.agents/skills/pre-changelog/SKILL.md
@@ -37,7 +37,7 @@ If the CLI changelog is not in the diff (for example an SDK-only release), stop 
 
 Process the version block exactly as `sync-changelog` does for the docs site, but only in memory:
 
-- **Strip** (`sync-changelog` step 3): drop the H1, the `### Patch Changes` / `### Minor Changes` / `### Major Changes` subheadings, PR links, and commit-hash links; keep only each entry's body text. The `Thanks [@user](...)!` credit (including the multi-author form) must be removed every time. Within each entry, drop SDK-only and provider-internal sentences (SDK capability mapping / API exposure, provider wire-format mechanics, internal XML markers) and keep only the user-facing effect and required constraints.
+- **Strip** (`sync-changelog` step 3): drop the H1, the `### Patch Changes` / `### Minor Changes` / `### Major Changes` subheadings, PR links, and commit-hash links; keep only each entry's body text. The `Thanks [@user](...)!` credit (including the multi-author form) must be removed every time. Within each entry, drop SDK-only and provider-internal sentences (SDK capability mapping / API exposure, provider wire-format mechanics, internal XML markers, hook/event payload mechanics such as what an event reports or carries) and keep only the user-facing effect and required constraints.
 - **Merge and deduplicate** (`sync-changelog` step 4): merge micro-tweaks to the same surface into one higher-level entry; when three or more fixes target the same UI area or the same class of problem, merge them into one higher-level fix entry (do not merge broad or genuinely distinct fixes); and drop a server/API entry that only backs a web feature already listed.
 - **Classify** (`sync-changelog` step 4): bucket into Features / Bug Fixes / Polish / Refactors / Other; order within each section by reader value (in Polish, user-visible improvements before protocol/internal adjustments).
 - **Translate** (`sync-changelog` step 6): translate entry bodies to Chinese; keep one sentence per entry with a parallel rhythm within a section; section headings become 新功能 / 修复 / 优化 / 重构 / 其他.
@@ -47,6 +47,8 @@ If an upstream entry is not in English, flag it and stop (changeset entries must
 ### 4. Output
 
 Print the preview directly. Use `<version>（预览）` as the heading because the version is not released yet. Write `无` for empty sections. Do not write any file.
+
+The preview is pasted into chat tools (for example Lark), where relative docs links do not resolve. Rewrite every docs link to its absolute published URL: map `../<path>.md[#anchor]` to `https://moonshotai.github.io/kimi-code/zh/<path>.html[#anchor]` — for example `../configuration/config-files.md#loop-control` → `https://moonshotai.github.io/kimi-code/zh/configuration/config-files.html#loop-control`. Never emit raw relative paths, and never wrap a link in backticks; code-style the link text inside the brackets instead ([`loop_control`](...)).
 
 ```
 发版 PR: <url>

--- a/.agents/skills/sync-changelog/SKILL.md
+++ b/.agents/skills/sync-changelog/SKILL.md
@@ -115,6 +115,7 @@ Drop SDK-only and provider-internal detail. This changelog serves `@moonshot-ai/
 
 - Drop sentences about how the SDK maps a capability, builds model aliases, or exposes a flag through an API such as `getExperimentalFeatures()` — that belongs in the SDK changelog, not here.
 - Drop provider / wire-format implementation mechanics (XML markers like `<tools_added>`, protocol field explanations, "the wire protocol is unchanged", cache-hit mechanics) unless they are the behavior a user perceives.
+- Drop hook/event payload mechanics — clauses about what extra fields an event payload carries or what an event reports in a specific case (for example "enrich hook payloads with the session title and client type", "`SessionEnd` reports `archive` when a session is archived"). Keep the new events or capability itself and how to configure it.
 - Keep the user-facing effect and any constraints users must follow (for example "question texts must be unique").
 
 Do not change facts or drop a real user-facing behavior — only trim the internal-only scaffolding. For over-long, internal-heavy entries, this trim applies on the English page too, not only in translation.
@@ -229,6 +230,8 @@ Example:
 - Update the native release workflow to use current GitHub artifact actions.
 ```
 
+Doc links: an entry that changes a documented config surface may end with a pointer to the docs page — `see [X](...) for details` (Chinese: `详见 [X](...)。`). Keep it a real Markdown link into the docs tree with a relative path (for example `../configuration/config-files.md#loop-control`). When the link text is a config key or another identifier, code-style the text inside the brackets: [`loop_control`](../configuration/config-files.md#loop-control). Never wrap the whole link in backticks — `` `[loop_control](...)` `` renders as raw inline code that exposes the relative path instead of a clickable link.
+
 ### 6. Translate The Increment Into Chinese
 
 After updating the English page, translate only the newly added English content into `docs/zh/release-notes/changelog.md`.
@@ -322,6 +325,7 @@ Check:
 - PR links and commit hashes were stripped.
 - No `Thanks ...!` credit remains (remove it every time).
 - Real internal identifiers were replaced with neutral placeholders.
+- Doc links are real Markdown links (code-styled text inside the brackets when needed), never wrapped in backticks.
 - There are no empty sections.
 - Markdown indentation and blank lines are intact.
 
@@ -454,6 +458,8 @@ Return the PR URL to the user when done.
 | Leaving empty sections | Delete sections with no entries |
 | Putting everything under Other for convenience | Classify what can be classified first |
 | Translating tool names, command names, or config keys | Keep them as written |
+| Wrapping a whole doc link in backticks | Code-style the link text inside the brackets instead, so the link stays clickable: [`loop_control`](...) |
+| Keeping hook/event payload-mechanics clauses | Drop what an event reports or carries; keep the new capability and how to configure it |
 | Creating a changeset for docs sync | Do not create one |
 | Committing or pushing directly on `main` | Create `docs/changelog-sync-<version>`, commit there, then open a PR |
 | Committing or opening a PR before the user skips review or confirms review is done | Wait at the human review checkpoint |

--- a/docs/en/release-notes/changelog.md
+++ b/docs/en/release-notes/changelog.md
@@ -10,12 +10,12 @@ This page documents the changes in each Kimi Code CLI release.
 
 ### Features
 
-- Add four hook events: `TurnStarted`, `UserPromptQueued`, `TaskStarted`, and `SessionHeartbeat`; `SessionEnd` now also reports `archive` when a session is archived instead of exited. Configure the events under `[[hooks]]` in `config.toml` — see [Hooks](../customization/hooks.md) for details.
+- Add four hook events: `TurnStarted`, `UserPromptQueued`, `TaskStarted`, and `SessionHeartbeat`. Configure them under `[[hooks]]` in `config.toml` — see [Hooks](https://moonshotai.github.io/kimi-code/en/customization/hooks.html) for details.
 
 ### Polish
 
-- Rename two `[loop_control]` keys: `max_retries_per_step` → `max_attempts_per_step` and `max_steps_per_run` → `max_steps_per_turn`; the old keys stop working — see [`loop_control`](../configuration/config-files.md#loop-control).
-- Add a `[token_counting]` config section: when a provider doesn't report token usage, switch the context-size display to local estimates — see [`token_counting`](../configuration/config-files.md#token-counting).
+- Rename two `[loop_control]` keys: `max_retries_per_step` → `max_attempts_per_step` and `max_steps_per_run` → `max_steps_per_turn`; the old keys stop working with a rename warning at startup — see [loop_control](https://moonshotai.github.io/kimi-code/en/configuration/config-files.html#loop-control).
+- Add a `[token_counting]` config section: when a provider doesn't report token usage, switch the context-size display to local estimates — see [token_counting](https://moonshotai.github.io/kimi-code/en/configuration/config-files.html#token-counting).
 
 ### Bug Fixes
 

--- a/docs/zh/release-notes/changelog.md
+++ b/docs/zh/release-notes/changelog.md
@@ -10,12 +10,12 @@ outline: 2
 
 ### 新功能
 
-- 新增 `TurnStarted`、`UserPromptQueued`、`TaskStarted` 和 `SessionHeartbeat` 四个 hook 事件；会话被归档（而非退出）时 `SessionEnd` 现上报为 `archive`。在 `config.toml` 的 `[[hooks]]` 下配置，详见 [Hooks](../customization/hooks.md)。
+- 新增四个 hook 事件：`TurnStarted`、`UserPromptQueued`、`TaskStarted` 和 `SessionHeartbeat`。在 `config.toml` 的 `[[hooks]]` 下配置，详见 [Hooks](https://moonshotai.github.io/kimi-code/zh/customization/hooks.html)。
 
 ### 优化
 
-- `[loop_control]` 两个配置键改名：`max_retries_per_step` → `max_attempts_per_step`、`max_steps_per_run` → `max_steps_per_turn`；旧键不再生效（启动时会有改名警告），详见 `[loop_control](../configuration/config-files.md#loop-control)`。
-- 新增 `[token_counting]` 配置节：供应商不上报 token 用量时，可将上下文大小显示切换为本地估算，详见 `[token_counting](../configuration/config-files.md#token-counting)`。
+- `[loop_control]` 两个配置键改名：`max_retries_per_step` → `max_attempts_per_step`、`max_steps_per_run` → `max_steps_per_turn`；旧键不再生效，启动时会有改名警告，详见 [loop_control](https://moonshotai.github.io/kimi-code/zh/configuration/config-files.html#loop-control)。
+- 新增 `[token_counting]` 配置节：供应商不上报 token 用量时，可将上下文大小显示切换为本地估算，详见 [token_counting](https://moonshotai.github.io/kimi-code/zh/configuration/config-files.html#token-counting)。
 
 ### 修复
 


### PR DESCRIPTION
## Related Issue

N/A — post-release docs maintenance

## Problem

The 0.32.0 changelog entries had several rendering problems, most visible when the text is pasted into chat tools:

- The two "详见" doc links on the Chinese page were wrapped in backticks, so they rendered as raw inline code exposing the relative path instead of clickable links.
- All doc links were relative paths, which do not resolve outside the docs site.
- The Features entry carried an internal `SessionEnd`-reporting clause with no user-facing value.
- Inline-code density was high, making the entries hard to scan.

## What changed

- `docs/zh` + `docs/en` 0.32.0: drop the `SessionEnd`-as-`archive` reporting clause; keep only the new hook events and how to configure them.
- Unwrap the backtick-wrapped doc links and point all three doc links at absolute published URLs (`https://moonshotai.github.io/kimi-code/...`), with plain link text instead of code-styled.
- Reduce inline-code density by rewording, while keeping code style on real identifiers (event names, config keys, `config.toml`, `/login`).
- `sync-changelog` skill: drop hook/event payload-mechanics clauses; document the doc-link format (real Markdown links, never backtick-wrapped); add matching Verify / Common Mistakes entries.
- `pre-changelog` skill: rewrite preview doc links to absolute published URLs, since the preview is pasted into chat tools.
- Verified with `pnpm -C docs run build`; anchors `#loop-control` / `#token-counting` exist on the target pages.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [ ] I have added tests that prove my feature works. (N/A — docs-only change)
- [x] Ran `gen-changesets` skill, or this PR needs no changeset. (No changeset — docs and agent-skill guidance only, nothing enters package output)
- [x] Ran `gen-docs` skill, or this PR needs no doc update. (This PR is the doc update)