### PR TITLE
fix(tui): reclaim transcript entries when turns fold

### DIFF
--- a/apps/kimi-code/src/tui/kimi-tui.ts
+++ b/apps/kimi-code/src/tui/kimi-tui.ts
@@ -2498,13 +2498,28 @@ export class KimiTUI {
       newChildren.push(children[i]!);
     }
 
-    for (const idx of toMergeIndices) {
-      const child = children[idx]!;
+    const mergedChildren = toMergeIndices.map((idx) => children[idx]!);
+    for (const child of mergedChildren) {
       if (hasDispose(child)) child.dispose();
     }
+    // The merged components are gone; their transcript entries have to go
+    // too, or the entry list keeps growing underneath the folded tree.
+    this.dropTranscriptEntriesOf(mergedChildren);
 
     children.splice(0, children.length, ...newChildren);
     return true;
+  }
+
+  private dropTranscriptEntriesOf(components: readonly Component[]): void {
+    const dropped = new Set<TranscriptEntry>();
+    for (const component of components) {
+      const entry = getTranscriptComponentEntry(component);
+      if (entry !== undefined) dropped.add(entry);
+    }
+    if (dropped.size === 0) return;
+    this.state.transcriptEntries = this.state.transcriptEntries.filter(
+      (entry) => !dropped.has(entry),
+    );
   }
 
   mergeAllTurnSteps(): void {
@@ -2583,6 +2598,7 @@ export class KimiTUI {
     for (const child of toDispose) {
       if (hasDispose(child)) child.dispose();
     }
+    this.dropTranscriptEntriesOf(toDispose);
     children.splice(0, children.length, ...newChildren);
   }
 

--- a/apps/kimi-code/test/tui/transcript-fold-reclaim.test.ts
+++ b/apps/kimi-code/test/tui/transcript-fold-reclaim.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { KimiTUI, type KimiTUIStartupInput } from '#/tui/kimi-tui';
+import { StepSummaryComponent } from '#/tui/components/messages/step-summary';
+
+function makeHarness() {
+  return {
+    getConfig: vi.fn(async () => ({
+      models: {
+        k2: { model: 'moonshot-v1', maxContextSize: 100 },
+      },
+    })),
+    createSession: vi.fn(async () => ({ id: 'ses-1', model: 'k2' })),
+    resumeSession: vi.fn(async () => ({ id: 'ses-1', model: 'k2' })),
+    listSessions: vi.fn(async () => []),
+    close: vi.fn(async () => {}),
+    track: vi.fn(),
+    setTelemetryContext: vi.fn(),
+    getExperimentalFeatures: vi.fn(async () => []),
+    supportsAtomicSectionReplace: vi.fn(() => false),
+    auth: {
+      status: vi.fn(async () => ({ providers: [] })),
+      login: vi.fn(async () => {}),
+      logout: vi.fn(),
+      getManagedUsage: vi.fn(),
+    },
+  };
+}
+
+function makeStartupInput(): KimiTUIStartupInput {
+  return {
+    cliOptions: {
+      session: undefined,
+      continue: false,
+      yolo: false,
+      auto: false,
+      plan: false,
+      model: undefined,
+      outputFormat: undefined,
+      prompt: undefined,
+      skillsDirs: [],
+      agent: undefined,
+      agentFiles: [],
+    },
+    tuiConfig: {
+      theme: 'dark',
+      disablePasteBurst: false,
+      editorCommand: null,
+      notifications: { enabled: true, condition: 'unfocused' },
+      upgrade: { autoInstall: true },
+      statusLine: { items: null, command: null },
+    },
+    version: '0.0.0-test',
+    workDir: '/tmp/proj-a',
+  };
+}
+
+function makeDriver() {
+  const driver = new KimiTUI(makeHarness() as never, makeStartupInput());
+  vi.spyOn(driver.state.ui, 'requestRender').mockImplementation(() => {});
+  vi.spyOn(driver.state.terminal, 'setProgress').mockImplementation(() => {});
+  return driver;
+}
+
+describe('transcript fold entry reclaim', () => {
+  it('drops the folded assistant entries when a completed turn folds', () => {
+    const driver = makeDriver();
+    driver.appendTranscriptEntry({ id: 'u1', kind: 'user', renderMode: 'plain', content: 'hello' });
+    for (const id of ['a0', 'a1', 'a2', 'a3']) {
+      driver.appendTranscriptEntry({
+        id,
+        kind: 'assistant',
+        turnId: 't1',
+        renderMode: 'markdown',
+        content: `message ${id}`,
+        modelText: true,
+      });
+    }
+    expect(driver.state.transcriptEntries).toHaveLength(5);
+
+    const folded = driver.mergeCompletedTurnAssistants();
+
+    expect(folded).toBe(true);
+    // the two oldest assistants merged into the summary; the tail stays
+    expect(driver.state.transcriptEntries.map((entry) => entry.id)).toEqual(['u1', 'a2', 'a3']);
+    const summaryCount = driver.state.transcriptContainer.children.filter(
+      (child) => child instanceof StepSummaryComponent,
+    ).length;
+    expect(summaryCount).toBe(1);
+  });
+
+  it('keeps every entry when nothing exceeds the fold caps', () => {
+    const driver = makeDriver();
+    driver.appendTranscriptEntry({ id: 'u1', kind: 'user', renderMode: 'plain', content: 'hello' });
+    for (const id of ['a0', 'a1']) {
+      driver.appendTranscriptEntry({
+        id,
+        kind: 'assistant',
+        turnId: 't1',
+        renderMode: 'markdown',
+        content: `message ${id}`,
+        modelText: true,
+      });
+    }
+
+    const folded = driver.mergeCompletedTurnAssistants();
+
+    expect(folded).toBe(false);
+    expect(driver.state.transcriptEntries.map((entry) => entry.id)).toEqual(['u1', 'a0', 'a1']);
+  });
+});


### PR DESCRIPTION
Refs #2556.

One of the two reclaim paths in that issue: both fold paths (`foldCurrentTurnContent` on turn completion, `mergeAllTurnSteps` for replayed sessions) dispose the merged components and splice the transcript child list, but the matching entries stay in `state.transcriptEntries` forever. Components shrink to a summary while the entry list keeps every thinking/tool/assistant record underneath, so memory keeps growing in exactly the sessions folding was meant to bound.

The `Component ↔ TranscriptEntry` WeakMap already exists for this mapping. Both fold paths now route their merged children through a small helper that drops the matching entries along with the components.

Scope note: this is the unambiguous half of #2556. The other half (pure `!` sessions pinning every entry in the untrimmable tail turn) is a trim-policy question, deliberately left out here.

## Verification

New `transcript-fold-reclaim.test.ts` builds a real `KimiTUI` against a mock harness, appends a turn with four assistant entries, folds on completion, and asserts the two folded entries are gone from `transcriptEntries` (the tail and the summary stay), plus the no-op case under the caps. The fold test fails without the change (entries survive the fold) and passes with it. Full `apps/kimi-code` TUI suite: 127 files, 1718 tests pass. oxlint/tsc clean.
