### PR TITLE
feat(mcp): carry an absolute expiresAt on the OAuth authorization-url update

### DIFF
--- a/packages/agent-core-v2/src/agent/mcp/tools/auth.ts
+++ b/packages/agent-core-v2/src/agent/mcp/tools/auth.ts
@@ -40,6 +40,7 @@ export const MCP_OAUTH_AUTHORIZATION_URL_TOOL_UPDATE = 'mcp.oauth.authorization_
 export interface McpOAuthAuthorizationUrlUpdateData {
   readonly serverName: string;
   readonly authorizationUrl: string;
+  readonly expiresAt?: number;
 }
 
 const DEFAULT_AUTH_TIMEOUT_MS = 15 * 60 * 1000;
@@ -103,9 +104,11 @@ export function createMcpAuthTool(options: CreateMcpAuthToolOptions): Executable
     }
 
     const urlText = flow.authorizationUrl.toString();
+    const waitTimeoutMs = timeoutMs ?? DEFAULT_AUTH_TIMEOUT_MS;
     const customData: McpOAuthAuthorizationUrlUpdateData = {
       serverName,
       authorizationUrl: urlText,
+      expiresAt: Date.now() + waitTimeoutMs,
     };
     onUpdate?.({
       kind: 'custom',
@@ -122,7 +125,7 @@ export function createMcpAuthTool(options: CreateMcpAuthToolOptions): Executable
     });
 
     try {
-      await flow.complete({ signal, timeoutMs: timeoutMs ?? DEFAULT_AUTH_TIMEOUT_MS });
+      await flow.complete({ signal, timeoutMs: waitTimeoutMs });
     } catch (error) {
       return errorResult(serverName, error, urlText);
     }

--- a/packages/agent-core-v2/test/agent/mcp/tools/auth.test.ts
+++ b/packages/agent-core-v2/test/agent/mcp/tools/auth.test.ts
@@ -62,14 +62,18 @@ describe('createMcpAuthTool', () => {
     expect(final.output).toMatch(/authenticated successfully/);
     expect(reconnectCalls).toBe(1);
     expect(updates.some((u) => u.text?.includes('https://example.com/authorize'))).toBe(true);
-    expect(updates).toContainEqual({
-      kind: 'custom',
-      customKind: MCP_OAUTH_AUTHORIZATION_URL_TOOL_UPDATE,
-      customData: {
-        serverName: 'notion',
-        authorizationUrl: 'https://example.com/authorize?state=abc',
-      },
+    const authUpdate = updates.find(
+      (u) => u.kind === 'custom' && u.customKind === MCP_OAUTH_AUTHORIZATION_URL_TOOL_UPDATE,
+    );
+    expect(authUpdate?.customData).toMatchObject({
+      serverName: 'notion',
+      authorizationUrl: 'https://example.com/authorize?state=abc',
     });
+    // The deadline is absolute (now + wait timeout), so hosts never mirror
+    // the engine-side constant.
+    const { expiresAt } = authUpdate?.customData as { expiresAt?: number };
+    expect(expiresAt).toBeGreaterThan(Date.now());
+    expect(expiresAt).toBeLessThanOrEqual(Date.now() + 15 * 60 * 1000);
   });
 
   it('falls through to reconnect when the provider reports already-authorized', async () => {

--- a/packages/agent-core/src/mcp/auth-tool.ts
+++ b/packages/agent-core/src/mcp/auth-tool.ts
@@ -113,9 +113,13 @@ export function createMcpAuthTool(options: CreateMcpAuthToolOptions): Executable
     }
 
     const urlText = flow.authorizationUrl.toString();
+    const waitTimeoutMs = timeoutMs ?? DEFAULT_AUTH_TIMEOUT_MS;
     const customData: McpOAuthAuthorizationUrlUpdateData = {
       serverName,
       authorizationUrl: urlText,
+      // Absolute deadline of the pending flow, so hosts can render countdown
+      // or expiry states without mirroring DEFAULT_AUTH_TIMEOUT_MS.
+      expiresAt: Date.now() + waitTimeoutMs,
     };
     onUpdate?.({
       kind: 'custom',
@@ -132,7 +136,7 @@ export function createMcpAuthTool(options: CreateMcpAuthToolOptions): Executable
     });
 
     try {
-      await flow.complete({ signal, timeoutMs: timeoutMs ?? DEFAULT_AUTH_TIMEOUT_MS });
+      await flow.complete({ signal, timeoutMs: waitTimeoutMs });
     } catch (error) {
       return errorResult(serverName, error, urlText);
     }

--- a/packages/agent-core/test/mcp/auth-tool.test.ts
+++ b/packages/agent-core/test/mcp/auth-tool.test.ts
@@ -66,14 +66,18 @@ describe('createMcpAuthTool', () => {
     expect(final.output).toMatch(/authenticated successfully/);
     expect(reconnectCalls).toBe(1);
     expect(updates.some((u) => u.text?.includes('https://example.com/authorize'))).toBe(true);
-    expect(updates).toContainEqual({
-      kind: 'custom',
-      customKind: MCP_OAUTH_AUTHORIZATION_URL_TOOL_UPDATE,
-      customData: {
-        serverName: 'notion',
-        authorizationUrl: 'https://example.com/authorize?state=abc',
-      },
+    const authUpdate = updates.find(
+      (u) => u.kind === 'custom' && u.customKind === MCP_OAUTH_AUTHORIZATION_URL_TOOL_UPDATE,
+    );
+    expect(authUpdate?.customData).toMatchObject({
+      serverName: 'notion',
+      authorizationUrl: 'https://example.com/authorize?state=abc',
     });
+    // The deadline is absolute (now + wait timeout), so hosts never mirror
+    // the engine-side constant.
+    const { expiresAt } = authUpdate?.customData as { expiresAt?: number };
+    expect(expiresAt).toBeGreaterThan(Date.now());
+    expect(expiresAt).toBeLessThanOrEqual(Date.now() + 15 * 60 * 1000);
   });
 
   it('falls through to reconnect when the provider reports already-authorized', async () => {

--- a/packages/kap-server/src/protocol/events-zod.ts
+++ b/packages/kap-server/src/protocol/events-zod.ts
@@ -469,6 +469,7 @@ export const toolUpdateSchema = z.object({
 export const mcpOAuthAuthorizationUrlUpdateDataSchema = z.object({
   serverName: z.string(),
   authorizationUrl: z.string(),
+  expiresAt: z.number().optional(),
 }) satisfies z.ZodType<McpOAuthAuthorizationUrlUpdateData>;
 
 export const turnEndReasonSchema = z.enum(['completed', 'cancelled', 'failed', 'blocked']) satisfies z.ZodType<TurnEndReason>;

--- a/packages/protocol/src/events.ts
+++ b/packages/protocol/src/events.ts
@@ -430,6 +430,12 @@ export const MCP_OAUTH_AUTHORIZATION_URL_TOOL_UPDATE = 'mcp.oauth.authorization_
 export interface McpOAuthAuthorizationUrlUpdateData {
   readonly serverName: string;
   readonly authorizationUrl: string;
+  /**
+   * Epoch-ms instant when the engine stops waiting for the OAuth callback.
+   * Hosts derive countdowns and expiry states from this value instead of
+   * mirroring the engine-side timeout constant.
+   */
+  readonly expiresAt?: number;
 }
 
 export type TurnEndReason = 'completed' | 'cancelled' | 'failed' | 'blocked';

--- a/packages/protocol/src/events.ts
+++ b/packages/protocol/src/events.ts
@@ -1370,6 +1370,7 @@ export const toolUpdateSchema = z.object({
 export const mcpOAuthAuthorizationUrlUpdateDataSchema = z.object({
   serverName: z.string(),
   authorizationUrl: z.string(),
+  expiresAt: z.number().optional(),
 }) satisfies z.ZodType<McpOAuthAuthorizationUrlUpdateData>;
 
 export const turnEndReasonSchema = z.enum(['completed', 'cancelled', 'failed', 'blocked']) satisfies z.ZodType<TurnEndReason>;


### PR DESCRIPTION
## Related Issue

Resolve #2607

## Problem

See linked issue: the `authenticate` flow waits for the OAuth callback with a fixed budget (`DEFAULT_AUTH_TIMEOUT_MS = 15 min`), but the `mcp.oauth.authorization_url` tool update surfaced to embedding hosts carries only `{serverName, authorizationUrl}`. A host that wants to render a countdown or an expired state has to hardcode its own mirror of the 15-minute constant and count from event receipt — a mirror that drifts with transport latency and silently breaks if the engine-side default ever changes.

## What changed

- `packages/protocol/src/events.ts`: `McpOAuthAuthorizationUrlUpdateData` gains an optional `expiresAt?: number` (epoch ms) — the instant the engine stops waiting for the callback. Optional and additive, so existing consumers are unaffected.
- v1 `packages/agent-core/src/mcp/auth-tool.ts` and v2 `packages/agent-core-v2/src/agent/mcp/tools/auth.ts`: the update payload includes `expiresAt = now + effective wait timeout`, computed from the same value later passed to `flow.complete` (so an overridden `timeoutMs` stays consistent with the advertised deadline).

No changeset: an additive optional field on an internal event payload; no user-visible CLI behavior changes.

## Verification

Updated the v1/v2 auth-tool tests: the update still matches on `serverName`/`authorizationUrl`, and `expiresAt` is asserted to lie between now and now + 15 min. `tsc --noEmit` passes for `protocol`, `agent-core`, and `agent-core-v2`; `oxlint` clean; both auth-tool suites pass (5 tests each).
