### PR TITLE
fix(agent-core-v2): bound the project skill-root watch fd footprint

### DIFF
--- a/.changeset/skill-watch-fd-exhaustion.md
+++ b/.changeset/skill-watch-fd-exhaustion.md
@@ -2,4 +2,4 @@
 "@moonshot-ai/kimi-code": patch
 ---
 
-Fix all tool calls failing with spawn EBADF on macOS when a skill folder contains a very large file tree (e.g. a bundled Python runtime); the skill watcher no longer opens every file it watches.
+Fix all tool calls failing with spawn EBADF on macOS when a skill folder contains a very large file tree.

--- a/.changeset/skill-watch-fd-exhaustion.md
+++ b/.changeset/skill-watch-fd-exhaustion.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Fix all tool calls failing with spawn EBADF on macOS when a skill folder contains a very large file tree (e.g. a bundled Python runtime); the skill watcher no longer opens every file it watches.

--- a/packages/agent-core-v2/src/_base/utils/paths.ts
+++ b/packages/agent-core-v2/src/_base/utils/paths.ts
@@ -1,14 +1,29 @@
 /**
  * Path-filter helpers — pure string predicates, no IO.
+ *
+ * `subtreeWatchFilter` builds an `ignored` predicate that confines a recursive
+ * fs watch to the candidate subtrees under `root` plus their ancestor chain
+ * (so candidates that do not exist yet are still detected once created). The
+ * optional knobs prune paths BELOW a candidate only: `skipEntry` rejects
+ * entries by basename (e.g. a scanner's `node_modules` / dot-entry rule) and
+ * `maxDepth` rejects anything deeper than that many segments below the
+ * candidate — letting a watch mirror a scanner's own pruning instead of
+ * watching subtrees the consumer would never read.
  */
 
 function normalizeSlashes(p: string): string {
   return p.replaceAll('\\', '/');
 }
 
+export interface SubtreeWatchFilterOptions {
+  readonly maxDepth?: number;
+  readonly skipEntry?: (entryName: string) => boolean;
+}
+
 export function subtreeWatchFilter(
   root: string,
   candidates: readonly string[],
+  options?: SubtreeWatchFilterOptions,
 ): (path: string) => boolean {
   const normRoot = normalizeSlashes(root);
   const normCandidates = candidates.map(normalizeSlashes);
@@ -16,9 +31,22 @@ export function subtreeWatchFilter(
     const norm = normalizeSlashes(p);
     if (norm === normRoot) return false;
     for (const candidate of normCandidates) {
-      if (norm === candidate || norm.startsWith(`${candidate}/`)) return false;
+      if (norm === candidate) return false;
+      if (norm.startsWith(`${candidate}/`)) {
+        return isPrunedBelowCandidate(norm.slice(candidate.length + 1), options);
+      }
       if (candidate.startsWith(`${norm}/`)) return false;
     }
     return true;
   };
+}
+
+function isPrunedBelowCandidate(
+  rel: string,
+  options: SubtreeWatchFilterOptions | undefined,
+): boolean {
+  if (options === undefined) return false;
+  const segments = rel.split('/');
+  if (options.skipEntry !== undefined && segments.some(options.skipEntry)) return true;
+  return options.maxDepth !== undefined && segments.length > options.maxDepth;
 }

--- a/packages/agent-core-v2/src/_base/utils/paths.ts
+++ b/packages/agent-core-v2/src/_base/utils/paths.ts
@@ -13,6 +13,7 @@ export interface SubtreeWatchFilterOptions {
   readonly maxDepth?: number;
   readonly skipEntry?: (entryName: string) => boolean;
   readonly keepEntryFile?: string;
+  readonly scannedDirectories?: readonly string[];
 }
 
 export function subtreeWatchFilter(
@@ -22,13 +23,22 @@ export function subtreeWatchFilter(
 ): (path: string) => boolean {
   const normRoot = normalizeSlashes(root);
   const normCandidates = candidates.map(normalizeSlashes);
+  const normScannedDirectories =
+    options?.scannedDirectories === undefined
+      ? undefined
+      : new Set([...normCandidates, ...options.scannedDirectories.map(normalizeSlashes)]);
   return (p: string): boolean => {
     const norm = normalizeSlashes(p);
     if (norm === normRoot) return false;
     for (const candidate of normCandidates) {
       if (norm === candidate) return false;
       if (norm.startsWith(`${candidate}/`)) {
-        return isPrunedBelowCandidate(norm.slice(candidate.length + 1), options);
+        return isPrunedBelowCandidate(
+          norm,
+          norm.slice(candidate.length + 1),
+          options,
+          normScannedDirectories,
+        );
       }
       if (candidate.startsWith(`${norm}/`)) return false;
     }
@@ -37,8 +47,10 @@ export function subtreeWatchFilter(
 }
 
 function isPrunedBelowCandidate(
+  normPath: string,
   rel: string,
   options: SubtreeWatchFilterOptions | undefined,
+  scannedDirectories: ReadonlySet<string> | undefined,
 ): boolean {
   if (options === undefined) return false;
   const segments = rel.split('/');
@@ -54,5 +66,29 @@ function isPrunedBelowCandidate(
       );
     }
   }
+  if (scannedDirectories !== undefined) {
+    return !isScannerVisiblePath(normPath, scannedDirectories, options.keepEntryFile);
+  }
   return false;
+}
+
+function isScannerVisiblePath(
+  normPath: string,
+  scannedDirectories: ReadonlySet<string>,
+  keepEntryFile: string | undefined,
+): boolean {
+  if (scannedDirectories.has(normPath)) return true;
+  const separatorAt = normPath.lastIndexOf('/');
+  if (separatorAt === -1) return false;
+  const parent = normPath.slice(0, separatorAt);
+  if (scannedDirectories.has(parent)) return true;
+  if (
+    keepEntryFile === undefined ||
+    normPath.slice(separatorAt + 1) !== keepEntryFile
+  ) {
+    return false;
+  }
+  const parentSeparatorAt = parent.lastIndexOf('/');
+  if (parentSeparatorAt === -1) return false;
+  return scannedDirectories.has(parent.slice(0, parentSeparatorAt));
 }

--- a/packages/agent-core-v2/src/_base/utils/paths.ts
+++ b/packages/agent-core-v2/src/_base/utils/paths.ts
@@ -4,11 +4,14 @@
  * `subtreeWatchFilter` builds an `ignored` predicate that confines a recursive
  * fs watch to the candidate subtrees under `root` plus their ancestor chain
  * (so candidates that do not exist yet are still detected once created). The
- * optional knobs prune paths BELOW a candidate only: `skipEntry` rejects
- * entries by basename (e.g. a scanner's `node_modules` / dot-entry rule) and
- * `maxDepth` rejects anything deeper than that many segments below the
- * candidate — letting a watch mirror a scanner's own pruning instead of
- * watching subtrees the consumer would never read.
+ * optional knobs prune paths BELOW a candidate only, mirroring a
+ * recursion-gated scanner: `maxDepth` rejects anything deeper than that many
+ * segments below the candidate, and an entry matching `skipEntry` (e.g. the
+ * skill scanner's `node_modules` / dot-entry rule) stops further watching —
+ * but the entry itself, and with `keepEntryFile` also its direct child file
+ * of that name, stay watched, because a scanner still probes those without
+ * recursing deeper. Everything below that point is what the consumer never
+ * reads, and only that is pruned.
  */
 
 function normalizeSlashes(p: string): string {
@@ -18,6 +21,7 @@ function normalizeSlashes(p: string): string {
 export interface SubtreeWatchFilterOptions {
   readonly maxDepth?: number;
   readonly skipEntry?: (entryName: string) => boolean;
+  readonly keepEntryFile?: string;
 }
 
 export function subtreeWatchFilter(
@@ -47,6 +51,16 @@ function isPrunedBelowCandidate(
 ): boolean {
   if (options === undefined) return false;
   const segments = rel.split('/');
-  if (options.skipEntry !== undefined && segments.some(options.skipEntry)) return true;
+  if (options.skipEntry !== undefined) {
+    const excludedAt = segments.findIndex(options.skipEntry);
+    if (excludedAt !== -1) {
+      if (segments.length <= excludedAt + 1) return false;
+      return !(
+        options.keepEntryFile !== undefined &&
+        segments.length === excludedAt + 2 &&
+        segments.at(-1) === options.keepEntryFile
+      );
+    }
+  }
   return options.maxDepth !== undefined && segments.length > options.maxDepth;
 }

--- a/packages/agent-core-v2/src/_base/utils/paths.ts
+++ b/packages/agent-core-v2/src/_base/utils/paths.ts
@@ -1,17 +1,8 @@
 /**
- * Path-filter helpers — pure string predicates, no IO.
+ * `_base/utils/paths` (cross-cutting) — pure path-filter predicates.
  *
- * `subtreeWatchFilter` builds an `ignored` predicate that confines a recursive
- * fs watch to the candidate subtrees under `root` plus their ancestor chain
- * (so candidates that do not exist yet are still detected once created). The
- * optional knobs prune paths BELOW a candidate only, mirroring a
- * recursion-gated scanner: `maxDepth` rejects anything deeper than that many
- * segments below the candidate, and an entry matching `skipEntry` (e.g. the
- * skill scanner's `node_modules` / dot-entry rule) stops further watching —
- * but the entry itself, and with `keepEntryFile` also its direct child file
- * of that name, stay watched, because a scanner still probes those without
- * recursing deeper. Everything below that point is what the consumer never
- * reads, and only that is pruned.
+ * Constrains filesystem watches to selected subtrees and scanner-visible
+ * entries.
  */
 
 function normalizeSlashes(p: string): string {
@@ -51,6 +42,7 @@ function isPrunedBelowCandidate(
 ): boolean {
   if (options === undefined) return false;
   const segments = rel.split('/');
+  if (options.maxDepth !== undefined && segments.length > options.maxDepth) return true;
   if (options.skipEntry !== undefined) {
     const excludedAt = segments.findIndex(options.skipEntry);
     if (excludedAt !== -1) {
@@ -62,5 +54,5 @@ function isPrunedBelowCandidate(
       );
     }
   }
-  return options.maxDepth !== undefined && segments.length > options.maxDepth;
+  return false;
 }

--- a/packages/agent-core-v2/src/app/skillCatalog/fileSkillDiscovery.ts
+++ b/packages/agent-core-v2/src/app/skillCatalog/fileSkillDiscovery.ts
@@ -40,6 +40,7 @@ export async function discoverFileSkills(
 ): Promise<SkillDiscoveryResult> {
   const byDiscoveryKey = new Map<string, SkillDefinition>();
   const skipped: SkippedSkill[] = [];
+  const scannedDirectories: string[] = [];
 
   async function walkSkillDir(
     dirPath: string,
@@ -56,6 +57,7 @@ export async function discoverFileSkills(
     } catch {
       return;
     }
+    scannedDirectories.push(dirPath);
 
     const directorySkills = new Set<string>();
     const subdirs: string[] = [];
@@ -138,6 +140,7 @@ export async function discoverFileSkills(
     skills: sortSkills([...byDiscoveryKey.values()]),
     skipped,
     scannedRoots: roots.map((root) => root.path),
+    scannedDirectories,
   };
 }
 

--- a/packages/agent-core-v2/src/app/skillCatalog/fileSkillDiscovery.ts
+++ b/packages/agent-core-v2/src/app/skillCatalog/fileSkillDiscovery.ts
@@ -2,8 +2,11 @@
  * `skillCatalog` domain — filesystem `ISkillDiscovery` backend.
  *
  * Discovers skill bundles by walking caller-supplied roots and parsing each
- * SKILL.md. Exposes both the App-scoped `ISkillDiscovery` service and a
- * stateless standalone function.
+ * SKILL.md, pruning `node_modules` / dot entries and capping the walk depth
+ * (`isSkillScanExcludedEntry`, `MAX_SKILL_SCAN_DEPTH` — exported so fs
+ * watches can mirror the scan's own pruning instead of watching subtrees it
+ * would never read). Exposes both the App-scoped `ISkillDiscovery` service
+ * and a stateless standalone function.
  */
 
 import { promises as fs } from 'node:fs';
@@ -16,7 +19,11 @@ import type { SkillDiscoveryResult, ISkillDiscovery } from './skillDiscovery';
 import type { SkillDefinition, SkillRoot, SkippedSkill } from './types';
 import { normalizeSkillName } from './types';
 
-const MAX_SKILL_SCAN_DEPTH = 8;
+export const MAX_SKILL_SCAN_DEPTH = 8;
+
+export function isSkillScanExcludedEntry(entryName: string): boolean {
+  return entryName === 'node_modules' || entryName.startsWith('.');
+}
 
 export class FileSkillDiscovery implements ISkillDiscovery {
   declare readonly _serviceBrand: undefined;
@@ -60,7 +67,7 @@ export async function discoverFileSkills(
       if (await isFile(path.join(entryPath, 'SKILL.md'))) {
         directorySkills.add(entry);
       }
-      if (entry === 'node_modules' || entry.startsWith('.')) continue;
+      if (isSkillScanExcludedEntry(entry)) continue;
       if (await isDir(entryPath)) subdirs.push(entry);
     }
 

--- a/packages/agent-core-v2/src/app/skillCatalog/fileSkillDiscovery.ts
+++ b/packages/agent-core-v2/src/app/skillCatalog/fileSkillDiscovery.ts
@@ -2,11 +2,8 @@
  * `skillCatalog` domain — filesystem `ISkillDiscovery` backend.
  *
  * Discovers skill bundles by walking caller-supplied roots and parsing each
- * SKILL.md, pruning `node_modules` / dot entries and capping the walk depth
- * (`isSkillScanExcludedEntry`, `MAX_SKILL_SCAN_DEPTH` — exported so fs
- * watches can mirror the scan's own pruning instead of watching subtrees it
- * would never read). Exposes both the App-scoped `ISkillDiscovery` service
- * and a stateless standalone function.
+ * SKILL.md. Exposes discovery through the App-scoped service and a stateless
+ * filesystem entry point.
  */
 
 import { promises as fs } from 'node:fs';

--- a/packages/agent-core-v2/src/app/skillCatalog/inMemorySkillDiscovery.ts
+++ b/packages/agent-core-v2/src/app/skillCatalog/inMemorySkillDiscovery.ts
@@ -52,7 +52,7 @@ export class InMemorySkillDiscovery implements ISkillDiscovery {
       if (roots.some((root) => root.source === 'user')) skills.push(...this.userSkills);
       if (roots.some((root) => root.source === 'project')) skills.push(...this.projectSkills);
     }
-    return { skills, skipped: [], scannedRoots: [] };
+    return { skills, skipped: [], scannedRoots: [], scannedDirectories: [] };
   }
 }
 

--- a/packages/agent-core-v2/src/app/skillCatalog/skillDiscovery.ts
+++ b/packages/agent-core-v2/src/app/skillCatalog/skillDiscovery.ts
@@ -19,6 +19,7 @@ export interface SkillDiscoveryResult {
   readonly skills: readonly SkillDefinition[];
   readonly skipped: readonly SkippedSkill[];
   readonly scannedRoots: readonly string[];
+  readonly scannedDirectories: readonly string[];
 }
 
 export interface ISkillDiscovery {

--- a/packages/agent-core-v2/src/app/skillCatalog/skillRoots.ts
+++ b/packages/agent-core-v2/src/app/skillCatalog/skillRoots.ts
@@ -54,7 +54,7 @@ export interface ProjectSkillRootCandidates {
 export async function projectSkillRootCandidates(
   workDir: string,
 ): Promise<ProjectSkillRootCandidates> {
-  const projectRoot = await findProjectRoot(workDir);
+  const projectRoot = await realpathOrSelf(await findProjectRoot(workDir));
   return {
     projectRoot,
     candidates: [...PROJECT_BRAND_DIRS, ...PROJECT_GENERIC_DIRS].map((dir) =>
@@ -143,6 +143,14 @@ async function isDir(p: string): Promise<boolean> {
 
 async function realpath(p: string): Promise<string> {
   return (await fs.realpath(p)).replaceAll('\\', '/');
+}
+
+async function realpathOrSelf(p: string): Promise<string> {
+  try {
+    return await realpath(p);
+  } catch {
+    return p.replaceAll('\\', '/');
+  }
 }
 
 async function exists(p: string): Promise<boolean> {

--- a/packages/agent-core-v2/src/os/backends/node-local/hostFsWatchService.ts
+++ b/packages/agent-core-v2/src/os/backends/node-local/hostFsWatchService.ts
@@ -1,28 +1,16 @@
 /**
  * `hostFsWatch` domain — `IHostFsWatchService` implementation.
  *
- * Wraps `chokidar` to report raw create/modify/delete events under an absolute
- * path. Each `watch()` call owns an independent watcher; disposing the handle
- * closes it. A `signal`-mode recursive watch on darwin/win32 instead uses ONE
- * native recursive `fs.watch` (FSEvents / ReadDirectoryChangesW), whose fd
- * footprint stays constant in the subtree size — chokidar holds one
- * `fs.watch` fd per file and per directory on macOS, so per-node watching of
- * a fat subtree can exhaust the process fd budget and break every subsequent
- * spawn. The signal leg owns its recovery: a native error (including sync
- * creation failure) fires one root-level invalidation and re-arms the native
- * watch with capped exponential backoff, so a transient failure neither
- * downgrades the consumer to the per-node watcher nor silently ends hot
- * reload; chokidar serves only when the platform has no recursive
- * `fs.watch`. Event mapping lives in `NativeSignalMapper` as pure logic
- * with the stat call injected, so it is testable off darwin/win32.
- * Bound at App scope.
+ * Reports precise or coarse host filesystem changes through platform
+ * watchers. Each handle owns and disposes its watcher. Bound at App scope.
  */
 
-import { watch as fsWatch, lstatSync, type FSWatcher as NodeFSWatcher } from 'node:fs';
+import { watch as fsWatch } from 'node:fs';
 import { basename, isAbsolute, join, relative } from 'node:path';
 
 import { FSWatcher } from 'chokidar';
 
+import type { IDisposable } from '#/_base/di/lifecycle';
 import { Emitter, type Event } from '#/_base/event';
 import { LifecycleScope, ScopeActivation, registerScopedService } from '#/_base/di/scope';
 import { onUnexpectedError } from '#/_base/errors/unexpectedError';
@@ -41,53 +29,34 @@ const DEFAULT_IGNORED = (p: string): boolean => /(?:^|[/\\])\.git(?:$|[/\\])/.te
 const NATIVE_RETRY_BASE_MS = 1000;
 const NATIVE_RETRY_MAX_MS = 30000;
 
-export interface NativeSignalStat {
-  kindOf(absPath: string): HostFsChangeKind | undefined;
+interface NativeFsWatcher {
+  close(): void;
+  on(event: 'error', listener: (error: NodeJS.ErrnoException) => void): this;
 }
 
-export class NativeSignalMapper {
-  private readonly knownKinds = new Map<string, HostFsChangeKind>();
-
-  constructor(private readonly stat: NativeSignalStat) {}
-
-  map(
+interface HostFsWatchRuntime {
+  readonly platform: NodeJS.Platform;
+  watchNative(
     root: string,
-    eventType: string,
-    filename: string | null,
-    ignored: (path: string) => boolean,
-  ): HostFsChange | undefined {
-    const absPath = this.resolveEventPath(root, filename);
-    if (absPath !== root && ignored(absPath)) return undefined;
-    if (eventType === 'change') {
-      return { path: absPath, action: 'modified', kind: this.knownKinds.get(absPath) ?? 'file' };
-    }
-    if (eventType !== 'rename') return undefined;
-    const statKind = this.stat.kindOf(absPath);
-    if (statKind !== undefined) {
-      const action: HostFsChangeAction = this.knownKinds.has(absPath) ? 'modified' : 'created';
-      this.knownKinds.set(absPath, statKind);
-      return { path: absPath, action, kind: statKind };
-    }
-    const kind = this.knownKinds.get(absPath) ?? 'file';
-    this.knownKinds.delete(absPath);
-    return { path: absPath, action: 'deleted', kind };
-  }
-
-  private resolveEventPath(root: string, filename: string | null): string {
-    if (filename === null || filename === '') return root;
-    if (isAbsolute(filename)) return clampToRoot(root, filename);
-    if (filename === basename(root) && this.stat.kindOf(join(root, filename)) === undefined) {
-      return root;
-    }
-    return join(root, filename);
-  }
+    listener: (eventType: string, filename: string | null) => void,
+  ): NativeFsWatcher;
+  scheduleRetry(callback: () => void, delayMs: number): IDisposable;
 }
 
-function clampToRoot(root: string, absPath: string): string {
-  const rel = relative(root, absPath);
-  if (rel === '' || (!rel.startsWith('..') && !isAbsolute(rel))) return absPath;
-  return root;
-}
+const NODE_HOST_FS_WATCH_RUNTIME: HostFsWatchRuntime = {
+  platform: process.platform,
+  watchNative: (root, listener) =>
+    fsWatch(root, { persistent: false, recursive: true }, listener),
+  scheduleRetry: (callback, delayMs) => {
+    const timer = setTimeout(callback, delayMs);
+    timer.unref?.();
+    return {
+      dispose: () => {
+        clearTimeout(timer);
+      },
+    };
+  },
+};
 
 class HostFsWatchHandle implements IHostFsWatchHandle {
   readonly onDidChange: Event<HostFsChange>;
@@ -129,22 +98,18 @@ class SignalWatchHandle implements IHostFsWatchHandle {
 
   private readonly emitter: Emitter<HostFsChange>;
   private readonly ignored: (path: string) => boolean;
-  private readonly mapper = new NativeSignalMapper({
-    kindOf: (absPath) => {
-      try {
-        return lstatSync(absPath).isDirectory() ? 'directory' : 'file';
-      } catch {
-        return undefined;
-      }
-    },
-  });
-  private nativeWatcher: NodeFSWatcher | undefined;
+  private nativeWatcher: NativeFsWatcher | undefined;
   private chokidarLeg: HostFsWatchHandle | undefined;
-  private retryTimer: ReturnType<typeof setTimeout> | undefined;
+  private retry: IDisposable | undefined;
   private retryAttempts = 0;
+  private recovering = false;
   private disposed = false;
 
-  constructor(private readonly root: string, options: HostFsWatchOptions | undefined) {
+  constructor(
+    private readonly root: string,
+    options: HostFsWatchOptions | undefined,
+    private readonly runtime: HostFsWatchRuntime,
+  ) {
     this.emitter = new Emitter<HostFsChange>();
     this.onDidChange = this.emitter.event;
     this.ignored = options?.ignored ?? DEFAULT_IGNORED;
@@ -154,41 +119,47 @@ class SignalWatchHandle implements IHostFsWatchHandle {
   private startNativeLeg(): void {
     if (this.disposed) return;
     try {
-      const watcher = fsWatch(
-        this.root,
-        { persistent: false, recursive: true },
-        (eventType, filename) => {
-          if (this.disposed) return;
-          const mapped = this.mapper.map(this.root, eventType, filename, this.ignored);
-          if (mapped !== undefined) this.emitter.fire(mapped);
-        },
-      );
+      const watcher = this.runtime.watchNative(this.root, (_eventType, filename) => {
+        if (this.disposed) return;
+        this.retryAttempts = 0;
+        const absPath = resolveNativeSignalPath(this.root, filename);
+        if (absPath !== this.root && this.ignored(absPath)) return;
+        this.fireInvalidation();
+      });
       watcher.on('error', (error: NodeJS.ErrnoException) => {
-        this.onNativeError(error);
+        this.onNativeError(watcher, error);
       });
       this.nativeWatcher = watcher;
-      this.retryAttempts = 0;
+      if (this.recovering) {
+        this.recovering = false;
+        this.fireInvalidation();
+      }
     } catch (error) {
-      this.onNativeError(error as NodeJS.ErrnoException);
+      this.onNativeError(undefined, error as NodeJS.ErrnoException);
     }
   }
 
-  private onNativeError(error: NodeJS.ErrnoException): void {
+  private onNativeError(watcher: NativeFsWatcher | undefined, error: NodeJS.ErrnoException): void {
     if (this.disposed) return;
-    this.nativeWatcher?.close();
+    if (watcher !== undefined && watcher !== this.nativeWatcher) return;
+    watcher?.close();
     this.nativeWatcher = undefined;
     if (error.code === 'ERR_FEATURE_UNAVAILABLE_ON_PLATFORM') {
+      this.recovering = false;
       this.startChokidarLeg();
+      this.fireInvalidation();
       return;
     }
     onUnexpectedError(error);
-    this.emitter.fire({ path: this.root, action: 'modified', kind: 'directory' });
+    this.recovering = true;
+    this.fireInvalidation();
     const delay = Math.min(NATIVE_RETRY_BASE_MS * 2 ** this.retryAttempts, NATIVE_RETRY_MAX_MS);
     this.retryAttempts += 1;
-    this.retryTimer = setTimeout(() => {
+    this.retry?.dispose();
+    this.retry = this.runtime.scheduleRetry(() => {
+      this.retry = undefined;
       this.startNativeLeg();
     }, delay);
-    this.retryTimer.unref?.();
   }
 
   private startChokidarLeg(): void {
@@ -200,10 +171,14 @@ class SignalWatchHandle implements IHostFsWatchHandle {
     this.chokidarLeg = leg;
   }
 
+  private fireInvalidation(): void {
+    this.emitter.fire({ path: this.root, action: 'modified', kind: 'directory' });
+  }
+
   dispose(): void {
     if (this.disposed) return;
     this.disposed = true;
-    if (this.retryTimer !== undefined) clearTimeout(this.retryTimer);
+    this.retry?.dispose();
     this.nativeWatcher?.close();
     this.chokidarLeg?.dispose();
     this.emitter.dispose();
@@ -213,20 +188,36 @@ class SignalWatchHandle implements IHostFsWatchHandle {
 export class HostFsWatchService implements IHostFsWatchService {
   declare readonly _serviceBrand: undefined;
 
+  constructor(private readonly runtime: HostFsWatchRuntime = NODE_HOST_FS_WATCH_RUNTIME) {}
+
   watch(path: string, options?: HostFsWatchOptions): IHostFsWatchHandle {
-    if (useNativeRecursive(options)) {
-      return new SignalWatchHandle(path, options);
+    if (useNativeRecursive(options, this.runtime.platform)) {
+      return new SignalWatchHandle(path, options, this.runtime);
     }
     return new HostFsWatchHandle(path, options);
   }
 }
 
-function useNativeRecursive(options: HostFsWatchOptions | undefined): boolean {
+function useNativeRecursive(
+  options: HostFsWatchOptions | undefined,
+  platform: NodeJS.Platform,
+): boolean {
   return (
     options?.signal === true &&
     options.recursive !== false &&
-    (process.platform === 'darwin' || process.platform === 'win32')
+    (platform === 'darwin' || platform === 'win32')
   );
+}
+
+function resolveNativeSignalPath(root: string, filename: string | null): string {
+  if (filename === null || filename === '' || filename === basename(root)) return root;
+  return clampToRoot(root, isAbsolute(filename) ? filename : join(root, filename));
+}
+
+function clampToRoot(root: string, absPath: string): string {
+  const rel = relative(root, absPath);
+  if (rel === '' || (!rel.startsWith('..') && !isAbsolute(rel))) return absPath;
+  return root;
 }
 
 function mapChokidarEvent(eventName: string, absPath: string): HostFsChange | undefined {

--- a/packages/agent-core-v2/src/os/backends/node-local/hostFsWatchService.ts
+++ b/packages/agent-core-v2/src/os/backends/node-local/hostFsWatchService.ts
@@ -58,14 +58,47 @@ const NODE_HOST_FS_WATCH_RUNTIME: HostFsWatchRuntime = {
   },
 };
 
+interface WatchReadiness {
+  readonly promise: Promise<void>;
+  resolve(): void;
+  reject(error: unknown): void;
+}
+
+function createWatchReadiness(): WatchReadiness {
+  let resolvePromise!: () => void;
+  let rejectPromise!: (error: unknown) => void;
+  let settled = false;
+  const promise = new Promise<void>((resolve, reject) => {
+    resolvePromise = resolve;
+    rejectPromise = reject;
+  });
+  void promise.catch(() => undefined);
+  return {
+    promise,
+    resolve: () => {
+      if (settled) return;
+      settled = true;
+      resolvePromise();
+    },
+    reject: (error) => {
+      if (settled) return;
+      settled = true;
+      rejectPromise(error);
+    },
+  };
+}
+
 class HostFsWatchHandle implements IHostFsWatchHandle {
+  readonly ready: Promise<void>;
   readonly onDidChange: Event<HostFsChange>;
 
+  private readonly readiness = createWatchReadiness();
   private readonly emitter: Emitter<HostFsChange>;
   private readonly watcher: FSWatcher;
   private disposed = false;
 
   constructor(path: string, options: HostFsWatchOptions | undefined) {
+    this.ready = this.readiness.promise;
     this.emitter = new Emitter<HostFsChange>();
     this.onDidChange = this.emitter.event;
     this.watcher = new FSWatcher({
@@ -80,22 +113,27 @@ class HostFsWatchHandle implements IHostFsWatchHandle {
       if (mapped !== undefined) this.emitter.fire(mapped);
     });
     this.watcher.on('error', (error: unknown) => {
+      this.readiness.reject(error);
       onUnexpectedError(error);
     });
+    this.watcher.once('ready', () => this.readiness.resolve());
     this.watcher.add(path);
   }
 
   dispose(): void {
     if (this.disposed) return;
     this.disposed = true;
+    this.readiness.resolve();
     void this.watcher.close().catch(() => undefined);
     this.emitter.dispose();
   }
 }
 
 class SignalWatchHandle implements IHostFsWatchHandle {
+  readonly ready: Promise<void>;
   readonly onDidChange: Event<HostFsChange>;
 
+  private readonly readiness = createWatchReadiness();
   private readonly emitter: Emitter<HostFsChange>;
   private readonly ignored: (path: string) => boolean;
   private nativeWatcher: NativeFsWatcher | undefined;
@@ -110,6 +148,7 @@ class SignalWatchHandle implements IHostFsWatchHandle {
     options: HostFsWatchOptions | undefined,
     private readonly runtime: HostFsWatchRuntime,
   ) {
+    this.ready = this.readiness.promise;
     this.emitter = new Emitter<HostFsChange>();
     this.onDidChange = this.emitter.event;
     this.ignored = options?.ignored ?? DEFAULT_IGNORED;
@@ -130,6 +169,7 @@ class SignalWatchHandle implements IHostFsWatchHandle {
         this.onNativeError(watcher, error);
       });
       this.nativeWatcher = watcher;
+      this.readiness.resolve();
       if (this.recovering) {
         this.recovering = false;
         this.fireInvalidation();
@@ -168,6 +208,10 @@ class SignalWatchHandle implements IHostFsWatchHandle {
     leg.onDidChange((event) => {
       if (!this.disposed) this.emitter.fire(event);
     });
+    void leg.ready.then(
+      () => this.readiness.resolve(),
+      (error: unknown) => this.readiness.reject(error),
+    );
     this.chokidarLeg = leg;
   }
 
@@ -178,6 +222,7 @@ class SignalWatchHandle implements IHostFsWatchHandle {
   dispose(): void {
     if (this.disposed) return;
     this.disposed = true;
+    this.readiness.resolve();
     this.retry?.dispose();
     this.nativeWatcher?.close();
     this.chokidarLeg?.dispose();

--- a/packages/agent-core-v2/src/os/backends/node-local/hostFsWatchService.ts
+++ b/packages/agent-core-v2/src/os/backends/node-local/hostFsWatchService.ts
@@ -2,9 +2,17 @@
  * `hostFsWatch` domain — `IHostFsWatchService` implementation.
  *
  * Wraps `chokidar` to report raw create/modify/delete events under an absolute
- * path. Each `watch()` call owns an independent `FSWatcher`; disposing the
- * handle closes it. Bound at App scope.
+ * path. Each `watch()` call owns an independent watcher; disposing the handle
+ * closes it. A `signal`-mode recursive watch on darwin/win32 instead uses ONE
+ * native recursive `fs.watch` (FSEvents / ReadDirectoryChangesW), whose fd
+ * footprint stays constant in the subtree size — chokidar holds one
+ * `fs.watch` fd per file and per directory on macOS, so per-node watching of
+ * a fat subtree can exhaust the process fd budget and break every subsequent
+ * spawn. Bound at App scope.
  */
+
+import { watch as fsWatch, lstatSync, type FSWatcher as NodeFSWatcher } from 'node:fs';
+import { join } from 'node:path';
 
 import { FSWatcher } from 'chokidar';
 
@@ -58,11 +66,88 @@ class HostFsWatchHandle implements IHostFsWatchHandle {
   }
 }
 
+class NativeRecursiveWatchHandle implements IHostFsWatchHandle {
+  readonly onDidChange: Event<HostFsChange>;
+
+  private readonly emitter: Emitter<HostFsChange>;
+  private readonly watcher: NodeFSWatcher;
+  private readonly ignored: (path: string) => boolean;
+  private readonly knownKinds = new Map<string, HostFsChangeKind>();
+  private disposed = false;
+
+  constructor(path: string, options: HostFsWatchOptions | undefined) {
+    this.emitter = new Emitter<HostFsChange>();
+    this.onDidChange = this.emitter.event;
+    this.ignored = options?.ignored ?? DEFAULT_IGNORED;
+    this.watcher = fsWatch(path, { persistent: false, recursive: true }, (eventType, filename) => {
+      this.onNativeEvent(path, eventType, filename);
+    });
+    this.watcher.on('error', (error: unknown) => {
+      onUnexpectedError(error);
+    });
+  }
+
+  private onNativeEvent(root: string, eventType: string, filename: string | null): void {
+    if (this.disposed) return;
+    const absPath = filename === null || filename === '' ? root : join(root, filename);
+    if (absPath !== root && this.ignored(absPath)) return;
+    const mapped = this.mapNativeEvent(absPath, eventType);
+    if (mapped !== undefined) this.emitter.fire(mapped);
+  }
+
+  private mapNativeEvent(absPath: string, eventType: string): HostFsChange | undefined {
+    if (eventType === 'change') {
+      return { path: absPath, action: 'modified', kind: this.knownKinds.get(absPath) ?? 'file' };
+    }
+    if (eventType !== 'rename') return undefined;
+    try {
+      const kind: HostFsChangeKind = lstatSync(absPath).isDirectory() ? 'directory' : 'file';
+      const action: HostFsChangeAction = this.knownKinds.has(absPath) ? 'modified' : 'created';
+      this.knownKinds.set(absPath, kind);
+      return { path: absPath, action, kind };
+    } catch {
+      const kind: HostFsChangeKind = this.knownKinds.get(absPath) ?? 'file';
+      this.knownKinds.delete(absPath);
+      return { path: absPath, action: 'deleted', kind };
+    }
+  }
+
+  dispose(): void {
+    if (this.disposed) return;
+    this.disposed = true;
+    this.watcher.close();
+    this.emitter.dispose();
+  }
+}
+
 export class HostFsWatchService implements IHostFsWatchService {
   declare readonly _serviceBrand: undefined;
 
   watch(path: string, options?: HostFsWatchOptions): IHostFsWatchHandle {
+    if (useNativeRecursive(options)) {
+      const native = tryNativeRecursiveWatch(path, options);
+      if (native !== undefined) return native;
+    }
     return new HostFsWatchHandle(path, options);
+  }
+}
+
+function useNativeRecursive(options: HostFsWatchOptions | undefined): boolean {
+  return (
+    options?.signal === true &&
+    options.recursive !== false &&
+    (process.platform === 'darwin' || process.platform === 'win32')
+  );
+}
+
+function tryNativeRecursiveWatch(
+  path: string,
+  options: HostFsWatchOptions | undefined,
+): IHostFsWatchHandle | undefined {
+  try {
+    return new NativeRecursiveWatchHandle(path, options);
+  } catch {
+    return undefined;
   }
 }
 

--- a/packages/agent-core-v2/src/os/backends/node-local/hostFsWatchService.ts
+++ b/packages/agent-core-v2/src/os/backends/node-local/hostFsWatchService.ts
@@ -8,11 +8,18 @@
  * footprint stays constant in the subtree size — chokidar holds one
  * `fs.watch` fd per file and per directory on macOS, so per-node watching of
  * a fat subtree can exhaust the process fd budget and break every subsequent
- * spawn. Bound at App scope.
+ * spawn. The signal leg owns its recovery: a native error (including sync
+ * creation failure) fires one root-level invalidation and re-arms the native
+ * watch with capped exponential backoff, so a transient failure neither
+ * downgrades the consumer to the per-node watcher nor silently ends hot
+ * reload; chokidar serves only when the platform has no recursive
+ * `fs.watch`. Event mapping lives in `NativeSignalMapper` as pure logic
+ * with the stat call injected, so it is testable off darwin/win32.
+ * Bound at App scope.
  */
 
 import { watch as fsWatch, lstatSync, type FSWatcher as NodeFSWatcher } from 'node:fs';
-import { join } from 'node:path';
+import { basename, isAbsolute, join, relative } from 'node:path';
 
 import { FSWatcher } from 'chokidar';
 
@@ -30,6 +37,57 @@ import {
 } from '#/os/interface/hostFsWatch';
 
 const DEFAULT_IGNORED = (p: string): boolean => /(?:^|[/\\])\.git(?:$|[/\\])/.test(p);
+
+const NATIVE_RETRY_BASE_MS = 1000;
+const NATIVE_RETRY_MAX_MS = 30000;
+
+export interface NativeSignalStat {
+  kindOf(absPath: string): HostFsChangeKind | undefined;
+}
+
+export class NativeSignalMapper {
+  private readonly knownKinds = new Map<string, HostFsChangeKind>();
+
+  constructor(private readonly stat: NativeSignalStat) {}
+
+  map(
+    root: string,
+    eventType: string,
+    filename: string | null,
+    ignored: (path: string) => boolean,
+  ): HostFsChange | undefined {
+    const absPath = this.resolveEventPath(root, filename);
+    if (absPath !== root && ignored(absPath)) return undefined;
+    if (eventType === 'change') {
+      return { path: absPath, action: 'modified', kind: this.knownKinds.get(absPath) ?? 'file' };
+    }
+    if (eventType !== 'rename') return undefined;
+    const statKind = this.stat.kindOf(absPath);
+    if (statKind !== undefined) {
+      const action: HostFsChangeAction = this.knownKinds.has(absPath) ? 'modified' : 'created';
+      this.knownKinds.set(absPath, statKind);
+      return { path: absPath, action, kind: statKind };
+    }
+    const kind = this.knownKinds.get(absPath) ?? 'file';
+    this.knownKinds.delete(absPath);
+    return { path: absPath, action: 'deleted', kind };
+  }
+
+  private resolveEventPath(root: string, filename: string | null): string {
+    if (filename === null || filename === '') return root;
+    if (isAbsolute(filename)) return clampToRoot(root, filename);
+    if (filename === basename(root) && this.stat.kindOf(join(root, filename)) === undefined) {
+      return root;
+    }
+    return join(root, filename);
+  }
+}
+
+function clampToRoot(root: string, absPath: string): string {
+  const rel = relative(root, absPath);
+  if (rel === '' || (!rel.startsWith('..') && !isAbsolute(rel))) return absPath;
+  return root;
+}
 
 class HostFsWatchHandle implements IHostFsWatchHandle {
   readonly onDidChange: Event<HostFsChange>;
@@ -66,56 +124,88 @@ class HostFsWatchHandle implements IHostFsWatchHandle {
   }
 }
 
-class NativeRecursiveWatchHandle implements IHostFsWatchHandle {
+class SignalWatchHandle implements IHostFsWatchHandle {
   readonly onDidChange: Event<HostFsChange>;
 
   private readonly emitter: Emitter<HostFsChange>;
-  private readonly watcher: NodeFSWatcher;
   private readonly ignored: (path: string) => boolean;
-  private readonly knownKinds = new Map<string, HostFsChangeKind>();
+  private readonly mapper = new NativeSignalMapper({
+    kindOf: (absPath) => {
+      try {
+        return lstatSync(absPath).isDirectory() ? 'directory' : 'file';
+      } catch {
+        return undefined;
+      }
+    },
+  });
+  private nativeWatcher: NodeFSWatcher | undefined;
+  private chokidarLeg: HostFsWatchHandle | undefined;
+  private retryTimer: ReturnType<typeof setTimeout> | undefined;
+  private retryAttempts = 0;
   private disposed = false;
 
-  constructor(path: string, options: HostFsWatchOptions | undefined) {
+  constructor(private readonly root: string, options: HostFsWatchOptions | undefined) {
     this.emitter = new Emitter<HostFsChange>();
     this.onDidChange = this.emitter.event;
     this.ignored = options?.ignored ?? DEFAULT_IGNORED;
-    this.watcher = fsWatch(path, { persistent: false, recursive: true }, (eventType, filename) => {
-      this.onNativeEvent(path, eventType, filename);
-    });
-    this.watcher.on('error', (error: unknown) => {
-      onUnexpectedError(error);
-    });
+    this.startNativeLeg();
   }
 
-  private onNativeEvent(root: string, eventType: string, filename: string | null): void {
+  private startNativeLeg(): void {
     if (this.disposed) return;
-    const absPath = filename === null || filename === '' ? root : join(root, filename);
-    if (absPath !== root && this.ignored(absPath)) return;
-    const mapped = this.mapNativeEvent(absPath, eventType);
-    if (mapped !== undefined) this.emitter.fire(mapped);
+    try {
+      const watcher = fsWatch(
+        this.root,
+        { persistent: false, recursive: true },
+        (eventType, filename) => {
+          if (this.disposed) return;
+          const mapped = this.mapper.map(this.root, eventType, filename, this.ignored);
+          if (mapped !== undefined) this.emitter.fire(mapped);
+        },
+      );
+      watcher.on('error', (error: NodeJS.ErrnoException) => {
+        this.onNativeError(error);
+      });
+      this.nativeWatcher = watcher;
+      this.retryAttempts = 0;
+    } catch (error) {
+      this.onNativeError(error as NodeJS.ErrnoException);
+    }
   }
 
-  private mapNativeEvent(absPath: string, eventType: string): HostFsChange | undefined {
-    if (eventType === 'change') {
-      return { path: absPath, action: 'modified', kind: this.knownKinds.get(absPath) ?? 'file' };
+  private onNativeError(error: NodeJS.ErrnoException): void {
+    if (this.disposed) return;
+    this.nativeWatcher?.close();
+    this.nativeWatcher = undefined;
+    if (error.code === 'ERR_FEATURE_UNAVAILABLE_ON_PLATFORM') {
+      this.startChokidarLeg();
+      return;
     }
-    if (eventType !== 'rename') return undefined;
-    try {
-      const kind: HostFsChangeKind = lstatSync(absPath).isDirectory() ? 'directory' : 'file';
-      const action: HostFsChangeAction = this.knownKinds.has(absPath) ? 'modified' : 'created';
-      this.knownKinds.set(absPath, kind);
-      return { path: absPath, action, kind };
-    } catch {
-      const kind: HostFsChangeKind = this.knownKinds.get(absPath) ?? 'file';
-      this.knownKinds.delete(absPath);
-      return { path: absPath, action: 'deleted', kind };
-    }
+    onUnexpectedError(error);
+    this.emitter.fire({ path: this.root, action: 'modified', kind: 'directory' });
+    const delay = Math.min(NATIVE_RETRY_BASE_MS * 2 ** this.retryAttempts, NATIVE_RETRY_MAX_MS);
+    this.retryAttempts += 1;
+    this.retryTimer = setTimeout(() => {
+      this.startNativeLeg();
+    }, delay);
+    this.retryTimer.unref?.();
+  }
+
+  private startChokidarLeg(): void {
+    if (this.chokidarLeg !== undefined) return;
+    const leg = new HostFsWatchHandle(this.root, { recursive: true, ignored: this.ignored });
+    leg.onDidChange((event) => {
+      if (!this.disposed) this.emitter.fire(event);
+    });
+    this.chokidarLeg = leg;
   }
 
   dispose(): void {
     if (this.disposed) return;
     this.disposed = true;
-    this.watcher.close();
+    if (this.retryTimer !== undefined) clearTimeout(this.retryTimer);
+    this.nativeWatcher?.close();
+    this.chokidarLeg?.dispose();
     this.emitter.dispose();
   }
 }
@@ -125,8 +215,7 @@ export class HostFsWatchService implements IHostFsWatchService {
 
   watch(path: string, options?: HostFsWatchOptions): IHostFsWatchHandle {
     if (useNativeRecursive(options)) {
-      const native = tryNativeRecursiveWatch(path, options);
-      if (native !== undefined) return native;
+      return new SignalWatchHandle(path, options);
     }
     return new HostFsWatchHandle(path, options);
   }
@@ -138,17 +227,6 @@ function useNativeRecursive(options: HostFsWatchOptions | undefined): boolean {
     options.recursive !== false &&
     (process.platform === 'darwin' || process.platform === 'win32')
   );
-}
-
-function tryNativeRecursiveWatch(
-  path: string,
-  options: HostFsWatchOptions | undefined,
-): IHostFsWatchHandle | undefined {
-  try {
-    return new NativeRecursiveWatchHandle(path, options);
-  } catch {
-    return undefined;
-  }
 }
 
 function mapChokidarEvent(eventName: string, absPath: string): HostFsChange | undefined {

--- a/packages/agent-core-v2/src/os/interface/hostFsWatch.ts
+++ b/packages/agent-core-v2/src/os/interface/hostFsWatch.ts
@@ -8,7 +8,9 @@
  * "something changed" signal (ignoring action/kind); the backend may then
  * pick a cheaper implementation (one native recursive watch instead of
  * per-node watchers). Signal events may use the watched root as their path
- * and report coarse action/kind values. App-scoped — one shared instance.
+ * and report coarse action/kind values. A handle's `ready` promise resolves
+ * after its backend has installed the initial subscription and rejects when
+ * initialization fails. App-scoped — one shared instance.
  */
 
 import { createDecorator, type ServiceIdentifier } from '#/_base/di/instantiation';
@@ -31,6 +33,7 @@ export interface HostFsWatchOptions {
 }
 
 export interface IHostFsWatchHandle extends IDisposable {
+  readonly ready: Promise<void>;
   readonly onDidChange: Event<HostFsChange>;
 }
 

--- a/packages/agent-core-v2/src/os/interface/hostFsWatch.ts
+++ b/packages/agent-core-v2/src/os/interface/hostFsWatch.ts
@@ -4,7 +4,12 @@
  * Defines the `IHostFsWatchService`, a thin primitive over the host OS file
  * watcher. It reports raw create/modify/delete events under an absolute path
  * and knows nothing about sessions, connections, workspaces or wire frames.
- * App-scoped — one shared instance.
+ * `HostFsWatchOptions.signal` marks callers that consume events as a mere
+ * "something changed" signal (ignoring action/kind); the backend may then
+ * pick a cheaper implementation (one native recursive watch instead of
+ * per-node watchers), and action/kind may be coarse — a deleted entry whose
+ * kind was never observed is reported as 'file'. App-scoped — one shared
+ * instance.
  */
 
 import { createDecorator, type ServiceIdentifier } from '#/_base/di/instantiation';
@@ -23,6 +28,7 @@ export interface HostFsChange {
 export interface HostFsWatchOptions {
   readonly recursive?: boolean;
   readonly ignored?: (path: string) => boolean;
+  readonly signal?: boolean;
 }
 
 export interface IHostFsWatchHandle extends IDisposable {

--- a/packages/agent-core-v2/src/os/interface/hostFsWatch.ts
+++ b/packages/agent-core-v2/src/os/interface/hostFsWatch.ts
@@ -7,9 +7,8 @@
  * `HostFsWatchOptions.signal` marks callers that consume events as a mere
  * "something changed" signal (ignoring action/kind); the backend may then
  * pick a cheaper implementation (one native recursive watch instead of
- * per-node watchers), and action/kind may be coarse — a deleted entry whose
- * kind was never observed is reported as 'file'. App-scoped — one shared
- * instance.
+ * per-node watchers). Signal events may use the watched root as their path
+ * and report coarse action/kind values. App-scoped — one shared instance.
  */
 
 import { createDecorator, type ServiceIdentifier } from '#/_base/di/instantiation';

--- a/packages/agent-core-v2/src/workspace/workspaceSkillCatalog/rootFileSkillSource.ts
+++ b/packages/agent-core-v2/src/workspace/workspaceSkillCatalog/rootFileSkillSource.ts
@@ -9,8 +9,9 @@
  * project root, watched whether or not they exist yet) through
  * `hostFsWatch` and re-fires `onDidChange` debounced, so the catalog
  * re-scans THIS source only when project skill files change. The watch
- * mirrors the scanner's own pruning — `node_modules` / dot entries, and the
- * scan depth cap plus two segments (the skill directory and its SKILL.md)
+ * mirrors the scanner's own pruning — `node_modules` / dot entries gate
+ * recursion but their direct SKILL.md stays watched, and the depth cap is
+ * the scanner's plus two segments (the skill directory and its SKILL.md)
  * — and runs in `signal` mode, so a fat skill subtree (e.g. a skill
  * bundling a runtime environment) does not cost one fs-watch fd per file.
  * Bound at Workspace scope so every session of the handler shares one scan.
@@ -98,6 +99,7 @@ export class WorkspaceRootSkillSource extends Disposable implements IWorkspaceRo
       ignored: subtreeWatchFilter(projectRoot, candidates, {
         maxDepth: MAX_SKILL_SCAN_DEPTH + 2,
         skipEntry: isSkillScanExcludedEntry,
+        keepEntryFile: 'SKILL.md',
       }),
       signal: true,
     });

--- a/packages/agent-core-v2/src/workspace/workspaceSkillCatalog/rootFileSkillSource.ts
+++ b/packages/agent-core-v2/src/workspace/workspaceSkillCatalog/rootFileSkillSource.ts
@@ -10,7 +10,7 @@
  */
 
 import { createDecorator, type ServiceIdentifier } from '#/_base/di/instantiation';
-import { Disposable } from '#/_base/di/lifecycle';
+import { Disposable, DisposableStore } from '#/_base/di/lifecycle';
 import { Emitter, type Event } from '#/_base/event';
 import { LifecycleScope, ScopeActivation, registerScopedService } from '#/_base/di/scope';
 import { TimeoutTimer } from '#/_base/utils/timer';
@@ -21,10 +21,6 @@ import {
   MERGE_ALL_AVAILABLE_SKILLS_SECTION,
   type MergeAllAvailableSkillsConfig,
 } from '#/app/skillCatalog/configSection';
-import {
-  MAX_SKILL_SCAN_DEPTH,
-  isSkillScanExcludedEntry,
-} from '#/app/skillCatalog/fileSkillDiscovery';
 import { ISkillDiscovery } from '#/app/skillCatalog/skillDiscovery';
 import { projectRoots, projectSkillRootCandidates } from '#/app/skillCatalog/skillRoots';
 import {
@@ -54,7 +50,9 @@ export class WorkspaceRootSkillSource extends Disposable implements IWorkspaceRo
   private readonly onDidChangeEmitter = this._register(new Emitter<void>());
   readonly onDidChange: Event<void> = this.onDidChangeEmitter.event;
   private readonly watchDebounce = this._register(new TimeoutTimer());
+  private readonly watchResources = this._register(new DisposableStore());
   private readonly watchReady: Promise<void>;
+  private watchSignature: string | undefined;
 
   constructor(
     @ISkillDiscovery private readonly discovery: ISkillDiscovery,
@@ -69,7 +67,7 @@ export class WorkspaceRootSkillSource extends Disposable implements IWorkspaceRo
         if (event.domain === MERGE_ALL_AVAILABLE_SKILLS_SECTION) this.onDidChangeEmitter.fire();
       }),
     );
-    this.watchReady = this.watchProjectSkillRoots();
+    this.watchReady = this.updateProjectSkillRootWatch([]);
   }
 
   async load(): Promise<SkillContribution> {
@@ -80,27 +78,33 @@ export class WorkspaceRootSkillSource extends Disposable implements IWorkspaceRo
     await this.config.ready;
     const mergeAllAvailableSkills =
       this.config.get<MergeAllAvailableSkillsConfig>(MERGE_ALL_AVAILABLE_SKILLS_SECTION) ?? true;
-    return this.discovery.discover(
+    const contribution = await this.discovery.discover(
       await projectRoots(this.workspace.cwd, { mergeAllAvailableSkills }),
     );
+    await this.updateProjectSkillRootWatch(contribution.scannedDirectories);
+    return contribution;
   }
 
-  private async watchProjectSkillRoots(): Promise<void> {
+  private async updateProjectSkillRootWatch(
+    scannedDirectories: readonly string[],
+  ): Promise<void> {
     const { projectRoot, candidates } = await projectSkillRootCandidates(this.workspace.cwd);
+    const signature = [...scannedDirectories].toSorted().join('\0');
+    if (signature === this.watchSignature) return;
     const handle = this.fsWatch.watch(projectRoot, {
       ignored: subtreeWatchFilter(projectRoot, candidates, {
-        maxDepth: MAX_SKILL_SCAN_DEPTH + 2,
-        skipEntry: isSkillScanExcludedEntry,
+        scannedDirectories,
         keepEntryFile: 'SKILL.md',
       }),
       signal: true,
     });
-    this._register(handle);
-    this._register(
-      handle.onDidChange(() => {
-        this.watchDebounce.cancelAndSet(() => this.onDidChangeEmitter.fire(), WATCH_DEBOUNCE_MS);
-      }),
-    );
+    const subscription = handle.onDidChange(() => {
+      this.watchDebounce.cancelAndSet(() => this.onDidChangeEmitter.fire(), WATCH_DEBOUNCE_MS);
+    });
+    this.watchResources.clear();
+    this.watchResources.add(handle);
+    this.watchResources.add(subscription);
+    this.watchSignature = signature;
   }
 }
 

--- a/packages/agent-core-v2/src/workspace/workspaceSkillCatalog/rootFileSkillSource.ts
+++ b/packages/agent-core-v2/src/workspace/workspaceSkillCatalog/rootFileSkillSource.ts
@@ -8,8 +8,12 @@
  * skill-root candidates (`.kimi-code/skills`, `.agents/skills` under the
  * project root, watched whether or not they exist yet) through
  * `hostFsWatch` and re-fires `onDidChange` debounced, so the catalog
- * re-scans THIS source only when project skill files change. Bound at
- * Workspace scope so every session of the handler shares one scan.
+ * re-scans THIS source only when project skill files change. The watch
+ * mirrors the scanner's own pruning — `node_modules` / dot entries, and the
+ * scan depth cap plus two segments (the skill directory and its SKILL.md)
+ * — and runs in `signal` mode, so a fat skill subtree (e.g. a skill
+ * bundling a runtime environment) does not cost one fs-watch fd per file.
+ * Bound at Workspace scope so every session of the handler shares one scan.
  */
 
 import { createDecorator, type ServiceIdentifier } from '#/_base/di/instantiation';
@@ -24,6 +28,10 @@ import {
   MERGE_ALL_AVAILABLE_SKILLS_SECTION,
   type MergeAllAvailableSkillsConfig,
 } from '#/app/skillCatalog/configSection';
+import {
+  MAX_SKILL_SCAN_DEPTH,
+  isSkillScanExcludedEntry,
+} from '#/app/skillCatalog/fileSkillDiscovery';
 import { ISkillDiscovery } from '#/app/skillCatalog/skillDiscovery';
 import { projectRoots, projectSkillRootCandidates } from '#/app/skillCatalog/skillRoots';
 import {
@@ -87,7 +95,11 @@ export class WorkspaceRootSkillSource extends Disposable implements IWorkspaceRo
   private async watchProjectSkillRoots(): Promise<void> {
     const { projectRoot, candidates } = await projectSkillRootCandidates(this.workspace.cwd);
     const handle = this.fsWatch.watch(projectRoot, {
-      ignored: subtreeWatchFilter(projectRoot, candidates),
+      ignored: subtreeWatchFilter(projectRoot, candidates, {
+        maxDepth: MAX_SKILL_SCAN_DEPTH + 2,
+        skipEntry: isSkillScanExcludedEntry,
+      }),
+      signal: true,
     });
     this._register(handle);
     this._register(

--- a/packages/agent-core-v2/src/workspace/workspaceSkillCatalog/rootFileSkillSource.ts
+++ b/packages/agent-core-v2/src/workspace/workspaceSkillCatalog/rootFileSkillSource.ts
@@ -52,6 +52,7 @@ export class WorkspaceRootSkillSource extends Disposable implements IWorkspaceRo
   private readonly watchDebounce = this._register(new TimeoutTimer());
   private readonly watchResources = this._register(new DisposableStore());
   private readonly watchReady: Promise<void>;
+  private activeWatchResources: DisposableStore | undefined;
   private watchSignature: string | undefined;
 
   constructor(
@@ -67,7 +68,7 @@ export class WorkspaceRootSkillSource extends Disposable implements IWorkspaceRo
         if (event.domain === MERGE_ALL_AVAILABLE_SKILLS_SECTION) this.onDidChangeEmitter.fire();
       }),
     );
-    this.watchReady = this.updateProjectSkillRootWatch([]);
+    this.watchReady = this.updateProjectSkillRootWatch([]).then(() => undefined);
   }
 
   async load(): Promise<SkillContribution> {
@@ -78,19 +79,24 @@ export class WorkspaceRootSkillSource extends Disposable implements IWorkspaceRo
     await this.config.ready;
     const mergeAllAvailableSkills =
       this.config.get<MergeAllAvailableSkillsConfig>(MERGE_ALL_AVAILABLE_SKILLS_SECTION) ?? true;
-    const contribution = await this.discovery.discover(
-      await projectRoots(this.workspace.cwd, { mergeAllAvailableSkills }),
-    );
-    await this.updateProjectSkillRootWatch(contribution.scannedDirectories);
+    const discover = async () =>
+      this.discovery.discover(
+        await projectRoots(this.workspace.cwd, { mergeAllAvailableSkills }),
+      );
+    let contribution = await discover();
+    while (await this.updateProjectSkillRootWatch(contribution.scannedDirectories)) {
+      contribution = await discover();
+    }
     return contribution;
   }
 
   private async updateProjectSkillRootWatch(
     scannedDirectories: readonly string[],
-  ): Promise<void> {
+  ): Promise<boolean> {
     const { projectRoot, candidates } = await projectSkillRootCandidates(this.workspace.cwd);
     const signature = [...scannedDirectories].toSorted().join('\0');
-    if (signature === this.watchSignature) return;
+    if (signature === this.watchSignature) return false;
+    const resources = this.watchResources.add(new DisposableStore());
     const handle = this.fsWatch.watch(projectRoot, {
       ignored: subtreeWatchFilter(projectRoot, candidates, {
         scannedDirectories,
@@ -98,13 +104,24 @@ export class WorkspaceRootSkillSource extends Disposable implements IWorkspaceRo
       }),
       signal: true,
     });
-    const subscription = handle.onDidChange(() => {
-      this.watchDebounce.cancelAndSet(() => this.onDidChangeEmitter.fire(), WATCH_DEBOUNCE_MS);
-    });
-    this.watchResources.clear();
-    this.watchResources.add(handle);
-    this.watchResources.add(subscription);
+    resources.add(handle);
+    resources.add(
+      handle.onDidChange(() => {
+        this.watchDebounce.cancelAndSet(() => this.onDidChangeEmitter.fire(), WATCH_DEBOUNCE_MS);
+      }),
+    );
+    try {
+      await handle.ready;
+    } catch (error) {
+      this.watchResources.delete(resources);
+      throw error;
+    }
+    if (this.watchResources.isDisposed) return false;
+    const previous = this.activeWatchResources;
+    this.activeWatchResources = resources;
     this.watchSignature = signature;
+    if (previous !== undefined) this.watchResources.delete(previous);
+    return true;
   }
 }
 

--- a/packages/agent-core-v2/src/workspace/workspaceSkillCatalog/rootFileSkillSource.ts
+++ b/packages/agent-core-v2/src/workspace/workspaceSkillCatalog/rootFileSkillSource.ts
@@ -4,17 +4,9 @@
  *
  * Discovers project skills from the handler's workspace root
  * (`workspaceContext.cwd`) through `ISkillDiscovery`, contributing them at
- * priority 30 (above user / extra / plugin / builtin). Watches the project
- * skill-root candidates (`.kimi-code/skills`, `.agents/skills` under the
- * project root, watched whether or not they exist yet) through
- * `hostFsWatch` and re-fires `onDidChange` debounced, so the catalog
- * re-scans THIS source only when project skill files change. The watch
- * mirrors the scanner's own pruning — `node_modules` / dot entries gate
- * recursion but their direct SKILL.md stays watched, and the depth cap is
- * the scanner's plus two segments (the skill directory and its SKILL.md)
- * — and runs in `signal` mode, so a fat skill subtree (e.g. a skill
- * bundling a runtime environment) does not cost one fs-watch fd per file.
- * Bound at Workspace scope so every session of the handler shares one scan.
+ * priority 30. Watches project skill-root candidates through `hostFsWatch`
+ * and emits debounced invalidations for source reloads. Bound at Workspace
+ * scope so every session of the handler shares one scan.
  */
 
 import { createDecorator, type ServiceIdentifier } from '#/_base/di/instantiation';

--- a/packages/agent-core-v2/test/_base/utils/paths.test.ts
+++ b/packages/agent-core-v2/test/_base/utils/paths.test.ts
@@ -1,0 +1,43 @@
+/**
+ * `_base/utils/paths` — unit tests for `subtreeWatchFilter`.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import { subtreeWatchFilter } from '#/_base/utils/paths';
+
+describe('subtreeWatchFilter', () => {
+  const root = '/repo';
+  const candidates = ['/repo/.kimi-code/skills', '/repo/.agents/skills'];
+
+  it('keeps the root, candidate ancestors and candidate subtrees watched', () => {
+    const ignored = subtreeWatchFilter(root, candidates);
+    expect(ignored('/repo')).toBe(false);
+    expect(ignored('/repo/.agents')).toBe(false);
+    expect(ignored('/repo/.agents/skills')).toBe(false);
+    expect(ignored('/repo/.agents/skills/demo/SKILL.md')).toBe(false);
+    expect(ignored('/repo/src')).toBe(true);
+    expect(ignored('/repo/src/index.ts')).toBe(true);
+  });
+
+  it('prunes skipped entries and over-depth paths below candidates', () => {
+    const ignored = subtreeWatchFilter(root, candidates, {
+      maxDepth: 3,
+      skipEntry: (name) => name === 'node_modules' || name.startsWith('.'),
+    });
+    expect(ignored('/repo/.agents/skills/demo/node_modules')).toBe(true);
+    expect(ignored('/repo/.agents/skills/demo/node_modules/pkg/x.js')).toBe(true);
+    expect(ignored('/repo/.agents/skills/demo/.venv/bin/python')).toBe(true);
+    expect(ignored('/repo/.agents/skills/demo/scripts/run.sh')).toBe(false);
+    expect(ignored('/repo/.agents/skills/a/b/c/d/e/f/SKILL.md')).toBe(true);
+  });
+
+  it('never prunes the candidate ancestor chain itself', () => {
+    const ignored = subtreeWatchFilter(root, candidates, {
+      skipEntry: (name) => name.startsWith('.'),
+    });
+    expect(ignored('/repo/.agents')).toBe(false);
+    expect(ignored('/repo/.agents/skills')).toBe(false);
+    expect(ignored('/repo/.agents/skills/demo')).toBe(false);
+  });
+});

--- a/packages/agent-core-v2/test/_base/utils/paths.test.ts
+++ b/packages/agent-core-v2/test/_base/utils/paths.test.ts
@@ -69,4 +69,39 @@ describe('subtree watch filtering', () => {
     expect(ignored('/repo/.agents/skills')).toBe(false);
     expect(ignored('/repo/.agents/skills/demo')).toBe(false);
   });
+
+  it('keeps direct probes but prunes payload below a terminal bundle', () => {
+    const ignored = subtreeWatchFilter(root, candidates, {
+      scannedDirectories: ['/repo/.agents/skills'],
+      keepEntryFile: 'SKILL.md',
+    });
+    expect(ignored('/repo/.agents/skills/demo')).toBe(false);
+    expect(ignored('/repo/.agents/skills/demo/SKILL.md')).toBe(false);
+    expect(ignored('/repo/.agents/skills/demo/runtime')).toBe(true);
+    expect(ignored('/repo/.agents/skills/demo/runtime/0.py')).toBe(true);
+    expect(ignored('/repo/.agents/skills/.flat.md')).toBe(false);
+  });
+
+  it('keeps direct bundle probes when the candidate root has not been scanned yet', () => {
+    const ignored = subtreeWatchFilter(root, candidates, {
+      scannedDirectories: [],
+      keepEntryFile: 'SKILL.md',
+    });
+    expect(ignored('/repo/.agents/skills/new-skill')).toBe(false);
+    expect(ignored('/repo/.agents/skills/new-skill/SKILL.md')).toBe(false);
+    expect(ignored('/repo/.agents/skills/new-skill/runtime')).toBe(true);
+  });
+
+  it('keeps direct sub-skill probes below a directory the scanner traversed', () => {
+    const ignored = subtreeWatchFilter(root, candidates, {
+      scannedDirectories: [
+        '/repo/.agents/skills',
+        '/repo/.agents/skills/parent',
+      ],
+      keepEntryFile: 'SKILL.md',
+    });
+    expect(ignored('/repo/.agents/skills/parent/child')).toBe(false);
+    expect(ignored('/repo/.agents/skills/parent/child/SKILL.md')).toBe(false);
+    expect(ignored('/repo/.agents/skills/parent/child/runtime')).toBe(true);
+  });
 });

--- a/packages/agent-core-v2/test/_base/utils/paths.test.ts
+++ b/packages/agent-core-v2/test/_base/utils/paths.test.ts
@@ -20,16 +20,31 @@ describe('subtreeWatchFilter', () => {
     expect(ignored('/repo/src/index.ts')).toBe(true);
   });
 
-  it('prunes skipped entries and over-depth paths below candidates', () => {
+  it('prunes what an excluded entry hides from the scanner, keeps what it still probes', () => {
     const ignored = subtreeWatchFilter(root, candidates, {
       maxDepth: 3,
       skipEntry: (name) => name === 'node_modules' || name.startsWith('.'),
+      keepEntryFile: 'SKILL.md',
     });
-    expect(ignored('/repo/.agents/skills/demo/node_modules')).toBe(true);
+    expect(ignored('/repo/.agents/skills/demo/node_modules')).toBe(false);
+    expect(ignored('/repo/.agents/skills/demo/node_modules/SKILL.md')).toBe(false);
+    expect(ignored('/repo/.agents/skills/demo/.hidden')).toBe(false);
+    expect(ignored('/repo/.agents/skills/demo/.hidden/SKILL.md')).toBe(false);
+    expect(ignored('/repo/.agents/skills/.flat.md')).toBe(false);
+    expect(ignored('/repo/.agents/skills/demo/node_modules/pkg')).toBe(true);
     expect(ignored('/repo/.agents/skills/demo/node_modules/pkg/x.js')).toBe(true);
     expect(ignored('/repo/.agents/skills/demo/.venv/bin/python')).toBe(true);
     expect(ignored('/repo/.agents/skills/demo/scripts/run.sh')).toBe(false);
     expect(ignored('/repo/.agents/skills/a/b/c/d/e/f/SKILL.md')).toBe(true);
+  });
+
+  it('prunes an excluded entry beyond itself when no keepEntryFile is set', () => {
+    const ignored = subtreeWatchFilter(root, candidates, {
+      skipEntry: (name) => name === 'node_modules',
+    });
+    expect(ignored('/repo/.agents/skills/demo/node_modules')).toBe(false);
+    expect(ignored('/repo/.agents/skills/demo/node_modules/SKILL.md')).toBe(true);
+    expect(ignored('/repo/.agents/skills/demo/node_modules/pkg')).toBe(true);
   });
 
   it('never prunes the candidate ancestor chain itself', () => {

--- a/packages/agent-core-v2/test/_base/utils/paths.test.ts
+++ b/packages/agent-core-v2/test/_base/utils/paths.test.ts
@@ -1,12 +1,16 @@
 /**
- * `_base/utils/paths` — unit tests for `subtreeWatchFilter`.
+ * Scenario: recursive watches constrained to selected candidate subtrees.
+ * Responsibilities: candidate ancestry, scan-depth bounds, and excluded-entry
+ * probing. Wiring: pure path predicates with no external collaborators.
+ * Run: `pnpm --filter @moonshot-ai/agent-core-v2 exec vitest run
+ * test/_base/utils/paths.test.ts`.
  */
 
 import { describe, expect, it } from 'vitest';
 
 import { subtreeWatchFilter } from '#/_base/utils/paths';
 
-describe('subtreeWatchFilter', () => {
+describe('subtree watch filtering', () => {
   const root = '/repo';
   const candidates = ['/repo/.kimi-code/skills', '/repo/.agents/skills'];
 
@@ -45,6 +49,16 @@ describe('subtreeWatchFilter', () => {
     expect(ignored('/repo/.agents/skills/demo/node_modules')).toBe(false);
     expect(ignored('/repo/.agents/skills/demo/node_modules/SKILL.md')).toBe(true);
     expect(ignored('/repo/.agents/skills/demo/node_modules/pkg')).toBe(true);
+  });
+
+  it('applies max depth before excluded-entry exceptions', () => {
+    const ignored = subtreeWatchFilter(root, candidates, {
+      maxDepth: 3,
+      skipEntry: (name) => name === 'node_modules',
+      keepEntryFile: 'SKILL.md',
+    });
+    expect(ignored('/repo/.agents/skills/demo/a/b/node_modules')).toBe(true);
+    expect(ignored('/repo/.agents/skills/demo/a/b/node_modules/SKILL.md')).toBe(true);
   });
 
   it('never prunes the candidate ancestor chain itself', () => {

--- a/packages/agent-core-v2/test/app/plugin/manager-consumption.test.ts
+++ b/packages/agent-core-v2/test/app/plugin/manager-consumption.test.ts
@@ -251,6 +251,7 @@ describe('PluginManager consumption plane', () => {
         skills: [stubSkill('provided')],
         skipped: [],
         scannedRoots: [],
+        scannedDirectories: [],
       }),
     });
     await manager.load();

--- a/packages/agent-core-v2/test/app/plugin/pluginService.test.ts
+++ b/packages/agent-core-v2/test/app/plugin/pluginService.test.ts
@@ -58,7 +58,12 @@ function makeHost(
     stubPair(IProviderService, providers),
     stubPair(ISkillDiscovery, {
       _serviceBrand: undefined,
-      discover: async () => ({ skills: [], skipped: [], scannedRoots: [] }),
+      discover: async () => ({
+        skills: [],
+        skipped: [],
+        scannedRoots: [],
+        scannedDirectories: [],
+      }),
     } satisfies ISkillDiscovery),
   ]);
 }

--- a/packages/agent-core-v2/test/app/skillCatalog/fileSkillDiscovery.test.ts
+++ b/packages/agent-core-v2/test/app/skillCatalog/fileSkillDiscovery.test.ts
@@ -198,6 +198,23 @@ describe('FileSkillDiscovery', () => {
     expect(result.skills.find((s) => s.name === 'outer.child')?.metadata.isSubSkill).toBe(true);
   });
 
+  it('reports only directories the scanner actually traverses', async () => {
+    await writeSkill('skills/terminal/SKILL.md', 'name: terminal\ndescription: terminal');
+    await mkdir(join(root, 'skills', 'terminal', 'runtime', 'nested'), { recursive: true });
+    await writeSkill(
+      'skills/parent/SKILL.md',
+      'name: parent\ndescription: parent\nhas-sub-skill: true',
+    );
+    await writeSkill('skills/parent/child/SKILL.md', 'name: child\ndescription: child');
+
+    const result = await discover([skillRoot('skills')]);
+
+    expect(result.scannedDirectories).toEqual([
+      join(root, 'skills'),
+      join(root, 'skills', 'parent'),
+    ]);
+  });
+
   it('ignores node_modules and dot directories while walking', async () => {
     await writeSkill(
       'skills/node_modules/hidden/SKILL.md',

--- a/packages/agent-core-v2/test/os/backends/node-local/hostFsWatchService.test.ts
+++ b/packages/agent-core-v2/test/os/backends/node-local/hostFsWatchService.test.ts
@@ -140,7 +140,7 @@ describe('host filesystem change notifications', () => {
     const svc = new HostFsWatchService();
     handle = svc.watch(root, { recursive });
     handle.onDidChange((e) => events.push(e));
-    await wait(200);
+    await handle.ready;
     return events;
   }
 
@@ -149,7 +149,7 @@ describe('host filesystem change notifications', () => {
     const svc = new HostFsWatchService();
     handle = svc.watch(root, { recursive: true, signal: true, ignored });
     handle.onDidChange((e) => events.push(e));
-    await wait(200);
+    await handle.ready;
     return events;
   }
 

--- a/packages/agent-core-v2/test/os/backends/node-local/hostFsWatchService.test.ts
+++ b/packages/agent-core-v2/test/os/backends/node-local/hostFsWatchService.test.ts
@@ -1,8 +1,10 @@
 /**
- * `hostFsWatch` domain — integration test against the real `chokidar`
- * watcher on a temporary directory.
+ * `hostFsWatch` domain — integration tests against the real watcher
+ * backends (chokidar, plus the native recursive watch used by `signal`
+ * mode on darwin/win32) on a temporary directory.
  */
 
+import { readdirSync } from 'node:fs';
 import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -28,6 +30,15 @@ describe('HostFsWatchService', () => {
     const events: HostFsChange[] = [];
     const svc = new HostFsWatchService();
     handle = svc.watch(root, { recursive });
+    handle.onDidChange((e) => events.push(e));
+    await wait(200);
+    return events;
+  }
+
+  async function startSignal(ignored?: (path: string) => boolean): Promise<HostFsChange[]> {
+    const events: HostFsChange[] = [];
+    const svc = new HostFsWatchService();
+    handle = svc.watch(root, { recursive: true, signal: true, ignored });
     handle.onDidChange((e) => events.push(e));
     await wait(200);
     return events;
@@ -86,4 +97,54 @@ describe('HostFsWatchService', () => {
 
     expect(events).toHaveLength(0);
   });
+
+  it('signal mode reports create / modify / delete for a file', async () => {
+    root = await mkdtemp(join(tmpdir(), 'hostfswatch-signal-'));
+    const events = await startSignal();
+
+    const file = join(root, 'a.txt');
+    await writeFile(file, 'v1');
+    await wait(500);
+    await writeFile(file, 'v2');
+    await wait(500);
+    await rm(file);
+    await wait(500);
+
+    const actions = events.filter((e) => e.path === file).map((e) => e.action);
+    expect(actions).toContain('created');
+    expect(actions).toContain('modified');
+    expect(actions).toContain('deleted');
+  });
+
+  it('signal mode honors the ignored predicate', async () => {
+    root = await mkdtemp(join(tmpdir(), 'hostfswatch-signal-'));
+    const events = await startSignal((p) => p.includes('node_modules'));
+
+    await mkdir(join(root, 'node_modules', 'pkg'), { recursive: true });
+    await writeFile(join(root, 'node_modules', 'pkg', 'index.js'), 'x');
+    await writeFile(join(root, 'visible.txt'), 'x');
+    await wait(500);
+
+    expect(events.some((e) => e.path.includes('node_modules'))).toBe(false);
+    expect(events.some((e) => e.path === join(root, 'visible.txt'))).toBe(true);
+  });
+
+  it.skipIf(process.platform !== 'darwin')(
+    'signal mode keeps the fd footprint bounded on a fat subtree',
+    async () => {
+      root = await mkdtemp(join(tmpdir(), 'hostfswatch-fat-'));
+      const fat = join(root, 'fat');
+      await mkdir(fat, { recursive: true });
+      for (let i = 0; i < 1200; i++) {
+        await writeFile(join(fat, `f${i}.txt`), 'x');
+      }
+
+      const fdsBefore = readdirSync('/dev/fd').length;
+      await startSignal();
+      const fdsAfter = readdirSync('/dev/fd').length;
+
+      expect(fdsAfter - fdsBefore).toBeLessThan(50);
+    },
+    30000,
+  );
 });

--- a/packages/agent-core-v2/test/os/backends/node-local/hostFsWatchService.test.ts
+++ b/packages/agent-core-v2/test/os/backends/node-local/hostFsWatchService.test.ts
@@ -1,117 +1,138 @@
 /**
- * `hostFsWatch` domain — integration tests against the real watcher
- * backends (chokidar, plus the native recursive watch used by `signal`
- * mode on darwin/win32) on a temporary directory, and platform-independent
- * unit tests for the native event-mapping logic (`NativeSignalMapper`,
- * stat injected).
+ * Scenario: precise host watches and coarse native signal watches.
+ * Responsibilities: event delivery, filtering, recovery, disposal, and the
+ * macOS descriptor bound. Wiring: real temporary files for integration and an
+ * injected native-watch boundary with a manual retry scheduler for recovery.
+ * Run: `pnpm --filter @moonshot-ai/agent-core-v2 exec vitest run
+ * test/os/backends/node-local/hostFsWatchService.test.ts`.
  */
 
 import { readdirSync } from 'node:fs';
 import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
-import { basename, join } from 'node:path';
+import { join } from 'node:path';
 
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 import {
-  HostFsWatchService,
-  NativeSignalMapper,
-} from '#/os/backends/node-local/hostFsWatchService';
+  resetUnexpectedErrorHandler,
+  setUnexpectedErrorHandler,
+} from '#/_base/errors/unexpectedError';
+import { HostFsWatchService } from '#/os/backends/node-local/hostFsWatchService';
 import type {
   HostFsChange,
-  HostFsChangeKind,
   IHostFsWatchHandle,
+  IHostFsWatchService,
 } from '#/os/interface/hostFsWatch';
 
 const wait = (ms: number): Promise<void> => new Promise((r) => setTimeout(r, ms));
 
-describe('NativeSignalMapper', () => {
-  const root = join(tmpdir(), 'mapper-root');
-  const noIgnore = (): boolean => false;
+type HostFsWatchRuntime = NonNullable<ConstructorParameters<typeof HostFsWatchService>[0]>;
 
-  function mapperWith(kinds: Record<string, HostFsChangeKind | undefined>): NativeSignalMapper {
-    return new NativeSignalMapper({ kindOf: (p) => kinds[p] });
+class TestNativeWatcher {
+  private errorListener: ((error: NodeJS.ErrnoException) => void) | undefined;
+  closed = false;
+
+  on(_event: 'error', listener: (error: NodeJS.ErrnoException) => void): this {
+    this.errorListener = listener;
+    return this;
   }
 
-  it('maps a create → modify → delete sequence', () => {
-    const file = join(root, 'a.txt');
-    const kinds: Record<string, HostFsChangeKind | undefined> = { [file]: 'file' };
-    const mapper = mapperWith(kinds);
-    expect(mapper.map(root, 'rename', 'a.txt', noIgnore)).toEqual({
-      path: file,
-      action: 'created',
-      kind: 'file',
-    });
-    expect(mapper.map(root, 'rename', 'a.txt', noIgnore)).toEqual({
-      path: file,
-      action: 'modified',
-      kind: 'file',
-    });
-    delete kinds[file];
-    expect(mapper.map(root, 'rename', 'a.txt', noIgnore)).toEqual({
-      path: file,
-      action: 'deleted',
-      kind: 'file',
-    });
-  });
+  close(): void {
+    this.closed = true;
+  }
 
-  it('reports the directory kind for renamed directories', () => {
-    const dir = join(root, 'd');
-    const mapper = mapperWith({ [dir]: 'directory' });
-    expect(mapper.map(root, 'rename', 'd', noIgnore)).toEqual({
-      path: dir,
-      action: 'created',
-      kind: 'directory',
-    });
-  });
+  fail(code = 'EIO'): void {
+    this.errorListener?.(Object.assign(new Error('native watch failed'), { code }));
+  }
+}
 
-  it('maps change events to modified without consulting stat', () => {
-    const file = join(root, 'a.txt');
-    const mapper = mapperWith({});
-    expect(mapper.map(root, 'change', 'a.txt', noIgnore)).toEqual({
-      path: file,
-      action: 'modified',
-      kind: 'file',
-    });
-  });
+interface TestNativeAttempt {
+  readonly watcher: TestNativeWatcher;
+  emit(filename: string | null): void;
+}
 
-  it('treats null, empty and root-basename filenames as root events', () => {
-    const mapper = mapperWith({ [root]: 'directory' });
-    expect(mapper.map(root, 'rename', null, noIgnore)?.path).toBe(root);
-    expect(mapper.map(root, 'rename', '', noIgnore)?.path).toBe(root);
-    expect(mapper.map(root, 'rename', basename(root), noIgnore)?.path).toBe(root);
-  });
+interface TestRetry {
+  readonly delayMs: number;
+  readonly active: boolean;
+  run(): void;
+}
 
-  it('keeps a root-basename filename as a child when that child exists', () => {
-    const child = join(root, basename(root));
-    const mapper = mapperWith({ [child]: 'file' });
-    expect(mapper.map(root, 'rename', basename(root), noIgnore)?.path).toBe(child);
-  });
+function signalRig(options?: { readonly synchronousFailures?: number }): {
+  readonly service: IHostFsWatchService;
+  readonly attempts: TestNativeAttempt[];
+  readonly retries: TestRetry[];
+  attempt(index: number): TestNativeAttempt;
+  retry(index: number): TestRetry;
+} {
+  const attempts: TestNativeAttempt[] = [];
+  const retries: TestRetry[] = [];
+  let synchronousFailures = options?.synchronousFailures ?? 0;
+  const runtime: HostFsWatchRuntime = {
+    platform: 'darwin',
+    watchNative: (_root, listener) => {
+      if (synchronousFailures > 0) {
+        synchronousFailures -= 1;
+        throw Object.assign(new Error('native watch creation failed'), { code: 'EIO' });
+      }
+      const watcher = new TestNativeWatcher();
+      attempts.push({
+        watcher,
+        emit: (filename) => {
+          listener('rename', filename);
+        },
+      });
+      return watcher;
+    },
+    scheduleRetry: (callback, delayMs) => {
+      let active = true;
+      retries.push({
+        delayMs,
+        get active() {
+          return active;
+        },
+        run: () => {
+          if (!active) return;
+          active = false;
+          callback();
+        },
+      });
+      return {
+        dispose: () => {
+          active = false;
+        },
+      };
+    },
+  };
+  return {
+    service: new HostFsWatchService(runtime),
+    attempts,
+    retries,
+    attempt: (index) => requiredAt(attempts, index),
+    retry: (index) => requiredAt(retries, index),
+  };
+}
 
-  it('keeps absolute filenames inside the root and clamps outside ones to a root event', () => {
-    const file = join(root, 'a.txt');
-    const mapper = mapperWith({ [file]: 'file' });
-    expect(mapper.map(root, 'rename', file, noIgnore)?.path).toBe(file);
-    expect(mapper.map(root, 'rename', join(tmpdir(), 'elsewhere'), noIgnore)?.path).toBe(root);
-  });
+function requiredAt<T>(values: readonly T[], index: number): T {
+  const value = values[index];
+  if (value === undefined) throw new Error(`missing test value at index ${index}`);
+  return value;
+}
 
-  it('drops events whose path is ignored', () => {
-    const file = join(root, 'node_modules', 'x.js');
-    const mapper = mapperWith({ [file]: 'file' });
-    expect(
-      mapper.map(root, 'rename', join('node_modules', 'x.js'), (p) => p.includes('node_modules')),
-    ).toBeUndefined();
-  });
-});
-
-describe('HostFsWatchService', () => {
+describe('host filesystem change notifications', () => {
   let root: string;
   let handle: IHostFsWatchHandle | undefined;
+
+  beforeEach(() => {
+    setUnexpectedErrorHandler(() => undefined);
+  });
 
   afterEach(async () => {
     handle?.dispose();
     handle = undefined;
     if (root) await rm(root, { recursive: true, force: true });
+    root = '';
+    resetUnexpectedErrorHandler();
   });
 
   async function start(recursive = true): Promise<HostFsChange[]> {
@@ -131,6 +152,97 @@ describe('HostFsWatchService', () => {
     await wait(200);
     return events;
   }
+
+  it('emits a coarse root invalidation when a native signal path changes', () => {
+    const rig = signalRig();
+    const events: HostFsChange[] = [];
+    handle = rig.service.watch('/repo', { signal: true });
+    handle.onDidChange((event) => events.push(event));
+
+    rig.attempt(0).emit('skills/demo/SKILL.md');
+
+    expect(events).toEqual([{ path: '/repo', action: 'modified', kind: 'directory' }]);
+  });
+
+  it('does not invalidate when a native signal path is ignored', () => {
+    const rig = signalRig();
+    const events: HostFsChange[] = [];
+    handle = rig.service.watch('/repo', {
+      signal: true,
+      ignored: (path) => path.includes('node_modules'),
+    });
+    handle.onDidChange((event) => events.push(event));
+
+    rig.attempt(0).emit('node_modules/pkg/index.js');
+
+    expect(events).toEqual([]);
+  });
+
+  it('increases the retry delay after consecutive native failures', () => {
+    const rig = signalRig();
+    handle = rig.service.watch('/repo', { signal: true });
+
+    rig.attempt(0).watcher.fail();
+    rig.retry(0).run();
+    rig.attempt(1).watcher.fail();
+    rig.retry(1).run();
+    rig.attempt(2).watcher.fail();
+
+    expect(rig.retries.map((retry) => retry.delayMs)).toEqual([1000, 2000, 4000]);
+  });
+
+  it('invalidates again after a native watch is rearmed', () => {
+    const rig = signalRig();
+    const events: HostFsChange[] = [];
+    handle = rig.service.watch('/repo', { signal: true });
+    handle.onDidChange((event) => events.push(event));
+
+    rig.attempt(0).watcher.fail();
+    rig.retry(0).run();
+
+    expect(events).toEqual([
+      { path: '/repo', action: 'modified', kind: 'directory' },
+      { path: '/repo', action: 'modified', kind: 'directory' },
+    ]);
+  });
+
+  it('invalidates after recovering from a synchronous native-watch creation failure', () => {
+    const rig = signalRig({ synchronousFailures: 1 });
+    const events: HostFsChange[] = [];
+    handle = rig.service.watch('/repo', { signal: true });
+    handle.onDidChange((event) => events.push(event));
+
+    rig.retry(0).run();
+
+    expect(rig.attempts).toHaveLength(1);
+    expect(events).toEqual([{ path: '/repo', action: 'modified', kind: 'directory' }]);
+  });
+
+  it('resets the retry delay after the recovered native watch emits an event', () => {
+    const rig = signalRig();
+    handle = rig.service.watch('/repo', { signal: true });
+
+    rig.attempt(0).watcher.fail();
+    rig.retry(0).run();
+    rig.attempt(1).emit('skills/demo/SKILL.md');
+    rig.attempt(1).watcher.fail();
+
+    expect(rig.retries.map((retry) => retry.delayMs)).toEqual([1000, 1000]);
+  });
+
+  it('cancels a pending native retry when the watch handle is disposed', () => {
+    const rig = signalRig();
+    handle = rig.service.watch('/repo', { signal: true });
+    rig.attempt(0).watcher.fail();
+
+    handle.dispose();
+    handle = undefined;
+    rig.retry(0).run();
+
+    expect(rig.retry(0).active).toBe(false);
+    expect(rig.attempt(0).watcher.closed).toBe(true);
+    expect(rig.attempts).toHaveLength(1);
+  });
 
   it('reports create / modify / delete for a file', async () => {
     root = await mkdtemp(join(tmpdir(), 'hostfswatch-'));
@@ -184,37 +296,6 @@ describe('HostFsWatchService', () => {
     await wait(300);
 
     expect(events).toHaveLength(0);
-  });
-
-  it('signal mode reports create / modify / delete for a file', async () => {
-    root = await mkdtemp(join(tmpdir(), 'hostfswatch-signal-'));
-    const events = await startSignal();
-
-    const file = join(root, 'a.txt');
-    await writeFile(file, 'v1');
-    await wait(500);
-    await writeFile(file, 'v2');
-    await wait(500);
-    await rm(file);
-    await wait(500);
-
-    const actions = events.filter((e) => e.path === file).map((e) => e.action);
-    expect(actions).toContain('created');
-    expect(actions).toContain('modified');
-    expect(actions).toContain('deleted');
-  });
-
-  it('signal mode honors the ignored predicate', async () => {
-    root = await mkdtemp(join(tmpdir(), 'hostfswatch-signal-'));
-    const events = await startSignal((p) => p.includes('node_modules'));
-
-    await mkdir(join(root, 'node_modules', 'pkg'), { recursive: true });
-    await writeFile(join(root, 'node_modules', 'pkg', 'index.js'), 'x');
-    await writeFile(join(root, 'visible.txt'), 'x');
-    await wait(500);
-
-    expect(events.some((e) => e.path.includes('node_modules'))).toBe(false);
-    expect(events.some((e) => e.path === join(root, 'visible.txt'))).toBe(true);
   });
 
   it.skipIf(process.platform !== 'darwin')(

--- a/packages/agent-core-v2/test/os/backends/node-local/hostFsWatchService.test.ts
+++ b/packages/agent-core-v2/test/os/backends/node-local/hostFsWatchService.test.ts
@@ -1,20 +1,108 @@
 /**
  * `hostFsWatch` domain — integration tests against the real watcher
  * backends (chokidar, plus the native recursive watch used by `signal`
- * mode on darwin/win32) on a temporary directory.
+ * mode on darwin/win32) on a temporary directory, and platform-independent
+ * unit tests for the native event-mapping logic (`NativeSignalMapper`,
+ * stat injected).
  */
 
 import { readdirSync } from 'node:fs';
 import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
-import { join } from 'node:path';
+import { basename, join } from 'node:path';
 
 import { afterEach, describe, expect, it } from 'vitest';
 
-import { HostFsWatchService } from '#/os/backends/node-local/hostFsWatchService';
-import type { HostFsChange, IHostFsWatchHandle } from '#/os/interface/hostFsWatch';
+import {
+  HostFsWatchService,
+  NativeSignalMapper,
+} from '#/os/backends/node-local/hostFsWatchService';
+import type {
+  HostFsChange,
+  HostFsChangeKind,
+  IHostFsWatchHandle,
+} from '#/os/interface/hostFsWatch';
 
 const wait = (ms: number): Promise<void> => new Promise((r) => setTimeout(r, ms));
+
+describe('NativeSignalMapper', () => {
+  const root = join(tmpdir(), 'mapper-root');
+  const noIgnore = (): boolean => false;
+
+  function mapperWith(kinds: Record<string, HostFsChangeKind | undefined>): NativeSignalMapper {
+    return new NativeSignalMapper({ kindOf: (p) => kinds[p] });
+  }
+
+  it('maps a create → modify → delete sequence', () => {
+    const file = join(root, 'a.txt');
+    const kinds: Record<string, HostFsChangeKind | undefined> = { [file]: 'file' };
+    const mapper = mapperWith(kinds);
+    expect(mapper.map(root, 'rename', 'a.txt', noIgnore)).toEqual({
+      path: file,
+      action: 'created',
+      kind: 'file',
+    });
+    expect(mapper.map(root, 'rename', 'a.txt', noIgnore)).toEqual({
+      path: file,
+      action: 'modified',
+      kind: 'file',
+    });
+    delete kinds[file];
+    expect(mapper.map(root, 'rename', 'a.txt', noIgnore)).toEqual({
+      path: file,
+      action: 'deleted',
+      kind: 'file',
+    });
+  });
+
+  it('reports the directory kind for renamed directories', () => {
+    const dir = join(root, 'd');
+    const mapper = mapperWith({ [dir]: 'directory' });
+    expect(mapper.map(root, 'rename', 'd', noIgnore)).toEqual({
+      path: dir,
+      action: 'created',
+      kind: 'directory',
+    });
+  });
+
+  it('maps change events to modified without consulting stat', () => {
+    const file = join(root, 'a.txt');
+    const mapper = mapperWith({});
+    expect(mapper.map(root, 'change', 'a.txt', noIgnore)).toEqual({
+      path: file,
+      action: 'modified',
+      kind: 'file',
+    });
+  });
+
+  it('treats null, empty and root-basename filenames as root events', () => {
+    const mapper = mapperWith({ [root]: 'directory' });
+    expect(mapper.map(root, 'rename', null, noIgnore)?.path).toBe(root);
+    expect(mapper.map(root, 'rename', '', noIgnore)?.path).toBe(root);
+    expect(mapper.map(root, 'rename', basename(root), noIgnore)?.path).toBe(root);
+  });
+
+  it('keeps a root-basename filename as a child when that child exists', () => {
+    const child = join(root, basename(root));
+    const mapper = mapperWith({ [child]: 'file' });
+    expect(mapper.map(root, 'rename', basename(root), noIgnore)?.path).toBe(child);
+  });
+
+  it('keeps absolute filenames inside the root and clamps outside ones to a root event', () => {
+    const file = join(root, 'a.txt');
+    const mapper = mapperWith({ [file]: 'file' });
+    expect(mapper.map(root, 'rename', file, noIgnore)?.path).toBe(file);
+    expect(mapper.map(root, 'rename', join(tmpdir(), 'elsewhere'), noIgnore)?.path).toBe(root);
+  });
+
+  it('drops events whose path is ignored', () => {
+    const file = join(root, 'node_modules', 'x.js');
+    const mapper = mapperWith({ [file]: 'file' });
+    expect(
+      mapper.map(root, 'rename', join('node_modules', 'x.js'), (p) => p.includes('node_modules')),
+    ).toBeUndefined();
+  });
+});
 
 describe('HostFsWatchService', () => {
   let root: string;

--- a/packages/agent-core-v2/test/workspace/workspaceAgentProfileLoader/agentProfileLoader.test.ts
+++ b/packages/agent-core-v2/test/workspace/workspaceAgentProfileLoader/agentProfileLoader.test.ts
@@ -113,6 +113,7 @@ function fsWatchStub(): IHostFsWatchService {
   return {
     _serviceBrand: undefined,
     watch: (): IHostFsWatchHandle => ({
+      ready: Promise.resolve(),
       onDidChange: Event.None as Event<HostFsChange>,
       dispose: () => {},
     }),

--- a/packages/agent-core-v2/test/workspace/workspaceFs/fsWatchService.test.ts
+++ b/packages/agent-core-v2/test/workspace/workspaceFs/fsWatchService.test.ts
@@ -68,6 +68,7 @@ function fakeHostFsWatch(): FakeWatch {
   let listener: ((e: HostFsChange) => void) | undefined;
   let disposedCount = 0;
   const handle: IHostFsWatchHandle = {
+    ready: Promise.resolve(),
     onDidChange: (l) => {
       listener = l;
       return { dispose: () => (listener = undefined) };

--- a/packages/agent-core-v2/test/workspace/workspaceInstructions/instructions.test.ts
+++ b/packages/agent-core-v2/test/workspace/workspaceInstructions/instructions.test.ts
@@ -73,7 +73,7 @@ describe('WorkspaceInstructionsService', () => {
           emitter = new Emitter<HostFsChange>();
           watchFires.set(path, emitter);
         }
-        return { onDidChange: emitter.event, dispose: () => {} };
+        return { ready: Promise.resolve(), onDidChange: emitter.event, dispose: () => {} };
       },
     };
   }

--- a/packages/agent-core-v2/test/workspace/workspaceMcp/initialization.test.ts
+++ b/packages/agent-core-v2/test/workspace/workspaceMcp/initialization.test.ts
@@ -91,6 +91,7 @@ describe('Workspace MCP initialization', () => {
         });
         reg.definePartialInstance(IHostFsWatchService, {
           watch: (): IHostFsWatchHandle => ({
+            ready: Promise.resolve(),
             onDidChange: Event.None as Event<HostFsChange>,
             dispose: () => {},
           }),

--- a/packages/agent-core-v2/test/workspace/workspaceMcpConfig/workspaceMcpConfig.test.ts
+++ b/packages/agent-core-v2/test/workspace/workspaceMcpConfig/workspaceMcpConfig.test.ts
@@ -91,7 +91,7 @@ describe('WorkspaceMcpConfigService', () => {
           emitter = new Emitter<HostFsChange>();
           watchFires.set(path, emitter);
         }
-        return { onDidChange: emitter.event, dispose: () => {} };
+        return { ready: Promise.resolve(), onDidChange: emitter.event, dispose: () => {} };
       },
     };
   }

--- a/packages/agent-core-v2/test/workspace/workspaceSkillCatalog/skillCatalog.test.ts
+++ b/packages/agent-core-v2/test/workspace/workspaceSkillCatalog/skillCatalog.test.ts
@@ -902,4 +902,42 @@ describe('WorkspaceSkillCatalogService', () => {
       await rm(workDir, { recursive: true, force: true });
     }
   }, 15000);
+
+  it('rescans when a skill under a dot directory appears on disk', async () => {
+    const workDir = await mkdtemp(join(tmpdir(), 'skill-watch-dot-'));
+    const host = createScopedTestHost([
+      stubPair(IBootstrapService, bootstrapStub),
+      stubPair(IConfigService, configStub()),
+      stubPair(IPluginService, pluginStub()),
+      stubPair(ILogService, stubLog()),
+      stubPair(ISkillDiscovery, new FileSkillDiscovery(stubLog())),
+      stubPair(IHostFsWatchService, new HostFsWatchService()),
+    ]);
+    const workspace = host.child(LifecycleScope.Workspace, 'w1', [
+      stubPair(IWorkspaceContext, workspaceContextStub(workDir)),
+    ]);
+
+    try {
+      const catalog = workspace.accessor.get(IWorkspaceSkillCatalog);
+      await catalog.load();
+      expect(catalog.catalog.getSkill('dot-skill')).toBeUndefined();
+
+      await mkdir(join(workDir, '.agents', 'skills', '.dot-skill'), { recursive: true });
+      await writeFile(
+        join(workDir, '.agents', 'skills', '.dot-skill', 'SKILL.md'),
+        '---\nname: dot-skill\ndescription: under dot dir\n---\nbody',
+        'utf8',
+      );
+
+      const deadline = Date.now() + 10000;
+      while (catalog.catalog.getSkill('dot-skill') === undefined) {
+        if (Date.now() > deadline) throw new Error('watch-driven refresh timed out');
+        await new Promise((resolve) => setTimeout(resolve, 100));
+      }
+      expect(catalog.catalog.getSkill('dot-skill')?.description).toBe('under dot dir');
+    } finally {
+      host.dispose();
+      await rm(workDir, { recursive: true, force: true });
+    }
+  }, 15000);
 });

--- a/packages/agent-core-v2/test/workspace/workspaceSkillCatalog/skillCatalog.test.ts
+++ b/packages/agent-core-v2/test/workspace/workspaceSkillCatalog/skillCatalog.test.ts
@@ -3,7 +3,10 @@
  *
  * Exercises the real Workspace-scoped catalog and source services with
  * filesystem or in-memory discovery boundaries, including controlled
- * concurrent refreshes and the fs-watch-driven single-source rescan.
+ * concurrent refreshes and the fs-watch-driven single-source rescan. On
+ * darwin the skill-source watch runs in native `signal` mode, which may
+ * surface coalesced ancestor-directory events, so the pruned-write case
+ * asserts unchanged catalog content there and zero rescans elsewhere.
  * Run: `pnpm --filter @moonshot-ai/agent-core-v2 exec vitest run
  * test/workspace/workspaceSkillCatalog/skillCatalog.test.ts`.
  */
@@ -830,6 +833,70 @@ describe('WorkspaceSkillCatalogService', () => {
 
       await expect(Promise.race([refreshed, timedOut])).resolves.toBe('workspace');
       expect(catalog.catalog.getSkill('watched-skill')?.description).toBe('from watch');
+    } finally {
+      host.dispose();
+      await rm(workDir, { recursive: true, force: true });
+    }
+  }, 15000);
+
+  it('ignores changes under scanner-pruned entries but still rescans on real skill changes', async () => {
+    const workDir = await mkdtemp(join(tmpdir(), 'skill-watch-pruned-'));
+    await mkdir(join(workDir, '.agents', 'skills', 'demo'), { recursive: true });
+    await writeFile(
+      join(workDir, '.agents', 'skills', 'demo', 'SKILL.md'),
+      '---\nname: demo\ndescription: v1\n---\nbody',
+      'utf8',
+    );
+    const host = createScopedTestHost([
+      stubPair(IBootstrapService, bootstrapStub),
+      stubPair(IConfigService, configStub()),
+      stubPair(IPluginService, pluginStub()),
+      stubPair(ILogService, stubLog()),
+      stubPair(ISkillDiscovery, new FileSkillDiscovery(stubLog())),
+      stubPair(IHostFsWatchService, new HostFsWatchService()),
+    ]);
+    const workspace = host.child(LifecycleScope.Workspace, 'w1', [
+      stubPair(IWorkspaceContext, workspaceContextStub(workDir)),
+    ]);
+
+    try {
+      const catalog = workspace.accessor.get(IWorkspaceSkillCatalog);
+      await catalog.load();
+      expect(catalog.catalog.getSkill('demo')?.description).toBe('v1');
+
+      const sourceIds: string[] = [];
+      const subscription = catalog.onDidChange((sourceId) => sourceIds.push(sourceId));
+
+      await mkdir(join(workDir, '.agents', 'skills', 'demo', 'node_modules', 'pkg'), {
+        recursive: true,
+      });
+      await writeFile(
+        join(workDir, '.agents', 'skills', 'demo', 'node_modules', 'pkg', 'index.js'),
+        'x',
+        'utf8',
+      );
+      await mkdir(join(workDir, '.agents', 'skills', 'demo', '.hidden'), { recursive: true });
+      await writeFile(join(workDir, '.agents', 'skills', 'demo', '.hidden', 'notes.md'), 'x', 'utf8');
+      await new Promise((resolve) => setTimeout(resolve, 1500));
+      if (process.platform === 'darwin') {
+        expect(catalog.catalog.getSkill('demo')?.description).toBe('v1');
+        expect(catalog.catalog.getSkill('pkg')).toBeUndefined();
+      } else {
+        expect(sourceIds).toEqual([]);
+      }
+
+      const refreshed = waitForEvents(catalog.onDidChange, 1);
+      const timedOut = new Promise<never>((_resolve, reject) => {
+        setTimeout(() => reject(new Error('watch-driven refresh timed out')), 10000);
+      });
+      await writeFile(
+        join(workDir, '.agents', 'skills', 'demo', 'SKILL.md'),
+        '---\nname: demo\ndescription: v2\n---\nbody',
+        'utf8',
+      );
+      await Promise.race([refreshed, timedOut]);
+      expect(catalog.catalog.getSkill('demo')?.description).toBe('v2');
+      subscription.dispose();
     } finally {
       host.dispose();
       await rm(workDir, { recursive: true, force: true });

--- a/packages/agent-core-v2/test/workspace/workspaceSkillCatalog/skillCatalog.test.ts
+++ b/packages/agent-core-v2/test/workspace/workspaceSkillCatalog/skillCatalog.test.ts
@@ -3,10 +3,7 @@
  *
  * Exercises the real Workspace-scoped catalog and source services with
  * filesystem or in-memory discovery boundaries, including controlled
- * concurrent refreshes and the fs-watch-driven single-source rescan. On
- * darwin the skill-source watch runs in native `signal` mode, which may
- * surface coalesced ancestor-directory events, so the pruned-write case
- * asserts unchanged catalog content there and zero rescans elsewhere.
+ * concurrent refreshes and fs-watch-driven single-source rescans.
  * Run: `pnpm --filter @moonshot-ai/agent-core-v2 exec vitest run
  * test/workspace/workspaceSkillCatalog/skillCatalog.test.ts`.
  */
@@ -839,70 +836,6 @@ describe('WorkspaceSkillCatalogService', () => {
     }
   }, 15000);
 
-  it('ignores changes under scanner-pruned entries but still rescans on real skill changes', async () => {
-    const workDir = await mkdtemp(join(tmpdir(), 'skill-watch-pruned-'));
-    await mkdir(join(workDir, '.agents', 'skills', 'demo'), { recursive: true });
-    await writeFile(
-      join(workDir, '.agents', 'skills', 'demo', 'SKILL.md'),
-      '---\nname: demo\ndescription: v1\n---\nbody',
-      'utf8',
-    );
-    const host = createScopedTestHost([
-      stubPair(IBootstrapService, bootstrapStub),
-      stubPair(IConfigService, configStub()),
-      stubPair(IPluginService, pluginStub()),
-      stubPair(ILogService, stubLog()),
-      stubPair(ISkillDiscovery, new FileSkillDiscovery(stubLog())),
-      stubPair(IHostFsWatchService, new HostFsWatchService()),
-    ]);
-    const workspace = host.child(LifecycleScope.Workspace, 'w1', [
-      stubPair(IWorkspaceContext, workspaceContextStub(workDir)),
-    ]);
-
-    try {
-      const catalog = workspace.accessor.get(IWorkspaceSkillCatalog);
-      await catalog.load();
-      expect(catalog.catalog.getSkill('demo')?.description).toBe('v1');
-
-      const sourceIds: string[] = [];
-      const subscription = catalog.onDidChange((sourceId) => sourceIds.push(sourceId));
-
-      await mkdir(join(workDir, '.agents', 'skills', 'demo', 'node_modules', 'pkg'), {
-        recursive: true,
-      });
-      await writeFile(
-        join(workDir, '.agents', 'skills', 'demo', 'node_modules', 'pkg', 'index.js'),
-        'x',
-        'utf8',
-      );
-      await mkdir(join(workDir, '.agents', 'skills', 'demo', '.hidden'), { recursive: true });
-      await writeFile(join(workDir, '.agents', 'skills', 'demo', '.hidden', 'notes.md'), 'x', 'utf8');
-      await new Promise((resolve) => setTimeout(resolve, 1500));
-      if (process.platform === 'darwin') {
-        expect(catalog.catalog.getSkill('demo')?.description).toBe('v1');
-        expect(catalog.catalog.getSkill('pkg')).toBeUndefined();
-      } else {
-        expect(sourceIds).toEqual([]);
-      }
-
-      const refreshed = waitForEvents(catalog.onDidChange, 1);
-      const timedOut = new Promise<never>((_resolve, reject) => {
-        setTimeout(() => reject(new Error('watch-driven refresh timed out')), 10000);
-      });
-      await writeFile(
-        join(workDir, '.agents', 'skills', 'demo', 'SKILL.md'),
-        '---\nname: demo\ndescription: v2\n---\nbody',
-        'utf8',
-      );
-      await Promise.race([refreshed, timedOut]);
-      expect(catalog.catalog.getSkill('demo')?.description).toBe('v2');
-      subscription.dispose();
-    } finally {
-      host.dispose();
-      await rm(workDir, { recursive: true, force: true });
-    }
-  }, 15000);
-
   it('rescans when a skill under a dot directory appears on disk', async () => {
     const workDir = await mkdtemp(join(tmpdir(), 'skill-watch-dot-'));
     const host = createScopedTestHost([
@@ -923,17 +856,14 @@ describe('WorkspaceSkillCatalogService', () => {
       expect(catalog.catalog.getSkill('dot-skill')).toBeUndefined();
 
       await mkdir(join(workDir, '.agents', 'skills', '.dot-skill'), { recursive: true });
+      const refreshed = waitForEvents(catalog.onDidChange, 1);
       await writeFile(
         join(workDir, '.agents', 'skills', '.dot-skill', 'SKILL.md'),
         '---\nname: dot-skill\ndescription: under dot dir\n---\nbody',
         'utf8',
       );
 
-      const deadline = Date.now() + 10000;
-      while (catalog.catalog.getSkill('dot-skill') === undefined) {
-        if (Date.now() > deadline) throw new Error('watch-driven refresh timed out');
-        await new Promise((resolve) => setTimeout(resolve, 100));
-      }
+      await refreshed;
       expect(catalog.catalog.getSkill('dot-skill')?.description).toBe('under dot dir');
     } finally {
       host.dispose();

--- a/packages/agent-core-v2/test/workspace/workspaceSkillCatalog/skillCatalog.test.ts
+++ b/packages/agent-core-v2/test/workspace/workspaceSkillCatalog/skillCatalog.test.ts
@@ -162,6 +162,7 @@ function fsWatchStub(
     watch: (_path, options): IHostFsWatchHandle => {
       onWatch?.(options);
       return {
+        ready: Promise.resolve(),
         onDidChange: Event.None as Event<HostFsChange>,
         dispose: () => {},
       };
@@ -805,6 +806,99 @@ describe('WorkspaceSkillCatalogService', () => {
       await rm(homeDir, { recursive: true, force: true });
     }
   });
+
+  it('keeps the old watch active until a ready replacement converges on post-scan changes', async () => {
+    const workDir = await mkdtemp(join(tmpdir(), 'skill-watch-handoff-'));
+    const skillRoot = join(workDir, '.agents', 'skills');
+    await mkdir(join(skillRoot, 'demo'), { recursive: true });
+    await writeFile(
+      join(skillRoot, 'demo', 'SKILL.md'),
+      '---\nname: demo\ndescription: initial\n---\nbody',
+      'utf8',
+    );
+    const scannedDirectory = await realpath(skillRoot);
+    const replacementReady = deferred<void>();
+    const replacementStarted = deferred<void>();
+
+    class TestWatchHandle implements IHostFsWatchHandle {
+      readonly changes = new Emitter<HostFsChange>();
+      readonly onDidChange = this.changes.event;
+      disposed = false;
+
+      constructor(readonly ready: Promise<void>) {}
+
+      dispose(): void {
+        this.disposed = true;
+        this.changes.dispose();
+      }
+    }
+
+    const handles: TestWatchHandle[] = [];
+    const watchService: IHostFsWatchService = {
+      _serviceBrand: undefined,
+      watch: () => {
+        const handle = new TestWatchHandle(
+          handles.length === 0 ? Promise.resolve() : replacementReady.promise,
+        );
+        handles.push(handle);
+        if (handles.length === 2) replacementStarted.resolve(undefined);
+        return handle;
+      },
+    };
+    let scans = 0;
+    const discovery: ISkillDiscovery = {
+      _serviceBrand: undefined,
+      discover: async () => {
+        scans += 1;
+        return {
+          skills: [stubSkill('demo', { description: scans === 1 ? 'stale' : 'fresh' })],
+          skipped: [],
+          scannedRoots: [scannedDirectory],
+          scannedDirectories: [scannedDirectory],
+        };
+      },
+    };
+
+    _clearScopedRegistryForTests();
+    registerScopedService(
+      LifecycleScope.Workspace,
+      IWorkspaceRootSkillSource,
+      WorkspaceRootSkillSource,
+    );
+    const host = createScopedTestHost([
+      stubPair(ISkillDiscovery, discovery),
+      stubPair(IBootstrapService, bootstrapStub),
+      stubPair(IConfigService, configStub()),
+      stubPair(IHostFsWatchService, watchService),
+    ]);
+    const workspace = host.child(LifecycleScope.Workspace, 'w1', [
+      stubPair(IWorkspaceContext, workspaceContextStub(workDir)),
+    ]);
+
+    try {
+      const loading = workspace.accessor.get(IWorkspaceRootSkillSource).load();
+      await replacementStarted.promise;
+      const initialHandle = handles[0];
+      const replacementHandle = handles[1];
+      if (initialHandle === undefined || replacementHandle === undefined) {
+        throw new Error('expected initial and replacement watch handles');
+      }
+
+      expect(initialHandle.disposed).toBe(false);
+
+      replacementReady.resolve(undefined);
+      const contribution = await loading;
+
+      expect(initialHandle.disposed).toBe(true);
+      expect(replacementHandle.disposed).toBe(false);
+      expect(scans).toBe(2);
+      expect(contribution.skills.map((skill) => skill.description)).toEqual(['fresh']);
+    } finally {
+      host.dispose();
+      await rm(workDir, { recursive: true, force: true });
+    }
+  });
+
   it('rescans the workspace-root source when a project skill file changes on disk', async () => {
     const workDir = await mkdtemp(join(tmpdir(), 'skill-watch-'));
     const host = createScopedTestHost([

--- a/packages/agent-core-v2/test/workspace/workspaceSkillCatalog/skillCatalog.test.ts
+++ b/packages/agent-core-v2/test/workspace/workspaceSkillCatalog/skillCatalog.test.ts
@@ -26,7 +26,12 @@ import { IPluginService } from '#/app/plugin/plugin';
 import { PluginService } from '#/app/plugin/pluginService';
 import type { ReloadSummary } from '#/app/plugin/types';
 import { IProviderService } from '#/kosong/provider/provider';
-import { IHostFsWatchService, type HostFsChange, type IHostFsWatchHandle } from '#/os/interface/hostFsWatch';
+import {
+  IHostFsWatchService,
+  type HostFsChange,
+  type HostFsWatchOptions,
+  type IHostFsWatchHandle,
+} from '#/os/interface/hostFsWatch';
 import { IAppStateService } from '#/app/state/appState';
 import { AppStateService } from '#/app/state/appStateService';
 import { IWorkspaceStateService } from '#/workspace/state/workspaceState';
@@ -149,13 +154,18 @@ function workspaceContextStub(workDir: string): IWorkspaceContext {
   };
 }
 
-function fsWatchStub(): IHostFsWatchService {
+function fsWatchStub(
+  onWatch?: (options: HostFsWatchOptions | undefined) => void,
+): IHostFsWatchService {
   return {
     _serviceBrand: undefined,
-    watch: (): IHostFsWatchHandle => ({
-      onDidChange: Event.None as Event<HostFsChange>,
-      dispose: () => {},
-    }),
+    watch: (_path, options): IHostFsWatchHandle => {
+      onWatch?.(options);
+      return {
+        onDidChange: Event.None as Event<HostFsChange>,
+        dispose: () => {},
+      };
+    },
   };
 }
 
@@ -408,7 +418,7 @@ describe('WorkspaceSkillCatalogService', () => {
       calls = 0;
       async discover() {
         this.calls++;
-        return { skills: [], skipped: [], scannedRoots: [] };
+        return { skills: [], skipped: [], scannedRoots: [], scannedDirectories: [] };
       }
     }
     const store = new CountingDiscovery();
@@ -492,7 +502,7 @@ describe('WorkspaceSkillCatalogService', () => {
         const pluginSkills = roots
           .filter((root) => root.plugin !== undefined)
           .map((root) => stubSkill('demo-skill', { source: 'extra', plugin: root.plugin }));
-        return { skills: pluginSkills, skipped: [], scannedRoots: [] };
+        return { skills: pluginSkills, skipped: [], scannedRoots: [], scannedDirectories: [] };
       }
     }
     const store = new ExtraRootStore();
@@ -519,6 +529,7 @@ describe('WorkspaceSkillCatalogService', () => {
             scannedRoots: roots
               .filter((root) => root.source === 'project')
               .map((root) => root.path),
+            scannedDirectories: [],
           };
         }
       }
@@ -551,6 +562,7 @@ describe('WorkspaceSkillCatalogService', () => {
             skills: [],
             skipped: isProject ? [skippedEntry] : [],
             scannedRoots: [],
+            scannedDirectories: [],
           };
         }
       }
@@ -835,6 +847,49 @@ describe('WorkspaceSkillCatalogService', () => {
       await rm(workDir, { recursive: true, force: true });
     }
   }, 15000);
+
+  it('prunes terminal skill payloads from the workspace watch after discovery', async () => {
+    const workDir = await mkdtemp(join(tmpdir(), 'skill-watch-plan-'));
+    const skillDir = join(workDir, '.agents', 'skills', 'demo');
+    const runtimeFile = join(skillDir, 'runtime', '0.py');
+    await mkdir(join(skillDir, 'runtime'), { recursive: true });
+    await writeFile(
+      join(skillDir, 'SKILL.md'),
+      '---\nname: demo\ndescription: demo\n---\nbody',
+      'utf8',
+    );
+    await writeFile(runtimeFile, 'x', 'utf8');
+    const watchedSkillDir = await realpath(skillDir);
+    const watchedRuntimeFile = await realpath(runtimeFile);
+    let ignored: ((path: string) => boolean) | undefined;
+    const host = createScopedTestHost([
+      stubPair(IBootstrapService, bootstrapStub),
+      stubPair(IConfigService, configStub()),
+      stubPair(IPluginService, pluginStub()),
+      stubPair(ILogService, stubLog()),
+      stubPair(ISkillDiscovery, new FileSkillDiscovery(stubLog())),
+      stubPair(
+        IHostFsWatchService,
+        fsWatchStub((options) => {
+          ignored = options?.ignored;
+        }),
+      ),
+    ]);
+    const workspace = host.child(LifecycleScope.Workspace, 'w1', [
+      stubPair(IWorkspaceContext, workspaceContextStub(workDir)),
+    ]);
+
+    try {
+      const catalog = workspace.accessor.get(IWorkspaceSkillCatalog);
+      await catalog.load();
+
+      expect(ignored?.(join(watchedSkillDir, 'SKILL.md'))).toBe(false);
+      expect(ignored?.(watchedRuntimeFile)).toBe(true);
+    } finally {
+      host.dispose();
+      await rm(workDir, { recursive: true, force: true });
+    }
+  });
 
   it('rescans when a skill under a dot directory appears on disk', async () => {
     const workDir = await mkdtemp(join(tmpdir(), 'skill-watch-dot-'));


### PR DESCRIPTION
## Related Issue

Resolve #2542

## Problem

On macOS, 0.31.1 can exhaust the process file-descriptor budget when a skill folder contains a very large file tree (e.g. a skill bundling a Python runtime): afterwards every spawn fails with `EBADF` and all tools (Bash, Grep, …) stop working. 0.29.1 did not have this problem.

Root cause: the Workspace-domain refactor (#2366, first released in 0.31.1) made the workspace skill-root source recursively watch the project skill-root candidates (`.kimi-code/skills`, `.agents/skills`, anchored at the project root so not-yet-existing roots are detected). chokidar v4 watches every node with its own `fs.watch`; on macOS each watched file or directory holds one kqueue fd, and the watch filter pruned nothing inside the skill subtrees — not even `node_modules` or dot directories, which the scanner itself never descends into. A 10k-file skill tree therefore pinned 10k+ fds for the lifetime of the workspace handler (which is never closed).

## What changed

Two complementary fixes that keep skill hot-reload working:

- **The watch now mirrors the scanner's pruning.** `subtreeWatchFilter` gains `maxDepth` / `skipEntry` options, the scanner exports its exclusion rule and depth cap, and the skill-root source watches with those rules (depth cap + 2 segments for the skill directory and its SKILL.md). Subtrees the scanner would never read no longer get watched — this bounds fd and event volume on every platform.
- **New `signal` mode in `hostFsWatch`.** Callers that consume events as a mere "something changed" signal (the skill source and similar rescan-style watchers) opt in; on darwin/win32 a signal-mode recursive watch then uses ONE native recursive `fs.watch` (FSEvents / ReadDirectoryChangesW) whose fd footprint is constant in the subtree size, instead of per-node watchers. Events in this mode may be coarse (a deleted entry of unknown kind is reported as `'file'`; FSEvents may coalesce a burst into an ancestor-directory event), which is safe for rescan-style consumers and documented on the interface. The `workspaceFs` watch bridge, whose subscribers receive precise action/kind, stays on chokidar unchanged.

Tests: unit tests for the new filter options; signal-mode integration tests (create/modify/delete mapping, ignored predicate); a darwin-only regression test asserting the fd footprint stays bounded over a 1200-file subtree; a catalog scenario test proving pruned writes do not change the catalog while real skill edits still hot-reload. Full `agent-core-v2` suite passes (296 files / 4620 tests), plus `typecheck` and `lint:imports`.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.