### PR TITLE
test(mcp): pin the auth-tool expiresAt to the effective wait timeout

### DIFF
--- a/packages/agent-core-v2/test/agent/mcp/tools/auth.test.ts
+++ b/packages/agent-core-v2/test/agent/mcp/tools/auth.test.ts
@@ -51,6 +51,7 @@ describe('createMcpAuthTool', () => {
       complete: async () => undefined,
       cancel: async () => undefined,
     }));
+    const before = Date.now();
     const { result, updates } = runTool({
       oauthService,
       reconnect: async () => {
@@ -69,11 +70,14 @@ describe('createMcpAuthTool', () => {
       serverName: 'notion',
       authorizationUrl: 'https://example.com/authorize?state=abc',
     });
-    // The deadline is absolute (now + wait timeout), so hosts never mirror
-    // the engine-side constant.
+    // The deadline is absolute (emit time + the effective wait timeout — the
+    // 100ms override here, not the 15-minute default), so hosts render from
+    // data instead of mirroring the engine constant. Bounding by the time
+    // window around the run keeps the assertion exact without depending on
+    // how long the test body takes.
     const { expiresAt } = authUpdate?.customData as { expiresAt?: number };
-    expect(expiresAt).toBeGreaterThan(Date.now());
-    expect(expiresAt).toBeLessThanOrEqual(Date.now() + 15 * 60 * 1000);
+    expect(expiresAt).toBeGreaterThanOrEqual(before + 100);
+    expect(expiresAt).toBeLessThanOrEqual(Date.now() + 100);
   });
 
   it('falls through to reconnect when the provider reports already-authorized', async () => {

--- a/packages/agent-core/test/mcp/auth-tool.test.ts
+++ b/packages/agent-core/test/mcp/auth-tool.test.ts
@@ -55,6 +55,7 @@ describe('createMcpAuthTool', () => {
       complete: async () => undefined,
       cancel: async () => undefined,
     }));
+    const before = Date.now();
     const { result, updates } = runTool({
       oauthService,
       reconnect: async () => {
@@ -73,11 +74,14 @@ describe('createMcpAuthTool', () => {
       serverName: 'notion',
       authorizationUrl: 'https://example.com/authorize?state=abc',
     });
-    // The deadline is absolute (now + wait timeout), so hosts never mirror
-    // the engine-side constant.
+    // The deadline is absolute (emit time + the effective wait timeout — the
+    // 100ms override here, not the 15-minute default), so hosts render from
+    // data instead of mirroring the engine constant. Bounding by the time
+    // window around the run keeps the assertion exact without depending on
+    // how long the test body takes.
     const { expiresAt } = authUpdate?.customData as { expiresAt?: number };
-    expect(expiresAt).toBeGreaterThan(Date.now());
-    expect(expiresAt).toBeLessThanOrEqual(Date.now() + 15 * 60 * 1000);
+    expect(expiresAt).toBeGreaterThanOrEqual(before + 100);
+    expect(expiresAt).toBeLessThanOrEqual(Date.now() + 100);
   });
 
   it('falls through to reconnect when the provider reports already-authorized', async () => {


### PR DESCRIPTION
## Related Issue

Follow-up to #2609 — tightens the tests it added; no separate issue.

## Problem

The v1/v2 auth-tool suites construct the tool with a `timeoutMs: 100` override, but the `expiresAt` assertions added in #2609 only bound the value by the 15-minute default — they pass even if the implementation ignored the override. Worse, the lower bound compares against `Date.now()` taken **after** the run completes, so the assertion becomes flaky the moment the test body takes longer than the 100ms override.

## What changed

Test-only. Both suites capture `before = Date.now()` ahead of the run and assert `expiresAt ∈ [before + 100, Date.now() + 100]` — pinning the deadline to *emit time + the effective wait timeout* exactly, with bounds that hold regardless of how long the test body takes.

No changeset: tests only.

## Verification

Both auth-tool suites pass (5 tests each); `oxlint` clean.
