### PR TITLE
fix(mcp): re-register the OAuth client when its redirect URI no longer matches

### DIFF
--- a/.changeset/mcp-oauth-stale-redirect-registration.md
+++ b/.changeset/mcp-oauth-stale-redirect-registration.md
@@ -1,0 +1,5 @@
+---
+'@moonshot-ai/kimi-code': patch
+---
+
+Fixed MCP OAuth re-authorization always failing with "Invalid redirect URI": the OAuth callback listener binds a random port per flow, but the dynamic client registration recorded the first flow's port, so every later interactive authorization was rejected at the authorization endpoint. A stale registration is now dropped automatically and the flow re-registers with the current callback URI.

--- a/packages/agent-core-v2/src/mcpCore/oauth/provider.ts
+++ b/packages/agent-core-v2/src/mcpCore/oauth/provider.ts
@@ -14,6 +14,13 @@
  * The provider does not open browsers or run servers — it is the
  * persistence + flow-state shim.
  *
+ * `invalidateStaleRegistration` guards interactive flows: the callback
+ * listener binds a random port per flow while a DCR registration pins the
+ * redirect URIs of the flow that created it, so a reused registration whose
+ * URIs no longer cover the current callback would be rejected at the
+ * authorization endpoint ("invalid redirect URI", rendered only in the
+ * user's browser). Dropping it lets `auth()` re-register.
+ *
  * `clientName` is the product token for the default label
  * (`<clientName> (<serverName>)`), carrying the configured custom identity; it
  * is ignored when `clientLabel` states the whole label explicitly.
@@ -169,6 +176,17 @@ export class McpOAuthClientProvider implements OAuthClientProvider {
   async discoveryState(): Promise<OAuthDiscoveryState | undefined> {
     await this.ready;
     return this.discoveryCache;
+  }
+
+  async invalidateStaleRegistration(redirectUri: string): Promise<boolean> {
+    await this.ready;
+    const info = this.clientCache;
+    if (info === undefined || !('redirect_uris' in info)) return false;
+    const uris = info.redirect_uris;
+    if (!Array.isArray(uris) || uris.length === 0) return false;
+    if (uris.includes(redirectUri)) return false;
+    await this.invalidateCredentials('client');
+    return true;
   }
 
   async invalidateCredentials(

--- a/packages/agent-core-v2/src/mcpCore/oauth/service.ts
+++ b/packages/agent-core-v2/src/mcpCore/oauth/service.ts
@@ -111,6 +111,7 @@ export class McpOAuthService {
 
     provider.setRedirectUrl(new URL(callbackServer.redirectUri));
     await provider.ready;
+    await provider.invalidateStaleRegistration(callbackServer.redirectUri);
 
     let authorizationUrl: URL | undefined;
     try {

--- a/packages/agent-core-v2/test/mcpCore/oauth/store.test.ts
+++ b/packages/agent-core-v2/test/mcpCore/oauth/store.test.ts
@@ -113,3 +113,46 @@ function token(accessToken: string): OAuthTokens {
     token_type: 'Bearer',
   };
 }
+
+describe('McpOAuthClientProvider.invalidateStaleRegistration', () => {
+  function makeProvider() {
+    return new McpOAuthClientProvider({
+      serverName: 'srv',
+      serverUrl: 'https://mcp.example.com/mcp',
+      store: createMemoryMcpOAuthStore(),
+    });
+  }
+
+  const registration: OAuthClientInformationFull = {
+    client_id: 'c1',
+    redirect_uris: ['http://127.0.0.1:11111/callback'],
+  };
+
+  it('drops a registration whose redirect_uris miss the current callback', async () => {
+    const provider = makeProvider();
+    await provider.ready;
+    await provider.saveClientInformation(registration);
+    await expect(
+      provider.invalidateStaleRegistration('http://127.0.0.1:22222/callback'),
+    ).resolves.toBe(true);
+    await expect(provider.clientInformation()).resolves.toBeUndefined();
+  });
+
+  it('keeps a registration that still covers the callback URI', async () => {
+    const provider = makeProvider();
+    await provider.ready;
+    await provider.saveClientInformation(registration);
+    await expect(
+      provider.invalidateStaleRegistration('http://127.0.0.1:11111/callback'),
+    ).resolves.toBe(false);
+    await expect(provider.clientInformation()).resolves.toMatchObject({ client_id: 'c1' });
+  });
+
+  it('is a no-op without a stored registration', async () => {
+    const provider = makeProvider();
+    await provider.ready;
+    await expect(
+      provider.invalidateStaleRegistration('http://127.0.0.1:11111/callback'),
+    ).resolves.toBe(false);
+  });
+});

--- a/packages/agent-core/src/mcp/oauth/provider.ts
+++ b/packages/agent-core/src/mcp/oauth/provider.ts
@@ -153,6 +153,29 @@ export class McpOAuthClientProvider implements OAuthClientProvider {
     return this.store.read<OAuthDiscoveryState>(`${this.storeKey}${DISCOVERY_SUFFIX}`);
   }
 
+  /**
+   * Drop the persisted DCR client registration when its `redirect_uris` no
+   * longer cover `redirectUri`. Returns true when a stale registration was
+   * dropped.
+   *
+   * The callback listener binds a random port per flow, while a DCR
+   * registration pins the redirect URIs of the flow that created it. Reusing
+   * a registration whose URIs no longer match guarantees an
+   * "invalid redirect URI" rejection at the authorization endpoint — rendered
+   * only in the user's browser, while this client waits for a callback that
+   * never comes. Dropping the registration lets the next `auth()` call
+   * re-register with the current callback URI.
+   */
+  invalidateStaleRegistration(redirectUri: string): boolean {
+    const info = this.clientInformation();
+    if (info === undefined || !('redirect_uris' in info)) return false;
+    const uris = info.redirect_uris;
+    if (!Array.isArray(uris) || uris.length === 0) return false;
+    if (uris.includes(redirectUri)) return false;
+    this.invalidateCredentials('client');
+    return true;
+  }
+
   invalidateCredentials(scope: 'all' | 'client' | 'tokens' | 'verifier' | 'discovery'): void {
     if (scope === 'verifier') {
       this._codeVerifier = undefined;

--- a/packages/agent-core/src/mcp/oauth/service.ts
+++ b/packages/agent-core/src/mcp/oauth/service.ts
@@ -126,6 +126,10 @@ export class McpOAuthService {
     }
 
     provider.setRedirectUrl(new URL(callbackServer.redirectUri));
+    // See invalidateStaleRegistration: a reused registration whose redirect
+    // URIs no longer cover this flow's random-port callback would be rejected
+    // at the authorization endpoint with an error only the browser ever sees.
+    provider.invalidateStaleRegistration(callbackServer.redirectUri);
 
     let authorizationUrl: URL | undefined;
     try {

--- a/packages/agent-core/test/mcp/oauth-store.test.ts
+++ b/packages/agent-core/test/mcp/oauth-store.test.ts
@@ -164,3 +164,47 @@ function token(accessToken: string): OAuthTokens {
     token_type: 'Bearer',
   };
 }
+
+describe('McpOAuthClientProvider.invalidateStaleRegistration', () => {
+  let dir: string;
+
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), 'kimi-mcp-oauth-stale-'));
+  });
+  afterEach(async () => {
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  function makeProvider() {
+    return new McpOAuthClientProvider({
+      serverName: 'srv',
+      serverUrl: 'https://mcp.example.com/mcp',
+      store: new JsonFileStore(dir),
+    });
+  }
+
+  it('drops a registration whose redirect_uris miss the current callback', () => {
+    const provider = makeProvider();
+    provider.saveClientInformation({
+      client_id: 'c1',
+      redirect_uris: ['http://127.0.0.1:11111/callback'],
+    });
+    expect(provider.invalidateStaleRegistration('http://127.0.0.1:22222/callback')).toBe(true);
+    expect(provider.clientInformation()).toBeUndefined();
+  });
+
+  it('keeps a registration that still covers the callback URI', () => {
+    const provider = makeProvider();
+    provider.saveClientInformation({
+      client_id: 'c1',
+      redirect_uris: ['http://127.0.0.1:11111/callback'],
+    });
+    expect(provider.invalidateStaleRegistration('http://127.0.0.1:11111/callback')).toBe(false);
+    expect(provider.clientInformation()).toMatchObject({ client_id: 'c1' });
+  });
+
+  it('is a no-op without a stored registration', () => {
+    const provider = makeProvider();
+    expect(provider.invalidateStaleRegistration('http://127.0.0.1:11111/callback')).toBe(false);
+  });
+});


### PR DESCRIPTION
## Related Issue

Resolve #2606

## Problem

See the linked issue and its root-cause comment: `startCallbackServer()` binds a **random free port** per flow (`oauth/callback-server.ts`, `listen(0)`), while dynamic client registration records the first flow's redirect URI. Every subsequent interactive authorization therefore presents a callback URI the registration does not cover, and the authorization endpoint rejects it with "Invalid redirect URI" — deterministically, on the second interactive flow and every one after. The rejection renders only in the user's browser; this client just waits for a callback that never comes. The only recovery was manually deleting `credentials/mcp/<key>-client.json`.

Verified live in both directions: a second interactive authorization against a stored registration failed with exactly this error; after clearing the registration the same flow succeeded first try.

## What changed

- `McpOAuthClientProvider` (v1 `mcp/oauth/provider.ts`, v2 `mcpCore/oauth/provider.ts`) gains `invalidateStaleRegistration(redirectUri)`: when a stored registration exists and its `redirect_uris` do not cover the given URI, the client registration is dropped (tokens and discovery state untouched) and `true` is returned.
- `beginAuthorization` (v1/v2 `oauth/service.ts`) calls it right after binding the callback listener, before invoking `auth()` — so `auth()` finds no client information and re-registers with the current callback URI. Flows whose registration still matches are untouched.

## Verification

- New unit tests (v1 `test/mcp/oauth-store.test.ts`, v2 `test/mcpCore/oauth/store.test.ts`): mismatched registration dropped with `true`; matching registration kept; no-op without a stored registration. Suites pass (16 v1 / 12 v2).
- `tsc --noEmit` and `oxlint` clean for both packages.
- Changeset included (`@moonshot-ai/kimi-code`: patch) — the failure is user-visible (re-authorization goes from always-failing to working).
