### PR TITLE
test(agent-core-v2): stop the reconcile loop during the sessionIndex read baseline

### DIFF
--- a/packages/agent-core-v2/src/app/sessionIndex/sessionIndexService.ts
+++ b/packages/agent-core-v2/src/app/sessionIndex/sessionIndexService.ts
@@ -246,6 +246,12 @@ export class FileSessionIndex extends Disposable implements ISessionIndex {
     await this.ensureProjection();
   }
 
+  /** Test hook: stop the background reconcile loop, so measurement windows
+   *  contain only the operations under test. */
+  stopReconcileLoop(): void {
+    this.reconcileTimer.cancel();
+  }
+
   private async tick(): Promise<void> {
     if (!this.readModelEnabled()) return;
     if (this.state === 'degraded') {

--- a/packages/agent-core-v2/test/app/sessionIndex/sessionIndex.test.ts
+++ b/packages/agent-core-v2/test/app/sessionIndex/sessionIndex.test.ts
@@ -888,8 +888,11 @@ describe('FileSessionIndex (read model)', () => {
   // every warm read must touch a bounded number of store rows and zero
   // session directories, and that work must be identical at 1k, 10k, and 50k
   // sessions — a linear regression changes the counts deterministically, on
-  // any runner. The single retry absorbs a background reconcile tick (60s
-  // interval) landing inside a counting window.
+  // any runner. The background reconcile loop is stopped right after
+  // prepare(): a tick's authoritative scan enumerates the session
+  // directories (60s interval), and on a runner slow enough for the test to
+  // cross that interval it would land inside a counting window and be
+  // attributed to the read under test. The retry absorbs runner hiccups.
   const baseline = { retry: 1, timeout: 120_000 };
 
   it('baseline: warm listRecent(limit=20) at 1k vs 10k vs 50k sessions', baseline, async () => {
@@ -907,6 +910,9 @@ describe('FileSessionIndex (read model)', () => {
     // directly into the generation (the mirror path is covered elsewhere).
     await seedSession('seed', { createdAt: 0, updatedAt: 0 });
     await store.prepare();
+    // Freeze the background reconcile loop so the counting windows below
+    // contain only the read under test.
+    store.stopReconcileLoop();
     const collection = sessionCollection(1);
 
     const seedRows = async (from: number, to: number): Promise<void> => {


### PR DESCRIPTION
## Related Issue

No linked issue — the problem is explained below. Observed on CI run 30975794688 (PR #2599, unrelated changes), shard `test (2)`.

## Problem

`FileSessionIndex (read model) > baseline: warm listRecent(limit=20) at 1k vs 10k vs 50k sessions` flakes on slow CI runners with `AssertionError: expected 2 to be +0` at the `expect(op.fsLists).toBe(0)` assertion.

The baseline gates warm reads on behavioral work counts, including "zero directory listings inside each counting window". But `FileSessionIndex` starts a background reconcile loop (`RECONCILE_INTERVAL_MS = 60_000`) once ready, and every tick unconditionally runs the projector's authoritative scan, which enumerates workspace + session directories — exactly two `storage.list` calls for the single-workspace test setup. Locally the test finishes in ~12s so the first tick never fires; on a loaded shared runner the test takes ~84s per attempt, so a tick lands inside a counting window on essentially every attempt and its two listings get attributed to the read under test. The existing `retry: 1` cannot absorb that — both attempts fail the same way (168s total in the observed run).

## What changed

- Added a `stopReconcileLoop()` test hook on `FileSessionIndex` (sibling of the existing `reconcileNow` / `reprojectNow` test/ops hooks) that cancels the reconcile `IntervalTimer`.
- The baseline test calls it right after `prepare()`, before any measurement, and the comment block now describes this instead of claiming the retry absorbs a tick.

This makes the gate deterministic rather than relaxing it: after `prepare()` + `stopReconcileLoop()`, the only remaining `storage.list` callers that could fire inside a counting window are the fallback read paths themselves (projector `project` runs during `prepare`, `reconcile` is stopped), so `fsLists > 0` can once again only mean a real regression. The reconcile loop itself is production behavior — it repairs drift the best-effort mirror misses (external `state.json` edits/deletions, dropped flushes) and stays covered by the dedicated `reconciliation repairs external edits and deletions of state.json` test.

Verified: `pnpm vitest run test/app/sessionIndex/sessionIndex.test.ts` — 29/29 pass; `tsc --noEmit` clean. Note the race itself cannot be reproduced locally (local runs finish well under the 60s tick interval); the fix removes the only background listing source, so runtime no longer matters.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.
