### PR TITLE
chore(changeset): add changesets for the v2 TUI and web UI updates

### DIFF
--- a/.changeset/tui-lazy-session-creation.md
+++ b/.changeset/tui-lazy-session-creation.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Start the interactive TUI without creating a session.

--- a/.changeset/tui-workspace-trust-prompt.md
+++ b/.changeset/tui-workspace-trust-prompt.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": minor
+---
+
+Ask whether to trust the current folder on startup.

--- a/.changeset/web-account-plan-usage.md
+++ b/.changeset/web-account-plan-usage.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+web: Show the signed-in account and plan usage.

--- a/.changeset/web-custom-providers.md
+++ b/.changeset/web-custom-providers.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": minor
+---
+
+web: Add and manage custom providers in settings.

--- a/.changeset/web-session-title-emoji.md
+++ b/.changeset/web-session-title-emoji.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+web: Set an emoji for the session title.

--- a/.changeset/web-sidebar-pinned-sessions.md
+++ b/.changeset/web-sidebar-pinned-sessions.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+web: Pin sessions to the top of the sidebar.

--- a/.changeset/web-ui-ux-polish.md
+++ b/.changeset/web-ui-ux-polish.md
@@ -2,4 +2,4 @@
 "@moonshot-ai/kimi-code": minor
 ---
 
-web: Polish the UI/UX and fix known issues.
+web: Overhaul the UI/UX and fix known issues.


### PR DESCRIPTION
## Related Issue

N/A — release changelog maintenance

## Problem

Several user-facing changes already on main have no changeset, so they would be missing from the next release's changelog: the v2 TUI workspace trust prompt, lazy session creation, and the web UI capabilities shipped in the bundled web app.

## What changed

- Add a changeset for the workspace trust prompt on TUI startup (`minor`)
- Add a changeset for starting the interactive TUI without creating a session (`patch`)
- Reword the existing web UI/UX entry from "Polish" to "Overhaul"
- Add web changesets: pin sessions to the top of the sidebar (`patch`), set an emoji for the session title (`patch`), show the signed-in account and plan usage (`patch`), and add/manage custom providers in settings (`minor`)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [ ] I have added tests that prove my feature works. (N/A — changelog-only changes)
- [x] Ran `gen-changesets` skill, or this PR needs no changeset. (This PR is the changesets)
- [x] Ran `gen-docs` skill, or this PR needs no doc update. (N/A — changeset entries only)