### PR TITLE
fix(minidb): silence the transform-types warning from the dev worker

### DIFF
--- a/packages/minidb/src/worker/text-build.ts
+++ b/packages/minidb/src/worker/text-build.ts
@@ -122,7 +122,9 @@ function spawnWorker(
   }
   return new Worker(entry.url, {
     workerData: spec,
-    execArgv: ['--experimental-transform-types'],
+    // --experimental-transform-types runs the TS worker source directly in dev;
+    // silence its experimental warning so it does not bleed into the TUI.
+    execArgv: ['--experimental-transform-types', '--disable-warning=ExperimentalWarning'],
     resourceLimits,
   });
 }


### PR DESCRIPTION
## Related Issue

N/A — dev-experience fix

## Problem

After the v2 engine became the default, running `make dev` prints `ExperimentalWarning: Transform Types is an experimental feature` directly into the TUI at startup (once per worker thread), looking like an error.

Root cause: the minidb text-build worker added in #2604 runs its TypeScript source directly in dev via `new Worker('./text-build-worker.ts', { execArgv: ['--experimental-transform-types'] })`. Every worker thread emits the experimental warning to stderr, and the v2 session index build at startup spawns it.

## What changed

- Add `--disable-warning=ExperimentalWarning` to the source-mode worker's `execArgv` in `packages/minidb/src/worker/text-build.ts`. The packaged CLI is unaffected: it uses the prebuilt JS worker with `execArgv: []`.

Verified:

- Reproduced the warning with a minimal transform-requiring TS worker (enum); the old `execArgv` warns, the new one does not, and the worker still runs.
- `pnpm -C packages/minidb test` passes (531 passed, 1 skipped).

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [ ] I have added tests that prove my feature works. (N/A — Node flag on a dev-only worker path; covered by the existing minidb suite)
- [x] Ran `gen-changesets` skill, or this PR needs no changeset. (No changeset — dev-only warning suppression, not perceivable in the shipped CLI)
- [x] Ran `gen-docs` skill, or this PR needs no doc update. (N/A — internal dev tooling)