### PR TITLE
chore(changeset): trim the v2 engine entry and drop the custom identity entry

### DIFF
--- a/.changeset/custom-agent-identity.md
+++ b/.changeset/custom-agent-identity.md
@@ -1,5 +1,0 @@
----
-"@moonshot-ai/kimi-code": minor
----
-
-Add a custom agent identity, plus a switch for the built-in skills that document Kimi Code itself. Set `[identity] name` in `config.toml` (or `KIMI_CODE_IDENTITY_NAME`) to change the name the agent uses for itself and the identifier it presents to third-party providers and MCP servers; set `builtin_product_skills = false` to drop the product-documentation skills.

--- a/.changeset/default-v2-engine-cli.md
+++ b/.changeset/default-v2-engine-cli.md
@@ -2,4 +2,4 @@
 "@moonshot-ai/kimi-code": minor
 ---
 
-Run the CLI surfaces (interactive TUI, `kimi -p`, `kimi doctor`, `kimi acp`, `kimi export`, `kimi provider`) on the agent-core-v2 engine by default, and drop the experimental `kimi acp-v2` command now that `kimi acp` uses the new engine directly. Set `KIMI_CODE_LEGACY_FLAG=1` to fall back to the legacy engine.
+Run the CLI surfaces (interactive TUI, `kimi -p`, `kimi acp`, `kimi export`, `kimi provider`) on the agent-core-v2 engine by default. Set `KIMI_CODE_LEGACY_FLAG=1` to fall back to the legacy engine.


### PR DESCRIPTION
## Related Issue

N/A — release changelog maintenance

## Problem

Review of the upcoming release changelog asked for two wording changes that were only applied to the preview, not to the changeset sources:

- The v2-engine default entry should not mention `kimi doctor` or the removed `kimi acp-v2` command.
- The custom agent identity entry (including the `builtin_product_skills` switch) should not appear in the changelog at all.

## What changed

- `.changeset/default-v2-engine-cli.md`: drop `kimi doctor` from the surface list and remove the `kimi acp-v2` sentence.
- Delete `.changeset/custom-agent-identity.md` so the entry is left out of the generated changelog; the shipped feature is unaffected.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [ ] I have added tests that prove my feature works. (N/A — changelog-only changes)
- [x] Ran `gen-changesets` skill, or this PR needs no changeset. (This PR edits changesets)
- [x] Ran `gen-docs` skill, or this PR needs no doc update. (N/A — changeset entries only)