### PR TITLE
fix(tui): clarify curated plugin marketplace

### DIFF
--- a/.changeset/curated-plugins-tab.md
+++ b/.changeset/curated-plugins-tab.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Rename the partner plugin marketplace tab to Curated and clarify that it contains third-party plugins from Kimi partners.

--- a/apps/kimi-code/src/tui/commands/plugins.ts
+++ b/apps/kimi-code/src/tui/commands/plugins.ts
@@ -131,7 +131,7 @@ export async function handlePluginsCommand(host: SlashCommandHost, rawArgs: stri
       const marketplaceSource = rest.join(' ').trim() || undefined;
       await showPluginsPicker(host, {
         // Custom marketplaces often omit `tier`, so their entries land on the
-        // Third-party tab (entry.tier !== 'official'). Open there when a custom
+        // Curated tab (entry.tier !== 'official'). Open there when a custom
         // source is supplied; otherwise the default catalog's official entries
         // make Official the right landing tab.
         initialTab: marketplaceSource === undefined ? 'official' : 'third-party',
@@ -282,7 +282,7 @@ async function showPluginsPicker(
     onCancel: () => {
       host.restoreEditor();
     },
-    // Every tab except Custom needs the catalog: Official/Third-party list it,
+    // Every tab except Custom needs the catalog: Official/Curated list it,
     // and Installed uses it to show update badges. The Installed/Custom tabs
     // keep working even when the marketplace is unreachable (badges simply stay
     // hidden until data arrives).
@@ -292,7 +292,7 @@ async function showPluginsPicker(
   });
   host.mountEditorReplacement(panel);
   // Kick off the catalog fetch for any tab that needs it: Installed uses it for
-  // update badges, Official/Third-party list it. Custom never reads the catalog,
+  // update badges, Official/Curated list it. Custom never reads the catalog,
   // so skip the fetch there. Done here (after `panel` is initialized) rather
   // than inside the component constructor, because the callback above closes
   // over `panel`.

--- a/apps/kimi-code/src/tui/components/dialogs/plugins-selector.ts
+++ b/apps/kimi-code/src/tui/components/dialogs/plugins-selector.ts
@@ -321,7 +321,7 @@ function renderUrlInputBox(
 }
 
 // ===========================================================================
-// Unified /plugins panel: Installed / Official / Third-party / Custom tabs.
+// Unified /plugins panel: Installed / Official / Curated / Custom tabs.
 // ===========================================================================
 
 export type PluginsPanelTabId = 'installed' | 'official' | 'third-party' | 'custom';
@@ -351,7 +351,7 @@ export interface PluginsPanelOptions {
   readonly pluginHint?: { readonly id: string; readonly text: string };
   readonly onSelect: (selection: PluginsPanelSelection) => void;
   readonly onCancel: () => void;
-  /** Called the first time the Official or Third-party tab needs its catalog.
+  /** Called the first time the Official or Curated tab needs its catalog.
    * The host fetches the marketplace and calls setMarketplace / setMarketplaceError. */
   readonly onRequestMarketplace?: () => void;
 }
@@ -365,7 +365,7 @@ type MarketState =
 const PLUGINS_PANEL_TABS: readonly { id: PluginsPanelTabId; label: string }[] = [
   { id: 'installed', label: 'Installed' },
   { id: 'official', label: 'Official' },
-  { id: 'third-party', label: 'Third-party' },
+  { id: 'third-party', label: 'Curated' },
   { id: 'custom', label: 'Custom' },
 ];
 
@@ -756,6 +756,11 @@ export class PluginsPanelComponent extends Container implements Focusable {
   }
 
   private renderThirdParty(lines: string[], width: number): void {
+    if (this.opts.catalogIsDefault !== false) {
+      const colors = currentTheme.palette;
+      lines.push(mutedHintLine(' Third-party plugins from our partners.', colors));
+      lines.push('');
+    }
     this.renderMarketplaceTab(lines, width, this.thirdPartyEntries);
   }
 

--- a/apps/kimi-code/test/tui/components/dialogs/plugins-selector.test.ts
+++ b/apps/kimi-code/test/tui/components/dialogs/plugins-selector.test.ts
@@ -288,7 +288,7 @@ describe('plugins selector dialogs', () => {
     expect(out).toContain('Plugins');
     expect(out).toContain('Installed');
     expect(out).toContain('Official');
-    expect(out).toContain('Third-party');
+    expect(out).toContain('Curated');
     expect(out).toContain('Custom');
     expect(out).toContain('? Superpowers  enabled');
     expect(out).toContain('Space toggle');
@@ -551,9 +551,9 @@ describe('plugins selector dialogs', () => {
     });
   });
 
-  it('installs a Third-party entry whose id matches the pinned WebBridge', () => {
+  it('installs a Curated entry whose id matches the pinned WebBridge', () => {
     // A curated/custom marketplace entry can legitimately reuse the
-    // kimi-webbridge id; on the Third-party tab it must install normally, not
+    // kimi-webbridge id; on the Curated tab it must install normally, not
     // open the WebBridge page (that shortcut is reserved for the pinned row).
     const entries = [
       {
@@ -566,6 +566,8 @@ describe('plugins selector dialogs', () => {
     const { panel, onSelect } = makePanel({ initialTab: 'third-party' });
     panel.setMarketplace(entries, '/tmp/marketplace.json');
     const out = strip(renderRaw(panel));
+    expect(out).toContain('Curated');
+    expect(out).toContain('Third-party plugins from our partners.');
     expect(out).toContain('Kimi WebBridge  install');
     panel.handleInput('\r');
     expect(onSelect).toHaveBeenCalledWith({
@@ -574,7 +576,7 @@ describe('plugins selector dialogs', () => {
     });
   });
 
-  it('installs the selected Third-party entry on Enter', () => {
+  it('installs the selected Curated entry on Enter', () => {
     const { panel, onSelect } = makePanel({ installed: [superpowers], initialTab: 'third-party' });
     panel.setMarketplace(marketplaceEntries, '/tmp/marketplace.json');
     panel.handleInput('\r');
@@ -604,14 +606,15 @@ describe('plugins selector dialogs', () => {
     });
   });
 
-  it('shows untiered marketplace entries on the Third-party tab', () => {
+  it('shows untiered custom marketplace entries without the partner description', () => {
     const untiered = [
       { id: 'custom-plugin', displayName: 'Custom Plugin', source: 'https://x/c.zip' },
     ];
-    const { panel } = makePanel({ initialTab: 'third-party' });
+    const { panel } = makePanel({ initialTab: 'third-party', catalogIsDefault: false });
     panel.setMarketplace(untiered, '/tmp/marketplace.json');
     const out = strip(renderRaw(panel));
     expect(out).toContain('Custom Plugin  install');
+    expect(out).not.toContain('Third-party plugins from our partners.');
   });
 
   it('shows an update badge when the marketplace version is newer than installed', () => {

--- a/docs/en/customization/plugins.md
+++ b/docs/en/customization/plugins.md
@@ -4,16 +4,16 @@ Plugins package reusable Kimi Code CLI capabilities into installable units — t
 
 ## Installation and Management
 
-Run `/plugins` in the TUI to open the plugin manager. It is a single panel with four tabs — **Installed** (manage what you have), **Official** (Kimi-maintained marketplace plugins), **Third-party** (marketplace plugins from other publishers), and **Custom** (install from a URL) — switched with `Tab` / `Shift-Tab`. Common keys:
+Run `/plugins` in the TUI to open the plugin manager. It is a single panel with four tabs — **Installed** (manage what you have), **Official** (Kimi-maintained marketplace plugins), **Curated** (third-party plugins from Kimi partners in the default marketplace), and **Custom** (install from a URL) — switched with `Tab` / `Shift-Tab`. Common keys:
 
 | Key | Action |
 | --- | --- |
-| `Tab` / `Shift-Tab` | Switch between the Installed / Official / Third-party / Custom tabs |
+| `Tab` / `Shift-Tab` | Switch between the Installed / Official / Curated / Custom tabs |
 | `Space` | Enable or disable the selected installed plugin (Installed tab) |
 | `D` | Remove the selected installed plugin (Installed tab) |
 | `M` | Manage MCP servers for the selected plugin (Installed tab) |
 | `R` | Reload `installed.json` and all manifests (Installed tab) |
-| `Enter` | Installed tab: install the available update, or view details if up to date · Official/Third-party tab: install or update · Custom tab: install |
+| `Enter` | Installed tab: install the available update, or view details if up to date · Official/Curated tab: install or update · Custom tab: install |
 | `I` | View plugin details (Installed tab) |
 | `Esc` | Go back or cancel |
 
@@ -33,7 +33,7 @@ You can also use slash commands directly:
 | `/plugins mcp enable <id> <server>` | Enable an MCP server declared by a plugin |
 | `/plugins mcp disable <id> <server>` | Disable an MCP server declared by a plugin |
 
-The **Installed** tab lists your installed plugins and shows an update badge when a newer version is available in the marketplace. When a turn that used an outdated plugin (its MCP tool or a `/<plugin>:<command>` slash command) ends, a one-time notice also points you to `/plugins` for the update; each new marketplace version is announced once. The **Official** and **Third-party** tabs list marketplace plugins by tier; the **Custom** tab installs from a URL. On the v2 engine, the Official tab also lists the built-in product capabilities (Kimi Computer Use — macOS only — and Kimi WebBridge). Their identity and install action come from the client, while the marketplace may supply a version for the normal `install` / `installed` / `update` status. Detailed runtime checks and install progress go to the log instead of changing the installed state. Pressing Enter for an install or update refreshes the binary runtime and wiring plugin together. When Kimi WebBridge is installed or updated, legacy standalone copies of its Skill are moved to `$KIMI_CODE_HOME/backups/kimi-webbridge-skills/` before the managed plugin takes over; the old files are backed up, not deleted. Marketplace catalogs load automatically when needed. Each install shows a trust badge: `kimi-official` (from an official address), `curated` (from a curated address), or `third-party` (everything else). Installing a third-party plugin (anything not from the official address, including Custom installs) first shows a confirmation prompt that defaults to cancelling, so it is only installed if you choose to trust the source.
+The **Installed** tab lists your installed plugins and shows an update badge when a newer version is available in the marketplace. When a turn that used an outdated plugin (its MCP tool or a `/<plugin>:<command>` slash command) ends, a one-time notice also points you to `/plugins` for the update; each new marketplace version is announced once. In the default marketplace, the **Official** and **Curated** tabs list Kimi-maintained and partner plugins; custom marketplaces also place their non-official entries under **Curated** without presenting them as Kimi partners. The **Custom** tab installs from a URL. On the v2 engine, the Official tab also lists the built-in product capabilities (Kimi Computer Use — macOS only — and Kimi WebBridge). Their identity and install action come from the client, while the marketplace may supply a version for the normal `install` / `installed` / `update` status. Detailed runtime checks and install progress go to the log instead of changing the installed state. Pressing Enter for an install or update refreshes the binary runtime and wiring plugin together. When Kimi WebBridge is installed or updated, legacy standalone copies of its Skill are moved to `$KIMI_CODE_HOME/backups/kimi-webbridge-skills/` before the managed plugin takes over; the old files are backed up, not deleted. Marketplace catalogs load automatically when needed. Each install shows a trust badge: `kimi-official` (from an official address), `curated` (from a curated address), or `third-party` (everything else). Installing a third-party plugin (anything not from the official address, including Custom installs) first shows a confirmation prompt that defaults to cancelling, so it is only installed if you choose to trust the source.
 
 ### Installing from GitHub
 

--- a/docs/zh/customization/plugins.md
+++ b/docs/zh/customization/plugins.md
@@ -4,16 +4,16 @@ Plugins 把可复用的 Kimi Code CLI 能力打包成可安装单元——可以
 
 ## 安装与管理
 
-在 TUI 中运行 `/plugins` 打开 plugin 管理器。它是一个面板，有四个 tab：**Installed**（管理已装的）、**Official**（Kimi 官方 marketplace plugin）、**Third-party**（第三方 marketplace plugin）、**Custom**（从 URL 安装），用 `Tab` / `Shift-Tab` 切换。常用按键：
+在 TUI 中运行 `/plugins` 打开 plugin 管理器。它是一个面板，有四个 tab：**Installed**（管理已装的）、**Official**（Kimi 官方 marketplace plugin）、**Curated**（默认 marketplace 中来自 Kimi 合作伙伴的第三方 plugin）、**Custom**（从 URL 安装），用 `Tab` / `Shift-Tab` 切换。常用按键：
 
 | 按键 | 操作 |
 | --- | --- |
-| `Tab` / `Shift-Tab` | 在 Installed / Official / Third-party / Custom 四个 tab 间切换 |
+| `Tab` / `Shift-Tab` | 在 Installed / Official / Curated / Custom 四个 tab 间切换 |
 | `Space` | 启用或禁用选中的已安装 plugin（Installed tab） |
 | `D` | 移除选中的已安装 plugin（Installed tab） |
 | `M` | 管理选中 plugin 的 MCP servers（Installed tab） |
 | `R` | 重新加载 `installed.json` 和所有 manifest（Installed tab） |
-| `Enter` | Installed tab：有更新时安装更新，否则查看 plugin 详情 · Official/Third-party tab：安装或更新 · Custom tab：安装 |
+| `Enter` | Installed tab：有更新时安装更新，否则查看 plugin 详情 · Official/Curated tab：安装或更新 · Custom tab：安装 |
 | `I` | 查看 plugin 详情（Installed tab） |
 | `Esc` | 返回或取消 |
 
@@ -33,7 +33,7 @@ Plugins 把可复用的 Kimi Code CLI 能力打包成可安装单元——可以
 | `/plugins mcp enable <id> <server>` | 启用 plugin 声明的 MCP server |
 | `/plugins mcp disable <id> <server>` | 禁用 plugin 声明的 MCP server |
 
-**Installed** tab 列出已安装的 plugin，并在 marketplace 有更新版本时显示更新徽章。当一个使用了过时 plugin（其 MCP 工具或 `/<plugin>:<command>` 斜杠命令）的 turn 结束后，也会出现一次性提示，引导你到 `/plugins` 更新；每个新的 marketplace 版本只提醒一次。**Official** 和 **Third-party** tab 按 tier 列出 marketplace plugin；**Custom** tab 从 URL 安装。在 v2 引擎下，**Official** tab 还会列出内置产品能力（Kimi Computer Use——仅限 macOS——和 Kimi WebBridge）。条目的身份和安装操作由客户端提供，marketplace 可以提供版本号，用于普通的 `install` / `installed` / `update` 状态；详细的运行时检查和安装进度写入日志，不再改变已安装状态。对可安装或可更新的条目按回车，会同时刷新二进制运行时和接线 plugin。安装或更新 Kimi WebBridge 时，旧的 standalone Skill 会先移动到 `$KIMI_CODE_HOME/backups/kimi-webbridge-skills/`，再由托管 plugin 接管；旧文件只备份，不删除。marketplace 目录会在需要时自动加载。每个安装会显示信任徽章：`kimi-official`（来自官方地址）、`curated`（来自精选地址）、`third-party`（其他所有情况）。安装第三方 plugin（任何非官方地址的 plugin，包括 Custom 安装）会先显示一个默认「取消」的确认提示，只有在你选择信任该来源后才会继续安装。
+**Installed** tab 列出已安装的 plugin，并在 marketplace 有更新版本时显示更新徽章。当一个使用了过时 plugin（其 MCP 工具或 `/<plugin>:<command>` 斜杠命令）的 turn 结束后，也会出现一次性提示，引导你到 `/plugins` 更新；每个新的 marketplace 版本只提醒一次。在默认 marketplace 中，**Official** 和 **Curated** tab 分别列出 Kimi 官方和合作伙伴 plugin；自定义 marketplace 的非官方条目也会放在 **Curated** 下，但不会显示为 Kimi 合作伙伴。**Custom** tab 从 URL 安装。在 v2 引擎下，**Official** tab 还会列出内置产品能力（Kimi Computer Use——仅限 macOS——和 Kimi WebBridge）。条目的身份和安装操作由客户端提供，marketplace 可以提供版本号，用于普通的 `install` / `installed` / `update` 状态；详细的运行时检查和安装进度写入日志，不再改变已安装状态。对可安装或可更新的条目按回车，会同时刷新二进制运行时和接线 plugin。安装或更新 Kimi WebBridge 时，旧的 standalone Skill 会先移动到 `$KIMI_CODE_HOME/backups/kimi-webbridge-skills/`，再由托管 plugin 接管；旧文件只备份，不删除。marketplace 目录会在需要时自动加载。每个安装会显示信任徽章：`kimi-official`（来自官方地址）、`curated`（来自精选地址）、`third-party`（其他所有情况）。安装第三方 plugin（任何非官方地址的 plugin，包括 Custom 安装）会先显示一个默认「取消」的确认提示，只有在你选择信任该来源后才会继续安装。
 
 ### 从 GitHub 安装
 


### PR DESCRIPTION
## Related Issue

No linked issue. This is a maintainer-requested wording update for the plugin marketplace.

## Problem

The default marketplace's `Third-party` tab groups curated partner plugins under a generic label, so users cannot tell that these entries come from Kimi partners.

## What changed

- Rename the visible `Third-party` tab to `Curated` while keeping the existing internal tab identifier and routing unchanged.
- Add a short partner description for the default marketplace while keeping custom marketplace entries neutral.
- Update focused TUI tests and the mirrored English and Chinese plugin documentation.
- Add a patch changeset for the CLI wording change.

Validation:

- `pnpm exec vitest run apps/kimi-code/test/tui/components/dialogs/plugins-selector.test.ts`
- `pnpm --filter @moonshot-ai/kimi-code typecheck`
- `pnpm exec oxlint --type-aware apps/kimi-code/src/tui/commands/plugins.ts apps/kimi-code/src/tui/components/dialogs/plugins-selector.ts apps/kimi-code/test/tui/components/dialogs/plugins-selector.test.ts`
- `pnpm -C docs build`
- `git diff --check`

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.
