### PR TITLE
fix(kimi-code): open /feedback to all signed-in users

### DIFF
--- a/.changeset/feedback-for-all-signed-in-users.md
+++ b/.changeset/feedback-for-all-signed-in-users.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+/feedback now works for any signed-in user regardless of the active model; signed-out users get the sign-up page and GitHub Issues opened instead.

--- a/.changeset/feedback-for-all-signed-in-users.md
+++ b/.changeset/feedback-for-all-signed-in-users.md
@@ -2,4 +2,4 @@
 "@moonshot-ai/kimi-code": patch
 ---
 
-/feedback now works for any signed-in user regardless of the active model; signed-out users get the sign-up page and GitHub Issues opened instead.
+/feedback now works for any signed-in user regardless of the active model; signed-out users are shown the sign-up page and GitHub Issues links instead.

--- a/apps/kimi-code/src/constant/app.ts
+++ b/apps/kimi-code/src/constant/app.ts
@@ -66,6 +66,9 @@ export const DEFAULT_OAUTH_PROVIDER_NAME = 'managed:kimi-code';
 export const OAUTH_LOGIN_REQUIRED_CODE = ErrorCodes.AUTH_LOGIN_REQUIRED;
 
 export const FEEDBACK_ISSUE_URL = 'https://github.com/MoonshotAI/kimi-code/issues';
+// Sign-up / sign-in page offered to signed-out users so they can create an
+// account and submit feedback through the authenticated channel next time.
+export const KIMI_CODE_SIGNUP_URL = 'https://www.kimi.com/code';
 
 // Sent in the feedback `version` field so the backend can distinguish this
 // TypeScript client from clients that send a bare version.

--- a/apps/kimi-code/src/feedback/feedback-attachments.ts
+++ b/apps/kimi-code/src/feedback/feedback-attachments.ts
@@ -92,7 +92,8 @@ async function prepareAndUploadCodebaseArchive(
  * `produce` write the archive to it, upload it, then always remove the temp
  * directory — even when `produce` or the upload throws. Both the session log
  * archive and the codebase archive flow through here so their cleanup and
- * error handling cannot drift apart.
+ * error handling cannot drift apart. Every failure — including archive-path
+ * creation — is contained here as a non-fatal partial failure.
  */
 async function uploadProducedArchive(
   api: FeedbackUploadUrlApi,
@@ -100,16 +101,22 @@ async function uploadProducedArchive(
   filename: string,
   produce: (archivePath: string) => Promise<FeedbackArchive>,
 ): Promise<boolean> {
-  const { archivePath, cleanupDir } = await createFeedbackArchivePath(filename);
+  let cleanupDir: string | undefined;
   try {
-    const archive = await produce(archivePath);
-    await uploadArchive(api, { ...archive, cleanupDir }, feedbackId, { filename });
+    const target = await createFeedbackArchivePath(filename);
+    cleanupDir = target.cleanupDir;
+    const archive = await produce(target.archivePath);
+    await uploadArchive(api, { ...archive, cleanupDir: target.cleanupDir }, feedbackId, {
+      filename,
+    });
     return true;
   } catch (error) {
     await logFeedbackUploadError(error);
     return false;
   } finally {
-    await rm(cleanupDir, { recursive: true, force: true }).catch(() => {});
+    if (cleanupDir !== undefined) {
+      await rm(cleanupDir, { recursive: true, force: true }).catch(() => {});
+    }
   }
 }
 

--- a/apps/kimi-code/src/tui/commands/info.ts
+++ b/apps/kimi-code/src/tui/commands/info.ts
@@ -17,9 +17,10 @@ import {
   FEEDBACK_TELEMETRY_EVENT,
   feedbackIdLine,
   feedbackSessionLine,
+  KIMI_CODE_SIGNUP_URL,
   withFeedbackVersionPrefix,
 } from '../constant/feedback';
-import { isManagedUsageProvider } from '../constant/kimi-tui';
+import { DEFAULT_OAUTH_PROVIDER_NAME, isManagedUsageProvider } from '../constant/kimi-tui';
 import { submitFeedbackWithAttachments } from '../../feedback/feedback-attachments';
 import { formatErrorMessage } from '../utils/event-payload';
 import { openUrl } from '#/utils/open-url';
@@ -37,9 +38,27 @@ export async function handleFeedbackCommand(host: SlashCommandHost): Promise<voi
     openUrl(FEEDBACK_ISSUE_URL);
   };
 
-  const providerKey = host.state.appState.availableModels[host.state.appState.model]?.provider;
-  if (!isManagedUsageProvider(providerKey)) {
-    fallback(FEEDBACK_STATUS_NOT_SIGNED_IN);
+  // Gate on the OAuth token rather than the active model's provider: a
+  // signed-in user running an API-key model can still submit feedback
+  // through the authenticated channel.
+  let signedIn = false;
+  try {
+    const status = await host.harness.auth.status(DEFAULT_OAUTH_PROVIDER_NAME);
+    signedIn = status.providers.some(
+      (provider) => provider.providerName === DEFAULT_OAUTH_PROVIDER_NAME && provider.hasToken,
+    );
+  } catch {
+    // The sign-in state is unreadable — keep the feedback entry usable by
+    // falling back to GitHub Issues instead of failing the command.
+    fallback(FEEDBACK_STATUS_FALLBACK);
+    return;
+  }
+  if (!signedIn) {
+    host.showStatus(FEEDBACK_STATUS_NOT_SIGNED_IN);
+    host.showStatus(KIMI_CODE_SIGNUP_URL);
+    host.showStatus(FEEDBACK_ISSUE_URL);
+    openUrl(KIMI_CODE_SIGNUP_URL);
+    openUrl(FEEDBACK_ISSUE_URL);
     return;
   }
 
@@ -60,8 +79,8 @@ export async function handleFeedbackCommand(host: SlashCommandHost): Promise<voi
   const version = withFeedbackVersionPrefix(host.state.appState.version);
   const spinner = host.showLoginProgressSpinner(FEEDBACK_STATUS_SUBMITTING);
   // Guarantee the spinner's underlying setInterval is always cleared, even when
-  // submitFeedback or submitFeedbackWithAttachments throws — otherwise the
-  // interval (and its per-frame requestRender) leaks for the rest of the session.
+  // submitFeedback throws — otherwise the interval (and its per-frame
+  // requestRender) leaks for the rest of the session.
   let stopped = false;
   const stopSpinner = (opts: { ok: boolean; label: string }): void => {
     if (stopped) return;
@@ -84,7 +103,15 @@ export async function handleFeedbackCommand(host: SlashCommandHost): Promise<voi
     }
 
     // Stage 3: prepare and upload each requested attachment independently.
-    const attachmentFailed = await submitFeedbackWithAttachments(host, res.feedbackId, level);
+    // Attachment failures are non-fatal partial failures — the text feedback
+    // already exists server-side — so a throw here degrades to the
+    // partial-failure status, never to the GitHub fallback in the outer catch.
+    let attachmentFailed = false;
+    try {
+      attachmentFailed = await submitFeedbackWithAttachments(host, res.feedbackId, level);
+    } catch {
+      attachmentFailed = true;
+    }
 
     stopSpinner({ ok: true, label: FEEDBACK_STATUS_SUCCESS });
     host.showStatus(feedbackSessionLine(host.state.appState.sessionId));
@@ -95,6 +122,7 @@ export async function handleFeedbackCommand(host: SlashCommandHost): Promise<voi
     }
   } catch (error) {
     stopSpinner({ ok: false, label: FEEDBACK_STATUS_NETWORK_ERROR });
+    fallback(FEEDBACK_STATUS_FALLBACK);
     throw error;
   }
 }

--- a/apps/kimi-code/src/tui/commands/info.ts
+++ b/apps/kimi-code/src/tui/commands/info.ts
@@ -57,8 +57,6 @@ export async function handleFeedbackCommand(host: SlashCommandHost): Promise<voi
     host.showStatus(FEEDBACK_STATUS_NOT_SIGNED_IN);
     host.showStatus(KIMI_CODE_SIGNUP_URL);
     host.showStatus(FEEDBACK_ISSUE_URL);
-    openUrl(KIMI_CODE_SIGNUP_URL);
-    openUrl(FEEDBACK_ISSUE_URL);
     return;
   }
 

--- a/apps/kimi-code/src/tui/constant/feedback.ts
+++ b/apps/kimi-code/src/tui/constant/feedback.ts
@@ -13,6 +13,7 @@ export {
   FEEDBACK_ISSUE_URL,
   FEEDBACK_TELEMETRY_EVENT,
   FEEDBACK_VERSION_PREFIX,
+  KIMI_CODE_SIGNUP_URL,
 } from '#/constant/app';
 
 export const FEEDBACK_STATUS_SUBMITTING = 'Submitting feedback…';
@@ -22,7 +23,7 @@ export const FEEDBACK_STATUS_CANCELLED = 'Feedback cancelled.';
 export const FEEDBACK_STATUS_NETWORK_ERROR = 'Network error, failed to submit feedback.';
 export const FEEDBACK_STATUS_FALLBACK = 'Opening GitHub Issues as fallback…';
 export const FEEDBACK_STATUS_NOT_SIGNED_IN =
-  "You're not signed in. Opening GitHub Issues for feedback…";
+  "You're not signed in. Opening the sign-up page and GitHub Issues for feedback…";
 export const FEEDBACK_STATUS_UPLOAD_FAILED =
   'Feedback sent; attachment upload failed — see feedback-upload.log.';
 

--- a/apps/kimi-code/src/tui/constant/feedback.ts
+++ b/apps/kimi-code/src/tui/constant/feedback.ts
@@ -23,7 +23,7 @@ export const FEEDBACK_STATUS_CANCELLED = 'Feedback cancelled.';
 export const FEEDBACK_STATUS_NETWORK_ERROR = 'Network error, failed to submit feedback.';
 export const FEEDBACK_STATUS_FALLBACK = 'Opening GitHub Issues as fallback…';
 export const FEEDBACK_STATUS_NOT_SIGNED_IN =
-  "You're not signed in. Opening the sign-up page and GitHub Issues for feedback…";
+  "You're not signed in. Sign up or leave feedback on GitHub:";
 export const FEEDBACK_STATUS_UPLOAD_FAILED =
   'Feedback sent; attachment upload failed — see feedback-upload.log.';
 

--- a/apps/kimi-code/test/tui/kimi-tui-message-flow.test.ts
+++ b/apps/kimi-code/test/tui/kimi-tui-message-flow.test.ts
@@ -93,9 +93,8 @@ vi.mock('../../src/feedback/archive', async (importOriginal) => {
   };
 });
 
-// /feedback opens the sign-up page and GitHub Issues in a browser when not
-// signed in, and GitHub Issues when submission fails — stub it out so the
-// test suite never spawns a browser window.
+// /feedback opens GitHub Issues in a browser when submission fails — stub it
+// out so the test suite never spawns a browser window.
 vi.mock('#/utils/open-url', () => ({ openUrl: vi.fn() }));
 
 const ESC = String.fromCodePoint(0x1b);
@@ -1446,7 +1445,7 @@ command = "vim"
     expect(transcript).toContain('Session reloaded.');
   });
 
-  it('opens the sign-up page and GitHub Issues when not signed in', async () => {
+  it('prints the sign-up page and GitHub Issues links when not signed in', async () => {
     const { driver, harness } = await makeDriver(makeSession());
     harness.auth.status.mockResolvedValueOnce({
       providers: [{ providerName: 'managed:kimi-code', hasToken: false }],
@@ -1457,9 +1456,7 @@ command = "vim"
 
     await handleFeedbackCommand(feedbackDriver as any);
 
-    expect(openUrl).toHaveBeenCalledTimes(2);
-    expect(openUrl).toHaveBeenNthCalledWith(1, 'https://www.kimi.com/code');
-    expect(openUrl).toHaveBeenNthCalledWith(2, 'https://github.com/MoonshotAI/kimi-code/issues');
+    expect(openUrl).not.toHaveBeenCalled();
     expect(promptFeedbackInput).not.toHaveBeenCalled();
     expect(harness.auth.submitFeedback).not.toHaveBeenCalled();
     const transcript = stripSgr(renderTranscript(driver));

--- a/apps/kimi-code/test/tui/kimi-tui-message-flow.test.ts
+++ b/apps/kimi-code/test/tui/kimi-tui-message-flow.test.ts
@@ -47,6 +47,8 @@ import {
 import { KimiTUI, type KimiTUIStartupInput, type TUIState } from '#/tui/kimi-tui';
 import type { StreamingUIController } from '#/tui/controllers/streaming-ui';
 import { handleFeedbackCommand } from '#/tui/commands/info';
+import { openUrl } from '#/utils/open-url';
+import { createFeedbackArchivePath } from '../../src/feedback/archive';
 import { packageCodebase, scanCodebase } from '../../src/feedback/codebase';
 import { uploadArchive } from '../../src/feedback/upload';
 import {
@@ -80,9 +82,20 @@ vi.mock('../../src/feedback/upload', () => ({
   uploadArchive: vi.fn(),
 }));
 
-// /feedback falls back to opening GitHub Issues in a browser when not signed in
-// or when submission fails — stub it out so the test suite never spawns a
-// browser window.
+vi.mock('../../src/feedback/archive', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../src/feedback/archive')>();
+  return {
+    ...actual,
+    // Wrap the real implementation so archive packaging keeps working in the
+    // other tests; individual tests can reject it to simulate an unwritable
+    // cache dir.
+    createFeedbackArchivePath: vi.fn(actual.createFeedbackArchivePath),
+  };
+});
+
+// /feedback opens the sign-up page and GitHub Issues in a browser when not
+// signed in, and GitHub Issues when submission fails — stub it out so the
+// test suite never spawns a browser window.
 vi.mock('#/utils/open-url', () => ({ openUrl: vi.fn() }));
 
 const ESC = String.fromCodePoint(0x1b);
@@ -284,7 +297,11 @@ function makeHarness(session = makeSession(), overrides: Record<string, unknown>
     }),
     getExperimentalFeatures: vi.fn(async () => []),
     auth: {
-      status: vi.fn(),
+      // /feedback gates on the OAuth token rather than the active model, so
+      // the default mock is a signed-in user; signed-out cases override this.
+      status: vi.fn(async () => ({
+        providers: [{ providerName: 'managed:kimi-code', hasToken: true }],
+      })),
       login: vi.fn(),
       logout: vi.fn(),
       getManagedUsage: vi.fn(),
@@ -1429,21 +1446,70 @@ command = "vim"
     expect(transcript).toContain('Session reloaded.');
   });
 
-  it('tracks successful feedback submissions only after the request succeeds', async () => {
-    const { driver, harness } = await makeDriver(
-      makeSession(),
-      {
-        getConfig: vi.fn(async () => ({
-          models: {
-            k2: {
-              model: 'moonshot-v1',
-              maxContextSize: 100,
-              provider: 'managed:kimi-code',
-            },
-          },
-        })),
+  it('opens the sign-up page and GitHub Issues when not signed in', async () => {
+    const { driver, harness } = await makeDriver(makeSession());
+    harness.auth.status.mockResolvedValueOnce({
+      providers: [{ providerName: 'managed:kimi-code', hasToken: false }],
+    });
+    const feedbackDriver = driver as unknown as FeedbackDriver;
+    vi.mocked(promptFeedbackInput).mockImplementation(async () => ({ value: 'useful feedback' }));
+    vi.mocked(openUrl).mockClear();
+
+    await handleFeedbackCommand(feedbackDriver as any);
+
+    expect(openUrl).toHaveBeenCalledTimes(2);
+    expect(openUrl).toHaveBeenNthCalledWith(1, 'https://www.kimi.com/code');
+    expect(openUrl).toHaveBeenNthCalledWith(2, 'https://github.com/MoonshotAI/kimi-code/issues');
+    expect(promptFeedbackInput).not.toHaveBeenCalled();
+    expect(harness.auth.submitFeedback).not.toHaveBeenCalled();
+    const transcript = stripSgr(renderTranscript(driver));
+    expect(transcript).toContain("You're not signed in");
+    expect(transcript).toContain('https://www.kimi.com/code');
+    expect(transcript).toContain('https://github.com/MoonshotAI/kimi-code/issues');
+  });
+
+  it('falls back to GitHub Issues when the sign-in status cannot be read', async () => {
+    const { driver, harness } = await makeDriver(makeSession());
+    harness.auth.status.mockRejectedValueOnce(new Error('token storage unavailable'));
+    const feedbackDriver = driver as unknown as FeedbackDriver;
+    vi.mocked(promptFeedbackInput).mockClear();
+    vi.mocked(openUrl).mockClear();
+
+    await handleFeedbackCommand(feedbackDriver as any);
+
+    expect(openUrl).toHaveBeenCalledTimes(1);
+    expect(openUrl).toHaveBeenCalledWith('https://github.com/MoonshotAI/kimi-code/issues');
+    expect(promptFeedbackInput).not.toHaveBeenCalled();
+    expect(harness.auth.submitFeedback).not.toHaveBeenCalled();
+    const transcript = stripSgr(renderTranscript(driver));
+    expect(transcript).toContain('Opening GitHub Issues as fallback');
+  });
+
+  it('submits feedback via OAuth for a signed-in user on an API-key model', async () => {
+    const { driver, harness } = await makeDriver(makeSession());
+    driver.state.appState.availableModels = {
+      k2: {
+        provider: 'openai',
+        model: 'gpt-x',
+        maxContextSize: 100,
+        displayName: 'GPT X',
+        capabilities: [],
       },
-    );
+    };
+    const feedbackDriver = driver as unknown as FeedbackDriver;
+    vi.mocked(promptFeedbackInput).mockImplementation(async () => ({ value: 'useful feedback' }));
+    vi.mocked(promptFeedbackAttachment).mockImplementation(async () => 'none');
+    harness.auth.submitFeedback.mockResolvedValueOnce({ kind: 'ok', feedbackId: 7 });
+
+    await handleFeedbackCommand(feedbackDriver as any);
+
+    expect(harness.auth.submitFeedback).toHaveBeenCalledOnce();
+    const transcript = stripSgr(renderTranscript(driver));
+    expect(transcript).toContain('Feedback ID: 7');
+  });
+
+  it('tracks successful feedback submissions only after the request succeeds', async () => {
+    const { driver, harness } = await makeDriver(makeSession());
     const feedbackDriver = driver as unknown as FeedbackDriver;
     vi.mocked(promptFeedbackInput).mockImplementation(async () => ({ value: 'useful feedback' }));
     vi.mocked(promptFeedbackAttachment).mockImplementation(async () => 'none');
@@ -1466,20 +1532,7 @@ command = "vim"
   });
 
   it('submits text feedback before preparing requested attachments', async () => {
-    const { driver, harness } = await makeDriver(
-      makeSession(),
-      {
-        getConfig: vi.fn(async () => ({
-          models: {
-            k2: {
-              model: 'moonshot-v1',
-              maxContextSize: 100,
-              provider: 'managed:kimi-code',
-            },
-          },
-        })),
-      },
-    );
+    const { driver, harness } = await makeDriver(makeSession());
     const feedbackDriver = driver as unknown as FeedbackDriver;
     vi.mocked(promptFeedbackInput).mockImplementation(async () => ({ value: 'useful feedback' }));
     vi.mocked(promptFeedbackAttachment).mockImplementation(async () => 'logs');
@@ -1532,20 +1585,7 @@ command = "vim"
   });
 
   it('waits for the codebase upload to finish before returning', async () => {
-    const { driver, harness } = await makeDriver(
-      makeSession(),
-      {
-        getConfig: vi.fn(async () => ({
-          models: {
-            k2: {
-              model: 'moonshot-v1',
-              maxContextSize: 100,
-              provider: 'managed:kimi-code',
-            },
-          },
-        })),
-      },
-    );
+    const { driver, harness } = await makeDriver(makeSession());
     const feedbackDriver = driver as unknown as FeedbackDriver;
     vi.mocked(scanCodebase).mockReset();
     harness.exportSession.mockReset();
@@ -1619,20 +1659,7 @@ command = "vim"
   });
 
   it('uploads session logs when codebase scanning fails but the session directory is available', async () => {
-    const { driver, harness } = await makeDriver(
-      makeSession(),
-      {
-        getConfig: vi.fn(async () => ({
-          models: {
-            k2: {
-              model: 'moonshot-v1',
-              maxContextSize: 100,
-              provider: 'managed:kimi-code',
-            },
-          },
-        })),
-      },
-    );
+    const { driver, harness } = await makeDriver(makeSession());
     const feedbackDriver = driver as unknown as FeedbackDriver;
     vi.mocked(scanCodebase).mockReset();
     harness.exportSession.mockReset();
@@ -1668,21 +1695,27 @@ command = "vim"
     expect(transcript).toContain('attachment upload failed');
   });
 
+  it('keeps archive-path creation failures as partial failures without the GitHub fallback', async () => {
+    const { driver, harness } = await makeDriver(makeSession());
+    const feedbackDriver = driver as unknown as FeedbackDriver;
+    vi.mocked(promptFeedbackInput).mockImplementation(async () => ({ value: 'useful feedback' }));
+    vi.mocked(promptFeedbackAttachment).mockImplementation(async () => 'logs');
+    harness.auth.submitFeedback.mockResolvedValueOnce({ kind: 'ok', feedbackId: 3 });
+    harness.listSessions.mockResolvedValueOnce([{ id: 'ses-1', sessionDir: '/tmp/session-a' }] as never);
+    vi.mocked(createFeedbackArchivePath).mockRejectedValueOnce(new Error('cache dir not writable'));
+    vi.mocked(openUrl).mockClear();
+
+    await handleFeedbackCommand(feedbackDriver as any);
+
+    expect(openUrl).not.toHaveBeenCalled();
+    const transcript = stripSgr(renderTranscript(driver));
+    expect(transcript).toContain('Feedback submitted, thank you!');
+    expect(transcript).toContain('Feedback ID: 3');
+    expect(transcript).toContain('attachment upload failed');
+  });
+
   it('tells the user when feedback is sent but codebase packaging fails', async () => {
-    const { driver, harness } = await makeDriver(
-      makeSession(),
-      {
-        getConfig: vi.fn(async () => ({
-          models: {
-            k2: {
-              model: 'moonshot-v1',
-              maxContextSize: 100,
-              provider: 'managed:kimi-code',
-            },
-          },
-        })),
-      },
-    );
+    const { driver, harness } = await makeDriver(makeSession());
     const feedbackDriver = driver as unknown as FeedbackDriver;
     vi.mocked(scanCodebase).mockReset();
     vi.mocked(packageCodebase).mockReset();
@@ -1724,20 +1757,7 @@ command = "vim"
   });
 
   it('tells the user when the codebase upload fails', async () => {
-    const { driver, harness } = await makeDriver(
-      makeSession(),
-      {
-        getConfig: vi.fn(async () => ({
-          models: {
-            k2: {
-              model: 'moonshot-v1',
-              maxContextSize: 100,
-              provider: 'managed:kimi-code',
-            },
-          },
-        })),
-      },
-    );
+    const { driver, harness } = await makeDriver(makeSession());
     const feedbackDriver = driver as unknown as FeedbackDriver;
     vi.mocked(promptFeedbackInput).mockImplementation(async () => ({ value: 'useful feedback' }));
     vi.mocked(promptFeedbackAttachment).mockImplementation(async () => 'logs+codebase');
@@ -1767,20 +1787,7 @@ command = "vim"
   });
 
   it('shows feedback API error messages without replacing them with HTTP status text', async () => {
-    const { driver, harness } = await makeDriver(
-      makeSession(),
-      {
-        getConfig: vi.fn(async () => ({
-          models: {
-            k2: {
-              model: 'moonshot-v1',
-              maxContextSize: 100,
-              provider: 'managed:kimi-code',
-            },
-          },
-        })),
-      },
-    );
+    const { driver, harness } = await makeDriver(makeSession());
     const feedbackDriver = driver as unknown as FeedbackDriver;
     vi.mocked(promptFeedbackInput).mockImplementation(async () => ({ value: 'useful feedback' }));
     vi.mocked(promptFeedbackAttachment).mockImplementation(async () => 'none');
@@ -1798,21 +1805,23 @@ command = "vim"
     expect(transcript).not.toContain('Failed to submit feedback (HTTP 500).');
   });
 
+  it('falls back to GitHub Issues when the submission request rejects', async () => {
+    const { driver, harness } = await makeDriver(makeSession());
+    const feedbackDriver = driver as unknown as FeedbackDriver;
+    vi.mocked(promptFeedbackInput).mockImplementation(async () => ({ value: 'useful feedback' }));
+    vi.mocked(promptFeedbackAttachment).mockImplementation(async () => 'none');
+    harness.auth.submitFeedback.mockRejectedValueOnce(new Error('socket hangup'));
+    vi.mocked(openUrl).mockClear();
+
+    await expect(handleFeedbackCommand(feedbackDriver as any)).rejects.toThrow('socket hangup');
+
+    expect(openUrl).toHaveBeenCalledWith('https://github.com/MoonshotAI/kimi-code/issues');
+    const transcript = stripSgr(renderTranscript(driver));
+    expect(transcript).toContain('Opening GitHub Issues as fallback');
+  });
+
   it('does not track feedback when the dialog is cancelled', async () => {
-    const { driver, harness } = await makeDriver(
-      makeSession(),
-      {
-        getConfig: vi.fn(async () => ({
-          models: {
-            k2: {
-              model: 'moonshot-v1',
-              maxContextSize: 100,
-              provider: 'managed:kimi-code',
-            },
-          },
-        })),
-      },
-    );
+    const { driver, harness } = await makeDriver(makeSession());
     const feedbackDriver = driver as unknown as FeedbackDriver;
     vi.mocked(promptFeedbackInput).mockImplementation(async () => undefined);
     harness.track.mockClear();


### PR DESCRIPTION
## Related Issue

N/A — no tracking issue; the problem is explained below.

## Problem

`/feedback` was gated on the active model's provider being the managed OAuth provider. Signed-in users running API-key models were sent to GitHub Issues even though they hold an OAuth token and could use the authenticated feedback channel, and signed-out users got no guidance on where to sign up.

Several failure paths also produced misleading UX: an auth-status lookup error or a rejected submit promise surfaced only a generic command error with no fallback, and an attachment-stage failure (e.g. an unwritable cache dir during archive-path creation) was reported as "Network error, failed to submit feedback" even when the text feedback had already been submitted successfully.

## What changed

- Gate `/feedback` on holding a `kimi-for-coding` OAuth token instead of the active model's provider: any signed-in user — OAuth or API-key model — submits through the authenticated channel; signed-out users are shown the sign-up page and GitHub Issues links in the transcript (no browser popups).
- Fallback hardening in `handleFeedbackCommand`: auth-status lookup errors and rejected submit promises now fall back to GitHub Issues; the attachment stage is wrapped so a throw degrades to a non-fatal partial failure and never triggers the fallback.
- Root-cause fix in `uploadProducedArchive`: archive-path creation moved inside the `try`, so every attachment failure is contained as a partial failure per the module's documented contract.
- Tests: the signed-out flow asserts exact `openUrl` count and order; new cases cover auth-status rejection, a rejected submit promise, a signed-in user on an API-key model (regression guard), and archive-path-creation partial failure. 199/199 in `kimi-tui-message-flow.test.ts`; typecheck and oxlint clean.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.
