### PR TITLE
fix(kosong): abort stalled model streams

### DIFF
--- a/.changeset/stop-stalled-model-streams.md
+++ b/.changeset/stop-stalled-model-streams.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Abort and retry model streams that stop producing data instead of leaving sessions hanging indefinitely.

--- a/packages/agent-core-v2/src/kosong/contract/generate.ts
+++ b/packages/agent-core-v2/src/kosong/contract/generate.ts
@@ -5,11 +5,15 @@
  * `ChatProvider.generate` and normalize the event stream": it merges streamed
  * deltas into a complete assistant `Message`, fires the caller's callbacks,
  * enforces the abort contract (standard abort DOMException, stream cancelled
- * on abort), and rejects empty or thinking-only responses with
- * `APIEmptyResponseError`.
+ * on abort), bounds response-header and between-part idle waits, and rejects
+ * empty or thinking-only responses with `APIEmptyResponseError`.
  */
 
-import { APIEmptyResponseError, createAbortError } from './errors';
+import {
+  APIEmptyResponseError,
+  APITimeoutError,
+  createAbortError,
+} from './errors';
 import {
   isContentPart,
   isToolCall,
@@ -24,6 +28,23 @@ import type { Tool } from './tool';
 import type { TokenUsage } from './usage';
 
 type StoredToolCall = Omit<ToolCall, '_streamIndex'>;
+
+export const DEFAULT_RESPONSE_TIMEOUT_MS = 300_000;
+export const DEFAULT_STREAM_IDLE_TIMEOUT_MS = 30_000;
+
+const MAX_TIMER_DELAY_MS = 0x7fffffff;
+const NEVER_ACTIVITY = new Promise<never>(() => {});
+
+export type ScheduleStreamIdleTimeout = (
+  callback: () => void,
+  timeoutMs: number,
+) => () => void;
+
+export interface GenerateDriverOptions extends GenerateOptions {
+  readonly responseTimeoutMs?: number;
+  readonly streamIdleTimeoutMs?: number;
+  readonly scheduleStreamIdleTimeout?: ScheduleStreamIdleTimeout;
+}
 
 export interface GenerateResult {
   readonly id: string | null;
@@ -45,7 +66,7 @@ export async function generate(
   tools: Tool[],
   history: Message[],
   callbacks?: GenerateCallbacks,
-  options?: GenerateOptions,
+  options?: GenerateDriverOptions,
 ): Promise<GenerateResult> {
   const message: Message = { role: 'assistant', content: [], toolCalls: [] };
   let pendingPart: StreamedMessagePart | null = null;
@@ -60,20 +81,84 @@ export async function generate(
     ? tools.filter((tool) => tool.deferred !== true)
     : tools;
 
+  const responseTimeoutMs = options?.responseTimeoutMs ?? DEFAULT_RESPONSE_TIMEOUT_MS;
+  const streamIdleTimeoutMs = options?.streamIdleTimeoutMs ?? DEFAULT_STREAM_IDLE_TIMEOUT_MS;
+  const scheduleIdleTimeout =
+    options?.scheduleStreamIdleTimeout ?? scheduleStreamIdleTimeout;
+  const requestController = new AbortController();
+  const requestSignal =
+    options?.signal === undefined
+      ? requestController.signal
+      : AbortSignal.any([options.signal, requestController.signal]);
+  let streamCancelled = false;
+  const stopRequest = (stream?: StreamedMessage, iterator?: AsyncIterator<StreamedMessagePart>) => {
+    if (!requestController.signal.aborted) {
+      requestController.abort(createAbortError());
+    }
+    if (stream === undefined || streamCancelled) return;
+    streamCancelled = true;
+    cancelStream(stream, iterator);
+  };
+
   options?.onRequestStart?.();
-  const stream = await provider.generate(systemPrompt, wireTools, history, options);
+  const streamPromise = provider.generate(
+    systemPrompt,
+    wireTools,
+    history,
+    toProviderOptions(options, requestSignal),
+  );
+  void streamPromise.then(
+    (lateStream) => {
+      if (requestSignal.aborted) {
+        stopRequest(lateStream);
+      }
+    },
+    () => {},
+  );
+  const stream = await waitForActivity(
+    streamPromise,
+    {
+      timeoutMs: responseTimeoutMs,
+      scheduleTimeout: scheduleIdleTimeout,
+      signal: options?.signal,
+      stop: stopRequest,
+      timeoutError: idleTimeoutError(provider, responseTimeoutMs, 'response'),
+    },
+  );
   if (stream.traceId !== undefined) {
     options?.onTraceId?.(stream.traceId);
   }
 
-  await throwIfAborted(options?.signal, stream);
+  throwIfAborted(options?.signal, () => {
+    stopRequest(stream);
+  });
 
   let serverDecodeMs = 0;
   let clientConsumeMs = 0;
   let firstPartAt: number | undefined;
   let lastResumeAt = 0;
+  let receivedPart = false;
+  const iterator = stream[Symbol.asyncIterator]();
+  const stopStream = () => {
+    stopRequest(stream, iterator);
+  };
 
-  for await (const part of stream) {
+  for (;;) {
+    const timeoutMs = receivedPart ? streamIdleTimeoutMs : responseTimeoutMs;
+    const next = await waitForActivity(Promise.resolve(iterator.next()), {
+      timeoutMs,
+      scheduleTimeout: scheduleIdleTimeout,
+      signal: options?.signal,
+      stop: stopStream,
+      timeoutError: idleTimeoutError(
+        provider,
+        timeoutMs,
+        receivedPart ? 'stream' : 'firstPart',
+      ),
+    });
+    if (next.done === true) break;
+    receivedPart = true;
+    const part = next.value;
     const arrivedAt = Date.now();
     if (firstPartAt === undefined) {
       firstPartAt = arrivedAt;
@@ -82,11 +167,11 @@ export async function generate(
     }
 
     try {
-      await throwIfAborted(options?.signal, stream);
+      throwIfAborted(options?.signal, stopStream);
 
       if (callbacks?.onMessagePart !== undefined) {
         await callbacks.onMessagePart(deepCopyPart(part));
-        await throwIfAborted(options?.signal, stream);
+        throwIfAborted(options?.signal, stopStream);
       }
 
       if (
@@ -113,13 +198,16 @@ export async function generate(
         flushPart(message, pendingPart, toolCallIndexMap);
         pendingPart = part;
       }
+    } catch (error) {
+      stopStream();
+      throw error;
     } finally {
       lastResumeAt = Date.now();
       clientConsumeMs += lastResumeAt - arrivedAt;
     }
   }
 
-  await throwIfAborted(options?.signal, stream);
+  throwIfAborted(options?.signal, stopStream);
   if (firstPartAt !== undefined) {
     serverDecodeMs += Date.now() - lastResumeAt;
   }
@@ -163,7 +251,7 @@ export async function generate(
 
   if (callbacks?.onToolCall !== undefined) {
     for (const toolCall of message.toolCalls) {
-      await throwIfAborted(options?.signal, stream);
+      throwIfAborted(options?.signal, stopStream);
       await callbacks.onToolCall(toolCall);
     }
   }
@@ -186,28 +274,126 @@ type CancelableStream = StreamedMessage & {
   return?: () => unknown;
 };
 
-async function cancelStream(stream: StreamedMessage): Promise<void> {
+function cancelStream(
+  stream?: StreamedMessage,
+  iterator?: AsyncIterator<StreamedMessagePart>,
+): void {
+  if (stream === undefined) return;
   const cancelable = stream as CancelableStream;
+  invokeCancellation(() => cancelable.cancel?.());
+  if (iterator !== undefined) {
+    invokeCancellation(() => iterator.return?.());
+  }
+  if ((iterator as unknown) !== stream) {
+    invokeCancellation(() => cancelable.return?.());
+  }
+}
 
+function invokeCancellation(cancel: () => unknown): void {
   try {
-    await cancelable.cancel?.();
-  } catch {}
-
-  try {
-    await cancelable.return?.();
+    void Promise.resolve(cancel()).catch(() => {});
   } catch {}
 }
 
-async function throwIfAborted(signal?: AbortSignal, stream?: StreamedMessage): Promise<void> {
+function throwIfAborted(
+  signal: AbortSignal | undefined,
+  stop: () => void,
+): void {
   if (!signal?.aborted) {
     return;
   }
 
-  if (stream !== undefined) {
-    await cancelStream(stream);
+  stop();
+  throw createAbortError();
+}
+
+interface ActivityWaitOptions {
+  readonly timeoutMs: number;
+  readonly scheduleTimeout: ScheduleStreamIdleTimeout;
+  readonly signal?: AbortSignal;
+  readonly stop: () => void;
+  readonly timeoutError: APITimeoutError;
+}
+
+async function waitForActivity<T>(
+  work: Promise<T>,
+  options: ActivityWaitOptions,
+): Promise<T> {
+  if (options.signal?.aborted === true) {
+    options.stop();
+    throw createAbortError();
   }
 
-  throw createAbortError();
+  const abortError = createAbortError();
+  let clearTimeout = () => {};
+  const timeout: Promise<never> =
+    options.timeoutMs <= 0
+      ? NEVER_ACTIVITY
+      : new Promise((_resolve, reject) => {
+          clearTimeout = options.scheduleTimeout(() => {
+            reject(options.timeoutError);
+          }, Math.min(options.timeoutMs, MAX_TIMER_DELAY_MS));
+        });
+
+  let removeAbortListener = () => {};
+  const aborted: Promise<never> =
+    options.signal === undefined
+      ? NEVER_ACTIVITY
+      : new Promise((_resolve, reject) => {
+          const onAbort = () => {
+            reject(abortError);
+          };
+          options.signal?.addEventListener('abort', onAbort, { once: true });
+          removeAbortListener = () => options.signal?.removeEventListener('abort', onAbort);
+        });
+
+  try {
+    return await Promise.race([work, timeout, aborted]);
+  } catch (error) {
+    if (error === abortError || error === options.timeoutError) {
+      options.stop();
+    }
+    throw error;
+  } finally {
+    clearTimeout();
+    removeAbortListener();
+  }
+}
+
+function scheduleStreamIdleTimeout(callback: () => void, timeoutMs: number): () => void {
+  const handle = setTimeout(callback, timeoutMs);
+  return () => {
+    clearTimeout(handle);
+  };
+}
+
+function toProviderOptions(
+  options: GenerateDriverOptions | undefined,
+  signal: AbortSignal,
+): GenerateOptions {
+  const {
+    responseTimeoutMs: _responseTimeoutMs,
+    streamIdleTimeoutMs: _streamIdleTimeoutMs,
+    scheduleStreamIdleTimeout: _scheduleStreamIdleTimeout,
+    ...providerOptions
+  } = options ?? {};
+  return { ...providerOptions, signal };
+}
+
+function idleTimeoutError(
+  provider: ChatProvider,
+  timeoutMs: number,
+  phase: 'response' | 'firstPart' | 'stream',
+): APITimeoutError {
+  const activity =
+    phase === 'response'
+      ? 'response headers'
+      : phase === 'firstPart'
+        ? 'the first streamed response part'
+        : 'the next streamed response part';
+  return new APITimeoutError(
+    `Timed out after ${String(timeoutMs)}ms waiting for ${activity} from provider "${provider.name}" model "${provider.modelName}".`,
+  );
 }
 
 function isPendingToolCallAtIndex(

--- a/packages/agent-core-v2/test/kosong/contract/generate.test.ts
+++ b/packages/agent-core-v2/test/kosong/contract/generate.test.ts
@@ -3,14 +3,21 @@
  *
  * Covers event normalization (text/think deltas merged, tool-call argument
  * deltas routed by stream index), the empty/thinking-only response
- * rejections, the abort contract (standard DOMException, stream cancelled),
- * callback plumbing, and per-turn intent passthrough via GenerateOptions.
+ * rejections, the abort and idle-deadline contracts, callback plumbing, and
+ * per-turn intent passthrough via GenerateOptions. Provider streams and the
+ * timeout scheduler are the only stubbed external boundaries. Run with
+ * `pnpm --filter @moonshot-ai/agent-core-v2 test --
+ * test/kosong/contract/generate.test.ts`.
  */
 
 import { describe, expect, it, vi } from 'vitest';
 
-import { APIEmptyResponseError } from '#/kosong/contract/errors';
-import { generate, type GenerateResult } from '#/kosong/contract/generate';
+import { APIEmptyResponseError, APITimeoutError } from '#/kosong/contract/errors';
+import {
+  generate,
+  type GenerateResult,
+  type ScheduleStreamIdleTimeout,
+} from '#/kosong/contract/generate';
 import type { Message, StreamedMessagePart, ToolCall } from '#/kosong/contract/message';
 import type {
   ChatProvider,
@@ -22,6 +29,44 @@ import type { Tool } from '#/kosong/contract/tool';
 import type { TokenUsage } from '#/kosong/contract/usage';
 
 const USAGE: TokenUsage = { inputOther: 10, output: 5, inputCacheRead: 2, inputCacheCreation: 1 };
+
+interface ManualTimeoutScheduler {
+  readonly schedule: ScheduleStreamIdleTimeout;
+  readonly lastDelayMs: () => number | undefined;
+  readonly waitUntilScheduled: () => Promise<void>;
+  readonly fire: () => void;
+}
+
+function createManualTimeoutScheduler(): ManualTimeoutScheduler {
+  let pending: (() => void) | undefined;
+  let delayMs: number | undefined;
+  let resolveScheduled: (() => void) | undefined;
+
+  return {
+    schedule: (callback, timeoutMs) => {
+      pending = callback;
+      delayMs = timeoutMs;
+      resolveScheduled?.();
+      resolveScheduled = undefined;
+      return () => {
+        if (pending === callback) pending = undefined;
+      };
+    },
+    lastDelayMs: () => delayMs,
+    waitUntilScheduled: () =>
+      pending === undefined
+        ? new Promise((resolve) => {
+            resolveScheduled = resolve;
+          })
+        : Promise.resolve(),
+    fire: () => {
+      const callback = pending;
+      pending = undefined;
+      if (callback === undefined) throw new Error('No idle timeout is scheduled.');
+      callback();
+    },
+  };
+}
 
 class FakeStreamedMessage implements StreamedMessage {
   readonly id: string | null = 'gen-1';
@@ -53,6 +98,37 @@ class FakeStreamedMessage implements StreamedMessage {
 
   cancel(): void {
     this.cancelCalls++;
+  }
+}
+
+class StallingStreamedMessage implements StreamedMessage {
+  readonly id: string | null = null;
+  readonly usage: TokenUsage | null = null;
+  readonly finishReason: FinishReason | null = null;
+  readonly rawFinishReason: string | null = null;
+  readonly stalled: Promise<void>;
+  readonly cancel = vi.fn();
+  private markStalled = () => {};
+
+  constructor() {
+    this.stalled = new Promise((resolve) => {
+      this.markStalled = resolve;
+    });
+  }
+
+  [Symbol.asyncIterator](): AsyncIterator<StreamedMessagePart> {
+    let emitted = false;
+    return {
+      next: () => {
+        if (!emitted) {
+          emitted = true;
+          return Promise.resolve({ done: false, value: { type: 'text', text: 'first' } });
+        }
+        this.markStalled();
+        return new Promise(() => {});
+      },
+      return: () => Promise.resolve({ done: true, value: undefined }),
+    };
   }
 }
 
@@ -297,6 +373,88 @@ describe('generate() abort contract', () => {
     expect((caught as DOMException).name).toBe('AbortError');
     expect(stream.cancelCalls).toBeGreaterThan(0);
   });
+
+  it('cancels the provider stream when onMessagePart throws', async () => {
+    const stream = new StallingStreamedMessage();
+    const { provider } = createFakeProvider(stream);
+
+    await expect(
+      generate(provider, SYSTEM_PROMPT, NO_TOOLS, HISTORY, {
+        onMessagePart: () => {
+          throw new Error('callback failed');
+        },
+      }),
+    ).rejects.toThrow('callback failed');
+
+    expect(stream.cancel).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('generate() idle deadline', () => {
+  it('aborts the provider request with APITimeoutError when response headers remain idle', async () => {
+    const scheduler = createManualTimeoutScheduler();
+    let providerSignal: AbortSignal | undefined;
+    const provider: ChatProvider = {
+      name: 'fake',
+      modelName: 'fake-model',
+      thinkingEffort: null,
+      generate: async (_systemPrompt, _tools, _history, options) => {
+        providerSignal = options?.signal;
+        return new Promise(() => {});
+      },
+    };
+
+    const pending = generate(provider, SYSTEM_PROMPT, NO_TOOLS, HISTORY, undefined, {
+      responseTimeoutMs: 321,
+      scheduleStreamIdleTimeout: scheduler.schedule,
+    });
+    await scheduler.waitUntilScheduled();
+    scheduler.fire();
+    const caughtError = await pending.catch((error: unknown) => error);
+
+    expect(caughtError).toBeInstanceOf(APITimeoutError);
+    expect(caughtError).toMatchObject({ message: expect.stringContaining('321ms') });
+    expect(providerSignal?.aborted).toBe(true);
+    expect(scheduler.lastDelayMs()).toBe(321);
+  });
+
+  it('cancels the stream when the next response part exceeds the idle deadline', async () => {
+    const scheduler = createManualTimeoutScheduler();
+    const stream = new StallingStreamedMessage();
+    const { provider } = createFakeProvider(stream);
+
+    const pending = generate(provider, SYSTEM_PROMPT, NO_TOOLS, HISTORY, undefined, {
+      streamIdleTimeoutMs: 654,
+      scheduleStreamIdleTimeout: scheduler.schedule,
+    });
+    await stream.stalled;
+    await scheduler.waitUntilScheduled();
+    scheduler.fire();
+    const caughtError = await pending.catch((error: unknown) => error);
+
+    expect(caughtError).toBeInstanceOf(APITimeoutError);
+    expect(stream.cancel).toHaveBeenCalledTimes(1);
+    expect(scheduler.lastDelayMs()).toBe(654);
+  });
+
+  it('preserves AbortError when the user cancels a stalled response stream', async () => {
+    const scheduler = createManualTimeoutScheduler();
+    const stream = new StallingStreamedMessage();
+    const { provider } = createFakeProvider(stream);
+    const controller = new AbortController();
+
+    const pending = generate(provider, SYSTEM_PROMPT, NO_TOOLS, HISTORY, undefined, {
+      signal: controller.signal,
+      streamIdleTimeoutMs: 987,
+      scheduleStreamIdleTimeout: scheduler.schedule,
+    });
+    await stream.stalled;
+    controller.abort();
+    const caughtError = await pending.catch((error: unknown) => error);
+
+    expect(caughtError).toMatchObject({ name: 'AbortError' });
+    expect(caughtError).not.toBeInstanceOf(APITimeoutError);
+  });
 });
 
 describe('generate() per-turn intent passthrough', () => {
@@ -315,6 +473,6 @@ describe('generate() per-turn intent passthrough', () => {
     await generate(provider, SYSTEM_PROMPT, NO_TOOLS, HISTORY, undefined, options);
 
     expect(generateSpy).toHaveBeenCalledTimes(1);
-    expect(generateSpy.mock.calls[0]?.[3]).toBe(options);
+    expect(generateSpy.mock.calls[0]?.[3]).toMatchObject(options);
   });
 });

--- a/packages/agent-core-v2/test/kosong/model/modelRequester.test.ts
+++ b/packages/agent-core-v2/test/kosong/model/modelRequester.test.ts
@@ -3,9 +3,9 @@
  * ChatProvider (the adapter registry is stubbed to return it, so no wire I/O
  * happens):
  *
- *  - `ModelRequestParams` map 1:1 onto `GenerateOptions` (cacheKey / sampling /
- *    thinking effort+keep / budget + window-clamp companions), with auth
- *    threaded per attempt;
+ *  - `ModelRequestParams` intent fields map onto `GenerateOptions` (cacheKey /
+ *    sampling / thinking effort+keep / budget + window-clamp companions),
+ *    with auth and caller cancellation threaded per attempt;
  *  - the event stream carries parts, usage, finish, and timing;
  *  - a 401 against a refreshable auth provider forces one token refresh and
  *    exactly one replay; a 401 that survives the replay surfaces as
@@ -144,15 +144,14 @@ async function collect(stream: AsyncIterable<ModelRequestEvent>): Promise<ModelR
 const INPUT = { systemPrompt: 'sys', tools: [], messages: [] };
 
 describe('ModelRequesterImpl request execution', () => {
-  it('maps ModelRequestParams onto GenerateOptions 1:1', async () => {
+  it('maps ModelRequestParams onto provider options for one request', async () => {
     const provider = new FakeChatProvider();
     const requester = new ModelRequesterImpl(modelWith(staticAuth('sk-1')), registryReturning(provider));
-    const signal = AbortSignal.timeout(1000);
 
     await collect(
       requester.request(
         { ...INPUT, responseFormat: { type: 'json_object' } },
-        signal,
+        undefined,
         {
           cacheKey: 'session-1',
           sampling: { temperature: 0.5, topP: 0.9 },
@@ -167,7 +166,6 @@ describe('ModelRequesterImpl request execution', () => {
 
     expect(provider.calls).toHaveLength(1);
     const options = provider.calls[0]!.options;
-    expect(options?.signal).toBe(signal);
     expect(options?.auth).toEqual({ apiKey: 'sk-1' });
     expect(options?.cacheKey).toBe('session-1');
     expect(options?.sampling).toEqual({ temperature: 0.5, topP: 0.9 });
@@ -176,6 +174,19 @@ describe('ModelRequesterImpl request execution', () => {
     expect(options?.usedContextTokens).toBe(5000);
     expect(options?.maxContextTokens).toBe(128000);
     expect(options?.responseFormat).toEqual({ type: 'json_object' });
+  });
+
+  it('preserves the caller reason when cancellation reaches the provider signal', async () => {
+    const provider = new FakeChatProvider();
+    const requester = new ModelRequesterImpl(modelWith(staticAuth()), registryReturning(provider));
+    const controller = new AbortController();
+
+    await collect(requester.request(INPUT, controller.signal));
+
+    const reason = new Error('caller cancelled');
+    controller.abort(reason);
+
+    expect(provider.calls[0]?.options?.signal).toMatchObject({ aborted: true, reason });
   });
 
   it('omits the thinking intent when no effort is requested', async () => {

--- a/packages/kosong/src/generate.ts
+++ b/packages/kosong/src/generate.ts
@@ -1,4 +1,4 @@
-import { APIEmptyResponseError } from './errors';
+import { APIEmptyResponseError, APITimeoutError } from './errors';
 import {
   isContentPart,
   isToolCall,
@@ -14,6 +14,30 @@ import type { TokenUsage } from './usage';
 
 /** Snapshot of a ToolCall excluding the internal `_streamIndex` routing field. */
 type StoredToolCall = Omit<ToolCall, '_streamIndex'>;
+
+/** Five minutes without response headers or the first streamed part is a dead request. */
+export const DEFAULT_RESPONSE_TIMEOUT_MS = 300_000;
+
+/** Thirty seconds between streamed parts is a stalled response. */
+export const DEFAULT_STREAM_IDLE_TIMEOUT_MS = 30_000;
+
+const MAX_TIMER_DELAY_MS = 0x7fffffff;
+const NEVER_ACTIVITY = new Promise<never>(() => {});
+
+export type ScheduleStreamIdleTimeout = (
+  callback: () => void,
+  timeoutMs: number,
+) => () => void;
+
+/** Driver-only controls layered over the provider's per-request options. */
+export interface GenerateDriverOptions extends GenerateOptions {
+  /** Maximum wait for response headers and the first streamed part. `0` disables it. */
+  readonly responseTimeoutMs?: number;
+  /** Maximum wait between streamed parts after output begins. `0` disables it. */
+  readonly streamIdleTimeoutMs?: number;
+  /** Host timer boundary used to schedule the deadline. */
+  readonly scheduleStreamIdleTimeout?: ScheduleStreamIdleTimeout;
+}
 
 /**
  * The result of a single {@link generate} call.
@@ -81,6 +105,8 @@ export interface GenerateCallbacks {
  *
  * @throws {DOMException} with name `"AbortError"` when `options.signal` is
  *   aborted before or during streaming.
+ * @throws {APITimeoutError} when no response headers or streamed part arrive
+ *   before the configured idle deadline.
  * @throws {APIEmptyResponseError} when the response contains no content and
  *   no tool calls, or only thinking content without any text or tool calls.
  */
@@ -90,7 +116,7 @@ export async function generate(
   tools: Tool[],
   history: Message[],
   callbacks?: GenerateCallbacks,
-  options?: GenerateOptions,
+  options?: GenerateDriverOptions,
 ): Promise<GenerateResult> {
   const message: Message = { role: 'assistant', content: [], toolCalls: [] };
   let pendingPart: StreamedMessagePart | null = null;
@@ -116,8 +142,53 @@ export async function generate(
     ? tools.filter((tool) => tool.deferred !== true)
     : tools;
 
+  const responseTimeoutMs = options?.responseTimeoutMs ?? DEFAULT_RESPONSE_TIMEOUT_MS;
+  const streamIdleTimeoutMs = options?.streamIdleTimeoutMs ?? DEFAULT_STREAM_IDLE_TIMEOUT_MS;
+  const scheduleIdleTimeout =
+    options?.scheduleStreamIdleTimeout ?? scheduleStreamIdleTimeout;
+  const requestController = new AbortController();
+  const requestSignal =
+    options?.signal === undefined
+      ? requestController.signal
+      : AbortSignal.any([options.signal, requestController.signal]);
+  let streamCancelled = false;
+  const stopRequest = (stream?: StreamedMessage, iterator?: AsyncIterator<StreamedMessagePart>) => {
+    if (!requestController.signal.aborted) {
+      requestController.abort(createAbortError());
+    }
+    if (stream === undefined || streamCancelled) return;
+    streamCancelled = true;
+    cancelStream(stream, iterator);
+  };
+
   options?.onRequestStart?.();
-  const stream = await provider.generate(systemPrompt, wireTools, history, options);
+  const streamPromise = provider.generate(
+    systemPrompt,
+    wireTools,
+    history,
+    toProviderOptions(options, requestSignal),
+  );
+  // A provider may resolve after the caller has already aborted or the idle
+  // deadline has fired. Cancel that late stream so it cannot keep its socket
+  // or response body alive after generate() has exited.
+  void streamPromise.then(
+    (lateStream) => {
+      if (requestSignal.aborted) {
+        stopRequest(lateStream);
+      }
+    },
+    () => {},
+  );
+  const stream = await waitForActivity(
+    streamPromise,
+    {
+      timeoutMs: responseTimeoutMs,
+      scheduleTimeout: scheduleIdleTimeout,
+      signal: options?.signal,
+      stop: stopRequest,
+      timeoutError: idleTimeoutError(provider, responseTimeoutMs, 'response'),
+    },
+  );
   // Early capture: the trace id arrives with the response headers, before the
   // stream body — and before any mid-stream abort — so hosts can attribute
   // even a cancelled stream to its server-side request.
@@ -128,7 +199,9 @@ export async function generate(
   // Post-await abort check: `provider.generate()` may have resolved before
   // noticing a mid-flight abort. Reject immediately rather than draining
   // the stream.
-  await throwIfAborted(options?.signal, stream);
+  throwIfAborted(options?.signal, () => {
+    stopRequest(stream);
+  });
 
   // Decode-phase accounting. We split the window from the first streamed part
   // to stream end into time spent awaiting the next part (server + network) vs.
@@ -141,8 +214,28 @@ export async function generate(
   let clientConsumeMs = 0;
   let firstPartAt: number | undefined;
   let lastResumeAt = 0;
+  let receivedPart = false;
+  const iterator = stream[Symbol.asyncIterator]();
+  const stopStream = () => {
+    stopRequest(stream, iterator);
+  };
 
-  for await (const part of stream) {
+  for (;;) {
+    const timeoutMs = receivedPart ? streamIdleTimeoutMs : responseTimeoutMs;
+    const next = await waitForActivity(Promise.resolve(iterator.next()), {
+      timeoutMs,
+      scheduleTimeout: scheduleIdleTimeout,
+      signal: options?.signal,
+      stop: stopStream,
+      timeoutError: idleTimeoutError(
+        provider,
+        timeoutMs,
+        receivedPart ? 'stream' : 'firstPart',
+      ),
+    });
+    if (next.done === true) break;
+    receivedPart = true;
+    const part = next.value;
     const arrivedAt = Date.now();
     if (firstPartAt === undefined) {
       firstPartAt = arrivedAt;
@@ -151,12 +244,12 @@ export async function generate(
     }
 
     try {
-      await throwIfAborted(options?.signal, stream);
+      throwIfAborted(options?.signal, stopStream);
 
       // Notify raw part callback (deep copy to avoid aliasing mutations).
       if (callbacks?.onMessagePart !== undefined) {
         await callbacks.onMessagePart(deepCopyPart(part));
-        await throwIfAborted(options?.signal, stream);
+        throwIfAborted(options?.signal, stopStream);
       }
 
       // Index-based routing for parallel tool call argument deltas.
@@ -193,13 +286,16 @@ export async function generate(
         flushPart(message, pendingPart, toolCallIndexMap);
         pendingPart = part;
       }
+    } catch (error) {
+      stopStream();
+      throw error;
     } finally {
       lastResumeAt = Date.now();
       clientConsumeMs += lastResumeAt - arrivedAt;
     }
   }
 
-  await throwIfAborted(options?.signal, stream);
+  throwIfAborted(options?.signal, stopStream);
   if (firstPartAt !== undefined) {
     // Tail wait: from the last processed part to the stream's done signal.
     serverDecodeMs += Date.now() - lastResumeAt;
@@ -247,7 +343,7 @@ export async function generate(
   // Fire onToolCall for every fully-assembled tool call, in final order.
   if (callbacks?.onToolCall !== undefined) {
     for (const toolCall of message.toolCalls) {
-      await throwIfAborted(options?.signal, stream);
+      throwIfAborted(options?.signal, stopStream);
       await callbacks.onToolCall(toolCall);
     }
   }
@@ -270,32 +366,134 @@ type CancelableStream = StreamedMessage & {
   return?: () => unknown;
 };
 
+function createAbortError(): DOMException {
+  return new DOMException('The operation was aborted.', 'AbortError');
+}
+
 function throwAbortError(): never {
-  throw new DOMException('The operation was aborted.', 'AbortError');
+  throw createAbortError();
 }
 
-async function cancelStream(stream: StreamedMessage): Promise<void> {
+function cancelStream(
+  stream?: StreamedMessage,
+  iterator?: AsyncIterator<StreamedMessagePart>,
+): void {
+  if (stream === undefined) return;
   const cancelable = stream as CancelableStream;
+  invokeCancellation(() => cancelable.cancel?.());
+  if (iterator !== undefined) {
+    invokeCancellation(() => iterator.return?.());
+  }
+  if ((iterator as unknown) !== stream) {
+    invokeCancellation(() => cancelable.return?.());
+  }
+}
 
+function invokeCancellation(cancel: () => unknown): void {
   try {
-    await cancelable.cancel?.();
-  } catch {}
-
-  try {
-    await cancelable.return?.();
+    void Promise.resolve(cancel()).catch(() => {});
   } catch {}
 }
 
-async function throwIfAborted(signal?: AbortSignal, stream?: StreamedMessage): Promise<void> {
+function throwIfAborted(
+  signal: AbortSignal | undefined,
+  stop: () => void,
+): void {
   if (!signal?.aborted) {
     return;
   }
 
-  if (stream !== undefined) {
-    await cancelStream(stream);
+  stop();
+  throwAbortError();
+}
+
+interface ActivityWaitOptions {
+  readonly timeoutMs: number;
+  readonly scheduleTimeout: ScheduleStreamIdleTimeout;
+  readonly signal?: AbortSignal;
+  readonly stop: () => void;
+  readonly timeoutError: APITimeoutError;
+}
+
+async function waitForActivity<T>(
+  work: Promise<T>,
+  options: ActivityWaitOptions,
+): Promise<T> {
+  if (options.signal?.aborted === true) {
+    options.stop();
+    throwAbortError();
   }
 
-  throwAbortError();
+  const abortError = createAbortError();
+  let clearTimeout = () => {};
+  const timeout: Promise<never> =
+    options.timeoutMs <= 0
+      ? NEVER_ACTIVITY
+      : new Promise((_resolve, reject) => {
+          clearTimeout = options.scheduleTimeout(() => {
+            reject(options.timeoutError);
+          }, Math.min(options.timeoutMs, MAX_TIMER_DELAY_MS));
+        });
+
+  let removeAbortListener = () => {};
+  const aborted: Promise<never> =
+    options.signal === undefined
+      ? NEVER_ACTIVITY
+      : new Promise((_resolve, reject) => {
+          const onAbort = () => {
+            reject(abortError);
+          };
+          options.signal?.addEventListener('abort', onAbort, { once: true });
+          removeAbortListener = () => options.signal?.removeEventListener('abort', onAbort);
+        });
+
+  try {
+    return await Promise.race([work, timeout, aborted]);
+  } catch (error) {
+    if (error === abortError || error === options.timeoutError) {
+      options.stop();
+    }
+    throw error;
+  } finally {
+    clearTimeout();
+    removeAbortListener();
+  }
+}
+
+function scheduleStreamIdleTimeout(callback: () => void, timeoutMs: number): () => void {
+  const handle = setTimeout(callback, timeoutMs);
+  return () => {
+    clearTimeout(handle);
+  };
+}
+
+function toProviderOptions(
+  options: GenerateDriverOptions | undefined,
+  signal: AbortSignal,
+): GenerateOptions {
+  const {
+    responseTimeoutMs: _responseTimeoutMs,
+    streamIdleTimeoutMs: _streamIdleTimeoutMs,
+    scheduleStreamIdleTimeout: _scheduleStreamIdleTimeout,
+    ...providerOptions
+  } = options ?? {};
+  return { ...providerOptions, signal };
+}
+
+function idleTimeoutError(
+  provider: ChatProvider,
+  timeoutMs: number,
+  phase: 'response' | 'firstPart' | 'stream',
+): APITimeoutError {
+  const activity =
+    phase === 'response'
+      ? 'response headers'
+      : phase === 'firstPart'
+        ? 'the first streamed response part'
+        : 'the next streamed response part';
+  return new APITimeoutError(
+    `Timed out after ${String(timeoutMs)}ms waiting for ${activity} from provider "${provider.name}" model "${provider.modelName}".`,
+  );
 }
 
 /** True when `pending` is a ToolCall whose _streamIndex equals `index`. */

--- a/packages/kosong/test/generate.test.ts
+++ b/packages/kosong/test/generate.test.ts
@@ -1,10 +1,58 @@
-import { APIEmptyResponseError } from '#/errors';
-import { generate } from '#/generate';
+/**
+ * Scenario: the public generate() driver normalizes provider streams.
+ *
+ * Covers response assembly, callbacks, cancellation, idle deadlines, and
+ * decode accounting. Provider streams and the timeout scheduler are the only
+ * stubbed external boundaries. Run with `pnpm --filter @moonshot-ai/kosong
+ * test -- generate.test.ts`.
+ */
+
+import { APIEmptyResponseError, APITimeoutError } from '#/errors';
+import { generate, type ScheduleStreamIdleTimeout } from '#/generate';
 import type { Message, StreamedMessagePart, ToolCall } from '#/message';
 import type { ChatProvider, StreamedMessage, ThinkingEffort } from '#/provider';
 import type { Tool } from '#/tool';
 import type { TokenUsage } from '#/usage';
 import { describe, expect, it, vi } from 'vitest';
+
+interface ManualTimeoutScheduler {
+  readonly schedule: ScheduleStreamIdleTimeout;
+  readonly lastDelayMs: () => number | undefined;
+  readonly waitUntilScheduled: () => Promise<void>;
+  readonly fire: () => void;
+}
+
+function createManualTimeoutScheduler(): ManualTimeoutScheduler {
+  let pending: (() => void) | undefined;
+  let delayMs: number | undefined;
+  let resolveScheduled: (() => void) | undefined;
+
+  return {
+    schedule: (callback, timeoutMs) => {
+      pending = callback;
+      delayMs = timeoutMs;
+      resolveScheduled?.();
+      resolveScheduled = undefined;
+      return () => {
+        if (pending === callback) pending = undefined;
+      };
+    },
+    lastDelayMs: () => delayMs,
+    waitUntilScheduled: () =>
+      pending === undefined
+        ? new Promise((resolve) => {
+            resolveScheduled = resolve;
+          })
+        : Promise.resolve(),
+    fire: () => {
+      const callback = pending;
+      pending = undefined;
+      if (callback === undefined) throw new Error('No idle timeout is scheduled.');
+      callback();
+    },
+  };
+}
+
 function createMockStream(
   parts: StreamedMessagePart[],
   opts?: {
@@ -46,6 +94,40 @@ function createMockProvider(stream: StreamedMessage): ChatProvider {
     },
   };
 }
+
+function createStallingStream(): StreamedMessage & {
+  readonly cancel: ReturnType<typeof vi.fn>;
+  readonly stalled: Promise<void>;
+} {
+  const cancel = vi.fn();
+  let markStalled = () => {};
+  const stalled = new Promise<void>((resolve) => {
+    markStalled = resolve;
+  });
+  return {
+    cancel,
+    stalled,
+    id: null,
+    usage: null,
+    finishReason: null,
+    rawFinishReason: null,
+    [Symbol.asyncIterator](): AsyncIterator<StreamedMessagePart> {
+      let emitted = false;
+      return {
+        next: () => {
+          if (!emitted) {
+            emitted = true;
+            return Promise.resolve({ done: false, value: { type: 'text', text: 'first' } });
+          }
+          markStalled();
+          return new Promise(() => {});
+        },
+        return: () => Promise.resolve({ done: true, value: undefined }),
+      };
+    },
+  };
+}
+
 describe('generate()', () => {
   it('omits trace metadata when the provider does not expose it', async () => {
     const onTraceId = vi.fn();
@@ -879,6 +961,89 @@ describe('generate()', () => {
     ).rejects.toMatchObject({ name: 'AbortError' });
 
     expect(cancel).toHaveBeenCalledTimes(1);
+  });
+
+  it('cancels the provider stream when onMessagePart throws', async () => {
+    const stream = createStallingStream();
+    const provider = createMockProvider(stream);
+
+    await expect(
+      generate(provider, '', [], [], {
+        onMessagePart: () => {
+          throw new Error('callback failed');
+        },
+      }),
+    ).rejects.toThrow('callback failed');
+
+    expect(stream.cancel).toHaveBeenCalledTimes(1);
+  });
+
+  it('aborts the provider request with APITimeoutError when response headers remain idle', async () => {
+    const scheduler = createManualTimeoutScheduler();
+    let providerSignal: AbortSignal | undefined;
+    const provider: ChatProvider = {
+      name: 'mock',
+      modelName: 'mock-model',
+      thinkingEffort: null,
+      generate: async (_systemPrompt, _tools, _history, options) => {
+        providerSignal = options?.signal;
+        return new Promise(() => {});
+      },
+      withThinking(): ChatProvider {
+        return this;
+      },
+    };
+
+    const pending = generate(provider, '', [], [], undefined, {
+      responseTimeoutMs: 321,
+      scheduleStreamIdleTimeout: scheduler.schedule,
+    });
+    await scheduler.waitUntilScheduled();
+    scheduler.fire();
+    const caughtError = await pending.catch((error: unknown) => error);
+
+    expect(caughtError).toBeInstanceOf(APITimeoutError);
+    expect(caughtError).toMatchObject({ message: expect.stringContaining('321ms') });
+    expect(providerSignal?.aborted).toBe(true);
+    expect(scheduler.lastDelayMs()).toBe(321);
+  });
+
+  it('cancels the stream when the next response part exceeds the idle deadline', async () => {
+    const scheduler = createManualTimeoutScheduler();
+    const stream = createStallingStream();
+    const provider = createMockProvider(stream);
+
+    const pending = generate(provider, '', [], [], undefined, {
+      streamIdleTimeoutMs: 654,
+      scheduleStreamIdleTimeout: scheduler.schedule,
+    });
+    await stream.stalled;
+    await scheduler.waitUntilScheduled();
+    scheduler.fire();
+    const caughtError = await pending.catch((error: unknown) => error);
+
+    expect(caughtError).toBeInstanceOf(APITimeoutError);
+    expect(stream.cancel).toHaveBeenCalledTimes(1);
+    expect(scheduler.lastDelayMs()).toBe(654);
+  });
+
+  it('preserves AbortError when the user cancels a stalled response stream', async () => {
+    const scheduler = createManualTimeoutScheduler();
+    const stream = createStallingStream();
+    const provider = createMockProvider(stream);
+    const controller = new AbortController();
+
+    const pending = generate(provider, '', [], [], undefined, {
+      signal: controller.signal,
+      streamIdleTimeoutMs: 987,
+      scheduleStreamIdleTimeout: scheduler.schedule,
+    });
+    await stream.stalled;
+    controller.abort();
+    const caughtError = await pending.catch((error: unknown) => error);
+
+    expect(caughtError).toMatchObject({ name: 'AbortError' });
+    expect(caughtError).not.toBeInstanceOf(APITimeoutError);
   });
 
   it('onToolCall receives tool calls in message order', async () => {


### PR DESCRIPTION
## Related Issue

Resolve #1050

Related to #2570.

## Problem

Model requests could remain pending forever while waiting for response headers, the first streamed part, or the next streamed part. The generation drivers used unbounded awaits, so the caller could not recover from a silent connection without cancelling or restarting the session.

## What changed

- bound response-header and first-part waits at five minutes, while enforcing a 30-second idle deadline between streamed parts
- abort the provider request and close acquired or late streams when a deadline or caller cancellation fires
- surface the existing retryable `APITimeoutError`, preserving the repository's retry behavior and the caller's `AbortError`
- apply the behavior to both v2 and legacy generation drivers
- cover header stalls, mid-stream stalls, callback failures, cancellation, and exactly-once stream cleanup

### Validation

- `@moonshot-ai/agent-core-v2` generate contract tests: 15 passed
- `@moonshot-ai/kosong` generate tests: 37 passed
- both affected packages typecheck
- v2 import-boundary check passes
- type-aware lint reports no warnings or errors on the changed TypeScript files
- changeset status reports a patch bump for `@moonshot-ai/kimi-code`

A full v2 suite run was also attempted; the remaining failures are unrelated current-main image-compression timeout, performance-baseline, and full-compaction cases outside these paths.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.