### PR TITLE
fix(kap-server): quote only the path in explorer /select, argument on Windows

### DIFF
--- a/.changeset/windows-explorer-select-quoting.md
+++ b/.changeset/windows-explorer-select-quoting.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Fix the web UI opening the Documents folder instead of the requested file on Windows when the file path contains spaces.

--- a/packages/kap-server/src/lib/fileLaunch.ts
+++ b/packages/kap-server/src/lib/fileLaunch.ts
@@ -6,6 +6,7 @@ export interface LaunchCommand {
   readonly command: string;
   readonly args: readonly string[];
   readonly shell?: boolean;
+  readonly windowsVerbatimArguments?: boolean;
 }
 
 export function openFileCommandFor(
@@ -44,7 +45,17 @@ export function revealFileCommandFor(
     case 'darwin':
       return { command: 'open', args: ['-R', absolutePath] };
     case 'win32':
-      return { command: 'explorer.exe', args: [`/select,${absolutePath}`] };
+      // explorer.exe parses its RAW command line (not argv), so Node's
+      // default spawn quoting breaks `/select,` whenever the path contains
+      // spaces: the command line becomes `"/select,\"C:\some dir\f.txt\""`,
+      // which explorer's parser rejects, silently opening the Documents
+      // folder. `windowsVerbatimArguments: true` keeps the command line in
+      // the documented `/select,"C:\some dir\f.txt"` form.
+      return {
+        command: 'explorer.exe',
+        args: [explorerSelectArg(absolutePath)],
+        windowsVerbatimArguments: true,
+      };
     default:
       return { command: 'xdg-open', args: [path.dirname(absolutePath)] };
   }
@@ -163,7 +174,11 @@ function openInFinder(
     case 'win32':
       return isDirectory
         ? { command: 'explorer.exe', args: [absolutePath] }
-        : { command: 'explorer.exe', args: [`/select,${absolutePath}`] };
+        : {
+            command: 'explorer.exe',
+            args: [explorerSelectArg(absolutePath)],
+            windowsVerbatimArguments: true,
+          };
     default:
       return {
         command: 'xdg-open',
@@ -191,6 +206,7 @@ export async function launchDetached(cmd: LaunchCommand): Promise<void> {
       detached: true,
       stdio: 'ignore',
       shell: cmd.shell,
+      windowsVerbatimArguments: cmd.windowsVerbatimArguments,
     });
     child.once('error', (err) => {
       if (settled) return;
@@ -217,6 +233,20 @@ function resolveEditorCommand(env: Record<string, string | undefined>): string |
 function supportsLineTarget(command: string): boolean {
   const first = command.trim().split(/\s+/)[0] ?? '';
   return /(?:^|\/)(code|cursor|windsurf)(?:\.cmd|\.exe)?$/i.test(first);
+}
+
+/**
+ * Build the single `/select,` argument for explorer.exe, quoting only the
+ * path: `/select,"C:\some dir\f.txt"`. Must be launched with
+ * `windowsVerbatimArguments: true` — explorer parses its raw command line,
+ * and Node's default quoting would wrap the whole argument as
+ * `"/select,\"C:\...\""`, which explorer rejects (it then silently opens the
+ * Documents folder). A trailing backslash is dropped so it cannot escape the
+ * closing quote.
+ */
+function explorerSelectArg(absolutePath: string): string {
+  const trimmed = absolutePath.replace(/\\+$/, '');
+  return `/select,"${trimmed}"`;
 }
 
 function quoteShellArg(value: string, platform: NodeJS.Platform): string {

--- a/packages/kap-server/test/fileLaunch.test.ts
+++ b/packages/kap-server/test/fileLaunch.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest';
+
+import { openInAppCommandFor, revealFileCommandFor } from '../src/lib/fileLaunch';
+
+describe('fileLaunch', () => {
+  describe('win32 explorer /select, quoting', () => {
+    // explorer.exe parses its RAW command line (not argv). Node's default
+    // spawn quoting renders a `/select,` argument with spaces as
+    // `"/select,\"C:\...\""`, which explorer rejects — it then silently opens
+    // the Documents folder. The argument must quote only the path, and the
+    // launch must bypass Node's quoting via windowsVerbatimArguments.
+    it('revealFileCommandFor quotes only the path and uses verbatim arguments', () => {
+      const cmd = revealFileCommandFor('C:\\some dir\\sub\\file.txt', 'win32');
+      expect(cmd.command).toBe('explorer.exe');
+      expect(cmd.args).toEqual(['/select,"C:\\some dir\\sub\\file.txt"']);
+      expect(cmd.windowsVerbatimArguments).toBe(true);
+    });
+
+    it('openInAppCommandFor (finder) quotes only the path and uses verbatim arguments', () => {
+      const cmd = openInAppCommandFor(
+        'finder',
+        'C:\\some dir\\sub\\file.txt',
+        { isDirectory: false },
+        'win32',
+      );
+      expect(cmd.command).toBe('explorer.exe');
+      expect(cmd.args).toEqual(['/select,"C:\\some dir\\sub\\file.txt"']);
+      expect(cmd.windowsVerbatimArguments).toBe(true);
+    });
+
+    it('openInAppCommandFor (finder) opens directories without /select,', () => {
+      const cmd = openInAppCommandFor(
+        'finder',
+        'C:\\some dir\\sub',
+        { isDirectory: true },
+        'win32',
+      );
+      expect(cmd.command).toBe('explorer.exe');
+      expect(cmd.args).toEqual(['C:\\some dir\\sub']);
+      expect(cmd.windowsVerbatimArguments).toBeUndefined();
+    });
+
+    it('drops a trailing backslash so it cannot escape the closing quote', () => {
+      const cmd = revealFileCommandFor('C:\\some dir\\sub\\', 'win32');
+      expect(cmd.args).toEqual(['/select,"C:\\some dir\\sub"']);
+    });
+
+    it('paths without spaces keep the same quoting', () => {
+      const cmd = revealFileCommandFor('C:\\proj\\file.txt', 'win32');
+      expect(cmd.args).toEqual(['/select,"C:\\proj\\file.txt"']);
+      expect(cmd.windowsVerbatimArguments).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
## Related Issue

No linked issue — the problem is explained below.

## Problem

On Windows, using "open in folder" / reveal from the web UI on a file whose path contains spaces (e.g. anything under `C:\Users\<name>\OneDrive - ...`) opens the **Documents** folder instead of selecting the file.

Root cause: the server launches `explorer.exe` with a single `/select,<path>` argument. explorer.exe parses its **raw command line** rather than argv, and Node's default spawn quoting renders the argument as `"/select,C:\some dir\file.txt"` (or `"/select,\"C:\...\""` when inner quotes are present) — neither form is parseable by explorer's private command-line parser, so it silently falls back to the Documents folder. Verified on a real Windows machine (Windows Server 2022, Node 24): both quoted-as-a-whole forms open `Documents`, while the documented `/select,"<path>"` command-line form opens the right folder and selects the file.

## What changed

- Build the argument as `/select,"<path>"` (quotes around the path portion only) and launch it with `windowsVerbatimArguments: true`, so Node passes the command line through verbatim and explorer receives exactly the documented form.
- Drop trailing backslashes from the path so they cannot escape the closing quote.
- Applied at both `explorer.exe /select,` call sites (reveal file and open-in-app "finder" on Windows); `launchDetached` now forwards `windowsVerbatimArguments`.
- Added unit tests covering paths with spaces, directories, and trailing backslashes.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.
