### PR TITLE
fix(agent-core-v2): seed the activity view's lastTurn from the persisted turn.ended record

### DIFF
--- a/.changeset/activity-view-last-turn-seed.md
+++ b/.changeset/activity-view-last-turn-seed.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Restore how the last turn ended (completed, cancelled, or failed) when a session is resumed after a server restart, so clients can still surface a previously failed turn instead of the session looking silently stopped.

--- a/packages/agent-core-v2/src/agent/activityView/activityViewService.ts
+++ b/packages/agent-core-v2/src/agent/activityView/activityViewService.ts
@@ -6,18 +6,16 @@
  * events drive the live phase/stream/retry detail, permission approval events
  * drive the pending-approval list, while task and full-compaction events drive
  * the background-work slice. The view seeds once from `IAgentLoopService`,
- * `IAgentTaskService`, and `IAgentFullCompactionService`, and folds the wire
- * `TurnModel`'s persisted `lastEnded` into `lastTurn` through the
- * `IWireService` `onDidRestore` hook — the journal is replayed only after the
- * agent scope (and this view) is constructed, so the restore-time fold is
- * what lets a cold-resumed agent still know how its last turn ended (reads,
+ * `IAgentTaskService`, and `IAgentFullCompactionService`, and recovers the
+ * last turn's outcome from the wire `TurnModel` through `IWireService`, so
+ * a cold-resumed agent still reports how its previous turn ended (reads,
  * never writes). Otherwise the view holds only derived state, so it can be
- * discarded and rebuilt at any time. The mutable view state (`lifecycle`, `turn`, `lastTurn`,
- * `background`, `current`) is registered into `agentState`
- * (`IAgentStateService`) and read/written through it; the event-bus
- * subscription handles stay mechanism held by the `Disposable` base, and
- * `MutableTurn`'s in-place-mutated Maps stay instance fields of that
- * per-turn class. Bound at Agent scope.
+ * discarded and rebuilt at any time. The mutable view state (`lifecycle`,
+ * `turn`, `lastTurn`, `background`, `current`) is registered into
+ * `agentState` (`IAgentStateService`) and read/written through it; the
+ * event-bus subscription handles stay mechanism held by the `Disposable`
+ * base, and `MutableTurn`'s in-place-mutated Maps stay instance fields of
+ * that per-turn class. Bound at Agent scope.
  */
 
 import { Disposable } from '#/_base/di/lifecycle';

--- a/packages/agent-core-v2/src/agent/activityView/activityViewService.ts
+++ b/packages/agent-core-v2/src/agent/activityView/activityViewService.ts
@@ -6,8 +6,10 @@
  * events drive the live phase/stream/retry detail, permission approval events
  * drive the pending-approval list, while task and full-compaction events drive
  * the background-work slice. The view seeds once from `IAgentLoopService`,
- * `IAgentTaskService`, and `IAgentFullCompactionService` (reads, never writes)
- * and otherwise holds only derived state, so it can be discarded and rebuilt
+ * `IAgentTaskService`, `IAgentFullCompactionService`, and the wire
+ * `TurnModel`'s persisted `lastEnded` — so a cold-resumed agent still knows
+ * how its last turn ended (reads, never writes) — and otherwise holds only
+ * derived state, so it can be discarded and rebuilt
  * at any time. The mutable view state (`lifecycle`, `turn`, `lastTurn`,
  * `background`, `current`) is registered into `agentState`
  * (`IAgentStateService`) and read/written through it; the event-bus
@@ -21,12 +23,14 @@ import { LifecycleScope, ScopeActivation, registerScopedService } from '#/_base/
 import { defineState } from '#/_base/state/stateRegistry';
 import { IEventBus } from '#/app/event/eventBus';
 import { IAgentLoopService } from '#/agent/loop/loop';
+import { TurnModel } from '#/agent/loop/turnOps';
 import { IAgentStateService } from '#/agent/state/agentState';
 import { IAgentTaskService } from '#/agent/task/task';
 import { IAgentFullCompactionService } from '#/agent/fullCompaction/fullCompaction';
 import { USER_PROMPT_ORIGIN } from '#/agent/contextMemory/types';
 import type { PromptOrigin } from '#/agent/contextMemory/types';
 import type { TurnEndReason } from '#/agent/loop/turnEvents';
+import { IWireService } from '#/wire/wire';
 
 import type {
   ActivityLastTurnState,
@@ -74,6 +78,7 @@ export class AgentActivityView extends Disposable implements IAgentActivityView 
     @IAgentTaskService private readonly tasks: IAgentTaskService,
     @IAgentFullCompactionService private readonly fullCompaction: IAgentFullCompactionService,
     @IAgentStateService private readonly states: IAgentStateService,
+    @IWireService private readonly wire: IWireService,
   ) {
     super();
     this.states.register(activityViewLifecycleKey);
@@ -220,8 +225,23 @@ export class AgentActivityView extends Disposable implements IAgentActivityView 
 
   private seedFromLoop(): void {
     const status = this.loop.status();
-    if (status.state !== 'running' || status.activeTurnId === undefined) return;
-    this.turn = new MutableTurn(status.activeTurnId, USER_PROMPT_ORIGIN);
+    if (status.state === 'running' && status.activeTurnId !== undefined) {
+      this.turn = new MutableTurn(status.activeTurnId, USER_PROMPT_ORIGIN);
+      this.publish();
+      return;
+    }
+    // Cold resume: no live turn has ended in this process, but the wire's
+    // persisted `turn.ended` record still knows how the last turn finished —
+    // seed `lastTurn` from it so the outcome (e.g. a provider failure)
+    // survives a server restart.
+    const lastEnded = this.wire.getModel(TurnModel).lastEnded;
+    if (lastEnded === undefined) return;
+    this.lastTurn = {
+      turnId: lastEnded.turnId,
+      reason: lastEnded.reason,
+      durationMs: lastEnded.durationMs,
+      at: Date.now(),
+    };
     this.publish();
   }
 

--- a/packages/agent-core-v2/src/agent/activityView/activityViewService.ts
+++ b/packages/agent-core-v2/src/agent/activityView/activityViewService.ts
@@ -6,11 +6,13 @@
  * events drive the live phase/stream/retry detail, permission approval events
  * drive the pending-approval list, while task and full-compaction events drive
  * the background-work slice. The view seeds once from `IAgentLoopService`,
- * `IAgentTaskService`, `IAgentFullCompactionService`, and the wire
- * `TurnModel`'s persisted `lastEnded` — so a cold-resumed agent still knows
- * how its last turn ended (reads, never writes) — and otherwise holds only
- * derived state, so it can be discarded and rebuilt
- * at any time. The mutable view state (`lifecycle`, `turn`, `lastTurn`,
+ * `IAgentTaskService`, and `IAgentFullCompactionService`, and folds the wire
+ * `TurnModel`'s persisted `lastEnded` into `lastTurn` through the
+ * `IWireService` `onDidRestore` hook — the journal is replayed only after the
+ * agent scope (and this view) is constructed, so the restore-time fold is
+ * what lets a cold-resumed agent still know how its last turn ended (reads,
+ * never writes). Otherwise the view holds only derived state, so it can be
+ * discarded and rebuilt at any time. The mutable view state (`lifecycle`, `turn`, `lastTurn`,
  * `background`, `current`) is registered into `agentState`
  * (`IAgentStateService`) and read/written through it; the event-bus
  * subscription handles stay mechanism held by the `Disposable` base, and
@@ -89,6 +91,12 @@ export class AgentActivityView extends Disposable implements IAgentActivityView 
     this.seedFromLoop();
     this.seedFromTasks();
     this.seedFromFullCompaction();
+    this._register(
+      this.wire.hooks.onDidRestore.register('activityView', async (_ctx, next) => {
+        this.seedLastTurnFromWire();
+        await next();
+      }),
+    );
 
     this._register(this.eventBus.subscribe('turn.started', (e) => this.onTurnStarted(e.turnId, e.origin)));
     this._register(this.eventBus.subscribe('turn.step.started', (e) => this.onStepStarted(e.step)));
@@ -230,10 +238,11 @@ export class AgentActivityView extends Disposable implements IAgentActivityView 
       this.publish();
       return;
     }
-    // Cold resume: no live turn has ended in this process, but the wire's
-    // persisted `turn.ended` record still knows how the last turn finished —
-    // seed `lastTurn` from it so the outcome (e.g. a provider failure)
-    // survives a server restart.
+    this.seedLastTurnFromWire();
+  }
+
+  private seedLastTurnFromWire(): void {
+    if (this.turn !== undefined || this.lastTurn !== undefined) return;
     const lastEnded = this.wire.getModel(TurnModel).lastEnded;
     if (lastEnded === undefined) return;
     this.lastTurn = {

--- a/packages/agent-core-v2/src/agent/loop/turnOps.ts
+++ b/packages/agent-core-v2/src/agent/loop/turnOps.ts
@@ -22,10 +22,6 @@ import type { PromptOrigin } from '#/agent/contextMemory/types';
 export interface TurnModelState {
   readonly nextTurnId: number;
   readonly cancelledTurnIds: readonly number[];
-  /** Terminal outcome of the most recently ended turn, folded from the
-   *  persisted `turn.ended` record — lets cold-resumed read models (the
-   *  activity view) recover how the last turn ended without replaying the
-   *  journal. */
   readonly lastEnded?: {
     readonly turnId: number;
     readonly reason: 'completed' | 'cancelled' | 'failed' | 'blocked';

--- a/packages/agent-core-v2/src/agent/loop/turnOps.ts
+++ b/packages/agent-core-v2/src/agent/loop/turnOps.ts
@@ -4,14 +4,10 @@
  *
  * Owns the next available turn id, including cancelled queued reservations and
  * legacy loop-event observations. Also persists the terminal `turn.ended`
- * record (reason / error / durationMs) so downstream history rebuilds can
- * recover how a turn ended; the model folds the latest record into
- * `lastEnded` — kept across prompt/queued-cancel clock advances, cleared as
- * soon as a newer turn's loop events land — so cold-resumed read models
- * (e.g. the activity view) can seed the last ended turn's outcome without
- * replaying the journal. Consumed by the
- * Agent-scope `loopService`; the `interruptionReminder` domain projects
- * `turn.cancel` into its own model.
+ * record (reason / error / durationMs) so downstream history rebuilds and
+ * cold-resumed read models (e.g. the activity view) can recover how the last
+ * turn ended. Consumed by the Agent-scope `loopService`; the
+ * `interruptionReminder` domain projects `turn.cancel` into its own model.
  */
 
 import { z } from 'zod';

--- a/packages/agent-core-v2/src/agent/loop/turnOps.ts
+++ b/packages/agent-core-v2/src/agent/loop/turnOps.ts
@@ -108,6 +108,7 @@ function advanceTurnClock(
   );
   while (pendingCancellations.delete(nextTurnId)) nextTurnId += 1;
   return {
+    ...state,
     nextTurnId,
     cancelledTurnIds: [...pendingCancellations].toSorted((a, b) => a - b),
   };

--- a/packages/agent-core-v2/src/agent/loop/turnOps.ts
+++ b/packages/agent-core-v2/src/agent/loop/turnOps.ts
@@ -6,8 +6,10 @@
  * legacy loop-event observations. Also persists the terminal `turn.ended`
  * record (reason / error / durationMs) so downstream history rebuilds can
  * recover how a turn ended; the model folds the latest record into
- * `lastEnded` so cold-resumed read models (e.g. the activity view) can seed
- * the last turn's outcome without replaying the journal. Consumed by the
+ * `lastEnded` — kept across prompt/queued-cancel clock advances, cleared as
+ * soon as a newer turn's loop events land — so cold-resumed read models
+ * (e.g. the activity view) can seed the last ended turn's outcome without
+ * replaying the journal. Consumed by the
  * Agent-scope `loopService`; the `interruptionReminder` domain projects
  * `turn.cancel` into its own model.
  */
@@ -40,9 +42,13 @@ export const TurnModel = defineModel<TurnModelState>(
         }
 
         const turnId = Number.parseInt(event.turnId, 10);
-        return Number.isInteger(turnId) && turnId >= state.nextTurnId
-          ? advanceTurnClock(state, turnId + 1)
-          : state;
+        if (!Number.isInteger(turnId)) return state;
+        let next = state;
+        if (turnId >= state.nextTurnId) next = advanceTurnClock(state, turnId + 1);
+        if (next.lastEnded !== undefined && turnId > next.lastEnded.turnId) {
+          next = { ...next, lastEnded: undefined };
+        }
+        return next;
       },
     },
   },

--- a/packages/agent-core-v2/src/agent/loop/turnOps.ts
+++ b/packages/agent-core-v2/src/agent/loop/turnOps.ts
@@ -5,9 +5,11 @@
  * Owns the next available turn id, including cancelled queued reservations and
  * legacy loop-event observations. Also persists the terminal `turn.ended`
  * record (reason / error / durationMs) so downstream history rebuilds can
- * recover how a turn ended; the record carries no engine-restorable state, so
- * its `apply` is a no-op. Consumed by the Agent-scope `loopService`; the
- * `interruptionReminder` domain projects `turn.cancel` into its own model.
+ * recover how a turn ended; the model folds the latest record into
+ * `lastEnded` so cold-resumed read models (e.g. the activity view) can seed
+ * the last turn's outcome without replaying the journal. Consumed by the
+ * Agent-scope `loopService`; the `interruptionReminder` domain projects
+ * `turn.cancel` into its own model.
  */
 
 import { z } from 'zod';
@@ -20,6 +22,15 @@ import type { PromptOrigin } from '#/agent/contextMemory/types';
 export interface TurnModelState {
   readonly nextTurnId: number;
   readonly cancelledTurnIds: readonly number[];
+  /** Terminal outcome of the most recently ended turn, folded from the
+   *  persisted `turn.ended` record — lets cold-resumed read models (the
+   *  activity view) recover how the last turn ended without replaying the
+   *  journal. */
+  readonly lastEnded?: {
+    readonly turnId: number;
+    readonly reason: 'completed' | 'cancelled' | 'failed' | 'blocked';
+    readonly durationMs?: number;
+  };
 }
 
 export const TurnModel = defineModel<TurnModelState>(
@@ -85,7 +96,10 @@ export const endTurn = TurnModel.defineOp('turn.ended', {
     error: z.custom<KimiErrorPayload>().optional(),
     durationMs: z.number().optional(),
   }),
-  apply: (s) => s,
+  apply: (s, { turnId, reason, durationMs }) => ({
+    ...s,
+    lastEnded: { turnId, reason, durationMs },
+  }),
 });
 
 function advanceTurnClock(

--- a/packages/agent-core-v2/test/agent/activityView/activityView.test.ts
+++ b/packages/agent-core-v2/test/agent/activityView/activityView.test.ts
@@ -71,12 +71,26 @@ function harness(
     status: () => ({ state: 'idle', pendingTurnIds: [], hasPendingRequests: false }),
   } as unknown as IAgentLoopService;
   const tasks = { list: () => seedTasks } as unknown as IAgentTaskService;
+  const wireState: { lastEnded?: TurnModelState['lastEnded'] } = { lastEnded };
+  const restoreHooks: Array<() => Promise<void>> = [];
   const wire = {
     getModel: (model: unknown) =>
       model === TurnModel
-        ? { nextTurnId: 1, cancelledTurnIds: [], lastEnded }
+        ? { nextTurnId: 1, cancelledTurnIds: [], lastEnded: wireState.lastEnded }
         : undefined,
+    hooks: {
+      onDidRestore: {
+        register: (_id: string, fn: (ctx: undefined, next: () => Promise<void>) => Promise<void>) => {
+          restoreHooks.push(async () => fn(undefined, async () => {}));
+          return { dispose: () => {} };
+        },
+      },
+    },
   } as unknown as IWireService;
+  const restore = async (ended: TurnModelState['lastEnded']): Promise<void> => {
+    wireState.lastEnded = ended;
+    for (const hook of restoreHooks) await hook();
+  };
   const ix = disposables.add(new TestInstantiationService());
   ix.stub(IEventBus, bus as unknown as IEventBus);
   ix.stub(IAgentLoopService, loop);
@@ -93,7 +107,7 @@ function harness(
     bus.published
       .filter((e) => e.type === 'agent.activity.updated')
       .map((e) => e as unknown as AgentActivityState);
-  return { bus, view, updates };
+  return { bus, view, updates, restore };
 }
 
 describe('AgentActivityView', () => {
@@ -127,9 +141,23 @@ describe('AgentActivityView', () => {
     expect(view.state().background).toEqual([{ kind: 'process', id: 'bash-9', since: 100 }]);
   });
 
-  it('seeds lastTurn from the wire TurnModel on a cold resume', () => {
+  it('seeds lastTurn from the wire TurnModel when the view is built after restore', () => {
     const { view } = harness([], null, { turnId: 7, reason: 'failed', durationMs: 1234 });
     expect(view.state().lastTurn).toMatchObject({ turnId: 7, reason: 'failed', durationMs: 1234 });
+  });
+
+  it('seeds lastTurn when the wire restore lands after construction (cold resume ordering)', async () => {
+    const { view, restore } = harness();
+    expect(view.state().lastTurn).toBeUndefined();
+    await restore({ turnId: 7, reason: 'failed', durationMs: 1234 });
+    expect(view.state().lastTurn).toMatchObject({ turnId: 7, reason: 'failed', durationMs: 1234 });
+  });
+
+  it('does not overwrite a live lastTurn when the restore hook runs', async () => {
+    const { bus, view, restore } = harness([], null, { turnId: 7, reason: 'failed' });
+    bus.publish({ type: 'turn.ended', turnId: 9, reason: 'completed' });
+    await restore({ turnId: 7, reason: 'failed' });
+    expect(view.state().lastTurn).toMatchObject({ turnId: 9, reason: 'completed' });
   });
 
   it('leaves lastTurn empty when the wire has no ended turn', () => {

--- a/packages/agent-core-v2/test/agent/activityView/activityView.test.ts
+++ b/packages/agent-core-v2/test/agent/activityView/activityView.test.ts
@@ -17,10 +17,10 @@ import { IAgentTaskService } from '#/agent/task/task';
 import type { AgentTaskInfo } from '#/agent/task/types';
 import { AgentActivityView } from '#/agent/activityView/activityViewService';
 import { IAgentActivityView, type AgentActivityState } from '#/agent/activityView/activityView';
-import {
-  IAgentFullCompactionService,
-  type FullCompactionTask,
-} from '#/agent/fullCompaction/fullCompaction';
+import { IAgentFullCompactionService } from '#/agent/fullCompaction/fullCompaction';
+import type { FullCompactionTask } from '#/agent/fullCompaction/fullCompaction';
+import { TurnModel, type TurnModelState } from '#/agent/loop/turnOps';
+import { IWireService } from '#/wire/wire';
 
 class FakeBus {
   private readonly byType = new Map<string, Array<(e: DomainEvent) => void>>();
@@ -64,16 +64,24 @@ let disposables: DisposableStore;
 function harness(
   seedTasks: readonly AgentTaskInfo[] = [],
   compacting: FullCompactionTask | null = null,
+  lastEnded?: TurnModelState['lastEnded'],
 ) {
   const bus = new FakeBus();
   const loop = {
     status: () => ({ state: 'idle', pendingTurnIds: [], hasPendingRequests: false }),
   } as unknown as IAgentLoopService;
   const tasks = { list: () => seedTasks } as unknown as IAgentTaskService;
+  const wire = {
+    getModel: (model: unknown) =>
+      model === TurnModel
+        ? { nextTurnId: 1, cancelledTurnIds: [], lastEnded }
+        : undefined,
+  } as unknown as IWireService;
   const ix = disposables.add(new TestInstantiationService());
   ix.stub(IEventBus, bus as unknown as IEventBus);
   ix.stub(IAgentLoopService, loop);
   ix.stub(IAgentTaskService, tasks);
+  ix.stub(IWireService, wire);
   ix.set(IAgentStateService, new AgentStateService());
   ix.stub(IAgentFullCompactionService, {
     _serviceBrand: undefined,
@@ -117,6 +125,16 @@ describe('AgentActivityView', () => {
   it('seeds the background slice from the task registry on creation', () => {
     const { view } = harness([makeTaskInfo('bash-9')]);
     expect(view.state().background).toEqual([{ kind: 'process', id: 'bash-9', since: 100 }]);
+  });
+
+  it('seeds lastTurn from the wire TurnModel on a cold resume', () => {
+    const { view } = harness([], null, { turnId: 7, reason: 'failed', durationMs: 1234 });
+    expect(view.state().lastTurn).toMatchObject({ turnId: 7, reason: 'failed', durationMs: 1234 });
+  });
+
+  it('leaves lastTurn empty when the wire has no ended turn', () => {
+    const { view } = harness();
+    expect(view.state().lastTurn).toBeUndefined();
   });
 
   it('folds full compaction into the background slice', () => {

--- a/packages/agent-core-v2/test/agent/loop/turnOps.test.ts
+++ b/packages/agent-core-v2/test/agent/loop/turnOps.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest';
+
+import { TurnModel, cancelTurn, endTurn, promptTurn } from '#/agent/loop/turnOps';
+
+describe('TurnModel lastEnded', () => {
+  it('keeps the stored outcome across prompts and queued cancels', () => {
+    let s = TurnModel.initial();
+    s = promptTurn.apply(s, { input: [], origin: { kind: 'user' } });
+    s = endTurn.apply(s, { turnId: 0, reason: 'failed', durationMs: 10 });
+    expect(s.lastEnded).toMatchObject({ turnId: 0, reason: 'failed' });
+    s = promptTurn.apply(s, { input: [], origin: { kind: 'user' } });
+    expect(s.lastEnded?.reason).toBe('failed');
+    s = cancelTurn.apply(s, { turnId: 1, target: 'queued' });
+    expect(s.lastEnded?.reason).toBe('failed');
+    s = endTurn.apply(s, { turnId: 1, reason: 'completed' });
+    expect(s.lastEnded).toMatchObject({ turnId: 1, reason: 'completed' });
+  });
+
+  it('starts without a stored outcome', () => {
+    expect(TurnModel.initial().lastEnded).toBeUndefined();
+  });
+});

--- a/packages/agent-core-v2/test/agent/loop/turnOps.test.ts
+++ b/packages/agent-core-v2/test/agent/loop/turnOps.test.ts
@@ -1,6 +1,14 @@
 import { describe, expect, it } from 'vitest';
 
+import { MODEL_CROSS_REDUCERS } from '#/wire/model';
 import { TurnModel, cancelTurn, endTurn, promptTurn } from '#/agent/loop/turnOps';
+
+function foldLoopEvent(s: import('#/agent/loop/turnOps').TurnModelState, turnId: string) {
+  const entries = MODEL_CROSS_REDUCERS.get('context.append_loop_event') ?? [];
+  const entry = entries.find((e) => e.model === TurnModel);
+  if (entry === undefined) throw new Error('turn model cross-reducer not registered');
+  return entry.reducer(s, { event: { type: 'step.begin', turnId } }) as typeof s;
+}
 
 describe('TurnModel lastEnded', () => {
   it('keeps the stored outcome across prompts and queued cancels', () => {
@@ -14,6 +22,24 @@ describe('TurnModel lastEnded', () => {
     expect(s.lastEnded?.reason).toBe('failed');
     s = endTurn.apply(s, { turnId: 1, reason: 'completed' });
     expect(s.lastEnded).toMatchObject({ turnId: 1, reason: 'completed' });
+  });
+
+  it('clears the stored outcome once a newer turn starts producing', () => {
+    let s = TurnModel.initial();
+    s = promptTurn.apply(s, { input: [], origin: { kind: 'user' } });
+    s = endTurn.apply(s, { turnId: 0, reason: 'failed' });
+    s = promptTurn.apply(s, { input: [], origin: { kind: 'user' } });
+    s = foldLoopEvent(s, '1');
+    expect(s.lastEnded).toBeUndefined();
+  });
+
+  it('keeps the stored outcome on the same turn’s own events', () => {
+    let s = TurnModel.initial();
+    s = promptTurn.apply(s, { input: [], origin: { kind: 'user' } });
+    s = foldLoopEvent(s, '0');
+    s = endTurn.apply(s, { turnId: 0, reason: 'completed' });
+    s = foldLoopEvent(s, '0');
+    expect(s.lastEnded?.reason).toBe('completed');
   });
 
   it('starts without a stored outcome', () => {


### PR DESCRIPTION
## Problem

A cold-resumed agent seeds its `AgentActivityView` only from live loop/task state (`seedFromLoop` / `seedFromTasks` / `seedFromFullCompaction`). The `lastTurn` outcome survives only as in-memory fold state, so a **server restart wipes it**: a session whose last turn failed (e.g. sustained provider 429 exhausting step retries) comes back from `resume` with `lastTurnReason: undefined`, and clients cannot surface the failure — the desktop/web conversation sits silently idle exactly like the original dead session did.

## Fix

Two small pieces on top of the existing persisted `turn.ended` wire record:

- `TurnModel` folds the latest `turn.ended` op into a new `lastEnded` state field (turnId / reason / durationMs). The op was already persisted for the transcript cold fold; the model just didn't retain it.
- `AgentActivityView.seedFromLoop` adopts `lastEnded` as `lastTurn` when no turn is active, so the session work aggregate (`ISessionActivityView` → `last_turn_reason` on the wire) reflects the last turn's outcome again after a cold start.

Live behavior is untouched: a running turn still seeds the active slice and returns early; live `turn.ended` events keep overwriting `lastTurn` as before.

## Tests

- New cases in `test/agent/activityView/activityView.test.ts`: seeds `lastTurn` from the wire model on cold resume; stays empty when the wire has no ended turn.
- Full `agent-core-v2` suite: 4714 passed; repo lint 0 errors; kap-server typecheck clean.

## Downstream

The desktop app (kimi-code-app) renders a persistent failed-turn card off `lastTurnReason` — this restores it across server restarts. A submodule bump there will follow once this lands.