### PR TITLE
fix(webui): wrap long unbroken text in markdown table cells

### DIFF
--- a/.changeset/fix-webui-table-overflow.md
+++ b/.changeset/fix-webui-table-overflow.md
@@ -1,0 +1,9 @@
+---
+"@moonshot-ai/kimi-web": patch
+---
+
+Fix markdown table overflow with long unbroken text in Web UI
+
+Add `overflow-wrap: anywhere` to table cells so long continuous text
+(URLs, base64, tokens) wraps inside the cell instead of stretching the
+table past the chat container width.

--- a/apps/kimi-web/src/components/chat/Markdown.vue
+++ b/apps/kimi-web/src/components/chat/Markdown.vue
@@ -726,6 +726,7 @@ function copyDiff(code: string, idx: number) {
   border: 1px solid var(--color-line);
   padding: 4px 10px;
   text-align: left;
+  overflow-wrap: anywhere;
 }
 .md :deep(table:not(.table-node) th) {
   background: var(--color-surface);
@@ -786,6 +787,13 @@ function copyDiff(code: string, idx: number) {
   display: inline-block;
   max-width: var(--p-table-cell-max);
   vertical-align: top;
+  /* break-word handles most prose, but long unbroken runs (URLs, base64,
+     tokens) still expand the column past --p-table-cell-max under
+     table-layout:auto because Chromium treats them as a single min-content
+     unit. `overflow-wrap: anywhere` (CSS Text 4) breaks anywhere needed, so
+     the column stops at the cap and the text wraps inside the cell instead
+     of stretching the table past the chat container (#2560). */
+  overflow-wrap: anywhere;
 }
 
 /* Drop markstream-vue's default table-row hover background — the conversation


### PR DESCRIPTION
## Related Issue

Resolve #2560

## Problem

Markdown tables rendered in the Web UI lack effective width constraints for long unbroken text (URLs, base64 strings, tokens). The existing `break-word` + `max-width` clamp on `.table-node .text-node` does not break long unbroken runs under Chromium's `table-layout: auto`, causing the table to stretch past the chat container and create a global horizontal scrollbar.

## Solution

Add `overflow-wrap: anywhere` (CSS Text 4) to both `.table-node .text-node` cells and raw HTML table cells (`td`/`th`). Unlike `break-word`, `anywhere` forces breaks at arbitrary points within long unbroken runs, so the column stops at `--p-table-cell-max` and the text wraps inside the cell instead of stretching the table.

## Verification

- Confirmed the existing `overflow-x: auto` wrapper + `max-width` clamp handles multi-column wide tables (scrolls inside the wrapper)
- The new `overflow-wrap: anywhere` specifically targets the long-unbroken-single-cell case that `break-word` misses under Chromium
- No impact on normal prose tables (short cells already wrap correctly)

## Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
