### PR TITLE
fix: classify context-overflow 401 responses correctly

### DIFF
--- a/.changeset/context-overflow-auth-classification.md
+++ b/.changeset/context-overflow-auth-classification.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Fix context-window 401 responses being reported as authentication failures in CLI and ACP sessions.

--- a/packages/acp-adapter/src/session.ts
+++ b/packages/acp-adapter/src/session.ts
@@ -774,6 +774,8 @@ export class AcpSession {
    *  - Auth-coded errors (`AUTH_LOGIN_REQUIRED`, `PROVIDER_AUTH_ERROR`)
    *    surface as `RequestError.authRequired()` so the ACP client can
    *    drive its own re-auth UX rather than a generic internal error.
+   *  - `CONTEXT_OVERFLOW` surfaces as an internal error carrying its public,
+   *    actionable provider message.
    *  - Everything else becomes `RequestError.internalError(...)` with
    *    the stack/message logged to the agent log file but NOT exposed
    *    to the client (the JSON-RPC layer would otherwise leak details).
@@ -1230,13 +1232,10 @@ export class AcpSession {
           if (!isFromMainAgent(event)) return;
           settled = true;
           if (event.reason === 'failed') {
-            // Failures bubble up via the SDK `error` payload. Phase 11.1
-            // upgrades the prior "log + resolve end_turn" behaviour to
-            // route auth-coded failures through `RequestError.authRequired()`
-            // so the client can trigger its re-auth UX. Other failure
-            // codes still resolve with `end_turn` (the spec discourages
-            // signaling errors through `stopReason`; the failure is
-            // observable in the log).
+            // Failures bubble up via the SDK `error` payload. Auth failures
+            // trigger the client's re-auth UX, while context overflow keeps
+            // the provider's actionable limit message. Other failure codes
+            // still resolve with `end_turn` and remain observable in the log.
             log.warn('acp: turn ended with failed reason', {
               sessionId,
               error: event.error,
@@ -1245,9 +1244,9 @@ export class AcpSession {
             startedToolCalls.clear();
             this.currentTurnId = undefined;
             unsub();
-            const authErr = authRequiredFromPayload(event.error);
-            if (authErr) {
-              reject(authErr);
+            const requestError = promptRequestErrorFromPayload(event.error);
+            if (requestError) {
+              reject(requestError);
               return;
             }
           } else {
@@ -1454,13 +1453,11 @@ export class AcpSession {
  * Map a Kimi SDK error (raw `Error`, `KimiError`, or `KimiErrorPayload`)
  * into the ACP {@link RequestError} shape used by the JSON-RPC layer.
  *
- * Auth-coded inputs (`auth.login_required`, `provider.auth_error`)
- * become `RequestError.authRequired()` so the client can drive its own
- * re-auth UX. Everything else becomes `RequestError.internalError(...)`
- * with the raw error logged to the agent log file but NOT exposed in
- * the JSON-RPC response — the client only sees the canonical
- * "session prompt failed" message, preventing accidental leakage of
- * stack frames or PII through the wire.
+ * Auth-coded inputs (`auth.login_required`, `provider.auth_error`) become
+ * `RequestError.authRequired()` so the client can drive its own re-auth UX.
+ * `context.overflow` carries its public provider message; everything else
+ * becomes `RequestError.internalError(...)` with the raw error logged but not
+ * exposed, preventing accidental leakage of stack frames or PII.
  *
  * The kimi-cli Python reference performs the same mapping at
  * `kimi-cli/src/kimi_cli/acp/session.py:218-247`; this is the TS port.
@@ -1593,13 +1590,13 @@ function detectLeadingSlashIntent(
 }
 
 function mapPromptError(err: unknown, sessionId: string): RequestError {
-  const authErr = authRequiredFromUnknown(err);
-  if (authErr) {
-    log.warn('acp: prompt rejected with auth error; mapping to authRequired', {
+  const requestError = promptRequestErrorFromUnknown(err);
+  if (requestError) {
+    log.warn('acp: prompt rejected with a public provider error', {
       sessionId,
       error: err instanceof Error ? err.message : String(err),
     });
-    return authErr;
+    return requestError;
   }
   log.error('acp: prompt failed', {
     sessionId,
@@ -1609,22 +1606,18 @@ function mapPromptError(err: unknown, sessionId: string): RequestError {
 }
 
 /**
- * Inspect a {@link KimiErrorPayload} (as carried on `turn.ended`
- * failed events) and return a `RequestError.authRequired()` if its
- * `code` is one of the auth-required codes; otherwise `undefined`.
+ * Inspect a {@link KimiErrorPayload} carried on a failed `turn.ended` event
+ * and map public auth/context failures to their ACP request error.
  *
- * Kept separate from {@link authRequiredFromUnknown} because the
+ * Kept separate from {@link promptRequestErrorFromUnknown} because the
  * `turn.ended` event hands us a serialized payload (no class identity
- * to branch on) — we only need the `code` discriminator here.
+ * to branch on).
  */
-function authRequiredFromPayload(
-  payload: { readonly code: unknown } | undefined,
+function promptRequestErrorFromPayload(
+  payload: { readonly code: unknown; readonly message?: unknown } | undefined,
 ): RequestError | undefined {
   if (!payload) return undefined;
-  if (isAuthErrorCode(payload.code)) {
-    return RequestError.authRequired();
-  }
-  return undefined;
+  return promptRequestError(payload.code, payload.message);
 }
 
 /**
@@ -1640,19 +1633,25 @@ function isAuthErrorCode(code: unknown): boolean {
 }
 
 /**
- * Best-effort detection of "auth required" for the `session.prompt(...)`
- * rejection path. The thrown value MAY be:
+ * Best-effort mapping for the `session.prompt(...)` rejection path. The
+ * thrown value MAY be:
  *  - A `KimiError` instance with a recognized `code` field.
  *  - A plain object that happens to expose a `code` (covers RPC-layer
  *    deserialized payloads that lost class identity).
  *  - Anything else — returns `undefined`.
  */
-function authRequiredFromUnknown(err: unknown): RequestError | undefined {
+function promptRequestErrorFromUnknown(err: unknown): RequestError | undefined {
   if (err && typeof err === 'object' && 'code' in err) {
-    const code = (err as { code?: unknown }).code;
-    if (isAuthErrorCode(code)) {
-      return RequestError.authRequired();
-    }
+    const coded = err as { code?: unknown; message?: unknown };
+    return promptRequestError(coded.code, coded.message);
+  }
+  return undefined;
+}
+
+function promptRequestError(code: unknown, message: unknown): RequestError | undefined {
+  if (isAuthErrorCode(code)) return RequestError.authRequired();
+  if (code === ErrorCodes.CONTEXT_OVERFLOW && typeof message === 'string' && message.length > 0) {
+    return RequestError.internalError(undefined, message);
   }
   return undefined;
 }

--- a/packages/acp-adapter/test/error-mapping.test.ts
+++ b/packages/acp-adapter/test/error-mapping.test.ts
@@ -163,15 +163,44 @@ describe('AcpServer error mapping', () => {
     ).rejects.toMatchObject({ code: -32000 });
   });
 
-  it('resolves with end_turn when turn.ended fails with a non-auth code (log-only path)', async () => {
-    // Non-auth failures stay on the existing log-and-resolve path so
-    // the client is unblocked. The error appears in the agent log;
-    // `stopReason` does not signal it (ACP spec discourages errors-via-stopReason).
+  it('preserves a context-overflow message from a failed turn', async () => {
     const sessionId = 'sess-context-overflow';
     const errorPayload: KimiErrorPayload = {
       code: ErrorCodes.CONTEXT_OVERFLOW,
-      message: 'Context window exceeded',
+      message: 'example-256k supports only 256K context.',
       retryable: true,
+    };
+    const { session, unsubscribeCount } = makeScriptedSession(sessionId, {
+      script: [
+        {
+          type: 'turn.ended',
+          sessionId,
+          agentId: 'main',
+          turnId: 1,
+          reason: 'failed',
+          error: errorPayload,
+        } as Event,
+      ],
+    });
+
+    const { agentStream, clientStream } = makeInMemoryStreamPair();
+    new AgentSideConnection((c) => new AcpServer(makeHarnessWithSession(session), c), agentStream);
+    const client = new ClientSideConnection(() => new StubClient(), clientStream);
+
+    await client.newSession({ cwd: '/tmp/x', mcpServers: [] });
+    await expect(client.prompt({ sessionId, prompt: [textBlock('hi')] })).rejects.toMatchObject({
+      code: -32603,
+      message: 'Internal error: example-256k supports only 256K context.',
+    });
+    expect(unsubscribeCount()).toBe(1);
+  });
+
+  it('resolves with end_turn when a failed turn has an unrelated error code', async () => {
+    const sessionId = 'sess-generic-failed-turn';
+    const errorPayload: KimiErrorPayload = {
+      code: ErrorCodes.COMPACTION_FAILED,
+      message: 'Compaction failed',
+      retryable: false,
     };
     const { session, unsubscribeCount } = makeScriptedSession(sessionId, {
       script: [
@@ -210,6 +239,26 @@ describe('AcpServer error mapping', () => {
     await expect(
       client.prompt({ sessionId, prompt: [textBlock('hi')] }),
     ).rejects.toMatchObject({ code: -32000 });
+  });
+
+  it('preserves a synchronous context-overflow rejection message', async () => {
+    const sessionId = 'sess-prompt-rejects-context';
+    const { session } = makeScriptedSession(sessionId, {
+      rejectWith: new KimiError(
+        ErrorCodes.CONTEXT_OVERFLOW,
+        'example-256k supports only 256K context.',
+      ),
+    });
+
+    const { agentStream, clientStream } = makeInMemoryStreamPair();
+    new AgentSideConnection((c) => new AcpServer(makeHarnessWithSession(session), c), agentStream);
+    const client = new ClientSideConnection(() => new StubClient(), clientStream);
+
+    await client.newSession({ cwd: '/tmp/x', mcpServers: [] });
+    await expect(client.prompt({ sessionId, prompt: [textBlock('hi')] })).rejects.toMatchObject({
+      code: -32603,
+      message: 'Internal error: example-256k supports only 256K context.',
+    });
   });
 
   it('maps a generic session.prompt rejection to internalError (-32603) without leaking the stack', async () => {

--- a/packages/agent-core-v2/src/agent/fullCompaction/fullCompactionService.ts
+++ b/packages/agent-core-v2/src/agent/fullCompaction/fullCompactionService.ts
@@ -754,7 +754,8 @@ export class AgentFullCompactionService extends Disposable implements IAgentFull
       if (
         isError2(error) &&
         (error.code === ErrorCodes.AUTH_LOGIN_REQUIRED ||
-          error.code === ErrorCodes.PROVIDER_AUTH_ERROR)
+          error.code === ErrorCodes.PROVIDER_AUTH_ERROR ||
+          error.code === ErrorCodes.CONTEXT_OVERFLOW)
       ) {
         throw error;
       }

--- a/packages/agent-core-v2/src/agent/fullCompaction/fullCompactionService.ts
+++ b/packages/agent-core-v2/src/agent/fullCompaction/fullCompactionService.ts
@@ -84,6 +84,7 @@ const OVERFLOW_CONTEXT_SAFETY_RATIO = 0.85;
 const OVERFLOW_STATUS_RECOVERY_RATIO = 0.5;
 const MAX_COMPACTION_OVERFLOW_SHRINK_ATTEMPTS = 3;
 const COMPACTION_OVERFLOW_SHRINK_RATIOS = [0.7, 0.5, 0.35] as const;
+const COMPACTION_CONTEXT_OVERFLOW_REASON = 'compaction_context_overflow';
 const EMPTY_TOOL_PARAMETERS: Record<string, unknown> = {
   type: 'object',
   properties: {},
@@ -298,7 +299,9 @@ export class AgentFullCompactionService extends Disposable implements IAgentFull
     error: unknown,
     estimatedRequestTokens = this.currentRequestTokens(),
   ): boolean {
-    if (isCodedError(error) && error.code === ErrorCodes.CONTEXT_OVERFLOW) return true;
+    if (isCodedError(error) && error.code === ErrorCodes.CONTEXT_OVERFLOW) {
+      return error.details?.['reason'] !== COMPACTION_CONTEXT_OVERFLOW_REASON;
+    }
     const statusError = findAPIStatusError(error);
     if (statusError instanceof APIContextOverflowError) return true;
     if (statusError === undefined || statusError.statusCode !== 413) return false;
@@ -751,11 +754,19 @@ export class AgentFullCompactionService extends Disposable implements IAgentFull
         trace_id: findAPIStatusError(error)?.traceId ?? active.traceId,
       };
       this.telemetry.track2('compaction_failed', properties);
+      if (isError2(error) && error.code === ErrorCodes.CONTEXT_OVERFLOW) {
+        throw new Error2(ErrorCodes.CONTEXT_OVERFLOW, error.message, {
+          cause: error,
+          details: {
+            ...error.details,
+            reason: COMPACTION_CONTEXT_OVERFLOW_REASON,
+          },
+        });
+      }
       if (
         isError2(error) &&
         (error.code === ErrorCodes.AUTH_LOGIN_REQUIRED ||
-          error.code === ErrorCodes.PROVIDER_AUTH_ERROR ||
-          error.code === ErrorCodes.CONTEXT_OVERFLOW)
+          error.code === ErrorCodes.PROVIDER_AUTH_ERROR)
       ) {
         throw error;
       }

--- a/packages/agent-core-v2/src/kosong/contract/errors.ts
+++ b/packages/agent-core-v2/src/kosong/contract/errors.ts
@@ -52,7 +52,8 @@ export function sanitizeStatusErrorMessage(message: string): string {
   return normalized.replaceAll('\r', '');
 }
 
-function codeForStatusError(statusCode: number): ProviderErrorCode {
+function codeForStatusError(statusCode: number, message: string): ProviderErrorCode {
+  if (isContextOverflowStatusError(statusCode, message)) return CONTEXT_OVERFLOW_ERROR_CODE;
   if (statusCode === 429) return PROVIDER_RATE_LIMIT_ERROR_CODE;
   if (statusCode === 401 || statusCode === 403) return PROVIDER_AUTH_ERROR_CODE;
   if (statusCode === 529) return PROVIDER_OVERLOADED_ERROR_CODE;
@@ -102,7 +103,7 @@ export class APIStatusError extends ChatProviderError {
     requestId?: string | null,
     retryAfterMs?: number | null,
     traceId?: string | null,
-    code: ProviderErrorCode = codeForStatusError(statusCode),
+    code: ProviderErrorCode = codeForStatusError(statusCode, message),
   ) {
     super(sanitizeStatusErrorMessage(message), code, {
       details: { statusCode, requestId: requestId ?? null, traceId: traceId ?? null },
@@ -292,6 +293,7 @@ const CONTEXT_OVERFLOW_MESSAGE_PATTERNS = [
   /context[ _-]?length/,
   /(?:context[ _-]?window.*exceed|exceed.*context[ _-]?window)/,
   /maximum context/,
+  /supports?\s+only\s+[\d,.]+\s*[km]?\s+context/,
   /exceed(?:ed|s|ing)?\s+(?:the\s+)?max(?:imum)?\s+tokens?/,
   /(?:too many tokens.*(?:prompt|input|context)|(?:prompt|input|context).*too many tokens)/,
   /prompt is too long.*maximum/,
@@ -401,7 +403,9 @@ export function parseTraceId(headers: unknown): string | null {
 }
 
 export function isContextOverflowStatusError(statusCode: number, message: string): boolean {
-  if (statusCode !== 400 && statusCode !== 413 && statusCode !== 422) return false;
+  if (statusCode !== 400 && statusCode !== 401 && statusCode !== 413 && statusCode !== 422) {
+    return false;
+  }
   const lowerMessage = message.toLowerCase();
   return CONTEXT_OVERFLOW_MESSAGE_PATTERNS.some((pattern) => pattern.test(lowerMessage));
 }

--- a/packages/agent-core-v2/src/kosong/model/modelRequesterImpl.ts
+++ b/packages/agent-core-v2/src/kosong/model/modelRequesterImpl.ts
@@ -11,18 +11,23 @@
  * The driver itself turns per-turn input (systemPrompt / tools / messages)
  * into the `ModelRequestEvent` stream via the contract's `generate(...)`, measures
  * stream timing (`buildStreamTiming`), and owns the auth-refresh replay: a
- * 401 against a refreshable (OAuth) auth provider triggers one forced token
- * refresh and exactly one replay; a 401 that survives the replay means the
- * provider rejected the account itself, so it is surfaced through
- * `translateProviderError` as `provider.auth_error` carrying the provider's
- * message instead of a misleading re-login prompt.
+ * credential 401 against a refreshable (OAuth) auth provider triggers one
+ * forced token refresh and exactly one replay; a credential 401 that survives
+ * the replay means the provider rejected the account itself, so it is surfaced
+ * through `translateProviderError` as `provider.auth_error` carrying the
+ * provider's message instead of a misleading re-login prompt.
  *
  * Constructed by `ModelCatalog` — plain constructor args, no DI.
  */
 
 import { AsyncEventQueue } from '#/_base/asyncEventQueue';
 import type { VideoURLPart } from '#/kosong/contract/message';
-import { APIStatusError, isAbortError, VideoUploadUnsupportedError } from '#/kosong/contract/errors';
+import {
+  APIStatusError,
+  isAbortError,
+  isContextOverflowStatusError,
+  VideoUploadUnsupportedError,
+} from '#/kosong/contract/errors';
 import { generate, type GenerateResult } from '#/kosong/contract/generate';
 import type {
   ChatProvider,
@@ -211,7 +216,11 @@ export class ModelRequesterImpl implements ModelRequester {
 }
 
 function isUnauthorizedStatusError(error: unknown): error is APIStatusError {
-  return error instanceof APIStatusError && error.statusCode === 401;
+  return (
+    error instanceof APIStatusError &&
+    error.statusCode === 401 &&
+    !isContextOverflowStatusError(error.statusCode, error.message)
+  );
 }
 
 type MutableModelRequestTiming = { -readonly [K in keyof ModelRequestTiming]: ModelRequestTiming[K] };

--- a/packages/agent-core-v2/test/agent/fullCompaction/fullCompaction.test.ts
+++ b/packages/agent-core-v2/test/agent/fullCompaction/fullCompaction.test.ts
@@ -1141,8 +1141,10 @@ describe('FullCompaction', () => {
     await ctx.expectResumeMatches();
   });
 
-  it('preserves context.overflow when auto compaction exceeds the model window', async () => {
+  it('fails after one auto compaction when compaction exceeds the model window', async () => {
+    let attempts = 0;
     const generate: GenerateFn = async () => {
+      attempts += 1;
       throw new APIContextOverflowError(401, 'example-256k supports only 256K context.');
     };
     const ctx = testAgent({ generate });
@@ -1155,6 +1157,7 @@ describe('FullCompaction', () => {
     await ctx.rpc.prompt({ input: [{ type: 'text', text: 'x'.repeat(40) }] });
     const events = await ctx.untilTurnEnd();
 
+    expect(attempts).toBe(2);
     expect(events).toContainEqual(
       expect.objectContaining({
         event: 'turn.ended',

--- a/packages/agent-core-v2/test/agent/fullCompaction/fullCompaction.test.ts
+++ b/packages/agent-core-v2/test/agent/fullCompaction/fullCompaction.test.ts
@@ -1141,6 +1141,35 @@ describe('FullCompaction', () => {
     await ctx.expectResumeMatches();
   });
 
+  it('preserves context.overflow when auto compaction exceeds the model window', async () => {
+    const generate: GenerateFn = async () => {
+      throw new APIContextOverflowError(401, 'example-256k supports only 256K context.');
+    };
+    const ctx = testAgent({ generate });
+    ctx.configure({
+      provider: CATALOGUED_PROVIDER,
+      modelCapabilities: { ...CATALOGUED_MODEL_CAPABILITIES, max_context_tokens: 14 },
+    });
+    ctx.appendExchange(1, 'old user one', 'old assistant one', 1);
+
+    await ctx.rpc.prompt({ input: [{ type: 'text', text: 'x'.repeat(40) }] });
+    const events = await ctx.untilTurnEnd();
+
+    expect(events).toContainEqual(
+      expect.objectContaining({
+        event: 'turn.ended',
+        args: expect.objectContaining({
+          reason: 'failed',
+          error: expect.objectContaining({
+            code: 'context.overflow',
+            message: 'example-256k supports only 256K context.',
+          }),
+        }),
+      }),
+    );
+    await ctx.expectResumeMatches();
+  });
+
   it('aborts an in-flight compaction when the agent is disposed', async () => {
     const started = deferred<void>();
     let signal: AbortSignal | undefined;

--- a/packages/agent-core-v2/test/app/llmProtocol/errors.test.ts
+++ b/packages/agent-core-v2/test/app/llmProtocol/errors.test.ts
@@ -360,6 +360,7 @@ describe('normalizeAPIStatusError', () => {
   it.each([
     [400, 'Context length exceeded'],
     [400, 'Exceeded max tokens'],
+    [401, 'example-256k supports only 256K context.'],
     [413, 'Context length exceeded'],
     [422, 'Maximum context window exceeded'],
     [400, 'context_length_exceeded'],
@@ -375,7 +376,6 @@ describe('normalizeAPIStatusError', () => {
   });
 
   it.each([
-    [401, 'Context length exceeded'],
     [500, 'Context length exceeded'],
     [400, 'Bad request'],
     [422, 'Invalid tool schema'],

--- a/packages/agent-core-v2/test/kosong/contract/errors.test.ts
+++ b/packages/agent-core-v2/test/kosong/contract/errors.test.ts
@@ -172,6 +172,9 @@ describe('classifyApiError', () => {
   it('classifies status errors by status code', () => {
     expect(classifyApiError(new APIStatusError(401, 'Unauthorized')).kind).toBe('auth');
     expect(classifyApiError(new APIStatusError(403, 'Forbidden')).kind).toBe('auth');
+    expect(
+      classifyApiError(new APIStatusError(401, 'example-256k supports only 256K context.')).kind,
+    ).toBe('context_overflow');
     expect(classifyApiError(new APIStatusError(500, 'Internal')).kind).toBe('5xx_server');
     expect(classifyApiError(new APIStatusError(422, 'Nope')).kind).toBe('4xx_client');
     // A 413 phrased as token overflow routes to compaction, not 4xx.

--- a/packages/agent-core-v2/test/kosong/model/modelRequester.test.ts
+++ b/packages/agent-core-v2/test/kosong/model/modelRequester.test.ts
@@ -244,6 +244,31 @@ describe('ModelRequesterImpl request execution', () => {
     expect(authCalls).toEqual([{}, { force: true }]);
   });
 
+  it('surfaces a context-overflow 401 without refreshing credentials', async () => {
+    const provider = new FakeChatProvider();
+    provider.handler = () =>
+      Promise.reject(new APIStatusError(401, 'example-256k supports only 256K context.'));
+    const authCalls: Array<{ force?: boolean }> = [];
+    const requester = new ModelRequesterImpl(
+      modelWith({
+        canRefresh: true,
+        getAuth: (options) => {
+          authCalls.push(options ?? {});
+          return Promise.resolve({ apiKey: 'tok' });
+        },
+      }),
+      registryReturning(provider),
+    );
+
+    const failure = await collect(requester.request(INPUT)).catch((error: unknown) => error);
+    expect(failure).toMatchObject({
+      code: ProtocolErrors.codes.CONTEXT_OVERFLOW,
+      message: 'example-256k supports only 256K context.',
+    });
+    expect(provider.calls).toHaveLength(1);
+    expect(authCalls).toEqual([{}]);
+  });
+
   it('surfaces a replay-surviving 401 as provider.auth_error', async () => {
     const provider = new FakeChatProvider();
     provider.handler = () => Promise.reject(new APIStatusError(401, 'account rejected'));

--- a/packages/agent-core/src/agent/compaction/full.ts
+++ b/packages/agent-core/src/agent/compaction/full.ts
@@ -12,10 +12,10 @@ import {
   type GenerateResult,
   type Message,
   type TokenUsage,
-  APIContextOverflowError,
   APIRequestTooLargeError,
   APIStatusError,
   createUserMessage,
+  isContextOverflowStatusError,
   isImageFormatError,
 } from '@moonshot-ai/kosong';
 
@@ -142,7 +142,7 @@ export class FullCompaction {
     error: unknown,
     estimatedRequestTokens = this.estimateCurrentRequestTokens(),
   ): boolean {
-    if (error instanceof APIContextOverflowError) return true;
+    if (isContextOverflowStatus(error)) return true;
     if (!(error instanceof APIStatusError) || error.statusCode !== 413) return false;
     const effectiveMax = this.getEffectiveMaxContextTokens();
     return (
@@ -658,6 +658,22 @@ export class FullCompaction {
         error_type: error instanceof Error ? error.name : 'Unknown',
         trace_id: this.lastTraceId,
       });
+      if (isContextOverflowStatus(error)) {
+        throw new KimiError(ErrorCodes.CONTEXT_OVERFLOW, error.message, {
+          cause: error,
+          details: {
+            reason: 'compaction_context_overflow',
+            statusCode: error.statusCode,
+            requestId: error.requestId,
+          },
+        });
+      }
+      if (isKimiError(error) && error.code === ErrorCodes.CONTEXT_OVERFLOW) {
+        throw new KimiError(ErrorCodes.CONTEXT_OVERFLOW, error.message, {
+          cause: error,
+          details: { ...error.details, reason: 'compaction_context_overflow' },
+        });
+      }
       if (
         isKimiError(error) &&
         (error.code === ErrorCodes.AUTH_LOGIN_REQUIRED ||
@@ -697,6 +713,13 @@ export class FullCompaction {
       },
     });
   }
+}
+
+function isContextOverflowStatus(error: unknown): error is APIStatusError {
+  return (
+    error instanceof APIStatusError &&
+    isContextOverflowStatusError(error.statusCode, error.message)
+  );
 }
 
 const MAX_COMPACTION_OVERFLOW_SHRINK_ATTEMPTS = 3;

--- a/packages/agent-core/src/agent/turn/index.ts
+++ b/packages/agent-core/src/agent/turn/index.ts
@@ -1025,9 +1025,14 @@ export class TurnFlow {
 
         return result.stopReason;
       } catch (error) {
+        const isCompactionContextOverflow =
+          isKimiError(error) &&
+          error.code === ErrorCodes.CONTEXT_OVERFLOW &&
+          error.details?.['reason'] === 'compaction_context_overflow';
         const isContextOverflow =
-          error instanceof APIContextOverflowError ||
-          (isKimiError(error) && error.code === ErrorCodes.CONTEXT_OVERFLOW);
+          !isCompactionContextOverflow &&
+          (error instanceof APIContextOverflowError ||
+            (isKimiError(error) && error.code === ErrorCodes.CONTEXT_OVERFLOW));
         const estimatedRequestTokens = isContextOverflow
           ? this.agent.fullCompaction.estimateCurrentRequestTokens()
           : undefined;
@@ -1552,11 +1557,11 @@ function classifyApiError(error: unknown, summary: KimiErrorPayload): ApiErrorCl
   const statusCode = apiStatusCode(error) ?? summaryStatusCode(summary);
   if (statusCode !== undefined) {
     if (statusCode === 429) return { errorType: 'rate_limit', statusCode };
-    if (statusCode === 401 || statusCode === 403) return { errorType: 'auth', statusCode };
-    if (statusCode >= 500) return { errorType: '5xx_server', statusCode };
     if (isContextOverflowStatusError(statusCode, summary.message)) {
       return { errorType: 'context_overflow', statusCode };
     }
+    if (statusCode === 401 || statusCode === 403) return { errorType: 'auth', statusCode };
+    if (statusCode >= 500) return { errorType: '5xx_server', statusCode };
     if (statusCode >= 400) return { errorType: '4xx_client', statusCode };
     return { errorType: 'api', statusCode };
   }

--- a/packages/agent-core/src/errors/serialize.ts
+++ b/packages/agent-core/src/errors/serialize.ts
@@ -5,6 +5,7 @@ import {
   APIStatusError,
   APITimeoutError,
   ChatProviderError,
+  isContextOverflowStatusError,
 } from '@moonshot-ai/kosong';
 
 import { KimiError } from './classes';
@@ -58,8 +59,9 @@ export function makeErrorPayload(
  *
  * Recognized errors:
  * - `KimiError`: passthrough.
- * - `APIStatusError`: 429 -> rate_limit, 401 -> auth_error, otherwise -> api_error.
- *   Exception: a quota-exhausted 429 maps to api_error (retryable: false) —
+ * - `APIStatusError`: context-limit wording -> context.overflow, 429 ->
+ *   rate_limit, 401 -> auth_error, otherwise -> api_error. A quota-exhausted
+ *   429 maps to api_error (retryable: false) —
  *   the rate_limit code would re-mint a rate-limit error across the wire
  *   boundary and drive the swarm requeue/suspend loop, which cannot help
  *   until the account is recharged.
@@ -84,11 +86,13 @@ export function toKimiErrorPayload(error: unknown): KimiErrorPayload {
     const code: KimiErrorCode =
       error instanceof APIProviderQuotaExhaustedError
         ? ErrorCodes.PROVIDER_API_ERROR
-        : error.statusCode === 429
-          ? ErrorCodes.PROVIDER_RATE_LIMIT
-          : error.statusCode === 401
-            ? ErrorCodes.PROVIDER_AUTH_ERROR
-            : ErrorCodes.PROVIDER_API_ERROR;
+        : isContextOverflowStatusError(error.statusCode, error.message)
+          ? ErrorCodes.CONTEXT_OVERFLOW
+          : error.statusCode === 429
+            ? ErrorCodes.PROVIDER_RATE_LIMIT
+            : error.statusCode === 401
+              ? ErrorCodes.PROVIDER_AUTH_ERROR
+              : ErrorCodes.PROVIDER_API_ERROR;
     return {
       code,
       message: sanitizeStatusErrorMessage(error.message),

--- a/packages/agent-core/src/session/provider-manager.ts
+++ b/packages/agent-core/src/session/provider-manager.ts
@@ -4,6 +4,7 @@ import {
   APIStatusError,
   classifyKimiQuotaError,
   getModelCapability,
+  isContextOverflowStatusError,
   UNKNOWN_CAPABILITY,
 } from '@moonshot-ai/kosong';
 import { parseKimiCodeCustomHeaders } from '@moonshot-ai/kimi-code-oauth';
@@ -214,7 +215,13 @@ export class ProviderManager implements ModelProvider {
         try {
           return await request(auth);
         } catch (error) {
-          if (!(error instanceof APIStatusError) || error.statusCode !== 401) throw error;
+          if (
+            !(error instanceof APIStatusError) ||
+            error.statusCode !== 401 ||
+            isContextOverflowStatusError(error.statusCode, error.message)
+          ) {
+            throw error;
+          }
           if (refreshed) {
             const reason = error.message.replaceAll('\r', '');
             throw new KimiError(

--- a/packages/agent-core/test/agent/compaction/full.test.ts
+++ b/packages/agent-core/test/agent/compaction/full.test.ts
@@ -1053,6 +1053,31 @@ describe('FullCompaction', () => {
     await ctx.expectResumeMatches();
   });
 
+  it('preserves context.overflow when auto compaction exceeds the model window', async () => {
+    const generate: GenerateFn = async () => {
+      throw new APIStatusError(401, 'example-256k supports only 256K context.');
+    };
+    const ctx = testAgent({ generate, compactionStrategy: alwaysCompactOnce });
+    ctx.configure();
+
+    await ctx.rpc.prompt({ input: [{ type: 'text', text: 'Trigger overflowing compaction' }] });
+    const events = await ctx.untilTurnEnd();
+
+    expect(events).toContainEqual(
+      expect.objectContaining({
+        event: 'turn.ended',
+        args: expect.objectContaining({
+          reason: 'failed',
+          error: expect.objectContaining({
+            code: 'context.overflow',
+            message: 'example-256k supports only 256K context.',
+          }),
+        }),
+      }),
+    );
+    await ctx.expectResumeMatches();
+  });
+
   it('names truncated compaction responses when retries are exhausted', async () => {
     vi.useFakeTimers();
     let attempts = 0;

--- a/packages/agent-core/test/agent/turn.test.ts
+++ b/packages/agent-core/test/agent/turn.test.ts
@@ -2165,6 +2165,13 @@ describe('Agent turn flow', () => {
       statusCode: 401,
     },
     {
+      name: '401 context overflow status',
+      createError: () =>
+        new APIStatusError(401, 'example-256k supports only 256K context.', 'req-context-401'),
+      errorType: 'context_overflow',
+      statusCode: 401,
+    },
+    {
       name: '403 status',
       createError: () => new APIStatusError(403, 'Forbidden', 'req-403'),
       errorType: 'auth',

--- a/packages/agent-core/test/errors/serialize.test.ts
+++ b/packages/agent-core/test/errors/serialize.test.ts
@@ -47,6 +47,18 @@ describe('toKimiErrorPayload — APIStatusError message sanitization', () => {
       'provider.auth_error',
     );
   });
+
+  it('maps a context-limit 401 to context.overflow and preserves its message', () => {
+    const payload = toKimiErrorPayload(
+      new APIStatusError(401, 'example-256k supports only 256K context.'),
+    );
+
+    expect(payload).toMatchObject({
+      code: 'context.overflow',
+      message: 'example-256k supports only 256K context.',
+      details: { statusCode: 401 },
+    });
+  });
 });
 
 describe('toKimiErrorPayload — quota-exhausted 429', () => {

--- a/packages/agent-core/test/harness/runtime-provider.test.ts
+++ b/packages/agent-core/test/harness/runtime-provider.test.ts
@@ -1,4 +1,4 @@
-import { classifyKimiQuotaError } from '@moonshot-ai/kosong';
+import { APIStatusError, classifyKimiQuotaError } from '@moonshot-ai/kosong';
 import { describe, expect, it } from 'vitest';
 
 import type { KimiConfig, ModelAlias } from '../../src/config';
@@ -1036,6 +1036,31 @@ describe('ProviderManager OAuth auth', () => {
     await expect(resolveAuth!(async () => 'ok')).rejects.toMatchObject({
       code: ErrorCodes.AUTH_LOGIN_REQUIRED,
     });
+  });
+
+  it('surfaces a context-overflow 401 without refreshing credentials', async () => {
+    const tokenCalls: Array<boolean | undefined> = [];
+    const manager = new ProviderManager({
+      config: oauthConfig(),
+      resolveOAuthTokenProvider: () => ({
+        getAccessToken(options) {
+          tokenCalls.push(options?.force);
+          return Promise.resolve('oauth-token');
+        },
+      }),
+    });
+    const overflow = new APIStatusError(401, 'example-256k supports only 256K context.');
+    let requestCount = 0;
+
+    const resolveAuth = manager.resolveAuth('kimi-code/kimi-for-coding');
+    const caught = await resolveAuth!(async () => {
+      requestCount += 1;
+      throw overflow;
+    }).catch((error: unknown) => error);
+
+    expect(caught).toBe(overflow);
+    expect(requestCount).toBe(1);
+    expect(tokenCalls).toEqual([undefined]);
   });
 });
 

--- a/packages/kosong/src/errors.ts
+++ b/packages/kosong/src/errors.ts
@@ -349,6 +349,7 @@ const CONTEXT_OVERFLOW_MESSAGE_PATTERNS = [
   /context[ _-]?length/,
   /(?:context[ _-]?window.*exceed|exceed.*context[ _-]?window)/,
   /maximum context/,
+  /supports?\s+only\s+[\d,.]+\s*[km]?\s+context/,
   /exceed(?:ed|s|ing)?\s+(?:the\s+)?max(?:imum)?\s+tokens?/,
   /(?:too many tokens.*(?:prompt|input|context)|(?:prompt|input|context).*too many tokens)/,
   /prompt is too long.*maximum/,
@@ -483,7 +484,9 @@ export function parseRetryAfterMs(headers: unknown): number | null {
 }
 
 export function isContextOverflowStatusError(statusCode: number, message: string): boolean {
-  if (statusCode !== 400 && statusCode !== 413 && statusCode !== 422) return false;
+  if (statusCode !== 400 && statusCode !== 401 && statusCode !== 413 && statusCode !== 422) {
+    return false;
+  }
   const lowerMessage = message.toLowerCase();
   return CONTEXT_OVERFLOW_MESSAGE_PATTERNS.some((pattern) => pattern.test(lowerMessage));
 }

--- a/packages/kosong/test/errors.test.ts
+++ b/packages/kosong/test/errors.test.ts
@@ -228,6 +228,7 @@ describe('normalizeAPIStatusError', () => {
   it.each([
     [400, 'Context length exceeded'],
     [400, 'Exceeded max tokens'],
+    [401, 'example-256k supports only 256K context.'],
     [413, 'Context length exceeded'],
     [422, 'Maximum context window exceeded'],
     [400, 'context_length_exceeded'],
@@ -243,7 +244,6 @@ describe('normalizeAPIStatusError', () => {
   });
 
   it.each([
-    [401, 'Context length exceeded'],
     [500, 'Context length exceeded'],
     [400, 'Bad request'],
     [422, 'Invalid tool schema'],

--- a/packages/node-sdk/src/kimi-code-model-provider.ts
+++ b/packages/node-sdk/src/kimi-code-model-provider.ts
@@ -21,7 +21,11 @@ import type {
   ProviderConfig as KosongProviderConfig,
   ProviderRequestAuth,
 } from '@moonshot-ai/kosong';
-import { APIStatusError, UNKNOWN_CAPABILITY } from '@moonshot-ai/kosong';
+import {
+  APIStatusError,
+  isContextOverflowStatusError,
+  UNKNOWN_CAPABILITY,
+} from '@moonshot-ai/kosong';
 
 import { mapOAuthTokenError } from '#/oauth-error';
 
@@ -110,7 +114,10 @@ export class KimiForCodingProvider implements ModelProvider {
         try {
           return await request(auth);
         } catch (error) {
-          const is401 = error instanceof APIStatusError && error.statusCode === 401;
+          const is401 =
+            error instanceof APIStatusError &&
+            error.statusCode === 401 &&
+            !isContextOverflowStatusError(error.statusCode, error.message);
           if (!is401) throw error;
           if (refreshed) {
             throw new KimiError(

--- a/packages/node-sdk/test/kimi-code-model-provider.test.ts
+++ b/packages/node-sdk/test/kimi-code-model-provider.test.ts
@@ -9,6 +9,7 @@ import {
   OAuthUnauthorizedError,
   RetryableRefreshError,
 } from '@moonshot-ai/kimi-code-oauth';
+import { APIStatusError } from '@moonshot-ai/kosong';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { ErrorCodes, KimiError, KimiForCodingProvider } from '#/index';
@@ -41,6 +42,42 @@ describe('KimiForCodingProvider OAuth error mapping', () => {
     await expect(auth(async () => 'ok')).rejects.toMatchObject({
       code: ErrorCodes.AUTH_LOGIN_REQUIRED,
     });
+  });
+
+  it('refreshes credentials once when a request returns an authentication 401', async () => {
+    vi.spyOn(KimiOAuthToolkit.prototype, 'ensureFresh').mockImplementation(
+      (_provider, options) =>
+        Promise.resolve(options?.force === true ? 'refreshed-token' : 'initial-token'),
+    );
+    const requestTokens: string[] = [];
+
+    const auth = resolveAuth();
+    const result = await auth(async (requestAuth) => {
+      requestTokens.push(requestAuth.apiKey ?? '<missing>');
+      if (requestTokens.length === 1) throw new APIStatusError(401, 'Unauthorized');
+      return 'ok';
+    });
+
+    expect(result).toBe('ok');
+    expect(requestTokens).toEqual(['initial-token', 'refreshed-token']);
+  });
+
+  it('surfaces a context-overflow 401 without refreshing credentials', async () => {
+    const ensureFresh = vi
+      .spyOn(KimiOAuthToolkit.prototype, 'ensureFresh')
+      .mockResolvedValue('oauth-token');
+    const overflow = new APIStatusError(401, 'example-256k supports only 256K context.');
+    let requestCount = 0;
+
+    const auth = resolveAuth();
+    const caught = await auth(async () => {
+      requestCount += 1;
+      throw overflow;
+    }).catch((error: unknown) => error);
+
+    expect(caught).toBe(overflow);
+    expect(requestCount).toBe(1);
+    expect(ensureFresh).toHaveBeenCalledTimes(1);
   });
 
   it('maps transient token failures to provider.connection_error', async () => {


### PR DESCRIPTION
## Related Issue

Resolve #2613

## Problem

Some managed models return HTTP 401 when a request exceeds the model context window. The provider message identifies the context limit, but both engines treated every 401 as an authentication failure, retried with a refreshed OAuth token, and ACP ultimately reported `Authentication required`.

## What changed

- Recognize context-limit wording, including `supports only 256K context`, before generic 401 authentication handling in both engines.
- Skip OAuth refresh for those errors while keeping the existing refresh-and-retry behavior for genuine credential failures.
- Preserve `context.overflow` through failed compaction and expose its actionable provider message to ACP clients.
- Add regression coverage for error normalization, OAuth refresh boundaries, compaction propagation, telemetry, serialization, and both ACP failure paths.

## Validation

- Focused Vitest run: 11 files passed, 517 tests passed, 1 skipped.
- TypeScript checks passed for `kosong`, `agent-core`, `agent-core-v2`, `kimi-code-sdk`, and `acp-adapter`.
- `agent-core-v2` import-boundary check passed.
- Repository lint completed with 0 errors.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.
