### PR TITLE
fix(docs): remove stale plan/PLAN references

### DIFF
--- a/packages/agent-core-v2/AGENTS.md
+++ b/packages/agent-core-v2/AGENTS.md
@@ -1,6 +1,6 @@
 # agent-core-v2 Agent Guide
 
-> New agent engine built on the DI Scope architecture — work-in-progress port of `packages/agent-core`. Design: `plan/PLAN.md`. Porting status: `GAP_ANALYSIS.md`.
+> New agent engine built on the DI Scope architecture — work-in-progress port of `packages/agent-core`. Architecture and development guides live in `docs/` below and `.agents/skills/agent-core-dev/`.
 
 ## Scopes
 

--- a/packages/agent-core-v2/docs/flag.md
+++ b/packages/agent-core-v2/docs/flag.md
@@ -106,5 +106,4 @@ if (!this.flags.enabled('my_feature')) return;
 - `packages/agent-core-v2/src/agent/toolSelect/flag.ts` — example per-domain flag contribution.
 - `packages/agent-core-v2/test/flag/flag.test.ts` — precedence + config subscription tests.
 - `packages/agent-core/src/flags/` — v1 source this was ported from.
-- `packages/agent-core-v2/GAP_ANALYSIS.md` §2.1 — gap closure note.
 - Root `AGENTS.md` — experimental-feature gating rule.


### PR DESCRIPTION
## Related Issue

No linked issue. This is a docs-only cleanup for broken internal references; CONTRIBUTING allows opening this kind of PR directly.

## Problem

`packages/agent-core-v2/AGENTS.md` and `packages/agent-core-v2/docs/flag.md` still pointed at `plan/PLAN.md` and `GAP_ANALYSIS.md`, which are not in the repository. Anyone following those links hits dead ends.

Git history shows these paths were never committed; the references date back to #1441 and #2451 already removed the same stale `plan/PLAN.md` link from `flag.md` but left the others.

Happy to adjust if these docs live elsewhere internally; I couldn't find them in git history.

## What changed

- Updated the `agent-core-v2` AGENTS.md intro blurb to point at existing documentation: `docs/` (listed in the same file) and `.agents/skills/agent-core-dev/`.
- Removed the stale `GAP_ANALYSIS.md` reference from `docs/flag.md`.

No behavior or API changes.

## Checklist

- [x] I have read the CONTRIBUTING document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works. (N/A — docs-only)
- [x] Ran gen-changesets skill, or this PR needs no changeset. (Not needed — docs-only)
- [x] Ran gen-docs skill, or this PR needs no doc update. (This PR is the doc update)