### PR TITLE
fix(docs): correct planService path in permission docs

### DIFF
--- a/.agents/skills/agent-core-dev/permission.md
+++ b/.agents/skills/agent-core-dev/permission.md
@@ -113,7 +113,7 @@ Most growth goes through the data path — node count is bounded by "kinds of be
 **Harness constraints and product reviews no longer live on the chain.** A domain that owns one registers an `onBeforeExecuteTool` veto listener and adjudicates through the event:
 
 ```ts
-// src/plan/planService.ts — constructor
+// src/agent/plan/planService.ts — constructor
 constructor(@IAgentToolExecutorService executor, ...) {
   executor.onBeforeExecuteTool((event) => this.guardToolExecution(event));
 }

--- a/packages/agent-core-v2/docs/Permission.md
+++ b/packages/agent-core-v2/docs/Permission.md
@@ -211,7 +211,7 @@ this.policies = registry.list()
 **Harness 约束与产物审批不再上链。** 拥有它们的 domain 注册一个 `onBeforeExecuteTool` veto 监听器，通过事件对象自行裁决：
 
 ```ts
-// src/plan/planService.ts —— 构造函数
+// src/agent/plan/planService.ts —— 构造函数
 constructor(@IAgentToolExecutorService executor, ...) {
   executor.onBeforeExecuteTool((event) => this.guardToolExecution(event));
 }


### PR DESCRIPTION
## Related Issue

No linked issue (docs path correction).

## Problem

The §5.4 code example in the permission docs still points to `src/plan/planService.ts`, a path that no longer exists after the v2 directory reorg. The actual implementation lives at `packages/agent-core-v2/src/agent/plan/planService.ts`. Maintainers following the docs to the source would be misled.

## What changed

Correct the example comment path to `src/agent/plan/planService.ts` in:

- `packages/agent-core-v2/docs/Permission.md`
- `.agents/skills/agent-core-dev/permission.md`

Docs-only fix; no runtime behavior change.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works. *(N/A — docs-only)*
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update. *(this PR is the doc fix)*