### PR TITLE
fix(kosong,agent-core-v2): hoist type into anyOf/oneOf branches

### DIFF
--- a/.changeset/kimi-schema-anyof-type-sibling.md
+++ b/.changeset/kimi-schema-anyof-type-sibling.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Fix chat requests failing with a 400 invalid tool schema error when a connected MCP server publishes a tool whose JSON Schema declares `type` next to `anyOf`/`oneOf`.

--- a/packages/agent-core-v2/src/kosong/provider/providers/kimi/kimi-schema.ts
+++ b/packages/agent-core-v2/src/kosong/provider/providers/kimi/kimi-schema.ts
@@ -1,9 +1,14 @@
 /**
  * `kosong/provider` domain — Kimi tool-schema dialect normalization.
  *
- * Pure functions: dereference local `$ref` pointers by inlining definitions,
- * then complete missing `type` fields from enum/const values or structural
- * keys — the schema dialect the Kimi tool endpoint accepts.
+ * Pure functions that rewrite a tool's JSON Schema into the dialect the Kimi
+ * tool endpoint accepts — provider-compatibility normalization, not a
+ * general-purpose schema compiler: local `$ref` pointers are inlined, the
+ * parameters root (which Moonshot requires to be a typed object) flattens
+ * `anyOf`/`oneOf` unions into one object schema, a `type` declared next to a
+ * nested `anyOf`/`oneOf` (a shape Moonshot rejects) is folded into the union
+ * branches, and missing or value-contradicting `type` fields are repaired
+ * from enum/const values or structural keys.
  *
  * Circular references are detected and left as `$ref` to avoid infinite
  * recursion; in that case the referenced definition bucket is preserved so the
@@ -46,6 +51,8 @@ const TYPE_COMPLETION_SKIP_KEYS = new Set([
   'oneOf',
   'then',
 ]);
+
+const TYPE_HOISTING_COMBINATOR_KEYS = ['anyOf', 'oneOf'] as const;
 
 const CHILD_SCHEMA_SLOTS = [
   { key: '$defs', kind: 'map' },
@@ -119,8 +126,365 @@ function ensureKimiPropertyTypes(schema: Record<string, unknown>): Record<string
       'JSON Schema root must normalize to an object.',
     );
   }
+  flattenRootUnion(normalized);
+  hoistCombinatorTypes(normalized);
   recurseSchema(normalized);
   return normalized;
+}
+
+function flattenRootUnion(root: Record<string, unknown>): void {
+  const variants: VariantEntry[] = [];
+  let flattened = false;
+  let exclusive = true;
+  for (const key of TYPE_HOISTING_COMBINATOR_KEYS) {
+    const value = root[key];
+    if (!Array.isArray(value)) continue;
+    flattened = true;
+    if (key === 'anyOf') exclusive = false;
+    for (const branch of value) {
+      if (mayAcceptAnyObject(branch)) {
+        variants.push({ kind: 'any' });
+      } else if (isObjectBranch(branch)) {
+        variants.push({ kind: 'object', schema: branch });
+      }
+      // Anything else cannot match an object and contributes nothing.
+    }
+    delete root[key];
+  }
+  if (!flattened) return;
+  // One unrestricted variant means no branch-derived constraint can be
+  // imposed on the root: for `anyOf` the union accepts any object, and for
+  // `oneOf` it makes the other variants invalid rather than more permissive —
+  // widening is the only representable outcome either way.
+  const unrestricted = variants.some((variant) => variant.kind === 'any');
+  const branches = unrestricted
+    ? []
+    : variants.flatMap((variant) => (variant.kind === 'object' ? [variant.schema] : []));
+
+  const properties: Record<string, unknown> = isRecord(root['properties'])
+    ? root['properties']
+    : {};
+  const requiredSets: string[][] = [];
+  const branchKeys = new Set<string>();
+  for (const branch of branches) {
+    const branchProperties = branch['properties'];
+    if (isRecord(branchProperties)) {
+      for (const name of Object.keys(branchProperties)) branchKeys.add(name);
+    }
+    requiredSets.push(
+      Array.isArray(branch['required'])
+        ? branch['required'].filter((name): name is string => typeof name === 'string')
+        : [],
+    );
+  }
+  for (const name of branchKeys) {
+    // The root's own property constraint already applied to every branch.
+    if (hasOwn(properties, name)) continue;
+    const variants = new Map<string, Record<string, unknown>>();
+    let unconstrained = false;
+    for (const branch of branches) {
+      const branchProperties = branch['properties'];
+      const patternProperties = branch['patternProperties'];
+      let constraint: unknown;
+      if (isRecord(branchProperties) && hasOwn(branchProperties, name)) {
+        constraint = branchProperties[name];
+      } else if (isRecord(patternProperties) && Object.keys(patternProperties).length > 0) {
+        constraint = true;
+      } else if (hasOwn(branch, 'additionalProperties')) {
+        constraint = branch['additionalProperties'];
+      } else {
+        constraint = true;
+      }
+      if (constraint === false) continue;
+      if (constraint === true || (isRecord(constraint) && Object.keys(constraint).length === 0)) {
+        unconstrained = true;
+        break;
+      }
+      if (!isRecord(constraint)) continue;
+      if (!hasOwn(constraint, 'type') && !hasExactValueType(constraint)) {
+        unconstrained = true;
+        break;
+      }
+      variants.set(canonicalJson(constraint), constraint);
+    }
+    if (unconstrained) continue;
+    const merged = [...variants.values()];
+    const [first] = merged;
+    if (merged.length === 1 && first !== undefined) {
+      properties[name] = first;
+    } else if (merged.length > 1) {
+      properties[name] = { anyOf: merged };
+    }
+  }
+
+  root['type'] = 'object';
+  root['properties'] = properties;
+  const alwaysRequired =
+    requiredSets.length > 0
+      ? requiredSets.reduce((acc, cur) => acc.filter((name) => cur.includes(name)))
+      : [];
+  const rootRequired = Array.isArray(root['required'])
+    ? root['required'].filter((name): name is string => typeof name === 'string')
+    : [];
+  // A `required` naming a property that is not in `properties` is rejected
+  // outright, and dropping one only widens what the wire accepts.
+  const required = [...new Set([...rootRequired, ...alwaysRequired])].filter((name) =>
+    hasOwn(properties, name),
+  );
+  if (required.length > 0) {
+    root['required'] = required;
+  } else {
+    delete root['required'];
+  }
+  const summary = summarizeVariants(variants, properties, exclusive);
+  if (summary !== undefined) {
+    const existing = root['description'];
+    root['description'] =
+      typeof existing === 'string' && existing.trim() !== '' ? `${existing}\n\n${summary}` : summary;
+  }
+}
+
+type VariantEntry = { kind: 'any' } | { kind: 'object'; schema: Record<string, unknown> };
+
+function summarizeVariants(
+  variants: VariantEntry[],
+  properties: Record<string, unknown>,
+  exclusive: boolean,
+): string | undefined {
+  if (variants.length < 2) return undefined;
+  const lines: string[] = [];
+  const described: string[] = [];
+  const dropped = new Map<string, string>();
+  for (const [index, variant] of variants.entries()) {
+    if (variant.kind === 'any') {
+      described.push(`(${index + 1}) any object.`);
+      continue;
+    }
+    const branch = variant.schema;
+    const branchProperties = isRecord(branch['properties']) ? branch['properties'] : {};
+    const declared = Object.keys(branchProperties);
+    const required = (Array.isArray(branch['required']) ? branch['required'] : []).filter(
+      (name): name is string => typeof name === 'string',
+    );
+    for (const name of [...required, ...declared]) {
+      if (hasOwn(properties, name) || dropped.has(name)) continue;
+      const entry = branchProperties[name];
+      const description = isRecord(entry) ? entry['description'] : undefined;
+      dropped.set(name, typeof description === 'string' ? description : '');
+    }
+    const parts: string[] = [];
+    if (required.length > 0) parts.push(`required: ${required.join(', ')}`);
+    const optional = declared.filter((name) => !required.includes(name));
+    if (optional.length > 0) parts.push(`optional: ${optional.join(', ')}`);
+    if (parts.length > 0) described.push(`(${index + 1}) ${parts.join('; ')}.`);
+  }
+  // An `anyOf` with an unrestricted variant accepts any object, so listing
+  // combinations would only mislead; the dropped field names still help.
+  const unrestricted = variants.some((variant) => variant.kind === 'any');
+  if (described.length >= 2 && (exclusive || !unrestricted)) {
+    lines.push(
+      `Valid argument variants (${exclusive ? 'exactly' : 'at least'} one must match): ${described.join(' ')}`,
+    );
+  }
+  if (dropped.size > 0) {
+    lines.push(
+      ['Fields without their own schema entry:']
+        .concat(
+          [...dropped].map(([name, description]) =>
+            description === '' ? `- ${name}` : `- ${name} — ${description}`,
+          ),
+        )
+        .join('\n'),
+    );
+  }
+  return lines.length > 0 ? lines.join('\n\n') : undefined;
+}
+
+function mayAcceptAnyObject(branch: unknown): boolean {
+  if (branch === true) return true;
+  if (!isRecord(branch)) return false;
+  if (hasOwn(branch, 'type')) {
+    const type = branch['type'];
+    const includesObject =
+      type === 'object' || (Array.isArray(type) && type.includes('object'));
+    if (!includesObject) return false;
+  }
+  const values = Array.isArray(branch['enum'])
+    ? branch['enum']
+    : hasOwn(branch, 'const')
+      ? [branch['const']]
+      : undefined;
+  if (values !== undefined) {
+    // Fixed values only match an object when one of them is an object.
+    return values.some((value) => isRecord(value));
+  }
+  return !hasAnyKey(branch, OBJECT_STRUCTURE_KEYS);
+}
+
+function groupValuesByType(values: unknown[]): Map<JsonSchemaType, unknown[]> | undefined {
+  const groups = new Map<JsonSchemaType, unknown[]>();
+  for (const value of values) {
+    const valueType = inferValueType(value);
+    if (valueType === undefined) return undefined;
+    const bucket = groups.get(valueType);
+    if (bucket === undefined) {
+      groups.set(valueType, [value]);
+    } else {
+      bucket.push(value);
+    }
+  }
+  return groups;
+}
+
+function hasExactValueType(schema: Record<string, unknown>): boolean {
+  const enumValues = schema['enum'];
+  if (Array.isArray(enumValues) && enumValues.length > 0) return true;
+  return hasOwn(schema, 'const');
+}
+
+function isObjectBranch(branch: unknown): branch is Record<string, unknown> {
+  if (!isRecord(branch)) return false;
+  const type = branch['type'];
+  if (type === 'object' || (Array.isArray(type) && type.includes('object'))) return true;
+  return !hasOwn(branch, 'type') && hasAnyKey(branch, OBJECT_STRUCTURE_KEYS);
+}
+
+function canonicalJson(value: unknown): string {
+  if (Array.isArray(value)) {
+    return `[${value.map((item) => canonicalJson(item)).join(',')}]`;
+  }
+  if (isRecord(value)) {
+    const entries = Object.keys(value)
+      .toSorted()
+      .map((key) => `${JSON.stringify(key)}:${canonicalJson(value[key])}`);
+    return `{${entries.join(',')}}`;
+  }
+  return JSON.stringify(value) ?? 'null';
+}
+
+function hoistCombinatorTypes(node: Record<string, unknown>): void {
+  for (const key of TYPE_HOISTING_COMBINATOR_KEYS) {
+    const branches = node[key];
+    if (!hasOwn(node, 'type') || !Array.isArray(branches)) continue;
+    const parentType = node['type'];
+    for (let i = branches.length - 1; i >= 0; i--) {
+      const branch: unknown = branches[i];
+      if (branch === true) {
+        branches[i] = { type: cloneJsonValue(parentType) };
+        continue;
+      }
+      // A boolean `false` (or any non-schema) branch is not accepted on the
+      // wire; dropping it only widens the union.
+      if (!isRecord(branch)) {
+        branches.splice(i, 1);
+        continue;
+      }
+      if (constrainBranchType(parentType, branch) === 'dead') {
+        branches.splice(i, 1);
+      }
+    }
+    if (branches.length === 0) {
+      // No live branch left: drop the union and keep the parent constraint —
+      // neither an empty array nor a boolean branch is a legal union member.
+      delete node[key];
+    } else {
+      delete node['type'];
+    }
+  }
+  visitChildSchemas(node, (child) => {
+    if (isRecord(child)) {
+      hoistCombinatorTypes(child);
+    }
+  });
+}
+
+function constrainBranchType(
+  parentType: unknown,
+  branch: Record<string, unknown>,
+): 'kept' | 'dead' {
+  const parent = toTypeSet(parentType);
+  if (parent === undefined) {
+    if (!hasOwn(branch, 'type')) {
+      branch['type'] = cloneJsonValue(parentType);
+    }
+    return 'kept';
+  }
+  let effective = parent;
+  if (hasOwn(branch, 'type')) {
+    const own = toTypeSet(branch['type']);
+    if (own === undefined) return 'kept';
+    effective = intersectTypeSets(effective, own);
+  }
+  if (effective.size === 0) return 'dead';
+
+  const enumValues = branch['enum'];
+  if (Array.isArray(enumValues) && enumValues.length > 0) {
+    const kept = enumValues.filter((value) => valueSatisfiesTypeSet(value, effective));
+    if (kept.length === 0) return 'dead';
+    const groups = groupValuesByType(kept);
+    if (groups !== undefined && groups.size > 1 && !hasOwn(branch, 'anyOf')) {
+      // A mixed-type enum cannot carry one `type`; split it into one typed
+      // variant per value type instead of emitting a mixed declaration.
+      delete branch['type'];
+      delete branch['enum'];
+      branch['anyOf'] = [...groups].map(([type, values]) => ({ type, enum: values }));
+      return 'kept';
+    }
+    branch['enum'] = kept;
+    branch['type'] = typeForValues(kept, effective);
+    return 'kept';
+  }
+  if (hasOwn(branch, 'const')) {
+    if (!valueSatisfiesTypeSet(branch['const'], effective)) return 'dead';
+    branch['type'] = typeForValues([branch['const']], effective);
+    return 'kept';
+  }
+
+  const types = [...effective];
+  const [only] = types;
+  branch['type'] = types.length === 1 && only !== undefined ? only : types;
+  return 'kept';
+}
+
+function typeForValues(values: unknown[], effective: Set<string>): unknown {
+  try {
+    return inferTypeFromValues(values);
+  } catch {}
+  const types = [...effective];
+  const [only] = types;
+  return types.length === 1 && only !== undefined ? only : types;
+}
+
+function valueSatisfiesTypeSet(value: unknown, types: Set<string>): boolean {
+  const valueType = inferValueType(value);
+  if (valueType === undefined) return false;
+  if (types.has(valueType)) return true;
+  return valueType === 'integer' && types.has('number');
+}
+
+function intersectTypeSets(a: Set<string>, b: Set<string>): Set<string> {
+  const result = new Set<string>();
+  for (const type of b) {
+    if (a.has(type)) {
+      result.add(type);
+    } else if (
+      (type === 'number' && a.has('integer')) ||
+      (type === 'integer' && a.has('number'))
+    ) {
+      result.add('integer');
+    }
+  }
+  return result;
+}
+
+function toTypeSet(value: unknown): Set<string> | undefined {
+  if (typeof value === 'string') {
+    return new Set([value]);
+  }
+  if (Array.isArray(value) && value.every((item) => typeof item === 'string')) {
+    return new Set(value);
+  }
+  return undefined;
 }
 
 function hasUnresolvedDefinitionRef(node: unknown, bucketKey: string): boolean {

--- a/packages/agent-core-v2/src/kosong/provider/providers/kimi/kimi-schema.ts
+++ b/packages/agent-core-v2/src/kosong/provider/providers/kimi/kimi-schema.ts
@@ -147,15 +147,10 @@ function flattenRootUnion(root: Record<string, unknown>): void {
       } else if (isObjectBranch(branch)) {
         variants.push({ kind: 'object', schema: branch });
       }
-      // Anything else cannot match an object and contributes nothing.
     }
     delete root[key];
   }
   if (!flattened) return;
-  // One unrestricted variant means no branch-derived constraint can be
-  // imposed on the root: for `anyOf` the union accepts any object, and for
-  // `oneOf` it makes the other variants invalid rather than more permissive —
-  // widening is the only representable outcome either way.
   const unrestricted = variants.some((variant) => variant.kind === 'any');
   const branches = unrestricted
     ? []
@@ -178,7 +173,6 @@ function flattenRootUnion(root: Record<string, unknown>): void {
     );
   }
   for (const name of branchKeys) {
-    // The root's own property constraint already applied to every branch.
     if (hasOwn(properties, name)) continue;
     const variants = new Map<string, Record<string, unknown>>();
     let unconstrained = false;
@@ -226,8 +220,6 @@ function flattenRootUnion(root: Record<string, unknown>): void {
   const rootRequired = Array.isArray(root['required'])
     ? root['required'].filter((name): name is string => typeof name === 'string')
     : [];
-  // A `required` naming a property that is not in `properties` is rejected
-  // outright, and dropping one only widens what the wire accepts.
   const required = [...new Set([...rootRequired, ...alwaysRequired])].filter((name) =>
     hasOwn(properties, name),
   );
@@ -278,8 +270,6 @@ function summarizeVariants(
     if (optional.length > 0) parts.push(`optional: ${optional.join(', ')}`);
     if (parts.length > 0) described.push(`(${index + 1}) ${parts.join('; ')}.`);
   }
-  // An `anyOf` with an unrestricted variant accepts any object, so listing
-  // combinations would only mislead; the dropped field names still help.
   const unrestricted = variants.some((variant) => variant.kind === 'any');
   if (described.length >= 2 && (exclusive || !unrestricted)) {
     lines.push(
@@ -315,7 +305,6 @@ function mayAcceptAnyObject(branch: unknown): boolean {
       ? [branch['const']]
       : undefined;
   if (values !== undefined) {
-    // Fixed values only match an object when one of them is an object.
     return values.some((value) => isRecord(value));
   }
   return !hasAnyKey(branch, OBJECT_STRUCTURE_KEYS);
@@ -373,8 +362,6 @@ function hoistCombinatorTypes(node: Record<string, unknown>): void {
         branches[i] = { type: cloneJsonValue(parentType) };
         continue;
       }
-      // A boolean `false` (or any non-schema) branch is not accepted on the
-      // wire; dropping it only widens the union.
       if (!isRecord(branch)) {
         branches.splice(i, 1);
         continue;
@@ -384,8 +371,6 @@ function hoistCombinatorTypes(node: Record<string, unknown>): void {
       }
     }
     if (branches.length === 0) {
-      // No live branch left: drop the union and keep the parent constraint —
-      // neither an empty array nor a boolean branch is a legal union member.
       delete node[key];
     } else {
       delete node['type'];
@@ -423,8 +408,6 @@ function constrainBranchType(
     if (kept.length === 0) return 'dead';
     const groups = groupValuesByType(kept);
     if (groups !== undefined && groups.size > 1 && !hasOwn(branch, 'anyOf')) {
-      // A mixed-type enum cannot carry one `type`; split it into one typed
-      // variant per value type instead of emitting a mixed declaration.
       delete branch['type'];
       delete branch['enum'];
       branch['anyOf'] = [...groups].map(([type, values]) => ({ type, enum: values }));

--- a/packages/agent-core-v2/test/kosong/provider/kimi-schema.test.ts
+++ b/packages/agent-core-v2/test/kosong/provider/kimi-schema.test.ts
@@ -1,0 +1,703 @@
+/**
+ * `kosong/provider` Kimi schema dialect — normalization shapes Moonshot's
+ * tool validator rejects: the parameters root must be a typed object (so
+ * root-level `anyOf`/`oneOf` unions flatten into one object schema), and
+ * `type` next to `anyOf`/`oneOf` on nested nodes is folded into the union
+ * branches while preserving the parent constraint on every branch.
+ * Wiring: pure function, no mocks.
+ * Run: pnpm exec vitest run packages/agent-core-v2/test/kosong/provider/kimi-schema.test.ts
+ */
+import { describe, expect, it } from 'vitest';
+
+import { normalizeKimiToolSchema } from '#/kosong/provider/providers/kimi/kimi-schema';
+
+/**
+ * Structure-only view: the variant summary appended to `description` has its
+ * own tests, so structural assertions below drop it.
+ */
+function structureOf(schema: Record<string, unknown>): Record<string, unknown> {
+  const { description: _description, ...rest } = normalizeKimiToolSchema(schema);
+  return rest;
+}
+
+describe('normalizeKimiToolSchema', () => {
+  it('flattens a root union into a single typed object root', () => {
+    const schema = {
+      type: 'object',
+      $schema: 'https://json-schema.org/draft/2020-12/schema',
+      description: 'Provide exactly one of the documented input variants.',
+      anyOf: [
+        {
+          type: 'object',
+          properties: {
+            filename: { type: 'string', minLength: 1 },
+            content: { type: 'string', maxLength: 1024 },
+          },
+          required: ['filename', 'content'],
+          additionalProperties: false,
+        },
+        {
+          type: 'object',
+          properties: {
+            source_id: { type: 'string', minLength: 1 },
+          },
+          required: ['source_id'],
+          additionalProperties: false,
+        },
+      ],
+    };
+
+    const result = normalizeKimiToolSchema(schema);
+
+    expect(result).toEqual({
+      type: 'object',
+      $schema: 'https://json-schema.org/draft/2020-12/schema',
+      description: [
+        'Provide exactly one of the documented input variants.',
+        'Valid argument variants (at least one must match): ' +
+          '(1) required: filename, content. (2) required: source_id.',
+      ].join('\n\n'),
+      properties: {
+        filename: { type: 'string', minLength: 1 },
+        content: { type: 'string', maxLength: 1024 },
+        source_id: { type: 'string', minLength: 1 },
+      },
+    });
+  });
+
+  it('collapses a root required-variant union onto the object root', () => {
+    const schema = {
+      type: 'object',
+      properties: {
+        a: { type: 'string' },
+        b: { type: 'string' },
+      },
+      anyOf: [{ required: ['a'] }, { required: ['b'] }],
+    };
+
+    const result = structureOf(schema);
+
+    expect(result).toEqual({
+      type: 'object',
+      properties: {
+        a: { type: 'string' },
+        b: { type: 'string' },
+      },
+    });
+  });
+
+  it('keeps fields required by every branch of a flattened root union', () => {
+    const schema = {
+      type: 'object',
+      anyOf: [
+        {
+          type: 'object',
+          properties: { id: { type: 'string' }, a: { type: 'string' } },
+          required: ['id', 'a'],
+          additionalProperties: false,
+        },
+        {
+          type: 'object',
+          properties: { id: { type: 'string' }, b: { type: 'string' } },
+          required: ['id', 'b'],
+          additionalProperties: false,
+        },
+      ],
+    };
+
+    const result = structureOf(schema);
+
+    expect(result).toEqual({
+      type: 'object',
+      properties: {
+        id: { type: 'string' },
+        a: { type: 'string' },
+        b: { type: 'string' },
+      },
+      required: ['id'],
+    });
+  });
+
+  it('flattens a root union produced by $ref sibling merging', () => {
+    const schema = {
+      type: 'object',
+      $ref: '#/$defs/Input',
+      $defs: {
+        Input: {
+          anyOf: [
+            {
+              type: 'object',
+              properties: { a: { type: 'string' } },
+              required: ['a'],
+              additionalProperties: false,
+            },
+            {
+              type: 'object',
+              properties: { b: { type: 'string' } },
+              required: ['b'],
+              additionalProperties: false,
+            },
+          ],
+        },
+      },
+    };
+
+    const result = structureOf(schema);
+
+    expect(result).toEqual({
+      type: 'object',
+      properties: {
+        a: { type: 'string' },
+        b: { type: 'string' },
+      },
+    });
+  });
+
+  it('rebuilds an empty object root when a root union has no object branches', () => {
+    const schema = {
+      type: 'integer',
+      anyOf: [{ const: 1.5 }],
+    };
+
+    const result = normalizeKimiToolSchema(schema);
+
+    expect(result).toEqual({
+      type: 'object',
+      properties: {},
+    });
+  });
+
+  it('treats patternProperties branches as unconstrained for undeclared keys', () => {
+    const schema = {
+      type: 'object',
+      anyOf: [
+        {
+          properties: { value: { type: 'string' } },
+          additionalProperties: false,
+        },
+        {
+          patternProperties: { '^value$': { type: 'number' } },
+          additionalProperties: false,
+        },
+      ],
+    };
+
+    const result = structureOf(schema);
+
+    expect(result).toEqual({
+      type: 'object',
+      properties: {},
+    });
+  });
+
+  it('omits typeless branch property schemas that type completion would narrow', () => {
+    const schema = {
+      type: 'object',
+      anyOf: [
+        {
+          properties: { value: { type: 'string' } },
+          additionalProperties: false,
+        },
+        {
+          properties: { value: { description: 'Any JSON value' } },
+          additionalProperties: false,
+        },
+      ],
+    };
+
+    const result = structureOf(schema);
+
+    expect(result).toEqual({
+      type: 'object',
+      properties: {},
+    });
+  });
+
+  it('keeps typeless enum contributions whose completion is value-exact', () => {
+    const schema = {
+      type: 'object',
+      anyOf: [
+        {
+          properties: { value: { enum: ['a'] } },
+          additionalProperties: false,
+        },
+        {
+          properties: { value: { enum: ['b'] } },
+          additionalProperties: false,
+        },
+      ],
+    };
+
+    const result = structureOf(schema);
+
+    expect(result).toEqual({
+      type: 'object',
+      properties: {
+        value: {
+          anyOf: [
+            { enum: ['a'], type: 'string' },
+            { enum: ['b'], type: 'string' },
+          ],
+        },
+      },
+    });
+  });
+
+  it('drops required entries for properties omitted from a flattened root union', () => {
+    // The property is unconstrained (a patternProperties branch may cover it),
+    // so it is omitted — a `required` naming a property that is not in
+    // `properties` is rejected outright by the validator.
+    const schema = {
+      type: 'object',
+      anyOf: [
+        {
+          properties: { value: { type: 'string' } },
+          required: ['value'],
+          additionalProperties: false,
+        },
+        {
+          patternProperties: { '^value$': { type: 'number' } },
+          required: ['value'],
+          additionalProperties: false,
+        },
+      ],
+    };
+
+    const result = structureOf(schema);
+
+    expect(result).toEqual({
+      type: 'object',
+      properties: {},
+    });
+  });
+
+  it('flattens a typeless root union with an any-object branch to an open object', () => {
+    const schema = {
+      anyOf: [true, { required: ['value'] }],
+    };
+
+    expect(structureOf(schema)).toEqual({
+      type: 'object',
+      properties: {},
+    });
+    // The union accepts any object, so no combination is listed — but the
+    // field name would otherwise disappear entirely.
+    expect(normalizeKimiToolSchema(schema)['description']).toBe(
+      'Fields without their own schema entry:\n- value',
+    );
+  });
+
+  it('keeps root properties but drops branch constraints when a branch accepts any object', () => {
+    const schema = {
+      type: 'object',
+      properties: { a: { type: 'string' } },
+      anyOf: [
+        {},
+        {
+          properties: { b: { type: 'number' } },
+          required: ['b'],
+          additionalProperties: false,
+        },
+      ],
+    };
+
+    expect(structureOf(schema)).toEqual({
+      type: 'object',
+      properties: { a: { type: 'string' } },
+    });
+    expect(normalizeKimiToolSchema(schema)['description']).toBe(
+      'Fields without their own schema entry:\n- b',
+    );
+  });
+
+  it('drops an explicit false branch from a nested union', () => {
+    const schema = {
+      type: 'object',
+      properties: {
+        x: {
+          type: 'object',
+          anyOf: [false, { properties: { a: { type: 'string' } } }],
+        },
+      },
+    };
+
+    const result = normalizeKimiToolSchema(schema);
+
+    expect(result).toEqual({
+      type: 'object',
+      properties: {
+        x: {
+          anyOf: [{ properties: { a: { type: 'string' } }, type: 'object' }],
+        },
+      },
+    });
+  });
+
+  it('splits a mixed-type enum branch into per-type variants', () => {
+    const schema = {
+      type: 'object',
+      properties: {
+        x: {
+          type: ['string', 'number'],
+          anyOf: [{ enum: ['a', 1] }],
+        },
+      },
+    };
+
+    const result = normalizeKimiToolSchema(schema);
+
+    expect(result).toEqual({
+      type: 'object',
+      properties: {
+        x: {
+          anyOf: [
+            {
+              anyOf: [
+                { type: 'string', enum: ['a'] },
+                { type: 'integer', enum: [1] },
+              ],
+            },
+          ],
+        },
+      },
+    });
+  });
+
+  it('keeps an opaque branch from narrowing the flattened root', () => {
+    // `not: { type: 'null' }` accepts every object, but it is neither an
+    // object-constraining branch nor a recognizable any-object one; ignoring
+    // it would pin the other branch's constraints onto the root and reject
+    // inputs the original accepts.
+    const schema = {
+      type: 'object',
+      anyOf: [
+        { not: { type: 'null' } },
+        {
+          properties: { a: { type: 'string', description: 'The a field.' } },
+          required: ['a'],
+          additionalProperties: false,
+        },
+      ],
+    };
+
+    const result = normalizeKimiToolSchema(schema);
+
+    expect(structureOf(schema)).toEqual({ type: 'object', properties: {} });
+    expect(result['description']).toBe(
+      'Fields without their own schema entry:\n- a — The a field.',
+    );
+  });
+
+  it('reports the unrestricted variant of an exclusive union', () => {
+    // A `{}` member of a oneOf does not make the union accept every object —
+    // it makes every other variant invalid. Widening is still the only
+    // representable option, so the structure is spelled out instead.
+    const schema = {
+      type: 'object',
+      oneOf: [{}, { required: ['mode'] }],
+    };
+
+    const result = normalizeKimiToolSchema(schema);
+
+    expect(structureOf(schema)).toEqual({ type: 'object', properties: {} });
+    expect(result['description']).toBe(
+      [
+        'Valid argument variants (exactly one must match): (1) any object. (2) required: mode.',
+        'Fields without their own schema entry:\n- mode',
+      ].join('\n\n'),
+    );
+  });
+
+  it('merges conflicting branch property schemas into a nested union', () => {
+    const schema = {
+      type: 'object',
+      anyOf: [
+        { properties: { value: { type: 'string' } }, required: ['value'] },
+        { properties: { value: { type: 'number' } }, required: ['value'] },
+      ],
+    };
+
+    const result = structureOf(schema);
+
+    expect(result).toEqual({
+      type: 'object',
+      properties: {
+        value: { anyOf: [{ type: 'string' }, { type: 'number' }] },
+      },
+      required: ['value'],
+    });
+  });
+
+  it('omits a property constraint that an open branch leaves unconstrained', () => {
+    const schema = {
+      type: 'object',
+      anyOf: [
+        {
+          properties: { a: { type: 'string' } },
+          required: ['a'],
+          additionalProperties: false,
+        },
+        {
+          properties: { b: { type: 'string' } },
+          required: ['b'],
+        },
+      ],
+    };
+
+    const result = structureOf(schema);
+
+    expect(result).toEqual({
+      type: 'object',
+      properties: {
+        b: { type: 'string' },
+      },
+    });
+  });
+
+  it('repairs type next to a combinator on nested property schemas', () => {
+    const schema = {
+      type: 'object',
+      properties: {
+        mode: {
+          type: 'string',
+          anyOf: [{ enum: ['fast'] }, { enum: ['safe'] }],
+        },
+        window: {
+          type: 'integer',
+          oneOf: [{ minimum: 1 }, { maximum: -1 }],
+        },
+      },
+    };
+
+    const result = normalizeKimiToolSchema(schema);
+
+    expect(result).toEqual({
+      type: 'object',
+      properties: {
+        mode: {
+          anyOf: [
+            { enum: ['fast'], type: 'string' },
+            { enum: ['safe'], type: 'string' },
+          ],
+        },
+        window: {
+          oneOf: [
+            { minimum: 1, type: 'integer' },
+            { maximum: -1, type: 'integer' },
+          ],
+        },
+      },
+    });
+  });
+
+  it('copies a nested type array verbatim into typeless combinator branches', () => {
+    const schema = {
+      type: 'object',
+      properties: {
+        x: {
+          type: ['object', 'null'],
+          anyOf: [{ properties: { a: { type: 'string' } } }],
+        },
+      },
+    };
+
+    const result = normalizeKimiToolSchema(schema);
+
+    expect(result).toEqual({
+      type: 'object',
+      properties: {
+        x: {
+          anyOf: [{ properties: { a: { type: 'string' } }, type: ['object', 'null'] }],
+        },
+      },
+    });
+  });
+
+  it('pushes the parent type into nested branches and removes dead ones', () => {
+    const schema = {
+      type: 'object',
+      properties: {
+        x: {
+          type: 'object',
+          anyOf: [{ type: 'string' }, { not: { const: null } }],
+        },
+      },
+    };
+
+    const result = normalizeKimiToolSchema(schema);
+
+    expect(result).toEqual({
+      type: 'object',
+      properties: {
+        x: {
+          anyOf: [{ not: { const: null, type: 'null' }, type: 'object' }],
+        },
+      },
+    });
+  });
+
+  it('narrows a nested branch type to its intersection with the parent type', () => {
+    const schema = {
+      type: 'object',
+      properties: {
+        x: {
+          type: ['string', 'integer'],
+          anyOf: [{ type: ['integer', 'boolean'] }, { type: 'number' }, { minLength: 2 }],
+        },
+      },
+    };
+
+    const result = normalizeKimiToolSchema(schema);
+
+    expect(result).toEqual({
+      type: 'object',
+      properties: {
+        x: {
+          anyOf: [
+            { type: 'integer' },
+            { type: 'integer' },
+            { minLength: 2, type: ['string', 'integer'] },
+          ],
+        },
+      },
+    });
+  });
+
+  it('replaces nested boolean true branches with the parent type constraint', () => {
+    const schema = {
+      type: 'object',
+      properties: {
+        x: {
+          type: 'object',
+          anyOf: [true, { properties: { a: { type: 'string' } } }],
+        },
+      },
+    };
+
+    const result = normalizeKimiToolSchema(schema);
+
+    expect(result).toEqual({
+      type: 'object',
+      properties: {
+        x: {
+          anyOf: [{ type: 'object' }, { properties: { a: { type: 'string' } }, type: 'object' }],
+        },
+      },
+    });
+  });
+
+  it('intersects an inherited nested type with enum inference instead of overwriting it', () => {
+    const schema = {
+      type: 'object',
+      properties: {
+        x: {
+          type: ['string', 'integer'],
+          anyOf: [{ enum: ['x'] }],
+        },
+      },
+    };
+
+    const result = normalizeKimiToolSchema(schema);
+
+    expect(result).toEqual({
+      type: 'object',
+      properties: {
+        x: {
+          anyOf: [{ enum: ['x'], type: 'string' }],
+        },
+      },
+    });
+  });
+
+  it('removes a nested branch whose enum values conflict with the inherited type', () => {
+    const schema = {
+      type: 'object',
+      properties: {
+        x: {
+          type: 'object',
+          anyOf: [{ enum: ['x'] }, { properties: { a: { type: 'string' } } }],
+        },
+      },
+    };
+
+    const result = normalizeKimiToolSchema(schema);
+
+    expect(result).toEqual({
+      type: 'object',
+      properties: {
+        x: {
+          anyOf: [{ properties: { a: { type: 'string' } }, type: 'object' }],
+        },
+      },
+    });
+  });
+
+  it('kills a nested const branch whose value does not satisfy the inherited type', () => {
+    const schema = {
+      type: 'object',
+      properties: {
+        x: {
+          type: 'integer',
+          anyOf: [{ const: 1.5 }],
+        },
+      },
+    };
+
+    const result = normalizeKimiToolSchema(schema);
+
+    expect(result).toEqual({
+      type: 'object',
+      properties: {
+        x: {
+          type: 'integer',
+        },
+      },
+    });
+  });
+
+  it('keeps a nested const branch whose value satisfies the inherited type', () => {
+    const schema = {
+      type: 'object',
+      properties: {
+        x: {
+          type: 'number',
+          anyOf: [{ const: 2 }],
+        },
+      },
+    };
+
+    const result = normalizeKimiToolSchema(schema);
+
+    expect(result).toEqual({
+      type: 'object',
+      properties: {
+        x: {
+          anyOf: [{ const: 2, type: 'integer' }],
+        },
+      },
+    });
+  });
+
+  it('filters nested enum members by the inherited type instead of widening it', () => {
+    const schema = {
+      type: 'object',
+      properties: {
+        x: {
+          type: 'integer',
+          anyOf: [{ enum: [1, 1.5] }],
+        },
+      },
+    };
+
+    const result = normalizeKimiToolSchema(schema);
+
+    expect(result).toEqual({
+      type: 'object',
+      properties: {
+        x: {
+          anyOf: [{ enum: [1], type: 'integer' }],
+        },
+      },
+    });
+  });
+});

--- a/packages/kosong/src/providers/kimi-schema.ts
+++ b/packages/kosong/src/providers/kimi-schema.ts
@@ -44,6 +44,12 @@ const TYPE_COMPLETION_SKIP_KEYS = new Set([
   'then',
 ]);
 
+// Moonshot rejects `type` declared next to `anyOf`/`oneOf` ("type should be
+// defined in anyOf items instead of the parent schema"). `allOf` is not
+// listed: a conjunction branch carrying the parent type is redundant, and the
+// validator accepts `type` next to `allOf`.
+const TYPE_HOISTING_COMBINATOR_KEYS = ['anyOf', 'oneOf'] as const;
+
 // Child-schema positions that this Kimi normalizer knows how to walk. This is
 // also the source of truth for child-schema keywords that imply the parent
 // schema's type. It is not a list of keywords that Moonshot accepts on the wire.
@@ -117,7 +123,9 @@ const NUMERIC_STRUCTURE_KEYS = new Set([
  * it resolves local refs, preserves combinator nodes, infers obvious
  * scalar/object/array types, and falls back to `string` only for nested
  * typeless property schemas. The root schema object is treated as a container
- * and is not itself normalized.
+ * and does not get a `type` defaulted onto it, but a `type` sitting next to
+ * `anyOf`/`oneOf` is hoisted into the branches on every node, root included —
+ * Moonshot rejects that shape outright.
  */
 export function normalizeKimiToolSchema(schema: Record<string, unknown>): Record<string, unknown> {
   return ensureKimiPropertyTypes(derefJsonSchema(schema));
@@ -128,8 +136,434 @@ function ensureKimiPropertyTypes(schema: Record<string, unknown>): Record<string
   if (!isRecord(normalized)) {
     throw new Error('JSON Schema root must normalize to an object.');
   }
+  // Hoist before type completion so a typeless branch inherits the parent's
+  // authoritative type instead of a structurally inferred fallback.
+  flattenRootUnion(normalized);
+  hoistCombinatorTypes(normalized);
   recurseSchema(normalized);
   return normalized;
+}
+
+/**
+ * Moonshot additionally requires the parameters root to carry
+ * `type: "object"` while rejecting `type` next to `anyOf`, so a root-level
+ * union is unrepresentable on the wire. Flatten it without narrowing what
+ * the schema accepts (the wire schema may only widen — the tool's own server
+ * performs the final validation): the root's own properties stay
+ * authoritative and keep whatever type completion does to them, with or
+ * without a union; a property defined differently across branches becomes a
+ * nested `anyOf` of the distinct variants; a property is omitted rather than
+ * pinned when any branch leaves it unconstrained — open additional
+ * properties, a `patternProperties` bag (no regex evaluation), or a typeless
+ * schema that type completion would pin to a fabricated type (bare
+ * enum/const schemas keep their value-implied type); a branch that accepts
+ * any object drops the branch-derived constraints entirely; `required` keeps
+ * the root's own list plus fields required by every branch, minus anything
+ * no longer in `properties`; per-branch `additionalProperties` is dropped.
+ * The exactly-one-of intent is necessarily lost as wire-side validation and
+ * stays in the description. Nested unions are untouched — only the root is
+ * constrained this way.
+ */
+function flattenRootUnion(root: Record<string, unknown>): void {
+  const variants: VariantEntry[] = [];
+  let flattened = false;
+  let exclusive = true;
+  for (const key of TYPE_HOISTING_COMBINATOR_KEYS) {
+    const value = root[key];
+    if (!Array.isArray(value)) continue;
+    flattened = true;
+    if (key === 'anyOf') exclusive = false;
+    for (const branch of value) {
+      if (mayAcceptAnyObject(branch)) {
+        variants.push({ kind: 'any' });
+      } else if (isObjectBranch(branch)) {
+        variants.push({ kind: 'object', schema: branch });
+      }
+      // Anything else cannot match an object and contributes nothing.
+    }
+    delete root[key];
+  }
+  if (!flattened) return;
+  // One unrestricted variant means no branch-derived constraint can be
+  // imposed on the root: for `anyOf` the union accepts any object, and for
+  // `oneOf` it makes the other variants invalid rather than more permissive —
+  // widening is the only representable outcome either way.
+  const unrestricted = variants.some((variant) => variant.kind === 'any');
+  const branches = unrestricted
+    ? []
+    : variants.flatMap((variant) => (variant.kind === 'object' ? [variant.schema] : []));
+
+  const properties: Record<string, unknown> = isRecord(root['properties'])
+    ? root['properties']
+    : {};
+  const requiredSets: string[][] = [];
+  const branchKeys = new Set<string>();
+  for (const branch of branches) {
+    const branchProperties = branch['properties'];
+    if (isRecord(branchProperties)) {
+      for (const name of Object.keys(branchProperties)) branchKeys.add(name);
+    }
+    requiredSets.push(
+      Array.isArray(branch['required'])
+        ? branch['required'].filter((name): name is string => typeof name === 'string')
+        : [],
+    );
+  }
+  for (const name of branchKeys) {
+    // The root's own property constraint already applied to every branch.
+    if (hasOwn(properties, name)) continue;
+    const variants = new Map<string, Record<string, unknown>>();
+    let unconstrained = false;
+    for (const branch of branches) {
+      const branchProperties = branch['properties'];
+      const patternProperties = branch['patternProperties'];
+      let constraint: unknown;
+      if (isRecord(branchProperties) && hasOwn(branchProperties, name)) {
+        constraint = branchProperties[name];
+      } else if (isRecord(patternProperties) && Object.keys(patternProperties).length > 0) {
+        // A pattern may cover this key; stay conservative instead of
+        // evaluating external regexes.
+        constraint = true;
+      } else if (hasOwn(branch, 'additionalProperties')) {
+        constraint = branch['additionalProperties'];
+      } else {
+        constraint = true;
+      }
+      if (constraint === false) continue;
+      if (constraint === true || (isRecord(constraint) && Object.keys(constraint).length === 0)) {
+        unconstrained = true;
+        break;
+      }
+      if (!isRecord(constraint)) continue;
+      if (!hasOwn(constraint, 'type') && !hasExactValueType(constraint)) {
+        // Type completion would pin a fabricated type onto a typeless schema,
+        // narrowing it below the original — treat it as unconstrained.
+        unconstrained = true;
+        break;
+      }
+      variants.set(canonicalJson(constraint), constraint);
+    }
+    if (unconstrained) continue;
+    const merged = [...variants.values()];
+    const [first] = merged;
+    if (merged.length === 1 && first !== undefined) {
+      properties[name] = first;
+    } else if (merged.length > 1) {
+      properties[name] = { anyOf: merged };
+    }
+  }
+
+  root['type'] = 'object';
+  root['properties'] = properties;
+  const alwaysRequired =
+    requiredSets.length > 0
+      ? requiredSets.reduce((acc, cur) => acc.filter((name) => cur.includes(name)))
+      : [];
+  const rootRequired = Array.isArray(root['required'])
+    ? root['required'].filter((name): name is string => typeof name === 'string')
+    : [];
+  // A `required` naming a property that is not in `properties` is rejected
+  // outright, and dropping one only widens what the wire accepts.
+  const required = [...new Set([...rootRequired, ...alwaysRequired])].filter((name) =>
+    hasOwn(properties, name),
+  );
+  if (required.length > 0) {
+    root['required'] = required;
+  } else {
+    delete root['required'];
+  }
+  const summary = summarizeVariants(variants, properties, exclusive);
+  if (summary !== undefined) {
+    const existing = root['description'];
+    root['description'] =
+      typeof existing === 'string' && existing.trim() !== '' ? `${existing}\n\n${summary}` : summary;
+  }
+}
+
+type VariantEntry = { kind: 'any' } | { kind: 'object'; schema: Record<string, unknown> };
+
+/**
+ * Restate the variant structure that flattening cannot express on the wire.
+ * The flattened root only shows a bag of merged properties, so which field
+ * combinations are actually valid — and the names of fields that had to be
+ * dropped from `properties` to avoid narrowing, together with their branch
+ * descriptions — survive as prose the model can read. The tool's own server
+ * still performs the real validation.
+ */
+function summarizeVariants(
+  variants: VariantEntry[],
+  properties: Record<string, unknown>,
+  exclusive: boolean,
+): string | undefined {
+  if (variants.length < 2) return undefined;
+  const lines: string[] = [];
+  const described: string[] = [];
+  const dropped = new Map<string, string>();
+  for (const [index, variant] of variants.entries()) {
+    if (variant.kind === 'any') {
+      described.push(`(${index + 1}) any object.`);
+      continue;
+    }
+    const branch = variant.schema;
+    const branchProperties = isRecord(branch['properties']) ? branch['properties'] : {};
+    const declared = Object.keys(branchProperties);
+    const required = (Array.isArray(branch['required']) ? branch['required'] : []).filter(
+      (name): name is string => typeof name === 'string',
+    );
+    for (const name of [...required, ...declared]) {
+      if (hasOwn(properties, name) || dropped.has(name)) continue;
+      const entry = branchProperties[name];
+      const description = isRecord(entry) ? entry['description'] : undefined;
+      dropped.set(name, typeof description === 'string' ? description : '');
+    }
+    const parts: string[] = [];
+    if (required.length > 0) parts.push(`required: ${required.join(', ')}`);
+    const optional = declared.filter((name) => !required.includes(name));
+    if (optional.length > 0) parts.push(`optional: ${optional.join(', ')}`);
+    if (parts.length > 0) described.push(`(${index + 1}) ${parts.join('; ')}.`);
+  }
+  // An `anyOf` with an unrestricted variant accepts any object, so listing
+  // combinations would only mislead; the dropped field names still help.
+  const unrestricted = variants.some((variant) => variant.kind === 'any');
+  if (described.length >= 2 && (exclusive || !unrestricted)) {
+    lines.push(
+      `Valid argument variants (${exclusive ? 'exactly' : 'at least'} one must match): ${described.join(' ')}`,
+    );
+  }
+  if (dropped.size > 0) {
+    lines.push(
+      ['Fields without their own schema entry:']
+        .concat(
+          [...dropped].map(([name, description]) =>
+            description === '' ? `- ${name}` : `- ${name} — ${description}`,
+          ),
+        )
+        .join('\n'),
+    );
+  }
+  return lines.length > 0 ? lines.join('\n\n') : undefined;
+}
+
+/**
+ * Whether a union member may match an arbitrary object. Conservative by
+ * design: a member this cannot classify — an opaque combinator, an
+ * unresolved `$ref`, annotations only — is reported as unrestricted so its
+ * permissiveness is never silently dropped, which would let the remaining
+ * members narrow the flattened root.
+ */
+function mayAcceptAnyObject(branch: unknown): boolean {
+  if (branch === true) return true;
+  if (!isRecord(branch)) return false;
+  if (hasOwn(branch, 'type')) {
+    const type = branch['type'];
+    const includesObject =
+      type === 'object' || (Array.isArray(type) && type.includes('object'));
+    if (!includesObject) return false;
+  }
+  const values = Array.isArray(branch['enum'])
+    ? branch['enum']
+    : hasOwn(branch, 'const')
+      ? [branch['const']]
+      : undefined;
+  if (values !== undefined) {
+    // Fixed values only match an object when one of them is an object.
+    return values.some((value) => isRecord(value));
+  }
+  return !hasAnyKey(branch, OBJECT_STRUCTURE_KEYS);
+}
+
+function groupValuesByType(values: unknown[]): Map<JsonSchemaType, unknown[]> | undefined {
+  const groups = new Map<JsonSchemaType, unknown[]>();
+  for (const value of values) {
+    const valueType = inferValueType(value);
+    if (valueType === undefined) return undefined;
+    const bucket = groups.get(valueType);
+    if (bucket === undefined) {
+      groups.set(valueType, [value]);
+    } else {
+      bucket.push(value);
+    }
+  }
+  return groups;
+}
+
+function hasExactValueType(schema: Record<string, unknown>): boolean {
+  const enumValues = schema['enum'];
+  if (Array.isArray(enumValues) && enumValues.length > 0) return true;
+  return hasOwn(schema, 'const');
+}
+
+function isObjectBranch(branch: unknown): branch is Record<string, unknown> {
+  if (!isRecord(branch)) return false;
+  const type = branch['type'];
+  if (type === 'object' || (Array.isArray(type) && type.includes('object'))) return true;
+  return !hasOwn(branch, 'type') && hasAnyKey(branch, OBJECT_STRUCTURE_KEYS);
+}
+
+function canonicalJson(value: unknown): string {
+  if (Array.isArray(value)) {
+    return `[${value.map((item) => canonicalJson(item)).join(',')}]`;
+  }
+  if (isRecord(value)) {
+    const entries = Object.keys(value)
+      .toSorted()
+      .map((key) => `${JSON.stringify(key)}:${canonicalJson(value[key])}`);
+    return `{${entries.join(',')}}`;
+  }
+  return JSON.stringify(value) ?? 'null';
+}
+
+/**
+ * Repair schema nodes that declare `type` next to `anyOf`/`oneOf` by moving
+ * the parent `type` into the branches, preserving the parent constraint on
+ * every one of them: each record branch is constrained through
+ * `constrainBranchType` (dead branches are removed), a boolean `true` branch
+ * becomes the bare parent constraint, and `false` branches match nothing
+ * either way and are left alone. An all-dead union keeps one legal
+ * never-matching `false` branch — `anyOf: []` is not valid JSON Schema.
+ * Unlike type completion this pass also visits the root: MCP servers may
+ * publish such roots directly, and `derefJsonSchema`'s sibling-key merge can
+ * synthesize them from a root-level `$ref`.
+ */
+function hoistCombinatorTypes(node: Record<string, unknown>): void {
+  for (const key of TYPE_HOISTING_COMBINATOR_KEYS) {
+    const branches = node[key];
+    if (!hasOwn(node, 'type') || !Array.isArray(branches)) continue;
+    const parentType = node['type'];
+    for (let i = branches.length - 1; i >= 0; i--) {
+      const branch: unknown = branches[i];
+      if (branch === true) {
+        branches[i] = { type: cloneJsonValue(parentType) };
+        continue;
+      }
+      // A boolean `false` (or any non-schema) branch is not accepted on the
+      // wire; dropping it only widens the union.
+      if (!isRecord(branch)) {
+        branches.splice(i, 1);
+        continue;
+      }
+      if (constrainBranchType(parentType, branch) === 'dead') {
+        branches.splice(i, 1);
+      }
+    }
+    if (branches.length === 0) {
+      // No live branch left: drop the union and keep the parent constraint —
+      // neither an empty array nor a boolean branch is a legal union member.
+      delete node[key];
+    } else {
+      delete node['type'];
+    }
+  }
+  visitChildSchemas(node, (child) => {
+    if (isRecord(child)) {
+      hoistCombinatorTypes(child);
+    }
+  });
+}
+
+/**
+ * Constrain one union branch to the parent `type` it inherits. The parent
+ * type is intersected with the branch's own `type` (when present), folding
+ * the `integer ⊂ number` subtype relation; enum/const values are then judged
+ * individually against that intersection — members that cannot satisfy it
+ * are filtered out (a `const: 1.5` under an `integer` parent is not an
+ * integer, so symmetric type algebra would widen the schema). A branch left
+ * with no possible value never matched anything under the original
+ * conjunction and reports 'dead'. Otherwise the branch's `type` becomes the
+ * value-derived type (or the intersection when no values constrain it),
+ * which also keeps the later enum/const type repair from rewriting an
+ * inherited constraint.
+ */
+function constrainBranchType(
+  parentType: unknown,
+  branch: Record<string, unknown>,
+): 'kept' | 'dead' {
+  const parent = toTypeSet(parentType);
+  if (parent === undefined) {
+    // Malformed parent type — plain inheritance for typeless branches.
+    if (!hasOwn(branch, 'type')) {
+      branch['type'] = cloneJsonValue(parentType);
+    }
+    return 'kept';
+  }
+  let effective = parent;
+  if (hasOwn(branch, 'type')) {
+    const own = toTypeSet(branch['type']);
+    if (own === undefined) return 'kept';
+    effective = intersectTypeSets(effective, own);
+  }
+  if (effective.size === 0) return 'dead';
+
+  const enumValues = branch['enum'];
+  if (Array.isArray(enumValues) && enumValues.length > 0) {
+    const kept = enumValues.filter((value) => valueSatisfiesTypeSet(value, effective));
+    if (kept.length === 0) return 'dead';
+    const groups = groupValuesByType(kept);
+    if (groups !== undefined && groups.size > 1 && !hasOwn(branch, 'anyOf')) {
+      // A mixed-type enum cannot carry one `type`; split it into one typed
+      // variant per value type instead of emitting a mixed declaration.
+      delete branch['type'];
+      delete branch['enum'];
+      branch['anyOf'] = [...groups].map(([type, values]) => ({ type, enum: values }));
+      return 'kept';
+    }
+    branch['enum'] = kept;
+    branch['type'] = typeForValues(kept, effective);
+    return 'kept';
+  }
+  if (hasOwn(branch, 'const')) {
+    if (!valueSatisfiesTypeSet(branch['const'], effective)) return 'dead';
+    branch['type'] = typeForValues([branch['const']], effective);
+    return 'kept';
+  }
+
+  const types = [...effective];
+  const [only] = types;
+  branch['type'] = types.length === 1 && only !== undefined ? only : types;
+  return 'kept';
+}
+
+function typeForValues(values: unknown[], effective: Set<string>): unknown {
+  try {
+    return inferTypeFromValues(values);
+  } catch {
+    // Mixed value types — fall back to the intersected schema types.
+  }
+  const types = [...effective];
+  const [only] = types;
+  return types.length === 1 && only !== undefined ? only : types;
+}
+
+function valueSatisfiesTypeSet(value: unknown, types: Set<string>): boolean {
+  const valueType = inferValueType(value);
+  if (valueType === undefined) return false;
+  if (types.has(valueType)) return true;
+  return valueType === 'integer' && types.has('number');
+}
+
+function intersectTypeSets(a: Set<string>, b: Set<string>): Set<string> {
+  const result = new Set<string>();
+  for (const type of b) {
+    if (a.has(type)) {
+      result.add(type);
+    } else if (
+      (type === 'number' && a.has('integer')) ||
+      (type === 'integer' && a.has('number'))
+    ) {
+      result.add('integer');
+    }
+  }
+  return result;
+}
+
+function toTypeSet(value: unknown): Set<string> | undefined {
+  if (typeof value === 'string') {
+    return new Set([value]);
+  }
+  if (Array.isArray(value) && value.every((item) => typeof item === 'string')) {
+    return new Set(value);
+  }
+  return undefined;
 }
 
 function hasUnresolvedDefinitionRef(node: unknown, bucketKey: string): boolean {

--- a/packages/kosong/test/providers/kimi-schema.test.ts
+++ b/packages/kosong/test/providers/kimi-schema.test.ts
@@ -1,4 +1,5 @@
 import { derefJsonSchema, normalizeKimiToolSchema } from '#/providers/kimi-schema';
+import Ajv from 'ajv';
 import { describe, expect, it, vi } from 'vitest';
 
 describe('derefJsonSchema', () => {
@@ -277,6 +278,15 @@ describe('derefJsonSchema', () => {
     expect(result['definitions']).toBeUndefined();
   });
 });
+
+/**
+ * Structure-only view: the variant summary appended to `description` has its
+ * own tests, so structural assertions below drop it.
+ */
+function structureOf(schema: Record<string, unknown>): Record<string, unknown> {
+  const { description: _description, ...rest } = normalizeKimiToolSchema(schema);
+  return rest;
+}
 
 describe('normalizeKimiToolSchema', () => {
   it.each([
@@ -753,19 +763,95 @@ describe('normalizeKimiToolSchema', () => {
     });
   });
 
-  it('preserves combinators while normalizing their schema branches', () => {
+  it('preserves nested combinators while normalizing their schema branches', () => {
     const schema = {
-      anyOf: [{ enum: ['auto', 'manual'] }, { const: false }],
-      oneOf: [
-        {
-          properties: {
-            strategy: { enum: ['replace', 'insert'] },
-          },
+      type: 'object',
+      properties: {
+        pick: {
+          anyOf: [{ enum: ['auto', 'manual'] }, { const: false }],
+          oneOf: [
+            {
+              properties: {
+                strategy: { enum: ['replace', 'insert'] },
+              },
+            },
+          ],
+          allOf: [
+            {
+              items: { const: 1 },
+            },
+          ],
         },
-      ],
-      allOf: [
+      },
+    };
+
+    const result = normalizeKimiToolSchema(schema);
+
+    expect(result).toEqual({
+      type: 'object',
+      properties: {
+        pick: {
+          anyOf: [
+            { enum: ['auto', 'manual'], type: 'string' },
+            { const: false, type: 'boolean' },
+          ],
+          oneOf: [
+            {
+              type: 'object',
+              properties: {
+                strategy: { enum: ['replace', 'insert'], type: 'string' },
+              },
+            },
+          ],
+          allOf: [
+            {
+              type: 'array',
+              items: { const: 1, type: 'integer' },
+            },
+          ],
+        },
+      },
+    });
+  });
+
+  it('flattens a root union into a single typed object root', () => {
+    // Regression: an MCP server published a tool whose root schema declared
+    // both `type: 'object'` and a three-way `anyOf`. Moonshot rejects `type`
+    // next to `anyOf` AND requires the parameters root to carry
+    // `type: "object"`, so a root union is unrepresentable on the wire:
+    // object branches merge into the root — properties first-wins, `required`
+    // keeps only fields every branch requires, and the exactly-one-of intent
+    // stays in the description (the MCP server still enforces it).
+    const schema = {
+      type: 'object',
+      $schema: 'https://json-schema.org/draft/2020-12/schema',
+      description: 'Provide exactly one of the documented input variants.',
+      anyOf: [
         {
-          items: { const: 1 },
+          type: 'object',
+          properties: {
+            filename: { type: 'string', minLength: 1 },
+            content: { type: 'string', maxLength: 1024 },
+          },
+          required: ['filename', 'content'],
+          additionalProperties: false,
+        },
+        {
+          type: 'object',
+          properties: {
+            filename: { type: 'string', minLength: 1 },
+            source_url: { type: 'string', minLength: 1 },
+          },
+          required: ['filename', 'source_url'],
+          additionalProperties: false,
+        },
+        {
+          type: 'object',
+          properties: {
+            source_id: { type: 'string', minLength: 1 },
+          },
+          required: ['source_id'],
+          additionalProperties: false,
         },
       ],
     };
@@ -773,25 +859,960 @@ describe('normalizeKimiToolSchema', () => {
     const result = normalizeKimiToolSchema(schema);
 
     expect(result).toEqual({
+      type: 'object',
+      $schema: 'https://json-schema.org/draft/2020-12/schema',
+      // The variant structure is unrepresentable on the wire, so it is
+      // restated in the description — otherwise the model only sees a bag of
+      // merged properties.
+      description: [
+        'Provide exactly one of the documented input variants.',
+        'Valid argument variants (at least one must match): ' +
+          '(1) required: filename, content. ' +
+          '(2) required: filename, source_url. ' +
+          '(3) required: source_id.',
+      ].join('\n\n'),
+      properties: {
+        filename: { type: 'string', minLength: 1 },
+        content: { type: 'string', maxLength: 1024 },
+        source_url: { type: 'string', minLength: 1 },
+        source_id: { type: 'string', minLength: 1 },
+      },
+    });
+  });
+
+  it('collapses a root required-variant union onto the object root', () => {
+    const schema = {
+      type: 'object',
+      properties: {
+        a: { type: 'string' },
+        b: { type: 'string' },
+      },
+      anyOf: [{ required: ['a'] }, { required: ['b'] }],
+    };
+
+    const result = structureOf(schema);
+
+    expect(result).toEqual({
+      type: 'object',
+      properties: {
+        a: { type: 'string' },
+        b: { type: 'string' },
+      },
+    });
+  });
+
+  it('keeps fields required by every branch of a flattened root union', () => {
+    const schema = {
+      type: 'object',
       anyOf: [
-        { enum: ['auto', 'manual'], type: 'string' },
-        { const: false, type: 'boolean' },
-      ],
-      oneOf: [
         {
           type: 'object',
-          properties: {
-            strategy: { enum: ['replace', 'insert'], type: 'string' },
-          },
+          properties: { id: { type: 'string' }, a: { type: 'string' } },
+          required: ['id', 'a'],
+          additionalProperties: false,
         },
-      ],
-      allOf: [
         {
-          type: 'array',
-          items: { const: 1, type: 'integer' },
+          type: 'object',
+          properties: { id: { type: 'string' }, b: { type: 'string' } },
+          required: ['id', 'b'],
+          additionalProperties: false,
         },
       ],
+    };
+
+    const result = structureOf(schema);
+
+    expect(result).toEqual({
+      type: 'object',
+      properties: {
+        id: { type: 'string' },
+        a: { type: 'string' },
+        b: { type: 'string' },
+      },
+      required: ['id'],
     });
-    expect(result).not.toHaveProperty('type');
   });
+
+  it('flattens a root union produced by $ref sibling merging', () => {
+    const schema = {
+      type: 'object',
+      $ref: '#/$defs/Input',
+      $defs: {
+        Input: {
+          anyOf: [
+            {
+              type: 'object',
+              properties: { a: { type: 'string' } },
+              required: ['a'],
+              additionalProperties: false,
+            },
+            {
+              type: 'object',
+              properties: { b: { type: 'string' } },
+              required: ['b'],
+              additionalProperties: false,
+            },
+          ],
+        },
+      },
+    };
+
+    const result = structureOf(schema);
+
+    expect(result).toEqual({
+      type: 'object',
+      properties: {
+        a: { type: 'string' },
+        b: { type: 'string' },
+      },
+    });
+  });
+
+  it('rebuilds an empty object root when a root union has no object branches', () => {
+    const schema = {
+      type: 'integer',
+      anyOf: [{ const: 1.5 }],
+    };
+
+    const result = normalizeKimiToolSchema(schema);
+
+    expect(result).toEqual({
+      type: 'object',
+      properties: {},
+    });
+  });
+
+  it('treats patternProperties branches as unconstrained for undeclared keys', () => {
+    const schema = {
+      type: 'object',
+      anyOf: [
+        {
+          properties: { value: { type: 'string' } },
+          additionalProperties: false,
+        },
+        {
+          patternProperties: { '^value$': { type: 'number' } },
+          additionalProperties: false,
+        },
+      ],
+    };
+
+    const result = structureOf(schema);
+
+    expect(result).toEqual({
+      type: 'object',
+      properties: {},
+    });
+  });
+
+  it('omits typeless branch property schemas that type completion would narrow', () => {
+    const schema = {
+      type: 'object',
+      anyOf: [
+        {
+          properties: { value: { type: 'string' } },
+          additionalProperties: false,
+        },
+        {
+          properties: { value: { description: 'Any JSON value' } },
+          additionalProperties: false,
+        },
+      ],
+    };
+
+    const result = structureOf(schema);
+
+    expect(result).toEqual({
+      type: 'object',
+      properties: {},
+    });
+  });
+
+  it('keeps typeless enum contributions whose completion is value-exact', () => {
+    const schema = {
+      type: 'object',
+      anyOf: [
+        {
+          properties: { value: { enum: ['a'] } },
+          additionalProperties: false,
+        },
+        {
+          properties: { value: { enum: ['b'] } },
+          additionalProperties: false,
+        },
+      ],
+    };
+
+    const result = structureOf(schema);
+
+    expect(result).toEqual({
+      type: 'object',
+      properties: {
+        value: {
+          anyOf: [
+            { enum: ['a'], type: 'string' },
+            { enum: ['b'], type: 'string' },
+          ],
+        },
+      },
+    });
+  });
+
+  it('drops required entries for properties omitted from a flattened root union', () => {
+    // The property is unconstrained (a patternProperties branch may cover it),
+    // so it is omitted — a `required` naming a property that is not in
+    // `properties` is rejected outright by the validator.
+    const schema = {
+      type: 'object',
+      anyOf: [
+        {
+          properties: { value: { type: 'string' } },
+          required: ['value'],
+          additionalProperties: false,
+        },
+        {
+          patternProperties: { '^value$': { type: 'number' } },
+          required: ['value'],
+          additionalProperties: false,
+        },
+      ],
+    };
+
+    const result = structureOf(schema);
+
+    expect(result).toEqual({
+      type: 'object',
+      properties: {},
+    });
+  });
+
+  it('flattens a typeless root union with an any-object branch to an open object', () => {
+    const schema = {
+      anyOf: [true, { required: ['value'] }],
+    };
+
+    expect(structureOf(schema)).toEqual({
+      type: 'object',
+      properties: {},
+    });
+    // The union accepts any object, so no combination is listed — but the
+    // field name would otherwise disappear entirely.
+    expect(normalizeKimiToolSchema(schema)['description']).toBe(
+      'Fields without their own schema entry:\n- value',
+    );
+  });
+
+  it('keeps root properties but drops branch constraints when a branch accepts any object', () => {
+    const schema = {
+      type: 'object',
+      properties: { a: { type: 'string' } },
+      anyOf: [
+        {},
+        {
+          properties: { b: { type: 'number' } },
+          required: ['b'],
+          additionalProperties: false,
+        },
+      ],
+    };
+
+    expect(structureOf(schema)).toEqual({
+      type: 'object',
+      properties: { a: { type: 'string' } },
+    });
+    expect(normalizeKimiToolSchema(schema)['description']).toBe(
+      'Fields without their own schema entry:\n- b',
+    );
+  });
+
+  it('drops an explicit false branch from a nested union', () => {
+    const schema = {
+      type: 'object',
+      properties: {
+        x: {
+          type: 'object',
+          anyOf: [false, { properties: { a: { type: 'string' } } }],
+        },
+      },
+    };
+
+    const result = normalizeKimiToolSchema(schema);
+
+    expect(result).toEqual({
+      type: 'object',
+      properties: {
+        x: {
+          anyOf: [{ properties: { a: { type: 'string' } }, type: 'object' }],
+        },
+      },
+    });
+  });
+
+  it('splits a mixed-type enum branch into per-type variants', () => {
+    const schema = {
+      type: 'object',
+      properties: {
+        x: {
+          type: ['string', 'number'],
+          anyOf: [{ enum: ['a', 1] }],
+        },
+      },
+    };
+
+    const result = normalizeKimiToolSchema(schema);
+
+    expect(result).toEqual({
+      type: 'object',
+      properties: {
+        x: {
+          anyOf: [
+            {
+              anyOf: [
+                { type: 'string', enum: ['a'] },
+                { type: 'integer', enum: [1] },
+              ],
+            },
+          ],
+        },
+      },
+    });
+  });
+
+  it('leaves the root own property schemas to the type-completion pass', () => {
+    // Flattening does not change what completion does to the root's own
+    // properties: a typeless schema is still completed to `string` exactly as
+    // it would be without a union. The superset guarantee is about the
+    // flattening step, not about this long-standing completion behavior.
+    const schema = {
+      type: 'object',
+      properties: { value: { description: 'Any JSON value' } },
+      anyOf: [{ required: ['value'] }],
+    };
+
+    const result = normalizeKimiToolSchema(schema);
+
+    expect(result).toEqual({
+      type: 'object',
+      properties: { value: { description: 'Any JSON value', type: 'string' } },
+      required: ['value'],
+    });
+    expect(normalizeKimiToolSchema({ type: 'object', properties: schema.properties })).toEqual({
+      type: 'object',
+      properties: { value: { description: 'Any JSON value', type: 'string' } },
+    });
+  });
+
+  it('names fields that lost their schema entry in the variant summary', () => {
+    // An open branch forces `source_url` out of `properties` (constraining it
+    // would narrow), so its name and description survive only in the summary.
+    const schema = {
+      type: 'object',
+      anyOf: [
+        {
+          properties: { text: { type: 'string' } },
+          required: ['text'],
+          additionalProperties: {},
+        },
+        {
+          properties: {
+            source_url: { type: 'string', description: 'A publicly reachable HTTPS URL.' },
+          },
+          required: ['source_url'],
+          additionalProperties: false,
+        },
+      ],
+    };
+
+    const result = normalizeKimiToolSchema(schema);
+
+    // `text` is only constrained by the closed branch, so it survives;
+    // `source_url` cannot be constrained without narrowing the open branch.
+    expect(result['properties']).toEqual({ text: { type: 'string' } });
+    expect(result['description']).toBe(
+      [
+        'Valid argument variants (at least one must match): ' +
+          '(1) required: text. (2) required: source_url.',
+        'Fields without their own schema entry:\n' +
+          '- source_url — A publicly reachable HTTPS URL.',
+      ].join('\n\n'),
+    );
+  });
+
+  it('reports an exclusive union as exactly one variant', () => {
+    const schema = {
+      type: 'object',
+      oneOf: [
+        { properties: { a: { type: 'string' } }, required: ['a'], additionalProperties: false },
+        { properties: { b: { type: 'string' } }, required: ['b'], additionalProperties: false },
+      ],
+    };
+
+    const result = normalizeKimiToolSchema(schema);
+
+    expect(result['description']).toBe(
+      'Valid argument variants (exactly one must match): (1) required: a. (2) required: b.',
+    );
+  });
+
+  it('lists optional branch fields alongside the required ones', () => {
+    const schema = {
+      type: 'object',
+      anyOf: [
+        {
+          properties: { a: { type: 'string' }, note: { type: 'string' } },
+          required: ['a'],
+          additionalProperties: false,
+        },
+        {
+          properties: { b: { type: 'string' } },
+          required: ['b'],
+          additionalProperties: false,
+        },
+      ],
+    };
+
+    const result = normalizeKimiToolSchema(schema);
+
+    expect(result['description']).toBe(
+      'Valid argument variants (at least one must match): ' +
+        '(1) required: a; optional: note. (2) required: b.',
+    );
+  });
+
+  it('adds no variant summary when a single branch carries the whole union', () => {
+    const schema = {
+      type: 'object',
+      properties: { value: { type: 'string' } },
+      anyOf: [{ required: ['value'] }],
+    };
+
+    const result = normalizeKimiToolSchema(schema);
+
+    expect(result).not.toHaveProperty('description');
+  });
+
+  it('keeps an opaque branch from narrowing the flattened root', () => {
+    // `not: { type: 'null' }` accepts every object, but it is neither an
+    // object-constraining branch nor a recognizable any-object one; ignoring
+    // it would pin the other branch's constraints onto the root and reject
+    // inputs the original accepts.
+    const schema = {
+      type: 'object',
+      anyOf: [
+        { not: { type: 'null' } },
+        {
+          properties: { a: { type: 'string', description: 'The a field.' } },
+          required: ['a'],
+          additionalProperties: false,
+        },
+      ],
+    };
+
+    const result = normalizeKimiToolSchema(schema);
+
+    expect(structureOf(schema)).toEqual({ type: 'object', properties: {} });
+    expect(result['description']).toBe(
+      'Fields without their own schema entry:\n- a — The a field.',
+    );
+  });
+
+  it('reports the unrestricted variant of an exclusive union', () => {
+    // A `{}` member of a oneOf does not make the union accept every object —
+    // it makes every other variant invalid. Widening is still the only
+    // representable option, so the structure is spelled out instead.
+    const schema = {
+      type: 'object',
+      oneOf: [{}, { required: ['mode'] }],
+    };
+
+    const result = normalizeKimiToolSchema(schema);
+
+    expect(structureOf(schema)).toEqual({ type: 'object', properties: {} });
+    expect(result['description']).toBe(
+      [
+        'Valid argument variants (exactly one must match): (1) any object. (2) required: mode.',
+        'Fields without their own schema entry:\n- mode',
+      ].join('\n\n'),
+    );
+  });
+
+  it('merges conflicting branch property schemas into a nested union', () => {
+    // A first-wins merge would keep only the string variant and reject
+    // `{ value: 1 }`, which the original schema accepts — the flattened root
+    // must stay a superset of the original object inputs.
+    const schema = {
+      type: 'object',
+      anyOf: [
+        { properties: { value: { type: 'string' } }, required: ['value'] },
+        { properties: { value: { type: 'number' } }, required: ['value'] },
+      ],
+    };
+
+    const result = structureOf(schema);
+
+    expect(result).toEqual({
+      type: 'object',
+      properties: {
+        value: { anyOf: [{ type: 'string' }, { type: 'number' }] },
+      },
+      required: ['value'],
+    });
+  });
+
+  it('omits a property constraint that an open branch leaves unconstrained', () => {
+    // The second branch has no `additionalProperties` bound, so it accepts
+    // any value for `a`; pinning `a` to the first branch's schema at the
+    // root would reject inputs the original schema allows.
+    const schema = {
+      type: 'object',
+      anyOf: [
+        {
+          properties: { a: { type: 'string' } },
+          required: ['a'],
+          additionalProperties: false,
+        },
+        {
+          properties: { b: { type: 'string' } },
+          required: ['b'],
+        },
+      ],
+    };
+
+    const result = structureOf(schema);
+
+    expect(result).toEqual({
+      type: 'object',
+      properties: {
+        b: { type: 'string' },
+      },
+    });
+  });
+
+  it('repairs type next to a combinator on nested property schemas', () => {
+    const schema = {
+      type: 'object',
+      properties: {
+        mode: {
+          type: 'string',
+          anyOf: [{ enum: ['fast'] }, { enum: ['safe'] }],
+        },
+        window: {
+          type: 'integer',
+          oneOf: [{ minimum: 1 }, { maximum: -1 }],
+        },
+      },
+    };
+
+    const result = normalizeKimiToolSchema(schema);
+
+    expect(result).toEqual({
+      type: 'object',
+      properties: {
+        mode: {
+          anyOf: [
+            { enum: ['fast'], type: 'string' },
+            { enum: ['safe'], type: 'string' },
+          ],
+        },
+        window: {
+          oneOf: [
+            { minimum: 1, type: 'integer' },
+            { maximum: -1, type: 'integer' },
+          ],
+        },
+      },
+    });
+  });
+
+  it('copies a nested type array verbatim into typeless combinator branches', () => {
+    const schema = {
+      type: 'object',
+      properties: {
+        x: {
+          type: ['object', 'null'],
+          anyOf: [{ properties: { a: { type: 'string' } } }],
+        },
+      },
+    };
+
+    const result = normalizeKimiToolSchema(schema);
+
+    expect(result).toEqual({
+      type: 'object',
+      properties: {
+        x: {
+          anyOf: [{ properties: { a: { type: 'string' } }, type: ['object', 'null'] }],
+        },
+      },
+    });
+  });
+
+  it('pushes the parent type into nested branches and removes dead ones', () => {
+    // Original semantics of x: object AND (string OR not-null) — only objects
+    // match (the string branch is unsatisfiable). The parent constraint must
+    // survive on every remaining branch, not silently widen.
+    const schema = {
+      type: 'object',
+      properties: {
+        x: {
+          type: 'object',
+          anyOf: [{ type: 'string' }, { not: { const: null } }],
+        },
+      },
+    };
+
+    const result = normalizeKimiToolSchema(schema);
+
+    expect(result).toEqual({
+      type: 'object',
+      properties: {
+        x: {
+          anyOf: [{ not: { const: null, type: 'null' }, type: 'object' }],
+        },
+      },
+    });
+  });
+
+  it('narrows a nested branch type to its intersection with the parent type', () => {
+    const schema = {
+      type: 'object',
+      properties: {
+        x: {
+          type: ['string', 'integer'],
+          anyOf: [{ type: ['integer', 'boolean'] }, { type: 'number' }, { minLength: 2 }],
+        },
+      },
+    };
+
+    const result = normalizeKimiToolSchema(schema);
+
+    expect(result).toEqual({
+      type: 'object',
+      properties: {
+        x: {
+          anyOf: [
+            { type: 'integer' },
+            { type: 'integer' },
+            { minLength: 2, type: ['string', 'integer'] },
+          ],
+        },
+      },
+    });
+  });
+
+  it('replaces nested boolean true branches with the parent type constraint', () => {
+    const schema = {
+      type: 'object',
+      properties: {
+        x: {
+          type: 'object',
+          anyOf: [true, { properties: { a: { type: 'string' } } }],
+        },
+      },
+    };
+
+    const result = normalizeKimiToolSchema(schema);
+
+    expect(result).toEqual({
+      type: 'object',
+      properties: {
+        x: {
+          anyOf: [{ type: 'object' }, { properties: { a: { type: 'string' } }, type: 'object' }],
+        },
+      },
+    });
+  });
+
+  it('intersects an inherited nested type with enum inference instead of overwriting it', () => {
+    // The enum/const type repair must not widen a branch beyond the parent
+    // constraint it inherited: the inherited type participates in the
+    // intersection rather than being replaced by the inferred value type.
+    const schema = {
+      type: 'object',
+      properties: {
+        x: {
+          type: ['string', 'integer'],
+          anyOf: [{ enum: ['x'] }],
+        },
+      },
+    };
+
+    const result = normalizeKimiToolSchema(schema);
+
+    expect(result).toEqual({
+      type: 'object',
+      properties: {
+        x: {
+          anyOf: [{ enum: ['x'], type: 'string' }],
+        },
+      },
+    });
+  });
+
+  it('removes a nested branch whose enum values conflict with the inherited type', () => {
+    // object AND enum-of-strings matches nothing — the branch is dead and
+    // must not come back as a plain string enum.
+    const schema = {
+      type: 'object',
+      properties: {
+        x: {
+          type: 'object',
+          anyOf: [{ enum: ['x'] }, { properties: { a: { type: 'string' } } }],
+        },
+      },
+    };
+
+    const result = normalizeKimiToolSchema(schema);
+
+    expect(result).toEqual({
+      type: 'object',
+      properties: {
+        x: {
+          anyOf: [{ properties: { a: { type: 'string' } }, type: 'object' }],
+        },
+      },
+    });
+  });
+
+  it('kills a nested const branch whose value does not satisfy the inherited type', () => {
+    // integer AND const 1.5 matches nothing; symmetric type algebra would
+    // keep the branch as `number` and start accepting 1.5. A union with no
+    // live branch is dropped, relaxing to the parent constraint — neither
+    // `anyOf: []` nor a boolean branch is accepted on the wire.
+    const schema = {
+      type: 'object',
+      properties: {
+        x: {
+          type: 'integer',
+          anyOf: [{ const: 1.5 }],
+        },
+      },
+    };
+
+    const result = normalizeKimiToolSchema(schema);
+
+    expect(result).toEqual({
+      type: 'object',
+      properties: {
+        x: {
+          type: 'integer',
+        },
+      },
+    });
+  });
+
+  it('keeps a nested const branch whose value satisfies the inherited type', () => {
+    const schema = {
+      type: 'object',
+      properties: {
+        x: {
+          type: 'number',
+          anyOf: [{ const: 2 }],
+        },
+      },
+    };
+
+    const result = normalizeKimiToolSchema(schema);
+
+    expect(result).toEqual({
+      type: 'object',
+      properties: {
+        x: {
+          anyOf: [{ const: 2, type: 'integer' }],
+        },
+      },
+    });
+  });
+
+  it('filters nested enum members by the inherited type instead of widening it', () => {
+    const schema = {
+      type: 'object',
+      properties: {
+        x: {
+          type: 'integer',
+          anyOf: [{ enum: [1, 1.5] }],
+        },
+      },
+    };
+
+    const result = normalizeKimiToolSchema(schema);
+
+    expect(result).toEqual({
+      type: 'object',
+      properties: {
+        x: {
+          anyOf: [{ enum: [1], type: 'integer' }],
+        },
+      },
+    });
+  });
+});
+
+describe('flattened roots stay a superset of the original object inputs', () => {
+  // Differential check: any object the original schema accepts must still be
+  // accepted by the normalized schema — the wire schema may only widen, the
+  // MCP server performs the final validation. Scope: the flattening step.
+  // The root's own property schemas keep whatever the type-completion pass
+  // does to them, union or not (see the test above), so these fixtures state
+  // branch-local constraints rather than relying on typeless root properties.
+  const cases: { name: string; schema: Record<string, unknown>; samples: unknown[] }[] = [
+    {
+      name: 'conflicting property variants',
+      schema: {
+        type: 'object',
+        anyOf: [
+          { properties: { value: { type: 'string' } }, required: ['value'] },
+          { properties: { value: { type: 'number' } }, required: ['value'] },
+        ],
+      },
+      samples: [{ value: 'x' }, { value: 1 }, { value: true }, {}],
+    },
+    {
+      name: 'exactly-one-of tool variants with closed branches',
+      schema: {
+        type: 'object',
+        anyOf: [
+          {
+            type: 'object',
+            properties: {
+              filename: { type: 'string', minLength: 1 },
+              content: { type: 'string' },
+            },
+            required: ['filename', 'content'],
+            additionalProperties: false,
+          },
+          {
+            type: 'object',
+            properties: {
+              filename: { type: 'string', minLength: 1 },
+              source_url: { type: 'string' },
+            },
+            required: ['filename', 'source_url'],
+            additionalProperties: false,
+          },
+          {
+            type: 'object',
+            properties: { source_id: { type: 'string' } },
+            required: ['source_id'],
+            additionalProperties: false,
+          },
+        ],
+      },
+      samples: [
+        { filename: 'a.txt', content: 'x' },
+        { filename: 'a.txt', source_url: 'https://example.com/f' },
+        { source_id: '123' },
+        { filename: 'a.txt' },
+        {},
+      ],
+    },
+    {
+      name: 'open branch accepting extra keys',
+      schema: {
+        type: 'object',
+        anyOf: [
+          {
+            properties: { a: { type: 'string' } },
+            required: ['a'],
+            additionalProperties: false,
+          },
+          {
+            properties: { b: { type: 'string' } },
+            required: ['b'],
+          },
+        ],
+      },
+      samples: [{ a: 'x' }, { b: 'y' }, { b: 'y', a: 123 }, { a: 123 }],
+    },
+    {
+      name: 'patternProperties branch allowing the same key',
+      schema: {
+        type: 'object',
+        anyOf: [
+          { properties: { value: { type: 'string' } }, additionalProperties: false },
+          { patternProperties: { '^value$': { type: 'number' } }, additionalProperties: false },
+        ],
+      },
+      samples: [{ value: 'x' }, { value: 1 }, { value: true }],
+    },
+    {
+      name: 'typeless branch property accepting any JSON value',
+      schema: {
+        type: 'object',
+        anyOf: [
+          { properties: { value: { type: 'string' } }, additionalProperties: false },
+          { properties: { value: { description: 'Any JSON value' } }, additionalProperties: false },
+        ],
+      },
+      samples: [{ value: 'x' }, { value: 1 }, { value: { nested: true } }],
+    },
+    {
+      name: 'required entries for an omitted property',
+      schema: {
+        type: 'object',
+        anyOf: [
+          {
+            properties: { value: { type: 'string' } },
+            required: ['value'],
+            additionalProperties: false,
+          },
+          {
+            patternProperties: { '^value$': { type: 'number' } },
+            required: ['value'],
+            additionalProperties: false,
+          },
+        ],
+      },
+      samples: [{ value: 'x' }, { value: 1 }, {}],
+    },
+    {
+      name: 'branch accepting any object',
+      schema: {
+        type: 'object',
+        anyOf: [{}, { properties: { b: { type: 'number' } }, required: ['b'] }],
+      },
+      samples: [{}, { b: 1 }, { b: 'x' }, { other: true }],
+    },
+    {
+      name: 'opaque branch accepting every object',
+      schema: {
+        type: 'object',
+        anyOf: [
+          { not: { type: 'null' } },
+          { properties: { a: { type: 'string' } }, required: ['a'], additionalProperties: false },
+        ],
+      },
+      samples: [{}, { a: 'x' }, { a: 123 }, { other: true }],
+    },
+    {
+      name: 'exclusive union with an unrestricted member',
+      schema: {
+        type: 'object',
+        oneOf: [{}, { properties: { a: { type: 'string' } }, required: ['a'] }],
+      },
+      samples: [{}, { a: 123 }, { other: 1 }],
+    },
+    {
+      name: 'required variants over shared root properties',
+      schema: {
+        type: 'object',
+        properties: { a: { type: 'string' }, b: { type: 'string' } },
+        anyOf: [{ required: ['a'] }, { required: ['b'] }],
+      },
+      samples: [{ a: 'x' }, { b: 'y' }, { a: 1 }, {}],
+    },
+  ];
+
+  for (const { name, schema, samples } of cases) {
+    it(`accepts every originally-valid object: ${name}`, () => {
+      const ajv = new Ajv({ strict: false });
+      const original = ajv.compile(schema);
+      const normalized = ajv.compile(normalizeKimiToolSchema(schema));
+      for (const sample of samples) {
+        if (original(sample)) {
+          expect(normalized(sample), `sample ${JSON.stringify(sample)}`).toBe(true);
+        }
+      }
+    });
+  }
 });


### PR DESCRIPTION
<!-- Per CONTRIBUTING: clear, reproducible bug fix with a focused diff — full analysis in the linked issue. -->

## Related Issue

Resolve #2661 — [bug: 400 "not a valid moonshot flavored json schema" when an MCP tool schema declares `type` next to `anyOf`](https://github.com/MoonshotAI/kimi-code/issues/2661)

## Problem

The tool validator enforces two rules on `tools.function.parameters` — no node may declare `type` beside `anyOf`/`oneOf`, and the root must carry `type: "object"`. Both were hit against the live endpoint:

```
Error: [provider.api_error] 400 tools.function.parameters is not a valid moonshot flavored json schema,
details: <At path 'root': when using anyOf, type should be defined in anyOf items instead of the parent schema>
```

```
Error: [provider.api_error] 400 tools.function.parameters.type is required and must be "object"
```

Together they leave a root-level union unrepresentable on the wire: moving the root `type` into the branches satisfies the first rule and then trips the second.

The whole `tools[]` array is validated per request, so **one MCP tool publishing a (perfectly valid) root-level union makes every prompt fail immediately with a non-retryable error — the CLI becomes unusable in any workspace that loads that server.** This is happening in the wild: the official Notion MCP server started publishing such a root for `notion-create-attachment` around 2026-08-04 (captured wire logs show a plain object root through 08-03 and the union root from 08-05).

Kimi Code forwards MCP `inputSchema` verbatim, and `normalizeKimiToolSchema` treated the root as a container and skipped every combinator-bearing node, so nothing could repair the shape. `derefJsonSchema`'s `$ref` sibling-key merge can also synthesize it from a root-level `$ref`, so the exposure is not vendor-specific. Full timeline and analysis in the linked issue.

## What changed

`normalizeKimiToolSchema` gains two passes between `$ref` dereferencing and type completion, in both copies of the normalizer (`packages/kosong/src/providers/kimi-schema.ts` and the agent-core-v2 dialect copy, kept logic-identical):

- **Root — `flattenRootUnion`.** A root union flattens into a single typed object root **without narrowing what the schema accepts** (the wire schema may only widen — the MCP server performs the final validation): the root's own properties stay authoritative; a property defined differently across branches becomes a nested `anyOf` of the distinct variants (deduplicated by canonical JSON); a property is omitted rather than pinned whenever any branch leaves it unconstrained — open additional properties, a `patternProperties` bag that may cover the key (no regex evaluation), or a typeless schema that type completion would pin to a fabricated type (bare `enum`/`const` schemas keep their value-implied type); a branch that accepts any object (`true`, `{}`, a bare `type: "object"`) drops the branch-derived constraints entirely; `required` keeps the root's own list plus fields required by every branch, minus anything no longer in `properties` (a `required` naming an absent property is itself rejected by the validator). The guarantee covers this step: the root's own property schemas keep whatever the long-standing type-completion pass does to them, union or not.
- **Restating what widening loses.** A flattened root only shows a bag of merged properties, so flattening appends the variant structure to the tool description — the valid field combinations, plus the names and descriptions of fields that had to be dropped from `properties`. Without it the model is left guessing among merged fields with only the MCP server's rejection as a guard, which turns schema precision into failed tool-call round-trips. For the Notion tool this reads:

  ```
  Valid argument variants (at least one must match): (1) required: filename, content;
  optional: content_type. (2) required: filename, source_url; optional: content_type.
  (3) required: source_file_id.

  Fields without their own schema entry:
  - source_url — A direct, publicly reachable HTTPS URL from which Notion can download …
  - source_file_id — The ID of a file upload this exact integration already created …
  ```
- **Nested — `hoistCombinatorTypes`** (nested `anyOf` without a sibling `type` is accepted by the validator): the parent `type` moves into the union branches and is dropped from the parent, preserving the constraint on every branch — typed branches narrow to the type intersection (folding `integer ⊂ number`); enum/const members are judged individually as values, filtering unsatisfiable ones (`enum: [1, 1.5]` under an `integer` parent becomes `enum: [1]`) and splitting a mixed-type enum into one typed variant per value type; `true` branches become the bare parent constraint; dead branches, explicit `false` branches, and any other non-schema member are dropped, and a union left with no live branch is removed so the node relaxes to its parent constraint (neither `anyOf: []` nor a boolean member is legal).

Tests (written first, observed failing): unit coverage for both passes in `packages/kosong/test/providers/kimi-schema.test.ts` and `packages/agent-core-v2/test/kosong/provider/kimi-schema.test.ts` (the v2 copy previously had no dedicated coverage), plus an AJV differential suite asserting that every object the original schema accepts is still accepted after flattening.

Verification: replayed all 102 tool schemas captured from a failing real session against the strict rules above — conforming typed object roots, no `type` beside a combinator, no empty or boolean union members, no `required` naming an absent property, no mixed-type `enum` — 0 violations. The two new passes act on exactly 1 of the 102 (the rest carry neither a root union nor a `type` beside a combinator, so they reach the type-completion pass untouched); full kosong suite, `typecheck` on both packages, `lint:imports`, and oxlint all pass. **Verified live** against the Moonshot endpoint with the affected MCP server connected: prompts complete normally instead of returning 400.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset. (changeset added: patch for `@moonshot-ai/kimi-code`)
- [x] Ran `gen-docs` skill, or this PR needs no doc update. (bug fix, no doc change needed)
