### PR TITLE
fix(kimi-code): render v2 background task notifications on session replay

### DIFF
--- a/.changeset/v2-task-notification-replay.md
+++ b/.changeset/v2-task-notification-replay.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Fix resumed sessions rendering background task completion notifications as raw protocol text instead of a task status card.

--- a/apps/kimi-code/src/tui/controllers/session-replay.ts
+++ b/apps/kimi-code/src/tui/controllers/session-replay.ts
@@ -3,7 +3,6 @@ import type {
   ContextMessage,
   GoalChange,
   PermissionMode,
-  PromptOrigin,
   ResumedAgentState,
   Session,
   ToolCall,
@@ -42,6 +41,7 @@ import {
   pluginCommandFromOrigin,
   toolCallFromReplayMessage,
   toolResultOutput,
+  type BackgroundTaskNotificationOrigin,
   type ReplayRenderContext,
   type SkillActivationProjection,
   type PluginCommandProjection,
@@ -667,7 +667,7 @@ export class SessionReplayRenderer {
 
   private renderBackgroundTaskNotification(
     context: ReplayRenderContext,
-    origin: Extract<PromptOrigin, { kind: 'background_task' }>,
+    origin: BackgroundTaskNotificationOrigin,
   ): void {
     const { sessionEventHandler } = this.host;
     const task = sessionEventHandler.backgroundTasks.get(origin.taskId);

--- a/apps/kimi-code/src/tui/utils/message-replay.ts
+++ b/apps/kimi-code/src/tui/utils/message-replay.ts
@@ -1,6 +1,7 @@
 import type {
   AgentReplayRecord,
   BackgroundTaskInfo,
+  BackgroundTaskStatus,
   ContentPart,
   ContextMessage,
   PromptOrigin,
@@ -204,10 +205,26 @@ export function contentPartsToText(content: readonly ContentPart[]): string {
   return content.map(contentPartToText).join('');
 }
 
+/**
+ * agent-core-v2's task domain persists the terminal notification under the
+ * 'task' spelling (v1 used 'background_task'); both reach replay verbatim.
+ */
+export interface TaskNotificationOrigin {
+  readonly kind: 'task';
+  readonly taskId: string;
+  readonly status: BackgroundTaskStatus;
+  readonly notificationId: string;
+}
+
+export type BackgroundTaskNotificationOrigin =
+  | Extract<PromptOrigin, { kind: 'background_task' }>
+  | TaskNotificationOrigin;
+
 export function backgroundOrigin(
   message: ContextMessage,
-): Extract<PromptOrigin, { kind: 'background_task' }> | undefined {
-  return message.origin?.kind === 'background_task' ? message.origin : undefined;
+): BackgroundTaskNotificationOrigin | undefined {
+  const origin = message.origin as BackgroundTaskNotificationOrigin | undefined;
+  return origin?.kind === 'background_task' || origin?.kind === 'task' ? origin : undefined;
 }
 
 export function skillActivationFromOrigin(

--- a/apps/kimi-code/test/tui/message-replay.test.ts
+++ b/apps/kimi-code/test/tui/message-replay.test.ts
@@ -25,6 +25,7 @@ import {
 } from '#/tui/utils/transcript-window';
 import { ToolCallComponent } from '#/tui/components/messages/tool-call';
 import { ReadGroupComponent } from '#/tui/components/messages/read-group';
+import type { TaskNotificationOrigin } from '#/tui/utils/message-replay';
 
 vi.mock('#/utils/open-url', () => ({ openUrl: vi.fn() }));
 
@@ -78,7 +79,7 @@ function message(
   extra: {
     readonly toolCalls?: readonly ToolCall[];
     readonly toolCallId?: string;
-    readonly origin?: PromptOrigin;
+    readonly origin?: PromptOrigin | TaskNotificationOrigin;
     readonly isError?: boolean;
   } = {},
 ): AgentReplayRecord {
@@ -90,7 +91,7 @@ function message(
       content: [...content],
       toolCalls: [...(extra.toolCalls ?? [])],
       toolCallId: extra.toolCallId,
-      origin: extra.origin,
+      origin: extra.origin as PromptOrigin | undefined,
       isError: extra.isError,
     },
   };
@@ -904,6 +905,46 @@ describe('KimiTUI resume message replay', () => {
     expect(status?.backgroundAgentStatus?.headline).toBe('bash task lost');
     expect(status?.backgroundAgentStatus?.detail).toContain('Background timestamp logger');
     expect(status?.backgroundAgentStatus?.headline).not.toContain('agent');
+  });
+
+  it('renders replayed v2 task notifications (task origin) as bash tasks', async () => {
+    const driver = await replayIntoDriver(
+      [
+        message(
+          'user',
+          [
+            {
+              type: 'text',
+              text: '<notification id="task:bash-done0000:completed" category="task" type="task.completed" source_kind="background_task" source_id="bash-done0000">\nTitle: Background process completed\n</notification>',
+            },
+          ],
+          {
+            origin: {
+              kind: 'task',
+              taskId: 'bash-done0000',
+              status: 'completed',
+              notificationId: 'task:bash-done0000:completed',
+            },
+          },
+        ),
+      ],
+      {
+        background: [backgroundTask('bash-done0000', 'Codex comment poller', 'completed')],
+      },
+    );
+
+    const status = driver.state.transcriptEntries.find(
+      (entry) => entry.backgroundAgentStatus !== undefined,
+    );
+
+    expect(status?.backgroundAgentStatus?.headline).toBe('bash task completed in background');
+    expect(status?.backgroundAgentStatus?.detail).toContain('Codex comment poller');
+    // The raw notification XML must not leak into the visible transcript.
+    expect(
+      driver.state.transcriptEntries.some(
+        (entry) => entry.kind === 'user' && entry.content.includes('<notification'),
+      ),
+    ).toBe(false);
   });
 
   it('renders only the most recent ten visible user turns', async () => {


### PR DESCRIPTION
## Related Issue

No linked issue — the problem is explained below.

## Problem

When the TUI runs on the v2 engine, resuming a session renders background-task terminal notifications as raw `<notification ...>` XML user messages instead of the usual task status card.

The v2 engine persists these notifications with prompt origin kind `task` (renamed from v1's `background_task`), and both spellings reach the replay verbatim. The TUI's replay path only recognized the legacy spelling, so a v2-spelled notification fell through every special-case branch and landed in the generic user-message renderer, leaking the protocol XML into the visible transcript.

## What changed

- The replay's background-task origin gate now accepts both spellings (`background_task` and `task`). The v2 spelling is declared as a local origin type because the SDK's `PromptOrigin` union only carries the v1 vocabulary; both shapes share the same `taskId` / `status` / `notificationId` fields and identical status value sets, so the status-card renderer works unchanged — only its parameter type was widened.
- Added a replay test feeding a v2-spelled completion notification: it renders as the bash task status card, and the test also asserts the raw notification XML never appears as a user message. The existing v1-spelling test keeps guarding the legacy path.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.