### PR TITLE
fix(tui): surface capability install errors

### DIFF
--- a/.changeset/kimi-cu-windows.md
+++ b/.changeset/kimi-cu-windows.md
@@ -2,4 +2,4 @@
 "@moonshot-ai/kimi-code": minor
 ---
 
-Add Windows support for the built-in Kimi Computer Use capability. Install it from `/plugins` on Windows x64.
+Add Windows support for the built-in Kimi Computer Use capability and show the underlying error when capability setup fails. Install it from `/plugins` on Windows x64.

--- a/apps/kimi-code/src/tui/commands/plugins.ts
+++ b/apps/kimi-code/src/tui/commands/plugins.ts
@@ -539,7 +539,8 @@ async function installCapabilityFromPanel(
   }
   logCapabilityStatus(result);
   if (result.install.error !== undefined) {
-    host.showError(`${label} installation failed. Check the logs and install again from /plugins.`);
+    host.showError(`${label} installation failed: ${result.install.error}`);
+    host.showStatus('Fix the reported error, then install again from /plugins.', 'warning');
     return;
   }
   if (result.state !== 'ready') {

--- a/apps/kimi-code/test/tui/commands/plugins-capability.test.ts
+++ b/apps/kimi-code/test/tui/commands/plugins-capability.test.ts
@@ -199,6 +199,29 @@ describe('plugins command capability surface', () => {
     expect(statuses.some((s) => s.includes('is installed'))).toBe(true);
   });
 
+  it('shows the engine error when a background capability install fails', async () => {
+    const { host, statuses } = fakeHost({
+      engineV2: true,
+      capabilityStatus: () =>
+        Promise.resolve({
+          state: 'not_installed',
+          steps: [],
+          install: { running: false, error: 'Authenticode signature is not valid' },
+        }),
+    });
+
+    await installCapabilityFromPanel(
+      host,
+      fakePanel().panel,
+      { id: 'kimi-cu', displayName: 'Kimi Computer Use', source: 'capability:kimi-cu' } as never,
+    );
+
+    expect(statuses).toContain(
+      'Kimi Computer Use installation failed: Authenticode signature is not valid',
+    );
+    expect(statuses).toContain('Fix the reported error, then install again from /plugins.');
+  });
+
   it('shows required permissions once after installation instead of exposing step details', async () => {
     const { host, statuses } = fakeHost({
       engineV2: true,

--- a/packages/agent-core-v2/src/app/capability/capabilityService.ts
+++ b/packages/agent-core-v2/src/app/capability/capabilityService.ts
@@ -4,14 +4,15 @@
  * Holds the closed registry of built-in capability entries and serializes
  * install runs per entry. Install progress lives in memory only and is
  * polled by clients; a failed attempt leaves its error in the progress state
- * until the next attempt starts. Listing degrades a single entry's failing
- * detection to a failed step on that entry instead of rejecting the whole
- * list. Bound at App scope.
+ * until the next attempt starts and logs the failure through `log`. Listing
+ * degrades a single entry's failing detection to a failed step on that entry
+ * instead of rejecting the whole list. Bound at App scope.
  */
 
 import { homedir } from 'node:os';
 
 import { LifecycleScope, ScopeActivation, registerScopedService } from '#/_base/di/scope';
+import { ILogService } from '#/_base/log/log';
 import { Error2 } from '#/errors';
 import { IBootstrapService } from '#/app/bootstrap/bootstrap';
 import { IPluginService } from '#/app/plugin/plugin';
@@ -42,6 +43,7 @@ export class CapabilityService implements ICapabilityService {
     @IBootstrapService bootstrap: IBootstrapService,
     @IPluginService plugins: IPluginService,
     @IHostProcessService hostProcess: IHostProcessService,
+    @ILogService private readonly log: ILogService,
     entriesOverride?: readonly CapabilityEntry[],
   ) {
     if (entriesOverride !== undefined) {
@@ -98,6 +100,12 @@ export class CapabilityService implements ICapabilityService {
         });
         this.installProgress.set(entry.id, { running: false });
       } catch (error) {
+        const step = this.installProgress.get(entry.id)?.step;
+        this.log.warn('capability install failed', {
+          capabilityId: entry.id,
+          step,
+          error,
+        });
         this.installProgress.set(entry.id, {
           running: false,
           error: error instanceof Error ? error.message : String(error),

--- a/packages/agent-core-v2/test/app/capability/capabilityService.test.ts
+++ b/packages/agent-core-v2/test/app/capability/capabilityService.test.ts
@@ -7,6 +7,7 @@
 import { describe, expect, it } from 'vitest';
 
 import { isError2 } from '#/_base/errors/errors';
+import type { ILogService, LogPayload } from '#/_base/log/log';
 import { CapabilityErrors } from '#/app/capability/errors';
 import { CapabilityService } from '#/app/capability/capabilityService';
 import type {
@@ -14,6 +15,8 @@ import type {
   CapabilityEntry,
   CapabilityInstallReporter,
 } from '#/app/capability/types';
+
+import { stubLog } from '../../_base/log/stubs';
 
 function fakeEntry(overrides: {
   id: 'kimi-cu' | 'kimi-webbridge';
@@ -36,12 +39,16 @@ function fakeEntry(overrides: {
   };
 }
 
-function fakeService(entries: readonly CapabilityEntry[]): CapabilityService {
+function fakeService(
+  entries: readonly CapabilityEntry[],
+  log: ILogService = stubLog(),
+): CapabilityService {
   // bootstrap / hostProcess are unused when entries are injected.
   return new CapabilityService(
     undefined as never,
     undefined as never,
     undefined as never,
+    log,
     entries,
   );
 }
@@ -238,5 +245,43 @@ describe('CapabilityService', () => {
     const retried = await service.getCapability('kimi-cu');
     expect(retried.install.error).toBeUndefined();
     expect(attempts).toBe(2);
+  });
+
+  it('logs an install error with its last progress step when setup fails', async () => {
+    const warnings: Array<{ message: string; payload?: LogPayload }> = [];
+    let resolveLogged: (() => void) | undefined;
+    const logged = new Promise<void>((resolve) => {
+      resolveLogged = resolve;
+    });
+    const error = new Error('signature mismatch');
+    const log = {
+      ...stubLog(),
+      warn: (message: string, payload?: LogPayload) => {
+        warnings.push({ message, payload });
+        resolveLogged?.();
+      },
+    } satisfies ILogService;
+    const service = fakeService(
+      [
+        fakeEntry({
+          id: 'kimi-cu',
+          install: async (report) => {
+            report('runtime');
+            throw error;
+          },
+        }),
+      ],
+      log,
+    );
+
+    await service.installCapability('kimi-cu');
+    await logged;
+
+    expect(warnings).toEqual([
+      {
+        message: 'capability install failed',
+        payload: { capabilityId: 'kimi-cu', step: 'runtime', error },
+      },
+    ]);
   });
 });


### PR DESCRIPTION
## Related Issue

No linked issue. This follows a reproduced Windows Computer Use installation failure.

## Problem

Built-in capability setup preserved its failure only in the in-memory install progress. The TUI replaced the underlying message with a generic `Check the logs` error, while the v2 diagnostic export did not receive the SDK logger entry. As a result, users could neither see the cause nor recover it from an exported session.

## What changed

- Show the engine-provided installation error in `/plugins`, followed by an actionable retry hint.
- Log the original exception, capability ID, and last progress step through the v2 app logger so diagnostic exports include the failure.
- Add focused coverage for both the user-visible output and diagnostic logging.
- Extend the existing Windows Computer Use changeset to cover the improved failure reporting.

## Verification

- `pnpm --filter @moonshot-ai/agent-core-v2 exec vitest run --maxWorkers=1` (4,752 passed)
- `pnpm --filter @moonshot-ai/kimi-code exec vitest run --maxWorkers=1` (2,571 passed, 2 skipped)
- Type checks passed for `@moonshot-ai/agent-core-v2` and `@moonshot-ai/kimi-code`.
- Import lint and `pnpm lint` passed with no errors.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update. No doc update is needed because the install command and configuration are unchanged.
