### PR TITLE
fix(kimi-code): select compatible PowerShell for Computer Use

### DIFF
--- a/.changeset/steady-powershell-fallback.md
+++ b/.changeset/steady-powershell-fallback.md
@@ -2,4 +2,4 @@
 "@moonshot-ai/kimi-code": patch
 ---
 
-Use a compatible PowerShell for Windows Kimi Computer Use installation and provide actionable recovery for locked plugin files.
+Use a compatible PowerShell for Windows Kimi Computer Use installation, provide actionable recovery for locked plugin files, and keep its marketplace name consistent after installation.

--- a/.changeset/steady-powershell-fallback.md
+++ b/.changeset/steady-powershell-fallback.md
@@ -2,4 +2,4 @@
 "@moonshot-ai/kimi-code": patch
 ---
 
-Select a compatible PowerShell installation before running the Windows Kimi Computer Use installer.
+Use a compatible PowerShell for Windows Kimi Computer Use installation and provide actionable recovery for locked plugin files.

--- a/.changeset/steady-powershell-fallback.md
+++ b/.changeset/steady-powershell-fallback.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Select a compatible PowerShell installation before running the Windows Kimi Computer Use installer.

--- a/apps/kimi-code/src/tui/commands/plugins.ts
+++ b/apps/kimi-code/src/tui/commands/plugins.ts
@@ -723,8 +723,9 @@ async function removePlugin(host: SlashCommandHost, id: string): Promise<void> {
   host.showStatus(`Removed ${id}.`);
   if (isCapabilityPluginId(host, id)) {
     host.showStatus(
-      'Note: the runtime binaries were left untouched, but Kimi Code plugin wiring is disabled for new sessions. Reinstall any time from the Official tab.',
+      'Note: the runtime binaries were left untouched, but Kimi Code plugin wiring is disabled for new sessions. Restart Kimi Code before reinstalling from the Official tab.',
     );
+    return;
   }
   host.showStatus(PLUGIN_RELOAD_HINT, 'warning');
 }

--- a/apps/kimi-code/test/tui/commands/plugins-capability.test.ts
+++ b/apps/kimi-code/test/tui/commands/plugins-capability.test.ts
@@ -128,6 +128,8 @@ describe('plugins command capability surface', () => {
     expect(statuses.some((s) => s.includes('Removed kimi-cu'))).toBe(true);
     expect(statuses.some((s) => s.includes('runtime binaries were left untouched'))).toBe(true);
     expect(statuses.some((s) => s.includes('plugin wiring is disabled for new sessions'))).toBe(true);
+    expect(statuses.some((s) => s.includes('Restart Kimi Code before reinstalling'))).toBe(true);
+    expect(statuses.some((s) => s.includes('Run /new or /reload'))).toBe(false);
   });
 
   it('keeps the runtime note for the Windows backing plugin id', async () => {

--- a/packages/agent-core-v2/src/app/capability/entries/kimiCu.ts
+++ b/packages/agent-core-v2/src/app/capability/entries/kimiCu.ts
@@ -640,7 +640,7 @@ function createWindowsKimiCuEntry(ctx: CapabilityEntryContext): CapabilityEntry 
     const before = await detect();
     const stepStates = new Map(before.steps.map((step) => [step.id, step.state]));
     const readyBefore = before.steps.every((step) => step.state === 'ok');
-    const installPlugin = stepStates.get('plugin') !== 'ok';
+    const installPlugin = stepStates.get('plugin') !== 'ok' || readyBefore;
     const installRuntime = stepStates.get('runtime') !== 'ok' || readyBefore;
     const installPowerShell = installRuntime ? await installerPowerShell() : undefined;
 

--- a/packages/agent-core-v2/src/app/capability/entries/kimiCu.ts
+++ b/packages/agent-core-v2/src/app/capability/entries/kimiCu.ts
@@ -566,7 +566,7 @@ function createWindowsKimiCuEntry(ctx: CapabilityEntryContext): CapabilityEntry 
     );
   }
 
-  async function runtimeStep(command = powershellPath): Promise<{
+  async function runtimeStep(command: string): Promise<{
     readonly step: CapabilityStep;
     readonly version?: string;
   }> {
@@ -608,10 +608,21 @@ function createWindowsKimiCuEntry(ctx: CapabilityEntryContext): CapabilityEntry 
       : { step: { id: 'runtime', state: 'ok', detail: doctor.version }, version: doctor.version };
   }
 
+  async function detectRuntimeStep(): Promise<{
+    readonly step: CapabilityStep;
+    readonly version?: string;
+  }> {
+    const systemRuntime = await runtimeStep(powershellPath);
+    if (systemRuntime.step.state !== 'failed') return systemRuntime;
+
+    const fallbackRuntime = await runtimeStep(powershell7Path);
+    return fallbackRuntime.step.state === 'ok' ? fallbackRuntime : systemRuntime;
+  }
+
   async function detect(): Promise<CapabilityDetectResult> {
     const [plugin, runtime] = await Promise.all([
       detectPluginLayer(ctx, WINDOWS_PLUGIN),
-      runtimeStep(),
+      detectRuntimeStep(),
     ]);
     return {
       steps: [plugin.step, runtime.step],

--- a/packages/agent-core-v2/src/app/capability/entries/kimiCu.ts
+++ b/packages/agent-core-v2/src/app/capability/entries/kimiCu.ts
@@ -704,7 +704,7 @@ function createWindowsKimiCuEntry(ctx: CapabilityEntryContext): CapabilityEntry 
   return {
     id: 'kimi-cu',
     pluginId: WINDOWS_PLUGIN.id,
-    displayName: 'Kimi Computer Use',
+    displayName: 'Kimi Computer Use for Windows',
     description:
       'Windows GUI automation — read app UIs and click, type, scroll, and drag in desktop apps.',
     supported,

--- a/packages/agent-core-v2/src/app/capability/entries/kimiCu.ts
+++ b/packages/agent-core-v2/src/app/capability/entries/kimiCu.ts
@@ -629,11 +629,29 @@ function createWindowsKimiCuEntry(ctx: CapabilityEntryContext): CapabilityEntry 
     const before = await detect();
     const stepStates = new Map(before.steps.map((step) => [step.id, step.state]));
     const readyBefore = before.steps.every((step) => step.state === 'ok');
+    const installPlugin = stepStates.get('plugin') !== 'ok';
     const installRuntime = stepStates.get('runtime') !== 'ok' || readyBefore;
     const installPowerShell = installRuntime ? await installerPowerShell() : undefined;
 
-    report('plugin');
-    await installPluginLayer(ctx, WINDOWS_PLUGIN);
+    if (installPlugin) {
+      report('plugin');
+      try {
+        await installPluginLayer(ctx, WINDOWS_PLUGIN);
+      } catch (error) {
+        if (
+          typeof error !== 'object' ||
+          error === null ||
+          !('code' in error) ||
+          error.code !== 'EBUSY'
+        ) {
+          throw error;
+        }
+        throw new Error(
+          'Kimi Computer Use plugin files are still in use by the current Kimi Code process. Restart Kimi Code, then install again.',
+          { cause: error },
+        );
+      }
+    }
 
     if (installPowerShell !== undefined) {
       const workDir = await mkdtemp(path.join(tmpdir(), 'kimi-cu-windows-install-'));

--- a/packages/agent-core-v2/src/app/capability/entries/kimiCu.ts
+++ b/packages/agent-core-v2/src/app/capability/entries/kimiCu.ts
@@ -20,6 +20,8 @@
  * blocking the replacement.
  * The Windows path downloads and runs the official `setup_windows.ps1`, so
  * its signature verification, rollback, and agent autostart stay upstream.
+ * It selects a trusted PowerShell installation that satisfies the script's
+ * command requirements before changing plugin wiring.
  */
 
 import { constants } from 'node:fs';
@@ -53,8 +55,18 @@ const LAUNCHD_LABEL = 'ai.kimi.cu.service';
 const COMMAND_TIMEOUT_MS = 30_000;
 const PERMISSIONS_TIMEOUT_MS = 15_000;
 const DETECT_PROBE_TIMEOUT_MS = 3_000;
+const WINDOWS_INSTALLER_PROBE_TIMEOUT_MS = 10_000;
 const WINDOWS_INSTALL_TIMEOUT_MS = 180_000;
 const DEFAULT_WINDOWS_SYSTEM_ROOT = 'C:\\Windows';
+const DEFAULT_WINDOWS_PROGRAM_FILES = 'C:\\Program Files';
+const WINDOWS_INSTALLER_PROBE_SCRIPT =
+  "$required = @('Get-FileHash', 'Expand-Archive', 'Get-AuthenticodeSignature', 'Get-CimInstance', 'Invoke-WebRequest', 'Invoke-RestMethod', 'ConvertFrom-Json', 'ConvertTo-Json'); " +
+  '$missing = @($required | Where-Object { -not (Get-Command $_ -CommandType Cmdlet,Function -ErrorAction SilentlyContinue) }); ' +
+  '$issues = @(); ' +
+  "if ($PSVersionTable.PSVersion -lt [Version]'5.1') { $issues += ('requires PowerShell 5.1 or newer; found ' + $PSVersionTable.PSVersion) }; " +
+  "if ($missing.Count -gt 0) { $issues += ('missing commands: ' + ($missing -join ', ')) }; " +
+  "if ($issues.Count -gt 0) { [Console]::Error.Write(($issues -join '; ')); exit 2 }; " +
+  "[Console]::Out.Write(('PowerShell ' + $PSVersionTable.PSVersion));";
 const WINDOWS_DOCTOR_SCRIPT =
   '$candidates = @($env:KIMI_CU_WINDOWS_EXE); ' +
   "if ($env:KIMI_CU_WINDOWS_HOME) { $candidates += (Join-Path $env:KIMI_CU_WINDOWS_HOME 'kimi-cu.exe') }; " +
@@ -115,6 +127,18 @@ export function windowsPowerShellPath(
   );
 }
 
+export function windowsPowerShell7Path(
+  programFiles =
+    process.env['ProgramW6432'] ??
+    process.env['ProgramFiles'] ??
+    DEFAULT_WINDOWS_PROGRAM_FILES,
+): string {
+  const root = path.win32.isAbsolute(programFiles)
+    ? programFiles
+    : DEFAULT_WINDOWS_PROGRAM_FILES;
+  return path.win32.join(root, 'PowerShell', '7', 'pwsh.exe');
+}
+
 export async function readAppBundleVersion(infoPlistPath: string): Promise<string | undefined> {
   try {
     const xml = await readFile(infoPlistPath, 'utf-8');
@@ -131,6 +155,18 @@ function appleScriptQuote(script: string): string {
 
 function errorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
+}
+
+function powerShellStringLiteral(value: string): string {
+  return `'${value.replaceAll("'", "''")}'`;
+}
+
+function powerShellSetupCommand(setupPath: string): string {
+  return (
+    '$utf8 = New-Object System.Text.UTF8Encoding($false); ' +
+    '[Console]::OutputEncoding = $utf8; $OutputEncoding = $utf8; ' +
+    `& ${powerShellStringLiteral(setupPath)}`
+  );
 }
 
 async function detectPluginLayer(
@@ -495,10 +531,42 @@ function createMacKimiCuEntry(ctx: CapabilityEntryContext): CapabilityEntry {
 function createWindowsKimiCuEntry(ctx: CapabilityEntryContext): CapabilityEntry {
   const supported = ctx.platform === 'win32' && ctx.arch === 'x64';
   const probeTimeoutMs = ctx.detectProbeTimeoutMs ?? DETECT_PROBE_TIMEOUT_MS;
+  const installerProbeTimeoutMs =
+    ctx.detectProbeTimeoutMs ?? WINDOWS_INSTALLER_PROBE_TIMEOUT_MS;
   const installTimeoutMs = ctx.commandTimeoutMs ?? WINDOWS_INSTALL_TIMEOUT_MS;
   const powershellPath = windowsPowerShellPath();
+  const powershell7Path = windowsPowerShell7Path();
 
-  async function runtimeStep(): Promise<{
+  async function installerPowerShell(): Promise<string> {
+    const failures: string[] = [];
+    for (const candidate of [
+      { label: 'Windows PowerShell', command: powershellPath },
+      { label: 'PowerShell 7', command: powershell7Path },
+    ]) {
+      try {
+        const result = await runCommand(
+          ctx.hostProcess,
+          candidate.command,
+          ['-NoProfile', '-NonInteractive', '-Command', WINDOWS_INSTALLER_PROBE_SCRIPT],
+          { timeout: installerProbeTimeoutMs },
+        );
+        if (result.code === 0) return candidate.command;
+        failures.push(
+          `${candidate.label} (${candidate.command}): ${
+            result.stderr.trim() || result.stdout.trim() || `exit code ${result.code}`
+          }`,
+        );
+      } catch (error) {
+        failures.push(`${candidate.label} (${candidate.command}): ${errorMessage(error)}`);
+      }
+    }
+    throw new Error(
+      'Kimi Computer Use requires Windows PowerShell 5.1 or PowerShell 7 with the commands required by its official installer. ' +
+        failures.join('; '),
+    );
+  }
+
+  async function runtimeStep(command = powershellPath): Promise<{
     readonly step: CapabilityStep;
     readonly version?: string;
   }> {
@@ -506,7 +574,7 @@ function createWindowsKimiCuEntry(ctx: CapabilityEntryContext): CapabilityEntry 
     try {
       result = await runCommand(
         ctx.hostProcess,
-        powershellPath,
+        command,
         ['-NoProfile', '-NonInteractive', '-Command', WINDOWS_DOCTOR_SCRIPT],
         { timeout: probeTimeoutMs },
       );
@@ -561,11 +629,13 @@ function createWindowsKimiCuEntry(ctx: CapabilityEntryContext): CapabilityEntry 
     const before = await detect();
     const stepStates = new Map(before.steps.map((step) => [step.id, step.state]));
     const readyBefore = before.steps.every((step) => step.state === 'ok');
+    const installRuntime = stepStates.get('runtime') !== 'ok' || readyBefore;
+    const installPowerShell = installRuntime ? await installerPowerShell() : undefined;
 
     report('plugin');
     await installPluginLayer(ctx, WINDOWS_PLUGIN);
 
-    if (stepStates.get('runtime') !== 'ok' || readyBefore) {
+    if (installPowerShell !== undefined) {
       const workDir = await mkdtemp(path.join(tmpdir(), 'kimi-cu-windows-install-'));
       try {
         const setupPath = path.join(workDir, 'setup_windows.ps1');
@@ -582,14 +652,14 @@ function createWindowsKimiCuEntry(ctx: CapabilityEntryContext): CapabilityEntry 
         report('runtime');
         const installed = await runCommand(
           ctx.hostProcess,
-          powershellPath,
+          installPowerShell,
           [
             '-NoProfile',
             '-NonInteractive',
             '-ExecutionPolicy',
             'Bypass',
-            '-File',
-            setupPath,
+            '-Command',
+            powerShellSetupCommand(setupPath),
           ],
           { timeout: installTimeoutMs },
         );
@@ -604,7 +674,7 @@ function createWindowsKimiCuEntry(ctx: CapabilityEntryContext): CapabilityEntry 
         await rm(workDir, { recursive: true, force: true }).catch(() => undefined);
       }
 
-      const runtime = await runtimeStep();
+      const runtime = await runtimeStep(installPowerShell);
       if (runtime.step.state !== 'ok') {
         throw new Error(
           `kimi-cu Windows runtime is not ready after install: ${runtime.step.detail ?? runtime.step.state}`,

--- a/packages/agent-core-v2/test/app/capability/kimiCu.test.ts
+++ b/packages/agent-core-v2/test/app/capability/kimiCu.test.ts
@@ -460,6 +460,66 @@ describe('kimi-cu entry', () => {
     ]);
   });
 
+  it('keeps the Windows runtime detectable after installing through PowerShell 7', async () => {
+    const plugins = fakePlugins([]);
+    const calls: string[] = [];
+    let runtimeInstalled = false;
+    const hostProcess = {
+      _serviceBrand: undefined,
+      spawn: (command: string, args: readonly string[] = []) => {
+        calls.push(`${command} ${args.join(' ')}`);
+        if (command === windowsPowerShellPath()) {
+          return Promise.reject(new Error('Windows PowerShell cannot launch'));
+        }
+        if (args.some((arg) => arg.includes('Get-FileHash'))) {
+          return Promise.resolve(fakeProc(0, 'PowerShell 7.5.2'));
+        }
+        if (args.some((arg) => arg.includes('setup_windows.ps1'))) {
+          runtimeInstalled = true;
+          return Promise.resolve(fakeProc(0));
+        }
+        return Promise.resolve(
+          runtimeInstalled
+            ? fakeProc(
+                0,
+                'version=0.2.14\r\nmcp=true\r\nhelper=embedded\r\nagent=running\r\n',
+              )
+            : fakeProc(3),
+        );
+      },
+    } as IHostProcessService;
+    const entry = createKimiCuEntry(
+      makeCtx({
+        platform: 'win32',
+        arch: 'x64',
+        plugins: plugins.service,
+        hostProcess,
+        fetchImpl: (() =>
+          Promise.resolve(
+            new Response("Write-Host 'official setup'", {
+              headers: { 'content-length': '27' },
+            }),
+          )) as typeof fetch,
+      }),
+    );
+
+    await entry.install(() => undefined);
+
+    await expect(entry.detect()).resolves.toEqual({
+      version: '0.2.14',
+      steps: [
+        { id: 'plugin', state: 'ok' },
+        { id: 'runtime', state: 'ok', detail: '0.2.14' },
+      ],
+    });
+    expect(
+      calls.some(
+        (call) =>
+          call.startsWith(windowsPowerShell7Path()) && call.includes('setup_windows.ps1'),
+      ),
+    ).toBe(true);
+  });
+
   it('leaves plugin wiring untouched when no PowerShell can run the installer', async () => {
     const plugins = fakePlugins([]);
     let downloads = 0;

--- a/packages/agent-core-v2/test/app/capability/kimiCu.test.ts
+++ b/packages/agent-core-v2/test/app/capability/kimiCu.test.ts
@@ -21,6 +21,7 @@ import {
   parseWindowsDoctorOutput,
   readAppBundleVersion,
   windowsPowerShellPath,
+  windowsPowerShell7Path,
 } from '#/app/capability/entries/kimiCu';
 
 function fakeProc(code: number, stdout = '', stderr = ''): IHostProcess {
@@ -189,6 +190,10 @@ describe('windowsPowerShellPath', () => {
       'D:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe',
     );
     expect(path.win32.isAbsolute(windowsPowerShellPath('relative'))).toBe(true);
+    expect(windowsPowerShell7Path('D:\\Program Files')).toBe(
+      'D:\\Program Files\\PowerShell\\7\\pwsh.exe',
+    );
+    expect(path.win32.isAbsolute(windowsPowerShell7Path('relative'))).toBe(true);
   });
 });
 
@@ -330,6 +335,12 @@ describe('kimi-cu entry', () => {
       _serviceBrand: undefined,
       spawn: (command: string, args: readonly string[] = []) => {
         calls.push(`${command} ${args.join(' ')}`);
+        if (args.some((arg) => arg.includes('Get-FileHash'))) {
+          return Promise.resolve(fakeProc(0, 'PowerShell 5.1'));
+        }
+        if (args.some((arg) => arg.includes('setup_windows.ps1'))) {
+          return Promise.resolve(fakeProc(0));
+        }
         if (args.includes('-Command')) {
           const result = doctorResults.shift();
           return Promise.resolve(
@@ -340,7 +351,7 @@ describe('kimi-cu entry', () => {
             ),
           );
         }
-        return Promise.resolve(fakeProc(args.includes('-File') ? 0 : 1));
+        return Promise.resolve(fakeProc(1));
       },
     } as IHostProcessService;
     const fetchImpl = (() => {
@@ -372,9 +383,110 @@ describe('kimi-cu entry', () => {
     expect(reports).toContainEqual(['download', 0]);
     expect(reports).toContainEqual(['download', 100]);
     expect(reports).toContainEqual(['runtime', undefined]);
-    expect(calls.some((call) => call.includes('-ExecutionPolicy Bypass -File'))).toBe(true);
+    expect(
+      calls.some(
+        (call) =>
+          call.includes('-ExecutionPolicy Bypass -Command') &&
+          call.includes('[Console]::OutputEncoding = $utf8') &&
+          call.includes('setup_windows.ps1'),
+      ),
+    ).toBe(true);
     expect(calls.every((call) => call.startsWith(windowsPowerShellPath()))).toBe(true);
     expect(doctorResults).toEqual([]);
+  });
+
+  it('uses trusted PowerShell 7 when system PowerShell cannot run the installer', async () => {
+    const plugins = fakePlugins([]);
+    const calls: string[] = [];
+    const doctorResults = [
+      { code: 3, stdout: '', stderr: '' },
+      {
+        code: 0,
+        stdout: 'version=0.2.14\r\nmcp=true\r\nhelper=embedded\r\nagent=running\r\n',
+        stderr: '',
+      },
+    ];
+    const hostProcess = {
+      _serviceBrand: undefined,
+      spawn: (command: string, args: readonly string[] = []) => {
+        calls.push(`${command} ${args.join(' ')}`);
+        if (args.some((arg) => arg.includes('Get-FileHash'))) {
+          return Promise.resolve(
+            command === windowsPowerShellPath()
+              ? fakeProc(2, '', 'missing commands: Get-FileHash')
+              : fakeProc(0, 'PowerShell 7.5.2'),
+          );
+        }
+        if (args.some((arg) => arg.includes('setup_windows.ps1'))) {
+          return Promise.resolve(fakeProc(0));
+        }
+        const result = doctorResults.shift();
+        return Promise.resolve(
+          fakeProc(result?.code ?? 1, result?.stdout ?? '', result?.stderr ?? 'unexpected doctor'),
+        );
+      },
+    } as IHostProcessService;
+    const entry = createKimiCuEntry(
+      makeCtx({
+        platform: 'win32',
+        arch: 'x64',
+        plugins: plugins.service,
+        hostProcess,
+        fetchImpl: (() =>
+          Promise.resolve(
+            new Response("Write-Host 'official setup'", {
+              headers: { 'content-length': '27' },
+            }),
+          )) as typeof fetch,
+      }),
+    );
+
+    await entry.install(() => undefined);
+
+    expect(
+      calls.some(
+        (call) =>
+          call.startsWith(windowsPowerShell7Path()) && call.includes('setup_windows.ps1'),
+      ),
+    ).toBe(true);
+    expect(plugins.installs).toEqual([
+      'https://cdn.kimi.com/kimi-computer-use-windows/latest/kimi-cu-win-plugin.zip',
+    ]);
+  });
+
+  it('leaves plugin wiring untouched when no PowerShell can run the installer', async () => {
+    const plugins = fakePlugins([]);
+    let downloads = 0;
+    const hostProcess = {
+      _serviceBrand: undefined,
+      spawn: (command: string, args: readonly string[] = []) => {
+        if (args.some((arg) => arg.includes('Get-FileHash'))) {
+          return Promise.resolve(
+            fakeProc(2, '', `${command}: missing commands: Get-FileHash, Expand-Archive`),
+          );
+        }
+        return Promise.resolve(fakeProc(3));
+      },
+    } as IHostProcessService;
+    const entry = createKimiCuEntry(
+      makeCtx({
+        platform: 'win32',
+        arch: 'x64',
+        plugins: plugins.service,
+        hostProcess,
+        fetchImpl: (() => {
+          downloads += 1;
+          return Promise.reject(new Error('download should not start'));
+        }) as typeof fetch,
+      }),
+    );
+
+    await expect(entry.install(() => undefined)).rejects.toThrow(
+      /requires Windows PowerShell 5\.1 or PowerShell 7.*Get-FileHash, Expand-Archive/,
+    );
+
+    expect(plugins.installs).toEqual([]);
+    expect(downloads).toBe(0);
   });
 
   it('does not reinstall a healthy Windows runtime when only the plugin is missing', async () => {

--- a/packages/agent-core-v2/test/app/capability/kimiCu.test.ts
+++ b/packages/agent-core-v2/test/app/capability/kimiCu.test.ts
@@ -601,6 +601,58 @@ describe('kimi-cu entry', () => {
     expect(doctorResults).toEqual([]);
   });
 
+  it('refreshes the Windows plugin when installation starts fully ready', async () => {
+    const plugins = fakePlugins([{ id: 'kimi-cu-win', enabled: true, state: 'ok' }]);
+    const doctorResults = [
+      {
+        code: 0,
+        stdout: 'version=0.2.14\r\nmcp=true\r\nhelper=embedded\r\nagent=running\r\n',
+        stderr: '',
+      },
+      {
+        code: 0,
+        stdout: 'version=0.2.14\r\nmcp=true\r\nhelper=embedded\r\nagent=running\r\n',
+        stderr: '',
+      },
+    ];
+    const hostProcess = {
+      _serviceBrand: undefined,
+      spawn: (_command: string, args: readonly string[] = []) => {
+        if (args.some((arg) => arg.includes('Get-FileHash'))) {
+          return Promise.resolve(fakeProc(0, 'PowerShell 5.1'));
+        }
+        if (args.some((arg) => arg.includes('setup_windows.ps1'))) {
+          return Promise.resolve(fakeProc(0));
+        }
+        const result = doctorResults.shift();
+        return Promise.resolve(
+          fakeProc(result?.code ?? 1, result?.stdout ?? '', result?.stderr ?? 'unexpected doctor'),
+        );
+      },
+    } as IHostProcessService;
+    const entry = createKimiCuEntry(
+      makeCtx({
+        platform: 'win32',
+        arch: 'x64',
+        plugins: plugins.service,
+        hostProcess,
+        fetchImpl: (() =>
+          Promise.resolve(
+            new Response("Write-Host 'official setup'", {
+              headers: { 'content-length': '27' },
+            }),
+          )) as typeof fetch,
+      }),
+    );
+
+    await entry.install(() => undefined);
+
+    expect(plugins.installs).toEqual([
+      'https://cdn.kimi.com/kimi-computer-use-windows/latest/kimi-cu-win-plugin.zip',
+    ]);
+    expect(doctorResults).toEqual([]);
+  });
+
   it('explains how to recover when Windows plugin files are still in use', async () => {
     const busy = Object.assign(new Error('resource busy or locked'), { code: 'EBUSY' });
     const plugins = fakePlugins([], () => {

--- a/packages/agent-core-v2/test/app/capability/kimiCu.test.ts
+++ b/packages/agent-core-v2/test/app/capability/kimiCu.test.ts
@@ -285,6 +285,12 @@ describe('kimi-cu entry', () => {
     );
   });
 
+  it('labels the Windows capability consistently with its installed plugin', () => {
+    expect(createKimiCuEntry(makeCtx({ platform: 'win32', arch: 'x64' })).displayName).toBe(
+      'Kimi Computer Use for Windows',
+    );
+  });
+
   it('detects the Windows plugin and signed runtime through doctor', async () => {
     const plugins = fakePlugins([
       { id: 'kimi-cu-win', enabled: true, state: 'ok', version: '0.2.14' },

--- a/packages/agent-core-v2/test/app/capability/kimiCu.test.ts
+++ b/packages/agent-core-v2/test/app/capability/kimiCu.test.ts
@@ -489,6 +489,78 @@ describe('kimi-cu entry', () => {
     expect(downloads).toBe(0);
   });
 
+  it('repairs a missing Windows runtime without replacing a healthy plugin', async () => {
+    const plugins = fakePlugins([{ id: 'kimi-cu-win', enabled: true, state: 'ok' }]);
+    const doctorResults = [
+      { code: 3, stdout: '', stderr: '' },
+      {
+        code: 0,
+        stdout: 'version=0.2.14\r\nmcp=true\r\nhelper=embedded\r\nagent=running\r\n',
+        stderr: '',
+      },
+    ];
+    const hostProcess = {
+      _serviceBrand: undefined,
+      spawn: (_command: string, args: readonly string[] = []) => {
+        if (args.some((arg) => arg.includes('Get-FileHash'))) {
+          return Promise.resolve(fakeProc(0, 'PowerShell 5.1'));
+        }
+        if (args.some((arg) => arg.includes('setup_windows.ps1'))) {
+          return Promise.resolve(fakeProc(0));
+        }
+        const result = doctorResults.shift();
+        return Promise.resolve(
+          fakeProc(result?.code ?? 1, result?.stdout ?? '', result?.stderr ?? 'unexpected doctor'),
+        );
+      },
+    } as IHostProcessService;
+    const entry = createKimiCuEntry(
+      makeCtx({
+        platform: 'win32',
+        arch: 'x64',
+        plugins: plugins.service,
+        hostProcess,
+        fetchImpl: (() =>
+          Promise.resolve(
+            new Response("Write-Host 'official setup'", {
+              headers: { 'content-length': '27' },
+            }),
+          )) as typeof fetch,
+      }),
+    );
+
+    await entry.install(() => undefined);
+
+    expect(plugins.installs).toEqual([]);
+    expect(doctorResults).toEqual([]);
+  });
+
+  it('explains how to recover when Windows plugin files are still in use', async () => {
+    const busy = Object.assign(new Error('resource busy or locked'), { code: 'EBUSY' });
+    const plugins = fakePlugins([], () => {
+      throw busy;
+    });
+    const host = fakeHostProcess([
+      {
+        match: '-Command',
+        code: 0,
+        stdout: 'version=0.2.14\nmcp=true\nhelper=embedded\nagent=running\n',
+      },
+    ]);
+    const entry = createKimiCuEntry(
+      makeCtx({
+        platform: 'win32',
+        arch: 'x64',
+        plugins: plugins.service,
+        hostProcess: host.service,
+      }),
+    );
+
+    await expect(entry.install(() => undefined)).rejects.toThrow(
+      'Kimi Computer Use plugin files are still in use by the current Kimi Code process. Restart Kimi Code, then install again.',
+    );
+  });
+
   it('does not reinstall a healthy Windows runtime when only the plugin is missing', async () => {
     const plugins = fakePlugins([]);
     const host = fakeHostProcess([


### PR DESCRIPTION
## Related Issue

No linked issue. This fixes Windows installation failures reproduced from Kimi Computer Use debug sessions and a naming mismatch observed after installation.

## Problem

The Windows Kimi Computer Use installer was always launched with the system `powershell.exe`. On systems where that PowerShell installation does not provide commands required by the official setup script, such as `Get-FileHash`, installation fails even when a compatible PowerShell 7 installation is available.

The failure also happened after entering the capability installation flow, without first checking whether the selected PowerShell could run the official installer.

A runtime repair also replaced the plugin even when its wiring was already healthy. On Windows, a live plugin MCP process can keep that managed directory locked, exposing a raw `EBUSY` rename error instead of actionable recovery guidance.

Before installation, the Official marketplace used the built-in capability name `Kimi Computer Use`. After installation, the Installed tab used the Windows plugin manifest name `Kimi Computer Use for Windows`, making the same product appear to change names.

## What changed

- Probe the system Windows PowerShell for the version and commands required by the official installer.
- Fall back to PowerShell 7 from its trusted Program Files installation path when the system PowerShell is incompatible.
- Fail with path-specific diagnostics before downloading the installer or changing plugin wiring when neither installation is compatible.
- Continue to run the unchanged official setup script, while forcing UTF-8 console output so PowerShell diagnostics remain readable.
- Keep healthy plugin wiring untouched when only the Windows runtime needs repair.
- Explain that Kimi Code must be restarted when live plugin files are locked, including after removing a built-in capability plugin.
- Use `Kimi Computer Use for Windows` for the Windows capability so the Official and Installed tabs display the same name.
- Cover the PowerShell selection, fail-before-mutation, healthy-plugin, locked-file, removal-hint, and Windows display-name paths with focused tests.
- Add a patch changeset for `@moonshot-ai/kimi-code`.

### Verification

- `pnpm --filter @moonshot-ai/agent-core-v2 exec vitest run test/app/capability/kimiCu.test.ts` — 31 tests passed.
- `pnpm exec vitest run apps/kimi-code/test/tui/commands/plugin-commands.test.ts apps/kimi-code/test/tui/commands/plugins-capability.test.ts` — 13 tests passed.
- `pnpm --filter @moonshot-ai/agent-core-v2 test` — 300 test files and 4757 tests passed.
- `pnpm --filter @moonshot-ai/agent-core-v2 typecheck` — passed.
- `pnpm --filter @moonshot-ai/agent-core-v2 lint:imports` — passed.
- `pnpm --filter @moonshot-ai/kimi-code typecheck` — passed.
- `pnpm exec oxlint --type-aware` on the changed TypeScript files — passed.
- `pnpm exec changeset status` — passed.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.
