### PR TITLE
docs: mention voice ACP clients with a qwen-audio-agent example

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,8 @@ For Zed, add this to `~/.config/zed/settings.json`:
 
 Then open a new conversation in Zed's Agent panel. See [Using in IDEs](https://moonshotai.github.io/kimi-code/en/guides/ides) for JetBrains setup and troubleshooting, and the [`kimi acp` reference](https://moonshotai.github.io/kimi-code/en/reference/kimi-acp) for the full capability matrix.
 
+ACP clients are not limited to editors. For example, [qwen-audio-agent](https://github.com/QwenAudio/qwen-audio-agent) is a realtime full-duplex voice frontend that drives a `kimi acp` session hands-free (barge-in, local wake word); point its generic ACP backend at Kimi Code with `ACP_COMMAND=kimi` and `ACP_ARGS=["acp"]`.
+
 ## Docs
 
 - [Getting Started](https://moonshotai.github.io/kimi-code/en/guides/getting-started)

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -87,6 +87,8 @@ Kimi Code CLI 支持 [Agent Client Protocol](https://agentclientprotocol.com/)�
 
 随后在 Zed 的 Agent 面板新建对话即可。JetBrains 配置与排障见[在 IDE 中使用](https://moonshotai.github.io/kimi-code/zh/guides/ides)，完整能力矩阵见 [`kimi acp` 参考](https://moonshotai.github.io/kimi-code/zh/reference/kimi-acp)。
 
+ACP 客户端不限于编辑器。例如 [qwen-audio-agent](https://github.com/QwenAudio/qwen-audio-agent) 是一个实时全双工语音前台，可以免提驱动 `kimi acp` 会话（支持插嘴打断、本地唤醒词）：在其通用 ACP 后台配置中设置 `ACP_COMMAND=kimi`、`ACP_ARGS=["acp"]` 即可接入。
+
 ## 文档
 
 - [快速上手](https://moonshotai.github.io/kimi-code/zh/guides/getting-started)


### PR DESCRIPTION
## Related Issue

No issue — docs-only change (README clarification), per CONTRIBUTING doc changes may be submitted directly.

## Problem

The README's "Use it in your editor (ACP)" section implies ACP usage is limited to editors. Since Kimi Code supports ACP over stdio (`kimi acp`), non-editor ACP clients — like voice frontends — can also drive it, but the README gives no example of this.

## What changed

Added one short paragraph to the ACP section of both `README.md` and `README.zh-CN.md`, noting that ACP clients are not limited to editors and giving a concrete voice example: [qwen-audio-agent](https://github.com/QwenAudio/qwen-audio-agent) (an ACP client list is maintained on the official ACP site). No code changes.

Disclosure: I'm a maintainer of qwen-audio-agent.

## Checklist

- [x] I have read the CONTRIBUTING document.
- [x] I have linked a related issue, or explained the problem above. (No issue — docs-only, explained above)
- [ ] I have added tests that prove my feature works. (N/A — README text only)
- [x] Ran `gen-changesets` skill, or this PR needs no changeset. (No changeset needed — README only)
- [x] Ran `gen-docs` skill, or this PR needs no doc update. (The README change itself is the doc update)
