### PR TITLE
feat(agent-core-v2): tombstone removed MCP servers and freeze plugin prompt inputs

### DIFF
--- a/.changeset/frozen-plugin-prompt-inputs.md
+++ b/.changeset/frozen-plugin-prompt-inputs.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Stop rewriting the current session's system prompt when plugins are installed, enabled, disabled, removed, or reloaded; the running session keeps its original prompt and the change takes effect in new sessions.

--- a/.changeset/mcp-removed-tombstone.md
+++ b/.changeset/mcp-removed-tombstone.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Keep live sessions stable when an MCP server is removed from the workspace config: its tools stay registered and return a removal notice instead of breaking in-flight calls, and the MCP panel shows the removed status. Plugin install, enable, disable, and remove now refresh workspace contributions immediately.

--- a/apps/kimi-code/src/tui/commands/plugins.ts
+++ b/apps/kimi-code/src/tui/commands/plugins.ts
@@ -32,6 +32,7 @@ import {
   isOfficialPluginInstall,
   isOfficialPluginSource,
 } from '../utils/plugin-source-label';
+import { isKimiV2Enabled } from '#/cli/experimental-v2';
 import { KIMI_CODE_PLUGIN_MARKETPLACE_URL_ENV, QUOTA_CONSUMING_PLUGIN_IDS } from '#/constant/app';
 import { loadPluginMarketplace, type PluginMarketplaceEntry } from '#/utils/plugin-marketplace';
 import { openUrl } from '#/utils/open-url';
@@ -557,11 +558,11 @@ async function installCapabilityFromPanel(
         `${label} installation did not complete. Check the logs and install again from /plugins.`,
       );
     }
-    host.showStatus(PLUGIN_RELOAD_HINT, 'warning');
+    host.showStatus(pluginReloadHint(), 'warning');
     return;
   }
   host.showStatus(`${label} is installed.`);
-  host.showStatus(PLUGIN_RELOAD_HINT, 'warning');
+  host.showStatus(pluginReloadHint(), 'warning');
 }
 
 async function installFromPanel(
@@ -727,7 +728,7 @@ async function removePlugin(host: SlashCommandHost, id: string): Promise<void> {
     );
     return;
   }
-  host.showStatus(PLUGIN_RELOAD_HINT, 'warning');
+  host.showStatus(pluginReloadHint(), 'warning');
 }
 
 async function renderPluginsList(
@@ -770,6 +771,13 @@ async function installPluginFromSource(
 
 const PLUGIN_RELOAD_HINT = 'Run /new or /reload to apply plugin changes.';
 
+const PLUGIN_RELOAD_HINT_V2 =
+  'Plugin changes apply immediately. MCP tools already loaded in open sessions stay visible but fail with a removal notice once uninstalled.';
+
+function pluginReloadHint(): string {
+  return isKimiV2Enabled() ? PLUGIN_RELOAD_HINT_V2 : PLUGIN_RELOAD_HINT;
+}
+
 const PLUGIN_QUOTA_NOTE = 'Note: This plugin consumes your quota.';
 
 function showPluginInstallResult(
@@ -785,7 +793,7 @@ function showPluginInstallResult(
       : '';
   const action = describeInstallAction(previous, summary);
   host.showStatus(`${action} (${summary.id}).${mcpHint}`);
-  host.showStatus(PLUGIN_RELOAD_HINT, 'warning');
+  host.showStatus(pluginReloadHint(), 'warning');
   // Gate on provenance, not just the id: a local/GitHub fork whose manifest
   // reuses a billed plugin's id is not the official quota-consuming build.
   if (QUOTA_CONSUMING_PLUGIN_IDS.includes(summary.id) && isOfficialPluginInstall(summary)) {

--- a/apps/kimi-code/src/tui/components/messages/mcp-status-panel.ts
+++ b/apps/kimi-code/src/tui/components/messages/mcp-status-panel.ts
@@ -12,6 +12,7 @@ const STATUS_PRIORITY: Record<McpServerInfo['status'], number> = {
   pending: 2,
   connected: 3,
   disabled: 4,
+  removed: 5,
 };
 
 const STATUS_LABEL: Record<McpServerInfo['status'], string> = {
@@ -20,6 +21,7 @@ const STATUS_LABEL: Record<McpServerInfo['status'], string> = {
   'needs-auth': 'needs auth',
   failed: 'failed',
   disabled: 'disabled',
+  removed: 'removed',
 };
 
 const SUMMARY_ORDER: readonly McpServerInfo['status'][] = [
@@ -28,6 +30,7 @@ const SUMMARY_ORDER: readonly McpServerInfo['status'][] = [
   'needs-auth',
   'failed',
   'disabled',
+  'removed',
 ];
 
 function statusPainter(
@@ -42,12 +45,13 @@ function statusPainter(
     case 'pending':
       return (text) => currentTheme.fg('warning', text);
     case 'disabled':
+    case 'removed':
       return (text) => currentTheme.fg('textDim', text);
   }
 }
 
 function formatToolCount(server: McpServerInfo): string {
-  if (server.status === 'disabled') return '—';
+  if (server.status === 'disabled' || server.status === 'removed') return '—';
   return `${server.toolCount} tool${server.toolCount === 1 ? '' : 's'}`;
 }
 

--- a/apps/kimi-code/src/tui/controllers/session-event-handler.ts
+++ b/apps/kimi-code/src/tui/controllers/session-event-handler.ts
@@ -950,6 +950,13 @@ export class SessionEventHandler {
           'textMuted',
         );
         return;
+      case 'removed':
+        this.finalizeMcpServerStatusRow(
+          server.name,
+          `MCP server "${server.name}" removed`,
+          'textMuted',
+        );
+        return;
       case 'pending':
         this.showMcpServerStatusSpinner(server.name);
         return;

--- a/apps/kimi-code/src/tui/utils/mcp-server-status.ts
+++ b/apps/kimi-code/src/tui/utils/mcp-server-status.ts
@@ -16,6 +16,8 @@ function mcpStartupStatusPriority(status: McpServerStatusSnapshot['status']): nu
       return 3;
     case 'disabled':
       return 4;
+    case 'removed':
+      return 5;
   }
 }
 
@@ -23,7 +25,7 @@ export function selectMcpStartupStatusRows(
   servers: readonly McpServerStatusSnapshot[],
 ): McpServerStatusSnapshot[] {
   return [...servers]
-    .filter((server) => server.status !== 'disabled')
+    .filter((server) => server.status !== 'disabled' && server.status !== 'removed')
     .toSorted((a, b) => mcpStartupStatusPriority(a.status) - mcpStartupStatusPriority(b.status))
     .slice(0, MCP_STARTUP_STATUS_ROW_LIMIT);
 }
@@ -36,6 +38,7 @@ export function formatMcpStartupStatusSummary(
   let connecting = 0;
   let connected = 0;
   let disabled = 0;
+  let removed = 0;
   for (const server of servers) {
     switch (server.status) {
       case 'failed':
@@ -53,6 +56,9 @@ export function formatMcpStartupStatusSummary(
       case 'disabled':
         disabled++;
         break;
+      case 'removed':
+        removed++;
+        break;
     }
   }
 
@@ -62,6 +68,7 @@ export function formatMcpStartupStatusSummary(
   if (connecting > 0) parts.push(`${connecting} connecting`);
   if (connected > 0) parts.push(`${connected} connected`);
   if (disabled > 0) parts.push(`${disabled} disabled`);
+  if (removed > 0) parts.push(`${removed} removed`);
   return parts.join(', ');
 }
 

--- a/apps/kimi-code/test/tui/kimi-tui-message-flow.test.ts
+++ b/apps/kimi-code/test/tui/kimi-tui-message-flow.test.ts
@@ -460,6 +460,7 @@ afterEach(async () => {
   } else {
     process.env['EDITOR'] = originalEditor;
   }
+  vi.unstubAllEnvs();
 });
 
 describe('KimiTUI message flow', () => {
@@ -5289,6 +5290,7 @@ command = "vim"
   });
 
   it('shows a quota note after installing a quota-consuming official plugin', async () => {
+    vi.stubEnv('KIMI_CODE_LEGACY_FLAG', '1');
     const session = makeSession({
       installPlugin: vi.fn(async () => ({
         id: 'kimi-datasource',
@@ -5315,6 +5317,37 @@ command = "vim"
       const transcript = stripSgr(renderTranscript(driver));
       expect(transcript).toContain('Run /new or /reload to apply plugin changes.');
       expect(transcript).toContain('Note: This plugin consumes your quota.');
+    });
+  });
+
+  it('shows the apply-immediately hint after installing a plugin on the v2 engine', async () => {
+    vi.stubEnv('KIMI_CODE_LEGACY_FLAG', '');
+    const session = makeSession({
+      installPlugin: vi.fn(async () => ({
+        id: 'demo',
+        displayName: 'Demo',
+        version: '1.0.0',
+        enabled: true,
+        state: 'ok',
+        skillCount: 0,
+        mcpServerCount: 1,
+        enabledMcpServerCount: 1,
+        hasErrors: false,
+        source: 'zip-url',
+        originalSource: 'https://code.kimi.com/kimi-code/plugins/official/demo.zip',
+      })),
+    });
+    const { driver } = await makeDriver(session);
+
+    // Official sources skip the trust prompt, so the install runs immediately.
+    driver.handleUserInput(
+      '/plugins install https://code.kimi.com/kimi-code/plugins/official/demo.zip',
+    );
+
+    await vi.waitFor(() => {
+      const transcript = stripSgr(renderTranscript(driver));
+      expect(transcript).toContain('Plugin changes apply immediately.');
+      expect(transcript).not.toContain('Run /new or /reload to apply plugin changes.');
     });
   });
 
@@ -5378,6 +5411,7 @@ command = "vim"
   });
 
   it('loads a local plugin marketplace file and installs from it', async () => {
+    vi.stubEnv('KIMI_CODE_LEGACY_FLAG', '1');
     const marketplaceDir = await makeTempHome();
     const marketplacePath = join(marketplaceDir, 'marketplace.json');
     await writeFile(

--- a/docs/en/customization/mcp.md
+++ b/docs/en/customization/mcp.md
@@ -21,7 +21,7 @@ Entries with the same name: the project-level entry takes precedence and overrid
 
 Run `/mcp-config` in the TUI to interactively add, edit, or delete servers without manually editing the JSON file. Run `/mcp` to view the connection status of all current servers.
 
-On the v2 engine, deleting a server from the configuration does not interrupt open sessions: the server stays listed in `/mcp` as `removed`, its tools remain visible there, and calls to them fail with a removal notice, while new sessions do not register the tools at all.
+Deleting a server from the configuration does not interrupt open sessions: the server stays listed in `/mcp` as `removed`, its tools remain visible there, and calls to them fail with a removal notice, while new sessions do not register the tools at all.
 
 Structure of `mcp.json`:
 
@@ -63,7 +63,7 @@ You do not have to set the connection timeout or the single tool-call timeout pe
 
 HTTP and SSE servers support providing static credentials via `headers` or `bearerTokenEnvVar`. When OAuth is needed, run `/mcp-config login <server-name>` to complete browser-based authorization.
 
-Plugins can also declare MCP servers in their manifest. Servers declared by a plugin are enabled by default and can be disabled or re-enabled in `/plugins` — on the v2 engine the change applies immediately, on the legacy engine after `/reload` or in a new session. See [Plugins](./plugins.md#mcp-servers-in-plugins) for details.
+Plugins can also declare MCP servers in their manifest. Servers declared by a plugin are enabled by default and can be disabled or re-enabled in `/plugins`, and the change applies immediately. See [Plugins](./plugins.md#mcp-servers-in-plugins) for details.
 
 ::: warning Note
 stdio entries in a project-level `.kimi-code/mcp.json` execute local commands when a session starts. Only enable these in repositories you trust.

--- a/docs/en/customization/mcp.md
+++ b/docs/en/customization/mcp.md
@@ -21,6 +21,8 @@ Entries with the same name: the project-level entry takes precedence and overrid
 
 Run `/mcp-config` in the TUI to interactively add, edit, or delete servers without manually editing the JSON file. Run `/mcp` to view the connection status of all current servers.
 
+On the v2 engine, deleting a server from the configuration does not interrupt open sessions: the server stays listed in `/mcp` as `removed`, its tools remain visible there, and calls to them fail with a removal notice, while new sessions do not register the tools at all.
+
 Structure of `mcp.json`:
 
 ```json
@@ -61,7 +63,7 @@ You do not have to set the connection timeout or the single tool-call timeout pe
 
 HTTP and SSE servers support providing static credentials via `headers` or `bearerTokenEnvVar`. When OAuth is needed, run `/mcp-config login <server-name>` to complete browser-based authorization.
 
-Plugins can also declare MCP servers in their manifest. Servers declared by a plugin are enabled by default and can be disabled or re-enabled in `/plugins`, then a new session must be started. See [Plugins](./plugins.md) for details.
+Plugins can also declare MCP servers in their manifest. Servers declared by a plugin are enabled by default and can be disabled or re-enabled in `/plugins` — on the v2 engine the change applies immediately, on the legacy engine after `/reload` or in a new session. See [Plugins](./plugins.md#mcp-servers-in-plugins) for details.
 
 ::: warning Note
 stdio entries in a project-level `.kimi-code/mcp.json` execute local commands when a session starts. Only enable these in repositories you trust.

--- a/docs/en/customization/plugins.md
+++ b/docs/en/customization/plugins.md
@@ -48,7 +48,7 @@ Network requests only go through `github.com` redirects and `codeload.github.com
 
 ### Notes
 
-- Plugin changes apply after `/reload` or in new sessions. After installing, enabling/disabling, or removing a plugin, run `/reload` or `/new`; the current session will not update.
+- On the v2 engine (the default), plugin changes apply immediately: installing, enabling, disabling, or removing a plugin refreshes its Skills, agents, MCP servers, and hooks in place. The running session keeps the system prompt it started with — new plugin instructions reach only new sessions and newly created agents — and MCP tools already loaded in an open session stay visible but fail with a removal notice once their plugin is uninstalled. On the legacy engine, run `/reload` or `/new` to apply plugin changes.
 - Local installations are copied to `$KIMI_CODE_HOME/plugins/managed/<id>/`, and the CLI always runs from this managed copy. Editing the original source directory after installation has no effect; you must reinstall.
 - Removing a plugin only deletes the installation record; the managed copy and original source files remain on disk.
 - Plugins are currently installed per-user and apply to all projects; project-level installation scope is not yet supported.
@@ -80,7 +80,7 @@ You must first complete OAuth login with a Kimi Code account via `/login`. The p
 
 1. Run `/plugins` and select **Official**
 2. Find **Kimi Datasource** and press `Enter` to install
-3. After installation completes, run `/reload` or `/new` to activate the plugin
+3. On the v2 engine the plugin activates as soon as installation completes; on the legacy engine, run `/reload` or `/new` to activate it
 
 Using Kimi Datasource consumes your Kimi Code plan quota; the install result reminds you of this. The current latest version is v3.3.0. The plugin does not update automatically — to upgrade to a newer version, repeat the installation steps above.
 
@@ -188,7 +188,7 @@ System-prompt contributions take effect on both agent engines. The interactive T
 
 Each field — the inline `systemPrompt` and the `systemPromptPath` file — is limited to 32 KB (UTF-8 bytes): oversized content is ignored and reported in the plugin diagnostics. Across all enabled plugins, one prompt build injects at most 64 KB of instructions; contributions beyond the budget are skipped with a warning, including a single plugin whose inline text and file together exceed that budget.
 
-New sessions and newly created agents read the contributions from the plugins currently enabled. An in-flight request keeps its existing system prompt. `/plugins reload` refreshes the plugin skill list and requests prompt rebuilds for live agents; use it when you need the change to converge deliberately before the next turn. On the v2 engine, installing, enabling, disabling, or removing a plugin updates the catalog immediately and a later prompt rebuild — for example after compaction or a tool-policy change — may pick up the new sections. The legacy engine keeps each live session's plugin snapshot until `/plugins reload` or a new session. A resumed session starts from its persisted prompt, and later rebuilds follow the engine-specific behavior above. Toggling a plugin's MCP server does not change system-prompt sections.
+New sessions and newly created agents read the contributions from the plugins currently enabled. An in-flight request keeps its existing system prompt. On the v2 engine, installing, enabling, disabling, or removing a plugin updates the contributions immediately: each agent snapshots the plugin instructions and skill listing when its system prompt is first built, so a running session never picks up plugin changes — even later rebuilds, for example after compaction or a tool-policy change, reuse the snapshot — and `/plugins reload` refreshes the plugin skill list for new agents without rewriting live prompts. The legacy engine keeps each live session's plugin snapshot until `/plugins reload` or a new session; there, `/plugins reload` also requests prompt rebuilds for live agents, so use it when you need a change to converge deliberately before the next turn. A resumed session starts from its persisted prompt, and later rebuilds follow the engine-specific behavior above. Toggling a plugin's MCP server does not change system-prompt sections.
 
 The built-in agent prompt includes instructions from enabled plugins automatically. A custom `SYSTEM.md` or agent file owns its template, so include `${plugin_sections}` where plugin-contributed instructions should appear. If the custom template includes `${base_prompt}` and that effective default already contains the plugin block, do not add `${plugin_sections}` again. See [Custom agents and SYSTEM.md](./agents.md#overriding-the-main-agent-s-system-prompt-with-system-md) for the complete variable table.
 
@@ -283,7 +283,7 @@ my-plugin/
     reviewer.md
 ```
 
-Plugin agents rank below every other file source: on a name collision, user-level, extra, project-level, and `--agent-file` agents all win over the plugin-provided one, and replacing a built-in agent still requires an explicit `override: true` in the frontmatter. After installing, enabling, disabling, or removing a plugin, the agent list refreshes in a new session (or on `/reload`); on the v2 engine the live session also refreshes after `/plugins reload`.
+Plugin agents rank below every other file source: on a name collision, user-level, extra, project-level, and `--agent-file` agents all win over the plugin-provided one, and replacing a built-in agent still requires an explicit `override: true` in the frontmatter. After installing, enabling, disabling, or removing a plugin, the agent list refreshes immediately on the v2 engine; on the legacy engine it refreshes in a new session or on `/reload`.
 
 ## MCP Servers in Plugins
 
@@ -316,15 +316,15 @@ HTTP server (remote service):
 
 For stdio servers, `command` can be a command on `PATH` or a path starting with `./` within the plugin root directory. `cwd` likewise must start with `./` and be within the plugin root directory; otherwise the server is ignored.
 
-Plugin MCP servers start after `/reload` or in new sessions. To enable or disable a server:
+On the v2 engine, plugin MCP servers start or stop as soon as the plugin change is applied; on the legacy engine they start after `/reload` or in new sessions. To enable or disable a server:
 
 ```sh
 /plugins mcp disable kimi-finance finance
-/reload
 
 /plugins mcp enable kimi-finance finance
-/reload
 ```
+
+On the legacy engine, run `/reload` after each command for the change to take effect. When a plugin's server is removed or disabled, tools it had loaded into an open session stay visible there, but calls to them fail with a removal notice, and new sessions do not register them at all.
 
 ## Hooks in Plugins
 
@@ -357,5 +357,5 @@ Plugins have a limited loading scope. The following operations do not occur duri
 
 - Command-type plugin tools and legacy tool runtimes are not executed
 - All paths must remain within the plugin root directory after symbolic link resolution
-- MCP servers of enabled plugins start after `/reload` or in new sessions and can be disabled at any time from `/plugins`
+- MCP servers of enabled plugins start as soon as the plugin is applied — immediately on the v2 engine, after `/reload` or in new sessions on the legacy engine — and can be disabled at any time from `/plugins`
 - Broken manifests or unsafe paths appear in `/plugins info <id>` diagnostics and do not affect other sessions

--- a/docs/en/customization/plugins.md
+++ b/docs/en/customization/plugins.md
@@ -48,7 +48,7 @@ Network requests only go through `github.com` redirects and `codeload.github.com
 
 ### Notes
 
-- On the v2 engine (the default), plugin changes apply immediately: installing, enabling, disabling, or removing a plugin refreshes its Skills, agents, MCP servers, and hooks in place. The running session keeps the system prompt it started with — new plugin instructions reach only new sessions and newly created agents — and MCP tools already loaded in an open session stay visible but fail with a removal notice once their plugin is uninstalled. On the legacy engine, run `/reload` or `/new` to apply plugin changes.
+- Plugin changes apply immediately: installing, enabling, disabling, or removing a plugin refreshes its Skills, agents, MCP servers, and hooks in place. The running session keeps the system prompt it started with — new plugin instructions reach only new sessions and newly created agents — and MCP tools already loaded in an open session stay visible but fail with a removal notice once their plugin is uninstalled.
 - Local installations are copied to `$KIMI_CODE_HOME/plugins/managed/<id>/`, and the CLI always runs from this managed copy. Editing the original source directory after installation has no effect; you must reinstall.
 - Removing a plugin only deletes the installation record; the managed copy and original source files remain on disk.
 - Plugins are currently installed per-user and apply to all projects; project-level installation scope is not yet supported.
@@ -80,7 +80,7 @@ You must first complete OAuth login with a Kimi Code account via `/login`. The p
 
 1. Run `/plugins` and select **Official**
 2. Find **Kimi Datasource** and press `Enter` to install
-3. On the v2 engine the plugin activates as soon as installation completes; on the legacy engine, run `/reload` or `/new` to activate it
+3. The plugin activates as soon as installation completes
 
 Using Kimi Datasource consumes your Kimi Code plan quota; the install result reminds you of this. The current latest version is v3.3.0. The plugin does not update automatically — to upgrade to a newer version, repeat the installation steps above.
 
@@ -188,7 +188,7 @@ System-prompt contributions take effect on both agent engines. The interactive T
 
 Each field — the inline `systemPrompt` and the `systemPromptPath` file — is limited to 32 KB (UTF-8 bytes): oversized content is ignored and reported in the plugin diagnostics. Across all enabled plugins, one prompt build injects at most 64 KB of instructions; contributions beyond the budget are skipped with a warning, including a single plugin whose inline text and file together exceed that budget.
 
-New sessions and newly created agents read the contributions from the plugins currently enabled. An in-flight request keeps its existing system prompt. On the v2 engine, installing, enabling, disabling, or removing a plugin updates the contributions immediately: each agent snapshots the plugin instructions and skill listing when its system prompt is first built, so a running session never picks up plugin changes — even later rebuilds, for example after compaction or a tool-policy change, reuse the snapshot — and `/plugins reload` refreshes the plugin skill list for new agents without rewriting live prompts. The legacy engine keeps each live session's plugin snapshot until `/plugins reload` or a new session; there, `/plugins reload` also requests prompt rebuilds for live agents, so use it when you need a change to converge deliberately before the next turn. A resumed session starts from its persisted prompt, and later rebuilds follow the engine-specific behavior above. Toggling a plugin's MCP server does not change system-prompt sections.
+New sessions and newly created agents read the contributions from the plugins currently enabled. An in-flight request keeps its existing system prompt. Installing, enabling, disabling, or removing a plugin updates the contributions immediately: each agent snapshots the plugin instructions and skill listing when its system prompt is first built, so a running session never picks up plugin changes — even later rebuilds, for example after compaction or a tool-policy change, reuse the snapshot — and `/plugins reload` refreshes the plugin skill list for new agents without rewriting live prompts. A resumed session starts from its persisted prompt, and later rebuilds follow the same snapshot rules. Toggling a plugin's MCP server does not change system-prompt sections.
 
 The built-in agent prompt includes instructions from enabled plugins automatically. A custom `SYSTEM.md` or agent file owns its template, so include `${plugin_sections}` where plugin-contributed instructions should appear. If the custom template includes `${base_prompt}` and that effective default already contains the plugin block, do not add `${plugin_sections}` again. See [Custom agents and SYSTEM.md](./agents.md#overriding-the-main-agent-s-system-prompt-with-system-md) for the complete variable table.
 
@@ -283,7 +283,7 @@ my-plugin/
     reviewer.md
 ```
 
-Plugin agents rank below every other file source: on a name collision, user-level, extra, project-level, and `--agent-file` agents all win over the plugin-provided one, and replacing a built-in agent still requires an explicit `override: true` in the frontmatter. After installing, enabling, disabling, or removing a plugin, the agent list refreshes immediately on the v2 engine; on the legacy engine it refreshes in a new session or on `/reload`.
+Plugin agents rank below every other file source: on a name collision, user-level, extra, project-level, and `--agent-file` agents all win over the plugin-provided one, and replacing a built-in agent still requires an explicit `override: true` in the frontmatter. After installing, enabling, disabling, or removing a plugin, the agent list refreshes immediately.
 
 ## MCP Servers in Plugins
 
@@ -316,7 +316,7 @@ HTTP server (remote service):
 
 For stdio servers, `command` can be a command on `PATH` or a path starting with `./` within the plugin root directory. `cwd` likewise must start with `./` and be within the plugin root directory; otherwise the server is ignored.
 
-On the v2 engine, plugin MCP servers start or stop as soon as the plugin change is applied; on the legacy engine they start after `/reload` or in new sessions. To enable or disable a server:
+Plugin MCP servers start or stop as soon as the plugin change is applied. To enable or disable a server:
 
 ```sh
 /plugins mcp disable kimi-finance finance
@@ -324,7 +324,7 @@ On the v2 engine, plugin MCP servers start or stop as soon as the plugin change 
 /plugins mcp enable kimi-finance finance
 ```
 
-On the legacy engine, run `/reload` after each command for the change to take effect. When a plugin's server is removed or disabled, tools it had loaded into an open session stay visible there, but calls to them fail with a removal notice, and new sessions do not register them at all.
+When a plugin's server is removed or disabled, tools it had loaded into an open session stay visible there, but calls to them fail with a removal notice, and new sessions do not register them at all.
 
 ## Hooks in Plugins
 
@@ -357,5 +357,5 @@ Plugins have a limited loading scope. The following operations do not occur duri
 
 - Command-type plugin tools and legacy tool runtimes are not executed
 - All paths must remain within the plugin root directory after symbolic link resolution
-- MCP servers of enabled plugins start as soon as the plugin is applied — immediately on the v2 engine, after `/reload` or in new sessions on the legacy engine — and can be disabled at any time from `/plugins`
+- MCP servers of enabled plugins start as soon as the plugin is applied and can be disabled at any time from `/plugins`
 - Broken manifests or unsafe paths appear in `/plugins info <id>` diagnostics and do not affect other sessions

--- a/docs/zh/customization/mcp.md
+++ b/docs/zh/customization/mcp.md
@@ -21,6 +21,8 @@ MCP server 配置写在 `mcp.json` 中，分两层：
 
 在 TUI 中运行 `/mcp-config` 可以交互式地新增、编辑或删除 server，无需手动编辑 JSON 文件。运行 `/mcp` 可查看当前所有 server 的连接状态。
 
+v2 引擎下，从配置中删除某个 server 不会打断进行中的会话：该 server 在 `/mcp` 中仍显示为 `removed`，其工具在这些会话中保持可见，但调用会失败并返回移除提示；新会话则完全不会注册这些工具。
+
 `mcp.json` 的结构：
 
 ```json
@@ -61,7 +63,7 @@ MCP server 配置写在 `mcp.json` 中，分两层：
 
 HTTP 与 SSE server 支持通过 `headers` 或 `bearerTokenEnvVar` 提供静态凭证。需要 OAuth 时，运行 `/mcp-config login <server-name>` 完成浏览器授权。
 
-Plugins 也可以在 manifest 中声明 MCP servers。Plugin 声明的 servers 默认启用，可以在 `/plugins` 中禁用或重新启用，然后开启新会话。详见 [Plugins](./plugins.md)。
+Plugins 也可以在 manifest 中声明 MCP servers。Plugin 声明的 servers 默认启用，可以在 `/plugins` 中禁用或重新启用——v2 引擎下变更立即生效，旧版引擎下在 `/reload` 后或新会话中生效。详见 [Plugins](./plugins.md#plugin-中的-mcp-servers)。
 
 ::: warning 注意
 项目级 `.kimi-code/mcp.json` 中的 stdio 条目会在会话启动时执行本地命令，只在你信任的仓库里启用。

--- a/docs/zh/customization/mcp.md
+++ b/docs/zh/customization/mcp.md
@@ -21,7 +21,7 @@ MCP server 配置写在 `mcp.json` 中，分两层：
 
 在 TUI 中运行 `/mcp-config` 可以交互式地新增、编辑或删除 server，无需手动编辑 JSON 文件。运行 `/mcp` 可查看当前所有 server 的连接状态。
 
-v2 引擎下，从配置中删除某个 server 不会打断进行中的会话：该 server 在 `/mcp` 中仍显示为 `removed`，其工具在这些会话中保持可见，但调用会失败并返回移除提示；新会话则完全不会注册这些工具。
+从配置中删除某个 server 不会打断进行中的会话：该 server 在 `/mcp` 中仍显示为 `removed`，其工具在这些会话中保持可见，但调用会失败并返回移除提示；新会话则完全不会注册这些工具。
 
 `mcp.json` 的结构：
 
@@ -63,7 +63,7 @@ v2 引擎下，从配置中删除某个 server 不会打断进行中的会话：
 
 HTTP 与 SSE server 支持通过 `headers` 或 `bearerTokenEnvVar` 提供静态凭证。需要 OAuth 时，运行 `/mcp-config login <server-name>` 完成浏览器授权。
 
-Plugins 也可以在 manifest 中声明 MCP servers。Plugin 声明的 servers 默认启用，可以在 `/plugins` 中禁用或重新启用——v2 引擎下变更立即生效，旧版引擎下在 `/reload` 后或新会话中生效。详见 [Plugins](./plugins.md#plugin-中的-mcp-servers)。
+Plugins 也可以在 manifest 中声明 MCP servers。Plugin 声明的 servers 默认启用，可以在 `/plugins` 中禁用或重新启用，变更立即生效。详见 [Plugins](./plugins.md#plugin-中的-mcp-servers)。
 
 ::: warning 注意
 项目级 `.kimi-code/mcp.json` 中的 stdio 条目会在会话启动时执行本地命令，只在你信任的仓库里启用。

--- a/docs/zh/customization/plugins.md
+++ b/docs/zh/customization/plugins.md
@@ -48,7 +48,7 @@ Plugins 把可复用的 Kimi Code CLI 能力打包成可安装单元——可以
 
 ### 注意事项
 
-- 在 v2 引擎（默认）下，plugin 变更立即生效：安装、启用、禁用或移除 plugin 会就地刷新其 Skill、Agent、MCP server 和 hook。正在运行的会话保持启动时的系统提示词——新的 plugin 指令只会进入新会话和新建 Agent——已加载到进行中的会话中的 MCP 工具仍然可见，但其 plugin 被卸载后调用会失败并返回移除提示。旧版引擎下，运行 `/reload` 或 `/new` 使 plugin 变更生效。
+- Plugin 变更立即生效：安装、启用、禁用或移除 plugin 会就地刷新其 Skill、Agent、MCP server 和 hook。正在运行的会话保持启动时的系统提示词——新的 plugin 指令只会进入新会话和新建 Agent——已加载到进行中的会话中的 MCP 工具仍然可见，但其 plugin 被卸载后调用会失败并返回移除提示。
 - 本地安装会被拷贝到 `$KIMI_CODE_HOME/plugins/managed/<id>/`，CLI 始终从这份托管副本运行。安装后编辑原始源目录不会生效，需重新安装。
 - 移除 plugin 只会删除安装记录，托管副本和原始源文件仍保留在磁盘上。
 - Plugin 目前按用户安装，对所有项目生效，暂不支持项目级安装范围。
@@ -80,7 +80,7 @@ Kimi Datasource 是 Kimi Code 官方数据插件，让你通过自然语言直�
 
 1. 运行 `/plugins`，选择 **Official**
 2. 找到 **Kimi Datasource**，按 `Enter` 安装
-3. v2 引擎下安装完成后 plugin 立即激活；旧版引擎下运行 `/reload` 或 `/new` 激活
+3. 安装完成后 plugin 立即激活
 
 使用 Kimi Datasource 会消耗你的 Kimi Code 套餐额度，安装结果中会提示这一点。当前最新版本为 v3.3.0。插件安装后不会自动更新，如需升级到新版本，重新执行上述安装步骤即可。
 
@@ -188,7 +188,7 @@ Plugin 是一个带 manifest 的目录或 zip 文件。Manifest 可以放在以�
 
 `systemPrompt` 字段与 `systemPromptPath` 文件各限制为 32 KB（UTF-8 字节）：超限内容会被忽略，并显示在 plugin 的 diagnostics 中。一次提示词构建最多注入所有已启用 plugin 合计 64 KB 的指令；超出预算的贡献会被跳过并给出警告——单个 plugin 的内联文本与文件合计超过该预算时同样整体跳过。
 
-新会话和新建 Agent 会读取当前已启用 plugin 的指令。正在进行的请求会继续使用已有的系统提示词。在 v2 引擎中，安装、启用、禁用或移除 plugin 会立即更新各项贡献：每个 Agent 在首次构建系统提示词时快照 plugin 指令和 Skill 列表，因此运行中的会话永远不会吸收 plugin 变更——之后的提示词重建（例如压缩上下文或修改工具策略后）也会复用这份快照——`/plugins reload` 会为新建 Agent 刷新 plugin Skill 列表，但不会改写活跃会话的提示词。旧版引擎会让每个活跃会话保留自己的 plugin 快照，直到 `/plugins reload` 或创建新会话；在旧版引擎下，`/plugins reload` 还会请求重建活跃 Agent 的提示词，如果需要让变更在下一轮前明确收敛，请使用这个命令。从磁盘恢复的会话会先使用持久化的提示词，后续重建再遵循对应引擎的行为。切换 plugin 的 MCP server 不会改变系统提示词指令。
+新会话和新建 Agent 会读取当前已启用 plugin 的指令。正在进行的请求会继续使用已有的系统提示词。安装、启用、禁用或移除 plugin 会立即更新各项贡献：每个 Agent 在首次构建系统提示词时快照 plugin 指令和 Skill 列表，因此运行中的会话永远不会吸收 plugin 变更——之后的提示词重建（例如压缩上下文或修改工具策略后）也会复用这份快照——`/plugins reload` 会为新建 Agent 刷新 plugin Skill 列表，但不会改写活跃会话的提示词。从磁盘恢复的会话会先使用持久化的提示词，后续重建遵循相同的快照规则。切换 plugin 的 MCP server 不会改变系统提示词指令。
 
 内置 Agent 提示词会自动包含已启用 plugin 的指令。自定义 `SYSTEM.md` 或 Agent 文件完全拥有自己的模板，因此应在希望出现 plugin 指令的位置加入 `${plugin_sections}`。如果自定义模板包含 `${base_prompt}`，且该有效默认提示词已经包含 plugin 块，就不要再重复加入 `${plugin_sections}`。完整变量表见 [自定义 Agent 与 SYSTEM.md](./agents.md#用-system-md-覆盖主-agent-的系统提示词)。
 
@@ -283,7 +283,7 @@ my-plugin/
     reviewer.md
 ```
 
-Plugin Agent 的优先级低于其他文件来源：同名时用户级、额外目录、项目级和 `--agent-file` 的 Agent 都会覆盖 plugin 提供的版本；替换内置 Agent 同样需要在 frontmatter 里显式写 `override: true`。安装、启用、禁用或移除 plugin 后，Agent 列表在 v2 引擎下立即刷新；旧版引擎下在新会话（或 `/reload`）时刷新。
+Plugin Agent 的优先级低于其他文件来源：同名时用户级、额外目录、项目级和 `--agent-file` 的 Agent 都会覆盖 plugin 提供的版本；替换内置 Agent 同样需要在 frontmatter 里显式写 `override: true`。安装、启用、禁用或移除 plugin 后，Agent 列表立即刷新。
 
 ## Plugin 中的 MCP servers
 
@@ -316,7 +316,7 @@ HTTP server（远程服务）：
 
 对于 stdio servers，`command` 可以是 `PATH` 上的命令，也可以是 plugin 根目录内以 `./` 开头的路径。`cwd` 同理，必须以 `./` 开头并位于 plugin 根目录内，否则该 server 会被忽略。
 
-v2 引擎下，plugin MCP servers 随 plugin 变更即时启动或停止；旧版引擎下会在 `/reload` 后或新会话中启动。启用或禁用某个 server：
+Plugin MCP servers 随 plugin 变更即时启动或停止。启用或禁用某个 server：
 
 ```sh
 /plugins mcp disable kimi-finance finance
@@ -324,7 +324,7 @@ v2 引擎下，plugin MCP servers 随 plugin 变更即时启动或停止；旧�
 /plugins mcp enable kimi-finance finance
 ```
 
-旧版引擎下，每条命令后需要再运行 `/reload` 才能生效。plugin 的 server 被移除或禁用后，它已加载到进行中的会话中的工具仍然可见，但调用会失败并返回移除提示；新会话完全不会注册这些工具。
+plugin 的 server 被移除或禁用后，它已加载到进行中的会话中的工具仍然可见，但调用会失败并返回移除提示；新会话完全不会注册这些工具。
 
 ## 插件中的 Hooks
 
@@ -357,5 +357,5 @@ Plugin 的加载范围有限，以下操作不会在安装或会话启动时发�
 
 - 不会执行命令型 plugin tools 或旧式工具运行时
 - 所有路径在解析符号链接后仍必须位于 plugin 根目录内
-- 已启用 plugin 的 MCP servers 随 plugin 生效即启动——v2 引擎下立即启动，旧版引擎下在 `/reload` 后或新会话中启动——且可随时从 `/plugins` 禁用
+- 已启用 plugin 的 MCP servers 随 plugin 生效即启动，且可随时从 `/plugins` 禁用
 - 损坏的 manifest 或不安全路径会显示在 `/plugins info <id>` 的 diagnostics 中，不影响其他会话

--- a/docs/zh/customization/plugins.md
+++ b/docs/zh/customization/plugins.md
@@ -48,7 +48,7 @@ Plugins 把可复用的 Kimi Code CLI 能力打包成可安装单元——可以
 
 ### 注意事项
 
-- Plugin 变更需要通过 `/reload` 或新会话生效。安装、启用/禁用、移除后，运行 `/reload` 或 `/new`；当前会话不会更新。
+- 在 v2 引擎（默认）下，plugin 变更立即生效：安装、启用、禁用或移除 plugin 会就地刷新其 Skill、Agent、MCP server 和 hook。正在运行的会话保持启动时的系统提示词——新的 plugin 指令只会进入新会话和新建 Agent——已加载到进行中的会话中的 MCP 工具仍然可见，但其 plugin 被卸载后调用会失败并返回移除提示。旧版引擎下，运行 `/reload` 或 `/new` 使 plugin 变更生效。
 - 本地安装会被拷贝到 `$KIMI_CODE_HOME/plugins/managed/<id>/`，CLI 始终从这份托管副本运行。安装后编辑原始源目录不会生效，需重新安装。
 - 移除 plugin 只会删除安装记录，托管副本和原始源文件仍保留在磁盘上。
 - Plugin 目前按用户安装，对所有项目生效，暂不支持项目级安装范围。
@@ -80,7 +80,7 @@ Kimi Datasource 是 Kimi Code 官方数据插件，让你通过自然语言直�
 
 1. 运行 `/plugins`，选择 **Official**
 2. 找到 **Kimi Datasource**，按 `Enter` 安装
-3. 安装完成后运行 `/reload` 或 `/new` 激活 plugin
+3. v2 引擎下安装完成后 plugin 立即激活；旧版引擎下运行 `/reload` 或 `/new` 激活
 
 使用 Kimi Datasource 会消耗你的 Kimi Code 套餐额度，安装结果中会提示这一点。当前最新版本为 v3.3.0。插件安装后不会自动更新，如需升级到新版本，重新执行上述安装步骤即可。
 
@@ -188,7 +188,7 @@ Plugin 是一个带 manifest 的目录或 zip 文件。Manifest 可以放在以�
 
 `systemPrompt` 字段与 `systemPromptPath` 文件各限制为 32 KB（UTF-8 字节）：超限内容会被忽略，并显示在 plugin 的 diagnostics 中。一次提示词构建最多注入所有已启用 plugin 合计 64 KB 的指令；超出预算的贡献会被跳过并给出警告——单个 plugin 的内联文本与文件合计超过该预算时同样整体跳过。
 
-新会话和新建 Agent 会读取当前已启用 plugin 的指令。正在进行的请求会继续使用已有的系统提示词。`/plugins reload` 会刷新 plugin Skill 列表，并请求重建活跃 Agent 的提示词；如果需要让变更在下一轮前明确收敛，请使用这个命令。在 v2 引擎中，安装、启用、禁用或移除 plugin 会立即更新 catalog，后续的提示词重建（例如压缩上下文或修改工具策略后）可能会读取新的指令。legacy 引擎会让每个活跃 session 保留自己的 plugin 快照，直到 `/plugins reload` 或创建新 session。从磁盘恢复的 session 会先使用持久化的提示词，后续重建再遵循对应引擎的行为。切换 plugin 的 MCP server 不会改变系统提示词指令。
+新会话和新建 Agent 会读取当前已启用 plugin 的指令。正在进行的请求会继续使用已有的系统提示词。在 v2 引擎中，安装、启用、禁用或移除 plugin 会立即更新各项贡献：每个 Agent 在首次构建系统提示词时快照 plugin 指令和 Skill 列表，因此运行中的会话永远不会吸收 plugin 变更——之后的提示词重建（例如压缩上下文或修改工具策略后）也会复用这份快照——`/plugins reload` 会为新建 Agent 刷新 plugin Skill 列表，但不会改写活跃会话的提示词。旧版引擎会让每个活跃会话保留自己的 plugin 快照，直到 `/plugins reload` 或创建新会话；在旧版引擎下，`/plugins reload` 还会请求重建活跃 Agent 的提示词，如果需要让变更在下一轮前明确收敛，请使用这个命令。从磁盘恢复的会话会先使用持久化的提示词，后续重建再遵循对应引擎的行为。切换 plugin 的 MCP server 不会改变系统提示词指令。
 
 内置 Agent 提示词会自动包含已启用 plugin 的指令。自定义 `SYSTEM.md` 或 Agent 文件完全拥有自己的模板，因此应在希望出现 plugin 指令的位置加入 `${plugin_sections}`。如果自定义模板包含 `${base_prompt}`，且该有效默认提示词已经包含 plugin 块，就不要再重复加入 `${plugin_sections}`。完整变量表见 [自定义 Agent 与 SYSTEM.md](./agents.md#用-system-md-覆盖主-agent-的系统提示词)。
 
@@ -283,7 +283,7 @@ my-plugin/
     reviewer.md
 ```
 
-Plugin Agent 的优先级低于其他文件来源：同名时用户级、额外目录、项目级和 `--agent-file` 的 Agent 都会覆盖 plugin 提供的版本；替换内置 Agent 同样需要在 frontmatter 里显式写 `override: true`。安装、启用、禁用或移除 plugin 后，Agent 列表在新会话（或 `/reload`）时刷新；v2 引擎的当前会话还会在 `/plugins reload` 后刷新。
+Plugin Agent 的优先级低于其他文件来源：同名时用户级、额外目录、项目级和 `--agent-file` 的 Agent 都会覆盖 plugin 提供的版本；替换内置 Agent 同样需要在 frontmatter 里显式写 `override: true`。安装、启用、禁用或移除 plugin 后，Agent 列表在 v2 引擎下立即刷新；旧版引擎下在新会话（或 `/reload`）时刷新。
 
 ## Plugin 中的 MCP servers
 
@@ -316,15 +316,15 @@ HTTP server（远程服务）：
 
 对于 stdio servers，`command` 可以是 `PATH` 上的命令，也可以是 plugin 根目录内以 `./` 开头的路径。`cwd` 同理，必须以 `./` 开头并位于 plugin 根目录内，否则该 server 会被忽略。
 
-Plugin MCP servers 会在 `/reload` 后或新会话中启动。启用或禁用某个 server：
+v2 引擎下，plugin MCP servers 随 plugin 变更即时启动或停止；旧版引擎下会在 `/reload` 后或新会话中启动。启用或禁用某个 server：
 
 ```sh
 /plugins mcp disable kimi-finance finance
-/reload
 
 /plugins mcp enable kimi-finance finance
-/reload
 ```
+
+旧版引擎下，每条命令后需要再运行 `/reload` 才能生效。plugin 的 server 被移除或禁用后，它已加载到进行中的会话中的工具仍然可见，但调用会失败并返回移除提示；新会话完全不会注册这些工具。
 
 ## 插件中的 Hooks
 
@@ -357,5 +357,5 @@ Plugin 的加载范围有限，以下操作不会在安装或会话启动时发�
 
 - 不会执行命令型 plugin tools 或旧式工具运行时
 - 所有路径在解析符号链接后仍必须位于 plugin 根目录内
-- 已启用 plugin 的 MCP servers 会在 `/reload` 后或新会话中启动，且可随时从 `/plugins` 禁用
+- 已启用 plugin 的 MCP servers 随 plugin 生效即启动——v2 引擎下立即启动，旧版引擎下在 `/reload` 后或新会话中启动——且可随时从 `/plugins` 禁用
 - 损坏的 manifest 或不安全路径会显示在 `/plugins info <id>` 的 diagnostics 中，不影响其他会话

--- a/packages/agent-core-v2/src/agent/mcp/mcpService.ts
+++ b/packages/agent-core-v2/src/agent/mcp/mcpService.ts
@@ -5,7 +5,9 @@
  * into the agent's tool registry (the manager arrives through the seeded
  * `ISessionMcpHandle` — one manager per workspace handler, shared by every
  * session and agent): registers qualified tools for connected servers,
- * keeps them registered across reconnects, swaps in the OAuth tool for
+ * keeps them registered across reconnects, keeps them registered (with
+ * calls short-circuited to a removal notice) when the server is tombstoned
+ * as `removed`, swaps in the OAuth tool for
  * `needs-auth` servers, journals tool discoveries on the wire (queued until
  * restore finishes), and publishes `mcp.server.status` / `tool.list.updated`
  * events. Sessions and agents construct without awaiting the manager's
@@ -58,7 +60,7 @@ export interface ErrorEvent extends KimiErrorPayload {
 export interface McpServerStatusPayload {
   readonly name: string;
   readonly transport: 'stdio' | 'http' | 'sse';
-  readonly status: 'pending' | 'connected' | 'failed' | 'disabled' | 'needs-auth';
+  readonly status: 'pending' | 'connected' | 'failed' | 'disabled' | 'needs-auth' | 'removed';
   readonly toolCount: number;
   readonly error?: string;
 }
@@ -235,7 +237,7 @@ export class AgentMcpService extends Service implements IAgentMcpService {
       this.registerNeedsAuthMcpServer(entry);
       return;
     }
-    if (entry.status === 'failed' || entry.status === 'pending') {
+    if (entry.status === 'failed' || entry.status === 'pending' || entry.status === 'removed') {
       return;
     }
     if (entry.status === 'disabled') {
@@ -330,6 +332,8 @@ export class AgentMcpService extends Service implements IAgentMcpService {
             originalsDir: sessionMediaOriginalsDir(this.sessionContext.sessionDir),
             telemetry: this.telemetry,
             reconnect: (signal) => this.reconnectForToolCall(serverName, client, signal),
+            isRemoved: () =>
+              this.mcpHandle.connectionManager.get(serverName)?.status === 'removed',
           }),
           { source: 'mcp' },
         ),

--- a/packages/agent-core-v2/src/agent/mcp/tools/mcp.ts
+++ b/packages/agent-core-v2/src/agent/mcp/tools/mcp.ts
@@ -21,6 +21,10 @@
  * processed the call but before the response arrived, the retry may
  * duplicate side effects. There is no protocol-level dedup across
  * reconnects, so this trade-off is accepted deliberately.
+ *
+ * When the server has been tombstoned as removed (`options.isRemoved`),
+ * the call short-circuits to an error result telling the model to stop
+ * calling the tool — no client call, no reconnect.
  */
 
 import type { Tool as KosongTool } from '#/kosong/contract/tool';
@@ -42,6 +46,7 @@ interface McpToolOptions {
   readonly originalsDir?: string;
   readonly telemetry?: ITelemetryService;
   readonly reconnect?: (signal?: AbortSignal) => Promise<MCPClient | undefined>;
+  readonly isRemoved?: () => boolean;
 }
 
 export function createMcpTool(
@@ -59,6 +64,14 @@ export function createMcpTool(
     resolveExecution: (args) => ({
       approvalRule: qualifiedName,
       execute: async (context) => {
+        if (options.isRemoved?.() === true) {
+          return {
+            output:
+              `MCP server for tool "${qualifiedName}" has been removed ` +
+              `(plugin uninstalled or config deleted). Do not call this tool again.`,
+            isError: true,
+          };
+        }
         let result;
         try {
           result = await callTool(client, args, context.signal);

--- a/packages/agent-core-v2/src/agent/profile/profileService.ts
+++ b/packages/agent-core-v2/src/agent/profile/profileService.ts
@@ -37,16 +37,20 @@
  * workspace handler's shared, watch-refreshed snapshot — the working
  * directory is always the session's frozen cwd, so the snapshot always
  * applies), and the provider's change event drives a `refreshSystemPrompt`. Prompt builds inject the enabled plugins'
- * system-prompt sections (budget-capped, see `PLUGIN_SECTIONS_MAX_BYTES`);
- * plugin changes reach the prompt when the skill catalog re-pulls its plugin
- * source on explicit plugin reload (the Workspace-scope catalog forwards the
- * plugin source's change through the session seed) — the same point where
- * plugin skills take effect. The builtin source is refreshed on the same
- * signal: it changes only when its config switch is toggled, so it costs what
- * a config edit costs, unlike the file-backed sources whose fs watches would
- * rebuild every agent's prompt on each edit. Subscribing to the catalog rather
- * than to the config section matters — the catalog fires after the
- * contribution is replaced, so the rebuilt prompt cannot read the old listing. `refreshSystemPrompt` never rejects: a
+ * system-prompt sections (budget-capped, see `PLUGIN_SECTIONS_MAX_BYTES`) and
+ * the model skill listing; both are snapshotted at the agent's first
+ * successful build and frozen for the agent's lifetime, so plugin install /
+ * enable / disable / remove / reload never rewrites a live agent's prompt —
+ * the same keep-live-sessions-stable philosophy as the MCP tombstone. New
+ * agents (new sessions, new subagents) snapshot the then-current state. The
+ * Workspace-scope catalog still re-pulls its plugin source on plugin reload
+ * (new agents and runtime skill lookups read it) and its change event still
+ * drives `refreshSystemPrompt`, but the rebuild reuses the frozen values, so
+ * the prompt only moves when non-plugin inputs change (AGENTS.md, the
+ * `[tools]` section, session tool policy, compaction). A side effect of the
+ * freeze: skills added mid-session to file-backed sources, and builtin-source
+ * config toggles, no longer ride an unrelated refresh into a live agent's
+ * prompt. `refreshSystemPrompt` never rejects: a
  * failed context build keeps the current prompt and surfaces a warning,
  * because the `[tools]` config watcher fires it voided (an unhandled
  * rejection would crash kap-server) and the Session tool-policy fan-out
@@ -61,8 +65,11 @@
  * The mutable plain-data state (`activeToolNamesOverlay` / `agentsMdWarning`
  * / the three emitted-warning dedupe sets) is registered into `agentState`
  * (`IAgentStateService`) and read/written through it; `optionsValue` (holds
- * the `cwd` / `emitStatusUpdated` callbacks) and `activeProfile`
- * (a `ResolvedAgentProfile` carrying the `systemPrompt` function) stay plain
+ * the `cwd` / `emitStatusUpdated` callbacks), `activeProfile`
+ * (a `ResolvedAgentProfile` carrying the `systemPrompt` function), and the
+ * frozen plugin-derived prompt inputs (`frozenSkillListing` /
+ * `frozenPluginSections` — one-shot snapshots, so there is nothing to
+ * restore) stay plain
  * fields because the container only holds pure data structures. After every
  * successful bind / apply / refresh (never before the new prompt commits,
  * so a failed build cannot poison the set), the injected AGENTS.md paths are
@@ -224,6 +231,14 @@ export class AgentProfileService extends Disposable implements IAgentProfileServ
   }
 
   private activeProfile: ResolvedAgentProfile | undefined;
+
+  // Plugin-derived prompt inputs, snapshotted on first successful build and
+  // frozen for the agent's lifetime (see the file header): a live agent's
+  // prompt must not move when plugins are installed / enabled / disabled /
+  // removed / reloaded. Never reset by applyProfile / useProfile /
+  // applyBindingSnapshot / refreshSystemPrompt.
+  private frozenSkillListing: string | undefined;
+  private frozenPluginSections: string | undefined;
 
   constructor(
     @IWireService private readonly wire: IWireService,
@@ -977,15 +992,21 @@ export class AgentProfileService extends Disposable implements IAgentProfileServ
   }
 
   private async resolveSkillListing(): Promise<string> {
+    if (this.frozenSkillListing !== undefined) return this.frozenSkillListing;
     try {
       await this.skillCatalog.ready;
-      return this.skillCatalog.catalog.getModelSkillListing();
+      const listing = this.skillCatalog.catalog.getModelSkillListing();
+      // Freeze only on success — a not-yet-ready catalog must not pin an
+      // empty listing for the agent's lifetime.
+      this.frozenSkillListing = listing;
+      return listing;
     } catch {
       return '';
     }
   }
 
   private async resolvePluginSections(): Promise<string> {
+    if (this.frozenPluginSections !== undefined) return this.frozenPluginSections;
     const sections = await this.plugins.enabledSystemPrompts();
     const parts: string[] = [];
     const skipped: string[] = [];
@@ -1013,7 +1034,11 @@ export class AgentProfileService extends Disposable implements IAgentProfileServ
         });
       }
     }
-    return parts.join('\n\n');
+    const resolved = parts.join('\n\n');
+    // Freeze only on success — a failed `enabledSystemPrompts()` read must
+    // not pin an empty section set for the agent's lifetime.
+    this.frozenPluginSections = resolved;
+    return resolved;
   }
 }
 

--- a/packages/agent-core-v2/src/agent/profile/profileService.ts
+++ b/packages/agent-core-v2/src/agent/profile/profileService.ts
@@ -1035,9 +1035,11 @@ export class AgentProfileService extends Disposable implements IAgentProfileServ
       }
     }
     const resolved = parts.join('\n\n');
-    // Freeze only on success — a failed `enabledSystemPrompts()` read must
-    // not pin an empty section set for the agent's lifetime.
-    this.frozenPluginSections = resolved;
+    // Freeze only on a real snapshot: while the initial plugin load has
+    // failed, `enabledSystemPrompts()` resolves to its consumption fallback
+    // instead of rejecting, and pinning that empty read would lock plugin
+    // sections out of the live agent even after a later successful reload.
+    if (this.plugins.hasLoadedSnapshot()) this.frozenPluginSections = resolved;
     return resolved;
   }
 }

--- a/packages/agent-core-v2/src/agent/rpc/core-api.ts
+++ b/packages/agent-core-v2/src/agent/rpc/core-api.ts
@@ -220,7 +220,7 @@ export interface RunCommandPayload {
 export interface McpServerInfo {
   readonly name: string;
   readonly transport: 'stdio' | 'http' | 'sse';
-  readonly status: 'pending' | 'connected' | 'failed' | 'disabled' | 'needs-auth';
+  readonly status: 'pending' | 'connected' | 'failed' | 'disabled' | 'needs-auth' | 'removed';
   readonly toolCount: number;
   readonly error?: string;
 }

--- a/packages/agent-core-v2/src/app/plugin/plugin.ts
+++ b/packages/agent-core-v2/src/app/plugin/plugin.ts
@@ -65,6 +65,10 @@ export interface IPluginService {
   enabledSystemPrompts(): Promise<readonly EnabledPluginSystemPrompt[]>;
   enabledMcpServers(): Promise<Record<string, McpServerConfig>>;
   enabledHooks(): Promise<readonly HookDef[]>;
+  // Consumption reads resolve to a per-method fallback (never reject) while
+  // no snapshot has loaded; consumers pinning a read use this to tell a real
+  // empty snapshot from the fallback.
+  hasLoadedSnapshot(): boolean;
   readonly onDidReload: Event<ReloadSummary>;
 }
 

--- a/packages/agent-core-v2/src/app/plugin/pluginService.ts
+++ b/packages/agent-core-v2/src/app/plugin/pluginService.ts
@@ -6,10 +6,12 @@
  * skill discovery, and resolves managed endpoint settings through the
  * provider service plus the startup snapshot. Exposes plugin contributions
  * through the hook, MCP, skill, and system-prompt contracts. Mutations
- * serialize through a queue, consumption reads wait on it, and every
- * mutation (install / enable / disable / remove) re-fires `onDidReload` so
- * workspace-scoped consumers refresh their contributions immediately.
- * Bound at App scope.
+ * serialize through a queue and consumption reads wait on it; while no
+ * snapshot has loaded, a consumption read resolves to its per-method
+ * fallback instead of rejecting (`hasLoadedSnapshot` exposes the state).
+ * Every mutation (install / enable / disable / remove) re-fires
+ * `onDidReload` so workspace-scoped consumers refresh their contributions
+ * immediately. Bound at App scope.
  */
 
 import { KIMI_CODE_PROVIDER_NAME } from '@moonshot-ai/kimi-code-oauth';
@@ -58,7 +60,7 @@ export class PluginService extends Service implements IPluginService {
   private readonly envOAuthHost: string | undefined;
   private readonly manager: PluginManager;
   private initialLoadPromise: Promise<void> | undefined;
-  private hasLoadedSnapshot = false;
+  private snapshotLoaded = false;
   private loadError: Error | undefined;
   private mutationQueue: Promise<void> = Promise.resolve();
   private readonly onDidReloadEmitter = this._register(new Emitter<ReloadSummary>());
@@ -139,7 +141,7 @@ export class PluginService extends Service implements IPluginService {
 
   private async reloadAndNotify(): Promise<ReloadSummary> {
     const summary = await this.manager.reload();
-    this.hasLoadedSnapshot = true;
+    this.snapshotLoaded = true;
     this.loadError = undefined;
     this.onDidReloadEmitter.fire(summary);
     return summary;
@@ -198,6 +200,10 @@ export class PluginService extends Service implements IPluginService {
     return this.runConsumptionRead([], async () => this.manager.enabledHooks());
   }
 
+  hasLoadedSnapshot(): boolean {
+    return this.snapshotLoaded;
+  }
+
   private runSerializedOperation<T>(operation: () => Promise<T>): Promise<T> {
     void this.startInitialLoad();
     return this.enqueueMutation(async () => {
@@ -214,7 +220,7 @@ export class PluginService extends Service implements IPluginService {
 
   private async runConsumptionRead<T>(fallback: T, operation: () => Promise<T>): Promise<T> {
     await this.waitForPendingMutations();
-    if (!this.hasLoadedSnapshot) return fallback;
+    if (!this.snapshotLoaded) return fallback;
     return operation();
   }
 
@@ -233,7 +239,7 @@ export class PluginService extends Service implements IPluginService {
   private async loadOnce(): Promise<void> {
     try {
       await this.manager.load();
-      this.hasLoadedSnapshot = true;
+      this.snapshotLoaded = true;
       this.loadError = undefined;
     } catch (error) {
       this.loadError = error instanceof Error ? error : new Error(String(error));

--- a/packages/agent-core-v2/src/app/plugin/pluginService.ts
+++ b/packages/agent-core-v2/src/app/plugin/pluginService.ts
@@ -6,8 +6,10 @@
  * skill discovery, and resolves managed endpoint settings through the
  * provider service plus the startup snapshot. Exposes plugin contributions
  * through the hook, MCP, skill, and system-prompt contracts. Mutations
- * serialize through a queue and consumption reads wait on it. Bound at App
- * scope.
+ * serialize through a queue, consumption reads wait on it, and every
+ * mutation (install / enable / disable / remove) re-fires `onDidReload` so
+ * workspace-scoped consumers refresh their contributions immediately.
+ * Bound at App scope.
  */
 
 import { KIMI_CODE_PROVIDER_NAME } from '@moonshot-ai/kimi-code-oauth';
@@ -89,6 +91,7 @@ export class PluginService extends Service implements IPluginService {
       const info = this.manager.info(record.id);
       if (info === undefined)
         throw new BugIndicatingError(`Plugin "${record.id}" missing right after install`);
+      await this.reloadAndNotify();
       return info;
     });
   }
@@ -96,29 +99,28 @@ export class PluginService extends Service implements IPluginService {
   setPluginEnabled(input: SetPluginEnabledInput): Promise<void> {
     return this.runSerializedOperation(async () => {
       await this.manager.setEnabled(input.id, input.enabled);
+      await this.reloadAndNotify();
     });
   }
 
   setPluginMcpServerEnabled(input: SetPluginMcpServerEnabledInput): Promise<void> {
     return this.runSerializedOperation(async () => {
       await this.manager.setMcpServerEnabled(input.id, input.server, input.enabled);
+      await this.reloadAndNotify();
     });
   }
 
   removePlugin(input: RemovePluginInput): Promise<void> {
     return this.runSerializedOperation(async () => {
       await this.manager.remove(input.id);
+      await this.reloadAndNotify();
     });
   }
 
   reloadPlugins(): Promise<ReloadSummary> {
     const reload = this.enqueueMutation(async () => {
       try {
-        const summary = await this.manager.reload();
-        this.hasLoadedSnapshot = true;
-        this.loadError = undefined;
-        this.onDidReloadEmitter.fire(summary);
-        return summary;
+        return await this.reloadAndNotify();
       } catch (error) {
         this.loadError = error instanceof Error ? error : new Error(String(error));
         throw new Error2(
@@ -133,6 +135,14 @@ export class PluginService extends Service implements IPluginService {
       () => undefined,
     );
     return reload;
+  }
+
+  private async reloadAndNotify(): Promise<ReloadSummary> {
+    const summary = await this.manager.reload();
+    this.hasLoadedSnapshot = true;
+    this.loadError = undefined;
+    this.onDidReloadEmitter.fire(summary);
+    return summary;
   }
 
   getPluginInfo(input: GetPluginInfoInput): Promise<PluginInfo> {

--- a/packages/agent-core-v2/src/mcpCore/connection-manager.ts
+++ b/packages/agent-core-v2/src/mcpCore/connection-manager.ts
@@ -12,6 +12,11 @@
  * (and the OAuth dynamic-registration label), consulted per connection so an
  * identity configured after construction still applies; omitted, or resolving
  * to `undefined`, keeps the built-in name.
+ *
+ * A server whose config disappears is tombstoned (`markRemoved`): the
+ * client is closed but the entry stays with status `removed` so consumers
+ * holding its tools can fail calls with a clear notice, until a same-named
+ * `connect` replaces it or `shutdown` clears everything.
  */
 
 import { ErrorCodes, Error2 } from '#/errors';
@@ -28,7 +33,7 @@ import { StdioMcpClient } from './client-stdio';
 import type { McpOAuthService } from '#/mcpCore/oauth/service';
 import { assertMcpInputSchema, type MCPClient, type MCPToolDefinition } from './types';
 
-export type McpServerStatus = 'pending' | 'connected' | 'failed' | 'disabled' | 'needs-auth';
+export type McpServerStatus = 'pending' | 'connected' | 'failed' | 'disabled' | 'needs-auth' | 'removed';
 
 export interface McpServerEntry {
   readonly name: string;
@@ -226,6 +231,19 @@ export class McpConnectionManager implements McpConnectionView {
     return true;
   }
 
+  async markRemoved(name: string): Promise<boolean> {
+    const entry = this.entries.get(name);
+    if (entry === undefined) return false;
+    await this.closeClient(entry);
+    entry.status = 'removed';
+    entry.tools = undefined;
+    entry.enabledNames = undefined;
+    entry.rawTools = undefined;
+    entry.error = undefined;
+    this.emit(entry);
+    return true;
+  }
+
   waitForInitialLoad(signal?: AbortSignal): Promise<void> {
     signal?.throwIfAborted();
     if (signal === undefined) return this.initialLoad;
@@ -259,7 +277,7 @@ export class McpConnectionManager implements McpConnectionView {
 
   async reconnect(name: string): Promise<void> {
     const entry = this.entries.get(name);
-    if (entry === undefined) {
+    if (entry === undefined || entry.status === 'removed') {
       throw new Error2(ErrorCodes.MCP_SERVER_NOT_FOUND, `Unknown MCP server: ${name}`);
     }
     if (entry.config.enabled === false) {

--- a/packages/agent-core-v2/src/workspace/workspaceMcp/workspaceMcpService.ts
+++ b/packages/agent-core-v2/src/workspace/workspaceMcp/workspaceMcpService.ts
@@ -5,7 +5,10 @@
  * shared by every session of the workspace). This service drives the
  * initial connect from the config domain's snapshot, applies its reconciled
  * change events incrementally (serialized on a mutation tail, always after
- * the initial connect settles), feeds the manager's global timeout defaults
+ * the initial connect settles — removals tombstone the server via
+ * `markRemoved` so live sessions keep the tool registrations but fail calls
+ * with a removal notice, while new sessions never see them), feeds the
+ * manager's global timeout defaults
  * from the config domain's tunables at each (re)connect, and reports
  * connection telemetry for the initial load. It also builds per-session
  * overlays (`sessionOverlay`): a session-owned manager for a session's
@@ -162,7 +165,7 @@ export class WorkspaceMcpService extends Service implements IWorkspaceMcpService
 
   private async apply(change: McpServersChange): Promise<void> {
     for (const name of change.remove) {
-      await this.manager.remove(name);
+      await this.manager.markRemoved(name);
     }
     for (const [name, config] of Object.entries(change.upsert)) {
       await this.manager.connect(name, config);

--- a/packages/agent-core-v2/test/agent/mcp/mcp.test.ts
+++ b/packages/agent-core-v2/test/agent/mcp/mcp.test.ts
@@ -64,6 +64,10 @@ class FakeMcpManager {
     return [...this.entries.values()];
   }
 
+  get(name: string): McpServerEntry | undefined {
+    return this.entries.get(name);
+  }
+
   resolved(name: string): ResolvedServer | undefined {
     if (this.entries.get(name)?.status !== 'connected') return undefined;
     return this.resolvedEntries.get(name);
@@ -173,6 +177,14 @@ class FakeMcpManager {
     const entry: McpServerEntry = { ...current, status: 'disabled', toolCount: 0 };
     this.emit(entry);
     this.entries.delete(name);
+  }
+
+  markRemoved(name: string): void {
+    const current = this.entries.get(name);
+    if (current === undefined) return;
+    const entry: McpServerEntry = { ...current, status: 'removed', toolCount: 0 };
+    this.entries.set(name, entry);
+    this.emit(entry);
   }
 
   private emit(entry: McpServerEntry): void {
@@ -335,6 +347,48 @@ describe('AgentMcpService', () => {
         serverName: 's',
       }),
     );
+  });
+
+  it('keeps tools registered when the server is tombstoned as removed, and calls fail with a removal notice', async () => {
+    const manager = new FakeMcpManager();
+    const counter = { calls: 0 };
+    const client = countingClient(fakeMcpClient(), counter);
+    manager.setResolved('s', client, await discoverTools(client));
+    createService(manager);
+    manager.connect('s');
+    expect(ix.get(IAgentToolRegistryService).list().filter((tool) => tool.source === 'mcp')).toHaveLength(2);
+
+    manager.markRemoved('s');
+
+    const registered = ix.get(IAgentToolRegistryService).list().filter((tool) => tool.source === 'mcp');
+    expect(registered).toHaveLength(2);
+    expect(events).not.toContainEqual(
+      expect.objectContaining({ type: 'tool.list.updated', reason: 'mcp.disconnected' }),
+    );
+
+    const echo = ix.get(IAgentToolRegistryService).resolve('mcp__s__echo');
+    expect(echo).toBeDefined();
+    const result = await executeTool(echo!, {
+      turnId: 1,
+      toolCallId: 'tc-removed',
+      args: { text: 'hello world' },
+      signal: new AbortController().signal,
+    });
+    expect(result.isError).toBe(true);
+    expect(result.output).toContain('has been removed');
+    expect(counter.calls).toBe(0);
+  });
+
+  it('does not register tools for a server tombstoned before the agent attached', async () => {
+    const manager = new FakeMcpManager();
+    const client = fakeMcpClient();
+    manager.setResolved('s', client, await discoverTools(client));
+    manager.connect('s');
+    manager.markRemoved('s');
+
+    createService(manager);
+
+    expect(ix.get(IAgentToolRegistryService).list().filter((tool) => tool.source === 'mcp')).toEqual([]);
   });
 
   it('reports same-server qualified-name collisions and keeps only the first tool', async () => {

--- a/packages/agent-core-v2/test/agent/plugin/agentPlugin.test.ts
+++ b/packages/agent-core-v2/test/agent/plugin/agentPlugin.test.ts
@@ -65,6 +65,7 @@ function pluginServiceStub(options: PluginServiceStubOptions): IPluginService {
     enabledSystemPrompts: async () => [],
     enabledMcpServers: async () => ({}),
     enabledHooks: async () => [],
+    hasLoadedSnapshot: () => true,
   };
 }
 

--- a/packages/agent-core-v2/test/agent/profile/apply-profile.test.ts
+++ b/packages/agent-core-v2/test/agent/profile/apply-profile.test.ts
@@ -260,6 +260,24 @@ describe('AgentProfileService.applyProfile', () => {
     expect(svc.data().systemPrompt).toBe(before);
   });
 
+  // While the initial plugin load has failed, `enabledSystemPrompts()`
+  // resolves to its consumption fallback instead of rejecting — that empty
+  // read must not freeze, or a later successful reload would never reach
+  // the live agent.
+  it('freezes plugin sections only once the plugin snapshot has loaded', async () => {
+    const sections = { value: [] as readonly EnabledPluginSystemPrompt[] };
+    const loaded = { value: false };
+    const { profile: svc } = buildContext(appService(IPluginService, pluginStub(sections, loaded)));
+    await svc.applyProfile(pluginProfile);
+    expect(svc.data().systemPrompt).toBe('');
+
+    loaded.value = true;
+    sections.value = [{ pluginId: 'demo', content: 'V1' }];
+    await svc.refreshSystemPrompt();
+
+    expect(svc.data().systemPrompt).toContain('<!-- From: plugin demo -->');
+  });
+
   it('lets a freshly built agent snapshot the current plugin sections', async () => {
     const sections = {
       value: [{ pluginId: 'demo', content: 'V1' }] as readonly EnabledPluginSystemPrompt[],
@@ -369,11 +387,13 @@ function skillCatalogWithChange(
   });
 }
 
-function pluginStub(sections: {
-  value: readonly EnabledPluginSystemPrompt[];
-}): IPluginService {
+function pluginStub(
+  sections: { value: readonly EnabledPluginSystemPrompt[] },
+  loaded: { value: boolean } = { value: true },
+): IPluginService {
   return {
     onDidReload: Event.None as IPluginService['onDidReload'],
+    hasLoadedSnapshot: () => loaded.value,
     pluginSkillRoots: async () => [],
     enabledSessionStarts: async () => [],
     enabledSystemPrompts: async () => sections.value,

--- a/packages/agent-core-v2/test/agent/profile/apply-profile.test.ts
+++ b/packages/agent-core-v2/test/agent/profile/apply-profile.test.ts
@@ -53,6 +53,14 @@ const skillsProfile: ResolvedAgentProfile = normalizeAgentProfile({
   tools: ['Skill'],
 });
 
+const agentsAndPluginsProfile: ResolvedAgentProfile = normalizeAgentProfile({
+  name: 'agents-and-plugins-profile',
+  systemPrompt: (context) =>
+    `agents:${typeof context['agentsMd'] === 'string' ? context['agentsMd'] : ''}\n` +
+    `plugins:${context['pluginSections'] ?? ''}`,
+  tools: [],
+});
+
 const exactProfile: ResolvedAgentProfile = normalizeAgentProfile({
   name: 'exact-profile',
   systemPrompt: (context) =>
@@ -203,7 +211,7 @@ describe('AgentProfileService.applyProfile', () => {
     );
   });
 
-  it('refreshes the system prompt when the plugin skill source reloads', async () => {
+  it('keeps the rendered prompt frozen when the plugin skill source reloads', async () => {
     const sections = {
       value: [{ pluginId: 'demo', content: 'V1' }] as readonly EnabledPluginSystemPrompt[],
     };
@@ -213,22 +221,83 @@ describe('AgentProfileService.applyProfile', () => {
       skillCatalogWithChange(change),
     );
     await svc.applyProfile(pluginProfile);
-    expect(svc.data().systemPrompt).toContain('V1');
+    const before = svc.data().systemPrompt;
+    expect(before).toContain('V1');
 
     sections.value = [{ pluginId: 'demo', content: 'V2' }];
     change.fire(PLUGIN_SKILL_SOURCE_ID);
+    await svc.refreshSystemPrompt();
 
-    await vi.waitFor(() => {
-      expect(svc.data().systemPrompt).toContain('V2');
-    });
+    expect(svc.data().systemPrompt).toBe(before);
     change.dispose();
   });
 
-  // The builtin source changes only when its config switch is toggled, so it
-  // shares the plugin source's refresh. Subscribing to the catalog rather than
-  // the config section is what makes the rebuilt prompt see the new listing:
-  // the catalog fires after the contribution is replaced.
-  it('refreshes the system prompt when the builtin skill source reloads', async () => {
+  it('does not change a live agent prompt when the contributing plugin is uninstalled', async () => {
+    const sections = {
+      value: [
+        { pluginId: 'demo', content: 'Always cite sources.' },
+      ] as readonly EnabledPluginSystemPrompt[],
+    };
+    const { profile: svc } = buildContext(appService(IPluginService, pluginStub(sections)));
+    await svc.applyProfile(pluginProfile);
+    const before = svc.data().systemPrompt;
+
+    sections.value = []; // plugin uninstalled
+    await svc.refreshSystemPrompt();
+
+    expect(svc.data().systemPrompt).toBe(before);
+  });
+
+  it('does not change a live agent prompt when a plugin is installed', async () => {
+    const sections = { value: [] as readonly EnabledPluginSystemPrompt[] };
+    const { profile: svc } = buildContext(appService(IPluginService, pluginStub(sections)));
+    await svc.applyProfile(pluginProfile);
+    const before = svc.data().systemPrompt;
+
+    sections.value = [{ pluginId: 'demo', content: 'Always cite sources.' }];
+    await svc.refreshSystemPrompt();
+
+    expect(svc.data().systemPrompt).toBe(before);
+  });
+
+  it('lets a freshly built agent snapshot the current plugin sections', async () => {
+    const sections = {
+      value: [{ pluginId: 'demo', content: 'V1' }] as readonly EnabledPluginSystemPrompt[],
+    };
+    const first = buildContext(appService(IPluginService, pluginStub(sections)));
+    await first.profile.applyProfile(pluginProfile);
+    expect(first.profile.data().systemPrompt).toContain('V1');
+
+    sections.value = [{ pluginId: 'demo', content: 'V2' }];
+    const second = buildContext(appService(IPluginService, pluginStub(sections)));
+    await second.profile.applyProfile(pluginProfile);
+
+    expect(second.profile.data().systemPrompt).toContain('V2');
+    await first.ctx.dispose();
+  });
+
+  it('keeps plugin sections frozen while other prompt inputs still refresh', async () => {
+    await writeFile(join(workDir, 'AGENTS.md'), 'old instructions', 'utf-8');
+    const sections = {
+      value: [{ pluginId: 'demo', content: 'cite' }] as readonly EnabledPluginSystemPrompt[],
+    };
+    const { profile: svc } = buildContext(appService(IPluginService, pluginStub(sections)));
+    await svc.applyProfile(agentsAndPluginsProfile);
+    expect(svc.data().systemPrompt).toContain('old instructions');
+    expect(svc.data().systemPrompt).toContain('cite');
+
+    sections.value = [];
+    await writeFile(join(workDir, 'AGENTS.md'), 'new instructions', 'utf-8');
+    await svc.refreshSystemPrompt();
+
+    expect(svc.data().systemPrompt).toContain('new instructions');
+    expect(svc.data().systemPrompt).toContain('cite');
+  });
+
+  // The skill listing is frozen together with the plugin sections: even the
+  // builtin source's reload rebuilds from the frozen listing, so a live
+  // agent's prompt stays byte-identical. New agents snapshot the new listing.
+  it('keeps the skill listing frozen when the builtin skill source reloads', async () => {
     const change = new Emitter<string>();
     const listing = { value: 'before' };
     const catalog = {
@@ -240,10 +309,9 @@ describe('AgentProfileService.applyProfile', () => {
 
     listing.value = 'after';
     change.fire(BUILTIN_SKILL_SOURCE_ID);
+    await svc.refreshSystemPrompt();
 
-    await vi.waitFor(() => {
-      expect(svc.data().systemPrompt).toBe('skills:after');
-    });
+    expect(svc.data().systemPrompt).toBe('skills:before');
     change.dispose();
   });
 
@@ -265,13 +333,15 @@ describe('AgentProfileService.applyProfile', () => {
     expect(svc.data().systemPrompt).toContain('<!-- From: plugin first -->');
     expect(svc.data().systemPrompt).not.toContain('<!-- From: plugin second -->');
 
+    // A reload-driven re-render reuses the frozen sections: the prompt does
+    // not change and the budget warning is not re-emitted.
     sections.value = [...sections.value, { pluginId: 'third', content: 'small' }];
     change.fire(PLUGIN_SKILL_SOURCE_ID);
-    await vi.waitFor(() => {
-      expect(svc.data().systemPrompt).toContain('<!-- From: plugin third -->');
-    });
+    await svc.refreshSystemPrompt();
 
+    expect(svc.data().systemPrompt).toContain('<!-- From: plugin first -->');
     expect(svc.data().systemPrompt).not.toContain('<!-- From: plugin second -->');
+    expect(svc.data().systemPrompt).not.toContain('<!-- From: plugin third -->');
     const events = context.newEvents() as readonly {
       event: string;
       args?: { code?: string };

--- a/packages/agent-core-v2/test/app/plugin/pluginService.test.ts
+++ b/packages/agent-core-v2/test/app/plugin/pluginService.test.ts
@@ -261,6 +261,29 @@ describe('PluginService (plugin boundary)', () => {
     }
   });
 
+  it('fires onDidReload after install / enable / disable / remove so workspace consumers refresh immediately', async () => {
+    const home = await makeHome();
+    await writeValidInstalledFile(home);
+    const pluginRoot = await makePluginDir('notify-demo', { description: 'demo plugin' });
+    createdDirs.push(pluginRoot);
+    const host = makeHost(home);
+    try {
+      const svc = host.app.accessor.get(IPluginService);
+      const reloads: ReloadSummary[] = [];
+      svc.onDidReload((summary) => reloads.push(summary));
+
+      await svc.installPlugin({ source: pluginRoot });
+      await svc.setPluginEnabled({ id: 'notify-demo', enabled: false });
+      await svc.setPluginEnabled({ id: 'notify-demo', enabled: true });
+      await svc.removePlugin({ id: 'notify-demo' });
+
+      expect(reloads).toHaveLength(4);
+      await expect(svc.listPlugins()).resolves.toEqual([]);
+    } finally {
+      host.dispose();
+    }
+  });
+
   it('serves enabled plugin system-prompt sections on the consumption plane', async () => {
     const home = await makeHome();
     const pluginRoot = await makePluginDir('prompt-demo', { systemPrompt: 'Always cite sources.' });

--- a/packages/agent-core-v2/test/mcpCore/connection-manager.test.ts
+++ b/packages/agent-core-v2/test/mcpCore/connection-manager.test.ts
@@ -86,6 +86,34 @@ describe('McpConnectionManager', () => {
     }
   }, 20000);
 
+  it('markRemoved tombstones the entry: client closed, entry kept, reconnect rejected, re-connect revives', async () => {
+    const cm = new McpConnectionManager();
+    try {
+      await cm.connectAll({ alpha: stdioConfig() });
+      expect(cm.get('alpha')?.status).toBe('connected');
+
+      const statuses: string[] = [];
+      cm.onStatusChange((entry) => statuses.push(`${entry.name}:${entry.status}`));
+
+      expect(await cm.markRemoved('alpha')).toBe(true);
+      const entry = cm.get('alpha');
+      expect(entry?.status).toBe('removed');
+      expect(entry?.toolCount).toBe(0);
+      expect(cm.resolved('alpha')).toBeUndefined();
+      expect(cm.list().map((e) => e.name)).toEqual(['alpha']);
+      expect(statuses).toContain('alpha:removed');
+      await expect(cm.reconnect('alpha')).rejects.toThrow('Unknown MCP server: alpha');
+
+      expect(await cm.markRemoved('missing')).toBe(false);
+
+      await cm.connect('alpha', stdioConfig());
+      expect(cm.get('alpha')?.status).toBe('connected');
+      expect(cm.resolved('alpha')).toBeDefined();
+    } finally {
+      await cm.shutdown();
+    }
+  }, 20000);
+
   it('marks HTTP servers failed when configured bearer token env var is missing', async () => {
     const cm = new McpConnectionManager({ envLookup: () => undefined });
     try {

--- a/packages/agent-core-v2/test/workspace/workspaceAgentProfileLoader/agentProfileLoader.test.ts
+++ b/packages/agent-core-v2/test/workspace/workspaceAgentProfileLoader/agentProfileLoader.test.ts
@@ -211,6 +211,7 @@ function pluginStub(
     enabledSystemPrompts: async () => [],
     enabledMcpServers: async () => ({}),
     enabledHooks: async () => [],
+    hasLoadedSnapshot: () => true,
   };
 }
 

--- a/packages/agent-core-v2/test/workspace/workspaceMcp/workspaceMcp.test.ts
+++ b/packages/agent-core-v2/test/workspace/workspaceMcp/workspaceMcp.test.ts
@@ -131,7 +131,7 @@ describe('WorkspaceMcpService', () => {
 
     await vi.waitFor(
       () => {
-        expect(manager?.get('alpha')).toBeUndefined();
+        expect(manager?.get('alpha')?.status).toBe('removed');
         expect(manager?.get('beta')?.status).toBe('connected');
       },
       { timeout: 10000, interval: 50 },
@@ -150,9 +150,9 @@ describe('WorkspaceMcpService', () => {
     const connect = vi
       .spyOn(McpConnectionManager.prototype, 'connect')
       .mockResolvedValue(undefined as never);
-    const remove = vi
-      .spyOn(McpConnectionManager.prototype, 'remove')
-      .mockResolvedValue(undefined as never);
+    const markRemoved = vi
+      .spyOn(McpConnectionManager.prototype, 'markRemoved')
+      .mockResolvedValue(true as never);
 
     const service = createService();
     manager = service.connectionManager();
@@ -160,13 +160,13 @@ describe('WorkspaceMcpService', () => {
     configChanges.fire({ upsert: { beta: stdioServer() }, remove: ['alpha'] });
     await new Promise((resolvePromise) => setTimeout(resolvePromise, 300));
     expect(connect).not.toHaveBeenCalled();
-    expect(remove).not.toHaveBeenCalled();
+    expect(markRemoved).not.toHaveBeenCalled();
 
     settleConnectAll();
     await service.ready;
     await vi.waitFor(
       () => {
-        expect(remove).toHaveBeenCalledWith('alpha');
+        expect(markRemoved).toHaveBeenCalledWith('alpha');
         expect(connect).toHaveBeenCalledWith('beta', stdioServer());
       },
       { timeout: 10000, interval: 50 },

--- a/packages/agent-core-v2/test/workspace/workspaceSkillCatalog/skillCatalog.test.ts
+++ b/packages/agent-core-v2/test/workspace/workspaceSkillCatalog/skillCatalog.test.ts
@@ -138,6 +138,7 @@ function pluginStub(
     enabledSystemPrompts: async () => [],
     enabledMcpServers: async () => ({}),
     enabledHooks: async () => [],
+    hasLoadedSnapshot: () => true,
   };
 }
 

--- a/packages/agent-core/src/rpc/core-api.ts
+++ b/packages/agent-core/src/rpc/core-api.ts
@@ -327,7 +327,9 @@ export interface ActivatePluginCommandPayload {
 export interface McpServerInfo {
   readonly name: string;
   readonly transport: 'stdio' | 'http' | 'sse';
-  readonly status: 'pending' | 'connected' | 'failed' | 'disabled' | 'needs-auth';
+  // 'removed' is only produced by the v2 engine (config-driven tombstone);
+  // v1 never emits it, but SDK consumers share this type across engines.
+  readonly status: 'pending' | 'connected' | 'failed' | 'disabled' | 'needs-auth' | 'removed';
   readonly toolCount: number;
   readonly error?: string;
 }

--- a/packages/agent-core/src/services/mcp/mcp.ts
+++ b/packages/agent-core/src/services/mcp/mcp.ts
@@ -27,6 +27,7 @@
  *   agent-core 'failed'     → wire 'error'
  *   agent-core 'disabled'   → wire 'disconnected'
  *   agent-core 'needs-auth' → wire 'error'   (last_error carries the hint)
+ *   agent-core 'removed'    → wire 'disconnected' (v2-only tombstone status)
  *
  * **MCP id**: agent-core's `McpServerInfo` has only `name`. We adopt
  * name-as-id at the wire boundary. Both are 1:1 within a daemon process.
@@ -57,6 +58,9 @@ function mapMcpStatus(s: McpServerInfo['status']): McpServerStatus {
     case 'needs-auth':
       // Closest wire literal; `last_error` carries the explanatory message.
       return 'error';
+    case 'removed':
+      // v2-only tombstone status; v1 never produces it.
+      return 'disconnected';
   }
 }
 

--- a/packages/kap-server/src/protocol/events-zod.ts
+++ b/packages/kap-server/src/protocol/events-zod.ts
@@ -941,7 +941,7 @@ export const toolListUpdatedEventSchema = z.object({
 export const mcpServerStatusPayloadSchema = z.object({
   name: z.string(),
   transport: z.enum(['stdio', 'http']),
-  status: z.enum(['pending', 'connected', 'failed', 'disabled', 'needs-auth']),
+  status: z.enum(['pending', 'connected', 'failed', 'disabled', 'needs-auth', 'removed']),
   toolCount: z.number(),
   error: z.string().optional(),
 }) satisfies z.ZodType<McpServerStatusPayload>;

--- a/packages/kap-server/src/routes/tools.ts
+++ b/packages/kap-server/src/routes/tools.ts
@@ -35,7 +35,7 @@
  *     (bound profile policy ∩ global `[tools]` config ∩ session denylist).
  *     Deliberate v2 extension beyond the v1 wire shape — v1 had no tool gates.
  *   - MCP `status`: `pending`→`connecting`, `connected`→`connected`,
- *     `failed`/`needs-auth`→`error`, `disabled`→`disconnected`.
+ *     `failed`/`needs-auth`→`error`, `disabled`/`removed`→`disconnected`.
  *   - MCP `last_error`: carried from `entry.error` when non-empty.
  *
  * **Error mapping**:
@@ -286,6 +286,8 @@ function mapMcpStatus(status: McpEntry['status']): McpServer['status'] {
     case 'connected':
       return 'connected';
     case 'disabled':
+      return 'disconnected';
+    case 'removed':
       return 'disconnected';
     case 'failed':
       return 'error';

--- a/packages/klient/src/contract/agent/services.ts
+++ b/packages/klient/src/contract/agent/services.ts
@@ -48,7 +48,7 @@ export const agentPlanContract = {
 export const mcpServerEntrySchema = z.object({
   name: z.string(),
   transport: z.enum(['stdio', 'http', 'sse']),
-  status: z.enum(['pending', 'connected', 'failed', 'disabled', 'needs-auth']),
+  status: z.enum(['pending', 'connected', 'failed', 'disabled', 'needs-auth', 'removed']),
   toolCount: z.number(),
   error: z.string().optional(),
 });

--- a/packages/protocol/src/events.ts
+++ b/packages/protocol/src/events.ts
@@ -930,7 +930,7 @@ export interface McpServerStatusEvent {
 export interface McpServerStatusPayload {
   readonly name: string;
   readonly transport: 'stdio' | 'http' | 'sse';
-  readonly status: 'pending' | 'connected' | 'failed' | 'disabled' | 'needs-auth';
+  readonly status: 'pending' | 'connected' | 'failed' | 'disabled' | 'needs-auth' | 'removed';
   readonly toolCount: number;
   readonly error?: string;
 }
@@ -1824,7 +1824,7 @@ export const toolListUpdatedEventSchema = z.object({
 export const mcpServerStatusPayloadSchema = z.object({
   name: z.string(),
   transport: z.enum(['stdio', 'http']),
-  status: z.enum(['pending', 'connected', 'failed', 'disabled', 'needs-auth']),
+  status: z.enum(['pending', 'connected', 'failed', 'disabled', 'needs-auth', 'removed']),
   toolCount: z.number(),
   error: z.string().optional(),
 }) satisfies z.ZodType<McpServerStatusPayload>;


### PR DESCRIPTION
## Related Issue

None — the problem is explained below.

## Problem

Two related live-session stability issues on the v2 engine (the default for the interactive TUI, `kimi -p`, and `kimi web`):

1. Removing an MCP server from the workspace config — including removing or disabling the plugin that declared it — dropped the server's tool registrations immediately, so an in-flight session broke the next time the model called one of those tools. Plugin mutations also did not notify workspace consumers, so skills, agents, hooks, and MCP contributions only refreshed after a manual `/reload` or in a new session.
2. Plugin-derived system-prompt inputs (the model skill listing and the plugin system-prompt sections) were re-resolved on every prompt refresh, so installing or removing a plugin could rewrite a running agent's system prompt mid-session — for example when a later rebuild was triggered by compaction or a tool-policy change.

## What changed

### 1. Tombstone removed MCP servers and apply plugin changes immediately

**What was done:**

- Added a `removed` MCP server status: workspace config removals now call `markRemoved` instead of `remove`, closing the connection but keeping tool registrations alive. Calls to a removed server's tools short-circuit with a removal notice telling the model to stop calling, and new sessions never register the tools.
- Every plugin mutation (install / enable / disable / remove / toggle a plugin MCP server) now re-fires `onDidReload`, so workspace-scoped consumers (skill catalog, MCP config, agent profiles, hooks) refresh contributions immediately instead of waiting for `/plugins reload`.
- The TUI renders the `removed` status in the `/mcp` panel and startup summary, and the `/plugins` hint on the v2 engine now says plugin changes apply immediately.

### 2. Freeze plugin prompt inputs for live agents

**What was done:**

- The model skill listing and plugin system-prompt sections are snapshotted on an agent's first successful prompt build and frozen for the agent's lifetime, so plugin install / enable / disable / remove / reload never rewrites a running agent's prompt — the same keep-live-sessions-stable philosophy as the MCP tombstone.
- Freezing happens only on success, so a not-yet-ready skill catalog or a failed plugin-sections read cannot pin empty values for the agent's lifetime.
- `refreshSystemPrompt` still rebuilds on catalog change events but reuses the frozen values, so a live prompt only moves when non-plugin inputs change (AGENTS.md, the `[tools]` section, session tool policy, compaction). New sessions and newly created subagents snapshot the then-current state.

### 3. Docs

**What was done:**

- Updated `docs/{en,zh}/customization/plugins.md` and `docs/{en,zh}/customization/mcp.md` for the new v2 behavior: plugin changes apply immediately, a running session's prompt stays frozen, and removed MCP servers keep their tools visible in open sessions with a removal notice on calls.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.
