### PR TITLE
feat(kimi-code): add kimi pet desktop pet for live session status

### DIFF
--- a/.changeset/kimi-pet-desktop.md
+++ b/.changeset/kimi-pet-desktop.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": minor
+---
+
+Add the `kimi pet` subcommand to launch an always-on-top desktop pet that mirrors live session status: it shows the current action while working, flags pending approvals and questions, and announces completion or failure. Multiple sessions aggregate by priority (awaiting > failed > working > done > idle) with a count badge on the pet, and you can swipe on the bubble or click the badge to page through each session. Right-click the pet for settings (pet size, bubble font size) or to quit. Run `kimi pet` to try it.

--- a/apps/kimi-code/package.json
+++ b/apps/kimi-code/package.json
@@ -50,7 +50,7 @@
     "provenance": true
   },
   "scripts": {
-    "build": "tsdown && node scripts/copy-native-assets.mjs && node scripts/check-web-assets.mjs",
+    "build": "tsdown && tsdown -c tsdown.pet.config.ts && node scripts/copy-native-assets.mjs && node scripts/check-web-assets.mjs",
     "prebuild": "node scripts/build-vis-asset.mjs",
     "catalog:update": "node scripts/update-catalog.mjs --out dist/built-in-catalog.json",
     "smoke": "node scripts/smoke.mjs",
@@ -82,6 +82,7 @@
     "node-pty": "^1.1.0"
   },
   "devDependencies": {
+    "@electron/get": "^4.0.0",
     "@moonshot-ai/acp-adapter": "workspace:^",
     "@moonshot-ai/acp-server": "workspace:^",
     "@moonshot-ai/agent-core-v2": "workspace:^",
@@ -99,6 +100,7 @@
     "chalk": "^5.4.1",
     "cli-highlight": "^2.1.11",
     "commander": "^13.1.0",
+    "extract-zip": "^2.0.1",
     "jimp": "^1.6.1",
     "pathe": "^2.0.3",
     "postject": "1.0.0-alpha.6",

--- a/apps/kimi-code/src/cli/commands.ts
+++ b/apps/kimi-code/src/cli/commands.ts
@@ -7,6 +7,7 @@ import { registerAcpCommand } from './sub/acp';
 import { registerDoctorCommand } from './sub/doctor';
 import { registerExportCommand } from './sub/export';
 import { registerLoginCommand } from './sub/login';
+import { registerPetCommand } from './sub/pet';
 import { registerProviderCommand } from './sub/provider';
 import { registerVisCommand } from './sub/vis';
 import { registerWebCommand } from './sub/web';
@@ -120,6 +121,7 @@ export function createProgram(
   registerLoginCommand(program);
   registerDoctorCommand(program);
   registerVisCommand(program);
+  registerPetCommand(program);
   registerMigrateCommand(program, onMigrate);
   program
     .command('upgrade')

--- a/apps/kimi-code/src/cli/run-prompt.ts
+++ b/apps/kimi-code/src/cli/run-prompt.ts
@@ -17,6 +17,7 @@ import {
 import { resolve } from 'pathe';
 
 import { CLI_SHUTDOWN_TIMEOUT_MS, PROMPT_CLEANUP_TIMEOUT_MS } from '#/constant/app';
+import { PetReporter } from '#/pet/reporter';
 
 import { resolveAgentProfileSelection } from './agent-selection';
 import { isKimiV2Enabled } from './experimental-v2';
@@ -144,6 +145,7 @@ export async function runPrompt(
     workDir,
   });
   let restorePromptSessionPermission = async (): Promise<void> => {};
+  let petReporter: PetReporter | undefined;
   let removeTerminationCleanup: (() => void) | undefined;
   let cleanupPromise: Promise<void> | undefined;
   const cleanupPromptRun = async (): Promise<void> => {
@@ -185,6 +187,9 @@ export async function runPrompt(
       );
     restorePromptSessionPermission = restorePermission;
 
+    petReporter = new PetReporter();
+    petReporter.attachSession(session, { sessionId: session.id, cwd: workDir });
+
     initializeCliTelemetry({
       harness,
       bootstrap: telemetryBootstrap,
@@ -218,6 +223,9 @@ export async function runPrompt(
       duration_ms: Date.now() - startedAt,
     });
   } finally {
+    // Deliberately not detaching the pet reporter: the final done/failed
+    // state file should outlive the process briefly so the pet can show the
+    // result; it expires via TTL shortly after.
     await cleanupPromptRun();
   }
 }

--- a/apps/kimi-code/src/cli/sub/pet.ts
+++ b/apps/kimi-code/src/cli/sub/pet.ts
@@ -1,0 +1,158 @@
+/**
+ * `kimi pet` sub-command.
+ *
+ * Launches (or stops) the desktop-pet overlay: a small always-on-top Electron
+ * window that mirrors the live status of running Kimi Code sessions. The
+ * overlay process is detached (it outlives this command); running sessions
+ * report their status through state files under `<dataDir>/pet/`.
+ */
+
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { spawn } from 'node:child_process';
+import { dirname } from 'node:path';
+import type { Command } from 'commander';
+
+import { getPetOverlayPidFile } from '#/pet/dirs';
+import { ensureElectronBinary, resolvePetOverlayEntry } from '#/pet/electron';
+import { getVersion } from '#/cli/version';
+
+interface WritableLike {
+  write(chunk: string): boolean;
+}
+
+export interface PetDeps {
+  readonly ensureElectron: () => Promise<string>;
+  readonly resolveOverlayEntry: () => string;
+  readonly spawnProcess: typeof spawn;
+  readonly pidFile: string;
+  readonly isProcessAlive: (pid: number) => boolean;
+  readonly killProcess: (pid: number) => void;
+  readonly stdout: WritableLike;
+  readonly stderr: WritableLike;
+  readonly exit: (code: number) => never;
+}
+
+export interface PetOptions {
+  readonly stop: boolean;
+  readonly skin?: string;
+}
+
+export async function handlePet(deps: PetDeps, opts: PetOptions): Promise<void> {
+  if (opts.stop) {
+    stopPet(deps);
+    return;
+  }
+  await startPet(deps, opts);
+}
+
+function readLivePid(deps: PetDeps): number | undefined {
+  try {
+    const raw = readFileSync(deps.pidFile, 'utf-8').trim();
+    const pid = Number.parseInt(raw, 10);
+    if (Number.isNaN(pid)) return undefined;
+    return deps.isProcessAlive(pid) ? pid : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+async function startPet(deps: PetDeps, opts: PetOptions): Promise<void> {
+  const running = readLivePid(deps);
+  if (running !== undefined) {
+    deps.stdout.write(`kimi pet is already running (pid ${running}).\n`);
+    return;
+  }
+
+  const overlayEntry = deps.resolveOverlayEntry();
+  if (!existsSync(overlayEntry)) {
+    deps.stderr.write(
+      `Pet overlay bundle not found at ${overlayEntry}. Run \`pnpm build\` first if you are in a source checkout.\n`,
+    );
+    return deps.exit(1);
+  }
+
+  let electronBin: string;
+  try {
+    electronBin = await deps.ensureElectron();
+  } catch (error) {
+    const msg = error instanceof Error ? error.message : String(error);
+    deps.stderr.write(`Failed to set up the pet runtime (Electron): ${msg}\n`);
+    return deps.exit(1);
+  }
+
+  const child = deps.spawnProcess(electronBin, [overlayEntry], {
+    detached: true,
+    stdio: 'ignore',
+    windowsHide: true,
+    env: {
+      ...process.env,
+      // Shown in the overlay's settings window (bottom-left version label).
+      KIMI_PET_CLI_VERSION: getVersion(),
+      ...(opts.skin === undefined ? {} : { KIMI_PET_SKIN: opts.skin }),
+    },
+  });
+  child.unref();
+  if (child.pid === undefined) {
+    deps.stderr.write('Failed to start the pet overlay process.\n');
+    return deps.exit(1);
+  }
+  mkdirSync(dirname(deps.pidFile), { recursive: true });
+  writeFileSync(deps.pidFile, String(child.pid), 'utf-8');
+  deps.stdout.write('kimi pet is on your desktop now. It will mirror your session status.\n');
+}
+
+function stopPet(deps: PetDeps): void {
+  const pid = readLivePid(deps);
+  if (pid === undefined) {
+    rmSync(deps.pidFile, { force: true });
+    deps.stdout.write('kimi pet is not running.\n');
+    return;
+  }
+  try {
+    deps.killProcess(pid);
+  } catch {
+    // Already gone.
+  }
+  rmSync(deps.pidFile, { force: true });
+  deps.stdout.write('kimi pet stopped.\n');
+}
+
+export function registerPetCommand(parent: Command, overrides?: Partial<PetDeps>): void {
+  parent
+    .command('pet')
+    .description('Launch the desktop pet that mirrors your session status.')
+    .option('--stop', 'Stop the desktop pet.')
+    .option(
+      '--skin <name>',
+      'Use a custom skin from <dataDir>/pet/pets/<name>/ (codex pet atlas format).',
+    )
+    .action(async (options: { stop?: boolean; skin?: string }) => {
+      await handlePet(createDefaultPetDeps(overrides), {
+        stop: options.stop === true,
+        ...(options.skin === undefined ? {} : { skin: options.skin }),
+      });
+    });
+}
+
+function createDefaultPetDeps(overrides: Partial<PetDeps> = {}): PetDeps {
+  return {
+    ensureElectron: overrides.ensureElectron ?? (() => ensureElectronBinary()),
+    resolveOverlayEntry: overrides.resolveOverlayEntry ?? resolvePetOverlayEntry,
+    spawnProcess: overrides.spawnProcess ?? spawn,
+    pidFile: overrides.pidFile ?? getPetOverlayPidFile(),
+    isProcessAlive:
+      overrides.isProcessAlive ??
+      ((pid) => {
+        try {
+          process.kill(pid, 0);
+          return true;
+        } catch {
+          return false;
+        }
+      }),
+    killProcess: overrides.killProcess ?? ((pid) => process.kill(pid)),
+    stdout: overrides.stdout ?? process.stdout,
+    stderr: overrides.stderr ?? process.stderr,
+    exit: overrides.exit ?? ((code: number) => process.exit(code)),
+  };
+}

--- a/apps/kimi-code/src/pet/dirs.ts
+++ b/apps/kimi-code/src/pet/dirs.ts
@@ -1,0 +1,60 @@
+/**
+ * Desktop-pet data paths.
+ *
+ * These intentionally do NOT reuse `#/utils/paths`: that module pulls in
+ * `#/constant/app`, which value-imports the whole SDK — fine for the main
+ * bundle, but the pet overlay is bundled separately and runs under Electron,
+ * where dragging in the SDK would bloat it by ~10 MB. The resolution rule
+ * (`KIMI_CODE_HOME` env > `~/.kimi-code`) mirrors `getDataDir()` and must be
+ * kept in sync with it.
+ */
+
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+
+const KIMI_CODE_HOME_ENV = 'KIMI_CODE_HOME';
+const KIMI_CODE_DATA_DIR_NAME = '.kimi-code';
+
+/** Root data directory: `KIMI_CODE_HOME` env var > `~/.kimi-code`. */
+export function getPetDataDir(): string {
+  const envDir = process.env[KIMI_CODE_HOME_ENV];
+  if (envDir !== undefined && envDir !== '') {
+    return envDir;
+  }
+  return join(homedir(), KIMI_CODE_DATA_DIR_NAME);
+}
+
+/** Desktop-pet root directory: `<dataDir>/pet/`. */
+export function getPetDir(): string {
+  return join(getPetDataDir(), 'pet');
+}
+
+/** One state file per reported session: `<dataDir>/pet/sessions/`. */
+export function getPetSessionsDir(): string {
+  return join(getPetDir(), 'sessions');
+}
+
+/** Custom pet skin root: `<dataDir>/pet/pets/`. */
+export function getPetSkinsDir(): string {
+  return join(getPetDir(), 'pets');
+}
+
+/** Overlay heartbeat file: `<dataDir>/pet/overlay.json`. */
+export function getPetOverlayHeartbeatFile(): string {
+  return join(getPetDir(), 'overlay.json');
+}
+
+/** Overlay pidfile: `<dataDir>/pet/overlay.pid`. */
+export function getPetOverlayPidFile(): string {
+  return join(getPetDir(), 'overlay.pid');
+}
+
+/** Persisted pet window position: `<dataDir>/pet/overlay-position.json`. */
+export function getPetOverlayPositionFile(): string {
+  return join(getPetDir(), 'overlay-position.json');
+}
+
+/** Pet display settings (size scale): `<dataDir>/pet/settings.json`. */
+export function getPetSettingsFile(): string {
+  return join(getPetDir(), 'settings.json');
+}

--- a/apps/kimi-code/src/pet/electron.ts
+++ b/apps/kimi-code/src/pet/electron.ts
@@ -1,0 +1,93 @@
+/**
+ * Electron runtime management for the pet overlay.
+ *
+ * Electron is deliberately NOT an npm dependency of the CLI — a ~100 MB
+ * per-platform binary should not be paid by users who never run `kimi pet`.
+ * It is downloaded lazily on first use into `<dataDir>/pet/electron/` and
+ * reused afterwards.
+ */
+
+import { existsSync, mkdirSync, renameSync, rmSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+
+import { getPetDir } from './dirs';
+
+/** Pinned Electron build used to run the pet overlay. */
+export const PET_ELECTRON_VERSION = '33.2.0';
+
+function electronBinaryRelativePath(platform: NodeJS.Platform): string {
+  switch (platform) {
+    case 'darwin':
+      return join('Electron.app', 'Contents', 'MacOS', 'Electron');
+    case 'win32':
+      return 'electron.exe';
+    default:
+      return 'electron';
+  }
+}
+
+export function electronBinaryPath(
+  cacheRoot: string,
+  platform: NodeJS.Platform = process.platform,
+  arch: string = process.arch,
+): string {
+  return join(
+    electronPackageDir(cacheRoot, platform, arch),
+    electronBinaryRelativePath(platform),
+  );
+}
+
+function electronPackageDir(cacheRoot: string, platform: NodeJS.Platform, arch: string): string {
+  return join(cacheRoot, `electron-v${PET_ELECTRON_VERSION}-${platform}-${arch}`);
+}
+
+/**
+ * Ensure the Electron binary is available, downloading and extracting it on
+ * first use. Returns the path to the executable. Honors the standard
+ * `ELECTRON_MIRROR` env var for users behind a mirror.
+ */
+export async function ensureElectronBinary(
+  cacheRoot: string = join(getPetDir(), 'electron'),
+): Promise<string> {
+  const binary = electronBinaryPath(cacheRoot);
+  if (existsSync(binary)) return binary;
+
+  const { downloadArtifact } = await import('@electron/get');
+  const zipPath = await downloadArtifact({
+    version: PET_ELECTRON_VERSION,
+    platform: process.platform,
+    arch: process.arch,
+    artifactName: 'electron',
+    cacheRoot: join(cacheRoot, 'zips'),
+  });
+
+  const { default: extract } = await import('extract-zip');
+  const finalDir = electronPackageDir(cacheRoot, process.platform, process.arch);
+  const tmpDir = `${finalDir}.tmp-${process.pid}`;
+  rmSync(tmpDir, { recursive: true, force: true });
+  mkdirSync(tmpDir, { recursive: true });
+  try {
+    await extract(zipPath, { dir: tmpDir });
+    rmSync(finalDir, { recursive: true, force: true });
+    renameSync(tmpDir, finalDir);
+  } catch (error) {
+    rmSync(tmpDir, { recursive: true, force: true });
+    throw error;
+  }
+  if (!existsSync(binary)) {
+    throw new Error(`Electron archive extracted but binary is missing at ${binary}`);
+  }
+  return binary;
+}
+
+/**
+ * Locate the bundled overlay entry (`pet-overlay.mjs`). In the packaged CLI it
+ * sits next to `main.mjs` in `dist/`; from a source checkout it is produced by
+ * `pnpm build` into the app `dist/`.
+ */
+export function resolvePetOverlayEntry(): string {
+  const here = import.meta.dirname;
+  const bundled = join(here, 'pet-overlay.mjs');
+  if (existsSync(bundled)) return bundled;
+  return resolve(here, '..', '..', 'dist', 'pet-overlay.mjs');
+}

--- a/apps/kimi-code/src/pet/overlay/electron.d.ts
+++ b/apps/kimi-code/src/pet/overlay/electron.d.ts
@@ -1,0 +1,92 @@
+/**
+ * Minimal type shim for the `electron` module.
+ *
+ * Electron is deliberately not an npm dependency of this package — the binary
+ * is downloaded lazily on first `kimi pet` run (see `src/pet/electron.ts`).
+ * The overlay bundle (`pet-overlay.mjs`) only uses the small API surface
+ * declared here, so we keep local typings instead of pulling the full
+ * `electron` package (and its ~100 MB binary download) into every install.
+ */
+
+declare module 'electron' {
+  export interface Rectangle {
+    x: number;
+    y: number;
+    width: number;
+    height: number;
+  }
+
+  export interface BrowserWindowConstructorOptions {
+    width?: number;
+    height?: number;
+    x?: number;
+    y?: number;
+    /** macOS-only: create the window as an NSPanel. Ignored on other platforms. */
+    type?: 'panel';
+    frame?: boolean;
+    transparent?: boolean;
+    resizable?: boolean;
+    minimizable?: boolean;
+    maximizable?: boolean;
+    fullscreenable?: boolean;
+    show?: boolean;
+    alwaysOnTop?: boolean;
+    skipTaskbar?: boolean;
+    hasShadow?: boolean;
+    title?: string;
+    /** macOS-only: hide the title bar but keep the traffic lights. */
+    titleBarStyle?: 'hiddenInset';
+    webPreferences?: {
+      nodeIntegration?: boolean;
+      contextIsolation?: boolean;
+    };
+  }
+
+  export interface WebContents {
+    send(channel: string, ...args: unknown[]): void;
+    on(event: 'did-finish-load', listener: () => void): void;
+  }
+
+  export class BrowserWindow {
+    constructor(options: BrowserWindowConstructorOptions);
+    readonly webContents: WebContents;
+    loadFile(path: string): Promise<void>;
+    getPosition(): [number, number];
+    getSize(): [number, number];
+    setPosition(x: number, y: number): void;
+    setBounds(bounds: Rectangle): void;
+    setAlwaysOnTop(flag: boolean, level?: string): void;
+    setVisibleOnAllWorkspaces(visible: boolean, options?: { visibleOnFullScreen?: boolean }): void;
+    setHiddenInMissionControl(hidden: boolean): void;
+    isDestroyed(): boolean;
+    show(): void;
+    showInactive(): void;
+    focus(): void;
+    on(event: 'moved' | 'move' | 'closed', listener: () => void): void;
+  }
+
+  export const ipcMain: {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    on(channel: string, listener: (event: unknown, ...args: any[]) => void): void;
+  };
+
+  export interface App {
+    requestSingleInstanceLock(): boolean;
+    whenReady(): Promise<void>;
+    quit(): void;
+    disableHardwareAcceleration(): void;
+    /** macOS-only; undefined elsewhere. */
+    readonly dock?: { hide(): void };
+    readonly commandLine: {
+      appendSwitch(name: string): void;
+    };
+    on(event: 'second-instance' | 'window-all-closed', listener: () => void): void;
+  }
+
+  export const app: App;
+
+  export const screen: {
+    getPrimaryDisplay(): { workAreaSize: { width: number; height: number } };
+    getCursorScreenPoint(): { x: number; y: number };
+  };
+}

--- a/apps/kimi-code/src/pet/overlay/pet-overlay.ts
+++ b/apps/kimi-code/src/pet/overlay/pet-overlay.ts
@@ -1,0 +1,400 @@
+/**
+ * Pet overlay — Electron main-process entry (bundled as `dist/pet-overlay.mjs`,
+ * executed by the Electron binary spawned from `kimi pet`).
+ *
+ * Renders a small transparent always-on-top window showing the aggregate
+ * status of all reporting Kimi Code sessions. State is pulled from
+ * `<dataDir>/pet/sessions/` (written by in-process reporters); this process
+ * also maintains the `overlay.json` heartbeat that gates those reporters.
+ */
+
+import { mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { spawn } from 'node:child_process';
+import { extname, join } from 'node:path';
+
+import { BrowserWindow, app, ipcMain, screen } from 'electron';
+
+import {
+  clampPetBubbleFontSize,
+  clampPetScale,
+  rankSessionStates,
+  readPetSessionStates,
+  readPetSettings,
+  readPetWindowPosition,
+  writePetOverlayHeartbeat,
+  writePetSettings,
+  writePetWindowPosition,
+  type PetOverlayState,
+  type PetSessionSummary,
+  type PetSettings,
+} from '#/pet/state';
+import { getPetDir, getPetSkinsDir } from '../dirs';
+
+import RENDERER_HTML from './renderer.html?raw';
+import SETTINGS_HTML from './settings.html?raw';
+
+// The window hugs its content: mascot-only when idle, growing upward and
+// outward (bottom-center anchored) while a bubble is shown — so the bubble is
+// never clipped by the frame, and the transparent window never covers more of
+// the desktop than the visible UI.
+const WINDOW_MIN_WIDTH = 170;
+const WINDOW_MIN_HEIGHT = 160;
+const WINDOW_MAX_HEIGHT = 264;
+// The max window width follows the bubble's text cap: 20 characters (the
+// title limit in renderer.html, ~1em each for CJK) plus the ellipsis glyph
+// at the configured font size, plus the bubble's horizontal chrome —
+// padding (26) + worst-case action cluster (58) + shadow slack (48) —
+// mirrored from renderer.html.
+const BUBBLE_TITLE_MAX_CHARS = 20;
+const BUBBLE_WIDTH_CHROME = 26 + 58 + 48;
+const POLL_INTERVAL_MS = 250;
+const HEARTBEAT_INTERVAL_MS = 1_000;
+const CURSOR_POLL_INTERVAL_MS = 80;
+
+/** `TERM_PROGRAM` value → macOS app name for focusing the session terminal. */
+const TERMINAL_APP_NAMES: Record<string, string> = {
+  'Warp': 'Warp',
+  'iTerm.app': 'iTerm',
+  'Apple_Terminal': 'Terminal',
+  'WezTerm': 'WezTerm',
+  'ghostty': 'Ghostty',
+  'kitty': 'kitty',
+  'Alacritty': 'Alacritty',
+  'Hyper': 'Hyper',
+  'Tabby': 'Tabby',
+  'vscode': 'Visual Studio Code',
+  'zed': 'Zed',
+};
+
+// Linux compositors generally need GPU off (and the visuals switch) for a
+// transparent window; harmless elsewhere.
+if (process.platform === 'linux') {
+  app.commandLine.appendSwitch('enable-transparent-visuals');
+  app.disableHardwareAcceleration();
+}
+
+if (!app.requestSingleInstanceLock()) {
+  // Another pet is already running: quit WITHOUT touching the ready handler,
+  // otherwise this instance would still create a window and timers that then
+  // fire against destroyed objects during teardown.
+  app.quit();
+  process.exit(0);
+}
+
+let win: BrowserWindow | null = null;
+let settingsWin: BrowserWindow | null = null;
+let lastPayload = '';
+/** User settings from the settings window; persisted in settings.json. */
+let petSettings: PetSettings = { scale: 1, bubbleFontSize: 13 };
+/** CLI version passed via env, shown in the settings window's footer. */
+const cliVersion = process.env['KIMI_PET_CLI_VERSION'] ?? '';
+
+app.on('second-instance', () => {
+  if (win !== null && !win.isDestroyed()) {
+    win.showInactive();
+  }
+});
+
+/** Load a custom codex-atlas skin selected via `KIMI_PET_SKIN`. */
+function loadSkinDataUrl(): string | undefined {
+  const name = process.env['KIMI_PET_SKIN'];
+  if (name === undefined || name === '') return undefined;
+  try {
+    const dir = join(getPetSkinsDir(), name);
+    const meta = JSON.parse(readFileSync(join(dir, 'pet.json'), 'utf-8')) as {
+      spritesheetPath?: string;
+    };
+    const file = join(dir, meta.spritesheetPath ?? 'spritesheet.webp');
+    const mime = extname(file) === '.png' ? 'image/png' : 'image/webp';
+    return `data:${mime};base64,${readFileSync(file).toString('base64')}`;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Open (or focus) the settings window. Unlike the transparent pet, this is a
+ * regular framed window that takes focus; edits are relayed back over the
+ * `pet:update-settings` IPC handled above.
+ */
+function openSettingsWindow(settingsFile: string): void {
+  if (settingsWin !== null && !settingsWin.isDestroyed()) {
+    settingsWin.show();
+    settingsWin.focus();
+    return;
+  }
+  settingsWin = new BrowserWindow({
+    width: 372,
+    height: 380,
+    resizable: false,
+    minimizable: false,
+    maximizable: false,
+    fullscreenable: false,
+    alwaysOnTop: true,
+    title: 'Kimi Pet 设置',
+    // macOS: keep the traffic lights but hide the title bar itself.
+    titleBarStyle: 'hiddenInset',
+    show: false,
+    webPreferences: {
+      // Local, fully-trusted page written by this process; no remote content.
+      nodeIntegration: true,
+      contextIsolation: false,
+    },
+  });
+  settingsWin.on('closed', () => {
+    settingsWin = null;
+  });
+  settingsWin.webContents.on('did-finish-load', () => {
+    settingsWin?.webContents.send('pet:settings-init', {
+      ...petSettings,
+      version: cliVersion,
+    });
+  });
+  void settingsWin.loadFile(settingsFile).then(() => {
+    settingsWin?.show();
+  });
+}
+
+void app.whenReady().then(() => {
+  const petDir = getPetDir();
+  mkdirSync(petDir, { recursive: true });
+  writePetOverlayHeartbeat();
+  setInterval(writePetOverlayHeartbeat, HEARTBEAT_INTERVAL_MS);
+  petSettings = readPetSettings();
+
+  // The pet is an accessory overlay, not a regular app: no Dock icon, no
+  // Mission Control thumbnail. This also keeps macOS from treating the window
+  // as a regular document window when joining fullscreen spaces.
+  app.dock?.hide();
+
+  const rendererFile = join(petDir, 'overlay-renderer.html');
+  writeFileSync(rendererFile, RENDERER_HTML, 'utf-8');
+  const settingsFile = join(petDir, 'overlay-settings.html');
+  writeFileSync(settingsFile, SETTINGS_HTML, 'utf-8');
+
+  const position = readPetWindowPosition();
+  const workArea = screen.getPrimaryDisplay().workAreaSize;
+  const initialWidth = Math.round(WINDOW_MIN_WIDTH * petSettings.scale);
+  const initialHeight = Math.round(WINDOW_MIN_HEIGHT * petSettings.scale);
+  win = new BrowserWindow({
+    width: initialWidth,
+    height: initialHeight,
+    x: position?.x ?? workArea.width - initialWidth - 24,
+    y: position?.y ?? workArea.height - initialHeight - 24,
+    // `panel` (macOS): an NSPanel can join fullscreen spaces as an auxiliary
+    // window — without it the system refuses to float the pet over fullscreen
+    // apps no matter how high the window level is. Ignored elsewhere.
+    type: 'panel',
+    frame: false,
+    transparent: true,
+    resizable: false,
+    maximizable: false,
+    fullscreenable: false,
+    // Hidden at construction so the always-on-top / all-spaces flags below are
+    // applied before the window is shown; Electron resets the collection
+    // behavior on show, so they are re-applied after `showInactive()`.
+    show: false,
+    alwaysOnTop: true,
+    skipTaskbar: true,
+    hasShadow: false,
+    webPreferences: {
+      // Local, fully-trusted page written by this process; no remote content.
+      nodeIntegration: true,
+      contextIsolation: false,
+    },
+  });
+  win.setAlwaysOnTop(true, 'screen-saver');
+  win.setVisibleOnAllWorkspaces(true, { visibleOnFullScreen: true });
+  win.setHiddenInMissionControl(true);
+  void win.loadFile(rendererFile);
+  win.showInactive();
+  win.on('closed', () => {
+    win = null;
+  });
+  // Re-apply after show: showing can reset the collection behavior, which is
+  // what actually gates floating over fullscreen windows.
+  win.setVisibleOnAllWorkspaces(true, { visibleOnFullScreen: true });
+  win.setAlwaysOnTop(true, 'screen-saver');
+
+  const persistPosition = (): void => {
+    if (win === null) return;
+    const [x, y] = win.getPosition();
+    writePetWindowPosition({ x, y });
+  };
+  win.on('moved', persistPosition);
+  win.on('move', () => {
+    persistPositionDebounced();
+  });
+
+  // Right-click "关闭宠物" in the renderer quits the overlay. The pidfile is
+  // left behind but `kimi pet` detects the dead pid on the next start.
+  ipcMain.on('pet:quit', () => {
+    app.quit();
+  });
+
+  // Bubble action "open session": focus the terminal app that owns the CLI
+  // process. Window-level focus is not portable, so this activates the app.
+  ipcMain.on('pet:open-session', (_event, payload: { termProgram?: string }) => {
+    if (process.platform !== 'darwin' || payload.termProgram === undefined) return;
+    const appName = TERMINAL_APP_NAMES[payload.termProgram] ?? payload.termProgram;
+    const child = spawn(
+      'osascript',
+      ['-e', `tell application "${appName.replaceAll('"', '')}" to activate`],
+      { detached: true, stdio: 'ignore' },
+    );
+    child.unref();
+  });
+
+  // Bubble action "stop": interrupt the session's current turn by sending the
+  // CLI process SIGINT (same as pressing Ctrl-C in its terminal).
+  ipcMain.on('pet:stop-session', (_event, payload: { pid?: number }) => {
+    if (typeof payload.pid !== 'number' || payload.pid === process.pid) return;
+    try {
+      process.kill(payload.pid, 'SIGINT');
+    } catch {
+      // Session process already gone.
+    }
+  });
+
+  // Manual drag from the renderer (see the drag comment in renderer.html).
+  let dragOrigin: { baseX: number; baseY: number; startX: number; startY: number } | null = null;
+  ipcMain.on('pet:drag-start', (_event, point: { x: number; y: number }) => {
+    if (win === null) return;
+    const [baseX, baseY] = win.getPosition();
+    dragOrigin = { baseX, baseY, startX: point.x, startY: point.y };
+  });
+  ipcMain.on('pet:drag-move', (_event, point: { x: number; y: number }) => {
+    if (win === null || dragOrigin === null) return;
+    win.setPosition(
+      Math.round(dragOrigin.baseX + point.x - dragOrigin.startX),
+      Math.round(dragOrigin.baseY + point.y - dragOrigin.startY),
+    );
+  });
+  ipcMain.on('pet:drag-end', () => {
+    dragOrigin = null;
+    persistPosition();
+  });
+
+  // Right-click "设置": open (or focus) the settings window. It is a regular
+  // framed window — unlike the transparent pet, it takes focus normally.
+  ipcMain.on('pet:open-settings', () => {
+    openSettingsWindow(settingsFile);
+  });
+
+  // Settings window edits: forward to the pet renderer immediately (smooth
+  // live preview), persist to settings.json debounced (the size slider fires
+  // continuously while dragged).
+  let settingsWriteTimer: NodeJS.Timeout | undefined;
+  ipcMain.on(
+    'pet:update-settings',
+    (_event, payload: { scale?: number; bubbleFontSize?: number }) => {
+      if (typeof payload.scale === 'number') {
+        petSettings = { ...petSettings, scale: clampPetScale(payload.scale) };
+      }
+      if (typeof payload.bubbleFontSize === 'number') {
+        petSettings = {
+          ...petSettings,
+          bubbleFontSize: clampPetBubbleFontSize(payload.bubbleFontSize),
+        };
+      }
+      if (win !== null && !win.isDestroyed()) {
+        win.webContents.send('pet:settings', petSettings);
+      }
+      clearTimeout(settingsWriteTimer);
+      settingsWriteTimer = setTimeout(() => {
+        writePetSettings(petSettings);
+      }, 300);
+    },
+  );
+
+  // Resize requests from the renderer: the window hugs its content. Growing
+  // keeps the mascot's bottom-center anchored so the pet stays put while the
+  // bubble expands above it.
+  ipcMain.on('pet:resize', (_event, requested: { width?: number; height?: number }) => {
+    if (win === null) return;
+    const scale = petSettings.scale;
+    const maxWidth =
+      Math.max(
+        WINDOW_MIN_WIDTH,
+        petSettings.bubbleFontSize * (BUBBLE_TITLE_MAX_CHARS + 1) + BUBBLE_WIDTH_CHROME,
+      ) * scale;
+    const width = Math.round(
+      Math.min(
+        Math.max(requested.width ?? WINDOW_MIN_WIDTH, WINDOW_MIN_WIDTH * scale),
+        maxWidth,
+      ),
+    );
+    const height = Math.round(
+      Math.min(
+        Math.max(requested.height ?? WINDOW_MIN_HEIGHT, WINDOW_MIN_HEIGHT * scale),
+        WINDOW_MAX_HEIGHT * scale,
+      ),
+    );
+    const [x, y] = win.getPosition();
+    const [currentWidth, currentHeight] = win.getSize();
+    if (width === currentWidth && height === currentHeight) return;
+    win.setBounds({
+      x: Math.round(x + currentWidth / 2 - width / 2),
+      y: Math.round(y + currentHeight - height),
+      width,
+      height,
+    });
+  });
+
+  let moveTimer: NodeJS.Timeout | undefined;
+  function persistPositionDebounced(): void {
+    clearTimeout(moveTimer);
+    moveTimer = setTimeout(persistPosition, 300);
+  }
+
+  const skinDataUrl = loadSkinDataUrl();
+  win.webContents.on('did-finish-load', () => {
+    win?.webContents.send('pet:settings', petSettings);
+    if (skinDataUrl !== undefined) {
+      win?.webContents.send('pet:skin', { dataUrl: skinDataUrl });
+    }
+  });
+
+  setInterval(() => {
+    if (win === null || win.isDestroyed()) return;
+    // Send the top-ranked session's fields plus the full ranked list, so the
+    // renderer can let the user page through session bubbles.
+    const sessions: PetSessionSummary[] = rankSessionStates(readPetSessionStates(), Date.now()).map(
+      (s) => ({
+        sessionId: s.sessionId,
+        status: s.status,
+        statusText: s.statusText,
+        title: s.title,
+        pid: s.pid,
+        termProgram: s.termProgram,
+      }),
+    );
+    const top = sessions[0];
+    const overlayState: PetOverlayState =
+      top === undefined
+        ? { status: 'idle', sessionCount: 0, sessions }
+        : { ...top, sessionCount: sessions.length, sessions };
+    const payload = JSON.stringify(overlayState);
+    if (payload === lastPayload) return;
+    lastPayload = payload;
+    win.webContents.send('pet:state', overlayState);
+  }, POLL_INTERVAL_MS);
+
+  // Eye-tracking: the renderer only sees mouse events while hovered, so the
+  // cursor is polled globally and relayed as window-relative coordinates.
+  let lastCursor = { x: 0, y: 0 };
+  setInterval(() => {
+    if (win === null || win.isDestroyed()) return;
+    const point = screen.getCursorScreenPoint();
+    const [winX, winY] = win.getPosition();
+    const relX = point.x - winX;
+    const relY = point.y - winY;
+    if (Math.abs(relX - lastCursor.x) < 2 && Math.abs(relY - lastCursor.y) < 2) return;
+    lastCursor = { x: relX, y: relY };
+    win.webContents.send('pet:cursor', lastCursor);
+  }, CURSOR_POLL_INTERVAL_MS);
+});
+
+app.on('window-all-closed', () => {
+  app.quit();
+});

--- a/apps/kimi-code/src/pet/overlay/renderer.html
+++ b/apps/kimi-code/src/pet/overlay/renderer.html
@@ -1,0 +1,1106 @@
+<!doctype html>
+<html lang="zh">
+  <head>
+    <meta charset="utf-8" />
+    <style>
+      html,
+      body {
+        margin: 0;
+        padding: 0;
+        width: 100%;
+        height: 100%;
+        background: transparent;
+        overflow: hidden;
+        -webkit-user-select: none;
+        user-select: none;
+        font-family:
+          -apple-system, 'PingFang SC', 'Segoe UI', 'Microsoft YaHei', sans-serif;
+      }
+      #bubble {
+        display: none;
+        /* anchored to the mascot's head (chip zone included), so the bubble
+           always floats directly above the pet regardless of window height */
+        position: absolute;
+        left: 50%;
+        bottom: 181px;
+        transform: translateX(-50%);
+        align-items: center;
+        gap: 8px;
+        width: fit-content;
+        /* follows the font-size-dependent text cap (set from JS); the default
+           matches the 13px base font */
+        max-width: var(--bubble-max-w, 335px);
+        margin: 0;
+        padding: 9px 11px 9px 15px;
+        border-radius: 18px;
+        background: rgba(255, 255, 255, 0.98);
+        box-shadow:
+          0 10px 30px rgba(31, 35, 50, 0.14),
+          0 2px 8px rgba(31, 35, 50, 0.08);
+        animation: bubble-in 0.18s ease-out;
+      }
+      #bubble.visible {
+        display: flex;
+      }
+      #bubble-text {
+        min-width: 0;
+      }
+      #bubble-title {
+        display: none;
+        font-size: var(--bubble-title-size, 13px);
+        font-weight: 500;
+        line-height: 1.4;
+        color: #2b2f3a;
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        max-width: var(--bubble-text-max-w, 220px);
+      }
+      #bubble-title.visible {
+        display: block;
+      }
+      #bubble-status {
+        font-size: var(--bubble-status-size, 11.5px);
+        line-height: 1.4;
+        color: #8a90a0;
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        max-width: var(--bubble-text-max-w, 220px);
+      }
+      #bubble-title:not(.visible) + #bubble-status {
+        font-size: var(--bubble-solo-size, 12.5px);
+        color: #3a3f4b;
+      }
+      /* action buttons on the right of the bubble (open / stop) */
+      #bubble-actions {
+        display: none;
+        gap: 4px;
+        margin-left: 2px;
+      }
+      #bubble-actions.visible {
+        display: flex;
+      }
+      #bubble-actions button {
+        width: 22px;
+        height: 22px;
+        padding: 0;
+        border: none;
+        border-radius: 50%;
+        background: #eef1f6;
+        color: #5a6274;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        cursor: pointer;
+      }
+      #bubble-actions button:hover {
+        background: #e0e5ef;
+        color: #2b2f3a;
+      }
+      /* green check badge shown when the task completes */
+      #bubble-done-badge {
+        display: none;
+        width: 22px;
+        height: 22px;
+        margin-left: 2px;
+        border-radius: 50%;
+        background: #e6f6e9;
+        color: #34a853;
+        align-items: center;
+        justify-content: center;
+      }
+      #bubble-done-badge.visible {
+        display: flex;
+      }
+      #bubble.awaiting {
+        animation:
+          bubble-in 0.18s ease-out,
+          bubble-glow 1.4s ease-in-out infinite;
+      }
+      @keyframes bubble-in {
+        from {
+          opacity: 0;
+          transform: translateX(-50%) translateY(4px);
+        }
+        to {
+          opacity: 1;
+          transform: translateX(-50%) translateY(0);
+        }
+      }
+      @keyframes bubble-glow {
+        0%,
+        100% {
+          box-shadow:
+            0 10px 30px rgba(31, 35, 50, 0.14),
+            0 2px 8px rgba(31, 35, 50, 0.08);
+        }
+        50% {
+          box-shadow:
+            0 10px 30px rgba(224, 175, 104, 0.45),
+            0 2px 10px rgba(224, 175, 104, 0.3);
+        }
+      }
+      /* little round chevron chip between the bubble and the mascot's head:
+         down-chevron collapses the bubble, up-chevron expands it again */
+      #bubble-chip {
+        display: none;
+        position: absolute;
+        left: 50%;
+        bottom: 158px;
+        transform: translateX(-50%);
+        width: 18px;
+        height: 18px;
+        margin: 0;
+        border-radius: 50%;
+        background: rgba(255, 255, 255, 0.98);
+        box-shadow: 0 4px 12px rgba(31, 35, 50, 0.16);
+        cursor: pointer;
+      }
+      #bubble-chip.visible {
+        display: block;
+      }
+      #bubble-chip::before {
+        content: '';
+        display: block;
+        width: 6px;
+        height: 6px;
+        margin: 4px auto 0;
+        border-right: 1.6px solid #8a90a0;
+        border-bottom: 1.6px solid #8a90a0;
+        transform: rotate(45deg);
+      }
+      #bubble-chip.expand::before {
+        margin: 7px auto 0;
+        transform: rotate(-135deg);
+      }
+      #pet {
+        position: absolute;
+        bottom: 0;
+        left: 50%;
+        transform: translateX(-50%);
+      }
+      #stage {
+        position: relative;
+        width: 100%;
+        height: 100%;
+      }
+      /* right-click popup. It lives OUTSIDE #stage on purpose: UI chrome must
+         not scale with the pet — only its anchor point tracks the mascot's
+         head (bottom set from JS as 100 * scale). The 24px right offset keeps
+         the drop shadow inside the transparent window. */
+      #pet-menu {
+        display: none;
+        position: absolute;
+        right: 24px;
+        /* JS overrides this as 100 * scale whenever the scale changes */
+        bottom: 100px;
+        padding: 6px;
+        border-radius: 12px;
+        background: rgba(255, 255, 255, 0.98);
+        color: #3a3f4b;
+        font-size: 12px;
+        line-height: 1;
+        white-space: nowrap;
+        box-shadow:
+          0 8px 24px rgba(31, 35, 50, 0.16),
+          0 2px 6px rgba(31, 35, 50, 0.08);
+        animation: menu-in 0.15s ease-out;
+        z-index: 10;
+      }
+      @keyframes menu-in {
+        from {
+          opacity: 0;
+          transform: translateY(4px);
+        }
+        to {
+          opacity: 1;
+          transform: translateY(0);
+        }
+      }
+      #pet-menu.visible {
+        display: flex;
+        flex-direction: column;
+        gap: 4px;
+      }
+      .pet-menu-item {
+        padding: 7px 10px;
+        border-radius: 8px;
+        cursor: pointer;
+      }
+      .pet-menu-item:hover {
+        background: #f0f2f7;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="stage">
+      <div id="bubble">
+        <div id="bubble-text">
+          <div id="bubble-title"></div>
+          <div id="bubble-status"></div>
+        </div>
+        <div id="bubble-actions">
+          <button id="bubble-open" type="button" title="打开会话">
+            <svg viewBox="0 0 12 12" width="11" height="11">
+              <path
+                d="M7 2.5 3.5 6 7 9.5"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="1.6"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              />
+              <path
+                d="M3.8 6H10"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="1.6"
+                stroke-linecap="round"
+              />
+            </svg>
+          </button>
+          <button id="bubble-stop" type="button" title="终止当前任务">
+            <svg viewBox="0 0 12 12" width="9" height="9">
+              <rect x="1.5" y="1.5" width="9" height="9" rx="2" fill="currentColor" />
+            </svg>
+          </button>
+        </div>
+        <div id="bubble-done-badge" title="任务完成">
+          <svg viewBox="0 0 12 12" width="11" height="11">
+            <path
+              d="M2.5 6.5 5 9 9.5 3.5"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="1.8"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+            />
+          </svg>
+        </div>
+      </div>
+      <div id="bubble-chip" title="收起"></div>
+      <canvas id="pet" width="300" height="312" style="width: 150px; height: 156px"></canvas>
+    </div>
+    <div id="pet-menu">
+      <div id="pet-menu-settings" class="pet-menu-item">设置</div>
+      <div id="pet-menu-close" class="pet-menu-item">关闭宠物</div>
+    </div>
+    <script>
+      const canvas = document.getElementById('pet');
+      const ctx = canvas.getContext('2d');
+      ctx.scale(2, 2);
+      const bubble = document.getElementById('bubble');
+      const bubbleChip = document.getElementById('bubble-chip');
+      const bubbleTitle = document.getElementById('bubble-title');
+      const bubbleStatus = document.getElementById('bubble-status');
+      const bubbleActions = document.getElementById('bubble-actions');
+      const bubbleDoneBadge = document.getElementById('bubble-done-badge');
+      // The chip toggles the bubble between collapsed and expanded.
+      let dismissedText = null;
+      bubbleChip.addEventListener('click', () => {
+        const text = bubbleSession.statusText ?? null;
+        dismissedText = dismissedText === text ? null : text;
+        renderBubble();
+      });
+
+      // Right-click popup: 设置 (opens the settings window) + 关闭宠物 (quits).
+      const petMenu = document.getElementById('pet-menu');
+      function setMenuVisible(visible) {
+        petMenu.classList.toggle('visible', visible);
+        requestResize();
+      }
+      document.addEventListener('contextmenu', (event) => {
+        event.preventDefault();
+        // Always open (never toggle): some synthetic right-clicks deliver the
+        // event twice, and a toggle would open-then-close.
+        setMenuVisible(true);
+      });
+      document.addEventListener('click', (event) => {
+        if (!petMenu.contains(event.target)) {
+          setMenuVisible(false);
+        }
+      });
+      document.addEventListener('keydown', (event) => {
+        if (event.key === 'Escape') setMenuVisible(false);
+      });
+      document.getElementById('pet-menu-settings').addEventListener('click', () => {
+        setMenuVisible(false);
+        ipcRenderer?.send('pet:open-settings');
+      });
+      document.getElementById('pet-menu-close').addEventListener('click', () => {
+        ipcRenderer?.send('pet:quit');
+      });
+
+      // Display scale (settings window slider). Pet content scales via CSS
+      // zoom on #stage; the canvas backing store is resized to stay crisp on
+      // retina screens. The menu is UI chrome and stays at a fixed size —
+      // only its anchor follows the mascot's head.
+      let petScale = 1;
+      function applyScale(scale) {
+        petScale = scale;
+        document.getElementById('stage').style.zoom = scale;
+        canvas.width = Math.round(300 * scale);
+        canvas.height = Math.round(312 * scale);
+        ctx.setTransform(2 * scale, 0, 0, 2 * scale, 0, 0);
+        petMenu.style.bottom = `${Math.round(100 * scale)}px`;
+        requestResize();
+      }
+
+      // Bubble text size (settings window input). The title line uses the
+      // base size; the status line and the solo-status variant derive from
+      // it. Applied as CSS variables so the `:not(.visible)` selector keeps
+      // working, and re-measured for the window-fit resize below. The text
+      // width cap also grows with the font size, so the 20-character title
+      // limit — not the CSS max-width — is what ellipsizes.
+      let bubbleFontSize = 13;
+      function applyBubbleFontSize(size) {
+        bubbleFontSize = size;
+        const rootStyle = document.documentElement.style;
+        rootStyle.setProperty('--bubble-title-size', `${size}px`);
+        rootStyle.setProperty('--bubble-status-size', `${size - 1.5}px`);
+        rootStyle.setProperty('--bubble-solo-size', `${size - 0.5}px`);
+        rootStyle.setProperty('--bubble-text-max-w', `${bubbleTextMaxW()}px`);
+        rootStyle.setProperty(
+          '--bubble-max-w',
+          `${bubbleTextMaxW() + BUBBLE_PAD_X + BUBBLE_ACTIONS_W}px`,
+        );
+        renderBubble();
+      }
+
+      // Manual dragging. `-webkit-app-region: drag` is NOT used on purpose:
+      // right-clicking a drag region is treated like a titlebar click and
+      // never reaches the page, which would kill the contextmenu popup above.
+      // Pointer capture keeps the drag alive when the cursor leaves the window.
+      let hovered = false;
+      let dragging = false;
+      let dragDir = 0;
+      let lastDragX = 0;
+      let currentT = 0;
+      let hoverSince = 0;
+      let dragSince = 0;
+      document.body.addEventListener('pointerenter', () => {
+        hovered = true;
+        hoverSince = currentT;
+      });
+      document.body.addEventListener('pointerleave', () => {
+        hovered = false;
+      });
+      let dragStart = null;
+      // Session-count badge hit test: the badge is drawn at (132, 22) r12 in
+      // the canvas's 150x156 CSS-pixel space. Clicking it pages sessions.
+      function isOnSessionBadge(event) {
+        const rect = canvas.getBoundingClientRect();
+        if (rect.width === 0 || rect.height === 0) return false;
+        const x = ((event.clientX - rect.left) / rect.width) * 150;
+        const y = ((event.clientY - rect.top) / rect.height) * 156;
+        return Math.hypot(x - 132, y - 22) <= 15;
+      }
+      document.addEventListener('pointerdown', (event) => {
+        if (event.button !== 0) return;
+        if (event.target.closest?.('#bubble, #bubble-chip, #pet-menu')) return;
+        if (petState.sessionCount > 1 && isOnSessionBadge(event)) {
+          cycleSession(1);
+          return;
+        }
+        dragStart = { x: event.screenX, y: event.screenY };
+        dragging = true;
+        dragDir = 0;
+        lastDragX = event.screenX;
+        dragSince = currentT;
+        try {
+          event.target.setPointerCapture?.(event.pointerId);
+        } catch {}
+        ipcRenderer?.send('pet:drag-start', dragStart);
+      });
+      document.addEventListener('pointermove', (event) => {
+        if (dragStart === null) return;
+        const dx = event.screenX - lastDragX;
+        if (Math.abs(dx) > 0.5) {
+          dragDir = Math.sign(dx);
+          lastDragX = event.screenX;
+        }
+        ipcRenderer?.send('pet:drag-move', { x: event.screenX, y: event.screenY });
+      });
+      document.addEventListener('pointerup', () => {
+        if (dragStart === null) return;
+        dragStart = null;
+        dragging = false;
+        dragDir = 0;
+        ipcRenderer?.send('pet:drag-end');
+      });
+
+      // The mascot (body color, work rings, attention marker, celebration)
+      // always reflects the MOST URGENT session — it never follows manual
+      // bubble paging. `petState` is that top-ranked session's state.
+      let petState = { status: 'idle', statusText: undefined, sessionCount: 0 };
+      // Which session the BUBBLE shows. Equals the top session by default;
+      // swiping on the bubble or clicking the count badge pages through the
+      // rest of the ranked list without touching the mascot's status.
+      let bubbleSession = petState;
+      // Switchable session list from the main process (ranked: highest
+      // priority first — awaiting > failed > working > done > idle).
+      let sessionList = [];
+      let selectedSessionId = null;
+      let manualSelectUntil = 0;
+      let lastTopKey = null;
+      let skinImg = null;
+      let ipcRenderer = null;
+      // Task-complete celebration: plays once per transition into `done`
+      // (null while idle). `lastStatus` edges the trigger; it is seeded with
+      // the first received status so launching into an already-done session
+      // does not fire the animation.
+      let celebration = null;
+      let lastStatus = null;
+      // Window-relative cursor position relayed from the main process (global
+      // polling), so the eyes can follow the cursor even outside the window.
+      let cursorPos = null;
+      const gaze = { x: 0, y: 0 };
+
+      // Which session the bubble shows: the top-ranked one, unless the user
+      // has recently paged to another session that is still live. A NEW
+      // urgent session (awaiting/failed reaching the top) always preempts a
+      // manual selection; an urgent top the user already paged away from
+      // waits for the manual window to expire.
+      function pickDisplayedSession(fallback) {
+        if (sessionList.length === 0) return fallback;
+        const top = sessionList[0];
+        const topKey = `${top.sessionId}:${top.status}`;
+        const urgent =
+          (top.status === 'awaiting' || top.status === 'failed') && topKey !== lastTopKey;
+        lastTopKey = topKey;
+        const manual = sessionList.find((s) => s.sessionId === selectedSessionId);
+        if (manual !== undefined && !urgent && Date.now() < manualSelectUntil) {
+          return { ...manual, sessionCount: sessionList.length };
+        }
+        selectedSessionId = null;
+        return { ...top, sessionCount: sessionList.length };
+      }
+
+      // Page to the previous/next session bubble (dir = ±1), pinning the
+      // selection for a short manual-browsing window. Only the bubble
+      // changes — the mascot keeps showing the most urgent session.
+      function cycleSession(dir) {
+        if (sessionList.length < 2) return;
+        const currentId = selectedSessionId ?? sessionList[0].sessionId;
+        const current = Math.max(
+          0,
+          sessionList.findIndex((s) => s.sessionId === currentId),
+        );
+        const next = sessionList[(current + dir + sessionList.length) % sessionList.length];
+        selectedSessionId = next.sessionId;
+        manualSelectUntil = Date.now() + 10_000;
+        dismissedText = null; // always reveal the newly selected bubble
+        bubbleSession = { ...next, sessionCount: sessionList.length };
+        renderBubble();
+      }
+
+      // Smoothed gaze as a unit direction + magnitude (0..1), so both the
+      // horizontal head-turn and the vertical eye travel are driven by WHERE
+      // the cursor is, not by raw pixel offsets. Magnitude ramps over ~180px
+      // so a cursor sitting on the pet does not max the gaze out.
+      function updateGaze() {
+        let dirX = 0;
+        let dirY = 0;
+        let mag = 0;
+        if (cursorPos !== null) {
+          const w = window.innerWidth;
+          const h = window.innerHeight;
+          // Mascot eye line: horizontally centered, 76 * scale px above the
+          // window bottom (canvas is bottom-anchored, eyes sit mid-canvas).
+          const dx = cursorPos.x - w / 2;
+          const dy = cursorPos.y - (h - 76 * petScale);
+          const len = Math.hypot(dx, dy) || 1;
+          dirX = dx / len;
+          dirY = dy / len;
+          mag = Math.min(1, len / 180);
+        }
+        gaze.x += (dirX * mag - gaze.x) * 0.18;
+        gaze.y += (dirY * mag - gaze.y) * 0.18;
+      }
+
+      try {
+        ipcRenderer = require('electron').ipcRenderer;
+        ipcRenderer.on('pet:state', (_e, state) => {
+          sessionList = state.sessions ?? [];
+          // The mascot state always tracks the top-ranked (most urgent)
+          // session; the celebration edges on it too.
+          const prev = lastStatus ?? state.status;
+          if (prev !== 'done' && state.status === 'done') {
+            celebration = createCelebration(currentT);
+          }
+          lastStatus = state.status;
+          petState = {
+            status: state.status,
+            statusText: state.statusText,
+            title: state.title,
+            pid: state.pid,
+            termProgram: state.termProgram,
+            sessionCount: state.sessionCount,
+          };
+          bubbleSession = pickDisplayedSession(petState);
+          renderBubble();
+        });
+        ipcRenderer.on('pet:skin', (_e, skin) => {
+          const img = new Image();
+          img.onload = () => {
+            skinImg = img;
+          };
+          img.src = skin.dataUrl;
+        });
+        ipcRenderer.on('pet:settings', (_e, settings) => {
+          if (typeof settings.scale === 'number') applyScale(settings.scale);
+          if (typeof settings.bubbleFontSize === 'number') applyBubbleFontSize(settings.bubbleFontSize);
+        });
+        ipcRenderer.on('pet:cursor', (_e, point) => {
+          cursorPos = point;
+        });
+      } catch (err) {
+        // No IPC (e.g. opened as a plain file) — stay in procedural idle mode.
+      }
+
+      // The window hugs its content: mascot-only while no bubble is shown,
+      // growing to fit the bubble otherwise (the main process keeps the
+      // mascot's bottom-center anchored). Text width is measured directly so
+      // the request does not depend on layout timing.
+      const measureCtx = document.createElement('canvas').getContext('2d');
+      const FONT_FAMILY = '-apple-system, "PingFang SC", "Segoe UI", "Microsoft YaHei", sans-serif';
+      const bubbleTitleFont = () => `500 ${bubbleFontSize}px ${FONT_FAMILY}`;
+      const bubbleStatusFont = () => `${bubbleFontSize - 1.5}px ${FONT_FAMILY}`;
+      // The title is capped at 20 characters (see truncateTitle); the text
+      // width cap follows the font size so those 20 characters plus the
+      // ellipsis glyph actually fit — CJK glyphs are ~1em wide.
+      // pet-overlay.ts derives its max window width from the same constant.
+      const BUBBLE_TITLE_MAX_CHARS = 20;
+      const bubbleTextMaxW = () => bubbleFontSize * (BUBBLE_TITLE_MAX_CHARS + 1);
+      // Horizontal chrome around the text, matching the CSS exactly: bubble
+      // padding 15+11; the actions cluster is margin 2 + gap 8 + two 22px
+      // buttons with gap 4; the done badge is margin 2 + gap 8 + 22px.
+      const BUBBLE_PAD_X = 26;
+      const BUBBLE_ACTIONS_W = 58;
+      const BUBBLE_BADGE_W = 32;
+      const bubbleLineTitleH = () => bubbleFontSize + 6;
+      const bubbleLineStatusH = () => bubbleFontSize + 4;
+      const BUBBLE_PAD_Y = 18; // 9px padding top + bottom
+      const CHIP_H = 23; // 18px + margins around it
+      // Transparent slack around the bubble so its drop shadow stays inside
+      // the window instead of being sliced by the frame edge.
+      const SHADOW_SLACK_X = 48; // 24px per side
+      const MASCOT_H = 156;
+      const TOP_SLACK = 12;
+      // Menu anchor: its bottom edge sits this many (scaled) px above the
+      // window bottom, hovering next to the mascot's head.
+      const MENU_ANCHOR_BOTTOM = 100;
+      let lastSentSize = { width: 0, height: 0 };
+
+      function requestResize() {
+        const s = petScale;
+        let width = 170 * s;
+        let height = (MASCOT_H + 4) * s;
+        if (bubble.classList.contains('visible') && bubbleSession.statusText) {
+          const hasTitle = Boolean(bubbleSession.title);
+          const active = bubbleSession.status === 'working' || bubbleSession.status === 'awaiting';
+          const done = bubbleSession.status === 'done';
+          measureCtx.font = bubbleTitleFont();
+          const titleW = hasTitle ? measureCtx.measureText(truncateTitle(bubbleSession.title)).width : 0;
+          measureCtx.font = bubbleStatusFont();
+          const statusW = measureCtx.measureText(bubbleSession.statusText).width;
+          const textW = Math.min(Math.max(titleW, statusW), bubbleTextMaxW());
+          const sideW = active ? BUBBLE_ACTIONS_W : done ? BUBBLE_BADGE_W : 0;
+          const bubbleW = textW + BUBBLE_PAD_X + sideW;
+          const bubbleH =
+            (hasTitle ? bubbleLineTitleH() : 0) + bubbleLineStatusH() + BUBBLE_PAD_Y;
+          width = Math.max(width, (bubbleW + SHADOW_SLACK_X) * s);
+          // mascot + chip zone + bubble + top slack
+          height = Math.max(height, 4 + (MASCOT_H + CHIP_H) * s + bubbleH * s + TOP_SLACK);
+        }
+        if (petMenu.classList.contains('visible')) {
+          // Fixed-size chrome: measured in screen px, not scaled.
+          const menuW = petMenu.offsetWidth || 120;
+          const menuH = petMenu.offsetHeight || 70;
+          width = Math.max(width, menuW + SHADOW_SLACK_X);
+          height = Math.max(height, 4 + MENU_ANCHOR_BOTTOM * s + menuH + TOP_SLACK);
+        }
+        // The expand/collapse chip needs its zone even while the bubble itself
+        // is collapsed.
+        if (bubbleChip.classList.contains('visible')) {
+          height = Math.max(height, (MASCOT_H + CHIP_H + 6) * s);
+        }
+        width = Math.round(width);
+        height = Math.round(height);
+        if (width !== lastSentSize.width || height !== lastSentSize.height) {
+          lastSentSize = { width, height };
+          ipcRenderer?.send('pet:resize', { width, height });
+        }
+      }
+
+      // The bubble title (prompt summary) shows at most 20 characters per
+      // line; the rest collapses into an ellipsis.
+      function truncateTitle(title) {
+        return title.length > BUBBLE_TITLE_MAX_CHARS
+          ? `${title.slice(0, BUBBLE_TITLE_MAX_CHARS)}…`
+          : title;
+      }
+
+      function renderBubble() {
+        const text = bubbleSession.statusText;
+        const dismissed = Boolean(text) && text === dismissedText;
+        const visible = Boolean(text) && !dismissed;
+        bubble.classList.toggle('visible', visible);
+        bubbleChip.classList.toggle('visible', Boolean(text));
+        bubbleChip.classList.toggle('expand', dismissed);
+        bubbleChip.title = dismissed ? '展开' : '收起';
+        if (!visible) {
+          requestResize();
+          return;
+        }
+        const hasTitle = Boolean(bubbleSession.title);
+        bubbleTitle.classList.toggle('visible', hasTitle);
+        bubbleTitle.textContent = truncateTitle(bubbleSession.title ?? '');
+        bubbleStatus.textContent = text;
+        const active = bubbleSession.status === 'working' || bubbleSession.status === 'awaiting';
+        bubbleActions.classList.toggle('visible', active);
+        bubbleDoneBadge.classList.toggle('visible', bubbleSession.status === 'done');
+        bubble.className = `visible ${bubbleSession.status}`;
+        requestResize();
+      }
+
+      document.getElementById('bubble-open').addEventListener('click', () => {
+        ipcRenderer?.send('pet:open-session', { termProgram: bubbleSession.termProgram });
+      });
+      document.getElementById('bubble-stop').addEventListener('click', () => {
+        ipcRenderer?.send('pet:stop-session', { pid: bubbleSession.pid });
+      });
+
+      // Paging between session bubbles: a horizontal two-finger swipe (or a
+      // vertical scroll) on the bubble cycles to the previous/next session.
+      // Wheel events stream continuously during one gesture (plus a decaying
+      // momentum tail), so accumulate and step once per threshold, treat a
+      // 150ms gap as a new gesture, and cool down briefly between steps so
+      // one flick does not flip twice.
+      let wheelAccum = 0;
+      let lastWheelAt = 0;
+      let wheelCooldownUntil = 0;
+      bubble.addEventListener(
+        'wheel',
+        (event) => {
+          if (sessionList.length < 2) return;
+          event.preventDefault();
+          const now = Date.now();
+          if (now < wheelCooldownUntil) return;
+          if (now - lastWheelAt > 150) wheelAccum = 0;
+          lastWheelAt = now;
+          const delta =
+            Math.abs(event.deltaX) > Math.abs(event.deltaY) ? event.deltaX : event.deltaY;
+          wheelAccum += delta;
+          if (Math.abs(wheelAccum) >= 40) {
+            cycleSession(Math.sign(wheelAccum));
+            wheelAccum = 0;
+            wheelCooldownUntil = now + 300;
+          }
+        },
+        { passive: false },
+      );
+
+      // Codex pet atlas layout: 8 cols x 9 rows of 192x208 cells.
+      const SKIN_ROWS = [6, 8, 8, 4, 5, 8, 6, 6, 6]; // frames per row
+      const STATUS_ROW = { idle: 0, working: 7, awaiting: 6, done: 8, failed: 5 };
+      const CELL_W = 192;
+      const CELL_H = 208;
+
+      function drawSkin(t) {
+        const row = STATUS_ROW[petState.status] ?? 0;
+        const frames = SKIN_ROWS[row];
+        const frame = Math.floor(t * 8) % frames;
+        ctx.drawImage(
+          skinImg,
+          frame * CELL_W,
+          row * CELL_H,
+          CELL_W,
+          CELL_H,
+          15,
+          13,
+          120,
+          130,
+        );
+      }
+
+      // Built-in look: a replica of the Kimi mascot from the web UI (the SVG
+      // fallback of the Rive KimiMascot component) — a blue gradient ball with
+      // two white capsule eyes. Coordinates below are in the original SVG
+      // space (viewBox 5 0 240.776 240.776) and get scaled into the canvas by
+      // drawMascot.
+      const SVG_CX = 125.388;
+      const SVG_CY = 120.388;
+      const SVG_R = 120.388;
+      // Eye slant / turn is modeled as a pseudo-3D head rotation (the same
+      // idea as Live2D's Angle X): each eye is anchored at a base angle on an
+      // imaginary sphere around the head; gazing adds a yaw, and the eye's
+      // screen position (sin), width (cos foreshortening) and slant all
+      // follow from the projected angle. Turning right therefore moves the
+      // right eye outward with a slant while the left eye settles back to the
+      // center — and vice versa. Eyes sit perfectly straight at rest.
+      const EYE_ORBIT_R = 55; // eye orbit radius, SVG units
+      const HEAD_YAW_MAX = 0.45; // ~26°
+      const EYE_TILT_MAX = 0.21; // ~12°
+      const EYES = [
+        { cx: 128.7, cy: 83.9, w: 31, h: 57, dy: 0 },
+        { cx: 190.2, cy: 75.4, w: 27.5, h: 52, dy: 8.5 },
+      ];
+      // Base surface angle of each eye on the imaginary sphere (the eye group
+      // carries a -33.4 x-offset in the original SVG, accounted for here).
+      const EYE_BASE_ANGLES = EYES.map((eye) =>
+        Math.asin(Math.max(-1, Math.min(1, (eye.cx - 33.4 - SVG_CX) / EYE_ORBIT_R))),
+      );
+      // Vertical gaze: eyes travel up/down the face along the pitch arc, and
+      // foreshorten in height as they approach the top/bottom edge.
+      const HEAD_PITCH_MAX = 0.55; // ~31°
+      const EYE_PITCH_TRAVEL = 30; // SVG units at full pitch
+      const EYE_PITCH_SQUASH = 0.18;
+      const BODY_STOPS = {
+        normal: ['#117DFB', '#449BFF', '#77B6FF'],
+        awaiting: ['#E8950B', '#F5B82E', '#FCDA7E'],
+        failed: ['#C81E1E', '#F04438', '#F98A80'],
+      };
+
+      // Working effect: waves of three glowing tech-blue halos. One wave =
+      // three consecutive rings (small phase spacing) rising from the feet to
+      // above the head; once the whole wave has left the top there is a quiet
+      // beat before the next wave starts. Ring width follows the travel
+      // sinusoidally — narrowest at the two ends, widest at the middle. Each
+      // ring is drawn in two halves — the back arc goes behind the body and
+      // the front arc over it, so the rings visibly wrap around the ball.
+      const RING_COUNT = 3;
+      const RING_TRAVEL_S = 1.6; // one ring's rise time
+      const RING_WAVE_PAUSE_S = 1.0; // quiet beat between waves
+      const RING_WAVE_S = RING_TRAVEL_S + RING_WAVE_PAUSE_S;
+      const RING_SPACING = 0.08; // phase offset between consecutive rings
+      const RING_MIN_RX = 18;
+      const RING_MAX_RX = 72;
+      const RING_COLOR = '#54c8ff';
+
+      function workRingGeometry(t, cy, index) {
+        const base = Math.min(1, (t % RING_WAVE_S) / RING_TRAVEL_S);
+        const p = base + index * RING_SPACING;
+        const y = cy + 62 - p * 128;
+        const rx = RING_MIN_RX + (RING_MAX_RX - RING_MIN_RX) * Math.sin(p * Math.PI);
+        // fade in/out at the two ends of the travel; p > 1 means this ring of
+        // the wave has already left the top (wave pause) and stays invisible
+        const alpha = p > 1 ? 0 : Math.min(1, Math.min(p, 1 - p) * 6);
+        return { y, rx, ry: rx * 0.28, alpha };
+      }
+
+      function drawWorkRing(t, cy, half) {
+        if (petState.status !== 'working') return;
+        ctx.save();
+        ctx.strokeStyle = RING_COLOR;
+        ctx.lineWidth = 2.5;
+        ctx.lineCap = 'round';
+        ctx.shadowColor = 'rgba(84, 200, 255, 0.8)';
+        ctx.shadowBlur = 9;
+        for (let i = 0; i < RING_COUNT; i++) {
+          const ring = workRingGeometry(t, cy, i);
+          if (ring.alpha <= 0) continue;
+          ctx.globalAlpha = ring.alpha * (half === 'back' ? 0.55 : 0.9);
+          ctx.beginPath();
+          if (half === 'back') {
+            ctx.ellipse(75, ring.y, ring.rx, ring.ry, 0, Math.PI, 2 * Math.PI);
+          } else {
+            ctx.ellipse(75, ring.y, ring.rx, ring.ry, 0, 0, Math.PI);
+          }
+          ctx.stroke();
+        }
+        ctx.restore();
+      }
+
+      function drawEyeCapsule(eye, projCx, heightScale, gazeDy, tilt, wScale) {
+        const h = eye.h * heightScale;
+        const w = eye.w * wScale;
+        ctx.save();
+        ctx.translate(projCx, eye.cy + eye.dy + gazeDy);
+        ctx.rotate(tilt);
+        ctx.beginPath();
+        ctx.roundRect(-w / 2, -h / 2, w, h, w / 2);
+        ctx.fillStyle = '#ffffff';
+        ctx.fill();
+        ctx.restore();
+      }
+
+      function drawCrossEye(eye, projCx, gazeDy, tilt, wScale) {
+        ctx.save();
+        ctx.translate(projCx, eye.cy + eye.dy + gazeDy);
+        ctx.rotate(tilt);
+        ctx.strokeStyle = '#3c4257';
+        ctx.lineWidth = 7;
+        ctx.lineCap = 'round';
+        const r = 13 * wScale;
+        for (const [dx1, dy1, dx2, dy2] of [
+          [-r, -r, r, r],
+          [-r, r, r, -r],
+        ]) {
+          ctx.beginPath();
+          ctx.moveTo(dx1, dy1);
+          ctx.lineTo(dx2, dy2);
+          ctx.stroke();
+        }
+        ctx.restore();
+      }
+
+      function drawMascot(t) {
+        const status = petState.status;
+        // Interaction animations (hover hop / drag hop) take priority over
+        // status bobbing so the two never fight each other.
+        const interactive = dragging || hovered;
+        let bob = 0;
+        if (!interactive) {
+          if (status === 'idle') bob = Math.sin(t * 1.6) * 3;
+          else if (status === 'working') bob = Math.sin(t * 6) * 4;
+          else if (status === 'awaiting') bob = -Math.abs(Math.sin(t * 5)) * 12;
+          else if (status === 'done') bob = Math.sin(t * 4) * 5;
+          else if (status === 'failed') bob = 6;
+        }
+        const statusTilt = !interactive && status === 'working' ? Math.sin(t * 3) * 0.06 : 0;
+
+        // Hop arcs use a parabola (0→1→0, peak mid-flight) plus squash &
+        // stretch anchored at the feet; each interaction starts its phase
+        // from its own timestamp so the motion never pops mid-cycle.
+        let hop = 0;
+        let lean = 0;
+        let pushX = 0;
+        let squash = 1;
+        if (dragging) {
+          const phase = ((t - dragSince) * 3.0) % 1;
+          const arc = 4 * phase * (1 - phase);
+          hop = -15 * arc;
+          lean = dragDir * (0.05 + 0.14 * arc);
+          pushX = dragDir * 4 * arc;
+          squash = 1 - 0.07 * Math.cos(phase * 2 * Math.PI);
+        } else if (hovered) {
+          const phase = ((t - hoverSince) * 2.2) % 1;
+          const arc = 4 * phase * (1 - phase);
+          hop = -9 * arc;
+          squash = 1 - 0.05 * Math.cos(phase * 2 * Math.PI);
+        } else if (celebration !== null && t - celebration.startT < 0.95) {
+          // celebration: two joyful hops, same parabola family as above
+          const phase = ((t - celebration.startT) * 2.1) % 1;
+          const arc = 4 * phase * (1 - phase);
+          hop = -13 * arc;
+          squash = 1 - 0.06 * Math.cos(phase * 2 * Math.PI);
+        }
+
+        const cx = 75 + pushX;
+        const cy = 88 + bob + hop;
+        const scale = 118 / (SVG_R * 2);
+        const tilt = statusTilt + lean;
+        const blinking =
+          !interactive && t % 3.4 < 0.12 && (status === 'idle' || status === 'working');
+        const eyeScale = blinking ? 0.12 : 1;
+
+        const celebE =
+          celebration !== null && t - celebration.startT < CELE_TOTAL_S
+            ? t - celebration.startT
+            : -1;
+
+        // shadow: stays on the ground, shrinking and fading as the pet rises
+        const lift = bob + hop;
+        ctx.fillStyle = `rgba(0,0,0,${Math.max(0.07, 0.18 + lift * 0.005)})`;
+        ctx.beginPath();
+        ctx.ellipse(cx, 146, Math.max(18, 34 + lift * 0.55), 6, 0, 0, Math.PI * 2);
+        ctx.fill();
+
+        drawCelebration(t, cx, cy, 'back');
+
+        drawWorkRing(t, cy, 'back');
+
+        ctx.save();
+        ctx.translate(cx, cy);
+        // squash & stretch around the feet (canvas-space body radius is ~46)
+        ctx.translate(0, 46);
+        ctx.scale(1 / Math.sqrt(squash), squash);
+        ctx.translate(0, -46);
+        ctx.rotate(tilt);
+        ctx.scale(scale, scale);
+        ctx.translate(-SVG_CX, -SVG_CY);
+
+        // body: base color + radial highlight (same stops as the web SVG)
+        const stops = BODY_STOPS[status] ?? BODY_STOPS.normal;
+        ctx.beginPath();
+        ctx.arc(SVG_CX, SVG_CY, SVG_R, 0, Math.PI * 2);
+        ctx.fillStyle = status === 'failed' ? '#F04438' : status === 'awaiting' ? '#F5B82E' : '#2389FF';
+        ctx.fill();
+        const gradient = ctx.createRadialGradient(SVG_CX, 105.735, 0, SVG_CX, 105.735, 121.866);
+        gradient.addColorStop(0, stops[0]);
+        gradient.addColorStop(0.759, stops[1]);
+        gradient.addColorStop(1, stops[2]);
+        ctx.beginPath();
+        ctx.arc(SVG_CX, SVG_CY, SVG_R, 0, Math.PI * 2);
+        ctx.fillStyle = gradient;
+        ctx.fill();
+
+        // eyes (the web SVG applies translate(-33.4 0) to the eye group):
+        // pseudo-3D head turn — yaw drives the horizontal orbit / width,
+        // pitch drives vertical travel / height foreshortening. The slant
+        // follows the quadrant rule: only the gaze-side eye slants, and the
+        // slant direction comes from the vertical component — looking up
+        // tips the top outward, looking down tips it inward.
+        ctx.translate(-33.4, 0);
+        const yn = Math.max(-1, Math.min(1, gaze.x));
+        const pn = Math.max(-1, Math.min(1, gaze.y));
+        const yaw = HEAD_YAW_MAX * yn;
+        const pitch = HEAD_PITCH_MAX * pn;
+        const pitchDy = EYE_PITCH_TRAVEL * Math.sin(pitch);
+        const pitchHScale = 1 - EYE_PITCH_SQUASH * Math.abs(Math.sin(pitch));
+        const slant = -Math.sign(yn * pn) * EYE_TILT_MAX * Math.abs(yn * pn);
+        EYES.forEach((eye, i) => {
+          const a = EYE_BASE_ANGLES[i] + yaw;
+          const projCx = SVG_CX + 33.4 + EYE_ORBIT_R * Math.sin(a);
+          const wScale = 0.72 + 0.28 * Math.cos(a);
+          const isGazeSide = yn !== 0 && yn < 0 === (i === 0);
+          const tilt = isGazeSide ? slant : 0;
+          if (status === 'failed') drawCrossEye(eye, projCx, pitchDy, tilt, wScale);
+          else drawEyeCapsule(eye, projCx, eyeScale * pitchHScale, pitchDy, tilt, wScale);
+        });
+        ctx.restore();
+
+        drawWorkRing(t, cy, 'front');
+
+        drawCelebration(t, cx, cy, 'front');
+      }
+
+      // Task-complete celebration, played once per transition into `done`:
+      // two joyful hops plus a confetti toss from the head — paper slips
+      // with a 3D flip (width follows the flip cosine), lateral sway, drag +
+      // gravity fall, and a soft golden halo pulse at the start. The ball
+      // itself never deforms. Confetti is split into a back layer (behind
+      // the body) and a front layer for depth.
+      const CELE_TOTAL_S = 3.2;
+      const CELE_CONFETTI_COLORS = ['#4C8DFF', '#FFC94D', '#FF5C7A', '#34D399', '#A78BFA', '#FF9F43'];
+
+      function createCelebration(startT) {
+        const confetti = [];
+        // two waves: the main toss plus a delayed follow-up pop
+        for (let i = 0; i < 90; i++) {
+          const secondWave = i >= 60;
+          // upward cone, ~±65° around vertical
+          const ang = -Math.PI / 2 + (Math.random() - 0.5) * 2.3;
+          const speed = (secondWave ? 70 : 90) + Math.random() * 80;
+          confetti.push({
+            vx: Math.cos(ang) * speed,
+            vy: Math.sin(ang) * speed,
+            delay: secondWave ? 0.3 + Math.random() * 0.15 : Math.random() * 0.12,
+            life: 1.8 + Math.random() * 1.0,
+            w: 6 + Math.random() * 5,
+            h: 4 + Math.random() * 2.5,
+            color: CELE_CONFETTI_COLORS[i % CELE_CONFETTI_COLORS.length],
+            flipSpeed: 6 + Math.random() * 8,
+            flipPhase: Math.random() * Math.PI * 2,
+            swayAmp: 5 + Math.random() * 4,
+            swayFreq: 1.5 + Math.random() * 1.5,
+            swayPhase: Math.random() * Math.PI * 2,
+            front: i % 2 === 0,
+            // some pieces are round sequins that sparkle instead of flip
+            sequin: i % 5 === 0,
+          });
+        }
+        return { startT, confetti };
+      }
+
+      function drawCelebration(t, cx, cy, layer) {
+        if (celebration === null) return;
+        const e = t - celebration.startT;
+        if (e < 0) return;
+        if (e >= CELE_TOTAL_S) {
+          celebration = null;
+          return;
+        }
+        if (layer === 'back' && e < 0.7) {
+          // soft golden halo pulse behind the pet
+          const u = e / 0.7;
+          const glow = ctx.createRadialGradient(cx, cy, 0, cx, cy, 60 + 70 * u);
+          glow.addColorStop(0, `rgba(255, 201, 77, ${0.45 * (1 - u)})`);
+          glow.addColorStop(1, 'rgba(255, 201, 77, 0)');
+          ctx.fillStyle = glow;
+          ctx.beginPath();
+          ctx.arc(cx, cy, 60 + 70 * u, 0, Math.PI * 2);
+          ctx.fill();
+        }
+        // Confetti: closed-form drag (k) + gravity (g) from the head top,
+        // in canvas (y-down) coordinates: v(t) = g/k + (v0 - g/k)·e^-kt.
+        // Paper flutters — heavy drag, low terminal velocity.
+        const DRAG = 2.2;
+        const G_OVER_K = 52; // gravity ≈115 px/s² / drag
+        for (const p of celebration.confetti) {
+          if ((layer === 'front') !== p.front) continue;
+          const d = e - p.delay;
+          if (d < 0 || d >= p.life) continue;
+          const ek = Math.exp(-DRAG * d);
+          const travel = (1 - ek) / DRAG;
+          const x =
+            cx + p.vx * travel + p.swayAmp * Math.sin(Math.PI * 2 * p.swayFreq * d + p.swayPhase);
+          const y = cy - 44 + G_OVER_K * d + (p.vy - G_OVER_K) * travel;
+          const flip = Math.cos(p.flipSpeed * d + p.flipPhase);
+          const alpha = Math.min(1, (1 - d / p.life) / 0.25);
+          ctx.save();
+          ctx.globalAlpha = alpha;
+          ctx.translate(x, y);
+          if (p.sequin) {
+            // round sequin: gentle pulse + fast sparkle, no paper flip
+            const sparkle = 0.65 + 0.35 * Math.sin(d * 26 + p.flipPhase);
+            ctx.globalAlpha = alpha * sparkle;
+            ctx.fillStyle = p.color;
+            ctx.beginPath();
+            ctx.arc(0, 0, p.w * 0.45 * (1 + 0.15 * Math.sin(d * 9 + p.swayPhase)), 0, Math.PI * 2);
+            ctx.fill();
+          } else {
+            ctx.rotate(Math.sin(p.flipSpeed * 0.5 * d + p.flipPhase) * 0.6);
+            ctx.scale(Math.max(0.15, Math.abs(flip)), 1);
+            ctx.fillStyle = p.color;
+            ctx.fillRect(-p.w / 2, -p.h / 2, p.w, p.h);
+          }
+          ctx.restore();
+        }
+      }
+
+      function drawBadge() {
+        if (petState.sessionCount > 1) {
+          ctx.fillStyle = 'rgba(40,40,60,0.85)';
+          ctx.beginPath();
+          ctx.arc(132, 22, 12, 0, Math.PI * 2);
+          ctx.fill();
+          ctx.fillStyle = '#fff';
+          ctx.font = 'bold 12px sans-serif';
+          ctx.textAlign = 'center';
+          ctx.textBaseline = 'middle';
+          ctx.fillText(String(petState.sessionCount), 132, 23);
+          ctx.textBaseline = 'alphabetic';
+        }
+      }
+
+      function frame(now) {
+        const t = now / 1000;
+        currentT = t;
+        // The manual session selection expires on the renderer's own clock:
+        // the main process only sends `pet:state` when the payload changes,
+        // so an idle session set would never revert to the top session.
+        if (selectedSessionId !== null && Date.now() > manualSelectUntil) {
+          bubbleSession = pickDisplayedSession(petState);
+          renderBubble();
+        }
+        updateGaze();
+        ctx.clearRect(0, 0, 150, 156);
+        if (skinImg) {
+          // Skins animate via atlas frames (no bob), so the ring tracks a
+          // fixed body center here.
+          drawWorkRing(t, 88, 'back');
+          drawSkin(t);
+          drawWorkRing(t, 88, 'front');
+        } else {
+          drawMascot(t);
+        }
+        drawBadge();
+        requestAnimationFrame(frame);
+      }
+      requestAnimationFrame(frame);
+    </script>
+  </body>
+</html>

--- a/apps/kimi-code/src/pet/overlay/settings.html
+++ b/apps/kimi-code/src/pet/overlay/settings.html
@@ -1,0 +1,188 @@
+<!doctype html>
+<html lang="zh-CN">
+  <head>
+    <meta charset="utf-8" />
+    <title>Kimi Pet 设置</title>
+    <style>
+      * {
+        margin: 0;
+        padding: 0;
+        box-sizing: border-box;
+        user-select: none;
+        -webkit-user-select: none;
+      }
+      html,
+      body {
+        height: 100%;
+      }
+      body {
+        font-family:
+          -apple-system, BlinkMacSystemFont, 'PingFang SC', 'Segoe UI', sans-serif;
+        background: #f5f5f7;
+        color: #1d1d1f;
+        display: flex;
+        flex-direction: column;
+      }
+      /* Room for the hidden-inset traffic lights; the strip is the window drag
+         handle. Tall enough that the title clears the traffic-light buttons. */
+      #titlebar {
+        -webkit-app-region: drag;
+        height: 64px;
+        flex: none;
+        display: flex;
+        align-items: flex-end;
+        padding: 0 20px 10px;
+        font-size: 13px;
+        font-weight: 600;
+      }
+      main {
+        flex: 1;
+        padding: 4px 20px 0;
+        display: flex;
+        flex-direction: column;
+        gap: 18px;
+      }
+      .field {
+        background: #fff;
+        border-radius: 10px;
+        padding: 12px 14px 14px;
+        box-shadow: 0 1px 2px rgba(0, 0, 0, 0.06);
+      }
+      .field-head {
+        display: flex;
+        justify-content: space-between;
+        align-items: baseline;
+        margin-bottom: 8px;
+      }
+      .field-label {
+        font-size: 12px;
+        font-weight: 500;
+        color: #1d1d1f;
+      }
+      .field-value {
+        font-size: 12px;
+        color: #86868b;
+        font-variant-numeric: tabular-nums;
+      }
+      input[type='range'] {
+        width: 100%;
+        height: 20px;
+        accent-color: #0a84ff;
+        cursor: pointer;
+      }
+      /* Sample bubble mirroring the real overlay bubble, so the font-size
+         slider's effect is visible right inside the settings window. */
+      #preview {
+        margin-top: 12px;
+        padding: 12px;
+        border-radius: 8px;
+        background: #f5f5f7;
+        display: flex;
+        justify-content: center;
+      }
+      #preview-bubble {
+        max-width: 100%;
+        padding: 9px 15px;
+        border-radius: 18px;
+        background: rgba(255, 255, 255, 0.98);
+        box-shadow:
+          0 10px 30px rgba(31, 35, 50, 0.14),
+          0 2px 8px rgba(31, 35, 50, 0.08);
+      }
+      #preview-title {
+        font-weight: 500;
+        line-height: 1.4;
+        color: #2b2f3a;
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+      }
+      #preview-status {
+        line-height: 1.4;
+        color: #8a90a0;
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+      }
+      footer {
+        flex: none;
+        padding: 10px 20px 14px;
+        text-align: left;
+        font-size: 11px;
+        color: #aeaeb2;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="titlebar">Kimi Pet 设置</div>
+    <main>
+      <div class="field">
+        <div class="field-head">
+          <span class="field-label">宠物大小</span>
+          <span class="field-value" id="scale-value">100%</span>
+        </div>
+        <input id="scale" type="range" min="0.5" max="2" step="0.05" value="1" />
+      </div>
+      <div class="field">
+        <div class="field-head">
+          <span class="field-label">气泡字号</span>
+          <span class="field-value" id="font-value">13px</span>
+        </div>
+        <input id="font" type="range" min="9" max="20" step="0.5" value="13" />
+        <div id="preview">
+          <div id="preview-bubble">
+            <div id="preview-title">帮我总结一下代码改动</div>
+            <div id="preview-status">Bash: npm test</div>
+          </div>
+        </div>
+      </div>
+    </main>
+    <footer id="version"></footer>
+    <script>
+      const { ipcRenderer } = require('electron');
+
+      const scaleInput = document.getElementById('scale');
+      const scaleValue = document.getElementById('scale-value');
+      const fontInput = document.getElementById('font');
+      const fontValue = document.getElementById('font-value');
+      const versionEl = document.getElementById('version');
+      const previewTitle = document.getElementById('preview-title');
+      const previewStatus = document.getElementById('preview-status');
+
+      // Same derivation as the real bubble: the status line is 1.5px smaller
+      // than the title line.
+      function applyPreviewFont(size) {
+        previewTitle.style.fontSize = `${size}px`;
+        previewStatus.style.fontSize = `${size - 1.5}px`;
+      }
+      applyPreviewFont(Number(fontInput.value));
+
+      ipcRenderer.on('pet:settings-init', (_event, settings) => {
+        if (typeof settings.scale === 'number') {
+          scaleInput.value = String(settings.scale);
+          scaleValue.textContent = `${Math.round(settings.scale * 100)}%`;
+        }
+        if (typeof settings.bubbleFontSize === 'number') {
+          fontInput.value = String(settings.bubbleFontSize);
+          fontValue.textContent = `${settings.bubbleFontSize}px`;
+          applyPreviewFont(settings.bubbleFontSize);
+        }
+        versionEl.textContent = settings.version ? `v${settings.version}` : '';
+      });
+
+      // Live preview: every edit is applied to the pet immediately; the main
+      // process debounces persistence.
+      scaleInput.addEventListener('input', () => {
+        const scale = Number(scaleInput.value);
+        scaleValue.textContent = `${Math.round(scale * 100)}%`;
+        ipcRenderer.send('pet:update-settings', { scale });
+      });
+      fontInput.addEventListener('input', () => {
+        const bubbleFontSize = Number(fontInput.value);
+        fontValue.textContent = `${bubbleFontSize}px`;
+        applyPreviewFont(bubbleFontSize);
+        ipcRenderer.send('pet:update-settings', { bubbleFontSize });
+      });
+    </script>
+  </body>
+</html>

--- a/apps/kimi-code/src/pet/reporter.ts
+++ b/apps/kimi-code/src/pet/reporter.ts
@@ -1,0 +1,188 @@
+/**
+ * Pet state reporter.
+ *
+ * Lives inside the CLI process (TUI or headless `-p` run) and mirrors the
+ * current session's activity into `<dataDir>/pet/sessions/<sessionId>.json`
+ * for the desktop-pet overlay to render. Writes are event-driven (no polling)
+ * and gated on the overlay heartbeat, so a stopped pet costs nothing.
+ */
+
+import { rmSync } from 'node:fs';
+
+import type { Event, Session } from '@moonshot-ai/kimi-code-sdk';
+
+import { getPetOverlayHeartbeatFile, getPetSessionsDir } from './dirs';
+
+import type { PetSessionState, PetSessionStatus } from './state';
+import { isPetOverlayAlive, petSessionStateFile, writeJsonFileAtomicSync } from './state';
+
+const STATUS_TEXT_MAX_LENGTH = 48;
+/** Pure liveness refreshes (deltas) persist at most this often. */
+const REFRESH_WRITE_INTERVAL_MS = 2_000;
+
+export interface PetReporterSessionMeta {
+  readonly sessionId: string;
+  readonly cwd?: string;
+}
+
+export interface PetReporterOptions {
+  readonly sessionsDir?: string;
+  readonly heartbeatFile?: string;
+  readonly now?: () => number;
+}
+
+type SessionEventSource = Pick<Session, 'onEvent'>;
+
+export class PetReporter {
+  private readonly sessionsDir: string;
+  private readonly heartbeatFile: string;
+  private readonly now: () => number;
+
+  private state: PetSessionState | undefined;
+  private unsubscribe: (() => void) | undefined;
+  private lastWriteAt = 0;
+
+  constructor(options: PetReporterOptions = {}) {
+    this.sessionsDir = options.sessionsDir ?? getPetSessionsDir();
+    this.heartbeatFile = options.heartbeatFile ?? getPetOverlayHeartbeatFile();
+    this.now = options.now ?? (() => Date.now());
+  }
+
+  attachSession(session: SessionEventSource, meta: PetReporterSessionMeta): void {
+    this.detachSession();
+    this.state = {
+      sessionId: meta.sessionId,
+      cwd: meta.cwd,
+      status: 'idle',
+      pid: process.pid,
+      termProgram: process.env['TERM_PROGRAM'],
+      updatedAt: this.now(),
+    };
+    this.unsubscribe = session.onEvent((event) => {
+      if (event.sessionId !== meta.sessionId) return;
+      this.handleEvent(event);
+    });
+  }
+
+  detachSession(): void {
+    this.unsubscribe?.();
+    this.unsubscribe = undefined;
+    const state = this.state;
+    this.state = undefined;
+    if (state !== undefined) {
+      rmSync(petSessionStateFile(this.sessionsDir, state.sessionId), { force: true });
+    }
+  }
+
+  /** Approval/question request surfaced — the pet should flag attention. */
+  notifyInteractionPending(statusText: string): void {
+    this.apply('awaiting', statusText);
+  }
+
+  /** The pending approval/question was answered; back to work. */
+  notifyInteractionResolved(): void {
+    if (this.state?.status === 'awaiting') {
+      this.apply('working', undefined);
+    }
+  }
+
+  handleEvent(event: Event): void {
+    switch (event.type) {
+      case 'turn.started':
+        if (event.prompt !== undefined) {
+          this.setTitle(truncate(oneLine(event.prompt), 60));
+        }
+        this.apply('working', '思考中…');
+        return;
+      case 'tool.call.started':
+        this.apply('working', truncate(oneLine(event.description ?? event.name)));
+        return;
+      case 'agent.status.updated': {
+        const phase = event.phase;
+        if (phase?.kind === 'awaiting_approval') {
+          this.apply('awaiting', '等待你的确认…');
+        } else if (phase?.kind === 'running' || phase?.kind === 'streaming') {
+          // Keep the current statusText (usually the active tool call).
+          this.apply('working', this.state?.statusText ?? '思考中…');
+        }
+        return;
+      }
+      case 'turn.ended':
+        switch (event.reason) {
+          case 'completed':
+            this.apply('done', `任务完成${formatDurationSuffix(event.durationMs)}`);
+            return;
+          case 'failed':
+            this.apply('failed', '任务出错了');
+            return;
+          case 'blocked':
+            this.apply('awaiting', '任务被阻塞，需要处理');
+            return;
+          default:
+            this.apply('idle', undefined);
+            return;
+        }
+      case 'error':
+        this.apply('failed', truncate(oneLine(event.message)));
+        return;
+      case 'assistant.delta':
+      case 'thinking.delta':
+        // Long streaming turns produce no other events; refresh the TTL so the
+        // pet does not fall back to idle mid-turn.
+        this.refresh();
+        return;
+      default:
+        return;
+    }
+  }
+
+  private refresh(): void {
+    if (this.state === undefined) return;
+    this.state = { ...this.state, updatedAt: this.now() };
+    if (this.now() - this.lastWriteAt >= REFRESH_WRITE_INTERVAL_MS) {
+      this.persist();
+    }
+  }
+
+  private setTitle(title: string): void {
+    if (this.state === undefined) return;
+    this.state = { ...this.state, title };
+  }
+
+  private apply(status: PetSessionStatus, statusText: string | undefined): void {
+    if (this.state === undefined) return;
+    const changed = this.state.status !== status || this.state.statusText !== statusText;
+    this.state = { ...this.state, status, statusText, updatedAt: this.now() };
+    if (changed) {
+      // State transitions are rare and user-visible; persist immediately.
+      this.lastWriteAt = 0;
+    }
+    this.refresh();
+  }
+
+  private persist(): void {
+    if (this.state === undefined) return;
+    if (!isPetOverlayAlive(this.heartbeatFile, this.now())) return;
+    this.lastWriteAt = this.now();
+    try {
+      writeJsonFileAtomicSync(petSessionStateFile(this.sessionsDir, this.state.sessionId), this.state);
+    } catch {
+      // Best-effort: a failed write must never break the session.
+    }
+  }
+}
+
+function oneLine(text: string): string {
+  return text.replaceAll(/\s+/g, ' ').trim();
+}
+
+function truncate(text: string, max: number = STATUS_TEXT_MAX_LENGTH): string {
+  return text.length <= max ? text : `${text.slice(0, max - 1)}…`;
+}
+
+function formatDurationSuffix(durationMs: number | undefined): string {
+  if (durationMs === undefined) return '';
+  const seconds = Math.round(durationMs / 1000);
+  if (seconds < 60) return `（${seconds}s）`;
+  return `（${Math.floor(seconds / 60)}m${seconds % 60}s）`;
+}

--- a/apps/kimi-code/src/pet/state.ts
+++ b/apps/kimi-code/src/pet/state.ts
@@ -1,0 +1,311 @@
+/**
+ * Desktop-pet state protocol.
+ *
+ * The pet overlay (`kimi pet`) runs as a separate process and cannot subscribe
+ * to the in-process engine, so running sessions report their status by writing
+ * one JSON file per session under `<dataDir>/pet/sessions/`. The overlay polls
+ * that directory and renders the aggregate. Liveness is TTL-based, so a
+ * crashed CLI process simply stops being reported instead of leaving stale
+ * state behind.
+ *
+ * This module is shared by the reporter (CLI/TUI process) and the overlay
+ * (Electron process); keep it free of TUI- or Electron-specific imports.
+ */
+
+import { existsSync, mkdirSync, readdirSync, readFileSync, renameSync, writeFileSync } from 'node:fs';
+import { readFile, rename, writeFile } from 'node:fs/promises';
+import { dirname, join } from 'node:path';
+
+import {
+  getPetOverlayHeartbeatFile,
+  getPetOverlayPositionFile,
+  getPetSessionsDir,
+  getPetSettingsFile,
+} from './dirs';
+
+/** How long a session state file stays meaningful without a refresh. */
+export const PET_SESSION_TTL_MS = 60_000;
+/** A `done` state only wins aggregation for this long before demoting to idle. */
+export const PET_DONE_DISPLAY_MS = 15_000;
+/** How stale the overlay heartbeat may be before reporters stop writing. */
+export const PET_OVERLAY_HEARTBEAT_FRESH_MS = 3_000;
+
+export type PetSessionStatus = 'idle' | 'working' | 'awaiting' | 'done' | 'failed';
+
+export interface PetSessionState {
+  readonly sessionId: string;
+  readonly cwd?: string;
+  readonly status: PetSessionStatus;
+  /** Short human-readable summary shown in the pet bubble, e.g. `Bash: ls`. */
+  readonly statusText?: string;
+  /** The active turn's prompt summary, shown as the bubble title line. */
+  readonly title?: string;
+  /** CLI process id, so the overlay can signal the session (e.g. SIGINT). */
+  readonly pid?: number;
+  /** `TERM_PROGRAM` of the CLI process, used to focus its terminal app. */
+  readonly termProgram?: string;
+  readonly updatedAt: number;
+}
+
+export interface PetOverlayHeartbeat {
+  readonly pid: number;
+  readonly updatedAt: number;
+}
+
+export interface PetAggregatedState {
+  readonly status: PetSessionStatus;
+  readonly statusText?: string;
+  readonly title?: string;
+  readonly pid?: number;
+  readonly termProgram?: string;
+  /** Number of live (non-expired) sessions behind the aggregate. */
+  readonly sessionCount: number;
+}
+
+export interface PetWindowPosition {
+  readonly x: number;
+  readonly y: number;
+}
+
+/** A session entry in the overlay's switchable session list. */
+export interface PetSessionSummary {
+  readonly sessionId: string;
+  readonly status: PetSessionStatus;
+  readonly statusText?: string;
+  readonly title?: string;
+  readonly pid?: number;
+  readonly termProgram?: string;
+}
+
+/**
+ * What the overlay main process sends to the renderer: the top-ranked
+ * session's fields (for backwards-compatible display) plus the full ranked
+ * list so the user can page through sessions.
+ */
+export interface PetOverlayState extends PetAggregatedState {
+  readonly sessions: readonly PetSessionSummary[];
+}
+
+/** Higher number wins when aggregating multiple sessions. */
+const STATUS_PRIORITY: Record<PetSessionStatus, number> = {
+  idle: 0,
+  done: 1,
+  working: 2,
+  failed: 3,
+  awaiting: 4,
+};
+
+/**
+ * Sort live sessions for display: expired sessions (older than `ttlMs`) are
+ * dropped, a `done` state older than `PET_DONE_DISPLAY_MS` demotes to idle,
+ * then highest status priority first with ties broken by recency. The
+ * overlay shows [0] by default; the rest are reachable by paging.
+ */
+export function rankSessionStates(
+  sessions: readonly PetSessionState[],
+  now: number,
+  ttlMs: number = PET_SESSION_TTL_MS,
+): PetSessionState[] {
+  const live: PetSessionState[] = [];
+  for (const session of sessions) {
+    if (now - session.updatedAt > ttlMs) continue;
+    live.push(
+      session.status === 'done' && now - session.updatedAt > PET_DONE_DISPLAY_MS
+        ? { ...session, status: 'idle', statusText: undefined }
+        : session,
+    );
+  }
+  return live.toSorted(
+    (a, b) => STATUS_PRIORITY[b.status] - STATUS_PRIORITY[a.status] || b.updatedAt - a.updatedAt,
+  );
+}
+
+/**
+ * Merge per-session states into the single status the pet should show.
+ * Equivalent to the first entry of {@link rankSessionStates}.
+ */
+export function aggregateSessionStates(
+  sessions: readonly PetSessionState[],
+  now: number,
+  ttlMs: number = PET_SESSION_TTL_MS,
+): PetAggregatedState {
+  const ranked = rankSessionStates(sessions, now, ttlMs);
+  const best = ranked[0];
+  if (best === undefined) {
+    return { status: 'idle', sessionCount: 0 };
+  }
+  return {
+    status: best.status,
+    statusText: best.statusText,
+    title: best.title,
+    pid: best.pid,
+    termProgram: best.termProgram,
+    sessionCount: ranked.length,
+  };
+}
+
+export function petSessionStateFile(sessionsDir: string, sessionId: string): string {
+  return join(sessionsDir, `${encodeURIComponent(sessionId)}.json`);
+}
+
+/** Atomic JSON write (tmp + rename) so pollers never read a partial file. */
+export async function writeJsonFileAtomic(file: string, value: unknown): Promise<void> {
+  mkdirSync(dirname(file), { recursive: true });
+  const tmp = `${file}.${process.pid}.tmp`;
+  await writeFile(tmp, JSON.stringify(value), 'utf-8');
+  await rename(tmp, file);
+}
+
+/** Sync variant of {@link writeJsonFileAtomic} for the in-process reporter. */
+export function writeJsonFileAtomicSync(file: string, value: unknown): void {
+  mkdirSync(dirname(file), { recursive: true });
+  const tmp = `${file}.${process.pid}.tmp`;
+  writeFileSync(tmp, JSON.stringify(value), 'utf-8');
+  renameSync(tmp, file);
+}
+
+export async function readJsonFile<T>(file: string): Promise<T | undefined> {
+  try {
+    return JSON.parse(await readFile(file, 'utf-8')) as T;
+  } catch {
+    return undefined;
+  }
+}
+
+/** List all session state files. Never throws — a dirty dir yields []. */
+export function readPetSessionStates(sessionsDir: string = getPetSessionsDir()): PetSessionState[] {
+  let names: string[];
+  try {
+    names = readdirSync(sessionsDir);
+  } catch {
+    return [];
+  }
+  const states: PetSessionState[] = [];
+  for (const name of names) {
+    if (!name.endsWith('.json')) continue;
+    try {
+      const raw = readFileSync(join(sessionsDir, name), 'utf-8');
+      const parsed = JSON.parse(raw) as PetSessionState;
+      if (typeof parsed.sessionId === 'string' && typeof parsed.updatedAt === 'number') {
+        states.push(parsed);
+      }
+    } catch {
+      // Ignore partially-written or foreign files.
+    }
+  }
+  return states;
+}
+
+/**
+ * Whether the pet overlay is currently running, from the CLI side. Reporters
+ * gate their writes on this so a stopped pet means zero file churn.
+ */
+export function isPetOverlayAlive(
+  heartbeatFile: string = getPetOverlayHeartbeatFile(),
+  now: number = Date.now(),
+): boolean {
+  try {
+    const raw = readFileSync(heartbeatFile, 'utf-8');
+    const heartbeat = JSON.parse(raw) as PetOverlayHeartbeat;
+    if (typeof heartbeat.updatedAt !== 'number') return false;
+    if (now - heartbeat.updatedAt > PET_OVERLAY_HEARTBEAT_FRESH_MS) return false;
+    process.kill(heartbeat.pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function writePetOverlayHeartbeat(
+  heartbeatFile: string = getPetOverlayHeartbeatFile(),
+): void {
+  mkdirSync(dirname(heartbeatFile), { recursive: true });
+  const tmp = `${heartbeatFile}.${process.pid}.tmp`;
+  writeFileSync(tmp, JSON.stringify({ pid: process.pid, updatedAt: Date.now() }), 'utf-8');
+  renameSync(tmp, heartbeatFile);
+}
+
+export function readPetWindowPosition(
+  file: string = getPetOverlayPositionFile(),
+): PetWindowPosition | undefined {
+  try {
+    if (!existsSync(file)) return undefined;
+    const parsed = JSON.parse(readFileSync(file, 'utf-8')) as PetWindowPosition;
+    if (typeof parsed.x === 'number' && typeof parsed.y === 'number') return parsed;
+    return undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+export const PET_SCALE_MIN = 0.5;
+export const PET_SCALE_MAX = 2;
+export const PET_BUBBLE_FONT_SIZE_MIN = 9;
+export const PET_BUBBLE_FONT_SIZE_MAX = 20;
+export const PET_BUBBLE_FONT_SIZE_DEFAULT = 13;
+
+export interface PetSettings {
+  readonly scale: number;
+  /** Bubble title font size in px; the status line is derived from it. */
+  readonly bubbleFontSize: number;
+}
+
+export const PET_SETTINGS_DEFAULTS: PetSettings = {
+  scale: 1,
+  bubbleFontSize: PET_BUBBLE_FONT_SIZE_DEFAULT,
+};
+
+export function clampPetScale(scale: number): number {
+  return Math.min(Math.max(scale, PET_SCALE_MIN), PET_SCALE_MAX);
+}
+
+export function clampPetBubbleFontSize(size: number): number {
+  return Math.min(Math.max(size, PET_BUBBLE_FONT_SIZE_MIN), PET_BUBBLE_FONT_SIZE_MAX);
+}
+
+export function readPetSettings(file: string = getPetSettingsFile()): PetSettings {
+  try {
+    if (!existsSync(file)) return PET_SETTINGS_DEFAULTS;
+    const parsed = JSON.parse(readFileSync(file, 'utf-8')) as {
+      scale?: unknown;
+      bubbleFontSize?: unknown;
+    };
+    return {
+      scale:
+        typeof parsed.scale === 'number' && !Number.isNaN(parsed.scale)
+          ? clampPetScale(parsed.scale)
+          : PET_SETTINGS_DEFAULTS.scale,
+      bubbleFontSize:
+        typeof parsed.bubbleFontSize === 'number' && !Number.isNaN(parsed.bubbleFontSize)
+          ? clampPetBubbleFontSize(parsed.bubbleFontSize)
+          : PET_SETTINGS_DEFAULTS.bubbleFontSize,
+    };
+  } catch {
+    return PET_SETTINGS_DEFAULTS;
+  }
+}
+
+/** Merge-write: fields left undefined keep their stored values. */
+export function writePetSettings(
+  settings: { scale?: number; bubbleFontSize?: number },
+  file: string = getPetSettingsFile(),
+): void {
+  const current = readPetSettings(file);
+  writeJsonFileAtomicSync(file, {
+    scale: settings.scale === undefined ? current.scale : clampPetScale(settings.scale),
+    bubbleFontSize:
+      settings.bubbleFontSize === undefined
+        ? current.bubbleFontSize
+        : clampPetBubbleFontSize(settings.bubbleFontSize),
+  });
+}
+
+export function writePetWindowPosition(
+  position: PetWindowPosition,
+  file: string = getPetOverlayPositionFile(),
+): void {
+  mkdirSync(dirname(file), { recursive: true });
+  const tmp = `${file}.${process.pid}.tmp`;
+  writeFileSync(tmp, JSON.stringify(position), 'utf-8');
+  renameSync(tmp, file);
+}

--- a/apps/kimi-code/src/raw-assets.d.ts
+++ b/apps/kimi-code/src/raw-assets.d.ts
@@ -1,0 +1,6 @@
+// TypeScript module declarations for `?raw` text imports (inlined at build
+// time by build/raw-text-plugin.mjs).
+declare module '*?raw' {
+  const content: string;
+  export default content;
+}

--- a/apps/kimi-code/src/tui/kimi-tui.ts
+++ b/apps/kimi-code/src/tui/kimi-tui.ts
@@ -28,6 +28,7 @@ import { resolve } from 'pathe';
 
 import type { CLIOptions } from '#/cli/options';
 import { MigrationScreenComponent, type MigrationScreenResult } from '#/migration/index';
+import { PetReporter } from '#/pet/reporter';
 import { copyTextToClipboard } from '#/utils/clipboard/clipboard-text';
 import { appendInputHistory, loadInputHistory } from '#/utils/history/input-history';
 import { openUrl } from '#/utils/open-url';
@@ -316,6 +317,7 @@ export class KimiTUI {
   private ensureSessionPromise: Promise<Session | undefined> | null = null;
   private readonly approvalController = new ApprovalController();
   private readonly questionController = new QuestionController();
+  private readonly petReporter = new PetReporter();
   private readonly reverseRpcDisposers: Array<() => void> = [];
   private skillCommands: readonly KimiSlashCommand[] = [];
   readonly skillCommandMap = new Map<string, string>();
@@ -1906,6 +1908,7 @@ export class KimiTUI {
     const previous = this.session;
     this.sessionEventUnsubscribe?.();
     this.sessionEventUnsubscribe = undefined;
+    this.petReporter.detachSession();
     this.clearReverseRpcPanels();
     previous?.setApprovalHandler(undefined);
     previous?.setQuestionHandler(undefined);
@@ -1926,12 +1929,33 @@ export class KimiTUI {
   }
 
   private registerSessionHandlers(session: Session): void {
-    session.setApprovalHandler(
-      createApprovalRequestHandler(this.approvalController, (request, response) => {
+    this.petReporter.attachSession(session, {
+      sessionId: session.id,
+      cwd: this.state.appState.workDir,
+    });
+    const approvalHandler = createApprovalRequestHandler(
+      this.approvalController,
+      (request, response) => {
         this.appendApprovalTranscriptEntry(request, response);
-      }),
+      },
     );
-    session.setQuestionHandler(createQuestionAskHandler(this.questionController));
+    session.setApprovalHandler(async (request) => {
+      this.petReporter.notifyInteractionPending('等待你的确认…');
+      try {
+        return await approvalHandler(request);
+      } finally {
+        this.petReporter.notifyInteractionResolved();
+      }
+    });
+    const questionHandler = createQuestionAskHandler(this.questionController);
+    session.setQuestionHandler(async (request) => {
+      this.petReporter.notifyInteractionPending('有问题等你回答…');
+      try {
+        return await questionHandler(request);
+      } finally {
+        this.petReporter.notifyInteractionResolved();
+      }
+    });
   }
 
   async fetchSessions(scope: 'cwd' | 'all' = this.state.sessionsScope): Promise<void> {

--- a/apps/kimi-code/test/cli/options.test.ts
+++ b/apps/kimi-code/test/cli/options.test.ts
@@ -589,6 +589,7 @@ describe('CLI options parsing', () => {
         'login',
         'doctor',
         'vis',
+        'pet',
         'migrate',
         'upgrade',
       ]);

--- a/apps/kimi-code/test/cli/pet.test.ts
+++ b/apps/kimi-code/test/cli/pet.test.ts
@@ -1,0 +1,128 @@
+/**
+ * `kimi pet` CLI layer: start/stop lifecycle with injected deps — no real
+ * Electron download, no real process spawn. Covers pidfile idempotency,
+ * error paths, and skin env forwarding.
+ */
+
+import { existsSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { handlePet, type PetDeps } from '#/cli/sub/pet';
+
+describe('handlePet', () => {
+  let dir: string;
+  let pidFile: string;
+  let out: string[];
+  let errored: string[];
+
+  function makeDeps(over: Partial<PetDeps> = {}): PetDeps {
+    return {
+      ensureElectron: vi.fn(async () => '/cache/electron/Electron'),
+      resolveOverlayEntry: () => join(dir, 'pet-overlay.mjs'),
+      spawnProcess: vi.fn(() => ({
+        pid: 4321,
+        unref: vi.fn(),
+      })) as unknown as PetDeps['spawnProcess'],
+      pidFile,
+      isProcessAlive: () => false,
+      killProcess: vi.fn(),
+      stdout: {
+        write: (s: string) => {
+          out.push(s);
+          return true;
+        },
+      },
+      stderr: {
+        write: (s: string) => {
+          errored.push(s);
+          return true;
+        },
+      },
+      exit: vi.fn() as unknown as PetDeps['exit'],
+      ...over,
+    };
+  }
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'kimi-pet-cmd-'));
+    pidFile = join(dir, 'overlay.pid');
+    out = [];
+    errored = [];
+    // The overlay entry must exist for the start path.
+    writeFileSync(join(dir, 'pet-overlay.mjs'), '// overlay');
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('spawns the detached overlay and writes the pidfile', async () => {
+    const deps = makeDeps();
+    await handlePet(deps, { stop: false });
+    expect(deps.ensureElectron).toHaveBeenCalledOnce();
+    expect(deps.spawnProcess).toHaveBeenCalledWith(
+      '/cache/electron/Electron',
+      [join(dir, 'pet-overlay.mjs')],
+      expect.objectContaining({ detached: true, stdio: 'ignore' }),
+    );
+    expect(existsSync(pidFile)).toBe(true);
+    expect(out.join('')).toContain('kimi pet is on your desktop');
+  });
+
+  it('forwards the selected skin via env', async () => {
+    const deps = makeDeps();
+    await handlePet(deps, { stop: false, skin: 'cat' });
+    const env = (deps.spawnProcess as ReturnType<typeof vi.fn>).mock.calls[0]?.[2]?.env as
+      | Record<string, string>
+      | undefined;
+    expect(env?.['KIMI_PET_SKIN']).toBe('cat');
+  });
+
+  it('is idempotent when the pet is already running', async () => {
+    writeFileSync(pidFile, '4321');
+    const deps = makeDeps({ isProcessAlive: () => true });
+    await handlePet(deps, { stop: false });
+    expect(deps.spawnProcess).not.toHaveBeenCalled();
+    expect(out.join('')).toContain('already running');
+  });
+
+  it('exits with an error when the overlay bundle is missing', async () => {
+    rmSync(join(dir, 'pet-overlay.mjs'));
+    const deps = makeDeps();
+    await handlePet(deps, { stop: false });
+    expect(deps.exit).toHaveBeenCalledWith(1);
+    expect(errored.join('')).toContain('not found');
+    expect(deps.spawnProcess).not.toHaveBeenCalled();
+  });
+
+  it('exits with an error when the Electron runtime cannot be set up', async () => {
+    const deps = makeDeps({
+      ensureElectron: vi.fn(async () => {
+        throw new Error('network unreachable');
+      }),
+    });
+    await handlePet(deps, { stop: false });
+    expect(deps.exit).toHaveBeenCalledWith(1);
+    expect(errored.join('')).toContain('network unreachable');
+    expect(deps.spawnProcess).not.toHaveBeenCalled();
+  });
+
+  it('stops a running pet and removes the pidfile', async () => {
+    writeFileSync(pidFile, '4321');
+    const deps = makeDeps({ isProcessAlive: () => true });
+    await handlePet(deps, { stop: true });
+    expect(deps.killProcess).toHaveBeenCalledWith(4321);
+    expect(existsSync(pidFile)).toBe(false);
+    expect(out.join('')).toContain('stopped');
+  });
+
+  it('reports stop as a no-op when the pet is not running', async () => {
+    const deps = makeDeps();
+    await handlePet(deps, { stop: true });
+    expect(deps.killProcess).not.toHaveBeenCalled();
+    expect(out.join('')).toContain('not running');
+  });
+});

--- a/apps/kimi-code/test/pet/reporter.test.ts
+++ b/apps/kimi-code/test/pet/reporter.test.ts
@@ -1,0 +1,142 @@
+/**
+ * Pet state reporter: event-to-state mapping, overlay-heartbeat gating,
+ * cross-session filtering, and cleanup on detach. Uses a fake session event
+ * source and temp dirs; no engine involved.
+ */
+
+import { existsSync, mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import type { Event } from '@moonshot-ai/kimi-code-sdk';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { PetReporter } from '#/pet/reporter';
+import type { PetSessionState } from '#/pet/state';
+import { petSessionStateFile, writePetOverlayHeartbeat } from '#/pet/state';
+
+class FakeSession {
+  private readonly listeners = new Set<(event: Event) => void>();
+
+  onEvent(listener: (event: Event) => void): () => void {
+    this.listeners.add(listener);
+    return () => this.listeners.delete(listener);
+  }
+
+  emit(event: Partial<Event> & { type: string }): void {
+    for (const listener of this.listeners) {
+      listener(event as Event);
+    }
+  }
+}
+
+describe('PetReporter', () => {
+  let dir: string;
+  let sessionsDir: string;
+  let heartbeatFile: string;
+  let session: FakeSession;
+  let reporter: PetReporter;
+
+  const stateFile = (sessionId: string): string => petSessionStateFile(sessionsDir, sessionId);
+
+  const readState = (sessionId: string): PetSessionState =>
+    JSON.parse(readFileSync(stateFile(sessionId), 'utf-8')) as PetSessionState;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'kimi-pet-reporter-'));
+    sessionsDir = join(dir, 'sessions');
+    heartbeatFile = join(dir, 'overlay.json');
+    session = new FakeSession();
+    reporter = new PetReporter({ sessionsDir, heartbeatFile });
+    reporter.attachSession(session, { sessionId: 's1', cwd: '/repo' });
+  });
+
+  afterEach(() => {
+    reporter.detachSession();
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('writes nothing while the overlay is not running', () => {
+    session.emit({ type: 'turn.started', sessionId: 's1', turnId: 1, prompt: 'fix the bug' });
+    expect(existsSync(stateFile('s1'))).toBe(false);
+  });
+
+  it('reports a working turn with the prompt as title once the overlay is alive', () => {
+    writePetOverlayHeartbeat(heartbeatFile);
+    session.emit({ type: 'turn.started', sessionId: 's1', turnId: 1, prompt: 'fix\n the bug' });
+    const state = readState('s1');
+    expect(state.status).toBe('working');
+    expect(state.title).toBe('fix the bug');
+    expect(state.statusText).toBe('思考中…');
+    expect(state.cwd).toBe('/repo');
+    expect(state.pid).toBe(process.pid);
+  });
+
+  it('mirrors tool calls as working status text', () => {
+    writePetOverlayHeartbeat(heartbeatFile);
+    session.emit({
+      type: 'tool.call.started',
+      sessionId: 's1',
+      turnId: 1,
+      toolCallId: 't1',
+      name: 'Bash',
+      description: 'Bash: npm test',
+    });
+    expect(readState('s1').statusText).toBe('Bash: npm test');
+  });
+
+  it('flags pending confirmations and returns to working once resolved', () => {
+    writePetOverlayHeartbeat(heartbeatFile);
+    reporter.notifyInteractionPending('等待你的确认…');
+    expect(readState('s1').status).toBe('awaiting');
+    reporter.notifyInteractionResolved();
+    expect(readState('s1').status).toBe('working');
+  });
+
+  it('maps awaiting_approval phases to the awaiting state', () => {
+    writePetOverlayHeartbeat(heartbeatFile);
+    session.emit({
+      type: 'agent.status.updated',
+      sessionId: 's1',
+      phase: { kind: 'awaiting_approval', turnId: 1, since: 1 },
+    });
+    expect(readState('s1').status).toBe('awaiting');
+  });
+
+  it('reports completed turns as done with the duration', () => {
+    writePetOverlayHeartbeat(heartbeatFile);
+    session.emit({
+      type: 'turn.ended',
+      sessionId: 's1',
+      turnId: 1,
+      reason: 'completed',
+      durationMs: 65_000,
+    });
+    const state = readState('s1');
+    expect(state.status).toBe('done');
+    expect(state.statusText).toBe('任务完成（1m5s）');
+  });
+
+  it('reports failed turns and error events as failed', () => {
+    writePetOverlayHeartbeat(heartbeatFile);
+    session.emit({ type: 'turn.ended', sessionId: 's1', turnId: 1, reason: 'failed' });
+    expect(readState('s1').status).toBe('failed');
+    session.emit({ type: 'error', sessionId: 's1', message: 'boom' });
+    expect(readState('s1').statusText).toBe('boom');
+  });
+
+  it('ignores events from other sessions', () => {
+    writePetOverlayHeartbeat(heartbeatFile);
+    session.emit({ type: 'turn.started', sessionId: 'other', turnId: 1, prompt: 'nope' });
+    expect(existsSync(stateFile('s1'))).toBe(false);
+    expect(existsSync(stateFile('other'))).toBe(false);
+  });
+
+  it('removes the state file on detach', () => {
+    writePetOverlayHeartbeat(heartbeatFile);
+    session.emit({ type: 'turn.started', sessionId: 's1', turnId: 1 });
+    expect(existsSync(stateFile('s1'))).toBe(true);
+    reporter.detachSession();
+    expect(existsSync(stateFile('s1'))).toBe(false);
+  });
+});

--- a/apps/kimi-code/test/pet/state.test.ts
+++ b/apps/kimi-code/test/pet/state.test.ts
@@ -1,0 +1,198 @@
+/**
+ * Pet state protocol: aggregation priority, TTL expiry, done demotion,
+ * overlay heartbeat liveness, and session-state file scanning.
+ */
+
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import type { PetSessionState } from '#/pet/state';
+import {
+  PET_BUBBLE_FONT_SIZE_MAX,
+  PET_BUBBLE_FONT_SIZE_MIN,
+  PET_DONE_DISPLAY_MS,
+  PET_SCALE_MAX,
+  PET_SCALE_MIN,
+  PET_SETTINGS_DEFAULTS,
+  aggregateSessionStates,
+  isPetOverlayAlive,
+  petSessionStateFile,
+  rankSessionStates,
+  readPetSessionStates,
+  readPetSettings,
+  writeJsonFileAtomicSync,
+  writePetOverlayHeartbeat,
+  writePetSettings,
+} from '#/pet/state';
+
+function session(partial: Partial<PetSessionState> = {}): PetSessionState {
+  return {
+    sessionId: 's1',
+    status: 'idle',
+    updatedAt: 1_000,
+    ...partial,
+  };
+}
+
+describe('aggregateSessionStates', () => {
+  it('returns idle with zero sessions when empty', () => {
+    expect(aggregateSessionStates([], 1_000)).toEqual({ status: 'idle', sessionCount: 0 });
+  });
+
+  it('drops sessions older than the TTL', () => {
+    const now = 100_000;
+    const stale = session({ status: 'working', updatedAt: now - 61_000 });
+    expect(aggregateSessionStates([stale], now)).toEqual({ status: 'idle', sessionCount: 0 });
+  });
+
+  it('prioritizes awaiting over failed over working over done over idle', () => {
+    const now = 10_000;
+    const states = [
+      session({ sessionId: 'a', status: 'idle', updatedAt: now }),
+      session({ sessionId: 'b', status: 'done', updatedAt: now }),
+      session({ sessionId: 'c', status: 'working', updatedAt: now }),
+      session({ sessionId: 'd', status: 'failed', updatedAt: now }),
+      session({
+        sessionId: 'e',
+        status: 'awaiting',
+        updatedAt: now,
+        statusText: '等待你的确认…',
+        title: 'fix the bug',
+        pid: 4321,
+      }),
+    ];
+    const aggregated = aggregateSessionStates(states, now);
+    expect(aggregated.status).toBe('awaiting');
+    expect(aggregated.statusText).toBe('等待你的确认…');
+    expect(aggregated.title).toBe('fix the bug');
+    expect(aggregated.pid).toBe(4321);
+    expect(aggregated.sessionCount).toBe(5);
+  });
+
+  it('demotes a stale done state to idle', () => {
+    const now = 100_000;
+    const done = session({
+      status: 'done',
+      statusText: '任务完成',
+      updatedAt: now - PET_DONE_DISPLAY_MS - 1,
+    });
+    const aggregated = aggregateSessionStates([done], now);
+    expect(aggregated.status).toBe('idle');
+    expect(aggregated.statusText).toBeUndefined();
+    expect(aggregated.sessionCount).toBe(1);
+  });
+
+  it('picks the most recently updated session within the same priority', () => {
+    const now = 10_000;
+    const older = session({ sessionId: 'a', status: 'working', statusText: 'Bash', updatedAt: now - 5 });
+    const newer = session({ sessionId: 'b', status: 'working', statusText: 'Read', updatedAt: now });
+    expect(aggregateSessionStates([older, newer], now).statusText).toBe('Read');
+  });
+});
+
+describe('rankSessionStates', () => {
+  it('sorts by status priority then recency and drops expired sessions', () => {
+    const now = 100_000;
+    const ranked = rankSessionStates(
+      [
+        session({ sessionId: 'expired', status: 'working', updatedAt: now - 61_000 }),
+        session({ sessionId: 'work', status: 'working', updatedAt: now - 1_000 }),
+        session({ sessionId: 'await', status: 'awaiting', updatedAt: now - 5_000 }),
+        session({ sessionId: 'work2', status: 'working', updatedAt: now - 500 }),
+      ],
+      now,
+    );
+    expect(ranked.map((s) => s.sessionId)).toEqual(['await', 'work2', 'work']);
+  });
+
+  it('demotes a stale done state to idle in the ranking', () => {
+    const now = 100_000;
+    const ranked = rankSessionStates(
+      [
+        session({ sessionId: 'done', status: 'done', updatedAt: now - PET_DONE_DISPLAY_MS - 1 }),
+        session({ sessionId: 'work', status: 'working', updatedAt: now - 59_000 }),
+      ],
+      now,
+    );
+    expect(ranked.map((s) => s.sessionId)).toEqual(['work', 'done']);
+    expect(ranked[1]?.status).toBe('idle');
+    expect(ranked[1]?.statusText).toBeUndefined();
+  });
+});
+
+describe('pet state files', () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'kimi-pet-test-'));
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('round-trips a session state file and scans the directory', () => {
+    const state = session({ sessionId: 'sess/1', status: 'working', statusText: 'Bash: ls' });
+    writeJsonFileAtomicSync(petSessionStateFile(dir, state.sessionId), state);
+    const states = readPetSessionStates(dir);
+    expect(states).toHaveLength(1);
+    expect(states[0]).toMatchObject({ sessionId: 'sess/1', status: 'working' });
+  });
+
+  it('ignores foreign and malformed files when scanning', () => {
+    writeFileSync(join(dir, 'notes.txt'), 'hello');
+    writeFileSync(join(dir, 'broken.json'), '{not json');
+    writeFileSync(join(dir, 'shape.json'), JSON.stringify({ nope: true }));
+    expect(readPetSessionStates(dir)).toEqual([]);
+  });
+
+  it('returns an empty list when the directory does not exist', () => {
+    expect(readPetSessionStates(join(dir, 'missing'))).toEqual([]);
+  });
+
+  it('treats a fresh heartbeat from a live pid as alive', () => {
+    const heartbeatFile = join(dir, 'overlay.json');
+    writePetOverlayHeartbeat(heartbeatFile);
+    expect(isPetOverlayAlive(heartbeatFile, Date.now())).toBe(true);
+  });
+
+  it('treats a stale or missing heartbeat as dead', () => {
+    const heartbeatFile = join(dir, 'overlay.json');
+    expect(isPetOverlayAlive(heartbeatFile, Date.now())).toBe(false);
+    writeFileSync(
+      heartbeatFile,
+      JSON.stringify({ pid: process.pid, updatedAt: Date.now() - 10_000 }),
+    );
+    expect(isPetOverlayAlive(heartbeatFile, Date.now())).toBe(false);
+  });
+
+  it('round-trips the pet display scale with clamping', () => {
+    const settingsFile = join(dir, 'settings.json');
+    expect(readPetSettings(settingsFile)).toEqual(PET_SETTINGS_DEFAULTS);
+    writePetSettings({ scale: 1.4 }, settingsFile);
+    expect(readPetSettings(settingsFile).scale).toBe(1.4);
+    writePetSettings({ scale: 99 }, settingsFile);
+    expect(readPetSettings(settingsFile).scale).toBe(PET_SCALE_MAX);
+    writePetSettings({ scale: 0.01 }, settingsFile);
+    expect(readPetSettings(settingsFile).scale).toBe(PET_SCALE_MIN);
+    writeFileSync(settingsFile, '{broken');
+    expect(readPetSettings(settingsFile)).toEqual(PET_SETTINGS_DEFAULTS);
+  });
+
+  it('round-trips the bubble font size with clamping and merge-writes', () => {
+    const settingsFile = join(dir, 'settings.json');
+    writePetSettings({ bubbleFontSize: 15 }, settingsFile);
+    expect(readPetSettings(settingsFile).bubbleFontSize).toBe(15);
+    writePetSettings({ bubbleFontSize: 99 }, settingsFile);
+    expect(readPetSettings(settingsFile).bubbleFontSize).toBe(PET_BUBBLE_FONT_SIZE_MAX);
+    writePetSettings({ bubbleFontSize: 1 }, settingsFile);
+    expect(readPetSettings(settingsFile).bubbleFontSize).toBe(PET_BUBBLE_FONT_SIZE_MIN);
+    // A font-size-only write keeps a previously stored scale (merge semantics).
+    writePetSettings({ scale: 1.4 }, settingsFile);
+    writePetSettings({ bubbleFontSize: 12 }, settingsFile);
+    expect(readPetSettings(settingsFile)).toEqual({ scale: 1.4, bubbleFontSize: 12 });
+  });
+});

--- a/apps/kimi-code/test/tui/kimi-tui-message-flow.test.ts
+++ b/apps/kimi-code/test/tui/kimi-tui-message-flow.test.ts
@@ -1906,7 +1906,9 @@ command = "vim"
         'Post-create setup failed: permission setup failed',
       );
     });
-    expect(failedSession.onEvent).toHaveBeenCalledOnce();
+    // The pet reporter adds a second subscription, so assert "subscribed"
+    // rather than an exact call count.
+    expect(failedSession.onEvent).toHaveBeenCalled();
   });
 
   it('tracks Shift-Tab mode switches through the editor handler', async () => {
@@ -1961,7 +1963,9 @@ command = "vim"
     driver.sessionEventHandler.startSubscription();
     await Promise.resolve();
 
-    expect(session.onEvent).toHaveBeenCalledOnce();
+    // The pet reporter adds a second subscription, so assert "subscribed"
+    // rather than an exact call count.
+    expect(session.onEvent).toHaveBeenCalled();
     expect(session.listMcpServers).toHaveBeenCalledOnce();
     const subscribeOrder = session.onEvent.mock.invocationCallOrder[0];
     const snapshotOrder = session.listMcpServers.mock.invocationCallOrder[0];
@@ -1994,7 +1998,12 @@ command = "vim"
 
     driver.sessionEventHandler.startSubscription();
     await Promise.resolve();
-    eventListeners[0]?.({
+    // Multiple subscribers exist (the session-event handler, the pet
+    // reporter, ...); deliver to all of them like the real session would.
+    const emit = (event: Event): void => {
+      for (const listener of eventListeners) listener(event);
+    };
+    emit({
       type: 'mcp.server.status',
       agentId: 'main',
       sessionId: 'ses-1',
@@ -2005,7 +2014,7 @@ command = "vim"
       1,
     );
 
-    eventListeners[0]?.({
+    emit({
       type: 'mcp.server.status',
       agentId: 'main',
       sessionId: 'ses-1',
@@ -2015,7 +2024,7 @@ command = "vim"
         toolCount: 0,
       },
     } as Event);
-    eventListeners[0]?.({
+    emit({
       type: 'mcp.server.status',
       agentId: 'main',
       sessionId: 'ses-1',
@@ -2051,17 +2060,21 @@ command = "vim"
     const { driver } = await makeDriver(session);
 
     driver.sessionEventHandler.startSubscription();
-    eventListeners[0]?.({
-      type: 'mcp.server.status',
-      agentId: 'main',
-      sessionId: 'ses-1',
-      server: {
-        name: 'local-tools',
-        transport: 'stdio',
-        status: 'connected',
-        toolCount: 2,
-      },
-    } as Event);
+    // Deliver to every subscriber (session-event handler, pet reporter, ...),
+    // not just the first registered listener.
+    for (const listener of eventListeners) {
+      listener({
+        type: 'mcp.server.status',
+        agentId: 'main',
+        sessionId: 'ses-1',
+        server: {
+          name: 'local-tools',
+          transport: 'stdio',
+          status: 'connected',
+          toolCount: 2,
+        },
+      } as Event);
+    }
     resolveSnapshot([
       {
         name: 'local-tools',

--- a/apps/kimi-code/tsdown.pet.config.ts
+++ b/apps/kimi-code/tsdown.pet.config.ts
@@ -1,0 +1,37 @@
+import { resolve } from 'node:path';
+
+import { defineConfig } from 'tsdown';
+
+import { rawTextPlugin } from '../../build/raw-text-plugin.mjs';
+
+const appRoot = import.meta.dirname;
+
+/**
+ * Separate bundle for the pet overlay (`kimi pet`). It runs under the
+ * Electron binary — not Node — so it gets its own single-file build instead
+ * of a second entry in the main config (`codeSplitting: false` forbids
+ * multiple entries). Built after the main bundle; `clean: false` keeps the
+ * main `dist/main.mjs` intact.
+ */
+export default defineConfig({
+  entry: ['./src/pet/overlay/pet-overlay.ts'],
+  format: ['esm'],
+  outDir: 'dist',
+  clean: false,
+  dts: false,
+  hash: false,
+  plugins: [rawTextPlugin()],
+  alias: {
+    '@': resolve(appRoot, 'src'),
+  },
+  deps: {
+    onlyBundle: false,
+    // Provided by the Electron binary at runtime; intentionally not an npm
+    // dependency of this package.
+    neverBundle: ['electron'],
+  },
+  outputOptions: {
+    codeSplitting: false,
+    entryFileNames: 'pet-overlay.mjs',
+  },
+});

--- a/docs/en/reference/kimi-command.md
+++ b/docs/en/reference/kimi-command.md
@@ -133,7 +133,7 @@ In `stream-json` mode, regular replies produce an Assistant message; when the mo
 
 ## Subcommands
 
-`kimi` provides the following subcommands: `login` (non-interactive login), `acp` (ACP IDE mode), `web` (run the local REST/WebSocket/web service in the foreground and open the web UI), `doctor` (validate configuration files), `export` (export a session), `migrate` (migrate legacy data), `upgrade` (check for updates), and `provider` (manage providers).
+`kimi` provides the following subcommands: `login` (non-interactive login), `acp` (ACP IDE mode), `web` (run the local REST/WebSocket/web service in the foreground and open the web UI), `doctor` (validate configuration files), `export` (export a session), `migrate` (migrate legacy data), `upgrade` (check for updates), `pet` (launch the desktop pet), and `provider` (manage providers).
 
 ### `kimi login`
 
@@ -294,6 +294,32 @@ kimi vis 01HZ...XYZ
 
 # Bind a fixed port and host without opening a browser (e.g. on a remote host)
 kimi vis --host 0.0.0.0 --port 8123 --no-open
+```
+
+### `kimi pet`
+
+Launch an always-on-top desktop pet (it floats above other windows, including fullscreen ones) that mirrors the status of your running Kimi Code sessions. While the agent works, a bubble shows a short summary of the current action (e.g. `Bash: npm test`); when the agent waits for an approval request or an answer, the pet jumps to get your attention; task completion and failures are surfaced the same way. The pet runs as a detached background process — the command returns immediately and does not occupy your terminal.
+
+```sh
+kimi pet [options]
+```
+
+| Option | Description |
+| --- | --- |
+| `--stop` | Stop the desktop pet |
+| `--skin <name>` | Use a custom skin loaded from `pet/pets/<name>/` under the [data directory](../configuration/data-locations.md) (codex pet atlas format: `pet.json` + `spritesheet.webp`) |
+
+On first run, the Electron runtime (about 100 MB) is downloaded once and cached under `pet/electron/` in the data directory; later launches reuse the cache. Drag the pet to reposition it — the position is remembered — and right-click it to open Settings (pet size and bubble font size sliders, with the version in the lower-left corner) or to close the pet. When several sessions run at once, the pet reflects the most urgent one by priority: awaiting input > failed > working > done > idle. A count badge on the pet shows how many sessions are live; swipe horizontally on the bubble (or click the badge) to page through each session's bubble — the pet itself always tracks the highest-priority session.
+
+```sh
+# Launch the desktop pet
+kimi pet
+
+# Use a custom skin
+kimi pet --skin my-pet
+
+# Stop the desktop pet
+kimi pet --stop
 ```
 
 ### `kimi provider`

--- a/docs/zh/reference/kimi-command.md
+++ b/docs/zh/reference/kimi-command.md
@@ -133,7 +133,7 @@ kimi -p "List changed files" --output-format stream-json
 
 ## 子命令
 
-`kimi` 提供以下子命令：`login`（非交互式登录）、`acp`（ACP IDE 模式）、`web`（前台运行本地 REST/WebSocket/web 服务并打开 web UI）、`doctor`（校验配置文件）、`export`（导出会话）、`migrate`（迁移旧版数据）、`upgrade`（检查更新）、`provider`（管理供应商）。
+`kimi` 提供以下子命令：`login`（非交互式登录）、`acp`（ACP IDE 模式）、`web`（前台运行本地 REST/WebSocket/web 服务并打开 web UI）、`doctor`（校验配置文件）、`export`（导出会话）、`migrate`（迁移旧版数据）、`upgrade`（检查更新）、`pet`（启动桌面宠物）、`provider`（管理供应商）。
 
 ### `kimi login`
 
@@ -294,6 +294,32 @@ kimi vis 01HZ...XYZ
 
 # 绑定固定主机和端口且不打开浏览器（例如在远程主机上）
 kimi vis --host 0.0.0.0 --port 8123 --no-open
+```
+
+### `kimi pet`
+
+在桌面上启动一只置顶（始终浮在其他窗口之上，包括全屏窗口）的桌面宠物，实时反映正在运行的 Kimi Code 会话状态：执行过程中气泡显示当前动作简述（例如 `Bash: npm test`）；Agent 等待你确认审批请求或回答问题时，宠物会跳动提醒；任务完成或出错时同样通过气泡告知。宠物以后台进程独立运行，启动命令执行完立即返回，不占用终端。
+
+```sh
+kimi pet [options]
+```
+
+| 选项 | 说明 |
+| --- | --- |
+| `--stop` | 停止桌面宠物 |
+| `--skin <name>` | 使用自定义皮肤，从[数据目录](../configuration/data-locations.md)下的 `pet/pets/<name>/` 读取（兼容 codex pet 精灵图格式：`pet.json` + `spritesheet.webp`） |
+
+首次运行会自动下载 Electron 运行时（约 100 MB），缓存到数据目录下的 `pet/electron/`，之后启动直接复用。宠物窗口可以拖动，位置会被记住；右键点击宠物可打开「设置」（调节宠物大小、气泡字号，左下角显示版本号）或「关闭宠物」。多个会话同时运行时，宠物状态按优先级取最紧急的一个：等待确认 > 出错 > 执行中 > 完成 > 空闲；此时宠物身上会显示会话数角标，在气泡上横向滑动（或点击角标）可以切换查看各个会话的气泡，宠物本体状态始终以最高优先级的会话为准。
+
+```sh
+# 启动桌面宠物
+kimi pet
+
+# 使用自定义皮肤
+kimi pet --skin my-pet
+
+# 停止桌面宠物
+kimi pet --stop
 ```
 
 ### `kimi provider`

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -74,6 +74,9 @@ importers:
 
   apps/kimi-code:
     devDependencies:
+      '@electron/get':
+        specifier: ^4.0.0
+        version: 4.0.3
       '@moonshot-ai/acp-adapter':
         specifier: workspace:^
         version: link:../../packages/acp-adapter
@@ -125,6 +128,9 @@ importers:
       commander:
         specifier: ^13.1.0
         version: 13.1.0
+      extract-zip:
+        specifier: ^2.0.1
+        version: 2.0.1
       jimp:
         specifier: ^1.6.1
         version: 1.6.1
@@ -1571,6 +1577,10 @@ packages:
   '@dotenvx/primitives@0.8.0':
     resolution: {integrity: sha512-VYJy0uhFm9zTJ1TxBaW/pA8bjbOM/OttaNMwZ1RHG4JKyRG7DhSdiqD1ipQoAyoD22olUtxbP78W9xY3Wd11bg==}
 
+  '@electron/get@4.0.3':
+    resolution: {integrity: sha512-HgUXcnXF37bz26gvhx47f6g0hfI3tccxbTjG+SyKXaaSE3QapDzUF3bpxfgu+x5D+jtarNrpLCWlYARfZzirAQ==}
+    engines: {node: '>=22.12.0'}
+
   '@emnapi/core@1.10.0':
     resolution: {integrity: sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==}
 
@@ -2332,6 +2342,9 @@ packages:
 
   '@jsquash/webp@1.5.0':
     resolution: {integrity: sha512-KggLoj2MnRSfIqTeKe1EmbljTX2vuV7mh79k89PCL1pyqiDULcPM1L47twxXt0hkb68F70bXiL31MxsuoZtKFw==}
+
+  '@keyv/serialize@1.1.1':
+    resolution: {integrity: sha512-dXn3FZhPv0US+7dtJsIi2R+c7qWYiReoEh5zUntWCf4oSpMNib8FDhSoed6m3QyZdx5hK7iLFkYk3rNxwt8vTA==}
 
   '@loaderkit/resolve@1.0.4':
     resolution: {integrity: sha512-rJzYKVcV4dxJv+vW6jlvagF8zvGxHJ2+HTr1e2qOejfmGhAApgJHl8Aog4mMszxceTRiKTTbnpgmTO1bEZHV/A==}
@@ -4007,6 +4020,10 @@ packages:
     resolution: {integrity: sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==}
     engines: {node: '>=10'}
 
+  '@sindresorhus/is@7.2.0':
+    resolution: {integrity: sha512-P1Cz1dWaFfR4IR+U13mqqiGsLFf1KbayybWwdd2vfctdV6hDpUkgCY0nKOLLTMSoRd/jJNjtbqzf13K8DCCXQw==}
+    engines: {node: '>=18'}
+
   '@sindresorhus/merge-streams@2.3.0':
     resolution: {integrity: sha512-LtoMMhxAlorcGhmFYI+LhPgbPZCkgP6ra1YL604EeF6U98pLlQ3iWIGMdWSC+vWmPBWBNgmDBAhnAobLROJmwg==}
     engines: {node: '>=18'}
@@ -4409,6 +4426,9 @@ packages:
 
   '@types/hast@3.0.4':
     resolution: {integrity: sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==}
+
+  '@types/http-cache-semantics@4.2.0':
+    resolution: {integrity: sha512-L3LgimLHXtGkWikKnsPg0/VFx9OGZaC+eN1u4r+OB1XRqH3meBIAVC2zr1WdMH+RHmnRkqliQAOHNJ/E0j/e0Q==}
 
   '@types/istanbul-lib-coverage@2.0.6':
     resolution: {integrity: sha512-2QF/t/auWm0lsy8XtKVPG19v3sSOQlJe/YHZgfjb/KBBHOGSV+J2q/S671rcq9uTBrLAXmZpqJiaQbMT+zNU1w==}
@@ -5022,6 +5042,10 @@ packages:
   boolbase@1.0.0:
     resolution: {integrity: sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==}
 
+  boolean@3.2.0:
+    resolution: {integrity: sha512-d0II/GO9uf9lfUHH2BQsjxzRJZBdsjgsBiW4BvhWk/3qoKwQFjIDVN19PfX8F2D/r9PCMTtLWjYVCFrpeYUzsw==}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
+
   boundary@2.0.0:
     resolution: {integrity: sha512-rJKn5ooC9u8q13IMCrW0RSp31pxBCHE3y9V/tp3TdWSLf8Em3p6Di4NBpfzbJge9YjjFEsD0RtFEjtvHL5VyEA==}
 
@@ -5064,6 +5088,10 @@ packages:
     resolution: {integrity: sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==}
     engines: {node: '>=18'}
 
+  byte-counter@0.1.0:
+    resolution: {integrity: sha512-jheRLVMeUKrDBjVw2O5+k4EvR4t9wtxHL+bo/LxfkxsVeuGMy3a5SEGgXdAFA4FSzTrU8rQXQIrsZ3oBq5a0pQ==}
+    engines: {node: '>=20'}
+
   bytes@3.1.2:
     resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
     engines: {node: '>= 0.8'}
@@ -5076,6 +5104,14 @@ packages:
   cac@7.0.0:
     resolution: {integrity: sha512-tixWYgm5ZoOD+3g6UTea91eow5z6AAHaho3g0V9CNSNb45gM8SmflpAc+GRd1InC4AqN/07Unrgp56Y94N9hJQ==}
     engines: {node: '>=20.19.0'}
+
+  cacheable-lookup@7.0.0:
+    resolution: {integrity: sha512-+qJyx4xiKra8mZrcwhjMRMUhD5NR1R8esPkzIYxX96JiecFoxAXFuz/GpR3+ev4PE1WamHip78wV0vcmPQtp8w==}
+    engines: {node: '>=14.16'}
+
+  cacheable-request@13.0.19:
+    resolution: {integrity: sha512-SVXGH037+Mo1aIMO5B2UcleR43FGjFdN+M8JObSyEoQ2Mn4CODRWx28gN5jiTF0n5ItsgtIZfyargMNs8GX4kg==}
+    engines: {node: '>=18'}
 
   call-bind-apply-helpers@1.0.2:
     resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
@@ -5583,6 +5619,10 @@ packages:
   decode-named-character-reference@1.3.0:
     resolution: {integrity: sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==}
 
+  decompress-response@10.0.0:
+    resolution: {integrity: sha512-oj7KWToJuuxlPr7VV0vabvxEIiqNMo+q0NueIiL3XhtwC6FVOX7Hr1c0C4eD0bmf7Zr+S/dSf2xvkH3Ad6sU3Q==}
+    engines: {node: '>=20'}
+
   decompress-response@6.0.0:
     resolution: {integrity: sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==}
     engines: {node: '>=10'}
@@ -5655,6 +5695,9 @@ packages:
 
   detect-node-es@1.1.0:
     resolution: {integrity: sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==}
+
+  detect-node@2.1.0:
+    resolution: {integrity: sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==}
 
   devlop@1.1.0:
     resolution: {integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==}
@@ -5788,6 +5831,10 @@ packages:
     resolution: {integrity: sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==}
     engines: {node: '>=6'}
 
+  env-paths@3.0.0:
+    resolution: {integrity: sha512-dtJUTepzMW3Lm/NPxRf3wP4642UWhjL2sQxc+ym2YMj1m/H2zDNQOlezafzkHwn6sMstjHTwG6iQQsctDW/b1A==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
   environment@1.1.0:
     resolution: {integrity: sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==}
     engines: {node: '>=18'}
@@ -5824,6 +5871,9 @@ packages:
 
   es-toolkit@1.47.0:
     resolution: {integrity: sha512-n1GuoD0WEQZMBk5tttoZSqwgyLx01oqa5XsBmCHwPyNe1S9jPBEmtR2pSgp2kJuWE3ciFZ6yRHmY4pM4C3OOkw==}
+
+  es6-error@4.1.1:
+    resolution: {integrity: sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==}
 
   esbuild@0.21.5:
     resolution: {integrity: sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==}
@@ -5923,6 +5973,11 @@ packages:
   extendable-error@0.1.7:
     resolution: {integrity: sha512-UOiS2in6/Q0FK0R0q6UY9vYpQ21mr/Qn1KOnte7vsACuNJf514WvCCUHSRCPcgjPT2bAhNIJdlE6bVap1GKmeg==}
 
+  extract-zip@2.0.1:
+    resolution: {integrity: sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==}
+    engines: {node: '>= 10.17.0'}
+    hasBin: true
+
   fast-decode-uri-component@1.0.1:
     resolution: {integrity: sha512-WKgKWg5eUxvRZGwW8FvfbaH7AXSh2cL+3j5fMGzUMCxWBJ3dV3a7Wz8y2f/uQ0e3B6WmodD3oS54jTQ9HVTIIg==}
 
@@ -5968,6 +6023,9 @@ packages:
 
   fault@2.0.1:
     resolution: {integrity: sha512-WtySTkS4OKev5JtpHXnib4Gxiurzh5NCGvWrFaZ34m6JehfTUhKZvn9njTfw48t6JumVQOmrKqpmGcdwxnhqBQ==}
+
+  fd-slicer@1.1.0:
+    resolution: {integrity: sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==}
 
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
@@ -6043,6 +6101,10 @@ packages:
   foreground-child@3.3.1:
     resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
     engines: {node: '>=14'}
+
+  form-data-encoder@4.1.0:
+    resolution: {integrity: sha512-G6NsmEW15s0Uw9XnCg+33H3ViYRyiM0hMrMhhqQOR8NFc5GhYrI+6I3u7OTw7b91J2g8rtvMBZJDbcGb2YUniw==}
+    engines: {node: '>= 18'}
 
   form-data@4.0.6:
     resolution: {integrity: sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==}
@@ -6147,6 +6209,10 @@ packages:
     resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
     engines: {node: '>= 0.4'}
 
+  get-stream@5.2.0:
+    resolution: {integrity: sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==}
+    engines: {node: '>=8'}
+
   get-stream@6.0.1:
     resolution: {integrity: sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==}
     engines: {node: '>=10'}
@@ -6189,6 +6255,10 @@ packages:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
     deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
+  global-agent@3.0.0:
+    resolution: {integrity: sha512-PT6XReJ+D07JvGoxQMkT6qji/jVNfX/h364XHZOWeRzy64sSFr+xJ5OX7LI3b4MPQzdL4H8Y8M0xzPpsVMwA8Q==}
+    engines: {node: '>=10.0'}
+
   globalthis@1.0.4:
     resolution: {integrity: sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==}
     engines: {node: '>= 0.4'}
@@ -6212,6 +6282,10 @@ packages:
   gopd@1.2.0:
     resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
     engines: {node: '>= 0.4'}
+
+  got@14.6.6:
+    resolution: {integrity: sha512-QLV1qeYSo5l13mQzWgP/y0LbMr5Plr5fJilgAIwgnwseproEbtNym8xpLsDzeZ6MWXgNE6kdWGBjdh3zT/Qerg==}
+    engines: {node: '>=20'}
 
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
@@ -6344,6 +6418,9 @@ packages:
   htmlparser2@10.1.0:
     resolution: {integrity: sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ==}
 
+  http-cache-semantics@4.2.0:
+    resolution: {integrity: sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==}
+
   http-errors@2.0.1:
     resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
     engines: {node: '>= 0.8'}
@@ -6351,6 +6428,10 @@ packages:
   http-proxy-agent@7.0.2:
     resolution: {integrity: sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==}
     engines: {node: '>= 14'}
+
+  http2-wrapper@2.2.1:
+    resolution: {integrity: sha512-V5nVw1PAOgfI3Lmeaj2Exmeg7fenjhRUgz1lPSezy1CuhPYbgQtbQj4jZfEAEMlaL+vupsvhjqCyjzob0yxsmQ==}
+    engines: {node: '>=10.19.0'}
 
   https-proxy-agent@7.0.6:
     resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
@@ -6800,6 +6881,9 @@ packages:
   json-schema-typed@8.0.2:
     resolution: {integrity: sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==}
 
+  json-stringify-safe@5.0.1:
+    resolution: {integrity: sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==}
+
   json5@2.2.3:
     resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
     engines: {node: '>=6'}
@@ -6837,6 +6921,9 @@ packages:
 
   keytar@7.9.0:
     resolution: {integrity: sha512-VPD8mtVtm5JNtA2AErl6Chp06JBfy7diFQ7TQQhdpWOl6MrCRB+eRbvAZUsbGQS9kiMq0coJsy0W0vHpDCkWsQ==}
+
+  keyv@5.6.0:
+    resolution: {integrity: sha512-CYDD3SOtsHtyXeEORYRx2qBtpDJFjRTGXUtmNEMGyzYOKj1TE3tycdlho7kA1Ufx9OYWZzg52QFBGALTirzDSw==}
 
   khroma@2.1.0:
     resolution: {integrity: sha512-Ls993zuzfayK269Svk9hzpeGUKob/sIgZzyHYdjQoAdQetRKpOLj+k/QQQ/6Qi0Yz65mlROrfd+Ev+1+7dz9Kw==}
@@ -7108,6 +7195,10 @@ packages:
     resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
     hasBin: true
 
+  lowercase-keys@3.0.0:
+    resolution: {integrity: sha512-ozCC6gdQ+glXOQsveKD0YsDy8DSQFjDTz4zyzEHNV5+JP5D62LmfDZ6o1cycFx9ouG940M5dE8C8CTewdj2YWQ==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
   lowlight@1.20.0:
     resolution: {integrity: sha512-8Ktj+prEb1RoCPkEOrPMYUN/nCggB7qAWe3a7OpMjWQkh3l2RD5wKRQ+o8Q8YuI9RG/xs95waaI/E6ym/7NsTw==}
 
@@ -7169,6 +7260,10 @@ packages:
     resolution: {integrity: sha512-jcByLnIFkd5gSXZmjNvS1TlmRhCXZjIzHYlaGkPlLIekG55JDR2Z4va9tZwCiP+/RDERiNhMOFu01xd6O5ct1Q==}
     engines: {node: '>= 16'}
     hasBin: true
+
+  matcher@3.0.0:
+    resolution: {integrity: sha512-OkeDaAZ/bQCxeFAozM55PKcKU0yJMPGifLwV4Qgjitu+5MoAfSQN4lsLJeXZ1b8w0x+/Emda6MZgXS1jvsapng==}
+    engines: {node: '>=10'}
 
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
@@ -7389,6 +7484,10 @@ packages:
     resolution: {integrity: sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==}
     engines: {node: '>=10'}
 
+  mimic-response@4.0.0:
+    resolution: {integrity: sha512-e5ISH9xMYU0DzrT+jl8q2ze9D6eWBto+I8CNpe+VI+K2J/F/k3PdkdTdz4wvGVH4NTpo+NRYTVIuMQEMMcsLqg==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
   minimatch@10.2.3:
     resolution: {integrity: sha512-Rwi3pnapEqirPSbWbrZaa6N3nmqq4Xer/2XooiOKyV3q12ML06f7MOuc5DVH8ONZIFhwIYQ3yzPH4nt7iWHaTg==}
     engines: {node: 18 || 20 || >=22}
@@ -7543,6 +7642,10 @@ packages:
     resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
     engines: {node: '>=0.10.0'}
 
+  normalize-url@8.1.1:
+    resolution: {integrity: sha512-JYc0DPlpGWB40kH5g07gGTrYuMqV653k3uBKY6uITPWds3M0ov3GaWGp9lbE3Bzngx8+XkfzgvASb9vk9JDFXQ==}
+    engines: {node: '>=14.16'}
+
   npm-run-path@4.0.1:
     resolution: {integrity: sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==}
     engines: {node: '>=8'}
@@ -7674,6 +7777,10 @@ packages:
     peerDependenciesMeta:
       oxlint-tsgolint:
         optional: true
+
+  p-cancelable@4.0.1:
+    resolution: {integrity: sha512-wBowNApzd45EIKdO1LaU+LrMBwAcjfPaYtVzV3lmfM3gf8Z4CHZsiIqlM8TZZ8okYvh5A1cP6gTfCRQtwUpaUg==}
+    engines: {node: '>=14.16'}
 
   p-filter@2.1.0:
     resolution: {integrity: sha512-ZBxxZ5sL2HghephhpGAQdoskxplTwr7ICaehZwLIlfL6acuVgZPm8yBNuRAFBGEqtD/hmUeq9eqLg2ys9Xr/yw==}
@@ -7962,6 +8069,10 @@ packages:
   process-warning@5.0.0:
     resolution: {integrity: sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA==}
 
+  progress@2.0.3:
+    resolution: {integrity: sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==}
+    engines: {node: '>=0.4.0'}
+
   prompts@2.4.2:
     resolution: {integrity: sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==}
     engines: {node: '>= 6'}
@@ -8014,6 +8125,10 @@ packages:
 
   quick-format-unescaped@4.0.4:
     resolution: {integrity: sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==}
+
+  quick-lru@5.1.1:
+    resolution: {integrity: sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==}
+    engines: {node: '>=10'}
 
   radix-ui@1.6.2:
     resolution: {integrity: sha512-OwYUjzMwiInCUxgAWpPsavXC3Kh4iyi/49uU1/qZTG3RQDlvegyk1GOMiGvSkjua1RDb3JD3fo3eroL9FV4GQw==}
@@ -8226,6 +8341,9 @@ packages:
   resize-observer-polyfill@1.5.1:
     resolution: {integrity: sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg==}
 
+  resolve-alpn@1.2.1:
+    resolution: {integrity: sha512-0a1F4l73/ZFZOakJnQ3FvkJ2+gSTQWz/r2KE5OdDY0TxPm5h4GkqkWWfM47T7HsbnOtcJVEF4epCVy6u7Q3K+g==}
+
   resolve-from@4.0.0:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
     engines: {node: '>=4'}
@@ -8241,6 +8359,10 @@ packages:
     resolution: {integrity: sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==}
     engines: {node: '>= 0.4'}
     hasBin: true
+
+  responselike@4.0.2:
+    resolution: {integrity: sha512-cGk8IbWEAnaCpdAt1BHzJ3Ahz5ewDJa0KseTsE3qIRMJ3C698W8psM7byCeWVpd/Ha7FUYzuRVzXoKoM6nRUbA==}
+    engines: {node: '>=20'}
 
   restore-cursor@5.1.0:
     resolution: {integrity: sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==}
@@ -8267,6 +8389,10 @@ packages:
 
   rfdc@1.4.1:
     resolution: {integrity: sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==}
+
+  roarr@2.15.4:
+    resolution: {integrity: sha512-CHhPh+UNHD2GTXNYhPWLnU8ONHdI+5DI+4EYIAOaiD63rHeYlZvyh8P+in5999TTSFgUYuKUAjzRI4mdh/p+2A==}
+    engines: {node: '>=8.0'}
 
   robust-predicates@3.0.3:
     resolution: {integrity: sha512-NS3levdsRIUOmiJ8FZWCP7LG3QpJyrs/TE0Zpf1yvZu8cAJJ6QMW92H1c7kWpdIHo8RvmLxN/o2JXTKHp74lUA==}
@@ -8399,6 +8525,9 @@ packages:
   secure-json-parse@4.1.0:
     resolution: {integrity: sha512-l4KnYfEyqYJxDwlNVyRfO2E4NTHfMKAWdUuA8J0yve2Dz/E/PdBepY03RvyJpssIpRFwJoCD55wA+mEDs6ByWA==}
 
+  semver-compare@1.0.0:
+    resolution: {integrity: sha512-YM3/ITh2MJ5MtzaM429anh+x2jiLVjqILF4m4oyQB18W7Ggea7BfqdH/wGMK7dDiMghv/6WG7znWMwUDzJiXow==}
+
   semver@5.7.2:
     resolution: {integrity: sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==}
     hasBin: true
@@ -8415,6 +8544,10 @@ packages:
   send@1.2.1:
     resolution: {integrity: sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==}
     engines: {node: '>= 18'}
+
+  serialize-error@7.0.1:
+    resolution: {integrity: sha512-8I8TjW5KMOKsZQTvoxjuSIa7foAwPWGOts+6o7sgjz41/qMD9VQHEDxi6PBvK2l0MXUmqZyNpUK+T2tQaaElvw==}
+    engines: {node: '>=10'}
 
   serialize-javascript@6.0.2:
     resolution: {integrity: sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==}
@@ -8649,6 +8782,9 @@ packages:
   sprintf-js@1.0.3:
     resolution: {integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==}
 
+  sprintf-js@1.1.3:
+    resolution: {integrity: sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==}
+
   ssh2@1.17.0:
     resolution: {integrity: sha512-wPldCk3asibAjQ/kziWQQt1Wh3PgDFpC0XpwclzKcdT1vql6KeYxf5LIt4nlFkUeR8WuphYMKqUA56X4rjbfgQ==}
     engines: {node: '>=10.16.0'}
@@ -8772,6 +8908,10 @@ packages:
 
   stylis@4.4.0:
     resolution: {integrity: sha512-5Z9ZpRzfuH6l/UAvCPAPUo3665Nk2wLaZU3x+TLHKVzIz33+sbJqbtrYoC3KD4/uVOr2Zp+L0LySezP9OHV9yA==}
+
+  sumchecker@3.0.1:
+    resolution: {integrity: sha512-MvjXzkz/BOfyVDkG0oFOtBxHX2u3gKbMHIF/dXblZsgD3BWOFLmHovIpZY7BykJdAjcqRCBi1WYBNdEC9yI7vg==}
+    engines: {node: '>= 8.0'}
 
   superjson@2.2.6:
     resolution: {integrity: sha512-H+ue8Zo4vJmV2nRjpx86P35lzwDT3nItnIsocgumgr0hHMQ+ZGq5vrERg9kJBo5AWGmxZDhzDo+WVIJqkB0cGA==}
@@ -9044,6 +9184,10 @@ packages:
   type-detect@4.1.0:
     resolution: {integrity: sha512-Acylog8/luQ8L7il+geoSxhEkazvkslg7PSNKOX59mbB9cOveP5aq9h74Y7YU8yDpJwetzQQrfIwtf4Wp4LKcw==}
     engines: {node: '>=4'}
+
+  type-fest@0.13.1:
+    resolution: {integrity: sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==}
+    engines: {node: '>=10'}
 
   type-fest@4.41.0:
     resolution: {integrity: sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==}
@@ -9652,6 +9796,9 @@ packages:
   yauzl-promise@4.0.0:
     resolution: {integrity: sha512-/HCXpyHXJQQHvFq9noqrjfa/WpQC2XYs3vI7tBiAi4QiIU1knvYhZGaO1QPjwIVMdqflxbmwgMXtYeaRiAE0CA==}
     engines: {node: '>=16'}
+
+  yauzl@2.10.0:
+    resolution: {integrity: sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==}
 
   yauzl@3.3.0:
     resolution: {integrity: sha512-PtGEvEP30p7sbIBJKUBjUnqgTVOyMURc4dLo9iNyAJnNIEz9pm88cCXF21w94Kg3k6RXkeZh5DHOGS0qEONvNQ==}
@@ -10555,6 +10702,20 @@ snapshots:
 
   '@dotenvx/primitives@0.8.0': {}
 
+  '@electron/get@4.0.3':
+    dependencies:
+      debug: 4.4.3(supports-color@8.1.1)
+      env-paths: 3.0.0
+      got: 14.6.6
+      graceful-fs: 4.2.11
+      progress: 2.0.3
+      semver: 7.7.4
+      sumchecker: 3.0.1
+    optionalDependencies:
+      global-agent: 3.0.0
+    transitivePeerDependencies:
+      - supports-color
+
   '@emnapi/core@1.10.0':
     dependencies:
       '@emnapi/wasi-threads': 1.2.1
@@ -11252,6 +11413,8 @@ snapshots:
   '@jsquash/webp@1.5.0':
     dependencies:
       wasm-feature-detect: 1.8.0
+
+  '@keyv/serialize@1.1.1': {}
 
   '@loaderkit/resolve@1.0.4':
     dependencies:
@@ -12778,6 +12941,8 @@ snapshots:
 
   '@sindresorhus/is@4.6.0': {}
 
+  '@sindresorhus/is@7.2.0': {}
+
   '@sindresorhus/merge-streams@2.3.0': {}
 
   '@sindresorhus/merge-streams@4.0.0': {}
@@ -13181,6 +13346,8 @@ snapshots:
     dependencies:
       '@types/unist': 3.0.3
 
+  '@types/http-cache-semantics@4.2.0': {}
+
   '@types/istanbul-lib-coverage@2.0.6': {}
 
   '@types/js-cookie@3.0.6': {}
@@ -13347,7 +13514,7 @@ snapshots:
       obug: 2.1.1
       std-env: 4.0.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.4(@types/node@22.19.17)(@vitest/coverage-v8@4.1.4)(jsdom@25.0.1)(msw@2.15.0(@types/node@22.19.17)(typescript@6.0.2))(vite@6.4.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3))
+      vitest: 4.1.4(@types/node@22.19.17)(@vitest/coverage-v8@4.1.4)(jsdom@25.0.1)(msw@2.15.0(@types/node@22.19.17)(typescript@6.0.2))(vite@8.0.8(@types/node@22.19.17)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
 
   '@vitest/expect@4.1.4':
     dependencies:
@@ -13884,6 +14051,9 @@ snapshots:
 
   boolbase@1.0.0: {}
 
+  boolean@3.2.0:
+    optional: true
+
   boundary@2.0.0: {}
 
   brace-expansion@1.1.15:
@@ -13929,6 +14099,8 @@ snapshots:
     dependencies:
       run-applescript: 7.1.0
 
+  byte-counter@0.1.0: {}
+
   bytes@3.1.2: {}
 
   c8@9.1.0:
@@ -13946,6 +14118,18 @@ snapshots:
       yargs-parser: 21.1.1
 
   cac@7.0.0: {}
+
+  cacheable-lookup@7.0.0: {}
+
+  cacheable-request@13.0.19:
+    dependencies:
+      '@types/http-cache-semantics': 4.2.0
+      get-stream: 9.0.1
+      http-cache-semantics: 4.2.0
+      keyv: 5.6.0
+      mimic-response: 4.0.0
+      normalize-url: 8.1.1
+      responselike: 4.0.2
 
   call-bind-apply-helpers@1.0.2:
     dependencies:
@@ -14480,6 +14664,10 @@ snapshots:
     dependencies:
       character-entities: 2.0.2
 
+  decompress-response@10.0.0:
+    dependencies:
+      mimic-response: 4.0.0
+
   decompress-response@6.0.0:
     dependencies:
       mimic-response: 3.1.0
@@ -14534,6 +14722,9 @@ snapshots:
   detect-libc@2.1.2: {}
 
   detect-node-es@1.1.0: {}
+
+  detect-node@2.1.0:
+    optional: true
 
   devlop@1.1.0:
     dependencies:
@@ -14628,7 +14819,6 @@ snapshots:
   end-of-stream@1.4.5:
     dependencies:
       once: 1.4.0
-    optional: true
 
   enhanced-resolve@5.20.1:
     dependencies:
@@ -14647,6 +14837,8 @@ snapshots:
   entities@7.0.1: {}
 
   env-paths@2.2.1: {}
+
+  env-paths@3.0.0: {}
 
   environment@1.1.0: {}
 
@@ -14735,6 +14927,9 @@ snapshots:
       is-symbol: 1.1.1
 
   es-toolkit@1.47.0: {}
+
+  es6-error@4.1.1:
+    optional: true
 
   esbuild@0.21.5:
     optionalDependencies:
@@ -14928,6 +15123,16 @@ snapshots:
 
   extendable-error@0.1.7: {}
 
+  extract-zip@2.0.1:
+    dependencies:
+      debug: 4.4.3(supports-color@8.1.1)
+      get-stream: 5.2.0
+      yauzl: 2.10.0
+    optionalDependencies:
+      '@types/yauzl': 2.10.3
+    transitivePeerDependencies:
+      - supports-color
+
   fast-decode-uri-component@1.0.1: {}
 
   fast-deep-equal@3.1.3: {}
@@ -14998,6 +15203,10 @@ snapshots:
   fault@2.0.1:
     dependencies:
       format: 0.2.2
+
+  fd-slicer@1.1.0:
+    dependencies:
+      pend: 1.2.0
 
   fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
@@ -15076,6 +15285,8 @@ snapshots:
     dependencies:
       cross-spawn: 7.0.6
       signal-exit: 4.1.0
+
+  form-data-encoder@4.1.0: {}
 
   form-data@4.0.6:
     dependencies:
@@ -15186,6 +15397,10 @@ snapshots:
       dunder-proto: 1.0.1
       es-object-atoms: 1.1.1
 
+  get-stream@5.2.0:
+    dependencies:
+      pump: 3.0.4
+
   get-stream@6.0.1: {}
 
   get-stream@9.0.1:
@@ -15243,6 +15458,16 @@ snapshots:
       once: 1.4.0
       path-is-absolute: 1.0.1
 
+  global-agent@3.0.0:
+    dependencies:
+      boolean: 3.2.0
+      es6-error: 4.1.1
+      matcher: 3.0.0
+      roarr: 2.15.4
+      semver: 7.7.4
+      serialize-error: 7.0.1
+    optional: true
+
   globalthis@1.0.4:
     dependencies:
       define-properties: 1.2.1
@@ -15280,6 +15505,21 @@ snapshots:
   google-logging-utils@1.1.3: {}
 
   gopd@1.2.0: {}
+
+  got@14.6.6:
+    dependencies:
+      '@sindresorhus/is': 7.2.0
+      byte-counter: 0.1.0
+      cacheable-lookup: 7.0.0
+      cacheable-request: 13.0.19
+      decompress-response: 10.0.0
+      form-data-encoder: 4.1.0
+      http2-wrapper: 2.2.1
+      keyv: 5.6.0
+      lowercase-keys: 3.0.0
+      p-cancelable: 4.0.1
+      responselike: 4.0.2
+      type-fest: 4.41.0
 
   graceful-fs@4.2.11: {}
 
@@ -15461,6 +15701,8 @@ snapshots:
       domutils: 3.2.2
       entities: 7.0.1
 
+  http-cache-semantics@4.2.0: {}
+
   http-errors@2.0.1:
     dependencies:
       depd: 2.0.0
@@ -15475,6 +15717,11 @@ snapshots:
       debug: 4.4.3(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
+
+  http2-wrapper@2.2.1:
+    dependencies:
+      quick-lru: 5.1.1
+      resolve-alpn: 1.2.1
 
   https-proxy-agent@7.0.6:
     dependencies:
@@ -15902,6 +16149,9 @@ snapshots:
 
   json-schema-typed@8.0.2: {}
 
+  json-stringify-safe@5.0.1:
+    optional: true
+
   json5@2.2.3: {}
 
   jsonc-parser@3.3.1: {}
@@ -15960,6 +16210,10 @@ snapshots:
       node-addon-api: 4.3.0
       prebuild-install: 7.1.3
     optional: true
+
+  keyv@5.6.0:
+    dependencies:
+      '@keyv/serialize': 1.1.1
 
   khroma@2.1.0: {}
 
@@ -16176,6 +16430,8 @@ snapshots:
     dependencies:
       js-tokens: 4.0.0
 
+  lowercase-keys@3.0.0: {}
+
   lowlight@1.20.0:
     dependencies:
       fault: 1.0.4
@@ -16238,6 +16494,11 @@ snapshots:
   marked@18.0.5: {}
 
   marked@9.1.6: {}
+
+  matcher@3.0.0:
+    dependencies:
+      escape-string-regexp: 4.0.0
+    optional: true
 
   math-intrinsics@1.1.0: {}
 
@@ -16695,6 +16956,8 @@ snapshots:
   mimic-response@3.1.0:
     optional: true
 
+  mimic-response@4.0.0: {}
+
   minimatch@10.2.3:
     dependencies:
       brace-expansion: 5.0.6
@@ -16863,6 +17126,8 @@ snapshots:
 
   normalize-path@3.0.0: {}
 
+  normalize-url@8.1.1: {}
+
   npm-run-path@4.0.1:
     dependencies:
       path-key: 3.1.1
@@ -17028,6 +17293,8 @@ snapshots:
       '@oxlint/binding-win32-ia32-msvc': 1.59.0
       '@oxlint/binding-win32-x64-msvc': 1.59.0
       oxlint-tsgolint: 0.20.0
+
+  p-cancelable@4.0.1: {}
 
   p-filter@2.1.0:
     dependencies:
@@ -17293,6 +17560,8 @@ snapshots:
 
   process-warning@5.0.0: {}
 
+  progress@2.0.3: {}
+
   prompts@2.4.2:
     dependencies:
       kleur: 3.0.3
@@ -17343,7 +17612,6 @@ snapshots:
     dependencies:
       end-of-stream: 1.4.5
       once: 1.4.0
-    optional: true
 
   punycode.js@2.3.1: {}
 
@@ -17361,6 +17629,8 @@ snapshots:
   queue-microtask@1.2.3: {}
 
   quick-format-unescaped@4.0.4: {}
+
+  quick-lru@5.1.1: {}
 
   radix-ui@1.6.2(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5):
     dependencies:
@@ -17728,6 +17998,8 @@ snapshots:
 
   resize-observer-polyfill@1.5.1: {}
 
+  resolve-alpn@1.2.1: {}
+
   resolve-from@4.0.0: {}
 
   resolve-from@5.0.0: {}
@@ -17740,6 +18012,10 @@ snapshots:
       is-core-module: 2.16.2
       path-parse: 1.0.7
       supports-preserve-symlinks-flag: 1.0.0
+
+  responselike@4.0.2:
+    dependencies:
+      lowercase-keys: 3.0.0
 
   restore-cursor@5.1.0:
     dependencies:
@@ -17757,6 +18033,16 @@ snapshots:
   reusify@1.1.0: {}
 
   rfdc@1.4.1: {}
+
+  roarr@2.15.4:
+    dependencies:
+      boolean: 3.2.0
+      detect-node: 2.1.0
+      globalthis: 1.0.4
+      json-stringify-safe: 5.0.1
+      semver-compare: 1.0.0
+      sprintf-js: 1.1.3
+    optional: true
 
   robust-predicates@3.0.3: {}
 
@@ -17977,6 +18263,9 @@ snapshots:
 
   secure-json-parse@4.1.0: {}
 
+  semver-compare@1.0.0:
+    optional: true
+
   semver@5.7.2: {}
 
   semver@6.3.1: {}
@@ -17998,6 +18287,11 @@ snapshots:
       statuses: 2.0.2
     transitivePeerDependencies:
       - supports-color
+
+  serialize-error@7.0.1:
+    dependencies:
+      type-fest: 0.13.1
+    optional: true
 
   serialize-javascript@6.0.2:
     dependencies:
@@ -18276,6 +18570,9 @@ snapshots:
 
   sprintf-js@1.0.3: {}
 
+  sprintf-js@1.1.3:
+    optional: true
+
   ssh2@1.17.0:
     dependencies:
       asn1: 0.2.6
@@ -18409,6 +18706,12 @@ snapshots:
   stylis@4.2.0: {}
 
   stylis@4.4.0: {}
+
+  sumchecker@3.0.1:
+    dependencies:
+      debug: 4.4.3(supports-color@8.1.1)
+    transitivePeerDependencies:
+      - supports-color
 
   superjson@2.2.6:
     dependencies:
@@ -18660,6 +18963,9 @@ snapshots:
   type-detect@4.0.8: {}
 
   type-detect@4.1.0: {}
+
+  type-fest@0.13.1:
+    optional: true
 
   type-fest@4.41.0: {}
 
@@ -19276,6 +19582,11 @@ snapshots:
       '@node-rs/crc32': 1.10.6
       is-it-type: 5.1.3
       simple-invariant: 2.0.1
+
+  yauzl@2.10.0:
+    dependencies:
+      buffer-crc32: 0.2.13
+      fd-slicer: 1.1.0
 
   yauzl@3.3.0:
     dependencies:


### PR DESCRIPTION
## Related Issue

No tracking issue — the problem is explained below.

## Problem

When a Kimi Code session runs a long task in the terminal, there is no ambient way to tell what it is doing, when it is blocked waiting for an approval or an answer, or when it has finished — you have to keep switching back to the terminal to check. With several sessions running in different terminals this gets worse.

## What changed

Adds a `kimi pet` subcommand that launches a small always-on-top desktop pet (it floats above fullscreen windows too) mirroring the live status of running Kimi Code sessions, similar in spirit to codex pet.

- **Reporting protocol**: the CLI/TUI process subscribes to session events and wraps the approval/question handlers, writing one JSON state file per session under `<dataDir>/pet/sessions/` (status, current action summary, turn title, pid, terminal app) with TTL-based liveness, so a crashed CLI simply stops being reported. Wired into the TUI session lifecycle and the v1 headless (`-p`) path.
- **Overlay**: a detached Electron process (runtime downloaded lazily on first run via `@electron/get`, pinned version, cached under `<dataDir>/pet/electron/`) polls the state directory and renders the aggregate. The window hugs its content and stays bottom-center anchored.
- **Status surfacing**: working shows the current action (e.g. `Bash: npm test`) with rising work rings; awaiting an approval/question turns the pet orange with a glowing bubble; done shows a green check badge; failed shows a distinct crashed look. The Kimi mascot replica follows the cursor with its gaze and hops on hover/drag.
- **Multiple sessions**: aggregate by priority (awaiting > failed > working > done > idle) with a count badge on the pet; swiping on the bubble or clicking the badge pages through each session's bubble while the mascot itself always tracks the most urgent one. New urgent sessions preempt manual browsing.
- **Bubble actions**: focus the session's terminal app, or interrupt the session's current turn (SIGINT to the CLI process).
- **Settings**: right-click menu opens a settings window (smooth pet-size slider, bubble font size with a live preview bubble, CLI version in the corner) or quits the pet; settings persist across restarts.
- **Custom skins**: `kimi pet --skin <name>` loads a codex pet atlas format spritesheet from `<dataDir>/pet/pets/<name>/`.

The overlay is bundled separately (`tsdown.pet.config.ts` → `dist/pet-overlay.mjs`, ~17 KB gzip) so the main CLI bundle is unaffected; Electron is not an npm dependency, only a local type shim is committed.

## How to test

- **Unit**: `pnpm --filter @moonshot-ai/kimi-code exec vitest run test/pet test/cli/pet.test.ts` — 30 tests covering session-state aggregation/ranking, TTL/done demotion, overlay heartbeat liveness, settings clamping and merge-writes, reporter event mapping (working/awaiting/done/failed, title/status text), and the `kimi pet` subcommand deps (start/stop/already-running). The full app suite (2594 tests) also passes.
- **Manual**:
  1. `pnpm build && node apps/kimi-code/dist/main.mjs pet` — the pet appears at the screen corner; first run downloads the Electron runtime into `<dataDir>/pet/electron/`.
  2. Start a TUI session and run a task — the pet shows working rings and the bubble mirrors the current action; when an approval prompt appears the pet turns orange with a glowing bubble; on completion a green check badge shows for ~15s.
  3. Run two sessions at once — a count badge appears; swipe horizontally on the bubble (or click the badge) to page between session bubbles while the mascot keeps the most urgent status.
  4. Right-click the pet → 设置: drag the size slider (pet resizes live and smoothly), change the bubble font size (the preview bubble in the settings window updates live), version shows in the lower-left corner; settings persist across `kimi pet --stop` / restart.
  5. `kimi pet --stop` quits the overlay.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.
