### PR TITLE
fix(agent-core-v2): count compaction tokens on the full-request basis

### DIFF
--- a/.changeset/compaction-token-full-request-basis.md
+++ b/.changeset/compaction-token-full-request-basis.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Fix the token counts reported after compaction reading far below the real context size: the before/after stats and the context gauge now include the system prompt and tool definitions, matching the numbers shown while the session runs.

--- a/packages/agent-core-v2/src/agent/contextMemory/compactionHandoff.ts
+++ b/packages/agent-core-v2/src/agent/contextMemory/compactionHandoff.ts
@@ -54,6 +54,12 @@ export interface ContextCompactionShapeInput {
    *  the generated summary. Preferred over the summary-text estimate in the
    *  `tokensAfter` fallback when present. */
   readonly summaryOutputTokens?: number;
+  /** Estimated fixed request overhead (system prompt + non-deferred tool
+   *  schemas) surviving the compaction; counted into the `tokensAfter`
+   *  fallback so the result stays on the same full-request basis as the
+   *  measured exchange anchors. Live path only — replay reads the persisted
+   *  `tokensAfter` verbatim. */
+  readonly requestOverheadTokens?: number;
   readonly keptUserMessageCount?: number;
   readonly keptHeadUserMessageCount?: number;
   readonly droppedCount?: number;
@@ -111,7 +117,9 @@ export function buildContextCompactionShape(
   const contextSummary = input.contextSummary ?? input.summary;
   const tokensAfter =
     input.tokensAfter ??
-    (input.summaryOutputTokens ?? estimate.text(contextSummary)) + estimate.messages(keptMessages);
+    (input.requestOverheadTokens ?? 0) +
+      (input.summaryOutputTokens ?? estimate.text(contextSummary)) +
+      estimate.messages(keptMessages);
   const keptUserMessageCount =
     input.keptUserMessageCount ?? selection.head.length + selection.tail.length;
   const keptHeadUserMessageCount =

--- a/packages/agent-core-v2/src/agent/contextMemory/contextMemory.ts
+++ b/packages/agent-core-v2/src/agent/contextMemory/contextMemory.ts
@@ -14,6 +14,11 @@ export interface ContextCompactionInput {
    *  size); preferred over the summary-text estimate in the `tokensAfter`
    *  fallback when present. */
   readonly summaryOutputTokens?: number;
+  /** Estimated fixed request overhead (system prompt + non-deferred tool
+   *  schemas) that every post-compaction exchange still carries. Counted into
+   *  the `tokensAfter` fallback so the result stays on the same full-request
+   *  basis as the measured exchange anchors. */
+  readonly requestOverheadTokens?: number;
   readonly keptUserMessageCount?: number;
   readonly keptHeadUserMessageCount?: number;
   readonly droppedCount?: number;

--- a/packages/agent-core-v2/src/agent/fullCompaction/fullCompactionService.ts
+++ b/packages/agent-core-v2/src/agent/fullCompaction/fullCompactionService.ts
@@ -367,7 +367,7 @@ export class AgentFullCompactionService extends Service implements IAgentFullCom
         'Cannot compact while a turn is active. Wait for it to finish, then retry.',
       );
     }
-    return this.tokenCounting.estimateMessages(history);
+    return this.requestTokens(history);
   }
 
   private createActiveCompaction(
@@ -595,7 +595,7 @@ export class AgentFullCompactionService extends Service implements IAgentFullCom
   ): Promise<CompactionResult> {
     const startedAt = Date.now();
     const originalHistory = [...this.context.get()];
-    const tokensBefore = this.tokenCounting.estimateMessages(originalHistory);
+    const tokensBefore = this.requestTokens(originalHistory);
     let retryCount = 0;
     let thinkingEffort = this.profile.data().thinkingLevel;
 
@@ -719,6 +719,7 @@ export class AgentFullCompactionService extends Service implements IAgentFullCom
         compactedCount: originalHistory.length,
         tokensBefore,
         summaryOutputTokens: attempt.usage?.output,
+        requestOverheadTokens: this.requestTokens([]),
         droppedCount: droppedCount === 0 ? undefined : droppedCount,
       });
 

--- a/packages/agent-core-v2/src/agent/tokenCounting/tokenCountingOps.ts
+++ b/packages/agent-core-v2/src/agent/tokenCounting/tokenCountingOps.ts
@@ -89,7 +89,9 @@ export const tokenCountingTruncated = TokenCountingModel.defineOp('token_countin
 
 /** Clear / compaction: reset the ledger to a single anchor. Compaction passes
  *  `measured: false` — its `tokensAfter` blends a measured summary with
- *  estimated kept messages. */
+ *  estimated kept messages and the estimated request overhead (system prompt
+ *  + tools), keeping the anchor on the same full-request basis as measured
+ *  exchange anchors. */
 export const tokenCountingRebased = TokenCountingModel.defineOp('token_counting.rebased', {
   schema: sizeSchema.extend({ measured: z.boolean() }),
   persist: false,

--- a/packages/agent-core-v2/test/agent/contextMemory/context.test.ts
+++ b/packages/agent-core-v2/test/agent/contextMemory/context.test.ts
@@ -812,6 +812,31 @@ describe('Agent context', () => {
       );
       expect(withMeasured.messages).toEqual(withEstimate.messages);
     });
+
+    it('counts the request overhead into tokensAfter on the full-request basis', () => {
+      const history = [userMessage('u1'), {
+        role: 'assistant',
+        content: [{ type: 'text', text: 'a1' }],
+        toolCalls: [],
+      } as ContextMessage];
+
+      const withOverhead = buildContextCompactionShape(history, {
+        summary: 'summary',
+        compactedCount: 2,
+        tokensBefore: 0,
+        summaryOutputTokens: 500,
+        requestOverheadTokens: 3_000,
+      });
+      const withoutOverhead = buildContextCompactionShape(history, {
+        summary: 'summary',
+        compactedCount: 2,
+        tokensBefore: 0,
+        summaryOutputTokens: 500,
+      });
+
+      expect(withOverhead.tokensAfter).toBe(withoutOverhead.tokensAfter + 3_000);
+      expect(withOverhead.messages).toEqual(withoutOverhead.messages);
+    });
   });
 });
 

--- a/packages/agent-core-v2/test/agent/fullCompaction/fullCompaction.test.ts
+++ b/packages/agent-core-v2/test/agent/fullCompaction/fullCompaction.test.ts
@@ -303,7 +303,7 @@ describe('FullCompaction', () => {
       properties: expect.objectContaining({
         agent_id: 'main',
         source: 'manual',
-        tokens_before: 39,
+        tokens_before: 3_299,
         tokens_after: expect.any(Number),
         duration_ms: expect.any(Number),
         compacted_count: 6,
@@ -544,7 +544,7 @@ describe('FullCompaction', () => {
       session_id: 'test-session',
       cwd: dir,
       trigger: 'auto',
-      token_count: 39,
+      token_count: 3_299,
     });
     expect(post).toMatchObject({
       hook_event_name: 'PostCompact',
@@ -630,7 +630,7 @@ describe('FullCompaction', () => {
       event: 'compaction_finished',
       properties: expect.objectContaining({
         source: 'manual',
-        tokens_before: 25,
+        tokens_before: 14_365,
         retry_count: 1,
         trace_id: 'trace-compact-1',
       }),
@@ -1013,7 +1013,7 @@ describe('FullCompaction', () => {
       properties: expect.objectContaining({
         agent_id: 'main',
         source: 'manual',
-        tokens_before: 25,
+        tokens_before: 14_365,
         duration_ms: expect.any(Number),
         round: 1,
         retry_count: 0,
@@ -1238,7 +1238,7 @@ describe('FullCompaction', () => {
       event: 'compaction_failed',
       properties: expect.objectContaining({
         source: 'manual',
-        tokens_before: 25,
+        tokens_before: 14_365,
         duration_ms: expect.any(Number),
         retry_count: 4,
         error_type: 'APIConnectionError',
@@ -1435,7 +1435,10 @@ describe('FullCompaction', () => {
   });
 
   it('auto-compacts very large context in one full-history round when the summarizer accepts it', async () => {
-    const maxContextTokens = 4_000;
+    // The window must stay above the harness's fixed request overhead
+    // (system prompt + tools, ~14k): the post-compaction size is reported on
+    // the full-request basis, so a smaller window could never be satisfied.
+    const maxContextTokens = 20_000;
     const ctx = testAgent();
     ctx.configure({
       provider: CATALOGUED_PROVIDER,
@@ -1462,7 +1465,7 @@ describe('FullCompaction', () => {
     const compactedPrefixSizes = ctx.llmCalls.map((call) =>
       estimateTokensForMessages(call.history.slice(0, -1)),
     );
-    expect(initialTokens).toBeGreaterThan(maxContextTokens * 9);
+    expect(initialTokens).toBeGreaterThan(maxContextTokens);
     expect(countEvents(events, 'full_compaction.complete')).toBe(1);
     expect(countEvents(events, 'compaction.completed')).toBe(1);
     expect(compactedPrefixSizes).toHaveLength(1);
@@ -1610,11 +1613,12 @@ describe('FullCompaction', () => {
       event: 'compaction_finished',
       properties: expect.objectContaining({
         source: 'auto',
-        tokens_before: 46,
+        tokens_before: 3_306,
+        // 3260 estimated request-overhead tokens (system prompt + tools) +
         // 9 measured summary output tokens (scripted compaction exchange) +
         // 21 estimated tokens for the kept user messages — the summary
         // component is the REAL provider count, not a text estimate.
-        tokens_after: 30,
+        tokens_after: 3_290,
         compacted_count: 7,
         retry_count: 0,
       }),


### PR DESCRIPTION
## Related Issue

No linked issue — the problem is explained below.

## Problem

After compaction, the reported token counts read far below the real context size. The compaction result (`tokensBefore`/`tokensAfter`, shown in the compaction divider and used to rebase the context-size gauge) was computed on a messages-only basis — summary plus kept user messages — while the context size reported between exchanges comes from measured LLM usage, i.e. the full request (system prompt + tool schemas + messages + output). In a session with ~39k of fixed request overhead, compacting a ~90k context reported "→ 1.3k" even though the real next request was ~36.5k; the gauge dipped to the small messages-only estimate and then jumped back on the following exchange.

## What changed

- `tokensBefore` is now the full-request estimate (system prompt + non-deferred tools + messages) via the existing request-size helper.
- `tokensAfter` adds the estimated request overhead (system prompt + non-deferred tool schemas) on top of the measured summary output tokens and the kept user messages, so it stays on the same full-request basis as the measured exchange anchors. The token-counting ledger rebase after compaction carries this full-basis size, so the reported context size no longer dips and jumps.
- The PreCompact hook `tokenCount` uses the same basis.
- Wire replay still reads the persisted `tokensAfter` verbatim, so old compaction records restore unchanged.
- Tests: updated the exact token assertions to the new basis, added a shape-level test pinning the overhead component, and raised the synthetic model window in one test whose 4k window sits below the harness's fixed overhead under the new basis.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.
