### PR TITLE
fix(agent-core-v2): import LifecycleScope from the L3 scopes module

### DIFF
--- a/packages/agent-core-v2/src/session/sessionActivity/sessionOutcomeMirrorService.ts
+++ b/packages/agent-core-v2/src/session/sessionActivity/sessionOutcomeMirrorService.ts
@@ -14,7 +14,8 @@
  */
 
 import { Disposable, DisposableStore } from '#/_base/di/lifecycle';
-import { LifecycleScope, ScopeActivation, registerScopedService } from '#/_base/di/scope';
+import { LifecycleScope } from '#/app/scopes';
+import { ScopeActivation, registerScopedService } from '#/_base/di/scope';
 import { IEventBus } from '#/app/event/eventBus';
 import {
   IAgentLifecycleService,

--- a/packages/agent-core-v2/test/session/sessionActivity/sessionOutcomeMirror.test.ts
+++ b/packages/agent-core-v2/test/session/sessionActivity/sessionOutcomeMirror.test.ts
@@ -1,9 +1,9 @@
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 import { DisposableStore } from '#/_base/di/lifecycle';
+import { LifecycleScope } from '#/app/scopes';
 import {
   _clearScopedRegistryForTests,
-  LifecycleScope,
   ScopeActivation,
   registerScopedService,
   type IAgentScopeHandle,


### PR DESCRIPTION
## What

`sessionOutcomeMirrorService.ts` and its test imported `LifecycleScope` from `#/_base/di/scope`, but the L3 unit layer refactor (#2678) moved it to `#/app/scopes`. This broke typecheck (`TS2305`) and import-time evaluation on main after #2666 merged.

## Fix

Import `LifecycleScope` from `#/app/scopes` in both files, matching the convention of every other migrated module. No behavior change.

## Verification

- `agent-core-v2` typecheck + full vitest suite green (310 files / 4864 tests)
- `kap-server` typecheck + full suite green (66 / 987)
- `node-sdk` typecheck + suite green, `klient` typecheck green
- Root `pnpm run build` green