### PR TITLE
fix(agent-core): strip unsupported media only for explicit capability matrices

### DIFF
--- a/.changeset/strip-unknown-media.md
+++ b/.changeset/strip-unknown-media.md
@@ -1,5 +1,0 @@
----
-"@moonshot-ai/kimi-code": patch
----
-
-Strip image, video, and audio history parts when the model has no media input capability, including uncatalogued custom providers that previously failed every later turn with a provider 400.

--- a/.changeset/strip-unknown-media.md
+++ b/.changeset/strip-unknown-media.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Strip image, video, and audio history parts when the model has no media input capability, including uncatalogued custom providers that previously failed every later turn with a provider 400.

--- a/packages/agent-core/src/agent/turn/kosong-llm.ts
+++ b/packages/agent-core/src/agent/turn/kosong-llm.ts
@@ -19,7 +19,6 @@ import {
   emptyUsage,
   generate as kosongGenerate,
   isRetryableGenerateError,
-  isUnknownCapability,
   type ChatProvider,
   type ContentPart,
   type GenerateCallbacks,
@@ -301,7 +300,13 @@ export function downgradeUnsupportedMedia(
   messages: readonly Message[],
   capability: ModelCapability | undefined,
 ): Message[] {
-  if (capability === undefined || isUnknownCapability(capability)) return [...messages];
+  // Undefined = host did not supply a capability matrix; leave history alone.
+  // UNKNOWN_CAPABILITY and any known matrix with image_in/video_in/audio_in
+  // false must strip those parts: replaying image_url to a text-only
+  // OpenAI-compatible provider returns 400 and poisons every subsequent turn
+  // (#2669). UNKNOWN was previously exempt, which left custom providers that
+  // declare no vision (or are uncatalogued) unprotected.
+  if (capability === undefined) return [...messages];
   const dropImage = !capability.image_in;
   const dropVideo = !capability.video_in;
   const dropAudio = !capability.audio_in;

--- a/packages/agent-core/src/agent/turn/kosong-llm.ts
+++ b/packages/agent-core/src/agent/turn/kosong-llm.ts
@@ -19,6 +19,7 @@ import {
   emptyUsage,
   generate as kosongGenerate,
   isRetryableGenerateError,
+  isUnknownCapability,
   type ChatProvider,
   type ContentPart,
   type GenerateCallbacks,
@@ -300,13 +301,19 @@ export function downgradeUnsupportedMedia(
   messages: readonly Message[],
   capability: ModelCapability | undefined,
 ): Message[] {
-  // Undefined = host did not supply a capability matrix; leave history alone.
-  // UNKNOWN_CAPABILITY and any known matrix with image_in/video_in/audio_in
-  // false must strip those parts: replaying image_url to a text-only
-  // OpenAI-compatible provider returns 400 and poisons every subsequent turn
-  // (#2669). UNKNOWN was previously exempt, which left custom providers that
-  // declare no vision (or are uncatalogued) unprotected.
-  if (capability === undefined) return [...messages];
+  // Leave history alone when the host omitted a matrix (undefined) or only
+  // knows the model is uncatalogued (UNKNOWN_CAPABILITY). UNKNOWN means "we
+  // do not know", not "text-only" — a multimodal custom model can still use
+  // that marker (SingleModelProvider default, KimiForCodingProvider).
+  //
+  // Explicit matrices still strip: ProviderManager merges declared
+  // capabilities with the catalog into a plain ModelCapability object, so a
+  // text-only custom model configured as capabilities = ["thinking",
+  // "tool_use"] gets image_in: false without the UNKNOWN marker and is
+  // protected against image_url 400s that brick later turns (#2669).
+  if (capability === undefined || isUnknownCapability(capability)) {
+    return [...messages];
+  }
   const dropImage = !capability.image_in;
   const dropVideo = !capability.video_in;
   const dropAudio = !capability.audio_in;

--- a/packages/agent-core/test/agent/kosong-llm.test.ts
+++ b/packages/agent-core/test/agent/kosong-llm.test.ts
@@ -440,10 +440,36 @@ describe('downgradeUnsupportedMedia', () => {
     expect(out[0]?.content).toEqual([imagePart, videoPart]);
   });
 
-  it('does not downgrade for UNKNOWN_CAPABILITY or an undefined capability', () => {
+  it('does not downgrade when capability is undefined (host omitted matrix)', () => {
     const input = [mediaMessage([videoPart])];
-    expect(downgradeUnsupportedMedia(input, UNKNOWN_CAPABILITY)[0]?.content).toEqual([videoPart]);
     expect(downgradeUnsupportedMedia(input, undefined)[0]?.content).toEqual([videoPart]);
+  });
+
+  it('strips media for UNKNOWN_CAPABILITY (image_in/video_in/audio_in are false)', () => {
+    // Custom OpenAI-compatible text-only providers are often uncatalogued;
+    // replaying image_url to them returns 400 and bricks the session (#2669).
+    const input = [mediaMessage([imagePart, videoPart, audioPart])];
+    expect(downgradeUnsupportedMedia(input, UNKNOWN_CAPABILITY)[0]?.content).toEqual([
+      { type: 'text', text: '[image omitted: current model has no image input]' },
+      { type: 'text', text: '[video omitted: current model has no video input]' },
+      { type: 'text', text: '[audio omitted: current model has no audio input]' },
+    ]);
+  });
+
+  it('strips images when capabilities declare thinking/tool_use but not image_in', () => {
+    const capability: ModelCapability = {
+      image_in: false,
+      video_in: false,
+      audio_in: false,
+      thinking: true,
+      tool_use: true,
+      max_context_tokens: 128_000,
+    };
+    const input = [mediaMessage([{ type: 'text', text: 'see this' }, imagePart])];
+    expect(downgradeUnsupportedMedia(input, capability)[0]?.content).toEqual([
+      { type: 'text', text: 'see this' },
+      { type: 'text', text: '[image omitted: current model has no image input]' },
+    ]);
   });
 
   it('returns a new array and never mutates the caller input', () => {

--- a/packages/agent-core/test/agent/kosong-llm.test.ts
+++ b/packages/agent-core/test/agent/kosong-llm.test.ts
@@ -445,18 +445,20 @@ describe('downgradeUnsupportedMedia', () => {
     expect(downgradeUnsupportedMedia(input, undefined)[0]?.content).toEqual([videoPart]);
   });
 
-  it('strips media for UNKNOWN_CAPABILITY (image_in/video_in/audio_in are false)', () => {
-    // Custom OpenAI-compatible text-only providers are often uncatalogued;
-    // replaying image_url to them returns 400 and bricks the session (#2669).
+  it('preserves media for UNKNOWN_CAPABILITY (uncatalogued ≠ text-only)', () => {
+    // UNKNOWN is the SingleModelProvider / unresolved default: the model may
+    // still be multimodal. Explicit text-only matrices are covered below.
     const input = [mediaMessage([imagePart, videoPart, audioPart])];
     expect(downgradeUnsupportedMedia(input, UNKNOWN_CAPABILITY)[0]?.content).toEqual([
-      { type: 'text', text: '[image omitted: current model has no image input]' },
-      { type: 'text', text: '[video omitted: current model has no video input]' },
-      { type: 'text', text: '[audio omitted: current model has no audio input]' },
+      imagePart,
+      videoPart,
+      audioPart,
     ]);
   });
 
-  it('strips images when capabilities declare thinking/tool_use but not image_in', () => {
+  it('strips images when an explicit matrix has no image_in (#2669)', () => {
+    // ProviderManager resolves declared capabilities into a plain object
+    // (not the UNKNOWN marker), e.g. capabilities = ["thinking", "tool_use"].
     const capability: ModelCapability = {
       image_in: false,
       video_in: false,


### PR DESCRIPTION
## Summary
- `downgradeUnsupportedMedia` must **not** treat `UNKNOWN_CAPABILITY` as text-only: that marker means uncatalogued (e.g. `SingleModelProvider` default) and can still represent a multimodal model.
- Stripping remains for **explicit** capability matrices with `image_in` / `video_in` / `audio_in` false — the shape `ProviderManager` produces from declared config such as `capabilities = ["thinking", "tool_use"]`.
- Documents and locks that distinction with regression tests (Codex P1).

Related to #2669 (text-only custom providers with an explicit no-vision matrix).

## Test plan
- [x] `vitest run test/agent/kosong-llm.test.ts` in `packages/agent-core` (18 passed)
  - preserves media for `UNKNOWN_CAPABILITY`
  - strips images for an explicit matrix without `image_in`