### PR TITLE
fix(agent-core-v2): degrade idle-session steer to turn launch like v1

### DIFF
--- a/.changeset/steer-goal-turn-boundary.md
+++ b/.changeset/steer-goal-turn-boundary.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Fix a spurious "Failed to steer" error when sending a message while a goal run is between turns.

--- a/packages/agent-core-v2/src/agent/rpc/rpcService.ts
+++ b/packages/agent-core-v2/src/agent/rpc/rpcService.ts
@@ -6,7 +6,7 @@ import { IAgentTokenCountingService } from '#/agent/tokenCounting/tokenCounting'
 import { IAgentFullCompactionService } from '#/agent/fullCompaction/fullCompaction';
 import { IEventBus } from '#/app/event/eventBus';
 import { IEventService } from '#/app/event/event';
-import { ErrorCodes, Error2 } from '#/errors';
+import { ErrorCodes, Error2, isError2 } from '#/errors';
 import { IAgentPermissionModeService } from '#/agent/permissionMode/permissionMode';
 import { IAgentScopeContext } from '#/agent/scopeContext/scopeContext';
 import {
@@ -112,14 +112,37 @@ export class AgentRPCService implements IAgentRPCService {
 
   async steer(payload: SteerPayload): Promise<PromptLaunchResult | undefined> {
     this.telemetry.track2('input_steer', { parts: payload.input.length });
+    if (this.scopeContext.agentId === MAIN_AGENT_ID) {
+      // A steer is user input like a prompt — and can even launch the
+      // session's first turn (e.g. goal mode) — so keep title/lastPrompt in
+      // sync the same way, matching v1.
+      await this.updatePromptMetadata(promptMetadataTextFromPayload(payload));
+    }
     const queued = await this.promptService.enqueue({ message: {
       role: 'user',
       content: [...payload.input],
       toolCalls: [],
     } });
-    const [steered] = await this.promptService.steer([queued.id]);
-    const turn = await steered?.launched;
-    return turn === undefined ? undefined : { turn_id: turn.id };
+    if (queued.state !== 'pending') {
+      // No active prompt at enqueue time, so the enqueue itself already
+      // launched this input as its own turn (idle session, or a goal-turn
+      // boundary where the previous turn just ended) — v1's
+      // steer-degrades-to-launch end state. Return that turn instead of
+      // rejecting on a steer-by-id that can never find the record pending.
+      const turn = await queued.launched;
+      return turn === undefined ? undefined : { turn_id: turn.id };
+    }
+    try {
+      const [steered] = await this.promptService.steer([queued.id]);
+      const turn = await steered?.launched;
+      return turn === undefined ? undefined : { turn_id: turn.id };
+    } catch (error) {
+      // Pending but nothing active to steer into (a manual compaction holds
+      // the context): the message stays queued and launches once compaction
+      // finishes, so report it as queued rather than failing the steer.
+      if (isError2(error) && error.code === ErrorCodes.PROMPT_NOT_FOUND) return undefined;
+      throw error;
+    }
   }
 
   cancel({ turnId }: CancelPayload): void {

--- a/packages/node-sdk/src/sdk-rpc-client-v2.ts
+++ b/packages/node-sdk/src/sdk-rpc-client-v2.ts
@@ -1608,12 +1608,10 @@ export class SDKRpcClientV2 extends SDKRpcClientBase {
   }
 
   /**
-   * Facade (`agentRPCService.steer`). Mid-turn steers match v1 (the input
-   * joins the running turn). The idle-session case diverges by design and is
-   * pinned in the parity tests: v1 launches a fresh turn off a steer and
-   * updates title/lastPrompt like a prompt; v2's enqueue launches the turn
-   * first, so the follow-up `steer()` finds nothing pending and rejects with
-   * `prompt.not_found` — and the v2 RPC path never touches the metadata.
+   * Facade (`agentRPCService.steer`). Matches v1 on both paths: mid-turn
+   * steers join the running turn, and an idle-session steer degrades to
+   * launching a fresh turn (the enqueue launches it directly) while
+   * title/lastPrompt are updated like a prompt's.
    */
   override async steer(input: SessionPromptRpcInput): Promise<void> {
     const agent = await this.agentFacade(input.sessionId);

--- a/packages/node-sdk/test/v1-v2-parity.test.ts
+++ b/packages/node-sdk/test/v1-v2-parity.test.ts
@@ -2423,28 +2423,26 @@ describe('v1↔v2 agent interaction parity', () => {
     }
   });
 
-  it('steer on an idle session: v1 launches a turn, v2 rejects prompt.not_found (pinned)', async () => {
+  it('steer on an idle session: both engines launch a turn and update metadata', async () => {
     const restoreEnv = scrubConfigEnv();
     const pair = await makeSessionParityPair();
     try {
       await createOnBoth(pair, { id: 'session_parity_agent_steer' });
       const input = { sessionId: 'session_parity_agent_steer' } as const;
-      // Pinned divergence: v1 treats an idle steer like a prompt — it
-      // launches a fresh turn and updates title/lastPrompt. v2's steer RPC
-      // enqueues first (which itself launches the turn), so the follow-up
-      // steer step finds no pending prompt and rejects with prompt.not_found;
-      // the v2 path never touches the metadata.
+      // v1 treats an idle steer like a prompt — it launches a fresh turn and
+      // updates title/lastPrompt. v2's steer RPC enqueues first (which itself
+      // launches the turn) and converges on the same end state: the launched
+      // turn is returned instead of rejecting, and the metadata is updated.
       await pair.v1.steer({ ...input, input: [{ type: 'text', text: 'steer text' }] });
-      await expect(
-        pair.v2.steer({ ...input, input: [{ type: 'text', text: 'steer text' }] }),
-      ).rejects.toMatchObject({ code: 'prompt.not_found' });
+      await pair.v2.steer({ ...input, input: [{ type: 'text', text: 'steer text' }] });
       const [v1List, v2List] = await Promise.all([
         pair.v1.listSessions(),
         pair.v2.listSessions(),
       ]);
       expect(v1List[0]?.title).toBe('steer text');
       expect(v1List[0]?.lastPrompt).toBe('steer text');
-      expect(v2List[0]?.lastPrompt).not.toBe('steer text');
+      expect(v2List[0]?.title).toBe('steer text');
+      expect(v2List[0]?.lastPrompt).toBe('steer text');
       await settleTurns();
     } finally {
       await closeSessionPair(pair);


### PR DESCRIPTION
## Related Issue

No linked issue — the problem is explained below.

## Problem

Sending a message (steer) while a goal run is between turns — or on an idle session — made v2 reject with a spurious `prompt.not_found` ("Failed to steer") error. v1 treats an idle steer like a prompt: it launches a fresh turn and updates the session title/lastPrompt. v2's steer RPC enqueues first, and the enqueue itself already launches the turn when nothing is pending, so the follow-up steer-by-id could never find the record pending and rejected. The v2 path also never synced the title/lastPrompt metadata.

## What changed

- `packages/agent-core-v2/src/agent/rpc/rpcService.ts`: when the enqueued message is no longer pending (the enqueue already launched it as its own turn), return that turn instead of rejecting — v1's steer-degrades-to-launch end state. When the message is pending but there is nothing active to steer into (a manual compaction holds the context), report it as queued (`undefined`) instead of failing, since it launches once compaction finishes. Also sync title/lastPrompt metadata on main-agent steer, matching v1's prompt behavior.
- `packages/node-sdk/src/sdk-rpc-client-v2.ts`: update the `steer` facade doc comment to describe the converged v1/v2 behavior.
- `packages/node-sdk/test/v1-v2-parity.test.ts`: replace the pinned-divergence test with one asserting both engines launch a turn and update metadata on an idle-session steer.

This approach keeps the fix at the RPC boundary, matching v1 semantics without changing the underlying prompt/steer pipeline.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.
