### PR TITLE
fix(mcp): discover OAuth from server metadata

### DIFF
--- a/.changeset/honest-mcp-oauth-discovery.md
+++ b/.changeset/honest-mcp-oauth-discovery.md
@@ -1,0 +1,6 @@
+---
+"@moonshot-ai/kimi-code": patch
+"@moonshot-ai/kimi-code-sdk": patch
+---
+
+Detect MCP OAuth support through standard metadata instead of explicit markers or arbitrary 401 responses, and report discovery failures as an unknown authorization status.

--- a/packages/agent-core-v2/src/mcpCore/config-schema.ts
+++ b/packages/agent-core-v2/src/mcpCore/config-schema.ts
@@ -5,11 +5,9 @@
  * the shape of MCP server entries as they appear in configuration (whether in
  * `config.toml` or an MCP-specific config file).
  *
- * Remote variants accept `auth: "oauth"`, mirroring v1: OAuth is still
- * discovered from a remote server's 401 response; the flag records that the
- * user explicitly chose OAuth, so static `headers` on the same entry are
- * treated as plain request headers (capability/identity declarations) rather
- * than as the server's credentials.
+ * Remote variants retain `auth: "oauth"` for compatibility with existing
+ * configuration and older hosts. Current OAuth discovery, status, and login
+ * do not depend on this marker.
  */
 
 import { z } from 'zod';

--- a/packages/agent-core-v2/src/mcpCore/connection-manager.ts
+++ b/packages/agent-core-v2/src/mcpCore/connection-manager.ts
@@ -31,6 +31,7 @@ import { SseMcpClient } from './client-sse';
 import type { UnexpectedCloseReason } from './client-shared';
 import { StdioMcpClient } from './client-stdio';
 import type { McpOAuthService } from '#/mcpCore/oauth/service';
+import { discoverMcpOAuth, hasAuthorizationHeader } from '#/mcpCore/oauth/discovery';
 import { assertMcpInputSchema, type MCPClient, type MCPToolDefinition } from './types';
 
 export type McpServerStatus = 'pending' | 'connected' | 'failed' | 'disabled' | 'needs-auth' | 'removed';
@@ -319,6 +320,7 @@ export class McpConnectionManager implements McpConnectionView {
       entry.config.startupTimeoutMs ??
       this.options.resolveDefaultTimeouts?.().startupTimeoutMs ??
       DEFAULT_STARTUP_TIMEOUT_MS;
+    const startupDeadlineMs = Date.now() + timeoutMs;
 
     let client: RuntimeMcpClient | undefined;
     try {
@@ -348,7 +350,7 @@ export class McpConnectionManager implements McpConnectionView {
         }
         return;
       }
-      if (this.shouldMarkNeedsAuth(entry, error)) {
+      if (await this.shouldMarkNeedsAuth(entry, error, startupDeadlineMs)) {
         entry.status = 'needs-auth';
         entry.error = `${entry.name} requires OAuth — run /mcp-config login ${entry.name}`;
       } else {
@@ -430,16 +432,36 @@ export class McpConnectionManager implements McpConnectionView {
     if (oauthService === undefined) return undefined;
     if (!isRemoteMcpConfig(config)) return undefined;
     if (config.bearerTokenEnvVar !== undefined) return undefined;
+    if (hasAuthorizationHeader(config.headers)) return undefined;
     if (!(await oauthService.hasTokens(name, config.url))) return undefined;
     return oauthService.getProvider(name, config.url);
   }
 
-  private shouldMarkNeedsAuth(entry: InternalEntry, error: unknown): boolean {
-    if (this.oauthService === undefined) return false;
+  private async shouldMarkNeedsAuth(
+    entry: InternalEntry,
+    error: unknown,
+    startupDeadlineMs: number,
+  ): Promise<boolean> {
+    const oauthService = this.oauthService;
+    if (oauthService === undefined) return false;
     if (!isRemoteMcpConfig(entry.config)) return false;
     if (entry.config.bearerTokenEnvVar !== undefined) return false;
-    if (entry.config.headers !== undefined && entry.config.auth !== 'oauth') return false;
-    return isUnauthorizedLikeError(error);
+    if (hasAuthorizationHeader(entry.config.headers)) return false;
+    if (!isUnauthorizedLikeError(error)) return false;
+    const remainingMs = startupDeadlineMs - Date.now();
+    if (remainingMs <= 0) return false;
+    try {
+      const discoveryState = await discoverMcpOAuth(entry.config.url, entry.config.headers, {
+        timeoutMs: remainingMs,
+      });
+      if (discoveryState === undefined) return false;
+      await oauthService
+        .getProvider(entry.name, entry.config.url)
+        .saveDiscoveryState(discoveryState);
+      return true;
+    } catch {
+      return false;
+    }
   }
 
   private async connectAndDiscoverTools(

--- a/packages/agent-core-v2/src/mcpCore/oauth/discovery.ts
+++ b/packages/agent-core-v2/src/mcpCore/oauth/discovery.ts
@@ -1,0 +1,223 @@
+import {
+  discoverAuthorizationServerMetadata,
+  discoverOAuthProtectedResourceMetadata,
+  extractWWWAuthenticateParams,
+  type OAuthDiscoveryState,
+} from '@modelcontextprotocol/sdk/client/auth.js';
+import type { FetchLike } from '@modelcontextprotocol/sdk/shared/transport.js';
+import {
+  checkResourceAllowed,
+  resourceUrlFromServerUrl,
+} from '@modelcontextprotocol/sdk/shared/auth-utils.js';
+
+const DEFAULT_DISCOVERY_TIMEOUT_MS = 5_000;
+const MAX_REDIRECTS = 5;
+
+export interface McpOAuthDiscoveryOptions {
+  readonly timeoutMs?: number;
+}
+
+export function hasAuthorizationHeader(headers: Record<string, string> | undefined): boolean {
+  return Object.keys(headers ?? {}).some((name) => name.toLowerCase() === 'authorization');
+}
+
+export function createMcpOAuthFetch(
+  serverUrl: string | URL,
+  configuredHeaders: Record<string, string> | undefined,
+  timeoutMs = DEFAULT_DISCOVERY_TIMEOUT_MS,
+): FetchLike {
+  const resourceOrigin = new URL(serverUrl).origin;
+  const extraHeaders = new Headers(configuredHeaders);
+  const hasConfiguredHeaders = [...extraHeaders].length > 0;
+  const deadlineMs = Date.now() + timeoutMs;
+
+  return async (input, init = {}) => {
+    const initialUrl = input instanceof Request ? input.url : input;
+    const initialHeaders = new Headers(input instanceof Request ? input.headers : undefined);
+    new Headers(init.headers).forEach((value, name) => {
+      initialHeaders.set(name, value);
+    });
+    let url = new URL(initialUrl);
+    let requestInit: RequestInit = { ...init, headers: initialHeaders };
+
+    for (let redirectCount = 0; ; redirectCount++) {
+      const headers = new Headers(requestInit.headers);
+      if (url.origin === resourceOrigin) {
+        extraHeaders.forEach((value, name) => {
+          if (!headers.has(name)) headers.set(name, value);
+        });
+      }
+      const remainingMs = deadlineMs - Date.now();
+      if (remainingMs <= 0) throw new Error('MCP OAuth discovery timeout exceeded');
+      const timeoutSignal = AbortSignal.timeout(remainingMs);
+      const signal = requestInit.signal
+        ? AbortSignal.any([requestInit.signal, timeoutSignal])
+        : timeoutSignal;
+      const response = await fetch(url, {
+        ...requestInit,
+        headers,
+        redirect: 'manual',
+        signal,
+      });
+      if (!isRedirect(response.status)) return response;
+
+      const location = response.headers.get('location');
+      if (location === null) return response;
+      if (redirectCount >= MAX_REDIRECTS) {
+        await response.body?.cancel();
+        throw new Error(`OAuth discovery exceeded ${MAX_REDIRECTS} redirects`);
+      }
+      const nextUrl = new URL(location, url);
+      if (hasConfiguredHeaders && nextUrl.origin !== url.origin) {
+        await response.body?.cancel();
+        throw new Error(
+          `OAuth discovery redirect to non-same-origin URL rejected: ${nextUrl.toString()}`,
+        );
+      }
+      await response.body?.cancel();
+      requestInit = redirectedRequestInit(requestInit, response.status);
+      url = nextUrl;
+    }
+  };
+}
+
+export async function discoverMcpOAuth(
+  serverUrl: string | URL,
+  configuredHeaders: Record<string, string> | undefined,
+  options: McpOAuthDiscoveryOptions = {},
+): Promise<OAuthDiscoveryState | undefined> {
+  const resourceUrl = new URL(serverUrl);
+  const fetchFn = createMcpOAuthFetch(resourceUrl, configuredHeaders, options.timeoutMs);
+  let resourceMetadata;
+  let resourceMetadataUrl: URL | undefined;
+
+  const response = await fetchFn(resourceUrl, {
+    method: 'GET',
+    headers: { Accept: 'application/json, text/event-stream' },
+  });
+  try {
+    if (
+      response.status >= 500 ||
+      response.status === 408 ||
+      response.status === 425 ||
+      response.status === 429
+    ) {
+      throw new Error(
+        `HTTP ${response.status} probing MCP OAuth support at ${resourceUrl.toString()}`,
+      );
+    }
+    if (response.status === 401) {
+      resourceMetadataUrl = extractWWWAuthenticateParams(response).resourceMetadataUrl;
+    }
+  } finally {
+    await response.body?.cancel();
+  }
+
+  if (resourceMetadataUrl !== undefined) {
+    resourceMetadata = await discoverOAuthProtectedResourceMetadata(
+      resourceUrl,
+      { resourceMetadataUrl },
+      fetchFn,
+    );
+  } else {
+    try {
+      resourceMetadata = await discoverOAuthProtectedResourceMetadata(
+        resourceUrl,
+        undefined,
+        fetchFn,
+      );
+    } catch (error) {
+      if (!isMissingProtectedResourceMetadata(error)) throw error;
+    }
+  }
+
+  if (
+    resourceMetadata !== undefined &&
+    !checkResourceAllowed({
+      requestedResource: resourceUrlFromServerUrl(resourceUrl),
+      configuredResource: resourceMetadata.resource,
+    })
+  ) {
+    throw new Error(
+      `Protected resource ${resourceMetadata.resource} does not match expected ${resourceUrlFromServerUrl(resourceUrl).toString()}`,
+    );
+  }
+  let authorizationServerUrl =
+    resourceMetadata?.authorization_servers?.[0] ?? resourceUrl.toString();
+  let authorizationServerMetadata = await discoverMcpAuthorizationServerMetadata(
+    authorizationServerUrl,
+    fetchFn,
+  );
+  if (authorizationServerMetadata === undefined && resourceMetadata === undefined) {
+    const legacyRootUrl = new URL('/', resourceUrl).toString();
+    if (legacyRootUrl !== authorizationServerUrl) {
+      const legacyRootMetadata = await discoverMcpAuthorizationServerMetadata(
+        legacyRootUrl,
+        fetchFn,
+      );
+      if (legacyRootMetadata !== undefined) {
+        authorizationServerUrl = legacyRootUrl;
+        authorizationServerMetadata = legacyRootMetadata;
+      }
+    }
+  }
+  if (authorizationServerMetadata === undefined) return undefined;
+  return {
+    authorizationServerUrl,
+    authorizationServerMetadata,
+    ...(resourceMetadata === undefined ? {} : { resourceMetadata }),
+    ...(resourceMetadataUrl === undefined
+      ? {}
+      : { resourceMetadataUrl: resourceMetadataUrl.toString() }),
+  };
+}
+
+async function discoverMcpAuthorizationServerMetadata(
+  authorizationServerUrl: string | URL,
+  fetchFn: FetchLike,
+) {
+  const expectedIssuer = new URL(authorizationServerUrl).toString();
+  return discoverAuthorizationServerMetadata(authorizationServerUrl, {
+    fetchFn: async (input, init) => {
+      const response = await fetchFn(input, init);
+      if (!response.ok) return response;
+      const metadata = JSON.parse(await response.text()) as Record<string, unknown>;
+      const issuer = metadata['issuer'];
+      if (issuer === undefined) {
+        metadata['issuer'] = expectedIssuer;
+      } else if (
+        typeof issuer === 'string' &&
+        new URL(issuer).toString() !== expectedIssuer
+      ) {
+        throw new Error(
+          `Authorization server issuer ${issuer} does not match expected ${expectedIssuer}`,
+        );
+      }
+      return new Response(JSON.stringify(metadata), {
+        status: response.status,
+        statusText: response.statusText,
+        headers: response.headers,
+      });
+    },
+  });
+}
+
+function isMissingProtectedResourceMetadata(error: unknown): boolean {
+  return (
+    error instanceof Error &&
+    error.message.includes('does not implement OAuth 2.0 Protected Resource Metadata')
+  );
+}
+
+function isRedirect(status: number): boolean {
+  return status === 301 || status === 302 || status === 303 || status === 307 || status === 308;
+}
+
+function redirectedRequestInit(init: RequestInit, status: number): RequestInit {
+  const method = init.method?.toUpperCase();
+  if (status !== 303 && !((status === 301 || status === 302) && method === 'POST')) return init;
+  const headers = new Headers(init.headers);
+  headers.delete('content-length');
+  headers.delete('content-type');
+  return { ...init, method: 'GET', body: undefined, headers };
+}

--- a/packages/agent-core-v2/test/mcpCore/connection-manager.test.ts
+++ b/packages/agent-core-v2/test/mcpCore/connection-manager.test.ts
@@ -46,6 +46,66 @@ import {
   stdioFixture,
 } from './stubs';
 
+async function startOAuthProtected401Server(options: {
+  readonly resourcePath?: string;
+  readonly requiredHeader?: readonly [name: string, value: string];
+  readonly resourceDelayMs?: number;
+  readonly metadataDelayMs?: number;
+} = {}): Promise<{ readonly server: HttpServer; readonly url: string }> {
+  const resourcePath = options.resourcePath ?? '/mcp';
+  let baseUrl = '';
+  const server: HttpServer = createHttpServer((req, res) => {
+    const path = new URL(req.url ?? '/', baseUrl).pathname;
+    const requiredHeader = options.requiredHeader;
+    if (
+      requiredHeader !== undefined &&
+      (path === resourcePath || path === `/.well-known/oauth-protected-resource${resourcePath}`) &&
+      req.headers[requiredHeader[0].toLowerCase()] !== requiredHeader[1]
+    ) {
+      res.writeHead(403).end('missing resource header');
+      return;
+    }
+    if (path === `/.well-known/oauth-protected-resource${resourcePath}`) {
+      setTimeout(() => {
+        res
+          .writeHead(200, { 'content-type': 'application/json' })
+          .end(
+            JSON.stringify({
+              resource: `${baseUrl}${resourcePath}`,
+              authorization_servers: [baseUrl],
+            }),
+          );
+      }, options.metadataDelayMs ?? 0);
+      return;
+    }
+    if (path === '/.well-known/oauth-authorization-server') {
+      res
+        .writeHead(200, { 'content-type': 'application/json' })
+        .end(
+          JSON.stringify({
+            issuer: baseUrl,
+            authorization_endpoint: `${baseUrl}/authorize`,
+            token_endpoint: `${baseUrl}/token`,
+            response_types_supported: ['code'],
+            code_challenge_methods_supported: ['S256'],
+          }),
+        );
+      return;
+    }
+    if (path === resourcePath) {
+      setTimeout(() => {
+        res.writeHead(401, { 'content-type': 'application/json' });
+        res.end(JSON.stringify({ error: 'unauthorized' }));
+      }, options.resourceDelayMs ?? 0);
+      return;
+    }
+    res.writeHead(404).end();
+  });
+  await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+  baseUrl = `http://127.0.0.1:${(server.address() as HttpAddress).port}`;
+  return { server, url: `${baseUrl}${resourcePath}` };
+}
+
 function stdioConfig(args: string[] = [stdioFixture]) {
   return {
     transport: 'stdio' as const,
@@ -575,57 +635,18 @@ describe('McpConnectionManager', () => {
     }
   }, 20000);
 
-  it('flips HTTP servers into needs-auth when the server returns 401 and no static token is set', async () => {
-    const server: HttpServer = createHttpServer((_req, res) => {
-      res.writeHead(401, {
-        'content-type': 'application/json',
-        'www-authenticate':
-          'Bearer realm="mcp", resource_metadata="http://x/.well-known/oauth-protected-resource"',
-      });
-      res.end(JSON.stringify({ error: 'unauthorized' }));
+  it('uses OAuth metadata after a 401 even with auxiliary headers and no auth marker', async () => {
+    const { server, url } = await startOAuthProtected401Server({
+      requiredHeader: ['x-tenant', 'example'],
     });
-    await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
-    const port = (server.address() as HttpAddress).port;
     const oauthService = new McpOAuthService({ store: createMemoryMcpOAuthStore() });
     const cm = new McpConnectionManager({ oauthService });
     try {
       await cm.connectAll({
         gated: {
           transport: 'http',
-          url: `http://127.0.0.1:${port}/mcp`,
-          startupTimeoutMs: 5_000,
-        },
-      });
-      const entry = cm.get('gated');
-      expect(entry?.status).toBe('needs-auth');
-      expect(entry?.error).toContain('run /mcp-config login gated');
-      expect(entry?.toolCount).toBe(0);
-    } finally {
-      await cm.shutdown();
-      await closeServer(server);
-    }
-  }, 15000);
-
-  it('marks an explicitly OAuth HTTP server as needs-auth when non-auth headers accompany a 401', async () => {
-    const server: HttpServer = createHttpServer((_req, res) => {
-      res.writeHead(401, {
-        'content-type': 'application/json',
-        'www-authenticate':
-          'Bearer realm="mcp", resource_metadata="http://x/.well-known/oauth-protected-resource"',
-      });
-      res.end(JSON.stringify({ error: 'unauthorized' }));
-    });
-    await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
-    const port = (server.address() as HttpAddress).port;
-    const oauthService = new McpOAuthService({ store: createMemoryMcpOAuthStore() });
-    const cm = new McpConnectionManager({ oauthService });
-    try {
-      await cm.connectAll({
-        gated: {
-          transport: 'http',
-          url: `http://127.0.0.1:${port}/mcp`,
+          url,
           headers: { 'X-Tenant': 'example' },
-          auth: 'oauth',
           startupTimeoutMs: 5_000,
         },
       });
@@ -633,26 +654,51 @@ describe('McpConnectionManager', () => {
       expect(entry?.status).toBe('needs-auth');
       expect(entry?.error).toContain('run /mcp-config login gated');
       expect(entry?.toolCount).toBe(0);
+      const provider = oauthService.getProvider('gated', url);
+      expect(await provider.discoveryState()).toMatchObject({
+        authorizationServerUrl: new URL(url).origin,
+      });
+      await provider.saveClientInformation({ client_id: 'manager-test-client' });
+      const flow = await oauthService.beginAuthorization('gated', url);
+      try {
+        expect(flow.authorizationUrl.toString()).toMatch(/^http:\/\/127\.0\.0\.1:\d+\/authorize\?/);
+      } finally {
+        await flow.cancel();
+      }
     } finally {
       await cm.shutdown();
       await closeServer(server);
     }
   }, 15000);
 
-  it('keeps a headers-only HTTP server failed (not needs-auth) on 401', async () => {
-    const server: HttpServer = createHttpServer((_req, res) => {
-      res.writeHead(401, { 'content-type': 'application/json' });
-      res.end(JSON.stringify({ error: 'unauthorized' }));
+  it('keeps 401 metadata discovery inside the startup timeout budget', async () => {
+    const { server, url } = await startOAuthProtected401Server({
+      resourceDelayMs: 50,
+      metadataDelayMs: 50,
     });
-    await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
-    const port = (server.address() as HttpAddress).port;
+    const oauthService = new McpOAuthService({ store: createMemoryMcpOAuthStore() });
+    const cm = new McpConnectionManager({ oauthService });
+    try {
+      await cm.connectAll({
+        slowAuth: { transport: 'http', url, startupTimeoutMs: 80 },
+      });
+      expect(cm.get('slowAuth')?.status).toBe('failed');
+      expect(await oauthService.getProvider('slowAuth', url).discoveryState()).toBeUndefined();
+    } finally {
+      await cm.shutdown();
+      await closeServer(server);
+    }
+  }, 15000);
+
+  it('keeps static Authorization failures out of OAuth even when metadata is available', async () => {
+    const { server, url } = await startOAuthProtected401Server();
     const oauthService = new McpOAuthService({ store: createMemoryMcpOAuthStore() });
     const cm = new McpConnectionManager({ oauthService });
     try {
       await cm.connectAll({
         keyed: {
           transport: 'http',
-          url: `http://127.0.0.1:${port}/mcp`,
+          url,
           headers: { Authorization: 'Bearer static-key' },
           startupTimeoutMs: 5_000,
         },
@@ -666,23 +712,14 @@ describe('McpConnectionManager', () => {
   }, 15000);
 
   it('flips SSE servers into needs-auth when the server returns 401 and no static token is set', async () => {
-    const server: HttpServer = createHttpServer((_req, res) => {
-      res.writeHead(401, {
-        'content-type': 'text/plain',
-        'www-authenticate':
-          'Bearer realm="mcp", resource_metadata="http://x/.well-known/oauth-protected-resource"',
-      });
-      res.end('unauthorized');
-    });
-    await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
-    const port = (server.address() as HttpAddress).port;
+    const { server, url } = await startOAuthProtected401Server({ resourcePath: '/sse' });
     const oauthService = new McpOAuthService({ store: createMemoryMcpOAuthStore() });
     const cm = new McpConnectionManager({ oauthService });
     try {
       await cm.connectAll({
         legacy: {
           transport: 'sse',
-          url: `http://127.0.0.1:${port}/sse`,
+          url,
           startupTimeoutMs: 5_000,
         },
       });
@@ -698,7 +735,29 @@ describe('McpConnectionManager', () => {
   }, 15000);
 
   it('flips cached OAuth credentials that require reauth into needs-auth', async () => {
+    let serverUrl = '';
+    let authServerUrl = '';
     const server: HttpServer = createHttpServer((req, res) => {
+      if (req.url === '/.well-known/oauth-protected-resource/mcp') {
+        res
+          .writeHead(200, { 'content-type': 'application/json' })
+          .end(JSON.stringify({ resource: serverUrl, authorization_servers: [authServerUrl] }));
+        return;
+      }
+      if (req.url === '/.well-known/oauth-authorization-server') {
+        res
+          .writeHead(200, { 'content-type': 'application/json' })
+          .end(
+            JSON.stringify({
+              issuer: authServerUrl,
+              authorization_endpoint: `${authServerUrl}/authorize`,
+              token_endpoint: `${authServerUrl}/token`,
+              response_types_supported: ['code'],
+              code_challenge_methods_supported: ['S256'],
+            }),
+          );
+        return;
+      }
       if (req.url === '/token') {
         res.writeHead(400, { 'content-type': 'application/json' });
         res.end(JSON.stringify({ error: 'invalid_grant' }));
@@ -712,8 +771,8 @@ describe('McpConnectionManager', () => {
     });
     await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
     const port = (server.address() as HttpAddress).port;
-    const serverUrl = `http://127.0.0.1:${port}/mcp`;
-    const authServerUrl = `http://127.0.0.1:${port}`;
+    authServerUrl = `http://127.0.0.1:${port}`;
+    serverUrl = `${authServerUrl}/mcp`;
     const oauthService = new McpOAuthService({ store: createMemoryMcpOAuthStore() });
     const provider = oauthService.getProvider('notion', serverUrl);
     await provider.saveDiscoveryState({

--- a/packages/agent-core/src/config/schema.ts
+++ b/packages/agent-core/src/config/schema.ts
@@ -292,9 +292,8 @@ export const McpServerHttpConfigSchema = z.object({
   transport: z.literal('http'),
   url: z.string().url(),
   headers: StringRecordSchema.optional(),
-  // Backward-compatible UI marker. OAuth is still discovered from a remote
-  // server's 401 response; this flag only records that the user explicitly
-  // chose OAuth and lets hosts expose login/reset controls before connecting.
+  // Backward-compatible marker retained for existing config round-trips and
+  // older hosts. Current OAuth discovery, status, and login do not depend on it.
   auth: z.literal('oauth').optional(),
   // Indirect secret reference: the bearer token is looked up from
   // `process.env[bearerTokenEnvVar]` at connection time, never committed.

--- a/packages/agent-core/src/mcp/connection-manager.ts
+++ b/packages/agent-core/src/mcp/connection-manager.ts
@@ -11,6 +11,7 @@ import { SseMcpClient } from './client-sse';
 import type { UnexpectedCloseReason } from './client-shared';
 import { StdioMcpClient } from './client-stdio';
 import type { McpOAuthService } from './oauth';
+import { discoverMcpOAuth, hasAuthorizationHeader } from './oauth/discovery';
 import { assertMcpInputSchema, type MCPClient, type MCPToolDefinition } from './types';
 
 export type McpServerStatus = 'pending' | 'connected' | 'failed' | 'disabled' | 'needs-auth';
@@ -326,6 +327,7 @@ export class McpConnectionManager {
       entry.config.startupTimeoutMs ??
       this.options.defaultStartupTimeoutMs ??
       DEFAULT_STARTUP_TIMEOUT_MS;
+    const startupDeadlineMs = Date.now() + timeoutMs;
 
     let client: RuntimeMcpClient | undefined;
     try {
@@ -356,7 +358,7 @@ export class McpConnectionManager {
         }
         return;
       }
-      if (this.shouldMarkNeedsAuth(entry, error)) {
+      if (await this.shouldMarkNeedsAuth(entry, error, startupDeadlineMs)) {
         entry.status = 'needs-auth';
         entry.error = `${entry.name} requires OAuth — run /mcp-config login ${entry.name}`;
       } else {
@@ -438,6 +440,7 @@ export class McpConnectionManager {
     if (oauthService === undefined) return undefined;
     if (!isRemoteMcpConfig(config)) return undefined;
     if (config.bearerTokenEnvVar !== undefined) return undefined;
+    if (hasAuthorizationHeader(config.headers)) return undefined;
     // Only attach the provider once tokens have been minted; before that,
     // the transport should propagate a clean 401 so we can flip the entry
     // into `needs-auth` rather than getting tangled in the SDK's auth()
@@ -446,16 +449,29 @@ export class McpConnectionManager {
     return oauthService.getProvider(name, config.url);
   }
 
-  private shouldMarkNeedsAuth(entry: InternalEntry, error: unknown): boolean {
-    if (this.oauthService === undefined) return false;
+  private async shouldMarkNeedsAuth(
+    entry: InternalEntry,
+    error: unknown,
+    startupDeadlineMs: number,
+  ): Promise<boolean> {
+    const oauthService = this.oauthService;
+    if (oauthService === undefined) return false;
     if (!isRemoteMcpConfig(entry.config)) return false;
     if (entry.config.bearerTokenEnvVar !== undefined) return false;
-    // If the user pinned a static `headers` block, treat 401s as a bad header
-    // rather than hijacking them into the OAuth flow — the real error is more
-    // actionable than "run /mcp-config login" for a server that doesn't speak
-    // OAuth.
-    if (entry.config.headers !== undefined && entry.config.auth !== 'oauth') return false;
-    return isUnauthorizedLikeError(error);
+    if (hasAuthorizationHeader(entry.config.headers)) return false;
+    if (!isUnauthorizedLikeError(error)) return false;
+    const remainingMs = startupDeadlineMs - Date.now();
+    if (remainingMs <= 0) return false;
+    try {
+      const discoveryState = await discoverMcpOAuth(entry.config.url, entry.config.headers, {
+        timeoutMs: remainingMs,
+      });
+      if (discoveryState === undefined) return false;
+      oauthService.getProvider(entry.name, entry.config.url).saveDiscoveryState(discoveryState);
+      return true;
+    } catch {
+      return false;
+    }
   }
 
   private async connectAndDiscoverTools(

--- a/packages/agent-core/src/mcp/oauth/discovery.ts
+++ b/packages/agent-core/src/mcp/oauth/discovery.ts
@@ -1,0 +1,223 @@
+import {
+  discoverAuthorizationServerMetadata,
+  discoverOAuthProtectedResourceMetadata,
+  extractWWWAuthenticateParams,
+  type OAuthDiscoveryState,
+} from '@modelcontextprotocol/sdk/client/auth.js';
+import type { FetchLike } from '@modelcontextprotocol/sdk/shared/transport.js';
+import {
+  checkResourceAllowed,
+  resourceUrlFromServerUrl,
+} from '@modelcontextprotocol/sdk/shared/auth-utils.js';
+
+const DEFAULT_DISCOVERY_TIMEOUT_MS = 5_000;
+const MAX_REDIRECTS = 5;
+
+export interface McpOAuthDiscoveryOptions {
+  readonly timeoutMs?: number;
+}
+
+export function hasAuthorizationHeader(headers: Record<string, string> | undefined): boolean {
+  return Object.keys(headers ?? {}).some((name) => name.toLowerCase() === 'authorization');
+}
+
+export function createMcpOAuthFetch(
+  serverUrl: string | URL,
+  configuredHeaders: Record<string, string> | undefined,
+  timeoutMs = DEFAULT_DISCOVERY_TIMEOUT_MS,
+): FetchLike {
+  const resourceOrigin = new URL(serverUrl).origin;
+  const extraHeaders = new Headers(configuredHeaders);
+  const hasConfiguredHeaders = [...extraHeaders].length > 0;
+  const deadlineMs = Date.now() + timeoutMs;
+
+  return async (input, init = {}) => {
+    const initialUrl = input instanceof Request ? input.url : input;
+    const initialHeaders = new Headers(input instanceof Request ? input.headers : undefined);
+    new Headers(init.headers).forEach((value, name) => {
+      initialHeaders.set(name, value);
+    });
+    let url = new URL(initialUrl);
+    let requestInit: RequestInit = { ...init, headers: initialHeaders };
+
+    for (let redirectCount = 0; ; redirectCount++) {
+      const headers = new Headers(requestInit.headers);
+      if (url.origin === resourceOrigin) {
+        extraHeaders.forEach((value, name) => {
+          if (!headers.has(name)) headers.set(name, value);
+        });
+      }
+      const remainingMs = deadlineMs - Date.now();
+      if (remainingMs <= 0) throw new Error('MCP OAuth discovery timeout exceeded');
+      const timeoutSignal = AbortSignal.timeout(remainingMs);
+      const signal = requestInit.signal
+        ? AbortSignal.any([requestInit.signal, timeoutSignal])
+        : timeoutSignal;
+      const response = await fetch(url, {
+        ...requestInit,
+        headers,
+        redirect: 'manual',
+        signal,
+      });
+      if (!isRedirect(response.status)) return response;
+
+      const location = response.headers.get('location');
+      if (location === null) return response;
+      if (redirectCount >= MAX_REDIRECTS) {
+        await response.body?.cancel();
+        throw new Error(`OAuth discovery exceeded ${MAX_REDIRECTS} redirects`);
+      }
+      const nextUrl = new URL(location, url);
+      if (hasConfiguredHeaders && nextUrl.origin !== url.origin) {
+        await response.body?.cancel();
+        throw new Error(
+          `OAuth discovery redirect to non-same-origin URL rejected: ${nextUrl.toString()}`,
+        );
+      }
+      await response.body?.cancel();
+      requestInit = redirectedRequestInit(requestInit, response.status);
+      url = nextUrl;
+    }
+  };
+}
+
+export async function discoverMcpOAuth(
+  serverUrl: string | URL,
+  configuredHeaders: Record<string, string> | undefined,
+  options: McpOAuthDiscoveryOptions = {},
+): Promise<OAuthDiscoveryState | undefined> {
+  const resourceUrl = new URL(serverUrl);
+  const fetchFn = createMcpOAuthFetch(resourceUrl, configuredHeaders, options.timeoutMs);
+  let resourceMetadata;
+  let resourceMetadataUrl: URL | undefined;
+
+  const response = await fetchFn(resourceUrl, {
+    method: 'GET',
+    headers: { Accept: 'application/json, text/event-stream' },
+  });
+  try {
+    if (
+      response.status >= 500 ||
+      response.status === 408 ||
+      response.status === 425 ||
+      response.status === 429
+    ) {
+      throw new Error(
+        `HTTP ${response.status} probing MCP OAuth support at ${resourceUrl.toString()}`,
+      );
+    }
+    if (response.status === 401) {
+      resourceMetadataUrl = extractWWWAuthenticateParams(response).resourceMetadataUrl;
+    }
+  } finally {
+    await response.body?.cancel();
+  }
+
+  if (resourceMetadataUrl !== undefined) {
+    resourceMetadata = await discoverOAuthProtectedResourceMetadata(
+      resourceUrl,
+      { resourceMetadataUrl },
+      fetchFn,
+    );
+  } else {
+    try {
+      resourceMetadata = await discoverOAuthProtectedResourceMetadata(
+        resourceUrl,
+        undefined,
+        fetchFn,
+      );
+    } catch (error) {
+      if (!isMissingProtectedResourceMetadata(error)) throw error;
+    }
+  }
+
+  if (
+    resourceMetadata !== undefined &&
+    !checkResourceAllowed({
+      requestedResource: resourceUrlFromServerUrl(resourceUrl),
+      configuredResource: resourceMetadata.resource,
+    })
+  ) {
+    throw new Error(
+      `Protected resource ${resourceMetadata.resource} does not match expected ${resourceUrlFromServerUrl(resourceUrl).toString()}`,
+    );
+  }
+  let authorizationServerUrl =
+    resourceMetadata?.authorization_servers?.[0] ?? resourceUrl.toString();
+  let authorizationServerMetadata = await discoverMcpAuthorizationServerMetadata(
+    authorizationServerUrl,
+    fetchFn,
+  );
+  if (authorizationServerMetadata === undefined && resourceMetadata === undefined) {
+    const legacyRootUrl = new URL('/', resourceUrl).toString();
+    if (legacyRootUrl !== authorizationServerUrl) {
+      const legacyRootMetadata = await discoverMcpAuthorizationServerMetadata(
+        legacyRootUrl,
+        fetchFn,
+      );
+      if (legacyRootMetadata !== undefined) {
+        authorizationServerUrl = legacyRootUrl;
+        authorizationServerMetadata = legacyRootMetadata;
+      }
+    }
+  }
+  if (authorizationServerMetadata === undefined) return undefined;
+  return {
+    authorizationServerUrl,
+    authorizationServerMetadata,
+    ...(resourceMetadata === undefined ? {} : { resourceMetadata }),
+    ...(resourceMetadataUrl === undefined
+      ? {}
+      : { resourceMetadataUrl: resourceMetadataUrl.toString() }),
+  };
+}
+
+async function discoverMcpAuthorizationServerMetadata(
+  authorizationServerUrl: string | URL,
+  fetchFn: FetchLike,
+) {
+  const expectedIssuer = new URL(authorizationServerUrl).toString();
+  return discoverAuthorizationServerMetadata(authorizationServerUrl, {
+    fetchFn: async (input, init) => {
+      const response = await fetchFn(input, init);
+      if (!response.ok) return response;
+      const metadata = JSON.parse(await response.text()) as Record<string, unknown>;
+      const issuer = metadata['issuer'];
+      if (issuer === undefined) {
+        metadata['issuer'] = expectedIssuer;
+      } else if (
+        typeof issuer === 'string' &&
+        new URL(issuer).toString() !== expectedIssuer
+      ) {
+        throw new Error(
+          `Authorization server issuer ${issuer} does not match expected ${expectedIssuer}`,
+        );
+      }
+      return new Response(JSON.stringify(metadata), {
+        status: response.status,
+        statusText: response.statusText,
+        headers: response.headers,
+      });
+    },
+  });
+}
+
+function isMissingProtectedResourceMetadata(error: unknown): boolean {
+  return (
+    error instanceof Error &&
+    error.message.includes('does not implement OAuth 2.0 Protected Resource Metadata')
+  );
+}
+
+function isRedirect(status: number): boolean {
+  return status === 301 || status === 302 || status === 303 || status === 307 || status === 308;
+}
+
+function redirectedRequestInit(init: RequestInit, status: number): RequestInit {
+  const method = init.method?.toUpperCase();
+  if (status !== 303 && !((status === 301 || status === 302) && method === 'POST')) return init;
+  const headers = new Headers(init.headers);
+  headers.delete('content-length');
+  headers.delete('content-type');
+  return { ...init, method: 'GET', body: undefined, headers };
+}

--- a/packages/agent-core/src/mcp/oauth/index.ts
+++ b/packages/agent-core/src/mcp/oauth/index.ts
@@ -1,4 +1,5 @@
 export * from './callback-server';
+export * from './discovery';
 export * from './provider';
 export * from './service';
 export * from './store';

--- a/packages/agent-core/src/rpc/core-api.ts
+++ b/packages/agent-core/src/rpc/core-api.ts
@@ -356,11 +356,13 @@ export type GlobalMcpServerAuthState =
   | 'not-applicable'
   | 'bearer-token'
   | 'oauth-required'
-  | 'oauth-authorized';
+  | 'oauth-authorized'
+  | 'unknown';
 
 export interface GlobalMcpServerAuthStatus {
   readonly name: string;
   readonly authStatus: GlobalMcpServerAuthState;
+  readonly error?: string;
 }
 
 export type BeginGlobalMcpServerAuthResult =

--- a/packages/agent-core/src/rpc/core-impl.ts
+++ b/packages/agent-core/src/rpc/core-impl.ts
@@ -39,7 +39,9 @@ import {
 import type { Logger } from '../logging/types';
 import {
   AlreadyAuthorizedError,
+  discoverMcpOAuth,
   GlobalMcpConfigStore,
+  hasAuthorizationHeader,
   McpConnectionManager,
   McpOAuthService,
   resolveMcpStartupTimeoutMs,
@@ -100,7 +102,6 @@ import type {
   EnterSwarmPayload,
   GoalSnapshot,
   GoalToolResult,
-  GlobalMcpServerAuthState,
   GlobalMcpServerAuthStatus,
   GlobalMcpServerConfig,
   GlobalMcpServerNamePayload,
@@ -772,12 +773,7 @@ export class KimiCore implements PromisableMethods<CoreAPI> {
     _input?: EmptyPayload,
   ): Promise<readonly GlobalMcpServerAuthStatus[]> {
     const servers = await this.globalMcpConfig.list();
-    return Promise.all(
-      servers.map(async (server) => ({
-        name: server.name,
-        authStatus: await this.globalMcpServerAuthState(server),
-      })),
-    );
+    return Promise.all(servers.map((server) => this.globalMcpServerAuthStatus(server)));
   }
 
   async addGlobalMcpServer(
@@ -804,6 +800,12 @@ export class KimiCore implements PromisableMethods<CoreAPI> {
     const server = await this.globalMcpConfig.get(name);
     const config = requireOAuthMcpServer(server);
     try {
+      const provider = this.globalMcpOAuth.getProvider(server.name, config.url);
+      let discoveryState = provider.discoveryState();
+      if (discoveryState === undefined) {
+        discoveryState = await discoverMcpOAuth(config.url, config.headers);
+        if (discoveryState !== undefined) provider.saveDiscoveryState(discoveryState);
+      }
       const flow = await this.globalMcpOAuth.beginAuthorization(server.name, config.url);
       const flowId = randomUUID();
       this.globalMcpOAuthFlows.set(flowId, { flow });
@@ -872,15 +874,34 @@ export class KimiCore implements PromisableMethods<CoreAPI> {
     }
   }
 
-  private async globalMcpServerAuthState(
+  private async globalMcpServerAuthStatus(
     server: GlobalMcpServerConfig,
-  ): Promise<GlobalMcpServerAuthState> {
-    if (server.transport === 'stdio') return 'not-applicable';
-    if (server.bearerTokenEnvVar !== undefined) return 'bearer-token';
-    if (server.auth !== 'oauth') return 'not-applicable';
-    return this.globalMcpOAuth.hasTokens(server.name, server.url)
-      ? 'oauth-authorized'
-      : 'oauth-required';
+  ): Promise<GlobalMcpServerAuthStatus> {
+    if (server.enabled === false || server.transport === 'stdio') {
+      return { name: server.name, authStatus: 'not-applicable' };
+    }
+    if (server.bearerTokenEnvVar !== undefined || hasAuthorizationHeader(server.headers)) {
+      return { name: server.name, authStatus: 'bearer-token' };
+    }
+    if (this.globalMcpOAuth.hasTokens(server.name, server.url)) {
+      return { name: server.name, authStatus: 'oauth-authorized' };
+    }
+    try {
+      const discovery = await discoverMcpOAuth(server.url, server.headers);
+      if (discovery !== undefined) {
+        this.globalMcpOAuth.getProvider(server.name, server.url).saveDiscoveryState(discovery);
+      }
+      return {
+        name: server.name,
+        authStatus: discovery === undefined ? 'not-applicable' : 'oauth-required',
+      };
+    } catch (error) {
+      return {
+        name: server.name,
+        authStatus: 'unknown',
+        error: error instanceof Error ? error.message : String(error),
+      };
+    }
   }
 
   prompt({ sessionId, ...payload }: SessionAgentPayload<PromptPayload>) {
@@ -1463,10 +1484,10 @@ function requireOAuthMcpServer(server: GlobalMcpServerConfig): McpRemoteServerCo
       `MCP server "${server.name}" uses a static bearer token`,
     );
   }
-  if (config.headers !== undefined && config.auth !== 'oauth') {
+  if (hasAuthorizationHeader(config.headers)) {
     throw new KimiError(
       ErrorCodes.REQUEST_INVALID,
-      `MCP server "${server.name}" uses static headers and is not marked for OAuth`,
+      `MCP server "${server.name}" uses a static Authorization header`,
     );
   }
   return config;

--- a/packages/agent-core/test/mcp/connection-manager.test.ts
+++ b/packages/agent-core/test/mcp/connection-manager.test.ts
@@ -61,6 +61,66 @@ const MOCK_PROVIDER: ProviderConfig = {
 };
 type SessionRpcEvent = AgentEvent & { readonly agentId: string };
 
+async function startOAuthProtected401Server(options: {
+  readonly resourcePath?: string;
+  readonly requiredHeader?: readonly [name: string, value: string];
+  readonly resourceDelayMs?: number;
+  readonly metadataDelayMs?: number;
+} = {}): Promise<{ readonly server: HttpServer; readonly url: string }> {
+  const resourcePath = options.resourcePath ?? '/mcp';
+  let baseUrl = '';
+  const server: HttpServer = createHttpServer((req, res) => {
+    const path = new URL(req.url ?? '/', baseUrl).pathname;
+    const requiredHeader = options.requiredHeader;
+    if (
+      requiredHeader !== undefined &&
+      (path === resourcePath || path === `/.well-known/oauth-protected-resource${resourcePath}`) &&
+      req.headers[requiredHeader[0].toLowerCase()] !== requiredHeader[1]
+    ) {
+      res.writeHead(403).end('missing resource header');
+      return;
+    }
+    if (path === `/.well-known/oauth-protected-resource${resourcePath}`) {
+      setTimeout(() => {
+        res
+          .writeHead(200, { 'content-type': 'application/json' })
+          .end(
+            JSON.stringify({
+              resource: `${baseUrl}${resourcePath}`,
+              authorization_servers: [baseUrl],
+            }),
+          );
+      }, options.metadataDelayMs ?? 0);
+      return;
+    }
+    if (path === '/.well-known/oauth-authorization-server') {
+      res
+        .writeHead(200, { 'content-type': 'application/json' })
+        .end(
+          JSON.stringify({
+            issuer: baseUrl,
+            authorization_endpoint: `${baseUrl}/authorize`,
+            token_endpoint: `${baseUrl}/token`,
+            response_types_supported: ['code'],
+            code_challenge_methods_supported: ['S256'],
+          }),
+        );
+      return;
+    }
+    if (path === resourcePath) {
+      setTimeout(() => {
+        res.writeHead(401, { 'content-type': 'application/json' });
+        res.end(JSON.stringify({ error: 'unauthorized' }));
+      }, options.resourceDelayMs ?? 0);
+      return;
+    }
+    res.writeHead(404).end();
+  });
+  await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+  baseUrl = `http://127.0.0.1:${(server.address() as HttpAddress).port}`;
+  return { server, url: `${baseUrl}${resourcePath}` };
+}
+
 function stdioConfig(args: string[] = [stdioFixture]) {
   return {
     transport: 'stdio' as const,
@@ -502,16 +562,10 @@ describe('McpConnectionManager', () => {
     }
   }, 20000);
 
-  it('marks an explicitly OAuth HTTP server as needs-auth when non-auth headers accompany a 401', async () => {
-    const server: HttpServer = createHttpServer((_req, res) => {
-      res.writeHead(401, {
-        'content-type': 'application/json',
-        'www-authenticate': 'Bearer realm="mcp", resource_metadata="http://x/.well-known/oauth-protected-resource"',
-      });
-      res.end(JSON.stringify({ error: 'unauthorized' }));
+  it('uses OAuth metadata after a 401 even with auxiliary headers and no auth marker', async () => {
+    const { server, url } = await startOAuthProtected401Server({
+      requiredHeader: ['x-tenant', 'example'],
     });
-    await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
-    const port = (server.address() as HttpAddress).port;
     const storeDir = await mkdtemp(join(tmpdir(), 'kimi-mcp-oauth-cm-'));
     const oauthService = new McpOAuthService({ store: new JsonFileStore(storeDir) });
     const cm = new McpConnectionManager({ oauthService });
@@ -519,9 +573,8 @@ describe('McpConnectionManager', () => {
       await cm.connectAll({
         gated: {
           transport: 'http',
-          url: `http://127.0.0.1:${port}/mcp`,
+          url,
           headers: { 'X-Tenant': 'example' },
-          auth: 'oauth',
           startupTimeoutMs: 5_000,
         },
       });
@@ -529,6 +582,17 @@ describe('McpConnectionManager', () => {
       expect(entry?.status).toBe('needs-auth');
       expect(entry?.error).toContain('run /mcp-config login gated');
       expect(entry?.toolCount).toBe(0);
+      const provider = oauthService.getProvider('gated', url);
+      expect(provider.discoveryState()).toMatchObject({
+        authorizationServerUrl: new URL(url).origin,
+      });
+      provider.saveClientInformation({ client_id: 'manager-test-client' });
+      const flow = await oauthService.beginAuthorization('gated', url);
+      try {
+        expect(flow.authorizationUrl.toString()).toMatch(/^http:\/\/127\.0\.0\.1:\d+\/authorize\?/);
+      } finally {
+        await flow.cancel();
+      }
     } finally {
       await cm.shutdown();
       await new Promise<void>((resolve, reject) => {
@@ -544,16 +608,34 @@ describe('McpConnectionManager', () => {
     }
   }, 15000);
 
-  it('flips SSE servers into needs-auth when the server returns 401 and no static token is set', async () => {
-    const server: HttpServer = createHttpServer((_req, res) => {
-      res.writeHead(401, {
-        'content-type': 'text/plain',
-        'www-authenticate': 'Bearer realm="mcp", resource_metadata="http://x/.well-known/oauth-protected-resource"',
-      });
-      res.end('unauthorized');
+  it('keeps 401 metadata discovery inside the startup timeout budget', async () => {
+    const { server, url } = await startOAuthProtected401Server({
+      resourceDelayMs: 50,
+      metadataDelayMs: 50,
     });
-    await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
-    const port = (server.address() as HttpAddress).port;
+    const storeDir = await mkdtemp(join(tmpdir(), 'kimi-mcp-oauth-deadline-'));
+    const oauthService = new McpOAuthService({ store: new JsonFileStore(storeDir) });
+    const cm = new McpConnectionManager({ oauthService });
+    try {
+      await cm.connectAll({
+        slowAuth: { transport: 'http', url, startupTimeoutMs: 80 },
+      });
+      expect(cm.get('slowAuth')?.status).toBe('failed');
+      expect(oauthService.getProvider('slowAuth', url).discoveryState()).toBeUndefined();
+    } finally {
+      await cm.shutdown();
+      await new Promise<void>((resolve, reject) => {
+        server.close((err) => {
+          if (err) reject(err);
+          else resolve();
+        });
+      });
+      await rm(storeDir, { recursive: true, force: true });
+    }
+  }, 15000);
+
+  it('flips SSE servers into needs-auth when the server returns 401 and no static token is set', async () => {
+    const { server, url } = await startOAuthProtected401Server({ resourcePath: '/sse' });
     const storeDir = await mkdtemp(join(tmpdir(), 'kimi-mcp-oauth-sse-cm-'));
     const oauthService = new McpOAuthService({ store: new JsonFileStore(storeDir) });
     const cm = new McpConnectionManager({ oauthService });
@@ -561,7 +643,7 @@ describe('McpConnectionManager', () => {
       await cm.connectAll({
         legacy: {
           transport: 'sse',
-          url: `http://127.0.0.1:${port}/sse`,
+          url,
           startupTimeoutMs: 5_000,
         },
       });
@@ -586,7 +668,29 @@ describe('McpConnectionManager', () => {
   }, 15000);
 
   it('flips cached OAuth credentials that require reauth into needs-auth', async () => {
+    let serverUrl = '';
+    let authServerUrl = '';
     const server: HttpServer = createHttpServer((req, res) => {
+      if (req.url === '/.well-known/oauth-protected-resource/mcp') {
+        res
+          .writeHead(200, { 'content-type': 'application/json' })
+          .end(JSON.stringify({ resource: serverUrl, authorization_servers: [authServerUrl] }));
+        return;
+      }
+      if (req.url === '/.well-known/oauth-authorization-server') {
+        res
+          .writeHead(200, { 'content-type': 'application/json' })
+          .end(
+            JSON.stringify({
+              issuer: authServerUrl,
+              authorization_endpoint: `${authServerUrl}/authorize`,
+              token_endpoint: `${authServerUrl}/token`,
+              response_types_supported: ['code'],
+              code_challenge_methods_supported: ['S256'],
+            }),
+          );
+        return;
+      }
       if (req.url === '/token') {
         res.writeHead(400, { 'content-type': 'application/json' });
         res.end(JSON.stringify({ error: 'invalid_grant' }));
@@ -600,8 +704,8 @@ describe('McpConnectionManager', () => {
     });
     await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
     const port = (server.address() as HttpAddress).port;
-    const serverUrl = `http://127.0.0.1:${port}/mcp`;
-    const authServerUrl = `http://127.0.0.1:${port}`;
+    authServerUrl = `http://127.0.0.1:${port}`;
+    serverUrl = `${authServerUrl}/mcp`;
     const storeDir = await mkdtemp(join(tmpdir(), 'kimi-mcp-oauth-cached-'));
     const oauthService = new McpOAuthService({ store: new JsonFileStore(storeDir) });
     const provider = oauthService.getProvider('notion', serverUrl);
@@ -826,12 +930,8 @@ describe('McpConnectionManager', () => {
     }
   }, 15000);
 
-  it('marks HTTP 401 as failed (not needs-auth) when the user pinned static headers', async () => {
-    const server: HttpServer = createHttpServer((_req, res) => {
-      res.writeHead(401).end('nope');
-    });
-    await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
-    const port = (server.address() as HttpAddress).port;
+  it('keeps static Authorization failures out of OAuth even when metadata is available', async () => {
+    const { server, url } = await startOAuthProtected401Server();
     const storeDir = await mkdtemp(join(tmpdir(), 'kimi-mcp-oauth-cm-'));
     const oauthService = new McpOAuthService({ store: new JsonFileStore(storeDir) });
     const cm = new McpConnectionManager({ oauthService });
@@ -839,8 +939,8 @@ describe('McpConnectionManager', () => {
       await cm.connectAll({
         keyed: {
           transport: 'http',
-          url: `http://127.0.0.1:${port}/mcp`,
-          headers: { 'X-API-Key': 'wrong' },
+          url,
+          headers: { authorization: 'Bearer wrong' },
           startupTimeoutMs: 5_000,
         },
       });
@@ -854,6 +954,36 @@ describe('McpConnectionManager', () => {
             return;
           }
           resolve();
+        });
+      });
+      await rm(storeDir, { recursive: true, force: true });
+    }
+  }, 15000);
+
+  it('keeps an unauthorized server failed when OAuth metadata is unavailable', async () => {
+    const server: HttpServer = createHttpServer((_req, res) => {
+      res.writeHead(401).end('nope');
+    });
+    await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+    const port = (server.address() as HttpAddress).port;
+    const storeDir = await mkdtemp(join(tmpdir(), 'kimi-mcp-no-oauth-cm-'));
+    const oauthService = new McpOAuthService({ store: new JsonFileStore(storeDir) });
+    const cm = new McpConnectionManager({ oauthService });
+    try {
+      await cm.connectAll({
+        unsupported: {
+          transport: 'http',
+          url: `http://127.0.0.1:${port}/mcp`,
+          startupTimeoutMs: 5_000,
+        },
+      });
+      expect(cm.get('unsupported')?.status).toBe('failed');
+    } finally {
+      await cm.shutdown();
+      await new Promise<void>((resolve, reject) => {
+        server.close((err) => {
+          if (err) reject(err);
+          else resolve();
         });
       });
       await rm(storeDir, { recursive: true, force: true });

--- a/packages/node-sdk/src/sdk-rpc-client-v2.ts
+++ b/packages/node-sdk/src/sdk-rpc-client-v2.ts
@@ -273,7 +273,6 @@ import type {
   ForkSessionInput,
   GetConfigOptions,
   GetCronTasksResult,
-  GlobalMcpServerAuthState,
   GlobalMcpServerAuthStatus,
   GoalSnapshot,
   GoalToolResult,
@@ -319,6 +318,10 @@ import {
   requireRemoteMcpServer,
   standaloneMcpTestResult,
 } from '#/v2/global-mcp';
+import {
+  discoverMcpOAuth,
+  hasAuthorizationHeader,
+} from '@moonshot-ai/agent-core-v2/mcpCore/oauth/discovery';
 import {
   normalizeWorkDir,
   v2MetaToSessionMeta,
@@ -2112,14 +2115,9 @@ export class SDKRpcClientV2 extends SDKRpcClientBase {
     readonly GlobalMcpServerAuthStatus[]
   > {
     const servers = await this.globalMcpConfig.list();
-    const oauth = new McpOAuthService({
-      store: createMcpOAuthStore(this.engineAccessor.get(IAtomicDocumentStore)),
-    });
+    const oauth = await this.globalMcpOAuthService();
     return Promise.all(
-      servers.map(async (server) => ({
-        name: server.name,
-        authStatus: await this.globalMcpServerAuthState(server, oauth),
-      })),
+      servers.map((server) => this.globalMcpServerAuthStatus(server, oauth)),
     );
   }
 
@@ -2151,6 +2149,12 @@ export class SDKRpcClientV2 extends SDKRpcClientBase {
     const config = requireOAuthMcpServer(server);
     try {
       const oauth = await this.globalMcpOAuthService();
+      const provider = oauth.getProvider(server.name, config.url);
+      let discoveryState = await provider.discoveryState();
+      if (discoveryState === undefined) {
+        discoveryState = await discoverMcpOAuth(config.url, config.headers);
+        if (discoveryState !== undefined) await provider.saveDiscoveryState(discoveryState);
+      }
       const flow = await oauth.beginAuthorization(server.name, config.url);
       const flowId = randomUUID();
       this.globalMcpOAuthFlows.set(flowId, { flow });
@@ -2232,16 +2236,35 @@ export class SDKRpcClientV2 extends SDKRpcClientBase {
     }
   }
 
-  private async globalMcpServerAuthState(
+  private async globalMcpServerAuthStatus(
     server: McpServerConfig,
     oauth: McpOAuthService,
-  ): Promise<GlobalMcpServerAuthState> {
-    if (server.transport === 'stdio') return 'not-applicable';
-    if (server.bearerTokenEnvVar !== undefined) return 'bearer-token';
-    if (server.auth !== 'oauth') return 'not-applicable';
-    return (await oauth.hasTokens(server.name, server.url))
-      ? 'oauth-authorized'
-      : 'oauth-required';
+  ): Promise<GlobalMcpServerAuthStatus> {
+    if (server.enabled === false || server.transport === 'stdio') {
+      return { name: server.name, authStatus: 'not-applicable' };
+    }
+    if (server.bearerTokenEnvVar !== undefined || hasAuthorizationHeader(server.headers)) {
+      return { name: server.name, authStatus: 'bearer-token' };
+    }
+    if (await oauth.hasTokens(server.name, server.url)) {
+      return { name: server.name, authStatus: 'oauth-authorized' };
+    }
+    try {
+      const discovery = await discoverMcpOAuth(server.url, server.headers);
+      if (discovery !== undefined) {
+        await oauth.getProvider(server.name, server.url).saveDiscoveryState(discovery);
+      }
+      return {
+        name: server.name,
+        authStatus: discovery === undefined ? 'not-applicable' : 'oauth-required',
+      };
+    } catch (error) {
+      return {
+        name: server.name,
+        authStatus: 'unknown',
+        error: error instanceof Error ? error.message : String(error),
+      };
+    }
   }
 
   /**

--- a/packages/node-sdk/src/v2/global-mcp.ts
+++ b/packages/node-sdk/src/v2/global-mcp.ts
@@ -28,6 +28,7 @@ import {
   type McpServerConfig,
 } from '@moonshot-ai/agent-core';
 import type { McpConnectionManager } from '@moonshot-ai/agent-core-v2/mcpCore/connection-manager';
+import { hasAuthorizationHeader } from '@moonshot-ai/agent-core-v2/mcpCore/oauth/discovery';
 import { atomicWrite } from '@moonshot-ai/agent-core-v2/_base/utils/fs';
 
 import type { McpTestResult } from '#/types';
@@ -161,10 +162,10 @@ export function requireOAuthMcpServer(server: GlobalMcpServerConfig): McpRemoteS
       `MCP server "${server.name}" uses a static bearer token`,
     );
   }
-  if (config.headers !== undefined && config.auth !== 'oauth') {
+  if (hasAuthorizationHeader(config.headers)) {
     throw new KimiError(
       ErrorCodes.REQUEST_INVALID,
-      `MCP server "${server.name}" uses static headers and is not marked for OAuth`,
+      `MCP server "${server.name}" uses a static Authorization header`,
     );
   }
   return config;

--- a/packages/node-sdk/test/mcp-auth-status-server.ts
+++ b/packages/node-sdk/test/mcp-auth-status-server.ts
@@ -1,0 +1,231 @@
+import { createServer, type IncomingMessage, type Server, type ServerResponse } from 'node:http';
+import type { AddressInfo } from 'node:net';
+
+export type McpAuthStatusServerMode =
+  | 'rfc9728'
+  | 'challenge'
+  | 'unsupported'
+  | 'error'
+  | 'slow-redirect'
+  | 'mismatch'
+  | 'redirect';
+
+export interface RecordedMcpAuthRequest {
+  readonly side: 'resource' | 'authorization';
+  readonly path: string;
+  readonly headers: Readonly<Record<string, string | string[] | undefined>>;
+}
+
+export interface McpAuthStatusTestServer {
+  readonly url: string;
+  readonly requests: RecordedMcpAuthRequest[];
+  readonly close: () => Promise<void>;
+}
+
+export async function startMcpAuthStatusTestServer(options: {
+  readonly mode: McpAuthStatusServerMode;
+  readonly requiredResourceHeader?: readonly [name: string, value: string];
+  readonly authorizationIssuer?: 'matching' | 'missing' | 'mismatched';
+}): Promise<McpAuthStatusTestServer> {
+  const requests: RecordedMcpAuthRequest[] = [];
+  const authorizationServer = createServer((request, response) => {
+    requests.push(recordRequest('authorization', request));
+    void handleAuthorizationRequest(
+      request,
+      response,
+      authorizationBase,
+      options.authorizationIssuer ?? 'matching',
+    );
+  });
+  await listen(authorizationServer);
+  const authorizationBase = serverBaseUrl(authorizationServer);
+
+  let resourceBase = '';
+  const resourceServer = createServer((request, response) => {
+    requests.push(recordRequest('resource', request));
+    void handleResourceRequest(
+      request,
+      response,
+      options,
+      resourceBase,
+      authorizationBase,
+    );
+  });
+  await listen(resourceServer);
+  resourceBase = serverBaseUrl(resourceServer);
+
+  return {
+    url: `${resourceBase}/mcp`,
+    requests,
+    async close() {
+      resourceServer.closeAllConnections();
+      authorizationServer.closeAllConnections();
+      await Promise.all([closeServer(resourceServer), closeServer(authorizationServer)]);
+    },
+  };
+}
+
+async function handleResourceRequest(
+  request: IncomingMessage,
+  response: ServerResponse,
+  options: {
+    readonly mode: McpAuthStatusServerMode;
+    readonly requiredResourceHeader?: readonly [name: string, value: string];
+  },
+  resourceBase: string,
+  authorizationBase: string,
+): Promise<void> {
+  const path = new URL(request.url ?? '/', resourceBase).pathname;
+  const requiredHeader = options.requiredResourceHeader;
+  if (
+    requiredHeader !== undefined &&
+    request.headers[requiredHeader[0].toLowerCase()] !== requiredHeader[1]
+  ) {
+    response.writeHead(403).end('missing resource header');
+    return;
+  }
+
+  if (options.mode === 'slow-redirect' && path === '/.well-known/oauth-protected-resource/mcp') {
+    await delay(20);
+    response.writeHead(302, { location: `${resourceBase}/slow-resource-metadata` }).end();
+    return;
+  }
+  if (options.mode === 'slow-redirect' && path === '/slow-resource-metadata') {
+    await delay(70);
+    sendJson(response, {
+      resource: `${resourceBase}/mcp`,
+      authorization_servers: [`${authorizationBase}/issuer`],
+    });
+    return;
+  }
+  if (options.mode === 'error' && path === '/.well-known/oauth-protected-resource/mcp') {
+    response.writeHead(500).end('metadata failure');
+    return;
+  }
+  if (options.mode === 'redirect' && path === '/.well-known/oauth-protected-resource/mcp') {
+    response.writeHead(302, { location: `${authorizationBase}/redirect-target` }).end();
+    return;
+  }
+  if (
+    (options.mode === 'rfc9728' || options.mode === 'mismatch') &&
+    path === '/.well-known/oauth-protected-resource/mcp'
+  ) {
+    sendJson(response, {
+      resource: options.mode === 'mismatch' ? `${resourceBase}/different` : `${resourceBase}/mcp`,
+      authorization_servers: [`${authorizationBase}/issuer`],
+    });
+    return;
+  }
+  if (options.mode === 'challenge' && path === '/mcp') {
+    response
+      .writeHead(401, {
+        'www-authenticate': `Bearer resource_metadata="${resourceBase}/resource-metadata"`,
+      })
+      .end('authorization required');
+    return;
+  }
+  if (options.mode === 'challenge' && path === '/resource-metadata') {
+    sendJson(response, {
+      resource: `${resourceBase}/mcp`,
+      authorization_servers: [`${authorizationBase}/issuer`],
+    });
+    return;
+  }
+  if (path === '/mcp') {
+    response.writeHead(405).end();
+    return;
+  }
+  response.writeHead(404).end();
+}
+
+async function handleAuthorizationRequest(
+  request: IncomingMessage,
+  response: ServerResponse,
+  authorizationBase: string,
+  issuerMode: 'matching' | 'missing' | 'mismatched',
+): Promise<void> {
+  const path = new URL(request.url ?? '/', authorizationBase).pathname;
+  if (path === '/.well-known/oauth-authorization-server/issuer') {
+    const metadata: Record<string, unknown> = {
+      authorization_endpoint: `${authorizationBase}/authorize`,
+      token_endpoint: `${authorizationBase}/token`,
+      registration_endpoint: `${authorizationBase}/register`,
+      response_types_supported: ['code'],
+      code_challenge_methods_supported: ['S256'],
+    };
+    if (issuerMode !== 'missing') {
+      metadata['issuer'] = issuerMode === 'matching'
+        ? `${authorizationBase}/issuer`
+        : 'https://unexpected-issuer.example';
+    }
+    sendJson(response, metadata);
+    return;
+  }
+  if (path === '/register' && request.method === 'POST') {
+    const body = JSON.parse(await readBody(request)) as { readonly redirect_uris?: string[] };
+    sendJson(response, {
+      client_id: 'test-client',
+      redirect_uris: body.redirect_uris ?? [],
+      token_endpoint_auth_method: 'none',
+    });
+    return;
+  }
+  if (path === '/token' && request.method === 'POST') {
+    sendJson(response, {
+      access_token: 'refreshed-test-token',
+      refresh_token: 'refresh-test-token',
+      token_type: 'Bearer',
+    });
+    return;
+  }
+  if (path === '/redirect-target') {
+    sendJson(response, { reached: true });
+    return;
+  }
+  response.writeHead(404).end();
+}
+
+function recordRequest(
+  side: RecordedMcpAuthRequest['side'],
+  request: IncomingMessage,
+): RecordedMcpAuthRequest {
+  return {
+    side,
+    path: new URL(request.url ?? '/', 'http://127.0.0.1').pathname,
+    headers: { ...request.headers },
+  };
+}
+
+function sendJson(response: ServerResponse, value: unknown): void {
+  response.writeHead(200, { 'content-type': 'application/json' });
+  response.end(JSON.stringify(value));
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function readBody(request: IncomingMessage): Promise<string> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of request) {
+    chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+  }
+  return Buffer.concat(chunks).toString('utf-8');
+}
+
+function serverBaseUrl(server: Server): string {
+  return `http://127.0.0.1:${(server.address() as AddressInfo).port}`;
+}
+
+function listen(server: Server): Promise<void> {
+  return new Promise((resolve) => server.listen(0, '127.0.0.1', resolve));
+}
+
+function closeServer(server: Server): Promise<void> {
+  return new Promise((resolve, reject) => {
+    server.close((error) => {
+      if (error) reject(error);
+      else resolve();
+    });
+  });
+}

--- a/packages/node-sdk/test/mcp-config.test.ts
+++ b/packages/node-sdk/test/mcp-config.test.ts
@@ -13,11 +13,16 @@ import { join } from 'node:path';
 import {
   createKimiHarness,
   KimiHarness,
+  SDKRpcClient,
   SDKRpcClientBase,
 } from '#/index';
 import { afterEach, describe, expect, it } from 'vitest';
 
 import { McpOAuthService } from '../../agent-core/src/mcp/oauth/service';
+import { discoverMcpOAuth as discoverMcpOAuthV1 } from '../../agent-core/src/mcp/oauth/discovery';
+import { discoverMcpOAuth as discoverMcpOAuthV2 } from '../../agent-core-v2/src/mcpCore/oauth/discovery';
+
+import { startMcpAuthStatusTestServer } from './mcp-auth-status-server';
 
 const tempDirs: string[] = [];
 const stdioFixture = join(
@@ -213,31 +218,57 @@ describe('standalone MCP check (connection result)', () => {
 });
 
 describe('MCP OAuth facade (host-controlled browser flow)', () => {
-  it('reports persisted authorization without starting an OAuth flow', async () => {
+  it('reports authorization from stored credentials and standard OAuth metadata', async () => {
     const homeDir = await makeTempDir();
-    const authorizedUrl = 'https://authorized.example.test/mcp';
+    const [rfc9728, challenge, unsupported, failure, mismatch] = await Promise.all([
+        startMcpAuthStatusTestServer({
+          mode: 'rfc9728',
+          requiredResourceHeader: ['x-api-key', 'resource-secret'],
+        }),
+        startMcpAuthStatusTestServer({ mode: 'challenge' }),
+        startMcpAuthStatusTestServer({ mode: 'unsupported' }),
+        startMcpAuthStatusTestServer({ mode: 'error' }),
+        startMcpAuthStatusTestServer({ mode: 'mismatch' }),
+      ]);
+    const storedUrl = 'http://127.0.0.1:1/stored';
     new McpOAuthService({ kimiHomeDir: homeDir })
-      .getProvider('oauth-authorized', authorizedUrl)
+      .getProvider('oauth-authorized', storedUrl)
       .saveTokens({ access_token: 'test-access-token', token_type: 'Bearer' });
     await writeMcpConfig(homeDir, {
       mcpServers: {
         stdio: { command: 'local-command' },
-        plain: { transport: 'http', url: 'https://plain.example.test/mcp' },
+        disabled: { transport: 'http', url: failure.url, enabled: false },
         bearer: {
           transport: 'http',
-          url: 'https://bearer.example.test/mcp',
+          url: 'http://127.0.0.1:1/bearer',
           bearerTokenEnvVar: 'EXAMPLE_MCP_TOKEN',
         },
-        'oauth-required': {
+        'authorization-header': {
           transport: 'http',
-          url: 'https://required.example.test/mcp',
-          auth: 'oauth',
+          url: 'http://127.0.0.1:1/static-authorization',
+          headers: { authorization: 'Bearer configured' },
         },
         'oauth-authorized': {
           transport: 'http',
-          url: authorizedUrl,
+          url: storedUrl,
+        },
+        'oauth-rfc9728': {
+          transport: 'http',
+          url: rfc9728.url,
+          headers: { 'X-Api-Key': 'resource-secret' },
+        },
+        'oauth-challenge': {
+          transport: 'http',
+          url: challenge.url,
+        },
+        'oauth-unsupported-marker': {
+          transport: 'http',
+          url: unsupported.url,
           auth: 'oauth',
         },
+        'oauth-mismatch': { transport: 'http', url: mismatch.url },
+        failed: { transport: 'http', url: failure.url },
+        'oauth-sse': { transport: 'sse', url: challenge.url },
       },
     });
     const harness = createKimiHarness({ homeDir });
@@ -245,13 +276,197 @@ describe('MCP OAuth facade (host-controlled browser flow)', () => {
     try {
       await expect(harness.listMcpServerAuthStatuses()).resolves.toEqual([
         { name: 'stdio', authStatus: 'not-applicable' },
-        { name: 'plain', authStatus: 'not-applicable' },
+        { name: 'disabled', authStatus: 'not-applicable' },
         { name: 'bearer', authStatus: 'bearer-token' },
-        { name: 'oauth-required', authStatus: 'oauth-required' },
+        { name: 'authorization-header', authStatus: 'bearer-token' },
         { name: 'oauth-authorized', authStatus: 'oauth-authorized' },
+        { name: 'oauth-rfc9728', authStatus: 'oauth-required' },
+        { name: 'oauth-challenge', authStatus: 'oauth-required' },
+        { name: 'oauth-unsupported-marker', authStatus: 'not-applicable' },
+        {
+          name: 'oauth-mismatch',
+          authStatus: 'unknown',
+          error: expect.stringMatching(/does not match expected/i),
+        },
+        {
+          name: 'failed',
+          authStatus: 'unknown',
+          error: expect.stringMatching(/HTTP 500/i),
+        },
+        { name: 'oauth-sse', authStatus: 'oauth-required' },
       ]);
+      expect(
+        rfc9728.requests
+          .filter((request) => request.side === 'resource')
+          .every((request) => request.headers['x-api-key'] === 'resource-secret'),
+      ).toBe(true);
+      expect(
+        rfc9728.requests
+          .filter((request) => request.side === 'authorization')
+          .every((request) => request.headers['x-api-key'] === undefined),
+      ).toBe(true);
     } finally {
       await harness.close();
+      await Promise.all(
+        [rfc9728, challenge, unsupported, failure, mismatch].map((server) => server.close()),
+      );
+    }
+  });
+
+  it('shares one timeout deadline across OAuth discovery redirects', async () => {
+    const server = await startMcpAuthStatusTestServer({ mode: 'slow-redirect' });
+    try {
+      await Promise.all(
+        [discoverMcpOAuthV1, discoverMcpOAuthV2].map(async (discover) => {
+          await expect(discover(server.url, undefined, { timeoutMs: 80 })).rejects.toThrow(
+            /abort|timeout/i,
+          );
+        }),
+      );
+      expect(server.requests.some((request) => request.path === '/slow-resource-metadata')).toBe(
+        true,
+      );
+    } finally {
+      await server.close();
+    }
+  });
+
+  it('rejects cross-origin discovery redirects without leaking configured headers', async () => {
+    const server = await startMcpAuthStatusTestServer({
+      mode: 'redirect',
+      requiredResourceHeader: ['x-api-key', 'resource-secret'],
+    });
+    try {
+      await Promise.all(
+        [discoverMcpOAuthV1, discoverMcpOAuthV2].map(async (discover) => {
+          await expect(
+            discover(server.url, { 'X-Api-Key': 'resource-secret' }),
+          ).rejects.toThrow(/non-same-origin/i);
+        }),
+      );
+      expect(
+        server.requests.some(
+          (request) => request.side === 'authorization' && request.path === '/redirect-target',
+        ),
+      ).toBe(false);
+    } finally {
+      await server.close();
+    }
+  });
+
+  it('reads the MCP resource challenge before probing well-known metadata', async () => {
+    const server = await startMcpAuthStatusTestServer({ mode: 'challenge' });
+    try {
+      for (const discover of [discoverMcpOAuthV1, discoverMcpOAuthV2]) {
+        const requestOffset = server.requests.length;
+        await expect(discover(server.url, undefined)).resolves.toBeDefined();
+        expect(
+          server.requests
+            .slice(requestOffset)
+            .filter((request) => request.side === 'resource')
+            .map((request) => request.path),
+        ).toEqual(['/mcp', '/resource-metadata']);
+      }
+    } finally {
+      await server.close();
+    }
+  });
+
+  it('accepts missing authorization issuers and rejects explicit mismatches', async () => {
+    const [missing, mismatched] = await Promise.all([
+      startMcpAuthStatusTestServer({ mode: 'rfc9728', authorizationIssuer: 'missing' }),
+      startMcpAuthStatusTestServer({ mode: 'rfc9728', authorizationIssuer: 'mismatched' }),
+    ]);
+    try {
+      for (const discover of [discoverMcpOAuthV1, discoverMcpOAuthV2]) {
+        await expect(discover(missing.url, undefined)).resolves.toMatchObject({
+          authorizationServerMetadata: {
+            authorization_endpoint: expect.stringMatching(/\/authorize$/),
+          },
+        });
+        await expect(discover(mismatched.url, undefined)).rejects.toThrow(
+          /issuer.*does not match/i,
+        );
+      }
+    } finally {
+      await Promise.all([missing.close(), mismatched.close()]);
+    }
+  });
+
+  it('begins OAuth with an auxiliary header regardless of the legacy auth marker', async () => {
+    const homeDir = await makeTempDir();
+    const server = await startMcpAuthStatusTestServer({
+      mode: 'rfc9728',
+      requiredResourceHeader: ['x-api-key', 'resource-secret'],
+    });
+    const oauth = new McpOAuthService({ kimiHomeDir: homeDir });
+    const cachedProvider = oauth.getProvider('cached-oauth', server.url);
+    cachedProvider.saveDiscoveryState(
+      (await discoverMcpOAuthV1(server.url, { 'X-Api-Key': 'resource-secret' }))!,
+    );
+    cachedProvider.saveClientInformation({ client_id: 'cached-test-client' });
+    cachedProvider.saveTokens({
+      access_token: 'expired-test-token',
+      refresh_token: 'refresh-test-token',
+      token_type: 'Bearer',
+    });
+    const rpc = new SDKRpcClient({ homeDir });
+    try {
+      await rpc.addGlobalMcpServer({
+        name: 'header-oauth',
+        transport: 'http',
+        url: server.url,
+        headers: { 'X-Api-Key': 'resource-secret' },
+      });
+      await rpc.addGlobalMcpServer({
+        name: 'marked-header-oauth',
+        transport: 'http',
+        url: server.url,
+        headers: { 'X-Api-Key': 'resource-secret' },
+        auth: 'oauth',
+      });
+      await rpc.addGlobalMcpServer({
+        name: 'static-authorization',
+        transport: 'http',
+        url: server.url,
+        headers: { Authorization: 'Bearer configured' },
+      });
+      await rpc.addGlobalMcpServer({
+        name: 'cached-oauth',
+        transport: 'http',
+        url: server.url,
+        headers: { 'X-Api-Key': 'resource-secret' },
+      });
+      const resourceRequestCount = server.requests.filter(
+        (request) => request.side === 'resource',
+      ).length;
+      await expect(rpc.beginGlobalMcpServerAuth('cached-oauth')).resolves.toEqual({
+        status: 'already-authorized',
+      });
+      expect(
+        server.requests.filter((request) => request.side === 'resource'),
+      ).toHaveLength(resourceRequestCount);
+      await expect(rpc.beginGlobalMcpServerAuth('static-authorization')).rejects.toThrow(
+        /static Authorization header/,
+      );
+      for (const name of ['header-oauth', 'marked-header-oauth']) {
+        const started = await rpc.beginGlobalMcpServerAuth(name);
+        expect(started).toMatchObject({
+          status: 'authorization-required',
+          authorizationUrl: expect.stringMatching(/\/authorize\?/),
+        });
+        if (started.status === 'authorization-required') {
+          await rpc.cancelGlobalMcpServerAuth(started.flowId);
+        }
+      }
+      expect(
+        server.requests
+          .filter((request) => request.side === 'authorization')
+          .every((request) => request.headers['x-api-key'] === undefined),
+      ).toBe(true);
+    } finally {
+      await rpc.close();
+      await server.close();
     }
   });
 

--- a/packages/node-sdk/test/sdk-rpc-client-v2.test.ts
+++ b/packages/node-sdk/test/sdk-rpc-client-v2.test.ts
@@ -29,9 +29,11 @@ import {
   IHostRequestHeaders,
 } from '@moonshot-ai/agent-core-v2';
 
+import { discoverMcpOAuth } from '../../agent-core/src/mcp/oauth/discovery';
 import { McpOAuthService } from '../../agent-core/src/mcp/oauth/service';
 
 import { TEST_IDENTITY } from './test-identity';
+import { startMcpAuthStatusTestServer } from './mcp-auth-status-server';
 import { recordingTelemetry, type TelemetryRecord } from './telemetry';
 
 const tempDirs: string[] = [];
@@ -53,35 +55,35 @@ async function makeHarness(): Promise<{ harness: KimiHarness; homeDir: string }>
 }
 
 describe('SDKRpcClientV2 (agent-core-v2 wiring MVP)', () => {
-  it('reports global MCP authorization from the persisted v2 credential store', async () => {
+  it('reports global MCP authorization from stored credentials and standard metadata', async () => {
     const homeDir = await mkdtemp(join(tmpdir(), 'kimi-sdk-v2-'));
     tempDirs.push(homeDir);
-    const authorizedUrl = 'https://authorized.example.test/mcp';
-    const requiredUrl = 'https://required.example.test/mcp';
+    const server = await startMcpAuthStatusTestServer({
+      mode: 'rfc9728',
+      requiredResourceHeader: ['x-api-key', 'resource-secret'],
+    });
     const externalOAuth = new McpOAuthService({ kimiHomeDir: homeDir });
     externalOAuth
-      .getProvider('oauth-authorized', authorizedUrl)
+      .getProvider('oauth-authorized', server.url)
       .saveTokens({ access_token: 'test-access-token', token_type: 'Bearer' });
     await writeFile(
       join(homeDir, 'mcp.json'),
       JSON.stringify({
         mcpServers: {
           stdio: { command: 'local-command' },
-          plain: { transport: 'http', url: 'https://plain.example.test/mcp' },
-          bearer: {
+          'authorization-header': {
             transport: 'http',
-            url: 'https://bearer.example.test/mcp',
-            bearerTokenEnvVar: 'EXAMPLE_MCP_TOKEN',
-          },
-          'oauth-required': {
-            transport: 'http',
-            url: requiredUrl,
-            auth: 'oauth',
+            url: server.url,
+            headers: { AUTHORIZATION: 'Bearer configured' },
           },
           'oauth-authorized': {
             transport: 'http',
-            url: authorizedUrl,
-            auth: 'oauth',
+            url: server.url,
+          },
+          'oauth-rfc9728': {
+            transport: 'http',
+            url: server.url,
+            headers: { 'X-Api-Key': 'resource-secret' },
           },
         },
       }),
@@ -92,26 +94,98 @@ describe('SDKRpcClientV2 (agent-core-v2 wiring MVP)', () => {
     try {
       await expect(harness.listMcpServerAuthStatuses()).resolves.toEqual([
         { name: 'stdio', authStatus: 'not-applicable' },
-        { name: 'plain', authStatus: 'not-applicable' },
-        { name: 'bearer', authStatus: 'bearer-token' },
-        { name: 'oauth-required', authStatus: 'oauth-required' },
+        { name: 'authorization-header', authStatus: 'bearer-token' },
         { name: 'oauth-authorized', authStatus: 'oauth-authorized' },
+        { name: 'oauth-rfc9728', authStatus: 'oauth-required' },
       ]);
-
-      externalOAuth
-        .getProvider('oauth-required', requiredUrl)
-        .saveTokens({ access_token: 'new-test-access-token', token_type: 'Bearer' });
-      externalOAuth.invalidate('oauth-authorized', authorizedUrl, 'tokens');
-
-      await expect(harness.listMcpServerAuthStatuses()).resolves.toEqual([
-        { name: 'stdio', authStatus: 'not-applicable' },
-        { name: 'plain', authStatus: 'not-applicable' },
-        { name: 'bearer', authStatus: 'bearer-token' },
-        { name: 'oauth-required', authStatus: 'oauth-authorized' },
-        { name: 'oauth-authorized', authStatus: 'oauth-required' },
-      ]);
+      expect(
+        server.requests
+          .filter((request) => request.side === 'authorization')
+          .every((request) => request.headers['x-api-key'] === undefined),
+      ).toBe(true);
     } finally {
       await harness.close();
+      await server.close();
+    }
+  });
+
+  it('begins OAuth with an auxiliary header regardless of the legacy auth marker', async () => {
+    const homeDir = await mkdtemp(join(tmpdir(), 'kimi-sdk-v2-'));
+    tempDirs.push(homeDir);
+    const server = await startMcpAuthStatusTestServer({
+      mode: 'rfc9728',
+      requiredResourceHeader: ['x-api-key', 'resource-secret'],
+    });
+    const cachedProvider = new McpOAuthService({ kimiHomeDir: homeDir }).getProvider(
+      'cached-oauth',
+      server.url,
+    );
+    cachedProvider.saveDiscoveryState(
+      (await discoverMcpOAuth(server.url, { 'X-Api-Key': 'resource-secret' }))!,
+    );
+    cachedProvider.saveClientInformation({ client_id: 'cached-test-client' });
+    cachedProvider.saveTokens({
+      access_token: 'expired-test-token',
+      refresh_token: 'refresh-test-token',
+      token_type: 'Bearer',
+    });
+    const rpc = new SDKRpcClientV2({ homeDir, identity: TEST_IDENTITY });
+    try {
+      await rpc.addGlobalMcpServer({
+        name: 'header-oauth',
+        transport: 'http',
+        url: server.url,
+        headers: { 'X-Api-Key': 'resource-secret' },
+      });
+      await rpc.addGlobalMcpServer({
+        name: 'marked-header-oauth',
+        transport: 'http',
+        url: server.url,
+        headers: { 'X-Api-Key': 'resource-secret' },
+        auth: 'oauth',
+      });
+      await rpc.addGlobalMcpServer({
+        name: 'static-authorization',
+        transport: 'http',
+        url: server.url,
+        headers: { Authorization: 'Bearer configured' },
+      });
+      await rpc.addGlobalMcpServer({
+        name: 'cached-oauth',
+        transport: 'http',
+        url: server.url,
+        headers: { 'X-Api-Key': 'resource-secret' },
+      });
+      const resourceRequestCount = server.requests.filter(
+        (request) => request.side === 'resource',
+      ).length;
+      await expect(rpc.beginGlobalMcpServerAuth('cached-oauth')).resolves.toEqual({
+        status: 'already-authorized',
+      });
+      expect(
+        server.requests.filter((request) => request.side === 'resource'),
+      ).toHaveLength(resourceRequestCount);
+      await expect(rpc.beginGlobalMcpServerAuth('static-authorization')).rejects.toThrow(
+        /static Authorization header/,
+      );
+      for (const name of ['header-oauth', 'marked-header-oauth']) {
+        const started = await rpc.beginGlobalMcpServerAuth(name);
+        expect(started).toMatchObject({
+          status: 'authorization-required',
+          authorizationUrl: expect.stringMatching(/\/authorize\?/),
+        });
+        if (started.status === 'authorization-required') {
+          await rpc.cancelGlobalMcpServerAuth(started.flowId);
+        }
+      }
+      expect(
+        server.requests
+          .filter((request) => request.side === 'authorization')
+          .every((request) => request.headers['x-api-key'] === undefined),
+      ).toBe(true);
+    } finally {
+      await rpc.close();
+      await server.close();
     }
   });
 

--- a/packages/node-sdk/test/v1-v2-parity.test.ts
+++ b/packages/node-sdk/test/v1-v2-parity.test.ts
@@ -3463,27 +3463,22 @@ async function expectSameMcpRejection(
 }
 
 describe('v1↔v2 global MCP parity', () => {
-  it('classifies global MCP authorization identically from persisted credentials', async () => {
+  it('classifies stored and static MCP credentials identically', async () => {
     const authorizedUrl = 'https://authorized.example.test/mcp';
     const pair = await makeGlobalMcpParityPair({
       mcpServers: {
         stdio: { command: 'local-command' },
-        plain: { transport: 'http', url: 'https://plain.example.test/mcp' },
         bearer: {
           transport: 'http',
           url: 'https://bearer.example.test/mcp',
           bearerTokenEnvVar: 'EXAMPLE_MCP_TOKEN',
         },
-        'oauth-required': {
+        'authorization-header': {
           transport: 'http',
-          url: 'https://required.example.test/mcp',
-          auth: 'oauth',
+          url: 'https://header.example.test/mcp',
+          headers: { Authorization: 'Bearer static' },
         },
-        'oauth-authorized': {
-          transport: 'http',
-          url: authorizedUrl,
-          auth: 'oauth',
-        },
+        'oauth-authorized': { transport: 'http', url: authorizedUrl },
       },
     });
     for (const homeDir of [pair.v1HomeDir, pair.v2HomeDir]) {
@@ -3500,9 +3495,8 @@ describe('v1↔v2 global MCP parity', () => {
       expect(v2Statuses).toEqual(v1Statuses);
       expect(v1Statuses).toEqual([
         { name: 'stdio', authStatus: 'not-applicable' },
-        { name: 'plain', authStatus: 'not-applicable' },
         { name: 'bearer', authStatus: 'bearer-token' },
-        { name: 'oauth-required', authStatus: 'oauth-required' },
+        { name: 'authorization-header', authStatus: 'bearer-token' },
         { name: 'oauth-authorized', authStatus: 'oauth-authorized' },
       ]);
     } finally {
@@ -3675,8 +3669,8 @@ describe('v1↔v2 global MCP parity', () => {
       },
     });
     try {
-      // begin: unknown server / non-remote / static token / static headers
-      // all reject before any network I/O.
+      // begin: unknown server / non-remote / static token / static Authorization
+      // all reject before network I/O.
       await expectSameMcpRejection(
         pair,
         (client) => client.beginGlobalMcpServerAuth('missing'),


### PR DESCRIPTION
## Related Issue

No linked issue. This fixes MCP OAuth status and login detection that previously depended on an explicit config marker or arbitrary 401 responses.

## Problem

Global MCP auth status and login were inferred from `auth: "oauth"` or an unauthorized response. That could hide valid OAuth servers using standard metadata, misclassify non-OAuth 401 responses, and fail OAuth discovery for configurations with auxiliary headers.

## What changed

- Discover OAuth via GET-first RFC 9728 protected-resource metadata and RFC 8414/OIDC authorization-server metadata.
- Preserve legacy missing-issuer compatibility while rejecting explicit issuer and resource mismatches.
- Reuse discovered state across status, login, and runtime authentication, independent of the legacy marker.
- Keep static bearer/Authorization credentials and stored OAuth token refresh behavior unchanged.
- Report transient discovery failures as `unknown`.

## Validation

- Focused OAuth tests: 25 passed.
- Targeted v1/v2 parity tests: 2 passed.
- Typechecks passed for agent-core, agent-core-v2, and kimi-code-sdk.
- agent-core-v2 import-boundary check passed.
- Full relevant-file run: 103 passed; 17 existing Windows-only baseline failures remain (fixture drive-path normalization and localized missing-executable output), with no OAuth-case failures.

## Checklist

- [x] I have read the CONTRIBUTING document.
- [x] I have explained the problem above.
- [x] I have added tests that prove the fix works.
- [x] Ran the `gen-changesets` workflow and added a patch changeset.
- [x] This PR needs no docs update.
