### PR TITLE
fix(sdk): probe MCP auth status through connection

### DIFF
--- a/.changeset/calm-mcp-auth-probe.md
+++ b/.changeset/calm-mcp-auth-probe.md
@@ -1,0 +1,6 @@
+---
+"@moonshot-ai/kimi-code": patch
+"@moonshot-ai/kimi-code-sdk": patch
+---
+
+Detect MCP servers that require OAuth by reusing the existing connection-time authorization check.

--- a/packages/agent-core/src/rpc/core-impl.ts
+++ b/packages/agent-core/src/rpc/core-impl.ts
@@ -857,7 +857,16 @@ export class KimiCore implements PromisableMethods<CoreAPI> {
     { name, cwd }: TestGlobalMcpServerPayload,
   ): Promise<GlobalMcpServerTestResult> {
     const server = await this.globalMcpConfig.get(name);
-    const config = mcpConfigWithoutName(server);
+    return this.withGlobalMcpServerProbe(server, cwd, (manager) =>
+      standaloneMcpTestResult(server.name, manager),
+    );
+  }
+
+  private async withGlobalMcpServerProbe<T>(
+    server: GlobalMcpServerConfig,
+    cwd: string | undefined,
+    inspect: (manager: McpConnectionManager) => T,
+  ): Promise<T> {
     const manager = new McpConnectionManager({
       stdioCwd: cwd,
       oauthService: this.globalMcpOAuth,
@@ -865,8 +874,8 @@ export class KimiCore implements PromisableMethods<CoreAPI> {
       defaultToolTimeoutMs: resolveMcpToolTimeoutMs(this.config.mcp?.toolTimeoutMs),
     });
     try {
-      await manager.connectAll({ [server.name]: config });
-      return standaloneMcpTestResult(server.name, manager);
+      await manager.connectAll({ [server.name]: mcpConfigWithoutName(server) });
+      return inspect(manager);
     } finally {
       await manager.shutdown();
     }
@@ -877,10 +886,16 @@ export class KimiCore implements PromisableMethods<CoreAPI> {
   ): Promise<GlobalMcpServerAuthState> {
     if (server.transport === 'stdio') return 'not-applicable';
     if (server.bearerTokenEnvVar !== undefined) return 'bearer-token';
-    if (server.auth !== 'oauth') return 'not-applicable';
-    return this.globalMcpOAuth.hasTokens(server.name, server.url)
-      ? 'oauth-authorized'
-      : 'oauth-required';
+    // Keep status classification aligned with the existing connection manager:
+    // unmarked static headers are not treated as OAuth credentials.
+    if (server.headers !== undefined && server.auth !== 'oauth') return 'not-applicable';
+    if (this.globalMcpOAuth.hasTokens(server.name, server.url)) return 'oauth-authorized';
+    if (server.auth === 'oauth') return 'oauth-required';
+    if (server.transport !== 'http') return 'not-applicable';
+
+    return this.withGlobalMcpServerProbe(server, undefined, (manager) =>
+      manager.get(server.name)?.status === 'needs-auth' ? 'oauth-required' : 'not-applicable',
+    );
   }
 
   prompt({ sessionId, ...payload }: SessionAgentPayload<PromptPayload>) {

--- a/packages/agent-core/src/rpc/core-impl.ts
+++ b/packages/agent-core/src/rpc/core-impl.ts
@@ -889,9 +889,9 @@ export class KimiCore implements PromisableMethods<CoreAPI> {
     // Keep status classification aligned with the existing connection manager:
     // unmarked static headers are not treated as OAuth credentials.
     if (server.headers !== undefined && server.auth !== 'oauth') return 'not-applicable';
+    if (server.transport !== 'http' && server.auth !== 'oauth') return 'not-applicable';
     if (this.globalMcpOAuth.hasTokens(server.name, server.url)) return 'oauth-authorized';
     if (server.auth === 'oauth') return 'oauth-required';
-    if (server.transport !== 'http') return 'not-applicable';
 
     return this.withGlobalMcpServerProbe(server, undefined, (manager) =>
       manager.get(server.name)?.status === 'needs-auth' ? 'oauth-required' : 'not-applicable',

--- a/packages/node-sdk/src/sdk-rpc-client-v2.ts
+++ b/packages/node-sdk/src/sdk-rpc-client-v2.ts
@@ -2212,11 +2212,20 @@ export class SDKRpcClientV2 extends SDKRpcClientBase {
     options: { readonly cwd?: string } = {},
   ): Promise<McpTestResult> {
     const server = await this.globalMcpConfig.get(name);
-    const config = mcpConfigWithoutName(server);
+    return this.withGlobalMcpServerProbe(server, options.cwd, (manager) =>
+      standaloneMcpTestResult(server.name, manager),
+    );
+  }
+
+  private async withGlobalMcpServerProbe<T>(
+    server: McpServerConfig,
+    cwd: string | undefined,
+    inspect: (manager: McpConnectionManager) => T,
+  ): Promise<T> {
     await this.configReady;
     const section = this.engineAccessor.get(IConfigService).get<McpSection | undefined>(MCP_SECTION);
     const manager = new McpConnectionManager({
-      stdioCwd: options.cwd,
+      stdioCwd: cwd,
       oauthService: await this.globalMcpOAuthService(),
       resolveClientName: () => this.resolveMcpClientName(),
       resolveDefaultTimeouts: () => ({
@@ -2225,8 +2234,8 @@ export class SDKRpcClientV2 extends SDKRpcClientBase {
       }),
     });
     try {
-      await manager.connectAll({ [server.name]: config });
-      return standaloneMcpTestResult(server.name, manager);
+      await manager.connectAll({ [server.name]: mcpConfigWithoutName(server) });
+      return inspect(manager);
     } finally {
       await manager.shutdown();
     }
@@ -2238,10 +2247,16 @@ export class SDKRpcClientV2 extends SDKRpcClientBase {
   ): Promise<GlobalMcpServerAuthState> {
     if (server.transport === 'stdio') return 'not-applicable';
     if (server.bearerTokenEnvVar !== undefined) return 'bearer-token';
-    if (server.auth !== 'oauth') return 'not-applicable';
-    return (await oauth.hasTokens(server.name, server.url))
-      ? 'oauth-authorized'
-      : 'oauth-required';
+    // Keep status classification aligned with the existing connection manager:
+    // unmarked static headers are not treated as OAuth credentials.
+    if (server.headers !== undefined && server.auth !== 'oauth') return 'not-applicable';
+    if (await oauth.hasTokens(server.name, server.url)) return 'oauth-authorized';
+    if (server.auth === 'oauth') return 'oauth-required';
+    if (server.transport !== 'http') return 'not-applicable';
+
+    return this.withGlobalMcpServerProbe(server, undefined, (manager) =>
+      manager.get(server.name)?.status === 'needs-auth' ? 'oauth-required' : 'not-applicable',
+    );
   }
 
   /**

--- a/packages/node-sdk/src/sdk-rpc-client-v2.ts
+++ b/packages/node-sdk/src/sdk-rpc-client-v2.ts
@@ -2250,9 +2250,9 @@ export class SDKRpcClientV2 extends SDKRpcClientBase {
     // Keep status classification aligned with the existing connection manager:
     // unmarked static headers are not treated as OAuth credentials.
     if (server.headers !== undefined && server.auth !== 'oauth') return 'not-applicable';
+    if (server.transport !== 'http' && server.auth !== 'oauth') return 'not-applicable';
     if (await oauth.hasTokens(server.name, server.url)) return 'oauth-authorized';
     if (server.auth === 'oauth') return 'oauth-required';
-    if (server.transport !== 'http') return 'not-applicable';
 
     return this.withGlobalMcpServerProbe(server, undefined, (manager) =>
       manager.get(server.name)?.status === 'needs-auth' ? 'oauth-required' : 'not-applicable',

--- a/packages/node-sdk/test/mcp-auth-status-server.ts
+++ b/packages/node-sdk/test/mcp-auth-status-server.ts
@@ -1,0 +1,35 @@
+import { createServer } from 'node:http';
+import type { AddressInfo } from 'node:net';
+
+export interface McpAuthStatusServer {
+  readonly plainUrl: string;
+  readonly oauthUrl: string;
+  close(): Promise<void>;
+}
+
+export async function startMcpAuthStatusServer(): Promise<McpAuthStatusServer> {
+  const server = createServer((request, response) => {
+    if (request.url === '/oauth') {
+      response.writeHead(401).end('Unauthorized');
+      return;
+    }
+    response.writeHead(404).end('Not found');
+  });
+  await new Promise<void>((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(0, '127.0.0.1', resolve);
+  });
+  const { port } = server.address() as AddressInfo;
+  const baseUrl = `http://127.0.0.1:${port}`;
+  return {
+    plainUrl: `${baseUrl}/plain`,
+    oauthUrl: `${baseUrl}/oauth`,
+    close: () =>
+      new Promise<void>((resolve, reject) => {
+        server.close((error) => {
+          if (error === undefined) resolve();
+          else reject(error);
+        });
+      }),
+  };
+}

--- a/packages/node-sdk/test/mcp-config.test.ts
+++ b/packages/node-sdk/test/mcp-config.test.ts
@@ -219,9 +219,13 @@ describe('MCP OAuth facade (host-controlled browser flow)', () => {
     const homeDir = await makeTempDir();
     const statusServer = await startMcpAuthStatusServer();
     const authorizedUrl = 'https://authorized.example.test/mcp';
-    new McpOAuthService({ kimiHomeDir: homeDir })
+    const externalOAuth = new McpOAuthService({ kimiHomeDir: homeDir });
+    externalOAuth
       .getProvider('oauth-authorized', authorizedUrl)
       .saveTokens({ access_token: 'test-access-token', token_type: 'Bearer' });
+    externalOAuth
+      .getProvider('sse', statusServer.oauthUrl)
+      .saveTokens({ access_token: 'stale-sse-token', token_type: 'Bearer' });
     await writeMcpConfig(homeDir, {
       mcpServers: {
         stdio: { command: 'local-command' },

--- a/packages/node-sdk/test/mcp-config.test.ts
+++ b/packages/node-sdk/test/mcp-config.test.ts
@@ -19,6 +19,8 @@ import { afterEach, describe, expect, it } from 'vitest';
 
 import { McpOAuthService } from '../../agent-core/src/mcp/oauth/service';
 
+import { startMcpAuthStatusServer } from './mcp-auth-status-server';
+
 const tempDirs: string[] = [];
 const stdioFixture = join(
   import.meta.dirname,
@@ -215,6 +217,7 @@ describe('standalone MCP check (connection result)', () => {
 describe('MCP OAuth facade (host-controlled browser flow)', () => {
   it('reports persisted authorization without starting an OAuth flow', async () => {
     const homeDir = await makeTempDir();
+    const statusServer = await startMcpAuthStatusServer();
     const authorizedUrl = 'https://authorized.example.test/mcp';
     new McpOAuthService({ kimiHomeDir: homeDir })
       .getProvider('oauth-authorized', authorizedUrl)
@@ -222,7 +225,10 @@ describe('MCP OAuth facade (host-controlled browser flow)', () => {
     await writeMcpConfig(homeDir, {
       mcpServers: {
         stdio: { command: 'local-command' },
-        plain: { transport: 'http', url: 'https://plain.example.test/mcp' },
+        plain: { transport: 'http', url: statusServer.plainUrl },
+        detected: { transport: 'http', url: statusServer.oauthUrl },
+        sse: { transport: 'sse', url: statusServer.oauthUrl },
+        'sse-oauth': { transport: 'sse', url: statusServer.oauthUrl, auth: 'oauth' },
         bearer: {
           transport: 'http',
           url: 'https://bearer.example.test/mcp',
@@ -246,14 +252,18 @@ describe('MCP OAuth facade (host-controlled browser flow)', () => {
       await expect(harness.listMcpServerAuthStatuses()).resolves.toEqual([
         { name: 'stdio', authStatus: 'not-applicable' },
         { name: 'plain', authStatus: 'not-applicable' },
+        { name: 'detected', authStatus: 'oauth-required' },
+        { name: 'sse', authStatus: 'not-applicable' },
+        { name: 'sse-oauth', authStatus: 'oauth-required' },
         { name: 'bearer', authStatus: 'bearer-token' },
         { name: 'oauth-required', authStatus: 'oauth-required' },
         { name: 'oauth-authorized', authStatus: 'oauth-authorized' },
       ]);
     } finally {
       await harness.close();
+      await statusServer.close();
     }
-  });
+  }, 15_000);
 
   it('resets authorization for a configured remote server', async () => {
     const homeDir = await makeTempDir();

--- a/packages/node-sdk/test/sdk-rpc-client-v2.test.ts
+++ b/packages/node-sdk/test/sdk-rpc-client-v2.test.ts
@@ -64,6 +64,9 @@ describe('SDKRpcClientV2 (agent-core-v2 wiring MVP)', () => {
     externalOAuth
       .getProvider('oauth-authorized', authorizedUrl)
       .saveTokens({ access_token: 'test-access-token', token_type: 'Bearer' });
+    externalOAuth
+      .getProvider('sse', statusServer.oauthUrl)
+      .saveTokens({ access_token: 'stale-sse-token', token_type: 'Bearer' });
     await writeFile(
       join(homeDir, 'mcp.json'),
       JSON.stringify({

--- a/packages/node-sdk/test/sdk-rpc-client-v2.test.ts
+++ b/packages/node-sdk/test/sdk-rpc-client-v2.test.ts
@@ -32,6 +32,7 @@ import {
 import { McpOAuthService } from '../../agent-core/src/mcp/oauth/service';
 
 import { TEST_IDENTITY } from './test-identity';
+import { startMcpAuthStatusServer } from './mcp-auth-status-server';
 import { recordingTelemetry, type TelemetryRecord } from './telemetry';
 
 const tempDirs: string[] = [];
@@ -56,6 +57,7 @@ describe('SDKRpcClientV2 (agent-core-v2 wiring MVP)', () => {
   it('reports global MCP authorization from the persisted v2 credential store', async () => {
     const homeDir = await mkdtemp(join(tmpdir(), 'kimi-sdk-v2-'));
     tempDirs.push(homeDir);
+    const statusServer = await startMcpAuthStatusServer();
     const authorizedUrl = 'https://authorized.example.test/mcp';
     const requiredUrl = 'https://required.example.test/mcp';
     const externalOAuth = new McpOAuthService({ kimiHomeDir: homeDir });
@@ -67,7 +69,10 @@ describe('SDKRpcClientV2 (agent-core-v2 wiring MVP)', () => {
       JSON.stringify({
         mcpServers: {
           stdio: { command: 'local-command' },
-          plain: { transport: 'http', url: 'https://plain.example.test/mcp' },
+          plain: { transport: 'http', url: statusServer.plainUrl },
+          detected: { transport: 'http', url: statusServer.oauthUrl },
+          sse: { transport: 'sse', url: statusServer.oauthUrl },
+          'sse-oauth': { transport: 'sse', url: statusServer.oauthUrl, auth: 'oauth' },
           bearer: {
             transport: 'http',
             url: 'https://bearer.example.test/mcp',
@@ -93,6 +98,9 @@ describe('SDKRpcClientV2 (agent-core-v2 wiring MVP)', () => {
       await expect(harness.listMcpServerAuthStatuses()).resolves.toEqual([
         { name: 'stdio', authStatus: 'not-applicable' },
         { name: 'plain', authStatus: 'not-applicable' },
+        { name: 'detected', authStatus: 'oauth-required' },
+        { name: 'sse', authStatus: 'not-applicable' },
+        { name: 'sse-oauth', authStatus: 'oauth-required' },
         { name: 'bearer', authStatus: 'bearer-token' },
         { name: 'oauth-required', authStatus: 'oauth-required' },
         { name: 'oauth-authorized', authStatus: 'oauth-authorized' },
@@ -106,14 +114,18 @@ describe('SDKRpcClientV2 (agent-core-v2 wiring MVP)', () => {
       await expect(harness.listMcpServerAuthStatuses()).resolves.toEqual([
         { name: 'stdio', authStatus: 'not-applicable' },
         { name: 'plain', authStatus: 'not-applicable' },
+        { name: 'detected', authStatus: 'oauth-required' },
+        { name: 'sse', authStatus: 'not-applicable' },
+        { name: 'sse-oauth', authStatus: 'oauth-required' },
         { name: 'bearer', authStatus: 'bearer-token' },
         { name: 'oauth-required', authStatus: 'oauth-authorized' },
         { name: 'oauth-authorized', authStatus: 'oauth-required' },
       ]);
     } finally {
       await harness.close();
+      await statusServer.close();
     }
-  });
+  }, 15_000);
 
   it('seeds the host request headers (User-Agent + X-Msh-*) into the engine', async () => {
     const homeDir = await mkdtemp(join(tmpdir(), 'kimi-sdk-v2-'));

--- a/packages/node-sdk/test/v1-v2-parity.test.ts
+++ b/packages/node-sdk/test/v1-v2-parity.test.ts
@@ -23,6 +23,8 @@ import {
 
 import { McpOAuthService } from '../../agent-core/src/mcp/oauth/service';
 
+import { startMcpAuthStatusServer } from './mcp-auth-status-server';
+
 import {
   createKimiHarness,
   createKimiHarnessV2,
@@ -3464,11 +3466,15 @@ async function expectSameMcpRejection(
 
 describe('v1↔v2 global MCP parity', () => {
   it('classifies global MCP authorization identically from persisted credentials', async () => {
+    const statusServer = await startMcpAuthStatusServer();
     const authorizedUrl = 'https://authorized.example.test/mcp';
     const pair = await makeGlobalMcpParityPair({
       mcpServers: {
         stdio: { command: 'local-command' },
-        plain: { transport: 'http', url: 'https://plain.example.test/mcp' },
+        plain: { transport: 'http', url: statusServer.plainUrl },
+        detected: { transport: 'http', url: statusServer.oauthUrl },
+        sse: { transport: 'sse', url: statusServer.oauthUrl },
+        'sse-oauth': { transport: 'sse', url: statusServer.oauthUrl, auth: 'oauth' },
         bearer: {
           transport: 'http',
           url: 'https://bearer.example.test/mcp',
@@ -3501,14 +3507,18 @@ describe('v1↔v2 global MCP parity', () => {
       expect(v1Statuses).toEqual([
         { name: 'stdio', authStatus: 'not-applicable' },
         { name: 'plain', authStatus: 'not-applicable' },
+        { name: 'detected', authStatus: 'oauth-required' },
+        { name: 'sse', authStatus: 'not-applicable' },
+        { name: 'sse-oauth', authStatus: 'oauth-required' },
         { name: 'bearer', authStatus: 'bearer-token' },
         { name: 'oauth-required', authStatus: 'oauth-required' },
         { name: 'oauth-authorized', authStatus: 'oauth-authorized' },
       ]);
     } finally {
       await closeGlobalMcpPair(pair);
+      await statusServer.close();
     }
-  });
+  }, 15_000);
 
   it('CRUD round-trips identically and writes byte-identical mcp.json files', async () => {
     const pair = await makeGlobalMcpParityPair({

--- a/packages/node-sdk/test/v1-v2-parity.test.ts
+++ b/packages/node-sdk/test/v1-v2-parity.test.ts
@@ -3493,9 +3493,13 @@ describe('v1↔v2 global MCP parity', () => {
       },
     });
     for (const homeDir of [pair.v1HomeDir, pair.v2HomeDir]) {
-      new McpOAuthService({ kimiHomeDir: homeDir })
+      const externalOAuth = new McpOAuthService({ kimiHomeDir: homeDir });
+      externalOAuth
         .getProvider('oauth-authorized', authorizedUrl)
         .saveTokens({ access_token: 'test-access-token', token_type: 'Bearer' });
+      externalOAuth
+        .getProvider('sse', statusServer.oauthUrl)
+        .saveTokens({ access_token: 'stale-sse-token', token_type: 'Bearer' });
     }
 
     try {


### PR DESCRIPTION
## Related Issue

Follow-up to the global MCP auth-status RPC added in #2706.

## Problem

The auth-status RPC only reported OAuth when the config explicitly contained `auth: "oauth"`. Kimi Code already classifies an uncredentialed HTTP MCP as `needs-auth` when the existing connection probe receives a 401, but the status RPC did not reuse that result.

## What changed

- Reuse one private global MCP connection probe for both `testGlobalMcpServer` and auth-status detection.
- Map the existing `needs-auth` result to `oauth-required` for markerless HTTP servers without static headers or stored tokens.
- Preserve existing stdio, bearer, explicit OAuth, persisted-token, and SSE behavior.
- Add a new patch changeset for the CLI and SDK.

The connection manager, 401 classification, OAuth begin/service/provider, token refresh, and configuration schema are unchanged.

## Validation

- Focused v1, v2, and parity auth-status tests: 7 passed.
- `@moonshot-ai/agent-core` typecheck passed.
- `@moonshot-ai/kimi-code-sdk` typecheck passed.
- Type-aware oxlint: 0 errors; two pre-existing warnings outside the changed hunks.
- Read-only final diff audit: PASS.

## Checklist

- [x] I have read the CONTRIBUTING document.
- [x] I have explained the problem above.
- [x] I have added tests that prove the fix works.
- [x] Added a patch changeset.
- [x] This PR needs no docs update.
