### PR TITLE
fix(vscode): support high-contrast dark theme

### DIFF
--- a/apps/vscode/webview-ui/src/main.tsx
+++ b/apps/vscode/webview-ui/src/main.tsx
@@ -3,7 +3,10 @@ import { createRoot } from "react-dom/client";
 import App from "./App";
 
 function syncTheme() {
-  const isDark = document.body.classList.contains("vscode-dark");
+  const themeKind = document.body.dataset.vscodeThemeKind;
+  const isDark =
+    themeKind === "vscode-dark" ||
+    themeKind === "vscode-high-contrast";
   document.documentElement.classList.toggle("dark", isDark);
 }
 


### PR DESCRIPTION
Fix VS Code dark theme detection for high-contrast dark themes.

The webview previously only treated `vscode-dark` as dark. VS Code uses `vscode-high-contrast` for dark high-contrast themes, causing Kimi Code to render with the light theme.

This change also treats `vscode-high-contrast` as dark while leaving `vscode-high-contrast-light` unchanged.