### PR TITLE
fix(agent-core): isolate builtin profile catalogs per session

### DIFF
--- a/.changeset/isolate-session-profile-catalogs.md
+++ b/.changeset/isolate-session-profile-catalogs.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Prevent one session's subagent tool projection from changing builtin profiles in later sessions.

--- a/packages/agent-core/src/profile/agentfile/catalog.ts
+++ b/packages/agent-core/src/profile/agentfile/catalog.ts
@@ -84,13 +84,45 @@ interface FileProfileEntry {
   readonly override: boolean;
 }
 
+/**
+ * Session-local copies of the builtin profiles. `DEFAULT_AGENT_PROFILES` is a
+ * process-wide constant; seeding `merged` with its values directly would let
+ * any session-scoped rewrite of a profile (e.g. a host runtime projecting
+ * profile tool lists onto the session's tool surface) mutate shared process
+ * state and leak into every later session. Clone each entry and re-link the
+ * delegation graph against the clones so the whole graph is session-local.
+ */
+function sessionLocalBuiltinProfiles(): Map<string, ResolvedAgentProfile> {
+  const cloned = new Map<string, ResolvedAgentProfile>(
+    Object.entries(DEFAULT_AGENT_PROFILES).map(([name, profile]) => [
+      name,
+      {
+        ...profile,
+        tools: [...profile.tools],
+        disallowedTools:
+          profile.disallowedTools === undefined ? undefined : [...profile.disallowedTools],
+      },
+    ]),
+  );
+  for (const profile of cloned.values()) {
+    if (profile.subagents === undefined) continue;
+    profile.subagents = Object.fromEntries(
+      Object.entries(profile.subagents).map(([name, target]) => [
+        name,
+        cloned.get(name) ?? target,
+      ]),
+    );
+  }
+  return cloned;
+}
+
 export class SessionAgentProfileCatalog {
   private merged: Map<string, ResolvedAgentProfile>;
   private readonly readyPromise: Promise<void>;
   private snapshotValue: AgentProfileCatalogSnapshot | undefined;
 
   constructor(private readonly options: SessionAgentCatalogOptions) {
-    this.merged = new Map(Object.entries(DEFAULT_AGENT_PROFILES));
+    this.merged = sessionLocalBuiltinProfiles();
     this.readyPromise = this.load();
     // Keep an un-awaited rejection from crashing the process; createMain /
     // spawn awaiters see the error through `ready`.
@@ -166,7 +198,7 @@ export class SessionAgentProfileCatalog {
     readonly entries: FileProfileEntry[];
     readonly systemMd: AgentFileDefinition | undefined;
   } {
-    this.merged = new Map(Object.entries(DEFAULT_AGENT_PROFILES));
+    this.merged = sessionLocalBuiltinProfiles();
 
     const builtinDefault = this.getDefault();
     const systemMd =

--- a/packages/agent-core/test/profile/agentfile.test.ts
+++ b/packages/agent-core/test/profile/agentfile.test.ts
@@ -372,6 +372,33 @@ describe('SessionAgentProfileCatalog', () => {
     expect(c.delegatableSubagents('agent')).not.toHaveProperty('agent');
   });
 
+  it('keeps builtin profiles session-local when a caller rewrites them in place', async () => {
+    const { workDir, brandHome, osHome } = await makeLayout();
+
+    const first = catalog({ workDir, brandHomeDir: brandHome, osHomeDir: osHome });
+    await first.ready;
+    const firstCoder = first.get('coder');
+    expect(firstCoder).toBeDefined();
+    // Host runtimes may project a session's catalog entries onto the session
+    // tool surface by rewriting them in place (host subagent projection).
+    firstCoder!.tools = ['Read'];
+
+    // The process-wide defaults stay pristine, and a later session's catalog
+    // seeds from them rather than from the rewritten objects.
+    expect(DEFAULT_AGENT_PROFILES['coder']!.tools).toContain('Bash');
+    const second = catalog({ workDir, brandHomeDir: brandHome, osHomeDir: osHome });
+    await second.ready;
+    expect(second.get('coder')?.tools).toEqual(DEFAULT_AGENT_PROFILES['coder']!.tools);
+
+    // The delegation graph is re-linked to the session-local copies, so an
+    // in-place projection reaches what useProfile and the Agent tool
+    // description actually read.
+    expect(first.delegatableSubagents('agent')['coder']).toBe(firstCoder);
+    expect(second.delegatableSubagents('agent')['coder']?.tools).toEqual(
+      DEFAULT_AGENT_PROFILES['coder']!.tools,
+    );
+  });
+
   it('extends SYSTEM.md delegation with custom agents without allowing self-delegation', async () => {
     const { workDir, brandHome, osHome } = await makeLayout();
     await writeFile(join(brandHome, 'SYSTEM.md'), 'Custom system.', 'utf-8');


### PR DESCRIPTION
<!--
Thank you for your contribution to Kimi Code!
Please open an issue before sending a feature PR — PRs without prior discussion may be closed without review.

See https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md for more.
-->

## Related Issue

No linked issue. This PR fixes a reproducible cross-session state leak in `SessionAgentProfileCatalog`.

## Problem

`DEFAULT_AGENT_PROFILES` contains process-wide mutable profile objects. Each `SessionAgentProfileCatalog` previously reused those objects directly.

When a host runtime projected a session-specific tool surface by rewriting a profile in place, the mutation also changed the process-wide builtin profile. As a result, later sessions could inherit the previous session's tool list. The shared delegation graph could also continue pointing to the mutated profile objects.

## What changed

- Create session-local clones of all builtin profiles for every `SessionAgentProfileCatalog` instance.
- Clone mutable `tools` and `disallowedTools` arrays.
- Re-link the `subagents` delegation graph to the session-local profile clones.
- Apply the same isolation when the catalog is reloaded.
- Add a regression test covering in-place profile rewrites and cross-session isolation.
- Add a patch changeset in `.changeset/isolate-session-profile-catalogs.md`.

This keeps builtin profiles isolated between sessions while preserving session-specific tool projections and delegation behavior.

## Validation

- `corepack pnpm exec vitest run test/profile/agentfile.test.ts`
  - 37 tests passed
- `git diff --check`

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have explained the problem above because there is no linked issue.
- [x] I have added tests that prove the fix works.
- [x] I have added the required changeset.
- [x] This is an internal bug fix and does not require a documentation update.
