### PR TITLE
fix(tui): include thinking effort in status line payload

### DIFF
--- a/.changeset/status-line-thinking-effort.md
+++ b/.changeset/status-line-thinking-effort.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Include the current thinking effort in custom status line command payloads.

--- a/apps/kimi-code/src/tui/components/chrome/footer.ts
+++ b/apps/kimi-code/src/tui/components/chrome/footer.ts
@@ -439,6 +439,7 @@ export class FooterComponent implements Component {
     const state = this.state;
     return {
       model: modelDisplayName(state),
+      thinkingEffort: state.thinkingEffort,
       cwd: state.workDir,
       gitBranch: this.gitCache.getStatus()?.branch ?? null,
       permissionMode: state.permissionMode,

--- a/apps/kimi-code/src/tui/utils/status-line-command.ts
+++ b/apps/kimi-code/src/tui/utils/status-line-command.ts
@@ -16,6 +16,7 @@ export const STATUS_LINE_MAX_CAPTURE_BYTES = 65_536;
 
 export interface StatusLinePayload {
   model: string;
+  thinkingEffort: string;
   cwd: string;
   gitBranch: string | null;
   permissionMode: string;

--- a/apps/kimi-code/test/tui/components/chrome/footer-status-line.test.ts
+++ b/apps/kimi-code/test/tui/components/chrome/footer-status-line.test.ts
@@ -43,6 +43,7 @@ const baseState: AppState = {
 
 const payload: StatusLinePayload = {
   model: 'kimi-k2',
+  thinkingEffort: 'off',
   cwd: '/tmp/project',
   gitBranch: 'main',
   permissionMode: 'manual',
@@ -140,6 +141,7 @@ describe('runStatusLineCommand', () => {
     expect(line).not.toBeNull();
     const parsed = JSON.parse(line!);
     expect(parsed.model).toBe('kimi-k2');
+    expect(parsed.thinkingEffort).toBe('off');
     expect(parsed.gitBranch).toBe('main');
     expect(parsed.cwd).toBe('/tmp/project');
   });
@@ -175,6 +177,21 @@ describe('runStatusLineCommand', () => {
 });
 
 describe('FooterComponent status_line command', () => {
+  it('passes the current thinking effort to the command', async () => {
+    const state: AppState = {
+      ...baseState,
+      thinkingEffort: 'max',
+      statusLine: { items: null, command: 'cat' },
+    };
+    const footer = new FooterComponent(state);
+
+    footer.render(1000);
+    await new Promise((resolve) => setTimeout(resolve, 200));
+
+    const parsed = JSON.parse(plain(footer.render(1000)[0]!).trim());
+    expect(parsed.thinkingEffort).toBe('max');
+  });
+
   it('swaps line 1 to the command output once it lands', async () => {
     const state: AppState = {
       ...baseState,

--- a/docs/en/configuration/config-files.md
+++ b/docs/en/configuration/config-files.md
@@ -435,7 +435,7 @@ Alongside `config.toml`, the CLI keeps terminal-UI and client preferences in a c
 | `[notifications].notification_condition` | `string` | `unfocused` | When to notify: `unfocused` (only when the terminal is not focused) or `always` |
 | `[upgrade].auto_install` | `boolean` | `true` | Whether new versions are installed automatically |
 | `[status_line].items` | `string[]` | `[]` | Built-in slots to show on the first footer line and their order: `mode`, `goal`, `model`, `tasks`, `cwd`, `git`, `tips`. Unset keeps the default layout; unknown ids are skipped with a warning |
-| `[status_line].command` | `string` | `""` | Custom status line command. Its first stdout line replaces the first footer line, with a JSON snapshot (model, cwd, git branch, permission mode, plan mode, context usage, session id, version) passed on stdin. Runs are capped at 300ms and throttled to once per second; failures fall back to the built-in layout |
+| `[status_line].command` | `string` | `""` | Custom status line command. Its first stdout line replaces the first footer line, with a JSON snapshot (model, `thinkingEffort`, cwd, git branch, permission mode, plan mode, context usage, session id, version) passed on stdin. Runs are capped at 300ms and throttled to once per second; failures fall back to the built-in layout |
 
 ```toml
 # ~/.kimi-code/tui.toml

--- a/docs/zh/configuration/config-files.md
+++ b/docs/zh/configuration/config-files.md
@@ -435,7 +435,7 @@ MCP server 的声明配置写在 `~/.kimi-code/mcp.json` 或项目内 `.kimi-cod
 | `[notifications].notification_condition` | `string` | `unfocused` | 何时通知：`unfocused`（仅终端失去焦点时）或 `always`（总是） |
 | `[upgrade].auto_install` | `boolean` | `true` | 是否自动安装新版本 |
 | `[status_line].items` | `string[]` | `[]` | 底部状态栏第一行展示哪些内置槽位及其顺序：`mode`、`goal`、`model`、`tasks`、`cwd`、`git`、`tips`。缺省保持默认布局；未知 id 跳过并告警 |
-| `[status_line].command` | `string` | `""` | 自定义状态栏命令。其 stdout 第一行替换状态栏第一行，stdin 会收到 JSON 快照（model、cwd、git 分支、permission 模式、plan 模式、上下文用量、session id、版本）。运行上限 300ms、每秒最多一次；失败时回退内置布局 |
+| `[status_line].command` | `string` | `""` | 自定义状态栏命令。其 stdout 第一行替换状态栏第一行，stdin 会收到 JSON 快照（model、`thinkingEffort`、cwd、git 分支、permission 模式、plan 模式、上下文用量、session id、版本）。运行上限 300ms、每秒最多一次；失败时回退内置布局 |
 
 ```toml
 # ~/.kimi-code/tui.toml


### PR DESCRIPTION
## Related Issue

Resolve #2713

## Problem

Custom status line commands receive a JSON snapshot on stdin, but that snapshot omitted the current thinking effort. The built-in footer therefore updated when the effort changed while a custom footer had no equivalent source of truth.

## What changed

- Add `thinkingEffort` to the custom status line payload and populate it from the current TUI state.
- Add regression coverage for the footer-to-command payload path.
- Document the field in the English and Chinese configuration references and add a patch changeset.

## Verification

- `pnpm exec vitest run apps/kimi-code/test/tui/components/chrome/footer-status-line.test.ts` — 17 passed
- `pnpm --filter @moonshot-ai/kimi-code typecheck`
- Focused type-aware `oxlint` — no new errors
- `pnpm --filter kimi-code-docs build`
- CLI package suite — 2,662 passed; one unrelated timing-sensitive test failed in the full concurrent run and passed when rerun alone

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.
