### PR TITLE
fix(agent-core-v2): resolve provider credentials from process env in the auth gate

### DIFF
--- a/.changeset/print-mode-env-provider-key.md
+++ b/.changeset/print-mode-env-provider-key.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Fix `kimi -p` refusing to start with an environment-supplied provider key: the auth readiness gate looked the vendor's declared `apiKeyEnv` up in the provider's `env` bag alone, so a key present only in the process environment was reported as `provider <id> has no credential configured` even though the adapter issuing the request would have read it. The gate now falls back to the process environment, with an explicit `[providers.<id>.env]` entry still taking precedence.

--- a/packages/agent-core-v2/src/kosong/model/modelAuth.ts
+++ b/packages/agent-core-v2/src/kosong/model/modelAuth.ts
@@ -62,33 +62,35 @@ export function resolveModelAuthMaterial(
   }
 
   const providerAuthType = args.provider?.type ?? args.model.protocol;
-  const providerEndpoint =
+
+  // Explicitly configured credentials are resolved first and in isolation: the
+  // provider's own `env` bag must not have to compete with ambient process env,
+  // or a vendor whose endpoint chain declares several keys (google-genai lists
+  // VERTEXAI_API_KEY ahead of GOOGLE_API_KEY) could resolve an ambient key in
+  // preference to the one the user configured.
+  const configuredEndpoint =
     providerAuthType === undefined
       ? {}
-      : explainProviderEndpoint(providerAuthType, {
-          ...process.env,
-          ...args.provider?.env,
-        });
-  const providerApiKey = nonEmpty(args.provider?.apiKey) ?? nonEmpty(providerEndpoint.apiKey);
-  if (providerApiKey !== undefined && args.provider?.oauth !== undefined) {
+      : explainProviderEndpoint(providerAuthType, args.provider?.env ?? {});
+  const configuredApiKey = nonEmpty(args.provider?.apiKey) ?? nonEmpty(configuredEndpoint.apiKey);
+
+  // Only explicitly configured credentials participate in the apiKey/oauth
+  // conflict check. An unrelated key that merely happens to exist in the shell
+  // must never invalidate a working oauth provider.
+  if (configuredApiKey !== undefined && args.provider?.oauth !== undefined) {
     throw authConflictError('Provider', args.providerName);
   }
-  if (providerApiKey !== undefined) {
+  if (configuredApiKey !== undefined) {
     trace?.record(
       'resolved.auth',
       nonEmpty(args.provider?.apiKey) !== undefined
         ? { kind: 'config', detail: `provider '${args.providerName}' apiKey` }
         : {
             kind: 'env',
-            detail: `${providerEndpoint.apiKeyEnvName ?? '?'} (${
-              providerEndpoint.apiKeyEnvName !== undefined &&
-              args.provider?.env?.[providerEndpoint.apiKeyEnvName] !== undefined
-                ? `provider '${args.providerName}' env bag`
-                : 'process env'
-            })`,
+            detail: `${configuredEndpoint.apiKeyEnvName ?? '?'} (provider '${args.providerName}' env bag)`,
           },
     );
-    return { apiKey: providerApiKey };
+    return { apiKey: configuredApiKey };
   }
   if (args.provider?.oauth !== undefined) {
     trace?.record('resolved.auth', {
@@ -99,6 +101,20 @@ export function resolveModelAuthMaterial(
       oauth: args.provider.oauth,
       oauthProviderKey: args.model.providerId ?? args.model.provider,
     };
+  }
+
+  // Nothing was configured anywhere. Fall back to the ambient process env, which
+  // is what the adapters themselves read when they construct the request; without
+  // this the readiness gate is stricter than the code it guards.
+  const ambientEndpoint =
+    providerAuthType === undefined ? {} : explainProviderEndpoint(providerAuthType, process.env);
+  const ambientApiKey = nonEmpty(ambientEndpoint.apiKey);
+  if (ambientApiKey !== undefined) {
+    trace?.record('resolved.auth', {
+      kind: 'env',
+      detail: `${ambientEndpoint.apiKeyEnvName ?? '?'} (process env)`,
+    });
+    return { apiKey: ambientApiKey };
   }
   trace?.record('resolved.auth', {
     kind: 'none',

--- a/packages/agent-core-v2/src/kosong/model/modelAuth.ts
+++ b/packages/agent-core-v2/src/kosong/model/modelAuth.ts
@@ -65,7 +65,10 @@ export function resolveModelAuthMaterial(
   const providerEndpoint =
     providerAuthType === undefined
       ? {}
-      : explainProviderEndpoint(providerAuthType, args.provider?.env ?? {});
+      : explainProviderEndpoint(providerAuthType, {
+          ...process.env,
+          ...args.provider?.env,
+        });
   const providerApiKey = nonEmpty(args.provider?.apiKey) ?? nonEmpty(providerEndpoint.apiKey);
   if (providerApiKey !== undefined && args.provider?.oauth !== undefined) {
     throw authConflictError('Provider', args.providerName);
@@ -77,7 +80,12 @@ export function resolveModelAuthMaterial(
         ? { kind: 'config', detail: `provider '${args.providerName}' apiKey` }
         : {
             kind: 'env',
-            detail: `${providerEndpoint.apiKeyEnvName ?? '?'} (provider '${args.providerName}' env bag)`,
+            detail: `${providerEndpoint.apiKeyEnvName ?? '?'} (${
+              providerEndpoint.apiKeyEnvName !== undefined &&
+              args.provider?.env?.[providerEndpoint.apiKeyEnvName] !== undefined
+                ? `provider '${args.providerName}' env bag`
+                : 'process env'
+            })`,
           },
     );
     return { apiKey: providerApiKey };

--- a/packages/agent-core-v2/test/kosong/model/modelAuth.test.ts
+++ b/packages/agent-core-v2/test/kosong/model/modelAuth.test.ts
@@ -124,6 +124,47 @@ describe('resolveModelAuthMaterial', () => {
     ).toEqual({ apiKey: 'inline-key' });
   });
 
+  it('prefers a configured env-bag key over an ambient key declared earlier in the chain', () => {
+    // google-genai declares VERTEXAI_API_KEY ahead of GOOGLE_API_KEY, so an
+    // ambient Vertex key must not outrank the Gemini key the user configured.
+    vi.stubEnv('VERTEXAI_API_KEY', 'ambient-vertex-key');
+    expect(
+      authMaterial({
+        model: { model: 'm' },
+        provider: { type: 'google-genai', env: { GOOGLE_API_KEY: 'configured-google-key' } },
+      }),
+    ).toEqual({ apiKey: 'configured-google-key' });
+  });
+
+  it('does not let an ambient key invalidate a provider configured for oauth', () => {
+    vi.stubEnv('OPENAI_API_KEY', 'ambient-unrelated-key');
+    expect(
+      authMaterial({
+        model: { model: 'm', providerId: 'p1' },
+        provider: { type: 'openai', oauth: { storage: 'file', key: 'k' } },
+      }),
+    ).toEqual({ oauth: { storage: 'file', key: 'k' }, oauthProviderKey: 'p1' });
+  });
+
+  it('still rejects a configured apiKey alongside oauth', () => {
+    expect(() =>
+      authMaterial({
+        model: { model: 'm' },
+        provider: { type: 'openai', apiKey: 'k', oauth: { storage: 'file', key: 'k' } },
+      }),
+    ).toThrowError(expect.objectContaining({ code: ConfigErrors.codes.CONFIG_INVALID }));
+    expect(() =>
+      authMaterial({
+        model: { model: 'm' },
+        provider: {
+          type: 'openai',
+          env: { OPENAI_API_KEY: 'bag-key' },
+          oauth: { storage: 'file', key: 'k' },
+        },
+      }),
+    ).toThrowError(expect.objectContaining({ code: ConfigErrors.codes.CONFIG_INVALID }));
+  });
+
   it('does not leak an unrelated vendor key from the process environment', () => {
     vi.stubEnv('OPENAI_API_KEY', 'process-env-key');
     vi.stubEnv('ANTHROPIC_API_KEY', '');

--- a/packages/agent-core-v2/test/kosong/model/modelAuth.test.ts
+++ b/packages/agent-core-v2/test/kosong/model/modelAuth.test.ts
@@ -12,7 +12,7 @@
  *    profile — inferred only for vendors whose thinking is not trait-driven.
  */
 
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { ConfigErrors } from '#/app/config/errors';
 import '#/kosong/provider/providers/kimi/kimi.contrib';
@@ -101,9 +101,43 @@ describe('resolveModelAuthMaterial', () => {
     ).toEqual({ apiKey: 'vertex-env-key' });
   });
 
+  it('falls back to the process environment when the provider declares no env bag', () => {
+    vi.stubEnv('OPENAI_API_KEY', 'process-env-key');
+    expect(authMaterial({ model: { model: 'm' }, provider: { type: 'openai' } })).toEqual({
+      apiKey: 'process-env-key',
+    });
+  });
+
+  it('prefers the provider env bag and inline apiKey over the process environment', () => {
+    vi.stubEnv('OPENAI_API_KEY', 'process-env-key');
+    expect(
+      authMaterial({
+        model: { model: 'm' },
+        provider: { type: 'openai', env: { OPENAI_API_KEY: 'bag-key' } },
+      }),
+    ).toEqual({ apiKey: 'bag-key' });
+    expect(
+      authMaterial({
+        model: { model: 'm' },
+        provider: { type: 'openai', apiKey: 'inline-key' },
+      }),
+    ).toEqual({ apiKey: 'inline-key' });
+  });
+
+  it('does not leak an unrelated vendor key from the process environment', () => {
+    vi.stubEnv('OPENAI_API_KEY', 'process-env-key');
+    vi.stubEnv('ANTHROPIC_API_KEY', '');
+    expect(authMaterial({ model: { model: 'm' }, provider: { type: 'anthropic' } })).toEqual({});
+  });
+
   it('returns empty material when nothing is configured', () => {
+    vi.stubEnv('OPENAI_API_KEY', '');
     expect(authMaterial({ model: { model: 'm' }, provider: { type: 'openai' } })).toEqual({});
     expect(authMaterial({ model: { model: 'm' } })).toEqual({});
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
   });
 });
 


### PR DESCRIPTION
Fixes #2745.

## Problem

`resolveModelAuthMaterial` passes `args.provider?.env ?? {}` to
`explainProviderEndpoint`:

```ts
: explainProviderEndpoint(providerAuthType, args.provider?.env ?? {});
```

`explainProviderEndpoint` defaults that parameter to `process.env`, so passing `{}`
replaces the default with an empty map for every provider that has no
`[providers.<id>.env]` table. The vendor's declared `apiKeyEnv` (`OPENAI_API_KEY`
for `type = "openai"`) is then looked up in an empty map and
`AuthService.ensureReady` throws `AuthTokenMissingError`.

The adapters that actually issue the request do read the process environment —
`firstProcessEnv(endpoint?.apiKeyEnv)` in `openai-legacy.contrib.ts`,
`openai-responses.contrib.ts`, `anthropic.contrib.ts` and
`google-genai.contrib.ts` — so the readiness gate is stricter than the code it
guards, and rejects configurations that would have worked.

This was latent behind the experimental flag until 0.33.0 inverted the engine
selection in `experimental-v2.ts` (`KIMI_CODE_EXPERIMENTAL_FLAG` opt-in became
`KIMI_CODE_LEGACY_FLAG` opt-out), making agent-core-v2 the default for `kimi -p`.
That turned it into a user-visible regression: print mode now rejects an
environment-supplied provider key that 0.32.0 accepted. Full bisect and root-cause
evidence in #2745.

## Change

Credentials are resolved in three ordered phases, and the process environment is
consulted only when nothing is configured at any layer.

1. **Explicitly configured credentials, resolved in isolation.** The provider's
   own `env` bag is passed to `explainProviderEndpoint` on its own, exactly as
   before, so ambient variables never compete with configured ones.
2. **OAuth**, if the provider declares it.
3. **Ambient `process.env`**, as a last resort — this is the case that previously
   threw.

Only explicitly configured credentials take part in the `apiKey`/`oauth`
mutual-exclusion check.

Resulting precedence:

`model.apiKey` > `model.oauth` > `provider.apiKey` > `provider.env` bag >
`provider.oauth` > `process.env`

That is the documented order, with one deliberate difference: `provider.oauth`
now outranks an ambient `process.env` key. Nothing regresses, because before this
change `process.env` could not be reached from this function at all.

The resolution trace previously labelled every env hit as coming from the
"env bag"; it now distinguishes the bag from the process environment, so `--trace`
output stays truthful.

### Note on the first revision of this PR

The initial commit merged `process.env` into the bag before resolution
(`{ ...process.env, ...args.provider?.env }`). The Codex review correctly flagged
two P1 defects in that approach, both of which I reproduced as failing tests
before rewriting it:

- **Precedence inversion.** `standard.contrib.ts` declares `VERTEXAI_API_KEY`
  ahead of `GOOGLE_API_KEY`. A provider explicitly configuring `GOOGLE_API_KEY`
  on a host that also exported `VERTEXAI_API_KEY` resolved the *ambient* Vertex
  key, silently sending the wrong credential.
- **OAuth providers broken.** An unrelated vendor key present in the shell became
  `providerApiKey` and tripped the mutual-exclusion check, so a previously working
  `oauth` provider failed with `config.invalid`.

Resolving the configured bag in isolation and moving the OAuth branch ahead of the
ambient lookup fixes both. Each has a regression test that fails on the previous
revision.

## Tests

Six cases in `packages/agent-core-v2/test/kosong/model/modelAuth.test.ts`, using
`vi.stubEnv` with `afterEach(() => vi.unstubAllEnvs())`:

- process-env fallback resolves when the provider declares no env bag;
- the provider env bag and an inline `apiKey` both still win over the process
  environment;
- a configured `GOOGLE_API_KEY` beats an ambient `VERTEXAI_API_KEY` despite the
  endpoint chain declaring Vertex first;
- an ambient key does not invalidate a provider configured for `oauth`;
- a configured `apiKey` alongside `oauth` is still rejected, whether the key comes
  from `provider.apiKey` or the provider's `env` bag;
- a `type = "anthropic"` provider does not pick up an unrelated `OPENAI_API_KEY`.

The first fails on `main`; the third and fourth fail on this PR's first revision.

`packages/agent-core-v2/test/kosong` and `test/app/auth` are green (359 tests), as
are `pnpm lint` and `tsc --noEmit` for `agent-core-v2`.

## Verification against the shipped CLI

Reproduced on Linux x86_64 / Node v22.22.2 with an `openai`-type provider whose
key exists only in `OPENAI_API_KEY`. A deliberately invalid key was used
throughout, so a provider `401` is the signal that the readiness gate was passed
and the request was actually issued:

| build | `kimi -p` with the key in the environment |
|---|---|
| 0.32.0 | request issued (provider `401`) |
| 0.33.0 | `provider oai has no credential configured` |
| 0.34.0 | `provider oai has no credential configured` |
| 0.34.0 with this change applied to `dist/main.mjs` | request issued (provider `401`) |

Flipping the engine flag instead of the version moves the behaviour the same way,
which is what identifies 0.33.0's engine switch rather than any auth change as the
regression trigger:

| run | result |
|---|---|
| 0.34.0 + `KIMI_CODE_LEGACY_FLAG=1` | request issued |
| 0.32.0 + `KIMI_CODE_EXPERIMENTAL_FLAG=1` | `provider oai has no credential configured` |

A control on the patched bundle confirms the configured bag still wins: with
`[providers.oai.env] OPENAI_API_KEY` set and a different ambient value present,
the request carries the bag's key.

### Independent confirmation on two more platforms

The same checks were re-run on two additional machines. Every verdict matched:

| platform | arch | Node | result |
|---|---|---|---|
| macOS 26.5.2 | arm64 | v26.5.0 | identical |
| Ubuntu 24.04.3 LTS | x86_64 | v22.22.0 | identical |

So the regression is not specific to a platform, architecture, or Node major.

On macOS the session wire log was inspected directly. A gate-blocked run emits only
`metadata`, `profile.bind` and `permission.set_mode` — no `turn.prompt` and no
`llm.request` — while a run that passes the gate adds `turn.prompt`,
`llm.tools_snapshot`, `llm.request` and `turn.ended`. The run aborts before the turn
begins, confirming at the trace level that no request is issued.

### End-to-end with a real credential from a production secret store

The runs above use a deliberately invalid key, so they prove the gate's behaviour but
not that a valid environment-supplied credential reaches the model. This one does.

Ubuntu 24.04.3 / x86_64 / Node v22.22.0. The credential is resolved from Bitwarden
Secrets Manager and injected into the child environment by `vaulted-agent`, a vault
launcher whose entire mechanism is environment injection — the real-world shape this
regression breaks. The provider table contains **no `api_key`**, so the environment is
the only possible source. All three probes ran under a **single** vault injection in
one child shell, so the environment is provably identical and only the binary/flag
differs:

| probe | build | flag | result |
|---|---|---|---|
| A | 0.34.0 stock | — | `provider oai has no credential configured` |
| B | 0.34.0 + this change | — | **`PONG`** — model answered |
| C | 0.34.0 stock | `KIMI_CODE_LEGACY_FLAG=1` | `PONG` |

Because B succeeds with no flag and no inline `api_key`, the failure in A cannot be
attributed to key validity, config path, provider wiring, or network reachability.

That transcript was produced with this PR's first revision. The rewrite does not
change behaviour for that configuration — a provider with no `env` bag and no
`oauth` reaches the same ambient lookup by both routes — and the dummy-key check
above was re-run against the current revision on the shipped bundle. I have not
re-run the live-key probe against the rewrite.

The patch was applied to a copy of the shipped `dist/main.mjs`; the target
expression occurs exactly once in the 0.34.0 bundle.

## Notes for reviewers

- Scope is deliberately limited to the credential gate. `catalogService.ts` has the
  same `providerConfig.env ?? {}` pattern for **baseUrl** resolution; that one does
  not block a turn, and changing it would let an ambient `OPENAI_BASE_URL`
  redirect configured providers, so I left it alone. Happy to address it here or
  in a follow-up if you'd prefer consistency.
- If you would rather thread an explicit env source through
  `resolveModelAuthMaterial` than read `process.env` at this layer, say the word
  and I will rework it — the observable behaviour is the part I care about.
- The interactive TUI path was not tested on any machine; that it is unaffected is
  an inference from the engine-selection code, not a measurement.
