### PR TITLE
fix(tui): drop misleading /login hint in /usage and /status before first message

### DIFF
--- a/.changeset/sessionless-usage-login-hint.md
+++ b/.changeset/sessionless-usage-login-hint.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Fix /usage and /status incorrectly prompting to /login when run before the first message of a session.

--- a/apps/kimi-code/src/tui/commands/info.ts
+++ b/apps/kimi-code/src/tui/commands/info.ts
@@ -219,6 +219,14 @@ export async function showMcpServers(host: SlashCommandHost): Promise<void> {
 }
 
 async function loadSessionUsageReport(host: SlashCommandHost): Promise<SessionUsageResult> {
+  // A /usage typed right behind the first prompt can land while the lazy
+  // session creation is still in flight; wait it out so the report isn't
+  // skipped as if no message had been sent yet (no-op otherwise).
+  await host.waitForLazyCreation();
+  // Session-less startup: the session is created lazily on the first message,
+  // so a missing session is not a sign-in problem — don't surface
+  // requireSession's "Send /login" error.
+  if (host.session === undefined) return {};
   try {
     return { usage: await host.requireSession().getUsage() };
   } catch (error) {
@@ -227,6 +235,12 @@ async function loadSessionUsageReport(host: SlashCommandHost): Promise<SessionUs
 }
 
 async function loadRuntimeStatusReport(host: SlashCommandHost): Promise<RuntimeStatusResult> {
+  // Same wait as loadSessionUsageReport: /status is always-available and can
+  // run while the first prompt's lazy session creation is still in flight.
+  await host.waitForLazyCreation();
+  // Same session-less guard as loadSessionUsageReport: a missing session just
+  // means no message has been sent yet.
+  if (host.session === undefined) return {};
   try {
     return { status: await host.requireSession().getStatus() };
   } catch (error) {

--- a/apps/kimi-code/test/tui/commands/info.test.ts
+++ b/apps/kimi-code/test/tui/commands/info.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import type { SlashCommandHost } from '#/tui/commands/dispatch';
+import { showStatusReport, showUsage } from '#/tui/commands/info';
+import { NO_ACTIVE_SESSION_MESSAGE } from '#/tui/constant/kimi-tui';
+
+function strip(text: string): string {
+  return text.replaceAll(/\[[0-9;]*m/g, '');
+}
+
+interface CapturedPanel {
+  render(width: number): string[];
+}
+
+function makeHost(overrides: {
+  hasSession: boolean;
+  /** Simulate an in-flight lazy creation that installs the session when awaited. */
+  installSessionOnWait?: boolean;
+}) {
+  const session = {
+    getUsage: vi.fn(async () => ({ byModel: {} })),
+    getStatus: vi.fn(async () => ({})),
+  };
+  const addedPanels: CapturedPanel[] = [];
+  const host = {
+    session: undefined as unknown,
+    state: {
+      appState: {
+        version: '1.2.3',
+        model: '',
+        workDir: '/tmp/project',
+        sessionId: '',
+        sessionTitle: null,
+        thinkingEffort: 'off',
+        permissionMode: 'manual',
+        planMode: false,
+        contextUsage: 0,
+        contextTokens: 0,
+        maxContextTokens: 0,
+        availableModels: {},
+      },
+      transcriptContainer: {
+        addChild: vi.fn((panel: CapturedPanel) => {
+          addedPanels.push(panel);
+        }),
+      },
+      ui: { requestRender: vi.fn() },
+    },
+    requireSession: vi.fn(() => {
+      if ((host as { session?: unknown }).session === undefined) {
+        throw new Error(NO_ACTIVE_SESSION_MESSAGE);
+      }
+      return (host as { session?: unknown }).session;
+    }),
+    waitForLazyCreation: vi.fn(async () => {
+      if (overrides.installSessionOnWait === true) {
+        (host as { session?: unknown }).session = session;
+      }
+    }),
+  } as unknown as SlashCommandHost;
+  if (overrides.hasSession) {
+    (host as { session?: unknown }).session = session;
+  }
+  return { host, addedPanels, session };
+}
+
+function renderLastPanel(panels: CapturedPanel[]): string {
+  const panel = panels.at(-1);
+  expect(panel).toBeDefined();
+  return panel!.render(80).map(strip).join('\n');
+}
+
+describe('/usage before the first message', () => {
+  it('does not tell the user to /login when the session is session-less', async () => {
+    const { host, addedPanels } = makeHost({ hasSession: false });
+
+    await showUsage(host);
+
+    const output = renderLastPanel(addedPanels);
+    expect(output).toContain('No token usage recorded yet.');
+    expect(output).not.toContain('/login');
+    expect(host.requireSession).not.toHaveBeenCalled();
+  });
+
+  it('waits for an in-flight lazy session creation instead of rendering session-less', async () => {
+    const { host, session } = makeHost({
+      hasSession: false,
+      installSessionOnWait: true,
+    });
+
+    await showUsage(host);
+
+    expect(host.waitForLazyCreation).toHaveBeenCalledTimes(1);
+    expect(session.getUsage).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('/status before the first message', () => {
+  it('shows no login warning when the session is session-less', async () => {
+    const { host, addedPanels } = makeHost({ hasSession: false });
+
+    await showStatusReport(host);
+
+    const output = renderLastPanel(addedPanels);
+    expect(output).toContain('Session      none');
+    expect(output).not.toContain('/login');
+    expect(host.requireSession).not.toHaveBeenCalled();
+  });
+
+  it('waits for an in-flight lazy session creation instead of rendering session-less', async () => {
+    const { host, session } = makeHost({
+      hasSession: false,
+      installSessionOnWait: true,
+    });
+
+    await showStatusReport(host);
+
+    expect(host.waitForLazyCreation).toHaveBeenCalledTimes(1);
+    expect(session.getStatus).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Related Issue

Resolve #2751

## Problem

See linked issue.

## What changed

The session-backed sections of `/usage` and `/status` loaded their data through `requireSession()` unconditionally. On the v2 engine the TUI starts session-less (the session is created lazily on the first message), so `requireSession()` throws `No active session. Send /login to login.` — correct on the v1 engine where a missing session means the user is not signed in, but wrong here.

Both loaders now skip the session-backed section when the v2 engine has no session yet: `/usage` falls back to the existing muted `No token usage recorded yet.` line and `/status` simply omits the warning row (its `Session` row already shows `none`). The account-level Plan usage section is unaffected, and the v1 engine keeps the `/login` hint. `/usage` deliberately stays out of the lazy-creation command set — viewing usage should not create a session.

Added unit tests covering both commands on both engines.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.