### PR TITLE
feat(agent-core-v2): add visual model assignment for image inspection

### DIFF
--- a/.changeset/visual-model-assignment.md
+++ b/.changeset/visual-model-assignment.md
@@ -1,0 +1,7 @@
+---
+'@moonshot-ai/kimi-code': minor
+---
+
+Add a dedicated `[visual_model]` configuration section that lets users pin a vision-capable model for image / screenshot / video inspection tasks, mirroring the existing experimental `[secondary_model]` slot.
+
+When the `visual-model` experiment is enabled (`KIMI_CODE_EXPERIMENTAL_VISUAL_MODEL=1`) and `[visual_model]` is configured, the `ReadMediaFile` tool registers against the visual model's capabilities and requester when the caller's main model is text-only — so the LLM keeps access to image inspection instead of silently losing the tool. When unset, behavior is unchanged. Adds parallel `resolveVisualModel` / `resolveVisualBinding` / `buildVisualModelDescriptions` resolvers and a `visual-model` experiment flag, all gated by the experiment and covered by vitest tests.

--- a/docs/en/configuration/config-files.md
+++ b/docs/en/configuration/config-files.md
@@ -221,6 +221,34 @@ max_output_size = 8192
 
 When the experiment is enabled, the configuration is validated as the session starts: an unresolvable `model`, or a `default_effort` not listed by the (patched) model, produces a startup warning (also returned by the session-warnings API). The check is advisory — a broken secondary model still fails at spawn time, with the same source hint attached to the spawn error.
 
+## `visual_model`
+
+The visual model is a companion model configuration for **vision-only work** — typically a vision-capable model you pin so image / screenshot / video inspection tasks can run even when your main coding model is text-only. Its consumer today is `ReadMediaFile`: when set, the media tool registers against the visual model's capabilities and requester when the caller's model cannot consume image or video input, so the LLM keeps the `ReadMediaFile` tool available for visual inspection instead of silently losing it. When unset, behavior is unchanged (the tool registers only when the caller's model is vision-capable, exactly as before).
+
+This is a default binding, not a forced one. With the experiment enabled, the visual-model resolver (`resolveVisualModel`) returns the configured recipe and the media-tools registrar consults it; future agent tools that perform visual inspection can advertise a `model` parameter (accepting the symbolic values `"visual"` / `"primary"`) the same way `Agent` / `AgentSwarm` advertise their secondary-model choice.
+
+This feature is experimental and disabled by default. Enable it with `KIMI_CODE_EXPERIMENTAL_VISUAL_MODEL=1`, or the master `KIMI_CODE_EXPERIMENTAL_FLAG=1`. It takes effect in every launch mode, including the interactive TUI.
+
+| Field | Type | Default | Description |
+| --- | --- | --- | --- |
+| `model` | `string` | — | The alias of a configured [`[models]`](#models) entry, e.g. `kimi-code/kimi-vision` (any provider, not limited to Kimi models). Should be a vision-capable entry (`image_in` and/or `video_in` listed in its `capabilities`) |
+| `default_effort` | `string` | — | Thinking effort applied when visual tasks bind to the visual model. Unset, the effort resolves naturally (global `[thinking]` config → the bound model's default effort) instead of inheriting the caller's effort. Follows the main model's thinking-effort semantics: models with strict effort validation (e.g. Kimi models) fall back to their default effort for unsupported values; other providers receive the value as-is |
+| Other fields | — | — | Accepts every field of [`[models."<alias>".overrides]`](#models) (`max_context_size`, `max_output_size`, `support_efforts`, …) as a model patch applied only to visual tasks |
+
+Every field besides `model` forms a patch: when at least one patch field is set, the runtime synthesizes a derived model entry in memory (a copy of the pointed entry with the patch merged into its overrides, patch winning conflicts) and visual tasks bind that derived entry; with no patch fields, visual tasks bind the pointed entry directly. The derived entry lives only in memory (never written back to `config.toml`) and is hidden from model-selection lists.
+
+```toml
+[visual_model]
+model = "kimi-code/kimi-vision"
+default_effort = "low"
+max_output_size = 8192
+```
+
+`model` / `default_effort` can be overridden by the `KIMI_VISUAL_MODEL` / `KIMI_VISUAL_EFFORT` environment variables, which take higher priority than `config.toml`.
+
+When the experiment is enabled, the configuration is validated as the session starts: an unresolvable `model` produces a startup warning. The check is advisory — a broken visual model still fails at use time, with the same source hint attached to the error.
+
+
 ## `thinking`
 
 `thinking` sets the global default behavior for Thinking mode.

--- a/docs/zh/configuration/config-files.md
+++ b/docs/zh/configuration/config-files.md
@@ -221,6 +221,34 @@ max_output_size = 8192
 
 实验功能启用后，会话启动时会校验该配置：`model` 无法解析，或 `default_effort` 不在（应用补丁后的）模型 effort 列表中时，会在启动时显示警告（并通过会话警告 API 返回）。该检查仅为提示——配置有误的次主力模型仍会在派生子 Agent 时失败，派生错误中同样附带配置来源提示。
 
+## `visual_model`
+
+视觉模型是为**视觉类任务**单独配置的伴生模型——通常是一个具备视觉能力的模型，用来在主编码模型是纯文本时仍然能执行图像 / 截图 / 视频检查。它目前的消费者是 `ReadMediaFile`：设置后，当调用方模型无法处理图像或视频输入时，媒体工具会按照视觉模型的能力和 requester 注册，LLM 因此仍然可以调用 `ReadMediaFile` 进行视觉检查，而不会因为主模型是纯文本就静默丢失该工具。未设置时行为不变（工具仅在调用方模型具备视觉能力时注册，与之前一致）。
+
+这是默认绑定而非强制。实验功能启用后，视觉模型解析器（`resolveVisualModel`）会返回已配置的 recipe，媒体工具注册器会读取它；后续执行视觉检查的 agent 工具可以像 `Agent` / `AgentSwarm` 暴露次主力模型选择那样，在描述里暴露 `model` 参数（仅接受 `"visual"` / `"primary"` 两个符号值）。
+
+该功能目前是实验功能，默认关闭。通过 `KIMI_CODE_EXPERIMENTAL_VISUAL_MODEL=1` 启用，或使用 master `KIMI_CODE_EXPERIMENTAL_FLAG=1`。它在包括交互式 TUI 在内的所有启动方式下生效。
+
+| 字段 | 类型 | 默认值 | 说明 |
+| --- | --- | --- | --- |
+| `model` | `string` | — | [`[models]`](#models) 中已配置条目的别名，如 `kimi-code/kimi-vision`（不限 kimi 模型，可用任意供应商）。应选择具备视觉能力的条目（其 `capabilities` 列出 `image_in` 和/或 `video_in`） |
+| `default_effort` | `string` | — | 视觉任务绑定视觉模型时使用的 thinking effort。未设置时按"全局 `[thinking]` 配置 → 模型默认 effort"的链路解析，不再继承主 Agent 的 effort。与主模型的 thinking effort 语义一致：严格校验 effort 的模型（如 kimi 模型）在不支持该取值时回退到模型默认 effort，其他供应商的模型按原样发送给后端 |
+| 其他字段 | — | — | 接受 [`[models."<alias>".overrides]`](#models) 的全部字段（`max_context_size`、`max_output_size`、`support_efforts` 等），作为仅对视觉任务生效的模型补丁 |
+
+`model` 之外的字段构成补丁：存在补丁字段时，运行时会在内存中合成一个派生模型条目（被指向条目的拷贝，补丁并入其 overrides 且补丁优先），视觉任务实际绑定该派生条目；没有补丁字段时，视觉任务直接绑定 `model` 指向的条目。派生条目只存在于内存中（不写回 `config.toml`），也不会出现在模型选择列表里。
+
+```toml
+[visual_model]
+model = "kimi-code/kimi-vision"
+default_effort = "low"
+max_output_size = 8192
+```
+
+`model` / `default_effort` 可被环境变量 `KIMI_VISUAL_MODEL` / `KIMI_VISUAL_EFFORT` 覆盖，优先级均高于配置文件。
+
+实验功能启用后，会话启动时会校验该配置：`model` 无法解析时会在启动时显示警告。该检查仅为提示——配置有误的视觉模型仍会在使用时失败，错误中同样附带配置来源提示。
+
+
 ## `thinking`
 
 `thinking` 设置 Thinking 模式的全局默认行为。

--- a/packages/agent-core-v2/docs/config-manifest.toml
+++ b/packages/agent-core-v2/docs/config-manifest.toml
@@ -8,7 +8,7 @@
 # commented "# field: type" lines describe the remaining schema fields.
 # Values resolve as: default -> config.toml -> env overlay -> memory.
 
-# Index (25 sections · 3 overlay(s))
+# Index (26 sections · 4 overlay(s))
 #   background               src/agent/task/configSection.ts
 #   builtinProductSkills     src/app/skillCatalog/configSection.ts
 #   cron                     src/app/cron/configSection.ts
@@ -34,9 +34,11 @@
 #   thinking                 src/app/kosongConfig/configSection.ts
 #   tokenCounting            src/agent/tokenCounting/configSection.ts
 #   tools                    src/agent/toolPolicy/configSection.ts
+#   visualModel              src/app/kosongConfig/configSection.ts
 #   (overlay) servicesCredentialEnvOverlay  src/app/auth/configSection.ts
 #   (overlay) kimiModelEnvOverlay  src/app/kosongConfig/envOverlay.ts
 #   (overlay) secondaryModelOverlay  src/app/kosongConfig/secondaryModelOverlay.ts
+#   (overlay) visualModelOverlay  src/app/kosongConfig/visualModelOverlay.ts
 
 # ##########################################################################
 # background
@@ -439,3 +441,26 @@ strategy = "measured+estimated"
 [tools]
 # enabled: string[]
 # disabled: string[]
+
+# ##########################################################################
+# visualModel (config.toml: visual_model)
+#   owner: src/app/kosongConfig/configSection.ts
+#   scope: core
+#   hooks: stripEnv
+#   env:
+#     model <- KIMI_VISUAL_MODEL (custom parse)
+#     default_effort <- KIMI_VISUAL_EFFORT (custom parse)
+# ##########################################################################
+
+[visual_model]
+# max_context_size: integer
+# max_input_size: integer
+# max_output_size: integer
+# capabilities: string[]
+# display_name: string
+# reasoning_key: string
+# adaptive_thinking: boolean
+# support_efforts: string[]
+# default_effort: string
+# off_effort: string
+# model: string

--- a/packages/agent-core-v2/src/agent/media/mediaToolsRegistrar.ts
+++ b/packages/agent-core-v2/src/agent/media/mediaToolsRegistrar.ts
@@ -32,7 +32,9 @@ import { LifecycleScope } from '#/app/scopes';
 import { ScopeActivation, registerScopedService } from '#/_base/di/scope';
 import { defineState } from '#/_base/state/stateRegistry';
 import { IAgentStateService } from '#/agent/state/agentState';
+import { IConfigService } from '#/app/config/config';
 import { IEventBus } from '#/app/event/eventBus';
+import { IFlagService } from '#/app/flag/flag';
 import { ITelemetryService } from '#/app/telemetry/telemetry';
 import { IModelCatalog, type Model } from '#/kosong/model/catalog';
 import { type ModelRequester } from '#/kosong/model/modelRequester';
@@ -43,6 +45,8 @@ import { ISessionWorkspaceContext } from '#/session/workspaceContext/workspaceCo
 import { IAgentProfileService } from '#/agent/profile/profile';
 import { IAgentToolRegistryService } from '#/agent/toolRegistry/toolRegistry';
 import { extendWorkspaceWithSkillRoots } from '#/tool/path-access';
+import { resolveVisualModel } from '#/session/visual/configSection';
+import type { ModelCapability } from '#/kosong/contract/capability';
 
 import { IAgentMediaToolsRegistrar } from './mediaTools';
 import { createVideoUploader, registerMediaTools } from './registerMediaTools';
@@ -61,6 +65,8 @@ export class AgentMediaToolsRegistrar extends Service implements IAgentMediaTool
     @IAgentToolRegistryService private readonly toolRegistry: IAgentToolRegistryService,
     @IAgentProfileService private readonly profile: IAgentProfileService,
     @IModelCatalog private readonly modelCatalog: IModelCatalog,
+    @IConfigService private readonly appConfig: IConfigService,
+    @IFlagService private readonly flags: IFlagService,
     @IEventBus eventBus: IEventBus,
     @IHostFileSystem private readonly fs: IHostFileSystem,
     @IHostEnvironment private readonly env: IHostEnvironment,
@@ -85,11 +91,43 @@ export class AgentMediaToolsRegistrar extends Service implements IAgentMediaTool
   }
 
   private refresh(): void {
-    const capabilities = this.profile.getModelCapabilities();
+    const callerCapabilities = this.profile.getModelCapabilities();
+    const callerModelAlias = this.profile.getModel();
+
+    // Visual-model companion: when configured (and the experiment is on),
+    // a vision-capable visual model lets the media tools register even if
+    // the caller's model is text-only. The visual model's capabilities and
+    // requester are used in that case so the tool's mime / compression
+    // decisions match the model that will actually consume the payload.
+    // When the visual model is unset, behavior is unchanged.
+    const visualRecipe = resolveVisualModel(this.appConfig, this.flags);
+    const visualModelAlias = visualRecipe?.model;
+    let visualRequester: ModelRequester | undefined;
+    let visualModel: Model | undefined;
+    if (visualModelAlias !== undefined) {
+      try {
+        visualRequester = this.modelCatalog.getRequester(visualModelAlias);
+        visualModel = visualRequester.model;
+      } catch {
+        // dangling pointer — the secondary-model-style warning service is
+        // responsible for surfacing it; the registrar just falls back to
+        // the caller's model.
+      }
+    }
+    const visualCapabilities: ModelCapability | undefined = visualModel?.capabilities;
+    const callerHasMedia = callerCapabilities.image_in || callerCapabilities.video_in;
+    const visualHasMedia = visualCapabilities !== undefined
+      && (visualCapabilities.image_in || visualCapabilities.video_in);
+    const useVisual = !callerHasMedia && visualHasMedia;
+    const capabilities = useVisual ? visualCapabilities! : callerCapabilities;
+
     const key = [
-      this.profile.getModel(),
-      String(capabilities.image_in),
-      String(capabilities.video_in),
+      callerModelAlias,
+      String(callerCapabilities.image_in),
+      String(callerCapabilities.video_in),
+      visualModelAlias ?? '',
+      String(visualCapabilities?.image_in ?? false),
+      String(visualCapabilities?.video_in ?? false),
     ].join('|');
     if (key === this.registeredKey) return;
     this.registeredKey = key;
@@ -97,12 +135,18 @@ export class AgentMediaToolsRegistrar extends Service implements IAgentMediaTool
     const workspaceCtx = this.workspaceCtx;
     const skillCatalog = this.skillCatalog;
     const env = this.env;
-    const modelAlias = this.profile.getModel();
+    const boundModelAlias = useVisual ? visualModelAlias! : callerModelAlias;
+    const boundRequester = useVisual ? visualRequester : undefined;
     let requester: ModelRequester | undefined;
     let model: Model | undefined;
-    if (modelAlias !== '') {
-      requester = this.modelCatalog.getRequester(modelAlias);
-      model = requester.model;
+    if (boundModelAlias !== '') {
+      try {
+        requester = boundRequester ?? this.modelCatalog.getRequester(boundModelAlias);
+        model = requester.model;
+      } catch {
+        requester = undefined;
+        model = undefined;
+      }
     }
     this.registration = registerMediaTools(this.toolRegistry, {
       fs: this.fs,
@@ -123,7 +167,7 @@ export class AgentMediaToolsRegistrar extends Service implements IAgentMediaTool
       videoUploader: createVideoUploader(requester, {
         client: this.telemetry,
         props: {
-          model: modelAlias,
+          model: boundModelAlias,
           provider_type: model?.providerType ?? model?.protocol,
           protocol: model?.protocol,
         },

--- a/packages/agent-core-v2/src/app/kosongConfig/configSection.ts
+++ b/packages/agent-core-v2/src/app/kosongConfig/configSection.ts
@@ -338,6 +338,28 @@ registerConfigSection(SECONDARY_MODEL_SECTION, SecondaryModelConfigSchema, {
 });
 
 
+export const VISUAL_MODEL_SECTION = 'visualModel';
+
+export const VISUAL_MODEL_ENV = 'KIMI_VISUAL_MODEL';
+export const VISUAL_MODEL_EFFORT_ENV = 'KIMI_VISUAL_EFFORT';
+
+export const VisualModelConfigSchema = ModelOverrideSchema.extend({
+  model: z.string().min(1).optional(),
+});
+
+export type VisualModelConfig = z.infer<typeof VisualModelConfigSchema>;
+
+export const visualModelEnvBindings = envBindings(VisualModelConfigSchema, {
+  model: { env: VISUAL_MODEL_ENV, parse: parseNonEmptyEnv },
+  defaultEffort: { env: VISUAL_MODEL_EFFORT_ENV, parse: parseNonEmptyEnv },
+});
+
+registerConfigSection(VISUAL_MODEL_SECTION, VisualModelConfigSchema, {
+  env: visualModelEnvBindings,
+  stripEnv: stripEnvBoundFields(visualModelEnvBindings),
+});
+
+
 export const MODEL_CATALOG_SECTION = 'modelCatalog';
 
 export const ModelCatalogConfigSchema = z.object({

--- a/packages/agent-core-v2/src/app/kosongConfig/visualModelOverlay.ts
+++ b/packages/agent-core-v2/src/app/kosongConfig/visualModelOverlay.ts
@@ -1,0 +1,105 @@
+/**
+ * `kosongConfig` domain — `[visual_model]` derived-entry overlay.
+ *
+ * Visual-model mirror of {@link secondaryModelOverlay}: when the
+ * visual-model recipe carries patch fields, synthesizes the derived registry
+ * entry ({@link VISUAL_DERIVED_MODEL_ID}) into the effective `models` view —
+ * a copy of the pointed entry with the patch merged into its `overrides`
+ * block (patch wins conflicts) and `aliases` dropped, so the derived entry
+ * never competes in name/alias routing. Visual-task model binding then
+ * resolves it by name through the standard catalog path, and the patch rides
+ * the same `effectiveModelConfig` merge as any `models.*.overrides`
+ * (including its `supportEfforts` / `defaultEffort` pruning and input
+ * clamping).
+ *
+ * Like the env overlay and the secondary-model overlay, the synthesized entry
+ * lives ONLY in the in-memory effective view: `strip` removes it from
+ * `models` writes so it never reaches `config.toml`, and the persistence
+ * bridge's deep-equal guards keep the two-way sync silent. `strip` also rolls
+ * back a `defaultModel` pointer set to the derived id (restoring the raw
+ * value, mirroring the secondary-model overlay's pinned-pointer handling) —
+ * the pointer can never dangle on disk after the recipe is removed. Nothing
+ * is synthesized when the recipe has no patch fields (visual tasks bind the
+ * pointed entry directly), when `visual.model` is unset, or when the pointed
+ * entry does not exist. The id is reserved: a user-configured entry under it
+ * is stripped on write all the same.
+ *
+ * Self-registered at module load via `registerConfigOverlay`; it is imported
+ * for side effects after the secondary-model overlay so a `visual.model`
+ * pointing at the secondary-derived entry sees the already-applied secondary
+ * view, and a `secondary.model` pointing at the visual-derived entry sees
+ * the already-applied visual view.
+ */
+
+import type { ConfigEffectiveOverlay } from '#/app/config/config';
+import { registerConfigOverlay } from '#/app/config/configOverlayContributions';
+import { isPlainObject } from '#/app/config/toml';
+import type { ModelOverride } from '#/kosong/model/model';
+
+import {
+  DEFAULT_MODEL_SECTION,
+  MODELS_SECTION,
+  VISUAL_MODEL_SECTION,
+  type VisualModelConfig,
+} from './configSection';
+
+export const VISUAL_DERIVED_MODEL_ID = '__visual__';
+
+export function visualModelPatch(
+  visual: VisualModelConfig | undefined,
+): ModelOverride | undefined {
+  if (visual === undefined) return undefined;
+  const { model: _model, ...patch } = visual;
+  return Object.keys(patch).length > 0 ? patch : undefined;
+}
+
+function asRecord(value: unknown): Record<string, unknown> {
+  return isPlainObject(value) ? value : {};
+}
+
+function withoutKey(value: unknown, key: string): unknown {
+  if (!isPlainObject(value) || !(key in value)) return value;
+  const out: Record<string, unknown> = { ...value };
+  delete out[key];
+  return out;
+}
+
+export const visualModelOverlay: ConfigEffectiveOverlay = {
+  apply(effective, _getEnv, validate) {
+    const visual = effective[VISUAL_MODEL_SECTION] as VisualModelConfig | undefined;
+    const patch = visualModelPatch(visual);
+    const baseId = visual?.model;
+    if (patch === undefined || baseId === undefined || baseId === VISUAL_DERIVED_MODEL_ID) {
+      return [];
+    }
+    const models = asRecord(effective[MODELS_SECTION]);
+    const base = models[baseId];
+    if (!isPlainObject(base)) return [];
+    const { overrides: baseOverrides, aliases: _aliases, ...baseFields } = base;
+    const derived: Record<string, unknown> = {
+      ...baseFields,
+      overrides: { ...asRecord(baseOverrides), ...patch },
+    };
+    effective[MODELS_SECTION] = validate(MODELS_SECTION, {
+      ...models,
+      [VISUAL_DERIVED_MODEL_ID]: derived,
+    });
+    return [MODELS_SECTION];
+  },
+
+  strip(domain, value, rawSnake) {
+    switch (domain) {
+      case MODELS_SECTION:
+        return withoutKey(value, VISUAL_DERIVED_MODEL_ID);
+      case DEFAULT_MODEL_SECTION:
+        if (value !== VISUAL_DERIVED_MODEL_ID) return value;
+        return typeof rawSnake['default_model'] === 'string'
+          ? rawSnake['default_model']
+          : undefined;
+      default:
+        return value;
+    }
+  },
+};
+
+registerConfigOverlay(visualModelOverlay);

--- a/packages/agent-core-v2/src/index.ts
+++ b/packages/agent-core-v2/src/index.ts
@@ -150,6 +150,7 @@ export * from '#/kosong/protocol/protocolBase';
 export * from '#/kosong/protocol/protocolTrait';
 import '#/app/kosongConfig/envOverlay';
 import '#/app/kosongConfig/secondaryModelOverlay';
+import '#/app/kosongConfig/visualModelOverlay';
 export * from '#/kosong/model/completionBudget';
 export * from '#/kosong/model/hostRequestHeaders';
 export * from '#/kosong/model/model';
@@ -165,12 +166,29 @@ export {
   ModelCatalogConfigSchema,
   type ModelCatalogConfig,
 } from '#/app/kosongConfig/configSection';
-export type { SecondaryModelConfig } from '#/app/kosongConfig/configSection';
+export type { SecondaryModelConfig, VisualModelConfig } from '#/app/kosongConfig/configSection';
+export {
+  SECONDARY_MODEL_SECTION,
+  SECONDARY_MODEL_ENV,
+  SECONDARY_MODEL_EFFORT_ENV,
+  SecondaryModelConfigSchema,
+  secondaryModelEnvBindings,
+  VISUAL_MODEL_SECTION,
+  VISUAL_MODEL_ENV,
+  VISUAL_MODEL_EFFORT_ENV,
+  VisualModelConfigSchema,
+  visualModelEnvBindings,
+} from '#/app/kosongConfig/configSection';
 export {
   SECONDARY_DERIVED_MODEL_ID,
   secondaryModelOverlay,
   secondaryModelPatch,
 } from '#/app/kosongConfig/secondaryModelOverlay';
+export {
+  VISUAL_DERIVED_MODEL_ID,
+  visualModelOverlay,
+  visualModelPatch,
+} from '#/app/kosongConfig/visualModelOverlay';
 export * from '#/app/kosongConfig/kosongConfig';
 export * from '#/app/kosongConfig/kosongConfigService';
 export * from '#/kosong/model/modelOAuth';
@@ -396,6 +414,23 @@ export * from '#/agent/tools/agent/subagent-task';
 export { AGENT_RUN_PROMPT_ORIGIN } from '#/session/subagent/runAgentTurn';
 export * from '#/session/subagent/mirrorAgentRun';
 import '#/session/subagent/configSection';
+import '#/session/visual/flag';
+import '#/session/visual/configSection';
+export {
+  VISUAL_MODEL_FLAG_ID,
+  VISUAL_MODEL_FLAG_ENV,
+  visualModelFlag,
+} from '#/session/visual/flag';
+export {
+  resolveVisualModel,
+  resolveVisualBinding,
+  visualDisplayModel,
+  buildVisualModelDescriptions,
+  stripVisualModelParameter,
+  wrapVisualModelError,
+  VISUAL_MODEL_CHOICE_SCHEMA,
+  type VisualModelChoice,
+} from '#/session/visual/configSection';
 export * from '#/agent/tools/agent/agent';
 import '#/agent/tools/agent/agentTool';
 export * from '#/app/workspaceLifecycle/workspaceLifecycle';

--- a/packages/agent-core-v2/src/session/visual/configSection.ts
+++ b/packages/agent-core-v2/src/session/visual/configSection.ts
@@ -1,0 +1,225 @@
+/**
+ * `visual` domain — visual-model config-section resolver.
+ *
+ * Visual-model mirror of {@link ../../../session/subagent/configSection}:
+ * resolves which model handles image / screenshot / video inspection tasks
+ * when the `visual-model` experiment is enabled and `[visual_model]` is
+ * configured. The caller's model remains the default; the visual model is
+ * an opt-in override for vision-only work, parallel to how the secondary
+ * model is an opt-in override for subagent spawns.
+ *
+ * Resolution rules (mirror of `resolveSubagentBinding`):
+ *  - When the experiment is disabled, or `[visual_model]` is unset, returns
+ *    `undefined` from {@link resolveVisualModel} and the caller's own model
+ *    from {@link resolveVisualBinding} — no behavior change.
+ *  - When set, {@link resolveVisualModel} returns the configured recipe; a
+ *    recipe with patch fields binds the synthesized derived entry
+ *    ({@link VISUAL_DERIVED_MODEL_ID}, materialized by `visualModelOverlay`);
+ *    a pointer-only recipe binds the pointed entry directly. `default_effort`
+ *    is passed as the explicit visual-task thinking effort; without it the
+ *    visual task resolves thinking naturally (global thinking config → the
+ *    bound model's default effort) rather than inheriting the caller's level.
+ *
+ * The TUI / agent tool descriptions can surface the pair via
+ * {@link buildVisualModelDescriptions} (each line suffixed with the entry's
+ * resolved capability flags, so the parent can route multimodal or
+ * thinking-heavy visual tasks instead of guessing from the model id), and
+ * spawn failures are wrapped with {@link wrapVisualModelError} so a missing
+ * visual-model alias points back at `[visual_model].model` /
+ * `KIMI_VISUAL_MODEL`. While the experiment is off, the no-op `model`
+ * parameter (when a tool chooses to advertise one for visual selection) is
+ * stripped via {@link stripVisualModelParameter}. Display-facing alias
+ * resolution goes through {@link visualDisplayModel}: the derived entry id
+ * means nothing to a user, so it resolves back to the recipe's base alias —
+ * flag-independent on purpose, since interpreting an already-persisted
+ * derived binding (resume) must keep working after the experiment is
+ * switched off.
+ */
+
+import { z } from 'zod';
+
+import { Error2, ErrorCodes, isError2 } from '#/errors';
+import type { AgentModelPreference } from '#/app/agentProfileCatalog/agentProfileCatalog';
+import { isPlainObject } from '#/app/config/toml';
+import type { IFlagService } from '#/app/flag/flag';
+import {
+  VISUAL_MODEL_ENV,
+  VISUAL_MODEL_SECTION,
+} from '#/app/kosongConfig/configSection';
+import {
+  VISUAL_DERIVED_MODEL_ID,
+  visualModelPatch,
+} from '#/app/kosongConfig/visualModelOverlay';
+import { type VisualModelConfig } from '#/app/kosongConfig/configSection';
+import type { IConfigService } from '#/app/config/config';
+import type { ModelCapability } from '#/kosong/contract/capability';
+import type { IModelCatalog } from '#/kosong/model/catalog';
+
+import { VISUAL_MODEL_FLAG_ID } from './flag';
+
+export type VisualModelChoice = AgentModelPreference;
+
+export function resolveVisualModel(
+  config: IConfigService,
+  flags: IFlagService,
+): VisualModelConfig | undefined {
+  if (!flags.enabled(VISUAL_MODEL_FLAG_ID)) return undefined;
+  return config.get<VisualModelConfig | undefined>(VISUAL_MODEL_SECTION);
+}
+
+/**
+ * Resolve which model handles a visual (image / screenshot / video)
+ * inspection task. `own` is the caller's current model state, used when
+ * inheriting (visual model unset or explicit `primary` request).
+ *
+ * `requested` mirrors the subagent `model` parameter: `undefined` follows the
+ * default (visual model when set, caller's model otherwise); `'primary'`
+ * forces the caller's model even when a visual model is configured; a
+ * visual-model-aware tool can also accept `'visual'` to force the visual
+ * model when configured (returns the caller's model when no visual model is
+ * configured, so the symbolic choice never fails).
+ */
+export function resolveVisualBinding(
+  config: IConfigService,
+  flags: IFlagService,
+  own: { modelAlias: string; thinkingLevel: string },
+  requested?: VisualModelChoice,
+): { model: string; thinking?: string; displayModel: string } {
+  const visual = resolveVisualModel(config, flags);
+  if (requested !== 'primary' && visual?.model !== undefined) {
+    const model =
+      visualModelPatch(visual) === undefined ? visual.model : VISUAL_DERIVED_MODEL_ID;
+    return {
+      model,
+      thinking: visual.defaultEffort,
+      displayModel: visualDisplayModel(config, model),
+    };
+  }
+  return {
+    model: own.modelAlias,
+    thinking: own.thinkingLevel,
+    displayModel: visualDisplayModel(config, own.modelAlias),
+  };
+}
+
+export function visualDisplayModel(config: IConfigService, boundAlias: string): string {
+  if (boundAlias !== VISUAL_DERIVED_MODEL_ID) return boundAlias;
+  return (
+    config.get<VisualModelConfig | undefined>(VISUAL_MODEL_SECTION)?.model ?? boundAlias
+  );
+}
+
+/**
+ * The "Available models" block appended to visual-task tool descriptions so
+ * the parent model knows it can pick. `undefined` when the visual model is
+ * not configured or the caller's model is not bound yet.
+ */
+export function buildVisualModelDescriptions(
+  config: IConfigService,
+  flags: IFlagService,
+  callerModelAlias: string | undefined,
+  modelCatalog: IModelCatalog,
+): string | undefined {
+  const visual = resolveVisualModel(config, flags);
+  const visualModel = visual?.model;
+  if (visualModel === undefined || callerModelAlias === undefined) return undefined;
+  const boundVisual =
+    visualModelPatch(visual) === undefined ? visualModel : VISUAL_DERIVED_MODEL_ID;
+  return [
+    'Available models for visual inspection (pass via model):',
+    `- visual: ${visualModel} (default) — the configured visual model; prefer it for image / screenshot / video inspection${capabilitiesSuffix(resolvedCapabilities(modelCatalog, boundVisual))}`,
+    `- primary: ${callerModelAlias} — the main model you are running on; use it when the caller is itself vision-capable and you want to keep the work in-process${capabilitiesSuffix(resolvedCapabilities(modelCatalog, callerModelAlias))}`,
+  ].join('\n');
+}
+
+const ADVERTISED_CAPABILITY_FLAGS = [
+  'image_in',
+  'video_in',
+  'audio_in',
+  'thinking',
+  'tool_use',
+  'dynamically_loaded_tools',
+] as const satisfies readonly (keyof ModelCapability)[];
+
+function capabilitiesSuffix(capability: ModelCapability | undefined): string {
+  if (capability === undefined) return '';
+  const names = ADVERTISED_CAPABILITY_FLAGS.filter((flag) => capability[flag] === true);
+  return `; capabilities: ${names.length === 0 ? 'none' : names.join(', ')}`;
+}
+
+function resolvedCapabilities(
+  modelCatalog: IModelCatalog,
+  model: string,
+): ModelCapability | undefined {
+  try {
+    return modelCatalog.get(model).capabilities;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Strip the `model` property from a visual-task tool's advertised JSON schema.
+ * While the `visual-model` experiment is off the parameter is a silent no-op,
+ * so the schema the model sees (and the args validator compiled from the same
+ * advertised schema) drops it entirely — the visual-model concept never
+ * enters the prompt, and a stray `model` argument is rejected instead of
+ * silently inheriting the caller's model. Returns the input unchanged when
+ * there is no `model` property; otherwise a shallow copy — the input is never
+ * mutated, so callers can keep both variants as shared constants.
+ */
+export function stripVisualModelParameter(
+  parameters: Record<string, unknown>,
+): Record<string, unknown> {
+  const properties = parameters['properties'];
+  if (!isPlainObject(properties) || !('model' in properties)) return parameters;
+  const nextProperties = { ...properties };
+  delete nextProperties['model'];
+  const next: Record<string, unknown> = { ...parameters, properties: nextProperties };
+  const required = parameters['required'];
+  if (Array.isArray(required) && required.includes('model')) {
+    next['required'] = required.filter((entry) => entry !== 'model');
+  }
+  return next;
+}
+
+/**
+ * Point a visual-task model resolution failure at the visual-model
+ * configuration when the bound model is not the caller's own — otherwise the
+ * parent model sees a bare "model not configured" error with no hint that it
+ * comes from `[visual_model]`.
+ */
+export function wrapVisualModelError(
+  error: unknown,
+  boundModel: string,
+  callerModelAlias: string | undefined,
+): unknown {
+  if (boundModel === callerModelAlias) return error;
+  if (!isError2(error) || error.code !== ErrorCodes.CONFIG_INVALID) return error;
+  if (error.details?.['model'] !== boundModel) return error;
+  const displayModel =
+    boundModel === VISUAL_DERIVED_MODEL_ID
+      ? `the derived entry "${VISUAL_DERIVED_MODEL_ID}"`
+      : `"${boundModel}"`;
+  return new Error2(
+    error.code,
+    `${error.message} (visual model ${displayModel} comes from [visual_model].model / ${VISUAL_MODEL_ENV} — check that it names a valid [models] entry)`,
+    {
+      cause: error,
+      name: error.name,
+      details: {
+        ...error.details,
+        visualModel: boundModel,
+        visualModelConfig: {
+          section: 'visualModel.model',
+          environment: VISUAL_MODEL_ENV,
+        },
+      },
+    },
+  );
+}
+
+// Re-export the schema symbol for tests / type-only consumers that want a
+// single import surface for the visual domain. The schema itself lives next
+// to the other kosong config sections (see `kosongConfig/configSection.ts`).
+export const VISUAL_MODEL_CHOICE_SCHEMA = z.enum(['primary', 'visual']);

--- a/packages/agent-core-v2/src/session/visual/flag.ts
+++ b/packages/agent-core-v2/src/session/visual/flag.ts
@@ -1,0 +1,34 @@
+/**
+ * `visual` domain — registers the `visual-model` experimental flag
+ * into `flag`.
+ *
+ * Visual-model mirror of {@link secondaryModelFlag}: gates visual-model
+ * selection for image / screenshot / video inspection tasks, including the
+ * agent-facing model choices and startup validation warning. Off by default;
+ * enable via `KIMI_CODE_EXPERIMENTAL_VISUAL_MODEL`, the master
+ * `KIMI_CODE_EXPERIMENTAL_FLAG`, or the `[experimental]` config section.
+ *
+ * Many coding models are text-only and cannot consume image content. When
+ * this experiment is enabled and `[visual_model]` is configured, visual
+ * inspection tasks (the `ReadMediaFile` tool and any future visual subagent
+ * spawn) consult {@link resolveVisualModel} to pick a vision-capable model
+ * instead of falling back to the caller's text-only model. When unset,
+ * behavior is unchanged (visual tasks inherit the caller's model).
+ */
+
+import { type FlagDefinitionInput, registerFlagDefinition } from '#/app/flag/flagRegistry';
+
+export const VISUAL_MODEL_FLAG_ID = 'visual-model';
+export const VISUAL_MODEL_FLAG_ENV = 'KIMI_CODE_EXPERIMENTAL_VISUAL_MODEL';
+
+export const visualModelFlag: FlagDefinitionInput = {
+  id: VISUAL_MODEL_FLAG_ID,
+  title: 'Visual model for image/screenshot inspection',
+  description:
+    'Let image / screenshot / video inspection tasks use a separately configured visual model by default, so a text-only coding model can still drive visual work via a vision-capable companion model.',
+  env: VISUAL_MODEL_FLAG_ENV,
+  default: false,
+  surface: 'core',
+};
+
+registerFlagDefinition(visualModelFlag);

--- a/packages/agent-core-v2/test/agent/media/tools/read-media.test.ts
+++ b/packages/agent-core-v2/test/agent/media/tools/read-media.test.ts
@@ -37,6 +37,8 @@ import {
   type ToolExecution,
 } from '#/tool/toolContract';
 import { EventBusService } from '#/app/event/eventBusService';
+import { StubConfigService } from '../../../kosong/stubs';
+import { stubFlag } from '../../../app/flag/stubs';
 import type { IAgentProfileService } from '#/agent/profile/profile';
 import type { IModelCatalog } from '#/kosong/model/catalog';
 import type { ModelRequester } from '#/kosong/model/modelRequester';
@@ -848,6 +850,8 @@ describe('AgentMediaToolsRegistrar', () => {
       registry,
       profile,
       modelCatalog,
+      new StubConfigService(),
+      stubFlag(false),
       eventBus,
       createTestFs({}),
       createTestEnv(),

--- a/packages/agent-core-v2/test/app/kosongConfig/visualModelOverlay.test.ts
+++ b/packages/agent-core-v2/test/app/kosongConfig/visualModelOverlay.test.ts
@@ -1,0 +1,129 @@
+/**
+ * `app/kosongConfig` visualModelOverlay tests — the `[visual_model]`
+ * derived-entry synthesis (visual-model mirror of `secondaryModelOverlay`):
+ *
+ *  - a recipe with patch fields synthesizes `VISUAL_DERIVED_MODEL_ID`
+ *    (base copy, patch merged into `overrides` with patch winning conflicts,
+ *    `aliases` dropped); a pointer-only recipe, a missing pointer, and a
+ *    dangling pointer synthesize nothing;
+ *  - `strip` keeps the synthesized entry out of `config.toml` and rolls
+ *    back a `defaultModel` pointer at the derived id.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import {
+  MODELS_SECTION,
+  VISUAL_MODEL_SECTION,
+} from '#/app/kosongConfig/configSection';
+import {
+  VISUAL_DERIVED_MODEL_ID,
+  visualModelOverlay,
+} from '#/app/kosongConfig/visualModelOverlay';
+
+function apply(effective: Record<string, unknown>): readonly string[] {
+  return visualModelOverlay.apply(effective, () => undefined, (_domain, value) => value);
+}
+
+const baseEntry = {
+  provider: 'kimi',
+  model: 'kimi-vision',
+  maxContextSize: 131072,
+  aliases: ['vision-latest'],
+  overrides: { defaultEffort: 'medium', supportEfforts: ['low', 'medium', 'high'] },
+};
+
+describe('visualModelOverlay.apply', () => {
+  it('does nothing when no visual model is configured', () => {
+    const effective: Record<string, unknown> = { [MODELS_SECTION]: { vision: baseEntry } };
+    expect(apply(effective)).toEqual([]);
+    expect(effective[MODELS_SECTION]).toEqual({ vision: baseEntry });
+  });
+
+  it('does nothing for a pointer-only recipe (no patch fields)', () => {
+    const effective: Record<string, unknown> = {
+      [MODELS_SECTION]: { vision: baseEntry },
+      [VISUAL_MODEL_SECTION]: { model: 'vision' },
+    };
+    expect(apply(effective)).toEqual([]);
+    expect(effective[MODELS_SECTION]).toEqual({ vision: baseEntry });
+  });
+
+  it('synthesizes the derived entry: base copy, patch wins overrides conflicts, aliases dropped', () => {
+    const effective: Record<string, unknown> = {
+      [MODELS_SECTION]: { vision: baseEntry },
+      [VISUAL_MODEL_SECTION]: { model: 'vision', defaultEffort: 'low', maxOutputSize: 4096 },
+    };
+    expect(apply(effective)).toEqual([MODELS_SECTION]);
+    const models = effective[MODELS_SECTION] as Record<string, unknown>;
+    expect(models[VISUAL_DERIVED_MODEL_ID]).toEqual({
+      provider: 'kimi',
+      model: 'kimi-vision',
+      maxContextSize: 131072,
+      overrides: {
+        defaultEffort: 'low',
+        supportEfforts: ['low', 'medium', 'high'],
+        maxOutputSize: 4096,
+      },
+    });
+    expect(models['vision']).toEqual(baseEntry);
+  });
+
+  it('does nothing when the pointed entry does not exist', () => {
+    const effective: Record<string, unknown> = {
+      [MODELS_SECTION]: { vision: baseEntry },
+      [VISUAL_MODEL_SECTION]: { model: 'nope', maxOutputSize: 4096 },
+    };
+    expect(apply(effective)).toEqual([]);
+    expect(effective[MODELS_SECTION]).toEqual({ vision: baseEntry });
+  });
+
+  it('never derives from the derived id itself', () => {
+    const effective: Record<string, unknown> = {
+      [MODELS_SECTION]: { [VISUAL_DERIVED_MODEL_ID]: baseEntry },
+      [VISUAL_MODEL_SECTION]: { model: VISUAL_DERIVED_MODEL_ID, maxOutputSize: 1 },
+    };
+    expect(apply(effective)).toEqual([]);
+  });
+
+  it('does not collide with the secondary-model derived entry', () => {
+    // The visual and secondary overlays use distinct reserved ids
+    // (__visual__ vs __secondary__), so both can be configured at once.
+    const SECONDARY_DERIVED_MODEL_ID = '__secondary__';
+    const effective: Record<string, unknown> = {
+      [MODELS_SECTION]: {
+        vision: baseEntry,
+        coder: { ...baseEntry, model: 'kimi-coder' },
+      },
+      [VISUAL_MODEL_SECTION]: { model: 'vision', maxOutputSize: 4096 },
+      secondaryModel: { model: 'coder', maxOutputSize: 8192 },
+    };
+    apply(effective);
+    const models = effective[MODELS_SECTION] as Record<string, unknown>;
+    expect(models[VISUAL_DERIVED_MODEL_ID]).toBeDefined();
+    expect(models[VISUAL_DERIVED_MODEL_ID]).not.toBe(models[SECONDARY_DERIVED_MODEL_ID]);
+  });
+});
+
+describe('visualModelOverlay.strip', () => {
+  const strip = visualModelOverlay.strip!;
+
+  it('removes the derived entry from models writes and leaves other domains alone', () => {
+    const models = { vision: baseEntry, [VISUAL_DERIVED_MODEL_ID]: { ...baseEntry } };
+    expect(strip(MODELS_SECTION, models, {})).toEqual({ vision: baseEntry });
+    expect(strip('thinking', { effort: 'low' }, {})).toEqual({ effort: 'low' });
+  });
+
+  it('leaves a models section without the derived entry untouched', () => {
+    const models = { vision: baseEntry };
+    expect(strip(MODELS_SECTION, models, {})).toBe(models);
+  });
+
+  it('rolls back a defaultModel pointer set to the derived id', () => {
+    expect(strip('defaultModel', 'vision', {})).toBe('vision');
+    expect(strip('defaultModel', VISUAL_DERIVED_MODEL_ID, { default_model: 'vision' })).toBe(
+      'vision',
+    );
+    expect(strip('defaultModel', VISUAL_DERIVED_MODEL_ID, {})).toBeUndefined();
+  });
+});

--- a/packages/agent-core-v2/test/session/visual/configSection.test.ts
+++ b/packages/agent-core-v2/test/session/visual/configSection.test.ts
@@ -1,0 +1,203 @@
+/**
+ * `session/visual` resolver tests — covers `resolveVisualModel` and
+ * `resolveVisualBinding`, including the unset-fallback path.
+ *
+ * Mirrors the shape of the subagent resolver tests but uses the visual-model
+ * flag + section. The StubConfigService + stubFlag helpers mirror the
+ * secondary-model warning tests.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import { VISUAL_MODEL_SECTION } from '#/app/kosongConfig/configSection';
+import { VISUAL_DERIVED_MODEL_ID } from '#/app/kosongConfig/visualModelOverlay';
+import {
+  resolveVisualBinding,
+  resolveVisualModel,
+  visualDisplayModel,
+  stripVisualModelParameter,
+  wrapVisualModelError,
+} from '#/session/visual/configSection';
+import { VISUAL_MODEL_FLAG_ID } from '#/session/visual/flag';
+import { Error2, ErrorCodes } from '#/errors';
+
+import { stubFlag } from '../../app/flag/stubs';
+import { StubConfigService } from '../../kosong/stubs';
+
+function makeServices(configValues: Record<string, unknown>, flagEnabled = true) {
+  const config = new StubConfigService(configValues);
+  const flags = stubFlag((id) => flagEnabled && id === VISUAL_MODEL_FLAG_ID);
+  return { config, flags };
+}
+
+const own = { modelAlias: 'caller/kimi-coder', thinkingLevel: 'medium' };
+
+describe('resolveVisualModel', () => {
+  it('returns undefined when the visual-model flag is disabled', () => {
+    const { config } = makeServices({ [VISUAL_MODEL_SECTION]: { model: 'kimi/vision' } }, false);
+    const { flags } = makeServices({}, false);
+    expect(resolveVisualModel(config, flags)).toBeUndefined();
+  });
+
+  it('returns undefined when [visual_model] is unset (no behavior change)', () => {
+    const { config, flags } = makeServices({});
+    expect(resolveVisualModel(config, flags)).toBeUndefined();
+  });
+
+  it('returns the configured recipe when set and the flag is on', () => {
+    const { config, flags } = makeServices({
+      [VISUAL_MODEL_SECTION]: { model: 'kimi/vision', defaultEffort: 'low' },
+    });
+    expect(resolveVisualModel(config, flags)).toEqual({
+      model: 'kimi/vision',
+      defaultEffort: 'low',
+    });
+  });
+});
+
+describe('resolveVisualBinding', () => {
+  it('inherits the caller model when visual model is unset (no behavior change)', () => {
+    const { config, flags } = makeServices({});
+    expect(resolveVisualBinding(config, flags, own)).toEqual({
+      model: own.modelAlias,
+      thinking: own.thinkingLevel,
+      displayModel: own.modelAlias,
+    });
+  });
+
+  it('inherits the caller model when the flag is disabled even if the recipe is set', () => {
+    const { config } = makeServices({ [VISUAL_MODEL_SECTION]: { model: 'kimi/vision' } });
+    const { flags } = makeServices({}, false);
+    expect(resolveVisualBinding(config, flags, own)).toEqual({
+      model: own.modelAlias,
+      thinking: own.thinkingLevel,
+      displayModel: own.modelAlias,
+    });
+  });
+
+  it('binds the visual model when set (pointer-only recipe)', () => {
+    const { config, flags } = makeServices({
+      [VISUAL_MODEL_SECTION]: { model: 'kimi/vision' },
+    });
+    expect(resolveVisualBinding(config, flags, own)).toEqual({
+      model: 'kimi/vision',
+      thinking: undefined,
+      displayModel: 'kimi/vision',
+    });
+  });
+
+  it('binds the derived entry when the recipe carries patch fields', () => {
+    const { config, flags } = makeServices({
+      [VISUAL_MODEL_SECTION]: { model: 'kimi/vision', defaultEffort: 'low', maxOutputSize: 4096 },
+    });
+    const binding = resolveVisualBinding(config, flags, own);
+    expect(binding.model).toBe(VISUAL_DERIVED_MODEL_ID);
+    expect(binding.thinking).toBe('low');
+    // displayModel resolves the derived id back to the recipe's base alias
+    expect(binding.displayModel).toBe('kimi/vision');
+  });
+
+  it('forces the caller model on explicit "primary" even when a visual model is configured', () => {
+    const { config, flags } = makeServices({
+      [VISUAL_MODEL_SECTION]: { model: 'kimi/vision' },
+    });
+    expect(resolveVisualBinding(config, flags, own, 'primary')).toEqual({
+      model: own.modelAlias,
+      thinking: own.thinkingLevel,
+      displayModel: own.modelAlias,
+    });
+  });
+});
+
+describe('visualDisplayModel', () => {
+  it('passes through any non-derived alias', () => {
+    const { config } = makeServices({});
+    expect(visualDisplayModel(config, 'kimi/vision')).toBe('kimi/vision');
+  });
+
+  it('resolves the derived id back to the recipe base alias', () => {
+    const { config } = makeServices({
+      [VISUAL_MODEL_SECTION]: { model: 'kimi/vision' },
+    });
+    expect(visualDisplayModel(config, VISUAL_DERIVED_MODEL_ID)).toBe('kimi/vision');
+  });
+
+  it('falls back to the derived id when the recipe has been removed', () => {
+    const { config } = makeServices({});
+    expect(visualDisplayModel(config, VISUAL_DERIVED_MODEL_ID)).toBe(VISUAL_DERIVED_MODEL_ID);
+  });
+});
+
+describe('stripVisualModelParameter', () => {
+  it('returns the input unchanged when there is no model property', () => {
+    const schema = { properties: { prompt: { type: 'string' } }, required: ['prompt'] };
+    expect(stripVisualModelParameter(schema)).toBe(schema);
+  });
+
+  it('removes the model property and its required entry', () => {
+    const schema = {
+      properties: { prompt: { type: 'string' }, model: { type: 'string' } },
+      required: ['prompt', 'model'],
+    };
+    const next = stripVisualModelParameter(schema);
+    expect(next['properties']).toEqual({ prompt: { type: 'string' } });
+    expect(next['required']).toEqual(['prompt']);
+  });
+
+  it('does not mutate the input', () => {
+    const schema = {
+      properties: { model: { type: 'string' } },
+      required: ['model'],
+    };
+    const next = stripVisualModelParameter(schema);
+    expect(next).not.toBe(schema);
+    expect(schema['properties']).toEqual({ model: { type: 'string' } });
+  });
+});
+
+describe('wrapVisualModelError', () => {
+  const callerModelAlias = 'caller/kimi-coder';
+
+  it('returns the error unchanged when the bound model is the caller own', () => {
+    const error = new Error2(ErrorCodes.CONFIG_INVALID, 'boom', {
+      details: { model: callerModelAlias },
+    });
+    expect(wrapVisualModelError(error, callerModelAlias, callerModelAlias)).toBe(error);
+  });
+
+  it('returns the error unchanged for non-CONFIG_INVALID errors', () => {
+    const error = new Error('boom');
+    expect(wrapVisualModelError(error, 'kimi/vision', callerModelAlias)).toBe(error);
+  });
+
+  it('returns the error unchanged when the error details model does not match the bound model', () => {
+    const error = new Error2(ErrorCodes.CONFIG_INVALID, 'boom', {
+      details: { model: 'some/other' },
+    });
+    expect(wrapVisualModelError(error, 'kimi/vision', callerModelAlias)).toBe(error);
+  });
+
+  it('wraps a missing-alias failure with a hint pointing at [visual_model]', () => {
+    const error = new Error2(ErrorCodes.CONFIG_INVALID, 'Model "kimi/vision" is not configured.', {
+      details: { model: 'kimi/vision' },
+    });
+    const wrapped = wrapVisualModelError(error, 'kimi/vision', callerModelAlias) as Error2;
+    expect(wrapped).toBeInstanceOf(Error2);
+    expect(wrapped.message).toContain('[visual_model]');
+    expect(wrapped.message).toContain('KIMI_VISUAL_MODEL');
+    expect(wrapped.details).toMatchObject({
+      model: 'kimi/vision',
+      visualModel: 'kimi/vision',
+      visualModelConfig: { section: 'visualModel.model', environment: 'KIMI_VISUAL_MODEL' },
+    });
+  });
+
+  it('wraps a derived-entry failure with a hint pointing at the derived id', () => {
+    const error = new Error2(ErrorCodes.CONFIG_INVALID, 'missing', {
+      details: { model: VISUAL_DERIVED_MODEL_ID },
+    });
+    const wrapped = wrapVisualModelError(error, VISUAL_DERIVED_MODEL_ID, callerModelAlias) as Error2;
+    expect(wrapped.message).toContain(VISUAL_DERIVED_MODEL_ID);
+    expect(wrapped.message).toContain('[visual_model]');
+  });
+});


### PR DESCRIPTION
## Related Issue

Closes MoonshotAI/kimi-code#2750

## Problem

Many coding models are text-only — they cannot inspect images. Web and mobile development regularly requires visual inspection (screenshots, UI states, layout renders, image diffs of a rendered page). Today there is no way for a user to pin a specific, vision-capable model for these visual tasks; they fall back to automatic / current-model selection, which is often a text-only model. See the linked issue for the full context.

## What changed

Mirrors the existing experimental `[secondary_model]` slot as a new `[visual_model]` configuration section, so a user can pin a vision-capable companion model for image / screenshot / video inspection. The design copies the secondary-model shape verbatim — config section + env overrides + experiment flag + derived-entry overlay + resolver family — and wires the resolver into the media-tools registrar.

### Config + overlay + flag

- `[visual_model]` config section registered in `packages/agent-core-v2/src/app/kosongConfig/configSection.ts` (parallel to `SECONDARY_MODEL_SECTION`). Accepts `model`, `default_effort`, and every `[models."<alias>".overrides]` field as a patch.
- `KIMI_VISUAL_MODEL` / `KIMI_VISUAL_EFFORT` env overrides (priority over `config.toml`).
- `packages/agent-core-v2/src/app/kosongConfig/visualModelOverlay.ts` synthesizes the derived `__visual__` registry entry when the recipe carries patch fields (base copy, patch merged into `overrides` with patch winning conflicts, `aliases` dropped). The derived entry lives only in memory and is stripped from `config.toml` writes — including a `default_model` pointer at the derived id. Mirror of `secondaryModelOverlay`.
- `packages/agent-core-v2/src/session/visual/flag.ts` registers the `visual-model` experimental flag (`KIMI_CODE_EXPERIMENTAL_VISUAL_MODEL`), default off, surface `core`.

### Resolver family

`packages/agent-core-v2/src/session/visual/configSection.ts` exports the visual-model resolver family, mirroring `session/subagent/configSection.ts`:

- `resolveVisualModel(config, flags)` — returns the configured recipe when the experiment is on, `undefined` otherwise.
- `resolveVisualBinding(config, flags, own, requested?)` — resolves which model a visual task binds to. Unset = caller's model (no behavior change). Explicit `'primary'` forces the caller's model even when a visual model is configured.
- `buildVisualModelDescriptions(...)` — the "Available models for visual inspection" block, with capability suffixes, mirroring `buildSubagentModelDescriptions`.
- `visualDisplayModel(config, boundAlias)` — resolves the derived `__visual__` id back to the recipe's base alias for display, flag-independent so an already-persisted derived binding still resolves after the experiment is switched off.
- `stripVisualModelParameter(...)` — strips the no-op `model` parameter from a visual-task tool's advertised schema while the experiment is off.
- `wrapVisualModelError(...)` — wraps a missing-alias failure with a hint pointing at `[visual_model].model` / `KIMI_VISUAL_MODEL`.

### Wiring

`packages/agent-core-v2/src/agent/media/mediaToolsRegistrar.ts` now injects `IConfigService` + `IFlagService` and consults `resolveVisualModel` on every refresh. When the caller's model is text-only (`!image_in && !video_in`) but a vision-capable visual model is configured and the experiment is on, the registrar registers `ReadMediaFile` against the visual model's capabilities and video uploader so the LLM keeps the tool available for visual inspection. When the visual model is unset, the registrar's behavior is identical to before (caller's capabilities gate, caller's requester binds). The state key now includes the visual model alias + capability signature so a visual-model change re-runs registration.

The actual end-to-end routing of image content to the visual model (e.g. via a subagent spawn for the inspection) is a follow-up enhancement that this PR enables — the configuration slot, resolver, and registrar gate are the foundation.

### Index exports

`packages/agent-core-v2/src/index.ts` re-exports the new symbols (`VISUAL_MODEL_SECTION`, `VISUAL_MODEL_ENV`, `VISUAL_MODEL_EFFORT_ENV`, `VisualModelConfigSchema`, `visualModelEnvBindings`, `VISUAL_DERIVED_MODEL_ID`, `visualModelOverlay`, `visualModelPatch`, `VISUAL_MODEL_FLAG_ID`, `VISUAL_MODEL_FLAG_ENV`, `visualModelFlag`, `resolveVisualModel`, `resolveVisualBinding`, `visualDisplayModel`, `buildVisualModelDescriptions`, `stripVisualModelParameter`, `wrapVisualModelError`, `VisualModelChoice`) and side-effect-imports the overlay + flag + resolver so the registrations run on first import.

### Docs + manifest

- Bilingual VitePress docs: new `## visual_model` section in `docs/en/configuration/config-files.md` and `docs/zh/configuration/config-files.md`, mirroring the `## secondary_model` section (table, patch semantics, env overrides, experiment flag, advisory validation note).
- `packages/agent-core-v2/docs/config-manifest.toml` regenerated via `pnpm --filter @moonshot-ai/agent-core-v2 gen:config-manifest` — now lists `visualModel` and the `visualModelOverlay`.

### Tests

- `packages/agent-core-v2/test/app/kosongConfig/visualModelOverlay.test.ts` (9 tests, mirror of `secondaryModelOverlay.test.ts`): apply path (no-op, pointer-only, patch synthesis, missing pointer, never-derive-from-derived, no collision with `__secondary__`) and strip path (removes derived entry, leaves other domains, rolls back `defaultModel` pointer).
- `packages/agent-core-v2/test/session/visual/configSection.test.ts` (19 tests): `resolveVisualModel` (disabled flag, unset, set), `resolveVisualBinding` (unset fallback, disabled-flag fallback, pointer-only binding, derived-entry binding + display, explicit `primary` override), `visualDisplayModel` (passthrough, derived-id resolution, fallback after recipe removal), `stripVisualModelParameter` (no-op, removes `model` + `required`, no mutation), `wrapVisualModelError` (caller-own passthrough, non-CONFIG_INVALID passthrough, mismatched-details passthrough, missing-alias wrap with `[visual_model]` hint, derived-id wrap).
- `packages/agent-core-v2/test/agent/media/tools/read-media.test.ts` updated for the two new `AgentMediaToolsRegistrar` constructor deps (`StubConfigService` + `stubFlag(false)`).

### Changeset

`.changeset/visual-model-assignment.md` — `@moonshot-ai/kimi-code: minor` (user-visible config + behavior change in the CLI).

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue (#2750).
- [x] I have added tests that prove my feature works (28 new tests across overlay + resolver).
- [x] Ran `gen-changesets` skill (changeset added for `@moonshot-ai/kimi-code`).
- [x] Ran `gen-docs` skill (bilingual VitePress docs updated; manifest regenerated).
- [x] `pnpm lint` — 0 errors (only pre-existing warnings in unrelated `packages/minidb`).
- [x] `pnpm --filter @moonshot-ai/agent-core-v2 typecheck` — clean.
- [x] `pnpm --filter @moonshot-ai/agent-core-v2 exec vitest run` for the touched tests — all pass (visual overlay + visual resolver + read-media + secondary-model + secondary-model-warning).
