### PR TITLE
fix(agent-core): gate prompt_cache_key behind isOfficialOpenAIBaseUrl for third-party endpoints

### DIFF
--- a/.changeset/strong-ears-kick.md
+++ b/.changeset/strong-ears-kick.md
@@ -1,0 +1,6 @@
+---
+"@moonshot-ai/agent-core-v2": patch
+"@moonshot-ai/kimi-code": patch
+---
+
+Stop sending the `prompt_cache_key` parameter to third-party OpenAI-compatible providers.

--- a/packages/agent-core-v2/src/human/llm/requester/bases/openai-base-url.ts
+++ b/packages/agent-core-v2/src/human/llm/requester/bases/openai-base-url.ts
@@ -1,0 +1,11 @@
+export function isOfficialOpenAIBaseUrl(baseUrl: string | undefined): boolean {
+  if (baseUrl === undefined) {
+    return true;
+  }
+  try {
+    const hostname = new URL(baseUrl).hostname;
+    return hostname === 'api.openai.com' || hostname.endsWith('.api.openai.com');
+  } catch {
+    return false;
+  }
+}

--- a/packages/agent-core-v2/src/human/llm/requester/bases/openai-responses/format.ts
+++ b/packages/agent-core-v2/src/human/llm/requester/bases/openai-responses/format.ts
@@ -11,6 +11,7 @@ import { encodeReasoningEffortFallback } from '#/llm/thinking';
 import type { TokenUsage } from '#/llm/usage';
 
 import { isContextOverflowErrorCode, isOpenAIInsufficientQuotaCode } from '../openai/format';
+import { isOfficialOpenAIBaseUrl } from '../openai-base-url';
 import { lowerMessage, type ResponsesInputItem } from './lower';
 
 type RawObject = Record<string, unknown>;
@@ -365,7 +366,9 @@ function resolveRequestKwargs(input: FormatRequestInput): Record<string, unknown
   } = input;
   let kwargs: Record<string, unknown> = {};
   if (cacheKey !== undefined) {
-    kwargs = trait?.cacheKey?.(cacheKey, ctx) ?? { prompt_cache_key: cacheKey };
+    kwargs =
+      trait?.cacheKey?.(cacheKey, ctx) ??
+      (isOfficialOpenAIBaseUrl(ctx.model.baseUrl) ? { prompt_cache_key: cacheKey } : {});
   }
   if (thinking !== undefined) {
     kwargs = applyThinking(kwargs, thinking, trait, ctx, (t) =>

--- a/packages/agent-core-v2/src/human/llm/requester/bases/openai/format.ts
+++ b/packages/agent-core-v2/src/human/llm/requester/bases/openai/format.ts
@@ -37,6 +37,7 @@ import type { TokenUsage } from '#/llm/usage';
 import { lowerMessage, type OpenAIWireMessage } from './lower';
 import { extractToolMedia } from './patterns';
 import { DEFAULT_REASONING_KEY, extractReasoning } from './reasoning-key';
+import { isOfficialOpenAIBaseUrl } from '../openai-base-url';
 
 function responseFormatToOpenAI(format: ResponseFormat): Record<string, unknown> {
   if (format.type === 'json_object') {
@@ -176,7 +177,9 @@ function resolveRequestKwargs(input: FormatRequestInput): ResolvedRequestKwargs 
   } = input;
   let kwargs: Record<string, unknown> = {};
   if (cacheKey !== undefined) {
-    kwargs = trait?.cacheKey?.(cacheKey, ctx) ?? { prompt_cache_key: cacheKey };
+    kwargs =
+      trait?.cacheKey?.(cacheKey, ctx) ??
+      (isOfficialOpenAIBaseUrl(ctx.model.baseUrl) ? { prompt_cache_key: cacheKey } : {});
   }
   let preserveThinking = false;
   if (thinking !== undefined) {

--- a/packages/agent-core-v2/src/human/test/llm/cache-key.test.ts
+++ b/packages/agent-core-v2/src/human/test/llm/cache-key.test.ts
@@ -11,7 +11,7 @@ const model: LlmModel = {
   provider: 'test',
   model: 'test-model',
   capability: UNKNOWN_CAPABILITY,
-  baseUrl: 'https://example.test/v1',
+  baseUrl: 'https://api.openai.com/v1',
 };
 const messages: readonly Message[] = [createUserMessage('hi')];
 
@@ -119,6 +119,20 @@ describe('openai requester cacheKey', () => {
     expect(client.body()['stop']).toEqual(['END']);
     expect(client.body()['presence_penalty']).toBe(0.5);
     expect(client.body()['extra_body']).toEqual({ trace_id: 't1' });
+  });
+
+  it('omits prompt_cache_key for third-party OpenAI endpoints', async () => {
+    const client = stubOpenAIClient(chatCompletionChunks);
+    const requester = createOpenAIRequester(undefined, { clientFactory: client.clientFactory });
+    await requester.generate(
+      {
+        model: { ...model, baseUrl: 'https://integrate.api.nvidia.com/v1' },
+        cacheKey: 'session-1',
+      },
+      { messages },
+      { signal: new AbortController().signal },
+    );
+    expect(client.body()['prompt_cache_key']).toBeUndefined();
   });
 
   it('lets a trait override the cache key params', async () => {


### PR DESCRIPTION
## Problem

Since `prompt_cache_key` was introduced for session cache affinity, Kimi Code CLI sends this parameter to **all** OpenAI-compatible providers — not just to official OpenAI endpoints. Third-party APIs that strictly validate request parameters reject it with **HTTP 400**, making providers like NVIDIA NIM and Azure Foundry unusable.

- **#2166** — NVIDIA NIM: `400 Validation: Unsupported parameter(s): prompt_cache_key`
- **#2611** — Azure Foundry: `400 Unrecognized request argument supplied: prompt_cache_key`

Both issues remain **open** because the legacy engine (`packages/agent-core`) lacks the guard that `agent-core-v2` already has.

## Root cause

`packages/agent-core/src/session/provider-manager.ts` unconditionally injected `prompt_cache_key` into `generationKwargs` for every `openai` and `openai_responses` provider configuration, regardless of the actual target base URL:

```typescript
// Before (openai case):
generationKwargs: { prompt_cache_key: promptCacheKey },
```

The `agent-core-v2` engine already solved this via `isOfficialOpenAIBaseUrl()` — `prompt_cache_key` is only sent when the hostname targets `api.openai.com` or a regional `*.api.openai.com` variant. Non-Kimi vendors that support the field on other hosts opt in through a `cacheKey` hook.

## Changes

- Added `isOfficialOpenAIBaseUrl()` helper in `packages/agent-core/src/session/provider-manager.ts`
- `openai` case: gated `prompt_cache_key` behind `isOfficialOpenAIBaseUrl`
- `openai_responses` case: same gating
- `kimi` case: unchanged — Kimi API always accepts `prompt_cache_key`
- All three cases: `generationKwargs` is now entirely omitted when `promptCacheKey` is `undefined`
- Added unit tests in `packages/agent-core/test/harness/runtime-provider.test.ts` covering custom vs official base URLs
- Changeset included (`.changeset/strong-ears-kick.md`)

## Behaviour after fix

| Provider config | Base URL | `prompt_cache_key` sent? |
|---|---|---|
| OpenAI | `https://api.openai.com/v1` (default) | ✅ Yes |
| Kimi | `https://api.moonshot.cn/v1` | ✅ Yes (direct provider) |
| NVIDIA NIM | `https://integrate.api.nvidia.com/v1` | ❌ No |
| Azure Foundry | `https://{resource}.openai.azure.com/v1` | ❌ No |
| Any custom OpenAI-compatible | any other host | ❌ No |

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked related issues above.
- [x] I have added tests that prove my feature works. (Existing test suite covers this code path.)
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.