### PR TITLE
fix(agent-core): recover from unsupported image_url variants

### DIFF
--- a/.changeset/quiet-pandas-strip-media.md
+++ b/.changeset/quiet-pandas-strip-media.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Fix context compaction for text-only models by retrying rejected image content without media.

--- a/packages/agent-core-v2/src/kosong/contract/errors.ts
+++ b/packages/agent-core-v2/src/kosong/contract/errors.ts
@@ -229,6 +229,7 @@ const IMAGE_FORMAT_PROVIDER_MESSAGE_PATTERNS = [
 
 const IMAGE_FORMAT_STATUS_MESSAGE_PATTERNS = [
   /unsupported image (?:url|format|type)/,
+  /unknown variant [`'"]?image_url[`'"]?/,
   /does not represent a valid image/,
   /could not (?:process|decode) (?:the |input )?image/,
   /unable to process (?:the |input )?image/,

--- a/packages/agent-core-v2/test/agent/fullCompaction/fullCompaction.test.ts
+++ b/packages/agent-core-v2/test/agent/fullCompaction/fullCompaction.test.ts
@@ -649,7 +649,7 @@ describe('FullCompaction', () => {
       );
       if (hasMedia) {
         sawMedia = true;
-        throw new APIStatusError(400, 'unsupported image format: image/avif');
+        throw new APIStatusError(400, 'unknown variant image_url, expected text');
       }
       sawStrippedResend = true;
       return textResult('Recovered compacted summary.');

--- a/packages/agent-core-v2/test/kosong/contract/errors.test.ts
+++ b/packages/agent-core-v2/test/kosong/contract/errors.test.ts
@@ -22,6 +22,7 @@ import {
   classifyApiError,
   createAbortError,
   isAbortError,
+  isImageFormatError,
   isRetryableGenerateError,
   normalizeAPIStatusError,
   throwIfAbortError,
@@ -128,6 +129,17 @@ describe('isRetryableGenerateError', () => {
   it('does not retry deterministic client failures', () => {
     expect(isRetryableGenerateError(new APIStatusError(400, 'Bad request'))).toBe(false);
     expect(isRetryableGenerateError(new APIStatusError(401, 'Unauthorized'))).toBe(false);
+  });
+});
+
+describe('isImageFormatError', () => {
+  it('recognizes providers that reject the image_url content variant', () => {
+    const error = new APIStatusError(
+      400,
+      'messages[124]: unknown variant image_url, expected text at line 1 column 811568',
+    );
+
+    expect(isImageFormatError(error)).toBe(true);
   });
 });
 


### PR DESCRIPTION
## Related Issue

Resolve #2759

## Problem

During context compaction, text-only providers can reject retained image blocks with `unknown variant image_url, expected text`. This diagnostic was not classified as an image-format error, so the existing media-stripped retry did not run.

## What changed

- Recognize the provider diagnostic in `isImageFormatError`.
- Cover it in the classifier test and the full-compaction recovery test.
- Add a patch changeset for the CLI behavior fix.

Tests:
- `pnpm --filter @moonshot-ai/agent-core-v2 test -- test/kosong/contract/errors.test.ts test/agent/fullCompaction/fullCompaction.test.ts` (89 passed)
- `pnpm --filter @moonshot-ai/agent-core-v2 lint:imports`
- `pnpm --filter @moonshot-ai/agent-core-v2 typecheck`
- `pnpm exec oxlint` on the changed TypeScript files

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.