### PR TITLE
feat(hooks): include final assistant message in Stop payload

### DIFF
--- a/.changeset/bright-hooks-report.md
+++ b/.changeset/bright-hooks-report.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Include the final assistant message in Stop hook payloads.

--- a/docs/en/customization/hooks.md
+++ b/docs/en/customization/hooks.md
@@ -103,7 +103,7 @@ Only **blockable events** (`PreToolUse`, `Stop`, `UserPromptSubmit`) have return
 | `UserPromptSubmit` | The text submitted by the user | ✓ | Triggered when the user sends a message; returned text is appended to context; if blocked, the model is not called for this turn |
 | `UserPromptQueued` | The queued prompt text | — | Triggered when a message is queued while a turn is still running; the payload includes `prompt_id`, `prompt`, and `queue_length` (observation only) |
 | `PreToolUse` | Tool name | ✓ | Triggered before a tool call (before permission checks); the tool will not execute if blocked |
-| `Stop` | Empty string | ✓ | Triggered when the model is about to end the current turn; if blocked, a message can be appended to let the model continue |
+| `Stop` | Empty string | ✓ | Triggered when the model is about to end the current turn; the payload includes the final assistant text as `last_assistant_message`; if blocked, a message can be appended to let the model continue |
 | `TurnStarted` | Turn origin kind (e.g. `user`, `task`, `system_trigger`) | — | Triggered when a new turn begins; the payload includes `turn_id`, `origin_kind`, `origin_name`, and `prompt` (observation only) |
 | `PostToolUse` | Tool name | — | Triggered after a tool executes successfully (observation only) |
 | `PostToolUseFailure` | Tool name | — | Triggered after a tool fails or is blocked (observation only) |

--- a/docs/zh/customization/hooks.md
+++ b/docs/zh/customization/hooks.md
@@ -103,7 +103,7 @@ Hook 命令的工作目录是当前会话的项目目录。非 Windows 平台上
 | `UserPromptSubmit` | 用户提交的文本内容 | ✓ | 用户发送消息时触发；返回文本会附加到上下文；若阻断，本轮不调用模型 |
 | `UserPromptQueued` | 排队消息的文本内容 | — | 上一回合仍在运行、消息进入队列时触发；payload 含 `prompt_id`、`prompt` 和 `queue_length`（观察用） |
 | `PreToolUse` | 工具名 | ✓ | 工具调用前触发（权限检查前）；阻断后工具不会执行 |
-| `Stop` | 空字符串 | ✓ | 模型准备结束本轮时触发；阻断后可追加一条消息让模型继续 |
+| `Stop` | 空字符串 | ✓ | 模型准备结束本轮时触发；payload 通过 `last_assistant_message` 提供最后一条助手文本；阻断后可追加一条消息让模型继续 |
 | `TurnStarted` | 回合来源类型（如 `user`、`task`、`system_trigger`） | — | 新回合开始时触发；payload 含 `turn_id`、`origin_kind`、`origin_name` 和 `prompt`（观察用） |
 | `PostToolUse` | 工具名 | — | 工具成功执行后触发（观察用） |
 | `PostToolUseFailure` | 工具名 | — | 工具失败或被阻断后触发（观察用） |

--- a/packages/agent-core-v2/src/agent/externalHooks/externalHooksService.ts
+++ b/packages/agent-core-v2/src/agent/externalHooks/externalHooksService.ts
@@ -49,6 +49,7 @@ import type { ResolvedToolExecutionHookContext, ToolDidExecuteContext } from '#/
 import { denyToolExecution } from '#/agent/toolExecutor/beforeToolExecuteEvent';
 import { IAgentToolExecutorService } from '#/agent/toolExecutor/toolExecutor';
 import { toKimiErrorPayload } from '#/errors';
+import { extractText } from '#/kosong/contract/message';
 import { ISessionContext } from '#/session/sessionContext/sessionContext';
 import { ISessionMetadata } from '#/session/sessionMetadata/sessionMetadata';
 
@@ -426,11 +427,15 @@ export class AgentExternalHooksService extends Service implements IAgentExternal
   private async runStop(ctx: AfterStepContext): Promise<string | undefined> {
     ctx.signal.throwIfAborted();
     if (this.stopHookContinuationUsed) return undefined;
+    const lastAssistant = this.context.get().findLast((entry) => entry.role === 'assistant');
 
     const block = await this.runner.triggerBlock('Stop', {
       signal: ctx.signal,
       sessionId: this.sessionContext.sessionId,
-      inputData: this.withSessionFacts({ stopHookActive: false }),
+      inputData: this.withSessionFacts({
+        stopHookActive: false,
+        last_assistant_message: lastAssistant === undefined ? '' : extractText(lastAssistant),
+      }),
     });
     ctx.signal.throwIfAborted();
     return block?.reason;

--- a/packages/agent-core-v2/test/app/externalHooksRunner/integration.test.ts
+++ b/packages/agent-core-v2/test/app/externalHooksRunner/integration.test.ts
@@ -327,6 +327,12 @@ describe('IExternalHooksRunnerService integration', () => {
       ix.set(IAgentExternalHooksService, new SyncDescriptor(AgentExternalHooksService));
       ix.get(IAgentExternalHooksService);
       const eventBus = ix.get(IEventBus);
+      const finalAssistantMessage = 'release is ready';
+      context.append({
+        role: 'assistant',
+        content: [{ type: 'text', text: finalAssistantMessage }],
+        toolCalls: [],
+      });
 
       const signal = new AbortController().signal;
       const filtered: AfterStepContext = {
@@ -336,7 +342,7 @@ describe('IExternalHooksRunnerService integration', () => {
       await loop.hooks.onDidFinishStep.run(filtered);
       expect(loop.hasPendingRequests()).toBe(false);
       expect(stopInputs).toEqual([]);
-      expect(context.messages).toEqual([]);
+      expect(context.messages).toHaveLength(1);
 
       const first = makeAfterStep(signal);
       await loop.hooks.onDidFinishStep.run(first);
@@ -353,7 +359,12 @@ describe('IExternalHooksRunnerService integration', () => {
       const second = makeAfterStep(signal);
       await loop.hooks.onDidFinishStep.run(second);
       expect(loop.hasPendingRequests()).toBe(false);
-      expect(stopInputs).toEqual([{ stopHookActive: false }]);
+      expect(stopInputs).toEqual([
+        {
+          stopHookActive: false,
+          last_assistant_message: finalAssistantMessage,
+        },
+      ]);
 
       eventBus.publish({
         type: 'turn.ended',
@@ -373,7 +384,16 @@ describe('IExternalHooksRunnerService integration', () => {
         }),
       );
       expect(loop.drainNextBatch(context)).toBeDefined();
-      expect(stopInputs).toEqual([{ stopHookActive: false }, { stopHookActive: false }]);
+      expect(stopInputs).toEqual([
+        {
+          stopHookActive: false,
+          last_assistant_message: finalAssistantMessage,
+        },
+        {
+          stopHookActive: false,
+          last_assistant_message: finalAssistantMessage,
+        },
+      ]);
     } finally {
       ix?.dispose();
       disposables.dispose();

--- a/packages/agent-core/src/agent/turn/index.ts
+++ b/packages/agent-core/src/agent/turn/index.ts
@@ -8,6 +8,7 @@ import {
   APIProviderQuotaExhaustedError,
   APIStatusError,
   APITimeoutError,
+  extractText,
   inputTotal,
   isContextOverflowStatusError,
   type ContentPart,
@@ -942,9 +943,16 @@ export class TurnFlow {
               // 3. The external Stop hook gets exactly one continuation; the cap
               //    is intentionally separate from (and does not cap) goal mode.
               if (!stopHookContinuationUsed) {
+                const lastAssistant = this.agent.context.history.findLast(
+                  (entry) => entry.role === 'assistant',
+                );
                 const stopBlock = await this.agent.hooks?.triggerBlock('Stop', {
                   signal,
-                  inputData: { stopHookActive: stopHookContinuationUsed },
+                  inputData: {
+                    stopHookActive: stopHookContinuationUsed,
+                    last_assistant_message:
+                      lastAssistant === undefined ? '' : extractText(lastAssistant),
+                  },
                 });
                 signal.throwIfAborted();
                 if (stopBlock !== undefined) {

--- a/packages/agent-core/test/agent/turn.test.ts
+++ b/packages/agent-core/test/agent/turn.test.ts
@@ -1466,6 +1466,37 @@ describe('Agent turn flow', () => {
     expect(JSON.stringify(ctx.agent.context.data().history)).toContain('Second answer.');
   });
 
+  it('includes the final assistant message in the Stop hook payload', async () => {
+    const script = [
+      "let input='';",
+      "process.stdin.on('data',chunk=>input+=chunk);",
+      "process.stdin.on('end',()=>{",
+      'const payload=JSON.parse(input);',
+      "process.stdout.write(JSON.stringify({hookSpecificOutput:{permissionDecision:'deny',permissionDecisionReason:payload.last_assistant_message}}));",
+      '});',
+    ].join('');
+    const hookEngine = new HookEngine([
+      {
+        event: 'Stop',
+        command: `node -e ${JSON.stringify(script)}`,
+      },
+    ]);
+    const ctx = testAgent({ hookEngine });
+    ctx.configure();
+    ctx.mockNextResponse({ type: 'text', text: 'Final answer for the hook.' });
+    ctx.mockNextResponse({ type: 'text', text: 'Continued after the hook.' });
+
+    await ctx.rpc.prompt({ input: [{ type: 'text', text: 'hello' }] });
+    await ctx.untilTurnEnd();
+
+    expect(ctx.agent.context.data().history).toContainEqual({
+      role: 'user',
+      content: [{ type: 'text', text: 'Final answer for the hook.' }],
+      toolCalls: [],
+      origin: { kind: 'system_trigger', name: 'stop_hook' },
+    });
+  });
+
   it('cancels while waiting for a Stop hook', async () => {
     const dir = mkdtempSync(join(tmpdir(), 'kimi-stop-hook-'));
     const marker = join(dir, 'started');


### PR DESCRIPTION
## Related Issue

Resolve #2123

(Reopens the work from #2443, which I closed by mistake; that PR could not be reopened because the branch was force-pushed after rebasing onto current `main`.)

## Problem

Stop hooks cannot inspect the assistant response that is about to end the turn, so an integration using the Stop payload cannot show what Kimi said when the turn ended. The text lives in `wire.jsonl` but consumers should not have to parse the on-disk session log. Claude Code exposes `last_assistant_message` in its Stop hook for exactly this.

## What changed

- include the last assistant message's text in the Stop hook input as `last_assistant_message`, in both the v1 (`agent-core`) and v2 (`agent-core-v2`) Stop paths
- v2 keeps the field alongside the existing `withSessionFacts` enrichment
- cover the hook payload in `agent-core` `turn.test.ts` and the v2 `externalHooksRunner` integration test
- document the field in the English and Chinese hook references
- add a patch changeset

## Test verification (RED → GREEN)

Rebased onto current `main` (`01c74e9`). Source reverted to `main` = RED, source with the patch = GREEN.

```text
# agent-core — test/agent/turn.test.ts "includes the final assistant message in the Stop hook payload"
RED  (src = main): PASS (0) FAIL (1)  AssertionError: expected history to contain the final assistant text
GREEN (src = patch): PASS (83) FAIL (0)

# agent-core-v2 — integration.test.ts "limits external Stop hook continuations to once per active turn"
RED  (src = main): PASS (0) FAIL (1)  expected [{ sessionTitle: undefined }] to deeply equal [{ stopHookActive, last_assistant_message }]
GREEN (src = patch): PASS (25) FAIL (0)
```

Additional validation:

```text
pnpm --filter @moonshot-ai/agent-core    typecheck   # clean
pnpm --filter @moonshot-ai/agent-core-v2 typecheck   # clean
```

## Checklist

- [x] I have read the CONTRIBUTING document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.
