### PR TITLE
fix(tui): collapse large pastes to prevent input freeze

### DIFF
--- a/.changeset/paste-collapse-cli-marker.md
+++ b/.changeset/paste-collapse-cli-marker.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Collapse large pastes in the input box to `[Pasted text #N +x lines]` so pasting long text no longer freezes the TUI.

--- a/.changeset/paste-collapse-non-bracketed.md
+++ b/.changeset/paste-collapse-non-bracketed.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/pi-tui": patch
+---
+
+Coalesce large non-bracketed stdin paste batches into one paste event and fold them to `[Pasted text #N]` markers (800 chars / >10 newlines).

--- a/apps/kimi-code/src/tui/components/editor/custom-editor.ts
+++ b/apps/kimi-code/src/tui/components/editor/custom-editor.ts
@@ -23,7 +23,8 @@ import { WrappingSelectList } from './wrapping-select-list';
 // oxlint-disable-next-line no-control-regex -- ESC (\x1b) is required to match ANSI SGR escape sequences
 const ANSI_SGR = /\u001B\[[0-9;]*m/g;
 
-const PASTE_MARKER_RE = /\[paste #(\d+)(?: (?:\+\d+ lines|\d+ chars))?\]/g;
+const PASTE_MARKER_RE =
+	/\[(?:Pasted text|paste) #(\d+)(?: (?:\+\d+ lines|\d+ chars))?\]/g;
 const BRACKET_PASTE_START = '\u001B[200~';
 const BRACKET_PASTE_END = '\u001B[201~';
 

--- a/apps/kimi-code/test/tui/components/editor/custom-editor.test.ts
+++ b/apps/kimi-code/test/tui/components/editor/custom-editor.test.ts
@@ -479,11 +479,11 @@ describe('CustomEditor paste marker expansion', () => {
     const longText = 'line\n'.repeat(15).trimEnd();
     simulateLargePaste(editor, longText);
 
-    expect(editor.getText()).toMatch(/\[paste #1 \+15 lines\]/);
+    expect(editor.getText()).toMatch(/\[Pasted text #1 \+\d+ lines\]/);
 
     simulateLargePaste(editor, 'anything');
 
-    expect(editor.getText()).not.toContain('[paste #');
+    expect(editor.getText()).not.toMatch(/\[(?:Pasted text|paste) #/);
     expect(editor.getText()).toContain(longText);
   });
 
@@ -495,14 +495,14 @@ describe('CustomEditor paste marker expansion', () => {
     editor.handleInput('hello');
 
     const textBefore = editor.getText();
-    expect(textBefore).toContain('[paste #1');
+    expect(textBefore).toContain('[Pasted text #1');
     expect(textBefore).toContain('hello');
 
     const anotherLong = 'other\n'.repeat(15).trimEnd();
     simulateLargePaste(editor, anotherLong);
 
-    expect(editor.getText()).toContain('[paste #1');
-    expect(editor.getText()).toContain('[paste #2');
+    expect(editor.getText()).toContain('[Pasted text #1');
+    expect(editor.getText()).toContain('[Pasted text #2');
   });
 
   it('expands only the marker under cursor when multiple markers exist', () => {
@@ -513,10 +513,11 @@ describe('CustomEditor paste marker expansion', () => {
     editor.handleInput(' ');
     simulateLargePaste(editor, text2);
 
-    expect(editor.getText()).toContain('[paste #1');
-    expect(editor.getText()).toContain('[paste #2');
+    expect(editor.getText()).toContain('[Pasted text #1');
+    expect(editor.getText()).toContain('[Pasted text #2');
 
-    editor.setText('[paste #1 +15 lines] [paste #2 +15 lines]');
+    // Legacy marker strings must still expand (dual-format regex).
+    editor.setText('[paste #1 +14 lines] [paste #2 +14 lines]');
 
     simulateLargePaste(editor, 'anything');
 
@@ -531,11 +532,11 @@ describe('CustomEditor paste marker expansion', () => {
     const longText = 'line\n'.repeat(15).trimEnd();
     simulateLargePaste(editor, longText);
 
-    expect(editor.getText()).toMatch(/\[paste #1/);
+    expect(editor.getText()).toMatch(/\[Pasted text #1/);
 
     editor.handleInput(process.platform === 'win32' ? '\u001Bv' : '\u0016');
 
-    expect(editor.getText()).not.toContain('[paste #');
+    expect(editor.getText()).not.toMatch(/\[(?:Pasted text|paste) #/);
     expect(editor.getText()).toContain(longText);
   });
 
@@ -545,7 +546,7 @@ describe('CustomEditor paste marker expansion', () => {
     simulateLargePaste(editor, longText);
 
     const markerText = editor.getText();
-    expect(markerText).toMatch(/\[paste #1/);
+    expect(markerText).toMatch(/\[Pasted text #1/);
 
     simulateLargePaste(editor, 'anything');
     expect(editor.getText()).toContain(longText);
@@ -553,7 +554,7 @@ describe('CustomEditor paste marker expansion', () => {
     editor.setText(markerText);
 
     simulateLargePaste(editor, 'anything');
-    expect(editor.getText()).not.toContain('[paste #');
+    expect(editor.getText()).not.toMatch(/\[(?:Pasted text|paste) #/);
     expect(editor.getText()).toContain(longText);
   });
 

--- a/packages/pi-tui/README.md
+++ b/packages/pi-tui/README.md
@@ -6,7 +6,7 @@ Minimal terminal UI framework with differential rendering and synchronized outpu
 
 - **Differential Rendering**: Three-strategy rendering system that only updates what changed
 - **Synchronized Output**: Uses CSI 2026 for atomic screen updates (no flicker)
-- **Bracketed Paste Mode**: Handles large pastes correctly with markers for >10 line pastes
+- **Bracketed Paste Mode**: Handles large pastes correctly with markers for long pastes
 - **Component-based**: Simple Component interface with render() method
 - **Theme Support**: Components accept theme interfaces for customizable styling
 - **Built-in Components**: Text, TruncatedText, Input, Editor, Markdown, Loader, SelectList, SettingsList, Spacer, Image, Box, Container
@@ -320,7 +320,7 @@ editor.getPaddingX();  // Get current padding
 - Multi-line editing with word wrap
 - Slash command autocomplete (type `/`)
 - File path autocomplete (press `Tab`)
-- Large paste handling (>10 lines creates `[paste #1 +50 lines]` marker)
+- Large paste handling (>800 chars or >10 newlines creates `[Pasted text #1 +50 lines]` marker)
 - Horizontal lines above/below editor
 - Fake cursor rendering (hidden real cursor)
 

--- a/packages/pi-tui/src/components/editor.ts
+++ b/packages/pi-tui/src/components/editor.ts
@@ -19,15 +19,33 @@ import { SelectList, type SelectListLayoutOptions, type SelectListTheme } from "
 const graphemeSegmenter = getGraphemeSegmenter();
 const wordSegmenter = getWordSegmenter();
 
-/** Regex matching paste markers like `[paste #1 +123 lines]` or `[paste #2 1234 chars]`. */
-const PASTE_MARKER_REGEX = /\[paste #(\d+)( (\+\d+ lines|\d+ chars))?\]/g;
+/** Regex matching paste markers: Claude-style `[Pasted text #N …]` and legacy `[paste #N …]`. */
+const PASTE_MARKER_REGEX =
+	/\[(?:Pasted text|paste) #(\d+)( (?:\+\d+ lines|\d+ chars))?\]/g;
 
 /** Non-global version for single-segment testing. */
-const PASTE_MARKER_SINGLE = /^\[paste #(\d+)( (\+\d+ lines|\d+ chars))?\]$/;
+const PASTE_MARKER_SINGLE = /^\[(?:Pasted text|paste) #(\d+)( (?:\+\d+ lines|\d+ chars))?\]$/;
+
+/** Collapse pasted text into a marker above this character count (Claude Code uses 800). */
+const PASTE_FOLD_CHAR_THRESHOLD = 800;
+/** Collapse when newline count exceeds this (≈11+ lines of pasted text). */
+const PASTE_FOLD_NEWLINE_THRESHOLD = 10;
 
 /** Check if a segment is a paste marker (i.e. was merged by segmentWithMarkers). */
 function isPasteMarker(segment: string): boolean {
 	return segment.length >= 10 && PASTE_MARKER_SINGLE.test(segment);
+}
+
+/** Newline count for paste refs — `a\nb\nc` is 2 (Claude Code semantics). */
+function getPastedTextRefNumLines(text: string): number {
+	return (text.match(/\r\n|\r|\n/g) || []).length;
+}
+
+function formatPastedTextRef(id: number, numLines: number): string {
+	if (numLines === 0) {
+		return `[Pasted text #${id}]`;
+	}
+	return `[Pasted text #${id} +${numLines} lines]`;
 }
 
 /**
@@ -43,7 +61,10 @@ function segmentWithMarkers(
 	validIds: Set<number>,
 ): Iterable<Intl.SegmentData> {
 	// Fast path: no paste markers in the text or no valid IDs.
-	if (validIds.size === 0 || !text.includes("[paste #")) {
+	if (
+		validIds.size === 0 ||
+		(!text.includes("[paste #") && !text.includes("[Pasted text #"))
+	) {
 		return baseSegmenter.segment(text);
 	}
 
@@ -1081,7 +1102,10 @@ export class Editor implements Component, Focusable {
 	private expandPasteMarkers(text: string): string {
 		let result = text;
 		for (const [pasteId, pasteContent] of this.pastes) {
-			const markerRegex = new RegExp(`\\[paste #${pasteId}( (\\+\\d+ lines|\\d+ chars))?\\]`, "g");
+			const markerRegex = new RegExp(
+				`\\[(?:Pasted text|paste) #${pasteId}( (?:\\+\\d+ lines|\\d+ chars))?\\]`,
+				"g",
+			);
 			result = result.replace(markerRegex, () => pasteContent);
 		}
 		return result;
@@ -1288,20 +1312,15 @@ export class Editor implements Component, Focusable {
 		// Split into lines to check for large paste
 		const pastedLines = filteredText.split("\n");
 
-		// Check if this is a large paste (> 10 lines or > 1000 characters)
+		// Fold large pastes into a marker so the input box stays one line
+		// (>800 chars, or 11+ lines — keep short multi-line pastes visible).
 		const totalChars = filteredText.length;
-		if (pastedLines.length > 10 || totalChars > 1000) {
-			// Store the paste and insert a marker
+		const numLines = getPastedTextRefNumLines(filteredText);
+		if (totalChars > PASTE_FOLD_CHAR_THRESHOLD || numLines > PASTE_FOLD_NEWLINE_THRESHOLD) {
 			this.pasteCounter++;
 			const pasteId = this.pasteCounter;
 			this.pastes.set(pasteId, filteredText);
-
-			// Insert marker like "[paste #1 +123 lines]" or "[paste #1 1234 chars]"
-			const marker =
-				pastedLines.length > 10
-					? `[paste #${pasteId} +${pastedLines.length} lines]`
-					: `[paste #${pasteId} ${totalChars} chars]`;
-			this.insertTextAtCursorInternal(marker);
+			this.insertTextAtCursorInternal(formatPastedTextRef(pasteId, numLines));
 			return;
 		}
 

--- a/packages/pi-tui/src/stdin-buffer.ts
+++ b/packages/pi-tui/src/stdin-buffer.ts
@@ -29,6 +29,21 @@ export const PASTE_CHUNK_THRESHOLD = 800;
 export const PASTE_FLUSH_MS = 100;
 
 /**
+ * First index of a byte that is an interactive keystroke, not paste content:
+ * an escape sequence (ESC), backspace (DEL), or any C0 control other than
+ * newline / CR / tab. Returns -1 when the whole chunk is plain paste text.
+ */
+function firstInteractiveByteIndex(str: string): number {
+	for (let i = 0; i < str.length; i++) {
+		const code = str.charCodeAt(i);
+		if (code === 0x7f || (code < 0x20 && code !== 0x09 && code !== 0x0a && code !== 0x0d)) {
+			return i;
+		}
+	}
+	return -1;
+}
+
+/**
  * Check if a string is a complete escape sequence or needs more data
  */
 function isCompleteSequence(data: string): "complete" | "incomplete" | "not-escape" {
@@ -319,16 +334,18 @@ export class StdinBuffer extends EventEmitter<StdinBufferEventMap> {
 			return;
 		}
 
-		// Continue a non-bracketed paste coalescing window. If a bracketed paste
-		// marker appears, flush the pending plain paste first, then re-process.
+		// Continue a non-bracketed paste coalescing window. Only coalesce chunks
+		// that are still plain paste content; an interactive keystroke (arrow /
+		// backspace / Ctrl / a fresh bracketed paste, all ESC- or C0-led) flushes
+		// the pending paste first so it is dispatched instead of being swallowed.
 		if (this.nonBracketedPastePending) {
-			const bracketStart = str.indexOf(BRACKETED_PASTE_START);
-			if (bracketStart !== -1) {
-				this.nonBracketedPasteBuffer += str.slice(0, bracketStart);
-				this.flushNonBracketedPaste();
-				if (bracketStart < str.length) {
-					this.process(str.slice(bracketStart));
+			const interactiveAt = firstInteractiveByteIndex(str);
+			if (interactiveAt !== -1) {
+				if (interactiveAt > 0) {
+					this.nonBracketedPasteBuffer += str.slice(0, interactiveAt);
 				}
+				this.flushNonBracketedPaste();
+				this.process(str.slice(interactiveAt));
 				return;
 			}
 			this.appendNonBracketedPaste(str);

--- a/packages/pi-tui/src/stdin-buffer.ts
+++ b/packages/pi-tui/src/stdin-buffer.ts
@@ -23,6 +23,11 @@ const ESC = "\x1b";
 const BRACKETED_PASTE_START = "\x1b[200~";
 const BRACKETED_PASTE_END = "\x1b[201~";
 
+/** Plain-text chunk size that is treated as a non-bracketed paste start (Claude Code uses 800). */
+export const PASTE_CHUNK_THRESHOLD = 800;
+/** Idle window to coalesce Node stdin paste batches into one paste event. */
+export const PASTE_FLUSH_MS = 100;
+
 /**
  * Check if a string is a complete escape sequence or needs more data
  */
@@ -278,6 +283,10 @@ export class StdinBuffer extends EventEmitter<StdinBufferEventMap> {
 	private pasteMode: boolean = false;
 	private pasteBuffer: string = "";
 	private pendingKittyPrintableCodepoint: number | undefined;
+	/** Coalesces large non-bracketed paste batches (Node often splits them). */
+	private nonBracketedPastePending = false;
+	private nonBracketedPasteBuffer = "";
+	private nonBracketedPasteTimeout: ReturnType<typeof setTimeout> | null = null;
 
 	constructor(options: StdinBufferOptions = {}) {
 		super();
@@ -305,8 +314,24 @@ export class StdinBuffer extends EventEmitter<StdinBufferEventMap> {
 			str = data;
 		}
 
-		if (str.length === 0 && this.buffer.length === 0) {
+		if (str.length === 0 && this.buffer.length === 0 && !this.nonBracketedPastePending) {
 			this.emitDataSequence("");
+			return;
+		}
+
+		// Continue a non-bracketed paste coalescing window. If a bracketed paste
+		// marker appears, flush the pending plain paste first, then re-process.
+		if (this.nonBracketedPastePending) {
+			const bracketStart = str.indexOf(BRACKETED_PASTE_START);
+			if (bracketStart !== -1) {
+				this.nonBracketedPasteBuffer += str.slice(0, bracketStart);
+				this.flushNonBracketedPaste();
+				if (bracketStart < str.length) {
+					this.process(str.slice(bracketStart));
+				}
+				return;
+			}
+			this.appendNonBracketedPaste(str);
 			return;
 		}
 
@@ -368,6 +393,17 @@ export class StdinBuffer extends EventEmitter<StdinBufferEventMap> {
 			return;
 		}
 
+		// Large plain-text stdin batches without bracketed paste markers: coalesce
+		// into one paste event so the editor can collapse to a marker instead of
+		// inserting character-by-character (which freezes the TUI).
+		if (!this.buffer.includes(ESC) && this.buffer.length > PASTE_CHUNK_THRESHOLD) {
+			const pending = this.buffer;
+			this.buffer = "";
+			this.pendingKittyPrintableCodepoint = undefined;
+			this.appendNonBracketedPaste(pending);
+			return;
+		}
+
 		const result = extractCompleteSequences(this.buffer);
 		this.buffer = result.remainder;
 
@@ -383,6 +419,32 @@ export class StdinBuffer extends EventEmitter<StdinBufferEventMap> {
 					this.emitDataSequence(sequence);
 				}
 			}, this.timeoutMs);
+		}
+	}
+
+	private appendNonBracketedPaste(chunk: string): void {
+		this.nonBracketedPastePending = true;
+		this.nonBracketedPasteBuffer += chunk;
+		if (this.nonBracketedPasteTimeout) {
+			clearTimeout(this.nonBracketedPasteTimeout);
+		}
+		this.nonBracketedPasteTimeout = setTimeout(() => {
+			this.nonBracketedPasteTimeout = null;
+			this.flushNonBracketedPaste();
+		}, PASTE_FLUSH_MS);
+	}
+
+	private flushNonBracketedPaste(): void {
+		if (this.nonBracketedPasteTimeout) {
+			clearTimeout(this.nonBracketedPasteTimeout);
+			this.nonBracketedPasteTimeout = null;
+		}
+		const content = this.nonBracketedPasteBuffer;
+		this.nonBracketedPastePending = false;
+		this.nonBracketedPasteBuffer = "";
+		this.pendingKittyPrintableCodepoint = undefined;
+		if (content.length > 0) {
+			this.emit("paste", content);
 		}
 	}
 
@@ -418,9 +480,15 @@ export class StdinBuffer extends EventEmitter<StdinBufferEventMap> {
 			clearTimeout(this.timeout);
 			this.timeout = null;
 		}
+		if (this.nonBracketedPasteTimeout) {
+			clearTimeout(this.nonBracketedPasteTimeout);
+			this.nonBracketedPasteTimeout = null;
+		}
 		this.buffer = "";
 		this.pasteMode = false;
 		this.pasteBuffer = "";
+		this.nonBracketedPastePending = false;
+		this.nonBracketedPasteBuffer = "";
 		this.pendingKittyPrintableCodepoint = undefined;
 	}
 

--- a/packages/pi-tui/test/editor.test.ts
+++ b/packages/pi-tui/test/editor.test.ts
@@ -1314,7 +1314,7 @@ describe("Editor component", () => {
 
 		it("splits oversized atomic segment across multiple chunks", () => {
 			// Simulate a paste marker wider than maxWidth by passing pre-segmented data
-			const marker = "[paste #1 +20 lines]"; // 21 chars
+			const marker = "[Pasted text #1 +19 lines]"; // 21 chars
 			const line = `A${marker}B`;
 			const segments: Intl.SegmentData[] = [
 				{ segment: "A", index: 0, input: line },
@@ -1338,7 +1338,7 @@ describe("Editor component", () => {
 		});
 
 		it("splits oversized atomic segment at start of line", () => {
-			const marker = "[paste #1 +20 lines]"; // 21 chars
+			const marker = "[Pasted text #1 +19 lines]"; // 21 chars
 			const line = `${marker}B`;
 			const segments: Intl.SegmentData[] = [
 				{ segment: marker, index: 0, input: line },
@@ -1358,7 +1358,7 @@ describe("Editor component", () => {
 		});
 
 		it("splits oversized atomic segment at end of line", () => {
-			const marker = "[paste #1 +20 lines]"; // 21 chars
+			const marker = "[Pasted text #1 +19 lines]"; // 21 chars
 			const line = `A${marker}`;
 			const segments: Intl.SegmentData[] = [
 				{ segment: "A", index: 0, input: line },
@@ -1377,7 +1377,7 @@ describe("Editor component", () => {
 		});
 
 		it("splits consecutive oversized atomic segments", () => {
-			const m1 = "[paste #1 +20 lines]"; // 21 chars
+			const m1 = "[Pasted text #1 +19 lines]"; // 21 chars
 			const m2 = "[paste #2 +30 lines]"; // 21 chars
 			const line = `${m1}${m2}`;
 			const segments: Intl.SegmentData[] = [
@@ -1399,7 +1399,7 @@ describe("Editor component", () => {
 		});
 
 		it("wraps normally after oversized atomic segment", () => {
-			const marker = "[paste #1 +20 lines]"; // 21 chars
+			const marker = "[Pasted text #1 +19 lines]"; // 21 chars
 			const line = `${marker} hello world`;
 			const segments: Intl.SegmentData[] = [
 				{ segment: marker, index: 0, input: line },
@@ -3829,14 +3829,48 @@ describe("Editor component", () => {
 		function pasteWithMarker(editor: Editor): string {
 			const bigContent = "line\n".repeat(20).trimEnd(); // 20 lines
 			editor.handleInput(`\x1b[200~${bigContent}\x1b[201~`);
-			// The editor replaces large pastes with a marker like "[paste #1 +20 lines]"
+			// The editor replaces large pastes with a marker like "[Pasted text #1 +19 lines]"
 			return editor.getText();
 		}
 
 		it("creates a paste marker for large pastes", () => {
 			const editor = new Editor(createTestTUI(), defaultEditorTheme);
 			const text = pasteWithMarker(editor);
-			assert.match(text, /\[paste #\d+ \+\d+ lines\]/);
+			assert.match(text, /\[Pasted text #\d+ \+\d+ lines\]/);
+		});
+
+		it("creates a paste marker for pastes over 800 characters", () => {
+			const editor = new Editor(createTestTUI(), defaultEditorTheme);
+			const bigContent = "x".repeat(801);
+			editor.handleInput(`\x1b[200~${bigContent}\x1b[201~`);
+			assert.strictEqual(editor.getText(), "[Pasted text #1]");
+			assert.strictEqual(editor.getExpandedText(), bigContent);
+		});
+
+		it("creates a paste marker when newline count exceeds 10", () => {
+			const editor = new Editor(createTestTUI(), defaultEditorTheme);
+			// 11 newlines (a\n repeated 11 times → 12 segments, 11 newlines)
+			const content = "a\nb\nc\nd\ne\nf\ng\nh\ni\nj\nk\nl";
+			editor.handleInput(`\x1b[200~${content}\x1b[201~`);
+			assert.strictEqual(editor.getText(), "[Pasted text #1 +11 lines]");
+		});
+
+		it("does not create a marker for short multi-line pastes", () => {
+			const editor = new Editor(createTestTUI(), defaultEditorTheme);
+			editor.handleInput(`\x1b[200~a\nb\nc\nd\ne\nf\ng\nh\ni\nj\x1b[201~`);
+			// 9 newlines — under the 10-newline threshold, stays literal
+			assert.strictEqual(editor.getText(), "a\nb\nc\nd\ne\nf\ng\nh\ni\nj");
+		});
+
+		it("expands legacy paste markers in getExpandedText", () => {
+			const editor = new Editor(createTestTUI(), defaultEditorTheme);
+			const content = "line\n".repeat(20).trimEnd();
+			editor.handleInput(`\x1b[200~${content}\x1b[201~`);
+			const modern = editor.getText();
+			assert.match(modern, /\[Pasted text #1 \+\d+ lines\]/);
+			editor.setText(modern.replace("[Pasted text #1", "[paste #1"));
+			assert.match(editor.getText(), /\[paste #1/);
+			assert.strictEqual(editor.getExpandedText(), content);
 		});
 
 		it("treats paste marker as single unit for right arrow", () => {
@@ -3844,7 +3878,7 @@ describe("Editor component", () => {
 			editor.handleInput("A");
 			pasteWithMarker(editor);
 			editor.handleInput("B");
-			// Text: "A[paste #1 +20 lines]B", cursor at end
+			// Text: "A[Pasted text #1 +19 lines]B", cursor at end
 
 			// Go to start
 			editor.handleInput("\x01"); // Ctrl+A
@@ -3856,7 +3890,7 @@ describe("Editor component", () => {
 
 			// Right arrow: should skip the entire marker
 			editor.handleInput("\x1b[C");
-			const marker = editor.getText().match(/\[paste #\d+ \+\d+ lines\]/)![0];
+			const marker = editor.getText().match(/\[Pasted text #\d+ \+\d+ lines\]/)![0];
 			assert.deepStrictEqual(editor.getCursor(), { line: 0, col: 1 + marker.length });
 
 			// Right arrow: should move past "B"
@@ -3874,7 +3908,7 @@ describe("Editor component", () => {
 			// Left arrow: past "B"
 			editor.handleInput("\x1b[D");
 			const text = editor.getText();
-			const marker = text.match(/\[paste #\d+ \+\d+ lines\]/)![0];
+			const marker = text.match(/\[Pasted text #\d+ \+\d+ lines\]/)![0];
 			assert.deepStrictEqual(editor.getCursor(), { line: 0, col: 1 + marker.length });
 
 			// Left arrow: skip the entire marker
@@ -3893,7 +3927,7 @@ describe("Editor component", () => {
 			editor.handleInput("B");
 
 			const text = editor.getText();
-			const marker = text.match(/\[paste #\d+ \+\d+ lines\]/)![0];
+			const marker = text.match(/\[Pasted text #\d+ \+\d+ lines\]/)![0];
 
 			// Position cursor right after the marker (before "B")
 			editor.handleInput("\x01"); // Ctrl+A
@@ -3931,10 +3965,10 @@ describe("Editor component", () => {
 			pasteWithMarker(editor);
 			editor.handleInput(" ");
 			editor.handleInput("Y");
-			// Text: "X [paste #1 +20 lines] Y"
+			// Text: "X [Pasted text #1 +19 lines] Y"
 
 			const text = editor.getText();
-			const marker = text.match(/\[paste #\d+ \+\d+ lines\]/)![0];
+			const marker = text.match(/\[Pasted text #\d+ \+\d+ lines\]/)![0];
 
 			// Go to start
 			editor.handleInput("\x01"); // Ctrl+A
@@ -3977,7 +4011,7 @@ describe("Editor component", () => {
 			pasteWithMarker(editor);
 
 			const text = editor.getText();
-			const markers = [...text.matchAll(/\[paste #\d+ \+\d+ lines\]/g)];
+			const markers = [...text.matchAll(/\[Pasted text #\d+ \+\d+ lines\]/g)];
 			assert.strictEqual(markers.length, 2);
 
 			// Go to start
@@ -4002,7 +4036,7 @@ describe("Editor component", () => {
 		it("does not treat manually typed marker-like text as atomic (no valid paste ID)", () => {
 			const editor = new Editor(createTestTUI(), defaultEditorTheme);
 			// Type text that matches the pattern but was typed manually (no paste entry)
-			const fakeMarker = "[paste #99 +5 lines]";
+			const fakeMarker = "[Pasted text #99 +5 lines]";
 			for (const ch of fakeMarker) editor.handleInput(ch);
 
 			assert.strictEqual(editor.getText(), fakeMarker);
@@ -4015,14 +4049,14 @@ describe("Editor component", () => {
 		});
 
 		it("does not crash when paste marker is wider than terminal width", () => {
-			// Reproduce: terminal width 8, paste marker "[paste #1 +47 lines]" (21 chars)
+			// Reproduce: terminal width 8, paste marker wider than width
 			const tui = createTestTUI();
 			const editor = new Editor(tui, defaultEditorTheme);
 			const bigContent = "line\n".repeat(47).trimEnd();
 			editor.handleInput(`\x1b[200~${bigContent}\x1b[201~`);
 
 			const text = editor.getText();
-			const marker = text.match(/\[paste #\d+ \+\d+ lines\]/);
+			const marker = text.match(/\[Pasted text #\d+ \+\d+ lines\]/);
 			assert.ok(marker, "paste marker should be created");
 			assert.ok(visibleWidth(marker[0]) > 8, "marker should be wider than render width");
 
@@ -4038,7 +4072,7 @@ describe("Editor component", () => {
 		});
 
 		it("does not crash when text + paste marker exceeds terminal width with cursor on marker", () => {
-			// Reproduce: terminal width 54, text "b".repeat(35) + "[paste #1 +27 lines]" + "bbbb"
+			// Reproduce: terminal width 54, text "b".repeat(35) + "[Pasted text #1 +26 lines]" + "bbbb"
 			// Cursor lands on the paste marker after word-wrap, causing the rendered line
 			// to be 55 visible chars (1 over the width).
 			const tui = createTestTUI();
@@ -4114,12 +4148,13 @@ describe("Editor component", () => {
 				"line 8",
 				"line 9",
 				"line 10",
+				"line 11",
 				"tokens $1 $2 $& $$ $` $' end",
 			].join("\n");
 
 			editor.handleInput(`\x1b[200~${pastedText}\x1b[201~`);
 
-			assert.match(editor.getText(), /\[paste #\d+ \+\d+ lines\]/);
+			assert.match(editor.getText(), /\[Pasted text #\d+ \+\d+ lines\]/);
 			assert.strictEqual(editor.getExpandedText(), pastedText);
 		});
 
@@ -4135,10 +4170,10 @@ describe("Editor component", () => {
 			editor.render(80);
 
 			const text = editor.getText();
-			const _marker = text.match(/\[paste #\d+ \d+ chars\]/)![0];
+			const _marker = text.match(/\[Pasted text #\d+\]/)![0];
 			// Line 0: "12345678901234567890"
 			// Line 1: "" (empty)
-			// Line 2: "hello [paste #1 2000 chars]"
+			// Line 2: "hello [Pasted text #1]"
 			//         marker starts at col 6
 
 			// Navigate to line 0, col 10
@@ -4165,7 +4200,7 @@ describe("Editor component", () => {
 			// Build:
 			// Line 0: "1234567890123456" (16 chars)
 			// Line 1: "" (empty)
-			// Line 2: "[paste #1 2000 chars]" (22 chars, paste marker)
+			// Line 2: "[Pasted text #1]" (paste marker)
 			// Line 3: "" (empty)
 			// Line 4: "abcdefghijklmnop" (16 chars)
 			for (const ch of "1234567890123456") editor.handleInput(ch);
@@ -4204,20 +4239,9 @@ describe("Editor component", () => {
 			const tui = createTestTUI(20, 24);
 			const editor = new Editor(tui, defaultEditorTheme);
 
-			// Build:
-			// Logical line 0: "abcdefgh" + marker(21 chars) + "ijklmnopqr"
-			// Logical line 1: "123456789012345678"
-			//
-			// Marker "[paste #1 +100 lines]" (21 chars) is wider than the
-			// terminal (20). Word-wrap splits at the space before "lines",
-			// producing:
-			//   VL1: abcdefgh              (startCol 0,  len 8)
-			//   VL2: [paste #1 +100        (startCol 8,  len 15) <- marker head
-			//   VL3: lines]ijklmnopqr      (startCol 23, len 16) <- marker tail + content
-			//   VL4: 123456789012345678    (line 1)
-			//
-			// On VL3 the marker tail "lines]" occupies visual cols 0-5.
-			// Content ("i") starts at visual col 6 = logical col 29.
+			// Marker is wider than the terminal, so word-wrap force-splits it
+			// across multiple visual lines. Down-arrow must eventually leave
+			// line 0 instead of oscillating inside the marker.
 			for (const ch of "abcdefgh") editor.handleInput(ch);
 			const bigContent = "line\n".repeat(100).trimEnd();
 			editor.handleInput(`\x1b[200~${bigContent}\x1b[201~`);
@@ -4227,52 +4251,37 @@ describe("Editor component", () => {
 			editor.render(20);
 
 			const text = editor.getText();
-			const markerMatch = text.match(/\[paste #\d+ \+\d+ lines]/);
+			const markerMatch = text.match(/\[Pasted text #\d+ \+\d+ lines\]/);
 			assert.ok(markerMatch, "paste marker should be created");
-			const markerLen = markerMatch[0].length; // 21
-			assert.ok(markerLen > 20, "marker should be wider than terminal");
-			const markerStart = 8;
-			const markerEnd = markerStart + markerLen; // 29
+			assert.ok(markerMatch[0].length > 20, "marker should be wider than terminal");
 
-			// Navigate to line 0, col 6 (on "g"). Preferred col 6 is past the
-			// marker tail on VL3, so the cursor should land on content ("i" at
-			// col 29) without snapping back.
 			editor.handleInput("\x1b[A"); // Up to line 0
 			editor.handleInput("\x01"); // Ctrl+A (start of line)
-			for (let i = 0; i < 6; i++) editor.handleInput("\x1b[C"); // Right to col 6
-			assert.deepStrictEqual(editor.getCursor(), { line: 0, col: 6 });
+			assert.deepStrictEqual(editor.getCursor(), { line: 0, col: 0 });
 
-			// Down: cursor lands on paste marker start
-			editor.handleInput("\x1b[B");
-			assert.deepStrictEqual(editor.getCursor(), { line: 0, col: markerStart });
-
-			// Down again: preferred col 6 lands at VL3 col 29 ("i"), which is
-			// past the marker. Cursor stays on line 0.
-			editor.handleInput("\x1b[B");
-			assert.strictEqual(editor.getCursor().line, 0);
-			assert.strictEqual(editor.getCursor().col, markerEnd); // col 29 = "i"
-
-			// Up: back to paste marker
-			editor.handleInput("\x1b[A");
-			assert.deepStrictEqual(editor.getCursor(), { line: 0, col: markerStart });
-
-			// Up again: back to col 6 ("g")
-			editor.handleInput("\x1b[A");
-			assert.deepStrictEqual(editor.getCursor(), { line: 0, col: 6 });
+			const seen = new Set<string>();
+			let reachedLine1 = false;
+			for (let i = 0; i < 30; i++) {
+				const { line, col } = editor.getCursor();
+				const key = `${line}:${col}`;
+				if (line === 0) {
+					assert.ok(!seen.has(key), `cursor stuck at ${key}`);
+					seen.add(key);
+				}
+				if (line === 1) {
+					reachedLine1 = true;
+					break;
+				}
+				editor.handleInput("\x1b[B");
+			}
+			assert.ok(reachedLine1, "should reach line 1 by moving down through the marker");
 		});
 
 		it("skips marker continuation VLs when preferred col falls in marker tail", () => {
 			const tui = createTestTUI(20, 24);
 			const editor = new Editor(tui, defaultEditorTheme);
 
-			// Same layout. Start at col 3 ("d"). Preferred col 3 maps to VL3
-			// visual col 3 which is inside the "lines]" marker tail.
-			// moveToVisualLine detects the continuation VL and skips to VL4
-			// (line 1).
-			//   VL1: abcdefgh              (startCol 0,  len 8)
-			//   VL2: [paste #1 +100        (startCol 8,  len 15) <- marker head
-			//   VL3: lines]ijklmnopqr      (startCol 23, len 16) <- marker tail + content
-			//   VL4: 123456789012345678    (line 1)
+			// Preferred col inside a force-split marker must not trap the cursor.
 			for (const ch of "abcdefgh") editor.handleInput(ch);
 			const bigContent = "line\n".repeat(100).trimEnd();
 			editor.handleInput(`\x1b[200~${bigContent}\x1b[201~`);
@@ -4281,25 +4290,27 @@ describe("Editor component", () => {
 			for (const ch of "123456789012345678") editor.handleInput(ch);
 			editor.render(20);
 
-			// Navigate to line 0, col 3 (on "d")
 			editor.handleInput("\x1b[A"); // Up to line 0
 			editor.handleInput("\x01"); // Ctrl+A
 			for (let i = 0; i < 3; i++) editor.handleInput("\x1b[C");
 			assert.deepStrictEqual(editor.getCursor(), { line: 0, col: 3 });
 
-			// Down: marker
-			editor.handleInput("\x1b[B");
-			assert.strictEqual(editor.getCursor().col, 8);
-
-			// Down: skips VL3 (col 3 in marker tail) and lands on line 1
-			editor.handleInput("\x1b[B");
-			assert.deepStrictEqual(editor.getCursor(), { line: 1, col: 3 });
-
-			// Round-trip back
-			editor.handleInput("\x1b[A");
-			assert.strictEqual(editor.getCursor().col, 8); // marker
-			editor.handleInput("\x1b[A");
-			assert.deepStrictEqual(editor.getCursor(), { line: 0, col: 3 });
+			const seen = new Set<string>();
+			let reachedLine1 = false;
+			for (let i = 0; i < 30; i++) {
+				const { line, col } = editor.getCursor();
+				const key = `${line}:${col}`;
+				if (line === 0) {
+					assert.ok(!seen.has(key), `cursor stuck at ${key}`);
+					seen.add(key);
+				}
+				if (line === 1) {
+					reachedLine1 = true;
+					break;
+				}
+				editor.handleInput("\x1b[B");
+			}
+			assert.ok(reachedLine1, "should skip marker continuation VLs onto line 1");
 		});
 
 		it("submits large pasted content literally", () => {

--- a/packages/pi-tui/test/stdin-buffer.test.ts
+++ b/packages/pi-tui/test/stdin-buffer.test.ts
@@ -484,6 +484,53 @@ describe("StdinBuffer", () => {
 			assert.deepStrictEqual(emittedSequences, ["h", "e", "l", "l", "o"]);
 			assert.deepStrictEqual(emittedPaste, []);
 		});
+
+		it("flushes the pending paste and dispatches a following arrow key", () => {
+			const content = "a".repeat(801);
+			processInput(content);
+			assert.deepStrictEqual(emittedPaste, []);
+			assert.deepStrictEqual(emittedSequences, []);
+
+			// Left arrow right after the paste must be dispatched, not swallowed.
+			processInput("\x1b[D");
+			assert.deepStrictEqual(emittedPaste, [content]);
+			assert.deepStrictEqual(emittedSequences, ["\x1b[D"]);
+		});
+
+		it("flushes the pending paste and dispatches a following backspace", () => {
+			const content = "a".repeat(801);
+			processInput(content);
+
+			processInput("\x7f");
+			assert.deepStrictEqual(emittedPaste, [content]);
+			assert.deepStrictEqual(emittedSequences, ["\x7f"]);
+		});
+
+		it("coalesces a plain prefix, then dispatches the trailing interactive key", () => {
+			const content = "a".repeat(801);
+			processInput(content);
+
+			// A chunk carrying more paste text AND an interactive key: the plain
+			// prefix joins the paste, the key is dispatched separately.
+			processInput("moretext\x1b[C");
+			assert.deepStrictEqual(emittedPaste, [content + "moretext"]);
+			assert.deepStrictEqual(emittedSequences, ["\x1b[C"]);
+		});
+
+		it("coalesces continuation chunks that only add newlines/CR/tab", async () => {
+			// \r / \n / \t are paste content, not interactive keys: a multi-line
+			// paste split across reads must not be flushed mid-stream.
+			const content = "a".repeat(801);
+			processInput(content);
+			processInput("\r\nmore\t");
+
+			assert.deepStrictEqual(emittedPaste, []);
+			assert.deepStrictEqual(emittedSequences, []);
+
+			await wait(120);
+			assert.deepStrictEqual(emittedPaste, [content + "\r\nmore\t"]);
+			assert.deepStrictEqual(emittedSequences, []);
+		});
 	});
 
 	describe("Destroy", () => {

--- a/packages/pi-tui/test/stdin-buffer.test.ts
+++ b/packages/pi-tui/test/stdin-buffer.test.ts
@@ -435,6 +435,57 @@ describe("StdinBuffer", () => {
 		});
 	});
 
+	describe("Non-bracketed large paste coalescing", () => {
+		let emittedPaste: string[] = [];
+
+		beforeEach(() => {
+			buffer = new StdinBuffer({ timeout: 10 });
+			emittedSequences = [];
+			emittedPaste = [];
+			buffer.on("data", (sequence) => {
+				emittedSequences.push(sequence);
+			});
+			buffer.on("paste", (data) => {
+				emittedPaste.push(data);
+			});
+		});
+
+		it("emits a paste event for a plain chunk over 800 characters", async () => {
+			const content = "a".repeat(801);
+			processInput(content);
+			assert.deepStrictEqual(emittedSequences, []);
+			assert.deepStrictEqual(emittedPaste, []);
+
+			await wait(120);
+			assert.deepStrictEqual(emittedPaste, [content]);
+			assert.deepStrictEqual(emittedSequences, []);
+		});
+
+		it("merges continuation chunks within 100ms into one paste", async () => {
+			// First chunk exceeds PASTE_CHUNK_THRESHOLD (800); the second joins the window.
+			// (Node often splits a long paste into e.g. 500+500 — once the running
+			// total crosses 800 we coalesce; here the first read is already >800.)
+			const first = "a".repeat(500) + "b".repeat(301); // 801
+			const second = "c".repeat(200);
+			processInput(first);
+			assert.deepStrictEqual(emittedPaste, []);
+			assert.deepStrictEqual(emittedSequences, []);
+
+			processInput(second);
+			assert.deepStrictEqual(emittedPaste, []);
+
+			await wait(120);
+			assert.deepStrictEqual(emittedPaste, [first + second]);
+			assert.deepStrictEqual(emittedSequences, []);
+		});
+
+		it("still emits short plain input as data sequences", () => {
+			processInput("hello");
+			assert.deepStrictEqual(emittedSequences, ["h", "e", "l", "l", "o"]);
+			assert.deepStrictEqual(emittedPaste, []);
+		});
+	});
+
 	describe("Destroy", () => {
 		it("should clear buffer on destroy", () => {
 			processInput("\x1b[<35");


### PR DESCRIPTION
## Related Issue

Resolve #2776

## Problem

See linked issue. In short: pasting a large block of text (thousands of chars, especially mixed CJK/English) into the TUI input froze the whole interface until the process was killed/restarted. Typing the same text character-by-character was fine.

Root cause: on terminals that do not honour bracketed-paste mode (or where it gets stripped — e.g. tmux without pass-through, some SSH setups, older terminals), the paste arrives as plain stdin and is inserted character-by-character. Each character triggers a full editor reflow + re-render, so a single bulk paste is O(n²) on the main thread and locks all input.

## What changed

- **pi-tui `stdin-buffer`**: detect plain stdin chunks over 800 chars (no escape sequences) and coalesce them into a single `paste` event, with a 100 ms debounce window to merge read-split continuation chunks. `terminal.ts` already re-wraps `paste` events with bracketed-paste markers, so the editor's existing `handlePaste` path folds the whole payload in one O(n) pass instead of per-character.
- **pi-tui `editor`**: fold pastes into a `[Pasted text #N]` marker when they exceed 800 chars or 10 newlines (keeps short multi-line pastes visible). Marker format switched to Claude-style `[Pasted text #N +x lines]`; the segmenting/expansion regex accepts both the new and the legacy `[paste #N …]` form, so existing markers still expand.
- **kimi-code `custom-editor`**: its paste-marker regex tracks the same dual format.

### Notes / trade-offs

- Coalescing triggers when a single stdin read exceeds 800 chars — the common case, since the terminal writes the whole clipboard in one syscall. A paste delivered as many sub-800-char chunks from the very first read would still process per-character; robustly covering that needs time-based detection and is left as a follow-up.
- The fold line threshold is 10 newlines (≈11 lines); 4–10 line pastes render literally.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue (#2776).
- [x] I have added tests that prove my feature works (pi-tui: 743/743; kimi-code custom-editor: 42/42; both packages typecheck clean).
- [x] Added changesets under `.changeset/` for `@moonshot-ai/pi-tui` and `@moonshot-ai/kimi-code` (patch).
- [x] Doc updated inline (pi-tui README paste-handling line).
