### PR TITLE
docs: clarify kimi-cli migration path

### DIFF
--- a/docs/en/guides/migration.md
+++ b/docs/en/guides/migration.md
@@ -6,6 +6,19 @@ Kimi Code CLI has gone through a major version upgrade — moving from Python/uv
 
 If you are migrating from the legacy version, follow the steps below — a single command migrates your config, MCP servers, and session history to the new version.
 
+## Which CLI should I use?
+
+`kimi-cli` and Kimi Code CLI are two generations of the terminal coding agent from the same team. For a new installation, use Kimi Code CLI. `kimi-cli` remains available for existing installations while that project is gradually wound down.
+
+| | `kimi-cli` | Kimi Code CLI |
+| --- | --- | --- |
+| Status | Earlier implementation, kept available for existing installations | Current generation, recommended for new installations |
+| Implementation | Python application installed with `uv` | TypeScript/Node.js codebase distributed as a standalone binary; users do not need to install Node.js |
+| Data directory | `~/.kimi/` | `~/.kimi-code/` |
+| Migration role | Source of supported config and optional session data | Destination for data imported by `kimi migrate` |
+
+Kimi Code CLI is a separate implementation, not an in-place update of the Python package. The migration command copies supported data into the new data directory without changing or deleting your `kimi-cli` data.
+
 ## What's new
 
 - **No more Python / uv**: Rebuilt on Node.js — no Python environment needed, simpler to install

--- a/docs/zh/guides/migration.md
+++ b/docs/zh/guides/migration.md
@@ -6,6 +6,19 @@ Kimi Code CLI 已完成重大版本升级，底层从 Python/uv 迁移至 Node.j
 
 如果你正在从旧版迁移，按照以下步骤操作——一条命令就能把配置、MCP server 与会话历史一并迁移至新版。
 
+## 应该使用哪个 CLI？
+
+`kimi-cli` 和 Kimi Code CLI 是同一团队推出的两代终端编程 Agent。全新安装时应选择 Kimi Code CLI；`kimi-cli` 仍可供已有安装继续使用，但该项目将逐步停止维护。
+
+| | `kimi-cli` | Kimi Code CLI |
+| --- | --- | --- |
+| 状态 | 较早的实现，继续供已有安装使用 | 当前一代，推荐用于全新安装 |
+| 实现方式 | Python 应用，通过 `uv` 安装 | TypeScript/Node.js 代码库，以独立二进制形式交付；用户无需安装 Node.js |
+| 数据目录 | `~/.kimi/` | `~/.kimi-code/` |
+| 迁移角色 | 提供受支持的配置和可选会话数据 | 通过 `kimi migrate` 接收导入的数据 |
+
+Kimi Code CLI 是独立实现，并非 Python 软件包的原地更新。迁移命令会把受支持的数据复制到新的数据目录，不会改动或删除 `kimi-cli` 的数据。
+
 ## 新版优势
 
 - **不再依赖 Python / uv**：基于 Node.js 重写，无需配置 Python 环境，安装更简单


### PR DESCRIPTION
## Related Issue

Resolve #129

## Problem

The migration guide explains how to move from kimi-cli, but it does not directly answer which CLI new users should choose or distinguish the source implementation from the end-user runtime requirements.

## What changed

- recommends Kimi Code CLI for new installations and describes kimi-cli's current role
- compares implementation, distribution, data directories, and migration roles
- clarifies that Kimi Code CLI is a separate implementation distributed as a standalone binary
- keeps the English and Chinese guides in sync

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works. (Documentation-only change; verified with `pnpm -C docs run build`.)
- [x] Ran `gen-changesets` skill, or this PR needs no changeset. (Documentation-only change.)
- [x] Ran `gen-docs` skill, or this PR needs no doc update. (Both locales updated; the changelog sync helper is absent from current `main` and is not applicable to this guide-only change.)

## Verification

- Node.js 24.15.0
- pnpm 10.33.0
- `pnpm -C docs run build`
- `git diff --check`
