### PR TITLE
feat(tui): restore prompt to input box on pre-reply Esc cancel

### DIFF
--- a/.changeset/editor-remove-last-history.md
+++ b/.changeset/editor-remove-last-history.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/pi-tui": patch
+---
+
+Add an optional `removeLastFromHistory(expected?)` method to the Editor to drop the most recent input-history entry.

--- a/.changeset/esc-restore-draft-on-cancel.md
+++ b/.changeset/esc-restore-draft-on-cancel.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Pressing Esc to cancel a turn before any model output (text or tool call) restores the prompt to the input box instead of showing "Interrupted by user".

--- a/apps/kimi-code/src/tui/commands/undo.ts
+++ b/apps/kimi-code/src/tui/commands/undo.ts
@@ -77,6 +77,11 @@ export async function handleUndoCommand(
   await undoByCount(host, count);
 }
 
+/** Undo the most recent user turn (context + transcript UI). Used by `/undo` and ESC draft restore. */
+export async function undoLastUserTurn(host: SlashCommandHost): Promise<boolean> {
+  return undoByCount(host, 1);
+}
+
 async function undoByCount(host: SlashCommandHost, count: number): Promise<boolean> {
   const session = host.session;
   if (session === undefined) {

--- a/apps/kimi-code/src/tui/controllers/session-event-handler.ts
+++ b/apps/kimi-code/src/tui/controllers/session-event-handler.ts
@@ -168,8 +168,6 @@ export class SessionEventHandler {
   private goalCompletionTurnEnded = false;
   /** Non-empty assistant text or any tool call this turn — blocks ESC draft restore. */
   private currentTurnHasMeaningfulOutput = false;
-  /** Armed by user-cancel with no meaningful output; consumed on turn.ended. */
-  private pendingDraftRestore = false;
   private pluginCommandTurns: Map<string, string> = new Map();
   private pluginMcpToolsUsedInTurn: Set<string> = new Set();
   private pendingModelBlockedFallback: GoalChange | undefined;
@@ -188,7 +186,6 @@ export class SessionEventHandler {
     this.goalCompletionAwaitingClear = false;
     this.goalCompletionTurnEnded = false;
     this.currentTurnHasMeaningfulOutput = false;
-    this.pendingDraftRestore = false;
     this.pluginCommandTurns.clear();
     this.pluginMcpToolsUsedInTurn.clear();
     this.pendingModelBlockedFallback = undefined;
@@ -328,7 +325,6 @@ export class SessionEventHandler {
 
   private handleTurnBegin(event: TurnStartedEvent): void {
     this.currentTurnHasMeaningfulOutput = false;
-    this.pendingDraftRestore = false;
     if (event.origin?.kind === 'plugin_command') {
       this.pluginCommandTurns.set(String(event.turnId), event.origin.pluginId);
     }
@@ -383,10 +379,12 @@ export class SessionEventHandler {
     this.host.streamingUI.finalizeTurn(sendQueued);
     this.host.recordSessionActivity();
     this.renderPendingModelBlockedFallback();
-    const shouldRestoreDraft =
-      event.reason === 'cancelled' && this.pendingDraftRestore && !this.currentTurnHasMeaningfulOutput;
+    // A cancelled turn with no meaningful output and a stashed draft is eligible
+    // for ESC draft restore — including early cancels that reach turn.ended with
+    // no prior turn.step.interrupted (e.g. aborts during prompt hooks / media
+    // resolution, for which the engine never emits a step event).
+    const shouldRestoreDraft = event.reason === 'cancelled' && this.isEligibleForDraftRestore();
     this.currentTurnHasMeaningfulOutput = false;
-    this.pendingDraftRestore = false;
     this.goalCompletionTurnEnded = true;
     // Plugin usage is reported once the whole turn's output has ended — but a
     // cancelled turn cut the output short, so skip the notice there.
@@ -412,15 +410,23 @@ export class SessionEventHandler {
     }
   }
 
+  /** A cancelled turn may restore the stashed draft iff no meaningful output ran. */
+  private isEligibleForDraftRestore(): boolean {
+    return (
+      !this.currentTurnHasMeaningfulOutput && this.host.peekPendingRestoreDraft() !== undefined
+    );
+  }
+
   private async maybeRestoreDraftAfterCancel(): Promise<void> {
-    const draft = this.host.peekPendingRestoreDraft();
+    // Take (own) the draft up front: a prompt submitted during the async undo
+    // below must get a fresh draft rather than be clobbered by this restore.
+    const draft = this.host.takePendingRestoreDraft();
     if (draft === undefined) return;
 
     const editorText = this.host.state.editor.getText();
     if (editorText.length > 0) {
       // User typed while waiting; keep their new draft and leave the submitted
-      // turn in place (status was already skipped when we armed restore).
-      this.host.clearPendingRestoreDraft();
+      // turn in place (the red status was already skipped on this cancelled turn).
       return;
     }
     // finalizeTurn may have already shifted a queued message for dispatch.
@@ -428,11 +434,9 @@ export class SessionEventHandler {
       this.host.state.queuedMessages.length > 0 ||
       this.host.state.queuedMessageDispatchPending
     ) {
-      this.host.clearPendingRestoreDraft();
       return;
     }
     if (this.host.state.appState.goal?.status === 'active') {
-      this.host.clearPendingRestoreDraft();
       return;
     }
 
@@ -440,19 +444,22 @@ export class SessionEventHandler {
       (entry) => entry.kind === 'user',
     );
     if (lastUser === undefined || lastUser.content !== draft.text) {
-      this.host.clearPendingRestoreDraft();
       this.host.showStatus('Interrupted by user', 'error');
       return;
     }
 
     const undone = await this.host.undoLastUserTurn();
     if (!undone) {
-      this.host.clearPendingRestoreDraft();
       this.host.showStatus('Interrupted by user', 'error');
       return;
     }
 
-    this.host.takePendingRestoreDraft();
+    // Revalidate after the await: a new prompt/turn may have started while the
+    // undo RPC was in flight. If so, leave the user's new input alone — do not
+    // overwrite the editor or mutate history.
+    if (this.host.state.editor.getText().length > 0) return;
+    if (this.host.state.appState.streamingPhase !== 'idle') return;
+
     this.host.removeLastInputHistory(draft.text);
     this.host.restoreInputText(draft.text);
   }
@@ -537,11 +544,10 @@ export class SessionEventHandler {
     if (reason === 'aborted' || reason === undefined || reason === '') {
       this.markActiveAgentSwarmsCancelled();
       if (event.message === undefined || event.message === '') {
-        // No meaningful assistant output yet: skip the red Interrupted status
-        // and arm draft restore for turn.ended (Claude-style pre-reply cancel).
-        if (!this.currentTurnHasMeaningfulOutput && this.host.peekPendingRestoreDraft() !== undefined) {
-          this.pendingDraftRestore = true;
-        } else {
+        // No meaningful assistant output yet: skip the red Interrupted status —
+        // turn.ended will restore the draft instead (Claude-style pre-reply
+        // cancel). Falls back to the red status when not eligible.
+        if (!this.isEligibleForDraftRestore()) {
           this.host.showStatus('Interrupted by user', 'error');
         }
       } else {

--- a/apps/kimi-code/src/tui/controllers/session-event-handler.ts
+++ b/apps/kimi-code/src/tui/controllers/session-event-handler.ts
@@ -82,6 +82,7 @@ import type {
   AppState,
   LivePaneState,
   QueuedMessage,
+  PendingRestoreDraft,
   ToolCallBlockData,
   ToolResultBlockData,
   TranscriptEntry,
@@ -108,6 +109,7 @@ export interface SessionEventHost {
   recordSessionActivity(): void;
   noteStepUsage(usage: TokenUsage | undefined): void;
   noteCompactionFinished(): void;
+  noteContextCut(): void;
   mountEditorReplacement(panel: Component & Focusable): void;
   restoreEditor(): void;
   restoreInputText(text: string): void;
@@ -118,6 +120,11 @@ export interface SessionEventHost {
   updateTerminalTitle(): void;
   sendQueuedMessage(session: Session, item: QueuedMessage): void;
   shiftQueuedMessage(): QueuedMessage | undefined;
+  takePendingRestoreDraft(): PendingRestoreDraft | undefined;
+  peekPendingRestoreDraft(): PendingRestoreDraft | undefined;
+  clearPendingRestoreDraft(): void;
+  removeLastInputHistory(expected: string): void;
+  undoLastUserTurn(): Promise<boolean>;
   readonly btwPanelController: BtwPanelController;
   readonly tasksBrowserController: TasksBrowserController;
 }
@@ -159,7 +166,10 @@ export class SessionEventHandler {
   mcpServers: Map<string, McpServerStatusSnapshot> = new Map();
   private goalCompletionAwaitingClear = false;
   private goalCompletionTurnEnded = false;
-  private currentTurnHasAssistantText = false;
+  /** Non-empty assistant text or any tool call this turn — blocks ESC draft restore. */
+  private currentTurnHasMeaningfulOutput = false;
+  /** Armed by user-cancel with no meaningful output; consumed on turn.ended. */
+  private pendingDraftRestore = false;
   private pluginCommandTurns: Map<string, string> = new Map();
   private pluginMcpToolsUsedInTurn: Set<string> = new Set();
   private pendingModelBlockedFallback: GoalChange | undefined;
@@ -177,7 +187,8 @@ export class SessionEventHandler {
     this.mcpServers.clear();
     this.goalCompletionAwaitingClear = false;
     this.goalCompletionTurnEnded = false;
-    this.currentTurnHasAssistantText = false;
+    this.currentTurnHasMeaningfulOutput = false;
+    this.pendingDraftRestore = false;
     this.pluginCommandTurns.clear();
     this.pluginMcpToolsUsedInTurn.clear();
     this.pendingModelBlockedFallback = undefined;
@@ -316,7 +327,8 @@ export class SessionEventHandler {
   // ---------------------------------------------------------------------------
 
   private handleTurnBegin(event: TurnStartedEvent): void {
-    this.currentTurnHasAssistantText = false;
+    this.currentTurnHasMeaningfulOutput = false;
+    this.pendingDraftRestore = false;
     if (event.origin?.kind === 'plugin_command') {
       this.pluginCommandTurns.set(String(event.turnId), event.origin.pluginId);
     }
@@ -371,7 +383,10 @@ export class SessionEventHandler {
     this.host.streamingUI.finalizeTurn(sendQueued);
     this.host.recordSessionActivity();
     this.renderPendingModelBlockedFallback();
-    this.currentTurnHasAssistantText = false;
+    const shouldRestoreDraft =
+      event.reason === 'cancelled' && this.pendingDraftRestore && !this.currentTurnHasMeaningfulOutput;
+    this.currentTurnHasMeaningfulOutput = false;
+    this.pendingDraftRestore = false;
     this.goalCompletionTurnEnded = true;
     // Plugin usage is reported once the whole turn's output has ended — but a
     // cancelled turn cut the output short, so skip the notice there.
@@ -390,6 +405,56 @@ export class SessionEventHandler {
     }
     this.pluginMcpToolsUsedInTurn.clear();
     this.scheduleQueuedGoalPromotion();
+    if (shouldRestoreDraft) {
+      void this.maybeRestoreDraftAfterCancel();
+    } else {
+      this.host.clearPendingRestoreDraft();
+    }
+  }
+
+  private async maybeRestoreDraftAfterCancel(): Promise<void> {
+    const draft = this.host.peekPendingRestoreDraft();
+    if (draft === undefined) return;
+
+    const editorText = this.host.state.editor.getText();
+    if (editorText.length > 0) {
+      // User typed while waiting; keep their new draft and leave the submitted
+      // turn in place (status was already skipped when we armed restore).
+      this.host.clearPendingRestoreDraft();
+      return;
+    }
+    // finalizeTurn may have already shifted a queued message for dispatch.
+    if (
+      this.host.state.queuedMessages.length > 0 ||
+      this.host.state.queuedMessageDispatchPending
+    ) {
+      this.host.clearPendingRestoreDraft();
+      return;
+    }
+    if (this.host.state.appState.goal?.status === 'active') {
+      this.host.clearPendingRestoreDraft();
+      return;
+    }
+
+    const lastUser = this.host.state.transcriptEntries.findLast(
+      (entry) => entry.kind === 'user',
+    );
+    if (lastUser === undefined || lastUser.content !== draft.text) {
+      this.host.clearPendingRestoreDraft();
+      this.host.showStatus('Interrupted by user', 'error');
+      return;
+    }
+
+    const undone = await this.host.undoLastUserTurn();
+    if (!undone) {
+      this.host.clearPendingRestoreDraft();
+      this.host.showStatus('Interrupted by user', 'error');
+      return;
+    }
+
+    this.host.takePendingRestoreDraft();
+    this.host.removeLastInputHistory(draft.text);
+    this.host.restoreInputText(draft.text);
   }
 
   private handleStepBegin(event: TurnStepStartedEvent): void {
@@ -472,7 +537,13 @@ export class SessionEventHandler {
     if (reason === 'aborted' || reason === undefined || reason === '') {
       this.markActiveAgentSwarmsCancelled();
       if (event.message === undefined || event.message === '') {
-        this.host.showStatus('Interrupted by user', 'error');
+        // No meaningful assistant output yet: skip the red Interrupted status
+        // and arm draft restore for turn.ended (Claude-style pre-reply cancel).
+        if (!this.currentTurnHasMeaningfulOutput && this.host.peekPendingRestoreDraft() !== undefined) {
+          this.pendingDraftRestore = true;
+        } else {
+          this.host.showStatus('Interrupted by user', 'error');
+        }
       } else {
         this.host.showError(event.message);
       }
@@ -511,7 +582,7 @@ export class SessionEventHandler {
     }
 
     if (event.delta.trim().length > 0) {
-      this.currentTurnHasAssistantText = true;
+      this.currentTurnHasMeaningfulOutput = true;
       this.pendingModelBlockedFallback = undefined;
     }
     streamingUI.appendAssistantDelta(event.delta);
@@ -534,7 +605,7 @@ export class SessionEventHandler {
     }
     this.host.streamingUI.finalizeAssistantStream();
     if (event.content.trim().length > 0) {
-      this.currentTurnHasAssistantText = true;
+      this.currentTurnHasMeaningfulOutput = true;
       this.pendingModelBlockedFallback = undefined;
     }
     this.host.appendTranscriptEntry({
@@ -554,6 +625,8 @@ export class SessionEventHandler {
   private handleToolCall(event: ToolCallStartedEvent): void {
     const { streamingUI } = this.host;
     streamingUI.flushNow();
+    this.currentTurnHasMeaningfulOutput = true;
+    this.pendingModelBlockedFallback = undefined;
     const { turnId, step } = streamingUI.getTurnContext();
     const toolCall: ToolCallBlockData = {
       id: event.toolCallId,
@@ -717,7 +790,7 @@ export class SessionEventHandler {
     if (change.kind === 'lifecycle' && change.status === 'blocked') {
       void this.notifyQueuedGoalWaitingOnBlocked();
       if (change.actor === 'model' || change.reason === undefined) {
-        this.pendingModelBlockedFallback = this.currentTurnHasAssistantText
+        this.pendingModelBlockedFallback = this.currentTurnHasMeaningfulOutput
           ? undefined
           : change;
         return;

--- a/apps/kimi-code/src/tui/kimi-tui.ts
+++ b/apps/kimi-code/src/tui/kimi-tui.ts
@@ -50,6 +50,7 @@ import {
   type SkillListSession,
 } from './commands';
 import * as slashCommands from './commands/dispatch';
+import { undoLastUserTurn as undoLastUserTurnCommand } from './commands/undo';
 import { CacheHintController } from './controllers/cache-hint-controller';
 import { BannerComponent } from './components/chrome/banner';
 import { DeviceCodeBoxComponent } from './components/chrome/device-code-box';
@@ -134,6 +135,7 @@ import {
   type KimiTUIOptions,
   type LivePaneState,
   type LoginProgressSpinnerHandle,
+  type PendingRestoreDraft,
   type QueuedMessage,
   type SteerInputItem,
   type TranscriptEntry,
@@ -349,6 +351,8 @@ export class KimiTUI {
   private currentLoadingTip: { kind: LoadingTipKind; tip: string | undefined } | undefined =
     undefined;
   private lastHistoryContent: string | undefined;
+  /** Stashed when a normal user prompt is sent; used to restore on pre-reply ESC cancel. */
+  private pendingRestoreDraft: PendingRestoreDraft | undefined;
   // Live `!` shell output entries, keyed by commandId so concurrent commands
   // each update their own card and stale events are dropped. Mutated in place
   // as `shell.output` events arrive; removed when the command completes.
@@ -1343,8 +1347,11 @@ export class KimiTUI {
   private async persistInputHistory(text: string): Promise<void> {
     const trimmed = text.trim();
     if (trimmed.length === 0) return;
-    if (trimmed === this.lastHistoryContent) return;
+    // Always try the in-memory ring: after ESC draft restore pops the entry,
+    // a resubmit of the same text must re-seed ↑ history even when the JSONL
+    // file already has it (lastHistoryContent match).
     this.state.editor.addToHistory(trimmed);
+    if (trimmed === this.lastHistoryContent) return;
     try {
       const file = getInputHistoryFile(this.state.appState.workDir);
       const written = await appendInputHistory(file, trimmed, this.lastHistoryContent);
@@ -1438,6 +1445,11 @@ export class KimiTUI {
       imageAttachmentIds,
     });
 
+    this.pendingRestoreDraft = {
+      text: input,
+      imageAttachmentIds,
+    };
+
     this.beginSessionRequest();
 
     const sdkInput = options?.parts ?? input;
@@ -1453,12 +1465,14 @@ export class KimiTUI {
         // TUI to the waiting phase, and no turn events may follow a failed
         // steer (e.g. the session is gone), which would leave the UI stuck
         // queueing input behind a request that never completes.
+        this.clearPendingRestoreDraft();
         this.failSessionRequest(`Failed to steer: ${message}`);
       });
       return;
     }
     void session.prompt(sdkInput).catch((error: unknown) => {
       const message = formatErrorMessage(error);
+      this.clearPendingRestoreDraft();
       this.failSessionRequest(`Failed to send: ${message}`);
     });
   }
@@ -3088,6 +3102,28 @@ export class KimiTUI {
     this.state.editor.setText(text);
     this.updateEditorBorderHighlight(text);
     this.state.ui.requestRender();
+  }
+
+  peekPendingRestoreDraft(): PendingRestoreDraft | undefined {
+    return this.pendingRestoreDraft;
+  }
+
+  takePendingRestoreDraft(): PendingRestoreDraft | undefined {
+    const draft = this.pendingRestoreDraft;
+    this.pendingRestoreDraft = undefined;
+    return draft;
+  }
+
+  clearPendingRestoreDraft(): void {
+    this.pendingRestoreDraft = undefined;
+  }
+
+  removeLastInputHistory(expected: string): void {
+    this.state.editor.removeLastFromHistory?.(expected);
+  }
+
+  async undoLastUserTurn(): Promise<boolean> {
+    return undoLastUserTurnCommand(this);
   }
 
   /** Latest in-process LLM round-trip; feeds the idle cache-hint scenario. */

--- a/apps/kimi-code/src/tui/types.ts
+++ b/apps/kimi-code/src/tui/types.ts
@@ -241,6 +241,15 @@ export interface QueuedMessage {
 }
 
 /**
+ * Draft stashed when a user prompt is sent, so ESC cancel before any
+ * meaningful assistant output can rewind the turn and put the text back.
+ */
+export interface PendingRestoreDraft {
+  readonly text: string;
+  readonly imageAttachmentIds?: readonly number[];
+}
+
+/**
  * One unit of Ctrl-S steer input: a queued message or the editor draft,
  * with the media parts extracted at submit/paste time so images and video
  * tags survive the steer path (which accepts full prompt parts, not just

--- a/apps/kimi-code/test/tui/controllers/session-event-handler-compaction.test.ts
+++ b/apps/kimi-code/test/tui/controllers/session-event-handler-compaction.test.ts
@@ -58,6 +58,12 @@ function makeHost() {
     sendNormalUserInput: vi.fn(),
     sendQueuedMessage: vi.fn(),
     shiftQueuedMessage: vi.fn(),
+    peekPendingRestoreDraft: vi.fn(() => undefined),
+    takePendingRestoreDraft: vi.fn(() => undefined),
+    clearPendingRestoreDraft: vi.fn(),
+    removeLastInputHistory: vi.fn(),
+    undoLastUserTurn: vi.fn(async () => false),
+    noteContextCut: vi.fn(),
     btwPanelController: { routeEvent: vi.fn(() => false) },
     tasksBrowserController: {},
   };

--- a/apps/kimi-code/test/tui/controllers/session-event-handler-goal-queue.test.ts
+++ b/apps/kimi-code/test/tui/controllers/session-event-handler-goal-queue.test.ts
@@ -96,6 +96,12 @@ function makeHost(options: { createGoalRejects?: boolean } = {}) {
     sendNormalUserInput: vi.fn(),
     sendQueuedMessage: vi.fn(),
     shiftQueuedMessage: vi.fn(),
+    peekPendingRestoreDraft: vi.fn(() => undefined),
+    takePendingRestoreDraft: vi.fn(() => undefined),
+    clearPendingRestoreDraft: vi.fn(),
+    removeLastInputHistory: vi.fn(),
+    undoLastUserTurn: vi.fn(async () => false),
+    noteContextCut: vi.fn(),
     btwPanelController: { routeEvent: vi.fn(() => false) },
     tasksBrowserController: {},
   };

--- a/apps/kimi-code/test/tui/controllers/session-event-handler-plugin-updates.test.ts
+++ b/apps/kimi-code/test/tui/controllers/session-event-handler-plugin-updates.test.ts
@@ -57,6 +57,12 @@ function makeHost() {
     sendNormalUserInput: vi.fn(),
     sendQueuedMessage: vi.fn(),
     shiftQueuedMessage: vi.fn(),
+    peekPendingRestoreDraft: vi.fn(() => undefined),
+    takePendingRestoreDraft: vi.fn(() => undefined),
+    clearPendingRestoreDraft: vi.fn(),
+    removeLastInputHistory: vi.fn(),
+    undoLastUserTurn: vi.fn(async () => false),
+    noteContextCut: vi.fn(),
     btwPanelController: { routeEvent: vi.fn(() => false) },
     tasksBrowserController: {},
   };

--- a/apps/kimi-code/test/tui/kimi-tui-message-flow.test.ts
+++ b/apps/kimi-code/test/tui/kimi-tui-message-flow.test.ts
@@ -4600,6 +4600,93 @@ command = "vim"
     expect(driver.state.editor.getText()).toBe('');
   });
 
+  it('restores the draft when a cancelled turn ends with no step event', async () => {
+    const { driver, session } = await makeDriver();
+    const sendQueued = vi.fn();
+
+    driver.handleUserInput('early cancel');
+    expect(session.prompt).toHaveBeenCalledWith('early cancel');
+    expect(driver.state.appState.streamingPhase).toBe('waiting');
+
+    // No turn.step.interrupted: the engine goes straight to turn.ended when a
+    // turn is cancelled before the first step (e.g. during prompt hooks / media
+    // resolution), so draft restore must not depend on a step-interrupted event.
+    driver.sessionEventHandler.handleEvent(
+      {
+        type: 'turn.started',
+        agentId: 'main',
+        sessionId: 'ses-1',
+        turnId: 1,
+      } as Event,
+      sendQueued,
+    );
+    driver.sessionEventHandler.handleEvent(
+      {
+        type: 'turn.ended',
+        agentId: 'main',
+        sessionId: 'ses-1',
+        turnId: 1,
+        reason: 'cancelled',
+      } as Event,
+      sendQueued,
+    );
+
+    await vi.waitFor(() => {
+      expect(session.undoHistory).toHaveBeenCalledWith(1);
+    });
+    await vi.waitFor(() => {
+      expect(driver.state.editor.getText()).toBe('early cancel');
+    });
+    expect(stripSgr(renderTranscript(driver))).not.toContain('Interrupted by user');
+    expect(driver.state.transcriptEntries).toEqual([]);
+  });
+
+  it('does not clobber the editor if the user types during the async undo', async () => {
+    const { driver, session } = await makeDriver();
+    const sendQueued = vi.fn();
+
+    driver.handleUserInput('original');
+    driver.sessionEventHandler.handleEvent(
+      {
+        type: 'turn.started',
+        agentId: 'main',
+        sessionId: 'ses-1',
+        turnId: 1,
+      } as Event,
+      sendQueued,
+    );
+
+    // Stall the undo RPC so we can act during its in-flight window.
+    let resolveUndo: () => void = () => {};
+    session.undoHistory = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveUndo = resolve;
+        }),
+    );
+
+    driver.sessionEventHandler.handleEvent(
+      {
+        type: 'turn.ended',
+        agentId: 'main',
+        sessionId: 'ses-1',
+        turnId: 1,
+        reason: 'cancelled',
+      } as Event,
+      sendQueued,
+    );
+    await vi.waitFor(() => expect(session.undoHistory).toHaveBeenCalledWith(1));
+
+    // The user starts a new draft while the undo RPC is still in flight.
+    driver.state.editor.setText('typed during undo');
+    resolveUndo();
+    await vi.waitFor(() => {
+      expect(driver.state.appState.streamingPhase).toBe('idle');
+    });
+
+    expect(driver.state.editor.getText()).toBe('typed during undo');
+  });
+
   it('appends the /export-debug-zip hint beneath session error messages', async () => {
     const { driver } = await makeDriver();
 

--- a/apps/kimi-code/test/tui/kimi-tui-message-flow.test.ts
+++ b/apps/kimi-code/test/tui/kimi-tui-message-flow.test.ts
@@ -4290,6 +4290,316 @@ command = "vim"
     expect(stripSgr(renderTranscript(driver))).toContain('Interrupted by user');
   });
 
+  it('restores the draft and undoes the turn when Esc cancels before any assistant output', async () => {
+    const { driver, session } = await makeDriver();
+    const sendQueued = vi.fn();
+
+    driver.handleUserInput('please help');
+    expect(session.prompt).toHaveBeenCalledWith('please help');
+    expect(driver.state.appState.streamingPhase).toBe('waiting');
+    expect(driver.state.editor.getText()).toBe('');
+
+    driver.sessionEventHandler.handleEvent(
+      {
+        type: 'turn.started',
+        agentId: 'main',
+        sessionId: 'ses-1',
+        turnId: 1,
+      } as Event,
+      sendQueued,
+    );
+    driver.sessionEventHandler.handleEvent(
+      {
+        type: 'turn.step.interrupted',
+        agentId: 'main',
+        sessionId: 'ses-1',
+        turnId: 1,
+        step: 1,
+        reason: 'aborted',
+      } as Event,
+      sendQueued,
+    );
+    expect(stripSgr(renderTranscript(driver))).not.toContain('Interrupted by user');
+
+    driver.sessionEventHandler.handleEvent(
+      {
+        type: 'turn.ended',
+        agentId: 'main',
+        sessionId: 'ses-1',
+        turnId: 1,
+        reason: 'cancelled',
+      } as Event,
+      sendQueued,
+    );
+
+    await vi.waitFor(() => {
+      expect(session.undoHistory).toHaveBeenCalledWith(1);
+    });
+    await vi.waitFor(() => {
+      expect(driver.state.editor.getText()).toBe('please help');
+    });
+    expect(stripSgr(renderTranscript(driver))).not.toContain('please help');
+    expect(stripSgr(renderTranscript(driver))).not.toContain('Interrupted by user');
+    expect(driver.state.transcriptEntries).toEqual([]);
+  });
+
+  it('keeps Interrupted status and does not restore after assistant text has started', async () => {
+    const { driver, session } = await makeDriver();
+    const sendQueued = vi.fn();
+
+    driver.handleUserInput('hello');
+    driver.sessionEventHandler.handleEvent(
+      {
+        type: 'turn.started',
+        agentId: 'main',
+        sessionId: 'ses-1',
+        turnId: 1,
+      } as Event,
+      sendQueued,
+    );
+    driver.sessionEventHandler.handleEvent(
+      {
+        type: 'assistant.delta',
+        agentId: 'main',
+        sessionId: 'ses-1',
+        turnId: 1,
+        delta: 'Hi',
+      } as Event,
+      sendQueued,
+    );
+    driver.sessionEventHandler.handleEvent(
+      {
+        type: 'turn.step.interrupted',
+        agentId: 'main',
+        sessionId: 'ses-1',
+        turnId: 1,
+        step: 1,
+        reason: 'aborted',
+      } as Event,
+      sendQueued,
+    );
+    driver.sessionEventHandler.handleEvent(
+      {
+        type: 'turn.ended',
+        agentId: 'main',
+        sessionId: 'ses-1',
+        turnId: 1,
+        reason: 'cancelled',
+      } as Event,
+      sendQueued,
+    );
+
+    expect(stripSgr(renderTranscript(driver))).toContain('Interrupted by user');
+    expect(session.undoHistory).not.toHaveBeenCalled();
+    expect(driver.state.editor.getText()).toBe('');
+    expect(driver.state.transcriptEntries.some((e) => e.kind === 'user' && e.content === 'hello')).toBe(
+      true,
+    );
+  });
+
+  it('keeps Interrupted status and does not restore after a tool call has started', async () => {
+    const { driver, session } = await makeDriver();
+    const sendQueued = vi.fn();
+
+    driver.handleUserInput('run something');
+    driver.sessionEventHandler.handleEvent(
+      {
+        type: 'turn.started',
+        agentId: 'main',
+        sessionId: 'ses-1',
+        turnId: 1,
+      } as Event,
+      sendQueued,
+    );
+    driver.sessionEventHandler.handleEvent(
+      {
+        type: 'tool.call.started',
+        agentId: 'main',
+        sessionId: 'ses-1',
+        turnId: 1,
+        toolCallId: 'call_1',
+        name: 'Bash',
+        args: { command: 'ls' },
+      } as Event,
+      sendQueued,
+    );
+    driver.sessionEventHandler.handleEvent(
+      {
+        type: 'turn.step.interrupted',
+        agentId: 'main',
+        sessionId: 'ses-1',
+        turnId: 1,
+        step: 1,
+        reason: 'aborted',
+      } as Event,
+      sendQueued,
+    );
+    driver.sessionEventHandler.handleEvent(
+      {
+        type: 'turn.ended',
+        agentId: 'main',
+        sessionId: 'ses-1',
+        turnId: 1,
+        reason: 'cancelled',
+      } as Event,
+      sendQueued,
+    );
+
+    expect(stripSgr(renderTranscript(driver))).toContain('Interrupted by user');
+    expect(session.undoHistory).not.toHaveBeenCalled();
+    expect(driver.state.editor.getText()).toBe('');
+  });
+
+  it('restores the draft when only thinking streamed before cancel', async () => {
+    const { driver, session } = await makeDriver();
+    const sendQueued = vi.fn();
+
+    driver.handleUserInput('think first');
+    driver.sessionEventHandler.handleEvent(
+      {
+        type: 'turn.started',
+        agentId: 'main',
+        sessionId: 'ses-1',
+        turnId: 1,
+      } as Event,
+      sendQueued,
+    );
+    driver.sessionEventHandler.handleEvent(
+      {
+        type: 'thinking.delta',
+        agentId: 'main',
+        sessionId: 'ses-1',
+        turnId: 1,
+        delta: 'reasoning...',
+      } as Event,
+      sendQueued,
+    );
+    driver.sessionEventHandler.handleEvent(
+      {
+        type: 'turn.step.interrupted',
+        agentId: 'main',
+        sessionId: 'ses-1',
+        turnId: 1,
+        step: 1,
+        reason: 'aborted',
+      } as Event,
+      sendQueued,
+    );
+    expect(stripSgr(renderTranscript(driver))).not.toContain('Interrupted by user');
+
+    driver.sessionEventHandler.handleEvent(
+      {
+        type: 'turn.ended',
+        agentId: 'main',
+        sessionId: 'ses-1',
+        turnId: 1,
+        reason: 'cancelled',
+      } as Event,
+      sendQueued,
+    );
+
+    await vi.waitFor(() => {
+      expect(session.undoHistory).toHaveBeenCalledWith(1);
+    });
+    await vi.waitFor(() => {
+      expect(driver.state.editor.getText()).toBe('think first');
+    });
+  });
+
+  it('does not overwrite editor text typed while waiting for a cancelled turn', async () => {
+    const { driver, session } = await makeDriver();
+    const sendQueued = vi.fn();
+
+    driver.handleUserInput('original');
+    driver.sessionEventHandler.handleEvent(
+      {
+        type: 'turn.started',
+        agentId: 'main',
+        sessionId: 'ses-1',
+        turnId: 1,
+      } as Event,
+      sendQueued,
+    );
+    driver.state.editor.setText('typed while waiting');
+    driver.sessionEventHandler.handleEvent(
+      {
+        type: 'turn.step.interrupted',
+        agentId: 'main',
+        sessionId: 'ses-1',
+        turnId: 1,
+        step: 1,
+        reason: 'aborted',
+      } as Event,
+      sendQueued,
+    );
+    // Armed restore skips Interrupted, but turn.ended must not clobber the new draft.
+    expect(stripSgr(renderTranscript(driver))).not.toContain('Interrupted by user');
+
+    driver.sessionEventHandler.handleEvent(
+      {
+        type: 'turn.ended',
+        agentId: 'main',
+        sessionId: 'ses-1',
+        turnId: 1,
+        reason: 'cancelled',
+      } as Event,
+      sendQueued,
+    );
+
+    await vi.waitFor(() => {
+      expect(driver.state.appState.streamingPhase).toBe('idle');
+    });
+    expect(session.undoHistory).not.toHaveBeenCalled();
+    expect(driver.state.editor.getText()).toBe('typed while waiting');
+    expect(driver.state.transcriptEntries.some((e) => e.kind === 'user' && e.content === 'original')).toBe(
+      true,
+    );
+  });
+
+  it('does not restore when messages are queued during the cancelled turn', async () => {
+    const { driver, session } = await makeDriver();
+    const sendQueued = vi.fn();
+
+    driver.handleUserInput('original');
+    driver.sessionEventHandler.handleEvent(
+      {
+        type: 'turn.started',
+        agentId: 'main',
+        sessionId: 'ses-1',
+        turnId: 1,
+      } as Event,
+      sendQueued,
+    );
+    driver.state.queuedMessages = [{ text: 'queued next' }];
+    driver.sessionEventHandler.handleEvent(
+      {
+        type: 'turn.step.interrupted',
+        agentId: 'main',
+        sessionId: 'ses-1',
+        turnId: 1,
+        step: 1,
+        reason: 'aborted',
+      } as Event,
+      sendQueued,
+    );
+    driver.sessionEventHandler.handleEvent(
+      {
+        type: 'turn.ended',
+        agentId: 'main',
+        sessionId: 'ses-1',
+        turnId: 1,
+        reason: 'cancelled',
+      } as Event,
+      sendQueued,
+    );
+
+    await vi.waitFor(() => {
+      expect(driver.state.appState.streamingPhase).toBe('idle');
+    });
+    expect(session.undoHistory).not.toHaveBeenCalled();
+    expect(driver.state.editor.getText()).toBe('');
+  });
+
   it('appends the /export-debug-zip hint beneath session error messages', async () => {
     const { driver } = await makeDriver();
 

--- a/packages/pi-tui/src/components/editor.ts
+++ b/packages/pi-tui/src/components/editor.ts
@@ -441,6 +441,21 @@ export class Editor implements Component, Focusable {
 		}
 	}
 
+	/**
+	 * Drop the most recent history entry (index 0). When `expected` is set,
+	 * only remove if it matches that entry after trim — used when a just-
+	 * submitted prompt is restored to the editor so ↑ does not immediately
+	 * resurface the same text.
+	 */
+	removeLastFromHistory(expected?: string): void {
+		if (this.history.length === 0) return;
+		if (expected !== undefined && this.history[0] !== expected.trim()) return;
+		this.history.shift();
+		if (this.historyIndex >= 0) {
+			this.historyIndex = Math.max(-1, this.historyIndex - 1);
+		}
+	}
+
 	private isEditorEmpty(): boolean {
 		return this.state.lines.length === 1 && this.state.lines[0] === "";
 	}

--- a/packages/pi-tui/src/editor-component.ts
+++ b/packages/pi-tui/src/editor-component.ts
@@ -38,6 +38,7 @@ export interface EditorComponent extends Component {
 
 	/** Add text to history for up/down navigation */
 	addToHistory?(text: string): void;
+	removeLastFromHistory?(expected?: string): void;
 
 	// =========================================================================
 	// Advanced text manipulation (optional)

--- a/packages/pi-tui/test/editor.test.ts
+++ b/packages/pi-tui/test/editor.test.ts
@@ -114,6 +114,27 @@ describe("Editor component", () => {
 			assert.strictEqual(editor.getText(), "second prompt");
 		});
 
+		it("removeLastFromHistory drops the most recent entry when it matches", () => {
+			const editor = new Editor(createTestTUI(), defaultEditorTheme);
+
+			editor.addToHistory("first");
+			editor.addToHistory("second");
+			editor.removeLastFromHistory("second");
+
+			editor.handleInput("\x1b[A");
+			assert.strictEqual(editor.getText(), "first");
+		});
+
+		it("removeLastFromHistory is a no-op when expected does not match", () => {
+			const editor = new Editor(createTestTUI(), defaultEditorTheme);
+
+			editor.addToHistory("kept");
+			editor.removeLastFromHistory("other");
+
+			editor.handleInput("\x1b[A");
+			assert.strictEqual(editor.getText(), "kept");
+		});
+
 		it("cycles through history entries on repeated Up arrow", () => {
 			const editor = new Editor(createTestTUI(), defaultEditorTheme);
 


### PR DESCRIPTION
## Related Issue

Resolve #2781

## Problem

See linked issue. In short: pressing Esc to cancel a turn **before the model has produced any output** consumed the submitted prompt and left a red `Interrupted by user` status, with the text gone. The desired behavior is to rewind the turn and put the prompt back into the input box so it can be edited and resent.

## What changed

- **"Has the model produced output yet" gate.** Renamed `currentTurnHasAssistantText` → `currentTurnHasMeaningfulOutput` and now also set it when a tool call starts (not just on non-whitespace assistant text). Thinking-only turns are intentionally *not* counted as meaningful output, so cancelling while the model is still thinking still restores the draft.
- **Two-phase restore.** At `turn.step.interrupted` (reason `aborted`, no message), if there is no meaningful output and a stashed draft exists, arm a `pendingDraftRestore` flag and **skip** the `Interrupted by user` status. The actual restore happens at `turn.ended` (reason `cancelled`) so the turn fully winds down first.
- **Restore with guards** (`maybeRestoreDraftAfterCancel`): only restore when the editor is empty (the user did not type something new while waiting), there are no queued messages or active goal, the last transcript user entry matches the stashed draft, and `undoLastUserTurn()` succeeds. Any guard failure falls back to the old `Interrupted by user` behavior — so this can never lose more than before.
- **Reuse existing machinery:** the rewind goes through the `/undo` path (`undoLastUserTurn` → `undoByCount(host, 1)`), and the text is put back via the existing `host.restoreInputText(text)`.
- **Input history:** the just-submitted entry is dropped from history (`Editor.removeLastFromHistory(expected?)`, new optional method) so pressing ↑ does not immediately resurface the text that was just restored into the editor; `persistInputHistory` now always re-seeds the in-memory ring so a resubmit repopulates ↑ correctly.

### Tests

6 new scenarios in `kimi-tui-message-flow.test.ts` covering every branch: restore + undo before output; keep `Interrupted` after assistant text; keep after a tool call; restore when only thinking streamed; do not overwrite text typed while waiting; do not restore when messages are queued. Host mocks in the three `session-event-handler-*` tests were extended for the new interface members. `editor.test.ts` covers `removeLastFromHistory` (match + no-op). All green: kimi-code 234/234, pi-tui 210/210; typecheck clean.

### Notes / known limitations

- `PendingRestoreDraft` carries `imageAttachmentIds`, but only text is restored on cancel; images attached to a cancelled-early prompt are not re-attached. Field kept as a hook for a follow-up.
- Cancelling mid-stream (after the model has emitted text or called a tool) is unchanged — `Interrupted by user` and no restore, since real output already exists.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue (#2781).
- [x] I have added tests that prove my feature works (6 new message-flow cases + editor history cases; 234/234 and 210/210 green; typecheck clean).
- [x] Added changesets under `.changeset/` for `@moonshot-ai/kimi-code` and `@moonshot-ai/pi-tui` (patch).
- [x] No user-facing doc surface changed (internal TUI behavior); no `gen-docs` run needed.
