### PR TITLE
feat: add remove-dir workspace management

### DIFF
--- a/.changeset/calm-workspace-roots.md
+++ b/.changeset/calm-workspace-roots.md
@@ -1,0 +1,6 @@
+---
+"@moonshot-ai/kimi-code": patch
+"@moonshot-ai/kimi-code-sdk": patch
+---
+
+Add `/remove-dir` and the public `Session.removeAdditionalDir` API so extra workspace roots can be removed from a live session or forgotten from project-local configuration.

--- a/apps/kimi-code/src/tui/commands/dispatch.ts
+++ b/apps/kimi-code/src/tui/commands/dispatch.ts
@@ -40,6 +40,7 @@ import {
 import { handleGoalCommand } from './goal';
 import { handleFeedbackCommand, showMcpServers, showStatusReport, showUsage } from './info';
 import { handleAddDirCommand } from './add-dir';
+import { handleRemoveDirCommand } from './remove-dir';
 import { parseSlashInput } from './parse';
 import { handlePluginsCommand } from './plugins';
 import { handleProviderCommand } from './provider';
@@ -74,6 +75,7 @@ export { handleLoginCommand, handleLogoutCommand } from './auth';
 export { handleBtwCommand } from './btw';
 export { handleCopyCommand } from './copy';
 export { handleAddDirCommand } from './add-dir';
+export { handleRemoveDirCommand } from './remove-dir';
 export {
   handleAutoCommand,
   handleCompactCommand,
@@ -421,6 +423,9 @@ async function handleBuiltInSlashCommand(
       return;
     case 'add-dir':
       await handleAddDirCommand(host, args);
+      return;
+    case 'remove-dir':
+      await handleRemoveDirCommand(host, args);
       return;
     case 'experiments':
       await showExperimentsPanel(host);

--- a/apps/kimi-code/src/tui/commands/registry.ts
+++ b/apps/kimi-code/src/tui/commands/registry.ts
@@ -57,6 +57,11 @@ export function addDirArgumentCompletions(argumentPrefix: string): AutocompleteI
   return completeLeadingArg(ADD_DIR_ARG_COMPLETIONS, argumentPrefix);
 }
 
+/** Path-only argument autocompletion for `/remove-dir`; bare input opens its selector. */
+export function removeDirArgumentCompletions(argumentPrefix: string): AutocompleteItem[] | null {
+  return isPathLikeAddDirArgument(argumentPrefix) ? completeAddDirPath(argumentPrefix) : null;
+}
+
 function isPathLikeAddDirArgument(argumentPrefix: string): boolean {
   return argumentPrefix === '.' || argumentPrefix === '..' || argumentPrefix.startsWith('./') || argumentPrefix.startsWith('../') || argumentPrefix.startsWith('/') || argumentPrefix.startsWith('~');
 }
@@ -261,6 +266,15 @@ export const BUILTIN_SLASH_COMMANDS = [
     availability: 'idle-only',
     argumentHint: '[list] | <path>',
     completeArgs: addDirArgumentCompletions,
+  },
+  {
+    name: 'remove-dir',
+    aliases: [],
+    description: 'Remove an additional workspace directory',
+    priority: 60,
+    availability: 'idle-only',
+    argumentHint: '[<path>]',
+    completeArgs: removeDirArgumentCompletions,
   },
   {
     name: 'experiments',

--- a/apps/kimi-code/src/tui/commands/remove-dir.ts
+++ b/apps/kimi-code/src/tui/commands/remove-dir.ts
@@ -1,0 +1,107 @@
+import { ChoicePickerComponent } from '../components/dialogs/choice-picker';
+import { NO_ACTIVE_SESSION_MESSAGE } from '../constant/kimi-tui';
+import type { SlashCommandHost } from './dispatch';
+import { slashBusyMessage, slashCommandBusyReason } from './resolve';
+
+type RemoveDirChoice = 'session' | 'forget' | 'cancel';
+
+export async function handleRemoveDirCommand(host: SlashCommandHost, args: string): Promise<void> {
+  const input = args.trim();
+  if (input.length > 0) {
+    await showRemovalScopePicker(host, input);
+    return;
+  }
+
+  const additionalDirs = host.session?.summary?.additionalDirs ?? host.state.appState.additionalDirs;
+  if (additionalDirs.length === 0) {
+    host.showStatus('No additional directories configured.');
+    return;
+  }
+
+  host.mountEditorReplacement(
+    new ChoicePickerComponent({
+      title: 'Remove an additional workspace directory',
+      hint: '↑↓ navigate · Enter select · Esc cancel',
+      options: additionalDirs.map((dir) => ({ value: dir, label: dir })),
+      onSelect: (value) => {
+        void showRemovalScopePicker(host, value);
+      },
+      onCancel: () => {
+        host.restoreEditor();
+        host.showStatus('Did not remove a working directory.');
+      },
+    }),
+  );
+}
+
+async function showRemovalScopePicker(host: SlashCommandHost, path: string): Promise<void> {
+  let session = host.session;
+  if (session === undefined) {
+    if (!host.engineV2) {
+      host.showError(NO_ACTIVE_SESSION_MESSAGE);
+      return;
+    }
+    session = await host.ensureSession();
+    if (session === undefined) return;
+    const busyReason = slashCommandBusyReason({
+      isStreaming: host.state.appState.streamingPhase !== 'idle',
+      isCompacting: host.state.appState.isCompacting,
+    });
+    if (busyReason !== undefined) {
+      host.showError(slashBusyMessage('remove-dir', busyReason));
+      return;
+    }
+  }
+
+  host.mountEditorReplacement(
+    new ChoicePickerComponent({
+      title: `Remove directory from workspace: ${path}`,
+      hint: '↑↓ navigate · Enter confirm · Esc cancel',
+      options: [
+        { value: 'session', label: 'Remove session-only directory' },
+        { value: 'forget', label: 'Remove and forget for this project' },
+        { value: 'cancel', label: 'Cancel' },
+      ],
+      onSelect: (value) => {
+        void handleRemoveDirChoice(host, session.id, path, value as RemoveDirChoice);
+      },
+      onCancel: () => {
+        host.restoreEditor();
+        host.showStatus(`Did not remove ${path} as a working directory.`);
+      },
+    }),
+  );
+}
+
+async function handleRemoveDirChoice(
+  host: SlashCommandHost,
+  sessionId: string,
+  path: string,
+  choice: RemoveDirChoice,
+): Promise<void> {
+  host.restoreEditor();
+  if (choice === 'cancel') {
+    host.showStatus(`Did not remove ${path} as a working directory.`);
+    return;
+  }
+
+  const session = host.session;
+  if (session === undefined || session.id !== sessionId) {
+    host.showError(NO_ACTIVE_SESSION_MESSAGE);
+    return;
+  }
+
+  try {
+    const result = await session.removeAdditionalDir(path, { forget: choice === 'forget' });
+    host.setAppState({ additionalDirs: result.additionalDirs });
+    host.refreshSlashCommandAutocomplete();
+    host.showStatus(
+      result.forgotten
+        ? `Removed workspace directory:\n  ${path}\n  Removed from:\n  ${result.configPath}`
+        : `Removed workspace directory:\n  ${path}\n  For this session only`,
+      'success',
+    );
+  } catch (error) {
+    host.showError(error instanceof Error ? error.message : String(error));
+  }
+}

--- a/apps/kimi-code/test/tui/commands/registry.test.ts
+++ b/apps/kimi-code/test/tui/commands/registry.test.ts
@@ -4,6 +4,7 @@ import {
   parseSlashInput,
   resolveSlashCommandAvailability,
   addDirArgumentCompletions,
+  removeDirArgumentCompletions,
   sortSlashCommands,
   swarmArgumentCompletions,
   type KimiSlashCommand,
@@ -96,6 +97,14 @@ describe('built-in slash command registry', () => {
     expect(homeCompletions.some((value) => value.startsWith('~/sers/'))).toBe(false);
   });
 
+  it('offers path-only remove-dir completions because bare input opens the selector', () => {
+    expect(removeDirArgumentCompletions('')).toBeNull();
+    expect(removeDirArgumentCompletions('list')).toBeNull();
+    const absolute = removeDirArgumentCompletions('/') ?? [];
+    expect(absolute.length).toBeGreaterThan(0);
+    expect(absolute.every((item) => item.value.startsWith('/'))).toBe(true);
+  });
+
   it('defaults commands without explicit availability to idle-only', () => {
     const command: KimiSlashCommand = {
       name: 'example',
@@ -150,6 +159,7 @@ describe('built-in slash command registry', () => {
     expect(names).toEqual(
       expect.arrayContaining([
         'add-dir',
+        'remove-dir',
         'compact',
         'btw',
         'editor',

--- a/apps/kimi-code/test/tui/commands/remove-dir.test.ts
+++ b/apps/kimi-code/test/tui/commands/remove-dir.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { handleRemoveDirCommand } from '#/tui/commands/remove-dir';
+import type { SlashCommandHost } from '#/tui/commands/dispatch';
+
+type MountedPanel = {
+  handleInput: (data: string) => void;
+  render: (width: number) => string[];
+};
+
+function makeHost(additionalDirs: readonly string[] = ['/repo/shared']) {
+  const state = {
+    appState: { additionalDirs, streamingPhase: 'idle', isCompacting: false },
+  };
+  let mountedPanel: MountedPanel | null = null;
+  const session = {
+    id: 'session-1',
+    summary: { additionalDirs },
+    removeAdditionalDir: vi.fn(async (path: string, options: { forget: boolean }) => ({
+      additionalDirs: additionalDirs.filter((dir) => dir !== path),
+      projectRoot: '/repo',
+      configPath: '/repo/.kimi-code/local.toml',
+      forgotten: options.forget,
+    })),
+  };
+  const host = {
+    state,
+    session,
+    engineV2: false,
+    setAppState: vi.fn((patch: Record<string, unknown>) => Object.assign(state.appState, patch)),
+    refreshSlashCommandAutocomplete: vi.fn(),
+    showError: vi.fn(),
+    showStatus: vi.fn(),
+    mountEditorReplacement: vi.fn((panel: MountedPanel) => { mountedPanel = panel; }),
+    restoreEditor: vi.fn(() => { mountedPanel = null; }),
+  } as unknown as SlashCommandHost & {
+    session: typeof session;
+    state: typeof state;
+    setAppState: ReturnType<typeof vi.fn>;
+    refreshSlashCommandAutocomplete: ReturnType<typeof vi.fn>;
+    showError: ReturnType<typeof vi.fn>;
+    showStatus: ReturnType<typeof vi.fn>;
+  };
+  return { host, session, getMountedPanel: () => mountedPanel };
+}
+
+describe('handleRemoveDirCommand', () => {
+  it('shows the empty message when no additional dirs are configured', async () => {
+    const { host } = makeHost([]);
+
+    await handleRemoveDirCommand(host, '');
+
+    expect(host.showStatus).toHaveBeenCalledWith('No additional directories configured.');
+  });
+
+  it('selects a configured root and removes a session-only directory', async () => {
+    const { host, session, getMountedPanel } = makeHost(['/repo/shared', '/repo/docs']);
+
+    await handleRemoveDirCommand(host, '');
+    expect(getMountedPanel()?.render(120).join('\n')).toContain('/repo/shared');
+    getMountedPanel()?.handleInput(' ');
+    await vi.waitFor(() => {
+      expect(getMountedPanel()?.render(120).join('\n')).toContain('Remove session-only directory');
+    });
+    getMountedPanel()?.handleInput(' ');
+
+    await vi.waitFor(() => {
+      expect(session.removeAdditionalDir).toHaveBeenCalledWith('/repo/shared', { forget: false });
+    });
+    expect(host.setAppState).toHaveBeenCalledWith({ additionalDirs: ['/repo/docs'] });
+    expect(host.refreshSlashCommandAutocomplete).toHaveBeenCalledOnce();
+  });
+
+  it('removes and forgets an explicit directory after confirmation', async () => {
+    const { host, session, getMountedPanel } = makeHost();
+
+    await handleRemoveDirCommand(host, '/repo/shared');
+    getMountedPanel()?.handleInput('\u001B[B');
+    getMountedPanel()?.handleInput(' ');
+
+    await vi.waitFor(() => {
+      expect(session.removeAdditionalDir).toHaveBeenCalledWith('/repo/shared', { forget: true });
+      expect(host.showStatus).toHaveBeenCalledWith(
+        'Removed workspace directory:\n  /repo/shared\n  Removed from:\n  /repo/.kimi-code/local.toml',
+        'success',
+      );
+    });
+  });
+
+  it('surfaces core validation errors without mutating app state', async () => {
+    const { host, session, getMountedPanel } = makeHost();
+    session.removeAdditionalDir.mockRejectedValueOnce(
+      new Error('The primary workspace directory cannot be removed'),
+    );
+
+    await handleRemoveDirCommand(host, '/repo');
+    getMountedPanel()?.handleInput(' ');
+
+    await vi.waitFor(() => {
+      expect(host.showError).toHaveBeenCalledWith(
+        'The primary workspace directory cannot be removed',
+      );
+    });
+    expect(host.setAppState).not.toHaveBeenCalled();
+  });
+
+  it('re-checks the busy gate after lazy session creation', async () => {
+    const { host, session, getMountedPanel } = makeHost();
+    Object.assign(host, {
+      session: undefined,
+      engineV2: true,
+      ensureSession: vi.fn(async () => {
+        host.state.appState.streamingPhase = 'waiting';
+        return session;
+      }),
+    });
+
+    await handleRemoveDirCommand(host, '/repo/shared');
+
+    expect(host.showError).toHaveBeenCalledWith(
+      'Cannot /remove-dir while streaming — press Esc or Ctrl-C first.',
+    );
+    expect(getMountedPanel()).toBeNull();
+    expect(session.removeAdditionalDir).not.toHaveBeenCalled();
+  });
+});

--- a/apps/vscode/src/handlers/config.handler.ts
+++ b/apps/vscode/src/handlers/config.handler.ts
@@ -32,6 +32,11 @@ const SLASH_COMMANDS: SlashCommandInfo[] = [
     aliases: [],
     description: "Add a directory to the workspace. Usage: /add-dir <path>",
   },
+  {
+    name: "remove-dir",
+    aliases: [],
+    description: "Remove a workspace directory. Usage: /remove-dir [--forget] <path>",
+  },
   { name: "export", aliases: [], description: "Export current session context to a markdown file" },
   { name: "import", aliases: [], description: "Import context from a file or session ID" },
 ];

--- a/apps/vscode/src/handlers/slash-command.ts
+++ b/apps/vscode/src/handlers/slash-command.ts
@@ -23,6 +23,7 @@ const HOST_COMMANDS = new Set([
   "afk",
   "plan",
   "add-dir",
+  "remove-dir",
   "export",
   "import",
 ]);
@@ -94,6 +95,9 @@ export async function runHostSlashCommand(
           break;
         case "add-dir":
           await runAddDirCommand(runtime, command.args, emit);
+          break;
+        case "remove-dir":
+          await runRemoveDirCommand(runtime, command.args, emit);
           break;
         case "export":
           await exportContext(runtime, command.args, emit);
@@ -182,6 +186,27 @@ async function runAddDirCommand(
   }
   const result = await runtime.session.addAdditionalDir(input, { persist: false });
   emit(`Added directory to workspace: ${result.additionalDirs.at(-1) ?? input}`);
+}
+
+async function runRemoveDirCommand(
+  runtime: SessionRuntime,
+  args: string,
+  emit: (text: string) => void,
+): Promise<void> {
+  const raw = args.trim();
+  const forget = raw.startsWith("--forget ");
+  const input = stripMatchingQuotes((forget ? raw.slice("--forget ".length) : raw).trim());
+  if (!input) {
+    const dirs = runtime.session.summary?.additionalDirs ?? [];
+    emit(dirs.length === 0
+      ? "No additional directories. Usage: /remove-dir [--forget] <path>"
+      : ["Additional directories:", ...dirs.map((path) => `  - ${path}`)].join("\n"));
+    return;
+  }
+  const result = await runtime.session.removeAdditionalDir(input, { forget });
+  emit(result.forgotten
+    ? `Removed and forgot workspace directory: ${input}`
+    : `Removed directory from this session: ${input}`);
 }
 
 async function exportContext(

--- a/apps/vscode/test/kimi-harness.integration.test.ts
+++ b/apps/vscode/test/kimi-harness.integration.test.ts
@@ -372,6 +372,7 @@ describe("VS Code Kimi harness integration (shares one in-process SDK home)", ()
       "auto",
       "plan",
       "add-dir",
+      "remove-dir",
       "export",
       "import",
       "skill:review",
@@ -1102,6 +1103,21 @@ describe("VS Code Kimi harness integration (shares one in-process SDK home)", ()
     const resumed = await openRuntimeSession(rig, sessionId);
 
     expect(resumed.session.summary?.additionalDirs).toContain(additionalDir);
+  });
+
+  it("removes a session-only slash-added directory before resume", async () => {
+    const rig = await createRuntimeRig();
+    const additionalDir = join(rig.workDir, "temporary workspace");
+    await mkdir(additionalDir);
+    const runtime = await openRuntimeSession(rig);
+    await runSlash(runtime, `/add-dir "${additionalDir}"`);
+
+    await expect(runSlash(runtime, `/remove-dir "${additionalDir}"`)).resolves.toBe(true);
+    expect(runtime.session.summary?.additionalDirs).not.toContain(additionalDir);
+    const sessionId = runtime.id;
+    await rig.runtime.detachView("view-1");
+    const resumed = await openRuntimeSession(rig, sessionId);
+    expect(resumed.session.summary?.additionalDirs).not.toContain(additionalDir);
   });
 
   it("rejects an invalid plan subcommand without leaving the runtime busy", async () => {

--- a/docs/en/configuration/config-files.md
+++ b/docs/en/configuration/config-files.md
@@ -464,7 +464,7 @@ Changes apply on the next start, or immediately with `/reload-tui` (which reload
 
 In addition to the user-level files under `~/.kimi-code`, Kimi Code reads a project-local configuration file at `<project-root>/.kimi-code/local.toml`. It holds settings that are specific to one project checkout and typically should not be shared with teammates.
 
-The file is created automatically when you add an extra workspace directory with [`/add-dir`](../reference/slash-commands.md) and choose to remember it for the project. You rarely need to edit it by hand.
+The file is updated automatically when you remember an extra workspace directory with [`/add-dir`](../reference/slash-commands.md), or forget one with [`/remove-dir`](../reference/slash-commands.md). You rarely need to edit it by hand.
 
 ### `[workspace]`
 
@@ -472,7 +472,7 @@ The `[workspace]` table groups project-level workspace settings:
 
 | Field | Type | Required | Description |
 | --- | --- | --- | --- |
-| `additional_dir` | `array<string>` | No | Additional workspace directories, stored as absolute paths. Written automatically when you confirm "remember this directory" in `/add-dir`; read back on startup so the directories are available in every session of this project |
+| `additional_dir` | `array<string>` | No | Additional workspace directories, stored as absolute paths. Updated automatically by the remember option in `/add-dir` and the forget option in `/remove-dir`; read back on startup so the directories are available in every session of this project |
 
 ```toml
 [workspace]

--- a/docs/en/reference/slash-commands.md
+++ b/docs/en/reference/slash-commands.md
@@ -41,6 +41,7 @@ Some commands are only available in the idle state. Executing these commands whi
 | `/export-debug-zip` | — | Export the current session as a debug ZIP archive (same behavior as [`kimi export`](./kimi-command.md#kimi-export)) | No |
 | `/copy` | — | Copy the last assistant message to the clipboard | No |
 | `/add-dir [<path>]` | — | Add an extra workspace directory to the current session. Run without a path (or with `list`) to list configured directories. When adding, choose whether to remember the directory for the project in `.kimi-code/local.toml` | No |
+| `/remove-dir [<path>]` | — | Remove an extra workspace directory. Run without a path to choose a configured root. Session-only roots can be removed from the current session; remembered roots must use “Remove and forget” so `.kimi-code/local.toml` and the live tool/file-mention roots stay in sync | No |
 | `/web` | — | Open the current session in the web UI: pick a running server to connect to, or start a new foreground server after the TUI exits. See [`kimi web`](./kimi-command.md#kimi-web) | Yes |
 
 ## Modes & Run Control

--- a/docs/zh/configuration/config-files.md
+++ b/docs/zh/configuration/config-files.md
@@ -464,7 +464,7 @@ auto_install = true
 
 除了 `~/.kimi-code` 下的用户级文件，Kimi Code 还会读取位于 `<项目根目录>/.kimi-code/local.toml` 的项目级本地配置文件。它保存的是与某一个项目检出相关、通常不应与队友共享的设置。
 
-该文件会在你通过 [`/add-dir`](../reference/slash-commands.md) 添加额外工作目录并选择记入项目时自动创建，通常无需手动编辑。
+当你通过 [`/add-dir`](../reference/slash-commands.md) 记住额外工作目录，或通过 [`/remove-dir`](../reference/slash-commands.md) 忘记目录时，该文件会自动更新，通常无需手动编辑。
 
 ### `[workspace]`
 
@@ -472,7 +472,7 @@ auto_install = true
 
 | 字段 | 类型 | 必填 | 说明 |
 | --- | --- | --- | --- |
-| `additional_dir` | `array<string>` | 否 | 额外工作目录列表，以绝对路径存储。在 `/add-dir` 中确认"记住此目录"时自动写入；启动时读回，使这些目录在该项目的每个会话中都可用 |
+| `additional_dir` | `array<string>` | 否 | 额外工作目录列表，以绝对路径存储。由 `/add-dir` 的“记住”选项和 `/remove-dir` 的“忘记”选项自动更新；启动时读回，使这些目录在该项目的每个会话中都可用 |
 
 ```toml
 [workspace]

--- a/docs/zh/reference/slash-commands.md
+++ b/docs/zh/reference/slash-commands.md
@@ -39,6 +39,7 @@
 | `/export-debug-zip` | — | 将当前会话导出为调试用 ZIP 压缩包（与 [`kimi export`](./kimi-command.md#kimi-export) 行为一致） | 否 |
 | `/copy` | — | 将最后一条 AI 回复复制到剪贴板 | 否 |
 | `/add-dir [<path>]` | — | 为当前会话添加额外的工作目录。不带路径（或传入 `list`）运行时列出已配置的目录。添加时可选择是否将目录记入项目的 `.kimi-code/local.toml` | 否 |
+| `/remove-dir [<path>]` | — | 移除额外工作目录。不带路径时可从已配置根目录中选择。仅会话目录可直接从当前会话移除；项目记住的目录必须选择“移除并忘记”，以同步更新 `.kimi-code/local.toml`、文件工具和文件引用补全 | 否 |
 | `/web` | — | 在 web UI 中打开当前会话：选择一个运行中的实例进行连接，或在 TUI 退出后新开一个前台服务器。参见 [`kimi web`](./kimi-command.md#kimi-web) | 是 |
 
 ## 模式与运行控制

--- a/packages/agent-core-v2/src/app/projectLocalConfig/projectLocalConfig.ts
+++ b/packages/agent-core-v2/src/app/projectLocalConfig/projectLocalConfig.ts
@@ -16,15 +16,24 @@ export interface ProjectAdditionalDirsLoadResult {
   readonly additionalDirs: readonly string[];
 }
 
+export interface ProjectAdditionalDirRemoveResult extends ProjectAdditionalDirsLoadResult {
+  readonly removed: boolean;
+}
+
 export interface IProjectLocalConfigService {
   readonly _serviceBrand: undefined;
 
   readAdditionalDirs(workDir: string): Promise<ProjectAdditionalDirsLoadResult>;
   resolveAdditionalDirs(baseDir: string, additionalDirs: readonly string[]): Promise<string[]>;
+  resolveAdditionalDirPath(baseDir: string, inputPath: string): string;
   appendAdditionalDir(
     workDir: string,
     inputPath: string,
   ): Promise<ProjectAdditionalDirsLoadResult>;
+  removeAdditionalDir(
+    workDir: string,
+    inputPath: string,
+  ): Promise<ProjectAdditionalDirRemoveResult>;
 }
 
 export const IProjectLocalConfigService: ServiceIdentifier<IProjectLocalConfigService> =

--- a/packages/agent-core-v2/src/persistence/backends/node-fs/projectLocalConfigService.ts
+++ b/packages/agent-core-v2/src/persistence/backends/node-fs/projectLocalConfigService.ts
@@ -17,6 +17,7 @@ import { ScopeActivation, registerScopedService } from '#/_base/di/scope';
 import { IBootstrapService } from '#/app/bootstrap/bootstrap';
 import {
   IProjectLocalConfigService,
+  type ProjectAdditionalDirRemoveResult,
   type ProjectAdditionalDirsLoadResult,
 } from '#/app/projectLocalConfig/projectLocalConfig';
 import { ErrorCodes, Error2, unwrapErrorCause } from '#/errors';
@@ -67,6 +68,10 @@ export class FileProjectLocalConfigService implements IProjectLocalConfigService
     return this.resolveAdditionalDirsInternal(baseDir, additionalDirs);
   }
 
+  resolveAdditionalDirPath(baseDir: string, inputPath: string): string {
+    return this.resolvePath(baseDir, normalizeAdditionalDirInput(inputPath));
+  }
+
   async appendAdditionalDir(
     workDir: string,
     inputPath: string,
@@ -94,6 +99,38 @@ export class FileProjectLocalConfigService implements IProjectLocalConfigService
     }
 
     return { projectRoot, configPath, additionalDirs: [...fileExistingDirs, additionalDir] };
+  }
+
+  async removeAdditionalDir(
+    workDir: string,
+    inputPath: string,
+  ): Promise<ProjectAdditionalDirRemoveResult> {
+    const projectRoot = await this.findProjectRoot(workDir);
+    const configPath = this.getProjectLocalConfigPath(projectRoot);
+    const target = this.resolveAdditionalDirPath(workDir, inputPath);
+    const file = await this.readProjectLocalToml(configPath);
+    if (file === undefined) {
+      return { projectRoot, configPath, additionalDirs: [], removed: false };
+    }
+
+    const fileAdditionalDirs = file.parsed.workspace?.additional_dir ?? [];
+    const existingDirs = this.resolveExistingAdditionalDirs(projectRoot, fileAdditionalDirs);
+    const additionalDirs = existingDirs.filter(
+      (dir) => normalize(dir) !== normalize(target),
+    );
+    if (additionalDirs.length === existingDirs.length) {
+      return { projectRoot, configPath, additionalDirs: existingDirs, removed: false };
+    }
+
+    const workspace = cloneRecord(file.raw['workspace']);
+    workspace['additional_dir'] = additionalDirs;
+    file.raw['workspace'] = workspace;
+    try {
+      await this.fs.writeText(configPath, `${stringifyToml(file.raw)}\n`);
+    } catch (error: unknown) {
+      throw toStorageIoError(error, { path: configPath, op: 'write' });
+    }
+    return { projectRoot, configPath, additionalDirs, removed: true };
   }
 
   private getProjectLocalConfigPath(projectRoot: string): string {

--- a/packages/agent-core-v2/src/session/workspaceContext/workspaceContext.ts
+++ b/packages/agent-core-v2/src/session/workspaceContext/workspaceContext.ts
@@ -5,8 +5,8 @@
  * paths against the session work directory and to enforce that file/process
  * operations stay within the workspace (plus any additional dirs). The view is
  * read-only: `workDir` is fixed at session creation; `additionalDirs` mirrors
- * the handler-shared set and refreshes when the workspace-level add-dir
- * surface changes it. Pure configuration + boundary — it performs no IO.
+ * the handler-shared set and refreshes when the workspace-level directory
+ * management surface changes it. Pure configuration + boundary — it performs no IO.
  * Session-scoped.
  */
 

--- a/packages/agent-core-v2/src/workspace/workspaceDirs/workspaceDirs.ts
+++ b/packages/agent-core-v2/src/workspace/workspaceDirs/workspaceDirs.ts
@@ -4,8 +4,8 @@
  *
  * Defines `IWorkspaceDirs`, the handler-level owner of the workspace's
  * `{root, additionalDirs[]}` set: at handler materialization it loads the
- * project-local `.kimi-code/local.toml` set; afterwards `addDir` mutations
- * (persisted appends or session-caller in-memory unions) and fs watch on
+ * project-local `.kimi-code/local.toml` set; afterwards `addDir` / `removeDir`
+ * mutations (persisted edits or session-caller in-memory changes) and fs watch on
  * `local.toml` (cross-process edits) refresh the set, fanning the change
  * out to every session of the handler through the `ISessionWorkspaceInfo`
  * seed (`sessionInfo()`). The set is shared by all sessions of the
@@ -23,11 +23,23 @@ export interface WorkspaceAddDirInput {
   readonly persist?: boolean;
 }
 
+export interface WorkspaceRemoveDirInput {
+  readonly path: string;
+  readonly forget?: boolean;
+}
+
 export interface WorkspaceAdditionalDirsResult {
   readonly projectRoot: string;
   readonly configPath: string;
   readonly additionalDirs: readonly string[];
   readonly persisted: boolean;
+}
+
+export interface WorkspaceRemoveDirResult {
+  readonly projectRoot: string;
+  readonly configPath: string;
+  readonly additionalDirs: readonly string[];
+  readonly forgotten: boolean;
 }
 
 export interface IWorkspaceDirs {
@@ -37,6 +49,7 @@ export interface IWorkspaceDirs {
   readonly additionalDirs: readonly string[];
   readonly onDidChange: Event<void>;
   addDir(input: WorkspaceAddDirInput): Promise<WorkspaceAdditionalDirsResult>;
+  removeDir(input: WorkspaceRemoveDirInput): Promise<WorkspaceRemoveDirResult>;
   mergeAdditionalDirs(baseDir: string, dirs: readonly string[]): Promise<void>;
   sessionInfo(): ISessionWorkspaceInfo;
 }

--- a/packages/agent-core-v2/src/workspace/workspaceDirs/workspaceDirsService.ts
+++ b/packages/agent-core-v2/src/workspace/workspaceDirs/workspaceDirsService.ts
@@ -8,7 +8,7 @@
  * change — including writes from OTHER processes), `ephemeralDirs` is the
  * in-memory union of non-persisted `addDir` calls and caller-provided dirs
  * from session create/resume options (it dies with the handler). Every
- * mutation serializes on one tail queue; the change event fires only when
+ * Add and remove mutations serialize on one tail queue; the change event fires only when
  * the combined list actually changed. The set reaches every session of the
  * handler through the `ISessionWorkspaceInfo` seed (`sessionInfo()`), a
  * live read view over this service. The plain-data state (`fileDirs`,
@@ -26,6 +26,7 @@ import { defineState } from '#/_base/state/stateRegistry';
 import { TimeoutTimer } from '#/_base/utils/timer';
 import { subtreeWatchFilter } from '#/_base/utils/paths';
 import { IProjectLocalConfigService } from '#/app/projectLocalConfig/projectLocalConfig';
+import { Error2, ErrorCodes } from '#/errors';
 import { IHostFsWatchService } from '#/os/interface/hostFsWatch';
 import type { ISessionWorkspaceInfo } from '#/session/workspaceInfo/workspaceInfo';
 import { IWorkspaceStateService } from '#/workspace/state/workspaceState';
@@ -35,6 +36,8 @@ import {
   IWorkspaceDirs,
   type WorkspaceAddDirInput,
   type WorkspaceAdditionalDirsResult,
+  type WorkspaceRemoveDirInput,
+  type WorkspaceRemoveDirResult,
 } from './workspaceDirs';
 
 const WATCH_DEBOUNCE_MS = 200;
@@ -99,6 +102,10 @@ export class WorkspaceDirsService extends Service implements IWorkspaceDirs {
     return this.enqueue(() => this.applyAddDir(input));
   }
 
+  removeDir(input: WorkspaceRemoveDirInput): Promise<WorkspaceRemoveDirResult> {
+    return this.enqueue(() => this.applyRemoveDir(input));
+  }
+
   mergeAdditionalDirs(baseDir: string, dirs: readonly string[]): Promise<void> {
     if (dirs.length === 0) return Promise.resolve();
     return this.enqueue(async () => {
@@ -158,6 +165,48 @@ export class WorkspaceDirsService extends Service implements IWorkspaceDirs {
       configPath: onDisk.configPath,
       additionalDirs: this.additionalDirs,
       persisted: false,
+    };
+  }
+
+  private async applyRemoveDir(input: WorkspaceRemoveDirInput): Promise<WorkspaceRemoveDirResult> {
+    const target = this.localConfig.resolveAdditionalDirPath(this.workspace.cwd, input.path);
+    if (target === this.workspace.cwd) {
+      throw new Error2(
+        ErrorCodes.REQUEST_INVALID,
+        'The primary workspace directory cannot be removed',
+      );
+    }
+    if (!this.additionalDirs.includes(target)) {
+      throw new Error2(
+        ErrorCodes.REQUEST_INVALID,
+        `Directory is not an additional workspace root: ${target}`,
+      );
+    }
+    if (input.forget !== true && this.fileDirs.includes(target)) {
+      throw new Error2(
+        ErrorCodes.REQUEST_INVALID,
+        'This directory is remembered by the project; choose the forget option to remove it',
+      );
+    }
+
+    const before = this.additionalDirs;
+    let forgotten = false;
+    if (input.forget === true) {
+      const result = await this.localConfig.removeAdditionalDir(this.workspace.cwd, target);
+      this.projectRoot = result.projectRoot;
+      this.configPath = result.configPath;
+      this.fileDirs = result.additionalDirs;
+      forgotten = result.removed;
+    }
+    this.ephemeralDirs = this.ephemeralDirs.filter((dir) => dir !== target);
+    if (!sameStringList(before, this.additionalDirs)) {
+      this.onDidChangeEmitter.fire();
+    }
+    return {
+      projectRoot: this.projectRoot,
+      configPath: this.configPath,
+      additionalDirs: this.additionalDirs,
+      forgotten,
     };
   }
 

--- a/packages/agent-core-v2/test/app/workspaceLifecycle/workspaceLifecycle.test.ts
+++ b/packages/agent-core-v2/test/app/workspaceLifecycle/workspaceLifecycle.test.ts
@@ -360,7 +360,9 @@ describe('WorkspaceLifecycleService', () => {
           }),
         resolveAdditionalDirs: (_base: string, dirs: readonly string[]) =>
           Promise.resolve([...dirs]),
+        resolveAdditionalDirPath: (_base: string, input: string) => input,
         appendAdditionalDir: () => Promise.reject(new Error('not implemented')),
+        removeAdditionalDir: () => Promise.reject(new Error('not implemented')),
       } satisfies IProjectLocalConfigService),
       stubPair(IHostFsWatchService, {
         _serviceBrand: undefined,

--- a/packages/agent-core-v2/test/session/sessionSeed/sessionSeedAdapters.test.ts
+++ b/packages/agent-core-v2/test/session/sessionSeed/sessionSeedAdapters.test.ts
@@ -156,6 +156,10 @@ class WorkspaceDirsStub implements IWorkspaceDirs {
     return Promise.reject(new Error('not implemented'));
   }
 
+  removeDir(): Promise<never> {
+    return Promise.reject(new Error('not implemented'));
+  }
+
   mergeAdditionalDirs(): Promise<void> {
     return Promise.resolve();
   }

--- a/packages/agent-core-v2/test/workspace/sessionLifecycle/sessionLifecycle.test.ts
+++ b/packages/agent-core-v2/test/workspace/sessionLifecycle/sessionLifecycle.test.ts
@@ -253,7 +253,10 @@ function projectLocalConfigStub(
       }),
     resolveAdditionalDirs: (baseDir: string, dirs: readonly string[]) =>
       Promise.resolve(dirs.map((d) => (isAbsolute(d) ? resolve(d) : resolve(baseDir, d)))),
+    resolveAdditionalDirPath: (baseDir: string, input: string) =>
+      isAbsolute(input) ? resolve(input) : resolve(baseDir, input),
     appendAdditionalDir: () => Promise.reject(new Error('not implemented')),
+    removeAdditionalDir: () => Promise.reject(new Error('not implemented')),
   };
 }
 

--- a/packages/agent-core-v2/test/workspace/workspaceDirs/workspaceDirs.test.ts
+++ b/packages/agent-core-v2/test/workspace/workspaceDirs/workspaceDirs.test.ts
@@ -460,6 +460,58 @@ describe('workspace add-dir (handler chain)', () => {
     expect(dirsOf(s2)).toEqual([extra]);
   });
 
+  it('removes an ephemeral dir from every live session without touching local.toml', async () => {
+    const homeDir = await makeRoot('kimi-remove-dir-home-');
+    const root = await makeProjectRoot();
+    const extra = await makeRoot('kimi-remove-dir-extra-');
+    const host = buildHost(homeDir);
+    const { service, dirs } = await handlerFor(host, root);
+    const s1 = await service.create({ sessionId: 's1', workDir: root });
+    await dirs.addDir({ path: extra, persist: false });
+
+    const result = await dirs.removeDir({ path: extra, forget: false });
+
+    expect(result).toMatchObject({ additionalDirs: [], forgotten: false });
+    expect(dirsOf(s1)).toEqual([]);
+    await expect(readFile(join(root, '.kimi-code', 'local.toml'), 'utf8')).rejects.toThrow();
+  });
+
+  it('forgets a persisted dir and allows cleanup after the directory was deleted', async () => {
+    const homeDir = await makeRoot('kimi-remove-dir-home-');
+    const root = await makeProjectRoot();
+    const extra = await makeRoot('kimi-remove-dir-extra-');
+    const host = buildHost(homeDir);
+    const { service, dirs } = await handlerFor(host, root);
+    const s1 = await service.create({ sessionId: 's1', workDir: root });
+    await dirs.addDir({ path: extra, persist: true });
+    await rm(extra, { recursive: true });
+
+    const result = await dirs.removeDir({ path: extra, forget: true });
+
+    expect(result).toMatchObject({ additionalDirs: [], forgotten: true });
+    expect(dirsOf(s1)).toEqual([]);
+    expect(await readFile(join(root, '.kimi-code', 'local.toml'), 'utf8')).not.toContain(extra);
+  });
+
+  it('rejects removing remembered roots without forgetting, unknown roots, and the primary root', async () => {
+    const homeDir = await makeRoot('kimi-remove-dir-home-');
+    const root = await makeProjectRoot();
+    const extra = await makeRoot('kimi-remove-dir-extra-');
+    const host = buildHost(homeDir);
+    const { dirs } = await handlerFor(host, root);
+    await dirs.addDir({ path: extra, persist: true });
+
+    await expect(dirs.removeDir({ path: extra, forget: false })).rejects.toThrow(
+      'choose the forget option',
+    );
+    await expect(dirs.removeDir({ path: join(root, 'missing'), forget: true })).rejects.toThrow(
+      'not an additional workspace root',
+    );
+    await expect(dirs.removeDir({ path: root, forget: true })).rejects.toThrow(
+      'primary workspace directory',
+    );
+  });
+
   it('refreshes live session views when another process edits local.toml', async () => {
     const homeDir = await makeRoot('kimi-add-dir-home-');
     const root = await makeProjectRoot();

--- a/packages/agent-core-v2/test/workspace/workspaceFs/fsService.test.ts
+++ b/packages/agent-core-v2/test/workspace/workspaceFs/fsService.test.ts
@@ -42,6 +42,7 @@ function stubWorkspaceDirs(): IWorkspaceDirs {
     additionalDirs: [],
     onDidChange: () => ({ dispose: () => {} }),
     addDir: () => Promise.reject(new Error('not supported in tests')),
+    removeDir: () => Promise.reject(new Error('not supported in tests')),
     mergeAdditionalDirs: () => Promise.resolve(),
     sessionInfo: () => {
       throw new Error('not supported in tests');

--- a/packages/agent-core-v2/test/workspace/workspaceFs/fsWatchService.test.ts
+++ b/packages/agent-core-v2/test/workspace/workspaceFs/fsWatchService.test.ts
@@ -48,6 +48,7 @@ function stubWorkspaceDirs(): IWorkspaceDirs {
     additionalDirs: [],
     onDidChange: () => ({ dispose: () => {} }),
     addDir: () => Promise.reject(new Error('not supported in tests')),
+    removeDir: () => Promise.reject(new Error('not supported in tests')),
     mergeAdditionalDirs: () => Promise.resolve(),
     sessionInfo: () => {
       throw new Error('not supported in tests');

--- a/packages/agent-core/src/config/workspace-local.ts
+++ b/packages/agent-core/src/config/workspace-local.ts
@@ -25,6 +25,10 @@ export interface WorkspaceAdditionalDirsLoadResult {
   readonly warning?: string;
 }
 
+export interface WorkspaceAdditionalDirRemoveResult extends WorkspaceAdditionalDirsLoadResult {
+  readonly removed: boolean;
+}
+
 export type WorkspaceLocalConfig = WorkspaceAdditionalDirsLoadResult;
 
 interface WorkspaceLocalTomlFile {
@@ -92,6 +96,44 @@ export async function appendWorkspaceAdditionalDir(
   await kaos.writeText(configPath, `${stringifyToml(file.raw)}\n`);
 
   return { projectRoot, configPath, additionalDirs: [...fileExistingDirs, additionalDir] };
+}
+
+export async function removeWorkspaceAdditionalDir(
+  kaos: Kaos,
+  workDir: string,
+  inputPath: string,
+): Promise<WorkspaceAdditionalDirRemoveResult> {
+  const projectRoot = await findProjectRoot(kaos, workDir);
+  const configPath = getWorkspaceLocalConfigPath(projectRoot);
+  const target = resolveWorkspaceAdditionalDirPath(kaos, workDir, inputPath);
+  const file = await readWorkspaceLocalToml(kaos, configPath);
+  if (file === undefined) {
+    return { projectRoot, configPath, additionalDirs: [], removed: false };
+  }
+
+  const fileAdditionalDirs = file.parsed.workspace?.additional_dir ?? [];
+  const existingDirs = resolveExistingAdditionalDirs(kaos, projectRoot, fileAdditionalDirs);
+  const additionalDirs = existingDirs.filter(
+    (dir) => normalizeForCompare(kaos, dir) !== normalizeForCompare(kaos, target),
+  );
+  if (additionalDirs.length === existingDirs.length) {
+    return { projectRoot, configPath, additionalDirs: existingDirs, removed: false };
+  }
+
+  const workspace = cloneRecord(file.raw['workspace']);
+  workspace['additional_dir'] = additionalDirs;
+  file.raw['workspace'] = workspace;
+  await kaos.writeText(configPath, `${stringifyToml(file.raw)}\n`);
+  return { projectRoot, configPath, additionalDirs, removed: true };
+}
+
+/** Resolve a removal target lexically without requiring it to still exist. */
+export function resolveWorkspaceAdditionalDirPath(
+  kaos: Kaos,
+  baseDir: string,
+  inputPath: string,
+): string {
+  return resolvePath(kaos, baseDir, normalizeAdditionalDirInput(inputPath));
 }
 
 export function normalizeAdditionalDirs(additionalDirs: readonly string[]): string[] {

--- a/packages/agent-core/src/rpc/core-api.ts
+++ b/packages/agent-core/src/rpc/core-api.ts
@@ -428,6 +428,18 @@ export interface AddAdditionalDirResult {
   readonly persisted: boolean;
 }
 
+export interface RemoveAdditionalDirPayload {
+  readonly path: string;
+  readonly forget: boolean;
+}
+
+export interface RemoveAdditionalDirResult {
+  readonly additionalDirs: readonly string[];
+  readonly projectRoot: string;
+  readonly configPath: string;
+  readonly forgotten: boolean;
+}
+
 export interface RenameSessionPayload {
   readonly title: string;
 }
@@ -535,6 +547,7 @@ export interface SessionAPI extends AgentAPIWithId {
   waitForBackgroundTasksOnPrint: (payload: EmptyPayload) => void;
   handlePrintMainTurnCompleted: (payload: EmptyPayload) => 'finish' | 'continue';
   addAdditionalDir: (payload: AddAdditionalDirPayload) => AddAdditionalDirResult;
+  removeAdditionalDir: (payload: RemoveAdditionalDirPayload) => RemoveAdditionalDirResult;
 }
 
 type SessionAPIWithId = WithSessionId<SessionAPI>;

--- a/packages/agent-core/src/rpc/core-impl.ts
+++ b/packages/agent-core/src/rpc/core-impl.ts
@@ -128,6 +128,8 @@ import type {
   RegisterToolPayload,
   ReloadSessionPayload,
   ReloadPluginsResult,
+  RemoveAdditionalDirPayload,
+  RemoveAdditionalDirResult,
   RemoveKimiProviderPayload,
   RemovePluginPayload,
   RenameSessionPayload,
@@ -1151,6 +1153,13 @@ export class KimiCore implements PromisableMethods<CoreAPI> {
     ...payload
   }: SessionScopedPayload<AddAdditionalDirPayload>): Promise<AddAdditionalDirResult> {
     return this.requireSession(sessionId).addAdditionalDir(payload.path, payload.persist);
+  }
+
+  removeAdditionalDir({
+    sessionId,
+    ...payload
+  }: SessionScopedPayload<RemoveAdditionalDirPayload>): Promise<RemoveAdditionalDirResult> {
+    return this.requireSession(sessionId).removeAdditionalDir(payload.path, payload.forget);
   }
 
   startBtw({ sessionId, ...payload }: SessionAgentPayload<EmptyPayload>): Promise<string> {

--- a/packages/agent-core/src/session/index.ts
+++ b/packages/agent-core/src/session/index.ts
@@ -20,6 +20,8 @@ import {
   PRINT_MAX_TURNS_DEFAULT,
   PRINT_WAIT_CEILING_S_DEFAULT,
   readWorkspaceAdditionalDirs,
+  removeWorkspaceAdditionalDir,
+  resolveWorkspaceAdditionalDirPath,
   resolveWorkspaceAdditionalDirs,
   resolveConfigValue,
   type BackgroundConfig,
@@ -394,10 +396,76 @@ export class Session {
     };
   }
 
+  async removeAdditionalDir(
+    path: string,
+    forget = false,
+  ): Promise<WorkspaceAdditionalDirsLoadResult & { readonly forgotten: boolean }> {
+    const cwd = this.toolKaos.getcwd();
+    const systemKaos = this.systemContextKaos(cwd);
+    const target = resolveWorkspaceAdditionalDirPath(systemKaos, cwd, path);
+    const samePath = (candidate: string): boolean =>
+      systemKaos.normpath(candidate) === systemKaos.normpath(target);
+
+    if (systemKaos.normpath(target) === systemKaos.normpath(cwd)) {
+      throw new KimiError(
+        ErrorCodes.REQUEST_INVALID,
+        'The primary workspace directory cannot be removed',
+      );
+    }
+    if (!this.additionalDirs.some(samePath)) {
+      throw new KimiError(
+        ErrorCodes.REQUEST_INVALID,
+        `Directory is not an additional workspace root: ${target}`,
+      );
+    }
+
+    const workspace = forget
+      ? await removeWorkspaceAdditionalDir(systemKaos, cwd, target)
+      : await readWorkspaceAdditionalDirs(systemKaos, cwd).then((currentConfig) => {
+          if (currentConfig.additionalDirs.some(samePath)) {
+            throw new KimiError(
+              ErrorCodes.REQUEST_INVALID,
+              'This directory is remembered by the project; choose the forget option to remove it',
+            );
+          }
+          return { ...currentConfig, removed: false };
+        });
+
+    const nextSessionAdditionalDirs = this.sessionAdditionalDirs.filter((dir) => !samePath(dir));
+    if (nextSessionAdditionalDirs.length !== this.sessionAdditionalDirs.length) {
+      const previousMetadata = this.metadata;
+      this.metadata = { ...this.metadata, additionalDirs: nextSessionAdditionalDirs };
+      try {
+        await this.writeMetadata();
+      } catch (error) {
+        this.metadata = previousMetadata;
+        throw error;
+      }
+      this.sessionAdditionalDirs = nextSessionAdditionalDirs;
+    }
+
+    const additionalDirs = this.additionalDirs.filter((dir) => !samePath(dir));
+    await this.setAdditionalDirs(additionalDirs);
+    this.notifyAdditionalDirRemoved(target, workspace.removed, workspace.configPath);
+    return {
+      projectRoot: workspace.projectRoot,
+      configPath: workspace.configPath,
+      additionalDirs,
+      forgotten: workspace.removed,
+    };
+  }
+
   private notifyAdditionalDirAdded(path: string, persisted: boolean, configPath: string): void {
     const message = persisted
       ? `Added workspace directory:\n  ${path}\n  Saved to:\n  ${configPath}`
       : `Added workspace directory:\n  ${path}\n  For this session only`;
+    this.requireMainAgent().context.appendLocalCommandStdout(message);
+  }
+
+  private notifyAdditionalDirRemoved(path: string, forgotten: boolean, configPath: string): void {
+    const message = forgotten
+      ? `Removed workspace directory:\n  ${path}\n  Removed from:\n  ${configPath}`
+      : `Removed workspace directory:\n  ${path}\n  For this session only`;
     this.requireMainAgent().context.appendLocalCommandStdout(message);
   }
 

--- a/packages/agent-core/src/session/rpc.ts
+++ b/packages/agent-core/src/session/rpc.ts
@@ -22,6 +22,8 @@ import type {
   PromptPayload,
   RunShellCommandPayload,
   ReconnectMcpServerPayload,
+  RemoveAdditionalDirPayload,
+  RemoveAdditionalDirResult,
   RenameSessionPayload,
   RegisterToolPayload,
   SessionAPI,
@@ -118,6 +120,10 @@ export class SessionAPIImpl implements PromisableMethods<SessionAPI> {
 
   addAdditionalDir(payload: AddAdditionalDirPayload): Promise<AddAdditionalDirResult> {
     return this.session.addAdditionalDir(payload.path, payload.persist);
+  }
+
+  removeAdditionalDir(payload: RemoveAdditionalDirPayload): Promise<RemoveAdditionalDirResult> {
+    return this.session.removeAdditionalDir(payload.path, payload.forget);
   }
 
   async prompt({ agentId, ...payload }: AgentScopedPayload<PromptPayload>) {

--- a/packages/agent-core/test/config/workspace-local.test.ts
+++ b/packages/agent-core/test/config/workspace-local.test.ts
@@ -11,6 +11,7 @@ import {
   loadWorkspaceLocalConfig,
   normalizeAdditionalDirs,
   readWorkspaceAdditionalDirs,
+  removeWorkspaceAdditionalDir,
 } from '../../src/config/workspace-local';
 
 const tempDirs: string[] = [];
@@ -174,6 +175,46 @@ describe('workspace local config', () => {
     const result = await appendWorkspaceAdditionalDir(testKaos, root, './shared', []);
 
     expect(result.additionalDirs).toEqual([sharedDir]);
+    await expect(readFile(configPath, 'utf-8')).resolves.toBe(before);
+  });
+
+  it('removes a remembered directory even after the directory was deleted', async () => {
+    const root = await makeProject();
+    const sharedDir = join(root, 'shared');
+    const otherDir = join(root, 'other');
+    await mkdir(sharedDir, { recursive: true });
+    await mkdir(otherDir, { recursive: true });
+    await mkdir(join(root, '.kimi-code'), { recursive: true });
+    const configPath = join(root, '.kimi-code', 'local.toml');
+    await writeFile(
+      configPath,
+      `[workspace]\nadditional_dir = ["shared", "other"]\nlabel = "keep"\n`,
+      'utf-8',
+    );
+    await rm(sharedDir, { recursive: true });
+
+    const result = await removeWorkspaceAdditionalDir(testKaos, root, 'shared');
+
+    expect(result).toMatchObject({ additionalDirs: [otherDir], removed: true });
+    const written = await readFile(configPath, 'utf-8');
+    expect(written).toContain(otherDir);
+    expect(written).not.toContain(sharedDir);
+    expect(written).toContain('label = "keep"');
+  });
+
+  it('does not rewrite local.toml when the removal target is not remembered', async () => {
+    const root = await makeProject();
+    const sharedDir = join(root, 'shared');
+    await mkdir(sharedDir, { recursive: true });
+    await mkdir(join(root, '.kimi-code'), { recursive: true });
+    const configPath = join(root, '.kimi-code', 'local.toml');
+    const before = '[workspace]\nadditional_dir = ["shared"]\n';
+    await writeFile(configPath, before, 'utf-8');
+
+    await expect(removeWorkspaceAdditionalDir(testKaos, root, 'other')).resolves.toMatchObject({
+      additionalDirs: [sharedDir],
+      removed: false,
+    });
     await expect(readFile(configPath, 'utf-8')).resolves.toBe(before);
   });
 

--- a/packages/node-sdk/src/rpc.ts
+++ b/packages/node-sdk/src/rpc.ts
@@ -50,6 +50,8 @@ import type {
   PluginInfo,
   PluginSummary,
   ReloadSummary,
+  RemoveAdditionalDirInput,
+  RemoveAdditionalDirResult,
   CompactOptions,
   SessionPlan,
   SessionStatus,
@@ -426,6 +428,17 @@ export abstract class SDKRpcClientBase {
   async addAdditionalDir(input: AddAdditionalDirInput): Promise<AddAdditionalDirResult> {
     const rpc = await this.getRpc();
     return rpc.addAdditionalDir({ sessionId: input.id, path: input.path, persist: input.persist });
+  }
+
+  async removeAdditionalDir(
+    input: RemoveAdditionalDirInput,
+  ): Promise<RemoveAdditionalDirResult> {
+    const rpc = await this.getRpc();
+    return rpc.removeAdditionalDir({
+      sessionId: input.id,
+      path: input.path,
+      forget: input.forget,
+    });
   }
 
   async startBtw(input: SessionIdRpcInput): Promise<string> {

--- a/packages/node-sdk/src/sdk-rpc-client-v2.ts
+++ b/packages/node-sdk/src/sdk-rpc-client-v2.ts
@@ -27,12 +27,12 @@
  *   every read behind its own initial load, so there is no ready trap here.
  * - `listSessions` / `createSession` / `renameSession` / `forkSession` /
  *   `closeSession` / `resumeSession` / `reloadSession` /
- *   `updateSessionMetadata` / `addAdditionalDir` → the session lifecycle
+ *   `updateSessionMetadata` / `addAdditionalDir` / `removeAdditionalDir` → the session lifecycle
  *   batch: `klient.global.sessions.list` plus the `klient.session(id)`
  *   metadata mutations where the facade reaches, and the
  *   `IWorkspaceLifecycleService` / handler chain / session-scope services through
  *   {@link engineAccessor} where it does not (explicit session ids, resume,
- *   fork ids, the workspace-level add-dir surface). The v1 `SessionSummary` / `SessionMeta`
+ *   fork ids, the workspace-level directory-management surface). The v1 `SessionSummary` / `SessionMeta`
  *   shapes are restored by the pure mapping layer in
  *   `src/v2/session-mapper.ts`. `deleteSession` stays `not_implemented` —
  *   the v2 engine has no session-deletion capability anywhere (tracked in
@@ -292,6 +292,8 @@ import type {
   PluginInfo,
   PluginSummary,
   ReloadSummary,
+  RemoveAdditionalDirInput,
+  RemoveAdditionalDirResult,
   RenameSessionInput,
   ResumeSessionInput,
   ResumedAgentState,
@@ -1248,6 +1250,15 @@ export class SDKRpcClientV2 extends SDKRpcClientBase {
     return handle.accessor
       .get(IWorkspaceDirs)
       .addDir({ path: input.path, persist: input.persist });
+  }
+
+  override async removeAdditionalDir(
+    input: RemoveAdditionalDirInput,
+  ): Promise<RemoveAdditionalDirResult> {
+    const handle = this.requireLiveSession(input.id);
+    return handle.accessor
+      .get(IWorkspaceDirs)
+      .removeDir({ path: input.path, forget: input.forget });
   }
 
   /**

--- a/packages/node-sdk/src/session.ts
+++ b/packages/node-sdk/src/session.ts
@@ -27,6 +27,8 @@ import type {
   PluginSummary,
   PromptInput,
   ReloadSessionOptions,
+  RemoveAdditionalDirOptions,
+  RemoveAdditionalDirResult,
   ReloadSummary,
   ResumedSessionState,
   ResumedSessionSummary,
@@ -198,6 +200,25 @@ export class Session {
       id: this.id,
       path: normalized,
       persist: options?.persist ?? true,
+    });
+    this.summary = { ...this.requireSummary(), additionalDirs: result.additionalDirs };
+    return result;
+  }
+
+  async removeAdditionalDir(
+    path: string,
+    options?: RemoveAdditionalDirOptions,
+  ): Promise<RemoveAdditionalDirResult> {
+    this.ensureOpen();
+    const normalized = normalizeRequiredString(
+      path,
+      'Additional directory cannot be empty',
+      ErrorCodes.REQUEST_INVALID,
+    );
+    const result = await this.rpc.removeAdditionalDir({
+      id: this.id,
+      path: normalized,
+      forget: options?.forget ?? false,
     });
     this.summary = { ...this.requireSummary(), additionalDirs: result.additionalDirs };
     return result;

--- a/packages/node-sdk/src/types.ts
+++ b/packages/node-sdk/src/types.ts
@@ -185,6 +185,17 @@ export interface AddAdditionalDirOptions {
   readonly persist: boolean;
 }
 
+export interface RemoveAdditionalDirInput {
+  readonly id: string;
+  readonly path: string;
+  readonly forget: boolean;
+}
+
+export interface RemoveAdditionalDirOptions {
+  /** Remove a remembered entry from project config as well as the live session. */
+  readonly forget: boolean;
+}
+
 export interface ForkSessionInput {
   readonly id: string;
   readonly forkId?: string;
@@ -297,6 +308,13 @@ export interface AddAdditionalDirResult {
   readonly projectRoot: string;
   readonly configPath: string;
   readonly persisted: boolean;
+}
+
+export interface RemoveAdditionalDirResult {
+  readonly additionalDirs: readonly string[];
+  readonly projectRoot: string;
+  readonly configPath: string;
+  readonly forgotten: boolean;
 }
 
 export type ResumedSessionState = Pick<ResumeSessionResult, 'sessionMetadata' | 'agents' | 'warning'>;

--- a/packages/node-sdk/test/session-context.test.ts
+++ b/packages/node-sdk/test/session-context.test.ts
@@ -45,6 +45,29 @@ describe('Session context', () => {
     }
   });
 
+  it('removes a session-only additional directory from the live session and resume metadata', async () => {
+    const homeDir = await makeTempDir(tempDirs, 'kimi-sdk-remove-home-');
+    const workDir = await makeTempDir(tempDirs, 'kimi-sdk-remove-work-');
+    const additionalDir = await makeTempDir(tempDirs, 'kimi-sdk-remove-dir-');
+    const harness = createKimiHarness({ homeDir, identity: TEST_IDENTITY });
+
+    try {
+      const session = await harness.createSession({ id: 'ses_additional_remove', workDir });
+      await session.addAdditionalDir(additionalDir, { persist: false });
+
+      await expect(
+        session.removeAdditionalDir(additionalDir, { forget: false }),
+      ).resolves.toMatchObject({ additionalDirs: [], forgotten: false });
+      expect(session.summary?.additionalDirs).toEqual([]);
+      await session.close();
+
+      const resumed = await harness.resumeSession({ id: 'ses_additional_remove' });
+      expect(resumed.summary?.additionalDirs).toEqual([]);
+    } finally {
+      await harness.close();
+    }
+  });
+
   it('clears context without replacing the session', async () => {
     const homeDir = await makeTempDir(tempDirs, 'kimi-sdk-context-home-');
     const workDir = await makeTempDir(tempDirs, 'kimi-sdk-context-work-');

--- a/packages/node-sdk/test/v1-v2-parity.test.ts
+++ b/packages/node-sdk/test/v1-v2-parity.test.ts
@@ -1566,12 +1566,49 @@ describe('v1↔v2 session lifecycle parity', () => {
         additionalDirs: [persistedDir, sessionOnlyDir],
         persisted: false,
       });
+      const [v1RemovedSession, v2RemovedSession] = await Promise.all([
+        pair.v1.removeAdditionalDir({
+          id: 'session_parity_adddir',
+          path: sessionOnlyDir,
+          forget: false,
+        }),
+        pair.v2.removeAdditionalDir({
+          id: 'session_parity_adddir',
+          path: sessionOnlyDir,
+          forget: false,
+        }),
+      ]);
+      expect(v2RemovedSession).toEqual(v1RemovedSession);
+      expect(v1RemovedSession).toMatchObject({
+        additionalDirs: [persistedDir],
+        forgotten: false,
+      });
+      const v1Forgotten = await pair.v1.removeAdditionalDir({
+        id: 'session_parity_adddir',
+        path: persistedDir,
+        forget: true,
+      });
+      const v2Forgotten = await pair.v2.removeAdditionalDir({
+        id: 'session_parity_adddir',
+        path: persistedDir,
+        forget: true,
+      });
+      expect(v1Forgotten).toMatchObject({ additionalDirs: [], forgotten: true });
+      // The clients share one project config in this parity fixture, so v1
+      // performs the disk deletion before v2; both live views still converge.
+      expect(v2Forgotten).toMatchObject({ additionalDirs: [] });
       // v1 requires the active session on both engines.
       await expect(
         pair.v1.addAdditionalDir({ id: 'session_missing', path: persistedDir, persist: true }),
       ).rejects.toMatchObject({ code: ErrorCodes.SESSION_NOT_FOUND });
       await expect(
         pair.v2.addAdditionalDir({ id: 'session_missing', path: persistedDir, persist: true }),
+      ).rejects.toMatchObject({ code: ErrorCodes.SESSION_NOT_FOUND });
+      await expect(
+        pair.v1.removeAdditionalDir({ id: 'session_missing', path: persistedDir, forget: true }),
+      ).rejects.toMatchObject({ code: ErrorCodes.SESSION_NOT_FOUND });
+      await expect(
+        pair.v2.removeAdditionalDir({ id: 'session_missing', path: persistedDir, forget: true }),
       ).rejects.toMatchObject({ code: ErrorCodes.SESSION_NOT_FOUND });
     } finally {
       await closeSessionPair(pair);


### PR DESCRIPTION
## Related Issue

Follow-up to #396 and #812.

## Problem

`/add-dir` can add session-only or remembered workspace roots, but there is no symmetric way to remove one. Users must edit `.kimi-code/local.toml` or restart the process, while live file-tool permissions and file-mention completion continue to include the old root.

## What Changed

- added `/remove-dir [<path>]` to the TUI
  - bare invocation opens a selector of configured roots
  - distinguishes removing a session-only root from removing and forgetting a project root
  - refreshes app state and slash/file completion after success
- added `/remove-dir [--forget] <path>` to the VS Code host commands
- added the public `Session.removeAdditionalDir()` SDK operation and v1/v2 RPC plumbing
- updated both engine implementations
  - removes roots from live file/process access immediately
  - updates session resume metadata for session-only roots
  - updates `.kimi-code/local.toml` for remembered roots while preserving unrelated TOML fields
  - permits cleanup when the removed directory no longer exists on disk
  - rejects the primary workspace root, unknown roots, and accidental session-only removal of remembered roots
- updated English and Chinese docs and added a patch changeset

## Verification

- TUI command/registry/availability suites: 38 tests
- agent-core project-local config removal tests
- agent-core-v2 workspace directory integration suite: 9 tests
- public SDK session removal test
- focused v1/v2 parity test
- focused VS Code integration test
- typecheck: agent-core, agent-core-v2, node-sdk, kimi-code app, and VS Code app
- package build, kimi-code production build, VS Code extension/webview build, and docs build
- agent-core-v2 import-boundary check
- full repository lint: 0 errors (existing warnings only)
- `git diff --check`

## Checklist

- [x] Existing open PRs searched; no duplicate remove-dir contribution found
- [x] Public API, both engines, TUI, and VS Code updated
- [x] Tests cover persistence, live-session refresh, invalid roots, and deleted directories
- [x] English and Chinese docs updated
- [x] Changeset added
