### PR TITLE
fix(auth): classify OAuth token errors as connection/login, not internal

### DIFF
--- a/.changeset/oauth-connection-error-classification.md
+++ b/.changeset/oauth-connection-error-classification.md
@@ -1,0 +1,7 @@
+---
+"@moonshot-ai/kimi-code": patch
+"@moonshot-ai/agent-core": patch
+"@moonshot-ai/agent-core-v2": patch
+---
+
+Classify OAuth connection failures during a running task as retryable connection errors instead of generic internal errors, so the session pauses with the correct reason rather than breaking on a transient auth-host outage.

--- a/packages/agent-core-v2/src/app/auth/authService.ts
+++ b/packages/agent-core-v2/src/app/auth/authService.ts
@@ -20,7 +20,10 @@ import {
   KIMI_CODE_PROVIDER_NAME,
   KimiOAuthToolkit,
   kimiCodeBaseUrl,
+  OAuthConnectionError,
   OAuthError,
+  OAuthUnauthorizedError,
+  RetryableRefreshError,
   applyManagedKimiCodeConfig,
   clearManagedKimiCodeConfig,
   fetchManagedKimiCodeModels,
@@ -47,6 +50,8 @@ import { Disposable } from '#/_base/di/lifecycle';
 import { LifecycleScope } from '#/app/scopes';
 import { ScopeActivation, registerScopedService } from '#/_base/di/scope';
 import { Error2, ErrorCodes } from '#/errors';
+import { AuthErrors } from '#/app/auth/errors';
+import { ProtocolErrors } from '#/kosong/protocol/errors';
 import { IBootstrapService } from '#/app/bootstrap/bootstrap';
 import { IConfigService } from '#/app/config/config';
 import { IEventService } from '#/app/event/event';
@@ -261,7 +266,25 @@ export class OAuthService extends Disposable implements IOAuthService {
   }
 
   resolveTokenProvider(provider: string, oauthRef?: OAuthRef): BearerTokenProvider | undefined {
-    return this.toolkit.tokenProvider(provider, this.resolveRuntimeOAuthRef(provider, oauthRef));
+    const tokenProvider = this.toolkit.tokenProvider(
+      provider,
+      this.resolveRuntimeOAuthRef(provider, oauthRef),
+    );
+    // Classify OAuth token failures into coded `Error2`s at the auth-domain
+    // boundary (`_base/errors` deliberately never imports a business domain, so
+    // the translation must happen here — see `_base/errors/serialize.ts`).
+    // Without this, a transport failure (e.g. auth host connect timeout during
+    // a long task) propagates as a raw `OAuthConnectionError` and serializes as
+    // `[internal]`, losing the retryable flag and the connection pause reason.
+    return {
+      getAccessToken: async (options) => {
+        try {
+          return await tokenProvider.getAccessToken(options);
+        } catch (error) {
+          throw classifyOAuthTokenError(error, provider) ?? error;
+        }
+      },
+    };
   }
 
   getCachedAccessToken(provider: string, oauthRef?: OAuthRef): Promise<string | undefined> {
@@ -857,6 +880,31 @@ function managedModel(
   alias: string,
 ): ManagedModel | undefined {
   return config.models?.[alias] as ManagedModel | undefined;
+}
+
+/**
+ * Classify an OAuth token-fetch failure into a coded `Error2` at the auth-
+ * domain boundary, so the turn serializes a precise code (`auth.login_required`
+ * / `provider.connection_error`) instead of the catch-all `internal`. Only
+ * positively-identified errors are mapped; the rest return `undefined` so the
+ * caller rethrows raw.
+ */
+function classifyOAuthTokenError(error: unknown, provider: string): Error2 | undefined {
+  if (error instanceof OAuthUnauthorizedError) {
+    return new Error2(
+      AuthErrors.codes.AUTH_LOGIN_REQUIRED,
+      `OAuth provider "${provider}" requires login before it can be used.`,
+      { cause: error },
+    );
+  }
+  if (error instanceof OAuthConnectionError || error instanceof RetryableRefreshError) {
+    return new Error2(
+      ProtocolErrors.codes.PROVIDER_CONNECTION_ERROR,
+      `OAuth provider "${provider}" failed to fetch an access token: ${error.message}`,
+      { cause: error },
+    );
+  }
+  return undefined;
 }
 
 class OAuthToolkitService extends KimiOAuthToolkit implements IOAuthToolkit {

--- a/packages/agent-core-v2/src/app/auth/authService.ts
+++ b/packages/agent-core-v2/src/app/auth/authService.ts
@@ -270,12 +270,6 @@ export class OAuthService extends Disposable implements IOAuthService {
       provider,
       this.resolveRuntimeOAuthRef(provider, oauthRef),
     );
-    // Classify OAuth token failures into coded `Error2`s at the auth-domain
-    // boundary (`_base/errors` deliberately never imports a business domain, so
-    // the translation must happen here — see `_base/errors/serialize.ts`).
-    // Without this, a transport failure (e.g. auth host connect timeout during
-    // a long task) propagates as a raw `OAuthConnectionError` and serializes as
-    // `[internal]`, losing the retryable flag and the connection pause reason.
     return {
       getAccessToken: async (options) => {
         try {
@@ -882,13 +876,6 @@ function managedModel(
   return config.models?.[alias] as ManagedModel | undefined;
 }
 
-/**
- * Classify an OAuth token-fetch failure into a coded `Error2` at the auth-
- * domain boundary, so the turn serializes a precise code (`auth.login_required`
- * / `provider.connection_error`) instead of the catch-all `internal`. Only
- * positively-identified errors are mapped; the rest return `undefined` so the
- * caller rethrows raw.
- */
 function classifyOAuthTokenError(error: unknown, provider: string): Error2 | undefined {
   if (error instanceof OAuthUnauthorizedError) {
     return new Error2(

--- a/packages/agent-core-v2/test/app/auth/auth.test.ts
+++ b/packages/agent-core-v2/test/app/auth/auth.test.ts
@@ -8,6 +8,9 @@
 import { afterEach, beforeEach, describe, expect, it, vi, type Mock } from 'vitest';
 import {
   clearManagedKimiCodeConfig,
+  OAuthConnectionError,
+  OAuthUnauthorizedError,
+  RetryableRefreshError,
   resolveKimiCodeOAuthKey,
   resolveKimiCodeRuntimeAuth,
 } from '@moonshot-ai/kimi-code-oauth';
@@ -16,7 +19,10 @@ import { DisposableStore } from '#/_base/di/lifecycle';
 import { createServices, type TestInstantiationService } from '#/_base/di/test';
 import { Emitter } from '#/_base/event';
 import { IAuthSummaryService, IOAuthService, IOAuthToolkit } from '#/app/auth/auth';
+import { AuthErrors } from '#/app/auth/errors';
 import { AuthSummaryService, OAuthService } from '#/app/auth/authService';
+import { Error2 } from '#/errors';
+import { ProtocolErrors } from '#/kosong/protocol/errors';
 import {
   SERVICES_SECTION,
   servicesFromToml,
@@ -209,6 +215,78 @@ describe('OAuthService', () => {
   function configBacking(): Record<string, unknown> {
     return { providers, models, services, defaultModel, thinking };
   }
+
+  describe('resolveTokenProvider — OAuth error classification', () => {
+    // See MoonshotAI/kimi-code#2786: without classification at the auth-domain
+    // boundary, a raw `OAuthConnectionError` from the toolkit serializes as
+    // `[internal]`, losing the retryable flag and the connection pause reason.
+    function throwingProvider(error: unknown): void {
+      toolkit.tokenProvider.mockReturnValue({
+        getAccessToken: async () => {
+          throw error;
+        },
+      });
+    }
+
+    async function catchTokenError(): Promise<unknown> {
+      return createService()
+        .resolveTokenProvider(OAUTH_PROVIDER)!
+        .getAccessToken()
+        .catch((caught: unknown) => caught);
+    }
+
+    it('maps OAuthConnectionError to provider.connection_error', async () => {
+      const tokenError = new OAuthConnectionError(
+        'OAuth request to https://auth.kimi.com/api/oauth/token failed: fetch failed',
+      );
+      throwingProvider(tokenError);
+
+      const error = await catchTokenError();
+
+      expect(error).toBeInstanceOf(Error2);
+      expect(error).toMatchObject({
+        code: ProtocolErrors.codes.PROVIDER_CONNECTION_ERROR,
+        message: expect.stringContaining(tokenError.message),
+        cause: tokenError,
+      });
+    });
+
+    it('maps RetryableRefreshError to provider.connection_error', async () => {
+      const tokenError = new RetryableRefreshError('Token refresh failed (HTTP 503).');
+      throwingProvider(tokenError);
+
+      const error = await catchTokenError();
+
+      expect(error).toBeInstanceOf(Error2);
+      expect(error).toMatchObject({
+        code: ProtocolErrors.codes.PROVIDER_CONNECTION_ERROR,
+        cause: tokenError,
+      });
+    });
+
+    it('maps OAuthUnauthorizedError to auth.login_required', async () => {
+      const tokenError = new OAuthUnauthorizedError('Stored token was rejected; re-login required.');
+      throwingProvider(tokenError);
+
+      const error = await catchTokenError();
+
+      expect(error).toBeInstanceOf(Error2);
+      expect(error).toMatchObject({
+        code: AuthErrors.codes.AUTH_LOGIN_REQUIRED,
+        cause: tokenError,
+      });
+    });
+
+    it('rethrows unrecognized errors raw instead of guessing a category', async () => {
+      const tokenError = new Error('storage exploded');
+      throwingProvider(tokenError);
+
+      const error = await catchTokenError();
+
+      expect(error).toBe(tokenError);
+      expect(error).not.toBeInstanceOf(Error2);
+    });
+  });
 
   function stubManagedModelsFetch(): ReturnType<typeof vi.fn> {
     const fetchMock = vi.fn().mockResolvedValue({

--- a/packages/agent-core/src/services/auth/managedAuth.ts
+++ b/packages/agent-core/src/services/auth/managedAuth.ts
@@ -6,14 +6,18 @@ import {
   applyManagedKimiCodeLogoutConfig,
   KIMI_CODE_PROVIDER_NAME,
   KimiOAuthToolkit,
+  OAuthConnectionError,
+  OAuthUnauthorizedError,
   resolveKimiCodeLoginAuth,
   resolveKimiCodeRuntimeAuth,
+  RetryableRefreshError,
   type BearerTokenProvider,
   type KimiHostIdentity,
   type KimiOAuthLoginOptions,
   type ManagedKimiConfigShape,
 } from '@moonshot-ai/kimi-code-oauth';
 
+import { ErrorCodes, KimiError } from '../../errors';
 import type { IEnvironmentService } from '../environment/environment';
 
 type ServicesManagedConfig = KimiConfig & ManagedKimiConfigShape;
@@ -125,10 +129,25 @@ class ServicesManagedAuthFacade implements ServicesAuthFacade {
     providerName: string,
     oauthRef?: OAuthRef | undefined,
   ): BearerTokenProvider => {
-    return this.toolkit.tokenProvider(
+    const provider = this.toolkit.tokenProvider(
       providerName,
       this.runtimeOAuthRef(providerName, oauthRef),
     );
+    // Classify OAuth token failures into the public KimiError protocol so the
+    // turn surfaces `auth.login_required` / `provider.connection_error` instead
+    // of collapsing everything to `internal`. Without this, a transport failure
+    // (e.g. auth host connect timeout during a long task) propagates as a raw
+    // `OAuthConnectionError` and serializes as `[internal]`, losing the
+    // retryable flag and the dedicated pause reason.
+    return {
+      getAccessToken: async (options) => {
+        try {
+          return await provider.getAccessToken(options);
+        } catch (error) {
+          throw mapOAuthTokenError(error, providerName) ?? error;
+        }
+      },
+    };
   };
 
   private resolveManagedAuth(providerName?: string | undefined): {
@@ -175,4 +194,33 @@ export function createManagedAuthFacade(
   identity?: KimiHostIdentity,
 ): ServicesAuthFacade {
   return new ServicesManagedAuthFacade(env, identity);
+}
+
+/**
+ * Classify an OAuth token-fetch failure into the public {@link KimiError}
+ * protocol so callers (turn serialization, SDK clients) can react on `code`
+ * rather than on class identity.
+ *
+ * Mirrors `mapOAuthTokenError` in `@moonshot-ai/kimi-code-sdk`; kept local
+ * because agent-core cannot import the SDK (the dependency direction is
+ * reversed). Only positively-identified errors are mapped — the rest return
+ * `undefined` so the caller rethrows raw and surfaces as `internal`, which is
+ * correct for genuinely unrecognized failures (e.g. storage or lock errors).
+ */
+function mapOAuthTokenError(error: unknown, providerName: string): KimiError | undefined {
+  if (error instanceof OAuthUnauthorizedError) {
+    return new KimiError(
+      ErrorCodes.AUTH_LOGIN_REQUIRED,
+      `OAuth provider "${providerName}" requires login before it can be used.`,
+      { cause: error },
+    );
+  }
+  if (error instanceof OAuthConnectionError || error instanceof RetryableRefreshError) {
+    return new KimiError(
+      ErrorCodes.PROVIDER_CONNECTION_ERROR,
+      `OAuth provider "${providerName}" failed to fetch an access token: ${error.message}`,
+      { cause: error },
+    );
+  }
+  return undefined;
 }

--- a/packages/agent-core/src/services/auth/managedAuth.ts
+++ b/packages/agent-core/src/services/auth/managedAuth.ts
@@ -133,12 +133,6 @@ class ServicesManagedAuthFacade implements ServicesAuthFacade {
       providerName,
       this.runtimeOAuthRef(providerName, oauthRef),
     );
-    // Classify OAuth token failures into the public KimiError protocol so the
-    // turn surfaces `auth.login_required` / `provider.connection_error` instead
-    // of collapsing everything to `internal`. Without this, a transport failure
-    // (e.g. auth host connect timeout during a long task) propagates as a raw
-    // `OAuthConnectionError` and serializes as `[internal]`, losing the
-    // retryable flag and the dedicated pause reason.
     return {
       getAccessToken: async (options) => {
         try {
@@ -196,17 +190,6 @@ export function createManagedAuthFacade(
   return new ServicesManagedAuthFacade(env, identity);
 }
 
-/**
- * Classify an OAuth token-fetch failure into the public {@link KimiError}
- * protocol so callers (turn serialization, SDK clients) can react on `code`
- * rather than on class identity.
- *
- * Mirrors `mapOAuthTokenError` in `@moonshot-ai/kimi-code-sdk`; kept local
- * because agent-core cannot import the SDK (the dependency direction is
- * reversed). Only positively-identified errors are mapped — the rest return
- * `undefined` so the caller rethrows raw and surfaces as `internal`, which is
- * correct for genuinely unrecognized failures (e.g. storage or lock errors).
- */
 function mapOAuthTokenError(error: unknown, providerName: string): KimiError | undefined {
   if (error instanceof OAuthUnauthorizedError) {
     return new KimiError(

--- a/packages/agent-core/test/services/oauth-service.test.ts
+++ b/packages/agent-core/test/services/oauth-service.test.ts
@@ -25,15 +25,25 @@
  *   - logout → delegates to facade.logout
  */
 
-import { assert, describe, expect, it, vi } from 'vitest';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, assert, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import {
   DeviceCodeTimeoutError,
+  KIMI_CODE_PROVIDER_NAME,
+  KimiOAuthToolkit,
+  OAuthConnectionError,
   OAuthError,
+  OAuthUnauthorizedError,
+  RetryableRefreshError,
   type DeviceAuthorization,
 } from '@moonshot-ai/kimi-code-oauth';
 
-import type { ServicesAuthFacade } from '../../src/services/auth/managedAuth';
+import { ErrorCodes, KimiError } from '../../src/errors';
+import { createManagedAuthFacade, type ServicesAuthFacade } from '../../src/services/auth/managedAuth';
 import { IEnvironmentService } from '../../src/services/environment/environment';
 import { OAuthService } from '../../src/services/oauth/oauthService';
 
@@ -335,5 +345,75 @@ describe('OAuthService.logout', () => {
     // After logout, the in-memory flow is in 'cancelled' terminal state
     expect(impl.getFlow()!.status).toBe('cancelled');
     expect(mock.loginCalls[0]!.signal!.aborted).toBe(true);
+  });
+});
+
+describe('ServicesManagedAuthFacade.resolveOAuthTokenProvider — OAuth error classification', () => {
+  // Without classification at the facade boundary, a transport failure (e.g.
+  // auth host connect timeout during a long task) propagates as a raw
+  // `OAuthConnectionError` and serializes as `[internal]`, losing the retryable
+  // flag and the dedicated pause reason. See MoonshotAI/kimi-code#2786.
+  let homeDir: string;
+
+  beforeEach(async () => {
+    homeDir = await mkdtemp(join(tmpdir(), 'kimi-managed-auth-'));
+  });
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    await rm(homeDir, { recursive: true, force: true });
+  });
+
+  async function caughtTokenError(tokenError: unknown): Promise<unknown> {
+    vi.spyOn(KimiOAuthToolkit.prototype, 'tokenProvider').mockReturnValue({
+      async getAccessToken() {
+        throw tokenError;
+      },
+    });
+    const facade = createManagedAuthFacade({ homeDir, configPath: join(homeDir, 'config.toml') });
+    return facade
+      .resolveOAuthTokenProvider(KIMI_CODE_PROVIDER_NAME)!
+      .getAccessToken()
+      .catch((caught: unknown) => caught);
+  }
+
+  it('maps transient OAuth transport failures to provider.connection_error', async () => {
+    const tokenErrors = [
+      new OAuthConnectionError(
+        'OAuth request to https://auth.kimi.com/api/oauth/token failed: fetch failed',
+      ),
+      new RetryableRefreshError('Token refresh failed (HTTP 503).'),
+    ];
+
+    for (const tokenError of tokenErrors) {
+      const error = await caughtTokenError(tokenError);
+
+      expect(error).toBeInstanceOf(KimiError);
+      expect(error).toMatchObject({
+        code: ErrorCodes.PROVIDER_CONNECTION_ERROR,
+        message: expect.stringContaining(tokenError.message),
+        cause: tokenError,
+      });
+    }
+  });
+
+  it('maps OAuth unauthorized failures to auth.login_required', async () => {
+    const tokenError = new OAuthUnauthorizedError('Stored token was rejected; re-login required.');
+
+    const error = await caughtTokenError(tokenError);
+
+    expect(error).toBeInstanceOf(KimiError);
+    expect(error).toMatchObject({
+      code: ErrorCodes.AUTH_LOGIN_REQUIRED,
+      cause: tokenError,
+    });
+  });
+
+  it('rethrows unrecognized errors raw instead of guessing a category', async () => {
+    const tokenError = new Error('storage exploded');
+
+    const error = await caughtTokenError(tokenError);
+
+    expect(error).toBe(tokenError);
+    expect(error).not.toBeInstanceOf(KimiError);
   });
 });


### PR DESCRIPTION
## Related Issue

Resolve #2786

## Problem

See linked issue (#2786). In short: on the default v2 engine (and the v1 daemon / legacy path), an OAuth token-fetch failure during a running task — e.g. a transient auth-host connect timeout — surfaced to the user as `[internal]` instead of a retryable `provider.connection_error`. That lost the retryable flag and routed the goal to the generic runtime pause reason instead of the dedicated connection pause, so a brief network blip broke long-running tasks.

Root cause: the OAuth-error → public-error-code classification (`mapOAuthTokenError`) existed only in `@moonshot-ai/kimi-code-sdk`'s `AuthFacade`. The token providers handed out by agent-core's `ManagedAuthFacade.resolveOAuthTokenProvider` and agent-core-v2's `OAuthService.resolveTokenProvider` propagated raw `OAuthConnectionError`s, which serialize as `internal`.

## What changed

Wrap the two unwrapped token-provider factories so `getAccessToken` classifies OAuth failures into the public coded errors at the auth-domain boundary (v2 `_base/errors` forbids importing business domains, so the translation belongs at the boundary, not in the central serializer):

- `packages/agent-core/src/services/auth/managedAuth.ts` — `resolveOAuthTokenProvider` now wraps the provider; added `mapOAuthTokenError` (mirrors the SDK helper; kept local because agent-core cannot import the SDK).
- `packages/agent-core-v2/src/app/auth/authService.ts` — `resolveTokenProvider` now wraps the provider; added `classifyOAuthTokenError`.

Mapping (matches the existing SDK behavior):
- `OAuthConnectionError` / `RetryableRefreshError` → `provider.connection_error` (retryable)
- `OAuthUnauthorizedError` → `auth.login_required`
- anything else → rethrown raw (no false classification)

`getCachedAccessToken` is intentionally left unwrapped: it only reads local token storage (no HTTP / refresh), so it cannot produce these OAuth errors — wrapping it would be a no-op.

node-sdk is untouched (its facade already classifies). The now-triplicated classification logic is tracked for consolidation in #2787.

Tests added to the existing test files (v1 `oauth-service.test.ts`, v2 `auth.test.ts`): each path covers the connection mapping, the unauthorized mapping, and the "rethrow unrecognized raw" case. 81 relevant tests pass; both packages `tsc --noEmit` clean.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.
