### PR TITLE
fix(agent-core-v2): normalize generated manifest paths to forward slashes

### DIFF
--- a/packages/agent-core-v2/scripts/gen-config-manifest.mts
+++ b/packages/agent-core-v2/scripts/gen-config-manifest.mts
@@ -22,8 +22,10 @@
  */
 
 import { readdirSync, readFileSync, statSync, writeFileSync } from 'node:fs';
-import { join, relative } from 'node:path';
+import { join } from 'node:path';
 import { pathToFileURL } from 'node:url';
+
+import { relative } from 'pathe';
 
 import { getConfigOverlayContributions } from '#/app/config/configOverlayContributions';
 import type { ConfigSectionContribution } from '#/app/config/configSectionContributions';

--- a/packages/agent-core-v2/scripts/gen-wire-manifest.mts
+++ b/packages/agent-core-v2/scripts/gen-wire-manifest.mts
@@ -23,8 +23,10 @@
  */
 
 import { existsSync, readdirSync, readFileSync, statSync, writeFileSync } from 'node:fs';
-import { dirname, join, relative } from 'node:path';
+import { dirname, join } from 'node:path';
 import { pathToFileURL } from 'node:url';
+
+import { relative } from 'pathe';
 
 import { MODEL_CROSS_REDUCERS } from '#/wire/model';
 import { OP_REGISTRY } from '#/wire/op';


### PR DESCRIPTION
`gen-config-manifest.mts`/`gen-wire-manifest.mts` used `node:path`'s `relative()`, which returns backslash paths on Windows, failing the docs 'up to date' check. Switched to `pathe`'s `relative()`, which normalizes to forward slashes directly.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.
