### PR TITLE
fix(vscode): report a busy session as turn.agent_busy, not an internal error

### DIFF
--- a/.changeset/vscode-busy-error-message.md
+++ b/.changeset/vscode-busy-error-message.md
@@ -1,0 +1,5 @@
+---
+"kimi-code": patch
+---
+
+Stop reporting a busy chat session as "Internal error occurred." A prompt sent while a response is still being generated now surfaces as "A message is being sent. Please wait." (code `turn.agent_busy`) with the original detail attached, instead of the generic internal-error message that the plain `Error` was mapped to.

--- a/apps/vscode/src/runtime/session-runtime.ts
+++ b/apps/vscode/src/runtime/session-runtime.ts
@@ -1,5 +1,6 @@
 import {
   isKimiError,
+  KimiError,
   type ContentPart as SdkContentPart,
   type Event,
   type PromptInput,
@@ -188,7 +189,7 @@ export class SessionRuntime {
       // such terminal event, so reject terminally: the caller's composer must
       // unlock rather than hang until the handshake timeout.
       this.emitError(
-        new Error(ALREADY_GENERATING_MESSAGE),
+        new KimiError("turn.agent_busy", ALREADY_GENERATING_MESSAGE),
         "runtime",
         { terminal: this.hasActiveWork ? false : undefined },
       );
@@ -225,7 +226,7 @@ export class SessionRuntime {
   beginHostAction(input: string | LegacyContentPart[], forkable = false): number {
     this.ensureOpen();
     if (this.isBusy) {
-      throw new Error(ALREADY_GENERATING_MESSAGE);
+      throw new KimiError("turn.agent_busy", ALREADY_GENERATING_MESSAGE);
     }
     const actionId = ++this.hostActionSequence;
     this.hostActionActive = true;

--- a/apps/vscode/test/kimi-runtime.test.ts
+++ b/apps/vscode/test/kimi-runtime.test.ts
@@ -652,6 +652,8 @@ describe("Kimi runtime (owns shared SDK sessions for Webviews)", () => {
     const busyWarning = broadcasts.find(({ data }) => (data as { type?: string }).type === "error");
     expect(busyWarning?.data).toMatchObject({
       type: "error",
+      code: "turn.agent_busy",
+      message: "A message is being sent. Please wait.",
       phase: "runtime",
       detail: "A response is already being generated for this session.",
       terminal: false,

--- a/apps/vscode/test/settings-store.test.ts
+++ b/apps/vscode/test/settings-store.test.ts
@@ -548,15 +548,15 @@ describe("Webview mid-turn warnings", () => {
 
     useChatStore.getState().processEvent({
       type: "error",
-      code: "internal",
-      message: "Internal error occurred.",
+      code: "turn.agent_busy",
+      message: "A message is being sent. Please wait.",
       detail: "A response is already being generated for this session.",
       phase: "runtime",
       terminal: false,
     });
 
     // The turn is still running: nothing unlocks, nothing flushes, nothing is retried.
-    expect(boundary.toastWarning).toHaveBeenCalledWith("Internal error occurred.");
+    expect(boundary.toastWarning).toHaveBeenCalledWith("A message is being sent. Please wait.");
     const state = useChatStore.getState();
     expect(state.isStreaming).toBe(true);
     expect(state.queue).toHaveLength(1);


### PR DESCRIPTION
## Related Issue

Resolve #2796

## Problem

See linked issue. A prompt sent while a session is busy is rejected with a plain `Error`, which `emitError` maps to code `internal`, so the webview shows **"Internal error occurred."** for what is simply "a response is already being generated". When a turn wedges (see #1050), every subsequent message in that session shows the scary generic error with no hint about the real state.

## What changed

`SessionRuntime.runTurnAction` and `beginHostAction` now throw `KimiError("turn.agent_busy", ...)` instead of a plain `Error`. `emitError` already special-cases `KimiError`, and the error table already maps `turn.agent_busy` → "A message is being sent. Please wait." — only the throw sites needed to change. Test expectations updated (`kimi-runtime.test.ts`, `settings-store.test.ts`) to assert the code and the user-facing message.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my fix works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset. (changeset included: `kimi-code` patch)
- [x] Ran `gen-docs` skill, or this PR needs no doc update.