### PR TITLE
fix(vscode): reuse the existing runtime when session opens race

### DIFF
--- a/.changeset/vscode-duplicate-session-wrap.md
+++ b/.changeset/vscode-duplicate-session-wrap.md
@@ -1,0 +1,5 @@
+---
+"kimi-code": patch
+---
+
+Fix duplicated, interleaved assistant output (e.g. "TheThe roaring roaring") when two views race to open the same session. A concurrent open/attach used to wrap the session in a second `SessionRuntime` whose event subscription was never cleaned up, so every streamed part was broadcast twice; the later open now reuses the existing runtime.

--- a/apps/vscode/src/runtime/kimi-runtime.ts
+++ b/apps/vscode/src/runtime/kimi-runtime.ts
@@ -117,6 +117,7 @@ export class KimiRuntime {
               metadata: legacyApprovalMetadata(defaultApproval),
             })
           : await this.harness.resumeSession({ id: requestedId, includeSubagents: true });
+      let wrapped: { runtime: SessionRuntime; reused: boolean } | undefined;
       try {
         assertSessionWorkDir(session, options.workDir);
         const storedApproval = readLegacyApprovalFlags(session.summary?.metadata);
@@ -128,11 +129,20 @@ export class KimiRuntime {
         }
         await applySessionSettings(session, options, approval);
         await this.detachView(options.webviewId);
-        runtime = this.wrapSession(session, approval);
+        wrapped = this.wrapSession(session, approval);
+        runtime = wrapped.runtime;
+        if (wrapped.reused) {
+          await this.reconcileWrappedApproval(session, runtime);
+        }
       } catch (error) {
-        await session.close().catch((closeError: unknown) => {
-          this.log("Failed to close a rejected session", closeError);
-        });
+        // When the wrap was reused, `session` is the losing race handle:
+        // closing it would close the shared engine session out from under the
+        // surviving runtime and any active turn.
+        if (wrapped?.reused !== true) {
+          await session.close().catch((closeError: unknown) => {
+            this.log("Failed to close a rejected session", closeError);
+          });
+        }
         throw error;
       }
     }
@@ -157,6 +167,7 @@ export class KimiRuntime {
     await this.detachView(webviewId);
     let runtime = existing ?? this.sessions.get(session.id);
     if (runtime === undefined) {
+      let wrapped: { runtime: SessionRuntime; reused: boolean } | undefined;
       try {
         const storedApproval = readLegacyApprovalFlags(session.summary?.metadata);
         const restoredApproval =
@@ -170,11 +181,20 @@ export class KimiRuntime {
         const status = await session.getStatus();
         const permission = corePermissionForLegacyApproval(approval);
         if (status.permission !== permission) await session.setPermission(permission);
-        runtime = this.wrapSession(session, approval);
+        wrapped = this.wrapSession(session, approval);
+        runtime = wrapped.runtime;
+        if (wrapped.reused) {
+          await this.reconcileWrappedApproval(session, runtime);
+        }
       } catch (error) {
-        await session.close().catch((closeError: unknown) => {
-          this.log("Failed to close a rejected session", closeError);
-        });
+        // When the wrap was reused, `session` is the losing race handle:
+        // closing it would close the shared engine session out from under the
+        // surviving runtime and any active turn.
+        if (wrapped?.reused !== true) {
+          await session.close().catch((closeError: unknown) => {
+            this.log("Failed to close a rejected session", closeError);
+          });
+        }
         throw error;
       }
     }
@@ -230,7 +250,27 @@ export class KimiRuntime {
     await this.harness.close();
   }
 
-  private wrapSession(session: Session, legacyApproval: LegacyApprovalFlags): SessionRuntime {
+  private wrapSession(
+    session: Session,
+    legacyApproval: LegacyApprovalFlags,
+  ): { runtime: SessionRuntime; reused: boolean } {
+    // Two views can race opening the same session (sidebar + editor tab, or a
+    // reload overlapping a reattach): both pass the `sessions.get` check in
+    // openSession/attachResumedSession, both resume, and without this guard
+    // the later call would overwrite the earlier runtime here — orphaning it
+    // with its event subscription still live, so every streamed part reaches
+    // the shared view twice (interleaved duplicated text in the UI). A
+    // resumed Session handle is inert until wrapped (its constructor
+    // registers nothing), so the loser's handle can simply be dropped.
+    //
+    // The loser may already have pushed its own approval state (metadata,
+    // permission) onto the shared engine session; when `reused` is true,
+    // callers must run reconcileWrappedApproval so the engine and the
+    // surviving runtime agree again.
+    const existing = this.sessions.get(session.id);
+    if (existing !== undefined) {
+      return { runtime: existing, reused: true };
+    }
     const runtime = new SessionRuntime({
       session,
       legacyApproval,
@@ -239,7 +279,24 @@ export class KimiRuntime {
       log: this.log,
     });
     this.sessions.set(session.id, runtime);
-    return runtime;
+    return { runtime, reused: false };
+  }
+
+  /**
+   * Re-assert a surviving runtime's approval state on the engine session
+   * after wrapSession reused it: a racing open that lost may already have
+   * written its own (possibly different) approval flags to the session
+   * metadata and permission before reaching the reuse guard.
+   */
+  private async reconcileWrappedApproval(
+    session: Session,
+    runtime: SessionRuntime,
+  ): Promise<void> {
+    const flags = runtime.legacyApprovalFlags;
+    const status = await session.getStatus();
+    const permission = corePermissionForLegacyApproval(flags);
+    if (status.permission !== permission) await session.setPermission(permission);
+    await session.updateMetadata(legacyApprovalMetadata(flags));
   }
 
   private async readMigratedLegacyApproval(

--- a/apps/vscode/test/kimi-runtime.test.ts
+++ b/apps/vscode/test/kimi-runtime.test.ts
@@ -24,6 +24,10 @@ import { describe, expect, it, vi } from "vitest";
 
 import { Events } from "../shared/bridge";
 import { KimiRuntime, type OpenSessionOptions } from "../src/runtime/kimi-runtime";
+import {
+  corePermissionForLegacyApproval,
+  legacyApprovalMetadata,
+} from "../src/runtime/legacy-approval";
 
 const sdkFactories = vi.hoisted(() => {
   const v1Harness = { homeDir: "/tmp/kimi-runtime-v1-home", close: vi.fn(async () => undefined) };
@@ -631,6 +635,83 @@ describe("Kimi runtime (owns shared SDK sessions for Webviews)", () => {
     });
     return { runtime, sdk, broadcasts };
   }
+
+  it("deduplicates concurrent opens of the same session", async () => {
+    const { runtime, sdk, broadcasts } = createRecordingRuntime();
+    const boundary = sdk.addSession("s1", "/workspace");
+
+    // Sidebar and editor tab racing to open the same session must end up on a
+    // single SessionRuntime: a second wrap would double-subscribe the event
+    // stream and broadcast every streamed part twice.
+    const [a, b] = await Promise.all([
+      runtime.openSession(openOptions({ webviewId: "view-1", sessionId: "s1" })),
+      runtime.openSession(openOptions({ webviewId: "view-2", sessionId: "s1" })),
+    ]);
+
+    expect(a).toBe(b);
+    expect(boundary.subscriptionCount()).toBe(1);
+
+    broadcasts.length = 0;
+    boundary.emit({
+      type: "assistant.delta",
+      agentId: "main",
+      sessionId: "s1",
+      delta: "hello",
+    } as unknown as Event);
+
+    // One adapted ContentPart per subscribed view, never two.
+    const parts = broadcasts.filter(
+      ({ data }) => (data as { type?: string }).type === "ContentPart",
+    );
+    expect(parts).toHaveLength(2);
+  });
+
+  it("reconciles approval state when a racing open loses with different settings", async () => {
+    const { runtime, sdk } = createRecordingRuntime();
+    const boundary = sdk.addSession("s1", "/workspace");
+
+    // The loser of the wrap race may already have written its own yoloMode to
+    // the engine session before the reuse guard fired; the surviving
+    // runtime's flags must be what the session is left with.
+    const [a, b] = await Promise.all([
+      runtime.openSession(openOptions({ webviewId: "view-1", sessionId: "s1", yoloMode: false })),
+      runtime.openSession(openOptions({ webviewId: "view-2", sessionId: "s1", yoloMode: true })),
+    ]);
+
+    expect(a).toBe(b);
+    const expected = corePermissionForLegacyApproval(a.legacyApprovalFlags);
+    expect(boundary.setPermissions.at(-1)).toBe(expected);
+    expect(boundary.metadataUpdates.at(-1)).toEqual(
+      legacyApprovalMetadata(a.legacyApprovalFlags),
+    );
+  });
+
+  it("does not close the shared session when the racing open's reconcile fails", async () => {
+    const { runtime, sdk } = createRecordingRuntime();
+    const boundary = sdk.addSession("s1", "/workspace");
+
+    // The third metadata write is always the losing call's reconcile (both
+    // racers write once before wrapping; the winner writes nothing after).
+    const realUpdate = boundary.session.updateMetadata.bind(boundary.session);
+    let writes = 0;
+    vi.spyOn(boundary.session, "updateMetadata").mockImplementation(async (patch: JsonObject) => {
+      writes += 1;
+      if (writes === 3) throw new Error("transient metadata failure");
+      return realUpdate(patch);
+    });
+
+    await expect(
+      Promise.all([
+        runtime.openSession(openOptions({ webviewId: "view-1", sessionId: "s1", yoloMode: false })),
+        runtime.openSession(openOptions({ webviewId: "view-2", sessionId: "s1", yoloMode: true })),
+      ]),
+    ).rejects.toThrow("transient metadata failure");
+
+    // The losing handle's failure must not close the shared engine session
+    // out from under the surviving runtime.
+    expect(boundary.closeCount()).toBe(0);
+    expect(runtime.getSession("s1")).toBeDefined();
+  });
 
   it("fails a reentrant prompt without disturbing the running turn", async () => {
     const { runtime, sdk, broadcasts } = createRecordingRuntime();


### PR DESCRIPTION
## Related Issue

Resolve #2799

## Problem

See linked issue. When two views race to open the same session (sidebar + editor tab, or a window reload overlapping a reattach), both get past the `sessions.get` check before either registers, and `wrapSession` unconditionally overwrites the map entry. The orphaned `SessionRuntime` keeps its `onEvent` subscription (and its approval/question handler registrations, which the SDK rpc layer keys by session id), so both runtimes adapt and broadcast every event — and a view subscribed in both receives every streamed part twice, rendered as strictly interleaved duplicated text ("TheThe roaring roaring …").

## What changed

- `wrapSession` returns the existing runtime when the session already has one, instead of blindly overwriting. The loser's freshly resumed `Session` handle is inert until wrapped — its constructor registers nothing, and listeners/handlers are only installed by the `SessionRuntime` constructor — so it can simply be dropped. It is deliberately **not** closed: `Session.close()` closes the shared engine-side session by id, which would kill it for the winning runtime. The error paths guard this too: a failing setup or reconciliation on the losing handle never closes the shared session (review feedback).
- Because the losing call may already have written its own approval state (metadata + permission) onto the shared engine session before reaching the guard, `wrapSession` reports `reused` and both call sites then run `reconcileWrappedApproval`, which re-asserts the surviving runtime's approval flags on the engine session — engine permission, persisted metadata, and the runtime's flags always end up consistent (review feedback).

Regression tests: (1) two concurrent `openSession` calls for the same session id end up on the same runtime, with exactly one event subscription and one `ContentPart` broadcast per view per delta — fails without the fix; (2) racing opens with different `yoloMode` values leave the engine permission and persisted metadata matching the surviving runtime's flags; (3) a failing reconciliation on the losing handle does not close the shared session — fails without the guard.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my fix works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset. (changeset included: `kimi-code` patch)
- [x] Ran `gen-docs` skill, or this PR needs no doc update.