### PR TITLE
fix(goal): stop daemon crash on goal pause; add graceful pause

### DIFF
--- a/.changeset/goal-pause-daemon-crash.md
+++ b/.changeset/goal-pause-daemon-crash.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Fix the `kimi web` server process exiting when a goal with a queued continuation is paused.

--- a/packages/agent-core-v2/src/agent/goal/goal.ts
+++ b/packages/agent-core-v2/src/agent/goal/goal.ts
@@ -18,6 +18,10 @@ export interface GoalReasonInput {
   readonly reason?: string;
 }
 
+export interface PauseGoalOptions {
+  readonly preserveLiveContinuation?: boolean;
+}
+
 export interface ResumeGoalInput extends GoalReasonInput {
   readonly continueIfPaused?: boolean;
   readonly continueIfBlocked?: boolean;
@@ -29,7 +33,11 @@ export interface IAgentGoalService {
   getGoal(): GoalToolResult;
   isGoalToolTarget(turnId: number, goalId: string): boolean;
   createGoal(input: CreateGoalInput, actor?: GoalActor): Promise<GoalSnapshot>;
-  pauseGoal(input?: GoalReasonInput, actor?: GoalActor): Promise<GoalSnapshot>;
+  pauseGoal(
+    input?: GoalReasonInput,
+    actor?: GoalActor,
+    opts?: PauseGoalOptions,
+  ): Promise<GoalSnapshot>;
   resumeGoal(input?: ResumeGoalInput, actor?: GoalActor): Promise<GoalSnapshot>;
   cancelGoal(input?: GoalReasonInput, actor?: GoalActor): Promise<GoalSnapshot>;
   setBudgetLimits(

--- a/packages/agent-core-v2/src/agent/goal/goalService.ts
+++ b/packages/agent-core-v2/src/agent/goal/goalService.ts
@@ -82,7 +82,7 @@ import { IWireService } from '#/wire/wire';
 import { defineModel } from '#/wire/model';
 import { IEventBus } from '#/app/event/eventBus';
 
-import { IAgentGoalService, type GoalReasonInput, type ResumeGoalInput } from './goal';
+import { IAgentGoalService, type GoalReasonInput, type PauseGoalOptions, type ResumeGoalInput } from './goal';
 import { IGoalDeadlineScheduler } from './goalDeadlineScheduler';
 import { clearGoal, createGoal, GoalModel, updateGoal, type GoalState } from './goalOps';
 import type {
@@ -544,7 +544,11 @@ export class AgentGoalService extends Disposable implements IAgentGoalService {
     this.clearInternal('system');
   }
 
-  async pauseGoal(input: GoalReasonInput = {}, actor: GoalActor = 'user'): Promise<GoalSnapshot> {
+  async pauseGoal(
+    input: GoalReasonInput = {},
+    actor: GoalActor = 'user',
+    opts: PauseGoalOptions = {},
+  ): Promise<GoalSnapshot> {
     this.assertSupportedAgent();
     const state = this.requireState();
     if (state.status === 'paused') return this.toSnapshot(state);
@@ -554,7 +558,9 @@ export class AgentGoalService extends Disposable implements IAgentGoalService {
         `Cannot pause a goal in status "${state.status}"`,
       );
     }
-    return this.applyLifecycle(state, 'paused', input.reason, actor);
+    return this.applyLifecycle(state, 'paused', input.reason, actor, {
+      preserveLiveContinuation: opts.preserveLiveContinuation === true,
+    });
   }
 
   async pauseActiveGoal(
@@ -951,6 +957,7 @@ export class AgentGoalService extends Disposable implements IAgentGoalService {
         }
         return turn.result;
       })
+      .catch(() => {})
       .finally(() => {
         if (pending.turnId !== undefined) this.pendingContinuationGoals.delete(pending.turnId);
         if (this.pendingContinuation === pending) this.pendingContinuation = undefined;

--- a/packages/agent-core-v2/src/app/sessionLegacy/sessionLegacyService.ts
+++ b/packages/agent-core-v2/src/app/sessionLegacy/sessionLegacyService.ts
@@ -142,6 +142,9 @@ export class SessionLegacyService implements ISessionLegacyService {
         case 'pause':
           await goal.pauseGoal({});
           break;
+        case 'pause_graceful':
+          await goal.pauseGoal({}, 'user', { preserveLiveContinuation: true });
+          break;
         case 'resume':
           await goal.resumeGoal({ continueIfPaused: true, continueIfBlocked: true });
           break;

--- a/packages/agent-core-v2/src/app/sessionLegacy/sessionProtocol.ts
+++ b/packages/agent-core-v2/src/app/sessionLegacy/sessionProtocol.ts
@@ -46,7 +46,7 @@ export const sessionAgentConfigSchema = z.object({
   plan_mode: z.boolean().optional(),
   swarm_mode: z.boolean().optional(),
   goal_objective: z.string().optional(),
-  goal_control: z.enum(['pause', 'resume', 'cancel']).optional(),
+  goal_control: z.enum(['pause', 'pause_graceful', 'resume', 'cancel']).optional(),
 });
 export type SessionAgentConfig = z.infer<typeof sessionAgentConfigSchema>;
 

--- a/packages/agent-core-v2/test/agent/goal/goal.test.ts
+++ b/packages/agent-core-v2/test/agent/goal/goal.test.ts
@@ -946,6 +946,15 @@ describe('AgentGoalService core workflow hooks', () => {
     expect(abort).toHaveBeenCalledOnce();
   });
 
+  it('keeps the live continuation running on a graceful pause', async () => {
+    const abort = await startLiveContinuation();
+
+    await goals.pauseGoal({}, 'user', { preserveLiveContinuation: true });
+
+    expect(abort).not.toHaveBeenCalled();
+    expect(goals.getGoal().goal?.status).toBe('paused');
+  });
+
   it('aborts a live continuation when the user cancels the goal', async () => {
     const abort = await startLiveContinuation();
 

--- a/packages/kap-server/src/protocol/rest-prompt.ts
+++ b/packages/kap-server/src/protocol/rest-prompt.ts
@@ -42,7 +42,7 @@ export const promptSubmissionSchema = z.object({
   plan_mode: z.boolean().optional(),
   swarm_mode: z.boolean().optional(),
   goal_objective: z.string().optional(),
-  goal_control: z.enum(['pause', 'resume', 'cancel']).optional(),
+  goal_control: z.enum(['pause', 'pause_graceful', 'resume', 'cancel']).optional(),
   // Client-managed session tool denylist: full-replace on every submit; the
   // bound profile's own deny always survives. Omit to keep the persisted
   // value, send `[]` to clear the client portion.

--- a/packages/telemetry/src/crash.ts
+++ b/packages/telemetry/src/crash.ts
@@ -55,11 +55,13 @@ export function installCrashHandlersForClient(client: TelemetryClient): () => vo
   // the only listener (print / server modes) rethrow to preserve it; the
   // dedupe set above keeps the monitor from double-reporting that path.
   installedRejectionHandler = (reason: unknown) => {
+    // AbortError rejections are expected cancellation noise (e.g. a goal's
+    // pending continuation aborted by pauseGoal) — never track or rethrow
+    // them, or the daemon dies on a perfectly normal cancel.
+    if (isAbortError(reason)) return;
     const soleListener = process.listenerCount('unhandledRejection') === 1;
-    if (!isAbortError(reason)) {
-      trackCrash(crashErrorType(reason), 'unhandledRejection');
-      recordedRejections.add(reason);
-    }
+    trackCrash(crashErrorType(reason), 'unhandledRejection');
+    recordedRejections.add(reason);
     if (soleListener) {
       throw reason;
     }


### PR DESCRIPTION
## Related Issue

Resolve #2801

## Problem

Pausing a goal from the web UI (`kimi web` / kap-server) on a session with a queued or in-flight goal continuation killed the whole server process with an uncaught `AbortError: Goal continuation cancelled`. Two layers combined:

1. The continuation bookkeeping promise chain in `launchContinuationTurn` had no `catch`, so aborting a pending continuation produced an unhandled `AbortError` rejection.
2. The telemetry `unhandledRejection` handler rethrows when it is the sole listener (print/server modes) — including `AbortError`, which is expected cancellation noise. The TUI survives the same action because it registers its own rejection handling; the daemon does not.

Additionally, pausing always interrupted the live goal turn mid-tool. The engine already had the `preserveLiveContinuation` flag (used for blocked/complete transitions) but no API surface exposed it.

## What changed

- **Fix**: the continuation bookkeeping chain now swallows rejections (it only cleans up bookkeeping state; real turn failures surface via `turn.ended` events), and the telemetry rejection handler returns early for `AbortError` instead of rethrowing it. Non-abort rejections still crash as before.
- **Feature**: `pauseGoal` accepts a `preserveLiveContinuation` option, exposed over the session profile API as `goal_control: "pause_graceful"`. Pausing this way lets the in-flight turn run to completion and simply stops further goal continuations.
- Regression test: graceful pause keeps the live continuation running while the goal transitions to `paused`.

## Verification

- Reproduced the crash deterministically with the telemetry handler installed as sole `unhandledRejection` listener plus an unhandled `AbortError` rejection: original code exits with the reported stack shape; patched code survives. Non-abort rejections still exit.
- `test/agent/goal` suite: 161/161 passing, including the new regression test.
- End-to-end against a dev server: goal with multi-turn continuation, `goal_control: "pause_graceful"` mid-turn → 200 OK, the running turn completed normally (no tool interruption), goal transitioned to `paused`, no further continuations, daemon stayed alive.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.