### PR TITLE
fix(agent-core-v2): normalize Windows UNC watch paths

### DIFF
--- a/.changeset/fix-windows-unc-watch.md
+++ b/.changeset/fix-windows-unc-watch.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Fix startup on Windows network shares by normalizing UNC paths before opening native filesystem watchers.

--- a/packages/agent-core-v2/src/os/backends/node-local/hostFsWatchService.ts
+++ b/packages/agent-core-v2/src/os/backends/node-local/hostFsWatchService.ts
@@ -6,7 +6,7 @@
  */
 
 import { watch as fsWatch } from 'node:fs';
-import { basename, isAbsolute, join, relative } from 'node:path';
+import { basename, isAbsolute, join, relative, win32 } from 'node:path';
 
 import { FSWatcher } from 'chokidar';
 
@@ -159,13 +159,16 @@ class SignalWatchHandle implements IHostFsWatchHandle {
   private startNativeLeg(): void {
     if (this.disposed) return;
     try {
-      const watcher = this.runtime.watchNative(this.root, (_eventType, filename) => {
-        if (this.disposed) return;
-        this.retryAttempts = 0;
-        const absPath = resolveNativeSignalPath(this.root, filename);
-        if (absPath !== this.root && this.ignored(absPath)) return;
-        this.fireInvalidation();
-      });
+      const watcher = this.runtime.watchNative(
+        toNativeWatchRoot(this.root, this.runtime.platform),
+        (_eventType, filename) => {
+          if (this.disposed) return;
+          this.retryAttempts = 0;
+          const absPath = resolveNativeSignalPath(this.root, filename);
+          if (absPath !== this.root && this.ignored(absPath)) return;
+          this.fireInvalidation();
+        },
+      );
       watcher.on('error', (error: NodeJS.ErrnoException) => {
         this.onNativeError(watcher, error);
       });
@@ -253,6 +256,10 @@ function useNativeRecursive(
     options.recursive !== false &&
     (platform === 'darwin' || platform === 'win32')
   );
+}
+
+function toNativeWatchRoot(root: string, platform: NodeJS.Platform): string {
+  return platform === 'win32' ? win32.normalize(root) : root;
 }
 
 function resolveNativeSignalPath(root: string, filename: string | null): string {

--- a/packages/agent-core-v2/test/os/backends/node-local/hostFsWatchService.test.ts
+++ b/packages/agent-core-v2/test/os/backends/node-local/hostFsWatchService.test.ts
@@ -48,6 +48,7 @@ class TestNativeWatcher {
 }
 
 interface TestNativeAttempt {
+  readonly root: string;
   readonly watcher: TestNativeWatcher;
   emit(filename: string | null): void;
 }
@@ -58,7 +59,10 @@ interface TestRetry {
   run(): void;
 }
 
-function signalRig(options?: { readonly synchronousFailures?: number }): {
+function signalRig(options?: {
+  readonly platform?: NodeJS.Platform;
+  readonly synchronousFailures?: number;
+}): {
   readonly service: IHostFsWatchService;
   readonly attempts: TestNativeAttempt[];
   readonly retries: TestRetry[];
@@ -69,14 +73,15 @@ function signalRig(options?: { readonly synchronousFailures?: number }): {
   const retries: TestRetry[] = [];
   let synchronousFailures = options?.synchronousFailures ?? 0;
   const runtime: HostFsWatchRuntime = {
-    platform: 'darwin',
-    watchNative: (_root, listener) => {
+    platform: options?.platform ?? 'darwin',
+    watchNative: (root, listener) => {
       if (synchronousFailures > 0) {
         synchronousFailures -= 1;
         throw Object.assign(new Error('native watch creation failed'), { code: 'EIO' });
       }
       const watcher = new TestNativeWatcher();
       attempts.push({
+        root,
         watcher,
         emit: (filename) => {
           listener('rename', filename);
@@ -162,6 +167,13 @@ describe('host filesystem change notifications', () => {
     rig.attempt(0).emit('skills/demo/SKILL.md');
 
     expect(events).toEqual([{ path: '/repo', action: 'modified', kind: 'directory' }]);
+  });
+
+  it('passes Windows UNC roots to the native watcher with native separators', () => {
+    const rig = signalRig({ platform: 'win32' });
+    handle = rig.service.watch('//server/share/repo', { signal: true });
+
+    expect(rig.attempt(0).root).toBe('\\\\server\\share\\repo');
   });
 
   it('does not invalidate when a native signal path is ignored', () => {


### PR DESCRIPTION
## Related Issue

Resolve #2771

## Problem

See linked issue. Project skill discovery can produce a forward-slash Windows UNC path, which the native recursive watcher does not reliably recognize as a network share.

## What changed

Normalize Windows watch roots with platform-native separators at the native filesystem-watch boundary while preserving the logical root used for filtering and emitted invalidations. Add a regression test that proves a forward-slash UNC root reaches the native watcher as `\\server\share\repo`.

## Validation

- `pnpm --filter @moonshot-ai/agent-core-v2 lint:imports`
- `pnpm --filter @moonshot-ai/agent-core-v2 typecheck`
- `pnpm --filter @moonshot-ai/agent-core-v2 test` (311 files, 4900 tests)
- Focused type-aware oxlint on the changed implementation and test (0 errors)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill and added a CLI patch changeset.
- [x] Ran `gen-docs` skill; this fix does not change documented commands, configuration, or usage.