### PR TITLE
fix(apps/kimi-code): allow deselecting Other option in multi-select question dialog

### DIFF
--- a/.changeset/fix-multi-select-other-deselect.md
+++ b/.changeset/fix-multi-select-other-deselect.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Fix multi-select "Other" options so they can be deselected after being committed.

--- a/apps/kimi-code/src/tui/components/dialogs/question-dialog.ts
+++ b/apps/kimi-code/src/tui/components/dialogs/question-dialog.ts
@@ -299,6 +299,12 @@ export class QuestionDialogComponent extends Container implements Focusable {
     this.reviewMessage = undefined;
 
     if (this.isOtherOption(questionIdx, optionIdx)) {
+      if (question.multi_select && this.multiSelections[questionIdx]?.has(optionIdx)) {
+        this.multiSelections[questionIdx].delete(optionIdx);
+        this.lastAnswerMethod = method;
+        this.updateAnswer(questionIdx);
+        return;
+      }
       this.enterOtherInput(questionIdx);
       return;
     }

--- a/apps/kimi-code/test/tui/components/dialogs/question-dialog.test.ts
+++ b/apps/kimi-code/test/tui/components/dialogs/question-dialog.test.ts
@@ -394,6 +394,42 @@ describe('QuestionDialogComponent', () => {
     expect(out).toContain('Mushroom');
   });
 
+  it('multi-select Other can be toggled off after it is committed', () => {
+    const pending = makePending([
+      {
+        question: 'Pick toppings?',
+        multi_select: true,
+        options: [{ label: 'Cheese' }, { label: 'Pepperoni' }],
+      },
+    ]);
+    const { dialog, collected } = makeDialog(pending);
+
+    // Select Other and commit a custom value.
+    dialog.handleInput('3');
+    dialog.handleInput('M');
+    dialog.handleInput('u');
+    dialog.handleInput('s');
+    dialog.handleInput('h');
+    dialog.handleInput('r');
+    dialog.handleInput('o');
+    dialog.handleInput('o');
+    dialog.handleInput('m');
+    dialog.handleInput('\r');
+
+    // Toggle it off using the same key.
+    dialog.handleInput('3');
+    // Select a preset option to confirm the answer still builds correctly.
+    dialog.handleInput('1');
+    dialog.handleInput('\t');
+
+    const review = strip(dialog.render(80).join('\n'));
+    expect(review).toContain('Cheese');
+    expect(review).not.toContain('Mushroom');
+
+    dialog.handleInput('1');
+    expect(collected).toEqual([['Cheese']]);
+  });
+
   it('escape dismisses with empty answers array', () => {
     const pending = makePending([
       {


### PR DESCRIPTION
## Related Issue

N/A

## Problem

In the TUI's `AskUserQuestion` multi-select dialog, selecting the synthetic "Other" option and committing a custom value permanently adds it to the selection set. There was no way to deselect "Other" afterwards, because pressing Enter/Space on "Other" always re-entered edit mode instead of toggling its selected state.

## What changed

- In `apps/kimi-code/src/tui/components/dialogs/question-dialog.ts`, `activateQuestionOption` now checks whether "Other" is already selected in multi-select mode. If so, it removes the option from `multiSelections` and updates the answer, effectively toggling it off. If not selected, it still enters the inline Other editor as before.
- Added a component test `multi-select Other can be toggled off after it is committed` covering the toggle-off behavior.
- Added a patch changeset for `@moonshot-ai/kimi-code`.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran gen-changesets skill, or this PR needs no changeset.
