### PR TITLE
fix: surface a readable error when Git Bash is missing on Windows

### DIFF
--- a/.changeset/fix-windows-missing-git-bash.md
+++ b/.changeset/fix-windows-missing-git-bash.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Show a clear error message on Windows when Git for Windows is not installed, instead of exiting silently.

--- a/packages/agent-core-v2/src/_base/execEnv/environmentProbe.ts
+++ b/packages/agent-core-v2/src/_base/execEnv/environmentProbe.ts
@@ -24,6 +24,19 @@ export type OsKind = string;
 export type ShellName = 'bash' | 'sh';
 export type PathClass = 'posix' | 'win32';
 
+/**
+ * Thrown by `probeHostEnvironment` on Windows when no Git Bash install can be
+ * located. Carries the list of paths that were probed so callers can include
+ * them in install hints and can distinguish a missing-shell failure from other
+ * probe errors.
+ */
+export class ProbeShellNotFoundError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'ProbeShellNotFoundError';
+  }
+}
+
 export interface HostEnvironmentInfo {
   readonly osKind: OsKind;
   readonly osArch: string;
@@ -181,7 +194,7 @@ async function locateWindowsGitBash(deps: HostEnvironmentProbeDeps): Promise<str
     }
   }
 
-  throw new Error(
+  throw new ProbeShellNotFoundError(
     `Git Bash was not found on this Windows host. Install Git for Windows from https://gitforwindows.org/ or set KIMI_SHELL_PATH to a bash.exe. Checked: ${checked.join(', ')}.`,
   );
 }

--- a/packages/agent-core-v2/src/_base/execEnv/environmentProbe.ts
+++ b/packages/agent-core-v2/src/_base/execEnv/environmentProbe.ts
@@ -195,7 +195,7 @@ async function locateWindowsGitBash(deps: HostEnvironmentProbeDeps): Promise<str
   }
 
   throw new ProbeShellNotFoundError(
-    `Git Bash was not found on this Windows host. Install Git for Windows from https://gitforwindows.org/ or set KIMI_SHELL_PATH to a bash.exe. Checked: ${checked.join(', ')}.`,
+    'Git Bash was not found on this Windows host. Install Git for Windows from https://gitforwindows.org/ or set KIMI_SHELL_PATH to a bash.exe.',
     checked,
   );
 }

--- a/packages/agent-core-v2/src/_base/execEnv/environmentProbe.ts
+++ b/packages/agent-core-v2/src/_base/execEnv/environmentProbe.ts
@@ -7,9 +7,11 @@
  * same suite runs identically on any host OS. `probeHostEnvironmentFromNode()`
  * bundles the Node defaults for production callers and memoises the promise.
  *
- * On Windows the probe expects bash from Git for Windows or MSYS2. If it
- * cannot be located the function throws a plain `Error` with the checked paths
- * in the message. Set `KIMI_SHELL_PATH` to override.
+ * On Windows the probe expects bash from Git for Windows or MSYS2. If no
+ * shell can be located the function throws `ProbeShellNotFoundError`, a
+ * distinct type whose message carries an install hint and the checked paths,
+ * so the DI boundary can tell a missing shell apart from other probe errors
+ * and translate it into a coded error. Set `KIMI_SHELL_PATH` to override.
  *
  * Kept as a pure helper with no DI dependencies.
  */
@@ -24,12 +26,6 @@ export type OsKind = string;
 export type ShellName = 'bash' | 'sh';
 export type PathClass = 'posix' | 'win32';
 
-/**
- * Thrown by `probeHostEnvironment` on Windows when no Git Bash install can be
- * located. Carries the list of paths that were probed so callers can include
- * them in install hints and can distinguish a missing-shell failure from other
- * probe errors.
- */
 export class ProbeShellNotFoundError extends Error {
   constructor(message: string) {
     super(message);

--- a/packages/agent-core-v2/src/_base/execEnv/environmentProbe.ts
+++ b/packages/agent-core-v2/src/_base/execEnv/environmentProbe.ts
@@ -9,9 +9,10 @@
  *
  * On Windows the probe expects bash from Git for Windows or MSYS2. If no
  * shell can be located the function throws `ProbeShellNotFoundError`, a
- * distinct type whose message carries an install hint and the checked paths,
- * so the DI boundary can tell a missing shell apart from other probe errors
- * and translate it into a coded error. Set `KIMI_SHELL_PATH` to override.
+ * distinct type carrying the checked paths (`checked`) with an install hint
+ * in its message, so the DI boundary can tell a missing shell apart from
+ * other probe errors and translate it into a coded error. Set
+ * `KIMI_SHELL_PATH` to override.
  *
  * Kept as a pure helper with no DI dependencies.
  */
@@ -27,9 +28,12 @@ export type ShellName = 'bash' | 'sh';
 export type PathClass = 'posix' | 'win32';
 
 export class ProbeShellNotFoundError extends Error {
-  constructor(message: string) {
+  readonly checked: readonly string[];
+
+  constructor(message: string, checked: readonly string[]) {
     super(message);
     this.name = 'ProbeShellNotFoundError';
+    this.checked = checked;
   }
 }
 
@@ -192,6 +196,7 @@ async function locateWindowsGitBash(deps: HostEnvironmentProbeDeps): Promise<str
 
   throw new ProbeShellNotFoundError(
     `Git Bash was not found on this Windows host. Install Git for Windows from https://gitforwindows.org/ or set KIMI_SHELL_PATH to a bash.exe. Checked: ${checked.join(', ')}.`,
+    checked,
   );
 }
 

--- a/packages/agent-core-v2/src/os/backends/node-local/hostEnvironmentService.ts
+++ b/packages/agent-core-v2/src/os/backends/node-local/hostEnvironmentService.ts
@@ -5,7 +5,12 @@
  * login-shell PATH enrichment (`applyLoginShellPathFromNode`) at construction
  * time; the sync fields become populated once `ready` resolves. Reads before
  * `ready` throws with a clear message so misuse fails loudly instead of
- * returning stale zeros. Bound at App scope.
+ * returning stale zeros. A failed probe is translated at this boundary — a
+ * missing Git Bash on Windows becomes `HostProcessError`
+ * (`shell.git_bash_not_found`) — and surfaces identically from `ready` and
+ * from sync field reads, while an internal no-op handler keeps the rejection
+ * from ever becoming an unhandledRejection during App-scope construction.
+ * Bound at App scope.
  */
 
 import { LifecycleScope } from '#/app/scopes';
@@ -40,18 +45,19 @@ export class HostEnvironmentService implements IHostEnvironment {
         this._info = info;
       }),
       applyLoginShellPathFromNode(),
-    ]).then(() => {});
-    // Catch the rejection so it can never become an unhandledRejection while
-    // the App scope is being constructed. The original error is preserved and
-    // rethrown when callers access sync fields or await `ready` themselves.
-    this.ready.catch((error: unknown) => {
-      this._probeError = error;
-    });
+    ])
+      .then(() => {})
+      .catch((error: unknown) => {
+        const translated = this.toHostProcessError(error);
+        this._probeError = translated;
+        throw translated;
+      });
+    this.ready.catch(() => {});
   }
 
   private require(field: keyof HostEnvironmentInfo): never | HostEnvironmentInfo[typeof field] {
     if (this._probeError !== undefined) {
-      throw this.wrapProbeError(this._probeError);
+      throw this._probeError;
     }
     if (this._info === undefined) {
       throw new BugIndicatingError(
@@ -61,7 +67,7 @@ export class HostEnvironmentService implements IHostEnvironment {
     return this._info[field];
   }
 
-  private wrapProbeError(error: unknown): unknown {
+  private toHostProcessError(error: unknown): unknown {
     if (error instanceof ProbeShellNotFoundError) {
       return new HostProcessError(
         OsProcessErrors.codes.SHELL_GIT_BASH_NOT_FOUND,

--- a/packages/agent-core-v2/src/os/backends/node-local/hostEnvironmentService.ts
+++ b/packages/agent-core-v2/src/os/backends/node-local/hostEnvironmentService.ts
@@ -36,7 +36,7 @@ export class HostEnvironmentService implements IHostEnvironment {
   declare readonly _serviceBrand: undefined;
 
   private _info?: HostEnvironmentInfo;
-  private _probeError?: unknown;
+  private _probeError?: Error;
   readonly ready: Promise<void>;
 
   constructor() {
@@ -67,14 +67,14 @@ export class HostEnvironmentService implements IHostEnvironment {
     return this._info[field];
   }
 
-  private toHostProcessError(error: unknown): unknown {
+  private toHostProcessError(error: unknown): Error {
     if (error instanceof ProbeShellNotFoundError) {
       return new HostProcessError(
         OsProcessErrors.codes.SHELL_GIT_BASH_NOT_FOUND,
         error.message,
       );
     }
-    return error;
+    return error instanceof Error ? error : new Error(String(error));
   }
 
   get osKind(): OsKind {

--- a/packages/agent-core-v2/src/os/backends/node-local/hostEnvironmentService.ts
+++ b/packages/agent-core-v2/src/os/backends/node-local/hostEnvironmentService.ts
@@ -12,7 +12,10 @@ import { LifecycleScope } from '#/app/scopes';
 
 import { ScopeActivation, registerScopedService } from '#/_base/di/scope';
 import { BugIndicatingError } from '#/_base/errors/errors';
-import { probeHostEnvironmentFromNode } from '#/_base/execEnv/environmentProbe';
+import {
+  probeHostEnvironmentFromNode,
+  ProbeShellNotFoundError,
+} from '#/_base/execEnv/environmentProbe';
 import { applyLoginShellPathFromNode } from '#/_base/execEnv/loginShellPath';
 
 import {
@@ -22,11 +25,13 @@ import {
   type PathClass,
   type ShellName,
 } from '#/os/interface/hostEnvironment';
+import { HostProcessError, OsProcessErrors } from '#/os/interface/hostProcess';
 
 export class HostEnvironmentService implements IHostEnvironment {
   declare readonly _serviceBrand: undefined;
 
   private _info?: HostEnvironmentInfo;
+  private _probeError?: unknown;
   readonly ready: Promise<void>;
 
   constructor() {
@@ -36,15 +41,34 @@ export class HostEnvironmentService implements IHostEnvironment {
       }),
       applyLoginShellPathFromNode(),
     ]).then(() => {});
+    // Catch the rejection so it can never become an unhandledRejection while
+    // the App scope is being constructed. The original error is preserved and
+    // rethrown when callers access sync fields or await `ready` themselves.
+    this.ready.catch((error: unknown) => {
+      this._probeError = error;
+    });
   }
 
   private require(field: keyof HostEnvironmentInfo): never | HostEnvironmentInfo[typeof field] {
+    if (this._probeError !== undefined) {
+      throw this.wrapProbeError(this._probeError);
+    }
     if (this._info === undefined) {
       throw new BugIndicatingError(
         `IHostEnvironment.${field} accessed before ready — await IHostEnvironment.ready first (composition root should do so before creating a Session scope).`,
       );
     }
     return this._info[field];
+  }
+
+  private wrapProbeError(error: unknown): unknown {
+    if (error instanceof ProbeShellNotFoundError) {
+      return new HostProcessError(
+        OsProcessErrors.codes.SHELL_GIT_BASH_NOT_FOUND,
+        error.message,
+      );
+    }
+    return error;
   }
 
   get osKind(): OsKind {

--- a/packages/agent-core-v2/src/os/backends/node-local/hostEnvironmentService.ts
+++ b/packages/agent-core-v2/src/os/backends/node-local/hostEnvironmentService.ts
@@ -72,6 +72,7 @@ export class HostEnvironmentService implements IHostEnvironment {
       return new HostProcessError(
         OsProcessErrors.codes.SHELL_GIT_BASH_NOT_FOUND,
         error.message,
+        { details: { checkedPaths: error.checked }, cause: error },
       );
     }
     return error instanceof Error ? error : new Error(String(error));

--- a/packages/agent-core-v2/src/os/interface/hostProcess.ts
+++ b/packages/agent-core-v2/src/os/interface/hostProcess.ts
@@ -82,6 +82,7 @@ registerErrorDomain(OsProcessErrors);
 export const HostProcessErrorCode = {
   SpawnFailed: OsProcessErrors.codes.OS_PROCESS_SPAWN_FAILED,
   KillFailed: OsProcessErrors.codes.OS_PROCESS_KILL_FAILED,
+  ShellGitBashNotFound: OsProcessErrors.codes.SHELL_GIT_BASH_NOT_FOUND,
 } as const;
 
 export type HostProcessErrorCode = (typeof HostProcessErrorCode)[keyof typeof HostProcessErrorCode];

--- a/packages/agent-core-v2/test/_base/execEnv/environmentProbe.test.ts
+++ b/packages/agent-core-v2/test/_base/execEnv/environmentProbe.test.ts
@@ -99,14 +99,18 @@ describe('probeHostEnvironment', () => {
   });
 
   it('throws ProbeShellNotFoundError when Git Bash is missing on Windows', async () => {
-    await expect(
-      probeHostEnvironment(
-        stubDeps({
-          platform: 'win32',
-          env: { PATH: 'C:\\Windows\\System32' },
-          existingPaths: [],
-        }),
-      ),
-    ).rejects.toBeInstanceOf(ProbeShellNotFoundError);
+    const rejected: unknown = await probeHostEnvironment(
+      stubDeps({
+        platform: 'win32',
+        env: { PATH: 'C:\\Windows\\System32' },
+        existingPaths: [],
+      }),
+    ).catch((error: unknown) => error);
+
+    expect(rejected).toBeInstanceOf(ProbeShellNotFoundError);
+    const probeError = rejected as ProbeShellNotFoundError;
+    expect(probeError.message).toContain('https://gitforwindows.org/');
+    expect(probeError.message).not.toContain('Checked:');
+    expect(probeError.checked.length).toBeGreaterThan(0);
   });
 });

--- a/packages/agent-core-v2/test/_base/execEnv/environmentProbe.test.ts
+++ b/packages/agent-core-v2/test/_base/execEnv/environmentProbe.test.ts
@@ -20,6 +20,7 @@ import { describe, expect, it } from 'vitest';
 
 import {
   probeHostEnvironment,
+  ProbeShellNotFoundError,
   type HostEnvironmentProbeDeps,
 } from '#/_base/execEnv/environmentProbe';
 
@@ -95,5 +96,17 @@ describe('probeHostEnvironment', () => {
     );
     expect(env.shellName).toBe('bash');
     expect(env.shellPath).toBe('C:\\msys64\\usr\\bin\\bash.exe');
+  });
+
+  it('throws ProbeShellNotFoundError when Git Bash is missing on Windows', async () => {
+    await expect(
+      probeHostEnvironment(
+        stubDeps({
+          platform: 'win32',
+          env: { PATH: 'C:\\Windows\\System32' },
+          existingPaths: [],
+        }),
+      ),
+    ).rejects.toBeInstanceOf(ProbeShellNotFoundError);
   });
 });

--- a/packages/agent-core-v2/test/os/backends/node-local/hostEnvironmentService.test.ts
+++ b/packages/agent-core-v2/test/os/backends/node-local/hostEnvironmentService.test.ts
@@ -12,6 +12,7 @@
 
 import { describe, expect, it, vi } from 'vitest';
 
+import { ProbeShellNotFoundError } from '#/_base/execEnv/environmentProbe';
 import { HostEnvironmentService } from '#/os/backends/node-local/hostEnvironmentService';
 import { HostProcessError, OsProcessErrors } from '#/os/interface/hostProcess';
 
@@ -20,7 +21,11 @@ vi.mock('#/_base/execEnv/environmentProbe', async (importOriginal) => {
   return {
     ...actual,
     probeHostEnvironmentFromNode: () =>
-      Promise.reject(new actual.ProbeShellNotFoundError('Git Bash missing (stubbed)')),
+      Promise.reject(
+        new actual.ProbeShellNotFoundError('Git Bash missing (stubbed)', [
+          'C:\\Program Files\\Git\\bin\\bash.exe',
+        ]),
+      ),
   };
 });
 
@@ -36,6 +41,17 @@ describe('HostEnvironmentService', () => {
     await expect(service.ready).rejects.toMatchObject({
       code: OsProcessErrors.codes.SHELL_GIT_BASH_NOT_FOUND,
     });
+  });
+
+  it('preserves the probe error as cause and checked paths as details', async () => {
+    const service = new HostEnvironmentService();
+
+    const rejected: unknown = await service.ready.catch((error: unknown) => error);
+
+    expect(rejected).toBeInstanceOf(HostProcessError);
+    const hostError = rejected as HostProcessError;
+    expect(hostError.details).toEqual({ checkedPaths: ['C:\\Program Files\\Git\\bin\\bash.exe'] });
+    expect(hostError.cause).toBeInstanceOf(ProbeShellNotFoundError);
   });
 
   it('does not surface the ready rejection as an unhandledRejection', async () => {

--- a/packages/agent-core-v2/test/os/backends/node-local/hostEnvironmentService.test.ts
+++ b/packages/agent-core-v2/test/os/backends/node-local/hostEnvironmentService.test.ts
@@ -1,23 +1,35 @@
 /**
  * HostEnvironmentService — shell-probe error handling.
  *
- * Verifies that a failed Windows Git Bash probe does not produce an
- * unhandledRejection and is surfaced as a HostProcessError when callers
- * access sync fields or await `ready`.
+ * Stubs the host-environment probe to fail the way a Windows host without Git
+ * Bash does, so the suite runs identically on any platform. Pins the failure
+ * contract: `ready` rejects with the translated `HostProcessError`
+ * (`shell.git_bash_not_found`), sync field reads after a failed probe throw
+ * the same coded error, and the rejection never surfaces as an
+ * unhandledRejection while the App scope is being constructed (vitest fails
+ * the file on any unhandled rejection).
  */
 
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
 import { HostEnvironmentService } from '#/os/backends/node-local/hostEnvironmentService';
 import { HostProcessError, OsProcessErrors } from '#/os/interface/hostProcess';
 
-describe('HostEnvironmentService', () => {
-  // The missing-Git-Bash path is Windows-only. On POSIX the probe resolves
-  // with /bin/bash or /bin/sh and never rejects.
-  const isWin = process.platform === 'win32';
+vi.mock('#/_base/execEnv/environmentProbe', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('#/_base/execEnv/environmentProbe')>();
+  return {
+    ...actual,
+    probeHostEnvironmentFromNode: () =>
+      Promise.reject(new actual.ProbeShellNotFoundError('Git Bash missing (stubbed)')),
+  };
+});
 
-  it('surfaces missing Git Bash as HostProcessError when awaiting ready', async () => {
-    if (!isWin) return;
+vi.mock('#/_base/execEnv/loginShellPath', () => ({
+  applyLoginShellPathFromNode: () => Promise.resolve(),
+}));
+
+describe('HostEnvironmentService', () => {
+  it('rejects ready with the translated HostProcessError when the probe fails', async () => {
     const service = new HostEnvironmentService();
 
     await expect(service.ready).rejects.toBeInstanceOf(HostProcessError);
@@ -26,22 +38,16 @@ describe('HostEnvironmentService', () => {
     });
   });
 
-  it('does not leave the ready rejection unhandled when Git Bash is missing', async () => {
-    if (!isWin) return;
+  it('does not surface the ready rejection as an unhandledRejection', async () => {
     const service = new HostEnvironmentService();
 
-    // The constructor attaches an internal catch handler so the rejection is
-    // never considered unhandled, even before the caller awaits `ready`.
     await new Promise((resolve) => setTimeout(resolve, 0));
 
     await expect(service.ready).rejects.toBeInstanceOf(HostProcessError);
   });
 
   it('throws HostProcessError when reading fields after a failed probe', async () => {
-    if (!isWin) return;
     const service = new HostEnvironmentService();
-
-    // Wait for the probe to settle (reject) before reading fields.
     await service.ready.catch(() => {});
 
     expect(() => service.shellPath).toThrow(HostProcessError);

--- a/packages/agent-core-v2/test/os/backends/node-local/hostEnvironmentService.test.ts
+++ b/packages/agent-core-v2/test/os/backends/node-local/hostEnvironmentService.test.ts
@@ -1,0 +1,50 @@
+/**
+ * HostEnvironmentService — shell-probe error handling.
+ *
+ * Verifies that a failed Windows Git Bash probe does not produce an
+ * unhandledRejection and is surfaced as a HostProcessError when callers
+ * access sync fields or await `ready`.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import { HostEnvironmentService } from '#/os/backends/node-local/hostEnvironmentService';
+import { HostProcessError, OsProcessErrors } from '#/os/interface/hostProcess';
+
+describe('HostEnvironmentService', () => {
+  // The missing-Git-Bash path is Windows-only. On POSIX the probe resolves
+  // with /bin/bash or /bin/sh and never rejects.
+  const isWin = process.platform === 'win32';
+
+  it('surfaces missing Git Bash as HostProcessError when awaiting ready', async () => {
+    if (!isWin) return;
+    const service = new HostEnvironmentService();
+
+    await expect(service.ready).rejects.toBeInstanceOf(HostProcessError);
+    await expect(service.ready).rejects.toMatchObject({
+      code: OsProcessErrors.codes.SHELL_GIT_BASH_NOT_FOUND,
+    });
+  });
+
+  it('does not leave the ready rejection unhandled when Git Bash is missing', async () => {
+    if (!isWin) return;
+    const service = new HostEnvironmentService();
+
+    // The constructor attaches an internal catch handler so the rejection is
+    // never considered unhandled, even before the caller awaits `ready`.
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    await expect(service.ready).rejects.toBeInstanceOf(HostProcessError);
+  });
+
+  it('throws HostProcessError when reading fields after a failed probe', async () => {
+    if (!isWin) return;
+    const service = new HostEnvironmentService();
+
+    // Wait for the probe to settle (reject) before reading fields.
+    await service.ready.catch(() => {});
+
+    expect(() => service.shellPath).toThrow(HostProcessError);
+    expect(() => service.osKind).toThrow(HostProcessError);
+  });
+});

--- a/packages/node-sdk/src/sdk-rpc-client-v2.ts
+++ b/packages/node-sdk/src/sdk-rpc-client-v2.ts
@@ -482,6 +482,10 @@ export class SDKRpcClientV2 extends SDKRpcClientBase {
 
   async ensureConfigFile(): Promise<void> {
     await ensureConfigFile(this.configPath);
+    // Wait for the App-scope host-environment probe so that a missing Git Bash
+    // on Windows is reported early, before the TUI starts, instead of surfacing
+    // as an unhandledRejection later in startup.
+    await this.app.accessor.get(IHostEnvironment).ready;
   }
 
   async close(): Promise<void> {

--- a/packages/node-sdk/src/sdk-rpc-client-v2.ts
+++ b/packages/node-sdk/src/sdk-rpc-client-v2.ts
@@ -482,10 +482,13 @@ export class SDKRpcClientV2 extends SDKRpcClientBase {
 
   async ensureConfigFile(): Promise<void> {
     await ensureConfigFile(this.configPath);
-    // Wait for the App-scope host-environment probe so that a missing Git Bash
-    // on Windows is reported early, before the TUI starts, instead of surfacing
-    // as an unhandledRejection later in startup.
-    await this.app.accessor.get(IHostEnvironment).ready;
+    // Surface a missing Git Bash early, before the TUI starts. The wait is
+    // Windows-only: the failure cannot happen on POSIX, and `ready` also
+    // covers the login-shell PATH enrichment, which spawns the user's login
+    // shell (5s timeout) — config-only commands must not block on that.
+    if (process.platform === 'win32') {
+      await this.app.accessor.get(IHostEnvironment).ready;
+    }
   }
 
   async close(): Promise<void> {

--- a/packages/node-sdk/test/sdk-rpc-client-v2.test.ts
+++ b/packages/node-sdk/test/sdk-rpc-client-v2.test.ts
@@ -11,7 +11,7 @@ import { mkdir, mkdtemp, readdir, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import {
   createKimiHarnessV2,
@@ -36,6 +36,21 @@ import { McpOAuthService } from '../../agent-core/src/mcp/oauth/service';
 import { TEST_IDENTITY } from './test-identity';
 import { startMcpAuthStatusServer } from './mcp-auth-status-server';
 import { recordingTelemetry, type TelemetryRecord } from './telemetry';
+
+const hostEnvProbe = vi.hoisted(() => ({ failWithMissingShell: false }));
+
+vi.mock('@moonshot-ai/agent-core-v2/_base/execEnv/environmentProbe', async (importOriginal) => {
+  const actual = await importOriginal<
+    typeof import('@moonshot-ai/agent-core-v2/_base/execEnv/environmentProbe')
+  >();
+  return {
+    ...actual,
+    probeHostEnvironmentFromNode: () =>
+      hostEnvProbe.failWithMissingShell
+        ? Promise.reject(new actual.ProbeShellNotFoundError('Git Bash missing (stubbed)'))
+        : actual.probeHostEnvironmentFromNode(),
+  };
+});
 
 const tempDirs: string[] = [];
 
@@ -149,18 +164,22 @@ describe('SDKRpcClientV2 (agent-core-v2 wiring MVP)', () => {
     }
   });
 
-  it('surfaces missing Git Bash during ensureConfigFile on Windows', async () => {
-    if (process.platform !== 'win32') return;
-    const homeDir = await mkdtemp(join(tmpdir(), 'kimi-sdk-v2-'));
-    tempDirs.push(homeDir);
-    const harness = createKimiHarnessV2({ homeDir, identity: TEST_IDENTITY });
+  it('surfaces a missing Git Bash probe failure during ensureConfigFile', async () => {
+    hostEnvProbe.failWithMissingShell = true;
     try {
-      await expect(harness.ensureConfigFile()).rejects.toBeInstanceOf(HostProcessError);
-      await expect(harness.ensureConfigFile()).rejects.toMatchObject({
-        code: OsProcessErrors.codes.SHELL_GIT_BASH_NOT_FOUND,
-      });
+      const homeDir = await mkdtemp(join(tmpdir(), 'kimi-sdk-v2-'));
+      tempDirs.push(homeDir);
+      const harness = createKimiHarnessV2({ homeDir, identity: TEST_IDENTITY });
+      try {
+        await expect(harness.ensureConfigFile()).rejects.toBeInstanceOf(HostProcessError);
+        await expect(harness.ensureConfigFile()).rejects.toMatchObject({
+          code: OsProcessErrors.codes.SHELL_GIT_BASH_NOT_FOUND,
+        });
+      } finally {
+        await harness.close();
+      }
     } finally {
-      await harness.close();
+      hostEnvProbe.failWithMissingShell = false;
     }
   });
 

--- a/packages/node-sdk/test/sdk-rpc-client-v2.test.ts
+++ b/packages/node-sdk/test/sdk-rpc-client-v2.test.ts
@@ -68,6 +68,16 @@ afterEach(async () => {
   }
 });
 
+function stubProcessPlatform(platform: NodeJS.Platform): () => void {
+  const descriptor = Object.getOwnPropertyDescriptor(process, 'platform');
+  Object.defineProperty(process, 'platform', { value: platform, configurable: true });
+  return () => {
+    if (descriptor !== undefined) {
+      Object.defineProperty(process, 'platform', descriptor);
+    }
+  };
+}
+
 async function makeHarness(): Promise<{ harness: KimiHarness; homeDir: string }> {
   const homeDir = await mkdtemp(join(tmpdir(), 'kimi-sdk-v2-'));
   tempDirs.push(homeDir);
@@ -168,8 +178,9 @@ describe('SDKRpcClientV2 (agent-core-v2 wiring MVP)', () => {
     }
   });
 
-  it('surfaces a missing Git Bash probe failure during ensureConfigFile', async () => {
+  it('surfaces a missing Git Bash probe failure during ensureConfigFile on Windows', async () => {
     hostEnvProbe.failWithMissingShell = true;
+    const restorePlatform = stubProcessPlatform('win32');
     try {
       const homeDir = await mkdtemp(join(tmpdir(), 'kimi-sdk-v2-'));
       tempDirs.push(homeDir);
@@ -184,6 +195,25 @@ describe('SDKRpcClientV2 (agent-core-v2 wiring MVP)', () => {
       }
     } finally {
       hostEnvProbe.failWithMissingShell = false;
+      restorePlatform();
+    }
+  });
+
+  it('does not block ensureConfigFile on the host environment probe on POSIX', async () => {
+    hostEnvProbe.failWithMissingShell = true;
+    const restorePlatform = stubProcessPlatform('darwin');
+    try {
+      const homeDir = await mkdtemp(join(tmpdir(), 'kimi-sdk-v2-'));
+      tempDirs.push(homeDir);
+      const harness = createKimiHarnessV2({ homeDir, identity: TEST_IDENTITY });
+      try {
+        await expect(harness.ensureConfigFile()).resolves.toBeUndefined();
+      } finally {
+        await harness.close();
+      }
+    } finally {
+      hostEnvProbe.failWithMissingShell = false;
+      restorePlatform();
     }
   });
 

--- a/packages/node-sdk/test/sdk-rpc-client-v2.test.ts
+++ b/packages/node-sdk/test/sdk-rpc-client-v2.test.ts
@@ -47,7 +47,11 @@ vi.mock('@moonshot-ai/agent-core-v2/_base/execEnv/environmentProbe', async (impo
     ...actual,
     probeHostEnvironmentFromNode: () =>
       hostEnvProbe.failWithMissingShell
-        ? Promise.reject(new actual.ProbeShellNotFoundError('Git Bash missing (stubbed)'))
+        ? Promise.reject(
+            new actual.ProbeShellNotFoundError('Git Bash missing (stubbed)', [
+              'C:\\Program Files\\Git\\bin\\bash.exe',
+            ]),
+          )
         : actual.probeHostEnvironmentFromNode(),
   };
 });

--- a/packages/node-sdk/test/sdk-rpc-client-v2.test.ts
+++ b/packages/node-sdk/test/sdk-rpc-client-v2.test.ts
@@ -26,7 +26,9 @@ import { foldAgentWireReplay } from '#/v2/resume-replay';
 import {
   drainQueryStoreDisposals,
   drainSessionIndexMirror,
+  HostProcessError,
   IHostRequestHeaders,
+  OsProcessErrors,
 } from '@moonshot-ai/agent-core-v2';
 
 import { McpOAuthService } from '../../agent-core/src/mcp/oauth/service';
@@ -144,6 +146,21 @@ describe('SDKRpcClientV2 (agent-core-v2 wiring MVP)', () => {
       expect(headers['X-Msh-Device-Id']).toBeTruthy();
     } finally {
       await client.close();
+    }
+  });
+
+  it('surfaces missing Git Bash during ensureConfigFile on Windows', async () => {
+    if (process.platform !== 'win32') return;
+    const homeDir = await mkdtemp(join(tmpdir(), 'kimi-sdk-v2-'));
+    tempDirs.push(homeDir);
+    const harness = createKimiHarnessV2({ homeDir, identity: TEST_IDENTITY });
+    try {
+      await expect(harness.ensureConfigFile()).rejects.toBeInstanceOf(HostProcessError);
+      await expect(harness.ensureConfigFile()).rejects.toMatchObject({
+        code: OsProcessErrors.codes.SHELL_GIT_BASH_NOT_FOUND,
+      });
+    } finally {
+      await harness.close();
     }
   });
 


### PR DESCRIPTION
<!--
Thank you for your contribution to Kimi Code!
Please open an issue before sending a feature PR — PRs without prior discussion may be closed without review.

See https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md for more.
-->

## Related Issue

No linked issue. This PR addresses a Windows startup crash reported by users running the native-compiled binary on a clean Windows host without Git for Windows installed.

## Problem

On Windows, when Git for Windows is not installed and `KIMI_SHELL_PATH` is not set, launching the native-compiled `kimi-code` binary causes a silent exit due to an unhandled rejection in the v2 engine host-environment probe. `--help` and `--version` continue to work because they do not initialize the v2 engine.

The failure is not surfaced to the user, so there is no actionable install hint.

## What changed

- `environmentProbe` now throws a dedicated `ProbeShellNotFoundError` when Git Bash cannot be located on Windows.
- `HostEnvironmentService` catches the async probe rejection so it cannot become an unhandled rejection, and re-throws it as a `HostProcessError(SHELL_GIT_BASH_NOT_FOUND)` when callers access environment fields or await `ready`.
- `SDKRpcClientV2.ensureConfigFile()` awaits `IHostEnvironment.ready`, so the missing-shell error surfaces before the TUI starts.
- Added tests for the new error path in `environmentProbe`, `HostEnvironmentService`, and `SDKRpcClientV2`.

Users without Git for Windows now see a clear install hint instead of a silent crash.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.
