### PR TITLE
feat(kimi-code): show live background agent activity in the /tasks panel

### DIFF
--- a/.changeset/background-agent-activity-view.md
+++ b/.changeset/background-agent-activity-view.md
@@ -2,4 +2,4 @@
 "@moonshot-ai/kimi-code": minor
 ---
 
-Add a live activity view for background agents in the `/tasks` panel: the preview pane shows the agent's recent steps and tool calls while it runs, and `Enter`/`O` opens a full-screen detail view with Markdown text and per-tool results (`Ctrl+O` expands results). Open `/tasks` and select an agent task to try it.
+Show the live work progress of background subagents in the `/tasks` panel.

--- a/.changeset/background-agent-activity-view.md
+++ b/.changeset/background-agent-activity-view.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": minor
+---
+
+Add a live activity view for background agents in the `/tasks` panel: the preview pane shows the agent's recent steps and tool calls while it runs, and `Enter`/`O` opens a full-screen detail view with Markdown text and per-tool results (`Ctrl+O` expands results). Open `/tasks` and select an agent task to try it.

--- a/apps/kimi-code/src/tui/components/dialogs/agent-activity-viewer.ts
+++ b/apps/kimi-code/src/tui/components/dialogs/agent-activity-viewer.ts
@@ -1,0 +1,434 @@
+/**
+ * AgentActivityViewer — full-screen detail view for a background agent task.
+ *
+ * Same full-screen skeleton as `TaskOutputViewer` (header / scrolling body /
+ * footer, tail-follow), but the body is assembled from the in-memory
+ * `SubagentActivityRecord` instead of the task's captured output: recent
+ * steps with their assistant text (Markdown, same as the main transcript)
+ * and tool calls rendered through the main-flow result renderers
+ * (`pickResultRenderer` / `pickChip` / `extractKeyArgument`). `ToolCallComponent`
+ * itself is not reused — it is a live, event-driven component, while this
+ * view renders a snapshot.
+ *
+ * Ctrl+O toggles a global expand of every tool result (same semantics as the
+ * main transcript's `toolOutputExpanded`), capped by what the store retained.
+ */
+
+import {
+  Container,
+  Key,
+  matchesKey,
+  type Focusable,
+  type Terminal,
+  truncateToWidth,
+  visibleWidth,
+} from '@moonshot-ai/pi-tui';
+import type { BackgroundTaskInfo } from '@moonshot-ai/kimi-code-sdk';
+
+import { MESSAGE_INDENT } from '#/tui/constant/rendering';
+import { STATUS_BULLET } from '#/tui/constant/symbols';
+import type {
+  SubagentActivityRecord,
+  SubToolCallActivity,
+} from '#/tui/controllers/subagent-activity-store';
+import { currentTheme } from '#/tui/theme';
+import type { ToolCallBlockData } from '#/tui/types';
+import { printableChar } from '#/tui/utils/printable-key';
+import { AssistantMessageComponent } from '../messages/assistant-message';
+import { extractKeyArgument } from '../messages/tool-call';
+import { pickChip } from '../messages/tool-renderers/chip';
+import { pickResultRenderer } from '../messages/tool-renderers/registry';
+import { STATUS_LABEL, statusColor } from './task-output-viewer';
+
+const ELLIPSIS = '…';
+
+export interface AgentActivityViewerProps {
+  readonly taskId: string;
+  readonly info: BackgroundTaskInfo | undefined;
+  readonly record: SubagentActivityRecord | undefined;
+  readonly onClose: () => void;
+}
+
+function padToWidth(line: string, width: number): string {
+  const w = visibleWidth(line);
+  if (w === width) return line;
+  if (w > width) return truncateToWidth(line, width, ELLIPSIS);
+  return line + ' '.repeat(width - w);
+}
+
+function fitExactly(line: string, width: number): string {
+  let s = line;
+  if (visibleWidth(s) > width) s = truncateToWidth(s, width, ELLIPSIS);
+  return padToWidth(s, width);
+}
+
+export class AgentActivityViewer extends Container implements Focusable {
+  focused = false;
+
+  private props: AgentActivityViewerProps;
+  private readonly terminal: Terminal;
+  private expanded = false;
+  /** Index of the topmost visible body line. */
+  private scrollTop = 0;
+  /** Stick to the bottom on updates until the user scrolls away. */
+  private followTail = true;
+  private lines: string[] = [];
+  private lastCacheKey = '';
+
+  constructor(props: AgentActivityViewerProps, terminal: Terminal) {
+    super();
+    this.props = props;
+    this.terminal = terminal;
+  }
+
+  setProps(next: AgentActivityViewerProps): void {
+    this.props = next;
+    this.invalidate();
+  }
+
+  override invalidate(): void {
+    // Theme switches arrive as a tree-wide invalidate; the styled body lines
+    // are cached, so drop the cache here to pick up the new palette.
+    this.lastCacheKey = '';
+    super.invalidate();
+  }
+
+  // ── input ──────────────────────────────────────────────────────────
+
+  handleInput(data: string): void {
+    const visible = this.viewableRows();
+    const k = printableChar(data);
+
+    if (matchesKey(data, Key.escape) || k === 'q' || k === 'Q') {
+      this.props.onClose();
+      return;
+    }
+    if (matchesKey(data, Key.ctrl('o'))) {
+      this.expanded = !this.expanded;
+      this.lastCacheKey = '';
+      this.invalidate();
+      return;
+    }
+    if (matchesKey(data, Key.up) || k === 'k') {
+      this.scrollBy(-1);
+      return;
+    }
+    if (matchesKey(data, Key.down) || k === 'j') {
+      this.scrollBy(1);
+      return;
+    }
+    if (
+      matchesKey(data, Key.pageUp) ||
+      matchesKey(data, Key.ctrl('u')) ||
+      k === ' ' ||
+      data === '\u0002' /* C-b */
+    ) {
+      this.scrollBy(-Math.max(1, visible - 1));
+      return;
+    }
+    if (
+      matchesKey(data, Key.pageDown) ||
+      matchesKey(data, Key.ctrl('d')) ||
+      data === '\u0006' /* C-f */
+    ) {
+      this.scrollBy(Math.max(1, visible - 1));
+      return;
+    }
+    if (matchesKey(data, Key.home) || k === 'g') {
+      this.scrollTo(0);
+      return;
+    }
+    if (matchesKey(data, Key.end) || k === 'G') {
+      this.scrollTo(this.maxScroll());
+      return;
+    }
+  }
+
+  private scrollBy(delta: number): void {
+    this.scrollTo(this.scrollTop + delta);
+  }
+
+  private scrollTo(target: number): void {
+    this.scrollTop = Math.max(0, Math.min(target, this.maxScroll()));
+    this.followTail = this.scrollTop >= this.maxScroll();
+    this.invalidate();
+  }
+
+  private maxScroll(): number {
+    return Math.max(0, this.lines.length - this.viewableRows());
+  }
+
+  /** Content rows inside the body frame: total rows minus header(1) +
+   *  footer(1) + top border(1) + bottom border(1). */
+  private viewableRows(): number {
+    return Math.max(1, this.terminal.rows - 4);
+  }
+
+  // ── body assembly ──────────────────────────────────────────────────
+
+  private cacheKey(innerWidth: number): string {
+    const record = this.props.record;
+    return [
+      String(innerWidth),
+      this.expanded ? 'x' : 'c',
+      record?.agentId ?? '',
+      String(record?.version ?? -1),
+    ].join('|');
+  }
+
+  private buildLines(innerWidth: number): string[] {
+    const record = this.props.record;
+    if (record === undefined) {
+      return [currentTheme.dim(`${MESSAGE_INDENT}[no activity recorded]`)];
+    }
+
+    const out: string[] = [];
+    for (const step of record.steps) {
+      out.push(currentTheme.dim(`── step ${String(step.step)} ──`));
+      if (step.retrying !== undefined) {
+        out.push(currentTheme.fg('warning', `${MESSAGE_INDENT}↻ ${step.retrying}`));
+      }
+      if (step.textTail.trim().length > 0) {
+        const message = new AssistantMessageComponent();
+        message.updateContent(step.textTail);
+        out.push(...message.render(innerWidth));
+      }
+      for (const call of step.toolCalls) {
+        out.push(this.buildToolCallHeader(call));
+        out.push(...this.renderToolCallBody(call, innerWidth));
+      }
+      out.push('');
+    }
+
+    if (record.error !== undefined && record.error.length > 0) {
+      out.push(currentTheme.fg('error', 'Failed'));
+      const message = new AssistantMessageComponent();
+      message.updateContent(record.error);
+      out.push(...message.render(innerWidth));
+    } else if (record.resultSummary !== undefined && record.resultSummary.length > 0) {
+      out.push(currentTheme.boldFg('primary', 'Result'));
+      const message = new AssistantMessageComponent();
+      message.updateContent(record.resultSummary);
+      out.push(...message.render(innerWidth));
+    }
+
+    if (out.length === 0) {
+      out.push(currentTheme.dim(`${MESSAGE_INDENT}Waiting for activity…`));
+    }
+    return out;
+  }
+
+  /** Same shape as the main flow's generic header (`tool-call.ts`
+   *  `buildHeader`): bullet + verb + name + key argument + chip. Custom
+   *  per-tool label wording (e.g. "Ran a command") is intentionally not
+   *  mirrored — the per-tool *body* renderers carry the specialization. */
+  private buildToolCallHeader(call: SubToolCallActivity): string {
+    let bullet: string;
+    if (call.status === 'error') {
+      bullet = currentTheme.fg('error', '✗ ');
+    } else if (call.status === 'done') {
+      bullet = currentTheme.fg('success', STATUS_BULLET);
+    } else {
+      bullet = currentTheme.fg('text', STATUS_BULLET);
+    }
+    const verb = call.status === 'running' ? 'Using' : 'Used';
+    const name = currentTheme.boldFg('primary', call.name);
+    const keyArg = extractKeyArgument(call.name, call.args);
+    const argStr = keyArg === null || keyArg.length === 0 ? '' : currentTheme.dim(` (${keyArg})`);
+
+    let chipStr = '';
+    if (call.result !== undefined) {
+      const provider = pickChip(call.name);
+      const text = provider?.(this.toToolCallBlockData(call), call.result) ?? '';
+      if (text.length > 0) {
+        chipStr =
+          call.result.is_error === true
+            ? currentTheme.fg('error', ` · ${text}`)
+            : currentTheme.dim(` · ${text}`);
+      }
+    }
+    return `${bullet}${verb} ${name}${argStr}${chipStr}`;
+  }
+
+  private renderToolCallBody(call: SubToolCallActivity, innerWidth: number): string[] {
+    if (call.result === undefined) {
+      return call.liveOutputTail === undefined || call.liveOutputTail.length === 0
+        ? []
+        : [currentTheme.dim(`${MESSAGE_INDENT}│ ${call.liveOutputTail}`)];
+    }
+    // The store caps retained output, which cannot survive as a parseable
+    // media envelope (base64) — show a marker instead of dumping the blob.
+    if (call.name === 'ReadMediaFile' && call.result.is_error !== true) {
+      return [currentTheme.dim(`${MESSAGE_INDENT}[media output omitted]`)];
+    }
+    const components = pickResultRenderer(call.name)(
+      this.toToolCallBlockData(call),
+      call.result,
+      { expanded: this.expanded },
+    );
+    const out: string[] = [];
+    for (const component of components) {
+      out.push(...component.render(innerWidth));
+    }
+    return out;
+  }
+
+  private toToolCallBlockData(call: SubToolCallActivity): ToolCallBlockData {
+    return { id: call.id, name: call.name, args: call.args };
+  }
+
+  // ── render ─────────────────────────────────────────────────────────
+
+  override render(width: number): string[] {
+    const rows = Math.max(3, this.terminal.rows);
+    const bodyHeight = rows - 2;
+    const innerWidth = Math.max(1, width - 4);
+
+    const key = this.cacheKey(innerWidth);
+    if (key !== this.lastCacheKey) {
+      this.lines = this.buildLines(innerWidth);
+      this.lastCacheKey = key;
+    }
+    if (this.followTail) this.scrollTop = this.maxScroll();
+
+    const header = this.renderHeader(width);
+    const body = this.renderBody(width, bodyHeight);
+    const footer = this.renderFooter(width, bodyHeight);
+
+    const out: string[] = [header];
+    for (const line of body) out.push(line);
+    out.push(footer);
+    return out;
+  }
+
+  private renderHeader(width: number): string {
+    const title = currentTheme.boldFg('primary', ' Agent activity ');
+    const record = this.props.record;
+    const info = this.props.info;
+    const segments: string[] = [];
+
+    if (record !== undefined) {
+      const label =
+        record.description !== undefined && record.description.length > 0
+          ? `${record.agentName} › ${record.description}`
+          : record.agentName;
+      segments.push(currentTheme.boldFg('text', label));
+    } else {
+      segments.push(currentTheme.boldFg('text', this.props.taskId));
+    }
+    if (info !== undefined) {
+      segments.push(currentTheme.fg(statusColor(info.status), STATUS_LABEL[info.status]));
+    }
+    if (record !== undefined && record.steps.length > 0) {
+      const from = record.steps[0]!.step;
+      const to = record.steps.at(-1)!.step;
+      let range = `step ${String(from)}–${String(to)} / ${String(record.totalSteps)}`;
+      if (record.totalSteps > record.steps.length) range += ' · earlier steps discarded';
+      segments.push(currentTheme.fg('textMuted', range));
+    }
+
+    const composed = title + segments.join('  ');
+    return fitExactly(composed, width);
+  }
+
+  private renderBody(width: number, bodyHeight: number): string[] {
+    const innerWidth = Math.max(1, width - 4);
+
+    const max = this.maxScroll();
+    if (this.scrollTop > max) this.scrollTop = max;
+    if (this.scrollTop < 0) this.scrollTop = 0;
+
+    const viewRows = Math.max(1, bodyHeight - 2);
+    const top = currentTheme.fg('primary', '┌' + '─'.repeat(Math.max(0, width - 2)) + '┐');
+    const bottom = currentTheme.fg('primary', '└' + '─'.repeat(Math.max(0, width - 2)) + '┘');
+
+    const out: string[] = [top];
+    for (let i = 0; i < viewRows; i++) {
+      const lineIndex = this.scrollTop + i;
+      const raw = this.lines[lineIndex] ?? '';
+      const inner = fitExactly(raw, innerWidth);
+      out.push(currentTheme.fg('primary', '│ ') + inner + currentTheme.fg('primary', ' │'));
+    }
+    out.push(bottom);
+    return out;
+  }
+
+  private renderFooter(width: number, bodyHeight: number): string {
+    const key = (text: string): string => currentTheme.boldFg('primary', text);
+    const dim = (text: string): string => currentTheme.fg('textMuted', text);
+
+    const total = this.lines.length;
+    const viewRows = Math.max(1, bodyHeight - 2);
+    const maxScroll = Math.max(0, total - viewRows);
+    const percent =
+      maxScroll === 0 ? 100 : Math.round((this.scrollTop / maxScroll) * 100);
+    const lineFrom = total === 0 ? 0 : this.scrollTop + 1;
+    const lineTo = Math.min(total, this.scrollTop + viewRows);
+
+    const position = currentTheme.fg(
+      'textMuted',
+      ` ${String(lineFrom)}-${String(lineTo)} / ${String(total)} (${String(percent)}%) `,
+    );
+    const keys =
+      `${key('↑↓')} ${dim('line')}  ` +
+      `${key('PgUp/PgDn')} ${dim('page')}  ` +
+      `${key('g/G')} ${dim('top/bot')}  ` +
+      `${key('Ctrl+O')} ${dim(this.expanded ? 'collapse' : 'expand')}  ` +
+      `${key('Q/Esc')} ${dim('cancel')}`;
+    const left = ` ${keys}`;
+    const leftW = visibleWidth(left);
+    const rightW = visibleWidth(position);
+    if (leftW + 2 + rightW <= width) {
+      return left + ' '.repeat(width - leftW - rightW) + position;
+    }
+    return fitExactly(left, width);
+  }
+}
+
+/**
+ * Plain-text preview of a record for the tasks browser's Preview frame (the
+ * frame styles whole lines itself, so this stays ANSI-free). The frame shows
+ * the tail of the string, so the full retained activity is returned.
+ */
+export function formatSubagentActivityPreview(record: SubagentActivityRecord): string {
+  const lines: string[] = [];
+  for (const step of record.steps) {
+    lines.push(`── step ${String(step.step)} ──`);
+    if (step.retrying !== undefined) lines.push(`${MESSAGE_INDENT}↻ ${step.retrying}`);
+    if (step.textTail.trim().length > 0) lines.push(...step.textTail.trimEnd().split('\n'));
+    for (const call of step.toolCalls) {
+      lines.push(formatPreviewToolCall(call));
+      if (
+        call.result === undefined &&
+        call.liveOutputTail !== undefined &&
+        call.liveOutputTail.length > 0
+      ) {
+        lines.push(`${MESSAGE_INDENT}│ ${call.liveOutputTail}`);
+      }
+    }
+  }
+  if (record.error !== undefined && record.error.length > 0) {
+    lines.push('Failed:', ...record.error.trimEnd().split('\n'));
+  } else if (record.resultSummary !== undefined && record.resultSummary.length > 0) {
+    lines.push('Result:', ...record.resultSummary.trimEnd().split('\n'));
+  }
+  if (lines.length === 0) {
+    return record.status === 'running' ? 'Waiting for activity…' : '';
+  }
+  return lines.join('\n');
+}
+
+function formatPreviewToolCall(call: SubToolCallActivity): string {
+  const mark = call.status === 'done' ? '✓' : call.status === 'error' ? '✗' : '●';
+  const verb = call.status === 'running' ? 'Using' : 'Used';
+  const keyArg = extractKeyArgument(call.name, call.args);
+  const argStr = keyArg === null || keyArg.length === 0 ? '' : ` (${keyArg})`;
+
+  let chip = '';
+  if (call.result !== undefined) {
+    const callData: ToolCallBlockData = { id: call.id, name: call.name, args: call.args };
+    const text = pickChip(call.name)?.(callData, call.result) ?? '';
+    if (text.length > 0) chip = ` · ${text}`;
+  }
+  return `${mark} ${verb} ${call.name}${argStr}${chip}`;
+}

--- a/apps/kimi-code/src/tui/components/dialogs/task-output-viewer.ts
+++ b/apps/kimi-code/src/tui/components/dialogs/task-output-viewer.ts
@@ -32,7 +32,7 @@ export interface TaskOutputViewerProps {
   readonly onClose: () => void;
 }
 
-const STATUS_LABEL: Record<BackgroundTaskStatus, string> = {
+export const STATUS_LABEL: Record<BackgroundTaskStatus, string> = {
   running: 'running',
   completed: 'completed',
   failed: 'failed',
@@ -41,7 +41,7 @@ const STATUS_LABEL: Record<BackgroundTaskStatus, string> = {
   lost: 'lost',
 };
 
-function statusColor(status: BackgroundTaskStatus): 'success' | 'textMuted' | 'error' {
+export function statusColor(status: BackgroundTaskStatus): 'success' | 'textMuted' | 'error' {
   switch (status) {
     case 'running':
       return 'success';

--- a/apps/kimi-code/src/tui/components/messages/tool-call.ts
+++ b/apps/kimi-code/src/tui/components/messages/tool-call.ts
@@ -412,7 +412,7 @@ function formatKeyArgument(
   return truncateArgValue(key, displayValue);
 }
 
-function extractKeyArgument(
+export function extractKeyArgument(
   toolName: string,
   args: Record<string, unknown>,
   workspaceDir?: string,

--- a/apps/kimi-code/src/tui/constant/rendering.ts
+++ b/apps/kimi-code/src/tui/constant/rendering.ts
@@ -18,6 +18,11 @@ export const COMMAND_PREVIEW_LINES = 10;
 export const MAX_SUBAGENT_ACTIVITY_STEPS = 20;
 export const SUBAGENT_STEP_TEXT_TAIL_CHARS = 4000;
 export const SUBAGENT_TOOL_OUTPUT_MAX_CHARS = 8000;
+// Cap on individual string argument values kept in a record (Write/Edit
+// carry whole-file contents). Only header summaries and the Edit/Write line
+// chips read args, so long values are truncated; chips become approximate
+// beyond the cap.
+export const SUBAGENT_ARG_STRING_MAX_CHARS = 16 * 1024;
 
 // Animation frames are shared by the login/update loaders and live thinking.
 export const BRAILLE_SPINNER_FRAMES = ['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏'];

--- a/apps/kimi-code/src/tui/constant/rendering.ts
+++ b/apps/kimi-code/src/tui/constant/rendering.ts
@@ -12,6 +12,13 @@ export const RESULT_PREVIEW_LINES = 3;
 export const THINKING_PREVIEW_LINES = 2;
 export const COMMAND_PREVIEW_LINES = 10;
 
+// Retention caps for the subagent activity store (background-agent detail
+// view): only the most recent steps are kept, older steps are discarded
+// whole, and per-step text / per-call output keep bounded tails.
+export const MAX_SUBAGENT_ACTIVITY_STEPS = 10;
+export const SUBAGENT_STEP_TEXT_TAIL_CHARS = 4000;
+export const SUBAGENT_TOOL_OUTPUT_MAX_CHARS = 8000;
+
 // Animation frames are shared by the login/update loaders and live thinking.
 export const BRAILLE_SPINNER_FRAMES = ['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏'];
 export const BRAILLE_SPINNER_INTERVAL_MS = 80;

--- a/apps/kimi-code/src/tui/constant/rendering.ts
+++ b/apps/kimi-code/src/tui/constant/rendering.ts
@@ -15,7 +15,7 @@ export const COMMAND_PREVIEW_LINES = 10;
 // Retention caps for the subagent activity store (background-agent detail
 // view): only the most recent steps are kept, older steps are discarded
 // whole, and per-step text / per-call output keep bounded tails.
-export const MAX_SUBAGENT_ACTIVITY_STEPS = 10;
+export const MAX_SUBAGENT_ACTIVITY_STEPS = 20;
 export const SUBAGENT_STEP_TEXT_TAIL_CHARS = 4000;
 export const SUBAGENT_TOOL_OUTPUT_MAX_CHARS = 8000;
 

--- a/apps/kimi-code/src/tui/controllers/session-event-handler.ts
+++ b/apps/kimi-code/src/tui/controllers/session-event-handler.ts
@@ -1144,6 +1144,21 @@ export class SessionEventHandler {
           description: info.description,
           status: info.status,
         });
+        // Stopped / timed-out agents terminate without a `subagent.failed`
+        // event — mark the activity record here so the detail view does not
+        // stay "running" forever. `subagent.completed` carries the result
+        // summary and may land after this, so only fill still-running records.
+        const agentId = info.agentId;
+        if (agentId !== undefined) {
+          const record = this.subAgentEventHandler.activityStore.get(agentId);
+          if (record !== undefined && record.status === 'running') {
+            if (info.status === 'completed') {
+              this.subAgentEventHandler.activityStore.markCompleted(agentId);
+            } else {
+              this.subAgentEventHandler.activityStore.markFailed(agentId);
+            }
+          }
+        }
       }
       if (!this.backgroundTaskTranscriptedTerminal.has(info.taskId)) {
         if (info.kind === 'process' || info.kind === 'question') {

--- a/apps/kimi-code/src/tui/controllers/session-event-handler.ts
+++ b/apps/kimi-code/src/tui/controllers/session-event-handler.ts
@@ -357,6 +357,10 @@ export class SessionEventHandler {
     if (event.reason === 'cancelled') {
       this.markActiveAgentSwarmsCancelled();
     }
+    // Aborted foreground subagents emit no completed/failed lifecycle event
+    // (v2 suppresses it for aborts), so their activity records would linger
+    // until the session reset — prune them when the owning turn ends.
+    this.subAgentEventHandler.dropForegroundOnlyActivityRecords();
     if (event.reason === 'failed' && event.error?.code === 'provider.filtered') {
       this.host.showStatus('Turn stopped: provider safety policy blocked the response.', 'error');
     }

--- a/apps/kimi-code/src/tui/controllers/subagent-activity-store.ts
+++ b/apps/kimi-code/src/tui/controllers/subagent-activity-store.ts
@@ -22,6 +22,7 @@ import type { Event } from '@moonshot-ai/kimi-code-sdk';
 
 import {
   MAX_SUBAGENT_ACTIVITY_STEPS,
+  SUBAGENT_ARG_STRING_MAX_CHARS,
   SUBAGENT_STEP_TEXT_TAIL_CHARS,
   SUBAGENT_TOOL_OUTPUT_MAX_CHARS,
 } from '#/tui/constant/rendering';
@@ -88,6 +89,22 @@ function tail(text: string, maxChars: number): string {
   return text.length <= maxChars ? text : text.slice(text.length - maxChars);
 }
 
+/** Truncate long string argument values before they are retained — Write and
+ *  Edit carry whole-file contents in args, which would otherwise dwarf every
+ *  other retention cap. Only header summaries (`extractKeyArgument`) and the
+ *  Edit/Write line chips read args, so truncation is display-safe; those
+ *  chips simply become approximate beyond the cap. Shallow on purpose: the
+ *  tools that matter have flat argument records. */
+function capArgStrings(args: Record<string, unknown>): Record<string, unknown> {
+  let capped: Record<string, unknown> | undefined;
+  for (const [key, value] of Object.entries(args)) {
+    if (typeof value !== 'string' || value.length <= SUBAGENT_ARG_STRING_MAX_CHARS) continue;
+    capped ??= { ...args };
+    capped[key] = `${value.slice(0, SUBAGENT_ARG_STRING_MAX_CHARS)}…`;
+  }
+  return capped ?? args;
+}
+
 export class SubagentActivityStore {
   private readonly records = new Map<string, SubagentActivityRecord>();
   /** Raw streaming-arguments buffer per in-flight tool call (from deltas). */
@@ -143,7 +160,7 @@ export class SubagentActivityStore {
       case 'tool.call.started': {
         const record = this.recordFor(event.agentId);
         const existing = this.findToolCall(record, event.toolCallId);
-        const args = argsRecord(event.args);
+        const args = capArgStrings(argsRecord(event.args));
         if (existing === undefined) {
           this.currentStep(record).toolCalls.push({
             id: event.toolCallId,
@@ -185,7 +202,7 @@ export class SubagentActivityStore {
           this.currentStep(record).toolCalls.push(call);
         }
         if (call.name.length === 0 && event.name !== undefined) call.name = event.name;
-        call.args = parseStreamingArgs(buffered);
+        call.args = capArgStrings(parseStreamingArgs(buffered));
         this.bump(record);
         return;
       }

--- a/apps/kimi-code/src/tui/controllers/subagent-activity-store.ts
+++ b/apps/kimi-code/src/tui/controllers/subagent-activity-store.ts
@@ -265,6 +265,7 @@ export class SubagentActivityStore {
     if (record === undefined) return;
     record.status = 'completed';
     record.resultSummary = resultSummary;
+    this.dropStreamingBuffers(agentId);
     this.bump(record);
   }
 
@@ -273,6 +274,7 @@ export class SubagentActivityStore {
     if (record === undefined) return;
     record.status = 'failed';
     record.error = error;
+    this.dropStreamingBuffers(agentId);
     this.bump(record);
   }
 
@@ -287,6 +289,12 @@ export class SubagentActivityStore {
    *  resident until the session reset. */
   drop(agentId: string): void {
     this.records.delete(agentId);
+    this.dropStreamingBuffers(agentId);
+  }
+
+  /** No more deltas arrive once the record is terminal, so any buffer left
+   *  by a call truncated before started/result can be released here. */
+  private dropStreamingBuffers(agentId: string): void {
     const prefix = `${agentId}:`;
     for (const key of this.streamingArgs.keys()) {
       if (key.startsWith(prefix)) this.streamingArgs.delete(key);

--- a/apps/kimi-code/src/tui/controllers/subagent-activity-store.ts
+++ b/apps/kimi-code/src/tui/controllers/subagent-activity-store.ts
@@ -255,6 +255,18 @@ export class SubagentActivityStore {
     this.streamingArgs.clear();
   }
 
+  /** Drop one agent's record and its in-flight arg buffers. Used when a
+   *  foreground-only subagent (never backgrounded, so it can never appear in
+   *  /tasks) reaches a terminal state — its record would otherwise stay
+   *  resident until the session reset. */
+  drop(agentId: string): void {
+    this.records.delete(agentId);
+    const prefix = `${agentId}:`;
+    for (const key of this.streamingArgs.keys()) {
+      if (key.startsWith(prefix)) this.streamingArgs.delete(key);
+    }
+  }
+
   /** Get-or-create: events can arrive for agents this process never saw a
    *  spawn for (e.g. switching back to a session whose background agents are
    *  still running) — keep their activity rather than dropping it. */

--- a/apps/kimi-code/src/tui/controllers/subagent-activity-store.ts
+++ b/apps/kimi-code/src/tui/controllers/subagent-activity-store.ts
@@ -1,0 +1,290 @@
+/**
+ * SubagentActivityStore — per-agent activity records feeding the background
+ * agent detail view (AgentActivityViewer).
+ *
+ * Child-agent events arrive at `SubAgentEventHandler.routeChildAgentEvent`
+ * regardless of foreground/background state, but are dropped there when the
+ * parent tool card is gone (Ctrl+B) or never existed (run_in_background).
+ * This store tees those events into a bounded per-agent fold so the tasks
+ * browser can show what a background agent is actually doing.
+ *
+ * Retention: only the most recent `MAX_SUBAGENT_ACTIVITY_STEPS` steps are
+ * kept (older steps are discarded whole — a step is the core loop's natural
+ * "one model response + tool execution" unit, bounded by the core's own
+ * `turn.step.started` events). Per-step assistant text keeps a trailing
+ * window; per-call result output is capped. Everything lives in memory and
+ * is released on session switch (`clear`).
+ *
+ * Pure logic — no TUI state, no components — so it is unit-testable.
+ */
+
+import type { Event } from '@moonshot-ai/kimi-code-sdk';
+
+import {
+  MAX_SUBAGENT_ACTIVITY_STEPS,
+  SUBAGENT_STEP_TEXT_TAIL_CHARS,
+  SUBAGENT_TOOL_OUTPUT_MAX_CHARS,
+} from '#/tui/constant/rendering';
+import type { ToolResultBlockData } from '../types';
+import {
+  argsRecord,
+  parseStreamingArgs,
+  serializeToolResultOutput,
+} from '../utils/event-payload';
+
+/** A single tool call inside a step, shaped so the viewer can feed the
+ *  main-flow renderers (`ToolCallBlockData` / `ToolResultBlockData`). */
+export interface SubToolCallActivity {
+  readonly id: string;
+  name: string;
+  args: Record<string, unknown>;
+  status: 'running' | 'done' | 'error';
+  readonly startedAt: number;
+  durationMs?: number;
+  result?: ToolResultBlockData;
+  /** Last line of stdout/stderr live progress, while the call is running. */
+  liveOutputTail?: string;
+}
+
+/** One step = one core loop iteration (`turn.step.started` … next start). */
+export interface SubagentStepActivity {
+  readonly step: number;
+  /** Assistant text of this step, trailing window only. */
+  textTail: string;
+  readonly toolCalls: SubToolCallActivity[];
+  retrying?: string;
+}
+
+export interface SubagentActivityRecord {
+  readonly agentId: string;
+  readonly agentName: string;
+  readonly description?: string;
+  readonly parentToolCallId: string;
+  model?: string;
+  effort?: string;
+  readonly steps: SubagentStepActivity[];
+  /** Count of real `turn.step.started` events seen (monotonic). */
+  totalSteps: number;
+  status: 'running' | 'completed' | 'failed';
+  resultSummary?: string;
+  error?: string;
+  /** Bumped on every mutation; the viewer caches its render against this. */
+  version: number;
+}
+
+export interface SubagentActivitySpawn {
+  readonly agentId: string;
+  readonly agentName: string;
+  readonly description?: string;
+  readonly parentToolCallId: string;
+  readonly model?: string;
+  readonly effort?: string;
+}
+
+const LIVE_OUTPUT_TAIL_CHARS = 200;
+
+function tail(text: string, maxChars: number): string {
+  return text.length <= maxChars ? text : text.slice(text.length - maxChars);
+}
+
+export class SubagentActivityStore {
+  private readonly records = new Map<string, SubagentActivityRecord>();
+  /** Raw streaming-arguments buffer per in-flight tool call (from deltas). */
+  private readonly streamingArgs = new Map<string, string>();
+
+  ensureRecord(spawn: SubagentActivitySpawn): SubagentActivityRecord {
+    const existing = this.records.get(spawn.agentId);
+    if (existing !== undefined) {
+      // A resumed subagent re-spawns under the same id: keep the accumulated
+      // steps and flip the record back to running.
+      existing.status = 'running';
+      existing.resultSummary = undefined;
+      existing.error = undefined;
+      return existing;
+    }
+    const record: SubagentActivityRecord = {
+      agentId: spawn.agentId,
+      agentName: spawn.agentName,
+      description: spawn.description,
+      parentToolCallId: spawn.parentToolCallId,
+      model: spawn.model,
+      effort: spawn.effort,
+      steps: [],
+      totalSteps: 0,
+      status: 'running',
+      version: 0,
+    };
+    this.records.set(spawn.agentId, record);
+    return record;
+  }
+
+  get(agentId: string): SubagentActivityRecord | undefined {
+    return this.records.get(agentId);
+  }
+
+  applyEvent(event: Event): void {
+    switch (event.type) {
+      case 'turn.step.started': {
+        const record = this.recordFor(event.agentId);
+        record.steps.push({ step: event.step, textTail: '', toolCalls: [] });
+        record.totalSteps += 1;
+        while (record.steps.length > MAX_SUBAGENT_ACTIVITY_STEPS) record.steps.shift();
+        this.bump(record);
+        return;
+      }
+      case 'assistant.delta': {
+        const record = this.recordFor(event.agentId);
+        const step = this.currentStep(record);
+        step.textTail = tail(step.textTail + event.delta, SUBAGENT_STEP_TEXT_TAIL_CHARS);
+        this.bump(record);
+        return;
+      }
+      case 'tool.call.started': {
+        const record = this.recordFor(event.agentId);
+        const existing = this.findToolCall(record, event.toolCallId);
+        const args = argsRecord(event.args);
+        if (existing === undefined) {
+          this.currentStep(record).toolCalls.push({
+            id: event.toolCallId,
+            name: event.name,
+            args,
+            status: 'running',
+            startedAt: Date.now(),
+          });
+        } else {
+          // Authoritative full args arrive with the start; replace the
+          // best-effort record assembled from streaming deltas.
+          existing.name = event.name;
+          existing.args = args;
+        }
+        this.streamingArgs.delete(this.streamKey(event.agentId, event.toolCallId));
+        this.bump(record);
+        return;
+      }
+      case 'tool.call.delta': {
+        const record = this.recordFor(event.agentId);
+        const key = this.streamKey(event.agentId, event.toolCallId);
+        const buffered = (this.streamingArgs.get(key) ?? '') + (event.argumentsPart ?? '');
+        this.streamingArgs.set(key, buffered);
+        let call = this.findToolCall(record, event.toolCallId);
+        if (call === undefined) {
+          call = {
+            id: event.toolCallId,
+            name: event.name ?? '',
+            args: {},
+            status: 'running',
+            startedAt: Date.now(),
+          };
+          this.currentStep(record).toolCalls.push(call);
+        }
+        if (call.name.length === 0 && event.name !== undefined) call.name = event.name;
+        call.args = parseStreamingArgs(buffered);
+        this.bump(record);
+        return;
+      }
+      case 'tool.progress': {
+        if (event.update.kind !== 'stdout' && event.update.kind !== 'stderr') return;
+        const text = event.update.text;
+        if (text === undefined || text.trim().length === 0) return;
+        const record = this.records.get(event.agentId);
+        const call = record === undefined ? undefined : this.findToolCall(record, event.toolCallId);
+        if (record === undefined || call === undefined) return;
+        const lines = text.trimEnd().split('\n');
+        call.liveOutputTail = tail(lines.at(-1) ?? '', LIVE_OUTPUT_TAIL_CHARS);
+        this.bump(record);
+        return;
+      }
+      case 'tool.result': {
+        const record = this.records.get(event.agentId);
+        const call = record === undefined ? undefined : this.findToolCall(record, event.toolCallId);
+        if (record === undefined || call === undefined) return;
+        let output = serializeToolResultOutput(event.output);
+        if (output.length > SUBAGENT_TOOL_OUTPUT_MAX_CHARS) {
+          output = `${output.slice(0, SUBAGENT_TOOL_OUTPUT_MAX_CHARS)}\n… [output truncated to ${String(SUBAGENT_TOOL_OUTPUT_MAX_CHARS)} chars]`;
+        }
+        call.result = {
+          tool_call_id: call.id,
+          output,
+          is_error: event.isError,
+          synthetic: event.synthetic,
+        };
+        call.status = event.isError === true ? 'error' : 'done';
+        call.durationMs = Date.now() - call.startedAt;
+        call.liveOutputTail = undefined;
+        this.streamingArgs.delete(this.streamKey(event.agentId, event.toolCallId));
+        this.bump(record);
+        return;
+      }
+      case 'turn.step.retrying': {
+        const record = this.recordFor(event.agentId);
+        const step = this.currentStep(record);
+        step.retrying = `retrying · attempt ${String(event.nextAttempt)}/${String(event.maxAttempts)} (${event.errorName})`;
+        this.bump(record);
+        return;
+      }
+      default:
+        return;
+    }
+  }
+
+  markCompleted(agentId: string, resultSummary?: string): void {
+    const record = this.records.get(agentId);
+    if (record === undefined) return;
+    record.status = 'completed';
+    record.resultSummary = resultSummary;
+    this.bump(record);
+  }
+
+  markFailed(agentId: string, error?: string): void {
+    const record = this.records.get(agentId);
+    if (record === undefined) return;
+    record.status = 'failed';
+    record.error = error;
+    this.bump(record);
+  }
+
+  clear(): void {
+    this.records.clear();
+    this.streamingArgs.clear();
+  }
+
+  /** Get-or-create: events can arrive for agents this process never saw a
+   *  spawn for (e.g. switching back to a session whose background agents are
+   *  still running) — keep their activity rather than dropping it. */
+  private recordFor(agentId: string): SubagentActivityRecord {
+    return (
+      this.records.get(agentId) ??
+      this.ensureRecord({ agentId, agentName: agentId, parentToolCallId: '' })
+    );
+  }
+
+  /** Latest step, creating a synthetic one when content arrives ahead of any
+   *  `turn.step.started` (same mid-flight case as `recordFor`). */
+  private currentStep(record: SubagentActivityRecord): SubagentStepActivity {
+    let step = record.steps.at(-1);
+    if (step === undefined) {
+      step = { step: 0, textTail: '', toolCalls: [] };
+      record.steps.push(step);
+    }
+    return step;
+  }
+
+  private findToolCall(
+    record: SubagentActivityRecord,
+    toolCallId: string,
+  ): SubToolCallActivity | undefined {
+    for (let i = record.steps.length - 1; i >= 0; i--) {
+      const call = record.steps[i]!.toolCalls.find((c) => c.id === toolCallId);
+      if (call !== undefined) return call;
+    }
+    return undefined;
+  }
+
+  private streamKey(agentId: string, toolCallId: string): string {
+    return `${agentId}:${toolCallId}`;
+  }
+
+  private bump(record: SubagentActivityRecord): void {
+    record.version += 1;
+  }
+}

--- a/apps/kimi-code/src/tui/controllers/subagent-activity-store.ts
+++ b/apps/kimi-code/src/tui/controllers/subagent-activity-store.ts
@@ -140,6 +140,10 @@ export class SubagentActivityStore {
     return this.records.get(agentId);
   }
 
+  agentIds(): readonly string[] {
+    return [...this.records.keys()];
+  }
+
   applyEvent(event: Event): void {
     switch (event.type) {
       case 'turn.step.started': {

--- a/apps/kimi-code/src/tui/controllers/subagent-activity-store.ts
+++ b/apps/kimi-code/src/tui/controllers/subagent-activity-store.ts
@@ -28,6 +28,7 @@ import {
 import type { ToolResultBlockData } from '../types';
 import {
   argsRecord,
+  appendStreamingArgsPreview,
   parseStreamingArgs,
   serializeToolResultOutput,
 } from '../utils/event-payload';
@@ -164,7 +165,13 @@ export class SubagentActivityStore {
       case 'tool.call.delta': {
         const record = this.recordFor(event.agentId);
         const key = this.streamKey(event.agentId, event.toolCallId);
-        const buffered = (this.streamingArgs.get(key) ?? '') + (event.argumentsPart ?? '');
+        // parseStreamingArgs only reads the preview window, so keep the raw
+        // buffer capped at the same size — an uncapped buffer would outgrow
+        // the store's retention caps on large Write/Edit argument streams.
+        const buffered = appendStreamingArgsPreview(
+          this.streamingArgs.get(key),
+          event.argumentsPart,
+        );
         this.streamingArgs.set(key, buffered);
         let call = this.findToolCall(record, event.toolCallId);
         if (call === undefined) {

--- a/apps/kimi-code/src/tui/controllers/subagent-activity-store.ts
+++ b/apps/kimi-code/src/tui/controllers/subagent-activity-store.ts
@@ -146,7 +146,16 @@ export class SubagentActivityStore {
         const record = this.recordFor(event.agentId);
         record.steps.push({ step: event.step, textTail: '', toolCalls: [] });
         record.totalSteps += 1;
-        while (record.steps.length > MAX_SUBAGENT_ACTIVITY_STEPS) record.steps.shift();
+        while (record.steps.length > MAX_SUBAGENT_ACTIVITY_STEPS) {
+          const evicted = record.steps.shift();
+          if (evicted === undefined) break;
+          // A call truncated before started/result only ever produced deltas;
+          // its arg buffer is keyed by id, so evicting the only step that
+          // referenced it must drop the buffer entry too.
+          for (const call of evicted.toolCalls) {
+            this.streamingArgs.delete(this.streamKey(record.agentId, call.id));
+          }
+        }
         this.bump(record);
         return;
       }

--- a/apps/kimi-code/src/tui/controllers/subagent-event-handler.ts
+++ b/apps/kimi-code/src/tui/controllers/subagent-event-handler.ts
@@ -293,6 +293,7 @@ export class SubAgentEventHandler {
     event: SubagentLifecycleEventOf<'subagent.completed'>,
   ): void {
     this.activityStore.markCompleted(event.subagentId, event.resultSummary);
+    this.pruneForegroundOnlyRecord(event.subagentId);
     const backgroundMeta = this.backgroundAgentMetadata.get(event.subagentId);
     if (backgroundMeta !== undefined) {
       const taskId = this.findAgentTaskId(
@@ -323,6 +324,7 @@ export class SubAgentEventHandler {
     event: SubagentLifecycleEventOf<'subagent.failed'>,
   ): void {
     this.activityStore.markFailed(event.subagentId, event.error);
+    this.pruneForegroundOnlyRecord(event.subagentId);
     const backgroundMeta = this.backgroundAgentMetadata.get(event.subagentId);
     if (backgroundMeta !== undefined) {
       const taskId = this.findAgentTaskId(
@@ -376,6 +378,16 @@ export class SubAgentEventHandler {
       match = info.taskId;
     }
     return match;
+  }
+
+  /** A subagent that never became a background task (foreground-only) can
+   *  never appear in /tasks, so its activity record is dropped at terminal
+   *  state — otherwise records would pile up for the rest of the session. */
+  private pruneForegroundOnlyRecord(subagentId: string): void {
+    for (const info of this.deps.backgroundTasks.values()) {
+      if (info.kind === 'agent' && info.agentId === subagentId) return;
+    }
+    this.activityStore.drop(subagentId);
   }
 
   private buildBackgroundAgentMetadata(

--- a/apps/kimi-code/src/tui/controllers/subagent-event-handler.ts
+++ b/apps/kimi-code/src/tui/controllers/subagent-event-handler.ts
@@ -22,6 +22,7 @@ import { argsRecord, serializeToolResultOutput } from '../utils/event-payload';
 import { formatHookResultPlain } from '../utils/hook-result-format';
 import { nextTranscriptId } from '../utils/transcript-id';
 import type { SessionEventHost } from './session-event-handler';
+import { SubagentActivityStore } from './subagent-activity-store';
 
 export interface SubagentInfo {
   readonly parentToolCallId: string;
@@ -56,6 +57,8 @@ export class SubAgentEventHandler {
   readonly subagentInfo: Map<string, SubagentInfo> = new Map();
   private readonly agentSwarmProgress: Map<string, AgentSwarmProgressComponent> = new Map();
   backgroundAgentMetadata: Map<string, BackgroundAgentMetadata> = new Map();
+  /** Bounded per-agent activity fold feeding the background-agent detail view. */
+  readonly activityStore = new SubagentActivityStore();
 
   constructor(
     private readonly host: SessionEventHost,
@@ -65,6 +68,7 @@ export class SubAgentEventHandler {
   resetRuntimeState(): void {
     this.subagentInfo.clear();
     this.backgroundAgentMetadata.clear();
+    this.activityStore.clear();
     this.clearAgentSwarmProgress();
   }
 
@@ -74,6 +78,11 @@ export class SubAgentEventHandler {
     const childAgentId = event.agentId;
     if (childAgentId === MAIN_AGENT_ID) return false;
     if (this.host.btwPanelController.routeEvent(event)) return true;
+
+    // Tee every child-agent event into the activity store before the routing
+    // below swallows events whose parent card is gone (Ctrl+B) or never
+    // existed (run_in_background) — that data is the background detail view.
+    this.activityStore.applyEvent(event);
 
     const info = this.subagentInfo.get(childAgentId);
     if (info === undefined || info.parentToolCallId.length === 0) return true;
@@ -283,6 +292,7 @@ export class SubAgentEventHandler {
   private handleSubagentCompleted(
     event: SubagentLifecycleEventOf<'subagent.completed'>,
   ): void {
+    this.activityStore.markCompleted(event.subagentId, event.resultSummary);
     const backgroundMeta = this.backgroundAgentMetadata.get(event.subagentId);
     if (backgroundMeta !== undefined) {
       const taskId = this.findAgentTaskId(
@@ -312,6 +322,7 @@ export class SubAgentEventHandler {
   private handleSubagentFailed(
     event: SubagentLifecycleEventOf<'subagent.failed'>,
   ): void {
+    this.activityStore.markFailed(event.subagentId, event.error);
     const backgroundMeta = this.backgroundAgentMetadata.get(event.subagentId);
     if (backgroundMeta !== undefined) {
       const taskId = this.findAgentTaskId(
@@ -408,6 +419,14 @@ export class SubAgentEventHandler {
       name: event.subagentName,
       runInBackground: event.runInBackground,
       swarmIndex: event.swarmIndex,
+    });
+    this.activityStore.ensureRecord({
+      agentId: event.subagentId,
+      agentName: event.subagentName,
+      description: event.description,
+      parentToolCallId: event.parentToolCallId,
+      model: this.spawnedModelDisplay(event),
+      effort: this.subagentEffortDisplay(event.thinkingEffort),
     });
   }
 

--- a/apps/kimi-code/src/tui/controllers/subagent-event-handler.ts
+++ b/apps/kimi-code/src/tui/controllers/subagent-event-handler.ts
@@ -393,6 +393,15 @@ export class SubAgentEventHandler {
     this.activityStore.drop(subagentId);
   }
 
+  /** Drop every foreground-only record. Called when the main turn ends: any
+   *  foreground subagent of the turn is over at that point, and an aborted
+   *  one emits no `subagent.completed`/`subagent.failed` to prune it. */
+  dropForegroundOnlyActivityRecords(): void {
+    for (const agentId of this.activityStore.agentIds()) {
+      this.pruneForegroundOnlyRecord(agentId);
+    }
+  }
+
   private buildBackgroundAgentMetadata(
     event: SubagentLifecycleEventOf<'subagent.spawned'>,
   ): BackgroundAgentMetadata {

--- a/apps/kimi-code/src/tui/controllers/subagent-event-handler.ts
+++ b/apps/kimi-code/src/tui/controllers/subagent-event-handler.ts
@@ -384,6 +384,9 @@ export class SubAgentEventHandler {
    *  never appear in /tasks, so its activity record is dropped at terminal
    *  state — otherwise records would pile up for the rest of the session. */
   private pruneForegroundOnlyRecord(subagentId: string): void {
+    // A spawn-time background agent keeps its record even when the
+    // background.task.started sync has not landed yet (short-lived agents).
+    if (this.backgroundAgentMetadata.has(subagentId)) return;
     for (const info of this.deps.backgroundTasks.values()) {
       if (info.kind === 'agent' && info.agentId === subagentId) return;
     }

--- a/apps/kimi-code/src/tui/controllers/tasks-browser.ts
+++ b/apps/kimi-code/src/tui/controllers/tasks-browser.ts
@@ -1,10 +1,13 @@
 import type { BackgroundTaskInfo, Session } from '@moonshot-ai/kimi-code-sdk';
 import type { Component, ProcessTerminal, TUI } from '@moonshot-ai/pi-tui';
 
+import { AgentActivityViewer, formatSubagentActivityPreview } from '../components/dialogs/agent-activity-viewer';
 import { TaskOutputViewer } from '../components/dialogs/task-output-viewer';
 import { TasksBrowserApp, type TasksFilter } from '../components/dialogs/tasks-browser';
 import type { Theme } from '#/tui/theme';
 import type { CustomEditor } from '../components/editor/custom-editor';
+import type { SessionEventHandler } from './session-event-handler';
+import type { SubagentActivityRecord } from './subagent-activity-store';
 
 export interface TasksBrowserHost {
   readonly state: {
@@ -15,6 +18,7 @@ export interface TasksBrowserHost {
     readonly editor: CustomEditor;
   };
   readonly backgroundTasks: ReadonlyMap<string, BackgroundTaskInfo>;
+  readonly sessionEventHandler: SessionEventHandler;
   readonly session: Session | undefined;
   showError(msg: string): void;
   setTasksBrowser(value: TasksBrowserState | undefined): void;
@@ -33,7 +37,7 @@ export type TasksBrowserState = {
   pollTimer: NodeJS.Timeout | undefined;
   viewer:
     | {
-        component: TaskOutputViewer;
+        component: TaskOutputViewer | AgentActivityViewer;
         savedChildren: readonly Component[];
         taskId: string;
         output: string;
@@ -140,6 +144,8 @@ export class TasksBrowserController {
     const browser = state.tasksBrowser;
     const viewer = browser?.viewer;
     if (browser === undefined || viewer === undefined) return;
+    // The agent activity viewer refreshes from the local store, not the RPC.
+    if (viewer.component instanceof AgentActivityViewer) return;
 
     const session = this.host.session;
     if (session === undefined) return;
@@ -214,7 +220,24 @@ export class TasksBrowserController {
       return;
     }
     if (state.tasksBrowser !== browser) return;
+    this.syncAgentPreview();
     this.pushProps(tasks);
+  }
+
+  /** Agent tasks capture output only on completion, so while one is selected
+   *  the Preview frame is fed from the in-memory activity store instead. */
+  private syncAgentPreview(): void {
+    const browser = this.host.state.tasksBrowser;
+    const selectedTaskId = browser?.selectedTaskId;
+    if (browser === undefined || selectedTaskId === undefined) return;
+    const info = this.host.backgroundTasks.get(selectedTaskId);
+    if (info?.kind !== 'agent' || info.agentId === undefined) return;
+    const record = this.host.sessionEventHandler.subAgentEventHandler.activityStore.get(
+      info.agentId,
+    );
+    if (record === undefined) return;
+    browser.tailOutput = formatSubagentActivityPreview(record);
+    browser.tailLoading = false;
   }
 
   private pushProps(tasks: readonly BackgroundTaskInfo[]): void {
@@ -317,6 +340,20 @@ export class TasksBrowserController {
     if (browser === undefined) return;
     if (browser.viewer !== undefined) return;
 
+    // Agent tasks get the activity detail view when this process holds a
+    // record for the agent; otherwise (e.g. a `lost` task after resume) fall
+    // through to the captured-output viewer.
+    const info = this.host.backgroundTasks.get(taskId);
+    if (info !== undefined && info.kind === 'agent' && info.agentId !== undefined) {
+      const record = this.host.sessionEventHandler.subAgentEventHandler.activityStore.get(
+        info.agentId,
+      );
+      if (record !== undefined) {
+        this.openAgentActivityViewer(taskId, info, record);
+        return;
+      }
+    }
+
     const session = this.host.session;
     if (session === undefined) {
       this.flash('No active session.');
@@ -334,7 +371,6 @@ export class TasksBrowserController {
     const current = state.tasksBrowser;
     if (current === undefined || current !== browser) return;
 
-    const info = this.host.backgroundTasks.get(taskId);
     const viewer = new TaskOutputViewer(
       {
         taskId,
@@ -367,10 +403,89 @@ export class TasksBrowserController {
     };
   }
 
+  private openAgentActivityViewer(
+    taskId: string,
+    info: BackgroundTaskInfo,
+    record: SubagentActivityRecord,
+  ): void {
+    const { state } = this.host;
+    const browser = state.tasksBrowser;
+    if (browser === undefined || browser.viewer !== undefined) return;
+
+    const viewer = new AgentActivityViewer(
+      {
+        taskId,
+        info,
+        record,
+        onClose: () => {
+          this.closeOutputViewer();
+        },
+      },
+      state.terminal,
+    );
+
+    const savedBrowserChildren = [...state.ui.children];
+    state.ui.clear();
+    state.ui.addChild(viewer);
+    state.ui.setFocus(viewer);
+    state.ui.requestRender(true);
+
+    // The activity store is in-memory — refreshing is a local read, no RPC.
+    const pollTimer = setInterval(() => {
+      this.refreshAgentActivityViewer();
+    }, 1000);
+
+    browser.viewer = {
+      component: viewer,
+      savedChildren: savedBrowserChildren,
+      taskId,
+      output: '',
+      refreshId: 0,
+      pollTimer,
+    };
+  }
+
+  private refreshAgentActivityViewer(): void {
+    const { state } = this.host;
+    const viewer = state.tasksBrowser?.viewer;
+    if (viewer === undefined || !(viewer.component instanceof AgentActivityViewer)) return;
+
+    const info = this.host.backgroundTasks.get(viewer.taskId);
+    const agentId = info?.kind === 'agent' ? info.agentId : undefined;
+    const record =
+      agentId === undefined
+        ? undefined
+        : this.host.sessionEventHandler.subAgentEventHandler.activityStore.get(agentId);
+    viewer.component.setProps({
+      taskId: viewer.taskId,
+      info,
+      record,
+      onClose: () => {
+        this.closeOutputViewer();
+      },
+    });
+    state.ui.requestRender();
+  }
+
   private loadTail(taskId: string): void {
     const { state } = this.host;
     const browser = state.tasksBrowser;
     if (browser === undefined) return;
+
+    // Agent tasks capture output only on completion — serve the preview from
+    // the in-memory activity store instead of the RPC when a record exists.
+    const info = this.host.backgroundTasks.get(taskId);
+    if (info !== undefined && info.kind === 'agent' && info.agentId !== undefined) {
+      const record = this.host.sessionEventHandler.subAgentEventHandler.activityStore.get(
+        info.agentId,
+      );
+      if (record !== undefined) {
+        browser.tailOutput = formatSubagentActivityPreview(record);
+        browser.tailLoading = false;
+        this.repaint();
+        return;
+      }
+    }
 
     const session = this.host.session;
     if (session === undefined) {

--- a/apps/kimi-code/test/tui/components/dialogs/agent-activity-viewer.test.ts
+++ b/apps/kimi-code/test/tui/components/dialogs/agent-activity-viewer.test.ts
@@ -1,0 +1,315 @@
+import type { Terminal } from '@moonshot-ai/pi-tui';
+import type { BackgroundTaskInfo } from '@moonshot-ai/kimi-code-sdk';
+import { describe, expect, it, vi } from 'vitest';
+
+import { AgentActivityViewer, formatSubagentActivityPreview } from '#/tui/components/dialogs/agent-activity-viewer';
+import type { SubagentActivityRecord } from '#/tui/controllers/subagent-activity-store';
+
+const ANSI_SGR = /\[[0-9;]*m/g;
+function strip(text: string): string {
+  return text.replaceAll(ANSI_SGR, '');
+}
+
+/** Kitty CSI-u form of Ctrl+O (codepoint 111, modifier 1+4). */
+const CTRL_O = '\u001B[111;5u';
+
+/** Minimal Terminal stub — only `rows` is read by the component. */
+function fakeTerminal(rows: number, columns = 120): Terminal {
+  return {
+    start: () => {},
+    stop: () => {},
+    drainInput: () => Promise.resolve(),
+    write: () => {},
+    get columns() {
+      return columns;
+    },
+    get rows() {
+      return rows;
+    },
+    get kittyProtocolActive() {
+      return false;
+    },
+    moveBy: () => {},
+    hideCursor: () => {},
+    showCursor: () => {},
+    clearLine: () => {},
+    clearFromCursor: () => {},
+    clearScreen: () => {},
+    setTitle: () => {},
+    setProgress: () => {},
+  };
+}
+
+function agentTask(overrides: Record<string, unknown> = {}): BackgroundTaskInfo {
+  return {
+    taskId: 'agent-task-1',
+    kind: 'agent',
+    agentId: 'agent-1',
+    description: 'find things',
+    status: 'running',
+    startedAt: Date.now() - 60_000,
+    endedAt: null,
+    ...overrides,
+  } as BackgroundTaskInfo;
+}
+
+function record(overrides: Partial<SubagentActivityRecord> = {}): SubagentActivityRecord {
+  return {
+    agentId: 'agent-1',
+    agentName: 'explore',
+    description: 'find things',
+    parentToolCallId: 'tc-1',
+    steps: [],
+    totalSteps: 0,
+    status: 'running',
+    version: 1,
+    ...overrides,
+  };
+}
+
+function makeViewer(
+  props: Partial<Parameters<typeof AgentActivityViewer.prototype.setProps>[0]> & {
+    record?: SubagentActivityRecord;
+  } = {},
+  rows = 20,
+  columns = 80,
+): AgentActivityViewer {
+  return new AgentActivityViewer(
+    {
+      taskId: 'agent-task-1',
+      info: agentTask(),
+      record: props.record,
+      onClose: vi.fn(),
+      ...props,
+    },
+    fakeTerminal(rows, columns),
+  );
+}
+
+function renderPlain(viewer: AgentActivityViewer, width = 80): string {
+  return strip(viewer.render(width).join('\n'));
+}
+
+describe('AgentActivityViewer', () => {
+  it('fills exactly terminal.rows lines', () => {
+    const viewer = makeViewer({}, 20);
+    expect(viewer.render(80).length).toBe(20);
+  });
+
+  it('shows agent label, status and step range in the header', () => {
+    const viewer = makeViewer({
+      record: record({
+        steps: [
+          { step: 8, textTail: '', toolCalls: [] },
+          { step: 9, textTail: '', toolCalls: [] },
+        ],
+        totalSteps: 12,
+      }),
+    });
+    const text = renderPlain(viewer, 120);
+    expect(text).toContain('Agent activity');
+    expect(text).toContain('explore › find things');
+    expect(text).toContain('running');
+    expect(text).toContain('step 8–9 / 12');
+    expect(text).toContain('earlier steps discarded');
+  });
+
+  it('renders steps with tool call headers and result renderer output', () => {
+    const viewer = makeViewer({
+      record: record({
+        steps: [
+          {
+            step: 0,
+            textTail: 'Looking for the event bus definition.',
+            toolCalls: [
+              {
+                id: 't1',
+                name: 'Grep',
+                args: { pattern: 'IEventBus' },
+                status: 'done',
+                startedAt: 0,
+                result: {
+                  tool_call_id: 't1',
+                  output: 'src/a.ts:1:IEventBus\nsrc/b.ts:2:IEventBus',
+                  is_error: false,
+                },
+              },
+            ],
+          },
+        ],
+        totalSteps: 1,
+      }),
+    });
+    const text = renderPlain(viewer);
+    expect(text).toContain('── step 0 ──');
+    expect(text).toContain('Looking for the event bus definition.');
+    expect(text).toContain('Used Grep (IEventBus) · 2 matches');
+    // grep glance renderer: path samples below the header (`path:line` form)
+    expect(text).toContain('src/a.ts:1, src/b.ts:2');
+  });
+
+  it('collapses long output by default and expands it with ctrl+o', () => {
+    const longOutput = Array.from({ length: 10 }, (_, i) => `line ${String(i + 1)}`).join('\n');
+    const makeRecord = (): SubagentActivityRecord =>
+      record({
+        steps: [
+          {
+            step: 0,
+            textTail: '',
+            toolCalls: [
+              {
+                id: 't1',
+                name: 'Bash',
+                args: { command: 'ls' },
+                status: 'done',
+                startedAt: 0,
+                result: { tool_call_id: 't1', output: longOutput, is_error: false },
+              },
+            ],
+          },
+        ],
+        totalSteps: 1,
+      });
+
+    const collapsed = makeViewer({ record: makeRecord() });
+    const collapsedText = renderPlain(collapsed);
+    expect(collapsedText).toContain('ctrl+o to expand');
+    expect(collapsedText).not.toContain('line 10');
+
+    collapsed.handleInput(CTRL_O);
+    const expandedText = renderPlain(collapsed);
+    expect(expandedText).toContain('line 10');
+  });
+
+  it('opens pinned to the latest activity and keeps scroll position when the user scrolled up', () => {
+    const steps = Array.from({ length: 8 }, (_, i) => ({
+      step: i,
+      textTail: `step ${String(i)} text`,
+      toolCalls: [],
+    }));
+    const rec = record({ steps, totalSteps: 8 });
+    const viewer = makeViewer({ record: rec }, 12);
+
+    // Initial render follows the tail: the last step is visible.
+    expect(renderPlain(viewer)).toContain('step 7 text');
+
+    // User scrolls to the top, then new activity arrives (version bump):
+    // the view must stay where the user parked it.
+    viewer.handleInput('g');
+    expect(renderPlain(viewer)).toContain('step 0 text');
+    rec.steps.push({ step: 8, textTail: 'step 8 text', toolCalls: [] });
+    rec.version += 1;
+    viewer.setProps({ taskId: 'agent-task-1', info: agentTask(), record: rec, onClose: vi.fn() });
+    const after = renderPlain(viewer);
+    expect(after).toContain('step 0 text');
+    expect(after).not.toContain('step 8 text');
+  });
+
+  it('shows an explicit empty state when no record exists', () => {
+    const viewer = makeViewer({ record: undefined });
+    expect(renderPlain(viewer)).toContain('[no activity recorded]');
+  });
+
+  it('renders the terminal result summary section', () => {
+    const viewer = makeViewer({
+      info: agentTask({ status: 'completed' }),
+      record: record({ status: 'completed', resultSummary: 'Found 3 call sites.' }),
+    });
+    const text = renderPlain(viewer);
+    expect(text).toContain('completed');
+    expect(text).toContain('Result');
+    expect(text).toContain('Found 3 call sites.');
+  });
+
+  it('closes on q and escape', () => {
+    const onClose = vi.fn();
+    const viewer = makeViewer({ record: record(), onClose });
+    viewer.handleInput('q');
+    expect(onClose).toHaveBeenCalledTimes(1);
+    viewer.handleInput('\u001B');
+    expect(onClose).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('formatSubagentActivityPreview', () => {
+  it('renders steps, tool calls and the terminal result as plain text', () => {
+    const text = formatSubagentActivityPreview(
+      record({
+        status: 'completed',
+        resultSummary: 'Found 3 call sites.',
+        totalSteps: 1,
+        steps: [
+          {
+            step: 0,
+            textTail: 'Looking around.',
+            toolCalls: [
+              {
+                id: 't1',
+                name: 'Grep',
+                args: { pattern: 'IEventBus' },
+                status: 'done',
+                startedAt: 0,
+                result: {
+                  tool_call_id: 't1',
+                  output: 'src/a.ts:1:IEventBus\nsrc/b.ts:2:IEventBus',
+                  is_error: false,
+                },
+              },
+              {
+                id: 't2',
+                name: 'Read',
+                args: { path: '/repo/src/a.ts' },
+                status: 'running',
+                startedAt: 0,
+                liveOutputTail: 'reading…',
+              },
+            ],
+          },
+        ],
+      }),
+    );
+    expect(text).toContain('── step 0 ──');
+    expect(text).toContain('Looking around.');
+    expect(text).toContain('✓ Used Grep (IEventBus) · 2 matches');
+    expect(text).toContain('● Using Read (/repo/src/a.ts)');
+    expect(text).toContain('│ reading…'); // live tail for the in-flight call
+    expect(text).toContain('Result:');
+    expect(text).toContain('Found 3 call sites.');
+    // The preview frame styles whole lines itself — the preview stays ANSI-free.
+    expect(text).not.toMatch(/\[[0-9;]*m/);
+  });
+
+  it('shows the live output tail for a running call', () => {
+    const text = formatSubagentActivityPreview(
+      record({
+        totalSteps: 1,
+        steps: [
+          {
+            step: 0,
+            textTail: '',
+            toolCalls: [
+              {
+                id: 't1',
+                name: 'Bash',
+                args: { command: 'pnpm test' },
+                status: 'running',
+                startedAt: 0,
+                liveOutputTail: '42 passing',
+              },
+            ],
+          },
+        ],
+      }),
+    );
+    expect(text).toContain('● Using Bash (pnpm test)');
+    expect(text).toContain('│ 42 passing');
+  });
+
+  it('returns a waiting placeholder for a fresh running record', () => {
+    expect(formatSubagentActivityPreview(record())).toBe('Waiting for activity…');
+  });
+
+  it('returns an empty string for a terminal record without any activity', () => {
+    expect(formatSubagentActivityPreview(record({ status: 'failed' }))).toBe('');
+  });
+});

--- a/apps/kimi-code/test/tui/controllers/session-event-handler-background-task.test.ts
+++ b/apps/kimi-code/test/tui/controllers/session-event-handler-background-task.test.ts
@@ -1,0 +1,196 @@
+import type { Event } from '@moonshot-ai/kimi-code-sdk';
+import { describe, expect, it, vi } from 'vitest';
+
+import { SessionEventHandler } from '#/tui/controllers/session-event-handler';
+import {
+  SubAgentEventHandler,
+  type SubagentLifecycleEvent,
+} from '#/tui/controllers/subagent-event-handler';
+import { getBuiltInPalette } from '#/tui/theme';
+
+function makeStreamingUIStub() {
+  return {
+    getToolComponent: vi.fn(() => undefined),
+    getActiveToolCall: vi.fn(() => undefined),
+    onToolCallStart: vi.fn(),
+    getTurnContext: vi.fn(() => ({ turnId: 1, step: 0 })),
+    removeToolComponentIfInactive: vi.fn(),
+    applyBackgroundTaskTerminalStatus: vi.fn(),
+    markSubagentBackgrounded: vi.fn(),
+  };
+}
+
+function makeSubagentHandler() {
+  const backgroundTasks = new Map<string, never>();
+  const host = {
+    state: {
+      appState: { availableModels: {} },
+      ui: { requestRender: vi.fn() },
+      transcriptContainer: { addChild: vi.fn() },
+    },
+    streamingUI: makeStreamingUIStub(),
+    appendTranscriptEntry: vi.fn(),
+    btwPanelController: { routeEvent: vi.fn(() => false) },
+    updateActivityPane: vi.fn(),
+  };
+  const handler = new SubAgentEventHandler(host as never, {
+    backgroundTasks,
+    backgroundTaskTranscriptedTerminal: new Set(),
+    syncBackgroundAgentBadge: vi.fn(),
+  });
+  return { handler, backgroundTasks };
+}
+
+function spawnEvent(subagentId: string, runInBackground: boolean): SubagentLifecycleEvent {
+  return {
+    sessionId: 's1',
+    agentId: 'main',
+    type: 'subagent.spawned',
+    subagentId,
+    subagentName: 'explore',
+    parentToolCallId: `tc-${subagentId}`,
+    description: `task ${subagentId}`,
+    runInBackground,
+  } as unknown as SubagentLifecycleEvent;
+}
+
+function completedEvent(subagentId: string): SubagentLifecycleEvent {
+  return {
+    sessionId: 's1',
+    agentId: 'main',
+    type: 'subagent.completed',
+    subagentId,
+    parentToolCallId: `tc-${subagentId}`,
+    resultSummary: 'done',
+  } as unknown as SubagentLifecycleEvent;
+}
+
+describe('SubAgentEventHandler — activity record pruning', () => {
+  it('drops the record of a foreground-only subagent at terminal state', () => {
+    const { handler } = makeSubagentHandler();
+    handler.handleLifecycleEvent(spawnEvent('a1', false));
+    handler.activityStore.applyEvent({
+      sessionId: 's1',
+      agentId: 'a1',
+      type: 'turn.step.started',
+      turnId: 1,
+      step: 0,
+    } as Event);
+    expect(handler.activityStore.get('a1')).toBeDefined();
+
+    handler.handleLifecycleEvent(completedEvent('a1'));
+
+    expect(handler.activityStore.get('a1')).toBeUndefined();
+  });
+
+  it('keeps the record of a spawn-time background agent even before the task syncs', () => {
+    const { handler } = makeSubagentHandler();
+    handler.handleLifecycleEvent(spawnEvent('a2', true));
+    handler.activityStore.applyEvent({
+      sessionId: 's1',
+      agentId: 'a2',
+      type: 'turn.step.started',
+      turnId: 1,
+      step: 0,
+    } as Event);
+
+    // No background.task.started has populated the task map yet.
+    handler.handleLifecycleEvent(completedEvent('a2'));
+
+    const record = handler.activityStore.get('a2');
+    expect(record?.status).toBe('completed');
+    expect(record?.resultSummary).toBe('done');
+  });
+});
+
+function makeSessionEventHost() {
+  const host = {
+    state: {
+      appState: {
+        sessionId: 's1',
+        workDir: '/tmp/wd',
+        streamingPhase: 'idle',
+        availableModels: {},
+      },
+      queuedMessages: [],
+      queuedMessageDispatchPending: false,
+      theme: { palette: getBuiltInPalette('dark') },
+      toolOutputExpanded: false,
+      todoPanel: { getTodos: vi.fn(() => []) },
+      transcriptContainer: { addChild: vi.fn() },
+      tasksBrowser: undefined,
+      footer: { setBackgroundCounts: vi.fn() },
+      ui: { requestRender: vi.fn() },
+    },
+    session: { id: 's1' },
+    aborted: false,
+    sessionEventUnsubscribe: undefined,
+    streamingUI: makeStreamingUIStub(),
+    requireSession: vi.fn(),
+    setAppState: vi.fn(),
+    patchLivePane: vi.fn(),
+    resetLivePane: vi.fn(),
+    showError: vi.fn(),
+    showStatus: vi.fn(),
+    showNotice: vi.fn(),
+    track: vi.fn(),
+    recordSessionActivity: vi.fn(),
+    noteStepUsage: vi.fn(),
+    noteCompactionFinished: vi.fn(),
+    mountEditorReplacement: vi.fn(),
+    restoreEditor: vi.fn(),
+    restoreInputText: vi.fn(),
+    appendTranscriptEntry: vi.fn(),
+    sendNormalUserInput: vi.fn(),
+    sendQueuedMessage: vi.fn(),
+    shiftQueuedMessage: vi.fn(),
+    btwPanelController: { routeEvent: vi.fn(() => false) },
+    tasksBrowserController: { repaint: vi.fn(), refreshOutputViewer: vi.fn() },
+  };
+  return host as never;
+}
+
+describe('SessionEventHandler — background.task.terminated', () => {
+  function terminatedEvent(agentId: string, status: string): Event {
+    return {
+      sessionId: 's1',
+      agentId: 'main',
+      type: 'background.task.terminated',
+      info: {
+        taskId: `task-${agentId}`,
+        kind: 'agent',
+        agentId,
+        description: 'bg task',
+        status,
+        startedAt: 0,
+        endedAt: 1,
+      },
+    } as unknown as Event;
+  }
+
+  it('marks a still-running record failed when an agent is stopped without subagent.failed', () => {
+    const handler = new SessionEventHandler(makeSessionEventHost());
+    handler.subAgentEventHandler.activityStore.ensureRecord({
+      agentId: 'agent-9',
+      agentName: 'explore',
+      parentToolCallId: 'tc-9',
+    });
+
+    handler.handleEvent(terminatedEvent('agent-9', 'killed'), vi.fn());
+
+    expect(handler.subAgentEventHandler.activityStore.get('agent-9')?.status).toBe('failed');
+  });
+
+  it('does not overwrite a record that already reached terminal state with a summary', () => {
+    const handler = new SessionEventHandler(makeSessionEventHost());
+    const store = handler.subAgentEventHandler.activityStore;
+    store.ensureRecord({ agentId: 'agent-8', agentName: 'explore', parentToolCallId: 'tc-8' });
+    store.markCompleted('agent-8', 'final summary');
+
+    handler.handleEvent(terminatedEvent('agent-8', 'completed'), vi.fn());
+
+    const record = store.get('agent-8');
+    expect(record?.status).toBe('completed');
+    expect(record?.resultSummary).toBe('final summary');
+  });
+});

--- a/apps/kimi-code/test/tui/controllers/session-event-handler-background-task.test.ts
+++ b/apps/kimi-code/test/tui/controllers/session-event-handler-background-task.test.ts
@@ -17,6 +17,11 @@ function makeStreamingUIStub() {
     removeToolComponentIfInactive: vi.fn(),
     applyBackgroundTaskTerminalStatus: vi.fn(),
     markSubagentBackgrounded: vi.fn(),
+    setTurnId: vi.fn(),
+    flushNow: vi.fn(),
+    setTodoList: vi.fn(),
+    resetToolUi: vi.fn(),
+    finalizeTurn: vi.fn(),
   };
 }
 
@@ -192,5 +197,24 @@ describe('SessionEventHandler — background.task.terminated', () => {
     const record = store.get('agent-8');
     expect(record?.status).toBe('completed');
     expect(record?.resultSummary).toBe('final summary');
+  });
+
+  it('drops foreground-only records when the main turn ends (aborted subagents emit no lifecycle event)', () => {
+    const handler = new SessionEventHandler(makeSessionEventHost());
+    const store = handler.subAgentEventHandler.activityStore;
+    store.ensureRecord({ agentId: 'agent-7', agentName: 'explore', parentToolCallId: 'tc-7' });
+
+    handler.handleEvent(
+      {
+        sessionId: 's1',
+        agentId: 'main',
+        type: 'turn.ended',
+        turnId: 1,
+        reason: 'cancelled',
+      } as Event,
+      vi.fn(),
+    );
+
+    expect(store.get('agent-7')).toBeUndefined();
   });
 });

--- a/apps/kimi-code/test/tui/controllers/subagent-activity-store.test.ts
+++ b/apps/kimi-code/test/tui/controllers/subagent-activity-store.test.ts
@@ -6,6 +6,7 @@ import {
   SUBAGENT_STEP_TEXT_TAIL_CHARS,
   SUBAGENT_TOOL_OUTPUT_MAX_CHARS,
 } from '#/tui/constant/rendering';
+import { STREAMING_ARGS_PREVIEW_MAX_CHARS } from '#/tui/constant/streaming';
 import {
   SubagentActivityStore,
   type SubagentActivitySpawn,
@@ -172,6 +173,24 @@ describe('SubagentActivityStore', () => {
     const store = new SubagentActivityStore();
     store.applyEvent(ev({ type: 'tool.result', turnId: 1, toolCallId: 't1', output: 'x' }));
     expect(store.get('agent-1')).toBeUndefined();
+  });
+
+  it('caps the raw streaming-args buffer at the preview window', () => {
+    const store = new SubagentActivityStore();
+    store.ensureRecord(spawn());
+    store.applyEvent(
+      ev({
+        type: 'tool.call.delta',
+        turnId: 1,
+        toolCallId: 't1',
+        name: 'Write',
+        argumentsPart: 'x'.repeat(STREAMING_ARGS_PREVIEW_MAX_CHARS + 1000),
+      }),
+    );
+    const buffers = (
+      store as unknown as { streamingArgs: Map<string, string> }
+    ).streamingArgs;
+    expect(buffers.get('agent-1:t1')?.length).toBeLessThanOrEqual(STREAMING_ARGS_PREVIEW_MAX_CHARS);
   });
 
   it('tracks terminal state and resets it on respawn', () => {

--- a/apps/kimi-code/test/tui/controllers/subagent-activity-store.test.ts
+++ b/apps/kimi-code/test/tui/controllers/subagent-activity-store.test.ts
@@ -1,0 +1,203 @@
+import type { Event } from '@moonshot-ai/kimi-code-sdk';
+import { describe, expect, it } from 'vitest';
+
+import {
+  MAX_SUBAGENT_ACTIVITY_STEPS,
+  SUBAGENT_STEP_TEXT_TAIL_CHARS,
+  SUBAGENT_TOOL_OUTPUT_MAX_CHARS,
+} from '#/tui/constant/rendering';
+import {
+  SubagentActivityStore,
+  type SubagentActivitySpawn,
+} from '#/tui/controllers/subagent-activity-store';
+
+function ev(partial: Record<string, unknown>): Event {
+  return { sessionId: 's1', agentId: 'agent-1', ...partial } as unknown as Event;
+}
+
+function spawn(overrides: Partial<SubagentActivitySpawn> = {}): SubagentActivitySpawn {
+  return {
+    agentId: 'agent-1',
+    agentName: 'explore',
+    description: 'find things',
+    parentToolCallId: 'tc-1',
+    model: 'K3',
+    effort: 'high',
+    ...overrides,
+  };
+}
+
+describe('SubagentActivityStore', () => {
+  it('folds a full step lifecycle (text + tool call + result)', () => {
+    const store = new SubagentActivityStore();
+    store.ensureRecord(spawn());
+    store.applyEvent(ev({ type: 'turn.step.started', turnId: 1, step: 0 }));
+    store.applyEvent(ev({ type: 'assistant.delta', turnId: 1, delta: 'Hello ' }));
+    store.applyEvent(ev({ type: 'assistant.delta', turnId: 1, delta: 'world' }));
+    store.applyEvent(
+      ev({ type: 'tool.call.started', turnId: 1, toolCallId: 't1', name: 'Grep', args: { pattern: 'foo' } }),
+    );
+    store.applyEvent(
+      ev({ type: 'tool.progress', turnId: 1, toolCallId: 't1', update: { kind: 'stdout', text: 'line1\nline2\n' } }),
+    );
+    store.applyEvent(
+      ev({ type: 'tool.result', turnId: 1, toolCallId: 't1', output: 'a\nb\nc', isError: false }),
+    );
+
+    const record = store.get('agent-1');
+    expect(record?.agentName).toBe('explore');
+    expect(record?.steps).toHaveLength(1);
+    expect(record?.totalSteps).toBe(1);
+    expect(record?.steps[0]?.textTail).toBe('Hello world');
+    const call = record?.steps[0]?.toolCalls[0];
+    expect(call?.name).toBe('Grep');
+    expect(call?.args).toEqual({ pattern: 'foo' });
+    expect(call?.status).toBe('done');
+    expect(call?.result?.output).toBe('a\nb\nc');
+    expect(call?.result?.is_error).toBe(false);
+    expect(call?.liveOutputTail).toBeUndefined();
+    expect(call?.durationMs).toBeGreaterThanOrEqual(0);
+    expect(record?.version).toBeGreaterThan(0);
+  });
+
+  it('creates a call from streaming deltas and replaces args on start', () => {
+    const store = new SubagentActivityStore();
+    store.ensureRecord(spawn());
+    store.applyEvent(
+      ev({ type: 'tool.call.delta', turnId: 1, toolCallId: 't1', name: 'Bash', argumentsPart: '{"command":"ls' }),
+    );
+    store.applyEvent(
+      ev({ type: 'tool.call.delta', turnId: 1, toolCallId: 't1', argumentsPart: ' -la"}' }),
+    );
+
+    let record = store.get('agent-1');
+    // No step event yet — a synthetic step holds the in-flight call.
+    expect(record?.steps).toHaveLength(1);
+    expect(record?.steps[0]?.toolCalls[0]?.args).toEqual({ command: 'ls -la' });
+
+    store.applyEvent(
+      ev({
+        type: 'tool.call.started',
+        turnId: 1,
+        toolCallId: 't1',
+        name: 'Bash',
+        args: { command: 'ls -la', timeout: 5 },
+      }),
+    );
+    record = store.get('agent-1');
+    expect(record?.steps[0]?.toolCalls[0]?.args).toEqual({ command: 'ls -la', timeout: 5 });
+  });
+
+  it('evicts whole steps beyond the cap while totalSteps keeps counting', () => {
+    const store = new SubagentActivityStore();
+    store.ensureRecord(spawn());
+    for (let i = 0; i < MAX_SUBAGENT_ACTIVITY_STEPS + 2; i++) {
+      store.applyEvent(ev({ type: 'turn.step.started', turnId: 1, step: i }));
+    }
+    const record = store.get('agent-1');
+    expect(record?.steps).toHaveLength(MAX_SUBAGENT_ACTIVITY_STEPS);
+    expect(record?.totalSteps).toBe(MAX_SUBAGENT_ACTIVITY_STEPS + 2);
+    expect(record?.steps[0]?.step).toBe(2);
+  });
+
+  it('keeps only the tail of long assistant text', () => {
+    const store = new SubagentActivityStore();
+    store.ensureRecord(spawn());
+    store.applyEvent(ev({ type: 'turn.step.started', turnId: 1, step: 0 }));
+    store.applyEvent(
+      ev({
+        type: 'assistant.delta',
+        turnId: 1,
+        delta: 'x'.repeat(SUBAGENT_STEP_TEXT_TAIL_CHARS) + 'y'.repeat(100),
+      }),
+    );
+    const step = store.get('agent-1')?.steps[0];
+    expect(step?.textTail).toHaveLength(SUBAGENT_STEP_TEXT_TAIL_CHARS);
+    expect(step?.textTail.endsWith('y'.repeat(100))).toBe(true);
+  });
+
+  it('caps tool output and appends a truncation sentinel', () => {
+    const store = new SubagentActivityStore();
+    store.ensureRecord(spawn());
+    store.applyEvent(ev({ type: 'turn.step.started', turnId: 1, step: 0 }));
+    store.applyEvent(
+      ev({ type: 'tool.call.started', turnId: 1, toolCallId: 't1', name: 'Bash', args: {} }),
+    );
+    store.applyEvent(
+      ev({
+        type: 'tool.result',
+        turnId: 1,
+        toolCallId: 't1',
+        output: 'y'.repeat(SUBAGENT_TOOL_OUTPUT_MAX_CHARS + 100),
+      }),
+    );
+    const call = store.get('agent-1')?.steps[0]?.toolCalls[0];
+    expect(call?.result?.output.startsWith('yyy')).toBe(true);
+    expect(call?.result?.output).toContain('[output truncated');
+    expect(call?.result?.output.length).toBeLessThan(SUBAGENT_TOOL_OUTPUT_MAX_CHARS + 120);
+  });
+
+  it('marks the current step on retry without opening a new one', () => {
+    const store = new SubagentActivityStore();
+    store.ensureRecord(spawn());
+    store.applyEvent(ev({ type: 'turn.step.started', turnId: 1, step: 0 }));
+    store.applyEvent(
+      ev({
+        type: 'turn.step.retrying',
+        turnId: 1,
+        step: 0,
+        nextAttempt: 2,
+        maxAttempts: 5,
+        errorName: 'RateLimitError',
+      }),
+    );
+    let record = store.get('agent-1');
+    expect(record?.steps).toHaveLength(1);
+    expect(record?.steps[0]?.retrying).toContain('2/5');
+
+    store.applyEvent(ev({ type: 'turn.step.started', turnId: 1, step: 1 }));
+    record = store.get('agent-1');
+    expect(record?.steps[1]?.retrying).toBeUndefined();
+  });
+
+  it('implicitly creates a record for events from an unseen agent', () => {
+    const store = new SubagentActivityStore();
+    store.applyEvent(ev({ type: 'assistant.delta', turnId: 1, delta: 'hi' }));
+    const record = store.get('agent-1');
+    expect(record?.agentName).toBe('agent-1');
+    expect(record?.steps[0]?.textTail).toBe('hi');
+  });
+
+  it('drops results for unknown agents instead of creating records', () => {
+    const store = new SubagentActivityStore();
+    store.applyEvent(ev({ type: 'tool.result', turnId: 1, toolCallId: 't1', output: 'x' }));
+    expect(store.get('agent-1')).toBeUndefined();
+  });
+
+  it('tracks terminal state and resets it on respawn', () => {
+    const store = new SubagentActivityStore();
+    store.ensureRecord(spawn());
+    store.markCompleted('agent-1', 'done summary');
+    let record = store.get('agent-1');
+    expect(record?.status).toBe('completed');
+    expect(record?.resultSummary).toBe('done summary');
+
+    store.ensureRecord(spawn());
+    record = store.get('agent-1');
+    expect(record?.status).toBe('running');
+    expect(record?.resultSummary).toBeUndefined();
+
+    store.markFailed('agent-1', 'boom');
+    record = store.get('agent-1');
+    expect(record?.status).toBe('failed');
+    expect(record?.error).toBe('boom');
+  });
+
+  it('clear() releases all records', () => {
+    const store = new SubagentActivityStore();
+    store.ensureRecord(spawn());
+    store.applyEvent(ev({ type: 'turn.step.started', turnId: 1, step: 0 }));
+    store.clear();
+    expect(store.get('agent-1')).toBeUndefined();
+  });
+});

--- a/apps/kimi-code/test/tui/controllers/subagent-activity-store.test.ts
+++ b/apps/kimi-code/test/tui/controllers/subagent-activity-store.test.ts
@@ -219,4 +219,22 @@ describe('SubagentActivityStore', () => {
     store.clear();
     expect(store.get('agent-1')).toBeUndefined();
   });
+
+  it('drop() removes one record along with its streaming buffers', () => {
+    const store = new SubagentActivityStore();
+    store.ensureRecord(spawn());
+    store.ensureRecord(spawn({ agentId: 'agent-2', agentName: 'general' }));
+    store.applyEvent(
+      ev({ type: 'tool.call.delta', turnId: 1, toolCallId: 't1', name: 'Write', argumentsPart: '{"path":"a"}' }),
+    );
+
+    store.drop('agent-1');
+
+    expect(store.get('agent-1')).toBeUndefined();
+    expect(store.get('agent-2')).toBeDefined();
+    const buffers = (
+      store as unknown as { streamingArgs: Map<string, string> }
+    ).streamingArgs;
+    expect([...buffers.keys()].every((key) => !key.startsWith('agent-1:'))).toBe(true);
+  });
 });

--- a/apps/kimi-code/test/tui/controllers/subagent-activity-store.test.ts
+++ b/apps/kimi-code/test/tui/controllers/subagent-activity-store.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'vitest';
 
 import {
   MAX_SUBAGENT_ACTIVITY_STEPS,
+  SUBAGENT_ARG_STRING_MAX_CHARS,
   SUBAGENT_STEP_TEXT_TAIL_CHARS,
   SUBAGENT_TOOL_OUTPUT_MAX_CHARS,
 } from '#/tui/constant/rendering';
@@ -236,5 +237,25 @@ describe('SubagentActivityStore', () => {
       store as unknown as { streamingArgs: Map<string, string> }
     ).streamingArgs;
     expect([...buffers.keys()].every((key) => !key.startsWith('agent-1:'))).toBe(true);
+  });
+
+  it('caps long string argument values retained in a record', () => {
+    const store = new SubagentActivityStore();
+    store.ensureRecord(spawn());
+    store.applyEvent(
+      ev({
+        type: 'tool.call.started',
+        turnId: 1,
+        toolCallId: 't1',
+        name: 'Write',
+        args: { path: 'a.ts', content: 'c'.repeat(SUBAGENT_ARG_STRING_MAX_CHARS + 500) },
+      }),
+    );
+    const call = store.get('agent-1')?.steps[0]?.toolCalls[0];
+    expect(typeof call?.args['content']).toBe('string');
+    expect((call?.args['content'] as string).length).toBeLessThanOrEqual(
+      SUBAGENT_ARG_STRING_MAX_CHARS + 1,
+    );
+    expect(call?.args['path']).toBe('a.ts');
   });
 });

--- a/apps/kimi-code/test/tui/controllers/subagent-activity-store.test.ts
+++ b/apps/kimi-code/test/tui/controllers/subagent-activity-store.test.ts
@@ -276,4 +276,19 @@ describe('SubagentActivityStore', () => {
     }
     expect(buffers.has('agent-1:t-trunc')).toBe(false);
   });
+
+  it('drops leftover arg buffers when the record turns terminal', () => {
+    const store = new SubagentActivityStore();
+    store.ensureRecord(spawn());
+    store.applyEvent(
+      ev({ type: 'tool.call.delta', turnId: 1, toolCallId: 't-trunc', name: 'Write', argumentsPart: '{"path":"a"' }),
+    );
+    const buffers = (
+      store as unknown as { streamingArgs: Map<string, string> }
+    ).streamingArgs;
+    expect(buffers.has('agent-1:t-trunc')).toBe(true);
+
+    store.markCompleted('agent-1', 'done');
+    expect(buffers.has('agent-1:t-trunc')).toBe(false);
+  });
 });

--- a/apps/kimi-code/test/tui/controllers/subagent-activity-store.test.ts
+++ b/apps/kimi-code/test/tui/controllers/subagent-activity-store.test.ts
@@ -258,4 +258,22 @@ describe('SubagentActivityStore', () => {
     );
     expect(call?.args['path']).toBe('a.ts');
   });
+
+  it('drops delta-only arg buffers when their step is evicted', () => {
+    const store = new SubagentActivityStore();
+    store.ensureRecord(spawn());
+    // A call truncated before started/result only ever produced deltas.
+    store.applyEvent(
+      ev({ type: 'tool.call.delta', turnId: 1, toolCallId: 't-trunc', name: 'Write', argumentsPart: '{"path":"a"' }),
+    );
+    const buffers = (
+      store as unknown as { streamingArgs: Map<string, string> }
+    ).streamingArgs;
+    expect(buffers.has('agent-1:t-trunc')).toBe(true);
+
+    for (let i = 0; i < MAX_SUBAGENT_ACTIVITY_STEPS; i++) {
+      store.applyEvent(ev({ type: 'turn.step.started', turnId: 1, step: i }));
+    }
+    expect(buffers.has('agent-1:t-trunc')).toBe(false);
+  });
 });

--- a/apps/kimi-code/test/tui/tasks-browser.test.ts
+++ b/apps/kimi-code/test/tui/tasks-browser.test.ts
@@ -1,5 +1,5 @@
 import type { Terminal } from '@moonshot-ai/pi-tui';
-import type { BackgroundTaskInfo, BackgroundTaskStatus } from '@moonshot-ai/kimi-code-sdk';
+import type { BackgroundTaskInfo, BackgroundTaskStatus, Event } from '@moonshot-ai/kimi-code-sdk';
 import { describe, expect, it, vi } from 'vitest';
 
 import {
@@ -7,6 +7,10 @@ import {
   type TasksBrowserProps,
   type TasksFilter,
 } from '@/tui/components/dialogs/tasks-browser';
+import { AgentActivityViewer } from '@/tui/components/dialogs/agent-activity-viewer';
+import { TaskOutputViewer } from '@/tui/components/dialogs/task-output-viewer';
+import { SubagentActivityStore } from '@/tui/controllers/subagent-activity-store';
+import { TasksBrowserController } from '@/tui/controllers/tasks-browser';
 import { darkColors } from '@/tui/theme/colors';
 
 const ANSI_SGR = /\[[0-9;]*m/g;
@@ -537,5 +541,125 @@ describe('TasksBrowserApp — setProps', () => {
         app.setProps(makeProps({ tasks, filter }));
       }).not.toThrow();
     }
+  });
+});
+
+describe('TasksBrowserController — opening an agent task', () => {
+  function makeControllerHost(tasks: BackgroundTaskInfo[], store: SubagentActivityStore) {
+    const ui = {
+      children: [] as unknown[],
+      clear() {
+        this.children = [];
+      },
+      addChild(child: unknown) {
+        this.children.push(child);
+      },
+      setFocus: () => {},
+      requestRender: () => {},
+    };
+    const state = {
+      tasksBrowser: undefined as unknown,
+      terminal: fakeTerminal(30),
+      ui,
+      editor: {},
+    };
+    const host = {
+      state,
+      backgroundTasks: new Map(tasks.map((t) => [t.taskId, t])),
+      sessionEventHandler: { subAgentEventHandler: { activityStore: store } },
+      session: {
+        listBackgroundTasks: async () => tasks,
+        getBackgroundTaskOutput: async () => 'captured output',
+      },
+      showError: vi.fn(),
+      setTasksBrowser(value: unknown) {
+        state.tasksBrowser = value;
+      },
+    };
+    return { host, state };
+  }
+
+  function agentTaskInfo(store: SubagentActivityStore | null): BackgroundTaskInfo {
+    const info = task({
+      taskId: 'agent-task-1',
+      kind: 'agent',
+      agentId: 'agent-1',
+      status: 'running',
+    } as Partial<BackgroundTaskInfo>);
+    if (store !== null) {
+      store.ensureRecord({ agentId: 'agent-1', agentName: 'explore', parentToolCallId: 'tc-1' });
+    }
+    return info;
+  }
+
+  async function openSelectedViewer(controller: TasksBrowserController, taskId: string) {
+    await (
+      controller as unknown as { handleOpenOutput(taskId: string): Promise<void> }
+    ).handleOpenOutput(taskId);
+  }
+
+  it('opens the activity viewer when a record exists for the agent', async () => {
+    const store = new SubagentActivityStore();
+    const { host, state } = makeControllerHost([agentTaskInfo(store)], store);
+    const controller = new TasksBrowserController(host as never);
+    await controller.show();
+
+    await openSelectedViewer(controller, 'agent-task-1');
+
+    const viewer = (state.tasksBrowser as { viewer: { component: unknown } }).viewer;
+    expect(viewer.component).toBeInstanceOf(AgentActivityViewer);
+    controller.close();
+  });
+
+  it('falls back to the output viewer when no record exists', async () => {
+    const store = new SubagentActivityStore();
+    const { host, state } = makeControllerHost([agentTaskInfo(null)], store);
+    const controller = new TasksBrowserController(host as never);
+    await controller.show();
+
+    await openSelectedViewer(controller, 'agent-task-1');
+
+    const viewer = (state.tasksBrowser as { viewer: { component: unknown } }).viewer;
+    expect(viewer.component).toBeInstanceOf(TaskOutputViewer);
+    controller.close();
+  });
+
+  it('feeds the preview pane from the activity store for agent tasks', async () => {
+    const store = new SubagentActivityStore();
+    store.ensureRecord({ agentId: 'agent-1', agentName: 'explore', parentToolCallId: 'tc-1' });
+    store.applyEvent({
+      sessionId: 's1',
+      agentId: 'agent-1',
+      type: 'turn.step.started',
+      turnId: 1,
+      step: 0,
+    } as Event);
+    store.applyEvent({
+      sessionId: 's1',
+      agentId: 'agent-1',
+      type: 'tool.call.started',
+      turnId: 1,
+      toolCallId: 't1',
+      name: 'Grep',
+      args: { pattern: 'foo' },
+    } as Event);
+    store.applyEvent({
+      sessionId: 's1',
+      agentId: 'agent-1',
+      type: 'tool.result',
+      turnId: 1,
+      toolCallId: 't1',
+      output: 'src/a.ts:1:foo\nsrc/b.ts:2:foo',
+      isError: false,
+    } as Event);
+
+    const { host, state } = makeControllerHost([agentTaskInfo(null)], store);
+    const controller = new TasksBrowserController(host as never);
+    await controller.show();
+
+    const browser = state.tasksBrowser as { tailOutput?: string };
+    expect(browser.tailOutput).toContain('── step 0 ──');
+    expect(browser.tailOutput).toContain('✓ Used Grep (foo) · 2 matches');
+    controller.close();
   });
 });

--- a/packages/acp-server/test/acp-fs.test.ts
+++ b/packages/acp-server/test/acp-fs.test.ts
@@ -51,7 +51,7 @@ describe('AcpHostFileSystem', () => {
 
   afterEach(async () => {
     if (tempDir !== undefined) {
-      await rm(tempDir, { recursive: true, force: true });
+      await rm(tempDir, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
       tempDir = undefined;
     }
   });

--- a/packages/acp-server/test/close.test.ts
+++ b/packages/acp-server/test/close.test.ts
@@ -16,7 +16,7 @@ describe('acp-server session/close', () => {
       client = undefined;
     }
     if (homeDir !== undefined) {
-      await rm(homeDir, { recursive: true, force: true });
+      await rm(homeDir, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
       homeDir = undefined;
     }
   });

--- a/packages/acp-server/test/config.test.ts
+++ b/packages/acp-server/test/config.test.ts
@@ -35,7 +35,7 @@ describe('acp-server config surface', () => {
       client = undefined;
     }
     if (homeDir !== undefined) {
-      await rm(homeDir, { recursive: true, force: true });
+      await rm(homeDir, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
       homeDir = undefined;
     }
   });

--- a/packages/acp-server/test/convert.test.ts
+++ b/packages/acp-server/test/convert.test.ts
@@ -93,7 +93,7 @@ describe('compressPromptImageParts', () => {
   const trash: string[] = [];
 
   afterEach(async () => {
-    await Promise.all(trash.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+    await Promise.all(trash.splice(0).map((dir) => rm(dir, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 })));
   });
 
   async function tempOriginalsDir(): Promise<string> {

--- a/packages/acp-server/test/e2e-turn.test.ts
+++ b/packages/acp-server/test/e2e-turn.test.ts
@@ -39,7 +39,7 @@ describe('acp-server real prompt turn (scripted LLM)', () => {
       client = undefined;
     }
     if (homeDir !== undefined) {
-      await rm(homeDir, { recursive: true, force: true });
+      await rm(homeDir, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
       homeDir = undefined;
     }
   });
@@ -562,7 +562,7 @@ describe('acp-server prompt error hygiene', () => {
       client = undefined;
     }
     if (homeDir !== undefined) {
-      await rm(homeDir, { recursive: true, force: true });
+      await rm(homeDir, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
       homeDir = undefined;
     }
   });
@@ -609,7 +609,7 @@ describe('acp-server builtin slash commands (local execution, no LLM turn)', () 
       client = undefined;
     }
     if (homeDir !== undefined) {
-      await rm(homeDir, { recursive: true, force: true });
+      await rm(homeDir, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
       homeDir = undefined;
     }
   });
@@ -826,7 +826,7 @@ describe('acp-server terminal reverse-RPC (clientCapabilities.terminal)', () => 
       client = undefined;
     }
     if (homeDir !== undefined) {
-      await rm(homeDir, { recursive: true, force: true });
+      await rm(homeDir, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
       homeDir = undefined;
     }
   });

--- a/packages/acp-server/test/initialize.test.ts
+++ b/packages/acp-server/test/initialize.test.ts
@@ -92,7 +92,7 @@ describe('acp-server initialize handshake', () => {
         toAgent.end();
         toClient.end();
       } finally {
-        await rm(homeDir, { recursive: true, force: true });
+        await rm(homeDir, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
       }
     },
     30_000,
@@ -125,7 +125,7 @@ describe('acp-server initialize handshake', () => {
         toAgent.end();
         toClient.end();
       } finally {
-        await rm(homeDir, { recursive: true, force: true });
+        await rm(homeDir, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
       }
     },
     30_000,
@@ -176,7 +176,7 @@ describe('acp-server initialize handshake', () => {
         toAgent.end();
         toClient.end();
       } finally {
-        await rm(homeDir, { recursive: true, force: true });
+        await rm(homeDir, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
       }
     },
     30_000,

--- a/packages/acp-server/test/lifecycle.test.ts
+++ b/packages/acp-server/test/lifecycle.test.ts
@@ -73,7 +73,7 @@ describe('acp-server session lifecycle', () => {
       client = undefined;
     }
     if (homeDir !== undefined) {
-      await rm(homeDir, { recursive: true, force: true });
+      await rm(homeDir, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
       homeDir = undefined;
     }
   });

--- a/packages/acp-server/test/skills.test.ts
+++ b/packages/acp-server/test/skills.test.ts
@@ -84,7 +84,7 @@ describe('acp-server skills / available commands', () => {
       client = undefined;
     }
     if (homeDir !== undefined) {
-      await rm(homeDir, { recursive: true, force: true });
+      await rm(homeDir, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
       homeDir = undefined;
     }
   });


### PR DESCRIPTION
## Related Issue

No linked issue — the problem is explained below.

## Problem

Background agents (subagents started with `run_in_background`, or foreground ones backgrounded with `Ctrl+B`) showed no run details in the TUI: the `/tasks` panel only displayed static metadata (agent id / type / model / effort), and its output view stays `[no output captured]` until the agent finishes, because agent tasks only capture output once at completion.

## What changed

- Tee child-agent events into a bounded in-memory per-agent activity store. These events already reach the TUI (the v2 engine forwards every agent's event stream) but were dropped whenever no foreground tool card existed. The fold is segmented by the engine's own `turn.step.started` events; only the most recent 20 steps are retained, with bounded assistant-text (4k chars) and tool-output (8k chars, marked with a truncation sentinel) tails.
- `/tasks` preview pane: agent tasks now show a live plain-text activity preview (recent steps, tool calls with key argument and result chips, live output tail) instead of `[no output captured]`, refreshed on selection and on the 1s poll.
- `Enter`/`O` on an agent task opens a full-screen activity view: step-grouped assistant text rendered as Markdown and tool results rendered through the same per-tool result renderers / chips as the main transcript (the live `ToolCallComponent` itself is intentionally not reused — it is event-driven, this view renders a snapshot). `Ctrl+O` toggles a global expand of all tool results, scrolling follows the tail, and the 1s refresh reads the local store only (no RPC).
- Agent tasks without an in-memory record (e.g. marked `lost` after a session resume) fall back to the previous captured-output view unchanged.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update. — No doc update: the docs only reference `/tasks` as a one-line entry in the slash-command table ("Browse the background task list", still accurate); no existing page covers the panel's internals, so nothing is stale.


Note: this PR also includes a test-only deflake commit for `acp-server` (temp-dir cleanup now retries on `ENOTEMPTY`). The race exists on `main` and fires intermittently there, but this PR's new test files reshuffled shard timing enough to make it fire consistently on shard 2 — so it is fixed here to unblock CI.
