### PR TITLE
fix(vscode): queue or restore prompts bounced by a busy session

### DIFF
--- a/.changeset/vscode-busy-bounce-queue.md
+++ b/.changeset/vscode-busy-bounce-queue.md
@@ -1,0 +1,5 @@
+---
+"kimi-code": patch
+---
+
+Fix prompts vanishing when sent while the session is busy with a turn the chat lost track of (e.g. a live turn after a window reload). The send used to be rejected with "A message is being sent." and the text was parked invisibly until the other turn ended; a busy bounce now moves the message into the queue so it sends when the running turn finishes, and any other send that fails before its turn starts immediately restores the text into the composer.

--- a/.changeset/vscode-busy-error-message.md
+++ b/.changeset/vscode-busy-error-message.md
@@ -1,0 +1,5 @@
+---
+"kimi-code": patch
+---
+
+Stop reporting a busy chat session as "Internal error occurred." A prompt sent while a response is still being generated now surfaces as "A message is being sent. Please wait." (code `turn.agent_busy`) with the original detail attached, instead of the generic internal-error message that the plain `Error` was mapped to.

--- a/apps/vscode/src/handlers/chat.handler.ts
+++ b/apps/vscode/src/handlers/chat.handler.ts
@@ -71,7 +71,7 @@ function prependSystemContext(content: string | ContentPart[], context: string):
   return copy;
 }
 
-const streamChat: Handler<StreamChatParams, { done: boolean }> = async (params, ctx) => {
+const streamChat: Handler<StreamChatParams, { done: boolean; bounced?: boolean; busyTurn?: boolean }> = async (params, ctx) => {
   if (!ctx.workDir) {
     emitPreflightError(ctx, "NO_WORKSPACE", "Please open a folder to start.");
     void vscode.window.showWarningMessage("Kimi: Please open a folder first.", "Open Folder").then((action) => {
@@ -137,7 +137,15 @@ const streamChat: Handler<StreamChatParams, { done: boolean }> = async (params, 
   const systemContext = await buildSystemContext(runtime.id, ctx);
   try {
     const result = await runtime.prompt(prependSystemContext(params.content, systemContext));
-    return { done: result.status === "finished" };
+    // A busy bounce tells the webview the message never started a turn and is
+    // safe to queue for when the live turn ends. busyTurn distinguishes a
+    // bounce racing a live turn (whose terminal event will flush the queue)
+    // from one during an exclusive operation (no terminal event will come).
+    return {
+      done: result.status === "finished",
+      bounced: result.reason === "busy" ? true : undefined,
+      busyTurn: result.reason === "busy" && result.activeTurn === true ? true : undefined,
+    };
   } catch (error) {
     emitCaughtError(ctx, error, "runtime", runtime.id);
     return { done: false };

--- a/apps/vscode/src/runtime/session-runtime.ts
+++ b/apps/vscode/src/runtime/session-runtime.ts
@@ -1,5 +1,6 @@
 import {
   isKimiError,
+  KimiError,
   type ContentPart as SdkContentPart,
   type Event,
   type PromptInput,
@@ -188,7 +189,7 @@ export class SessionRuntime {
       // such terminal event, so reject terminally: the caller's composer must
       // unlock rather than hang until the handshake timeout.
       this.emitError(
-        new Error(ALREADY_GENERATING_MESSAGE),
+        new KimiError("turn.agent_busy", ALREADY_GENERATING_MESSAGE),
         "runtime",
         { terminal: this.hasActiveWork ? false : undefined },
       );
@@ -225,7 +226,7 @@ export class SessionRuntime {
   beginHostAction(input: string | LegacyContentPart[], forkable = false): number {
     this.ensureOpen();
     if (this.isBusy) {
-      throw new Error(ALREADY_GENERATING_MESSAGE);
+      throw new KimiError("turn.agent_busy", ALREADY_GENERATING_MESSAGE);
     }
     const actionId = ++this.hostActionSequence;
     this.hostActionActive = true;

--- a/apps/vscode/src/runtime/session-runtime.ts
+++ b/apps/vscode/src/runtime/session-runtime.ts
@@ -50,6 +50,17 @@ const ALREADY_GENERATING_MESSAGE = "A response is already being generated for th
 
 export interface PromptResult {
   readonly status: "finished" | "cancelled" | "failed";
+  /**
+   * Present when the call was rejected because the session was already busy —
+   * the message never started a turn and can safely be queued for later.
+   */
+  readonly reason?: "busy";
+  /**
+   * Present when a busy rejection raced a live turn: that turn's terminal
+   * event is guaranteed to arrive later, so the caller can queue the message
+   * instead of restoring it to the composer.
+   */
+  readonly activeTurn?: boolean;
 }
 
 interface SuppressedError {
@@ -193,7 +204,7 @@ export class SessionRuntime {
         "runtime",
         { terminal: this.hasActiveWork ? false : undefined },
       );
-      return { status: "failed" };
+      return { status: "failed", reason: "busy", activeTurn: this.hasActiveWork };
     }
 
     let resolveCompletion!: (result: PromptResult) => void;

--- a/apps/vscode/test/kimi-harness.integration.test.ts
+++ b/apps/vscode/test/kimi-harness.integration.test.ts
@@ -1209,7 +1209,7 @@ describe("VS Code Kimi harness integration (shares one in-process SDK home)", ()
     const first = runtime.prompt("first message");
     await blocked.started;
 
-    await expect(runtime.prompt("concurrent message")).resolves.toEqual({ status: "failed" });
+    await expect(runtime.prompt("concurrent message")).resolves.toEqual({ status: "failed", reason: "busy", activeTurn: true });
 
     // The rejection surfaces as a mid-turn warning; the active turn is untouched.
     expect(runtime.isBusy).toBe(true);

--- a/apps/vscode/test/kimi-runtime.test.ts
+++ b/apps/vscode/test/kimi-runtime.test.ts
@@ -645,7 +645,7 @@ describe("Kimi runtime (owns shared SDK sessions for Webviews)", () => {
     boundary.emit({ type: "turn.started", agentId: "main", sessionId: opened.id, turnId: "t1" } as unknown as Event);
     expect(opened.isBusy).toBe(true);
 
-    await expect(opened.prompt("concurrent message")).resolves.toEqual({ status: "failed" });
+    await expect(opened.prompt("concurrent message")).resolves.toEqual({ status: "failed", reason: "busy", activeTurn: true });
 
     // The rejection surfaces as a mid-turn warning; the active turn is untouched.
     expect(opened.isBusy).toBe(true);
@@ -679,7 +679,7 @@ describe("Kimi runtime (owns shared SDK sessions for Webviews)", () => {
     // terminal so the caller's composer can unlock.
     expect(opened.isBusy).toBe(true);
 
-    await expect(opened.prompt("during fork")).resolves.toEqual({ status: "failed" });
+    await expect(opened.prompt("during fork")).resolves.toEqual({ status: "failed", reason: "busy", activeTurn: false });
     const rejection = broadcasts.find(({ data }) => (data as { type?: string }).type === "error");
     expect(rejection?.data).toMatchObject({ type: "error", phase: "runtime" });
     expect((rejection?.data as Record<string, unknown>)["terminal"]).toBeUndefined();

--- a/apps/vscode/test/kimi-runtime.test.ts
+++ b/apps/vscode/test/kimi-runtime.test.ts
@@ -652,6 +652,8 @@ describe("Kimi runtime (owns shared SDK sessions for Webviews)", () => {
     const busyWarning = broadcasts.find(({ data }) => (data as { type?: string }).type === "error");
     expect(busyWarning?.data).toMatchObject({
       type: "error",
+      code: "turn.agent_busy",
+      message: "A message is being sent. Please wait.",
       phase: "runtime",
       detail: "A response is already being generated for this session.",
       terminal: false,

--- a/apps/vscode/test/settings-store.test.ts
+++ b/apps/vscode/test/settings-store.test.ts
@@ -548,15 +548,15 @@ describe("Webview mid-turn warnings", () => {
 
     useChatStore.getState().processEvent({
       type: "error",
-      code: "internal",
-      message: "Internal error occurred.",
+      code: "turn.agent_busy",
+      message: "A message is being sent. Please wait.",
       detail: "A response is already being generated for this session.",
       phase: "runtime",
       terminal: false,
     });
 
     // The turn is still running: nothing unlocks, nothing flushes, nothing is retried.
-    expect(boundary.toastWarning).toHaveBeenCalledWith("Internal error occurred.");
+    expect(boundary.toastWarning).toHaveBeenCalledWith("A message is being sent. Please wait.");
     const state = useChatStore.getState();
     expect(state.isStreaming).toBe(true);
     expect(state.queue).toHaveLength(1);

--- a/apps/vscode/test/settings-store.test.ts
+++ b/apps/vscode/test/settings-store.test.ts
@@ -67,6 +67,7 @@ beforeEach(() => {
     isStreaming: false,
     isCompacting: false,
     handshakeReceived: false,
+    awaitingTurnBegin: false,
     draftMedia: [],
     lastStatus: null,
     tokenUsage: { input_other: 0, output: 0, input_cache_read: 0, input_cache_creation: 0 },
@@ -541,6 +542,8 @@ describe("Webview thinking effort parity with the TUI", () => {
 
 describe("Webview mid-turn warnings", () => {
   it("shows a non-terminal error as a toast without unlocking the composer", async () => {
+    // A genuinely started turn keeps its bridge call open until the turn ends.
+    boundary.streamChat.mockImplementation(() => new Promise(() => {}));
     useChatStore.getState().sendMessage("first message");
     useChatStore.getState().sendMessage("queued follow-up");
     expect(useChatStore.getState().isStreaming).toBe(true);
@@ -569,5 +572,240 @@ describe("Webview mid-turn warnings", () => {
     await vi.waitFor(() => {
       expect(boundary.streamChat).toHaveBeenCalledTimes(2);
     });
+  });
+});
+
+describe("Webview send bounce handling", () => {
+  it("enqueues the message when the session bounced the send as busy", async () => {
+    boundary.streamChat.mockResolvedValue({ done: false, bounced: true });
+
+    useChatStore.getState().sendMessage("hold this");
+
+    await vi.waitFor(() => {
+      expect(useChatStore.getState().queue).toHaveLength(1);
+    });
+    const state = useChatStore.getState();
+    expect(state.queue[0]?.content).toBe("hold this");
+    // The live (untracked) turn still owns the composer state: stays
+    // streaming so further input enqueues, and nothing is parked in
+    // pendingInput.
+    expect(state.isStreaming).toBe(true);
+    expect(state.pendingInput).toBeNull();
+    expect(state.awaitingTurnBegin).toBe(false);
+  });
+
+  it("rolls the composer back when the send never started a turn", async () => {
+    boundary.streamChat.mockResolvedValue({ done: false });
+
+    useChatStore.getState().sendMessage("give it back");
+
+    await vi.waitFor(() => {
+      expect(useChatStore.getState().isStreaming).toBe(false);
+    });
+    const state = useChatStore.getState();
+    // pendingInput keeps the text so the composer restores it.
+    expect(state.pendingInput).toEqual({ content: "give it back", model: "plain" });
+    expect(state.queue).toHaveLength(0);
+    expect(state.awaitingTurnBegin).toBe(false);
+  });
+
+  it("does not roll back a send whose turn already started", async () => {
+    let resolveSend!: (result: { done: boolean }) => void;
+    boundary.streamChat.mockImplementation(
+      () => new Promise<{ done: boolean }>((resolve) => { resolveSend = resolve; }),
+    );
+
+    useChatStore.getState().sendMessage("in flight");
+    useChatStore.getState().processEvent({
+      type: "TurnBegin",
+      payload: { user_input: "in flight" },
+    });
+    resolveSend({ done: true });
+
+    await vi.waitFor(() => {
+      expect(boundary.streamChat).toHaveBeenCalledTimes(1);
+    });
+    const state = useChatStore.getState();
+    expect(state.isStreaming).toBe(true);
+    expect(state.pendingInput).toEqual({ content: "in flight", model: "plain" });
+    expect(state.queue).toHaveLength(0);
+  });
+});
+
+describe("Webview send bounce ordering", () => {
+  it("resends the prompt when the busy turn completes before the bounce reply arrives", async () => {
+    let resolveFirst!: (result: { done: boolean; bounced: boolean }) => void;
+    boundary.streamChat
+      .mockImplementationOnce(
+        () =>
+          new Promise<{ done: boolean; bounced: boolean }>((resolve) => {
+            resolveFirst = resolve;
+          }),
+      )
+      .mockResolvedValue({ done: true });
+
+    useChatStore.getState().sendMessage("later");
+    // The live turn ends before the bounce reply lands: its terminal event
+    // clears the parked input and the streaming state.
+    useChatStore.getState().processEvent({ type: "stream_complete", result: { status: "finished" } });
+    resolveFirst({ done: false, bounced: true });
+
+    await vi.waitFor(() => {
+      expect(boundary.streamChat).toHaveBeenCalledTimes(2);
+    });
+    const state = useChatStore.getState();
+    expect(state.isStreaming).toBe(true);
+    expect(state.pendingInput).toEqual({ content: "later", model: "plain" });
+    expect(state.queue).toHaveLength(0);
+  });
+
+  it("re-enqueues a busyTurn bounce that lands after the store already unlocked", async () => {
+    vi.useFakeTimers();
+    try {
+      let resolveSend!: (result: { done: boolean; bounced: boolean; busyTurn?: boolean }) => void;
+      boundary.streamChat
+        .mockImplementationOnce(
+          () =>
+            new Promise<{ done: boolean; bounced: boolean; busyTurn?: boolean }>((resolve) => {
+              resolveSend = resolve;
+            }),
+        )
+        // The safety-flush resend stays in flight for the rest of the test.
+        .mockImplementation(() => new Promise(() => {}));
+
+      useChatStore.getState().sendMessage("raced the winning view");
+      // A terminal event for the previous turn already unlocked the composer
+      // while our bounce reply was in flight; the input stays parked.
+      useChatStore.getState().processEvent({
+        type: "error",
+        code: "provider.api_error",
+        message: "Service temporarily unavailable.",
+        phase: "runtime",
+      });
+      expect(useChatStore.getState().isStreaming).toBe(false);
+      expect(useChatStore.getState().pendingInput).not.toBeNull();
+
+      resolveSend({ done: false, bounced: true, busyTurn: true });
+      await vi.advanceTimersByTimeAsync(0);
+
+      // The host reports a live turn: queue for its terminal flush instead of
+      // dropping the prompt back into the composer.
+      expect(useChatStore.getState().queue).toHaveLength(1);
+      expect(useChatStore.getState().queue[0]?.content).toBe("raced the winning view");
+      expect(useChatStore.getState().pendingInput).toBeNull();
+
+      // If that turn's terminal event was the one already processed above, no
+      // flush will come — the safety retry frees the item instead.
+      await vi.advanceTimersByTimeAsync(100);
+      expect(boundary.streamChat).toHaveBeenCalledTimes(2);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});
+
+describe("Webview send reply correlation", () => {
+  it("enqueues a bounced send even when another view's TurnBegin arrived first", async () => {
+    boundary.streamChat.mockResolvedValue({ done: false, bounced: true });
+
+    useChatStore.getState().sendMessage("from the losing view");
+    // The winning view's TurnBegin is broadcast to every subscriber and
+    // clears our awaitingTurnBegin before our bounce reply arrives.
+    useChatStore.getState().processEvent({
+      type: "TurnBegin",
+      payload: { user_input: "the winning view" },
+    });
+
+    await vi.waitFor(() => {
+      expect(useChatStore.getState().queue).toHaveLength(1);
+    });
+    expect(useChatStore.getState().queue[0]?.content).toBe("from the losing view");
+  });
+
+  it("ignores a stale bridge reply once a newer send owns the composer", async () => {
+    let resolveFirst!: (result: { done: boolean }) => void;
+    boundary.streamChat
+      .mockImplementationOnce(
+        () => new Promise<{ done: boolean }>((resolve) => { resolveFirst = resolve; }),
+      )
+      // The second send stays in flight for the whole test.
+      .mockImplementation(() => new Promise(() => {}));
+
+    useChatStore.getState().sendMessage("first");
+    useChatStore.getState().processEvent({
+      type: "TurnBegin",
+      payload: { user_input: "first" },
+    });
+    useChatStore.getState().processEvent({
+      type: "error",
+      code: "provider.api_error",
+      message: "Service temporarily unavailable.",
+      phase: "runtime",
+    });
+    expect(useChatStore.getState().isStreaming).toBe(false);
+
+    useChatStore.getState().sendMessage("second");
+    // The first send's bridge reply only arrives now — it must not touch the
+    // second send's state.
+    resolveFirst({ done: false });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    const state = useChatStore.getState();
+    expect(state.isStreaming).toBe(true);
+    expect(state.pendingInput).toEqual({ content: "second", model: "plain" });
+    expect(state.queue).toHaveLength(0);
+  });
+
+  it("ignores a stale bridge rejection once a newer send owns the composer", async () => {
+    let rejectFirst!: (error: unknown) => void;
+    boundary.streamChat
+      .mockImplementationOnce(
+        () => new Promise<{ done: boolean }>((_, reject) => { rejectFirst = reject; }),
+      )
+      // The second send stays in flight for the whole test.
+      .mockImplementation(() => new Promise(() => {}));
+
+    useChatStore.getState().sendMessage("first");
+    useChatStore.getState().processEvent({
+      type: "error",
+      code: "provider.api_error",
+      message: "Service temporarily unavailable.",
+      phase: "runtime",
+    });
+    expect(useChatStore.getState().isStreaming).toBe(false);
+
+    useChatStore.getState().sendMessage("second");
+    // The first send's bridge call rejects only now (e.g. a request timeout
+    // firing mid-turn): it must not unlock the second send's composer.
+    rejectFirst(new Error("Bridge streamChat timed out"));
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    const state = useChatStore.getState();
+    expect(state.isStreaming).toBe(true);
+    expect(state.pendingInput).toEqual({ content: "second", model: "plain" });
+    expect(state.queue).toHaveLength(0);
+  });
+
+  it("does not resend a stale bounced prompt into a freshly loaded session", async () => {
+    let resolveFirst!: (result: { done: boolean; bounced: boolean }) => void;
+    boundary.streamChat
+      .mockImplementationOnce(
+        () =>
+          new Promise<{ done: boolean; bounced: boolean }>((resolve) => {
+            resolveFirst = resolve;
+          }),
+      )
+      .mockResolvedValue({ done: true });
+
+    useChatStore.getState().sendMessage("old session prompt");
+    // The busy turn ends before the reply: the parked input is cleared, which
+    // would normally arm the resend branch.
+    useChatStore.getState().processEvent({ type: "stream_complete", result: { status: "finished" } });
+    await useChatStore.getState().loadSession("another-session", []);
+
+    resolveFirst({ done: false, bounced: true });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(boundary.streamChat).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/vscode/webview-ui/src/services/bridge.ts
+++ b/apps/vscode/webview-ui/src/services/bridge.ts
@@ -21,7 +21,7 @@ import type {
 interface PendingRequest {
   resolve: (value: unknown) => void;
   reject: (error: Error) => void;
-  timeout: ReturnType<typeof setTimeout>;
+  timeout?: ReturnType<typeof setTimeout>;
 }
 
 const DEFAULT_REQUEST_TIMEOUT_MS = 10 * 60 * 1000;
@@ -85,10 +85,16 @@ class Bridge {
     const id = `${++this.requestId}_${Date.now()}`;
 
     return new Promise((resolve, reject) => {
-      const timeout = setTimeout(() => {
-        this.pending.delete(id);
-        reject(new Error(`Bridge ${method} timed out`));
-      }, timeoutMs);
+      // A zero timeout opts out: the request stays pending until the host
+      // replies (used by streamChat, whose reply only settles when the whole
+      // turn ends — long turns must not trip a generic request timeout).
+      const timeout =
+        timeoutMs > 0
+          ? setTimeout(() => {
+              this.pending.delete(id);
+              reject(new Error(`Bridge ${method} timed out`));
+            }, timeoutMs)
+          : undefined;
 
       this.pending.set(id, { resolve: resolve as (v: unknown) => void, reject, timeout });
       this.vscode.postMessage({ id, method, params, webviewId: this.webviewId });
@@ -184,7 +190,11 @@ class Bridge {
   }
 
   streamChat(content: string | ContentPart[], model: string, effort: string, planMode: boolean, sessionId?: string) {
-    return this.call<{ done: boolean }>(Methods.StreamChat, { content, model, effort, planMode, sessionId });
+    return this.call<{ done: boolean; bounced?: boolean; busyTurn?: boolean }>(
+      Methods.StreamChat,
+      { content, model, effort, planMode, sessionId },
+      0,
+    );
   }
 
   abortChat() {

--- a/apps/vscode/webview-ui/src/stores/chat.store.ts
+++ b/apps/vscode/webview-ui/src/stores/chat.store.ts
@@ -93,6 +93,8 @@ export interface ChatState {
   isStreaming: boolean;
   isCompacting: boolean;
   handshakeReceived: boolean;
+  /** True from send until the sent message's TurnBegin arrives. */
+  awaitingTurnBegin: boolean;
   draftMedia: DraftMediaItem[];
   lastStatus: StatusUpdate | null;
   tokenUsage: TokenUsage;
@@ -125,6 +127,9 @@ export interface ChatState {
 }
 
 let handshakeTimer: ReturnType<typeof setTimeout> | null = null;
+// Monotonic token identifying the latest send; bridge replies from earlier
+// sends must not touch composer state they no longer own.
+let sendGeneration = 0;
 
 function clearHandshakeTimer() {
   if (handshakeTimer) {
@@ -144,6 +149,7 @@ function clearAllInlineErrors(draft: ChatState): void {
 function doSend(state: ChatState, content: string | ContentPart[], model: string) {
   const { sessionId, planMode } = state;
   const { thinkingEffort } = useSettingsStore.getState();
+  const generation = ++sendGeneration;
 
   clearHandshakeTimer();
   handshakeTimer = setTimeout(() => {
@@ -161,7 +167,66 @@ function doSend(state: ChatState, content: string | ContentPart[], model: string
 
   void bridge
     .streamChat(content, model, thinkingEffort, planMode, sessionId ?? undefined)
+    .then((result) => {
+      // Ignore stale replies: a newer send owns the composer state now.
+      if (generation !== sendGeneration) {
+        return;
+      }
+      const s = useChatStore.getState();
+      if (result.bounced === true) {
+        // Our send never started a turn. Note the TurnBegin that may have
+        // cleared awaitingTurnBegin is not necessarily ours: with the same
+        // session open in two views, the winning view's TurnBegin is
+        // broadcast to every subscriber, so key the branches on the parked
+        // input instead. When the host says the bounce raced a live turn
+        // (busyTurn), that turn's terminal event is still coming even if our
+        // store has not seen its TurnBegin yet — queue unconditionally then.
+        if (s.pendingInput !== null) {
+          if (s.isStreaming || result.busyTurn === true) {
+            // The session is busy with a turn this store lost track of (e.g.
+            // a live turn after a reload, or another view's): queue the
+            // message so it sends when that turn's terminal event flushes
+            // the queue, and keep the streaming state so further input
+            // enqueues too.
+            const pending = s.pendingInput;
+            useChatStore.setState({ awaitingTurnBegin: false, pendingInput: null });
+            s.enqueue(pending.content, pending.model);
+            // Safety net: that turn's terminal event may already have been
+            // processed before this reply arrived (its flush saw an empty
+            // queue). This retry no-ops while the session is busy, and frees
+            // the item otherwise instead of stranding it.
+            setTimeout(() => useChatStore.getState().sendNextQueued(), 50);
+          } else {
+            // A terminal error event already handled this send (e.g. a bounce
+            // during an exclusive operation) — keep the state it produced;
+            // the parked pendingInput drives the composer restore.
+            useChatStore.setState({ awaitingTurnBegin: false });
+          }
+        } else {
+          // The busy turn ended before this reply arrived: its stream_complete
+          // already cleared the parked input, so the session is free now —
+          // send again instead of losing the prompt.
+          useChatStore.setState(
+            produce((draft: ChatState) => {
+              draft.isStreaming = true;
+              draft.handshakeReceived = false;
+              draft.awaitingTurnBegin = true;
+              draft.pendingInput = { content, model };
+            }),
+          );
+          doSend(useChatStore.getState(), content, model);
+        }
+      } else if (result.done === false && s.awaitingTurnBegin) {
+        // The send never started a turn: roll the text back into the composer
+        // (via pendingInput) instead of parking it until some later event.
+        useChatStore.setState({ isStreaming: false, awaitingTurnBegin: false });
+      }
+    })
     .catch((error: unknown) => {
+      // Ignore stale rejections: a newer send owns the composer state now.
+      if (generation !== sendGeneration) {
+        return;
+      }
       const detail = error instanceof Error ? error.message : String(error);
       useChatStore.getState().processEvent({
         type: "error",
@@ -179,6 +244,7 @@ export const useChatStore = create<ChatState>((set, get) => ({
   isStreaming: false,
   isCompacting: false,
   handshakeReceived: false,
+  awaitingTurnBegin: false,
   draftMedia: [],
   lastStatus: null,
   tokenUsage: createEmptyTokenUsage(),
@@ -213,6 +279,7 @@ export const useChatStore = create<ChatState>((set, get) => ({
         draft.draftMedia = [];
         draft.isStreaming = true;
         draft.handshakeReceived = false;
+        draft.awaitingTurnBegin = true;
         draft.pendingInput = { content, model: currentModel };
       }),
     );
@@ -234,6 +301,7 @@ export const useChatStore = create<ChatState>((set, get) => ({
         clearAllInlineErrors(draft);
         draft.isStreaming = true;
         draft.handshakeReceived = false;
+        draft.awaitingTurnBegin = true;
         const lastAssistant = draft.messages.at(-1);
         if (lastAssistant?.role === "assistant" && lastAssistant.inlineError) {
           draft.messages.pop();
@@ -258,7 +326,10 @@ export const useChatStore = create<ChatState>((set, get) => ({
       return;
     }
     // Clear handshake timeout on receiving valid response
-    if (event.type === "TurnBegin" || event.type === "StepBegin" || event.type === "ContentPart") {
+    if (event.type === "TurnBegin") {
+      clearHandshakeTimer();
+      set({ handshakeReceived: true, awaitingTurnBegin: false });
+    } else if (event.type === "StepBegin" || event.type === "ContentPart") {
       clearHandshakeTimer();
       set({ handshakeReceived: true });
     } else if (event.type === "stream_complete" || event.type === "error") {
@@ -282,6 +353,10 @@ export const useChatStore = create<ChatState>((set, get) => ({
 
   loadSession: async (sessionId, events) => {
     clearHandshakeTimer();
+    // Invalidate in-flight sends: their replies must not touch the freshly
+    // loaded session's state (a stale bounced reply would resend the old
+    // prompt into it).
+    sendGeneration += 1;
 
     // Abort any ongoing stream when switching sessions
     const { isStreaming: wasStreaming } = get();
@@ -295,6 +370,7 @@ export const useChatStore = create<ChatState>((set, get) => ({
       isStreaming: false,
       isCompacting: false,
       handshakeReceived: false,
+      awaitingTurnBegin: false,
       draftMedia: [],
       lastStatus: null,
       tokenUsage: createEmptyTokenUsage(),
@@ -334,6 +410,8 @@ export const useChatStore = create<ChatState>((set, get) => ({
 
   startNewConversation: async () => {
     clearHandshakeTimer();
+    // Invalidate in-flight sends, same as loadSession.
+    sendGeneration += 1;
 
     // Abort any ongoing stream before starting new conversation
     const { isStreaming: wasStreaming } = get();
@@ -349,6 +427,7 @@ export const useChatStore = create<ChatState>((set, get) => ({
       isStreaming: false,
       isCompacting: false,
       handshakeReceived: false,
+      awaitingTurnBegin: false,
       draftMedia: [],
       lastStatus: null,
       tokenUsage: createEmptyTokenUsage(),
@@ -476,6 +555,7 @@ export const useChatStore = create<ChatState>((set, get) => ({
         draft.queue = rest;
         draft.isStreaming = true;
         draft.handshakeReceived = false;
+        draft.awaitingTurnBegin = true;
         draft.pendingInput = { content: next.content, model: next.model };
         draft.draftMedia = [];
       }),


### PR DESCRIPTION
## Related Issue

Resolve #2817

(Stacked on #2798 — shares the `turn.agent_busy` busy-rejection path.)

## Problem

See linked issue. `loadSession` resets `isStreaming: false` even when the session has a live turn, so after a window reload/reattach the composer takes the send path for a session that is actually busy. The runtime rejects the send (`turn.agent_busy`, non-terminal), and the text is parked in `pendingInput` with no `TurnBegin` — invisible limbo until the other turn's terminal event finally restores it. The bridge result was ignored, so the webview couldn't distinguish "bounced, never started" from "turn ended".

## What changed

- `SessionRuntime`'s busy rejection now returns `PromptResult.reason: "busy"`, and `streamChat` maps it to `{ done, bounced: true }` on the bridge.
- The webview store now handles the bridge result, keyed on the parked input rather than on `awaitingTurnBegin` (a TurnBegin broadcast from another view sharing the session may clear that flag first), and stale replies are discarded with a per-send generation token:
  - **bounced while a live turn owns the session** → the message moves into the send queue and streaming state is kept, so it sends when the running turn's terminal event flushes the queue, and further input enqueues as usual;
  - **bounced but the live turn's `stream_complete` landed first** (the reply arrived after the terminal event cleared the parked input) → the session is free, so the prompt is simply sent again;
  - **any other send that fails before its TurnBegin** → the text rolls back into the composer immediately instead of parking;
  - **bounce during an exclusive operation** (terminal rejection surfaced via an inline error) → left to the existing error path;
  - **a late reply from a superseded send** → ignored entirely.
- Tests: bounce → enqueued (including when another view's TurnBegin arrived first); bounce after the turn's terminal event → resent; stale reply after a newer send → ignored; non-busy failure → composer restored; started turn → untouched by the late bridge resolution.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my fix works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset. (changeset included: `kimi-code` patch)
- [x] Ran `gen-docs` skill, or this PR needs no doc update.

## Update (2026-08-19): bounce-race hardening

Second round after dogfooding surfaced "enqueue works only sometimes":

- **Bounce replies now carry `busyTurn`** (`PromptResult.activeTurn` → bridge): the host distinguishes a bounce racing a live turn (whose terminal event is guaranteed to come) from one during an exclusive operation (none will). The webview re-enqueues on `busyTurn` even if its own store already unlocked — previously that ordering dropped the popped queue item back into the composer, neither queued nor sent.
- **Safety flush**: after a bounce-enqueue, a no-op-when-busy retry (50 ms) frees the item if the live turn's terminal event was already processed before the reply arrived (its own flush saw an empty queue).
- **`streamChat` no longer uses the generic 10-minute bridge timeout** — its reply only settles when the whole turn ends, so any turn longer than 10 minutes rejected webview-side and falsely unlocked the composer mid-turn. The timeout now opts out (`0`); other bridge calls keep the default.
- **Stale rejections guarded**: the `streamChat` `.catch` now checks the per-send generation token like the `.then` does (a late timeout rejection of a superseded send no longer injects a preflight error into the current send's state).
- **Session switch/new conversation invalidates in-flight sends** (`sendGeneration` bump): a stale bounced reply can no longer resend the old prompt into a freshly loaded session.
- New tests: busyTurn bounce after unlock → re-enqueued + safety flush resends when no terminal follows; stale rejection ignored; stale bounce after `loadSession` → no resend. Host-side `PromptResult` assertions updated for `activeTurn`.
