### PR TITLE
fix(agent-core-v2): rebuild hook index on config change so late [[hooks]] fire

### DIFF
--- a/.changeset/hooks-reload-on-config-change.md
+++ b/.changeset/hooks-reload-on-config-change.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Rebuild the external-hook index when the config changes so `[[hooks]]` that arrive after engine construction (e.g. the interactive TUI loading config.toml) fire instead of silently never running.

--- a/packages/agent-core-v2/src/app/externalHooksRunner/externalHooksRunnerService.ts
+++ b/packages/agent-core-v2/src/app/externalHooksRunner/externalHooksRunnerService.ts
@@ -56,6 +56,20 @@ export class ExternalHooksRunnerService extends Disposable implements IExternalH
         void this.reloadSafe();
       }),
     );
+    // Rebuild the hook index when the config changes, not just on plugin
+    // reload. The user config file (`config.toml`) can be (re)loaded into the
+    // layered config service after this runner's initial `loadSafe()` — in the
+    // interactive TUI in particular, `[[hooks]]` may arrive late. Without this
+    // subscription the index would stay empty forever and every hook would
+    // silently never fire (#2779). The member check keeps the subscription a
+    // no-op against partial `IConfigService` stubs in unit tests.
+    if (this.config.onDidChangeConfiguration !== undefined) {
+      this._register(
+        this.config.onDidChangeConfiguration(() => {
+          void this.reloadSafe();
+        }),
+      );
+    }
   }
 
   get summary(): Record<string, number> {

--- a/packages/agent-core-v2/src/app/externalHooksRunner/externalHooksRunnerService.ts
+++ b/packages/agent-core-v2/src/app/externalHooksRunner/externalHooksRunnerService.ts
@@ -3,7 +3,10 @@
  *
  * Owns the configured-hook lifecycle: builds the event→hooks index from
  * `IConfigService` (`[[hooks]]`) + `IPluginService.enabledHooks()`, reloads it
- * on `plugin.onDidReload`, and dispatches each trigger through the pure
+ * on plugin reload and on config change (the interactive TUI can (re)load
+ * `config.toml` into the layered config after app-scope construction, so the
+ * index must be rebuilt or late `[[hooks]]` would silently never fire, #2779),
+ * and dispatches each trigger through the pure
  * `runMatchedHooks`. The App-scope `IHostProcessService` is injected here and
  * threaded down to `runHook`, so hook commands spawn through the shared host
  * process service (cross-platform kill, hidden console on Windows) rather than
@@ -38,6 +41,9 @@ export class ExternalHooksRunnerService extends Disposable implements IExternalH
 
   private byEvent = new Map<string, HookDef[]>();
   readonly ready: Promise<void>;
+  // Serializes index rebuilds so a trigger that lands right after a config
+  // change awaits the newest index instead of reading the stale one.
+  private reloadChain: Promise<void>;
 
   private readonly _onDidReload = this._register(new Emitter<void>());
   readonly onDidReload: Event<void> = this._onDidReload.event;
@@ -51,22 +57,21 @@ export class ExternalHooksRunnerService extends Disposable implements IExternalH
   ) {
     super();
     this.ready = this.loadSafe();
+    this.reloadChain = Promise.resolve();
     this._register(
       this.plugins.onDidReload(() => {
-        void this.reloadSafe();
+        this.queueReload();
       }),
     );
     // Rebuild the hook index when the config changes, not just on plugin
-    // reload. The user config file (`config.toml`) can be (re)loaded into the
-    // layered config service after this runner's initial `loadSafe()` — in the
-    // interactive TUI in particular, `[[hooks]]` may arrive late. Without this
-    // subscription the index would stay empty forever and every hook would
-    // silently never fire (#2779). The member check keeps the subscription a
-    // no-op against partial `IConfigService` stubs in unit tests.
+    // reload: the user config file (`config.toml`) can be (re)loaded into the
+    // layered config service after this runner's initial `loadSafe()`, and in
+    // the interactive TUI `[[hooks]]` may arrive late. The member check keeps
+    // the subscription a no-op against partial `IConfigService` stubs.
     if (this.config.onDidChangeConfiguration !== undefined) {
       this._register(
         this.config.onDidChangeConfiguration(() => {
-          void this.reloadSafe();
+          this.queueReload();
         }),
       );
     }
@@ -115,6 +120,7 @@ export class ExternalHooksRunnerService extends Disposable implements IExternalH
     args: ExternalHooksRunnerTriggerArgs,
   ): Promise<HookResult[]> {
     await this.ready;
+    await this.reloadChain;
     return runMatchedHooks(
       this.hostProcess,
       this.byEvent,
@@ -137,10 +143,8 @@ export class ExternalHooksRunnerService extends Disposable implements IExternalH
     } catch {}
   }
 
-  private async reloadSafe(): Promise<void> {
-    try {
-      await this.load();
-    } catch {}
+  private queueReload(): void {
+    this.reloadChain = this.reloadChain.then(() => this.loadSafe());
   }
 
   private async load(): Promise<void> {

--- a/packages/agent-core-v2/test/agent/externalHooks/runner-stub.ts
+++ b/packages/agent-core-v2/test/agent/externalHooks/runner-stub.ts
@@ -31,6 +31,8 @@ export function makeHookRunner(
       reason: string | undefined,
       durationMs: number,
     ) => void;
+    /** Emit when the backing config gains/loses hook sections (mirrors `IConfigService.onDidChangeConfiguration`). */
+    onDidChangeConfiguration?: Event<void>;
   } = {},
 ): ExternalHooksRunnerService {
   return new ExternalHooksRunnerService(
@@ -38,6 +40,7 @@ export function makeHookRunner(
       _serviceBrand: undefined,
       ready: Promise.resolve(),
       get: (section: string) => (section === HOOKS_SECTION ? hooks : undefined),
+      onDidChangeConfiguration: options.onDidChangeConfiguration ?? Event.None,
     } as unknown as IConfigService,
     {
       _serviceBrand: undefined,

--- a/packages/agent-core-v2/test/app/externalHooksRunner/externalHooksRunner.test.ts
+++ b/packages/agent-core-v2/test/app/externalHooksRunner/externalHooksRunner.test.ts
@@ -1,6 +1,8 @@
 import { realpathSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 
+import { Emitter } from '#/_base/event';
+import type { HookDef } from '#/agent/externalHooks/types';
 import type { ContentPart } from '#/kosong/contract/message';
 import { describe, expect, it, vi } from 'vitest';
 
@@ -340,5 +342,27 @@ describe('ExternalHooksRunnerService', () => {
     expect(runner.hasHooksFor('PreToolUse')).toBe(true);
     expect(runner.hasHooksFor('SessionHeartbeat')).toBe(true);
     expect(runner.hasHooksFor('Stop')).toBe(false);
+  });
+
+  it('rebuilds the hook index when hooks arrive through a config change', async () => {
+    const hooks: HookDef[] = [];
+    const emitter = new Emitter<void>();
+    const runner = makeHookRunner(hooks, { onDidChangeConfiguration: emitter.event });
+
+    await runner.ready;
+    expect(runner.hasHooksFor('SessionStart')).toBe(false);
+
+    // The config gains a [[hooks]] section after the runner was constructed
+    // (the interactive TUI can load config.toml after app-scope construction).
+    // The runner must re-read the config instead of keeping the empty index
+    // forever, or the hook would silently never fire.
+    hooks.push({ event: 'SessionStart', command: nodeCommand('process.exit(0);'), timeout: 5 });
+    emitter.fire();
+
+    await vi.waitFor(() => {
+      expect(runner.hasHooksFor('SessionStart')).toBe(true);
+    });
+    const results = await runner.trigger('SessionStart');
+    expect(results).toHaveLength(1);
   });
 });


### PR DESCRIPTION
## Problem

Fixes #2779. On 0.34.0 the interactive TUI can silently run zero configured `[[hooks]]` (SessionStart / UserPromptSubmit / SessionHeartbeat), while `kimi -p` on the same `config.toml` fires them. The engine gives no warning — the hooks "just never run" — matching the reporter's macOS repro.

## Root cause

`ExternalHooksRunnerService` (App scope) builds its event→hooks index exactly once, in `loadSafe()` at construction, and only ever rebuilds it on `plugin.onDidReload`. The user config file (`config.toml`) is (re)loaded into the layered `IConfigService` asynchronously — in the interactive TUI the `[[hooks]]` section can arrive after this runner's one-shot index is built. Because `loadSafe()`/`trigger()` swallow errors and `hasHooksFor()` falls back to an empty index, every trigger silently returns `[]` and no hook ever fires, with no diagnostic.

This is distinct from #2766 / PR #2772, which address the separate hook-spawn-failure path (logging). This PR targets the hooks-not-firing-at-all load path.

## Fix

Subscribe `ExternalHooksRunnerService` to `IConfigService.onDidChangeConfiguration` and re-run `load()` — the same rebuild the plugin-reload path already uses — so a hooks section that is present in, or (re)loaded into, the config is picked up instead of being permanently missed. A member check keeps the subscription a no-op against partial `IConfigService` stubs in unit tests.

## Test

New regression test in `packages/agent-core-v2/test/app/externalHooksRunner/externalHooksRunner.test.ts`: builds a runner whose config initially has no hooks, then delivers a `SessionStart` hook through a config-change event and asserts `hasHooksFor('SessionStart')` becomes true and the hook fires. It fails on the pre-fix code (index never rebuilt) and passes after.

Fixes #2779