### PR TITLE
chore(changesets): simplify pending CLI changelog entries

### DIFF
--- a/.changeset/calm-mcp-auth-probe.md
+++ b/.changeset/calm-mcp-auth-probe.md
@@ -3,4 +3,4 @@
 "@moonshot-ai/kimi-code-sdk": patch
 ---
 
-Detect MCP servers that require OAuth by reusing the existing connection-time authorization check.
+Detect MCP servers that require OAuth without needing `auth: "oauth"` in the config.

--- a/.changeset/compaction-token-full-request-basis.md
+++ b/.changeset/compaction-token-full-request-basis.md
@@ -2,4 +2,4 @@
 "@moonshot-ai/kimi-code": patch
 ---
 
-Fix the token counts reported after compaction reading far below the real context size: the before/after stats and the context gauge now include the system prompt and tool definitions, matching the numbers shown while the session runs.
+Fix the token counts reported after compaction reading far below the real context size; they now match the numbers shown while the session runs.

--- a/.changeset/fix-tui-startup-freeze.md
+++ b/.changeset/fix-tui-startup-freeze.md
@@ -2,4 +2,4 @@
 "@moonshot-ai/kimi-code": patch
 ---
 
-Fix multi-second typing and rendering freezes at startup or while idle when a large search index loads, replays, or rebuilds.
+Fix multi-second freezes at startup or while idle when a large search index loads, replays, or rebuilds.

--- a/.changeset/isolate-session-profile-catalogs.md
+++ b/.changeset/isolate-session-profile-catalogs.md
@@ -2,4 +2,4 @@
 "@moonshot-ai/kimi-code": patch
 ---
 
-Prevent one session's subagent tool projection from changing builtin profiles in later sessions.
+Fix subagent tool changes in one session leaking into builtin profiles in later sessions.

--- a/.changeset/windows-bare-command-binary-planting.md
+++ b/.changeset/windows-bare-command-binary-planting.md
@@ -2,4 +2,4 @@
 "@moonshot-ai/kimi-code": patch
 ---
 
-Fix a Windows binary-planting risk: child processes spawned by bare command name before the workspace trust prompt (stty, fd detection, package-manager update installs) could resolve to a malicious executable placed in the current directory. These commands are now skipped on Windows, deferred until after the trust prompt, or resolved to an absolute PATH location with hits inside the current directory refused.
+Fix a Windows security risk where commands launched before the workspace trust prompt could run a malicious executable placed in the current folder.


### PR DESCRIPTION
## Related Issue

N/A — changelog wording maintenance before the pending release.

## Problem

Several pending changesets for the next release (0.34.1) are long or describe internal mechanics instead of the user-visible effect. The open release PR (#2710) pre-generates `apps/kimi-code/CHANGELOG.md` from these changesets, and the docs-site changelog later inherits the same wording, so the text should be concise and user-facing before the release ships.

## What changed

Reworded five pending changesets to one short, user-facing sentence each; facts and bump levels are unchanged:

- `calm-mcp-auth-probe`: drop the internal "reusing the connection-time check" phrasing; state the effect (OAuth servers detected without `auth: "oauth"` in the config)
- `compaction-token-full-request-basis`: drop the stat-composition detail; keep that counts now match the numbers shown during the session
- `fix-tui-startup-freeze`: trim redundant wording
- `isolate-session-profile-catalogs`: replace internal jargon ("subagent tool projection") with the user-visible leak
- `windows-bare-command-binary-planting`: collapse the two-sentence mechanism description into one sentence about the risk

The remaining pending CLI changesets (`fix-multi-select-other-deselect`, `fix-windows-missing-git-bash`, `steer-goal-turn-boundary`) are already single short sentences and were left untouched, as was the SDK-only `quiet-mcp-auth-status`. Once this merges, the changesets action regenerates release PR #2710 with the new wording.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [ ] I have added tests that prove my feature works. (N/A — changelog text only)
- [x] Ran `gen-changesets` skill, or this PR needs no changeset. (No changeset — this PR only edits pending changeset wording)
- [x] Ran `gen-docs` skill, or this PR needs no doc update. (No doc update — the docs changelog syncs post-release from the regenerated changelog)