### PR TITLE
fix(acp): keep mode state synchronized

### DIFF
--- a/.changeset/fix-acp-mode-state.md
+++ b/.changeset/fix-acp-mode-state.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Report the active permission or plan mode to ACP clients when creating or restoring a session.

--- a/.changeset/fix-acp-mode-state.md
+++ b/.changeset/fix-acp-mode-state.md
@@ -2,4 +2,4 @@
 "@moonshot-ai/kimi-code": patch
 ---
 
-Report the active permission or plan mode to ACP clients when creating or restoring a session.
+Keep ACP clients synchronized with the active permission or plan mode throughout a session.

--- a/packages/acp-server/src/modes.ts
+++ b/packages/acp-server/src/modes.ts
@@ -3,8 +3,8 @@
  *
  * The 4 modes (`default`, `plan`, `auto`, `yolo`) are the locked decision.
  * Every `session/new` and `session/load` response advertises {@link ACP_MODES}
- * as the mode picker plus {@link DEFAULT_MODE_ID} as `currentModeId`, so ACP
- * clients render the dropdown from a single canonical source.
+ * as the mode picker plus the mode derived from the engine's current plan and
+ * permission state, so ACP clients render an accurate dropdown.
  *
  * `session/set_mode` and the `mode` arm of `session/set_config_option` consume
  * the same source of truth: {@link isAcpModeId} narrows the wire string, and
@@ -42,7 +42,7 @@ export const ACP_MODES = [
   },
 ] as const satisfies readonly SessionMode[];
 
-/** Initial `currentModeId` for every freshly created ACP session. */
+/** Fallback mode until the engine state has been read. */
 export const DEFAULT_MODE_ID = 'default' as const;
 
 /** The four wire-level mode ids understood by this host. */
@@ -82,6 +82,26 @@ export function acpModeToToggles(id: AcpModeId): AcpModeToggles {
     default: {
       const _exhaustive: never = id;
       throw new Error(`Unhandled AcpModeId: ${String(_exhaustive)}`);
+    }
+  }
+}
+
+/** Project the engine's plan and permission state into the ACP mode taxonomy. */
+export function acpModeFromEngineState(
+  permission: PermissionMode,
+  planActive: boolean,
+): AcpModeId {
+  if (planActive) return 'plan';
+  switch (permission) {
+    case 'manual':
+      return 'default';
+    case 'auto':
+      return 'auto';
+    case 'yolo':
+      return 'yolo';
+    default: {
+      const _exhaustive: never = permission;
+      throw new Error(`Unhandled PermissionMode: ${String(_exhaustive)}`);
     }
   }
 }

--- a/packages/acp-server/src/session.ts
+++ b/packages/acp-server/src/session.ts
@@ -192,6 +192,16 @@ export class AcpSession {
   private currentThinkingLevel: string = 'off';
   /** Current ACP mode. */
   private currentModeId: AcpModeId = DEFAULT_MODE_ID;
+  /** Last mode included in a lifecycle response or pushed to the ACP client. */
+  private reportedModeId: AcpModeId = DEFAULT_MODE_ID;
+  /** Coalesces permission/plan invalidations into one authoritative refresh loop. */
+  private modeRefreshDirty = false;
+  private modeRefreshRevision = 0;
+  private modeRefreshRunner: Promise<void> | undefined;
+  private modeStateInitialized = false;
+  /** Suppresses intermediate updates while `setMode` changes two engine toggles. */
+  private modeMutationDepth = 0;
+  private disposed = false;
   /**
    * Cached session skill summaries — the backing data for slash-intent
    * detection and `availableCommands()`. Seeded in `init()` and refreshed on
@@ -316,6 +326,14 @@ export class AcpSession {
           this.onTurnEnded(event);
         });
       }),
+      events.on('permission.mode.changed', () => {
+        void this.requestModeRefresh();
+      }),
+      events.on('agent.status.updated', (event) => {
+        if (typeof event.planMode === 'boolean') {
+          void this.requestModeRefresh();
+        }
+      }),
       // Compaction runs as a background LLM task outside any turn, so these
       // are not turn-scoped; the subscription is already agent-grained (this
       // session's main agent), which keeps other sessions' events out.
@@ -364,21 +382,86 @@ export class AcpSession {
         error: error instanceof Error ? error.message : String(error),
       });
     }
+    // Awaited: the post-`session/new` `available_commands_update` must already
+    // carry the skills (see `activateSession`).
+    await this.refreshSkills();
+    await this.requestModeRefresh();
+    this.reportedModeId = this.currentModeId;
+    this.modeStateInitialized = true;
+  }
+
+  /** Mark the engine mode snapshot stale and join the current refresh, if any. */
+  private requestModeRefresh(): Promise<void> {
+    if (this.disposed) return Promise.resolve();
+    this.modeRefreshDirty = true;
+    this.modeRefreshRevision += 1;
+    if (this.modeRefreshRunner !== undefined) return this.modeRefreshRunner;
+    const runner = this.runModeRefreshLoop();
+    this.modeRefreshRunner = runner;
+    return runner;
+  }
+
+  /** Re-read until no permission/plan invalidation arrived during the last read. */
+  private async runModeRefreshLoop(): Promise<void> {
     try {
-      const [permission, plan] = await Promise.all([
+      while (this.modeRefreshDirty && !this.disposed) {
+        this.modeRefreshDirty = false;
+        await this.refreshModeState(this.modeRefreshRevision);
+      }
+    } finally {
+      this.modeRefreshRunner = undefined;
+    }
+  }
+
+  /** Reconcile the cached ACP projection from one permission/plan snapshot. */
+  private async refreshModeState(revision: number): Promise<void> {
+    let permission: Awaited<ReturnType<AgentHandle['getPermission']>>;
+    let plan: Awaited<ReturnType<AgentHandle['getPlan']>>;
+    try {
+      [permission, plan] = await Promise.all([
         this.agent.getPermission(),
         this.agent.getPlan(),
       ]);
-      this.currentModeId = acpModeFromEngineState(permission, plan !== null);
     } catch (error) {
-      log.warn('acp: could not seed permission/plan state', {
+      log.warn('acp: could not refresh permission/plan state', {
+        sessionId: this.sessionId,
+        error: error instanceof Error ? error.message : String(error),
+      });
+      return;
+    }
+    // A later invalidation owns the authoritative snapshot. Skip this result
+    // entirely so a trailing refresh cannot be preceded by a stale update.
+    if (
+      this.disposed ||
+      revision !== this.modeRefreshRevision ||
+      this.modeMutationDepth > 0
+    ) {
+      return;
+    }
+
+    const nextModeId = acpModeFromEngineState(permission, plan !== null);
+    this.currentModeId = nextModeId;
+    if (!this.modeStateInitialized || nextModeId === this.reportedModeId) {
+      return;
+    }
+
+    this.reportedModeId = nextModeId;
+    await this.emitModeStateUpdate(nextModeId);
+  }
+
+  /** Push both ACP representations from the same reconciled mode snapshot. */
+  private async emitModeStateUpdate(modeId: AcpModeId): Promise<void> {
+    if (this.disposed) return;
+    try {
+      await this.conn.sessionUpdate(currentModeUpdateNotification(this.sessionId, modeId));
+    } catch (error) {
+      log.warn('acp: failed to push current_mode_update', {
         sessionId: this.sessionId,
         error: error instanceof Error ? error.message : String(error),
       });
     }
-    // Awaited: the post-`session/new` `available_commands_update` must already
-    // carry the skills (see `activateSession`).
-    await this.refreshSkills();
+    if (this.disposed) return;
+    await this.emitConfigOptionUpdate(modeId);
   }
 
   /** Refresh the skill cache from the session catalog (best-effort). */
@@ -399,6 +482,9 @@ export class AcpSession {
    * and detaches the event subscriptions. Idempotent.
    */
   dispose(): void {
+    if (this.disposed) return;
+    this.disposed = true;
+    this.modeRefreshDirty = false;
     this.cancel();
     const driver = this.driver;
     if (driver !== undefined) {
@@ -1033,13 +1119,15 @@ export class AcpSession {
    * thinking-capable (see `buildSessionConfigOptions`).
    */
   async configOptions(): Promise<SessionConfigOption[]> {
+    return this.configOptionsForMode(this.currentModeId);
+  }
+
+  /** Build config options with a captured mode so paired updates cannot diverge. */
+  private async configOptionsForMode(modeId: AcpModeId): Promise<SessionConfigOption[]> {
+    const modelId = this.currentModelId;
+    const thinkingLevel = this.currentThinkingLevel;
     const models = projectModelCatalog(await this.klient.global.kosong.listModels());
-    return buildSessionConfigOptions(
-      models,
-      this.currentModelId,
-      this.currentThinkingLevel,
-      this.currentModeId,
-    );
+    return buildSessionConfigOptions(models, modelId, thinkingLevel, modeId);
   }
 
   /**
@@ -1120,30 +1208,32 @@ export class AcpSession {
   /** Switch the ACP mode (plan mode + permission mode). */
   async setMode(id: AcpModeId): Promise<void> {
     const { plan, permission } = acpModeToToggles(id);
-    if (plan) {
-      await this.agent.enterPlan();
-    } else {
-      // KLIENT-GAP(plan): `exitPlan` (`planService.exit()`) is not on the
-      // klient surface; `cancelPlan` (`planModeCancel`) has the identical
-      // state effect (see `agent/plan/planOps.ts`) — only the persisted op
-      // name differs.
-      await this.agent.cancelPlan();
+    this.modeMutationDepth += 1;
+    try {
+      if (plan) {
+        await this.agent.enterPlan();
+      } else {
+        // KLIENT-GAP(plan): `exitPlan` (`planService.exit()`) is not on the
+        // klient surface; `cancelPlan` (`planModeCancel`) has the identical
+        // state effect (see `agent/plan/planOps.ts`) — only the persisted op
+        // name differs.
+        await this.agent.cancelPlan();
+      }
+      await this.agent.setPermission(permission);
+    } finally {
+      this.modeMutationDepth -= 1;
+      await this.requestModeRefresh();
     }
-    await this.agent.setPermission(permission);
-    this.currentModeId = id;
-    // Both notifications fire: `current_mode_update` serves clients reading
-    // the first-class `modes` state, `config_option_update` serves clients
-    // reading the `mode` config-option arm. (Engine-side mode changes are not
-    // observable — klient exposes no permission/plan change event.)
-    this.emit(currentModeUpdateNotification(this.sessionId, id));
-    await this.emitConfigOptionUpdate();
   }
 
   /** Push a fresh `config_option_update` to the client. */
-  private async emitConfigOptionUpdate(): Promise<void> {
+  private async emitConfigOptionUpdate(modeId = this.currentModeId): Promise<void> {
     try {
       await this.conn.sessionUpdate(
-        configOptionUpdateNotification(this.sessionId, await this.configOptions()),
+        configOptionUpdateNotification(
+          this.sessionId,
+          await this.configOptionsForMode(modeId),
+        ),
       );
     } catch (error) {
       log.warn('acp: failed to push config_option_update', {

--- a/packages/acp-server/src/session.ts
+++ b/packages/acp-server/src/session.ts
@@ -84,7 +84,13 @@ import {
 import { AcpInteractionBridge } from './interaction-bridge';
 import { log } from './log';
 import { projectModelCatalog } from './model-catalog';
-import { ACP_MODES, type AcpModeId, acpModeToToggles, DEFAULT_MODE_ID } from './modes';
+import {
+  ACP_MODES,
+  type AcpModeId,
+  acpModeFromEngineState,
+  acpModeToToggles,
+  DEFAULT_MODE_ID,
+} from './modes';
 import { projectHistoryToSessionUpdates } from './replay';
 import { buildAcpSkillSlashCommands, detectSlashIntent } from './slash';
 
@@ -354,6 +360,18 @@ export class AcpSession {
     } catch (error) {
       // Keep the unbound defaults — configOptions stays honest.
       log.warn('acp: could not seed model/thinking state', {
+        sessionId: this.sessionId,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+    try {
+      const [permission, plan] = await Promise.all([
+        this.agent.getPermission(),
+        this.agent.getPlan(),
+      ]);
+      this.currentModeId = acpModeFromEngineState(permission, plan !== null);
+    } catch (error) {
+      log.warn('acp: could not seed permission/plan state', {
         sessionId: this.sessionId,
         error: error instanceof Error ? error.message : String(error),
       });

--- a/packages/acp-server/test/config.test.ts
+++ b/packages/acp-server/test/config.test.ts
@@ -2,7 +2,7 @@ import { mkdtemp, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { AcpSession } from '../src/session';
 import { createTestClient, type TestClient } from './_helpers/acpClient';
@@ -28,6 +28,12 @@ interface NewSessionResult extends SessionConfigSnapshot {
   readonly sessionId: string;
 }
 
+interface ModeProjectionUpdate {
+  readonly sessionUpdate?: string;
+  readonly currentModeId?: string;
+  readonly configOptions?: readonly ConfigOption[];
+}
+
 describe('acp-server config surface', () => {
   let homeDir: string | undefined;
   let client: TestClient | undefined;
@@ -51,9 +57,12 @@ describe('acp-server config surface', () => {
     altThinking?: boolean;
     altSupportEfforts?: readonly string[];
     altDefaultEffort?: string;
+    configToml?: string;
   }): Promise<TestClient> {
     homeDir = await mkdtemp(join(tmpdir(), 'acp-config-'));
-    if (opts?.fakeModel === true) {
+    if (opts?.configToml !== undefined) {
+      await writeFile(join(homeDir, 'config.toml'), opts.configToml, 'utf8');
+    } else if (opts?.fakeModel === true) {
       await writeFakeModelConfig(homeDir, {
         thinking: opts?.thinking === true,
         supportEfforts: opts?.supportEfforts,
@@ -73,6 +82,24 @@ describe('acp-server config surface', () => {
       cwd: homeDir,
       mcpServers: [],
     })) as NewSessionResult;
+  }
+
+  function modeProjectionUpdates(
+    messages: ReturnType<TestClient['sessionUpdates']>,
+  ): { current: string[]; config: string[] } {
+    const current: string[] = [];
+    const config: string[] = [];
+    for (const message of messages) {
+      const update = (message.params as { update?: ModeProjectionUpdate } | undefined)?.update;
+      if (update?.sessionUpdate === 'current_mode_update' && update.currentModeId !== undefined) {
+        current.push(update.currentModeId);
+      }
+      if (update?.sessionUpdate === 'config_option_update') {
+        const mode = update.configOptions?.find((option) => option.id === 'mode')?.currentValue;
+        if (mode !== undefined) config.push(mode);
+      }
+    }
+    return { current, config };
   }
 
   it(
@@ -109,18 +136,11 @@ describe('acp-server config surface', () => {
   it.each(['auto', 'yolo'] as const)(
     'session/new reports the engine %s permission mode',
     async (permission) => {
-      homeDir = await mkdtemp(join(tmpdir(), 'acp-config-'));
-      await writeFile(
-        join(homeDir, 'config.toml'),
-        `default_permission_mode = "${permission}"\n`,
-        'utf8',
-      );
-      client = await createTestClient({ homeDir });
-      await client.send('initialize', { protocolVersion: 1, clientCapabilities: {} });
+      await boot({ configToml: `default_permission_mode = "${permission}"\n` });
 
       const { sessionId, configOptions, modes } = await newSession();
       await expect(
-        client.server.klient.session(sessionId).agent('main').getPermission(),
+        client!.server.klient.session(sessionId).agent('main').getPermission(),
       ).resolves.toBe(permission);
       expect(modes?.currentModeId).toBe(permission);
       expect(configOptions.find((option) => option.id === 'mode')?.currentValue).toBe(permission);
@@ -152,18 +172,90 @@ describe('acp-server config surface', () => {
   it(
     'session/new reports plan mode ahead of the permission mode',
     async () => {
-      homeDir = await mkdtemp(join(tmpdir(), 'acp-config-'));
-      await writeFile(
-        join(homeDir, 'config.toml'),
-        'default_plan_mode = true\ndefault_permission_mode = "yolo"\n',
-        'utf8',
-      );
-      client = await createTestClient({ homeDir });
-      await client.send('initialize', { protocolVersion: 1, clientCapabilities: {} });
+      await boot({
+        configToml: 'default_plan_mode = true\ndefault_permission_mode = "yolo"\n',
+      });
 
       const { configOptions, modes } = await newSession();
       expect(modes?.currentModeId).toBe('plan');
       expect(configOptions.find((option) => option.id === 'mode')?.currentValue).toBe('plan');
+    },
+    30_000,
+  );
+
+  it.each(['auto', 'yolo'] as const)(
+    'pushes consistent ACP projections when permission changes to %s outside ACP',
+    async (permission) => {
+      await boot();
+      const { sessionId } = await newSession();
+      const cursor = client!.sessionUpdates().length;
+
+      await client!.server.klient.session(sessionId).agent('main').setPermission(permission);
+
+      await vi.waitFor(() => {
+        expect(modeProjectionUpdates(client!.sessionUpdates().slice(cursor))).toEqual({
+          current: [permission],
+          config: [permission],
+        });
+      });
+    },
+    30_000,
+  );
+
+  it(
+    'pushes plan projection when plan mode is entered outside ACP',
+    async () => {
+      await boot({ configToml: 'default_permission_mode = "auto"\n' });
+      const { sessionId } = await newSession();
+      const cursor = client!.sessionUpdates().length;
+
+      await client!.server.klient.session(sessionId).agent('main').enterPlan();
+
+      await vi.waitFor(() => {
+        expect(modeProjectionUpdates(client!.sessionUpdates().slice(cursor))).toEqual({
+          current: ['plan'],
+          config: ['plan'],
+        });
+      });
+    },
+    30_000,
+  );
+
+  it(
+    'restores yolo projection when plan mode is exited outside ACP',
+    async () => {
+      await boot({
+        configToml: 'default_plan_mode = true\ndefault_permission_mode = "yolo"\n',
+      });
+      const { sessionId } = await newSession();
+      const cursor = client!.sessionUpdates().length;
+
+      await client!.server.klient.session(sessionId).agent('main').cancelPlan();
+
+      await vi.waitFor(() => {
+        expect(modeProjectionUpdates(client!.sessionUpdates().slice(cursor))).toEqual({
+          current: ['yolo'],
+          config: ['yolo'],
+        });
+      });
+    },
+    30_000,
+  );
+
+  it(
+    'publishes only yolo when ACP switches from plan mode',
+    async () => {
+      await boot();
+      const { sessionId } = await newSession();
+      await client!.send('session/set_mode', { sessionId, modeId: 'plan' });
+      const cursor = client!.sessionUpdates().length;
+
+      await client!.send('session/set_mode', { sessionId, modeId: 'yolo' });
+
+      expect(modeProjectionUpdates(client!.sessionUpdates().slice(cursor))).toEqual({
+        current: ['yolo'],
+        config: ['yolo'],
+      });
     },
     30_000,
   );
@@ -201,6 +293,8 @@ describe('acp-server config surface', () => {
         enterPlan: async () => {
           throw new Error('plan toggle failed');
         },
+        getPermission: async () => 'manual' as const,
+        getPlan: async () => null,
         setPermission: async () => {},
       };
       Object.assign(session as unknown as Record<string, unknown>, {
@@ -208,6 +302,12 @@ describe('acp-server config surface', () => {
         conn: { sessionUpdate: async (update: unknown) => updates.push(update) },
         sessionId: 'session-test',
         currentModeId: 'default',
+        disposed: false,
+        modeMutationDepth: 0,
+        modeRefreshDirty: false,
+        modeRefreshRevision: 0,
+        modeStateInitialized: true,
+        reportedModeId: 'default',
       });
 
       await expect(session.setMode('plan')).rejects.toThrow('plan toggle failed');

--- a/packages/acp-server/test/config.test.ts
+++ b/packages/acp-server/test/config.test.ts
@@ -19,10 +19,13 @@ interface ModesState {
   readonly availableModes: ReadonlyArray<{ readonly id: string }>;
 }
 
-interface NewSessionResult {
-  readonly sessionId: string;
+interface SessionConfigSnapshot {
   readonly configOptions: readonly ConfigOption[];
   readonly modes?: ModesState;
+}
+
+interface NewSessionResult extends SessionConfigSnapshot {
+  readonly sessionId: string;
 }
 
 describe('acp-server config surface', () => {
@@ -99,6 +102,68 @@ describe('acp-server config surface', () => {
         'auto',
         'yolo',
       ]);
+    },
+    30_000,
+  );
+
+  it.each(['auto', 'yolo'] as const)(
+    'session/new reports the engine %s permission mode',
+    async (permission) => {
+      homeDir = await mkdtemp(join(tmpdir(), 'acp-config-'));
+      await writeFile(
+        join(homeDir, 'config.toml'),
+        `default_permission_mode = "${permission}"\n`,
+        'utf8',
+      );
+      client = await createTestClient({ homeDir });
+      await client.send('initialize', { protocolVersion: 1, clientCapabilities: {} });
+
+      const { sessionId, configOptions, modes } = await newSession();
+      await expect(
+        client.server.klient.session(sessionId).agent('main').getPermission(),
+      ).resolves.toBe(permission);
+      expect(modes?.currentModeId).toBe(permission);
+      expect(configOptions.find((option) => option.id === 'mode')?.currentValue).toBe(permission);
+    },
+    30_000,
+  );
+
+  it(
+    'session/resume restores the persisted permission mode',
+    async () => {
+      await boot();
+      const { sessionId } = await newSession();
+      await client!.send('session/set_mode', { sessionId, modeId: 'auto' });
+      await client!.send('session/close', { sessionId });
+
+      const resumed = (await client!.send('session/resume', {
+        sessionId,
+        cwd: homeDir,
+        mcpServers: [],
+      })) as SessionConfigSnapshot;
+      expect(resumed.modes?.currentModeId).toBe('auto');
+      expect(resumed.configOptions.find((option) => option.id === 'mode')?.currentValue).toBe(
+        'auto',
+      );
+    },
+    30_000,
+  );
+
+  it(
+    'session/new reports plan mode ahead of the permission mode',
+    async () => {
+      homeDir = await mkdtemp(join(tmpdir(), 'acp-config-'));
+      await writeFile(
+        join(homeDir, 'config.toml'),
+        'default_plan_mode = true\ndefault_permission_mode = "yolo"\n',
+        'utf8',
+      );
+      client = await createTestClient({ homeDir });
+      await client.send('initialize', { protocolVersion: 1, clientCapabilities: {} });
+
+      const { configOptions, modes } = await newSession();
+      expect(modes?.currentModeId).toBe('plan');
+      expect(configOptions.find((option) => option.id === 'mode')?.currentValue).toBe('plan');
     },
     30_000,
   );

--- a/packages/klient/src/contract/agent/events.ts
+++ b/packages/klient/src/contract/agent/events.ts
@@ -1,15 +1,16 @@
 /**
  * Klient-level agent-scope events — the public, typed, namespaced event
- * surface of one agent. All registrations filter the per-agent `events`
- * scope stream by `type`; the payload is the whole flat `{ type, ... }`
- * event (schemas keep the `type` literal so listeners receive it intact).
- * Payload shapes mirror `protocol/src/events.ts`; events that are loose in
- * the engine (or absent from the protocol union) are `z.looseObject`s.
+ * surface of one agent. Most registrations filter the per-agent `events`
+ * scope stream by `type`; domain-specific changes may bind a Service emitter
+ * instead. Stream payloads keep the whole flat `{ type, ... }` event intact.
+ * Payload shapes mirror `protocol/src/events.ts`; events that are loose in the
+ * engine (or absent from the protocol union) are `z.looseObject`s.
  */
 
 import { z } from 'zod';
 
 import type { EventRegistration } from '../types.js';
+import { permissionModeSchema } from './rpc.js';
 
 /**
  * Scope-stream registration (`kind: 'stream'`). Declared structurally here
@@ -166,6 +167,11 @@ export const permissionApprovalResolvedEventSchema = z.looseObject({
   toolCallId: z.string(),
 });
 
+export const permissionModeChangedEventSchema = z.object({
+  mode: permissionModeSchema,
+  previousMode: permissionModeSchema,
+});
+
 /** `error` payloads carry the full `KimiErrorPayload`; kept loose. */
 export const errorEventSchema = z.looseObject({
   message: z.string(),
@@ -180,6 +186,7 @@ export const warningEventSchema = z.object({
 /** `agent.status.updated` carries a wide optional status bag; kept loose. */
 export const agentStatusUpdatedEventSchema = z.looseObject({
   phase: z.string().optional(),
+  planMode: z.boolean().optional(),
 });
 
 // ── registrations ───────────────────────────────────────────────────────────
@@ -202,6 +209,7 @@ export interface AgentEventPayloads {
   'compaction.completed': z.infer<typeof compactionCompletedEventSchema>;
   'permission.approval.requested': z.infer<typeof permissionApprovalRequestedEventSchema>;
   'permission.approval.resolved': z.infer<typeof permissionApprovalResolvedEventSchema>;
+  'permission.mode.changed': z.infer<typeof permissionModeChangedEventSchema>;
   error: z.infer<typeof errorEventSchema>;
   warning: z.infer<typeof warningEventSchema>;
   'agent.status.updated': z.infer<typeof agentStatusUpdatedEventSchema>;
@@ -256,6 +264,12 @@ export const agentEvents = {
     name: 'events',
     type: 'permission.approval.resolved',
     schema: permissionApprovalResolvedEventSchema,
+  },
+  'permission.mode.changed': {
+    kind: 'emitter',
+    service: 'agentPermissionModeService',
+    event: 'onDidChangeMode',
+    schema: permissionModeChangedEventSchema,
   },
   error: { kind: 'stream', name: 'events', type: 'error', schema: errorEventSchema },
   warning: { kind: 'stream', name: 'events', type: 'warning', schema: warningEventSchema },

--- a/packages/klient/src/contract/agent/services.ts
+++ b/packages/klient/src/contract/agent/services.ts
@@ -1,7 +1,7 @@
 /**
  * Agent-scope domain service contracts. These mirror the positional-arg
  * signatures of the engine's domain Services (shellCommand / profile / usage /
- * plan / task) that the agent facade calls directly; payload and result
+ * permissionMode / plan / task) that the agent facade calls directly; payload and result
  * schemas are shared with `agent/rpc.ts` (they mirror the same wire shapes).
  */
 
@@ -11,6 +11,7 @@ import { maybe, noResult } from '../helpers.js';
 import type { ServiceContract } from '../types.js';
 import {
   agentTaskInfoSchema,
+  permissionModeSchema,
   planDataSchema,
   runShellCommandPayloadSchema,
   setModelResultSchema,
@@ -35,6 +36,10 @@ export const agentProfileContract = {
 
 export const agentUsageContract = {
   status: { input: z.tuple([]), output: usageStatusSchema },
+} satisfies ServiceContract;
+
+export const agentPermissionModeContract = {
+  mode: { input: z.tuple([]), output: permissionModeSchema },
 } satisfies ServiceContract;
 
 export const agentPlanContract = {

--- a/packages/klient/src/contract/agent/services.ts
+++ b/packages/klient/src/contract/agent/services.ts
@@ -1,8 +1,8 @@
 /**
  * Agent-scope domain service contracts. These mirror the positional-arg
  * signatures of the engine's domain Services (shellCommand / profile / usage /
- * permissionMode / plan / task) that the agent facade calls directly; payload and result
- * schemas are shared with `agent/rpc.ts` (they mirror the same wire shapes).
+ * permissionMode / plan / task) that the agent facade calls directly; payload
+ * and result schemas are shared with `agent/rpc.ts`.
  */
 
 import { z } from 'zod';

--- a/packages/klient/src/contract/index.ts
+++ b/packages/klient/src/contract/index.ts
@@ -12,6 +12,7 @@ import { agentRpcContract } from './agent/rpc.js';
 import {
   agentFullCompactionContract,
   agentMcpContract,
+  agentPermissionModeContract,
   agentPlanContract,
   agentProfileContract,
   agentShellCommandContract,
@@ -72,6 +73,7 @@ export const globalContract: KlientContract = {
   agentShellCommandService: agentShellCommandContract,
   agentProfileService: agentProfileContract,
   agentUsageService: agentUsageContract,
+  agentPermissionModeService: agentPermissionModeContract,
   agentPlanService: agentPlanContract,
   agentTaskService: agentTaskContract,
   agentMcpService: agentMcpContract,

--- a/packages/klient/src/core/facade/agent.ts
+++ b/packages/klient/src/core/facade/agent.ts
@@ -2,8 +2,8 @@
  * The agent facade — one `session.agent(id)` handle over the agent-scope
  * services the wire exposes. Turn-driving calls (prompt / steer / cancel) go
  * through the `agentRPCService` channel; shell commands, model, usage,
- * permission, plan, and task calls go straight to their domain services. Prompt streaming is
- * NOT on this interface: it flows through the agent's `events` hub
+ * permission, plan, and task calls go straight to their domain services.
+ * Prompt streaming is NOT on this interface: it flows through the agent's `events` hub
  * (`turn.*`, `assistant.delta`, `tool.call.*`, `prompt.completed`, …).
  */
 

--- a/packages/klient/src/core/facade/agent.ts
+++ b/packages/klient/src/core/facade/agent.ts
@@ -1,8 +1,8 @@
 /**
  * The agent facade — one `session.agent(id)` handle over the agent-scope
  * services the wire exposes. Turn-driving calls (prompt / steer / cancel) go
- * through the `agentRPCService` channel; shell commands, model, usage, plan,
- * and task calls go straight to their domain services. Prompt streaming is
+ * through the `agentRPCService` channel; shell commands, model, usage,
+ * permission, plan, and task calls go straight to their domain services. Prompt streaming is
  * NOT on this interface: it flows through the agent's `events` hub
  * (`turn.*`, `assistant.delta`, `tool.call.*`, `prompt.completed`, …).
  */
@@ -55,6 +55,7 @@ export interface AgentFacade {
   getThinking(): Promise<ThinkingLevel>;
   setThinking(level: string): Promise<void>;
   setPermission(mode: PermissionMode): Promise<void>;
+  getPermission(): Promise<PermissionMode>;
   getUsage(): Promise<UsageStatus>;
   getContext(): Promise<AgentContextData>;
   listCommands(): Promise<readonly AgentCommandInfo[]>;
@@ -101,6 +102,8 @@ export function createAgentFacade(call: ScopedCaller, scope: ScopeRef): AgentFac
     setThinking: (level) =>
       call(scope, 'agentProfileService', 'setThinking', [level]) as Promise<void>,
     setPermission: (mode) => rpc('setPermission', { mode }) as Promise<void>,
+    getPermission: () =>
+      call(scope, 'agentPermissionModeService', 'mode', []) as Promise<PermissionMode>,
     getUsage: () => call(scope, 'agentUsageService', 'status', []) as Promise<UsageStatus>,
     getContext: () => rpc('getContext', {}) as Promise<AgentContextData>,
     listCommands: () => rpc('listCommands', {}) as Promise<readonly AgentCommandInfo[]>,

--- a/packages/klient/src/transports/memory/serviceRegistry.ts
+++ b/packages/klient/src/transports/memory/serviceRegistry.ts
@@ -32,6 +32,7 @@ import { ISessionQuestionService } from '@moonshot-ai/agent-core-v2/session/ques
 import { ISessionSkillCatalog } from '@moonshot-ai/agent-core-v2/session/sessionSkillCatalog/skillCatalog';
 import { IAgentRPCService } from '@moonshot-ai/agent-core-v2/agent/rpc/rpc';
 import { IAgentActivityView } from '@moonshot-ai/agent-core-v2/agent/activityView/activityView';
+import { IAgentPermissionModeService } from '@moonshot-ai/agent-core-v2/agent/permissionMode/permissionMode';
 import { IAgentPlanService } from '@moonshot-ai/agent-core-v2/features/plan/plan';
 import { IAgentProfileService } from '@moonshot-ai/agent-core-v2/agent/profile/profile';
 import { IAgentShellCommandService } from '@moonshot-ai/agent-core-v2/agent/shellCommand/shellCommand';
@@ -68,6 +69,7 @@ export const serviceTokens: Readonly<Record<string, ServiceIdentifier<unknown>>>
   agentShellCommandService: IAgentShellCommandService,
   agentProfileService: IAgentProfileService,
   agentUsageService: IAgentUsageService,
+  agentPermissionModeService: IAgentPermissionModeService,
   agentPlanService: IAgentPlanService,
   agentTaskService: IAgentTaskService,
   agentMcpService: IAgentMcpService,

--- a/packages/klient/test/contract-parity.ts
+++ b/packages/klient/test/contract-parity.ts
@@ -22,7 +22,10 @@ import type {
   TurnPhase,
 } from '@moonshot-ai/agent-core-v2/agent/activityView/activityView';
 import type { AgentContextData } from '@moonshot-ai/agent-core-v2/agent/contextMemory/types';
-import type { IAgentPermissionModeService } from '@moonshot-ai/agent-core-v2/agent/permissionMode/permissionMode';
+import type {
+  IAgentPermissionModeService,
+  PermissionModeChangedContext,
+} from '@moonshot-ai/agent-core-v2/agent/permissionMode/permissionMode';
 import type { TurnEndReason } from '@moonshot-ai/agent-core-v2/agent/loop/turnEvents';
 import type { PlanData } from '@moonshot-ai/agent-core-v2/features/plan/plan';
 import type {
@@ -191,6 +194,7 @@ import {
   compactionStartedEventSchema,
   promptAbortedEventSchema,
   promptCompletedEventSchema,
+  permissionModeChangedEventSchema,
   thinkingDeltaEventSchema,
   toolCallDeltaEventSchema,
   toolCallStartedEventSchema,
@@ -621,6 +625,10 @@ const _compactionCancelledEvent: AssertWire<
 const _compactionCompletedEvent: AssertWire<
   typeof compactionCompletedEventSchema,
   CompactionCompletedEvent
+> = true;
+const _permissionModeChangedEvent: AssertWire<
+  typeof permissionModeChangedEventSchema,
+  PermissionModeChangedContext
 > = true;
 const _warningEvent: AssertWire<typeof warningEventSchema, WarningEvent> = true;
 // No parity assertions for `errorEventSchema`, `permissionApproval*Schema`,

--- a/packages/klient/test/contract-parity.ts
+++ b/packages/klient/test/contract-parity.ts
@@ -22,6 +22,7 @@ import type {
   TurnPhase,
 } from '@moonshot-ai/agent-core-v2/agent/activityView/activityView';
 import type { AgentContextData } from '@moonshot-ai/agent-core-v2/agent/contextMemory/types';
+import type { IAgentPermissionModeService } from '@moonshot-ai/agent-core-v2/agent/permissionMode/permissionMode';
 import type { TurnEndReason } from '@moonshot-ai/agent-core-v2/agent/loop/turnEvents';
 import type { PlanData } from '@moonshot-ai/agent-core-v2/features/plan/plan';
 import type {
@@ -167,6 +168,7 @@ import {
   getTaskOutputPayloadSchema,
   getTasksPayloadSchema,
   planDataSchema,
+  permissionModeSchema,
   promptLaunchResultSchema,
   promptPartSchema,
   promptPayloadSchema,
@@ -532,6 +534,7 @@ type PromptLaunchResult = NonNullable<ReturnType<AgentAPI['prompt']>>;
 type SteerPayload = Parameters<AgentAPI['steer']>[0];
 type CancelPayload = Parameters<AgentAPI['cancel']>[0];
 type SetPermissionPayload = Parameters<AgentAPI['setPermission']>[0];
+type PermissionMode = IAgentPermissionModeService['mode'];
 type AgentCommandInfo = Awaited<ReturnType<AgentAPI['listCommands']>>[number];
 type RunCommandPayload = Parameters<AgentAPI['runCommand']>[0];
 type TokenUsage = NonNullable<UsageStatus['total']>;
@@ -560,6 +563,7 @@ const _setModelPayload: AssertWire<typeof setModelPayloadSchema, SetModelPayload
 const _setModelResult: AssertWire<typeof setModelResultSchema, SetModelResult> = true;
 const _setPermissionPayload: AssertWire<typeof setPermissionPayloadSchema, SetPermissionPayload> =
   true;
+const _permissionMode: AssertWire<typeof permissionModeSchema, PermissionMode> = true;
 const _tokenUsage: AssertWire<typeof tokenUsageSchema, TokenUsage> = true;
 const _usageStatus: AssertWire<typeof usageStatusSchema, UsageStatus> = true;
 // One-directional: `history` entries are full `ContextMessage`s (deep

--- a/packages/klient/test/facade.test.ts
+++ b/packages/klient/test/facade.test.ts
@@ -182,6 +182,23 @@ describe('agent profile routing', () => {
   });
 });
 
+describe('agent permission routing', () => {
+  it('getPermission routes through the permission mode service', async () => {
+    const channel = new FakeChannel();
+    const klient = createKlientFromChannel(channel);
+    const agent = klient.session('s1').agent('main');
+
+    channel.result = 'auto';
+    await expect(agent.getPermission()).resolves.toBe('auto');
+    expect(channel.calls[0]).toEqual({
+      scope: { sessionId: 's1', agentId: 'main' },
+      service: 'agentPermissionModeService',
+      method: 'mode',
+      args: [],
+    });
+  });
+});
+
 describe('session skills routing', () => {
   it('skills.list routes to sessionSkillCatalog.list with the session scope', async () => {
     const channel = new FakeChannel();

--- a/packages/klient/test/facade.test.ts
+++ b/packages/klient/test/facade.test.ts
@@ -197,6 +197,26 @@ describe('agent permission routing', () => {
       args: [],
     });
   });
+
+  it('permission.mode.changed maps to the permission mode emitter', () => {
+    const channel = new FakeChannel();
+    const klient = createKlientFromChannel(channel);
+    const agent = klient.session('s1').agent('main');
+    const seen: unknown[] = [];
+
+    agent.events.on('permission.mode.changed', (event) => seen.push(event));
+    expect(channel.subscriptions[0]).toMatchObject({
+      scope: { sessionId: 's1', agentId: 'main' },
+      source: {
+        kind: 'emitter',
+        service: 'agentPermissionModeService',
+        event: 'onDidChangeMode',
+      },
+    });
+
+    channel.emit(0, { mode: 'auto', previousMode: 'manual' });
+    expect(seen).toEqual([{ mode: 'auto', previousMode: 'manual' }]);
+  });
 });
 
 describe('session skills routing', () => {

--- a/packages/klient/test/helpers/conformance.ts
+++ b/packages/klient/test/helpers/conformance.ts
@@ -323,5 +323,20 @@ export function defineKlientConformance(
         await target.klient.session(created.id).close();
       }
     });
+
+    it('reads the current agent permission mode', async () => {
+      const created = await target.klient.global.sessions.create({
+        workDir: process.cwd(),
+        title: 'conformance permission mode',
+      });
+
+      try {
+        const agent = target.klient.session(created.id).agent('main');
+        await agent.setPermission('auto');
+        await expect(agent.getPermission()).resolves.toBe('auto');
+      } finally {
+        await target.klient.session(created.id).close();
+      }
+    });
   });
 }

--- a/packages/klient/test/helpers/conformance.ts
+++ b/packages/klient/test/helpers/conformance.ts
@@ -338,5 +338,29 @@ export function defineKlientConformance(
         await target.klient.session(created.id).close();
       }
     });
+
+    it('emits the current permission mode change', async () => {
+      const created = await target.klient.global.sessions.create({
+        workDir: process.cwd(),
+        title: 'conformance permission event',
+      });
+
+      try {
+        const agent = target.klient.session(created.id).agent('main');
+        const changed = new Promise<{ mode: string; previousMode: string }>((resolve) => {
+          const subscription = agent.events.on('permission.mode.changed', (event) => {
+            subscription.dispose();
+            resolve(event);
+          });
+        });
+        await agent.getPermission();
+
+        await agent.setPermission('auto');
+
+        await expect(changed).resolves.toEqual({ mode: 'auto', previousMode: 'manual' });
+      } finally {
+        await target.klient.session(created.id).close();
+      }
+    });
   });
 }


### PR DESCRIPTION
## Related Issue

Resolve #2828

## Problem

ACP initialized both mode projections to `default` regardless of the engine's active permission or plan state. The cached projection also became stale when permission or plan mode changed at runtime, so an IDE could display a mode that did not match the behavior actually enforced by the engine.

## What changed

- Expose the current permission mode and its change event through the Klient agent facade.
- Derive ACP mode state from the engine's permission and plan state when a session is created or restored, with plan mode taking precedence.
- Keep both ACP projections synchronized at runtime by coalescing permission and plan invalidations into an authoritative refresh, discarding stale snapshots and suppressing intermediate states during `session/set_mode`.
- Push `current_mode_update` and `config_option_update` from the same reconciled snapshot and stop in-flight refreshes from publishing after session disposal.
- Cover configured and persisted modes, runtime permission changes, plan entry and exit, atomic plan-to-permission transitions, event routing, and both memory and IPC transports.
- Add a patch changeset for the corrected ACP behavior. No documentation update is needed because the existing mode configuration and protocol surface are unchanged.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.
