### PR TITLE
fix(node-sdk): bind --agent/--agent-file profile on interactive session create (v2)

### DIFF
--- a/.changeset/interactive-agent-profile-bind.md
+++ b/.changeset/interactive-agent-profile-bind.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code-sdk": patch
+---
+
+fix: bind `--agent`/`--agent-file` profile on interactive session create (v2)

--- a/packages/node-sdk/src/sdk-rpc-client-v2.ts
+++ b/packages/node-sdk/src/sdk-rpc-client-v2.ts
@@ -180,6 +180,7 @@ import {
   IBootstrapService,
   IConfigService,
   IEventService,
+  IExplicitAgentProfileLoader,
   IHostEnvironment,
   IHostFileSystem,
   IModelCatalog,
@@ -1090,6 +1091,33 @@ export class SDKRpcClientV2 extends SDKRpcClientBase {
     // — so a profile's `tools` / `disallowedTools` policy is enforced in
     // interactive sessions too, not just `-p`.
     const agentProfileName = await this.resolveStartupAgentProfile(input, workDir);
+    // Register `--agent-file` profiles with the engine before the main agent
+    // binds them: the workspace explicit loader reads only
+    // `IBootstrapService.args.agentFiles`, and this client's bootstrap seeds
+    // only `skillDirs`, so an agentfile supplied solely through `agentFiles`
+    // would otherwise be absent from the session catalog and `profile.bind`
+    // would reject it as an unknown profile. Seed the session's files through
+    // the same channel `run-v2-print` uses at bootstrap, then re-arm the
+    // workspace explicit loader (`handlerFor` is create-or-get, so a
+    // pre-existing handler would otherwise keep a stale explicit contribution)
+    // so the catalog re-projects before the bind below.
+    const sessionAgentFiles =
+      input.agentFiles !== undefined && input.agentFiles.length > 0
+        ? [...input.agentFiles]
+        : undefined;
+    const bootstrapService = this.engineAccessor.get(IBootstrapService);
+    // `bootstrap.args` is the plain object this client seeded at bootstrap; the
+    // `HostArgs` fields are typed `readonly`, but nothing re-derives them after
+    // construction, so the session's files ride the same channel `run-v2-print`
+    // seeds at bootstrap time.
+    const hostArgs = bootstrapService.args as { agentFiles?: readonly string[] };
+    // Only touch the channel when this session has files or a previous session
+    // seeded the process-global args — clearing on the no-agent-file path stops
+    // a prior session's files leaking into a fresh workspace handler.
+    if (sessionAgentFiles !== undefined || hostArgs.agentFiles !== undefined) {
+      hostArgs.agentFiles = sessionAgentFiles;
+      await handler.accessor.get(IExplicitAgentProfileLoader).reload();
+    }
     if (
       agentProfileName !== undefined ||
       input.model !== undefined ||

--- a/packages/node-sdk/src/sdk-rpc-client-v2.ts
+++ b/packages/node-sdk/src/sdk-rpc-client-v2.ts
@@ -127,7 +127,7 @@
  *   matching v1's aggregate.
  */
 import { randomUUID } from 'node:crypto';
-import { readdir } from 'node:fs/promises';
+import { readFile, readdir } from 'node:fs/promises';
 import { join } from 'node:path';
 
 import {
@@ -221,6 +221,8 @@ import {
   ProfileError,
   ProfileErrors,
   promptMetadataTextFromSkill,
+  parseAgentFileText,
+  resolveAgentPath,
   resolveAgentTaskConfig,
   resolveConfigPath,
   resolveKimiHome,
@@ -1081,12 +1083,21 @@ export class SDKRpcClientV2 extends SDKRpcClientBase {
     // Wired before the optional main-agent materialization so a profile-bind
     // warning (oversized AGENTS.md) reaches the listeners like v1's create.
     this.wireSession(handle);
+    // `--agent` / `--agent-file` select the startup session's main-agent
+    // profile. Resolve the explicit profile (an agentfile contributes the
+    // profile under its frontmatter `name`) and bind it when the main agent is
+    // materialized — the same binding print mode applies via `mainAgentBinding`
+    // — so a profile's `tools` / `disallowedTools` policy is enforced in
+    // interactive sessions too, not just `-p`.
+    const agentProfileName = await this.resolveStartupAgentProfile(input, workDir);
     if (
+      agentProfileName !== undefined ||
       input.model !== undefined ||
       input.thinking !== undefined ||
       input.permission !== undefined
     ) {
       const agent = await this.materializeMainAgent(handle, {
+        profile: agentProfileName,
         model: input.model,
         thinking: input.thinking,
       });
@@ -1324,21 +1335,25 @@ export class SDKRpcClientV2 extends SDKRpcClientBase {
    */
   private async materializeMainAgent(
     session: ISessionScopeHandle,
-    binding?: { readonly model?: string; readonly thinking?: string },
+    binding?: { readonly profile?: string; readonly model?: string; readonly thinking?: string },
   ): Promise<IAgentScopeHandle> {
     await this.modelReady;
     const agent = await ensureMainAgent(session);
     const profile = agent.accessor.get(IAgentProfileService);
-    if (binding !== undefined || profile.data().profileName === undefined) {
+    // A fresh agent binds the requested startup profile when one was selected,
+    // else the default profile + configured default model. An agent that is
+    // already bound (startup `--agent` binding, or a resumed profile restored
+    // from wire) is left alone so the explicit binding is never overwritten.
+    if (binding?.profile !== undefined || profile.data().profileName === undefined) {
       try {
         await profile.bind({
-          profile: DEFAULT_AGENT_PROFILE_NAME,
+          profile: binding?.profile ?? DEFAULT_AGENT_PROFILE_NAME,
           model: binding?.model,
           thinking: binding?.thinking,
         });
       } catch (error) {
         if (
-          binding === undefined &&
+          binding?.profile === undefined &&
           error instanceof ProfileError &&
           error.code === ProfileErrors.codes.MODEL_NOT_CONFIGURED
         ) {
@@ -1348,6 +1363,50 @@ export class SDKRpcClientV2 extends SDKRpcClientBase {
       }
     }
     return agent;
+  }
+
+  /**
+   * Resolve the `--agent` / `--agent-file` main-agent profile for a new
+   * session: an explicit `--agent` name wins; otherwise the first `--agent-file`
+   * contributes the profile under its frontmatter `name` (parsed here, fatal on
+   * error, so a bad file fails before any session materializes — the same
+   * precedence print mode applies in `run-v2-print`).
+   */
+  private async resolveStartupAgentProfile(
+    input: CreateSessionOptions,
+    workDir: string,
+  ): Promise<string | undefined> {
+    if (input.agentProfile !== undefined) return input.agentProfile;
+    const agentFile = input.agentFiles?.[0];
+    if (agentFile === undefined) return undefined;
+    const agentFilePath = resolveAgentPath(
+      agentFile,
+      workDir,
+      this.engineAccessor.get(IBootstrapService).osHomeDir,
+    );
+    let text: string;
+    try {
+      text = await readFile(agentFilePath, 'utf8');
+    } catch (error) {
+      throw new KimiError(
+        ErrorCodes.AGENT_NOT_FOUND,
+        `Failed to read agent file "${agentFilePath}": ${error instanceof Error ? error.message : String(error)}`,
+        { cause: error },
+      );
+    }
+    try {
+      return parseAgentFileText({
+        path: agentFilePath,
+        source: 'explicit',
+        text,
+      }).name;
+    } catch (error) {
+      throw new KimiError(
+        ErrorCodes.AGENT_NOT_FOUND,
+        `Invalid agent file "${agentFilePath}": ${error instanceof Error ? error.message : String(error)}`,
+        { cause: error },
+      );
+    }
   }
 
   /** The target agent's live scope handle (see the section header). */

--- a/packages/node-sdk/test/session-agent-profile.test.ts
+++ b/packages/node-sdk/test/session-agent-profile.test.ts
@@ -129,4 +129,44 @@ describe('SDKRpcClientV2.createSession startup agent profile', () => {
       await rpc.close();
     }
   });
+
+  it('binds an --agent-file profile that is not discoverable from user/project agent dirs', async () => {
+    const homeDir = await makeTempDir('kimi-sdk-agent-file-home-');
+    const workDir = await makeTempDir('kimi-sdk-agent-file-work-');
+    await writeTestHome(homeDir);
+    // Supplied solely through `agentFiles`: the file lives at the (otherwise
+    // empty) workDir root — not under <homeDir>/agents and not under any
+    // project agent root (.kimi-code/agents / .agents/agents) — so only the
+    // engine's explicit loader (which the SDK seeds from `agentFiles`) can
+    // register it. Without that registration the parsed profile name is absent
+    // from the session catalog and `profile.bind` would reject it as unknown.
+    const agentFilePath = join(workDir, 'explicit-only.md');
+    await writeFile(
+      agentFilePath,
+      `---
+name: explicit-only
+description: Agent-file-only profile for the interactive --agent-file bind.
+tools:
+  - Read
+  - Glob
+---
+
+You are an explicit agent-file-only profile.
+`,
+      'utf-8',
+    );
+    const rpc = new SDKRpcClientV2({ homeDir, identity: TEST_IDENTITY });
+    try {
+      const summary = await rpc.createSession({
+        workDir,
+        model: 'kimi-test-model',
+        agentFiles: [agentFilePath],
+      });
+      const data = await mainAgentProfileData(rpc, summary.id);
+      expect(data.profileName).toBe('explicit-only');
+      expect(data.activeToolNames).toEqual(['Read', 'Glob']);
+    } finally {
+      await rpc.close();
+    }
+  });
 });

--- a/packages/node-sdk/test/session-agent-profile.test.ts
+++ b/packages/node-sdk/test/session-agent-profile.test.ts
@@ -1,0 +1,132 @@
+/**
+ * Scenario: startup `--agent` / `--agent-file` profile binding on interactive
+ * session creation (agent-core-v2 engine).
+ * Responsibilities: a session created through the v2 SDK client with
+ * `agentProfile` binds that profile as the main agent — so the profile's
+ * `tools` / `disallowedTools` policy is enforced in interactive sessions too,
+ * not just `-p` print mode. Without an explicit profile the main agent falls
+ * back to the default profile (v1's eager equivalent).
+ * Wiring: real agent-core-v2 engine in-process on a temp KIMI_CODE_HOME; no
+ * provider calls (the configured model is never invoked).
+ * Run: pnpm -C packages/node-sdk exec vitest run test/session-agent-profile.test.ts
+ */
+
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import {
+  ensureMainAgent,
+  getLiveSessionById,
+  IAgentProfileService,
+} from '@moonshot-ai/agent-core-v2';
+
+import { SDKRpcClientV2 } from '#/index';
+
+import { TEST_IDENTITY } from './test-identity';
+
+const tempDirs: string[] = [];
+
+afterEach(async () => {
+  for (const dir of tempDirs.splice(0)) {
+    for (let attempt = 0; attempt < 10; attempt++) {
+      try {
+        await rm(dir, { recursive: true, force: true });
+        break;
+      } catch (error) {
+        const code = (error as NodeJS.ErrnoException).code;
+        if (code !== 'ENOTEMPTY' && code !== 'EBUSY' && code !== 'EPERM') throw error;
+        await new Promise((resolve) => setTimeout(resolve, 10));
+      }
+    }
+  }
+});
+
+async function makeTempDir(prefix: string): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), prefix));
+  tempDirs.push(dir);
+  return dir;
+}
+
+async function writeTestHome(homeDir: string): Promise<void> {
+  await writeFile(
+    join(homeDir, 'config.toml'),
+    `
+[providers.local]
+type = "kimi"
+base_url = "https://example.test/v1"
+api_key = "sk-test"
+
+[models."kimi-test-model"]
+provider = "local"
+model = "kimi-test-model"
+max_context_size = 1000
+`,
+    'utf-8',
+  );
+  const agentDir = join(homeDir, 'agents');
+  await mkdir(agentDir, { recursive: true });
+  await writeFile(
+    join(agentDir, 'restricted.md'),
+    `---
+name: restricted
+description: Read-only test agent with a tools allowlist.
+tools:
+  - Read
+  - Glob
+---
+
+You are a read-only test agent.
+`,
+    'utf-8',
+  );
+}
+
+async function mainAgentProfileData(rpc: SDKRpcClientV2, sessionId: string) {
+  const session = getLiveSessionById(rpc.engineAccessor, sessionId);
+  if (session === undefined) {
+    throw new Error(`live session "${sessionId}" not found`);
+  }
+  const agent = await ensureMainAgent(session);
+  return agent.accessor.get(IAgentProfileService).data();
+}
+
+describe('SDKRpcClientV2.createSession startup agent profile', () => {
+  it('binds the --agent profile so its tools policy applies to the interactive main agent', async () => {
+    const homeDir = await makeTempDir('kimi-sdk-agent-profile-home-');
+    const workDir = await makeTempDir('kimi-sdk-agent-profile-work-');
+    await writeTestHome(homeDir);
+    const rpc = new SDKRpcClientV2({ homeDir, identity: TEST_IDENTITY });
+    try {
+      const summary = await rpc.createSession({
+        workDir,
+        model: 'kimi-test-model',
+        agentProfile: 'restricted',
+      });
+      const data = await mainAgentProfileData(rpc, summary.id);
+      expect(data.profileName).toBe('restricted');
+      expect(data.activeToolNames).toEqual(['Read', 'Glob']);
+    } finally {
+      await rpc.close();
+    }
+  });
+
+  it('falls back to the default profile when no --agent is selected', async () => {
+    const homeDir = await makeTempDir('kimi-sdk-agent-profile-home-');
+    const workDir = await makeTempDir('kimi-sdk-agent-profile-work-');
+    await writeTestHome(homeDir);
+    const rpc = new SDKRpcClientV2({ homeDir, identity: TEST_IDENTITY });
+    try {
+      const summary = await rpc.createSession({
+        workDir,
+        model: 'kimi-test-model',
+      });
+      const data = await mainAgentProfileData(rpc, summary.id);
+      expect(data.profileName).toBe('agent');
+    } finally {
+      await rpc.close();
+    }
+  });
+});


### PR DESCRIPTION
Fixes #2765

## Problem

Agent profile frontmatter `tools` (allowlist) and `disallowedTools` (denylist)
are enforced in `-p` print mode but completely ignored in interactive TUI
sessions. The interactive session is created through the SDK's agent-core-v2
client, and its `createSession` never bound the requested startup profile —
the main agent fell back to the default profile, so the model saw the full,
unrestricted tool set regardless of the profile's tool policy.

The profile's system prompt appeared to be applied because profile text can
still influence prompt rendering, but the tool policy (activation fold +
execution guard) is driven by the bound profile's `tools` / `disallowedTools`,
which were never applied in interactive mode.

## Root cause

`SDKRpcClientV2.createSession` (the v2 engine client used by the interactive
TUI, `run-shell.ts` → `createKimiHarnessV2`) dropped
`CreateSessionOptions.agentProfile` / `agentFiles` entirely: it created the
session with no `mainAgentBinding` and `materializeMainAgent` always bound
`DEFAULT_AGENT_PROFILE_NAME`. Print mode (`run-v2-print.ts`), by contrast,
resolves the profile name and passes it into the session's `mainAgentBinding`,
so the tool policy is enforced there.

## Fix

`packages/node-sdk/src/sdk-rpc-client-v2.ts`:
- `createSession` now resolves the startup profile (`--agent` name, or the
  `--agent-file`'s frontmatter `name`, mirroring `run-v2-print.ts`) and passes
  it to main-agent materialization, so the interactive session binds the same
  profile (and its tool policy) as print mode.
- `materializeMainAgent` accepts the optional `profile` and binds it instead
  of unconditionally binding the default profile; an already-bound agent is
  left alone so the explicit binding is never overwritten.

## Verification

- New regression test `packages/node-sdk/test/session-agent-profile.test.ts`
  creates a v2 session with `agentProfile` pointing at a restricted profile
  and asserts the interactive main agent binds that profile (`profileName` +
  `activeToolNames`). It fails on the previous code (main agent bound the
  default profile) and passes with the fix.
- Run: `pnpm -C packages/node-sdk exec vitest run test/session-agent-profile.test.ts`

Note: unrelated to the earlier open PR #2822 (hooks index rebuild), which
touches the hooks domain of agent-core-v2.