### PR TITLE
fix: harden quota-exhausted detection and MCP schema compatibility

### DIFF
--- a/.changeset/quota-and-schema-hardening.md
+++ b/.changeset/quota-and-schema-hardening.md
@@ -1,0 +1,8 @@
+---
+"@moonshot-ai/kimi-code": patch
+"@moonshot-ai/kosong": patch
+"@moonshot-ai/agent-core": patch
+"@moonshot-ai/agent-core-v2": patch
+---
+
+Harden quota-exhausted detection and MCP schema compatibility: fail fast on Alibaba/DashScope billing 429s (arrearage/balance/quota) instead of retry-looping on dead token plans, and normalize stray `regex` JSON Schema keyword to `pattern` at MCP import/Kimi normalization to fix Meta Muse Spark strict validation errors.

--- a/packages/agent-core-v2/src/kosong/provider/bases/openai/openai-common.ts
+++ b/packages/agent-core-v2/src/kosong/provider/bases/openai/openai-common.ts
@@ -107,14 +107,29 @@ export function toolToOpenAI(tool: Tool): OpenAIToolParam {
 }
 
 export function isOpenAIInsufficientQuotaCode(code: string | null | undefined): boolean {
-  return code === 'insufficient_quota';
+  return code !== null && code !== undefined && code.toLowerCase() === 'insufficient_quota';
+}
+
+const GENERIC_QUOTA_EXHAUSTED_MESSAGE_PATTERNS = [
+  /insufficient_quota/,
+  /insufficient balance/,
+  /check your account balance/,
+  /exceeded your current (?:token )?quota/,
+  /recharge your account|please recharge/,
+  /account (?:is )?in arrears/,
+  /arrearage/,
+] as const;
+
+export function isGenericQuotaExhaustedMessage(message: string): boolean {
+  const lower = message.toLowerCase();
+  return GENERIC_QUOTA_EXHAUSTED_MESSAGE_PATTERNS.some((p) => p.test(lower));
 }
 
 function isOpenAIInsufficientQuotaError(error: OpenAIAPIError): boolean {
   if (error.status !== 429) return false;
   if (typeof error.code === 'string' && isOpenAIInsufficientQuotaCode(error.code)) return true;
   if (typeof error.type === 'string' && isOpenAIInsufficientQuotaCode(error.type)) return true;
-  return error.message.toLowerCase().includes('insufficient_quota');
+  return isGenericQuotaExhaustedMessage(error.message);
 }
 
 export function convertOpenAIError(

--- a/packages/agent-core-v2/src/kosong/provider/bases/openai/openai-responses.ts
+++ b/packages/agent-core-v2/src/kosong/provider/bases/openai/openai-responses.ts
@@ -47,6 +47,7 @@ import { ProtocolErrors } from '#/kosong/protocol/errors';
 import {
   convertOpenAIError,
   hasModelPrefix,
+  isGenericQuotaExhaustedMessage,
   isMediaPart,
   isOpenAIInsufficientQuotaCode,
   isOpenAIReasoningModel,
@@ -273,7 +274,11 @@ function errorFromOpenAIResponsesEvent(
   if (isContextOverflowErrorCode(code)) {
     return new APIContextOverflowError(400, fullMessage);
   }
-  if (isOpenAIInsufficientQuotaCode(code)) {
+  if (
+    isOpenAIInsufficientQuotaCode(code) ||
+    isGenericQuotaExhaustedMessage(message) ||
+    isGenericQuotaExhaustedMessage(code ?? '')
+  ) {
     return new APIProviderQuotaExhaustedError(fullMessage);
   }
   if (code === 'rate_limit_exceeded' || readEmbeddedStatusCode(message) === 429) {

--- a/packages/agent-core-v2/src/kosong/provider/providers/kimi/kimi-schema.ts
+++ b/packages/agent-core-v2/src/kosong/provider/providers/kimi/kimi-schema.ts
@@ -119,8 +119,28 @@ function ensureKimiPropertyTypes(schema: Record<string, unknown>): Record<string
       'JSON Schema root must normalize to an object.',
     );
   }
+  sanitizeRegexKeyword(normalized);
   recurseSchema(normalized);
   return normalized;
+}
+
+function sanitizeRegexKeyword(node: unknown): void {
+  if (Array.isArray(node)) {
+    for (const item of node) sanitizeRegexKeyword(item);
+    return;
+  }
+  if (typeof node !== 'object' || node === null) return;
+  const obj = node as Record<string, unknown>;
+  if ('regex' in obj) {
+    const regexValue = obj['regex'];
+    if (typeof regexValue === 'string' && !('pattern' in obj)) {
+      obj['pattern'] = regexValue;
+    }
+    delete obj['regex'];
+  }
+  for (const value of Object.values(obj)) {
+    sanitizeRegexKeyword(value);
+  }
 }
 
 function hasUnresolvedDefinitionRef(node: unknown, bucketKey: string): boolean {

--- a/packages/agent-core-v2/src/mcpCore/types.ts
+++ b/packages/agent-core-v2/src/mcpCore/types.ts
@@ -54,10 +54,31 @@ export function assertMcpInputSchema(
   inputSchema: unknown,
 ): Record<string, unknown> {
   if (typeof inputSchema === 'object' && inputSchema !== null && !Array.isArray(inputSchema)) {
-    return inputSchema as Record<string, unknown>;
+    const schema = inputSchema as Record<string, unknown>;
+    sanitizeMcpSchemaRegex(schema);
+    return schema;
   }
   throw new Error2(
     ErrorCodes.MCP_STARTUP_FAILED,
     `Invalid inputSchema for MCP tool "${toolName}": schema must be a JSON object`,
   );
+}
+
+function sanitizeMcpSchemaRegex(node: unknown): void {
+  if (Array.isArray(node)) {
+    for (const item of node) sanitizeMcpSchemaRegex(item);
+    return;
+  }
+  if (typeof node !== 'object' || node === null) return;
+  const obj = node as Record<string, unknown>;
+  if ('regex' in obj) {
+    const regexValue = obj['regex'];
+    if (typeof regexValue === 'string' && !('pattern' in obj)) {
+      obj['pattern'] = regexValue;
+    }
+    delete obj['regex'];
+  }
+  for (const value of Object.values(obj)) {
+    sanitizeMcpSchemaRegex(value);
+  }
 }

--- a/packages/agent-core/src/mcp/types.ts
+++ b/packages/agent-core/src/mcp/types.ts
@@ -101,7 +101,28 @@ export function assertMcpInputSchema(
   inputSchema: unknown,
 ): Record<string, unknown> {
   if (typeof inputSchema === 'object' && inputSchema !== null && !Array.isArray(inputSchema)) {
-    return inputSchema as Record<string, unknown>;
+    const schema = inputSchema as Record<string, unknown>;
+    sanitizeMcpSchemaRegex(schema);
+    return schema;
   }
   throw new Error(`Invalid inputSchema for MCP tool "${toolName}": schema must be a JSON object`);
+}
+
+function sanitizeMcpSchemaRegex(node: unknown): void {
+  if (Array.isArray(node)) {
+    for (const item of node) sanitizeMcpSchemaRegex(item);
+    return;
+  }
+  if (typeof node !== 'object' || node === null) return;
+  const obj = node as Record<string, unknown>;
+  if ('regex' in obj) {
+    const regexValue = obj['regex'];
+    if (typeof regexValue === 'string' && !('pattern' in obj)) {
+      obj['pattern'] = regexValue;
+    }
+    delete obj['regex'];
+  }
+  for (const value of Object.values(obj)) {
+    sanitizeMcpSchemaRegex(value);
+  }
 }

--- a/packages/kosong/src/providers/kimi-schema.ts
+++ b/packages/kosong/src/providers/kimi-schema.ts
@@ -128,8 +128,28 @@ function ensureKimiPropertyTypes(schema: Record<string, unknown>): Record<string
   if (!isRecord(normalized)) {
     throw new Error('JSON Schema root must normalize to an object.');
   }
+  sanitizeRegexKeyword(normalized);
   recurseSchema(normalized);
   return normalized;
+}
+
+function sanitizeRegexKeyword(node: unknown): void {
+  if (Array.isArray(node)) {
+    for (const item of node) sanitizeRegexKeyword(item);
+    return;
+  }
+  if (typeof node !== 'object' || node === null) return;
+  const obj = node as Record<string, unknown>;
+  if ('regex' in obj) {
+    const regexValue = obj['regex'];
+    if (typeof regexValue === 'string' && !('pattern' in obj)) {
+      obj['pattern'] = regexValue;
+    }
+    delete obj['regex'];
+  }
+  for (const value of Object.values(obj)) {
+    sanitizeRegexKeyword(value);
+  }
 }
 
 function hasUnresolvedDefinitionRef(node: unknown, bucketKey: string): boolean {

--- a/packages/kosong/src/providers/openai-common.ts
+++ b/packages/kosong/src/providers/openai-common.ts
@@ -105,16 +105,29 @@ export function toolToOpenAI(tool: Tool): OpenAIToolParam {
 // `exceeded_current_quota_error`) live with their vendor and reach this
 // converter through the optional `convertErrorHook` instead.
 export function isOpenAIInsufficientQuotaCode(code: string | null | undefined): boolean {
-  return code === 'insufficient_quota';
+  return code !== null && code !== undefined && code.toLowerCase() === 'insufficient_quota';
+}
+
+const GENERIC_QUOTA_EXHAUSTED_MESSAGE_PATTERNS = [
+  /insufficient_quota/,
+  /insufficient balance/,
+  /check your account balance/,
+  /exceeded your current (?:token )?quota/,
+  /recharge your account|please recharge/,
+  /account (?:is )?in arrears/,
+  /arrearage/,
+] as const;
+
+export function isGenericQuotaExhaustedMessage(message: string): boolean {
+  const lower = message.toLowerCase();
+  return GENERIC_QUOTA_EXHAUSTED_MESSAGE_PATTERNS.some((p) => p.test(lower));
 }
 
 function isOpenAIInsufficientQuotaError(error: OpenAIAPIError): boolean {
   if (error.status !== 429) return false;
   if (typeof error.code === 'string' && isOpenAIInsufficientQuotaCode(error.code)) return true;
   if (typeof error.type === 'string' && isOpenAIInsufficientQuotaCode(error.type)) return true;
-  // Gateways sometimes flatten the JSON body into the message text; the
-  // literal code string is unambiguous there, unlike prose wordings.
-  return error.message.toLowerCase().includes('insufficient_quota');
+  return isGenericQuotaExhaustedMessage(error.message);
 }
 
 export function convertOpenAIError(

--- a/packages/kosong/src/providers/openai-responses.ts
+++ b/packages/kosong/src/providers/openai-responses.ts
@@ -23,6 +23,7 @@ import OpenAI from 'openai';
 import { usesOpenAIResponsesDeveloperRole } from './capability-registry';
 import {
   convertOpenAIError,
+  isGenericQuotaExhaustedMessage,
   isMediaPart,
   isOpenAIInsufficientQuotaCode,
   TOOL_RESULT_MEDIA_PLACEHOLDER,
@@ -253,12 +254,11 @@ function errorFromOpenAIResponsesEvent(
   if (isContextOverflowErrorCode(code)) {
     return new APIContextOverflowError(400, fullMessage);
   }
-  // Quota/balance exhaustion first — otherwise an `insufficient_quota` event
-  // falls through to the base ChatProviderError (whose unclassified fallback
-  // is retryable), and a quota message with an embedded status_code=429 would
-  // classify as a retryable rate limit. Only OpenAI's own documented code is
-  // recognized here; vendor-specific quota signals live with their vendor.
-  if (isOpenAIInsufficientQuotaCode(code)) {
+  if (
+    isOpenAIInsufficientQuotaCode(code) ||
+    isGenericQuotaExhaustedMessage(message) ||
+    isGenericQuotaExhaustedMessage(code ?? '')
+  ) {
     return new APIProviderQuotaExhaustedError(fullMessage);
   }
   if (code === 'rate_limit_exceeded' || readEmbeddedStatusCode(message) === 429) {


### PR DESCRIPTION
## Related Issue

Relates to Meta Muse Spark strict tool-schema validation and Alibaba/DashScope token-plan quota exhaustion causing stuck retries.

## Problem

1. **Meta Muse Spark 400**: `^[a-zA-Z0-9@#%^&*()_+\-=[\]{}|;:,.<>?~\`]*$ is not a "regex"` — Spark validates tool `parameters` as JSON Schema strictly; keyword is `pattern`, not `regex`. Some MCP/openapi imports emit `regex`, so the request fails before any inference.

2. **Alibaba token plan stuck on quota**: DashScope `sk-sp-H.HMXYM…` token (Alibaba Cloud) when quota runs out returns `429` billing phrases (`Arrearage`/`arrears`/`check your account balance`/`quota exceeded`). Host classified it as retryable rate-limit and retried in a loop; needs fast-fail as `quota_exhausted` (non-retryable).

## What changed

- **openai-common (kosong + agent-core-v2)**: make `isOpenAIInsufficientQuotaCode` case-insensitive; add `isGenericQuotaExhaustedMessage` anchored to Kimi billing wordings + `Arrearage`/`arrearage`; `isOpenAIInsufficientQuotaError` now uses it — Alibaba/DashScope 429 now fast-fails as `APIProviderQuotaExhaustedError` instead of retrying.

- **openai-responses (both)**: stream error `errorFromOpenAIResponsesEvent` also fast-fails when `code` or `message` matches quota billing phrases.

- **kimi-schema (both) + mcp types (both)**: normalize stray `regex` → `pattern` (delete `regex` if `pattern` absent) at Kimi schema normalization and at MCP `assertMcpInputSchema` import. Fixes Muse Spark 400 on imported schemas with `regex: "^[a-zA-Z0-9@#%^&*()_+\-=[\]{}|;:,.<>?~\`]*$"`.

<img width="834" height="244" alt="image" src="https://github.com/user-attachments/assets/17c0c41a-77a0-467b-abb3-226881659b13" />


## Checklist

- [x] I have read the CONTRIBUTING document.
- [x] I have explained the problem above.
- [x] Ran `gen-changesets` skill — `.changeset/quota-and-schema-hardening.md`
