### PR TITLE
docs(changelog): sync 0.35.0 from apps/kimi-code/CHANGELOG.md

### DIFF
--- a/docs/en/release-notes/changelog.md
+++ b/docs/en/release-notes/changelog.md
@@ -6,6 +6,19 @@ outline: 2
 
 This page documents the changes in each Kimi Code CLI release.
 
+## 0.35.0 (2026-08-12)
+
+### Features
+
+- Show the live work progress of background subagents in the `/tasks` panel.
+
+### Bug Fixes
+
+- Fix coder subagents spawning further subagents by default.
+- Fix the token counts reported after compaction reading far below the real context size; they now match the numbers shown while the session runs.
+- Fix two binary-planting risks on Windows.
+- Fix several known issues and make various refinements. See the [changelog on GitHub](https://github.com/MoonshotAI/kimi-code/blob/main/apps/kimi-code/CHANGELOG.md) for more technical entries.
+
 ## 0.34.0 (2026-08-06)
 
 ### Features

--- a/docs/en/release-notes/changelog.md
+++ b/docs/en/release-notes/changelog.md
@@ -10,6 +10,7 @@ This page documents the changes in each Kimi Code CLI release.
 
 ### Features
 
+- Add the Modern Web Guidance plugin to the bundled plugin marketplace. Run `/plugins` and select Modern Web Guidance to install it.
 - Show the live work progress of background subagents in the `/tasks` panel.
 
 ### Bug Fixes

--- a/docs/zh/release-notes/changelog.md
+++ b/docs/zh/release-notes/changelog.md
@@ -10,6 +10,7 @@ outline: 2
 
 ### 新功能
 
+- 内置插件市场新增 Modern Web Guidance 插件，通过 `/plugins` 选择 Modern Web Guidance 安装。
 - `/tasks` 面板现实时展示后台子 Agent 的工作进度。
 
 ### 修复

--- a/docs/zh/release-notes/changelog.md
+++ b/docs/zh/release-notes/changelog.md
@@ -6,6 +6,19 @@ outline: 2
 
 本页记录 Kimi Code CLI 每个版本的变更内容。
 
+## 0.35.0（2026-08-12）
+
+### 新功能
+
+- `/tasks` 面板现实时展示后台子 Agent 的工作进度。
+
+### 修复
+
+- 修复 coder 子 Agent 默认可继续派生子 Agent 的问题。
+- 修复压缩后 token 数显示偏低的问题，现在与会话中看到的数字一致。
+- 修复 Windows 上的两处二进制植入风险。
+- 修复了一些已知问题，并做了若干细节优化。更详细的变更记录见 [GitHub](https://github.com/MoonshotAI/kimi-code/blob/main/apps/kimi-code/CHANGELOG.md)。
+
 ## 0.34.0（2026-08-06）
 
 ### 新功能


### PR DESCRIPTION
## Related Issue

N/A — post-release docs maintenance

## Problem

The docs-site changelog has not yet been synced for `0.35.0` after the npm release.

## What changed

- Synced `0.35.0` from `apps/kimi-code/CHANGELOG.md` into `docs/en/release-notes/changelog.md`
- Translated the new English increment into `docs/zh/release-notes/changelog.md`
- Curated per the sync-changelog gates: kept 1 feature (`/tasks` live subagent progress) and 3 fixes (coder subagent delegation default, post-compaction token counts, Windows binary-planting pair merged); folded the remaining 16 low-signal entries into the catch-all line
- Verified with `pnpm --filter kimi-code-docs run build`

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [ ] I have added tests that prove my feature works. (N/A — docs-only sync)
- [x] Ran `gen-changesets` skill, or this PR needs no changeset. (No changeset — docs sync is out of bundle)
- [x] Ran `gen-docs` skill, or this PR needs no doc update. (This PR is the dedicated changelog sync)