### PR TITLE
feat(plugins): add Modern Web Guidance to marketplace

### DIFF
--- a/.changeset/add-modern-web-guidance.md
+++ b/.changeset/add-modern-web-guidance.md
@@ -1,5 +1,0 @@
----
-"@moonshot-ai/kimi-code": patch
----
-
-Add the Modern Web Guidance plugin to the bundled plugin marketplace. Run /plugins and select Modern Web Guidance to install it.

--- a/.changeset/add-modern-web-guidance.md
+++ b/.changeset/add-modern-web-guidance.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Add the Modern Web Guidance plugin to the bundled plugin marketplace. Run /plugins and select Modern Web Guidance to install it.

--- a/apps/kimi-code/CHANGELOG.md
+++ b/apps/kimi-code/CHANGELOG.md
@@ -50,6 +50,8 @@
 
 - [#2813](https://github.com/MoonshotAI/kimi-code/pull/2813) [`619564d`](https://github.com/MoonshotAI/kimi-code/commit/619564dcf9ee10a3cfbf7ecbc764c6b9b63fc91b) Thanks [@wbxl2000](https://github.com/wbxl2000)! - Fix the web UI repeatedly losing its realtime connection every ~30 seconds when the server runs behind a reverse proxy or gateway with an idle connection timeout; the server now sends a WebSocket heartbeat and only closes connections that stop responding entirely.
 
+- [#2842](https://github.com/MoonshotAI/kimi-code/pull/2842) [`e476c5a`](https://github.com/MoonshotAI/kimi-code/commit/e476c5a8bbe68fb0b6eb0096aa1efcb893b1a8fc) Thanks [@wbxl2000](https://github.com/wbxl2000)! - Add the Modern Web Guidance plugin to the bundled plugin marketplace. Run /plugins and select Modern Web Guidance to install it.
+
 ## 0.34.0
 
 ### Minor Changes

--- a/plugins/marketplace.json
+++ b/plugins/marketplace.json
@@ -36,6 +36,15 @@
       "homepage": "https://vercel.com/docs/agent-resources/vercel-plugin",
       "keywords": ["vercel", "deployment", "nextjs", "skills", "agents"],
       "source": "https://github.com/vercel/vercel-plugin"
+    },
+    {
+      "id": "modern-web-guidance",
+      "tier": "curated",
+      "displayName": "Modern Web Guidance",
+      "description": "Modern web platform expertise, best practices, and browser compatibility data for coding agents, from the Google Chrome team.",
+      "homepage": "https://github.com/GoogleChrome/modern-web-guidance",
+      "keywords": ["web", "css", "browser", "frontend", "skills"],
+      "source": "https://github.com/GoogleChrome/modern-web-guidance"
     }
   ]
 }


### PR DESCRIPTION
## Related Issue

N/A — see the problem section below.

## Problem

Kimi Code supports installing the Google Chrome team's [Modern Web Guidance](https://github.com/GoogleChrome/modern-web-guidance) plugin (`/plugins install https://github.com/GoogleChrome/modern-web-guidance`), but it is not listed in the bundled plugin marketplace, so users cannot discover it from `/plugins`.

## What changed

- Added `modern-web-guidance` (curated tier) to `plugins/marketplace.json`, sourced from https://github.com/GoogleChrome/modern-web-guidance — a set of skills that embed modern web platform expertise, best practices, and browser compatibility data into coding agents.
- No changeset in this PR: the changelog entry was added directly to the [0.35.0 release notes](https://github.com/MoonshotAI/kimi-code/releases/tag/%40moonshot-ai/kimi-code%400.35.0), so the changeset-bot "No Changeset found" warning is expected.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [ ] I have added tests that prove my feature works. (N/A — marketplace metadata only; JSON validity verified.)
- [x] Ran `gen-changesets` skill, or this PR needs no changeset. (Changelog entry backfilled into the 0.35.0 release notes instead.)
- [x] Ran `gen-docs` skill, or this PR needs no doc update. (No doc update needed — the plugin is discoverable via `/plugins`.)
