### PR TITLE
docs(changelog): thank security reporters for Windows binary-planting reports

### DIFF
--- a/docs/en/release-notes/changelog.md
+++ b/docs/en/release-notes/changelog.md
@@ -17,7 +17,7 @@ This page documents the changes in each Kimi Code CLI release.
 
 - Fix coder subagents spawning further subagents by default.
 - Fix the token counts reported after compaction reading far below the real context size; they now match the numbers shown while the session runs.
-- Fix two binary-planting risks on Windows.
+- Fix two binary-planting risks on Windows. Thanks [@Leakless](https://github.com/Leakless) and [@winmin](https://github.com/winmin) for reporting them.
 - Fix several known issues and make various refinements. See the [changelog on GitHub](https://github.com/MoonshotAI/kimi-code/blob/main/apps/kimi-code/CHANGELOG.md) for more technical entries.
 
 ## 0.34.0 (2026-08-06)

--- a/docs/zh/release-notes/changelog.md
+++ b/docs/zh/release-notes/changelog.md
@@ -17,7 +17,7 @@ outline: 2
 
 - 修复 coder 子 Agent 默认可继续派生子 Agent 的问题。
 - 修复压缩后 token 数显示偏低的问题，现在与会话中看到的数字一致。
-- 修复 Windows 上的两处二进制植入风险。
+- 修复 Windows 上的两处二进制植入风险。感谢 [@Leakless](https://github.com/Leakless) 与 [@winmin](https://github.com/winmin) 报告这些问题。
 - 修复了一些已知问题，并做了若干细节优化。更详细的变更记录见 [GitHub](https://github.com/MoonshotAI/kimi-code/blob/main/apps/kimi-code/CHANGELOG.md)。
 
 ## 0.34.0（2026-08-06）


### PR DESCRIPTION
## Related Issue

N/A — post-release docs maintenance (follow-up to #2841, which merged before this addition).

## Problem

The 0.35.0 changelog entry for the Windows binary-planting fixes did not credit the reporters who disclosed the vulnerabilities.

## What changed

- Appended a thanks to the 0.35.0 Windows binary-planting entry on both changelog pages, crediting [@Leakless](https://github.com/Leakless) and [@winmin](https://github.com/winmin) for reporting the issues.
- This is a deliberate reporter acknowledgment requested by the maintainer, distinct from the changesets PR-author credits that the sync flow strips.
- Verified with `pnpm --filter kimi-code-docs run build`.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [ ] I have added tests that prove my feature works. (N/A — docs-only)
- [x] Ran `gen-changesets` skill, or this PR needs no changeset. (No changeset — docs sync is out of bundle)
- [x] Ran `gen-docs` skill, or this PR needs no doc update. (This PR is part of the dedicated changelog sync flow)
