### PR TITLE
chore(changelog): thank security reporters in 0.35.0 entry

### DIFF
--- a/apps/kimi-code/CHANGELOG.md
+++ b/apps/kimi-code/CHANGELOG.md
@@ -52,6 +52,8 @@
 
 - [#2842](https://github.com/MoonshotAI/kimi-code/pull/2842) [`e476c5a`](https://github.com/MoonshotAI/kimi-code/commit/e476c5a8bbe68fb0b6eb0096aa1efcb893b1a8fc) Thanks [@wbxl2000](https://github.com/wbxl2000)! - Add the Modern Web Guidance plugin to the bundled plugin marketplace. Run /plugins and select Modern Web Guidance to install it.
 
+- Thanks [@Leakless](https://github.com/Leakless) and [@winmin](https://github.com/winmin) for reporting the Windows binary-planting issues fixed in this release.
+
 ## 0.34.0
 
 ### Minor Changes


### PR DESCRIPTION
## Related Issue

N/A — post-release changelog maintenance.

## Problem

The 0.35.0 entry in `apps/kimi-code/CHANGELOG.md` does not credit the reporters who disclosed the Windows binary-planting vulnerabilities fixed in #2695 and #2838.

## What changed

- Appended a reporter thanks line to the end of the 0.35.0 block, crediting [@Leakless](https://github.com/Leakless) and [@winmin](https://github.com/winmin) for reporting the Windows binary-planting issues fixed in this release.
- The same line was added to the `@moonshot-ai/kimi-code@0.35.0` GitHub Release notes.
- Maintainer-requested, deliberate reporter acknowledgment — distinct from the changesets PR-author credits. The 0.35.0 block is already released, so changesets will not regenerate or overwrite it.
- The docs-site changelog intentionally does not carry this line (decided with the maintainer; see closed #2844).

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [ ] I have added tests that prove my feature works. (N/A — changelog text only)
- [x] Ran `gen-changesets` skill, or this PR needs no changeset. (No changeset — editing an already-released changelog entry does not enter the bundle)
- [x] Ran `gen-docs` skill, or this PR needs no doc update. (Docs changelog intentionally not updated)
