### PR TITLE
fix(tui): detect external session wire-file appends before accepting input

### DIFF
--- a/.changeset/tui-wire-staleness-backward-scan.md
+++ b/.changeset/tui-wire-staleness-backward-scan.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+TUI: detect external wire-journal appends even when a turn's response or tool output exceeds 64 KiB. `readWireTurnBoundaryTime` now scans backward past the tail read window to locate the newest `turn.prompt` boundary, so the staleness guard no longer fails open for large external appends.

--- a/apps/kimi-code/src/tui/controllers/session-event-handler.ts
+++ b/apps/kimi-code/src/tui/controllers/session-event-handler.ts
@@ -117,6 +117,8 @@ export interface SessionEventHost {
   handleShellStarted(event: { commandId: string; taskId: string }): void;
   sendNormalUserInput(text: string): void;
   updateTerminalTitle(): void;
+  /** Re-read the active session's wire journal into the staleness baseline. */
+  refreshWireTipFromDisk(): void;
   sendQueuedMessage(session: Session, item: QueuedMessage): void;
   shiftQueuedMessage(): QueuedMessage | undefined;
   readonly btwPanelController: BtwPanelController;
@@ -398,6 +400,9 @@ export class SessionEventHandler {
     }
     this.pluginMcpToolsUsedInTurn.clear();
     this.scheduleQueuedGoalPromotion();
+    // The turn's journal records are now on disk; advance the staleness
+    // baseline so the next input is not mistaken for an external append.
+    this.host.refreshWireTipFromDisk();
   }
 
   private handleStepBegin(event: TurnStepStartedEvent): void {

--- a/apps/kimi-code/src/tui/kimi-tui.ts
+++ b/apps/kimi-code/src/tui/kimi-tui.ts
@@ -178,6 +178,10 @@ import {
   groupTurns,
   turnsToTrim,
 } from './utils/transcript-window';
+import {
+  readWireTurnBoundaryTime,
+  wireTailAheadOfTranscript,
+} from './utils/wire-staleness';
 
 export type { TUIState } from './tui-state';
 export { createTUIState } from './tui-state';
@@ -360,6 +364,16 @@ export class KimiTUI {
   private currentLoadingTip: { kind: LoadingTipKind; tip: string | undefined } | undefined =
     undefined;
   private lastHistoryContent: string | undefined;
+  /**
+   * The newest user-turn timestamp this TUI has observed on the active
+   * session's wire journal (seeded at session switch, advanced after each turn
+   * ends). The send guard compares the live journal against this to detect
+   * turns appended by external clients. `undefined` until a session exposes a
+   * readable journal (fresh sessions start undefined and stay fail-open).
+   */
+  private wireTipTime: number | undefined;
+  /** In-flight {@link refreshWireTipFromDisk} read, awaited by the send guard. */
+  private wireTipRefresh: Promise<void> | null = null;
   // Live `!` shell output entries, keyed by commandId so concurrent commands
   // each update their own card and stale events are dropped. Mutated in place
   // as `shell.output` events arrive; removed when the command completes.
@@ -1275,6 +1289,56 @@ export class KimiTUI {
     this.updateQueueDisplay();
   }
 
+  /**
+   * Re-read the active session's newest wire user-turn into {@link wireTipTime}.
+   * Failures keep the last observed tip so the guard stays fail-open.
+   */
+  refreshWireTipFromDisk(): void {
+    const sessionDir = this.session?.summary?.sessionDir;
+    if (sessionDir === undefined) return;
+    const task = readWireTurnBoundaryTime(sessionDir, MAIN_AGENT_ID)
+      .then((time) => {
+        this.wireTipTime = time;
+      })
+      .catch(() => {
+        // Keep the last observed tip; the guard fails open when unreadable.
+      });
+    this.wireTipRefresh = task;
+    void task.finally(() => {
+      if (this.wireTipRefresh === task) this.wireTipRefresh = null;
+    });
+  }
+
+  /**
+   * Block a prompt when an external client has appended a turn to the session's
+   * wire journal after this TUI last rendered one. Sending anyway would fork
+   * the session into two divergent histories, so the user is told to resume
+   * fresh instead. Only meaningful while the session is idle — in-flight input
+   * is queued by the caller and must not be gated on the live journal.
+   */
+  private async assertWireFresh(session: Session): Promise<boolean> {
+    if (this.state.appState.streamingPhase !== 'idle') return false;
+    // A tip refresh kicked off by the last turn may still be in flight; await
+    // it so the comparison never sees a stale baseline and false-positives.
+    if (this.wireTipRefresh !== null) {
+      await this.wireTipRefresh.catch(() => undefined);
+    }
+    const sessionDir = session.summary?.sessionDir;
+    if (sessionDir === undefined) return false;
+    const wireTailTime = await readWireTurnBoundaryTime(sessionDir, MAIN_AGENT_ID).catch(
+      () => undefined,
+    );
+    if (!wireTailAheadOfTranscript({ transcriptTipTime: this.wireTipTime, wireTailTime })) {
+      return false;
+    }
+    this.showStatus(
+      'Session was modified outside this terminal; your transcript is out of date.\n' +
+        `Resume with: kimi -S ${quoteShellArg(session.id)} to reload the latest history before continuing.`,
+      'warning',
+    );
+    return true;
+  }
+
   async sendNormalUserInput(text: string, preExtracted?: ExtractionResult): Promise<void> {
     if (this.btwPanelController.sendUserInput(text)) return;
     if (this.state.appState.model.trim().length === 0) {
@@ -1310,6 +1374,14 @@ export class KimiTUI {
       }
       session = await this.ensureSession();
       if (session === undefined) return;
+    }
+    // An external client may have appended turns to the session's wire journal
+    // while this TUI was idle. Sending now would continue from a stale context
+    // and silently fork the session, so refuse until the user resumes fresh.
+    if (await this.assertWireFresh(session)) {
+      this.updateQueueDisplay();
+      this.state.ui.requestRender();
+      return;
     }
     if (extraction.hasMedia) {
       this.sendMessage(session, text, {
@@ -1882,6 +1954,9 @@ export class KimiTUI {
     this.harness.setTelemetryContext({ sessionId: session.id });
     this.registerSessionHandlers(session);
     this.syncAdditionalDirs(session);
+    // Seed the wire staleness baseline for the newly active session (fresh
+    // sessions yield `undefined` and stay fail-open until their first turn).
+    this.refreshWireTipFromDisk();
   }
 
   async syncRuntimeState(session: Session = this.requireSession()): Promise<void> {

--- a/apps/kimi-code/src/tui/utils/wire-staleness.ts
+++ b/apps/kimi-code/src/tui/utils/wire-staleness.ts
@@ -28,7 +28,7 @@ export function agentWirePath(sessionDir: string, agentId: string): string {
   return join(sessionDir, 'agents', agentId, 'wire.jsonl');
 }
 
-/** How many trailing bytes of the journal we read to locate the newest turn. */
+/** Size of the backward scan windows used to locate the newest turn. */
 const WIRE_TAIL_READ_BYTES = 64 * 1024;
 
 /**
@@ -49,7 +49,7 @@ export function lastTurnBoundaryTimeInChunk(chunk: string): number | undefined {
     try {
       record = JSON.parse(line) as { type?: unknown; time?: unknown };
     } catch {
-      // Fragment from the tail-read boundary — keep scanning upward.
+      // Fragment from the read boundary — keep scanning upward.
       continue;
     }
     if (typeof record.time === 'number' && TURN_BOUNDARY_TYPES.has(record.type as string)) {
@@ -76,9 +76,17 @@ export function wireTailAheadOfTranscript(opts: {
 /**
  * Read the newest user-turn timestamp of an agent's `wire.jsonl`.
  *
- * Failures (missing session dir, unreadable journal, a tail record larger than
- * {@link WIRE_TAIL_READ_BYTES}) degrade to `undefined` so the staleness guard
- * always fails open rather than blocking the user on a corrupt file.
+ * Walks backward from the journal tail in {@link WIRE_TAIL_READ_BYTES} windows
+ * until a `turn.prompt` boundary is found or the start of the file is reached,
+ * so a single external turn whose response/tool output spans more than one
+ * window cannot hide its prompt boundary. A record split across a read
+ * boundary is reassembled before scanning: the fragment at the top of each
+ * window is the tail half of a record whose head lives at the end of the next
+ * (older) window, and the two are joined back into one line.
+ *
+ * Failures (missing session dir, unreadable journal) degrade to `undefined`
+ * so the staleness guard always fails open rather than blocking the user on a
+ * corrupt file.
  */
 export async function readWireTurnBoundaryTime(
   sessionDir: string,
@@ -89,10 +97,35 @@ export async function readWireTurnBoundaryTime(
     try {
       const { size } = await file.stat();
       if (size <= 0) return undefined;
-      const length = Math.min(size, WIRE_TAIL_READ_BYTES);
-      const buffer = Buffer.alloc(length);
-      await file.read(buffer, 0, length, size - length);
-      return lastTurnBoundaryTimeInChunk(buffer.toString('utf8'));
+      let offset = size;
+      // Tail half of the record split by the last read boundary; its head is
+      // the final line of the next (older) window.
+      let carry = '';
+      while (offset > 0) {
+        const start = Math.max(0, offset - WIRE_TAIL_READ_BYTES);
+        const length = offset - start;
+        const buffer = Buffer.alloc(length);
+        await file.read(buffer, 0, length, start);
+        const chunk = buffer.toString('utf8');
+        const firstNl = chunk.indexOf('\n');
+        if (firstNl >= 0) {
+          // The first line may be the tail half of a split record; the rest
+          // are complete. Appending the carried tail to the window's own last
+          // line (the head half) reassembles the split record, which is the
+          // newest line this window contributes and is scanned first.
+          const rest = chunk.slice(firstNl + 1);
+          const time = lastTurnBoundaryTimeInChunk(rest + carry);
+          if (time !== undefined) return time;
+          carry = chunk.slice(0, firstNl);
+        } else {
+          // The whole window is one un-terminated record — accumulate it with
+          // the carried tail so the record is reassembled in an older window.
+          carry = chunk + carry;
+        }
+        offset = start;
+      }
+      // The oldest record reached the head of the file still split.
+      return carry.length > 0 ? lastTurnBoundaryTimeInChunk(carry) : undefined;
     } finally {
       await file.close();
     }

--- a/apps/kimi-code/src/tui/utils/wire-staleness.ts
+++ b/apps/kimi-code/src/tui/utils/wire-staleness.ts
@@ -1,0 +1,102 @@
+/**
+ * Staleness detection for the interactive TUI transcript vs the session's
+ * on-disk wire journal.
+ *
+ * The TUI renders a pure in-memory transcript while the engine persists every
+ * op to `<sessionDir>/agents/<agentId>/wire.jsonl`. External clients (ACP
+ * attach, mobile) can append turns to that journal without the TUI ever seeing
+ * an event, so the user would keep typing against a stale context and silently
+ * fork the session into two divergent histories. These helpers let the TUI
+ * compare the newest user-turn it has rendered against the journal's newest
+ * user-turn before accepting the next input.
+ *
+ * The comparison deliberately keys on `turn.prompt` records rather than any
+ * timestamped record: compaction, plan-mode toggles and config writes advance
+ * the journal tail without opening a new conversational turn, so they must not
+ * count as external activity. `turn.prompt` is the wire's authoritative
+ * user-turn boundary (see `agent-core-v2/src/agent/loop/turnOps.ts`).
+ */
+
+import { open } from 'node:fs/promises';
+import { join } from 'node:path';
+
+/** Record types that open a new conversational turn in the wire journal. */
+const TURN_BOUNDARY_TYPES = new Set(['turn.prompt']);
+
+/** Path of an agent's persisted journal inside a session directory. */
+export function agentWirePath(sessionDir: string, agentId: string): string {
+  return join(sessionDir, 'agents', agentId, 'wire.jsonl');
+}
+
+/** How many trailing bytes of the journal we read to locate the newest turn. */
+const WIRE_TAIL_READ_BYTES = 64 * 1024;
+
+/**
+ * Extract the newest user-turn (`turn.prompt`) timestamp from a chunk read off
+ * the tail of a JSONL wire journal.
+ *
+ * A tail chunk may begin mid-record (the read boundary split a line); the scan
+ * runs from the last line upward, skipping fragments that fail to parse and
+ * non-boundary records. Returns `undefined` when the chunk holds no complete
+ * `turn.prompt` record with a numeric `time`.
+ */
+export function lastTurnBoundaryTimeInChunk(chunk: string): number | undefined {
+  const lines = chunk.split('\n');
+  for (let i = lines.length - 1; i >= 0; i -= 1) {
+    const line = lines[i]!.trim();
+    if (line.length === 0) continue;
+    let record: { type?: unknown; time?: unknown };
+    try {
+      record = JSON.parse(line) as { type?: unknown; time?: unknown };
+    } catch {
+      // Fragment from the tail-read boundary — keep scanning upward.
+      continue;
+    }
+    if (typeof record.time === 'number' && TURN_BOUNDARY_TYPES.has(record.type as string)) {
+      return record.time;
+    }
+  }
+  return undefined;
+}
+
+/**
+ * True when the wire journal has a user-turn newer than the newest turn the
+ * TUI has rendered — i.e. an external client appended a turn the user never
+ * saw. Fails open (false) whenever either side is unknown.
+ */
+export function wireTailAheadOfTranscript(opts: {
+  readonly transcriptTipTime: number | undefined;
+  readonly wireTailTime: number | undefined;
+}): boolean {
+  const { transcriptTipTime, wireTailTime } = opts;
+  if (transcriptTipTime === undefined || wireTailTime === undefined) return false;
+  return wireTailTime > transcriptTipTime;
+}
+
+/**
+ * Read the newest user-turn timestamp of an agent's `wire.jsonl`.
+ *
+ * Failures (missing session dir, unreadable journal, a tail record larger than
+ * {@link WIRE_TAIL_READ_BYTES}) degrade to `undefined` so the staleness guard
+ * always fails open rather than blocking the user on a corrupt file.
+ */
+export async function readWireTurnBoundaryTime(
+  sessionDir: string,
+  agentId: string,
+): Promise<number | undefined> {
+  try {
+    const file = await open(agentWirePath(sessionDir, agentId), 'r');
+    try {
+      const { size } = await file.stat();
+      if (size <= 0) return undefined;
+      const length = Math.min(size, WIRE_TAIL_READ_BYTES);
+      const buffer = Buffer.alloc(length);
+      await file.read(buffer, 0, length, size - length);
+      return lastTurnBoundaryTimeInChunk(buffer.toString('utf8'));
+    } finally {
+      await file.close();
+    }
+  } catch {
+    return undefined;
+  }
+}

--- a/apps/kimi-code/test/tui/wire-staleness.test.ts
+++ b/apps/kimi-code/test/tui/wire-staleness.test.ts
@@ -4,19 +4,26 @@
  * next input silently forks the conversation.
  *
  * Responsibilities: `lastTurnBoundaryTimeInChunk` recovers the newest user-turn
- * (`turn.prompt`) timestamp from a wire-journal tail chunk, and
- * `wireTailAheadOfTranscript` decides staleness by comparing that against the
- * newest turn the in-memory transcript has rendered.
+ * (`turn.prompt`) timestamp from a wire-journal tail chunk,
+ * `readWireTurnBoundaryTime` locates that boundary in the on-disk journal even
+ * when it has been pushed past the tail read window, and
+ * `wireTailAheadOfTranscript` decides staleness by comparing the boundary
+ * against the newest turn the in-memory transcript has rendered.
  *
- * Wiring: pure helpers only — no TUI or SDK imports, so the check runs without
- * any terminal, session, or engine dependency.
+ * Wiring: pure helpers + a single file read only — no TUI or SDK imports, so
+ * the check runs without any terminal, session, or engine dependency.
  * Run: pnpm -C apps/kimi-code exec vitest run test/tui/wire-staleness.test.ts
  */
 
+import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { describe, expect, it } from 'vitest';
 
 import {
+  agentWirePath,
   lastTurnBoundaryTimeInChunk,
+  readWireTurnBoundaryTime,
   wireTailAheadOfTranscript,
 } from '@/tui/utils/wire-staleness';
 
@@ -103,5 +110,97 @@ describe('lastTurnBoundaryTimeInChunk', () => {
   it('ignores empty trailing lines and returns the newest complete record', () => {
     const chunk = '{"type":"turn.prompt","time":100,"input":{}}\n\n';
     expect(lastTurnBoundaryTimeInChunk(chunk)).toBe(100);
+  });
+});
+
+describe('readWireTurnBoundaryTime', () => {
+  /** Writes a journal and runs the assertion against it, cleaning up after. */
+  async function withJournal(
+    lines: string[],
+    run: (dir: string, agentId: string) => Promise<void>,
+  ): Promise<void> {
+    const dir = await mkdtemp(join(tmpdir(), 'wire-staleness-'));
+    try {
+      const agentId = 'agent-1';
+      await mkdir(join(dir, 'agents', agentId), { recursive: true });
+      await writeFile(agentWirePath(dir, agentId), lines.join('\n'));
+      await run(dir, agentId);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  }
+
+  it('reads the newest `turn.prompt` from a small journal', async () => {
+    await withJournal(
+      [
+        '{"type":"metadata","protocol_version":"1","created_at":10}',
+        '{"type":"turn.prompt","time":100,"input":{}}',
+        '{"type":"turn.ended","time":200,"turnId":1,"reason":"completed"}',
+        '{"type":"turn.prompt","time":300,"input":{}}',
+        '{"type":"usage.record","time":400,"usage":{}}',
+      ],
+      async (dir, agentId) => {
+        await expect(readWireTurnBoundaryTime(dir, agentId)).resolves.toBe(300);
+      },
+    );
+  });
+
+  it('recovers a `turn.prompt` pushed past the 64 KiB tail window by a large post-prompt record', async () => {
+    await withJournal(
+      [
+        '{"type":"metadata","protocol_version":"1","created_at":10}',
+        '{"type":"turn.prompt","time":100,"input":{}}',
+        // A single tool-output record larger than the 64 KiB tail read window
+        // sits between the prompt and the journal tail. A single tail read
+        // would only see the end of this record plus the newer records, miss
+        // the prompt boundary, and fail open — the exact silent-fork path this
+        // guard exists to catch.
+        `{"type":"context.append_loop_event","time":200,"event":{"type":"content.part","part":{"type":"text","text":"${'x'.repeat(80 * 1024)}"}}}`,
+        '{"type":"usage.record","time":300,"usage":{}}',
+      ],
+      async (dir, agentId) => {
+        await expect(readWireTurnBoundaryTime(dir, agentId)).resolves.toBe(100);
+      },
+    );
+  });
+
+  it('recovers a `turn.prompt` when a record spanning several windows sits after it', async () => {
+    await withJournal(
+      [
+        '{"type":"turn.prompt","time":50,"input":{}}',
+        `{"type":"context.append_loop_event","time":60,"event":{"type":"content.part","part":{"type":"text","text":"${'y'.repeat(200 * 1024)}"}}}`,
+        '{"type":"usage.record","time":70,"usage":{}}',
+      ],
+      async (dir, agentId) => {
+        await expect(readWireTurnBoundaryTime(dir, agentId)).resolves.toBe(50);
+      },
+    );
+  });
+
+  it('fails open (undefined) when the journal holds no user-turn record', async () => {
+    await withJournal(
+      [
+        '{"type":"metadata","protocol_version":"1","created_at":10}',
+        `{"type":"context.append_loop_event","time":20,"event":{"type":"content.part","part":{"type":"text","text":"${'z'.repeat(80 * 1024)}"}}}`,
+        '{"type":"usage.record","time":30,"usage":{}}',
+      ],
+      async (dir, agentId) => {
+        await expect(readWireTurnBoundaryTime(dir, agentId)).resolves.toBeUndefined();
+      },
+    );
+  });
+
+  it('fails open (undefined) for an empty journal, missing session, or missing agent', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'wire-staleness-'));
+    try {
+      const agentId = 'agent-1';
+      await mkdir(join(dir, 'agents', agentId), { recursive: true });
+      await writeFile(agentWirePath(dir, agentId), '');
+      await expect(readWireTurnBoundaryTime(dir, agentId)).resolves.toBeUndefined();
+      await expect(readWireTurnBoundaryTime('/nonexistent-session', agentId)).resolves.toBeUndefined();
+      await expect(readWireTurnBoundaryTime(dir, 'no-such-agent')).resolves.toBeUndefined();
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
   });
 });

--- a/apps/kimi-code/test/tui/wire-staleness.test.ts
+++ b/apps/kimi-code/test/tui/wire-staleness.test.ts
@@ -1,0 +1,107 @@
+/**
+ * Scenario: the interactive TUI detects when an external client has appended
+ * turns to the session's wire journal so it can warn the user before their
+ * next input silently forks the conversation.
+ *
+ * Responsibilities: `lastTurnBoundaryTimeInChunk` recovers the newest user-turn
+ * (`turn.prompt`) timestamp from a wire-journal tail chunk, and
+ * `wireTailAheadOfTranscript` decides staleness by comparing that against the
+ * newest turn the in-memory transcript has rendered.
+ *
+ * Wiring: pure helpers only — no TUI or SDK imports, so the check runs without
+ * any terminal, session, or engine dependency.
+ * Run: pnpm -C apps/kimi-code exec vitest run test/tui/wire-staleness.test.ts
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import {
+  lastTurnBoundaryTimeInChunk,
+  wireTailAheadOfTranscript,
+} from '@/tui/utils/wire-staleness';
+
+describe('wireTailAheadOfTranscript', () => {
+  it('detects a wire user-turn newer than the in-memory transcript tip', () => {
+    expect(
+      wireTailAheadOfTranscript({
+        transcriptTipTime: 1_700_000_000_000,
+        wireTailTime: 1_700_000_500_000,
+      }),
+    ).toBe(true);
+  });
+
+  it('is false when the wire user-turn matches the transcript tip', () => {
+    expect(
+      wireTailAheadOfTranscript({
+        transcriptTipTime: 1_700_000_500_000,
+        wireTailTime: 1_700_000_500_000,
+      }),
+    ).toBe(false);
+  });
+
+  it('is false when the wire user-turn predates the transcript tip', () => {
+    expect(
+      wireTailAheadOfTranscript({
+        transcriptTipTime: 1_700_000_500_000,
+        wireTailTime: 1_700_000_000_000,
+      }),
+    ).toBe(false);
+  });
+
+  it('fails open when either timestamp is unknown', () => {
+    expect(
+      wireTailAheadOfTranscript({ transcriptTipTime: undefined, wireTailTime: 1_700_000_500_000 }),
+    ).toBe(false);
+    expect(
+      wireTailAheadOfTranscript({ transcriptTipTime: 1_700_000_000_000, wireTailTime: undefined }),
+    ).toBe(false);
+    expect(
+      wireTailAheadOfTranscript({ transcriptTipTime: undefined, wireTailTime: undefined }),
+    ).toBe(false);
+  });
+});
+
+describe('lastTurnBoundaryTimeInChunk', () => {
+  it('returns the newest `turn.prompt` time, skipping non-boundary records', () => {
+    const chunk = [
+      '{"type":"turn.prompt","time":100,"input":{"input":[],"origin":{}}}',
+      '{"type":"turn.ended","time":200,"turnId":1,"reason":"completed"}',
+      '{"type":"context.append_loop_event","time":300,"event":{"type":"content.part","part":{"type":"text","text":"hi"}}}',
+      '{"type":"usage.record","time":400,"usage":{}}',
+    ].join('\n');
+    expect(lastTurnBoundaryTimeInChunk(chunk)).toBe(100);
+  });
+
+  it('returns the last of several `turn.prompt` records', () => {
+    const chunk = [
+      '{"type":"turn.prompt","time":100,"input":{}}',
+      '{"type":"turn.ended","time":150,"turnId":1,"reason":"completed"}',
+      '{"type":"turn.prompt","time":200,"input":{}}',
+      '{"type":"turn.ended","time":250,"turnId":2,"reason":"completed"}',
+    ].join('\n');
+    expect(lastTurnBoundaryTimeInChunk(chunk)).toBe(200);
+  });
+
+  it('returns undefined when the chunk holds no user-turn record', () => {
+    expect(
+      lastTurnBoundaryTimeInChunk(
+        '{"type":"metadata","protocol_version":"1","created_at":10}\n{"type":"usage.record","time":20,"usage":{}}\n',
+      ),
+    ).toBeUndefined();
+    expect(lastTurnBoundaryTimeInChunk('')).toBeUndefined();
+  });
+
+  it('scans past a partial line fragment from the read-tail boundary', () => {
+    // The read boundary split a long record; the fragment fails to parse and
+    // the scan keeps going until it finds the complete `turn.prompt`.
+    const chunk =
+      '{"type":"context.append_loop_event","time":1,"event":{"type":"content.part","part":{"type":"text","text":"' +
+      '\n{"type":"turn.prompt","time":300,"input":{}}';
+    expect(lastTurnBoundaryTimeInChunk(chunk)).toBe(300);
+  });
+
+  it('ignores empty trailing lines and returns the newest complete record', () => {
+    const chunk = '{"type":"turn.prompt","time":100,"input":{}}\n\n';
+    expect(lastTurnBoundaryTimeInChunk(chunk)).toBe(100);
+  });
+});


### PR DESCRIPTION
Fixes #2835

## Problem

The interactive TUI keeps a pure in-memory transcript while external clients (ACP attach / mobile) append turns to the session's `wire.jsonl`. The TUI never detects the external modification — no file-watch, no tip-vs-wire-tail comparison — so the user keeps typing into a stale context and silently forks the session into two divergent histories.

## Root cause

The send path (`sendNormalUserInput`) resolves the session and dispatches `session.prompt()` unconditionally. Nothing compares the newest turn the in-memory transcript has rendered against the journal's current tail, so external appends go unnoticed.

## Fix

Before accepting a prompt, compare the session's on-disk wire journal against the newest turn the TUI has rendered:

- New `apps/kimi-code/src/tui/utils/wire-staleness.ts` reads the newest `turn.prompt` timestamp from the tail of `<sessionDir>/agents/main/wire.jsonl` and decides whether it is ahead of the in-memory transcript tip. Keying on `turn.prompt` (the wire's authoritative user-turn boundary) means compaction, plan-mode toggles and config writes — which advance the journal without opening a turn — never false-positive.
- The TUI seeds the baseline on session switch (`setSession` -> `refreshWireTipFromDisk`) and re-reads it after each `turn.ended` so its own turns never look external.
- `sendNormalUserInput` runs `assertWireFresh` while the session is idle; when the wire is ahead it refuses the send and directs the user to resume with `kimi -S <id>` so the fork cannot happen silently.

## Test

`apps/kimi-code/test/tui/wire-staleness.test.ts` covers the pure decision logic (`wireTailAheadOfTranscript`) and the tail-chunk parser (`lastTurnBoundaryTimeInChunk`): detects a newer wire turn, picks the newest of several turns, ignores non-boundary records, scans past read-tail fragments, and fails open when either side is unknown.