### PR TITLE
test(node-sdk): stop comparing killed-task exitCode across engines

### DIFF
--- a/packages/node-sdk/test/v1-v2-parity.test.ts
+++ b/packages/node-sdk/test/v1-v2-parity.test.ts
@@ -296,9 +296,11 @@ const KNOWN_DIFFS = {
   // diverges after a detach by design (v1 keeps the foreground deadline in
   // the reported info; v2 rewrites it to the detach deadline — pinned in the
   // migration tracker), so it is deleted too; the pre-detach equality is
-  // asserted explicitly at the call site. Everything else (kind, command,
-  // description, status, detached, exitCode, stopReason, flags) compares in
-  // full.
+  // asserted explicitly at the call site. `exitCode` is deleted only for
+  // `killed` tasks, where the value is an OS race rather than an engine
+  // difference (see projectBackgroundTask). Everything else (kind, command,
+  // description, status, detached, exitCode on non-killed tasks, stopReason,
+  // flags) compares in full.
   listBackgroundTasks: (tasks: readonly BackgroundTaskInfo[]): unknown =>
     tasks.map((task) => projectBackgroundTask(task)),
   detachBackgroundTask: (info: BackgroundTaskInfo | undefined): unknown =>
@@ -354,6 +356,14 @@ function projectBackgroundTask(info: BackgroundTaskInfo): unknown {
   delete projected['startedAt'];
   delete projected['endedAt'];
   delete projected['timeoutMs'];
+  // Killing a background task signals the whole process group, and the shell
+  // settles two ways depending on which member the signal is observed on
+  // first: reaped by SIGTERM itself (`code=null`, mapped to -1) or outliving
+  // its child and exiting 128+SIGTERM (143). Both engines map the raw `exit`
+  // payload with the same `code ?? -1`, so each lands on its own side of that
+  // OS race and the two disagree at random. Status and stopReason still
+  // compare, and non-killed tasks keep their deterministic exit codes.
+  if (projected['status'] === 'killed') delete projected['exitCode'];
   return projected;
 }
 
@@ -3167,6 +3177,11 @@ describe('v1↔v2 background task parity', () => {
       ]);
       expect(projectList([v2Killed])).toEqual(projectList([v1Killed]));
       expect(v1Killed).toMatchObject({ status: 'killed', stopReason: 'parity stop' });
+      // The projection drops `exitCode` for killed tasks because the value is
+      // an OS race, not an engine difference. Both engines must still settle
+      // on a concrete code rather than leaving the field unset.
+      expect(typeof (v1Killed as { readonly exitCode?: unknown }).exitCode).toBe('number');
+      expect(typeof (v2Killed as { readonly exitCode?: unknown }).exitCode).toBe('number');
       // Active-only filtering drops the terminal task on both engines.
       const [v1Active, v2Active] = await Promise.all([
         pair.v1.listBackgroundTasks({ ...input, activeOnly: true }),


### PR DESCRIPTION
## Related Issue

No existing issue — the problem is explained below. (Searched open issues and PRs for this flake first; nothing covers it.)

## Problem

`pnpm test` intermittently fails the background-task lifecycle parity test:

```
FAIL |kimi-sdk| test/v1-v2-parity.test.ts > v1↔v2 background task parity > task lifecycle matches: list / detach / output / stop
-     "exitCode": -1      <- expected (v1)
+     "exitCode": 143     <- received (v2)
```

This is a flaky test, not an engine divergence. The killed-task step stops `sh -c "echo bg-out; sleep 30"`, and stopping signals the whole process group (`process.kill(-pid, 'SIGTERM')` — v1 `packages/kaos/src/local.ts`, v2 `packages/agent-core-v2/src/os/backends/node-local/hostProcessService.ts`). The shell then settles one of two ways depending on which group member observes the SIGTERM first:

- reaped by the signal itself → `exit` fires with `code=null, signal=SIGTERM`, which both backends map through the same `code ?? -1` to `-1`;
- it outlives `sleep` and exits with the shell's 128+15 convention → `code=143, signal=null` → `143`.

Both backends' `child.on('exit')` handlers are line-for-line identical, and so is the settle logic in v1 `ProcessBackgroundTask` and v2 `ProcessTask` — so a `143` can only come from the shell itself. I reproduced the race outside the engines with a bare `spawn` of the same command (detached, group-SIGTERM after 60ms, 40 trials): 38x `code=null signal=SIGTERM`, 2x `code=143 signal=null` on an idle machine. Each engine independently lands on either side of that coin flip, and the parity comparison fails whenever they disagree.

## What changed

Test-only, one file (`packages/node-sdk/test/v1-v2-parity.test.ts`):

- `projectBackgroundTask()` now deletes `exitCode` **only when `status === 'killed'`**, with a comment explaining the OS race. Completed and failed tasks keep comparing `exitCode` in full — the drain-mode test's `exitCode: 0` assertion is deliberately untouched.
- The `KNOWN_DIFFS.listBackgroundTasks` doc comment is updated to match (that block documents every projected-away field and why).
- At the killed-task call site, two new assertions keep the field covered instead of dropping it silently: each engine must still settle on a `number` exit code. Not asserting `-1 | 143` specifically, because those values are POSIX-specific and the suite also runs on Windows.

This follows the file's existing pattern: `KNOWN_DIFFS` projections remove per-run nondeterminism (pids, timestamps, task-id suffixes) while call-site assertions pin the invariants that do hold. An engine-side fix was considered — mapping signal deaths to `128+N` would make the reported code deterministic here — but that changes the SDK-visible `exitCode` for every signal-killed task on both engines, which is a behavior change deserving its own discussion, and the engines already agree exactly on how they map the exit payload today, so there is no cross-engine bug for this parity test to catch.

Verification:

- `pnpm vitest run packages/node-sdk/test/v1-v2-parity.test.ts` → 84 passed, several consecutive runs.
- Forced-divergence control: with the killed-task infos hard-coded to `exitCode: 143` vs `-1`, the fixed projection passes; with the new projection line disabled, it fails with exactly the original error signature.
- `pnpm lint` → 0 errors, warning count identical to `main`.
- Package-scoped `tsc --noEmit` on `@moonshot-ai/kimi-code-sdk` passes.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.
