### PR TITLE
fix(kimi-code): disable Windows progress in WSL

### DIFF
--- a/.changeset/calm-windows-progress.md
+++ b/.changeset/calm-windows-progress.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Avoid sending terminal progress sequences from WSL sessions in Windows Terminal so they do not interfere with the auto-hidden Windows taskbar.

--- a/apps/kimi-code/src/tui/utils/terminal-notification.ts
+++ b/apps/kimi-code/src/tui/utils/terminal-notification.ts
@@ -120,7 +120,12 @@ export function supportsOsc9Notification(env: NodeJS.ProcessEnv = process.env): 
  * always safe.
  */
 export function supportsTerminalProgress(env: NodeJS.ProcessEnv = process.env): boolean {
-  if ((env['WT_SESSION'] ?? '').length > 0) return true;
+  const isWindowsTerminal = (env['WT_SESSION'] ?? '').length > 0;
+  const isWsl = env['WSL_DISTRO_NAME'] !== undefined || env['WSL_INTEROP'] !== undefined;
+  // Windows Terminal forwards OSC 9;4 from WSL to the Windows taskbar, where
+  // an active progress state blocks the auto-hidden taskbar's edge trigger.
+  if (isWindowsTerminal && isWsl) return false;
+  if (isWindowsTerminal) return true;
   if (env['ConEmuANSI'] === 'ON') return true;
   const termProgram = env['TERM_PROGRAM'] ?? '';
   if (termProgram === 'ghostty' || termProgram === 'WezTerm') return true;

--- a/apps/kimi-code/test/tui/terminal-notification.test.ts
+++ b/apps/kimi-code/test/tui/terminal-notification.test.ts
@@ -222,6 +222,50 @@ describe('supportsTerminalProgress', () => {
     expect(supportsTerminalProgress({ ConEmuANSI: 'ON' })).toBe(true);
   });
 
+  it('does not enable Windows Terminal progress inside WSL', () => {
+    expect(supportsTerminalProgress({ WT_SESSION: 'abc-123', WSL_DISTRO_NAME: 'Ubuntu' })).toBe(
+      false,
+    );
+    expect(
+      supportsTerminalProgress({ WT_SESSION: 'abc-123', WSL_INTEROP: '/run/WSL/123_interop' }),
+    ).toBe(false);
+  });
+
+  it.each([
+    { ConEmuANSI: 'ON' },
+    { TERM_PROGRAM: 'WezTerm' },
+    { TERM_PROGRAM: 'ghostty' },
+    { TERM: 'xterm-ghostty' },
+  ])('keeps WSL Windows Terminal disabled when other progress markers are present', (marker) => {
+    expect(
+      supportsTerminalProgress({
+        WT_SESSION: 'abc-123',
+        WSL_DISTRO_NAME: 'Ubuntu',
+        ...marker,
+      }),
+    ).toBe(false);
+    expect(
+      supportsTerminalProgress({
+        WT_SESSION: 'abc-123',
+        WSL_INTEROP: '/run/WSL/123_interop',
+        ...marker,
+      }),
+    ).toBe(false);
+  });
+
+  it('preserves progress support for non-Windows-Terminal sessions inside WSL', () => {
+    expect(supportsTerminalProgress({ WSL_DISTRO_NAME: 'Ubuntu', ConEmuANSI: 'ON' })).toBe(true);
+    expect(
+      supportsTerminalProgress({ WSL_INTEROP: '/run/WSL/123_interop', TERM_PROGRAM: 'WezTerm' }),
+    ).toBe(true);
+    expect(supportsTerminalProgress({ WSL_DISTRO_NAME: 'Ubuntu', TERM_PROGRAM: 'ghostty' })).toBe(
+      true,
+    );
+    expect(
+      supportsTerminalProgress({ WSL_INTEROP: '/run/WSL/123_interop', TERM: 'xterm-ghostty' }),
+    ).toBe(true);
+  });
+
   it('detects Ghostty / WezTerm via TERM_PROGRAM and TERM', () => {
     expect(supportsTerminalProgress({ TERM_PROGRAM: 'ghostty' })).toBe(true);
     expect(supportsTerminalProgress({ TERM: 'xterm-ghostty' })).toBe(true);


### PR DESCRIPTION
## Related Issue

Resolves #727

## Problem

In WSL sessions hosted by Windows Terminal, Kimi Code treats `WT_SESSION` as unconditional support for OSC 9;4 terminal progress. Windows Terminal forwards that progress state to the Windows taskbar, which prevents an auto-hidden taskbar from responding at the screen edge while a turn is active.

## What changed

- Disable terminal progress only when Windows Terminal is detected together with either WSL marker (`WSL_DISTRO_NAME` or `WSL_INTEROP`).
- Give that WSL + Windows Terminal decision precedence over inherited ConEmu, Ghostty, or WezTerm markers.
- Preserve progress support for native Windows Terminal and for non-Windows-Terminal ConEmu, Ghostty, and WezTerm sessions.
- Add a patch changeset for `@moonshot-ai/kimi-code`.

Open PR #2073 also touches the capability check to add VS Code support, but its behavior is complementary: this patch only gives the WSL + Windows Terminal exclusion precedence and preserves the other allowlisted terminals. A small rebase conflict may need resolution if #2073 lands first.

### Verification

- Focused terminal/activity tests: 34 passed.
- Full `@moonshot-ai/kimi-code` suite: 2,776 passed, 2 skipped.
- Package typecheck: passed.
- Root lint: 0 errors (existing warnings only).
- Changed-file type-aware lint: 0 warnings, 0 errors.
- `git diff --check` and changeset status: passed.

Manual Windows 11 + WSL2 + Windows Terminal taskbar verification is still recommended because this macOS environment cannot exercise the Windows shell UI.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill; added a patch changeset for `@moonshot-ai/kimi-code`.
- [x] Ran `gen-docs` skill; no documentation update is needed because this only narrows automatic capability detection for an existing terminal integration.
