### PR TITLE
docs: add source build instructions

### DIFF
--- a/docs/en/guides/getting-started.md
+++ b/docs/en/guides/getting-started.md
@@ -53,6 +53,41 @@ Or with pnpm:
 pnpm add -g @moonshot-ai/kimi-code
 ```
 
+## Build from source
+
+To build a standalone `kimi` executable from the repository, first clone it:
+
+```sh
+git clone https://github.com/MoonshotAI/kimi-code.git
+cd kimi-code
+```
+
+On macOS, Linux, or WSL, use [nvm](https://github.com/nvm-sh/nvm) to install the Node.js version pinned in `.nvmrc`, then enable pnpm through Corepack:
+
+```sh
+nvm install
+corepack enable pnpm
+```
+
+On native Windows, `nvm-sh` does not apply. Install the Node.js version shown in `.nvmrc`; for example, pass it explicitly to [nvm-windows](https://github.com/coreybutler/nvm-windows), then enable pnpm:
+
+```powershell
+$nodeVersion = (Get-Content .nvmrc).Trim()
+nvm install $nodeVersion
+nvm use $nodeVersion
+corepack enable pnpm
+```
+
+Corepack uses the pnpm version declared in `package.json`. Install the dependencies, build the native executable, and run its smoke test:
+
+```sh
+pnpm install --frozen-lockfile
+pnpm --filter @moonshot-ai/kimi-code run build:native:sea
+pnpm --filter @moonshot-ai/kimi-code run test:native:smoke
+```
+
+The executable is written to `apps/kimi-code/dist-native/bin/<platform>-<architecture>/kimi` (`kimi.exe` on Windows). This builds for the current platform and architecture; release signing and notarization are not required for a local build.
+
 ## Upgrade and uninstall
 
 After installation, verify that the executable is ready:

--- a/docs/en/guides/getting-started.md
+++ b/docs/en/guides/getting-started.md
@@ -62,6 +62,16 @@ git clone https://github.com/MoonshotAI/kimi-code.git
 cd kimi-code
 ```
 
+Source builds support these operating system and architecture combinations:
+
+| Operating system | Architectures | Build targets |
+| --- | --- | --- |
+| macOS | `arm64`, `x64` | `darwin-arm64`, `darwin-x64` |
+| GNU/Linux, including WSL | `arm64`, `x64` | `linux-arm64`, `linux-x64` |
+| Windows | `arm64`, `x64` | `win32-arm64`, `win32-x64` |
+
+Other operating systems and architectures are not supported by the native build.
+
 On macOS, Linux, or WSL, use [nvm](https://github.com/nvm-sh/nvm) to install the Node.js version pinned in `.nvmrc`, then enable pnpm through Corepack:
 
 ```sh

--- a/docs/zh/guides/getting-started.md
+++ b/docs/zh/guides/getting-started.md
@@ -53,6 +53,41 @@ npm install -g @moonshot-ai/kimi-code
 pnpm add -g @moonshot-ai/kimi-code
 ```
 
+## 从源码构建
+
+如需从仓库构建独立的 `kimi` 可执行文件，请先克隆仓库：
+
+```sh
+git clone https://github.com/MoonshotAI/kimi-code.git
+cd kimi-code
+```
+
+在 macOS、Linux 或 WSL 上，使用 [nvm](https://github.com/nvm-sh/nvm) 安装 `.nvmrc` 中锁定的 Node.js 版本，再通过 Corepack 启用 pnpm：
+
+```sh
+nvm install
+corepack enable pnpm
+```
+
+在原生 Windows 上不适用 `nvm-sh`。请安装 `.nvmrc` 中标明的 Node.js 版本；例如，将该版本显式传给 [nvm-windows](https://github.com/coreybutler/nvm-windows)，然后启用 pnpm：
+
+```powershell
+$nodeVersion = (Get-Content .nvmrc).Trim()
+nvm install $nodeVersion
+nvm use $nodeVersion
+corepack enable pnpm
+```
+
+Corepack 会使用 `package.json` 中声明的 pnpm 版本。接着安装依赖、构建原生可执行文件并运行 smoke 测试：
+
+```sh
+pnpm install --frozen-lockfile
+pnpm --filter @moonshot-ai/kimi-code run build:native:sea
+pnpm --filter @moonshot-ai/kimi-code run test:native:smoke
+```
+
+可执行文件会写入 `apps/kimi-code/dist-native/bin/<platform>-<architecture>/kimi`（Windows 上为 `kimi.exe`）。该命令面向当前平台和架构进行构建；本地构建无需发布签名或公证。
+
 ## 升级与卸载
 
 安装完成后，验证可执行文件是否就绪：

--- a/docs/zh/guides/getting-started.md
+++ b/docs/zh/guides/getting-started.md
@@ -62,6 +62,16 @@ git clone https://github.com/MoonshotAI/kimi-code.git
 cd kimi-code
 ```
 
+源码构建支持以下操作系统和架构组合：
+
+| 操作系统 | 架构 | 构建目标 |
+| --- | --- | --- |
+| macOS | `arm64`、`x64` | `darwin-arm64`、`darwin-x64` |
+| GNU/Linux（包括 WSL） | `arm64`、`x64` | `linux-arm64`、`linux-x64` |
+| Windows | `arm64`、`x64` | `win32-arm64`、`win32-x64` |
+
+原生构建不支持其他操作系统或架构。
+
 在 macOS、Linux 或 WSL 上，使用 [nvm](https://github.com/nvm-sh/nvm) 安装 `.nvmrc` 中锁定的 Node.js 版本，再通过 Corepack 启用 pnpm：
 
 ```sh


### PR DESCRIPTION
## Related Issue

Resolves #1202

## Problem

The documentation explains package installation and the repository contribution workflow, but it does not show how to build and verify the standalone native `kimi` executable from source.

## What changed

- add matching English and Chinese source-build instructions to Getting Started
- distinguish the `nvm-sh` flow on macOS/Linux/WSL from native Windows setup with `nvm-windows`
- enable the repository-pinned pnpm version through Corepack
- document the native build, smoke test, output path, and local signing expectations

## Verification

- Node.js 24.15.0 / pnpm 10.33.0: `pnpm --filter @moonshot-ai/kimi-code run build:native:sea`
- `pnpm --filter @moonshot-ai/kimi-code run test:native:smoke`
- generated `apps/kimi-code/dist-native/bin/darwin-arm64/kimi`; `kimi --version` reported `0.35.0`
- `pnpm -C docs run build`
- `git diff --check`

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [ ] I have added tests that prove my feature works. (Documentation-only change; verified with the native smoke test and documentation build above.)
- [x] Ran `gen-changesets` skill; documentation-only change needs no changeset.
- [x] Ran `gen-docs` skill; both locales and the documentation build were verified.
