### PR TITLE
fix(kimi-web): cache content-hashed assets

### DIFF
--- a/.changeset/cache-web-assets.md
+++ b/.changeset/cache-web-assets.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Cache content-hashed Kimi Web assets across reloads while keeping the app entry point revalidated.

--- a/packages/kap-server/src/routes/webAssets.ts
+++ b/packages/kap-server/src/routes/webAssets.ts
@@ -1,6 +1,6 @@
 import { createReadStream } from 'node:fs';
 import { stat } from 'node:fs/promises';
-import { extname, join, normalize, resolve, sep } from 'node:path';
+import { extname, join, normalize, relative, resolve, sep } from 'node:path';
 
 import type { FastifyReply, FastifyRequest } from 'fastify';
 
@@ -56,8 +56,18 @@ async function serveWebAsset(
 
   return reply
     .type(mimeType(filePath))
+    .header('Cache-Control', cacheControl(assetsDir, filePath))
     .header('Content-Length', String(fileInfo.size))
     .send(createReadStream(filePath));
+}
+
+function cacheControl(assetsDir: string, filePath: string): string {
+  const assetPath = relative(assetsDir, filePath);
+  const fileName = filePath.slice(filePath.lastIndexOf(sep) + 1);
+  if (assetPath.startsWith(`assets${sep}`) && /[-.][A-Za-z0-9_-]{8}\.[^.]+$/.test(fileName)) {
+    return 'public, max-age=31536000, immutable';
+  }
+  return 'no-cache';
 }
 
 async function resolveStaticFile(

--- a/packages/kap-server/test/webAssets.test.ts
+++ b/packages/kap-server/test/webAssets.test.ts
@@ -1,0 +1,53 @@
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import Fastify, { type FastifyInstance } from 'fastify';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { registerWebAssetRoutes } from '../src/routes/webAssets';
+
+describe('web asset cache policy', () => {
+  let app: FastifyInstance;
+  let assetsDir: string;
+
+  beforeEach(async () => {
+    assetsDir = await mkdtemp(join(tmpdir(), 'kimi-web-assets-'));
+    await mkdir(join(assetsDir, 'assets'));
+    await Promise.all([
+      writeFile(join(assetsDir, 'index.html'), '<main>Kimi</main>'),
+      writeFile(join(assetsDir, 'assets', 'index-Dy7xs5tu.js'), 'export {};'),
+      writeFile(join(assetsDir, 'assets', 'application-configuration.json'), '{}'),
+      writeFile(join(assetsDir, 'favicon.svg'), '<svg></svg>'),
+    ]);
+    app = Fastify();
+    await registerWebAssetRoutes(app, assetsDir);
+  });
+
+  afterEach(async () => {
+    await app.close();
+    await rm(assetsDir, { recursive: true, force: true });
+  });
+
+  it('caches content-hashed assets as immutable', async () => {
+    const response = await app.inject({ method: 'GET', url: '/assets/index-Dy7xs5tu.js' });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.headers['cache-control']).toBe('public, max-age=31536000, immutable');
+  });
+
+  it.each([
+    '/index.html',
+    '/sessions/active',
+    '/favicon.svg',
+    '/assets/application-configuration.json',
+  ])(
+    'requires revalidation for %s',
+    async (url) => {
+      const response = await app.inject({ method: 'GET', url });
+
+      expect(response.statusCode).toBe(200);
+      expect(response.headers['cache-control']).toBe('no-cache');
+    },
+  );
+});


### PR DESCRIPTION
## Related Issue

Resolve #1894

## Problem

See linked issue. Kimi Web currently serves every static asset without an explicit cache policy, so browsers download the full content-hashed bundle again after reloads. At the same time, caching the SPA entry point permanently would prevent clients from discovering new bundle filenames after an update.

## What changed

- Serve files in the `assets/` directory whose names end in the Vite eight-character content hash with `Cache-Control: public, max-age=31536000, immutable`.
- Serve the app entry point, SPA fallbacks, favicons, and other non-hashed assets with `Cache-Control: no-cache` so browsers revalidate them.
- Add route-level tests covering immutable hashed assets, direct and fallback HTML, and long non-hashed filenames.
- Add a patch changeset for the shipped CLI bundle.

Validation:

- `pnpm --filter @moonshot-ai/kap-server exec vitest run test/webAssets.test.ts`
- `pnpm --filter @moonshot-ai/kap-server typecheck`
- `pnpm exec oxlint packages/kap-server/src/routes/webAssets.ts packages/kap-server/test/webAssets.test.ts`

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.