### PR TITLE
fix: stop repeated file-watcher errors on Windows drive-root and UNC workspaces

### DIFF
--- a/.changeset/fix-windows-project-root-watch.md
+++ b/.changeset/fix-windows-project-root-watch.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Fix repeated file-watcher errors on Windows when the workspace is a drive root (such as `E:\`) or a UNC network share.

--- a/packages/agent-core-v2/src/_base/utils/paths.ts
+++ b/packages/agent-core-v2/src/_base/utils/paths.ts
@@ -1,12 +1,38 @@
 /**
- * `_base/utils/paths` (cross-cutting) — pure path-filter predicates.
+ * `_base/utils/paths` (cross-cutting) — pure path predicates and directory
+ * walks.
  *
  * Constrains filesystem watches to selected subtrees and scanner-visible
- * entries.
+ * entries, and walks host directory chains with platform-native path
+ * semantics so drive-letter / UNC roots keep their host form.
  */
+
+import nodePath from 'node:path';
 
 function normalizeSlashes(p: string): string {
   return p.replaceAll('\\', '/');
+}
+
+export interface UpwardRootPathApi {
+  resolve(dir: string): string;
+  dirname(dir: string): string;
+  join(...segments: string[]): string;
+}
+
+export async function findUpwardRoot(
+  workDir: string,
+  markerName: string,
+  hasMarker: (markerPath: string) => Promise<boolean>,
+  pathApi: UpwardRootPathApi = nodePath,
+): Promise<string> {
+  const start = pathApi.resolve(workDir);
+  let current = start;
+  while (true) {
+    if (await hasMarker(pathApi.join(current, markerName))) return normalizeSlashes(current);
+    const parent = pathApi.dirname(current);
+    if (parent === current) return normalizeSlashes(start);
+    current = parent;
+  }
 }
 
 export interface SubtreeWatchFilterOptions {

--- a/packages/agent-core-v2/src/app/skillCatalog/skillRoots.ts
+++ b/packages/agent-core-v2/src/app/skillCatalog/skillRoots.ts
@@ -11,6 +11,8 @@
 import { promises as fs } from 'node:fs';
 import path from 'pathe';
 
+import { findUpwardRoot } from '#/_base/utils/paths';
+
 import type { SkillRoot, SkillSource } from './types';
 
 const USER_BRAND_DIRS = ['skills'] as const;
@@ -78,14 +80,7 @@ export async function configuredRoots(
 }
 
 async function findProjectRoot(workDir: string): Promise<string> {
-  const start = path.resolve(workDir);
-  let current = start;
-  while (true) {
-    if (await exists(path.join(current, '.git'))) return current;
-    const parent = path.dirname(current);
-    if (parent === current) return start;
-    current = parent;
-  }
+  return findUpwardRoot(workDir, '.git', exists);
 }
 
 async function pushFirstExisting(

--- a/packages/agent-core-v2/src/workspace/workspaceAgentProfileLoader/internal/agentRoots.ts
+++ b/packages/agent-core-v2/src/workspace/workspaceAgentProfileLoader/internal/agentRoots.ts
@@ -5,8 +5,9 @@
  * filesystem boundary. Pure path probes; no scoped state.
  */
 
-import { dirname, join, resolve } from 'pathe';
+import { join } from 'pathe';
 
+import { findUpwardRoot } from '#/_base/utils/paths';
 import type { IHostFileSystem } from '#/os/interface/hostFileSystem';
 import { HostFsError, OsFsErrors } from '#/os/interface/hostFsErrors';
 
@@ -86,20 +87,15 @@ async function findProjectRoot(
   workDir: string,
   warn?: AgentRootWarn,
 ): Promise<string> {
-  const start = resolve(workDir);
-  let current = start;
-  while (true) {
-    const marker = join(current, '.git');
+  return findUpwardRoot(workDir, '.git', async (marker) => {
     try {
-      if (await pathExists(fs, marker)) return current;
+      return await pathExists(fs, marker);
     } catch (error) {
       if (isUnavailable(error)) throw error;
       warn?.(`Skipping unreadable project marker ${marker}: ${errorMessage(error)}`, error);
+      return false;
     }
-    const parent = dirname(current);
-    if (parent === current) return start;
-    current = parent;
-  }
+  });
 }
 
 async function pushFirstExisting(

--- a/packages/agent-core-v2/test/_base/utils/paths.test.ts
+++ b/packages/agent-core-v2/test/_base/utils/paths.test.ts
@@ -1,14 +1,19 @@
 /**
  * Scenario: recursive watches constrained to selected candidate subtrees.
- * Responsibilities: candidate ancestry, scan-depth bounds, and excluded-entry
- * probing. Wiring: pure path predicates with no external collaborators.
+ * Responsibilities: candidate ancestry, scan-depth bounds, excluded-entry
+ * probing, and the marker-based upward root walk. Wiring: pure path
+ * predicates and walks with no external collaborators.
  * Run: `pnpm --filter @moonshot-ai/agent-core-v2 exec vitest run
  * test/_base/utils/paths.test.ts`.
  */
 
-import { describe, expect, it } from 'vitest';
+import { mkdtemp, mkdir, rm, stat } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import nodePath, { win32 } from 'node:path';
 
-import { subtreeWatchFilter } from '#/_base/utils/paths';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { findUpwardRoot, subtreeWatchFilter } from '#/_base/utils/paths';
 
 describe('subtree watch filtering', () => {
   const root = '/repo';
@@ -103,5 +108,72 @@ describe('subtree watch filtering', () => {
     expect(ignored('/repo/.agents/skills/parent/child')).toBe(false);
     expect(ignored('/repo/.agents/skills/parent/child/SKILL.md')).toBe(false);
     expect(ignored('/repo/.agents/skills/parent/child/runtime')).toBe(true);
+  });
+});
+
+describe('findUpwardRoot', () => {
+  const noMarker = async () => false;
+
+  describe('with host-default path semantics', () => {
+    let root: string;
+
+    beforeEach(async () => {
+      root = await mkdtemp(nodePath.join(tmpdir(), 'upward-root-'));
+    });
+
+    afterEach(async () => {
+      await rm(root, { recursive: true, force: true });
+    });
+
+    const hasMarker = async (markerPath: string): Promise<boolean> => {
+      try {
+        await stat(markerPath);
+        return true;
+      } catch {
+        return false;
+      }
+    };
+
+    it('stops at the nearest ancestor holding the marker', async () => {
+      await mkdir(nodePath.join(root, '.git'));
+      const child = nodePath.join(root, 'src', 'pkg');
+      await mkdir(child, { recursive: true });
+
+      const found = await findUpwardRoot(child, '.git', hasMarker);
+
+      expect(found).toBe(root.replaceAll('\\', '/'));
+    });
+
+    it('falls back to the working directory when no ancestor holds the marker', async () => {
+      const child = nodePath.join(root, 'src', 'pkg');
+      await mkdir(child, { recursive: true });
+
+      const found = await findUpwardRoot(child, '.git', hasMarker);
+
+      expect(found).toBe(child.replaceAll('\\', '/'));
+    });
+  });
+
+  it('keeps a Windows drive-root working directory in host form', async () => {
+    const found = await findUpwardRoot('E:\\', '.git', noMarker, win32);
+
+    expect(found).toBe('E:/');
+  });
+
+  it('keeps a Windows UNC working directory in host form', async () => {
+    const found = await findUpwardRoot('\\\\fs1\\share\\dir', '.git', noMarker, win32);
+
+    expect(found).toBe('//fs1/share/dir');
+  });
+
+  it('stops at the nearest Windows ancestor holding the marker', async () => {
+    const found = await findUpwardRoot(
+      'E:\\repo\\src',
+      '.git',
+      async (markerPath) => markerPath === 'E:\\repo\\.git',
+      win32,
+    );
+
+    expect(found).toBe('E:/repo');
   });
 });


### PR DESCRIPTION
## Related Issue

Resolve #2771

## Problem

On Windows, when the workspace is a drive root (e.g. `E:`) or a UNC network share (the linked issue), the project-root walk POSIX-ized the host path — `E:` became `/E:`, `\\server\share\dir` became `/server/share/dir`. The skill-root file watcher then received a path that does not exist, so `fs.watch` threw ENOENT and the watcher kept retrying with backoff, logging repeated errors and firing invalidations.

## What changed

The `.git` walk-up now resolves with platform-native path semantics (`node:path`) through a shared helper, so drive-letter roots and UNC roots keep their host form and the walk terminates at the volume root; results are still normalized to forward slashes for internal use. Both copies of the walk (skill roots and agent-profile roots) share the helper.

Tests inject win32 path semantics so the drive-root / UNC regression is covered on any host (Windows CI is currently disabled).

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my fix works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.