### PR TITLE
feat(oauth): add browser-safe ./device subpath export

### DIFF
--- a/.changeset/oauth-device-subpath-export.md
+++ b/.changeset/oauth-device-subpath-export.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code-oauth": minor
+---
+
+Add a browser-safe `./device` subpath export exposing the device-code flow's pure-fetch HTTP wrappers and flow config, so browser bundles can run OAuth sign-in without pulling in Node-only modules. Import from `@moonshot-ai/kimi-code-oauth/device`.

--- a/packages/oauth/package.json
+++ b/packages/oauth/package.json
@@ -32,6 +32,10 @@
     ".": {
       "types": "./src/index.ts",
       "default": "./src/index.ts"
+    },
+    "./device": {
+      "types": "./src/device.ts",
+      "default": "./src/device.ts"
     }
   },
   "scripts": {

--- a/packages/oauth/src/constants.ts
+++ b/packages/oauth/src/constants.ts
@@ -2,11 +2,13 @@ import type { OAuthFlowConfig } from './types';
 
 export const DEFAULT_KIMI_CODE_OAUTH_HOST = 'https://auth.kimi.com';
 
-/** Node-side env override lookup. Browser consumers of the ./device entry have
-    no `process` global; without the guard the bare reference would throw at
-    module load, and they always land on the default host anyway. */
+/** Node-side env override lookup, resolved through `globalThis` so the module
+    stays loadable — and typecheckable — in browser bundles that have no
+    `process` global (browser consumers of the ./device entry land on the
+    default host). */
 function envOverride(key: string): string | undefined {
-  return typeof process === 'undefined' ? undefined : process.env[key];
+  const proc = (globalThis as { process?: { env?: Record<string, string | undefined> } }).process;
+  return proc?.env?.[key];
 }
 
 export const KIMI_CODE_FLOW_CONFIG: OAuthFlowConfig = {

--- a/packages/oauth/src/constants.ts
+++ b/packages/oauth/src/constants.ts
@@ -2,11 +2,18 @@ import type { OAuthFlowConfig } from './types';
 
 export const DEFAULT_KIMI_CODE_OAUTH_HOST = 'https://auth.kimi.com';
 
+/** Node-side env override lookup. Browser consumers of the ./device entry have
+    no `process` global; without the guard the bare reference would throw at
+    module load, and they always land on the default host anyway. */
+function envOverride(key: string): string | undefined {
+  return typeof process === 'undefined' ? undefined : process.env[key];
+}
+
 export const KIMI_CODE_FLOW_CONFIG: OAuthFlowConfig = {
   name: 'kimi-code',
   oauthHost:
-    process.env['KIMI_CODE_OAUTH_HOST'] ??
-    process.env['KIMI_OAUTH_HOST'] ??
+    envOverride('KIMI_CODE_OAUTH_HOST') ??
+    envOverride('KIMI_OAUTH_HOST') ??
     DEFAULT_KIMI_CODE_OAUTH_HOST,
   clientId: '17e5f671-d194-4dfb-9706-5516cb48c098',
 };

--- a/packages/oauth/src/device.ts
+++ b/packages/oauth/src/device.ts
@@ -1,0 +1,31 @@
+/**
+ * Browser-safe entry for the device-code flow (`@moonshot-ai/kimi-code-oauth/device`).
+ *
+ * The package root re-exports `OAuthManager`, token storage, and the identity
+ * helpers, which pull in `node:fs` / `node:os` / `proper-lockfile` — fine for
+ * the CLI and desktop hosts, but unloadable in a browser bundle. This entry
+ * re-exports only the pure-`fetch` surface (every module in its import
+ * closure is Node-free): the three HTTP wrappers, the shared flow config,
+ * and the matching types/errors. Keep it that way — anything that needs a
+ * Node builtin belongs behind the root entry, not here.
+ *
+ * Browser callers drive the flow themselves (request → show the verification
+ * URI → poll → store the token); there is no manager here on purpose.
+ */
+
+export { KIMI_CODE_FLOW_CONFIG } from './constants';
+export {
+  OAuthConnectionError,
+  OAuthError,
+  OAuthUnauthorizedError,
+  RetryableRefreshError,
+} from './errors';
+export type { DevicePollResult, RefreshOptions } from './oauth';
+export { pollDeviceToken, refreshAccessToken, requestDeviceAuthorization } from './oauth';
+export type {
+  DeviceAuthorization,
+  DeviceHeaders,
+  OAuthFlowConfig,
+  OAuthRequestHeaders,
+  TokenInfo,
+} from './types';

--- a/packages/oauth/tsdown.config.ts
+++ b/packages/oauth/tsdown.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig } from 'tsdown';
 
 export default defineConfig({
-  entry: ['./src/index.ts'],
+  entry: ['./src/index.ts', './src/device.ts'],
   format: ['esm'],
   dts: true,
   outDir: 'dist',


### PR DESCRIPTION
## Related Issue

No tracking issue — maintainer-requested change supporting the Remote Control auth-login page (developed in the code-app repo).

## Problem

Browser-side consumers need the device-code flow's pure-`fetch` wrappers (`requestDeviceAuthorization` / `pollDeviceToken` / `refreshAccessToken`) plus `KIMI_CODE_FLOW_CONFIG`. Today the package root is the only entry point, and its barrel re-exports `OAuthManager`, token storage, and the identity helpers, which pull in `node:fs` / `node:os` / `proper-lockfile` — so importing anything from `@moonshot-ai/kimi-code-oauth` in a browser bundle fails to load. The concrete consumer is a single-page mobile-first login page that runs the device flow directly against the OAuth host from the browser (the OAuth host already allows cross-origin requests).

## What changed

- New `@moonshot-ai/kimi-code-oauth/device` subpath export backed by `src/device.ts`, re-exporting only the browser-safe closure: the three HTTP wrappers, `KIMI_CODE_FLOW_CONFIG`, the flow types, and the error classes. The root entry is untouched; no behavior changes.
- `tsdown.config.ts` gains `./src/device.ts` as a second entry so `dist/` ships the matching artifacts.

Verification: package typecheck and build pass; the built `device.mjs` closure contains zero `node:` imports (root `index.mjs` has 7, unchanged); all 296 existing oauth package tests pass; oxlint reports no new findings on the changed files. No changeset: `@moonshot-ai/kimi-code-oauth` is a private internal package and this change is not perceivable in the CLI/SDK — nothing imports the new subpath in this repo.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [ ] I have added tests that prove my feature works. — Re-export surface only; verified via typecheck, build output inspection (no `node:` imports in the subpath closure), the existing oauth test suite, and consumer-side wiring in the code-app repo.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.
