### PR TITLE
test(minidb): deflake the evict-lru compaction-churn guard

### DIFF
--- a/packages/minidb/test/e2e/stress.test.ts
+++ b/packages/minidb/test/e2e/stress.test.ts
@@ -22,6 +22,7 @@ import { MiniDb } from '../../src/index.js';
 import { startServer } from '../../src/server.js';
 import { tmpDir, rmrf } from './helpers/tmp.js';
 import { mulberry32 } from './helpers/prng.js';
+import { waitFor } from '../helpers.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -570,7 +571,11 @@ test(
         await db.set(`ek${i}`, { i, pad: 'e'.repeat(1100) });
         if (i % 7 === 0) db.get(`ek${Math.max(0, i - 3)}`);
       }
-      expect(db.stats.compactions).toBeGreaterThan(0);
+      // Auto-compaction is fire-and-forget through the maintenance scheduler,
+      // so the write loop finishing does not imply a run has completed yet —
+      // wait for the churn this scenario requires instead of assuming the
+      // loop outlasted it (flakes on loaded CI runners).
+      await waitFor(() => db.stats.compactions > 0, 'auto compaction under churn');
       expect(db.store.bytes).toBeLessThanOrEqual(Math.ceil(budget * 1.05));
       expect(db.stats.evictions).toBeGreaterThan(0);
     } catch (err) {


### PR DESCRIPTION
## Related Issue

None — the problem is explained below.

## Problem

`stress: evict-lru under compaction churn` asserted `db.stats.compactions > 0` immediately after its 2500-write loop. Auto-compaction is fire-and-forget through the maintenance scheduler, and the counter only increments once a run fully completes (rotation + generation publish). On a loaded CI runner the write loop can finish before the first compaction lands, so the guard reads 0 and the test fails even though nothing is broken — seen in practice on a docs-only PR's CI run, green on rerun.

## What changed

Replace the immediate assertion with the existing `waitFor` test helper: wait until at least one auto-compaction has completed (10 s timeout, loud failure). This keeps the guard's intent — the scenario only tests "under compaction churn" if a compaction actually happened — without depending on the wall-clock coincidence that the loop outlasts the first compaction. If auto-compaction genuinely breaks, the wait times out and the test still fails. The neighboring `evictions > 0` guard needs no wait: eviction is awaited on the write path.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.