### PR TITLE
fix(tui): keep task browser frames aligned on Windows

### DIFF
--- a/.changeset/fix-windows-task-output-frames.md
+++ b/.changeset/fix-windows-task-output-frames.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Fix task browser frames becoming misaligned when Windows background task output contains terminal control characters.

--- a/apps/kimi-code/src/tui/components/dialogs/task-output-viewer.ts
+++ b/apps/kimi-code/src/tui/components/dialogs/task-output-viewer.ts
@@ -22,6 +22,7 @@ import type { BackgroundTaskInfo, BackgroundTaskStatus } from '@moonshot-ai/kimi
 
 import { currentTheme } from '#/tui/theme';
 import { printableChar } from '@/tui/utils/printable-key';
+import { sanitizeShellOutput } from '@/tui/utils/shell-output';
 
 const ELLIPSIS = '…';
 
@@ -104,7 +105,7 @@ export class TaskOutputViewer extends Container implements Focusable {
   }
 
   private splitOutput(output: string): string[] {
-    return (output.length > 0 ? output : '[no output captured]').split('\n');
+    return sanitizeShellOutput(output.length > 0 ? output : '[no output captured]').split('\n');
   }
 
   // ── input ──────────────────────────────────────────────────────────

--- a/apps/kimi-code/src/tui/components/dialogs/tasks-browser.ts
+++ b/apps/kimi-code/src/tui/components/dialogs/tasks-browser.ts
@@ -27,6 +27,7 @@ import type { BackgroundTaskInfo, BackgroundTaskStatus } from '@moonshot-ai/kimi
 import { SELECT_POINTER } from '@/tui/constant/symbols';
 import { currentTheme } from '#/tui/theme';
 import { printableChar } from '@/tui/utils/printable-key';
+import { sanitizeShellOutput } from '@/tui/utils/shell-output';
 
 const ELLIPSIS = '…';
 
@@ -605,7 +606,7 @@ export class TasksBrowserApp extends Container implements Focusable {
       body = '[no output captured]';
     else body = this.props.tailOutput;
 
-    const rawLines = body.split('\n');
+    const rawLines = sanitizeShellOutput(body).split('\n');
     const tailLines = rawLines.slice(-innerHeight);
     const styled = tailLines.map((line) => currentTheme.fg('textDim', line));
     while (styled.length < innerHeight) styled.push('');

--- a/apps/kimi-code/test/tui/task-output-viewer.test.ts
+++ b/apps/kimi-code/test/tui/task-output-viewer.test.ts
@@ -75,6 +75,14 @@ describe('TaskOutputViewer — rendering', () => {
     expect(lines.length).toBe(24);
   });
 
+  it('removes carriage returns from Windows task output so frames stay aligned', () => {
+    const lines = makeViewer({
+      output: 'Reply from 127.0.0.1: time<1ms TTL=128\r\nReply from 127.0.0.1: time<1ms TTL=128\r\n',
+    }).render(120);
+
+    expect(lines.every((line) => !line.includes('\r'))).toBe(true);
+  });
+
   it('shows the task header (id + status + description)', () => {
     const out = strip(
       makeViewer({

--- a/apps/kimi-code/test/tui/tasks-browser.test.ts
+++ b/apps/kimi-code/test/tui/tasks-browser.test.ts
@@ -243,6 +243,16 @@ describe('TasksBrowserApp — full-screen rendering', () => {
     expect(out).toContain('listening on :3000');
   });
 
+  it('removes carriage returns from Windows task output so frames stay aligned', () => {
+    const lines = makeApp({
+      tasks: [task({ taskId: 'bash-aaaaaaaa' })],
+      selectedTaskId: 'bash-aaaaaaaa',
+      tailOutput: 'Reply from 127.0.0.1: time<1ms TTL=128\r\nReply from 127.0.0.1: time<1ms TTL=128\r\n',
+    }).render(120);
+
+    expect(lines.every((line) => !line.includes('\r'))).toBe(true);
+  });
+
   it('shows a loading state when tail is loading', () => {
     const out = strip(
       makeApp({


### PR DESCRIPTION
## Related Issue

Resolve #2233

## Problem

Windows background processes can emit CRLF output. The task browser split output only on `\n`, leaving `\r` characters that move the terminal cursor to column zero and cause frame borders to render in the wrong column.

## What changed

Sanitize captured task output before rendering it in both the `/tasks` preview and the full task output viewer. Added regression coverage using Windows CRLF output.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.
