### PR TITLE
feat(kap-server): expose the subagent registry id in /tasks responses

### DIFF
--- a/packages/kap-server/src/protocol/task.ts
+++ b/packages/kap-server/src/protocol/task.ts
@@ -30,5 +30,6 @@ export const taskSchema = z.object({
   model: z.string().optional(),
   /** Subagent tasks only: the child's effective thinking effort at spawn. */
   thinking_effort: z.string().optional(),
+  agent_id: z.string().optional(),
 });
 export type Task = z.infer<typeof taskSchema>;

--- a/packages/kap-server/src/routes/tasks.ts
+++ b/packages/kap-server/src/routes/tasks.ts
@@ -375,6 +375,9 @@ function toWireTask(
   if (info.kind === 'agent' && info.thinkingEffort !== undefined) {
     base.thinking_effort = info.thinkingEffort;
   }
+  if (info.kind === 'agent' && info.agentId !== undefined) {
+    base.agent_id = info.agentId;
+  }
   if (output !== undefined) {
     base.output_preview = output.preview;
     base.output_bytes = output.bytes;

--- a/packages/kap-server/test/tasks.test.ts
+++ b/packages/kap-server/test/tasks.test.ts
@@ -35,6 +35,7 @@ interface TaskWire {
   completed_at?: string;
   output_preview?: string;
   output_bytes?: number;
+  agent_id?: string;
 }
 
 interface ListWire {
@@ -214,6 +215,7 @@ describe('server-v2 /api/v1/sessions/{sid}/tasks', () => {
       status: 'running',
       model: 'provider/secondary', // subagent tasks expose the bound display model
       thinking_effort: 'low', // …and its effective thinking effort
+      agent_id: 'sub-1',
     });
     expect(byId.get(agentId)?.command).toBeUndefined();
 
@@ -223,6 +225,8 @@ describe('server-v2 /api/v1/sessions/{sid}/tasks', () => {
       kind: 'tool', // question → tool
       status: 'running',
     });
+    expect(byId.get(processId)?.agent_id).toBeUndefined();
+    expect(byId.get(questionId)?.agent_id).toBeUndefined();
   });
 
   it('filters the list by wire status', async () => {
@@ -245,11 +249,22 @@ describe('server-v2 /api/v1/sessions/{sid}/tasks', () => {
     const id = await createSession();
     const tasks = await mainAgentTasks(id);
     const taskId = tasks.registerTask(fakeTask('process'));
+    const subagentId = tasks.registerTask(fakeTask('agent'));
     await flush();
 
     const got = await getJson<TaskWire>(`/api/v1/sessions/${id}/tasks/${taskId}`);
     expect(got.body.code).toBe(0);
     expect(got.body.data).toMatchObject({ id: taskId, session_id: id, kind: 'bash' });
+    expect(got.body.data.agent_id).toBeUndefined();
+
+    const gotSubagent = await getJson<TaskWire>(`/api/v1/sessions/${id}/tasks/${subagentId}`);
+    expect(gotSubagent.body.code).toBe(0);
+    expect(gotSubagent.body.data).toMatchObject({
+      id: subagentId,
+      session_id: id,
+      kind: 'subagent',
+      agent_id: 'sub-1',
+    });
 
     const missing = await getJson<null>(`/api/v1/sessions/${id}/tasks/nope`);
     expect(missing.body.code).toBe(40406);

--- a/packages/protocol/src/task.ts
+++ b/packages/protocol/src/task.ts
@@ -30,6 +30,7 @@ export const taskSchema = z.object({
   model: z.string().optional(),
   /** Subagent tasks only: the child's effective thinking effort at spawn. */
   thinking_effort: z.string().optional(),
+  agent_id: z.string().optional(),
 });
 export type Task = z.infer<typeof taskSchema>;
 


### PR DESCRIPTION
## Related Issue

No tracking issue in this repo — the problem is explained below.

## Problem

After a background subagent finishes, clients can no longer read back its working transcript — only the final answer card remains. The task cards a client holds are keyed by the runtime task id (`agent-<8 hex chars>`), but transcripts are stored and served by the agent registry id (`agent-N`): the live transcript store is keyed by registry id, and the cold path (`GET /api/v1/sessions/{sid}/transcript?agent_id=`) reads `<sessionDir>/agents/<agent_id>/wire.jsonl` directly. A lookup by runtime id therefore misses in both paths and silently returns an empty transcript.

## What changed

The `GET /api/v1/sessions/{sid}/tasks` list and `GET /api/v1/sessions/{sid}/tasks/{task_id}` responses now carry an optional `agent_id` field on `kind: "subagent"` task items, holding the subagent's registry id (the `agent-N` form that maps to `<sessionDir>/agents/<agent_id>/wire.jsonl`). Clients can then uniformly read the transcript by registry id, both while the subagent runs and after it completes.

- The mapping is not new: the persisted task record already carries both ids; the `/tasks` projection simply did not expose the registry id. Both endpoints share the same projection, so both are covered.
- `bash`/`tool` task items omit the field entirely (absent, not `null`).
- Purely additive on the server: the field is optional in both mirrored task wire schemas (`kap-server` and the shared `protocol` package), and no runtime-id → registry-id resolution layer is introduced. Existing clients that do not read the new field are unaffected.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.
