### PR TITLE
fix(google-genai): preserve Gemini tool-call thought signature and trailing user text order

### DIFF
--- a/.changeset/fix-gemini-thought-signature.md
+++ b/.changeset/fix-gemini-thought-signature.md
@@ -1,5 +1,6 @@
 ---
 "@moonshot-ai/kimi-code": patch
+"@moonshot-ai/kimi-code-sdk": patch
 ---
 
-Fix Gemini tool calls failing with a missing thought_signature error on the follow-up request.
+Fix Gemini tool-calling sessions failing on follow-up requests: preserve the tool-call thought signature and keep trailing user text before function results.

--- a/.changeset/fix-gemini-thought-signature.md
+++ b/.changeset/fix-gemini-thought-signature.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Fix Gemini tool calls failing with a missing thought_signature error on the follow-up request.

--- a/packages/agent-core-v2/src/agent/loop/loopService.ts
+++ b/packages/agent-core-v2/src/agent/loop/loopService.ts
@@ -947,6 +947,7 @@ export class AgentLoopService extends Disposable implements IAgentLoopService {
       onToolCall: ({ toolCallId, name, args }) => {
         const callUuid = randomUUID();
         toolCallUuids.set(toolCallId, callUuid);
+        const extras = response.message.toolCalls.find((t) => t.id === toolCallId)?.extras;
         this.context.appendLoopEvent({
           type: 'tool.call',
           uuid: callUuid,
@@ -956,6 +957,7 @@ export class AgentLoopService extends Disposable implements IAgentLoopService {
           toolCallId,
           name,
           args,
+          extras,
         });
       },
     })) {

--- a/packages/agent-core-v2/src/kosong/provider/bases/google-genai/google-genai.ts
+++ b/packages/agent-core-v2/src/kosong/provider/bases/google-genai/google-genai.ts
@@ -445,7 +445,17 @@ export function messagesToGoogleGenAIContents(messages: Message[]): GoogleConten
     isToolResultOnly: (content) =>
       content.parts.length > 0 &&
       content.parts.every((part) => part.functionResponse !== undefined),
-    merge: (last, next) => ({ ...last, parts: [...last.parts, ...next.parts] }),
+    merge: (last, next) => {
+      const lastStartsWithFunctionResponse =
+        last.parts[0]?.functionResponse !== undefined;
+      const nextHasFunctionResponse = next.parts.some(
+        (part) => part.functionResponse !== undefined,
+      );
+      if (lastStartsWithFunctionResponse && !nextHasFunctionResponse) {
+        return { ...next, parts: [...next.parts, ...last.parts] };
+      }
+      return { ...last, parts: [...last.parts, ...next.parts] };
+    },
   });
 }
 

--- a/packages/agent-core-v2/test/agent/loop/loop.test.ts
+++ b/packages/agent-core-v2/test/agent/loop/loop.test.ts
@@ -404,6 +404,49 @@ describe('Agent loop', () => {
   `);
   });
 
+  it('preserves tool call extras (Gemini thought_signature) through to context', async () => {
+    // Regression: Gemini 3 requires the thought_signature returned on a
+    // functionCall to be echoed back when the call is re-sent in the next
+    // step. The signature travels as ToolCall.extras.thought_signature_b64; it
+    // must survive loopService's tool.call event recording so the fold
+    // rebuilds the assistant message with extras for the provider to echo.
+    const sigCall: ToolCall = {
+      type: 'function',
+      id: 'call_sig',
+      name: 'Lookup',
+      arguments: '{"query":"moon"}',
+      extras: { thought_signature_b64: 'c2lnbmF0dXJl' },
+    };
+    const lookupTool: ExecutableTool<{ query: string }> = {
+      name: 'Lookup',
+      description: 'Look up a short test value.',
+      parameters: {
+        type: 'object',
+        properties: {
+          query: { type: 'string' },
+        },
+        required: ['query'],
+        additionalProperties: false,
+      },
+      resolveExecution: () => ({
+        approvalRule: 'Lookup',
+        execute: async () => ({ output: 'lookup-result' }),
+      }),
+    };
+
+    profile.update({ activeToolNames: ['Lookup'] });
+    ctx.get(IAgentToolRegistryService).register(lookupTool);
+
+    ctx.mockNextResponse({ type: 'text', text: 'I will look it up.' }, sigCall);
+    await ctx.rpc.prompt({ input: [{ type: 'text', text: 'Look up moon' }] });
+    ctx.mockNextResponse({ type: 'text', text: 'The lookup result is lookup-result.' });
+    await ctx.untilApproval(true);
+    await ctx.untilTurnEnd();
+
+    const assistant = ctx.contextData().history.find((m) => m.role === 'assistant');
+    expect(assistant?.toolCalls[0]?.extras).toEqual({ thought_signature_b64: 'c2lnbmF0dXJl' });
+  });
+
   it('lets non-external stop hooks continue a turn more than once', async () => {
     profile.update({ activeToolNames: [] });
     let continuations = 0;

--- a/packages/agent-core-v2/test/agent/loop/loop.test.ts
+++ b/packages/agent-core-v2/test/agent/loop/loop.test.ts
@@ -405,11 +405,6 @@ describe('Agent loop', () => {
   });
 
   it('preserves tool call extras (Gemini thought_signature) through to context', async () => {
-    // Regression: Gemini 3 requires the thought_signature returned on a
-    // functionCall to be echoed back when the call is re-sent in the next
-    // step. The signature travels as ToolCall.extras.thought_signature_b64; it
-    // must survive loopService's tool.call event recording so the fold
-    // rebuilds the assistant message with extras for the provider to echo.
     const sigCall: ToolCall = {
       type: 'function',
       id: 'call_sig',

--- a/packages/kosong/src/providers/google-genai.ts
+++ b/packages/kosong/src/providers/google-genai.ts
@@ -498,7 +498,17 @@ export function messagesToGoogleGenAIContents(messages: Message[]): GoogleConten
     isToolResultOnly: (content) =>
       content.parts.length > 0 &&
       content.parts.every((part) => part.functionResponse !== undefined),
-    merge: (last, next) => ({ ...last, parts: [...last.parts, ...next.parts] }),
+    merge: (last, next) => {
+      const lastStartsWithFunctionResponse =
+        last.parts[0]?.functionResponse !== undefined;
+      const nextHasFunctionResponse = next.parts.some(
+        (part) => part.functionResponse !== undefined,
+      );
+      if (lastStartsWithFunctionResponse && !nextHasFunctionResponse) {
+        return { ...next, parts: [...next.parts, ...last.parts] };
+      }
+      return { ...last, parts: [...last.parts, ...next.parts] };
+    },
   });
 }
 export class GoogleGenAIStreamedMessage implements StreamedMessage {

--- a/packages/kosong/test/google-genai.test.ts
+++ b/packages/kosong/test/google-genai.test.ts
@@ -337,6 +337,40 @@ describe('GoogleGenAIChatProvider', () => {
       const last = contents.at(-1)!;
       expect(last.parts.some((p) => p.functionResponse !== undefined)).toBe(true);
       expect(last.parts.some((p) => p.text === 'Now multiply')).toBe(true);
+      // Gemini rejects a trailing Content whose parts start with
+      // functionResponse followed by text ("Requests ending with a model turn
+      // are not supported"); the merged Content must keep the user text first.
+      expect(last.parts[0]).toEqual({ text: 'Now multiply' });
+    });
+
+    it('keeps trailing user text before a multimodal tool-result Content when merging', () => {
+      // A tool result carrying media yields [functionResponse, inlineData];
+      // the reorder must still put a following user text part first.
+      const toolCall: ToolCall = {
+        type: 'function',
+        id: 'call_img',
+        name: 'inspect',
+        arguments: '{}',
+      };
+      const contents = messagesToGoogleGenAIContents([
+        { role: 'user', content: [{ type: 'text', text: 'Inspect it' }], toolCalls: [] },
+        { role: 'assistant', content: [], toolCalls: [toolCall] },
+        {
+          role: 'tool',
+          content: [
+            { type: 'text', text: 'here is the image' },
+            { type: 'image_url', imageUrl: { url: 'data:image/png;base64,AAAA' } },
+          ],
+          toolCallId: 'call_img',
+          toolCalls: [],
+        },
+        { role: 'user', content: [{ type: 'text', text: 'Now explain it' }], toolCalls: [] },
+      ]);
+
+      expect(contents.map((c) => c.role)).toEqual(['user', 'model', 'user']);
+      const last = contents.at(-1)!;
+      expect(last.parts[0]).toEqual({ text: 'Now explain it' });
+      expect(last.parts.some((p) => p.functionResponse !== undefined)).toBe(true);
     });
 
     it('multi-turn conversation with system prompt sets systemInstruction', async () => {


### PR DESCRIPTION
## Related Issue

Resolve #2913

## Problem

Gemini (`google-genai`, e.g. `gemini-3.7-flash` thinking model) tool-calling sessions fail on the follow-up request with one of two upstream 400 errors:

1. `Function call is missing a thought_signature in functionCall parts. ...` — the v2 engine's `tool.call` loop event drops `ToolCall.extras` (`thought_signature_b64`), so the fold-rebuilt assistant message cannot echo `thoughtSignature` on the outbound functionCall part.
2. `Requests ending with a model turn are not supported.` — `mergeConsecutiveUserMessages` merges a trailing plain user message into the preceding tool-result Content as `[functionResponse, text]`; Gemini 3.x rejects a request whose last Content starts with `functionResponse` followed by text.

Error #1 masks #2; after fixing #1, long tool-calling sessions then hit #2.

## What changed

- `packages/agent-core-v2/src/agent/loop/loopService.ts`: pass `extras` (looked up from `response.message.toolCalls`) into the `tool.call` loop event, matching what the v1 engine already does. The event type and the fold already supported the field.
- `packages/kosong/src/providers/google-genai.ts` and `packages/agent-core-v2/.../google-genai.ts`: when merging a tool-result Content with a following text-only user Content, keep the text part first (`[text, functionResponse]`), which the upstream accepts.

## Validation

- Regression test in `packages/agent-core-v2/test/agent/loop/loop.test.ts` (extras survive tool.call → fold → context); reverting the fix makes it fail with `expected undefined to deeply equal {thought_signature_b64}`.
- Order assertion added to `packages/kosong/test/google-genai.test.ts`.
- Replayed a real failing session's wire log through fold → projector → content assembly: trailing Content is now `[text, functionResponse, text]`, accepted by the upstream (200); the pre-fix `[functionResponse, text]` reproduced the exact 400.
- `kosong` 85 tests + agent-core-v2 loop 49 tests pass; both packages typecheck.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset. (changeset included: `.changeset/fix-gemini-thought-signature.md`)
- [x] Ran `gen-docs` skill, or this PR needs no doc update. (no user-facing doc change)
