### PR TITLE
fix(tui): sanitize foreground Bash tool output

### DIFF
--- a/.changeset/sanitize-foreground-bash-output.md
+++ b/.changeset/sanitize-foreground-bash-output.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Sanitize foreground Bash tool output so captured terminal escape sequences no longer change the host terminal state.

--- a/apps/kimi-code/src/tui/components/messages/shell-execution.ts
+++ b/apps/kimi-code/src/tui/components/messages/shell-execution.ts
@@ -3,6 +3,7 @@ import { Container, Text } from '@moonshot-ai/pi-tui';
 
 import { currentTheme } from '#/tui/theme';
 import type { ToolCallBlockData, ToolResultBlockData } from '#/tui/types';
+import { sanitizeShellOutput } from '#/tui/utils/shell-output';
 
 import type { ResultRenderer } from './tool-renderers/types';
 import { PREVIEW_LINES } from './tool-renderers/types';
@@ -68,8 +69,10 @@ export class ShellExecutionComponent extends Container {
     expandHint: boolean,
   ): void {
     if (!result.output) return;
+    // Untrusted bytes: sanitize the whole buffer, not each chunk, so escape
+    // sequences split across live-output chunks cannot reach the terminal.
     this.addChild(
-      new TruncatedOutputComponent(result.output, {
+      new TruncatedOutputComponent(sanitizeShellOutput(result.output), {
         expanded,
         isError: result.is_error ?? false,
         maxLines: previewLines,


### PR DESCRIPTION
## Related Issue

Fixes #2915

## Problem

Foreground Bash tool stdout/stderr reaches pi-tui unsanitized, both while streaming and in the final result. A captured `ESC[?1049h` switches the host terminal to the alternate screen; inside tmux this makes native scrollback unavailable, and the pane stays in that state after Kimi Code exits because no matching `ESC[?1049l` is emitted.

`sanitizeShellOutput` already guards `!` shell mode and the background task views (#2863), but not the tool-call card.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.