### PR TITLE
chore: downgrade plan viewer changeset from minor to patch

### DIFF
--- a/.changeset/plan-panel-view.md
+++ b/.changeset/plan-panel-view.md
@@ -1,5 +1,5 @@
 ---
-"@moonshot-ai/kimi-code": minor
+"@moonshot-ai/kimi-code": patch
 ---
 
 web: Add a plan viewer panel: click a plan entry in the work bar to see the full plan, review results, and feedback.


### PR DESCRIPTION
## Related Issue

N/A — release versioning adjustment

## Problem

The plan viewer panel changeset is marked `minor`, which would bump the pending release to 0.37.0. It is a web-only viewer panel on the existing plan surface, and everything else in the pending release is a fix, so `patch` fits the change better and keeps the release at 0.36.1.

## What changed

- `.changeset/plan-panel-view.md`: frontmatter `minor` → `patch`; entry wording unchanged
- After merge, the changesets action regenerates the release PR as 0.36.1 with this entry under Patch Changes

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [ ] I have added tests that prove my feature works. (N/A — changeset metadata only)
- [x] Ran `gen-changesets` skill, or this PR needs no changeset. (This PR is itself a changeset adjustment)
- [x] Ran `gen-docs` skill, or this PR needs no doc update. (N/A — no behavior change)