### PR TITLE
fix: tolerate Anthropic-style streams that omit text payloads

### DIFF
--- a/.changeset/fix-assistant-delta-missing-text.md
+++ b/.changeset/fix-assistant-delta-missing-text.md
@@ -2,4 +2,4 @@
 "@moonshot-ai/kimi-code": patch
 ---
 
-Fix a TUI crash when a provider streams Anthropic-style events that omit text payloads.
+Harden the assistant-message path against Anthropic-style streams that omit text payloads: the assembly layer (kosong and agent-core-v2) drops empty text parts so a tool-use turn no longer re-sends them verbatim to strict endpoints, the loop event bus coerces missing delta text to an empty string, and the TUI coerces missing thinking/hook-result content instead of crashing on `.trim()` of `undefined`.

--- a/.changeset/fix-assistant-delta-missing-text.md
+++ b/.changeset/fix-assistant-delta-missing-text.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Fix a TUI crash when a provider streams Anthropic-style events that omit text payloads.

--- a/apps/kimi-code/src/tui/controllers/session-event-handler.ts
+++ b/apps/kimi-code/src/tui/controllers/session-event-handler.ts
@@ -558,15 +558,19 @@ export class SessionEventHandler {
 
   private handleAssistantDelta(event: AssistantDeltaEvent): void {
     const { state, streamingUI } = this.host;
+    // Malformed/provider-quirk wire records can arrive without a delta payload
+    // (e.g. an Anthropic content_block_start whose text block omits `text` —
+    // JSON serialization then drops the key). Coerce instead of crashing.
+    const delta = typeof event.delta === 'string' ? event.delta : '';
     if (streamingUI.hasThinkingDraft()) {
       streamingUI.flushThinkingToTranscript('idle');
     }
 
-    if (event.delta.trim().length > 0) {
+    if (delta.trim().length > 0) {
       this.currentTurnHasAssistantText = true;
       this.pendingModelBlockedFallback = undefined;
     }
-    streamingUI.appendAssistantDelta(event.delta);
+    streamingUI.appendAssistantDelta(delta);
 
     this.host.patchLivePane({
       mode: 'idle',

--- a/apps/kimi-code/src/tui/controllers/session-event-handler.ts
+++ b/apps/kimi-code/src/tui/controllers/session-event-handler.ts
@@ -539,6 +539,11 @@ export class SessionEventHandler {
 
   private handleThinkingDelta(event: ThinkingDeltaEvent): void {
     const { state, streamingUI } = this.host;
+    // Malformed/provider-quirk wire records can arrive without a delta payload
+    // (e.g. an Anthropic content_block_start whose thinking block omits
+    // `thinking` — JSON serialization then drops the key). Coerce instead of
+    // crashing.
+    const delta = typeof event.delta === 'string' ? event.delta : '';
     // Encrypted / redacted reasoning (e.g. Kimi over the Anthropic-compatible
     // protocol) streams thinking deltas whose visible text is empty — only an
     // opaque signature rides along. Models also occasionally stream whitespace-
@@ -547,8 +552,8 @@ export class SessionEventHandler {
     // moon spinner while no ThinkingComponent is ever created (it needs visible
     // text), leaving a blank, spinner-less gap until the first real text/tool
     // token arrives. Keep the moon up until actual thinking text shows up.
-    if (event.delta.trim().length === 0 && !streamingUI.hasThinkingDraft()) return;
-    streamingUI.appendThinkingDelta(event.delta);
+    if (delta.trim().length === 0 && !streamingUI.hasThinkingDraft()) return;
+    streamingUI.appendThinkingDelta(delta);
     this.host.patchLivePane({ mode: 'idle' });
     if (state.appState.streamingPhase !== 'thinking') {
       this.host.setAppState({ streamingPhase: 'thinking', streamingStartTime: Date.now() });
@@ -589,7 +594,11 @@ export class SessionEventHandler {
       this.host.streamingUI.flushThinkingToTranscript('idle');
     }
     this.host.streamingUI.finalizeAssistantStream();
-    if (event.content.trim().length > 0) {
+    // Malformed/provider-quirk wire records can arrive without content (the
+    // provider may omit the hook result payload — JSON serialization then
+    // drops the key). Coerce instead of crashing.
+    const content = typeof event.content === 'string' ? event.content : '';
+    if (content.trim().length > 0) {
       this.currentTurnHasAssistantText = true;
       this.pendingModelBlockedFallback = undefined;
     }

--- a/apps/kimi-code/src/tui/utils/hook-result-format.ts
+++ b/apps/kimi-code/src/tui/utils/hook-result-format.ts
@@ -13,6 +13,10 @@ function formatHookResultTitle(event: HookResultEvent): string {
 }
 
 function formatHookResultBody(event: HookResultEvent): string {
-  const content = event.content.trim();
-  return content.length === 0 ? '(empty)' : content;
+  // Malformed/provider-quirk wire records can arrive without content (the
+  // provider may omit the hook result payload — JSON serialization then drops
+  // the key). Coerce instead of crashing.
+  const content = typeof event.content === 'string' ? event.content : '';
+  const trimmed = content.trim();
+  return trimmed.length === 0 ? '(empty)' : trimmed;
 }

--- a/apps/kimi-code/test/tui/controllers/session-event-handler-plugin-updates.test.ts
+++ b/apps/kimi-code/test/tui/controllers/session-event-handler-plugin-updates.test.ts
@@ -187,3 +187,22 @@ describe('SessionEventHandler plugin update notices', () => {
     expect(notifier.handlePluginCommandCompleted).not.toHaveBeenCalled();
   });
 });
+
+describe('SessionEventHandler malformed assistant.delta', () => {
+  it('coerces a missing delta payload to an empty delta instead of throwing', () => {
+    const { host, streamingUI } = makeHost();
+    const ui = streamingUI as unknown as Record<string, unknown>;
+    ui['hasThinkingDraft'] = vi.fn(() => false);
+    ui['appendAssistantDelta'] = vi.fn();
+    ui['scheduleFlush'] = vi.fn();
+    const handler = new SessionEventHandler(host, makeNotifier() as unknown as PluginUpdateNotifier);
+
+    expect(() =>
+      handler.handleEvent(
+        { type: 'assistant.delta', sessionId: 's1', agentId: 'main', turnId: 1 } as never,
+        sendQueued,
+      ),
+    ).not.toThrow();
+    expect(ui['appendAssistantDelta']).toHaveBeenCalledWith('');
+  });
+});

--- a/apps/kimi-code/test/tui/controllers/session-event-handler-plugin-updates.test.ts
+++ b/apps/kimi-code/test/tui/controllers/session-event-handler-plugin-updates.test.ts
@@ -197,12 +197,56 @@ describe('SessionEventHandler malformed assistant.delta', () => {
     ui['scheduleFlush'] = vi.fn();
     const handler = new SessionEventHandler(host, makeNotifier() as unknown as PluginUpdateNotifier);
 
-    expect(() =>
+    expect(() => {
       handler.handleEvent(
         { type: 'assistant.delta', sessionId: 's1', agentId: 'main', turnId: 1 } as never,
         sendQueued,
-      ),
-    ).not.toThrow();
+      );
+    }).not.toThrow();
     expect(ui['appendAssistantDelta']).toHaveBeenCalledWith('');
+  });
+});
+
+describe('SessionEventHandler malformed thinking.delta', () => {
+  it('coerces a missing delta payload to an empty delta instead of throwing', () => {
+    const { host, streamingUI } = makeHost();
+    const ui = streamingUI as unknown as Record<string, unknown>;
+    ui['hasThinkingDraft'] = vi.fn(() => true);
+    ui['appendThinkingDelta'] = vi.fn();
+    ui['scheduleFlush'] = vi.fn();
+    const handler = new SessionEventHandler(host, makeNotifier() as unknown as PluginUpdateNotifier);
+
+    expect(() => {
+      handler.handleEvent(
+        { type: 'thinking.delta', sessionId: 's1', agentId: 'main', turnId: 1 } as never,
+        sendQueued,
+      );
+    }).not.toThrow();
+    expect(ui['appendThinkingDelta']).toHaveBeenCalledWith('');
+  });
+});
+
+describe('SessionEventHandler malformed hook.result', () => {
+  it('coerces a missing content payload instead of throwing', () => {
+    const { host, streamingUI } = makeHost();
+    const ui = streamingUI as unknown as Record<string, unknown>;
+    ui['hasThinkingDraft'] = vi.fn(() => false);
+    ui['flushThinkingToTranscript'] = vi.fn();
+    ui['finalizeAssistantStream'] = vi.fn();
+    const handler = new SessionEventHandler(host, makeNotifier() as unknown as PluginUpdateNotifier);
+    const h = host as unknown as { appendTranscriptEntry: ReturnType<typeof vi.fn> };
+
+    expect(() => {
+      handler.handleEvent(
+        { type: 'hook.result', sessionId: 's1', agentId: 'main', turnId: 1, hookEvent: 'pre-tool-use' } as never,
+        sendQueued,
+      );
+    }).not.toThrow();
+    // The rendered markdown must still be produced, falling back to the empty
+    // placeholder instead of crashing on `event.content.trim()`.
+    expect(h.appendTranscriptEntry).toHaveBeenCalledTimes(1);
+    const entry = h.appendTranscriptEntry.mock.calls[0]?.[0] as { content: string };
+    expect(entry.content).toContain('pre-tool-use hook');
+    expect(entry.content).toContain('(empty)');
   });
 });

--- a/packages/agent-core-v2/src/agent/loop/loopService.ts
+++ b/packages/agent-core-v2/src/agent/loop/loopService.ts
@@ -1099,12 +1099,12 @@ export class AgentLoopService extends Disposable implements IAgentLoopService {
           case 'text':
             onResponseEvent();
             accumulate(part);
-            this.eventBus.publish({ type: 'assistant.delta', turnId, delta: part.text });
+            this.eventBus.publish({ type: 'assistant.delta', turnId, delta: part.text ?? '' });
             return;
           case 'think':
             onResponseEvent();
             accumulate(part);
-            this.eventBus.publish({ type: 'thinking.delta', turnId, delta: part.think });
+            this.eventBus.publish({ type: 'thinking.delta', turnId, delta: part.think ?? '' });
             return;
           case 'image_url':
           case 'audio_url':

--- a/packages/agent-core-v2/src/kosong/contract/generate.ts
+++ b/packages/agent-core-v2/src/kosong/contract/generate.ts
@@ -130,6 +130,21 @@ export async function generate(
   if (pendingPart !== null) {
     flushPart(message, pendingPart, toolCallIndexMap);
   }
+  // Drop vacuous text parts (empty string) from the final message: they carry
+  // nothing and convertMessage re-sends them verbatim, which strict Anthropic
+  // endpoints reject (400, "text blocks must be non-empty") — aborting a
+  // tool-use loop. Filtering after mergeInPlace keeps compliant streams (an
+  // empty block start merged with later text deltas) intact. A response that
+  // is otherwise entirely empty is left alone so its existing downstream flow
+  // (the transcript's settleStep removes the empty step) stays unchanged
+  // instead of tripping the empty-response error below.
+  if (
+    message.toolCalls.length > 0 ||
+    message.content.some((part) => part.type !== 'text' || part.text !== '')
+  ) {
+    const kept = message.content.filter((part) => !(part.type === 'text' && part.text === ''));
+    message.content.splice(0, message.content.length, ...kept);
+  }
   if (message.content.length === 0 && message.toolCalls.length === 0) {
     throw new APIEmptyResponseError(
       'The API returned an empty response (no content, no tool calls).' +

--- a/packages/agent-core-v2/src/kosong/provider/bases/anthropic/anthropic.ts
+++ b/packages/agent-core-v2/src/kosong/provider/bases/anthropic/anthropic.ts
@@ -668,7 +668,7 @@ class AnthropicStreamedMessage implements StreamedMessage {
       switch (block.type) {
         case 'text':
           if (block.text !== undefined) {
-            yield { type: 'text', text: block.text ?? '' };
+            yield { type: 'text', text: block.text };
           }
           break;
         case 'thinking':

--- a/packages/agent-core-v2/src/kosong/provider/bases/anthropic/anthropic.ts
+++ b/packages/agent-core-v2/src/kosong/provider/bases/anthropic/anthropic.ts
@@ -668,7 +668,7 @@ class AnthropicStreamedMessage implements StreamedMessage {
       switch (block.type) {
         case 'text':
           if (block.text !== undefined) {
-            yield { type: 'text', text: block.text };
+            yield { type: 'text', text: block.text ?? '' };
           }
           break;
         case 'thinking':
@@ -721,7 +721,7 @@ class AnthropicStreamedMessage implements StreamedMessage {
           // eslint-disable-next-line typescript-eslint/switch-exhaustiveness-check
           switch (block.type) {
             case 'text':
-              yield { type: 'text', text: block.text };
+              yield { type: 'text', text: block.text ?? '' };
               break;
             case 'thinking':
               yield { type: 'think', think: block.thinking ?? '' };
@@ -751,7 +751,7 @@ class AnthropicStreamedMessage implements StreamedMessage {
           // eslint-disable-next-line typescript-eslint/switch-exhaustiveness-check
           switch (delta.type) {
             case 'text_delta':
-              yield { type: 'text', text: delta.text };
+              yield { type: 'text', text: delta.text ?? '' };
               break;
             case 'thinking_delta':
               yield { type: 'think', think: delta.thinking ?? '' };

--- a/packages/agent-core-v2/test/kosong/provider/composition.test.ts
+++ b/packages/agent-core-v2/test/kosong/provider/composition.test.ts
@@ -60,6 +60,7 @@ import {
   APIStatusError,
   isRetryableGenerateError,
 } from '#/kosong/contract/errors';
+import { generate } from '#/kosong/contract/generate';
 import type { Message } from '#/kosong/contract/message';
 import type {
   ChatProvider,
@@ -1434,5 +1435,98 @@ describe('malformed anthropic stream resilience', () => {
     const textParts = parts.filter((part) => part.type === 'text');
     expect(textParts.length).toBeGreaterThan(0);
     for (const part of textParts) expect(part.text).toBe('');
+  });
+
+  it('contract generate() drops empty text parts but keeps tool calls intact', async () => {
+    const provider = registry.createChatProvider({
+      protocol: 'anthropic',
+      modelName: 'claude-opus-4-6',
+      apiKey: 'sk-probe',
+    });
+    const client = sdkClient(provider) as {
+      messages: { create: unknown };
+      beta: { messages: { create: unknown } };
+    };
+    async function* malformedToolStream(): AsyncIterable<unknown> {
+      yield {
+        type: 'message_start',
+        message: { id: 'msg_probe_tool', usage: { input_tokens: 3, output_tokens: 1 } },
+      };
+      // A non-compliant relay may omit `text` on the block start and on deltas.
+      yield { type: 'content_block_start', index: 0, content_block: { type: 'text' } };
+      yield { type: 'content_block_delta', index: 0, delta: { type: 'text_delta' } };
+      yield { type: 'content_block_stop', index: 0 };
+      yield {
+        type: 'content_block_start',
+        index: 1,
+        content_block: { type: 'tool_use', id: 'toolu_probe', name: 'read', input: {} },
+      };
+      yield {
+        type: 'content_block_delta',
+        index: 1,
+        delta: { type: 'input_json_delta', partial_json: '{"path":"a.txt"}' },
+      };
+      yield { type: 'content_block_stop', index: 1 };
+      yield {
+        type: 'message_delta',
+        delta: { stop_reason: 'tool_use' },
+        usage: { output_tokens: 1 },
+      };
+      yield { type: 'message_stop' };
+    }
+    const create = vi.fn().mockImplementation(() => Promise.resolve(malformedToolStream()));
+    client.messages.create = create;
+    client.beta.messages.create = create;
+
+    const { message } = await generate(provider, '', [], PROBE_HISTORY);
+
+    // The empty text part (coerced from the missing `text` payload) must not
+    // reach the final message — convertMessage would re-send it verbatim and
+    // strict Anthropic endpoints reject empty text blocks (400), aborting the
+    // tool-use loop. The tool call must assemble normally.
+    expect(message.content.filter((p) => p.type === 'text')).toEqual([]);
+    expect(message.toolCalls).toHaveLength(1);
+    expect(message.toolCalls[0]!.id).toBe('toolu_probe');
+    expect(message.toolCalls[0]!.name).toBe('read');
+    expect(message.toolCalls[0]!.arguments).toBe('{"path":"a.txt"}');
+  });
+
+  it('contract generate() keeps an all-empty response intact for downstream settleStep removal', async () => {
+    const provider = registry.createChatProvider({
+      protocol: 'anthropic',
+      modelName: 'claude-opus-4-6',
+      apiKey: 'sk-probe',
+    });
+    const client = sdkClient(provider) as {
+      messages: { create: unknown };
+      beta: { messages: { create: unknown } };
+    };
+    async function* allEmptyStream(): AsyncIterable<unknown> {
+      yield {
+        type: 'message_start',
+        message: { id: 'msg_probe_empty', usage: { input_tokens: 3, output_tokens: 1 } },
+      };
+      // A non-compliant relay may omit `text` on the block start and on deltas.
+      yield { type: 'content_block_start', index: 0, content_block: { type: 'text' } };
+      yield { type: 'content_block_delta', index: 0, delta: { type: 'text_delta' } };
+      yield { type: 'content_block_stop', index: 0 };
+      yield {
+        type: 'message_delta',
+        delta: { stop_reason: 'end_turn' },
+        usage: { output_tokens: 1 },
+      };
+      yield { type: 'message_stop' };
+    }
+    const create = vi.fn().mockImplementation(() => Promise.resolve(allEmptyStream()));
+    client.messages.create = create;
+    client.beta.messages.create = create;
+
+    // An all-empty response (no tool calls) keeps its existing flow: it is
+    // returned (not thrown as APIEmptyResponseError) so the transcript's
+    // settleStep removes the vacuous step downstream. Only empty text parts
+    // riding alongside real content or tool calls are filtered.
+    const { message } = await generate(provider, '', [], PROBE_HISTORY);
+    expect(message.content).toEqual([{ type: 'text', text: '' }]);
+    expect(message.toolCalls).toEqual([]);
   });
 });

--- a/packages/agent-core-v2/test/kosong/provider/composition.test.ts
+++ b/packages/agent-core-v2/test/kosong/provider/composition.test.ts
@@ -1395,3 +1395,44 @@ describe('429 wire behavior over real HTTP (no hidden SDK retry)', () => {
     },
   );
 });
+
+describe('malformed anthropic stream resilience', () => {
+  it('coerces text blocks/deltas that omit `text` into empty-string deltas', async () => {
+    const provider = registry.createChatProvider({
+      protocol: 'anthropic',
+      modelName: 'claude-opus-4-6',
+      apiKey: 'sk-probe',
+    });
+    const client = sdkClient(provider) as {
+      messages: { create: unknown };
+      beta: { messages: { create: unknown } };
+    };
+    async function* malformedStream(): AsyncIterable<unknown> {
+      yield {
+        type: 'message_start',
+        message: { id: 'msg_probe', usage: { input_tokens: 3, output_tokens: 1 } },
+      };
+      // A non-compliant relay may omit `text` on the block start and on deltas.
+      yield { type: 'content_block_start', index: 0, content_block: { type: 'text' } };
+      yield { type: 'content_block_delta', index: 0, delta: { type: 'text_delta' } };
+      yield { type: 'content_block_stop', index: 0 };
+      yield {
+        type: 'message_delta',
+        delta: { stop_reason: 'end_turn' },
+        usage: { output_tokens: 1 },
+      };
+    }
+    const create = vi.fn().mockImplementation(() => Promise.resolve(malformedStream()));
+    client.messages.create = create;
+    client.beta.messages.create = create;
+
+    const parts: { type: string; text?: unknown }[] = [];
+    for await (const part of await provider.generate('', [], PROBE_HISTORY)) {
+      parts.push(part as { type: string; text?: unknown });
+    }
+
+    const textParts = parts.filter((part) => part.type === 'text');
+    expect(textParts.length).toBeGreaterThan(0);
+    for (const part of textParts) expect(part.text).toBe('');
+  });
+});

--- a/packages/kosong/src/generate.ts
+++ b/packages/kosong/src/generate.ts
@@ -212,6 +212,21 @@ export async function generate(
   if (pendingPart !== null) {
     flushPart(message, pendingPart, toolCallIndexMap);
   }
+  // Drop vacuous text parts (empty string) from the final message: they carry
+  // nothing and convertMessage re-sends them verbatim, which strict Anthropic
+  // endpoints reject (400, "text blocks must be non-empty") — aborting a
+  // tool-use loop. Filtering after mergeInPlace keeps compliant streams (an
+  // empty block start merged with later text deltas) intact. A response that
+  // is otherwise entirely empty is left alone so its existing downstream flow
+  // (the transcript's settleStep removes the empty step) stays unchanged
+  // instead of tripping the empty-response error below.
+  if (
+    message.toolCalls.length > 0 ||
+    message.content.some((part) => part.type !== 'text' || part.text !== '')
+  ) {
+    const kept = message.content.filter((part) => !(part.type === 'text' && part.text === ''));
+    message.content.splice(0, message.content.length, ...kept);
+  }
   if (message.content.length === 0 && message.toolCalls.length === 0) {
     throw new APIEmptyResponseError(
       'The API returned an empty response (no content, no tool calls).' +

--- a/packages/kosong/src/providers/anthropic.ts
+++ b/packages/kosong/src/providers/anthropic.ts
@@ -809,7 +809,7 @@ class AnthropicStreamedMessage implements StreamedMessage {
           // eslint-disable-next-line typescript-eslint/switch-exhaustiveness-check
           switch (block.type) {
             case 'text':
-              yield { type: 'text', text: block.text };
+              yield { type: 'text', text: block.text ?? '' };
               break;
             case 'thinking':
               yield { type: 'think', think: block.thinking ?? '' };
@@ -842,7 +842,7 @@ class AnthropicStreamedMessage implements StreamedMessage {
           // eslint-disable-next-line typescript-eslint/switch-exhaustiveness-check
           switch (delta.type) {
             case 'text_delta':
-              yield { type: 'text', text: delta.text };
+              yield { type: 'text', text: delta.text ?? '' };
               break;
             case 'thinking_delta':
               yield { type: 'think', think: delta.thinking ?? '' };

--- a/packages/kosong/test/anthropic.test.ts
+++ b/packages/kosong/test/anthropic.test.ts
@@ -2846,6 +2846,87 @@ describe('AnthropicChatProvider', () => {
       ]);
     });
 
+    it('generate() drops empty text parts while keeping tool calls intact', async () => {
+      // End-to-end through the contract generate(): a stream whose text block
+      // omits `text` (coerced to an empty string by the adapter) must not leak
+      // an empty text part into the final assistant message — convertMessage
+      // would re-send it verbatim and strict Anthropic endpoints reject empty
+      // text blocks (400), aborting the tool-use loop.
+      const { generate } = await import('#/generate');
+
+      const provider = createStreamProvider();
+      const stream = mockStream([
+        {
+          type: 'message_start',
+          message: { id: 'msg_stream_tool', usage: { input_tokens: 10 } },
+        },
+        { type: 'content_block_start', index: 0, content_block: { type: 'text' } },
+        { type: 'content_block_delta', index: 0, delta: { type: 'text_delta' } },
+        { type: 'content_block_stop', index: 0 },
+        {
+          type: 'content_block_start',
+          index: 1,
+          content_block: { type: 'tool_use', id: 'toolu_x', name: 'add', input: {} },
+        },
+        {
+          type: 'content_block_delta',
+          index: 1,
+          delta: { type: 'input_json_delta', partial_json: '{"a":2,"b":3}' },
+        },
+        { type: 'content_block_stop', index: 1 },
+        { type: 'message_delta', delta: { stop_reason: 'tool_use' }, usage: { output_tokens: 5 } },
+        { type: 'message_stop' },
+      ]);
+
+      (provider as any)._client.messages.create = vi.fn().mockResolvedValue(stream) as never;
+
+      const { message } = await generate(
+        provider,
+        '',
+        [],
+        [{ role: 'user', content: [{ type: 'text', text: 'Hi' }], toolCalls: [] }],
+      );
+
+      expect(message.content.filter((p) => p.type === 'text')).toEqual([]);
+      expect(message.toolCalls).toHaveLength(1);
+      expect(message.toolCalls[0]!.id).toBe('toolu_x');
+      expect(message.toolCalls[0]!.name).toBe('add');
+      expect(message.toolCalls[0]!.arguments).toBe('{"a":2,"b":3}');
+    });
+
+    it('generate() leaves an all-empty response intact for downstream removal', async () => {
+      // A response that is entirely an empty text block (no tool calls) keeps
+      // its existing flow: generate() returns it instead of throwing
+      // APIEmptyResponseError, and the transcript's settleStep removes the
+      // vacuous step downstream. Only empty text parts riding alongside real
+      // content or tool calls are filtered.
+      const { generate } = await import('#/generate');
+
+      const provider = createStreamProvider();
+      const stream = mockStream([
+        {
+          type: 'message_start',
+          message: { id: 'msg_stream_empty', usage: { input_tokens: 10 } },
+        },
+        { type: 'content_block_start', index: 0, content_block: { type: 'text' } },
+        { type: 'content_block_delta', index: 0, delta: { type: 'text_delta' } },
+        { type: 'message_delta', delta: {}, usage: { output_tokens: 5 } },
+        { type: 'message_stop' },
+      ]);
+
+      (provider as any)._client.messages.create = vi.fn().mockResolvedValue(stream) as never;
+
+      const { message } = await generate(
+        provider,
+        '',
+        [],
+        [{ role: 'user', content: [{ type: 'text', text: 'Hi' }], toolCalls: [] }],
+      );
+
+      expect(message.content).toEqual([{ type: 'text', text: '' }]);
+      expect(message.toolCalls).toEqual([]);
+    });
+
     it('yields thinking delta and signature from stream events', async () => {
       const provider = createStreamProvider();
       const stream = mockStream([

--- a/packages/kosong/test/anthropic.test.ts
+++ b/packages/kosong/test/anthropic.test.ts
@@ -2816,6 +2816,36 @@ describe('AnthropicChatProvider', () => {
       });
     });
 
+    it('coerces text blocks and deltas that omit `text` to empty strings', async () => {
+      const provider = createStreamProvider();
+      const stream = mockStream([
+        {
+          type: 'message_start',
+          message: { id: 'msg_stream_malformed', usage: { input_tokens: 10 } },
+        },
+        // A non-compliant relay may omit `text` on the block start and on deltas.
+        { type: 'content_block_start', index: 0, content_block: { type: 'text' } },
+        { type: 'content_block_delta', index: 0, delta: { type: 'text_delta' } },
+        { type: 'message_delta', delta: {}, usage: { output_tokens: 5 } },
+        { type: 'message_stop' },
+      ]);
+
+      (provider as any)._client.messages.create = vi.fn().mockResolvedValue(stream) as never;
+
+      const result = await provider.generate(
+        '',
+        [],
+        [{ role: 'user', content: [{ type: 'text', text: 'Hi' }], toolCalls: [] }],
+      );
+
+      const parts = await collectParts(result);
+
+      expect(parts).toEqual([
+        { type: 'text', text: '' },
+        { type: 'text', text: '' },
+      ]);
+    });
+
     it('yields thinking delta and signature from stream events', async () => {
       const provider = createStreamProvider();
       const stream = mockStream([

--- a/packages/kosong/test/regression.test.ts
+++ b/packages/kosong/test/regression.test.ts
@@ -46,7 +46,7 @@ function createMockProvider(stream: StreamedMessage): ChatProvider {
 
 describe('regression', () => {
   describe('empty text parts', () => {
-    it('standalone empty TextPart is kept in content', async () => {
+    it('standalone empty TextPart is filtered out of content', async () => {
       const stream = createMockStream([
         { type: 'text', text: 'before' },
         { type: 'image_url', imageUrl: { url: 'https://example.com/img.png' } },
@@ -56,10 +56,12 @@ describe('regression', () => {
 
       const result = await generate(provider, '', [], []);
 
+      // Empty text parts carry nothing and would be rejected verbatim by
+      // strict Anthropic endpoints when re-sent on a tool-use turn, so the
+      // assembly layer drops them.
       expect(result.message.content).toEqual([
         { type: 'text', text: 'before' },
         { type: 'image_url', imageUrl: { url: 'https://example.com/img.png' } },
-        { type: 'text', text: '' },
       ]);
     });
   });


### PR DESCRIPTION
## Related Issue

Resolve #2924

## Problem

See linked issue. In short: when an Anthropic-compatible endpoint (typically a relay/proxy) streams `content_block_start` / `text_delta` events that omit the `text` field, the engine produces text parts with `text: undefined`; JSON serialization then drops the `delta` key from the `assistant.delta` event, and the TUI crashes on `event.delta.trim()`.

## What changed

- **Parsers** (`packages/kosong` and `packages/agent-core-v2` Anthropic bases): coerce missing `text` on `content_block_start`, `text_delta`, and the non-stream text block to `''` — the same pattern already used for `thinking ?? ''` right below.
- **TUI** (`handleAssistantDelta`): coerce a non-string `event.delta` to `''` before use, so a malformed wire record can never crash the handler regardless of engine version.
- **Tests**: regression coverage for both layers — a malformed Anthropic stream (kosong + v2 composition) and a missing-payload `assistant.delta` event (TUI handler).

The empty-string coercion preserves existing behavior for compliant providers (Anthropic already emits `text: ''` on block start), and matches how thinking deltas are handled today.

## Round 2: assembly-layer filtering + boundary hardening

Review surfaced one real follow-up risk and a few defense gaps; this round addresses them:

- **Assembly** (`kosong/src/generate.ts`, `agent-core-v2/src/kosong/contract/generate.ts`): after `mergeInPlace`, drop `text === ''` parts **only when the message has tool calls or any non-empty content**. A part that stays empty after merging means the provider sent a bare vacuous block; replaying it on the next tool-use round makes strict Anthropic endpoints answer `400: text content blocks must be non-empty`. All-empty responses are deliberately kept intact so the existing `settleStep` removal path handles them unchanged (filtering them to `content: []` would instead trip the retryable `APIEmptyResponseError`).
- **Loop choke point** (`agent-core-v2/src/agent/loop/loopService.ts`): `part.text ?? ''` / `part.think ?? ''` where delta events are published, protecting every event consumer independent of provider.
- **Dead code** (`agent-core-v2` anthropic base): remove `?? ''` under an existing `!== undefined` guard.
- **TUI**: same `typeof` coercion for `thinking.delta` and `hook.result` content; `formatHookResultBody` now tolerates a missing `content` field, which also covers the subagent/btw panel renderers that share it.
- **Tests**: pin the new filtering behavior at both assembly layers (empty text dropped while tool calls stay intact; all-empty response untouched); restore exact provider-level coercion assertions; cover malformed `thinking.delta` / `hook.result` payloads. One pre-existing regression pin (`standalone empty TextPart is kept in content`) is intentionally inverted to match the new assembly contract.

## Deliberate non-goals

- The swarm progress panel (`agent-swarm-progress.ts` `appendModelDelta`) has the same class of exposure on a missing `delta`, but it is a separate display path; left untouched to keep this PR focused. Happy to follow up if you want it covered here.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.
