### PR TITLE
fix: restore live context usage meter after v2

### DIFF
--- a/.changeset/fix-context-usage-meter.md
+++ b/.changeset/fix-context-usage-meter.md
@@ -1,0 +1,6 @@
+---
+"@moonshot-ai/kimi-code-sdk": patch
+"@moonshot-ai/kimi-code": patch
+---
+
+Restore live context-window usage on agent status so the TUI and VS Code meters update after attach and during a turn.

--- a/apps/vscode/src/runtime/event-adapter.ts
+++ b/apps/vscode/src/runtime/event-adapter.ts
@@ -325,12 +325,24 @@ function mapLegacyWireEvent(
   }
 }
 
+function contextUsageRatio(
+  sdkEvent: Extract<Event, { type: 'agent.status.updated' }>,
+): number | undefined {
+  const tokens = sdkEvent.contextTokens;
+  const max = sdkEvent.maxContextTokens;
+  if (typeof tokens === 'number' && typeof max === 'number' && max > 0) {
+    return tokens / max;
+  }
+  return sdkEvent.contextUsage;
+}
+
 function mapStatusUpdate(
   state: EventAdapterState,
   sdkEvent: Extract<Event, { type: 'agent.status.updated' }>,
 ): MappedLegacyWireEvent {
   const payload: StatusUpdate = {};
-  if (sdkEvent.contextUsage !== undefined) payload.context_usage = sdkEvent.contextUsage;
+  const contextUsage = contextUsageRatio(sdkEvent);
+  if (contextUsage !== undefined) payload.context_usage = contextUsage;
   if (sdkEvent.planMode !== undefined) payload.plan_mode = sdkEvent.planMode;
   if (sdkEvent.model !== undefined) payload.model = sdkEvent.model;
   if (sdkEvent.thinkingEffort !== undefined) payload.thinking_effort = sdkEvent.thinkingEffort;

--- a/apps/vscode/src/runtime/session-runtime.ts
+++ b/apps/vscode/src/runtime/session-runtime.ts
@@ -160,6 +160,7 @@ export class SessionRuntime {
           model: status.model,
           thinking_effort: status.thinkingEffort,
           plan_mode: status.planMode,
+          context_usage: status.contextUsage,
         },
         _sessionId: this.id,
       },

--- a/apps/vscode/test/event-adapter.test.ts
+++ b/apps/vscode/test/event-adapter.test.ts
@@ -262,6 +262,37 @@ describe('event adapter (projects SDK events into the legacy Webview contract)',
     });
   });
 
+  it('derives context_usage from token counts when the SDK omits contextUsage', () => {
+    const result = adaptSdkEvent(createEventAdapterState(), {
+      type: 'agent.status.updated',
+      sessionId: 'session-1',
+      agentId: 'main',
+      contextTokens: 25_600,
+      maxContextTokens: 256_000,
+    });
+
+    expect(result.event).toEqual({
+      type: 'StatusUpdate',
+      payload: { context_usage: 0.1 },
+      _sessionId: 'session-1',
+    });
+  });
+
+  it('prefers live token counts over an explicit contextUsage of 0', () => {
+    const result = adaptSdkEvent(createEventAdapterState(), {
+      type: 'agent.status.updated',
+      sessionId: 'session-1',
+      agentId: 'main',
+      contextUsage: 0,
+      contextTokens: 25_600,
+      maxContextTokens: 256_000,
+    });
+
+    expect(result.event).toMatchObject({
+      payload: { context_usage: 0.1 },
+    });
+  });
+
   it('emits snake-case status fields when agent status changes', () => {
     const result = adaptSdkEvent(createEventAdapterState(), {
       type: 'agent.status.updated',

--- a/apps/vscode/test/kimi-runtime.test.ts
+++ b/apps/vscode/test/kimi-runtime.test.ts
@@ -440,7 +440,12 @@ describe("Kimi runtime (owns shared SDK sessions for Webviews)", () => {
       event: Events.StreamEvent,
       data: {
         type: "StatusUpdate",
-        payload: { model: "kimi-test", thinking_effort: "max", plan_mode: true },
+        payload: {
+          model: "kimi-test",
+          thinking_effort: "max",
+          plan_mode: true,
+          context_usage: 0,
+        },
         _sessionId: "saved-1",
       },
       webviewId: "view-1",

--- a/apps/vscode/test/session-runtime.test.ts
+++ b/apps/vscode/test/session-runtime.test.ts
@@ -219,6 +219,22 @@ function turnEnded(
 }
 
 describe("session runtime (adapts one SDK session for subscribed Webviews)", () => {
+  it("announces context_usage from the session status snapshot", async () => {
+    const { runtime, broadcasts } = createRuntime();
+
+    await runtime.announceStatus("view-1");
+
+    expect(streamData(broadcasts)[0]).toMatchObject({
+      type: "StatusUpdate",
+      payload: {
+        thinking_effort: "off",
+        plan_mode: false,
+        context_usage: 0,
+      },
+      _sessionId: "session-1",
+    });
+  });
+
   it("renders a host-only command without making it a forkable core turn", () => {
     const { runtime, broadcasts } = createRuntime();
 

--- a/packages/node-sdk/src/v2/session-wiring.ts
+++ b/packages/node-sdk/src/v2/session-wiring.ts
@@ -282,11 +282,16 @@ function withStatusSnapshot(agent: IAgentScopeHandle, event: DomainEvent): Domai
   const contextTokens = tokenCounting.statusSize();
   const capabilities = profile.getModelCapabilities();
   const maxContextTokens = capabilities.max_input_tokens ?? capabilities.max_context_tokens;
+  const contextUsage =
+    typeof maxContextTokens === 'number' && maxContextTokens > 0
+      ? contextTokens / maxContextTokens
+      : 0;
   return {
     ...event,
     usage: usageService.status(),
     contextTokens,
     maxContextTokens,
+    contextUsage,
     model: profile.getModel(),
   } as unknown as DomainEvent;
 }

--- a/packages/node-sdk/test/session-event-wiring.test.ts
+++ b/packages/node-sdk/test/session-event-wiring.test.ts
@@ -138,6 +138,7 @@ describe('SessionEventWiring status snapshot fold', () => {
       usage: USAGE,
       contextTokens: 10,
       maxContextTokens: 128_000,
+      contextUsage: 10 / 128_000,
       model: 'sub-model',
     });
     expect(events[1]).toMatchObject({ type: 'assistant.delta', delta: 'Hi' });


### PR DESCRIPTION
VS Code and TUI only showed 0% because v2 status snapshots omitted contextUsage and attach did not announce it.

<!--
Thank you for your contribution to Kimi Code!
Please open an issue before sending a feature PR — PRs without prior discussion may be closed without review.

See https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md for more.
-->

## Related Issue

<!-- Link the issue this feature came from. If there is no issue, explain the problem in the next section instead. -->

Resolve #(issue_number)

## Problem

<!-- What user need or limitation does this address? If the linked issue already covers this, write "See linked issue". -->

## What changed

<!-- What did you implement, and why does this approach fit Kimi Code? -->

## Checklist

- [ ] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [ ] I have linked a related issue, or explained the problem above.
- [ ] I have added tests that prove my feature works.
- [ ] Ran `gen-changesets` skill, or this PR needs no changeset.
- [ ] Ran `gen-docs` skill, or this PR needs no doc update.
