### PR TITLE
fix(agent-core): stop retrying exhausted file watchers

### DIFF
--- a/.changeset/disable-exhausted-fs-watchers.md
+++ b/.changeset/disable-exhausted-fs-watchers.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Prevent filesystem watcher exhaustion from repeatedly retrying and crashing the Kimi CLI.

--- a/packages/agent-core-v2/src/os/backends/node-local/hostFsWatchService.ts
+++ b/packages/agent-core-v2/src/os/backends/node-local/hostFsWatchService.ts
@@ -23,6 +23,11 @@ const DEFAULT_IGNORED = (p: string): boolean => /(?:^|[/\\])\.git(?:$|[/\\])/.te
 const NATIVE_RETRY_BASE_MS = 1000;
 const NATIVE_RETRY_MAX_MS = 30000;
 
+function isWatchResourceExhaustion(error: unknown): boolean {
+  const code = (error as NodeJS.ErrnoException | undefined)?.code;
+  return code === 'EMFILE' || code === 'ENFILE';
+}
+
 interface NativeFsWatcher {
   close(): void;
   on(event: 'error', listener: (error: NodeJS.ErrnoException) => void): this;
@@ -107,6 +112,11 @@ class HostFsWatchHandle implements IHostFsWatchHandle {
       if (mapped !== undefined) this.emitter.fire(mapped);
     });
     this.watcher.on('error', (error: unknown) => {
+      if (isWatchResourceExhaustion(error)) {
+        onUnexpectedError(error);
+        this.dispose();
+        return;
+      }
       this.readiness.reject(error);
       onUnexpectedError(error);
     });
@@ -135,6 +145,7 @@ class SignalWatchHandle implements IHostFsWatchHandle {
   private retry: IDisposable | undefined;
   private retryAttempts = 0;
   private recovering = false;
+  private resourceExhausted = false;
   private disposed = false;
 
   constructor(
@@ -150,7 +161,7 @@ class SignalWatchHandle implements IHostFsWatchHandle {
   }
 
   private startNativeLeg(): void {
-    if (this.disposed) return;
+    if (this.disposed || this.resourceExhausted) return;
     try {
       const watcher = this.runtime.watchNative(this.root, (_eventType, filename) => {
         if (this.disposed) return;
@@ -178,6 +189,13 @@ class SignalWatchHandle implements IHostFsWatchHandle {
     if (watcher !== undefined && watcher !== this.nativeWatcher) return;
     watcher?.close();
     this.nativeWatcher = undefined;
+    if (isWatchResourceExhaustion(error)) {
+      this.resourceExhausted = true;
+      this.recovering = false;
+      this.readiness.resolve();
+      onUnexpectedError(error);
+      return;
+    }
     if (error.code === 'ERR_FEATURE_UNAVAILABLE_ON_PLATFORM') {
       this.recovering = false;
       this.startChokidarLeg();

--- a/packages/agent-core-v2/test/os/backends/node-local/hostFsWatchService.test.ts
+++ b/packages/agent-core-v2/test/os/backends/node-local/hostFsWatchService.test.ts
@@ -49,7 +49,10 @@ interface TestRetry {
   run(): void;
 }
 
-function signalRig(options?: { readonly synchronousFailures?: number }): {
+function signalRig(options?: {
+  readonly synchronousFailures?: number;
+  readonly synchronousFailureCode?: string;
+}): {
   readonly service: IHostFsWatchService;
   readonly attempts: TestNativeAttempt[];
   readonly retries: TestRetry[];
@@ -64,7 +67,9 @@ function signalRig(options?: { readonly synchronousFailures?: number }): {
     watchNative: (_root, listener) => {
       if (synchronousFailures > 0) {
         synchronousFailures -= 1;
-        throw Object.assign(new Error('native watch creation failed'), { code: 'EIO' });
+        throw Object.assign(new Error('native watch creation failed'), {
+          code: options?.synchronousFailureCode ?? 'EIO',
+        });
       }
       const watcher = new TestNativeWatcher();
       attempts.push({
@@ -220,6 +225,38 @@ describe('host filesystem change notifications', () => {
 
     expect(rig.retries.map((retry) => retry.delayMs)).toEqual([1000, 1000]);
   });
+
+  it.each(['EMFILE', 'ENFILE'])(
+    'disables a native watch instead of retrying after %s',
+    async (code) => {
+      const rig = signalRig();
+      const events: HostFsChange[] = [];
+      const reported: unknown[] = [];
+      setUnexpectedErrorHandler((error) => reported.push(error));
+      handle = rig.service.watch('/repo', { signal: true });
+      handle.onDidChange((event) => events.push(event));
+      await handle.ready;
+
+      rig.attempt(0).watcher.fail(code);
+
+      expect(rig.attempt(0).watcher.closed).toBe(true);
+      expect(rig.retries).toHaveLength(0);
+      expect(events).toHaveLength(0);
+      expect(reported).toHaveLength(1);
+    },
+  );
+
+  it.each(['EMFILE', 'ENFILE'])(
+    'becomes ready without retrying when native watch creation fails with %s',
+    async (code) => {
+      const rig = signalRig({ synchronousFailures: 1, synchronousFailureCode: code });
+      handle = rig.service.watch('/repo', { signal: true });
+
+      await expect(handle.ready).resolves.toBeUndefined();
+      expect(rig.attempts).toHaveLength(0);
+      expect(rig.retries).toHaveLength(0);
+    },
+  );
 
   it('cancels a pending native retry when the watch handle is disposed', () => {
     const rig = signalRig();


### PR DESCRIPTION
## Related Issue

Related to #2929

## Problem

When a host filesystem watcher hits `EMFILE` or `ENFILE`, retrying cannot recover until descriptors are released. The native signal watcher currently treats these errors as transient, emits invalidations, and repeatedly rearms itself; the precise watcher also stays live after reporting the error. That can amplify resource exhaustion instead of letting the CLI continue with file watching disabled for the affected handle.

## What changed

- Treat `EMFILE` and `ENFILE` as terminal for the affected watch handle.
- Close precise watchers and stop native retries while still reporting the original error once.
- Resolve watch readiness so startup can continue in degraded mode.
- Cover synchronous and asynchronous native failures for both resource-exhaustion codes.

## Verification

- `pnpm --filter @moonshot-ai/agent-core-v2 lint:imports`
- `pnpm --filter @moonshot-ai/agent-core-v2 typecheck`
- `pnpm --filter @moonshot-ai/agent-core-v2 exec vitest run test/os/backends/node-local/hostFsWatchService.test.ts` (15 passed, 1 platform skip)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.
