### PR TITLE
feat(plugins): add Mem0 to marketplace

### DIFF
--- a/.changeset/add-mem0-plugin.md
+++ b/.changeset/add-mem0-plugin.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Add the Mem0 plugin to the bundled plugin marketplace. Run /plugins and select Mem0 to install it.

--- a/plugins/marketplace.json
+++ b/plugins/marketplace.json
@@ -45,6 +45,15 @@
       "homepage": "https://github.com/GoogleChrome/modern-web-guidance",
       "keywords": ["web", "css", "browser", "frontend", "skills"],
       "source": "https://github.com/GoogleChrome/modern-web-guidance"
+    },
+    {
+      "id": "mem0",
+      "tier": "curated",
+      "displayName": "Mem0",
+      "description": "Persistent memory for Kimi Code CLI. Remembers your decisions, conventions, and preferences across sessions.",
+      "homepage": "https://mem0.ai",
+      "keywords": ["memory", "personalization", "mcp", "semantic-search"],
+      "source": "https://github.com/mem0ai/mem0/tree/main/integrations/mem0-plugin"
     }
   ]
 }


### PR DESCRIPTION
## What changed

Adds a `curated` marketplace entry for **Mem0** so Kimi Code CLI users can install it from `/plugins`. Mem0 gives the agent persistent, cross-session memory of decisions, conventions, and preferences, via the Mem0 MCP server, skills, and auto-capture hooks.

- `plugins/marketplace.json`: new curated entry
- `.changeset/add-mem0-plugin.md`: patch changeset

No prior issue, as this is a small marketplace data addition.

Note on `source`: the plugin lives in a monorepo subdirectory (`mem0ai/mem0` at `integrations/mem0-plugin`), so `source` is a `/tree/main/<subdir>` URL rather than a repo root. It installs cleanly as a local path; flagging in case the resolver expects a repo-root manifest, in which case we can point at a dedicated repo.

## Checklist

- [x] I have read the CONTRIBUTING document.
- [x] Changeset included.
- [x] No doc update needed.
