### PR TITLE
fix(tui): add provider refresh action

### DIFF
--- a/.changeset/refresh-provider-manager.md
+++ b/.changeset/refresh-provider-manager.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Add an explicit refresh action to the `/provider` manager. Press `R` to refresh provider models.

--- a/apps/kimi-code/src/tui/commands/provider.ts
+++ b/apps/kimi-code/src/tui/commands/provider.ts
@@ -77,6 +77,7 @@ function buildProviderManagerOptions(host: SlashCommandHost): ProviderManagerOpt
 }
 
 async function handleProviderManagerRefresh(host: SlashCommandHost): Promise<void> {
+  const managerAtRefreshStart = host.state.editorContainer.children[0];
   const spinner = host.showProgressSpinner('Refreshing provider models...');
   try {
     const result = await host.authFlow.refreshProviderModels();
@@ -92,7 +93,9 @@ async function handleProviderManagerRefresh(host: SlashCommandHost): Promise<voi
     spinner.stop({ ok: false, label: 'Provider refresh failed.' });
     throw error;
   } finally {
-    reopenProviderManager(host);
+    if (host.state.editorContainer.children[0] === managerAtRefreshStart) {
+      reopenProviderManager(host);
+    }
   }
 }
 

--- a/apps/kimi-code/src/tui/commands/provider.ts
+++ b/apps/kimi-code/src/tui/commands/provider.ts
@@ -60,6 +60,11 @@ function buildProviderManagerOptions(host: SlashCommandHost): ProviderManagerOpt
         host.showError(`Add provider failed: ${formatErrorMessage(error)}`);
       });
     },
+    onRefresh: () => {
+      void handleProviderManagerRefresh(host).catch((error: unknown) => {
+        host.showError(`Refresh providers failed: ${formatErrorMessage(error)}`);
+      });
+    },
     onDeleteSource: (providerIds) => {
       void handleProviderManagerDeleteSource(host, providerIds).catch((error: unknown) => {
         host.showError(`Remove provider failed: ${formatErrorMessage(error)}`);
@@ -69,6 +74,26 @@ function buildProviderManagerOptions(host: SlashCommandHost): ProviderManagerOpt
       host.restoreEditor();
     },
   };
+}
+
+async function handleProviderManagerRefresh(host: SlashCommandHost): Promise<void> {
+  const spinner = host.showProgressSpinner('Refreshing provider models...');
+  try {
+    const result = await host.authFlow.refreshProviderModels();
+    const ok = result.failed.length === 0;
+    spinner.stop({
+      ok,
+      label: ok ? 'Provider refresh finished.' : 'Provider refresh finished with warnings.',
+    });
+    for (const failure of result.failed) {
+      host.showStatus(`Skipped refreshing ${failure.provider}: ${failure.reason}`, 'warning');
+    }
+  } catch (error) {
+    spinner.stop({ ok: false, label: 'Provider refresh failed.' });
+    throw error;
+  } finally {
+    reopenProviderManager(host);
+  }
 }
 
 async function handleProviderManagerDeleteSource(

--- a/apps/kimi-code/src/tui/components/dialogs/provider-manager.ts
+++ b/apps/kimi-code/src/tui/components/dialogs/provider-manager.ts
@@ -14,6 +14,7 @@
  *   - ↑ / ↓             move highlight
  *   - ← / → · PgUp/PgDn page
  *   - Enter             on `[ Add New Platform ]` → `onAdd()`
+ *   - R                 refresh provider models via `onRefresh()`
  *   - D                 delete with inline `[y/N]` confirmation
  *                         on a source row → `onDeleteSource(providerIds)`
  *                         on `[ Add New Platform ]` → ignored
@@ -61,6 +62,7 @@ export interface ProviderManagerOptions {
   /** Provider id of the currently active model. */
   readonly activeProviderId?: string;
   readonly onAdd: () => void;
+  readonly onRefresh: () => void;
   /** Delete all providers under a source (Open Platform / custom-registry
    *  fetch / standalone). Passed the full provider-id list so the host
    *  doesn't have to re-derive the source grouping. */
@@ -91,7 +93,7 @@ type Row = SourceRow | AddRow;
 
 const ADD_ROW_LABEL = '[ Add New Platform ]';
 const PAGE_SIZE = 8;
-const HEADER_HINT = '↑↓ navigate · D delete · Esc cancel';
+const HEADER_HINT = '↑↓ navigate · R refresh · D delete · Esc cancel';
 
 // Narrows a `ProviderConfig` blob to a `CustomRegistrySource` payload.
 // Mirrors `readCustomRegistrySource` in `kimi-tui.ts`. We can't import
@@ -312,8 +314,13 @@ export class ProviderManagerComponent extends Container implements Focusable {
       return;
     }
 
-    // Delete the highlighted provider with the D key.
     const ch = printableChar(data);
+    if (ch === 'r' || ch === 'R') {
+      this.opts.onRefresh();
+      return;
+    }
+
+    // Delete the highlighted provider with the D key.
     if (ch === 'd' || ch === 'D') {
       this.armDeleteConfirm();
     }

--- a/apps/kimi-code/src/tui/controllers/auth-flow.ts
+++ b/apps/kimi-code/src/tui/controllers/auth-flow.ts
@@ -210,9 +210,7 @@ export class AuthFlowController {
 
   private async refreshProviderModelsWithScope(scope: RefreshProviderScope): Promise<RefreshResult> {
     const result = await refreshAllProviderModels(this.buildRefreshHost(), { scope });
-    if (result.changed.length > 0) {
-      await this.refreshAvailableModels();
-    }
+    await this.refreshAvailableModels();
     return result;
   }
 

--- a/apps/kimi-code/test/tui/components/dialogs/provider-manager.test.ts
+++ b/apps/kimi-code/test/tui/components/dialogs/provider-manager.test.ts
@@ -1,3 +1,8 @@
+/**
+ * Scenario: Provider Manager rendering and keyboard actions.
+ * Responsibilities: expose stable provider actions and dispatch public callbacks.
+ * Wiring: real component with callback spies; run with this file through Vitest.
+ */
 import type { ProviderConfig } from '@moonshot-ai/kimi-code-sdk';
 import chalk from 'chalk';
 import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
@@ -25,6 +30,7 @@ function makeComponent(overrides: Partial<ProviderManagerOptions> = {}): Provide
   return new ProviderManagerComponent({
     providers: {} as Record<string, ProviderConfig>,
     onAdd: vi.fn(),
+    onRefresh: vi.fn(),
     onDeleteSource: vi.fn(),
     onClose: vi.fn(),
     ...overrides,
@@ -121,6 +127,19 @@ describe('ProviderManagerComponent', () => {
     expect(rendered(component)).toContain('[y/N]');
     component.handleInput('y');
     expect(onDeleteSource).toHaveBeenCalledWith(['acme']);
+  });
+
+  it('dispatches refresh when R arrives through the Kitty keyboard protocol', () => {
+    const onRefresh = vi.fn();
+    const component = makeComponent({ onRefresh });
+
+    component.handleInput(`${ESC}[114u`);
+
+    expect(onRefresh).toHaveBeenCalledOnce();
+  });
+
+  it('advertises the R refresh shortcut in the header hint', () => {
+    expect(rendered(makeComponent())).toContain('R refresh');
   });
 
   it('closes on Esc', () => {

--- a/apps/kimi-code/test/tui/components/dialogs/provider-manager.test.ts
+++ b/apps/kimi-code/test/tui/components/dialogs/provider-manager.test.ts
@@ -1,12 +1,13 @@
 /**
- * Scenario: Provider Manager rendering and keyboard actions.
- * Responsibilities: expose stable provider actions and dispatch public callbacks.
- * Wiring: real component with callback spies; run with this file through Vitest.
+ * Scenario: Provider Manager rendering, keyboard actions, and refresh lifecycle.
+ * Responsibilities: expose stable provider actions and preserve explicit dismissal during refresh.
+ * Wiring: real component and command handler with callback spies; run with this file through Vitest.
  */
 import type { ProviderConfig } from '@moonshot-ai/kimi-code-sdk';
 import chalk from 'chalk';
 import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
 
+import { handleProviderCommand } from '#/tui/commands/provider';
 import {
   ProviderManagerComponent,
   type ProviderManagerOptions,
@@ -140,6 +141,55 @@ describe('ProviderManagerComponent', () => {
 
   it('advertises the R refresh shortcut in the header hint', () => {
     expect(rendered(makeComponent())).toContain('R refresh');
+  });
+
+  it('keeps the editor active when provider refresh finishes after the manager is dismissed', async () => {
+    const editor = {};
+    let focused: unknown = editor;
+    const editorChildren: unknown[] = [editor];
+    let finishRefresh!: () => void;
+    const refreshProviderModels = vi.fn(
+      () =>
+        new Promise<{ changed: []; unchanged: []; failed: [] }>((resolve) => {
+          finishRefresh = () => {
+            resolve({ changed: [], unchanged: [], failed: [] });
+          };
+        }),
+    );
+    const host = {
+      state: {
+        appState: {
+          availableModels: {},
+          availableProviders: {},
+          model: '',
+        },
+        editorContainer: { children: editorChildren },
+      },
+      authFlow: { refreshProviderModels },
+      mountEditorReplacement: (component: unknown) => {
+        editorChildren.splice(0, editorChildren.length, component);
+        focused = component;
+      },
+      restoreEditor: () => {
+        editorChildren.splice(0, editorChildren.length, editor);
+        focused = editor;
+      },
+      showError: vi.fn(),
+      showProgressSpinner: () => ({ stop: vi.fn() }),
+      showStatus: vi.fn(),
+    } as unknown as Parameters<typeof handleProviderCommand>[0];
+    await handleProviderCommand(host);
+    const manager = focused as ProviderManagerComponent;
+
+    manager.handleInput('R');
+    expect(refreshProviderModels).toHaveBeenCalledOnce();
+    manager.handleInput(ESC);
+    expect(focused).toBe(editor);
+
+    finishRefresh();
+    await Promise.resolve();
+
+    expect(focused).toBe(editor);
   });
 
   it('closes on Esc', () => {

--- a/apps/kimi-code/test/tui/kimi-tui-startup.test.ts
+++ b/apps/kimi-code/test/tui/kimi-tui-startup.test.ts
@@ -36,6 +36,7 @@ const copyTextToClipboardMock = vi.mocked(copyTextToClipboard);
 
 interface StartupDriver {
   state: TUIState;
+  readonly authFlow: KimiTUI['authFlow'];
   init(): Promise<boolean>;
   handleLoginCommand(): Promise<void>;
   handleLogoutCommand(): Promise<void>;
@@ -1509,6 +1510,36 @@ describe('KimiTUI startup', () => {
 
     expect(showStatus).toHaveBeenCalledTimes(1);
     expect(showStatus).toHaveBeenCalledWith("New Models · +2 models.");
+  });
+
+  it('reloads provider state when a refresh reports no model changes', async () => {
+    const getConfig = vi
+      .fn()
+      .mockResolvedValueOnce({ providers: {}, models: {} })
+      .mockResolvedValue({
+        providers: {
+          acme: {
+            type: 'openai',
+            baseUrl: 'https://api.example.test/v1',
+            apiKey: 'YOUR_API_KEY',
+          },
+        },
+        models: {
+          'acme/example-model': {
+            provider: 'acme',
+            model: 'example-model',
+            maxContextSize: 4096,
+            capabilities: [],
+          },
+        },
+      });
+    const harness = makeHarness(makeSession(), { getConfig });
+    const driver = makeDriver(harness, makeStartupInput());
+
+    await driver.authFlow.refreshProviderModels();
+
+    expect(driver.state.appState.availableProviders).toHaveProperty('acme');
+    expect(driver.state.appState.availableModels).toHaveProperty('acme/example-model');
   });
 
   it("stages provider-refresh removals and persists one atomic write on atomic-capable harnesses", async () => {


### PR DESCRIPTION
## Related Issue

Part of #2111

## Problem

The `/provider` command advertises refresh support, but the Provider Manager exposes only add and delete actions. Provider and model state also reloads only when a refresh reports model-list changes, so the TUI can retain stale configuration state.

## What changed

- Add an `R` refresh action and visible key hint to Provider Manager.
- Run the existing provider refresh flow with progress and failure feedback, then reopen the manager with the latest state.
- Reload configured providers and models after every completed refresh, including unchanged results.
- Add component and controller regression coverage.

This intentionally leaves models.dev provenance and unsupported-provider discovery out of scope.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill and added a patch changeset.
- [x] Ran `gen-docs` skill; no docs update is needed because this implements refresh behavior already advertised by `/provider`.
