### PR TITLE
fix(agent-core-v2): gate image formats on hook-blocked prompts

### DIFF
--- a/.changeset/hook-blocked-prompt-image-gate.md
+++ b/.changeset/hook-blocked-prompt-image-gate.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Fix prompts blocked by a UserPromptSubmit hook keeping unsupported or malformed images in the session history unfiltered; blocked prompts now go through the same image format check as prompts that reach the model, so a rejected image becomes a text notice instead of failing later requests.

--- a/packages/agent-core-v2/src/agent/prompt/promptService.ts
+++ b/packages/agent-core-v2/src/agent/prompt/promptService.ts
@@ -3,7 +3,7 @@ import { IInstantiationService } from '#/_base/di/instantiation';
 import { LifecycleScope } from '#/app/scopes';
 import { ScopeActivation, registerScopedService } from '#/_base/di/scope';
 import { defineState } from '#/state/state';
-import { extractImageCompressionCaptions } from '#/agent/media/image-compress';
+import { extractImageCompressionCaptions, gateImageFormatParts } from '#/agent/media/image-compress';
 import { userCancellationReason } from '#/_base/utils/abort';
 import { IAgentContextMemoryService } from '#/agent/contextMemory/contextMemory';
 import { newMessageId } from '#/agent/contextMemory/messageId';
@@ -471,7 +471,8 @@ export class AgentPromptService implements IAgentPromptService {
         ownerPromptId,
       });
     }
-    if (message.content.length > 0) this.context.append({ ...message, id: ownerPromptId });
+    const content = gateImageFormatParts(message.content);
+    if (content.length > 0) this.context.append({ ...message, id: ownerPromptId, content });
   }
   private async deliverToolResult(ctx: ToolDidExecuteContext): Promise<void> {
     const delivery = ctx.result.delivery; if (delivery === undefined) return;

--- a/packages/agent-core-v2/test/agent/prompt/promptService.test.ts
+++ b/packages/agent-core-v2/test/agent/prompt/promptService.test.ts
@@ -274,6 +274,35 @@ describe('AgentPromptService', () => {
     ).toBe(true);
   });
 
+  it('gates hook-blocked prompt images too', async () => {
+    const { prompt, context } = harness();
+    prompt.hooks.onBeforeSubmitPrompt.register('block', async (ctx, next) => { ctx.block = true; await next(); });
+    const avifUrl = `data:image/avif;base64,${Buffer.from([7, 8, 9]).toString('base64')}`;
+    const handle = await prompt.enqueue({
+      id: 'prompt-blocked-img',
+      message: {
+        role: 'user',
+        content: [
+          { type: 'text', text: 'look' },
+          { type: 'image_url', imageUrl: { url: avifUrl } },
+          { type: 'image_url', imageUrl: { url: 'data:image/png,not-a-base64-payload' } },
+        ],
+        toolCalls: [],
+        origin: { kind: 'user' },
+      },
+    });
+    await expect(handle.completion).resolves.toMatchObject({ state: 'blocked' });
+
+    const appended = context.get();
+    expect(appended).toHaveLength(1);
+    expect(appended[0]?.id).toBe('prompt-blocked-img');
+    const parts = appended[0]!.content;
+    expect(parts.some((part) => part.type === 'image_url')).toBe(false);
+    expect(parts[0]).toEqual({ type: 'text', text: 'look' });
+    expect((parts[1] as { text: string }).text).toContain('image/avif');
+    expect((parts[2] as { text: string }).text).toContain('not a valid data URL');
+  });
+
   it('materializes daemon-ref media at steer intake', async () => {
     const { prompt, intake } = harness();
     const active = await prompt.enqueue({ message: message('active') });


### PR DESCRIPTION
## 相关 Issue

Resolves #2947

## 问题

见关联 issue。概括：自 #1626（v2 引擎的图片格式闸门，对应 v1 的 #1536）起，每个 prompt 入口在把图片写进会话历史前都会过一次 `gateImageFormatParts`——坏图 / provider 不接受的格式换成 `[Image omitted: …]` 文字说明，被接受的图片按规范形式转发（`image/jpg` → `image/jpeg`、按字节嗅探纠正 MIME）。prompt / steer 两类 step request 是 SDK/RPC 路径的"last-funnel"兜底。

这道兜底漏了一条分支：`UserPromptSubmit` 钩子把 prompt 拦下时，调度器不走 step request，而是自己把用户消息写进历史（`AgentPromptService.appendPrompt`），这次写入没有过闸门。被拦下的 prompt 于是带着原始 `image_url` part 留在历史里（并落盘 `wire.jsonl`），而同一条 prompt 不被拦时会被过滤。该分支从 #1626 落地起就没过闸，release 0.34.0 ～ 0.36.1 均为同一段代码。

触发需同时满足：① 一条会拦 prompt 的 `UserPromptSubmit` 钩子（exit 2 / block）；② 一张闸门本来会改写的图片，从"引擎闸门是唯一一道闸"的入口进来——`kimi web` 的 REST（`source.kind: "url"` 的 `data:` URL 在边缘不做检查；`kind: "base64"` 带 `image/jpg` 这类别名且未触发压缩时原样到引擎）或 SDK / klient 通道（VS Code 扩展、嵌入方；例如扩展名与字节不符的文件）。TUI 粘贴（魔数嗅探）与 ACP（提交前先过闸）不受影响。

后果（实测，Anthropic 方言，用只记录请求体的假 provider）：这条消息之后每一轮随历史发出，请求 converter 抛 `Invalid data URL for image …` / `Unsupported media type for base64 image: image/jpg`，引擎的图片格式恢复把**本轮请求里所有图片**（含用户后来正常发的好图）换成占位文字后重发，日志可见 `provider rejected an image in the request; resending with rejected media stripped`；恢复按 turn 记录，之后每轮如此，直到会话清空——模型在该会话里再也看不见任何图片。OpenAI 兼容方言把 URL 原样发给 provider，能否恢复取决于 400 文案是否命中内置正则，否则该轮直接失败、之后每轮都失败。两种情况都严格差于正常路径（坏图变一句无害文字、好图始终可见）。

## 改动内容

- `AgentPromptService.appendPrompt` 在写入前对 content 过同一道 `gateImageFormatParts`，防空判断改成基于过滤后的 content——与 `UserMessageStepRequest` 在正常路径 / steer 路径上的处理一致。caption 投递与 undo 归属不变。
- `promptService.test.ts` 新增回归用例 `gates hook-blocked prompt images too`，紧跟既有的正常路径 / steer 路径闸门用例；在 `main` 上失败、修复后通过。
- changeset：`@moonshot-ai/kimi-code` patch。

验证：`promptService.test.ts` 13/13；`packages/agent-core-v2/test/agent` + `test/app` + kap-server `prompts.test.ts` 共 157 个文件 / 2825 个用例全绿；agent-core-v2 包内 `tsc --noEmit` 无错误；`oxlint --type-aware` 对改动文件无新增 warning。另用真实 `kimi web` + 真实 `[[hooks]]` 子进程 + curl，以及 `@moonshot-ai/kimi-code-sdk` 两条路径做了端到端复现：`main` 上原始图片进历史，本分支上变为 `[Image omitted: …]`；这些端到端复现脚本不在本 PR 内。

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.
