### PR TITLE
fix(tui): restore prompt on early escape

### DIFF
--- a/.changeset/restore-early-escape-prompt.md
+++ b/.changeset/restore-early-escape-prompt.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Restore a submitted prompt to the editor when Esc cancels before any response appears.

--- a/apps/kimi-code/src/tui/controllers/editor-keyboard.ts
+++ b/apps/kimi-code/src/tui/controllers/editor-keyboard.ts
@@ -60,6 +60,7 @@ export interface EditorKeyboardHost {
   clearQueuedMessages(): void;
   setExternalEditorRunning(running: boolean): void;
   updateActivityPane(): void;
+  restoreSubmittedInputOnEscape(): void;
 }
 
 export class EditorKeyboardController {
@@ -221,6 +222,7 @@ export class EditorKeyboardController {
         return;
       }
       if (host.state.appState.streamingPhase !== 'idle') {
+        host.restoreSubmittedInputOnEscape();
         this.cancelCurrentStream();
         this.clearPendingUndoEsc();
         return;

--- a/apps/kimi-code/src/tui/controllers/session-event-handler.ts
+++ b/apps/kimi-code/src/tui/controllers/session-event-handler.ts
@@ -168,6 +168,10 @@ export class SessionEventHandler {
   private queuedGoalPromotionInFlight = false;
   private queuedGoalPromotionTimer: ReturnType<typeof setTimeout> | undefined;
   private stepRetryAttemptTimer: ReturnType<typeof setTimeout> | undefined;
+  // A plain submitted prompt remains restorable only until response content
+  // becomes visible. Esc then arms one-shot suppression for its abort event.
+  private pendingPromptRestore: string | undefined;
+  private suppressNextUserInterruption = false;
 
   resetRuntimeState(): void {
     this.backgroundTasks.clear();
@@ -187,7 +191,28 @@ export class SessionEventHandler {
     this.queuedGoalPromotionInFlight = false;
     this.clearQueuedGoalPromotionTimer();
     this.clearStepRetryAttemptTimer();
+    this.clearPromptRestoreWindow();
     this.stopAllMcpServerStatusSpinners();
+  }
+
+  beginPromptRestoreWindow(restorableInput?: string): void {
+    this.pendingPromptRestore = restorableInput;
+    this.suppressNextUserInterruption = false;
+  }
+
+  restorePendingPromptOnEscape(): void {
+    const input = this.pendingPromptRestore;
+    if (input === undefined) return;
+    this.pendingPromptRestore = undefined;
+    this.suppressNextUserInterruption = true;
+
+    const draft = this.host.state.editor.getText();
+    this.host.restoreInputText(draft.length === 0 ? input : `${input}\n${draft}`);
+  }
+
+  clearPromptRestoreWindow(): void {
+    this.pendingPromptRestore = undefined;
+    this.suppressNextUserInterruption = false;
   }
 
   clearAgentSwarmProgress(): void {
@@ -358,6 +383,7 @@ export class SessionEventHandler {
   private handleTurnEnd(event: TurnEndedEvent, sendQueued: (item: QueuedMessage) => void): void {
     this.host.streamingUI.flushNow();
     this.clearStepRetry();
+    this.clearPromptRestoreWindow();
     if (event.reason === 'cancelled') {
       this.markActiveAgentSwarmsCancelled();
     }
@@ -520,11 +546,16 @@ export class SessionEventHandler {
     this.host.streamingUI.resetToolUi();
     this.host.streamingUI.finalizeLiveTextBuffers('idle');
     const reason = event.reason;
+    const hasMessage = event.message !== undefined && event.message !== '';
+    const suppressInterruption = !hasMessage && this.suppressNextUserInterruption;
+    this.clearPromptRestoreWindow();
     if (reason === 'error') return;
     if (reason === 'aborted' || reason === undefined || reason === '') {
       this.markActiveAgentSwarmsCancelled();
-      if (event.message === undefined || event.message === '') {
-        this.host.showStatus('Interrupted by user', 'error');
+      if (!hasMessage) {
+        if (!suppressInterruption) {
+          this.host.showStatus('Interrupted by user', 'error');
+        }
       } else {
         this.host.showError(event.message);
       }
@@ -548,6 +579,7 @@ export class SessionEventHandler {
     // text), leaving a blank, spinner-less gap until the first real text/tool
     // token arrives. Keep the moon up until actual thinking text shows up.
     if (event.delta.trim().length === 0 && !streamingUI.hasThinkingDraft()) return;
+    this.markResponseVisible();
     streamingUI.appendThinkingDelta(event.delta);
     this.host.patchLivePane({ mode: 'idle' });
     if (state.appState.streamingPhase !== 'thinking') {
@@ -563,6 +595,7 @@ export class SessionEventHandler {
     }
 
     if (event.delta.trim().length > 0) {
+      this.markResponseVisible();
       this.currentTurnHasAssistantText = true;
       this.pendingModelBlockedFallback = undefined;
     }
@@ -585,6 +618,7 @@ export class SessionEventHandler {
       this.host.streamingUI.flushThinkingToTranscript('idle');
     }
     this.host.streamingUI.finalizeAssistantStream();
+    this.markResponseVisible();
     if (event.content.trim().length > 0) {
       this.currentTurnHasAssistantText = true;
       this.pendingModelBlockedFallback = undefined;
@@ -606,6 +640,7 @@ export class SessionEventHandler {
   private handleToolCall(event: ToolCallStartedEvent): void {
     const { streamingUI } = this.host;
     streamingUI.flushNow();
+    this.markResponseVisible();
     const { turnId, step } = streamingUI.getTurnContext();
     const toolCall: ToolCallBlockData = {
       id: event.toolCallId,
@@ -632,6 +667,9 @@ export class SessionEventHandler {
     const { state, streamingUI } = this.host;
     streamingUI.accumulateToolCallDelta(event.toolCallId, event.name, event.argumentsPart);
     const preview = streamingUI.getStreamingToolCallPreview(event.toolCallId);
+    if (preview !== undefined) {
+      this.markResponseVisible();
+    }
     if (
       preview !== undefined &&
       (preview.name === 'AgentSwarm' || this.subAgentEventHandler.hasAgentSwarmProgress(event.toolCallId))
@@ -650,6 +688,10 @@ export class SessionEventHandler {
       this.host.setAppState({ streamingPhase: 'composing', streamingStartTime: Date.now() });
     }
     streamingUI.scheduleFlush();
+  }
+
+  private markResponseVisible(): void {
+    this.pendingPromptRestore = undefined;
   }
 
   private handleToolProgress(event: ToolProgressEvent): void {

--- a/apps/kimi-code/src/tui/kimi-tui.ts
+++ b/apps/kimi-code/src/tui/kimi-tui.ts
@@ -1453,7 +1453,8 @@ export class KimiTUI {
     this.track('input_queue');
   }
 
-  beginSessionRequest(): void {
+  beginSessionRequest(restorableInput?: string): void {
+    this.sessionEventHandler.beginPromptRestoreWindow(restorableInput);
     this.cacheHint.onTurnBegin();
     this.streamingUI.setTurnId(undefined);
     this.streamingUI.resetLiveText();
@@ -1472,6 +1473,7 @@ export class KimiTUI {
   }
 
   failSessionRequest(message: string): void {
+    this.sessionEventHandler.clearPromptRestoreWindow();
     this.setAppState({ streamingPhase: 'idle' });
     this.resetLivePane();
     this.showError(message);
@@ -1494,7 +1496,12 @@ export class KimiTUI {
     this.sessionEventHandler.requestQueuedGoalPromotion();
   }
 
-  private sendMessageInternal(session: Session, input: string, options?: SendMessageOptions): void {
+  private sendMessageInternal(
+    session: Session,
+    input: string,
+    options?: SendMessageOptions,
+    restoreOnEarlyEscape = false,
+  ): void {
     const imageAttachmentIds =
       options?.imageAttachmentIds !== undefined && options.imageAttachmentIds.length > 0
         ? options.imageAttachmentIds
@@ -1508,7 +1515,7 @@ export class KimiTUI {
       imageAttachmentIds,
     });
 
-    this.beginSessionRequest();
+    this.beginSessionRequest(restoreOnEarlyEscape ? input : undefined);
 
     const sdkInput = options?.parts ?? input;
     // While a goal is being pursued the engine holds its active turn across the
@@ -1590,7 +1597,11 @@ export class KimiTUI {
       this.enqueueMessage(input, options);
       return;
     }
-    this.sendMessageInternal(session, input, options);
+    this.sendMessageInternal(session, input, options, options?.hasMedia !== true);
+  }
+
+  restoreSubmittedInputOnEscape(): void {
+    this.sessionEventHandler.restorePendingPromptOnEscape();
   }
 
   steerMessage(session: Session, input: readonly SteerInputItem[]): void {

--- a/apps/kimi-code/test/tui/controllers/editor-keyboard.test.ts
+++ b/apps/kimi-code/test/tui/controllers/editor-keyboard.test.ts
@@ -1,3 +1,7 @@
+// Scenario: editor shortcut routing across idle, streaming, compaction, and dialogs.
+// Responsibilities: prioritize the active surface and delegate the selected action once.
+// Wiring: real EditorKeyboardController with editor, session, and host boundaries stubbed.
+// Run: pnpm --filter @moonshot-ai/kimi-code exec vitest run test/tui/controllers/editor-keyboard.test.ts
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { DOUBLE_ESC_WINDOW_MS, NO_ACTIVE_SESSION_MESSAGE } from '#/tui/constant/kimi-tui';
@@ -48,6 +52,7 @@ function createHarness(options: { streamingPhase?: string; isCompacting?: boolea
     cancelRunningShellCommand,
     updateEditorBorderHighlight: vi.fn(),
     updateGoalLengthWarning: vi.fn(),
+    restoreSubmittedInputOnEscape: vi.fn(),
   } as unknown as EditorKeyboardHost;
 
   const controller = new EditorKeyboardController(

--- a/apps/kimi-code/test/tui/kimi-tui-message-flow.test.ts
+++ b/apps/kimi-code/test/tui/kimi-tui-message-flow.test.ts
@@ -1,3 +1,7 @@
+// Scenario: user input dispatch and SDK session events through the interactive TUI.
+// Responsibilities: preserve observable editor, transcript, queue, and session behavior.
+// Wiring: real KimiTUI/controllers/components with only SDK and OS boundaries stubbed.
+// Run: pnpm --filter @moonshot-ai/kimi-code exec vitest run test/tui/kimi-tui-message-flow.test.ts
 import { AsyncLocalStorage } from 'node:async_hooks';
 import { mkdtemp, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
@@ -2692,6 +2696,84 @@ command = "vim"
     driver.state.editor.onCtrlC?.();
 
     expect(session.cancel).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns a pre-response cancellation to the editor without an interruption error', async () => {
+    const { driver, session } = await makeDriver();
+
+    driver.handleUserInput('inspect the failing request');
+    await vi.waitFor(() => {
+      expect(session.prompt).toHaveBeenCalledWith('inspect the failing request');
+    });
+
+    driver.state.editor.onEscape?.();
+    driver.sessionEventHandler.handleEvent(
+      {
+        type: 'turn.step.interrupted',
+        agentId: 'main',
+        sessionId: 'ses-1',
+        turnId: 1,
+        step: 1,
+        reason: 'aborted',
+      } as Event,
+      vi.fn(),
+    );
+
+    expect(session.cancel).toHaveBeenCalledOnce();
+    expect(driver.state.editor.getText()).toBe('inspect the failing request');
+    expect(stripSgr(renderTranscript(driver))).not.toContain('Interrupted by user');
+  });
+
+  it('prepends the submitted prompt when Escape restores over a newer draft', async () => {
+    const { driver, session } = await makeDriver();
+
+    driver.handleUserInput('inspect the failing request');
+    await vi.waitFor(() => {
+      expect(session.prompt).toHaveBeenCalledWith('inspect the failing request');
+    });
+    driver.state.editor.setText('keep this newer draft');
+
+    driver.state.editor.onEscape?.();
+
+    expect(driver.state.editor.getText()).toBe(
+      'inspect the failing request\nkeep this newer draft',
+    );
+  });
+
+  it('keeps the submitted text consumed when Escape cancels after visible output', async () => {
+    const { driver, session } = await makeDriver();
+
+    driver.handleUserInput('inspect after output');
+    await vi.waitFor(() => {
+      expect(session.prompt).toHaveBeenCalledWith('inspect after output');
+    });
+    driver.sessionEventHandler.handleEvent(
+      {
+        type: 'assistant.delta',
+        agentId: 'main',
+        sessionId: 'ses-1',
+        turnId: 1,
+        step: 1,
+        delta: 'Visible response',
+      } as Event,
+      vi.fn(),
+    );
+
+    driver.state.editor.onEscape?.();
+    driver.sessionEventHandler.handleEvent(
+      {
+        type: 'turn.step.interrupted',
+        agentId: 'main',
+        sessionId: 'ses-1',
+        turnId: 1,
+        step: 1,
+        reason: 'aborted',
+      } as Event,
+      vi.fn(),
+    );
+
+    expect(driver.state.editor.getText()).toBe('');
+    expect(stripSgr(renderTranscript(driver))).toContain('Interrupted by user');
   });
 
   it('clears streaming editor text before cancelling the active turn on Ctrl-C', async () => {


### PR DESCRIPTION
## Related Issue

Resolve #2781

## Problem

See linked issue.

## What changed

- Keep a directly submitted plain-text prompt restorable until thinking, assistant text, hook output, or a tool call becomes visible.
- Restore the prompt when Esc cancels during that window, preserving any newer editor draft and suppressing only the matching empty interruption marker.
- Preserve existing cancellation behavior after visible output and for queued, media, skill, plugin-command, shell, and Ctrl-C flows.

## Verification

- `vitest run apps/kimi-code/test/tui/kimi-tui-message-flow.test.ts --testNamePattern "pre-response cancellation|newer draft|after visible output"` (3 passed)
- `vitest run apps/kimi-code/test/tui/controllers/editor-keyboard.test.ts` (28 passed)
- `tsc -p apps/kimi-code/tsconfig.json --noEmit`
- `oxlint` on all changed source and test files (0 errors)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.
