### PR TITLE
fix(mcp): report reconnect as pending while closing

### DIFF
--- a/.changeset/fix-mcp-reconnect-state.md
+++ b/.changeset/fix-mcp-reconnect-state.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Fix MCP servers reporting as connected while their previous client is still closing during reconnect.

--- a/packages/agent-core-v2/src/mcpCore/connection-manager.ts
+++ b/packages/agent-core-v2/src/mcpCore/connection-manager.ts
@@ -284,14 +284,15 @@ export class McpConnectionManager implements McpConnectionView {
       throw new Error2(ErrorCodes.MCP_SERVER_DISABLED, `MCP server is disabled: ${name}`);
     }
     const attemptId = this.beginConnectAttempt(entry);
-    await this.closeClient(entry);
-    if (!this.isCurrent(entry, attemptId)) return;
+    const closing = this.closeClient(entry);
     entry.status = 'pending';
     entry.tools = undefined;
     entry.enabledNames = undefined;
     entry.rawTools = undefined;
     entry.error = undefined;
     this.emit(entry);
+    await closing;
+    if (!this.isCurrent(entry, attemptId)) return;
     await this.connectOne(entry, attemptId);
   }
 

--- a/packages/agent-core-v2/test/mcpCore/connection-manager.test.ts
+++ b/packages/agent-core-v2/test/mcpCore/connection-manager.test.ts
@@ -30,6 +30,7 @@ import { z } from 'zod';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { Error2 } from '#/errors';
+import { StdioMcpClient } from '#/mcpCore/client-stdio';
 import { KIMI_MCP_CLIENT_NAME } from '#/mcpCore/client-shared';
 import { McpConnectionManager, type McpServerEntry } from '#/mcpCore/connection-manager';
 import { McpOAuthService } from '#/mcpCore/oauth/service';
@@ -237,6 +238,54 @@ describe('McpConnectionManager', () => {
       ]);
     } finally {
       await cm.shutdown();
+    }
+  }, 15000);
+
+  it('reconnect reports pending while the previous client is still closing', async () => {
+    const cm = new McpConnectionManager();
+    let releaseClose!: () => void;
+    let reportCloseStarted!: () => void;
+    const closeGate = new Promise<void>((resolve) => {
+      releaseClose = resolve;
+    });
+    const closeStarted = new Promise<void>((resolve) => {
+      reportCloseStarted = resolve;
+    });
+    const originalClose = StdioMcpClient.prototype.close;
+    const closeSpy = vi
+      .spyOn(StdioMcpClient.prototype, 'close')
+      .mockImplementation(async function (this: StdioMcpClient) {
+        reportCloseStarted();
+        await closeGate;
+        await originalClose.call(this);
+      });
+    const seen: Array<[McpServerEntry['status'], number, string | undefined]> = [];
+    let reconnect: Promise<void> | undefined;
+
+    try {
+      await cm.connectAll({ alpha: stdioConfig() });
+      cm.onStatusChange((entry) => {
+        seen.push([entry.status, entry.toolCount, entry.error]);
+      });
+
+      reconnect = cm.reconnect('alpha');
+      await closeStarted;
+
+      expect(cm.get('alpha')).toMatchObject({
+        status: 'pending',
+        toolCount: 0,
+        error: undefined,
+      });
+      expect(cm.resolved('alpha')).toBeUndefined();
+      expect(seen).toEqual([['pending', 0, undefined]]);
+    } finally {
+      releaseClose();
+      await reconnect?.catch(() => undefined);
+      try {
+        await cm.shutdown();
+      } finally {
+        closeSpy.mockRestore();
+      }
     }
   }, 15000);
 

--- a/packages/agent-core/src/mcp/connection-manager.ts
+++ b/packages/agent-core/src/mcp/connection-manager.ts
@@ -304,14 +304,15 @@ export class McpConnectionManager {
       throw new KimiError(ErrorCodes.MCP_SERVER_DISABLED, `MCP server is disabled: ${name}`);
     }
     const attemptId = this.beginConnectAttempt(entry);
-    await this.closeClient(entry);
-    if (!this.isCurrent(entry, attemptId)) return;
+    const closing = this.closeClient(entry);
     entry.status = 'pending';
     entry.tools = undefined;
     entry.rawTools = undefined;
     entry.enabledNames = undefined;
     entry.error = undefined;
     this.emit(entry);
+    await closing;
+    if (!this.isCurrent(entry, attemptId)) return;
     await this.connectOne(entry, attemptId);
   }
 

--- a/packages/agent-core/test/mcp/connection-manager.test.ts
+++ b/packages/agent-core/test/mcp/connection-manager.test.ts
@@ -32,6 +32,7 @@ import type {
 import { z } from 'zod';
 
 import { KimiError } from '../../src/errors';
+import { StdioMcpClient } from '../../src/mcp/client-stdio';
 import { ProviderManager } from '../../src/session/provider-manager';
 import {
   MCP_STARTUP_TIMEOUT_ENV,
@@ -203,6 +204,54 @@ describe('McpConnectionManager', () => {
       expect(statuses).toEqual(['pending', 'connected']);
     } finally {
       await cm.shutdown();
+    }
+  }, 15000);
+
+  it('reconnect reports pending while the previous client is still closing', async () => {
+    const cm = new McpConnectionManager();
+    let releaseClose!: () => void;
+    let reportCloseStarted!: () => void;
+    const closeGate = new Promise<void>((resolve) => {
+      releaseClose = resolve;
+    });
+    const closeStarted = new Promise<void>((resolve) => {
+      reportCloseStarted = resolve;
+    });
+    const originalClose = StdioMcpClient.prototype.close;
+    const closeSpy = vi
+      .spyOn(StdioMcpClient.prototype, 'close')
+      .mockImplementation(async function (this: StdioMcpClient) {
+        reportCloseStarted();
+        await closeGate;
+        await originalClose.call(this);
+      });
+    const seen: Array<[McpServerEntry['status'], number, string | undefined]> = [];
+    let reconnect: Promise<void> | undefined;
+
+    try {
+      await cm.connectAll({ alpha: stdioConfig() });
+      cm.onStatusChange((entry) => {
+        seen.push([entry.status, entry.toolCount, entry.error]);
+      });
+
+      reconnect = cm.reconnect('alpha');
+      await closeStarted;
+
+      expect(cm.get('alpha')).toMatchObject({
+        status: 'pending',
+        toolCount: 0,
+        error: undefined,
+      });
+      expect(cm.resolved('alpha')).toBeUndefined();
+      expect(seen).toEqual([['pending', 0, undefined]]);
+    } finally {
+      releaseClose();
+      await reconnect?.catch(() => undefined);
+      try {
+        await cm.shutdown();
+      } finally {
+        closeSpy.mockRestore();
+      }
     }
   }, 15000);
 


### PR DESCRIPTION
## Related Issue

Resolve #2956

## Problem

During MCP reconnect, both connection managers awaited the previous client's asynchronous `close()` before publishing the `pending` state. Because `closeClient()` clears the active client synchronously, `get()` could still report `connected` with the previous tool count while `resolved()` already returned `undefined`.

## What changed

- Start closing the previous client, immediately clear the resolved tool state, and emit `pending` before awaiting the close in both agent-core v1 and v2.
- Preserve the existing reconnect attempt guard before starting the replacement connection.
- Add mirrored regression tests that block the previous stdio client's close and verify the public state and status event.
- Add a patch changeset for `@moonshot-ai/kimi-code`.

Validation:

- Focused connection-manager tests: v1 44 passed; v2 42 passed.
- Full package tests: v1 4143 passed; v2 5067 passed.
- v1/v2 typecheck, v2 import-boundary lint, and type-aware oxlint on the four changed TypeScript files passed.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.
