### PR TITLE
feat(cli): add --web-title and expose it via /meta

### DIFF
--- a/.changeset/web-title-flag.md
+++ b/.changeset/web-title-flag.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Add `kimi web --web-title <title>` to set a custom browser tab title for the web UI instance, so multiple instances on different machines are easy to tell apart; without the flag the tab title shows the active workspace's directory name.

--- a/apps/kimi-code/src/cli/sub/web/run.ts
+++ b/apps/kimi-code/src/cli/sub/web/run.ts
@@ -149,6 +149,10 @@ export function buildWebCommand(cmd: Command): Command {
       'Mount /api/v1/debug/* routes for test introspection. OFF by default; production callers leave this unset.',
       false,
     )
+    .option(
+      '--web-title <title>',
+      'Set a custom browser tab title for this web UI instance (default: "<workspace dir> | Kimi Code").',
+    )
     .option('--no-open', 'Do not open the web UI in the default browser.', true)
     .action(async (opts: WebCliOptions) => {
       try {
@@ -295,6 +299,7 @@ async function runServerInProcess(
     allowRemoteTerminals: options.allowRemoteTerminals,
     allowedHosts: options.allowedHosts,
     disableAuth: options.dangerousBypassAuth,
+    webTitle: options.webTitle,
     // Attach the engine's cloud telemetry appender (still gated by the config
     // `telemetry` toggle). Complements the v1 client registered above, which
     // only covers host-level events.

--- a/apps/kimi-code/src/cli/sub/web/shared.ts
+++ b/apps/kimi-code/src/cli/sub/web/shared.ts
@@ -46,6 +46,8 @@ export interface ParsedServerOptions {
   dangerousBypassAuth: boolean;
   /** Extra `Host` header values to allow through the DNS-rebinding check. */
   allowedHosts: readonly string[];
+  /** Custom browser tab title for this web UI instance (`--web-title`). */
+  webTitle?: string;
 }
 
 export interface ServerCliOptions {
@@ -63,6 +65,8 @@ export interface ServerCliOptions {
   dangerousBypassAuth?: boolean;
   /** Extra `Host` header values to allow (`--allowed-host`). */
   allowedHost?: string[];
+  /** Custom browser tab title for this web UI instance (`--web-title`). */
+  webTitle?: string;
 }
 
 export function parseServerOptions(opts: ServerCliOptions): ParsedServerOptions {
@@ -76,6 +80,7 @@ export function parseServerOptions(opts: ServerCliOptions): ParsedServerOptions 
     allowRemoteTerminals: opts.allowRemoteTerminals === true,
     dangerousBypassAuth: opts.dangerousBypassAuth === true,
     allowedHosts: parseAllowedHostArgs(opts.allowedHost),
+    webTitle: opts.webTitle,
   };
 }
 

--- a/apps/kimi-code/test/cli/web/web.test.ts
+++ b/apps/kimi-code/test/cli/web/web.test.ts
@@ -103,6 +103,7 @@ describe('kimi web', () => {
     expect(longs).toContain('--dangerous-bypass-auth');
     expect(longs).toContain('--log-level');
     expect(longs).toContain('--debug-endpoints');
+    expect(longs).toContain('--web-title');
     // web opens the browser by default → the option is the negative --no-open.
     expect(longs).toContain('--no-open');
     // The background/daemon era flags are gone: the server always runs in the
@@ -468,6 +469,32 @@ describe('`kimi web` option threading', () => {
     );
 
     expect(calls.options).toMatchObject({ logLevel: 'debug' });
+  });
+
+  it('passes --web-title through to the runner', async () => {
+    const { handleWebCommand } = await import('#/cli/sub/web/run');
+    const { runner, calls } = makeRunner();
+    const { stdout, stderr } = makeIo();
+
+    await handleWebCommand(
+      { port: '58627', webTitle: 'My Dev Box', open: false },
+      { startServerForeground: runner, openUrl: vi.fn(), stdout, stderr },
+    );
+
+    expect(calls.options).toMatchObject({ webTitle: 'My Dev Box' });
+  });
+
+  it('leaves webTitle undefined when --web-title is not passed', async () => {
+    const { handleWebCommand } = await import('#/cli/sub/web/run');
+    const { runner, calls } = makeRunner();
+    const { stdout, stderr } = makeIo();
+
+    await handleWebCommand(
+      { port: '58627', open: false },
+      { startServerForeground: runner, openUrl: vi.fn(), stdout, stderr },
+    );
+
+    expect(calls.options?.webTitle).toBeUndefined();
   });
 
   it('rejects an invalid --log-level before calling the runner', async () => {

--- a/packages/kap-server/src/protocol/rest-meta.ts
+++ b/packages/kap-server/src/protocol/rest-meta.ts
@@ -50,6 +50,13 @@ export const metaResponseSchema = z.object({
    * probing routes.
    */
   backend: z.enum(['v1', 'v2']).optional(),
+  /**
+   * Custom browser tab title for this instance, set by the host at boot
+   * (the CLI's `--web-title`). Instance-level and frozen at registration —
+   * never changes for the life of the process. Absent when unset: the web UI
+   * then falls back to `<workspace dir> | Kimi Code`.
+   */
+  web_title: z.string().optional(),
 });
 
 export type MetaResponse = z.infer<typeof metaResponseSchema>;

--- a/packages/kap-server/src/routes/meta.ts
+++ b/packages/kap-server/src/routes/meta.ts
@@ -43,6 +43,12 @@ export interface MetaRouteOptions {
    */
   readonly dangerousBypassAuth: boolean;
   /**
+   * Custom browser tab title for this instance (the CLI's `--web-title`).
+   * Surfaced as `web_title` in the `/meta` payload; instance-level and frozen
+   * at boot, so it joins the frozen static fields. Omitted when unset.
+   */
+  readonly webTitle?: string;
+  /**
    * Resolves the effective experimental-flag map (flag id → enabled) at
    * request time. Backed by `IFlagService.snapshot()` in production; tests may
    * stub it. May return a promise — the handler awaits it, so flag state
@@ -67,6 +73,7 @@ export function registerMetaRoute(app: RouteHost, opts: MetaRouteOptions): void 
     open_in_apps: [],
     dangerous_bypass_auth: opts.dangerousBypassAuth,
     backend: 'v2' as const,
+    ...(opts.webTitle !== undefined ? { web_title: opts.webTitle } : {}),
   });
 
   const route = defineRoute(

--- a/packages/kap-server/src/routes/registerApiV1Routes.ts
+++ b/packages/kap-server/src/routes/registerApiV1Routes.ts
@@ -88,6 +88,12 @@ export interface RegisterApiV1RoutesOptions {
    * flag).
    */
   readonly dangerousBypassAuth?: boolean;
+  /**
+   * Custom browser tab title for this instance, surfaced as `web_title` in the
+   * `/meta` payload. Set by `start.ts` from the `webTitle` server option (the
+   * CLI's `--web-title` flag).
+   */
+  readonly webTitle?: string;
 }
 
 export async function registerApiV1Routes(
@@ -110,6 +116,7 @@ export async function registerApiV1Routes(
         serverId: ulid(),
         startedAt: new Date().toISOString(),
         dangerousBypassAuth: opts.dangerousBypassAuth === true,
+        webTitle: opts.webTitle,
         getExperimentalFlags: async () => {
           // Same edge-facade contract as the config route: never project
           // config-derived state before the initial load settles — an early

--- a/packages/kap-server/src/start.ts
+++ b/packages/kap-server/src/start.ts
@@ -133,6 +133,13 @@ export interface ServerStartOptions {
   readonly authTokenService?: IAuthTokenService;
   readonly disableAuth?: boolean;
   /**
+   * Custom browser tab title for this web UI instance (the CLI's
+   * `--web-title`). Surfaced as `web_title` in `GET /api/v1/meta` so the web
+   * UI can distinguish multiple instances on different machines. Instance-level
+   * and frozen at boot; omit to let the UI fall back to `<workspace dir> | Kimi Code`.
+   */
+  readonly webTitle?: string;
+  /**
    * Optional *additional* credential accepted on the RPC surface (debug REST +
    * WebSocket) alongside the persistent bearer token. Never required and never
    * the only gate: the persistent token always protects the RPC surface. Leave
@@ -548,6 +555,7 @@ export async function startServer(opts: ServerStartOptions): Promise<RunningServ
     broadcaster,
     transcriptService,
     dangerousBypassAuth: opts.disableAuth === true,
+    webTitle: opts.webTitle,
   });
 
   // `/api/v2` — same envelope conventions as v1, domain-grouped payloads.

--- a/packages/kap-server/test/meta.test.ts
+++ b/packages/kap-server/test/meta.test.ts
@@ -124,3 +124,49 @@ describe('/api/v1/meta experimental_flags', () => {
     expect((await getMetaFlags(base))['tool-select']).toBe(true);
   });
 });
+
+describe('/api/v1/meta web_title', () => {
+  let server: RunningServer | undefined;
+  let home: string | undefined;
+
+  afterEach(async () => {
+    if (server !== undefined) {
+      await server.close();
+      server = undefined;
+    }
+    if (home !== undefined) {
+      await rm(home, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
+      home = undefined;
+    }
+  });
+
+  async function bootWithWebTitle(
+    webTitle?: string,
+  ): Promise<{ base: string; body: { data: { web_title?: string } } }> {
+    home = await mkdtemp(join(tmpdir(), 'kimi-server-v2-meta-title-'));
+    server = await startServer({
+      hostIdentity: TEST_HOST_IDENTITY,
+      host: '127.0.0.1',
+      port: 0,
+      homeDir: home,
+      logLevel: 'silent',
+      webTitle,
+    });
+    const base = `http://127.0.0.1:${server.port}`;
+    const res = await authedFetch(server, base, '/api/v1/meta');
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { code: number; data: { web_title?: string } };
+    expect(body.code).toBe(0);
+    return { base, body };
+  }
+
+  it('surfaces the boot-time webTitle as web_title', async () => {
+    const { body } = await bootWithWebTitle('My Dev Box');
+    expect(body.data.web_title).toBe('My Dev Box');
+  });
+
+  it('omits web_title when no webTitle was passed', async () => {
+    const { body } = await bootWithWebTitle();
+    expect(body.data.web_title).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## 背景

多台开发机各开一个 kimi web 实例时，浏览器标签页 title 完全一致，无法区分（含 pin tab 场景）。

## 改动

- `kimi web` 新增 `--web-title <title>` 启动参数（覆盖默认标题，纯字符串）；
- 参数经 `parseServerOptions` 透传到 kap-server 启动选项；
- `GET /api/v1/meta` 响应新增 `web_title` 字段（未设置时省略）。

默认标题逻辑（`{workspace 目录名} | Kimi Code`）在客户端仓库 kimi-code-app 的配套 PR 中实现（本 PR 不含默认标题，只提供 override 通道）。

## 验证

- 两包 tsc 0 错误；web.test.ts 55/55；kap-server 全量 70 文件 1062 测试通过；
- 新增用例：CLI 选项注册/透传 ×3、/meta 暴露与省略 web_title ×2。