### PR TITLE
fix(os): normalize Windows drive-root paths for fs.watch

### DIFF
--- a/packages/agent-core-v2/src/os/backends/node-local/hostFsWatchService.ts
+++ b/packages/agent-core-v2/src/os/backends/node-local/hostFsWatchService.ts
@@ -1,3 +1,10 @@
+/**
+ * Host filesystem watch service.
+ *
+ * On Windows, drive-root watch paths such as `D:` / `/D:` are normalized to
+ * `D:\\` before `fs.watch`, avoiding ENOENT when the process CWD is a drive root.
+ */
+
 import { watch as fsWatch } from 'node:fs';
 import { basename, isAbsolute, join, relative } from 'node:path';
 
@@ -230,11 +237,21 @@ export class HostFsWatchService implements IHostFsWatchService {
   constructor(private readonly runtime: HostFsWatchRuntime = NODE_HOST_FS_WATCH_RUNTIME) {}
 
   watch(path: string, options?: HostFsWatchOptions): IHostFsWatchHandle {
+    const root = normalizeWatchRoot(path, this.runtime.platform);
     if (useNativeRecursive(options, this.runtime.platform)) {
-      return new SignalWatchHandle(path, options, this.runtime);
+      return new SignalWatchHandle(root, options, this.runtime);
     }
-    return new HostFsWatchHandle(path, options);
+    return new HostFsWatchHandle(root, options);
   }
+}
+
+function normalizeWatchRoot(path: string, platform: NodeJS.Platform): string {
+  if (platform !== 'win32') return path;
+  const driveOnly = path.match(/^\/?([A-Za-z]):\/?$/);
+  if (driveOnly) {
+    return `${driveOnly[1].toUpperCase()}:\\`;
+  }
+  return path;
 }
 
 function useNativeRecursive(

--- a/packages/agent-core-v2/test/os/backends/node-local/hostFsWatchService.test.ts
+++ b/packages/agent-core-v2/test/os/backends/node-local/hostFsWatchService.test.ts
@@ -289,6 +289,26 @@ describe('host filesystem change notifications', () => {
     expect(events).toHaveLength(0);
   });
 
+  it('normalizes Windows drive-root watch paths before calling watchNative', () => {
+    const watched: string[] = [];
+    const runtime: HostFsWatchRuntime = {
+      platform: 'win32',
+      watchNative: (root, _listener) => {
+        watched.push(root);
+        return new TestNativeWatcher();
+      },
+      scheduleRetry: () => ({ dispose: () => undefined }),
+    };
+    const service = new HostFsWatchService(runtime);
+    handle = service.watch('/D:', { signal: true });
+    expect(watched).toEqual(['D:\\']);
+    handle.dispose();
+    handle = undefined;
+
+    handle = service.watch('E:', { signal: true });
+    expect(watched).toEqual(['D:\\', 'E:\\']);
+  });
+
   it.skipIf(process.platform !== 'darwin')(
     'signal mode keeps the fd footprint bounded on a fat subtree',
     async () => {


### PR DESCRIPTION
## Summary
- On Windows, starting from a drive root CWD such as `D:` can produce a POSIX-ish watch path `/D:`.
- `fs.watch('/D:')` then fails with `ENOENT: no such file or directory, watch '/D:'`.
- Normalize drive-only roots to `D:\` before creating native/chokidar watchers.
- Add a regression test for `/D:` and `E:`.

Related: MoonshotAI/kimi-cli#2600

## Testing plan
- [x] Added unit test that `watchNative` receives `D:\\` when given `/D:` / `E:` on `win32`.
- [ ] Manual: set PowerShell start directory to `D:\` (drive root), launch Kimi Code, confirm no `watch '/D:'` crash.