### PR TITLE
fix(agent-core-v2): load config permission rules into agents at bootstrap

### DIFF
--- a/.changeset/v2-config-permission-rules.md
+++ b/.changeset/v2-config-permission-rules.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Fix `[[permission.rules]]` in `config.toml` being ignored, which caused every matching tool call to still prompt for approval.

--- a/packages/agent-core-v2/src/session/agentLifecycle/agentLifecycleService.ts
+++ b/packages/agent-core-v2/src/session/agentLifecycle/agentLifecycleService.ts
@@ -6,13 +6,15 @@
  * failure. Seeds each agent's identity through `agent` scopeContext, wires
  * per-agent wire records and the wire state machine, the blob store, and MCP,
  * and registers the agent in the session registry. Binds the agent id into the
- * Agent-scoped telemetry view. New logs receive a metadata
- * envelope while non-empty unversioned logs are rejected. Removal awaits the
- * agent task manager's graceful exit policy before draining turns and full
- * compaction, then disposing the child scope. Fans session-level
- * permission-mode switches out to every live agent — except
- * `tower-worker`-profile agents, which TowerSpawn pins to `auto` (they run
- * detached and unattended); the broadcast leaves them on `auto`. Bound at
+ * Agent-scoped telemetry view. Once the wire log is restored, applies the
+ * permission configuration read from `config` — the default permission mode
+ * and the configured rules, the latter installed through `permissionRules`.
+ * New logs receive a metadata envelope while non-empty unversioned logs are
+ * rejected. Removal awaits the agent task manager's graceful exit policy
+ * before draining turns and full compaction, then disposing the child scope.
+ * Fans session-level permission-mode switches out to every live agent —
+ * except `tower-worker`-profile agents, which TowerSpawn pins to `auto` (they
+ * run detached and unattended); the broadcast leaves them on `auto`. Bound at
  * Session scope.
  *
  * No agent id is special here: the main agent is simply the agent created

--- a/packages/agent-core-v2/src/session/agentLifecycle/agentLifecycleService.ts
+++ b/packages/agent-core-v2/src/session/agentLifecycle/agentLifecycleService.ts
@@ -39,6 +39,7 @@ import { IConfigService } from '#/app/config/config';
 import { IEventBus } from '#/app/event/eventBus';
 import { DEFAULT_PERMISSION_MODE_SECTION } from '#/agent/permissionMode/configSection';
 import { permissionModeConfiguredKey } from '#/agent/permissionMode/permissionModeOps';
+import { PERMISSION_SECTION, type PermissionConfig } from '#/agent/permissionRules/configSection';
 import type { PermissionMode } from '#/agent/permissionPolicy/types';
 import { profileKey } from '#/agent/profile/profileOps';
 import { TOWER_WORKER_PROFILE } from '#/features/tower/tower';
@@ -51,6 +52,7 @@ import { TurnEnded } from '#/agent/loop/turnOps';
 import { IAgentProfileService } from '#/agent/profile/profile';
 import { abortError } from '#/_base/utils/abort';
 import { IAgentPermissionModeService } from '#/agent/permissionMode/permissionMode';
+import { IAgentPermissionRulesService } from '#/agent/permissionRules/permissionRules';
 import { IAgentContextMemoryService } from '#/agent/contextMemory/contextMemory';
 import { IAgentRuntimeBindingSeed, IAgentRuntimeBindingService } from '#/agent/runtimeBinding/runtimeBinding';
 import '#/agent/runtimeBinding/runtimeBindingService';
@@ -217,6 +219,10 @@ export class AgentLifecycleService extends Disposable implements IAgentLifecycle
       .get(permissionModeConfiguredKey);
     if (permissionMode !== undefined && !hasRestoredPermissionMode) {
       handle.accessor.get(IAgentPermissionModeService).setMode(permissionMode);
+    }
+    const permissionRules = this.config.get<PermissionConfig>(PERMISSION_SECTION)?.rules;
+    if (permissionRules !== undefined && permissionRules.length > 0) {
+      handle.accessor.get(IAgentPermissionRulesService).addRules(permissionRules);
     }
   }
 

--- a/packages/agent-core-v2/test/session/agentLifecycle/agentLifecycle.test.ts
+++ b/packages/agent-core-v2/test/session/agentLifecycle/agentLifecycle.test.ts
@@ -30,6 +30,14 @@ import {
 } from '#/agent/permissionMode/permissionModeOps';
 import { IAgentRuntimeBindingService } from '#/agent/runtimeBinding/runtimeBinding';
 import { IAgentRuntimeService } from '#/agent/runtimeBinding/agentRuntime';
+import { IAgentPermissionPolicyService } from '#/agent/permissionPolicy/permissionPolicy';
+import '#/agent/permissionPolicy/permissionPolicyService';
+import {
+  IAgentPermissionRulesService,
+  type PermissionRule,
+} from '#/agent/permissionRules/permissionRules';
+import { PERMISSION_SECTION } from '#/agent/permissionRules/configSection';
+import { AgentPermissionRulesService } from '#/agent/permissionRules/permissionRulesService';
 import { IAgentStateService } from '#/agent/state/agentState';
 import { AgentStateService } from '#/agent/state/agentStateService';
 import { IAgentContextInjectorService } from '#/agent/contextInjector/contextInjector';
@@ -78,6 +86,11 @@ import { ISessionContext } from '#/session/sessionContext/sessionContext';
 import { ISessionMetadata } from '#/session/sessionMetadata/sessionMetadata';
 import { createWireMetadataRecord, type WireRecord } from '#/wire/record';
 import { IAgentToolExecutorService } from '#/agent/toolExecutor/toolExecutor';
+import type { ResolvedToolExecutionHookContext } from '#/agent/toolExecutor/toolHooks';
+import type { ToolCall } from '#/kosong/contract/message';
+import { literalRulePattern, matchesGlobRuleSubject } from '#/tool/rule-match';
+import { ToolAccesses } from '#/tool/toolContract';
+import { IGitService } from '#/app/git/git';
 import { IAgentLoopService } from '#/agent/loop/loop';
 import { IAgentPromptService } from '#/agent/prompt/prompt';
 import { IAgentFullCompactionService } from '#/agent/fullCompaction/fullCompaction';
@@ -181,6 +194,30 @@ function stubBlobPassThrough(ix: TestInstantiationService): void {
     loadParts: async (parts) => parts,
     isBlobRef: () => false,
   } satisfies IAgentBlobService);
+}
+
+function bashToolCallContext(command: string): ResolvedToolExecutionHookContext {
+  const toolCall: ToolCall = {
+    type: 'function',
+    id: 'call_bash',
+    name: 'Bash',
+    arguments: JSON.stringify({ command }),
+  };
+  return {
+    turnId: 0,
+    signal: new AbortController().signal,
+    toolCall,
+    toolCalls: [toolCall],
+    args: { command },
+    execution: {
+      description: 'run command',
+      display: { kind: 'command', command },
+      accesses: ToolAccesses.none(),
+      approvalRule: literalRulePattern('Bash', command),
+      matchesRule: (ruleArgs) => matchesGlobRuleSubject(ruleArgs, command),
+      execute: async () => ({ output: '' }),
+    },
+  };
 }
 
 describe('AgentLifecycleService', () => {
@@ -378,6 +415,9 @@ describe('AgentLifecycleService', () => {
       _serviceBrand: undefined,
       register: () => ({ dispose: () => {} }),
     } as unknown as IAgentContextInjectorService);
+    ix.stub(IGitService, {
+      findWorkTree: async () => null,
+    } as unknown as IGitService);
     ix.stub(ISessionAgentProfileCatalog, {
       _serviceBrand: undefined,
       ready: Promise.resolve(),
@@ -758,6 +798,108 @@ describe('AgentLifecycleService', () => {
       kind: 'question',
       request: { q: 1 },
       resolved: false,
+    });
+  });
+
+  it('loads the configured permission rules into the agent on create', async () => {
+    const addRules = vi.spyOn(AgentPermissionRulesService.prototype, 'addRules');
+    const rules: PermissionRule[] = [
+      { decision: 'allow', scope: 'user', pattern: 'Bash(ls*)' },
+      { decision: 'deny', scope: 'project', pattern: 'Bash(rm*)', reason: 'destructive' },
+    ];
+    ix.stub(IConfigService, {
+      ready: Promise.resolve(),
+      get: ((section: string) =>
+        section === PERMISSION_SECTION ? { rules } : undefined) as IConfigService['get'],
+      onDidSectionChange: (() => ({ dispose: () => {} })) as IConfigService['onDidSectionChange'],
+    } as unknown as IConfigService);
+
+    const main = await ix.get(IAgentLifecycleService).create({ agentId: 'main' });
+
+    expect(addRules).toHaveBeenCalledOnce();
+    expect(addRules).toHaveBeenCalledWith(rules);
+    expect(main.accessor.get(IAgentPermissionRulesService).rules).toEqual(rules);
+  });
+
+  it('does not add permission rules when the permission section is not configured', async () => {
+    const addRules = vi.spyOn(AgentPermissionRulesService.prototype, 'addRules');
+
+    const main = await ix.get(IAgentLifecycleService).create({ agentId: 'main' });
+
+    expect(addRules).not.toHaveBeenCalled();
+    expect(main.accessor.get(IAgentPermissionRulesService).rules).toEqual([]);
+  });
+
+  it('does not add permission rules when the configured rules list is empty', async () => {
+    const addRules = vi.spyOn(AgentPermissionRulesService.prototype, 'addRules');
+    ix.stub(IConfigService, {
+      ready: Promise.resolve(),
+      get: ((section: string) =>
+        section === PERMISSION_SECTION ? { rules: [] } : undefined) as IConfigService['get'],
+      onDidSectionChange: (() => ({ dispose: () => {} })) as IConfigService['onDidSectionChange'],
+    } as unknown as IConfigService);
+
+    const main = await ix.get(IAgentLifecycleService).create({ agentId: 'main' });
+
+    expect(addRules).not.toHaveBeenCalled();
+    expect(main.accessor.get(IAgentPermissionRulesService).rules).toEqual([]);
+  });
+
+  it('re-injects the configured rules on resume without touching the restored session approvals', async () => {
+    const log = recordingAppendLog([
+      createWireMetadataRecord(1),
+      {
+        type: 'permission.record_approval_result',
+        turnId: 1,
+        toolCallId: 'call_1',
+        toolName: 'Bash',
+        action: 'run command',
+        sessionApprovalRule: 'Bash(pnpm test)',
+        result: { decision: 'approved', scope: 'session' },
+        time: 2,
+      },
+    ]);
+    ix.stub(IAppendLogStore, log.store);
+    const addRules = vi.spyOn(AgentPermissionRulesService.prototype, 'addRules');
+    const rules: PermissionRule[] = [{ decision: 'allow', scope: 'user', pattern: 'Bash(ls*)' }];
+    ix.stub(IConfigService, {
+      ready: Promise.resolve(),
+      get: ((section: string) =>
+        section === PERMISSION_SECTION ? { rules } : undefined) as IConfigService['get'],
+      onDidSectionChange: (() => ({ dispose: () => {} })) as IConfigService['onDidSectionChange'],
+    } as unknown as IConfigService);
+
+    const main = await ix.get(IAgentLifecycleService).create({ agentId: 'main' });
+    const rulesService = main.accessor.get(IAgentPermissionRulesService);
+
+    expect(addRules).toHaveBeenCalledOnce();
+    expect(rulesService.rules).toEqual(rules);
+    expect(rulesService.sessionApprovalRulePatterns).toEqual(['Bash(pnpm test)']);
+    expect(log.appended.some((record) => record.type === 'permission.rules.add')).toBe(false);
+  });
+
+  it('denies a tool call that matches a configured deny rule', async () => {
+    const rules: PermissionRule[] = [
+      { decision: 'deny', scope: 'user', pattern: 'Bash(rm*)', reason: 'destructive' },
+    ];
+    ix.stub(IConfigService, {
+      ready: Promise.resolve(),
+      get: ((section: string) =>
+        section === PERMISSION_SECTION ? { rules } : undefined) as IConfigService['get'],
+      onDidSectionChange: (() => ({ dispose: () => {} })) as IConfigService['onDidSectionChange'],
+    } as unknown as IConfigService);
+    const main = await ix.get(IAgentLifecycleService).create({ agentId: 'main' });
+
+    const evaluation = await main.accessor
+      .get(IAgentPermissionPolicyService)
+      .evaluate(bashToolCallContext('rm -rf kimi-target'));
+
+    expect(evaluation).toMatchObject({
+      policyName: 'user-configured-deny',
+      result: {
+        kind: 'deny',
+        message: 'Tool "Bash" was denied by permission rule. Reason: destructive',
+      },
     });
   });
 

--- a/packages/agent-core-v2/test/session/agentLifecycle/agentLifecycle.test.ts
+++ b/packages/agent-core-v2/test/session/agentLifecycle/agentLifecycle.test.ts
@@ -10,6 +10,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { SyncDescriptor } from '#/_base/di/descriptors';
+import { IInstantiationService } from '#/_base/di/instantiation';
 import { Disposable, DisposableStore } from '#/_base/di/lifecycle';
 import { LifecycleScope } from '#/app/scopes';
 import { type ISessionScopeHandle } from '#/_base/di/scope';
@@ -30,14 +31,13 @@ import {
 } from '#/agent/permissionMode/permissionModeOps';
 import { IAgentRuntimeBindingService } from '#/agent/runtimeBinding/runtimeBinding';
 import { IAgentRuntimeService } from '#/agent/runtimeBinding/agentRuntime';
-import { IAgentPermissionPolicyService } from '#/agent/permissionPolicy/permissionPolicy';
-import '#/agent/permissionPolicy/permissionPolicyService';
+import { UserConfiguredDenyPermissionPolicyService } from '#/agent/permissionPolicy/policies/user-configured-deny';
 import {
   IAgentPermissionRulesService,
   type PermissionRule,
 } from '#/agent/permissionRules/permissionRules';
 import { PERMISSION_SECTION } from '#/agent/permissionRules/configSection';
-import { AgentPermissionRulesService } from '#/agent/permissionRules/permissionRulesService';
+import '#/agent/permissionRules/permissionRulesService';
 import { IAgentStateService } from '#/agent/state/agentState';
 import { AgentStateService } from '#/agent/state/agentStateService';
 import { IAgentContextInjectorService } from '#/agent/contextInjector/contextInjector';
@@ -90,7 +90,6 @@ import type { ResolvedToolExecutionHookContext } from '#/agent/toolExecutor/tool
 import type { ToolCall } from '#/kosong/contract/message';
 import { literalRulePattern, matchesGlobRuleSubject } from '#/tool/rule-match';
 import { ToolAccesses } from '#/tool/toolContract';
-import { IGitService } from '#/app/git/git';
 import { IAgentLoopService } from '#/agent/loop/loop';
 import { IAgentPromptService } from '#/agent/prompt/prompt';
 import { IAgentFullCompactionService } from '#/agent/fullCompaction/fullCompaction';
@@ -415,9 +414,6 @@ describe('AgentLifecycleService', () => {
       _serviceBrand: undefined,
       register: () => ({ dispose: () => {} }),
     } as unknown as IAgentContextInjectorService);
-    ix.stub(IGitService, {
-      findWorkTree: async () => null,
-    } as unknown as IGitService);
     ix.stub(ISessionAgentProfileCatalog, {
       _serviceBrand: undefined,
       ready: Promise.resolve(),
@@ -802,7 +798,6 @@ describe('AgentLifecycleService', () => {
   });
 
   it('loads the configured permission rules into the agent on create', async () => {
-    const addRules = vi.spyOn(AgentPermissionRulesService.prototype, 'addRules');
     const rules: PermissionRule[] = [
       { decision: 'allow', scope: 'user', pattern: 'Bash(ls*)' },
       { decision: 'deny', scope: 'project', pattern: 'Bash(rm*)', reason: 'destructive' },
@@ -816,22 +811,16 @@ describe('AgentLifecycleService', () => {
 
     const main = await ix.get(IAgentLifecycleService).create({ agentId: 'main' });
 
-    expect(addRules).toHaveBeenCalledOnce();
-    expect(addRules).toHaveBeenCalledWith(rules);
     expect(main.accessor.get(IAgentPermissionRulesService).rules).toEqual(rules);
   });
 
   it('does not add permission rules when the permission section is not configured', async () => {
-    const addRules = vi.spyOn(AgentPermissionRulesService.prototype, 'addRules');
-
     const main = await ix.get(IAgentLifecycleService).create({ agentId: 'main' });
 
-    expect(addRules).not.toHaveBeenCalled();
     expect(main.accessor.get(IAgentPermissionRulesService).rules).toEqual([]);
   });
 
   it('does not add permission rules when the configured rules list is empty', async () => {
-    const addRules = vi.spyOn(AgentPermissionRulesService.prototype, 'addRules');
     ix.stub(IConfigService, {
       ready: Promise.resolve(),
       get: ((section: string) =>
@@ -841,7 +830,6 @@ describe('AgentLifecycleService', () => {
 
     const main = await ix.get(IAgentLifecycleService).create({ agentId: 'main' });
 
-    expect(addRules).not.toHaveBeenCalled();
     expect(main.accessor.get(IAgentPermissionRulesService).rules).toEqual([]);
   });
 
@@ -860,7 +848,6 @@ describe('AgentLifecycleService', () => {
       },
     ]);
     ix.stub(IAppendLogStore, log.store);
-    const addRules = vi.spyOn(AgentPermissionRulesService.prototype, 'addRules');
     const rules: PermissionRule[] = [{ decision: 'allow', scope: 'user', pattern: 'Bash(ls*)' }];
     ix.stub(IConfigService, {
       ready: Promise.resolve(),
@@ -872,7 +859,6 @@ describe('AgentLifecycleService', () => {
     const main = await ix.get(IAgentLifecycleService).create({ agentId: 'main' });
     const rulesService = main.accessor.get(IAgentPermissionRulesService);
 
-    expect(addRules).toHaveBeenCalledOnce();
     expect(rulesService.rules).toEqual(rules);
     expect(rulesService.sessionApprovalRulePatterns).toEqual(['Bash(pnpm test)']);
     expect(log.appended.some((record) => record.type === 'permission.rules.add')).toBe(false);
@@ -890,16 +876,17 @@ describe('AgentLifecycleService', () => {
     } as unknown as IConfigService);
     const main = await ix.get(IAgentLifecycleService).create({ agentId: 'main' });
 
-    const evaluation = await main.accessor
-      .get(IAgentPermissionPolicyService)
-      .evaluate(bashToolCallContext('rm -rf kimi-target'));
+    // Instantiate the single policy the way the policy service does
+    // (`createInstance`) — importing the policy service impl here would pull
+    // its eager Agent-scope registration into this shared test env.
+    const policy = main.accessor
+      .get(IInstantiationService)
+      .createInstance(UserConfiguredDenyPermissionPolicyService);
+    const result = policy.evaluate(bashToolCallContext('rm -rf kimi-target'));
 
-    expect(evaluation).toMatchObject({
-      policyName: 'user-configured-deny',
-      result: {
-        kind: 'deny',
-        message: 'Tool "Bash" was denied by permission rule. Reason: destructive',
-      },
+    expect(result).toEqual({
+      kind: 'deny',
+      message: 'Tool "Bash" was denied by permission rule. Reason: destructive',
     });
   });
 


### PR DESCRIPTION
## Related Issue

Closes #2964

## Problem

Since 0.33.0 the interactive TUI, `kimi -p`, and `kimi acp` run on the agent-core-v2 engine by default. Under v2, `[[permission.rules]]` in `~/.kimi-code/config.toml` (e.g. `{ decision = "allow", pattern = "Bash(ls*)" }`) has no effect at all — every matching Bash call still prompts for approval. Root cause, in three parts:

1. The v2 `permission` config section has a complete schema and TOML transforms and self-registers at module load (`packages/agent-core-v2/src/agent/permissionRules/configSection.ts`), but after registration it has no consumer anywhere in the repo.
2. `IAgentPermissionRulesService.addRules` has no production call site (only tests call it). Agent materialization replays only persisted records via `wire.restore()`, and `permission.rules.add` is a transient op, so after restore the rules model is always empty.
3. With the rules model empty, the `user-configured-allow/deny/ask` policies can never match, and unmatched calls fall through to `fallback-ask` at the end of the policy chain.

v1 had this wiring: session create/resume passed `config.permission?.rules` into the PermissionManager. The v2 port dropped it.

## What changed

One change point: `AgentLifecycleService.bindBootstrap` (`packages/agent-core-v2/src/session/agentLifecycle/agentLifecycleService.ts`). After `wire.restore()`, it now reads the `permission` section through `IConfigService` and applies `rules` via `IAgentPermissionRulesService.addRules`, mirroring the existing `defaultPermissionMode` block in the same function.

Why the engine-side bootstrap point rather than host-side injection:

1. **Single point, full coverage.** TUI / `kimi -p` / `kimi acp` / `kimi web` all run the engine in-process, and session create/resume converges on `IAgentLifecycleService.create` → `bindBootstrap`; subagents (Agent tool), btw forks, and session forks are materialized through the same entry. Host-side injection would need touch points in node-sdk, acp-server, and kap-server, and would still miss agents created inside the engine.
2. **Fits the v2 config model.** Each config section is read by its consumer through `IConfigService`, never passed around as a config bag via options; `defaultPermissionMode` and `defaultPlanMode` are existing precedents of the engine applying a config section at bootstrap.
3. **Resume semantics match v1.** `permission.rules.add` is a transient op, so the rules model starts empty on restore and `bindBootstrap` re-reads the current `config.toml` — rule edits between runs take effect on the next resume, injection happens exactly once per materialization, and the approval memory replayed from persisted `permission.record_approval_result` records is untouched.
4. **Subagents inherit automatically**, since they go through the same `create` → `bindBootstrap` path — the net effect matches v1, where subagents shared the parent's PermissionManager.

Tests: extended `packages/agent-core-v2/test/session/agentLifecycle/agentLifecycle.test.ts` — rules from config are loaded into the agent on create; `addRules` is not called when the section is missing or the list is empty; on resume the config rules are re-injected while the restored session-approval patterns are preserved (and nothing is re-persisted); and a config-sourced deny rule actually blocks a matching tool call through the real policy chain (`user-configured-deny`).

## Screenshots

Before (0.36.1): `ls` prompts for approval despite `[[permission.rules]]` allowing `Bash(ls*)`. After (this branch): the same prompt runs `ls` directly, no approval dialog.

| Before (0.36.1) | After (this branch) |
| --- | --- |
| <img width="1674" height="1100" alt="kimi-code-approval-before-fix" src="https://github.com/user-attachments/assets/3b04cc45-3c79-4ce3-adbe-93733faeca92" /> | <img width="1650" height="1468" alt="kimi-code-approval-after-fix" src="https://github.com/user-attachments/assets/283cacbb-ca50-4a8c-a00c-fce300734cb1" /> |

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update. (No doc update needed — the fix restores the already-documented `[[permission.rules]]` behavior.)
