### PR TITLE
fix(agent-core-v2): degrade media tool registration when the bound model alias is stale

### DIFF
--- a/.changeset/media-registrar-stale-alias.md
+++ b/.changeset/media-registrar-stale-alias.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Fix an `[unexpected] Error2: Model "<alias>" is not configured in config.toml` error printed on startup when a restored session references a model that is no longer configured (e.g. after logging out of the managed Kimi Code account). Media tool registration now degrades gracefully instead of throwing from the `agent.status.updated` listener.

--- a/packages/agent-core-v2/src/agent/media/mediaToolsRegistrar.ts
+++ b/packages/agent-core-v2/src/agent/media/mediaToolsRegistrar.ts
@@ -124,8 +124,19 @@ export class AgentMediaToolsRegistrar extends Service implements IAgentMediaTool
     let requester: ModelRequester | undefined;
     let model: Model | undefined;
     if (modelAlias !== '') {
-      requester = this.modelCatalog.getRequester(modelAlias);
-      model = requester.model;
+      // The alias comes from persisted profile state, which is replayed on
+      // resume without catalog validation — it may no longer resolve (e.g.
+      // the model was removed from config.toml when the user logged out).
+      // A listener throw escapes into the event bus and is reported as an
+      // `[unexpected]` error, so degrade to "no model" instead: media tools
+      // stay registered, just without a model-bound video uploader.
+      try {
+        requester = this.modelCatalog.getRequester(modelAlias);
+        model = requester.model;
+      } catch {
+        requester = undefined;
+        model = undefined;
+      }
     }
     this.registration = registerMediaTools(this.toolRegistry, {
       runtime,

--- a/packages/agent-core-v2/src/agent/media/mediaToolsRegistrar.ts
+++ b/packages/agent-core-v2/src/agent/media/mediaToolsRegistrar.ts
@@ -17,6 +17,14 @@
  * converts `video_url` takes the inline fallback when no upload hook
  * exists.
  *
+ * The alias re-resolved on every refresh comes from persisted profile
+ * state that resume replays without catalog validation, so it may no
+ * longer resolve (e.g. its config.toml entry was removed on logout).
+ * A failed resolution degrades to "no model" — registration proceeds
+ * from the profile-reported capabilities without a model-bound video
+ * uploader — instead of throwing out of the event listener, where the
+ * escape would surface as an `[unexpected]` error.
+ *
  * The plain-data state (`registeredKey`) is registered into `agentState`
  * (`IAgentStateService`) and read/written through it; `registration` stays an
  * instance field (the live `IDisposable` tool-registration handle, not plain
@@ -124,12 +132,6 @@ export class AgentMediaToolsRegistrar extends Service implements IAgentMediaTool
     let requester: ModelRequester | undefined;
     let model: Model | undefined;
     if (modelAlias !== '') {
-      // The alias comes from persisted profile state, which is replayed on
-      // resume without catalog validation — it may no longer resolve (e.g.
-      // the model was removed from config.toml when the user logged out).
-      // A listener throw escapes into the event bus and is reported as an
-      // `[unexpected]` error, so degrade to "no model" instead: media tools
-      // stay registered, just without a model-bound video uploader.
       try {
         requester = this.modelCatalog.getRequester(modelAlias);
         model = requester.model;

--- a/packages/agent-core-v2/test/agent/media/tools/read-media.test.ts
+++ b/packages/agent-core-v2/test/agent/media/tools/read-media.test.ts
@@ -9,7 +9,7 @@
 
 import * as posixPath from 'node:path/posix';
 
-import type { ModelCapability } from '#/kosong/contract/capability';
+import { UNKNOWN_CAPABILITY, type ModelCapability } from '#/kosong/contract/capability';
 import type { ContentPart } from '#/kosong/contract/message';
 import { VideoUploadUnsupportedError } from '#/kosong/contract/errors';
 import { Jimp } from 'jimp';
@@ -925,7 +925,10 @@ describe('AgentMediaToolsRegistrar', () => {
     const breakAlias = (alias: string): void => {
       brokenAliases.add(alias);
     };
-    return { registry, registrar, bindModel, setRuntimeAvailable, breakAlias };
+    const healAlias = (alias: string): void => {
+      brokenAliases.delete(alias);
+    };
+    return { registry, registrar, bindModel, setRuntimeAvailable, breakAlias, healAlias };
   }
 
   it('registers nothing until a media-capable model binds, then registers ReadMediaFile', () => {
@@ -979,18 +982,20 @@ describe('AgentMediaToolsRegistrar', () => {
     expect(registry.resolve('ReadMediaFile')).toBe(first);
   });
 
-  it('degrades to no requester when the bound alias is not configured', () => {
+  it('survives an unconfigured bound alias and recovers when it resolves again', () => {
     const unexpected: unknown[] = [];
     setUnexpectedErrorHandler((err) => unexpected.push(err));
     try {
-      const { registry, bindModel, breakAlias } = createRegistrarHarness();
+      const { registry, bindModel, breakAlias, healAlias } = createRegistrarHarness();
       breakAlias('stale-model');
-      // A stale alias restored from a pre-logout session no longer resolves in
-      // the catalog; the listener must not surface an [unexpected] error, and
-      // media tools stay registered off the profile-reported capabilities.
-      bindModel('stale-model', capabilities({ image_in: true, video_in: true }));
+      bindModel('stale-model', UNKNOWN_CAPABILITY);
       expect(unexpected).toHaveLength(0);
+      expect(registry.resolve('ReadMediaFile')).toBeUndefined();
+
+      healAlias('stale-model');
+      bindModel('stale-model', capabilities({ image_in: true, video_in: true }));
       expect(registry.resolve('ReadMediaFile')).toBeInstanceOf(ReadMediaFileTool);
+      expect(unexpected).toHaveLength(0);
     } finally {
       resetUnexpectedErrorHandler();
     }

--- a/packages/agent-core-v2/test/agent/media/tools/read-media.test.ts
+++ b/packages/agent-core-v2/test/agent/media/tools/read-media.test.ts
@@ -16,6 +16,10 @@ import { Jimp } from 'jimp';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { Emitter } from '#/_base/event';
+import {
+  resetUnexpectedErrorHandler,
+  setUnexpectedErrorHandler,
+} from '#/_base/errors/unexpectedError';
 import type { IHostFileSystem } from '#/os/interface/hostFileSystem';
 import type { IHostEnvironment } from '#/os/interface/hostEnvironment';
 import type { IAgentRuntimeService } from '#/agent/runtimeBinding/agentRuntime';
@@ -872,10 +876,14 @@ describe('AgentMediaToolsRegistrar', () => {
       getModelCapabilities: () => state.capabilities,
       getModel: () => state.alias,
     } as unknown as IAgentProfileService;
+    const brokenAliases = new Set<string>();
     const modelCatalog = {
-      getRequester: (id: string) => ({
-        model: { id, name: id, providerName: 'test', protocol: 'openai' },
-      }),
+      getRequester: (id: string) => {
+        if (brokenAliases.has(id)) {
+          throw new Error(`Model "${id}" is not configured in config.toml.`);
+        }
+        return { model: { id, name: id, providerName: 'test', protocol: 'openai' } };
+      },
     } as unknown as IModelCatalog;
     const workspaceCtx = {
       workDir: '/workspace',
@@ -914,7 +922,10 @@ describe('AgentMediaToolsRegistrar', () => {
       runtimeAvailable = available;
       runtimeChanges.fire();
     };
-    return { registry, registrar, bindModel, setRuntimeAvailable };
+    const breakAlias = (alias: string): void => {
+      brokenAliases.add(alias);
+    };
+    return { registry, registrar, bindModel, setRuntimeAvailable, breakAlias };
   }
 
   it('registers nothing until a media-capable model binds, then registers ReadMediaFile', () => {
@@ -966,6 +977,23 @@ describe('AgentMediaToolsRegistrar', () => {
 
     bindModel('vision-model', capabilities({ image_in: true, video_in: true }));
     expect(registry.resolve('ReadMediaFile')).toBe(first);
+  });
+
+  it('degrades to no requester when the bound alias is not configured', () => {
+    const unexpected: unknown[] = [];
+    setUnexpectedErrorHandler((err) => unexpected.push(err));
+    try {
+      const { registry, bindModel, breakAlias } = createRegistrarHarness();
+      breakAlias('stale-model');
+      // A stale alias restored from a pre-logout session no longer resolves in
+      // the catalog; the listener must not surface an [unexpected] error, and
+      // media tools stay registered off the profile-reported capabilities.
+      bindModel('stale-model', capabilities({ image_in: true, video_in: true }));
+      expect(unexpected).toHaveLength(0);
+      expect(registry.resolve('ReadMediaFile')).toBeInstanceOf(ReadMediaFileTool);
+    } finally {
+      resetUnexpectedErrorHandler();
+    }
   });
 
   it('unregisters on dispose', () => {


### PR DESCRIPTION
## Problem

Starting `kimi web` (or resuming a session in any host) with a session whose persisted profile references a model that is no longer in `config.toml` prints a scary but harmless startup error:

```
[unexpected] Error2: Model "kimi-code/k3-256k" is not configured in config.toml.
    at ModelCatalog.buildModel (...)
    at ModelCatalog.entry (...)
    at ModelCatalog.getRequester (...)
    at AgentMediaToolsRegistrar.refresh (...)
    ...
    at AgentProfileService.emitStatusUpdated (...)
{ code: 'config.invalid', details: { model: 'kimi-code/k3-256k' } }
```

Repro: log in to the managed Kimi Code account, run some sessions (the model alias, e.g. `kimi-code/k3-256k`, is persisted in each session's wire log via `profile.bind`), log out (which removes the managed provider/models from `config.toml`), then restart and reopen an old session.

## Root cause

- Session resume replays the wire log **silently and without catalog validation** (by design, see `profileOps.ts`), so the profile can carry a stale `modelAlias`.
- The first live profile update after resume publishes `agent.status.updated` with that alias.
- `AgentMediaToolsRegistrar.refresh()` — the `agent.status.updated` listener that keeps `ReadMediaFile` registration in sync with the model — called `modelCatalog.getRequester(modelAlias)` **unguarded**. `buildModel` throws `config.invalid`, the throw escapes the listener, and `safelyCallListener` reports it via `onUnexpectedError` → `console.error('[unexpected]', err)`.

Every other consumer of a possibly-stale alias already degrades gracefully (`tryResolveRawModel` in the profile service, `defaultModelContextTokens` in kap-server's legacyStatus, `resolveDefaultModelContextTokens` in sessionLegacy, `listModels`'s per-model fallback). This listener was the only unguarded background path.

## Fix

Catch the resolution failure in `refresh()` and degrade to "no model": media tools stay registered from the profile-reported capabilities, just without a model-bound video uploader. The registration key still includes the alias, so the next status update after the model becomes resolvable again (e.g. re-login) re-registers correctly — no sticky bad state.

## Tests

- New regression test `degrades to no requester when the bound alias is not configured` in `test/agent/media/tools/read-media.test.ts`: fails before the fix (the stale alias surfaces as an `[unexpected]` listener error), passes after.
- Full `agent-core-v2` suite: 325 files / 5141 tests green.