### PR TITLE
docs: fix thinking-effort examples in configuration docs

### DIFF
--- a/docs/en/configuration/config-files.md
+++ b/docs/en/configuration/config-files.md
@@ -40,7 +40,7 @@ model = "k3"
 max_context_size = 1048576
 capabilities = [ "thinking", "always_thinking", "image_in", "video_in", "tool_use" ]
 display_name = "K3"
-support_efforts = [ "max" ]
+support_efforts = [ "low", "high", "max" ]
 default_effort = "max"
 
 [models."kimi-code/kimi-for-coding"]
@@ -220,7 +220,7 @@ A configured pool — an explicit `[secondary_model.models]` table or a lone `de
 default_model = "kimi-code/kimi-for-coding-highspeed"
 [secondary_model.models]
 "kimi-code/k3" = "Pick this for hard problems. Strong at complex reasoning, algorithm design, deep debugging, math, and systematic challenges."
-"kimi-code/kimi-for-coding-highspeed" = "Fast and cheap. Good for daily refactoring, code explanation, small edits, summaries, and simple batch tasks."
+"kimi-code/kimi-for-coding-highspeed" = "Fast but priced higher. Good for latency-sensitive tasks: daily refactoring, code explanation, small edits, and summaries."
 "kimi-code/kimi-for-coding" = "A balanced coding workhorse. Good for most feature development and code-change tasks."
 ```
 
@@ -236,23 +236,26 @@ force = true
 
 With `force` set, the `model` parameter is not advertised (just like when nothing is configured) and every spawn binds `default_model`; an explicit `model` argument, `"primary"` included, is rejected with an error. `force` requires `default_model` and cannot be combined with a `[secondary_model.models]` table — the table exists to offer a choice, and force removes it.
 
-Because natural resolution lands on the bound model's default effort, different pool entries can carry different thinking levels: register a second `[models]` entry as a "variant" of the same underlying model, override only its `default_effort` via [`[models."<alias>".overrides]`](#model-overrides), and list both aliases in the pool — the main agent picks the thinking level together with the alias:
+Because natural resolution lands on the bound model's default effort, different pool entries can carry different thinking levels: register a second `[models]` entry as a "variant" of the same underlying model, override only its `default_effort` via [`[models."<alias>".overrides]`](#model-overrides), and list both aliases in the pool — the main agent picks the thinking level together with the alias. Two prerequisites: the underlying model must declare `support_efforts` (under `managed:kimi-code` only the k3 family currently declares effort levels), and the variant is a standalone entry that does not inherit fields from the entry it points at — copy `capabilities`, `support_efforts`, and the other metadata over in full, otherwise `default_effort` has no effect (it must be a member of `support_efforts`):
 
 ```toml
-# "kimi-code/kimi-for-coding-highspeed" is provisioned by /login; this
-# registers a higher-effort variant of the same model
-[models.kimi-for-coding-highspeed-deep]
+# "kimi-code/k3" is provisioned by /login (default: high); this registers
+# a max-effort variant of the same model
+[models.k3-max]
 provider = "managed:kimi-code"
-model = "kimi-for-coding-highspeed"
+model = "k3"
+max_context_size = 1048576
+capabilities = [ "thinking", "always_thinking", "image_in", "video_in", "tool_use" ]
+support_efforts = [ "low", "high", "max" ]
 
-[models.kimi-for-coding-highspeed-deep.overrides]
-default_effort = "high"
+[models.k3-max.overrides]
+default_effort = "max"
 
 [secondary_model]
-default_model = "kimi-code/kimi-for-coding-highspeed"
+default_model = "kimi-code/k3"
 [secondary_model.models]
-"kimi-code/kimi-for-coding-highspeed" = "Fast and cheap. Good for daily refactoring, code explanation, small edits, summaries, and simple batch tasks."
-kimi-for-coding-highspeed-deep = "The same model at a high thinking level. Good for harder subtasks."
+"kimi-code/k3" = "Default high effort. Good for most implementation, analysis, and multi-turn interaction tasks."
+k3-max = "The same model at max thinking effort. Good for the hardest subtasks."
 ```
 
 Note that `default_effort` stays a model-level default: once a global `[thinking].effort` is set, it wins for the main agent and subagents alike, and the variant's default only applies when no global effort is set. Value and fallback rules follow the [`[models]` entry's `default_effort`](#models).

--- a/docs/zh/configuration/config-files.md
+++ b/docs/zh/configuration/config-files.md
@@ -40,7 +40,7 @@ model = "k3"
 max_context_size = 1048576
 capabilities = [ "thinking", "always_thinking", "image_in", "video_in", "tool_use" ]
 display_name = "K3"
-support_efforts = [ "max" ]
+support_efforts = [ "low", "high", "max" ]
 default_effort = "max"
 
 [models."kimi-code/kimi-for-coding"]
@@ -220,7 +220,7 @@ default_model = "kimi-code/kimi-for-coding-highspeed"
 default_model = "kimi-code/kimi-for-coding-highspeed"
 [secondary_model.models]
 "kimi-code/k3" = "难题选它。擅长复杂推理、算法设计、深度调试、数学和系统性难题。"
-"kimi-code/kimi-for-coding-highspeed" = "又快又便宜。适合日常重构、代码解释、小改动、总结和批量简单任务。"
+"kimi-code/kimi-for-coding-highspeed" = "速度快但单价较高。适合日常重构、代码解释、小改动、总结等看重响应速度的任务。"
 "kimi-code/kimi-for-coding" = "均衡的编码主力。适合大多数功能开发和代码修改任务。"
 ```
 
@@ -236,22 +236,25 @@ force = true
 
 设置 `force` 后不再提供 `model` 参数（与完全未配置时一样），每次派生都绑定 `default_model`；显式传入 `model`（包括 `"primary"`）会报错。`force` 必须搭配 `default_model`，且不能与 `[secondary_model.models]` 表同时使用——表的意义在于提供选择，而 force 取消了选择。
 
-利用自然解析会落到所绑定模型的默认 effort 这一点，可以给池中不同条目配不同的 Thinking 档位：为同一个底层模型再注册一个 `[models]` 条目作为「变体」，用 [`[models."<alias>".overrides]`](#模型覆盖项) 只覆盖 `default_effort`，再把两个别名都放进模型池——main agent 挑选别名时便同时选定了档位：
+利用自然解析会落到所绑定模型的默认 effort 这一点，可以给池中不同条目配不同的 Thinking 档位：为同一个底层模型再注册一个 `[models]` 条目作为「变体」，用 [`[models."<alias>".overrides]`](#模型覆盖项) 只覆盖 `default_effort`，再把两个别名都放进模型池——main agent 挑选别名时便同时选定了档位。有两个前提：底层模型必须声明了 `support_efforts`（`managed:kimi-code` 下目前只有 k3 系列声明了档位）；且变体是独立条目，不会继承被指向条目的字段——`capabilities`、`support_efforts` 等元数据要完整照抄，否则 `default_effort` 不生效（它必须是 `support_efforts` 列表中的值）：
 
 ```toml
-# "kimi-code/kimi-for-coding-highspeed" 由 /login 提供；这里为同一模型注册一个高档位变体
-[models.kimi-for-coding-highspeed-deep]
+# "kimi-code/k3" 由 /login 提供（默认 high 档）；这里为同一模型注册一个 max 档位变体
+[models.k3-max]
 provider = "managed:kimi-code"
-model = "kimi-for-coding-highspeed"
+model = "k3"
+max_context_size = 1048576
+capabilities = [ "thinking", "always_thinking", "image_in", "video_in", "tool_use" ]
+support_efforts = [ "low", "high", "max" ]
 
-[models.kimi-for-coding-highspeed-deep.overrides]
-default_effort = "high"
+[models.k3-max.overrides]
+default_effort = "max"
 
 [secondary_model]
-default_model = "kimi-code/kimi-for-coding-highspeed"
+default_model = "kimi-code/k3"
 [secondary_model.models]
-"kimi-code/kimi-for-coding-highspeed" = "又快又便宜。适合日常重构、代码解释、小改动、总结和批量简单任务。"
-kimi-for-coding-highspeed-deep = "同一模型的高 Thinking 档位。适合较难的子任务。"
+"kimi-code/k3" = "默认 high 档位。适合大多数实现、分析和多轮交互任务。"
+k3-max = "同一模型的 max Thinking 档位。适合最难的子任务。"
 ```
 
 注意 `default_effort` 是模型级默认值：一旦设置了全局 `[thinking].effort`，它对 main agent 和 subagent 都优先生效，变体的默认档位只在全局未设置时起作用。取值与回落规则同 [`[models]` 条目的 `default_effort`](#models)。


### PR DESCRIPTION
## Related Issue

None — the problem is explained in the next section.

## Problem

The `[secondary_model]` docs showed a thinking-effort "variant" example that cannot work as written:

- The variant was based on `kimi-code/kimi-for-coding-highspeed`, which declares no `support_efforts` (under `managed:kimi-code`, only the k3 family declares effort levels), and `default_effort` only takes effect when it is a member of `support_efforts`.
- The variant entry carried only `provider` + `model`; a `[models]` entry does not inherit fields from the provisioned entry it points at, so the variant had no `capabilities` / `support_efforts` at all and resolved thinking to off — the opposite of the documented high thinking level.
- The full-config example listed k3 with `support_efforts = [ "max" ]`, which matches neither what `/login` provisions (`low` / `high` / `max`) nor the `[thinking] effort = "high"` shown in the same file (unlisted values fall back to the model default under Kimi's strict validation).
- The pool hint described `kimi-for-coding-highspeed` as cheap, but it is priced higher.

## What changed

- Rewrote the variant example around `kimi-code/k3`: the variant copies the full model metadata and overrides only `default_effort = "max"`, with both prerequisites (declared `support_efforts`; no field inheritance between entries) stated in the prose.
- Fixed the full-config example's k3 `support_efforts` to `[ "low", "high", "max" ]` so the shown `[thinking] effort = "high"` is a valid value.
- Reworded the highspeed pool hint: no longer described as cheap; positioned for latency-sensitive tasks.

Docs-only; both locales updated in sync.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works. (N/A — docs-only change)
- [x] Ran `gen-changesets` skill, or this PR needs no changeset. (docs-only — no changeset)
- [x] Ran `gen-docs` skill, or this PR needs no doc update. (this PR is the doc update)
