### PR TITLE
test(agent-core-v2): deflake the stdio early-close replay test

### DIFF
--- a/packages/agent-core-v2/test/mcpCore/client-stdio.test.ts
+++ b/packages/agent-core-v2/test/mcpCore/client-stdio.test.ts
@@ -45,6 +45,10 @@ function createClient(
   });
 }
 
+function isTransportSettledError(error: unknown): boolean {
+  return error instanceof Error && error.message.includes('Not connected');
+}
+
 describe('StdioMcpClient', () => {
   it('rejects unsupported executor at construction time', () => {
     expect(
@@ -320,17 +324,19 @@ describe('StdioMcpClient', () => {
       expect(client.stderrSnapshot()).toContain(banner);
 
       const drainDeadline = Date.now() + 5000;
-      let transportConfirmedDead = false;
+      let closeProcessed = false;
       while (Date.now() < drainDeadline) {
         try {
           await client.callTool('echo', { text: 'probe' });
-        } catch {
-          transportConfirmedDead = true;
-          break;
+        } catch (error) {
+          if (isTransportSettledError(error)) {
+            closeProcessed = true;
+            break;
+          }
         }
         await new Promise((r) => setTimeout(r, 10));
       }
-      expect(transportConfirmedDead).toBe(true);
+      expect(closeProcessed).toBe(true);
 
       let received: { stderr?: string } | undefined;
       let syncedOnRegister = false;


### PR DESCRIPTION
## Related Issue

No linked issue — this fixes a flaky test failure observed in CI (see Problem).

## Problem

`StdioMcpClient > buffers an early close and replays it on listener registration` flaked in CI at the assertion that a late-registered `onUnexpectedClose` listener synchronously replays the buffered close reason.

The test waits for the child process exit to be fully processed by polling `callTool` until a request fails, then registers the listener. But a failed probe has two possible causes:

- `Not connected`: the SDK has fully processed the close (its `_onclose()` ran, which synchronously buffers the close reason in the client) and now rejects new requests up front.
- `write EPIPE`: the child's stdin is gone, but the exit event is still queued in the event loop, so the close reason has not been buffered yet.

The loop broke on any error, so under CI scheduling it could stop on `EPIPE` and register the listener before the reason was buffered, failing the synchronous-replay assertion. Locally the exit event almost always lands before the probe, which made the flake CI-only.

## What changed

Test-only fix in `packages/agent-core-v2/test/mcpCore/client-stdio.test.ts`:

- The drain loop now breaks only when the probe fails with `Not connected` — a state the SDK reaches only after the close has been fully processed, so the buffered reason is guaranteed to exist at registration time. Early errors such as `EPIPE` keep polling until the existing deadline.
- The predicate is factored into a small `isTransportSettledError` helper.

No product behavior changed. Verified: the fixed test ran 40 times under full CPU load with 0 failures, and the full `test/mcpCore/` suite passes.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.
