### PR TITLE
feat(vscode): add background task browser

### DIFF
--- a/.changeset/vscode-background-tasks.md
+++ b/.changeset/vscode-background-tasks.md
@@ -1,0 +1,5 @@
+---
+"kimi-code": minor
+---
+
+Add background task monitoring and controls to Kimi Code for VS Code. Use the Tasks badge above the composer to filter tasks, inspect live output, and stop running work.

--- a/apps/vscode/README.md
+++ b/apps/vscode/README.md
@@ -8,6 +8,7 @@ AI coding assistant for VS Code, built for long-context workflows and complex co
 - **Thinking controls**: Toggle reasoning or choose a model-supported thinking effort
 - **Provider-aware models**: Distinguish and select same-named models across configured providers
 - **Native editor integration**: Review AI-proposed changes directly in VS Code's diff viewer
+- **Background tasks**: Track running work, inspect live output, and stop tasks from the tasks panel
 - **MCP support**: Extend capabilities with Model Context Protocol servers
 - **Slash commands**: Quick actions like `/init` to analyze your project and `/compact` to manage context
 

--- a/apps/vscode/shared/bridge.ts
+++ b/apps/vscode/shared/bridge.ts
@@ -61,6 +61,10 @@ export const Methods = {
   ShowLogs: "showLogs",
   ReloadWebview: "reloadWebview",
   RespondQuestion: "respondQuestion",
+
+  ListBackgroundTasks: "listBackgroundTasks",
+  GetBackgroundTaskOutput: "getBackgroundTaskOutput",
+  StopBackgroundTask: "stopBackgroundTask",
 } as const;
 
 export type RpcMethod = (typeof Methods)[keyof typeof Methods];
@@ -96,6 +100,7 @@ export const Events = {
   FileChangesUpdated: "fileChangesUpdated",
   RollbackInput: "rollbackInput",
   LoginUrl: "loginUrl",
+  BackgroundTasksChanged: "backgroundTasksChanged",
 } as const;
 
 const rpcMethods = new Set<string>(Object.values(Methods));
@@ -148,6 +153,7 @@ function validateParams(method: RpcMethod, params: unknown): boolean {
     case Methods.ClearTrackedFiles:
     case Methods.ShowLogs:
     case Methods.ReloadWebview:
+    case Methods.ListBackgroundTasks:
       return params === undefined;
 
     case Methods.AddInputHistory:
@@ -180,6 +186,13 @@ function validateParams(method: RpcMethod, params: unknown): boolean {
         && isNonEmptyString(params["rpcRequestId"])
         && isNonEmptyString(params["questionRequestId"])
         && isStringRecord(params["answers"]);
+    case Methods.GetBackgroundTaskOutput:
+      return isPlainObject(params)
+        && isNonEmptyString(params["taskId"])
+        && (params["tail"] === undefined
+          || (Number.isInteger(params["tail"]) && (params["tail"] as number) > 0));
+    case Methods.StopBackgroundTask:
+      return isPlainObject(params) && isNonEmptyString(params["taskId"]);
     case Methods.SetPlanMode:
       return hasBoolean(params, "enabled");
     case Methods.SteerChat:

--- a/apps/vscode/shared/legacy-sdk.ts
+++ b/apps/vscode/shared/legacy-sdk.ts
@@ -128,6 +128,57 @@ export interface SubagentEvent {
   event: LegacyWireEvent;
 }
 
+export type BackgroundTaskStatus =
+  | 'running'
+  | 'completed'
+  | 'failed'
+  | 'timed_out'
+  | 'killed'
+  | 'lost';
+
+export interface BackgroundTaskInfoBase {
+  taskId: string;
+  description: string;
+  status: BackgroundTaskStatus;
+  /** `false` means a tool call is still waiting on this task in the foreground. */
+  detached?: boolean;
+  startedAt: number;
+  endedAt: number | null;
+  stopReason?: string;
+  terminalNotificationSuppressed?: boolean;
+  timeoutMs?: number;
+}
+
+export interface ProcessBackgroundTaskInfo extends BackgroundTaskInfoBase {
+  kind: 'process';
+  command: string;
+  pid: number;
+  exitCode: number | null;
+}
+
+export interface AgentBackgroundTaskInfo extends BackgroundTaskInfoBase {
+  kind: 'agent';
+  agentId?: string;
+  subagentType?: string;
+  model?: string;
+  thinkingEffort?: string;
+}
+
+export interface QuestionBackgroundTaskInfo extends BackgroundTaskInfoBase {
+  kind: 'question';
+  questionCount: number;
+  toolCallId?: string;
+}
+
+export type BackgroundTaskInfo =
+  | ProcessBackgroundTaskInfo
+  | AgentBackgroundTaskInfo
+  | QuestionBackgroundTaskInfo;
+
+export function isBackgroundTaskTerminal(status: BackgroundTaskStatus): boolean {
+  return status !== 'running';
+}
+
 export type LegacyWireEvent =
   | { type: 'TurnBegin'; payload: TurnBegin & { forkable?: boolean } }
   | { type: 'TurnEnd'; payload: Record<string, never> }
@@ -142,6 +193,7 @@ export type LegacyWireEvent =
   | { type: 'ToolResult'; payload: ToolResult }
   | { type: 'SteerInput'; payload: { user_input: string | ContentPart[] } }
   | { type: 'SubagentEvent'; payload: SubagentEvent }
+  | { type: 'BackgroundTaskStatus'; payload: { info: BackgroundTaskInfo } }
   | { type: string; payload: unknown };
 
 export type StreamEvent =

--- a/apps/vscode/shared/types.ts
+++ b/apps/vscode/shared/types.ts
@@ -1,4 +1,4 @@
-import type { RunResult, StreamEvent } from "./legacy-sdk";
+import type { BackgroundTaskInfo, RunResult, StreamEvent } from "./legacy-sdk";
 
 export interface SessionConfig {
   model: string;
@@ -24,6 +24,11 @@ export interface FileChange {
   status: "Modified" | "Added" | "Deleted";
   additions: number;
   deletions: number;
+}
+
+export interface BackgroundTasksChangedPayload {
+  sessionId: string | null;
+  tasks: BackgroundTaskInfo[];
 }
 
 export interface ExtensionConfig {

--- a/apps/vscode/src/handlers/index.ts
+++ b/apps/vscode/src/handlers/index.ts
@@ -5,6 +5,7 @@ import { chatHandlers } from "./chat.handler";
 import { fileHandlers } from "./file.handler";
 import { workspaceHandlers } from "./workspace.handler";
 import { authHandlers } from "./auth.handler";
+import { tasksHandlers } from "./tasks.handler";
 import type { Handler } from "./types";
 
 export type { Handler, HandlerContext, BroadcastFn, ReloadWebviewFn, ShowLogsFn } from "./types";
@@ -17,4 +18,5 @@ export const handlers: Record<string, Handler<any, any>> = {
   ...chatHandlers,
   ...fileHandlers,
   ...authHandlers,
+  ...tasksHandlers,
 };

--- a/apps/vscode/src/handlers/session.handler.ts
+++ b/apps/vscode/src/handlers/session.handler.ts
@@ -149,17 +149,15 @@ export const sessionHandlers: Record<string, Handler<any, any>> = {
     // transcript (isVisibleUserMessage), so restore their terminal status as
     // status cards — the same shape live task events produce.
     try {
-      const tasks = await runtime.session.listBackgroundTasks({ activeOnly: false });
+      const tasks = await runtime.announceBackgroundTasks(ctx.webviewId);
       for (const info of tasks) {
         if (!isBackgroundTaskTerminal(info.status)) continue;
         history.push({ type: "BackgroundTaskStatus", payload: { info }, _sessionId: runtime.id });
       }
     } catch (error) {
       ctx.logError("Unable to restore background task statuses", error);
+      ctx.broadcast(Events.BackgroundTasksChanged, [], ctx.webviewId);
     }
-    await runtime.announceBackgroundTasks(ctx.webviewId).catch((error: unknown) => {
-      ctx.logError("Unable to announce background tasks", error);
-    });
 
     ctx.fileManager.clearTracked(ctx.webviewId);
     const baseline = baselineSession(runtime.summary ?? {

--- a/apps/vscode/src/handlers/session.handler.ts
+++ b/apps/vscode/src/handlers/session.handler.ts
@@ -156,7 +156,11 @@ export const sessionHandlers: Record<string, Handler<any, any>> = {
       }
     } catch (error) {
       ctx.logError("Unable to restore background task statuses", error);
-      ctx.broadcast(Events.BackgroundTasksChanged, [], ctx.webviewId);
+      ctx.broadcast(
+        Events.BackgroundTasksChanged,
+        { sessionId: runtime.id, tasks: [] },
+        ctx.webviewId,
+      );
     }
 
     ctx.fileManager.clearTracked(ctx.webviewId);

--- a/apps/vscode/src/handlers/session.handler.ts
+++ b/apps/vscode/src/handlers/session.handler.ts
@@ -3,7 +3,7 @@ import * as vscode from "vscode";
 import type { SessionSummary } from "@moonshot-ai/kimi-code-sdk";
 
 import { Events, Methods } from "../../shared/bridge";
-import type { SessionInfo } from "../../shared/legacy-sdk";
+import { isBackgroundTaskTerminal, type SessionInfo } from "../../shared/legacy-sdk";
 import type { BaselineSession } from "../managers/baseline.manager";
 import { replaySessionToWebviewEvents } from "../runtime/replay-adapter";
 import { areSameFsPath, isFsPathInsideOrEqual } from "../utils/fs-path";
@@ -144,6 +144,22 @@ export const sessionHandlers: Record<string, Handler<any, any>> = {
       await ctx.closeSession();
       throw error;
     }
+
+    // Background completion notifications are hidden from the replayed
+    // transcript (isVisibleUserMessage), so restore their terminal status as
+    // status cards — the same shape live task events produce.
+    try {
+      const tasks = await runtime.session.listBackgroundTasks({ activeOnly: false });
+      for (const info of tasks) {
+        if (!isBackgroundTaskTerminal(info.status)) continue;
+        history.push({ type: "BackgroundTaskStatus", payload: { info }, _sessionId: runtime.id });
+      }
+    } catch (error) {
+      ctx.logError("Unable to restore background task statuses", error);
+    }
+    await runtime.announceBackgroundTasks(ctx.webviewId).catch((error: unknown) => {
+      ctx.logError("Unable to announce background tasks", error);
+    });
 
     ctx.fileManager.clearTracked(ctx.webviewId);
     const baseline = baselineSession(runtime.summary ?? {

--- a/apps/vscode/src/handlers/tasks.handler.ts
+++ b/apps/vscode/src/handlers/tasks.handler.ts
@@ -14,7 +14,7 @@ export const tasksHandlers: Record<string, Handler<any, any>> = {
   [Methods.ListBackgroundTasks]: async (_, ctx): Promise<BackgroundTaskInfo[]> => {
     const runtime = ctx.getSession();
     if (runtime === undefined) return [];
-    const tasks = await runtime.session.listBackgroundTasks({ activeOnly: false });
+    const tasks = await runtime.listBackgroundTasks();
     return [...tasks];
   },
 
@@ -24,19 +24,14 @@ export const tasksHandlers: Record<string, Handler<any, any>> = {
   ): Promise<{ output: string }> => {
     const runtime = ctx.getSession();
     if (runtime === undefined) return { output: "" };
-    const output = await runtime.session.getBackgroundTaskOutput(
-      params.taskId,
-      { tail: params.tail },
-    );
+    const output = await runtime.getBackgroundTaskOutput(params.taskId, params.tail);
     return { output };
   },
 
   [Methods.StopBackgroundTask]: async (params: TaskIdParams, ctx): Promise<{ ok: boolean }> => {
     const runtime = ctx.getSession();
     if (runtime === undefined) return { ok: false };
-    await runtime.session.stopBackgroundTask(params.taskId, {
-      reason: "Stopped from VS Code tasks panel",
-    });
+    await runtime.stopBackgroundTask(params.taskId);
     // The terminated event refreshes every view; nudge the requesting view so
     // the panel reflects the stop without waiting for the engine round-trip.
     await runtime.announceBackgroundTasks(ctx.webviewId).catch((error: unknown) => {

--- a/apps/vscode/src/handlers/tasks.handler.ts
+++ b/apps/vscode/src/handlers/tasks.handler.ts
@@ -1,0 +1,47 @@
+import { Methods } from "../../shared/bridge";
+import type { BackgroundTaskInfo } from "../../shared/legacy-sdk";
+import type { Handler } from "./types";
+
+interface TaskIdParams {
+  taskId: string;
+}
+
+interface TaskOutputParams extends TaskIdParams {
+  tail?: number;
+}
+
+export const tasksHandlers: Record<string, Handler<any, any>> = {
+  [Methods.ListBackgroundTasks]: async (_, ctx): Promise<BackgroundTaskInfo[]> => {
+    const runtime = ctx.getSession();
+    if (runtime === undefined) return [];
+    const tasks = await runtime.session.listBackgroundTasks({ activeOnly: false });
+    return [...tasks];
+  },
+
+  [Methods.GetBackgroundTaskOutput]: async (
+    params: TaskOutputParams,
+    ctx,
+  ): Promise<{ output: string }> => {
+    const runtime = ctx.getSession();
+    if (runtime === undefined) return { output: "" };
+    const output = await runtime.session.getBackgroundTaskOutput(
+      params.taskId,
+      { tail: params.tail },
+    );
+    return { output };
+  },
+
+  [Methods.StopBackgroundTask]: async (params: TaskIdParams, ctx): Promise<{ ok: boolean }> => {
+    const runtime = ctx.getSession();
+    if (runtime === undefined) return { ok: false };
+    await runtime.session.stopBackgroundTask(params.taskId, {
+      reason: "Stopped from VS Code tasks panel",
+    });
+    // The terminated event refreshes every view; nudge the requesting view so
+    // the panel reflects the stop without waiting for the engine round-trip.
+    await runtime.announceBackgroundTasks(ctx.webviewId).catch((error: unknown) => {
+      ctx.logError("Failed to refresh background tasks after a stop", error);
+    });
+    return { ok: true };
+  },
+};

--- a/apps/vscode/src/handlers/tasks.handler.ts
+++ b/apps/vscode/src/handlers/tasks.handler.ts
@@ -1,5 +1,5 @@
 import { Methods } from "../../shared/bridge";
-import type { BackgroundTaskInfo } from "../../shared/legacy-sdk";
+import type { BackgroundTasksChangedPayload } from "../../shared/types";
 import type { Handler } from "./types";
 
 interface TaskIdParams {
@@ -11,11 +11,11 @@ interface TaskOutputParams extends TaskIdParams {
 }
 
 export const tasksHandlers: Record<string, Handler<any, any>> = {
-  [Methods.ListBackgroundTasks]: async (_, ctx): Promise<BackgroundTaskInfo[]> => {
+  [Methods.ListBackgroundTasks]: async (_, ctx): Promise<BackgroundTasksChangedPayload> => {
     const runtime = ctx.getSession();
-    if (runtime === undefined) return [];
+    if (runtime === undefined) return { sessionId: null, tasks: [] };
     const tasks = await runtime.listBackgroundTasks();
-    return [...tasks];
+    return { sessionId: runtime.id, tasks: [...tasks] };
   },
 
   [Methods.GetBackgroundTaskOutput]: async (

--- a/apps/vscode/src/runtime/kimi-runtime.ts
+++ b/apps/vscode/src/runtime/kimi-runtime.ts
@@ -242,6 +242,7 @@ export class KimiRuntime {
   private wrapSession(session: Session, legacyApproval: LegacyApprovalFlags): SessionRuntime {
     const runtime = new SessionRuntime({
       session,
+      withInteractiveAgent: (agentId, fn) => this.harness.withInteractiveAgent(agentId, fn),
       legacyApproval,
       broadcast: this.broadcast,
       captureBaseline: this.captureBaseline,

--- a/apps/vscode/src/runtime/kimi-runtime.ts
+++ b/apps/vscode/src/runtime/kimi-runtime.ts
@@ -140,6 +140,9 @@ export class KimiRuntime {
     runtime.subscribe(options.webviewId);
     this.sessionByView.set(options.webviewId, runtime.id);
     await runtime.announceStatus(options.webviewId);
+    await runtime.announceBackgroundTasks(options.webviewId).catch((error: unknown) => {
+      this.log("Failed to announce background tasks", error);
+    });
     return runtime;
   }
 
@@ -152,6 +155,9 @@ export class KimiRuntime {
     if (existing !== undefined && this.sessionByView.get(webviewId) === session.id) {
       existing.subscribe(webviewId);
       await existing.announceStatus(webviewId);
+      await existing.announceBackgroundTasks(webviewId).catch((error: unknown) => {
+        this.log("Failed to announce background tasks", error);
+      });
       return existing;
     }
     await this.detachView(webviewId);
@@ -181,6 +187,9 @@ export class KimiRuntime {
     runtime.subscribe(webviewId);
     this.sessionByView.set(webviewId, runtime.id);
     await runtime.announceStatus(webviewId);
+    await runtime.announceBackgroundTasks(webviewId).catch((error: unknown) => {
+      this.log("Failed to announce background tasks", error);
+    });
     return runtime;
   }
 

--- a/apps/vscode/src/runtime/session-runtime.ts
+++ b/apps/vscode/src/runtime/session-runtime.ts
@@ -1,5 +1,6 @@
 import {
   isKimiError,
+  type BackgroundTaskInfo as SdkBackgroundTaskInfo,
   type ContentPart as SdkContentPart,
   type Event,
   type PromptInput,
@@ -7,7 +8,11 @@ import {
   type SessionSummary,
 } from "@moonshot-ai/kimi-code-sdk";
 
-import type { ContentPart as LegacyContentPart, ApprovalResponse } from "../../shared/legacy-sdk";
+import type {
+  BackgroundTaskInfo,
+  ContentPart as LegacyContentPart,
+  ApprovalResponse,
+} from "../../shared/legacy-sdk";
 import { Events } from "../../shared/bridge";
 import { getUserMessage } from "../../shared/errors";
 import type { ErrorPhase, UIStreamEvent } from "../../shared/types";
@@ -89,6 +94,9 @@ export class SessionRuntime {
   private suppressedError: SuppressedError | undefined;
   private legacyApproval: LegacyApprovalFlags;
   private closed = false;
+  private readonly backgroundTasks = new Map<string, BackgroundTaskInfo>();
+  /** Dedupe keys for transcript status cards: `started:<taskId>` and `<taskId>:<status>`. */
+  private readonly backgroundTranscripted = new Set<string>();
 
   constructor(options: SessionRuntimeOptions) {
     this.session = options.session;
@@ -169,6 +177,20 @@ export class SessionRuntime {
 
   unsubscribeView(webviewId: string): void {
     this.webviewIds.delete(webviewId);
+  }
+
+  /**
+   * Push the session's current background tasks to a view. Called whenever a
+   * view opens or re-enters a session so the tasks badge matches engine truth
+   * even after a webview reload.
+   */
+  async announceBackgroundTasks(webviewId: string): Promise<void> {
+    this.ensureOpen();
+    const tasks = await this.session.listBackgroundTasks({ activeOnly: false });
+    if (this.closed || !this.webviewIds.has(webviewId)) return;
+    this.backgroundTasks.clear();
+    for (const task of tasks) this.backgroundTasks.set(task.taskId, task);
+    this.broadcast(Events.BackgroundTasksChanged, [...this.backgroundTasks.values()], webviewId);
   }
 
   async prompt(input: string | LegacyContentPart[]): Promise<PromptResult> {
@@ -455,6 +477,10 @@ export class SessionRuntime {
       this.captureFileBaseline(event);
     }
 
+    if (event.type === "background.task.started" || event.type === "background.task.terminated") {
+      this.handleBackgroundTaskEvent(event.info);
+    }
+
     if (event.type === "turn.step.retrying") {
       this.log(
         `Provider retry ${event.nextAttempt}/${event.maxAttempts} in ${event.delayMs}ms`,
@@ -582,6 +608,30 @@ export class SessionRuntime {
     for (const webviewId of this.webviewIds) {
       this.broadcast(Events.StreamEvent, event, webviewId);
     }
+  }
+
+  /**
+   * Track background tasks for the tasks badge and mirror lifecycle transitions
+   * into the transcript as status cards, matching the CLI's `/tasks` behavior.
+   */
+  private handleBackgroundTaskEvent(info: SdkBackgroundTaskInfo): void {
+    const wireInfo: BackgroundTaskInfo = info;
+    this.backgroundTasks.set(wireInfo.taskId, wireInfo);
+    const tasks = [...this.backgroundTasks.values()];
+    for (const webviewId of this.webviewIds) {
+      this.broadcast(Events.BackgroundTasksChanged, tasks, webviewId);
+    }
+
+    const key = wireInfo.status === "running"
+      ? `started:${wireInfo.taskId}`
+      : `${wireInfo.taskId}:${wireInfo.status}`;
+    if (this.backgroundTranscripted.has(key)) return;
+    this.backgroundTranscripted.add(key);
+    this.emitStreamEvent({
+      type: "BackgroundTaskStatus",
+      payload: { info: wireInfo },
+      _sessionId: this.id,
+    });
   }
 
   private settlePrompt(result: PromptResult): void {

--- a/apps/vscode/src/runtime/session-runtime.ts
+++ b/apps/vscode/src/runtime/session-runtime.ts
@@ -15,7 +15,11 @@ import type {
 } from "../../shared/legacy-sdk";
 import { Events } from "../../shared/bridge";
 import { getUserMessage } from "../../shared/errors";
-import type { ErrorPhase, UIStreamEvent } from "../../shared/types";
+import type {
+  BackgroundTasksChangedPayload,
+  ErrorPhase,
+  UIStreamEvent,
+} from "../../shared/types";
 import {
   adaptSdkEvent,
   createEventAdapterState,
@@ -192,7 +196,8 @@ export class SessionRuntime {
     this.ensureOpen();
     const tasks = await this.listBackgroundTasks();
     if (!this.closed && this.webviewIds.has(webviewId)) {
-      this.broadcast(Events.BackgroundTasksChanged, tasks, webviewId);
+      const payload: BackgroundTasksChangedPayload = { sessionId: this.id, tasks: [...tasks] };
+      this.broadcast(Events.BackgroundTasksChanged, payload, webviewId);
     }
     return tasks;
   }
@@ -676,8 +681,9 @@ export class SessionRuntime {
     this.backgroundTasks.set(wireInfo.taskId, wireInfo);
     this.backgroundTaskOwners.set(wireInfo.taskId, agentId);
     const tasks = [...this.backgroundTasks.values()];
+    const payload: BackgroundTasksChangedPayload = { sessionId: this.id, tasks };
     for (const webviewId of this.webviewIds) {
-      this.broadcast(Events.BackgroundTasksChanged, tasks, webviewId);
+      this.broadcast(Events.BackgroundTasksChanged, payload, webviewId);
     }
 
     const key = wireInfo.status === "running"

--- a/apps/vscode/src/runtime/session-runtime.ts
+++ b/apps/vscode/src/runtime/session-runtime.ts
@@ -33,6 +33,7 @@ export type RuntimeBroadcast = (event: string, data: unknown, webviewId?: string
 
 export interface SessionRuntimeOptions {
   readonly session: Session;
+  readonly withInteractiveAgent: <T>(agentId: string, fn: () => T) => T;
   readonly legacyApproval: LegacyApprovalFlags;
   readonly broadcast: RuntimeBroadcast;
   readonly captureBaseline: (
@@ -76,6 +77,7 @@ export class SessionRuntime {
   readonly session: Session;
 
   private readonly broadcast: RuntimeBroadcast;
+  private readonly withInteractiveAgent: SessionRuntimeOptions["withInteractiveAgent"];
   private readonly captureBaseline: SessionRuntimeOptions["captureBaseline"];
   private readonly log: SessionRuntimeOptions["log"];
   private readonly webviewIds = new Set<string>();
@@ -95,11 +97,13 @@ export class SessionRuntime {
   private legacyApproval: LegacyApprovalFlags;
   private closed = false;
   private readonly backgroundTasks = new Map<string, BackgroundTaskInfo>();
+  private readonly backgroundTaskOwners = new Map<string, string>();
   /** Dedupe keys for transcript status cards: `started:<taskId>` and `<taskId>:<status>`. */
   private readonly backgroundTranscripted = new Set<string>();
 
   constructor(options: SessionRuntimeOptions) {
     this.session = options.session;
+    this.withInteractiveAgent = options.withInteractiveAgent;
     this.broadcast = options.broadcast;
     this.captureBaseline = options.captureBaseline;
     this.log = options.log;
@@ -184,13 +188,66 @@ export class SessionRuntime {
    * view opens or re-enters a session so the tasks badge matches engine truth
    * even after a webview reload.
    */
-  async announceBackgroundTasks(webviewId: string): Promise<void> {
+  async announceBackgroundTasks(webviewId: string): Promise<readonly BackgroundTaskInfo[]> {
     this.ensureOpen();
-    const tasks = await this.session.listBackgroundTasks({ activeOnly: false });
-    if (this.closed || !this.webviewIds.has(webviewId)) return;
+    const tasks = await this.listBackgroundTasks();
+    if (!this.closed && this.webviewIds.has(webviewId)) {
+      this.broadcast(Events.BackgroundTasksChanged, tasks, webviewId);
+    }
+    return tasks;
+  }
+
+  async listBackgroundTasks(): Promise<readonly BackgroundTaskInfo[]> {
+    this.ensureOpen();
+    const nextTasks = new Map<string, BackgroundTaskInfo>();
+    const nextOwners = new Map<string, string>();
+
+    for (const agentId of this.backgroundTaskAgentIds()) {
+      try {
+        const tasks = await this.withInteractiveAgent(agentId, () =>
+          this.session.listBackgroundTasks({ activeOnly: false }),
+        );
+        for (const task of tasks) {
+          nextTasks.set(task.taskId, task);
+          nextOwners.set(task.taskId, agentId);
+        }
+      } catch (error) {
+        if (agentId === "main") throw error;
+        this.log(`Unable to list background tasks for agent ${agentId}`, error);
+        for (const [taskId, owner] of this.backgroundTaskOwners) {
+          if (owner !== agentId) continue;
+          const task = this.backgroundTasks.get(taskId);
+          if (task !== undefined) {
+            nextTasks.set(taskId, task);
+            nextOwners.set(taskId, owner);
+          }
+        }
+      }
+    }
+
     this.backgroundTasks.clear();
-    for (const task of tasks) this.backgroundTasks.set(task.taskId, task);
-    this.broadcast(Events.BackgroundTasksChanged, [...this.backgroundTasks.values()], webviewId);
+    this.backgroundTaskOwners.clear();
+    for (const [taskId, task] of nextTasks) this.backgroundTasks.set(taskId, task);
+    for (const [taskId, owner] of nextOwners) this.backgroundTaskOwners.set(taskId, owner);
+    return [...this.backgroundTasks.values()];
+  }
+
+  async getBackgroundTaskOutput(taskId: string, tail?: number): Promise<string> {
+    this.ensureOpen();
+    const agentId = this.backgroundTaskOwners.get(taskId) ?? "main";
+    return this.withInteractiveAgent(agentId, () =>
+      this.session.getBackgroundTaskOutput(taskId, { tail }),
+    );
+  }
+
+  async stopBackgroundTask(taskId: string): Promise<void> {
+    this.ensureOpen();
+    const agentId = this.backgroundTaskOwners.get(taskId) ?? "main";
+    await this.withInteractiveAgent(agentId, () =>
+      this.session.stopBackgroundTask(taskId, {
+        reason: "Stopped from VS Code tasks panel",
+      }),
+    );
   }
 
   async prompt(input: string | LegacyContentPart[]): Promise<PromptResult> {
@@ -478,7 +535,7 @@ export class SessionRuntime {
     }
 
     if (event.type === "background.task.started" || event.type === "background.task.terminated") {
-      this.handleBackgroundTaskEvent(event.info);
+      this.handleBackgroundTaskEvent(event.info, event.agentId);
     }
 
     if (event.type === "turn.step.retrying") {
@@ -614,9 +671,10 @@ export class SessionRuntime {
    * Track background tasks for the tasks badge and mirror lifecycle transitions
    * into the transcript as status cards, matching the CLI's `/tasks` behavior.
    */
-  private handleBackgroundTaskEvent(info: SdkBackgroundTaskInfo): void {
+  private handleBackgroundTaskEvent(info: SdkBackgroundTaskInfo, agentId: string): void {
     const wireInfo: BackgroundTaskInfo = info;
     this.backgroundTasks.set(wireInfo.taskId, wireInfo);
+    this.backgroundTaskOwners.set(wireInfo.taskId, agentId);
     const tasks = [...this.backgroundTasks.values()];
     for (const webviewId of this.webviewIds) {
       this.broadcast(Events.BackgroundTasksChanged, tasks, webviewId);
@@ -632,6 +690,14 @@ export class SessionRuntime {
       payload: { info: wireInfo },
       _sessionId: this.id,
     });
+  }
+
+  private backgroundTaskAgentIds(): readonly string[] {
+    const agentIds = new Set<string>(["main"]);
+    const resumeState = this.session.getResumeState();
+    for (const agentId of Object.keys(resumeState?.agents ?? {})) agentIds.add(agentId);
+    for (const agentId of this.backgroundTaskOwners.values()) agentIds.add(agentId);
+    return [...agentIds];
   }
 
   private settlePrompt(result: PromptResult): void {

--- a/apps/vscode/test/background-tasks-ui.test.ts
+++ b/apps/vscode/test/background-tasks-ui.test.ts
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 /**
  * Scenario: background task state in the VS Code Webview across session restoration and output refreshes.
- * Responsibilities: restored task announcements survive history replay, and a successful output refresh replaces a transient error.
+ * Responsibilities: task state stays session-scoped and monotonic while sessions restore and output refreshes recover.
  * Wiring: the real Zustand stores and TasksModal are used; only the VS Code bridge process boundary is mocked.
  * Run: pnpm --filter kimi-code exec vitest run --config vitest.config.ts test/background-tasks-ui.test.ts
  */
@@ -11,6 +11,7 @@ import { createRoot, type Root } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { BackgroundTaskInfo } from "../shared/legacy-sdk";
+import type { BackgroundTasksChangedPayload, UIStreamEvent } from "../shared/types";
 import { TasksModal } from "../webview-ui/src/components/TasksModal";
 import { useChatStore } from "../webview-ui/src/stores/chat.store";
 import { useTasksStore } from "../webview-ui/src/stores/tasks.store";
@@ -19,6 +20,7 @@ const { bridgeMock } = vi.hoisted(() => ({
   bridgeMock: {
     getBackgroundTaskOutput: vi.fn(),
     listBackgroundTasks: vi.fn(),
+    loadSessionHistory: vi.fn(),
     stopBackgroundTask: vi.fn(),
   },
 }));
@@ -40,12 +42,15 @@ const runningTask: BackgroundTaskInfo = {
 let root: Root | undefined;
 
 beforeEach(() => {
-  globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+  (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT: boolean })
+    .IS_REACT_ACT_ENVIRONMENT = true;
   bridgeMock.getBackgroundTaskOutput.mockReset();
   bridgeMock.listBackgroundTasks.mockReset();
+  bridgeMock.loadSessionHistory.mockReset();
   bridgeMock.stopBackgroundTask.mockReset();
-  useChatStore.setState({ isStreaming: false });
-  useTasksStore.setState({ tasks: [], browserOpen: false });
+  useChatStore.setState({ sessionId: null, messages: [], isStreaming: false });
+  useTasksStore.getState().setSession(null);
+  useTasksStore.getState().setBrowserOpen(false);
 });
 
 afterEach(async () => {
@@ -54,24 +59,127 @@ afterEach(async () => {
     root = undefined;
   }
   document.body.replaceChildren();
+  (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT: boolean })
+    .IS_REACT_ACT_ENVIRONMENT = false;
   vi.restoreAllMocks();
 });
 
 describe("background task Webview state (restores task lists and output)", () => {
   it("preserves announced tasks when session history finishes loading", async () => {
-    useTasksStore.getState().setTasks([runningTask]);
+    useTasksStore.getState().setSession("session-2");
+    useTasksStore.getState().applySnapshot({ sessionId: "session-2", tasks: [runningTask] });
 
     await useChatStore.getState().loadSession("session-2", []);
 
     expect(useTasksStore.getState().tasks).toEqual([runningTask]);
   });
 
+  it("ignores task notifications when they belong to another session", () => {
+    const currentTask = { ...runningTask, taskId: "bash-current" };
+    useTasksStore.getState().setSession("session-current");
+    useTasksStore.getState().applySnapshot({
+      sessionId: "session-current",
+      tasks: [currentTask],
+    });
+
+    useTasksStore.getState().applySnapshot({
+      sessionId: "session-other",
+      tasks: [runningTask],
+    });
+
+    expect(useTasksStore.getState().tasks).toEqual([currentTask]);
+  });
+
+  it("discards a refresh response when a newer lifecycle snapshot arrives", async () => {
+    let resolveRefresh!: (snapshot: BackgroundTasksChangedPayload) => void;
+    bridgeMock.listBackgroundTasks.mockReturnValue(
+      new Promise<BackgroundTasksChangedPayload>((resolve) => {
+        resolveRefresh = resolve;
+      }),
+    );
+    useTasksStore.getState().setSession("session-1");
+    useTasksStore.getState().applySnapshot({ sessionId: "session-1", tasks: [runningTask] });
+    const refresh = useTasksStore.getState().refreshTasks();
+    const completedTask: BackgroundTaskInfo = {
+      ...runningTask,
+      status: "completed",
+      exitCode: 0,
+      endedAt: 2000,
+    };
+    useTasksStore.getState().applySnapshot({
+      sessionId: "session-1",
+      tasks: [completedTask],
+    });
+
+    resolveRefresh({ sessionId: "session-1", tasks: [runningTask] });
+    await refresh;
+
+    expect(useTasksStore.getState().tasks).toEqual([completedTask]);
+  });
+
+  it("commits only the latest session when history responses complete later", async () => {
+    let resolveFirst!: (events: UIStreamEvent[]) => void;
+    let activeHostSession: string | null = null;
+    const firstHistory = new Promise<UIStreamEvent[]>((resolve) => {
+      resolveFirst = resolve;
+    });
+    bridgeMock.loadSessionHistory
+      .mockImplementationOnce((sessionId: string) => {
+        return firstHistory.then((events) => {
+          activeHostSession = sessionId;
+          return events;
+        });
+      })
+      .mockImplementationOnce(async (sessionId: string) => {
+        activeHostSession = sessionId;
+        return [];
+      });
+
+    const first = useChatStore.getState().restoreSession("session-1");
+    await Promise.resolve();
+    const second = useChatStore.getState().restoreSession("session-2");
+    resolveFirst([]);
+
+    await expect(first).resolves.toBe(false);
+    await expect(second).resolves.toBe(true);
+    expect(useChatStore.getState().sessionId).toBe("session-2");
+    expect(useTasksStore.getState().sessionId).toBe("session-2");
+    expect(activeHostSession).toBe("session-2");
+  });
+
+  it("restores the committed task session when history loading fails", async () => {
+    const committedTask = { ...runningTask, taskId: "bash-committed" };
+    await useChatStore.getState().loadSession("session-committed", []);
+    useTasksStore.getState().applySnapshot({
+      sessionId: "session-committed",
+      tasks: [committedTask],
+    });
+    bridgeMock.loadSessionHistory.mockRejectedValue(new Error("history unavailable"));
+    bridgeMock.listBackgroundTasks.mockResolvedValue({
+      sessionId: "session-committed",
+      tasks: [committedTask],
+    });
+
+    await expect(
+      useChatStore.getState().restoreSession("session-unavailable"),
+    ).rejects.toThrow("history unavailable");
+
+    expect(useChatStore.getState().sessionId).toBe("session-committed");
+    expect(useTasksStore.getState().sessionId).toBe("session-committed");
+    expect(useTasksStore.getState().tasks).toEqual([committedTask]);
+  });
+
   it("shows recovered output when a successful refresh follows a transient error", async () => {
-    bridgeMock.listBackgroundTasks.mockResolvedValue([runningTask]);
+    bridgeMock.listBackgroundTasks.mockResolvedValue({
+      sessionId: "session-1",
+      tasks: [runningTask],
+    });
     bridgeMock.getBackgroundTaskOutput
       .mockRejectedValueOnce(new Error("temporary output failure"))
       .mockResolvedValueOnce({ output: "server ready" });
-    useTasksStore.setState({ tasks: [runningTask], browserOpen: true });
+    useTasksStore.getState().setSession("session-1");
+    useTasksStore.getState().applySnapshot({ sessionId: "session-1", tasks: [runningTask] });
+    useTasksStore.setState({ browserOpen: true });
     const container = document.createElement("div");
     document.body.append(container);
     root = createRoot(container);
@@ -83,9 +191,10 @@ describe("background task Webview state (restores task lists and output)", () =>
     expect(container.textContent).toContain("temporary output failure");
 
     await act(async () => {
-      useTasksStore.getState().setTasks([
-        { ...runningTask, status: "completed", exitCode: 0, endedAt: 2000 },
-      ]);
+      useTasksStore.getState().applySnapshot({
+        sessionId: "session-1",
+        tasks: [{ ...runningTask, status: "completed", exitCode: 0, endedAt: 2000 }],
+      });
     });
 
     expect(container.textContent).toContain("server ready");

--- a/apps/vscode/test/background-tasks-ui.test.ts
+++ b/apps/vscode/test/background-tasks-ui.test.ts
@@ -1,0 +1,94 @@
+// @vitest-environment jsdom
+/**
+ * Scenario: background task state in the VS Code Webview across session restoration and output refreshes.
+ * Responsibilities: restored task announcements survive history replay, and a successful output refresh replaces a transient error.
+ * Wiring: the real Zustand stores and TasksModal are used; only the VS Code bridge process boundary is mocked.
+ * Run: pnpm --filter kimi-code exec vitest run --config vitest.config.ts test/background-tasks-ui.test.ts
+ */
+
+import { act, createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { BackgroundTaskInfo } from "../shared/legacy-sdk";
+import { TasksModal } from "../webview-ui/src/components/TasksModal";
+import { useChatStore } from "../webview-ui/src/stores/chat.store";
+import { useTasksStore } from "../webview-ui/src/stores/tasks.store";
+
+const { bridgeMock } = vi.hoisted(() => ({
+  bridgeMock: {
+    getBackgroundTaskOutput: vi.fn(),
+    listBackgroundTasks: vi.fn(),
+    stopBackgroundTask: vi.fn(),
+  },
+}));
+
+vi.mock("@/services", () => ({ bridge: bridgeMock }));
+
+const runningTask: BackgroundTaskInfo = {
+  taskId: "bash-1",
+  kind: "process",
+  description: "dev server",
+  status: "running",
+  command: "pnpm dev",
+  pid: 1234,
+  exitCode: null,
+  startedAt: 1000,
+  endedAt: null,
+};
+
+let root: Root | undefined;
+
+beforeEach(() => {
+  globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+  bridgeMock.getBackgroundTaskOutput.mockReset();
+  bridgeMock.listBackgroundTasks.mockReset();
+  bridgeMock.stopBackgroundTask.mockReset();
+  useChatStore.setState({ isStreaming: false });
+  useTasksStore.setState({ tasks: [], browserOpen: false });
+});
+
+afterEach(async () => {
+  if (root !== undefined) {
+    await act(async () => root?.unmount());
+    root = undefined;
+  }
+  document.body.replaceChildren();
+  vi.restoreAllMocks();
+});
+
+describe("background task Webview state (restores task lists and output)", () => {
+  it("preserves announced tasks when session history finishes loading", async () => {
+    useTasksStore.getState().setTasks([runningTask]);
+
+    await useChatStore.getState().loadSession("session-2", []);
+
+    expect(useTasksStore.getState().tasks).toEqual([runningTask]);
+  });
+
+  it("shows recovered output when a successful refresh follows a transient error", async () => {
+    bridgeMock.listBackgroundTasks.mockResolvedValue([runningTask]);
+    bridgeMock.getBackgroundTaskOutput
+      .mockRejectedValueOnce(new Error("temporary output failure"))
+      .mockResolvedValueOnce({ output: "server ready" });
+    useTasksStore.setState({ tasks: [runningTask], browserOpen: true });
+    const container = document.createElement("div");
+    document.body.append(container);
+    root = createRoot(container);
+
+    await act(async () => root?.render(createElement(TasksModal)));
+    const expandButton = container.querySelector<HTMLButtonElement>('button[title="View output"]');
+    expect(expandButton).not.toBeNull();
+    await act(async () => expandButton?.click());
+    expect(container.textContent).toContain("temporary output failure");
+
+    await act(async () => {
+      useTasksStore.getState().setTasks([
+        { ...runningTask, status: "completed", exitCode: 0, endedAt: 2000 },
+      ]);
+    });
+
+    expect(container.textContent).toContain("server ready");
+    expect(container.textContent).not.toContain("temporary output failure");
+  });
+});

--- a/apps/vscode/test/bridge-handler.test.ts
+++ b/apps/vscode/test/bridge-handler.test.ts
@@ -11,7 +11,7 @@ import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi, type Mock } from "vitest";
 import type * as vscode from "vscode";
 
-import { Methods } from "../shared/bridge";
+import { Events, Methods } from "../shared/bridge";
 import { BridgeHandler } from "../src/bridge-handler";
 
 const host = vi.hoisted(() => {
@@ -28,6 +28,7 @@ const host = vi.hoisted(() => {
     setConfig: vi.fn(async () => undefined),
     listSessions: vi.fn(async () => []),
     resumeSession: vi.fn(),
+    withInteractiveAgent: vi.fn((_agentId: string, fn: () => unknown) => fn()),
     forkSession: vi.fn(),
     deleteSession: vi.fn(async () => undefined),
   };
@@ -86,6 +87,7 @@ vi.mock("@moonshot-ai/kimi-code-sdk", async (importOriginal) => {
 
 let bridge: BridgeHandler;
 let root: string;
+let broadcast: Mock<(event: string, data: unknown, webviewId?: string) => void>;
 let showLogs: Mock<() => void>;
 let writeLog: Mock<(message: string) => void>;
 let workspaceState: { get: ReturnType<typeof vi.fn>; update: ReturnType<typeof vi.fn> };
@@ -93,6 +95,7 @@ let workspaceState: { get: ReturnType<typeof vi.fn>; update: ReturnType<typeof v
 beforeEach(async () => {
   root = await mkdtemp(join(tmpdir(), "kimi-vscode-bridge-"));
   host.workspaceFolders.splice(0, host.workspaceFolders.length, { uri: new host.Uri(root) });
+  broadcast = vi.fn();
   showLogs = vi.fn();
   writeLog = vi.fn();
   host.harness.resumeSession.mockReset();
@@ -104,7 +107,7 @@ beforeEach(async () => {
   host.showWarningMessage.mockResolvedValue(undefined);
   workspaceState = { get: vi.fn((_key, fallback) => fallback), update: vi.fn() };
   bridge = new BridgeHandler(
-    vi.fn(),
+    broadcast,
     workspaceState as unknown as vscode.Memento,
     join(root, "global-storage"),
     vi.fn(),
@@ -495,6 +498,27 @@ describe("Webview RPC boundary (validates requests before host dispatch)", () =>
     await vi.waitFor(() => expect(showLogs).toHaveBeenCalledOnce());
   });
 
+  it("clears previous task state when restored task lookup fails", async () => {
+    const session = {
+      ...createResumedSession("session-1", root),
+      listBackgroundTasks: vi.fn(async () => {
+        throw new Error("task lookup unavailable");
+      }),
+    };
+    host.harness.resumeSession.mockResolvedValueOnce(session as never);
+
+    await bridge.handle(
+      {
+        id: "rpc-1",
+        method: Methods.LoadKimiSessionHistory,
+        params: { kimiSessionId: "session-1" },
+      },
+      "view-1",
+    );
+
+    expect(broadcast).toHaveBeenCalledWith(Events.BackgroundTasksChanged, [], "view-1");
+  });
+
   it("returns a readable error when persisted session state is corrupt without wedging the bridge", async () => {
     host.harness.resumeSession.mockRejectedValueOnce(
       new Error("Session state is invalid JSON at line 4"),
@@ -656,5 +680,6 @@ function createResumedSession(id: string, workDir: string) {
     setApprovalHandler: () => undefined,
     setQuestionHandler: () => undefined,
     onEvent: () => () => undefined,
+    listBackgroundTasks: async () => [],
   };
 }

--- a/apps/vscode/test/bridge-handler.test.ts
+++ b/apps/vscode/test/bridge-handler.test.ts
@@ -213,6 +213,56 @@ describe("Webview RPC boundary (validates requests before host dispatch)", () =>
     expect(showLogs).not.toHaveBeenCalled();
   });
 
+  it("rejects task listing when the no-params method receives a payload", async () => {
+    const result = await bridge.handle(
+      { id: "rpc-tasks", method: Methods.ListBackgroundTasks, params: {} },
+      "view-1",
+    );
+
+    expect(result).toEqual({
+      id: "rpc-tasks",
+      error: "Invalid bridge params for method: listBackgroundTasks",
+    });
+  });
+
+  it.each([
+    ["missing params", undefined],
+    ["missing task id", {}],
+    ["blank task id", { taskId: " " }],
+    ["non-string task id", { taskId: 42 }],
+  ])("rejects stopping a background task with %s", async (_, params) => {
+    const result = await bridge.handle(
+      { id: "rpc-stop-task", method: Methods.StopBackgroundTask, params },
+      "view-1",
+    );
+
+    expect(result).toEqual({
+      id: "rpc-stop-task",
+      error: "Invalid bridge params for method: stopBackgroundTask",
+    });
+  });
+
+  it.each([
+    ["zero", 0],
+    ["a negative integer", -1],
+    ["a fraction", 1.5],
+    ["a string", "4000"],
+  ])("rejects background task output when tail is %s", async (_, tail) => {
+    const result = await bridge.handle(
+      {
+        id: "rpc-task-output",
+        method: Methods.GetBackgroundTaskOutput,
+        params: { taskId: "bash-1", tail },
+      },
+      "view-1",
+    );
+
+    expect(result).toEqual({
+      id: "rpc-task-output",
+      error: "Invalid bridge params for method: getBackgroundTaskOutput",
+    });
+  });
+
   it("does not execute an object-payload handler when a required field has the wrong type", async () => {
     const result = await bridge.handle(
       { id: "rpc-1", method: Methods.AddInputHistory, params: { text: 42 } },

--- a/apps/vscode/test/bridge-handler.test.ts
+++ b/apps/vscode/test/bridge-handler.test.ts
@@ -516,7 +516,11 @@ describe("Webview RPC boundary (validates requests before host dispatch)", () =>
       "view-1",
     );
 
-    expect(broadcast).toHaveBeenCalledWith(Events.BackgroundTasksChanged, [], "view-1");
+    expect(broadcast).toHaveBeenCalledWith(
+      Events.BackgroundTasksChanged,
+      { sessionId: "session-1", tasks: [] },
+      "view-1",
+    );
   });
 
   it("returns a readable error when persisted session state is corrupt without wedging the bridge", async () => {

--- a/apps/vscode/test/kimi-harness.integration.test.ts
+++ b/apps/vscode/test/kimi-harness.integration.test.ts
@@ -127,7 +127,12 @@ async function createRuntimeRig(extraAliases: readonly string[] = []): Promise<R
       try {
         await closeProvider();
       } finally {
-        await rm(rootDir, { recursive: true, force: true });
+        await rm(rootDir, {
+          recursive: true,
+          force: true,
+          maxRetries: 5,
+          retryDelay: 50,
+        });
       }
     }
   });

--- a/apps/vscode/test/session-runtime.test.ts
+++ b/apps/vscode/test/session-runtime.test.ts
@@ -43,7 +43,11 @@ interface FakeSessionBoundary {
   readonly handlerInstallations: { approval: number; question: number };
   readonly metadataUpdates: JsonObject[];
   readonly setPermissions: PermissionMode[];
-  setBackgroundTasks(tasks: readonly BackgroundTaskInfo[]): void;
+  setBackgroundTasks(tasks: readonly BackgroundTaskInfo[], agentId?: string): void;
+  setResumeAgentIds(agentIds: readonly string[]): void;
+  readonly taskOutputRequests: Array<{ agentId: string; taskId: string; tail?: number }>;
+  readonly stoppedTasks: Array<{ agentId: string; taskId: string }>;
+  withInteractiveAgent<T>(agentId: string, fn: () => T): T;
   readonly subscriptionCount: () => number;
   readonly cancelCount: () => number;
   readonly cancelCompactionCount: () => number;
@@ -68,7 +72,11 @@ function createFakeSession(): FakeSessionBoundary {
   let questionHandler: QuestionHandler | undefined;
   let nextPromptError: Error | undefined;
   let nextMetadataError: Error | undefined;
-  let backgroundTasks: readonly BackgroundTaskInfo[] = [];
+  const backgroundTasks = new Map<string, readonly BackgroundTaskInfo[]>();
+  const taskOutputRequests: Array<{ agentId: string; taskId: string; tail?: number }> = [];
+  const stoppedTasks: Array<{ agentId: string; taskId: string }> = [];
+  let activeAgentId = "main";
+  let resumeAgentIds: readonly string[] = ["main"];
   let subscriptions = 0;
   let cancellations = 0;
   let compactionCancellations = 0;
@@ -88,6 +96,11 @@ function createFakeSession(): FakeSessionBoundary {
     id: summary.id,
     workDir: summary.workDir,
     summary,
+    getResumeState() {
+      return {
+        agents: Object.fromEntries(resumeAgentIds.map((agentId) => [agentId, {}])),
+      };
+    },
     setApprovalHandler(handler: ApprovalHandler | undefined) {
       approvalHandler = handler;
       if (handler !== undefined) handlerInstallations.approval += 1;
@@ -133,7 +146,14 @@ function createFakeSession(): FakeSessionBoundary {
       setPermissions.push(mode);
     },
     async listBackgroundTasks() {
-      return backgroundTasks;
+      return backgroundTasks.get(activeAgentId) ?? [];
+    },
+    async getBackgroundTaskOutput(taskId: string, options?: { tail?: number }) {
+      taskOutputRequests.push({ agentId: activeAgentId, taskId, tail: options?.tail });
+      return `output from ${activeAgentId}`;
+    },
+    async stopBackgroundTask(taskId: string) {
+      stoppedTasks.push({ agentId: activeAgentId, taskId });
     },
     async updateMetadata(patch: JsonObject) {
       if (nextMetadataError !== undefined) {
@@ -155,8 +175,22 @@ function createFakeSession(): FakeSessionBoundary {
     handlerInstallations,
     metadataUpdates,
     setPermissions,
-    setBackgroundTasks(tasks) {
-      backgroundTasks = tasks;
+    taskOutputRequests,
+    stoppedTasks,
+    withInteractiveAgent(agentId, fn) {
+      const previousAgentId = activeAgentId;
+      activeAgentId = agentId;
+      try {
+        return fn();
+      } finally {
+        activeAgentId = previousAgentId;
+      }
+    },
+    setBackgroundTasks(tasks, agentId = "main") {
+      backgroundTasks.set(agentId, tasks);
+    },
+    setResumeAgentIds(agentIds) {
+      resumeAgentIds = agentIds;
     },
     subscriptionCount: () => subscriptions,
     cancelCount: () => cancellations,
@@ -188,6 +222,7 @@ function createRuntime(legacyApproval = DEFAULT_LEGACY_APPROVAL) {
   const baselines: BaselineRecord[] = [];
   const runtime = new SessionRuntime({
     session: sdk.session,
+    withInteractiveAgent: (agentId, fn) => sdk.withInteractiveAgent(agentId, fn),
     legacyApproval,
     broadcast: (event, data, webviewId) => broadcasts.push({ event, data, webviewId }),
     captureBaseline: (session, filePath, webviewIds) => {
@@ -507,6 +542,97 @@ describe("session runtime (adapts one SDK session for subscribed Webviews)", () 
           webviewId: "view-2",
         },
       ]);
+    });
+
+    it("announces tasks from every resumed agent when a session is restored", async () => {
+      const { runtime, sdk, broadcasts } = createRuntime();
+      const mainTask: BackgroundTaskInfo = {
+        taskId: "bash-main",
+        kind: "process",
+        description: "main task",
+        status: "running",
+        command: "pnpm dev",
+        pid: 1234,
+        exitCode: null,
+        startedAt: 1000,
+        endedAt: null,
+      };
+      const workerTask: BackgroundTaskInfo = {
+        taskId: "bash-worker",
+        kind: "process",
+        description: "worker task",
+        status: "completed",
+        command: "pnpm test",
+        pid: 5678,
+        exitCode: 0,
+        startedAt: 1100,
+        endedAt: 2000,
+      };
+      sdk.setResumeAgentIds(["main", "worker-1"]);
+      sdk.setBackgroundTasks([mainTask]);
+      sdk.setBackgroundTasks([workerTask], "worker-1");
+
+      await runtime.announceBackgroundTasks("view-1");
+
+      expect(broadcasts).toContainEqual({
+        event: Events.BackgroundTasksChanged,
+        data: [mainTask, workerTask],
+        webviewId: "view-1",
+      });
+    });
+
+    it("loads task output from the agent that announced the task", async () => {
+      const { runtime, sdk } = createRuntime();
+      const info: BackgroundTaskInfo = {
+        taskId: "bash-worker",
+        kind: "process",
+        description: "worker task",
+        status: "running",
+        command: "pnpm test",
+        pid: 5678,
+        exitCode: null,
+        startedAt: 1000,
+        endedAt: null,
+      };
+      sdk.emit({
+        type: "background.task.started",
+        sessionId: "session-1",
+        agentId: "worker-1",
+        info,
+      });
+
+      await expect(runtime.getBackgroundTaskOutput("bash-worker", 4000)).resolves.toBe(
+        "output from worker-1",
+      );
+
+      expect(sdk.taskOutputRequests).toEqual([
+        { agentId: "worker-1", taskId: "bash-worker", tail: 4000 },
+      ]);
+    });
+
+    it("stops a task through the agent that announced the task", async () => {
+      const { runtime, sdk } = createRuntime();
+      const info: BackgroundTaskInfo = {
+        taskId: "bash-worker",
+        kind: "process",
+        description: "worker task",
+        status: "running",
+        command: "pnpm test",
+        pid: 5678,
+        exitCode: null,
+        startedAt: 1000,
+        endedAt: null,
+      };
+      sdk.emit({
+        type: "background.task.started",
+        sessionId: "session-1",
+        agentId: "worker-1",
+        info,
+      });
+
+      await runtime.stopBackgroundTask("bash-worker");
+
+      expect(sdk.stoppedTasks).toEqual([{ agentId: "worker-1", taskId: "bash-worker" }]);
     });
   });
 

--- a/apps/vscode/test/session-runtime.test.ts
+++ b/apps/vscode/test/session-runtime.test.ts
@@ -446,7 +446,7 @@ describe("session runtime (adapts one SDK session for subscribed Webviews)", () 
 
       expect(broadcasts).toContainEqual({
         event: Events.BackgroundTasksChanged,
-        data: [info],
+        data: { sessionId: "session-1", tasks: [info] },
         webviewId: "view-1",
       });
     });
@@ -538,7 +538,7 @@ describe("session runtime (adapts one SDK session for subscribed Webviews)", () 
       expect(broadcasts).toEqual([
         {
           event: Events.BackgroundTasksChanged,
-          data: [info],
+          data: { sessionId: "session-1", tasks: [info] },
           webviewId: "view-2",
         },
       ]);
@@ -576,7 +576,7 @@ describe("session runtime (adapts one SDK session for subscribed Webviews)", () 
 
       expect(broadcasts).toContainEqual({
         event: Events.BackgroundTasksChanged,
-        data: [mainTask, workerTask],
+        data: { sessionId: "session-1", tasks: [mainTask, workerTask] },
         webviewId: "view-1",
       });
     });

--- a/apps/vscode/test/session-runtime.test.ts
+++ b/apps/vscode/test/session-runtime.test.ts
@@ -8,6 +8,7 @@
 import type {
   ApprovalHandler,
   ApprovalRequest,
+  BackgroundTaskInfo,
   Event,
   JsonObject,
   PermissionMode,
@@ -42,6 +43,7 @@ interface FakeSessionBoundary {
   readonly handlerInstallations: { approval: number; question: number };
   readonly metadataUpdates: JsonObject[];
   readonly setPermissions: PermissionMode[];
+  setBackgroundTasks(tasks: readonly BackgroundTaskInfo[]): void;
   readonly subscriptionCount: () => number;
   readonly cancelCount: () => number;
   readonly cancelCompactionCount: () => number;
@@ -66,6 +68,7 @@ function createFakeSession(): FakeSessionBoundary {
   let questionHandler: QuestionHandler | undefined;
   let nextPromptError: Error | undefined;
   let nextMetadataError: Error | undefined;
+  let backgroundTasks: readonly BackgroundTaskInfo[] = [];
   let subscriptions = 0;
   let cancellations = 0;
   let compactionCancellations = 0;
@@ -129,6 +132,9 @@ function createFakeSession(): FakeSessionBoundary {
       permission = mode;
       setPermissions.push(mode);
     },
+    async listBackgroundTasks() {
+      return backgroundTasks;
+    },
     async updateMetadata(patch: JsonObject) {
       if (nextMetadataError !== undefined) {
         const error = nextMetadataError;
@@ -149,6 +155,9 @@ function createFakeSession(): FakeSessionBoundary {
     handlerInstallations,
     metadataUpdates,
     setPermissions,
+    setBackgroundTasks(tasks) {
+      backgroundTasks = tasks;
+    },
     subscriptionCount: () => subscriptions,
     cancelCount: () => cancellations,
     cancelCompactionCount: () => compactionCancellations,
@@ -375,6 +384,129 @@ describe("session runtime (adapts one SDK session for subscribed Webviews)", () 
       type: "ContentPart",
       payload: { type: "think", think: "Checking the edge case" },
       _sessionId: "session-1",
+    });
+  });
+
+  describe("background tasks (publishes task lifecycle state to subscribed Webviews)", () => {
+    it("broadcasts the current task list when a background task starts", () => {
+      const { sdk, broadcasts } = createRuntime();
+      const info: BackgroundTaskInfo = {
+        taskId: "bash-1",
+        kind: "process",
+        description: "dev server",
+        status: "running",
+        command: "pnpm dev",
+        pid: 1234,
+        exitCode: null,
+        startedAt: 1000,
+        endedAt: null,
+      };
+
+      sdk.emit({
+        type: "background.task.started",
+        sessionId: "session-1",
+        agentId: "main",
+        info,
+      });
+
+      expect(broadcasts).toContainEqual({
+        event: Events.BackgroundTasksChanged,
+        data: [info],
+        webviewId: "view-1",
+      });
+    });
+
+    it("adds a transcript status card when a background task starts", () => {
+      const { sdk, broadcasts } = createRuntime();
+      const info: BackgroundTaskInfo = {
+        taskId: "bash-1",
+        kind: "process",
+        description: "dev server",
+        status: "running",
+        command: "pnpm dev",
+        pid: 1234,
+        exitCode: null,
+        startedAt: 1000,
+        endedAt: null,
+      };
+
+      sdk.emit({
+        type: "background.task.started",
+        sessionId: "session-1",
+        agentId: "main",
+        info,
+      });
+
+      expect(streamData(broadcasts)).toContainEqual({
+        type: "BackgroundTaskStatus",
+        payload: { info },
+        _sessionId: "session-1",
+      });
+    });
+
+    it("emits one terminal status card when the same task status is repeated", () => {
+      const { sdk, broadcasts } = createRuntime();
+      const info: BackgroundTaskInfo = {
+        taskId: "bash-1",
+        kind: "process",
+        description: "dev server",
+        status: "completed",
+        command: "pnpm dev",
+        pid: 1234,
+        exitCode: 0,
+        startedAt: 1000,
+        endedAt: 2000,
+      };
+      const event: Event = {
+        type: "background.task.terminated",
+        sessionId: "session-1",
+        agentId: "main",
+        info,
+      };
+
+      sdk.emit(event);
+      sdk.emit(event);
+
+      expect(
+        streamData(broadcasts).filter(
+          (streamEvent) =>
+            typeof streamEvent === "object" &&
+            streamEvent !== null &&
+            "type" in streamEvent &&
+            streamEvent.type === "BackgroundTaskStatus",
+        ),
+      ).toEqual([
+        {
+          type: "BackgroundTaskStatus",
+          payload: { info },
+          _sessionId: "session-1",
+        },
+      ]);
+    });
+
+    it("announces restored task state only to the requested subscribed Webview", async () => {
+      const { runtime, sdk, broadcasts } = createRuntime();
+      const info: BackgroundTaskInfo = {
+        taskId: "agent-1",
+        kind: "agent",
+        description: "review changes",
+        status: "completed",
+        agentId: "reviewer",
+        startedAt: 1000,
+        endedAt: 2000,
+      };
+      sdk.setBackgroundTasks([info]);
+      runtime.subscribe("view-2");
+
+      await runtime.announceBackgroundTasks("view-2");
+
+      expect(broadcasts).toEqual([
+        {
+          event: Events.BackgroundTasksChanged,
+          data: [info],
+          webviewId: "view-2",
+        },
+      ]);
     });
   });
 

--- a/apps/vscode/test/workspace-paths.test.ts
+++ b/apps/vscode/test/workspace-paths.test.ts
@@ -305,6 +305,7 @@ describe("Webview workspace paths (selected-directory containment)", () => {
     } as unknown as Session;
     const runtime = new SessionRuntime({
       session,
+      withInteractiveAgent: (_agentId, fn) => fn(),
       legacyApproval: { yolo: false, afk: false },
       broadcast: vi.fn(),
       captureBaseline: (summary, filePath, webviewIds) => {

--- a/apps/vscode/tsconfig.json
+++ b/apps/vscode/tsconfig.json
@@ -15,5 +15,5 @@
     }
   },
   "include": ["src/**/*", "shared/**/*", "test/**/*"],
-  "exclude": ["dist", "node_modules", "webview-ui", "test/settings-store.test.ts", "test/app-init.test.ts"]
+  "exclude": ["dist", "node_modules", "webview-ui", "test/settings-store.test.ts", "test/app-init.test.ts", "test/background-tasks-ui.test.ts"]
 }

--- a/apps/vscode/webview-ui/src/App.tsx
+++ b/apps/vscode/webview-ui/src/App.tsx
@@ -5,19 +5,22 @@ import { ChatArea } from "./components/ChatArea";
 import { InputArea } from "./components/inputarea/InputArea";
 import { MCPServersModal } from "./components/MCPServersModal";
 import { WorkDirModal } from "./components/WorkDirModal";
+import { TasksModal } from "./components/TasksModal";
 import { ConfigErrorScreen } from "./components/ConfigErrorScreen";
 import { LoginScreen } from "./components/LoginScreen";
 import { Toaster, toast } from "./components/ui/sonner";
-import { useChatStore, useSettingsStore } from "./stores";
+import { useChatStore, useSettingsStore, useTasksStore } from "./stores";
 import { bridge, Events } from "./services";
 import { useAppInit, resolveAppView } from "./hooks/useAppInit";
 import { isPreflightError } from "shared/errors";
 import type { UIStreamEvent, StreamError, ExtensionConfig } from "shared/types";
+import type { BackgroundTaskInfo } from "shared/legacy-sdk";
 import "./styles/index.css";
 
 function MainContent({ onAuthAction }: { onAuthAction: () => void }) {
   const { processEvent, startNewConversation, sessionId } = useChatStore();
   const { setMCPServers, setExtensionConfig, extensionConfig } = useSettingsStore();
+  const setTasks = useTasksStore((s) => s.setTasks);
 
   useEffect(() => {
     return bridge.on(Events.StreamEvent, (event: UIStreamEvent) => {
@@ -39,6 +42,7 @@ function MainContent({ onAuthAction }: { onAuthAction: () => void }) {
   useEffect(() => {
     const unsubs = [
       bridge.on(Events.MCPServersChanged, setMCPServers),
+      bridge.on(Events.BackgroundTasksChanged, (tasks: BackgroundTaskInfo[]) => setTasks(tasks)),
       bridge.on(Events.ExtensionConfigChanged, ({ config }: { config: ExtensionConfig }) => setExtensionConfig(config)),
       bridge.on(Events.FocusInput, () => document.querySelector<HTMLTextAreaElement>("textarea")?.focus()),
       bridge.on(Events.NewConversation, () => {
@@ -48,7 +52,7 @@ function MainContent({ onAuthAction }: { onAuthAction: () => void }) {
       }),
     ];
     return () => unsubs.forEach((u) => u());
-  }, [setMCPServers, setExtensionConfig, startNewConversation]);
+  }, [setMCPServers, setExtensionConfig, startNewConversation, setTasks]);
 
   useEffect(() => {
     if (!extensionConfig.enableNewConversationShortcut) return;
@@ -74,6 +78,7 @@ function MainContent({ onAuthAction }: { onAuthAction: () => void }) {
       </div>
       <MCPServersModal />
       <WorkDirModal />
+      <TasksModal />
     </>
   );
 }

--- a/apps/vscode/webview-ui/src/App.tsx
+++ b/apps/vscode/webview-ui/src/App.tsx
@@ -13,14 +13,18 @@ import { useChatStore, useSettingsStore, useTasksStore } from "./stores";
 import { bridge, Events } from "./services";
 import { useAppInit, resolveAppView } from "./hooks/useAppInit";
 import { isPreflightError } from "shared/errors";
-import type { UIStreamEvent, StreamError, ExtensionConfig } from "shared/types";
-import type { BackgroundTaskInfo } from "shared/legacy-sdk";
+import type {
+  BackgroundTasksChangedPayload,
+  UIStreamEvent,
+  StreamError,
+  ExtensionConfig,
+} from "shared/types";
 import "./styles/index.css";
 
 function MainContent({ onAuthAction }: { onAuthAction: () => void }) {
   const { processEvent, startNewConversation, sessionId } = useChatStore();
   const { setMCPServers, setExtensionConfig, extensionConfig } = useSettingsStore();
-  const setTasks = useTasksStore((s) => s.setTasks);
+  const applyTaskSnapshot = useTasksStore((s) => s.applySnapshot);
 
   useEffect(() => {
     return bridge.on(Events.StreamEvent, (event: UIStreamEvent) => {
@@ -42,7 +46,9 @@ function MainContent({ onAuthAction }: { onAuthAction: () => void }) {
   useEffect(() => {
     const unsubs = [
       bridge.on(Events.MCPServersChanged, setMCPServers),
-      bridge.on(Events.BackgroundTasksChanged, (tasks: BackgroundTaskInfo[]) => setTasks(tasks)),
+      bridge.on(Events.BackgroundTasksChanged, (payload: BackgroundTasksChangedPayload) => {
+        applyTaskSnapshot(payload);
+      }),
       bridge.on(Events.ExtensionConfigChanged, ({ config }: { config: ExtensionConfig }) => setExtensionConfig(config)),
       bridge.on(Events.FocusInput, () => document.querySelector<HTMLTextAreaElement>("textarea")?.focus()),
       bridge.on(Events.NewConversation, () => {
@@ -52,7 +58,7 @@ function MainContent({ onAuthAction }: { onAuthAction: () => void }) {
       }),
     ];
     return () => unsubs.forEach((u) => u());
-  }, [setMCPServers, setExtensionConfig, startNewConversation, setTasks]);
+  }, [setMCPServers, setExtensionConfig, startNewConversation, applyTaskSnapshot]);
 
   useEffect(() => {
     if (!extensionConfig.enableNewConversationShortcut) return;

--- a/apps/vscode/webview-ui/src/components/BackgroundTaskStatusLine.tsx
+++ b/apps/vscode/webview-ui/src/components/BackgroundTaskStatusLine.tsx
@@ -1,0 +1,96 @@
+import { cn } from "@/lib/utils";
+import type { BackgroundTaskInfo, BackgroundTaskStatus } from "shared/legacy-sdk";
+
+const MAX_DETAIL_LENGTH = 240;
+
+type Phase = "started" | "completed" | "failed";
+
+function phaseFromStatus(status: BackgroundTaskStatus): Phase {
+  switch (status) {
+    case "running":
+      return "started";
+    case "completed":
+      return "completed";
+    case "failed":
+    case "timed_out":
+    case "killed":
+    case "lost":
+      return "failed";
+  }
+}
+
+function subjectFor(info: BackgroundTaskInfo): string {
+  if (info.kind === "agent") return "agent task";
+  if (info.kind === "question") return "question task";
+  return "bash task";
+}
+
+function headlineFor(info: BackgroundTaskInfo): string {
+  const subject = subjectFor(info);
+  switch (info.status) {
+    case "running":
+      return `${subject} started in background`;
+    case "completed":
+      return `${subject} completed in background`;
+    case "failed":
+      return `${subject} failed in background`;
+    case "timed_out":
+      return `${subject} timed out`;
+    case "killed":
+      return `${subject} stopped`;
+    case "lost":
+      return `${subject} lost`;
+  }
+}
+
+function truncate(value: string | undefined): string | undefined {
+  if (value === undefined) return undefined;
+  const collapsed = value.trim().replaceAll(/\s+/g, " ");
+  if (collapsed.length === 0) return undefined;
+  if (collapsed.length <= MAX_DETAIL_LENGTH) return collapsed;
+  return `${collapsed.slice(0, MAX_DETAIL_LENGTH - 3)}...`;
+}
+
+function detailFor(info: BackgroundTaskInfo): string | undefined {
+  const parts: string[] = [];
+  const description = truncate(info.description);
+  if (description !== undefined) parts.push(description);
+
+  if (info.status === "completed" || info.status === "failed") {
+    if (info.kind === "process" && info.exitCode !== null) {
+      parts.push(`exit ${info.exitCode}`);
+    }
+  }
+  if (info.status === "killed") {
+    const reason = truncate(info.stopReason);
+    parts.push(reason !== undefined ? `stopped — ${reason}` : "stopped");
+  }
+  if (info.status === "failed") {
+    const reason = truncate(info.stopReason);
+    if (reason !== undefined) parts.push(reason);
+  }
+  if (info.status === "timed_out") parts.push("timed out");
+  if (info.status === "lost") {
+    parts.push("session restarted before completion");
+  }
+
+  return parts.length > 0 ? parts.join(" · ") : undefined;
+}
+
+const PHASE_DOT_CLASS: Record<Phase, string> = {
+  started: "bg-blue-400",
+  completed: "bg-green-500",
+  failed: "bg-red-500",
+};
+
+export function BackgroundTaskStatusLine({ info }: { info: BackgroundTaskInfo }) {
+  const phase = phaseFromStatus(info.status);
+  const detail = detailFor(info);
+  return (
+    <div className="flex items-baseline gap-1.5 text-xs py-0.5">
+      <span className={cn("size-1.5 rounded-full shrink-0 self-center", PHASE_DOT_CLASS[phase])} />
+      <span className="text-muted-foreground">{headlineFor(info)}</span>
+      {detail && <span className="text-muted-foreground/70 truncate min-w-0">({detail})</span>}
+    </div>
+  );
+}

--- a/apps/vscode/webview-ui/src/components/BottomToolbar.tsx
+++ b/apps/vscode/webview-ui/src/components/BottomToolbar.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from "react";
-import { IconChevronUp, IconStack2, IconFileCode } from "@tabler/icons-react";
-import { useChatStore } from "@/stores";
+import { IconChevronUp, IconStack2, IconFileCode, IconTerminal2 } from "@tabler/icons-react";
+import { useChatStore, useTasksStore, visibleBackgroundTasks, runningTaskCount } from "@/stores";
 import { bridge, Events } from "@/services";
 import { cn } from "@/lib/utils";
 import { FileChangesPanel } from "./FileChangesPanel";
@@ -15,6 +15,8 @@ export function BottomToolbar() {
   const { queue } = useChatStore();
   const [activeTab, setActiveTab] = useState<TabId>(null);
   const [fileChanges, setFileChanges] = useState<FileChange[]>([]);
+  const tasks = useTasksStore((s) => s.tasks);
+  const setBrowserOpen = useTasksStore((s) => s.setBrowserOpen);
 
   useEffect(() => {
     return bridge.on<FileChange[]>(Events.FileChangesUpdated, setFileChanges);
@@ -32,7 +34,10 @@ export function BottomToolbar() {
 
   const hasQueue = queue.length > 0;
   const hasChanges = fileChanges.length > 0;
-  const hasTabs = hasQueue || hasChanges;
+  const visibleTasks = visibleBackgroundTasks(tasks);
+  const runningTasks = runningTaskCount(visibleTasks);
+  const hasTasks = visibleTasks.length > 0;
+  const hasTabs = hasQueue || hasChanges || hasTasks;
 
   const toggleTab = (tab: TabId) => {
     setActiveTab((prev) => (prev === tab ? null : tab));
@@ -86,6 +91,17 @@ export function BottomToolbar() {
                   <span className="text-green-600 dark:text-green-400">+{fileStats.additions}</span> <span className="text-red-600 dark:text-red-400">-{fileStats.deletions}</span>
                 </span>
                 <IconChevronUp className={cn("size-3 transition-transform", activeTab === "changes" && "rotate-180")} />
+              </button>
+            )}
+
+            {hasTasks && (
+              <button
+                onClick={() => setBrowserOpen(true)}
+                className="flex items-center gap-1.5 px-2 py-0.5 rounded text-xs transition-colors hover:bg-muted/50 text-muted-foreground"
+                title="View background tasks"
+              >
+                <IconTerminal2 className={cn("size-3.5", runningTasks > 0 && "animate-pulse text-blue-500")} />
+                <span>{runningTasks > 0 ? `${runningTasks} Running` : "Tasks"}</span>
               </button>
             )}
           </div>

--- a/apps/vscode/webview-ui/src/components/ChatMessage.tsx
+++ b/apps/vscode/webview-ui/src/components/ChatMessage.tsx
@@ -151,7 +151,7 @@ function ForkButton({ turnIndex, className }: ForkButtonProps) {
   const [isForking, setIsForking] = useState(false);
   const sessionId = useChatStore((s) => s.sessionId);
   const isStreaming = useChatStore((s) => s.isStreaming);
-  const loadSession = useChatStore((s) => s.loadSession);
+  const restoreSession = useChatStore((s) => s.restoreSession);
 
   const handleFork = () => {
     if (!sessionId || turnIndex < 0) return;
@@ -166,8 +166,7 @@ function ForkButton({ turnIndex, className }: ForkButtonProps) {
       const result = await bridge.forkSession(sessionId, turnIndex);
       if (result) {
         // Load the forked session
-        const events = await bridge.loadSessionHistory(result.sessionId);
-        await loadSession(result.sessionId, events);
+        await restoreSession(result.sessionId);
       }
     } catch (error) {
       toast.error(`Failed to fork conversation: ${error instanceof Error ? error.message : String(error)}`);

--- a/apps/vscode/webview-ui/src/components/ChatMessage.tsx
+++ b/apps/vscode/webview-ui/src/components/ChatMessage.tsx
@@ -7,6 +7,7 @@ import { ToolCallCard } from "./ToolRenderers";
 import { CopyButton } from "./CopyButton";
 import { ThinkingBlock } from "./ThinkingBlock";
 import { CompactionCard } from "./CompactionCard";
+import { BackgroundTaskStatusLine } from "./BackgroundTaskStatusLine";
 import { MediaThumbnail } from "./MediaThumbnail";
 import { MediaPreviewModal } from "./MediaPreviewModal";
 import { InlineError } from "./InlineError";
@@ -58,6 +59,8 @@ function StepItemRenderer({ item }: { item: UIStepItem }) {
       return <CompactionCard />;
     case "steer":
       return <SteerBubble content={item.content} />;
+    case "background_task":
+      return <BackgroundTaskStatusLine info={item.info} />;
     default:
       return null;
   }
@@ -285,7 +288,7 @@ function AssistantMessage({ message, turnIndex, isStreaming }: { message: ChatMe
                     const hasIndicator = stepHasIndicator[globalIndex];
                     const hasNextIndicator = stepHasIndicator.slice(globalIndex + 1).some(Boolean);
                     const showConnector = hasIndicator && hasNextIndicator && !isLastInGroup && !isLastOverall;
-                    return <StepContent key={step.n} step={step} showConnector={showConnector} />;
+                    return <StepContent key={`${step.n}-${i}`} step={step} showConnector={showConnector} />;
                   });
 
                   if (group.planMode) {

--- a/apps/vscode/webview-ui/src/components/SessionList.tsx
+++ b/apps/vscode/webview-ui/src/components/SessionList.tsx
@@ -79,8 +79,8 @@ function SessionItem({ session, isSelected, onSelect, onDelete, dirLabel }: Sess
 }
 
 export function SessionList({ onClose }: SessionListProps) {
-  const { loadSession, sessionId, startNewConversation, isStreaming } = useChatStore();
-  const { workspaceRoot, currentWorkDir, setCurrentWorkDir } = useSettingsStore();
+  const { restoreSession, sessionId, startNewConversation, isStreaming } = useChatStore();
+  const { workspaceRoot, currentWorkDir } = useSettingsStore();
   const [searchQuery, setSearchQuery] = useState("");
   const [deleteTarget, setDeleteTarget] = useState<SessionInfo | null>(null);
   const [isDeleting, setIsDeleting] = useState(false);
@@ -122,18 +122,21 @@ export function SessionList({ onClose }: SessionListProps) {
 
   const doLoadSession = async (session: SessionInfo) => {
     try {
-      // Switch workDir if session is from a different directory
-      const activeWorkDir = currentWorkDir || workspaceRoot;
-      if (session.workDir !== activeWorkDir) {
-        const newWorkDir = session.workDir === workspaceRoot ? null : session.workDir;
-        const result = await bridge.setWorkDir(newWorkDir);
-        if (result.ok) {
-          setCurrentWorkDir(newWorkDir);
+      const restored = await restoreSession(session.id, async () => {
+        // Switch workDir if session is from a different directory
+        const settings = useSettingsStore.getState();
+        const activeWorkDir = settings.currentWorkDir ?? settings.workspaceRoot;
+        if (session.workDir !== activeWorkDir) {
+          const newWorkDir = session.workDir === settings.workspaceRoot ? null : session.workDir;
+          const result = await bridge.setWorkDir(newWorkDir);
+          if (result.ok) {
+            settings.setCurrentWorkDir(newWorkDir);
+          }
         }
+      });
+      if (restored) {
+        onClose();
       }
-      const events = await bridge.loadSessionHistory(session.id);
-      await loadSession(session.id, events);
-      onClose();
     } catch (error) {
       console.error("[SessionList] Failed to load session:", error);
       toast.error(`Unable to open the conversation: ${error instanceof Error ? error.message : String(error)}`);

--- a/apps/vscode/webview-ui/src/components/TasksModal.tsx
+++ b/apps/vscode/webview-ui/src/components/TasksModal.tsx
@@ -76,7 +76,10 @@ function TaskOutput({ task }: { task: BackgroundTaskInfo }) {
       bridge
         .getBackgroundTaskOutput(task.taskId, OUTPUT_TAIL_BYTES)
         .then((result) => {
-          if (!cancelled) setOutput(result.output);
+          if (!cancelled) {
+            setOutput(result.output);
+            setError(null);
+          }
         })
         .catch((loadError: unknown) => {
           if (!cancelled) setError(loadError instanceof Error ? loadError.message : String(loadError));

--- a/apps/vscode/webview-ui/src/components/TasksModal.tsx
+++ b/apps/vscode/webview-ui/src/components/TasksModal.tsx
@@ -1,0 +1,297 @@
+import { useState, useEffect } from "react";
+import {
+  IconX,
+  IconChevronDown,
+  IconLoader2,
+  IconPlayerStop,
+  IconRefresh,
+  IconTerminal2,
+} from "@tabler/icons-react";
+import { Button } from "@/components/ui/button";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import { useTasksStore, visibleBackgroundTasks } from "@/stores";
+import { bridge } from "@/services";
+import { cn } from "@/lib/utils";
+import {
+  isBackgroundTaskTerminal,
+  type BackgroundTaskInfo,
+  type BackgroundTaskStatus,
+} from "shared/legacy-sdk";
+
+type Filter = "all" | "active";
+
+const OUTPUT_REFRESH_INTERVAL_MS = 2000;
+const OUTPUT_TAIL_BYTES = 4000;
+
+const STATUS_DOT_CLASS: Record<BackgroundTaskStatus, string> = {
+  running: "bg-blue-400 animate-pulse",
+  completed: "bg-green-500",
+  failed: "bg-red-500",
+  timed_out: "bg-red-500",
+  killed: "bg-red-500",
+  lost: "bg-red-500",
+};
+
+const STATUS_LABEL: Record<BackgroundTaskStatus, string> = {
+  running: "Running",
+  completed: "Completed",
+  failed: "Failed",
+  timed_out: "Timed out",
+  killed: "Stopped",
+  lost: "Lost",
+};
+
+function kindLabel(info: BackgroundTaskInfo): string {
+  if (info.kind === "agent") return "agent";
+  if (info.kind === "question") return "question";
+  return "bash";
+}
+
+function formatDuration(info: BackgroundTaskInfo): string {
+  const end = info.endedAt ?? Date.now();
+  const seconds = Math.max(0, Math.round((end - info.startedAt) / 1000));
+  if (seconds < 60) return `${seconds}s`;
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `${minutes}m ${seconds % 60}s`;
+  return `${Math.floor(minutes / 60)}h ${minutes % 60}m`;
+}
+
+function TaskOutput({ task }: { task: BackgroundTaskInfo }) {
+  const [output, setOutput] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const running = task.status === "running";
+
+  useEffect(() => {
+    let cancelled = false;
+    const load = () => {
+      bridge
+        .getBackgroundTaskOutput(task.taskId, OUTPUT_TAIL_BYTES)
+        .then((result) => {
+          if (!cancelled) setOutput(result.output);
+        })
+        .catch((loadError: unknown) => {
+          if (!cancelled) setError(loadError instanceof Error ? loadError.message : String(loadError));
+        });
+    };
+    load();
+    if (!running) return () => { cancelled = true; };
+    const timer = setInterval(load, OUTPUT_REFRESH_INTERVAL_MS);
+    return () => {
+      cancelled = true;
+      clearInterval(timer);
+    };
+  }, [task.taskId, running]);
+
+  if (error !== null) {
+    return <div className="text-[10px] text-destructive px-2 py-1">{error}</div>;
+  }
+  if (output === null) {
+    return (
+      <div className="flex items-center gap-1.5 text-[10px] text-muted-foreground px-2 py-1">
+        <IconLoader2 className="size-3 animate-spin" />
+        Loading output...
+      </div>
+    );
+  }
+  if (output.length === 0) {
+    return (
+      <div className="text-[10px] text-muted-foreground px-2 py-1">
+        {running ? "No output yet." : "No output."}
+      </div>
+    );
+  }
+  return (
+    <pre className="text-[10px] font-mono bg-muted/50 rounded p-2 whitespace-pre-wrap break-all max-h-48 overflow-auto">
+      {output}
+    </pre>
+  );
+}
+
+function TaskItem({ task, onStop }: { task: BackgroundTaskInfo; onStop: (taskId: string) => void }) {
+  const [expanded, setExpanded] = useState(false);
+  const running = task.status === "running";
+
+  return (
+    <div className="rounded-md border border-border/60 bg-card px-2.5 py-2">
+      <div className="flex items-center gap-2">
+        <span className={cn("size-1.5 rounded-full shrink-0", STATUS_DOT_CLASS[task.status])} />
+        <span className="rounded bg-muted px-1 py-0.5 text-[10px] text-muted-foreground shrink-0">
+          {kindLabel(task)}
+        </span>
+        <span className="flex-1 min-w-0 truncate text-xs" title={task.description}>
+          {task.description || task.taskId}
+        </span>
+        <span className="text-[10px] text-muted-foreground shrink-0 tabular-nums">
+          {STATUS_LABEL[task.status]} · {formatDuration(task)}
+        </span>
+        {running && (
+          <Button
+            variant="ghost"
+            size="icon"
+            className="size-6 text-muted-foreground hover:text-destructive"
+            title="Stop task"
+            onClick={() => onStop(task.taskId)}
+          >
+            <IconPlayerStop className="size-3.5" />
+          </Button>
+        )}
+        <Button
+          variant="ghost"
+          size="icon"
+          className="size-6 text-muted-foreground"
+          title={expanded ? "Hide output" : "View output"}
+          onClick={() => setExpanded((prev) => !prev)}
+        >
+          <IconChevronDown className={cn("size-3.5 transition-transform", expanded && "rotate-180")} />
+        </Button>
+      </div>
+      {task.kind === "process" && (
+        <div className="mt-1 truncate text-[10px] font-mono text-muted-foreground/70" title={task.command}>
+          {task.command}
+        </div>
+      )}
+      {expanded && (
+        <div className="mt-2">
+          <TaskOutput task={task} />
+        </div>
+      )}
+    </div>
+  );
+}
+
+export function TasksModal() {
+  const { tasks, browserOpen, setBrowserOpen, refreshTasks } = useTasksStore();
+  const [filter, setFilter] = useState<Filter>("all");
+  const [stopTarget, setStopTarget] = useState<string | null>(null);
+  const [isStopping, setIsStopping] = useState(false);
+  const [actionError, setActionError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (browserOpen) {
+      void refreshTasks().catch((error: unknown) => {
+        setActionError(error instanceof Error ? error.message : String(error));
+      });
+    }
+  }, [browserOpen, refreshTasks]);
+
+  const handleStop = async () => {
+    if (stopTarget === null) return;
+    setIsStopping(true);
+    setActionError(null);
+    try {
+      await bridge.stopBackgroundTask(stopTarget);
+    } catch (error) {
+      setActionError(error instanceof Error ? error.message : String(error));
+    }
+    setIsStopping(false);
+    setStopTarget(null);
+  };
+
+  if (!browserOpen) return null;
+
+  const visible = visibleBackgroundTasks(tasks);
+  const filtered = filter === "active"
+    ? visible.filter((task) => !isBackgroundTaskTerminal(task.status))
+    : visible;
+  const sorted = [...filtered].sort((a, b) => {
+    const aRunning = a.status === "running" ? 0 : 1;
+    const bRunning = b.status === "running" ? 0 : 1;
+    if (aRunning !== bRunning) return aRunning - bRunning;
+    return b.startedAt - a.startedAt;
+  });
+
+  return (
+    <>
+      <div className="fixed inset-0 z-40 flex flex-col bg-background">
+        <div className="flex items-center justify-between px-3 py-2 border-b">
+          <div className="flex items-center gap-2">
+            <IconTerminal2 className="size-4 text-blue-500" />
+            <h2 className="text-xs font-medium">Background Tasks</h2>
+          </div>
+          <div className="flex items-center gap-1">
+            <div className="flex items-center rounded-md border border-border/60 overflow-hidden">
+              {(["all", "active"] as const).map((value) => (
+                <button
+                  key={value}
+                  onClick={() => setFilter(value)}
+                  className={cn(
+                    "px-2 py-0.5 text-[10px] capitalize transition-colors",
+                    filter === value ? "bg-accent text-accent-foreground" : "text-muted-foreground hover:bg-muted/50",
+                  )}
+                >
+                  {value}
+                </button>
+              ))}
+            </div>
+            <Button
+              variant="ghost"
+              size="icon"
+              className="size-6"
+              title="Refresh"
+              onClick={() => {
+                void refreshTasks().catch((error: unknown) => {
+                  setActionError(error instanceof Error ? error.message : String(error));
+                });
+              }}
+            >
+              <IconRefresh className="size-3.5" />
+            </Button>
+            <Button variant="ghost" size="icon" className="size-6" onClick={() => setBrowserOpen(false)}>
+              <IconX className="size-3.5" />
+            </Button>
+          </div>
+        </div>
+        <div className="flex-1 overflow-y-auto">
+          <div className="max-w-2xl mx-auto px-3 py-3 space-y-1.5">
+            {actionError && (
+              <div className="rounded border border-destructive/30 bg-destructive/5 px-2.5 py-2 text-xs text-destructive">
+                {actionError}
+              </div>
+            )}
+            {sorted.map((task) => (
+              <TaskItem key={task.taskId} task={task} onStop={setStopTarget} />
+            ))}
+            {sorted.length === 0 && (
+              <div className="py-6 text-center">
+                <IconTerminal2 className="size-6 mx-auto text-muted-foreground/30 mb-1" />
+                <p className="text-xs text-muted-foreground">
+                  {filter === "active" ? "No running background tasks" : "No background tasks"}
+                </p>
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+
+      <AlertDialog open={stopTarget !== null} onOpenChange={(open) => !open && setStopTarget(null)}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Stop Background Task?</AlertDialogTitle>
+            <AlertDialogDescription>
+              This will stop "{stopTarget}". The process is asked to terminate gracefully first.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={isStopping}>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={() => { void handleStop(); }}
+              disabled={isStopping}
+              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+            >
+              {isStopping ? "Stopping..." : "Stop"}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </>
+  );
+}

--- a/apps/vscode/webview-ui/src/services/bridge.ts
+++ b/apps/vscode/webview-ui/src/services/bridge.ts
@@ -1,6 +1,7 @@
 import { Methods, Events } from "shared/bridge";
 import type {
   ApprovalResponse,
+  BackgroundTaskInfo,
   ContentPart,
   MCPServerConfig,
   SessionInfo,
@@ -293,6 +294,18 @@ class Bridge {
 
   reloadWebview() {
     return this.call<{ ok: boolean }>(Methods.ReloadWebview);
+  }
+
+  listBackgroundTasks() {
+    return this.call<BackgroundTaskInfo[]>(Methods.ListBackgroundTasks);
+  }
+
+  getBackgroundTaskOutput(taskId: string, tail?: number) {
+    return this.call<{ output: string }>(Methods.GetBackgroundTaskOutput, { taskId, tail });
+  }
+
+  stopBackgroundTask(taskId: string) {
+    return this.call<{ ok: boolean }>(Methods.StopBackgroundTask, { taskId });
   }
 }
 

--- a/apps/vscode/webview-ui/src/services/bridge.ts
+++ b/apps/vscode/webview-ui/src/services/bridge.ts
@@ -1,7 +1,6 @@
 import { Methods, Events } from "shared/bridge";
 import type {
   ApprovalResponse,
-  BackgroundTaskInfo,
   ContentPart,
   MCPServerConfig,
   SessionInfo,
@@ -12,6 +11,7 @@ import type {
 } from "shared/legacy-sdk";
 import type {
   FileChange,
+  BackgroundTasksChangedPayload,
   SessionConfig,
   ExtensionConfig,
   WorkspaceStatus,
@@ -297,7 +297,7 @@ class Bridge {
   }
 
   listBackgroundTasks() {
-    return this.call<BackgroundTaskInfo[]>(Methods.ListBackgroundTasks);
+    return this.call<BackgroundTasksChangedPayload>(Methods.ListBackgroundTasks);
   }
 
   getBackgroundTaskOutput(taskId: string, tail?: number) {

--- a/apps/vscode/webview-ui/src/stores/chat.store.ts
+++ b/apps/vscode/webview-ui/src/stores/chat.store.ts
@@ -108,6 +108,7 @@ export interface ChatState {
   retryLastMessage: () => void;
   processEvent: (event: UIStreamEvent) => void;
   loadSession: (sessionId: string, events: UIStreamEvent[]) => Promise<void>;
+  restoreSession: (sessionId: string, prepare?: () => Promise<void>) => Promise<boolean>;
   startNewConversation: () => Promise<void>;
   abort: () => void;
   addDraftMedia: (id: string, dataUri?: string) => void;
@@ -127,6 +128,8 @@ export interface ChatState {
 }
 
 let handshakeTimer: ReturnType<typeof setTimeout> | null = null;
+let restoreSequence = 0;
+let restoreQueue = Promise.resolve();
 
 function clearHandshakeTimer() {
   if (handshakeTimer) {
@@ -267,6 +270,10 @@ export const useChatStore = create<ChatState>((set, get) => ({
       clearHandshakeTimer();
     }
 
+    if (event.type === "session_start" && "sessionId" in event && event.sessionId) {
+      useTasksStore.getState().setSession(event.sessionId);
+    }
+
     set(
       produce((draft: ChatState) => {
         processEvent(draft, event);
@@ -291,6 +298,7 @@ export const useChatStore = create<ChatState>((set, get) => ({
       await bridge.abortChat();
     }
 
+    useTasksStore.getState().setSession(sessionId);
     set({
       sessionId,
       messages: [],
@@ -334,8 +342,36 @@ export const useChatStore = create<ChatState>((set, get) => ({
     useApprovalStore.getState().clearRequests();
   },
 
+  restoreSession: (sessionId, prepare) => {
+    const sequence = ++restoreSequence;
+    const committedSessionId = get().sessionId;
+    useTasksStore.getState().setSession(sessionId);
+
+    const restore = restoreQueue.then(async () => {
+      try {
+        if (sequence !== restoreSequence) return false;
+        await prepare?.();
+        if (sequence !== restoreSequence) return false;
+        const events = await bridge.loadSessionHistory(sessionId);
+        if (sequence !== restoreSequence) return false;
+        await get().loadSession(sessionId, events);
+        return true;
+      } catch (error) {
+        if (sequence !== restoreSequence) return false;
+        const tasksStore = useTasksStore.getState();
+        tasksStore.setSession(committedSessionId);
+        await tasksStore.refreshTasks().catch(() => undefined);
+        if (sequence !== restoreSequence) return false;
+        throw error;
+      }
+    });
+    restoreQueue = restore.then(() => undefined, () => undefined);
+    return restore;
+  },
+
   startNewConversation: async () => {
     clearHandshakeTimer();
+    restoreSequence += 1;
 
     // Abort any ongoing stream before starting new conversation
     const { isStreaming: wasStreaming } = get();
@@ -361,7 +397,7 @@ export const useChatStore = create<ChatState>((set, get) => ({
       planMode: false,
     });
     useApprovalStore.getState().clearRequests();
-    useTasksStore.getState().setTasks([]);
+    useTasksStore.getState().setSession(null);
   },
 
   abort: () => {

--- a/apps/vscode/webview-ui/src/stores/chat.store.ts
+++ b/apps/vscode/webview-ui/src/stores/chat.store.ts
@@ -307,7 +307,6 @@ export const useChatStore = create<ChatState>((set, get) => ({
       planMode: false,
     });
     useApprovalStore.getState().clearRequests();
-    useTasksStore.getState().setTasks([]);
 
     for (const event of events) {
       get().processEvent(event);

--- a/apps/vscode/webview-ui/src/stores/chat.store.ts
+++ b/apps/vscode/webview-ui/src/stores/chat.store.ts
@@ -3,11 +3,12 @@ import { produce } from "immer";
 import { bridge } from "@/services";
 import { Content } from "@/lib/content";
 import { useApprovalStore } from "./approval.store";
+import { useTasksStore } from "./tasks.store";
 import { toast } from "@/components/ui/sonner";
 
 import { useSettingsStore } from "./settings.store";
 import { processEvent } from "./event-handlers";
-import type { StatusUpdate, ContentPart, QuestionRequest, ToolResult } from "shared/legacy-sdk";
+import type { StatusUpdate, ContentPart, QuestionRequest, ToolResult, BackgroundTaskInfo } from "shared/legacy-sdk";
 import type { UIStreamEvent } from "shared/types";
 
 const HANDSHAKE_TIMEOUT_MS = 30_000;
@@ -35,6 +36,7 @@ export type UIStepItem =
   | { type: "text"; content: string; finished?: boolean }
   | { type: "compaction" }
   | { type: "steer"; content: string | ContentPart[] }
+  | { type: "background_task"; info: BackgroundTaskInfo }
   | {
       type: "tool_use";
       id: string;
@@ -305,6 +307,7 @@ export const useChatStore = create<ChatState>((set, get) => ({
       planMode: false,
     });
     useApprovalStore.getState().clearRequests();
+    useTasksStore.getState().setTasks([]);
 
     for (const event of events) {
       get().processEvent(event);
@@ -359,6 +362,7 @@ export const useChatStore = create<ChatState>((set, get) => ({
       planMode: false,
     });
     useApprovalStore.getState().clearRequests();
+    useTasksStore.getState().setTasks([]);
   },
 
   abort: () => {

--- a/apps/vscode/webview-ui/src/stores/event-handlers.ts
+++ b/apps/vscode/webview-ui/src/stores/event-handlers.ts
@@ -3,7 +3,7 @@ import { useApprovalStore } from "./approval.store";
 import { useSettingsStore } from "./settings.store";
 import { isPreflightError, isUserInterrupt } from "shared/errors";
 import type { ChatMessage, UIStep, UIStepItem, ChatState, TokenUsage } from "./chat.store";
-import type { ContentPart, ToolCall, ToolResult, TurnBegin, SubagentEvent, ApprovalRequestPayload, DiffBlock, RunResult, QuestionRequest } from "shared/legacy-sdk";
+import type { ContentPart, ToolCall, ToolResult, TurnBegin, SubagentEvent, ApprovalRequestPayload, BackgroundTaskInfo, DiffBlock, RunResult, QuestionRequest } from "shared/legacy-sdk";
 import type { UIStreamEvent, StreamError } from "shared/types";
 
 type EventHandler = (draft: ChatState, payload: any) => void;
@@ -564,6 +564,28 @@ const eventHandlers: Record<string, EventHandler> = {
 
     finishAllTextItems(last.steps);
     currentStep.items.push({ type: "steer", content: payload.user_input });
+  },
+
+  BackgroundTaskStatus: (draft, payload: { info: BackgroundTaskInfo }) => {
+    // Task lifecycle events have no StepBegin/StepEnd framing, so append a
+    // fresh step to the last assistant message (or a synthetic one when the
+    // transcript is still empty) instead of guessing at engine step ownership.
+    let last = getLastAssistant(draft);
+    if (!last) {
+      last = {
+        id: crypto.randomUUID(),
+        role: "assistant",
+        content: "",
+        timestamp: Date.now(),
+        steps: [],
+      };
+      draft.messages.push(last);
+    }
+    if (!last.steps) {
+      last.steps = [];
+    }
+    const nextStepNumber = (last.steps.at(-1)?.n ?? 0) + 1;
+    last.steps.push({ n: nextStepNumber, items: [{ type: "background_task", info: payload.info }] });
   },
 };
 

--- a/apps/vscode/webview-ui/src/stores/index.ts
+++ b/apps/vscode/webview-ui/src/stores/index.ts
@@ -18,3 +18,5 @@ export type { MediaRequirements, ModelProviderGroup } from "./settings.store";
 
 export { useApprovalStore } from "./approval.store";
 export type { ApprovalRequest } from "./approval.store";
+
+export { useTasksStore, visibleBackgroundTasks, runningTaskCount } from "./tasks.store";

--- a/apps/vscode/webview-ui/src/stores/tasks.store.ts
+++ b/apps/vscode/webview-ui/src/stores/tasks.store.ts
@@ -1,0 +1,38 @@
+import { create } from "zustand";
+import type { BackgroundTaskInfo } from "shared/legacy-sdk";
+import { bridge } from "@/services";
+
+interface TasksState {
+  tasks: BackgroundTaskInfo[];
+  browserOpen: boolean;
+  setTasks: (tasks: BackgroundTaskInfo[]) => void;
+  setBrowserOpen: (open: boolean) => void;
+  refreshTasks: () => Promise<void>;
+}
+
+export const useTasksStore = create<TasksState>((set) => ({
+  tasks: [],
+  browserOpen: false,
+
+  setTasks: (tasks) => {
+    set({ tasks });
+  },
+
+  setBrowserOpen: (open) => {
+    set({ browserOpen: open });
+  },
+
+  refreshTasks: async () => {
+    const tasks = await bridge.listBackgroundTasks();
+    set({ tasks });
+  },
+}));
+
+/** Foreground tool calls (`detached === false`) are not user-facing background tasks. */
+export function visibleBackgroundTasks(tasks: BackgroundTaskInfo[]): BackgroundTaskInfo[] {
+  return tasks.filter((task) => task.detached !== false);
+}
+
+export function runningTaskCount(tasks: BackgroundTaskInfo[]): number {
+  return tasks.filter((task) => task.status === "running").length;
+}

--- a/apps/vscode/webview-ui/src/stores/tasks.store.ts
+++ b/apps/vscode/webview-ui/src/stores/tasks.store.ts
@@ -1,21 +1,37 @@
 import { create } from "zustand";
 import type { BackgroundTaskInfo } from "shared/legacy-sdk";
+import type { BackgroundTasksChangedPayload } from "shared/types";
 import { bridge } from "@/services";
 
 interface TasksState {
+  sessionId: string | null;
   tasks: BackgroundTaskInfo[];
   browserOpen: boolean;
-  setTasks: (tasks: BackgroundTaskInfo[]) => void;
+  updateVersion: number;
+  setSession: (sessionId: string | null) => void;
+  applySnapshot: (payload: BackgroundTasksChangedPayload) => void;
   setBrowserOpen: (open: boolean) => void;
   refreshTasks: () => Promise<void>;
 }
 
-export const useTasksStore = create<TasksState>((set) => ({
+export const useTasksStore = create<TasksState>((set, get) => ({
+  sessionId: null,
   tasks: [],
   browserOpen: false,
+  updateVersion: 0,
 
-  setTasks: (tasks) => {
-    set({ tasks });
+  setSession: (sessionId) => {
+    set((state) => {
+      if (state.sessionId === sessionId) return state;
+      return { sessionId, tasks: [], updateVersion: state.updateVersion + 1 };
+    });
+  },
+
+  applySnapshot: (payload) => {
+    set((state) => {
+      if (state.sessionId !== payload.sessionId) return state;
+      return { tasks: payload.tasks, updateVersion: state.updateVersion + 1 };
+    });
   },
 
   setBrowserOpen: (open) => {
@@ -23,8 +39,17 @@ export const useTasksStore = create<TasksState>((set) => ({
   },
 
   refreshTasks: async () => {
-    const tasks = await bridge.listBackgroundTasks();
-    set({ tasks });
+    const { sessionId, updateVersion } = get();
+    if (sessionId === null) return;
+    const snapshot = await bridge.listBackgroundTasks();
+    set((state) => {
+      if (
+        state.sessionId !== sessionId
+        || snapshot.sessionId !== sessionId
+        || state.updateVersion !== updateVersion
+      ) return state;
+      return { tasks: snapshot.tasks, updateVersion: state.updateVersion + 1 };
+    });
   },
 }));
 

--- a/apps/vscode/webview-ui/tsconfig.json
+++ b/apps/vscode/webview-ui/tsconfig.json
@@ -20,5 +20,5 @@
       "shared/*": ["../shared/*"]
     }
   },
-  "include": ["src", "../test/settings-store.test.ts", "../test/app-init.test.ts"]
+  "include": ["src", "../test/settings-store.test.ts", "../test/app-init.test.ts", "../test/background-tasks-ui.test.ts"]
 }


### PR DESCRIPTION
## Related Issue

No related issue. The problem is described below.

## Problem

Kimi Code for VS Code can run background processes, subagents, and question tasks through the shared engine, but the extension does not expose their status or controls. Users cannot see that work is still running, inspect its output, stop it, or recover terminal task status when reopening a session.

## What changed

- Add extension-host bridge methods for listing tasks, reading output, and stopping a task, plus lifecycle broadcasts backed by the public Node SDK session surface.
- Show task lifecycle cards in the transcript, deduplicate repeated terminal events, and restore terminal cards and current task state when session history is loaded.
- Add a Tasks badge above the composer and a fullscreen All/Active task browser with live output polling and stop confirmation. Foreground tasks remain hidden until detached, matching the TUI behavior.
- Add runtime and RPC boundary coverage, document the feature in the extension README, and include a minor changeset for the VS Code package.

## Verification

- `pnpm --filter kimi-code test` (330 tests)
- `pnpm --filter kimi-code typecheck`
- `pnpm --filter kimi-code build:webview`
- `pnpm lint` (0 errors)
- `pnpm --filter kimi-code package:platform -- --target darwin-arm64` (VSIX package/static audit passed)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.