### PR TITLE
fix(acp): stream scheduled turn activity

### DIFF
--- a/.changeset/bright-crons-stream.md
+++ b/.changeset/bright-crons-stream.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Stream scheduled task activity to ACP clients while interactive prompts wait.

--- a/docs/en/reference/kimi-acp.md
+++ b/docs/en/reference/kimi-acp.md
@@ -53,7 +53,7 @@ The spec divides methods into a **stable** surface and an evolving **unstable** 
 
 | Method | Implemented | Description |
 | --- | --- | --- |
-| `session/update` | Yes | Streams `agent_message_chunk` / `tool_call*` / `plan` / `config_option_update` / `available_commands_update` |
+| `session/update` | Yes | Streams turn activity for both client prompts and scheduled cron tasks, plus `config_option_update` / `available_commands_update` |
 | `session/request_permission` | Yes | Shared channel for tool approval and question elicitation |
 | `fs/read_text_file` | Yes | File reads at the kaos layer are routed to the client (advertised via `fsCapabilities`) |
 | `fs/write_text_file` | Yes | File writes at the kaos layer are routed to the client |

--- a/docs/zh/reference/kimi-acp.md
+++ b/docs/zh/reference/kimi-acp.md
@@ -53,7 +53,7 @@ kimi acp
 
 | 方法 | 状态 | 说明 |
 | --- | --- | --- |
-| `session/update` | 是 | 流式推送 `agent_message_chunk` / `tool_call*` / `plan` / `config_option_update` / `available_commands_update` |
+| `session/update` | 是 | 流式推送客户端 prompt 与定时 cron 任务的 turn 活动，以及 `config_option_update` / `available_commands_update` |
 | `session/request_permission` | 是 | 工具审批和问题 elicitation 共用此通道 |
 | `fs/read_text_file` | 是 | kaos 层文件读取路由到客户端（通过 `fsCapabilities` 公告） |
 | `fs/write_text_file` | 是 | kaos 层文件写入路由到客户端 |

--- a/packages/acp-server/src/session.ts
+++ b/packages/acp-server/src/session.ts
@@ -103,6 +103,16 @@ function leadingText(blocks: readonly ContentBlock[]): string | undefined {
  */
 const TURN_AGENT_BUSY_CODE = 'turn.agent_busy';
 
+/** Whether a turn was started by the session cron scheduler. */
+function isScheduledTurnOrigin(origin: unknown): boolean {
+  return (
+    typeof origin === 'object' &&
+    origin !== null &&
+    'kind' in origin &&
+    origin.kind === 'cron_job'
+  );
+}
+
 /**
  * Map a prompt-launch rejection (from `agent.prompt` / `agent.activateSkill`)
  * to the JSON-RPC error the client sees.
@@ -194,6 +204,8 @@ export class AcpSession {
   private skills: readonly SkillSummary[] = [];
   /** The in-flight prompt's driver, if any. */
   private driver: TurnDriver | undefined;
+  /** Cron turns whose output must remain visible even without an ACP prompt driver. */
+  private readonly scheduledTurnIds = new Set<number>();
   /**
    * Abort markers of prompts still in their pre-turn image-compression phase
    * (no turn launched yet, so `agent.cancel` has nothing to cancel).
@@ -275,6 +287,11 @@ export class AcpSession {
   async init(): Promise<void> {
     const events = this.agent.events;
     this.subscriptions.push(
+      events.on('turn.started', (event) => {
+        if (isScheduledTurnOrigin(event.origin)) {
+          this.scheduledTurnIds.add(event.turnId);
+        }
+      }),
       events.on('assistant.delta', (event) => {
         this.dispatchTurnEvent(event.turnId, () => {
           this.onAssistantDelta(event);
@@ -393,6 +410,7 @@ export class AcpSession {
     for (const subscription of this.subscriptions.splice(0)) {
       subscription.dispose();
     }
+    this.scheduledTurnIds.clear();
   }
 
   /**
@@ -706,6 +724,13 @@ export class AcpSession {
    * is still unknown (see {@link TurnDriver.early}), otherwise dispatch live.
    */
   private dispatchTurnEvent(turnId: number, dispatch: () => void): void {
+    // A prompt submitted while a cron turn is running waits for that turn's
+    // launch slot. Its driver therefore has no turn id yet; do not buffer and
+    // later discard the scheduled turn's activity behind that pending driver.
+    if (this.scheduledTurnIds.has(turnId)) {
+      dispatch();
+      return;
+    }
     const driver = this.driver;
     if (driver !== undefined && !driver.settled && driver.turnId === undefined) {
       driver.early.push({ turnId, dispatch });
@@ -734,18 +759,23 @@ export class AcpSession {
     return driver;
   }
 
+  /** Whether this ACP session should stream events from the given turn. */
+  private followsTurn(turnId: number): boolean {
+    return this.driverFor(turnId) !== undefined || this.scheduledTurnIds.has(turnId);
+  }
+
   private onAssistantDelta(event: AgentEventPayloads['assistant.delta']): void {
-    if (this.driverFor(event.turnId) === undefined) return;
+    if (!this.followsTurn(event.turnId)) return;
     this.emit(assistantDeltaToSessionUpdate(this.sessionId, event));
   }
 
   private onThinkingDelta(event: AgentEventPayloads['thinking.delta']): void {
-    if (this.driverFor(event.turnId) === undefined) return;
+    if (!this.followsTurn(event.turnId)) return;
     this.emit(thinkingDeltaToSessionUpdate(this.sessionId, event));
   }
 
   private onToolCallStarted(event: AgentEventPayloads['tool.call.started']): void {
-    if (this.driverFor(event.turnId) === undefined) return;
+    if (!this.followsTurn(event.turnId)) return;
     // The klient payload mirrors `ToolCallStartedEvent` (`args` / `display`
     // arrive as `unknown` — cast at this seam).
     const mapped = event as unknown as ToolCallStartedEvent;
@@ -787,7 +817,7 @@ export class AcpSession {
   }
 
   private onToolCallDelta(event: AgentEventPayloads['tool.call.delta']): void {
-    if (this.driverFor(event.turnId) === undefined) return;
+    if (!this.followsTurn(event.turnId)) return;
     // The klient payload mirrors `ToolCallDeltaEvent` field-for-field.
     const mapped = event as unknown as ToolCallDeltaEvent;
     const key = acpToolCallId(event.turnId, event.toolCallId);
@@ -809,7 +839,7 @@ export class AcpSession {
   }
 
   private onToolProgress(event: AgentEventPayloads['tool.progress']): void {
-    if (this.driverFor(event.turnId) === undefined) return;
+    if (!this.followsTurn(event.turnId)) return;
     // The klient payload mirrors `ToolProgressEvent` field-for-field; the
     // helper forwards only `status` updates with text (as a title refresh)
     // and returns null for everything else, which `emit` drops.
@@ -817,7 +847,7 @@ export class AcpSession {
   }
 
   private onToolResult(event: AgentEventPayloads['tool.result']): void {
-    if (this.driverFor(event.turnId) === undefined) return;
+    if (!this.followsTurn(event.turnId)) return;
     const key = acpToolCallId(event.turnId, event.toolCallId);
     const locations = this.toolLocations.get(key);
     this.toolLocations.delete(key);
@@ -905,8 +935,12 @@ export class AcpSession {
   }
 
   private onTurnEnded(event: AgentEventPayloads['turn.ended']): void {
+    const scheduled = this.scheduledTurnIds.delete(event.turnId);
     const driver = this.driverFor(event.turnId);
-    if (driver === undefined) return;
+    if (driver === undefined) {
+      if (scheduled) void this.emitUsageUpdate();
+      return;
+    }
     const error = event.error as { readonly code: string; readonly message?: string } | undefined;
     this.settleDriver(driver, () => {
       // Auth failures must surface as a JSON-RPC `auth_required` error

--- a/packages/acp-server/src/session.ts
+++ b/packages/acp-server/src/session.ts
@@ -1022,17 +1022,22 @@ export class AcpSession {
       // The launch round-trip has not returned the turn id yet. The engine's
       // cancel payload makes turnId optional — an empty call cancels whatever
       // turn is active (the same contract kap-server's cancel route relies
-      // on) — and concurrent prompts are rejected, so the active turn can only
-      // be this driver's. Flag the driver too: when the id lands, the launch
-      // handler re-issues a precisely-addressed cancel, and a no-launch
-      // outcome settles `cancelled` instead of `end_turn`.
+      // on). A tracked scheduled turn may still be active while this prompt's
+      // turn is queued, so an unaddressed cancel would terminate the scheduled
+      // work instead. In that case only flag the driver and wait for its id;
+      // otherwise keep the immediate best-effort cancel for a prompt turn that
+      // started before its launch response arrived. The launch handler always
+      // re-issues a precisely-addressed cancel once the id lands, and a
+      // no-launch outcome settles `cancelled` instead of `end_turn`.
       driver.cancelRequested = true;
-      void this.agent.cancel().catch((error) => {
-        log.warn('acp: cancel (unaddressed) failed', {
-          sessionId: this.sessionId,
-          error: error instanceof Error ? error.message : String(error),
+      if (this.scheduledTurnIds.size === 0) {
+        void this.agent.cancel().catch((error) => {
+          log.warn('acp: cancel (unaddressed) failed', {
+            sessionId: this.sessionId,
+            error: error instanceof Error ? error.message : String(error),
+          });
         });
-      });
+      }
       return;
     }
     void this.agent.cancel({ turnId }).catch((error) => {

--- a/packages/acp-server/test/e2e-turn.test.ts
+++ b/packages/acp-server/test/e2e-turn.test.ts
@@ -18,9 +18,9 @@ import { getLiveSessionById, IAgentLifecycleService, IEventBus } from '@moonshot
 import { IAgentLoopService } from '@moonshot-ai/agent-core-v2/agent/loop/loop';
 import { IAgentPromptService } from '@moonshot-ai/agent-core-v2/agent/prompt/prompt';
 import { ToolProgress } from '@moonshot-ai/agent-core-v2/agent/toolExecutor/toolExecutorEvents';
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
-import { mapPromptLaunchError } from '../src/session';
+import { AcpSession, mapPromptLaunchError } from '../src/session';
 import { createTestClient, type TestClient } from './_helpers/acpClient';
 import { writeFakeModelConfig } from './_helpers/fakeModelConfig';
 import { solidPngBase64 } from './_helpers/png';
@@ -368,6 +368,79 @@ describe('acp-server real prompt turn (scripted LLM)', () => {
     expect(chunks).toContain('scheduled turn finished');
     expect(chunks).toContain('queued prompt answered');
   }, 30_000);
+
+  it('does not cancel an active scheduled turn while a queued prompt awaits its turn id', async () => {
+    const createEvents = () => {
+      const listeners = new Map<string, Set<(event: unknown) => void>>();
+      return {
+        on(name: string, listener: (event: unknown) => void) {
+          const registered = listeners.get(name) ?? new Set<(event: unknown) => void>();
+          registered.add(listener);
+          listeners.set(name, registered);
+          return { dispose: () => registered.delete(listener) };
+        },
+        emit(name: string, event: unknown) {
+          for (const listener of listeners.get(name) ?? []) listener(event);
+        },
+      };
+    };
+    const agentEvents = createEvents();
+    const sessionEvents = createEvents();
+    let resolveLaunch: ((result: { turn_id: number } | undefined) => void) | undefined;
+    const launch = new Promise<{ turn_id: number } | undefined>((resolve) => {
+      resolveLaunch = resolve;
+    });
+    const cancel = vi.fn(async (_payload?: { turnId?: number }) => undefined);
+    const agent = {
+      events: agentEvents,
+      getModel: async () => '',
+      getThinking: async () => 'off',
+      getContext: async () => ({ history: [], tokenCount: 0 }),
+      prompt: vi.fn(() => launch),
+      cancel,
+    };
+    const sessionHandle = {
+      agent: () => agent,
+      events: sessionEvents,
+      skills: { list: async () => [] },
+      interactions: { list: async () => [], respond: async () => undefined },
+      get: async () => ({}),
+    };
+    const klient = {
+      session: () => sessionHandle,
+      global: { kosong: { listModels: async () => [] } },
+    };
+    const conn = { sessionUpdate: async () => undefined };
+    const acpConnection = { onTerminalCreated: () => () => undefined };
+    const acpSession = new AcpSession(
+      conn as unknown as ConstructorParameters<typeof AcpSession>[0],
+      klient as unknown as ConstructorParameters<typeof AcpSession>[1],
+      'scheduled-cancel-safety',
+      acpConnection as unknown as ConstructorParameters<typeof AcpSession>[3],
+      false,
+    );
+    await acpSession.init();
+    agentEvents.emit('turn.started', { turnId: 41, origin: { kind: 'cron_job' } });
+    const prompt = acpSession.prompt([{ type: 'text', text: 'status?' }]);
+    for (let attempt = 0; attempt < 10 && agent.prompt.mock.calls.length === 0; attempt += 1) {
+      await Promise.resolve();
+    }
+    expect(agent.prompt).toHaveBeenCalledOnce();
+
+    acpSession.cancel();
+    expect(cancel).not.toHaveBeenCalled();
+
+    resolveLaunch!({ turn_id: 42 });
+    for (let attempt = 0; attempt < 10 && cancel.mock.calls.length === 0; attempt += 1) {
+      await Promise.resolve();
+    }
+    expect(cancel).toHaveBeenCalledOnce();
+    expect(cancel).toHaveBeenCalledWith({ turnId: 42 });
+
+    agentEvents.emit('turn.ended', { turnId: 42, reason: 'cancelled' });
+    await expect(prompt).resolves.toEqual({ stopReason: 'cancelled' });
+    acpSession.dispose();
+  });
 
   it('settles as cancelled when cancel arrives while the launch is in flight', async () => {
     const c = await boot();

--- a/packages/acp-server/test/e2e-turn.test.ts
+++ b/packages/acp-server/test/e2e-turn.test.ts
@@ -15,6 +15,9 @@ import { join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 import { getLiveSessionById, IAgentLifecycleService, IEventBus } from '@moonshot-ai/agent-core-v2';
+import { IAgentPromptService } from '@moonshot-ai/agent-core-v2/agent/prompt/prompt';
+import { promptLaunchingKey } from '@moonshot-ai/agent-core-v2/agent/prompt/promptService';
+import { IAgentStateService } from '@moonshot-ai/agent-core-v2/agent/state/agentState';
 import { ToolProgress } from '@moonshot-ai/agent-core-v2/agent/toolExecutor/toolExecutorEvents';
 import { afterEach, describe, expect, it } from 'vitest';
 
@@ -290,6 +293,80 @@ describe('acp-server real prompt turn (scripted LLM)', () => {
     const result = (await firstPrompt) as { stopReason: string };
     expect(result.stopReason).toBe('end_turn');
     expect(scripted!.callCount()).toBe(2);
+  }, 30_000);
+
+  it('streams a scheduled turn while an ACP prompt waits behind it', async () => {
+    const c = await boot();
+    scripted!.mockNextResponse({
+      type: 'function',
+      id: 'call_cron',
+      name: 'Bash',
+      arguments: '{"command":"echo scheduled_turn"}',
+    });
+    scripted!.mockNextText('scheduled turn finished');
+    scripted!.mockNextText('queued prompt answered');
+
+    let answerPermission: ((response: unknown) => void) | undefined;
+    const permissionSeen = new Promise<void>((seen) => {
+      c.onRequest('session/request_permission', () => {
+        seen();
+        return new Promise((resolve) => {
+          answerPermission = resolve;
+        });
+      });
+    });
+
+    const created = (await c.send('session/new', { cwd: homeDir, mcpServers: [] })) as {
+      sessionId: string;
+    };
+    await c.waitForSessionUpdate('available_commands_update', 10_000);
+
+    const session = getLiveSessionById(c.server.core.accessor, created.sessionId);
+    const agentHandle = session?.accessor.get(IAgentLifecycleService).get('main');
+    const prompts = agentHandle?.accessor.get(IAgentPromptService);
+    const states = agentHandle?.accessor.get(IAgentStateService);
+    expect(prompts).toBeDefined();
+    expect(states).toBeDefined();
+
+    const scheduled = await prompts!.inject({
+      role: 'user',
+      content: [{ type: 'text', text: 'run the scheduled task' }],
+      toolCalls: [],
+      origin: {
+        kind: 'cron_job',
+        jobId: 'scheduled-visibility',
+        cron: '* * * * *',
+        recurring: true,
+        coalescedCount: 1,
+        stale: false,
+      },
+    });
+    expect(scheduled).toBeDefined();
+    await permissionSeen;
+
+    const queuedPrompt = c.send('session/prompt', {
+      sessionId: created.sessionId,
+      prompt: [{ type: 'text', text: 'status?' }],
+    });
+    for (let attempt = 0; attempt < 100 && !states!.get(promptLaunchingKey); attempt++) {
+      await new Promise((resolve) => setTimeout(resolve, 10));
+    }
+    const promptWaitedForTheScheduledTurn = states!.get(promptLaunchingKey);
+    answerPermission!({ outcome: { outcome: 'selected', optionId: 'approve_once' } });
+    expect(promptWaitedForTheScheduledTurn).toBe(true);
+    const result = (await queuedPrompt) as { stopReason: string };
+    expect(result.stopReason).toBe('end_turn');
+
+    const chunks = c
+      .sessionUpdates()
+      .map((message) =>
+        (message.params as { update?: { sessionUpdate?: string; content?: { text?: string } } })
+          .update,
+      )
+      .filter((update) => update?.sessionUpdate === 'agent_message_chunk')
+      .map((update) => update?.content?.text);
+    expect(chunks).toContain('scheduled turn finished');
+    expect(chunks).toContain('queued prompt answered');
   }, 30_000);
 
   it('settles as cancelled when cancel arrives while the launch is in flight', async () => {

--- a/packages/acp-server/test/e2e-turn.test.ts
+++ b/packages/acp-server/test/e2e-turn.test.ts
@@ -15,9 +15,8 @@ import { join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 import { getLiveSessionById, IAgentLifecycleService, IEventBus } from '@moonshot-ai/agent-core-v2';
+import { IAgentLoopService } from '@moonshot-ai/agent-core-v2/agent/loop/loop';
 import { IAgentPromptService } from '@moonshot-ai/agent-core-v2/agent/prompt/prompt';
-import { promptLaunchingKey } from '@moonshot-ai/agent-core-v2/agent/prompt/promptService';
-import { IAgentStateService } from '@moonshot-ai/agent-core-v2/agent/state/agentState';
 import { ToolProgress } from '@moonshot-ai/agent-core-v2/agent/toolExecutor/toolExecutorEvents';
 import { afterEach, describe, expect, it } from 'vitest';
 
@@ -323,10 +322,10 @@ describe('acp-server real prompt turn (scripted LLM)', () => {
 
     const session = getLiveSessionById(c.server.core.accessor, created.sessionId);
     const agentHandle = session?.accessor.get(IAgentLifecycleService).get('main');
+    const loop = agentHandle?.accessor.get(IAgentLoopService);
     const prompts = agentHandle?.accessor.get(IAgentPromptService);
-    const states = agentHandle?.accessor.get(IAgentStateService);
+    expect(loop).toBeDefined();
     expect(prompts).toBeDefined();
-    expect(states).toBeDefined();
 
     const scheduled = await prompts!.inject({
       role: 'user',
@@ -348,12 +347,13 @@ describe('acp-server real prompt turn (scripted LLM)', () => {
       sessionId: created.sessionId,
       prompt: [{ type: 'text', text: 'status?' }],
     });
-    for (let attempt = 0; attempt < 100 && !states!.get(promptLaunchingKey); attempt++) {
+    for (let attempt = 0; attempt < 100 && loop!.status().pendingTurnIds.length === 0; attempt++) {
       await new Promise((resolve) => setTimeout(resolve, 10));
     }
-    const promptWaitedForTheScheduledTurn = states!.get(promptLaunchingKey);
+    const queuedStatus = loop!.status();
     answerPermission!({ outcome: { outcome: 'selected', optionId: 'approve_once' } });
-    expect(promptWaitedForTheScheduledTurn).toBe(true);
+    expect(queuedStatus.activeTurnId).toBe(scheduled!.id);
+    expect(queuedStatus.pendingTurnIds).toHaveLength(1);
     const result = (await queuedPrompt) as { stopReason: string };
     expect(result.stopReason).toBe('end_turn');
 


### PR DESCRIPTION
## Related Issue

Resolve #2991

## Problem

ACP only forwarded events from the turn owned by the active `session/prompt` request. A cron-triggered turn has no such request driver, so its assistant, thinking, and tool activity was discarded. When an interactive prompt waited behind that turn, the pending driver also buffered and later dropped the scheduled turn's remaining events.

## What changed

- Track cron-triggered turns from their `turn.started` origin and forward their normal ACP updates.
- Keep scheduled activity streaming while an interactive prompt waits for its own turn, then clean up tracking and publish usage when the scheduled turn ends.
- Keep cancellation of a queued ACP prompt scoped to that prompt instead of cancelling the active scheduled task.
- Add an end-to-end regression covering a scheduled turn with a queued ACP prompt, plus mirrored English and Chinese documentation.

## Verification

- The exact pre-fix implementation failed the scheduled-update assertion, while the current implementation passed it.
- The complete ACP server test suite, including queued-prompt cancellation safety, passed.
- The full workspace build and CLI bundle smoke check passed.
- ACP server type checking, changed-file type-aware linting, repository lint, package and workspace consistency checks, and the documentation build passed.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.
