### PR TITLE
fix(kap-server): deliver nested subagent lifecycle events

### DIFF
--- a/packages/kap-server/src/transport/ws/v1/sessionEventBroadcaster.ts
+++ b/packages/kap-server/src/transport/ws/v1/sessionEventBroadcaster.ts
@@ -1431,8 +1431,16 @@ function isGlobalEvent(type: string): boolean {
   );
 }
 
-function isAgentLifecycleEvent(type: string): boolean {
-  return type === 'agent.created' || type === 'agent.disposed';
+function isControlPlaneLifecycleEvent(type: string): boolean {
+  return (
+    type === 'agent.created' ||
+    type === 'agent.disposed' ||
+    type === 'subagent.spawned' ||
+    type === 'subagent.started' ||
+    type === 'subagent.suspended' ||
+    type === 'subagent.completed' ||
+    type === 'subagent.failed'
+  );
 }
 
 /**
@@ -1441,9 +1449,8 @@ function isAgentLifecycleEvent(type: string): boolean {
  * `filter`:
  *   - `filter === undefined` → receive every agent (legacy session-grained
  *     behavior);
- *   - global events (session/workspace/config) and agent lifecycle events
- *     (`agent.created` / `agent.disposed`) are not per-agent stream content
- *     and always pass;
+ *   - global events (session/workspace/config) and control-plane lifecycle
+ *     events are not per-agent stream content and always pass;
  *   - events without a string `agentId` (should not happen on the v1 wire,
  *     where the broadcaster stamps every event) pass defensively rather than
  *     being dropped;
@@ -1452,7 +1459,7 @@ function isAgentLifecycleEvent(type: string): boolean {
 function matchesAgentFilter(envelope: EventEnvelope, filter: AgentFilter): boolean {
   if (filter === undefined) return true;
   if (isGlobalEvent(envelope.type)) return true;
-  if (isAgentLifecycleEvent(envelope.type)) return true;
+  if (isControlPlaneLifecycleEvent(envelope.type)) return true;
   const payload = envelope.payload;
   const agentId =
     typeof payload === 'object' && payload !== null
@@ -1541,7 +1548,7 @@ const TRANSCRIPT_PROJECTED_EVENT_TYPES: ReadonlySet<string> = new Set([
  * the transcript stream:
  *   - `spec === undefined` → nothing is suppressed (legacy connections see
  *     every `session_event`);
- *   - global events and agent lifecycle events are never suppressed;
+ *   - global events and control-plane lifecycle events are never suppressed;
  *   - events without a string `agentId` pass defensively (same rule as the
  *     agent allowlist);
  *   - an 'off' grade for the emitting agent suppresses nothing;
@@ -1554,7 +1561,7 @@ function suppressedByTranscript(
 ): boolean {
   if (spec === undefined) return false;
   if (isGlobalEvent(envelope.type)) return false;
-  if (isAgentLifecycleEvent(envelope.type)) return false;
+  if (isControlPlaneLifecycleEvent(envelope.type)) return false;
   const payload = envelope.payload;
   const agentId =
     typeof payload === 'object' && payload !== null

--- a/packages/kap-server/test/sessionEventBroadcaster.test.ts
+++ b/packages/kap-server/test/sessionEventBroadcaster.test.ts
@@ -2141,6 +2141,110 @@ describe('SessionEventBroadcaster', () => {
       ops: Array<{ op: string }>;
     }
 
+    it('delivers nested subagent lifecycle events past the main-only agent filter while keeping child content filtered', async () => {
+      const lc = new FakeLifecycle();
+      lc.addAgent('main');
+      const requester = lc.addAgent('parent-agent');
+      lc.addAgent('nested-child');
+      sessions.set('s1', lc);
+      bc = makeBroadcasterWithTranscript();
+
+      const filtered = collectingTarget();
+      const graded = collectingTarget();
+      const legacy = collectingTarget();
+      await bc.subscribe('s1', filtered.target, new Set(['main']));
+      await bc.subscribe('s1', graded.target, new Set(['main']), { '*': 'delta' });
+      await bc.subscribe('s1', legacy.target);
+
+      requester.bus.emit(agentEvent('subagent.completed', { subagentId: 'nested-child' }));
+      requester.bus.emit(agentEvent('assistant.delta', { turnId: 1, delta: 'child content' }));
+      requester.bus.emit(
+        agentEvent('tool.result', { turnId: 1, toolCallId: 'tc-child', output: 'child result' }),
+      );
+      await bc.getCursor('s1');
+
+      const filteredTypes = filtered.envelopes.map((e) => e.type);
+      expect(filteredTypes).toContain('subagent.completed');
+      expect(filteredTypes).not.toContain('assistant.delta');
+      expect(filteredTypes).not.toContain('tool.result');
+      const filteredTerminal = filtered.envelopes.find((e) => e.type === 'subagent.completed');
+      expect(filteredTerminal?.payload).toMatchObject({
+        agentId: 'parent-agent',
+        subagentId: 'nested-child',
+      });
+
+      const gradedSessionTypes = graded.envelopes
+        .filter((e) => e.type !== 'transcript.reset' && e.type !== 'transcript.ops')
+        .map((e) => e.type);
+      expect(gradedSessionTypes).toContain('subagent.completed');
+      expect(gradedSessionTypes).not.toContain('assistant.delta');
+      expect(gradedSessionTypes).not.toContain('tool.result');
+      const gradedTerminal = graded.envelopes.find((e) => e.type === 'subagent.completed');
+      expect(gradedTerminal?.payload).toMatchObject({
+        agentId: 'parent-agent',
+        subagentId: 'nested-child',
+      });
+      expect(transcriptEnvelopes(graded.envelopes).length).toBeGreaterThan(0);
+
+      const legacyTypes = legacy.envelopes.map((e) => e.type);
+      expect(legacyTypes).toContain('subagent.completed');
+      expect(legacyTypes).toContain('assistant.delta');
+      expect(legacyTypes).toContain('tool.result');
+      const legacyTerminal = legacy.envelopes.find((e) => e.type === 'subagent.completed');
+      expect(legacyTerminal?.payload).toMatchObject({
+        agentId: 'parent-agent',
+        subagentId: 'nested-child',
+      });
+    });
+
+    it('replays nested subagent lifecycle events past the main-only agent filter while keeping child content filtered', async () => {
+      const lc = new FakeLifecycle();
+      lc.addAgent('main');
+      const requester = lc.addAgent('parent-agent');
+      lc.addAgent('nested-child');
+      sessions.set('s1', lc);
+      bc = makeBroadcasterWithTranscript();
+
+      await bc.subscribe('s1', collectingTarget().target);
+      requester.bus.emit(agentEvent('subagent.completed', { subagentId: 'nested-child' }));
+      requester.bus.emit(agentEvent('assistant.delta', { turnId: 1, delta: 'child content' }));
+      requester.bus.emit(
+        agentEvent('tool.result', { turnId: 1, toolCallId: 'tc-child', output: 'child result' }),
+      );
+      await bc.getCursor('s1');
+
+      const filtered = await bc.getBufferedSince('s1', { seq: 0 }, new Set(['main']), {
+        '*': 'delta',
+      });
+      expect(filtered.resyncRequired).toBe(false);
+      const filteredTypes = filtered.events.map((e) => e.envelope.type);
+      expect(filteredTypes).toContain('subagent.completed');
+      expect(filteredTypes).not.toContain('assistant.delta');
+      expect(filteredTypes).not.toContain('tool.result');
+      const filteredTerminal = filtered.events.find((e) => e.envelope.type === 'subagent.completed');
+      expect(filteredTerminal?.envelope.payload).toMatchObject({
+        agentId: 'parent-agent',
+        subagentId: 'nested-child',
+      });
+
+      const legacy = await bc.getBufferedSince('s1', { seq: 0 });
+      expect(legacy.resyncRequired).toBe(false);
+      const legacyTypes = legacy.events.map((e) => e.envelope.type);
+      expect(legacyTypes).toContain('subagent.completed');
+      expect(legacyTypes).toContain('tool.result');
+      const legacyTerminal = legacy.events.find((e) => e.envelope.type === 'subagent.completed');
+      expect(legacyTerminal?.envelope.payload).toMatchObject({
+        agentId: 'parent-agent',
+        subagentId: 'nested-child',
+      });
+      const legacyToolResult = legacy.events.find((e) => e.envelope.type === 'tool.result');
+      expect(legacyToolResult?.envelope.payload).toMatchObject({
+        agentId: 'parent-agent',
+        toolCallId: 'tc-child',
+        output: 'child result',
+      });
+    });
+
     it('sends transcript.reset on first subscription, then fans ops out filtered per grade', async () => {
       const lc = new FakeLifecycle();
       const main = lc.addAgent('main');


### PR DESCRIPTION
## Related Issue

Resolve #2992

https://github.com/MoonshotAI/kimi-code/issues/2992

## Problem

Nested requester-owned terminal lifecycle events were cropped by the main-only `agent_filter`, leaving snapshot-seeded cards running.

## What changed

Introduced one shared session control-plane lifecycle predicate for live filtering, replay, and transcript suppression.

Guardrails:
- Ordinary child content remains filtered.
- No payload/schema/REST/config/docs/Web bundle changes.

Verification:
- RED live/replay failures reproduced before the fix.
- Focused GREEN live/replay checks passed after the fix.
- Broadcaster 83/83 passed.
- Adjacent 110/110 passed.
- kap-server typecheck/build passed.
- Five-lane review pass completed.
- `git diff --check` passed.
- No changeset/docs updates required by the already-recorded gen-changesets/gen-docs decisions.

Browser limitation:
- Deterministic merge gate passed, but browser QA is not claimed because Chrome is missing at `/opt/google/chrome/chrome`.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.
