### PR TITLE
fix(vscode): preserve queued host commands

### DIFF
--- a/.changeset/vscode-queued-host-command.md
+++ b/.changeset/vscode-queued-host-command.md
@@ -1,0 +1,5 @@
+---
+"kimi-code": patch
+---
+
+Keep queued VS Code slash commands pending until the active response finishes instead of steering them into the model and discarding them.

--- a/apps/vscode/shared/host-slash-command.ts
+++ b/apps/vscode/shared/host-slash-command.ts
@@ -1,0 +1,29 @@
+const HOST_COMMANDS = new Set([
+  "init",
+  "compact",
+  "clear",
+  "reset",
+  "yolo",
+  "auto",
+  "afk",
+  "plan",
+  "add-dir",
+  "export",
+  "import",
+]);
+
+export interface HostSlashCommand {
+  readonly name: string;
+  readonly args: string;
+  readonly raw: string;
+}
+
+export function parseHostSlashCommand(content: string | readonly unknown[]): HostSlashCommand | undefined {
+  if (typeof content !== "string") return undefined;
+  const raw = content.trim();
+  const match = /^\/([^\s]+)(?:\s+(.*))?\s*$/s.exec(raw);
+  if (match === null) return undefined;
+  const name = match[1]!.toLowerCase();
+  if (!HOST_COMMANDS.has(name) && !name.startsWith("skill:")) return undefined;
+  return { name, args: match[2]?.trim() ?? "", raw };
+}

--- a/apps/vscode/src/handlers/slash-command.ts
+++ b/apps/vscode/src/handlers/slash-command.ts
@@ -4,6 +4,11 @@ import { homedir } from "node:os";
 import { basename, dirname, isAbsolute, join, resolve } from "node:path";
 import * as vscode from "vscode";
 
+import {
+  parseHostSlashCommand,
+  type HostSlashCommand,
+} from "../../shared/host-slash-command";
+
 import type { SessionRuntime } from "../runtime/session-runtime";
 import {
   buildExportMarkdown,
@@ -13,36 +18,9 @@ import {
 } from "../utils/session-context";
 import type { HandlerContext } from "./types";
 
-const HOST_COMMANDS = new Set([
-  "init",
-  "compact",
-  "clear",
-  "reset",
-  "yolo",
-  "auto",
-  "afk",
-  "plan",
-  "add-dir",
-  "export",
-  "import",
-]);
 const MAX_IMPORT_BYTES = 10 * 1024 * 1024;
 
-export interface HostSlashCommand {
-  readonly name: string;
-  readonly args: string;
-  readonly raw: string;
-}
-
-export function parseHostSlashCommand(content: string | readonly unknown[]): HostSlashCommand | undefined {
-  if (typeof content !== "string") return undefined;
-  const raw = content.trim();
-  const match = /^\/([^\s]+)(?:\s+(.*))?\s*$/s.exec(raw);
-  if (match === null) return undefined;
-  const name = match[1]!.toLowerCase();
-  if (!HOST_COMMANDS.has(name) && !name.startsWith("skill:")) return undefined;
-  return { name, args: match[2]?.trim() ?? "", raw };
-}
+export { parseHostSlashCommand, type HostSlashCommand } from "../../shared/host-slash-command";
 
 export async function runHostSlashCommand(
   runtime: SessionRuntime,

--- a/apps/vscode/test/settings-store.test.ts
+++ b/apps/vscode/test/settings-store.test.ts
@@ -11,6 +11,7 @@ import { MCP_SECRET_MASK } from "../shared/legacy-sdk";
 const boundary = vi.hoisted(() => ({
   saveConfig: vi.fn(),
   streamChat: vi.fn(),
+  steerChat: vi.fn(),
   abortChat: vi.fn(),
   trackFiles: vi.fn(),
   toastError: vi.fn(),
@@ -21,6 +22,7 @@ vi.mock("@/services", () => ({
   bridge: {
     saveConfig: boundary.saveConfig,
     streamChat: boundary.streamChat,
+    steerChat: boundary.steerChat,
     abortChat: boundary.abortChat,
     trackFiles: boundary.trackFiles,
   },
@@ -55,6 +57,8 @@ beforeEach(() => {
   boundary.saveConfig.mockReset();
   boundary.streamChat.mockReset();
   boundary.streamChat.mockResolvedValue({ done: false });
+  boundary.steerChat.mockReset();
+  boundary.steerChat.mockResolvedValue({ ok: true });
   boundary.abortChat.mockReset();
   boundary.abortChat.mockResolvedValue({ aborted: true });
   boundary.trackFiles.mockReset();
@@ -75,6 +79,40 @@ beforeEach(() => {
     queue: [],
     pendingQuestion: null,
     planMode: false,
+  });
+});
+
+describe("Webview queued messages", () => {
+  it("keeps host slash commands queued instead of steering them as model input", async () => {
+    useChatStore.setState({
+      isStreaming: true,
+      queue: [{ id: "auto-command", content: "/auto", model: "plain" }],
+    });
+
+    await useChatStore.getState().steerQueued("auto-command");
+
+    expect(boundary.steerChat).not.toHaveBeenCalled();
+    expect(useChatStore.getState().queue).toEqual([
+      { id: "auto-command", content: "/auto", model: "plain" },
+    ]);
+
+    useChatStore.getState().processEvent({ type: "stream_complete", result: { status: "finished" } });
+    await vi.waitFor(() => {
+      expect(boundary.streamChat).toHaveBeenCalledWith("/auto", "plain", "off", false, undefined);
+    });
+    expect(useChatStore.getState().queue).toEqual([]);
+  });
+
+  it("still steers ordinary queued follow-ups", async () => {
+    useChatStore.setState({
+      isStreaming: true,
+      queue: [{ id: "follow-up", content: "also update the tests", model: "plain" }],
+    });
+
+    await useChatStore.getState().steerQueued("follow-up");
+
+    expect(boundary.steerChat).toHaveBeenCalledWith("also update the tests");
+    expect(useChatStore.getState().queue).toEqual([]);
   });
 });
 

--- a/apps/vscode/webview-ui/src/components/QueuedMessagesPanel.tsx
+++ b/apps/vscode/webview-ui/src/components/QueuedMessagesPanel.tsx
@@ -2,23 +2,18 @@ import { useState } from "react";
 import { IconTrash, IconArrowUp, IconPencil, IconCheck, IconX, IconBolt } from "@tabler/icons-react";
 import { Button } from "@/components/ui/button";
 import { useChatStore } from "@/stores";
-import { bridge } from "@/services";
+import { canSteerQueuedContent } from "@/stores/chat.store";
 import { Content } from "@/lib/content";
 
 import type { ContentPart } from "shared/legacy-sdk";
 
 function QueueItem({ id, content, isStreaming, onEdit }: { id: string; content: string | ContentPart[]; isStreaming: boolean; onEdit: (id: string) => void }) {
-  const { removeFromQueue, moveQueueItemUp, queue } = useChatStore();
+  const { removeFromQueue, moveQueueItemUp, steerQueued, queue } = useChatStore();
   const text = Content.getText(content);
   const hasMedia = Content.hasMedia(content);
   const isFirst = queue[0]?.id === id;
 
-  const handleSteer = async () => {
-    const result = await bridge.steerChat(content);
-    if (result.ok) {
-      removeFromQueue(id);
-    }
-  };
+  const canSteer = canSteerQueuedContent(content);
 
   return (
     <div className="group flex items-start px-2.5 py-0.5 hover:bg-muted/50 transition-colors">
@@ -27,13 +22,13 @@ function QueueItem({ id, content, isStreaming, onEdit }: { id: string; content: 
         {hasMedia && text && <span className="text-[10px] text-muted-foreground">+ media</span>}
       </div>
       <div className="flex items-center gap-0.5 shrink-0 opacity-0 group-hover:opacity-100 transition-opacity">
-        {isStreaming && (
+        {isStreaming && canSteer && (
           <Button
             variant="ghost"
             size="icon"
             className="size-5 border-0! text-amber-500 hover:text-amber-600"
             onClick={() => {
-              void handleSteer();
+              void steerQueued(id);
             }}
             title="Insert now (steer)"
           >

--- a/apps/vscode/webview-ui/src/stores/chat.store.ts
+++ b/apps/vscode/webview-ui/src/stores/chat.store.ts
@@ -8,6 +8,7 @@ import { toast } from "@/components/ui/sonner";
 import { useSettingsStore } from "./settings.store";
 import { processEvent } from "./event-handlers";
 import type { StatusUpdate, ContentPart, QuestionRequest, ToolResult } from "shared/legacy-sdk";
+import { parseHostSlashCommand } from "shared/host-slash-command";
 import type { UIStreamEvent } from "shared/types";
 
 const HANDSHAKE_TIMEOUT_MS = 30_000;
@@ -87,6 +88,10 @@ export interface QueuedItem {
   model: string;
 }
 
+export function canSteerQueuedContent(content: string | ContentPart[]): boolean {
+  return parseHostSlashCommand(content) === undefined;
+}
+
 export interface ChatState {
   sessionId: string | null;
   messages: ChatMessage[];
@@ -121,6 +126,7 @@ export interface ChatState {
   removeFromQueue: (id: string) => void;
   editQueueItem: (id: string, content: string | ContentPart[]) => void;
   moveQueueItemUp: (id: string) => void;
+  steerQueued: (id: string) => Promise<void>;
   sendNextQueued: () => void;
 }
 
@@ -460,6 +466,14 @@ export const useChatStore = create<ChatState>((set, get) => ({
       [next[idx - 1], next[idx]] = [next[idx], next[idx - 1]];
       return { queue: next };
     });
+  },
+
+  steerQueued: async (id) => {
+    const item = get().queue.find((queued) => queued.id === id);
+    if (item === undefined || !canSteerQueuedContent(item.content)) return;
+
+    const result = await bridge.steerChat(item.content);
+    if (result.ok) get().removeFromQueue(id);
   },
 
   sendNextQueued: () => {


### PR DESCRIPTION
## Related Issue

Resolves #2580

## Problem

While a response is streaming, using **Insert now (steer)** on a queued host slash command sends it through the model steer path and removes it from the queue. Commands such as `/auto` therefore never reach the host command handler.

## What changed

Share host slash-command parsing with the Webview, keep host commands out of the steer path, and leave them queued until the active response finishes. Ordinary queued follow-ups remain steerable. Regression tests cover both paths.

## Checklist

- [x] I have read the CONTRIBUTING document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill; added a patch changeset for `kimi-code`.
- [x] This bug fix needs no documentation update.