### PR TITLE
fix(kimi-code): revert the todo panel to its pre-turn state on undo

### DIFF
--- a/.changeset/undo-todo-panel-revert.md
+++ b/.changeset/undo-todo-panel-revert.md
@@ -1,0 +1,6 @@
+---
+"@moonshot-ai/kimi-code": patch
+"@moonshot-ai/kimi-code-sdk": patch
+---
+
+Fix the todo panel keeping items written by an undone turn: /undo now restores the todo list to its state before the undone turn.

--- a/apps/kimi-code/src/tui/commands/undo.ts
+++ b/apps/kimi-code/src/tui/commands/undo.ts
@@ -162,7 +162,12 @@ async function refreshTodoPanel(host: SlashCommandHost): Promise<void> {
   const session = host.session;
   if (session === undefined) return;
   try {
-    host.streamingUI.setTodoList(await session.getTodos());
+    const todos = await session.getTodos();
+    if (todos.length > 0 && todos.every((todo) => todo.status === 'done')) {
+      host.streamingUI.setTodoList([]);
+      return;
+    }
+    host.streamingUI.setTodoList(todos);
   } catch {
     return;
   }

--- a/apps/kimi-code/src/tui/commands/undo.ts
+++ b/apps/kimi-code/src/tui/commands/undo.ts
@@ -107,6 +107,7 @@ async function undoByCount(host: SlashCommandHost, count: number): Promise<boole
     return false;
   }
   host.noteContextCut?.();
+  await refreshTodoPanel(host);
 
   const children = host.state.transcriptContainer.children;
   const lastUserComponentIndex = findUndoAnchorComponentIndex(children, count);
@@ -155,6 +156,16 @@ async function undoByCount(host: SlashCommandHost, count: number): Promise<boole
 
   host.state.ui.requestRender();
   return true;
+}
+
+async function refreshTodoPanel(host: SlashCommandHost): Promise<void> {
+  const session = host.session;
+  if (session === undefined) return;
+  try {
+    host.streamingUI.setTodoList(await session.getTodos());
+  } catch {
+    return;
+  }
 }
 
 async function showUndoSelector(host: SlashCommandHost): Promise<void> {

--- a/apps/kimi-code/test/tui/commands/undo.test.ts
+++ b/apps/kimi-code/test/tui/commands/undo.test.ts
@@ -144,4 +144,19 @@ describe('/undo todo panel refresh', () => {
 
     expect(setTodoList).not.toHaveBeenCalled();
   });
+
+  it('hides the panel when the restored todos are all done', async () => {
+    const entries: TranscriptEntry[] = [
+      entry({ kind: 'user', content: 'question' }),
+      entry({ kind: 'assistant', content: 'answer' }),
+    ];
+    const { host, setTodoList } = hostWithTodos(entries, {
+      undoHistory: vi.fn(async () => {}),
+      getTodos: vi.fn(async () => [{ title: 'finished', status: 'done' }]),
+    });
+
+    await handleUndoCommand(host, '1');
+
+    expect(setTodoList).toHaveBeenCalledWith([]);
+  });
 });

--- a/apps/kimi-code/test/tui/commands/undo.test.ts
+++ b/apps/kimi-code/test/tui/commands/undo.test.ts
@@ -100,3 +100,48 @@ describe('/undo with bundled prompts', () => {
     expect(entries).toHaveLength(0);
   });
 });
+
+describe('/undo todo panel refresh', () => {
+  function hostWithTodos(
+    entries: TranscriptEntry[],
+    session: Record<string, unknown>,
+  ): { host: SlashCommandHost; setTodoList: ReturnType<typeof vi.fn> } {
+    const host = hostWith(entries);
+    const setTodoList = vi.fn();
+    (host as { streamingUI?: unknown }).streamingUI = { setTodoList };
+    (host as { session?: unknown }).session = session;
+    return { host, setTodoList };
+  }
+
+  it('re-pulls the engine todo state after a successful undo', async () => {
+    const entries: TranscriptEntry[] = [
+      entry({ kind: 'user', content: 'question' }),
+      entry({ kind: 'assistant', content: 'answer' }),
+    ];
+    const { host, setTodoList } = hostWithTodos(entries, {
+      undoHistory: vi.fn(async () => {}),
+      getTodos: vi.fn(async () => [{ title: 'kept', status: 'pending' }]),
+    });
+
+    await handleUndoCommand(host, '1');
+
+    expect(setTodoList).toHaveBeenCalledWith([{ title: 'kept', status: 'pending' }]);
+  });
+
+  it('keeps the panel as-is when the engine has no todo read surface', async () => {
+    const entries: TranscriptEntry[] = [
+      entry({ kind: 'user', content: 'question' }),
+      entry({ kind: 'assistant', content: 'answer' }),
+    ];
+    const { host, setTodoList } = hostWithTodos(entries, {
+      undoHistory: vi.fn(async () => {}),
+      getTodos: vi.fn(async () => {
+        throw new Error('getTodos is only available on the agent-core-v2 engine.');
+      }),
+    });
+
+    await handleUndoCommand(host, '1');
+
+    expect(setTodoList).not.toHaveBeenCalled();
+  });
+});

--- a/apps/kimi-code/test/tui/controllers/session-event-handler-todo.test.ts
+++ b/apps/kimi-code/test/tui/controllers/session-event-handler-todo.test.ts
@@ -1,0 +1,87 @@
+import type { Event } from '@moonshot-ai/kimi-code-sdk';
+import { describe, expect, it, vi } from 'vitest';
+
+import { SessionEventHandler } from '#/tui/controllers/session-event-handler';
+import type { ToolCallBlockData } from '#/tui/types';
+
+function makeHarness() {
+  const activeCalls = new Map<string, ToolCallBlockData>();
+  const streamingUI = {
+    setTurnId: vi.fn(),
+    flushNow: vi.fn(),
+    getTurnContext: vi.fn(() => ({ turnId: 1, step: 0 })),
+    registerToolCall: vi.fn((call: ToolCallBlockData) => {
+      activeCalls.set(call.id, call);
+      return true;
+    }),
+    completeToolResult: vi.fn((toolCallId: string) => {
+      const call = activeCalls.get(toolCallId);
+      activeCalls.delete(toolCallId);
+      return call;
+    }),
+    setTodoList: vi.fn(),
+  };
+  const host = {
+    state: {
+      appState: { availableModels: {}, workDir: '/tmp/work', stepRetry: null },
+      ui: { requestRender: vi.fn() },
+      transcriptContainer: { addChild: vi.fn() },
+    },
+    session: undefined,
+    streamingUI,
+    appendTranscriptEntry: vi.fn(),
+    patchLivePane: vi.fn(),
+    setAppState: vi.fn(),
+    btwPanelController: { routeEvent: vi.fn(() => false) },
+    updateActivityPane: vi.fn(),
+    showStatus: vi.fn(),
+  };
+  const handler = new SessionEventHandler(host as never);
+  return { handler, streamingUI };
+}
+
+function todoCallStarted(toolCallId: string, todos: unknown): Event {
+  return {
+    sessionId: 's1',
+    agentId: 'main',
+    type: 'tool.call.started',
+    turnId: 1,
+    toolCallId,
+    name: 'TodoList',
+    args: { todos },
+  } as unknown as Event;
+}
+
+function todoResult(toolCallId: string, isError = false): Event {
+  return {
+    sessionId: 's1',
+    agentId: 'main',
+    type: 'tool.result',
+    turnId: 1,
+    toolCallId,
+    output: 'ok',
+    isError,
+  } as unknown as Event;
+}
+
+describe('SessionEventHandler — todo panel feed', () => {
+  it('feeds the panel from TodoList call args when the tool result arrives', () => {
+    const { handler, streamingUI } = makeHarness();
+    const todos = [{ title: '测试 Todo 项', status: 'in_progress' }];
+
+    handler.handleEvent(todoCallStarted('tc-1', todos), vi.fn());
+    expect(streamingUI.setTodoList).not.toHaveBeenCalled();
+
+    handler.handleEvent(todoResult('tc-1'), vi.fn());
+    expect(streamingUI.setTodoList).toHaveBeenCalledWith(todos);
+  });
+
+  it('ignores failed TodoList results', () => {
+    const { handler, streamingUI } = makeHarness();
+
+    handler.handleEvent(todoCallStarted('tc-1', [{ title: 'x', status: 'pending' }]), vi.fn());
+    handler.handleEvent(todoResult('tc-1', true), vi.fn());
+
+    expect(streamingUI.setTodoList).not.toHaveBeenCalled();
+  });
+});

--- a/packages/node-sdk/src/rpc.ts
+++ b/packages/node-sdk/src/rpc.ts
@@ -59,6 +59,7 @@ import type {
   CompactOptions,
   SessionPlan,
   SessionStatus,
+  SessionTodoItem,
   SessionUsage,
   PromptInput,
   PromptSkillActivation,
@@ -716,6 +717,14 @@ export abstract class SDKRpcClientBase {
       sessionId: input.sessionId,
       agentId: this.interactiveAgentId,
     });
+  }
+
+  async getTodos(input: SessionIdRpcInput): Promise<readonly SessionTodoItem[]> {
+    void input;
+    throw new KimiError(
+      ErrorCodes.NOT_IMPLEMENTED,
+      'getTodos is only available on the agent-core-v2 engine.',
+    );
   }
 
   async undoHistory(input: SessionIdRpcInput & { count: number }): Promise<void> {

--- a/packages/node-sdk/src/sdk-rpc-client-v2.ts
+++ b/packages/node-sdk/src/sdk-rpc-client-v2.ts
@@ -1848,7 +1848,10 @@ export class SDKRpcClientV2 extends SDKRpcClientBase {
    */
   override async getTodos(input: SessionIdRpcInput): Promise<readonly SessionTodoItem[]> {
     const session = this.requireLiveSession(input.sessionId);
-    return session.accessor.get(ISessionTodoService).getTodos();
+    return session.accessor
+      .get(ISessionTodoService)
+      .getTodos()
+      .map((todo) => ({ title: todo.title, status: todo.status }));
   }
 
   override async undoHistory(input: SessionIdRpcInput & { count: number }): Promise<void> {

--- a/packages/node-sdk/src/sdk-rpc-client-v2.ts
+++ b/packages/node-sdk/src/sdk-rpc-client-v2.ts
@@ -210,6 +210,7 @@ import {
   ISessionMcpHandle,
   ISessionMetadata,
   ISessionSkillCatalog,
+  ISessionTodoService,
   ISessionWorkspaceContext,
   ITelemetryService,
   IWorkspaceAliases,
@@ -317,6 +318,7 @@ import type {
   SessionStatus,
   SessionSummary,
   SessionSummaryPage,
+  SessionTodoItem,
   SessionUsage,
   SkillSummary,
   TelemetryClient,
@@ -1844,6 +1846,11 @@ export class SDKRpcClientV2 extends SDKRpcClientBase {
    * v1 splices a partial suffix out of the live history and then throws
    * `request.invalid` — pinned in the parity KNOWN_DIFFS.
    */
+  override async getTodos(input: SessionIdRpcInput): Promise<readonly SessionTodoItem[]> {
+    const session = this.requireLiveSession(input.sessionId);
+    return session.accessor.get(ISessionTodoService).getTodos();
+  }
+
   override async undoHistory(input: SessionIdRpcInput & { count: number }): Promise<void> {
     const agent = await this.agentScope(input.sessionId);
     await agent.accessor.get(IAgentConversationUndoService).undo(input.count);

--- a/packages/node-sdk/src/session.ts
+++ b/packages/node-sdk/src/session.ts
@@ -36,6 +36,7 @@ import type {
   SessionPlan,
   SessionStatus,
   SessionSummary,
+  SessionTodoItem,
   SessionUsage,
   SkillSummary,
   PluginCommandDef,
@@ -367,6 +368,11 @@ export class Session {
   async undoHistory(count: number = 1): Promise<void> {
     this.ensureOpen();
     await this.rpc.undoHistory({ sessionId: this.id, count });
+  }
+
+  async getTodos(): Promise<readonly SessionTodoItem[]> {
+    this.ensureOpen();
+    return this.rpc.getTodos({ sessionId: this.id });
   }
 
   /** Clear this session's model context without creating a new session. */

--- a/packages/node-sdk/src/types.ts
+++ b/packages/node-sdk/src/types.ts
@@ -311,6 +311,13 @@ export interface PlanInfo {
 
 export type SessionPlan = PlanInfo | null;
 
+export type SessionTodoStatus = 'pending' | 'in_progress' | 'done';
+
+export interface SessionTodoItem {
+  readonly title: string;
+  readonly status: SessionTodoStatus;
+}
+
 export interface TokenUsage {
   readonly inputOther: number;
   readonly output: number;

--- a/packages/node-sdk/test/sdk-rpc-client-v2.test.ts
+++ b/packages/node-sdk/test/sdk-rpc-client-v2.test.ts
@@ -896,6 +896,11 @@ key = "${titleOAuthRef.key}"
         { title: 'write tests', status: 'in_progress' },
         { title: 'ship it', status: 'pending' },
       ]);
+
+      const served = await client.getTodos({ sessionId: 'ses_todos' });
+      const stored = handle!.accessor.get(ISessionTodoService).getTodos();
+      expect(served).not.toBe(stored);
+      expect(served[0]).not.toBe(stored[0]);
       await expect(client.getTodos({ sessionId: 'ses_missing' })).rejects.toMatchObject({
         code: ErrorCodes.SESSION_NOT_FOUND,
       });

--- a/packages/node-sdk/test/sdk-rpc-client-v2.test.ts
+++ b/packages/node-sdk/test/sdk-rpc-client-v2.test.ts
@@ -34,9 +34,12 @@ import { foldAgentWireReplay } from '#/v2/resume-replay';
 import {
   drainQueryStoreDisposals,
   drainSessionIndexMirror,
+  getLiveSessionById,
   HostProcessError,
+  IAgentLifecycleService,
   IHostRequestHeaders,
   ISessionManager,
+  ISessionTodoService,
   OsProcessErrors,
 } from '@moonshot-ai/agent-core-v2';
 
@@ -868,6 +871,36 @@ key = "${titleOAuthRef.key}"
       });
     } finally {
       await harness.close();
+    }
+  });
+
+  it('serves getTodos from the live session todo state', async () => {
+    const homeDir = await mkdtemp(join(tmpdir(), 'kimi-sdk-v2-'));
+    tempDirs.push(homeDir);
+    const workDir = await mkdtemp(join(tmpdir(), 'kimi-sdk-v2-work-'));
+    tempDirs.push(workDir);
+    const client = new SDKRpcClientV2({ homeDir, identity: TEST_IDENTITY });
+    try {
+      await client.createSession({ id: 'ses_todos', workDir });
+      expect(await client.getTodos({ sessionId: 'ses_todos' })).toEqual([]);
+
+      const handle = getLiveSessionById(client.engineAccessor, 'ses_todos');
+      expect(handle).toBeDefined();
+      await handle!.accessor.get(IAgentLifecycleService).create({ agentId: 'main' });
+      handle!.accessor.get(ISessionTodoService).setTodos([
+        { title: 'write tests', status: 'in_progress' },
+        { title: 'ship it', status: 'pending' },
+      ]);
+
+      expect(await client.getTodos({ sessionId: 'ses_todos' })).toEqual([
+        { title: 'write tests', status: 'in_progress' },
+        { title: 'ship it', status: 'pending' },
+      ]);
+      await expect(client.getTodos({ sessionId: 'ses_missing' })).rejects.toMatchObject({
+        code: ErrorCodes.SESSION_NOT_FOUND,
+      });
+    } finally {
+      await client.close();
     }
   });
 });


### PR DESCRIPTION
## Related Issue

No linked issue — the problem is explained below.

## Problem

When the model updates the todo list during a turn and the user then runs `/undo` on that turn, the todo panel keeps showing the undone turn's items instead of reverting to the pre-turn state.

The engine already rolls the todo state back correctly (it is an undoable replayable state), but the TUI panel is a local copy fed only by `TodoList` tool-result events. Undo produces no new tool events, and the SDK exposed no way to read the rolled-back todo state, so the stale copy lingered on screen.

## What changed

- The SDK gains a `getTodos()` session read that returns the engine's current todo state. On the v2 engine it reads the live session todo state; the v1 client answers `not_implemented` since the legacy engine has no todo read path.
- The `/undo` handler re-pulls the todo state after a successful undo and refreshes the panel, mirroring how resume hydrates it. If the read is unavailable or fails (e.g. the v1 engine), the panel is left untouched and the undo command still succeeds.
- Tests: SDK coverage for the new read (empty state, round-trip after an engine-side write, missing-session rejection) and TUI coverage for the post-undo refresh and the degradation path, plus a test pinning the existing tool-result feed that drives the panel during normal turns.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.
