### PR TITLE
feat(kap-server): add workspace fs:suggest file completion endpoint

### DIFF
--- a/apps/kimi-inspect/src/App.tsx
+++ b/apps/kimi-inspect/src/App.tsx
@@ -26,6 +26,7 @@ import { AppServicesView } from './components/AppServicesView';
 import { BashParserView } from './components/BashParserView';
 import { ChatView, type ChatJump } from './components/ChatView';
 import { DiInspectionView } from './components/DiInspectionView';
+import { FsSuggestView } from './components/FsSuggestView';
 import { ModelCatalogView } from './components/ModelCatalogView';
 import { NavRail, type AppView } from './components/NavRail';
 import { RightPanel } from './components/RightPanel';
@@ -117,6 +118,8 @@ export function App() {
           <AppServicesView />
         ) : view === 'workspace' ? (
           <WorkspaceServicesView />
+        ) : view === 'suggest' ? (
+          <FsSuggestView />
         ) : view === 'bash' ? (
           <BashParserView />
         ) : view === 'di' ? (

--- a/apps/kimi-inspect/src/components/FsSuggestView.tsx
+++ b/apps/kimi-inspect/src/components/FsSuggestView.tsx
@@ -1,0 +1,231 @@
+import { IWorkspaceService, type Workspace } from '@moonshot-ai/agent-core-v2/app/workspace/workspace';
+import { useMutation, useQuery } from '@tanstack/react-query';
+import { useEffect, useState } from 'react';
+
+import { useConnection } from '../connection';
+import { fetchWorkspaceFsSuggest, type FsSuggestResult } from '../fs/api';
+import { Badge, ErrorLine } from '../ui';
+import { WorkspaceDirBrowser } from './WorkspaceDirBrowser';
+
+function parseGlobs(value: string): string[] | undefined {
+  const globs = value
+    .split(',')
+    .map((glob) => glob.trim())
+    .filter((glob) => glob.length > 0);
+  return globs.length === 0 ? undefined : globs;
+}
+
+export function FsSuggestView() {
+  const { klient, baseUrl } = useConnection();
+  const [workspace, setWorkspace] = useState<Workspace | null>(null);
+  const [query, setQuery] = useState('');
+  const [limit, setLimit] = useState('50');
+  const [followGitignore, setFollowGitignore] = useState(true);
+  const [showHidden, setShowHidden] = useState(false);
+  const [includeGlobs, setIncludeGlobs] = useState('');
+  const [excludeGlobs, setExcludeGlobs] = useState('');
+
+  const workspaces = useQuery({
+    queryKey: ['workspaces', klient.baseUrl],
+    queryFn: () => klient.core(IWorkspaceService).list(),
+  });
+
+  const suggest = useMutation<FsSuggestResult, Error>({
+    mutationFn: async () => {
+      if (workspace === null) throw new Error('select a workspace first');
+      const parsedLimit = Number.parseInt(limit, 10);
+      return fetchWorkspaceFsSuggest({
+        baseUrl: klient.baseUrl,
+        token: klient.token,
+        workspace: workspace.id,
+        query,
+        limit: Number.isFinite(parsedLimit) && parsedLimit > 0 ? parsedLimit : undefined,
+        followGitignore,
+        showHidden,
+        includeGlobs: parseGlobs(includeGlobs),
+        excludeGlobs: parseGlobs(excludeGlobs),
+      });
+    },
+  });
+
+  useEffect(() => {
+    setWorkspace(null);
+    suggest.reset();
+  }, [baseUrl]);
+
+  const selectWorkspace = (next: Workspace) => {
+    setWorkspace(next);
+    suggest.reset();
+  };
+
+  return (
+    <div className="flex min-h-0 min-w-0 flex-1">
+      <aside className="flex w-72 shrink-0 flex-col border-r border-neutral-800">
+        <div className="border-b border-neutral-800 px-3 py-2">
+          <div className="text-[10px] font-semibold uppercase tracking-wider text-neutral-500">
+            Workspace
+          </div>
+          <div title={workspace?.root} className="truncate font-mono text-[11px] text-neutral-300">
+            {workspace === null ? <span className="text-neutral-600 italic">none selected</span> : `${workspace.name} — ${workspace.root}`}
+          </div>
+          {workspaces.isError ? <ErrorLine error={workspaces.error} /> : null}
+        </div>
+        <WorkspaceDirBrowser
+          klient={klient}
+          workspaces={workspaces.data}
+          onSelect={selectWorkspace}
+        />
+      </aside>
+      <main className="min-h-0 min-w-0 flex-1 overflow-y-auto p-4">
+        <div className="mx-auto max-w-6xl space-y-4">
+          <div>
+            <h1 className="text-sm font-semibold text-neutral-200">Filesystem Suggest</h1>
+            <p className="mt-1 text-[11px] text-neutral-500">
+              Query file and directory completion candidates from the selected workspace.
+            </p>
+          </div>
+          <form
+            className="grid gap-3 rounded border border-neutral-800 bg-neutral-900/30 p-3 md:grid-cols-2"
+            onSubmit={(event) => {
+              event.preventDefault();
+              suggest.mutate();
+            }}
+          >
+            <label className="md:col-span-2">
+              <span className="mb-1 block text-[10px] font-semibold uppercase tracking-wider text-neutral-500">
+                Query
+              </span>
+              <input
+                autoFocus
+                className="w-full rounded border border-neutral-700 bg-neutral-950 px-2 py-1.5 font-mono text-[12px] text-neutral-100 outline-none focus:border-sky-600"
+                value={query}
+                onChange={(event) => setQuery(event.target.value)}
+                placeholder="apps/de or README"
+              />
+            </label>
+            <label>
+              <span className="mb-1 block text-[10px] font-semibold uppercase tracking-wider text-neutral-500">
+                Limit
+              </span>
+              <input
+                className="w-full rounded border border-neutral-700 bg-neutral-950 px-2 py-1.5 font-mono text-[12px] text-neutral-100 outline-none focus:border-sky-600"
+                inputMode="numeric"
+                value={limit}
+                onChange={(event) => setLimit(event.target.value)}
+              />
+            </label>
+            <div className="flex items-end gap-4 pb-1 text-[11px] text-neutral-300">
+              <label className="flex items-center gap-1.5">
+                <input
+                  type="checkbox"
+                  checked={followGitignore}
+                  onChange={(event) => setFollowGitignore(event.target.checked)}
+                />
+                follow gitignore
+              </label>
+              <label className="flex items-center gap-1.5">
+                <input
+                  type="checkbox"
+                  checked={showHidden}
+                  onChange={(event) => setShowHidden(event.target.checked)}
+                />
+                show hidden
+              </label>
+            </div>
+            <label>
+              <span className="mb-1 block text-[10px] font-semibold uppercase tracking-wider text-neutral-500">
+                Include globs
+              </span>
+              <input
+                className="w-full rounded border border-neutral-700 bg-neutral-950 px-2 py-1.5 font-mono text-[11px] text-neutral-100 outline-none focus:border-sky-600"
+                value={includeGlobs}
+                onChange={(event) => setIncludeGlobs(event.target.value)}
+                placeholder="**/*.ts, src/**"
+              />
+            </label>
+            <label>
+              <span className="mb-1 block text-[10px] font-semibold uppercase tracking-wider text-neutral-500">
+                Exclude globs
+              </span>
+              <input
+                className="w-full rounded border border-neutral-700 bg-neutral-950 px-2 py-1.5 font-mono text-[11px] text-neutral-100 outline-none focus:border-sky-600"
+                value={excludeGlobs}
+                onChange={(event) => setExcludeGlobs(event.target.value)}
+                placeholder="dist/**, node_modules/**"
+              />
+            </label>
+            <div className="flex items-end md:col-span-2">
+              <button
+                type="submit"
+                disabled={workspace === null || suggest.isPending}
+                className="rounded bg-sky-600 px-3 py-1.5 text-[12px] font-medium text-white hover:bg-sky-500 disabled:opacity-40"
+              >
+                {suggest.isPending ? 'loading…' : 'Suggest'}
+              </button>
+              {workspace === null ? (
+                <span className="ml-3 text-[11px] text-neutral-600">select a workspace first</span>
+              ) : null}
+            </div>
+          </form>
+          {suggest.isError ? <ErrorLine error={suggest.error} /> : null}
+          {suggest.data === undefined && !suggest.isError ? (
+            <div className="rounded border border-dashed border-neutral-800 p-6 text-center text-[12px] text-neutral-600">
+              Submit a query to inspect the complete response.
+            </div>
+          ) : null}
+          {suggest.data !== undefined ? <SuggestResult result={suggest.data} /> : null}
+        </div>
+      </main>
+    </div>
+  );
+}
+
+function SuggestResult({ result }: { readonly result: FsSuggestResult }) {
+  return (
+    <div className="space-y-3">
+      <div className="flex items-center gap-2 text-[11px] text-neutral-400">
+        <span>{result.items.length} items</span>
+        <Badge tone={result.truncated ? 'amber' : 'green'}>
+          {result.truncated ? 'truncated' : 'complete'}
+        </Badge>
+      </div>
+      <section className="overflow-x-auto rounded border border-neutral-800">
+        <table className="w-full min-w-[680px] text-left text-[11px]">
+          <thead className="border-b border-neutral-800 bg-neutral-900/50 text-neutral-500">
+            <tr>
+              <th className="px-2 py-1.5">path</th>
+              <th className="px-2 py-1.5">name</th>
+              <th className="px-2 py-1.5">kind</th>
+              <th className="px-2 py-1.5">score</th>
+              <th className="px-2 py-1.5">match positions</th>
+            </tr>
+          </thead>
+          <tbody>
+            {result.items.map((item) => (
+              <tr key={item.path} className="border-b border-neutral-900 last:border-0">
+                <td className="px-2 py-1.5 font-mono text-neutral-200">{item.path}</td>
+                <td className="px-2 py-1.5 font-mono text-neutral-400">{item.name}</td>
+                <td className="px-2 py-1.5 text-neutral-400">{item.kind}</td>
+                <td className="px-2 py-1.5 font-mono text-neutral-400">{item.score}</td>
+                <td className="px-2 py-1.5 font-mono text-neutral-400">
+                  {item.matchPositions.join(', ') || '—'}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+        {result.items.length === 0 ? (
+          <div className="p-4 text-center text-[11px] text-neutral-600">no matching items</div>
+        ) : null}
+      </section>
+      <details className="rounded border border-neutral-800 bg-neutral-950/50">
+        <summary className="cursor-pointer px-3 py-2 text-[11px] font-semibold uppercase tracking-wider text-neutral-500">
+          Full JSON response
+        </summary>
+        <pre className="max-h-[420px] overflow-auto border-t border-neutral-800 p-3 text-[11px] leading-relaxed text-neutral-300">
+          {JSON.stringify(result, null, 2)}
+        </pre>
+      </details>
+    </div>
+  );
+}

--- a/apps/kimi-inspect/src/components/NavRail.tsx
+++ b/apps/kimi-inspect/src/components/NavRail.tsx
@@ -6,7 +6,15 @@
 
 import type { ReactNode } from 'react';
 
-export type AppView = 'chat' | 'search' | 'models' | 'services' | 'workspace' | 'bash' | 'di';
+export type AppView =
+  | 'chat'
+  | 'search'
+  | 'models'
+  | 'services'
+  | 'workspace'
+  | 'suggest'
+  | 'bash'
+  | 'di';
 
 interface ViewDef {
   readonly id: AppView;
@@ -74,6 +82,16 @@ const VIEWS: readonly ViewDef[] = [
     icon: (
       <svg {...iconProps}>
         <path d="M20 20a2 2 0 0 0 2-2V8a2 2 0 0 0-2-2h-7.9a2 2 0 0 1-1.69-.9L9.6 3.9A2 2 0 0 0 7.93 3H4a2 2 0 0 0-2 2v13a2 2 0 0 0 2 2Z" />
+      </svg>
+    ),
+  },
+  {
+    id: 'suggest',
+    title: 'Filesystem Suggest',
+    icon: (
+      <svg {...iconProps}>
+        <path d="M4 4h6l2 2h8v14H4z" />
+        <path d="m9 14 2 2 4-4" />
       </svg>
     ),
   },

--- a/apps/kimi-inspect/src/fs/api.test.ts
+++ b/apps/kimi-inspect/src/fs/api.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it } from 'vitest';
+
+import { fetchWorkspaceFsSuggest } from './api';
+
+function okEnvelope(data: unknown) {
+  return { code: 0, msg: 'success', data, request_id: 'r1' };
+}
+
+function fakeFetch(envelope: unknown) {
+  const calls: { url: string; init?: RequestInit }[] = [];
+  const fetchImpl = (async (url: string | URL, init?: RequestInit) => {
+    calls.push({ url: String(url), init });
+    return { json: async () => envelope };
+  }) as unknown as typeof fetch;
+  return { calls, fetchImpl };
+}
+
+const resultData = {
+  items: [
+    {
+      path: 'apps/desktop',
+      name: 'desktop',
+      kind: 'directory',
+      score: 0.9,
+      match_positions: [5, 6],
+    },
+    { path: 'README.md', name: 'README.md', kind: 'file', score: 0.8, match_positions: [0, 1] },
+    { path: 'broken' },
+  ],
+  truncated: true,
+};
+
+describe('fetchWorkspaceFsSuggest', () => {
+  it('posts the workspace suggestion request and maps items', async () => {
+    const { calls, fetchImpl } = fakeFetch(okEnvelope(resultData));
+    const result = await fetchWorkspaceFsSuggest({
+      baseUrl: 'http://h:1/',
+      token: 'tok',
+      workspace: 'ws-1',
+      query: 'apps/de',
+      limit: 20,
+      followGitignore: true,
+      showHidden: false,
+      includeGlobs: ['**/*.ts'],
+      excludeGlobs: ['dist/**'],
+      runtimeId: 'local',
+      fetchImpl,
+    });
+
+    expect(calls[0]!.url).toBe('http://h:1/api/v1/workspace/fs:suggest');
+    expect(calls[0]!.init?.method).toBe('POST');
+    expect(calls[0]!.init?.headers).toEqual({
+      'content-type': 'application/json',
+      authorization: 'Bearer tok',
+    });
+    expect(JSON.parse(calls[0]!.init?.body as string)).toEqual({
+      workspace: 'ws-1',
+      query: 'apps/de',
+      limit: 20,
+      follow_gitignore: true,
+      show_hidden: false,
+      include_globs: ['**/*.ts'],
+      exclude_globs: ['dist/**'],
+      runtime_id: 'local',
+    });
+    expect(result.items).toEqual([
+      {
+        path: 'apps/desktop',
+        name: 'desktop',
+        kind: 'directory',
+        score: 0.9,
+        matchPositions: [5, 6],
+      },
+      {
+        path: 'README.md',
+        name: 'README.md',
+        kind: 'file',
+        score: 0.8,
+        matchPositions: [0, 1],
+      },
+    ]);
+    expect(result.truncated).toBe(true);
+  });
+
+  it('omits optional fields and authorization when not configured', async () => {
+    const { calls, fetchImpl } = fakeFetch(okEnvelope({ items: [], truncated: false }));
+    await fetchWorkspaceFsSuggest({
+      baseUrl: 'http://h:1',
+      workspace: '/tmp/workspace',
+      query: '',
+      fetchImpl,
+    });
+    expect(calls[0]!.init?.headers).toEqual({ 'content-type': 'application/json' });
+    expect(JSON.parse(calls[0]!.init?.body as string)).toEqual({
+      workspace: '/tmp/workspace',
+      query: '',
+    });
+  });
+
+  it('throws on a non-zero envelope code', async () => {
+    const { fetchImpl } = fakeFetch({ code: 40410, msg: 'workspace missing', data: null });
+    await expect(
+      fetchWorkspaceFsSuggest({
+        baseUrl: 'http://h:1',
+        workspace: 'missing',
+        query: 'x',
+        fetchImpl,
+      }),
+    ).rejects.toThrow(/40410/);
+  });
+
+  it('throws on a malformed payload', async () => {
+    const { fetchImpl } = fakeFetch(okEnvelope({ truncated: false }));
+    await expect(
+      fetchWorkspaceFsSuggest({ baseUrl: 'http://h:1', workspace: 'ws', query: 'x', fetchImpl }),
+    ).rejects.toThrow(/unexpected response shape/);
+  });
+});

--- a/apps/kimi-inspect/src/fs/api.ts
+++ b/apps/kimi-inspect/src/fs/api.ts
@@ -1,0 +1,91 @@
+export type FsSuggestKind = 'file' | 'directory' | 'symlink';
+
+export interface FsSuggestItem {
+  readonly path: string;
+  readonly name: string;
+  readonly kind: FsSuggestKind;
+  readonly score: number;
+  readonly matchPositions: readonly number[];
+}
+
+export interface FsSuggestResult {
+  readonly items: readonly FsSuggestItem[];
+  readonly truncated: boolean;
+}
+
+export interface FetchWorkspaceFsSuggestOptions {
+  readonly baseUrl: string;
+  readonly token?: string;
+  readonly workspace: string;
+  readonly query: string;
+  readonly limit?: number;
+  readonly followGitignore?: boolean;
+  readonly showHidden?: boolean;
+  readonly includeGlobs?: readonly string[];
+  readonly excludeGlobs?: readonly string[];
+  readonly runtimeId?: string;
+  readonly fetchImpl?: typeof fetch;
+}
+
+const KINDS = new Set<FsSuggestKind>(['file', 'directory', 'symlink']);
+
+function parseItem(value: unknown): FsSuggestItem | undefined {
+  if (value === null || typeof value !== 'object' || Array.isArray(value)) return undefined;
+  const item = value as Record<string, unknown>;
+  if (
+    typeof item['path'] !== 'string' ||
+    typeof item['name'] !== 'string' ||
+    typeof item['kind'] !== 'string' ||
+    !KINDS.has(item['kind'] as FsSuggestKind) ||
+    typeof item['score'] !== 'number' ||
+    !Array.isArray(item['match_positions']) ||
+    !item['match_positions'].every((position) => typeof position === 'number')
+  ) {
+    return undefined;
+  }
+  return {
+    path: item['path'],
+    name: item['name'],
+    kind: item['kind'] as FsSuggestKind,
+    score: item['score'],
+    matchPositions: item['match_positions'] as number[],
+  };
+}
+
+export async function fetchWorkspaceFsSuggest(
+  opts: FetchWorkspaceFsSuggestOptions,
+): Promise<FsSuggestResult> {
+  const headers: Record<string, string> = { 'content-type': 'application/json' };
+  if (opts.token !== undefined && opts.token !== '') {
+    headers['authorization'] = `Bearer ${opts.token}`;
+  }
+  const doFetch = opts.fetchImpl ?? fetch;
+  const res = await doFetch(`${opts.baseUrl.replace(/\/$/, '')}/api/v1/workspace/fs:suggest`, {
+    method: 'POST',
+    headers,
+    body: JSON.stringify({
+      workspace: opts.workspace,
+      query: opts.query,
+      limit: opts.limit,
+      follow_gitignore: opts.followGitignore,
+      show_hidden: opts.showHidden,
+      include_globs: opts.includeGlobs,
+      exclude_globs: opts.excludeGlobs,
+      runtime_id: opts.runtimeId,
+    }),
+  });
+  const envelope = (await res.json()) as { code: number; msg: string; data: unknown };
+  if (envelope.code !== 0) {
+    throw new Error(`workspace fs:suggest failed (${envelope.code}): ${envelope.msg}`);
+  }
+  const data = envelope.data as Record<string, unknown> | null;
+  if (data === null || typeof data !== 'object' || !Array.isArray(data['items'])) {
+    throw new Error('workspace fs:suggest: unexpected response shape');
+  }
+  return {
+    items: (data['items'] as unknown[])
+      .map(parseItem)
+      .filter((item): item is FsSuggestItem => item !== undefined),
+    truncated: data['truncated'] === true,
+  };
+}

--- a/packages/agent-core-v2/src/app/telemetry/events.ts
+++ b/packages/agent-core-v2/src/app/telemetry/events.ts
@@ -327,6 +327,10 @@ export interface FsGrepNodeFallbackEvent {
   reason: 'rg_missing';
 }
 
+export interface FsSuggestNodeFallbackEvent {
+  reason: 'rg_missing' | 'rg_error';
+}
+
 export interface SubagentCreatedEvent {
   subagent_name: string;
   run_in_background: boolean;
@@ -808,6 +812,11 @@ export const telemetryEventDefinitions = {
   fs_grep_node_fallback: defineTelemetryEvent<FsGrepNodeFallbackEvent>({
     owner: 'kimi-code',
     comment: 'The fs grep path falls back to the node implementation.',
+    properties: { reason: 'Why the fallback was taken' },
+  }),
+  fs_suggest_node_fallback: defineTelemetryEvent<FsSuggestNodeFallbackEvent>({
+    owner: 'kimi-code',
+    comment: 'The fs suggest path falls back to the node implementation.',
     properties: { reason: 'Why the fallback was taken' },
   }),
   subagent_created: defineTelemetryEvent<SubagentCreatedEvent>({

--- a/packages/agent-core-v2/src/workspace/workspaceFs/fs.ts
+++ b/packages/agent-core-v2/src/workspace/workspaceFs/fs.ts
@@ -182,6 +182,31 @@ export const fsSearchResponseSchema = z.object({
 });
 export type FsSearchResponse = z.infer<typeof fsSearchResponseSchema>;
 
+export const fsSuggestItemSchema = z.object({
+  path: z.string(),
+  name: z.string(),
+  kind: fsKindSchema,
+  score: z.number().min(0).max(1),
+  match_positions: z.array(z.number().int().nonnegative()),
+});
+export type FsSuggestItem = z.infer<typeof fsSuggestItemSchema>;
+
+export const fsSuggestRequestSchema = z.object({
+  query: z.string(),
+  limit: z.number().int().min(1).max(200).default(50),
+  follow_gitignore: z.boolean().default(true),
+  show_hidden: z.boolean().default(false),
+  include_globs: z.array(z.string()).optional(),
+  exclude_globs: z.array(z.string()).optional(),
+});
+export type FsSuggestRequest = z.infer<typeof fsSuggestRequestSchema>;
+
+export const fsSuggestResponseSchema = z.object({
+  items: z.array(fsSuggestItemSchema),
+  truncated: z.boolean(),
+});
+export type FsSuggestResponse = z.infer<typeof fsSuggestResponseSchema>;
+
 export const fsGrepRequestSchema = z.object({
   pattern: z.string().min(1),
   regex: z.boolean().default(false),
@@ -229,6 +254,7 @@ export interface IWorkspaceFsService {
   statMany(req: FsStatManyRequest): Promise<FsStatManyResponse>;
   mkdir(req: FsMkdirRequest): Promise<FsMkdirResponse>;
   search(req: FsSearchRequest): Promise<FsSearchResponse>;
+  suggest(req: FsSuggestRequest): Promise<FsSuggestResponse>;
   grep(req: FsGrepRequest): Promise<FsGrepResponse>;
   gitStatus(req: FsGitStatusRequest): Promise<FsGitStatusResponse>;
   diff(req: FsDiffRequest): Promise<FsDiffResponse>;

--- a/packages/agent-core-v2/src/workspace/workspaceFs/fsService.ts
+++ b/packages/agent-core-v2/src/workspace/workspaceFs/fsService.ts
@@ -23,6 +23,8 @@ import {
   type FsStatManyResponse,
   type FsStatRequest,
   type FsStatResponse,
+  type FsSuggestRequest,
+  type FsSuggestResponse,
 } from './fs';
 
 const FsWireErrorCode = {
@@ -59,15 +61,21 @@ import {
   compileGrepPattern,
   computeFuzzyScore,
   computeMatchPositions,
+  evaluateSuggestCandidate,
   matchesAnyGlob,
   type RgJsonRecord,
   rgPath,
   rgText,
   stripTrailingNewline,
+  SuggestTopHeap,
+  type SuggestQuery,
+  VCS_METADATA_DIRS,
 } from './internal/fsSearch';
 
 const SEARCH_HARD_CAP = 500;
 const GREP_TIMEOUT_MS = 30_000;
+const SUGGEST_TIMEOUT_MS = 10_000;
+const SUGGEST_WALK_ABORTED = new Error('suggest walk aborted');
 const WALK_MAX_DEPTH = 64;
 
 const FS_READ_MAX_BYTES = 10 * 1024 * 1024;
@@ -487,6 +495,214 @@ export class WorkspaceFsService implements IWorkspaceFsService {
     const effectiveCap = Math.min(req.limit, SEARCH_HARD_CAP);
     const truncated = candidates.length > effectiveCap;
     return { items: candidates.slice(0, effectiveCap), truncated };
+  }
+
+  async suggest(req: FsSuggestRequest): Promise<FsSuggestResponse> {
+    if (req.query === '') {
+      const listed = await this.list({
+        path: '.',
+        depth: 1,
+        limit: SEARCH_HARD_CAP,
+        show_hidden: req.show_hidden,
+        follow_gitignore: req.follow_gitignore,
+        exclude_globs: req.exclude_globs,
+        sort: 'type_first',
+        include_git_status: false,
+      });
+      const filtered = listed.items
+        .filter((entry) => !VCS_METADATA_DIRS.has(entry.name))
+        .filter(
+          (entry) =>
+            req.include_globs === undefined || matchesAnyGlob(entry.path, req.include_globs),
+        );
+      const items = filtered.slice(0, req.limit).map((entry) => ({
+        path: entry.path,
+        name: entry.name,
+        kind: entry.kind,
+        score: 1,
+        match_positions: [],
+      }));
+      return { items, truncated: listed.truncated || filtered.length > req.limit };
+    }
+
+    const queryLower = req.query.toLowerCase();
+    const pathSegments = queryLower.includes('/')
+      ? queryLower.split('/').filter((seg) => seg.length > 0)
+      : [];
+    if (queryLower.includes('/') && pathSegments.length === 0) {
+      return { items: [], truncated: false };
+    }
+    const query: SuggestQuery = {
+      nameQuery: queryLower,
+      pathSegments,
+      showHidden: req.show_hidden,
+      followGitignore: req.follow_gitignore,
+      includeGlobs: req.include_globs,
+      excludeGlobs: req.exclude_globs,
+    };
+    const cap = req.limit;
+
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), SUGGEST_TIMEOUT_MS);
+    timer.unref?.();
+    try {
+      let resolution: RgResolution | null = null;
+      try {
+        resolution = await this.resolveRg();
+      } catch {
+        resolution = null;
+      }
+      if (resolution !== null) {
+        try {
+          return await this.suggestWithRg(query, cap, controller.signal, resolution.path);
+        } catch (err) {
+          if (controller.signal.aborted) throw err;
+          this.telemetry.track2('fs_suggest_node_fallback', { reason: 'rg_error' });
+          return await this.suggestWithNode(query, cap, controller.signal);
+        }
+      }
+      this.telemetry.track2('fs_suggest_node_fallback', { reason: 'rg_missing' });
+      return await this.suggestWithNode(query, cap, controller.signal);
+    } finally {
+      clearTimeout(timer);
+    }
+  }
+
+  private async suggestWithRg(
+    query: SuggestQuery,
+    cap: number,
+    signal: AbortSignal,
+    rgBinary: string,
+  ): Promise<FsSuggestResponse> {
+    const args = ['--files'];
+    if (query.followGitignore) {
+      args.push('--no-require-git');
+    } else {
+      args.push('--no-ignore');
+    }
+    if (query.showHidden) args.push('--hidden');
+    for (const dir of VCS_METADATA_DIRS) args.push('-g', `!${dir}`, '-g', `!${dir}/**`);
+
+    const lease = this.resolver.acquire(
+      { workspaceId: this.workspaceId, runtimeId: this.runtimeId },
+      ['process'],
+    );
+    const proc = await lease.runtime.process!.spawn(rgBinary, args, { cwd: this.workDir });
+
+    const top = new SuggestTopHeap(cap);
+    const seenDirs = new Set<string>();
+    let matched = 0;
+    let killed = false;
+    const kill = (): void => {
+      if (killed) return;
+      killed = true;
+      void proc.kill('SIGKILL');
+    };
+    const onAbort = (): void => kill();
+    if (signal.aborted) kill();
+    else signal.addEventListener('abort', onAbort, { once: true });
+
+    const handleLine = (raw: string): void => {
+      let line = raw;
+      if (line.endsWith('\r')) line = line.slice(0, -1);
+      if (line.startsWith('./')) line = line.slice(2);
+      if (line.length === 0) return;
+      const file = evaluateSuggestCandidate(line, 'file', query);
+      if (file !== null) {
+        matched += 1;
+        top.push(file);
+      }
+      let slash = line.lastIndexOf('/');
+      while (slash > 0) {
+        const dir = line.slice(0, slash);
+        if (!seenDirs.has(dir)) {
+          seenDirs.add(dir);
+          const candidate = evaluateSuggestCandidate(dir, 'directory', query);
+          if (candidate !== null) {
+            matched += 1;
+            top.push(candidate);
+          }
+        }
+        slash = line.lastIndexOf('/', slash - 1);
+      }
+    };
+
+    let stdoutBuf = '';
+    const drainStdout = async (): Promise<void> => {
+      proc.stdout.setEncoding('utf-8');
+      try {
+        for await (const chunk of proc.stdout) {
+          stdoutBuf += chunk as string;
+          let nl = stdoutBuf.indexOf('\n');
+          while (nl >= 0) {
+            handleLine(stdoutBuf.slice(0, nl));
+            stdoutBuf = stdoutBuf.slice(nl + 1);
+            nl = stdoutBuf.indexOf('\n');
+          }
+        }
+        if (stdoutBuf.length > 0) handleLine(stdoutBuf);
+      } catch (error) {
+        if (!(killed && isPrematureCloseError(error))) throw error;
+      }
+    };
+
+    let exitCode: number;
+    try {
+      [, , exitCode] = await Promise.all([
+        drainStdout(),
+        readStream(proc.stderr),
+        proc.wait().catch(() => -1),
+      ]);
+    } finally {
+      signal.removeEventListener('abort', onAbort);
+      try {
+        void proc.dispose();
+      } catch {
+      }
+      lease.dispose();
+    }
+
+    if (!killed && exitCode !== 0 && exitCode !== 1) {
+      throw new Error(`rg --files exited with code ${exitCode}`);
+    }
+
+    const items = top.drain().map((candidate) => ({
+      path: candidate.path,
+      name: candidate.name,
+      kind: candidate.kind,
+      score: candidate.score,
+      match_positions: [...candidate.positions],
+    }));
+    return { items, truncated: matched > cap || signal.aborted };
+  }
+
+  private async suggestWithNode(
+    query: SuggestQuery,
+    cap: number,
+    signal: AbortSignal,
+  ): Promise<FsSuggestResponse> {
+    const matcher = query.followGitignore ? await this.matcher() : undefined;
+    const top = new SuggestTopHeap(cap);
+    let matched = 0;
+    try {
+      await this.walk('', matcher, async (relPath, _name, kind) => {
+        if (signal.aborted) throw SUGGEST_WALK_ABORTED;
+        const candidate = evaluateSuggestCandidate(relPath, kind, query);
+        if (candidate === null) return;
+        matched += 1;
+        top.push(candidate);
+      });
+    } catch (err) {
+      if (err !== SUGGEST_WALK_ABORTED) throw err;
+    }
+    const items = top.drain().map((candidate) => ({
+      path: candidate.path,
+      name: candidate.name,
+      kind: candidate.kind,
+      score: candidate.score,
+      match_positions: [...candidate.positions],
+    }));
+    return { items, truncated: matched > cap || signal.aborted };
   }
 
   async grep(req: FsGrepRequest): Promise<FsGrepResponse> {

--- a/packages/agent-core-v2/src/workspace/workspaceFs/internal/fsSearch.ts
+++ b/packages/agent-core-v2/src/workspace/workspaceFs/internal/fsSearch.ts
@@ -136,3 +136,206 @@ export function rgText(l: RgLinesField | undefined): string {
   }
   return '';
 }
+
+export const VCS_METADATA_DIRS: ReadonlySet<string> = new Set([
+  '.git',
+  '.jj',
+  '.svn',
+  '.hg',
+  '.bzr',
+]);
+
+export interface SuggestQuery {
+  readonly nameQuery: string;
+  readonly pathSegments: readonly string[];
+  readonly showHidden: boolean;
+  readonly followGitignore: boolean;
+  readonly includeGlobs?: readonly string[];
+  readonly excludeGlobs?: readonly string[];
+}
+
+export interface SuggestCandidate {
+  readonly path: string;
+  readonly name: string;
+  readonly kind: 'file' | 'directory' | 'symlink';
+  readonly tier: number;
+  readonly depth: number;
+  readonly span: number;
+  readonly score: number;
+  readonly positions: readonly number[];
+}
+
+interface SuggestMatch {
+  readonly tier: number;
+  readonly span: number;
+  readonly positions: number[];
+}
+
+function subsequencePositions(segment: string, query: string): number[] | null {
+  const positions: number[] = [];
+  let idx = 0;
+  for (const ch of query) {
+    const found = segment.indexOf(ch, idx);
+    if (found < 0) return null;
+    positions.push(found);
+    idx = found + 1;
+  }
+  return positions;
+}
+
+function matchSuggestName(name: string, queryLower: string): SuggestMatch | null {
+  const positions = subsequencePositions(name.toLowerCase(), queryLower);
+  if (positions === null) return null;
+  const nameLower = name.toLowerCase();
+  const tier = nameLower === queryLower ? 3 : nameLower.startsWith(queryLower) ? 2 : 1;
+  const span = positions[positions.length - 1]! - positions[0]! + 1;
+  return { tier, span, positions };
+}
+
+function matchSuggestPath(path: string, querySegments: readonly string[]): SuggestMatch | null {
+  const pathLower = path.toLowerCase();
+  const pathSegments = pathLower.split('/');
+  const offsets: number[] = [];
+  let offset = 0;
+  for (const seg of pathSegments) {
+    offsets.push(offset);
+    offset += seg.length + 1;
+  }
+  const positions: number[] = [];
+  let nextSeg = 0;
+  let lastSeg = -1;
+  let lastSegPrefix = false;
+  for (const querySeg of querySegments) {
+    let matchedSeg = -1;
+    let segPositions: number[] | null = null;
+    for (let s = nextSeg; s < pathSegments.length; s++) {
+      segPositions = subsequencePositions(pathSegments[s]!, querySeg);
+      if (segPositions !== null) {
+        matchedSeg = s;
+        break;
+      }
+    }
+    if (matchedSeg < 0 || segPositions === null) return null;
+    for (const p of segPositions) positions.push(offsets[matchedSeg]! + p);
+    lastSegPrefix = pathSegments[matchedSeg]!.startsWith(querySeg);
+    lastSeg = matchedSeg;
+    nextSeg = matchedSeg + 1;
+  }
+  const tier =
+    pathLower === querySegments.join('/')
+      ? 3
+      : lastSeg === pathSegments.length - 1 && lastSegPrefix
+        ? 2
+        : 1;
+  const span = positions[positions.length - 1]! - positions[0]! + 1;
+  return { tier, span, positions };
+}
+
+export function evaluateSuggestCandidate(
+  relPath: string,
+  kind: 'file' | 'directory' | 'symlink',
+  query: SuggestQuery,
+): SuggestCandidate | null {
+  const segments = relPath.split('/');
+  if (segments.some((s) => VCS_METADATA_DIRS.has(s))) return null;
+  if (!query.showHidden && segments.some((s) => s.startsWith('.'))) return null;
+  const name = segments[segments.length - 1]!;
+  const pathMode = query.pathSegments.length > 0;
+  const match = pathMode
+    ? matchSuggestPath(relPath, query.pathSegments)
+    : matchSuggestName(name, query.nameQuery);
+  if (match === null) return null;
+  if (query.includeGlobs !== undefined && !matchesAnyGlob(relPath, query.includeGlobs)) return null;
+  if (query.excludeGlobs !== undefined && matchesAnyGlob(relPath, query.excludeGlobs)) return null;
+  const queryLength = pathMode
+    ? query.pathSegments.reduce((total, seg) => total + seg.length, 0)
+    : query.nameQuery.length;
+  const raw =
+    match.tier +
+    0.5 / segments.length +
+    0.25 * (queryLength / Math.max(name.length, 1)) +
+    0.25 * (queryLength / Math.max(match.span, 1));
+  const score = Math.min(1, raw / 4);
+  const base = relPath.length - name.length;
+  const positions = pathMode ? match.positions : match.positions.map((p) => base + p);
+  return {
+    path: relPath,
+    name,
+    kind,
+    tier: match.tier,
+    depth: segments.length,
+    span: match.span,
+    score,
+    positions,
+  };
+}
+
+export function compareSuggestCandidates(a: SuggestCandidate, b: SuggestCandidate): number {
+  if (a.tier !== b.tier) return b.tier - a.tier;
+  if (a.depth !== b.depth) return a.depth - b.depth;
+  if (a.name.length !== b.name.length) return a.name.length - b.name.length;
+  if (a.span !== b.span) return a.span - b.span;
+  if (a.path < b.path) return -1;
+  if (a.path > b.path) return 1;
+  return 0;
+}
+
+export class SuggestTopHeap {
+  private readonly heap: SuggestCandidate[] = [];
+
+  constructor(private readonly cap: number) {}
+
+  get size(): number {
+    return this.heap.length;
+  }
+
+  push(candidate: SuggestCandidate): void {
+    if (this.cap <= 0) return;
+    if (this.heap.length < this.cap) {
+      this.heap.push(candidate);
+      this.siftUp(this.heap.length - 1);
+      return;
+    }
+    if (compareSuggestCandidates(this.heap[0]!, candidate) <= 0) return;
+    this.heap[0] = candidate;
+    this.siftDown(0);
+  }
+
+  drain(): SuggestCandidate[] {
+    return this.heap.slice().sort(compareSuggestCandidates);
+  }
+
+  private siftUp(index: number): void {
+    let i = index;
+    while (i > 0) {
+      const parent = (i - 1) >> 1;
+      if (compareSuggestCandidates(this.heap[parent]!, this.heap[i]!) >= 0) break;
+      [this.heap[parent], this.heap[i]] = [this.heap[i]!, this.heap[parent]!];
+      i = parent;
+    }
+  }
+
+  private siftDown(index: number): void {
+    let i = index;
+    for (;;) {
+      const left = i * 2 + 1;
+      const right = left + 1;
+      let worst = i;
+      if (
+        left < this.heap.length &&
+        compareSuggestCandidates(this.heap[left]!, this.heap[worst]!) > 0
+      ) {
+        worst = left;
+      }
+      if (
+        right < this.heap.length &&
+        compareSuggestCandidates(this.heap[right]!, this.heap[worst]!) > 0
+      ) {
+        worst = right;
+      }
+      if (worst === i) break;
+      [this.heap[worst], this.heap[i]] = [this.heap[i]!, this.heap[worst]!];
+      i = worst;
+    }
+  }
+}

--- a/packages/agent-core-v2/test/workspace/workspaceFs/fsService.test.ts
+++ b/packages/agent-core-v2/test/workspace/workspaceFs/fsService.test.ts
@@ -535,6 +535,386 @@ describe('WorkspaceFsService.search', () => {
   });
 });
 
+describe('WorkspaceFsService.suggest', () => {
+  function rgLinesHandler(lines: readonly string[], captured?: string[][]): RunHandler {
+    return (args) => {
+      captured?.push([...args]);
+      if (args[0] === 'rg' && args[1] === '--version') {
+        return { stdout: 'ripgrep 15.0.0', exitCode: 0 };
+      }
+      if (args[0] === 'rg' && args.includes('--files')) {
+        return { stdout: lines.map((l) => `${l}\n`).join(''), exitCode: 0 };
+      }
+      return { stdout: '', exitCode: 0 };
+    };
+  }
+
+  function rgMissingHandler(args: readonly string[]): { stdout: string; exitCode: number } {
+    if (args[0] === 'rg' && args[1] === '--version') return { stdout: '', exitCode: 1 };
+    return { stdout: '', exitCode: 0 };
+  }
+
+  it('matches path segments in order and ranks the matched directory first', async () => {
+    const fs = makeSession(
+      {},
+      rgLinesHandler(['apps/desktop/package.json', 'apps/mobile/app.ts', 'src/api/index.ts']),
+    );
+    const result = await fs.suggest({
+      query: 'apps/de',
+      limit: 50,
+      follow_gitignore: true,
+      show_hidden: false,
+    });
+    expect(result.items[0]).toMatchObject({
+      path: 'apps/desktop',
+      name: 'desktop',
+      kind: 'directory',
+    });
+    expect(result.items.map((i) => i.path)).toContain('apps/desktop/package.json');
+  });
+
+  it('allows skipping segments when consuming the query', async () => {
+    const fs = makeSession(
+      {},
+      rgLinesHandler(['apps/desktop/package.json', 'src/api/index.ts']),
+    );
+    const result = await fs.suggest({
+      query: 'ap/de',
+      limit: 50,
+      follow_gitignore: true,
+      show_hidden: false,
+    });
+    expect(result.items[0]?.path).toBe('apps/desktop');
+    expect(result.items.map((i) => i.path)).toContain('src/api/index.ts');
+  });
+
+  it('matches a file several segments deep', async () => {
+    const fs = makeSession({}, rgLinesHandler(['apps/desktop/package.json']));
+    const result = await fs.suggest({
+      query: 'apps/pack',
+      limit: 50,
+      follow_gitignore: true,
+      show_hidden: false,
+    });
+    expect(result.items.map((i) => i.path)).toContain('apps/desktop/package.json');
+  });
+
+  it('ignores an empty last query segment', async () => {
+    const fs = makeSession(
+      {},
+      rgLinesHandler(['apps/desktop/package.json', 'src/app.ts']),
+    );
+    const result = await fs.suggest({
+      query: 'apps/',
+      limit: 50,
+      follow_gitignore: true,
+      show_hidden: false,
+    });
+    expect(result.items[0]?.path).toBe('apps');
+  });
+
+  it('returns an empty list when a path-form query has no match', async () => {
+    const fs = makeSession({}, rgLinesHandler(['apps/desktop/package.json']));
+    const result = await fs.suggest({
+      query: 'zzz/qqq',
+      limit: 50,
+      follow_gitignore: true,
+      show_hidden: false,
+    });
+    expect(result.items).toEqual([]);
+    expect(result.truncated).toBe(false);
+  });
+
+  it('matches basenames across the whole workspace in name mode', async () => {
+    const fs = makeSession({}, rgLinesHandler(['docs/README.md', 'src/app.ts']));
+    const result = await fs.suggest({
+      query: 'readme',
+      limit: 50,
+      follow_gitignore: true,
+      show_hidden: false,
+    });
+    expect(result.items.map((i) => i.path)).toEqual(['docs/README.md']);
+    expect(result.items[0]).toMatchObject({ name: 'README.md', kind: 'file' });
+    expect(result.items[0]?.match_positions).toEqual([5, 6, 7, 8, 9, 10]);
+  });
+
+  it('ranks a shallow prefix hit before a deeper one and varies scores', async () => {
+    const fs = makeSession({}, rgLinesHandler(['apps/index.ts', 'src/deep/api.ts']));
+    const result = await fs.suggest({
+      query: 'a',
+      limit: 50,
+      follow_gitignore: true,
+      show_hidden: false,
+    });
+    const paths = result.items.map((i) => i.path);
+    expect(paths).toContain('apps');
+    expect(paths.indexOf('apps')).toBeLessThan(paths.indexOf('src/deep/api.ts'));
+    expect(new Set(result.items.map((i) => i.score)).size).toBeGreaterThan(1);
+  });
+
+  it('ranks an exact short hit before weaker longer or deeper hits', async () => {
+    const fs = makeSession({}, rgLinesHandler(['apps/x.ts', 'xapps/y.ts']));
+    const result = await fs.suggest({
+      query: 'apps',
+      limit: 50,
+      follow_gitignore: true,
+      show_hidden: false,
+    });
+    expect(result.items[0]?.path).toBe('apps');
+  });
+
+  it('passes gitignore and hidden flags to rg', async () => {
+    const captured: string[][] = [];
+    const fs = makeSession({}, rgLinesHandler([], captured));
+    await fs.suggest({ query: 'x', limit: 50, follow_gitignore: true, show_hidden: true });
+    const filesArgs = captured.find((a) => a.includes('--files'))!;
+    expect(filesArgs).toContain('--no-require-git');
+    expect(filesArgs).toContain('--hidden');
+    expect(filesArgs).not.toContain('--no-ignore');
+    expect(filesArgs).toContain('!.git/**');
+  });
+
+  it('passes --no-ignore to rg when follow_gitignore is false', async () => {
+    const captured: string[][] = [];
+    const fs = makeSession({}, rgLinesHandler([], captured));
+    await fs.suggest({ query: 'x', limit: 50, follow_gitignore: false, show_hidden: false });
+    const filesArgs = captured.find((a) => a.includes('--files'))!;
+    expect(filesArgs).toContain('--no-ignore');
+    expect(filesArgs).not.toContain('--no-require-git');
+    expect(filesArgs).not.toContain('--hidden');
+  });
+
+  it('hides dot-prefixed entries at any depth unless show_hidden is set', async () => {
+    const fs = makeSession(
+      {},
+      rgLinesHandler(['visible.ts', '.env.ts', 'sub/.secret/x.ts']),
+    );
+    const off = await fs.suggest({
+      query: 'ts',
+      limit: 50,
+      follow_gitignore: true,
+      show_hidden: false,
+    });
+    expect(off.items.map((i) => i.path)).toEqual(['visible.ts']);
+    const on = await fs.suggest({
+      query: 'ts',
+      limit: 50,
+      follow_gitignore: true,
+      show_hidden: true,
+    });
+    expect(on.items.map((i) => i.path)).toContain('.env.ts');
+    expect(on.items.map((i) => i.path)).toContain('sub/.secret/x.ts');
+  });
+
+  it('never returns VCS metadata entries even with show_hidden', async () => {
+    const fs = makeSession({}, rgLinesHandler(['.git/x.ts', 'src/.jj/y.ts', 'ok.ts']));
+    const result = await fs.suggest({
+      query: 'ts',
+      limit: 50,
+      follow_gitignore: true,
+      show_hidden: true,
+    });
+    expect(result.items.map((i) => i.path)).toEqual(['ok.ts']);
+  });
+
+  it('lists root entries for an empty query and never lists VCS dirs', async () => {
+    const fs = makeSession(
+      { 'kept.ts': '', '.hidden.ts': '', '.git/config': '' },
+      emptyHandler,
+      [],
+      defaultGitStub(),
+      ['link'],
+    );
+    const shown = await fs.suggest({
+      query: '',
+      limit: 50,
+      follow_gitignore: false,
+      show_hidden: true,
+    });
+    const paths = shown.items.map((i) => i.path);
+    expect(paths).toContain('.hidden.ts');
+    expect(paths).toContain('kept.ts');
+    expect(paths).not.toContain('.git');
+    expect(shown.items.find((i) => i.path === 'link')?.kind).toBe('symlink');
+
+    const hidden = await fs.suggest({
+      query: '',
+      limit: 50,
+      follow_gitignore: false,
+      show_hidden: false,
+    });
+    expect(hidden.items.map((i) => i.path)).not.toContain('.hidden.ts');
+  });
+
+  it('truncates at the limit and reports it', async () => {
+    const fs = makeSession({}, rgLinesHandler(['a1.ts', 'a2.ts', 'a3.ts', 'a4.ts']));
+    const result = await fs.suggest({
+      query: 'a',
+      limit: 2,
+      follow_gitignore: true,
+      show_hidden: false,
+    });
+    expect(result.items).toHaveLength(2);
+    expect(result.truncated).toBe(true);
+  });
+
+  it('applies include_globs and exclude_globs after matching', async () => {
+    const fs = makeSession({}, rgLinesHandler(['src/a.ts', 'src/a.md', 'dist/a.ts']));
+    const included = await fs.suggest({
+      query: 'a',
+      limit: 50,
+      follow_gitignore: true,
+      show_hidden: false,
+      include_globs: ['**/*.ts'],
+    });
+    expect(included.items.map((i) => i.path)).toContain('src/a.ts');
+    expect(included.items.map((i) => i.path)).not.toContain('src/a.md');
+    const excluded = await fs.suggest({
+      query: 'a',
+      limit: 50,
+      follow_gitignore: true,
+      show_hidden: false,
+      exclude_globs: ['dist/**'],
+    });
+    expect(excluded.items.map((i) => i.path)).not.toContain('dist/a.ts');
+  });
+
+  it('falls back to the node walk when rg is unavailable', async () => {
+    const events: Array<{ event: string; properties: Record<string, unknown> }> = [];
+    const fs = makeSession(
+      {
+        'src/foo.ts': '',
+        'src/nested/bar.ts': '',
+        '.gitignore': 'ignored.ts\n',
+        'ignored.ts': '',
+      },
+      rgMissingHandler,
+      events,
+      defaultGitStub(),
+      ['src/link'],
+    );
+    const result = await fs.suggest({
+      query: 'foo',
+      limit: 50,
+      follow_gitignore: true,
+      show_hidden: false,
+    });
+    expect(result.items.map((i) => i.path)).toContain('src/foo.ts');
+    expect(events).toContainEqual({
+      event: 'fs_suggest_node_fallback',
+      properties: { reason: 'rg_missing' },
+    });
+
+    const pathResult = await fs.suggest({
+      query: 'src/nested',
+      limit: 50,
+      follow_gitignore: true,
+      show_hidden: false,
+    });
+    expect(pathResult.items.map((i) => i.path)).toContain('src/nested/bar.ts');
+
+    const linkResult = await fs.suggest({
+      query: 'link',
+      limit: 50,
+      follow_gitignore: true,
+      show_hidden: false,
+    });
+    expect(linkResult.items.find((i) => i.path === 'src/link')?.kind).toBe('symlink');
+    expect(linkResult.items.some((i) => i.path.startsWith('src/link/'))).toBe(false);
+
+    const ignored = await fs.suggest({
+      query: 'ignored',
+      limit: 50,
+      follow_gitignore: true,
+      show_hidden: false,
+    });
+    expect(ignored.items.map((i) => i.path)).not.toContain('ignored.ts');
+  });
+
+  it('hides dot entries in the fallback walk unless show_hidden is set', async () => {
+    const fs = makeSession({ '.secret.ts': '', 'plain.ts': '' }, rgMissingHandler);
+    const off = await fs.suggest({
+      query: 'ts',
+      limit: 50,
+      follow_gitignore: true,
+      show_hidden: false,
+    });
+    expect(off.items.map((i) => i.path)).toEqual(['plain.ts']);
+    const on = await fs.suggest({
+      query: 'ts',
+      limit: 50,
+      follow_gitignore: true,
+      show_hidden: true,
+    });
+    expect(on.items.map((i) => i.path)).toContain('.secret.ts');
+  });
+
+  it('falls back to the node walk when rg fails to spawn', async () => {
+    const events: Array<{ event: string; properties: Record<string, unknown> }> = [];
+    const runner: IHostProcessService = {
+      _serviceBrand: undefined,
+      spawn: async (command, args) => {
+        const all = [command, ...(args ?? [])];
+        if (all[0] === 'rg' && all[1] === '--version') {
+          return fakeProcess('ripgrep 15.0.0', '', 0);
+        }
+        throw new Error('spawn EAGAIN');
+      },
+    };
+    const fs = makeSession({ 'src/foo.ts': '' }, emptyHandler, events, defaultGitStub(), [], runner);
+    const result = await fs.suggest({
+      query: 'foo',
+      limit: 50,
+      follow_gitignore: true,
+      show_hidden: false,
+    });
+    expect(result.items.map((i) => i.path)).toContain('src/foo.ts');
+    expect(events).toContainEqual({
+      event: 'fs_suggest_node_fallback',
+      properties: { reason: 'rg_error' },
+    });
+  });
+
+  it('falls back to the node walk when rg exits with an error status', async () => {
+    const events: Array<{ event: string; properties: Record<string, unknown> }> = [];
+    const runner: IHostProcessService = {
+      _serviceBrand: undefined,
+      spawn: async (command, args) => {
+        const all = [command, ...(args ?? [])];
+        if (all[0] === 'rg' && all[1] === '--version') {
+          return fakeProcess('ripgrep 15.0.0', '', 0);
+        }
+        return fakeProcess('', 'permission denied', 2);
+      },
+    };
+    const fs = makeSession({ 'src/foo.ts': '' }, emptyHandler, events, defaultGitStub(), [], runner);
+    const result = await fs.suggest({
+      query: 'foo',
+      limit: 50,
+      follow_gitignore: true,
+      show_hidden: false,
+    });
+    expect(result.items.map((i) => i.path)).toContain('src/foo.ts');
+    expect(events).toContainEqual({
+      event: 'fs_suggest_node_fallback',
+      properties: { reason: 'rg_error' },
+    });
+  });
+
+  it('filters the root listing before applying the limit', async () => {
+    const fs = makeSession({ 'aaa/x.ts': '', 'y.ts': '', 'z.ts': '' }, emptyHandler);
+    const result = await fs.suggest({
+      query: '',
+      limit: 1,
+      follow_gitignore: true,
+      show_hidden: false,
+      include_globs: ['**/*.ts'],
+    });
+    expect(result.items.map((i) => i.path)).toEqual(['y.ts']);
+    expect(result.truncated).toBe(true);
+  });
+});
+
 describe('WorkspaceFsService.grep', () => {
   it('falls back to the node implementation when rg is unavailable', async () => {
     const events: Array<{ event: string; properties: Record<string, unknown> }> = [];

--- a/packages/kap-server/src/routes/fs.ts
+++ b/packages/kap-server/src/routes/fs.ts
@@ -28,6 +28,8 @@ import {
   fsSearchResponseSchema,
   fsStatManyRequestSchema,
   fsStatRequestSchema,
+  fsSuggestRequestSchema,
+  fsSuggestResponseSchema,
 } from '@moonshot-ai/agent-core-v2/workspace/workspaceFs/fs';
 import { GitService } from '@moonshot-ai/agent-core-v2/app/git/gitService';
 import type { IHostFileSystem } from '@moonshot-ai/agent-core-v2/os/interface/hostFileSystem';
@@ -91,6 +93,11 @@ const fsDownloadQuerySchema = z.object({
 });
 
 const workspaceFsSearchBodySchema = fsSearchRequestSchema.extend({
+  workspace: z.string().min(1),
+  runtime_id: z.string().min(1).optional(),
+});
+
+const workspaceFsSuggestBodySchema = fsSuggestRequestSchema.extend({
   workspace: z.string().min(1),
   runtime_id: z.string().min(1).optional(),
 });
@@ -404,6 +411,51 @@ export function registerFsRoutes(app: FsRouteHost, core: Scope): void {
     workspaceSearchRoute.path,
     workspaceSearchRoute.options,
     workspaceSearchRoute.handler as unknown as Parameters<FsRouteHost['post']>[2],
+  );
+
+  const workspaceSuggestRoute = defineRoute(
+    {
+      method: 'POST',
+      path: '/workspace/fs::suggest',
+      body: workspaceFsSuggestBodySchema,
+      success: { data: fsSuggestResponseSchema },
+      errors: {
+        [ErrorCode.VALIDATION_FAILED]: { detailsSchema },
+        [ErrorCode.WORKSPACE_NOT_FOUND]: {},
+      },
+      description:
+        'Suggest file and directory completion candidates in a workspace without a session. `workspace` accepts a registered workspace id or an absolute root (registered on the spot).',
+      tags: ['fs'],
+      operationId: 'workspaceFsSuggest',
+    },
+    async (req, reply) => {
+      const { workspace, runtime_id, ...suggestRequest } = req.body;
+      let runtimeFs: RuntimeFsScope | undefined;
+      try {
+        runtimeFs = await resolveWorkspaceFs(core, workspace, runtime_id ?? 'local', ['fs']);
+        if (runtimeFs === undefined) {
+          reply.send(
+            errEnvelope(
+              ErrorCode.WORKSPACE_NOT_FOUND,
+              `workspace ${workspace} does not exist`,
+              req.id,
+            ),
+          );
+          return;
+        }
+        const data = await runtimeFs.fs.suggest(suggestRequest);
+        reply.send(okEnvelope(data, req.id));
+      } catch (err) {
+        sendMappedError(reply, req, err);
+      } finally {
+        runtimeFs?.lease.dispose();
+      }
+    },
+  );
+  app.post(
+    workspaceSuggestRoute.path,
+    workspaceSuggestRoute.options,
+    workspaceSuggestRoute.handler as unknown as Parameters<FsRouteHost['post']>[2],
   );
 
   const downloadRoute = defineRoute(

--- a/packages/kap-server/test/__snapshots__/apiSurface.snapshot.test.ts.snap
+++ b/packages/kap-server/test/__snapshots__/apiSurface.snapshot.test.ts.snap
@@ -454,6 +454,10 @@ exports[`API surface snapshot > matches the documented v2 route table and meta e
     ],
     [
       "POST",
+      "/api/v1/workspace/fs:suggest",
+    ],
+    [
+      "POST",
       "/api/v1/workspaces",
     ],
     [

--- a/packages/kap-server/test/fs.test.ts
+++ b/packages/kap-server/test/fs.test.ts
@@ -1,4 +1,4 @@
-import { chmod, mkdtemp, rm, symlink, writeFile } from 'node:fs/promises';
+import { chmod, mkdir, mkdtemp, rm, symlink, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
@@ -488,6 +488,136 @@ describe('server-v2 /api/v1 fs routes', () => {
 
   it('workspace fs:search rejects a missing workspace field with VALIDATION_FAILED', async () => {
     const body = await postWorkspaceSearch<null>({ query: 'x' });
+    expect(body.code).toBe(ErrorCode.VALIDATION_FAILED);
+  });
+
+  interface SuggestItemWire {
+    path: string;
+    name: string;
+    kind: string;
+    score: number;
+    match_positions: number[];
+  }
+
+  async function postWorkspaceSuggest<T>(body: unknown): Promise<Envelope<T>> {
+    const res = await fetch(`${base}/api/v1/workspace/fs:suggest`, {
+      method: 'POST',
+      headers: authHeaders(server as RunningServer, { 'content-type': 'application/json' }),
+      body: JSON.stringify({ runtime_id: 'local', ...(body as object) }),
+    } as never);
+    return (await res.json()) as Envelope<T>;
+  }
+
+  it('workspace fs:suggest finds files by registered workspace id', async () => {
+    await writeFile(join(work!, 'epsilon.ts'), '');
+    const res = await fetch(`${base}/api/v1/workspaces`, {
+      method: 'POST',
+      headers: authHeaders(server as RunningServer, { 'content-type': 'application/json' }),
+      body: JSON.stringify({ root: work }),
+    } as never);
+    const created = (await res.json()) as Envelope<{ id: string }>;
+    expect(created.code).toBe(0);
+
+    const body = await postWorkspaceSuggest<{ items: SuggestItemWire[]; truncated: boolean }>({
+      workspace: created.data.id,
+      query: 'epsilon',
+    });
+    expect(body.code).toBe(0);
+    expect(body.data.items.map((i) => i.path)).toContain('epsilon.ts');
+  });
+
+  it('workspace fs:suggest finds files by absolute root path', async () => {
+    await writeFile(join(work!, 'zeta.ts'), '');
+    const body = await postWorkspaceSuggest<{ items: SuggestItemWire[]; truncated: boolean }>({
+      workspace: work,
+      query: 'zeta',
+    });
+    expect(body.code).toBe(0);
+    expect(body.data.items.map((i) => i.path)).toContain('zeta.ts');
+  });
+
+  it('workspace fs:suggest lists top-level entries for an empty query', async () => {
+    await writeFile(join(work!, 'eta.ts'), '');
+    const body = await postWorkspaceSuggest<{ items: SuggestItemWire[]; truncated: boolean }>({
+      workspace: work,
+      query: '',
+    });
+    expect(body.code).toBe(0);
+    expect(body.data.items.map((i) => i.path)).toContain('eta.ts');
+  });
+
+  it('workspace fs:suggest matches path segments and returns scored items', async () => {
+    await mkdir(join(work!, 'apps'));
+    await mkdir(join(work!, 'apps', 'desktop'));
+    await writeFile(join(work!, 'apps', 'desktop', 'package.json'), '{}');
+    const body = await postWorkspaceSuggest<{ items: SuggestItemWire[]; truncated: boolean }>({
+      workspace: work,
+      query: 'apps/de',
+    });
+    expect(body.code).toBe(0);
+    expect(body.data.items.length).toBeGreaterThan(0);
+    expect(body.data.items[0]?.path).toBe('apps/desktop');
+    expect(body.data.items[0]?.kind).toBe('directory');
+    expect(body.data.items.map((i) => i.path)).toContain('apps/desktop/package.json');
+    for (const item of body.data.items) {
+      expect(item.score).toBeGreaterThan(0);
+      expect(item.score).toBeLessThanOrEqual(1);
+      expect(Array.isArray(item.match_positions)).toBe(true);
+    }
+  });
+
+  it('workspace fs:suggest returns an empty list when a path-form query has no match', async () => {
+    const body = await postWorkspaceSuggest<{ items: SuggestItemWire[]; truncated: boolean }>({
+      workspace: work,
+      query: 'zzz/qqq',
+    });
+    expect(body.code).toBe(0);
+    expect(body.data.items).toEqual([]);
+    expect(body.data.truncated).toBe(false);
+  });
+
+  it('workspace fs:suggest hides dotfiles by default and shows them with show_hidden', async () => {
+    await writeFile(join(work!, '.theta.ts'), '');
+    const hidden = await postWorkspaceSuggest<{ items: SuggestItemWire[] }>({
+      workspace: work,
+      query: 'theta',
+    });
+    expect(hidden.code).toBe(0);
+    expect(hidden.data.items.map((i) => i.path)).not.toContain('.theta.ts');
+
+    const shown = await postWorkspaceSuggest<{ items: SuggestItemWire[] }>({
+      workspace: work,
+      query: 'theta',
+      show_hidden: true,
+    });
+    expect(shown.code).toBe(0);
+    expect(shown.data.items.map((i) => i.path)).toContain('.theta.ts');
+  });
+
+  it('workspace fs:suggest defaults to the local runtime when runtime_id is omitted', async () => {
+    await writeFile(join(work!, 'iota.ts'), '');
+    const res = await fetch(`${base}/api/v1/workspace/fs:suggest`, {
+      method: 'POST',
+      headers: authHeaders(server as RunningServer, { 'content-type': 'application/json' }),
+      body: JSON.stringify({ workspace: work, query: 'iota' }),
+    } as never);
+    const body = (await res.json()) as Envelope<{ items: SuggestItemWire[]; truncated: boolean }>;
+    expect(body.code).toBe(0);
+    expect(body.data.items.map((i) => i.path)).toContain('iota.ts');
+  });
+
+  it('workspace fs:suggest maps an unknown ref to WORKSPACE_NOT_FOUND', async () => {
+    const body = await postWorkspaceSuggest<null>({ workspace: 'does-not-exist', query: 'x' });
+    expect(body.code).toBe(ErrorCode.WORKSPACE_NOT_FOUND);
+  });
+
+  it('workspace fs:suggest rejects a missing workspace field with VALIDATION_FAILED', async () => {
+    const body = await postWorkspaceSuggest<null>({ query: 'x' });
+    expect(body.code).toBe(ErrorCode.VALIDATION_FAILED);
+  });
+
+  it('workspace fs:suggest rejects a missing query field with VALIDATION_FAILED', async () => {
+    const body = await postWorkspaceSuggest<null>({ workspace: work });
     expect(body.code).toBe(ErrorCode.VALIDATION_FAILED);
   });
 });

--- a/packages/protocol/src/__tests__/fs.test.ts
+++ b/packages/protocol/src/__tests__/fs.test.ts
@@ -12,6 +12,7 @@ import {
   fsGrepMatchSchema,
   fsKindSchema,
   fsSearchHitSchema,
+  fsSuggestItemSchema,
   type FsChangeEntry,
   type FsChangeEvent,
   type FsEntry,
@@ -19,6 +20,7 @@ import {
   type FsGrepFileHit,
   type FsGrepMatch,
   type FsSearchHit,
+  type FsSuggestItem,
 } from '../fs';
 
 describe('fsKindSchema', () => {
@@ -145,6 +147,31 @@ describe('fsSearchHitSchema (W11.1 / Chain 11)', () => {
 
   it('accepts an empty match_positions list', () => {
     expect(fsSearchHitSchema.parse({ ...hit, match_positions: [] }).match_positions).toEqual([]);
+  });
+});
+
+describe('fsSuggestItemSchema', () => {
+  const item: FsSuggestItem = {
+    path: 'apps/desktop',
+    name: 'desktop',
+    kind: 'directory',
+    score: 0.87,
+    match_positions: [5, 6],
+  };
+
+  it('round-trips a populated item', () => {
+    expect(fsSuggestItemSchema.parse(item)).toEqual(item);
+  });
+
+  it('rejects score outside 0..1', () => {
+    expect(fsSuggestItemSchema.safeParse({ ...item, score: 1.5 }).success).toBe(false);
+    expect(fsSuggestItemSchema.safeParse({ ...item, score: -0.1 }).success).toBe(false);
+  });
+
+  it('rejects negative match positions', () => {
+    expect(
+      fsSuggestItemSchema.safeParse({ ...item, match_positions: [-1] }).success,
+    ).toBe(false);
   });
 });
 

--- a/packages/protocol/src/__tests__/rest-fs.test.ts
+++ b/packages/protocol/src/__tests__/rest-fs.test.ts
@@ -19,6 +19,8 @@ import {
   fsStatManyRequestSchema,
   fsStatManyResponseSchema,
   fsStatRequestSchema,
+  fsSuggestRequestSchema,
+  fsSuggestResponseSchema,
 } from '../rest/fs';
 
 describe('fsListRequestSchema', () => {
@@ -283,6 +285,62 @@ describe('fsSearchResponseSchema (W11.1)', () => {
       truncated: true,
     };
     expect(fsSearchResponseSchema.parse(r)).toEqual(r);
+  });
+});
+
+describe('fsSuggestRequestSchema', () => {
+  it('applies all defaults on minimal body', () => {
+    const parsed = fsSuggestRequestSchema.parse({ query: 'Button' });
+    expect(parsed).toEqual({
+      query: 'Button',
+      limit: 50,
+      follow_gitignore: true,
+      show_hidden: false,
+    });
+  });
+
+  it('accepts an empty query (workspace-root listing)', () => {
+    expect(fsSuggestRequestSchema.safeParse({ query: '' }).success).toBe(true);
+  });
+
+  it('caps limit at 200', () => {
+    expect(fsSuggestRequestSchema.safeParse({ query: 'a', limit: 201 }).success).toBe(false);
+    expect(fsSuggestRequestSchema.safeParse({ query: 'a', limit: 200 }).success).toBe(true);
+  });
+
+  it('round-trips a fully populated request', () => {
+    const body = {
+      query: 'apps/de',
+      limit: 100,
+      follow_gitignore: false,
+      show_hidden: true,
+      include_globs: ['**/*.ts'],
+      exclude_globs: ['**/node_modules/**'],
+    };
+    expect(fsSuggestRequestSchema.parse(body)).toEqual(body);
+  });
+});
+
+describe('fsSuggestResponseSchema', () => {
+  it('round-trips an empty response', () => {
+    expect(fsSuggestResponseSchema.parse({ items: [], truncated: false }))
+      .toEqual({ items: [], truncated: false });
+  });
+
+  it('round-trips a populated response', () => {
+    const r = {
+      items: [
+        {
+          path: 'apps/desktop',
+          name: 'desktop',
+          kind: 'directory' as const,
+          score: 0.9,
+          match_positions: [5, 6],
+        },
+      ],
+      truncated: true,
+    };
+    expect(fsSuggestResponseSchema.parse(r)).toEqual(r);
   });
 });
 

--- a/packages/protocol/src/fs.ts
+++ b/packages/protocol/src/fs.ts
@@ -42,6 +42,15 @@ export const fsSearchHitSchema = z.object({
 });
 export type FsSearchHit = z.infer<typeof fsSearchHitSchema>;
 
+export const fsSuggestItemSchema = z.object({
+  path: z.string(),
+  name: z.string(),
+  kind: fsKindSchema,
+  score: z.number().min(0).max(1),
+  match_positions: z.array(z.number().int().nonnegative()),
+});
+export type FsSuggestItem = z.infer<typeof fsSuggestItemSchema>;
+
 export const fsGrepMatchSchema = z.object({
   line: z.number().int().positive(),
   col: z.number().int().positive(),

--- a/packages/protocol/src/rest/fs.ts
+++ b/packages/protocol/src/rest/fs.ts
@@ -72,6 +72,7 @@ import {
   fsGitStatusSchema,
   fsGrepFileHitSchema,
   fsSearchHitSchema,
+  fsSuggestItemSchema,
 } from '../fs';
 
 export const fsListSortSchema = z.enum([
@@ -239,6 +240,22 @@ export const fsSearchResponseSchema = z.object({
   truncated: z.boolean(),
 });
 export type FsSearchResponse = z.infer<typeof fsSearchResponseSchema>;
+
+export const fsSuggestRequestSchema = z.object({
+  query: z.string(),
+  limit: z.number().int().min(1).max(200).default(50),
+  follow_gitignore: z.boolean().default(true),
+  show_hidden: z.boolean().default(false),
+  include_globs: z.array(z.string()).optional(),
+  exclude_globs: z.array(z.string()).optional(),
+});
+export type FsSuggestRequest = z.infer<typeof fsSuggestRequestSchema>;
+
+export const fsSuggestResponseSchema = z.object({
+  items: z.array(fsSuggestItemSchema),
+  truncated: z.boolean(),
+});
+export type FsSuggestResponse = z.infer<typeof fsSuggestResponseSchema>;
 
 export const fsGrepRequestSchema = z.object({
   pattern: z.string().min(1),


### PR DESCRIPTION
## Related Issue

No linked issue — the problem is explained below.

## Problem

Editor integrations need a file/folder completion backend for `@` mentions: as the user types a partial name or path, the server should return a small set of highly relevant path candidates. The existing `fs:search` only scores basenames, has no path-pattern mode, and offers no hidden-file control, so it cannot drive `@` completion.

## What changed

- **New endpoint** `POST /api/v1/workspace/fs:suggest` (session-less, same envelope/conventions as `fs:search`): empty query lists the workspace root; a query containing `/` matches path segments in order (subsequence within a segment, segment skipping allowed); a plain query fuzzy-matches basenames. Ranking prefers exact/prefix hits, then shorter names and shallower paths; `limit`, `truncated`, `follow_gitignore`, `show_hidden`, and include/exclude globs are supported, and missing-path matches return an empty list rather than an error.
- **Engine** (`agent-core-v2`): `IWorkspaceFsService.suggest` enumerates candidates with `rg --files` (streamed line-by-line into a bounded top-N heap, so memory stays flat on large trees), which gives git-consistent nested `.gitignore` handling for local and remote runtimes; when rg is unavailable it falls back to the existing Node walk and emits a telemetry event. Accepted trade-offs: the rg path yields no symlink candidates, and the walk fallback does not honor nested gitignore.
- **Protocol**: request/response schemas mirrored into `packages/protocol` (`src/fs.ts`, `src/rest/fs.ts`).
- **kimi-inspect**: new "Filesystem Suggest" icon-rail view (workspace picker, query form, result table with score/match positions, raw JSON) over a typed REST client.
- **Tests**: engine coverage with in-memory fs and a fake rg runner, real-HTTP route tests, protocol schema tests, and kimi-inspect client tests. Measured on a ~6000-file workspace: root listing p95 ~2-3ms, lookups p95 ~21-48ms (budget: 20ms / 100ms).

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset. (No changeset: kap-server REST addition currently consumed only by dev tooling / external editor clients, not perceivable from the CLI.)
- [x] Ran `gen-docs` skill, or this PR needs no doc update. (No user-facing surface changed.)
