### PR TITLE
fix(tui): persist ctrl+s-steered editor drafts into input history

### DIFF
--- a/.changeset/fix-ctrl-s-steer-input-history.md
+++ b/.changeset/fix-ctrl-s-steer-input-history.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Fix Ctrl-S steering of an unsubmitted editor draft not being saved to input history, so ↑ recall lost steered messages.

--- a/.changeset/fix-ctrl-s-steer-input-history.md
+++ b/.changeset/fix-ctrl-s-steer-input-history.md
@@ -2,4 +2,4 @@
 "@moonshot-ai/kimi-code": patch
 ---
 
-Fix Ctrl-S steering of an unsubmitted editor draft not being saved to input history, so ↑ recall lost steered messages.
+修复 Ctrl-S steer 直接发送的消息不写入输入历史的问题，避免按 ↑ 无法召回。

--- a/apps/kimi-code/src/tui/controllers/editor-keyboard.ts
+++ b/apps/kimi-code/src/tui/controllers/editor-keyboard.ts
@@ -40,6 +40,12 @@ export interface EditorKeyboardHost {
   harness?: KimiHarness | undefined;
 
   handleUserInput(text: string): void;
+  /**
+   * Append one submitted input to the persistent input history (↑ recall).
+   * `handleUserInput` writes history itself; paths that dispatch editor text
+   * directly (Ctrl-S steering the draft) must call this explicitly.
+   */
+  persistInputHistory(text: string): void;
   readonly btwPanelController: BtwPanelController;
   readonly skillCommandMap: Map<string, string>;
   steerMessage(session: Session, input: readonly SteerInputItem[]): void;
@@ -401,7 +407,13 @@ export class EditorKeyboardController {
         host.state.queuedMessages = queued.filter(
           (m, index) => m.mode === 'bash' || (firstBundle !== -1 && index >= firstBundle),
         );
-        if (!editorIsBash && !editorHasInlineSkills && firstBundle === -1) editor.setText('');
+        if (!editorIsBash && !editorHasInlineSkills && firstBundle === -1) {
+          // A steered editor draft bypasses handleUserInput (and its input-
+          // history write) — persist it here, or ↑ recall loses Ctrl-S-sent
+          // input. Queued items were already persisted at submit time.
+          if (text.length > 0) host.persistInputHistory(text);
+          editor.setText('');
+        }
         for (const run of runs) {
           if (run.kind === 'text') {
             host.steerMessage(session, run.items);

--- a/apps/kimi-code/src/tui/kimi-tui.ts
+++ b/apps/kimi-code/src/tui/kimi-tui.ts
@@ -1568,7 +1568,7 @@ export class KimiTUI {
     }
   }
 
-  private async persistInputHistory(text: string): Promise<void> {
+  async persistInputHistory(text: string): Promise<void> {
     const trimmed = text.trim();
     if (trimmed.length === 0) return;
     if (trimmed === this.lastHistoryContent) return;

--- a/apps/kimi-code/test/tui/controllers/editor-keyboard.test.ts
+++ b/apps/kimi-code/test/tui/controllers/editor-keyboard.test.ts
@@ -476,9 +476,11 @@ describe('EditorKeyboardController Ctrl-S steering', () => {
     queued: Array<Record<string, unknown>>;
     engineV2?: boolean;
     skillCommandMap?: Map<string, string>;
+    model?: string;
   }) {
     const steerMessage = vi.fn();
     const steerSkillActivation = vi.fn();
+    const persistInputHistory = vi.fn();
     const updateQueueDisplay = vi.fn();
     const setText = vi.fn();
     const editor: Record<string, ((...args: never[]) => unknown) | undefined> = {
@@ -493,7 +495,7 @@ describe('EditorKeyboardController Ctrl-S steering', () => {
         editor,
         activeDialog: null,
         queuedMessages: options.queued,
-        appState: { streamingPhase: 'waiting', isCompacting: false, model: 'k2' },
+        appState: { streamingPhase: 'waiting', isCompacting: false, model: options.model ?? 'k2' },
         footer: { setTransientHint: vi.fn() },
         ui: { requestRender: vi.fn() },
       },
@@ -502,8 +504,10 @@ describe('EditorKeyboardController Ctrl-S steering', () => {
       skillCommandMap: options.skillCommandMap ?? new Map(),
       steerMessage,
       steerSkillActivation,
+      persistInputHistory,
       updateQueueDisplay,
       validateMediaCapabilities: vi.fn(() => true),
+      releaseStagingMedia: vi.fn(),
       showError: vi.fn(),
       track: vi.fn(),
       btwPanelController: {
@@ -513,7 +517,7 @@ describe('EditorKeyboardController Ctrl-S steering', () => {
     } as unknown as EditorKeyboardHost;
     const controller = new EditorKeyboardController(
       host,
-      undefined as unknown as ImageAttachmentStore,
+      { get: vi.fn(() => undefined), retainFileIds: vi.fn() } as unknown as ImageAttachmentStore,
     );
     controller.install();
     const onCtrlS = editor['onCtrlS'];
@@ -524,10 +528,66 @@ describe('EditorKeyboardController Ctrl-S steering', () => {
       setText,
       steerMessage,
       steerSkillActivation,
+      persistInputHistory,
       updateQueueDisplay,
       onCtrlS: onCtrlS as () => void,
     };
   }
+
+  it('persists a steered editor draft into input history', () => {
+    const { host, setText, steerMessage, persistInputHistory, onCtrlS } = createCtrlSHarness({
+      editorText: 'fresh steer',
+      queued: [],
+    });
+
+    onCtrlS();
+
+    expect(steerMessage).toHaveBeenCalledWith(host.session, [
+      { text: 'fresh steer', parts: undefined, imageAttachmentIds: undefined, stagingPaths: [] },
+    ]);
+    expect(persistInputHistory).toHaveBeenCalledWith('fresh steer');
+    expect(setText).toHaveBeenCalledWith('');
+  });
+
+  it('does not re-persist queued items — they were persisted at submit time', () => {
+    const { steerMessage, persistInputHistory, onCtrlS } = createCtrlSHarness({
+      editorText: '',
+      queued: [{ text: 'queued text', agentId: 'main' }],
+    });
+
+    onCtrlS();
+
+    expect(steerMessage).toHaveBeenCalled();
+    expect(persistInputHistory).not.toHaveBeenCalled();
+  });
+
+  it('does not persist the draft when steering is rejected and the draft stays', () => {
+    const { setText, steerMessage, persistInputHistory, onCtrlS } = createCtrlSHarness({
+      editorText: 'fresh steer',
+      queued: [],
+      model: '',
+    });
+
+    onCtrlS();
+
+    expect(steerMessage).not.toHaveBeenCalled();
+    expect(persistInputHistory).not.toHaveBeenCalled();
+    expect(setText).not.toHaveBeenCalled();
+  });
+
+  it('does not persist an inline-skill draft left in the editor for the grouped path', () => {
+    const { setText, persistInputHistory, onCtrlS } = createCtrlSHarness({
+      editorText: 'check /skill:review',
+      queued: [],
+      engineV2: true,
+      skillCommandMap: new Map([['skill:review', 'review']]),
+    });
+
+    onCtrlS();
+
+    expect(persistInputHistory).not.toHaveBeenCalled();
+    expect(setText).not.toHaveBeenCalled();
+  });
 
   it('steers text as a message, skill items as activations, and keeps bash queued', () => {
     const { host, steerMessage, steerSkillActivation, updateQueueDisplay, onCtrlS } =


### PR DESCRIPTION
## Problem

In the TUI, pressing **Ctrl-S while a turn is running steers the unsubmitted editor draft directly into the turn** (`onCtrlS` in `editor-keyboard.ts`). That path bypasses `handleUserInput`, which is the only place input history (↑ recall) is written (`persistInputHistory` in `kimi-tui.ts`). As a result, messages sent via Ctrl-S steer never land in input history — pressing ↑ afterwards cannot recall them.

- Enter → queued → Ctrl-S steer: **not affected** (history was written at Enter time).
- Type draft → Ctrl-S directly: **lost from history** (this bug).

(Session transcripts are unaffected: the v2 engine records steered messages as durable `context.append_message`, so resume/cold rebuild shows them.)

## Fix

Minimal, TUI-only: when Ctrl-S consumes the editor draft for steering, persist it into input history at the same point the draft is cleared. `persistInputHistory` already trims and dedupes against the last entry. Queued items are not re-persisted (they were written at submit time); drafts that stay in the editor (rejected media, inline-skill bundles, missing model) persist nothing.

- `editor-keyboard.ts`: call `host.persistInputHistory(text)` where the steered draft is consumed; add `persistInputHistory` to `EditorKeyboardHost`.
- `kimi-tui.ts`: make `persistInputHistory` public so the keyboard controller can reach it.

## Tests

New Ctrl-S steering tests in `editor-keyboard.test.ts`:

- `persists a steered editor draft into input history` — draft steered → history written with the draft text, editor cleared.
- `does not re-persist queued items — they were persisted at submit time`.
- `does not persist the draft when steering is rejected and the draft stays` (no model set).
- `does not persist an inline-skill draft left in the editor for the grouped path`.

Test harness: added a minimal image-store stub (the draft-steer path calls `extractMediaAttachments`, which touches `store.retainFileIds` even for plain text) and a `releaseStagingMedia` mock.

## Verification

- `pnpm vitest run test/tui/controllers/editor-keyboard.test.ts` — 37/37 passed.
- `pnpm run typecheck` (apps/kimi-code) — clean.
- Full app suite `pnpm vitest run` — 2946 passed, 2 skipped (1 pre-existing failure unrelated to this change, also fails on main).
