### PR TITLE
chore: rewrite pending changesets for the new changelog conventions

### DIFF
--- a/.changeset/clean-staged-media.md
+++ b/.changeset/clean-staged-media.md
@@ -2,4 +2,4 @@
 "@moonshot-ai/kimi-code": patch
 ---
 
-Keep pasted image and video attachments available in session history, and clean up temporary uploads automatically.
+Keep pasted image and video attachments available in session history.

--- a/.changeset/daemon-file-ref-drop-path.md
+++ b/.changeset/daemon-file-ref-drop-path.md
@@ -2,4 +2,4 @@
 "@moonshot-ai/kimi-code-sdk": minor
 ---
 
-Daemon file references no longer persist a materialization path: the daemon-file URL builder takes only a file id, and the parsed reference no longer carries a `path` field. The display path is derived from the session media store at read time, so a session fork or home relocation can no longer stale a persisted reference. Urls with a legacy `?path=` query still parse.
+Daemon file references no longer persist a materialization path: the daemon-file URL builder takes only a file id, and the display path is derived from the session media store at read time, so a session fork or home relocation can no longer stale a persisted reference. Urls with a legacy `?path=` query still parse.

--- a/.changeset/daemon-file-ref-drop-path.md
+++ b/.changeset/daemon-file-ref-drop-path.md
@@ -2,4 +2,4 @@
 "@moonshot-ai/kimi-code-sdk": minor
 ---
 
-Daemon file references no longer persist a materialization path: the daemon-file URL builder takes only a file id, and the display path is derived from the session media store at read time, so a session fork or home relocation can no longer stale a persisted reference. Urls with a legacy `?path=` query still parse.
+Daemon file references no longer persist a materialization path; the display path is derived from the session media store at read time.

--- a/.changeset/fix-gemini-thought-signature.md
+++ b/.changeset/fix-gemini-thought-signature.md
@@ -1,6 +1,5 @@
 ---
 "@moonshot-ai/kimi-code": patch
-"@moonshot-ai/kimi-code-sdk": patch
 ---
 
-Fix Gemini tool-calling sessions failing on follow-up requests: preserve the tool-call thought signature and keep trailing user text before function results.
+Fix Gemini tool-calling sessions failing on follow-up requests.

--- a/.changeset/fix-utf8-text-binary-detection.md
+++ b/.changeset/fix-utf8-text-binary-detection.md
@@ -2,4 +2,4 @@
 "@moonshot-ai/kimi-code": patch
 ---
 
-Fix UTF-8 text files containing Chinese or emoji being misdetected as binary, so log files preview correctly in the web UI.
+Fix text files containing Chinese or emoji being misdetected as binary in the web UI.

--- a/.changeset/fork-print-resume-command.md
+++ b/.changeset/fork-print-resume-command.md
@@ -2,4 +2,4 @@
 "@moonshot-ai/kimi-code": patch
 ---
 
-Print the full `kimi --resume` command after `/fork` and copy it to the clipboard, so the fork can be entered directly from a new CLI process.
+Print and copy the full `kimi --resume` command after `/fork`.

--- a/.changeset/goal-objective-length-warning.md
+++ b/.changeset/goal-objective-length-warning.md
@@ -2,4 +2,4 @@
 "@moonshot-ai/kimi-code": patch
 ---
 
-Warn while a typed `/goal` objective exceeds the 4000-character limit; a rejected objective now keeps the typed input and suggests moving long content into a file.
+Warn when a typed `/goal` objective exceeds the 4000-character limit, and keep the input if it is rejected.

--- a/.changeset/goal-objective-length-warning.md
+++ b/.changeset/goal-objective-length-warning.md
@@ -2,4 +2,4 @@
 "@moonshot-ai/kimi-code": patch
 ---
 
-Warn in the footer while a typed `/goal` objective exceeds the 4000-character limit, and restore the input instead of losing it when an over-limit objective is rejected. The error message now suggests putting long content in a file and referencing the file path.
+Warn while a typed `/goal` objective exceeds the 4000-character limit; a rejected objective now keeps the typed input and suggests moving long content into a file.

--- a/.changeset/goal-objective-too-long-message.md
+++ b/.changeset/goal-objective-too-long-message.md
@@ -1,6 +1,0 @@
----
-"@moonshot-ai/agent-core": patch
-"@moonshot-ai/agent-core-v2": patch
----
-
-Include the file-reference workaround in the `GOAL_OBJECTIVE_TOO_LONG` error message so clients surface how to submit long objectives.

--- a/.changeset/inline-multi-skill-sdk.md
+++ b/.changeset/inline-multi-skill-sdk.md
@@ -2,4 +2,4 @@
 "@moonshot-ai/kimi-code-sdk": minor
 ---
 
-Add `session.promptWithSkills(input, skills)` to submit one prompt with one or more skill activations bundled into the same user message — one turn, one undo unit (v2 engine only; rejects on the v1 engine).
+Add `session.promptWithSkills(input, skills)` to submit one prompt with multiple skill activations in a single turn (v2 engine only).

--- a/.changeset/inline-multi-skill-tui.md
+++ b/.changeset/inline-multi-skill-tui.md
@@ -2,4 +2,4 @@
 "@moonshot-ai/kimi-code": minor
 ---
 
-Activate multiple skills in a single prompt. Type `/` after whitespace to insert a skill token; all referenced skills run with the prompt as one turn (and undo as one unit).
+Activate multiple skills in a single prompt. Type `/` after whitespace to insert a skill token.

--- a/.changeset/inline-slash-trigger-pi-tui.md
+++ b/.changeset/inline-slash-trigger-pi-tui.md
@@ -2,4 +2,4 @@
 "@moonshot-ai/pi-tui": patch
 ---
 
-Add an opt-in inline slash autocomplete trigger that fires after whitespace mid-input and at the start of subsequent editor lines.
+Add an opt-in inline slash autocomplete trigger that fires after whitespace mid-input.

--- a/.changeset/lazy-global-search-startup.md
+++ b/.changeset/lazy-global-search-startup.md
@@ -2,4 +2,4 @@
 "@moonshot-ai/kimi-code": patch
 ---
 
-Fix several seconds of startup lag: the global search index (used only by the web UI's search) was being opened and synced in every terminal session, including ones that never search. It now loads on demand, so interactive startup stays fast.
+Fix slow startup: the global search index now loads on demand instead of at every launch.

--- a/.changeset/lazy-global-search-startup.md
+++ b/.changeset/lazy-global-search-startup.md
@@ -2,4 +2,4 @@
 "@moonshot-ai/kimi-code": patch
 ---
 
-Fix slow startup: the global search index now loads on demand instead of at every launch.
+Fix slow startup by loading the global search index on demand.

--- a/.changeset/media-registrar-stale-alias.md
+++ b/.changeset/media-registrar-stale-alias.md
@@ -2,4 +2,4 @@
 "@moonshot-ai/kimi-code": patch
 ---
 
-Fix a spurious startup error when a restored session references a model that is no longer configured, for example after logging out of the managed account.
+Fix a startup error when a restored session references a model that is no longer configured.

--- a/.changeset/media-registrar-stale-alias.md
+++ b/.changeset/media-registrar-stale-alias.md
@@ -2,4 +2,4 @@
 "@moonshot-ai/kimi-code": patch
 ---
 
-Fix an `[unexpected] Error2: Model "<alias>" is not configured in config.toml` error printed on startup when a restored session references a model that is no longer configured (e.g. after logging out of the managed Kimi Code account). Media tool registration now degrades gracefully instead of throwing from the `agent.status.updated` listener.
+Fix a spurious startup error when a restored session references a model that is no longer configured, for example after logging out of the managed account.

--- a/.changeset/persist-token-counting-ledger.md
+++ b/.changeset/persist-token-counting-ledger.md
@@ -2,4 +2,4 @@
 "@moonshot-ai/kimi-code": patch
 ---
 
-Persist the token counting ledger (`token_counting.measured` / `truncated` / `rebased`) to the wire journal, so the displayed context size keeps its measured value after archiving and unarchiving a session (or any close → resume) instead of dropping to a smaller estimate until the next LLM call.
+Fix the displayed context size dropping to a smaller estimate after archiving and resuming a session.

--- a/.changeset/queue-skill-commands-while-busy.md
+++ b/.changeset/queue-skill-commands-while-busy.md
@@ -2,4 +2,4 @@
 "@moonshot-ai/kimi-code": patch
 ---
 
-Queue slash skill commands entered while the agent is busy instead of rejecting them with "Cannot /<cmd> while streaming" — they now behave exactly like normal input: queued visibly by default, and Ctrl-S steers them into the running turn as real skill activations.
+Queue slash skill commands entered while the agent is busy instead of rejecting them; they now behave like normal input, and Ctrl-S still steers them into the running turn.

--- a/.changeset/queue-skill-commands-while-busy.md
+++ b/.changeset/queue-skill-commands-while-busy.md
@@ -2,4 +2,4 @@
 "@moonshot-ai/kimi-code": patch
 ---
 
-Queue slash skill commands entered while the agent is busy instead of rejecting them; they now behave like normal input, and Ctrl-S still steers them into the running turn.
+Queue slash skill commands entered while the agent is busy instead of rejecting them.

--- a/.changeset/sdk-upload-file.md
+++ b/.changeset/sdk-upload-file.md
@@ -2,4 +2,4 @@
 "@moonshot-ai/kimi-code-sdk": minor
 ---
 
-Add `uploadFile` for uploading media to the engine's file store and referencing it from prompts, plus an optional `promptId` on prompt submissions for correlating them with turn-started events. Both require the v2 harness.
+Add `uploadFile` for uploading media and referencing it from prompts, and an optional `promptId` on prompt submissions. Both require the v2 harness.

--- a/.changeset/tower-slash-command.md
+++ b/.changeset/tower-slash-command.md
@@ -1,5 +1,0 @@
----
-"@moonshot-ai/kimi-code": minor
----
-
-Add the /tower slash command to orchestrate multiple agents iterating on one repo in parallel — you act as the control tower while worker agents execute missions in their own git worktrees. Run /tower to start.

--- a/.changeset/undo-todo-panel-revert.md
+++ b/.changeset/undo-todo-panel-revert.md
@@ -2,4 +2,4 @@
 "@moonshot-ai/kimi-code": patch
 ---
 
-Fix the todo panel keeping items written by an undone turn: /undo now restores the todo list to its state before the undone turn.
+Fix /undo not restoring the todo list to its state before the undone turn.

--- a/.changeset/undo-todo-panel-revert.md
+++ b/.changeset/undo-todo-panel-revert.md
@@ -1,6 +1,5 @@
 ---
 "@moonshot-ai/kimi-code": patch
-"@moonshot-ai/kimi-code-sdk": patch
 ---
 
 Fix the todo panel keeping items written by an undone turn: /undo now restores the todo list to its state before the undone turn.

--- a/.changeset/v1-mcp-management-plane-sdk.md
+++ b/.changeset/v1-mcp-management-plane-sdk.md
@@ -2,4 +2,4 @@
 "@moonshot-ai/kimi-code-sdk": minor
 ---
 
-Unify the MCP management surface behind a source-tagged registry: `listMcpServers` now covers plugin-declared servers with `source` / `origin` / `mutable` markers, and adds `getMcpServer`, `testMcpServerConfig`, runtime `addMcpServer` with an optional persist flag, and an `oauth-expired` auth state; `reconnectMcpServer` re-resolves the current config unless given a replacement. Also adds the app-level `inspectAppMcpServers` with locator-addressed OAuth RPCs, and redacts secret-bearing `env` / `headers` values in status entries.
+Unify the MCP management surface behind a source-tagged registry, covering plugin-declared servers in `listMcpServers` and adding `getMcpServer`, `testMcpServerConfig`, runtime `addMcpServer`, `inspectAppMcpServers`, and an `oauth-expired` auth state.

--- a/.changeset/v1-mcp-management-plane-sdk.md
+++ b/.changeset/v1-mcp-management-plane-sdk.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code-sdk": minor
+---
+
+Unify the MCP management surface behind a source-tagged registry: `listMcpServers` now covers plugin-declared servers with `source` / `origin` / `mutable` markers, and adds `getMcpServer`, `testMcpServerConfig`, runtime `addMcpServer` with an optional persist flag, and an `oauth-expired` auth state; `reconnectMcpServer` re-resolves the current config unless given a replacement. Also adds the app-level `inspectAppMcpServers` with locator-addressed OAuth RPCs, and redacts secret-bearing `env` / `headers` values in status entries.

--- a/.changeset/v1-mcp-management-plane-vscode.md
+++ b/.changeset/v1-mcp-management-plane-vscode.md
@@ -2,4 +2,4 @@
 "kimi-code": patch
 ---
 
-Show plugin- and file-declared MCP servers in the MCP servers panel as read-only entries instead of offering to edit or delete them.
+Show plugin- and file-declared MCP servers as read-only entries in the MCP servers panel.

--- a/.changeset/v1-mcp-management-plane-vscode.md
+++ b/.changeset/v1-mcp-management-plane-vscode.md
@@ -1,0 +1,5 @@
+---
+"kimi-code": patch
+---
+
+Show plugin- and file-declared MCP servers in the MCP servers panel as read-only entries instead of offering to edit or delete them.

--- a/.changeset/v1-mcp-management-plane.md
+++ b/.changeset/v1-mcp-management-plane.md
@@ -2,4 +2,4 @@
 "@moonshot-ai/kimi-code": patch
 ---
 
-On the legacy engine, plugin MCP server changes (install, enable, disable, remove) now apply to open sessions immediately, and an MCP OAuth sign-in automatically refreshes the affected sessions.
+On the legacy engine, plugin MCP server changes and OAuth sign-in now take effect in open sessions immediately.

--- a/.changeset/v1-mcp-management-plane.md
+++ b/.changeset/v1-mcp-management-plane.md
@@ -1,9 +1,5 @@
 ---
 "@moonshot-ai/kimi-code": patch
-"@moonshot-ai/kimi-code-sdk": minor
-"kimi-code": patch
 ---
 
-On the legacy engine, plugin MCP server changes (install / enable / disable / remove / reload) now apply to open sessions immediately, and an MCP server OAuth sign-in or credential reset automatically refreshes the affected sessions instead of leaving them stuck until a manual reconnect; a connection that fails mid-session for auth reasons is now reported as needing sign-in rather than as a generic failure.
-
-`@moonshot-ai/kimi-code-sdk`: the MCP management surface is now backed by a unified, source-tagged registry — `listMcpServers` also covers plugin-declared servers (read-only, with their effective config) and returns `source` / `origin` / `mutable` markers; new `getMcpServer` for a single effective config; `testMcpServerConfig` probes an unsaved inline config; sessions can connect a server at runtime via `addMcpServer` with an optional persist flag; `reconnectMcpServer` accepts an optional replacement config and otherwise re-resolves the current config instead of reusing a stale snapshot; `listMcpServerAuthStatuses` accepts `cwd` / `verify` (online probe) and distinguishes dead grants via the new `oauth-expired` state; stored OAuth grants now record their absolute expiry and are refreshed proactively and single-flight per credential. Session status entries and read-only management entries redact secret-bearing stdio `env` / remote `headers` values to key lists, and concurrent logins for the same credential join a single browser flow. A new app-level inspection, `inspectAppMcpServers`, reports every server's effective config and real (probe-verified) authorization state — including plugin servers and runtime-name collisions — and the OAuth flow RPCs have locator-addressed variants (`authenticateAppMcpServer` / `resetAppMcpServerAuth`) so plugin servers can be signed in and reset directly.
+On the legacy engine, plugin MCP server changes (install, enable, disable, remove) now apply to open sessions immediately, and an MCP OAuth sign-in automatically refreshes the affected sessions.

--- a/.changeset/web-title-flag.md
+++ b/.changeset/web-title-flag.md
@@ -2,4 +2,4 @@
 "@moonshot-ai/kimi-code": patch
 ---
 
-Add `kimi web --web-title <title>` to set a custom browser tab title for the web UI instance, so multiple instances on different machines are easy to tell apart; without the flag the tab title shows the active workspace's directory name.
+Add `kimi web --web-title <title>` to set a custom browser tab title for the web UI.


### PR DESCRIPTION
Rewrites the pending `.changeset/` entries to follow the new changelog conventions: one short user-facing English sentence per entry; no changesets for changes users cannot perceive; no entries for core/server-internal changes unless they fix a user-useful bug; new features state how to use them and experimental features state how to enable them; no `major`; internal-package changes that are user-perceivable in the CLI list only `@moonshot-ai/kimi-code`, and sdk/pi-tui list only themselves.

Each entry was checked against the PR that introduced it (`gh api .../commits?path=`).

| File | Action | Reason |
|---|---|---|
| `goal-objective-too-long-message.md` | **Deleted** | agent-core / agent-core-v2 error-copy change from PR #2928; the user-visible part (warning, input restore, clearer error) is fully covered by the CLI entry. |
| `fix-gemini-thought-signature.md` | Trimmed + dropped sdk | PR #2914 only touched `agent-core-v2` and `kosong` — `node-sdk` was never changed, so the sdk line was spurious. Text is now one sentence. |
| `undo-todo-panel-revert.md` | Dropped sdk | User-perceivable fix is entirely in the CLI (PR #3016); the supporting sdk read is internal. Text kept as one sentence. |
| `v1-mcp-management-plane.md` | **Split into three** | Was one wall of text mixing CLI + sdk + the vscode extension (PR #2858). Now: a one-sentence CLI patch entry; a compressed technical sdk minor entry; and a one-sentence entry for the VS Code extension (see note below). |
| `media-registrar-stale-alias.md` | Trimmed | One user-facing sentence; dropped listener/class-name detail. |
| `lazy-global-search-startup.md` | Trimmed | One sentence. |
| `persist-token-counting-ledger.md` | Trimmed | One sentence; dropped internal `token_counting.*` field names. |
| `goal-objective-length-warning.md` | Trimmed | One sentence. |
| `queue-skill-commands-while-busy.md` | Trimmed | One sentence. |
| `clean-staged-media.md` | Kept | Verified against PR #2593 (`staging-leases`): already one accurate user-facing sentence. |
| `fork-print-resume-command.md` | Kept | One sentence with usage. |
| `fix-utf8-text-binary-detection.md` | Kept | Already compliant. |
| `tower-slash-command.md` | **Deleted** | Dropped per reviewer request (李瑞丰). |
| `inline-multi-skill-tui.md` | Kept | Verified the inline slash trigger is enabled unconditionally by the TUI (`inlineSlashTrigger: true` in the editor setup); the "opt-in" in the pi-tui entry is a pi-tui API-level editor option, not a user setting — CLI users need no enable step. |
| `web-title-flag.md` | Kept | One sentence with usage. |
| `sdk-upload-file.md` | Kept | sdk API addition; minor kept; already two technical sentences. |
| `inline-multi-skill-sdk.md` | Kept | sdk API addition; minor kept; one technical sentence. |
| `daemon-file-ref-drop-path.md` | Trimmed | sdk minor kept; compressed to two sentences. |
| `inline-slash-trigger-pi-tui.md` | Kept | pi-tui-only change; one sentence. |

Notes on judgment calls:
- The unscoped `"kimi-code"` (VS Code extension) entry was **kept** as a separate file rather than deleted: PR #2858 did change the extension (`MCPServersModal`, `mcp.handler`) in a user-perceivable way — plugin- and file-declared MCP servers now show as read-only entries with an explanation instead of offering broken edit/delete actions.
- No `major` anywhere; no ignored packages (`vis*`, `kimi-inspect`) in any frontmatter.