### PR TITLE
fix(agent-core-v2): resolve pasted file:// videos before they reach the model

### DIFF
--- a/.changeset/resolve-pasted-file-url-videos.md
+++ b/.changeset/resolve-pasted-file-url-videos.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Stop sending pasted videos as unresolved local file URLs.

--- a/packages/agent-core-v2/src/agent/media/mediaResolverService.ts
+++ b/packages/agent-core-v2/src/agent/media/mediaResolverService.ts
@@ -1,5 +1,5 @@
 import { createHash } from 'node:crypto';
-import { readFile } from 'node:fs/promises';
+import { readFile, stat } from 'node:fs/promises';
 import { basename } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -248,8 +248,17 @@ export class AgentMediaResolverService implements IAgentMediaResolverService {
     if (path.trim().length === 0) return videoTag(path);
     if (!requester.model.capabilities.video_in) return videoTag(path);
 
+    let identity: string;
+    try {
+      const info = await stat(path);
+      identity = `${info.size}\0${info.mtimeMs}`;
+    } catch {
+      signal?.throwIfAborted();
+      return videoTag(path);
+    }
+
     const providerKey = requester.model.providerType ?? requester.model.protocol;
-    const cacheKey = `file\0${path}\0${providerKey}`;
+    const cacheKey = `file\0${path}\0${identity}\0${providerKey}`;
     const memoed = this.resolved.get(cacheKey);
     if (memoed !== undefined) return memoed;
 
@@ -287,6 +296,7 @@ export class AgentMediaResolverService implements IAgentMediaResolverService {
       return part;
     } catch (error) {
       if (signal?.aborted) throw error;
+      if (isVideoUploadAuthError(error)) throw error;
       const part = videoTag(path);
       this.resolved.set(cacheKey, part);
       return part;

--- a/packages/agent-core-v2/src/agent/media/mediaResolverService.ts
+++ b/packages/agent-core-v2/src/agent/media/mediaResolverService.ts
@@ -1,4 +1,7 @@
 import { createHash } from 'node:crypto';
+import { readFile } from 'node:fs/promises';
+import { basename } from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 import { ScopeActivation, registerScopedService } from '#/_base/di/scope';
 import { defineState } from '#/state/state';
@@ -70,18 +73,24 @@ export class AgentMediaResolverService implements IAgentMediaResolverService {
     requester: ModelRequester,
     signal?: AbortSignal,
   ): Promise<readonly Message[]> {
-    if (!messages.some(hasDaemonFileMediaPart)) return messages;
+    if (!messages.some(hasResolvableMediaPart)) return messages;
 
     let changed = false;
     const out: Message[] = [];
     for (const message of messages) {
-      if (!hasDaemonFileMediaPart(message)) {
+      if (!hasResolvableMediaPart(message)) {
         out.push(message);
         continue;
       }
       const content: ContentPart[] = [];
       let sawVideoRef = false;
       for (const part of message.content) {
+        const fileUrl = localFileVideoUrl(part);
+        if (fileUrl !== undefined) {
+          sawVideoRef = true;
+          content.push(await this.resolveLocalVideoPart(fileUrl, requester, signal));
+          continue;
+        }
         const daemonPart = daemonFileRefFromPart(part);
         if (daemonPart === undefined) {
           content.push(part);
@@ -222,8 +231,77 @@ export class AgentMediaResolverService implements IAgentMediaResolverService {
     const { bytes, filename } = source;
     const fileType = detectFileType(filename, bytes.subarray(0, MEDIA_SNIFF_BYTES), 'media');
     if (fileType.kind !== 'video') return { part: videoTag(tagPath), memoize: true };
-    const mimeType = fileType.mimeType;
+    return this.deliverRecognizedVideo(bytes, filename, fileType.mimeType, tagPath, requester, cacheKey, signal);
+  }
 
+  private async resolveLocalVideoPart(
+    fileUrl: string,
+    requester: ModelRequester,
+    signal: AbortSignal | undefined,
+  ): Promise<ContentPart> {
+    let path: string;
+    try {
+      path = fileURLToPath(fileUrl);
+    } catch {
+      return unavailableMediaText('video');
+    }
+    if (path.trim().length === 0) return videoTag(path);
+    if (!requester.model.capabilities.video_in) return videoTag(path);
+
+    const providerKey = requester.model.providerType ?? requester.model.protocol;
+    const cacheKey = `file\0${path}\0${providerKey}`;
+    const memoed = this.resolved.get(cacheKey);
+    if (memoed !== undefined) return memoed;
+
+    const cachedLlmFileId = await this.readCachedUpload(cacheKey);
+    if (cachedLlmFileId !== undefined) {
+      const part = { type: 'video_url' as const, videoUrl: { url: `ms://${cachedLlmFileId}`, id: cachedLlmFileId } };
+      this.resolved.set(cacheKey, part);
+      return part;
+    }
+
+    try {
+      signal?.throwIfAborted();
+      const bytes = await readFile(path, signal === undefined ? undefined : { signal });
+      if (bytes.length === 0) {
+        const part = videoTag(path);
+        this.resolved.set(cacheKey, part);
+        return part;
+      }
+      const fileType = detectFileType(path, bytes.subarray(0, MEDIA_SNIFF_BYTES), 'media');
+      if (fileType.kind !== 'video') {
+        const part = videoTag(path);
+        this.resolved.set(cacheKey, part);
+        return part;
+      }
+      const { part, memoize } = await this.deliverRecognizedVideo(
+        bytes,
+        basename(path),
+        fileType.mimeType,
+        path,
+        requester,
+        cacheKey,
+        signal,
+      );
+      if (memoize) this.resolved.set(cacheKey, part);
+      return part;
+    } catch (error) {
+      if (signal?.aborted) throw error;
+      const part = videoTag(path);
+      this.resolved.set(cacheKey, part);
+      return part;
+    }
+  }
+
+  private async deliverRecognizedVideo(
+    bytes: Buffer,
+    filename: string,
+    mimeType: string,
+    tagPath: string | undefined,
+    requester: ModelRequester,
+    cacheKey: string,
+    signal: AbortSignal | undefined,
+  ): Promise<{ part: ContentPart; memoize: boolean }> {
     const model = requester.model;
     const inlineSupported = inlineVideoSupportedForProtocol(model.protocol);
 
@@ -292,8 +370,16 @@ export class AgentMediaResolverService implements IAgentMediaResolverService {
   }
 }
 
-function hasDaemonFileMediaPart(message: Message): boolean {
-  return message.content.some((part) => daemonFileRefFromPart(part) !== undefined);
+function localFileVideoUrl(part: ContentPart): string | undefined {
+  return part.type === 'video_url' && part.videoUrl.url.startsWith('file:')
+    ? part.videoUrl.url
+    : undefined;
+}
+
+function hasResolvableMediaPart(message: Message): boolean {
+  return message.content.some(
+    (part) => daemonFileRefFromPart(part) !== undefined || localFileVideoUrl(part) !== undefined,
+  );
 }
 
 function degradedImage(path: string | undefined): ContentPart {

--- a/packages/agent-core-v2/test/agent/media/mediaResolver.test.ts
+++ b/packages/agent-core-v2/test/agent/media/mediaResolver.test.ts
@@ -782,6 +782,43 @@ describe('AgentMediaResolverService local file:// videos', () => {
     expect(upload).not.toHaveBeenCalled();
   });
 
+  it('rethrows an auth failure from a file:// upload so credential refresh can run', async () => {
+    const path = join(sessionDir, 'clip.mp4');
+    await writeFile(path, VIDEO_BYTES);
+    const upload = vi.fn(async () => {
+      throw Object.assign(new Error('unauthorized'), { statusCode: 401 });
+    });
+
+    await expect(
+      resolver(new Map()).resolve(
+        [videoMessage(pathToFileURL(path).href)],
+        requester({ uploadVideo: upload }),
+      ),
+    ).rejects.toThrow('unauthorized');
+  });
+
+  it('re-uploads a file:// video once its contents change', async () => {
+    const path = join(sessionDir, 'clip.mp4');
+    const res = resolver(new Map());
+    await writeFile(path, VIDEO_BYTES);
+    const first = vi.fn(async (): Promise<VideoURLPart> => msPart('prov-first'));
+    const before = await res.resolve(
+      [videoMessage(pathToFileURL(path).href)],
+      requester({ uploadVideo: first }),
+    );
+
+    await writeFile(path, Buffer.concat([VIDEO_BYTES, Buffer.from(' second take')]));
+    const second = vi.fn(async (): Promise<VideoURLPart> => msPart('prov-second'));
+    const after = await res.resolve(
+      [videoMessage(pathToFileURL(path).href)],
+      requester({ uploadVideo: second }),
+    );
+
+    expect(firstPart(before)).toEqual(msPart('prov-first'));
+    expect(firstPart(after)).toEqual(msPart('prov-second'));
+    expect(second).toHaveBeenCalledTimes(1);
+  });
+
   it('degrades a file:// video when the model cannot accept video', async () => {
     const path = join(sessionDir, 'clip.mp4');
     await writeFile(path, VIDEO_BYTES);

--- a/packages/agent-core-v2/test/agent/media/mediaResolver.test.ts
+++ b/packages/agent-core-v2/test/agent/media/mediaResolver.test.ts
@@ -2,6 +2,7 @@ import { mkdtemp, mkdir, readdir, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { Readable } from 'node:stream';
+import { pathToFileURL } from 'node:url';
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -751,6 +752,47 @@ describe('AgentMediaResolverService session-canonical display path', () => {
       { type: 'text', text: VIDEO_TAG },
       { type: 'text', text: VIDEO_UNAVAILABLE_TEXT },
     ]);
+  });
+});
+
+describe('AgentMediaResolverService local file:// videos', () => {
+  it('uploads a readable file:// video and never forwards the local URL', async () => {
+    const path = join(sessionDir, 'clip.mp4');
+    await writeFile(path, VIDEO_BYTES);
+    const upload = vi.fn(async (): Promise<VideoURLPart> => msPart('prov-local'));
+    const message = videoMessage(pathToFileURL(path).href);
+
+    const out = await resolver(new Map()).resolve([message], requester({ uploadVideo: upload }));
+
+    expect(firstPart(out)).toEqual(msPart('prov-local'));
+    expect(JSON.stringify(out)).not.toContain('file://');
+    expect(upload).toHaveBeenCalledTimes(1);
+  });
+
+  it('degrades a missing file:// video instead of forwarding the URL', async () => {
+    const path = join(sessionDir, 'gone.mp4');
+    const upload = vi.fn();
+    const out = await resolver(new Map()).resolve(
+      [videoMessage(pathToFileURL(path).href)],
+      requester({ uploadVideo: upload }),
+    );
+
+    expect(firstPart(out)).toEqual({ type: 'text', text: `<video path="${path}"></video>` });
+    expect(JSON.stringify(out)).not.toContain('file://');
+    expect(upload).not.toHaveBeenCalled();
+  });
+
+  it('degrades a file:// video when the model cannot accept video', async () => {
+    const path = join(sessionDir, 'clip.mp4');
+    await writeFile(path, VIDEO_BYTES);
+    const upload = vi.fn();
+    const out = await resolver(new Map()).resolve(
+      [videoMessage(pathToFileURL(path).href)],
+      requester({ videoIn: false, uploadVideo: upload }),
+    );
+
+    expect(firstPart(out)).toEqual({ type: 'text', text: `<video path="${path}"></video>` });
+    expect(upload).not.toHaveBeenCalled();
   });
 });
 


### PR DESCRIPTION
## Related Issue

Fixes #2979
Resolve #2979

## Problem

See linked issue. Pasting a video into the TUI expands to a local `file://` `video_url`. The default v2 media resolver only rewrote `kimi-file://` daemon refs, so the raw `file://` URL went to the provider and was replayed on every later turn.

## What changed

The request-time media resolver now treats local `file://` videos the same way it treats daemon video refs: upload when the provider can accept video, otherwise replace the part with a `<video path>` tag. A missing or unreadable file degrades to the tag instead of forwarding the URL.

This is the same last-mile path `llmRequester` already uses, so already-poisoned sessions recover on the next request.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.

## Tests run

- `pnpm --filter @moonshot-ai/agent-core-v2 exec vitest run test/agent/media/mediaResolver.test.ts` (36 passed; the three new `file://` cases were RED on unfixed code, then GREEN)
- `pnpm --filter @moonshot-ai/agent-core-v2 typecheck`
- `pnpm --filter @moonshot-ai/agent-core-v2 lint:imports`
- `oxlint` on the touched media resolver files
- `scripts/check-no-comments.mjs`

Did not run the full monorepo `pnpm test` / `pnpm lint` / `pnpm typecheck`.


Made with [Cursor](https://cursor.com)