### PR TITLE
chore: remove internal-network references from comments and test fixtures

### DIFF
--- a/apps/kimi-code/test/cli/web/web.test.ts
+++ b/apps/kimi-code/test/cli/web/web.test.ts
@@ -283,8 +283,8 @@ describe('ready banner reflects the bind class', () => {
         startServerForeground: runner,
         resolveToken: () => 'tok-xyz',
         networkAddresses: [
-          { address: '192.168.98.66', family: 'IPv4' },
-          { address: '10.8.12.216', family: 'IPv4' },
+          { address: '192.0.2.66', family: 'IPv4' },
+          { address: '198.51.100.216', family: 'IPv4' },
         ],
         openUrl: vi.fn(),
         stdout,
@@ -299,8 +299,8 @@ describe('ready banner reflects the bind class', () => {
     // Full token-bearing URLs are printed plainly (no box, no truncation) so
     // they are easy to copy.
     expect(raw).toContain('http://localhost:58627/#token=tok-xyz');
-    expect(raw).toContain('http://192.168.98.66:58627/#token=tok-xyz');
-    expect(raw).toContain('http://10.8.12.216:58627/#token=tok-xyz');
+    expect(raw).toContain('http://192.0.2.66:58627/#token=tok-xyz');
+    expect(raw).toContain('http://198.51.100.216:58627/#token=tok-xyz');
     expect(raw).toContain('Token:');
     expect(raw).toContain('tok-xyz');
     expect(raw).not.toContain('╭');
@@ -317,7 +317,7 @@ describe('ready banner reflects the bind class', () => {
         startServerForeground: runner,
         resolveToken: () => 'tok-loop',
         // Injected interface addresses must NOT leak into a loopback banner.
-        networkAddresses: [{ address: '192.168.98.66', family: 'IPv4' }],
+        networkAddresses: [{ address: '192.0.2.66', family: 'IPv4' }],
         openUrl: vi.fn(),
         stdout,
         stderr,
@@ -333,7 +333,7 @@ describe('ready banner reflects the bind class', () => {
     // No network URLs on a loopback bind — just the "off" hint.
     expect(raw).toContain('use --host to enable');
     expect(raw).not.toContain('Network:  http');
-    expect(raw).not.toContain('192.168.98.66');
+    expect(raw).not.toContain('192.0.2.66');
     expect(raw).not.toContain('╭');
   });
 });

--- a/packages/agent-core/src/agent/tool/index.ts
+++ b/packages/agent-core/src/agent/tool/index.ts
@@ -958,7 +958,7 @@ export class ToolManager {
     // Self-heal an empty builtin table. The constructor and every config-
     // mutation checkpoint gate initializeBuiltinTools() on hasProvider, but a
     // provider that becomes resolvable asynchronously (OAuth / managed
-    // free-tokens model registration) trips none of them — without this the
+    // model registration) trips none of them — without this the
     // agent runs with zero tools while the system prompt still advertises them.
     // loopTools is re-read before every step, so the table is populated on the
     // first step after the provider resolves. Steady state short-circuits on

--- a/packages/agent-core/test/agent/tool.test.ts
+++ b/packages/agent-core/test/agent/tool.test.ts
@@ -419,7 +419,7 @@ describe('Agent tools', () => {
     // The ProviderManager reads this live config; it starts with no model or
     // provider, so hasProvider is false at Agent construction and
     // initializeBuiltinTools() is skipped — the state the asynchronous
-    // free-tokens / OAuth model registration produces.
+    // OAuth / managed model registration produces.
     const liveConfig: KimiConfig = { providers: {}, models: {} };
     const ctx = testAgent({
       providerManager: new ProviderManager({ config: () => liveConfig }),

--- a/packages/agent-core/test/harness/runtime-provider.test.ts
+++ b/packages/agent-core/test/harness/runtime-provider.test.ts
@@ -1114,7 +1114,7 @@ describe('google base URL forwarding', () => {
           gemini: {
             type: 'google-genai',
             apiKey: 'g-key',
-            baseUrl: 'https://qianxun.example/v1beta',
+            baseUrl: 'https://genai-gateway.example/v1beta',
           },
         },
         models: {
@@ -1126,7 +1126,7 @@ describe('google base URL forwarding', () => {
     expect(resolved.provider).toMatchObject({
       type: 'google-genai',
       model: 'gemini-2.5-pro',
-      baseUrl: 'https://qianxun.example/v1beta',
+      baseUrl: 'https://genai-gateway.example/v1beta',
     });
   });
 
@@ -1161,7 +1161,7 @@ describe('google base URL forwarding', () => {
           vertex: {
             type: 'vertexai',
             apiKey: 'v-key',
-            baseUrl: 'https://qianxun.example/vertex',
+            baseUrl: 'https://genai-gateway.example/vertex',
           },
         },
         models: {
@@ -1173,7 +1173,7 @@ describe('google base URL forwarding', () => {
     expect(resolved.provider).toMatchObject({
       type: 'vertexai',
       model: 'gemini-1.5-pro',
-      baseUrl: 'https://qianxun.example/vertex',
+      baseUrl: 'https://genai-gateway.example/vertex',
     });
   });
 

--- a/packages/kosong/test/google-genai.test.ts
+++ b/packages/kosong/test/google-genai.test.ts
@@ -1048,9 +1048,9 @@ describe('GoogleGenAIChatProvider', () => {
       const provider = new GoogleGenAIChatProvider({
         model: 'gemini-2.5-flash',
         apiKey: 'test-key',
-        baseUrl: 'https://qianxun.example/v1beta',
+        baseUrl: 'https://genai-gateway.example/v1beta',
       });
-      expect(customBaseUrl(provider)).toBe('https://qianxun.example/v1beta');
+      expect(customBaseUrl(provider)).toBe('https://genai-gateway.example/v1beta');
     });
 
     it('leaves the SDK default endpoint in place when no baseUrl is set', () => {
@@ -1065,7 +1065,7 @@ describe('GoogleGenAIChatProvider', () => {
       const provider = new GoogleGenAIChatProvider({
         model: 'gemini-2.5-flash',
         apiKey: 'test-key',
-        baseUrl: 'https://qianxun.example/v1beta',
+        baseUrl: 'https://genai-gateway.example/v1beta',
         defaultHeaders: { 'User-Agent': 'kimi-code-cli/test' },
       });
       const client = (
@@ -1078,7 +1078,7 @@ describe('GoogleGenAIChatProvider', () => {
           };
         }
       )._client;
-      expect(client.apiClient.getCustomBaseUrl()).toBe('https://qianxun.example/v1beta');
+      expect(client.apiClient.getCustomBaseUrl()).toBe('https://genai-gateway.example/v1beta');
       expect(client.apiClient.getHeaders()).toMatchObject({
         'User-Agent': 'kimi-code-cli/test',
       });
@@ -1089,9 +1089,9 @@ describe('GoogleGenAIChatProvider', () => {
         model: 'gemini-1.5-pro',
         apiKey: 'test-key',
         vertexai: true,
-        baseUrl: 'https://qianxun.example/vertex',
+        baseUrl: 'https://genai-gateway.example/vertex',
       });
-      expect(customBaseUrl(provider)).toBe('https://qianxun.example/vertex');
+      expect(customBaseUrl(provider)).toBe('https://genai-gateway.example/vertex');
     });
   });
 


### PR DESCRIPTION
## What

Scrubs internal-network-flavored names from comments and test fixtures. No behavior change.

- **Comments** — reworded two comments that named the internal free-tokens model registration flow; the generic OAuth / managed wording carries the same meaning
  - `packages/agent-core/src/agent/tool/index.ts`
  - `packages/agent-core/test/agent/tool.test.ts`
- **Placeholder domain** — replaced the `qianxun.example` placeholder base URL with `genai-gateway.example` in the Google GenAI baseUrl-forwarding tests
  - `packages/kosong/test/google-genai.test.ts`
  - `packages/agent-core/test/harness/runtime-provider.test.ts`
- **Fixture IPs** — swapped realistic-looking LAN addresses for RFC 5737 documentation ranges in the `kimi web` banner tests (`192.168.98.66` → `192.0.2.66`, `10.8.12.216` → `198.51.100.216`)
  - `apps/kimi-code/test/cli/web/web.test.ts`

No changeset: comment/test-only cleanup, not user-facing.

## Tests

- `packages/kosong` google-genai.test.ts: 86/86 passed
- `packages/agent-core` tool.test.ts + runtime-provider.test.ts: 72/72 passed
- `apps/kimi-code` web.test.ts: 55/55 passed