### PR TITLE
test: drop the assertion for the removed ambiguous-means-task example

### DIFF
--- a/packages/agent-core/test/profile/default-agent-profiles.test.ts
+++ b/packages/agent-core/test/profile/default-agent-profiles.test.ts
@@ -153,7 +153,6 @@ describe('default agent profiles', () => {
       // render this same paragraph, so it must not tell them editing files is free.
       expect(prompt).toContain('Local, reversible work your role permits');
       // Concrete one-line examples anchoring high-frequency abstract rules.
-      expect(prompt).toContain('locate the method in the code'); // ambiguous instruction -> edit code, not echo text
       expect(prompt).toContain('update the related tests'); // preamble phrasing example
       expect(prompt).toContain('premature abstraction'); // MINIMAL-changes counterexample
     }


### PR DESCRIPTION
## Related Issue

Follow-up to #3028.

## Problem

#3028 removed the "treat ambiguous requests as tasks" rule and its `locate the method in the code` example from the default system prompt. `test/profile/default-agent-profiles.test.ts` pinned that example verbatim (`expect(prompt).toContain('locate the method in the code')`), so the shard covering `kimi-core` profile tests fails on main.

## What changed

Drops the single stale assertion. The removal was intentional product behavior, so the test is updated to the new contract; the remaining example pins (`update the related tests`, `premature abstraction`) still hold. Verified locally: `default-agent-profiles` + `prompt-placeholders` + `prompt-service` suites pass (74 tests).

No changeset: test-only change.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.