### PR TITLE
fix(vscode): keep long-running chat streams alive

### DIFF
--- a/.changeset/keep-vscode-stream-alive.md
+++ b/.changeset/keep-vscode-stream-alive.md
@@ -1,0 +1,5 @@
+---
+"kimi-code": patch
+---
+
+Keep long-running VS Code chat streams active until the engine reports completion instead of expiring them after ten minutes.

--- a/.changeset/keep-vscode-stream-alive.md
+++ b/.changeset/keep-vscode-stream-alive.md
@@ -1,5 +1,5 @@
 ---
-"kimi-code": patch
+"@moonshot-ai/kimi-code": patch
 ---
 
 Keep long-running VS Code chat streams active until the engine reports completion instead of expiring them after ten minutes.

--- a/apps/vscode/test/settings-store.test.ts
+++ b/apps/vscode/test/settings-store.test.ts
@@ -245,6 +245,40 @@ describe("Webview MCP update bridge", () => {
       }),
     ]);
   });
+
+  it("does not expire a streamChat request at the generic ten-minute bridge timeout", async () => {
+    vi.useFakeTimers();
+    try {
+      const posted: Array<{ id: string; method: string }> = [];
+      let receiveMessage: ((event: { data: unknown }) => void) | undefined;
+      vi.stubGlobal("document", {
+        body: { getAttribute: () => "stream-test-view" },
+      });
+      vi.stubGlobal("window", {
+        addEventListener: (_type: string, listener: (event: { data: unknown }) => void) => {
+          receiveMessage = listener;
+        },
+      });
+      vi.stubGlobal("acquireVsCodeApi", () => ({
+        postMessage: (message: { id: string; method: string }) => posted.push(message),
+        getState: () => undefined,
+        setState: () => undefined,
+      }));
+      vi.resetModules();
+      const { bridge } = await import("../webview-ui/src/services/bridge");
+
+      let settled = false;
+      const pending = bridge.streamChat("long turn", "model", "off", false);
+      void pending.then(() => { settled = true; }, () => { settled = true; });
+      await vi.advanceTimersByTimeAsync(10 * 60 * 1000 + 1);
+      expect(settled).toBe(false);
+
+      receiveMessage?.({ data: { id: posted[0]?.id, result: { done: true } } });
+      await expect(pending).resolves.toEqual({ done: true });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
 });
 
 describe("Webview chat error recovery", () => {

--- a/apps/vscode/webview-ui/src/services/bridge.ts
+++ b/apps/vscode/webview-ui/src/services/bridge.ts
@@ -21,7 +21,7 @@ import type {
 interface PendingRequest {
   resolve: (value: unknown) => void;
   reject: (error: Error) => void;
-  timeout: ReturnType<typeof setTimeout>;
+  timeout?: ReturnType<typeof setTimeout>;
 }
 
 const DEFAULT_REQUEST_TIMEOUT_MS = 10 * 60 * 1000;
@@ -64,7 +64,7 @@ class Bridge {
 
     if (msg.id && this.pending.has(msg.id)) {
       const { resolve, reject, timeout } = this.pending.get(msg.id)!;
-      clearTimeout(timeout);
+      if (timeout !== undefined) clearTimeout(timeout);
       this.pending.delete(msg.id);
 
       if (msg.error) {
@@ -81,14 +81,16 @@ class Bridge {
     }
   };
 
-  private call<T>(method: string, params?: unknown, timeoutMs = DEFAULT_REQUEST_TIMEOUT_MS): Promise<T> {
+  private call<T>(method: string, params?: unknown, timeoutMs: number | null = DEFAULT_REQUEST_TIMEOUT_MS): Promise<T> {
     const id = `${++this.requestId}_${Date.now()}`;
 
     return new Promise((resolve, reject) => {
-      const timeout = setTimeout(() => {
-        this.pending.delete(id);
-        reject(new Error(`Bridge ${method} timed out`));
-      }, timeoutMs);
+      const timeout = timeoutMs === null
+        ? undefined
+        : setTimeout(() => {
+          this.pending.delete(id);
+          reject(new Error(`Bridge ${method} timed out`));
+        }, timeoutMs);
 
       this.pending.set(id, { resolve: resolve as (v: unknown) => void, reject, timeout });
       this.vscode.postMessage({ id, method, params, webviewId: this.webviewId });
@@ -184,7 +186,7 @@ class Bridge {
   }
 
   streamChat(content: string | ContentPart[], model: string, effort: string, planMode: boolean, sessionId?: string) {
-    return this.call<{ done: boolean }>(Methods.StreamChat, { content, model, effort, planMode, sessionId });
+    return this.call<{ done: boolean }>(Methods.StreamChat, { content, model, effort, planMode, sessionId }, null);
   }
 
   abortChat() {


### PR DESCRIPTION
## Related Issue

No linked issue — the problem is clear and reproducible in the VS Code Webview: a chat request that runs longer than ten minutes is rejected by the generic Bridge timeout even though the engine turn is still active.

## Problem

`streamChat` shares the default ten-minute RPC timeout with short-lived Webview requests. When a long-running turn crosses that limit, the Bridge rejects the request and the chat store reports a terminal send error, so the Webview can show the session as finished while the engine is still working.

## What changed

- Keep the generic ten-minute timeout for ordinary Bridge calls.
- Allow a request to opt out of that timeout and use it only for `streamChat`, whose lifetime is the engine turn.
- Let the existing `stream_complete` or terminal error event determine the visible streaming state.
- Add a fake-timer regression test proving that a `streamChat` request remains pending beyond ten minutes and resolves when the Host replies.
- Add a patch changeset for the Kimi Code package.
- Rebase the change onto the current `main` branch.

## Verification

- [x] Focused VS Code test: `settings-store.test.ts` — 29 passed.
- [x] Full VS Code suite — 20 test files, 363 passed.
- [x] VS Code extension and Webview typecheck passed on Node 24.16.0 / pnpm 10.33.0.
- [x] Repository lint passed with 0 errors; existing warnings only.
- [x] `git diff --check` passed.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill; added a patch changeset for the Kimi Code package.
- [x] Ran `gen-docs` skill; no documentation update is needed because this changes an internal VS Code request lifetime and adds no user-facing configuration or workflow.
