### PR TITLE
fix(vscode): scope New Conversation to the sidebar view

### DIFF
--- a/.changeset/vscode-new-conversation-scope.md
+++ b/.changeset/vscode-new-conversation-scope.md
@@ -1,0 +1,5 @@
+---
+"kimi-code": patch
+---
+
+The sidebar's New Conversation action now resets only the sidebar view; Kimi views opened as editor tabs keep their conversation and their in-flight turn.

--- a/apps/vscode/src/KimiWebviewProvider.ts
+++ b/apps/vscode/src/KimiWebviewProvider.ts
@@ -18,6 +18,7 @@ function getNonce(): string {
  */
 export class KimiWebviewProvider implements vscode.WebviewViewProvider {
   private webviews = new Map<string, vscode.Webview>();
+  private sidebarWebviewId: string | undefined;
   private bridgeHandler: BridgeHandler;
 
   constructor(
@@ -50,9 +51,11 @@ export class KimiWebviewProvider implements vscode.WebviewViewProvider {
 
   resolveWebviewView(webviewView: vscode.WebviewView): void {
     const webviewId = `sidebar_${crypto.randomUUID()}`;
+    this.sidebarWebviewId = webviewId;
     this.setupWebview(webviewId, webviewView.webview);
 
     webviewView.onDidDispose(() => {
+      if (this.sidebarWebviewId === webviewId) this.sidebarWebviewId = undefined;
       void this.bridgeHandler.disposeView(webviewId);
       this.webviews.delete(webviewId);
     });
@@ -79,6 +82,12 @@ export class KimiWebviewProvider implements vscode.WebviewViewProvider {
 
   broadcast(event: string, data: unknown): void {
     this.broadcastInternal(event, data);
+  }
+
+  /** Actions contributed to the sidebar's `view/title` act on that view alone; panels own their own state. */
+  broadcastToSidebar(event: string, data: unknown): void {
+    if (this.sidebarWebviewId === undefined) return;
+    this.broadcastInternal(event, data, this.sidebarWebviewId);
   }
 
   async insertEditorMention(documentUri: vscode.Uri, selection: vscode.Selection): Promise<boolean> {

--- a/apps/vscode/src/extension.ts
+++ b/apps/vscode/src/extension.ts
@@ -115,7 +115,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
     },
     "kimi.newConversation": async () => {
       await vscode.commands.executeCommand("kimi.webview.focus");
-      provider?.broadcast(Events.NewConversation, {});
+      provider?.broadcastToSidebar(Events.NewConversation, {});
     },
     "kimi.showLogs": () => outputChannel?.show(),
     "kimi.resetKimi": () => provider?.resetAllWebviews(),

--- a/apps/vscode/test/webview-provider.test.ts
+++ b/apps/vscode/test/webview-provider.test.ts
@@ -1,0 +1,224 @@
+/**
+ * Scenario: the Kimi sidebar and one or more editor-tab panels are open at the same time.
+ * Responsibilities: an action owned by the sidebar's view/title must reach the sidebar alone —
+ * panels hold independent sessions — while genuinely global notifications still reach every view.
+ * Wiring: the real KimiWebviewProvider and BridgeHandler; VS Code and the public Node SDK harness
+ * boundary are replaced.
+ * Run: pnpm --filter kimi-code exec vitest run --config vitest.config.ts test/webview-provider.test.ts
+ */
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type * as vscode from "vscode";
+
+import { KimiWebviewProvider } from "../src/KimiWebviewProvider";
+
+const host = vi.hoisted(() => {
+  const watcher = {
+    onDidChange: vi.fn(),
+    onDidCreate: vi.fn(),
+    onDidDelete: vi.fn(),
+    dispose: vi.fn(),
+  };
+  const harness = {
+    homeDir: "/tmp/kimi-code-test-home",
+    close: vi.fn(async () => undefined),
+    getConfig: vi.fn(async () => ({ models: {} })),
+    setConfig: vi.fn(async () => undefined),
+    listSessions: vi.fn(async () => []),
+    resumeSession: vi.fn(),
+    forkSession: vi.fn(),
+    deleteSession: vi.fn(async () => undefined),
+  };
+
+  class Uri {
+    readonly scheme = "file";
+    readonly authority = "";
+    readonly path: string;
+
+    constructor(readonly fsPath: string) {
+      this.path = fsPath;
+    }
+
+    static joinPath(base: Uri, ...segments: string[]): Uri {
+      return new Uri(join(base.fsPath, ...segments));
+    }
+
+    toString(): string {
+      return `file://${this.path}`;
+    }
+  }
+
+  return {
+    Uri,
+    watcher,
+    harness,
+    createWebviewPanel: vi.fn(),
+    workspaceFolders: [] as Array<{ uri: Uri }>,
+  };
+});
+
+vi.mock("vscode", () => ({
+  Uri: host.Uri,
+  ViewColumn: { One: 1 },
+  workspace: {
+    get workspaceFolders() {
+      return host.workspaceFolders;
+    },
+    getConfiguration: () => ({ get: (_key: string, fallback: unknown) => fallback }),
+    createFileSystemWatcher: () => host.watcher,
+    textDocuments: [],
+  },
+  window: {
+    showWarningMessage: vi.fn(async () => undefined),
+    createWebviewPanel: (...args: unknown[]) => host.createWebviewPanel(...args),
+  },
+}));
+
+vi.mock("@moonshot-ai/kimi-code-sdk", async (importOriginal) => {
+  const original = await importOriginal<typeof import("@moonshot-ai/kimi-code-sdk")>();
+  return {
+    ...original,
+    createKimiHarness: () => host.harness,
+    createKimiHarnessV2: () => host.harness,
+  };
+});
+
+interface FakeView {
+  readonly posted: Array<{ event?: string; data?: unknown }>;
+  readonly webview: vscode.Webview;
+  /** Captures the provider's onDidDispose callback so a test can close the view like VS Code does. */
+  register: (handler: () => void) => void;
+  dispose: () => void;
+}
+
+function createFakeView(): FakeView {
+  const posted: Array<{ event?: string; data?: unknown }> = [];
+  let disposeHandler: () => void = () => undefined;
+
+  const webview = {
+    options: {},
+    html: "",
+    cspSource: "vscode-webview:",
+    asWebviewUri: (uri: { toString: () => string }) => uri,
+    onDidReceiveMessage: () => ({ dispose: () => undefined }),
+    postMessage: async (message: { event?: string; data?: unknown }) => {
+      posted.push(message);
+      return true;
+    },
+  } as unknown as vscode.Webview;
+
+  return {
+    posted,
+    webview,
+    register: (handler) => {
+      disposeHandler = handler;
+    },
+    dispose: () => {
+      disposeHandler();
+    },
+  };
+}
+
+function asWebviewView(view: FakeView): vscode.WebviewView {
+  return {
+    webview: view.webview,
+    onDidDispose: (handler: () => void) => {
+      view.register(handler);
+      return { dispose: () => undefined };
+    },
+  } as unknown as vscode.WebviewView;
+}
+
+function asWebviewPanel(view: FakeView): vscode.WebviewPanel {
+  return {
+    webview: view.webview,
+    onDidDispose: (handler: () => void) => {
+      view.register(handler);
+      return { dispose: () => undefined };
+    },
+  } as unknown as vscode.WebviewPanel;
+}
+
+let provider: KimiWebviewProvider;
+let root: string;
+
+beforeEach(async () => {
+  root = await mkdtemp(join(tmpdir(), "kimi-vscode-provider-"));
+  host.workspaceFolders.splice(0, host.workspaceFolders.length, { uri: new host.Uri(root) });
+  const context = {
+    workspaceState: { get: vi.fn((_key: string, fallback: unknown) => fallback), update: vi.fn() },
+    globalStorageUri: new host.Uri(join(root, "global-storage")),
+  } as unknown as vscode.ExtensionContext;
+
+  provider = new KimiWebviewProvider(
+    new host.Uri(root) as unknown as vscode.Uri,
+    context,
+    () => undefined,
+    () => undefined,
+  );
+});
+
+afterEach(async () => {
+  await provider.shutdown();
+  vi.clearAllMocks();
+  await rm(root, { recursive: true, force: true });
+});
+
+describe("Webview broadcast scope (sidebar actions must not reset editor-tab panels)", () => {
+  it("delivers a sidebar-scoped event to the sidebar view only", () => {
+    const sidebar = createFakeView();
+    const panel = createFakeView();
+    host.createWebviewPanel.mockReturnValue(asWebviewPanel(panel));
+
+    provider.resolveWebviewView(asWebviewView(sidebar));
+    provider.createPanel();
+
+    provider.broadcastToSidebar("newConversation", {});
+
+    expect(sidebar.posted).toEqual([{ event: "newConversation", data: {} }]);
+    expect(panel.posted).toEqual([]);
+  });
+
+  it("still delivers an unscoped broadcast to every view", () => {
+    const sidebar = createFakeView();
+    const panel = createFakeView();
+    host.createWebviewPanel.mockReturnValue(asWebviewPanel(panel));
+
+    provider.resolveWebviewView(asWebviewView(sidebar));
+    provider.createPanel();
+
+    provider.broadcast("extensionConfigChanged", { config: {} });
+
+    expect(sidebar.posted).toHaveLength(1);
+    expect(panel.posted).toHaveLength(1);
+  });
+
+  it("drops a sidebar-scoped event when no sidebar view is registered", () => {
+    const panel = createFakeView();
+    host.createWebviewPanel.mockReturnValue(asWebviewPanel(panel));
+
+    provider.createPanel();
+
+    provider.broadcastToSidebar("newConversation", {});
+
+    expect(panel.posted).toEqual([]);
+  });
+
+  it("stops targeting the sidebar view after it is disposed", () => {
+    const sidebar = createFakeView();
+    const panel = createFakeView();
+    host.createWebviewPanel.mockReturnValue(asWebviewPanel(panel));
+
+    provider.resolveWebviewView(asWebviewView(sidebar));
+    provider.createPanel();
+    sidebar.dispose();
+
+    provider.broadcastToSidebar("newConversation", {});
+
+    expect(sidebar.posted).toEqual([]);
+    expect(panel.posted).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Related Issue

Resolves #3036

## Problem

`kimi.newConversation` 这个命令自己前后两行是矛盾的（[`apps/vscode/src/extension.ts:116-119`](https://github.com/MoonshotAI/kimi-code/blob/02aa24e2f460e7806ee08793c7bd260bb614d295/apps/vscode/src/extension.ts#L116-L119)）：

```ts
await vscode.commands.executeCommand("kimi.webview.focus");  // ① 只作用于侧边栏视图
provider?.broadcast(Events.NewConversation, {});             // ② 广播给所有 webview
```

第 ① 行无条件 reveal 并聚焦 `kimi.webview`（侧边栏视图专属、由 VS Code 自动生成的命令），第 ② 行却发给每一个已注册的 webview。

结果：只要有 Kimi 对话窗口开在编辑器标签页里，点一下侧边栏标题栏的 `+`，那些标签页的对话也会被清空，正在流式输出的回合被停掉。而每个视图持有各自独立的 session 和工作目录（`BridgeHandler` 按 `webviewId` 分别管理），不应该"一次点击重置全部"。

同一功能的另外两个入口——webview 内部 Header 的 `+`、以及 Cmd/Ctrl+N 快捷键（[`webview-ui/src/App.tsx:53-65`](https://github.com/MoonshotAI/kimi-code/blob/02aa24e2f460e7806ee08793c7bd260bb614d295/apps/vscode/webview-ui/src/App.tsx#L53-L65)）——都只影响自己所在的对话窗口。命令这条路径与它们不一致。

复现步骤和动图见关联 issue。

## What changed

**`KimiWebviewProvider`**：新增 `sidebarWebviewId` 字段。`resolveWebviewView` 是唯一创建侧边栏视图的入口，在那里记录 id；视图销毁时清除。清除加了 `=== webviewId` 判断——侧边栏关闭后重开时，VS Code 可能先创建新视图再销毁旧视图，无条件清空会把刚记录的新 id 一起抹掉。

新增 `broadcastToSidebar()`。定向投递能力本来就有：`broadcastInternal` 的第三个参数（[`KimiWebviewProvider.ts:112`](https://github.com/MoonshotAI/kimi-code/blob/02aa24e2f460e7806ee08793c7bd260bb614d295/apps/vscode/src/KimiWebviewProvider.ts#L112)）就是干这个的，`insertEditorMention` 一直在逐 `webviewId` 使用它。这里只是把它接到命令上。

**`extension.ts`**：`kimi.newConversation` 改用 `broadcastToSidebar`。第 ① 行的 focus 一个字没动——它本来就是这个命令归属侧边栏的自证。

**测试**：`KimiWebviewProvider` 此前没有测试文件，因此新建 `test/webview-provider.test.ts`（无既有文件可归并）。4 个用例：定向事件只到侧边栏、不定向广播仍到所有视图、无侧边栏时丢弃而非群发、侧边栏销毁后不再定向。

以 `origin/main` 为基线时其中 3 个用例失败；把新方法临时改回不定向的群发也是同样 3 个失败——用例抓的是这个缺陷本身，不只是新方法的存在。

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.
