### PR TITLE
fix: allow archiving a session whose workspace root no longer exists

### DIFF
--- a/.changeset/fix-archive-session-missing-workspace-root.md
+++ b/.changeset/fix-archive-session-missing-workspace-root.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Fix archiving a session failing when its workspace directory no longer exists.

--- a/packages/kap-server/src/routes/sessions.ts
+++ b/packages/kap-server/src/routes/sessions.ts
@@ -10,6 +10,7 @@ import {
   ISessionBtwService,
   ISessionContext,
   ISessionIndex,
+  ISessionIndexMirror,
   ISessionMetadata,
   ISessionLegacyService,
   ISessionTitleService,
@@ -21,6 +22,7 @@ import {
   getLiveSessionById,
   programForSession,
   resumeSessionById,
+  setSessionArchivedBatch,
   isError2,
   Error2,
   type ContextMessage,
@@ -732,15 +734,14 @@ export function registerSessionsRoutes(app: SessionRouteHost, core: Scope): void
           return;
         }
 
-        const archiveHandler = await programForSession(core.accessor, parsed.id);
-        const archived =
-          archiveHandler === undefined
-            ? undefined
-            : await core.accessor.get(ISessionManager).resume(parsed.id);
-        if (archived === undefined || archiveHandler === undefined) {
-          throw new Error2(ErrorCodes.SESSION_NOT_FOUND, `session ${parsed.id} does not exist`);
+        const [archiveOutcome] = await setSessionArchivedBatch(core.accessor, [parsed.id], true);
+        if (archiveOutcome === undefined || !archiveOutcome.ok) {
+          if (archiveOutcome?.reason === 'not_found') {
+            throw new Error2(ErrorCodes.SESSION_NOT_FOUND, archiveOutcome.message);
+          }
+          throw new Error(archiveOutcome?.message ?? `failed to archive session ${parsed.id}`);
         }
-        await core.accessor.get(ISessionManager).archive(parsed.id);
+        await core.accessor.get(ISessionIndexMirror).drain();
         requestLog(req)?.info({ session_id: parsed.id, action: 'archive' }, 'session action completed');
         reply.send(okEnvelope({ archived: true }, req.id));
       } catch (error) {

--- a/packages/kap-server/test/sessions.test.ts
+++ b/packages/kap-server/test/sessions.test.ts
@@ -18,6 +18,7 @@ import {
   IAgentLifecycleService,
   IEventBus,
   IEventService,
+  IWorkspaceService,
   MAIN_AGENT_ID,
   closeSessionById,
   getLiveSessionById,
@@ -767,6 +768,25 @@ describe('server-v2 /api/v1/sessions', () => {
     const cwd = home as string;
     const created = await postJson<SessionWire>('/api/v1/sessions', { metadata: { cwd } });
     const id = created.body.data.id;
+
+    const archived = await postJson<{ archived: boolean }>(`/api/v1/sessions/${id}:archive`);
+    expect(archived.body.code).toBe(0);
+    expect(archived.body.data).toEqual({ archived: true });
+
+    const got = await getJson<SessionWire>(`/api/v1/sessions/${id}`);
+    expect(got.body.code).toBe(0);
+    expect(got.body.data.archived).toBe(true);
+  });
+
+  it('archives a cold session via :archive after its workspace root was deleted', async () => {
+    const wsDir = await mkdtemp(join(tmpdir(), 'kimi-archive-ws-'));
+    const created = await postJson<SessionWire>('/api/v1/sessions', { metadata: { cwd: wsDir } });
+    const id = created.body.data.id;
+    const workspaceId = created.body.data.workspace_id;
+
+    await closeSessionById((server as RunningServer).core.accessor, id);
+    await (server as RunningServer).core.accessor.get(IWorkspaceService).delete(workspaceId);
+    await rm(wsDir, { recursive: true, force: true });
 
     const archived = await postJson<{ archived: boolean }>(`/api/v1/sessions/${id}:archive`);
     expect(archived.body.code).toBe(0);


### PR DESCRIPTION
## Related Issue

No linked issue — the problem is explained below.

## Problem

Archiving a session via `POST /api/v1/sessions/{id}:archive` fails with `workspace root <path> does not exist` once the session's workspace directory has been deleted (e.g. a cleaned-up temporary task directory). Archiving is a pure bookkeeping operation — it flips the `archived`/`archivedAt` metadata — but the v1 route first materialized the workspace (`programForSession`) and fully resumed the cold session before archiving it, so a missing workspace directory made the session impossible to archive.

## What changed

- The v1 `:archive` branch now delegates to the existing `setSessionArchivedBatch` path (the same one backing `POST /api/v2/sessions:archive`): a live session is archived through the normal lifecycle-serialized `archive()`, while a cold session is archived by `setColdSessionArchived`, which only updates the persisted session metadata, the session index mirror, and publishes the `SessionArchived` event — it never touches the workspace directory. This also removes the needless full resume of a cold session before archiving it.
- Wire contract is unchanged: same route, same `{ archived: true }` response, missing sessions still return 40401 `SESSION_NOT_FOUND`.
- Added a regression test that creates a session, closes it, removes the workspace catalog entry, deletes the workspace directory, and asserts `:archive` succeeds and the archived flag is visible via GET.
- `WorkspaceService.createOrTouch`'s directory-existence check is deliberately left as is.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.
