### PR TITLE
fix(kimi-code): upload pasted videos to the daemon file store

### DIFF
--- a/.changeset/fix-video-paste-daemon-upload.md
+++ b/.changeset/fix-video-paste-daemon-upload.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Fix pasted videos failing to submit instead of reaching the model.

--- a/apps/kimi-code/src/tui/constant/media.ts
+++ b/apps/kimi-code/src/tui/constant/media.ts
@@ -1,6 +1,6 @@
 /** TUI-only daemon staging lifetimes for pasted media. */
 
-export const IMAGE_STAGING_TTL_SECONDS = 60 * 60;
-export const IMAGE_FILE_REF_MIN_REMAINING_MS = 60_000;
-/** How long submit waits for a just-pasted image's background ingestion before falling back to the inline form. */
-export const IMAGE_INGESTION_SUBMIT_WAIT_MS = 2_000;
+export const MEDIA_STAGING_TTL_SECONDS = 60 * 60;
+export const MEDIA_FILE_REF_MIN_REMAINING_MS = 60_000;
+/** How long submit waits for a just-pasted medium's background ingestion before giving up on the daemon-ref form. */
+export const MEDIA_INGESTION_SUBMIT_WAIT_MS = 2_000;

--- a/apps/kimi-code/src/tui/controllers/cache-hint-controller.ts
+++ b/apps/kimi-code/src/tui/controllers/cache-hint-controller.ts
@@ -52,7 +52,7 @@ export interface CacheHintHost {
    * staged media with queue-recall semantics (consume retains, retire staged
    * copies, rebase videos) — without this the retains/copies would leak.
    */
-  recallStashedMedia(text: string, extraction: ExtractionResult | undefined): void;
+  recallStashedMedia(extraction: ExtractionResult | undefined): void;
   showError(message: string): void;
   createNewSession(): Promise<void>;
   sendNormalUserInput(text: string, preExtracted?: ExtractionResult): Promise<void>;
@@ -394,7 +394,7 @@ export class CacheHintController {
     if (stash === undefined) return;
     this.restoredTexts.push(stash.text);
     this.host.restoreInputText(this.restoredTexts.join('\n'));
-    this.host.recallStashedMedia(stash.text, stash.extraction);
+    this.host.recallStashedMedia(stash.extraction);
   }
 
   private upstreamModelId(): string | undefined {

--- a/apps/kimi-code/src/tui/controllers/editor-keyboard.ts
+++ b/apps/kimi-code/src/tui/controllers/editor-keyboard.ts
@@ -1,7 +1,13 @@
+import { readFile } from 'node:fs/promises';
+
 import type { FileMeta, KimiHarness, Session } from '@moonshot-ai/kimi-code-sdk';
 import { compressImageForModel } from '@moonshot-ai/kimi-code-sdk';
 
-import { ClipboardMediaError, readClipboardMedia } from '#/utils/clipboard/clipboard-image';
+import {
+  ClipboardMediaError,
+  readClipboardMedia,
+  type ClipboardVideo,
+} from '#/utils/clipboard/clipboard-image';
 import { parseImageMeta } from '#/utils/image/image-mime';
 import { editInExternalEditor, resolveEditorCommand } from '#/utils/process/external-editor';
 
@@ -13,9 +19,13 @@ import {
   LLM_NOT_SET_MESSAGE,
   NO_ACTIVE_SESSION_MESSAGE,
 } from '../constant/kimi-tui';
-import { IMAGE_STAGING_TTL_SECONDS } from '../constant/media';
+import { MEDIA_STAGING_TTL_SECONDS } from '../constant/media';
 import { formatErrorMessage } from '../utils/event-payload';
-import type { ImageAttachment, ImageAttachmentStore } from '../utils/image-attachment-store';
+import type {
+  ImageAttachment,
+  ImageAttachmentStore,
+  VideoAttachment,
+} from '../utils/image-attachment-store';
 import { extractMediaAttachments, imageExtensionForMime } from '../utils/image-placeholder';
 import { extractInlineSkillActivations } from '../utils/inline-skill-tokens';
 import type { PendingExit, QueuedMessage, SteerInputItem } from '../types';
@@ -28,7 +38,8 @@ export interface EditorKeyboardHost {
   /**
    * True when the TUI runs on the agent-core-v2 engine (startup-selected).
    * Gates the paste-time upload to the daemon file store; the v1 engine has
-   * no file store and keeps the submit-time inline base64 form.
+   * no file store, so images keep the submit-time inline base64 form and
+   * videos cannot be submitted at all.
    */
   readonly engineV2: boolean;
   cancelInFlight: (() => void) | undefined;
@@ -49,7 +60,7 @@ export interface EditorKeyboardHost {
     imageAttachmentIds: readonly number[];
     videoAttachmentIds: readonly number[];
   }): boolean;
-  releaseStagingMedia(imageAttachmentIds: readonly number[], paths: readonly string[]): void;
+  releaseStagingMedia(mediaAttachmentIds: readonly number[]): void;
   recallLastQueued(): QueuedMessage | undefined;
   showError(msg: string): void;
   track(event: string, props?: Record<string, unknown>): void;
@@ -345,7 +356,7 @@ export class EditorKeyboardController {
             text: trimmed,
             parts: m.parts,
             imageAttachmentIds: m.imageAttachmentIds,
-            stagingPaths: m.stagingPaths,
+            videoAttachmentIds: m.videoAttachmentIds,
           });
         }
       }
@@ -355,11 +366,12 @@ export class EditorKeyboardController {
           // Synchronous path: an image still ingesting in the background
           // extracts to its inline fallback here (no bounded wait like
           // `sendNormalUserInput` — this handler cannot await without
-          // interleaving queue/draft edits).
+          // interleaving queue/draft edits); a video still uploading refuses
+          // the submission instead (no inline form exists).
           editorExtraction = extractMediaAttachments(text, this.imageStore);
         } catch (error) {
-          // Cache copy failed (e.g. the pasted video's source vanished) —
-          // leave the queue and the editor draft untouched.
+          // Media expansion failed (e.g. the pasted video's upload is still
+          // in flight) — leave the queue and the editor draft untouched.
           host.showError(`Failed to prepare media attachment: ${formatErrorMessage(error)}`);
           return;
         }
@@ -370,7 +382,10 @@ export class EditorKeyboardController {
             editorExtraction.imageAttachmentIds.length > 0
               ? editorExtraction.imageAttachmentIds
               : undefined,
-          stagingPaths: editorExtraction.stagingPaths,
+          videoAttachmentIds:
+            editorExtraction.videoAttachmentIds.length > 0
+              ? editorExtraction.videoAttachmentIds
+              : undefined,
         });
       }
       flushTextRun();
@@ -383,18 +398,18 @@ export class EditorKeyboardController {
           editorExtraction !== undefined &&
           !host.validateMediaCapabilities(editorExtraction)
         ) {
-          host.releaseStagingMedia(
-            editorExtraction.imageAttachmentIds,
-            editorExtraction.stagingPaths,
-          );
+          host.releaseStagingMedia([
+            ...editorExtraction.imageAttachmentIds,
+            ...editorExtraction.videoAttachmentIds,
+          ]);
           return;
         }
         const session = host.session;
         if (host.state.appState.model.trim().length === 0 || session === undefined) {
-          host.releaseStagingMedia(
-            editorExtraction?.imageAttachmentIds ?? [],
-            editorExtraction?.stagingPaths ?? [],
-          );
+          host.releaseStagingMedia([
+            ...(editorExtraction?.imageAttachmentIds ?? []),
+            ...(editorExtraction?.videoAttachmentIds ?? []),
+          ]);
           host.showError(LLM_NOT_SET_MESSAGE);
           return;
         }
@@ -540,10 +555,22 @@ export class EditorKeyboardController {
     if (media === null) return false;
 
     if (media.kind === 'video') {
+      // Same shape as the image flow below: register the attachment and put
+      // its placeholder in the editor first, then upload the source file to
+      // the daemon file store in the background — typing never waits on it,
+      // and submit gives a pending upload the bounded `pendingMediaIngestions`
+      // wait. Unlike an image there is no inline fallback form, so a video
+      // whose upload has not landed (or failed) refuses the submission at
+      // extraction time.
       const attachment = this.imageStore.addVideo(media.mimeType, media.sourcePath, media.filename);
       this.host.state.editor.insertTextAtCursor?.(`${attachment.placeholder} `);
       this.host.state.ui.requestRender();
       this.host.track('shortcut_paste', { kind: 'video' });
+      attachment.pending = this.finishClipboardVideoPaste(attachment, media).catch(
+        (error: unknown) => {
+          this.host.showError(`Failed to process pasted video: ${formatErrorMessage(error)}`);
+        },
+      );
       return true;
     }
 
@@ -663,12 +690,59 @@ export class EditorKeyboardController {
       const meta = await harness.uploadFile(bytes, {
         name: `pasted-image.${imageExtensionForMime(mime)}`,
         mimeType: mime,
-        expiresInSec: IMAGE_STAGING_TTL_SECONDS,
+        expiresInSec: MEDIA_STAGING_TTL_SECONDS,
       });
       return meta;
     } catch {
       return undefined;
     }
+  }
+
+  /**
+   * Paste-time upload of the video's source file to the engine's daemon file
+   * store (agent-core-v2 only), run as background ingestion exactly like the
+   * image upload above. Best effort: any failure returns undefined, leaving
+   * the attachment without a `fileId` — submit-time expansion then refuses
+   * the submission, since a video has no inline fallback form.
+   */
+  private async uploadVideoToDaemonFileStore(
+    media: ClipboardVideo,
+  ): Promise<FileMeta | undefined> {
+    if (!this.host.engineV2) return undefined;
+    const harness = this.host.harness;
+    if (harness === undefined) return undefined;
+    let bytes: Uint8Array;
+    try {
+      bytes = await readFile(media.sourcePath);
+    } catch {
+      // The source (e.g. a clipboard temp file) vanished before the upload
+      // could read it — same outcome as a failed upload.
+      return undefined;
+    }
+    try {
+      return await harness.uploadFile(bytes, {
+        name: media.filename,
+        mimeType: media.mimeType,
+        expiresInSec: MEDIA_STAGING_TTL_SECONDS,
+      });
+    } catch {
+      return undefined;
+    }
+  }
+
+  private async finishClipboardVideoPaste(
+    attachment: VideoAttachment,
+    media: ClipboardVideo,
+  ): Promise<void> {
+    const uploaded = await this.uploadVideoToDaemonFileStore(media);
+    const completed = this.imageStore.completeVideo(attachment, {
+      fileId: uploaded?.id,
+      fileExpiresAt: parseExpiry(uploaded),
+    });
+    if (completed === undefined && uploaded !== undefined) {
+      await this.host.harness?.deleteFile(uploaded.id).catch(() => undefined);
+    }
+    this.host.state.ui.requestRender();
   }
 
   private async openExternalEditor(): Promise<void> {

--- a/apps/kimi-code/src/tui/controllers/staging-leases.ts
+++ b/apps/kimi-code/src/tui/controllers/staging-leases.ts
@@ -8,11 +8,11 @@
  *
  * - Daemon uploads become garbage — the engine materialized its own session
  *   copy at intake — so the turn-end release deletes them.
- * - Local cache copies may still be referenced by persisted history: a v1
- *   video degrade writes its `<video path="…">` tag with the cache path, and
- *   skill/plugin args carry the path as plain text; neither form is rewritten
- *   to the session media dir. Turn-end release therefore retires cache copies
- *   to a session-lifetime bucket, deleted at session close / shutdown.
+ * - Local cache copies may still be referenced by persisted history: slash /
+ *   plugin command args carry the path as plain text (the model reads it
+ *   with `ReadMediaFile`), and that form is never rewritten to the session
+ *   media dir. Turn-end release therefore retires cache copies to a
+ *   session-lifetime bucket, deleted at session close / shutdown.
  *
  * Media that never gets consumed (validation/render failure, queue discard,
  * a dispatch RPC that failed before any turn claimed the lease) is deleted
@@ -59,7 +59,7 @@ import type { QueuedMessage } from '../types';
 export type StagingLeaseOrigin = 'user' | 'skill_activation' | 'plugin_command';
 
 export interface StagingLease {
-  readonly imageAttachmentIds: readonly number[];
+  readonly mediaAttachmentIds: readonly number[];
   readonly paths: readonly string[];
   readonly origin: StagingLeaseOrigin;
   readonly submissionId?: string;
@@ -69,9 +69,9 @@ export interface StagingLease {
 
 export interface StagingLeaseEffects {
   /** Resolve attachment ids to the staged daemon file ids, consuming the mapping. */
-  readonly takeFileIds: (imageAttachmentIds: readonly number[]) => readonly string[];
+  readonly takeFileIds: (mediaAttachmentIds: readonly number[]) => readonly string[];
   /** Consume retains without taking the staged files (queue recall keeps them). */
-  readonly releaseRetains: (imageAttachmentIds: readonly number[]) => void;
+  readonly releaseRetains: (mediaAttachmentIds: readonly number[]) => void;
   /** Delete staged files (daemon uploads + local cache copies); never rejects. */
   readonly deleteFiles: (fileIds: readonly string[], paths: readonly string[]) => Promise<void>;
   /**
@@ -91,27 +91,27 @@ export class StagingLeaseTracker {
   private readonly leasesBySubmissionId = new Map<string, StagingLease>();
   /**
    * Cache copies whose consuming turn already ended. Persisted history may
-   * still reference their paths (v1 video degrade tags, skill/plugin text
-   * references), so they survive until the session closes.
+   * still reference their paths (skill/plugin args carry them as plain
+   * text), so they survive until the session closes.
    */
   private readonly retiredPaths = new Set<string>();
 
   constructor(private readonly effects: StagingLeaseEffects) {}
 
   create(
-    imageAttachmentIds: readonly number[],
+    mediaAttachmentIds: readonly number[],
     paths: readonly string[],
     origin: StagingLeaseOrigin,
     submissionId?: string,
   ): StagingLease | undefined {
-    // `imageAttachmentIds` multiplicity is the retain count this lease must
+    // `mediaAttachmentIds` multiplicity is the retain count this lease must
     // release: each extraction/rewrite retains once per unique id, so callers
     // dedupe repeated placeholder occurrences per contribution before handing
     // the ids over (one message referencing an image twice contributes it
     // once; two batched messages sharing an image contribute it twice).
-    if (imageAttachmentIds.length === 0 && paths.length === 0) return undefined;
+    if (mediaAttachmentIds.length === 0 && paths.length === 0) return undefined;
     const lease: StagingLease = {
-      imageAttachmentIds: [...imageAttachmentIds],
+      mediaAttachmentIds: [...mediaAttachmentIds],
       paths: [...paths],
       origin,
       submissionId,
@@ -211,32 +211,36 @@ export class StagingLeaseTracker {
   }
 
   /** Release staged media that never got a lease (validation/render failures). */
-  releaseMedia(imageAttachmentIds: readonly number[], paths: readonly string[]): void {
-    const fileIds = this.effects.takeFileIds(imageAttachmentIds);
+  releaseMedia(mediaAttachmentIds: readonly number[], paths: readonly string[]): void {
+    const fileIds = this.effects.takeFileIds(mediaAttachmentIds);
     this.deleteStaged(fileIds, paths);
   }
 
   releaseQueued(items: readonly QueuedMessage[]): void {
     const fileIds = items.flatMap((item) =>
-      this.effects.takeFileIds(item.imageAttachmentIds ?? []),
+      this.effects.takeFileIds([
+        ...(item.imageAttachmentIds ?? []),
+        ...(item.videoAttachmentIds ?? []),
+      ]),
     );
-    const paths = items.flatMap((item) => item.stagingPaths ?? []);
-    this.deleteStaged(fileIds, paths);
+    this.deleteStaged(fileIds, []);
   }
 
   /**
    * Release a queued item (or a cache-hint stash's extraction) recalled into
    * the editor: the restored draft still references its attachments, so this
    * is not a discard — daemon uploads stay staged (only the retain is
-   * consumed; the next submit re-retains them) and cache copies retire to
-   * session lifetime instead of being deleted.
+   * consumed; the next submit re-retains them). `retirePaths` carries the
+   * slash/plugin-args channel's cache copies: the queued rewrite's args
+   * reference them by path, so they retire to session lifetime instead of
+   * being deleted.
    */
-  releaseRecalled(item: {
-    imageAttachmentIds?: readonly number[];
-    stagingPaths?: readonly string[];
-  }): void {
-    this.effects.releaseRetains(item.imageAttachmentIds ?? []);
-    for (const path of item.stagingPaths ?? []) this.retiredPaths.add(path);
+  releaseRecalled(
+    mediaAttachmentIds: readonly number[],
+    retirePaths: readonly string[] = [],
+  ): void {
+    this.effects.releaseRetains(mediaAttachmentIds);
+    for (const path of retirePaths) this.retiredPaths.add(path);
   }
 
   /**
@@ -298,6 +302,6 @@ export class StagingLeaseTracker {
     // Multiplicity in the lease's id list is the retain count (creation sites
     // dedupe per extraction before contributing ids): consume one retain per
     // occurrence.
-    return lease.imageAttachmentIds.flatMap((id) => this.effects.takeFileIds([id]));
+    return lease.mediaAttachmentIds.flatMap((id) => this.effects.takeFileIds([id]));
   }
 }

--- a/apps/kimi-code/src/tui/kimi-tui.ts
+++ b/apps/kimi-code/src/tui/kimi-tui.ts
@@ -115,7 +115,7 @@ import {
   SESSION_LIST_PAGE_SIZE,
   SESSIONLESS_STARTUP_NOTICE,
 } from './constant/kimi-tui';
-import { IMAGE_INGESTION_SUBMIT_WAIT_MS } from './constant/media';
+import { MEDIA_INGESTION_SUBMIT_WAIT_MS } from './constant/media';
 import { CHROME_GUTTER } from './constant/rendering';
 import { MAX_TERMINAL_TITLE_LENGTH } from './constant/terminal';
 import { AuthFlowController } from './controllers/auth-flow';
@@ -160,11 +160,10 @@ import { ImageAttachmentStore, type ImageAttachment } from './utils/image-attach
 import {
   extractMediaAttachments,
   originalsDirForSession,
-  pendingImageIngestions,
+  pendingMediaIngestions,
   refreshExpiringImageFileRefs,
   resolveOriginalCaptions,
   rewriteMediaPlaceholders,
-  videoAttachmentIdsInText,
 } from './utils/image-placeholder';
 import type { ExtractionResult } from './utils/image-placeholder';
 import { installInputLatencyProbe } from './utils/input-latency';
@@ -290,12 +289,12 @@ function createInitialAppState(input: KimiTUIStartupInput): AppState {
 interface SendMessageOptions {
   readonly parts?: readonly PromptPart[];
   readonly imageAttachmentIds?: readonly number[];
-  readonly stagingPaths?: readonly string[];
+  readonly videoAttachmentIds?: readonly number[];
   readonly hasMedia?: boolean;
   /**
    * Lease pre-created at extraction time by `sendNormalUserInput`. Dispatch
    * reuses it (carrying its exact-binding submission id); enqueueing defers
-   * it — the queue item owns the raw ids/paths and re-leases at dequeue.
+   * it — the queue item owns the raw ids and re-leases at dequeue.
    */
   readonly lease?: StagingLease;
 }
@@ -1330,23 +1329,20 @@ export class KimiTUI {
     }
     let extraction: ReturnType<typeof extractMediaAttachments>;
     if (preExtracted === undefined) {
-      // A just-pasted image may still be finishing its background ingestion
-      // (compression/daemon upload): give it a bounded moment so the submit
-      // can use the compressed/daemon-ref form — a slower ingestion extracts
-      // to the inline fallback instead. Undefined when nothing is pending,
+      // A just-pasted image/video may still be finishing its background
+      // ingestion (compression/daemon upload): give it a bounded moment so
+      // the submit can use the daemon-ref form — a slower image ingestion
+      // extracts to the inline fallback instead, a slower video upload
+      // refuses the submission below. Undefined when nothing is pending,
       // keeping the media-free send path synchronous.
-      const ingestionWait = pendingImageIngestions(
+      const ingestionWait = pendingMediaIngestions(
         text,
         this.imageStore,
-        IMAGE_INGESTION_SUBMIT_WAIT_MS,
+        MEDIA_INGESTION_SUBMIT_WAIT_MS,
       );
       if (ingestionWait !== undefined) await ingestionWait;
     }
     try {
-      // Pasted videos are copied into the cache and expand to a `file://`
-      // `video_url` part; the engine resolves (uploads or degrades) them
-      // inside the turn, so submission stays fully synchronous.
-      //
       // A cache-hint-swallowed resend passes its pre-dialog extraction back
       // in: the image store may already be cleared (e.g. after "Start a new
       // session"), so re-extracting from the text would lose the media.
@@ -1360,13 +1356,13 @@ export class KimiTUI {
         if (parts !== extraction.parts) extraction = { ...extraction, parts };
       }
     } catch (error) {
-      // A video cache copy failed (unwritable cache dir, vanished source…);
-      // nothing was dispatched.
+      // A pasted video's daemon upload was unusable (still in flight,
+      // failed, expired); nothing was dispatched.
       this.showError(`Failed to prepare media attachment: ${formatErrorMessage(error)}`);
       return;
     }
     // Create the staging lease right after extraction, so every exit below
-    // releases through the tracker instead of open-coding ids/paths — a
+    // releases through the tracker instead of open-coding ids — a
     // forgotten exit degrades to an unclaimed lease (swept by `releaseAll`)
     // instead of a permanently retained upload. The lease carries the
     // exact-binding submission id: the consuming turn's `turn.started` echoes
@@ -1375,8 +1371,8 @@ export class KimiTUI {
     const stagingLease = this.staging.create(
       // One retain per unique id per extraction: dedupe repeated placeholder
       // occurrences so the lease's id multiplicity matches the retain count.
-      [...new Set(extraction.imageAttachmentIds)],
-      extraction.stagingPaths,
+      [...new Set([...extraction.imageAttachmentIds, ...extraction.videoAttachmentIds])],
+      [],
       'user',
       extraction.hasMedia && this.state.appState.goal?.status !== 'active'
         ? randomUUID()
@@ -1414,7 +1410,7 @@ export class KimiTUI {
         hasMedia: true,
         parts: extraction.parts,
         imageAttachmentIds: extraction.imageAttachmentIds,
-        stagingPaths: extraction.stagingPaths,
+        videoAttachmentIds: extraction.videoAttachmentIds,
         lease: stagingLease,
       });
     } else {
@@ -1463,7 +1459,7 @@ export class KimiTUI {
               hasMedia: true,
               parts: extraction.parts,
               imageAttachmentIds: extraction.imageAttachmentIds,
-              stagingPaths: extraction.stagingPaths,
+              videoAttachmentIds: extraction.videoAttachmentIds,
               inlineSkillActivations: activations,
             }
           : { inlineSkillActivations: activations },
@@ -1587,38 +1583,27 @@ export class KimiTUI {
     const last = this.state.queuedMessages.at(-1)!;
     this.state.queuedMessages = this.state.queuedMessages.slice(0, -1);
     // A recall restores the draft into the editor — it is not a discard:
-    // consumes the retains only, keeping staged files alive (see
-    // `releaseRecalled`), and rebases recalled videos onto their staged cache
-    // copies so a vanished original source cannot lose the media.
-    this.staging.releaseRecalled(last);
-    this.rebaseRecalledVideoSources(last.text, last.stagingPaths);
+    // consumes the retains only, keeping the staged daemon uploads alive
+    // (see `releaseRecalled`) so the restored draft resubmits them.
+    this.staging.releaseRecalled([
+      ...(last.imageAttachmentIds ?? []),
+      ...(last.videoAttachmentIds ?? []),
+    ]);
     return last;
   }
 
   /**
    * Cache-hint restore: a dismissed/hand-back interception returns its draft
    * to the editor — same semantics as a queue recall (consume the stash
-   * extraction's retains, retire its staged copies, rebase videos onto them).
+   * extraction's retains; the staged daemon uploads stay alive for the
+   * restored draft).
    */
-  recallStashedMedia(text: string, extraction: ExtractionResult | undefined): void {
+  recallStashedMedia(extraction: ExtractionResult | undefined): void {
     if (extraction === undefined) return;
-    this.staging.releaseRecalled({
-      imageAttachmentIds: extraction.imageAttachmentIds,
-      stagingPaths: extraction.stagingPaths,
-    });
-    this.rebaseRecalledVideoSources(text, extraction.stagingPaths);
-  }
-
-  private rebaseRecalledVideoSources(
-    text: string,
-    stagingPaths: readonly string[] | undefined,
-  ): void {
-    if (stagingPaths === undefined || stagingPaths.length === 0) return;
-    const videoIds = videoAttachmentIdsInText(text, this.imageStore);
-    stagingPaths.forEach((path, index) => {
-      const id = videoIds[index];
-      if (id !== undefined) this.imageStore.rebaseVideoSource(id, path);
-    });
+    this.staging.releaseRecalled([
+      ...extraction.imageAttachmentIds,
+      ...extraction.videoAttachmentIds,
+    ]);
   }
 
   // =========================================================================
@@ -1640,9 +1625,9 @@ export class KimiTUI {
         options?.imageAttachmentIds !== undefined && options.imageAttachmentIds.length > 0
           ? options.imageAttachmentIds
           : undefined,
-      stagingPaths:
-        options?.stagingPaths !== undefined && options.stagingPaths.length > 0
-          ? options.stagingPaths
+      videoAttachmentIds:
+        options?.videoAttachmentIds !== undefined && options.videoAttachmentIds.length > 0
+          ? options.videoAttachmentIds
           : undefined,
       mode,
       inlineSkillActivations: options?.inlineSkillActivations,
@@ -1709,9 +1694,8 @@ export class KimiTUI {
           parts: refreshed,
           hasMedia: refreshed.length > 0,
           imageAttachmentIds: item.imageAttachmentIds !== undefined ? [...item.imageAttachmentIds] : [],
-          videoAttachmentIds: [],
+          videoAttachmentIds: item.videoAttachmentIds !== undefined ? [...item.videoAttachmentIds] : [],
           imageSnapshots: [],
-          stagingPaths: item.stagingPaths !== undefined ? [...item.stagingPaths] : [],
         },
       ).catch((error: unknown) => {
         this.failSessionRequest(`Skill activation failed: ${formatErrorMessage(error)}`);
@@ -1730,7 +1714,7 @@ export class KimiTUI {
       this.sendMessageInternal(session, item.text, {
         parts,
         imageAttachmentIds: item.imageAttachmentIds,
-        stagingPaths: item.stagingPaths,
+        videoAttachmentIds: item.videoAttachmentIds,
       });
     });
   }
@@ -1743,8 +1727,8 @@ export class KimiTUI {
     this.staging.handleTurnEnded(event);
   }
 
-  releaseStagingMedia(imageAttachmentIds: readonly number[], paths: readonly string[]): void {
-    this.staging.releaseMedia(imageAttachmentIds, paths);
+  releaseStagingMedia(mediaAttachmentIds: readonly number[]): void {
+    this.staging.releaseMedia(mediaAttachmentIds, []);
   }
 
   requestQueuedGoalPromotion(): void {
@@ -1791,22 +1775,24 @@ export class KimiTUI {
     const goalActive = this.state.appState.goal?.status === 'active';
     // The lease normally arrives pre-created by sendNormalUserInput (carrying
     // its exact-binding submission id). Queued dispatches and steer batches
-    // arrive with raw ids/paths instead: a prompt submission carrying staged
+    // arrive with raw ids instead: a prompt submission carrying staged
     // media gets a client-chosen prompt id minted here — the engine echoes it
     // on the consuming turn's `turn.started` (`promptId`), so the lease binds
     // exactly instead of through the origin heuristic. The goal-steer path
     // binds its lease explicitly below, so it gets no id.
+    const stagingIds = [
+      ...(options?.imageAttachmentIds ?? []),
+      ...(options?.videoAttachmentIds ?? []),
+    ];
     const stagingLease =
       options?.lease ??
       this.staging.create(
         // One retain per unique id per extraction: dedupe repeated placeholder
         // occurrences so the lease's id multiplicity matches the retain count.
-        imageAttachmentIds === undefined ? [] : [...new Set(imageAttachmentIds)],
-        options?.stagingPaths ?? [],
+        [...new Set(stagingIds)],
+        [],
         'user',
-        !goalActive && (imageAttachmentIds !== undefined || (options?.stagingPaths?.length ?? 0) > 0)
-          ? randomUUID()
-          : undefined,
+        !goalActive && stagingIds.length > 0 ? randomUUID() : undefined,
       );
     const submissionId = stagingLease?.submissionId;
     // While a goal is being pursued the engine holds its active turn across the
@@ -1870,10 +1856,7 @@ export class KimiTUI {
         skillName,
         skillArgs: rewrite.text,
       });
-      this.staging.releaseRecalled({
-        imageAttachmentIds: rewrite.imageAttachmentIds,
-        stagingPaths: rewrite.stagingPaths,
-      });
+      this.staging.releaseRecalled([...rewrite.imageAttachmentIds], rewrite.stagingPaths);
       this.track('input_queue');
       this.updateQueueDisplay();
       this.state.ui.requestRender();
@@ -1938,7 +1921,7 @@ export class KimiTUI {
       this.state.appState.isCompacting
     ) {
       // A queued message re-leases its staged media at dequeue dispatch; the
-      // pre-dispatch lease defers to the queue item's raw ids/paths.
+      // pre-dispatch lease defers to the queue item's raw ids.
       this.staging.defer(options?.lease);
       this.enqueueMessage(input, options);
       return;
@@ -1975,12 +1958,11 @@ export class KimiTUI {
     }
 
     // Dedupe per item, not across the batch: each queued message retained a
-    // shared image once, so the batch's id multiplicity is the retain count.
-    const imageAttachmentIds = input.flatMap((item) => [
-      ...new Set(item.imageAttachmentIds ?? []),
+    // shared medium once, so the batch's id multiplicity is the retain count.
+    const mediaAttachmentIds = input.flatMap((item) => [
+      ...new Set([...(item.imageAttachmentIds ?? []), ...(item.videoAttachmentIds ?? [])]),
     ]);
-    const stagingPaths = input.flatMap((item) => item.stagingPaths ?? []);
-    const stagingLease = this.staging.create(imageAttachmentIds, stagingPaths, 'user');
+    const stagingLease = this.staging.create(mediaAttachmentIds, [], 'user');
     const currentTurnId = this.streamingUI.getTurnContext().turnId;
     if (currentTurnId !== undefined) this.staging.bindToTurn(stagingLease, currentTurnId);
     // Same dispatch-time caption resolution as sendMessageInternal — the

--- a/apps/kimi-code/src/tui/types.ts
+++ b/apps/kimi-code/src/tui/types.ts
@@ -270,7 +270,7 @@ export interface QueuedMessage {
   readonly agentId?: string;
   readonly parts?: readonly PromptPart[];
   readonly imageAttachmentIds?: readonly number[];
-  readonly stagingPaths?: readonly string[];
+  readonly videoAttachmentIds?: readonly number[];
   /** `bash` for a `!` shell command queued while another command is running;
    *  `skill` for a slash-skill activation queued while the session is busy;
    *  undefined (=`prompt`) for a normal message. */
@@ -294,7 +294,7 @@ export interface SteerInputItem {
   readonly text: string;
   readonly parts?: readonly PromptPart[];
   readonly imageAttachmentIds?: readonly number[];
-  readonly stagingPaths?: readonly string[];
+  readonly videoAttachmentIds?: readonly number[];
 }
 
 export const INITIAL_LIVE_PANE: LivePaneState = {

--- a/apps/kimi-code/src/tui/utils/image-attachment-store.ts
+++ b/apps/kimi-code/src/tui/utils/image-attachment-store.ts
@@ -8,8 +8,9 @@
  * walks the text and expands image placeholders to image content parts
  * (dispatch-time caption resolution then precedes them with a compression
  * caption when paste-time compression shrank the bytes — see
- * `ImageAttachment.original`) and video placeholders to file-path tags
- * for `ReadMediaFile`.
+ * `ImageAttachment.original`) and video placeholders to `kimi-file://`
+ * daemon references (the paste was uploaded to the daemon file store in
+ * the background, exactly like an uploaded image).
  *
  * Scope is per-`KimiTUI` instance. Reloads (`/new`, `/clear`,
  * session switch) call `clear()` so ids restart from 1 and stale
@@ -82,6 +83,21 @@ export interface VideoAttachment {
   readonly filename: string;
   readonly sourcePath: string;
   readonly label: string;
+  /**
+   * Daemon file-store id, set when the source file was uploaded at paste
+   * time. Submit-time expansion emits a `kimi-file://` video reference;
+   * absent means the upload failed or is still in flight (`pending`), and
+   * expansion refuses the submission — a video has no inline fallback.
+   */
+  fileId?: string;
+  /** Epoch milliseconds when the daemon staging upload expires. */
+  fileExpiresAt?: number;
+  /**
+   * Background upload still in flight (see `ImageAttachment.pending` — the
+   * same bounded submit wait applies, `pendingMediaIngestions`). Cleared
+   * when the upload completes.
+   */
+  pending?: Promise<void>;
   /** Rendered placeholder string, e.g. `[video #1 sample.mov]`. */
   readonly placeholder: string;
 }
@@ -90,10 +106,6 @@ export type MediaAttachment = ImageAttachment | VideoAttachment;
 
 type MutableImageAttachment = {
   -readonly [Property in keyof ImageAttachment]: ImageAttachment[Property];
-};
-
-type MutableVideoAttachment = {
-  -readonly [Property in keyof VideoAttachment]: VideoAttachment[Property];
 };
 
 export class ImageAttachmentStore {
@@ -181,6 +193,26 @@ export class ImageAttachmentStore {
   }
 
   /**
+   * Complete a video whose background daemon upload finished. Returns
+   * undefined when the attachment was cleared while the upload was in
+   * flight — the caller then deletes the orphaned upload.
+   */
+  completeVideo(
+    attachment: VideoAttachment,
+    input: {
+      fileId?: string;
+      fileExpiresAt?: number;
+    },
+  ): VideoAttachment | undefined {
+    const current = this.byId.get(attachment.id);
+    if (current !== attachment || attachment.kind !== 'video') return undefined;
+    attachment.fileId = input.fileId;
+    attachment.fileExpiresAt = input.fileExpiresAt;
+    attachment.pending = undefined;
+    return attachment;
+  }
+
+  /**
    * Record where an attachment's pre-compression original was persisted and
    * release the in-memory buffer — the on-disk copy is the original from
    * then on, and the caption only needs the retained metadata. Dispatch-time
@@ -198,8 +230,15 @@ export class ImageAttachmentStore {
     return this.byId.get(id);
   }
 
+  /**
+   * Drop every attachment and return the staged daemon file ids to delete.
+   * Uploads with an outstanding retain are excluded: a stashed/queued draft
+   * still references them (e.g. a cache-hint resend into the NEXT session),
+   * so they stay alive for that consumer; if none claims them, the daemon's
+   * staging TTL reaps them.
+   */
   clear(): readonly string[] {
-    const fileIds = this.fileIds();
+    const fileIds = this.fileIds((id) => (this.stagingUses.get(id) ?? 0) === 0);
     this.byId.clear();
     this.stagingUses.clear();
     this.nextId = 1;
@@ -212,7 +251,7 @@ export class ImageAttachmentStore {
    */
   remove(id: number): string | undefined {
     const attachment = this.byId.get(id);
-    const fileId = attachment?.kind === 'image' ? attachment.fileId : undefined;
+    const fileId = attachment?.fileId;
     this.byId.delete(id);
     this.stagingUses.delete(id);
     return fileId;
@@ -234,7 +273,7 @@ export class ImageAttachmentStore {
       if (retained.has(id)) continue;
       retained.add(id);
       const attachment = this.byId.get(id);
-      if (attachment?.kind !== 'image' || attachment.fileId === undefined) continue;
+      if (attachment?.fileId === undefined) continue;
       this.stagingUses.set(id, (this.stagingUses.get(id) ?? 0) + 1);
     }
   }
@@ -246,7 +285,7 @@ export class ImageAttachmentStore {
       if (taken.has(id)) continue;
       taken.add(id);
       const attachment = this.byId.get(id);
-      if (attachment?.kind !== 'image' || attachment.fileId === undefined) continue;
+      if (attachment?.fileId === undefined) continue;
       const uses = this.stagingUses.get(id) ?? 0;
       if (uses > 1) {
         this.stagingUses.set(id, uses - 1);
@@ -277,21 +316,12 @@ export class ImageAttachmentStore {
     }
   }
 
-  /**
-   * Repoint a recalled video at its staged cache copy: the original source
-   * (e.g. a clipboard temp file) may be gone by the time the restored draft
-   * is resubmitted, and re-extraction re-materializes from `sourcePath`.
-   */
-  rebaseVideoSource(id: number, sourcePath: string): void {
-    const attachment = this.byId.get(id);
-    if (attachment?.kind !== 'video') return;
-    (attachment as MutableVideoAttachment).sourcePath = sourcePath;
-  }
-
-  private fileIds(): readonly string[] {
-    return [...this.byId.values()]
-      .filter((attachment): attachment is ImageAttachment => attachment.kind === 'image')
-      .flatMap((attachment) => attachment.fileId ?? []);
+  private fileIds(include?: (id: number) => boolean): readonly string[] {
+    return [...this.byId.values()].flatMap((attachment) =>
+      attachment.fileId !== undefined && (include?.(attachment.id) ?? true)
+        ? [attachment.fileId]
+        : [],
+    );
   }
 
   size(): number {

--- a/apps/kimi-code/src/tui/utils/image-placeholder.ts
+++ b/apps/kimi-code/src/tui/utils/image-placeholder.ts
@@ -15,12 +15,14 @@
  *     so `resolveOriginalCaptions` adds them at dispatch time, persisting the
  *     in-memory original (`ImageAttachment.original`) into the session's
  *     media-originals dir first;
- *   - video placeholders are copied into the shared cache (`getCacheDir()`)
- *     and expand to a `video_url` part pointing at the cache copy with a
- *     `file://` url. The v1 engine resolves that local reference inside the
- *     turn — uploading it (the `ms://` inline form) or degrading to a
- *     `<video path>` tag the model reads with `ReadMediaFile` — before the
- *     prompt lands in history.
+ *   - video placeholders expand to a bare `kimi-file://<id>` video part:
+ *     the paste was uploaded to the daemon file store in the background
+ *     (`VideoAttachment.fileId`), and the engine's prompt intake
+ *     materializes the session copy and rewrites the reference with its
+ *     `?path=`, exactly like an uploaded image. A video without a usable
+ *     upload — still in flight after the bounded submit wait, failed, or
+ *     expired — aborts extraction with an error: video bytes have no
+ *     inline fallback form.
  *
  * `rewriteMediaPlaceholders` is the separate text channel for slash-command
  * args (`/skill`, plugin commands): those are plain text, so media is rendered
@@ -41,7 +43,6 @@ import { createHash, randomUUID } from 'node:crypto';
 import { copyFileSync, mkdirSync, readdirSync, statSync, unlinkSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { pathToFileURL } from 'node:url';
 
 import type { PromptPart, Session } from '@moonshot-ai/kimi-code-sdk';
 import {
@@ -53,7 +54,7 @@ import {
 
 import { getCacheDir } from '#/utils/paths';
 
-import { IMAGE_FILE_REF_MIN_REMAINING_MS } from '../constant/media';
+import { MEDIA_FILE_REF_MIN_REMAINING_MS } from '../constant/media';
 import type {
   ImageAttachment,
   ImageAttachmentStore,
@@ -80,13 +81,6 @@ export interface ExtractionResult {
    * snapshots to rebuild the image parts as inline data URLs.
    */
   imageSnapshots: ImageResendSnapshot[];
-  /**
-   * Cache copies staged by this submission. Lifecycle is owned by the
-   * StagingLeaseTracker: deleted immediately when the submission is
-   * abandoned, retired to session lifetime once a turn consumes them
-   * (persisted history may still reference their paths).
-   */
-  stagingPaths: string[];
 }
 
 export interface ImageResendSnapshot {
@@ -116,118 +110,96 @@ export function extractMediaAttachments(
   const imageAttachmentIds: number[] = [];
   const videoAttachmentIds: number[] = [];
   const imageSnapshots: ImageResendSnapshot[] = [];
-  const stagingPaths: string[] = [];
   let cursor = 0;
   let hasMedia = false;
 
-  try {
-    PLACEHOLDER_REGEX.lastIndex = 0;
-    let match: RegExpExecArray | null;
-    while ((match = PLACEHOLDER_REGEX.exec(text)) !== null) {
-      const [literal, kind, idStr] = match;
-      if (kind !== 'image' && kind !== 'video') continue;
-      if (idStr === undefined) continue;
-      const id = Number.parseInt(idStr, 10);
-      const attachment = store.get(id);
-      if (attachment === undefined) continue; // stale / user-typed — leave as text
-      if (attachment.kind !== kind) continue;
-      const before = text.slice(cursor, match.index);
-      pushText(parts, before);
-      if (attachment.kind === 'video') {
-        // Copy the paste into the shared cache and reference it by a `file://`
-        // url; the engine resolves (uploads or degrades) it inside the turn.
-        const cachePath = materializeVideoToCache(attachment);
-        stagingPaths.push(cachePath);
-        parts.push(videoPartForCachePath(cachePath));
-        videoAttachmentIds.push(id);
-      } else {
-        const original = attachment.original;
-        imageSnapshots.push({
-          bytes: attachment.bytes,
-          mime: attachment.mime,
-          width: attachment.width,
-          height: attachment.height,
-          original:
-            original?.bytes === undefined
-              ? undefined
-              : {
-                  bytes: original.bytes,
-                  width: original.width,
-                  height: original.height,
-                  mime: original.mime,
-                },
-        });
-        // No compression caption here: `resolveOriginalCaptions` authors it
-        // at dispatch time, once the session (and its media-originals dir)
-        // is known.
-        if (attachment.fileId !== undefined) {
-          // The bytes were uploaded to the daemon file store at paste time
-          // (v2): reference them by a bare `kimi-file://` url — the engine's
-          // prompt intake materializes the session copy and rewrites the
-          // reference with its `?path=`, so the edge stages no local copy.
-          parts.push({
-            type: 'image_url',
-            imageUrl: { url: buildDaemonFileUrl(attachment.fileId) },
-          });
-        } else {
-          parts.push(imagePartForAttachment(attachment));
-        }
-        imageAttachmentIds.push(id);
-      }
-      hasMedia = true;
-      cursor = match.index + literal.length;
-    }
-    const tail = text.slice(cursor);
-    pushText(parts, tail);
-
-    store.retainFileIds(imageAttachmentIds);
-    const freshParts = refreshExpiringImageFileRefs(parts, imageAttachmentIds, store);
-    return {
-      // Text-only submissions drop the synthesised parts array — the
-      // caller's contract is "parts is meaningful iff hasMedia", and
-      // emitting a stray TextPart confuses consumers that branch on
-      // `parts.length > 0`.
-      parts: hasMedia ? freshParts : [],
-      hasMedia,
-      imageAttachmentIds,
-      videoAttachmentIds,
-      imageSnapshots,
-      stagingPaths,
-    };
-  } catch (error) {
-    cleanupStagingPaths(stagingPaths);
-    throw error;
-  }
-}
-
-/**
- * The video attachment ids referenced by `text`, in placeholder order — the
- * same order extraction staged their cache copies in, so callers can zip the
- * result with a submission's `stagingPaths`.
- */
-export function videoAttachmentIdsInText(text: string, store: ImageAttachmentStore): number[] {
-  const ids: number[] = [];
   PLACEHOLDER_REGEX.lastIndex = 0;
   let match: RegExpExecArray | null;
   while ((match = PLACEHOLDER_REGEX.exec(text)) !== null) {
-    const [, kind, idStr] = match;
-    if (kind !== 'video' || idStr === undefined) continue;
+    const [literal, kind, idStr] = match;
+    if (kind !== 'image' && kind !== 'video') continue;
+    if (idStr === undefined) continue;
     const id = Number.parseInt(idStr, 10);
-    if (store.get(id)?.kind === 'video') ids.push(id);
+    const attachment = store.get(id);
+    if (attachment === undefined) continue; // stale / user-typed — leave as text
+    if (attachment.kind !== kind) continue;
+    const before = text.slice(cursor, match.index);
+    pushText(parts, before);
+    if (attachment.kind === 'video') {
+      // The paste was uploaded to the daemon file store in the background:
+      // reference it by a bare `kimi-file://` url — the engine's prompt
+      // intake materializes the session copy, so the edge stages no local
+      // copy. Throws when the upload is unusable (still in flight, failed,
+      // expired): a video has no inline fallback.
+      parts.push(videoPartForAttachment(attachment));
+      videoAttachmentIds.push(id);
+    } else {
+      const original = attachment.original;
+      imageSnapshots.push({
+        bytes: attachment.bytes,
+        mime: attachment.mime,
+        width: attachment.width,
+        height: attachment.height,
+        original:
+          original?.bytes === undefined
+            ? undefined
+            : {
+                bytes: original.bytes,
+                width: original.width,
+                height: original.height,
+                mime: original.mime,
+              },
+      });
+      // No compression caption here: `resolveOriginalCaptions` authors it
+      // at dispatch time, once the session (and its media-originals dir)
+      // is known.
+      if (attachment.fileId !== undefined) {
+        // The bytes were uploaded to the daemon file store at paste time
+        // (v2): reference them by a bare `kimi-file://` url — the engine's
+        // prompt intake materializes the session copy and rewrites the
+        // reference with its `?path=`, so the edge stages no local copy.
+        parts.push({
+          type: 'image_url',
+          imageUrl: { url: buildDaemonFileUrl(attachment.fileId) },
+        });
+      } else {
+        parts.push(imagePartForAttachment(attachment));
+      }
+      imageAttachmentIds.push(id);
+    }
+    hasMedia = true;
+    cursor = match.index + literal.length;
   }
-  return ids;
+  const tail = text.slice(cursor);
+  pushText(parts, tail);
+
+  store.retainFileIds([...imageAttachmentIds, ...videoAttachmentIds]);
+  const freshParts = refreshExpiringImageFileRefs(parts, imageAttachmentIds, store);
+  return {
+    // Text-only submissions drop the synthesised parts array — the
+    // caller's contract is "parts is meaningful iff hasMedia", and
+    // emitting a stray TextPart confuses consumers that branch on
+    // `parts.length > 0`.
+    parts: hasMedia ? freshParts : [],
+    hasMedia,
+    imageAttachmentIds,
+    videoAttachmentIds,
+    imageSnapshots,
+  };
 }
 
 /**
- * Give images referenced by `text` a bounded moment to finish their
- * background paste ingestion (compression/upload — see `ImageAttachment.pending`)
- * before extraction, so a paste-then-immediately-submit still expands to the
- * compressed/daemon-ref form. The returned promise resolves after `timeoutMs`
- * at the latest; whatever has not landed by then simply extracts to the
- * inline fallback form. Returns undefined when nothing is pending, so the
- * submit path stays synchronous for media-free prompts.
+ * Give media referenced by `text` a bounded moment to finish its background
+ * paste ingestion (image compression/upload, video daemon upload — see
+ * `ImageAttachment.pending` / `VideoAttachment.pending`) before extraction,
+ * so a paste-then-immediately-submit still expands to the daemon-ref form.
+ * The returned promise resolves after `timeoutMs` at the latest; an image
+ * whose ingestion has not landed by then extracts to the inline fallback
+ * form, a video refuses the submission (no inline form exists). Returns
+ * undefined when nothing is pending, so the submit path stays synchronous
+ * for media-free prompts.
  */
-export function pendingImageIngestions(
+export function pendingMediaIngestions(
   text: string,
   store: ImageAttachmentStore,
   timeoutMs: number,
@@ -237,9 +209,10 @@ export function pendingImageIngestions(
   let match: RegExpExecArray | null;
   while ((match = PLACEHOLDER_REGEX.exec(text)) !== null) {
     const [, kind, idStr] = match;
-    if (kind !== 'image' || idStr === undefined) continue;
+    if (kind !== 'image' && kind !== 'video') continue;
+    if (idStr === undefined) continue;
     const attachment = store.get(Number.parseInt(idStr, 10));
-    if (attachment?.kind === 'image' && attachment.pending !== undefined) {
+    if (attachment?.kind === kind && attachment.pending !== undefined) {
       pendings.push(attachment.pending);
     }
   }
@@ -280,7 +253,7 @@ export function refreshExpiringImageFileRefs(
     const expiresAt = attachment.fileExpiresAt;
     const usable =
       fileId !== undefined &&
-      (expiresAt === undefined || expiresAt - now > IMAGE_FILE_REF_MIN_REMAINING_MS);
+      (expiresAt === undefined || expiresAt - now > MEDIA_FILE_REF_MIN_REMAINING_MS);
     if (usable) {
       const url = buildDaemonFileUrl(fileId);
       if (url === part.imageUrl.url) return part;
@@ -298,10 +271,12 @@ export function refreshExpiringImageFileRefs(
 
 /**
  * Make an extraction safe to resend after a session reset. The reset clears
- * the image store and deletes daemon file ids, so uploaded image refs must be
- * replaced with the bytes captured during the original extraction. Cache
- * paths are intentionally preserved: they are carried by the resend's new
- * staging lease and remain available to any path tag in the prompt.
+ * the image store and deletes unretained daemon file ids, so uploaded image
+ * refs must be replaced with the bytes captured during the original
+ * extraction. Video refs pass through unchanged: their uploads were retained
+ * by the stash, and `ImageAttachmentStore.clear` keeps retained uploads
+ * alive for exactly this resend (unclaimed survivors fall to the daemon's
+ * staging TTL).
  *
  * Snapshots of compressed pastes also carry the pre-compression original: the
  * cleared store took the attachment with it, so dispatch-time caption
@@ -507,17 +482,39 @@ function imagePartMatchesAttachment(
 }
 
 /**
- * A `video_url` prompt part pointing at a cache copy by `file://` url. The v1
- * engine resolves the local reference in-turn (upload → `ms://`, or degrade to
- * a `<video path>` tag) before it reaches the model or the persisted history.
+ * A `video_url` prompt part referencing the paste's daemon upload by a bare
+ * `kimi-file://` url — the engine's prompt intake materializes the session
+ * copy before the part reaches the model or the persisted history. Throws
+ * when the upload is unusable: video bytes have no inline fallback, so the
+ * submission is refused with an actionable message instead.
  */
-function videoPartForCachePath(cachePath: string): PromptPart {
-  return {
-    type: 'video_url',
-    videoUrl: { url: pathToFileURL(cachePath).href },
-  };
+function videoPartForAttachment(att: VideoAttachment): PromptPart {
+  const fileId = att.fileId;
+  const expired =
+    att.fileExpiresAt !== undefined &&
+    att.fileExpiresAt - Date.now() <= MEDIA_FILE_REF_MIN_REMAINING_MS;
+  if (fileId !== undefined && !expired) {
+    return {
+      type: 'video_url',
+      videoUrl: { url: buildDaemonFileUrl(fileId) },
+    };
+  }
+  if (att.pending !== undefined) {
+    throw new Error(`Video "${att.label}" is still uploading; try again in a moment.`);
+  }
+  throw new Error(
+    expired
+      ? `Video "${att.label}" expired before it was sent; paste it again.`
+      : `Video "${att.label}" could not be uploaded; paste it again.`,
+  );
 }
 
+/**
+ * Copy a pasted video into the shared cache for the slash-command args
+ * channel (`rewriteMediaPlaceholders`): command args are plain text, so the
+ * model reaches the video through `ReadMediaFile` on the cache copy — the
+ * prompt-part channel never stages one (see `videoPartForAttachment`).
+ */
 function materializeVideoToCache(att: VideoAttachment, escapeProofName = false): string {
   const cacheDir = getCacheDir();
   mkdirSync(cacheDir, { recursive: true });

--- a/apps/kimi-code/test/tui/controllers/cache-hint-controller.test.ts
+++ b/apps/kimi-code/test/tui/controllers/cache-hint-controller.test.ts
@@ -97,7 +97,6 @@ function uploadedExtraction(fileId: string, byte: number): ExtractionResult {
     imageAttachmentIds: [1],
     videoAttachmentIds: [],
     imageSnapshots: [{ bytes: new Uint8Array([byte]), mime: 'image/png', width: 640, height: 480 }],
-    stagingPaths: [path],
   };
 }
 
@@ -269,11 +268,11 @@ describe('CacheHintController scenario 2 (idle submit)', () => {
     await flush();
 
     // Nothing was sent; the draft is back in the editor and the stash's
-    // retains/staged copies go through recall — without this the retain count
-    // never returns to zero and the upload can never be lease-deleted.
+    // retains go through recall — without this the retain count never
+    // returns to zero and the upload can never be lease-deleted.
     expect(host.sendNormalUserInput).not.toHaveBeenCalled();
     expect(host.restoreInputText).toHaveBeenCalledWith('describe [image #1 (1×1)]');
-    expect(host.recallStashedMedia).toHaveBeenCalledWith('describe [image #1 (1×1)]', extraction);
+    expect(host.recallStashedMedia).toHaveBeenCalledWith(extraction);
   });
 
   it('hands the stashed input back when the session switched during the fetch', async () => {

--- a/apps/kimi-code/test/tui/controllers/editor-keyboard-image-paste.test.ts
+++ b/apps/kimi-code/test/tui/controllers/editor-keyboard-image-paste.test.ts
@@ -17,7 +17,7 @@
  */
 
 import { existsSync } from 'node:fs';
-import { mkdtemp, rm } from 'node:fs/promises';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
@@ -107,8 +107,7 @@ function createPasteHarness(
     async pasteImage() {
       await pasteImageRaw();
       for (let id = 1; id <= store.size(); id++) {
-        const attachment = store.get(id);
-        if (attachment?.kind === 'image') await attachment.pending;
+        await store.get(id)?.pending;
       }
     },
     pasteImageRaw,
@@ -439,5 +438,150 @@ describe('clipboard image paste compression', () => {
 
     expect(att.fileId).toBe('file-late');
     expect(att.pending).toBeUndefined();
+  });
+});
+
+describe('clipboard video paste upload', () => {
+  beforeEach(() => {
+    readClipboardMedia.mockReset();
+  });
+
+  async function withSourceVideo(run: (sourcePath: string) => Promise<void>): Promise<void> {
+    const dir = await mkdtemp(join(tmpdir(), 'paste-video-'));
+    try {
+      const sourcePath = join(dir, 'clip.mp4');
+      await writeFile(sourcePath, 'video-bytes');
+      await run(sourcePath);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  }
+
+  it('uploads the pasted video to the daemon file store (v2)', async () => {
+    await withSourceVideo(async (sourcePath) => {
+      readClipboardMedia.mockResolvedValue({
+        kind: 'video',
+        mimeType: 'video/mp4',
+        filename: 'clip.mp4',
+        sourcePath,
+      });
+      const uploadFile = uploadFileMock('file-v1');
+
+      const { store, pasteImage } = createPasteHarness({ engineV2: true, uploadFile });
+      await pasteImage();
+
+      const att = store.get(1);
+      if (att?.kind !== 'video') throw new Error('expected video attachment');
+      expect(att.placeholder).toBe('[video #1 clip.mp4]');
+      expect(att.fileId).toBe('file-v1');
+      expect(att.fileExpiresAt).toBe(Date.parse('2030-01-02T03:04:05.000Z'));
+      expect(att.pending).toBeUndefined();
+      const [data, opts] = uploadFile.mock.calls[0]!;
+      expect(new Uint8Array(data)).toEqual(new TextEncoder().encode('video-bytes'));
+      expect(opts).toEqual({ name: 'clip.mp4', mimeType: 'video/mp4', expiresInSec: 60 * 60 });
+    });
+  });
+
+  it('settles the paste callback before the background upload completes (v2)', async () => {
+    await withSourceVideo(async (sourcePath) => {
+      readClipboardMedia.mockResolvedValue({
+        kind: 'video',
+        mimeType: 'video/mp4',
+        filename: 'clip.mp4',
+        sourcePath,
+      });
+      let resolveUpload!: (meta: { id: string }) => void;
+      const uploadFile = vi.fn(
+        (
+          _data: Uint8Array,
+          _opts: { name: string; mimeType?: string; expiresInSec?: number },
+        ): Promise<{ id: string }> =>
+          new Promise<{ id: string }>((resolve) => {
+            resolveUpload = resolve;
+          }),
+      );
+
+      const { store, pasteImageRaw } = createPasteHarness({ engineV2: true, uploadFile });
+      // The handler returns once the placeholder is in the editor; the upload
+      // is still unresolved here — typing is never held behind it.
+      await pasteImageRaw();
+
+      const att = store.get(1);
+      if (att?.kind !== 'video') throw new Error('expected video attachment');
+      expect(att.fileId).toBeUndefined();
+      expect(att.pending).toBeDefined();
+
+      // The upload starts once the source file has been read in the
+      // background; only then can it be resolved.
+      await vi.waitFor(() => {
+        expect(uploadFile).toHaveBeenCalled();
+      });
+      resolveUpload({ id: 'file-vlate' });
+      await att.pending;
+
+      expect(att.fileId).toBe('file-vlate');
+      expect(att.pending).toBeUndefined();
+    });
+  });
+
+  it('leaves the video without a fileId when the daemon upload fails (v2)', async () => {
+    await withSourceVideo(async (sourcePath) => {
+      readClipboardMedia.mockResolvedValue({
+        kind: 'video',
+        mimeType: 'video/mp4',
+        filename: 'clip.mp4',
+        sourcePath,
+      });
+      const uploadFile = vi.fn(async (): Promise<{ id: string }> => {
+        throw new Error('daemon down');
+      });
+
+      const { store, pasteImage } = createPasteHarness({ engineV2: true, uploadFile });
+      await pasteImage(); // must not throw
+
+      const att = store.get(1);
+      if (att?.kind !== 'video') throw new Error('expected video attachment');
+      expect(att.fileId).toBeUndefined();
+      expect(att.pending).toBeUndefined();
+    });
+  });
+
+  it('leaves the video without a fileId when the source file vanished (v2)', async () => {
+    readClipboardMedia.mockResolvedValue({
+      kind: 'video',
+      mimeType: 'video/mp4',
+      filename: 'clip.mp4',
+      sourcePath: '/tmp/kimi-paste-vanished-source.mp4',
+    });
+    const uploadFile = uploadFileMock('file-v1');
+
+    const { store, pasteImage } = createPasteHarness({ engineV2: true, uploadFile });
+    await pasteImage();
+
+    expect(uploadFile).not.toHaveBeenCalled();
+    const att = store.get(1);
+    if (att?.kind !== 'video') throw new Error('expected video attachment');
+    expect(att.fileId).toBeUndefined();
+  });
+
+  it('never uploads on the v1 engine', async () => {
+    await withSourceVideo(async (sourcePath) => {
+      readClipboardMedia.mockResolvedValue({
+        kind: 'video',
+        mimeType: 'video/mp4',
+        filename: 'clip.mp4',
+        sourcePath,
+      });
+      const uploadFile = uploadFileMock('file-v1');
+
+      // engineV2 unset — the v1 host shape.
+      const { store, pasteImage } = createPasteHarness({ uploadFile });
+      await pasteImage();
+
+      expect(uploadFile).not.toHaveBeenCalled();
+      const att = store.get(1);
+      if (att?.kind !== 'video') throw new Error('expected video attachment');
+      expect(att.fileId).toBeUndefined();
+    });
   });
 });

--- a/apps/kimi-code/test/tui/controllers/staging-leases.test.ts
+++ b/apps/kimi-code/test/tui/controllers/staging-leases.test.ts
@@ -227,10 +227,8 @@ describe('StagingLeaseTracker', () => {
       [
         'releaseMedia and releaseQueued',
         (tracker: StagingLeaseTracker) => {
-          tracker.releaseMedia([1], ['/cache/a']);
-          tracker.releaseQueued([
-            { text: 'q', agentId: 'main', imageAttachmentIds: [2], stagingPaths: ['/cache/b'] },
-          ]);
+          tracker.releaseMedia([1], ['/cache/a', '/cache/b']);
+          tracker.releaseQueued([{ text: 'q', agentId: 'main', videoAttachmentIds: [2] }]);
         },
       ],
       [
@@ -257,11 +255,8 @@ describe('StagingLeaseTracker', () => {
 
       // A recall restores the draft into the editor — not a discard: the
       // daemon upload stays staged (only the retain is consumed) and the
-      // cache copy retires to session lifetime.
-      tracker.releaseRecalled({
-        imageAttachmentIds: [2],
-        stagingPaths: ['/cache/b'],
-      });
+      // rewrite channel's cache copy retires to session lifetime.
+      tracker.releaseRecalled([2], ['/cache/b']);
 
       expect(releaseRetains).toHaveBeenCalledWith([2]);
       expect(deleted.fileIds).toEqual([]);

--- a/apps/kimi-code/test/tui/input/image-attachment-store.test.ts
+++ b/apps/kimi-code/test/tui/input/image-attachment-store.test.ts
@@ -179,16 +179,50 @@ describe('ImageAttachmentStore', () => {
     expect(att.fileId).toBeUndefined();
   });
 
-  it('rebaseVideoSource repoints a recalled video at its staged cache copy', () => {
+  it('completeVideo lands the daemon upload id and clears the pending marker', () => {
     const s = new ImageAttachmentStore();
     const att = s.addVideo('video/mp4', '/tmp/original.mp4');
+    att.pending = Promise.resolve();
 
-    s.rebaseVideoSource(att.id, '/cache/original.mp4');
-    expect(att.sourcePath).toBe('/cache/original.mp4');
+    const completed = s.completeVideo(att, { fileId: 'file-v1', fileExpiresAt: 123_000 });
 
-    // Images and unknown ids are ignored.
-    const image = s.addImage(new Uint8Array([1]), 'image/png', 10, 10);
-    s.rebaseVideoSource(image.id, '/cache/nope');
-    expect(s.get(image.id)).toBe(image);
+    expect(completed).toBe(att);
+    expect(att.fileId).toBe('file-v1');
+    expect(att.fileExpiresAt).toBe(123_000);
+    expect(att.pending).toBeUndefined();
+
+    // A cleared attachment is not completed — the caller deletes the upload.
+    s.clear();
+    const stale = att;
+    const fresh = s.addVideo('video/mp4', '/tmp/other.mp4');
+    expect(s.completeVideo(stale, { fileId: 'file-v2' })).toBeUndefined();
+    expect(fresh.fileId).toBeUndefined();
+  });
+
+  it('clear() keeps staged uploads that still have an outstanding retain', () => {
+    const s = new ImageAttachmentStore();
+    const img = s.addImage(new Uint8Array(), 'image/png', 10, 10, undefined, 'file-1');
+    const vid = s.addVideo('video/mp4', '/tmp/a.mp4');
+    s.completeVideo(vid, { fileId: 'file-2' });
+
+    // The video's upload is still referenced by a stashed/queued draft; the
+    // image's is not, so only the latter comes back for deletion.
+    s.retainFileIds([vid.id]);
+    expect(s.clear()).toEqual(['file-1']);
+    expect(s.size()).toBe(0);
+    expect(img.fileId).toBe('file-1');
+  });
+
+  it('takes a video upload through the same retain/take lifecycle as an image', () => {
+    const s = new ImageAttachmentStore();
+    const vid = s.addVideo('video/mp4', '/tmp/a.mp4');
+    s.completeVideo(vid, { fileId: 'file-v1' });
+
+    s.retainFileIds([vid.id]);
+    s.retainFileIds([vid.id]);
+    expect(s.takeFileIds([vid.id])).toEqual([]);
+    expect(vid.fileId).toBe('file-v1');
+    expect(s.takeFileIds([vid.id])).toEqual(['file-v1']);
+    expect(vid.fileId).toBeUndefined();
   });
 });

--- a/apps/kimi-code/test/tui/input/image-placeholder.test.ts
+++ b/apps/kimi-code/test/tui/input/image-placeholder.test.ts
@@ -6,7 +6,6 @@
 import { existsSync, mkdtempSync, readFileSync, readdirSync, rmSync, utimesSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { fileURLToPath } from 'node:url';
 
 import { describe, it, expect } from 'vitest';
 
@@ -17,7 +16,7 @@ import { ImageAttachmentStore } from '#/tui/utils/image-attachment-store';
 import {
   extractMediaAttachments,
   makeExtractionResendable,
-  pendingImageIngestions,
+  pendingMediaIngestions,
   persistOriginalImageSync,
   refreshExpiringImageFileRefs,
   resolveOriginalCaptions,
@@ -56,14 +55,14 @@ function makeTempDir(): string {
 type VideoUrlPart = { type: 'video_url'; videoUrl: { url: string } };
 
 // Prompt-attached videos are emitted as a `video_url` part whose url is a
-// local `file://` reference to the cache copy; decode it back to a filesystem
-// path for assertions.
-function videoPathFromParts(parts: unknown[]): string {
+// bare `kimi-file://` daemon reference (the paste was uploaded at paste
+// time); pull the url out for assertions.
+function videoUrlFromParts(parts: unknown[]): string {
   const part = parts.find(
     (p): p is VideoUrlPart => (p as VideoUrlPart).type === 'video_url',
   );
   if (!part) throw new Error(`no video_url part found in: ${JSON.stringify(parts)}`);
-  return fileURLToPath(part.videoUrl.url);
+  return part.videoUrl.url;
 }
 
 describe('extractMediaAttachments', () => {
@@ -105,30 +104,21 @@ describe('extractMediaAttachments', () => {
   });
 
   it('keeps matched-placeholder order with mixed image and video attachments', () => {
-    const { cleanup } = setupTempCache();
-    const srcDir = makeTempDir();
-    try {
-      const srcVideo = join(srcDir, 'clip.mov');
-      writeFileSync(srcVideo, 'video-bytes');
-      const store = new ImageAttachmentStore();
-      const img = store.addImage(new Uint8Array([1]), 'image/png', 10, 10);
-      const vid = store.addVideo('video/quicktime', srcVideo);
-      const text = `first ${img.placeholder} then ${vid.placeholder} end`;
-      const r = extractMediaAttachments(text, store);
-      expect(r.imageAttachmentIds).toEqual([1]);
-      expect(r.videoAttachmentIds).toEqual([2]);
-      expect(r.parts[0]).toEqual({ type: 'text', text: 'first ' });
-      expect(r.parts[1]).toEqual({
-        type: 'image_url',
-        imageUrl: { url: 'data:image/png;base64,AQ==' },
-      });
-      const cachePath = videoPathFromParts(r.parts);
-      expect(cachePath.startsWith(getCacheDir())).toBe(true);
-      expect(readFileSync(cachePath, 'utf8')).toBe('video-bytes');
-    } finally {
-      cleanup();
-      rmSync(srcDir, { recursive: true, force: true });
-    }
+    const store = new ImageAttachmentStore();
+    const img = store.addImage(new Uint8Array([1]), 'image/png', 10, 10);
+    const vid = store.addVideo('video/quicktime', '/tmp/clip.mov');
+    store.completeVideo(vid, { fileId: 'file-v1' });
+    const text = `first ${img.placeholder} then ${vid.placeholder} end`;
+    const r = extractMediaAttachments(text, store);
+    expect(r.imageAttachmentIds).toEqual([1]);
+    expect(r.videoAttachmentIds).toEqual([2]);
+    expect(r.parts).toEqual([
+      { type: 'text', text: 'first ' },
+      { type: 'image_url', imageUrl: { url: 'data:image/png;base64,AQ==' } },
+      { type: 'text', text: ' then ' },
+      { type: 'video_url', videoUrl: { url: 'kimi-file://file-v1' } },
+      { type: 'text', text: ' end' },
+    ]);
   });
 
   it('leaves unresolved (typed by hand) placeholders as literal text', () => {
@@ -149,49 +139,53 @@ describe('extractMediaAttachments', () => {
     });
   });
 
-  it('keeps the video label (including special chars) in the cache path', () => {
+  it('emits a bare kimi-file video_url part for an uploaded video', () => {
     const { cleanup } = setupTempCache();
-    const srcDir = makeTempDir();
     try {
-      const srcVideo = join(srcDir, 'source.mp4');
-      writeFileSync(srcVideo, 'x');
       const store = new ImageAttachmentStore();
-      // The filename drives the cache label; `&` is a valid path char the cache
-      // copy keeps verbatim (the engine escapes it if it later renders a tag).
-      const att = store.addVideo('video/mp4', srcVideo, 'a&b.mp4');
-      const r = extractMediaAttachments(att.placeholder, store);
-      expect(r.parts).toHaveLength(1);
-      expect((r.parts[0] as VideoUrlPart).type).toBe('video_url');
-      expect(videoPathFromParts(r.parts).endsWith('a&b.mp4')).toBe(true);
-    } finally {
-      cleanup();
-      rmSync(srcDir, { recursive: true, force: true });
-    }
-  });
-
-  it('copies video placeholders into the cache and emits a file:// video_url part', () => {
-    const { cleanup } = setupTempCache();
-    const srcDir = makeTempDir();
-    try {
-      const srcVideo = join(srcDir, 'sample.mp4');
-      writeFileSync(srcVideo, 'video-data');
-      const store = new ImageAttachmentStore();
-      const att = store.addVideo('video/mp4', srcVideo);
+      const att = store.addVideo('video/mp4', '/tmp/sample.mp4');
+      store.completeVideo(att, { fileId: 'file-v1' });
       const r = extractMediaAttachments(att.placeholder, store);
       expect(r.hasMedia).toBe(true);
       expect(r.videoAttachmentIds).toEqual([1]);
+      expect(r.parts).toHaveLength(1);
       const part = r.parts[0] as VideoUrlPart;
       expect(part.type).toBe('video_url');
-      expect(part.videoUrl.url.startsWith('file:')).toBe(true);
-      const cachePath = videoPathFromParts(r.parts);
-      // The part points at the cache copy, not the original source path.
-      expect(cachePath.startsWith(getCacheDir())).toBe(true);
-      expect(cachePath).not.toBe(srcVideo);
-      expect(readFileSync(cachePath, 'utf8')).toBe('video-data');
+      // No cache copy and no `?path=`: the engine's prompt intake
+      // materializes the session copy and rewrites the reference — the part
+      // is self-contained.
+      expect(parseDaemonFileUrl(part.videoUrl.url)).toEqual({ fileId: 'file-v1' });
+      expect(existsSync(getCacheDir())).toBe(false);
     } finally {
       cleanup();
-      rmSync(srcDir, { recursive: true, force: true });
     }
+  });
+
+  it('refuses a video whose upload is still in flight', () => {
+    const store = new ImageAttachmentStore();
+    const att = store.addVideo('video/mp4', '/tmp/sample.mp4');
+    att.pending = new Promise<void>(() => undefined); // never settles
+    expect(() => extractMediaAttachments(att.placeholder, store)).toThrow(
+      /still uploading/,
+    );
+  });
+
+  it('refuses a video whose upload failed or is missing', () => {
+    const store = new ImageAttachmentStore();
+    const att = store.addVideo('video/mp4', '/tmp/sample.mp4');
+    expect(() => extractMediaAttachments(att.placeholder, store)).toThrow(
+      /could not be uploaded/,
+    );
+  });
+
+  it('refuses a video whose staged upload is too close to expiry', () => {
+    const store = new ImageAttachmentStore();
+    const att = store.addVideo('video/mp4', '/tmp/sample.mp4');
+    store.completeVideo(att, {
+      fileId: 'file-v1',
+      fileExpiresAt: Date.now() + 1_000,
+    });
+    expect(() => extractMediaAttachments(att.placeholder, store)).toThrow(/expired/);
   });
 
   it('expands a compressed paste without a caption — captions are authored at dispatch', () => {
@@ -240,7 +234,6 @@ describe('extractMediaAttachments', () => {
       expect(parseDaemonFileUrl('kimi-file://file-1')).toEqual({ fileId: 'file-1' });
       // The edge stages no local copy for an uploaded image — the cache dir
       // is never even created.
-      expect(r.stagingPaths).toEqual([]);
       expect(existsSync(getCacheDir())).toBe(false);
     } finally {
       cleanup();
@@ -288,7 +281,6 @@ describe('extractMediaAttachments', () => {
         type: 'image_url',
         imageUrl: { url: 'data:image/png;base64,iVBORw==' },
       });
-      expect(resend.stagingPaths).toHaveLength(0);
     } finally {
       cleanup();
     }
@@ -359,23 +351,23 @@ describe('extractMediaAttachments', () => {
     }
   });
 
-  it('rolls back cache copies when a later attachment cannot be materialized', () => {
+  it('stages nothing when a later video refuses the submission', () => {
     const { cleanup } = setupTempCache();
-    const srcDir = makeTempDir();
     try {
-      const firstPath = join(srcDir, 'first.mp4');
-      writeFileSync(firstPath, 'video-bytes');
       const store = new ImageAttachmentStore();
-      const first = store.addVideo('video/mp4', firstPath);
-      const missing = store.addVideo('video/mp4', join(srcDir, 'missing.mp4'));
+      const first = store.addVideo('video/mp4', '/tmp/first.mp4');
+      store.completeVideo(first, { fileId: 'file-v1' });
+      const missing = store.addVideo('video/mp4', '/tmp/missing.mp4');
 
       expect(() =>
         extractMediaAttachments(`${first.placeholder} ${missing.placeholder}`, store),
-      ).toThrow();
-      expect(readdirSync(getCacheDir())).toEqual([]);
+      ).toThrow(/could not be uploaded/);
+      // The prompt path stages no cache copies at all, so the throw leaves
+      // no local cleanup behind — the first video's daemon upload is owned
+      // by its retain, not by a staging path.
+      expect(existsSync(getCacheDir())).toBe(false);
     } finally {
       cleanup();
-      rmSync(srcDir, { recursive: true, force: true });
     }
   });
 });
@@ -790,15 +782,15 @@ describe('rewriteMediaPlaceholders', () => {
   });
 });
 
-describe('pendingImageIngestions', () => {
-  it('returns undefined for text without image placeholders', () => {
+describe('pendingMediaIngestions', () => {
+  it('returns undefined for text without media placeholders', () => {
     const store = new ImageAttachmentStore();
-    expect(pendingImageIngestions('hello world', store, 5)).toBeUndefined();
+    expect(pendingMediaIngestions('hello world', store, 5)).toBeUndefined();
   });
 
   it('returns undefined when no referenced image has a pending ingestion', () => {
     const { store, placeholder } = storeWith(new Uint8Array([0xaa, 0xbb]));
-    expect(pendingImageIngestions(`describe ${placeholder}`, store, 5)).toBeUndefined();
+    expect(pendingMediaIngestions(`describe ${placeholder}`, store, 5)).toBeUndefined();
   });
 
   it('waits for a pending ingestion so extraction can use the daemon-ref form', async () => {
@@ -817,7 +809,7 @@ describe('pendingImageIngestions', () => {
       };
     });
 
-    const waited = pendingImageIngestions(`describe ${placeholder}`, store, 1_000);
+    const waited = pendingMediaIngestions(`describe ${placeholder}`, store, 1_000);
     if (waited === undefined) throw new Error('expected a pending wait');
     let settled = false;
     void waited.then(() => {
@@ -837,6 +829,26 @@ describe('pendingImageIngestions', () => {
     expect(parseDaemonFileUrl(part.imageUrl.url)?.fileId).toBe('file-1');
   });
 
+  it('waits for a pending video upload so extraction can use the daemon-ref form', async () => {
+    const store = new ImageAttachmentStore();
+    const att = store.addVideo('video/mp4', '/tmp/clip.mp4');
+    let finish!: () => void;
+    att.pending = new Promise<void>((resolve) => {
+      finish = () => {
+        store.completeVideo(att, { fileId: 'file-v1' });
+        resolve();
+      };
+    });
+
+    const waited = pendingMediaIngestions(`watch ${att.placeholder}`, store, 1_000);
+    if (waited === undefined) throw new Error('expected a pending wait');
+    finish();
+    await waited;
+
+    const r = extractMediaAttachments(`watch ${att.placeholder}`, store);
+    expect(videoUrlFromParts(r.parts)).toBe('kimi-file://file-v1');
+  });
+
   it('bounds the wait by the timeout so a slow ingestion extracts to the inline form', async () => {
     const { store, placeholder } = storeWith(new Uint8Array([0xaa, 0xbb]));
     const att = store.get(1);
@@ -844,7 +856,7 @@ describe('pendingImageIngestions', () => {
     att.pending = new Promise<void>(() => undefined); // never settles
 
     const start = Date.now();
-    const waited = pendingImageIngestions(`describe ${placeholder}`, store, 20);
+    const waited = pendingMediaIngestions(`describe ${placeholder}`, store, 20);
     if (waited === undefined) throw new Error('expected a pending wait');
     await waited;
     expect(Date.now() - start).toBeLessThan(1_000);

--- a/apps/kimi-code/test/tui/kimi-tui-message-flow.test.ts
+++ b/apps/kimi-code/test/tui/kimi-tui-message-flow.test.ts
@@ -467,18 +467,6 @@ async function makeTempHome(): Promise<string> {
   return dir;
 }
 
-/** Runs `run` with a temp clip.mp4 source, removing the temp dir afterwards. */
-async function withTempVideo(run: (srcVideo: string) => Promise<void>): Promise<void> {
-  const dir = await mkdtemp(join(tmpdir(), 'tui-video-'));
-  try {
-    const srcVideo = join(dir, 'clip.mp4');
-    await writeFile(srcVideo, 'video-bytes');
-    await run(srcVideo);
-  } finally {
-    await rm(dir, { recursive: true, force: true });
-  }
-}
-
 function stagedImage(imageStore: ImageAttachmentStore, fileId: string) {
   return imageStore.addImage(new Uint8Array([0xaa, 0xbb]), 'image/png', 1, 1, undefined, fileId);
 }
@@ -3167,90 +3155,58 @@ command = "vim"
     expect(transcript).not.toContain('review');
   });
 
-  it('keeps a pasted video cache copy for history until the session closes', async () => {
-    process.env['KIMI_CODE_HOME'] = await makeTempHome();
-    let finishPrompt!: () => void;
-    const promptSettled = new Promise<void>((resolve) => {
-      finishPrompt = resolve;
-    });
-    const session = makeSession({ prompt: vi.fn(() => promptSettled) });
-    const { driver } = await makeDriver(session);
+  it('deletes a pasted video’s daemon upload when the consuming turn ends', async () => {
+    const session = makeSession();
+    const { driver, harness } = await makeDriver(session);
     const imageStore = (driver as unknown as { imageStore: ImageAttachmentStore }).imageStore;
-    try {
-      await withTempVideo(async (srcVideo) => {
-        const attachment = imageStore.addVideo('video/mp4', srcVideo);
+    const attachment = imageStore.addVideo('video/mp4', '/tmp/clip.mp4');
+    imageStore.completeVideo(attachment, { fileId: 'file-v1' });
 
-        // Submission is fully synchronous: the paste is copied to the cache and
-        // referenced by a `file://` video_url the engine resolves in-turn.
-        driver.handleUserInput(`watch ${attachment.placeholder}`);
+    // The paste was uploaded to the daemon file store, so the submission
+    // carries a bare `kimi-file://` reference — no local cache copy.
+    driver.handleUserInput(`watch ${attachment.placeholder}`);
 
-        const parts = vi.mocked(session.prompt).mock.calls[0]?.[0] as
-          | Array<{
-              type: string;
-              text?: string;
-              videoUrl?: { url: string };
-            }>
-          | undefined;
-        expect(parts?.[0]).toEqual({ type: 'text', text: 'watch ' });
-        expect(parts?.[1]?.type).toBe('video_url');
-        expect(parts?.[1]?.videoUrl?.url).toMatch(/^file:\/\/.*clip\.mp4$/);
-        const stagingPath = driver.state.queuedMessages[0]?.stagingPaths?.[0]
-          ?? new URL(parts![1]!.videoUrl!.url).pathname;
-        expect(existsSync(stagingPath)).toBe(true);
+    const parts = vi.mocked(session.prompt).mock.calls[0]?.[0] as
+      | Array<{
+          type: string;
+          text?: string;
+          videoUrl?: { url: string };
+        }>
+      | undefined;
+    expect(parts?.[0]).toEqual({ type: 'text', text: 'watch ' });
+    expect(parts?.[1]).toEqual({ type: 'video_url', videoUrl: { url: 'kimi-file://file-v1' } });
+    expect(harness.deleteFile).not.toHaveBeenCalled();
 
-        driver.sessionEventHandler.handleEvent(
-          { type: 'turn.started', agentId: 'main', turnId: 1, origin: { kind: 'user' } } as Event,
-          () => {},
-        );
-        finishPrompt();
-        expect(existsSync(stagingPath)).toBe(true);
-        driver.sessionEventHandler.handleEvent(
-          { type: 'turn.ended', agentId: 'main', turnId: 1, reason: 'completed' } as Event,
-          () => {},
-        );
-        // The cache copy survives the consuming turn: a v1 degrade persists a
-        // `<video path>` tag carrying this exact path into history, and later
-        // turns re-open it with ReadMediaFile.
-        await new Promise((resolve) => {
-          setTimeout(resolve, 20);
-        });
-        expect(existsSync(stagingPath)).toBe(true);
+    emitTurn(driver, 1);
 
-        // Session close retires it.
-        await driver.closeSession('test');
-        await vi.waitFor(() => {
-          expect(existsSync(stagingPath)).toBe(false);
-        });
-      });
-    } finally {
-      finishPrompt();
-    }
+    // The engine materialized its own session copy at intake, so the staged
+    // upload is garbage once the consuming turn ends.
+    await vi.waitFor(() => {
+      expect(harness.deleteFile).toHaveBeenCalledWith('file-v1');
+    });
+    expect(attachment.fileId).toBeUndefined();
   });
 
-  it('queues a pasted video (file:// part) while a turn is streaming', async () => {
-    process.env['KIMI_CODE_HOME'] = await makeTempHome();
+  it('queues a pasted video (kimi-file part) while a turn is streaming', async () => {
     const session = makeSession();
     const { driver } = await makeDriver(session);
     const imageStore = (driver as unknown as { imageStore: ImageAttachmentStore }).imageStore;
-    await withTempVideo(async (srcVideo) => {
-      const attachment = imageStore.addVideo('video/mp4', srcVideo);
-      driver.state.appState.streamingPhase = 'waiting';
+    const attachment = imageStore.addVideo('video/mp4', '/tmp/clip.mp4');
+    imageStore.completeVideo(attachment, { fileId: 'file-v1' });
+    driver.state.appState.streamingPhase = 'waiting';
 
-      driver.handleUserInput(`describe ${attachment.placeholder}`);
+    driver.handleUserInput(`describe ${attachment.placeholder}`);
 
-      expect(session.prompt).not.toHaveBeenCalled();
-      expect(driver.state.queuedMessages).toHaveLength(1);
-      const queued = driver.state.queuedMessages[0];
-      const parts = queued?.parts as Array<{ type: string; text?: string; videoUrl?: { url: string } }>;
-      expect(parts?.[0]).toEqual({ type: 'text', text: 'describe ' });
-      expect(parts?.[1]?.type).toBe('video_url');
-      expect(parts?.[1]?.videoUrl?.url).toMatch(/^file:\/\/.*clip\.mp4$/);
-      expect(queued?.stagingPaths).toHaveLength(1);
-      expect(existsSync(queued!.stagingPaths![0]!)).toBe(true);
+    expect(session.prompt).not.toHaveBeenCalled();
+    expect(driver.state.queuedMessages).toHaveLength(1);
+    const queued = driver.state.queuedMessages[0];
+    const parts = queued?.parts as Array<{ type: string; text?: string; videoUrl?: { url: string } }>;
+    expect(parts?.[0]).toEqual({ type: 'text', text: 'describe ' });
+    expect(parts?.[1]).toEqual({ type: 'video_url', videoUrl: { url: 'kimi-file://file-v1' } });
+    expect(queued?.videoAttachmentIds).toEqual([attachment.id]);
 
-      driver.sendQueuedMessage(session, queued!);
-      expect(vi.mocked(session.prompt).mock.calls[0]?.[0]).toEqual(parts);
-    });
+    driver.sendQueuedMessage(session, queued!);
+    expect(vi.mocked(session.prompt).mock.calls[0]?.[0]).toEqual(parts);
   });
 
   it('falls back to retained bytes when a queued image upload expires before dispatch', async () => {
@@ -3364,9 +3320,9 @@ command = "vim"
 
     // Simulate a cache-hint interception dismissed back into the editor: the
     // submit's extraction is stashed, then restored with recall semantics
-    // (retain consumed, staged files kept for the restored draft).
+    // (retain consumed, staged upload kept for the restored draft).
     const extraction = extractMediaAttachments(text, imageStore);
-    driver.recallStashedMedia(text, extraction);
+    driver.recallStashedMedia(extraction);
 
     // The restored draft resubmits and re-retains; the consuming turn must
     // still delete the daemon upload — a retain leaked by the dismissal would
@@ -3479,12 +3435,7 @@ command = "vim"
 
     driver.handleUserInput(`first ${attachment.placeholder}`);
     driver.handleUserInput(`second ${attachment.placeholder}`);
-    const stagingPaths = driver.state.queuedMessages.flatMap((item) => item.stagingPaths ?? []);
     expect(driver.state.queuedMessages).toHaveLength(2);
-    // An uploaded image stages no local cache copy — the engine's intake
-    // materializes the session copy — so only the daemon upload lease rides
-    // with each queued message.
-    expect(stagingPaths).toHaveLength(0);
 
     driver.clearQueuedMessages();
 
@@ -4033,28 +3984,30 @@ command = "vim"
     expect(harness.deleteFile).toHaveBeenCalledTimes(1);
   });
 
-  it('rebases a recalled video onto its staged cache copy', async () => {
-    process.env['KIMI_CODE_HOME'] = await makeTempHome();
+  it('keeps a recalled video’s daemon upload alive for the restored draft', async () => {
     const session = makeSession();
-    const { driver } = await makeDriver(session);
+    const { driver, harness } = await makeDriver(session);
     const imageStore = (driver as unknown as { imageStore: ImageAttachmentStore }).imageStore;
-    await withTempVideo(async (srcVideo) => {
-      const attachment = imageStore.addVideo('video/mp4', srcVideo);
-      driver.state.appState.streamingPhase = 'waiting';
+    const attachment = imageStore.addVideo('video/mp4', '/tmp/clip.mp4');
+    imageStore.completeVideo(attachment, { fileId: 'file-v1' });
+    driver.state.appState.streamingPhase = 'waiting';
 
-      driver.handleUserInput(`describe ${attachment.placeholder}`);
-      const queued = driver.state.queuedMessages[0]!;
-      const cachePath = queued.stagingPaths![0]!;
-      expect(existsSync(cachePath)).toBe(true);
+    driver.handleUserInput(`describe ${attachment.placeholder}`);
+    expect(driver.state.queuedMessages).toHaveLength(1);
 
-      const recalled = driver.recallLastQueued();
-      expect(recalled?.text).toContain(attachment.placeholder);
-      await new Promise((resolve) => setTimeout(resolve, 20));
-      // The cache copy survives the recall and becomes the video's source, so
-      // a vanished original cannot lose the media on resubmit.
-      expect(existsSync(cachePath)).toBe(true);
-      expect(attachment.sourcePath).toBe(cachePath);
-    });
+    const recalled = driver.recallLastQueued();
+    expect(recalled?.text).toContain(attachment.placeholder);
+    // The recall consumed the retain but kept the upload, so resubmitting
+    // the restored draft re-extracts the same daemon reference — a vanished
+    // original source cannot lose the media.
+    expect(attachment.fileId).toBe('file-v1');
+    expect(harness.deleteFile).not.toHaveBeenCalled();
+
+    driver.handleUserInput(recalled!.text);
+    const queued = driver.state.queuedMessages[0];
+    const parts = queued?.parts as Array<{ type: string; videoUrl?: { url: string } }>;
+    expect(parts?.[1]).toEqual({ type: 'video_url', videoUrl: { url: 'kimi-file://file-v1' } });
+    expect(queued?.videoAttachmentIds).toEqual([attachment.id]);
   });
 
   it('steers consecutive image-only messages without a whitespace-only separator part', async () => {

--- a/apps/kimi-code/test/tui/kimi-tui-message-flow.test.ts
+++ b/apps/kimi-code/test/tui/kimi-tui-message-flow.test.ts
@@ -135,7 +135,7 @@ interface MessageDriver {
   persistInputHistory(text: string): Promise<void>;
   sendQueuedMessage(session: unknown, item: QueuedMessage): void;
   recallLastQueued(): QueuedMessage | undefined;
-  recallStashedMedia(text: string, extraction: ExtractionResult | undefined): void;
+  recallStashedMedia(extraction: ExtractionResult | undefined): void;
   clearQueuedMessages(): void;
   closeSession(reason: string): Promise<void>;
   setSession(session: unknown): Promise<void>;


### PR DESCRIPTION
## Related Issue

Resolve #2979

## Problem

Pasting a video into the TUI staged a local cache copy and submitted a bare `file://` `video_url` part. The v2 engine only resolves `kimi-file://` daemon references, so the raw `file://` URL was sent to the provider as-is: the submission failed, and because the unresolvable part landed in persisted history, every later turn replayed it — the session stayed broken.

## What changed

Video paste now mirrors the image paste flow (`#2593`), with no engine-side changes needed:

- At paste time the video's source file is uploaded to the daemon file store in the background (same 1h staging TTL as images; the existing 100 MB clipboard cap still applies), so typing never waits on it.
- At submit time the placeholder expands to a bare `kimi-file://<id>` `video_url` part — the engine's prompt intake materializes the session copy, exactly like an uploaded image. Submit gives a just-pasted video the same bounded wait images get; a video whose upload is still in flight, failed, or expired refuses the submission with an actionable error, since video bytes have no inline fallback form.
- The staging lease / queue / steer channels now carry both image and video attachment ids, and the prompt path no longer stages any local cache copies (the slash-command args channel keeps its cache copies — the model reads those with `ReadMediaFile`). Recalled drafts keep the daemon upload alive instead of rebasing onto a staged cache copy, and a store `clear()` no longer eagerly deletes uploads that still have an outstanding retain (e.g. a cache-hint resend into a new session).

Supersedes #3027, which instead patched the v2 resolver to upload/degrade bare `file://` refs — we deliberately moved the fix to the edge so the engine contract stays `kimi-file://`-only.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.