### PR TITLE
fix(agent-core-v2): fall back to the persisted model snapshot when a session's model alias is removed from config

### DIFF
--- a/packages/agent-core-v2/docs/state-manifest.d.ts
+++ b/packages/agent-core-v2/docs/state-manifest.d.ts
@@ -27,7 +27,7 @@
 // references become '(circular)', and class instances collapse to a '(ClassName)'
 // marker — the wire shape of an entry is the JSON projection of the type here.
 //
-// Index (App: 0 keys · Workspace: 6 keys · Session: 18 keys · Agent: 98 keys)
+// Index (App: 0 keys · Workspace: 6 keys · Session: 18 keys · Agent: 99 keys)
 //   App
 //   Workspace
 //     workspaceDirs.ephemeralDirs          src/workspace/workspaceDirs/workspaceDirsService.ts
@@ -106,6 +106,7 @@
 //     mcp.mcpToolsByServer                            src/agent/mcp/mcpService.ts
 //     media.registeredKey                             src/agent/media/mediaToolsRegistrar.ts
 //     media.resolved                                  src/agent/media/mediaResolverService.ts
+//     modelSnapshot.records                           src/agent/modelSnapshot/modelSnapshotOps.ts
 //     permissionMode                                  src/agent/permissionMode/permissionModeOps.ts
 //     permissionMode.configured                       src/agent/permissionMode/permissionModeOps.ts
 //     permissionMode.lastMode                         src/agent/permissionMode/injection/permissionModeInjection.ts
@@ -1341,6 +1342,47 @@ export interface AgentStateSnapshot {
   }>;
   // src/agent/media/mediaToolsRegistrar.ts
   'media.registeredKey': string | undefined;
+  // src/agent/modelSnapshot/modelSnapshotOps.ts
+  // replayable · durable — folds: ModelSnapshot
+  'modelSnapshot.records': /* ModelSnapshotsState — packages/agent-core-v2/src/agent/modelSnapshot/modelSnapshotOps.ts */ {
+    [key: string]: /* ModelSnapshotRecord — packages/agent-core-v2/src/agent/modelSnapshot/modelSnapshot.ts */ {
+    providerId?: string;
+    baseUrl?: string;
+    oauth?: /* OAuthRef — packages/agent-core-v2/src/kosong/provider/provider.ts */ {
+      storage: 'file' | 'keyring';
+      key: string;
+      oauthHost?: string;
+    };
+    protocol?: 'anthropic' | 'openai' | 'openai_responses' | 'google-genai';
+    name?: string;
+    aliases?: string[];
+    provider?: string;
+    model?: string;
+    maxContextSize?: number;
+    maxInputSize?: number;
+    maxOutputSize?: number;
+    capabilities?: string[];
+    displayName?: string;
+    reasoningKey?: string;
+    adaptiveThinking?: boolean;
+    betaApi?: boolean;
+    supportEfforts?: string[];
+    defaultEffort?: string;
+    offEffort?: string;
+    overrides?: /* ModelOverride — packages/agent-core-v2/src/kosong/model/model.ts */ {
+      maxContextSize?: number;
+      maxInputSize?: number;
+      maxOutputSize?: number;
+      capabilities?: string[];
+      displayName?: string;
+      reasoningKey?: string;
+      adaptiveThinking?: boolean;
+      supportEfforts?: string[];
+      defaultEffort?: string;
+      offEffort?: string;
+    };
+  };
+  };
   // src/agent/permissionMode/injection/permissionModeInjection.ts
   'permissionMode.lastMode': 'manual' | 'yolo' | 'auto' | undefined;
   // src/agent/permissionMode/permissionModeOps.ts

--- a/packages/agent-core-v2/docs/wire-manifest.d.ts
+++ b/packages/agent-core-v2/docs/wire-manifest.d.ts
@@ -24,7 +24,7 @@
 // cross-reducers), blobs (the folding states whose blob codec offloads inline
 // media to blob storage), owner (the source file declaring the class).
 
-// Index (49 record types)
+// Index (50 record types)
 //   config.update                      profile                                                               src/agent/profile/profileOps.ts
 //   context.append_loop_event          contextMemory, turn                                                   src/agent/contextMemory/contextEvents.ts
 //   context.append_message             contextMemory, goalForkNotice, plan, task.notificationDelivery, todo  src/agent/contextMemory/contextEvents.ts
@@ -44,6 +44,7 @@
 //   llm.request                        llm.requestTrace                                                      src/agent/llmRequester/llmRequestOps.ts
 //   llm.tools_snapshot                 llm.requestTrace                                                      src/agent/llmRequester/llmRequestOps.ts
 //   mcp.tools_discovered               mcp.discovery                                                         src/agent/mcp/mcpDiscoveryOps.ts
+//   model.snapshot                     modelSnapshot.records                                                 src/agent/modelSnapshot/modelSnapshotOps.ts
 //   permission.record_approval_result  permissionRules                                                       src/agent/permissionRules/permissionRulesOps.ts
 //   permission.set_mode                permissionMode, permissionMode.configured                             src/agent/permissionMode/permissionModeOps.ts
 //   plan_mode.cancel                   plan                                                                  src/features/plan/planOps.ts
@@ -339,6 +340,52 @@ interface McpToolsDiscoveredPayload {
     toolName: string;
     collidesWith: { kind: 'same_server', toolName: string } | { kind: 'other_server', serverName: string };
   }[];
+}
+
+/**
+ * states: modelSnapshot.records
+ * owner: src/agent/modelSnapshot/modelSnapshotOps.ts
+ */
+interface ModelSnapshotPayload {
+  _name: 'model.snapshot';
+  alias: string;
+  record: {
+    providerId?: string;
+    baseUrl?: string;
+    oauth?: {
+      storage: 'file' | 'keyring';
+      key: string;
+      oauthHost?: string;
+    };
+    protocol?: 'anthropic' | 'openai' | 'openai_responses' | 'google-genai';
+    name?: string;
+    aliases?: string[];
+    provider?: string;
+    model?: string;
+    maxContextSize?: number;
+    maxInputSize?: number;
+    maxOutputSize?: number;
+    capabilities?: string[];
+    displayName?: string;
+    reasoningKey?: string;
+    adaptiveThinking?: boolean;
+    betaApi?: boolean;
+    supportEfforts?: string[];
+    defaultEffort?: string;
+    offEffort?: string;
+    overrides?: {
+      maxContextSize?: number;
+      maxInputSize?: number;
+      maxOutputSize?: number;
+      capabilities?: string[];
+      displayName?: string;
+      reasoningKey?: string;
+      adaptiveThinking?: boolean;
+      supportEfforts?: string[];
+      defaultEffort?: string;
+      offEffort?: string;
+    };
+  };
 }
 
 /**
@@ -728,6 +775,7 @@ interface WirePayloadMap {
   "llm.request": LlmRequestPayload;
   "llm.tools_snapshot": LlmToolsSnapshotPayload;
   "mcp.tools_discovered": McpToolsDiscoveredPayload;
+  "model.snapshot": ModelSnapshotPayload;
   "permission.record_approval_result": PermissionRecordApprovalResultPayload;
   "permission.set_mode": PermissionSetModePayload;
   "plan_mode.cancel": PlanModeCancelPayload;

--- a/packages/agent-core-v2/src/agent/llmRequester/llmRequesterService.ts
+++ b/packages/agent-core-v2/src/agent/llmRequester/llmRequesterService.ts
@@ -11,6 +11,7 @@ import {
 import { IAgentTokenCountingService } from '#/agent/tokenCounting/tokenCounting';
 import { IAgentProfileService, type ProfileModelContext } from '#/agent/profile/profile';
 import { IAgentStateService } from '#/agent/state/agentState';
+import { IAgentModelSnapshotService } from '#/agent/modelSnapshot/modelSnapshot';
 import { IAgentToolRegistryService } from '#/agent/toolRegistry/toolRegistry';
 import { IAgentToolSelectService } from '#/agent/toolSelect/toolSelect';
 import { IAgentMediaResolverService } from '#/agent/media/mediaResolver';
@@ -155,6 +156,7 @@ export class AgentLLMRequesterService implements IAgentLLMRequesterService {
     @ITelemetryService private readonly telemetry: ITelemetryService,
     @IEventDispatcher private readonly dispatcher: IEventDispatcher,
     @IAgentStateService private readonly states: IAgentStateService,
+    @IAgentModelSnapshotService private readonly modelSnapshots: IAgentModelSnapshotService,
   ) {
     this.states.contributeState(llmRequestTraceKey);
     this.states.contributeState(llmRequesterLastConfigLogSignatureKey);
@@ -588,7 +590,7 @@ export class AgentLLMRequesterService implements IAgentLLMRequesterService {
           ? this.tokenCounting.get().measured
           : undefined,
     });
-    const requester = this.modelCatalog.getRequester(resolved.modelAlias);
+    const requester = this.modelSnapshots.resolveRequester(resolved.modelAlias);
 
     const messages = overrides.messages ?? this.context.get();
     return {

--- a/packages/agent-core-v2/src/agent/modelSnapshot/modelSnapshot.ts
+++ b/packages/agent-core-v2/src/agent/modelSnapshot/modelSnapshot.ts
@@ -1,0 +1,39 @@
+import { createDecorator, type ServiceIdentifier } from '#/_base/di/instantiation';
+import type { Model } from '#/kosong/model/catalog';
+import type { ModelOverride } from '#/kosong/model/model';
+import type { ModelRequester } from '#/kosong/model/modelRequester';
+import type { OAuthRef } from '#/kosong/provider/provider';
+import type { Protocol } from '#/kosong/protocol/protocol';
+
+export type ModelSnapshotRecord = {
+  providerId?: string;
+  baseUrl?: string;
+  oauth?: OAuthRef;
+  protocol?: Protocol;
+  name?: string;
+  aliases?: string[];
+  provider?: string;
+  model?: string;
+  maxContextSize?: number;
+  maxInputSize?: number;
+  maxOutputSize?: number;
+  capabilities?: string[];
+  displayName?: string;
+  reasoningKey?: string;
+  adaptiveThinking?: boolean;
+  betaApi?: boolean;
+  supportEfforts?: string[];
+  defaultEffort?: string;
+  offEffort?: string;
+  overrides?: ModelOverride;
+};
+
+export interface IAgentModelSnapshotService {
+  readonly _serviceBrand: undefined;
+
+  resolve(alias: string): Model;
+  resolveRequester(alias: string): ModelRequester;
+}
+
+export const IAgentModelSnapshotService: ServiceIdentifier<IAgentModelSnapshotService> =
+  createDecorator<IAgentModelSnapshotService>('agentModelSnapshotService');

--- a/packages/agent-core-v2/src/agent/modelSnapshot/modelSnapshotOps.ts
+++ b/packages/agent-core-v2/src/agent/modelSnapshot/modelSnapshotOps.ts
@@ -1,0 +1,60 @@
+/* oxlint-disable typescript-eslint/no-unsafe-declaration-merging, eslint-plugin-import/namespace -- Event2 class+payload-interface declaration merging is the sanctioned event-declaration idiom. */
+import { z } from 'zod';
+
+import { type AssertExact, type Equal } from '#/_base/utils/typeEquality';
+import { ModelOverrideSchema, OAuthRefSchema } from '#/app/kosongConfig/configSection';
+import { Event2 } from '#/app/event/event2';
+import { ProtocolSchema } from '#/kosong/protocol/protocol';
+import { defineState } from '#/state/state';
+
+import type { ModelSnapshotRecord } from './modelSnapshot';
+
+export const modelSnapshotRecordSchema = z.object({
+  providerId: z.string().optional(),
+  baseUrl: z.string().optional(),
+  oauth: OAuthRefSchema.optional(),
+  protocol: ProtocolSchema.optional(),
+  name: z.string().optional(),
+  aliases: z.array(z.string()).optional(),
+  provider: z.string().optional(),
+  model: z.string().optional(),
+  maxContextSize: z.number().optional(),
+  maxInputSize: z.number().optional(),
+  maxOutputSize: z.number().optional(),
+  capabilities: z.array(z.string()).optional(),
+  displayName: z.string().optional(),
+  reasoningKey: z.string().optional(),
+  adaptiveThinking: z.boolean().optional(),
+  betaApi: z.boolean().optional(),
+  supportEfforts: z.array(z.string()).optional(),
+  defaultEffort: z.string().optional(),
+  offEffort: z.string().optional(),
+  overrides: ModelOverrideSchema.optional(),
+});
+
+type _AssertModelSnapshotRecord = AssertExact<
+  Equal<z.infer<typeof modelSnapshotRecordSchema>, ModelSnapshotRecord>
+>;
+
+const modelSnapshotSchema = z.object({
+  alias: z.string().min(1),
+  record: modelSnapshotRecordSchema,
+});
+
+export class ModelSnapshot extends Event2<z.infer<typeof modelSnapshotSchema>> {
+  static override readonly type = 'model.snapshot';
+  static override readonly durable = true;
+  static override readonly schema = modelSnapshotSchema;
+}
+export interface ModelSnapshot extends z.infer<typeof modelSnapshotSchema> {}
+
+export type ModelSnapshotsState = Record<string, ModelSnapshotRecord>;
+
+export const modelSnapshotsKey = defineState(
+  'modelSnapshot.records',
+  (): ModelSnapshotsState => ({}),
+)
+  .replayable({ schema: z.record(z.string(), modelSnapshotRecordSchema) })
+  .on(ModelSnapshot, (s, e) => {
+    s[e.alias] = e.record;
+  });

--- a/packages/agent-core-v2/src/agent/modelSnapshot/modelSnapshotService.ts
+++ b/packages/agent-core-v2/src/agent/modelSnapshot/modelSnapshotService.ts
@@ -1,0 +1,172 @@
+import { Disposable } from '#/_base/di/lifecycle';
+import { isError2 } from '#/_base/errors/errors';
+import { ScopeActivation, registerScopedService } from '#/_base/di/scope';
+import { type AssertExact, type Equal } from '#/_base/utils/typeEquality';
+import { LifecycleScope } from '#/app/scopes';
+import { WarningIssued } from '#/agent/profile/profileOps';
+import { IAgentStateService } from '#/agent/state/agentState';
+import { CONFIG_INVALID_ERROR_CODE } from '#/kosong/contract/errors';
+import { IModelCatalog, type Model } from '#/kosong/model/catalog';
+import { IModelService, type ModelRecord } from '#/kosong/model/model';
+import { nonEmpty } from '#/kosong/model/modelAuth';
+import type { ModelRequester } from '#/kosong/model/modelRequester';
+import { IProviderService } from '#/kosong/provider/provider';
+import { IEventDispatcher } from '#/state/eventDispatcher';
+
+import { IAgentModelSnapshotService, type ModelSnapshotRecord } from './modelSnapshot';
+import {
+  ModelSnapshot,
+  modelSnapshotsKey,
+  type ModelSnapshotsState,
+} from './modelSnapshotOps';
+
+const SNAPSHOT_FIELD_NAMES = [
+  'providerId',
+  'baseUrl',
+  'oauth',
+  'protocol',
+  'name',
+  'aliases',
+  'provider',
+  'model',
+  'maxContextSize',
+  'maxInputSize',
+  'maxOutputSize',
+  'capabilities',
+  'displayName',
+  'reasoningKey',
+  'adaptiveThinking',
+  'betaApi',
+  'supportEfforts',
+  'defaultEffort',
+  'offEffort',
+  'overrides',
+] as const;
+
+type _AssertSnapshotFieldNames = AssertExact<
+  Equal<(typeof SNAPSHOT_FIELD_NAMES)[number], keyof ModelSnapshotRecord>
+>;
+
+export class AgentModelSnapshotService extends Disposable implements IAgentModelSnapshotService {
+  declare readonly _serviceBrand: undefined;
+
+  private readonly fallbackWarnedAliases = new Set<string>();
+
+  constructor(
+    @IModelCatalog private readonly catalog: IModelCatalog,
+    @IModelService private readonly models: IModelService,
+    @IProviderService private readonly providers: IProviderService,
+    @IAgentStateService private readonly states: IAgentStateService,
+    @IEventDispatcher private readonly dispatcher: IEventDispatcher,
+  ) {
+    super();
+    this.states.contributeState(modelSnapshotsKey);
+  }
+
+  resolve(alias: string): Model {
+    try {
+      const model = this.catalog.get(alias);
+      this.refreshSnapshot(alias);
+      return model;
+    } catch (error) {
+      return this.resolveFromSnapshot(alias, error, (record) =>
+        this.catalog.getFromRecord(alias, record),
+      );
+    }
+  }
+
+  resolveRequester(alias: string): ModelRequester {
+    try {
+      const requester = this.catalog.getRequester(alias);
+      this.refreshSnapshot(alias);
+      return requester;
+    } catch (error) {
+      return this.resolveFromSnapshot(alias, error, (record) =>
+        this.catalog.getRequesterFromRecord(alias, record),
+      );
+    }
+  }
+
+  private get snapshots(): ModelSnapshotsState {
+    return this.states.get(modelSnapshotsKey) as ModelSnapshotsState;
+  }
+
+  private refreshSnapshot(alias: string): void {
+    const record = this.models.get(alias);
+    if (record === undefined) return;
+    if (nonEmpty(record.apiKey) !== undefined) return;
+    const snapshot = toSnapshotRecord(record);
+    if (snapshot.providerId === undefined && snapshot.provider === undefined) {
+      const defaultProvider = this.providers.getDefaultProvider();
+      if (defaultProvider !== undefined) snapshot.provider = defaultProvider;
+    }
+    const existing = this.snapshots[alias];
+    if (existing !== undefined && snapshotRecordsEqual(existing, snapshot)) return;
+    void this.dispatcher.dispatch(new ModelSnapshot({ alias, record: snapshot }));
+  }
+
+  private resolveFromSnapshot<T>(
+    alias: string,
+    error: unknown,
+    build: (record: ModelSnapshotRecord) => T,
+  ): T {
+    if (!isError2(error) || error.code !== CONFIG_INVALID_ERROR_CODE) throw error;
+    if (this.models.get(alias) !== undefined) throw error;
+    const snapshot = this.snapshots[alias];
+    if (snapshot === undefined) throw error;
+    const providerId = snapshot.providerId ?? snapshot.provider;
+    if (providerId !== undefined && this.providers.get(providerId) === undefined) throw error;
+    const resolved = build(snapshot);
+    this.warnOnce(alias);
+    return resolved;
+  }
+
+  private warnOnce(alias: string): void {
+    if (this.fallbackWarnedAliases.has(alias)) return;
+    this.fallbackWarnedAliases.add(alias);
+    void this.dispatcher.dispatch(
+      new WarningIssued({
+        code: 'model-snapshot-fallback',
+        message: `Model "${alias}" is no longer configured in config.toml; this session continues with the last resolved configuration for it.`,
+      }),
+    );
+  }
+}
+
+function toSnapshotRecord(record: ModelRecord): ModelSnapshotRecord {
+  const out: Record<string, unknown> = {};
+  for (const key of SNAPSHOT_FIELD_NAMES) {
+    const value = record[key];
+    if (value === undefined) continue;
+    out[key] = structuredClone(value);
+  }
+  return out as ModelSnapshotRecord;
+}
+
+function snapshotRecordsEqual(a: ModelSnapshotRecord, b: ModelSnapshotRecord): boolean {
+  return stableStringify(a) === stableStringify(b);
+}
+
+function stableStringify(value: unknown): string {
+  return JSON.stringify(sortKeysDeep(value));
+}
+
+function sortKeysDeep(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(sortKeysDeep);
+  if (typeof value === 'object' && value !== null) {
+    return Object.fromEntries(
+      Object.entries(value)
+        .toSorted(([a], [b]) => a.localeCompare(b))
+        .map(([key, entry]) => [key, sortKeysDeep(entry)]),
+    );
+  }
+  return value;
+}
+
+registerScopedService(
+  LifecycleScope.Agent,
+  IAgentModelSnapshotService,
+  AgentModelSnapshotService,
+  ScopeActivation.OnScopeCreated,
+  'modelSnapshot',
+);

--- a/packages/agent-core-v2/src/agent/profile/profileService.ts
+++ b/packages/agent-core-v2/src/agent/profile/profileService.ts
@@ -42,6 +42,7 @@ import { IPluginService } from '#/app/plugin/plugin';
 import type { ResolvedAgentProfile, SystemPromptContext } from '#/agent/profile/profile';
 import { IAgentStateService } from '#/agent/state/agentState';
 import { IAgentAgentsMdReminderService } from '#/agent/agentsMdReminder/agentsMdReminder';
+import { IAgentModelSnapshotService } from '#/agent/modelSnapshot/modelSnapshot';
 
 import { ITelemetryService } from '#/app/telemetry/telemetry';
 import { IAgentTelemetryContextService } from '#/app/telemetry/agentTelemetryContext';
@@ -165,6 +166,7 @@ export class AgentProfileService extends Disposable implements IAgentProfileServ
     @IPluginService private readonly plugins: IPluginService,
     @IAgentIdentity private readonly identity: IAgentIdentity,
     @IAgentAgentsMdReminderService private readonly agentsMdReminder: IAgentAgentsMdReminderService,
+    @IAgentModelSnapshotService private readonly modelSnapshots: IAgentModelSnapshotService,
   ) {
     super();
     this.states.contributeState(profileKey);
@@ -486,7 +488,7 @@ export class AgentProfileService extends Disposable implements IAgentProfileServ
 
   resolveModelContext(): ProfileModelContext {
     const modelAlias = this.model;
-    const model = this.modelCatalog.get(modelAlias);
+    const model = this.modelSnapshots.resolve(modelAlias);
     const loopControl = this.config.get<LoopControl>('loopControl');
     return {
       modelAlias,

--- a/packages/agent-core-v2/src/index.ts
+++ b/packages/agent-core-v2/src/index.ts
@@ -640,6 +640,9 @@ export * from '#/mcpCore/config-schema';
 export * from '#/agent/media/mediaTools';
 export * from '#/agent/media/mediaToolsRegistrar';
 export * from '#/agent/media/registerMediaTools';
+export * from '#/agent/modelSnapshot/modelSnapshot';
+export * from '#/agent/modelSnapshot/modelSnapshotOps';
+export * from '#/agent/modelSnapshot/modelSnapshotService';
 export {
   buildDaemonFileUrl,
   buildMediaPathTag,

--- a/packages/agent-core-v2/src/kosong/model/catalog.ts
+++ b/packages/agent-core-v2/src/kosong/model/catalog.ts
@@ -180,6 +180,8 @@ export interface IModelCatalog {
 
   get(id: string): Model;
   getRequester(id: string): ModelRequester;
+  getFromRecord(id: string, record: ModelRecord): Model;
+  getRequesterFromRecord(id: string, record: ModelRecord): ModelRequester;
   inspect(id: string): ModelInspection;
   ping(id: string): Promise<ModelPingResult>;
   findByName(name: string): readonly string[];

--- a/packages/agent-core-v2/src/kosong/model/catalogService.ts
+++ b/packages/agent-core-v2/src/kosong/model/catalogService.ts
@@ -81,6 +81,7 @@ export class ModelCatalog extends Disposable implements IModelCatalog {
   declare readonly _serviceBrand: undefined;
 
   private readonly cache = new Map<string, CatalogEntry>();
+  private readonly recordCache = new Map<string, CatalogEntry>();
 
   constructor(
     @IProviderService private readonly providers: IProviderService,
@@ -97,6 +98,7 @@ export class ModelCatalog extends Disposable implements IModelCatalog {
 
   notifyConfigChanged(): void {
     this.cache.clear();
+    this.recordCache.clear();
   }
 
   get(id: string): Model {
@@ -105,6 +107,14 @@ export class ModelCatalog extends Disposable implements IModelCatalog {
 
   getRequester(id: string): ModelRequester {
     return this.entry(id).requester;
+  }
+
+  getFromRecord(id: string, record: ModelRecord): Model {
+    return this.recordEntry(id, record).model;
+  }
+
+  getRequesterFromRecord(id: string, record: ModelRecord): ModelRequester {
+    return this.recordEntry(id, record).requester;
   }
 
   findByName(name: string): readonly string[] {
@@ -119,14 +129,39 @@ export class ModelCatalog extends Disposable implements IModelCatalog {
   private entry(id: string): CatalogEntry {
     const cached = this.cache.get(id);
     if (cached !== undefined) return cached;
+    const configuredModel = this.models.get(id);
+    if (configuredModel === undefined) {
+      throw new Error2(
+        CONFIG_INVALID_ERROR_CODE,
+        `Model "${id}" is not configured in config.toml.`,
+        { details: { model: id } },
+      );
+    }
+    return this.buildEntry(id, configuredModel, id, this.cache, true);
+  }
+
+  private recordEntry(id: string, record: ModelRecord): CatalogEntry {
+    const key = `${id}\0${JSON.stringify(record)}`;
+    const cached = this.recordCache.get(key);
+    if (cached !== undefined) return cached;
+    return this.buildEntry(id, record, key, this.recordCache, false);
+  }
+
+  private buildEntry(
+    id: string,
+    record: ModelRecord,
+    cacheKey: string,
+    cache: Map<string, CatalogEntry>,
+    allowDefaultProvider: boolean,
+  ): CatalogEntry {
     const trace = new ResolutionTraceCollector();
-    const model = this.buildModel(id, trace);
+    const model = this.buildModel(id, record, trace, allowDefaultProvider);
     const entry: CatalogEntry = {
       model,
       requester: new ModelRequesterImpl(model, this.protocolRegistry),
       trace,
     };
-    this.cache.set(id, entry);
+    cache.set(cacheKey, entry);
     return entry;
   }
 
@@ -252,21 +287,18 @@ export class ModelCatalog extends Disposable implements IModelCatalog {
     return this.providers.get(providerId ?? '')?.type ?? record.protocol;
   }
 
-  private buildModel(id: string, trace: ResolutionTraceCollector): Model {
-    const configuredModel = this.models.get(id);
-    if (configuredModel === undefined) {
-      throw new Error2(
-        CONFIG_INVALID_ERROR_CODE,
-        `Model "${id}" is not configured in config.toml.`,
-        { details: { model: id } },
-      );
-    }
+  private buildModel(
+    id: string,
+    configuredModel: ModelRecord,
+    trace: ResolutionTraceCollector,
+    allowDefaultProvider: boolean,
+  ): Model {
     trace.capture(TRACE.configuredModel, configuredModel);
     trace.record('model.record', { kind: 'config', detail: '[models.*] section' });
 
     const routingModel = effectiveModelConfig(configuredModel);
     const { providerConfig, providerName, resolvedBaseUrl: rawBaseUrl } =
-      this.resolveProviderContext(id, routingModel, trace);
+      this.resolveProviderContext(id, routingModel, trace, allowDefaultProvider);
     trace.capture(TRACE.providerConfig, providerConfig);
     trace.capture(TRACE.providerName, providerName);
     trace.capture(TRACE.rawBaseUrl, rawBaseUrl);
@@ -375,13 +407,16 @@ export class ModelCatalog extends Disposable implements IModelCatalog {
     id: string,
     model: ModelRecord,
     trace: ResolutionTraceCollector,
+    allowDefaultProvider: boolean,
   ): {
     readonly providerConfig: ProviderConfig | undefined;
     readonly providerName: string;
     readonly resolvedBaseUrl: string | undefined;
   } {
     const providerId =
-      model.providerId ?? model.provider ?? this.providers.getDefaultProvider();
+      model.providerId ??
+      model.provider ??
+      (allowDefaultProvider ? this.providers.getDefaultProvider() : undefined);
     if (providerId !== undefined) {
       trace.record('provider', {
         kind: 'config',

--- a/packages/agent-core-v2/test/agent/llmRequester/llmRequesterService.test.ts
+++ b/packages/agent-core-v2/test/agent/llmRequester/llmRequesterService.test.ts
@@ -21,6 +21,7 @@ import { AgentStateService } from '#/agent/state/agentStateService';
 import { IAgentToolRegistryService } from '#/agent/toolRegistry/toolRegistry';
 import { IAgentToolSelectService } from '#/agent/toolSelect/toolSelect';
 import { IAgentMediaResolverService } from '#/agent/media/mediaResolver';
+import { IAgentModelSnapshotService } from '#/agent/modelSnapshot/modelSnapshot';
 import { IAgentUsageService } from '#/agent/usage/usage';
 import { IConfigService } from '#/app/config/config';
 import type { Event2 } from '#/app/event/event2';
@@ -240,6 +241,10 @@ function createService(
     get: () => requester.model,
     getRequester: () => requester,
     findByName: () => [],
+  });
+  ix.stub(IAgentModelSnapshotService, {
+    resolve: () => requester.model,
+    resolveRequester: () => requester,
   });
   ix.stub(IModelService, {
     get: () => undefined,

--- a/packages/agent-core-v2/test/agent/loop/loop.test.ts
+++ b/packages/agent-core-v2/test/agent/loop/loop.test.ts
@@ -71,6 +71,7 @@ describe('Agent loop', () => {
       [wire] turn.prompt                 { "input": [ { "type": "text", "text": "Hello" } ], "origin": { "kind": "user" }, "time": "<time>" }
       [emit] turn.started                { "time": "<time>", "turnId": 0, "origin": { "kind": "user" }, "prompt": "Hello" }
       [emit] agent.activity.updated      { "time": "<time>", "lifecycle": "ready", "turn": { "turnId": 0, "origin": { "kind": "user" }, "phase": "running", "step": 0, "ending": false, "pendingApprovals": [], "activeToolCalls": [], "since": "<time>" }, "background": [] }
+      [wire] model.snapshot              { "alias": "mock-model", "record": { "provider": "test-provider", "model": "mock-model", "maxContextSize": 1000000, "capabilities": [] }, "time": "<time>" }
       [emit] context.spliced             { "time": "<time>", "start": 0, "deleteCount": 0, "messages": [ { "role": "user", "content": [ { "type": "text", "text": "Hello" } ], "toolCalls": [], "origin": { "kind": "user" }, "id": "<msg-1>" } ] }
       [wire] context.append_message      { "message": { "role": "user", "content": [ { "type": "text", "text": "Hello" } ], "toolCalls": [], "origin": { "kind": "user" }, "id": "<msg-1>" }, "time": "<time>" }
       [wire] plugin.session_start        { "content": null, "time": "<time>" }
@@ -128,6 +129,7 @@ describe('Agent loop', () => {
       [wire] turn.prompt                 { "input": [ { "type": "text", "text": "Hello" } ], "origin": { "kind": "user" }, "time": "<time>" }
       [emit] turn.started                { "time": "<time>", "turnId": 0, "origin": { "kind": "user" }, "prompt": "Hello" }
       [emit] agent.activity.updated      { "time": "<time>", "lifecycle": "ready", "turn": { "turnId": 0, "origin": { "kind": "user" }, "phase": "running", "step": 0, "ending": false, "pendingApprovals": [], "activeToolCalls": [], "since": "<time>" }, "background": [] }
+      [wire] model.snapshot              { "alias": "mock-model", "record": { "provider": "test-provider", "model": "mock-model", "maxContextSize": 1000000, "capabilities": [] }, "time": "<time>" }
       [emit] context.spliced             { "time": "<time>", "start": 0, "deleteCount": 0, "messages": [ { "role": "user", "content": [ { "type": "text", "text": "Hello" } ], "toolCalls": [], "origin": { "kind": "user" }, "id": "<msg-1>" } ] }
       [wire] context.append_message      { "message": { "role": "user", "content": [ { "type": "text", "text": "Hello" } ], "toolCalls": [], "origin": { "kind": "user" }, "id": "<msg-1>" }, "time": "<time>" }
       [wire] plugin.session_start        { "content": null, "time": "<time>" }
@@ -350,6 +352,7 @@ describe('Agent loop', () => {
       [wire] turn.prompt                     { "input": [ { "type": "text", "text": "Look up moon" } ], "origin": { "kind": "user" }, "time": "<time>" }
       [emit] turn.started                    { "time": "<time>", "turnId": 0, "origin": { "kind": "user" }, "prompt": "Look up moon" }
       [emit] agent.activity.updated          { "time": "<time>", "lifecycle": "ready", "turn": { "turnId": 0, "origin": { "kind": "user" }, "phase": "running", "step": 0, "ending": false, "pendingApprovals": [], "activeToolCalls": [], "since": "<time>" }, "background": [] }
+      [wire] model.snapshot                  { "alias": "mock-model", "record": { "provider": "test-provider", "model": "mock-model", "maxContextSize": 1000000, "capabilities": [] }, "time": "<time>" }
       [emit] context.spliced                 { "time": "<time>", "start": 0, "deleteCount": 0, "messages": [ { "role": "user", "content": [ { "type": "text", "text": "Look up moon" } ], "toolCalls": [], "origin": { "kind": "user" }, "id": "<msg-1>" } ] }
       [wire] context.append_message          { "message": { "role": "user", "content": [ { "type": "text", "text": "Look up moon" } ], "toolCalls": [], "origin": { "kind": "user" }, "id": "<msg-1>" }, "time": "<time>" }
       [wire] plugin.session_start            { "content": null, "time": "<time>" }

--- a/packages/agent-core-v2/test/agent/modelSnapshot/modelSnapshot.test.ts
+++ b/packages/agent-core-v2/test/agent/modelSnapshot/modelSnapshot.test.ts
@@ -1,0 +1,263 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { isError2 } from '#/_base/errors/errors';
+import { IAgentLLMRequesterService } from '#/agent/llmRequester/llmRequester';
+import { IAgentModelSnapshotService } from '#/agent/modelSnapshot/modelSnapshot';
+import { IAgentProfileService } from '#/agent/profile/profile';
+import { WIRE_PROTOCOL_VERSION } from '#/index';
+import type { WireRecord } from '#/wire/record';
+
+import {
+  configServices,
+  createTestAgent,
+  InMemoryWireRecordPersistence,
+  wireRecordPersistenceServices,
+  type TestAgentContext,
+} from '../../harness';
+
+function userMessage(text: string) {
+  return { role: 'user' as const, content: [{ type: 'text' as const, text }], toolCalls: [] };
+}
+
+function snapshotRecords(records: readonly WireRecord[]): WireRecord[] {
+  return records.filter((record) => record.type === 'model.snapshot');
+}
+
+function warningEvents(ctx: TestAgentContext) {
+  return ctx.allEvents.filter((entry) => entry.event === 'warning');
+}
+
+describe('AgentModelSnapshotService', () => {
+  let ctx: TestAgentContext;
+  let profile: IAgentProfileService;
+
+  beforeEach(() => {
+    ctx = createTestAgent();
+    profile = ctx.get(IAgentProfileService);
+  });
+
+  afterEach(async () => {
+    try {
+      await ctx.expectResumeMatches();
+    } finally {
+      await ctx.dispose();
+    }
+  });
+
+  it('writes a snapshot on successful resolution and skips rewrites while unchanged', async () => {
+    profile.resolveModelContext();
+    let records = await ctx.persistedWireRecords();
+    const written = snapshotRecords(records);
+    expect(written).toHaveLength(1);
+    expect(written[0]).toMatchObject({
+      alias: 'mock-model',
+      record: {
+        provider: 'test-provider',
+        model: 'mock-model',
+        maxContextSize: 1_000_000,
+      },
+    });
+    expect(JSON.stringify(written[0])).not.toMatch(/api_?key|token|authorization|headers/i);
+
+    profile.resolveModelContext();
+    ctx.get(IAgentModelSnapshotService).resolveRequester('mock-model');
+    records = await ctx.persistedWireRecords();
+    expect(snapshotRecords(records)).toHaveLength(1);
+  });
+
+  it('falls back to the snapshot when the alias disappears from config, warning once', async () => {
+    profile.resolveModelContext();
+    ctx.kimiConfig = { ...ctx.kimiConfig, models: {} };
+
+    const resolved = profile.resolveModelContext();
+    expect(resolved.modelAlias).toBe('mock-model');
+    expect(resolved.modelCapabilities.max_context_tokens).toBe(1_000_000);
+    expect(warningEvents(ctx)).toHaveLength(1);
+    expect(warningEvents(ctx)[0]?.args).toMatchObject({ code: 'model-snapshot-fallback' });
+
+    profile.resolveModelContext();
+    expect(warningEvents(ctx)).toHaveLength(1);
+  });
+
+  it('serves requests through the snapshot after the alias disappears', async () => {
+    profile.resolveModelContext();
+    ctx.kimiConfig = { ...ctx.kimiConfig, models: {} };
+
+    ctx.mockNextResponse({ type: 'text', text: 'fallback works' });
+    const finish = await ctx.get(IAgentLLMRequesterService).request({
+      messages: [userMessage('hi')],
+      systemPrompt: 'sys',
+    });
+    expect(finish.message.content).toEqual([{ type: 'text', text: 'fallback works' }]);
+    expect(ctx.llmCalls).toHaveLength(1);
+  });
+
+  it('keeps failing loud when the provider is gone too', async () => {
+    profile.resolveModelContext();
+    ctx.kimiConfig = { ...ctx.kimiConfig, models: {}, providers: {} };
+
+    let thrown: unknown;
+    try {
+      profile.resolveModelContext();
+    } catch (error) {
+      thrown = error;
+    }
+    expect(thrown).toSatisfy((e) => isError2(e) && e.code === 'config.invalid');
+    expect(warningEvents(ctx)).toHaveLength(0);
+  });
+
+  it('does not snapshot models carrying inline apiKey auth', async () => {
+    const flatModels = {
+      flat: {
+        model: 'flat-model',
+        baseUrl: 'https://flat.example.test/v1',
+        apiKey: 'sk-flat',
+        protocol: 'openai',
+        maxContextSize: 8192,
+      },
+    } as unknown as TestAgentContext['kimiConfig']['models'];
+    ctx.kimiConfig = { ...ctx.kimiConfig, models: flatModels };
+    profile.update({ modelAlias: 'flat' });
+
+    profile.resolveModelContext();
+
+    const records = await ctx.persistedWireRecords();
+    expect(snapshotRecords(records)).toHaveLength(0);
+  });
+
+  it('refreshes the snapshot when the alias config changes', async () => {
+    profile.resolveModelContext();
+    ctx.kimiConfig = {
+      ...ctx.kimiConfig,
+      models: {
+        'mock-model': {
+          provider: 'test-provider',
+          model: 'mock-model',
+          maxContextSize: 500_000,
+          capabilities: [],
+        },
+      },
+    };
+
+    const resolved = profile.resolveModelContext();
+    expect(resolved.modelCapabilities.max_context_tokens).toBe(500_000);
+
+    const records = await ctx.persistedWireRecords();
+    const written = snapshotRecords(records);
+    expect(written).toHaveLength(2);
+    expect(written[1]).toMatchObject({ record: { maxContextSize: 500_000 } });
+  });
+
+  it('pins the resolved default provider into the snapshot', async () => {
+    const snapshots = ctx.get(IAgentModelSnapshotService);
+    const models = {
+      routed: { model: 'routed-model', maxContextSize: 64_000 },
+    } as unknown as TestAgentContext['kimiConfig']['models'];
+    ctx.kimiConfig = {
+      providers: {
+        'provider-a': { type: 'kimi', apiKey: 'key-a', baseUrl: 'https://a.example.test/v1' },
+        'provider-b': { type: 'kimi', apiKey: 'key-b', baseUrl: 'https://b.example.test/v1' },
+      },
+      defaultProvider: 'provider-a',
+      models,
+    };
+    profile.update({ modelAlias: 'routed' });
+    profile.resolveModelContext();
+
+    const written = snapshotRecords(await ctx.persistedWireRecords());
+    expect(written).toHaveLength(1);
+    expect(written[0]).toMatchObject({ alias: 'routed', record: { provider: 'provider-a' } });
+
+    ctx.kimiConfig = { ...ctx.kimiConfig, models: {}, defaultProvider: 'provider-b' };
+    const resolved = snapshots.resolve('routed');
+    expect(resolved.providerName).toBe('provider-a');
+    expect(resolved.baseUrl).toBe('https://a.example.test/v1');
+
+    ctx.kimiConfig = {
+      providers: {
+        'provider-b': { type: 'kimi', apiKey: 'key-b', baseUrl: 'https://b.example.test/v1' },
+      },
+      defaultProvider: 'provider-b',
+      models: {},
+    };
+    let thrown: unknown;
+    try {
+      snapshots.resolve('routed');
+    } catch (error) {
+      thrown = error;
+    }
+    expect(thrown).toSatisfy((e) => isError2(e) && e.code === 'config.invalid');
+  });
+
+  it('keeps flat models flat when a default provider appears after the snapshot', async () => {
+    const snapshots = ctx.get(IAgentModelSnapshotService);
+    const models = {
+      flat: {
+        model: 'flat-model',
+        baseUrl: 'https://flat.example.test/v1',
+        protocol: 'openai',
+        maxContextSize: 8192,
+      },
+    } as unknown as TestAgentContext['kimiConfig']['models'];
+    ctx.kimiConfig = {
+      providers: {
+        'late-default': { type: 'kimi', apiKey: 'key-late', baseUrl: 'https://late.example.test/v1' },
+      },
+      models,
+    };
+    profile.update({ modelAlias: 'flat' });
+    profile.resolveModelContext();
+
+    const written = snapshotRecords(await ctx.persistedWireRecords());
+    expect(written).toHaveLength(1);
+    expect(written[0]).toMatchObject({ alias: 'flat' });
+    expect((written[0]?.['record'] as Record<string, unknown>)['provider']).toBeUndefined();
+
+    ctx.kimiConfig = { ...ctx.kimiConfig, models: {}, defaultProvider: 'late-default' };
+    const resolved = snapshots.resolve('flat');
+    expect(resolved.providerName).toBe('flat.example.test');
+    expect(resolved.baseUrl).toBe('https://flat.example.test/v1');
+  });
+
+  it('resolves after resume via the persisted snapshot when the alias is gone from config', async () => {
+    const source = createTestAgent({ persistence: new InMemoryWireRecordPersistence() });
+    let records: readonly WireRecord[];
+    try {
+      source.get(IAgentProfileService).resolveModelContext();
+      records = await source.persistedWireRecords();
+    } finally {
+      await source.dispose();
+    }
+    const seeded: WireRecord[] =
+      records[0]?.type === 'metadata'
+        ? [...records]
+        : [
+            { type: 'metadata', protocol_version: WIRE_PROTOCOL_VERSION, created_at: 1 },
+            ...records,
+          ];
+    const resumedConfig = {
+      providers: {
+        'test-provider': {
+          type: 'kimi',
+          apiKey: 'test-key',
+          baseUrl: 'https://api.example.test/v1',
+        },
+      },
+      models: {},
+    };
+    const resumed = createTestAgent(
+      { autoConfigure: false },
+      configServices(() => resumedConfig),
+      wireRecordPersistenceServices(new InMemoryWireRecordPersistence(seeded)),
+    );
+    try {
+      await resumed.restorePersisted();
+      const resolved = resumed.get(IAgentProfileService).resolveModelContext();
+      expect(resolved.modelAlias).toBe('mock-model');
+      expect(resolved.modelCapabilities.max_context_tokens).toBe(1_000_000);
+      expect(warningEvents(resumed)).toHaveLength(1);
+    } finally {
+      await resumed.dispose();
+    }
+  });
+});

--- a/packages/agent-core-v2/test/agent/profile/profileOps.test.ts
+++ b/packages/agent-core-v2/test/agent/profile/profileOps.test.ts
@@ -12,6 +12,7 @@ import {
   type EnvironmentDisclosureSnapshot,
 } from '#/app/agentProfileCatalog/agentProfileCatalog';
 import { IAgentAgentsMdReminderService } from '#/agent/agentsMdReminder/agentsMdReminder';
+import { IAgentModelSnapshotService } from '#/agent/modelSnapshot/modelSnapshot';
 import { ISessionAgentProfileCatalog } from '#/session/sessionAgentProfileCatalog/sessionAgentProfileCatalog';
 import { IBootstrapService } from '#/app/bootstrap/bootstrap';
 import { IConfigService } from '#/app/config/config';
@@ -107,6 +108,12 @@ function createModelCatalogStub(models: Readonly<Record<string, Model>> = {}): I
       return model;
     },
     getRequester: () => {
+      throw new Error('not exercised');
+    },
+    getFromRecord: () => {
+      throw new Error('not exercised');
+    },
+    getRequesterFromRecord: () => {
       throw new Error('not exercised');
     },
     inspect: () => {
@@ -205,6 +212,10 @@ function buildHost(key: string): {
   );
   host.stub(IConfigService, createConfigStub());
   host.stub(IModelCatalog, modelCatalog);
+  host.stub(IAgentModelSnapshotService, {
+    resolve: (alias) => modelCatalog.get(alias),
+    resolveRequester: (alias) => modelCatalog.getRequester(alias),
+  });
   host.stub(IProtocolAdapterRegistry, createProtocolRegistryStub());
   host.stub(IHostEnvironment, stubUnused());
   host.stub(IHostFileSystem, stubUnused());

--- a/packages/agent-core-v2/test/app/config/config.test.ts
+++ b/packages/agent-core-v2/test/app/config/config.test.ts
@@ -313,6 +313,7 @@ describe('Agent config', () => {
       [wire] turn.prompt                     { "input": [ { "type": "text", "text": "Look up before config changes" } ], "origin": { "kind": "user" }, "time": "<time>" }
       [emit] turn.started                    { "time": "<time>", "turnId": 0, "origin": { "kind": "user" }, "prompt": "Look up before config changes" }
       [emit] agent.activity.updated          { "time": "<time>", "lifecycle": "ready", "turn": { "turnId": 0, "origin": { "kind": "user" }, "phase": "running", "step": 0, "ending": false, "pendingApprovals": [], "activeToolCalls": [], "since": "<time>" }, "background": [] }
+      [wire] model.snapshot                  { "alias": "mock-model", "record": { "provider": "test-provider", "model": "mock-model", "maxContextSize": 1000000, "capabilities": [] }, "time": "<time>" }
       [emit] context.spliced                 { "time": "<time>", "start": 0, "deleteCount": 0, "messages": [ { "role": "user", "content": [ { "type": "text", "text": "Look up before config changes" } ], "toolCalls": [], "origin": { "kind": "user" }, "id": "<msg-1>" } ] }
       [wire] context.append_message          { "message": { "role": "user", "content": [ { "type": "text", "text": "Look up before config changes" } ], "toolCalls": [], "origin": { "kind": "user" }, "id": "<msg-1>" }, "time": "<time>" }
       [wire] plugin.session_start            { "content": null, "time": "<time>" }
@@ -363,6 +364,7 @@ describe('Agent config', () => {
       [wire] context.append_loop_event   { "event": { "type": "tool.result", "parentUuid": "<uuid-3>", "toolCallId": "call_lookup", "result": { "output": "original-result" } }, "time": "<time>" }
       [emit] turn.step.completed         { "time": "<time>", "turnId": 0, "step": 1, "stepId": "<uuid-1>", "usage": { "inputOther": 9, "output": 17, "inputCacheRead": 0, "inputCacheCreation": 0 }, "finishReason": "tool_use", "providerFinishReason": "tool_calls", "rawFinishReason": "tool_calls" }
       [wire] context.append_loop_event   { "event": { "type": "step.end", "uuid": "<uuid-1>", "turnId": "0", "step": 1, "finishReason": "tool_use", "usage": { "inputOther": 9, "output": 17, "inputCacheRead": 0, "inputCacheCreation": 0 }, "messageId": "mock-1", "providerFinishReason": "tool_calls", "rawFinishReason": "tool_calls" }, "time": "<time>" }
+      [wire] model.snapshot              { "alias": "changed-model", "record": { "provider": "test-provider", "model": "changed-model", "maxContextSize": 1000000, "capabilities": [] }, "time": "<time>" }
       [emit] turn.step.started           { "time": "<time>", "turnId": 0, "step": 2, "stepId": "<uuid-4>" }
       [emit] agent.activity.updated      { "time": "<time>", "lifecycle": "ready", "turn": { "turnId": 0, "origin": { "kind": "user" }, "phase": "running", "step": 2, "ending": false, "pendingApprovals": [], "activeToolCalls": [], "since": "<time>" }, "background": [] }
       [wire] context.append_loop_event   { "event": { "type": "step.begin", "uuid": "<uuid-4>", "turnId": "0", "step": 2 }, "time": "<time>" }

--- a/packages/agent-core-v2/test/features/plan/plan.test.ts
+++ b/packages/agent-core-v2/test/features/plan/plan.test.ts
@@ -718,6 +718,7 @@ describe('Plan service', () => {
         [wire] turn.prompt                 { "input": [ { "type": "text", "text": "Inspect without mutating files" } ], "origin": { "kind": "user" }, "time": "<time>" }
         [emit] turn.started                { "time": "<time>", "turnId": 0, "origin": { "kind": "user" }, "prompt": "Inspect without mutating files" }
         [emit] agent.activity.updated      { "time": "<time>", "lifecycle": "ready", "turn": { "turnId": 0, "origin": { "kind": "user" }, "phase": "running", "step": 0, "ending": false, "pendingApprovals": [], "activeToolCalls": [], "since": "<time>" }, "background": [] }
+        [wire] model.snapshot              { "alias": "mock-model", "record": { "provider": "test-provider", "model": "mock-model", "maxContextSize": 1000000, "capabilities": [] }, "time": "<time>" }
         [emit] context.spliced             { "time": "<time>", "start": 0, "deleteCount": 0, "messages": [ { "role": "user", "content": [ { "type": "text", "text": "Inspect without mutating files" } ], "toolCalls": [], "origin": { "kind": "user" }, "id": "<msg-1>" } ] }
         [wire] context.append_message      { "message": { "role": "user", "content": [ { "type": "text", "text": "Inspect without mutating files" } ], "toolCalls": [], "origin": { "kind": "user" }, "id": "<msg-1>" }, "time": "<time>" }
         [wire] plugin.session_start        { "content": null, "time": "<time>" }
@@ -798,6 +799,7 @@ describe('Plan service', () => {
         [wire] turn.prompt                 { "input": [ { "type": "text", "text": "Remove forbidden.txt" } ], "origin": { "kind": "user" }, "time": "<time>" }
         [emit] turn.started                { "time": "<time>", "turnId": 0, "origin": { "kind": "user" }, "prompt": "Remove forbidden.txt" }
         [emit] agent.activity.updated      { "time": "<time>", "lifecycle": "ready", "turn": { "turnId": 0, "origin": { "kind": "user" }, "phase": "running", "step": 0, "ending": false, "pendingApprovals": [], "activeToolCalls": [], "since": "<time>" }, "background": [] }
+        [wire] model.snapshot              { "alias": "mock-model", "record": { "provider": "test-provider", "model": "mock-model", "maxContextSize": 1000000, "capabilities": [] }, "time": "<time>" }
         [emit] context.spliced             { "time": "<time>", "start": 0, "deleteCount": 0, "messages": [ { "role": "user", "content": [ { "type": "text", "text": "Remove forbidden.txt" } ], "toolCalls": [], "origin": { "kind": "user" }, "id": "<msg-1>" } ] }
         [wire] context.append_message      { "message": { "role": "user", "content": [ { "type": "text", "text": "Remove forbidden.txt" } ], "toolCalls": [], "origin": { "kind": "user" }, "id": "<msg-1>" }, "time": "<time>" }
         [wire] plugin.session_start        { "content": null, "time": "<time>" }

--- a/packages/agent-core-v2/test/index.test.ts
+++ b/packages/agent-core-v2/test/index.test.ts
@@ -75,6 +75,7 @@ const V1_RECORD_TYPES: ReadonlySet<string> = new Set([
 const V2_ONLY_RECORD_TYPES: ReadonlySet<string> = new Set([
   'tools.reset_active_tools',
   'profile.bind',
+  'model.snapshot',
 ]);
 
 const V2_RECORD_TYPES: ReadonlySet<string> = new Set([

--- a/packages/agent-core-v2/test/kosong/model/catalog.test.ts
+++ b/packages/agent-core-v2/test/kosong/model/catalog.test.ts
@@ -1354,3 +1354,102 @@ describe('ModelCatalog setDefaultModel', () => {
     }
   });
 });
+
+describe('ModelCatalog record-based assembly', () => {
+  const ghostRecord: ModelRecord = {
+    provider: 'kimi',
+    model: 'kimi-k2-ghost',
+    maxContextSize: 131_072,
+  };
+
+  it('builds a model from an explicit record while reading provider data live', async () => {
+    const { host, catalog } = createHost(kimiSections);
+    try {
+      const model = catalog.getFromRecord('ghost', ghostRecord);
+      expect(model.name).toBe('kimi-k2-ghost');
+      expect(model.providerName).toBe('kimi');
+      expect(model.baseUrl).toBe('https://api.moonshot.ai/v1');
+      expect(model.maxContextSize).toBe(131_072);
+      await expect(model.authProvider.getAuth()).resolves.toEqual({ apiKey: 'sk-test' });
+      expect(catalog.getRequesterFromRecord('ghost', ghostRecord).model).toBe(model);
+    } finally {
+      host.dispose();
+    }
+  });
+
+  it('rebuilds from live provider data after config changes clear the record cache', async () => {
+    const { host, catalog, providers } = createHost(kimiSections);
+    try {
+      const before = catalog.getFromRecord('ghost', ghostRecord);
+      expect(before.baseUrl).toBe('https://api.moonshot.ai/v1');
+
+      providers.loadAll(
+        { kimi: { type: 'kimi', apiKey: 'sk-rotated', baseUrl: 'https://rotated.example.test/v1' } },
+        undefined,
+      );
+
+      const after = catalog.getFromRecord('ghost', ghostRecord);
+      expect(after.baseUrl).toBe('https://rotated.example.test/v1');
+      await expect(after.authProvider.getAuth()).resolves.toEqual({ apiKey: 'sk-rotated' });
+    } finally {
+      host.dispose();
+    }
+  });
+
+  it('throws config.invalid when the record references a missing provider', () => {
+    const { host, catalog } = createHost(kimiSections);
+    try {
+      let thrown: unknown;
+      try {
+        catalog.getFromRecord('ghost', { provider: 'gone', model: 'x', maxContextSize: 1024 });
+      } catch (error) {
+        thrown = error;
+      }
+      expect(thrown).toSatisfy((e) => isError2(e) && e.code === 'config.invalid');
+    } finally {
+      host.dispose();
+    }
+  });
+
+  it('keeps the record cache separate from the configured-alias cache', () => {
+    const { host, catalog } = createHost(kimiSections);
+    try {
+      const shadow = catalog.getFromRecord('k1', {
+        provider: 'kimi',
+        model: 'shadow-model',
+        maxContextSize: 64_000,
+      });
+      expect(shadow.name).toBe('shadow-model');
+      expect(catalog.get('k1').name).toBe('kimi-k2');
+    } finally {
+      host.dispose();
+    }
+  });
+
+  it('keys record-built entries by the supplied record', () => {
+    const { host, catalog } = createHost(kimiSections);
+    try {
+      const a = catalog.getFromRecord('ghost', {
+        provider: 'kimi',
+        model: 'model-a',
+        maxContextSize: 64_000,
+      });
+      const b = catalog.getFromRecord('ghost', {
+        provider: 'kimi',
+        model: 'model-b',
+        maxContextSize: 32_000,
+      });
+      expect(a.name).toBe('model-a');
+      expect(b.name).toBe('model-b');
+      expect(
+        catalog.getFromRecord('ghost', {
+          provider: 'kimi',
+          model: 'model-a',
+          maxContextSize: 64_000,
+        }),
+      ).toBe(a);
+    } finally {
+      host.dispose();
+    }
+  });
+});

--- a/packages/agent-core-v2/test/session/agentLifecycle/agentLifecycle.test.ts
+++ b/packages/agent-core-v2/test/session/agentLifecycle/agentLifecycle.test.ts
@@ -8,6 +8,7 @@ import { TestInstantiationService } from '#/_base/di/test';
 import { Event } from '#/_base/event';
 import { IAgentProfileService } from '#/agent/profile/profile';
 import '#/agent/profile/profileService';
+import '#/agent/modelSnapshot/modelSnapshotService';
 import { ProfileBind } from '#/agent/profile/profileOps';
 import { TOWER_WORKER_PROFILE } from '#/features/tower/tower';
 import { IAgentAgentsMdReminderService } from '#/agent/agentsMdReminder/agentsMdReminder';
@@ -27,6 +28,8 @@ import { IAgentContextInjectorService } from '#/agent/contextInjector/contextInj
 import { IAgentIdentity } from '#/app/agentIdentity/agentIdentity';
 import { IBuiltinAgentProfileLoader } from '#/app/agentProfileCatalog/builtinAgentProfileLoader';
 import { IModelCatalog } from '#/kosong/model/catalog';
+import { IModelService } from '#/kosong/model/model';
+import { IProviderService } from '#/kosong/provider/provider';
 import { IProtocolAdapterRegistry } from '#/kosong/protocol/protocol';
 import { IHostClock } from '#/os/interface/hostClock';
 import { ISessionStateService } from '#/session/state/sessionState';
@@ -354,6 +357,8 @@ describe('AgentLifecycleService', () => {
     ix.stub(IHostFileSystem, { _serviceBrand: undefined } as IHostFileSystem);
     ix.stub(IHostClock, { _serviceBrand: undefined } as IHostClock);
     ix.stub(IModelCatalog, { _serviceBrand: undefined } as IModelCatalog);
+    ix.stub(IModelService, { _serviceBrand: undefined } as IModelService);
+    ix.stub(IProviderService, { _serviceBrand: undefined } as IProviderService);
     ix.stub(IProtocolAdapterRegistry, {
       _serviceBrand: undefined,
     } as IProtocolAdapterRegistry);

--- a/packages/agent-core-v2/test/state/builtinReplayableKeys.ts
+++ b/packages/agent-core-v2/test/state/builtinReplayableKeys.ts
@@ -8,6 +8,7 @@ import { interruptionReminderKey } from '#/agent/interruptionReminder/interrupti
 import { llmRequestTraceKey } from '#/agent/llmRequester/llmRequestOps';
 import { turnKey } from '#/agent/loop/turnOps';
 import { mcpDiscoveryKey } from '#/agent/mcp/mcpDiscoveryOps';
+import { modelSnapshotsKey } from '#/agent/modelSnapshot/modelSnapshotOps';
 import {
   permissionModeConfiguredKey,
   permissionModeKey,
@@ -39,6 +40,7 @@ export const BUILTIN_REPLAYABLE_STATE_KEYS: readonly ReplayableStateKey<any>[] =
   llmRequestTraceKey,
   turnKey,
   mcpDiscoveryKey,
+  modelSnapshotsKey,
   permissionModeKey,
   permissionModeConfiguredKey,
   permissionRulesKey,

--- a/packages/agent-core-v2/test/tool/tool.test.ts
+++ b/packages/agent-core-v2/test/tool/tool.test.ts
@@ -3341,6 +3341,7 @@ describe('Agent tools', () => {
         [wire] turn.prompt                 { "input": [ { "type": "text", "text": "Look up moon" } ], "origin": { "kind": "user" }, "time": "<time>" }
         [emit] turn.started                { "time": "<time>", "turnId": 0, "origin": { "kind": "user" }, "prompt": "Look up moon" }
         [emit] agent.activity.updated      { "time": "<time>", "lifecycle": "ready", "turn": { "turnId": 0, "origin": { "kind": "user" }, "phase": "running", "step": 0, "ending": false, "pendingApprovals": [], "activeToolCalls": [], "since": "<time>" }, "background": [] }
+        [wire] model.snapshot              { "alias": "mock-model", "record": { "provider": "test-provider", "model": "mock-model", "maxContextSize": 1000000, "capabilities": [] }, "time": "<time>" }
         [emit] context.spliced             { "time": "<time>", "start": 0, "deleteCount": 0, "messages": [ { "role": "user", "content": [ { "type": "text", "text": "Look up moon" } ], "toolCalls": [], "origin": { "kind": "user" }, "id": "<msg-1>" } ] }
         [emit] context.spliced             { "time": "<time>", "start": 1, "deleteCount": 0, "messages": [ { "role": "user", "content": [ { "type": "text", "text": "<auto-mode-enter-reminder>" } ], "toolCalls": [], "origin": { "kind": "injection", "variant": "permission_mode" } } ] }
         [wire] context.append_message      { "message": { "role": "user", "content": [ { "type": "text", "text": "Look up moon" } ], "toolCalls": [], "origin": { "kind": "user" }, "id": "<msg-1>" }, "time": "<time>" }

--- a/packages/kap-server/test/fs.test.ts
+++ b/packages/kap-server/test/fs.test.ts
@@ -47,6 +47,12 @@ describe('server-v2 /api/v1 fs routes', () => {
       getRequester: () => {
         throw new Error('modelCatalog.getRequester not exercised in this test');
       },
+      getFromRecord: () => {
+        throw new Error('modelCatalog.getFromRecord not exercised in this test');
+      },
+      getRequesterFromRecord: () => {
+        throw new Error('modelCatalog.getRequesterFromRecord not exercised in this test');
+      },
       inspect: () => {
         throw new Error('modelCatalog.inspect not exercised in this test');
       },

--- a/packages/kap-server/test/messages.test.ts
+++ b/packages/kap-server/test/messages.test.ts
@@ -57,6 +57,12 @@ describe('server-v2 /api/v1/sessions/{sid}/messages', () => {
       getRequester: () => {
         throw new Error('modelCatalog.getRequester not exercised in this test');
       },
+      getFromRecord: () => {
+        throw new Error('modelCatalog.getFromRecord not exercised in this test');
+      },
+      getRequesterFromRecord: () => {
+        throw new Error('modelCatalog.getRequesterFromRecord not exercised in this test');
+      },
       inspect: () => {
         throw new Error('modelCatalog.inspect not exercised in this test');
       },

--- a/packages/kap-server/test/modelCatalog.test.ts
+++ b/packages/kap-server/test/modelCatalog.test.ts
@@ -267,6 +267,12 @@ describe('server-v2 /api/v1 model/provider catalog', () => {
       getRequester: () => {
         throw new Error('unused');
       },
+      getFromRecord: () => {
+        throw new Error('unused');
+      },
+      getRequesterFromRecord: () => {
+        throw new Error('unused');
+      },
       inspect: () => {
         throw new Error('unused');
       },

--- a/packages/kap-server/test/tasks.test.ts
+++ b/packages/kap-server/test/tasks.test.ts
@@ -59,6 +59,12 @@ describe('server-v2 /api/v1/sessions/{sid}/tasks', () => {
       getRequester: () => {
         throw new Error('modelCatalog.getRequester not exercised in this test');
       },
+      getFromRecord: () => {
+        throw new Error('modelCatalog.getFromRecord not exercised in this test');
+      },
+      getRequesterFromRecord: () => {
+        throw new Error('modelCatalog.getRequesterFromRecord not exercised in this test');
+      },
       inspect: () => {
         throw new Error('modelCatalog.inspect not exercised in this test');
       },

--- a/packages/kap-server/test/tools.test.ts
+++ b/packages/kap-server/test/tools.test.ts
@@ -51,6 +51,12 @@ describe('server-v2 /api/v1 tools + mcp', () => {
       getRequester: () => {
         throw new Error('modelCatalog.getRequester not exercised in this test');
       },
+      getFromRecord: () => {
+        throw new Error('modelCatalog.getFromRecord not exercised in this test');
+      },
+      getRequesterFromRecord: () => {
+        throw new Error('modelCatalog.getRequesterFromRecord not exercised in this test');
+      },
       inspect: () => {
         throw new Error('modelCatalog.inspect not exercised in this test');
       },

--- a/packages/kap-server/test/transcript.test.ts
+++ b/packages/kap-server/test/transcript.test.ts
@@ -125,6 +125,12 @@ describe('server-v2 /api/v1/sessions/{sid}/transcript', () => {
       getRequester: () => {
         throw new Error('modelCatalog.getRequester not exercised in this test');
       },
+      getFromRecord: () => {
+        throw new Error('modelCatalog.getFromRecord not exercised in this test');
+      },
+      getRequesterFromRecord: () => {
+        throw new Error('modelCatalog.getRequesterFromRecord not exercised in this test');
+      },
       inspect: () => {
         throw new Error('modelCatalog.inspect not exercised in this test');
       },


### PR DESCRIPTION
## Related Issue

No linked issue — the problem is described below.

## Problem

Providers configured with a `[source]` registry (e.g. `kind = "apiJson"`) refresh in the background and materialize the remote model catalog into `config.toml`, deleting aliases that disappeared upstream. That upstream catalog is unstable, so an alias a live session is bound to can vanish mid-session. Every turn re-resolves the alias against live config, so the next turn fails with `config.invalid` (`Model "<alias>" is not configured in config.toml`), and resuming or forking such a session fails the same way on its first turn — even though the provider entry (URL + credentials) is still perfectly usable.

## What changed

Sessions now keep working on a persisted per-agent snapshot of the resolved model configuration when the alias leaves config, as long as the provider entry itself remains:

- **Agent-scope snapshot**: new `agent/modelSnapshot` domain. After each successful passive model resolution, the agent persists a config-level mirror of the `[models."<alias>"]` record as a durable `model.snapshot` wire record folded into a replayable `modelSnapshot.records` state key. The mirror contains only scalar config fields — never `apiKey`, resolved headers, or auth material — and records ride along resume and fork through the normal wire copy. Models with an inline `apiKey` are never snapshotted, since their credentials cannot be rebuilt from a provider entry; those keep failing explicitly.
- **Record-based rebuild**: `IModelCatalog` gains `getFromRecord` / `getRequesterFromRecord`, reusing the existing build pipeline with an explicit record while reading base URL, credentials, and headers from the live provider. Fallback entries use a separate cache invalidated on config change, so explicit binds against a deleted alias (new-session create, `--model`) still fail loud, and hot-reload semantics (`/model`, `/reload`, provider refresh updates, OAuth rotation) are unaffected.
- **Passive resolution fallback**: `profileService.resolveModelContext` and `llmRequesterService.resolveRequest` resolve through the snapshot service — live config first, snapshot only when the error is "alias not configured", a snapshot exists, and the referenced provider is still configured. On fallback the session emits a one-time warning through the existing session-warnings channel. If the provider entry is gone too, the turn keeps failing with `config.invalid`.
- The `[secondary_model]` pool pre-flight stays fail-loud by design.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.
