### PR TITLE
feat(tui): send native Windows toast notifications in Windows Terminal

### DIFF
--- a/.changeset/great-donkeys-toast.md
+++ b/.changeset/great-donkeys-toast.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Send native Windows toast notifications when running in Windows Terminal.

--- a/apps/kimi-code/src/tui/utils/terminal-notification.ts
+++ b/apps/kimi-code/src/tui/utils/terminal-notification.ts
@@ -1,3 +1,5 @@
+import { execFile } from 'node:child_process';
+
 import type { Terminal } from '@moonshot-ai/pi-tui';
 
 import { BEL, ESC, MAX_TERMINAL_NOTIFICATION_MESSAGE_LENGTH, ST } from '#/tui/constant/terminal';
@@ -11,6 +13,7 @@ export interface TerminalNotification {
 export interface EmitOptions {
   readonly supportsOsc9?: boolean;
   readonly insideTmux?: boolean;
+  readonly windowsTerminal?: boolean;
 }
 
 export interface BuildOptions {
@@ -39,12 +42,22 @@ export function emitTerminalNotification(
   notification: TerminalNotification,
   options: EmitOptions = {},
 ): void {
+  const supportsOsc9 = options.supportsOsc9 ?? supportsOsc9Notification();
   const sequences = buildTerminalNotificationSequences(notification, {
-    supportsOsc9: options.supportsOsc9 ?? supportsOsc9Notification(),
+    supportsOsc9,
     insideTmux: options.insideTmux ?? isInsideTmux(),
   });
   for (const sequence of sequences) {
     terminal.write(sequence);
+  }
+  // Windows Terminal does not support OSC 9 (its OSC 9 is taken by ConEmu
+  // progress semantics), so on the BEL fallback path we additionally pop a
+  // native toast. The BEL stays as a generic audible fallback.
+  if (!supportsOsc9 && (options.windowsTerminal ?? isWindowsTerminalSession())) {
+    const message = formatNotification(notification);
+    if (message.length > 0) {
+      sendWindowsToast(message);
+    }
   }
 }
 
@@ -132,6 +145,59 @@ export function supportsTerminalProgress(env: NodeJS.ProcessEnv = process.env): 
 export function isInsideTmux(env: NodeJS.ProcessEnv = process.env): boolean {
   const tmux = env['TMUX'] ?? '';
   return tmux.length > 0;
+}
+
+/**
+ * Detect Windows Terminal via the `WT_SESSION` variable it always sets.
+ * Deliberately env-only: under WSL `process.platform` is `linux` but
+ * `WT_SESSION` is still inherited and `powershell.exe` works via interop.
+ */
+export function isWindowsTerminalSession(env: NodeJS.ProcessEnv = process.env): boolean {
+  return (env['WT_SESSION'] ?? '').length > 0;
+}
+
+const WINDOWS_TOAST_NOTIFIER_ID = 'Kimi Code';
+
+/**
+ * Build the `powershell.exe` invocation that pops a native WinRT toast.
+ *
+ * Ported from pi-notify (MIT, https://github.com/ferologics/pi-notify),
+ * with two fixes over the original: the message is single-quote escaped
+ * before being interpolated into the script, and the caller swallows all
+ * spawn errors (see `sendWindowsToast`). The toast uses the single-text
+ * ToastText01 template; `CreateTextNode` escapes XML for us. The notifier
+ * id (AUMID) is the fixed string 'Kimi Code', so toasts carry no app
+ * registration and no click callback.
+ */
+export function buildWindowsToastCommand(message: string): { file: string; args: string[] } {
+  const type = 'Windows.UI.Notifications';
+  const mgr = `[${type}.ToastNotificationManager, ${type}, ContentType = WindowsRuntime]`;
+  const template = `[${type}.ToastTemplateType]::ToastText01`;
+  const escaped = message.replaceAll("'", "''");
+  const script = [
+    `${mgr} > $null`,
+    `$xml = [${type}.ToastNotificationManager]::GetTemplateContent(${template})`,
+    `$xml.GetElementsByTagName('text')[0].AppendChild($xml.CreateTextNode('${escaped}')) > $null`,
+    `[${type}.ToastNotificationManager]::CreateToastNotifier('${WINDOWS_TOAST_NOTIFIER_ID}').Show([${type}.ToastNotification]::new($xml))`,
+  ].join('; ');
+  return { file: 'powershell.exe', args: ['-NoProfile', '-NonInteractive', '-Command', script] };
+}
+
+/**
+ * Fire-and-forget toast delivery: spawn without waiting, swallow every
+ * error (a missing `powershell.exe` must never crash the TUI), and unref
+ * the child so it can't keep the process alive.
+ */
+export function sendWindowsToast(message: string): void {
+  try {
+    const { file, args } = buildWindowsToastCommand(message);
+    const child = execFile(file, args, () => {
+      // Intentionally empty: delivery errors are not actionable here.
+    });
+    child.unref();
+  } catch {
+    // Notification delivery must never take down the TUI.
+  }
 }
 
 function sanitizeNotificationText(value: string): string {

--- a/apps/kimi-code/test/tui/terminal-notification.test.ts
+++ b/apps/kimi-code/test/tui/terminal-notification.test.ts
@@ -1,11 +1,22 @@
-import { describe, expect, it, vi } from 'vitest';
+/* eslint-disable import/first -- vi.mock setup must run before the imports it stubs out. */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  execFile: vi.fn(),
+}));
+
+vi.mock('node:child_process', () => ({
+  execFile: mocks.execFile,
+}));
 
 import type { TUIState } from '#/tui/kimi-tui';
 import {
   buildTerminalNotificationSequences,
+  buildWindowsToastCommand,
   emitTerminalNotification,
   formatNotification,
   isInsideTmux,
+  isWindowsTerminalSession,
   notifyTerminalOnce,
   supportsOsc9Notification,
   supportsTerminalProgress,
@@ -250,5 +261,115 @@ describe('isInsideTmux', () => {
   it('returns false when TMUX is empty or unset', () => {
     expect(isInsideTmux({ TMUX: '' })).toBe(false);
     expect(isInsideTmux({})).toBe(false);
+  });
+});
+
+describe('isWindowsTerminalSession', () => {
+  it('detects Windows Terminal via the WT_SESSION env var', () => {
+    expect(isWindowsTerminalSession({ WT_SESSION: 'abc-123' })).toBe(true);
+  });
+
+  it('returns false when WT_SESSION is empty or unset', () => {
+    expect(isWindowsTerminalSession({ WT_SESSION: '' })).toBe(false);
+    expect(isWindowsTerminalSession({})).toBe(false);
+  });
+});
+
+describe('buildWindowsToastCommand', () => {
+  it('targets powershell.exe with a non-interactive -Command script', () => {
+    const { file, args } = buildWindowsToastCommand('Kimi Code: Approval required');
+
+    expect(file).toBe('powershell.exe');
+    expect(args.slice(0, 3)).toEqual(['-NoProfile', '-NonInteractive', '-Command']);
+    const script = args[3]!;
+    expect(script).toContain('ToastTemplateType]::ToastText01');
+    expect(script).toContain("CreateToastNotifier('Kimi Code')");
+    expect(script).toContain("CreateTextNode('Kimi Code: Approval required')");
+  });
+
+  it('escapes single quotes in the message for the PowerShell script', () => {
+    const { args } = buildWindowsToastCommand("it's done");
+
+    expect(args[3]).toContain("CreateTextNode('it''s done')");
+  });
+});
+
+describe('Windows Terminal toast notifications', () => {
+  beforeEach(() => {
+    mocks.execFile.mockReset();
+    mocks.execFile.mockReturnValue({ unref: vi.fn() });
+  });
+
+  it('spawns a toast alongside BEL in Windows Terminal without OSC 9', () => {
+    const terminal = { write: vi.fn() };
+
+    emitTerminalNotification(
+      terminal,
+      { title: 'Kimi Code', body: 'Approval required' },
+      { supportsOsc9: false, insideTmux: false, windowsTerminal: true },
+    );
+
+    expect(terminal.write).toHaveBeenCalledTimes(1);
+    expect(terminal.write).toHaveBeenCalledWith('\u0007');
+    expect(mocks.execFile).toHaveBeenCalledTimes(1);
+    const [file, args] = mocks.execFile.mock.calls[0]!;
+    expect(file).toBe('powershell.exe');
+    expect(args[3]).toContain("CreateTextNode('Kimi Code: Approval required')");
+  });
+
+  it('does not spawn a toast when OSC 9 is supported', () => {
+    const terminal = { write: vi.fn() };
+
+    emitTerminalNotification(
+      terminal,
+      { title: 'Kimi Code', body: 'Approval required' },
+      { supportsOsc9: true, insideTmux: false, windowsTerminal: true },
+    );
+
+    expect(mocks.execFile).not.toHaveBeenCalled();
+  });
+
+  it('does not spawn a toast outside Windows Terminal', () => {
+    const terminal = { write: vi.fn() };
+
+    emitTerminalNotification(
+      terminal,
+      { title: 'Kimi Code', body: 'Approval required' },
+      { supportsOsc9: false, insideTmux: false, windowsTerminal: false },
+    );
+
+    expect(terminal.write).toHaveBeenCalledWith('\u0007');
+    expect(mocks.execFile).not.toHaveBeenCalled();
+  });
+
+  it('swallows errors passed to the execFile callback', () => {
+    const terminal = { write: vi.fn() };
+    mocks.execFile.mockImplementation(
+      (_file: string, _args: string[], callback: (error: Error | null) => void) => {
+        callback(new Error('spawn powershell.exe ENOENT'));
+        return { unref: vi.fn() };
+      },
+    );
+
+    expect(() => {
+      emitTerminalNotification(
+        terminal,
+        { title: 'Kimi Code', body: 'Approval required' },
+        { supportsOsc9: false, insideTmux: false, windowsTerminal: true },
+      );
+    }).not.toThrow();
+  });
+
+  it('does not spawn a toast for an empty message', () => {
+    const terminal = { write: vi.fn() };
+
+    emitTerminalNotification(
+      terminal,
+      { title: '', body: '' },
+      { supportsOsc9: false, insideTmux: false, windowsTerminal: true },
+    );
+
+    expect(terminal.write).not.toHaveBeenCalled();
+    expect(mocks.execFile).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Problem

Desktop notifications in the TUI are delivered via OSC 9 escape sequences, gated on a small allow-list (iTerm2 / WezTerm / Ghostty / Warp / Kitty). Every other terminal only gets a bare BEL. Windows Terminal does not support OSC 9 desktop notifications — its OSC 9 is taken by ConEmu progress semantics — so Windows Terminal users never get a visual notification when a task completes or approval is needed; they only get the bell.

## Fix

When the session is Windows Terminal (`WT_SESSION` is set) and OSC 9 is not supported, the BEL fallback path now additionally fires a native Windows toast via the system `powershell.exe` (WinRT `Windows.UI.Notifications`, `ToastText01` template, notifier id `Kimi Code`). The spawn is fire-and-forget: `execFile` with an error-swallowing callback, wrapped in try/catch, and `unref`ed — notification delivery can never crash or hang the TUI.

Ported from the MIT-licensed [pi-notify](https://github.com/ferologics/pi-notify) (credited in code comments), with two fixes over the original:

- the notification text is single-quote escaped (`'` → `''`) before being interpolated into the PowerShell script;
- `execFile` gets an error callback (the original passes none, so a missing `powershell.exe` would raise an unhandled error and crash the process).

No new npm dependencies, no binaries.

## Design trade-offs

- **WT only.** The OSC 9 path is completely untouched, and we do not pre-send OSC 777 to Windows Terminal — if WT ever grows OSC 9/777 notification support, users won't get double notifications.
- **BEL stays** as the generic audible fallback: a double sound is preferable to no notification.
- **Env-only detection** (`WT_SESSION` non-empty, no `process.platform` check): under WSL, `process.platform` is `linux` but `WT_SESSION` is inherited and `powershell.exe` works via interop.
- **No click callback / AUMID registration**: the toast uses the fixed notifier id `Kimi Code` and the single-text `ToastText01` template; XML injection is a non-issue since `CreateTextNode` escapes for us.

## Tests

New cases in `apps/kimi-code/test/tui/terminal-notification.test.ts`:

- `isWindowsTerminalSession` detection with and without `WT_SESSION`
- `buildWindowsToastCommand` shape (`powershell.exe -NoProfile -NonInteractive -Command …`, `ToastText01`, notifier id `Kimi Code`) and single-quote escaping
- `emitTerminalNotification` (with `node:child_process` `execFile` mocked): WT + no OSC 9 → BEL written **and** toast spawned; WT + OSC 9 → no spawn; non-WT + no OSC 9 → no spawn; `execFile` callback invoked with an `Error` → no throw; empty message → no spawn

Local results: `vitest run test/tui/terminal-notification.test.ts` — 31/31 passed; `tsc --noEmit` typecheck clean; `oxlint --type-aware` on the changed files reports 0 warnings / 0 errors.

On-Windows verification (actual toast rendering in Windows Terminal) will be done by maintainer 瑞丰.
