### PR TITLE
feat(agent-core-v2): include the prompt in turn.started for goal continuations

### DIFF
--- a/packages/agent-core-v2/src/agent/loop/turnEvents.ts
+++ b/packages/agent-core-v2/src/agent/loop/turnEvents.ts
@@ -42,6 +42,10 @@ export function turnPromptText(
 
 export function isDisplayablePromptOrigin(origin: PromptOrigin): boolean {
   if (origin.kind === 'user') return true;
+  // Goal continuations surface as a visible prompt bubble in chat UIs (like a
+  // cron fire), so the prompt text must travel with turn.started for the live
+  // view to render it — history already carries it on the persisted message.
+  if (origin.kind === 'system_trigger') return origin.name === 'goal_continuation';
   return (
     (origin.kind === 'skill_activation' || origin.kind === 'plugin_command') &&
     origin.trigger === 'user-slash'

--- a/packages/agent-core-v2/test/agent/loop/loop.test.ts
+++ b/packages/agent-core-v2/test/agent/loop/loop.test.ts
@@ -758,15 +758,16 @@ describe('Agent loop', () => {
     );
   });
 
-  it('omits the turn.started prompt for system-triggered turns', async () => {
+  it('omits the turn.started prompt for system-triggered turns except goal continuations', async () => {
     const prompts: Array<string | undefined> = [];
     const subscription = ctx.get(IEventBus).subscribe(TurnStarted, (event) => {
       prompts.push(event.prompt);
     });
     ctx.mockNextResponse({ type: 'text', text: 'continued' });
+    ctx.mockNextResponse({ type: 'text', text: 'subagent work' });
     ctx.mockNextResponse({ type: 'text', text: 'hi there' });
 
-    const system = (
+    const goal = (
       await loop.enqueue(
         new MessageStepRequest(
           {
@@ -779,12 +780,28 @@ describe('Agent loop', () => {
         ),
       ).assigned
     ).turn;
-    await system.result;
+    await goal.result;
+    const subagent = (
+      await loop.enqueue(
+        new MessageStepRequest(
+          {
+            role: 'user',
+            content: [{ type: 'text', text: 'subagent hidden prompt' }],
+            toolCalls: [],
+            origin: { kind: 'system_trigger', name: 'subagent' },
+          },
+          { admission: 'newTurn' },
+        ),
+      ).assigned
+    ).turn;
+    await subagent.result;
     const user = (await loop.enqueue(nextTurnMessage('hi')).assigned).turn;
     await user.result;
     subscription.dispose();
 
-    expect(prompts).toEqual([undefined, 'hi']);
+    // Goal continuations carry their prompt (chat UIs render it as a visible
+    // bubble, like a cron fire); other system triggers stay hidden.
+    expect(prompts).toEqual(['continue the goal', undefined, 'hi']);
   });
 });
 


### PR DESCRIPTION
## Why

The chat UI (kimi-code-app) renders a goal-continuation prompt as a visible right-side bubble, like a cron fire (MoonshotAI/kimi-code-app#273). The live view builds that bubble from the `turn.started` event — but `turn.started.prompt` is gated by `isDisplayablePromptOrigin`, which hides every system trigger, so live the bubble has no text and the raw prompt only appears after a reload (the persisted trigger message always carried it).

## What

`isDisplayablePromptOrigin` now also returns true for `{ kind: 'system_trigger', name: 'goal_continuation' }` — only goal continuations; every other system trigger (subagent etc.) keeps its prompt hidden.

The TUI does not consume `turn.started.prompt` for these turns (verified: `handleTurnBegin` ignores it), and the kap-server transcript projection is unchanged, so behavior elsewhere is unaffected.

## Tests

Updated the loop test that pinned prompt omission: it now asserts goal continuations carry their prompt while other system triggers stay hidden. `loop.test.ts` 45/45, `goal.test.ts` + `resume.test.ts` 132/132.

No changeset: no CLI-user-visible change (the payload addition only feeds the desktop/web UI).