### PR TITLE
fix(agent-core-v2): register needs-auth MCP authenticate tool regardless of settle timing

### DIFF
--- a/.changeset/mcp-oauth-authenticate-tool.md
+++ b/.changeset/mcp-oauth-authenticate-tool.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Fix the missing OAuth authenticate tool for remote MCP servers that require login.

--- a/packages/agent-core-v2/src/workspace/workspaceMcp/workspaceMcpService.ts
+++ b/packages/agent-core-v2/src/workspace/workspaceMcp/workspaceMcpService.ts
@@ -156,24 +156,33 @@ export class WorkspaceMcpService extends Disposable implements IWorkspaceMcpServ
     ready: Promise<void>,
     extra?: readonly string[],
   ): (name: string) => boolean {
-    const baseline = new Set<string>(extra);
-    for (const entry of view.list()) {
-      baseline.add(entry.name);
-    }
+    let baseline: Set<string> | undefined;
     let frozen = false;
+    const snapshot = (): Set<string> => {
+      if (baseline === undefined) {
+        baseline = new Set<string>(extra);
+        for (const entry of view.list()) {
+          baseline.add(entry.name);
+        }
+      }
+      return baseline;
+    };
     void ready.then(
       () => {
+        snapshot();
         frozen = true;
       },
       () => {
+        snapshot();
         frozen = true;
       },
     );
     return (name) => {
-      if (baseline.has(name)) return true;
+      const names = snapshot();
+      if (names.has(name)) return true;
       if (frozen) return false;
       if (view.get(name) === undefined) return false;
-      baseline.add(name);
+      names.add(name);
       return true;
     };
   }

--- a/packages/agent-core-v2/test/agent/mcp/mcp.test.ts
+++ b/packages/agent-core-v2/test/agent/mcp/mcp.test.ts
@@ -1207,6 +1207,34 @@ describe('AgentMcpService', () => {
     ]);
   });
 
+  it('registers the synthetic authenticate tool for a server that settled needs-auth before attach', () => {
+    const oauthService = {
+      beginAuthorization: async () => ({
+        authorizationUrl: new URL('https://example.com/authorize'),
+        complete: async () => {},
+        cancel: async () => {},
+      }),
+    } as unknown as McpOAuthService;
+    const manager = new FakeMcpManager({ oauthService });
+    manager.needsAuth();
+
+    createService(manager);
+
+    const tools = ix.get(IAgentToolRegistryService).list();
+    expect(tools).toEqual([
+      expect.objectContaining({
+        name: 'mcp__needs-auth__authenticate',
+        source: 'mcp',
+      }),
+    ]);
+    expect(events).toContainEqual(
+      expect.objectContaining({
+        type: 'mcp.server.status',
+        server: expect.objectContaining({ name: 'needs-auth', status: 'needs-auth' }),
+      }),
+    );
+  });
+
   it('keeps tools registered when a connected server fails so later calls can heal', async () => {
     const manager = new FakeMcpManager();
     const client = fakeMcpClient();

--- a/packages/agent-core-v2/test/workspace/workspaceMcp/workspaceMcp.test.ts
+++ b/packages/agent-core-v2/test/workspace/workspaceMcp/workspaceMcp.test.ts
@@ -33,7 +33,7 @@ import { IWorkspaceMcpService, type ISessionMcpOverlay } from '#/workspace/works
 import { WorkspaceMcpService } from '#/workspace/workspaceMcp/workspaceMcpService';
 
 import { stubLog } from '../../_base/log/stubs';
-import { createMemoryMcpOAuthStore, stdioFixture } from '../../mcpCore/stubs';
+import { createMemoryMcpOAuthStore, startInProcessHttpMcpServer, stdioFixture } from '../../mcpCore/stubs';
 import { registerAgentIdentityStub } from '../../app/agentIdentity/stubs';
 
 function stdioServer(): McpServerConfig {
@@ -214,6 +214,35 @@ describe('WorkspaceMcpService', () => {
     expect(handle.isBaselineServer('alpha')).toBe(true);
 
     expect(service.sessionHandle().isBaselineServer('late')).toBe(true);
+  }, 20000);
+
+  it('sessionHandle admits servers that finished the initial load before the first baseline read', async () => {
+    current = { alpha: stdioServer() };
+    const service = createService();
+    manager = service.connectionManager();
+    const handle = service.sessionHandle();
+
+    await service.ready;
+    expect(manager.get('alpha')?.status).toBe('connected');
+
+    expect(handle.isBaselineServer('alpha')).toBe(true);
+  }, 20000);
+
+  it('sessionHandle admits a needs-auth server that settled before the first baseline read', async () => {
+    const server = await startInProcessHttpMcpServer({ authToken: 'secret' });
+    try {
+      current = { remote: { transport: 'http', url: server.url } };
+      const service = createService();
+      manager = service.connectionManager();
+      const handle = service.sessionHandle();
+
+      await service.ready;
+      expect(manager.get('remote')?.status).toBe('needs-auth');
+
+      expect(handle.isBaselineServer('remote')).toBe(true);
+    } finally {
+      await server.close();
+    }
   }, 20000);
 
   it('sessionOverlay marks the ephemeral server names as baseline by construction', async () => {


### PR DESCRIPTION
## Related Issue

No linked issue — the problem is explained below.

## Problem

Since #2627 (`f881cdd970`) made the CLI default to the agent-core-v2 engine, headless runs can permanently lose the synthetic `mcp__<server>__authenticate` tool for remote (streamable-http) MCP servers that answer `initialize` with 401.

Reproduction (deterministic in clean environments): configure a localhost streamable-http MCP server that replies 401 immediately, start a headless run with a fresh HOME, and inspect the first chat-completions request — `mcp__<server>__authenticate` is absent, and no later request ever gains it. The server status itself is still computed correctly (`needs-auth` shows in the client log); only the tool registration is lost. Delaying the 401 response by ~800ms, or slowing startup down (populated HOME), makes the tool appear — it is a startup-timing race. Fast-401 (localhost) MCP servers in headless mode hit it every time; slower setups mask it.

## What changed

**Root cause.** `WorkspaceMcpService.sessionBaseline()` snapshotted the baseline server set eagerly when the session handle was created and froze it when the workspace MCP `ready` promise resolved. `AgentMcpService` (Agent scope) attaches later: its initial `attachMcpTools()` pass replays already-settled entries from `list()`, but `handleMcpServerStatusChange` drops any entry that fails the `isBaselineServer` gate. When the 401 settled before the session's agent attached — i.e. the status-change event fired before anyone subscribed and `ready` resolved before the first `isBaselineServer` call — the entry was neither in the eager snapshot nor admissible via the pre-freeze lazy-add path, so the gate rejected it at replay time and nothing ever retried. The same hole also swallowed fast-*connecting* servers (their real tools never registered either), and it would have blocked the post-OAuth `reconnect` events for the same reason.

**Fix.** `sessionBaseline` now takes the snapshot lazily — at the first `isBaselineServer` read, or when the baseline freezes at `ready`, whichever comes first. Any server that completed the initial load before the freeze is therefore admitted (mid-session additions still land after the initial connect via the mutation tail, so they stay excluded, exactly as #2702 pinned). The gate semantics for live status events are unchanged.

**Regression coverage** (both fail before, pass after):

- `test/workspace/workspaceMcp/workspaceMcp.test.ts`: a session handle created before the initial load runs still admits a server that settled `connected`, and one that settled `needs-auth` (real in-process 401 HTTP MCP server), before the first baseline read.
- `test/agent/mcp/mcp.test.ts`: a server that reached `needs-auth` before `AgentMcpService` attached still gets `mcp__<name>__authenticate` registered on the initial replay pass.

**Validation.**

- `pnpm --filter @moonshot-ai/agent-core-v2 test` — 330 files / 5302 tests pass; typecheck and `lint:imports` clean.
- Black-box evidence: the regression was caught and verified with the `mcp-oauth-needs-auth` scenario from the `kimi-code-release-e2e` release harness. Without this change it fails with `provider tool names did not include "mcp__oauth_fixture__authenticate"`; with this change the scenario passes end-to-end.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.
