### PR TITLE
feat(agent-core-v2): report the bound model alias in subagent_created telemetry

### DIFF
--- a/packages/agent-core-v2/src/app/telemetry/events.ts
+++ b/packages/agent-core-v2/src/app/telemetry/events.ts
@@ -345,6 +345,7 @@ export interface SubagentCreatedEvent {
   agent_id: string;
   parent_agent_id: string;
   parent_tool_call_id: string;
+  model?: string;
 }
 
 export interface McpConnectedEvent {
@@ -848,6 +849,7 @@ export const telemetryEventDefinitions = {
       agent_id: 'Child agent id',
       parent_agent_id: 'Parent (caller) agent id',
       parent_tool_call_id: "Tool call id of the launching call in the parent agent; '' when not launched from a tool call",
+      model: 'Model alias the subagent binds to (secondary-model choice or inherited caller model); omitted when no binding was resolved',
     },
   }),
   mcp_connected: defineTelemetryEvent<McpConnectedEvent>({

--- a/packages/agent-core-v2/src/session/subagent/mirrorAgentRun.ts
+++ b/packages/agent-core-v2/src/session/subagent/mirrorAgentRun.ts
@@ -6,6 +6,7 @@ import { IAgentProfileService } from '#/agent/profile/profile';
 import { isProviderRateLimitError } from '#/kosong/contract/errors';
 import { type TokenUsage } from '#/kosong/contract/usage';
 import { ITelemetryService } from '#/app/telemetry/telemetry';
+import type { SubagentCreatedEvent } from '#/app/telemetry/events';
 import { Event2 } from '#/app/event/event2';
 import { isAbortError } from '#/_base/utils/abort';
 import { IAgentLifecycleService } from '#/session/agentLifecycle/agentLifecycle';
@@ -114,13 +115,15 @@ export function emitAgentRunSpawned(
     }),
   );
   childProfile?.republishStatus();
-  requester.accessor.get(ITelemetryService)?.track2('subagent_created', {
+  const telemetryEvent: SubagentCreatedEvent = {
     subagent_name: meta.profileName,
     run_in_background: meta.runInBackground ?? false,
     agent_id: targetAgentId,
     parent_agent_id: requester.id,
     parent_tool_call_id: meta.parentToolCallId ?? '',
-  });
+    model: meta.model,
+  };
+  requester.accessor.get(ITelemetryService)?.track2('subagent_created', telemetryEvent);
 }
 
 export async function mirrorAgentRun(

--- a/packages/agent-core-v2/test/tool/tool.test.ts
+++ b/packages/agent-core-v2/test/tool/tool.test.ts
@@ -1532,6 +1532,7 @@ describe('Agent tool execution contract', () => {
         agent_id: 'agent-child',
         parent_agent_id: 'main',
         parent_tool_call_id: 'call_agent',
+        model: 'provider/secondary',
       },
     });
     expect(events.find((event) => event.type === 'subagent.completed')).toMatchObject({


### PR DESCRIPTION
## Related Issue

None — the problem is explained in the next section.

## Problem

The `secondary-model` experiment routes subagent calls to a separately configured model, but telemetry cannot attribute those calls: `subagent_created` reported only ids and the profile name, and the only event carrying a model identity is `api_error`, which fires on failures alone. Secondary-model adoption and per-model subagent behavior (latency, error rate) were not measurable.

## What changed

- `subagent_created` now carries an optional `model` property: the model alias the subagent binds to (the secondary-model choice or the inherited caller model), taken from the same spawn metadata that already feeds the `SubagentSpawned` domain event; omitted when no binding was resolved.
- Registered the property in the telemetry event registry (`events.ts`) and extended the existing `emitAgentRunSpawned` test to assert it.

Downstream, joining on `agent_id` attributes the subagent's `turn_started` / `turn_ended` / `api_error` events to the bound model.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.
