### PR TITLE
docs: document KIMI_CODE_CUSTOM_HEADERS on the env vars page

### DIFF
--- a/docs/en/configuration/env-vars.md
+++ b/docs/en/configuration/env-vars.md
@@ -36,6 +36,22 @@ export KIMI_DISABLE_TELEMETRY=1
 
 Switch models temporarily without modifying `config.toml` — when `KIMI_MODEL_NAME` is set, the CLI synthesizes a temporary provider in memory; the change does not persist after restart. See [Define a model from environment variables](#define-a-model-from-environment-variables-kimi-model).
 
+### `KIMI_CODE_CUSTOM_HEADERS`
+
+Attaches custom HTTP headers to every outbound model request — both LLM chat requests (across all provider protocols) and `/models` listing requests. Useful when a gateway routes by header, for example to pin a specific cluster:
+
+```sh
+export KIMI_CODE_CUSTOM_HEADERS=$'x-msh-certain-provider: my-cluster\nX-Custom-Tag: debug'
+```
+
+The format mirrors `ANTHROPIC_CUSTOM_HEADERS`: newline-separated `Name: Value` lines. Names and values are trimmed, and lines without a colon are ignored.
+
+::: info Added
+Added in 0.2.0.
+:::
+
+> This is the lowest-precedence header layer — headers of the same name are overridden by the Kimi identity headers (`User-Agent`, `X-Msh-*`), by a provider's `custom_headers` in `config.toml` (see [Config files](./config-files.md#providers)), and by request auth (`Authorization`), so it cannot be used to change authentication. Use `custom_headers` when headers need to differ per provider.
+
 ## Provider credential key names (written in config.toml)
 
 The key names below are not read directly from the shell — they are key names written inside the `[providers.<name>.env]` sub-table of `config.toml`, serving as fallback values for `api_key` / `base_url`. The CLI reads only from the config file, not from `process.env`.

--- a/docs/zh/configuration/env-vars.md
+++ b/docs/zh/configuration/env-vars.md
@@ -36,6 +36,22 @@ export KIMI_DISABLE_TELEMETRY=1
 
 不修改 `config.toml` 临时切换模型——设置 `KIMI_MODEL_NAME` 后，CLI 在内存里合成一个临时供应商，重启后失效。详见[用环境变量定义模型](#用环境变量定义模型-kimi-model)。
 
+### `KIMI_CODE_CUSTOM_HEADERS`
+
+为所有出站的模型请求附加自定义 HTTP 请求头——LLM 聊天请求（所有供应商协议）和 `/models` 模型列表请求都会携带。适合网关按请求头路由的场景，例如指定集群：
+
+```sh
+export KIMI_CODE_CUSTOM_HEADERS=$'x-msh-certain-provider: my-cluster\nX-Custom-Tag: debug'
+```
+
+格式与 `ANTHROPIC_CUSTOM_HEADERS` 一致：由换行分隔的 `Name: Value` 行，键名和值两端的空白会被去除，不含冒号的行会被忽略。
+
+::: info 新增
+新增于 0.2.0。
+:::
+
+> 这层请求头优先级最低——同名头会被 Kimi 身份头（`User-Agent`、`X-Msh-*`）、`config.toml` 里供应商的 `custom_headers`（见[配置文件](./config-files.md#providers)）以及认证头（`Authorization`）覆盖，因此不能用它修改认证信息。需要按供应商区分请求头时，请改用 `custom_headers`。
+
 ## 供应商凭证键（写在 config.toml 里）
 
 下面这些键名不是直接从 shell 读取的——它们是写在 `config.toml` 的 `[providers.<name>.env]` 子表里、作为 `api_key` / `base_url` 备用来源的键名。CLI 只从配置文件读取，不从 `process.env` 读取。


### PR DESCRIPTION
## Motivation

`KIMI_CODE_CUSTOM_HEADERS` shipped in 0.2.0 (see the [0.2.0 changelog entry](https://github.com/MoonshotAI/kimi-code/blob/main/docs/zh/release-notes/changelog.md)) but is not documented on the [environment variables page](https://www.kimi.com/code/docs/kimi-code-cli/configuration/env-vars.html). Users running Kimi Code behind a gateway that routes by request headers (e.g. setting `x-msh-certain-provider` to pin a cluster) have no docs page to discover the variable from.

## What changed

Adds a `KIMI_CODE_CUSTOM_HEADERS` entry under "Core paths" in both `docs/zh/configuration/env-vars.md` and `docs/en/configuration/env-vars.md`, covering:

- Purpose: attaches custom HTTP headers to every outbound model request — LLM chat requests (all provider protocols) and `/models` listing requests.
- Format: newline-separated `Name: Value` lines (mirrors `ANTHROPIC_CUSTOM_HEADERS`); names/values trimmed, lines without a colon ignored. Verified against `parseKimiCodeCustomHeaders` in `packages/oauth/src/identity.ts`.
- An example for the gateway-cluster scenario (`x-msh-certain-provider`).
- Precedence caveat: it is the lowest-precedence layer — same-name headers are overridden by the Kimi identity headers (`User-Agent`, `X-Msh-*`), a provider's `custom_headers` in `config.toml`, and request auth (`Authorization`), so it cannot change authentication. Verified against `toKosongProviderConfig` in `packages/agent-core/src/session/provider-manager.ts` and `resolveOutboundHeaders` in `packages/agent-core-v2/src/kosong/model/catalogService.ts`.
- `::: info Added` version block (0.2.0) per the docs authoring conventions.

Docs-only change; no changeset (matching recent docs-only PRs, e.g. #1582).
