### PR TITLE
refactor(kap-server): table-driven dispatch for multi-action routes

### DIFF
--- a/packages/agent-core-v2/src/app/sessionIndex/sessionIndexService.ts
+++ b/packages/agent-core-v2/src/app/sessionIndex/sessionIndexService.ts
@@ -344,6 +344,8 @@ export class FileSessionIndex extends Disposable implements ISessionIndex {
     generation: number,
     id: string,
   ): Promise<SessionSummary | undefined> {
+    const queued = this.mirror.pending().find((summary) => summary.id === id);
+    if (queued !== undefined) return queued;
     const cached: unknown = await this.queryStore.get(sessionCollection(generation), id);
     if (isSessionSummaryShape(cached)) return stripRecencyField(generation, cached);
     const summary = await this.getLegacy(id);

--- a/packages/agent-core-v2/src/app/sessionManager/sessionManager.ts
+++ b/packages/agent-core-v2/src/app/sessionManager/sessionManager.ts
@@ -1,6 +1,7 @@
 import { createDecorator, type ServiceIdentifier } from '#/_base/di/instantiation';
 import type { ISessionScopeHandle } from '#/_base/di/scope';
 import type { Event, IWaitUntil } from '#/_base/event';
+import type { SessionSummary } from '#/app/sessionIndex/sessionIndex';
 import type {
   CreateChildSessionOptions,
   CreateSessionOptions,
@@ -34,6 +35,7 @@ export interface ISessionManager {
   create(options: CreateManagedSessionOptions): Promise<ISessionScopeHandle>;
   resume(sessionId: string, options?: ResumeSessionOptions): Promise<ISessionScopeHandle | undefined>;
   get(sessionId: string): ISessionScopeHandle | undefined;
+  status(sessionId: string): Promise<SessionSummary | undefined>;
   whenResumeSettled(sessionId: string): Promise<void>;
   withLifecycleSerialization<T>(
     sessionId: string,

--- a/packages/agent-core-v2/src/app/sessionManager/sessionManagerService.ts
+++ b/packages/agent-core-v2/src/app/sessionManager/sessionManagerService.ts
@@ -4,7 +4,7 @@ import { Emitter, type Event, type IWaitUntil } from '#/_base/event';
 import { ScopeActivation, registerScopedService, type ISessionScopeHandle } from '#/_base/di/scope';
 import { LifecycleScope } from '#/app/scopes';
 import { Error2, ErrorCodes } from '#/errors';
-import { ISessionIndex } from '#/app/sessionIndex/sessionIndex';
+import { ISessionIndex, type SessionSummary } from '#/app/sessionIndex/sessionIndex';
 import {
   type CreateChildSessionOptions,
   type ForkSessionOptions,
@@ -86,6 +86,10 @@ export class SessionManager implements ISessionManager {
 
   get(sessionId: string): ISessionScopeHandle | undefined {
     return this.sessions.get(sessionId);
+  }
+
+  status(sessionId: string): Promise<SessionSummary | undefined> {
+    return this.index.get(sessionId);
   }
 
   async whenResumeSettled(sessionId: string): Promise<void> {

--- a/packages/agent-core-v2/src/workspace/sessionLifecycle/coldSessionArchive.ts
+++ b/packages/agent-core-v2/src/workspace/sessionLifecycle/coldSessionArchive.ts
@@ -63,6 +63,24 @@ export async function setColdSessionArchived(
   return 'updated';
 }
 
+export async function setSessionArchived(
+  accessor: ServicesAccessor,
+  sessionId: string,
+  archived: boolean,
+): Promise<ColdSessionArchiveOutcome> {
+  const manager = accessor.get(ISessionManager);
+  return manager.withLifecycleSerialization(sessionId, async (unguarded) => {
+    await manager.whenResumeSettled(sessionId);
+    const live = getLiveSessionById(accessor, sessionId);
+    if (live !== undefined) {
+      if (archived) await unguarded.archive();
+      else await unguarded.restore();
+      return 'updated';
+    }
+    return setColdSessionArchived(accessor, sessionId, archived);
+  });
+}
+
 export type SessionArchiveBatchItemOutcome =
   | { id: string; ok: true }
   | { id: string; ok: false; reason: 'not_found' | 'error'; message: string };
@@ -75,20 +93,10 @@ export async function setSessionArchivedBatch(
   const outcomes: (SessionArchiveBatchItemOutcome | undefined)[] = ids.map(() => undefined);
   const applyOne = async (id: string): Promise<SessionArchiveBatchItemOutcome> => {
     try {
-      const manager = accessor.get(ISessionManager);
-      return await manager.withLifecycleSerialization(id, async (unguarded) => {
-        await manager.whenResumeSettled(id);
-        const live = getLiveSessionById(accessor, id);
-        if (live !== undefined) {
-          if (archived) await unguarded.archive();
-          else await unguarded.restore();
-          return { id, ok: true };
-        }
-        const outcome = await setColdSessionArchived(accessor, id, archived);
-        return outcome === 'updated'
-          ? { id, ok: true }
-          : { id, ok: false, reason: 'not_found', message: `session ${id} does not exist` };
-      });
+      const outcome = await setSessionArchived(accessor, id, archived);
+      return outcome === 'updated'
+        ? { id, ok: true }
+        : { id, ok: false, reason: 'not_found', message: `session ${id} does not exist` };
     } catch (error) {
       return {
         id,

--- a/packages/agent-core-v2/test/app/sessionExport/sessionExport.test.ts
+++ b/packages/agent-core-v2/test/app/sessionExport/sessionExport.test.ts
@@ -890,6 +890,7 @@ function registerSessionExportServices(
     },
     resume: async () => options.lifecycleHandle,
     get: () => options.lifecycleHandle,
+    status: async () => options.summary,
     whenResumeSettled: async () => {},
     withLifecycleSerialization: async <T>(
       _sessionId: string,

--- a/packages/kap-server/src/routes/action-dispatch.ts
+++ b/packages/kap-server/src/routes/action-dispatch.ts
@@ -1,0 +1,90 @@
+import { z } from 'zod';
+
+import { parseActionSuffix } from './action-suffix';
+
+export interface ActionHandler<TExtra> {
+  readonly body?: z.ZodTypeAny;
+  handle(ctx: TExtra & { readonly id: string; readonly body: unknown }): Promise<void> | void;
+}
+
+export type ActionTable<TAction extends string, TExtra> = Readonly<
+  Record<TAction, ActionHandler<TExtra>>
+>;
+
+export function actionNames<TAction extends string, TExtra>(
+  actions: ActionTable<TAction, TExtra>,
+): readonly TAction[] {
+  return Object.keys(actions) as unknown as readonly TAction[];
+}
+
+/**
+ * Parse an `{id}:{action}` path tail against the table's action names.
+ * Returns the resolved target, or `{ message }` for the validation-failure
+ * response when the tail is not a known action.
+ */
+export function resolveActionTarget<TAction extends string, TExtra>(opts: {
+  readonly tail: string;
+  readonly actions: ActionTable<TAction, TExtra>;
+  readonly resourceLabel: string;
+}): { readonly id: string; readonly action: TAction } | { readonly message: string } {
+  const parsed = parseActionSuffix({
+    tail: opts.tail,
+    allowedActions: actionNames(opts.actions),
+    resourceLabel: opts.resourceLabel,
+  });
+  if (parsed.kind !== 'action') {
+    return {
+      message: parsed.kind === 'invalid' ? parsed.reason : `unsupported action: ${opts.tail}`,
+    };
+  }
+  return { id: parsed.id, action: parsed.action };
+}
+
+/**
+ * Invoke the table entry for `action`, validating the raw body against the
+ * entry's schema first when it declares one. Returns false when no entry
+ * matches, leaving the unsupported-action response to the caller.
+ */
+export async function runAction<TAction extends string, TExtra>(opts: {
+  readonly action: string;
+  readonly id: string;
+  readonly actions: ActionTable<TAction, TExtra>;
+  readonly extra: TExtra;
+  readonly body?: unknown;
+}): Promise<boolean> {
+  const entry = opts.actions[opts.action as TAction];
+  if (entry === undefined) {
+    return false;
+  }
+  const body = entry.body === undefined ? opts.body : entry.body.parse(opts.body);
+  await entry.handle({ ...opts.extra, id: opts.id, body });
+  return true;
+}
+
+/**
+ * Resolve the tail and invoke the matching handler in one step, for routes
+ * whose parse guard needs no site-specific logic. `onUnsupported` produces
+ * the route's validation-failure response; the return value reports whether
+ * a handler ran.
+ */
+export async function dispatchAction<TAction extends string, TExtra>(opts: {
+  readonly tail: string;
+  readonly actions: ActionTable<TAction, TExtra>;
+  readonly resourceLabel: string;
+  readonly extra: TExtra;
+  readonly body?: unknown;
+  readonly onUnsupported: (message: string) => void;
+}): Promise<boolean> {
+  const target = resolveActionTarget(opts);
+  if ('message' in target) {
+    opts.onUnsupported(target.message);
+    return false;
+  }
+  return runAction({
+    action: target.action,
+    id: target.id,
+    actions: opts.actions,
+    extra: opts.extra,
+    body: opts.body,
+  });
+}

--- a/packages/kap-server/src/routes/modelCatalog.ts
+++ b/packages/kap-server/src/routes/modelCatalog.ts
@@ -46,6 +46,7 @@ import {
   replaceProviderResponseSchema,
   type ProviderCollectionActionBody,
 } from '../protocol/rest-modelCatalog';
+import { type ActionTable, runAction } from './action-dispatch';
 import { parseActionSuffix } from './action-suffix';
 
 interface ModelCatalogRouteHost {
@@ -501,25 +502,15 @@ export function registerModelCatalogRoutes(app: ModelCatalogRouteHost, core: Sco
     async (req, reply) => {
       const raw = req.params.action;
       const action = raw.startsWith(':') ? raw.slice(1) : raw;
-      if (action === 'refresh_oauth') {
-        const result = await (await loadOAuth(core)).refreshOAuthProviderModels();
-        reply.send(okEnvelope(result, req.id));
-        return;
+      const handled = await runAction({
+        action,
+        id: '',
+        actions: providerCollectionActions,
+        extra: { core, req, reply },
+      });
+      if (!handled) {
+        reply.send(errEnvelope(ErrorCode.VALIDATION_FAILED, `unsupported action: ${raw}`, req.id));
       }
-      if (action === 'refresh') {
-        const result = await (await loadDiscovery(core)).refreshProviderModels({ scope: 'all' });
-        reply.send(okEnvelope(result, req.id));
-        return;
-      }
-      if (action === 'import_catalog') {
-        await enqueueProviderWrite(() => handleImportCatalog(req, reply, core));
-        return;
-      }
-      if (action === 'import_registry') {
-        await enqueueProviderWrite(() => handleImportRegistry(req, reply, core));
-        return;
-      }
-      reply.send(errEnvelope(ErrorCode.VALIDATION_FAILED, `unsupported action: ${raw}`, req.id));
     },
   );
   app.post(
@@ -846,5 +837,47 @@ async function handleImportRegistry(
     if (sendModelsDevImportError(reply, req.id, err)) return;
     throw err;
   }
+}
+
+type ProviderCollectionActionExtra = {
+  readonly core: Scope;
+  readonly req: {
+    readonly id: string;
+    readonly body: ProviderCollectionActionBody | undefined;
+  };
+  readonly reply: { readonly send: (payload: unknown) => unknown };
+};
+
+type ProviderCollectionActionCtx = ProviderCollectionActionExtra & {
+  readonly id: string;
+  readonly body: unknown;
+};
+
+const providerCollectionActions: ActionTable<
+  'refresh_oauth' | 'refresh' | 'import_catalog' | 'import_registry',
+  ProviderCollectionActionExtra
+> = {
+  refresh_oauth: { handle: refreshOAuthProvidersAction },
+  refresh: { handle: refreshProvidersAction },
+  import_catalog: { handle: importCatalogProviderAction },
+  import_registry: { handle: importRegistryProviderAction },
+};
+
+async function refreshOAuthProvidersAction(ctx: ProviderCollectionActionCtx): Promise<void> {
+  const result = await (await loadOAuth(ctx.core)).refreshOAuthProviderModels();
+  ctx.reply.send(okEnvelope(result, ctx.req.id));
+}
+
+async function refreshProvidersAction(ctx: ProviderCollectionActionCtx): Promise<void> {
+  const result = await (await loadDiscovery(ctx.core)).refreshProviderModels({ scope: 'all' });
+  ctx.reply.send(okEnvelope(result, ctx.req.id));
+}
+
+async function importCatalogProviderAction(ctx: ProviderCollectionActionCtx): Promise<void> {
+  await enqueueProviderWrite(() => handleImportCatalog(ctx.req, ctx.reply, ctx.core));
+}
+
+async function importRegistryProviderAction(ctx: ProviderCollectionActionCtx): Promise<void> {
+  await enqueueProviderWrite(() => handleImportRegistry(ctx.req, ctx.reply, ctx.core));
 }
 

--- a/packages/kap-server/src/routes/plugins.ts
+++ b/packages/kap-server/src/routes/plugins.ts
@@ -28,7 +28,7 @@ import {
   pluginSummarySchema,
   type PluginMarketplaceEntryWire,
 } from '../protocol/rest-plugin';
-import { parseActionSuffix } from './action-suffix';
+import { type ActionTable, dispatchAction } from './action-dispatch';
 
 interface PluginsRouteHost {
   get(
@@ -49,7 +49,29 @@ interface PluginsRouteHost {
   ): unknown;
 }
 
-const PLUGIN_ACTIONS = ['enable', 'disable', 'remove'] as const;
+const pluginActions: ActionTable<'enable' | 'disable' | 'remove', PluginActionExtra> = {
+  enable: { handle: enablePluginAction },
+  disable: { handle: disablePluginAction },
+  remove: { handle: removePluginAction },
+};
+
+type PluginActionExtra = {
+  readonly plugins: IPluginService;
+};
+
+type PluginActionCtx = PluginActionExtra & { readonly id: string; readonly body: unknown };
+
+async function enablePluginAction(ctx: PluginActionCtx): Promise<void> {
+  await ctx.plugins.setPluginEnabled({ id: ctx.id, enabled: true });
+}
+
+async function disablePluginAction(ctx: PluginActionCtx): Promise<void> {
+  await ctx.plugins.setPluginEnabled({ id: ctx.id, enabled: false });
+}
+
+async function removePluginAction(ctx: PluginActionCtx): Promise<void> {
+  await ctx.plugins.removePlugin({ id: ctx.id });
+}
 
 const CAPABILITY_ROW_IDS: Readonly<
   Record<string, { capabilityId: string; wiringPluginIds: readonly string[] }>
@@ -281,31 +303,20 @@ export function registerPluginsRoutes(
       operationId: 'pluginAction',
     },
     async (req, reply) => {
-      const parsed = parseActionSuffix({
-        tail: req.params.tail,
-        allowedActions: PLUGIN_ACTIONS,
-        resourceLabel: 'plugin',
-      });
-      if (parsed.kind !== 'action') {
-        const message =
-          parsed.kind === 'invalid' ? parsed.reason : `unsupported action: ${req.params.tail}`;
-        reply.send(errEnvelope(ErrorCode.VALIDATION_FAILED, message, req.id));
-        return;
-      }
       const plugins = core.accessor.get(IPluginService);
       try {
-        switch (parsed.action) {
-          case 'enable':
-            await plugins.setPluginEnabled({ id: parsed.id, enabled: true });
-            break;
-          case 'disable':
-            await plugins.setPluginEnabled({ id: parsed.id, enabled: false });
-            break;
-          case 'remove':
-            await plugins.removePlugin({ id: parsed.id });
-            break;
+        const handled = await dispatchAction({
+          tail: req.params.tail,
+          actions: pluginActions,
+          resourceLabel: 'plugin',
+          extra: { plugins },
+          onUnsupported: (message) => {
+            reply.send(errEnvelope(ErrorCode.VALIDATION_FAILED, message, req.id));
+          },
+        });
+        if (handled) {
+          reply.send(okEnvelope({ ok: true as const }, req.id));
         }
-        reply.send(okEnvelope({ ok: true as const }, req.id));
       } catch (error) {
         reply.send(mapPluginError(error, req.id));
       }

--- a/packages/kap-server/src/routes/prompts.ts
+++ b/packages/kap-server/src/routes/prompts.ts
@@ -58,7 +58,7 @@ import {
 import { requestLog } from '../lib/requestLog';
 import { defineRoute } from '../middleware/defineRoute';
 import { ensureMainAgent, MAIN_AGENT_ID } from '../transport/mainAgent';
-import { parseActionSuffix } from './action-suffix';
+import { type ActionTable, resolveActionTarget, runAction } from './action-dispatch';
 
 interface PromptRouteHost {
   get(
@@ -391,31 +391,55 @@ export function registerPromptsRoutes(app: PromptRouteHost, core: Scope): void {
     async (req, reply) => {
       try {
         const { session_id, tail } = req.params as { session_id: string; tail: string };
-        const parsed = parseActionSuffix({
+        const target = resolveActionTarget({
           tail,
-          allowedActions: ['abort', 'steer'] as const,
+          actions: promptActions,
           resourceLabel: 'prompt',
         });
-        if (parsed.kind !== 'action') {
-          const message = parsed.kind === 'invalid' ? parsed.reason : `unsupported action: ${tail}`;
-          reply.send(errEnvelope(ErrorCode.VALIDATION_FAILED, message, req.id));
+        if ('message' in target) {
+          reply.send(errEnvelope(ErrorCode.VALIDATION_FAILED, target.message, req.id));
           return;
         }
         const resolved = await resolvePrompt(core, session_id);
-        if (parsed.action === 'abort') {
-          resolved.prompt.abort(parsed.id);
-          requestLog(req)?.info({ session_id, prompt_id: parsed.id }, 'prompt aborted');
-          reply.send(okEnvelope({ aborted: true }, req.id));
-        } else {
-          await resolved.prompt.steer([parsed.id]);
-          reply.send(okEnvelope({ steered: true, prompt_ids: [parsed.id] }, req.id));
-        }
+        await runAction({
+          action: target.action,
+          id: target.id,
+          actions: promptActions,
+          extra: { resolved, session_id, req, reply },
+        });
       } catch (error) {
         sendMappedError(reply, req, error);
       }
     },
   );
   app.post(actionRoute.path, actionRoute.options, actionRoute.handler as Parameters<PromptRouteHost['post']>[2]);
+}
+
+type PromptActionExtra = {
+  readonly resolved: Awaited<ReturnType<typeof resolvePrompt>>;
+  readonly session_id: string;
+  readonly req: { readonly id: string };
+  readonly reply: { readonly send: (payload: unknown) => unknown };
+};
+
+type PromptActionCtx = PromptActionExtra & { readonly id: string; readonly body: unknown };
+
+const promptActions: ActionTable<'abort' | 'steer', PromptActionExtra> = {
+  abort: { handle: abortPromptAction },
+  steer: { handle: steerPromptAction },
+};
+
+async function abortPromptAction(ctx: PromptActionCtx): Promise<void> {
+  const { resolved, session_id, req, reply, id } = ctx;
+  resolved.prompt.abort(id);
+  requestLog(req)?.info({ session_id, prompt_id: id }, 'prompt aborted');
+  reply.send(okEnvelope({ aborted: true }, req.id));
+}
+
+async function steerPromptAction(ctx: PromptActionCtx): Promise<void> {
+  const { resolved, req, reply, id } = ctx;
+  await resolved.prompt.steer([id]);
+  reply.send(okEnvelope({ steered: true, prompt_ids: [id] }, req.id));
 }
 
 function projectPromptList(snapshot: PromptQueueSnapshot) {

--- a/packages/kap-server/src/routes/questions.ts
+++ b/packages/kap-server/src/routes/questions.ts
@@ -30,6 +30,7 @@ import { z } from 'zod';
 import { errEnvelope, okEnvelope } from '../envelope';
 import { requestLog } from '../lib/requestLog';
 import { defineRoute } from '../middleware/defineRoute';
+import { type ActionTable, runAction } from './action-dispatch';
 import { parseActionSuffix } from './action-suffix';
 
 interface QuestionRouteHost {
@@ -172,56 +173,12 @@ export function registerQuestionsRoutes(app: QuestionRouteHost, core: Scope): vo
 
       const questions = handle.accessor.get(ISessionQuestionService);
 
-      if (action === 'dismiss') {
-        questions.dismiss(questionId);
-        requestLog(req)?.info(
-          { session_id, question_id: questionId, action: 'dismiss' },
-          'question dismissed',
-        );
-        reply.send({
-          code: ErrorCode.QUESTION_DISMISSED,
-          msg: `question ${questionId} dismissed`,
-          data: { dismissed: true as const, dismissed_at: new Date().toISOString() },
-          request_id: req.id,
-        });
-        return;
-      }
-
-      const bodyParse = questionResolveRequestSchema.safeParse(req.body);
-      if (!bodyParse.success) {
-        const details = bodyParse.error.issues.map((issue) => ({
-          path: issue.path.join('.'),
-          message: issue.message,
-        }));
-        const first = details[0];
-        const msg =
-          first === undefined
-            ? 'validation failed'
-            : first.path === ''
-              ? first.message
-              : `${first.path}: ${first.message}`;
-        reply.send({
-          code: ErrorCode.VALIDATION_FAILED,
-          msg,
-          data: null,
-          request_id: req.id,
-          details,
-        });
-        return;
-      }
-
-      const result = toInProcessResponse(
-        bodyParse.data,
-        toWireQuestion(pendingInteraction, session_id),
-      );
-      questions.answer(questionId, result);
-      requestLog(req)?.info(
-        { session_id, question_id: questionId, action: 'answer' },
-        'question answered',
-      );
-      reply.send(
-        okEnvelope({ resolved: true as const, resolved_at: new Date().toISOString() }, req.id),
-      );
+      await runAction({
+        action,
+        id: questionId,
+        actions: questionActions,
+        extra: { questions, pendingInteraction, session_id, req, reply },
+      });
     },
   );
   app.post(
@@ -229,6 +186,64 @@ export function registerQuestionsRoutes(app: QuestionRouteHost, core: Scope): vo
     resolveRoute.options,
     resolveRoute.handler as Parameters<QuestionRouteHost['post']>[2],
   );
+}
+
+type QuestionActionExtra = {
+  readonly questions: ISessionQuestionService;
+  readonly pendingInteraction: Interaction;
+  readonly session_id: string;
+  readonly req: { readonly id: string; readonly body: unknown };
+  readonly reply: { readonly send: (payload: unknown) => unknown };
+};
+
+type QuestionActionCtx = QuestionActionExtra & { readonly id: string; readonly body: unknown };
+
+const questionActions: ActionTable<'resolve' | 'dismiss', QuestionActionExtra> = {
+  resolve: { handle: resolveQuestionAction },
+  dismiss: { handle: dismissQuestionAction },
+};
+
+async function resolveQuestionAction(ctx: QuestionActionCtx): Promise<void> {
+  const { questions, pendingInteraction, session_id, req, reply, id } = ctx;
+  const bodyParse = questionResolveRequestSchema.safeParse(req.body);
+  if (!bodyParse.success) {
+    const details = bodyParse.error.issues.map((issue) => ({
+      path: issue.path.join('.'),
+      message: issue.message,
+    }));
+    const first = details[0];
+    const msg =
+      first === undefined
+        ? 'validation failed'
+        : first.path === ''
+          ? first.message
+          : `${first.path}: ${first.message}`;
+    reply.send({
+      code: ErrorCode.VALIDATION_FAILED,
+      msg,
+      data: null,
+      request_id: req.id,
+      details,
+    });
+    return;
+  }
+
+  const result = toInProcessResponse(bodyParse.data, toWireQuestion(pendingInteraction, session_id));
+  questions.answer(id, result);
+  requestLog(req)?.info({ session_id, question_id: id, action: 'answer' }, 'question answered');
+  reply.send(okEnvelope({ resolved: true as const, resolved_at: new Date().toISOString() }, req.id));
+}
+
+async function dismissQuestionAction(ctx: QuestionActionCtx): Promise<void> {
+  const { questions, session_id, req, reply, id } = ctx;
+  questions.dismiss(id);
+  requestLog(req)?.info({ session_id, question_id: id, action: 'dismiss' }, 'question dismissed');
+  reply.send({
+    code: ErrorCode.QUESTION_DISMISSED,
+    msg: `question ${id} dismissed`,
+    data: { dismissed: true as const, dismissed_at: new Date().toISOString() },
+    request_id: req.id,
+  });
 }
 
 function buildOption(opt: QuestionOption, itemIdx: number, optIdx: number): ProtocolQuestionOption {

--- a/packages/kap-server/src/routes/sessions.ts
+++ b/packages/kap-server/src/routes/sessions.ts
@@ -21,6 +21,7 @@ import {
   getLiveSessionById,
   programForSession,
   resumeSessionById,
+  setSessionArchived,
   isError2,
   Error2,
   type ContextMessage,
@@ -62,7 +63,7 @@ import { errEnvelope, okEnvelope } from '../envelope';
 import { requestLog } from '../lib/requestLog';
 import { defineRoute } from '../middleware/defineRoute';
 import { ensureMainAgent } from '../transport/mainAgent';
-import { parseActionSuffix } from './action-suffix';
+import { type ActionTable, dispatchAction } from './action-dispatch';
 import { applySessionAgentConfig } from './sessionAgentConfig';
 import { updateSessionProfile } from './sessionProfile';
 
@@ -605,144 +606,16 @@ export function registerSessionsRoutes(app: SessionRouteHost, core: Scope): void
     },
     async (req, reply) => {
       try {
-        const { tail } = req.params;
-        const parsed = parseActionSuffix({
-          tail,
-          allowedActions: ['fork', 'compact', 'undo', 'abort', 'btw', 'archive', 'restore'] as const,
+        await dispatchAction({
+          tail: req.params.tail,
+          actions: sessionActions,
           resourceLabel: 'session',
+          extra: { core, req, reply },
+          body: req.body,
+          onUnsupported: (message) => {
+            reply.send(buildValidationEnvelope([{ path: 'session_id', message }], req.id));
+          },
         });
-        if (parsed.kind !== 'action') {
-          const message = parsed.kind === 'invalid' ? parsed.reason : `unsupported action: ${tail}`;
-          reply.send(buildValidationEnvelope([{ path: 'session_id', message }], req.id));
-          return;
-        }
-
-        const legacy = core.accessor.get(ISessionLegacyService);
-
-        if (parsed.action === 'fork') {
-          const body = forkSessionRequestSchema.parse(req.body);
-          const forkHandler = await programForSession(core.accessor, parsed.id);
-          if (forkHandler === undefined) {
-            throw new Error2(
-              ErrorCodes.SESSION_NOT_FOUND,
-              `session ${parsed.id} does not exist`,
-            );
-          }
-          const handle = await core.accessor.get(ISessionManager).fork({
-            sourceSessionId: parsed.id,
-            title: body.title,
-            metadata: body.metadata,
-          });
-          const meta = await handle.accessor.get(ISessionMetadata).read();
-          const ctx = handle.accessor.get(ISessionContext);
-          const session = toWireSession(
-            { ...meta, workspaceId: ctx.workspaceId },
-            ctx.cwd,
-            resolveSessionFacts(core, meta.id),
-          );
-          core.accessor.get(IEventService).publish(
-            new SessionCreated({ payload: { agentId: 'main', sessionId: session.id, session } }),
-          );
-          requestLog(req)?.info(
-            { session_id: parsed.id, action: 'fork', new_session_id: session.id },
-            'session action completed',
-          );
-          reply.send(okEnvelope(session, req.id));
-          return;
-        }
-
-        if (parsed.action === 'compact') {
-          const body = compactSessionRequestSchema.parse(req.body);
-          const agent = await resolveMainAgent(core, parsed.id);
-          agent.accessor
-            .get(IAgentFullCompactionService)
-            .begin({ source: 'manual', instruction: normalizeOptional(body.instruction) });
-          requestLog(req)?.info({ session_id: parsed.id, action: 'compact' }, 'session action completed');
-          reply.send(okEnvelope({}, req.id));
-          return;
-        }
-
-        if (parsed.action === 'undo') {
-          const body = undoSessionRequestSchema.parse(req.body);
-          const agent = await resolveMainAgent(core, parsed.id);
-          await agent.accessor.get(IAgentConversationUndoService).undo(body.count);
-          const history = agent.accessor.get(IAgentContextMemoryService).get();
-          requestLog(req)?.info({ session_id: parsed.id, action: 'undo' }, 'session action completed');
-          const [summary, status] = await Promise.all([
-            core.accessor.get(ISessionIndex).get(parsed.id),
-            legacy.status(parsed.id),
-          ]);
-          reply.send(
-            okEnvelope(
-              {
-                messages: pageUndoMessages(
-                  parsed.id,
-                  summary?.createdAt ?? 0,
-                  history,
-                  body.page_size,
-                ),
-                status,
-              },
-              req.id,
-            ),
-          );
-          return;
-        }
-
-        if (parsed.action === 'abort') {
-          const agent = await resolveMainAgent(core, parsed.id);
-          agent.accessor.get(IAgentLoopService).cancelFromUser();
-          requestLog(req)?.info({ session_id: parsed.id, action: 'abort' }, 'session action completed');
-          reply.send(okEnvelope({ aborted: true }, req.id));
-          return;
-        }
-
-        if (parsed.action === 'btw') {
-          const session = await resumeSessionById(core.accessor, parsed.id);
-          if (session === undefined) {
-            throw new Error2(
-              ErrorCodes.SESSION_NOT_FOUND,
-              `session ${parsed.id} does not exist`,
-            );
-          }
-          await core.accessor.get(IAuthSummaryService).ensureReady();
-          const agentId = await session.accessor.get(ISessionBtwService).start();
-          reply.send(okEnvelope({ agent_id: agentId }, req.id));
-          return;
-        }
-
-        if (parsed.action === 'restore') {
-          const restoreHandler = await programForSession(core.accessor, parsed.id);
-          const restored =
-            restoreHandler === undefined
-              ? undefined
-              : await core.accessor.get(ISessionManager).restore(parsed.id);
-          if (restored === undefined) {
-            throw new Error2(ErrorCodes.SESSION_NOT_FOUND, `session ${parsed.id} does not exist`);
-          }
-          const meta = await restored.accessor.get(ISessionMetadata).read();
-          const ctx = restored.accessor.get(ISessionContext);
-          const session = toWireSession(
-            { ...meta, workspaceId: ctx.workspaceId },
-            ctx.cwd,
-            resolveSessionFacts(core, meta.id),
-          );
-          requestLog(req)?.info({ session_id: parsed.id, action: 'restore' }, 'session action completed');
-          reply.send(okEnvelope(session, req.id));
-          return;
-        }
-
-        const archiveHandler = await programForSession(core.accessor, parsed.id);
-        const archived =
-          archiveHandler === undefined
-            ? undefined
-            : await core.accessor.get(ISessionManager).resume(parsed.id);
-        if (archived === undefined || archiveHandler === undefined) {
-          throw new Error2(ErrorCodes.SESSION_NOT_FOUND, `session ${parsed.id} does not exist`);
-        }
-        await core.accessor.get(ISessionManager).archive(parsed.id);
-        requestLog(req)?.info({ session_id: parsed.id, action: 'archive' }, 'session action completed');
-        reply.send(okEnvelope({ archived: true }, req.id));
       } catch (error) {
         sendMappedError(reply, req, error);
       }
@@ -966,6 +839,142 @@ export function registerSessionsRoutes(app: SessionRouteHost, core: Scope): void
     sessionWarningsRoute.options,
     sessionWarningsRoute.handler as Parameters<SessionRouteHost['get']>[2],
   );
+}
+
+type SessionAction = 'fork' | 'compact' | 'undo' | 'abort' | 'btw' | 'restore' | 'archive';
+
+interface SessionActionExtra {
+  readonly core: Scope;
+  readonly req: { readonly id: string };
+  readonly reply: { readonly send: (payload: unknown) => unknown };
+}
+
+type SessionActionCtx<TBody = unknown> = SessionActionExtra & {
+  readonly id: string;
+  readonly body: TBody;
+};
+
+const sessionActions: ActionTable<SessionAction, SessionActionExtra> = {
+  fork: { body: forkSessionRequestSchema, handle: forkSessionAction },
+  compact: { body: compactSessionRequestSchema, handle: compactSessionAction },
+  undo: { body: undoSessionRequestSchema, handle: undoSessionAction },
+  abort: { handle: abortSessionAction },
+  btw: { handle: btwSessionAction },
+  restore: { handle: restoreSessionAction },
+  archive: { handle: archiveSessionAction },
+};
+
+async function forkSessionAction(
+  ctx: SessionActionCtx<z.infer<typeof forkSessionRequestSchema>>,
+): Promise<void> {
+  const { core, req, reply, id, body } = ctx;
+  const forkHandler = await programForSession(core.accessor, id);
+  if (forkHandler === undefined) {
+    throw new Error2(ErrorCodes.SESSION_NOT_FOUND, `session ${id} does not exist`);
+  }
+  const handle = await core.accessor.get(ISessionManager).fork({
+    sourceSessionId: id,
+    title: body.title,
+    metadata: body.metadata,
+  });
+  const meta = await handle.accessor.get(ISessionMetadata).read();
+  const sessionCtx = handle.accessor.get(ISessionContext);
+  const session = toWireSession(
+    { ...meta, workspaceId: sessionCtx.workspaceId },
+    sessionCtx.cwd,
+    resolveSessionFacts(core, meta.id),
+  );
+  core.accessor
+    .get(IEventService)
+    .publish(new SessionCreated({ payload: { agentId: 'main', sessionId: session.id, session } }));
+  requestLog(req)?.info(
+    { session_id: id, action: 'fork', new_session_id: session.id },
+    'session action completed',
+  );
+  reply.send(okEnvelope(session, req.id));
+}
+
+async function compactSessionAction(
+  ctx: SessionActionCtx<z.infer<typeof compactSessionRequestSchema>>,
+): Promise<void> {
+  const { core, req, reply, id, body } = ctx;
+  const agent = await resolveMainAgent(core, id);
+  agent.accessor
+    .get(IAgentFullCompactionService)
+    .begin({ source: 'manual', instruction: normalizeOptional(body.instruction) });
+  requestLog(req)?.info({ session_id: id, action: 'compact' }, 'session action completed');
+  reply.send(okEnvelope({}, req.id));
+}
+
+async function undoSessionAction(
+  ctx: SessionActionCtx<z.infer<typeof undoSessionRequestSchema>>,
+): Promise<void> {
+  const { core, req, reply, id, body } = ctx;
+  const agent = await resolveMainAgent(core, id);
+  await agent.accessor.get(IAgentConversationUndoService).undo(body.count);
+  const history = agent.accessor.get(IAgentContextMemoryService).get();
+  requestLog(req)?.info({ session_id: id, action: 'undo' }, 'session action completed');
+  const legacy = core.accessor.get(ISessionLegacyService);
+  const [summary, status] = await Promise.all([
+    core.accessor.get(ISessionIndex).get(id),
+    legacy.status(id),
+  ]);
+  reply.send(
+    okEnvelope(
+      {
+        messages: pageUndoMessages(id, summary?.createdAt ?? 0, history, body.page_size),
+        status,
+      },
+      req.id,
+    ),
+  );
+}
+
+async function abortSessionAction(ctx: SessionActionCtx): Promise<void> {
+  const { core, req, reply, id } = ctx;
+  const agent = await resolveMainAgent(core, id);
+  agent.accessor.get(IAgentLoopService).cancelFromUser();
+  requestLog(req)?.info({ session_id: id, action: 'abort' }, 'session action completed');
+  reply.send(okEnvelope({ aborted: true }, req.id));
+}
+
+async function btwSessionAction(ctx: SessionActionCtx): Promise<void> {
+  const { core, req, reply, id } = ctx;
+  const session = await resumeSessionById(core.accessor, id);
+  if (session === undefined) {
+    throw new Error2(ErrorCodes.SESSION_NOT_FOUND, `session ${id} does not exist`);
+  }
+  await core.accessor.get(IAuthSummaryService).ensureReady();
+  const agentId = await session.accessor.get(ISessionBtwService).start();
+  reply.send(okEnvelope({ agent_id: agentId }, req.id));
+}
+
+async function restoreSessionAction(ctx: SessionActionCtx): Promise<void> {
+  const { core, req, reply, id } = ctx;
+  const restored = await core.accessor.get(ISessionManager).restore(id);
+  if (restored === undefined) {
+    throw new Error2(ErrorCodes.SESSION_NOT_FOUND, `session ${id} does not exist`);
+  }
+  const meta = await restored.accessor.get(ISessionMetadata).read();
+  const sessionCtx = restored.accessor.get(ISessionContext);
+  const session = toWireSession(
+    { ...meta, workspaceId: sessionCtx.workspaceId },
+    sessionCtx.cwd,
+    resolveSessionFacts(core, meta.id),
+  );
+  requestLog(req)?.info({ session_id: id, action: 'restore' }, 'session action completed');
+  reply.send(okEnvelope(session, req.id));
+}
+
+async function archiveSessionAction(ctx: SessionActionCtx): Promise<void> {
+  const { core, req, reply, id } = ctx;
+  const summary = await core.accessor.get(ISessionManager).status(id);
+  if (summary === undefined) {
+    throw new Error2(ErrorCodes.SESSION_NOT_FOUND, `session ${id} does not exist`);
+  }
+  await setSessionArchived(core.accessor, id, true);
+  requestLog(req)?.info({ session_id: id, action: 'archive' }, 'session action completed');
+  reply.send(okEnvelope({ archived: true }, req.id));
 }
 
 export interface SessionWireFields {


### PR DESCRIPTION
## Related Issue

None — internal refactor; see Problem.

## Problem

kap-server's `{id}:{action}` routes parse the action suffix with `parseActionSuffix` but then dispatch through sequential if-else chains or switch blocks inside one large handler closure — `sessions.ts` alone carried 7 actions in ~170 lines of branching. Every action's logic is tangled into the shared closure, which makes individual actions hard to read, test in isolation, and extend.

While refactoring, one related inefficiency surfaced: the session archive action resumed (fully initialized) the target session first, because `SessionLifecycleService.archive` only operates on live sessions and the route relied on `resume`'s return value for the not-found check. Archiving a cold session therefore built up two DI scope containers, loaded metadata/profiles/skills, and created the main agent — only to tear everything down immediately.

## What changed

- **Table-driven action dispatch**: new shared `packages/kap-server/src/routes/action-dispatch.ts` helper (`ActionTable` / `ActionHandler` types plus `resolveActionTarget` / `runAction` / `dispatchAction`). The 5 multi-action route sites — sessions (7 actions), modelCatalog collection routes (4), plugins (3), prompts (2), questions (2) — now declare action tables whose handlers are independent module-level functions. Parsing guards, table lookup, the `unsupported action` response, and error mapping live in one place. Wire behavior, error codes, OpenAPI docs, and operationIds are unchanged (existing route test suites serve as the regression net).
- **`ISessionManager.status(sessionId)`**: returns the session's persisted summary (`SessionSummary`, which already carries `archived`), or `undefined` when the session is unknown.
- **Cheaper cold-session archive**: the archive action checks `status` for `SESSION_NOT_FOUND` and archives through `setSessionArchived`, which dispatches live sessions to the normal lifecycle path and cold sessions to the persisted-metadata update shared with the v2 batch archive — no session initialization needed.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works (behavior-preserving refactor — covered by the existing kap-server route suites: sessions, v2Sessions, prompts, questions, plugins, modelCatalog, OpenAPI snapshots).
- [x] Ran `gen-changesets` skill, or this PR needs no changeset (internal refactor; not user-perceivable).
- [x] Ran `gen-docs` skill, or this PR needs no doc update (no wire or user-facing change).
