### PR TITLE
fix(agent-core-v2): record step.end for failed or interrupted steps in wire log

### DIFF
--- a/packages/agent-core-v2/src/agent/contextMemory/loopEventFold.ts
+++ b/packages/agent-core-v2/src/agent/contextMemory/loopEventFold.ts
@@ -152,6 +152,7 @@ function createLoopEventFoldWithState(
           return;
         }
         case 'step.end': {
+          if (event.finishReason === 'interrupted' || event.finishReason === 'error') return;
           settleOpen(time);
           flushDeferred();
           return;

--- a/packages/agent-core-v2/src/agent/loop/loopService.ts
+++ b/packages/agent-core-v2/src/agent/loop/loopService.ts
@@ -803,40 +803,56 @@ export class AgentLoopService extends Disposable implements IAgentLoopService {
     this.activeRequestTrace = undefined;
     await this.hooks.onWillBeginStep.run({ turnId, step: currentStep, firstStepOfTurn, signal });
     const markStepStarted = this.beginStep(turnId, signal, currentStep, stepUuid, onStarted);
-    const streamParts = this.createStreamPartHandler(turnId, markStepStarted);
-    const request = this.llmRequester.start(
-      { source: { type: 'turn', turnId, step: currentStep } },
-      streamParts.handle,
-      signal,
-    );
-    this.activeRequestTrace = request.trace;
-    let response: AgentLLMRequestFinish;
+    let stepEndAppended = false;
     try {
-      response = await request.result;
+      const streamParts = this.createStreamPartHandler(turnId, markStepStarted);
+      const request = this.llmRequester.start(
+        { source: { type: 'turn', turnId, step: currentStep } },
+        streamParts.handle,
+        signal,
+      );
+      this.activeRequestTrace = request.trace;
+      let response: AgentLLMRequestFinish;
+      try {
+        response = await request.result;
+      } catch (error) {
+        this.appendInterruptedStreamContent(turnId, currentStep, stepUuid, streamParts, turnSignal);
+        throw error;
+      }
+      this.lastRequestTraceId = request.trace.traceId;
+      this.appendResponseContent(turnId, currentStep, stepUuid, response);
+      const finishReason = await this.executeStepTools(
+        turnId,
+        signal,
+        currentStep,
+        stepUuid,
+        response,
+        request.trace,
+      );
+      this.finishStep(turnId, signal, currentStep, stepUuid, response, finishReason, markStepStarted);
+      stepEndAppended = true;
+      const hookStopTurn = await this.runAfterStep(
+        turnId,
+        signal,
+        currentStep,
+        firstStepOfTurn,
+        response.usage,
+        finishReason,
+      );
+      return { stopReason: finishReason, hookStopTurn };
     } catch (error) {
-      this.appendInterruptedStreamContent(turnId, currentStep, stepUuid, streamParts, turnSignal);
+      if (!stepEndAppended) {
+        this.context.appendLoopEvent({
+          type: 'step.end',
+          uuid: stepUuid,
+          turnId: String(turnId),
+          step: currentStep,
+          finishReason:
+            isAbortError(error) || signal.aborted || turnSignal.aborted ? 'interrupted' : 'error',
+        });
+      }
       throw error;
     }
-    this.lastRequestTraceId = request.trace.traceId;
-    this.appendResponseContent(turnId, currentStep, stepUuid, response);
-    const finishReason = await this.executeStepTools(
-      turnId,
-      signal,
-      currentStep,
-      stepUuid,
-      response,
-      request.trace,
-    );
-    this.finishStep(turnId, signal, currentStep, stepUuid, response, finishReason, markStepStarted);
-    const hookStopTurn = await this.runAfterStep(
-      turnId,
-      signal,
-      currentStep,
-      firstStepOfTurn,
-      response.usage,
-      finishReason,
-    );
-    return { stopReason: finishReason, hookStopTurn };
   }
 
   private beginStep(

--- a/packages/agent-core-v2/test/agent/contextMemory/loopEventFold.test.ts
+++ b/packages/agent-core-v2/test/agent/contextMemory/loopEventFold.test.ts
@@ -216,6 +216,54 @@ describe('loop-event fold parity', () => {
     expect(folded).toEqual([]);
   });
 
+  it('keeps the open assistant untouched when step.end reports an interruption', () => {
+    const folded = foldAll([], [
+      { type: 'step.begin', uuid: 's1' },
+      {
+        type: 'content.part',
+        stepUuid: 's1',
+        part: { type: 'text', text: 'partial' },
+      },
+      { type: 'step.end', uuid: 's1', finishReason: 'interrupted' },
+    ]);
+
+    expect(shapes(folded)).toEqual([
+      {
+        role: 'assistant',
+        content: [{ type: 'text', text: 'partial' }],
+        toolCalls: [],
+        toolCallId: undefined,
+        isError: undefined,
+        partial: true,
+      },
+    ]);
+  });
+
+  it('settles a failed step at the next step.begin as before', () => {
+    const folded = foldAll([], [
+      { type: 'step.begin', uuid: 's1' },
+      { type: 'step.end', uuid: 's1', finishReason: 'error' },
+      { type: 'step.begin', uuid: 's2' },
+      {
+        type: 'content.part',
+        stepUuid: 's2',
+        part: { type: 'text', text: 'recovered' },
+      },
+      { type: 'step.end', uuid: 's2' },
+    ]);
+
+    expect(shapes(folded)).toEqual([
+      {
+        role: 'assistant',
+        content: [{ type: 'text', text: 'recovered' }],
+        toolCalls: [],
+        toolCallId: undefined,
+        isError: undefined,
+        partial: undefined,
+      },
+    ]);
+  });
+
   it('drops an assistant whose only recorded part is an empty thinking block at step.end', () => {
     const folded = foldAll([], [
       { type: 'step.begin', uuid: 's1' },

--- a/packages/agent-core-v2/test/agent/loop/loop.test.ts
+++ b/packages/agent-core-v2/test/agent/loop/loop.test.ts
@@ -274,6 +274,37 @@ describe('Agent loop', () => {
     );
   });
 
+  it('records step.end with finishReason error when a step fails', async () => {
+    profile.update({ activeToolNames: [] });
+
+    await ctx.rpc.prompt({ input: [{ type: 'text', text: 'Hello' }] });
+    await ctx.untilTurnEnd();
+
+    const begins = wireLoopEvents(ctx, 'step.begin');
+    const ends = wireLoopEvents(ctx, 'step.end');
+    expect(begins).toHaveLength(1);
+    expect(ends).toEqual([
+      expect.objectContaining({ uuid: begins[0]!['uuid'], finishReason: 'error' }),
+    ]);
+  });
+
+  it('records step.end with finishReason interrupted when the turn is cancelled mid-step', async () => {
+    ctx.mockNextResponse({ type: 'text', text: 'partial answer' }, { type: 'text', text: ' more' });
+    const subscription = ctx.get(IEventBus).subscribe(AssistantDelta, () => {
+      loop.cancel();
+    });
+    const turn = (await loop.enqueue(nextTurnMessage('Hello')).assigned).turn;
+    await expect(turn.result).resolves.toMatchObject({ type: 'cancelled' });
+    subscription.dispose();
+
+    const begins = wireLoopEvents(ctx, 'step.begin');
+    const ends = wireLoopEvents(ctx, 'step.end');
+    expect(begins).toHaveLength(1);
+    expect(ends).toEqual([
+      expect.objectContaining({ uuid: begins[0]!['uuid'], finishReason: 'interrupted' }),
+    ]);
+  });
+
   it('does not run loop error handlers for aborted turns', async () => {
     let called = false;
     loop.registerLoopErrorHandler({
@@ -1497,6 +1528,20 @@ function nextTurnMessage(text: string): MessageStepRequest {
     },
     { admission: 'newTurn' },
   );
+}
+
+function wireLoopEvents(
+  target: TestAgentContext,
+  eventType: string,
+): Array<Record<string, unknown>> {
+  return target.allEvents
+    .filter(
+      (entry) =>
+        entry.type === '[wire]' &&
+        entry.event === 'context.append_loop_event' &&
+        (entry.args as { event?: { type?: string } }).event?.type === eventType,
+    )
+    .map((entry) => (entry.args as { event: Record<string, unknown> }).event);
 }
 
 function createTimingRequester(): IAgentLLMRequesterService {

--- a/packages/agent-core-v2/test/agent/stepRetry/stepRetry.test.ts
+++ b/packages/agent-core-v2/test/agent/stepRetry/stepRetry.test.ts
@@ -33,6 +33,17 @@ describe('stepRetry plugin', () => {
     return ctx.allEvents.filter((event) => event.type === '[rpc]' && event.event === name);
   }
 
+  function wireLoopEvents(eventType: string): Array<Record<string, unknown>> {
+    return ctx.allEvents
+      .filter(
+        (entry) =>
+          entry.type === '[wire]' &&
+          entry.event === 'context.append_loop_event' &&
+          (entry.args as { event?: { type?: string } }).event?.type === eventType,
+      )
+      .map((entry) => (entry.args as { event: Record<string, unknown> }).event);
+  }
+
   async function runTurn(turnId: number, signal?: AbortSignal) {
     void ctx.dispatcher.dispatch(new TurnStarted({ turnId, origin: { kind: 'user' } }));
     const loop = ctx.get(IAgentLoopService);
@@ -106,6 +117,37 @@ describe('stepRetry plugin', () => {
         content: [{ type: 'text', text: 'recovered' }],
       }),
     ]);
+  });
+
+  it('pairs every retried step.begin with a step.end in the wire', async () => {
+    vi.useFakeTimers();
+    let calls = 0;
+    ctx = createTestAgent(
+      llmGenerateServices(async () => {
+        calls += 1;
+        if (calls === 1) throw new APIConnectionError('terminated');
+        return {
+          id: 'retry-response',
+          message: {
+            role: 'assistant',
+            content: [{ type: 'text', text: 'recovered' }],
+            toolCalls: [],
+          },
+          usage: emptyUsage(),
+          finishReason: 'completed',
+          rawFinishReason: 'stop',
+        };
+      }),
+    );
+
+    const result = await runTurn(1);
+
+    expect(result).toEqual({ type: 'completed', steps: 2, truncated: false });
+    const begins = wireLoopEvents('step.begin');
+    const ends = wireLoopEvents('step.end');
+    expect(begins).toHaveLength(2);
+    expect(ends.map((event) => event['finishReason'])).toEqual(['error', 'end_turn']);
+    expect(ends.map((event) => event['uuid'])).toEqual(begins.map((event) => event['uuid']));
   });
 
   it('fails the turn after maxAttempts and reports the interruption only then', async () => {


### PR DESCRIPTION
## Related Issue

No linked issue — the problem is explained below.

## Problem

The session wire log (`wire.jsonl`) records `step.begin` when an agent step starts, but only records the matching `step.end` on the success path. Any failed or interrupted step — LLM request errors and their retries, aborts/user cancellations, tool execution exceptions — throws between the two and leaves an orphaned `step.begin`. In real sessions this shows up as systematic begin/end mismatches (e.g. a turn with 10 consecutive LLM timeouts logs 10 `step.begin` records with no closing event), which makes per-step latency and failure analysis over wire data impossible to attribute.

## What changed

- **`loopService.executeLoopStep`**: the step body after `beginStep` is now wrapped in a try/catch. Any error exit appends a closing `step.end` (carrying only `uuid`, `turnId`, `step`, and `finishReason: 'error' | 'interrupted'`) to the wire before rethrowing, so retry, fail, and cancellation handling is unchanged. A local flag skips the extra record when the success path already wrote `step.end`. The interrupted-content backfill keeps its record order ahead of the new `step.end`.
- **`loopEventFold`**: a `step.end` with `finishReason` `'error'`/`'interrupted'` is treated as a pure wire marker and does not settle the open assistant message (settling still happens at the next `step.begin`), so live and replayed context content is byte-identical to before — interruption reminder and projection keep relying on the `partial` flag.
- **Tests**: new cases cover error-path pairing, mid-step cancellation pairing, real `AgentStepRetryService` retry pairing (every retried `step.begin` gets its `step.end`), and the fold's marker/no-settle behavior.

No new wire vocabulary: the record shape stays `context.append_loop_event` with the existing `step.end` event, so downstream consumers (fold, transcript, wireExtract, vis) need no adaptation. v1 (`packages/agent-core`) keeps its documented behavior unchanged.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.
