### PR TITLE
feat(kimi-code): load startup banner from client_configs

### DIFF
--- a/apps/kimi-code/src/constant/app.ts
+++ b/apps/kimi-code/src/constant/app.ts
@@ -1,5 +1,4 @@
 import { ErrorCodes } from '@moonshot-ai/kimi-code-sdk';
-import { kimiCdnContentUrl } from '@moonshot-ai/kimi-code-oauth';
 
 import { currentKimiProfile } from '#/utils/region';
 
@@ -109,10 +108,6 @@ export function kimiCodeCdnLatestJsonUrl(): string {
 // (same layout install.ps1 consumes).
 export function kimiCodeCdnBinariesBase(): string {
   return `${kimiCodeCdnBase()}/binaries`;
-}
-// The tips banner rides the content CDN, which both regions currently share.
-export function kimiCodeTipsBannerUrl(): string {
-  return kimiCdnContentUrl('kimi-code-tips/tips.json');
 }
 // The marketplace env override name lives in the shared agent-core-v2 plugin
 // domain (kap-server consumes it from there). Deep-path import: this module is

--- a/apps/kimi-code/src/tui/banner/banner-config.ts
+++ b/apps/kimi-code/src/tui/banner/banner-config.ts
@@ -1,0 +1,24 @@
+import { z } from 'zod';
+
+import { fetchClientConfig, type ClientConfigFetchOptions } from '#/utils/client-configs';
+
+/** The tips/banner payload is one named config on the client-configs endpoint. */
+const CONFIG_NAME = 'client_banner';
+
+/** The payload keeps the legacy tips.json shape, which banner-provider parses
+    defensively; the schema only guarantees an object. */
+const bannerConfigSchema = z.looseObject({});
+
+export type BannerConfig = z.infer<typeof bannerConfigSchema>;
+export type BannerConfigFetchOptions = ClientConfigFetchOptions;
+
+/**
+ * Fetches the banner config straight from the endpoint — banners are
+ * time-sensitive announcements, so no caching layer is used. Any failure
+ * resolves to `undefined` — callers treat that as "no banner".
+ */
+export async function getBannerConfig(
+  options: BannerConfigFetchOptions = {},
+): Promise<BannerConfig | undefined> {
+  return fetchClientConfig(CONFIG_NAME, bannerConfigSchema, options);
+}

--- a/apps/kimi-code/src/tui/banner/banner-provider.ts
+++ b/apps/kimi-code/src/tui/banner/banner-provider.ts
@@ -2,9 +2,9 @@ import { createHash } from 'node:crypto';
 
 import { eq, gte, lt, valid } from 'semver';
 
-import { kimiCodeTipsBannerUrl } from '#/constant/app';
 import type { BannerDisplay, BannerState } from '#/tui/types';
 
+import { getBannerConfig } from './banner-config';
 import type { BannerDisplayState } from './state';
 
 interface BannerVersionFields {
@@ -19,8 +19,11 @@ interface TipsBannerFallbackItem extends BannerVersionFields {
   banner_title?: string | null;
   banner_maintext?: string;
   banner_subtext?: string | null;
+  banner_start_time?: string | null;
+  banner_end_time?: string | null;
   banner_display?: unknown;
   banner_display_ttl_hours?: unknown;
+  banner_platform?: string | null;
 }
 
 interface TipsBannerJson extends BannerVersionFields {
@@ -35,6 +38,7 @@ interface TipsBannerJson extends BannerVersionFields {
   banner_display_ttl_hours?: unknown;
   banner_fallback_enabled?: boolean;
   banner_fallback_list?: unknown[];
+  banner_platform?: string | null;
 }
 
 interface BannerHashInput {
@@ -129,6 +133,15 @@ function meetsVersion(banner: BannerVersionFields, clientVersion: string): boole
   );
 }
 
+/** The CLI shows banners targeting every platform (missing / empty / 'all')
+    or the CLI itself; any other platform value ('desktop', 'web', …) hides
+    the banner here. */
+function meetsPlatform(value: unknown): boolean {
+  if (typeof value !== 'string') return true;
+  const platform = value.trim().toLowerCase();
+  return platform === '' || platform === 'all' || platform === 'cli';
+}
+
 function parseBannerDisplay(value: unknown): BannerDisplay {
   if (value === 'once') return 'once';
   if (value === 'cooldown') return 'cooldown';
@@ -198,6 +211,7 @@ function pickActiveBanner(
 ): BannerState | null {
   if (json.banner_enabled !== true) return null;
   if (!meetsVersion(json, clientVersion)) return null;
+  if (!meetsPlatform(json.banner_platform)) return null;
   const start = parseDate(json.banner_start_time);
   const end = parseDate(json.banner_end_time);
   if (!isWithinWindow(start, end, now)) return null;
@@ -219,6 +233,7 @@ function pickActiveBanner(
 function pickFallbackCandidates(
   json: TipsBannerJson,
   clientVersion: string,
+  now: Date,
 ): BannerState[] {
   if (json.banner_fallback_enabled !== true) return [];
   const list = Array.isArray(json.banner_fallback_list) ? json.banner_fallback_list : [];
@@ -228,6 +243,10 @@ function pickFallbackCandidates(
     const item = raw as TipsBannerFallbackItem;
     if (item.enabled !== true) continue;
     if (!meetsVersion(item, clientVersion)) continue;
+    if (!meetsPlatform(item.banner_platform)) continue;
+    const start = parseDate(item.banner_start_time);
+    const end = parseDate(item.banner_end_time);
+    if (!isWithinWindow(start, end, now)) continue;
     const mainText = normalizeText(item.banner_maintext);
     if (mainText === null) continue;
     const display = parseBannerDisplay(item.banner_display);
@@ -239,6 +258,8 @@ function pickFallbackCandidates(
         subText: item.banner_subtext,
         display,
         ttlHours: display === 'cooldown' ? parseBannerDisplayTtlHours(item.banner_display_ttl_hours) : undefined,
+        startTime: item.banner_start_time,
+        endTime: item.banner_end_time,
       }),
     );
   }
@@ -254,9 +275,10 @@ function pickRandomCandidate(candidates: BannerState[], random: () => number): B
 function pickFallbackBanner(
   json: TipsBannerJson,
   clientVersion: string,
+  now: Date,
   random: () => number,
 ): BannerState | null {
-  return pickRandomCandidate(pickFallbackCandidates(json, clientVersion), random);
+  return pickRandomCandidate(pickFallbackCandidates(json, clientVersion, now), random);
 }
 
 function parseShownAt(value: string | undefined): Date | null {
@@ -292,7 +314,7 @@ export function selectBannerState(
   const typed = typeof json === 'object' && json !== null ? (json as TipsBannerJson) : {};
   return (
     pickActiveBanner(typed, clientVersion, now) ??
-    pickFallbackBanner(typed, clientVersion, random)
+    pickFallbackBanner(typed, clientVersion, now, random)
   );
 }
 
@@ -306,44 +328,29 @@ export function selectDisplayableBanner({
   const typed = typeof json === 'object' && json !== null ? (json as TipsBannerJson) : {};
   const active = pickActiveBanner(typed, clientVersion, now);
   if (active !== null && shouldDisplayBanner(active, state, now)) return active;
-  const candidates = pickFallbackCandidates(typed, clientVersion).filter((candidate) =>
+  const candidates = pickFallbackCandidates(typed, clientVersion, now).filter((candidate) =>
     shouldDisplayBanner(candidate, state, now),
   );
   return pickRandomCandidate(candidates, random);
 }
 
 export class BannerProvider {
-  constructor(
-    private readonly clientVersion: string,
-    private readonly url: string = kimiCodeTipsBannerUrl(),
-  ) {}
+  constructor(private readonly clientVersion: string) {}
 
-  async load(
-    fetchImpl: typeof fetch = fetch,
-    options: BannerProviderLoadOptions = {},
-  ): Promise<BannerState | null> {
-    try {
-      const controller = new AbortController();
-      const timeout = setTimeout(() => {
-        controller.abort();
-      }, 3000);
-      const response = await fetchImpl(this.url, { signal: controller.signal });
-      clearTimeout(timeout);
-      if (!response.ok) return null;
-      const json = await response.json();
-      const now = options.now ?? new Date();
-      const random = options.random ?? Math.random;
-      return options.state === undefined
-        ? selectBannerState(json, this.clientVersion, now, random)
-        : selectDisplayableBanner({
-            json,
-            clientVersion: this.clientVersion,
-            now,
-            random,
-            state: options.state,
-          });
-    } catch {
-      return null;
-    }
+  async load(options: BannerProviderLoadOptions = {}): Promise<BannerState | null> {
+    // getBannerConfig never throws; undefined means "config unavailable".
+    const json = await getBannerConfig();
+    if (json === undefined) return null;
+    const now = options.now ?? new Date();
+    const random = options.random ?? Math.random;
+    return options.state === undefined
+      ? selectBannerState(json, this.clientVersion, now, random)
+      : selectDisplayableBanner({
+          json,
+          clientVersion: this.clientVersion,
+          now,
+          random,
+          state: options.state,
+        });
   }
 }

--- a/apps/kimi-code/src/tui/kimi-tui.ts
+++ b/apps/kimi-code/src/tui/kimi-tui.ts
@@ -665,7 +665,7 @@ export class KimiTUI {
     const provider = new BannerProvider(this.state.appState.version);
     const displayState = await readBannerDisplayState();
     const now = new Date();
-    const banner = await provider.load(fetch, {
+    const banner = await provider.load({
       state: displayState,
       now,
     });

--- a/apps/kimi-code/test/tui/banner/banner-provider.test.ts
+++ b/apps/kimi-code/test/tui/banner/banner-provider.test.ts
@@ -428,6 +428,105 @@ describe('selectBannerState', () => {
       ttlHours: 168,
     });
   });
+
+  it('shows the banner when banner_platform is missing, empty, all, or cli', () => {
+    for (const banner_platform of [undefined, null, '', '  ', 'all', 'cli', 'ALL', ' CLI ']) {
+      const result = selectBannerState(
+        {
+          banner_enabled: true,
+          banner_maintext: 'Active',
+          banner_platform,
+        },
+        '0.14.0',
+        now,
+        () => 0,
+      );
+      expect(result, `platform=${String(banner_platform)}`).not.toBeNull();
+    }
+  });
+
+  it('skips the active banner when banner_platform targets other platforms', () => {
+    for (const banner_platform of ['desktop', 'web']) {
+      const result = selectBannerState(
+        {
+          banner_enabled: true,
+          banner_maintext: 'Active',
+          banner_platform,
+          banner_fallback_enabled: true,
+          banner_fallback_list: [{ enabled: true, banner_maintext: 'Fallback' }],
+        },
+        '0.14.0',
+        now,
+        () => 0,
+      );
+      expectAlwaysBanner(result, { tag: null, mainText: 'Fallback', subText: null });
+    }
+  });
+
+  it('filters fallback entries by banner_platform', () => {
+    const result = selectBannerState(
+      {
+        banner_enabled: false,
+        banner_fallback_enabled: true,
+        banner_fallback_list: [
+          { enabled: true, banner_maintext: 'Desktop tip', banner_platform: 'desktop' },
+          { enabled: true, banner_maintext: 'Web tip', banner_platform: 'web' },
+          { enabled: true, banner_maintext: 'Cli tip', banner_platform: 'cli' },
+        ],
+      },
+      '0.14.0',
+      now,
+      () => 0.99,
+    );
+    expectAlwaysBanner(result, { tag: null, mainText: 'Cli tip', subText: null });
+  });
+
+  it('filters fallback entries by their time window', () => {
+    const result = selectBannerState(
+      {
+        banner_enabled: false,
+        banner_fallback_enabled: true,
+        banner_fallback_list: [
+          {
+            enabled: true,
+            banner_maintext: 'Expired tip',
+            banner_end_time: '2026-06-01T00:00:00+08:00',
+          },
+          {
+            enabled: true,
+            banner_maintext: 'Future tip',
+            banner_start_time: '2026-07-01T00:00:00+08:00',
+          },
+          {
+            enabled: true,
+            banner_maintext: 'Current tip',
+            banner_start_time: '2026-06-01T00:00:00+08:00',
+            banner_end_time: '2026-06-30T00:00:00+08:00',
+          },
+        ],
+      },
+      '0.14.0',
+      now,
+      () => 0.99,
+    );
+    expectAlwaysBanner(result, { tag: null, mainText: 'Current tip', subText: null });
+  });
+
+  it('treats fallback entries without time fields as always valid', () => {
+    const result = selectBannerState(
+      {
+        banner_enabled: false,
+        banner_fallback_enabled: true,
+        banner_fallback_list: [
+          { enabled: true, banner_maintext: 'No window', banner_start_time: '', banner_end_time: null },
+        ],
+      },
+      '0.14.0',
+      now,
+      () => 0,
+    );
+    expectAlwaysBanner(result, { tag: null, mainText: 'No window', subText: null });
+  });
 });
 
 describe('shouldDisplayBanner', () => {


### PR DESCRIPTION
## Related Issue

Internal request — no linked issue.

## Problem

The startup tips banner is served from a CDN-hosted `tips.json`. Banner content needs to be managed through the backend `client_configs` endpoint instead, with per-platform targeting so the CLI, desktop, and web clients can receive different banner content from a single config.

## What changed

- `BannerProvider` now reads the `client_banner` config from the `POST /client_configs` endpoint instead of fetching `tips.json` from the CDN. The config is fetched fresh on every startup (no caching), and any failure degrades to "no banner". The payload keeps the existing tips.json shape.
- New `banner_platform` field on the top-level banner and on fallback entries: missing / empty / `all` targets every platform; the CLI shows entries targeting `all` or `cli` and skips everything else (e.g. `desktop`, `web`).
- Fallback entries now honor `banner_start_time` / `banner_end_time` scheduling windows with the same semantics as the active banner, and the fields participate in the content-hash banner key.
- Removed the now-unused CDN tips.json URL constant.
- Tests: platform filtering for the active banner and fallback entries, and fallback time-window filtering.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [ ] I have linked a related issue (external PRs: the issue must have a maintainer's `/approve`).
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.
