### PR TITLE
chore(datasource): add changeset for the 13 new sources

### DIFF
--- a/.changeset/datasource-new-sources.md
+++ b/.changeset/datasource-new-sources.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Add 13 data sources to the official Kimi Datasource plugin — Chinese government data (NDA/NBS) and standards (GB/HB/DB/TT), eight international organization datasets (WHO, FAO, UNSD, ECB, Eurostat, UNICEF, OECD, FRED), Xinhua Finance, and Caixin. Update the plugin from the Official tab in /plugins.


### PR DESCRIPTION
## Related Issue

Follow-up to #3115.

## Problem

#3115 shipped the Kimi Datasource plugin v3.4.0 content (13 new data sources, rewritten plugin description) without a changeset, so the next CLI release changelog would not mention it. Users should see the new data coverage in the release notes.

## What changed

Adds a single changeset marking `@moonshot-ai/kimi-code` as `minor`: the official Kimi Datasource plugin gains 13 data sources (Chinese government data and standards, eight international organization datasets, Xinhua Finance, Caixin), which users could not query before. No code changes.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [x] I have added tests that prove my feature works — N/A, changeset-only PR; the feature tests landed in #3115.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset — this PR is the changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update — docs landed in #3115.
