### PR TITLE
docs: restructure the secondary_model config section for scannability

### DIFF
--- a/docs/en/configuration/config-files.md
+++ b/docs/en/configuration/config-files.md
@@ -196,24 +196,31 @@ Subagents inherit the model the main agent is running by default. The `[secondar
 
 ### Subagent model pool
 
-This feature is experimental and disabled by default. Enable it with `KIMI_CODE_EXPERIMENTAL_SECONDARY_MODEL=1`, or the master `KIMI_CODE_EXPERIMENTAL_FLAG=1`. It takes effect in every launch mode, including the interactive TUI. While the experiment is off, the pool keys stay inert: subagents inherit the caller's model and session startup skips the pool validation.
+This feature is experimental and disabled by default. Enable it with `KIMI_CODE_EXPERIMENTAL_SECONDARY_MODEL=1`, or the master `KIMI_CODE_EXPERIMENTAL_FLAG=1`; it takes effect in every launch mode, including the interactive TUI. While the experiment is off, the pool keys stay inert: subagents inherit the caller's model and session startup skips the pool validation.
 
-To simply point every subagent at one model by default, no models table is needed — a single `default_model` line is a pool with a single entry:
+The minimal configuration is one line — a lone `default_model` is a pool with a single entry:
 
 ```toml
 [secondary_model]
 default_model = "kimi-code/kimi-for-coding-highspeed"
 ```
 
-In the interactive TUI, the [`/secondary-model`](../reference/slash-commands.md) command (alias `/subagent-model`) opens a model selector for this: the choice is written to `default_model` (when a models table exists and the picked alias is not in it, an entry with an empty description is added), and newly spawned subagents pick up the new default immediately — no session restart needed.
-
 | Field | Type | Default | Description |
 | --- | --- | --- | --- |
-| `default_model` | `string` | — | Default subagent model. Required when `[secondary_model.models]` is configured, and must be one of its keys; written on its own (without a models table) it is equivalent to a pool containing only that entry |
-| `models` | `table<string, string>` | — | Subagent model pool. Each key is the alias of a configured [`[models]`](#models) entry; each value is the description the main agent sees when picking a subagent model (Chinese or English; an empty string lists the alias with no hint) |
-| `force` | `boolean` | `false` | Pin every subagent to `default_model`: the `model` parameter is not advertised, so the main agent cannot pick another model or `"primary"`. Requires `default_model`; cannot be combined with `[secondary_model.models]` |
+| `default_model` | `string` | — | The default model for subagents |
+| `models` | `table<string, string>` | — | Subagent model pool. Each key is the alias of a configured [`[models]`](#models) entry; each value is the selection hint shown to the main agent |
+| `force` | `boolean` | `false` | Pin every subagent to `default_model`, taking the choice away from the main agent |
 
-A configured pool — an explicit `[secondary_model.models]` table or a lone `default_model` — enables model selection: the `Agent` / `AgentSwarm` tools gain a `model` parameter, and the tool description lists the pool (the default marked `[default]`) so the main agent can choose per spawn (unless `force` is set — see below). The pool only references configured [`[models]`](#models) entries — the `kimi-code/*` aliases below are provisioned by `/login` — and attaches the selection hints:
+Constraints between the fields:
+
+- `default_model`: required when a `models` table is configured, and must be one of its keys.
+- `models`: values may be Chinese or English; an empty string lists the alias with no hint.
+- `force`: requires `default_model` and cannot be combined with a `models` table — the table exists to offer a choice, and force removes it.
+- `primary` is a reserved alias (see below) and cannot be a pool key.
+
+In the interactive TUI, the [`/secondary-model`](../reference/slash-commands.md) command (alias `/subagent-model`) opens a model selector: the choice is written to `default_model` (when a models table exists and the picked alias is not in it, an entry with an empty description is added), and newly spawned subagents pick up the new default immediately — no session restart needed.
+
+A configured pool — an explicit `models` table or a lone `default_model` — enables model selection: the `Agent` / `AgentSwarm` tools gain a `model` parameter, and the tool description lists the pool (the default marked `[default]`) so the main agent can choose per spawn. Pool keys can only reference configured [`[models]`](#models) entries — the `kimi-code/*` aliases below are provisioned by `/login`:
 
 ```toml
 [secondary_model]
@@ -224,9 +231,20 @@ default_model = "kimi-code/kimi-for-coding-highspeed"
 "kimi-code/kimi-for-coding" = "A balanced coding workhorse. Good for most feature development and code-change tasks."
 ```
 
-A spawn resolves the subagent's model in this order: an explicit tool-call `model` → `default_model`. The `model` parameter accepts any pool alias, or `"primary"` — the model the caller itself is running, always valid even when that model is not in the pool. When neither `default_model` nor `[secondary_model.models]` is configured, the parameter is not advertised and subagents inherit the caller's model. Binding a pool alias carries no explicit thinking effort — the subagent resolves it naturally (global `[thinking]` config → the bound model's default effort) instead of inheriting the caller's level, while `"primary"` inherits both the model and the level from the caller.
+A spawn resolves the subagent's model in this order:
 
-To take the choice away from the main agent entirely — every subagent runs on one fixed model — add `force = true`:
+1. An explicit `model` passed in the tool call
+2. `default_model`
+
+Rules for the `model` parameter:
+
+- It accepts any pool alias, or `"primary"` — the model the caller itself is running, always valid even when not in the pool.
+- When neither `default_model` nor `models` is configured, the parameter is not advertised and subagents inherit the caller's model.
+- Binding a pool alias carries no explicit thinking effort: the subagent resolves it as "global `[thinking]` config → the bound model's default effort" instead of inheriting the caller's level.
+- `"primary"` inherits both the model and the effort level from the caller.
+- A value that is neither a pool alias nor `"primary"` fails the spawn with an error listing the available choices.
+
+To take the choice away from the main agent and run every subagent on one fixed model, add `force = true`:
 
 ```toml
 [secondary_model]
@@ -234,9 +252,14 @@ default_model = "kimi-code/kimi-for-coding-highspeed"
 force = true
 ```
 
-With `force` set, the `model` parameter is not advertised (just like when nothing is configured) and every spawn binds `default_model`; an explicit `model` argument, `"primary"` included, is rejected with an error. `force` requires `default_model` and cannot be combined with a `[secondary_model.models]` table — the table exists to offer a choice, and force removes it.
+With `force` set, the `model` parameter is not advertised (just like when nothing is configured) and every spawn binds `default_model`; an explicit `model` argument, `"primary"` included, is rejected with an error.
 
-Because natural resolution lands on the bound model's default effort, different pool entries can carry different thinking levels: register a second `[models]` entry as a "variant" of the same underlying model, override only its `default_effort` via [`[models."<alias>".overrides]`](#model-overrides), and list both aliases in the pool — the main agent picks the thinking level together with the alias. Two prerequisites: the underlying model must declare `support_efforts` (under `managed:kimi-code` only the k3 family currently declares effort levels), and the variant is a standalone entry that does not inherit fields from the entry it points at — copy `capabilities`, `support_efforts`, and the other metadata over in full, otherwise `default_effort` has no effect (it must be a member of `support_efforts`):
+### Different thinking efforts per pool entry
+
+Binding a pool alias lands the subagent on the bound model's default effort. You can exploit this by registering a "variant" entry for the same underlying model, so the main agent picks the thinking level together with the alias:
+
+1. Register a second entry for the same underlying model in [`[models]`](#models), overriding only `default_effort` via [`[models."<alias>".overrides]`](#model-overrides).
+2. List both the original alias and the variant alias in the pool.
 
 ```toml
 # "kimi-code/k3" is provisioned by /login (default: high); this registers
@@ -258,9 +281,19 @@ default_model = "kimi-code/k3"
 k3-max = "The same model at max thinking effort. Good for the hardest subtasks."
 ```
 
-Note that `default_effort` stays a model-level default: once a global `[thinking].effort` is set, it wins for the main agent and subagents alike, and the variant's default only applies when no global effort is set. Value and fallback rules follow the [`[models]` entry's `default_effort`](#models).
+Two prerequisites:
 
-Configuration errors fail loudly instead of falling back silently: session creation, resume, and fork all fail at startup when `default_model` is missing, is not a pool key, or a pool key does not resolve to a configured `[models]` entry — and likewise when `force` is set without `default_model` or combined with a `[secondary_model.models]` table. The alias `primary` is reserved — it always binds the caller's own model — and is rejected as a pool key. A spawn whose `model` is neither a pool alias nor `"primary"` fails with an error listing the available choices.
+- The underlying model must declare `support_efforts` (under `managed:kimi-code` only the k3 family currently declares effort levels).
+- The variant is a standalone entry and does not inherit fields from the entry it points at — copy `capabilities`, `support_efforts`, and the other metadata over in full, otherwise `default_effort` has no effect (it must be a member of `support_efforts`).
+
+Also note that `default_effort` stays a model-level default: once a global `[thinking].effort` is set, it wins for the main agent and subagents alike, and the variant's default only applies when no global effort is set. Value and fallback rules follow the [`[models]` entry's `default_effort`](#models).
+
+::: warning Note
+Configuration errors fail loudly instead of falling back silently. Session creation, resume, and fork all fail at startup when:
+
+- `default_model` is missing, is not a pool key, or a pool key does not resolve to a configured [`[models]`](#models) entry;
+- `force` is set without `default_model`, or combined with a `models` table.
+:::
 
 ## `thinking`
 

--- a/docs/zh/configuration/config-files.md
+++ b/docs/zh/configuration/config-files.md
@@ -192,28 +192,35 @@ display_name = "Kimi for Coding (custom)"
 
 ## `secondary_model`
 
-subagent 默认继承 main agent 正在运行的模型。`[secondary_model]` 节把这件事变成可配置的：为 subagent 准备一批候选模型（模型池）并指定默认绑定——通常是一个更便宜的模型，供不需要主模型能力的子任务使用。
+subagent 默认继承 main agent 正在运行的模型。`[secondary_model]` 节把这件事变成可配置的：为 subagent 准备一批候选模型（模型池）并指定默认绑定——典型用法是给不需要主模型能力的子任务换一个更便宜的模型。
 
 ### subagent 模型池
 
-该功能目前是实验功能，默认关闭。通过 `KIMI_CODE_EXPERIMENTAL_SECONDARY_MODEL=1` 启用，或使用 master `KIMI_CODE_EXPERIMENTAL_FLAG=1`。它在包括交互式 TUI 在内的所有启动方式下生效。实验功能关闭时，模型池配置不生效：subagent 继承调用方模型，会话启动也会跳过池校验。
+该功能目前是实验功能，默认关闭。通过 `KIMI_CODE_EXPERIMENTAL_SECONDARY_MODEL=1` 启用，或使用 master `KIMI_CODE_EXPERIMENTAL_FLAG=1`，在包括交互式 TUI 在内的所有启动方式下生效。实验功能关闭时模型池配置不生效：subagent 继承调用方模型，会话启动也会跳过池校验。
 
-只想让所有 subagent 默认换用一个模型时不需要 models 表——一行 `default_model` 就是只含一个条目的模型池：
+最小配置只有一行——单独写下的 `default_model` 就是只含一个条目的模型池：
 
 ```toml
 [secondary_model]
 default_model = "kimi-code/kimi-for-coding-highspeed"
 ```
 
-在交互式 TUI 中，也可以用 [`/secondary-model`](../reference/slash-commands.md) 命令（别名 `/subagent-model`）打开模型选择器来设置：选择后写入 `default_model`（已有 models 表而所选别名不在其中时，会一并补一条空描述条目），之后派生的 subagent 立即按新默认值绑定，无需重启会话。
-
 | 字段 | 类型 | 默认值 | 说明 |
 | --- | --- | --- | --- |
-| `default_model` | `string` | — | subagent 默认模型。配置 `[secondary_model.models]` 时必填，且必须是其中的 key；单独写下它（不写 models 表）则等价于只含它一个条目的模型池 |
-| `models` | `table<string, string>` | — | subagent 模型池。key 是 [`[models]`](#models) 中已配置条目的别名，value 是 main agent 挑选 subagent 模型时看到的描述（中英文均可；空字符串表示只列出别名、不给提示） |
-| `force` | `boolean` | `false` | 把所有 subagent 固定到 `default_model`：不再提供 `model` 参数，main agent 无法改选其他模型或 `"primary"`。必须配置 `default_model`，且不能与 `[secondary_model.models]` 同时使用 |
+| `default_model` | `string` | — | subagent 的默认模型 |
+| `models` | `table<string, string>` | — | subagent 模型池。key 是 [`[models]`](#models) 条目的别名，value 是给 main agent 的挑选提示 |
+| `force` | `boolean` | `false` | 把所有 subagent 固定到 `default_model`，收回 main agent 的选择权 |
 
-配置模型池（显式的 `[secondary_model.models]` 表，或仅一行 `default_model` 形成的隐式单条目池）即启用模型选择：`Agent` / `AgentSwarm` 工具会获得 `model` 参数，工具描述中会列出模型池（默认模型标注 `[default]`），main agent 可按次派生选择模型（除非设置了 `force`，见下文）。模型池只引用已配置的 [`[models]`](#models) 条目——下面的 `kimi-code/*` 别名由 `/login` 自动提供——并附上挑选提示：
+字段之间的约束：
+
+- `default_model`：配置 `models` 表时必填，且必须是其中的 key。
+- `models`：value 中英文均可；空字符串表示只列出别名、不给提示。
+- `force`：必须搭配 `default_model`，且不能与 `models` 表同用——表的意义在于提供选择，而 force 取消了选择。
+- `primary` 是保留字（含义见下文），不能作为池中 key。
+
+在交互式 TUI 中，也可以用 [`/secondary-model`](../reference/slash-commands.md) 命令（别名 `/subagent-model`）打开模型选择器：选择后写入 `default_model`（已有 models 表而所选别名不在其中时，会一并补一条空描述条目），之后派生的 subagent 立即按新默认值绑定，无需重启会话。
+
+配置了模型池（显式的 `models` 表或隐式的单条目池）即启用模型选择：`Agent` / `AgentSwarm` 工具会获得 `model` 参数，工具描述中列出模型池（默认模型标注 `[default]`），main agent 可按次派生选择模型。池 key 只能引用已配置的 [`[models]`](#models) 条目——下面的 `kimi-code/*` 别名由 `/login` 自动提供：
 
 ```toml
 [secondary_model]
@@ -224,9 +231,20 @@ default_model = "kimi-code/kimi-for-coding-highspeed"
 "kimi-code/kimi-for-coding" = "均衡的编码主力。适合大多数功能开发和代码修改任务。"
 ```
 
-派生时按以下顺序解析 subagent 的模型：工具调用显式传入的 `model` → `default_model`。`model` 参数接受池中任意别名，或 `"primary"` ——调用方自己正在运行的模型，始终合法，即使它不在池中。`default_model` 与 `[secondary_model.models]` 都未配置时，该参数不会出现，subagent 继承调用方模型。绑定池中别名时不携带显式 Thinking 档位——subagent 按 "全局 `[thinking]` 配置 → 所绑定模型的默认 effort" 自然解析，不继承调用方的档位；`"primary"` 则连模型带档位一起继承调用方。
+派生时按以下顺序解析 subagent 的模型：
 
-要彻底收回 main agent 的选择权——让所有 subagent 固定跑在同一个模型上——加上 `force = true`：
+1. 工具调用显式传入的 `model`
+2. `default_model`
+
+`model` 参数的取值规则：
+
+- 接受池中任意别名，或 `"primary"`——调用方自己正在运行的模型，始终合法，即使不在池中。
+- `default_model` 与 `models` 都未配置时该参数不存在，subagent 继承调用方模型。
+- 绑定池中别名时不携带显式 Thinking 档位：subagent 按 "全局 `[thinking]` 配置 → 所绑定模型的默认 effort" 解析，不继承调用方的档位。
+- `"primary"` 则连模型带档位一起继承调用方。
+- 传入的值既不是池中别名也不是 `"primary"` 时，本次派生报错并列出可选值。
+
+要收回 main agent 的选择权、让所有 subagent 固定跑同一个模型，加上 `force = true`：
 
 ```toml
 [secondary_model]
@@ -234,9 +252,14 @@ default_model = "kimi-code/kimi-for-coding-highspeed"
 force = true
 ```
 
-设置 `force` 后不再提供 `model` 参数（与完全未配置时一样），每次派生都绑定 `default_model`；显式传入 `model`（包括 `"primary"`）会报错。`force` 必须搭配 `default_model`，且不能与 `[secondary_model.models]` 表同时使用——表的意义在于提供选择，而 force 取消了选择。
+设置 `force` 后不再提供 `model` 参数（与完全未配置时一样），每次派生都绑定 `default_model`；显式传入 `model`（包括 `"primary"`）会报错。
 
-利用自然解析会落到所绑定模型的默认 effort 这一点，可以给池中不同条目配不同的 Thinking 档位：为同一个底层模型再注册一个 `[models]` 条目作为「变体」，用 [`[models."<alias>".overrides]`](#模型覆盖项) 只覆盖 `default_effort`，再把两个别名都放进模型池——main agent 挑选别名时便同时选定了档位。有两个前提：底层模型必须声明了 `support_efforts`（`managed:kimi-code` 下目前只有 k3 系列声明了档位）；且变体是独立条目，不会继承被指向条目的字段——`capabilities`、`support_efforts` 等元数据要完整照抄，否则 `default_effort` 不生效（它必须是 `support_efforts` 列表中的值）：
+### 为池内条目配置不同 Thinking 档位
+
+绑定池中别名时，subagent 的 Thinking 档位会落到所绑定模型的默认 effort。利用这一点，可以为同一底层模型注册一个「变体」条目，让 main agent 选别名时同时选定档位：
+
+1. 在 [`[models]`](#models) 中为同一底层模型再注册一个条目，用 [`[models."<alias>".overrides]`](#模型覆盖项) 只覆盖 `default_effort`。
+2. 把原别名和变体别名都放进模型池。
 
 ```toml
 # "kimi-code/k3" 由 /login 提供（默认 high 档）；这里为同一模型注册一个 max 档位变体
@@ -257,9 +280,19 @@ default_model = "kimi-code/k3"
 k3-max = "同一模型的 max Thinking 档位。适合最难的子任务。"
 ```
 
-注意 `default_effort` 是模型级默认值：一旦设置了全局 `[thinking].effort`，它对 main agent 和 subagent 都优先生效，变体的默认档位只在全局未设置时起作用。取值与回落规则同 [`[models]` 条目的 `default_effort`](#models)。
+两个前提：
 
-配置错误一律直接报错，不做静默回退：`default_model` 缺失、不是池中 key，或池中 key 无法解析到已配置的 `[models]` 条目时，会话的创建、恢复（resume）与 fork 都会在启动时直接失败；`force` 未搭配 `default_model` 或与 `[secondary_model.models]` 表同用时亦然。别名 `primary` 是保留字——它始终绑定调用方自己的模型——不能作为池中 key。工具调用传入的 `model` 既不是池中别名也不是 `"primary"` 时，本次派生报错并列出可选值。
+- 底层模型必须声明了 `support_efforts`（`managed:kimi-code` 下目前只有 k3 系列声明了档位）。
+- 变体是独立条目，不会继承被指向条目的字段——`capabilities`、`support_efforts` 等元数据要完整照抄，否则 `default_effort` 不生效（它必须是 `support_efforts` 列表中的值）。
+
+另外注意，`default_effort` 只是模型级默认值：全局 `[thinking].effort` 一旦设置，对 main agent 和 subagent 都优先生效，变体的默认档位只在全局未设置时起作用。取值与回落规则同 [`[models]` 条目的 `default_effort`](#models)。
+
+::: warning 注意
+配置错误一律直接报错，不做静默回退。出现以下情况时，会话的创建、恢复（resume）与 fork 都会在启动时失败：
+
+- `default_model` 缺失、不是池中 key，或池中 key 无法解析到已配置的 [`[models]`](#models) 条目；
+- `force` 未搭配 `default_model`，或与 `models` 表同时使用。
+:::
 
 ## `thinking`
 


### PR DESCRIPTION
## Related Issue

N/A — internal docs-only change, no linked issue.

## Problem

The `secondary_model` section in the configuration docs was reported as too dense to parse: field semantics buried in long table cells, spawn-time resolution order / `"primary"` / thinking-effort inheritance packed into single multi-clause sentences, and advanced content (per-entry effort variants, config-error semantics) mixed into the main reading path.

## What changed

Restructured the section in both locales (`docs/zh` + `docs/en`, mirrored), keeping every behavioral fact from the original text:

- Lead with the minimal one-line config, then a one-sentence-per-row field table.
- Cross-field constraints (required keys, `force` / `models` mutual exclusion, reserved `primary`) moved into bullets.
- Spawn-time model resolution becomes a numbered list; `model` parameter rules become bullets.
- Per-entry thinking-effort variants split into their own subsection (steps + prerequisites).
- Config-error semantics collapsed into a `::: warning` callout.

No code changes. Verified with `npm run build` in `docs/`.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [ ] I have linked a related issue (N/A — internal docs change).
- [ ] I have added tests that prove my feature works. (N/A — docs only; `npm run build` in `docs/` passes)
- [x] Ran `gen-changesets` skill, or this PR needs no changeset. (No changeset: docs-only change that never enters the shipped artifact.)
- [x] Ran `gen-docs` skill, or this PR needs no doc update. (This PR is itself the doc update.)