### PR TITLE
fix(agent-core-v2): remove duplicate launch-time subagent.spawned

### DIFF
--- a/packages/agent-core-v2/src/agent/tools/agent/agentTool.ts
+++ b/packages/agent-core-v2/src/agent/tools/agent/agentTool.ts
@@ -344,15 +344,6 @@ export class SubagentTool implements ISubagentTool {
       });
     }
 
-    const runInBackground = args.run_in_background === true;
-    emitAgentRunSpawned(requester, agentId, {
-      profileName,
-      parentToolCallId: toolCallId,
-      description: args.description,
-      runInBackground,
-      model: displayModel,
-    });
-
     const target = this.lifecycle.findAgentHandle(agentId);
     if (target === undefined) throw new Error(`Agent "${agentId}" does not exist`);
     const run = await this.subagents.run(

--- a/packages/agent-core-v2/test/tool/tool.test.ts
+++ b/packages/agent-core-v2/test/tool/tool.test.ts
@@ -1335,6 +1335,29 @@ describe('Agent tool execution contract', () => {
     expect(result.output).toContain('child result');
   });
 
+  it('emits subagent.spawned exactly once, after task registration, carrying the task id', async () => {
+    const lifecycle = createAgentLifecycleStub({
+      createAgentIds: ['agent-child'],
+      runCompletion: async () => ({ summary: 'child result' }),
+    });
+    const context = createAgentToolContext(lifecycle);
+
+    await executeAgentTool(context, {
+      prompt: 'Investigate',
+      description: 'Find cause',
+      subagent_type: 'explore',
+    });
+
+    const spawned = lifecycle.publishedEvents.filter(
+      (event) => event.type === 'subagent.spawned',
+    );
+    expect(spawned).toHaveLength(1);
+    expect(spawned[0]).toMatchObject({
+      subagentId: 'agent-child',
+      taskId: expect.any(String),
+    });
+  });
+
   it('spawns the subagent on the pool default model when the tool call omits model', async () => {
     const lifecycle = createAgentLifecycleStub({ createAgentIds: ['agent-child'] });
     const context = createAgentToolContext(lifecycle, secondaryModelFlags(), {


### PR DESCRIPTION
## Related Issue

No linked issue — the problem was found while investigating an internal report of subagent task rows stuck in the "running" state.

## Problem

Every Agent-tool subagent emits `subagent.spawned` twice: once inside `launch()` right after the agent scope is created (without a task id), and once after `registerTask` succeeds (carrying the task id). The launch-time emission had been deliberately removed by #3005 and was accidentally reintroduced by the model-as-container refactor #3103.

Downstream effects of the duplicate:

- Transcript-protocol consumers (`AgentTranscriptProjector.onSubagentSpawned`) create a second task row keyed by the agent id; `subagent.started/completed/failed` fold only into the task-id-keyed row, so the agent-id-keyed row stays `running` forever after the subagent has finished.
- The spawning tool frame gets the same agent ref appended twice.
- The `subagent_created` telemetry event is double-counted.

## What changed

- `packages/agent-core-v2/src/agent/tools/agent/agentTool.ts`: removed the launch-time `emitAgentRunSpawned` call (and the `runInBackground` local that only fed it), restoring the #3005 semantics — `subagent.spawned` is emitted exactly once, after task registration, carrying the task id, followed by `subagent.started`.
- `packages/agent-core-v2/test/tool/tool.test.ts`: added a regression test asserting the Agent tool emits `subagent.spawned` exactly once and that the event carries the registered task id.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [ ] I have linked a related issue (external PRs: the issue must have a maintainer's `/approve`).
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.
