### PR TITLE
feat: add Tencent CloudBase plugin to the curated marketplace

### DIFF
--- a/.changeset/cloudbase-marketplace.md
+++ b/.changeset/cloudbase-marketplace.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Add the Tencent CloudBase plugin to the curated marketplace.

--- a/plugins/marketplace.json
+++ b/plugins/marketplace.json
@@ -45,6 +45,16 @@
       "homepage": "https://github.com/GoogleChrome/modern-web-guidance",
       "keywords": ["web", "css", "browser", "frontend", "skills"],
       "source": "https://github.com/GoogleChrome/modern-web-guidance"
+    },
+    {
+      "id": "cloudbase",
+      "tier": "curated",
+      "displayName": "Tencent CloudBase",
+      "version": "0.2.0",
+      "description": "Build, deploy, and manage Tencent CloudBase apps — databases, cloud functions, storage, auth, and hosting, powered by cloudbase-mcp.",
+      "homepage": "https://github.com/TencentCloudBase/CloudBase-AI-Toolkit",
+      "keywords": ["cloudbase", "tencent-cloud", "baas", "database", "cloud-function", "mcp"],
+      "source": "https://github.com/TencentCloudBase/CloudBase-AI-Toolkit/releases/latest/download/cloudbase-kimi.zip"
     }
   ]
 }


### PR DESCRIPTION
## Related Issue

N/A — internal plugin-marketplace onboarding. Upstream plugin manifest: [TencentCloudBase/CloudBase-AI-Toolkit#932](https://github.com/TencentCloudBase/CloudBase-AI-Toolkit/pull/932).

## Problem

The curated marketplace had no Tencent CloudBase entry. Upstream ships an official Kimi plugin manifest and, per our recommendation, now publishes a single-plugin zip (`cloudbase-kimi.zip`) as a GitHub release asset — so the marketplace can list it like any other curated plugin.

## What changed

- `plugins/marketplace.json`: new curated `cloudbase` entry. `source` points at the upstream release asset via the stable latest-release URL (`releases/latest/download/cloudbase-kimi.zip`); `version` is pinned to the plugin manifest version (0.2.0), which upstream versions independently of the toolkit's own release numbers — so the update badge only moves when the plugin itself revs.
- Changeset: `patch`.

Verified end to end against the real artifacts: installing through the new entry downloads the upstream zip and yields a healthy plugin (29 skills discovered, `plugin-cloudbase:cloudbase` MCP server enabled, `sessionStart` routing skill wired, no diagnostics, reinstall idempotent). CLI marketplace tests (33) pass.

Testing note: installing within seconds of an upstream release can hit a transient MCP startup failure if the GitHub asset lands before `@cloudbase/cloudbase-mcp` finishes publishing on npm (the manifest pins the exact MCP version). Flagged to upstream; retrying after the npm publish resolves it.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue (external PRs: the issue must have a maintainer's `/approve`). N/A — internal change.
- [x] I have added tests that prove my feature works. Existing CLI marketplace tests cover catalog parsing/loading; the entry itself was verified by installing the real upstream artifact (see above).
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.
