### PR TITLE
fix(agent-core-v2): let session archive proceed after a failed resume

### DIFF
--- a/.changeset/archive-missing-workspace.md
+++ b/.changeset/archive-missing-workspace.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Fix sessions failing to archive when their workspace folder no longer exists.

--- a/packages/agent-core-v2/src/workspace/sessionLifecycle/coldSessionArchive.ts
+++ b/packages/agent-core-v2/src/workspace/sessionLifecycle/coldSessionArchive.ts
@@ -72,7 +72,7 @@ export async function setSessionArchived(
 ): Promise<ColdSessionArchiveOutcome> {
   const manager = accessor.get(ISessionManager);
   return manager.withLifecycleSerialization(sessionId, async (unguarded) => {
-    await manager.whenResumeSettled(sessionId);
+    await manager.whenResumeSettled(sessionId).catch(() => undefined);
     const live = getLiveSessionById(accessor, sessionId);
     if (live !== undefined) {
       if (archived) await unguarded.archive();

--- a/packages/agent-core-v2/test/workspace/sessionLifecycle/coldSessionArchive.test.ts
+++ b/packages/agent-core-v2/test/workspace/sessionLifecycle/coldSessionArchive.test.ts
@@ -171,20 +171,16 @@ describe('setSessionArchivedBatch', () => {
     expect(persisted['isCustomTitle']).toBe(true);
   });
 
-  it('fails the item when a concurrent resume failed instead of cold-classifying', async () => {
+  it('cold-classifies the item when a concurrent resume failed', async () => {
     const outcomes = await setSessionArchivedBatch(
       coldPathAccessor({
-        storeGet: async () => {
-          throw new Error('unreachable — the settle throws first');
-        },
+        storeGet: async () => ({ id: 's1', createdAt: 1, updatedAt: 2, archived: false }),
         resumeError: new Error('resume boom'),
       }),
       ['s1'],
       true,
     );
-    expect(outcomes).toEqual([
-      { id: 's1', ok: false, reason: 'error', message: 'resume boom' },
-    ]);
+    expect(outcomes).toEqual([{ id: 's1', ok: true }]);
   });
 
   it('reads and migrates the legacy session-meta location before answering not_found', async () => {

--- a/packages/kap-server/test/sessions.test.ts
+++ b/packages/kap-server/test/sessions.test.ts
@@ -20,9 +20,11 @@ import {
   IEventService,
   ISessionCronService,
   ISessionManager,
+  IWorkspaceService,
   MAIN_AGENT_ID,
   closeSessionById,
   getLiveSessionById,
+  resumeSessionById,
   sessionDirOf,
   type ServiceIdentifier,
   type ScopeSeed,
@@ -772,6 +774,30 @@ describe('server-v2 /api/v1/sessions', () => {
     const cwd = home as string;
     const created = await postJson<SessionWire>('/api/v1/sessions', { metadata: { cwd } });
     const id = created.body.data.id;
+
+    const archived = await postJson<{ archived: boolean }>(`/api/v1/sessions/${id}:archive`);
+    expect(archived.body.code).toBe(0);
+    expect(archived.body.data).toEqual({ archived: true });
+
+    const got = await getJson<SessionWire>(`/api/v1/sessions/${id}`);
+    expect(got.body.code).toBe(0);
+    expect(got.body.data.archived).toBe(true);
+  });
+
+  it('archives a cold session after a failed resume when the workspace root is gone', async () => {
+    const cwd = join(home as string, 'gone-ws');
+    await mkdir(cwd);
+    const created = await postJson<SessionWire>('/api/v1/sessions', { metadata: { cwd } });
+    const id = created.body.data.id;
+    await closeSessionById((server as RunningServer).core.accessor, id);
+    await (server as RunningServer).core.accessor
+      .get(IWorkspaceService)
+      .delete(encodeWorkDirKey(cwd));
+    await rm(cwd, { recursive: true, force: true });
+
+    await expect(
+      resumeSessionById((server as RunningServer).core.accessor, id),
+    ).rejects.toThrow(/does not exist/);
 
     const archived = await postJson<{ archived: boolean }>(`/api/v1/sessions/${id}:archive`);
     expect(archived.body.code).toBe(0);


### PR DESCRIPTION
## Related Issue

None — the problem is explained below (no tracking issue exists yet).

## Problem

Archiving a session can fail with the error of an earlier, unrelated resume attempt: after a session's workspace is unregistered and its directory deleted, opening the session fails with `workspace root ... does not exist`, and every subsequent `:archive` call for that session fails with the same error (40409) until the server restarts.

Root cause: a failed resume is cached by `SessionManager` and rethrown by `whenResumeSettled`. `setSessionArchived` awaits that settle before classifying the session as live or cold, so the stale resume error aborts the archive before it ever reaches the cold path — even though cold archive only rewrites session metadata in the home directory and never touches the workspace.

## What changed

- `setSessionArchived` still waits for an in-flight resume to settle (required for a correct live/cold classification) but no longer rethrows a historical resume failure: a failed resume leaves no live handle, so falling through to the cold metadata path is the correct behavior. Live sessions are unaffected and still go through the full lifecycle chain (agents drain, scope disposal, events).
- Added a kap-server regression test: a cold session whose resume failed because the workspace root is gone archives successfully via `:archive`.
- Inverted the agent-core-v2 unit test that pinned the old "propagate failed resumes to the next settle" behavior for archive; it now asserts the failed resume is ignored and the item is cold-classified.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue (none exists; problem explained above).
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.
