### PR TITLE
fix(agent-core-v2): stop refreshing the system prompt on AGENTS.md changes

### DIFF
--- a/packages/agent-core-v2/src/agent/profile/profileService.ts
+++ b/packages/agent-core-v2/src/agent/profile/profileService.ts
@@ -183,11 +183,6 @@ export class AgentProfileService extends Disposable implements IAgentProfileServ
       }),
     );
     this._register(
-      this.instructions.onDidChange(() => {
-        void this.refreshSystemPrompt();
-      }),
-    );
-    this._register(
       this.config.onDidSectionChange(({ domain }) => {
         if (domain === TOOLS_SECTION) {
           this.publishToolPatternWarnings();

--- a/packages/agent-core-v2/test/agent/profile/binding.test.ts
+++ b/packages/agent-core-v2/test/agent/profile/binding.test.ts
@@ -4,7 +4,7 @@ import { join, normalize } from 'pathe';
 
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { Event } from '#/_base/event';
+import { Emitter, Event } from '#/_base/event';
 import { InstantiationService } from '#/_base/di/instantiationService';
 import { ServiceCollection } from '#/_base/di/serviceCollection';
 import { ConfigTarget, IConfigService } from '#/app/config/config';
@@ -25,6 +25,7 @@ import { IAgentToolRegistryService } from '#/agent/toolRegistry/toolRegistry';
 import { SELECT_TOOLS_TOOL_NAME } from '#/agent/toolSelect/toolSelect';
 import { IAtomicDocumentStore, type IAtomicDocumentStore as AtomicDocumentStore } from '#/persistence/interface/atomicDocumentStore';
 import { ISessionAgentProfileCatalog } from '#/session/sessionAgentProfileCatalog/sessionAgentProfileCatalog';
+import { ISessionInstructionsProvider } from '#/session/sessionInstructions/instructionsProvider';
 import { ISessionSkillCatalog } from '#/session/sessionSkillCatalog/skillCatalog';
 import { ISessionToolPolicy } from '#/session/sessionToolPolicy/sessionToolPolicy';
 import { ISessionToolPolicyGate } from '#/session/sessionToolPolicyGate/sessionToolPolicyGate';
@@ -263,6 +264,45 @@ describe('AgentProfileService.bind', () => {
     } finally {
       await rm(workDir, { recursive: true, force: true });
     }
+  });
+
+  it('freezes the system prompt when the session instructions change', async () => {
+    const persistence = new InMemoryWireRecordPersistence();
+    const emitter = new Emitter<void>();
+    let agentsMd = 'v1 instructions';
+    ctx = createTestAgent(
+      { persistence },
+      hostEnvironmentServices(homeDir),
+      sessionService(ISessionInstructionsProvider, {
+        _serviceBrand: undefined,
+        ready: Promise.resolve(),
+        get agentsMd() {
+          return agentsMd;
+        },
+        agentsMdWarning: undefined,
+        agentsMdPaths: [],
+        onDidChange: emitter.event,
+      } satisfies ISessionInstructionsProvider),
+    );
+    const svc = ctx.get(IAgentProfileService);
+    await svc.bind({ profile: DEFAULT_AGENT_PROFILE_NAME, model: MOCK_MODEL });
+    const before = svc.getSystemPrompt();
+    expect(before).toContain('v1 instructions');
+    await ctx.get(IWireService).flush();
+    const configUpdates = () =>
+      persistence.records.filter(
+        (record) => record.type === 'config.update' && 'systemPrompt' in record,
+      );
+    const configUpdateCount = configUpdates().length;
+
+    const refreshSpy = vi.spyOn(svc, 'refreshSystemPrompt');
+    agentsMd = 'v2 instructions';
+    emitter.fire();
+    await ctx.get(IWireService).flush();
+
+    expect(refreshSpy).not.toHaveBeenCalled();
+    expect(svc.getSystemPrompt()).toBe(before);
+    expect(configUpdates()).toHaveLength(configUpdateCount);
   });
 
   it('setModel applies the default profile when none is bound yet', async () => {


### PR DESCRIPTION
## Related Issue

Related to #3105

## Problem

The agent profile service subscribes to session-instructions change events and re-renders the entire system prompt whenever they fire. That event channel also fires once when the first AGENTS.md load completes inside a process — so on every session resume, the system prompt restored from the wire is replaced by a fresh render. Any drift between the replayed prompt and the new render (directory listing, AGENTS.md content, skill listing) truncates the server-side prompt prefix cache at the point of difference, forcing a full recompute of the conversation history on the next request.

## What changed

- Removed the profile service's subscription to session-instructions change events, so an agent's system prompt is frozen against AGENTS.md changes for its lifetime; AGENTS.md edits now take effect only for newly built sessions (bind / profile switch), matching the freeze semantics already used for other prompt inputs.
- The remaining refresh triggers (session tool policy, `[tools]` config, builtin skill catalog, post-compaction) are unchanged.
- Added a regression test asserting that firing the instructions change event leaves the system prompt byte-identical and dispatches no config update carrying a system prompt.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue (external PRs: the issue must have a maintainer's `/approve`).
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.
