### PR TITLE
fix(agent-core-v2): honor default thinking effort for secondary-bound subagents

### DIFF
--- a/.changeset/secondary-model-thinking-effort.md
+++ b/.changeset/secondary-model-thinking-effort.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Fix subagents bound to a configured secondary model ignoring its default thinking effort; [secondary_model].default_effort and the bound model's own default_effort are now honored.

--- a/docs/en/configuration/config-files.md
+++ b/docs/en/configuration/config-files.md
@@ -242,7 +242,7 @@ Rules for the `model` parameter:
 
 - It accepts any pool alias, or `"primary"` — the model the caller itself is running, always valid even when not in the pool.
 - When neither `default_model` nor `models` is configured, the parameter is not advertised and subagents inherit the caller's model.
-- Binding a pool alias does not inherit the caller's thinking effort. The subagent's effort resolves in this order: the section's `default_effort`, the bound model entry's `default_effort`, the global `[thinking]` config, then the middle of the bound model's `support_efforts`.
+- Binding a pool alias does not inherit the caller's thinking effort. The section's `default_effort` wins when set. Otherwise, `[thinking].enabled = false` keeps Thinking off; when Thinking is enabled, resolution continues with the bound model entry's `default_effort`, the global `[thinking].effort`, then the middle of the bound model's `support_efforts`.
 - `"primary"` inherits both the model and the effort level from the caller.
 - A value that is neither a pool alias nor `"primary"` fails the spawn with an error listing the available choices.
 

--- a/docs/en/configuration/config-files.md
+++ b/docs/en/configuration/config-files.md
@@ -210,12 +210,14 @@ default_model = "kimi-code/kimi-for-coding-highspeed"
 | `default_model` | `string` | — | The default model for subagents |
 | `models` | `table<string, string>` | — | Subagent model pool. Each key is the alias of a configured [`[models]`](#models) entry; each value is the selection hint shown to the main agent |
 | `force` | `boolean` | `false` | Pin every subagent to `default_model`, taking the choice away from the main agent |
+| `default_effort` | `string` | — | The thinking effort every spawned subagent binds with; outranks the bound model entry's own `default_effort` |
 
 Constraints between the fields:
 
 - `default_model`: required when a `models` table is configured, and must be one of its keys.
 - `models`: values may be Chinese or English; an empty string lists the alias with no hint.
 - `force`: requires `default_model` and cannot be combined with a `models` table — the table exists to offer a choice, and force removes it.
+- `default_effort` is section-wide: every spawn binds it regardless of the chosen pool entry (or the forced model). For per-entry efforts, leave it unset and use model variants (see below).
 - `primary` is a reserved alias (see below) and cannot be a pool key.
 
 In the interactive TUI, the [`/secondary-model`](../reference/slash-commands.md) command (alias `/subagent-model`) opens a model selector: the choice is written to `default_model` (when a models table exists and the picked alias is not in it, an entry with an empty description is added), and newly spawned subagents pick up the new default immediately — no session restart needed.
@@ -240,7 +242,7 @@ Rules for the `model` parameter:
 
 - It accepts any pool alias, or `"primary"` — the model the caller itself is running, always valid even when not in the pool.
 - When neither `default_model` nor `models` is configured, the parameter is not advertised and subagents inherit the caller's model.
-- Binding a pool alias carries no explicit thinking effort: the subagent resolves it as "global `[thinking]` config → the bound model's default effort" instead of inheriting the caller's level.
+- Binding a pool alias does not inherit the caller's thinking effort. The subagent's effort resolves in this order: the section's `default_effort`, the bound model entry's `default_effort`, the global `[thinking]` config, then the middle of the bound model's `support_efforts`.
 - `"primary"` inherits both the model and the effort level from the caller.
 - A value that is neither a pool alias nor `"primary"` fails the spawn with an error listing the available choices.
 
@@ -286,7 +288,7 @@ Two prerequisites:
 - The underlying model must declare `support_efforts` (under `managed:kimi-code` only the k3 family currently declares effort levels).
 - The variant is a standalone entry and does not inherit fields from the entry it points at — copy `capabilities`, `support_efforts`, and the other metadata over in full, otherwise `default_effort` has no effect (it must be a member of `support_efforts`).
 
-Also note that `default_effort` stays a model-level default: once a global `[thinking].effort` is set, it wins for the main agent and subagents alike, and the variant's default only applies when no global effort is set. Value and fallback rules follow the [`[models]` entry's `default_effort`](#models).
+Note the asymmetry between the main agent and pool-bound subagents: for the main agent, a configured global `[thinking].effort` overrides the variant's `default_effort`; for subagents the variant's `default_effort` wins over the global value, and only `[secondary_model].default_effort` outranks it. Value and fallback rules follow the [`[models]` entry's `default_effort`](#models).
 
 ::: warning Note
 Configuration errors fail loudly instead of falling back silently. Session creation, resume, and fork all fail at startup when:

--- a/docs/zh/configuration/config-files.md
+++ b/docs/zh/configuration/config-files.md
@@ -210,12 +210,14 @@ default_model = "kimi-code/kimi-for-coding-highspeed"
 | `default_model` | `string` | — | subagent 的默认模型 |
 | `models` | `table<string, string>` | — | subagent 模型池。key 是 [`[models]`](#models) 条目的别名，value 是给 main agent 的挑选提示 |
 | `force` | `boolean` | `false` | 把所有 subagent 固定到 `default_model`，收回 main agent 的选择权 |
+| `default_effort` | `string` | — | 每次派生的 subagent 绑定的 Thinking 档位，优先于所绑定模型条目自己的 `default_effort` |
 
 字段之间的约束：
 
 - `default_model`：配置 `models` 表时必填，且必须是其中的 key。
 - `models`：value 中英文均可；空字符串表示只列出别名、不给提示。
 - `force`：必须搭配 `default_model`，且不能与 `models` 表同用——表的意义在于提供选择，而 force 取消了选择。
+- `default_effort` 是节级设置：无论派生绑定到池中哪个条目（或 force 固定的模型）都生效。想按条目区分档位时不要设置它，改用下文的模型「变体」。
 - `primary` 是保留字（含义见下文），不能作为池中 key。
 
 在交互式 TUI 中，也可以用 [`/secondary-model`](../reference/slash-commands.md) 命令（别名 `/subagent-model`）打开模型选择器：选择后写入 `default_model`（已有 models 表而所选别名不在其中时，会一并补一条空描述条目），之后派生的 subagent 立即按新默认值绑定，无需重启会话。
@@ -240,7 +242,7 @@ default_model = "kimi-code/kimi-for-coding-highspeed"
 
 - 接受池中任意别名，或 `"primary"`——调用方自己正在运行的模型，始终合法，即使不在池中。
 - `default_model` 与 `models` 都未配置时该参数不存在，subagent 继承调用方模型。
-- 绑定池中别名时不携带显式 Thinking 档位：subagent 按 "全局 `[thinking]` 配置 → 所绑定模型的默认 effort" 解析，不继承调用方的档位。
+- 绑定池中别名时不继承调用方的 Thinking 档位，subagent 的档位按以下顺序解析：本节的 `default_effort`、所绑定模型条目的 `default_effort`、全局 `[thinking]` 配置、所绑定模型 `support_efforts` 的中间项。
 - `"primary"` 则连模型带档位一起继承调用方。
 - 传入的值既不是池中别名也不是 `"primary"` 时，本次派生报错并列出可选值。
 
@@ -285,7 +287,7 @@ k3-max = "同一模型的 max Thinking 档位。适合最难的子任务。"
 - 底层模型必须声明了 `support_efforts`（`managed:kimi-code` 下目前只有 k3 系列声明了档位）。
 - 变体是独立条目，不会继承被指向条目的字段——`capabilities`、`support_efforts` 等元数据要完整照抄，否则 `default_effort` 不生效（它必须是 `support_efforts` 列表中的值）。
 
-另外注意，`default_effort` 只是模型级默认值：全局 `[thinking].effort` 一旦设置，对 main agent 和 subagent 都优先生效，变体的默认档位只在全局未设置时起作用。取值与回落规则同 [`[models]` 条目的 `default_effort`](#models)。
+另外注意 main agent 与 subagent 的不对称：对 main agent，全局 `[thinking].effort` 一旦设置就压过变体的 `default_effort`；对绑定池内别名的 subagent，变体的 `default_effort` 优先于全局值，只有 `[secondary_model].default_effort` 的优先级更高。取值与回落规则同 [`[models]` 条目的 `default_effort`](#models)。
 
 ::: warning 注意
 配置错误一律直接报错，不做静默回退。出现以下情况时，会话的创建、恢复（resume）与 fork 都会在启动时失败：

--- a/docs/zh/configuration/config-files.md
+++ b/docs/zh/configuration/config-files.md
@@ -242,7 +242,7 @@ default_model = "kimi-code/kimi-for-coding-highspeed"
 
 - 接受池中任意别名，或 `"primary"`——调用方自己正在运行的模型，始终合法，即使不在池中。
 - `default_model` 与 `models` 都未配置时该参数不存在，subagent 继承调用方模型。
-- 绑定池中别名时不继承调用方的 Thinking 档位，subagent 的档位按以下顺序解析：本节的 `default_effort`、所绑定模型条目的 `default_effort`、全局 `[thinking]` 配置、所绑定模型 `support_efforts` 的中间项。
+- 绑定池中别名时不继承调用方的 Thinking 档位。本节设置了 `default_effort` 时以它为准；否则，`[thinking].enabled = false` 会保持关闭 Thinking；开启 Thinking 时，再依次使用所绑定模型条目的 `default_effort`、全局 `[thinking].effort`、所绑定模型 `support_efforts` 的中间项。
 - `"primary"` 则连模型带档位一起继承调用方。
 - 传入的值既不是池中别名也不是 `"primary"` 时，本次派生报错并列出可选值。
 

--- a/packages/agent-core-v2/src/features/tower/tools/spawn/spawnTool.ts
+++ b/packages/agent-core-v2/src/features/tower/tools/spawn/spawnTool.ts
@@ -23,6 +23,7 @@ import { ITowerRateLimitService } from '#/features/tower/towerRateLimit';
 import { IConfigService } from '#/app/config/config';
 import { IFlagService } from '#/app/flag/flag';
 import { IModelCatalog } from '#/kosong/model/catalog';
+import { declaredDefaultEffortForModel } from '#/kosong/model/thinking';
 import { toInputJsonSchema } from '#/tool/input-schema';
 import {
   type ExecutableToolContext,
@@ -279,12 +280,12 @@ export class TowerSpawnTool implements ITowerSpawnTool {
 
     let createdContext: AgentContext;
     try {
-      if (binding !== undefined) this.modelCatalog.get(binding.model);
+      const model = binding === undefined ? undefined : this.modelCatalog.get(binding.model);
       createdContext = await this.agentLifecycle.create({
         binding: {
           profile: TOWER_WORKER_PROFILE,
           model: binding?.model,
-          thinking: binding?.thinking,
+          thinking: binding?.thinking ?? declaredDefaultEffortForModel(model),
         },
         labels: subagentLabels(this.callerAgentId),
       });

--- a/packages/agent-core-v2/src/features/tower/tools/spawn/spawnTool.ts
+++ b/packages/agent-core-v2/src/features/tower/tools/spawn/spawnTool.ts
@@ -23,7 +23,6 @@ import { ITowerRateLimitService } from '#/features/tower/towerRateLimit';
 import { IConfigService } from '#/app/config/config';
 import { IFlagService } from '#/app/flag/flag';
 import { IModelCatalog } from '#/kosong/model/catalog';
-import { declaredDefaultEffortForModel } from '#/kosong/model/thinking';
 import { toInputJsonSchema } from '#/tool/input-schema';
 import {
   type ExecutableToolContext,
@@ -36,6 +35,7 @@ import { ISessionContext } from '#/session/sessionContext/sessionContext';
 import {
   DEFAULT_SUBAGENT_TIMEOUT_MS,
   resolveSubagentBinding,
+  resolveSubagentThinking,
   wrapSubagentModelError,
 } from '#/session/subagent/configSection';
 import { emitAgentRunSpawned, mirrorAgentRun } from '#/session/subagent/mirrorAgentRun';
@@ -285,7 +285,7 @@ export class TowerSpawnTool implements ITowerSpawnTool {
         binding: {
           profile: TOWER_WORKER_PROFILE,
           model: binding?.model,
-          thinking: binding?.thinking ?? declaredDefaultEffortForModel(model),
+          thinking: resolveSubagentThinking(this.config, model, binding?.thinking),
         },
         labels: subagentLabels(this.callerAgentId),
       });
@@ -406,4 +406,3 @@ export class TowerSpawnTool implements ITowerSpawnTool {
     );
   }
 }
-

--- a/packages/agent-core-v2/src/kosong/model/thinking.ts
+++ b/packages/agent-core-v2/src/kosong/model/thinking.ts
@@ -125,6 +125,15 @@ export function defaultThinkingEffortForModel(
   return 'on';
 }
 
+export function declaredDefaultEffortForModel(
+  model: ModelThinkingMetadata | undefined,
+): ThinkingEffort | undefined {
+  if (!modelSupportsThinking(model)) return undefined;
+  const declared = nonEmpty(model?.defaultEffort);
+  if (declared === undefined) return undefined;
+  return effortsFor(model).includes(declared) ? (declared as ThinkingEffort) : undefined;
+}
+
 export function modelSupportsThinkingEffort(
   effort: ThinkingEffort,
   model: ModelThinkingMetadata | undefined,

--- a/packages/agent-core-v2/src/session/subagent/configSection.ts
+++ b/packages/agent-core-v2/src/session/subagent/configSection.ts
@@ -10,7 +10,12 @@ import {
   type IConfigService,
 } from '#/app/config/config';
 import { registerConfigSection } from '#/app/config/configSectionContributions';
-import type { IModelCatalog } from '#/kosong/model/catalog';
+import { THINKING_SECTION } from '#/app/kosongConfig/configSection';
+import type { IModelCatalog, Model } from '#/kosong/model/catalog';
+import {
+  declaredDefaultEffortForModel,
+  type ThinkingConfig,
+} from '#/kosong/model/thinking';
 
 import { SECONDARY_MODEL_FLAG_ID } from './flag';
 
@@ -280,6 +285,16 @@ export function resolveSubagentBinding(
     );
   }
   return { model: choice, thinking: section?.defaultEffort };
+}
+
+export function resolveSubagentThinking(
+  config: IConfigService,
+  model: Model | undefined,
+  explicit: string | undefined,
+): string | undefined {
+  if (explicit !== undefined) return explicit;
+  if (config.get<ThinkingConfig>(THINKING_SECTION)?.enabled === false) return undefined;
+  return declaredDefaultEffortForModel(model);
 }
 
 export function buildSubagentModelDescriptions(

--- a/packages/agent-core-v2/src/session/subagent/configSection.ts
+++ b/packages/agent-core-v2/src/session/subagent/configSection.ts
@@ -240,7 +240,7 @@ export function resolveSubagentBinding(
         { details: { model: requested } },
       );
     }
-    return { model: forcedModel };
+    return { model: forcedModel, thinking: section.defaultEffort };
   }
   if (requested === PRIMARY_SUBAGENT_MODEL_CHOICE) {
     return { model: own.modelAlias, thinking: own.thinkingLevel };
@@ -279,7 +279,7 @@ export function resolveSubagentBinding(
       { details: { model: choice, availableModels: available } },
     );
   }
-  return { model: choice };
+  return { model: choice, thinking: section?.defaultEffort };
 }
 
 export function buildSubagentModelDescriptions(

--- a/packages/agent-core-v2/src/session/subagent/subagentService.ts
+++ b/packages/agent-core-v2/src/session/subagent/subagentService.ts
@@ -24,7 +24,8 @@ import { IAgentRuntimeService } from '#/agent/runtimeBinding/agentRuntime';
 import type { Runtime } from '#/runtime/runtime';
 import { IConfigService } from '#/app/config/config';
 import { IFlagService } from '#/app/flag/flag';
-import { IModelCatalog } from '#/kosong/model/catalog';
+import { IModelCatalog, type Model } from '#/kosong/model/catalog';
+import { declaredDefaultEffortForModel } from '#/kosong/model/thinking';
 import { ILogService } from '#/_base/log/log';
 import { ISessionContext } from '#/session/sessionContext/sessionContext';
 import { RuntimeWorkspaceView } from '#/runtime/runtimeWorkspaceView';
@@ -133,15 +134,16 @@ export class SessionSubagentService extends Service implements ISessionSubagentS
           { modelAlias: own.modelAlias, thinkingLevel: own.thinkingLevel },
           input.model,
         );
+    let model: Model;
     try {
-      this.modelCatalog.get(binding.model);
+      model = this.modelCatalog.get(binding.model);
     } catch (error) {
       throw wrapSubagentModelError(error, binding.model, own.modelAlias);
     }
     return {
       profileName: profile?.name ?? requestedProfileName,
       model: binding.model,
-      thinking: binding.thinking,
+      thinking: binding.thinking ?? declaredDefaultEffortForModel(model),
       fork,
     };
   }

--- a/packages/agent-core-v2/src/session/subagent/subagentService.ts
+++ b/packages/agent-core-v2/src/session/subagent/subagentService.ts
@@ -25,7 +25,6 @@ import type { Runtime } from '#/runtime/runtime';
 import { IConfigService } from '#/app/config/config';
 import { IFlagService } from '#/app/flag/flag';
 import { IModelCatalog, type Model } from '#/kosong/model/catalog';
-import { declaredDefaultEffortForModel } from '#/kosong/model/thinking';
 import { ILogService } from '#/_base/log/log';
 import { ISessionContext } from '#/session/sessionContext/sessionContext';
 import { RuntimeWorkspaceView } from '#/runtime/runtimeWorkspaceView';
@@ -42,7 +41,11 @@ import {
   type RunAgentOptions,
 } from './subagent';
 import { runAgentTurn } from './runAgentTurn';
-import { resolveSubagentBinding, wrapSubagentModelError } from './configSection';
+import {
+  resolveSubagentBinding,
+  resolveSubagentThinking,
+  wrapSubagentModelError,
+} from './configSection';
 import {
   DEFAULT_PROFILE_NAME,
   FORK_CONTEXT_NOTICE,
@@ -143,7 +146,7 @@ export class SessionSubagentService extends Service implements ISessionSubagentS
     return {
       profileName: profile?.name ?? requestedProfileName,
       model: binding.model,
-      thinking: binding.thinking ?? declaredDefaultEffortForModel(model),
+      thinking: resolveSubagentThinking(this.configService, model, binding.thinking),
       fork,
     };
   }

--- a/packages/agent-core-v2/test/app/config/config.test.ts
+++ b/packages/agent-core-v2/test/app/config/config.test.ts
@@ -1814,7 +1814,7 @@ describe('subagent config section', () => {
     });
     expect(resolveSubagentBinding(config, secondaryModelFlags(), own)).toEqual({
       model: 'provider/fast',
-      thinking: undefined,
+      thinking: 'low',
     });
     expect(() => resolveSubagentBinding(config, secondaryModelFlags(), own, 'provider/smart')).toThrow(
       /Invalid model "provider\/smart"\. Available models: provider\/fast, primary\./,
@@ -1890,6 +1890,25 @@ describe('subagent config section', () => {
     const after = config.get<SecondaryModelConfig>(SECONDARY_MODEL_SECTION);
     expect(after?.defaultEffort).toBe('low');
     expect(after?.maxOutputSize).toBe(8192);
+
+    disposables.dispose();
+  });
+
+  it('binds [secondary_model].default_effort as the subagent thinking', async () => {
+    const own = { modelAlias: 'provider/main', thinkingLevel: 'medium' };
+    const { config, disposables } = await createConfig(
+      {},
+      '[secondary_model]\ndefault_model = "provider/fast"\ndefault_effort = "max"\n',
+    );
+
+    expect(resolveSubagentBinding(config, secondaryModelFlags(), own)).toEqual({
+      model: 'provider/fast',
+      thinking: 'max',
+    });
+    expect(resolveSubagentBinding(config, secondaryModelFlags(), own, 'primary')).toEqual({
+      model: 'provider/main',
+      thinking: 'medium',
+    });
 
     disposables.dispose();
   });

--- a/packages/agent-core-v2/test/features/tower/tools/spawnTool.test.ts
+++ b/packages/agent-core-v2/test/features/tower/tools/spawnTool.test.ts
@@ -25,7 +25,8 @@ import { IConfigService } from '#/app/config/config';
 import { IEventBus } from '#/app/event/eventBus';
 import { EventBusService } from '#/app/event/eventBusService';
 import { IFlagService } from '#/app/flag/flag';
-import { IModelCatalog } from '#/kosong/model/catalog';
+import { UNKNOWN_CAPABILITY } from '#/kosong/contract/capability';
+import { IModelCatalog, type Model } from '#/kosong/model/catalog';
 import { IAgentLifecycleService } from '#/session/agentLifecycle/agentLifecycle';
 import { ISessionContext } from '#/session/sessionContext/sessionContext';
 import {
@@ -75,7 +76,8 @@ describe('TowerSpawnTool', () => {
   let registerTask: Mock<IAgentTaskService['registerTask']>;
   let completion: Deferred<{ readonly summary: string }>;
   let secondaryFlagOn: boolean;
-  let secondaryModel: { readonly model: string } | undefined;
+  let secondaryModel: { readonly model: string; readonly defaultEffort?: string } | undefined;
+  let modelMeta: Record<string, Partial<Model>>;
   let createdSetMode: Mock<(mode: PermissionMode) => void>;
 
   async function git(cwd: string, ...args: string[]): Promise<void> {
@@ -100,6 +102,7 @@ describe('TowerSpawnTool', () => {
     completion = deferred();
     secondaryFlagOn = false;
     secondaryModel = undefined;
+    modelMeta = {};
     createdSetMode = vi.fn();
     createAgent = vi.fn(async () => stubAgentContext('agent-7', 1));
     runAgent = vi.fn(
@@ -176,7 +179,9 @@ describe('TowerSpawnTool', () => {
     ix.stub(IFlagService, {
       enabled: (id: string) => id === SECONDARY_MODEL_FLAG_ID && secondaryFlagOn,
     } as unknown as IFlagService);
-    ix.stub(IModelCatalog, { get: () => ({}) } as unknown as IModelCatalog);
+    ix.stub(IModelCatalog, {
+      get: (alias: string) => ({ id: alias, ...modelMeta[alias] }) as Model,
+    } as unknown as IModelCatalog);
     ix.set(ITowerSpawnTool, new SyncDescriptor(TowerSpawnTool));
   });
 
@@ -319,6 +324,37 @@ describe('TowerSpawnTool', () => {
     });
     const activityLog = await readFile(join(repo, '.tower/comms/log/activity.log'), 'utf8');
     expect(activityLog).toMatch(/spawn .*model=cheap\/fast/);
+  });
+
+  it('passes [secondary_model].default_effort to the spawned worker', async () => {
+    secondaryFlagOn = true;
+    secondaryModel = { model: 'cheap/fast', defaultEffort: 'low' };
+
+    const result = await execute(WORKER_ARGS);
+
+    expect(result.isError).toBeUndefined();
+    expect(createAgent).toHaveBeenCalledWith({
+      binding: { profile: 'tower-worker', model: 'cheap/fast', thinking: 'low' },
+      labels: { parentAgentId: 'main' },
+    });
+  });
+
+  it('falls back to the bound model default_effort when the section declares none', async () => {
+    secondaryFlagOn = true;
+    secondaryModel = { model: 'cheap/fast' };
+    modelMeta['cheap/fast'] = {
+      capabilities: { ...UNKNOWN_CAPABILITY, thinking: true },
+      supportEfforts: ['low', 'high', 'max'],
+      defaultEffort: 'max',
+    };
+
+    const result = await execute(WORKER_ARGS);
+
+    expect(result.isError).toBeUndefined();
+    expect(createAgent).toHaveBeenCalledWith({
+      binding: { profile: 'tower-worker', model: 'cheap/fast', thinking: 'max' },
+      labels: { parentAgentId: 'main' },
+    });
   });
 
   it('inherits the tower model when the secondary-model experiment is off', async () => {

--- a/packages/agent-core-v2/test/features/tower/tools/spawnTool.test.ts
+++ b/packages/agent-core-v2/test/features/tower/tools/spawnTool.test.ts
@@ -77,6 +77,7 @@ describe('TowerSpawnTool', () => {
   let completion: Deferred<{ readonly summary: string }>;
   let secondaryFlagOn: boolean;
   let secondaryModel: { readonly model: string; readonly defaultEffort?: string } | undefined;
+  let thinkingEnabled: boolean | undefined;
   let modelMeta: Record<string, Partial<Model>>;
   let createdSetMode: Mock<(mode: PermissionMode) => void>;
 
@@ -102,6 +103,7 @@ describe('TowerSpawnTool', () => {
     completion = deferred();
     secondaryFlagOn = false;
     secondaryModel = undefined;
+    thinkingEnabled = undefined;
     modelMeta = {};
     createdSetMode = vi.fn();
     createAgent = vi.fn(async () => stubAgentContext('agent-7', 1));
@@ -174,7 +176,11 @@ describe('TowerSpawnTool', () => {
     } as unknown as IAgentProfileService);
     ix.stub(IConfigService, {
       get: ((domain: string) =>
-        domain === SECONDARY_MODEL_SECTION ? secondaryModel : undefined) as IConfigService['get'],
+        domain === SECONDARY_MODEL_SECTION
+          ? secondaryModel
+          : domain === 'thinking' && thinkingEnabled !== undefined
+            ? { enabled: thinkingEnabled }
+            : undefined) as IConfigService['get'],
     });
     ix.stub(IFlagService, {
       enabled: (id: string) => id === SECONDARY_MODEL_FLAG_ID && secondaryFlagOn,
@@ -353,6 +359,25 @@ describe('TowerSpawnTool', () => {
     expect(result.isError).toBeUndefined();
     expect(createAgent).toHaveBeenCalledWith({
       binding: { profile: 'tower-worker', model: 'cheap/fast', thinking: 'max' },
+      labels: { parentAgentId: 'main' },
+    });
+  });
+
+  it('leaves thinking unset for global resolution when thinking is disabled', async () => {
+    secondaryFlagOn = true;
+    secondaryModel = { model: 'cheap/fast' };
+    thinkingEnabled = false;
+    modelMeta['cheap/fast'] = {
+      capabilities: { ...UNKNOWN_CAPABILITY, thinking: true },
+      supportEfforts: ['low', 'high', 'max'],
+      defaultEffort: 'max',
+    };
+
+    const result = await execute(WORKER_ARGS);
+
+    expect(result.isError).toBeUndefined();
+    expect(createAgent).toHaveBeenCalledWith({
+      binding: { profile: 'tower-worker', model: 'cheap/fast', thinking: undefined },
       labels: { parentAgentId: 'main' },
     });
   });

--- a/packages/agent-core-v2/test/kosong/model/thinking.test.ts
+++ b/packages/agent-core-v2/test/kosong/model/thinking.test.ts
@@ -4,6 +4,7 @@ import { ProtocolAdapterRegistry } from '#/kosong/provider/protocolAdapterRegist
 import '#/kosong/provider/providers/kimi/kimi.contrib';
 import '#/kosong/provider/providers/standard.contrib';
 import {
+  declaredDefaultEffortForModel,
   defaultThinkingEffortForModel,
   drivesThinkingThroughTraits,
   modelSupportsThinkingEffort,
@@ -87,6 +88,24 @@ describe('resolveThinkingEffortForModel', () => {
     expect(modelSupportsThinkingEffort('extreme', thinkingModel, true)).toBe(false);
     expect(modelSupportsThinkingEffort('off', thinkingModel, true)).toBe(true);
     expect(modelSupportsThinkingEffort('extreme', thinkingModel, false)).toBe(true);
+  });
+
+  it('declaredDefaultEffortForModel returns the declared default only when the model lists it', () => {
+    expect(declaredDefaultEffortForModel(thinkingModel)).toBe('high');
+    expect(
+      declaredDefaultEffortForModel({
+        capabilities: ['thinking'],
+        supportEfforts: ['low', 'medium'],
+        defaultEffort: 'high',
+      }),
+    ).toBeUndefined();
+    expect(
+      declaredDefaultEffortForModel({ capabilities: ['thinking'], supportEfforts: ['low'] }),
+    ).toBeUndefined();
+    expect(
+      declaredDefaultEffortForModel({ supportEfforts: ['max'], defaultEffort: 'max' }),
+    ).toBeUndefined();
+    expect(declaredDefaultEffortForModel(undefined)).toBeUndefined();
   });
 });
 

--- a/packages/agent-core-v2/test/session/subagent/spawn.test.ts
+++ b/packages/agent-core-v2/test/session/subagent/spawn.test.ts
@@ -331,6 +331,7 @@ describe('SessionSubagentService planSpawn and spawn', () => {
           models: { 'provider/fast': 'fast model' },
           defaultEffort: 'max',
         },
+        thinking: { enabled: false },
       },
       true,
     );
@@ -388,6 +389,29 @@ describe('SessionSubagentService planSpawn and spawn', () => {
     const plan = await svc.planSpawn({ callerAgentId: CALLER_ID, profileName: 'coder' });
 
     expect(plan.thinking).toBe('max');
+  });
+
+  it('leaves thinking unset for global resolution when thinking is disabled', async () => {
+    modelIds.add('provider/fast');
+    modelMeta.set('provider/fast', {
+      capabilities: { ...UNKNOWN_CAPABILITY, thinking: true },
+      supportEfforts: ['low', 'high', 'max'],
+      defaultEffort: 'max',
+    });
+    const svc = service(
+      {
+        [SECONDARY_MODEL_SECTION]: {
+          defaultModel: 'provider/fast',
+          models: { 'provider/fast': 'fast model' },
+        },
+        thinking: { enabled: false },
+      },
+      true,
+    );
+
+    const plan = await svc.planSpawn({ callerAgentId: CALLER_ID, profileName: 'coder' });
+
+    expect(plan.thinking).toBeUndefined();
   });
 
   it('leaves the subagent thinking unset when the bound model declares no valid default_effort', async () => {

--- a/packages/agent-core-v2/test/session/subagent/spawn.test.ts
+++ b/packages/agent-core-v2/test/session/subagent/spawn.test.ts
@@ -18,6 +18,7 @@ import { IAgentPermissionModeService } from '#/agent/permissionMode/permissionMo
 import { IAgentUserToolService } from '#/agent/userTool/userTool';
 import { IAgentRuntimeService } from '#/agent/runtimeBinding/agentRuntime';
 import { Error2, ErrorCodes, isError2 } from '#/errors';
+import { UNKNOWN_CAPABILITY } from '#/kosong/contract/capability';
 import { IModelCatalog, type Model } from '#/kosong/model/catalog';
 import { FakeRuntime } from '#/runtime/fakeRuntime';
 import type { RuntimeLease } from '#/runtime/runtime';
@@ -50,6 +51,7 @@ describe('SessionSubagentService planSpawn and spawn', () => {
   let callerData: ProfileData;
   let profiles: AgentProfile[];
   let modelIds: Set<string>;
+  let modelMeta: Map<string, Partial<Model>>;
   let caller: IAgentScopeHandle;
   let createdHandles: Map<string, IAgentScopeHandle>;
   let createAgent: ReturnType<typeof vi.fn>;
@@ -120,6 +122,7 @@ describe('SessionSubagentService planSpawn and spawn', () => {
       }),
     ];
     modelIds = new Set(['main-model']);
+    modelMeta = new Map();
     callerPermissionMode = { mode: 'auto', setMode: vi.fn() };
     createdPermissionMode = { mode: 'manual', setMode: vi.fn() };
     callerUserTools = userToolsStub();
@@ -202,7 +205,7 @@ describe('SessionSubagentService planSpawn and spawn', () => {
             { details: { model: alias } },
           );
         }
-        return { id: alias } as Model;
+        return { id: alias, ...modelMeta.get(alias) } as Model;
       },
     } as unknown as IModelCatalog);
     ix.stub(ISessionContext, { _serviceBrand: undefined, cwd: '/repo' } as unknown as ISessionContext);
@@ -317,6 +320,138 @@ describe('SessionSubagentService planSpawn and spawn', () => {
     expect(error.code).toBe(ErrorCodes.CONFIG_INVALID);
     expect(error.message).toContain('Model "provider/bad" is not configured in config.toml.');
     expect(error.message).toContain('comes from [secondary_model.models]');
+  });
+
+  it('passes [secondary_model].default_effort as the explicit subagent thinking', async () => {
+    modelIds.add('provider/fast');
+    const svc = service(
+      {
+        [SECONDARY_MODEL_SECTION]: {
+          defaultModel: 'provider/fast',
+          models: { 'provider/fast': 'fast model' },
+          defaultEffort: 'max',
+        },
+      },
+      true,
+    );
+
+    const plan = await svc.planSpawn({ callerAgentId: CALLER_ID, profileName: 'coder' });
+
+    expect(plan).toEqual({
+      profileName: 'coder',
+      model: 'provider/fast',
+      thinking: 'max',
+      fork: false,
+    });
+  });
+
+  it('prefers [secondary_model].default_effort over the bound model default_effort', async () => {
+    modelIds.add('provider/fast');
+    modelMeta.set('provider/fast', {
+      capabilities: { ...UNKNOWN_CAPABILITY, thinking: true },
+      supportEfforts: ['low', 'high', 'max'],
+      defaultEffort: 'high',
+    });
+    const svc = service(
+      {
+        [SECONDARY_MODEL_SECTION]: {
+          defaultModel: 'provider/fast',
+          models: { 'provider/fast': 'fast model' },
+          defaultEffort: 'max',
+        },
+      },
+      true,
+    );
+
+    const plan = await svc.planSpawn({ callerAgentId: CALLER_ID, profileName: 'coder' });
+
+    expect(plan.thinking).toBe('max');
+  });
+
+  it('falls back to the bound model default_effort when the section declares none', async () => {
+    modelIds.add('provider/fast');
+    modelMeta.set('provider/fast', {
+      capabilities: { ...UNKNOWN_CAPABILITY, thinking: true },
+      supportEfforts: ['low', 'high', 'max'],
+      defaultEffort: 'max',
+    });
+    const svc = service(
+      {
+        [SECONDARY_MODEL_SECTION]: {
+          defaultModel: 'provider/fast',
+          models: { 'provider/fast': 'fast model' },
+        },
+      },
+      true,
+    );
+
+    const plan = await svc.planSpawn({ callerAgentId: CALLER_ID, profileName: 'coder' });
+
+    expect(plan.thinking).toBe('max');
+  });
+
+  it('leaves the subagent thinking unset when the bound model declares no valid default_effort', async () => {
+    modelIds.add('provider/fast');
+    modelMeta.set('provider/fast', {
+      capabilities: { ...UNKNOWN_CAPABILITY, thinking: true },
+      supportEfforts: ['low', 'high'],
+      defaultEffort: 'max',
+    });
+    const svc = service(
+      {
+        [SECONDARY_MODEL_SECTION]: {
+          defaultModel: 'provider/fast',
+          models: { 'provider/fast': 'fast model' },
+        },
+      },
+      true,
+    );
+
+    const plan = await svc.planSpawn({ callerAgentId: CALLER_ID, profileName: 'coder' });
+
+    expect(plan.thinking).toBeUndefined();
+  });
+
+  it('passes [secondary_model].default_effort with the forced model', async () => {
+    modelIds.add('provider/fast');
+    const svc = service(
+      {
+        [SECONDARY_MODEL_SECTION]: {
+          force: true,
+          defaultModel: 'provider/fast',
+          defaultEffort: 'max',
+        },
+      },
+      true,
+    );
+
+    const plan = await svc.planSpawn({ callerAgentId: CALLER_ID, profileName: 'coder' });
+
+    expect(plan).toEqual({
+      profileName: 'coder',
+      model: 'provider/fast',
+      thinking: 'max',
+      fork: false,
+    });
+  });
+
+  it('inherits the caller model and thinking when the secondary-model experiment is off', async () => {
+    const svc = service({
+      [SECONDARY_MODEL_SECTION]: {
+        defaultModel: 'provider/fast',
+        models: { 'provider/fast': 'fast model' },
+        defaultEffort: 'max',
+      },
+    });
+
+    const plan = await svc.planSpawn({ callerAgentId: CALLER_ID, profileName: 'coder' });
+
+    expect(plan).toEqual({
+      profileName: 'coder',
+      model: 'main-model',
+      thinking: 'high',
+      fork: false,
+    });
   });
 
   it('skips the allowlist check when forking', async () => {


### PR DESCRIPTION
## Related Issue

No tracking issue — this comes from a user bug report: with the `secondary-model` experiment enabled and a third-party model configured for subagents, spawned subagents always ran at the caller's thinking effort (`high`). Adjusting `[secondary_model]`, the bound model entry, the web settings, or even stating the effort in the prompt had no effect.

## Problem

Subagents bound to a secondary/pool model had no working knob for thinking effort:

- `[secondary_model].default_effort` was parsed by the config schema but never consumed — dead config.
- The bind-time explicit effort slot was left empty on the pool and force paths, so resolution fell through to the global `[thinking].effort` — a main-agent-oriented setting that a subagent cannot override interactively — or to the middle of the bound model's `support_efforts` (typically `high`). For non-strict providers the global value is forwarded verbatim even when the bound model does not list it.

## What changed

- `resolveSubagentBinding` returns `[secondary_model].default_effort` as the explicit spawn thinking on the pool and force branches.
- `planSpawn` falls back to the bound model entry's declared `default_effort` (only when the model lists it in `support_efforts`, via the new `declaredDefaultEffortForModel`).
- Both are passed as the bind-time explicit effort, which outranks the global thinking config.

Effective precedence for secondary-bound subagents: `[secondary_model].default_effort` → bound model entry's `default_effort` → global `[thinking].effort` → middle of `support_efforts`. Inherit paths (`primary`, experiment off) and main-agent resolution are unchanged; all edits live in the subagent domain. The `configuration/config-files` docs (en + zh) are updated to match.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [ ] I have linked a related issue (external PRs: the issue must have a maintainer's `/approve`).
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.