### PR TITLE
refactor(agent-core-v2): migrate interaction to agent runtime contract and drop legacy runtime facilities

### DIFF
--- a/packages/agent-core-v2/src/agent/runtime/agentRuntime.ts
+++ b/packages/agent-core-v2/src/agent/runtime/agentRuntime.ts
@@ -6,7 +6,6 @@ import type {
 
 import { collection } from '#/_base/di/collection';
 import type { ServiceIdentifier } from '#/_base/di/instantiation';
-import type { IDisposable } from '#/_base/di/lifecycle';
 import type { Event } from '#/_base/event';
 import type { AgentContext } from '#/agent/agentContext/agentContext';
 import { registerEvent2Class, type Event2, type Event2Class } from '#/app/event/event2';
@@ -26,21 +25,12 @@ export interface AgentRuntimeContext<State> {
   getLogicState<T>(): T;
   dispatch(event: Event2<any>): Promise<void>;
   send(event: unknown): void;
-  own(resource: IDisposable | (() => void | Promise<void>)): void;
-  track<T>(work: Promise<T>): Promise<T>;
   readonly onDidChange: Event<State>;
 }
 
 export interface AgentRuntimeRestoreEvent {
   readonly type: 'runtime.restore';
   waitUntil(work: Promise<unknown>): void;
-}
-
-export const AgentRuntimeLifecycle = Symbol('agentRuntimeLifecycle');
-
-export interface AgentRuntimeLifecycle {
-  start?(): void;
-  dispose?(): void | Promise<void>;
 }
 
 export interface AgentRuntimeDurableDefinition<State> {
@@ -73,7 +63,6 @@ export interface AgentRuntimeProvider<Runtime> {
 
 const descriptors = new WeakMap<object, AgentRuntimeDescriptor<any, any>>();
 const definitionIds = new WeakMap<object, string>();
-const providerContracts = new WeakMap<object, AgentRuntimeDefinition<any>>();
 
 export type RuntimeOf<Definition> =
   Definition extends AgentRuntimeDefinition<any, infer Runtime> ? Runtime : never;
@@ -91,50 +80,30 @@ export function defineAgentRuntimeProvider<State, Runtime>(
   for (const cls of descriptor.durable?.events ?? []) registerEvent2Class(cls);
   const provider = Object.freeze({ contract }) as AgentRuntimeProvider<Runtime>;
   descriptors.set(provider, descriptor);
-  providerContracts.set(provider, contract);
   return provider;
 }
 
-export function defineAgentRuntime<State, Runtime>(
-  descriptor: AgentRuntimeDescriptor<State, Runtime>,
-): AgentRuntimeDefinition<Runtime> {
-  for (const cls of descriptor.durable?.events ?? []) registerEvent2Class(cls);
-  const definition = defineAgentRuntimeContract<Runtime>(descriptor.id);
-  descriptors.set(definition, descriptor);
-  return definition;
-}
-
 export function getAgentRuntimeDefinitionId(
-  definition: AgentRuntimeDefinition<any> | AgentRuntimeProvider<any>,
+  definition: AgentRuntimeDefinition<any>,
 ): string {
-  const contract = providerContracts.get(definition) ?? definition;
-  const id = definitionIds.get(contract);
+  const id = definitionIds.get(definition);
   if (id === undefined) throw new Error('Unknown agent runtime definition');
   return id;
 }
 
-export function getAgentRuntimeContract(
-  contribution: AgentRuntimeDefinition<any> | AgentRuntimeProvider<any>,
-): AgentRuntimeDefinition<any> {
-  return providerContracts.get(contribution) ?? (contribution as AgentRuntimeDefinition<any>);
-}
-
 export function getAgentRuntimeDescriptor(
-  contribution: AgentRuntimeDefinition<any> | AgentRuntimeProvider<any>,
+  provider: AgentRuntimeProvider<any>,
 ): AgentRuntimeDescriptor<any, any> {
-  const descriptor = descriptors.get(contribution);
+  const descriptor = descriptors.get(provider);
   if (descriptor === undefined) throw new Error('Unknown agent runtime provider');
   return descriptor;
 }
 
-export type AgentRuntimeContribution =
-  | AgentRuntimeDefinition<any>
-  | AgentRuntimeProvider<any>;
+export type AgentRuntimeContribution = AgentRuntimeProvider<any>;
 
 const validateRuntimeContribution = (value: AgentRuntimeContribution, existing: readonly AgentRuntimeContribution[]): void => {
-  const contract = getAgentRuntimeContract(value);
-  const id = getAgentRuntimeDefinitionId(contract);
-  if (existing.some((item) => getAgentRuntimeDefinitionId(getAgentRuntimeContract(item)) === id)) {
+  const id = getAgentRuntimeDefinitionId(value.contract);
+  if (existing.some((item) => getAgentRuntimeDefinitionId(item.contract) === id)) {
     throw new Error(`Agent runtime '${id}' already has an active provider`);
   }
 };
@@ -151,7 +120,7 @@ export const AgentRuntimeOverrideContributionPoint = collection<AgentRuntimeCont
 
 export interface AgentRuntimeDefinitionRecord {
   readonly definition: AgentRuntimeDefinition<any>;
-  readonly provider?: AgentRuntimeProvider<any> | AgentRuntimeDefinition<any>;
+  readonly provider: AgentRuntimeProvider<any>;
   readonly generation: number;
   readonly providerGeneration?: number;
   active: boolean;

--- a/packages/agent-core-v2/src/agent/runtime/agentRuntimeSet.ts
+++ b/packages/agent-core-v2/src/agent/runtime/agentRuntimeSet.ts
@@ -7,13 +7,11 @@ import type { AgentContext } from '#/agent/agentContext/agentContext';
 import { IEventDispatcher, type DurableRuntimeParticipantHost } from '#/state/eventDispatcher';
 
 import {
-  AgentRuntimeLifecycle,
   type AgentRuntimeContext,
   type AgentRuntimeContributionSnapshot,
   type AgentRuntimeDefinition,
   type AgentRuntimeDefinitionRecord,
   type AgentRuntimeDescriptor,
-  type AgentRuntimeLifecycle as AgentRuntimeLifecycleProtocol,
   type AgentRuntimeRestoreEvent,
   type AgentRuntimeStatus,
   type DurableAgentRuntimeParticipant,
@@ -21,39 +19,6 @@ import {
   getAgentRuntimeDescriptor,
   type RuntimeOf,
 } from './agentRuntime';
-
-class RuntimeScope {
-  private readonly cleanups: Array<() => void | Promise<void>> = [];
-  private readonly tracked = new Set<Promise<unknown>>();
-  private disposed = false;
-
-  register(cleanup: IDisposable | (() => void | Promise<void>)): void {
-    const dispose = typeof cleanup === 'function' ? cleanup : () => cleanup.dispose();
-    if (this.disposed) {
-      void dispose();
-      return;
-    }
-    this.cleanups.push(dispose);
-  }
-
-  track<T>(work: Promise<T>): Promise<T> {
-    if (this.disposed) throw new Error('Runtime scope is disposed');
-    const tracked = work.finally(() => { this.tracked.delete(tracked); });
-    this.tracked.add(tracked);
-    return tracked;
-  }
-
-  async dispose(): Promise<void> {
-    if (this.disposed) return;
-    this.disposed = true;
-    await Promise.allSettled(this.tracked);
-    for (let index = this.cleanups.length - 1; index >= 0; index -= 1) {
-      try {
-        await this.cleanups[index]!();
-      } catch {}
-    }
-  }
-}
 
 interface RuntimeEntry {
   record: AgentRuntimeDefinitionRecord;
@@ -64,12 +29,9 @@ interface RuntimeEntry {
   listeners?: Set<(state: any) => void>;
   subscription?: { unsubscribe(): void };
   attachment?: IDisposable;
-  readonly leases: Set<Promise<unknown>>;
   retiring: boolean;
   retired: boolean;
-  drain?: Promise<void>;
   error?: unknown;
-  scope?: RuntimeScope;
   context?: AgentRuntimeContext<any>;
   restored: boolean;
   restorePromise?: Promise<void>;
@@ -81,7 +43,6 @@ export class AgentRuntimeSet {
   private durableHost: DurableRuntimeParticipantHost | undefined;
   private restored = false;
   private closed = false;
-  private closeDrain: Promise<void> | undefined;
 
   constructor(
     private readonly agent: AgentContext,
@@ -90,7 +51,7 @@ export class AgentRuntimeSet {
 
   apply(record: AgentRuntimeDefinitionRecord): void {
     if (this.closed) return;
-    const descriptor = getAgentRuntimeDescriptor(record.provider ?? record.definition);
+    const descriptor = getAgentRuntimeDescriptor(record.provider);
     const existing = this.entries.get(descriptor.id);
     if (existing !== undefined) {
       if (existing.record === record) return;
@@ -102,7 +63,6 @@ export class AgentRuntimeSet {
       record,
       descriptor,
       status: 'registered',
-      leases: new Set(),
       retiring: false,
       retired: false,
       restored: false,
@@ -193,18 +153,9 @@ export class AgentRuntimeSet {
   }
 
   close(): Promise<void> {
-    if (this.closeDrain !== undefined) return this.closeDrain;
     this.closed = true;
     for (const entry of this.entries.values()) this.retireEntry(entry);
-    const drains: Promise<void>[] = [];
-    for (const entry of this.entries.values()) {
-      if (entry.drain !== undefined) drains.push(entry.drain);
-    }
-    for (const entry of this.graveyard) {
-      if (entry.drain !== undefined) drains.push(entry.drain);
-    }
-    this.closeDrain = Promise.all(drains).then(() => undefined);
-    return this.closeDrain;
+    return Promise.resolve();
   }
 
   private runtime(entry: RuntimeEntry): unknown {
@@ -214,12 +165,11 @@ export class AgentRuntimeSet {
     try {
       const runtime = entry.descriptor.createApi(context);
       entry.runtime = runtime;
-      this.lifecycleOf(runtime)?.start?.();
       return runtime;
     } catch (error) {
       entry.status = 'failed';
       entry.error = error;
-      void this.disposeRuntimeResources(entry);
+      this.disposeRuntimeResources(entry);
       throw error;
     }
   }
@@ -231,9 +181,7 @@ export class AgentRuntimeSet {
     }
     const descriptor = entry.descriptor;
     const listeners = new Set<(state: any) => void>();
-    const scope = new RuntimeScope();
     entry.listeners = listeners;
-    entry.scope = scope;
     entry.context = {
       agent: this.agent,
       get: (id) => this.accessor.get(id),
@@ -246,13 +194,9 @@ export class AgentRuntimeSet {
       getLogicState: <T>() => entry.actor!.getSnapshot().context as T,
       dispatch: (event) => this.accessor.get(IEventDispatcher).dispatch(event),
       send: (event) => { entry.actor!.send(event); },
-      own: (resource) => scope.register(resource),
-      track: (work) => scope.track(this.track(entry, work)),
       onDidChange: (listener) => {
         listeners.add(listener);
-        const disposable = toDisposable(() => { listeners.delete(listener); });
-        scope.register(disposable);
-        return disposable;
+        return toDisposable(() => { listeners.delete(listener); });
       },
     };
     try {
@@ -318,73 +262,30 @@ export class AgentRuntimeSet {
     if (descriptor.eager === true) this.runtime(entry);
   }
 
-  private track<T>(entry: RuntimeEntry, work: Promise<T>): Promise<T> {
-    if (this.closed || entry.retiring) {
-      throw new Error(`Agent runtime '${entry.descriptor.id}' is retiring`);
-    }
-    const lease = work.finally(() => { entry.leases.delete(lease); });
-    entry.leases.add(lease);
-    return lease;
-  }
-
   private retireEntry(entry: RuntimeEntry): void {
     if (entry.retiring) return;
     entry.retiring = true;
-    entry.drain = entry.leases.size === 0
-      ? this.stopEntry(entry)
-      : Promise.allSettled(entry.leases).then(() => this.stopEntry(entry));
+    this.stopEntry(entry);
   }
 
-  private stopEntry(entry: RuntimeEntry): Promise<void> {
-    if (entry.retired) return Promise.resolve();
+  private stopEntry(entry: RuntimeEntry): void {
+    if (entry.retired) return;
     entry.retired = true;
     entry.status = 'retired';
-    return this.disposeRuntimeResources(entry);
+    this.disposeRuntimeResources(entry);
   }
 
-  private disposeRuntimeResources(entry: RuntimeEntry): Promise<void> {
+  private disposeRuntimeResources(entry: RuntimeEntry): void {
     entry.attachment?.dispose();
     entry.attachment = undefined;
-    const finish = (): void => {
-      entry.subscription?.unsubscribe();
-      entry.actor?.stop();
-      entry.subscription = undefined;
-      entry.actor = undefined;
-      entry.runtime = undefined;
-      entry.listeners = undefined;
-      entry.scope = undefined;
-      entry.context = undefined;
-      entry.restored = false;
-    };
-    const disposeScope = (): Promise<void> => {
-      const scope = entry.scope;
-      if (scope === undefined) {
-        finish();
-        return Promise.resolve();
-      }
-      return scope.dispose().then(finish);
-    };
-    try {
-      const disposal = this.lifecycleOf(entry.runtime)?.dispose?.();
-      if (disposal instanceof Promise) {
-        return disposal.then(disposeScope, (error: unknown) => {
-          entry.error = error;
-          return disposeScope();
-        });
-      }
-    } catch (error) {
-      entry.error = error;
-    }
-    return disposeScope();
-  }
-
-  private lifecycleOf(runtime: unknown): AgentRuntimeLifecycleProtocol | undefined {
-    if ((typeof runtime !== 'object' || runtime === null) && typeof runtime !== 'function') {
-      return undefined;
-    }
-    return (runtime as { readonly [AgentRuntimeLifecycle]?: AgentRuntimeLifecycleProtocol })[
-      AgentRuntimeLifecycle
-    ];
+    entry.subscription?.unsubscribe();
+    entry.actor?.stop();
+    entry.subscription = undefined;
+    entry.actor = undefined;
+    entry.runtime = undefined;
+    entry.listeners = undefined;
+    entry.context = undefined;
+    entry.restored = false;
   }
 
   private line(entry: RuntimeEntry): AgentRuntimeContributionSnapshot {

--- a/packages/agent-core-v2/src/features/feature.ts
+++ b/packages/agent-core-v2/src/features/feature.ts
@@ -31,8 +31,6 @@ import {
 import {
   AgentRuntimeContributionPoint,
   AgentRuntimeOverrideContributionPoint,
-  type AgentRuntimeContribution,
-  type AgentRuntimeDefinition,
   type AgentRuntimeProvider,
 } from '#/agent/runtime/agentRuntime';
 import type {
@@ -57,22 +55,12 @@ export abstract class Feature extends Service {
     return this.provide(AgentModelContribution, definition as AgentModelDefinition<any, any>);
   }
 
-  contributeAgentRuntime<Runtime>(
-    provider: AgentRuntimeProvider<Runtime> | AgentRuntimeDefinition<Runtime>,
-  ): FiberHandle {
-    return this.provide(
-      AgentRuntimeContributionPoint,
-      provider as AgentRuntimeContribution,
-    );
+  contributeAgentRuntime<Runtime>(provider: AgentRuntimeProvider<Runtime>): FiberHandle {
+    return this.provide(AgentRuntimeContributionPoint, provider);
   }
 
-  overrideAgentRuntime<Runtime>(
-    provider: AgentRuntimeProvider<Runtime> | AgentRuntimeDefinition<Runtime>,
-  ): FiberHandle {
-    return this.provide(
-      AgentRuntimeOverrideContributionPoint,
-      provider as AgentRuntimeContribution,
-    );
+  overrideAgentRuntime<Runtime>(provider: AgentRuntimeProvider<Runtime>): FiberHandle {
+    return this.provide(AgentRuntimeOverrideContributionPoint, provider);
   }
 
   contributeConfig<T>(

--- a/packages/agent-core-v2/src/features/interaction/interactionAgentRuntime.ts
+++ b/packages/agent-core-v2/src/features/interaction/interactionAgentRuntime.ts
@@ -1,13 +1,11 @@
-import { assign, setup, type Snapshot } from 'xstate';
+import { assign, fromCallback, setup, type Snapshot } from 'xstate';
 
-import { DisposableStore } from '#/_base/di/lifecycle';
 import { Emitter, type Event } from '#/_base/event';
 import { TurnEnded } from '#/agent/loop/turnOps';
 import {
-  AgentRuntimeLifecycle,
-  defineAgentRuntime,
+  defineAgentRuntimeContract,
+  defineAgentRuntimeProvider,
   type AgentRuntimeContext,
-  type AgentRuntimeLifecycle as AgentRuntimeLifecycleProtocol,
 } from '#/agent/runtime/agentRuntime';
 import { IEventBus } from '#/app/event/eventBus';
 
@@ -32,8 +30,18 @@ interface PendingEntry {
   readonly resolve: (response: unknown) => void;
 }
 
+interface InteractionEffectState {
+  readonly pending: Map<string, PendingEntry>;
+  readonly recentlyResolved: Map<string, number>;
+  nextId: number;
+  readonly changeEmitter: Emitter<InteractionPendingChangedEvent>;
+  readonly resolveEmitter: Emitter<InteractionResolution>;
+}
+
 interface InteractionActorContext {
   readonly records: InteractionModelState;
+  readonly effects: InteractionEffectState;
+  readonly runtime: AgentRuntimeContext<InteractionModelState>;
 }
 
 interface InteractionCommitEvent {
@@ -43,39 +51,58 @@ interface InteractionCommitEvent {
 
 type InteractionActorSnapshot = Snapshot<unknown> & { readonly context: InteractionActorContext };
 
+function rememberResolved(effects: InteractionEffectState, id: string): void {
+  const now = Date.now();
+  for (const [key, resolvedAt] of effects.recentlyResolved) {
+    if (now - resolvedAt > RECENTLY_RESOLVED_TTL_MS) effects.recentlyResolved.delete(key);
+  }
+  while (effects.recentlyResolved.size >= RECENTLY_RESOLVED_MAX) {
+    const oldest = effects.recentlyResolved.keys().next().value;
+    if (oldest === undefined) break;
+    effects.recentlyResolved.delete(oldest);
+  }
+  effects.recentlyResolved.set(id, now);
+}
+
+function recordResolved(runtime: AgentRuntimeContext<InteractionModelState>, id: string, response: unknown): void {
+  void runtime.dispatch(
+    new InteractionResolvedEvent({
+      agentId: runtime.agent.agentId,
+      id,
+      response,
+    }),
+  );
+}
+
+function cancelTurnPending(
+  runtime: AgentRuntimeContext<InteractionModelState>,
+  effects: InteractionEffectState,
+  turnId: number,
+): void {
+  let changed = false;
+  for (const [id, entry] of effects.pending) {
+    if (entry.interaction.origin?.turnId !== turnId) continue;
+    effects.pending.delete(id);
+    rememberResolved(effects, id);
+    const response = { cancelled: true, reason: 'turn_ended' };
+    entry.resolve(response);
+    recordResolved(runtime, id, response);
+    effects.resolveEmitter.fire({ id, response });
+    changed = true;
+  }
+  if (changed) effects.changeEmitter.fire({ pending: [...effects.pending.keys()] });
+}
+
 export class InteractionRuntime {
-  private readonly pending = new Map<string, PendingEntry>();
-  private lifecycleDisposer: (() => void) | undefined;
-  private readonly recentlyResolved = new Map<string, number>();
-  private nextId = 0;
-  private readonly changeEmitter = new Emitter<InteractionPendingChangedEvent>();
-  private readonly resolveEmitter = new Emitter<InteractionResolution>();
+  private readonly effects: InteractionEffectState;
 
-  readonly onDidChangePending: Event<InteractionPendingChangedEvent> = this.changeEmitter.event;
-  readonly onDidResolve: Event<InteractionResolution> = this.resolveEmitter.event;
+  readonly onDidChangePending: Event<InteractionPendingChangedEvent>;
+  readonly onDidResolve: Event<InteractionResolution>;
 
-  readonly [AgentRuntimeLifecycle]: AgentRuntimeLifecycleProtocol = {
-    start: () => { this.lifecycleDisposer = this.attach(); },
-    dispose: () => {
-      for (const entry of this.pending.values()) {
-        entry.resolve({ cancelled: true, reason: 'agent_closed' });
-      }
-      this.pending.clear();
-      this.lifecycleDisposer?.();
-      this.lifecycleDisposer = undefined;
-    },
-  };
-
-  constructor(private readonly runtime: AgentRuntimeContext<InteractionModelState>) {}
-
-  private attach(): () => void {
-    const store = new DisposableStore();
-    store.add(this.changeEmitter);
-    store.add(this.resolveEmitter);
-    store.add(
-      this.runtime.get(IEventBus).subscribe(TurnEnded, (e) => this.cancelPendingForTurn(e.turnId)),
-    );
-    return () => store.dispose();
+  constructor(private readonly runtime: AgentRuntimeContext<InteractionModelState>) {
+    this.effects = runtime.getLogicState<InteractionActorContext>().effects;
+    this.onDidChangePending = this.effects.changeEmitter.event;
+    this.onDidResolve = this.effects.resolveEmitter.event;
   }
 
   request<TPayload, TResponse>(req: InteractionRequest<TPayload>): Promise<TResponse> {
@@ -89,53 +116,42 @@ export class InteractionRuntime {
   }
 
   respond(id: string, response: unknown): boolean {
-    const entry = this.pending.get(id);
+    const entry = this.effects.pending.get(id);
     if (entry === undefined) return false;
-    this.pending.delete(id);
-    this.rememberResolved(id);
+    this.effects.pending.delete(id);
+    rememberResolved(this.effects, id);
     entry.resolve(response);
-    this.recordResolved(id, response);
-    this.changeEmitter.fire({ pending: [...this.pending.keys()] });
-    this.resolveEmitter.fire({ id, response });
+    recordResolved(this.runtime, id, response);
+    this.effects.changeEmitter.fire({ pending: [...this.effects.pending.keys()] });
+    this.effects.resolveEmitter.fire({ id, response });
     return true;
   }
 
   listPending(kind?: InteractionKind): readonly Interaction[] {
-    const all = [...this.pending.values()].map((p) => p.interaction);
+    const all = [...this.effects.pending.values()].map((p) => p.interaction);
     return kind === undefined ? all : all.filter((i) => i.kind === kind);
   }
 
   isRecentlyResolved(id: string): boolean {
-    const resolvedAt = this.recentlyResolved.get(id);
+    const resolvedAt = this.effects.recentlyResolved.get(id);
     if (resolvedAt === undefined) return false;
     if (Date.now() - resolvedAt > RECENTLY_RESOLVED_TTL_MS) {
-      this.recentlyResolved.delete(id);
+      this.effects.recentlyResolved.delete(id);
       return false;
     }
     return true;
   }
 
   cancelPendingForTurn(turnId: number): void {
-    let changed = false;
-    for (const [id, entry] of this.pending) {
-      if (entry.interaction.origin?.turnId !== turnId) continue;
-      this.pending.delete(id);
-      this.rememberResolved(id);
-      const response = { cancelled: true, reason: 'turn_ended' };
-      entry.resolve(response);
-      this.recordResolved(id, response);
-      this.resolveEmitter.fire({ id, response });
-      changed = true;
-    }
-    if (changed) this.changeEmitter.fire({ pending: [...this.pending.keys()] });
+    cancelTurnPending(this.runtime, this.effects, turnId);
   }
 
   private park<TPayload>(
     req: InteractionRequest<TPayload>,
     resolve: (response: unknown) => void,
   ): Interaction {
-    const id = req.id ?? `${this.runtime.agent.agentId}:interaction-${this.nextId++}`;
-    if (this.pending.has(id)) throw new Error(`Interaction "${id}" is already pending`);
+    const id = req.id ?? `${this.runtime.agent.agentId}:interaction-${this.effects.nextId++}`;
+    if (this.effects.pending.has(id)) throw new Error(`Interaction "${id}" is already pending`);
     const interaction: Interaction<TPayload> = {
       id,
       kind: req.kind,
@@ -143,7 +159,7 @@ export class InteractionRuntime {
       origin: req.origin ?? {},
       createdAt: Date.now(),
     };
-    this.pending.set(id, { interaction, resolve });
+    this.effects.pending.set(id, { interaction, resolve });
     void this.runtime.dispatch(
       new InteractionRequestEvent({
         agentId: this.runtime.agent.agentId,
@@ -153,31 +169,8 @@ export class InteractionRuntime {
         request: interaction.payload,
       }),
     );
-    this.changeEmitter.fire({ pending: [...this.pending.keys()] });
+    this.effects.changeEmitter.fire({ pending: [...this.effects.pending.keys()] });
     return interaction;
-  }
-
-  private recordResolved(id: string, response: unknown): void {
-    void this.runtime.dispatch(
-      new InteractionResolvedEvent({
-        agentId: this.runtime.agent.agentId,
-        id,
-        response,
-      }),
-    );
-  }
-
-  private rememberResolved(id: string): void {
-    const now = Date.now();
-    for (const [key, resolvedAt] of this.recentlyResolved) {
-      if (now - resolvedAt > RECENTLY_RESOLVED_TTL_MS) this.recentlyResolved.delete(key);
-    }
-    while (this.recentlyResolved.size >= RECENTLY_RESOLVED_MAX) {
-      const oldest = this.recentlyResolved.keys().next().value;
-      if (oldest === undefined) break;
-      this.recentlyResolved.delete(oldest);
-    }
-    this.recentlyResolved.set(id, now);
   }
 }
 
@@ -187,13 +180,51 @@ function readPayloadToolCallId(payload: unknown): string | undefined {
   return typeof value === 'string' ? value : undefined;
 }
 
+const interactionEffects = fromCallback(({
+  input,
+}: {
+  input: {
+    readonly runtime: AgentRuntimeContext<InteractionModelState>;
+    readonly effects: InteractionEffectState;
+  };
+}) => {
+  const subscription = input.runtime.get(IEventBus).subscribe(TurnEnded, (e) => {
+    cancelTurnPending(input.runtime, input.effects, e.turnId);
+  });
+  return () => {
+    subscription.dispose();
+    for (const entry of input.effects.pending.values()) {
+      entry.resolve({ cancelled: true, reason: 'agent_closed' });
+    }
+    input.effects.pending.clear();
+    input.effects.changeEmitter.dispose();
+    input.effects.resolveEmitter.dispose();
+  };
+});
+
 const interactionActorLogic = setup({
   types: {} as {
     context: InteractionActorContext;
+    input: AgentRuntimeContext<InteractionModelState>;
     events: InteractionCommitEvent;
   },
+  actors: { interactionEffects },
 }).createMachine({
-  context: { records: new Map() },
+  context: ({ input }) => ({
+    records: new Map(),
+    effects: {
+      pending: new Map(),
+      recentlyResolved: new Map(),
+      nextId: 0,
+      changeEmitter: new Emitter(),
+      resolveEmitter: new Emitter(),
+    },
+    runtime: input,
+  }),
+  invoke: {
+    src: 'interactionEffects',
+    input: ({ context }) => ({ runtime: context.runtime, effects: context.effects }),
+  },
   on: {
     'interaction.commit': {
       actions: assign({ records: ({ event }) => event.records }),
@@ -201,7 +232,9 @@ const interactionActorLogic = setup({
   },
 });
 
-export const AgentInteraction = defineAgentRuntime<InteractionModelState, InteractionRuntime>({
+export const AgentInteraction = defineAgentRuntimeContract<InteractionRuntime>('interaction');
+
+export const interactionAgentRuntimeProvider = defineAgentRuntimeProvider<InteractionModelState, InteractionRuntime>(AgentInteraction, {
   id: 'interaction',
   logic: interactionActorLogic,
   durable: {
@@ -238,4 +271,3 @@ export const AgentInteraction = defineAgentRuntime<InteractionModelState, Intera
     }));
   },
 });
-

--- a/packages/agent-core-v2/src/features/interaction/interactionFeature.ts
+++ b/packages/agent-core-v2/src/features/interaction/interactionFeature.ts
@@ -1,13 +1,13 @@
 import { Feature } from '#/features/feature';
 import { registerFeature } from '#/features/featureRegistry';
-import { AgentInteraction } from '#/features/interaction/interactionAgentRuntime';
+import { interactionAgentRuntimeProvider } from '#/features/interaction/interactionAgentRuntime';
 
 export class InteractionFeature extends Feature {
   static override readonly name = 'interaction';
 
   constructor() {
     super();
-    this.contributeAgentRuntime(AgentInteraction);
+    this.contributeAgentRuntime(interactionAgentRuntimeProvider);
   }
 }
 

--- a/packages/agent-core-v2/src/index.ts
+++ b/packages/agent-core-v2/src/index.ts
@@ -112,7 +112,6 @@ export * from '#/state/agentModel';
 export {
   AgentRuntimeContributionPoint,
   AgentRuntimeOverrideContributionPoint,
-  defineAgentRuntime,
   defineAgentRuntimeContract,
   defineAgentRuntimeProvider,
 } from '#/agent/runtime/agentRuntime';

--- a/packages/agent-core-v2/src/session/agentLifecycle/agentLifecycleService.ts
+++ b/packages/agent-core-v2/src/session/agentLifecycle/agentLifecycleService.ts
@@ -51,7 +51,6 @@ import {
   type AgentRuntimeDefinition,
   type AgentRuntimeDefinitionRecord,
   type AgentRuntimeSnapshot,
-  getAgentRuntimeContract,
   getAgentRuntimeDefinitionId,
   type RuntimeOf,
 } from '#/agent/runtime/agentRuntime';
@@ -131,7 +130,7 @@ export class AgentLifecycleService extends Disposable implements IAgentLifecycle
 
   private registerContribution(contribution: AgentRuntimeContribution, override: boolean): void {
     if (this.contributions.has(contribution)) return;
-    const definition = getAgentRuntimeContract(contribution);
+    const definition = contribution.contract;
     const id = getAgentRuntimeDefinitionId(definition);
     const generation = (this.recordGenerations.get(id) ?? 0) + 1;
     this.recordGenerations.set(id, generation);

--- a/packages/agent-core-v2/test/agent/runtime/agentRuntimeSet.test.ts
+++ b/packages/agent-core-v2/test/agent/runtime/agentRuntimeSet.test.ts
@@ -5,7 +5,8 @@ import type { ServicesAccessor } from '#/_base/di/instantiation';
 import type { AgentContext } from '#/agent/agentContext/agentContext';
 import { AgentSpaceImpl } from '#/agent/agentContext/agentSpace';
 import {
-  defineAgentRuntime,
+  defineAgentRuntimeContract,
+  defineAgentRuntimeProvider,
   type AgentRuntimeDefinition,
   type AgentRuntimeDefinitionRecord,
   type AgentRuntimeDescriptor,
@@ -25,8 +26,11 @@ function record<Runtime>(
   logic: AgentRuntimeDescriptor<any, any>['logic'] = fromCallback(() => {}),
   durable?: AgentRuntimeDescriptor<any, any>['durable'],
 ): AgentRuntimeDefinitionRecord & { definition: AgentRuntimeDefinition<any, Runtime> } {
+  const definition = defineAgentRuntimeContract<Runtime>(id) as AgentRuntimeDefinition<any, Runtime>;
+  const provider = defineAgentRuntimeProvider(definition, { id, logic, durable, createApi });
   return {
-    definition: defineAgentRuntime({ id, logic, durable, createApi }),
+    definition,
+    provider,
     generation,
     active: true,
   };
@@ -241,70 +245,10 @@ describe('AgentRuntimeSet', () => {
     await set.close();
   });
 
-  it('drains a tracked lease before disposing the actor', async () => {
-    let stopped = 0;
-    let release!: () => void;
-    const runtime = record(
-      'leased',
-      (context) => ({
-        run: () => context.track(new Promise<void>((resolve) => { release = resolve; })),
-      }),
-      1,
-      fromCallback(() => () => { stopped += 1; }),
-    );
-    const set = new AgentRuntimeSet(agent, accessor);
-    set.apply(runtime);
-    const runtimeInstance = set.resolve(runtime.definition);
-    void runtimeInstance.run();
-
-    const closing = set.close();
-    await Promise.resolve();
-    expect(stopped).toBe(0);
-    release();
-    await closing;
-    expect(stopped).toBe(1);
-  });
-
-  it('disposes registered resources before stopping its actor', async () => {
-    const order: string[] = [];
-    let releaseCleanup!: () => void;
-    const runtime = record(
-      'scope',
-      (context) => {
-        context.own({ dispose: () => { order.push('subscription'); } });
-        context.own({ dispose: () => { order.push('tool'); } });
-        context.own(async () => {
-          order.push('cleanup:start');
-          await new Promise<void>((resolve) => { releaseCleanup = resolve; });
-          order.push('cleanup:end');
-        });
-        return {};
-      },
-      1,
-      fromCallback(() => () => { order.push('actor:stop'); }),
-    );
-    const set = new AgentRuntimeSet(agent, accessor);
-    set.apply(runtime);
-    set.resolve(runtime.definition);
-
-    const closing = set.close();
-    await Promise.resolve();
-    expect(order).toEqual(['cleanup:start']);
-
-    releaseCleanup();
-    await closing;
-
-    expect(order).toEqual(['cleanup:start', 'cleanup:end', 'tool', 'subscription', 'actor:stop']);
-  });
-
   it('resolves only the current definition object for a runtime id', async () => {
     const old = record('identity', () => ({ generation: 1 }), 1);
     const current = record('identity', () => ({ generation: 2 }), 2);
-    const forged = defineAgentRuntime({
-      id: 'identity',
-      logic: fromCallback(() => {}),
-      createApi: () => ({ generation: 999 }),
-    });
+    const forged = defineAgentRuntimeContract<{ generation: number }>('identity');
     const set = new AgentRuntimeSet(agent, accessor);
     set.apply(old);
 

--- a/packages/agent-core-v2/test/features/feature.test.ts
+++ b/packages/agent-core-v2/test/features/feature.test.ts
@@ -22,7 +22,11 @@ import { ConfigSectionContribution } from '#/app/config/configSectionContributio
 import { IFeatureManager } from '#/app/feature/featureManager';
 import { FeatureManagerService } from '#/app/feature/featureManagerService';
 import { LifecycleScope } from '#/app/scopes';
-import { AgentRuntimeContributionPoint, defineAgentRuntime } from '#/agent/runtime/agentRuntime';
+import {
+  AgentRuntimeContributionPoint,
+  defineAgentRuntimeContract,
+  defineAgentRuntimeProvider,
+} from '#/agent/runtime/agentRuntime';
 import { AgentToolContribution } from '#/agent/toolRegistry/toolContribution';
 import { Feature } from '#/features/feature';
 import { IFeatureAssemblyService } from '#/features/featureAssembly';
@@ -169,7 +173,8 @@ describe('Feature — built-in capability assembly (src/features)', () => {
       state: { initial: () => 0, schema: z.custom<number>() },
       events: [],
     });
-    const runtime = defineAgentRuntime<number, object>({
+    const runtimeContract = defineAgentRuntimeContract<object>('test-feature.runtime');
+    const runtime = defineAgentRuntimeProvider<number, object>(runtimeContract, {
       id: 'test-feature.runtime',
       logic: fromTransition(
         (_state: number, event: { readonly type: 'commit'; readonly state: number }) => event.state,

--- a/packages/agent-core-v2/test/features/interaction/interaction.test.ts
+++ b/packages/agent-core-v2/test/features/interaction/interaction.test.ts
@@ -6,7 +6,6 @@ import { Event } from '#/_base/event';
 import { TestInstantiationService } from '#/_base/di/test';
 import type { AgentContext } from '#/agent/agentContext/agentContext';
 import {
-  AgentRuntimeLifecycle,
   type AgentRuntimeDefinition,
   type RuntimeOf,
 } from '#/agent/runtime/agentRuntime';
@@ -21,6 +20,7 @@ import { IFileSystemStorageService } from '#/persistence/interface/storage';
 import { IAgentLifecycleService } from '#/session/agentLifecycle/agentLifecycle';
 import {
   AgentInteraction,
+  interactionAgentRuntimeProvider,
   type InteractionRuntime,
 } from '#/features/interaction/interactionAgentRuntime';
 import {
@@ -78,6 +78,7 @@ function makeRuntimeAgent(agentId: string): RuntimeAgent {
   const runtimes = new AgentRuntimeSet(context, { get: (id) => ix.get(id) });
   runtimes.apply({
     definition: AgentInteraction,
+    provider: interactionAgentRuntimeProvider,
     generation: 1,
     active: true,
   });
@@ -192,7 +193,7 @@ describe('interaction runtime', () => {
     agent.disposables.add(agent.runtime.onDidChangePending(() => changes++));
     const pending = agent.runtime.request({ kind: 'question', payload: {} });
 
-    await agent.runtime[AgentRuntimeLifecycle].dispose?.();
+    await agent.runtimes.close();
 
     await expect(pending).resolves.toEqual({ cancelled: true, reason: 'agent_closed' });
     expect(seen).toEqual([]);

--- a/packages/agent-core-v2/test/features/interaction/stubs.ts
+++ b/packages/agent-core-v2/test/features/interaction/stubs.ts
@@ -13,6 +13,7 @@ import { IEventBus } from '#/app/event/eventBus';
 import { IAgentLifecycleService } from '#/session/agentLifecycle/agentLifecycle';
 import {
   AgentInteraction,
+  interactionAgentRuntimeProvider,
   type InteractionRuntime,
 } from '#/features/interaction/interactionAgentRuntime';
 import { IEventDispatcher } from '#/state/eventDispatcher';
@@ -49,6 +50,7 @@ export function stubInteractionManagerFor(agentIds: readonly string[]): Interact
     const runtimes = new AgentRuntimeSet(context, { get: (id) => ix.get(id) });
     runtimes.apply({
       definition: AgentInteraction,
+      provider: interactionAgentRuntimeProvider,
       generation: 1,
       active: true,
     });

--- a/packages/agent-core-v2/test/features/todo/sessionTodo.test.ts
+++ b/packages/agent-core-v2/test/features/todo/sessionTodo.test.ts
@@ -9,7 +9,8 @@ import { TestInstantiationService } from '#/_base/di/test';
 import { KeyedResourceLeasePool } from '#/_base/lifecycle/keyedResource';
 import type { AgentContext } from '#/agent/agentContext/agentContext';
 import {
-  defineAgentRuntime,
+  defineAgentRuntimeContract,
+  defineAgentRuntimeProvider,
   type AgentRuntimeDefinitionRecord,
   getAgentRuntimeDefinitionId,
 } from '#/agent/runtime/agentRuntime';
@@ -376,7 +377,8 @@ describe('TodoAgentRuntime', () => {
 
   it('materializes non-durable definitions lazily on first resolve', async () => {
     let creates = 0;
-    const ephemeral = defineAgentRuntime<undefined, object>({
+    const ephemeral = defineAgentRuntimeContract<object>('ephemeral-runtime');
+    const ephemeralProvider = defineAgentRuntimeProvider<undefined, object>(ephemeral, {
       id: 'ephemeral-runtime',
       logic: fromCallback(() => {}),
       createApi: () => {
@@ -387,6 +389,7 @@ describe('TodoAgentRuntime', () => {
     const registry = new RuntimeRegistry();
     registry.register({
       definition: ephemeral,
+      provider: ephemeralProvider,
       generation: 1,
       active: true,
     });
@@ -413,73 +416,6 @@ describe('TodoAgentRuntime', () => {
     managed.runtimeSet.resolve(ephemeral);
     expect(creates).toBe(1);
     expect(managed.runtimeSet.inspect()[0]).toMatchObject({ status: 'materialized' });
-    await managed.runtimeSet.close();
-    handle.dispose();
-  });
-
-  it('drains tracked promise leases before stopping actors on withdraw and close', async () => {
-    const pending: (() => void)[] = [];
-    const leaseDefinition = defineAgentRuntime<undefined, { run(): Promise<void> }>({
-      id: 'lease-runtime',
-      logic: fromCallback(() => {}),
-      createApi: (context) => ({
-        run: () => {
-          let resolveWork!: () => void;
-          const work = new Promise<void>((resolve) => {
-            resolveWork = resolve;
-          });
-          const tracked = context.track(work);
-          pending.push(resolveWork);
-          return tracked;
-        },
-      }),
-    });
-    const record: AgentRuntimeDefinitionRecord = {
-      definition: leaseDefinition,
-      generation: 1,
-      active: true,
-    };
-    const registry = new RuntimeRegistry();
-    registry.register(record);
-    const scope = makeAgentScopeContext({ agentId: 'main', agentScope: 'agents/main', generation: 1 });
-    const ix = new TestInstantiationService();
-    ix.set(IAgentScopeContext, scope);
-    ix.set(IAgentBlobService, noopBlob);
-    ix.set(IAgentStateService, new AgentStateService());
-    ix.set(IEventBus, new EventBusService());
-    ix.set(IWireService, stubWireJournal([]));
-    ix.set(IEventDispatcher, new SyncDescriptor(EventDispatcherService));
-    const handle: IAgentScopeHandle = {
-      id: 'main',
-      kind: LifecycleScope.Agent,
-      accessor: ix,
-      dispose: () => { ix.dispose(); },
-    };
-    const managed = new ManagedAgent(scope.agentContext, handle, []);
-    registry.track(managed);
-    const runtime = managed.runtimeSet.resolve(leaseDefinition);
-    void runtime.run();
-
-    registry.withdraw(record);
-    expect(() => runtime.run()).toThrow('retiring');
-    expect(managed.runtimeSet.inspect()[0]).toMatchObject({ status: 'materialized' });
-
-    pending.shift()!();
-    await nextTick();
-    expect(managed.runtimeSet.inspect()[0]).toMatchObject({ status: 'retired' });
-
-    registry.register({ ...record, generation: 2, active: true });
-    const revived = managed.runtimeSet.resolve(leaseDefinition);
-    void revived.run();
-    let closed = false;
-    const closing = managed.runtimeSet.close().then(() => {
-      closed = true;
-    });
-    await nextTick();
-    expect(closed).toBe(false);
-    pending.shift()!();
-    await closing;
-    expect(closed).toBe(true);
     await managed.runtimeSet.close();
     handle.dispose();
   });
@@ -535,7 +471,8 @@ describe('TodoAgentRuntime', () => {
   });
 
   it('retains actor failure status and inspection diagnostics', async () => {
-    const definition = defineAgentRuntime<number, object>({
+    const definition = defineAgentRuntimeContract<object>('failed-runtime');
+    const provider = defineAgentRuntimeProvider<number, object>(definition, {
       id: 'failed-runtime',
       logic: fromCallback(() => { throw new Error('actor failed'); }),
       durable: {
@@ -551,6 +488,7 @@ describe('TodoAgentRuntime', () => {
     const registry = new RuntimeRegistry();
     registry.register({
       definition,
+      provider,
       generation: 1,
       active: true,
     });

--- a/packages/agent-core-v2/test/session/agentLifecycle/agentLifecycle.test.ts
+++ b/packages/agent-core-v2/test/session/agentLifecycle/agentLifecycle.test.ts
@@ -58,7 +58,7 @@ import { ICronCreateTool } from '#/features/cron/tools/cron-create/cron-create';
 import { ICronDeleteTool } from '#/features/cron/tools/cron-delete/cron-delete';
 import { ICronListTool } from '#/features/cron/tools/cron-list/cron-list';
 import { CRON_SECTION } from '#/features/cron/configSection';
-import { AgentInteraction } from '#/features/interaction/interactionAgentRuntime';
+import { interactionAgentRuntimeProvider } from '#/features/interaction/interactionAgentRuntime';
 import { Ledger } from '#/_base/lifecycle/ledger';
 import { BugIndicatingError } from '#/_base/errors/errors';
 import { AgentRuntimeContributionPoint } from '#/agent/runtime/agentRuntime';
@@ -487,7 +487,7 @@ describe('AgentLifecycleService', () => {
       AgentRuntimeContributionPoint,
       'test',
       new Ledger('test'),
-      AgentInteraction,
+      interactionAgentRuntimeProvider,
     );
   }
 

--- a/packages/agent-core-v2/test/tool/tool.test.ts
+++ b/packages/agent-core-v2/test/tool/tool.test.ts
@@ -101,7 +101,7 @@ import { stubAgentContext } from '../agent/agentContext/stubs';
 import { agentContextOf } from '#/agent/scopeContext/scopeContext';
 import { ManagedAgent } from '#/session/agentLifecycle/managedAgent';
 import { AgentTodo, todoAgentRuntimeProvider } from '#/features/todo/todoAgentRuntime';
-import { AgentInteraction } from '#/features/interaction/interactionAgentRuntime';
+import { AgentInteraction, interactionAgentRuntimeProvider } from '#/features/interaction/interactionAgentRuntime';
 import { AgentCron, cronAgentRuntimeProvider } from '#/features/cron/cronAgentRuntime';
 import { AgentGoal, goalAgentRuntimeProvider } from '#/features/goal/goalAgentRuntime';
 
@@ -461,6 +461,7 @@ function createAgentLifecycleStub(options: AgentLifecycleStubOptions = {}): Agen
         },
         {
           definition: AgentInteraction,
+          provider: interactionAgentRuntimeProvider,
           generation: 1,
           active: true,
         },

--- a/packages/agent-core-v2/test/wire/stubs.ts
+++ b/packages/agent-core-v2/test/wire/stubs.ts
@@ -13,7 +13,7 @@ import { EventDispatcherService } from '#/state/eventDispatcherService';
 import { AgentTodo, todoAgentRuntimeProvider } from '#/features/todo/todoAgentRuntime';
 import { AgentCron, cronAgentRuntimeProvider } from '#/features/cron/cronAgentRuntime';
 import { AgentGoal, goalAgentRuntimeProvider } from '#/features/goal/goalAgentRuntime';
-import { AgentInteraction } from '#/features/interaction/interactionAgentRuntime';
+import { AgentInteraction, interactionAgentRuntimeProvider } from '#/features/interaction/interactionAgentRuntime';
 import {
   IWireService,
   type IWireService as AgentWire,
@@ -155,6 +155,7 @@ export function attachInteractionRuntime(
   const runtimes = new AgentRuntimeSet(agent, { get: (id) => ix.get(id) });
   runtimes.apply({
     definition: AgentInteraction,
+    provider: interactionAgentRuntimeProvider,
     generation: 1,
     active: true,
   });


### PR DESCRIPTION
## Related Issue

No linked issue — internal refactor; the closing leg of the agent-runtime migration roadmap from #3175 and #3184.

## Problem

Interaction was the last domain still running on the legacy `defineAgentRuntime` middle state from #3175. That middle state kept a set of transitional runtime facilities alive in agent-core-v2: the `AgentRuntimeLifecycle` start/dispose protocol, `AgentRuntimeContext.own/track` backed by `RuntimeScope`, the lease/drain retire mechanism in `AgentRuntimeSet`, and the legacy `defineAgentRuntime` creation channel itself. Migrating Interaction to the same contract + provider shape as todo/cron/goal allows all of that to be deleted.

## What changed

- **Interaction migration**: `AgentInteraction` is now a stable contract token (`defineAgentRuntimeContract`) with a replaceable default provider (`interactionAgentRuntimeProvider`), contributed via `InteractionFeature.contributeAgentRuntime`. All side effects moved into the XState logic: a root-invoked `interactionEffects` callback actor owns the `TurnEnded` subscription and, on actor stop, silently settles pending waiters (`{cancelled, reason:'agent_closed'}`). Volatile state (pending waiters, recently-resolved window, id counter, emitters) lives in the machine context as `effects`; the `InteractionRuntime` API becomes a stateless projection whose public methods and semantics are unchanged.
- **Legacy facility removal**: deleted `AgentRuntimeLifecycle`, `AgentRuntimeContext.own/track`, `RuntimeScope`, the lease/drain retire path, and legacy `defineAgentRuntime` (including its package-root export). `AgentRuntimeContribution` converged to provider-only, `AgentRuntimeDefinitionRecord.provider` is now required, and the RuntimeSet materialize/dispose paths are simplified accordingly.
- **Tests**: fixtures rewritten as contract + provider pairs; the three own/track/lease tests removed together with the APIs they pinned; the close-settle test now goes through `runtimeSet.close()`.

No behavior change: durable wire vocabulary (`interaction.request` / `interaction.resolved`), journal bytes, replay, and REST/WS-observable semantics (pending list, resolve/pending events, recently-resolved TTL, turn_ended cancellation) are unchanged; the wire/state/config manifests regenerate with zero diff. Verified with agent-core-v2 typecheck, import lint, and full vitest, plus downstream typechecks (kap-server, node-sdk, klient, acp-server, apps/kimi-code) and focused kap-server approvals/questions and node-sdk session-event-wiring tests.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [ ] I have linked a related issue (internal roadmap item; see above).
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset. (internal refactor, not user-perceivable)
- [x] Ran `gen-docs` skill, or this PR needs no doc update. (no repo docs reference the removed facilities)
