### PR TITLE
refactor(kap-server): serve WS fs watch from the engine workspace fs watch service

### DIFF
--- a/packages/agent-core-v2/src/workspace/workspaceFs/fsWatch.ts
+++ b/packages/agent-core-v2/src/workspace/workspaceFs/fsWatch.ts
@@ -26,6 +26,9 @@ export interface IWorkspaceFsWatchSubscription extends IDisposable {
 
   readonly watchedPaths: readonly string[];
 
+  /** Resolves when the OS watcher backing the current watched paths reports readiness; resolves immediately while nothing is watched. */
+  readonly ready: Promise<void>;
+
   readonly onDidChangeFiles: Event<FsChangeEvent>;
 }
 

--- a/packages/agent-core-v2/src/workspace/workspaceFs/fsWatchService.ts
+++ b/packages/agent-core-v2/src/workspace/workspaceFs/fsWatchService.ts
@@ -81,6 +81,10 @@ export class WorkspaceFsWatchService extends Disposable implements IWorkspaceFsW
     this.syncHandle();
   }
 
+  watchHandleReady(): Promise<void> {
+    return this.handle?.ready ?? Promise.resolve();
+  }
+
   private ensureHandle(): void {
     if (this.handle !== undefined) return;
     this.loadGitignore();
@@ -198,6 +202,10 @@ class WorkspaceFsWatchSubscription implements IWorkspaceFsWatchSubscription {
 
   get watchedPaths(): readonly string[] {
     return Array.from(this.watched);
+  }
+
+  get ready(): Promise<void> {
+    return this.owner.watchHandleReady();
   }
 
   hasPaths(): boolean {

--- a/packages/agent-core-v2/test/runtime/architectureBoundaries.test.ts
+++ b/packages/agent-core-v2/test/runtime/architectureBoundaries.test.ts
@@ -93,11 +93,10 @@ describe('runtime architecture boundaries', () => {
     expect(readTool).not.toContain("'acquire' in runtime");
   });
 
-  it('routes terminal, watch, MCP, and external FS through explicit runtime selection', () => {
+  it('routes terminal, MCP, and external FS through explicit runtime selection', () => {
     const terminal = source('session/terminal/terminalService.ts');
     const mcp = source('workspace/workspaceMcp/workspaceMcpService.ts');
     const externalFs = kapSource('routes/fs.ts');
-    const externalWatch = kapSource('transport/ws/v1/fsWatchBridge.ts');
 
     expect(terminal).toContain('this.runtimeResolver.acquire(');
     expect(terminal).toContain('new RuntimeWorkspaceView(');
@@ -106,8 +105,13 @@ describe('runtime architecture boundaries', () => {
     expect(mcp).not.toMatch(/@IHost(?:FileSystem|FsWatchService|ProcessService|TerminalService)/);
     expect(externalFs).toContain('get(IRuntimeResolver).acquire(');
     expect(externalFs).not.toMatch(/\.get\(IHost(?:FileSystem|FsWatchService|ProcessService|TerminalService)\)/);
-    expect(externalWatch).toContain('get(IRuntimeResolver).acquire(');
-    expect(externalWatch).toContain('new RuntimeWorkspaceView(');
+  });
+
+  it('serves WS fs watch from the engine-owned workspace watch service', () => {
+    const externalWatch = kapSource('transport/ws/v1/fsWatchBridge.ts');
+    expect(externalWatch).toContain('get(IWorkspaceInstanceManager)');
+    expect(externalWatch).toContain('.program.watch');
     expect(externalWatch).not.toMatch(/\.get\(IHost(?:FileSystem|FsWatchService|ProcessService|TerminalService)\)/);
+    expect(externalWatch).not.toContain('runtime.watch');
   });
 });

--- a/packages/agent-core-v2/test/workspace/workspaceFs/fsWatchService.test.ts
+++ b/packages/agent-core-v2/test/workspace/workspaceFs/fsWatchService.test.ts
@@ -52,12 +52,12 @@ interface FakeWatch {
   readonly disposedCount: () => number;
 }
 
-function fakeHostFsWatch(): FakeWatch {
+function fakeHostFsWatch(handleReady: Promise<void> = Promise.resolve()): FakeWatch {
   const watchCalls: string[] = [];
   let listener: ((e: HostFsChange) => void) | undefined;
   let disposedCount = 0;
   const handle: IHostFsWatchHandle = {
-    ready: Promise.resolve(),
+    ready: handleReady,
     onDidChange: (l) => {
       listener = l;
       return { dispose: () => (listener = undefined) };
@@ -100,8 +100,8 @@ interface Harness {
   readonly watch: FakeWatch;
 }
 
-function makeWorkspace(gitignore?: string): Harness {
-  const watch = fakeHostFsWatch();
+function makeWorkspace(gitignore?: string, handleReady?: Promise<void>): Harness {
+  const watch = fakeHostFsWatch(handleReady);
   const disposables = new DisposableStore();
   const services = createServices(disposables, {
     additionalServices: (registry) => {
@@ -140,6 +140,24 @@ describe('WorkspaceFsWatchService', () => {
     sub.setWatchedPaths(['src']);
     expect(watch.watchCalls).toEqual([WORK_DIR]);
     expect(sub.watchedPaths).toEqual(['src']);
+  });
+
+  it('gates subscription readiness on the backing watcher readiness', async () => {
+    let resolveReady: (() => void) | undefined;
+    const { svc } = makeWorkspace(undefined, new Promise<void>((r) => (resolveReady = r)));
+    const sub = svc.subscribe();
+    await expect(sub.ready).resolves.toBeUndefined();
+
+    sub.setWatchedPaths(['src']);
+    let settled = false;
+    void sub.ready.then(() => (settled = true));
+    await Promise.resolve();
+    expect(settled).toBe(false);
+
+    resolveReady?.();
+    await expect(sub.ready).resolves.toBeUndefined();
+    await Promise.resolve();
+    expect(settled).toBe(true);
   });
 
   it('drops events outside the subscribed subtree', () => {

--- a/packages/kap-server/src/transport/ws/v1/fsWatchBridge.ts
+++ b/packages/kap-server/src/transport/ws/v1/fsWatchBridge.ts
@@ -1,30 +1,23 @@
+import { isAbsolute, relative, sep } from 'node:path';
+
 import {
   type IDisposable,
-  type ISessionScopeHandle,
   ISessionWorkspaceContext,
   ISessionContext,
-  IRuntimeResolver,
   IWorkspaceInstanceManager,
   getLiveSessionById,
   type Scope,
 } from '@moonshot-ai/agent-core-v2';
-import type { Runtime, RuntimeLease } from '@moonshot-ai/agent-core-v2/runtime/runtime';
-import { RuntimeWorkspaceView } from '@moonshot-ai/agent-core-v2/runtime/runtimeWorkspaceView';
-import type { IHostFsWatchHandle, HostFsChange } from '@moonshot-ai/agent-core-v2/os/interface/hostFsWatch';
-import type { FsChangeEntry, FsChangeEvent } from '@moonshot-ai/agent-core-v2/workspace/workspaceFs/fsWatch';
+import type { Program } from '@moonshot-ai/agent-core-v2/program/program';
+import type {
+  FsChangeEntry,
+  FsChangeEvent,
+  IWorkspaceFsWatchSubscription,
+} from '@moonshot-ai/agent-core-v2/workspace/workspaceFs/fsWatch';
 
 import type { EventEnvelope, JournalLogger } from './sessionEventJournal';
 
 const MAX_PATHS_PER_CONNECTION = 100;
-const DEFAULT_DEBOUNCE_MS = 200;
-const DEFAULT_MAX_CHANGES_PER_WINDOW = 500;
-
-function readPositiveIntEnv(name: string, fallback: number): number {
-  const raw = process.env[name];
-  if (raw === undefined || raw === '') return fallback;
-  const value = Number.parseInt(raw, 10);
-  return Number.isFinite(value) && value > 0 ? value : fallback;
-}
 
 function sessionRuntimeKey(sessionId: string, runtimeId: string): string {
   return `${sessionId}\0${runtimeId}`;
@@ -67,23 +60,15 @@ interface SessionWatch {
   readonly id: string;
   readonly runtimeId: string;
   readonly workspaceId: string;
-  readonly generation: string;
-  readonly session: ISessionScopeHandle;
-  readonly runtime: Runtime;
-  readonly view: RuntimeWorkspaceView;
-  readonly handle: IHostFsWatchHandle;
-  readonly lease: RuntimeLease;
   readonly workspace: ISessionWorkspaceContext;
+  readonly program: Program;
+  readonly programSub: IDisposable;
+  programGeneration: string | undefined;
+  watchSub: IWorkspaceFsWatchSubscription | undefined;
+  watchEventSub: IDisposable | undefined;
   readonly conns: Map<string, ConnEntry>;
   union: Set<string>;
   seq: number;
-  sub: IDisposable | undefined;
-  pending: FsChangeEntry[];
-  rawCount: number;
-  truncated: boolean;
-  debounceTimer: NodeJS.Timeout | undefined;
-  readonly debounceMs: number;
-  readonly maxChangesPerWindow: number;
 }
 
 export class FsWatchBridge {
@@ -91,8 +76,6 @@ export class FsWatchBridge {
   private readonly logger: JournalLogger | undefined;
   private readonly bySession = new Map<string, SessionWatch>();
   private readonly connPathCount = new Map<string, number>();
-  private readonly rebuilding = new Map<string, Promise<SessionWatch | undefined>>();
-  private readonly registrySubscriptions = new Map<string, IDisposable>();
 
   constructor(opts: { core: Scope; logger?: JournalLogger }) {
     this.core = opts.core;
@@ -105,11 +88,15 @@ export class FsWatchBridge {
     rawPaths: readonly string[],
     runtimeId: string,
   ): Promise<FsWatchAck> {
-    const resolved = await this.resolveSession(sessionId, runtimeId);
-    if (resolved === undefined) {
+    const sw = this.resolveSession(sessionId, runtimeId);
+    if (sw === undefined) {
       return { code: FS_WATCH_CODE.SESSION_NOT_FOUND, msg: 'session not found' };
     }
-    const sw = resolved;
+    const watchSub = sw.watchSub;
+    if (watchSub === undefined) {
+      if (sw.conns.size === 0) this.teardownSession(sw);
+      return { code: 1, msg: 'fs watch unavailable' };
+    }
 
     const normalized: string[] = [];
     for (const raw of rawPaths) {
@@ -138,6 +125,16 @@ export class FsWatchBridge {
     for (const rel of toAdd) entry.paths.add(rel);
     this.connPathCount.set(conn.id, current + toAdd.length);
     this.recomputeAndApply(sw);
+    try {
+      await watchSub.ready;
+    } catch (error) {
+      for (const rel of toAdd) entry.paths.delete(rel);
+      if (entry.paths.size === 0) sw.conns.delete(conn.id);
+      this.connPathCount.set(conn.id, current);
+      this.recomputeAndApply(sw);
+      if (sw.conns.size === 0) this.teardownSession(sw);
+      throw error;
+    }
 
     return this.ok(sw, conn);
   }
@@ -181,124 +178,69 @@ export class FsWatchBridge {
   }
 
   dispose(): void {
-    for (const subscription of this.registrySubscriptions.values()) subscription.dispose();
-    this.registrySubscriptions.clear();
     for (const sw of this.bySession.values()) this.teardownSession(sw);
   }
 
-  private async resolveSession(sessionId: string, runtimeId: string): Promise<SessionWatch | undefined> {
+  private resolveSession(sessionId: string, runtimeId: string): SessionWatch | undefined {
     const key = sessionRuntimeKey(sessionId, runtimeId);
-    const pending = this.rebuilding.get(key);
-    if (pending !== undefined) return pending;
     const existing = this.bySession.get(key);
-    if (existing !== undefined) {
-      if (this.isCurrentGeneration(existing)) return existing;
-      return this.rebuild(existing);
-    }
-    return this.createSessionWatch(sessionId, runtimeId, undefined);
-  }
+    if (existing !== undefined) return existing;
 
-  private async createSessionWatch(
-    sessionId: string,
-    runtimeId: string,
-    carried: { readonly conns: Map<string, ConnEntry>; readonly seq: number } | undefined,
-  ): Promise<SessionWatch | undefined> {
-    const key = sessionRuntimeKey(sessionId, runtimeId);
     const session = getLiveSessionById(this.core.accessor, sessionId);
     if (session === undefined) return undefined;
-    const context = session.accessor.get(ISessionWorkspaceContext);
-    const sessionContext = session.accessor.get(ISessionContext);
-    const lease = this.core.accessor.get(IRuntimeResolver).acquire(
-      { workspaceId: sessionContext.workspaceId, runtimeId },
-      ['watch'],
-    );
-    try {
-      const view = new RuntimeWorkspaceView(lease.runtime, context);
-      const handle = lease.track(lease.runtime.watch!.watch(view.workDir, { recursive: true }));
-      await handle.ready;
-      const sw: SessionWatch = {
-        id: sessionId,
-        runtimeId,
-        workspaceId: sessionContext.workspaceId,
-        generation: lease.runtime.identity.generation,
-        session,
-        runtime: lease.runtime,
-        view,
-        handle,
-        lease,
-        workspace: context,
-        conns: carried?.conns ?? new Map(),
-        union: new Set(),
-        seq: carried?.seq ?? 0,
-        sub: undefined,
-        pending: [],
-        rawCount: 0,
-        truncated: false,
-        debounceTimer: undefined,
-        debounceMs: readPositiveIntEnv('KIMI_CODE_FS_WATCH_DEBOUNCE_MS', DEFAULT_DEBOUNCE_MS),
-        maxChangesPerWindow: readPositiveIntEnv('KIMI_CODE_FS_WATCH_MAX_CHANGES_PER_WINDOW', DEFAULT_MAX_CHANGES_PER_WINDOW),
-      };
-      sw.sub = handle.onDidChange((event) => this.onRuntimeEvent(key, event));
-      this.recomputeAndApply(sw);
-      this.bySession.set(key, sw);
-      this.subscribeRegistry(sessionContext.workspaceId);
-      return sw;
-    } catch (error) {
-      lease.dispose();
-      throw error;
-    }
+    if (runtimeId !== 'local') throw new Error(`fs watch unavailable for runtime "${runtimeId}"`);
+    const workspace = session.accessor.get(ISessionWorkspaceContext);
+    const workspaceId = session.accessor.get(ISessionContext).workspaceId;
+    const instance = this.core.accessor.get(IWorkspaceInstanceManager).get(workspaceId);
+    if (instance === undefined) throw new Error(`workspace "${workspaceId}" unavailable`);
+    const program = instance.program;
+
+    const sw: SessionWatch = {
+      id: sessionId,
+      runtimeId,
+      workspaceId,
+      workspace,
+      program,
+      programSub: program.onDidChange(() => {
+        this.onProgramChange(sw);
+      }),
+      programGeneration: undefined,
+      watchSub: undefined,
+      watchEventSub: undefined,
+      conns: new Map(),
+      union: new Set(),
+      seq: 0,
+    };
+    this.bySession.set(key, sw);
+    this.attachWatch(sw);
+    return sw;
   }
 
-  private async rebuild(sw: SessionWatch): Promise<SessionWatch | undefined> {
-    const key = sessionRuntimeKey(sw.id, sw.runtimeId);
-    const pending = this.rebuilding.get(key);
-    if (pending !== undefined) return pending;
-    const task = (async () => {
-      const { conns, seq } = sw;
-      this.teardownSession(sw);
-      return this.createSessionWatch(sw.id, sw.runtimeId, { conns, seq });
-    })();
-    this.rebuilding.set(key, task);
+  private attachWatch(sw: SessionWatch): void {
+    sw.watchEventSub?.dispose();
+    sw.watchEventSub = undefined;
+    sw.watchSub?.dispose();
+    sw.watchSub = undefined;
+    let service;
     try {
-      return await task;
-    } finally {
-      this.rebuilding.delete(key);
-    }
-  }
-
-  private async refreshIfStale(sw: SessionWatch): Promise<void> {
-    const key = sessionRuntimeKey(sw.id, sw.runtimeId);
-    const pending = this.rebuilding.get(key);
-    if (pending !== undefined) await pending.catch(() => undefined);
-    const current = this.bySession.get(key);
-    if (current === undefined || this.isCurrentGeneration(current)) return;
-    try {
-      await this.rebuild(current);
-    } catch (error) {
-      this.logger?.warn({ sessionId: sw.id, err: String(error) }, 'fs-watch rebuild after runtime generation change failed');
-    }
-  }
-
-  private isCurrentGeneration(sw: SessionWatch): boolean {
-    try {
-      const runtime = this.core.accessor.get(IRuntimeResolver).inspect({ workspaceId: sw.workspaceId, runtimeId: sw.runtimeId });
-      return runtime.identity.generation === sw.generation;
+      service = sw.program.watch;
     } catch {
-      return false;
+      sw.programGeneration = undefined;
+      return;
     }
+    sw.programGeneration = sw.program.snapshot().generation;
+    const sub = service.subscribe();
+    sw.watchSub = sub;
+    sw.watchEventSub = sub.onDidChangeFiles((event) => {
+      this.onWatchEvent(sw, event);
+    });
+    this.applyUnion(sw);
   }
 
-  private subscribeRegistry(workspaceId: string): void {
-    if (this.registrySubscriptions.has(workspaceId)) return;
-    const workspace = this.core.accessor.get(IWorkspaceInstanceManager).get(workspaceId);
-    if (workspace === undefined) return;
-    const subscription = workspace.runtimes.onDidChange((change) => {
-      for (const sw of this.bySession.values()) {
-        if (sw.workspaceId !== workspaceId || sw.runtimeId !== change.runtimeId) continue;
-        void this.refreshIfStale(sw);
-      }
-    });
-    this.registrySubscriptions.set(workspaceId, subscription);
+  private onProgramChange(sw: SessionWatch): void {
+    if (!this.bySession.has(sessionRuntimeKey(sw.id, sw.runtimeId))) return;
+    if (sw.program.snapshot().generation === sw.programGeneration) return;
+    this.attachWatch(sw);
   }
 
   private recomputeAndApply(sw: SessionWatch): void {
@@ -307,57 +249,27 @@ export class FsWatchBridge {
       for (const p of paths) union.add(p);
     }
     sw.union = union;
+    this.applyUnion(sw);
+  }
+
+  private applyUnion(sw: SessionWatch): void {
+    if (sw.watchSub === undefined) return;
+    try {
+      sw.watchSub.setWatchedPaths([...sw.union]);
+    } catch (error) {
+      this.logger?.warn({ sessionId: sw.id, err: String(error) }, 'fs-watch apply watched paths failed');
+    }
   }
 
   private teardownSession(sw: SessionWatch): void {
-    sw.sub?.dispose();
-    sw.sub = undefined;
-    if (sw.debounceTimer !== undefined) clearTimeout(sw.debounceTimer);
-    sw.debounceTimer = undefined;
-    sw.handle.dispose();
-    sw.lease.dispose();
+    sw.programSub.dispose();
+    sw.watchEventSub?.dispose();
+    sw.watchSub?.dispose();
     this.bySession.delete(sessionRuntimeKey(sw.id, sw.runtimeId));
   }
 
-  private onRuntimeEvent(key: string, event: HostFsChange): void {
-    const sw = this.bySession.get(key);
-    if (sw === undefined) return;
-    const relative = sw.runtime.path.relative(sw.view.workDir, event.path);
-    const path = relative === '' ? '.' : relative.split(sw.runtime.path.separator).join('/');
-    if (!isUnderAny(path, sw.union)) return;
-    sw.pending.push({ path, change: event.action, kind: event.kind });
-    sw.rawCount += 1;
-    if (sw.pending.length > sw.maxChangesPerWindow) {
-      sw.truncated = true;
-      sw.pending = [];
-    }
-    if (sw.debounceTimer === undefined) {
-      sw.debounceTimer = setTimeout(() => this.flush(key), sw.debounceMs);
-      sw.debounceTimer.unref?.();
-    }
-  }
-
-  private flush(key: string): void {
-    const sw = this.bySession.get(key);
-    if (sw === undefined) return;
-    sw.debounceTimer = undefined;
-    if (sw.rawCount === 0) return;
-    const truncated = sw.truncated;
-    const count = sw.rawCount;
-    const changes = truncated ? [] : sw.pending;
-    sw.pending = [];
-    sw.rawCount = 0;
-    sw.truncated = false;
-    this.onSessionEvent(key, {
-      changes,
-      coalesced_window_ms: sw.debounceMs,
-      ...(truncated ? { truncated: true, count } : {}),
-    });
-  }
-
-  private onSessionEvent(key: string, ev: FsChangeEvent): void {
-    const sw = this.bySession.get(key);
-    if (sw === undefined) return;
+  private onWatchEvent(sw: SessionWatch, ev: FsChangeEvent): void {
+    if (!this.bySession.has(sessionRuntimeKey(sw.id, sw.runtimeId))) return;
     for (const { conn, paths } of sw.conns.values()) {
       let changes: FsChangeEntry[];
       if (ev.truncated === true) {
@@ -389,15 +301,17 @@ export class FsWatchBridge {
   /** Lexical confinement + workspace-relative normalization (no `stat`). */
   private normalize(sw: SessionWatch, raw: string): string | undefined {
     if (raw === '' || raw === '/') return undefined;
-    if (sw.runtime.path.isAbsolute(raw)) return undefined;
+    if (isAbsolute(raw)) return undefined;
     if (raw.split(/[/\\]+/).some((s) => s === '..')) return undefined;
+    let absolute: string;
     try {
-      const absolute = sw.view.resolve(raw);
-      const relative = sw.runtime.path.relative(sw.view.workDir, absolute);
-      return relative === '' ? '.' : relative.split(sw.runtime.path.separator).join('/');
+      absolute = sw.workspace.resolve(raw);
     } catch {
       return undefined;
     }
+    if (!sw.workspace.isWithin(absolute)) return undefined;
+    const rel = relative(sw.workspace.workDir, absolute);
+    return rel === '' ? '.' : rel.split(sep).join('/');
   }
 
   private ok(sw: SessionWatch, conn: FsWatchConnection): FsWatchAck {

--- a/packages/kap-server/test/fs-watch.e2e.test.ts
+++ b/packages/kap-server/test/fs-watch.e2e.test.ts
@@ -2,10 +2,6 @@ import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
-import { IWorkspaceInstanceManager } from '@moonshot-ai/agent-core-v2';
-import type { HostFsChange, IHostFsWatchService } from '@moonshot-ai/agent-core-v2/os/interface/hostFsWatch';
-import { FakeRuntime } from '@moonshot-ai/agent-core-v2/runtime/fakeRuntime';
-import type { RuntimeProviderRuntimeHandle } from '@moonshot-ai/agent-core-v2/runtime/runtimeUnitHost';
 import { pino } from 'pino';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { WebSocket, type RawData } from 'ws';
@@ -196,6 +192,60 @@ describe('WS fs watch (kap-server)', () => {
     conn.ws.close();
   });
 
+  it('delivers a change made immediately after the ack, without a settle wait', async () => {
+    const r = await boot();
+    const sid = await createSession(r);
+    const conn = await openConn(wsUrl(r));
+    await helloAndSubscribe(conn, 'A', sid);
+
+    conn.ws.send(
+      JSON.stringify({
+        type: 'watch_fs_add',
+        id: 'w1',
+        payload: { session_id: sid, runtime_id: 'local', paths: ['src'] },
+      }),
+    );
+    const ack = await receiveType(conn, 'ack', 1000);
+    expect(ack.code).toBe(0);
+
+    writeFileSync(join(workspace, 'src', 'instant.ts'), 'export const i = 1;\n');
+
+    const ev = await receiveType(conn, 'event.fs.changed', 3000);
+    expect(ev.session_id).toBe(sid);
+    const payload = ev.payload as { changes: Array<{ path: string }> };
+    expect(payload.changes.some((c) => c.path === 'src/instant.ts' || c.path === 'src')).toBe(true);
+
+    conn.ws.close();
+  });
+
+  it("subscribe '.' → create nested file → receive event.fs.changed", async () => {
+    const r = await boot();
+    const sid = await createSession(r);
+    const conn = await openConn(wsUrl(r));
+    await helloAndSubscribe(conn, 'A', sid);
+
+    conn.ws.send(
+      JSON.stringify({
+        type: 'watch_fs_add',
+        id: 'w1',
+        payload: { session_id: sid, runtime_id: 'local', paths: ['.'] },
+      }),
+    );
+    const ack = await receiveType(conn, 'ack', 1000);
+    expect(ack.code).toBe(0);
+    expect(ack.payload).toMatchObject({ watched_paths: ['.'] });
+
+    await sleep(WATCH_SETTLE_MS);
+    writeFileSync(join(workspace, 'src', 'deep.ts'), 'export const z = 3;\n');
+
+    const ev = await receiveType(conn, 'event.fs.changed', 2000);
+    expect(ev.session_id).toBe(sid);
+    const payload = ev.payload as { changes: Array<{ path: string }> };
+    expect(payload.changes.some((c) => c.path === 'src/deep.ts' || c.path === 'src' || c.path === '.')).toBe(true);
+
+    conn.ws.close();
+  });
+
   it('watch_fs_add without runtime_id defaults to the local runtime', async () => {
     const r = await boot();
     const sid = await createSession(r);
@@ -231,53 +281,6 @@ describe('WS fs watch (kap-server)', () => {
 
     conn.ws.close();
   });
-
-  it.skipIf(process.platform === 'win32')(
-    'burst > 500 changes inside 200ms window → truncated:true',
-    { timeout: 15000 },
-    async () => {
-      vi.stubEnv('KIMI_CODE_FS_WATCH_DEBOUNCE_MS', '500');
-      vi.stubEnv('KIMI_CODE_FS_WATCH_MAX_CHANGES_PER_WINDOW', '100');
-      const r = await boot();
-      const sid = await createSession(r);
-      const conn = await openConn(wsUrl(r));
-      await helloAndSubscribe(conn, 'A', sid);
-
-      conn.ws.send(
-        JSON.stringify({
-          type: 'watch_fs_add',
-          id: 'w2',
-          payload: { session_id: sid, runtime_id: 'local', paths: ['.'] },
-        }),
-      );
-      await receiveType(conn, 'ack', 1000);
-      await sleep(WATCH_SETTLE_MS);
-
-      const burstDir = join(workspace, 'burst');
-      mkdirSync(burstDir, { recursive: true });
-      for (let i = 0; i < 600; i++) writeFileSync(join(burstDir, `f${i}.txt`), `x${i}`);
-
-      const deadline = Date.now() + 12000;
-      let sawTruncated = false;
-      while (Date.now() < deadline) {
-        let frame: WsFrame;
-        try {
-          frame = await receive(conn, deadline - Date.now());
-        } catch {
-          break;
-        }
-        if (frame.type !== 'event.fs.changed') continue;
-        const payload = frame.payload as { truncated?: boolean; count?: number };
-        if (payload.truncated === true) {
-          expect(payload.count).toBeGreaterThan(100);
-          sawTruncated = true;
-          break;
-        }
-      }
-      expect(sawTruncated).toBe(true);
-      conn.ws.close();
-    },
-  );
 
   it('two clients on disjoint paths receive only their own changes', async () => {
     const r = await boot();
@@ -419,107 +422,22 @@ describe('WS fs watch (kap-server)', () => {
     conn.ws.close();
   });
 
-  it('keeps delivering events after the runtime generation is replaced, without a client re-add', async () => {
+  it('watch_fs_add with a runtime_id other than local → error ack', async () => {
     const r = await boot();
     const sid = await createSession(r);
-
-    interface FakeHandle {
-      disposed: number;
-      fire(change: HostFsChange): void;
-    }
-    const fakeWatch = (): { readonly service: IHostFsWatchService; readonly handles: FakeHandle[] } => {
-      const handles: FakeHandle[] = [];
-      const service = {
-        watch: () => {
-          const listeners = new Set<(change: HostFsChange) => void>();
-          const handle: FakeHandle & {
-            readonly ready: Promise<void>;
-            onDidChange(listener: (change: HostFsChange) => void): { dispose(): void };
-            dispose(): void;
-          } = {
-            ready: Promise.resolve(),
-            disposed: 0,
-            onDidChange: (listener) => {
-              listeners.add(listener);
-              return { dispose: () => { listeners.delete(listener); } };
-            },
-            dispose: () => { handle.disposed += 1; },
-            fire: (change) => { for (const listener of [...listeners]) listener(change); },
-          };
-          handles.push(handle);
-          return handle;
-        },
-      } as unknown as IHostFsWatchService;
-      return { service, handles };
-    };
-    const watchOne = fakeWatch();
-    const watchTwo = fakeWatch();
-    let workspaceId = '';
-    let handle: RuntimeProviderRuntimeHandle | undefined;
-    const makeRuntime = (generation: string, service: IHostFsWatchService): FakeRuntime =>
-      Object.assign(
-        new FakeRuntime(
-          { workspaceId, runtimeId: 'watch-test', generation },
-          { capabilities: ['watch'] },
-        ),
-        { watch: service },
-      );
-    const provider = await r.core.accessor.get(IWorkspaceInstanceManager).addProvider({
-      id: 'watch-test-provider',
-      imports: { root: [], imports: [], local: [] },
-      attach: async (context, host) => {
-        workspaceId = context.id;
-        handle = host.registerRuntime(makeRuntime('watch-generation-1', watchOne.service));
-        return { dispose: () => handle!.remove() };
-      },
-    });
-
     const conn = await openConn(wsUrl(r));
-    try {
-      await helloAndSubscribe(conn, 'A', sid);
-      conn.ws.send(
-        JSON.stringify({
-          type: 'watch_fs_add',
-          id: 'w1',
-          payload: { session_id: sid, runtime_id: 'watch-test', paths: ['src'] },
-        }),
-      );
-      const ack = await receiveType(conn, 'ack', 1000);
-      expect(ack.code).toBe(0);
-      expect(ack.payload).toMatchObject({ watched_paths: ['src'] });
-      expect(watchOne.handles).toHaveLength(1);
+    await helloAndSubscribe(conn, 'A', sid);
 
-      watchOne.handles[0]!.fire({ path: join(workspace, 'src', 'one.ts'), action: 'created', kind: 'file' });
-      const evOne = await receiveType(conn, 'event.fs.changed', 2000);
-      expect((evOne.payload as { changes: Array<{ path: string }> }).changes.some((c) => c.path === 'src/one.ts')).toBe(true);
+    conn.ws.send(
+      JSON.stringify({
+        type: 'watch_fs_add',
+        id: 'wbad',
+        payload: { session_id: sid, runtime_id: 'no-such-runtime', paths: ['src'] },
+      }),
+    );
+    const ack = await receiveType(conn, 'ack', 1000);
+    expect(ack.code).not.toBe(0);
 
-      await handle!.update(() => makeRuntime('watch-generation-2', watchTwo.service));
-
-      const deadline = Date.now() + 2000;
-      while (watchTwo.handles.length === 0 && Date.now() < deadline) await sleep(25);
-      expect(watchTwo.handles).toHaveLength(1);
-      expect(watchOne.handles[0]!.disposed).toBe(1);
-      await sleep(WATCH_SETTLE_MS);
-
-      watchTwo.handles[0]!.fire({ path: join(workspace, 'src', 'two.ts'), action: 'created', kind: 'file' });
-      const evTwo = await receiveType(conn, 'event.fs.changed', 2000);
-      expect(evTwo.session_id).toBe(sid);
-      expect((evTwo.payload as { changes: Array<{ path: string }> }).changes.some((c) => c.path === 'src/two.ts')).toBe(true);
-      expect(evTwo.seq).toBe((evOne.seq ?? 0) + 1);
-
-      conn.ws.send(
-        JSON.stringify({
-          type: 'watch_fs_add',
-          id: 'w2',
-          payload: { session_id: sid, runtime_id: 'watch-test', paths: ['docs'] },
-        }),
-      );
-      const ackTwo = await receiveType(conn, 'ack', 1000);
-      expect(ackTwo.code).toBe(0);
-      expect(ackTwo.payload).toMatchObject({ watched_paths: ['docs', 'src'] });
-    } finally {
-      conn.ws.close();
-      await provider.dispose();
-    }
+    conn.ws.close();
   });
 });


### PR DESCRIPTION
## Related Issue

N/A — internal task, no tracking issue.

## Problem

The `burst > 500 changes inside 200ms window → truncated:true` e2e case in `packages/kap-server/test/fs-watch.e2e.test.ts` flaked on CI (`AssertionError: expected false to be true`). The assertion only holds when the OS watcher delivers more raw events than the per-window cap inside a single debounce window — a timing accident that depends on runner load, so it passes on fast machines and fails intermittently on a loaded CI runner.

Below the test there was a structural cause: the coalescing/truncation logic existed in two parallel implementations. The engine-side `WorkspaceFsWatchService` had a full deterministic unit suite but no consumers, while `FsWatchBridge` — the path WS clients actually use — opened its own OS watcher per session with a hand-rolled copy of the same windowing and had no deterministic tests, only this rate-dependent e2e.

## What changed

- The WS fs-watch surface now consumes the engine's `IWorkspaceFsWatchService` (session → `IWorkspaceInstanceManager` → `program.watch`). `FsWatchBridge` is reduced to a thin edge: connection registry, per-connection path sets with the 100-path limit, union computation, and per-connection fanout with seq numbering. Debounce/truncation windowing, `.gitignore` filtering, runtime lease acquisition, and generation rebuild are all owned by the engine (`Program`) now — one OS watcher per workspace instead of one per session.
- Truncation/coalescing semantics stay pinned by the existing deterministic unit suite in agent-core-v2 (`fsWatchService.test.ts`), which covers the exact implementation now serving the WS surface.
- e2e: dropped the rate-dependent burst case; added a `watch '.'` path case and a case asserting an error ack for a `runtime_id` other than `local`.
- Intentional behavior alignments: WS file-change notifications now honor `.git/`/`.gitignore` filtering (same as engine semantics); a `runtime_id` other than `local` is explicitly rejected with an error ack — kap-server registers no non-local runtime providers and ACP runtimes expose no watch capability, so no production client can be using it.

Wire format is unchanged: `watch_fs_add` / `watch_fs_remove` acks and `event.fs.changed` frames keep the same shape and codes.

Verified: kap-server full suite (72 files, 1211 passed, 1 skipped), agent-core-v2 fs-watch unit suite (11 passed), typecheck and lint clean.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue (N/A — internal task, no tracking issue).
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.
