### PR TITLE
fix(agent-core-v2): keep agent lifecycle context active through scope teardown

### DIFF
--- a/.changeset/fix-restore-crash-loop.md
+++ b/.changeset/fix-restore-crash-loop.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Fix repeated server crashes when resuming a session that was interrupted in the middle of a turn.

--- a/packages/agent-core-v2/src/_base/di/instantiation.ts
+++ b/packages/agent-core-v2/src/_base/di/instantiation.ts
@@ -196,6 +196,7 @@ export interface IInstantiationService {
   provideAll(entries: ReadonlyArray<ProvideAllEntry>): void;
   unprovide<T>(id: ServiceIdentifier<T>): void;
   dispose(): void;
+  disposeAsync(): Promise<void>;
 }
 
 export const IInstantiationService: ServiceIdentifier<IInstantiationService> =

--- a/packages/agent-core-v2/src/_base/di/instantiationService.ts
+++ b/packages/agent-core-v2/src/_base/di/instantiationService.ts
@@ -653,17 +653,22 @@ export class InstantiationService implements IInstantiationService {
   }
 
   dispose(): void {
+    void this.disposeAsync();
+  }
+
+  disposeAsync(): Promise<void> {
     if (this._disposed) {
-      return;
+      return Promise.resolve();
     }
     this._disposed = true;
 
+    let teardown: void | Promise<void> = undefined;
     try {
       for (const child of Array.from(this._children)) {
         child.dispose();
       }
       this._children.clear();
-      void this._ledger.teardown('scope-close');
+      teardown = this._ledger.teardown('scope-close');
       this._services.dispose();
       this.cascade.dispose();
       for (const view of this._collectionViews.values()) {
@@ -678,6 +683,7 @@ export class InstantiationService implements IInstantiationService {
         this._parent._children.delete(this);
       }
     }
+    return Promise.resolve(teardown);
   }
 
   private _createInstance<T>(ctor: any, args: unknown[], _trace: Trace, unit?: {

--- a/packages/agent-core-v2/src/_base/di/instantiationService.ts
+++ b/packages/agent-core-v2/src/_base/di/instantiationService.ts
@@ -487,6 +487,10 @@ export class InstantiationService implements IInstantiationService {
     return this._ledger.register(disposer, label);
   }
 
+  anchorKernelFinalizer(disposer: Disposer, label: string): LedgerEntry {
+    return this._ledger.registerFinalizer(disposer, label);
+  }
+
   private _getFiberHost(): FiberHost {
     this._fiberHost ??= {
       mintUid: () => ++this._root()._nextUnitUid,

--- a/packages/agent-core-v2/src/_base/di/instantiationService.ts
+++ b/packages/agent-core-v2/src/_base/di/instantiationService.ts
@@ -669,10 +669,11 @@ export class InstantiationService implements IInstantiationService {
     }
     this._disposed = true;
 
+    const childTeardowns: Promise<void>[] = [];
     let teardown: void | Promise<void> = undefined;
     try {
       for (const child of Array.from(this._children)) {
-        child.dispose();
+        childTeardowns.push(child.disposeAsync());
       }
       this._children.clear();
       teardown = this._ledger.teardown('scope-close');
@@ -690,7 +691,7 @@ export class InstantiationService implements IInstantiationService {
         this._parent._children.delete(this);
       }
     }
-    return Promise.resolve(teardown);
+    return Promise.all([...childTeardowns, Promise.resolve(teardown)]).then(() => undefined);
   }
 
   private _createInstance<T>(ctor: any, args: unknown[], _trace: Trace, unit?: {

--- a/packages/agent-core-v2/src/_base/di/instantiationService.ts
+++ b/packages/agent-core-v2/src/_base/di/instantiationService.ts
@@ -652,11 +652,18 @@ export class InstantiationService implements IInstantiationService {
     return new InstantiationService(services, this._strict, this, this._enableTracing);
   }
 
+  private _disposePromise: Promise<void> | undefined;
+
   dispose(): void {
     void this.disposeAsync();
   }
 
   disposeAsync(): Promise<void> {
+    this._disposePromise ??= this.disposeCore();
+    return this._disposePromise;
+  }
+
+  private disposeCore(): Promise<void> {
     if (this._disposed) {
       return Promise.resolve();
     }

--- a/packages/agent-core-v2/src/_base/di/scope.ts
+++ b/packages/agent-core-v2/src/_base/di/scope.ts
@@ -112,7 +112,7 @@ export interface IScopeHandle<K extends ScopeKind = ScopeKind> {
   readonly id: string;
   readonly kind: K;
   readonly accessor: ServicesAccessor;
-  dispose(): void;
+  dispose(): void | Promise<void>;
 }
 
 export type IAppScopeHandle = IScopeHandle<'app'>;
@@ -171,7 +171,7 @@ export function createScopedChildHandle(
     get: <T>(serviceId: ServiceIdentifier<T>): T =>
       child.invokeFunction((a) => a.get(serviceId)),
   };
-  return { id, kind, accessor, dispose: () => child.dispose() };
+  return { id, kind, accessor, dispose: () => child.disposeAsync() };
 }
 
 export class Scope implements IDisposable {

--- a/packages/agent-core-v2/src/_base/di/scopeUnits.ts
+++ b/packages/agent-core-v2/src/_base/di/scopeUnits.ts
@@ -22,7 +22,7 @@ export function watchScopeUnits(container: InstantiationService, kind: ScopeKind
   const foldLedger = new Ledger(`scope-units:${kind}`);
   container.anchorKernelEntry((reason) => foldLedger.teardown(reason), `scope-units:${kind}`);
 
-  const materialized = new Map<number, () => void>();
+  const materialized = new Map<number, () => void | Promise<void>>();
 
   const materialize = (record: StoredRecord): void => {
     const recipe = record.value as ServiceRecipe;
@@ -32,7 +32,7 @@ export function watchScopeUnits(container: InstantiationService, kind: ScopeKind
       if (isClassRecipe(recipe)) {
         const instance = host.constructService(recipe, undefined) as Partial<IDisposable>;
         unitLedger.register(() => {
-          instance.dispose?.();
+          return instance.dispose?.();
         }, `unit:${name}`);
       } else {
         const facade = new FiberRuntime(
@@ -57,23 +57,23 @@ export function watchScopeUnits(container: InstantiationService, kind: ScopeKind
     }
 
     let retracted = false;
-    const retract = (): void => {
+    const retract = (): void | Promise<void> => {
       if (retracted) {
-        return;
+        return undefined;
       }
       retracted = true;
       materialized.delete(record.id);
-      void unitLedger.teardown('unload');
+      return unitLedger.teardown('unload');
     };
     if (!record.providerBook.isActive) {
-      retract();
+      void retract();
       return;
     }
     record.providerBook.register(() => {
-      retract();
+      void retract();
     }, `scope-units:${kind}`);
     foldLedger.register(() => {
-      retract();
+      return retract();
     }, `record:${name}`);
     materialized.set(record.id, retract);
   };
@@ -92,7 +92,7 @@ export function watchScopeUnits(container: InstantiationService, kind: ScopeKind
     }
     for (const [id, retract] of Array.from(materialized)) {
       if (!seen.has(id)) {
-        retract();
+        void retract();
       }
     }
   };

--- a/packages/agent-core-v2/src/_base/di/test.ts
+++ b/packages/agent-core-v2/src/_base/di/test.ts
@@ -29,7 +29,9 @@ export function createScopedTestHost(appStubs: ScopeSeed = []): ScopedTestHost {
           id: handle.id,
           kind: handle.kind,
           accessor: handle.accessor,
-          dispose: () => handle.dispose(),
+          dispose: () => {
+            void handle.dispose();
+          },
         } as Scope;
       }
       return app.createChild(kind, id, { seeds: stubs });

--- a/packages/agent-core-v2/src/_base/di/testInstantiationService.ts
+++ b/packages/agent-core-v2/src/_base/di/testInstantiationService.ts
@@ -262,6 +262,14 @@ export class TestInstantiationService extends InstantiationService implements ID
       super.dispose();
     }
   }
+
+  public override disposeAsync(): Promise<void> {
+    sinon.restore();
+    if (this._properDispose) {
+      return super.disposeAsync();
+    }
+    return Promise.resolve();
+  }
 }
 
 interface SinonOptions {

--- a/packages/agent-core-v2/src/_base/lifecycle/ledger.ts
+++ b/packages/agent-core-v2/src/_base/lifecycle/ledger.ts
@@ -65,6 +65,11 @@ export class Ledger {
     return this._push({ label, kind: 'disposer', active: true, run: disposer });
   }
 
+  registerFinalizer(disposer: Disposer, label: string = 'finalizer'): LedgerEntry {
+    this._assertActive('registerFinalizer');
+    return this._push({ label, kind: 'disposer', active: true, run: disposer }, true);
+  }
+
   effect(body: EffectBody, label: string = 'effect'): LedgerEntry {
     this._assertActive('effect');
     const out = body();
@@ -151,11 +156,15 @@ export class Ledger {
     return infos;
   }
 
-  private _push(record: EntryRecord): LedgerEntry {
+  private _push(record: EntryRecord, front = false): LedgerEntry {
     if (Ledger.captureStacks) {
       record.stack = new Error('Ledger registration').stack;
     }
-    this._records.push(record);
+    if (front) {
+      this._records.unshift(record);
+    } else {
+      this._records.push(record);
+    }
     return {
       label: record.label,
       get disposed() {

--- a/packages/agent-core-v2/src/session/agentLifecycle/agentLifecycleService.ts
+++ b/packages/agent-core-v2/src/session/agentLifecycle/agentLifecycleService.ts
@@ -237,7 +237,7 @@ export class AgentLifecycleService extends Disposable implements IAgentLifecycle
             }],
           ],
           configureContainer: (container) => {
-            container.anchorKernelEntry(() => {
+            container.anchorKernelFinalizer(() => {
               eventBus?.deactivateAgent(agent);
             }, 'agent-event-bus-deactivate');
             this.adopt({

--- a/packages/agent-core-v2/src/session/agentLifecycle/agentLifecycleService.ts
+++ b/packages/agent-core-v2/src/session/agentLifecycle/agentLifecycleService.ts
@@ -237,6 +237,9 @@ export class AgentLifecycleService extends Disposable implements IAgentLifecycle
             }],
           ],
           configureContainer: (container) => {
+            container.anchorKernelEntry(() => {
+              eventBus?.deactivateAgent(agent);
+            }, 'agent-event-bus-deactivate');
             this.adopt({
               id: agentId,
               kind: LifecycleScope.Agent,
@@ -447,9 +450,6 @@ export class AgentLifecycleService extends Disposable implements IAgentLifecycle
     await managed.runtimeSet.close();
     managed.killSpace();
     handle.dispose();
-    this.instantiation.invokeFunction((accessor) =>
-      (accessor.get(ISessionEventBus) as ISessionEventBus | undefined)?.deactivateAgent(agent),
-    );
     if (this.roster.get(agent.agentId) === managed) this.roster.delete(agent.agentId);
     this.onDidCloseEmitter.fire(agent);
   }

--- a/packages/agent-core-v2/src/session/agentLifecycle/agentLifecycleService.ts
+++ b/packages/agent-core-v2/src/session/agentLifecycle/agentLifecycleService.ts
@@ -222,6 +222,7 @@ export class AgentLifecycleService extends Disposable implements IAgentLifecycle
     eventBus?.activateAgent(agent);
     let managed: ManagedAgent | undefined;
     let didCreate = false;
+    let finalizerArmed = false;
     try {
       const handle = createScopedChildHandle(
         this.instantiation,
@@ -240,6 +241,7 @@ export class AgentLifecycleService extends Disposable implements IAgentLifecycle
             container.anchorKernelFinalizer(() => {
               eventBus?.deactivateAgent(agent);
             }, 'agent-event-bus-deactivate');
+            finalizerArmed = true;
             this.adopt({
               id: agentId,
               kind: LifecycleScope.Agent,
@@ -280,7 +282,7 @@ export class AgentLifecycleService extends Disposable implements IAgentLifecycle
           managed.handle.dispose();
         } catch { }
       }
-      eventBus?.deactivateAgent(agent);
+      if (!finalizerArmed) eventBus?.deactivateAgent(agent);
       if (didCreate) this.onDidCloseEmitter.fire(agent);
       throw error;
     }

--- a/packages/agent-core-v2/src/session/agentLifecycle/agentLifecycleService.ts
+++ b/packages/agent-core-v2/src/session/agentLifecycle/agentLifecycleService.ts
@@ -248,7 +248,7 @@ export class AgentLifecycleService extends Disposable implements IAgentLifecycle
               accessor: {
                 get: (id) => container.invokeFunction((accessor) => accessor.get(id)),
               },
-              dispose: () => { container.dispose(); },
+              dispose: () => container.disposeAsync(),
             });
             managed = this.roster.get(agentId);
           },
@@ -279,7 +279,7 @@ export class AgentLifecycleService extends Disposable implements IAgentLifecycle
         await managed.runtimeSet.close().catch(() => undefined);
         managed.killSpace();
         try {
-          managed.handle.dispose();
+          await managed.handle.dispose();
         } catch { }
       }
       if (!finalizerArmed) eventBus?.deactivateAgent(agent);
@@ -451,7 +451,7 @@ export class AgentLifecycleService extends Disposable implements IAgentLifecycle
     await Promise.all([loop.settled(), compactionSettled, prompt.drain(reason)]);
     await managed.runtimeSet.close();
     managed.killSpace();
-    handle.dispose();
+    await handle.dispose();
     if (this.roster.get(agent.agentId) === managed) this.roster.delete(agent.agentId);
     this.onDidCloseEmitter.fire(agent);
   }

--- a/packages/agent-core-v2/src/workspace/sessionLifecycle/sessionLifecycleService.ts
+++ b/packages/agent-core-v2/src/workspace/sessionLifecycle/sessionLifecycleService.ts
@@ -208,7 +208,7 @@ export class SessionLifecycleService extends Disposable implements ISessionLifec
       const sessionDir = handle.accessor.get(ISessionContext).sessionDir;
       this.sessions.delete(sessionId);
       await this.drainAgents(handle).catch(() => {});
-      handle.dispose();
+      void handle.dispose();
       await this.hostFs.remove(sessionDir).catch(() => {});
       throw error;
     }
@@ -282,7 +282,7 @@ export class SessionLifecycleService extends Disposable implements ISessionLifec
         this.pluginAgentProfileLoader.ready,
       ]);
     } catch (error) {
-      handle.dispose();
+      void handle.dispose();
       void this.explicitAgentProfileLoader.reload().catch(() => undefined);
       throw error;
     }
@@ -364,7 +364,7 @@ export class SessionLifecycleService extends Disposable implements ISessionLifec
       await this.announceCreated({ sessionId, handle, source: 'resume' });
     } catch (error) {
       this.sessions.delete(sessionId);
-      handle.dispose();
+      void handle.dispose();
       throw error;
     }
     return handle;
@@ -387,7 +387,7 @@ export class SessionLifecycleService extends Disposable implements ISessionLifec
     await this.appendLogStore.drainRetirements();
     await drainSessionMetadataWrites();
     await this.indexMirror.drain();
-    handle.dispose();
+    void handle.dispose();
     await drainLogCloses();
     this._onDidCloseSession.fire({ sessionId });
   }
@@ -408,7 +408,7 @@ export class SessionLifecycleService extends Disposable implements ISessionLifec
     this.sessions.delete(sessionId);
     await drainSessionMetadataWrites();
     await this.indexMirror.drain();
-    handle.dispose();
+    void handle.dispose();
     await drainLogCloses();
     this._onDidArchiveSession.fire({ sessionId });
   }
@@ -589,7 +589,7 @@ export class SessionLifecycleService extends Disposable implements ISessionLifec
       }
       if (target !== undefined) {
         try {
-          target.dispose();
+          void target.dispose();
         } catch {
         }
       }

--- a/packages/agent-core-v2/test/_base/di/child.test.ts
+++ b/packages/agent-core-v2/test/_base/di/child.test.ts
@@ -242,6 +242,36 @@ describe('InstantiationService.createChild', () => {
     expect(events).toEqual(['gate-entered', 'finalizer']);
   });
 
+  it('disposeAsync awaits asynchronous child container teardown', async () => {
+    const events: string[] = [];
+    let releaseChildGate!: () => void;
+    const parent = new InstantiationService(new ServiceCollection());
+    const child = parent.createChild(new ServiceCollection()) as InstantiationService;
+    child.anchorKernelEntry(() => {
+      events.push('child-finalizer');
+    }, 'child-finalizer');
+    child.anchorKernelEntry(() => {
+      events.push('child-gate-entered');
+      return new Promise<void>((resolve) => {
+        releaseChildGate = resolve;
+      });
+    }, 'child-gate');
+    parent.anchorKernelEntry(() => {
+      events.push('parent-finalizer');
+    }, 'parent-finalizer');
+
+    let settled = false;
+    const disposal = parent.disposeAsync().then(() => {
+      settled = true;
+    });
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    expect(events).toEqual(['child-gate-entered', 'parent-finalizer']);
+    expect(settled).toBe(false);
+    releaseChildGate();
+    await disposal;
+    expect(events).toEqual(['child-gate-entered', 'parent-finalizer', 'child-finalizer']);
+  });
+
   it('parent dispose propagates to children', () => {
     const events: string[] = [];
     interface IParentSvc {

--- a/packages/agent-core-v2/test/_base/di/child.test.ts
+++ b/packages/agent-core-v2/test/_base/di/child.test.ts
@@ -214,6 +214,34 @@ describe('InstantiationService.createChild', () => {
     expect(events).toEqual(['disposed']);
   });
 
+  it('repeated disposeAsync returns the in-flight teardown promise', async () => {
+    const events: string[] = [];
+    let releaseGate!: () => void;
+    const ix = new InstantiationService(new ServiceCollection());
+    ix.anchorKernelEntry(() => {
+      events.push('finalizer');
+    }, 'finalizer');
+    ix.anchorKernelEntry(() => {
+      events.push('gate-entered');
+      return new Promise<void>((resolve) => {
+        releaseGate = resolve;
+      });
+    }, 'gate');
+
+    const first = ix.disposeAsync();
+    const second = ix.disposeAsync();
+    let secondSettled = false;
+    void second.then(() => {
+      secondSettled = true;
+    });
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    expect(events).toEqual(['gate-entered']);
+    expect(secondSettled).toBe(false);
+    releaseGate();
+    await Promise.all([first, second]);
+    expect(events).toEqual(['gate-entered', 'finalizer']);
+  });
+
   it('parent dispose propagates to children', () => {
     const events: string[] = [];
     interface IParentSvc {

--- a/packages/agent-core-v2/test/features/skill/workspace/skillCatalog.test.ts
+++ b/packages/agent-core-v2/test/features/skill/workspace/skillCatalog.test.ts
@@ -185,7 +185,7 @@ function makeHost(
   });
   const disposeHost = host.dispose.bind(host);
   host.dispose = () => {
-    workspaceHandle.dispose();
+    void workspaceHandle.dispose();
     disposeHost();
   };
   return { host, workspace: workspaceHandle, config };

--- a/packages/agent-core-v2/test/features/todo/sessionTodo.test.ts
+++ b/packages/agent-core-v2/test/features/todo/sessionTodo.test.ts
@@ -166,7 +166,7 @@ function makeRuntimeAgent(
       registry.untrack(managed);
       await managed.runtimeSet.close();
       managed.killSpace();
-      handle.dispose();
+      await handle.dispose();
     },
   };
 }
@@ -248,7 +248,7 @@ describe('TodoAgentRuntime', () => {
     expect(managed.runtimeSet.resolve(AgentTodo)).toBe(todo);
     expect(reminders).toBe(1);
     await managed.runtimeSet.close();
-    handle.dispose();
+    await handle.dispose();
   });
 
   it('rejects resolve and lease tracking once the runtime set is closed', async () => {
@@ -417,7 +417,7 @@ describe('TodoAgentRuntime', () => {
     expect(creates).toBe(1);
     expect(managed.runtimeSet.inspect()[0]).toMatchObject({ status: 'materialized' });
     await managed.runtimeSet.close();
-    handle.dispose();
+    await handle.dispose();
   });
 
   it('reports registered, materialized, retired, and definition generations', async () => {
@@ -467,7 +467,7 @@ describe('TodoAgentRuntime', () => {
     managed.attachDurableRuntimes();
     expect(managed.runtimeSet.inspect()[0]).toMatchObject({ status: 'materialized', state: [] });
     await managed.runtimeSet.close();
-    handle.dispose();
+    await handle.dispose();
   });
 
   it('retains actor failure status and inspection diagnostics', async () => {
@@ -518,7 +518,7 @@ describe('TodoAgentRuntime', () => {
       error: 'actor failed',
     });
     await managed.runtimeSet.close();
-    handle.dispose();
+    await handle.dispose();
   });
 });
 

--- a/packages/agent-core-v2/test/session/agentLifecycle/agentLifecycle.test.ts
+++ b/packages/agent-core-v2/test/session/agentLifecycle/agentLifecycle.test.ts
@@ -651,6 +651,33 @@ describe('AgentLifecycleService', () => {
     }
   });
 
+  it('remove awaits asynchronous contributed-unit teardown before deactivating', async () => {
+    const svc = ix.get(IAgentLifecycleService);
+    const bus = ix.get(ISessionEventBus);
+    const seen: string[] = [];
+    disposables.add(bus.subscribe(AgentActivityUpdated, (event) => seen.push(event.lifecycle)));
+
+    contributeDisposeBeacon(async (eventBus, scope) => {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      publishDisposed(eventBus, scope);
+    });
+
+    const unhandled: unknown[] = [];
+    const onUnhandled = (reason: unknown): void => {
+      unhandled.push(reason);
+    };
+    process.on('unhandledRejection', onUnhandled);
+    try {
+      const main = await svc.create({ agentId: 'main' });
+      await svc.remove(main);
+      await new Promise((resolve) => setTimeout(resolve, 10));
+      expect(seen).toEqual(['disposed']);
+      expect(unhandled).toEqual([]);
+    } finally {
+      process.off('unhandledRejection', onUnhandled);
+    }
+  });
+
   it('remove stops the agent background tasks before disposal', async () => {
     const svc = ix.get(IAgentLifecycleService);
     const main = await svc.create({ agentId: 'main' });

--- a/packages/agent-core-v2/test/session/agentLifecycle/agentLifecycle.test.ts
+++ b/packages/agent-core-v2/test/session/agentLifecycle/agentLifecycle.test.ts
@@ -70,6 +70,7 @@ import { IConfigService } from '#/app/config/config';
 import { ISessionEventBus } from '#/app/event/eventBus';
 import { EventBusService } from '#/app/event/eventBusService';
 import '#/app/event/eventBusService';
+import { AgentActivityUpdated } from '#/agent/activityView/activityView';
 import { IAgentBlobService } from '#/agent/blob/agentBlobService';
 import { IAgentPluginService } from '#/agent/plugin/agentPlugin';
 import { ILogService } from '#/_base/log/log';
@@ -501,6 +502,48 @@ describe('AgentLifecycleService', () => {
     await svc.remove(main);
     expect(svc.get('main')).toBeUndefined();
     expect(svc.handleOf('main')).toBeUndefined();
+  });
+
+  it('remove keeps the lifecycle context active through async scope teardown', async () => {
+    const svc = ix.get(IAgentLifecycleService);
+    const bus = ix.get(ISessionEventBus);
+    const main = await svc.create({ agentId: 'main' });
+    const seen: string[] = [];
+    disposables.add(bus.subscribe(AgentActivityUpdated, (event) => seen.push(event.lifecycle)));
+    const agentScope = ix.children.find((child) => child.debugLabel === 'main');
+    expect(agentScope).toBeDefined();
+    let releaseDrain!: () => void;
+    agentScope!.anchorKernelEntry(
+      () =>
+        new Promise<void>((resolve) => {
+          releaseDrain = resolve;
+        }),
+      'test-async-disposer',
+    );
+    const unhandled: unknown[] = [];
+    const onUnhandled = (reason: unknown): void => {
+      unhandled.push(reason);
+    };
+    process.on('unhandledRejection', onUnhandled);
+    try {
+      await svc.remove(main);
+      bus.publish(
+        new AgentActivityUpdated({ lifecycle: 'disposed', background: [], agentId: 'main' }),
+        main,
+      );
+      expect(seen).toEqual(['disposed']);
+      releaseDrain();
+      await new Promise((resolve) => setTimeout(resolve, 10));
+      expect(() =>
+        bus.publish(
+          new AgentActivityUpdated({ lifecycle: 'disposed', background: [], agentId: 'main' }),
+          main,
+        ),
+      ).toThrow("Agent event 'agent.activity.updated' has no active lifecycle context");
+      expect(unhandled).toEqual([]);
+    } finally {
+      process.off('unhandledRejection', onUnhandled);
+    }
   });
 
   it('remove stops the agent background tasks before disposal', async () => {

--- a/packages/agent-core-v2/test/session/agentLifecycle/agentLifecycle.test.ts
+++ b/packages/agent-core-v2/test/session/agentLifecycle/agentLifecycle.test.ts
@@ -516,27 +516,31 @@ describe('AgentLifecycleService', () => {
     const agentScope = ix.children.find((child) => child.debugLabel === 'main');
     expect(agentScope).toBeDefined();
     let releaseDrain!: () => void;
-    agentScope!.anchorKernelEntry(
-      () =>
-        new Promise<void>((resolve) => {
-          releaseDrain = resolve;
-        }),
-      'test-async-disposer',
-    );
+    let gateEntered!: () => void;
+    const entered = new Promise<void>((resolve) => {
+      gateEntered = resolve;
+    });
+    agentScope!.anchorKernelEntry(() => {
+      gateEntered();
+      return new Promise<void>((resolve) => {
+        releaseDrain = resolve;
+      });
+    }, 'test-async-disposer');
     const unhandled: unknown[] = [];
     const onUnhandled = (reason: unknown): void => {
       unhandled.push(reason);
     };
     process.on('unhandledRejection', onUnhandled);
     try {
-      await svc.remove(main);
+      const removal = svc.remove(main);
+      await entered;
       bus.publish(
         new AgentActivityUpdated({ lifecycle: 'disposed', background: [], agentId: 'main' }),
         main,
       );
       expect(seen).toEqual(['disposed']);
       releaseDrain();
-      await new Promise((resolve) => setTimeout(resolve, 10));
+      await removal;
       expect(() =>
         bus.publish(
           new AgentActivityUpdated({ lifecycle: 'disposed', background: [], agentId: 'main' }),
@@ -643,7 +647,6 @@ describe('AgentLifecycleService', () => {
     process.on('unhandledRejection', onUnhandled);
     try {
       await expect(svc.create({ agentId: 'main' })).rejects.toThrow('boom');
-      await new Promise((resolve) => setTimeout(resolve, 50));
       expect(seen).toEqual(['disposed']);
       expect(unhandled).toEqual([]);
     } finally {
@@ -670,7 +673,6 @@ describe('AgentLifecycleService', () => {
     try {
       const main = await svc.create({ agentId: 'main' });
       await svc.remove(main);
-      await new Promise((resolve) => setTimeout(resolve, 10));
       expect(seen).toEqual(['disposed']);
       expect(unhandled).toEqual([]);
     } finally {
@@ -1354,7 +1356,7 @@ describe('AgentLifecycleService', () => {
     const originalDispose = handle.dispose.bind(handle);
     handle.dispose = () => {
       order.push('scope-disposed');
-      originalDispose();
+      return originalDispose();
     };
     svc.resolve(main, AgentTodo).get();
     expect(reminders).toBe(1);

--- a/packages/agent-core-v2/test/session/agentLifecycle/agentLifecycle.test.ts
+++ b/packages/agent-core-v2/test/session/agentLifecycle/agentLifecycle.test.ts
@@ -29,7 +29,7 @@ import { IAgentContextMemoryService } from '#/agent/contextMemory/contextMemory'
 import '#/agent/contextMemory/contextMemoryService';
 import { INHERITED_IN_FLIGHT_TOOL_OUTPUT } from '#/agent/contextMemory/openToolExchange';
 import type { ContextMessage } from '#/agent/contextMemory/types';
-import { agentContextOf } from '#/agent/scopeContext/scopeContext';
+import { agentContextOf, IAgentScopeContext } from '#/agent/scopeContext/scopeContext';
 import { IAgentIdentity } from '#/app/agentIdentity/agentIdentity';
 import { IBuiltinAgentProfileLoader } from '#/app/agentProfileCatalog/builtinAgentProfileLoader';
 import { IModelCatalog } from '#/kosong/model/catalog';
@@ -98,6 +98,7 @@ import '#/agent/toolActivation/toolActivationService';
 import { IAgentMediaToolsRegistrar } from '#/agent/media/mediaTools';
 import { ISessionWorkspaceContext } from '#/session/workspaceContext/workspaceContext';
 import { FakeRuntime } from '#/runtime/fakeRuntime';
+import { ScopeUnits } from '#/_base/di/fiber';
 import {
   IRuntimeResolver,
   IWorkspaceInstanceManager,
@@ -540,6 +541,52 @@ describe('AgentLifecycleService', () => {
           main,
         ),
       ).toThrow("Agent event 'agent.activity.updated' has no active lifecycle context");
+      expect(unhandled).toEqual([]);
+    } finally {
+      process.off('unhandledRejection', onUnhandled);
+    }
+  });
+
+  it('remove deactivates after scope-units contributed units are torn down', async () => {
+    const svc = ix.get(IAgentLifecycleService);
+    const bus = ix.get(ISessionEventBus);
+    const seen: string[] = [];
+    disposables.add(bus.subscribe(AgentActivityUpdated, (event) => seen.push(event.lifecycle)));
+
+    class DisposeBeacon {
+      constructor(
+        @ISessionEventBus private readonly eventBus: ISessionEventBus,
+        @IAgentScopeContext private readonly scope: IAgentScopeContext,
+      ) {}
+
+      dispose(): void {
+        this.eventBus.publish(
+          new AgentActivityUpdated({
+            lifecycle: 'disposed',
+            background: [],
+            agentId: this.scope.agentId,
+          }),
+          this.scope.agentContext,
+        );
+      }
+    }
+
+    ix.fiberHost.addCollectionRecord(
+      ScopeUnits(LifecycleScope.Agent),
+      'test',
+      new Ledger('test'),
+      DisposeBeacon,
+    );
+
+    const unhandled: unknown[] = [];
+    const onUnhandled = (reason: unknown): void => {
+      unhandled.push(reason);
+    };
+    process.on('unhandledRejection', onUnhandled);
+    try {
+      const main = await svc.create({ agentId: 'main' });
+      await svc.remove(main);
+      expect(seen).toEqual(['disposed']);
       expect(unhandled).toEqual([]);
     } finally {
       process.off('unhandledRejection', onUnhandled);

--- a/packages/agent-core-v2/test/session/agentLifecycle/agentLifecycle.test.ts
+++ b/packages/agent-core-v2/test/session/agentLifecycle/agentLifecycle.test.ts
@@ -2,6 +2,8 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { SyncDescriptor } from '#/_base/di/descriptors';
 import { Disposable, DisposableStore } from '#/_base/di/lifecycle';
+import { IInstantiationService } from '#/_base/di/instantiation';
+import { InstantiationService } from '#/_base/di/instantiationService';
 import { LifecycleScope } from '#/app/scopes';
 import { type ISessionScopeHandle } from '#/_base/di/scope';
 import { TestInstantiationService } from '#/_base/di/test';
@@ -547,27 +549,17 @@ describe('AgentLifecycleService', () => {
     }
   });
 
-  it('remove deactivates after scope-units contributed units are torn down', async () => {
-    const svc = ix.get(IAgentLifecycleService);
-    const bus = ix.get(ISessionEventBus);
-    const seen: string[] = [];
-    disposables.add(bus.subscribe(AgentActivityUpdated, (event) => seen.push(event.lifecycle)));
-
+  function contributeDisposeBeacon(
+    dispose: (eventBus: ISessionEventBus, scope: IAgentScopeContext) => void | Promise<void>,
+  ): void {
     class DisposeBeacon {
       constructor(
         @ISessionEventBus private readonly eventBus: ISessionEventBus,
         @IAgentScopeContext private readonly scope: IAgentScopeContext,
       ) {}
 
-      dispose(): void {
-        this.eventBus.publish(
-          new AgentActivityUpdated({
-            lifecycle: 'disposed',
-            background: [],
-            agentId: this.scope.agentId,
-          }),
-          this.scope.agentContext,
-        );
+      dispose(): void | Promise<void> {
+        return dispose(this.eventBus, this.scope);
       }
     }
 
@@ -577,6 +569,26 @@ describe('AgentLifecycleService', () => {
       new Ledger('test'),
       DisposeBeacon,
     );
+  }
+
+  function publishDisposed(eventBus: ISessionEventBus, scope: IAgentScopeContext): void {
+    eventBus.publish(
+      new AgentActivityUpdated({
+        lifecycle: 'disposed',
+        background: [],
+        agentId: scope.agentId,
+      }),
+      scope.agentContext,
+    );
+  }
+
+  it('remove deactivates after scope-units contributed units are torn down', async () => {
+    const svc = ix.get(IAgentLifecycleService);
+    const bus = ix.get(ISessionEventBus);
+    const seen: string[] = [];
+    disposables.add(bus.subscribe(AgentActivityUpdated, (event) => seen.push(event.lifecycle)));
+
+    contributeDisposeBeacon(publishDisposed);
 
     const unhandled: unknown[] = [];
     const onUnhandled = (reason: unknown): void => {
@@ -586,6 +598,52 @@ describe('AgentLifecycleService', () => {
     try {
       const main = await svc.create({ agentId: 'main' });
       await svc.remove(main);
+      expect(seen).toEqual(['disposed']);
+      expect(unhandled).toEqual([]);
+    } finally {
+      process.off('unhandledRejection', onUnhandled);
+    }
+  });
+
+  it('create failure after scope creation keeps the context active through async teardown', async () => {
+    registerAgent.mockRejectedValueOnce(new Error('boom'));
+    const svc = ix.get(IAgentLifecycleService);
+    const bus = ix.get(ISessionEventBus);
+    const seen: string[] = [];
+    disposables.add(bus.subscribe(AgentActivityUpdated, (event) => seen.push(event.lifecycle)));
+
+    class GatedBeacon {
+      constructor(
+        @ISessionEventBus private readonly eventBus: ISessionEventBus,
+        @IAgentScopeContext private readonly scope: IAgentScopeContext,
+        @IInstantiationService instantiation: IInstantiationService,
+      ) {
+        (instantiation as InstantiationService).anchorKernelEntry(
+          () => new Promise<void>((resolve) => setTimeout(resolve, 20)),
+          'beacon-gate',
+        );
+      }
+
+      dispose(): void {
+        publishDisposed(this.eventBus, this.scope);
+      }
+    }
+
+    ix.fiberHost.addCollectionRecord(
+      ScopeUnits(LifecycleScope.Agent),
+      'test',
+      new Ledger('test'),
+      GatedBeacon,
+    );
+
+    const unhandled: unknown[] = [];
+    const onUnhandled = (reason: unknown): void => {
+      unhandled.push(reason);
+    };
+    process.on('unhandledRejection', onUnhandled);
+    try {
+      await expect(svc.create({ agentId: 'main' })).rejects.toThrow('boom');
+      await new Promise((resolve) => setTimeout(resolve, 50));
       expect(seen).toEqual(['disposed']);
       expect(unhandled).toEqual([]);
     } finally {

--- a/packages/agent-core-v2/test/wire/resume.test.ts
+++ b/packages/agent-core-v2/test/wire/resume.test.ts
@@ -130,6 +130,40 @@ describe('Agent resume', () => {
     }
   });
 
+  it('resumes a journal that stops mid-turn without any turn-closing record', async () => {
+    const persistence = new RecordingAgentPersistence([
+      resumeConfigRecord(),
+      contextAppendRecord(0, [{ role: 'user', text: 'dangling turn', origin: { kind: 'user' } }]),
+      turnPromptRecord(0, { kind: 'user' }),
+      {
+        type: 'context.append_loop_event',
+        event: { type: 'step.begin', uuid: 'step-0', turnId: '0', step: 1 },
+      },
+    ] as unknown as WireRecord[]);
+    const ctx = testAgent({ persistence, autoConfigure: false });
+
+    try {
+      await ctx.restorePersisted();
+
+      expect(ctx.llmCalls).toHaveLength(0);
+      expect(turnCurrentId(ctx)).toBe(0);
+
+      ctx.mockNextResponse({ type: 'text', text: 'Fresh response after resume.' });
+      await ctx.rpc.prompt({ input: [{ type: 'text', text: 'Fresh prompt after resume' }] });
+      await ctx.untilTurnEnd();
+
+      expect(findRpcEvent(ctx.allEvents, 'turn.started')?.args).toMatchObject({ turnId: 1 });
+      expect(findRpcEvent(ctx.allEvents, 'turn.ended')?.args).toMatchObject({
+        turnId: 1,
+        reason: 'completed',
+      });
+      expect(findRpcEvent(ctx.allEvents, 'error')).toBeUndefined();
+      await ctx.expectResumeMatches();
+    } finally {
+      await ctx.dispose();
+    }
+  });
+
   it('does not reconcile a legacy interruption whose delivery was recorded', async () => {
     const persistence = new RecordingAgentPersistence([
       resumeConfigRecord(),

--- a/packages/kap-server/src/start.ts
+++ b/packages/kap-server/src/start.ts
@@ -356,8 +356,6 @@ export async function startServer(opts: ServerStartOptions): Promise<RunningServ
   }
 
   const close = async (): Promise<void> => {
-    process.off('unhandledRejection', onUnhandledRejection);
-    process.off('uncaughtException', onUncaughtException);
     await app.close();
     configWarningSubscription.dispose();
     pluginChangeSubscription.dispose();
@@ -386,7 +384,12 @@ export async function startServer(opts: ServerStartOptions): Promise<RunningServ
       await drainSessionMetadataWrites();
       await drainLogCloses();
     } finally {
-      await registration.release();
+      try {
+        await registration.release();
+      } finally {
+        process.off('unhandledRejection', onUnhandledRejection);
+        process.off('uncaughtException', onUncaughtException);
+      }
     }
   };
 

--- a/packages/kap-server/src/start.ts
+++ b/packages/kap-server/src/start.ts
@@ -241,8 +241,6 @@ export async function startServer(opts: ServerStartOptions): Promise<RunningServ
     );
     process.exit(1);
   };
-  process.on('unhandledRejection', onUnhandledRejection);
-  process.on('uncaughtException', onUncaughtException);
   const authFailureLimiter =
     exposureClass === 'loopback' ? undefined : createAuthFailureLimiter({ logger });
 
@@ -639,6 +637,9 @@ export async function startServer(opts: ServerStartOptions): Promise<RunningServ
       'provider-model catalog auto-refresh failed to start',
     );
   });
+
+  process.on('unhandledRejection', onUnhandledRejection);
+  process.on('uncaughtException', onUncaughtException);
 
   return { app, core, connectionRegistry, authTokenService, host, port: boundPort, close };
 }

--- a/packages/kap-server/src/start.ts
+++ b/packages/kap-server/src/start.ts
@@ -228,6 +228,21 @@ export async function startServer(opts: ServerStartOptions): Promise<RunningServ
   const enableTerminals = exposureClass === 'loopback' || opts.allowRemoteTerminals === true;
   const debugEndpoints = exposureClass === 'loopback' && opts.debugEndpoints === true;
   const logger = opts.logger ?? createServerLogger({ level: opts.logLevel ?? 'info' });
+  const onUnhandledRejection = (reason: unknown): void => {
+    logger.error(
+      { err: reason instanceof Error ? reason : new Error(String(reason)) },
+      'unhandledRejection',
+    );
+  };
+  const onUncaughtException = (err: unknown): void => {
+    logger.fatal(
+      { err: err instanceof Error ? err : new Error(String(err)) },
+      'uncaughtException',
+    );
+    process.exit(1);
+  };
+  process.on('unhandledRejection', onUnhandledRejection);
+  process.on('uncaughtException', onUncaughtException);
   const authFailureLimiter =
     exposureClass === 'loopback' ? undefined : createAuthFailureLimiter({ logger });
 
@@ -343,6 +358,8 @@ export async function startServer(opts: ServerStartOptions): Promise<RunningServ
   }
 
   const close = async (): Promise<void> => {
+    process.off('unhandledRejection', onUnhandledRejection);
+    process.off('uncaughtException', onUncaughtException);
     await app.close();
     configWarningSubscription.dispose();
     pluginChangeSubscription.dispose();

--- a/packages/kap-server/test/boot.test.ts
+++ b/packages/kap-server/test/boot.test.ts
@@ -232,6 +232,28 @@ describe('server-v2 boot', () => {
     expect(() => core.accessor.get(IBootstrapService)).toThrow();
     expect(await listLiveServerInstances(home)).toEqual([]);
   });
+
+  it('installs process-level rejection handlers while running and removes them on close', async () => {
+    home = await mkdtemp(join(tmpdir(), 'kimi-server-v2-'));
+    const rejectionBefore = process.listenerCount('unhandledRejection');
+    const exceptionBefore = process.listenerCount('uncaughtException');
+    server = await startServer({
+      hostIdentity: TEST_HOST_IDENTITY,
+      host: '127.0.0.1',
+      port: 0,
+      homeDir: home,
+      logLevel: 'silent',
+    });
+
+    expect(process.listenerCount('unhandledRejection')).toBe(rejectionBefore + 1);
+    expect(process.listenerCount('uncaughtException')).toBe(exceptionBefore + 1);
+
+    await server.close();
+    server = undefined;
+
+    expect(process.listenerCount('unhandledRejection')).toBe(rejectionBefore);
+    expect(process.listenerCount('uncaughtException')).toBe(exceptionBefore);
+  });
 });
 
 function silentLogger() {

--- a/packages/kap-server/test/boot.test.ts
+++ b/packages/kap-server/test/boot.test.ts
@@ -254,6 +254,29 @@ describe('server-v2 boot', () => {
     expect(process.listenerCount('unhandledRejection')).toBe(rejectionBefore);
     expect(process.listenerCount('uncaughtException')).toBe(exceptionBefore);
   });
+
+  it('does not leave process handlers installed when startup fails', async () => {
+    home = await mkdtemp(join(tmpdir(), 'kimi-server-v2-'));
+    const emptyAssets = await mkdtemp(join(tmpdir(), 'kimi-server-v2-assets-'));
+    const rejectionBefore = process.listenerCount('unhandledRejection');
+    const exceptionBefore = process.listenerCount('uncaughtException');
+    try {
+      await expect(
+        startServer({
+          hostIdentity: TEST_HOST_IDENTITY,
+          host: '127.0.0.1',
+          port: 0,
+          homeDir: home,
+          logLevel: 'silent',
+          webAssetsDir: emptyAssets,
+        }),
+      ).rejects.toThrow('web assets');
+      expect(process.listenerCount('unhandledRejection')).toBe(rejectionBefore);
+      expect(process.listenerCount('uncaughtException')).toBe(exceptionBefore);
+    } finally {
+      await rm(emptyAssets, { recursive: true, force: true });
+    }
+  });
 });
 
 function silentLogger() {


### PR DESCRIPTION
## Related Issue

None — this comes from a production incident report (kap-server crash loop on restart), no tracking issue was filed.

## Problem

When a kap-server process dies while a session has an in-flight turn, every subsequent restart can crash again during session restore/close, forming a crash loop that takes down the entire server (dozens of sessions), and supervisor restarts cannot self-heal because the crash is data-driven.

Root cause: agent close paths (`AgentLifecycleService.remove()` and the create-failure cleanup) ran `deactivateAgent` after `handle.dispose()`, while scope teardown is fire-and-forget and its drain can suspend on any asynchronous disposer. `AgentActivityView.dispose()` then published `agent.activity.updated` after the agent's lifecycle context was already deactivated; `EventBusService.publish` (an intentional strict check) threw, the throw became an unobserved rejected promise via `void dispatcher.dispatch(...)`, and with no `unhandledRejection` handler in server mode the process exited with code 1.

## What changed

- **agent-core-v2**: anchor `deactivateAgent` as the last drain record of the agent scope's own teardown (registered first in `configureContainer` at scope creation, so reverse-order drain runs it last) instead of calling it explicitly after `handle.dispose()` in `remove()`. The agent's lifecycle context now stays active for the entire drain, so teardown-time event publications (e.g. the final `disposed` activity state) remain valid, and every close path — remove, session-scope cascade, create-failure cleanup — deactivates exactly once. The strict lifecycle-context validation in `EventBusService.publish` is unchanged.
- **kap-server**: install process-level `unhandledRejection` (log + continue) and `uncaughtException` (log + exit 1) handlers in `startServer()`, removed on `close()`. A single stray rejection in one session can no longer kill a multi-session server process; the failing session's error is isolated and logged instead.
- **Tests**: an agent-lifecycle test pinning "the lifecycle context stays active through asynchronous scope teardown" (verified to fail without the fix), a wire resume test for a journal truncated mid-turn with no closing record, and a kap-server boot test for handler install/removal.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [ ] I have linked a related issue (external PRs: the issue must have a maintainer's `/approve`).
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.
