### PR TITLE
refactor(agent-core-v2): drop in-place system prompt refresh

### DIFF
--- a/apps/kimi-inspect/src/panels.ts
+++ b/apps/kimi-inspect/src/panels.ts
@@ -158,7 +158,6 @@ export const AGENT_PANELS: readonly ServicePanelDef[] = [
     }),
     actions: [
       { label: 'Set model', input: 'Model id', run: (svc, model) => call(svc, 'setModel', model) },
-      { label: 'Refresh system prompt', run: (svc) => call(svc, 'refreshSystemPrompt') },
     ],
   },
   {

--- a/packages/agent-core-v2/src/agent/agentsMdReminder/agentsMdReminderService.ts
+++ b/packages/agent-core-v2/src/agent/agentsMdReminder/agentsMdReminderService.ts
@@ -9,8 +9,10 @@ import { IBootstrapService } from '#/app/bootstrap/bootstrap';
 import type { AgentsMdReminderShownEvent } from '#/app/telemetry/events';
 import { ITelemetryService } from '#/app/telemetry/telemetry';
 import type { IHostFileSystem } from '#/os/interface/hostFileSystem';
+import type { HostFsChange } from '#/os/interface/hostFsWatch';
 import { IAgentRuntimeService } from '#/agent/runtimeBinding/agentRuntime';
 import { ISessionContext } from '#/session/sessionContext/sessionContext';
+import { ISessionInstructionsProvider } from '#/session/sessionInstructions/instructionsProvider';
 import { normalizeUserPath } from '#/tool/path-access';
 import {
   AGENTS_MD_PLAIN_NAMES,
@@ -65,11 +67,17 @@ export class AgentAgentsMdReminderService
     @ITelemetryService private readonly telemetry: ITelemetryService,
     @IEventDispatcher private readonly dispatcher: IEventDispatcher,
       @IAgentStateService private readonly agentState: IAgentStateService,
+    @ISessionInstructionsProvider private readonly instructions: ISessionInstructionsProvider,
   ) {
     super();
     this.states.contributeState(agentsMdReminderKnownKey);
     this.states.contributeState(agentsMdReminderCwdKey);
     this.states.contributeState(agentsMdReminderSeededKey);
+    this._register(
+      this.instructions.onDidChange((changes) => {
+        this.announceChanged(changes);
+      }),
+    );
     this._register(
       this.dispatcher.hooks.onDidRestore.register('agentsMdReminder', async (_ctx, next) => {
         const profile = this.agentState.get(profileKey);
@@ -92,6 +100,24 @@ export class AgentAgentsMdReminderService
     this.states.set(agentsMdReminderKnownKey, new Set(known));
     this.states.set(agentsMdReminderCwdKey, cwd);
     this.states.set(agentsMdReminderSeededKey, true);
+  }
+
+  private announceChanged(changes: readonly HostFsChange[]): void {
+    if (!this.states.get(agentsMdReminderSeededKey)) return;
+    const entries = new Map<string, HostFsChange>();
+    for (const change of changes) {
+      const path = normalize(change.path);
+      entries.set(path, { ...change, path });
+    }
+    if (entries.size === 0) return;
+    const list = [...entries.values()];
+    this.reminders.appendSystemReminder(changeReminderText(list), {
+      kind: 'injection',
+      variant: 'agents_md_change',
+    });
+    this.publishKnown(
+      list.filter((change) => change.action !== 'deleted').map((change) => change.path),
+    );
   }
 
   private readonly claimed = new Set<string>();
@@ -284,6 +310,16 @@ function reminderText(paths: readonly string[]): string {
     'The path(s) touched by a recent tool call are covered by AGENTS.md instruction file(s) that were not part of the injected instructions:\n' +
     paths.map((path) => `- ${path}`).join('\n') +
     '\nRead them before making changes in those directories. Each file is suggested at most once per agent.'
+  );
+}
+
+function changeReminderText(changes: readonly HostFsChange[]): string {
+  return (
+    'The AGENTS.md instruction file(s) below changed on disk after they were injected into the system prompt:\n' +
+    changes
+      .map((change) => `- ${change.path}${change.action === 'deleted' ? ' (deleted)' : ''}`)
+      .join('\n') +
+    '\nRead the current file(s) and follow the latest contents; the copies injected in the system prompt are stale.'
   );
 }
 

--- a/packages/agent-core-v2/src/agent/fullCompaction/fullCompactionService.ts
+++ b/packages/agent-core-v2/src/agent/fullCompaction/fullCompactionService.ts
@@ -2,7 +2,6 @@ import type { IDisposable } from '#/_base/di/lifecycle';
 import { Service } from "#/_base/di/service";
 import { LifecycleScope } from '#/app/scopes';
 import { ScopeActivation, registerScopedService } from '#/_base/di/scope';
-import { ILogService } from '#/_base/log/log';
 import { defineState } from '#/state/state';
 import { renderPrompt } from "#/_base/utils/render-prompt";
 import { estimateTokensForMessage } from "#/kosong/contract/tokens";
@@ -151,7 +150,6 @@ export class AgentFullCompactionService extends Service implements IAgentFullCom
     @ITelemetryService private readonly telemetry: ITelemetryService,
     @IEventDispatcher private readonly dispatcher: IEventDispatcher,
     @IEventBus private readonly eventBus: IEventBus,
-    @ILogService private readonly log: ILogService,
     @IAgentLoopService private readonly loopService: IAgentLoopService,
     @IAgentStateService private readonly states: IAgentStateService,
   ) {
@@ -578,11 +576,6 @@ export class AgentFullCompactionService extends Service implements IAgentFullCom
     try {
       const result = await this.compactionRound(active, data);
       if (this._compacting !== active) throw compactionCancelledReason(active);
-      try {
-        await this.profile.refreshSystemPrompt();
-      } catch (error) {
-        this.log.error('failed to refresh system prompt after compaction', { error });
-      }
       this.lastCompactedTokenCount = result.tokensAfter;
       if (!this.markCompleted(active)) {
         throw compactionCancelledReason(active);

--- a/packages/agent-core-v2/src/agent/profile/profile.ts
+++ b/packages/agent-core-v2/src/agent/profile/profile.ts
@@ -122,7 +122,6 @@ export interface IAgentProfileService {
   getModel(): string;
   useProfile(profile: ResolvedAgentProfile, context: SystemPromptContext): void;
   applyProfile(profile: ResolvedAgentProfile, options?: ApplyProfileOptions): Promise<void>;
-  refreshSystemPrompt(): Promise<void>;
   getAgentsMdWarning(): string | undefined;
   data(): ProfileData;
   getEffectiveThinkingLevel(): ThinkingEffort;

--- a/packages/agent-core-v2/src/agent/profile/profileService.ts
+++ b/packages/agent-core-v2/src/agent/profile/profileService.ts
@@ -34,7 +34,6 @@ import type { ToolSource } from '#/tool/toolContract';
 import { ISessionWorkspaceContext } from '#/session/workspaceContext/workspaceContext';
 import { ISessionInstructionsProvider } from '#/session/sessionInstructions/instructionsProvider';
 import { ISessionSkillCatalog } from '#/features/skill/session/skillCatalog';
-import { BUILTIN_SKILL_SOURCE_ID } from '#/features/skill/catalog/skillSource';
 import { ISessionAgentProfileCatalog } from '#/session/sessionAgentProfileCatalog/sessionAgentProfileCatalog';
 import { ISessionToolPolicy } from '#/session/sessionToolPolicy/sessionToolPolicy';
 import { ISessionToolPolicyGate } from '#/session/sessionToolPolicyGate/sessionToolPolicyGate';
@@ -178,22 +177,9 @@ export class AgentProfileService extends Disposable implements IAgentProfileServ
     this.states.contributeState(profileEmittedPluginBudgetWarningsKey);
     this.configure({});
     this._register(
-      this.sessionToolPolicy.onDidChange((event) => {
-        event.waitUntil(this.refreshSystemPrompt());
-      }),
-    );
-    this._register(
       this.config.onDidSectionChange(({ domain }) => {
         if (domain === TOOLS_SECTION) {
           this.publishToolPatternWarnings();
-          void this.refreshSystemPrompt();
-        }
-      }),
-    );
-    this._register(
-      this.skillCatalog.onDidChange((sourceId) => {
-        if (sourceId === BUILTIN_SKILL_SOURCE_ID) {
-          void this.refreshSystemPrompt();
         }
       }),
     );
@@ -419,36 +405,6 @@ export class AgentProfileService extends Disposable implements IAgentProfileServ
     this.cacheAgentsMdWarning(context);
     this.publishAgentsMdWarning();
     this.publishToolPatternWarnings(profile);
-  }
-
-  async refreshSystemPrompt(): Promise<void> {
-    const profile = this.resolveActiveProfile();
-    if (profile === undefined) return;
-
-    let context: SystemPromptContext;
-    try {
-      context = await this.buildSystemPromptContext(profile);
-    } catch (error) {
-      void this.dispatcher.dispatch(
-        new WarningIssued({
-          agentId: this.scopeContext.agentId,
-          message: `System prompt refresh skipped: ${error instanceof Error ? error.message : String(error)}`,
-          code: 'system-prompt-refresh-failed',
-        }),
-      );
-      return;
-    }
-    this.activeProfile = profile;
-    const rendered = profile.renderSystemPrompt(context);
-    this.update({
-      profileName: profile.name,
-      systemPrompt: rendered.text,
-      environmentDisclosure: rendered.environment,
-      agentsMdPaths: context.agentsMdPaths ?? [],
-    });
-    this.seedAgentsMdReminder(context);
-    this.cacheAgentsMdWarning(context);
-    this.publishAgentsMdWarning();
   }
 
   private seedAgentsMdReminder(context: SystemPromptContext): void {
@@ -763,13 +719,6 @@ export class AgentProfileService extends Disposable implements IAgentProfileServ
         { current, requested },
       );
     }
-  }
-
-  private resolveActiveProfile(): ResolvedAgentProfile | undefined {
-    if (this.activeProfile !== undefined) return this.activeProfile;
-    const profileName = this.profileName;
-    if (profileName === undefined) return undefined;
-    return this.catalog.get(profileName);
   }
 
   private cacheAgentsMdWarning(context: Pick<SystemPromptContext, 'agentsMdWarning'>): void {

--- a/packages/agent-core-v2/src/session/sessionInstructions/instructionsProvider.ts
+++ b/packages/agent-core-v2/src/session/sessionInstructions/instructionsProvider.ts
@@ -1,6 +1,7 @@
 import { createDecorator, type ServiceIdentifier } from '#/_base/di/instantiation';
 import type { ScopeSeed } from '#/_base/di/scope';
 import type { Event } from '#/_base/event';
+import type { HostFsChange } from '#/os/interface/hostFsWatch';
 
 export interface ISessionInstructionsProvider {
   readonly _serviceBrand: undefined;
@@ -9,7 +10,7 @@ export interface ISessionInstructionsProvider {
   readonly agentsMd: string | undefined;
   readonly agentsMdWarning: string | undefined;
   readonly agentsMdPaths: readonly string[] | undefined;
-  readonly onDidChange: Event<void>;
+  readonly onDidChange: Event<readonly HostFsChange[]>;
 }
 
 export const ISessionInstructionsProvider: ServiceIdentifier<ISessionInstructionsProvider> =

--- a/packages/agent-core-v2/src/workspace/workspaceInstructions/workspaceInstructions.ts
+++ b/packages/agent-core-v2/src/workspace/workspaceInstructions/workspaceInstructions.ts
@@ -1,5 +1,6 @@
 import { createDecorator, type ServiceIdentifier } from '#/_base/di/instantiation';
 import type { Event } from '#/_base/event';
+import type { HostFsChange } from '#/os/interface/hostFsWatch';
 import type { ISessionInstructionsProvider } from '#/session/sessionInstructions/instructionsProvider';
 
 export interface WorkspaceInstructionsSnapshot {
@@ -13,7 +14,7 @@ export interface IWorkspaceInstructionsService {
 
   readonly ready: Promise<void>;
   readonly snapshot: WorkspaceInstructionsSnapshot;
-  readonly onDidChange: Event<void>;
+  readonly onDidChange: Event<readonly HostFsChange[]>;
   reload(): Promise<void>;
   sessionProvider(): ISessionInstructionsProvider;
 }

--- a/packages/agent-core-v2/src/workspace/workspaceInstructions/workspaceInstructionsService.ts
+++ b/packages/agent-core-v2/src/workspace/workspaceInstructions/workspaceInstructionsService.ts
@@ -8,7 +8,7 @@ import { agentsMdWatchRoots, loadAgentsMdForRoots } from '#/agent/profile/contex
 import { IBootstrapService } from '#/app/bootstrap/bootstrap';
 import { IHostEnvironment, type HostEnvironmentInfo } from '#/os/interface/hostEnvironment';
 import { IHostFileSystem } from '#/os/interface/hostFileSystem';
-import { IHostFsWatchService } from '#/os/interface/hostFsWatch';
+import { IHostFsWatchService, type HostFsChange } from '#/os/interface/hostFsWatch';
 import type { ISessionInstructionsProvider } from '#/session/sessionInstructions/instructionsProvider';
 import { IWorkspaceStateService } from '#/workspace/state/workspaceState';
 import { IWorkspaceContext } from '#/workspace/workspaceContext/workspaceContext';
@@ -32,10 +32,12 @@ export class WorkspaceInstructionsService
   declare readonly _serviceBrand: undefined;
 
   readonly ready: Promise<void>;
-  private readonly onDidChangeEmitter = this._register(new Emitter<void>());
-  readonly onDidChange: Event<void> = this.onDidChangeEmitter.event;
+  private readonly onDidChangeEmitter = this._register(new Emitter<readonly HostFsChange[]>());
+  readonly onDidChange: Event<readonly HostFsChange[]> = this.onDidChangeEmitter.event;
   private readonly watchDebounce = this._register(new TimeoutTimer());
   private reloadTail: Promise<void> = Promise.resolve();
+  private loaded = false;
+  private readonly pendingChanges = new Map<string, HostFsChange>();
 
   constructor(
     @IWorkspaceContext private readonly workspace: IWorkspaceContext,
@@ -80,8 +82,12 @@ export class WorkspaceInstructionsService
         next.agentsMd !== this.current.agentsMd ||
         next.agentsMdWarning !== this.current.agentsMdWarning;
       this.current = next;
-      if (changed) {
-        this.onDidChangeEmitter.fire();
+      const changes = [...this.pendingChanges.values()];
+      this.pendingChanges.clear();
+      const loaded = this.loaded;
+      this.loaded = true;
+      if (changed && loaded) {
+        this.onDidChangeEmitter.fire(changes);
       }
     });
     this.reloadTail = tail;
@@ -121,7 +127,8 @@ export class WorkspaceInstructionsService
         });
         this._register(handle);
         this._register(
-          handle.onDidChange(() => {
+          handle.onDidChange((change) => {
+            this.pendingChanges.set(change.path, change);
             this.watchDebounce.cancelAndSet(() => {
               void this.reload().catch((error) => {
                 this.log.warn(`AGENTS.md reload failed: ${String(error)}`);

--- a/packages/agent-core-v2/test/agent/agentsMdReminder/agentsMdReminder.test.ts
+++ b/packages/agent-core-v2/test/agent/agentsMdReminder/agentsMdReminder.test.ts
@@ -6,6 +6,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { DisposableStore } from '#/_base/di/lifecycle';
 import { createServices, type TestInstantiationService } from '#/_base/di/test';
+import { Emitter } from '#/_base/event';
 import { IBashParserService } from '#/app/bashParser/bashParser';
 import { BashParserService } from '#/app/bashParser/bashParserService';
 import { ITelemetryService } from '#/app/telemetry/telemetry';
@@ -16,6 +17,8 @@ import { IHostFileSystem, type HostFileStat } from '#/os/interface/hostFileSyste
 import type { RuntimeLease } from '#/runtime/runtime';
 import { IAgentRuntimeService } from '#/agent/runtimeBinding/agentRuntime';
 import { ISessionContext } from '#/session/sessionContext/sessionContext';
+import { ISessionInstructionsProvider } from '#/session/sessionInstructions/instructionsProvider';
+import type { HostFsChange } from '#/os/interface/hostFsWatch';
 import {
   ToolAccesses,
   type ToolAccesses as ToolAccessesType,
@@ -48,7 +51,10 @@ import { OrderedHookSlot } from '#/hooks';
 import { IEventDispatcher } from '#/state/eventDispatcher';
 import type { ToolDidExecuteContext } from '#/agent/toolExecutor/toolHooks';
 import { IAgentAgentsMdReminderService } from '#/agent/agentsMdReminder/agentsMdReminder';
-import { AgentAgentsMdReminderService } from '#/agent/agentsMdReminder/agentsMdReminderService';
+import {
+  AgentAgentsMdReminderService,
+  agentsMdReminderKnownKey,
+} from '#/agent/agentsMdReminder/agentsMdReminderService';
 import { extractBashTargetDirs } from '#/agent/agentsMdReminder/bashTargets';
 import { recordingTelemetry, type TelemetryRecord } from '../../app/telemetry/stubs';
 import { stubToolExecutorEvents, type ToolExecutorEventStubs } from '../toolExecutor/stubs';
@@ -85,6 +91,7 @@ interface Harness {
   readonly dispatcher: IEventDispatcher;
   readonly telemetryEvents: TelemetryRecord[];
   readonly reminders: CapturedReminder[];
+  readonly instructionsChange: Emitter<readonly HostFsChange[]>;
 }
 
 function createHarness(
@@ -104,6 +111,7 @@ function createHarness(
   const telemetryEvents: TelemetryRecord[] = [];
   const reminders: CapturedReminder[] = [];
   const events = stubToolExecutorEvents();
+  const instructionsChange = disposables.add(new Emitter<readonly HostFsChange[]>());
   const ix = createServices(disposables, {
     additionalServices: (reg) => {
       if (options.withRealExecutor === true) {
@@ -161,6 +169,14 @@ function createHarness(
         scope: (sub?: string): string =>
           sub ? `sessions/workspace-1/session-1/${sub}` : 'sessions/workspace-1/session-1',
       } satisfies ISessionContext);
+      reg.defineInstance(ISessionInstructionsProvider, {
+        _serviceBrand: undefined,
+        ready: Promise.resolve(),
+        agentsMd: undefined,
+        agentsMdWarning: undefined,
+        agentsMdPaths: undefined,
+        onDidChange: instructionsChange.event,
+      } satisfies ISessionInstructionsProvider);
       const hostFs = options.hostFs ?? new HostFileSystem();
       const hostEnvironment = {
         _serviceBrand: undefined,
@@ -214,7 +230,7 @@ function createHarness(
   });
   const reminder = ix.get(IAgentAgentsMdReminderService);
   const dispatcher = ix.get(IEventDispatcher);
-  return { ix, events, reminder, dispatcher, telemetryEvents, reminders };
+  return { ix, events, reminder, dispatcher, telemetryEvents, reminders, instructionsChange };
 }
 
 function didCtx(
@@ -285,6 +301,54 @@ async function writeAgentsMd(dir: string, content = 'instructions'): Promise<str
   await writeFile(path, content, 'utf-8');
   return normalize(path);
 }
+
+describe('agentsMdReminder instructions change announcements', () => {
+  it('appends a path-announcement reminder when an injected AGENTS.md changes on disk', async () => {
+    const h = createHarness();
+    const rootAgentsMd = await writeAgentsMd(workDir, 'root instructions');
+    h.reminder.seedInjected([rootAgentsMd], workDir);
+
+    h.instructionsChange.fire([{ path: rootAgentsMd, action: 'modified', kind: 'file' }]);
+
+    expect(h.reminders).toHaveLength(1);
+    expect(h.reminders[0]?.origin).toEqual({ kind: 'injection', variant: 'agents_md_change' });
+    expect(h.reminders[0]?.content).toContain(rootAgentsMd);
+    expect(h.reminders[0]?.content).toContain('stale');
+  });
+
+  it('marks deleted AGENTS.md files in the announcement', async () => {
+    const h = createHarness();
+    const rootAgentsMd = await writeAgentsMd(workDir, 'root instructions');
+    h.reminder.seedInjected([rootAgentsMd], workDir);
+
+    h.instructionsChange.fire([{ path: rootAgentsMd, action: 'deleted', kind: 'file' }]);
+
+    expect(h.reminders).toHaveLength(1);
+    expect(h.reminders[0]?.content).toContain(`${rootAgentsMd} (deleted)`);
+  });
+
+  it('stays silent when the agent has not been seeded yet', async () => {
+    const h = createHarness();
+
+    h.instructionsChange.fire([
+      { path: join(workDir, 'AGENTS.md'), action: 'modified', kind: 'file' },
+    ]);
+
+    expect(h.reminders).toHaveLength(0);
+  });
+
+  it('adds announced paths to the known set so discovery does not repeat them', async () => {
+    const h = createHarness();
+    const rootAgentsMd = await writeAgentsMd(workDir, 'root instructions');
+    h.reminder.seedInjected([], workDir);
+
+    h.instructionsChange.fire([{ path: rootAgentsMd, action: 'created', kind: 'file' }]);
+
+    expect(h.reminders).toHaveLength(1);
+    const known = h.ix.get(IAgentStateService).get(agentsMdReminderKnownKey);
+    expect(known.has(normalize(rootAgentsMd))).toBe(true);
+  });
+});
 
 describe('agentsMdReminder path-carrying tools', () => {
   it('appends a reminder listing the uninjected AGENTS.md when Read touches its directory', async () => {

--- a/packages/agent-core-v2/test/agent/fullCompaction/fullCompaction.test.ts
+++ b/packages/agent-core-v2/test/agent/fullCompaction/fullCompaction.test.ts
@@ -77,7 +77,7 @@ const SNAPSHOT_VISIBLE_TOOLS = [
   'ExitPlanMode',
 ] as const;
 const LARGE_MCP_TOOL = 'mcp__srv__large';
-const EXACT_COMPACTION_REFRESH_PROFILE: ResolvedAgentProfile = normalizeAgentProfile({
+const EXACT_COMPACTION_PROFILE: ResolvedAgentProfile = normalizeAgentProfile({
   name: 'exact-compaction-refresh',
   systemPrompt: (context) =>
     [
@@ -351,7 +351,7 @@ describe('FullCompaction', () => {
     hook.dispose();
   });
 
-  it('refreshes the active profile system prompt after compaction without resetting active tools', async () => {
+  it('keeps the active profile system prompt frozen after compaction without resetting active tools', async () => {
     const homeDir = mkdtempSync(join(tmpdir(), 'kimi-compact-refresh-home-'));
     const workDir = mkdtempSync(join(tmpdir(), 'kimi-compact-refresh-work-'));
     try {
@@ -363,14 +363,12 @@ describe('FullCompaction', () => {
       );
       ctx.configureRuntimeModel(CATALOGUED_PROVIDER, CATALOGUED_MODEL_CAPABILITIES);
       const profile = ctx.get(IAgentProfileService);
-      await profile.applyProfile(EXACT_COMPACTION_REFRESH_PROFILE);
+      await profile.applyProfile(EXACT_COMPACTION_PROFILE);
       profile.update({ activeToolNames: ['Read'] });
 
-      expect(profile.data().systemPrompt).toBe(
-        exactCompactionRefreshPrompt(workDir, 'old project instructions'),
-      );
+      const before = profile.data().systemPrompt;
+      expect(before).toBe(exactCompactionPrompt(workDir, 'old project instructions'));
 
-      const refreshSpy = vi.spyOn(profile, 'refreshSystemPrompt');
       writeFileSync(join(workDir, 'AGENTS.md'), 'new project instructions', 'utf-8');
       ctx.appendExchange(1, 'old user one', 'old assistant one', 20);
       ctx.appendExchange(2, 'recent user two', 'recent assistant two', 80);
@@ -380,10 +378,7 @@ describe('FullCompaction', () => {
       await ctx.rpc.beginCompaction({});
       await completed;
 
-      expect(refreshSpy).toHaveBeenCalledTimes(1);
-      expect(profile.data().systemPrompt).toBe(
-        exactCompactionRefreshPrompt(workDir, 'new project instructions'),
-      );
+      expect(profile.data().systemPrompt).toBe(before);
       expect(profile.getActiveToolNames()).toEqual(['Read']);
     } finally {
       rmSync(homeDir, { recursive: true, force: true });
@@ -3014,7 +3009,7 @@ function countEvents(events: ReturnType<TestAgentContext['newEvents']>, type: st
   }).length;
 }
 
-function exactCompactionRefreshPrompt(workDir: string, agentsMd: string): string {
+function exactCompactionPrompt(workDir: string, agentsMd: string): string {
   return [
     `cwd:${workDir}`,
     'os:Linux',

--- a/packages/agent-core-v2/test/agent/profile/apply-profile.test.ts
+++ b/packages/agent-core-v2/test/agent/profile/apply-profile.test.ts
@@ -2,7 +2,7 @@ import { mkdtemp, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { basename, dirname, isAbsolute, join, relative, resolve } from 'pathe';
 
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 import { Emitter, Event } from '#/_base/event';
 import { HostFileSystem } from '#/os/backends/node-local/hostFsService';
@@ -205,17 +205,18 @@ describe('AgentProfileService.applyProfile', () => {
     expect(prompt).toContain('ls:\nextra:');
   });
 
-  it('refreshes the active profile system prompt exactly without resetting active tools', async () => {
+  it('keeps the system prompt frozen until an explicit applyProfile rebuild', async () => {
     await writeFile(join(workDir, 'AGENTS.md'), 'old instructions', 'utf-8');
     const { profile: svc } = buildContext();
     await svc.applyProfile(exactProfile);
-    svc.update({ activeToolNames: ['Read'] });
+    const before = svc.data().systemPrompt;
     await writeFile(join(workDir, 'AGENTS.md'), 'new instructions', 'utf-8');
 
-    await svc.refreshSystemPrompt();
+    expect(svc.data().systemPrompt).toBe(before);
+
+    await svc.applyProfile(exactProfile);
 
     expect(svc.data().systemPrompt).toBe(exactSystemPrompt(workDir, 'new instructions'));
-    expect(svc.getActiveToolNames()).toEqual(['Read']);
   });
 
   it('caches an agents-md warning when the content exceeds the 32 KB soft budget', async () => {
@@ -278,7 +279,7 @@ describe('AgentProfileService.applyProfile', () => {
 
     sections.value = [{ pluginId: 'demo', content: 'V2' }];
     change.fire(PLUGIN_SKILL_SOURCE_ID);
-    await svc.refreshSystemPrompt();
+    await svc.applyProfile(pluginProfile);
 
     expect(svc.data().systemPrompt).toBe(before);
     change.dispose();
@@ -295,7 +296,7 @@ describe('AgentProfileService.applyProfile', () => {
     const before = svc.data().systemPrompt;
 
     sections.value = [];
-    await svc.refreshSystemPrompt();
+    await svc.applyProfile(pluginProfile);
 
     expect(svc.data().systemPrompt).toBe(before);
   });
@@ -307,7 +308,7 @@ describe('AgentProfileService.applyProfile', () => {
     const before = svc.data().systemPrompt;
 
     sections.value = [{ pluginId: 'demo', content: 'Always cite sources.' }];
-    await svc.refreshSystemPrompt();
+    await svc.applyProfile(pluginProfile);
 
     expect(svc.data().systemPrompt).toBe(before);
   });
@@ -321,7 +322,7 @@ describe('AgentProfileService.applyProfile', () => {
 
     loaded.value = true;
     sections.value = [{ pluginId: 'demo', content: 'V1' }];
-    await svc.refreshSystemPrompt();
+    await svc.applyProfile(pluginProfile);
 
     expect(svc.data().systemPrompt).toContain('<!-- From: plugin demo -->');
   });
@@ -342,7 +343,7 @@ describe('AgentProfileService.applyProfile', () => {
     await first.ctx.dispose();
   });
 
-  it('keeps plugin sections frozen while other prompt inputs still refresh', async () => {
+  it('keeps plugin sections frozen across rebuilds while other prompt inputs re-render', async () => {
     await writeFile(join(workDir, 'AGENTS.md'), 'old instructions', 'utf-8');
     const sections = {
       value: [{ pluginId: 'demo', content: 'cite' }] as readonly EnabledPluginSystemPrompt[],
@@ -354,7 +355,7 @@ describe('AgentProfileService.applyProfile', () => {
 
     sections.value = [];
     await writeFile(join(workDir, 'AGENTS.md'), 'new instructions', 'utf-8');
-    await svc.refreshSystemPrompt();
+    await svc.applyProfile(agentsAndPluginsProfile);
 
     expect(svc.data().systemPrompt).toContain('new instructions');
     expect(svc.data().systemPrompt).toContain('cite');
@@ -372,7 +373,7 @@ describe('AgentProfileService.applyProfile', () => {
 
     listing.value = 'after';
     change.fire(BUILTIN_SKILL_SOURCE_ID);
-    await svc.refreshSystemPrompt();
+    await svc.applyProfile(skillsProfile);
 
     expect(svc.data().systemPrompt).toBe('skills:before');
     change.dispose();
@@ -397,7 +398,7 @@ describe('AgentProfileService.applyProfile', () => {
     change.dispose();
   });
 
-  it('rebuilds the system prompt when the builtin skill source changes', async () => {
+  it('does not rebuild the system prompt when the builtin skill source changes', async () => {
     let renders = 0;
     const countingProfile: ResolvedAgentProfile = normalizeAgentProfile({
       name: 'counting-profile',
@@ -410,10 +411,9 @@ describe('AgentProfileService.applyProfile', () => {
     expect(svc.data().systemPrompt).toBe('render:1');
 
     change.fire(BUILTIN_SKILL_SOURCE_ID);
+    await new Promise((resolve) => setTimeout(resolve, 20));
 
-    await vi.waitFor(() => {
-      expect(svc.data().systemPrompt).toBe('render:2');
-    });
+    expect(svc.data().systemPrompt).toBe('render:1');
     change.dispose();
   });
 
@@ -437,7 +437,7 @@ describe('AgentProfileService.applyProfile', () => {
 
     sections.value = [...sections.value, { pluginId: 'third', content: 'small' }];
     change.fire(PLUGIN_SKILL_SOURCE_ID);
-    await svc.refreshSystemPrompt();
+    await svc.applyProfile(pluginProfile);
 
     expect(svc.data().systemPrompt).toContain('<!-- From: plugin first -->');
     expect(svc.data().systemPrompt).not.toContain('<!-- From: plugin second -->');

--- a/packages/agent-core-v2/test/agent/profile/binding.test.ts
+++ b/packages/agent-core-v2/test/agent/profile/binding.test.ts
@@ -18,6 +18,7 @@ import { registerAgentProfile } from '#/app/agentProfileCatalog/contribution';
 import type { ToolCall } from '#/kosong/contract/message';
 import { IAgentProfileService, type ResolvedAgentProfile } from '#/agent/profile/profile';
 import { IHostClock } from '#/os/interface/hostClock';
+import type { HostFsChange } from '#/os/interface/hostFsWatch';
 import { IAgentAgentsMdReminderService } from '#/agent/agentsMdReminder/agentsMdReminder';
 import { IAgentToolPolicyService } from '#/agent/toolPolicy/toolPolicy';
 import { IAgentToolExecutorService } from '#/agent/toolExecutor/toolExecutor';
@@ -249,18 +250,19 @@ describe('AgentProfileService.bind', () => {
     );
   });
 
-  it('refreshes the system prompt from the session cwd after a default bind', async () => {
+  it('keeps the system prompt frozen after a default bind when AGENTS.md changes', async () => {
     const workDir = await mkdtemp(join(tmpdir(), 'kimi-bind-work-'));
     try {
       await writeFile(join(workDir, 'AGENTS.md'), 'v1 instructions', 'utf-8');
       ctx = createTestAgent(hostEnvironmentServices(homeDir), { cwd: workDir });
       const svc = ctx.get(IAgentProfileService);
       await svc.bind({ profile: DEFAULT_AGENT_PROFILE_NAME, model: MOCK_MODEL });
+      const bound = svc.getSystemPrompt();
+      expect(bound).toContain('v1 instructions');
 
       await writeFile(join(workDir, 'AGENTS.md'), 'v2 instructions', 'utf-8');
-      await svc.refreshSystemPrompt();
 
-      expect(svc.getSystemPrompt()).toContain('v2 instructions');
+      expect(svc.getSystemPrompt()).toBe(bound);
     } finally {
       await rm(workDir, { recursive: true, force: true });
     }
@@ -268,7 +270,7 @@ describe('AgentProfileService.bind', () => {
 
   it('freezes the system prompt when the session instructions change', async () => {
     const persistence = new InMemoryWireRecordPersistence();
-    const emitter = new Emitter<void>();
+    const emitter = new Emitter<readonly HostFsChange[]>();
     let agentsMd = 'v1 instructions';
     ctx = createTestAgent(
       { persistence },
@@ -295,12 +297,10 @@ describe('AgentProfileService.bind', () => {
       );
     const configUpdateCount = configUpdates().length;
 
-    const refreshSpy = vi.spyOn(svc, 'refreshSystemPrompt');
     agentsMd = 'v2 instructions';
-    emitter.fire();
+    emitter.fire([{ path: '/repo/AGENTS.md', action: 'modified', kind: 'file' }]);
     await ctx.get(IWireService).flush();
 
-    expect(refreshSpy).not.toHaveBeenCalled();
     expect(svc.getSystemPrompt()).toBe(before);
     expect(configUpdates()).toHaveLength(configUpdateCount);
   });
@@ -748,7 +748,7 @@ describe('AgentToolPolicyService.setSessionDisabledTools', () => {
     expect(toolPolicy.isToolActive('Bash')).toBe(false);
   });
 
-  it('removes the skill listing when the session disables Skill', async () => {
+  it('keeps the skill listing frozen when the session disables Skill', async () => {
     const skillMarker = 'session-policy-skill-marker';
     ctx = createTestAgent(
       hostEnvironmentServices(homeDir),
@@ -764,12 +764,13 @@ describe('AgentToolPolicyService.setSessionDisabledTools', () => {
     );
     const { profile, toolPolicy } = profileServices(ctx);
     await profile.bind({ profile: DEFAULT_AGENT_PROFILE_NAME, model: MOCK_MODEL });
-    expect(profile.getSystemPrompt()).toContain(skillMarker);
+    const before = profile.getSystemPrompt();
+    expect(before).toContain(skillMarker);
 
     await toolPolicy.setSessionDisabledTools(['Skill']);
 
     expect(toolPolicy.isToolActive('Skill')).toBe(false);
-    expect(profile.getSystemPrompt()).not.toContain(skillMarker);
+    expect(profile.getSystemPrompt()).toBe(before);
   });
 
   it('omits the skill listing when global tools disable Skill', async () => {
@@ -794,7 +795,7 @@ describe('AgentToolPolicyService.setSessionDisabledTools', () => {
     expect(profile.getSystemPrompt()).not.toContain(skillMarker);
   });
 
-  it('refreshes the skill listing when global tool policy changes at runtime', async () => {
+  it('keeps the skill listing frozen when global tool policy changes at runtime', async () => {
     const skillMarker = 'live-global-policy-skill-marker';
     ctx = createTestAgent(
       hostEnvironmentServices(homeDir),
@@ -810,14 +811,15 @@ describe('AgentToolPolicyService.setSessionDisabledTools', () => {
     );
     const { profile, toolPolicy } = profileServices(ctx);
     await profile.bind({ profile: DEFAULT_AGENT_PROFILE_NAME, model: MOCK_MODEL });
-    expect(profile.getSystemPrompt()).toContain(skillMarker);
+    const before = profile.getSystemPrompt();
+    expect(before).toContain(skillMarker);
 
     await ctx
       .get(IConfigService)
       .replace(TOOLS_SECTION, { disabled: ['Skill'] }, ConfigTarget.Memory);
 
     expect(toolPolicy.isToolActive('Skill')).toBe(false);
-    await vi.waitFor(() => expect(profile.getSystemPrompt()).not.toContain(skillMarker));
+    expect(profile.getSystemPrompt()).toBe(before);
   });
 });
 

--- a/packages/agent-core-v2/test/agent/profile/profileOps.test.ts
+++ b/packages/agent-core-v2/test/agent/profile/profileOps.test.ts
@@ -233,7 +233,7 @@ function buildHost(key: string): {
     agentsMd: undefined,
     agentsMdWarning: undefined,
     agentsMdPaths: undefined,
-    onDidChange: Event.None as Event<void>,
+    onDidChange: Event.None as ISessionInstructionsProvider['onDidChange'],
   } satisfies ISessionInstructionsProvider);
   host.stub(IAgentAgentsMdReminderService, {
     _serviceBrand: undefined,

--- a/packages/agent-core-v2/test/harness/agent.ts
+++ b/packages/agent-core-v2/test/harness/agent.ts
@@ -2110,7 +2110,7 @@ export class AgentTestContext {
       get agentsMdPaths() {
         return current.paths;
       },
-      onDidChange: Event.None as Event<void>,
+      onDidChange: Event.None as ISessionInstructionsProvider['onDidChange'],
     };
   }
 

--- a/packages/agent-core-v2/test/session/agentLifecycle/agentLifecycle.test.ts
+++ b/packages/agent-core-v2/test/session/agentLifecycle/agentLifecycle.test.ts
@@ -433,7 +433,7 @@ describe('AgentLifecycleService', () => {
       agentsMd: undefined,
       agentsMdWarning: undefined,
       agentsMdPaths: undefined,
-      onDidChange: Event.None as Event<void>,
+      onDidChange: Event.None as ISessionInstructionsProvider['onDidChange'],
     } satisfies ISessionInstructionsProvider);
     ix.stub(IAgentAgentsMdReminderService, {
       _serviceBrand: undefined,

--- a/packages/agent-core-v2/test/workspace/workspaceInstructions/instructions.test.ts
+++ b/packages/agent-core-v2/test/workspace/workspaceInstructions/instructions.test.ts
@@ -109,6 +109,40 @@ describe('WorkspaceInstructionsService', () => {
     expect(provider.agentsMdWarning).toBeUndefined();
   });
 
+  it('does not fire onDidChange for the initial load', async () => {
+    await writeFile(join(workDir, 'AGENTS.md'), 'project instructions', 'utf8');
+
+    let fired = 0;
+    const { service } = createService();
+    service.onDidChange(() => {
+      fired += 1;
+    });
+    await service.ready;
+    await new Promise((resolvePromise) => setTimeout(resolvePromise, 50));
+
+    expect(fired).toBe(0);
+    expect(service.snapshot.agentsMd).toContain('project instructions');
+  });
+
+  it('fires onDidChange with the changed file paths when a watched file changes', async () => {
+    const file = join(workDir, 'AGENTS.md');
+    await writeFile(file, 'old instructions', 'utf8');
+    const { service } = createService();
+    await service.ready;
+
+    const changed = new Promise<readonly HostFsChange[]>((resolvePromise) => {
+      const d = service.onDidChange((changes) => {
+        d.dispose();
+        resolvePromise(changes);
+      });
+    });
+    await writeFile(file, 'new instructions', 'utf8');
+    fireWatch(file);
+    const changes = await changed;
+
+    expect(changes).toEqual([{ path: file, action: 'modified', kind: 'file' }]);
+  });
+
   it('refreshes the snapshot and fires onDidChange when a watched file changes', async () => {
     const file = join(workDir, 'AGENTS.md');
     await writeFile(file, 'old instructions', 'utf8');


### PR DESCRIPTION
## Related Issue

Related to #3105

## Problem

The v2 engine re-rendered and rewrote the bound system prompt mid-session through `AgentProfileService.refreshSystemPrompt()`, fired by the session tool-policy watcher, `[tools]` config changes, the builtin skill catalog watcher, and after every full compaction (#3182 already removed the AGENTS.md watcher trigger). Each rewrite changed prompt bytes mid-session, so server-side prefix caches (longest-prefix match) lost not just the prompt but the entire conversation history behind it — on prefix-cached backends this showed up as full-history recompute and multi-second TTFT spikes after resume or compaction. The refresh was also functionally unnecessary: tool gating is driven by the per-request wire tools array, not prompt text, and compaction changes no prompt input.

## What changed

- **Removed the refresh mechanism**: `IAgentProfileService.refreshSystemPrompt` is gone, together with its remaining triggers (session tool-policy watcher, builtin skill catalog watcher, `[tools]` config refresh, post-compaction call) and the kimi-inspect "Refresh system prompt" debug action. A bound system prompt is now frozen for the agent's lifetime; new content only takes effect on real (re)builds — bind, resume replay, explicit profile switch.
- **AGENTS.md changes become append-only reminders**: a change or deletion during a session appends a reminder naming the affected path and suggesting a re-read, instead of rewriting the prompt. The instructions `onDidChange` event now carries the `HostFsChange[]` payload, and the workspace instructions service no longer fires on its initial load — that initial-load event was the hidden trigger that rewrote the prompt on every session resume.
- **Tests**: refresh cases removed or inverted into freeze assertions (plugin/skill freeze verified through explicit `applyProfile` rebuilds); new coverage for the change-announce reminder, first-load silence, and change payloads.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue (external PRs: the issue must have a maintainer's `/approve`).
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.
