### PR TITLE
fix(mcp): send content or structuredContent to the model, never both

### DIFF
--- a/.changeset/mcp-structured-content-fallback.md
+++ b/.changeset/mcp-structured-content-fallback.md
@@ -2,4 +2,4 @@
 "@moonshot-ai/kimi-code": patch
 ---
 
-Stop sending duplicate MCP tool results to the model when a server returns the same data in both content and structuredContent.
+Send MCP structuredContent to the model only when the tool result has no usable content, avoiding duplicate tool output.

--- a/.changeset/mcp-structured-content-fallback.md
+++ b/.changeset/mcp-structured-content-fallback.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Stop sending duplicate MCP tool results to the model when a server returns the same data in both content and structuredContent.

--- a/packages/agent-core-v2/src/agent/mcp/output.ts
+++ b/packages/agent-core-v2/src/agent/mcp/output.ts
@@ -136,7 +136,7 @@ export async function mcpResultToExecutableOutput(
     if (serialized !== undefined) {
       wrapped.push({
         type: 'text',
-        text: `\n<mcp-structured-result>\n${serialized}\n</mcp-structured-result>`,
+        text: `\n<mcp-result-extras>\n${serialized}\n</mcp-result-extras>`,
       });
     }
   }
@@ -170,7 +170,7 @@ export async function mcpResultToExecutableOutput(
 
 function serializeStructuredExtras(extras: Record<string, unknown>): string | undefined {
   try {
-    return JSON.stringify(extras).replaceAll('</mcp-structured-result>', '');
+    return JSON.stringify(extras).replaceAll('</mcp-result-extras>', '');
   } catch {
     return undefined;
   }

--- a/packages/agent-core-v2/src/agent/mcp/output.ts
+++ b/packages/agent-core-v2/src/agent/mcp/output.ts
@@ -22,8 +22,6 @@ const MCP_OUTPUT_TRUNCATED_TEXT = `\n\n[Output truncated: exceeded ${String(
 export const MCP_MAX_BINARY_PART_BYTES = 10 * 1024 * 1024;
 const MCP_MAX_BINARY_PART_CHARS = Math.ceil((MCP_MAX_BINARY_PART_BYTES * 4) / 3);
 
-const MCP_STRUCTURED_LOSSY_RATIO = 2;
-
 function binaryPartTooLargeNotice(kind: 'image' | 'audio' | 'video', urlLength: number): string {
   const approxMb = ((urlLength * 3) / 4 / (1024 * 1024)).toFixed(1);
   const capMb = String(MCP_MAX_BINARY_PART_BYTES / (1024 * 1024));
@@ -120,19 +118,12 @@ export async function mcpResultToExecutableOutput(
   }
 
   const wrapped = wrapMediaOnly(converted, qualifiedToolName);
-  const textLength = converted.reduce(
-    (n, part) => (part.type === 'text' ? n + part.text.trim().length : n),
-    0,
+  const hasUsableContent = converted.some((part) =>
+    part.type === 'text' ? part.text.trim().length > 0 : true,
   );
   const structuredExtras: Record<string, unknown> = {};
-  if (result.structuredContent !== undefined) {
-    const structuredJson = trySerialize(result.structuredContent);
-    if (
-      structuredJson !== undefined &&
-      (textLength === 0 || structuredJson.length > MCP_STRUCTURED_LOSSY_RATIO * textLength)
-    ) {
-      structuredExtras['structuredContent'] = result.structuredContent;
-    }
+  if (result.structuredContent !== undefined && !hasUsableContent) {
+    structuredExtras['structuredContent'] = result.structuredContent;
   }
   if (result._meta !== undefined) {
     const meta = stripReservedMetaKeys(result._meta);
@@ -205,15 +196,6 @@ function isReservedMetaKey(key: string): boolean {
     (label, i) =>
       (label === 'modelcontextprotocol' || label === 'mcp') && i < labels.length - 1,
   );
-}
-
-function trySerialize(value: unknown): string | undefined {
-  try {
-    const serialized = JSON.stringify(value);
-    return typeof serialized === 'string' ? serialized : undefined;
-  } catch {
-    return undefined;
-  }
 }
 
 function wrapMediaOnly(parts: readonly ContentPart[], qualifiedToolName: string): ContentPart[] {

--- a/packages/agent-core-v2/src/agent/mcp/output.ts
+++ b/packages/agent-core-v2/src/agent/mcp/output.ts
@@ -118,8 +118,11 @@ export async function mcpResultToExecutableOutput(
   }
 
   const wrapped = wrapMediaOnly(converted, qualifiedToolName);
+  const hasUsableText = converted.some(
+    (part) => part.type === 'text' && part.text.trim().length > 0,
+  );
   const structuredExtras: Record<string, unknown> = {};
-  if (result.structuredContent !== undefined) {
+  if (result.structuredContent !== undefined && !hasUsableText) {
     structuredExtras['structuredContent'] = result.structuredContent;
   }
   if (result._meta !== undefined) {

--- a/packages/agent-core-v2/src/agent/mcp/output.ts
+++ b/packages/agent-core-v2/src/agent/mcp/output.ts
@@ -22,6 +22,8 @@ const MCP_OUTPUT_TRUNCATED_TEXT = `\n\n[Output truncated: exceeded ${String(
 export const MCP_MAX_BINARY_PART_BYTES = 10 * 1024 * 1024;
 const MCP_MAX_BINARY_PART_CHARS = Math.ceil((MCP_MAX_BINARY_PART_BYTES * 4) / 3);
 
+const MCP_STRUCTURED_LOSSY_RATIO = 2;
+
 function binaryPartTooLargeNotice(kind: 'image' | 'audio' | 'video', urlLength: number): string {
   const approxMb = ((urlLength * 3) / 4 / (1024 * 1024)).toFixed(1);
   const capMb = String(MCP_MAX_BINARY_PART_BYTES / (1024 * 1024));
@@ -118,12 +120,19 @@ export async function mcpResultToExecutableOutput(
   }
 
   const wrapped = wrapMediaOnly(converted, qualifiedToolName);
+  const textLength = converted.reduce(
+    (n, part) => (part.type === 'text' ? n + part.text.trim().length : n),
+    0,
+  );
   const structuredExtras: Record<string, unknown> = {};
-  if (
-    result.structuredContent !== undefined &&
-    !serializesStructuredContent(converted, result.structuredContent)
-  ) {
-    structuredExtras['structuredContent'] = result.structuredContent;
+  if (result.structuredContent !== undefined) {
+    const structuredJson = trySerialize(result.structuredContent);
+    if (
+      structuredJson !== undefined &&
+      (textLength === 0 || structuredJson.length > MCP_STRUCTURED_LOSSY_RATIO * textLength)
+    ) {
+      structuredExtras['structuredContent'] = result.structuredContent;
+    }
   }
   if (result._meta !== undefined) {
     const meta = stripReservedMetaKeys(result._meta);
@@ -198,38 +207,13 @@ function isReservedMetaKey(key: string): boolean {
   );
 }
 
-function serializesStructuredContent(
-  parts: readonly ContentPart[],
-  structured: unknown,
-): boolean {
-  return parts.some(
-    (part) => part.type === 'text' && textIsJsonSerializationOf(part.text, structured),
-  );
-}
-
-function textIsJsonSerializationOf(text: string, structured: unknown): boolean {
-  const trimmed = text.trim();
-  if (!trimmed.startsWith('{') && !trimmed.startsWith('[')) return false;
-  let parsed: unknown;
+function trySerialize(value: unknown): string | undefined {
   try {
-    parsed = JSON.parse(trimmed);
+    const serialized = JSON.stringify(value);
+    return typeof serialized === 'string' ? serialized : undefined;
   } catch {
-    return false;
+    return undefined;
   }
-  return canonicalJson(parsed) === canonicalJson(structured);
-}
-
-function canonicalJson(value: unknown): string {
-  if (Array.isArray(value)) {
-    return `[${value.map((item) => canonicalJson(item)).join(',')}]`;
-  }
-  if (typeof value === 'object' && value !== null) {
-    const entries = Object.entries(value)
-      .sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0))
-      .map(([key, val]) => `${JSON.stringify(key)}:${canonicalJson(val)}`);
-    return `{${entries.join(',')}}`;
-  }
-  return String(JSON.stringify(value));
 }
 
 function wrapMediaOnly(parts: readonly ContentPart[], qualifiedToolName: string): ContentPart[] {

--- a/packages/agent-core-v2/src/agent/mcp/output.ts
+++ b/packages/agent-core-v2/src/agent/mcp/output.ts
@@ -118,11 +118,11 @@ export async function mcpResultToExecutableOutput(
   }
 
   const wrapped = wrapMediaOnly(converted, qualifiedToolName);
-  const hasUsableText = converted.some(
-    (part) => part.type === 'text' && part.text.trim().length > 0,
-  );
   const structuredExtras: Record<string, unknown> = {};
-  if (result.structuredContent !== undefined && !hasUsableText) {
+  if (
+    result.structuredContent !== undefined &&
+    !serializesStructuredContent(converted, result.structuredContent)
+  ) {
     structuredExtras['structuredContent'] = result.structuredContent;
   }
   if (result._meta !== undefined) {
@@ -196,6 +196,40 @@ function isReservedMetaKey(key: string): boolean {
     (label, i) =>
       (label === 'modelcontextprotocol' || label === 'mcp') && i < labels.length - 1,
   );
+}
+
+function serializesStructuredContent(
+  parts: readonly ContentPart[],
+  structured: unknown,
+): boolean {
+  return parts.some(
+    (part) => part.type === 'text' && textIsJsonSerializationOf(part.text, structured),
+  );
+}
+
+function textIsJsonSerializationOf(text: string, structured: unknown): boolean {
+  const trimmed = text.trim();
+  if (!trimmed.startsWith('{') && !trimmed.startsWith('[')) return false;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(trimmed);
+  } catch {
+    return false;
+  }
+  return canonicalJson(parsed) === canonicalJson(structured);
+}
+
+function canonicalJson(value: unknown): string {
+  if (Array.isArray(value)) {
+    return `[${value.map((item) => canonicalJson(item)).join(',')}]`;
+  }
+  if (typeof value === 'object' && value !== null) {
+    const entries = Object.entries(value)
+      .sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0))
+      .map(([key, val]) => `${JSON.stringify(key)}:${canonicalJson(val)}`);
+    return `{${entries.join(',')}}`;
+  }
+  return String(JSON.stringify(value));
 }
 
 function wrapMediaOnly(parts: readonly ContentPart[], qualifiedToolName: string): ContentPart[] {

--- a/packages/agent-core-v2/test/agent/mcp/output.test.ts
+++ b/packages/agent-core-v2/test/agent/mcp/output.test.ts
@@ -268,10 +268,10 @@ describe('mcpResultToExecutableOutput', () => {
     expect(out).toEqual({ output: 'oops', isError: true });
   });
 
-  test('omits structuredContent when content already carries usable text', async () => {
+  test('omits structuredContent when a text block already carries its serialization', async () => {
     const out = await mcpResultToExecutableOutput(
       {
-        content: [{ type: 'text', text: 'ok' }],
+        content: [{ type: 'text', text: '{"foo":1}' }],
         isError: false,
         structuredContent: { foo: 1 },
         _meta: { bar: 2 },
@@ -284,6 +284,33 @@ describe('mcpResultToExecutableOutput', () => {
     expect(joined).toContain('<mcp-structured-result>');
     expect(joined).toContain('"_meta":{"bar":2}');
     expect(out.isError).toBe(false);
+  });
+
+  test('matches the serialization across formatting and key order', async () => {
+    const out = await mcpResultToExecutableOutput(
+      {
+        content: [{ type: 'text', text: '{\n  "total": 1,\n  "rows": [ { "id": 1 } ]\n}' }],
+        isError: false,
+        structuredContent: { rows: [{ id: 1 }], total: 1 },
+      },
+      'mcp__s__t',
+    );
+    expect(out.output).toBe('{\n  "total": 1,\n  "rows": [ { "id": 1 } ]\n}');
+  });
+
+  test('appends structuredContent when content text is a summary, not the serialization', async () => {
+    const out = await mcpResultToExecutableOutput(
+      {
+        content: [{ type: 'text', text: 'list_projects returned 1 item(s).' }],
+        isError: false,
+        structuredContent: { projects: [{ id: 1 }] },
+      },
+      'mcp__s__t',
+    );
+    const parts = out.output as ContentPart[];
+    const joined = parts.map((p) => (p.type === 'text' ? p.text : '')).join('');
+    expect(joined).toContain('list_projects returned 1 item(s).');
+    expect(joined).toContain('"structuredContent":{"projects":[{"id":1}]}');
   });
 
   test('falls back to structuredContent when content carries no usable text', async () => {
@@ -710,7 +737,7 @@ describe('mcpResultToExecutableOutput over a real stdio server', () => {
   test('dual-emitting servers reach the model once, through content', async () => {
     const out = await callFixtureTool('dual_emit');
     const text = joinedText(out.output);
-    expect(text).toContain('{"rows":[{"id":1}],"total":1}');
+    expect(text).toContain('"rows"');
     expect(text).not.toContain('<mcp-structured-result>');
   }, 15000);
 
@@ -721,11 +748,11 @@ describe('mcpResultToExecutableOutput over a real stdio server', () => {
     expect(text).toContain('"structuredContent":{"rows":[{"id":1}],"total":1}');
   }, 15000);
 
-  test('prose content suppresses structuredContent rather than duplicating it', async () => {
+  test('a prose summary keeps the structured payload alongside it', async () => {
     const out = await callFixtureTool('prose_plus_structured');
     const text = joinedText(out.output);
     expect(text).toContain('Found 1 row.');
-    expect(text).not.toContain('"structuredContent"');
+    expect(text).toContain('"structuredContent":{"rows":[{"id":1}],"total":1}');
   }, 15000);
 
   test('vendor _meta keys pass through alongside content text', async () => {

--- a/packages/agent-core-v2/test/agent/mcp/output.test.ts
+++ b/packages/agent-core-v2/test/agent/mcp/output.test.ts
@@ -319,7 +319,7 @@ describe('mcpResultToExecutableOutput', () => {
     expect(out.output).toBe(text);
   });
 
-  test('appends structuredContent when the payload dwarfs a lossy summary', async () => {
+  test('suppresses structuredContent whenever content carries usable text', async () => {
     const out = await mcpResultToExecutableOutput(
       {
         content: [{ type: 'text', text: 'list_projects returned 6 item(s).' }],
@@ -337,11 +337,7 @@ describe('mcpResultToExecutableOutput', () => {
       },
       'mcp__s__t',
     );
-    const parts = out.output as ContentPart[];
-    const joined = parts.map((p) => (p.type === 'text' ? p.text : '')).join('');
-    expect(joined).toContain('list_projects returned 6 item(s).');
-    expect(joined).toContain('"structuredContent"');
-    expect(joined).toContain('"name":"Zeta"');
+    expect(out.output).toBe('list_projects returned 6 item(s).');
   });
 
   test('falls back to structuredContent when content carries no usable text', async () => {
@@ -359,7 +355,7 @@ describe('mcpResultToExecutableOutput', () => {
     expect(joined).toContain('"structuredContent":{"foo":1}');
   });
 
-  test('keeps the mcp_tool_result wrap when a media-only result carries structuredContent', async () => {
+  test('keeps the mcp_tool_result wrap for media-only results and suppresses structuredContent', async () => {
     const out = await mcpResultToExecutableOutput(
       {
         content: [{ type: 'image', data: 'AAA', mimeType: 'image/png' }],
@@ -370,9 +366,9 @@ describe('mcpResultToExecutableOutput', () => {
     );
     const parts = out.output as ContentPart[];
     expect(parts[0]).toEqual({ type: 'text', text: '<mcp_tool_result name="mcp__s__shot">' });
-    expect(parts.at(-2)).toEqual({ type: 'text', text: '</mcp_tool_result>' });
-    const last = parts.at(-1);
-    expect(last?.type === 'text' && last.text.includes('<mcp-structured-result>')).toBe(true);
+    expect(parts.at(-1)).toEqual({ type: 'text', text: '</mcp_tool_result>' });
+    const joined = parts.map((p) => (p.type === 'text' ? p.text : '')).join('');
+    expect(joined).not.toContain('<mcp-structured-result>');
   });
 
   test('strips literal closing tags inside the structured payload', async () => {
@@ -779,11 +775,11 @@ describe('mcpResultToExecutableOutput over a real stdio server', () => {
     expect(text).toContain('"structuredContent":{"rows":[{"id":1}],"total":1}');
   }, 15000);
 
-  test('a prose summary keeps the structured payload alongside it', async () => {
+  test('a prose summary suppresses the structured payload', async () => {
     const out = await callFixtureTool('prose_plus_structured');
     const text = joinedText(out.output);
     expect(text).toContain('Found 1 row.');
-    expect(text).toContain('"structuredContent":{"rows":[{"id":1}],"total":1}');
+    expect(text).not.toContain('<mcp-structured-result>');
   }, 15000);
 
   test('a faithful rendering of similar size suppresses the structured copy', async () => {

--- a/packages/agent-core-v2/test/agent/mcp/output.test.ts
+++ b/packages/agent-core-v2/test/agent/mcp/output.test.ts
@@ -286,7 +286,7 @@ describe('mcpResultToExecutableOutput', () => {
     expect(out.isError).toBe(false);
   });
 
-  test('matches the serialization across formatting and key order', async () => {
+  test('omits structuredContent for dual-emit servers even when the serialized text is reformatted', async () => {
     const out = await mcpResultToExecutableOutput(
       {
         content: [{ type: 'text', text: '{\n  "total": 1,\n  "rows": [ { "id": 1 } ]\n}' }],
@@ -298,19 +298,50 @@ describe('mcpResultToExecutableOutput', () => {
     expect(out.output).toBe('{\n  "total": 1,\n  "rows": [ { "id": 1 } ]\n}');
   });
 
-  test('appends structuredContent when content text is a summary, not the serialization', async () => {
+  test('omits structuredContent when content is a faithful rendering of similar size', async () => {
+    const text =
+      'Project: Central Macaw [d594e625]\n' +
+      'Description: none\n' +
+      'Timeline: 1920x1080 @ 30fps | durationInFrames=0\n' +
+      'Assets: total=0';
     const out = await mcpResultToExecutableOutput(
       {
-        content: [{ type: 'text', text: 'list_projects returned 1 item(s).' }],
+        content: [{ type: 'text', text }],
         isError: false,
-        structuredContent: { projects: [{ id: 1 }] },
+        structuredContent: {
+          project: { id: 'd594e625', name: 'Central Macaw', description: null },
+          timeline: { width: 1920, height: 1080, fps: 30, durationInFrames: 0 },
+          assets: { total: 0 },
+        },
+      },
+      'mcp__s__t',
+    );
+    expect(out.output).toBe(text);
+  });
+
+  test('appends structuredContent when the payload dwarfs a lossy summary', async () => {
+    const out = await mcpResultToExecutableOutput(
+      {
+        content: [{ type: 'text', text: 'list_projects returned 6 item(s).' }],
+        isError: false,
+        structuredContent: {
+          projects: [
+            { id: 'p1', name: 'Alpha' },
+            { id: 'p2', name: 'Beta' },
+            { id: 'p3', name: 'Gamma' },
+            { id: 'p4', name: 'Delta' },
+            { id: 'p5', name: 'Epsilon' },
+            { id: 'p6', name: 'Zeta' },
+          ],
+        },
       },
       'mcp__s__t',
     );
     const parts = out.output as ContentPart[];
     const joined = parts.map((p) => (p.type === 'text' ? p.text : '')).join('');
-    expect(joined).toContain('list_projects returned 1 item(s).');
-    expect(joined).toContain('"structuredContent":{"projects":[{"id":1}]}');
+    expect(joined).toContain('list_projects returned 6 item(s).');
+    expect(joined).toContain('"structuredContent"');
+    expect(joined).toContain('"name":"Zeta"');
   });
 
   test('falls back to structuredContent when content carries no usable text', async () => {
@@ -753,6 +784,13 @@ describe('mcpResultToExecutableOutput over a real stdio server', () => {
     const text = joinedText(out.output);
     expect(text).toContain('Found 1 row.');
     expect(text).toContain('"structuredContent":{"rows":[{"id":1}],"total":1}');
+  }, 15000);
+
+  test('a faithful rendering of similar size suppresses the structured copy', async () => {
+    const out = await callFixtureTool('faithful_rendering');
+    const text = joinedText(out.output);
+    expect(text).toContain('Project: Central Macaw');
+    expect(text).not.toContain('<mcp-structured-result>');
   }, 15000);
 
   test('vendor _meta keys pass through alongside content text', async () => {

--- a/packages/agent-core-v2/test/agent/mcp/output.test.ts
+++ b/packages/agent-core-v2/test/agent/mcp/output.test.ts
@@ -9,6 +9,9 @@ import { describe, expect, test } from 'vitest';
 import type { ITelemetryService, TelemetryProperties } from '#/app/telemetry/telemetry';
 import { convertMCPContentBlock, mcpResultToExecutableOutput } from '#/agent/mcp/output';
 import { createMcpTool } from '#/agent/mcp/tools/mcp';
+import { StdioMcpClient } from '#/mcpCore/client-stdio';
+import { HostProcessService } from '#/os/backends/node-local/hostProcessService';
+import { FakeRuntime } from '#/runtime/fakeRuntime';
 import type { MCPClient, MCPContentBlock, MCPToolResult } from '#/mcpCore/types';
 import type { ToolExecution } from '#/tool/toolContract';
 import { sniffImageDimensions } from '#/agent/media/file-type';
@@ -656,4 +659,79 @@ describe('createMcpTool', () => {
     expect(result).toEqual({ output: 'ok' });
     expect(result).not.toHaveProperty('truncated');
   });
+});
+
+describe('mcpResultToExecutableOutput over a real stdio server', () => {
+  const fixture = join(import.meta.dirname, '../../mcpCore/fixtures/structured-content-stdio-server.mjs');
+
+  async function callFixtureTool(name: string) {
+    const runtime = Object.assign(
+      new FakeRuntime(
+        { workspaceId: 'workspace', runtimeId: 'local', generation: 'test' },
+        { capabilities: ['process'] },
+      ),
+      { process: new HostProcessService() },
+    );
+    const client = new StdioMcpClient(
+      {
+        transport: 'stdio',
+        command: process.execPath,
+        args: [fixture],
+      },
+      {
+        runtimeResolver: {
+          _serviceBrand: undefined,
+          inspect: () => runtime,
+          acquire: () => ({
+            runtime,
+            track: (resource) => resource,
+            dispose: () => {},
+          }),
+        },
+        workspaceId: 'workspace',
+        runtimeId: 'local',
+        defaultCwd: process.cwd(),
+      },
+    );
+    try {
+      await client.connect();
+      return await mcpResultToExecutableOutput(await client.callTool(name, {}), 'mcp__mock__t');
+    } finally {
+      await client.close();
+    }
+  }
+
+  function joinedText(output: string | ContentPart[]): string {
+    return typeof output === 'string'
+      ? output
+      : output.map((p) => (p.type === 'text' ? p.text : '')).join('');
+  }
+
+  test('dual-emitting servers reach the model once, through content', async () => {
+    const out = await callFixtureTool('dual_emit');
+    const text = joinedText(out.output);
+    expect(text).toContain('{"rows":[{"id":1}],"total":1}');
+    expect(text).not.toContain('<mcp-structured-result>');
+  }, 15000);
+
+  test('structuredContent-only results still reach the model as a fallback block', async () => {
+    const out = await callFixtureTool('structured_only');
+    const text = joinedText(out.output);
+    expect(text).toContain('<mcp-structured-result>');
+    expect(text).toContain('"structuredContent":{"rows":[{"id":1}],"total":1}');
+  }, 15000);
+
+  test('prose content suppresses structuredContent rather than duplicating it', async () => {
+    const out = await callFixtureTool('prose_plus_structured');
+    const text = joinedText(out.output);
+    expect(text).toContain('Found 1 row.');
+    expect(text).not.toContain('"structuredContent"');
+  }, 15000);
+
+  test('vendor _meta keys pass through alongside content text', async () => {
+    const out = await callFixtureTool('meta_vendor');
+    const text = joinedText(out.output);
+    expect(text).toContain('done');
+    expect(text).toContain('"_meta":{"example.com/trace":"abc123"}');
+  }, 15000);
 });

--- a/packages/agent-core-v2/test/agent/mcp/output.test.ts
+++ b/packages/agent-core-v2/test/agent/mcp/output.test.ts
@@ -281,7 +281,7 @@ describe('mcpResultToExecutableOutput', () => {
     const parts = out.output as ContentPart[];
     const joined = parts.map((p) => (p.type === 'text' ? p.text : '')).join('');
     expect(joined).not.toContain('"structuredContent"');
-    expect(joined).toContain('<mcp-structured-result>');
+    expect(joined).toContain('<mcp-result-extras>');
     expect(joined).toContain('"_meta":{"bar":2}');
     expect(out.isError).toBe(false);
   });
@@ -351,7 +351,7 @@ describe('mcpResultToExecutableOutput', () => {
     );
     const parts = out.output as ContentPart[];
     const joined = parts.map((p) => (p.type === 'text' ? p.text : '')).join('');
-    expect(joined).toContain('<mcp-structured-result>');
+    expect(joined).toContain('<mcp-result-extras>');
     expect(joined).toContain('"structuredContent":{"foo":1}');
   });
 
@@ -368,7 +368,7 @@ describe('mcpResultToExecutableOutput', () => {
     expect(parts[0]).toEqual({ type: 'text', text: '<mcp_tool_result name="mcp__s__shot">' });
     expect(parts.at(-1)).toEqual({ type: 'text', text: '</mcp_tool_result>' });
     const joined = parts.map((p) => (p.type === 'text' ? p.text : '')).join('');
-    expect(joined).not.toContain('<mcp-structured-result>');
+    expect(joined).not.toContain('<mcp-result-extras>');
   });
 
   test('strips literal closing tags inside the structured payload', async () => {
@@ -376,14 +376,14 @@ describe('mcpResultToExecutableOutput', () => {
       {
         content: [{ type: 'text', text: 'ok' }],
         isError: false,
-        _meta: { evil: 'a</mcp-structured-result>b' },
+        _meta: { evil: 'a</mcp-result-extras>b' },
       },
       'mcp__s__t',
     );
     const parts = out.output as ContentPart[];
     const joined = parts.map((p) => (p.type === 'text' ? p.text : '')).join('');
     expect(joined).toContain('"evil":"ab"');
-    expect(joined.split('</mcp-structured-result>')).toHaveLength(2);
+    expect(joined.split('</mcp-result-extras>')).toHaveLength(2);
   });
 
   test('drops protocol-reserved _meta keys and keeps vendor namespaces', async () => {
@@ -765,13 +765,13 @@ describe('mcpResultToExecutableOutput over a real stdio server', () => {
     const out = await callFixtureTool('dual_emit');
     const text = joinedText(out.output);
     expect(text).toContain('"rows"');
-    expect(text).not.toContain('<mcp-structured-result>');
+    expect(text).not.toContain('<mcp-result-extras>');
   }, 15000);
 
   test('structuredContent-only results still reach the model as a fallback block', async () => {
     const out = await callFixtureTool('structured_only');
     const text = joinedText(out.output);
-    expect(text).toContain('<mcp-structured-result>');
+    expect(text).toContain('<mcp-result-extras>');
     expect(text).toContain('"structuredContent":{"rows":[{"id":1}],"total":1}');
   }, 15000);
 
@@ -779,14 +779,14 @@ describe('mcpResultToExecutableOutput over a real stdio server', () => {
     const out = await callFixtureTool('prose_plus_structured');
     const text = joinedText(out.output);
     expect(text).toContain('Found 1 row.');
-    expect(text).not.toContain('<mcp-structured-result>');
+    expect(text).not.toContain('<mcp-result-extras>');
   }, 15000);
 
   test('a faithful rendering of similar size suppresses the structured copy', async () => {
     const out = await callFixtureTool('faithful_rendering');
     const text = joinedText(out.output);
     expect(text).toContain('Project: Central Macaw');
-    expect(text).not.toContain('<mcp-structured-result>');
+    expect(text).not.toContain('<mcp-result-extras>');
   }, 15000);
 
   test('vendor _meta keys pass through alongside content text', async () => {

--- a/packages/agent-core-v2/test/agent/mcp/output.test.ts
+++ b/packages/agent-core-v2/test/agent/mcp/output.test.ts
@@ -265,7 +265,7 @@ describe('mcpResultToExecutableOutput', () => {
     expect(out).toEqual({ output: 'oops', isError: true });
   });
 
-  test('surfaces structuredContent and _meta as a serialized mcp-structured-result block', async () => {
+  test('omits structuredContent when content already carries usable text', async () => {
     const out = await mcpResultToExecutableOutput(
       {
         content: [{ type: 'text', text: 'ok' }],
@@ -277,10 +277,25 @@ describe('mcpResultToExecutableOutput', () => {
     );
     const parts = out.output as ContentPart[];
     const joined = parts.map((p) => (p.type === 'text' ? p.text : '')).join('');
+    expect(joined).not.toContain('"structuredContent"');
     expect(joined).toContain('<mcp-structured-result>');
-    expect(joined).toContain('"structuredContent":{"foo":1}');
     expect(joined).toContain('"_meta":{"bar":2}');
     expect(out.isError).toBe(false);
+  });
+
+  test('falls back to structuredContent when content carries no usable text', async () => {
+    const out = await mcpResultToExecutableOutput(
+      {
+        content: [{ type: 'text', text: '   ' }],
+        isError: false,
+        structuredContent: { foo: 1 },
+      },
+      'mcp__s__t',
+    );
+    const parts = out.output as ContentPart[];
+    const joined = parts.map((p) => (p.type === 'text' ? p.text : '')).join('');
+    expect(joined).toContain('<mcp-structured-result>');
+    expect(joined).toContain('"structuredContent":{"foo":1}');
   });
 
   test('keeps the mcp_tool_result wrap when a media-only result carries structuredContent', async () => {

--- a/packages/agent-core-v2/test/mcpCore/fixtures/structured-content-stdio-server.mjs
+++ b/packages/agent-core-v2/test/mcpCore/fixtures/structured-content-stdio-server.mjs
@@ -6,11 +6,12 @@ const server = new McpServer({ name: 'mock-structured-content', version: '0.0.1'
 server.registerTool(
   'dual_emit',
   {
-    description: 'Returns the same JSON as a text block and as structuredContent',
+    description:
+      'Returns the same JSON as a text block (pretty-printed, different key order) and as structuredContent',
     inputSchema: {},
   },
   () => ({
-    content: [{ type: 'text', text: '{"rows":[{"id":1}],"total":1}' }],
+    content: [{ type: 'text', text: '{\n  "total": 1,\n  "rows": [ { "id": 1 } ]\n}' }],
     structuredContent: { rows: [{ id: 1 }], total: 1 },
   }),
 );

--- a/packages/agent-core-v2/test/mcpCore/fixtures/structured-content-stdio-server.mjs
+++ b/packages/agent-core-v2/test/mcpCore/fixtures/structured-content-stdio-server.mjs
@@ -1,0 +1,53 @@
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+
+const server = new McpServer({ name: 'mock-structured-content', version: '0.0.1' });
+
+server.registerTool(
+  'dual_emit',
+  {
+    description: 'Returns the same JSON as a text block and as structuredContent',
+    inputSchema: {},
+  },
+  () => ({
+    content: [{ type: 'text', text: '{"rows":[{"id":1}],"total":1}' }],
+    structuredContent: { rows: [{ id: 1 }], total: 1 },
+  }),
+);
+
+server.registerTool(
+  'structured_only',
+  {
+    description: 'Returns structuredContent without any text content',
+    inputSchema: {},
+  },
+  () => ({
+    structuredContent: { rows: [{ id: 1 }], total: 1 },
+  }),
+);
+
+server.registerTool(
+  'prose_plus_structured',
+  {
+    description: 'Returns a prose summary in content plus distinct structuredContent',
+    inputSchema: {},
+  },
+  () => ({
+    content: [{ type: 'text', text: 'Found 1 row.' }],
+    structuredContent: { rows: [{ id: 1 }], total: 1 },
+  }),
+);
+
+server.registerTool(
+  'meta_vendor',
+  {
+    description: 'Returns text content plus a vendor-namespaced _meta key',
+    inputSchema: {},
+  },
+  () => ({
+    content: [{ type: 'text', text: 'done' }],
+    _meta: { 'example.com/trace': 'abc123' },
+  }),
+);
+
+await server.connect(new StdioServerTransport());

--- a/packages/agent-core-v2/test/mcpCore/fixtures/structured-content-stdio-server.mjs
+++ b/packages/agent-core-v2/test/mcpCore/fixtures/structured-content-stdio-server.mjs
@@ -51,4 +51,25 @@ server.registerTool(
   }),
 );
 
+server.registerTool(
+  'faithful_rendering',
+  {
+    description: 'content is a faithful human rendering of structuredContent at similar size',
+    inputSchema: {},
+  },
+  () => ({
+    content: [
+      {
+        type: 'text',
+        text: 'Project: Central Macaw [d594e625]\nDescription: none\nTimeline: 1920x1080 @ 30fps | durationInFrames=0\nAssets: total=0',
+      },
+    ],
+    structuredContent: {
+      project: { id: 'd594e625', name: 'Central Macaw', description: null },
+      timeline: { width: 1920, height: 1080, fps: 30, durationInFrames: 0 },
+      assets: { total: 0 },
+    },
+  }),
+);
+
 await server.connect(new StdioServerTransport());

--- a/packages/agent-core/src/mcp/output.ts
+++ b/packages/agent-core/src/mcp/output.ts
@@ -68,13 +68,6 @@ const MCP_OUTPUT_TRUNCATED_TEXT = `\n\n[Output truncated: exceeded ${String(
 export const MCP_MAX_BINARY_PART_BYTES = 10 * 1024 * 1024;
 const MCP_MAX_BINARY_PART_CHARS = Math.ceil((MCP_MAX_BINARY_PART_BYTES * 4) / 3);
 
-// Size ratio (serialized structuredContent vs. content text) above which a
-// result is treated as a lossy summary and the structured payload is
-// forwarded alongside the content. Faithful renderings measure close to 1
-// (the spec's verbatim dual-emit ≈1, human reorganisations ≈1-2 in
-// practice); lossy summaries sit orders of magnitude higher.
-const MCP_STRUCTURED_LOSSY_RATIO = 2;
-
 function binaryPartTooLargeNotice(kind: 'image' | 'audio' | 'video', urlLength: number): string {
   const approxMb = ((urlLength * 3) / 4 / (1024 * 1024)).toFixed(1);
   const capMb = String(MCP_MAX_BINARY_PART_BYTES / (1024 * 1024));
@@ -203,28 +196,18 @@ export async function mcpResultToExecutableOutput(
   // block. Protocol-reserved _meta keys are dropped first: those carry
   // host/protocol plumbing, not model-facing data.
   //
-  // structuredContent is appended only when content does not already cover
-  // it. Well-behaved servers render the same data into content — as the
-  // spec's verbatim-serialization fallback, or as a faithful human-readable
-  // reorganisation — and either way the rendered text measures at roughly
-  // the same size as the payload. Forwarding the payload there would send
-  // the same information twice. A payload many times larger than the text
-  // is the signature of a lossy summary (or no text at all), where the
-  // structured data must reach the model. _meta has no such overlap and
-  // always passes through.
-  const textLength = converted.reduce(
-    (n, part) => (part.type === 'text' ? n + part.text.trim().length : n),
-    0,
+  // content and structuredContent are alternatives — never both forwarded.
+  // content wins whenever it carries anything usable (a media block or
+  // non-whitespace text): there is no reliable signal that the structured
+  // payload is richer than what the server already rendered into content,
+  // so the only case structuredContent fills in is an empty content array.
+  // _meta has no such overlap and always passes through.
+  const hasUsableContent = converted.some((part) =>
+    part.type === 'text' ? part.text.trim().length > 0 : true,
   );
   const structuredExtras: Record<string, unknown> = {};
-  if (result.structuredContent !== undefined) {
-    const structuredJson = trySerialize(result.structuredContent);
-    if (
-      structuredJson !== undefined &&
-      (textLength === 0 || structuredJson.length > MCP_STRUCTURED_LOSSY_RATIO * textLength)
-    ) {
-      structuredExtras['structuredContent'] = result.structuredContent;
-    }
+  if (result.structuredContent !== undefined && !hasUsableContent) {
+    structuredExtras['structuredContent'] = result.structuredContent;
   }
   if (result._meta !== undefined) {
     const meta = stripReservedMetaKeys(result._meta);
@@ -325,15 +308,6 @@ function isReservedMetaKey(key: string): boolean {
     (label, i) =>
       (label === 'modelcontextprotocol' || label === 'mcp') && i < labels.length - 1,
   );
-}
-
-function trySerialize(value: unknown): string | undefined {
-  try {
-    const serialized = JSON.stringify(value);
-    return typeof serialized === 'string' ? serialized : undefined;
-  } catch {
-    return undefined;
-  }
 }
 
 /**

--- a/packages/agent-core/src/mcp/output.ts
+++ b/packages/agent-core/src/mcp/output.ts
@@ -196,16 +196,18 @@ export async function mcpResultToExecutableOutput(
   // block. Protocol-reserved _meta keys are dropped first: those carry
   // host/protocol plumbing, not model-facing data.
   //
-  // structuredContent is only a FALLBACK for content blocks without usable
-  // text: the MCP spec asks servers returning structuredContent to also
-  // place the serialized JSON in a TextContent block, so forwarding it next
-  // to real text would send the same data to the model twice. _meta has no
-  // such overlap and always passes through.
-  const hasUsableText = converted.some(
-    (part) => part.type === 'text' && part.text.trim().length > 0,
-  );
+  // structuredContent is skipped only when a content text block already
+  // carries its verbatim serialization — the spec's backwards-compatibility
+  // pattern (e.g. the Google Workspace servers) — where forwarding it would
+  // send the same data to the model twice. Servers are equally allowed to
+  // put a lossy human summary in content, so "has text" alone must NOT
+  // suppress the structured payload. _meta has no such overlap and always
+  // passes through.
   const structuredExtras: Record<string, unknown> = {};
-  if (result.structuredContent !== undefined && !hasUsableText) {
+  if (
+    result.structuredContent !== undefined &&
+    !serializesStructuredContent(converted, result.structuredContent)
+  ) {
     structuredExtras['structuredContent'] = result.structuredContent;
   }
   if (result._meta !== undefined) {
@@ -307,6 +309,51 @@ function isReservedMetaKey(key: string): boolean {
     (label, i) =>
       (label === 'modelcontextprotocol' || label === 'mcp') && i < labels.length - 1,
   );
+}
+
+/**
+ * True when some converted text part is exactly the JSON serialization of
+ * `structured` — the pattern the MCP spec recommends for backwards
+ * compatibility. The comparison is semantic (parse, then compare with
+ * canonical key order), not textual, so formatting and key-order
+ * differences still count as the same payload.
+ *
+ * Conservative by construction: any doubt — non-JSON text, prose wrapped
+ * around the JSON, structural mismatch — returns false and the structured
+ * block is appended. A duplicate costs tokens; a wrong drop loses data.
+ */
+function serializesStructuredContent(
+  parts: readonly ContentPart[],
+  structured: unknown,
+): boolean {
+  return parts.some(
+    (part) => part.type === 'text' && textIsJsonSerializationOf(part.text, structured),
+  );
+}
+
+function textIsJsonSerializationOf(text: string, structured: unknown): boolean {
+  const trimmed = text.trim();
+  if (!trimmed.startsWith('{') && !trimmed.startsWith('[')) return false;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(trimmed);
+  } catch {
+    return false;
+  }
+  return canonicalJson(parsed) === canonicalJson(structured);
+}
+
+function canonicalJson(value: unknown): string {
+  if (Array.isArray(value)) {
+    return `[${value.map((item) => canonicalJson(item)).join(',')}]`;
+  }
+  if (typeof value === 'object' && value !== null) {
+    const entries = Object.entries(value)
+      .sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0))
+      .map(([key, val]) => `${JSON.stringify(key)}:${canonicalJson(val)}`);
+    return `{${entries.join(',')}}`;
+  }
+  return String(JSON.stringify(value));
 }
 
 /**

--- a/packages/agent-core/src/mcp/output.ts
+++ b/packages/agent-core/src/mcp/output.ts
@@ -218,12 +218,12 @@ export async function mcpResultToExecutableOutput(
   if (Object.keys(structuredExtras).length > 0) {
     try {
       const serialized = JSON.stringify(structuredExtras).replaceAll(
-        '</mcp-structured-result>',
+        '</mcp-result-extras>',
         '',
       );
       wrapped.push({
         type: 'text',
-        text: `\n<mcp-structured-result>\n${serialized}\n</mcp-structured-result>`,
+        text: `\n<mcp-result-extras>\n${serialized}\n</mcp-result-extras>`,
       });
     } catch {
       // Non-serialisable payloads are dropped rather than failing the call.

--- a/packages/agent-core/src/mcp/output.ts
+++ b/packages/agent-core/src/mcp/output.ts
@@ -195,8 +195,17 @@ export async function mcpResultToExecutableOutput(
   // payload are stripped so server data cannot fake an early end of the
   // block. Protocol-reserved _meta keys are dropped first: those carry
   // host/protocol plumbing, not model-facing data.
+  //
+  // structuredContent is only a FALLBACK for content blocks without usable
+  // text: the MCP spec asks servers returning structuredContent to also
+  // place the serialized JSON in a TextContent block, so forwarding it next
+  // to real text would send the same data to the model twice. _meta has no
+  // such overlap and always passes through.
+  const hasUsableText = converted.some(
+    (part) => part.type === 'text' && part.text.trim().length > 0,
+  );
   const structuredExtras: Record<string, unknown> = {};
-  if (result.structuredContent !== undefined) {
+  if (result.structuredContent !== undefined && !hasUsableText) {
     structuredExtras['structuredContent'] = result.structuredContent;
   }
   if (result._meta !== undefined) {

--- a/packages/agent-core/src/mcp/output.ts
+++ b/packages/agent-core/src/mcp/output.ts
@@ -68,6 +68,13 @@ const MCP_OUTPUT_TRUNCATED_TEXT = `\n\n[Output truncated: exceeded ${String(
 export const MCP_MAX_BINARY_PART_BYTES = 10 * 1024 * 1024;
 const MCP_MAX_BINARY_PART_CHARS = Math.ceil((MCP_MAX_BINARY_PART_BYTES * 4) / 3);
 
+// Size ratio (serialized structuredContent vs. content text) above which a
+// result is treated as a lossy summary and the structured payload is
+// forwarded alongside the content. Faithful renderings measure close to 1
+// (the spec's verbatim dual-emit ≈1, human reorganisations ≈1-2 in
+// practice); lossy summaries sit orders of magnitude higher.
+const MCP_STRUCTURED_LOSSY_RATIO = 2;
+
 function binaryPartTooLargeNotice(kind: 'image' | 'audio' | 'video', urlLength: number): string {
   const approxMb = ((urlLength * 3) / 4 / (1024 * 1024)).toFixed(1);
   const capMb = String(MCP_MAX_BINARY_PART_BYTES / (1024 * 1024));
@@ -196,19 +203,28 @@ export async function mcpResultToExecutableOutput(
   // block. Protocol-reserved _meta keys are dropped first: those carry
   // host/protocol plumbing, not model-facing data.
   //
-  // structuredContent is skipped only when a content text block already
-  // carries its verbatim serialization — the spec's backwards-compatibility
-  // pattern (e.g. the Google Workspace servers) — where forwarding it would
-  // send the same data to the model twice. Servers are equally allowed to
-  // put a lossy human summary in content, so "has text" alone must NOT
-  // suppress the structured payload. _meta has no such overlap and always
-  // passes through.
+  // structuredContent is appended only when content does not already cover
+  // it. Well-behaved servers render the same data into content — as the
+  // spec's verbatim-serialization fallback, or as a faithful human-readable
+  // reorganisation — and either way the rendered text measures at roughly
+  // the same size as the payload. Forwarding the payload there would send
+  // the same information twice. A payload many times larger than the text
+  // is the signature of a lossy summary (or no text at all), where the
+  // structured data must reach the model. _meta has no such overlap and
+  // always passes through.
+  const textLength = converted.reduce(
+    (n, part) => (part.type === 'text' ? n + part.text.trim().length : n),
+    0,
+  );
   const structuredExtras: Record<string, unknown> = {};
-  if (
-    result.structuredContent !== undefined &&
-    !serializesStructuredContent(converted, result.structuredContent)
-  ) {
-    structuredExtras['structuredContent'] = result.structuredContent;
+  if (result.structuredContent !== undefined) {
+    const structuredJson = trySerialize(result.structuredContent);
+    if (
+      structuredJson !== undefined &&
+      (textLength === 0 || structuredJson.length > MCP_STRUCTURED_LOSSY_RATIO * textLength)
+    ) {
+      structuredExtras['structuredContent'] = result.structuredContent;
+    }
   }
   if (result._meta !== undefined) {
     const meta = stripReservedMetaKeys(result._meta);
@@ -311,49 +327,13 @@ function isReservedMetaKey(key: string): boolean {
   );
 }
 
-/**
- * True when some converted text part is exactly the JSON serialization of
- * `structured` — the pattern the MCP spec recommends for backwards
- * compatibility. The comparison is semantic (parse, then compare with
- * canonical key order), not textual, so formatting and key-order
- * differences still count as the same payload.
- *
- * Conservative by construction: any doubt — non-JSON text, prose wrapped
- * around the JSON, structural mismatch — returns false and the structured
- * block is appended. A duplicate costs tokens; a wrong drop loses data.
- */
-function serializesStructuredContent(
-  parts: readonly ContentPart[],
-  structured: unknown,
-): boolean {
-  return parts.some(
-    (part) => part.type === 'text' && textIsJsonSerializationOf(part.text, structured),
-  );
-}
-
-function textIsJsonSerializationOf(text: string, structured: unknown): boolean {
-  const trimmed = text.trim();
-  if (!trimmed.startsWith('{') && !trimmed.startsWith('[')) return false;
-  let parsed: unknown;
+function trySerialize(value: unknown): string | undefined {
   try {
-    parsed = JSON.parse(trimmed);
+    const serialized = JSON.stringify(value);
+    return typeof serialized === 'string' ? serialized : undefined;
   } catch {
-    return false;
+    return undefined;
   }
-  return canonicalJson(parsed) === canonicalJson(structured);
-}
-
-function canonicalJson(value: unknown): string {
-  if (Array.isArray(value)) {
-    return `[${value.map((item) => canonicalJson(item)).join(',')}]`;
-  }
-  if (typeof value === 'object' && value !== null) {
-    const entries = Object.entries(value)
-      .sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0))
-      .map(([key, val]) => `${JSON.stringify(key)}:${canonicalJson(val)}`);
-    return `{${entries.join(',')}}`;
-  }
-  return String(JSON.stringify(value));
 }
 
 /**

--- a/packages/agent-core/test/mcp/fixtures/structured-content-stdio-server.mjs
+++ b/packages/agent-core/test/mcp/fixtures/structured-content-stdio-server.mjs
@@ -11,11 +11,12 @@ const server = new McpServer({ name: 'mock-structured-content', version: '0.0.1'
 server.registerTool(
   'dual_emit',
   {
-    description: 'Returns the same JSON as a text block and as structuredContent',
+    description:
+      'Returns the same JSON as a text block (pretty-printed, different key order) and as structuredContent',
     inputSchema: {},
   },
   () => ({
-    content: [{ type: 'text', text: '{"rows":[{"id":1}],"total":1}' }],
+    content: [{ type: 'text', text: '{\n  "total": 1,\n  "rows": [ { "id": 1 } ]\n}' }],
     structuredContent: { rows: [{ id: 1 }], total: 1 },
   }),
 );

--- a/packages/agent-core/test/mcp/fixtures/structured-content-stdio-server.mjs
+++ b/packages/agent-core/test/mcp/fixtures/structured-content-stdio-server.mjs
@@ -56,4 +56,25 @@ server.registerTool(
   }),
 );
 
+server.registerTool(
+  'faithful_rendering',
+  {
+    description: 'content is a faithful human rendering of structuredContent at similar size',
+    inputSchema: {},
+  },
+  () => ({
+    content: [
+      {
+        type: 'text',
+        text: 'Project: Central Macaw [d594e625]\nDescription: none\nTimeline: 1920x1080 @ 30fps | durationInFrames=0\nAssets: total=0',
+      },
+    ],
+    structuredContent: {
+      project: { id: 'd594e625', name: 'Central Macaw', description: null },
+      timeline: { width: 1920, height: 1080, fps: 30, durationInFrames: 0 },
+      assets: { total: 0 },
+    },
+  }),
+);
+
 await server.connect(new StdioServerTransport());

--- a/packages/agent-core/test/mcp/fixtures/structured-content-stdio-server.mjs
+++ b/packages/agent-core/test/mcp/fixtures/structured-content-stdio-server.mjs
@@ -1,0 +1,58 @@
+// MCP stdio server fixture covering structured-content result shapes, mirroring
+// what real servers put on the wire (the Google Workspace servers dual-emit per
+// the spec's backwards-compatibility SHOULD; others return structuredContent
+// only).
+
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+
+const server = new McpServer({ name: 'mock-structured-content', version: '0.0.1' });
+
+server.registerTool(
+  'dual_emit',
+  {
+    description: 'Returns the same JSON as a text block and as structuredContent',
+    inputSchema: {},
+  },
+  () => ({
+    content: [{ type: 'text', text: '{"rows":[{"id":1}],"total":1}' }],
+    structuredContent: { rows: [{ id: 1 }], total: 1 },
+  }),
+);
+
+server.registerTool(
+  'structured_only',
+  {
+    description: 'Returns structuredContent without any text content',
+    inputSchema: {},
+  },
+  () => ({
+    structuredContent: { rows: [{ id: 1 }], total: 1 },
+  }),
+);
+
+server.registerTool(
+  'prose_plus_structured',
+  {
+    description: 'Returns a prose summary in content plus distinct structuredContent',
+    inputSchema: {},
+  },
+  () => ({
+    content: [{ type: 'text', text: 'Found 1 row.' }],
+    structuredContent: { rows: [{ id: 1 }], total: 1 },
+  }),
+);
+
+server.registerTool(
+  'meta_vendor',
+  {
+    description: 'Returns text content plus a vendor-namespaced _meta key',
+    inputSchema: {},
+  },
+  () => ({
+    content: [{ type: 'text', text: 'done' }],
+    _meta: { 'example.com/trace': 'abc123' },
+  }),
+);
+
+await server.connect(new StdioServerTransport());

--- a/packages/agent-core/test/mcp/output.test.ts
+++ b/packages/agent-core/test/mcp/output.test.ts
@@ -264,7 +264,7 @@ describe('mcpResultToExecutableOutput', () => {
     expect(out).toEqual({ output: 'oops', isError: true });
   });
 
-  test('surfaces structuredContent and _meta as a serialized mcp-structured-result block', async () => {
+  test('omits structuredContent when content already carries usable text', async () => {
     const out = await mcpResultToExecutableOutput(
       {
         content: [{ type: 'text', text: 'ok' }],
@@ -276,10 +276,29 @@ describe('mcpResultToExecutableOutput', () => {
     );
     const parts = out.output as ContentPart[];
     const joined = parts.map((p) => (p.type === 'text' ? p.text : '')).join('');
+    // Dual-emitting servers already place the serialized JSON in a
+    // TextContent block per the MCP spec, so forwarding structuredContent
+    // too would send the same data to the model twice. _meta has no such
+    // overlap and still passes through.
+    expect(joined).not.toContain('"structuredContent"');
     expect(joined).toContain('<mcp-structured-result>');
-    expect(joined).toContain('"structuredContent":{"foo":1}');
     expect(joined).toContain('"_meta":{"bar":2}');
     expect(out.isError).toBe(false);
+  });
+
+  test('falls back to structuredContent when content carries no usable text', async () => {
+    const out = await mcpResultToExecutableOutput(
+      {
+        content: [{ type: 'text', text: '   ' }],
+        isError: false,
+        structuredContent: { foo: 1 },
+      },
+      'mcp__s__t',
+    );
+    const parts = out.output as ContentPart[];
+    const joined = parts.map((p) => (p.type === 'text' ? p.text : '')).join('');
+    expect(joined).toContain('<mcp-structured-result>');
+    expect(joined).toContain('"structuredContent":{"foo":1}');
   });
 
   test('keeps the mcp_tool_result wrap when a media-only result carries structuredContent', async () => {

--- a/packages/agent-core/test/mcp/output.test.ts
+++ b/packages/agent-core/test/mcp/output.test.ts
@@ -287,7 +287,7 @@ describe('mcpResultToExecutableOutput', () => {
     expect(out.isError).toBe(false);
   });
 
-  test('matches the serialization across formatting and key order', async () => {
+  test('omits structuredContent for dual-emit servers even when the serialized text is reformatted', async () => {
     const out = await mcpResultToExecutableOutput(
       {
         content: [{ type: 'text', text: '{\n  "total": 1,\n  "rows": [ { "id": 1 } ]\n}' }],
@@ -300,21 +300,54 @@ describe('mcpResultToExecutableOutput', () => {
     expect(out.output).toBe('{\n  "total": 1,\n  "rows": [ { "id": 1 } ]\n}');
   });
 
-  test('appends structuredContent when content text is a summary, not the serialization', async () => {
+  test('omits structuredContent when content is a faithful rendering of similar size', async () => {
+    // The common well-behaved pattern: content reorganises the same data
+    // into human-readable text, so the payload adds nothing but tokens.
+    const text =
+      'Project: Central Macaw [d594e625]\n' +
+      'Description: none\n' +
+      'Timeline: 1920x1080 @ 30fps | durationInFrames=0\n' +
+      'Assets: total=0';
     const out = await mcpResultToExecutableOutput(
       {
-        content: [{ type: 'text', text: 'list_projects returned 1 item(s).' }],
+        content: [{ type: 'text', text }],
         isError: false,
-        structuredContent: { projects: [{ id: 1 }] },
+        structuredContent: {
+          project: { id: 'd594e625', name: 'Central Macaw', description: null },
+          timeline: { width: 1920, height: 1080, fps: 30, durationInFrames: 0 },
+          assets: { total: 0 },
+        },
+      },
+      'mcp__s__t',
+    );
+    expect(out.output).toBe(text);
+  });
+
+  test('appends structuredContent when the payload dwarfs a lossy summary', async () => {
+    const out = await mcpResultToExecutableOutput(
+      {
+        content: [{ type: 'text', text: 'list_projects returned 6 item(s).' }],
+        isError: false,
+        structuredContent: {
+          projects: [
+            { id: 'p1', name: 'Alpha' },
+            { id: 'p2', name: 'Beta' },
+            { id: 'p3', name: 'Gamma' },
+            { id: 'p4', name: 'Delta' },
+            { id: 'p5', name: 'Epsilon' },
+            { id: 'p6', name: 'Zeta' },
+          ],
+        },
       },
       'mcp__s__t',
     );
     const parts = out.output as ContentPart[];
     const joined = parts.map((p) => (p.type === 'text' ? p.text : '')).join('');
-    // Servers may put a lossy human summary in content; "has text" alone
-    // must not suppress the structured payload.
-    expect(joined).toContain('list_projects returned 1 item(s).');
-    expect(joined).toContain('"structuredContent":{"projects":[{"id":1}]}');
+    // A payload many times larger than the text is the signature of a lossy
+    // summary; the structured data must still reach the model.
+    expect(joined).toContain('list_projects returned 6 item(s).');
+    expect(joined).toContain('"structuredContent"');
+    expect(joined).toContain('"name":"Zeta"');
   });
 
   test('falls back to structuredContent when content carries no usable text', async () => {
@@ -883,6 +916,13 @@ describe('mcpResultToExecutableOutput over a real stdio server', () => {
     const text = joinedText(out.output);
     expect(text).toContain('Found 1 row.');
     expect(text).toContain('"structuredContent":{"rows":[{"id":1}],"total":1}');
+  }, 15000);
+
+  test('a faithful rendering of similar size suppresses the structured copy', async () => {
+    const out = await callFixtureTool('faithful_rendering');
+    const text = joinedText(out.output);
+    expect(text).toContain('Project: Central Macaw');
+    expect(text).not.toContain('<mcp-structured-result>');
   }, 15000);
 
   test('vendor _meta keys pass through alongside content text', async () => {

--- a/packages/agent-core/test/mcp/output.test.ts
+++ b/packages/agent-core/test/mcp/output.test.ts
@@ -282,7 +282,7 @@ describe('mcpResultToExecutableOutput', () => {
     // too would send the same data to the model twice. _meta has no such
     // overlap and still passes through.
     expect(joined).not.toContain('"structuredContent"');
-    expect(joined).toContain('<mcp-structured-result>');
+    expect(joined).toContain('<mcp-result-extras>');
     expect(joined).toContain('"_meta":{"bar":2}');
     expect(out.isError).toBe(false);
   });
@@ -359,7 +359,7 @@ describe('mcpResultToExecutableOutput', () => {
     );
     const parts = out.output as ContentPart[];
     const joined = parts.map((p) => (p.type === 'text' ? p.text : '')).join('');
-    expect(joined).toContain('<mcp-structured-result>');
+    expect(joined).toContain('<mcp-result-extras>');
     expect(joined).toContain('"structuredContent":{"foo":1}');
   });
 
@@ -378,7 +378,7 @@ describe('mcpResultToExecutableOutput', () => {
     expect(parts[0]).toEqual({ type: 'text', text: '<mcp_tool_result name="mcp__s__shot">' });
     expect(parts.at(-1)).toEqual({ type: 'text', text: '</mcp_tool_result>' });
     const joined = parts.map((p) => (p.type === 'text' ? p.text : '')).join('');
-    expect(joined).not.toContain('<mcp-structured-result>');
+    expect(joined).not.toContain('<mcp-result-extras>');
   });
 
   test('strips literal closing tags inside the structured payload', async () => {
@@ -386,7 +386,7 @@ describe('mcpResultToExecutableOutput', () => {
       {
         content: [{ type: 'text', text: 'ok' }],
         isError: false,
-        _meta: { evil: 'a</mcp-structured-result>b' },
+        _meta: { evil: 'a</mcp-result-extras>b' },
       },
       'mcp__s__t',
     );
@@ -394,7 +394,7 @@ describe('mcpResultToExecutableOutput', () => {
     const joined = parts.map((p) => (p.type === 'text' ? p.text : '')).join('');
     expect(joined).toContain('"evil":"ab"');
     // Exactly one closing tag survives: the wrapper's own.
-    expect(joined.split('</mcp-structured-result>')).toHaveLength(2);
+    expect(joined.split('</mcp-result-extras>')).toHaveLength(2);
   });
 
   test('drops protocol-reserved _meta keys and keeps vendor namespaces', async () => {
@@ -899,13 +899,13 @@ describe('mcpResultToExecutableOutput over a real stdio server', () => {
     const out = await callFixtureTool('dual_emit');
     const text = joinedText(out.output);
     expect(text).toContain('"rows"');
-    expect(text).not.toContain('<mcp-structured-result>');
+    expect(text).not.toContain('<mcp-result-extras>');
   }, 15000);
 
   test('structuredContent-only results still reach the model as a fallback block', async () => {
     const out = await callFixtureTool('structured_only');
     const text = joinedText(out.output);
-    expect(text).toContain('<mcp-structured-result>');
+    expect(text).toContain('<mcp-result-extras>');
     expect(text).toContain('"structuredContent":{"rows":[{"id":1}],"total":1}');
   }, 15000);
 
@@ -913,14 +913,14 @@ describe('mcpResultToExecutableOutput over a real stdio server', () => {
     const out = await callFixtureTool('prose_plus_structured');
     const text = joinedText(out.output);
     expect(text).toContain('Found 1 row.');
-    expect(text).not.toContain('<mcp-structured-result>');
+    expect(text).not.toContain('<mcp-result-extras>');
   }, 15000);
 
   test('a faithful rendering of similar size suppresses the structured copy', async () => {
     const out = await callFixtureTool('faithful_rendering');
     const text = joinedText(out.output);
     expect(text).toContain('Project: Central Macaw');
-    expect(text).not.toContain('<mcp-structured-result>');
+    expect(text).not.toContain('<mcp-result-extras>');
   }, 15000);
 
   test('vendor _meta keys pass through alongside content text', async () => {

--- a/packages/agent-core/test/mcp/output.test.ts
+++ b/packages/agent-core/test/mcp/output.test.ts
@@ -323,7 +323,7 @@ describe('mcpResultToExecutableOutput', () => {
     expect(out.output).toBe(text);
   });
 
-  test('appends structuredContent when the payload dwarfs a lossy summary', async () => {
+  test('suppresses structuredContent whenever content carries usable text', async () => {
     const out = await mcpResultToExecutableOutput(
       {
         content: [{ type: 'text', text: 'list_projects returned 6 item(s).' }],
@@ -341,13 +341,11 @@ describe('mcpResultToExecutableOutput', () => {
       },
       'mcp__s__t',
     );
-    const parts = out.output as ContentPart[];
-    const joined = parts.map((p) => (p.type === 'text' ? p.text : '')).join('');
-    // A payload many times larger than the text is the signature of a lossy
-    // summary; the structured data must still reach the model.
-    expect(joined).toContain('list_projects returned 6 item(s).');
-    expect(joined).toContain('"structuredContent"');
-    expect(joined).toContain('"name":"Zeta"');
+    // By design content and structuredContent are alternatives: there is no
+    // reliable signal that the payload is richer than the server's own
+    // rendering, so even a terse summary wins. The lone text block
+    // collapses to a plain string.
+    expect(out.output).toBe('list_projects returned 6 item(s).');
   });
 
   test('falls back to structuredContent when content carries no usable text', async () => {
@@ -365,7 +363,7 @@ describe('mcpResultToExecutableOutput', () => {
     expect(joined).toContain('"structuredContent":{"foo":1}');
   });
 
-  test('keeps the mcp_tool_result wrap when a media-only result carries structuredContent', async () => {
+  test('keeps the mcp_tool_result wrap for media-only results and suppresses structuredContent', async () => {
     const out = await mcpResultToExecutableOutput(
       {
         content: [{ type: 'image', data: 'AAA', mimeType: 'image/png' }],
@@ -375,12 +373,12 @@ describe('mcpResultToExecutableOutput', () => {
       'mcp__s__shot',
     );
     const parts = out.output as ContentPart[];
-    // The structured block sits OUTSIDE the media wrap, after the closing
-    // tag, so the image keeps its tool attribution.
+    // Media already counts as usable content, so the structured payload is
+    // not forwarded; the media wrap is the only surrounding text.
     expect(parts[0]).toEqual({ type: 'text', text: '<mcp_tool_result name="mcp__s__shot">' });
-    expect(parts.at(-2)).toEqual({ type: 'text', text: '</mcp_tool_result>' });
-    const last = parts.at(-1);
-    expect(last?.type === 'text' && last.text.includes('<mcp-structured-result>')).toBe(true);
+    expect(parts.at(-1)).toEqual({ type: 'text', text: '</mcp_tool_result>' });
+    const joined = parts.map((p) => (p.type === 'text' ? p.text : '')).join('');
+    expect(joined).not.toContain('<mcp-structured-result>');
   });
 
   test('strips literal closing tags inside the structured payload', async () => {
@@ -911,11 +909,11 @@ describe('mcpResultToExecutableOutput over a real stdio server', () => {
     expect(text).toContain('"structuredContent":{"rows":[{"id":1}],"total":1}');
   }, 15000);
 
-  test('a prose summary keeps the structured payload alongside it', async () => {
+  test('a prose summary suppresses the structured payload', async () => {
     const out = await callFixtureTool('prose_plus_structured');
     const text = joinedText(out.output);
     expect(text).toContain('Found 1 row.');
-    expect(text).toContain('"structuredContent":{"rows":[{"id":1}],"total":1}');
+    expect(text).not.toContain('<mcp-structured-result>');
   }, 15000);
 
   test('a faithful rendering of similar size suppresses the structured copy', async () => {

--- a/packages/agent-core/test/mcp/output.test.ts
+++ b/packages/agent-core/test/mcp/output.test.ts
@@ -265,10 +265,10 @@ describe('mcpResultToExecutableOutput', () => {
     expect(out).toEqual({ output: 'oops', isError: true });
   });
 
-  test('omits structuredContent when content already carries usable text', async () => {
+  test('omits structuredContent when a text block already carries its serialization', async () => {
     const out = await mcpResultToExecutableOutput(
       {
-        content: [{ type: 'text', text: 'ok' }],
+        content: [{ type: 'text', text: '{"foo":1}' }],
         isError: false,
         structuredContent: { foo: 1 },
         _meta: { bar: 2 },
@@ -285,6 +285,36 @@ describe('mcpResultToExecutableOutput', () => {
     expect(joined).toContain('<mcp-structured-result>');
     expect(joined).toContain('"_meta":{"bar":2}');
     expect(out.isError).toBe(false);
+  });
+
+  test('matches the serialization across formatting and key order', async () => {
+    const out = await mcpResultToExecutableOutput(
+      {
+        content: [{ type: 'text', text: '{\n  "total": 1,\n  "rows": [ { "id": 1 } ]\n}' }],
+        isError: false,
+        structuredContent: { rows: [{ id: 1 }], total: 1 },
+      },
+      'mcp__s__t',
+    );
+    // Nothing appended: the lone text block collapses to a plain string.
+    expect(out.output).toBe('{\n  "total": 1,\n  "rows": [ { "id": 1 } ]\n}');
+  });
+
+  test('appends structuredContent when content text is a summary, not the serialization', async () => {
+    const out = await mcpResultToExecutableOutput(
+      {
+        content: [{ type: 'text', text: 'list_projects returned 1 item(s).' }],
+        isError: false,
+        structuredContent: { projects: [{ id: 1 }] },
+      },
+      'mcp__s__t',
+    );
+    const parts = out.output as ContentPart[];
+    const joined = parts.map((p) => (p.type === 'text' ? p.text : '')).join('');
+    // Servers may put a lossy human summary in content; "has text" alone
+    // must not suppress the structured payload.
+    expect(joined).toContain('list_projects returned 1 item(s).');
+    expect(joined).toContain('"structuredContent":{"projects":[{"id":1}]}');
   });
 
   test('falls back to structuredContent when content carries no usable text', async () => {
@@ -837,7 +867,7 @@ describe('mcpResultToExecutableOutput over a real stdio server', () => {
   test('dual-emitting servers reach the model once, through content', async () => {
     const out = await callFixtureTool('dual_emit');
     const text = joinedText(out.output);
-    expect(text).toContain('{"rows":[{"id":1}],"total":1}');
+    expect(text).toContain('"rows"');
     expect(text).not.toContain('<mcp-structured-result>');
   }, 15000);
 
@@ -848,11 +878,11 @@ describe('mcpResultToExecutableOutput over a real stdio server', () => {
     expect(text).toContain('"structuredContent":{"rows":[{"id":1}],"total":1}');
   }, 15000);
 
-  test('prose content suppresses structuredContent rather than duplicating it', async () => {
+  test('a prose summary keeps the structured payload alongside it', async () => {
     const out = await callFixtureTool('prose_plus_structured');
     const text = joinedText(out.output);
     expect(text).toContain('Found 1 row.');
-    expect(text).not.toContain('"structuredContent"');
+    expect(text).toContain('"structuredContent":{"rows":[{"id":1}],"total":1}');
   }, 15000);
 
   test('vendor _meta keys pass through alongside content text', async () => {

--- a/packages/agent-core/test/mcp/output.test.ts
+++ b/packages/agent-core/test/mcp/output.test.ts
@@ -7,6 +7,7 @@ import { join } from 'node:path';
 import { describe, expect, test } from 'vitest';
 
 import { convertMCPContentBlock, mcpResultToExecutableOutput } from '../../src/mcp/output';
+import { StdioMcpClient } from '../../src/mcp/client-stdio';
 import type { MCPContentBlock, MCPToolResult } from '../../src/mcp/types';
 import type { TelemetryClient } from '../../src/telemetry';
 import { sniffImageDimensions } from '../../src/tools/support/file-type';
@@ -804,4 +805,60 @@ describe('mcpResultToExecutableOutput', () => {
     expect(joined).not.toContain('Output truncated');
     await rm(dir, { recursive: true, force: true });
   });
+});
+
+// Round-trip over a real stdio MCP server: exercises the SDK wire format,
+// toMcpToolResult normalisation, and the output pipeline together, so the
+// structuredContent fallback is verified against real protocol bytes rather
+// than hand-built result objects.
+describe('mcpResultToExecutableOutput over a real stdio server', () => {
+  const fixture = join(import.meta.dirname, 'fixtures', 'structured-content-stdio-server.mjs');
+
+  async function callFixtureTool(name: string) {
+    const client = new StdioMcpClient({
+      transport: 'stdio',
+      command: process.execPath,
+      args: [fixture],
+    });
+    try {
+      await client.connect();
+      return await mcpResultToExecutableOutput(await client.callTool(name, {}), 'mcp__mock__t');
+    } finally {
+      await client.close();
+    }
+  }
+
+  function joinedText(output: string | ContentPart[]): string {
+    return typeof output === 'string'
+      ? output
+      : output.map((p) => (p.type === 'text' ? p.text : '')).join('');
+  }
+
+  test('dual-emitting servers reach the model once, through content', async () => {
+    const out = await callFixtureTool('dual_emit');
+    const text = joinedText(out.output);
+    expect(text).toContain('{"rows":[{"id":1}],"total":1}');
+    expect(text).not.toContain('<mcp-structured-result>');
+  }, 15000);
+
+  test('structuredContent-only results still reach the model as a fallback block', async () => {
+    const out = await callFixtureTool('structured_only');
+    const text = joinedText(out.output);
+    expect(text).toContain('<mcp-structured-result>');
+    expect(text).toContain('"structuredContent":{"rows":[{"id":1}],"total":1}');
+  }, 15000);
+
+  test('prose content suppresses structuredContent rather than duplicating it', async () => {
+    const out = await callFixtureTool('prose_plus_structured');
+    const text = joinedText(out.output);
+    expect(text).toContain('Found 1 row.');
+    expect(text).not.toContain('"structuredContent"');
+  }, 15000);
+
+  test('vendor _meta keys pass through alongside content text', async () => {
+    const out = await callFixtureTool('meta_vendor');
+    const text = joinedText(out.output);
+    expect(text).toContain('done');
+    expect(text).toContain('"_meta":{"example.com/trace":"abc123"}');
+  }, 15000);
 });


### PR DESCRIPTION
## Related Issue

Follow-up to #2596 (which resolved #2554), addressing user feedback that MCP tool results reached the model twice.

## Problem

#2596 made the MCP `structuredContent` and `_meta` fields visible to the model by appending them as a serialized `<mcp-result-extras>` text block. But servers already render their data into `content` — as the spec's verbatim-JSON fallback (Google Workspace style) or as a human-readable reorganisation — so the model received the same information twice.

## What changed

**`content` and `structuredContent` become alternatives — never both forwarded:**

- `content` wins whenever it carries anything usable (a media block or non-whitespace text);
- `structuredContent` fills in only when the content array is effectively empty (structuredContent-only servers keep working, preserving the #2596 fix);
- `_meta` (vendor-namespaced keys, protocol-reserved keys still filtered) is unchanged and always passes through.

Why not a smarter heuristic: there is no reliable signal that the structured payload is richer than what the server rendered into content — semantic equality misses faithful human reorganisations, and size ratios misjudge both directions. Rather than guess, the rule is absolute. The accepted trade-off: servers that put a lossy summary in content while keeping the real payload only in structuredContent will have that payload suppressed — such servers should render the data into content (the spec's SHOULD).

Applied identically to the v1 (`packages/agent-core/src/mcp/output.ts`) and v2 (`packages/agent-core-v2/src/agent/mcp/output.ts`) output pipelines.

## Verification

- Unit tests per server shape: verbatim dual-emit (incl. reformatted), faithful rendering, prose summary (suppressed by design), whitespace-only content (fallback fires), media-only (media counts as content), `_meta` filtering.
- Round-trip suites in both packages spawn a real stdio MCP server (`structured-content-stdio-server.mjs` fixture) and push five result shapes through `StdioMcpClient` → `toMcpToolResult` → `mcpResultToExecutableOutput`:
  - `dual_emit` / `faithful_rendering` / `prose_plus_structured` → model receives content only, no structured block;
  - `structured_only` → payload still surfaced;
  - `meta_vendor` → vendor `_meta` passes through.
- Full suites green: agent-core 246 tests, agent-core-v2 240 tests; lint and typecheck clean.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue (external PRs: the issue must have a maintainer's `/approve`).
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.

