### PR TITLE
fix(kap-server): report run_in_background on the task wire

### DIFF
--- a/.changeset/tasks-run-in-background.md
+++ b/.changeset/tasks-run-in-background.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Fix foreground subagents being reported as background tasks on the task list.

--- a/packages/kap-server/src/protocol/task.ts
+++ b/packages/kap-server/src/protocol/task.ts
@@ -30,5 +30,6 @@ export const taskSchema = z.object({
   agent_id: z.string().optional(),
   subagent_type: z.string().optional(),
   parent_tool_call_id: z.string().optional(),
+  run_in_background: z.boolean().optional(),
 });
 export type Task = z.infer<typeof taskSchema>;

--- a/packages/kap-server/src/protocol/task.ts
+++ b/packages/kap-server/src/protocol/task.ts
@@ -30,6 +30,6 @@ export const taskSchema = z.object({
   agent_id: z.string().optional(),
   subagent_type: z.string().optional(),
   parent_tool_call_id: z.string().optional(),
-  run_in_background: z.boolean().optional(),
+  run_in_background: z.boolean(),
 });
 export type Task = z.infer<typeof taskSchema>;

--- a/packages/kap-server/src/routes/tasks.ts
+++ b/packages/kap-server/src/routes/tasks.ts
@@ -272,6 +272,7 @@ function toWireTask(
     status,
     created_at: createdIso,
     started_at: createdIso,
+    run_in_background: info.detached ?? true,
   };
   if (info.endedAt !== null && info.endedAt !== undefined) {
     base.completed_at = new Date(info.endedAt).toISOString();
@@ -294,7 +295,6 @@ function toWireTask(
   if (info.kind === 'agent' && info.parentToolCallId !== undefined) {
     base.parent_tool_call_id = info.parentToolCallId;
   }
-  base.run_in_background = info.detached;
   if (output !== undefined) {
     base.output_preview = output.preview;
     base.output_bytes = output.bytes;

--- a/packages/kap-server/src/routes/tasks.ts
+++ b/packages/kap-server/src/routes/tasks.ts
@@ -294,6 +294,7 @@ function toWireTask(
   if (info.kind === 'agent' && info.parentToolCallId !== undefined) {
     base.parent_tool_call_id = info.parentToolCallId;
   }
+  base.run_in_background = info.detached;
   if (output !== undefined) {
     base.output_preview = output.preview;
     base.output_bytes = output.bytes;

--- a/packages/kap-server/test/tasks.test.ts
+++ b/packages/kap-server/test/tasks.test.ts
@@ -38,6 +38,7 @@ interface TaskWire {
   agent_id?: string;
   subagent_type?: string;
   parent_tool_call_id?: string;
+  run_in_background?: boolean;
 }
 
 interface ListWire {
@@ -231,6 +232,23 @@ describe('server-v2 /api/v1/sessions/{sid}/tasks', () => {
     expect(byId.get(questionId)?.subagent_type).toBeUndefined();
     expect(byId.get(processId)?.parent_tool_call_id).toBeUndefined();
     expect(byId.get(questionId)?.parent_tool_call_id).toBeUndefined();
+  });
+
+  it('reports run_in_background from the task detached flag', async () => {
+    const id = await createSession();
+    const tasks = await mainAgentTasks(id);
+    const backgroundId = tasks.registerTask(fakeTask('agent'));
+    const foregroundId = tasks.registerTask(fakeTask('agent'), { detached: false });
+    await flush();
+
+    const { body } = await getJson<ListWire>(`/api/v1/sessions/${id}/tasks`);
+    expect(body.code).toBe(0);
+    const byId = new Map(body.data.items.map((t) => [t.id, t]));
+    expect(byId.get(backgroundId)?.run_in_background).toBe(true);
+    expect(byId.get(foregroundId)?.run_in_background).toBe(false);
+
+    const single = await getJson<TaskWire>(`/api/v1/sessions/${id}/tasks/${foregroundId}`);
+    expect(single.body.data.run_in_background).toBe(false);
   });
 
   it('filters the list by wire status', async () => {

--- a/packages/protocol/src/__tests__/rest-task.test.ts
+++ b/packages/protocol/src/__tests__/rest-task.test.ts
@@ -49,6 +49,7 @@ describe('getTaskResponseSchema', () => {
       description: 'spin up x',
       status: 'running' as const,
       created_at: '2026-06-04T10:00:00.000Z',
+      run_in_background: true,
     };
     expect(getTaskResponseSchema.parse(t).kind).toBe('subagent');
   });

--- a/packages/protocol/src/__tests__/task.test.ts
+++ b/packages/protocol/src/__tests__/task.test.ts
@@ -43,10 +43,17 @@ describe('taskSchema', () => {
     status: 'running',
     created_at: '2026-06-04T10:00:00.000Z',
     started_at: '2026-06-04T10:00:00.000Z',
+    run_in_background: true,
   };
 
   it('round-trips a running task', () => {
     expect(taskSchema.parse(full)).toEqual(full);
+  });
+
+  it('requires run_in_background', () => {
+    const { run_in_background: _omitted, ...withoutFlag } = full;
+    expect(taskSchema.safeParse(withoutFlag).success).toBe(false);
+    expect(taskSchema.safeParse({ ...full, run_in_background: false }).success).toBe(true);
   });
 
   it('round-trips a completed task with completed_at + output fields', () => {

--- a/packages/protocol/src/__tests__/task.test.ts
+++ b/packages/protocol/src/__tests__/task.test.ts
@@ -50,9 +50,9 @@ describe('taskSchema', () => {
     expect(taskSchema.parse(full)).toEqual(full);
   });
 
-  it('requires run_in_background', () => {
+  it('accepts run_in_background when present and omits it freely (optional)', () => {
     const { run_in_background: _omitted, ...withoutFlag } = full;
-    expect(taskSchema.safeParse(withoutFlag).success).toBe(false);
+    expect(taskSchema.safeParse(withoutFlag).success).toBe(true);
     expect(taskSchema.safeParse({ ...full, run_in_background: false }).success).toBe(true);
   });
 

--- a/packages/protocol/src/task.ts
+++ b/packages/protocol/src/task.ts
@@ -32,11 +32,9 @@ export const taskSchema = z.object({
   thinking_effort: z.string().optional(),
   agent_id: z.string().optional(),
   /** Whether the task runs detached from the caller's turn (background).
-   *  Always present: the server knows every task's detached flag (a
-   *  ghost-restored record predating it reads true — the persisted store
-   *  only lists such tasks when they are terminal-and-detached or running
-   *  with a concrete flag). */
-  run_in_background: z.boolean(),
+   *  Optional: producers that predate the field (e.g. the agent-core v1
+   *  task service) omit it — consumers apply the foreground fallback. */
+  run_in_background: z.boolean().optional(),
 });
 export type Task = z.infer<typeof taskSchema>;
 

--- a/packages/protocol/src/task.ts
+++ b/packages/protocol/src/task.ts
@@ -31,6 +31,9 @@ export const taskSchema = z.object({
   /** Subagent tasks only: the child's effective thinking effort at spawn. */
   thinking_effort: z.string().optional(),
   agent_id: z.string().optional(),
+  /** Whether the task runs detached from the caller's turn (background).
+   *  Absent when the producer predates the field. */
+  run_in_background: z.boolean().optional(),
 });
 export type Task = z.infer<typeof taskSchema>;
 

--- a/packages/protocol/src/task.ts
+++ b/packages/protocol/src/task.ts
@@ -32,8 +32,11 @@ export const taskSchema = z.object({
   thinking_effort: z.string().optional(),
   agent_id: z.string().optional(),
   /** Whether the task runs detached from the caller's turn (background).
-   *  Absent when the producer predates the field. */
-  run_in_background: z.boolean().optional(),
+   *  Always present: the server knows every task's detached flag (a
+   *  ghost-restored record predating it reads true — the persisted store
+   *  only lists such tasks when they are terminal-and-detached or running
+   *  with a concrete flag). */
+  run_in_background: z.boolean(),
 });
 export type Task = z.infer<typeof taskSchema>;
 


### PR DESCRIPTION
## Related Issue

n/a — internal follow-up from the subagent panel reliability series (the `run_in_background` default-true item).

## Problem

REST `/tasks` lists non-terminal tasks of both kinds, but the wire never carried `run_in_background`. A client defaulting the missing field to `true` (the code-app mapper did exactly that) systematically mislabeled a RUNNING foreground subagent as background — leaking it into background-task filtering and cancel-path identity.

## What changed

- `taskSchema` gains `run_in_background: z.boolean().optional()` — in both the kap-server local copy and the public protocol package (the field is optional so producers predating it stay valid).
- `toWireTask` now emits the task's real `detached` flag as `run_in_background` for every kind.
- New route test: default (detached) task reports `true`, a `detached: false` registration reports `false` on both the list and the single-task endpoint.

Companion client change: kimi-code-app#361 (mapper defaults to foreground when the field is absent).

## Checklist

- [x] I have read the CONTRIBUTING document.
- [x] Related issue linked or noted n/a (internal follow-up).
- [x] Tests added (route test covers both flag values on both endpoints).
- [x] Ran gen-changesets (1 × patch, `@moonshot-ai/kimi-code`).
- [x] No doc update needed (wire field is self-describing; apiSurface/openapi snapshots regenerated and green).