### PR TITLE
fix(agent/loop): abort listeners

### DIFF
--- a/.changeset/abort-signal-listener-ceiling.md
+++ b/.changeset/abort-signal-listener-ceiling.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Silence the MaxListenersExceededWarning that could appear during long agent turns with many parallel tool calls.

--- a/packages/agent-core-v2/src/agent/loop/loopService.ts
+++ b/packages/agent-core-v2/src/agent/loop/loopService.ts
@@ -1,4 +1,5 @@
 import { randomUUID } from 'node:crypto';
+import { EventEmitter } from 'node:events';
 
 import { createControlledPromise } from '@antfu/utils';
 
@@ -81,6 +82,8 @@ export const loopLastRequestTraceIdKey = defineState<string | undefined>(
   () => undefined as string | undefined,
 );
 export const loopDisposingKey = defineState<boolean>('loop.disposing', () => false);
+
+const MAX_STEP_SIGNAL_LISTENERS = 64;
 
 export class AgentLoopService extends Disposable implements IAgentLoopService {
   declare readonly _serviceBrand: undefined;
@@ -702,6 +705,7 @@ export class AgentLoopService extends Disposable implements IAgentLoopService {
         ? runtime.turnSignal
         : AbortSignal.any([runtime.turnSignal, mutableStep.controller.signal]),
     };
+    EventEmitter.setMaxListeners(MAX_STEP_SIGNAL_LISTENERS, step.signal);
     this.materializeBatch(batch);
     return { step };
   }

--- a/packages/agent-core-v2/src/workspace/workspaceFs/internal/fsProcess.ts
+++ b/packages/agent-core-v2/src/workspace/workspaceFs/internal/fsProcess.ts
@@ -35,12 +35,16 @@ export async function runCommand(
     else signal.addEventListener('abort', onAbort, { once: true });
   }
 
-  const [stdout, stderr, exitCode] = await Promise.all([
-    readStream(proc.stdout),
-    readStream(proc.stderr),
-    proc.wait().catch(() => -1),
-  ]);
-  return { exitCode, stdout, stderr };
+  try {
+    const [stdout, stderr, exitCode] = await Promise.all([
+      readStream(proc.stdout),
+      readStream(proc.stderr),
+      proc.wait().catch(() => -1),
+    ]);
+    return { exitCode, stdout, stderr };
+  } finally {
+    signal?.removeEventListener('abort', onAbort);
+  }
 }
 
 export function readStream(stream: Readable): Promise<string> {

--- a/packages/agent-core-v2/test/agent/loop/loop.test.ts
+++ b/packages/agent-core-v2/test/agent/loop/loop.test.ts
@@ -1,3 +1,5 @@
+import { getMaxListeners } from 'node:events';
+
 import { type ToolCall } from '#/kosong/contract/message';
 import { emptyUsage } from '#/kosong/contract/usage';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
@@ -501,6 +503,22 @@ describe('Agent loop', () => {
         origin: { kind: 'system_trigger', name: 'stop_hook' },
       }),
     );
+  });
+
+  it('raises the abort-listener ceiling on the step signal for parallel tool bursts', async () => {
+    profile.update({ activeToolNames: [] });
+    let observed = 0;
+    loop.hooks.onDidFinishStep.register('test-step-signal-listener-ceiling', async (hookCtx, next) => {
+      observed = getMaxListeners(hookCtx.signal);
+      await next();
+    });
+
+    ctx.mockNextResponse({ type: 'text', text: 'answer' });
+
+    await ctx.rpc.prompt({ input: [{ type: 'text', text: 'hello' }] });
+    await ctx.untilTurnEnd();
+
+    expect(observed).toBe(64);
   });
 
   it('ends the turn when an afterStep hook sets stopTurn even though the model requested tool calls', async () => {

--- a/packages/agent-core-v2/test/workspace/workspaceFs/fsProcess.test.ts
+++ b/packages/agent-core-v2/test/workspace/workspaceFs/fsProcess.test.ts
@@ -1,3 +1,4 @@
+import { listenerCount, type EventEmitter } from 'node:events';
 import { Readable, Writable } from 'node:stream';
 
 import { describe, expect, it } from 'vitest';
@@ -75,5 +76,11 @@ describe('runCommand', () => {
     controller.abort();
     await promise;
     expect(killed).toBe(true);
+  });
+
+  it('removes the abort listener once the command completes', async () => {
+    const controller = new AbortController();
+    await runCommand(fakeRunner(fakeProcess()), ['echo'], { signal: controller.signal });
+    expect(listenerCount(controller.signal as unknown as EventEmitter, 'abort')).toBe(0);
   });
 });


### PR DESCRIPTION
## Problem

`/tower` 体验期间，修复 listener 注册了不删，泄漏导致的警告。

```bash
(node:90448) MaxListenersExceededWarning: Possible EventTarget memory leak detected. 11 abort listeners added to [AbortSignal]. MaxListeners is 10. Use events.setMaxListeners() to increase limit
(Use `node --trace-warnings ...` to show where the warning was created)
```

## What changed

<!-- What did you implement, and why does this approach fit Kimi Code? -->

## Checklist

- [ ] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [ ] I have linked a related issue (external PRs: the issue must have a maintainer's `/approve`).
- [ ] I have added tests that prove my feature works.
- [ ] Ran `gen-changesets` skill, or this PR needs no changeset.
- [ ] Ran `gen-docs` skill, or this PR needs no doc update.
