### PR TITLE
chore: curate release changesets

### DIFF
--- a/.changeset/mobile-switcher-flat-grouped-tabs.md
+++ b/.changeset/mobile-switcher-flat-grouped-tabs.md
@@ -2,4 +2,4 @@
 "@moonshot-ai/kimi-code": minor
 ---
 
-web: Add a flat/by-workspace tab to the mobile session list — the flat view sorts purely by recency and the grouped view orders each workspace by its latest session.
+web: Add a flat/by-workspace tab to the mobile session list.

--- a/.changeset/remove-perm-thinking-slash-commands.md
+++ b/.changeset/remove-perm-thinking-slash-commands.md
@@ -1,5 +1,0 @@
----
-"@moonshot-ai/kimi-code": patch
----
-
-web: Remove the /auto, /yolo, and /thinking slash commands; permission mode and thinking effort remain adjustable from their settings UI.

--- a/.changeset/secondary-model-thinking-effort.md
+++ b/.changeset/secondary-model-thinking-effort.md
@@ -2,4 +2,4 @@
 "@moonshot-ai/kimi-code": patch
 ---
 
-Fix subagents bound to a configured secondary model ignoring its default thinking effort; [secondary_model].default_effort and the bound model's own default_effort are now honored.
+Fix subagents bound to a configured secondary model ignoring its default thinking effort.

--- a/.changeset/subagent-fork-context.md
+++ b/.changeset/subagent-fork-context.md
@@ -2,4 +2,4 @@
 "@moonshot-ai/kimi-code": minor
 ---
 
-Add an optional ‎`fork` parameter to the subagent and swarm tools that starts the subagent with a snapshot of the calling agent’s conversation history instead of an empty context. Experimental: enable it by setting `KIMI_CODE_EXPERIMENTAL_SUBAGENT_FORK=true` or `subagent_fork = true` under `[experimental]` in config.toml.
+Add an optional `fork` parameter to subagent and swarm tools that starts the subagent with a snapshot of the calling agent's conversation history; set `KIMI_CODE_EXPERIMENTAL_SUBAGENT_FORK=1` or `subagent_fork = true` under `[experimental]` in config.toml to enable it.

--- a/.changeset/tower-feature.md
+++ b/.changeset/tower-feature.md
@@ -1,5 +1,0 @@
----
-"@moonshot-ai/kimi-code": minor
----
-
-Tower mode is Kimi Code's experimental multi-agent collaboration mode. Once enabled with `/tower on`, you can hand off research, development, or verification tasks at any time, and orchestration begins right away: agents work in parallel, each in its own isolated git worktree; an independent reviewer agent examines every change, and only approved work is merged into your chosen branch — with a summary reported back when done. Task boundaries, reviews, and merge order are enforced by tooling rather than prompts alone, so tasks never interfere with one another. Everything is logged and auditable, and you can adjust requirements at any point while work is underway.

--- a/.changeset/tower-mode-command.md
+++ b/.changeset/tower-mode-command.md
@@ -2,4 +2,4 @@
 "@moonshot-ai/kimi-code": minor
 ---
 
-Add tower mode as a plan-parallel mode gated behind an experimental flag (off by default). Set `KIMI_CODE_EXPERIMENTAL_TOWER=1` to enable it; `/tower` reports status, `/tower on|off` toggles the mode with a footer indicator, and `/tower <objective>` starts multi-agent orchestration.
+Add tower mode as an experimental multi-agent orchestration mode. Set `KIMI_CODE_EXPERIMENTAL_TOWER=1` to enable it, then run `/tower on` and `/tower <objective>` to start.

--- a/.changeset/tower-mode-command.md
+++ b/.changeset/tower-mode-command.md
@@ -2,4 +2,4 @@
 "@moonshot-ai/kimi-code": minor
 ---
 
-Add tower mode as an experimental multi-agent orchestration mode. Set `KIMI_CODE_EXPERIMENTAL_TOWER=1` to enable it, then run `/tower on` and `/tower <objective>` to start.
+Add experimental tower mode for multi-agent orchestration; set `KIMI_CODE_EXPERIMENTAL_TOWER=1`, then run `/tower on` and `/tower <objective>` to start.

--- a/.changeset/tower-mode-command.md
+++ b/.changeset/tower-mode-command.md
@@ -2,4 +2,4 @@
 "@moonshot-ai/kimi-code": minor
 ---
 
-Add tower mode as a plan-parallel mode gated behind the experimental flag `KIMI_CODE_EXPERIMENTAL_TOWER` (off by default): /tower reports status, /tower on|off toggles the mode with a footer indicator, and /tower <objective> starts multi-agent orchestration.
+Add tower mode as a plan-parallel mode gated behind an experimental flag (off by default). Set `KIMI_CODE_EXPERIMENTAL_TOWER=1` to enable it; `/tower` reports status, `/tower on|off` toggles the mode with a footer indicator, and `/tower <objective>` starts multi-agent orchestration.

--- a/.changeset/transcript-activity-state.md
+++ b/.changeset/transcript-activity-state.md
@@ -1,6 +1,0 @@
----
-"@moonshot-ai/kap-server": patch
-"@moonshot-ai/transcript": patch
----
-
-Publish per-agent transcript activity state (idle / turn) on transcript snapshots, derived from live loop status and preserved across cold rebuilds and live backfills.

--- a/.changeset/transcript-prompt-entities.md
+++ b/.changeset/transcript-prompt-entities.md
@@ -1,7 +1,0 @@
----
-"@moonshot-ai/agent-core-v2": patch
-"@moonshot-ai/kap-server": patch
-"@moonshot-ai/node-sdk": patch
----
-
-Expose prompt queue entities through the transcript surface: accepted and queued prompts carry their content, queued prompts keep it after dequeueing, and the schema-less prompt.accepted event no longer leaks into the v1 event stream.

--- a/.changeset/transcript-subagent-model-meta.md
+++ b/.changeset/transcript-subagent-model-meta.md
@@ -1,6 +1,0 @@
----
-"@moonshot-ai/kap-server": patch
-"@moonshot-ai/transcript": patch
----
-
-Keep subagent task model and thinking-effort metadata on transcript tasks, including after the task terminates.


### PR DESCRIPTION
## Related Issue

N/A — pre-release changeset cleanup.

## Problem

Several pending changesets did not match the intended release changelog preview, and one invalid package reference could prevent the release PR from regenerating.

## What changed

- Clarified tower mode enablement with `KIMI_CODE_EXPERIMENTAL_TOWER=1` and kept the entry to one sentence.
- Removed the duplicate long-form tower changeset.
- Shortened the mobile session list and secondary-model changesets.
- Removed the slash-command removal changeset from the pending release notes.
- Removed private transcript changesets, including the invalid `@moonshot-ai/node-sdk` reference that broke `changeset status`.
- Cleaned up the subagent fork changeset and normalized its flag example to `KIMI_CODE_EXPERIMENTAL_SUBAGENT_FORK=1`.

## Verification

- `./node_modules/.bin/changeset status`

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue, or explained the problem above.
- [ ] I have added tests that prove my feature works. (N/A — changeset-only cleanup)
- [x] Ran `gen-changesets` skill, or this PR needs no changeset. (Updated existing changesets)
- [x] Ran `gen-docs` skill, or this PR needs no doc update. (No doc update — changeset-only cleanup)