### PR TITLE
fix: [Bug] Trailing backslash degrades the whole bash parse to a single ERROR node

### DIFF
--- a/.changeset/fix-trailing-backslash-bash-parse.md
+++ b/.changeset/fix-trailing-backslash-bash-parse.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Fix bash commands ending in a lone trailing backslash being misread as unparseable, which could affect command safety checks.

--- a/packages/tree-sitter-bash/src/lexer.ts
+++ b/packages/tree-sitter-bash/src/lexer.ts
@@ -566,7 +566,7 @@ export class Lexer {
         // A line continuation ends the run (it acts as whitespace); a lone
         // trailing backslash at end of range is consumed as word text.
         if (this.source[i + 1] === '\n') break;
-        i += 2;
+        i = Math.min(i + 2, this.end);
         continue;
       }
       if (ch === '"') {

--- a/packages/tree-sitter-bash/src/parser.ts
+++ b/packages/tree-sitter-bash/src/parser.ts
@@ -1031,7 +1031,7 @@ export class Parser {
       const ch = this.source[j]!;
       if (ch === '\n' || ch === ';') break; // defensive: malformed item
       if (ch === '\\') {
-        j += 2;
+        j = Math.min(j + 2, end);
         continue;
       }
       if (ch === '"') {
@@ -3482,7 +3482,7 @@ export class Parser {
         continue;
       }
       if (c === '\\') {
-        j += 2;
+        j = Math.min(j + 2, end);
         continue;
       }
       j++;
@@ -3652,7 +3652,7 @@ export class Parser {
       const ch = this.source[j]!;
       if (ch === '\n') break;
       if (ch === '\\') {
-        j += 2;
+        j = Math.min(j + 2, end);
         continue;
       }
       if (ch === '"') {

--- a/packages/tree-sitter-bash/test/parse.test.ts
+++ b/packages/tree-sitter-bash/test/parse.test.ts
@@ -375,6 +375,27 @@ describe('statement lists', () => {
     expectTree('ls |', `(program (pipeline (command (command_name (word "ls"))) "|"))`, true);
   });
 
+  it('keeps a lone trailing backslash as word text instead of degrading the whole parse', () => {
+    expectTree('echo \\', `(program (command (command_name (word "echo")) (word "\\\\")))`);
+    expectTree('\\', `(program (command (command_name (word "\\\\"))))`);
+  });
+
+  it('recovers a test command whose expression ends in a lone trailing backslash', () => {
+    expectTree(
+      '[[ -f x && \\',
+      `(program (test_command "[[" (binary_expression (unary_expression (test_operator "-f") (word "x")) "&&" (word "\\\\")) "]]"))`,
+      true,
+    );
+  });
+
+  it('recovers a case item pattern that ends in a lone trailing backslash', () => {
+    expectTree(
+      'case x in a\\',
+      `(program (case_statement "case" (word "x") "in" (case_item (word "a\\\\"))))`,
+      true,
+    );
+  });
+
   it('continues a list across a newline after &&', () => {
     expectTree(
       'a &&\nb',


### PR DESCRIPTION
Fixes #3237.

## What changed
- `packages/tree-sitter-bash/src/lexer.ts`
- `packages/tree-sitter-bash/src/parser.ts`
- `packages/tree-sitter-bash/test/parse.test.ts`
- `.changeset/fix-trailing-backslash-bash-parse.md`

## Verification
The project's own test suite was run before and after this change; it introduces no new test failures or lint violations.