### PR TITLE
feat(kap-server): advertise transcript prompt entities in /meta capabilities

### DIFF
--- a/packages/kap-server/src/protocol/rest-meta.ts
+++ b/packages/kap-server/src/protocol/rest-meta.ts
@@ -11,6 +11,7 @@ export const metaCapabilitiesSchema = z.object({
   mcp: z.literal(true),
   tasks: z.literal(true),
   terminal: z.literal(true),
+  transcript_prompts: z.literal(true),
 });
 
 export type MetaCapabilities = z.infer<typeof metaCapabilitiesSchema>;

--- a/packages/kap-server/src/routes/meta.ts
+++ b/packages/kap-server/src/routes/meta.ts
@@ -34,6 +34,7 @@ export function registerMetaRoute(app: RouteHost, opts: MetaRouteOptions): void 
       mcp: true as const,
       tasks: true as const,
       terminal: true as const,
+      transcript_prompts: true as const,
     }),
     server_id: opts.serverId,
     started_at: opts.startedAt,

--- a/packages/kap-server/test/meta.test.ts
+++ b/packages/kap-server/test/meta.test.ts
@@ -108,6 +108,38 @@ describe('/api/v1/meta experimental_flags', () => {
   });
 });
 
+describe('/api/v1/meta capabilities', () => {
+  let server: RunningServer | undefined;
+  let home: string | undefined;
+
+  afterEach(async () => {
+    if (server !== undefined) {
+      await server.close();
+      server = undefined;
+    }
+    if (home !== undefined) {
+      await rm(home, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
+      home = undefined;
+    }
+  });
+
+  it('advertises transcript prompt entities', async () => {
+    home = await mkdtemp(join(tmpdir(), 'kimi-server-v2-meta-'));
+    server = await startServer({
+      hostIdentity: TEST_HOST_IDENTITY,
+      host: '127.0.0.1',
+      port: 0,
+      homeDir: home,
+      logLevel: 'silent',
+    });
+    const res = await authedFetch(server, `http://127.0.0.1:${server.port}`, '/api/v1/meta');
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { code: number; data: { capabilities?: Record<string, boolean> } };
+    expect(body.code).toBe(0);
+    expect(body.data.capabilities?.['transcript_prompts']).toBe(true);
+  });
+});
+
 describe('/api/v1/meta web_title', () => {
   let server: RunningServer | undefined;
   let home: string | undefined;


### PR DESCRIPTION
## Problem

Clients driving the main transcript from the transcript protocol (kimi-code-app #279 onward) need the daemon's **prompt entities** (live `prompt.upsert` ops + the `prompts` field of the transcript read) to reconcile their optimistic user bubbles. That capability only exists since #3102 — older daemons never broadcast prompt entities, so a new client connected to an old daemon renders every sent message twice for the whole turn.

The app's migration plan explicitly decided *not* to build old-daemon fallbacks — but to surface the skew loudly instead of silently misbehaving. That requires the daemon to advertise the capability so clients can detect its absence.

## Change

Add `transcript_prompts: true` to the `capabilities` object of `GET /api/v1/meta` (route + wire schema). The flag is additive: older clients ignore unknown capability keys.

A client that requires prompt entities can then warn clearly ("server too old") when the key is absent, instead of showing duplicated messages.

## Tests

- New case in `packages/kap-server/test/meta.test.ts` asserting the capability is advertised.
- `pnpm --filter @moonshot-ai/kap-server typecheck`, repo `check-no-comments`, and oxlint on the touched packages all pass.

No changeset: internal protocol surface, not user-perceivable per the gen-changesets rules.
