### PR TITLE
fix(kap-server): project steered messages as live user frames in the transcript

### DIFF
--- a/packages/agent-core-v2/src/agent/loop/turnOps.ts
+++ b/packages/agent-core-v2/src/agent/loop/turnOps.ts
@@ -51,6 +51,7 @@ const turnSteerSchema = z.object(turnInputShape);
 export class TurnSteer extends AgentEvent2<z.infer<typeof turnSteerSchema>> {
   static override readonly type = 'turn.steer';
   static override readonly durable = true;
+  static override readonly observable = true;
   static override readonly schema = turnSteerSchema;
 }
 export interface TurnSteer {

--- a/packages/agent-core-v2/test/agent/prompt/promptService.test.ts
+++ b/packages/agent-core-v2/test/agent/prompt/promptService.test.ts
@@ -11,6 +11,7 @@ import type { ContextMessage } from '#/agent/contextMemory/types';
 import type { ContentPart } from '#/kosong/contract/message';
 import { IAgentFullCompactionService } from '#/agent/fullCompaction/fullCompaction';
 import { IAgentLoopService } from '#/agent/loop/loop';
+import { TurnSteer } from '#/agent/loop/turnOps';
 import { IAgentPromptService } from '#/agent/prompt/prompt';
 import { AgentPromptService, PromptQueued, PromptStarted, PromptSteered, PromptSubmitted } from '#/agent/prompt/promptService';
 import { IAgentScopeContext, makeAgentScopeContext } from '#/agent/scopeContext/scopeContext';
@@ -200,6 +201,28 @@ describe('AgentPromptService', () => {
     const handles = await prompt.steer([two.id, one.id]);
     expect(handles.map((item) => item.id)).toEqual([one.id, two.id]);
     loop.drainNextBatch(context);
+  });
+
+  it('publishes turn.steer at materialize time without altering the wire payload shape', async () => {
+    const { prompt, context, loop, eventBus } = harness();
+    const events: TurnSteer[] = [];
+    eventBus.subscribe(TurnSteer, (event) => events.push(event));
+    const active = await prompt.enqueue({ message: message('active') });
+    await active.launched;
+    const one = await prompt.enqueue({ message: message('one') });
+    const two = await prompt.enqueue({ message: message('two') });
+
+    await prompt.steer([two.id, one.id]);
+    loop.drainNextBatch(context);
+    await Promise.resolve();
+
+    expect(events).toHaveLength(1);
+    expect(events[0]?.input).toEqual([
+      { type: 'text', text: 'one' },
+      { type: 'text', text: 'two' },
+    ]);
+    expect(events[0]).not.toHaveProperty('messageId');
+    expect(events[0]).not.toHaveProperty('promptIds');
   });
 
   it('aborts pending prompts and settles completion', async () => {

--- a/packages/kap-server/src/services/transcript/coreEventMap.ts
+++ b/packages/kap-server/src/services/transcript/coreEventMap.ts
@@ -7,7 +7,7 @@ import type {
   CompactionCompleted,
   CompactionStarted,
 } from '@moonshot-ai/agent-core-v2/agent/fullCompaction/compactionOps';
-import type { ContentPart, ContextUndone, CronFired, GoalUpdated } from '@moonshot-ai/agent-core-v2';
+import { daemonFileRefFromPart, type ContentPart, type ContextUndone, type CronFired, type GoalUpdated } from '@moonshot-ai/agent-core-v2';
 import type {
   AssistantDelta,
   ThinkingDelta,
@@ -17,7 +17,7 @@ import type {
   TurnStepInterrupted,
   TurnStepStarted,
 } from '@moonshot-ai/agent-core-v2/agent/loop/turnEvents';
-import type { TurnEnded } from '@moonshot-ai/agent-core-v2/agent/loop/turnOps';
+import type { TurnEnded, TurnSteer } from '@moonshot-ai/agent-core-v2/agent/loop/turnOps';
 import type { AgentErrorEvent } from '@moonshot-ai/agent-core-v2/agent/mcp/mcpEvents';
 import type { PluginCommandActivated } from '@moonshot-ai/agent-core-v2/agent/pluginCommand/pluginCommand';
 import type { WarningIssued } from '@moonshot-ai/agent-core-v2/agent/profile/profileOps';
@@ -99,6 +99,7 @@ type PromptStartedEvent = { readonly type: 'prompt.started' } & PromptStarted;
 type PromptCompletedEvent = { readonly type: 'prompt.completed' } & PromptCompleted;
 type PromptAbortedEvent = { readonly type: 'prompt.aborted' } & PromptAborted;
 type PromptSteeredEvent = { readonly type: 'prompt.steered' } & PromptSteered;
+type TurnSteerEvent = { readonly type: 'turn.steer' } & TurnSteer;
 
 export type ProjectorBusEvent =
   | PlanRevisionEvent
@@ -135,6 +136,7 @@ export type ProjectorBusEvent =
   | PromptCompletedEvent
   | PromptAbortedEvent
   | PromptSteeredEvent
+  | TurnSteerEvent
   | ({ readonly type: 'hook.result' } & HookResult)
   | ({ readonly type: 'skill.activated' } & SkillActivated)
   | ({ readonly type: 'plugin_command.activated' } & PluginCommandActivated)
@@ -185,8 +187,11 @@ export class AgentTranscriptProjector {
   private currentTurn: TurnHeader | undefined;
   private currentStep: StepHeader | undefined;
   private pendingTaskNotifications: { text: string; taskId: string | undefined }[] = [];
+  private pendingSteers: { input: readonly ContentPart[]; promptIds: readonly string[] | undefined }[] = [];
+  private unpairedSteerPromptIds: string[][] = [];
   private readonly stepOrdinals = new Map<string, number>();
   private frameOrdinal = 0;
+  private attachmentOrdinal = 0;
   private openText: OpenTextFrame | undefined;
   private openThinking: OpenTextFrame | undefined;
   private readonly toolFrames = new Map<string, ToolFrameRecord>();
@@ -294,6 +299,8 @@ export class AgentTranscriptProjector {
         return this.onPromptAborted(event);
       case 'prompt.steered':
         return this.onPromptSteered(event);
+      case 'turn.steer':
+        return this.onTurnSteered(event);
       case 'hook.result':
         return [this.markerOp('hook', restOf(event))];
       case 'skill.activated':
@@ -356,6 +363,7 @@ export class AgentTranscriptProjector {
     };
     this.currentStep = undefined;
     this.pendingTaskNotifications = [];
+    this.pendingSteers = [];
     this.openText = undefined;
     this.openThinking = undefined;
     ops.push({ op: 'turn.upsert', turn: this.currentTurn });
@@ -379,6 +387,12 @@ export class AgentTranscriptProjector {
       this.currentStep = step;
       ops.push({ op: 'step.upsert', turnId: step.turnId, step });
     }
+    if (this.currentStep !== undefined) {
+      for (const pending of this.pendingSteers) {
+        this.steerUserFrame(ops, turnId, this.currentStep.stepId, pending.input, pending.promptIds);
+      }
+    }
+    this.pendingSteers = [];
     const prev =
       this.currentTurn?.turnId === turnId ? this.currentTurn : this.lookups?.turn?.(turnId);
     const state = mapTurnEndState(event.reason);
@@ -442,6 +456,7 @@ export class AgentTranscriptProjector {
       startedAt: nowIso(),
     };
     this.frameOrdinal = 0;
+    this.attachmentOrdinal = 0;
     this.openText = undefined;
     this.openThinking = undefined;
     const ops: TranscriptOperation[] = [{ op: 'step.upsert', turnId, step: this.currentStep }];
@@ -460,6 +475,10 @@ export class AgentTranscriptProjector {
       });
     }
     this.pendingTaskNotifications = [];
+    for (const pending of this.pendingSteers) {
+      this.steerUserFrame(ops, turnId, stepId, pending.input, pending.promptIds);
+    }
+    this.pendingSteers = [];
     return ops;
   }
 
@@ -1335,6 +1354,7 @@ export class AgentTranscriptProjector {
       steeredAt: event.steeredAt,
     }));
     ops.push({ op: 'prompt.upsert', prompt: active });
+    this.unpairedSteerPromptIds.push([...event.promptIds]);
     for (const promptId of event.promptIds) {
       const steered = this.upsertPrompt(promptId, (prev) => ({
         promptId,
@@ -1348,6 +1368,62 @@ export class AgentTranscriptProjector {
       ops.push({ op: 'prompt.upsert', prompt: steered });
     }
     return ops;
+  }
+
+  private onTurnSteered(event: TurnSteerEvent): TranscriptOperation[] {
+    const origin = event.origin;
+    if (origin?.kind !== 'user') return [];
+    const turn = this.currentTurn;
+    if (turn !== undefined && turn.state !== 'running') return [];
+    const skip = origin.skillActivations?.length ?? 0;
+    const input = skip > 0 ? event.input.slice(skip) : event.input;
+    const step = this.currentStep;
+    if (step !== undefined && step.state === 'running') {
+      const ops: TranscriptOperation[] = [];
+      this.steerUserFrame(ops, step.turnId, step.stepId, input, this.unpairedSteerPromptIds.shift());
+      return ops;
+    }
+    this.pendingSteers.push({ input, promptIds: this.unpairedSteerPromptIds.shift() });
+    return [];
+  }
+
+  private steerUserFrame(
+    ops: TranscriptOperation[],
+    turnId: string,
+    stepId: string,
+    input: readonly ContentPart[],
+    promptIds: readonly string[] | undefined,
+  ): void {
+    const texts: string[] = [];
+    const attachmentIds: string[] = [];
+    for (const part of input) {
+      if (part.type === 'text') {
+        texts.push(part.text);
+        continue;
+      }
+      const ref = daemonFileRefFromPart(part);
+      if (ref === undefined) continue;
+      const attachment: TranscriptAttachment = {
+        attachmentId: `${stepId}.att${++this.attachmentOrdinal}`,
+        mediaType: `${ref.kind}/*`,
+        source: { kind: 'session_media', fileId: ref.ref.fileId },
+      };
+      ops.push({ op: 'attachment.upsert', attachment });
+      attachmentIds.push(attachment.attachmentId);
+    }
+    ops.push({
+      op: 'frame.upsert',
+      turnId,
+      stepId,
+      frame: {
+        kind: 'text',
+        frameId: `${stepId}.f${++this.frameOrdinal}`,
+        role: 'user',
+        text: texts.join(''),
+        attachmentIds: attachmentIds.length > 0 ? attachmentIds : undefined,
+        promptIds,
+      },
+    });
   }
 
   private upsertPrompt(

--- a/packages/kap-server/src/services/transcript/transcriptService.ts
+++ b/packages/kap-server/src/services/transcript/transcriptService.ts
@@ -465,6 +465,7 @@ export class TranscriptService {
     }
     const messages = [...reduceContextTranscript(records).entries];
     const taskOriginTurnTaskIds = new Set<string>();
+    const steeredContents = new Map<string, number>();
     const anchorStack: { taskIdsSnapshot: Set<string> }[] = [];
     let anchorFloor = 0;
     let sawTurnPrompt = false;
@@ -489,6 +490,14 @@ export class TranscriptService {
         }
         continue;
       }
+      if (record.type === 'turn.steer') {
+        const input = record['input'];
+        if (Array.isArray(input)) {
+          const key = JSON.stringify(input);
+          steeredContents.set(key, (steeredContents.get(key) ?? 0) + 1);
+        }
+        continue;
+      }
       if (record.type !== 'turn.prompt') continue;
       sawTurnPrompt = true;
       const origin = (record as { origin?: { kind?: unknown; taskId?: unknown } }).origin;
@@ -502,7 +511,7 @@ export class TranscriptService {
     }
     const base = groupMessagesIntoSnapshot(
       messages,
-      sawTurnPrompt ? { taskOriginTurnTaskIds } : undefined,
+      sawTurnPrompt || steeredContents.size > 0 ? { taskOriginTurnTaskIds, steeredContents } : undefined,
     );
     const folded = foldWireRecordFacts(records, base);
     const status = getLiveSessionById(this.deps.core.accessor, sessionId)

--- a/packages/kap-server/src/transport/ws/v1/sessionEventBroadcaster.ts
+++ b/packages/kap-server/src/transport/ws/v1/sessionEventBroadcaster.ts
@@ -1153,6 +1153,7 @@ const TRANSCRIPT_PROJECTED_EVENT_TYPES: ReadonlySet<string> = new Set([
   'prompt.completed',
   'prompt.aborted',
   'prompt.steered',
+  'turn.steer',
   'event.question.requested',
   'event.question.dismissed',
   'event.question.answered',

--- a/packages/kap-server/test/services/transcript.test.ts
+++ b/packages/kap-server/test/services/transcript.test.ts
@@ -1900,6 +1900,197 @@ describe('AgentTranscriptProjector', () => {
     ]);
   });
 
+  it('projects turn.steer as a user frame at the next step start, pairing promptIds from prompt.steered', () => {
+    const projector = new AgentTranscriptProjector('main');
+    const tx = new AgentTranscript('main');
+    const feed = (event: ProjectorBusEvent): void => void tx.apply(projector.map(event));
+
+    feed(ev({ type: 'turn.started', turnId: 3, origin: { kind: 'user' }, prompt: 'active' }));
+    feed(ev({ type: 'turn.step.started', turnId: 3, step: 1 }));
+    feed(ev({ type: 'turn.step.completed', turnId: 3, step: 1 }));
+    feed(
+      ev({
+        type: 'prompt.steered',
+        activePromptId: 'p1',
+        promptIds: ['p2'],
+        content: [{ type: 'text', text: 'steered in' }],
+        steeredAt: '2026-01-01T00:00:02.000Z',
+      }),
+    );
+    feed(
+      ev({
+        type: 'turn.steer',
+        input: [{ type: 'text', text: 'steered in' }],
+        origin: { kind: 'user' },
+      }),
+    );
+    expect(turnOps('t3', tx.getItems()).steps).toHaveLength(1);
+
+    feed(ev({ type: 'turn.step.started', turnId: 3, step: 2 }));
+    const turn = turnOps('t3', tx.getItems());
+    expect(turn.steps).toHaveLength(2);
+    expect(turn.steps[1]?.frames[0]).toMatchObject({
+      kind: 'text',
+      role: 'user',
+      text: 'steered in',
+      promptIds: ['p2'],
+    });
+  });
+
+  it('projects turn.steer into the running step immediately, with daemon media as attachments', () => {
+    const projector = new AgentTranscriptProjector('main');
+    const tx = new AgentTranscript('main');
+    const ops: TranscriptOperation[] = [];
+    const feed = (event: ProjectorBusEvent): void => {
+      const mapped = projector.map(event);
+      ops.push(...mapped);
+      tx.apply(mapped);
+    };
+
+    feed(ev({ type: 'turn.started', turnId: 4, origin: { kind: 'user' }, prompt: 'active' }));
+    feed(ev({ type: 'turn.step.started', turnId: 4, step: 1 }));
+    feed(
+      ev({
+        type: 'prompt.steered',
+        activePromptId: 'p1',
+        promptIds: ['p2', 'p3'],
+        content: [
+          { type: 'text', text: 'look at this' },
+          {
+            type: 'image_url',
+            imageUrl: { url: 'kimi-file://f_img9?path=%2Fabs%2Fsession%2Fmedia%2Ff_img9.png' },
+          },
+        ],
+        steeredAt: '2026-01-01T00:00:02.000Z',
+      }),
+    );
+    feed(
+      ev({
+        type: 'turn.steer',
+        input: [
+          { type: 'text', text: 'look at this' },
+          {
+            type: 'image_url',
+            imageUrl: { url: 'kimi-file://f_img9?path=%2Fabs%2Fsession%2Fmedia%2Ff_img9.png' },
+          },
+        ],
+        origin: { kind: 'user' },
+      }),
+    );
+
+    const attachmentOp = ops.find((op) => op.op === 'attachment.upsert');
+    expect(attachmentOp).toMatchObject({
+      attachment: { mediaType: 'image/*', source: { kind: 'session_media', fileId: 'f_img9' } },
+    });
+    const frame = turnOps('t4', tx.getItems()).steps[0]?.frames[0];
+    expect(frame).toMatchObject({ kind: 'text', role: 'user', text: 'look at this', promptIds: ['p2', 'p3'] });
+    expect(frame?.kind === 'text' ? frame.attachmentIds : undefined).toEqual([
+      attachmentOp?.op === 'attachment.upsert' ? attachmentOp.attachment.attachmentId : undefined,
+    ]);
+  });
+
+  it('ignores turn.steer for non-user origins and for turns that are not running', () => {
+    const projector = new AgentTranscriptProjector('main');
+    const tx = new AgentTranscript('main');
+    const feed = (event: ProjectorBusEvent): void => void tx.apply(projector.map(event));
+
+    feed(ev({ type: 'turn.started', turnId: 5, origin: { kind: 'user' }, prompt: 'active' }));
+    feed(ev({ type: 'turn.step.started', turnId: 5, step: 1 }));
+    feed(
+      ev({
+        type: 'turn.steer',
+        input: [{ type: 'text', text: 'backgrounded output' }],
+        origin: { kind: 'injection', variant: 'shell_command_backgrounded' },
+      }),
+    );
+    expect(turnOps('t5', tx.getItems()).steps[0]?.frames).toHaveLength(0);
+
+    feed(ev({ type: 'turn.step.completed', turnId: 5, step: 1 }));
+    feed(ev({ type: 'turn.ended', turnId: 5, reason: 'completed' }));
+    feed(
+      ev({
+        type: 'turn.steer',
+        input: [{ type: 'text', text: 'too late' }],
+        origin: { kind: 'user' },
+      }),
+    );
+    expect(
+      turnOps('t5', tx.getItems()).steps.flatMap((step) => step.frames),
+    ).toHaveLength(0);
+  });
+
+  it('flushes a pending steer into the last step when the turn ends before the next step', () => {
+    const projector = new AgentTranscriptProjector('main');
+    const tx = new AgentTranscript('main');
+    const feed = (event: ProjectorBusEvent): void => void tx.apply(projector.map(event));
+
+    feed(ev({ type: 'turn.started', turnId: 6, origin: { kind: 'user' }, prompt: 'active' }));
+    feed(ev({ type: 'turn.step.started', turnId: 6, step: 1 }));
+    feed(ev({ type: 'turn.step.completed', turnId: 6, step: 1 }));
+    feed(
+      ev({
+        type: 'prompt.steered',
+        activePromptId: 'p1',
+        promptIds: ['p2'],
+        content: [{ type: 'text', text: 'last word' }],
+        steeredAt: '2026-01-01T00:00:02.000Z',
+      }),
+    );
+    feed(
+      ev({
+        type: 'turn.steer',
+        input: [{ type: 'text', text: 'last word' }],
+        origin: { kind: 'user' },
+      }),
+    );
+    feed(ev({ type: 'turn.ended', turnId: 6, reason: 'cancelled', interruptReason: 'user_cancelled' }));
+
+    const turn = turnOps('t6', tx.getItems());
+    const lastStep = turn.steps.at(-1);
+    expect(lastStep?.frames.at(-1)).toMatchObject({
+      kind: 'text',
+      role: 'user',
+      text: 'last word',
+      promptIds: ['p2'],
+    });
+  });
+
+  it('buffers turn.steer seen before the projector ever saw turn.started (mid-turn attach)', () => {
+    const projector = new AgentTranscriptProjector('main');
+    const tx = new AgentTranscript('main');
+    const ops: TranscriptOperation[] = [];
+    const feed = (event: ProjectorBusEvent): void => {
+      ops.push(...projector.map(event));
+    };
+
+    feed(
+      ev({
+        type: 'prompt.steered',
+        activePromptId: 'p1',
+        promptIds: ['p2'],
+        content: [{ type: 'text', text: 'steered mid-attach' }],
+        steeredAt: '2026-01-01T00:00:02.000Z',
+      }),
+    );
+    feed(
+      ev({
+        type: 'turn.steer',
+        input: [{ type: 'text', text: 'steered mid-attach' }],
+        origin: { kind: 'user' },
+      }),
+    );
+    expect(ops).toHaveLength(2);
+    expect(ops.every((op) => op.op === 'prompt.upsert')).toBe(true);
+
+    feed(ev({ type: 'turn.step.started', turnId: 3, step: 2 }));
+    const frameOp = ops.find((op) => op.op === 'frame.upsert');
+    expect(frameOp).toMatchObject({
+      turnId: 't3',
+      stepId: 't3.2',
+      frame: { kind: 'text', role: 'user', text: 'steered mid-attach', promptIds: ['p2'] },
+    });
+  });
+
   it('readColdSnapshot answers empty for path-hostile agent ids without touching disk', async () => {
     const service = new TranscriptService({
       homeDir: '/nonexistent-home',
@@ -2118,6 +2309,36 @@ describe('AgentTranscriptProjector', () => {
       expect(
         turn.steps.flatMap((step) => step.frames).some((f) => f.kind === 'text' && f.role === 'user'),
       ).toBe(true);
+    } finally {
+      await rm(home, { recursive: true, force: true });
+    }
+  });
+
+  it('readColdSnapshot folds a steered user message into its turn instead of opening a new one', async () => {
+    const home = await mkdtemp(join(tmpdir(), 'transcript-cold-steer-'));
+    try {
+      const wireDir = join(home, 'sessions', 'ws', 's1', 'agents', 'main');
+      await mkdir(wireDir, { recursive: true });
+      const records = [
+        { type: 'context.append_message', message: { role: 'user', content: [{ type: 'text', text: 'active' }], toolCalls: [], origin: { kind: 'user' } }, time: 1000 },
+        { type: 'context.append_message', message: { role: 'assistant', content: [{ type: 'text', text: 'working' }], toolCalls: [] }, time: 2000 },
+        { type: 'turn.steer', input: [{ type: 'text', text: 'steered in' }], origin: { kind: 'user' }, time: 3000 },
+        { type: 'context.append_message', message: { role: 'user', content: [{ type: 'text', text: 'steered in' }], toolCalls: [], origin: { kind: 'user' } }, time: 3001 },
+        { type: 'context.append_message', message: { role: 'assistant', content: [{ type: 'text', text: 'noted' }], toolCalls: [] }, time: 4000 },
+      ];
+      await writeFile(join(wireDir, 'wire.jsonl'), `${records.map((r) => JSON.stringify(r)).join('\n')}\n`);
+
+      const snapshot = await coldTranscriptService(home).readColdSnapshot('s1', 'main');
+      const turns = snapshot!.items.filter((item) => item.kind === 'turn');
+      expect(turns).toHaveLength(1);
+      const turn = turns[0];
+      if (turn?.kind !== 'turn') throw new Error('expected turn');
+      expect(turn.steps).toHaveLength(2);
+      expect(turn.steps[1]?.frames[0]).toMatchObject({
+        kind: 'text',
+        role: 'user',
+        text: 'steered in',
+      });
     } finally {
       await rm(home, { recursive: true, force: true });
     }

--- a/packages/transcript/src/contract/schema.ts
+++ b/packages/transcript/src/contract/schema.ts
@@ -69,6 +69,7 @@ export const textFrameSchema = z.object({
   text: z.string(),
   attachmentIds: z.array(z.string()).optional(),
   taskId: taskIdSchema.optional(),
+  promptIds: z.array(z.string()).optional(),
 });
 
 export const thinkingFrameSchema = z.object({

--- a/packages/transcript/src/history/groupTurns.ts
+++ b/packages/transcript/src/history/groupTurns.ts
@@ -67,12 +67,20 @@ export function groupMessagesIntoSnapshot(
   messages: readonly HistoryMessage[],
   options?: {
     readonly taskOriginTurnTaskIds?: ReadonlySet<string>;
+    readonly steeredContents?: ReadonlyMap<string, number>;
   },
 ): AgentTranscriptSnapshot {
   const items: TranscriptItem[] = [];
   const attachments: TranscriptAttachment[] = [];
+  const steeredContents = new Map(options?.steeredContents ?? []);
   let turn: TurnDraft | undefined;
-  let pendingNotificationFrames: { text: string; taskId: string | undefined }[] = [];
+  let pendingNotificationFrames: {
+    text: string;
+    taskId: string | undefined;
+    attachmentIds?: string[];
+    promptIds?: readonly string[];
+    steered?: boolean;
+  }[] = [];
   let nextOrdinal = 0;
   let markerCount = 0;
 
@@ -141,7 +149,30 @@ export function groupMessagesIntoSnapshot(
     return turn;
   };
 
+  const flushSteeredLeftovers = (): void => {
+    const leftovers = pendingNotificationFrames.filter((pending) => pending.steered);
+    if (leftovers.length === 0) return;
+    pendingNotificationFrames = pendingNotificationFrames.filter((pending) => !pending.steered);
+    for (const pending of leftovers) {
+      const lastStep = turn?.steps.at(-1);
+      if (turn === undefined || lastStep === undefined) {
+        startTurn({ kind: 'user' }, pending.text, pending.attachmentIds);
+        continue;
+      }
+      lastStep.frames.push({
+        kind: 'text',
+        frameId: `${lastStep.stepId}.f${lastStep.frames.length + 1}`,
+        role: 'user',
+        text: pending.text,
+        attachmentIds: pending.attachmentIds,
+        promptIds: pending.promptIds,
+      });
+      syncTurnItem(items, turn);
+    }
+  };
+
   const startTurn = (origin: TurnOrigin, prompt?: string, attachmentIds?: string[]): TurnDraft => {
+    flushSteeredLeftovers();
     const ordinal = nextOrdinal;
     nextOrdinal += 1;
     pendingNotificationFrames = [];
@@ -170,6 +201,28 @@ export function groupMessagesIntoSnapshot(
         if (opensOwnTurn(message)) {
           startTurn(mapOrigin(message));
         }
+        continue;
+      }
+      const contentKey = JSON.stringify(message.content ?? []);
+      const steeredRemaining = steeredContents.get(contentKey) ?? 0;
+      if (steeredRemaining > 0) {
+        steeredContents.set(contentKey, steeredRemaining - 1);
+        const bundled = bundledSkillActivations(message);
+        const parts = message.content ?? [];
+        bundled.forEach((activation, index) => {
+          const block = parts[index];
+          pushMarker('skill', {
+            text: block !== undefined && block.type === 'text' && 'text' in block ? block.text : '',
+            origin: { kind: 'skill_activation', trigger: 'user-slash', ...activation },
+          });
+        });
+        const opening = foldTurnOpeningInput({ ...message, content: parts.slice(bundled.length) });
+        pendingNotificationFrames.push({
+          text: opening.text,
+          taskId: undefined,
+          attachmentIds: opening.attachmentIds,
+          steered: true,
+        });
         continue;
       }
       const markerKey = originKind !== undefined ? MARKER_USER_ORIGINS[originKind] : undefined;
@@ -238,6 +291,8 @@ export function groupMessagesIntoSnapshot(
           role: 'user',
           text: pending.text,
           taskId: pending.taskId,
+          attachmentIds: pending.attachmentIds,
+          promptIds: pending.promptIds,
         });
       }
       pendingNotificationFrames = [];
@@ -277,6 +332,8 @@ export function groupMessagesIntoSnapshot(
       }
     }
   }
+
+  flushSteeredLeftovers();
 
   return { items, tasks: [], interactions: [], attachments, todos: [], prompts: [], meta: {} };
 }

--- a/packages/transcript/src/model/frame.ts
+++ b/packages/transcript/src/model/frame.ts
@@ -14,6 +14,7 @@ export interface TextFrame {
   readonly text: string;
   readonly attachmentIds?: readonly AttachmentId[];
   readonly taskId?: TaskId;
+  readonly promptIds?: readonly string[];
 }
 
 export interface ThinkingFrame {

--- a/packages/transcript/test/layers.test.ts
+++ b/packages/transcript/test/layers.test.ts
@@ -498,6 +498,88 @@ describe('groupMessagesIntoSnapshot (cold path)', () => {
     ]);
   });
 
+  it('folds a user message whose content matches a turn.steer record into the current turn as a user frame', () => {
+    const snapshot = groupMessagesIntoSnapshot(
+      [
+        { role: 'user', content: [{ type: 'text', text: 'active' }], toolCalls: [], origin: { kind: 'user' } },
+        { role: 'assistant', content: [{ type: 'text', text: 'working' }], toolCalls: [] },
+        { role: 'user', content: [{ type: 'text', text: 'steered in' }], toolCalls: [], origin: { kind: 'user' } },
+        { role: 'assistant', content: [{ type: 'text', text: 'noted' }], toolCalls: [] },
+      ],
+      { steeredContents: new Map([[JSON.stringify([{ type: 'text', text: 'steered in' }]), 1]]) },
+    );
+
+    expect(snapshot.items.map((i) => i.kind)).toEqual(['turn']);
+    const turn = snapshot.items[0];
+    if (turn?.kind !== 'turn') throw new Error('expected turn');
+    expect(turn.steps).toHaveLength(2);
+    expect(turn.steps[1]?.frames[0]).toMatchObject({
+      kind: 'text',
+      role: 'user',
+      text: 'steered in',
+    });
+  });
+
+  it('keeps a trailing steered message visible by appending it to the last step', () => {
+    const snapshot = groupMessagesIntoSnapshot(
+      [
+        { role: 'user', content: [{ type: 'text', text: 'active' }], toolCalls: [], origin: { kind: 'user' } },
+        { role: 'assistant', content: [{ type: 'text', text: 'working' }], toolCalls: [] },
+        { role: 'user', content: [{ type: 'text', text: 'steered in' }], toolCalls: [], origin: { kind: 'user' } },
+      ],
+      { steeredContents: new Map([[JSON.stringify([{ type: 'text', text: 'steered in' }]), 1]]) },
+    );
+
+    expect(snapshot.items.map((i) => i.kind)).toEqual(['turn']);
+    const turn = snapshot.items[0];
+    if (turn?.kind !== 'turn') throw new Error('expected turn');
+    const lastStep = turn.steps.at(-1);
+    expect(lastStep?.frames.at(-1)).toMatchObject({
+      kind: 'text',
+      role: 'user',
+      text: 'steered in',
+    });
+  });
+
+  it('flushes a pending steer into the closing turn when a new turn opens before any reply', () => {
+    const snapshot = groupMessagesIntoSnapshot(
+      [
+        { role: 'user', content: [{ type: 'text', text: 'active' }], toolCalls: [], origin: { kind: 'user' } },
+        { role: 'assistant', content: [{ type: 'text', text: 'working' }], toolCalls: [] },
+        { role: 'user', content: [{ type: 'text', text: 'steered in' }], toolCalls: [], origin: { kind: 'user' } },
+        { role: 'user', content: [{ type: 'text', text: 'next question' }], toolCalls: [], origin: { kind: 'user' } },
+        { role: 'assistant', content: [{ type: 'text', text: 'answer' }], toolCalls: [] },
+      ],
+      { steeredContents: new Map([[JSON.stringify([{ type: 'text', text: 'steered in' }]), 1]]) },
+    );
+
+    const turns = snapshot.items.filter((i) => i.kind === 'turn');
+    expect(turns).toHaveLength(2);
+    const first = turns[0];
+    if (first?.kind !== 'turn') throw new Error('expected turn');
+    expect(first.steps.at(-1)?.frames.at(-1)).toMatchObject({
+      kind: 'text',
+      role: 'user',
+      text: 'steered in',
+    });
+    const second = turns[1];
+    if (second?.kind !== 'turn') throw new Error('expected turn');
+    expect(second.prompt).toBe('next question');
+  });
+
+  it('still opens its own turn for a mid-conversation user message unknown to the steer map', () => {
+    const snapshot = groupMessagesIntoSnapshot(
+      [
+        { role: 'user', content: [{ type: 'text', text: 'active' }], toolCalls: [], origin: { kind: 'user' } },
+        { role: 'assistant', content: [{ type: 'text', text: 'working' }], toolCalls: [] },
+        { role: 'user', content: [{ type: 'text', text: 'plain follow-up' }], toolCalls: [], origin: { kind: 'user' } },
+      ],
+      { steeredContents: new Map([[JSON.stringify([{ type: 'text', text: 'steered in' }]), 1]]) },
+    );
+
+    expect(snapshot.items.map((i) => i.kind)).toEqual(['turn', 'turn']);
+  });
+
   it('stops folded notification text before child output blocks', () => {
     const xml = [
       '<notification id="task:task-9:completed" category="task" type="task.completed" source_kind="background_task" source_id="task-9">',


### PR DESCRIPTION
## Related Issue

No linked issue — fixes a live-transcript regression reported internally (a steered message vanishes from the live view).

## Problem

Steering a queued prompt into the running turn makes its optimistic bubble vanish instantly, and the message never reappears in the live transcript; it only comes back — as a wrong, standalone turn — after a cold rebuild. The daemon's live transcript projection never mapped the steered message body into the transcript: `prompt.steered` only updates prompt queue entities (and is suppressed for transcript-protocol connections), so nothing tells the client where the steered message landed.

The durable `turn.steer` event already fires at the exact materialize moment, but it never reached the live projector (non-observable events are not published to the in-process event bus), and the cold rebuild ignored it.

## What changed

The wire format is deliberately untouched: `turn.steer` records keep their exact previous shape; all correlation happens against facts already persisted.

- agent-core-v2: `turn.steer` becomes `observable` so the live transcript projector receives it over the in-process event bus. No payload/schema change — wire records are byte-identical to before.
- kap-server: the transcript projector maps `turn.steer` (user origins only, bundled skill blocks stripped) to a `role: 'user'` text frame in the running turn — flushed at the next step start when no step is running, and into the last step if the turn ends first — with daemon media projected as attachments. The frame's `promptIds` are paired in-projector from the preceding `prompt.steered` (FIFO; engine guarantees steers and their materializations are serialized in the same order). `turn.steer` joins `TRANSCRIPT_PROJECTED_EVENT_TYPES`, so transcript-protocol connections receive only the ops while legacy connections see an additive new event type.
- transcript contract: `TextFrame` gains an optional `promptIds` field so clients can reconcile their promptId-keyed optimistic bubbles against the frame (live only).
- Cold rebuild: `readColdSnapshot` tallies wire `turn.steer` records by content key, and `groupMessagesIntoSnapshot` folds a user message whose content matches an unconsumed steer record into its turn as the same user-frame shape instead of opening a standalone turn. Content equality holds by construction: the steered context message and the `turn.steer` input are the same post-gating content parts. A non-matching message simply falls back to the old behavior, so the failure mode degrades rather than corrupts.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [ ] I have linked a related issue (none — internal regression report).
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.
