### PR TITLE
feat(agent-core-v2): capture real file content for Edit/Write tool calls

### DIFF
--- a/packages/agent-core-v2/docs/wire-manifest.d.ts
+++ b/packages/agent-core-v2/docs/wire-manifest.d.ts
@@ -24,7 +24,7 @@
 // cross-reducers), blobs (the folding states whose blob codec offloads inline
 // media to blob storage), owner (the source file declaring the class).
 
-// Index (55 record types)
+// Index (56 record types)
 //   config.update                      profile                                               src/agent/profile/profileOps.ts
 //   context.append_loop_event          contextMemory, turn                                   src/agent/contextMemory/contextEvents.ts
 //   context.append_message             contextMemory, plan, task.notificationDelivery        src/agent/contextMemory/contextEvents.ts
@@ -34,6 +34,7 @@
 //   cron.add                           (none)                                                src/features/cron/cronOps.ts
 //   cron.cursor                        (none)                                                src/features/cron/cronOps.ts
 //   cron.delete                        (none)                                                src/features/cron/cronOps.ts
+//   file.edit_snapshot                 (none)                                                src/app/edit/fileEditEvents.ts
 //   forked                             (none)                                                src/features/goal/goalOps.ts
 //   full_compaction.begin              fullCompaction                                        src/agent/fullCompaction/compactionOps.ts
 //   full_compaction.cancel             fullCompaction                                        src/agent/fullCompaction/compactionOps.ts
@@ -212,6 +213,21 @@ interface CronCursorPayload {
 interface CronDeletePayload {
   _name: 'cron.delete';
   ids: string[];
+}
+
+/**
+ * states: (none)
+ * owner: src/app/edit/fileEditEvents.ts
+ */
+interface FileEditSnapshotPayload {
+  _name: 'file.edit_snapshot';
+  agentId: string;
+  turnId: number;
+  toolCallId: string;
+  path: string;
+  before?: string | null;
+  after?: string;
+  truncated?: boolean;
 }
 
 /**
@@ -837,6 +853,7 @@ interface WirePayloadMap {
   "cron.add": CronAddPayload;
   "cron.cursor": CronCursorPayload;
   "cron.delete": CronDeletePayload;
+  "file.edit_snapshot": FileEditSnapshotPayload;
   "forked": ForkedPayload;
   "full_compaction.begin": FullCompactionBeginPayload;
   "full_compaction.cancel": FullCompactionCancelPayload;

--- a/packages/agent-core-v2/src/agent/toolExecutor/toolExecutorService.ts
+++ b/packages/agent-core-v2/src/agent/toolExecutor/toolExecutorService.ts
@@ -1,5 +1,6 @@
 import { toDisposable } from '#/_base/di/lifecycle';
 import { LifecycleScope } from '#/app/scopes';
+import { FileEditSnapshot } from '#/app/edit/fileEditEvents';
 import { ScopeActivation, registerScopedService } from '#/_base/di/scope';
 import { AsyncEmitter, type Event } from '#/_base/event';
 import { defineState } from '#/state/state';
@@ -564,6 +565,7 @@ export class AgentToolExecutorService implements IAgentToolExecutorService {
       approvalRule: execution?.approvalRule,
       stopBatchAfterThis: normalized.stopBatchAfterThis ?? execution?.stopBatchAfterThis,
       delivery: coerced.delivery,
+      fileSnapshot: coerced.fileSnapshot,
     };
   }
 
@@ -605,6 +607,19 @@ export class AgentToolExecutorService implements IAgentToolExecutorService {
         isError: result.isError,
       }),
     );
+    if (result.fileSnapshot !== undefined) {
+      void this.dispatcher.dispatch(
+        new FileEditSnapshot({
+          agentId: this.scopeContext.agentId,
+          turnId: options.turnId,
+          toolCallId: call.toolCall.id,
+          path: result.fileSnapshot.path,
+          before: result.fileSnapshot.before,
+          after: result.fileSnapshot.after,
+          truncated: result.fileSnapshot.truncated,
+        }),
+      );
+    }
   }
 
   private dispatchToolProgress(
@@ -671,6 +686,7 @@ export class AgentToolExecutorService implements IAgentToolExecutorService {
         effectiveResult.stopTurn === true,
       stopBatchAfterThis: result.stopBatchAfterThis,
       delivery: coercedResult.delivery,
+      fileSnapshot: coercedResult.fileSnapshot,
     };
     return this.resultTruncation.truncateForModel({
       toolName: call.toolName,

--- a/packages/agent-core-v2/src/agent/tools/edit/editTool.ts
+++ b/packages/agent-core-v2/src/agent/tools/edit/editTool.ts
@@ -17,6 +17,7 @@ import {
   type ToolExecution,
 } from '#/tool/toolContract';
 import { registerAgentToolService } from '#/agent/toolRegistry/toolContribution';
+import { buildFileSnapshot } from '#/agent/tools/fileSnapshot';
 
 import { EditInputSchema, IEditTool, type EditInput } from './edit';
 import editDescriptionTemplate from './edit.md?raw';
@@ -108,7 +109,10 @@ export class EditTool implements IEditTool {
       return { isError: true, output: result.error };
     }
     const word = result.count === 1 ? 'occurrence' : 'occurrences';
-    return { output: `Replaced ${String(result.count)} ${word} in ${args.path}` };
+    return {
+      output: `Replaced ${String(result.count)} ${word} in ${args.path}`,
+      fileSnapshot: buildFileSnapshot(args.path, result.before, result.after),
+    };
   }
 }
 

--- a/packages/agent-core-v2/src/agent/tools/fileSnapshot.ts
+++ b/packages/agent-core-v2/src/agent/tools/fileSnapshot.ts
@@ -1,0 +1,11 @@
+import type { FileSnapshot } from '#/tool/toolContract';
+
+const MAX_FILE_SNAPSHOT_CHARS = 256 * 1024;
+
+export function buildFileSnapshot(path: string, before: string | null, after: string): FileSnapshot {
+  const size = (before?.length ?? 0) + after.length;
+  if (size > MAX_FILE_SNAPSHOT_CHARS) {
+    return { path, truncated: true };
+  }
+  return { path, before, after };
+}

--- a/packages/agent-core-v2/src/agent/tools/os/write/writeTool.ts
+++ b/packages/agent-core-v2/src/agent/tools/os/write/writeTool.ts
@@ -12,6 +12,7 @@ import {
   type ToolExecution,
 } from '#/tool/toolContract';
 import { registerAgentToolService } from '#/agent/toolRegistry/toolContribution';
+import { buildFileSnapshot } from '#/agent/tools/fileSnapshot';
 import {
   resolvePathAccessPath,
   type WorkspaceConfig,
@@ -78,14 +79,25 @@ export class WriteTool implements IWriteTool {
     };
   }
 
+  private async existingContent(fs: IHostFileSystem, safePath: string): Promise<string | null | undefined> {
+    try {
+      return await fs.readText(safePath, { errors: 'strict' });
+    } catch (error) {
+      const code = (unwrapErrorCause(error) as { code?: unknown } | null)?.code;
+      return code === 'ENOENT' ? null : undefined;
+    }
+  }
+
   private async execution(fs: IHostFileSystem, args: WriteInput, safePath: string): Promise<ExecutableToolResult> {
     const parentError = await this.ensureParentDirectory(fs, safePath);
     if (parentError !== undefined) {
       return { isError: true, output: parentError };
     }
 
+    const mode = args.mode ?? 'overwrite';
+    const before = mode === 'append' ? undefined : await this.existingContent(fs, safePath);
+
     try {
-      const mode = args.mode ?? 'overwrite';
       if (mode === 'append') {
         await fs.appendText(safePath, args.content);
       } else {
@@ -94,6 +106,7 @@ export class WriteTool implements IWriteTool {
       const bytesWritten = Buffer.byteLength(args.content, 'utf8');
       return {
         output: `${mode === 'append' ? 'Appended' : 'Wrote'} ${String(bytesWritten)} bytes to ${args.path}`,
+        fileSnapshot: before === undefined ? undefined : buildFileSnapshot(args.path, before, args.content),
       };
     } catch (error) {
       const code = (unwrapErrorCause(error) as { code?: unknown } | null)?.code;

--- a/packages/agent-core-v2/src/app/edit/fileEdit.ts
+++ b/packages/agent-core-v2/src/app/edit/fileEdit.ts
@@ -10,7 +10,7 @@ export interface FileEditInput {
 }
 
 export type FileEditResult =
-  | { readonly ok: true; readonly count: number }
+  | { readonly ok: true; readonly count: number; readonly before: string; readonly after: string }
   | { readonly ok: false; readonly error: string };
 
 export interface IFileEditService {

--- a/packages/agent-core-v2/src/app/edit/fileEditEvents.ts
+++ b/packages/agent-core-v2/src/app/edit/fileEditEvents.ts
@@ -1,0 +1,34 @@
+/* oxlint-disable typescript-eslint/no-unsafe-declaration-merging, eslint-plugin-import/namespace -- Event2 class+payload-interface declaration merging is the sanctioned event-declaration idiom. */
+import { z } from 'zod';
+
+import { AgentEvent2, registerEvent2Class } from '#/app/event/event2';
+
+export interface FileEditSnapshotPayload {
+  readonly agentId: string;
+  readonly turnId: number;
+  readonly toolCallId: string;
+  readonly path: string;
+  readonly before?: string | null;
+  readonly after?: string;
+  readonly truncated?: boolean;
+}
+
+const fileEditSnapshotSchema = z.object({
+  agentId: z.string(),
+  turnId: z.number(),
+  toolCallId: z.string(),
+  path: z.string(),
+  before: z.string().nullable().optional(),
+  after: z.string().optional(),
+  truncated: z.boolean().optional(),
+}) satisfies z.ZodType<FileEditSnapshotPayload>;
+
+export class FileEditSnapshot extends AgentEvent2<FileEditSnapshotPayload> {
+  static override readonly type = 'file.edit_snapshot';
+  static override readonly durable = true;
+  static override readonly observable = true;
+  static override readonly schema = fileEditSnapshotSchema;
+}
+export interface FileEditSnapshot extends FileEditSnapshotPayload {}
+
+registerEvent2Class(FileEditSnapshot);

--- a/packages/agent-core-v2/src/app/edit/fileEditService.ts
+++ b/packages/agent-core-v2/src/app/edit/fileEditService.ts
@@ -31,7 +31,7 @@ export class FileEditService implements IFileEditService {
         return { ok: false, error: result.error };
       }
       await fs.writeText(input.path, result.rawContent);
-      return { ok: true, count: result.count };
+      return { ok: true, count: result.count, before: raw, after: result.rawContent };
     } catch (error) {
       const code = (unwrapErrorCause(error) as { code?: unknown } | null)?.code;
       if (code === 'EISDIR') {

--- a/packages/agent-core-v2/src/tool/toolContract.ts
+++ b/packages/agent-core-v2/src/tool/toolContract.ts
@@ -29,6 +29,13 @@ export interface ToolDelivery {
   readonly message: ToolDeliveryMessage;
 }
 
+export interface FileSnapshot {
+  readonly path: string;
+  readonly before?: string | null;
+  readonly after?: string;
+  readonly truncated?: boolean;
+}
+
 export interface ExecutableToolSuccessResult {
   readonly output: ExecutableToolOutput;
   readonly isError?: false | undefined;
@@ -38,6 +45,7 @@ export interface ExecutableToolSuccessResult {
   readonly delivery?: ToolDelivery | undefined;
   readonly spill?: ToolResultSpill;
   readonly spillExempt?: true;
+  readonly fileSnapshot?: FileSnapshot | undefined;
 }
 
 export interface ExecutableToolErrorResult {
@@ -49,6 +57,7 @@ export interface ExecutableToolErrorResult {
   readonly delivery?: ToolDelivery | undefined;
   readonly spill?: ToolResultSpill;
   readonly spillExempt?: true;
+  readonly fileSnapshot?: FileSnapshot | undefined;
 }
 
 export type ExecutableToolResult = ExecutableToolSuccessResult | ExecutableToolErrorResult;

--- a/packages/agent-core-v2/test/app/edit/tools/edit.test.ts
+++ b/packages/agent-core-v2/test/app/edit/tools/edit.test.ts
@@ -210,6 +210,43 @@ describe('EditTool', () => {
     expect(writeText).toHaveBeenCalledWith('/tmp/a.txt', 'alpha gamma');
   });
 
+  it('reports the real before/after file content as fileSnapshot', async () => {
+    const { fs } = createSpiedEditFs({
+      readText: vi.fn().mockResolvedValue('alpha beta'),
+      writeText: vi.fn().mockResolvedValue(undefined),
+    });
+    const tool = buildTool(fs, createTestEnv(), PERMISSIVE_WORKSPACE);
+
+    const result = await execute(tool, {
+      path: '/tmp/a.txt',
+      old_string: 'beta',
+      new_string: 'gamma',
+    });
+
+    expect(result.fileSnapshot).toEqual({
+      path: '/tmp/a.txt',
+      before: 'alpha beta',
+      after: 'alpha gamma',
+    });
+  });
+
+  it('marks fileSnapshot truncated instead of shipping oversized content', async () => {
+    const big = 'x'.repeat(200 * 1024);
+    const { fs } = createSpiedEditFs({
+      readText: vi.fn().mockResolvedValue(`${big} beta`),
+      writeText: vi.fn().mockResolvedValue(undefined),
+    });
+    const tool = buildTool(fs, createTestEnv(), PERMISSIVE_WORKSPACE);
+
+    const result = await execute(tool, {
+      path: '/tmp/big.txt',
+      old_string: 'beta',
+      new_string: 'gamma',
+    });
+
+    expect(result.fileSnapshot).toEqual({ path: '/tmp/big.txt', truncated: true });
+  });
+
   it('executes against the selected runtime filesystem instead of the App filesystem', async () => {
     const runtimeWrite = vi.fn().mockResolvedValue(undefined);
     const { fs: runtimeFs } = createSpiedEditFs({

--- a/packages/agent-core-v2/test/index.test.ts
+++ b/packages/agent-core-v2/test/index.test.ts
@@ -87,6 +87,7 @@ const V2_RECORD_TYPES: ReadonlySet<string> = new Set([
   'interaction.request',
   'interaction.resolved',
   'plan.revision',
+  'file.edit_snapshot',
   'interruptionReminder.recorded',
   'plugin.session_start',
   'runtime.set_binding',

--- a/packages/agent-core-v2/test/os/backends/node-local/tools/write.test.ts
+++ b/packages/agent-core-v2/test/os/backends/node-local/tools/write.test.ts
@@ -172,6 +172,35 @@ describe('WriteTool', () => {
     expect(result.output).toContain('Wrote 5 bytes');
   });
 
+  it('reports a real fileSnapshot for an overwrite, with before:null for a new file', async () => {
+    const { tool } = makeTool();
+
+    const result = await execute(tool, { path: '/tmp/new.txt', content: 'hello' });
+
+    expect(result.fileSnapshot).toEqual({ path: '/tmp/new.txt', before: null, after: 'hello' });
+  });
+
+  it('reports the true prior content as fileSnapshot.before when overwriting an existing file', async () => {
+    const { tool } = makeTool({ readText: async () => 'old content' });
+
+    const result = await execute(tool, { path: '/tmp/existing.txt', content: 'new content' });
+
+    expect(result.fileSnapshot).toEqual({
+      path: '/tmp/existing.txt',
+      before: 'old content',
+      after: 'new content',
+    });
+  });
+
+  it('ships no fileSnapshot for an append — the tool never reads to build one', async () => {
+    const { tool, readText } = makeTool();
+
+    const result = await execute(tool, { path: '/tmp/existing.txt', content: '\nhello', mode: 'append' });
+
+    expect(readText).not.toHaveBeenCalled();
+    expect(result.fileSnapshot).toBeUndefined();
+  });
+
   it('expands leading tilde paths using the kaos home directory', async () => {
     const fakes = createWriteFs();
     const environment = createTestEnv('/home/test');

--- a/packages/kap-server/src/protocol/events-zod.ts
+++ b/packages/kap-server/src/protocol/events-zod.ts
@@ -68,6 +68,7 @@ import type {
   ToolProgressPayload,
   ToolResultEventPayload,
 } from '@moonshot-ai/agent-core-v2/agent/toolExecutor/toolExecutorEvents';
+import type { FileEditSnapshotPayload } from '@moonshot-ai/agent-core-v2/app/edit/fileEditEvents';
 import type { UsageStatus } from '@moonshot-ai/agent-core-v2/agent/usage/usage';
 import type { FinishReason } from '@moonshot-ai/agent-core-v2/kosong/contract/provider';
 import type { TokenUsage } from '@moonshot-ai/agent-core-v2/kosong/contract/usage';
@@ -863,6 +864,17 @@ export const toolResultEventSchema = z.object({
   synthetic: z.boolean().optional(),
 }) satisfies z.ZodType<ToolResultEventPayload>;
 
+export const fileEditSnapshotEventSchema = z.object({
+  type: z.literal('file.edit_snapshot'),
+  agentId: z.string(),
+  turnId: z.number(),
+  toolCallId: z.string(),
+  path: z.string(),
+  before: z.string().nullable().optional(),
+  after: z.string().optional(),
+  truncated: z.boolean().optional(),
+}) satisfies z.ZodType<FileEditSnapshotPayload & { type: 'file.edit_snapshot' }>;
+
 export const subagentSpawnedEventSchema = z.object({
   type: z.literal('subagent.spawned'),
   subagentId: z.string(),
@@ -1052,6 +1064,7 @@ export const agentEventSchema = z.discriminatedUnion('type', [
   shellStartedEventSchema,
   shellCompletedEventSchema,
   toolResultEventSchema,
+  fileEditSnapshotEventSchema,
   toolListUpdatedEventSchema,
   mcpServerStatusEventSchema,
   subagentSpawnedEventSchema,

--- a/packages/kap-server/src/services/transcript/coreEventMap.ts
+++ b/packages/kap-server/src/services/transcript/coreEventMap.ts
@@ -47,6 +47,7 @@ import type {
   ToolProgress,
   ToolResultEvent,
 } from '@moonshot-ai/agent-core-v2/agent/toolExecutor/toolExecutorEvents';
+import type { FileEditSnapshot } from '@moonshot-ai/agent-core-v2/app/edit/fileEditEvents';
 import type { AgentStatusUpdated } from '@moonshot-ai/agent-core-v2/agent/usage/usageEvents';
 import type { PlanRevision } from '@moonshot-ai/agent-core-v2/features/plan/planOps';
 import type { SubagentSuspended } from '@moonshot-ai/agent-core-v2/features/swarm/session/sessionSwarmService';
@@ -114,6 +115,7 @@ export type ProjectorBusEvent =
   | ({ readonly type: 'tool.progress' } & ToolProgress)
   | ({ readonly type: 'tool.call.started' } & ToolCallStarted)
   | ({ readonly type: 'tool.result' } & ToolResultEvent)
+  | ({ readonly type: 'file.edit_snapshot' } & FileEditSnapshot)
   | ({ readonly type: 'task.started' } & TaskStarted)
   | ({ readonly type: 'task.terminated' } & TaskTerminatedNotice)
   | ({ readonly type: 'task.notified' } & TaskNotified)
@@ -256,6 +258,8 @@ export class AgentTranscriptProjector {
         return this.onToolCallStarted(event);
       case 'tool.result':
         return this.onToolResult(event);
+      case 'file.edit_snapshot':
+        return this.onFileEditSnapshot(event);
       case 'task.started':
       case 'task.terminated':
         return this.onTaskLifecycle(event);
@@ -778,6 +782,28 @@ export class AgentTranscriptProjector {
       }
     }
     return ops;
+  }
+
+  private onFileEditSnapshot(event: {
+    toolCallId: string;
+    path: string;
+    before?: string | null;
+    after?: string;
+    truncated?: boolean;
+  }): TranscriptOperation[] {
+    const hit = this.toolFrames.get(event.toolCallId) ?? this.adoptToolFrame(event.toolCallId);
+    if (hit === undefined) return [];
+    const frame: ToolCallFrame = {
+      ...hit.frame,
+      edit: {
+        path: event.path,
+        before: event.before,
+        after: event.after,
+        truncated: event.truncated,
+      },
+    };
+    this.toolFrames.set(event.toolCallId, { ...hit, frame });
+    return [{ op: 'frame.upsert', turnId: hit.turnId, stepId: hit.stepId, frame }];
   }
 
   private adoptToolFrame(toolCallId: string): ToolFrameRecord | undefined {

--- a/packages/kap-server/src/transport/ws/v1/sessionEventBroadcaster.ts
+++ b/packages/kap-server/src/transport/ws/v1/sessionEventBroadcaster.ts
@@ -1121,6 +1121,7 @@ const TRANSCRIPT_PROJECTED_EVENT_TYPES: ReadonlySet<string> = new Set([
   'tool.call.started',
   'tool.progress',
   'tool.result',
+  'file.edit_snapshot',
   'shell.started',
   'shell.output',
   'shell.completed',

--- a/packages/klient/src/contract/agent/events.ts
+++ b/packages/klient/src/contract/agent/events.ts
@@ -114,6 +114,17 @@ export const toolResultEventSchema = z.object({
   synthetic: z.boolean().optional(),
 });
 
+export const fileEditSnapshotEventSchema = z.object({
+  type: z.literal('file.edit_snapshot'),
+  time: z.number().optional(),
+  turnId: z.number(),
+  toolCallId: z.string(),
+  path: z.string(),
+  before: z.string().nullable().optional(),
+  after: z.string().optional(),
+  truncated: z.boolean().optional(),
+});
+
 export const promptCompletedEventSchema = z.object({
   type: z.literal('prompt.completed'),
   time: z.number().optional(),
@@ -216,6 +227,7 @@ export interface AgentEventPayloads {
   'tool.call.delta': z.infer<typeof toolCallDeltaEventSchema>;
   'tool.progress': z.infer<typeof toolProgressEventSchema>;
   'tool.result': z.infer<typeof toolResultEventSchema>;
+  'file.edit_snapshot': z.infer<typeof fileEditSnapshotEventSchema>;
   'prompt.completed': z.infer<typeof promptCompletedEventSchema>;
   'prompt.aborted': z.infer<typeof promptAbortedEventSchema>;
   'compaction.started': z.infer<typeof compactionStartedEventSchema>;
@@ -241,6 +253,12 @@ export const agentEvents = {
   'tool.call.delta': { kind: 'stream', name: 'events', type: 'tool.call.delta', schema: toolCallDeltaEventSchema },
   'tool.progress': { kind: 'stream', name: 'events', type: 'tool.progress', schema: toolProgressEventSchema },
   'tool.result': { kind: 'stream', name: 'events', type: 'tool.result', schema: toolResultEventSchema },
+  'file.edit_snapshot': {
+    kind: 'stream',
+    name: 'events',
+    type: 'file.edit_snapshot',
+    schema: fileEditSnapshotEventSchema,
+  },
   'prompt.completed': { kind: 'stream', name: 'events', type: 'prompt.completed', schema: promptCompletedEventSchema },
   'prompt.aborted': { kind: 'stream', name: 'events', type: 'prompt.aborted', schema: promptAbortedEventSchema },
   'compaction.started': {

--- a/packages/node-sdk/test/session-event-types.test.ts
+++ b/packages/node-sdk/test/session-event-types.test.ts
@@ -99,6 +99,7 @@ describe('Event public types', () => {
         case 'shell.started':
         case 'shell.completed':
         case 'tool.result':
+        case 'file.edit_snapshot':
         case 'tool.list.updated':
         case 'mcp.server.status':
         case 'subagent.spawned':

--- a/packages/protocol/src/events.ts
+++ b/packages/protocol/src/events.ts
@@ -850,6 +850,16 @@ export interface ToolResultEvent {
   readonly synthetic?: boolean;
 }
 
+export interface FileEditSnapshotEvent {
+  readonly type: 'file.edit_snapshot';
+  readonly turnId: number;
+  readonly toolCallId: string;
+  readonly path: string;
+  readonly before?: string | null;
+  readonly after?: string;
+  readonly truncated?: boolean;
+}
+
 export interface SubagentSpawnedEvent {
   readonly type: 'subagent.spawned';
   readonly subagentId: string;
@@ -1037,6 +1047,7 @@ export type AgentEvent =
   | ShellStartedEvent
   | ShellCompletedEvent
   | ToolResultEvent
+  | FileEditSnapshotEvent
   | ToolListUpdatedEvent
   | McpServerStatusEvent
   | SubagentSpawnedEvent
@@ -1801,6 +1812,16 @@ export const toolResultEventSchema = z.object({
   synthetic: z.boolean().optional(),
 }) satisfies z.ZodType<ToolResultEvent>;
 
+export const fileEditSnapshotEventSchema = z.object({
+  type: z.literal('file.edit_snapshot'),
+  turnId: z.number(),
+  toolCallId: z.string(),
+  path: z.string(),
+  before: z.string().nullable().optional(),
+  after: z.string().optional(),
+  truncated: z.boolean().optional(),
+}) satisfies z.ZodType<FileEditSnapshotEvent>;
+
 export const subagentSpawnedEventSchema = z.object({
   type: z.literal('subagent.spawned'),
   subagentId: z.string(),
@@ -1976,6 +1997,7 @@ export const agentEventSchema = z.discriminatedUnion('type', [
   shellStartedEventSchema,
   shellCompletedEventSchema,
   toolResultEventSchema,
+  fileEditSnapshotEventSchema,
   toolListUpdatedEventSchema,
   mcpServerStatusEventSchema,
   subagentSpawnedEventSchema,

--- a/packages/transcript/src/contract/schema.ts
+++ b/packages/transcript/src/contract/schema.ts
@@ -90,6 +90,13 @@ export const toolFrameProgressSchema = z.object({
   customData: z.unknown().optional(),
 });
 
+export const toolFrameFileEditSchema = z.object({
+  path: z.string(),
+  before: z.string().nullable().optional(),
+  after: z.string().optional(),
+  truncated: z.boolean().optional(),
+});
+
 export const toolCallFrameSchema = z.object({
   kind: z.literal('tool'),
   frameId: frameIdSchema,
@@ -107,6 +114,7 @@ export const toolCallFrameSchema = z.object({
   approvalId: z.string().optional(),
   todoId: z.string().optional(),
   agentRefs: z.array(agentRefSchema).optional(),
+  edit: toolFrameFileEditSchema.optional(),
 });
 
 export const interactionSchema = z.object({

--- a/packages/transcript/src/history/foldFacts.ts
+++ b/packages/transcript/src/history/foldFacts.ts
@@ -1,3 +1,4 @@
+import type { TranscriptFrame } from '../model/frame';
 import type { TranscriptInteraction } from '../model/interaction';
 import type { TranscriptItem, TranscriptMarker, TranscriptTaskRef } from '../model/item';
 import type { GoalMeta, GoalStatus, TranscriptMeta } from '../model/meta';
@@ -54,6 +55,14 @@ interface PlanRevisionPayload {
   readonly path?: unknown;
   readonly sha256?: unknown;
   readonly bytes?: unknown;
+}
+
+interface FileEditSnapshotPayload {
+  readonly toolCallId?: unknown;
+  readonly path?: unknown;
+  readonly before?: unknown;
+  readonly after?: unknown;
+  readonly truncated?: unknown;
 }
 
 interface TurnEndedPayload {
@@ -170,6 +179,45 @@ function readTodoItems(raw: unknown): TodoItem[] {
   return items;
 }
 
+function patchToolFrameEdits(
+  items: readonly TranscriptItem[],
+  snapshots: ReadonlyMap<string, HistoryWireRecord>,
+): TranscriptItem[] {
+  return items.map((item) => {
+    if (item.kind !== 'turn') return item;
+    let turnChanged = false;
+    const steps = item.steps.map((step) => {
+      let stepChanged = false;
+      const frames = step.frames.map((frame): TranscriptFrame => {
+        if (frame.kind !== 'tool') return frame;
+        const record = snapshots.get(frame.toolCallId);
+        if (record === undefined) return frame;
+        stepChanged = true;
+        const payload = record as FileEditSnapshotPayload;
+        return {
+          ...frame,
+          edit: {
+            path: typeof payload.path === 'string' ? payload.path : '',
+            before:
+              typeof payload.before === 'string'
+                ? payload.before
+                : payload.before === null
+                  ? null
+                  : undefined,
+            after: typeof payload.after === 'string' ? payload.after : undefined,
+            truncated: typeof payload.truncated === 'boolean' ? payload.truncated : undefined,
+          },
+        };
+      });
+      if (!stepChanged) return step;
+      turnChanged = true;
+      return { ...step, frames };
+    });
+    if (!turnChanged) return item;
+    return { ...item, steps };
+  });
+}
+
 export function foldWireRecordFacts(
   records: Iterable<HistoryWireRecord>,
   base: AgentTranscriptSnapshot,
@@ -177,6 +225,7 @@ export function foldWireRecordFacts(
   const tasks = new Map<string, TranscriptTask>();
   const interactions = new Map<string, TranscriptInteraction>();
   const endedTurns = new Map<number, HistoryWireRecord>();
+  const fileEditSnapshots = new Map<string, HistoryWireRecord>();
   let nextTurnId = 0;
   const cancelledTurnIds = new Set<number>();
   const hiddenTurnIds = new Set<number>();
@@ -332,6 +381,11 @@ export function foldWireRecordFacts(
         pushMarker('plan.revision', record);
         break;
       }
+      case 'file.edit_snapshot': {
+        const payload = record as FileEditSnapshotPayload;
+        if (typeof payload.toolCallId === 'string') fileEditSnapshots.set(payload.toolCallId, record);
+        break;
+      }
       case 'swarm_mode.enter': {
         swarmActive = true;
         pushMarker('swarm.enter', record);
@@ -444,7 +498,7 @@ export function foldWireRecordFacts(
     endedByOrdinal.set(turnId - hidden, record);
   }
 
-  const items =
+  const endedItems =
     endedByOrdinal.size > 0
       ? base.items.map((item) => {
           if (item.kind !== 'turn') return item;
@@ -461,6 +515,9 @@ export function foldWireRecordFacts(
           };
         })
       : base.items;
+
+  const items =
+    fileEditSnapshots.size > 0 ? patchToolFrameEdits(endedItems, fileEditSnapshots) : endedItems;
 
   const modesTouched = planActive !== undefined || swarmActive !== undefined || towerActive !== undefined;
   const meta: TranscriptMeta = {

--- a/packages/transcript/src/model/frame.ts
+++ b/packages/transcript/src/model/frame.ts
@@ -54,6 +54,14 @@ export interface ToolCallFrame {
   readonly approvalId?: InteractionId;
   readonly todoId?: TodoId;
   readonly agentRefs?: readonly AgentRef[];
+  readonly edit?: ToolFrameFileEdit;
+}
+
+export interface ToolFrameFileEdit {
+  readonly path: string;
+  readonly before?: string | null;
+  readonly after?: string;
+  readonly truncated?: boolean;
 }
 
 export interface NoticeFrame {

--- a/packages/transcript/test/layers.test.ts
+++ b/packages/transcript/test/layers.test.ts
@@ -1064,6 +1064,49 @@ describe('foldWireRecordFacts (cold facts)', () => {
     expect(folded.items).toBe(base.items);
   });
 
+  it('patches a tool frame with real before/after content from a file.edit_snapshot record', () => {
+    const base = groupMessagesIntoSnapshot([
+      { role: 'user', content: [{ type: 'text', text: 'edit it' }], toolCalls: [], origin: { kind: 'user' } },
+      {
+        role: 'assistant',
+        content: [],
+        toolCalls: [{ id: 'call_1', name: 'Edit', arguments: '{"path":"a.ts"}' }],
+      },
+      { role: 'tool', toolCallId: 'call_1', content: [{ type: 'text', text: 'Replaced 1 occurrence' }], toolCalls: [] },
+    ]);
+    const folded = foldWireRecordFacts(
+      [
+        {
+          type: 'file.edit_snapshot',
+          toolCallId: 'call_1',
+          path: 'a.ts',
+          before: 'old content',
+          after: 'new content',
+          time: 1000,
+        },
+      ],
+      base,
+    );
+    const turn = folded.items[0];
+    if (turn?.kind !== 'turn') throw new Error('expected turn');
+    const frame = turn.steps[0]?.frames.find((f) => f.kind === 'tool');
+    expect(frame?.kind === 'tool' && frame.edit).toEqual({
+      path: 'a.ts',
+      before: 'old content',
+      after: 'new content',
+      truncated: undefined,
+    });
+  });
+
+  it('ignores a file.edit_snapshot record for a toolCallId with no matching frame', () => {
+    const base = baseWithMarker();
+    const folded = foldWireRecordFacts(
+      [{ type: 'file.edit_snapshot', toolCallId: 'no-such-call', path: 'a.ts', before: 'x', after: 'y', time: 1000 }],
+      base,
+    );
+    expect(folded.items).toEqual(base.items);
+  });
+
   it('folds todo records into the global todo document, last write wins', () => {
     const base = baseWithMarker();
     const folded = foldWireRecordFacts(


### PR DESCRIPTION
## Related Issue

No tracked issue — this came out of a cross-repo investigation into why the code-app client's per-turn "files changed" diff shows phantom added-then-removed lines when a turn edits the same file with overlapping regions across multiple calls.

## Problem

Edit and Write tool calls already read/write the real file content as part of executing, but that content is discarded — only a plain output string (e.g. "Replaced 1 occurrence in foo.ts") ever reaches clients. Clients are left reconstructing a diff purely from tool-call args (`old_string`/`new_string`), which breaks once two calls in a turn touch overlapping text: a later call's `old_string` can be a mix of a prior call's own inserted output plus untouched original content, and the client has no way to tell the two apart from args alone.

## What changed

- `FileEditService`/`EditTool`/`WriteTool` now capture the real before/after file content they already read/write, size-capped at 256 KB combined (over cap → `truncated: true`, no content). Append-mode Write is intentionally excluded — it never reads before appending, and an existing test pins that as deliberate.
- A new `fileSnapshot` field on `ExecutableToolResult` carries this out of tool execution.
- A new durable + observable `FileEditSnapshot` event (`file.edit_snapshot`) persists it — kept separate from `ToolResultEvent` because `durable` is a static per-event-class flag, and making the shared result event durable would make every tool's result durable (Bash, Read, Grep, …), not just edit/write.
- Wired into the transcript `ToolCallFrame.edit` field, both the live projection (`coreEventMap.ts`) and cold rebuild from the wire journal (`foldFacts.ts`, keyed by `toolCallId` — no turn-ordinal remapping needed, unlike `turn.ended`).
- Registered through all three independent hand-written wire schemas (`kap-server/protocol/events-zod.ts`, `protocol/events.ts`, `klient/contract/agent/events.ts`) and the WS broadcaster's transcript-projection allowlist.

Consumers can now diff a file's real before/after content directly instead of reconstructing it from args. A matching code-app client change (separate PR) prefers this field when present, falling back to the old arg-based reconstruction for daemons that don't ship it yet.

## Checklist

- [x] I have read the CONTRIBUTING document.
- [x] I have added tests that prove my feature works.
- [x] This PR needs no changeset — it only adds wire/protocol capacity; no existing CLI/TUI consumer changes behavior from this PR alone.
- [ ] Ran `gen-docs` skill, or this PR needs no doc update.