### PR TITLE
fix(agent-core-v2): fall back to kimi-file URL for prompt attachments

### DIFF
--- a/.changeset/turn-started-kimi-file-attachments.md
+++ b/.changeset/turn-started-kimi-file-attachments.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Fix attached images disappearing from the user message while the agent is working.

--- a/packages/agent-core-v2/src/agent/loop/turnEvents.ts
+++ b/packages/agent-core-v2/src/agent/loop/turnEvents.ts
@@ -47,19 +47,20 @@ export function turnPromptAttachments(
   input: readonly ContentPart[],
 ): TurnStartedPayload['promptAttachments'] {
   const attachments: { kind: 'image' | 'video' | 'audio'; fileId: string }[] = [];
-  const sessionMediaFileId = (url: string, id: string | undefined): string | undefined => {
-    if (id === undefined) return undefined;
-    return parseDaemonFileUrl(url)?.fileId === id ? id : undefined;
+  const promptMediaFileId = (url: string, id: string | undefined): string | undefined => {
+    const fileId = parseDaemonFileUrl(url)?.fileId;
+    if (id === undefined) return fileId;
+    return fileId === id ? id : undefined;
   };
   for (const part of input) {
     if (part.type === 'image_url') {
-      const fileId = sessionMediaFileId(part.imageUrl.url, part.imageUrl.id);
+      const fileId = promptMediaFileId(part.imageUrl.url, part.imageUrl.id);
       if (fileId !== undefined) attachments.push({ kind: 'image', fileId });
     } else if (part.type === 'video_url') {
-      const fileId = sessionMediaFileId(part.videoUrl.url, part.videoUrl.id);
+      const fileId = promptMediaFileId(part.videoUrl.url, part.videoUrl.id);
       if (fileId !== undefined) attachments.push({ kind: 'video', fileId });
     } else if (part.type === 'audio_url') {
-      const fileId = sessionMediaFileId(part.audioUrl.url, part.audioUrl.id);
+      const fileId = promptMediaFileId(part.audioUrl.url, part.audioUrl.id);
       if (fileId !== undefined) attachments.push({ kind: 'audio', fileId });
     }
   }

--- a/packages/agent-core-v2/test/agent/loop/loop.test.ts
+++ b/packages/agent-core-v2/test/agent/loop/loop.test.ts
@@ -843,6 +843,46 @@ describe('Agent loop', () => {
 
     expect(prompts).toEqual([undefined, 'hi']);
   });
+
+  it('carries kimi-file prompt attachments on turn.started, falling back to the URL file id', async () => {
+    const payloads: Array<readonly { kind: string; fileId: string }[] | undefined> = [];
+    const subscription = ctx.get(IEventBus).subscribe(TurnStarted, (event) => {
+      payloads.push(event.promptAttachments);
+    });
+    ctx.mockNextResponse({ type: 'text', text: 'seen' });
+
+    const turn = (
+      await loop.enqueue(
+        new MessageStepRequest(
+          {
+            role: 'user',
+            content: [
+              { type: 'image_url', imageUrl: { url: 'kimi-file://file_1', id: 'file_1' } },
+              { type: 'video_url', videoUrl: { url: 'kimi-file://file_2', id: 'file_2' } },
+              { type: 'image_url', imageUrl: { url: 'kimi-file://file_3' } },
+              { type: 'image_url', imageUrl: { url: 'kimi-file://file_4', id: 'other' } },
+              { type: 'image_url', imageUrl: { url: 'https://example.com/no-id.png' } },
+              { type: 'image_url', imageUrl: { url: 'ms://provider-blob', id: 'prov_1' } },
+              { type: 'text', text: 'look' },
+            ],
+            toolCalls: [],
+            origin: { kind: 'user' },
+          },
+          { admission: 'newTurn' },
+        ),
+      ).assigned
+    ).turn;
+    await turn.result;
+    subscription.dispose();
+
+    expect(payloads).toEqual([
+      [
+        { kind: 'image', fileId: 'file_1' },
+        { kind: 'video', fileId: 'file_2' },
+        { kind: 'image', fileId: 'file_3' },
+      ],
+    ]);
+  });
 });
 
 describe('turn telemetry', () => {


### PR DESCRIPTION
## Related Issue

N/A — internal bug report (no public issue).

## Problem

Prompt images uploaded through the global file library reach the engine as `kimi-file://` media parts without a media id. `turn.started` only produced `promptAttachments` when the part id matched the kimi-file URL, so a live transcript turn got no attachmentIds for these images. Clients that synthesize the user message from `turn.prompt + turn.attachmentIds` therefore dropped the optimistic image bubble for the entire run — the images only came back after the post-turn transcript heal. A pure-image prompt looked like it had never been sent.

## What changed

- `turnPromptAttachments` now falls back to the file id parsed from the kimi-file URL when the media part carries no id. The live transcript's first-frame attachments now match what the post-turn heal already recovers, so the user message keeps its images from turn start.
- #3088 semantics are preserved: an explicit id must still match the URL file id (guard against provider remote URLs), and non-kimi-file URLs never count.
- Restored the `turn.started` prompt-attachment regression coverage that was dropped during the model-as-container refactor, and extended it to the id-less kimi-file form plus a conflicting-id negative control.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] Related issue: N/A — internal bug report; problem explained above.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.
