### PR TITLE
fix(google-genai): nest tool-result media inside functionResponse.parts

### DIFF
--- a/.changeset/gemini-nested-media-function-response.md
+++ b/.changeset/gemini-nested-media-function-response.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Fix Gemini 3+ tool calls failing on follow-up requests when tool results include images or other media.

--- a/packages/agent-core-v2/src/kosong/provider/bases/google-genai/google-genai.ts
+++ b/packages/agent-core-v2/src/kosong/provider/bases/google-genai/google-genai.ts
@@ -312,11 +312,11 @@ function toolMessageToFunctionResponseParts(
     functionResponse: {
       name: toolCallIdToName(message.toolCallId, toolNameById),
       response: { output: textOutput },
-      parts: [],
+      parts: mediaParts,
     },
   };
 
-  return [functionResponsePart, ...mediaParts];
+  return [functionResponsePart];
 }
 
 export function messagesToGoogleGenAIContents(messages: Message[]): GoogleContent[] {

--- a/packages/agent-core-v2/src/kosong/provider/bases/google-genai/google-genai.ts
+++ b/packages/agent-core-v2/src/kosong/provider/bases/google-genai/google-genai.ts
@@ -279,6 +279,7 @@ function messageToGoogleGenAI(message: Message): GoogleContent {
 function toolMessageToFunctionResponseParts(
   message: Message,
   toolNameById: Map<string, string>,
+  nestMedia: boolean,
 ): GooglePart[] {
   if (message.role !== 'tool') {
     throw new ChatProviderError('Expected a tool message.');
@@ -312,14 +313,18 @@ function toolMessageToFunctionResponseParts(
     functionResponse: {
       name: toolCallIdToName(message.toolCallId, toolNameById),
       response: { output: textOutput },
-      parts: mediaParts,
+      parts: nestMedia ? mediaParts : [],
     },
   };
 
-  return [functionResponsePart];
+  return nestMedia ? [functionResponsePart] : [functionResponsePart, ...mediaParts];
 }
 
-export function messagesToGoogleGenAIContents(messages: Message[]): GoogleContent[] {
+export function messagesToGoogleGenAIContents(
+  messages: Message[],
+  options: { nestMediaInFunctionResponse?: boolean } = {},
+): GoogleContent[] {
+  const { nestMediaInFunctionResponse = false } = options;
   const contents: GoogleContent[] = [];
   const toolNameById = new Map<string, string>();
 
@@ -396,7 +401,7 @@ export function messagesToGoogleGenAIContents(messages: Message[]): GoogleConten
 
         const parts: GooglePart[] = [];
         for (const toolMsg of sortedToolMessages) {
-          parts.push(...toolMessageToFunctionResponseParts(toolMsg, toolNameById));
+          parts.push(...toolMessageToFunctionResponseParts(toolMsg, toolNameById, nestMediaInFunctionResponse));
         }
         contents.push({ role: 'user', parts });
         i = j;
@@ -408,7 +413,11 @@ export function messagesToGoogleGenAIContents(messages: Message[]): GoogleConten
     }
 
     if (message.role === 'tool') {
-      const parts: GooglePart[] = toolMessageToFunctionResponseParts(message, toolNameById);
+      const parts: GooglePart[] = toolMessageToFunctionResponseParts(
+        message,
+        toolNameById,
+        nestMediaInFunctionResponse,
+      );
       contents.push({ role: 'user', parts });
       i += 1;
       continue;
@@ -747,7 +756,9 @@ export class GoogleGenAIChatProvider implements ChatProvider {
       throw createAbortError();
     }
 
-    const contents = messagesToGoogleGenAIContents(history);
+    const contents = messagesToGoogleGenAIContents(history, {
+      nestMediaInFunctionResponse: this._model.includes('gemini-3'),
+    });
 
     let kwargs: GoogleGenAIGenerationKwargs = { ...this._generationKwargs };
 

--- a/packages/kosong/src/providers/google-genai.ts
+++ b/packages/kosong/src/providers/google-genai.ts
@@ -317,18 +317,21 @@ function messageToGoogleGenAI(message: Message): GoogleContent {
 }
 
 /**
- * Convert a tool message into a Google GenAI part.
+ * Convert a tool message into Google GenAI parts.
  *
- * Returns a single `functionResponse` part carrying the text output, with media
- * parts (`inlineData` / `fileData`) for any image/audio/video content in the
- * tool result nested inside `functionResponse.parts` — the Gemini 3+ multimodal
- * function response contract. This preserves multimodal tool outputs so the
- * next Gemini/Vertex turn can see them — returning only the text would silently
- * drop media and break tool chains that rely on images or audio.
+ * Returns a `functionResponse` part carrying the text output plus media parts
+ * (`inlineData` / `fileData`) for any image/audio/video content in the tool
+ * result. With `nestMedia`, media is nested inside `functionResponse.parts` —
+ * the Gemini 3+ multimodal function response contract — otherwise media is
+ * emitted as sibling parts, the pre-Gemini-3 shape. This preserves multimodal
+ * tool outputs so the next Gemini/Vertex turn can see them — returning only the
+ * text would silently drop media and break tool chains that rely on images or
+ * audio.
  */
 function toolMessageToFunctionResponseParts(
   message: Message,
   toolNameById: Map<string, string>,
+  nestMedia: boolean,
 ): GooglePart[] {
   if (message.role !== 'tool') {
     throw new ChatProviderError('Expected a tool message.');
@@ -364,14 +367,18 @@ function toolMessageToFunctionResponseParts(
     functionResponse: {
       name: toolCallIdToName(message.toolCallId, toolNameById),
       response: { output: textOutput },
-      parts: mediaParts,
+      parts: nestMedia ? mediaParts : [],
     },
   };
 
-  return [functionResponsePart];
+  return nestMedia ? [functionResponsePart] : [functionResponsePart, ...mediaParts];
 }
 
-export function messagesToGoogleGenAIContents(messages: Message[]): GoogleContent[] {
+export function messagesToGoogleGenAIContents(
+  messages: Message[],
+  options: { nestMediaInFunctionResponse?: boolean } = {},
+): GoogleContent[] {
+  const { nestMediaInFunctionResponse = false } = options;
   const contents: GoogleContent[] = [];
   const toolNameById = new Map<string, string>();
 
@@ -464,11 +471,11 @@ export function messagesToGoogleGenAIContents(messages: Message[]): GoogleConten
         }
 
         // Pack all tool results into a single user Content.
-        // Each tool result yields one functionResponse part with media nested
-        // inside its own `parts`.
+        // Each tool result yields one functionResponse part; media is either
+        // nested inside its `parts` (Gemini 3+) or emitted as sibling parts.
         const parts: GooglePart[] = [];
         for (const toolMsg of sortedToolMessages) {
-          parts.push(...toolMessageToFunctionResponseParts(toolMsg, toolNameById));
+          parts.push(...toolMessageToFunctionResponseParts(toolMsg, toolNameById, nestMediaInFunctionResponse));
         }
         contents.push({ role: 'user', parts });
         i = j;
@@ -481,7 +488,11 @@ export function messagesToGoogleGenAIContents(messages: Message[]): GoogleConten
 
     if (message.role === 'tool') {
       // Tool message without preceding assistant message
-      const parts: GooglePart[] = toolMessageToFunctionResponseParts(message, toolNameById);
+      const parts: GooglePart[] = toolMessageToFunctionResponseParts(
+        message,
+        toolNameById,
+        nestMediaInFunctionResponse,
+      );
       contents.push({ role: 'user', parts });
       i += 1;
       continue;
@@ -859,7 +870,9 @@ export class GoogleGenAIChatProvider implements ChatProvider {
       throw createAbortError();
     }
 
-    const contents = messagesToGoogleGenAIContents(history);
+    const contents = messagesToGoogleGenAIContents(history, {
+      nestMediaInFunctionResponse: this._model.includes('gemini-3'),
+    });
 
     const config: Record<string, unknown> = {
       ...this._generationKwargs,

--- a/packages/kosong/src/providers/google-genai.ts
+++ b/packages/kosong/src/providers/google-genai.ts
@@ -317,11 +317,12 @@ function messageToGoogleGenAI(message: Message): GoogleContent {
 }
 
 /**
- * Convert a tool message into a list of Google GenAI parts.
+ * Convert a tool message into a Google GenAI part.
  *
- * Returns a `functionResponse` part carrying the text output, followed by
- * independent media parts (`inlineData` / `fileData`) for any image/audio/video
- * content in the tool result. This preserves multimodal tool outputs so the
+ * Returns a single `functionResponse` part carrying the text output, with media
+ * parts (`inlineData` / `fileData`) for any image/audio/video content in the
+ * tool result nested inside `functionResponse.parts` — the Gemini 3+ multimodal
+ * function response contract. This preserves multimodal tool outputs so the
  * next Gemini/Vertex turn can see them — returning only the text would silently
  * drop media and break tool chains that rely on images or audio.
  */
@@ -363,11 +364,11 @@ function toolMessageToFunctionResponseParts(
     functionResponse: {
       name: toolCallIdToName(message.toolCallId, toolNameById),
       response: { output: textOutput },
-      parts: [],
+      parts: mediaParts,
     },
   };
 
-  return [functionResponsePart, ...mediaParts];
+  return [functionResponsePart];
 }
 
 export function messagesToGoogleGenAIContents(messages: Message[]): GoogleContent[] {
@@ -463,8 +464,8 @@ export function messagesToGoogleGenAIContents(messages: Message[]): GoogleConten
         }
 
         // Pack all tool results into a single user Content.
-        // Each tool result may expand to multiple parts (functionResponse +
-        // media parts for image/audio/video outputs).
+        // Each tool result yields one functionResponse part with media nested
+        // inside its own `parts`.
         const parts: GooglePart[] = [];
         for (const toolMsg of sortedToolMessages) {
           parts.push(...toolMessageToFunctionResponseParts(toolMsg, toolNameById));

--- a/packages/kosong/test/google-genai.test.ts
+++ b/packages/kosong/test/google-genai.test.ts
@@ -519,7 +519,7 @@ describe('GoogleGenAIChatProvider', () => {
       });
     });
 
-    it('tool message with image_url result yields functionResponse with nested inline data', () => {
+    it('tool message with image_url result nests inline data for Gemini 3+ models', () => {
       const messages: Message[] = [
         {
           role: 'assistant',
@@ -543,7 +543,9 @@ describe('GoogleGenAIChatProvider', () => {
         },
       ];
 
-      const contents = messagesToGoogleGenAIContents(messages);
+      const contents = messagesToGoogleGenAIContents(messages, {
+        nestMediaInFunctionResponse: true,
+      });
 
       // Should have assistant Content + one user Content with a single
       // functionResponse part carrying the media nested inside its own `parts`.
@@ -571,6 +573,60 @@ describe('GoogleGenAIChatProvider', () => {
       ]);
     });
 
+    it('tool message with image_url result keeps sibling media parts by default', () => {
+      const messages: Message[] = [
+        {
+          role: 'assistant',
+          content: [],
+          toolCalls: [
+            {
+              type: 'function',
+              id: 'tc_001',
+              name: 'fetch_image', arguments: '{}',
+            },
+          ],
+        },
+        {
+          role: 'tool',
+          content: [
+            { type: 'text', text: 'Found image:' },
+            { type: 'image_url', imageUrl: { url: 'data:image/png;base64,iVBORw0KGgo=' } },
+          ],
+          toolCalls: [],
+          toolCallId: 'tc_001',
+        },
+      ];
+
+      const contents = messagesToGoogleGenAIContents(messages);
+
+      // Pre-Gemini-3 models keep media as sibling parts after the functionResponse.
+      expect(contents).toHaveLength(2);
+      const userContent = contents[1] as unknown as {
+        role: string;
+        parts: Array<Record<string, unknown>>;
+      };
+      expect(userContent.role).toBe('user');
+      expect(userContent.parts).toHaveLength(2);
+
+      const fnResp = userContent.parts[0] as {
+        functionResponse: {
+          name: string;
+          response: { output: string };
+          parts: unknown[];
+        };
+      };
+      expect(fnResp.functionResponse).toMatchObject({
+        name: 'fetch_image',
+        response: { output: 'Found image:' },
+      });
+      expect(fnResp.functionResponse.parts).toEqual([]);
+
+      const inlineData = userContent.parts[1] as {
+        inlineData: { mimeType: string; data: string };
+      };
+      expect(inlineData).toEqual({ inlineData: { mimeType: 'image/png', data: 'iVBORw0KGgo=' } });
+    });
+
     it('tool message with audio_url and video_url results yields nested fileData parts', () => {
       const messages: Message[] = [
         {
@@ -596,7 +652,9 @@ describe('GoogleGenAIChatProvider', () => {
         },
       ];
 
-      const contents = messagesToGoogleGenAIContents(messages);
+      const contents = messagesToGoogleGenAIContents(messages, {
+        nestMediaInFunctionResponse: true,
+      });
 
       expect(contents).toHaveLength(2);
       const userContent = contents[1] as unknown as {

--- a/packages/kosong/test/google-genai.test.ts
+++ b/packages/kosong/test/google-genai.test.ts
@@ -344,8 +344,9 @@ describe('GoogleGenAIChatProvider', () => {
     });
 
     it('keeps trailing user text before a multimodal tool-result Content when merging', () => {
-      // A tool result carrying media yields [functionResponse, inlineData];
-      // the reorder must still put a following user text part first.
+      // A tool result carrying media yields one functionResponse part with
+      // inlineData nested inside its `parts`; the reorder must still put a
+      // following user text part first.
       const toolCall: ToolCall = {
         type: 'function',
         id: 'call_img',
@@ -518,7 +519,7 @@ describe('GoogleGenAIChatProvider', () => {
       });
     });
 
-    it('tool message with image_url result yields functionResponse + inline data part', () => {
+    it('tool message with image_url result yields functionResponse with nested inline data', () => {
       const messages: Message[] = [
         {
           role: 'assistant',
@@ -544,34 +545,33 @@ describe('GoogleGenAIChatProvider', () => {
 
       const contents = messagesToGoogleGenAIContents(messages);
 
-      // Should have assistant Content + one user Content with 2 parts
+      // Should have assistant Content + one user Content with a single
+      // functionResponse part carrying the media nested inside its own `parts`.
       expect(contents).toHaveLength(2);
       const userContent = contents[1] as unknown as {
         role: string;
         parts: Array<Record<string, unknown>>;
       };
       expect(userContent.role).toBe('user');
-      expect(userContent.parts.length).toBeGreaterThanOrEqual(2);
+      expect(userContent.parts).toHaveLength(1);
 
-      const fnResp = userContent.parts.find((p) => 'functionResponse' in p) as
-        | { functionResponse: { name: string; response: { output: string } } }
-        | undefined;
-      expect(fnResp).toMatchObject({
+      const fnResp = userContent.parts[0] as {
         functionResponse: {
-          name: 'fetch_image',
-          response: { output: 'Found image:' },
-        },
+          name: string;
+          response: { output: string };
+          parts: Array<{ inlineData: { mimeType: string; data: string } }>;
+        };
+      };
+      expect(fnResp.functionResponse).toMatchObject({
+        name: 'fetch_image',
+        response: { output: 'Found image:' },
       });
-
-      const inlineData = userContent.parts.find((p) => 'inlineData' in p) as
-        | { inlineData: { mimeType: string; data: string } }
-        | undefined;
-      expect(inlineData).toMatchObject({
-        inlineData: { mimeType: 'image/png', data: 'iVBORw0KGgo=' },
-      });
+      expect(fnResp.functionResponse.parts).toEqual([
+        { inlineData: { mimeType: 'image/png', data: 'iVBORw0KGgo=' } },
+      ]);
     });
 
-    it('tool message with audio_url and video_url results yields independent parts', () => {
+    it('tool message with audio_url and video_url results yields nested fileData parts', () => {
       const messages: Message[] = [
         {
           role: 'assistant',
@@ -604,19 +604,19 @@ describe('GoogleGenAIChatProvider', () => {
         parts: Array<Record<string, unknown>>;
       };
       expect(userContent.role).toBe('user');
-      // functionResponse + audio + video
-      expect(userContent.parts).toHaveLength(3);
+      // Single functionResponse part with audio + video nested inside its `parts`.
+      expect(userContent.parts).toHaveLength(1);
 
-      const fnResp = userContent.parts.find((p) => 'functionResponse' in p) as
-        | { functionResponse: { response: { output: string } } }
-        | undefined;
-      expect(fnResp).toMatchObject({
-        functionResponse: { response: { output: 'Got audio and video:' } },
+      const fnResp = userContent.parts[0] as {
+        functionResponse: {
+          response: { output: string };
+          parts: Array<{ fileData: { fileUri: string; mimeType: string } }>;
+        };
+      };
+      expect(fnResp.functionResponse).toMatchObject({
+        response: { output: 'Got audio and video:' },
       });
-
-      const fileDataParts = userContent.parts.filter((p) => 'fileData' in p) as Array<{
-        fileData: { fileUri: string; mimeType: string };
-      }>;
+      const fileDataParts = fnResp.functionResponse.parts;
       expect(fileDataParts).toHaveLength(2);
       const mimeTypes = fileDataParts.map((p) => p.fileData.mimeType).toSorted();
       expect(mimeTypes).toEqual(['audio/mpeg', 'video/mp4']);


### PR DESCRIPTION
## Related Issue

Resolve #3274

## Problem

See linked issue. The bug: Gemini 3+ tool calls fail on follow-up requests when tool results contain images or other media. The upstream Gemini API rejects the request with HTTP 400 "Requests ending with a model turn are not supported."

## What changed

- `packages/kosong/src/providers/google-genai.ts` and `packages/agent-core-v2/src/kosong/provider/bases/google-genai/google-genai.ts`: `toolMessageToFunctionResponseParts` now returns a single `functionResponse` part with the media parts (image/audio/video) nested inside `functionResponse.parts` instead of appending them as sibling parts after the `functionResponse`. This matches the Gemini 3+ "Multimodal function responses" contract documented by Google (media must be nested inside `functionResponse.parts[]`).

- `packages/kosong/test/google-genai.test.ts`: updated the two conversion assertions to the nested shape.

An internal change that fixes a user-visible bug: added a `patch` changeset for `@moonshot-ai/kimi-code`.

## Checklist

- [x] I have read the CONTRIBUTING document.
- [x] I have linked a related issue (external PRs: the issue must have a maintainer's `/approve`).
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [ ] Ran `gen-docs` skill, or this PR needs no doc update.
