### PR TITLE
fix(vscode): serialize per-view session opens to stop duplicated streaming

### DIFF
--- a/.changeset/fix-vscode-duplicated-stream-events.md
+++ b/.changeset/fix-vscode-duplicated-stream-events.md
@@ -1,0 +1,5 @@
+---
+"kimi-code": patch
+---
+
+Fix streamed replies occasionally showing every character twice and tool calls appearing in duplicate.

--- a/apps/vscode/src/runtime/kimi-runtime.ts
+++ b/apps/vscode/src/runtime/kimi-runtime.ts
@@ -56,6 +56,7 @@ export class KimiRuntime {
   private readonly log: KimiRuntimeOptions["log"];
   private readonly sessions = new Map<string, SessionRuntime>();
   private readonly sessionByView = new Map<string, string>();
+  private readonly viewChains = new Map<string, Promise<void>>();
   private closed = false;
 
   constructor(options: KimiRuntimeOptions) {
@@ -86,6 +87,10 @@ export class KimiRuntime {
   }
 
   async openSession(options: OpenSessionOptions): Promise<SessionRuntime> {
+    return this.serializeView(options.webviewId, () => this.openSessionInner(options));
+  }
+
+  private async openSessionInner(options: OpenSessionOptions): Promise<SessionRuntime> {
     this.ensureOpen();
     const current = this.getSessionForView(options.webviewId);
     const requestedId = options.sessionId ?? current?.id;
@@ -104,7 +109,7 @@ export class KimiRuntime {
     if (runtime !== undefined) {
       assertSessionWorkDir(runtime.session, options.workDir);
       await applySessionSettings(runtime.session, options, runtime.legacyApprovalFlags);
-      await this.detachView(options.webviewId);
+      await this.detachViewInner(options.webviewId);
     } else {
       const defaultApproval: LegacyApprovalFlags = { yolo: options.yoloMode, afk: false };
       const session =
@@ -127,7 +132,7 @@ export class KimiRuntime {
           await session.updateMetadata(legacyApprovalMetadata(approval));
         }
         await applySessionSettings(session, options, approval);
-        await this.detachView(options.webviewId);
+        await this.detachViewInner(options.webviewId);
         runtime = this.wrapSession(session, approval);
       } catch (error) {
         await session.close().catch((closeError: unknown) => {
@@ -148,13 +153,23 @@ export class KimiRuntime {
     session: Session,
     defaultYoloMode = false,
   ): Promise<SessionRuntime> {
+    return this.serializeView(webviewId, () =>
+      this.attachResumedSessionInner(webviewId, session, defaultYoloMode),
+    );
+  }
+
+  private async attachResumedSessionInner(
+    webviewId: string,
+    session: Session,
+    defaultYoloMode: boolean,
+  ): Promise<SessionRuntime> {
     const existing = this.sessions.get(session.id);
     if (existing !== undefined && this.sessionByView.get(webviewId) === session.id) {
       existing.subscribe(webviewId);
       await existing.announceStatus(webviewId);
       return existing;
     }
-    await this.detachView(webviewId);
+    await this.detachViewInner(webviewId);
     let runtime = existing ?? this.sessions.get(session.id);
     if (runtime === undefined) {
       try {
@@ -185,6 +200,10 @@ export class KimiRuntime {
   }
 
   async detachView(webviewId: string): Promise<void> {
+    return this.serializeView(webviewId, () => this.detachViewInner(webviewId));
+  }
+
+  private async detachViewInner(webviewId: string): Promise<void> {
     const id = this.sessionByView.get(webviewId);
     if (id === undefined) return;
     this.sessionByView.delete(webviewId);
@@ -195,6 +214,23 @@ export class KimiRuntime {
       this.sessions.delete(id);
       await runtime.close();
     }
+  }
+
+  // A view attaches to at most one session, so opens/detaches for one view
+  // must never overlap: concurrent callers that both miss `this.sessions`
+  // would wrap the same SDK session twice and double every streamed event.
+  private serializeView<T>(webviewId: string, work: () => Promise<T>): Promise<T> {
+    const prev = this.viewChains.get(webviewId) ?? Promise.resolve();
+    const run = prev.then(work, work);
+    const next = run.then(
+      () => undefined,
+      () => undefined,
+    );
+    this.viewChains.set(webviewId, next);
+    void next.finally(() => {
+      if (this.viewChains.get(webviewId) === next) this.viewChains.delete(webviewId);
+    });
+    return run;
   }
 
   async closeSession(id: string): Promise<void> {

--- a/apps/vscode/test/kimi-runtime.test.ts
+++ b/apps/vscode/test/kimi-runtime.test.ts
@@ -396,6 +396,91 @@ describe("Kimi runtime (owns shared SDK sessions for Webviews)", () => {
     expect(boundary.handlerInstallations).toEqual({ approval: 1, question: 1 });
   });
 
+  it("does not double-wrap the SDK session when two opens race for it", async () => {
+    const sdk = createFakeHarness();
+    const broadcasts: { event: string; data: unknown; webviewId?: string }[] = [];
+    const runtime = new KimiRuntime({
+      version: "0.6.0",
+      harness: sdk.harness,
+      broadcast: (event, data, webviewId) => {
+        broadcasts.push({ event, data, webviewId });
+      },
+      captureBaseline: () => undefined,
+      log: () => undefined,
+    });
+    const boundary = sdk.addSession("saved-1", "/workspace");
+
+    const [first, second] = await Promise.all([
+      runtime.openSession(openOptions({ sessionId: "saved-1" })),
+      runtime.openSession(openOptions({ sessionId: "saved-1" })),
+    ]);
+
+    expect(second).toBe(first);
+    expect(boundary.subscriptionCount()).toBe(1);
+
+    boundary.emit({
+      type: "assistant.delta",
+      sessionId: "saved-1",
+      agentId: "main",
+      turnId: 1,
+      delta: "Hello",
+    });
+
+    const parts = broadcasts.filter(
+      ({ data }) => (data as { type?: string }).type === "ContentPart",
+    );
+    expect(parts).toHaveLength(1);
+  });
+
+  it("coalesces two concurrent new-session opens for one view onto one session", async () => {
+    const { runtime, sdk } = createRuntime();
+
+    const [first, second] = await Promise.all([
+      runtime.openSession(openOptions()),
+      runtime.openSession(openOptions()),
+    ]);
+
+    expect(second).toBe(first);
+    expect(sdk.createInputs).toHaveLength(1);
+    expect(first.subscribers).toEqual(["view-1"]);
+  });
+
+  it("does not double-wrap the SDK session when two attaches race for it", async () => {
+    const sdk = createFakeHarness();
+    const broadcasts: { event: string; data: unknown; webviewId?: string }[] = [];
+    const runtime = new KimiRuntime({
+      version: "0.6.0",
+      harness: sdk.harness,
+      broadcast: (event, data, webviewId) => {
+        broadcasts.push({ event, data, webviewId });
+      },
+      captureBaseline: () => undefined,
+      log: () => undefined,
+    });
+    const boundary = sdk.addSession("saved-1", "/workspace");
+
+    const [first, second] = await Promise.all([
+      runtime.attachResumedSession("view-1", boundary.session),
+      runtime.attachResumedSession("view-1", boundary.session),
+    ]);
+
+    expect(second).toBe(first);
+    expect(boundary.subscriptionCount()).toBe(1);
+
+    boundary.emit({
+      type: "assistant.delta",
+      sessionId: "saved-1",
+      agentId: "main",
+      turnId: 1,
+      delta: "Hello",
+    });
+
+    const parts = broadcasts.filter(
+      ({ data }) => (data as { type?: string }).type === "ContentPart",
+    );
+    expect(parts).toHaveLength(1);
+  });
+
   it("preserves the resumed session's model instead of reapplying the configured default", async () => {
     const { runtime, sdk } = createRuntime();
     const session = sdk.addSession("saved-1", "/workspace", { model: "old-model" });


### PR DESCRIPTION
## Related Issue

No linked issue — this comes from an internal bug report (VS Code extension, duplicated streaming output).

## Problem

In the VS Code extension, a streamed assistant reply would occasionally render every character twice and list each tool call twice in the same turn, while the persisted conversation history stayed correct. Reloading the window or starting a new session made it disappear.

Root cause: `KimiRuntime.openSession` / `attachResumedSession` check the `sessions` map synchronously, then run several awaited steps (resume RPC, metadata/status calls) before registering the new `SessionRuntime`. Two overlapping opens for the same webview both miss the map and both wrap the same SDK `Session` facade (the Node SDK harness coalesces concurrent resumes onto one facade). Each wrapper subscribes to session events and broadcasts to the same webview, so every delta and tool call is delivered twice; the overwritten wrapper is never closed and keeps duplicating for the rest of the window's lifetime. Natural triggers are back-to-back bridge calls within milliseconds (e.g. rapid double-select of a history session, a queued auto-send racing a session switch), not slow user machines.

## What changed

- `KimiRuntime`: queue `openSession`, `attachResumedSession`, and `detachView` per `webviewId` (the same promise-chain pattern as `SessionManagerService.serializeLifecycle` in agent-core-v2). A view shows at most one session, so per-view serialization is the natural boundary; the second overlapping call now runs after the first one registers its runtime and takes the existing dedupe path. Method bodies moved to `*Inner` methods, and internal calls use `detachViewInner` to avoid self-deadlock on the chain.
- Tests: three regression cases in `apps/vscode/test/kimi-runtime.test.ts` (raced resume-open, raced attach, raced create) asserting a single runtime, a single SDK event subscription, and exactly one broadcast per delta. They were red before the fix and are green after; a manual repro with an artificial 300 ms delay in the open path showed duplicated output before the fix and clean output after.
- Changeset for `kimi-code` (patch).

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue (external PRs: the issue must have a maintainer's `/approve`).
- [x] I have added tests that prove my feature works.
- [x] Ran the gen-changesets skill, or this PR needs no changeset.
- [x] Ran the gen-docs skill, or this PR needs no doc update.
