### PR TITLE
fix(agent-core-v2): retry failed wire journal repair before accepting appends

### DIFF
--- a/packages/agent-core-v2/src/wire/repair.ts
+++ b/packages/agent-core-v2/src/wire/repair.ts
@@ -23,7 +23,7 @@ export async function repairWireJournal(
   key: string,
   records: readonly unknown[],
   truncation: AppendLogTruncation,
-): Promise<void> {
+): Promise<'repaired' | 'failed'> {
   const { appendLog, storage, log, telemetry } = services;
   let backupCreated = false;
   let outcome: 'repaired' | 'failed' = 'repaired';
@@ -60,6 +60,7 @@ export async function repairWireJournal(
     dropped_count: droppedCount,
     backup_created: backupCreated,
   });
+  return outcome;
 }
 
 function countJournalLines(data: Uint8Array): number {

--- a/packages/agent-core-v2/src/wire/wireService.ts
+++ b/packages/agent-core-v2/src/wire/wireService.ts
@@ -39,6 +39,10 @@ export class WireService extends Service implements IWireService {
 
   private readonly wireScope: string;
   private persistQueue: Promise<void> | undefined;
+  private pendingRepair:
+    | { readonly records: WireRecord[]; readonly truncation: AppendLogTruncation }
+    | undefined;
+  private persistError: Error | undefined;
 
   constructor(
     @IAgentScopeContext scopeContext: IAgentScopeContext,
@@ -63,7 +67,11 @@ export class WireService extends Service implements IWireService {
   }
 
   appendRecord(record: WireRecord, dehydrate?: RecordDehydrator): void {
-    if (dehydrate === undefined && this.persistQueue === undefined) {
+    if (
+      this.pendingRepair === undefined &&
+      dehydrate === undefined &&
+      this.persistQueue === undefined
+    ) {
       try {
         this.appendRecordLow(record);
       } catch (error) {
@@ -77,6 +85,9 @@ export class WireService extends Service implements IWireService {
       ) as Promise<readonly unknown[]>;
     const queued = (this.persistQueue ?? Promise.resolve())
       .then(async () => {
+        if (this.pendingRepair !== undefined) {
+          await this.repairPendingJournal();
+        }
         const output = dehydrate === undefined ? record : await dehydrate(record, transform);
         this.appendRecordLow(output);
       })
@@ -165,7 +176,7 @@ export class WireService extends Service implements IWireService {
         records.push(record);
       }
     }
-    await repairWireJournal(
+    const outcome = await repairWireJournal(
       {
         appendLog: this.log,
         storage: this.storage,
@@ -177,10 +188,35 @@ export class WireService extends Service implements IWireService {
       records,
       truncation,
     );
+    this.pendingRepair = outcome === 'failed' ? { records, truncation } : undefined;
+  }
+
+  private async repairPendingJournal(): Promise<void> {
+    const pending = this.pendingRepair;
+    if (pending === undefined) return;
+    await this.repairJournal(pending.truncation, pending.records);
+    if (this.pendingRepair !== undefined) {
+      const error = new WireError(
+        WireErrors.codes.RECORDS_WRITE_FAILED,
+        'Wire journal repair did not complete; record was not appended',
+        {
+          details: {
+            scope: this.wireScope,
+            key: AGENT_WIRE_RECORD_KEY,
+            lineNumber: pending.truncation.lineNumber,
+          },
+        },
+      );
+      this.persistError = error;
+      throw error;
+    }
   }
 
   async flush(): Promise<void> {
     await this.persistQueue;
+    const persistError = this.persistError;
+    this.persistError = undefined;
+    if (persistError !== undefined) throw persistError;
     await this.log.flush();
   }
 

--- a/packages/agent-core-v2/test/wire/wireService.test.ts
+++ b/packages/agent-core-v2/test/wire/wireService.test.ts
@@ -14,6 +14,7 @@ import { IAppendLogStore } from '#/persistence/interface/appendLogStore';
 import { IFileSystemStorageService, StorageError, StorageErrors } from '#/persistence/interface/storage';
 import { WIRE_PROTOCOL_VERSION } from '#/wire/migration/migration';
 import { wireJournalBackupKey } from '#/wire/repair';
+import { WireError, WireErrors } from '#/wire/errors';
 import { IWireService } from '#/wire/wire';
 import { AGENT_WIRE_RECORD_KEY, type WireRecord } from '#/wire/record';
 
@@ -590,6 +591,147 @@ describe('WireService corruption repair', () => {
         },
       },
     ]);
+  });
+
+  it('retries a failed repair before the next append and heals the journal first', async () => {
+    const capture: RepairCapture = { warnings: [], events: [] };
+    const svc = wireWithCapture(KEY, capture);
+    const prefix = `${currentMetadata()}\n`;
+    const raw = `${prefix}GARBAGE\n`;
+    await seedCorrupt(raw);
+    const originalWrite = storage.write.bind(storage);
+    storage.write = async (scope, key, data, options) => {
+      if (key === AGENT_WIRE_RECORD_KEY) throw new Error('disk full');
+      return originalWrite(scope, key, data, options);
+    };
+    await collect(svc.readJournal());
+    storage.write = originalWrite;
+
+    svc.appendRecord({ type: 'wire.test.new', time: 7 });
+    await svc.flush();
+
+    expect(await rawBytes()).toBe(`${prefix}${JSON.stringify({ type: 'wire.test.new', time: 7 })}\n`);
+    expect(await rawBytes(BACKUP_KEY)).toBe(raw);
+    expect(await collect(svc.readJournal())).toEqual([
+      { type: 'metadata', protocol_version: WIRE_PROTOCOL_VERSION, created_at: 1 },
+      { type: 'wire.test.new', time: 7 },
+    ]);
+    expect(capture.events).toEqual([
+      {
+        name: 'wire_repair',
+        payload: {
+          kind: 'corrupted',
+          outcome: 'failed',
+          dropped_count: 1,
+          backup_created: true,
+        },
+      },
+      {
+        name: 'wire_repair',
+        payload: {
+          kind: 'corrupted',
+          outcome: 'repaired',
+          dropped_count: 1,
+          backup_created: false,
+        },
+      },
+    ]);
+  });
+
+  it('refuses to append behind the corrupted tail while a failed repair keeps failing', async () => {
+    const capture: RepairCapture = { warnings: [], events: [] };
+    const svc = wireWithCapture(KEY, capture);
+    const prefix = `${currentMetadata()}\n`;
+    const raw = `${prefix}GARBAGE\n`;
+    await seedCorrupt(raw);
+    const originalWrite = storage.write.bind(storage);
+    storage.write = async (scope, key, data, options) => {
+      if (key === AGENT_WIRE_RECORD_KEY) throw new Error('disk full');
+      return originalWrite(scope, key, data, options);
+    };
+    await collect(svc.readJournal());
+
+    const unexpected: unknown[] = [];
+    setUnexpectedErrorHandler((error) => unexpected.push(error));
+    try {
+      svc.appendRecord({ type: 'wire.test.doomed', time: 8 });
+      await expect(svc.flush()).rejects.toThrow('Wire journal repair did not complete');
+
+      expect(await rawBytes()).toBe(raw);
+      expect(unexpected).toHaveLength(1);
+      expect(unexpected[0]).toBeInstanceOf(WireError);
+      expect((unexpected[0] as WireError).code).toBe(WireErrors.codes.RECORDS_WRITE_FAILED);
+      expect(capture.events).toEqual([
+        {
+          name: 'wire_repair',
+          payload: {
+            kind: 'corrupted',
+            outcome: 'failed',
+            dropped_count: 1,
+            backup_created: true,
+          },
+        },
+        {
+          name: 'wire_repair',
+          payload: {
+            kind: 'corrupted',
+            outcome: 'failed',
+            dropped_count: 1,
+            backup_created: false,
+          },
+        },
+      ]);
+    } finally {
+      resetUnexpectedErrorHandler();
+    }
+  });
+
+  it('surfaces the discarded record to flush callers when the repair never reaches the rewrite', async () => {
+    const capture: RepairCapture = { warnings: [], events: [] };
+    const svc = wireWithCapture(KEY, capture);
+    const prefix = `${currentMetadata()}\n`;
+    const raw = `${prefix}GARBAGE\n`;
+    await seedCorrupt(raw);
+    const originalWrite = storage.write.bind(storage);
+    storage.write = async (scope, key, data, options) => {
+      if (key === BACKUP_KEY) throw new Error('disk full');
+      return originalWrite(scope, key, data, options);
+    };
+    await collect(svc.readJournal());
+
+    const unexpected: unknown[] = [];
+    setUnexpectedErrorHandler((error) => unexpected.push(error));
+    try {
+      svc.appendRecord({ type: 'wire.test.doomed', time: 9 });
+      await expect(svc.flush()).rejects.toThrow('Wire journal repair did not complete');
+
+      expect(await rawBytes()).toBe(raw);
+      expect(unexpected).toHaveLength(1);
+      expect(unexpected[0]).toBeInstanceOf(WireError);
+      expect((unexpected[0] as WireError).code).toBe(WireErrors.codes.RECORDS_WRITE_FAILED);
+      expect(capture.events).toEqual([
+        {
+          name: 'wire_repair',
+          payload: {
+            kind: 'corrupted',
+            outcome: 'failed',
+            dropped_count: 1,
+            backup_created: false,
+          },
+        },
+        {
+          name: 'wire_repair',
+          payload: {
+            kind: 'corrupted',
+            outcome: 'failed',
+            dropped_count: 1,
+            backup_created: false,
+          },
+        },
+      ]);
+    } finally {
+      resetUnexpectedErrorHandler();
+    }
   });
 });
 


### PR DESCRIPTION
## Related Issue

Addresses the Codex P1 review on #3281. This PR is stacked on #3281: the branch contains its commit, so until #3281 merges the diff shows both changes; once #3281 merges, the diff reduces to this fix alone.

## Problem

On #3281, when the on-disk repair of a corrupted wire journal fails — most notably when backup creation fails while the disk is full — restore continues with the valid prefix, but the append log stays writable behind the corrupted tail. If disk space is freed before the next event, that event is appended after the still-corrupted line, and the next restore truncates at the original corruption, silently discarding every record written behind it. A failed repair must therefore quarantine the log or retry before accepting writes, rather than allow new durable activity behind the corrupted tail.

## What changed

- `repairWireJournal` returns its outcome (`'repaired' | 'failed'`).
- `WireService` keeps a sticky `pendingRepair` marker (valid-prefix records + truncation info) whenever a repair fails.
- While the marker is set, `appendRecord` no longer takes the synchronous fast path: appends go through the persist queue, which first retries the repair. A successful retry heals the file (its rewrite also lifts the append-log store's sticky storage failure) before the record is appended. A still-failing retry throws `WireError(records.write_failed)`, surfaced through `onUnexpectedError`, and the record is never written — no doomed durable activity behind the corrupted tail.
- The fork path's read-only repair call site is unchanged.

Tests cover both ends: retry-then-heal ordering (file ends up as valid prefix + new record, telemetry sequence `failed → repaired`, backup not recreated) and refuse-while-failing (file bytes unchanged, no record appended behind the corrupted line, `records.write_failed` surfaced).

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue (external PRs: the issue must have a maintainer's `/approve`).
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset. (No new changeset: internal hardening of the unreleased feature whose user-facing entry ships with #3281.)
- [x] Ran `gen-docs` skill, or this PR needs no doc update.
