### PR TITLE
fix(transcript): drop rewound turns' prompts on items.remove

### DIFF
--- a/packages/transcript/src/ops/apply.ts
+++ b/packages/transcript/src/ops/apply.ts
@@ -413,14 +413,19 @@ function applyItemsRemove(state: AgentState, ids: readonly string[]): ApplyResul
   if (items.length === state.items.length) return { state, changed: false };
   let pending = state.pendingInteractions;
   let interactions = state.interactions;
+  let prompts = state.prompts;
   if (removedTurns.length > 0) {
     const anchoredToolCallIds = new Set<string>();
+    const removedPromptIds = new Set<PromptId>();
     const nextPending = new Set(pending);
     const deadEntityIds = new Set<InteractionId>();
     for (const turn of removedTurns) {
       for (const step of turn.steps) {
         for (const frame of step.frames) {
           if (frame.kind === 'tool') anchoredToolCallIds.add(frame.toolCallId);
+          if (frame.kind === 'text' && frame.role === 'user' && frame.promptIds !== undefined) {
+            for (const promptId of frame.promptIds) removedPromptIds.add(promptId);
+          }
         }
       }
     }
@@ -436,8 +441,34 @@ function applyItemsRemove(state: AgentState, ids: readonly string[]): ApplyResul
       interactions = nextInteractions;
     }
     pending = nextPending;
+    // A turn's own prompt entity shares the turn's time bounds; a steered
+    // prompt's entity is paired by the frame's promptIds. Drop both so a
+    // rewound turn can't leave its prompts behind to cover a fresh send.
+    const removedTimeBounds = removedTurns.map((turn) => ({
+      startedAt: turn.startedAt,
+      endedAt: turn.endedAt,
+    }));
+    const nextPrompts = new Map(prompts);
+    let promptsChanged = false;
+    for (const [promptId, prompt] of prompts) {
+      if (removedPromptIds.has(promptId)) {
+        nextPrompts.delete(promptId);
+        promptsChanged = true;
+        continue;
+      }
+      for (const bounds of removedTimeBounds) {
+        if (bounds.startedAt === undefined) continue;
+        const end = bounds.endedAt ?? bounds.startedAt;
+        if (prompt.createdAt >= bounds.startedAt && prompt.createdAt <= end) {
+          nextPrompts.delete(promptId);
+          promptsChanged = true;
+          break;
+        }
+      }
+    }
+    if (promptsChanged) prompts = nextPrompts;
   }
-  return { state: { ...state, items, interactions, pendingInteractions: pending }, changed: true };
+  return { state: { ...state, items, interactions, prompts, pendingInteractions: pending }, changed: true };
 }
 
 function applyTaskUpsert(state: AgentState, task: TranscriptTask): ApplyResult {

--- a/packages/transcript/test/store.test.ts
+++ b/packages/transcript/test/store.test.ts
@@ -357,6 +357,71 @@ describe('AgentTranscript', () => {
     expect(tx.listPendingInteractions()).toEqual([]);
   });
 
+  it('items.remove drops prompts paired by steered frames and time bounds', () => {
+    const tx = new AgentTranscript('main');
+    tx.apply([
+      {
+        op: 'prompt.upsert',
+        prompt: {
+          promptId: 'p-turn',
+          status: 'completed',
+          createdAt: '2026-08-26T15:00:00.000Z',
+        },
+      },
+      {
+        op: 'prompt.upsert',
+        prompt: {
+          promptId: 'p-steer',
+          status: 'completed',
+          createdAt: '2026-08-26T15:01:00.000Z',
+          steeredAt: '2026-08-26T15:01:30.000Z',
+        },
+      },
+      {
+        op: 'prompt.upsert',
+        prompt: {
+          promptId: 'p-other',
+          status: 'completed',
+          createdAt: '2026-08-26T14:00:00.000Z',
+        },
+      },
+      {
+        op: 'turn.upsert',
+        turn: {
+          kind: 'turn',
+          turnId: 't1',
+          ordinal: 1,
+          state: 'completed',
+          origin: { kind: 'user' },
+          prompt: 'hi',
+          startedAt: '2026-08-26T15:00:00.000Z',
+          endedAt: '2026-08-26T15:02:00.000Z',
+        },
+      },
+      {
+        op: 'step.upsert',
+        turnId: 't1',
+        step: { kind: 'step', stepId: 't1.1', turnId: 't1', ordinal: 1, state: 'completed' },
+      },
+      {
+        op: 'frame.upsert',
+        turnId: 't1',
+        stepId: 't1.1',
+        frame: {
+          kind: 'text',
+          frameId: 't1.1.f1',
+          role: 'user',
+          text: 'steered',
+          promptIds: ['p-steer'],
+        },
+      },
+    ]);
+
+    expect(tx.snapshot().prompts.map((p) => p.promptId)).toEqual(['p-turn', 'p-steer', 'p-other']);
+    tx.apply([{ op: 'items.remove', ids: ['t1'] }]);
+    expect(tx.snapshot().prompts.map((p) => p.promptId)).toEqual(['p-other']);
+  });
+
   it('receive() equals full reset seed; snapshot windowing keeps newest turns', () => {
     const tx = new AgentTranscript('main');
     for (let n = 1; n <= 5; n += 1) {


### PR DESCRIPTION
context.undone 移除 turns 时，applyItemsRemove 只清理 items 和 interactions，不移除 prompts。被撤销 turn 的 prompt 实体残留在 prompts 中，导致前端 uncertainEchoMatchedIds 可能匹配到已撤销 turn 的 prompt 实体，乐观气泡被错误覆盖。

applyItemsRemove 现在联动移除相关 prompts：steer 消息的 prompt（通过 frame 的 promptIds 配对）和 turn 自身的 prompt（通过 turn 的时间边界匹配）。

packages/transcript/test/store.test.ts 全部 28 个测试通过。