### PR TITLE
fix(transcript): carry the orchestrator's prompt on subagent turns

### DIFF
--- a/.changeset/subagent-turn-prompts.md
+++ b/.changeset/subagent-turn-prompts.md
@@ -1,0 +1,6 @@
+---
+"@moonshot-ai/agent-core-v2": patch
+"@moonshot-ai/transcript": patch
+---
+
+Carry the orchestrator's prompt on subagent turns: `isDisplayablePromptOrigin` now accepts `system_trigger/subagent`, so live `turn.started` events include the prompt, and cold rebuild folds the opening input (text and attachments) into turns opened by subagent run messages. Other system triggers (goal_continuation, stop_hook, loadable-tools) remain promptless.

--- a/packages/agent-core-v2/src/agent/loop/turnEvents.ts
+++ b/packages/agent-core-v2/src/agent/loop/turnEvents.ts
@@ -69,6 +69,7 @@ export function turnPromptAttachments(
 
 export function isDisplayablePromptOrigin(origin: PromptOrigin): boolean {
   if (origin.kind === 'user') return true;
+  if (origin.kind === 'system_trigger' && origin.name === 'subagent') return true;
   return (
     (origin.kind === 'skill_activation' || origin.kind === 'plugin_command') &&
     origin.trigger === 'user-slash'

--- a/packages/agent-core-v2/test/agent/loop/loop.test.ts
+++ b/packages/agent-core-v2/test/agent/loop/loop.test.ts
@@ -844,6 +844,32 @@ describe('Agent loop', () => {
     expect(prompts).toEqual([undefined, 'hi']);
   });
 
+  it('carries the turn.started prompt for subagent system triggers', async () => {
+    const prompts: Array<string | undefined> = [];
+    const subscription = ctx.get(IEventBus).subscribe(TurnStarted, (event) => {
+      prompts.push(event.prompt);
+    });
+    ctx.mockNextResponse({ type: 'text', text: 'scanned' });
+
+    const subagent = (
+      await loop.enqueue(
+        new MessageStepRequest(
+          {
+            role: 'user',
+            content: [{ type: 'text', text: 'scan the repo' }],
+            toolCalls: [],
+            origin: { kind: 'system_trigger', name: 'subagent' },
+          },
+          { admission: 'newTurn' },
+        ),
+      ).assigned
+    ).turn;
+    await subagent.result;
+    subscription.dispose();
+
+    expect(prompts).toEqual(['scan the repo']);
+  });
+
   it('carries kimi-file prompt attachments on turn.started, falling back to the URL file id', async () => {
     const payloads: Array<readonly { kind: string; fileId: string }[] | undefined> = [];
     const subscription = ctx.get(IEventBus).subscribe(TurnStarted, (event) => {

--- a/packages/kap-server/test/search/wireExtract.test.ts
+++ b/packages/kap-server/test/search/wireExtract.test.ts
@@ -56,6 +56,14 @@ describe('extractFromWireLine', () => {
     },
   );
 
+  it('filters out subagent system triggers even though they open transcript turns', () => {
+    expect(
+      extractFromWireLine(
+        userRecord('scan the repo', 1_700_000_000_000, { kind: 'system_trigger', name: 'subagent' }),
+      ),
+    ).toEqual([]);
+  });
+
   it.each(['skill_activation', 'plugin_command'])(
     'keeps %s messages the user typed as a slash command',
     (kind) => {

--- a/packages/kap-server/test/services/transcript.test.ts
+++ b/packages/kap-server/test/services/transcript.test.ts
@@ -175,6 +175,31 @@ describe('AgentTranscriptProjector', () => {
     expect(turn.state).toBe('completed');
   });
 
+  it('projects the live prompt for subagent system triggers and keeps it through turn.ended', () => {
+    const projector = new AgentTranscriptProjector('main', TEST_SESSION_ID);
+    const tx = new AgentTranscript('main');
+    const feed = (event: ProjectorBusEvent): void => {
+      tx.apply(projector.map(event));
+    };
+
+    feed(
+      ev({
+        type: 'turn.started',
+        turnId: 0,
+        origin: { kind: 'system_trigger', name: 'subagent' },
+        prompt: 'scan the repo',
+        promptAttachments: [{ kind: 'image', fileId: 'file_1' }],
+      }),
+    );
+    feed(ev({ type: 'assistant.delta', turnId: 0, delta: 'scanning' }));
+    feed(ev({ type: 'turn.ended', turnId: 0, reason: 'completed' }));
+
+    const turn = turnOps('t0', tx.getItems());
+    expect(turn.prompt).toBe('scan the repo');
+    expect(turn.attachmentIds).toEqual(['t0.att1']);
+    expect(turn.state).toBe('completed');
+  });
+
   it('projects turn.started promptAttachments into attachment entities and turn.attachmentIds', () => {
     const projector = new AgentTranscriptProjector('main', TEST_SESSION_ID);
     const tx = new AgentTranscript('main');

--- a/packages/kap-server/test/transcript.test.ts
+++ b/packages/kap-server/test/transcript.test.ts
@@ -1055,9 +1055,10 @@ describe('server-v2 /api/v1/sessions/{sid}/transcript', () => {
     const main = byAgent.get('main')!;
     expect(main.messages.map((m) => [m.turn_id, m.prompt])).toEqual([
       ['t0', 'hi'],
+      ['t1', 'subagent run prompt'],
       ['t2', 'second question'],
     ]);
-    expect(main.messages[1]!.attachment_ids).toEqual(['att_1']);
+    expect(main.messages[2]!.attachment_ids).toEqual(['att_1']);
     expect(main.attachments).toEqual([
       expect.objectContaining({
         attachmentId: 'att_1',

--- a/packages/node-sdk/test/session-prompt-events.test.ts
+++ b/packages/node-sdk/test/session-prompt-events.test.ts
@@ -14,7 +14,7 @@ import { KIMI_CODE_PLATFORM } from '@moonshot-ai/kimi-code-oauth';
 import type * as KosongModule from '@moonshot-ai/kosong';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { createKimiHarness, type Event, type KimiHarness } from '#/index';
+import { createKimiHarness, createKimiHarnessV2, type Event, type KimiHarness } from '#/index';
 
 import { TEST_IDENTITY } from './test-identity';
 
@@ -343,6 +343,70 @@ describe('Session.prompt events', () => {
       const state = JSON.parse(await readFile(statePath, 'utf-8')) as Record<string, unknown>;
       expect(state['lastPrompt']).toBeUndefined();
     } finally {
+      await harness.close();
+    }
+  });
+
+  it('carries the prompt on the public turn.started event for subagent system triggers (v2 engine)', async () => {
+    const homeDir = await makeTempDir();
+    const workDir = await makeTempDir();
+    const harness = createKimiHarnessV2({
+      identity: TEST_IDENTITY,
+      homeDir,
+    });
+    const sseChunk = (delta: Record<string, unknown>, finishReason: string | null = null): string =>
+      `data: ${JSON.stringify({
+        id: 'chatcmpl-stub',
+        object: 'chat.completion.chunk',
+        created: 0,
+        model: 'fake-model',
+        choices: [{ index: 0, delta, finish_reason: finishReason }],
+      })}`;
+    const fetchStub = vi.spyOn(globalThis, 'fetch').mockImplementation(async (input) => {
+      const url = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url;
+      if (url === 'https://model.example.test/v1/chat/completions') {
+        const body = [sseChunk({ role: 'assistant', content: 'init done' }), sseChunk({}, 'stop'), 'data: [DONE]']
+          .map((line) => line + '\n\n')
+          .join('');
+        return new Response(body, {
+          status: 200,
+          headers: { 'Content-Type': 'text/event-stream' },
+        });
+      }
+      throw new Error(`Unexpected fetch: ${url}`);
+    });
+
+    try {
+      await harness.setConfig({
+        providers: {
+          local: { type: 'openai', baseUrl: 'https://model.example.test/v1', apiKey: 'sk-test' },
+        },
+        models: {
+          'fake-model': { provider: 'local', model: 'fake-model', maxContextSize: 262144 },
+        },
+        defaultModel: 'fake-model',
+      });
+      const session = await harness.createSession({ id: 'ses_init_rpc_v2', workDir });
+      const events: Event[] = [];
+      const unsubscribe = session.onEvent((event) => {
+        events.push(event);
+      });
+
+      await session.init();
+      unsubscribe();
+
+      const spawned = events.find((event) => event.type === 'subagent.spawned');
+      expect(events).toContainEqual(
+        expect.objectContaining({
+          type: 'turn.started',
+          sessionId: session.id,
+          agentId: spawned?.type === 'subagent.spawned' ? spawned.subagentId : undefined,
+          origin: { kind: 'system_trigger', name: 'subagent' },
+          prompt: expect.stringContaining('Task requirements:'),
+        }),
+      );
+    } finally {
+      fetchStub.mockRestore();
       await harness.close();
     }
   });

--- a/packages/transcript/src/history/groupTurns.ts
+++ b/packages/transcript/src/history/groupTurns.ts
@@ -199,7 +199,11 @@ export function groupMessagesIntoSnapshot(
     if (message.role === 'user') {
       if (originKind !== undefined && HIDDEN_USER_ORIGINS.has(originKind)) {
         if (opensOwnTurn(message)) {
-          startTurn(mapOrigin(message));
+          const opening =
+            (message.origin as { name?: unknown }).name === 'subagent'
+              ? foldTurnOpeningInput(message)
+              : undefined;
+          startTurn(mapOrigin(message), opening?.text || undefined, opening?.attachmentIds);
         }
         continue;
       }

--- a/packages/transcript/test/layers.test.ts
+++ b/packages/transcript/test/layers.test.ts
@@ -991,7 +991,7 @@ describe('groupMessagesIntoSnapshot (cold path)', () => {
     if (subTurn?.kind !== 'turn') throw new Error('expected turn');
     expect(subTurn.ordinal).toBe(1);
     expect(subTurn.origin.kind).toBe('other');
-    expect(subTurn.prompt).toBeUndefined();
+    expect(subTurn.prompt).toBe('scan the repo');
     expect(subTurn.steps).toHaveLength(1);
   });
 


### PR DESCRIPTION
## Related Issue

None — internal bug fix (reported from the code-app desktop client).

## Problem

In the right-sidebar subagent panel (code-app desktop/web), when the orchestrator resumes a subagent, the follow-up message overwrites the original task brief in the panel's prompt bubble instead of appearing as a new user message after the first turn's AI messages.

Root cause: subagent turns never carry `prompt`. The `system_trigger/subagent` origin is classified as non-displayable, so both the live projection (`turn.started` gated by `isDisplayablePromptOrigin`) and the cold rebuild (`groupTurns`) drop the prompt text. Clients therefore cannot render per-turn user messages for a subagent and synthesize a single bubble from the main transcript's Agent tool call — which a resume re-links to the LATEST spawning call, replacing P1 with P2.

## What changed

- `isDisplayablePromptOrigin` now also accepts `system_trigger` origins named `subagent`, so live `turn.started` events carry the prompt for subagent run turns. Other system triggers (`goal_continuation`, `stop_hook`, `loadable-tools`) stay promptless.
- Cold rebuild folds the opening input (text + attachments, via the existing `foldTurnOpeningInput`) into the turn for `subagent` origins only; `goal_continuation` remains promptless.
- The transcript projector, heal, live-overlay and wire schemas needed no changes — `prompt` was already an optional field end to end.
- Tests: updated existing expectations (transcript layers, kap-server cold `/transcript/user-messages`) and added coverage for the loop gate (subagent carries, goal_continuation does not), the live projector (prompt + attachments), a wire-index exclusion guard (subagent turns stay out of the cold search index), and the public node-sdk `turn.started` event on the v2 engine.

Behavior change to be aware of: the public SDK `turn.started` event for subagent system triggers now includes `prompt`, and `/transcript/user-messages` plus live search start exposing subagent prompts (the cold wire index intentionally does not).

Companion client change: code-app PR (anchors the panel bubble to the subagent's own transcript).

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue (external PRs: the issue must have a maintainer's `/approve`). — N/A, internal fix.
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset. — Changeset added for `@moonshot-ai/agent-core-v2` and `@moonshot-ai/transcript` (patch); no CLI entry.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.
