### PR TITLE
fix(agent-core-v2): notify the model of previous background tasks terminated by app exit

### DIFF
--- a/.changeset/task-resume-termination-reminder.md
+++ b/.changeset/task-resume-termination-reminder.md
@@ -2,4 +2,4 @@
 "@moonshot-ai/kimi-code": patch
 ---
 
-When a session resumes after the app exited, the assistant is now told that its previously running background tasks were terminated.
+When a session resumes, the assistant is warned that background tasks from the previous session may still be running.

--- a/.changeset/task-resume-termination-reminder.md
+++ b/.changeset/task-resume-termination-reminder.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+When a session resumes after the app exited, the assistant is now told that its previously running background tasks were terminated.

--- a/packages/agent-core-v2/docs/state-manifest.d.ts
+++ b/packages/agent-core-v2/docs/state-manifest.d.ts
@@ -1326,6 +1326,7 @@ export interface AgentStateSnapshot {
     readonly endedAt: number | null;
     readonly stopReason?: string;
     readonly terminalNotificationSuppressed?: boolean;
+    readonly resumeReminded?: boolean;
     readonly timeoutMs?: number;
   } | /* SubagentTaskInfo — packages/agent-core-v2/src/agent/tools/agent/subagent-task.ts */ {
     readonly kind: 'agent';
@@ -1342,6 +1343,7 @@ export interface AgentStateSnapshot {
     readonly endedAt: number | null;
     readonly stopReason?: string;
     readonly terminalNotificationSuppressed?: boolean;
+    readonly resumeReminded?: boolean;
     readonly timeoutMs?: number;
   } | /* ProcessTaskInfo — packages/agent-core-v2/src/agent/tools/os/bash/process-task.ts */ {
     readonly kind: 'process';
@@ -1357,6 +1359,7 @@ export interface AgentStateSnapshot {
     readonly endedAt: number | null;
     readonly stopReason?: string;
     readonly terminalNotificationSuppressed?: boolean;
+    readonly resumeReminded?: boolean;
     readonly timeoutMs?: number;
   }>;
   // src/agent/task/taskService.ts
@@ -1374,6 +1377,7 @@ export interface AgentStateSnapshot {
     readonly endedAt: number | null;
     readonly stopReason?: string;
     readonly terminalNotificationSuppressed?: boolean;
+    readonly resumeReminded?: boolean;
     readonly timeoutMs?: number;
   } | /* SubagentTaskInfo — packages/agent-core-v2/src/agent/tools/agent/subagent-task.ts */ {
     readonly kind: 'agent';
@@ -1390,6 +1394,7 @@ export interface AgentStateSnapshot {
     readonly endedAt: number | null;
     readonly stopReason?: string;
     readonly terminalNotificationSuppressed?: boolean;
+    readonly resumeReminded?: boolean;
     readonly timeoutMs?: number;
   } | /* ProcessTaskInfo — packages/agent-core-v2/src/agent/tools/os/bash/process-task.ts */ {
     readonly kind: 'process';
@@ -1405,6 +1410,7 @@ export interface AgentStateSnapshot {
     readonly endedAt: number | null;
     readonly stopReason?: string;
     readonly terminalNotificationSuppressed?: boolean;
+    readonly resumeReminded?: boolean;
     readonly timeoutMs?: number;
   }>;
   // replayable · durable · undoable — folds: ContextAppendMessage, TaskWaitDelivered

--- a/packages/agent-core-v2/src/agent/task/taskService.ts
+++ b/packages/agent-core-v2/src/agent/task/taskService.ts
@@ -562,7 +562,7 @@ export class AgentTaskService extends Disposable implements IAgentTaskService {
     for (const info of lostTasks) {
       this.recordTaskTerminated(info);
     }
-    await this.appendPreviousSessionTasksReminder();
+    this.appendPreviousSessionTasksReminder();
     await this.restoreAgentTaskNotifications();
     return lostTasks;
   }
@@ -1144,11 +1144,18 @@ export class AgentTaskService extends Disposable implements IAgentTaskService {
     }
   }
 
-  private async appendPreviousSessionTasksReminder(): Promise<void> {
+  private appendPreviousSessionTasksReminder(): void {
     const tasks: AgentTaskInfo[] = [];
     for (const info of this.ghosts.values()) {
       if (info.resumeReminded === true) continue;
       if (!isPreviousSessionTermination(info)) continue;
+      if (
+        this.hasPreviousSessionReminder(info.taskId) ||
+        (info.status === 'lost' && this.hasDeliveredTaskOrigin(info))
+      ) {
+        this.persistPreviousSessionReminderMarker(info);
+        continue;
+      }
       tasks.push(info);
     }
     if (tasks.length === 0) return;
@@ -1164,10 +1171,67 @@ export class AgentTaskService extends Disposable implements IAgentTaskService {
         { variant: TASK_RESUME_TERMINATION_VARIANT },
       );
     for (const info of tasks) {
-      const marked: AgentTaskInfo = { ...info, resumeReminded: true };
-      this.ghosts.set(info.taskId, marked);
-      await this.persistence.writeTask(marked);
+      this.firePreviousSessionLostTaskNotificationHook(info);
+      this.persistPreviousSessionReminderMarker(info);
     }
+  }
+
+  private hasPreviousSessionReminder(taskId: string): boolean {
+    const taskLinePrefix = `- ${taskId} "`;
+    return this.context.get().some((message) => {
+      if (
+        message.origin?.kind !== 'injection' ||
+        message.origin.variant !== TASK_RESUME_TERMINATION_VARIANT
+      ) {
+        return false;
+      }
+      return message.content.some(
+        (part) =>
+          part.type === 'text' &&
+          part.text.split('\n').some((line) => line.startsWith(taskLinePrefix)),
+      );
+    });
+  }
+
+  private hasDeliveredTaskOrigin(info: AgentTaskInfo): boolean {
+    const origin: TaskNotificationOrigin = {
+      taskId: info.taskId,
+      status: info.status,
+      notificationId: taskNotificationId(info.taskId, info.status),
+    };
+    const key = notificationKey(origin);
+    return (
+      this.states.get(taskNotificationDeliveryKey).includes(key) ||
+      this.deliveredNotificationKeys.has(key) ||
+      this.hasDeliveredNotification(key)
+    );
+  }
+
+  private persistPreviousSessionReminderMarker(info: AgentTaskInfo): void {
+    const marked: AgentTaskInfo = { ...info, resumeReminded: true };
+    this.ghosts.set(info.taskId, marked);
+    void this.persistence.writeTask(marked).catch((error: unknown) => {
+      this.log.error('previous-session task reminder marker write failed', {
+        taskId: info.taskId,
+        error,
+      });
+    });
+  }
+
+  private firePreviousSessionLostTaskNotificationHook(info: AgentTaskInfo): void {
+    if (info.status !== 'lost') return;
+    if (info.detached === false) return;
+    if (info.terminalNotificationSuppressed === true) return;
+    const origin: TaskNotificationOrigin = {
+      taskId: info.taskId,
+      status: info.status,
+      notificationId: taskNotificationId(info.taskId, info.status),
+    };
+    const key = notificationKey(origin);
+    if (this.scheduledNotificationKeys.has(key)) return;
+    if (this.deliveredNotificationKeys.has(key)) return;
+    if (this.hasDeliveredNotification(key)) return;
+    this.fireNotificationHook(buildAgentTaskNotification(info));
   }
 
   private async restoreAgentTaskNotification(info: AgentTaskInfo): Promise<void> {
@@ -1217,18 +1281,10 @@ export class AgentTaskService extends Disposable implements IAgentTaskService {
       if (this.deliveredNotificationKeys.has(key)) return undefined;
       if (this.hasDeliveredNotification(key)) return undefined;
       this.scheduledNotificationKeys.add(key);
-      const notification: AgentTaskNotification = {
-        id: origin.notificationId,
-        category: 'task',
-        type: `task.${info.status}`,
-        source_kind: 'background_task',
-        source_id: info.taskId,
-        agent_id: info.kind === 'agent' ? info.agentId : undefined,
-        title: `Background ${info.kind} ${info.status}`,
-        severity: info.status === 'completed' ? 'info' : 'warning',
-        body: buildAgentTaskNotificationBody(info),
-        children: agentTaskNotificationChildren(output),
-      };
+      const notification = buildAgentTaskNotification(
+        info,
+        agentTaskNotificationChildren(output),
+      );
       const content = [
         {
           type: 'text',
@@ -1450,6 +1506,24 @@ function buildAgentTaskNotificationBody(info: AgentTaskInfo): string {
   ].join('\n');
 
   return `${baseLine}${recovery}`;
+}
+
+function buildAgentTaskNotification(
+  info: AgentTaskInfo,
+  children?: readonly string[],
+): AgentTaskNotification {
+  return {
+    id: taskNotificationId(info.taskId, info.status),
+    category: 'task',
+    type: `task.${info.status}`,
+    source_kind: 'background_task',
+    source_id: info.taskId,
+    agent_id: info.kind === 'agent' ? info.agentId : undefined,
+    title: `Background ${info.kind} ${info.status}`,
+    severity: info.status === 'completed' ? 'info' : 'warning',
+    body: buildAgentTaskNotificationBody(info),
+    children,
+  };
 }
 
 function generateTaskId(kind: string): string {

--- a/packages/agent-core-v2/src/agent/task/taskService.ts
+++ b/packages/agent-core-v2/src/agent/task/taskService.ts
@@ -26,6 +26,7 @@ import { IAgentConversationUndoParticipantRegistry } from '#/agent/contextMemory
 import { IEventDispatcher } from '#/state/eventDispatcher';
 import type { ContextMessage, TaskOrigin } from '#/agent/contextMemory/types';
 import { activateReminderWhenReady } from '#/features/reminder/internal/reminderActivation';
+import { AgentReminder } from '#/features/reminder/reminderAgentRuntime';
 import { IAgentLifecycleService } from '#/session/agentLifecycle/agentLifecycle';
 import { IAgentLoopService } from '#/agent/loop/loop';
 import { MessageStepRequest } from '#/agent/loop/stepRequest';
@@ -165,6 +166,7 @@ const TASK_ID_ALPHABET = '0123456789abcdefghijklmnopqrstuvwxyz';
 const SESSION_CLOSED_REASON = 'Session closed';
 const NOTIFICATION_FALLBACK_PREVIEW_BYTES = 3_000;
 const ACTIVE_BACKGROUND_TASK_INJECTION_VARIANT = 'background_task_status';
+const TASK_RESUME_TERMINATION_VARIANT = 'task_resume_termination';
 const ACTIVE_BACKGROUND_TASK_GUIDANCE = [
   'The conversation was compacted, so the earlier messages that started these background tasks are gone — but the tasks are still running from before.',
   'Do not start duplicates. Use TaskList to list them, TaskOutput for a non-blocking status/output snapshot, and TaskStop to cancel one — completion arrives via automatic notification.',
@@ -239,7 +241,7 @@ export class AgentTaskService extends Disposable implements IAgentTaskService {
     @ITaskService private readonly taskService: ITaskService,
     @IEventBus private readonly eventBus: IEventBus,
     @IEventDispatcher private readonly dispatcher: IEventDispatcher,
-    @IAgentLifecycleService agentLifecycle: IAgentLifecycleService,
+    @IAgentLifecycleService private readonly agentLifecycle: IAgentLifecycleService,
     @IAgentLoopService private readonly loop: IAgentLoopService,
     @IAgentConversationUndoParticipantRegistry
     undoParticipants: IAgentConversationUndoParticipantRegistry,
@@ -560,6 +562,7 @@ export class AgentTaskService extends Disposable implements IAgentTaskService {
     for (const info of lostTasks) {
       this.recordTaskTerminated(info);
     }
+    await this.appendPreviousSessionTasksReminder();
     await this.restoreAgentTaskNotifications();
     return lostTasks;
   }
@@ -1136,7 +1139,34 @@ export class AgentTaskService extends Disposable implements IAgentTaskService {
   private async restoreAgentTaskNotificationsNow(): Promise<void> {
     for (const info of this.list(false)) {
       if (!isAgentTaskTerminal(info.status)) continue;
+      if (info.status === 'lost') continue;
       await this.restoreAgentTaskNotification(info);
+    }
+  }
+
+  private async appendPreviousSessionTasksReminder(): Promise<void> {
+    const tasks: AgentTaskInfo[] = [];
+    for (const info of this.ghosts.values()) {
+      if (info.resumeReminded === true) continue;
+      if (!isPreviousSessionTermination(info)) continue;
+      tasks.push(info);
+    }
+    if (tasks.length === 0) return;
+    const lines = tasks.map((info) => previousSessionTaskLine(info));
+    this.agentLifecycle
+      .resolve(this.scopeContext.agentContext, AgentReminder)
+      .notify(
+        [
+          'The user exited the application after your last turn, so your background tasks from the previous session lost contact:',
+          ...lines,
+          "Don't assume any of them completed; check current state (they may still be running), then re-run or resume only what you still need.",
+        ].join('\n'),
+        { variant: TASK_RESUME_TERMINATION_VARIANT },
+      );
+    for (const info of tasks) {
+      const marked: AgentTaskInfo = { ...info, resumeReminded: true };
+      this.ghosts.set(info.taskId, marked);
+      await this.persistence.writeTask(marked);
     }
   }
 
@@ -1451,6 +1481,22 @@ function createForegroundRelease(): ForegroundRelease {
 function errorMessage(error: unknown): string {
   if (error instanceof Error) return error.message;
   return String(error);
+}
+
+function previousSessionTaskLine(info: AgentTaskInfo): string {
+  if (info.kind === 'agent' && info.agentId !== undefined) {
+    return `- ${info.taskId} "${info.description}" (subagent) — resume it with Agent(resume="${info.agentId}", prompt="Pick up where you left off; redo the last tool call if its result was never observed.") to continue from its prior context.`;
+  }
+  return `- ${info.taskId} "${info.description}" (${info.kind === 'process' ? 'bash' : info.kind})`;
+}
+
+function isPreviousSessionTermination(info: AgentTaskInfo): boolean {
+  if (info.status === 'lost') return true;
+  return (
+    info.status === 'killed' &&
+    info.terminalNotificationSuppressed === true &&
+    info.stopReason === SESSION_CLOSED_REASON
+  );
 }
 
 registerScopedService(

--- a/packages/agent-core-v2/src/agent/task/types.ts
+++ b/packages/agent-core-v2/src/agent/task/types.ts
@@ -29,6 +29,7 @@ export interface AgentTaskInfoBase {
   readonly endedAt: number | null;
   readonly stopReason?: string;
   readonly terminalNotificationSuppressed?: boolean;
+  readonly resumeReminded?: boolean;
   readonly timeoutMs?: number;
 }
 

--- a/packages/agent-core-v2/test/agent/task/idle-notification-repro.test.ts
+++ b/packages/agent-core-v2/test/agent/task/idle-notification-repro.test.ts
@@ -364,7 +364,7 @@ describe('task notification → main agent (real Agent instance)', () => {
       }
     });
 
-    it('RESUME: terminal bg tasks discovered on reconcile are SILENTLY injected (no auto-turn)', async () => {
+    it('RESUME: previous-session lost tasks surface as one unified reminder (no auto-turn)', async () => {
 
       const launchSpy = vi.spyOn(loop as unknown as { startTurn: () => unknown }, 'startTurn');
 
@@ -375,8 +375,10 @@ describe('task notification → main agent (real Agent instance)', () => {
 
       await vi.waitFor(() => {
         const flatContext = JSON.stringify(ctx.contextData());
-        expect(flatContext).toContain('bash-prev0000');
+        expect(flatContext).toContain('task_resume_termination');
+        expect(flatContext).toContain('<system-reminder>');
         expect(flatContext).toContain('agent-prev0000');
+        expect(flatContext).toContain('bash-prev0000');
       });
 
       expect(launchSpy).not.toHaveBeenCalled();
@@ -387,7 +389,7 @@ describe('task notification → main agent (real Agent instance)', () => {
       expect(flatContext).toContain('<output-file');
       expect(flatContext).not.toContain('previous bash output');
       expect(flatContext).toMatch(/task\.completed/);
-      expect(flatContext).toMatch(/task\.lost/);
+      expect(flatContext).not.toMatch(/task\.lost/);
     });
   });
 });

--- a/packages/agent-core-v2/test/agent/task/rpc-events.test.ts
+++ b/packages/agent-core-v2/test/agent/task/rpc-events.test.ts
@@ -830,6 +830,7 @@ describe('AgentTaskService — notification delivery', () => {
     const sessionDir = await mkdtemp(join(tmpdir(), 'kimi-bg-agent-lost-'));
     let fixture: TaskServiceFixture | undefined;
     try {
+      const fireAndForgetTrigger = vi.fn<FireAndForgetTrigger>(async () => []);
       const persistence = createAgentTaskPersistence(sessionDir);
       await persistence.writeTask(
         persistedAgent({
@@ -839,7 +840,10 @@ describe('AgentTaskService — notification delivery', () => {
           status: 'running',
         }),
       );
-      fixture = createAgentTaskService({ sessionDir });
+      fixture = createAgentTaskService({
+        sessionDir,
+        hooks: { fireAndForgetTrigger },
+      });
       const { agent, manager } = fixture;
 
       await manager.loadFromDisk();
@@ -856,6 +860,140 @@ describe('AgentTaskService — notification delivery', () => {
       });
       expect(message.content[0]!.text).toContain('<system-reminder>');
       expect(message.content[0]!.text).toContain('agent-run00000');
+      await vi.waitFor(() => {
+        expect(fireAndForgetTrigger).toHaveBeenCalledTimes(1);
+      });
+      expect(fireAndForgetTrigger).toHaveBeenCalledWith('Notification', expect.objectContaining({
+        matcherValue: 'task.lost',
+        inputData: expect.objectContaining({
+          sink: 'context',
+          notificationType: 'task.lost',
+          title: 'Background agent lost',
+          body: expect.stringContaining('interrupted task lost.'),
+          severity: 'warning',
+          sourceKind: 'background_task',
+          sourceId: 'agent-run00000',
+        }),
+      }));
+    } finally {
+      await cleanupSessionDir(sessionDir, fixture);
+    }
+  });
+
+  it('does not repeat a restored lost-task reminder when its marker is missing', async () => {
+    const sessionDir = await mkdtemp(join(tmpdir(), 'kimi-bg-agent-reminded-'));
+    let fixture: TaskServiceFixture | undefined;
+    try {
+      const persistence = createAgentTaskPersistence(sessionDir);
+      await persistence.writeTask(
+        persistedAgent({
+          taskId: 'agent-hist0000',
+          description: 'interrupted task',
+          status: 'lost',
+        }),
+      );
+      fixture = createAgentTaskService({ sessionDir });
+      const { agent, ctx, manager } = fixture;
+      ctx.appendSystemReminder(
+        '- agent-hist0000 "interrupted task" (subagent)',
+        { kind: 'injection', variant: 'task_resume_termination' },
+      );
+
+      await manager.loadFromDisk();
+      await manager.reconcile();
+
+      expect(agent.context.appendUserMessage).toHaveBeenCalledTimes(1);
+      await vi.waitFor(async () => {
+        await expect(persistence.readTask('agent-hist0000')).resolves.toMatchObject({
+          resumeReminded: true,
+        });
+      });
+    } finally {
+      await cleanupSessionDir(sessionDir, fixture);
+    }
+  });
+
+  it('does not replace a delivered legacy lost-task notification with a reminder', async () => {
+    const sessionDir = await mkdtemp(join(tmpdir(), 'kimi-bg-agent-delivered-'));
+    let fixture: TaskServiceFixture | undefined;
+    try {
+      const persistence = createAgentTaskPersistence(sessionDir);
+      await persistence.writeTask(
+        persistedAgent({
+          taskId: 'agent-old00000',
+          description: 'interrupted task',
+          status: 'lost',
+        }),
+      );
+      fixture = createAgentTaskService({ sessionDir });
+      const { agent, ctx, manager } = fixture;
+      ctx.get(IAgentContextMemoryService).append({
+        role: 'user',
+        content: [{ type: 'text', text: '<notification>interrupted task lost.</notification>' }],
+        toolCalls: [],
+        origin: {
+          kind: 'task',
+          taskId: 'agent-old00000',
+          status: 'lost',
+          notificationId: 'task:agent-old00000:lost',
+        },
+      });
+
+      await manager.loadFromDisk();
+      await manager.reconcile();
+
+      expect(agent.context.appendUserMessage).toHaveBeenCalledTimes(1);
+      expect(
+        ctx.contextData().history.filter(
+          (message) =>
+            message.origin?.kind === 'injection' &&
+            message.origin.variant === 'task_resume_termination',
+        ),
+      ).toEqual([]);
+      await vi.waitFor(async () => {
+        await expect(persistence.readTask('agent-old00000')).resolves.toMatchObject({
+          resumeReminded: true,
+        });
+      });
+    } finally {
+      await cleanupSessionDir(sessionDir, fixture);
+    }
+  });
+
+  it('does not block restore when persisting a reminder marker fails', async () => {
+    const sessionDir = await mkdtemp(join(tmpdir(), 'kimi-bg-agent-marker-'));
+    let fixture: TaskServiceFixture | undefined;
+    try {
+      const persistence = createAgentTaskPersistence(sessionDir);
+      await persistence.writeTask(
+        persistedAgent({
+          taskId: 'agent-mark0000',
+          description: 'interrupted task',
+          status: 'lost',
+        }),
+      );
+      fixture = createAgentTaskService({ sessionDir });
+      const { agent, manager } = fixture;
+      await manager.loadFromDisk();
+      const internalPersistence = (
+        manager as unknown as {
+          readonly persistence: Pick<ReturnType<typeof createAgentTaskPersistence>, 'writeTask'>;
+        }
+      ).persistence;
+      vi.spyOn(internalPersistence, 'writeTask').mockRejectedValueOnce(
+        new Error('marker write failed'),
+      );
+
+      await expect(manager.reconcile()).resolves.toEqual([]);
+
+      expect(manager.getTask('agent-mark0000')).toMatchObject({
+        status: 'lost',
+        resumeReminded: true,
+      });
+      expect(firstAppendedContextMessage(agent).origin).toMatchObject({
+        kind: 'injection',
+        variant: 'task_resume_termination',
+      });
     } finally {
       await cleanupSessionDir(sessionDir, fixture);
     }

--- a/packages/agent-core-v2/test/agent/task/rpc-events.test.ts
+++ b/packages/agent-core-v2/test/agent/task/rpc-events.test.ts
@@ -850,15 +850,12 @@ describe('AgentTaskService — notification delivery', () => {
         expect(agent.context.appendUserMessage).toHaveBeenCalledTimes(1);
       });
       const message = firstAppendedContextMessage(agent);
-      expect(message.origin).toEqual({
-        kind: 'task',
-        taskId: 'agent-run00000',
-        status: 'lost',
-        notificationId: 'task:agent-run00000:lost',
+      expect(message.origin).toMatchObject({
+        kind: 'injection',
+        variant: 'task_resume_termination',
       });
-      expect(message.content[0]!.text).toContain(
-        'Background agent lost',
-      );
+      expect(message.content[0]!.text).toContain('<system-reminder>');
+      expect(message.content[0]!.text).toContain('agent-run00000');
     } finally {
       await cleanupSessionDir(sessionDir, fixture);
     }


### PR DESCRIPTION
## Related Issue

N/A — internal behavior fix; the motivation is described below.

## Problem

When the user exits the app with background tasks (bash commands or subagents) still running and later resumes the session, the model never learns those tasks are gone. It keeps waiting for completion notifications that will never arrive, and may reason as if the tasks had succeeded.

- Normal exit (`stopAllOnExit`): detached tasks are killed with `stopReason = 'Session closed'` and their terminal notification is suppressed — nothing reaches the model.
- Abnormal exit: the persisted task record stays `running`, reconcile marks it `lost`, and the per-task restore path injects a thin `<notification>xxx lost.</notification>` line that explains neither the cause nor what to do next.

## What changed

On resume, reconciliation now delivers one unified `ReminderRuntime.notify` covering every background task that was still running when the previous process exited:

- Collects every ghost task whose last state is `lost` (process died without a terminal record), or `killed` with `stopReason = 'Session closed'` (the exit path actively stopped it).
- Renders one line per task: subagents get `Agent(resume="agentId")` recovery guidance (their context is persisted); bash tasks are listed without claiming death ("the process may still be running").
- Persists a `resumeReminded?: boolean` marker on each ghost task so repeated reconcile passes and history replay can never re-inject the same reminder.
- Excludes tasks the model deliberately stopped via TaskStop (`stopReason` differs), and excludes lost ghosts from the per-task restore path (the unified reminder replaces it, not duplicates it).

Mechanically this is deliberately small: a single collector + one notify call + one persistence write, no new durable event, no new delivery-key space, no new registry. The existing rejection/suppression mechanisms are untouched.

Example (user resumes after the app exits):

```
<system-reminder>
The user exited the application after your last turn, so your background tasks from the previous session lost contact:
- agent-prev0000 "previous agent task" (subagent) — resume it with Agent(resume="agent-prev0000", prompt="Pick up where you left off.") ...
- bash-run77777 "npm run dev" (bash)
Don't assume any of them completed; check current state (they may still be running), then re-run or resume only what you still need.
</system-reminder>
```

Diff-size note: the final net change is roughly +50 lines of feel code (collector + reminder + persistence marker + tests), because the reminder is an additive capability; everything that could be deleted without harming existing behavior was deleted in earlier passes of this PR (suppression-abuse checks, an invented delivery-state event, fold registrations, dispatch infrastructure). What remains is the irreducible code for the new path. Tests (idle-notification-repro, rpc-events) were rewritten, not added, wherever possible.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [ ] I have linked a related issue (N/A — internal behavior fix).
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update. (No doc update needed.)
