### PR TITLE
fix(auth): keep OAuth login alive when its own provisioning writes the provider

### DIFF
--- a/.changeset/fix-oauth-login-self-cancel.md
+++ b/.changeset/fix-oauth-login-self-cancel.md
@@ -1,0 +1,5 @@
+---
+"@moonshot-ai/kimi-code": patch
+---
+
+Fix sign-in briefly showing a device-code-expired error after a successful authorization.

--- a/packages/agent-core-v2/src/app/auth/authService.ts
+++ b/packages/agent-core-v2/src/app/auth/authService.ts
@@ -86,7 +86,6 @@ interface FlowState {
   readonly loginBaseUrl: string | undefined;
   device: DeviceAuthorization | undefined;
   status: OAuthFlowStatus;
-  provisioning: boolean;
   expiresAt: number;
   gcTimer: ReturnType<typeof setTimeout> | undefined;
   errorMessage: string | undefined;
@@ -136,7 +135,6 @@ export class OAuthService extends Disposable implements IOAuthService {
       loginBaseUrl: loginAuth.baseUrl,
       device: undefined,
       status: 'pending',
-      provisioning: false,
       expiresAt: Date.now() + DEFAULT_DEVICE_EXPIRES_IN_SEC * 1000,
       gcTimer: undefined,
       errorMessage: undefined,
@@ -471,7 +469,6 @@ export class OAuthService extends Disposable implements IOAuthService {
     for (const state of this.flows.values()) {
       if (!affected.has(state.provider)) continue;
       if (state.status !== 'pending') continue;
-      if (state.provisioning) continue;
       state.controller.abort();
       state.errorMessage = 'Provider configuration changed during login.';
       this.setTerminal(state, 'cancelled');
@@ -480,32 +477,28 @@ export class OAuthService extends Disposable implements IOAuthService {
 
   private handleSuccess(state: FlowState): void {
     if (state.status !== 'pending') return;
-    void this.finalizeAuthentication(state);
+    this.setTerminal(state, 'authenticated');
+    void this.provisionAfterSuccess(state);
   }
 
   private async completeAlreadyAuthenticatedLogin(state: FlowState): Promise<void> {
-    await this.finalizeAuthentication(state);
+    if (state.status !== 'pending') return;
+    this.setTerminal(state, 'authenticated');
+    await this.provisionAfterSuccess(state);
   }
 
-  private async finalizeAuthentication(state: FlowState): Promise<void> {
-    state.provisioning = true;
+  private async provisionAfterSuccess(state: FlowState): Promise<void> {
     try {
       await this.provisionProvider(state.provider, state.oauthRef, state.loginBaseUrl);
-      if (state.status !== 'pending') return;
+      if (this.flows.get(state.provider) !== state) return;
       if (state.provider === KIMI_CODE_PROVIDER_NAME) {
         await this.refreshOAuthProviderModelsBestEffort(state.provider);
-        if (state.status !== 'pending') return;
       }
     } catch (error) {
       this.log.warn('oauth provider provisioning failed', {
         provider: state.provider,
         error: error instanceof Error ? error.message : String(error),
       });
-    } finally {
-      state.provisioning = false;
-      if (state.status === 'pending') {
-        this.setTerminal(state, 'authenticated');
-      }
     }
   }
 

--- a/packages/agent-core-v2/src/app/auth/authService.ts
+++ b/packages/agent-core-v2/src/app/auth/authService.ts
@@ -86,6 +86,7 @@ interface FlowState {
   readonly loginBaseUrl: string | undefined;
   device: DeviceAuthorization | undefined;
   status: OAuthFlowStatus;
+  tokenGranted: boolean;
   expiresAt: number;
   gcTimer: ReturnType<typeof setTimeout> | undefined;
   errorMessage: string | undefined;
@@ -135,6 +136,7 @@ export class OAuthService extends Disposable implements IOAuthService {
       loginBaseUrl: loginAuth.baseUrl,
       device: undefined,
       status: 'pending',
+      tokenGranted: false,
       expiresAt: Date.now() + DEFAULT_DEVICE_EXPIRES_IN_SEC * 1000,
       gcTimer: undefined,
       errorMessage: undefined,
@@ -469,6 +471,7 @@ export class OAuthService extends Disposable implements IOAuthService {
     for (const state of this.flows.values()) {
       if (!affected.has(state.provider)) continue;
       if (state.status !== 'pending') continue;
+      if (state.tokenGranted) continue;
       state.controller.abort();
       state.errorMessage = 'Provider configuration changed during login.';
       this.setTerminal(state, 'cancelled');
@@ -477,13 +480,13 @@ export class OAuthService extends Disposable implements IOAuthService {
 
   private handleSuccess(state: FlowState): void {
     if (state.status !== 'pending') return;
-    this.setTerminal(state, 'authenticated');
+    state.tokenGranted = true;
     void this.provisionAfterSuccess(state);
   }
 
   private async completeAlreadyAuthenticatedLogin(state: FlowState): Promise<void> {
     if (state.status !== 'pending') return;
-    this.setTerminal(state, 'authenticated');
+    state.tokenGranted = true;
     await this.provisionAfterSuccess(state);
   }
 
@@ -499,6 +502,10 @@ export class OAuthService extends Disposable implements IOAuthService {
         provider: state.provider,
         error: error instanceof Error ? error.message : String(error),
       });
+    } finally {
+      if (state.status === 'pending') {
+        this.setTerminal(state, 'authenticated');
+      }
     }
   }
 

--- a/packages/agent-core-v2/src/app/auth/authService.ts
+++ b/packages/agent-core-v2/src/app/auth/authService.ts
@@ -86,6 +86,7 @@ interface FlowState {
   readonly loginBaseUrl: string | undefined;
   device: DeviceAuthorization | undefined;
   status: OAuthFlowStatus;
+  provisioning: boolean;
   expiresAt: number;
   gcTimer: ReturnType<typeof setTimeout> | undefined;
   errorMessage: string | undefined;
@@ -135,6 +136,7 @@ export class OAuthService extends Disposable implements IOAuthService {
       loginBaseUrl: loginAuth.baseUrl,
       device: undefined,
       status: 'pending',
+      provisioning: false,
       expiresAt: Date.now() + DEFAULT_DEVICE_EXPIRES_IN_SEC * 1000,
       gcTimer: undefined,
       errorMessage: undefined,
@@ -469,6 +471,7 @@ export class OAuthService extends Disposable implements IOAuthService {
     for (const state of this.flows.values()) {
       if (!affected.has(state.provider)) continue;
       if (state.status !== 'pending') continue;
+      if (state.provisioning) continue;
       state.controller.abort();
       state.errorMessage = 'Provider configuration changed during login.';
       this.setTerminal(state, 'cancelled');
@@ -485,6 +488,7 @@ export class OAuthService extends Disposable implements IOAuthService {
   }
 
   private async finalizeAuthentication(state: FlowState): Promise<void> {
+    state.provisioning = true;
     try {
       await this.provisionProvider(state.provider, state.oauthRef, state.loginBaseUrl);
       if (state.status !== 'pending') return;
@@ -498,6 +502,7 @@ export class OAuthService extends Disposable implements IOAuthService {
         error: error instanceof Error ? error.message : String(error),
       });
     } finally {
+      state.provisioning = false;
       if (state.status === 'pending') {
         this.setTerminal(state, 'authenticated');
       }

--- a/packages/agent-core-v2/test/app/auth/auth.test.ts
+++ b/packages/agent-core-v2/test/app/auth/auth.test.ts
@@ -98,7 +98,7 @@ describe('OAuthService', () => {
   let defaultModel: string | undefined;
   let thinking: { enabled?: boolean; effort?: string } | undefined;
   let toolkit: FakeToolkit;
-  let providerSet: ReturnType<typeof vi.fn>;
+  let providerSet: ReturnType<typeof vi.fn<(name: string, config: ProviderConfig) => Promise<void>>>;
   let configSet: ReturnType<typeof vi.fn>;
   let configReplace: ReturnType<typeof vi.fn>;
   let events: Event2[];
@@ -579,10 +579,8 @@ describe('OAuthService', () => {
 
     await svc.startLogin(OAUTH_PROVIDER);
     await vi.waitFor(() => expect(svc.getFlow(OAUTH_PROVIDER)?.status).toBe('authenticated'));
-    await vi.waitFor(() => {
-      expect(fetchMock).toHaveBeenCalledTimes(1);
-    });
 
+    expect(fetchMock).toHaveBeenCalledTimes(1);
     expect(providerSet).toHaveBeenCalledWith(
       OAUTH_PROVIDER,
       expect.objectContaining({
@@ -663,6 +661,33 @@ describe('OAuthService', () => {
     await vi.waitFor(() => expect(svc.getFlow(OAUTH_PROVIDER)?.status).toBe('cancelled'));
   });
 
+  it('reports pending until provisioning finishes after the grant settles', async () => {
+    stubManagedModelsFetch();
+    toolkit.login.mockImplementation((_provider, options) => {
+      options.onDeviceCode(deviceAuth);
+      return Promise.resolve({ providerName: OAUTH_PROVIDER, ok: true });
+    });
+    let resolveProvision!: () => void;
+    providerSet.mockImplementation((name: string, config: ProviderConfig) => {
+      providers = { ...providers, [name]: config };
+      return new Promise<void>((resolve) => {
+        resolveProvision = resolve;
+      });
+    });
+    const svc = createService();
+    await svc.startLogin(OAUTH_PROVIDER);
+
+    await vi.waitFor(() => {
+      expect(providerSet).toHaveBeenCalled();
+    });
+    expect(svc.getFlow(OAUTH_PROVIDER)?.status).toBe('pending');
+
+    resolveProvision();
+    await vi.waitFor(() => {
+      expect(svc.getFlow(OAUTH_PROVIDER)?.status).toBe('authenticated');
+    });
+  });
+
   it('keeps the login authenticated when its own provisioning fires a provider change', async () => {
     stubManagedModelsFetch();
     toolkit.login.mockImplementation((_provider, options) => {
@@ -672,6 +697,7 @@ describe('OAuthService', () => {
     providerSet.mockImplementation((name: string, config: ProviderConfig) => {
       providers = { ...providers, [name]: config };
       providerChangedEmitter.fire({ added: [], removed: [], changed: [name] });
+      return Promise.resolve();
     });
     const svc = createService();
     await svc.startLogin(OAUTH_PROVIDER);

--- a/packages/agent-core-v2/test/app/auth/auth.test.ts
+++ b/packages/agent-core-v2/test/app/auth/auth.test.ts
@@ -579,8 +579,10 @@ describe('OAuthService', () => {
 
     await svc.startLogin(OAUTH_PROVIDER);
     await vi.waitFor(() => expect(svc.getFlow(OAUTH_PROVIDER)?.status).toBe('authenticated'));
+    await vi.waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+    });
 
-    expect(fetchMock).toHaveBeenCalledTimes(1);
     expect(providerSet).toHaveBeenCalledWith(
       OAUTH_PROVIDER,
       expect.objectContaining({

--- a/packages/agent-core-v2/test/app/auth/auth.test.ts
+++ b/packages/agent-core-v2/test/app/auth/auth.test.ts
@@ -661,6 +661,22 @@ describe('OAuthService', () => {
     await vi.waitFor(() => expect(svc.getFlow(OAUTH_PROVIDER)?.status).toBe('cancelled'));
   });
 
+  it('keeps the login authenticated when its own provisioning fires a provider change', async () => {
+    stubManagedModelsFetch();
+    toolkit.login.mockImplementation((_provider, options) => {
+      options.onDeviceCode(deviceAuth);
+      return Promise.resolve({ providerName: OAUTH_PROVIDER, ok: true });
+    });
+    providerSet.mockImplementation((name: string, config: ProviderConfig) => {
+      providers = { ...providers, [name]: config };
+      providerChangedEmitter.fire({ added: [], removed: [], changed: [name] });
+    });
+    const svc = createService();
+    await svc.startLogin(OAUTH_PROVIDER);
+
+    await vi.waitFor(() => expect(svc.getFlow(OAUTH_PROVIDER)?.status).toBe('authenticated'));
+  });
+
   it('cancelLogin aborts a pending flow and marks it cancelled', async () => {
     let capturedSignal: AbortSignal | undefined;
     toolkit.login.mockImplementation((_provider, options) => {


### PR DESCRIPTION
## Related Issue

Internal bug report (client login UX) — no linked issue.

## Problem

After the user finishes authorizing in the browser, the OAuth flow in the
daemon is briefly cancelled by itself: `finalizeAuthentication` writes the
provisioned provider via `providerService.set()`, the resulting
`ProvidersChanged` event is picked up by `invalidateFlows`, which treats it as
an external config change during login and cancels the still-pending flow. The
client then flashes a "device code expired" dialog before the login actually
completes.

## What changed

The flow now tracks the grant decision and the publishable state separately:

- The moment the grant settles (token obtained, or the cached-token fast
  path), the flow is marked `tokenGranted`. From then on it is no longer
  cancellable by `invalidateFlows` — a completed login can never be cancelled
  by the provider-changed events its own provisioning writes raise.
  `invalidateFlows` still cancels genuinely pending flows on external provider
  changes during login.
- The externally visible `authenticated` state is published only after
  provisioning finishes (provider written, managed models refreshed,
  best-effort — failures log but still publish, matching the previous
  `finally` semantics). Clients polling `GET /oauth/login` therefore never see
  `authenticated` before the configuration that follow-up prompt/session
  requests depend on is usable.
- `provisionAfterSuccess` re-checks `flows.get(provider) === state` before the
  model refresh so a superseded login cannot overwrite a newer flow's config.
- Regression tests: one fires the provider-changed event from inside the
  provision write and asserts the flow still lands on `authenticated`; another
  holds the provision write open and asserts the flow keeps reporting
  `pending` until provisioning completes.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/MoonshotAI/kimi-code/blob/main/CONTRIBUTING.md) document.
- [x] I have linked a related issue (internal report, no public issue).
- [x] I have added tests that prove my feature works.
- [x] Ran `gen-changesets` skill, or this PR needs no changeset.
- [x] Ran `gen-docs` skill, or this PR needs no doc update.
